### PR TITLE
some web guide links don't work

### DIFF
--- a/files/pt-br/_redirects.txt
+++ b/files/pt-br/_redirects.txt
@@ -294,8 +294,8 @@
 /pt-BR/docs/Web/Events/resize	/pt-BR/docs/Web/API/Window/resize_event
 /pt-BR/docs/Web/Events/scroll	/pt-BR/docs/Web/API/Document/scroll_event
 /pt-BR/docs/Web/Events/touchstart	/pt-BR/docs/Web/API/Element/touchstart_event
-/pt-BR/docs/Web/Guide/CSS	/pt-BR/docs/Learn/CSS
-/pt-BR/docs/Web/Guide/HTML	/pt-BR/docs/Learn/HTML
+/pt-BR/docs/Web/Guide/CSS	/pt-BR/docs/Aprender/CSS
+/pt-BR/docs/Web/Guide/HTML	/pt-BR/docs/Aprender/HTML
 /pt-BR/docs/Web/HTML/Element/%3Cb%3E	/pt-BR/docs/Web/HTML/Element/b
 /pt-BR/docs/Web/HTML/Elementos_nlock-level	/pt-BR/docs/Web/HTML/Elementos_block-level
 /pt-BR/docs/Web/HTML/HTML5/HTML5_element_list	/pt-BR/docs/Web/HTML/Element


### PR DESCRIPTION
Two paths had redirection problems:
from `/pt-BR/docs/Web/Guide/CSS` to `/pt-BR/docs/Learn/CSS`
and from `/pt-BR/docs/Web/Guide/HTML` to `/pt-BR/docs/Learn/HTML`

the links did not work because the paths `/pt-BR/docs/Learn/CSS` and `/pt-BR/docs/Learn/HTML` do not exist, the redirects should go from `/pt-BR/docs/Web/Guide/CSS` to `/pt-BR/docs/Aprender/ CSS` and from `/pt-BR/docs/Web/Guide/HTML` to `/pt-BR/docs/Aprender/HTML`.