### PR TITLE
Typo

### DIFF
--- a/files/es/web/javascript/referencia/objetos_globales/date/tolocaledatestring/index.html
+++ b/files/es/web/javascript/referencia/objetos_globales/date/tolocaledatestring/index.html
@@ -90,7 +90,7 @@ console.log(date.toLocaleDateString('ko-KR'));
 console.log(date.toLocaleDateString('fa-IR'));
 // → "۱۳۹۱/۹/۳۰"
 
-// El árave en la mayoría de paises arabehablantes hace uso de los dígitos árabes
+// El árabe en la mayoría de paises arabehablantes hace uso de los dígitos árabes
 console.log(date.toLocaleDateString('ar-EG'));
 // → "<span dir="rtl">٢٠‏/١٢‏/٢٠١٢</span>"
 


### PR DESCRIPTION
The right word is "árabe" instead of "árave".