### PR TITLE
update tfoot translation to be HTML5 conform

### DIFF
--- a/files/de/web/html/element/table/index.html
+++ b/files/de/web/html/element/table/index.html
@@ -293,18 +293,18 @@ translation_of: Web/HTML/Element/table
       &lt;th&gt;Header content 2&lt;/th&gt;
     &lt;/tr&gt;
   &lt;/thead&gt;
-  &lt;tfoot&gt;
-    &lt;tr&gt;
-      &lt;td&gt;Footer content 1&lt;/td&gt;
-      &lt;td&gt;Footer content 2&lt;/td&gt;
-    &lt;/tr&gt;
-  &lt;/tfoot&gt;
   &lt;tbody&gt;
     &lt;tr&gt;
       &lt;td&gt;Body content 1&lt;/td&gt;
       &lt;td&gt;Body content 2&lt;/td&gt;
     &lt;/tr&gt;
   &lt;/tbody&gt;
+  &lt;tfoot&gt;
+    &lt;tr&gt;
+      &lt;td&gt;Footer content 1&lt;/td&gt;
+      &lt;td&gt;Footer content 2&lt;/td&gt;
+    &lt;/tr&gt;
+  &lt;/tfoot&gt;
 &lt;/table&gt;
 
 &lt;p&gt;Tabelle mit colgroup&lt;/p&gt;

--- a/files/de/web/html/element/table/index.html
+++ b/files/de/web/html/element/table/index.html
@@ -33,20 +33,11 @@ translation_of: Web/HTML/Element/table
      <li>ein optionales {{HTMLElement("thead")}}-Element,</li>
      <li>eine der beiden Alternativen:
       <ul>
-       <li>ein {{HTMLElement("tfoot")}}-Element, gefolgt von:
-        <ul>
-         <li>null oder mehr {{HTMLElement("tbody")}}-Elementen,</li>
-         <li>oder einem oder mehr {{HTMLElement("tr")}}-Elementen,</li>
-        </ul>
-       </li>
-       <li>eine zweite Alternative gefolgt von einem optionalen {{HTMLElement("tfoot")}}-Element:
-        <ul>
-         <li>entweder null oder mehr {{HTMLElement("tbody")}}-Elemente,</li>
-         <li>oder ein oder mehr {{HTMLElement("tr")}}-Elemente</li>
-        </ul>
-       </li>
+        <li>null oder mehr {{HTMLElement("tbody")}}-Elementen,</li>
+        <li>oder einem oder mehr {{HTMLElement("tr")}}-Elementen,</li>
       </ul>
      </li>
+     <li>ein optionales {{HTMLElement("tfoot")}}-Element</li>
     </ul>
     </div>
     </div>


### PR DESCRIPTION
since HTML5 it's not allowed anymore to have a `<tfoot>` elements after a `<thead>` .The English documentation is correct, but the german, french and Spanish ones need to be updated. See here: https://www.w3.org/TR/html51/tabular-data.html#elementdef-table