### PR TITLE
Fix wrong page reference

### DIFF
--- a/files/de/web/javascript/reference/global_objects/math/random/index.html
+++ b/files/de/web/javascript/reference/global_objects/math/random/index.html
@@ -16,7 +16,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/Math/math.random
 <div>{{EmbedInteractiveExample("pages/js/math-random.html")}}</div>
 
 <div class="note">
-<p><code>Math.random()</code> stellt <em>keine</em> kryprografisch sicheren Zufallszahlen bereit. <span id="result_box" lang="de"><span class="hps">Verwenden Sie sie auf keinen Fall für </span><span class="hps">etwas, das  in Verbindung mit </span><span class="hps">Sicherheit steht</span><span>.</span></span> Benutzen Sie stattdessen die Web Crypto API, genauer gesagt die {{domxref("RandomSource.getRandomValues()", "window.crypto.getRandomValues()")}}-Methode.</p>
+<p><code>Math.random()</code> stellt <em>keine</em> kryprografisch sicheren Zufallszahlen bereit. <span id="result_box" lang="de"><span class="hps">Verwenden Sie sie auf keinen Fall für </span><span class="hps">etwas, das  in Verbindung mit </span><span class="hps">Sicherheit steht</span><span>.</span></span> Benutzen Sie stattdessen die Web Crypto API, genauer gesagt die {{domxref("Crypto.getRandomValues()", "window.crypto.getRandomValues()")}}-Methode.</p>
 </div>
 
 <h2 id="Syntax">Syntax</h2>


### PR DESCRIPTION
RandomSource.getRandomValues() leads to 'page not found' without a note that only an English version is available.