### PR TITLE
FIX: Typo in URL for interactive sample on Object.seal() - Issue #115

### DIFF
--- a/files/fr/web/javascript/reference/global_objects/object/seal/index.html
+++ b/files/fr/web/javascript/reference/global_objects/object/seal/index.html
@@ -15,7 +15,7 @@ original_slug: Web/JavaScript/Reference/Objets_globaux/Object/seal
 
 <p>La méthode <code><strong>Object.seal()</strong></code> scelle un objet afin d'empêcher l'ajout de nouvelles propriétés, en marquant les propriétés existantes comme non-configurables. Les valeurs des propriétés courantes peuvent toujours être modifiées si elles sont accessibles en écriture.</p>
 
-<div>{{EmbedInteractiveExample("pages/js/object-prototype-seal.html")}}</div>
+<div>{{EmbedInteractiveExample("pages/js/object-seal.html")}}</div>
 
 <p class="hidden">Le code source de cet exemple interactif est disponible dans un dépôt GitHub. Si vous souhaitez contribuez à ces exemples, n'hésitez pas à cloner <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> et à envoyer une <em>pull request</em> !</p>
 

--- a/files/fr/web/javascript/reference/global_objects/object/seal/index.html
+++ b/files/fr/web/javascript/reference/global_objects/object/seal/index.html
@@ -147,8 +147,8 @@ Object.seal(1);
 
 <ul>
  <li>{{jsxref("Object.isSealed()")}}</li>
- <li>{{jsxref("Object.isFrozen()")}}</li>
- <li>{{jsxref("Object.isExtensible()")}}</li>
  <li>{{jsxref("Object.preventExtensions()")}}</li>
+ <li>{{jsxref("Object.isExtensible()")}}</li>
  <li>{{jsxref("Object.freeze()")}}</li>
+ <li>{{jsxref("Object.isFrozen()")}}</li>
 </ul>


### PR DESCRIPTION
Hello,

Following issue #115, I am pushing this content change with the correction of the interactive example link correcting the error currently present on the French page.

Changes:
- Correction of the link of the interactive example
- Correction of the "See also" links which were not up to date with the EN version

Issue #106 will require the same change.