### PR TITLE
FIX: Fix the semicolon by a correct comma line 232 - Issue #101

### DIFF
--- a/files/fr/web/javascript/reference/operators/destructuring_assignment/index.html
+++ b/files/fr/web/javascript/reference/operators/destructuring_assignment/index.html
@@ -2,10 +2,14 @@
 title: Affecter par décomposition
 slug: Web/JavaScript/Reference/Operators/Destructuring_assignment
 tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Opérateur
-  - Reference
+- Destructuration
+- Affectation de déstructuration
+- ECMAScript 2015
+- ES6
+- JavaScript
+- Caractéristiques de la langue
+- Déstructuration des objets imbriqués et des tableaux
+- Opérateur
 translation_of: Web/JavaScript/Reference/Operators/Destructuring_assignment
 original_slug: Web/JavaScript/Reference/Opérateurs/Affecter_par_décomposition
 ---
@@ -225,7 +229,7 @@ console.log(truc); // true</pre>
 
 <p>Une variable peut recevoir une valeur par défaut lors de la décomposition si la propriété correspondante de l'objet vaut <code>undefined</code>.</p>
 
-<pre class="brush: js">const {a = 10; b = 5} = {a: 3};
+<pre class="brush: js">const {a = 10, b = 5} = {a: 3};
 
 console.log(a); // 3
 console.log(b); // 5</pre>

--- a/files/fr/web/javascript/reference/operators/destructuring_assignment/index.html
+++ b/files/fr/web/javascript/reference/operators/destructuring_assignment/index.html
@@ -2,14 +2,15 @@
 title: Affecter par décomposition
 slug: Web/JavaScript/Reference/Operators/Destructuring_assignment
 tags:
-- Destructuration
-- Affectation de déstructuration
-- ECMAScript 2015
-- ES6
-- JavaScript
-- Caractéristiques de la langue
-- Déstructuration des objets imbriqués et des tableaux
-- Opérateur
+  - Destructuration
+  - Affectation de déstructuration
+  - ECMAScript 2015
+  - ES6
+  - JavaScript
+  - Caractéristiques de la langue
+  - Déstructuration des objets imbriqués et des tableaux
+  - Opérateur
+  - Reference
 translation_of: Web/JavaScript/Reference/Operators/Destructuring_assignment
 original_slug: Web/JavaScript/Reference/Opérateurs/Affecter_par_décomposition
 ---


### PR DESCRIPTION
**Related issue:** #101 
**Observed issue:** One block of code contained a sign error

**Commit changes:**
- [x] Typo: Fix a semilicon in the Javascript code block that should have been a comma
- [x] Tags is updated with french tags from en-US version