### PR TITLE
fr - Bring 'Web' landing page to parity with last en-US commit (as of 2021-03-14)

### DIFF
--- a/files/fr/web/index.html
+++ b/files/fr/web/index.html
@@ -2,111 +2,40 @@
 title: Technologies web pour développeurs
 slug: Web
 tags:
-  - Développement Web
-  - Technologie
+  - Landing
   - Web
 translation_of: Web
 ---
-<p>Le Web ouvert offre une opportunité incroyable aux personnes qui veulent créer des sites ou des applications en ligne. Pour tirer le meilleur parti de ces technologies, il faut savoir comment les utiliser. Vous trouverez ci-dessous les liens vers notre documentation à propos des technologies web.</p>
+<p>Le Web fournit d'incroyables opportunités aux développeuses et développeurs. Pour tirer le meilleur parti de ces technologies, il est nécessaire de savoir comment les utiliser. Voici différents liens qui vous permettront de naviguer dans la documentation de ces technologies web.</p>
 
-<div class="row topicpage-table">
-<div class="section">
-<h2 class="Documentation" id="Technologies_web">Technologies web</h2>
-
-<h3 id="Les_bases">Les bases</h3>
+<h2 class="Documentation" id="Docs_for_developers">Documentation pour le développement web</h2>
 
 <dl>
+ <dt><a href="/fr/docs/Web/Reference">Références</a></dt>
+ <dd>Une liste de l'ensemble des références sur les technologies web dont celles sur HTML, CSS, etc.</dd>
+ <dt><a href="/fr/docs/Web/Guide">Guides</a></dt>
+ <dd>Cette page fournit différents tutoriels pour vous aider à manipuler les technologies web afin de réaliser ce que vous souhaitez.</dd>
+ <dt><a href="/fr/docs/Web/Tutorials">Tutoriels</a></dt>
+ <dd>Une liste de tutoriels qui progressent étape par étape pour apprendre les API, langages et autres sujets.</dd>
+ <dt><a href="/fr/docs/Web/Progressive_web_apps">Les applications web progressives (<i>Progressive Web Applications</i> ou PWA en anglais)</a></dt>
+ <dd>Les applications web progressives sont des applications web qui utilisent les API et les fonctionnalités du navigateur ainsi que des stratégies d'amélioration progressive afin d'apporter une expérience utilisateur semblable aux applications natives et qui puissent fonctionner sur les différentes plateformes web.</dd>
+</dl>
+
+<h2 class="Documentation" id="Web_technology_references">Références des technologies web</h2>
+
+<dl>
+ <dt><a href="/fr/docs/Web/Reference/API">API Web</a></dt>
+ <dd>Les références pour l'ensemble des API qui permettent de rendre le Web interactif et scriptable. On y trouve notamment le DOM, les diverses interfaces et API utilisées pour construire du contenu et des applications web.</dd>
  <dt><a href="/fr/docs/Web/HTML">HTML</a></dt>
- <dd><strong>HyperText Markup Language</strong> (langage de balisage hypertexte ou <strong>HTML</strong>) est le langage utilisé pour décrire et définir le <em>contenu</em> d'une page web.</dd>
+ <dd><i>HyperText Markup Language</i> est le langage utilisé pour décrire et définir le contenu d'une page web.</dd>
  <dt><a href="/fr/docs/Web/CSS">CSS</a></dt>
- <dd><strong>Cascading Style Sheets</strong> (feuilles de style en cascade ou <strong>CSS</strong>) est utilisé pour décrire l'apparence du contenu d'une page web.</dd>
- <dt><a href="/fr/docs/Web/HTTP">HTTP</a></dt>
- <dd><strong><dfn>Hypertext Transfer Protocol <em>(HTTP</em>)</dfn></strong> est un protocole de <a href="https://fr.wikipedia.org/wiki/Couche_application">la couche application</a>, orienté client-serveur, qui permet le transfert de documents web tels que des documents HTML.</dd>
-</dl>
-
-<h3 id="Script">Script</h3>
-
-<dl>
+ <dd><i>Cascading Style Sheets</i> est le langage utilisé pour décrire l'apparence du contenu web.</dd>
  <dt><a href="/fr/docs/Web/JavaScript">JavaScript</a></dt>
- <dd><strong>JavaScript </strong>est le langage de programmation exécuté du côté de votre navigateur. Vous pouvez l'utiliser pour ajouter un côté interactif et dynamique a votre site web ou application.</dd>
- <dd>Avec l'avènement de <a href="/fr/docs/Glossaire/Node.js">Node.js</a>, vous pouvez également exécuter JavaScript sur le serveur.</dd>
- <dt><a href="/fr/docs/Web/API">Les API web</a></dt>
- <dd>Les <strong>interfaces de programmation d'application Web (API Web)</strong> sont utilisées pour effectuer une variété de tâches, telles que la manipulation du <a href="/fr/docs/DOM">DOM</a>, la lecture audio ou vidéo, ou la génération de graphiques 3D.
- <ul>
-  <li><a href="/fr/docs/Web/API">La référence des interfaces des différentes API web</a> : toutes les interfaces, triées par ordre alphabétique.</li>
-  <li><a href="/fr/docs/WebAPI">WebAPI</a> : cette page liste les API d’accès aux composants des appareils, ainsi que d’autres API utiles pour les applications.</li>
-  <li><a href="/fr/docs/Web/Events">La référence des évènements</a> décrit l'ensemble des évènements qui peuvent être utilisés pour réagir aux évènements marquants qui se sont produits dans une page web ou une application.</li>
- </ul>
- </dd>
- <dt><a href="/fr/docs/Web/Web_Components">Web components</a></dt>
- <dd><strong>Web Components</strong> est une suite de différentes technologies vous permettant de créer des éléments personnalisés réutilisables - avec leurs fonctionnalités encapsulées à l'écart du reste de votre code - et les utiliser dans vos applications Web.</dd>
-</dl>
-
-<h3 id="Graphiques">Graphiques</h3>
-
-<dl>
- <dt><a href="/fr/docs/Web/HTML/Canvas">Canvas</a></dt>
- <dd>L'élément {{HTMLElement("<em><strong>canvas</strong></em>")}} délivre des APIs pour dessiner des graphiques 2D utilisant Javascript.</dd>
+ <dd>JavaScript est le langage de programmation utilisé pour ajouter de l'interactivité à un site web.</dd>
+ <dt><a href="/fr/docs/Web/HTTP">HTTP</a></dt>
+ <dd><i>HyperText Transfer Protocol</i> est le protocole utilisé entre le navigateur et les serveurs web.</dd>
  <dt><a href="/fr/docs/Web/SVG">SVG</a></dt>
- <dd><strong>Scalable Vector Graphics<em> </em>(SVG)</strong> permettent de décrire des images comme des ensembles de vecteurs et de formes afin de pouvoir changer leur taille librement sans pixellisation. Un des avantages du format SVG est qu'il est possible de redimensionner un dessin à l'infini, sans perdre aucun détail.</dd>
- <dt><a href="/fr/docs/Web/WebGL">WebGL</a></dt>
- <dd><strong>WebGL </strong>apporte des<strong> graphismes 3D sur le Web</strong> grâce à une API respectant OpenGL ES 2.0 et pouvant être utilisée sur les éléments HTML {{HTMLElement("canvas")}}.</dd>
-</dl>
-
-<h3 id="Audio_vidéo_multimédia">Audio, vidéo, multimédia</h3>
-
-<dl>
- <dt><a href="/fr/docs/Web/Media">Les technologies média Web</a></dt>
- <dd>Une <strong>liste d'API</strong> avec des liens vers leurs documentations respectives.</dd>
-</dl>
-
-<dl>
- <dt><a href="/fr/docs/Web/Media/Overview">Aperçu des technologies multi-média du web</a></dt>
- <dd>Un <strong>aperçu général</strong> des technologies Web ouvertes et des API qui prennent en charge la lecture, la manipulation et l’enregistrement audio et vidéo. Si vous ne savez pas quelle API vous devez utiliser, c'est ici que vous devez commencer.</dd>
-</dl>
-
-<dl>
- <dt><a href="/fr/docs/Web/API/Media_Streams_API">Les API de capture et de diffusion multimédia</a></dt>
- <dd>Une liste qui référence l'ensemble des API qui permettent de diffuser, enregistrer et modifier des flux médias, localement et au travers d'un réseau. Elle comprend l'utilisation des caméras et micros afin d'enregistrer de la vidéo de l'audio et des images.</dd>
- <dt><a href="/fr/Apprendre/HTML/Multimedia_and_embedding/Contenu_audio_et_video">Utiliser HTML5 audio et video</a></dt>
- <dd><strong>Intégrer</strong> de la <strong>vidéo </strong>et / ou de l'<strong>audio </strong>dans une page Web et contrôler leur lecture.</dd>
- <dt><a href="/fr/docs/Web/API/WebRTC_API">WebRTC</a></dt>
- <dd>Le <strong>RTC</strong> dans <strong>WebRTC </strong>signifie <strong>Real-Time Communications</strong>, une technologie qui permet le streaming audio / vidéo et le partage de données entre les clients du navigateur (pairs/peers).</dd>
-</dl>
-
-<h3 id="Autres">Autres</h3>
-
-<dl>
+ <dd><i>Scalable Vector Graphics</i> est un format qui permet de décrire des images comme ensembles de vecteurs et de formes afin de pouvoir les mettre à l'échelle quelles que soient les dimensions selon lesquelles elles sont dessinées.</dd>
  <dt><a href="/fr/docs/Web/MathML">MathML</a></dt>
- <dd><strong>Mathematical Markup Language</strong> (langage de balisage mathématique) rend possible l'affichage d'équations mathématiques complexes.</dd>
+ <dd><i>Mathematical Markup Language</i> est un langage qui permet d'afficher des expressions mathématiques complexes.</dd>
 </dl>
-</div>
-
-<div class="section">
-<h2 class="Documentation" id="Apprendre">Apprendre</h2>
-
-<dl>
- <dt><a href="/fr/Apprendre">Apprendre le développement web</a></dt>
- <dd>Cet ensemble d'articles couvre tout ce qu'il est nécessaire de savoir pour commencer à développer des sites web simples.</dd>
- <dt><a href="/fr/Apps/Progressive">Applications Web Progressives</a></dt>
- <dd>Les <strong>applications Web progressistes</strong> utilisent des API Web modernes ainsi qu'une stratégie d'amélioration progressive traditionnelle pour créer des applications Web multiplateformes. Ces applications fonctionnent partout et offrent plusieurs fonctionnalités qui leur offrent les mêmes avantages que les applications natives. Cet ensemble de documents et de guides vous dit tout ce que vous devez savoir sur les PWA.</dd>
-</dl>
-
-<h3 id="Autres_sujets">Autres sujets</h3>
-
-<dl>
- <dt><a href="/fr/Apps">Développer des applications web</a></dt>
- <dd>Documentation pour développeurs d'applications web. Les applications web sont écrites une fois et déployées partout : sur mobile et ordinateurs.</dd>
- <dt><a href="/fr/docs/Accessibilité">Accessibilité</a></dt>
- <dd>L’accessibilité, en développement web, signifie faire en sorte qu’un maximum de personnes, même celles présentant des handicaps, puissent visiter des sites web. Cette section fournit des informations sur la manière de rendre le contenu accessible.</dd>
- <dt><a href="/fr/docs/Web/Localization">Localisation (L10n) et Internationalisation (I18n)</a></dt>
- <dd>Le web a une communauté mondiale ! Faites en sorte que votre site ou application en fasse partie en gardant à l'esprit de diffuser le contenu et son organisation dans la langue de vos utilisateurs.</dd>
- <dt><a href="/fr/docs/Web/Security">Sécurité</a></dt>
- <dd>Les techniques pour assurer la sécurité de votre site web ou application.</dd>
- <dt><a href="/fr/docs/WebAssembly">WebAssembly</a></dt>
- <dd><strong>WebAssembly </strong>est un nouveau type de code qui peut être exécuté dans les navigateurs Web modernes. Il s'agit d'un langage de type bas niveau avec un format binaire compact qui fonctionne avec des performances quasi natives et fournit des langages tels que C / C ++ avec une cible de compilation afin qu'ils puissent fonctionner sur le web. Il est également conçu pour fonctionner avec JavaScript, permettant aux deux de travailler ensemble.</dd>
-</dl>
-
-<p><span class="alllinks"><a href="/fr/docs/tag/Web">Voir tout…</a></span></p>
-</div>
-</div>


### PR DESCRIPTION
This PR updates /web/index.html to parity with https://github.com/mdn/content/blob/f99dbe91376f2861bf7c0469b51001a2434cc3c7/files/en-us/web/index.html