### PR TITLE
L10N: Complete translation of the Performance interface

### DIFF
--- a/files/fr/web/api/performance/clearmarks/index.html
+++ b/files/fr/web/api/performance/clearmarks/index.html
@@ -1,0 +1,94 @@
+---
+title: performance.clearMarks()
+slug: Web/API/Performance/clearMarks
+tags:
+  - API
+  - Method
+  - Méthode
+  - Reference
+  - Performance web
+translation_of: Web/API/Performance/clearMarks
+---
+<div>{{APIRef("User Timing API")}}</div>
+
+<p>La méthode <strong><code>clearMarks()</code></strong> supprime les <em>marques nommées</em> du tampon d'entrée des performances du navigateur. Si la méthode est appelée sans arguments, toutes les {{domxref("PerformanceEntry", "entrées de performance")}} avec un {{domxref("PerformanceEntry.entryType", "entryType")}} de « <code>mark</code> » seront supprimées du tampon d'entrée de performance.</p>
+
+<p>{{AvailableInWorkers}}</p>
+
+<h2 id="Syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+  <em>performance</em>.clearMarks();
+  <em>performance</em>.clearMarks(name);
+</pre>
+
+<h3 id="Arguments">Arguments</h3>
+
+<dl>
+  <dt>name {{optional_inline}}</dt>
+  <dd>Un {{domxref("DOMString")}} représentant le nom de l'horodatage. Si cet argument est omis, toutes les {{domxref("PerformanceEntry","entrées de performance")}} avec un {{domxref("PerformanceEntry.entryType","entryType")}} de « <code>mark</code> » seront supprimés.</dd>
+</dl>
+
+<h3 id="Return_value">Valeur de retour</h3>
+
+<dl>
+  <dt>void</dt>
+  <dd> </dd>
+</dl>
+
+<h2 id="Example">Exemple</h2>
+
+<p>L'exemple suivant montre les deux utilisations de la méthode <code>clearMarks()</code>.</p>
+
+<pre class="brush: js">// Créé une petite aide pour montrer combien d'entrées PerformanceMark il y a.
+function logMarkCount() {
+  console.log(
+    "J'ai trouvé autant d'entrées : " + performance.getEntriesByType("mark").length
+  );
+}
+
+// Crée une série de marques.
+performance.mark("squirrel");
+performance.mark("squirrel");
+performance.mark("monkey");
+performance.mark("monkey");
+performance.mark("dog");
+performance.mark("dog");
+
+logMarkCount() // "J'ai trouvé autant d'entrées : 6"
+
+// Supprime seulement les entrées "squirrel" de PerformanceMark.
+performance.clearMarks('squirrel');
+logMarkCount() // "J'ai trouvé autant d'entrées : 4"
+
+// Supprime toutes les entrées de PerformanceMark.
+performance.clearMarks();
+logMarkCount() // "J'ai trouvé autant d'entrées : 0"
+</pre>
+
+<h2 id="Specifications">Spécifications</h2>
+
+<table class="standard-table">
+  <tbody>
+    <tr>
+      <th scope="col">Spécification</th>
+      <th scope="col">Statut</th>
+      <th scope="col">Commentaire</th>
+    </tr>
+    <tr>
+      <td>{{SpecName('User Timing Level 2', '#dom-performance-clearmarks',
+        'clearMarks()')}}</td>
+      <td>{{Spec2('User Timing Level 2')}}</td>
+      <td>Clarification de <code>clearMarks()</code>.</td>
+    </tr>
+    <tr>
+      <td>{{SpecName('User Timing', '#dom-performance-clearmarks', 'clearMarks()')}}</td>
+      <td>{{Spec2('User Timing')}}</td>
+      <td>Définition initiale.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat("api.Performance.clearMarks")}}</p>

--- a/files/fr/web/api/performance/clearmarks/index.html
+++ b/files/fr/web/api/performance/clearmarks/index.html
@@ -11,7 +11,7 @@ translation_of: Web/API/Performance/clearMarks
 ---
 <div>{{APIRef("User Timing API")}}</div>
 
-<p>La méthode <strong><code>clearMarks()</code></strong> supprime les <em>marques nommées</em> du tampon d'entrée des performances du navigateur. Si la méthode est appelée sans arguments, toutes les {{domxref("PerformanceEntry", "entrées de performance")}} avec un {{domxref("PerformanceEntry.entryType", "entryType")}} de « <code>mark</code> » seront supprimées du tampon d'entrée de performance.</p>
+<p class="seoSummary">La méthode <strong><code>clearMarks()</code></strong> supprime les <em>marqueurs nommés</em> du tampon d'entrée des performances du navigateur. Si la méthode est appelée sans arguments, toutes les {{domxref("PerformanceEntry", "entrées de performance")}} avec un {{domxref("PerformanceEntry.entryType", "entryType")}} de « <code>mark</code> » seront supprimées du tampon d'entrée de performance.</p>
 
 <p>{{AvailableInWorkers}}</p>
 
@@ -47,7 +47,7 @@ function logMarkCount() {
   );
 }
 
-// Crée une série de marques.
+// Crée une série de marqueurs.
 performance.mark("squirrel");
 performance.mark("squirrel");
 performance.mark("monkey");

--- a/files/fr/web/api/performance/clearmarks/index.html
+++ b/files/fr/web/api/performance/clearmarks/index.html
@@ -11,7 +11,7 @@ translation_of: Web/API/Performance/clearMarks
 ---
 <div>{{APIRef("User Timing API")}}</div>
 
-<p class="seoSummary">La méthode <strong><code>clearMarks()</code></strong> supprime les <em>marqueurs nommés</em> du tampon d'entrée des performances du navigateur. Si la méthode est appelée sans arguments, toutes les {{domxref("PerformanceEntry", "entrées de performance")}} avec un {{domxref("PerformanceEntry.entryType", "entryType")}} de « <code>mark</code> » seront supprimées du tampon d'entrée de performance.</p>
+<p class="seoSummary">La méthode <strong><code>clearMarks()</code></strong> supprime les <em>marqueurs nommés</em> du tampon d'entrée des performances du navigateur. Si la méthode est appelée sans arguments, toutes les {{domxref("PerformanceEntry", "entrées de performance","",1)}} avec un {{domxref("PerformanceEntry.entryType", "entryType")}} de « <code>mark</code> » seront supprimées du tampon d'entrée de performance.</p>
 
 <p>{{AvailableInWorkers}}</p>
 
@@ -26,15 +26,12 @@ translation_of: Web/API/Performance/clearMarks
 
 <dl>
   <dt>name {{optional_inline}}</dt>
-  <dd>Un {{domxref("DOMString")}} représentant le nom de l'horodatage. Si cet argument est omis, toutes les {{domxref("PerformanceEntry","entrées de performance")}} avec un {{domxref("PerformanceEntry.entryType","entryType")}} de « <code>mark</code> » seront supprimés.</dd>
+  <dd>Un {{domxref("DOMString")}} représentant le nom de l'horodatage. Si cet argument est omis, toutes les {{domxref("PerformanceEntry","entrées de performance","",1)}} avec un {{domxref("PerformanceEntry.entryType","entryType")}} de « <code>mark</code> » seront supprimés.</dd>
 </dl>
 
 <h3 id="Return_value">Valeur de retour</h3>
 
-<dl>
-  <dt>void</dt>
-  <dd> </dd>
-</dl>
+<p>Aucune.</p>
 
 <h2 id="Example">Exemple</h2>
 
@@ -69,12 +66,14 @@ logMarkCount() // "J'ai trouvé autant d'entrées : 0"
 <h2 id="Specifications">Spécifications</h2>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
       <th scope="col">Spécification</th>
       <th scope="col">Statut</th>
       <th scope="col">Commentaire</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td>{{SpecName('User Timing Level 2', '#dom-performance-clearmarks',
         'clearMarks()')}}</td>

--- a/files/fr/web/api/performance/clearmeasures/index.html
+++ b/files/fr/web/api/performance/clearmeasures/index.html
@@ -11,7 +11,7 @@ translation_of: Web/API/Performance/clearMeasures
 ---
 <div>{{APIRef("User Timing API")}}</div>
 
-<p>La méthode <strong><code>clearMeasures()</code></strong> supprime les <em>mesures nommées</em> du tampon d'entrée des performances du navigateur. Si la méthode est appelée sans arguments, toutes les {{domxref("PerformanceEntry", "entrées de performance")}} avec un {{domxref("PerformanceEntry.entryType","entryType")}} de « <code>measure</code> » seront supprimées du tampon d'entrée de performance.</p>
+<p class="seoSummary">La méthode <strong><code>clearMeasures()</code></strong> supprime les <em>mesures nommés</em> du tampon d'entrée des performances du navigateur. Si la méthode est appelée sans arguments, toutes les {{domxref("PerformanceEntry", "entrées de performance")}} avec un {{domxref("PerformanceEntry.entryType","entryType")}} de « <code>measure</code> » seront supprimées du tampon d'entrée de performance.</p>
 
 <p>{{AvailableInWorkers}}</p>
 

--- a/files/fr/web/api/performance/clearmeasures/index.html
+++ b/files/fr/web/api/performance/clearmeasures/index.html
@@ -1,0 +1,96 @@
+---
+title: performance.clearMeasures()
+slug: Web/API/Performance/clearMeasures
+tags:
+  - API
+  - Method
+  - Méthode
+  - Reference
+  - Performance web
+translation_of: Web/API/Performance/clearMeasures
+---
+<div>{{APIRef("User Timing API")}}</div>
+
+<p>La méthode <strong><code>clearMeasures()</code></strong> supprime les <em>mesures nommées</em> du tampon d'entrée des performances du navigateur. Si la méthode est appelée sans arguments, toutes les {{domxref("PerformanceEntry", "entrées de performance")}} avec un {{domxref("PerformanceEntry.entryType","entryType")}} de « <code>measure</code> » seront supprimées du tampon d'entrée de performance.</p>
+
+<p>{{AvailableInWorkers}}</p>
+
+<h2 id="Syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+  <em>performance</em>.clearMeasures();
+  <em>performance</em>.clearMeasures(name);
+</pre>
+
+<h3 id="Arguments">Arguments</h3>
+
+<dl>
+  <dt>name {{optional_inline}}</dt>
+  <dd>Un {{domxref("DOMString")}} représentant le nom de l'horodatage. Si cet argument est omis, toutes les {{domxref("PerformanceEntry","entrées de performance")}} avec un {{domxref("PerformanceEntry.entryType","entrType")}} de « <code>measure</code> » seront supprimés.</dd>
+</dl>
+
+<h3 id="Return_value">Valeur de retour</h3>
+
+<dl>
+  <dt>void</dt>
+  <dd> </dd>
+</dl>
+
+<h2 id="Example">Exemple</h2>
+
+<p>L'exemple suivant montre les deux utilisations de la méthode <code>clearMeasures()</code>.</p>
+
+<pre class="brush: js">// Crée une petite aide pour montrer combien d'entrées PerformanceMeasure il y a.
+function logMeasureCount() {
+  console.log(
+    "J'ai trouvé ces nombreuses entrées : " + performance.getEntriesByType("measure").length
+  );
+}
+
+// Crée un ensemble de mesures.
+performance.measure("from navigation");
+performance.mark("a");
+performance.measure("from mark a", "a");
+performance.measure("from navigation");
+performance.measure("from mark a", "a");
+performance.mark("b");
+performance.measure("between a and b", "a", "b");
+
+logMeasureCount() // "J'ai trouvé ces nombreuses entrées : 5"
+
+// Supprime uniquement les entrées PerformanceMeasure "from navigation".
+performance.clearMeasures("from navigation");
+logMeasureCount() // "J'ai trouvé ces nombreuses entrées : 3"
+
+// Supprime toutes les entrées de PerformanceMeasure.
+performance.clearMeasures();
+logMeasureCount() // "J'ai trouvé ces nombreuses entrées : 0"
+</pre>
+
+<h2 id="Specifications">Spécifications</h2>
+
+<table class="standard-table">
+  <tbody>
+    <tr>
+      <th scope="col">Spécification</th>
+      <th scope="col">Statut</th>
+      <th scope="col">Commentaire</th>
+    </tr>
+    <tr>
+      <td>{{SpecName('User Timing Level 2', '#dom-performance-clearmeasures',
+        'clearMeasures()')}}</td>
+      <td>{{Spec2('User Timing Level 2')}}</td>
+      <td>Carification de <code>clearMeasures()</code>.</td>
+    </tr>
+    <tr>
+      <td>{{SpecName('User Timing', '#dom-performance-clearmeasures', 'clearMeasures()')}}
+      </td>
+      <td>{{Spec2('User Timing')}}</td>
+      <td>Définition initiale.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat("api.Performance.clearMeasures")}}</p>

--- a/files/fr/web/api/performance/clearmeasures/index.html
+++ b/files/fr/web/api/performance/clearmeasures/index.html
@@ -11,7 +11,7 @@ translation_of: Web/API/Performance/clearMeasures
 ---
 <div>{{APIRef("User Timing API")}}</div>
 
-<p class="seoSummary">La méthode <strong><code>clearMeasures()</code></strong> supprime les <em>mesures nommés</em> du tampon d'entrée des performances du navigateur. Si la méthode est appelée sans arguments, toutes les {{domxref("PerformanceEntry", "entrées de performance")}} avec un {{domxref("PerformanceEntry.entryType","entryType")}} de « <code>measure</code> » seront supprimées du tampon d'entrée de performance.</p>
+<p class="seoSummary">La méthode <strong><code>clearMeasures()</code></strong> supprime les <em>mesures nommées</em> du tampon d'entrée des performances du navigateur. Si la méthode est appelée sans arguments, toutes les {{domxref("PerformanceEntry", "entrées de performance","",1)}} avec un {{domxref("PerformanceEntry.entryType","entryType")}} de « <code>measure</code> » seront supprimées du tampon d'entrée de performance.</p>
 
 <p>{{AvailableInWorkers}}</p>
 
@@ -26,15 +26,12 @@ translation_of: Web/API/Performance/clearMeasures
 
 <dl>
   <dt>name {{optional_inline}}</dt>
-  <dd>Un {{domxref("DOMString")}} représentant le nom de l'horodatage. Si cet argument est omis, toutes les {{domxref("PerformanceEntry","entrées de performance")}} avec un {{domxref("PerformanceEntry.entryType","entrType")}} de « <code>measure</code> » seront supprimés.</dd>
+  <dd>Un {{domxref("DOMString")}} représentant le nom de l'horodatage. Si cet argument est omis, toutes les {{domxref("PerformanceEntry","entrées de performance","",1)}} avec un {{domxref("PerformanceEntry.entryType","entrType")}} de « <code>measure</code> » seront supprimés.</dd>
 </dl>
 
 <h3 id="Return_value">Valeur de retour</h3>
 
-<dl>
-  <dt>void</dt>
-  <dd> </dd>
-</dl>
+<p>Aucune.</p>
 
 <h2 id="Example">Exemple</h2>
 
@@ -70,12 +67,14 @@ logMeasureCount() // "J'ai trouvé ces nombreuses entrées : 0"
 <h2 id="Specifications">Spécifications</h2>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
       <th scope="col">Spécification</th>
       <th scope="col">Statut</th>
       <th scope="col">Commentaire</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td>{{SpecName('User Timing Level 2', '#dom-performance-clearmeasures',
         'clearMeasures()')}}</td>

--- a/files/fr/web/api/performance/clearresourcetimings/index.html
+++ b/files/fr/web/api/performance/clearresourcetimings/index.html
@@ -11,7 +11,7 @@ translation_of: Web/API/Performance/clearResourceTimings
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
-<p class="seoSummary">La méthode <strong><code>clearResourceTimings()</code></strong> supprime toutes les {{domxref("PerformanceEntry", "entrées de performance")}} avec un {{domxref("PerformanceEntry.entryType","entryType")}} de « <code>resource</code> » du tampon d'entrée de performance et fixe la taille du tampon de données de performance à zéro. Pour définir la taille du tampon de données de performance du navigateur, utilisez la méthode {{domxref("Performance.setResourceTimingBufferSize()")}}.</p>
+<p class="seoSummary">La méthode <strong><code>clearResourceTimings()</code></strong> supprime toutes les {{domxref("PerformanceEntry", "entrées de performance","",1)}} avec un {{domxref("PerformanceEntry.entryType","entryType")}} de « <code>resource</code> » du tampon d'entrée de performance et fixe la taille du tampon de données de performance à zéro. Pour définir la taille du tampon de données de performance du navigateur, utilisez la méthode {{domxref("Performance.setResourceTimingBufferSize()")}}.</p>
 
 <p>{{AvailableInWorkers}}</p>
 
@@ -22,17 +22,11 @@ translation_of: Web/API/Performance/clearResourceTimings
 
 <h3 id="Arguments">Arguments</h3>
 
-<dl>
-  <dt>void</dt>
-  <dd> </dd>
-</dl>
+<p>Aucun.</p>
 
 <h3 id="Return_Value">Valeur de retour</h3>
 
-<dl>
-  <dt>none</dt>
-  <dd>Cette méthode n'a pas de valeur de retour.</dd>
-</dl>
+<p>Aucune.</p>
 
 <h2 id="Example">Exemple</h2>
 
@@ -68,12 +62,14 @@ function clear_performance_timings() {
 <h2 id="Specifications">Spécifications</h2>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
       <th scope="col">Spécification</th>
       <th scope="col">Statut</th>
       <th scope="col">Commentaire</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td>{{SpecName('Resource Timing', '#dom-performance-clearresourcetimings',
         'clearResourceTimings()')}}</td>

--- a/files/fr/web/api/performance/clearresourcetimings/index.html
+++ b/files/fr/web/api/performance/clearresourcetimings/index.html
@@ -1,0 +1,87 @@
+---
+title: performance.clearResourceTimings()
+slug: Web/API/Performance/clearResourceTimings
+tags:
+- API
+- Method
+- Reference
+- Web Performance
+translation_of: Web/API/Performance/clearResourceTimings
+---
+<div>{{APIRef("Resource Timing API")}}</div>
+
+<p>La méthode <strong><code>clearResourceTimings()</code></strong> supprime toutes les {{domxref("PerformanceEntry", "entrées de performance")}} avec un {{domxref("PerformanceEntry.entryType","entryType")}} de « <code>resource</code> » du tampon d'entrée de performance et fixe la taille du tampon de données de performance à zéro. Pour définir la taille du tampon de données de performance du navigateur, utilisez la méthode {{domxref("Performance.setResourceTimingBufferSize()")}}.</p>
+
+<p>{{AvailableInWorkers}}</p>
+
+<h2 id="Syntax">Syntaxe</h2>
+
+<pre class="brush: js"><em>performance</em>.clearResourceTimings();
+</pre>
+
+<h3 id="Arguments">Arguments</h3>
+
+<dl>
+  <dt>void</dt>
+  <dd> </dd>
+</dl>
+
+<h3 id="Return_Value">Valeur de retour</h3>
+
+<dl>
+  <dt>none</dt>
+  <dd>Cette méthode n'a pas de valeur de retour.</dd>
+</dl>
+
+<h2 id="Example">Exemple</h2>
+
+<pre class="brush: js">function load_resource() {
+  var image = new Image();
+  image.src = "https://developer.mozilla.org/static/img/opengraph-logo.png";
+}
+function clear_performance_timings() {
+  if (performance === undefined) {
+    log("Le navigateur ne prend pas en charge les performances Web");
+    return;
+  }
+  // Crée une entrée de performance de synchronisation des ressources en chargeant une image
+  load_resource();
+
+  var supported = typeof performance.clearResourceTimings == "function";
+  if (supported) {
+    console.log("Exécuter : performance.clearResourceTimings()");
+    performance.clearResourceTimings();
+  } else {
+    console.log("performance.clearResourceTimings() N'EST PAS supporté");
+    return;
+  }
+  // getEntries devrait maintenant retourner zéro
+  var p = performance.getEntriesByType("resource");
+  if (p.length == 0)
+    console.log("... Le tampon de données de performance a été effacé");
+  else
+    console.log("... Le tampon de données de performance n'a PAS été effacé !");
+}
+</pre>
+
+<h2 id="Specifications">Spécifications</h2>
+
+<table class="standard-table">
+  <tbody>
+    <tr>
+      <th scope="col">Spécification</th>
+      <th scope="col">Statut</th>
+      <th scope="col">Commentaire</th>
+    </tr>
+    <tr>
+      <td>{{SpecName('Resource Timing', '#dom-performance-clearresourcetimings',
+        'clearResourceTimings()')}}</td>
+      <td>{{Spec2('Resource Timing')}}</td>
+      <td>Définition initiale.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat("api.Performance.clearResourceTimings")}}</p>

--- a/files/fr/web/api/performance/clearresourcetimings/index.html
+++ b/files/fr/web/api/performance/clearresourcetimings/index.html
@@ -4,8 +4,9 @@ slug: Web/API/Performance/clearResourceTimings
 tags:
 - API
 - Method
+- Méthode
 - Reference
-- Web Performance
+- Performance web
 translation_of: Web/API/Performance/clearResourceTimings
 ---
 <div>{{APIRef("Resource Timing API")}}</div>

--- a/files/fr/web/api/performance/clearresourcetimings/index.html
+++ b/files/fr/web/api/performance/clearresourcetimings/index.html
@@ -11,7 +11,7 @@ translation_of: Web/API/Performance/clearResourceTimings
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
-<p>La méthode <strong><code>clearResourceTimings()</code></strong> supprime toutes les {{domxref("PerformanceEntry", "entrées de performance")}} avec un {{domxref("PerformanceEntry.entryType","entryType")}} de « <code>resource</code> » du tampon d'entrée de performance et fixe la taille du tampon de données de performance à zéro. Pour définir la taille du tampon de données de performance du navigateur, utilisez la méthode {{domxref("Performance.setResourceTimingBufferSize()")}}.</p>
+<p class="seoSummary">La méthode <strong><code>clearResourceTimings()</code></strong> supprime toutes les {{domxref("PerformanceEntry", "entrées de performance")}} avec un {{domxref("PerformanceEntry.entryType","entryType")}} de « <code>resource</code> » du tampon d'entrée de performance et fixe la taille du tampon de données de performance à zéro. Pour définir la taille du tampon de données de performance du navigateur, utilisez la méthode {{domxref("Performance.setResourceTimingBufferSize()")}}.</p>
 
 <p>{{AvailableInWorkers}}</p>
 

--- a/files/fr/web/api/performance/getentries/index.html
+++ b/files/fr/web/api/performance/getentries/index.html
@@ -1,0 +1,103 @@
+---
+title: performance.getEntries()
+slug: Web/API/Performance/getEntries
+tags:
+- API
+- Method
+- Reference
+- Web Performance
+translation_of: Web/API/Performance/getEntries
+---
+<div>{{APIRef("Performance Timeline API")}}</div>
+
+<p>La méthode <strong><code>getEntries()</code></strong> renvoie une liste de tous les objets {{domxref("PerformanceEntry")}} pour la page. Les membres de la liste (<em>entrées</em>) peuvent être créés en faisant des <em>marques</em> ou des <em>mesures</em> de performance (par exemple en appelant la méthode {{domxref("Performance.mark", "mark()")}}) à des moments explicites. Si vous ne vous intéressez qu'aux entrées de performance de certains types ou qui portent certains noms, regardez {{domxref("Performance.getEntriesByType", "getEntriesByType()")}} et {{domxref("Performance.getEntriesByName", "getEntriesByName()")}}.</p>
+
+<p>{{AvailableInWorkers}}</p>
+
+<h2 id="Syntax">Syntaxe</h2>
+
+<p>Syntaxe générale :</p>
+
+<pre class="brush: js">
+  <em>entries</em> = window.performance.getEntries();
+</pre>
+
+<h3 id="Return_Value">Valeur de retour</h3>
+
+<dl>
+  <dt>entries</dt>
+  <dd>Un <code>array</code> d'objets {{domxref("PerformanceEntry")}}. Les éléments seront classés par ordre chronologique en fonction des entrées {{domxref("PerformanceEntry.startTime","startTime")}}.</dd>
+</dl>
+
+<h2 id="Example">Exemple</h2>
+
+<pre class="brush: js">function use_PerformanceEntry_methods() {
+  console.log("PerformanceEntry tests ...");
+
+  if (performance.mark === undefined) {
+    console.log("... performance.mark Non pris en charge");
+    return;
+  }
+
+  // Crée quelques entrées de performance via la méthode mark()
+  performance.mark("Begin");
+  do_work(50000);
+  performance.mark("End");
+  performance.mark("Begin");
+  do_work(100000);
+  performance.mark("End");
+  do_work(200000);
+  performance.mark("End");
+
+  // Utilise getEntries() pour itérer à travers chaque entrée.
+  let p = performance.getEntries();
+  for (var i=0; i &lt; p.length; i++) {
+    console.log("Entry[" + i + "]");
+    check_PerformanceEntry(p[i]);
+  }
+
+  // Utilise getEntriesByType() pour obtenir toutes les entrées "mark".
+  p = performance.getEntriesByType("mark");
+  for (let i=0; i &lt; p.length; i++) {
+    console.log ("Mark only entry[" + i + "]: name = " + p[i].name +
+         "; startTime = " + p[i].startTime +
+         "; duration  = " + p[i].duration);
+  }
+
+  // Utilise getEntriesByName() pour obtenir toutes les entrées "mark" nommées "Begin".
+  p = performance.getEntriesByName("Begin", "mark");
+  for (let i=0; i &lt; p.length; i++) {
+    console.log ("Mark and Begin entry[" + i + "]: name = " + p[i].name +
+         "; startTime = " + p[i].startTime +
+         "; duration  = " + p[i].duration);
+  }
+}
+</pre>
+
+<h2 id="Specifications">Spécifications</h2>
+
+<table class="standard-table">
+  <tbody>
+    <tr>
+      <th scope="col">Spécification</th>
+      <th scope="col">Statut</th>
+      <th scope="col">Commentaire</th>
+    </tr>
+    <tr>
+      <td>{{SpecName('Performance Timeline Level 2', '#dom-performance-getentries',
+        'getEntries()')}}</td>
+      <td>{{Spec2('Performance Timeline Level 2')}}</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>{{SpecName('Performance Timeline', '#dom-performance-getentries',
+        'getEntries()')}}</td>
+      <td>{{Spec2('Performance Timeline')}}</td>
+      <td>Définition initiale.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat("api.Performance.getEntries")}}</p>

--- a/files/fr/web/api/performance/getentries/index.html
+++ b/files/fr/web/api/performance/getentries/index.html
@@ -4,8 +4,9 @@ slug: Web/API/Performance/getEntries
 tags:
 - API
 - Method
+- Méthode
 - Reference
-- Web Performance
+- Performance web
 translation_of: Web/API/Performance/getEntries
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>

--- a/files/fr/web/api/performance/getentries/index.html
+++ b/files/fr/web/api/performance/getentries/index.html
@@ -11,23 +11,21 @@ translation_of: Web/API/Performance/getEntries
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
-<p class="seoSummary">La méthode <strong><code>getEntries()</code></strong> renvoie une liste de tous les objets {{domxref("PerformanceEntry")}} pour la page. Les membres de la liste (<em>entrées</em>) peuvent être créés en faisant des <em>marqueurs</em> ou des <em>mesures</em> de performance (par exemple en appelant la méthode {{domxref("Performance.mark", "mark()")}}) à des moments explicites. Si vous ne vous intéressez qu'aux entrées de performance de certains types ou qui portent certains noms, regardez {{domxref("Performance.getEntriesByType", "getEntriesByType()")}} et {{domxref("Performance.getEntriesByName", "getEntriesByName()")}}.</p>
+<p class="seoSummary">La méthode <strong><code>getEntries()</code></strong> renvoie une liste de tous les objets {{domxref("PerformanceEntry")}} pour la page. Les membres de la liste (<em>entrées</em>) peuvent être créés en faisant des <em>marqueurs</em> ou des <em>mesures</em> de performance (par exemple en appelant la méthode {{domxref("Performance.mark", "mark()")}}) à des moments explicites. Si vous souhaitez filtrer  les entrées de performance en fonction de leur type ou de leur nom, consultez la documentation des méthodes {{domxref("Performance.getEntriesByType", "getEntriesByType()")}} et {{domxref("Performance.getEntriesByName", "getEntriesByName()")}}.</p>
 
 <p>{{AvailableInWorkers}}</p>
 
 <h2 id="Syntax">Syntaxe</h2>
 
-<p>Syntaxe générale :</p>
-
 <pre class="brush: js">
-  <em>entries</em> = window.performance.getEntries();
+  <var>entries</var> = window.performance.getEntries();
 </pre>
 
 <h3 id="Return_Value">Valeur de retour</h3>
 
 <dl>
-  <dt>entries</dt>
-  <dd>Un <code>array</code> d'objets {{domxref("PerformanceEntry")}}. Les éléments seront classés par ordre chronologique en fonction des entrées {{domxref("PerformanceEntry.startTime","startTime")}}.</dd>
+  <dt><code>entries</code></dt>
+  <dd>Un tableau ({{jsxref("Array")}}) d'objets {{domxref("PerformanceEntry")}}. Les éléments seront classés par ordre chronologique en fonction des entrées {{domxref("PerformanceEntry.startTime","startTime")}}.</dd>
 </dl>
 
 <h2 id="Example">Exemple</h2>
@@ -78,12 +76,14 @@ translation_of: Web/API/Performance/getEntries
 <h2 id="Specifications">Spécifications</h2>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
-      <th scope="col">Spécification</th>
-      <th scope="col">Statut</th>
-      <th scope="col">Commentaire</th>
+        <th scope="col">Spécification</th>
+        <th scope="col">Statut</th>
+        <th scope="col">Commentaire</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td>{{SpecName('Performance Timeline Level 2', '#dom-performance-getentries',
         'getEntries()')}}</td>

--- a/files/fr/web/api/performance/getentries/index.html
+++ b/files/fr/web/api/performance/getentries/index.html
@@ -11,7 +11,7 @@ translation_of: Web/API/Performance/getEntries
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
-<p>La méthode <strong><code>getEntries()</code></strong> renvoie une liste de tous les objets {{domxref("PerformanceEntry")}} pour la page. Les membres de la liste (<em>entrées</em>) peuvent être créés en faisant des <em>marques</em> ou des <em>mesures</em> de performance (par exemple en appelant la méthode {{domxref("Performance.mark", "mark()")}}) à des moments explicites. Si vous ne vous intéressez qu'aux entrées de performance de certains types ou qui portent certains noms, regardez {{domxref("Performance.getEntriesByType", "getEntriesByType()")}} et {{domxref("Performance.getEntriesByName", "getEntriesByName()")}}.</p>
+<p class="seoSummary">La méthode <strong><code>getEntries()</code></strong> renvoie une liste de tous les objets {{domxref("PerformanceEntry")}} pour la page. Les membres de la liste (<em>entrées</em>) peuvent être créés en faisant des <em>marqueurs</em> ou des <em>mesures</em> de performance (par exemple en appelant la méthode {{domxref("Performance.mark", "mark()")}}) à des moments explicites. Si vous ne vous intéressez qu'aux entrées de performance de certains types ou qui portent certains noms, regardez {{domxref("Performance.getEntriesByType", "getEntriesByType()")}} et {{domxref("Performance.getEntriesByName", "getEntriesByName()")}}.</p>
 
 <p>{{AvailableInWorkers}}</p>
 

--- a/files/fr/web/api/performance/getentriesbyname/index.html
+++ b/files/fr/web/api/performance/getentriesbyname/index.html
@@ -11,30 +11,30 @@ translation_of: Web/API/Performance/getEntriesByName
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
-<p class="seoSummary">La méthode <strong><code>getEntriesByName()</code></strong> renvoie une liste de tous les objets {{domxref("PerformanceEntry")}} pour les <em>name</em> et <em>type</em> donnés. Les membres de la liste (<em>entrées</em>) peuvent être créés en faisant des <em>marqueurs</em> ou des <em>mesures</em> de performance (par exemple en appelant la méthode {{domxref("Performance.mark", "mark()")}}) à des moments explicites.</p>
+<p class="seoSummary">La méthode <strong><code>getEntriesByName()</code></strong> renvoie une liste de tous les objets {{domxref("PerformanceEntry")}} ayant un nom (et éventuellement un type) donné(s). Les entrées de performance auront pu être créées au préalable avec des <em>marqueurs</em> ou des <em>mesures</em> de performance (par exemple en appelant la méthode {{domxref("Performance.mark", "mark()")}}) à des moments explicites.</p>
 
 <p>{{AvailableInWorkers}}</p>
 
 <h2 id="Syntax">Syntaxe</h2>
 
 <pre class="brush: js">
-  <em>entries</em> = window.performance.getEntriesByName(name, type);
+  <var>entries</var> = window.performance.getEntriesByName(name, type);
 </pre>
 
 <h3 id="Arguments">Arguments</h3>
 
 <dl>
-  <dt>name</dt>
+  <dt><code>name</code></dt>
   <dd>Le nom de l'entrée à récupérer.</dd>
-  <dt>type {{optional_inline}}</dt>
+  <dt><code>type</code> {{optional_inline}}</dt>
   <dd>Le type d'entrée à récupérer tel que « <code>mark</code> ». Les types d'entrées valides sont listés dans {{domxref("PerformanceEntry.entryType")}}.</dd>
 </dl>
 
 <h3 id="Return_Value">Valeur de retour</h3>
 
 <dl>
-  <dt>entries</dt>
-  <dd>Une liste de tous les objets {{domxref("PerformanceEntry")}} ayant les <em>name</em> et <em>type</em> spécifiés. Si l'argument <code>type</code> n'est pas spécifié, seul le <code>name</code> sera utilisé pour déterminer les entrées à retourner. Les éléments seront dans l'ordre chronologique basé sur les {{domxref("PerformanceEntry.startTime", "startTime")}} des entrées. Si aucun objet ne répond aux critères spécifiés, une liste vide est retournée.</dd>
+  <dt><code>entries</code></dt>
+  <dd>Une liste de tous les objets {{domxref("PerformanceEntry")}} ayant le nom et le type spécifiés. Si l'argument <code>type</code> n'est pas spécifié, seul le nom (<code>name</code>) sera utilisé pour déterminer les entrées à renvoyer. Les éléments seront dans l'ordre chronologique basé sur les {{domxref("PerformanceEntry.startTime", "startTime")}} des entrées. Si aucun objet ne répond aux critères spécifiés, une liste vide est retournée.</dd>
 </dl>
 
 <h2 id="Example">Exemple</h2>
@@ -92,12 +92,14 @@ translation_of: Web/API/Performance/getEntriesByName
 <h2 id="Specifications">Spécifications</h2>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
       <th scope="col">Spécification</th>
       <th scope="col">Statut</th>
       <th scope="col">Commentaire</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td>{{SpecName('Performance Timeline Level 2', '#dom-performance-getentriesbyname',
         'getEntriesByName()')}}</td>

--- a/files/fr/web/api/performance/getentriesbyname/index.html
+++ b/files/fr/web/api/performance/getentriesbyname/index.html
@@ -1,0 +1,118 @@
+---
+title: performance.getEntriesByName()
+slug: Web/API/Performance/getEntriesByName
+tags:
+  - API
+  - Method
+  - Méthode
+  - Reference
+  - Performance web
+translation_of: Web/API/Performance/getEntriesByName
+---
+<div>{{APIRef("Performance Timeline API")}}</div>
+
+<p>La méthode <strong><code>getEntriesByName()</code></strong> renvoie une liste de tous les objets {{domxref("PerformanceEntry")}} pour les <em>name</em> et <em>type</em> donnés. Les membres de la liste (<em>entrées</em>) peuvent être créés en faisant des <em>marques</em> ou des <em>mesures</em> de performance (par exemple en appelant la méthode {{domxref("Performance.mark", "mark()")}}) à des moments explicites.</p>
+
+<p>{{AvailableInWorkers}}</p>
+
+<h2 id="Syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+  <em>entries</em> = window.performance.getEntriesByName(name, type);
+</pre>
+
+<h3 id="Arguments">Arguments</h3>
+
+<dl>
+  <dt>name</dt>
+  <dd>Le nom de l'entrée à récupérer.</dd>
+  <dt>type {{optional_inline}}</dt>
+  <dd>Le type d'entrée à récupérer tel que « <code>mark</code> ». Les types d'entrées valides sont listés dans {{domxref("PerformanceEntry.entryType")}}.</dd>
+</dl>
+
+<h3 id="Return_Value">Valeur de retour</h3>
+
+<dl>
+  <dt>entries</dt>
+  <dd>Une liste de tous les objets {{domxref("PerformanceEntry")}} ayant les <em>name</em> et <em>type</em> spécifiés. Si l'argument <code>type</code> n'est pas spécifié, seul le <code>name</code> sera utilisé pour déterminer les entrées à retourner. Les éléments seront dans l'ordre chronologique basé sur les {{domxref("PerformanceEntry.startTime", "startTime")}} des entrées. Si aucun objet ne répond aux critères spécifiés, une liste vide est retournée.</dd>
+</dl>
+
+<h2 id="Example">Exemple</h2>
+
+<pre class="brush: js">function use_PerformanceEntry_methods() {
+  log("PerformanceEntry tests ...");
+
+  if (performance.mark === undefined) {
+    log("... performance.mark Non pris en charge");
+    return;
+  }
+
+  // Crée quelques entrées de performance via la méthode mark()
+  performance.mark("Begin");
+  do_work(50000);
+  performance.mark("End");
+  performance.mark("Begin");
+  do_work(100000);
+  performance.mark("End");
+  do_work(200000);
+  performance.mark("End");
+
+  // Utilise getEntries() pour itérer à travers chaque entrée
+  var p = performance.getEntries();
+  for (var i=0; i &lt; p.length; i++) {
+    log("Entry[" + i + "]");
+    check_PerformanceEntry(p[i]);
+  }
+
+  // Utilise getEntries(name, entryType) pour obtenir des entrées spécifiques
+  p = performance.getEntries({name : "Begin", entryType: "mark"});
+  for (var i=0; i &lt; p.length; i++) {
+    log("Begin[" + i + "]");
+    check_PerformanceEntry(p[i]);
+  }
+
+  // Utilise getEntriesByType() pour obtenir toutes les entrées "mark"
+  p = performance.getEntriesByType("mark");
+  for (var i=0; i &lt; p.length; i++) {
+    log ("Mark only entry[" + i + "]: name = " + p[i].name +
+         "; startTime = " + p[i].startTime +
+         "; duration  = " + p[i].duration);
+  }
+
+  // Utilisez getEntriesByName() pour obtenir toutes les entrées "mark" nommées "Begin"
+  p = performance.getEntriesByName("Begin", "mark");
+  for (var i=0; i &lt; p.length; i++) {
+    log ("Mark and Begin entry[" + i + "]: name = " + p[i].name +
+         "; startTime = " + p[i].startTime +
+         "; duration  = " + p[i].duration);
+  }
+}
+</pre>
+
+<h2 id="Specifications">Spécifications</h2>
+
+<table class="standard-table">
+  <tbody>
+    <tr>
+      <th scope="col">Spécification</th>
+      <th scope="col">Statut</th>
+      <th scope="col">Commentaire</th>
+    </tr>
+    <tr>
+      <td>{{SpecName('Performance Timeline Level 2', '#dom-performance-getentriesbyname',
+        'getEntriesByName()')}}</td>
+      <td>{{Spec2('Performance Timeline Level 2')}}</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>{{SpecName('Performance Timeline', '#dom-performance-getentriesbyname',
+        'getEntriesByName()')}}</td>
+      <td>{{Spec2('Performance Timeline')}}</td>
+      <td>Définition initiale.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat("api.Performance.getEntriesByName")}}</p>

--- a/files/fr/web/api/performance/getentriesbyname/index.html
+++ b/files/fr/web/api/performance/getentriesbyname/index.html
@@ -11,7 +11,7 @@ translation_of: Web/API/Performance/getEntriesByName
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
-<p>La méthode <strong><code>getEntriesByName()</code></strong> renvoie une liste de tous les objets {{domxref("PerformanceEntry")}} pour les <em>name</em> et <em>type</em> donnés. Les membres de la liste (<em>entrées</em>) peuvent être créés en faisant des <em>marques</em> ou des <em>mesures</em> de performance (par exemple en appelant la méthode {{domxref("Performance.mark", "mark()")}}) à des moments explicites.</p>
+<p class="seoSummary">La méthode <strong><code>getEntriesByName()</code></strong> renvoie une liste de tous les objets {{domxref("PerformanceEntry")}} pour les <em>name</em> et <em>type</em> donnés. Les membres de la liste (<em>entrées</em>) peuvent être créés en faisant des <em>marqueurs</em> ou des <em>mesures</em> de performance (par exemple en appelant la méthode {{domxref("Performance.mark", "mark()")}}) à des moments explicites.</p>
 
 <p>{{AvailableInWorkers}}</p>
 

--- a/files/fr/web/api/performance/getentriesbytype/index.html
+++ b/files/fr/web/api/performance/getentriesbytype/index.html
@@ -11,7 +11,7 @@ translation_of: Web/API/Performance/getEntriesByType
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
-<p>La méthode <strong><code>getEntriesByName()</code></strong> renvoie une liste de tous les objets {{domxref("PerformanceEntry")}} pour les <em>type</em> donnés. Les membres de la liste (<em>entrées</em>) peuvent être créés en faisant des <em>marques</em> ou des <em>mesures</em> de performance (par exemple en appelant la méthode {{domxref("Performance.mark", "mark()")}}) à des moments explicites.</p>
+<p class="seoSummary">La méthode <strong><code>getEntriesByName()</code></strong> renvoie une liste de tous les objets {{domxref("PerformanceEntry")}} pour les <em>type</em> donnés. Les membres de la liste (<em>entrées</em>) peuvent être créés en faisant des <em>marqueurs</em> ou des <em>mesures</em> de performance (par exemple en appelant la méthode {{domxref("Performance.mark", "mark()")}}) à des moments explicites.</p>
 
 <p>{{AvailableInWorkers}}</p>
 

--- a/files/fr/web/api/performance/getentriesbytype/index.html
+++ b/files/fr/web/api/performance/getentriesbytype/index.html
@@ -1,0 +1,116 @@
+---
+title: performance.getEntriesByType()
+slug: Web/API/Performance/getEntriesByType
+tags:
+- API
+- Method
+- Méthode
+- Reference
+- Performance web
+translation_of: Web/API/Performance/getEntriesByType
+---
+<div>{{APIRef("Performance Timeline API")}}</div>
+
+<p>La méthode <strong><code>getEntriesByName()</code></strong> renvoie une liste de tous les objets {{domxref("PerformanceEntry")}} pour les <em>type</em> donnés. Les membres de la liste (<em>entrées</em>) peuvent être créés en faisant des <em>marques</em> ou des <em>mesures</em> de performance (par exemple en appelant la méthode {{domxref("Performance.mark", "mark()")}}) à des moments explicites.</p>
+
+<p>{{AvailableInWorkers}}</p>
+
+<h2 id="Syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+  <em>entries</em> = window.performance.getEntriesByType(type);
+</pre>
+
+<h3 id="Arguments">Arguments</h3>
+
+<dl>
+  <dt>type</dt>
+  <dd>Le type d'entrée à récupérer tel que « <code>mark</code> ». Les types d'entrées valides sont listés dans {{domxref("PerformanceEntry.entryType")}}.</dd>
+</dl>
+
+<h3 id="Return_Value">Valeur de retour</h3>
+
+<dl>
+  <dt>entries</dt>
+  <dd>Une liste de tous les objets {{domxref("PerformanceEntry")}} ayant les <em>type</em> spécifiés. Les éléments seront dans l'ordre chronologique basé sur les {{domxref("PerformanceEntry.startTime", "startTime")}} des entrées. Si aucun objet ne possède le <code>type</code> spécifié, ou si aucun argument n'est fourni, une liste vide est retournée.</dd>
+</dl>
+
+<h2 id="Example">Exemple</h2>
+
+<pre class="brush: js">function usePerformanceEntryMethods() {
+  log("PerformanceEntry tests ...");
+
+  if (performance.mark === undefined) {
+    log("... performance.mark Non pris en charge");
+    return;
+  }
+
+  // Crée quelques entrées de performance via la méthode mark()
+  performance.mark("Begin");
+  doWork(50000);
+  performance.mark("End");
+  performance.mark("Begin");
+  doWork(100000);
+  performance.mark("End");
+  doWork(200000);
+  performance.mark("End");
+
+  // Utilise getEntries() pour itérer à travers chaque entrée.
+  var p = performance.getEntries();
+  for (var i=0; i &lt; p.length; i++) {
+    log("Entry[" + i + "]");
+    checkPerformanceEntry(p[i]);
+  }
+
+  // Utilise getEntries(name, entryType) pour obtenir des entrées spécifiques.
+  p = performance.getEntries({name : "Begin", entryType: "mark"});
+  for (var i=0; i &lt; p.length; i++) {
+    log("Begin[" + i + "]");
+    checkPerformanceEntry(p[i]);
+  }
+
+  // Utilise getEntriesByType() pour obtenir toutes les entrées "mark".
+  p = performance.getEntriesByType("mark");
+  for (var i=0; i &lt; p.length; i++) {
+    log("Mark only entry[" + i + "]: name = " + p[i].name +
+         "; startTime = " + p[i].startTime +
+         "; duration  = " + p[i].duration);
+  }
+
+  // Utilise getEntriesByName() pour obtenir toutes les entrées "mark" nommées "Begin".
+  p = performance.getEntriesByName("Begin", "mark");
+  for (var i=0; i &lt; p.length; i++) {
+    log("Mark and Begin entry[" + i + "]: name = " + p[i].name +
+         "; startTime = " + p[i].startTime +
+         "; duration  = " + p[i].duration);
+  }
+}
+</pre>
+
+<h2 id="Specifications">Spécifications</h2>
+
+<table class="standard-table">
+  <tbody>
+    <tr>
+      <th scope="col">Spécification</th>
+      <th scope="col">Statut</th>
+      <th scope="col">Commentaire</th>
+    </tr>
+    <tr>
+      <td>{{SpecName('Performance Timeline Level 2', '#dom-performance-getentriesbytype',
+        'getEntriesByType()')}}</td>
+      <td>{{Spec2('Performance Timeline Level 2')}}</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>{{SpecName('Performance Timeline', '#dom-performance-getentriesbytype',
+        'getEntriesByType()')}}</td>
+      <td>{{Spec2('Performance Timeline')}}</td>
+      <td>Définition initiale.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat("api.Performance.getEntriesByType")}}</p>

--- a/files/fr/web/api/performance/getentriesbytype/index.html
+++ b/files/fr/web/api/performance/getentriesbytype/index.html
@@ -11,28 +11,28 @@ translation_of: Web/API/Performance/getEntriesByType
 ---
 <div>{{APIRef("Performance Timeline API")}}</div>
 
-<p class="seoSummary">La méthode <strong><code>getEntriesByName()</code></strong> renvoie une liste de tous les objets {{domxref("PerformanceEntry")}} pour les <em>type</em> donnés. Les membres de la liste (<em>entrées</em>) peuvent être créés en faisant des <em>marqueurs</em> ou des <em>mesures</em> de performance (par exemple en appelant la méthode {{domxref("Performance.mark", "mark()")}}) à des moments explicites.</p>
+<p class="seoSummary">La méthode <strong><code>getEntriesByName()</code></strong> renvoie une liste de tous les objets {{domxref("PerformanceEntry")}} pour le type donné. Les entrées de performance auront pu être créées au préalable avec des <em>marqueurs</em> ou des <em>mesures</em> de performance (par exemple en appelant la méthode {{domxref("Performance.mark", "mark()")}}) à des moments explicites.</p>
 
 <p>{{AvailableInWorkers}}</p>
 
 <h2 id="Syntax">Syntaxe</h2>
 
 <pre class="brush: js">
-  <em>entries</em> = window.performance.getEntriesByType(type);
+  let <var>entries</var> = window.performance.getEntriesByType(type);
 </pre>
 
 <h3 id="Arguments">Arguments</h3>
 
 <dl>
-  <dt>type</dt>
+  <dt><code>type</code></dt>
   <dd>Le type d'entrée à récupérer tel que « <code>mark</code> ». Les types d'entrées valides sont listés dans {{domxref("PerformanceEntry.entryType")}}.</dd>
 </dl>
 
 <h3 id="Return_Value">Valeur de retour</h3>
 
 <dl>
-  <dt>entries</dt>
-  <dd>Une liste de tous les objets {{domxref("PerformanceEntry")}} ayant les <em>type</em> spécifiés. Les éléments seront dans l'ordre chronologique basé sur les {{domxref("PerformanceEntry.startTime", "startTime")}} des entrées. Si aucun objet ne possède le <code>type</code> spécifié, ou si aucun argument n'est fourni, une liste vide est retournée.</dd>
+  <dt><code>entries</code></dt>
+  <dd>Une liste de tous les objets {{domxref("PerformanceEntry")}} ayant le <em>type</em> spécifié. Les éléments seront triés dans l'ordre chronologique basé sur les propriétés {{domxref("PerformanceEntry.startTime", "startTime")}} des entrées. Si aucun objet ne possède le type spécifié, ou si aucun argument n'est fourni, une liste vide est renvoyée.</dd>
 </dl>
 
 <h2 id="Example">Exemple</h2>
@@ -90,12 +90,14 @@ translation_of: Web/API/Performance/getEntriesByType
 <h2 id="Specifications">Spécifications</h2>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
       <th scope="col">Spécification</th>
       <th scope="col">Statut</th>
       <th scope="col">Commentaire</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td>{{SpecName('Performance Timeline Level 2', '#dom-performance-getentriesbytype',
         'getEntriesByType()')}}</td>

--- a/files/fr/web/api/performance/index.html
+++ b/files/fr/web/api/performance/index.html
@@ -11,11 +11,11 @@ translation_of: Web/API/Performance
 ---
 <div>{{APIRef("High Resolution Time")}}</div>
 
-<p>L'interface <strong><code>Performance</code></strong> donne accès à des informations liées aux performances pour la page actuelle. Elle fait partie de l'API « High Resolution Time », mais est complétée par les APIs <a href="/fr/docs/Web/API/Performance_Timeline">Performance Timeline</a>, <a href="/fr/docs/Web/API/Navigation_timing_API">Navigation Timing</a>, <a href="/fr/docs/Web/API/User_Timing_API">User Timing</a>, et <a href="/fr/docs/Web/API/Resource_Timing_API">Resource Timing</a>.</p>
+<p class="seoSummary">L'interface <strong><code>Performance</code></strong> donne accès à des informations liées aux performances pour la page actuelle. Elle fait partie de l'API « High Resolution Time », mais est complétée par les APIs <a href="/fr/docs/Web/API/Performance_Timeline">Performance Timeline</a>, <a href="/fr/docs/Web/API/Navigation_timing_API">Navigation Timing</a>, <a href="/fr/docs/Web/API/User_Timing_API">User Timing</a>, et <a href="/fr/docs/Web/API/Resource_Timing_API">Resource Timing</a>.</p>
 
 <p>Un objet de ce type peut être obtenu en appelant l'attribut en lecture seule {{domxref("Window.performance")}}.</p>
 
-<div class="note">
+<div class="notecard note">
   <p><strong>Note :</strong> Cette interface et ses attributs sont accessibles aux <a href="/fr/docs/Web/API/Web_Workers_API">Web Workers</a> via <code><a href="/fr/docs/Web/API/WorkerGlobalScope/performance">WorkerGlobalScope.performance</a></code> sauf dans les cas cités ci-dessous. Notez également que les marqueurs et les mesures de performance sont définis par contexte. Si vous créez un marqueur dans le processus principal (ou un autre Web Worker), vous ne pourrez pas le voir dans le processus du Web Worker, et réciproquement.</p>
 </div>
 
@@ -28,7 +28,7 @@ translation_of: Web/API/Performance
     {{domxref("performance.navigation")}} {{readonlyInline}} {{deprecated_inline}}
   </dt>
   <dd>
-    {{domxref("PerformanceNavigation")}} est un objet qui fournit des informations contextuelles sur les opérations inclues dans les indicateurs de <code>timing</code>, notamment si la page a été chargée ou actualisée, combien de redirections ont été effectuées, etc…
+    {{domxref("PerformanceNavigation")}} est un objet qui fournit des informations contextuelles sur les opérations incluses dans les indicateurs de <code>timing</code>, notamment si la page a été chargée ou actualisée, combien de redirections ont été effectuées, etc…
     <div class="notecard note">
       <p>Indisponible dans les Web Workers.</p>
     </div>
@@ -48,7 +48,7 @@ translation_of: Web/API/Performance
     Une <em>extension non standard</em> ajoutée dans Chrome, cette propriété fournit à un objet des informations de base sur l'utilisation de la mémoire. <em>Vous <strong>ne devriez pas utiliser</strong> cette API non standard.</em>
   </dd>
   <dt>
-    {{domxref("Performance.timeOrigin")}} {{readonlyInline}} {{Non-standard_inline}}
+    {{domxref("Performance.timeOrigin")}} {{readonlyInline}} {{Experimental_inline}}
   </dt>
   <dd>
     Renvoie un horodatage haute résolution de l'heure de début de la mesure de performance.
@@ -84,9 +84,9 @@ translation_of: Web/API/Performance
   <dd>Retourne un objet JSON représentant l'objet <code>Performance</code>.</dd>
 </dl>
 
-<h2 id="Events">Événéments</h2>
+<h2 id="Events">Événements</h2>
 
-<p>Écoutez ces événéments en utilisant <code>addEventListener()</code> ou en assignant un écouteur d'événément à la propriété <code>on<em>EventName</em></code> de cette interface.</p>
+<p>Écoutez ces événements en utilisant <code>addEventListener()</code> ou en assignant un écouteur d'événement à la propriété <code>on<em>EventName</em></code> de cette interface.</p>
 
 <dl>
   <dt>{{DOMxRef("Performance.resourcetimingbufferfull_event", "resourcetimingbufferfull")}}</dt>

--- a/files/fr/web/api/performance/index.html
+++ b/files/fr/web/api/performance/index.html
@@ -13,7 +13,7 @@ translation_of: Web/API/Performance
 
 <p class="seoSummary">L'interface <strong><code>Performance</code></strong> donne accès à des informations liées aux performances pour la page actuelle. Elle fait partie de l'API « High Resolution Time », mais est complétée par les APIs <a href="/fr/docs/Web/API/Performance_Timeline">Performance Timeline</a>, <a href="/fr/docs/Web/API/Navigation_timing_API">Navigation Timing</a>, <a href="/fr/docs/Web/API/User_Timing_API">User Timing</a>, et <a href="/fr/docs/Web/API/Resource_Timing_API">Resource Timing</a>.</p>
 
-<p>Un objet de ce type peut être obtenu en appelant l'attribut en lecture seule {{domxref("Window.performance")}}.</p>
+<p>Un objet de ce type peut être obtenu en appelant l'attribut en lecture seule {{domxref("window.performance")}}.</p>
 
 <div class="notecard note">
   <p><strong>Note :</strong> Cette interface et ses attributs sont accessibles aux <a href="/fr/docs/Web/API/Web_Workers_API">Web Workers</a> via <code><a href="/fr/docs/Web/API/WorkerGlobalScope/performance">WorkerGlobalScope.performance</a></code> sauf dans les cas cités ci-dessous. Notez également que les marqueurs et les mesures de performance sont définis par contexte. Si vous créez un marqueur dans le processus principal (ou un autre Web Worker), vous ne pourrez pas le voir dans le processus du Web Worker, et réciproquement.</p>
@@ -45,13 +45,13 @@ translation_of: Web/API/Performance
   <dt>
     {{domxref("performance.memory")}} {{readonlyInline}} {{Non-standard_inline}}</dt>
   <dd>
-    Une <em>extension non standard</em> ajoutée dans Chrome, cette propriété fournit à un objet des informations de base sur l'utilisation de la mémoire. <em>Vous <strong>ne devriez pas utiliser</strong> cette API non standard.</em>
+    Une extension <em>non standard</em> ajoutée dans Chrome, cette propriété fournit à un objet des informations de base sur l'utilisation de la mémoire. <em>Vous <strong>ne devriez pas utiliser</strong> cette API non standard.</em>
   </dd>
   <dt>
     {{domxref("Performance.timeOrigin")}} {{readonlyInline}} {{Experimental_inline}}
   </dt>
   <dd>
-    Renvoie un horodatage haute résolution de l'heure de début de la mesure de performance.
+    Fournit un horodatage haute résolution de l'heure de début de la mesure de performance.
   </dd>
 </dl>
 
@@ -65,13 +65,13 @@ translation_of: Web/API/Performance
   <dt>{{domxref("performance.clearMeasures()")}}</dt>
   <dd>Supprime la <em>mesure</em> indiquée des données de performances du navigateur mises en mémoire tampon.</dd>
   <dt>{{domxref("performance.clearResourceTimings()")}}</dt>
-  <dd>Supprime toutes les {{domxref("PerformanceEntry","entrées de performance")}} avec un {{domxref("PerformanceEntry.entryType","entryType")}} "<code>resource</code>" des données de performances du navigateur mises en mémoire tampon.</dd>
+  <dd>Supprime toutes les {{domxref("PerformanceEntry","entrées de performance","",1)}} avec un {{domxref("PerformanceEntry.entryType","entryType")}} "<code>resource</code>" des données de performances du navigateur mises en mémoire tampon.</dd>
   <dt>{{domxref("performance.getEntries()")}}</dt>
-  <dd>Retourne une liste d'objets {domxref("PerformanceEntry")}} basée sur le <em>filter</em> indiqué.</dd>
+  <dd>Retourne une liste d'objets {{domxref("PerformanceEntry")}} basée sur le <em>filtre</em> indiqué.</dd>
   <dt>{{domxref("performance.getEntriesByName()")}}</dt>
-  <dd>Retourne une liste d'objets {{domxref("PerformanceEntry")}} basée sur le <em>nom</em> d'entrée indiqué.</dd>
+  <dd>Retourne une liste d'objets {{domxref("PerformanceEntry")}} basée sur le <em>nom</em> indiqué.</dd>
   <dt>{{domxref("performance.getEntriesByType()")}}</dt>
-  <dd>Retourne une liste d'objets {{domxref("PerformanceEntry")}} basée sur le <em>type</em> d'entrée indiqué.</dd>
+  <dd>Retourne une liste d'objets {{domxref("PerformanceEntry")}} basée sur le <em>type</em> indiqué.</dd>
   <dt>{{domxref("performance.mark()")}}</dt>
   <dd>Crée un {{domxref("DOMHighResTimeStamp","timestamp")}} avec le nom indiqué, dans la mémoire tampon du navigateur dédiée aux performances.</dd>
   <dt>{{domxref("performance.measure()")}}</dt>
@@ -79,30 +79,31 @@ translation_of: Web/API/Performance
   <dt>{{domxref("Performance.now()")}}</dt>
   <dd>Retourne un objet {{domxref("DOMHighResTimeStamp")}} représentant le nombre de millisecondes écoulées depuis un instant donné.</dd>
   <dt>{{domxref("performance.setResourceTimingBufferSize()")}}</dt>
-  <dd>Configure la taille de la mémoire tampon pour le chronométrage des ressources du navigateur, avec le nombre indiqué de {{domxref("PerformanceEntry.entryType","type")}} d'{{domxref("PerformanceEntry","performance entry")}}objets "<code>resource</code>" .</dd>
+  <dd>Configure la taille de la mémoire tampon pour le chronométrage des ressources du navigateur. La valeur passée en argument indiquera le nombre maximal d'objets {{domxref("PerformanceEntry")}} ayant le {{domxref("PerformanceEntry.entryType","type")}} "<code>resource</code>" qu'il sera possible d'y stocker.</dd>
   <dt>{{domxref("Performance.toJSON()")}}</dt>
   <dd>Retourne un objet JSON représentant l'objet <code>Performance</code>.</dd>
 </dl>
 
 <h2 id="Events">Événements</h2>
 
-<p>Écoutez ces événements en utilisant <code>addEventListener()</code> ou en assignant un écouteur d'événement à la propriété <code>on<em>EventName</em></code> de cette interface.</p>
+<p>On pourra écouter ces événements en utilisant <code>addEventListener()</code> ou en assignant un gestionnaire d'événement à la propriété <code>on<em>&lt;EventName&gt;</em></code> de cette interface.</p>
 
 <dl>
   <dt>{{DOMxRef("Performance.resourcetimingbufferfull_event", "resourcetimingbufferfull")}}</dt>
-  <dd>Déclenché lorsque la fenêtre de <a href="/fr/docs/Web/API/Performance/setResourceTimingBufferSize">tampon de synchronisation des ressources</a> du navigateur est pleine.<br>
-  Également disponible via la propriété {{DOMxRef("Performance.onresourcetimingbufferfull", "onresourcetimingbufferfull")}}.</dd>
+  <dd>Déclenché lorsque le <a href="/fr/docs/Web/API/Performance/setResourceTimingBufferSize">tampon de synchronisation des ressources</a> du navigateur est plein. Également disponible via la propriété {{DOMxRef("Performance.onresourcetimingbufferfull", "onresourcetimingbufferfull")}}.</dd>
 </dl>
 
 <h2 id="Specifications">Spécifications</h2>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
       <th scope="col">Spécification</th>
       <th scope="col">Statut</th>
       <th scope="col">Commentaires</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td>{{SpecName('Highres Time Level 2', '#sec-performance', 'Performance')}}</td>
       <td>{{Spec2('Highres Time Level 2')}}</td>
@@ -121,7 +122,7 @@ translation_of: Web/API/Performance
     <tr>
       <td>{{SpecName('Performance Timeline', '#extensions-to-the-performance-interface', 'Performance extensions')}}</td>
       <td>{{Spec2('Performance Timeline')}}</td>
-      <td>Définition des méthodes <code>getEntries()</code>, <code>getEntriesByType()</code> et  <code>getEntriesByName()</code>.</td>
+      <td>Définition des méthodes <code>getEntries()</code>, <code>getEntriesByType()</code> et <code>getEntriesByName()</code>.</td>
     </tr>
     <tr>
       <td>{{SpecName('Resource Timing', '#extensions-performance-interface', 'Performance extensions')}}</td>

--- a/files/fr/web/api/performance/index.html
+++ b/files/fr/web/api/performance/index.html
@@ -3,117 +3,153 @@ title: Performance
 slug: Web/API/Performance
 tags:
   - API
+  - Navigation Timing
   - Performance
   - Performance Web
+  - Reference
 translation_of: Web/API/Performance
 ---
-<div>{{APIRef("Navigation Timing")}}</div>
+<div>{{APIRef("High Resolution Time")}}</div>
 
-<p>L'interface <strong><code>Performance</code></strong> donne accès à des informations liées aux performances pour la page actuelle. Elle fait partie de l'API High Resolution Time, mais est complétée par les APIs <a href="/en-US/docs/Web/API/Performance_Timeline">Performance Timeline</a>, <a href="/en-US/docs/Web/API/Navigation_timing_API">Navigation Timing</a>, <a href="/en-US/docs/Web/API/User_Timing_API">User Timing</a>, et <a href="/en-US/docs/Web/API/Resource_Timing_API">Resource Timing</a>.</p>
+<p>L'interface <strong><code>Performance</code></strong> donne accès à des informations liées aux performances pour la page actuelle. Elle fait partie de l'API « High Resolution Time », mais est complétée par les APIs <a href="/fr/docs/Web/API/Performance_Timeline">Performance Timeline</a>, <a href="/fr/docs/Web/API/Navigation_timing_API">Navigation Timing</a>, <a href="/fr/docs/Web/API/User_Timing_API">User Timing</a>, et <a href="/fr/docs/Web/API/Resource_Timing_API">Resource Timing</a>.</p>
 
-<p>Un objet de ce type peut être obtenu en appelant  l'attribut en lecture seule {{domxref("Window.performance")}}.</p>
+<p>Un objet de ce type peut être obtenu en appelant l'attribut en lecture seule {{domxref("Window.performance")}}.</p>
 
 <div class="note">
-<p><strong><em>Note</em>: </strong>Cette interface et ses attributs sont accessibles aux {{domxref("Web Worker")}} sauf dans les cas cités ci-dessous. Notez également que les marqueurs et les mesures de performance sont définis par contexte. Si vous créez un marqueur dans le processus principal (ou un autre Web Worker), vous ne pourrez pas le voir dans le processus du Web Worker, et réciproquement.</p>
+  <p><strong>Note :</strong> Cette interface et ses attributs sont accessibles aux <a href="/fr/docs/Web/API/Web_Workers_API">Web Workers</a> via <code><a href="/fr/docs/Web/API/WorkerGlobalScope/performance">WorkerGlobalScope.performance</a></code> sauf dans les cas cités ci-dessous. Notez également que les marqueurs et les mesures de performance sont définis par contexte. Si vous créez un marqueur dans le processus principal (ou un autre Web Worker), vous ne pourrez pas le voir dans le processus du Web Worker, et réciproquement.</p>
 </div>
 
-<h2 id="Propriétés">Propriétés</h2>
+<h2 id="Properties">Propriétés</h2>
 
-<p><em>L'interface<code>Performance</code> n'hérite d'aucune propriété.</em></p>
-
-<dl>
- <dt>{{deprecated_inline}}  {{domxref("performance.navigation")}} {{readonlyInline}}</dt>
- <dd>{{domxref("PerformanceNavigation")}} est un objet qui fournit des informations contextuelles sur les opérations inclues dans les indicateurs de <code>timing</code>, notamment si la page a été chargée ou actualisée, combien de redirections ont été effectuées, etc… Indisponible dans les Web Workers.</dd>
-</dl>
+<p><em>L'interface <code>Performance</code> n'hérite d'aucune propriété.</em></p>
 
 <dl>
- <dt>{{deprecated_inline}}  {{domxref("performance.timing")}} {{readonlyInline}}</dt>
- <dd>{{domxref("PerformanceTiming")}} est un objet contenant des informations de performance liées à la latence. Indisponible dans les Web Workers.</dd>
- <dt>{{domxref("performance.memory")}} {{Non-standard_inline}}</dt>
- <dd>{{domxref("PerformanceNavigation")}} est un objet non-standard ajouté dans Chrome, contenant des informations basiques d'utilisation de la mémoire.</dd>
+  <dt>
+    {{domxref("performance.navigation")}} {{readonlyInline}} {{deprecated_inline}}
+  </dt>
+  <dd>
+    {{domxref("PerformanceNavigation")}} est un objet qui fournit des informations contextuelles sur les opérations inclues dans les indicateurs de <code>timing</code>, notamment si la page a été chargée ou actualisée, combien de redirections ont été effectuées, etc…
+    <div class="notecard note">
+      <p>Indisponible dans les Web Workers.</p>
+    </div>
+  </dd>
+  <dt>
+    {{domxref("performance.timing")}} {{readonlyInline}} {{deprecated_inline}}
+  </dt>
+  <dd>
+    {{domxref("PerformanceTiming")}} est un objet contenant des informations de performance liées à la latence.
+    <div class="notecard note">
+      <p>Indisponible dans les Web Workers.</p>
+    </div>
+  </dd>
+  <dt>
+    {{domxref("performance.memory")}} {{readonlyInline}} {{Non-standard_inline}}</dt>
+  <dd>
+    Une <em>extension non standard</em> ajoutée dans Chrome, cette propriété fournit à un objet des informations de base sur l'utilisation de la mémoire. <em>Vous <strong>ne devriez pas utiliser</strong> cette API non standard.</em>
+  </dd>
+  <dt>
+    {{domxref("Performance.timeOrigin")}} {{readonlyInline}} {{Non-standard_inline}}
+  </dt>
+  <dd>
+    Renvoie un horodatage haute résolution de l'heure de début de la mesure de performance.
+  </dd>
 </dl>
 
-<h2 id="Méthodes">Méthodes</h2>
+<h2 id="Methods">Méthodes</h2>
 
-<p><em><em>L'interface <code>Performance</code> n'hérite d'aucune méthode</em></em>.</p>
-
-<p> </p>
+<p><em>L'interface <code>Performance</code> n'hérite d'aucune méthode</em>.</p>
 
 <dl>
- <dt>{{domxref("performance.clearMarks()")}}</dt>
- <dd>Supprime le <em>marqueur</em> indiqué des données de performances du navigateur mises en mémoire tampon.</dd>
- <dt>{{domxref("performance.clearMeasures()")}}</dt>
- <dd>Supprime la <em>mesure</em> indiquée des données de performances du navigateur mises en mémoire tampon.</dd>
- <dt>{{domxref("performance.clearResourceTimings()")}}</dt>
- <dd>Supprime toutes les {{domxref("PerformanceEntry","entrées de performance")}} avec un {{domxref("PerformanceEntry.entryType","entryType")}} "<code>resource</code>" des données de performances du navigateur mises en mémoire tampon.</dd>
- <dt>{{domxref("performance.getEntries()")}}</dt>
- <dd>Retourne une liste d'objets {domxref("PerformanceEntry")}} basée sur le <em>filter</em> indiqué.</dd>
- <dt>{{domxref("performance.getEntriesByName()")}}</dt>
- <dd>Retourne une liste d'objets {{domxref("PerformanceEntry")}} basée sur le <em>nom</em> d'entrée indiqué.</dd>
- <dt>{{domxref("performance.getEntriesByType()")}}</dt>
- <dd>Retourne une liste d'objets {{domxref("PerformanceEntry")}} basée sur le <em>type</em> d'entrée indiqué.</dd>
- <dt>{{domxref("performance.mark()")}}</dt>
- <dd>Crée un {{domxref("DOMHighResTimeStamp","timestamp")}} avec le nom indiqué, dans la mémoire tampon du navigateur dédiée aux performances.</dd>
- <dt>{{domxref("performance.measure()")}}</dt>
- <dd>Crée un {{domxref("DOMHighResTimeStamp","timestamp")}} nommé, dans la mémoire tampon du navigateur dédiée aux performances, entre deux marqueurs spécifiques (connus comme le <em>marqueur de début</em> et le <em>marqueur de fin</em>, respectivement).</dd>
+  <dt>{{domxref("performance.clearMarks()")}}</dt>
+  <dd>Supprime le <em>marqueur</em> indiqué des données de performances du navigateur mises en mémoire tampon.</dd>
+  <dt>{{domxref("performance.clearMeasures()")}}</dt>
+  <dd>Supprime la <em>mesure</em> indiquée des données de performances du navigateur mises en mémoire tampon.</dd>
+  <dt>{{domxref("performance.clearResourceTimings()")}}</dt>
+  <dd>Supprime toutes les {{domxref("PerformanceEntry","entrées de performance")}} avec un {{domxref("PerformanceEntry.entryType","entryType")}} "<code>resource</code>" des données de performances du navigateur mises en mémoire tampon.</dd>
+  <dt>{{domxref("performance.getEntries()")}}</dt>
+  <dd>Retourne une liste d'objets {domxref("PerformanceEntry")}} basée sur le <em>filter</em> indiqué.</dd>
+  <dt>{{domxref("performance.getEntriesByName()")}}</dt>
+  <dd>Retourne une liste d'objets {{domxref("PerformanceEntry")}} basée sur le <em>nom</em> d'entrée indiqué.</dd>
+  <dt>{{domxref("performance.getEntriesByType()")}}</dt>
+  <dd>Retourne une liste d'objets {{domxref("PerformanceEntry")}} basée sur le <em>type</em> d'entrée indiqué.</dd>
+  <dt>{{domxref("performance.mark()")}}</dt>
+  <dd>Crée un {{domxref("DOMHighResTimeStamp","timestamp")}} avec le nom indiqué, dans la mémoire tampon du navigateur dédiée aux performances.</dd>
+  <dt>{{domxref("performance.measure()")}}</dt>
+  <dd>Crée un {{domxref("DOMHighResTimeStamp","timestamp")}} nommé, dans la mémoire tampon du navigateur dédiée aux performances, entre deux marqueurs spécifiques (connus comme le <em>marqueur de début</em> et le <em>marqueur de fin</em>, respectivement).</dd>
+  <dt>{{domxref("Performance.now()")}}</dt>
+  <dd>Retourne un objet {{domxref("DOMHighResTimeStamp")}} représentant le nombre de millisecondes écoulées depuis un instant donné.</dd>
+  <dt>{{domxref("performance.setResourceTimingBufferSize()")}}</dt>
+  <dd>Configure la taille de la mémoire tampon pour le chronométrage des ressources du navigateur, avec le nombre indiqué de {{domxref("PerformanceEntry.entryType","type")}} d'{{domxref("PerformanceEntry","performance entry")}}objets "<code>resource</code>" .</dd>
+  <dt>{{domxref("Performance.toJSON()")}}</dt>
+  <dd>Retourne un objet JSON représentant l'objet <code>Performance</code>.</dd>
 </dl>
 
-<p> </p>
+<h2 id="Events">Événéments</h2>
+
+<p>Écoutez ces événéments en utilisant <code>addEventListener()</code> ou en assignant un écouteur d'événément à la propriété <code>on<em>EventName</em></code> de cette interface.</p>
 
 <dl>
- <dt>{{domxref("Performance.now()")}}</dt>
- <dd>Retourne un objet {{domxref("DOMHighResTimeStamp")}} représentant le nombre de millisecondes écoulées depuis un instant donné.</dd>
- <dt>{{domxref("performance.setResourceTimingBufferSize()")}}</dt>
- <dd>Configure la taille de la mémoire tampon pour le chronométrage des ressources du navigateur, avec le nombre indiqué de {{domxref("PerformanceEntry.entryType","type")}} d'{{domxref("PerformanceEntry","performance entry")}}objets "<code>resource</code>" .</dd>
- <dt>{{domxref("Performance.toJSON()")}} {{non-standard_inline}}</dt>
- <dd>Retourne un objet JSON représentant l'objet <code>Performance</code>.</dd>
- <dt> </dt>
+  <dt>{{DOMxRef("Performance.resourcetimingbufferfull_event", "resourcetimingbufferfull")}}</dt>
+  <dd>Déclenché lorsque la fenêtre de <a href="/fr/docs/Web/API/Performance/setResourceTimingBufferSize">tampon de synchronisation des ressources</a> du navigateur est pleine.<br>
+  Également disponible via la propriété {{DOMxRef("Performance.onresourcetimingbufferfull", "onresourcetimingbufferfull")}}.</dd>
 </dl>
 
-<h2 id="Events">Events</h2>
-
-<p>Écoutez ces événéments en utilisant <code>addEventListener()</code> ou en assignant un écouteur d'événément à la propriété <font face="consolas, Liberation Mono, courier, monospace"><span style="background-color: rgba(220, 220, 220, 0.5);">on<em>EventName</em> de cette interface.</span></font></p>
-
-<dl>
- <dt><code><a href="https://developer.mozilla.org/en-US/docs/Web/API/Performance/resourcetimingbufferfull_event">resourcetimingbufferfull</a></code></dt>
- <dd>Déclenchée quaund les ressources de la mémoire tampon du navigateur pour le chronométrage est pleine.<br>
- Également disponible via la propriété <code><a href="https://developer.mozilla.org/en-US/docs/Web/API/Performance/onresourcetimingbufferfull">onresourcetimingbufferfull</a></code>.</dd>
-</dl>
-
-<h2 id="Spécifications">Spécifications</h2>
+<h2 id="Specifications">Spécifications</h2>
 
 <table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Spécification</th>
-   <th scope="col">Statut</th>
-   <th scope="col">Commentaires</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Highres Time', '#sec-extenstions-performance-interface', 'Performance')}}</td>
-   <td>{{Spec2('Highres Time')}}</td>
-   <td>Ajout de la méthode <code>now()</code>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Navigation Timing', '#sec-window.performance-attribute', 'Performance')}}</td>
-   <td>{{Spec2('Navigation Timing')}}</td>
-   <td>Définition initiale.</td>
-  </tr>
- </tbody>
+  <tbody>
+    <tr>
+      <th scope="col">Spécification</th>
+      <th scope="col">Statut</th>
+      <th scope="col">Commentaires</th>
+    </tr>
+    <tr>
+      <td>{{SpecName('Highres Time Level 2', '#sec-performance', 'Performance')}}</td>
+      <td>{{Spec2('Highres Time Level 2')}}</td>
+      <td>Définition de la méthode <code>toJson()</code>.</td>
+    </tr>
+    <tr>
+      <td>{{SpecName('Highres Time', '#performance', 'Performance')}}</td>
+      <td>{{Spec2('Highres Time')}}</td>
+      <td>Définition de la méthode <code>now()</code>.</td>
+    </tr>
+    <tr>
+      <td>{{SpecName('Performance Timeline Level 2', '#extensions-to-the-performance-interface',  'Performance extensions')}}</td>
+      <td>{{Spec2('Performance Timeline Level 2')}}</td>
+      <td>Changements sur l'interface <code>getEntries()</code>.</td>
+    </tr>
+    <tr>
+      <td>{{SpecName('Performance Timeline', '#extensions-to-the-performance-interface', 'Performance extensions')}}</td>
+      <td>{{Spec2('Performance Timeline')}}</td>
+      <td>Définition des méthodes <code>getEntries()</code>, <code>getEntriesByType()</code> et  <code>getEntriesByName()</code>.</td>
+    </tr>
+    <tr>
+      <td>{{SpecName('Resource Timing', '#extensions-performance-interface', 'Performance extensions')}}</td>
+      <td>{{Spec2('Resource Timing')}}</td>
+      <td>Définition des méthodes <code>clearResourceTimings()</code> et <code>setResourceTimingBufferSize()</code> et de la propriété <code>onresourcetimingbufferfull</code>.</td>
+    </tr>
+    <tr>
+      <td>{{SpecName('User Timing Level 2', '#extensions-performance-interface', 'Performance extensions')}}</td>
+      <td>{{Spec2('User Timing Level 2')}}</td>
+      <td>Clarifications des méthodes <code>mark()</code>, <code>clearMark()</code>, <code>measure()</code> et <code>clearMeasure()</code>.</td>
+    </tr>
+    <tr>
+      <td>{{SpecName('User Timing', '#extensions-performance-interface', 'Performance extensions')}}</td>
+      <td>{{Spec2('User Timing')}}</td>
+      <td>Définition des méthodes <code>mark()</code>, <code>clearMark()</code>, <code>measure()</code> et <code>clearMeasure()</code>.</td>
+    </tr>
+  </tbody>
 </table>
 
-<h2 id="Compatibilité_des_navigateurs">Compatibilité des navigateurs</h2>
-
-<div>
-<div>
-
+<h2 id="Browser_compatibility">Compatibilité des navigateurs</h2>
 
 <p>{{Compat("api.Performance")}}</p>
-</div>
-</div>
 
-<h2 id="Voir_aussi">Voir aussi</h2>
+<h2 id="See_Also">Voir aussi</h2>
 
 <ul>
- <li>Interfaces liées : {{domxref("PerformanceTiming")}}, {{domxref("PerformanceNavigation")}}.</li>
+  <li><a href="/fr/docs/Web/API/Performance_Timeline">Performance Timeline</a></li>
+  <li><a href="/fr/docs/Web/API/Navigation_timing_API">Navigation Timing API</a></li>
+  <li><a href="/fr/docs/Web/API/User_Timing_API">User Timing API</a></li>
+  <li><a href="/fr/docs/Web/API/Resource_Timing_API">Resource Timing API</a></li>
 </ul>

--- a/files/fr/web/api/performance/mark/index.html
+++ b/files/fr/web/api/performance/mark/index.html
@@ -11,7 +11,7 @@ translation_of: Web/API/Performance/mark
 ---
 <div>{{APIRef("User Timing API")}}</div>
 
-<p>La méthode <strong><code>mark()</code></strong> crée un {{domxref("DOMHighResTimeStamp", "timestamp")}} dans le <em>tampon d'entrée de performance</em> du navigateur avec le nom donné.</p>
+<p class="seoSummary">La méthode <strong><code>mark()</code></strong> crée un {{domxref("DOMHighResTimeStamp", "timestamp")}} dans le <em>tampon d'entrée de performance</em> du navigateur avec le nom donné.</p>
 
 <p>L'horodatage défini par l'application peut être récupéré par l'une des méthodes <code>getEntries*()</code> de l'interface {{domxref("Performance")}} ({{domxref("Performance.getEntries", "getEntries()")}}, {{domxref("Performance.getEntriesByName", "getEntriesByName()")}} ou {{domxref("Performance.getEntriesByType", "getEntriesByType()")}}).</p>
 
@@ -29,7 +29,7 @@ translation_of: Web/API/Performance/mark
 
 <dl>
   <dt>name</dt>
-  <dd>Un {{domxref("DOMString")}} représentant le nom de la marque. Si le <code>name</code> donné à cette méthode existe déjà dans l'interface {{domxref("PerformanceTiming")}}, une {{jsxref("SyntaxError")}} est levée.</dd>
+  <dd>Un {{domxref("DOMString")}} représentant le nom du marqueur. Si le <code>name</code> donné à cette méthode existe déjà dans l'interface {{domxref("PerformanceTiming")}}, une {{jsxref("SyntaxError")}} est levée.</dd>
 </dl>
 
 <h3 id="Return_value">Valeur de retour</h3>
@@ -43,7 +43,7 @@ translation_of: Web/API/Performance/mark
 
 <p>L'exemple suivant montre comment utiliser <code>mark()</code> pour créer et récupérer des entrées {{domxref("PerformanceMark")}}.</p>
 
-<pre class="brush:js">// Créez un ensemble de marques.
+<pre class="brush:js">// Crée un ensemble de marqueurs.
 performance.mark("squirrel");
 performance.mark("squirrel");
 performance.mark("monkey");
@@ -61,7 +61,7 @@ const monkeyEntries = performance.getEntriesByName("monkey");
 console.log(monkeyEntries.length);
 // 2
 
-// Efface toutes les marques.
+// Efface tous les marqueurs.
 performance.clearMarks();
 </pre>
 

--- a/files/fr/web/api/performance/mark/index.html
+++ b/files/fr/web/api/performance/mark/index.html
@@ -11,33 +11,30 @@ translation_of: Web/API/Performance/mark
 ---
 <div>{{APIRef("User Timing API")}}</div>
 
-<p class="seoSummary">La méthode <strong><code>mark()</code></strong> crée un {{domxref("DOMHighResTimeStamp", "timestamp")}} dans le <em>tampon d'entrée de performance</em> du navigateur avec le nom donné.</p>
+<p class="seoSummary">La méthode <strong><code>mark()</code></strong> crée un {{domxref("DOMHighResTimeStamp", "timestamp")}} dans le <em>tampon d'entrée de performance</em> du navigateur avec le nom donné en argument.</p>
 
-<p>L'horodatage défini par l'application peut être récupéré par l'une des méthodes <code>getEntries*()</code> de l'interface {{domxref("Performance")}} ({{domxref("Performance.getEntries", "getEntries()")}}, {{domxref("Performance.getEntriesByName", "getEntriesByName()")}} ou {{domxref("Performance.getEntriesByType", "getEntriesByType()")}}).</p>
+<p>L'horodatage ainsi défini par l'application peut être récupéré par l'une des méthodes <code>getEntries*()</code> de l'interface {{domxref("Performance")}} ({{domxref("Performance.getEntries", "getEntries()")}}, {{domxref("Performance.getEntriesByName", "getEntriesByName()")}} ou {{domxref("Performance.getEntriesByType", "getEntriesByType()")}}).</p>
 
-<p>La méthode <code>mark()</code> stocke ses données en interne sous la forme {{domxref("PerformanceEntry")}}.</p>
+<p>La méthode <code>mark()</code> stocke ses données en interne sous la forme d'objets {{domxref("PerformanceEntry")}}.</p>
 
 <p>{{AvailableInWorkers}}</p>
 
 <h2 id="Syntax">Syntaxe</h2>
 
 <pre class="brush: js">
-  <em>performance</em>.mark(name);
+  performance.mark(name);
 </pre>
 
 <h3 id="Arguments">Arguments</h3>
 
 <dl>
-  <dt>name</dt>
-  <dd>Un {{domxref("DOMString")}} représentant le nom du marqueur. Si le <code>name</code> donné à cette méthode existe déjà dans l'interface {{domxref("PerformanceTiming")}}, une {{jsxref("SyntaxError")}} est levée.</dd>
+  <dt><code>name</code></dt>
+  <dd>Une chaîne de caractères ({{domxref("DOMString")}}) représentant le nom du marqueur. Si le nom donné à cette méthode existe déjà dans l'interface {{domxref("PerformanceTiming")}}, une exception {{jsxref("SyntaxError")}} est levée.</dd>
 </dl>
 
 <h3 id="Return_value">Valeur de retour</h3>
 
-<dl>
-  <dt>void</dt>
-  <dd> </dd>
-</dl>
+<p>Aucune.</p>>
 
 <h2 id="Example">Exemple</h2>
 
@@ -68,12 +65,14 @@ performance.clearMarks();
 <h2 id="Specifications">Spécifications</h2>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
       <th scope="col">Spécification</th>
       <th scope="col">Statut</th>
       <th scope="col">Commentaire</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td>{{SpecName('User Timing Level 2', '#dom-performance-mark', 'mark()')}}</td>
       <td>{{Spec2('User Timing Level 2')}}</td>

--- a/files/fr/web/api/performance/mark/index.html
+++ b/files/fr/web/api/performance/mark/index.html
@@ -1,0 +1,92 @@
+---
+title: performance.mark()
+slug: Web/API/Performance/mark
+tags:
+- API
+- Method
+- Méthode
+- Reference
+- Performance web
+translation_of: Web/API/Performance/mark
+---
+<div>{{APIRef("User Timing API")}}</div>
+
+<p>La méthode <strong><code>mark()</code></strong> crée un {{domxref("DOMHighResTimeStamp", "timestamp")}} dans le <em>tampon d'entrée de performance</em> du navigateur avec le nom donné.</p>
+
+<p>L'horodatage défini par l'application peut être récupéré par l'une des méthodes <code>getEntries*()</code> de l'interface {{domxref("Performance")}} ({{domxref("Performance.getEntries", "getEntries()")}}, {{domxref("Performance.getEntriesByName", "getEntriesByName()")}} ou {{domxref("Performance.getEntriesByType", "getEntriesByType()")}}).</p>
+
+<p>La méthode <code>mark()</code> stocke ses données en interne sous la forme {{domxref("PerformanceEntry")}}.</p>
+
+<p>{{AvailableInWorkers}}</p>
+
+<h2 id="Syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+  <em>performance</em>.mark(name);
+</pre>
+
+<h3 id="Arguments">Arguments</h3>
+
+<dl>
+  <dt>name</dt>
+  <dd>Un {{domxref("DOMString")}} représentant le nom de la marque. Si le <code>name</code> donné à cette méthode existe déjà dans l'interface {{domxref("PerformanceTiming")}}, une {{jsxref("SyntaxError")}} est levée.</dd>
+</dl>
+
+<h3 id="Return_value">Valeur de retour</h3>
+
+<dl>
+  <dt>void</dt>
+  <dd> </dd>
+</dl>
+
+<h2 id="Example">Exemple</h2>
+
+<p>L'exemple suivant montre comment utiliser <code>mark()</code> pour créer et récupérer des entrées {{domxref("PerformanceMark")}}.</p>
+
+<pre class="brush:js">// Créez un ensemble de marques.
+performance.mark("squirrel");
+performance.mark("squirrel");
+performance.mark("monkey");
+performance.mark("monkey");
+performance.mark("dog");
+performance.mark("dog");
+
+// Obtient toutes les entrées de PerformanceMark.
+const allEntries = performance.getEntriesByType("mark");
+console.log(allEntries.length);
+// 6
+
+// Obtient toutes les entrées "monkey" de PerformanceMark.
+const monkeyEntries = performance.getEntriesByName("monkey");
+console.log(monkeyEntries.length);
+// 2
+
+// Efface toutes les marques.
+performance.clearMarks();
+</pre>
+
+<h2 id="Specifications">Spécifications</h2>
+
+<table class="standard-table">
+  <tbody>
+    <tr>
+      <th scope="col">Spécification</th>
+      <th scope="col">Statut</th>
+      <th scope="col">Commentaire</th>
+    </tr>
+    <tr>
+      <td>{{SpecName('User Timing Level 2', '#dom-performance-mark', 'mark()')}}</td>
+      <td>{{Spec2('User Timing Level 2')}}</td>
+      <td>Clarification du modèle de traitement <code>mark()</code>.</td>
+    </tr>
+    <tr>
+      <td>{{SpecName('User Timing', '#dom-performance-mark', 'mark()')}}</td>
+      <td>{{Spec2('User Timing')}}</td>
+      <td>Définition initiale.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat("api.Performance.mark")}}</p>

--- a/files/fr/web/api/performance/measure/index.html
+++ b/files/fr/web/api/performance/measure/index.html
@@ -12,17 +12,17 @@ translation_of: Web/API/Performance/measure
 ---
 <div>{{APIRef("User Timing API")}}</div>
 
-<p class="seoSummary">La méthode <strong><code>measure()</code></strong> crée un {{domxref("DOMHighResTimeStamp", "timestamp")}} nommé dans le <em>tampon d'entrée de performance</em> du navigateur entre deux marqueurs, l'heure de début de navigation ou l'heure actuelle. Lors d'une mesure entre deux marqueurs, il existe respectivement un <em>marqueur de début</em> et un <em>marqueur de fin</em>. L'horodatage nommé est désigné comme une <em>mesure</em>.</p>
+<p class="seoSummary">La méthode <strong><code>measure()</code></strong> crée un {{domxref("DOMHighResTimeStamp", "timestamp")}} nommé dans le <em>tampon d'entrée de performance</em> du navigateur entre deux marqueurs, l'heure de début de navigation ou l'heure actuelle. Lors d'une mesure entre deux marqueurs, on aura un <em>marqueur de début</em> et un <em>marqueur de fin</em>. L'horodatage ainsi nommé est désigné comme une <em>mesure</em>.</p>
 
-<p>La <code>measure</code> peut être récupérée par l'une des interfaces {{domxref("Performance")}} : ({{domxref("Performance.getEntries", "getEntries()")}}, {{domxref("Performance.getEntriesByName", "getEntriesByName()")}} ou {{domxref("Performance.getEntriesByType", "getEntriesByType()")}}).</p>
+<p>La mesure correspondante peut être récupérée par l'une des méthodes suivantes de l'interface {{domxref("Performance")}} : {{domxref("Performance.getEntries", "getEntries()")}}, {{domxref("Performance.getEntriesByName", "getEntriesByName()")}} ou {{domxref("Performance.getEntriesByType", "getEntriesByType()")}}.</p>
 
-<p>L'{{domxref("PerformanceEntry", "entrée de performance")}} de la <code>measure</code> aura les valeurs de propriété suivantes :</p>
+<p>L'{{domxref("PerformanceEntry", "entrée de performance","",1)}} créée par <code>measure()</code> aura les valeurs de propriété suivantes :</p>
 
 <ul>
-  <li>{{domxref("PerformanceEntry.entryType","entryType")}} - fixé à une « <code>measure</code> ».</li>
-  <li>{{domxref("PerformanceEntry.name","name")}} - fixé à un « <code>name</code> » donné lors de la création de la mesure.</li>
-  <li>{{domxref("PerformanceEntry.startTime","startTime")}} - fixé à un marqueur de départ {{domxref("DOMHighResTimeStamp","timestamp")}}.</li>
-  <li>{{domxref("PerformanceEntry.duration","duration")}} - fixé à un {{domxref("DOMHighResTimeStamp")}} qui correspond à la durée de la mesure (généralement, l'horodatage du marqueur de fin moins l'horodatage du marqueur de début).</li>
+  <li>{{domxref("PerformanceEntry.entryType","entryType")}} : <code>"measure"</code>.</li>
+  <li>{{domxref("PerformanceEntry.name","name")}} : le nom passé en argument lors de la création de la mesure (cf. ci-après).</li>
+  <li>{{domxref("PerformanceEntry.startTime","startTime")}} : fixé selon le marqueur de départ (type {{domxref("DOMHighResTimeStamp")}}).</li>
+  <li>{{domxref("PerformanceEntry.duration","duration")}} : fixé à un {{domxref("DOMHighResTimeStamp")}} qui correspond à la durée de la mesure (généralement, l'horodatage du marqueur de fin moins l'horodatage du marqueur de début).</li>
 </ul>
 
 <p>{{AvailableInWorkers}}</p>
@@ -30,33 +30,30 @@ translation_of: Web/API/Performance/measure
 <h2 id="Syntax">Syntaxe</h2>
 
 <pre class="brush: js">
-  <em>performance</em>.measure(name);
-  <em>performance</em>.measure(name, startMark);
-  <em>performance</em>.measure(name, startMark, endMark);
-  <em>performance</em>.measure(name, undefined, endMark);
+  performance.measure(name);
+  performance.measure(name, startMark);
+  performance.measure(name, startMark, endMark);
+  performance.measure(name, undefined, endMark);
 </pre>
 
 <h3 id="Arguments">Arguments</h3>
 
 <dl>
-  <dt>name</dt>
+  <dt><code>name</code></dt>
   <dd>Une {{domxref("DOMString")}} représentant le nom de la mesure.</dd>
-  <dt>startMark {{optional_inline}}</dt>
-  <dd>Une {{domxref("DOMString")}} représentant le nom du marqueur de départ de la mesure. Peut également être le nom d'une propriété {{domxref("PerformanceTiming")}}. S'il est omis, l'heure de début sera celle de la navigation.</dd>
-  <dt>endMark {{optional_inline}}</dt>
-  <dd>Une {{domxref("DOMString")}} représentant le nom du marqueur de fin de la mesure. Peut également être le nom d'une propriété {{domxref("PerformanceTiming")}}. S'il est omis, le temps actuel est utilisé.</dd>
+  <dt><code>startMark</code> {{optional_inline}}</dt>
+  <dd>Une {{domxref("DOMString")}} représentant le nom du marqueur de départ de la mesure. Peut également être le nom d'une propriété {{domxref("PerformanceTiming")}}. Si elle est omise, l'heure de début sera celle de la navigation.</dd>
+  <dt><code>endMark</code> {{optional_inline}}</dt>
+  <dd>Une {{domxref("DOMString")}} représentant le nom du marqueur de fin de la mesure. Peut également être le nom d'une propriété {{domxref("PerformanceTiming")}}. Si elle est omise, le temps actuel est utilisé.</dd>
 </dl>
 
 <h3 id="Return_value">Valeur de retour</h3>
 
-<dl>
-  <dt>void</dt>
-  <dd> </dd>
-</dl>
+<p>Aucune</p>
 
 <h2 id="Example">Exemple</h2>
 
-<p>L'exemple suivant montre comment <code>measure()</code> est utilisé pour créer une nouvelle <em>mesure</em> d'{{domxref("PerformanceEntry", "entrée de performance")}} dans le tampon d'entrée de performance du navigateur.</p>
+<p>L'exemple suivant montre comment <code>measure()</code> est utilisé pour créer une nouvelle <em>mesure</em> d'{{domxref("PerformanceEntry", "entrée de performance","",1)}} dans le tampon d'entrée de performance du navigateur.</p>
 
 <pre class="brush: js">const markerNameA = "example-marker-a"
 const markerNameB = "example-marker-b"
@@ -68,10 +65,10 @@ setTimeout(function() {
   setTimeout(function() {
 
     // Crée une variété de mesures.
-    performance.measure("measure a to b", markerNameA, markerNameB);
-    performance.measure("measure a to now", markerNameA);
-    performance.measure("measure from navigation start to b", undefined, markerNameB);
-    performance.measure("measure from the start of navigation to now");
+    performance.measure("mesure a à b", markerNameA, markerNameB);
+    performance.measure("mesure a à maintenant", markerNameA);
+    performance.measure("mesure du début de la navigation à b", undefined, markerNameB);
+    performance.measure("mesure du début de la navigation à maintenant");
 
     // Sort toutes les mesures.
     console.log(performance.getEntriesByType("measure"));
@@ -86,12 +83,14 @@ setTimeout(function() {
 <h2 id="Specifications">Spécifications</h2>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
       <th scope="col">Spécification</th>
       <th scope="col">Statut</th>
       <th scope="col">Commentaire</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td>{{SpecName('User Timing Level 2', '#dom-performance-measure', 'measure()')}}
       </td>

--- a/files/fr/web/api/performance/measure/index.html
+++ b/files/fr/web/api/performance/measure/index.html
@@ -1,0 +1,111 @@
+---
+title: performance.measure()
+slug: Web/API/Performance/measure
+tags:
+- API
+- Method
+- Méthode
+- Reference
+- Performance web
+- Web Workers
+translation_of: Web/API/Performance/measure
+---
+<div>{{APIRef("User Timing API")}}</div>
+
+<p>La méthode <strong><code>measure()</code></strong> crée un {{domxref("DOMHighResTimeStamp", "timestamp")}} nommé dans le <em>tampon d'entrée de performance</em> du navigateur entre deux marques, l'heure de début de navigation ou l'heure actuelle. Lors d'une mesure entre deux marques, il existe respectivement une <em>marque de début</em> et une <em>marque de fin</em>. L'horodatage nommé est désigné comme une <em>mesure</em>.</p>
+
+<p>La <code>measure</code> peut être récupérée par l'une des interfaces {{domxref("Performance")}} : ({{domxref("Performance.getEntries", "getEntries()")}}, {{domxref("Performance.getEntriesByName", "getEntriesByName()")}} ou {{domxref("Performance.getEntriesByType", "getEntriesByType()")}}).</p>
+
+<p>L'{{domxref("PerformanceEntry", "entrée de performance")}} de la <code>measure</code> aura les valeurs de propriété suivantes :</p>
+
+<ul>
+  <li>{{domxref("PerformanceEntry.entryType","entryType")}} - fixé à une « <code>measure</code> ».</li>
+  <li>{{domxref("PerformanceEntry.name","name")}} - fixé à un « <code>name</code> » donné lors de la création de la mesure.</li>
+  <li>{{domxref("PerformanceEntry.startTime","startTime")}} - fixé à la marque de départ {{domxref("DOMHighResTimeStamp","timestamp")}}.</li>
+  <li>{{domxref("PerformanceEntry.duration","duration")}} - fixé à un {{domxref("DOMHighResTimeStamp")}} qui correspond à la durée de la mesure (généralement, l'horodatage de la marque de fin moins l'horodatage de la marque de début).</li>
+</ul>
+
+<p>{{AvailableInWorkers}}</p>
+
+<h2 id="Syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+  <em>performance</em>.measure(name);
+  <em>performance</em>.measure(name, startMark);
+  <em>performance</em>.measure(name, startMark, endMark);
+  <em>performance</em>.measure(name, undefined, endMark);
+</pre>
+
+<h3 id="Arguments">Arguments</h3>
+
+<dl>
+  <dt>name</dt>
+  <dd>Une {{domxref("DOMString")}} représentant le nom de la mesure.</dd>
+  <dt>startMark {{optional_inline}}</dt>
+  <dd>Une {{domxref("DOMString")}} représentant le nom de la marque de départ de la mesure. Peut également être le nom d'une propriété {{domxref("PerformanceTiming")}}. S'il est omis, l'heure de début sera celle de la navigation.</dd>
+  <dt>endMark {{optional_inline}}</dt>
+  <dd>Une {{domxref("DOMString")}} représentant le nom de la marque de fin de la mesure. Peut également être le nom d'une propriété {{domxref("PerformanceTiming")}}. S'il est omis, le temps actuel est utilisé.</dd>
+</dl>
+
+<h3 id="Return_value">Valeur de retour</h3>
+
+<dl>
+  <dt>void</dt>
+  <dd> </dd>
+</dl>
+
+<h2 id="Example">Exemple</h2>
+
+<p>L'exemple suivant montre comment <code>measure()</code> est utilisé pour créer une nouvelle <em>mesure</em> d'{{domxref("PerformanceEntry", "entrée de performance")}} dans le tampon d'entrée de performance du navigateur.</p>
+
+<pre class="brush: js">const markerNameA = "example-marker-a"
+const markerNameB = "example-marker-b"
+
+// Exécute des temporisations imbriquées et crée un PerformanceMark pour chacune d'entre elles.
+performance.mark(markerNameA);
+setTimeout(function() {
+  performance.mark(markerNameB);
+  setTimeout(function() {
+
+    // Crée une variété de mesures.
+    performance.measure("measure a to b", markerNameA, markerNameB);
+    performance.measure("measure a to now", markerNameA);
+    performance.measure("measure from navigation start to b", undefined, markerNameB);
+    performance.measure("measure from the start of navigation to now");
+
+    // Sort toutes les mesures.
+    console.log(performance.getEntriesByType("measure"));
+
+    // Enfin, nettoye les entrées.
+    performance.clearMarks();
+    performance.clearMeasures();
+  }, 1000);
+}, 1000);
+</pre>
+
+<h2 id="Specifications">Spécifications</h2>
+
+<table class="standard-table">
+  <tbody>
+    <tr>
+      <th scope="col">Spécification</th>
+      <th scope="col">Statut</th>
+      <th scope="col">Commentaire</th>
+    </tr>
+    <tr>
+      <td>{{SpecName('User Timing Level 2', '#dom-performance-measure', 'measure()')}}
+      </td>
+      <td>{{Spec2('User Timing Level 2')}}</td>
+      <td>Clarification du modèle de traitement de <code>mesure()</code>.</td>
+    </tr>
+    <tr>
+      <td>{{SpecName('User Timing', '#dom-performance-measure', 'measure()')}}</td>
+      <td>{{Spec2('User Timing')}}</td>
+      <td>Définition initiale.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat("api.Performance.measure")}}</p>

--- a/files/fr/web/api/performance/measure/index.html
+++ b/files/fr/web/api/performance/measure/index.html
@@ -12,7 +12,7 @@ translation_of: Web/API/Performance/measure
 ---
 <div>{{APIRef("User Timing API")}}</div>
 
-<p>La méthode <strong><code>measure()</code></strong> crée un {{domxref("DOMHighResTimeStamp", "timestamp")}} nommé dans le <em>tampon d'entrée de performance</em> du navigateur entre deux marques, l'heure de début de navigation ou l'heure actuelle. Lors d'une mesure entre deux marques, il existe respectivement une <em>marque de début</em> et une <em>marque de fin</em>. L'horodatage nommé est désigné comme une <em>mesure</em>.</p>
+<p class="seoSummary">La méthode <strong><code>measure()</code></strong> crée un {{domxref("DOMHighResTimeStamp", "timestamp")}} nommé dans le <em>tampon d'entrée de performance</em> du navigateur entre deux marqueurs, l'heure de début de navigation ou l'heure actuelle. Lors d'une mesure entre deux marqueurs, il existe respectivement un <em>marqueur de début</em> et un <em>marqueur de fin</em>. L'horodatage nommé est désigné comme une <em>mesure</em>.</p>
 
 <p>La <code>measure</code> peut être récupérée par l'une des interfaces {{domxref("Performance")}} : ({{domxref("Performance.getEntries", "getEntries()")}}, {{domxref("Performance.getEntriesByName", "getEntriesByName()")}} ou {{domxref("Performance.getEntriesByType", "getEntriesByType()")}}).</p>
 
@@ -21,8 +21,8 @@ translation_of: Web/API/Performance/measure
 <ul>
   <li>{{domxref("PerformanceEntry.entryType","entryType")}} - fixé à une « <code>measure</code> ».</li>
   <li>{{domxref("PerformanceEntry.name","name")}} - fixé à un « <code>name</code> » donné lors de la création de la mesure.</li>
-  <li>{{domxref("PerformanceEntry.startTime","startTime")}} - fixé à la marque de départ {{domxref("DOMHighResTimeStamp","timestamp")}}.</li>
-  <li>{{domxref("PerformanceEntry.duration","duration")}} - fixé à un {{domxref("DOMHighResTimeStamp")}} qui correspond à la durée de la mesure (généralement, l'horodatage de la marque de fin moins l'horodatage de la marque de début).</li>
+  <li>{{domxref("PerformanceEntry.startTime","startTime")}} - fixé à un marqueur de départ {{domxref("DOMHighResTimeStamp","timestamp")}}.</li>
+  <li>{{domxref("PerformanceEntry.duration","duration")}} - fixé à un {{domxref("DOMHighResTimeStamp")}} qui correspond à la durée de la mesure (généralement, l'horodatage du marqueur de fin moins l'horodatage du marqueur de début).</li>
 </ul>
 
 <p>{{AvailableInWorkers}}</p>
@@ -42,9 +42,9 @@ translation_of: Web/API/Performance/measure
   <dt>name</dt>
   <dd>Une {{domxref("DOMString")}} représentant le nom de la mesure.</dd>
   <dt>startMark {{optional_inline}}</dt>
-  <dd>Une {{domxref("DOMString")}} représentant le nom de la marque de départ de la mesure. Peut également être le nom d'une propriété {{domxref("PerformanceTiming")}}. S'il est omis, l'heure de début sera celle de la navigation.</dd>
+  <dd>Une {{domxref("DOMString")}} représentant le nom du marqueur de départ de la mesure. Peut également être le nom d'une propriété {{domxref("PerformanceTiming")}}. S'il est omis, l'heure de début sera celle de la navigation.</dd>
   <dt>endMark {{optional_inline}}</dt>
-  <dd>Une {{domxref("DOMString")}} représentant le nom de la marque de fin de la mesure. Peut également être le nom d'une propriété {{domxref("PerformanceTiming")}}. S'il est omis, le temps actuel est utilisé.</dd>
+  <dd>Une {{domxref("DOMString")}} représentant le nom du marqueur de fin de la mesure. Peut également être le nom d'une propriété {{domxref("PerformanceTiming")}}. S'il est omis, le temps actuel est utilisé.</dd>
 </dl>
 
 <h3 id="Return_value">Valeur de retour</h3>

--- a/files/fr/web/api/performance/memory/index.html
+++ b/files/fr/web/api/performance/memory/index.html
@@ -1,0 +1,43 @@
+---
+title: performance.memory
+slug: Web/API/Performance/memory
+tags:
+  - API
+  - Reference
+  - Performance web
+translation_of: Web/API/Performance/memory
+---
+<p>{{APIRef}}</p>
+
+{{Non-standardGeneric('header')}}
+
+<h2 id="Syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+  <em>timingInfo</em> = <em>performance</em>.memory
+</pre>
+
+<h2 id="Attributes">Attributs</h2>
+
+<dl>
+  <dt><code>jsHeapSizeLimit</code></dt>
+  <dd>La taille maximale du tas, en octets, qui est disponible pour le contexte.</dd>
+  <dt><code>totalJSHeapSize</code></dt>
+  <dd>La taille totale du répertoire alloué, en octets.</dd>
+  <dt>usedJSHeapSize</dt>
+  <dd>Le segment actuellement actif du répertoire JS, en octets.</dd>
+</dl>
+
+<h2 id="Specifications">Spécifications</h2>
+
+<p>Aucune</p>
+
+<h2 id="Browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat("api.Performance.memory")}}</p>
+
+<h2 id="See_also">Voir aussi</h2>
+
+<ul>
+  <li>L'interface {{domxref("Performance")}} à laquelle il appartient.</li>
+</ul>

--- a/files/fr/web/api/performance/navigation/index.html
+++ b/files/fr/web/api/performance/navigation/index.html
@@ -34,12 +34,14 @@ translation_of: Web/API/Performance/navigation
 <h2 id="Specifications">Spécifications</h2>
 
 <table class="standard-table">
- <tbody>
+ <thead>
   <tr>
    <th scope="col">Spécification</th>
    <th scope="col">Statut</th>
    <th scope="col">Commentaire</th>
   </tr>
+ </thead>
+ <tbody>
   <tr>
    <td>{{SpecName('Navigation Timing', '#sec-window.performance-attribute', 'Performance.navigation')}}</td>
    <td>{{Spec2('Navigation Timing')}}</td>

--- a/files/fr/web/api/performance/navigation/index.html
+++ b/files/fr/web/api/performance/navigation/index.html
@@ -21,7 +21,7 @@ translation_of: Web/API/Performance/navigation
   <p>Cette propriété est dépréciée dans la spécification <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>.</p>
 </div>
 
-<p>L'ancienne propriété en lecture seule <strong><code>Performance.navigation</code></strong> renvoie un objet {{domxref("PerformanceNavigation")}} représentant le type de navigation qui se produit dans le contexte de navigation donné, comme le nombre de redirections nécessaires pour aller chercher la ressource.</p>
+<p class="seoSummary">L'ancienne propriété en lecture seule <strong><code>Performance.navigation</code></strong> renvoie un objet {{domxref("PerformanceNavigation")}} représentant le type de navigation qui se produit dans le contexte de navigation donné, comme le nombre de redirections nécessaires pour aller chercher la ressource.</p>
 
 {{warning("Cette propriété n'est pas disponible dans les Web Workers.")}}
 

--- a/files/fr/web/api/performance/navigation/index.html
+++ b/files/fr/web/api/performance/navigation/index.html
@@ -1,52 +1,59 @@
 ---
-title: Performance.navigation
+title: performance.navigation
 slug: Web/API/Performance/navigation
 tags:
+  - API
+  - Rétrocompatibilité
+  - Déprécié
   - HTTP
   - Performance
   - Propriété
-  - lecture seule
+  - Property
+  - Lecture seule
+  - Read-only
+  - Reference
+  - legacy
 translation_of: Web/API/Performance/navigation
 ---
-<p>{{APIRef("Navigation Timing")}}</p>
+<p>{{Deprecated_Header}}{{APIRef("Navigation Timing")}}</p>
 
-<h2 id="Summary">Summary</h2>
+<div class="notecard warning">
+  <p>Cette propriété est dépréciée dans la spécification <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2 specification</a>.</p>
+</div>
 
-<p>La propriété en lecture seule <code><strong>Performance</strong></code><strong><code>.navigation</code></strong> permet d'accéder à un objet de type {{domxref("PerformanceNavigation")}} représentant la navigation qui a lieu dans le contexte courant, par êxemple, le nombre de redirections.</p>
+<p>L'ancienne propriété en lecture seule <strong><code>Performance.navigation</code></strong> renvoie un objet {{domxref("PerformanceNavigation")}} représentant le type de navigation qui se produit dans le contexte de navigation donné, comme le nombre de redirections nécessaires pour aller chercher la ressource.</p>
 
-<h2 id="Syntax">Syntax</h2>
+{{warning("Cette propriété n'est pas disponible dans les Web Workers.")}}
 
-<pre class="syntaxbox"><em>navObject</em> = <em>performance</em>.navigation;</pre>
+<h2 id="Syntax">Syntaxe</h2>
 
-<h2 id="Specifications">Specifications</h2>
+<pre class="brush: js">
+  <em>navObject</em> = <em>performance</em>.navigation;
+</pre>
+
+<h2 id="Specifications">Spécifications</h2>
 
 <table class="standard-table">
  <tbody>
   <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
+   <th scope="col">Spécification</th>
+   <th scope="col">Statut</th>
+   <th scope="col">Commentaire</th>
   </tr>
   <tr>
    <td>{{SpecName('Navigation Timing', '#sec-window.performance-attribute', 'Performance.navigation')}}</td>
    <td>{{Spec2('Navigation Timing')}}</td>
-   <td>Initial definition.</td>
+   <td>Définition initiale.</td>
   </tr>
  </tbody>
 </table>
 
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-<div>
-<div>
-
+<h2 id="Browser_compatibility">Compatibilité des navigateurs</h2>
 
 <p>{{Compat("api.Performance.navigation")}}</p>
-</div>
-</div>
 
-<h2 id="See_also">See also</h2>
+<h2 id="See_also">Voir aussi</h2>
 
 <ul>
- <li>The {{domxref("Performance")}} interface it belongs to.</li>
+ <li>L'interface {{domxref("Performance")}} à laquelle il appartient.</li>
 </ul>

--- a/files/fr/web/api/performance/now/index.html
+++ b/files/fr/web/api/performance/now/index.html
@@ -12,17 +12,17 @@ translation_of: Web/API/Performance/now
 ---
 <p>{{APIRef("High Resolution Timing")}}</p>
 
-<p class="seoSummary">La méthode <code><strong>Performance.now()</strong></code> retourne un {{domxref("DOMHighResTimeStamp")}}, mesuré en millisecondes, avec une précision de 5 millième de milliseconde (5 microsecondes).</p>
+<p class="seoSummary">La méthode <code><strong>Performance.now()</strong></code> retourne une valeur de type {{domxref("DOMHighResTimeStamp")}}, mesurée en millisecondes et avec une précision de 5 millièmes de milliseconde (5 microsecondes).</p>
 
 <p>{{AvailableInWorkers}}</p>
 
-<p>La valeur retournée représente le temps écoulé depuis le <a href="/fr/docs/Web/API/DOMHighResTimeStamp#The_time_origin">temps d'origine</a>.</p>
+<p>La valeur retournée représente le temps écoulé depuis le <a href="/fr/docs/Web/API/DOMHighResTimeStamp#the_time_origin">temps d'origine</a>.</p>
 
-<p>Gardez présents à l'esprit les points suivants :</p>
+<p>Attention à garder à l'esprit les points suivants :</p>
 
 <ul>
-  <li>Dans les workers dédiés créés à partir d'un contexte {{domxref("Window")}}, la valeur dans le worker sera inférieure à <code>performance.now()</code> dans la fenêtre qui a créé ce worker. C'était auparavant la même chose que le <code>t0</code> du contexte principal, mais cela a été changé.</li>
-  <li>Dans les workers partagés ou service sorkers, la valeur dans le worker peut être supérieure à celle du contexte principal, car cette fenêtre peut être créée après ces workers.</li>
+  <li>Dans les workers dédiés créés à partir d'un contexte {{domxref("Window")}}, la valeur dans le worker sera inférieure à celle obtenue par  <code>performance.now()</code> exécuté dans la fenêtre ayant créé le worker. La fenêtre et le worker partageaient avant le même temps de référence <code>t0</code> à partir du contexte principal, mais cela a été changé.</li>
+  <li>Dans les workers partagés ou service sorkers, la valeur dans le worker peut être supérieure à celle du contexte principal, car la fenêtre pourra avoir été créée après ces workers.</li>
 </ul>
 
 <p>Il est important de garder à l'esprit que pour atténuer les menaces de sécurité potentielles telles que <a href="https://spectreattack.com/">Spectre</a>, les navigateurs arrondissent généralement la valeur retournée d'une certaine quantité afin d'être moins prévisible. Cela introduit intrinsèquement un degré d'imprécision en limitant la résolution ou la précision de la minuterie. Par exemple, Firefox arrondit le temps renvoyé à des incréments de 1 milliseconde.</p>
@@ -44,13 +44,13 @@ translation_of: Web/API/Performance/now
   console.log("L'appel de doSomething a demandé " + (t1 - t0) + " millisecondes.")
 </pre>
 
-<p>Contrairement aux autres données de temps disponibles en JavaScript (par exemple <a href="/fr/docs/JavaScript/Reference/Global_Objects/Date/now"><code>Date.now</code></a>), les horodatages retournés par <code>Performance.now()</code> ne sont pas limités à une précision d'une milliseconde. Au contraire, ils représentent les temps comme des nombres flottants avec une précision pouvant aller jusqu'à une microseconde.</p>
+<p>Contrairement aux autres données de temps disponibles en JavaScript (par exemple <a href="/fr/docs/Web/JavaScript/Reference/Global_Objects/Date/now"><code>Date.now</code></a>), les horodatages retournés par <code>Performance.now()</code> ne sont pas limités à une précision d'une milliseconde. Au contraire, ils représentent les temps comme des nombres flottants avec une précision pouvant aller jusqu'à une microseconde.</p>
 
-<p>Également contrairement à <code>Date.now()</code>, les valeurs retournées par <code>Performance.now() </code>sont toujours incrémentées à un taux constant, indépendant de l'horloge du système (qui peut être ajustée manuellement ou par l'intermédiaire d'un logiciel comme NTP). Sinon, <code>performance.timing.navigationStart + performance.now()</code> sera approximativement égal à <code>Date.now().</code></p>
+<p>Également contrairement à <code>Date.now()</code>, les valeurs retournées par <code>Performance.now() </code>sont toujours incrémentées à un taux constant, indépendant de l'horloge du système (qui peut être ajustée manuellement ou par l'intermédiaire d'un logiciel comme NTP). Sinon, <code>performance.timing.navigationStart + performance.now()</code> serait approximativement égal à <code>Date.now().</code></p>
 
 <h2 id="Reduced_time_precision">Précision réduite du temps</h2>
 
-<p>Pour offrir une protection contre les attaques de temporisation et les empreintes digitales, la précision de <code>performance.now()</code> pourrait être arrondie en fonction des paramètres du navigateur.<br>Dans Firefox, la préférence <code>privacy.reduceTimerPrecision</code> est activée par défaut et prend la valeur 1ms par défaut.</p>
+<p>Pour offrir une protection contre les attaques de temporisation et les empreintes digitales, la précision de <code>performance.now()</code> peut être arrondie en fonction des paramètres du navigateur. Dans Firefox, la préférence <code>privacy.reduceTimerPrecision</code> est activée par défaut et prend la valeur 1ms par défaut.</p>
 
 <pre class="brush: js">// précision temporelle réduite (1ms) dans Firefox 60
 performance.now();
@@ -67,7 +67,7 @@ performance.now();
 // ...
 </pre>
 
-<p>Dans Firefox, vous pouvez également activer <code>privacy.resistFingerprinting</code> - cela change la précision à 100ms ou à la valeur de <code>privacy.resistFingerprinting.reduceTimerPrecision.microseconds</code>, la plus grande des deux.</p>
+<p>Dans Firefox, vous pouvez également activer <code>privacy.resistFingerprinting</code> - cela change la précision à 100ms ou à la valeur de <code>privacy.resistFingerprinting.reduceTimerPrecision.microseconds</code> en fonction de la plus grande des deux.</p>
 
 <p>À partir de Firefox 79, les minuteurs haute résolution peuvent être utilisés si vous isolez votre document en utilisant les en-têtes {{HTTPHeader("Cross-Origin-Opener-Policy")}} et {{HTTPHeader("Cross-Origin-Embedder-Policy")}} :</p>
 
@@ -79,12 +79,14 @@ Cross-Origin-Embedder-Policy: require-corp</pre>
 <h2 id="Specifications">Spécifications</h2>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
       <th scope="col">Spécification</th>
       <th scope="col">Statut</th>
       <th scope="col">Commentaire</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td>{{SpecName('Highres Time Level 2',  '#dom-performance-now', 'performance.now()')}}</td>
       <td>{{Spec2('Highres Time Level 2')}}</td>

--- a/files/fr/web/api/performance/now/index.html
+++ b/files/fr/web/api/performance/now/index.html
@@ -1,9 +1,10 @@
 ---
-title: Performance.now()
+title: performance.now()
 slug: Web/API/Performance/now
 tags:
   - API
   - API Performance Web
+  - Method
   - Méthode
   - Performance
   - Reference
@@ -11,67 +12,98 @@ translation_of: Web/API/Performance/now
 ---
 <p>{{APIRef("High Resolution Timing")}}</p>
 
-<p>La méthode <code><strong>Performance.now()</strong></code> retourne un {{domxref("DOMHighResTimeStamp")}}, mesuré en millisecondes, avec une précision de 5 millième de milliseconde (5 microsecondes).</p>
+<p class="seoSummary">La méthode <code><strong>Performance.now()</strong></code> retourne un {{domxref("DOMHighResTimeStamp")}}, mesuré en millisecondes, avec une précision de 5 millième de milliseconde (5 microsecondes).</p>
 
-<p> </p>
+<p>{{AvailableInWorkers}}</p>
 
-<p>La valeur retournée représente le temps écoulé depuis l'origine de temps.</p>
+<p>La valeur retournée représente le temps écoulé depuis le <a href="/fr/docs/Web/API/DOMHighResTimeStamp#The_time_origin">temps d'origine</a>.</p>
 
 <p>Gardez présents à l'esprit les points suivants :</p>
 
 <ul>
- <li>Dans les workers dédiés créés à partir d'un contexte {{domxref("Window")}}, la valeur dans le worker sera inférieure à <code>performance.now()</code> dans la fenêtre qui a créé ce worker. C'était auparavant la même chose que le <code>t0</code> du contexte principal, mais cela a été changé.</li>
- <li>Dans les workers partagés ou de service, la valeur dans le worker peut être supérieure à celle du contexte principal, car cette fenêtre peut être créée après ces workers.</li>
+  <li>Dans les workers dédiés créés à partir d'un contexte {{domxref("Window")}}, la valeur dans le worker sera inférieure à <code>performance.now()</code> dans la fenêtre qui a créé ce worker. C'était auparavant la même chose que le <code>t0</code> du contexte principal, mais cela a été changé.</li>
+  <li>Dans les workers partagés ou service sorkers, la valeur dans le worker peut être supérieure à celle du contexte principal, car cette fenêtre peut être créée après ces workers.</li>
 </ul>
 
-<p> </p>
+<p>Il est important de garder à l'esprit que pour atténuer les menaces de sécurité potentielles telles que <a href="https://spectreattack.com/">Spectre</a>, les navigateurs arrondissent généralement la valeur retournée d'une certaine quantité afin d'être moins prévisible. Cela introduit intrinsèquement un degré d'imprécision en limitant la résolution ou la précision de la minuterie. Par exemple, Firefox arrondit le temps renvoyé à des incréments de 1 milliseconde.</p>
 
-<h2 id="Syntaxe">Syntaxe</h2>
+<p>La précision de la valeur retournée est susceptible de changer si/quand les problèmes de sécurité sont atténués par d'autres moyens.</p>
 
-<div class="geckoVersionNote">
-<p class="syntaxbox">t = performance.now();</p>
-</div>
+<h2 id="Syntax">Syntaxe</h2>
 
-<h2 id="Exemple">Exemple</h2>
-
-<pre class="brush: js">var t0 = performance.now();
-faireQuelqueChose();
-var t1 = performance.now();
-console.log("L'appel à faireQuelqueChose a pris " + (t1 - t0) + " millisecondes.")
+<pre class="brush: js">
+  t = performance.now();
 </pre>
 
-<p>Contrairement aux autres données de temps disponibles en JavaScript (par exemple <a href="/en-US/docs/JavaScript/Reference/Global_Objects/Date/now" title="/en-US/docs/JavaScript/Reference/Global_Objects/Date/now"><code>Date.now</code></a>), les horodatages retournés par <code>Performance.now()</code> ne sont pas limités à une précision d'une milliseconde. Au contraire, ils représentent les temps comme des nombres flottants avec une précision pouvant aller jusqu'à une microseconde.</p>
+<h2 id="Example">Exemple</h2>
 
-<p>Également contrairement à <code>Date.now()</code>, les valeurs retournées par <code>Performance.now() </code>sont toujours incrémentées à un taux constant, indépendant de l'horloge du système (qui peut être ajustée manuellement ou par l'intermédiaire d'un logiciel comme NTP). Sinon, <code>performance.timing.navigationStart + performance.now()</code> sera approximativement égal à <code>Date.now().</code></p>
+<pre class="brush: js">
+  var t0 = performance.now();
+  doSomething();
+  var t1 = performance.now();
+  console.log("L'appel de doSomething a demandé " + (t1 - t0) + " millisecondes.")
+</pre>
 
-<h2 id="Spécifications">Spécifications</h2>
+<p>Contrairement aux autres données de temps disponibles en JavaScript (par exemple <a href="/fr/docs/JavaScript/Reference/Global_Objects/Date/now"><code>Date.now</code></a>), les horodatages retournés par <code>Performance.now()</code> ne sont pas limités à une précision d'une milliseconde. Au contraire, ils représentent les temps comme des nombres flottants avec une précision pouvant aller jusqu'à une microseconde.</p>
+
+<p>Également contrairement à <code>Date.now()</code>, les valeurs retournées par <code>Performance.now() </code>sont toujours incrémentées à un taux constant, indépendant de l'horloge du système (qui peut être ajustée manuellement ou par l'intermédiaire d'un logiciel comme NTP). Sinon, <code>performance.timing.navigationStart + performance.now()</code> sera approximativement égal à <code>Date.now().</code></p>
+
+<h2 id="Reduced_time_precision">Précision réduite du temps</h2>
+
+<p>Pour offrir une protection contre les attaques de temporisation et les empreintes digitales, la précision de <code>performance.now()</code> pourrait être arrondie en fonction des paramètres du navigateur.<br>Dans Firefox, la préférence <code>privacy.reduceTimerPrecision</code> est activée par défaut et prend la valeur 1ms par défaut.</p>
+
+<pre class="brush: js">// précision temporelle réduite (1ms) dans Firefox 60
+performance.now();
+// 8781416
+// 8781815
+// 8782206
+// ...
+
+// précision du temps réduite avec `privacy.resistFingerprinting` activé
+performance.now();
+// 8865400
+// 8866200
+// 8866700
+// ...
+</pre>
+
+<p>Dans Firefox, vous pouvez également activer <code>privacy.resistFingerprinting</code> - cela change la précision à 100ms ou à la valeur de <code>privacy.resistFingerprinting.reduceTimerPrecision.microseconds</code>, la plus grande des deux.</p>
+
+<p>À partir de Firefox 79, les minuteurs haute résolution peuvent être utilisés si vous isolez votre document en utilisant les en-têtes {{HTTPHeader("Cross-Origin-Opener-Policy")}} et {{HTTPHeader("Cross-Origin-Embedder-Policy")}} :</p>
+
+<pre class="brush: plain">Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp</pre>
+
+<p>Ces en-têtes garantissent qu'un document de premier niveau ne partage pas un groupe de contexte de navigation avec des documents d'origine croisée. Le processus COOP isole votre document et les attaquants potentiels ne peuvent pas accéder à votre objet global s'ils l'ouvrent dans une fenêtre contextuelle, ce qui permet d'éviter un ensemble d'attaques d'origine croisée appelées <a href="https://github.com/xsleaks/xsleaks">XS-Leaks</a>.</p>
+
+<h2 id="Specifications">Spécifications</h2>
 
 <table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Spécification</th>
-   <th scope="col">Statut</th>
-   <th scope="col">Commentaire</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Highres Time Level 2', '#dom-performance-now', 'performance.now()')}}</td>
-   <td>{{Spec2('Highres Time Level 2')}}</td>
-   <td>Définitions plus strictes des interfaces et des types.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Highres Time', '#dom-performance-now', 'Performance.now()')}}</td>
-   <td>{{Spec2('Highres Time')}}</td>
-   <td>Définition initiale</td>
-  </tr>
- </tbody>
+  <tbody>
+    <tr>
+      <th scope="col">Spécification</th>
+      <th scope="col">Statut</th>
+      <th scope="col">Commentaire</th>
+    </tr>
+    <tr>
+      <td>{{SpecName('Highres Time Level 2',  '#dom-performance-now', 'performance.now()')}}</td>
+      <td>{{Spec2('Highres Time Level 2')}}</td>
+      <td>Définitions plus strictes des interfaces et des types.</td>
+    </tr>
+    <tr>
+      <td>{{SpecName('Highres Time',  '#dom-performance-now', 'Performance.now()')}}</td>
+      <td>{{Spec2('Highres Time')}}</td>
+      <td>Définition initiale</td>
+    </tr>
+  </tbody>
 </table>
 
-<h2 id="Compatibilité_des_navigateurs">Compatibilité des navigateurs</h2>
+<h2 id="Browser_compatibility">Compatibilité des navigateurs</h2>
 
 <p>{{Compat("api.Performance.now")}}</p>
 
-<h2 id="Voir_aussi">Voir aussi</h2>
+<h2 id="See_also">Voir aussi</h2>
 
 <ul>
- <li><a href="http://updates.html5rocks.com/2012/08/When-milliseconds-are-not-enough-performance-now" title="http://updates.html5rocks.com/2012/08/When-milliseconds-are-not-enough-performance-now">When milliseconds are not enough: performance.now() </a>de HTML5 Rocks.</li>
+  <li><a href="http://updates.html5rocks.com/2012/08/When-milliseconds-are-not-enough-performance-now">Quand les millisecondes ne suffisent pas : performance.now() <small>(en)</small></a> de HTML5 Rocks.</li>
 </ul>

--- a/files/fr/web/api/performance/onresourcetimingbufferfull/index.html
+++ b/files/fr/web/api/performance/onresourcetimingbufferfull/index.html
@@ -11,7 +11,7 @@ translation_of: Web/API/Performance/onresourcetimingbufferfull
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
-<p>La propriété <strong><code>onresourcetimingbufferfull</code></strong> est un gestionnaire d'événements qui sera appelé lorsque l'événement {{event("resourcetimingbufferfull")}} est déclenché. Cet événement est déclenché lorsque le tampon de performance de synchronisation des ressources du navigateur est plein.</p>
+<p class="seoSummary">La propriété <strong><code>onresourcetimingbufferfull</code></strong> est un gestionnaire d'événements qui sera appelé lorsque l'événement {{event("resourcetimingbufferfull")}} est déclenché. Cet événement est déclenché lorsque le tampon de performance de synchronisation des ressources du navigateur est plein.</p>
 
 <p>{{AvailableInWorkers}}</p>
 

--- a/files/fr/web/api/performance/onresourcetimingbufferfull/index.html
+++ b/files/fr/web/api/performance/onresourcetimingbufferfull/index.html
@@ -1,0 +1,77 @@
+---
+title: performance.onresourcetimingbufferfull
+slug: Web/API/Performance/onresourcetimingbufferfull
+tags:
+- API
+- Method
+- Méthode
+- Reference
+- Performance web
+translation_of: Web/API/Performance/onresourcetimingbufferfull
+---
+<div>{{APIRef("Resource Timing API")}}</div>
+
+<p>La propriété <strong><code>onresourcetimingbufferfull</code></strong> est un gestionnaire d'événements qui sera appelé lorsque l'événement {{event("resourcetimingbufferfull")}} est déclenché. Cet événement est déclenché lorsque le tampon de performance de synchronisation des ressources du navigateur est plein.</p>
+
+<p>{{AvailableInWorkers}}</p>
+
+<h2 id="Syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+  callback = <em>performance</em>.onresourcetimingbufferfull = buffer_full_cb;
+</pre>
+
+<h3 id="Return_Value">Valeur de retour</h3>
+
+<dl>
+  <dt>callback</dt>
+  <dd>Un {{domxref("EventHandler")}} qui est invoqué lorsque l'événement {{event("resourcetimingbufferfull")}} est déclenché.</dd>
+</dl>
+
+<h2 id="Example">Exemple</h2>
+
+<p>L'exemple suivant définit une fonction de rappel sur la propriété <code>onresourcetimingbufferfull</code>.</p>
+
+<pre class="brush: js">function buffer_full(event) {
+  console.log("WARNING: Resource Timing Buffer is FULL!");
+  performance.setResourceTimingBufferSize(200);
+}
+function init() {
+  // Définit un rappel si le tampon de ressources est rempli.
+  performance.onresourcetimingbufferfull = buffer_full;
+}
+&lt;body onload="init()"&gt;
+</pre>
+
+<h2 id="Specifications">Spécifications</h2>
+
+<table class="standard-table">
+  <tbody>
+    <tr>
+      <th scope="col">Spécification</th>
+      <th scope="col">Statut</th>
+      <th scope="col">Commentaire</th>
+    </tr>
+    <tr>
+      <td>{{SpecName('Resource Timing', '#dom-performance-onresourcetimingbufferfull',
+        'onresourcetimingbufferfull')}}</td>
+      <td>{{Spec2('Resource Timing')}}</td>
+      <td>Définition initiale.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat("api.Performance.onresourcetimingbufferfull")}}</p>
+
+<h2 id="See_also">Voir aussi</h2>
+
+<ul>
+  <li>Événément {{event("resourcetimingbufferfull")}}</li>
+  <li>{{domxref("Performance.clearResourceTimings","Performance.clearResourceTimings()")}}
+  </li>
+  <li>
+    {{domxref("Performance.setResourceTimingBufferSize","Performance.setResourceTimingBufferSize()")}}
+  </li>
+</ul>

--- a/files/fr/web/api/performance/onresourcetimingbufferfull/index.html
+++ b/files/fr/web/api/performance/onresourcetimingbufferfull/index.html
@@ -11,21 +11,21 @@ translation_of: Web/API/Performance/onresourcetimingbufferfull
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
-<p class="seoSummary">La propriété <strong><code>onresourcetimingbufferfull</code></strong> est un gestionnaire d'événements qui sera appelé lorsque l'événement {{event("resourcetimingbufferfull")}} est déclenché. Cet événement est déclenché lorsque le tampon de performance de synchronisation des ressources du navigateur est plein.</p>
+<p class="seoSummary">La propriété <strong><code>onresourcetimingbufferfull</code></strong> est un gestionnaire d'événements qui sera appelé lorsque l'événement <a href="/fr/docs/Web/API/Performance/resourcetimingbufferfull_event"><code>resourcetimingbufferfull</code></a> est déclenché. Ce déclenchement a lieu lorsque le tampon de performance de synchronisation des ressources du navigateur est plein.</p>
 
 <p>{{AvailableInWorkers}}</p>
 
 <h2 id="Syntax">Syntaxe</h2>
 
 <pre class="brush: js">
-  callback = <em>performance</em>.onresourcetimingbufferfull = buffer_full_cb;
+  callback = performance.onresourcetimingbufferfull = buffer_full_cb;
 </pre>
 
 <h3 id="Return_Value">Valeur de retour</h3>
 
 <dl>
-  <dt>callback</dt>
-  <dd>Un {{domxref("EventHandler")}} qui est invoqué lorsque l'événement {{event("resourcetimingbufferfull")}} est déclenché.</dd>
+  <dt><code>callback</code></dt>
+  <dd>Un {{domxref("EventHandler")}} qui est invoqué lorsque l'événement <a href="/fr/docs/Web/API/Performance/resourcetimingbufferfull_event"><code>resourcetimingbufferfull</code></a> est déclenché.</dd>
 </dl>
 
 <h2 id="Example">Exemple</h2>
@@ -40,18 +40,19 @@ function init() {
   // Définit un rappel si le tampon de ressources est rempli.
   performance.onresourcetimingbufferfull = buffer_full;
 }
-&lt;body onload="init()"&gt;
 </pre>
 
 <h2 id="Specifications">Spécifications</h2>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
       <th scope="col">Spécification</th>
       <th scope="col">Statut</th>
       <th scope="col">Commentaire</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td>{{SpecName('Resource Timing', '#dom-performance-onresourcetimingbufferfull',
         'onresourcetimingbufferfull')}}</td>
@@ -68,7 +69,7 @@ function init() {
 <h2 id="See_also">Voir aussi</h2>
 
 <ul>
-  <li>Événément {{event("resourcetimingbufferfull")}}</li>
+  <li>Événément <a href="/fr/docs/Web/API/Performance/resourcetimingbufferfull_event"><code>resourcetimingbufferfull</code></a></li>
   <li>{{domxref("Performance.clearResourceTimings","Performance.clearResourceTimings()")}}
   </li>
   <li>

--- a/files/fr/web/api/performance/resourcetimingbufferfull_event/index.html
+++ b/files/fr/web/api/performance/resourcetimingbufferfull_event/index.html
@@ -30,7 +30,7 @@ translation_of: Web/API/Performance/resourcetimingbufferfull_event
    <td>{{domxref("Event")}}</td>
   </tr>
   <tr>
-   <th scope="row">Propriété du gestionnaire d'événements</th>
+   <th scope="row">Propriété pour le gestionnaire d'événements correspondant</th>
    <td>{{domxref("Performance.onresourcetimingbufferfull", "onresourcetimingbufferfull")}}</td>
   </tr>
  </tbody>
@@ -41,7 +41,7 @@ translation_of: Web/API/Performance/resourcetimingbufferfull_event
 <p>L'exemple suivant définit une fonction de rappel sur la propriété <code>onresourcetimingbufferfull</code>.</p>
 
 <pre class="brush: js">function buffer_full(event) {
-  console.log("AVERTISSEMENT : La mémoire tampon des ressources est COMPLETE !");
+  console.log("AVERTISSEMENT : La mémoire tampon des ressources est COMPLÈTE !");
   performance.setResourceTimingBufferSize(200);
 }
 function init() {
@@ -58,12 +58,14 @@ function init() {
 <h2 id="Specifications">Spécifications</h2>
 
 <table class="standard-table">
- <tbody>
+ <thead>
   <tr>
    <th scope="col">Spécification</th>
    <th scope="col">Statut</th>
    <th scope="col">Commentaire</th>
   </tr>
+ </thead>
+ <tbody>
   <tr>
    <td>{{SpecName('Resource Timing', '#dom-performance-onresourcetimingbufferfull', 'onresourcetimingbufferfull')}}</td>
    <td>{{Spec2('Resource Timing')}}</td>

--- a/files/fr/web/api/performance/resourcetimingbufferfull_event/index.html
+++ b/files/fr/web/api/performance/resourcetimingbufferfull_event/index.html
@@ -13,7 +13,7 @@ translation_of: Web/API/Performance/resourcetimingbufferfull_event
 ---
 <div>{{APIRef}}</div>
 
-<p>L'événement <code>resourcetimingbufferfull</code> se déclenche lorsque la mémoire <a href="/fr/docs/Web/API/Performance/setResourceTimingBufferSize">tampon de synchronisation des ressources</a> du navigateur est pleine.</p>
+<p class="seoSummary">L'événement <code>resourcetimingbufferfull</code> se déclenche lorsque la mémoire <a href="/fr/docs/Web/API/Performance/setResourceTimingBufferSize">tampon de synchronisation des ressources</a> du navigateur est pleine.</p>
 
 <table class="properties">
  <tbody>

--- a/files/fr/web/api/performance/resourcetimingbufferfull_event/index.html
+++ b/files/fr/web/api/performance/resourcetimingbufferfull_event/index.html
@@ -1,0 +1,84 @@
+---
+title: 'Performance : Événement resourcetimingbufferfull'
+slug: Web/API/Performance/resourcetimingbufferfull_event
+tags:
+  - API
+  - DOM
+  - Event
+  - Performance
+  - Reference
+  - Performance web
+  - onresourcetimingbufferfull
+translation_of: Web/API/Performance/resourcetimingbufferfull_event
+---
+<div>{{APIRef}}</div>
+
+<p>L'événement <code>resourcetimingbufferfull</code> se déclenche lorsque la mémoire <a href="/fr/docs/Web/API/Performance/setResourceTimingBufferSize">tampon de synchronisation des ressources</a> du navigateur est pleine.</p>
+
+<table class="properties">
+ <tbody>
+  <tr>
+   <th scope="row">Propagation</th>
+   <td>Oui</td>
+  </tr>
+  <tr>
+   <th scope="row">Annulable</th>
+   <td>Oui</td>
+  </tr>
+  <tr>
+   <th scope="row">Interface</th>
+   <td>{{domxref("Event")}}</td>
+  </tr>
+  <tr>
+   <th scope="row">Propriété du gestionnaire d'événements</th>
+   <td>{{domxref("Performance.onresourcetimingbufferfull", "onresourcetimingbufferfull")}}</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Examples">Exemples</h2>
+
+<p>L'exemple suivant définit une fonction de rappel sur la propriété <code>onresourcetimingbufferfull</code>.</p>
+
+<pre class="brush: js">function buffer_full(event) {
+  console.log("AVERTISSEMENT : La mémoire tampon des ressources est COMPLETE !");
+  performance.setResourceTimingBufferSize(200);
+}
+function init() {
+  // Définit un rappel si le tampon de ressources est rempli.
+  performance.onresourcetimingbufferfull = buffer_full;
+}
+&lt;body onload="init()"&gt;</pre>
+
+<p>Notez que vous pouvez également configurer le gestionnaire à l'aide de la fonction addEventListener() :</p>
+
+<pre class="brush: js">performance.addEventListener('resourcetimingbufferfull', buffer_full);
+</pre>
+
+<h2 id="Specifications">Spécifications</h2>
+
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Spécification</th>
+   <th scope="col">Statut</th>
+   <th scope="col">Commentaire</th>
+  </tr>
+  <tr>
+   <td>{{SpecName('Resource Timing', '#dom-performance-onresourcetimingbufferfull', 'onresourcetimingbufferfull')}}</td>
+   <td>{{Spec2('Resource Timing')}}</td>
+   <td>Définition initialen.</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat("api.Performance.resourcetimingbufferfull_event")}}</p>
+
+<h2 id="See_also">Voir aussi</h2>
+
+<ul>
+ <li>{{domxref("Performance.clearResourceTimings","Performance.clearResourceTimings()")}}</li>
+ <li>{{domxref("Performance.setResourceTimingBufferSize","Performance.setResourceTimingBufferSize()")}}</li>
+</ul>

--- a/files/fr/web/api/performance/setresourcetimingbuffersize/index.html
+++ b/files/fr/web/api/performance/setresourcetimingbuffersize/index.html
@@ -11,7 +11,7 @@ translation_of: Web/API/Performance/setResourceTimingBufferSize
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
-<p>La méthode <strong><code>setResourceTimingBufferSize()</code></strong> définit la taille du <em>tampon de synchronisation des ressources</em> du navigateur au nombre spécifié d'objets « <code>resource</code> » d'{{domxref("PerformanceEntry.entryType", "entryType")}}.</p>
+<p class="seoSummary">La méthode <strong><code>setResourceTimingBufferSize()</code></strong> définit la taille du <em>tampon de synchronisation des ressources</em> du navigateur au nombre spécifié d'objets « <code>resource</code> » d'{{domxref("PerformanceEntry.entryType", "entryType")}}.</p>
 
 <p>La taille recommandée du tampon de synchronisation des ressources d'un navigateur est d'au moins 150 objets d'{{domxref("PerformanceEntry","entrée de performance")}}.</p>
 

--- a/files/fr/web/api/performance/setresourcetimingbuffersize/index.html
+++ b/files/fr/web/api/performance/setresourcetimingbuffersize/index.html
@@ -1,0 +1,77 @@
+---
+title: performance.setResourceTimingBufferSize()
+slug: Web/API/Performance/setResourceTimingBufferSize
+tags:
+- API
+- Method
+- Méthode
+- Reference
+- Performance web
+translation_of: Web/API/Performance/setResourceTimingBufferSize
+---
+<div>{{APIRef("Resource Timing API")}}</div>
+
+<p>La méthode <strong><code>setResourceTimingBufferSize()</code></strong> définit la taille du <em>tampon de synchronisation des ressources</em> du navigateur au nombre spécifié d'objets « <code>resource</code> » d'{{domxref("PerformanceEntry.entryType", "entryType")}}.</p>
+
+<p>La taille recommandée du tampon de synchronisation des ressources d'un navigateur est d'au moins 150 objets d'{{domxref("PerformanceEntry","entrée de performance")}}.</p>
+
+<p>{{AvailableInWorkers}}</p>
+
+<h2 id="Syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+  <em>performance</em>.setResourceTimingBufferSize(maxSize);
+</pre>
+
+<h3 id="Arguments">Arguments</h3>
+
+<dl>
+  <dt>maxSize</dt>
+  <dd>Un <code>number</code> représentant le nombre maximal d'objets {{domxref("PerformanceEntry", "d'entrée de performance")}} que le navigateur doit contenir dans son tampon d'entrée de performance.</dd>
+</dl>
+
+<h3 id="Return_Value">Valeur de retour</h3>
+
+<dl>
+  <dt>none</dt>
+  <dd>Cette méthode n'a pas de valeur de retour.</dd>
+</dl>
+
+<h2 id="Example">Exemple</h2>
+
+<pre class="brush: js">function setResourceTimingBufferSize(maxSize) {
+  if (performance === undefined) {
+    log("Le navigateur ne prend pas en charge les performances Web");
+    return;
+  }
+  var supported = typeof performance.setResourceTimingBufferSize == "function";
+  if (supported) {
+    log("... Performance.setResourceTimingBufferSize() = Oui");
+    performance.setResourceTimingBufferSize(maxSize);
+  } else {
+    log("... Performance.setResourceTimingBufferSize() = NON pris en charge");
+  }
+}
+</pre>
+
+<h2 id="Specifications">Spécifications</h2>
+
+<table class="standard-table">
+  <tbody>
+    <tr>
+      <th scope="col">Spécification</th>
+      <th scope="col">Statut</th>
+      <th scope="col">Commentaire</th>
+    </tr>
+    <tr>
+      <td>{{SpecName('Resource Timing', '#dom-performance-setresourcetimingbuffersize',
+        'setResourceTimingBufferSize()')}}</td>
+      <td>{{Spec2('Resource Timing')}}</td>
+      <td>Définition initiale.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat("api.Performance.setResourceTimingBufferSize")}}</p>

--- a/files/fr/web/api/performance/setresourcetimingbuffersize/index.html
+++ b/files/fr/web/api/performance/setresourcetimingbuffersize/index.html
@@ -11,9 +11,9 @@ translation_of: Web/API/Performance/setResourceTimingBufferSize
 ---
 <div>{{APIRef("Resource Timing API")}}</div>
 
-<p class="seoSummary">La méthode <strong><code>setResourceTimingBufferSize()</code></strong> définit la taille du <em>tampon de synchronisation des ressources</em> du navigateur au nombre spécifié d'objets « <code>resource</code> » d'{{domxref("PerformanceEntry.entryType", "entryType")}}.</p>
+<p class="seoSummary">La méthode <strong><code>setResourceTimingBufferSize()</code></strong> définit la taille du tampon mémoire du navigateur dans lequel sont stockés les objets de mesures de performance de type <code>"resource"</code> (voir {{domxref("PerformanceEntry.entryType", "entryType")}}).</p>
 
-<p>La taille recommandée du tampon de synchronisation des ressources d'un navigateur est d'au moins 150 objets d'{{domxref("PerformanceEntry","entrée de performance")}}.</p>
+<p>La taille recommandée du tampon de synchronisation des ressources d'un navigateur est au moins 150 objets <code>{{domxref("PerformanceEntry")}}</code>.</p>
 
 <p>{{AvailableInWorkers}}</p>
 
@@ -26,16 +26,13 @@ translation_of: Web/API/Performance/setResourceTimingBufferSize
 <h3 id="Arguments">Arguments</h3>
 
 <dl>
-  <dt>maxSize</dt>
-  <dd>Un <code>number</code> représentant le nombre maximal d'objets {{domxref("PerformanceEntry", "d'entrée de performance")}} que le navigateur doit contenir dans son tampon d'entrée de performance.</dd>
+  <dt><code>maxSize</code></dt>
+  <dd>Un nombre (cf. {{jsxref("Number")}}) représentant le nombre maximal d'objets {{domxref("PerformanceEntry", "d'entrée de performance","",1)}} avec le type <code>"resource"</code> que le navigateur doit contenir dans le tampon correspondant.</dd>
 </dl>
 
 <h3 id="Return_Value">Valeur de retour</h3>
 
-<dl>
-  <dt>none</dt>
-  <dd>Cette méthode n'a pas de valeur de retour.</dd>
-</dl>
+<p>Aucune.</p>
 
 <h2 id="Example">Exemple</h2>
 
@@ -57,12 +54,14 @@ translation_of: Web/API/Performance/setResourceTimingBufferSize
 <h2 id="Specifications">Spécifications</h2>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
       <th scope="col">Spécification</th>
       <th scope="col">Statut</th>
       <th scope="col">Commentaire</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td>{{SpecName('Resource Timing', '#dom-performance-setresourcetimingbuffersize',
         'setResourceTimingBufferSize()')}}</td>

--- a/files/fr/web/api/performance/timeorigin/index.html
+++ b/files/fr/web/api/performance/timeorigin/index.html
@@ -14,7 +14,7 @@ translation_of: Web/API/Performance/getEntriesByName
 ---
 <p>{{SeeCompatTable}}{{APIRef("High Resolution Time")}}</p>
 
-<p>La propriété en lecture seule <strong><code>timeOrigin</code></strong> de l'interface {{domxref("Performance")}} renvoie l'horodatage haute résolution de l'heure de début de la mesure de performance.</p>
+<p class="seoSummary">La propriété en lecture seule <strong><code>timeOrigin</code></strong> de l'interface {{domxref("Performance")}} renvoie l'horodatage haute résolution de l'heure de début de la mesure de performance.</p>
 
 <p>{{AvailableInWorkers}}</p>
 

--- a/files/fr/web/api/performance/timeorigin/index.html
+++ b/files/fr/web/api/performance/timeorigin/index.html
@@ -26,16 +26,18 @@ translation_of: Web/API/Performance/getEntriesByName
 
 <h3 id="Value">Valeur</h3>
 
-<p>Un horodatage haute résolution.</p>
+<p>Un horodatage haute résolution (voir le type <a href="/fr/docs/Web/API/DOMHighResTimeStamp"><code>DOMHighResTimeStamp</code></a>).</p>
 
 <h2 id="Specifications">Spécifications</h2>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
       <th scope="col">Spécification</th>
       <th scope="col">Statut</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td>{{SpecName('Highres Time Level 2','#timeorigin-attribute','timeOrigin')}}</td>
       <td>{{Spec2('Highres Time Level 2')}}</td>

--- a/files/fr/web/api/performance/timeorigin/index.html
+++ b/files/fr/web/api/performance/timeorigin/index.html
@@ -1,0 +1,48 @@
+---
+title: performance.timeOrigin
+slug: Web/API/Performance/timeOrigin
+tags:
+  - API
+  - Experimental
+  - High Resolution Time API
+  - Performance
+  - Property
+  - Propriété
+  - Reference
+  - timeOrigin
+translation_of: Web/API/Performance/getEntriesByName
+---
+<p>{{SeeCompatTable}}{{APIRef("High Resolution Time")}}</p>
+
+<p>La propriété en lecture seule <strong><code>timeOrigin</code></strong> de l'interface {{domxref("Performance")}} renvoie l'horodatage haute résolution de l'heure de début de la mesure de performance.</p>
+
+<p>{{AvailableInWorkers}}</p>
+
+<h2 id="Syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+  var timeOrigin = performance.timeOrigin
+</pre>
+
+<h3 id="Value">Valeur</h3>
+
+<p>Un horodatage haute résolution.</p>
+
+<h2 id="Specifications">Spécifications</h2>
+
+<table class="standard-table">
+  <tbody>
+    <tr>
+      <th scope="col">Spécification</th>
+      <th scope="col">Statut</th>
+    </tr>
+    <tr>
+      <td>{{SpecName('Highres Time Level 2','#timeorigin-attribute','timeOrigin')}}</td>
+      <td>{{Spec2('Highres Time Level 2')}}</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat("api.Performance.timeOrigin")}}</p>

--- a/files/fr/web/api/performance/timing/index.html
+++ b/files/fr/web/api/performance/timing/index.html
@@ -11,6 +11,7 @@ tags:
   - Propriété
   - Read-only
   - Lecture seule
+  - Reference
 translation_of: Web/API/Performance/timing
 ---
 <p>{{deprecated_header}}{{APIRef("Navigation Timing")}}</p>
@@ -19,25 +20,27 @@ translation_of: Web/API/Performance/timing
   <p>Cette propriété est dépréciée dans la spécification <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2</a>. Veuillez utiliser l'interface {{domxref("PerformanceNavigationTiming")}} à la place.</p>
 </div>
 
-<p class="seoSummary">L'ancienne propriété <strong><code>Performance.timing</code></strong> en lecture seule renvoie un objet {{domxref("PerformanceTiming")}} contenant des informations de performance liées à la latence.</p>
+<p class="seoSummary">L'ancienne propriété <strong><code>Performance.timing</code></strong> renvoie un objet {{domxref("PerformanceTiming")}}  en lecture seule contenant des informations de performance liées à la latence.</p>
 
 {{warning("Cette propriété n'est pas disponible dans les Web Workers.")}}
 
 <h2 id="Syntax">Syntaxe</h2>
 
 <pre class="brush: js">
-  <em>timingInfo</em> = <em>performance</em>.timing;
+  <var>timingInfo</var> = performance.timing;
 </pre>
 
 <h2 id="Specifications">Spécifications</h2>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
       <th scope="col">Spécification</th>
       <th scope="col">Statut</th>
       <th scope="col">Commentaire</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td>{{SpecName('Navigation Timing Level 2', '#obsolete')}}</td>
       <td>{{Spec2('Navigation Timing Level 2')}}</td>

--- a/files/fr/web/api/performance/timing/index.html
+++ b/files/fr/web/api/performance/timing/index.html
@@ -19,7 +19,7 @@ translation_of: Web/API/Performance/timing
   <p>Cette propriété est dépréciée dans la spécification <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2</a>. Veuillez utiliser l'interface {{domxref("PerformanceNavigationTiming")}} à la place.</p>
 </div>
 
-<p>L'ancienne propriété <strong><code>Performance.timing</code></strong> en lecture seule renvoie un objet {{domxref("PerformanceTiming")}} contenant des informations de performance liées à la latence.</p>
+<p class="seoSummary">L'ancienne propriété <strong><code>Performance.timing</code></strong> en lecture seule renvoie un objet {{domxref("PerformanceTiming")}} contenant des informations de performance liées à la latence.</p>
 
 {{warning("Cette propriété n'est pas disponible dans les Web Workers.")}}
 

--- a/files/fr/web/api/performance/timing/index.html
+++ b/files/fr/web/api/performance/timing/index.html
@@ -1,0 +1,57 @@
+---
+title: performance.timing
+slug: Web/API/Performance/timing
+tags:
+  - API
+  - Rétrocompatibilité
+  - Déprécié
+  - Navigation Timing
+  - Performance
+  - Property
+  - Propriété
+  - Read-only
+  - Lecture seule
+translation_of: Web/API/Performance/timing
+---
+<p>{{deprecated_header}}{{APIRef("Navigation Timing")}}</p>
+
+<div class="notecard warning">
+  <p>Cette propriété est dépréciée dans la spécification <a href="https://w3c.github.io/navigation-timing/#obsolete">Navigation Timing Level 2</a>. Veuillez utiliser l'interface {{domxref("PerformanceNavigationTiming")}} à la place.</p>
+</div>
+
+<p>L'ancienne propriété <strong><code>Performance.timing</code></strong> en lecture seule renvoie un objet {{domxref("PerformanceTiming")}} contenant des informations de performance liées à la latence.</p>
+
+{{warning("Cette propriété n'est pas disponible dans les Web Workers.")}}
+
+<h2 id="Syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+  <em>timingInfo</em> = <em>performance</em>.timing;
+</pre>
+
+<h2 id="Specifications">Spécifications</h2>
+
+<table class="standard-table">
+  <tbody>
+    <tr>
+      <th scope="col">Spécification</th>
+      <th scope="col">Statut</th>
+      <th scope="col">Commentaire</th>
+    </tr>
+    <tr>
+      <td>{{SpecName('Navigation Timing Level 2', '#obsolete')}}</td>
+      <td>{{Spec2('Navigation Timing Level 2')}}</td>
+      <td>Définition initiale.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat("api.Performance.timing")}}</p>
+
+<h2 id="See_also">Voir aussi</h2>
+
+<ul>
+  <li>L'interface {{domxref("Performance")}} à laquelle il appartient.</li>
+</ul>

--- a/files/fr/web/api/performance/tojson/index.html
+++ b/files/fr/web/api/performance/tojson/index.html
@@ -11,7 +11,7 @@ translation_of: Web/API/Performance/toJSON
 ---
 <div>{{APIRef("High Resolution Timing")}}</div>
 
-<p>La méthode <strong><code>toJSON()</code></strong> de l'interface {{domxref("Performance")}} est un sérialiseur standard : elle renvoie une représentation JSON des propriétés de l'objet performance.</p>
+<p class="seoSummary">La méthode <strong><code>toJSON()</code></strong> de l'interface {{domxref("Performance")}} est un sérialiseur standard : elle renvoie une représentation JSON des propriétés de l'objet performance.</p>
 
 <p>{{AvailableInWorkers}}</p>
 

--- a/files/fr/web/api/performance/tojson/index.html
+++ b/files/fr/web/api/performance/tojson/index.html
@@ -23,15 +23,12 @@ translation_of: Web/API/Performance/toJSON
 
 <h3 id="Arguments">Arguments</h3>
 
-<dl>
-  <dt>None</dt>
-  <dd>Cette méthode ne demande aucun argument.</dd>
-</dl>
+<p>Aucun</p>
 
 <h3 id="Return_value">Valeur de retour</h3>
 
 <dl>
-  <dt>myPerf</dt>
+  <dt><code>myPerf</code></dt>
   <dd>Un objet JSON qui est la sérialisation de l'objet {{domxref("Performance")}}.</dd>
 </dl>
 
@@ -45,12 +42,14 @@ console.log("json = " + JSON.stringify(js));
 <h2 id="Specifications">Spécifications</h2>
 
 <table class="standard-table">
-  <tbody>
+  <thead>
     <tr>
       <th scope="col">Spécification</th>
       <th scope="col">Statut</th>
       <th scope="col">Commentaire</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td>{{SpecName('Highres Time Level 2', '#dom-performance-tojson', 'toJSON()
         serializer')}}</td>

--- a/files/fr/web/api/performance/tojson/index.html
+++ b/files/fr/web/api/performance/tojson/index.html
@@ -1,0 +1,65 @@
+---
+title: performance.toJSON()
+slug: Web/API/Performance/toJSON
+tags:
+  - API
+  - Method
+  - Méthode
+  - Performance Web
+  - Référence
+translation_of: Web/API/Performance/toJSON
+---
+<div>{{APIRef("High Resolution Timing")}}</div>
+
+<p>La méthode <strong><code>toJSON()</code></strong> de l'interface {{domxref("Performance")}} est un sérialiseur standard : elle renvoie une représentation JSON des propriétés de l'objet performance.</p>
+
+<p>{{AvailableInWorkers}}</p>
+
+<h2 id="Syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+  myPerf = performance.toJSON()
+</pre>
+
+<h3 id="Arguments">Arguments</h3>
+
+<dl>
+  <dt>None</dt>
+  <dd>Cette méthode ne demande aucun argument.</dd>
+</dl>
+
+<h3 id="Return_value">Valeur de retour</h3>
+
+<dl>
+  <dt>myPerf</dt>
+  <dd>Un objet JSON qui est la sérialisation de l'objet {{domxref("Performance")}}.</dd>
+</dl>
+
+<h2 id="Example">Exemple</h2>
+
+<pre class="brush: js">var js;
+js = window.performance.toJSON();
+console.log("json = " + JSON.stringify(js));
+</pre>
+
+<h2 id="Specifications">Spécifications</h2>
+
+<table class="standard-table">
+  <tbody>
+    <tr>
+      <th scope="col">Spécification</th>
+      <th scope="col">Statut</th>
+      <th scope="col">Commentaire</th>
+    </tr>
+    <tr>
+      <td>{{SpecName('Highres Time Level 2', '#dom-performance-tojson', 'toJSON()
+        serializer')}}</td>
+      <td>{{Spec2('Highres Time Level 2')}}</td>
+      <td>Définition de <code>toJson()</code>.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat("api.Performance.toJSON")}}</p>


### PR DESCRIPTION
### Related issues
N/A
### Observed issues
Many of the missing pages in the French version were identified as a result of a previous PR updating the Events page. This PR contains the complete update of one of the files that is not complete.

### Changes in commits
- Performence (**UPDATED**)
  - clearMarks (**CREATED**)
  - clearMeasures (**CREATED**)
  - clearResourceTimings (**CREATED**)
  - getEntries (**CREATED**)
  - getEntriesByName (**CREATED**)
  - getEntriesByType (**CREATED**)
  - mark (**CREATED**)
  - measure (**CREATED**)
  - memory (**CREATED**)
  - navigation (**UPDATED**) (Depreciated)
  - now (**UPDATED**)
  - onresourcetimingbufferfull (**CREATED**)
  - resourcetimingbufferfull_event (**CREATED**)
  - setResourceTimingBufferSize (**CREATED**)
  - timeOrigin (**CREATED**) (Depreciated)
  - toJSON (**CREATED**)