### PR TITLE
Update Web/JavaScript/Reference/Global_Objects/Date/getUTCDate

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/date/getutcdate/index.html
+++ b/files/ja/web/javascript/reference/global_objects/date/getutcdate/index.html
@@ -2,64 +2,63 @@
 title: Date.prototype.getUTCDate()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getUTCDate
 tags:
-  - Date
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
+- Date
+- JavaScript
+- Method
+- Prototype
+- Reference
 translation_of: Web/JavaScript/Reference/Global_Objects/Date/getUTCDate
 ---
 <div>{{JSRef}}</div>
 
-<p><strong><code>getUTCDay()</code></strong> メソッドは、協定世界時に基づき、指定された日時の「曜日」を返します。0 は日曜日を表します。</p>
+<p><strong><code>getUTCDate()</code></strong> メソッドは、協定世界時に基づき、指定された日時の月内の日 (1～31) を返します。</p>
 
-<div>{{EmbedInteractiveExample("pages/js/date-getutcday.html")}}</div>
+<div>{{EmbedInteractiveExample("pages/js/date-getutcdate.html")}}</div>
 
 <div class="hidden">このデモのソースファイルは GitHub リポジトリに格納されています。デモプロジェクトに協力したい場合は、 <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> をクローンしてプルリクエストを送信してください。</div>
 
-<h2 id="Syntax" name="Syntax">構文</h2>
+<h2 id="Syntax">構文</h2>
 
-<pre class="syntaxbox notranslate"><var>dateObj</var>.getUTCDay()</pre>
+<pre class="brush: js"><var>dateObj</var>.getUTCDate()</pre>
 
-<h3 id="Return_value" name="Return_value">返値</h3>
+<h3 id="Return_value">返値</h3>
 
-<p>協定世界時に基づき、与えられた日付の「曜日」に相当する整数値。0 は日曜日、1 は月曜日、2 は火曜日を表します。</p>
+<p>協定世界時に基づき、与えられた日付の「日」を表す 1 から 31 までの整数値です。</p>
 
-<h2 id="Examples" name="Examples">例</h2>
+<h2 id="Examples">例</h2>
 
-<h3 id="Using_getUTCDay" name="Using_getUTCDay">getUTCDay() の使用</h3>
+<h3 id="Using_getUTCDate">getUTCDate() の使用</h3>
 
-<p>次の例は、現在日時の「曜日」部を変数 <code>weekday</code> に代入します。</p>
+<p>次の例は、現在日時の「日」の部分を変数 <code>dayOfMonth</code> に代入します。</p>
 
-<pre class="brush: js notranslate">var today = new Date();
-var weekday = today.getUTCDay();
+<pre class="brush: js">var today = new Date();
+var dayOfMonth = today.getUTCDate();
 </pre>
 
-<h2 id="Specifications" name="Specifications">仕様書</h2>
+<h2 id="Specifications">仕様書</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">仕様書</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-date.prototype.getutcday', 'Date.prototype.getUTCDay')}}</td>
-  </tr>
- </tbody>
+  <thead>
+    <tr>
+      <th scope="col">仕様書</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{SpecName('ESDraft', '#sec-date.prototype.getutcdate',
+        'Date.prototype.getUTCDate')}}</td>
+    </tr>
+  </tbody>
 </table>
 
-<h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
+<h2 id="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
+<p>{{Compat("javascript.builtins.Date.getUTCDate")}}</p>
 
-<p>{{Compat("javascript.builtins.Date.getUTCDay")}}</p>
-
-<h2 id="See_also" name="See_also">関連情報</h2>
+<h2 id="See_also">関連情報</h2>
 
 <ul>
- <li>{{jsxref("Date.prototype.getUTCDate()")}}</li>
- <li>{{jsxref("Date.prototype.getDay()")}}</li>
- <li>{{jsxref("Date.prototype.setUTCDate()")}}</li>
+  <li>{{jsxref("Date.prototype.getUTCDate()")}}</li>
+  <li>{{jsxref("Date.prototype.getDay()")}}</li>
+  <li>{{jsxref("Date.prototype.setUTCDate()")}}</li>
 </ul>


### PR DESCRIPTION
- fix #152
- 2021/02/20 時点の英語版を反映