### PR TITLE
Major correction of the examples, texts and formatting of the page - Issue #180

### DIFF
--- a/files/fr/web/api/eventtarget/addeventlistener/index.html
+++ b/files/fr/web/api/eventtarget/addeventlistener/index.html
@@ -15,21 +15,32 @@ tags:
   - attachEvent
   - Écouteurs
   - Écouteurs d'Évènements
+  - AccessOuterData
+  - Detecting Events
+  - Event Handlers
+  - Event Listener
+  - EventTarget
+  - Method
+  - PassingData
+  - Receiving Events
+  - addEventListener
+  - events
+  - mselementresize
 translation_of: Web/API/EventTarget/addEventListener
 ---
 <p>{{APIRef("DOM Events")}}</p>
 
-<p class="seoSummary">La méthode <code><strong>addEventListener()</strong></code> de {{domxref("EventTarget")}} installe une fonction à appeler chaque fois que l'événement spécifié est envoyé à la cible. Les cibles courantes sont un {{domxref("Element")}}, le {{domxref("Document")}} lui-même et une {{domxref("Window")}}, mais elle peut être tout objet prenant en charge les évènements (comme {{domxref("XMLHttpRequest")}}).</p>
+<p><span class="seoSummary">La méthode <code><strong>addEventListener()</strong></code> de {{domxref("EventTarget")}} attache une fonction à appeler chaque fois que l'évènement spécifié est envoyé à la cible.</span> Les cibles courantes sont un {{domxref("Element")}}, le {{domxref("Document")}} lui-même et une {{domxref("Window")}}, mais on peut tout à fait cible n'importe quel objet prenant en charge les évènements (comme {{domxref("XMLHttpRequest")}}).</p>
 
-<p><code>addEventListener()</code> agit en ajoutant une fonction ou un objet qui implémente {{domxref("EventListener")}} à la liste des écouteurs d'événements pour le type d'événement spécifié sur le {{domxref("EventTarget")}} dans lequel il est appelé.</p>
+<p><code>addEventListener()</code> agit en ajoutant une fonction ou un objet qui implémente {{domxref("EventListener")}} à la liste des gestionnaires d'évènement pour le type d'évènement spécifié sur la cible ({{domxref("EventTarget")}}) à partir de laquelle il est appelé.</p>
 
 <h2 id="Syntax">Syntaxe</h2>
 
-<pre class="syntaxbox">
-  target.addEventListener(type, listener [, options]);
-  target.addEventListener(type, listener [, useCapture]);
-  target.addEventListener(type, listener [, useCapture, wantsUntrusted {{Non-standard_inline}}]); // Gecko/Mozilla seulement
-</pre>
+<pre
+  class="brush: js"><var>target</var>.addEventListener(<var>type</var>, <var>listener</var> [, <var>options</var>]);
+<var>target</var>.addEventListener(<var>type</var>, <var>listener</var> [, <var>useCapture</var>]);
+<var>target</var>.addEventListener(<var>type</var>, <var>listener</var> [, <var>useCapture</var>, <var>wantsUntrusted</var> {{Non-standard_inline}}]); // Gecko/Mozilla uniquement</pre>
+
 
 <h3 id="Parameters">Paramètres</h3>
 
@@ -37,35 +48,35 @@ translation_of: Web/API/EventTarget/addEventListener
   <dt><code>type</code></dt>
   <dd>Une chaîne sensible à la casse représentant le <a href="/fr/docs/Web/Events">type d'évènement</a> à écouter.</dd>
   <dt><code>listener</code></dt>
-  <dd>L'objet qui recevra une notification (un objet qui implémente l'interface {{domxref("Event")}}) lorsqu'un évènement du type spécifié se produit. Cela doit être un objet implémentant l'interface {{domxref("EventListener")}} ou une <a href="/fr/docs/Web/JavaScript/Guide/Functions">fonction</a> JavaScript. Voir {{anch("The_event_listener_callback", "Rappel de l'écouteur d'évènement")}} pour des détails sur le rappel lui-même.</dd>
+  <dd>L'objet qui recevra un évènement (c'est-à-dire un objet qui implémente l'interface {{domxref("Event")}}) lorsqu'un évènement du type spécifié se produit. Cet argument doit être un objet implémentant l'interface {{domxref("EventListener")}} ou une <a href="/fr/docs/Web/JavaScript/Guide/Functions">fonction</a> JavaScript. Voir {{anch("The_event_listener_callback", "Fonction de rappel (<i>callback</i> pour le gestionnaire d'évènement)")}} pour plus de détails sur le fonctionnement d'une fonction de rappel.</dd>
   <dt><code>options</code> {{optional_inline}}</dt>
   <dd>Un objet options spécifie les caractéristiques de l'écouteur d'évènements. Les options disponibles sont :
     <dl>
       <dt><code>capture</code></dt>
-        <dd>Un {{jsxref("Boolean")}} indiquant que les évènements de ce type seront distribués à l'<code><var>écouteur</var></code> enregistré avant d'être distribués à tout <code>EventTarget</code> située en-dessous dans l'arborescence DOM.</dd>
+        <dd>Un booléen ({{jsxref("Boolean")}}) indiquant que les évènements de ce type seront distribués à l'<code><var>listener</var></code> enregistré avant d'être distribués à tout <code>EventTarget</code> située en dessous dans l'arborescence DOM.</dd>
         <dt><code>once</code></dt>
-        <dd>Un {{jsxref("Boolean")}} indiquant que l'<em><code>écouteur</code></em> doit être invoqué au plus une fois après avoir été ajouté. Si <code>true</code> (<em>vrai</em>), l'<em><code>écouteur</code></em> sera automatiquement supprimé après son appel.</dd>
+        <dd>Un booléen ({{jsxref("Boolean")}}) indiquant que <code>listener</code> doit être invoqué au plus une fois après avoir été ajouté. Si <code>true</code> (vrai), <code>listener</code> sera automatiquement supprimé après son appel.</dd>
         <dt><code>passive</code></dt>
-        <dd>Un {{jsxref("Boolean")}} qui, si <code>true</code>, indique que la fonction spécifiée par l'<em><code>écouteur</code></em> n'appellera jamais {{domxref("Event.preventDefault", "preventDefault()")}}. Si un écouteur passif appelle <code>preventDefault()</code>, l'agent utilisateur ne fera rien d'autre que de générer un avertissement sur la console. Voir {{anch("Amélioration des performances de défilement avec les écouteurs passifs")}} pour en apprendre davantage.</dd>
+        <dd>Un booléen ({{jsxref("Boolean")}}) qui, si <code>true</code>, indique que la fonction spécifiée par <code>listener</code> n'appellera jamais {{domxref("Event.preventDefault", "preventDefault()")}}. Si un écouteur passif appelle <code>preventDefault()</code>, l'agent utilisateur ne fera rien d'autre que de générer un avertissement dans la console. Voir {{anch("Improving_scrolling_performance_with_passive_listeners","Améliorer les performances du défilement avec des gestionnaires passifs")}} pour en apprendre davantage.</dd>
         <dt><code>mozSystemGroup</code> {{non-standard_inline}}</dt>
-        <dd>Un {{jsxref("Boolean")}} indiquant que l'écouteur doit être ajouté au groupe système. Disponible seulement pour le code s'exécutant dans XBL ou dans le {{glossary("chrome")}} du navigateur Firefox.</dd>
+        <dd>Un booléen ({{jsxref("Boolean")}}) indiquant que l'écouteur doit être ajouté au groupe système. Disponible uniquement pour le code s'exécutant dans XBL ou dans le {{glossary("chrome")}} du navigateur Firefox.</dd>
       </dl>
     </dd>
   <dt><code>useCapture</code> {{optional_inline}}</dt>
-  <dd>Un {{jsxref("Boolean")}} indiquant si les événements de ce type seront distribués au <em><code>listener</code></em> enregistré <em>avant</em> d'être distribués à toute <code>EventTarget</code> (« cible d'évènement ») située en-dessous dans l'arborescence DOM. Les événements qui se propagent vers le haut dans l'arborescence ne déclencheront pas un écouteur indiqué comme utilisant la capture. La propagation et la capture d'événements sont deux manières de propager des événements qui se produisent dans un élément imbriqué dans un autre, lorsque les deux éléments ont enregistré un gestionnaire pour cet événement. Le mode de propagation de l'évènement détermine l'ordre dans lequel les éléments reçoivent l'événement. Voir les <a href="http://www.w3.org/TR/DOM-Level-3-Events/#event-flow">DOM Level 3 Events</a> et <a href="http://www.quirksmode.org/js/events_order.html#link4">JavaScript Event order</a> pour une explication détaillée. Si non spécifié, <em><code>useCapture</code></em> a <code>false</code> pour valeur par défaut.</dd>
+  <dd>Un booléen ({{jsxref("Boolean")}}) indiquant si les évènements de ce type seront distribués au <code>listener</code> enregistré avant d'être distribués à toute <code>EventTarget</code> (« cible d'évènement ») située en dessous dans l'arborescence DOM. Les évènements qui se propagent vers le haut dans l'arborescence ne déclencheront pas un écouteur indiqué comme utilisant la capture. La propagation et la capture d'évènements sont deux manières de propager des évènements qui se produisent dans un élément imbriqué dans un autre, lorsque les deux éléments ont enregistré un gestionnaire pour cet évènement. Le mode de propagation de l'évènement détermine l'ordre dans lequel les éléments reçoivent l'évènement. Voir les <a href="http://www.w3.org/TR/DOM-Level-3-Events/#event-flow">DOM Level 3 Events</a> et <a href="http://www.quirksmode.org/js/events_order.html#link4">JavaScript Event order</a> pour une explication détaillée. S'il n'est pas spécifié, <code>useCapture</code> aura <code>false</code> comme valeur par défaut.</dd>
 </dl>
 
 <div class="notecard note">
-  <p><strong>Note :</strong> Pour les écouteurs attachés à la cible d'évènement, l'évènement se trouve dans la phase cible, plutôt que dans les phases de propagation et de capture. Les évènements dans la phase cible déclencheront tous les écouteurs d'un élément dans l'ordre où ils ont été enregistrés, indépendamment du paramètre <em><code>useCapture</code></em>.</p>
+  <p><strong>Note :</strong> Pour les écouteurs attachés à la cible d'évènement, l'évènement se trouve dans la phase cible, plutôt que dans les phases de propagation et de capture. Les évènements dans la phase cible déclencheront tous les écouteurs d'un élément dans l'ordre où ils ont été enregistrés, indépendamment du paramètre <code>useCapture</code>.</p>
 </div>
 
 <div class="notecard note">
-  <p><strong>Note :</strong> <em><code>useCapture</code></em> n'est pas toujours facultatif. Idéalement, vous devriez l'inclure pour une compatibilité de navigateurs la plus large possible.</p>
+  <p><strong>Note :</strong> <code>useCapture</code> n'a pas toujours été facultatif. Idéalement, vous devriez l'inclure pour une compatibilité navigateur la plus large possible.</p>
 </div>
 
 <dl>
-  <dt><em><code>wantsUntrusted</code></em> {{Non-standard_inline}}</dt>
-  <dd>Un paramètre spécifique à Firefox (Gecko). Si <code>true</code>, l'écouteur reçoit les événements synthétiques distribués par le contenu web (le défaut est <code>false</code> pour le {{glossary("chrome")}} du navigateur et <code>true</code> pour les pages web ordinaires). Ce paramètre est utile pour le code qui se trouve dans les compléments, ainsi que pour le navigateur lui-même.</dd>
+  <dt><code>wantsUntrusted</code> {{Non-standard_inline}}</dt>
+  <dd>Un paramètre spécifique à Firefox (Gecko). Si <code>true</code>, l'écouteur reçoit les évènements synthétiques distribués par le contenu web (le défaut est <code>false</code> pour le {{glossary("chrome")}} du navigateur et <code>true</code> pour les pages web ordinaires). Ce paramètre est utile pour le code qui se trouve dans les compléments, ainsi que pour le navigateur lui-même.</dd>
 </dl>
 
 <h3 id="Return_value">Valeur de retour</h3>
@@ -74,13 +85,13 @@ translation_of: Web/API/EventTarget/addEventListener
 
 <h2 id="Usage_notes">Notes d'utilisation</h2>
 
-<h3 id="The_event_listener_callback">Rappel de l'écouteur d'évènement</h3>
+<h3 id="The_event_listener_callback">Utilisation d'une fonction de rappel (<i>callback</i>)</h3>
 
-<p>L'écouteur d'évènement peut être spécifié, soit comme une fonction de rappel, soit comme un objet qui implémente {{domxref("EventListener")}}, dont la méthode {{domxref("EventListener.handleEvent", "handleEvent()")}} sert de fonction de rappel.</p>
+<p>L'écouteur d'évènement peut être spécifié, soit comme une fonction de rappel (<i>callback</i>), soit comme un objet qui implémente {{domxref("EventListener")}} dont la méthode {{domxref("EventListener.handleEvent", "handleEvent()")}} sert de fonction de rappel.</p>
 
-<p>La fonction de rappel a elle-même les mêmes paramètres et la même valeur de retour que la méthode <code>handleEvent()</code> ; c'est-à-dire que le rappel accepte un seul paramètre : un objet basé sur {{domxref("Event")}} décrivant l'événement qui s'est produit, et il ne retourne rien.</p>
+<p>La fonction de rappel reçoit les mêmes paramètres et fournit la même valeur de retour que la méthode <code>handleEvent()</code> ; c'est-à-dire que le rappel accepte un seul paramètre : un objet basé sur {{domxref("Event")}} décrivant l'évènement qui s'est produit, et il ne retourne rien.</p>
 
-<p>Par exemple, un rappel de gestionnaire d'événements pouvant être utilisé pour gérer à la fois {{domxref("Element/fullscreenchange_event", "fullscreenchange")}} et {{domxref("Element/fullscreenerror_event", "fullscreenerror")}} peut ressembler à ceci :</p>
+<p>Par exemple, un rappel de gestionnaire d'évènements pouvant être utilisé pour gérer à la fois {{domxref("Element/fullscreenchange_event", "fullscreenchange")}} et {{domxref("Element/fullscreenerror_event", "fullscreenerror")}} peut ressembler à ceci :</p>
 
 <pre class="brush: js">
 function eventHandler(event) {
@@ -92,11 +103,11 @@ function eventHandler(event) {
 }
 </pre>
 
-<h3 id="Safely_detecting_option_support">Détection sûre du support des options</h3>
+<h3 id="Safely_detecting_option_support">Détection la prise en charge d'<code>options</code></h3>
 
-<p>Dans les anciennes versions de la spécification DOM, le troisième paramètre de <code>addEventListener()</code> était une valeur booléenne indiquant s'il fallait ou non utiliser la capture. Au fil du temps, il est devenu clair que davantage d'options étaient nécessaires. Plutôt que d'ajouter davantage de paramètres à la fonction (ce qui complique énormément les choses lors du traitement des valeurs optionnelles), le troisième paramètre a été changé en un objet pouvant contenir diverses propriétés définissant les valeurs des options pour configurer le processus de suppression de l'écouteur d'événement.</p>
+<p>Dans les anciennes versions de la spécification DOM, le troisième paramètre de <code>addEventListener()</code> était une valeur booléenne indiquant s'il fallait ou non utiliser la capture. Au fil du temps, il est devenu clair que davantage d'options étaient nécessaires. Plutôt que d'ajouter davantage de paramètres à la fonction (ce qui complique énormément les choses lors du traitement des valeurs optionnelles), le troisième paramètre a été changé en un objet pouvant contenir diverses propriétés définissant les valeurs des options pour configurer le processus de suppression de l'écouteur d'évènement.</p>
 
-<p>Du fait que les navigateurs anciens (ainsi que certains navigateurs "pas si vieux") supposent toujours que le troisième paramètre est un Boolean, vous devez construire votre code de façon à gérer ce scénario intelligemment. Vous pouvez le faire en utilisant la détection de fonctionnalité pour chacune des options qui vous intéresse.</p>
+<p>Du fait que les navigateurs anciens supposent toujours que le troisième paramètre est un booléen, vous devez construire votre code de façon à gérer ce scénario intelligemment. Vous pouvez le faire en utilisant la détection de fonctionnalité pour chacune des options qui vous intéresse.</p>
 
 <p>Par exemple, si vous voulez vérifier l'option <code>passive</code> :</p>
 
@@ -117,11 +128,11 @@ try {
 }
 </pre>
 
-<p>Cela crée un objet <em><code>options</code></em> avec une fonction accesseur pour la propriété <code>passive</code> ; l'accesseur initialise un indicateur, <em><code>passiveSupported</code></em>, à <code>true</code> si elle est appelée. Cela signifie que si le navigateur vérifie la valeur de la propriété <code>passive</code> dans l'objet <em><code>options</code></em>, <em><code>passiveSupported</code></em> sera initialisé à <code>true</code> ; sinon, il restera <code>false</code>. Nous appelons alors <code>addEventListener()</code> pour installer un faux gestionnaire d'événements, en spécifiant ces options, se sorte qu'elles soient vérifiées si le navigateur reconnaît un objet comme troisième paramètre. Ensuite, nous appelons <code>removeEventListener()</code> pour faire le ménage après notre passage. (Notez que <code>handleEvent()</code> est ignoré dans les écouteurs d'événements qui ne sont pas appelés).</p>
+<p>Cela crée un objet <code>options</code> avec une fonction accesseur pour la propriété <code>passive</code> ; l'accesseur initialise un indicateur, <code>passiveSupported</code>, à <code>true</code> si elle est appelée. Cela signifie que si le navigateur vérifie la valeur de la propriété <code>passive</code> dans l'objet <code>options</code>, <code>passiveSupported</code> sera initialisé à <code>true</code> ; sinon, il restera <code>false</code>. Nous appelons alors <code>addEventListener()</code> pour installer un faux gestionnaire d'évènements, en spécifiant ces options, se sorte qu'elles soient vérifiées si le navigateur reconnaît un objet comme troisième paramètre. Ensuite, nous appelons <code>removeEventListener()</code> pour faire le ménage après notre passage. (Notez que <code>handleEvent()</code> est ignoré dans les écouteurs d'évènements qui ne sont pas appelés).</p>
 
 <p>Vous pouvez vérifier de cette façon si une option quelconque est supportée. Ajoutez simplement un accesseur pour cette option en utilisant un code similaire à celui montré ci-dessus.</p>
 
-<p>Ensuite, lorsque vous voulez créer un écouteur d'événements réel qui utilise les options en question, vous pouvez faire quelque chose comme ce qui suit :</p>
+<p>Ensuite, lorsque vous voulez créer un écouteur d'évènements réel qui utilise les options en question, vous pouvez faire quelque chose comme ce qui suit :</p>
 
 <pre class="brush: js">
 someElement.addEventListener(
@@ -131,9 +142,9 @@ someElement.addEventListener(
 );
 </pre>
 
-<p>Ici, nous ajoutons un écouteur pour l'événement {{domxref("Element/mouseup_event", "mouseup")}} dans l'élément <em><code>someElement</code></em>. Pour le troisième paramètre, si <em><code>passiveSupported</code></em> est <code>true</code>, nous spécifions un objet <em><code>options</code></em> avec <code>passive</code> initialisée à <code>true</code> ; sinon, nous savons que nous devons passer un Boolean, et nous passons <code>false</code> comme valeur du paramètre <em><code>useCapture</code></em>.</p>
+<p>Ici, nous ajoutons un écouteur pour l'évènement {{domxref("Element/mouseup_event", "mouseup")}} dans l'élément <code>someElement</code>. Pour le troisième paramètre, si <code>passiveSupported</code> est <code>true</code>, nous spécifions un objet <code>options</code> avec <code>passive</code> initialisée à <code>true</code> ; sinon, nous savons que nous devons passer un Boolean, et nous passons <code>false</code> comme valeur du paramètre <code>useCapture</code>.</p>
 
-<p>Si vous préférez, vous pouvez utiliser une bibliothèque tierce comme <a href="https://modernizr.com/docs">Modernizr</a> ou <a href="https://github.com/rafrex/detect-it">Detect It</a> pour faire ce test pour vous.</p>
+<p>Si vous préférez, vous pouvez utiliser une bibliothèque tierce comme <a href="https://github.com/modernizr/modernizr">Modernizr</a> ou <a href="https://github.com/rafrex/detect-it">Detect It</a> pour faire ce test pour vous.</p>
 
 <p>Vous pouvez en apprendre davantage dans l'article à propos des <code><a href="https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md#feature-detection">EventListenerOptions</a></code> du <a href="https://wicg.github.io/admin/charter.html">Groupe Web Incubator Community</a>.</p>
 
@@ -178,7 +189,7 @@ el.addEventListener("click", modifyText, false);
 
 <h3 id="Event_listener_with_anonymous_function">Écouteur d'évènement avec une fonction anonyme</h3>
 
-<p>Ici, nous allons voir comment utiliser une fonction anonyme pour passer des paramètres à l'écouteur d'événements.</p>
+<p>Ici, nous allons voir comment utiliser une fonction anonyme pour passer des paramètres à l'écouteur d'évènements.</p>
 
 <h4 id="HTML_2">HTML</h4>
 
@@ -203,7 +214,7 @@ const el = document.querySelector("#outside");
 el.addEventListener("click", function(){modifyText("quatre")}, false);
 </pre>
 
-<p>Notez que l'écouteur est une fonction anonyme encapsulant le code qui peut à son tour envoyer des paramètres à la fonction <code>modifyText()</code>, qui est responsable de la réponse effective à l'événement.</p>
+<p>Notez que l'écouteur est une fonction anonyme encapsulant le code qui peut à son tour envoyer des paramètres à la fonction <code>modifyText()</code>, qui est responsable de la réponse effective à l'évènement.</p>
 
 <h4 id="Result_2">Résultat</h4>
 
@@ -211,7 +222,7 @@ el.addEventListener("click", function(){modifyText("quatre")}, false);
 
 <h3 id="Event_listener_with_an_arrow_function">Écouteur d'évènement avec une fonction fléchée</h3>
 
-<p>Cet exemple montre un écouteur d'événement simple implémenté en utilisant la notation de fonction fléchée.</p>
+<p>Cet exemple montre un écouteur d'évènement simple implémenté en utilisant la notation de fonction fléchée.</p>
 
 <h4 id="HTML_3">HTML</h4>
 
@@ -241,7 +252,7 @@ el.addEventListener("click", () =&gt; {
 
 <p>{{EmbedLiveSample('Event_listener_with_an_arrow_function')}}</p>
 
-<p>Notez que si les fonctions anonymes et fléchées sont similaires, elles ont des liaisons <code>this</code> différentes. Alors que les fonctions anonymes (et toutes les fonctions JavaScript traditionnelles) créent leurs propres liaisons <code>this</code>, les fonctions fléchées héritent la liaison <code>this</code> de la fonction contenante.</p>
+<p>Notez que si les fonctions anonymes et fléchées sont similaires, elles ont des liaisons <code>this</code> différentes. Alors que les fonctions anonymes (et toutes les fonctions JavaScript traditionnelles) créent leurs propres liaisons <code>this</code>, les fonctions fléchées héritent la liaison <code>this</code> de la fonction contenante. <a href="fr/docs/Web/JavaScript/Reference/Operators/this#avec_les_fonctions_fléchées">Voir la page sur l'opérateur <code>this</code> pour plus d'informations.</a></p>
 
 <p>Cela signifie que les variables et constantes disponibles pour la fonction contenante sont aussi disponibles pour le gestionnaire d'évènements lors de l'utilisation d'une fonction fléchée.</p>
 
@@ -329,33 +340,33 @@ inner1.addEventListener('click', passiveHandler, passive);
 inner2.addEventListener('click', nonePassiveHandler, nonePassive);
 
 function onceHandler(event) {
-  alert('extérieur, once');
+  console.log('extérieur, once');
 }
 function noneOnceHandler(event) {
-  alert('extérieur, none-once, default');
+  console.log('extérieur, none-once, default');
 }
 function captureHandler(event) {
   // event.stopImmediatePropagation();
-  alert('milieur, capture');
+  console.log('milieur, capture');
 }
 function noneCaptureHandler(event) {
-  alert('milieur, none-capture, default');
+  console.log('milieur, none-capture, default');
 }
 function passiveHandler(event) {
   // Impossible d'utiliser preventDefault à l'intérieur de l'invocation d'un écouteur d'évènements passif.
   event.preventDefault();
-  alert('intérieur1, passive, nouvelle page ouverte');
+  console.log('intérieur1, passive, nouvelle page ouverte');
 }
 function nonePassiveHandler(event) {
   event.preventDefault();
   // event.stopPropagation();
-  alert('intérieur2, none-passive, default, nouvelle page non ouverte');
+  console.log('intérieur2, none-passive, default, nouvelle page non ouverte');
 }
 </pre>
 
 <h4 id="Result_4">Résultat</h4>
 
-<p>Cliquer les conteneurs extérieur, milieu, intérieurs respectivement pour voir comment les options fonctionnent.</p>
+<p>Cliquez les conteneurs <var>extérieur</var>, <var>milieu</var>, <var>intérieurs</var> respectivement pour voir comment les options fonctionnent. Vous pouvez ouvrir la console pour observer les différents messages émis.</p>
 
 <p>{{EmbedLiveSample('Example_of_options_usage', '', '320')}}</p>
 
@@ -377,7 +388,7 @@ function nonePassiveHandler(event) {
 <h4 id="JavaScript_5">JavaScript</h4>
 
 <pre class="brush: js">
-// Ajout d'un écouteur d'événement annulable à la table
+// Ajout d'un écouteur d'évènement annulable à la table
 const controller = new AbortController();
 const el = document.querySelector("#outside");
 el.addEventListener("click", modifyText, { signal: controller.signal });
@@ -394,7 +405,7 @@ function modifyText() {
 }
 </pre>
 
-<p>Dans l'exemple ci-dessus, nous modifions le code de l'exemple {{anch('Add_a_simple_listener', 'Ajouter un écouteur simple')}} de telle sorte qu'après que le contenu de la deuxième ligne soit devenu « trois », nous appelons <code>abort()</code> à partir du {{domxref("AbortController")}} que nous avons passé à l'appel <code>addEventListener()</code>. Cela a pour résultat que la valeur reste à "trois" pour toujours, parce que nous n'avons plus de code écoutant un événement de clic.</p>
+<p>Dans l'exemple ci-dessus, nous modifions le code de l'exemple {{anch('Add_a_simple_listener', 'Ajouter un écouteur simple')}} de telle sorte qu'après que le contenu de la deuxième ligne soit devenu « trois », nous appelons <code>abort()</code> à partir du {{domxref("AbortController")}} que nous avons passé à l'appel <code>addEventListener()</code>. Cela a pour résultat que la valeur reste à "trois" pour toujours, parce que nous n'avons plus de code écoutant un évènement de clic.</p>
 
 <h4 id="Result_5">Résultat</h4>
 
@@ -439,7 +450,7 @@ my_element.addEventListener('click', function(e) {
 })
 </pre>
 
-<p>Pour mémoire, les <a href="/fr/docs/Web/JavaScript/Reference/Functions/Arrow_functions#no_separate_this">fonctions fléchées n'ont pas leur propre contexte <code>this</code></a>.</p>
+<p>Pour mémoire, les <a href="/fr/docs/Web/JavaScript/Reference/Functions/Arrow_functions#pas_de_this_lié_à_la_fonction">fonctions fléchées n'ont pas de <code>this</code> lié</a>.</p>
 
 <pre class="brush: js">
 my_element.addEventListener('click', (e) =&gt; {
@@ -448,21 +459,23 @@ my_element.addEventListener('click', (e) =&gt; {
 })
 </pre>
 
-<p>Si un gestionnaire d'événements (par exemple, {{domxref("GlobalEventHandlers.onclick", "onclick")}}) est spécifié sur un élément dans la source HTML, le code JavaScript dans la valeur de l'attribut est effectivement encapsulé dans une fonction du gestionnaire qui lie la valeur de <code>this</code> d'une manière cohérente avec le <code>addEventListener()</code> ; une occurrence de <code>this</code> dans le code représente une référence à l'élément.</p>
+<p>Si un gestionnaire d'évènements (par exemple, {{domxref("GlobalEventHandlers.onclick", "onclick")}}) est spécifié sur un élément dans la source HTML, le code JavaScript dans la valeur de l'attribut est effectivement encapsulé dans une fonction du gestionnaire qui lie la valeur de <code>this</code> d'une manière cohérente avec le <code>addEventListener()</code> ; une occurrence de <code>this</code> dans le code représente une référence à l'élément.</p>
 
 <pre class="brush: html">
-&lt;table id="my_table" onclick="console.log(this.id);"&gt;&lt;!-- `this` fait référence à la table ; journalise 'my_table' --&gt;
+&lt;table id="my_table" onclick="console.log(this.id);"&gt;
+&lt;!-- `this` fait référence à la table ; journalise 'my_table' --&gt;
   ...
 &lt;/table&gt;
 </pre>
 
-<p>Notez que la valeur de <code>this</code> à l'intérieur d'une fonction, <em>appelée</em> par le code dans la valeur de l'attribut, se comporte selon les <a href="/fr/docs/Web/JavaScript/Reference/Operators/this">règles standard</a>. Ceci est illustré dans l'exemple suivant :</p>
+<p>Notez que la valeur de <code>this</code> à l'intérieur d'une fonction, appelée par le code dans la valeur de l'attribut, se comporte selon les <a href="/fr/docs/Web/JavaScript/Reference/Operators/this">règles standard</a>. Ceci est illustré dans l'exemple suivant :</p>
 
 <pre class="brush: html">
 &lt;script&gt;
   function logID() { console.log(this.id); }
 &lt;/script&gt;
-&lt;table id="my_table" onclick="logID();"&gt;&lt;!-- lorsqu'appelée, `this` fera référence à l'objet global --&gt;
+&lt;table id="my_table" onclick="logID();"&gt;
+&lt;!-- lorsqu'appelée, `this` fera référence à l'objet global --&gt;
   ...
 &lt;/table&gt;
 </pre>
@@ -520,7 +533,7 @@ const Something = function(element) {
 const s = new Something(document.body);
 </pre>
 
-<p>Une autre manière de gérer la référence à <em>this</em> est de passer à l'<code>EventListener</code> une fonction qui appelle la méthode de l'objet qui contient les champs auxquels on a besoin d'accéder :</p>
+<p>Une autre manière de gérer la référence à this est de passer à l'<code>EventListener</code> une fonction qui appelle la méthode de l'objet qui contient les champs auxquels on a besoin d'accéder :</p>
 
 <pre class="brush: js">
 class SomeClass {
@@ -554,7 +567,7 @@ myObject.register();
 
 <h3 id="Getting_data_into_and_out_of_an_event_listener">Passer des données à et depuis un écouteur d'évènements</h3>
 
-<p>On peut avoir l'impression que les écouteurs d'évènements sont comme des îles et qu'il est extrêmement difficile de leur passer des données quelconques, encore moins d'en récupérer après qu'ils ont été exécutés. Les écouteurs d'évènements ne prennent qu'un seul argument, l'<a href="/fr/docs/Learn/JavaScript/Building_blocks/Events#event_objects">Event Object</a>, qui est passé automatiquement à l'écouteur, et la valeur retournée est ignorée. Donc à nouveau, comment pouvons-nous leur passer des données et en récupérer ? Il y a certain nombre de bonnes méthodes pour ce faire.</p>
+<p>On peut avoir l'impression que les écouteurs d'évènements sont comme des îles et qu'il est extrêmement difficile de leur passer des données quelconques, encore moins d'en récupérer après qu'ils ont été exécutés. Les écouteurs d'évènements ne prennent qu'un seul argument, l'objet <a href="/fr/docs/Learn/JavaScript/Building_blocks/Events#event_objects"><code>event</code></a>, qui est passé automatiquement à l'écouteur, et la valeur retournée est ignorée. Aussi, comment pouvons-nous leur passer des données et en récupérer ? Il y a certain nombre de bonnes méthodes pour ce faire.</p>
 
 <h4 id="Getting_data_into_an_event_listener_using_this">Passer des données à un écouteur d'évènement en utilisant "this"</h4>
 
@@ -594,10 +607,10 @@ console.log(someString);  // Valeur attendue : 'Donnée' (ne donnera jamais 'Enc
 
 <h4 id="Getting_data_into_and_out_of_an_event_listener_using_objects">Passer des données à et depuis un écouteur d'évènements en utilisant des objets</h4>
 
-<p>A l'inverse de la plupart des fonctions en JavaScript, les objets sont conservés en mémoire aussi longtemps qu'une variable les référençant existe en mémoire. Ceci, et le fait que les objets peuvent avoir des propriétés, et qu'ils peuvent être passés alentour par référence, en fait des candidats plausibles pour partager des données entre les portées. Explorons cela.</p>
+<p>A l'inverse de la plupart des fonctions en JavaScript, les objets sont conservés en mémoire aussi longtemps qu'une variable les référençant existe en mémoire. Ceci, et le fait que les objets peuvent avoir des propriétés, et qu'ils peuvent être passés alentour par référence, en font des candidats plausibles pour partager des données entre les portées. Explorons cela.</p>
 
 <div class="notecard note">
-<p><strong>Note :</strong> les fonctions en JavaScript sont en fait des objets. (Par conséquent, elles aussi peuvent avoir des propriétés, et seront conservées en mémoire même après qu'elles ont fini de s'exécuter, si elles ont été affectées à une variable qui persiste en mémoire.)</p>
+<p><strong>Note :</strong> Les fonctions en JavaScript sont en fait des objets. (Par conséquent, elles aussi peuvent avoir des propriétés, et seront conservées en mémoire même après qu'elles ont fini de s'exécuter, si elles ont été affectées à une variable qui persiste en mémoire.)</p>
 </div>
 
 <p>Du fait que les propriétés d'un objet peuvent être utilisées pour stocker des données en mémoire aussi longtemps qu'une variable référençant l'objet existe en mémoire, vous pouvez en fait les utiliser pour passer des données dans un écouteur d'évènements, et retourner tous les changements aux données après que l'écouteur d'évènements s'est exécuté. Considérez cet exemple :</p>
@@ -615,24 +628,24 @@ myButton.addEventListener('click', function() {
 window.setInterval(function() {
   if (someObject.aProperty === 'Encore des données') {
     console.log('Encore des données : Vrai');
-    someObject.aProperty = 'Donnée';  // Rétablit la valeur pour attendre l'exécution du prochain événement
+    someObject.aProperty = 'Donnée';  // Rétablit la valeur pour attendre l'exécution du prochain évènement
   }
 }, 5000);
 </pre>
 
-<p>Dans cet exemple, même si la portée dans laquelle à la fois l'écouteur d'évènements et la fonction d'intervalle ont été définis a fini de s'exécuter avant que la valeur originale de <code>unObjet.unePropriete</code> ait changé, du fait que <code>someObject</code> persiste en mémoire (par <em>référence</em>) à la fois dans l'écouteur d'évènements et dans la fonction d'intervalle, tous deux ont accès aux mêmes données (i.e. quand l'un change les données, l'autre peut répondre aux changements).</p>
+<p>Dans cet exemple, même si la portée dans laquelle à la fois l'écouteur d'évènements et la fonction d'intervalle ont été définis a fini de s'exécuter avant que la valeur originale de <code>unObjet.unePropriete</code> ait changé, du fait que <code>someObject</code> persiste en mémoire (par référence) à la fois dans l'écouteur d'évènements et dans la fonction d'intervalle, tous deux ont accès aux mêmes données (i.e. quand l'un change les données, l'autre peut répondre aux changements).</p>
 
 <div class="notecard note">
-  <p><strong>Note :</strong> les objets sont stockés dans les variables par référence, ce qui signifie que seul l'emplacement en mémoire des données elles-mêmes est stocké dans la variable. Entre autres choses, cela signifie que les variables qui "stockent" des objets peuvent en fait affecter d'autres variables qui se voient affecter ("stocker") la même référence d'objet. Quand deux variables référencent le même objet (par ex., <code>let a = b = {aProperty: 'Ouai'};</code>), le fait de changer les données dans l'une ou l'autre des variables affectera l'autre.</p>
+  <p><strong>Note :</strong> Les objets sont stockés dans les variables par référence, ce qui signifie que seul l'emplacement en mémoire des données elles-mêmes est stocké dans la variable. Entre autres choses, cela signifie que les variables qui "stockent" des objets peuvent en fait affecter d'autres variables qui se voient affecter ("stocker") la même référence d'objet. Quand deux variables référencent le même objet (par ex., <code>let a = b = {aProperty: 'Ouai'};</code>), le fait de changer les données dans l'une ou l'autre des variables affectera l'autre.</p>
 </div>
 
 <div class="notecard note">
-  <p><strong>Note :</strong> du fait que les objets sont stockés dans les variables par référence, vous pouvez retourner un objet depuis une fonction pour le maintenir en vie (le conserver en mémoire, de sorte que vous n'en perdiez pas les données) après que cette fonction a fini de s'exécuter.</p>
+  <p><strong>Note :</strong> Du fait que les objets sont stockés dans les variables par référence, vous pouvez retourner un objet depuis une fonction pour le maintenir en vie (le conserver en mémoire, de sorte que vous n'en perdiez pas les données) après que cette fonction a fini de s'exécuter.</p>
 </div>
 
-<h3 id="Legacy_Internet_Explorer_and_attachEvent">Héritage Internet Explorer et attachEvent</h3>
+<h3 id="Legacy_Internet_Explorer_and_attachEvent">Prise en charge d'Internet Explorer et attachEvent</h3>
 
-<p>Dans les versions Internet Explorer versions avant IE 9, vous deviez utiliser {{domxref("EventTarget.attachEvent", "attachEvent()")}}, plutôt que la méthode standard <code>addEventListener</code>. Pour IE, nous modifions l'exemple précédent en :</p>
+<p>Dans les versions Internet Explorer versions avant IE 9, vous deviez utiliser <code>attachEvent()</code> plutôt que la méthode standard <code>addEventListener</code>. Pour IE, nous modifions l'exemple précédent en :</p>
 
 <pre class="brush: js">
 if (el.addEventListener) {
@@ -646,7 +659,7 @@ if (el.addEventListener) {
 
 <p>La méthode <code>attachEvent()</code> peut être couplée avec l'évènement <code>onresize</code> pour détecter que certains éléments dans une page web ont été redimensionnés. L'évènement propriétaire <code>mselementresize</code>, lorsqu'il est couplé avec la méthode <code>addEventListener</code> d'enregistrement des gestionnaires d'évènements, fournit une fonctionnalité similaire à celle de <code>onresize</code>, se déclenchant quand certains éléments HTML sont redimensionnés.</p>
 
-<h3 id="Polyfill">Prothèse d'émulation</h3>
+<h3 id="Polyfill">Prothèse d'émulation (<i>polyfill</i>)</h3>
 
 <p>Vous pouvez contourner le fait que <code>addEventListener()</code>, <code>removeEventListener()</code>, {{domxref("Event.preventDefault()")}} et {{domxref("Event.stopPropagation()")}} ne sont pas pris en charge par IE 8 en utilisant le code suivant au début de votre script. Le code prend en charge l'utilisation de <code>handleEvent()</code>, et aussi l'évènement {{event("DOMContentLoaded")}}.</p>
 
@@ -734,7 +747,8 @@ if (el.addEventListener) {
 <p>La méthode <code>addEventListener()</code> a été ajoutée dans la spécification DOM 2 <a class="external" href="http://www.w3.org/TR/DOM-Level-2-Events">Events</a>. Avant cela, les écouteurs d'évènements étaient enregistrés de la manière suivante :</p>
 
 <pre class="brush: js">
-// Passage d'une référence à une fonction — ne pas ajouter de '()' après, cela appelerait la fonction !
+// Passage d'une référence à une fonction
+// Ne pas ajouter de '()' après, cela appelerait la fonction !
 el.onclick = modifyText;
 
 // Utilisation d'une fonction directe
@@ -745,7 +759,7 @@ element.onclick = function() {
 
 <p>Cette méthode remplace l'(les) écouteur(s) d'évènements <code>click</code> existant(s) de l'élément s'il y en a. D'autres évènements et leurs gestionnaires d'évènements associés comme <code>blur</code> (<code>onblur</code>), et  <code>keypress</code> ( <code>onkeypress</code>) se comportent de façon similaire.</p>
 
-<p>Comme elle faisait partie de façon fondamentale du DOM 0, cette méthode est très largement prise en charge et ne nécessite aucun code multi-navigateur. C'est pourquoi elle est souvent utilisée pour enregistrer des évènements dynamiquement quand de très anciens navigateurs (comme IE &lt;=8) doivent être pris en charge ; voir la table plus bas pour les détails de la prise en charge par les navigateurs pour <code>addEventListener</code>.</p>
+<p>Comme elle faisait partie de façon fondamentale du DOM 0, cette méthode est très largement prise en charge et ne nécessite aucun code multi-navigateur. C'est pourquoi elle est souvent utilisée pour enregistrer des évènements dynamiquement quand de très anciens navigateurs (comme IE dans les versions antérieures à IE8) doivent être pris en charge ; voir la table plus bas pour les détails de la prise en charge par les navigateurs pour <code>addEventListener</code>.</p>
 
 <h3 id="Memory_issues">Problèmes de mémoire</h3>
 
@@ -792,12 +806,12 @@ for (let i=0, j=0 ; i&lt;els.length ; i++) {
 
 <h3 id="Improving_scrolling_performance_with_passive_listeners">Amélioration des performances de défilement avec les écouteurs passifs</h3>
 
-<p>D'après la spécification, la valeur par défaut pour l'option <code>passive</code> est toujours <code>false</code> (<em>faux</em>). Toutefois, cela introduit la possibilité que des écouteurs d'évènements gérant certains évènements tactiles (parmi d'autres) bloquent le fil d'exécution principal du navigateur pendant qu'il essaye de gérer le défilement, avec pour résultat une possiblement énorme réduction de performance pendant la gestion du défilement.</p>
+<p>D'après la spécification, la valeur par défaut pour l'option <code>passive</code> est toujours <code>false</code>. Toutefois, cela introduit la possibilité que des écouteurs d'évènements gérant certains évènements tactiles (parmi d'autres) bloquent le fil d'exécution principal du navigateur pendant qu'il essaye de gérer le défilement, avec pour résultat une possiblement énorme réduction de performance pendant la gestion du défilement.</p>
 
 <p>Pour prévenir ce problème, certains navigateurs (spécifiquement, Chrome et Firefox) ont changé la valeur par défault de l'option <code>passive</code> à <code>true</code> pour les évènements {{event("touchstart")}} et {{event("touchmove")}} dans les nœuds de niveau document {{domxref("Window")}}, {{domxref("Document")}}, et {{domxref("Document.body")}}. Cela empêche que l'écouteur d'évènement ne soit appelé, de sorte qu'il ne peut pas bloquer le rendu de la page pendant que l'utilisateur fait un défilement.</p>
 
 <div class="notecard note">
-  <p><strong>Note :</strong> voir la table de compatibilité ci-dessous si vous avez besoin de savoir quels navigateurs (et/ou quelles versions de ces navigateurs) implémentent ce comportement modifié.</p>
+  <p><strong>Note :</strong> Voir la table de compatibilité ci-dessous si vous avez besoin de savoir quels navigateurs (et/ou quelles versions de ces navigateurs) implémentent ce comportement modifié.</p>
 </div>
 
 <p>Vous pouvez passer outre ce comportement en initialisant explicitement la valeur de <code>passive</code> à <code>false</code>, comme montré ci-dessous :</p>
@@ -865,6 +879,6 @@ window.addEventListener('scroll', function(event) {
 
 <ul>
   <li>{{domxref("EventTarget.removeEventListener()")}}</li>
-  <li><a href="/fr/docs/Web/Guide/Events/Creating_and_triggering_events">Création et déclenchement d'événements</a></li>
+  <li><a href="/fr/docs/Web/Guide/Events/Creating_and_triggering_events">Création et déclenchement d'évènements</a></li>
   <li><a href="http://www.quirksmode.org/js/this.html">Plus de détails sur l'utilisation de <code>this</code> dans les gestionnaires d'évènements</a></li>
 </ul>

--- a/files/fr/web/api/eventtarget/addeventlistener/index.html
+++ b/files/fr/web/api/eventtarget/addeventlistener/index.html
@@ -101,10 +101,10 @@ function eventHandler(event) {
 <p>Par exemple, si vous voulez vérifier l'option <code>passive</code> :</p>
 
 <pre class="brush: js">
-var passiveSupported = false;
+let passiveSupported = false;
 
 try {
-  var options = Object.defineProperty({}, "passive", {
+  let options = Object.defineProperty({}, "passive", {
     get: function() {
       passiveSupported = true;
     }
@@ -124,15 +124,18 @@ try {
 <p>Ensuite, lorsque vous voulez créer un écouteur d'événements réel qui utilise les options en question, vous pouvez faire quelque chose comme ce qui suit :</p>
 
 <pre class="brush: js">
-someElement.addEventListener("mouseup", handleMouseUp, passiveSupported
-                              ? { passive: true } : false);
+someElement.addEventListener(
+  "mouseup",
+  handleMouseUp,
+  passiveSupported ? { passive: true } : false
+);
 </pre>
 
 <p>Ici, nous ajoutons un écouteur pour l'événement {{domxref("Element/mouseup_event", "mouseup")}} dans l'élément <em><code>someElement</code></em>. Pour le troisième paramètre, si <em><code>passiveSupported</code></em> est <code>true</code>, nous spécifions un objet <em><code>options</code></em> avec <code>passive</code> initialisée à <code>true</code> ; sinon, nous savons que nous devons passer un Boolean, et nous passons <code>false</code> comme valeur du paramètre <em><code>useCapture</code></em>.</p>
 
 <p>Si vous préférez, vous pouvez utiliser une bibliothèque tierce comme <a href="https://modernizr.com/docs">Modernizr</a> ou <a href="https://github.com/rafrex/detect-it">Detect It</a> pour faire ce test pour vous.</p>
 
-<p>Vous pouvez en apprendre davantage dans l'article à propos des <code><a href="https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md#feature-detection">EventListenerOptions</a></code>  du <a href="https://wicg.github.io/admin/charter.html">Groupe Web Incubator Community</a>.</p>
+<p>Vous pouvez en apprendre davantage dans l'article à propos des <code><a href="https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md#feature-detection">EventListenerOptions</a></code> du <a href="https://wicg.github.io/admin/charter.html">Groupe Web Incubator Community</a>.</p>
 
 <h2 id="Examples">Exemples</h2>
 
@@ -154,7 +157,7 @@ someElement.addEventListener("mouseup", handleMouseUp, passiveSupported
 <pre class="brush: js">
 // Fonction pour changer le contenu de t2
 function modifyText() {
-  var t2 = document.querySelector("#t2");
+  const t2 = document.querySelector("#t2");
   if (t2.firstChild.nodeValue == "trois") {
     t2.firstChild.nodeValue = "deux";
   } else {
@@ -163,7 +166,7 @@ function modifyText() {
 }
 
 // Ajouter un écouteur d'évènements à la table
-var el = document.querySelector("#outside");
+const el = document.querySelector("#outside");
 el.addEventListener("click", modifyText, false);
 </pre>
 
@@ -191,12 +194,12 @@ el.addEventListener("click", modifyText, false);
 <pre class="brush: js">
 // Fonction pour changer le contenu de t2
 function modifyText(newText) {
-  var t2 = document.querySelector("#t2");
+  const t2 = document.querySelector("#t2");
   t2.firstChild.nodeValue = newText;
 }
 
 // Fonction pour ajouter un écouteur d'évènement à la table
-var el = document.querySelector("#outside");
+const el = document.querySelector("#outside");
 el.addEventListener("click", function(){modifyText("quatre")}, false);
 </pre>
 
@@ -224,13 +227,15 @@ el.addEventListener("click", function(){modifyText("quatre")}, false);
 <pre class="brush: js">
 // Fonction pour changer le contenu de t2
 function modifyText(newText) {
-  var t2 = document.querySelector("#t2");
+  const t2 = document.querySelector("#t2");
   t2.firstChild.nodeValue = newText;
 }
 
 // Ajouter un écouteur d'évènements à la table avec une fonction fléchée
-var el = document.querySelector("#outside");
-el.addEventListener("click", () =&gt; { modifyText("quatre"); }, false);</pre>
+const el = document.querySelector("#outside");
+el.addEventListener("click", () =&gt; {
+  modifyText("quatre");
+}, false);</pre>
 
 <h4 id="Result_3">Résultat</h4>
 
@@ -262,33 +267,37 @@ el.addEventListener("click", () =&gt; { modifyText("quatre"); }, false);</pre>
 <h4 id="CSS">CSS</h4>
 
 <pre class="brush: css">
-.outer, .middle, .inner1, .inner2 {
+.outer,
+.middle,
+.inner1,
+.inner2 {
   display: block;
-  width:   520px;
+  width: 520px;
   padding: 15px;
-  margin:  15px;
+  margin: 15px;
   text-decoration: none;
 }
 .outer {
   border: 1px solid red;
-  color:  red;
+  color: red;
 }
 .middle {
   border: 1px solid green;
-  color:  green;
-  width:  460px;
+  color: green;
+  width: 460px;
 }
-.inner1, .inner2 {
+.inner1,
+.inner2 {
   border: 1px solid purple;
-  color:  purple;
-  width:  400px;
+  color: purple;
+  width: 400px;
 }
 </pre>
 
 <h4 id="JavaScript_4">JavaScript</h4>
 
 <pre class="brush: js">
-const outer  = document.querySelector('.outer');
+const outer = document.querySelector('.outer');
 const middle = document.querySelector('.middle');
 const inner1 = document.querySelector('.inner1');
 const inner2 = document.querySelector('.inner2');
@@ -467,7 +476,7 @@ my_element.addEventListener('click', (e) =&gt; {
 <p>Ceci est un exemple avec et sans <code>bind()</code> :</p>
 
 <pre class="brush: js">
-var Something = function(element) {
+const Something = function(element) {
   // |this| est un objet nouvellement créé
   this.name = 'Quelque chose de bon';
   this.onclick1 = function(event) {
@@ -741,8 +750,8 @@ element.onclick = function() {
 <h3 id="Memory_issues">Problèmes de mémoire</h3>
 
 <pre class="brush: js">
-var i;
-var els = document.getElementsByTagName('*');
+let i;
+const els = document.getElementsByTagName('*');
 
 // Cas 1
 for (i=0 ; i&lt;els.length ; i++) {

--- a/files/fr/web/api/eventtarget/addeventlistener/index.html
+++ b/files/fr/web/api/eventtarget/addeventlistener/index.html
@@ -19,76 +19,80 @@ translation_of: Web/API/EventTarget/addEventListener
 ---
 <p>{{APIRef("DOM Events")}}</p>
 
-<p>La méthode <code><strong>addEventListener()</strong></code> d'{{domxref("EventTarget")}} installe une fonction à appeler chaque fois que l'événement spécifié est envoyé à la cible. Les cibles courantes sont un {{domxref("Element")}}, le {{domxref("Document")}} lui-même et une {{domxref("Window")}}, mais elle peut être tout objet prenant en charge les évènements (comme <code><a href="https://developer.mozilla.org/fr/docs/Web/API/XMLHttpRequest">XMLHttpRequest</a></code>).</p>
+<p class="seoSummary">La méthode <code><strong>addEventListener()</strong></code> de {{domxref("EventTarget")}} installe une fonction à appeler chaque fois que l'événement spécifié est envoyé à la cible. Les cibles courantes sont un {{domxref("Element")}}, le {{domxref("Document")}} lui-même et une {{domxref("Window")}}, mais elle peut être tout objet prenant en charge les évènements (comme {{domxref("XMLHttpRequest")}}).</p>
 
-<p><code>addEventListener()</code> fonctionne en ajoutant une fonction, ou un objet implémentant {{domxref("EventListener")}}, à la liste des écouteurs d'évènements du type d'évènement spécifié dans la {{domxref("EventTarget")}} dans laquelle il est appelé.</p>
+<p><code>addEventListener()</code> agit en ajoutant une fonction ou un objet qui implémente {{domxref("EventListener")}} à la liste des écouteurs d'événements pour le type d'événement spécifié sur le {{domxref("EventTarget")}} dans lequel il est appelé.</p>
 
-<h2 id="Syntaxe">Syntaxe</h2>
+<h2 id="Syntax">Syntaxe</h2>
 
-<pre class="syntaxbox notranslate"><em>target</em>.addEventListener(<em>type</em>, <em>écouteur [, </em><em>options</em>]);
-<em>target</em>.addEventListener(<em>type</em>, <em>écouteur [, utiliserCapture</em>]);
-<em>target</em>.addEventListener(<em>type</em>, <em>écouteur [, utiliserCapture</em>, <em>veutNonFiables </em>{{Non-standard_inline}}]); // Gecko/Mozilla seulement</pre>
+<pre class="syntaxbox">
+  target.addEventListener(type, listener [, options]);
+  target.addEventListener(type, listener [, useCapture]);
+  target.addEventListener(type, listener [, useCapture, wantsUntrusted {{Non-standard_inline}}]); // Gecko/Mozilla seulement
+</pre>
 
-<h3 id="Paramètres">Paramètres</h3>
-
-<dl>
- <dt><em><code>type</code></em> </dt>
- <dd>Une chaîne sensible à la casse représentant le <a href="https://developer.mozilla.org/fr/docs/Web/Events">type d'évènement</a> à écouter.</dd>
- <dt><code><var>écouteur</var></code></dt>
- <dd>L'objet qui recevra une notification (un objet qui implémente l'interface {{domxref("Event")}}) lorsqu'un évènement du type spécifié se produit. Cela doit être un objet implémentant l'interface {{domxref("EventListener")}} ou une <a href="https://developer.mozilla.org/fr/docs/Web/JavaScript/Guide/Fonctions" title="fr/Référence_de_JavaScript_1.5_Core/Fonctions">fonction</a> JavaScript. Voir {{anch("The event listener callback")}} pour des détails sur le rappel lui-même.</dd>
- <dt><code><var>options</var></code> {{optional_inline}}</dt>
- <dd>Un objet options spécifie les caractéristiques de l'écouteur d'évènements. Les options disponibles sont :
- <dl>
-  <dt><code>capture</code></dt>
-  <dd>Un {{jsxref("Boolean")}} indiquant que les évènements de ce type seront distribués à l'<code><var>écouteur</var></code> enregistré avant d'être distribués à tout <code>EventTarget</code> située en-dessous dans l'arborescence DOM.</dd>
-  <dt><code>once</code></dt>
-  <dd>Un {{jsxref("Boolean")}} indiquant que l'<em><code>écouteur</code></em> doit être invoqué au plus une fois après avoir été ajouté. Si <code>true</code> (<em>vrai</em>), l'<em><code>écouteur</code></em> sera automatiquement supprimé après son appel.</dd>
-  <dt><code>passive</code></dt>
-  <dd>Un {{jsxref("Boolean")}} qui, si <code>true</code>, indique que la fonction spécifiée par l'<em><code>écouteur</code></em> n'appellera jamais {{domxref("Event.preventDefault", "preventDefault()")}}. Si un écouteur passif appelle <code>preventDefault()</code>, l'agent utilisateur ne fera rien d'autre que de générer un avertissement sur la console. Voir {{anch("Amélioration des performances de défilement avec les écouteurs passifs")}} pour en apprendre davantage.</dd>
-  <dt>{{non-standard_inline}} <code>mozSystemGroup</code></dt>
-  <dd>Un {{jsxref("Boolean")}} indiquant que l'écouteur doit être ajouté au groupe système. Disponible seulement pour le code s'exécutant dans XBL ou dans le {{glossary("chrome")}} du navigateur Firefox.</dd>
- </dl>
- </dd>
- <dt><code><var>utiliserCapture</var></code> {{optional_inline}}</dt>
- <dd>Un  {{jsxref("Boolean")}} indiquant si les événements de ce type seront distribués à l'<em><code>écouteur</code></em> enregistré <em>avant</em> d'être distribués à toute <code>EventTarget</code> (cible d'évènement) située en-dessous dans l'arborescence DOM. Les événements qui se propagent vers le haut dans l'arborescence ne déclencheront pas un écouteur indiqué comme utilisant la capture. La propagation et la capture d'événements sont deux manières de propager des événements qui se produisent dans un élément imbriqué dans un autre, lorsque les deux éléments ont enregistré un gestionnaire pour cet événement. Le mode de propagation de l'évènement détermine l'ordre dans lequel les éléments reçoivent l'événement. Voir les <a href="http://www.w3.org/TR/DOM-Level-3-Events/#event-flow">DOM Level 3 Events</a> et <a href="http://www.quirksmode.org/js/events_order.html#link4">JavaScript Event order</a> pour une explication détaillée. Si non spécifié, <em><code>useCapture</code></em> a <code>false</code> pour valeur par défaut.</dd>
-</dl>
-
-<div class="note">
-<p><strong>Note : </strong>pour les écouteurs attachés à la cible d'évènement, l'évènement se trouve dans la phase cible, plutôt que dans les phases de propagation et de capture. Les évènements dans la phase cible déclencheront tous les écouteurs d'un élément dans l'ordre où ils ont été enregistrés, indépendamment du paramètre <em><code>useCapture</code></em>.</p>
-</div>
-
-<div class="note">
-<p><strong>Note :</strong> <em><code>useCapture</code></em> n'est pas toujours facultatif. Idéalement, vous devriez l'inclure pour une compatibilité de navigateurs la plus large possible.</p>
-</div>
+<h3 id="Parameters">Paramètres</h3>
 
 <dl>
- <dt><em><code>veutNonFiables</code></em> {{Non-standard_inline}}</dt>
- <dd>Un paramètre spécifique à Firefox (Gecko). Si <code>true</code>, l'écouteur reçoit les événements synthétiques distribués par le contenu web (le défaut est <code>false</code> pour le {{glossary("chrome")}} du navigateur et <code>true</code> pour les pages web ordinaires). Ce paramètre est utile pour le code qui se trouve dans les compléments, ainsi que pour le navigateur lui-même.</dd>
+  <dt><code>type</code></dt>
+  <dd>Une chaîne sensible à la casse représentant le <a href="/fr/docs/Web/Events">type d'évènement</a> à écouter.</dd>
+  <dt><code>listener</code></dt>
+  <dd>L'objet qui recevra une notification (un objet qui implémente l'interface {{domxref("Event")}}) lorsqu'un évènement du type spécifié se produit. Cela doit être un objet implémentant l'interface {{domxref("EventListener")}} ou une <a href="/fr/docs/Web/JavaScript/Guide/Functions">fonction</a> JavaScript. Voir {{anch("The_event_listener_callback", "Rappel de l'écouteur d'évènement")}} pour des détails sur le rappel lui-même.</dd>
+  <dt><code>options</code> {{optional_inline}}</dt>
+  <dd>Un objet options spécifie les caractéristiques de l'écouteur d'évènements. Les options disponibles sont :
+    <dl>
+      <dt><code>capture</code></dt>
+        <dd>Un {{jsxref("Boolean")}} indiquant que les évènements de ce type seront distribués à l'<code><var>écouteur</var></code> enregistré avant d'être distribués à tout <code>EventTarget</code> située en-dessous dans l'arborescence DOM.</dd>
+        <dt><code>once</code></dt>
+        <dd>Un {{jsxref("Boolean")}} indiquant que l'<em><code>écouteur</code></em> doit être invoqué au plus une fois après avoir été ajouté. Si <code>true</code> (<em>vrai</em>), l'<em><code>écouteur</code></em> sera automatiquement supprimé après son appel.</dd>
+        <dt><code>passive</code></dt>
+        <dd>Un {{jsxref("Boolean")}} qui, si <code>true</code>, indique que la fonction spécifiée par l'<em><code>écouteur</code></em> n'appellera jamais {{domxref("Event.preventDefault", "preventDefault()")}}. Si un écouteur passif appelle <code>preventDefault()</code>, l'agent utilisateur ne fera rien d'autre que de générer un avertissement sur la console. Voir {{anch("Amélioration des performances de défilement avec les écouteurs passifs")}} pour en apprendre davantage.</dd>
+        <dt><code>mozSystemGroup</code> {{non-standard_inline}}</dt>
+        <dd>Un {{jsxref("Boolean")}} indiquant que l'écouteur doit être ajouté au groupe système. Disponible seulement pour le code s'exécutant dans XBL ou dans le {{glossary("chrome")}} du navigateur Firefox.</dd>
+      </dl>
+    </dd>
+  <dt><code>useCapture</code> {{optional_inline}}</dt>
+  <dd>Un {{jsxref("Boolean")}} indiquant si les événements de ce type seront distribués au <em><code>listener</code></em> enregistré <em>avant</em> d'être distribués à toute <code>EventTarget</code> (« cible d'évènement ») située en-dessous dans l'arborescence DOM. Les événements qui se propagent vers le haut dans l'arborescence ne déclencheront pas un écouteur indiqué comme utilisant la capture. La propagation et la capture d'événements sont deux manières de propager des événements qui se produisent dans un élément imbriqué dans un autre, lorsque les deux éléments ont enregistré un gestionnaire pour cet événement. Le mode de propagation de l'évènement détermine l'ordre dans lequel les éléments reçoivent l'événement. Voir les <a href="http://www.w3.org/TR/DOM-Level-3-Events/#event-flow">DOM Level 3 Events</a> et <a href="http://www.quirksmode.org/js/events_order.html#link4">JavaScript Event order</a> pour une explication détaillée. Si non spécifié, <em><code>useCapture</code></em> a <code>false</code> pour valeur par défaut.</dd>
 </dl>
 
-<h3 id="Valeur_retournée">Valeur retournée</h3>
+<div class="notecard note">
+  <p><strong>Note :</strong> Pour les écouteurs attachés à la cible d'évènement, l'évènement se trouve dans la phase cible, plutôt que dans les phases de propagation et de capture. Les évènements dans la phase cible déclencheront tous les écouteurs d'un élément dans l'ordre où ils ont été enregistrés, indépendamment du paramètre <em><code>useCapture</code></em>.</p>
+</div>
+
+<div class="notecard note">
+  <p><strong>Note :</strong> <em><code>useCapture</code></em> n'est pas toujours facultatif. Idéalement, vous devriez l'inclure pour une compatibilité de navigateurs la plus large possible.</p>
+</div>
+
+<dl>
+  <dt><em><code>wantsUntrusted</code></em> {{Non-standard_inline}}</dt>
+  <dd>Un paramètre spécifique à Firefox (Gecko). Si <code>true</code>, l'écouteur reçoit les événements synthétiques distribués par le contenu web (le défaut est <code>false</code> pour le {{glossary("chrome")}} du navigateur et <code>true</code> pour les pages web ordinaires). Ce paramètre est utile pour le code qui se trouve dans les compléments, ainsi que pour le navigateur lui-même.</dd>
+</dl>
+
+<h3 id="Return_value">Valeur de retour</h3>
 
 <p><code>undefined</code></p>
 
-<h2 id="Notes_dutilisation">Notes d'utilisation</h2>
+<h2 id="Usage_notes">Notes d'utilisation</h2>
 
-<h3 id="Le_rappel_de_lécouteur_dévènement">Le rappel de l'écouteur d'évènement</h3>
+<h3 id="The_event_listener_callback">Rappel de l'écouteur d'évènement</h3>
 
-<p>L'écouteur d'évènement peut être spécifié, soit comme une fonction de rappel, soit comme un objet qui implémente {{domxref ("EventListener")}}, dont la méthode {{domxref ("EventListener.handleEvent", "handleEvent ()")}} sert de fonction de rappel.</p>
+<p>L'écouteur d'évènement peut être spécifié, soit comme une fonction de rappel, soit comme un objet qui implémente {{domxref("EventListener")}}, dont la méthode {{domxref("EventListener.handleEvent", "handleEvent()")}} sert de fonction de rappel.</p>
 
-<p>La fonction de rappel a elle-même les mêmes paramètres et la même valeur de retour que la méthode <code>handleEvent()</code> ; c'est-à-dire que le rappel accepte un seul paramètre : un objet basé sur {{domxref ("Event")}} décrivant l'événement qui s'est produit, et il ne retourne rien.</p>
+<p>La fonction de rappel a elle-même les mêmes paramètres et la même valeur de retour que la méthode <code>handleEvent()</code> ; c'est-à-dire que le rappel accepte un seul paramètre : un objet basé sur {{domxref("Event")}} décrivant l'événement qui s'est produit, et il ne retourne rien.</p>
 
 <p>Par exemple, un rappel de gestionnaire d'événements pouvant être utilisé pour gérer à la fois {{domxref("Element/fullscreenchange_event", "fullscreenchange")}} et {{domxref("Element/fullscreenerror_event", "fullscreenerror")}} peut ressembler à ceci :</p>
 
-<pre class="brush: js line-numbers  language-js notranslate">function gestionnaireDEvenement(evenement) {
-  if (evenement.type == fullscreenchange) {
+<pre class="brush: js">
+function eventHandler(event) {
+  if (event.type == 'fullscreenchange') {
     /* gérer un passage en plein écran */
   } else /* fullscreenerror */ {
     /* gérer une erreur de passage en plein écran */
   }
-}</pre>
+}
+</pre>
 
-<h3 id="Détection_de_la_prise_en_charge_des_options_en_toute_sécurité">Détection de la prise en charge des options en toute sécurité</h3>
+<h3 id="Safely_detecting_option_support">Détection sûre du support des options</h3>
 
 <p>Dans les anciennes versions de la spécification DOM, le troisième paramètre de <code>addEventListener()</code> était une valeur booléenne indiquant s'il fallait ou non utiliser la capture. Au fil du temps, il est devenu clair que davantage d'options étaient nécessaires. Plutôt que d'ajouter davantage de paramètres à la fonction (ce qui complique énormément les choses lors du traitement des valeurs optionnelles), le troisième paramètre a été changé en un objet pouvant contenir diverses propriétés définissant les valeurs des options pour configurer le processus de suppression de l'écouteur d'événement.</p>
 
@@ -96,54 +100,61 @@ translation_of: Web/API/EventTarget/addEventListener
 
 <p>Par exemple, si vous voulez vérifier l'option <code>passive</code> :</p>
 
-<pre class="brush: js line-numbers  language-js notranslate">var passiveSupportee = false;
+<pre class="brush: js">
+var passiveSupported = false;
 
 try {
   var options = Object.defineProperty({}, "passive", {
     get: function() {
-      passiveSupportee = true;
+      passiveSupported = true;
     }
   });
 
-  window.addEventListener("test", options, options);
-  window.removeEventListener("test", options, options);
+  window.addEventListener("test", null, options);
+  window.removeEventListener("test", null, options);
 } catch(err) {
-  passiveSupportee = false;
-}</pre>
+  passiveSupported = false;
+}
+</pre>
 
-<p>Cela crée un objet <em><code>options</code></em> avec une fonction accesseur pour la propriété <code>passive</code> ; l'accesseur initialise un indicateur, <code>passiveSupportee</code>, à <code>true</code> si elle est appelée. Cela signifie que si le navigateur vérifie la valeur de la propriété <code>passive</code> dans l'objet <em><code>options</code></em>, <code>passiveSupportee</code> sera initialisé à <code>true</code> ; sinon, il restera <code>false</code>. Nous appelons alors <code>addEventListener()</code> pour installer un faux gestionnaire d'événements, en spécifiant ces options, se sorte qu'elles soient vérifiées si le navigateur reconnaît un objet comme troisième paramètre. Ensuite, nous appelons <code>removeEventListener()</code> pour faire le ménage après notre passage. (Notez que <code>handleEvent()</code> est ignoré dans les écouteurs d'événements qui ne sont pas appelés).</p>
+<p>Cela crée un objet <em><code>options</code></em> avec une fonction accesseur pour la propriété <code>passive</code> ; l'accesseur initialise un indicateur, <em><code>passiveSupported</code></em>, à <code>true</code> si elle est appelée. Cela signifie que si le navigateur vérifie la valeur de la propriété <code>passive</code> dans l'objet <em><code>options</code></em>, <em><code>passiveSupported</code></em> sera initialisé à <code>true</code> ; sinon, il restera <code>false</code>. Nous appelons alors <code>addEventListener()</code> pour installer un faux gestionnaire d'événements, en spécifiant ces options, se sorte qu'elles soient vérifiées si le navigateur reconnaît un objet comme troisième paramètre. Ensuite, nous appelons <code>removeEventListener()</code> pour faire le ménage après notre passage. (Notez que <code>handleEvent()</code> est ignoré dans les écouteurs d'événements qui ne sont pas appelés).</p>
 
 <p>Vous pouvez vérifier de cette façon si une option quelconque est supportée. Ajoutez simplement un accesseur pour cette option en utilisant un code similaire à celui montré ci-dessus.</p>
 
 <p>Ensuite, lorsque vous voulez créer un écouteur d'événements réel qui utilise les options en question, vous pouvez faire quelque chose comme ce qui suit :</p>
 
-<pre class="brush: js line-numbers  language-js notranslate">unElement.addEventListener("mouseup", gererMouseUp, passiveSupportee
-                               ? { passive: true } : false);</pre>
+<pre class="brush: js">
+someElement.addEventListener("mouseup", handleMouseUp, passiveSupported
+                              ? { passive: true } : false);
+</pre>
 
-<p>Ici, nous ajoutons un écouteur pour l'événement {{domxref("Element/mouseup_event", "mouseup")}} dans l'élément <em><code>unElement</code></em>. Pour le troisième paramètre, si <em><code>passiveSupportee</code></em> est <code>true</code>, nous spécifions un objet <em><code>options</code></em> avec <code>passive</code> initialisée à <code>true</code> ; sinon, nous savons que nous devons passer un Boolean, et nous passons <code>false</code> comme valeur du paramètre <em><code>useCapture</code></em>.</p>
+<p>Ici, nous ajoutons un écouteur pour l'événement {{domxref("Element/mouseup_event", "mouseup")}} dans l'élément <em><code>someElement</code></em>. Pour le troisième paramètre, si <em><code>passiveSupported</code></em> est <code>true</code>, nous spécifions un objet <em><code>options</code></em> avec <code>passive</code> initialisée à <code>true</code> ; sinon, nous savons que nous devons passer un Boolean, et nous passons <code>false</code> comme valeur du paramètre <em><code>useCapture</code></em>.</p>
 
 <p>Si vous préférez, vous pouvez utiliser une bibliothèque tierce comme <a href="https://modernizr.com/docs">Modernizr</a> ou <a href="https://github.com/rafrex/detect-it">Detect It</a> pour faire ce test pour vous.</p>
 
 <p>Vous pouvez en apprendre davantage dans l'article à propos des <code><a href="https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md#feature-detection">EventListenerOptions</a></code>  du <a href="https://wicg.github.io/admin/charter.html">Groupe Web Incubator Community</a>.</p>
 
-<h2 id="Exemples">Exemples</h2>
+<h2 id="Examples">Exemples</h2>
 
-<h3 id="Ajouter_un_écouteur_simple">Ajouter un écouteur simple</h3>
+<h3 id="Add_a_simple_listener">Ajouter un écouteur simple</h3>
 
 <p>Cet exemple montre comment utiliser <code>addEventListener()</code> pour surveiller les clics de souris sur un élément.</p>
 
 <h4 id="HTML">HTML</h4>
 
-<pre class="brush: html line-numbers  language-html notranslate">&lt;table id="aLExterieur"&gt;
-    &lt;tr&gt;&lt;td id="t1"&gt;un&lt;/td&gt;&lt;/tr&gt;
-    &lt;tr&gt;&lt;td id="t2"&gt;deux&lt;/td&gt;&lt;/tr&gt;
-&lt;/table&gt;</pre>
+<pre class="brush: html">
+&lt;table id="outside"&gt;
+  &lt;tr&gt;&lt;td id="t1"&gt;un&lt;/td&gt;&lt;/tr&gt;
+  &lt;tr&gt;&lt;td id="t2"&gt;deux&lt;/td&gt;&lt;/tr&gt;
+&lt;/table&gt;
+</pre>
 
 <h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js line-numbers  language-js notranslate">// Fonction pour changer le contenu de t2
-function modifierTexte() {
-  var t2 = document.getElementById("t2");
+<pre class="brush: js">
+// Fonction pour changer le contenu de t2
+function modifyText() {
+  var t2 = document.querySelector("#t2");
   if (t2.firstChild.nodeValue == "trois") {
     t2.firstChild.nodeValue = "deux";
   } else {
@@ -152,87 +163,96 @@ function modifierTexte() {
 }
 
 // Ajouter un écouteur d'évènements à la table
-var el = document.getElementById("aLExterieur");
-el.addEventListener("click", modifierTexte, false);</pre>
+var el = document.querySelector("#outside");
+el.addEventListener("click", modifyText, false);
+</pre>
 
-<p>Dans ce code, <code>modifierTexte()</code> est un écouteur pour les évènements <code>click</code> enregistré en utilisant <code>addEventListener()</code>. Un clic n'importe où sur la table se propagera jusqu'au gestionnaire et exécutera <code>modifierTexte()</code>.</p>
+<p>Dans ce code, <code>modifyText()</code> est un écouteur pour les évènements <code>click</code> enregistré en utilisant <code>addEventListener()</code>. Un clic n'importe où sur la table se propagera jusqu'au gestionnaire et exécutera <code>modifyText()</code>.</p>
 
-<h4 id="Résultat">Résultat</h4>
+<h4 id="Result">Résultat</h4>
 
 <p>{{EmbedLiveSample('Add_a_simple_listener')}}</p>
 
-<h3 id="Écouteur_dévènement_avec_une_fonction_anonyme">Écouteur d'évènement avec une fonction anonyme</h3>
+<h3 id="Event_listener_with_anonymous_function">Écouteur d'évènement avec une fonction anonyme</h3>
 
 <p>Ici, nous allons voir comment utiliser une fonction anonyme pour passer des paramètres à l'écouteur d'événements.</p>
 
 <h4 id="HTML_2">HTML</h4>
 
-<pre class="brush: html line-numbers  language-html notranslate">&lt;table id="aLExterieur"&gt;
-    &lt;tr&gt;&lt;td id="t1"&gt;un&lt;/td&gt;&lt;/tr&gt;
-    &lt;tr&gt;&lt;td id="t2"&gt;deux&lt;/td&gt;&lt;/tr&gt;
-&lt;/table&gt;</pre>
+<pre class="brush: html">
+&lt;table id="outside"&gt;
+  &lt;tr&gt;&lt;td id="t1"&gt;un&lt;/td&gt;&lt;/tr&gt;
+  &lt;tr&gt;&lt;td id="t2"&gt;deux&lt;/td&gt;&lt;/tr&gt;
+&lt;/table&gt;
+</pre>
 
 <h4 id="JavaScript_2">JavaScript</h4>
 
-<pre class="brush: js line-numbers  language-js notranslate">// Fonction pour changer le contenu de t2
-function modifierTexte(nouveau_texte) {
-  var t2 = document.getElementById("t2");
-  t2.firstChild.nodeValue = nouveau_texte;
+<pre class="brush: js">
+// Fonction pour changer le contenu de t2
+function modifyText(newText) {
+  var t2 = document.querySelector("#t2");
+  t2.firstChild.nodeValue = newText;
 }
 
 // Fonction pour ajouter un écouteur d'évènement à la table
-var el = document.getElementById("aLExterieur");
-el.addEventListener("click", function(){modifierTexte("quatre")}, false);</pre>
+var el = document.querySelector("#outside");
+el.addEventListener("click", function(){modifyText("quatre")}, false);
+</pre>
 
-<p>Notez que l'écouteur est une fonction anonyme encapsulant le code qui peut à son tour envoyer des paramètres à la fonction <code>modifierTexte()</code>, qui est responsable de la réponse effective à l'événement.</p>
+<p>Notez que l'écouteur est une fonction anonyme encapsulant le code qui peut à son tour envoyer des paramètres à la fonction <code>modifyText()</code>, qui est responsable de la réponse effective à l'événement.</p>
 
-<h4 id="Résultat_2">Résultat</h4>
+<h4 id="Result_2">Résultat</h4>
 
 <p>{{EmbedLiveSample('Event_listener_with_anonymous_function')}}</p>
 
-<h3 id="Écouteur_dévènement_avec_une_fonction_fléchée">Écouteur d'évènement avec une fonction fléchée</h3>
+<h3 id="Event_listener_with_an_arrow_function">Écouteur d'évènement avec une fonction fléchée</h3>
 
 <p>Cet exemple montre un écouteur d'événement simple implémenté en utilisant la notation de fonction fléchée.</p>
 
 <h4 id="HTML_3">HTML</h4>
 
-<pre class="brush: html line-numbers  language-html notranslate">&lt;table id="aLExterieur"&gt;
-    &lt;tr&gt;&lt;td id="t1"&gt;un&lt;/td&gt;&lt;/tr&gt;
-    &lt;tr&gt;&lt;td id="t2"&gt;deux&lt;/td&gt;&lt;/tr&gt;
-&lt;/table&gt;</pre>
+<pre class="brush: html">
+&lt;table id="outside"&gt;
+  &lt;tr&gt;&lt;td id="t1"&gt;un&lt;/td&gt;&lt;/tr&gt;
+  &lt;tr&gt;&lt;td id="t2"&gt;deux&lt;/td&gt;&lt;/tr&gt;
+&lt;/table&gt;
+</pre>
 
 <h4 id="JavaScript_3">JavaScript</h4>
 
-<pre class="brush: js line-numbers  language-js notranslate">// Fonction pour changer le contenu de t2
-function modifierTexte(nouveau_texte) {
-  var t2 = document.getElementById("t2");
-  t2.firstChild.nodeValue = nouveau_texte;
+<pre class="brush: js">
+// Fonction pour changer le contenu de t2
+function modifyText(newText) {
+  var t2 = document.querySelector("#t2");
+  t2.firstChild.nodeValue = newText;
 }
 
 // Ajouter un écouteur d'évènements à la table avec une fonction fléchée
-var el = document.getElementById("aLExterieur");
-el.addEventListener("click", () =&gt; { modifierTexte("quatre"); }, false);</pre>
+var el = document.querySelector("#outside");
+el.addEventListener("click", () =&gt; { modifyText("quatre"); }, false);</pre>
 
-<h4 id="Résultat_3">Résultat</h4>
+<h4 id="Result_3">Résultat</h4>
 
 <p>{{EmbedLiveSample('Event_listener_with_an_arrow_function')}}</p>
 
-<p>Notez que si les fonctions anonymes et fléchées sont similaires, elles ont des liaisons <code>this</code> différentes. Alors que les fonctions anonymes (et toutes les fonctions JavaScript traditionnelles) créent leurs propres liaisons <code>this</code>, les fonctions fléchées héritent la liaison<code> this</code> de la fonction contenante.</p>
+<p>Notez que si les fonctions anonymes et fléchées sont similaires, elles ont des liaisons <code>this</code> différentes. Alors que les fonctions anonymes (et toutes les fonctions JavaScript traditionnelles) créent leurs propres liaisons <code>this</code>, les fonctions fléchées héritent la liaison <code>this</code> de la fonction contenante.</p>
 
 <p>Cela signifie que les variables et constantes disponibles pour la fonction contenante sont aussi disponibles pour le gestionnaire d'évènements lors de l'utilisation d'une fonction fléchée.</p>
 
-<h3 id="Exemple_dutilisation_des_options">Exemple d'utilisation des options</h3>
+<h3 id="Example_of_options_usage">Exemple d'utilisation des options</h3>
 
 <h4 id="HTML_4">HTML</h4>
 
-<pre class="brush: html notranslate">&lt;div class="exterieur"&gt;
+<pre class="brush: html">
+&lt;div class="outer"&gt;
   extérieur, once &amp; none-once
-  &lt;div class="milieu" target="_blank"&gt;
+  &lt;div class="middle" target="_blank"&gt;
     milieu, capture &amp; none-capture
-    &lt;a class="interieur1" href="https://www.mozilla.org" target="_blank"&gt;
+    &lt;a class="inner1" href="https://www.mozilla.org" target="_blank"&gt;
       intérieur1, passive &amp; preventDefault (ce qui n'est pas autorisé)
     &lt;/a&gt;
-    &lt;a class="interieur2" href="https://developer.mozilla.org/" target="_blank"&gt;
+    &lt;a class="inner2" href="https://developer.mozilla.org/" target="_blank"&gt;
       intérieur2, none-passive &amp; preventDefault (nouvelle page non ouverte)
     &lt;/a&gt;
   &lt;/div&gt;
@@ -241,23 +261,24 @@ el.addEventListener("click", () =&gt; { modifierTexte("quatre"); }, false);</pre
 
 <h4 id="CSS">CSS</h4>
 
-<pre class="brush: css notranslate">.exterieur, .milieu, .interieur1, .interieur2 {
+<pre class="brush: css">
+.outer, .middle, .inner1, .inner2 {
   display: block;
   width:   520px;
   padding: 15px;
   margin:  15px;
   text-decoration: none;
 }
-.exterieur {
+.outer {
   border: 1px solid red;
   color:  red;
 }
-.milieu {
+.middle {
   border: 1px solid green;
   color:  green;
   width:  460px;
 }
-.interieur1, .interieur2 {
+.inner1, .inner2 {
   border: 1px solid purple;
   color:  purple;
   width:  400px;
@@ -266,160 +287,210 @@ el.addEventListener("click", () =&gt; { modifierTexte("quatre"); }, false);</pre
 
 <h4 id="JavaScript_4">JavaScript</h4>
 
-<pre class="brush: js notranslate">const exterieur  = document.querySelector('.exterieur');
-const milieu     = document.querySelector('.milieu');
-const interieur1 = document.querySelector('.interieur1');
-const interieur2 = document.querySelector('.interieur2');
+<pre class="brush: js">
+const outer  = document.querySelector('.outer');
+const middle = document.querySelector('.middle');
+const inner1 = document.querySelector('.inner1');
+const inner2 = document.querySelector('.inner2');
 
 const capture = {
-  capture : true
+  capture: true
 };
 const noneCapture = {
-  capture : false
+  capture: false
 };
 const once = {
-  once : true
+  once: true
 };
 const noneOnce = {
-  once : false
+  once: false
 };
 const passive = {
-  passive : true
+  passive: true
 };
 const nonePassive = {
-  passive : false
+  passive: false
 };
 
-exterieur .addEventListener('click', onceHandler, once);
-exterieur .addEventListener('click', noneOnceHandler, noneOnce);
-milieu    .addEventListener('click', captureHandler, capture);
-milieu    .addEventListener('click', noneCaptureHandler, noneCapture);
-interieur1.addEventListener('click', passiveHandler, passive);
-interieur2.addEventListener('click', nonePassiveHandler, nonePassive);
+outer.addEventListener('click', onceHandler, once);
+outer.addEventListener('click', noneOnceHandler, noneOnce);
+middle.addEventListener('click', captureHandler, capture);
+middle.addEventListener('click', noneCaptureHandler, noneCapture);
+inner1.addEventListener('click', passiveHandler, passive);
+inner2.addEventListener('click', nonePassiveHandler, nonePassive);
 
-function onceHandler(evenement) {
-  alert('exterieur, once');
+function onceHandler(event) {
+  alert('extérieur, once');
 }
-function noneOnceHandler(evenement) {
-  alert('exterieur, none-once, default');
+function noneOnceHandler(event) {
+  alert('extérieur, none-once, default');
 }
-function captureHandler(evenement) {
-  //evenement.stopImmediatePropagation();
-  alert('milieu, capture');
+function captureHandler(event) {
+  // event.stopImmediatePropagation();
+  alert('milieur, capture');
 }
-function noneCaptureHandler(evenement) {
-  alert('milieu, none-capture, default');
+function noneCaptureHandler(event) {
+  alert('milieur, none-capture, default');
 }
-function passiveHandler(evenement) {
+function passiveHandler(event) {
   // Impossible d'utiliser preventDefault à l'intérieur de l'invocation d'un écouteur d'évènements passif.
-  evenement.preventDefault();
-  alert('interieur1, passive, nouvelle page ouverte');
+  event.preventDefault();
+  alert('intérieur1, passive, nouvelle page ouverte');
 }
-function nonePassiveHandler(evenement) {
-  evenement.preventDefault();
-  //evenement.stopPropagation();
-  alert('interieur2, none-passive, défaut, nouvelle page non ouverte');
+function nonePassiveHandler(event) {
+  event.preventDefault();
+  // event.stopPropagation();
+  alert('intérieur2, none-passive, default, nouvelle page non ouverte');
 }
 </pre>
 
-<h4 id="Résultat_4">Résultat</h4>
+<h4 id="Result_4">Résultat</h4>
 
 <p>Cliquer les conteneurs extérieur, milieu, intérieurs respectivement pour voir comment les options fonctionnent.</p>
 
-<p>{{ EmbedLiveSample('Example_of_options_usage', 600, 310, '', 'Web/API/EventTarget/addEventListener') }}</p>
+<p>{{EmbedLiveSample('Example_of_options_usage', '', '320')}}</p>
 
-<p>Avant d'utiliser une valeur particulière dans l'objet <code><var>options</var></code>, c'est une bonne idée que de s'assurer que le navigateur de l'utilisateur la prend en charge, du fait qu'elles sont un ajout que tous les navigateurs n'ont pas pris en charge historiquement. Voir {{anch("Safely detecting option support")}} pour les détails.</p>
+<p>Avant d'utiliser une valeur particulière dans l'objet <code>options</code>, c'est une bonne idée que de s'assurer que le navigateur de l'utilisateur la prend en charge, du fait qu'elles sont un ajout que tous les navigateurs n'ont pas pris en charge historiquement. Voir {{anch("Safely_detecting_option_support", "Détection sûre du support des options")}} pour les détails.</p>
 
-<h2 id="Autres_notes">Autres notes</h2>
+<h3 id="Add_a_abortable_listener">Ajout d'un écouteur annulable</h3>
 
-<h3 id="Pourquoi_utiliser_addEventListener">Pourquoi utiliser addEventListener() ?</h3>
+<p>Cet exemple montre comment ajouter un <code>addEventListener()</code> qui peut être interrompu par un {{domxref("AbortSignal")}}.</p>
+
+<h4 id="HTML_5">HTML</h4>
+
+<pre class="brush: html">
+&lt;table id="outside"&gt;
+  &lt;tr&gt;&lt;td id="t1"&gt;un&lt;/td&gt;&lt;/tr&gt;
+  &lt;tr&gt;&lt;td id="t2"&gt;deux&lt;/td&gt;&lt;/tr&gt;
+&lt;/table&gt;
+</pre>
+
+<h4 id="JavaScript_5">JavaScript</h4>
+
+<pre class="brush: js">
+// Ajout d'un écouteur d'événement annulable à la table
+const controller = new AbortController();
+const el = document.querySelector("#outside");
+el.addEventListener("click", modifyText, { signal: controller.signal });
+
+// Fonction permettant de modifier le contenu de t2
+function modifyText() {
+  const t2 = document.querySelector("#t2");
+  if (t2.firstChild.nodeValue == "trois") {
+    t2.firstChild.nodeValue = "deux";
+  } else {
+    t2.firstChild.nodeValue = "trois";
+    controller.abort(); // supprime l'écouteur lorsque la valeur est "trois".
+  }
+}
+</pre>
+
+<p>Dans l'exemple ci-dessus, nous modifions le code de l'exemple {{anch('Add_a_simple_listener', 'Ajouter un écouteur simple')}} de telle sorte qu'après que le contenu de la deuxième ligne soit devenu « trois », nous appelons <code>abort()</code> à partir du {{domxref("AbortController")}} que nous avons passé à l'appel <code>addEventListener()</code>. Cela a pour résultat que la valeur reste à "trois" pour toujours, parce que nous n'avons plus de code écoutant un événement de clic.</p>
+
+<h4 id="Result_5">Résultat</h4>
+
+<p>{{EmbedLiveSample('Add_a_abortable_listener')}}</p>
+
+<h2 id="Other_notes">Autres notes</h2>
+
+<h3 id="Why_use_addEventListener">Pourquoi utiliser addEventListener() ?</h3>
 
 <p><code>addEventListener</code> est la manière d'enregistrer un écouteur d'évènements telle que spécifiée dans le DOM du W3C. Ses avantages sont les suivants :</p>
 
 <ul>
- <li>Elle permet d'ajouter plus d'un seul gestionnaire pour un évènement. Cela peut s'avérer particulièrement utile pour les bibliothèques {{Glossary("AJAX")}}, les modules JavaScript ou tout autre sorte de code qui a besoin de fonctionner correctement avec d'autres bibliothèques/extensions.</li>
- <li>Elle donne un contrôle plus fin sur la phase d'activation de l'écouteur (capture contre propagation)</li>
- <li>Elle fonctionne avec tout élément DOM, pas seulement avec les éléments HTML.</li>
+  <li>Elle permet d'ajouter plus d'un seul gestionnaire pour un évènement. Cela peut s'avérer particulièrement utile pour les bibliothèques {{Glossary("AJAX")}}, les modules JavaScript ou tout autre sorte de code qui a besoin de fonctionner correctement avec d'autres bibliothèques/extensions.</li>
+  <li>Elle donne un contrôle plus fin sur la phase d'activation de l'écouteur (capture contre propagation)</li>
+  <li>Elle fonctionne avec tout élément DOM, pas seulement avec les éléments HTML.</li>
 </ul>
 
-<p>L'<a href="https://wiki.developer.mozilla.org/fr/docs/Web/API/EventTarget/addEventListener$edit#Older_way_to_register_event_listeners">ancienne manière alternative</a> d'enregistrer des évènements est décrite ci-dessous.</p>
+<p>L'<a href="#older_way_to_register_event_listeners">ancienne manière alternative</a> d'enregistrer des évènements est décrite ci-dessous.</p>
 
-<h3 id="Ajout_dun_écouteur_pendant_la_distribution_dun_évènement">Ajout d'un écouteur pendant la distribution d'un évènement</h3>
+<h3 id="Adding_a_listener_during_event_dispatch">Ajout d'un écouteur pendant la distribution d'un évènement</h3>
 
 <p>Si un {{domxref("EventListener")}} est ajouté à une {{domxref("EventTarget")}} pendant qu'elle traite un évènement, cet évènement ne déclenchera l'écouteur. Cependant, le même écouteur pourra être déclenché à une étape ultérieure du flux d'évènements, telle que la phase de propagation.</p>
 
-<h3 id="Écouteurs_dévènements_identiques_multiples">Écouteurs d'évènements identiques multiples</h3>
+<h3 id="Multiple_identical_event_listeners">Écouteurs d'évènements identiques multiples</h3>
 
-<p>Si des <code>EventListener</code>s identiques multiples sont enregistrés sur la même <code>EventTarget</code> avec les mêmes paramètres, les instances dupliquées sont supprimées. Elles ne provoqueront pas un appel en double de l'<code>EventListener</code>, et elles n'ont pas besoin d'être enlevées avec la méthode {{domxref("EventTarget.removeEventListener()", "removeEventListener()")}}.</p>
+<p>Si des <code>EventListener</code> identiques multiples sont enregistrés sur la même <code>EventTarget</code> avec les mêmes paramètres, les instances dupliquées sont supprimées. Elles ne provoqueront pas un appel en double de l'<code>EventListener</code>, et elles n'ont pas besoin d'être enlevées avec la méthode {{domxref("EventTarget.removeEventListener()", "removeEventListener()")}}.</p>
 
 <p>Notez toutefois que lors de l'utilisation d'une fonction anonyme comme gestionnaire, de tels écouteurs ne seront PAS identiques, du fait que les fonctions anonymes ne sont pas identiques, même si définies en utilisant le MÊME code source inchangé, simplement appelé répétitivement, même dans une boucle.</p>
 
-<p>Cependant, le fait de définir répétitivement la même fonction nommée dans de tels cas peut être davantage problématique. (Voir <a href="https://wiki.developer.mozilla.org/fr/docs/Web/API/EventTarget/addEventListener$edit#Memory_issues">Problèmes de mémoire</a> ci-dessous.)</p>
+<p>Cependant, le fait de définir répétitivement la même fonction nommée dans de tels cas peut être davantage problématique. (Voir <a href="#memory_issues">Problèmes de mémoire</a> ci-dessous.)</p>
 
-<h3 id="La_valeur_de_this_à_lintérieur_du_gestionnaire">La valeur de "this" à l'intérieur du gestionnaire</h3>
+<h3 id="The_value_of_this_within_the_handler">La valeur de "this" à l'intérieur du gestionnaire</h3>
 
 <p>Il est souvent souhaitable de référencer l'élément sur lequel le gestionnaire d'évènements a été déclenché, comme lors de l'utilisation d'un gestionnaire générique pour un ensemble d'éléments similaires.</p>
 
 <p>Lorsqu'une fonction gestionnaire est attachée à un élément en utilisant <code>addEventListener()</code>, la valeur de {{jsxref("Operators/this","this")}} à l'intérieur du gestionnaire est une référence à l'élément. C'est la même valeur que celle de la propriété <code>currentTarget</code> de l'argument évènement qui est passé au gestionnaire.</p>
 
-<pre class="brush: js notranslate">mon_element.addEventListener('click', function (e) {
-  console.log(this.className)           // journalise le className de mon_element
+<pre class="brush: js">
+my_element.addEventListener('click', function(e) {
+  console.log(this.className)           // journalise le className de my_element
   console.log(e.currentTarget === this) // journalise `true`
 })
 </pre>
 
-<p>Pour mémoire, les <a href="https://wiki.developer.mozilla.org/fr-FR/docs/Web/JavaScript/Reference/Functions/Arrow_functions#No_separate_this">fonctions fléchées n'ont pas leur propre contexte <code>this</code></a>.</p>
+<p>Pour mémoire, les <a href="/fr/docs/Web/JavaScript/Reference/Functions/Arrow_functions#no_separate_this">fonctions fléchées n'ont pas leur propre contexte <code>this</code></a>.</p>
 
-<pre class="brush: js notranslate">mon_element.addEventListener('click', (e) =&gt; {
-  console.log(this.className)           // ATTENTION : `this` n'est pas `mon_element`
+<pre class="brush: js">
+my_element.addEventListener('click', (e) =&gt; {
+  console.log(this.className)           // ATTENTION : `this` n'est pas `my_element`
   console.log(e.currentTarget === this) // journalise `false`
-})</pre>
+})
+</pre>
 
-<p>Si un attribut d'évènement (par exemple, {{domxref("GlobalEventHandlers.onclick", "onclick")}}) est spécifié dans un élément dans le source HTML, le code JavaScript dans la valeur de l'attribut est effectivement encapsulé dans une fonction gestionnaire qui lie la valeur de <code>this</code> d'une manière cohérente avec l'<code>addEventListener()</code> ; une occurrence de <code>this</code> dans le code représente une référence à l'élément.</p>
+<p>Si un gestionnaire d'événements (par exemple, {{domxref("GlobalEventHandlers.onclick", "onclick")}}) est spécifié sur un élément dans la source HTML, le code JavaScript dans la valeur de l'attribut est effectivement encapsulé dans une fonction du gestionnaire qui lie la valeur de <code>this</code> d'une manière cohérente avec le <code>addEventListener()</code> ; une occurrence de <code>this</code> dans le code représente une référence à l'élément.</p>
 
-<pre class="brush: html notranslate">&lt;table id="ma_table" onclick="console.log(this.id);"&gt;&lt;!-- `this` fait référence à la table ; journalise 'ma_table' --&gt;
+<pre class="brush: html">
+&lt;table id="my_table" onclick="console.log(this.id);"&gt;&lt;!-- `this` fait référence à la table ; journalise 'my_table' --&gt;
   ...
-&lt;/table&gt;</pre>
+&lt;/table&gt;
+</pre>
 
-<p>Notez que la valeur de <code>this</code> à l'intérieur d'une fonction, <em>appelée</em> par le code dans la valeur de l'attribut, se comporte selon les <a href="https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Op%C3%A9rateurs/L_op%C3%A9rateur_this">règles standard</a>. Ceci est illustré dans l'exemple suivant :</p>
+<p>Notez que la valeur de <code>this</code> à l'intérieur d'une fonction, <em>appelée</em> par le code dans la valeur de l'attribut, se comporte selon les <a href="/fr/docs/Web/JavaScript/Reference/Operators/this">règles standard</a>. Ceci est illustré dans l'exemple suivant :</p>
 
-<pre class="brush: html notranslate">&lt;script&gt;
-  function journaliserID() { console.log(this.id); }
+<pre class="brush: html">
+&lt;script&gt;
+  function logID() { console.log(this.id); }
 &lt;/script&gt;
-&lt;table id="ma_table" onclick="journaliserID();"&gt;&lt;!-- lorsqu'appelée, `this` fera référence à l'objet global --&gt;
+&lt;table id="my_table" onclick="logID();"&gt;&lt;!-- lorsqu'appelée, `this` fera référence à l'objet global --&gt;
   ...
-&lt;/table&gt;</pre>
+&lt;/table&gt;
+</pre>
 
-<p>La valeur de <code>this</code> à l'intérieur de <code>journaliserID</code> est une référence à l'objet global {{domxref("Window")}} (ou <code>undefined</code> dans le cas du <a href="https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Strict_mode">mode strict</a>).</p>
+<p>La valeur de <code>this</code> à l'intérieur de <code>logID</code> est une référence à l'objet global {{domxref("Window")}} (ou <code>undefined</code> dans le cas du <a href="/fr/docs/Web/JavaScript/Reference/Strict_mode">mode strict</a>).</p>
 
-<h4 id="Spécification_de_this_en_utilisant_bind">Spécification de "this" en utilisant bind()</h4>
+<h4 id="Specifying_this_using_bind">Spécification de "this" en utilisant bind()</h4>
 
 <p>La méthode {{jsxref("Function.prototype.bind()")}} vous permet de spécifier la valeur qui doit être utilisée comme <code>this</code> pour tous les appels à une fonction donnée. Cette méthode vous permet de contourner facilement les problèmes dans lesquels ce que <code>this</code> sera n'est pas clair, en fonction du contexte depuis lequel votre fonction a été appelée. Notez toutefois que vous aurez besoin de conserver quelque part une référence à l'écouteur, de façon à pouvoir le supprimer ultérieurement.</p>
 
 <p>Ceci est un exemple avec et sans <code>bind()</code> :</p>
 
-<pre class="brush: js line-numbers  language-js notranslate">var QuelqueChose = function(element) {
+<pre class="brush: js">
+var Something = function(element) {
   // |this| est un objet nouvellement créé
-  this.name = 'Quelque Chose de Bon';
-  this.onclick1 = function(evenement) {
-    console.log(this.name); // undefined, du fait que |this| est l'élément
+  this.name = 'Quelque chose de bon';
+  this.onclick1 = function(event) {
+    console.log(this.name); // undefined, car |this| est l'élément
   };
-  this.onclick2 = function(evenement) {
-    console.log(this.name); // 'Quelque Chose de Bon', du fait que |this| est lié à l'objet nouvellement créé
+  this.onclick2 = function(event) {
+    console.log(this.name); // 'Quelque chose de bon', car |this| est lié à l'objet nouvellement créé
   };
   element.addEventListener('click', this.onclick1, false);
   element.addEventListener('click', this.onclick2.bind(this), false); // Astuce
 }
-var q = new QuelqueChose(document.body);</pre>
+const s = new Something(document.body);
+</pre>
 
 <p>Une autre solution consiste à utiliser une fonction spéciale appelée <code>handleEvent()</code> to intercepter tous les évènements :</p>
 
-<pre class="brush: js notranslate">const QuelqueChose = function(element) {
+<pre class="brush: js">
+const Something = function(element) {
   // |this| est un objet nouvellement créé
-  this.name = 'Quelque Chose de Bon';
-  this.<code>handleEvent</code> = function(evenement) {
-    console.log(this.name); // 'Quelque Chose de Bon', du fait que this est lié à l'objet nouvellement créé
-    switch(evenement.type) {
+  this.name = 'Quelque chose de bon';
+  this.handleEvent = function(event) {
+    console.log(this.name); // "Quelque chose de bon", car |this| est lié à l'objet nouvellement créé.
+    switch(event.type) {
       case 'click':
         // un peu de code ici...
         break;
@@ -429,31 +500,32 @@ var q = new QuelqueChose(document.body);</pre>
     }
   };
 
-  // Notez que les écouteurs dans ce cas sont |this|, pas this.<code>handleEvent</code>
+  // Notez que les écouteurs dans ce cas sont |this|, et non this.handleEvent
   element.addEventListener('click', this, false);
   element.addEventListener('dblclick', this, false);
 
-  // Vous pouvez enlever correctement les écouteurs
+  // Vous pouvez retirer correctement les écouteurs
   element.removeEventListener('click', this, false);
   element.removeEventListener('dblclick', this, false);
 }
-const q = new QuelqueChose(document.body);
+const s = new Something(document.body);
 </pre>
 
 <p>Une autre manière de gérer la référence à <em>this</em> est de passer à l'<code>EventListener</code> une fonction qui appelle la méthode de l'objet qui contient les champs auxquels on a besoin d'accéder :</p>
 
-<pre class="brush: js notranslate">class UneClasse {
+<pre class="brush: js">
+class SomeClass {
 
   constructor() {
-    this.name = 'Quelque Chose de Bon';
+    this.name = 'Quelque chose de bon';
   }
 
-  enregistrer() {
-    const cela = this;
-    window.addEventListener('keydown', function(e) { cela.uneMethode(e); });
+  register() {
+    const that = this;
+    window.addEventListener('keydown', function(e) { that.someMethod(e); });
   }
 
-  uneMethode(e) {
+  someMethod(e) {
     console.log(this.name);
     switch(e.keyCode) {
       case 5:
@@ -467,107 +539,114 @@ const q = new QuelqueChose(document.body);
 
 }
 
-const monObjet = new UneClass();
-monObjet.enregistrer();</pre>
+const myObject = new SomeClass();
+myObject.register();
+</pre>
 
-<h3 id="Passer_des_données_à_et_depuis_un_écouteur_dévènements">Passer des données à et depuis un écouteur d'évènements</h3>
+<h3 id="Getting_data_into_and_out_of_an_event_listener">Passer des données à et depuis un écouteur d'évènements</h3>
 
-<p>On peut avoir l'impression que les écouteurs d'évènements sont comme des îles et qu'il est extrêmement difficile de leur passer des données quelconques, encore moins d'en récupérer après qu'ils ont été exécutés. Les écouteurs d'évènements ne prennent qu'un seul argument, l'<a href="https://wiki.developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#Event_objects">Event Object</a>, qui est passé automatiquement à l'écouteur, et la valeur retournée est ignorée. Donc à nouveau, comment pouvons-nous leur passer des données et en récupérer ? Il y a certain nombre de bonnes méthodes pour ce faire.</p>
+<p>On peut avoir l'impression que les écouteurs d'évènements sont comme des îles et qu'il est extrêmement difficile de leur passer des données quelconques, encore moins d'en récupérer après qu'ils ont été exécutés. Les écouteurs d'évènements ne prennent qu'un seul argument, l'<a href="/fr/docs/Learn/JavaScript/Building_blocks/Events#event_objects">Event Object</a>, qui est passé automatiquement à l'écouteur, et la valeur retournée est ignorée. Donc à nouveau, comment pouvons-nous leur passer des données et en récupérer ? Il y a certain nombre de bonnes méthodes pour ce faire.</p>
 
-<h4 id="Passer_des_données_à_un_écouteur_dévènement_en_utilisant_this">Passer des données à un écouteur d'évènement en utilisant "this"</h4>
+<h4 id="Getting_data_into_an_event_listener_using_this">Passer des données à un écouteur d'évènement en utilisant "this"</h4>
 
-<p>Comme mentionné <a href="https://wiki.developer.mozilla.org/fr/docs/Web/API/EventTarget/addEventListener$edit#Specifying_this_using_bind">ci-dessus</a>, vous pouvez utiliser <code>Function.prototype.bind()</code> pour passer une valeur à un écouteur d'évènements via la variable de référence <code>this</code>.</p>
+<p>Comme mentionné <a href="#specifying_this_using_bind">ci-dessus</a>, vous pouvez utiliser <code>Function.prototype.bind()</code> pour passer une valeur à un écouteur d'évènements via la variable de référence <code>this</code>.</p>
 
-<pre class="brush: js notranslate">const monBouton = document.getElementById('id-de-mon-bouton');
-const uneChaine = 'Données';
+<pre class="brush: js">
+const myButton = document.getElementById('my-button-id');
+const someString = 'Donnée';
 
-monButton.addEventListener('click', function () {
-  console.log(this);  // Valeur Attendue : 'Données'
-}.bind(uneChaine));
+myButton.addEventListener('click', function () {
+  console.log(this); // Valeur attendue : "Donnée".
+}.bind(someString));
 </pre>
 
 <p>Cette méthode est appropriée quand vous n'avez pas besoin de savoir sur quel élément HTML l'écouteur d'évènement a été déclenché par programme depuis l'intérieur de l'écouteur d'évènements. Le principal avantage de cette façon de faire est que l'écouteur d'évènements reçoit les données sensiblement de la même manière qu'il le ferait si vous les lui passiez au moyen de sa liste d'arguments.</p>
 
-<h4 id="Passer_des_données_à_un_écouteur_dévènements_en_utilisant_une_propriété_de_portée_externe">Passer des données à un écouteur d'évènements en utilisant une propriété de portée externe</h4>
+<h4 id="Getting_data_into_an_event_listener_using_the_outer_scope_property">Passer des données à un écouteur d'évènements en utilisant une propriété de portée externe</h4>
 
-<p>Quand une portée externe contient une déclaration de variable (avec <code>const</code>, <code>let</code>), toutes les fonctions internes déclarées dans cette portée ont accès à cette variable (voir <a href="https://wiki.developer.mozilla.org/fr-FR/docs/Glossary/Function#Different_types_of_functions">ici</a> pour des informations sur les fonctions externes/internes, et <a href="https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var#Implicit_globals_and_outer_function_scope">ici</a> pour des informations sur la portée des variables). Par conséquent, une des façons les plus simples pour accéder à des données depuis l'extérieur d'un écouteur d'évènements est de le rendre accessible dans la portée dans laquelle l'écouteur d'évènement est déclaré.</p>
+<p>Quand une portée externe contient une déclaration de variable (avec <code>const</code>, <code>let</code>), toutes les fonctions internes déclarées dans cette portée ont accès à cette variable (voir <a href="/fr/docs/Glossary/Function#different_types_of_functions">ici</a> pour des informations sur les fonctions externes/internes, et <a href="/fr/docs/Web/JavaScript/Reference/Statements/var#implicit_globals_and_outer_function_scope">ici</a> pour des informations sur la portée des variables). Par conséquent, une des façons les plus simples pour accéder à des données depuis l'extérieur d'un écouteur d'évènements est de le rendre accessible dans la portée dans laquelle l'écouteur d'évènement est déclaré.</p>
 
-<pre class="brush: js notranslate">const monButton = document.getElementById('id-de-mon-bouton');
-const uneChaine = 'Données';
+<pre class="brush: js">
+const myButton = document.getElementById('my-button-id');
+let someString = 'Donnée';
 
-monButton.addEventListener('click', function() {
-  console.log(uneChaine);  // Valeur Attendue : 'Données'
+myButton.addEventListener('click', function() {
+  console.log(someString);  // Valeur attendue : 'Donnée'
 
-  uneChaine = 'Encore des Données';
+  someString = 'Encore des données';
 });
 
-console.log(uneChaine);  // Valeur Attendue : 'Données' (ne produira jamais 'Encore des Données')
+console.log(someString);  // Valeur attendue : 'Donnée' (ne donnera jamais 'Encore des données')
 </pre>
 
-<div class="note">
+<div class="notecard note">
 <p><strong>Note :</strong> Bien que les portées internes aient accès aux variables <code>const</code> et <code>let</code> depuis les portées externes, vous ne pouvez pas vous attendre à ce que des changements quelconques de ces variables soient accessibles après la définition de l'écouteur d'évènements, à l'intérieur de la même portée externe. Pourquoi ? Simplement parce qu'au moment où l'écouteur d'évènements s'exécutera, la portée dans laquelle il a été défini pourra avoir déjà fini de s'exécuter.</p>
 </div>
 
-<h4 id="Passer_des_données_à_et_depuis_un_écouteur_dévènements_en_utilisant_des_objets">Passer des données à et depuis un écouteur d'évènements en utilisant des objets</h4>
+<h4 id="Getting_data_into_and_out_of_an_event_listener_using_objects">Passer des données à et depuis un écouteur d'évènements en utilisant des objets</h4>
 
 <p>A l'inverse de la plupart des fonctions en JavaScript, les objets sont conservés en mémoire aussi longtemps qu'une variable les référençant existe en mémoire. Ceci, et le fait que les objets peuvent avoir des propriétés, et qu'ils peuvent être passés alentour par référence, en fait des candidats plausibles pour partager des données entre les portées. Explorons cela.</p>
 
-<div class="note">
+<div class="notecard note">
 <p><strong>Note :</strong> les fonctions en JavaScript sont en fait des objets. (Par conséquent, elles aussi peuvent avoir des propriétés, et seront conservées en mémoire même après qu'elles ont fini de s'exécuter, si elles ont été affectées à une variable qui persiste en mémoire.)</p>
 </div>
 
 <p>Du fait que les propriétés d'un objet peuvent être utilisées pour stocker des données en mémoire aussi longtemps qu'une variable référençant l'objet existe en mémoire, vous pouvez en fait les utiliser pour passer des données dans un écouteur d'évènements, et retourner tous les changements aux données après que l'écouteur d'évènements s'est exécuté. Considérez cet exemple :</p>
 
-<pre class="brush: js notranslate">const monBouton = document.getElementById('id-de-mon-bouton');
-const unObjet = {unePropriete: 'Données'};
+<pre class="brush: js">
+const myButton = document.getElementById('my-button-id');
+const someObject = {aProperty: 'Donnée'};
 
-monButton.addEventListener('click', function() {
-  console.log(unObjet.unePropriete);  // Valeur Attendue : 'Données'
+myButton.addEventListener('click', function() {
+  console.log(someObject.aProperty);  // Valeur attendue : "Donnée".
 
-  unObjet.unePropriete = 'Encore des Données';  // Changer la valeur
+  someObject.aProperty = 'Encore des données';  // Modifie la valeur
 });
 
 window.setInterval(function() {
-  if (unObjet.unePropriete === 'Encore des Données') {
-    console.log('Encore des Données: Vrai');
-    unObjet.unePropriete = 'Données';  // Réinitialiser la valeur pour attendre la prochaine exécution de l'évènement
+  if (someObject.aProperty === 'Encore des données') {
+    console.log('Encore des données : Vrai');
+    someObject.aProperty = 'Donnée';  // Rétablit la valeur pour attendre l'exécution du prochain événement
   }
 }, 5000);
 </pre>
 
 <p>Dans cet exemple, même si la portée dans laquelle à la fois l'écouteur d'évènements et la fonction d'intervalle ont été définis a fini de s'exécuter avant que la valeur originale de <code>unObjet.unePropriete</code> ait changé, du fait que <code>someObject</code> persiste en mémoire (par <em>référence</em>) à la fois dans l'écouteur d'évènements et dans la fonction d'intervalle, tous deux ont accès aux mêmes données (i.e. quand l'un change les données, l'autre peut répondre aux changements).</p>
 
-<div class="note">
-<p><strong>Note :</strong> les objets sont stockés dans les variables par référence, ce qui signifie que seul l'emplacement en mémoire des données elles-mêmes est stocké dans la variable. Entre autres choses, cela signifie que les variables qui "stockent" des objets peuvent en fait affecter d'autres variables qui se voient affecter ("stocker") la même référence d'objet. Quand deux variables référencent le même objet (par ex., <code>let a = b = {unePropriete: 'Ouais'};</code>), le fait de changer les données dans l'une ou l'autre des variables affectera l'autre.</p>
+<div class="notecard note">
+  <p><strong>Note :</strong> les objets sont stockés dans les variables par référence, ce qui signifie que seul l'emplacement en mémoire des données elles-mêmes est stocké dans la variable. Entre autres choses, cela signifie que les variables qui "stockent" des objets peuvent en fait affecter d'autres variables qui se voient affecter ("stocker") la même référence d'objet. Quand deux variables référencent le même objet (par ex., <code>let a = b = {aProperty: 'Ouai'};</code>), le fait de changer les données dans l'une ou l'autre des variables affectera l'autre.</p>
 </div>
 
-<div class="note">
-<p><strong>Note :</strong> du fait que les objets sont stockés dans les variables par référence, vous pouvez retourner un objet depuis une fonction pour le maintenir en vie (le conserver en mémoire, de sorte que vous n'en perdiez pas les données) après que cette fonction a fini de s'exécuter.</p>
+<div class="notecard note">
+  <p><strong>Note :</strong> du fait que les objets sont stockés dans les variables par référence, vous pouvez retourner un objet depuis une fonction pour le maintenir en vie (le conserver en mémoire, de sorte que vous n'en perdiez pas les données) après que cette fonction a fini de s'exécuter.</p>
 </div>
 
-<h3 id="Héritage_Internet_Explorer_et_attachEvent">  Héritage Internet Explorer et attachEvent</h3>
+<h3 id="Legacy_Internet_Explorer_and_attachEvent">Héritage Internet Explorer et attachEvent</h3>
 
-<p>Dans les versions Internet Explorer versions avant IE 9, vous deviez utiliser {{domxref("EventTarget.attachEvent", "attachEvent()")}}, plutôt que la méthode standard <code>addEventListener</code>. Pour IE, nous modifions l'exemple précédent en :</p>
+<p>Dans les versions Internet Explorer versions avant IE 9, vous deviez utiliser {{domxref("EventTarget.attachEvent", "attachEvent()")}}, plutôt que la méthode standard <code>addEventListener</code>. Pour IE, nous modifions l'exemple précédent en :</p>
 
-<pre class="brush: js line-numbers  language-js notranslate">if (el.addEventListener) {
+<pre class="brush: js">
+if (el.addEventListener) {
   el.addEventListener('click', modifierTexte, false);
 } else if (el.attachEvent)  {
   el.attachEvent('onclick', modifierTexte);
-}</pre>
+}
+</pre>
 
 <p>Il y a un inconvénient avec <code>attachEvent</code> : la valeur de <code>this</code> sera une référence à l'objet <code>window</code>, au lieu de l'élément sur lequel il a été déclenché.</p>
 
 <p>La méthode <code>attachEvent()</code> peut être couplée avec l'évènement <code>onresize</code> pour détecter que certains éléments dans une page web ont été redimensionnés. L'évènement propriétaire <code>mselementresize</code>, lorsqu'il est couplé avec la méthode <code>addEventListener</code> d'enregistrement des gestionnaires d'évènements, fournit une fonctionnalité similaire à celle de <code>onresize</code>, se déclenchant quand certains éléments HTML sont redimensionnés.</p>
 
-<h3 id="Émulation">Émulation</h3>
+<h3 id="Polyfill">Prothèse d'émulation</h3>
 
 <p>Vous pouvez contourner le fait que <code>addEventListener()</code>, <code>removeEventListener()</code>, {{domxref("Event.preventDefault()")}} et {{domxref("Event.stopPropagation()")}} ne sont pas pris en charge par IE 8 en utilisant le code suivant au début de votre script. Le code prend en charge l'utilisation de <code>handleEvent()</code>, et aussi l'évènement {{event("DOMContentLoaded")}}.</p>
 
-<div class="note">
-<p><strong>Note : </strong><code>useCapture</code> n'est pas pris en charge, du fait qu'IE 8 n'a aucune méthode alternative. Le code suivant ajoute seulement la prise en charge d'IE 8. Cette émulation pour IE 8 fonctionne uniquement en mode standard : une déclaration <code>doctype</code> est requise.</p>
+<div class="cardnote note">
+  <p><strong>Note :</strong> <code>useCapture</code> n'est pas pris en charge, du fait qu'IE 8 n'a aucune méthode alternative. Le code suivant ajoute seulement la prise en charge d'IE 8. Cette émulation pour IE 8 fonctionne uniquement en mode standard : une déclaration <code>doctype</code> est requise.</p>
 </div>
 
-<pre class="brush: js line-numbers  language-js notranslate">(function() {
+<pre class="brush: js">
+(function() {
   if (!Event.prototype.preventDefault) {
     Event.prototype.preventDefault=function() {
       this.returnValue=false;
@@ -638,14 +717,16 @@ window.setInterval(function() {
       Window.prototype.removeEventListener=removeEventListener;
     }
   }
-})();</pre>
+})();
+</pre>
 
-<h3 id="Ancienne_manière_denregistrer_les_écouteurs_dévènements">Ancienne manière d'enregistrer les écouteurs d'évènements</h3>
+<h3 id="Older_way_to_register_event_listeners">Ancienne manière d'enregistrer les écouteurs d'évènements</h3>
 
-<p>La méthode <code>addEventListener()</code> a été ajoutée dans la spécification DOM 2 <a class="external" href="http://www.w3.org/TR/DOM-Level-2-Events">Events</a>. Avant cela, les écouteurs d'évènements étaient enregistrés de la manière suivante :</p>
+<p>La méthode <code>addEventListener()</code> a été ajoutée dans la spécification DOM 2 <a class="external" href="http://www.w3.org/TR/DOM-Level-2-Events">Events</a>. Avant cela, les écouteurs d'évènements étaient enregistrés de la manière suivante :</p>
 
-<pre class="notranslate">// Passage d'une référence à une fonction — ne pas ajouter de '()' après, cela appelerait la fonction !
-el.onclick = modifierTexte;
+<pre class="brush: js">
+// Passage d'une référence à une fonction — ne pas ajouter de '()' après, cela appelerait la fonction !
+el.onclick = modifyText;
 
 // Utilisation d'une fonction directe
 element.onclick = function() {
@@ -653,64 +734,68 @@ element.onclick = function() {
 };
 </pre>
 
-<p>Cette méthode remplace l'(les)écouteur(s) d'évènements <code>click</code> existant(s) de l'élément s'il y en a. D'autres évènements et leurs gestionnaires d'évènements associés comme <code>blur</code> (<code>onblur</code>), et  <code>keypress</code> ( <code>onkeypress</code>) se comportent de façon similaire.</p>
+<p>Cette méthode remplace l'(les) écouteur(s) d'évènements <code>click</code> existant(s) de l'élément s'il y en a. D'autres évènements et leurs gestionnaires d'évènements associés comme <code>blur</code> (<code>onblur</code>), et  <code>keypress</code> ( <code>onkeypress</code>) se comportent de façon similaire.</p>
 
 <p>Comme elle faisait partie de façon fondamentale du DOM 0, cette méthode est très largement prise en charge et ne nécessite aucun code multi-navigateur. C'est pourquoi elle est souvent utilisée pour enregistrer des évènements dynamiquement quand de très anciens navigateurs (comme IE &lt;=8) doivent être pris en charge ; voir la table plus bas pour les détails de la prise en charge par les navigateurs pour <code>addEventListener</code>.</p>
 
-<h3 id="Problèmes_de_mémoire">Problèmes de mémoire</h3>
+<h3 id="Memory_issues">Problèmes de mémoire</h3>
 
-<pre class="brush: js line-numbers  language-js notranslate">var i;
+<pre class="brush: js">
+var i;
 var els = document.getElementsByTagName('*');
 
 // Cas 1
-for(i=0 ; i&lt;els.length ; i++){
+for (i=0 ; i&lt;els.length ; i++) {
   els[i].addEventListener("click", function(e){/*faire quelque chose*/}, false);
 }
 
 // Cas 2
-function traiterEvenement(e){
+function processEvent(e) {
   /* faire quelque chose */
 }
 
-for(i=0 ; i&lt;els.length ; i++){
-  els[i].addEventListener("click", traiterEvenement, false);
-}</pre>
+for (i=0 ; i&lt;els.length ; i++) {
+  els[i].addEventListener("click", processEvent, false);
+}
+</pre>
 
-<p>Dans le premier cas ci-dessus, une nouvelle fonction gestionnaire (anonyme) est créée à chaque itération de la boucle. Dans le second cas, la même fonction déclarée préalablement est utilisée comme gestionnaire d'évènements. Cela entraîne une consommation de mémoire réduite. De plus, dans le premier cas, il n'est pas possible d'appeler {{domxref("EventTarget.removeEventListener", "removeEventListener()")}} du fait qu'aucune référence à la fonction anonyme n'est conservée (ou ici, n'est conservée aucune des multiples fonctions anonymes que la boucle peut créer). Dans le second cas, il est possible de faire <code>monElement.removeEventListener("click", traiterEvenement, false)</code> du fait que <code>traiterEvenement</code> est la référence à la fonction.</p>
+<p>Dans le premier cas ci-dessus, une nouvelle fonction gestionnaire (anonyme) est créée à chaque itération de la boucle. Dans le second cas, la même fonction déclarée préalablement est utilisée comme gestionnaire d'évènements. Cela entraîne une consommation de mémoire réduite. De plus, dans le premier cas, il n'est pas possible d'appeler {{domxref("EventTarget.removeEventListener", "removeEventListener()")}} du fait qu'aucune référence à la fonction anonyme n'est conservée (ou ici, n'est conservée aucune des multiples fonctions anonymes que la boucle peut créer). Dans le second cas, il est possible de faire <code>myElement.removeEventListener("click", processEvent, false)</code> du fait que <code>processEvent</code> est la référence à la fonction.</p>
 
 <p>En fait, en ce qui concerne la consommation de mémoire, l'absence de conservation d'une référence à la fonction n'est pas le problème réel ; c'est plutôt l'absence de conservation d'une référence STATIQUE à la fonction. Dans les deux cas à problème ci-dessous, une référence à la fonction est conservée, mais du fait qu'elle est redéfinie à chaque itération, elle n'est pas statique. Dans le troisème cas, la référence à la fonction anonyme est réaffectée à chaque itération. Dans le quatrième cas, la définition entière de la fonction est inchangée, mais elle est néanmoins répétitivement définie comme si elle était nouvelle (à moins qu'elle n'ait été [[promue]] par le compilateur), et elle n'est donc pas statique. Par conséquent, bien qu'il ne semble y avoir simplement que des [[Multiple identical event listeners]], dans les deux cas, chaque itération créera à la place un nouvel écouteur avec sa propre unique référence à la fonction gestionnaire. Cependant, du fait que la définition de la fonction elle-même ne change pas, la MÊME fonction peut toujours être appelée pour chaque écouteur dupliqué (spécialement si le code est optimisé.)</p>
 
 <p>Également dans les deux cas, du fait que la référence à la fonction e été conservée mais est répétitivement redéfinie par chaque ajout, l'instruction 'remove' ci-dessus peut toujours supprimer un écouteur, mais seulement le dernier ajouté.</p>
 
-<pre class="brush: js notranslate">// Pour illustration seulement : notez la "FAUTE" de [j] au lieu de [i] entrainant ainsi que les évènements voulus sont tous enregistrés pour le MÊME élément
+<pre class="brush: js">
+// Pour illustration seulement : notez la "FAUTE" de [j] au lieu de [i] entrainant ainsi que les évènements voulus sont tous enregistrés pour le MÊME élément
 
 // Cas 3
-for(let i=0, j=0 ; i&lt;els.length ; i++){
+for (let i=0, j=0 ; i&lt;els.length ; i++) {
   /* faire des tas de choses avec j */
-  els[j].addEventListener("click", traiterEvenement = function(e){/*faire quelque chose*/}, false);
+  els[j].addEventListener("click", processEvent = function(e) {/*faire quelque chose*/}, false);
 }
 
 // Cas 4
-for(let i=0, j=0 ; i&lt;els.length ; i++){
+for (let i=0, j=0 ; i&lt;els.length ; i++) {
   /* faire des tas de choses avec  j */
-  function traiterEvenement(e){/*faire quelque chose*/};
-  els[j].addEventListener("click", traiterEvenement, false);
+  function processEvent(e) {/*faire quelque chose*/};
+  els[j].addEventListener("click", processEvent, false);
 }</pre>
 
-<h3 id="Amélioration_des_performances_de_défilement_avec_les_écouteurs_passifs">Amélioration des performances de défilement avec les écouteurs passifs</h3>
+<h3 id="Improving_scrolling_performance_with_passive_listeners">Amélioration des performances de défilement avec les écouteurs passifs</h3>
 
 <p>D'après la spécification, la valeur par défaut pour l'option <code>passive</code> est toujours <code>false</code> (<em>faux</em>). Toutefois, cela introduit la possibilité que des écouteurs d'évènements gérant certains évènements tactiles (parmi d'autres) bloquent le fil d'exécution principal du navigateur pendant qu'il essaye de gérer le défilement, avec pour résultat une possiblement énorme réduction de performance pendant la gestion du défilement.</p>
 
 <p>Pour prévenir ce problème, certains navigateurs (spécifiquement, Chrome et Firefox) ont changé la valeur par défault de l'option <code>passive</code> à <code>true</code> pour les évènements {{event("touchstart")}} et {{event("touchmove")}} dans les nœuds de niveau document {{domxref("Window")}}, {{domxref("Document")}}, et {{domxref("Document.body")}}. Cela empêche que l'écouteur d'évènement ne soit appelé, de sorte qu'il ne peut pas bloquer le rendu de la page pendant que l'utilisateur fait un défilement.</p>
 
-<div class="note">
-<p><strong>Note :</strong> voir la table de compatibilité ci-dessous si vous avez besoin de savoir quels navigateurs (et/ou quelles versions de ces navigateurs) implémentent ce comportement modifié.</p>
+<div class="notecard note">
+  <p><strong>Note :</strong> voir la table de compatibilité ci-dessous si vous avez besoin de savoir quels navigateurs (et/ou quelles versions de ces navigateurs) implémentent ce comportement modifié.</p>
 </div>
 
 <p>Vous pouvez passer outre ce comportement en initialisant explicitement la valeur de <code>passive</code> à <code>false</code>, comme montré ci-dessous :</p>
 
-<pre class="brush: js notranslate">/* Détection de fonctionnalité */
-let passiveSiSupportee = false;
+<pre class="brush: js">
+/* Détection de la fonctionnalité */
+let passiveIfSupported = false;
 
 try {
   window.addEventListener("test", null,
@@ -718,58 +803,59 @@ try {
       {},
       "passive",
       {
-        get: function() { passiveSiSupportee = { passive: false }; }
+        get: function() { passiveIfSupported = { passive: true }; }
       }
     )
   );
 } catch(err) {}
 
-window.addEventListener('scroll', function(evenement) {
+window.addEventListener('scroll', function(event) {
   /* faire quelque chose */
-  // pas possible d'utiliser evenement.preventDefault();
-}, passiveSiSupportee );</pre>
+  // ne peut pas utiliser event.preventDefault();
+}, passiveIfSupported );
+</pre>
 
-<p>Dans les navigateurs anciens qui ne prennent pas en charge le paramètre <code>options</code> d'<code>addEventListener()</code>, le fait d'essayer de l'utiliser empêche l'utilisation de l'argument <code>useCapture</code> sans utilisation appropriée de la <a href="https://wiki.developer.mozilla.org/fr/docs/Web/API/EventTarget/addEventListener$edit#Safely_detecting_option_support">détection de fonctionnalité</a>.</p>
+<p>Dans les navigateurs anciens qui ne prennent pas en charge le paramètre <code>options</code> d'<code>addEventListener()</code>, le fait d'essayer de l'utiliser empêche l'utilisation de l'argument <code>useCapture</code> sans utilisation appropriée de la <a href="#safely_detecting_option_support">détection de fonctionnalité</a>.</p>
 
 <p>Vous n'avez pas besoin de vous inquiéter de la valeur de <code>passive</code> pour l'évènement {{event("scroll")}} de base. Du fait qu'il ne peut pas être annulé, les écouteurs d'évènements ne peuvant pas bloquer le rendu de la page de toute façon.</p>
 
-<h2 id="Spécifications">Spécifications</h2>
+<h2 id="Specifications">Spécifications</h2>
 
 <table class="standard-table">
- <tbody>
-  <tr>
-   <th>Spécification</th>
-   <th>Statut</th>
-   <th>Commentaire</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM WHATWG", "#dom-eventtarget-addeventlistener", "EventTarget.addEventListener()")}}</td>
-   <td>{{Spec2("DOM WHATWG")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM4", "#dom-eventtarget-addeventlistener", "EventTarget.addEventListener()")}}</td>
-   <td>{{Spec2("DOM4")}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM2 Events", "#Events-EventTarget-addEventListener", "EventTarget.addEventListener()")}}</td>
-   <td>{{Spec2("DOM2 Events")}}</td>
-   <td>Définition initiale.</td>
-  </tr>
- </tbody>
+  <thead>
+    <tr>
+      <th>Spécification</th>
+      <th>Statut</th>
+      <th>Commentaire</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{SpecName("DOM WHATWG", "#dom-eventtarget-addeventlistener", "EventTarget.addEventListener()")}}</td>
+      <td>{{Spec2("DOM WHATWG")}}</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>{{SpecName("DOM4", "#dom-eventtarget-addeventlistener", "EventTarget.addEventListener()")}}</td>
+      <td>{{Spec2("DOM4")}}</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>{{SpecName("DOM2 Events", "#Events-EventTarget-addEventListener", "EventTarget.addEventListener()")}}</td>
+      <td>{{Spec2("DOM2 Events")}}</td>
+      <td>Définition initiale.</td>
+    </tr>
+  </tbody>
 </table>
 
-<h2 id="Compatibilité_des_navigateurs">Compatibilité des navigateurs</h2>
-
-<div class="hidden">La table de compatibilité de cette page est générée à partir de données structurées. Si vous souhaitez contribuer aux données, visitez <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> et envoyez nous une "pull request".</div>
+<h2 id="Browser_compatibility">Compatibilité des navigateurs</h2>
 
 <p>{{Compat("api.EventTarget.addEventListener", 3)}}</p>
 
-<h2 id="Voir_aussi">Voir aussi</h2>
+<h2 id="See_also">Voir aussi</h2>
 
 <ul>
- <li>{{domxref("EventTarget.removeEventListener()")}}</li>
- <li><a href="https://developer.mozilla.org/fr/docs/Web/Guide/DOM/Events/Creating_and_triggering_events">Création et déclenchement d'évènements personnalisés</a></li>
- <li><a href="http://www.quirksmode.org/js/this.html">Plus de détails sur l'utilisation de <code>this</code> dans les gestionnaires d'évènements</a></li>
+  <li>{{domxref("EventTarget.removeEventListener()")}}</li>
+  <li><a href="/fr/docs/Web/Guide/Events/Creating_and_triggering_events">Création et déclenchement d'événements</a></li>
+  <li><a href="http://www.quirksmode.org/js/this.html">Plus de détails sur l'utilisation de <code>this</code> dans les gestionnaires d'évènements</a></li>
 </ul>


### PR DESCRIPTION
### Related issues
#180 Broken examples in the addEventListener() page
### Observed issues
All examples on the page did not work due to the translation of the texts in the `id` attributes. Many elements are also not up to date from a visual or textual point of view. Some elements that should not be translated have been translated.

### Changes in commits
- Correction of example blocks
- Rewriting the elements that should be in English: function names (js blocks), variable names (js blocks), anchor `id`s in HTML, and other things in the examples
- Rewriting of some texts to change the wording
- Corrected many incorrect links and shortened internal links