### PR TITLE
Fix direction of text in the JS example

### DIFF
--- a/files/ru/web/api/document/readystate/index.html
+++ b/files/ru/web/api/document/readystate/index.html
@@ -37,7 +37,7 @@ translation_of: Web/API/Document/readyState
 
 <h3 id="Разные_состояния_загрузки_страницы">Разные состояния загрузки страницы</h3>
 
-<pre class="brush: js notranslate" dir="rtl"><span>switch (document.readyState) {
+<pre class="brush: js notranslate"><span>switch (document.readyState) {
   case "loading":
     // Страница все еще загружается
     break;


### PR DESCRIPTION
Fixes #198: right-to-left text in the JS example in https://developer.mozilla.org/ru/docs/Web/API/Document/readyState.

ps. This is literally the first time I’m doing this so please feel free to let me know if there’s anything I should keep in mind next time.