### PR TITLE
Fix: incorrect use atribute dir in code exemple

### DIFF
--- a/files/pt-br/web/api/element/classlist/index.html
+++ b/files/pt-br/web/api/element/classlist/index.html
@@ -34,7 +34,7 @@ translation_of: Web/API/Element/classList
 
 <h2 id="Exemplos">Exemplos</h2>
 
-<pre class="brush: js" dir="rtl">// div é uma referência de objeto para um elemento &lt;div&gt; com class = "foo bar"
+<pre class="brush: js" >// div é uma referência de objeto para um elemento &lt;div&gt; com class = "foo bar"
 div.classList.remove("foo");
 div.classList.add("anotherclass");
 


### PR DESCRIPTION
The exemple code has atribute `dir=rtl`, but it's worn becose text write correct is `dir=ltr`

I remove this atribute to fix direction to writer

Error printscreen:
![image](https://user-images.githubusercontent.com/16208496/111641205-afaefb00-87db-11eb-8bef-9054631b4876.png)
