### PR TITLE
Add ja translation of the HTML Portal element

### DIFF
--- a/files/ja/web/html/element/portal/index.html
+++ b/files/ja/web/html/element/portal/index.html
@@ -1,0 +1,85 @@
+---
+title: '<portal>: The Portal element'
+slug: Web/HTML/Element/portal
+tags:
+  - Content
+  - Element
+  - Embedded content
+  - Embedding
+  - HTML
+  - HTML embedded content
+  - Reference
+  - Web
+  - Portal
+---
+<div>{{HTMLRef}}</div>
+
+<p><span class="seoSummary">The <strong>HTML Portal element (<code>&lt;portal&gt;</code>)</strong> enables the embedding of another HTML page into the current one for the purposes of allowing smoother navigation into new pages.</span></p>
+
+<p>A <code>&lt;portal&gt;</code> is similar to an <code>&lt;iframe&gt;</code>. An <code>&lt;iframe&gt;</code> allows a separate {{Glossary("browsing context")}} to be embedded. However, the embedded content of a <code>&lt;portal&gt;</code> is more limited than that of an <code>&lt;iframe&gt;</code>. It cannot be interacted with, and therefore is not suitable for embedding widgets into a document. Instead, the <code>&lt;portal&gt;</code> acts as a preview of the content of another page. It can be navigated into therefore allowing for seamless transition to the embedded content.</p>
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Implicit ARIA role</th>
+      <td><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/button_role">button</a></td>
+    </tr>
+    <tr>
+      <th scope="row">DOM interface</th>
+      <td>{{domxref("HTMLPortalElement")}}</td>
+     </tr>
+  </tbody>
+</table>
+   
+<h2 id="Attributes">Attributes</h2>
+
+<p>This element includes the <a href="/en-US/docs/Web/HTML/Global_attributes">global attributes</a>.</p>
+
+<dl>
+  <dt id="attr-referrer">{{htmlattrdef("referrerpolicy")}}</dt>
+  <dd>Sets the <a href="/en-US/docs/Web/HTTP/Headers/Referrer-Policy">referrer policy</a> to use when requesting the page at the URL given as the value of the <code>src</code> attribute. 
+  </dd>
+  <dt id="attr-src">{{htmlattrdef("src")}}</dt>
+  <dd>The URL of the page to embed.</dd>
+</dl>
+
+<h2 id="Examples">Examples</h2>
+
+<h3>Basic example</h3>
+
+<p>The following example will embed the contents of <code>https://example.com</code> as a preview.</p>
+
+<pre class="brush:html">&lt;portal id="exampleportal" src="https://example.com/"&gt;&lt;/portal&gt;</pre>
+
+<h2 id="Accessibility_concerns">Accessibility concerns</h2>
+
+<p>The preview displayed by a <code>&lt;portal&gt;</code> is not interactive, therefore does not receive input events or focus. Therefore the embedded contents of the portal are not exposed as elements in the {{Glossary("accessibility tree")}}. The portal can be navigated to and activated like a button, the default behavior when clicking on the portal is to activate it.</p>
+
+<p>Portals are given a default label which is the title of the embedded page. If no title is present the visible text in the preview is concatenated to create a label. The {{htmlattrxref("aria-label")}} attribute can be used to override this.</p>
+
+<p>Portals used for prerendering only should be hidden with the hidden HTML attribute or the CSS {{cssxref("display")}} property with a value of <code>none</code>.</p>
+
+<p>When using animations during portal activation the {{cssxref("@media/prefers-reduced-motion", "prefers-reduced-motion")}} <a href="/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#Media_features">media feature</a> should be respected.</p>
+
+<h2 id="Specifications">Specifications</h2>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+ </thead>
+ <tbody>
+   <tr>
+   <td>{{SpecName('Portals')}}</td>
+   <td>{{Spec2('Portals')}}</td>
+   <td>Initial definition.</td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("html.elements.portal")}}</p>

--- a/files/ja/web/html/element/portal/index.html
+++ b/files/ja/web/html/element/portal/index.html
@@ -1,5 +1,5 @@
 ---
-title: '<portal>: The Portal element'
+title: '<portal>: ポータル要素'
 slug: Web/HTML/Element/portal
 tags:
   - Content
@@ -11,75 +11,76 @@ tags:
   - Reference
   - Web
   - Portal
+translation_of: Web/HTML/Element/portal
 ---
 <div>{{HTMLRef}}</div>
 
-<p><span class="seoSummary">The <strong>HTML Portal element (<code>&lt;portal&gt;</code>)</strong> enables the embedding of another HTML page into the current one for the purposes of allowing smoother navigation into new pages.</span></p>
+<p><span class="seoSummary"><strong>HTML のポータル要素 (<code>&lt;portal&gt;</code>)</strong> は、他の HTML ページを現在のページに埋め込み、新しいページへの移動がスムーズにできるようにします。</span></p>
 
-<p>A <code>&lt;portal&gt;</code> is similar to an <code>&lt;iframe&gt;</code>. An <code>&lt;iframe&gt;</code> allows a separate {{Glossary("browsing context")}} to be embedded. However, the embedded content of a <code>&lt;portal&gt;</code> is more limited than that of an <code>&lt;iframe&gt;</code>. It cannot be interacted with, and therefore is not suitable for embedding widgets into a document. Instead, the <code>&lt;portal&gt;</code> acts as a preview of the content of another page. It can be navigated into therefore allowing for seamless transition to the embedded content.</p>
+<p><code>&lt;portal&gt;</code> は <code>&lt;iframe&gt;</code> に似ています。 <code>&lt;iframe&gt;</code> では独立した{{Glossary("browsing context", "閲覧コンテキスト")}}を作成して埋め込みます。しかし、 <code>&lt;portal&gt;</code> で埋め込まれるコンテンツは <code>&lt;iframe&gt;</code> の場合よりも制限されます。これを操作することはできませんので、文書にウィジェットを埋め込むには適していません。その代わり、 <code>&lt;portal&gt;</code> は他のページのコンテンツのプレビューとして動作します。そのため、埋め込まれたコンテンツへのシームレスな遷移により移動を行うことができます。</p>
 
 <table class="properties">
   <tbody>
     <tr>
-      <th scope="row">Implicit ARIA role</th>
+      <th scope="row">暗黙の ARIA ロール</th>
       <td><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/button_role">button</a></td>
     </tr>
     <tr>
-      <th scope="row">DOM interface</th>
+      <th scope="row">DOM インターフェイス</th>
       <td>{{domxref("HTMLPortalElement")}}</td>
      </tr>
   </tbody>
 </table>
    
-<h2 id="Attributes">Attributes</h2>
+<h2 id="Attributes">属性</h2>
 
-<p>This element includes the <a href="/en-US/docs/Web/HTML/Global_attributes">global attributes</a>.</p>
+<p>この要素には<a href="/ja/docs/Web/HTML/Global_attributes">グローバル属性</a>があります。</p>
 
 <dl>
   <dt id="attr-referrer">{{htmlattrdef("referrerpolicy")}}</dt>
-  <dd>Sets the <a href="/en-US/docs/Web/HTTP/Headers/Referrer-Policy">referrer policy</a> to use when requesting the page at the URL given as the value of the <code>src</code> attribute. 
+  <dd><a href="/ja/docs/Web/HTTP/Headers/Referrer-Policy">リファラーポリシー</a>を設定します。これは、 <code>src</code> 属性の値で指定された URL のページをリクエストする際に使用されます。
   </dd>
   <dt id="attr-src">{{htmlattrdef("src")}}</dt>
-  <dd>The URL of the page to embed.</dd>
+  <dd>埋め込むページの URL です。</dd>
 </dl>
 
-<h2 id="Examples">Examples</h2>
+<h2 id="Examples">例</h2>
 
-<h3>Basic example</h3>
+<h3>基本的な例</h3>
 
-<p>The following example will embed the contents of <code>https://example.com</code> as a preview.</p>
+<p>以下の例は <code>https://example.com</code> のコンテンツをプレビューとして埋め込みます。</p>
 
 <pre class="brush:html">&lt;portal id="exampleportal" src="https://example.com/"&gt;&lt;/portal&gt;</pre>
 
-<h2 id="Accessibility_concerns">Accessibility concerns</h2>
+<h2 id="Accessibility_concerns">アクセシビリティの考慮</h2>
 
-<p>The preview displayed by a <code>&lt;portal&gt;</code> is not interactive, therefore does not receive input events or focus. Therefore the embedded contents of the portal are not exposed as elements in the {{Glossary("accessibility tree")}}. The portal can be navigated to and activated like a button, the default behavior when clicking on the portal is to activate it.</p>
+<p><code>&lt;portal&gt;</code>が表示するプレビューは、操作が可能ではないため、入力イベントやフォーカスを受けません。そのため、ポータルの埋め込みコンテンツは、{{Glossary("accessibility tree", "アクセシビリティツリー")}}の要素として公開されません。ポータルは、ボタンのように移動してアクティブにすることができ、クリックしたときの既定の動作は、ポータルを有効にすることです。</p>
 
-<p>Portals are given a default label which is the title of the embedded page. If no title is present the visible text in the preview is concatenated to create a label. The {{htmlattrxref("aria-label")}} attribute can be used to override this.</p>
+<p>ポータルには、埋め込まれたページのタイトルが既定のラベルが与えられます。タイトルがない場合は、プレビューで表示されるテキストが結合されてラベルが作成されます。 {{htmlattrxref("aria-label")}} 属性を使用すると、これを上書きすることができます。</p>
 
-<p>Portals used for prerendering only should be hidden with the hidden HTML attribute or the CSS {{cssxref("display")}} property with a value of <code>none</code>.</p>
+<p>事前レンダリングのためにポータルを使用する場合は、 HTML の hidden 属性または CSS の {{cssxref("display")}} プロパティの値を <code>none</code> にして非表示にしてください。</p>
 
-<p>When using animations during portal activation the {{cssxref("@media/prefers-reduced-motion", "prefers-reduced-motion")}} <a href="/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#Media_features">media feature</a> should be respected.</p>
+<p>ポータルがアクティブ化している間にアニメーションを使用する場合は、 {{cssxref("@media/prefers-reduced-motion", "prefers-reduced-motion")}} <a href="/ja/docs/Web/CSS/Media_Queries/Using_media_queries#Media_features">メディア特性</a>を尊重してください。</p>
 
-<h2 id="Specifications">Specifications</h2>
+<h2 id="Specifications">仕様書</h2>
 
 <table class="standard-table">
  <thead>
   <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
+   <th scope="col">仕様書</th>
+   <th scope="col">状態</th>
+   <th scope="col">備考</th>
   </tr>
  </thead>
  <tbody>
    <tr>
    <td>{{SpecName('Portals')}}</td>
    <td>{{Spec2('Portals')}}</td>
-   <td>Initial definition.</td>
+   <td>初回定義</td>
   </tr>
  </tbody>
 </table>
 
-<h2 id="Browser_compatibility">Browser compatibility</h2>
+<h2 id="Browser_compatibility">ブラウザーの互換性</h2>
 
 <p>{{Compat("html.elements.portal")}}</p>


### PR DESCRIPTION
translated based on 2020-01-22 version in en-us
fix https://github.com/mozilla-japan/translation/issues/541