### PR TITLE
Web/API/IntersectionObserver/IntersectionObserverの翻訳修正

### DIFF
--- a/files/ja/web/api/intersectionobserver/intersectionobserver/index.html
+++ b/files/ja/web/api/intersectionobserver/intersectionobserver/index.html
@@ -26,7 +26,7 @@ translation_of: Web/API/IntersectionObserver/IntersectionObserver
  <dd>対象の要素が見えている割合が、表示されて閾値を越えたときに実行します。コールバックは 2 つの引数を受け取ります。
  <dl>
   <dt><code>entries</code></dt>
-  <dd>{{domxref("IntersectionObserverEntry")}} オブジェクトの配列で、それぞれの要素がしきい値となります。これは、見えている割合が下から上に、または上から下にその値を越える時に callback が呼ばれるよう指定するものです。</dd>
+  <dd>{{domxref("IntersectionObserverEntry")}} オブジェクトの配列で、それぞれの要素が閾値となります。これは、見えている割合が下から上に、または上から下にその値を越える時に callback が呼ばれるよう指定するものです。</dd>
   <dt><code>observer</code></dt>
   <dd>コールバックが呼び出される {{domxref("IntersectionObserver")}} です。</dd>
  </dl>

--- a/files/ja/web/api/intersectionobserver/intersectionobserver/index.html
+++ b/files/ja/web/api/intersectionobserver/intersectionobserver/index.html
@@ -13,7 +13,7 @@ translation_of: Web/API/IntersectionObserver/IntersectionObserver
 ---
 <div>{{APIRef("Intersection Observer API")}}</div>
 
-<p><span class="seoSummary"><strong><code>IntersectionObserver()</code></strong> コンストラクタは、新しい {{domxref("IntersectionObserver")}} オブジェクトを生成します。</span> <code>rootMargin</code> は、指定されていた場合は構文が正しいかが確認され、閾値は、0.0 から 1.0 の間であるか確認され、閾値のリストは昇順に並べ替えられます。</p>
+<p><span class="seoSummary"><strong><code>IntersectionObserver()</code></strong> コンストラクターは、新しい {{domxref("IntersectionObserver")}} オブジェクトを生成します。</span> <code>rootMargin</code> は、指定されていた場合は構文が正しいかが確認され、閾値は、0.0 から 1.0 の間であるか確認され、閾値のリストは昇順に並べ替えられます。閾値のリストが空の場合、 [0.0] の配列に設定されます。</p>
 
 <h2 id="Syntax" name="Syntax">構文</h2>
 
@@ -23,30 +23,30 @@ translation_of: Web/API/IntersectionObserver/IntersectionObserver
 
 <dl>
  <dt><code>callback</code></dt>
- <dd>対象の要素の比率が、閾値と交差して表示されたときに実行します。コールバックは 2 つの引数を受け取ります。
+ <dd>対象の要素が見えている割合が、表示されて閾値を越えたときに実行します。コールバックは 2 つの引数を受け取ります。
  <dl>
   <dt><code>entries</code></dt>
-  <dd>{{domxref("IntersectionObserverEntry")}} オブジェクトの配列で、それぞれ、その閾値によって指定された割合より多くあるいは少なく表示されているかに関わらず、 1 つの交差した閾値を表します。</dd>
+  <dd>{{domxref("IntersectionObserverEntry")}} オブジェクトの配列で、それぞれの要素がしきい値となります。これは、見えている割合が下から上に、または上から下にその値を越える時に callback が呼ばれるよう指定するものです。</dd>
   <dt><code>observer</code></dt>
-  <dd>コールバックが呼び出される {{domxref("IntersectionObserver")}} 。</dd>
+  <dd>コールバックが呼び出される {{domxref("IntersectionObserver")}} です。</dd>
  </dl>
  </dd>
  <dt><code>options</code> {{optional_inline}}</dt>
- <dd>オブザーバをカスタマイズするためのオプションオブジェクトです。 もし <code>options</code> に何も指定されていない場合、オブザーバはルートとして、余白の無い、閾値 0% のドキュメントビューポートを使用します（つまり、1px でも閾値に入ればコールバックが実行されます）。次のオプションから任意の組み合わせを利用できます。
+ <dd>オブザーバをカスタマイズするためのオプションオブジェクトです。 もし <code>options</code> に何も指定されていない場合、オブザーバーはルートとして、余白の無い、閾値 0% のドキュメントビューポートを使用します（つまり、1px でもドキュメントビューポート内に入ればコールバックが実行されます）。次のオプションから任意の組み合わせを利用できます。
  <dl>
   <dt><code>root</code></dt>
-  <dd>{{domxref("Element")}} または {{domxref("Document")}} オブジェクトは、対象の祖先要素であり、これらの<span>矩形はビューポートとみなされます。対象の要素が</span> <code>root</code> の表示領域においてどの部分も表示されていなければ、見えていないことになります。</dd>
+  <dd>{{domxref("Element")}} または {{domxref("Document")}} オブジェクトは、対象の祖先要素であり、これらの<span>矩形</span>はビューポートとみなされます。 <code>root</code> の可視領域に見えていない部分はいずれも、見えているとみなされません。</dd>
   <dt><code>rootMargin</code></dt>
   <dd>交差状態を計算するときに root の {{Glossary('bounding_box')}} に適用されるオフセットのセットを指定する文字列で、計算のために root を効果的に縮小または拡大させます。構文は概ね CSS の {{cssxref("margin")}} プロパティのものと同じです。margin のしくみと構文について詳しくは {{SectionOnPage("/ja/docs/Web/API/Intersection_Observer_API", "The root element and root margin")}} を御覧ください。デフォルト値は "0px 0px 0px 0px" です。</dd>
   <dt><code>threshold</code></dt>
-  <dd>1 つの数字か、または 0.0 と 1.0 の間の数字の配列で指定し、監視対象の<span class="ILfuVd"><span class="hgKElc">矩形</span></span>の総面積に対する交差領域の比率を指定します。 0.0 に指定された場合、1px でも交差領域に入ったらその対象要素は表示されたとみなされます。threshold がどのように使われるかについては、 {{SectionOnPage("/ja/docs/Web/API/Intersection_Observer_API", "Thresholds")}} でより深く説明されています。 デフォルトの閾値は 0.0 です。</dd>
+  <dd>1 つの数値か、または 0.0 と 1.0 の間の数字の配列で指定し、監視対象の<span class="ILfuVd"><span class="hgKElc">矩形</span></span>の総面積に対する交差領域の比率を指定します。 0.0 に指定された場合、1px でも交差領域に入ったらその対象要素は表示されたとみなされます。threshold がどのように使われるかについては、 {{SectionOnPage("/ja/docs/Web/API/Intersection_Observer_API", "Thresholds")}} でより詳しく説明されています。 デフォルトの値は 0.0 です。</dd>
  </dl>
  </dd>
 </dl>
 
 <h3 id="Return_value" name="Return_value">戻り値</h3>
 
-<p>新しい {{domxref("IntersectionObserver")}} は、対象要素が、指定された <code>root</code> 内で <code>threshold</code> の可視閾値を通過して表示されたかどうかの可視性を監視するために使用できます。対象要素の可視性の変更を監視し始めるには、 {{domxref("IntersectionObserver.observe", "observe()")}} メソッドを呼び出します。</p>
+<p>新しい {{domxref("IntersectionObserver")}} は、対象要素が指定された <code>root</code> 内で <code>threshold</code> の可視閾値を越えて表示されたかどうかを監視するために使用することができます。対象要素の表示の変更を監視し始めるには、 {{domxref("IntersectionObserver.observe", "observe()")}} メソッドを呼び出します。</p>
 
 <h3 id="Exceptions" name="Exceptions">例外</h3>
 
@@ -59,7 +59,7 @@ translation_of: Web/API/IntersectionObserver/IntersectionObserver
 
 <h2 id="Example" name="Example">例</h2>
 
-<p>この例では、監視されている要素の可視範囲が 10% 以上になったときに毎回 <code>myObserverCallback</code> を呼び出すような新しい intersection observer を生成しています。</p>
+<p>この例では、監視されている要素の可視範囲が 10% を越える毎に <code>myObserverCallback</code> を呼び出すような新しい intersection observer を生成しています。</p>
 
 <pre class="brush: js notranslate">let observer = new IntersectionObserver(myObserverCallback,
                    {threshold: 0.1});</pre>


### PR DESCRIPTION
## 翻訳ページ
原文
https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver

日本語
https://developer.mozilla.org/ja/docs/Web/API/IntersectionObserver/IntersectionObserver

## 備考
すでに翻訳したページの修正で、以下 mozilla-japan の Issue の反映です。
fix https://github.com/mozilla-japan/translation/issues/524