### PR TITLE
Fixed a small typo

### DIFF
--- a/files/es/web/http/status/408/index.html
+++ b/files/es/web/http/status/408/index.html
@@ -9,7 +9,7 @@ translation_of: Web/HTTP/Status/408
 
 <p>Un servidor debe enviar "close" en el campo de la cabecera {{HTTPHeader("Connection")}} en la respuesta, ya que <code>408</code> implica que el servidor ha decidido cerrar la conexión en lugar de continuar esperando.</p>
 
-<p>Esta respuesta es usada mucho más desde que algunos navegadores, como Chrome, Firefox 27+, y IE9, usan el mecanizmo de pre-conexión HTTP para acelerar la naveación.</p>
+<p>Esta respuesta es usada mucho más desde que algunos navegadores, como Chrome, Firefox 27+, y IE9, usan el mecanizmo de pre-conexión HTTP para acelerar la navegación.</p>
 
 <div class="note">
 <p><strong>Nota: </strong><span id="result_box" lang="es">algunos servidores simplemente cierran la conexión sin enviar este mensaje.</span></p>


### PR DESCRIPTION
Navegación was mistyped, it said "naveación".