### PR TITLE
Default :focus was not accessible

### DIFF
--- a/files/fr/web/css/_colon_focus-visible/index.html
+++ b/files/fr/web/css/_colon_focus-visible/index.html
@@ -70,7 +70,7 @@ translation_of: 'Web/CSS/:focus-visible'
 custom-button:focus {
   /* Fournir une alternative pour les navigateurs
      qui ne prennent pas en charge :focus-visible */
-  outline: none;
+  outline: 2px solid red;
   background: lightgrey;
 }
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

On the default `:focus` example the outline was removed completely, thus making it inaccessible to people using browsers that don't support `:focus-visible`

> MDN URL of main page changed

https://developer.mozilla.org/fr/docs/Web/CSS/:focus-visible

> Issue number (if there is an associated issue)

(none)

> Anything else that could help us review it
