### PR TITLE
fix broken link in pt-BR docs

### DIFF
--- a/files/pt-br/learn/javascript/first_steps/variables/index.html
+++ b/files/pt-br/learn/javascript/first_steps/variables/index.html
@@ -310,7 +310,7 @@ const horasNoDia = 24;</span></span></span></span></pre>
 
 <h2 id="Teste_suas_habilidades!">Teste suas habilidades!</h2>
 
-<p>Você chegou ao final deste artigo, mas consegue se lembrar das informações mais importantes? Você pode encontrar alguns testes adicionais para verificar se você reteve essas informações antes de prosseguir — veja <a href="https://developer.mozilla.org/pt-BR/docs/Learn/JavaScript/First_steps/Teste_suas_habilidades:_variaveis">Teste suas habilidades: variáveis</a>.</p>
+<p>Você chegou ao final deste artigo, mas consegue se lembrar das informações mais importantes? Você pode encontrar alguns testes adicionais para verificar se você reteve essas informações antes de prosseguir — veja <a href="https://developer.mozilla.org/pt-BR/docs/Learn/JavaScript/First_steps/Test_your_skills:_variables">Teste suas habilidades: variáveis</a>.</p>
 
 <h2 id="Sumário">Sumário</h2>
 


### PR DESCRIPTION
I found a broken link on the following page of the documentation in pt-br In the session test your skills


page link:
https://developer.mozilla.org/pt-BR/docs/Learn/JavaScript/First_steps/Variables#teste_suas_habilidades!