### PR TITLE
fr - Typo in code example for IntersectionObserver interface page

### DIFF
--- a/files/fr/web/api/intersectionobserver/index.html
+++ b/files/fr/web/api/intersectionobserver/index.html
@@ -55,7 +55,7 @@ translation_of: Web/API/IntersectionObserver
 </dl>
 
 <pre class="brush: js">var intersectionObserver = new IntersectionObserver(function (entrées) {
-  // Si ratioIntersection vaut 0 ou moins, la cible
+  // Si intersectionRatio vaut 0 ou moins, la cible
   // est hors de vue et rien n'est alors fait
   if (entrées[0].intersectionRatio &lt;= 0) return;
 


### PR DESCRIPTION
From: ` Si ratioIntersection ..` to `Si intersectionRatio` to match name on line 60.