### PR TITLE
Fix misleading description in Clipboard API

### DIFF
--- a/files/ru/web/api/clipboard_api/index.html
+++ b/files/ru/web/api/clipboard_api/index.html
@@ -24,7 +24,7 @@ translation_of: Web/API/Clipboard_API
 
 <div></div>
 
-<p>API предназначен для доступа к буферу обмена, используя {{domxref("document.execCommand()")}}.</p>
+<p>API предназначен заменить {{domxref("document.execCommand()")}} в качестве способа для доступа к буферу обмена.</p>
 
 <h2 id="Доступ_к_буферу_обмена">Доступ к буферу обмена</h2>
 


### PR DESCRIPTION
The english version has a paragraph: "`This API is designed to supersede accessing the clipboard using document.execCommand().`". 
In russian it's "`API предназначен для доступа к буферу обмена, используя document.execCommand().`", that means "``This API is using document.execCommand()", which is complete opposite of the original phrase.