### PR TITLE
html/global_attributes/lang: fixes spec anchors

### DIFF
--- a/files/fr/web/html/global_attributes/lang/index.html
+++ b/files/fr/web/html/global_attributes/lang/index.html
@@ -55,12 +55,12 @@ original_slug: Web/HTML/Attributs_universels/lang
    <td>Aucun changement depuis la dernière dérivation, {{SpecName('HTML5.1')}}</td>
   </tr>
   <tr>
-   <td>{{SpecName('HTML5.1', "dom.html#the-lang-and-xml:lang-attributes", "lang")}}</td>
+   <td>{{SpecName('HTML5.1', "dom.html#the-lang-and-xmllang-attributes", "lang")}}</td>
    <td>{{Spec2('HTML5.1')}}</td>
    <td>Dérivée de {{SpecName('HTML WHATWG')}}, aucun changement de {{SpecName('HTML5 W3C')}}</td>
   </tr>
   <tr>
-   <td>{{SpecName('HTML5 W3C', "dom.html#the-lang-and-xml:lang-attributes", "lang")}}</td>
+   <td>{{SpecName('HTML5 W3C', "dom.html#the-lang-and-xmllang-attributes", "lang")}}</td>
    <td>{{Spec2('HTML5 W3C')}}</td>
    <td>Dérivée de {{SpecName('HTML WHATWG')}}. Définition du comportement de l'attribut <strong>xml:lang</strong> et de l'algorithme à utiliser pour déterminer la langue utilisée. Cet attribut devient également un attribut global à part entière.</td>
   </tr>


### PR DESCRIPTION
Anchors to `lang` attribute section in HTML 5 and HTML 5.1 specifications were broken: this fix removes colon between `xml` prefix and `lang`.

Correct links:
https://www.w3.org/TR/html52/dom.html#the-lang-and-xmllang-attributes
https://www.w3.org/TR/html51/dom.html#the-lang-and-xmllang-attributes

HTML 4 and Living Standard are not affected.

By the way (other issue), HTML5 links to HTML5.2, shouldn’t it link to HTML50?