### PR TITLE
link to XML updated

### DIFF
--- a/files/fr/web/svg/tutorial/index.html
+++ b/files/fr/web/svg/tutorial/index.html
@@ -8,7 +8,7 @@ tags:
 translation_of: Web/SVG/Tutorial
 original_slug: Web/SVG/Tutoriel
 ---
-<p><a href="/fr/SVG" title="fr/SVG">SVG</a>, pour Scalable Vector Graphics (ou encore Graphismes vectoriels redimensionnables), est un langage basé sur le <a href="/fr/XML" title="fr/XML">XML</a> du W3C qui permet de définir des éléments graphiques avec des balises. Ce langage est plus ou moins implémenté dans Firefox, Opera, les navigateurs à base de Webkit, Internet Explorer et les autres navigateurs Web.</p>
+<p><a href="/fr/SVG" title="fr/SVG">SVG</a>, pour Scalable Vector Graphics (ou encore Graphismes vectoriels redimensionnables), est un langage basé sur le <a href="/fr/docs/Web/XML" title="fr/XML">XML</a> du W3C qui permet de définir des éléments graphiques avec des balises. Ce langage est plus ou moins implémenté dans Firefox, Opera, les navigateurs à base de Webkit, Internet Explorer et les autres navigateurs Web.</p>
 
 <p>Ce tutoriel a pour but d'expliquer les mécanismes internes de SVG et regorge de détails techniques. Si vous souhaitez juste dessiner de belles images, vous trouverez plus facilement votre bonheur sur la <a class="external" href="http://inkscape.org/doc/" title="page de documentation d'Inkscape">page de documentation d'Inkscape</a>. Le W3C fournit également une <a class="external" href="http://www.w3.org/Graphics/SVG/IG/resources/svgprimer.html" title="An SVG Primer">bonne introduction au format SVG</a>, en anglais malheureusement.</p>
 


### PR DESCRIPTION
`<a href="/fr/SVG" title="fr/SVG">SVG</a>`

Please, note the previous (broken) link was `href="/fr/XML"`

I proposed `href="/fr/docs/Web/XML"`

But I not sure as the `href="/fr/SVG"` works fine.
Please, check this.

good day, jrd10 from France
