### PR TITLE
表記ゆれの修正

### DIFF
--- a/files/ja/web/http/headers/index.html
+++ b/files/ja/web/http/headers/index.html
@@ -331,7 +331,7 @@ translation_of: Web/HTTP/Headers
  <dt>{{HTTPHeader("X-Frame-Options")}} (XFO)</dt>
  <dd>ブラウザーがページを {{HTMLElement("frame")}}, {{HTMLElement("iframe")}}, {{HTMLElement("embed")}}, {{HTMLElement("object")}} の内部に表示することを許可するかを示します。</dd>
  <dt>{{HTTPHeader("X-Permitted-Cross-Domain-Policies")}}</dt>
- <dd>クロスドメインポリシーファイル (<code>crossdomain.xml</code>) を許可するかどうかを指定します。このファイルは、 Adobe の Flash Player、Adobe Acrobat、Microsoft Silverlight、Apache Flex などのクライアントに、<a href="/ja/docs/Web/Security/Same-origin_policy">同一ドメインポリシー</a>によって制限されているドメイン間のデータを処理する許可を与えるポリシーを定義することができます。詳細については、 <a href="https://www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html">Cross-domain Policy File Specification</a> を参照してください。</dd>
+ <dd>クロスドメインポリシーファイル (<code>crossdomain.xml</code>) を許可するかどうかを指定します。このファイルは、 Adobe の Flash Player、Adobe Acrobat、Microsoft Silverlight、Apache Flex などのクライアントに、<a href="/ja/docs/Web/Security/Same-origin_policy">同一オリジンポリシー</a>によって制限されているドメイン間のデータを処理する許可を与えるポリシーを定義することができます。詳細については、 <a href="https://www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html">Cross-domain Policy File Specification</a> を参照してください。</dd>
  <dt>{{HTTPHeader("X-Powered-By")}}</dt>
  <dd>ホスティング環境やその他のフレームワークによって設定される可能性があり、アプリケーションや訪問者に有益ではない情報を含みます。潜在的な脆弱性が発現することを防ぐために、このヘッダーは設定しないでください。</dd>
  <dt>{{HTTPHeader("X-XSS-Protection")}}</dt>


### PR DESCRIPTION
他と表記を合わせるために以下のように修正しました

- 同一ドメインポリシー -> 同一オリジンポリシー

```console
$ git grep -c "同一ドメインポリシー"
files/ja/web/http/headers/index.html:1
```

```console
$ git grep -c "同一オリジンポリシー"
files/ja/glossary/origin/index.html:1
files/ja/glossary/same-origin_policy/index.html:4
files/ja/web/api/document/cookie/index.html:1
files/ja/web/api/document/domain/index.html:2
files/ja/web/api/document/open/index.html:1
files/ja/web/api/indexeddb_api/index.html:1
files/ja/web/api/location/reload/index.html:1
files/ja/web/api/window/postmessage/index.html:1
files/ja/web/api/xmlhttprequest/index.html:1
files/ja/web/html/element/iframe/index.html:3
files/ja/web/http/basics_of_http/evolution_of_http/index.html:1
files/ja/web/http/cors/errors/index.html:1
files/ja/web/http/cors/index.html:2
files/ja/web/http/csp/index.html:1
files/ja/web/http/headers/content-security-policy/sandbox/index.html:1
files/ja/web/http/headers/origin/index.html:1
files/ja/web/http/headers/referrer-policy/index.html:1
files/ja/web/javascript/reference/errors/property_access_denied/index.html:2
files/ja/web/security/index.html:2
files/ja/web/security/same-origin_policy/index.html:4
files/ja/web/svg/element/use/index.html:1
```