### PR TITLE
update(zh-cn): target=_blank implicit noopener

### DIFF
--- a/files/zh-cn/web/html/element/a/index.html
+++ b/files/zh-cn/web/html/element/a/index.html
@@ -104,7 +104,7 @@ translation_of: Web/HTML/Element/a
  </dd>
  <dd>
  <div class="note">
- <p><strong>注意：</strong>使用target时，考虑添加 rel="noopener noreferrer" 以防止针对 window.opener API 的恶意行为。</p>
+ <p><strong>注意：</strong>在 <code>&lt;a&gt;</code> 元素上使用 <code>target="_blank"</code> 隐式提供了与使用 <code><a href="/zh-CN/docs/Web/HTML/Link_types/noopener">rel="noopener"</a></code> 相同的 <code>rel</code> 行为，即不会设置 <code>window.opener</code>。
  </div>
  </dd>
  <dd>

--- a/files/zh-cn/web/html/element/a/index.html
+++ b/files/zh-cn/web/html/element/a/index.html
@@ -104,7 +104,7 @@ translation_of: Web/HTML/Element/a
  </dd>
  <dd>
  <div class="note">
- <p><strong>注意：</strong>在 <code>&lt;a&gt;</code> 元素上使用 <code>target="_blank"</code> 隐式提供了与使用 <code><a href="/zh-CN/docs/Web/HTML/Link_types/noopener">rel="noopener"</a></code> 相同的 <code>rel</code> 行为，即不会设置 <code>window.opener</code>。
+ <p><strong>注意：</strong>在 <code>&lt;a&gt;</code> 元素上使用 <code>target="_blank"</code> 隐式提供了与使用 <code><a href="/en-US/docs/Web/HTML/Link_types/noopener">rel="noopener"</a></code> 相同的 <code>rel</code> 行为，即不会设置 <code>window.opener</code>。
  </div>
  </dd>
  <dd>

--- a/files/zh-cn/web/html/element/a/index.html
+++ b/files/zh-cn/web/html/element/a/index.html
@@ -12,7 +12,7 @@ translation_of: Web/HTML/Element/a
 ---
 <div>{{HTMLRef}}</div>
 
-<p><span class="seoSummary"><strong>HTML <code>&lt;a&gt;</code> 元素</strong>（或称锚元素）可以创建通向其他网页、文件、同一页面内的位置、电子邮件地址或任何其他 URL 的超链接。</span></p>
+<p><span class="seoSummary"><strong>HTML <code>&lt;a&gt;</code> 元素</strong>（或称锚元素）可以通过<a href="#href">它的 <code>href</code> 属性</a>创建通向其他网页、文件、同一页面内的位置、电子邮件地址或任何其他 URL 的超链接。</span><code>&lt;a&gt;</code> 中的内容<strong>应该</strong>应该指明链接的意图。如果存在<span class="seoSummary"><a href="#href"> <code>href</code> 属性</a></span>，当 <code>&lt;a&gt;</code> 元素聚焦时按下回车键就会激活它。</p>
 
 <div>{{EmbedInteractiveExample("pages/tabbed/a.html")}}</div>
 


### PR DESCRIPTION
`a` element target to _blank have noopener by default

reference to [whatwg/html#4330](https://github.com/whatwg/html/pull/4330) and [mdn/content#2236](https://github.com/mdn/content/pull/2236)