### PR TITLE
一文翻訳が抜けていたので追加

### DIFF
--- a/files/ja/web/javascript/reference/statements/try...catch/index.html
+++ b/files/ja/web/javascript/reference/statements/try...catch/index.html
@@ -111,7 +111,7 @@ catch (e) {
 
 <h3 id="The_exception_identifier" name="The_exception_identifier">例外識別子</h3>
 
-<p>例外が <code>try</code> ブロックの中で投げられたときは、<em><code>exception_var</code></em> (たとえば、<code>catch (e)</code> における <code>e</code>) が例外の値を保持します。この識別子を使用して、発生した例外についての情報を取得することができます。この識別子は <code>catch</code> ブロックの{{Glossary("Scope", "スコープ")}}でのみ利用できます。</p>
+<p>例外が <code>try</code> ブロックの中で投げられたときは、<em><code>exception_var</code></em> (たとえば、<code>catch (e)</code> における <code>e</code>) が例外の値を保持します。この識別子を使用して、発生した例外についての情報を取得することができます。この識別子は <code>catch</code> ブロックの{{Glossary("Scope", "スコープ")}}でのみ利用できます。例外の値が必要ない場合にはこれは省略できます。</p>
 
 <pre class="brush: js notranslate">function isValidJSON(text) {
   try {


### PR DESCRIPTION
直下の JS 例文と本文が合わないので原文を確認してみた所、一文だけ翻訳が抜けていたようなので追加してみました。

References: https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/statements/try...catch/index.html#L141-L142