### PR TITLE
Fix escaped characters: 日本語

### DIFF
--- a/files/ja/web/api/document/createevent/index.html
+++ b/files/ja/web/api/document/createevent/index.html
@@ -25,7 +25,7 @@ translation_of: Web/API/Document/createEvent
 </pre>
 
 <ul>
- <li><code><var>event</var></code> は作成された a href="/ja/docs/DOM/event"&gt;イベントオブジェクトです。</li>
+ <li><code><var>event</var></code> は作成された <a href="/ja/docs/DOM/event">イベント</a> オブジェクトです。</li>
  <li><code><var>type</var></code> は作成するイベント型を表す文字列です。取り得るイベント型は <code>"UIEvents"</code>, <code>"MouseEvents"</code>, <code>"MutationEvents"</code>, <code>"HTMLEvents"</code> のいずれかです。詳しくは{{Anch("Notes", "注")}}の項目を参照してください。</li>
 </ul>
 


### PR DESCRIPTION
[The section](https://developer.mozilla.org/ja/docs/Web/API/Document/createEvent#syntax) contains unexpected escaped characters and it breaks a link.
This PR is to fix the problem.

The problem in Japanese page
![image](https://user-images.githubusercontent.com/212837/114795081-c9d2fd80-9dc8-11eb-990b-e6e0600d557f.png)

[Original page](https://developer.mozilla.org/en-US/docs/Web/API/Document/createEvent)
![image](https://user-images.githubusercontent.com/212837/114795146-e7a06280-9dc8-11eb-900c-563ee85d4be4.png)
