### PR TITLE
Web/HTTP/Headers/Referer を更新

### DIFF
--- a/files/ja/web/http/headers/referer/index.html
+++ b/files/ja/web/http/headers/referer/index.html
@@ -50,12 +50,15 @@ translation_of: Web/HTTP/Headers/Referer
 
 <dl>
  <dt>&lt;url&gt;</dt>
- <dd>現在リクエスト中のページにつながるリンクがある直前のページの、絶対または相対アドレスです。 URL フラグメント (つまり "#section") およびユーザー情報 ("https://username:password@example.com/foo/bar/" の "username:password" の部分) は含まれません。</dd>
+ <dd>現在リクエスト中のページにつながるリンクがある直前のページの、絶対または相対アドレスです。 URL フラグメント (つまり "#section") およびユーザー情報 ("https://username:password@example.com/foo/bar/" の "username:password" の部分) は含まれません。リファラーポリシーによっては、オリジン、パス、クエリ文字列が含まれる場合があります。</dd>
 </dl>
 
 <h2 id="Examples" name="Examples">例</h2>
 
-<pre>Referer: https://developer.mozilla.org/en-US/docs/Web/JavaScript</pre>
+<pre>Referer: https://developer.mozilla.org/en-US/docs/Web/JavaScript
+Referer: https://example.com/page?q=123
+Referer: https://example.com/
+</pre>
 
 <h2 id="Specifications" name="Specifications">仕様書</h2>
 


### PR DESCRIPTION
2021/3/17更新の英語版に基づき、url属性の説明文に1文を追記。例示を2つ追加。