### PR TITLE
Web/HTTP/Headers/Host を修正

### DIFF
--- a/files/ja/web/http/headers/host/index.html
+++ b/files/ja/web/http/headers/host/index.html
@@ -24,7 +24,7 @@ translation_of: Web/HTTP/Headers/Host
   </tr>
   <tr>
    <th scope="row">{{Glossary("Forbidden header name", "禁止ヘッダー名")}}</th>
-   <td>いいえ</td>
+   <td>はい</td>
   </tr>
  </tbody>
 </table>


### PR DESCRIPTION
2021/4/17時点、英語版では「Yes」であることを確認。
「禁止ヘッダー」のページでも、Hostヘッダーが「禁止ヘッダー」の対象であることを確認。