### PR TITLE
Web/HTTP/Headers/Server の修正（typo）

### DIFF
--- a/files/ja/web/http/headers/server/index.html
+++ b/files/ja/web/http/headers/server/index.html
@@ -38,7 +38,7 @@ translation_of: Web/HTTP/Headers/Server
 <dl>
  <dt><code>&lt;product&gt;</code></dt>
  <dd>
- <p>リクエストを処理したソフトウェアまたは製品の名前です。通常は {{HTTPHeader('User-Agent')}}} と似た形式です。</p>
+ <p>リクエストを処理したソフトウェアまたは製品の名前です。通常は {{HTTPHeader('User-Agent')}} と似た形式です。</p>
  </dd>
 </dl>
 


### PR DESCRIPTION
編集記号の閉じカッコが余剰で、ブラウザ上に描画されていたため削除。