### PR TITLE
Web/HTTP/Headers/Location の修正

### DIFF
--- a/files/ja/web/http/headers/location/index.html
+++ b/files/ja/web/http/headers/location/index.html
@@ -16,7 +16,7 @@ translation_of: Web/HTTP/Headers/Location
 
 <ul>
  <li>{{HTTPStatus("303")}} (See Also) レスポンスは常に {{HTTPMethod("GET")}} メソッドを使用するように誘導され、 {{HTTPStatus("307")}} (Temporary Redirect) および {{HTTPStatus("308")}} (Permanent Redirect) は元のリクエストにおいて使用されたメソッドを変更しません。</li>
- <li>{{HTTPStatus("301")}} (Permanent Redirect) と {{HTTPStatus("302")}} (Found) は多くの場合はメソッドを変更しませんが、古いユーザーエージェントは変更することがあります (そのため、基本的に結果は不明です)。</li>
+ <li>{{HTTPStatus("301")}} (Moved Permanently) と {{HTTPStatus("302")}} (Found) は多くの場合はメソッドを変更しませんが、古いユーザーエージェントは変更することがあります (そのため、基本的に結果は不明です)。</li>
 </ul>
 
 <p>これらのステータスコードを持つすべてのレスポンスは、 <code>Location</code> ヘッダーを送信します。</p>


### PR DESCRIPTION
HTTPステータス301は「Permanent Redirect)」ではなく「Moved Permanently」。    
https://developer.mozilla.org/ja/docs/Web/HTTP/Status/301

英語版も同様のミスがあったため、事前にPRし、レビュー済み。  
https://github.com/mdn/content/pull/4198