### PR TITLE
web/javascript/reference/global_objects/null を修正（typo）

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/null/index.html
+++ b/files/ja/web/javascript/reference/global_objects/null/index.html
@@ -10,7 +10,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/null
 ---
 <div>{{jsSidebar("Objects")}}</div>
 
-<p><code>null</code> null という値は、意図的にオブジェクトの値が存在しないことを表します。これは JavaScript の<a href="/ja/docs/Glossary/Primitive">プリミティブ値</a>の 1 つであり、ブール演算では <a href="/ja/docs/Glossary/Falsy">falsy</a> として扱われます。</p>
+<p><code>null</code> という値は、意図的にオブジェクトの値が存在しないことを表します。これは JavaScript の<a href="/ja/docs/Glossary/Primitive">プリミティブ値</a>の 1 つであり、ブール演算では <a href="/ja/docs/Glossary/Falsy">falsy</a> として扱われます。</p>
 
 <div>{{EmbedInteractiveExample("pages/js/globalprops-null.html")}}</div>
 


### PR DESCRIPTION
文中で「null」が二重に続いていたため、原文を確認の上、片方を削除。