### PR TITLE
Web/API/HTMLIFrameElement/ReferrerPolicy の修正（typo）

### DIFF
--- a/files/ja/web/api/htmliframeelement/referrerpolicy/index.html
+++ b/files/ja/web/api/htmliframeelement/referrerpolicy/index.html
@@ -26,7 +26,7 @@ translation_of: Web/API/HTMLIFrameElement/referrerPolicy
  <ul>
   <li><code>"no-referrer"</code> は、<code>Referer:</code> HTTP ヘッダーがリファラを送信しないことを意味します。</li>
   <li><code>"origin"</code> は、リファラがページのオリジンになることを意味します。大まかにいえば、オリジンはスキーマとホスト、ポートです。</li>
-  <li><code>"unsafe-url"</code> は、リファラにオリジンとパスが含まれることを意味します（フラグメントやパスワード、ユーザー名は含まれません）。このケースは、TSL を使用して 3rd パーティーから隠しているパス情報が漏洩する可能性があるため、安全ではありません。</li>
+  <li><code>"unsafe-url"</code> は、リファラにオリジンとパスが含まれることを意味します（フラグメントやパスワード、ユーザー名は含まれません）。このケースは、TLS を使用して 3rd パーティーから隠しているパス情報が漏洩する可能性があるため、安全ではありません。</li>
  </ul>
  </dd>
 </dl>


### PR DESCRIPTION
typoの修正（TSL → TLS）のみ。  
2021/4/18現在、日本語コンテンツ内で、「TSL」のtypoは他ページには無いようです。