### PR TITLE
Getting_started_with_the_web/HTML_basics の修正(Typo)

### DIFF
--- a/files/ja/learn/getting_started_with_the_web/html_basics/index.html
+++ b/files/ja/learn/getting_started_with_the_web/html_basics/index.html
@@ -193,7 +193,7 @@ translation_of: Learn/Getting_started_with_the_web/HTML_basics
 <p>リンクはとても重要です ―― これが Web をひとつの Web にします。リンクを追加するには、シンプルな要素 {{htmlelement("a")}} を使えばよいです。 <code>a</code> は "anchor" を省略したものです。段落中の文字をリンクにするには次の手順で行います。</p>
 
 <ol>
- <li>リンクにしたい文字を選びます。今回は "Mozila Manifesto" を選びました。</li>
+ <li>リンクにしたい文字を選びます。今回は "Mozilla Manifesto" を選びました。</li>
  <li>選んだ文字を {{htmlelement("a")}} 要素で囲みます。
   <pre class="brush: html notranslate">&lt;a&gt;Mozilla Manifesto&lt;/a&gt;</pre>
  </li>


### PR DESCRIPTION
Mozila → Mozillaに修正。  
同様の誤りは検索した限り無し。