### PR TITLE
Docs/Glossary/Forbidden_header_name を更新

### DIFF
--- a/files/ja/glossary/forbidden_header_name/index.html
+++ b/files/ja/glossary/forbidden_header_name/index.html
@@ -43,7 +43,7 @@ translation_of: Glossary/Forbidden_header_name
 </ul>
 
 <div class="note">
-<p><strong>注</strong>: <code>User-Agent</code> ヘッダーは<a href="https://fetch.spec.whatwg.org/#terminology-headers">仕様としては</a>禁止ではなくなりました (Firefox 43 で実装された forbidden header name list を参照)。 Fetch の <a href="/ja/docs/Web/API/Headers">Headers</a> オブジェクトや、XHR の <a href="/ja/docs/Web/API/XMLHttpRequest#setRequestHeader%28%29">setRequestHeader()</a> などでこのヘッダーを設定することが可能です。</p>
+<p><strong>注</strong>: <code>User-Agent</code> ヘッダーは<a href="https://fetch.spec.whatwg.org/#terminology-headers">仕様としては</a>禁止ではなくなりました (Firefox 43 で実装された forbidden header name list を参照)。 Fetch の <a href="/ja/docs/Web/API/Headers">Headers</a> オブジェクトや、XHR の <a href="/ja/docs/Web/API/XMLHttpRequest#setRequestHeader%28%29">setRequestHeader()</a> などでこのヘッダーを設定することが可能です。ただし、 Chrome は Fetch リクエストからこのヘッダーを暗黙的に削除します（<a href="https://bugs.chromium.org/p/chromium/issues/detail?id=571722">Chromium バグ 571722</a> を参照）。</p>
 </div>
 
 <section class="Quick_links" id="Quick_Links">


### PR DESCRIPTION
英語版 Last modified: Jan 27, 2021 と同期。  
Note の最後1文が未訳であった。