### PR TITLE
docs/Web/JavaScript/Guide/Regular_Expressions の修正

### DIFF
--- a/files/ja/web/javascript/guide/regular_expressions/index.html
+++ b/files/ja/web/javascript/guide/regular_expressions/index.html
@@ -313,7 +313,7 @@ translation_of: Web/JavaScript/Guide/Regular_Expressions
    <tr>
     <td><a href="#special-white-space" id="special-white-space" name="special-white-space"><code>\s</code></a></td>
     <td>
-     <p>スペース、タブ、改ページ、改行を含むホワイトスペース文字にマッチします。<code>[ \f\n\r\t\v​\u00a0\u1680​\u180e\u2000​-\u200a​\u2028\u2029\u202f\u205f​\u3000\ufeff]</code> に相当します。</p>
+     <p>スペース、タブ、改ページ、改行を含むホワイトスペース文字にマッチします。<code>[ \f\n\r\t\v\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]</code> に相当します。</p>
 
      <p>例えば <code>/\s\w*/</code> は "foo bar" の ' bar' にマッチします。</p>
     </td>


### PR DESCRIPTION
このPRは正規表現の文字クラス`\s`の説明を修正します。

正規表現の文字クラス`\s`に`\u180e`が含まれるとありますが、間違っているようなので`\u180e`を削除します。

英語版では`\u180e`は含まれていないようです。
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes

---

このリポジトリで`u180e`で検索をするとかなりの数が出てくるようです。おそらく他の翻訳も間違っているものが多いと思われます。
