### PR TITLE
KS: Removal of the least used macros - l10n-zh

### DIFF
--- a/files/zh-cn/mdn/guidelines/does_this_belong_on_mdn/index.html
+++ b/files/zh-cn/mdn/guidelines/does_this_belong_on_mdn/index.html
@@ -107,7 +107,7 @@ original_slug: MDN/Guidelines/Rules_Of_MDN_Documenting
  <li>Design documents</li>
  <li>Project proposals</li>
  <li>Specifications or standards</li>
- <li>Promotional material, advertising, or personal information{{ref("*")}}</li>
+ <li>Promotional material, advertising, or personal information</li>
 </ul>
 
 <h2 id="Advantages_to_documenting_on_MDN">Advantages to documenting on MDN</h2>
@@ -123,7 +123,7 @@ original_slug: MDN/Guidelines/Rules_Of_MDN_Documenting
  <li>We have a core community of volunteers who contribute substantial amounts of content and can help you.</li>
  <li>The MDN team can work with you to ensure that your documentation project is adequately staffed.</li>
  <li>The broader MDN community also contributes enormously; from typo fixes to editorial reviews of your content, they can save your bacon.</li>
- <li>The {{IRCLink("mdn")}} channel offers a resource where you can talk to our writing community and get their advice, or recruit help with the production of or maintenance of your content.</li>
+ <li>The <a href="https://chat.mozilla.org/#/room/#mdn:mozilla.org">Matrix</a> channel offers a resource where you can talk to our writing community and get their advice, or recruit help with the production of or maintenance of your content.</li>
  <li>Because we have contributors all over the world, there's always someone around, watching for problems and fixing them.</li>
  <li>Our community of volunteers includes translators for many languages, who can help localize your documentation.</li>
 </ul>
@@ -191,4 +191,4 @@ original_slug: MDN/Guidelines/Rules_Of_MDN_Documenting
 
 <p>Still, this can be a viable option (possibly even a good option) for some types of projects, especially small ones or those that aren't expected to get much interest.</p>
 
-<p>{{endnote("*")}} It's OK to put a limited amount of personal information on your MDN profile page. User profiles should reflect a human being, not a business or organization. A moderate degree of self-promotion is OK, but link-spamming is not. Please <em>do not </em>use your profile to upload personal photos or other irrelevant files.</p>
+<p>It's OK to put a limited amount of personal information on your MDN profile page. User profiles should reflect a human being, not a business or organization. A moderate degree of self-promotion is OK, but link-spamming is not. Please <em>do not </em>use your profile to upload personal photos or other irrelevant files.</p>

--- a/files/zh-cn/mdn/guidelines/writing_style_guide/index.html
+++ b/files/zh-cn/mdn/guidelines/writing_style_guide/index.html
@@ -204,7 +204,7 @@ original_slug: MDN/Guidelines/Style_guide
 <p>类似地，“Warning”样式用来创建一个警告框。</p>
 </div>
 
-<p>除非有特殊需要，否则请不要用 HTML 的 <code>style</code> 属性来手动给内容添加样式。如果你没有找到你需要的预定义样式，可以放置一个 {{IRCLink("mdn")}} 并寻求帮助。</p>
+<p>除非有特殊需要，否则请不要用 HTML 的 <code>style</code> 属性来手动给内容添加样式。如果你没有找到你需要的预定义样式，可以放置一个 <a href="https://chat.mozilla.org/#/room/#mdn:mozilla.org">Matrix</a> 并寻求帮助。</p>
 
 <h3 id="示例代码的格式和样式">示例代码的格式和样式</h3>
 

--- a/files/zh-cn/mdn/structures/macros/index.html
+++ b/files/zh-cn/mdn/structures/macros/index.html
@@ -44,5 +44,3 @@ translation_of: MDN/Structures/Macros
 <p>宏可以像插入更大的文本块或从MDN的另一部分交换内容一样简单，也可以通过搜索站点的各个部分，设置输出样式和添加链接来构建整个内容索引。</p>
 
 <p>您可以在<a href="/en-US/docs/MDN/Contribute/Structures/Macros/Commonly-used_macros" title="/en-US/docs/Project:MDN/Contributing/Custom_macros">Commonly-used macros</a>页面上阅读我们最常用的宏;另外，这里有<a href="https://developer.mozilla.org/en-US/docs/templates" title="https://developer.mozilla.org/en-US/docs/templates">complete list of all macros</a>。大多数宏都有内置的文档，作为顶部的注释。</p>
-
-<p>{{EditorGuideQuicklinks}}</p>

--- a/files/zh-cn/web/api/document/width/index.html
+++ b/files/zh-cn/web/api/document/width/index.html
@@ -6,7 +6,6 @@ translation_of: Web/API/Document/width
 <div>
  {{ApiRef}} {{Obsolete_header}}</div>
 <div class="geckoVersionNote">
- <p>{{gecko_callout_heading("6.0")}}</p>
  <p>从Gecko 6.0开始,<code>不再支持document.width,请使用</code><code>document.body.clientWidth</code>来代替.查看{{domxref("element.clientWidth")}}.</p>
 </div>
 <h2 id="Summary" name="Summary">概述</h2>

--- a/files/zh-cn/web/api/filelist/index.html
+++ b/files/zh-cn/web/api/filelist/index.html
@@ -13,8 +13,6 @@ translation_of: Web/API/FileList
 <p>一个 FileList 对象通常来自于一个 HTML {{HTMLElement("input")}} 元素的 <code>files</code> 属性，你可以通过这个对象访问到用户所选择的文件。该类型的对象还有可能来自用户的拖放操作，查看 <a href="/zh-CN/docs/DragDrop/DataTransfer" title="DragDrop/DataTransfer"><code>DataTransfer</code></a> 对象了解详情。</p>
 
 <div class="geckoVersionNote">
-<div>{{ gecko_callout_heading("1.9.2") }}</div>
-
 <p>在 Gecko 1.9.2 之前,通过 <code>input</code> 元素，每次只能选择一个文件，这意味着该 <code>input</code> 元素的 <code>files</code> 属性上的 FileList 对象无论如何都只能包含一个文件。从Gecko 1.9.2 开始，如果一个 <code>input</code> 元素拥有 <code>multiple</code> 属性，则可以用它来选择多个文件。</p>
 </div>
 

--- a/files/zh-cn/web/api/htmlelement/dir/index.html
+++ b/files/zh-cn/web/api/htmlelement/dir/index.html
@@ -38,9 +38,7 @@ parg.dir = "rtl";
 <p>当表格的<code>dir</code>属性设置为"rtl"时, 那么该表格的所有列将从右到左排列.</p>
 
 <div class="geckoVersionNote">
-<p>{{ gecko_callout_heading("7.0") }}</p>
-
-<p>在Gecko 7.0 {{ geckoRelease("7.0") }}之前, 该属性的返回值不一定都是小写的.从 Gecko 7.0开始, 该属性的返回值全部为小写字母, 这也是规范中所规定的.</p>
+<p>在Gecko 7.0 之前, 该属性的返回值不一定都是小写的.从 Gecko 7.0开始, 该属性的返回值全部为小写字母, 这也是规范中所规定的.</p>
 </div>
 
 <h3 id="Specification" name="Specification">规范</h3>

--- a/files/zh-cn/web/api/htmlmediaelement/index.html
+++ b/files/zh-cn/web/api/htmlmediaelement/index.html
@@ -183,7 +183,7 @@ translation_of: Web/API/HTMLMediaElement
        <td>正在加载.</td>
       </tr>
       <tr>
-       <td><code>NETWORK_NO_SOURCE</code>{{ ref("1") }}</td>
+       <td><code>NETWORK_NO_SOURCE</code></td>
        <td>3</td>
        <td></td>
       </tr>

--- a/files/zh-cn/web/api/keyboardevent/key/key_values/index.html
+++ b/files/zh-cn/web/api/keyboardevent/key/key_values/index.html
@@ -3158,7 +3158,7 @@ translation_of: Web/API/KeyboardEvent/key/Key_Values
   </tr>
   <tr>
    <td><code>"LaunchCalculator"</code> [5]</td>
-   <td>The <kbd>Calculator</kbd> key, often labeled with an icon such as <kbd>{{FontAwesomeIcon("icon-calculator")}}</kbd>. This is often used as a generic application launcher key (<code>APPCOMMAND_LAUNCH_APP2</code>).</td>
+   <td>The <kbd>Calculator</kbd> key, often labeled with an icon such as calculator icon. This is often used as a generic application launcher key (<code>APPCOMMAND_LAUNCH_APP2</code>).</td>
    <td><code>APPCOMMAND_LAUNCH_APP2</code></td>
    <td></td>
    <td><code>GDK_KEY_Calculator</code> (0x1008FF1D)<br>
@@ -3167,7 +3167,7 @@ translation_of: Web/API/KeyboardEvent/key/Key_Values
   </tr>
   <tr>
    <td><code>"LaunchCalendar"</code> [5]</td>
-   <td>The <kbd>Calendar</kbd> key, often labeled with an icon like <kbd>{{FontAwesomeIcon("icon-calendar")}}</kbd>.</td>
+   <td>The <kbd>Calendar</kbd> key, often labeled with an icon like a calendar icon.</td>
    <td></td>
    <td></td>
    <td><code>GDK_KEY_Calendar</code> (0x1008FF20)<br>
@@ -3184,7 +3184,7 @@ translation_of: Web/API/KeyboardEvent/key/Key_Values
   </tr>
   <tr>
    <td><code>"LaunchMail"</code></td>
-   <td>The <kbd>Mail</kbd> key. This is often displayed as <kbd>{{FontAwesomeIcon("icon-envelope-o")}}</kbd>.</td>
+   <td>The <kbd>Mail</kbd> key. This is often displayed as envelope icon.</td>
    <td><code>VK_LAUNCH_MAIL</code> (0xB4)<br>
     <code>APPCOMMAND_LAUNCH_MAIL</code></td>
    <td></td>
@@ -3206,7 +3206,7 @@ translation_of: Web/API/KeyboardEvent/key/Key_Values
   </tr>
   <tr>
    <td><code>"LaunchMusicPlayer"</code> [5]</td>
-   <td>The <kbd>Music Player</kbd> key, often labeled with an icon such as <kbd>{{FontAwesomeIcon("icon-music")}}</kbd>.</td>
+   <td>The <kbd>Music Player</kbd> key, often labeled with an icon such as music icon.</td>
    <td></td>
    <td></td>
    <td><code>GDK_KEY_Music</code> (0x1008FF92)<br>
@@ -3242,7 +3242,7 @@ translation_of: Web/API/KeyboardEvent/key/Key_Values
   </tr>
   <tr>
    <td><code>"LaunchSpreadsheet"</code> [4]</td>
-   <td>The <kbd>Spreadsheet</kbd> key. This key may be labeled with an icon such as <kbd>{{FontAwesomeIcon("icon-table")}}</kbd> or that of a specific spreadsheet application.</td>
+   <td>The <kbd>Spreadsheet</kbd> key. This key may be labeled with an icon such as table icon or that of a specific spreadsheet application.</td>
    <td></td>
    <td></td>
    <td><code>GDK_KEY_Excel</code> (0x1008FF5C)<br>
@@ -3251,7 +3251,7 @@ translation_of: Web/API/KeyboardEvent/key/Key_Values
   </tr>
   <tr>
    <td><code>"LaunchWebBrowser"</code> [4]</td>
-   <td>The <kbd>Web Browser</kbd> key. This key is frequently labeled with an icon such as <kbd>{{FontAwesomeIcon("icon-globe")}}</kbd> or the icon of a specific browser, depending on the device manufacturer.</td>
+   <td>The <kbd>Web Browser</kbd> key. This key is frequently labeled with an icon such as globe icon or the icon of a specific browser, depending on the device manufacturer.</td>
    <td></td>
    <td></td>
    <td><code>GDK_KEY_WWW</code> (0x1008FF2E)<br>

--- a/files/zh-cn/web/api/navigatoronline/online_and_offline_events/index.html
+++ b/files/zh-cn/web/api/navigatoronline/online_and_offline_events/index.html
@@ -117,5 +117,3 @@ translation_of: Web/API/NavigatorOnLine/Online_and_offline_events
  <li><a class="external" href="http://ejohn.org/blog/offline-events/">An explanation of Online/Offline events</a></li>
  <li><a class="external" href="http://hacks.mozilla.org/2010/01/offline-web-applications/" title="http://hacks.mozilla.org/2010/01/offline-web-applications/">offline web applications</a> at hacks.mozilla.org - showcases an offline app demo and explains how it works.</li>
 </ul>
-
-<div>{{ HTML5ArticleTOC() }}</div>

--- a/files/zh-cn/web/api/window/open/index.html
+++ b/files/zh-cn/web/api/window/open/index.html
@@ -108,8 +108,6 @@ const openRequestedPopup = () =&gt; {
 
 <h3 id="Position_and_size_features" name="Position_and_size_features"></h3>
 
-<div>{{gecko_minversion_note("1.9.2", "Starting in Gecko 1.9.2 (Firefox 3.6), overriding the position of a window using window features will not change the persisted values saved by the session store feature. That means the next time the window is opened, it will still open in the saved location.")}}</div>
-
 <p><a href="https://developer.mozilla.org/zh-CN/docs/Web/API/Window/open$edit#Note_on_position_and_dimension_error_correction">Note on position and dimension error correction</a></p>
 
 <div class="bug">{{bug(176320)}}</div>

--- a/files/zh-cn/web/css/background-size/index.html
+++ b/files/zh-cn/web/css/background-size/index.html
@@ -156,9 +156,7 @@ background-size: 50% 25%;</code></pre>
 <p>位图一定有固有尺寸与固有比例，矢量图可能两者都有，也可能只有一个。渐变视为只有固有尺寸或者只有固有比例的图片。</p>
 
 <div class="geckoVersionNote">
-<p>{{gecko_callout_heading("8.0")}}</p>
-
-<p>This behavior changed in Gecko 8.0 {{geckoRelease("8.0")}}. Before this, gradients were treated as images with no intrinsic dimensions, with an intrinsic proportion identical to that of the background positioning area.</p>
+<p>This behavior changed in Gecko 8.0. Before this, gradients were treated as images with no intrinsic dimensions, with an intrinsic proportion identical to that of the background positioning area.</p>
 </div>
 
 <p>由 {{cssxref("-moz-element")}} 生成的背景图片，(which actually match an element) are currently treated as images with the dimensions of the element, or of the background positioning area if the element is SVG, with the corresponding intrinsic proportion.</p>

--- a/files/zh-cn/web/guide/html/using_html_sections_and_outlines/index.html
+++ b/files/zh-cn/web/guide/html/using_html_sections_and_outlines/index.html
@@ -374,5 +374,3 @@ original_slug: Web/Guide/HTML/Sections_and_Outlines_of_an_HTML5_document
 <h2 id="总结">总结</h2>
 
 <p>HTML5中新的节段和标题标签带来了以标准的方法来描述web文档的结构和大纲。其为人们使用HTML5浏览器和需要结构来帮助他们理解页面带来了一个很大的优势。例如，人们需要一些辅助技术的帮助。这些新的语义元素使用简单，几乎没有负担，也可以在不支持HTML5的浏览器中工作。因此，他们应该被广泛使用。</p>
-
-<div>{{HTML5ArticleTOC()}}</div>

--- a/files/zh-cn/web/http/headers/user-agent/firefox/index.html
+++ b/files/zh-cn/web/http/headers/user-agent/firefox/index.html
@@ -37,8 +37,6 @@ translation_of: Web/HTTP/Headers/User-Agent/Firefox
  </li>
 </ul>
 
-<p>{{ h2_gecko_minversion("移动设备与平板设备的标注", "11.0") }}</p>
-
 <p>User Agent（UA String）的<strong><em>platform</em></strong>部分，标明了 Firefox 是否运行在手机或平板尺寸的设备上。当Firefox运行在移动设备上时，UA 中的这个字段将包含<strong>Mobile;</strong>。当Firefox运行于平板设备时，UA 中的这个字段将包含<strong>Tablet;</strong>。例如：</p>
 
 <pre>Mozilla/5.0 (Android 4.4; <strong>Mobile</strong>; rv:41.0) Gecko/41.0 Firefox/41.0

--- a/files/zh-cn/web/xslt/index.html
+++ b/files/zh-cn/web/xslt/index.html
@@ -7,7 +7,7 @@ translation_of: Web/XSLT
 ---
 <p> </p>
 
-<div><strong>可扩展样式表语言转换(XSLT)</strong>是一种基于<a href="cn/XML">XML</a>的语言，和专门的处理软件一起使用，用于XML文档转换。虽然这个处理过程被称作“转换”，但并没有改变原始文档，而是在原文档内容的基础上创建了一个新的XML文档。然后, 这个新文档会被处理器序列化（输出）为标准的XML语法或其他格式，如<a href="cn/HTML">HTML</a>或纯文本。XSLT最常用于不同XML模式间的数据转换，或用于将XML数据转换为网页或PDF文档。 {{ Ref("one") }}</div>
+<div><strong>可扩展样式表语言转换(XSLT)</strong>是一种基于<a href="cn/XML">XML</a>的语言，和专门的处理软件一起使用，用于XML文档转换。虽然这个处理过程被称作“转换”，但并没有改变原始文档，而是在原文档内容的基础上创建了一个新的XML文档。然后, 这个新文档会被处理器序列化（输出）为标准的XML语法或其他格式，如<a href="cn/HTML">HTML</a>或纯文本。XSLT最常用于不同XML模式间的数据转换，或用于将XML数据转换为网页或PDF文档。</div>
 
 <table class="topicpage-table">
  <tbody>

--- a/files/zh-tw/mdn/guidelines/writing_style_guide/index.html
+++ b/files/zh-tw/mdn/guidelines/writing_style_guide/index.html
@@ -71,7 +71,7 @@ translation_of: MDN/Guidelines/Writing_style_guide
 
 <div class="warning"><strong>警告：</strong>同樣，“警告”樣式用於創建警告框，就像這樣。</div>
 
-<p>除非有明確指令，否則<strong>請勿</strong>使用 HTML 的 <code>style</code> 屬性來手動更改內容的風格。如果你無法使用預先定義的 class 來達成目的，就將他丟到 {{IRCLink("mdn")}} 以尋求協助。</p>
+<p>除非有明確指令，否則<strong>請勿</strong>使用 HTML 的 <code>style</code> 屬性來手動更改內容的風格。如果你無法使用預先定義的 class 來達成目的，就將他丟到 <a href="https://chat.mozilla.org/#/room/#mdn:mozilla.org">Matrix</a> 以尋求協助。</p>
 
 <h3 id="範例程式的樣式與格式">範例程式的樣式與格式</h3>
 

--- a/files/zh-tw/mozilla/firefox/releases/4/index.html
+++ b/files/zh-tw/mozilla/firefox/releases/4/index.html
@@ -6,8 +6,6 @@ translation_of: Mozilla/Firefox/Releases/4
 <div>{{FirefoxSidebar}}</div><p>2010 年六月起進入 Beta 測試期的 Firefox 4，增進了效能、加強針對 HTML 5 及其他創新網際科技的支援程度，也更加安全。本文為網頁、附加元件、Gecko 平台開發者們提供這一版的簡要技術相關資訊。</p>
 
 <div class="geckoVersionNote">
-<p>{{ gecko_callout_heading("2") }}</p>
-
 <p>Gecko 1.9.3 即將更名為 Gecko 2，但許多文件還沒有針對此點更新，在接下來的幾個星期中才會有所更動。</p>
 </div>
 

--- a/files/zh-tw/web/api/canvas_api/tutorial/applying_styles_and_colors/index.html
+++ b/files/zh-tw/web/api/canvas_api/tutorial/applying_styles_and_colors/index.html
@@ -633,9 +633,7 @@ var ptrn = ctx.createPattern(img,'repeat');
 <p><code>shadowOffsetX和shadowOffsetY會決定陰影延伸大小，若是為正值，則陰影會往右(沿X軸)和往下(沿Y軸)延伸，若是為負值，則會往正值相反方向延伸。</code></p>
 
 <div class="geckoVersionNote">
-<p>{{gecko_callout_heading("7.0")}}</p>
-
-<p>Note: 基於HTML5提議規格變更，從{{Gecko("7.0")}}開始，陰影只會在source-over的<a href="/en-US/docs/Web/Guide/HTML/Canvas_tutorial/Compositing" title="/en-US/docs/Web/Guide/HTML/Canvas_tutorial/Compositing">構圖排列</a>下產生</p>
+<p>Note: 基於HTML5提議規格變更，從 開始，陰影只會在source-over的<a href="/en-US/docs/Web/Guide/HTML/Canvas_tutorial/Compositing" title="/en-US/docs/Web/Guide/HTML/Canvas_tutorial/Compositing">構圖排列</a>下產生</p>
 </div>
 
 <h3 id="文字陰影範例">文字陰影範例</h3>

--- a/files/zh-tw/web/api/file/using_files_from_web_applications/index.html
+++ b/files/zh-tw/web/api/file/using_files_from_web_applications/index.html
@@ -407,5 +407,3 @@ function handleFiles(files) {
  <li><a href="/en/Extensions/Using_the_DOM_File_API_in_chrome_code" title="en/Extensions/Using the DOM File API in chrome code">Using the DOM File API in chrome code</a></li>
  <li><code>{{domxref("XMLHttpRequest")}}</code></li>
 </ul>
-
-<p>{{ HTML5ArticleTOC() }}</p>

--- a/files/zh-tw/web/api/html_drag_and_drop_api/drag_operations/index.html
+++ b/files/zh-tw/web/api/html_drag_and_drop_api/drag_operations/index.html
@@ -119,8 +119,6 @@ dt.setData("text/plain", "http://www.mozilla.org");
 
 <p>上面我們的canvas是50 x 50px大小，然後我們位移一半25讓圖片落在滑鼠指標中央。 </p>
 
-<p>{{h2_gecko_minversion("使用XUL panel元素作為拖曳圖片", "9.0")}}</p>
-
 <p>在Gecko上開發，比如說外掛或Mozllia應用程式，Gecko9.0{{geckoRelease("9.0")}}支援使用{{XULElem("panel")}}元素作為拖曳圖片，簡單將XUL panel元素傳入setDragImage方法即可。</p>
 
 <p>試想下面這個 {{XULElem("panel")}}元素:</p>

--- a/files/zh-tw/web/api/messageevent/index.html
+++ b/files/zh-tw/web/api/messageevent/index.html
@@ -75,7 +75,6 @@ original_slug: WebSockets/WebSockets_reference/MessageEvent
 </div>
 <h3 id="Gecko_備註">Gecko 備註</h3>
 <div class="geckoVersionNote">
- <p>{{ gecko_callout_heading("6.0") }}</p>
  <p>此時此刻，Gecko 不支援 <code><a href="/en/JavaScript_typed_arrays/ArrayBuffer" title="en/JavaScript typed arrays/ArrayBuffer">ArrayBuffer</a></code> 或 {{ domxref("Blob") }} 作為 <code>data</code>。</p>
 </div>
 <p>{{ languages ( {"en": "en/WebSockets/WebSockets_reference/MessageEvent"} ) }}</p>

--- a/files/zh-tw/web/api/permissions_api/index.html
+++ b/files/zh-tw/web/api/permissions_api/index.html
@@ -4,9 +4,8 @@ slug: Web/API/Permissions_API
 translation_of: Web/API/Permissions_API
 original_slug: WebAPI/Permissions
 ---
+<p>{{DefaultAPISidebar("Permissions API")}}</p>
 <p>{{ draft() }}</p>
-<p>{{ non-standard_header }}</p>
-<p>{{ B2GOnlyHeader2('certified') }}</p>
 <h2 id="摘要">摘要</h2>
 <p>Permissions API 可顯示 Apps 所要求的所有權限，以利使用者管理。Apps 可透過此 API 而讀取其他 Apps 的權限並進一步變更。</p>
 <p>透過 <a href="https://developer.mozilla.org/en-US/docs/DOM/PermissionSettings" title="/en-US/docs/DOM/PermissionSettings"><code>PermissionSettings</code></a> 介面的 <a href="https://developer.mozilla.org/en-US/docs/DOM/window.navigator.mozPermissionSettings" title="/en-US/docs/DOM/window.navigator.mozPermissionSettings"><code>navigator.mozPermissionSettings</code></a> 屬性，即可存取 Permission Manager。</p>

--- a/files/zh-tw/web/api/websocket/index.html
+++ b/files/zh-tw/web/api/websocket/index.html
@@ -189,8 +189,6 @@ void send(
 <h6 id="註釋">註釋</h6>
 
 <div class="geckoVersionNote">
-<p>{{ gecko_callout_heading("6.0") }}</p>
-
 <p>Gecko <code>send()</code> 方法的實作與 Gecko 6.0 的規範有差別。Gecko 回傳一個 <code>boolean</code> 以表示連線是否仍處於開啟狀態（且資料成功隊列／傳輸）。另外，此時此刻，Gecko 不支援 <code><a href="/zh_tw/JavaScript_typed_arrays/ArrayBuffer" title="zh tw/JavaScript typed arrays/ArrayBuffer">ArrayBuffer</a></code> 或 {{ domxref("Blob") }} 作為資料形態。</p>
 </div>
 

--- a/files/zh-tw/web/api/websockets_api/index.html
+++ b/files/zh-tw/web/api/websockets_api/index.html
@@ -142,14 +142,10 @@ original_slug: WebSockets
 <h3 id="Gecko_附註">Gecko 附註</h3>
 <p>Firefox 的 WebSockets 支援正在持續追蹤發展中的 WebSocket 規範。Firefox 6 實作底層協定版號 7，Firefox 7 實作協定版號 8（IETF 草案 10 的內容）。Firefox mobile 在 7.0 版支援 WebSocket。</p>
 <div class="geckoVersionNote">
- <p>{{ gecko_callout_heading("6.0") }}</p>
- <p>Gecko 6.0 {{ geckoRelease("6.0") }} 之前，不該存在的 <code>WebSocket</code> 物件使得某些開發者認為 <code>WebSocket</code> 服務沒有前輟，此物件已被更名為 <code>MozWebSocket</code>。</p>
+ <p>Gecko 6.0 之前，不該存在的 <code>WebSocket</code> 物件使得某些開發者認為 <code>WebSocket</code> 服務沒有前輟，此物件已被更名為 <code>MozWebSocket</code>。</p>
 </div>
 <div class="geckoVersionNote">
- <p>{{ gecko_callout_heading("7.0") }}</p>
- <p>自從 Gecko 7.0 {{ geckoRelease("7.0") }}，偏好設定 <code>network.websocket.max-connections</code> 可以用來設定 WebSocket 連線同時開啟的最大個數。預設值為 200。</p>
+ <p>自從 Gecko 7.0，偏好設定 <code>network.websocket.max-connections</code> 可以用來設定 WebSocket 連線同時開啟的最大個數。預設值為 200。</p>
 </div>
 <div class="warning">
  <strong>警告：</strong>雖然不是唯一的理由，但是目前 WebSockets 被 Firefox 4 與 5 禁用的關鍵原因是一個<a class="external" href="http://www.ietf.org/mail-archive/web/hybi/current/msg04744.html" title="http://www.ietf.org/mail-archive/web/hybi/current/msg04744.html">協定設計上的安全問題</a>，因此不建議在生產環境下使用這些 Firefox 版本的 WebSockets。若仍想測試 WebSockets，你可以開啟 <code>about:config</code> 並設定 <code>network.websocket.enabled</code> 的取值至 <code>true</code>，並需要同時設定 <code>network.websocket.override-security-block</code> 的取值至 <code>true</code> 才能允許 WebSocket 連線的初始化。</div>
-<p>{{ HTML5ArticleTOC() }}</p>
-<p>{{ languages ( {"en": "en/WebSockets", "es": "es/WebSockets"} ) }}</p>

--- a/files/zh-tw/web/css/css_transitions/using_css_transitions/index.html
+++ b/files/zh-tw/web/css/css_transitions/using_css_transitions/index.html
@@ -377,8 +377,5 @@ translation_of: Web/CSS/CSS_Transitions/Using_CSS_transitions
    <li>{{ cssxref("-moz-transition-timing-function") }}</li>
    <li>{{ cssxref("-moz-transition-delay") }}</li>
   </ul>
-  <p>{{ HTML5ArticleTOC() }}</p>
-  <p>{{ languages( { "es": "es/CSS/Transiciones_de_CSS", "ja": "ja/CSS/CSS_transitions" } ) }}</p>
  </div>
 </div>
-<p> </p>

--- a/files/zh-tw/web/guide/html/html5/index.html
+++ b/files/zh-tw/web/guide/html/html5/index.html
@@ -106,7 +106,3 @@ translation_of: Web/Guide/HTML/HTML5
  <li><a href="/Firefox/Releases/2" title="en/Firefox 2 for developers">Firefox 2 技術文件</a></li>
  <li><a href="/Firefox/Releases/1.5" title="en/Firefox 1.5 for developers">Firefox 1.5 技術文件</a></li>
 </ul>
-
-<p>{{ HTML5ArticleTOC() }}</p>
-
-<p>{{ languages( {"es": "es/HTML/HTML5", "fr": "fr/HTML/HTML5", "ja": "ja/HTML/HTML5" , "ko": "ko/HTML/HTML5" , "pt": "pt/HTML/HTML5", "zh-cn": "cn/HTML/HTML5", "zh-tw": "zh_tw/HTML/HTML5", "pt-br": "pt-br/HTML/HTML5"} ) }}</p>


### PR DESCRIPTION
### 🎫 Related issues
See main PR : #611
mdn/yari#3063

### 👀 Observed issues
KumaScript macros are being phased out, to help the Yari dev team, here is a list of macros that will disappear from your files.

I invite you to check your files in your languages to make sure it doesn't break any translations. You can edit them directly on my branch. If you want to take care of it after merging this request, feel free :)

### 🔁 Changes in commits
*This list is taken from the issue quoted above, the numbers are not current.*
```
kumascript/macros/原語併記.ejs                         88
kumascript/macros/HTML5ArticleTOC.ejs              77
kumascript/macros/EditorGuideQuicklinks.ejs        42
kumascript/macros/gecko_callout_heading.ejs        38
kumascript/macros/IRCLink.ejs                      26
kumascript/macros/ref.ejs                          25
kumascript/macros/gecko_minversion_note.ejs        22
kumascript/macros/h1_gecko_minversion.ejs          20
kumascript/macros/FontAwesomeIcon.ejs              11
kumascript/macros/endnote.ejs                      11
kumascript/macros/h2_gecko_minversion.ejs          10
kumascript/macros/UserLink.ejs                     9
kumascript/macros/訳語.ejs                           6
kumascript/macros/LXRSearch.ejs                    2
kumascript/macros/tree.ejs                         2
kumascript/macros/B2GOnlyHeader2.ejs               1
```

```diff
! Only macros used less than 100 times for the moment.
! The pull request would be too big to process everything at once.
```

The compatibility tables are not done in this pull request (except when I stumble upon them). They require a query of their own, as there are many of them.