### PR TITLE
fix: very small typo

### DIFF
--- a/files/ja/web/http/headers/content-language/index.html
+++ b/files/ja/web/http/headers/content-language/index.html
@@ -101,5 +101,5 @@ Content-Language: de-DE, en-CA
 <ul>
  <li>{{HTTPHeader("Accept-Language")}}</li>
  <li><a href="https://www.w3.org/International/questions/qa-http-and-lang.en">HTTP headers, meta elements and language information</a></li>
- <li><a href="/ja/docs/Web/HTML/Global_attributes/lang">HTML の <code>lang</code> 属し得</a></li>
+ <li><a href="/ja/docs/Web/HTML/Global_attributes/lang">HTML の <code>lang</code> 属性</a></li>
 </ul>


### PR DESCRIPTION
### 修正箇所
- files/ja/web/http/headers/content-language/index.html
- L.104 `lang属し得`->`lang属性`