### PR TITLE
Web/JavaScript/Reference/Functions を更新

### DIFF
--- a/files/ja/web/javascript/reference/functions/index.html
+++ b/files/ja/web/javascript/reference/functions/index.html
@@ -12,21 +12,21 @@ translation_of: Web/JavaScript/Reference/Functions
 ---
 <div>{{jsSidebar("Functions")}}</div>
 
-<p>一般的に言うと、関数とは外部 (再帰の場合は内部) から <em>呼ばれる</em> ことのできる「サブプログラム」です。プログラムそのもののように、関数は<em>{{ 訳語("関数本体", "function body") }}</em>と呼ばれる連続した文で構成されます。値を関数に <em>渡す</em> 事ができ、関数は値を<em>返す</em>事ができます。</p>
+<p>一般的に言うと、関数とは外部 (再帰の場合は内部) から <em>呼び出す</em> ことのできる「サブプログラム」です。プログラムそのもののように、関数は関数本体 (<em>function body</em>) と呼ばれる連続した文で構成されます。値を関数に <em>渡す</em> ことができ、関数は値を<em>返す</em>ことができます。</p>
 
-<p>JavaScript において、関数は第一級オブジェクトです。すなわち、関数はオブジェクトであり、他のあらゆるオブジェクトと同じように操作したり渡したりする事ができます。具体的には、関数は <code><a href="/ja/docs/JavaScript/Reference/Global_Objects/Function" title="Ja/JavaScript/Reference/Global_Objects/Function">Function</a></code> オブジェクトです。</p>
+<p>JavaScript において、関数は第一級オブジェクトです。すなわち、関数はオブジェクトであり、他のあらゆるオブジェクトと同じように操作したり渡したりすることができます。具体的には、関数は <code><a href="/ja/docs/Web/JavaScript/Reference/Global_Objects/Function" title="Ja/JavaScript/Reference/Global_Objects/Function">Function</a></code> オブジェクトです。</p>
 
 <p>より詳細な例や解説については、<a href="/ja/docs/Web/JavaScript/Guide/Functions">JavaScript の関数のガイド</a>を参照してください。</p>
 
-<h2 id="Description" name="Description">解説</h2>
+<h2 id="Description">解説</h2>
 
-<p>JavaScript における全ての関数は、実際には <code>Function</code> オブジェクトです。<code>Function</code> オブジェクトのプロパティとメソッドについての情報は {{jsxref("Function")}} をご覧ください。</p>
+<p>JavaScript におけるすべての関数は、実際には <code>Function</code> オブジェクトです。<code>Function</code> オブジェクトのプロパティとメソッドについての情報は {{jsxref("Function")}} をご覧ください。</p>
 
-<p>初期値以外の値を返すためには、返す値を指定する <code><a href="/ja/docs/JavaScript/Reference/Statements/return" title="Ja/JavaScript/Reference/Statements/return">return</a></code> 文が関数内になくてはなりません。<code>return</code> 文を持たない関数は初期値を返します。<code><a href="/ja/docs/JavaScript/Reference/Operators/new">new</a></code> キーワードとともに <a href="/ja/docs/JavaScript/Reference/Global_Objects/Object/constructor" title="JavaScript/Reference/Global_Objects/Object/constructor">constructor</a> が呼び出された場合、その <code>this</code> パラメータが初期値となります。それ以外の全ての関数がデフォルトで返す値は {{jsxref("undefined")}} です。</p>
+<p>初期値以外の値を返すためには、返す値を指定する <code><a href="/ja/docs/Web/JavaScript/Reference/Statements/return">return</a></code> 文が関数内になくてはなりません。<code>return</code> 文を持たない関数は初期値を返します。<a href="/ja/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor">コンストラクター</a>が <code><a href="/ja/docs/Web/JavaScript/Reference/Operators/new">new</a></code> キーワードとともに呼び出された場合、その <code>this</code> 引数が初期値となります。それ以外のすべての関数が既定で返す値は {{jsxref("undefined")}} です。</p>
 
-<p>関数の仮引数 (パラメータ) には、関数呼び出しにおいて実引数 (アーギュメント) が渡されます。実引数は、関数に「<em>値渡し</em>」されます: 関数の中で引数の値を変更しても、その変更はグローバルスコープもしくは呼び出し元の関数内には反映されません。オブジェクト参照も「値」ですが、こちらは特別です: 参照されているオブジェクトのプロパティを関数の中で変更すると、次の例にあるように、その変更を関数の外部から見ることができます:</p>
+<p>関数の仮引数 (parameter) には、関数呼び出しにおいて実引数 (<em>argument</em>) が渡されます。実引数は、関数に<em>値渡し</em>されます。関数の中で引数の値を変更しても、その変更はグローバルスコープもしくは呼び出し元の関数内には反映されません。オブジェクト参照も「値」ですが、こちらは特別です。参照されているオブジェクトのプロパティを関数の中で変更すると、次の例にあるように、その変更を関数の外部から見ることができます。</p>
 
-<pre class="brush: js notranslate"> /* 関数 'myFunc' を宣言 */
+<pre class="brush: js"> /* 関数 'myFunc' を宣言 */
 function myFunc(theObject) {
   theObject.brand = "Toyota";
 }
@@ -49,138 +49,121 @@ console.log(mycar.brand);
 myFunc(mycar);
 
 /*
- * オブジェクトの 'brand' プロパティの値は関数によって変更されたので
- * 'Toyota' と出力される
+ * オブジェクトの 'brand' プロパティの値は関数によって
+ * 変更されたので 'Toyota' と出力される
  */
 console.log(mycar.brand);
 </pre>
 
-<p><a href="/ja/docs/JavaScript/Reference/Operators/this" title="JavaScript/Reference/Operators/this"><code>this</code> キーワード</a>は現在実行中の関数を参照しません。よって、関数内部であっても、名前によって <code>Function</code> オブジェクトを参照しなければなりません。</p>
+<p><a href="/ja/docs/Web/JavaScript/Reference/Operators/this"><code>this</code> キーワード</a>は現在実行中の関数を参照しません。よって、関数本体であっても、名前によって <code>Function</code> オブジェクトを参照しなければなりません。</p>
 
-<h2 id="Defining_functions" name="Defining_functions">関数を定義する</h2>
+<h2 id="Defining_functions">関数の定義</h2>
 
 <p>関数を定義するのにはいくつかの方法があります。</p>
 
-<h3 id="The_function_declaration_function_statement" name="The_function_declaration_function_statement">関数宣言 (<code>function</code> 文)</h3>
+<h3 id="The_function_declaration_function_statement">関数宣言 (<code>function</code> 文)</h3>
 
-<p>関数を宣言するための特殊な構文があります。(詳細は <a href="/ja/docs/JavaScript/Reference/Statements/function" title="Ja/JavaScript/Reference/Statements/function">function 文</a>を参照)</p>
+<p>関数を宣言するための特殊な構文があります。(詳細は <a href="/ja/docs/Web/JavaScript/Reference/Statements/function">function 文</a>を参照)</p>
 
-<pre class="syntaxbo notranslatex notranslate">function <em>name</em>([<em>param</em>[, <em>param</em>[, ... <em>param</em>]]]) {
-   <em>statements</em>
+<pre class="brush: js">function <var>name</var>([<var>param</var>[, <var>param</var>[, ... <var>param</var>]]]) {
+   <var>statements</var>
 }
 </pre>
 
 <dl>
- <dt><code>name</code></dt>
- <dd>関数名。</dd>
+  <dt><code><var>name</var></code></dt>
+  <dd>関数名です。</dd>
+  <dt><code><var>param</var></code></dt>
+  <dd>関数に渡される引数の名前です。</dd>
+  <dt><code><var>statements</var></code></dt>
+  <dd>関数の本体を構成する文です。</dd>
 </dl>
 
-<dl>
- <dt><code>param</code></dt>
- <dd>関数に渡される引数の名前です。</dd>
-</dl>
+<h3 id="The_function_expression_function_expression">関数式 (<code>function</code> 式)</h3>
 
-<dl>
- <dt><code>statements</code></dt>
- <dd>関数の本体を構成する文。</dd>
-</dl>
+<p>関数式は、関数宣言と似ており、同じ構文を持っています (詳細は <a href="/ja/docs/Web/JavaScript/Reference/Operators/function">関数式</a>を参照)。関数式はより大きな式の一部になることもあります。「名前付き」の関数式を定義することもできます (例えばその名前はコールスタック内で使われるかもしれません) し、「無名の」関数式を定義することもできます。関数式はスコープの開始時に「巻き上げ」られないので、コード内でそれらが登場するより前に使用することはできません。</p>
 
-<h3 id="The_function_expression_function_expression" name="The_function_expression_function_expression">関数式 (<code>function</code> 演算子)</h3>
-
-<p>関数式は、関数宣言と似ており、同じ構文を持っています （詳細は <a href="/ja/docs/JavaScript/Reference/Operators/Special_Operators/function_Operator" title="ja/JavaScript/Reference/Operators/Special_Operators/function_Operator">function 演算子</a>を参照）。関数式はより大きな式の一部になることもあります。「名前付き」の関数式を定義することもできます（例えばその名前はコールスタック内で使われるかもしれません）し、「無名の」関数式を定義することもできます。関数式はスコープの開始時に「巻き上げ」られないので、コード内でそれらが登場するより前に使用することはできません。</p>
-
-<pre class="syntaxbox notranslate">function [<em>name</em>]([<em>param</em>[, <em>param</em>[, ... <em>param</em>]]]) {
-   <em>statements</em>
+<pre class="brush: js">function [<var>name</var>]([<var>param</var>[, <var>param</var>[, ... <var>param</var>]]]) {
+   <var>statements</var>
 }
 </pre>
 
 <dl>
- <dt><code>name</code></dt>
- <dd>関数名。省略する事ができ、その場合関数は無名関数と見なされます。</dd>
+  <dt><code><var>name</var></code></dt>
+  <dd>関数名。省略することができ、その場合は関数は無名関数と見なされます。</dd>
+  <dt><code><var>param</var></code></dt>
+  <dd>関数に渡される引数の名前です。</dd>
+  <dt><code><var>statements</var></code></dt>
+  <dd>関数の本体を構成する文です。</dd>
 </dl>
 
-<dl>
- <dt><code>param</code></dt>
- <dd>関数に渡される引数の名前です。</dd>
- <dt><code>statements</code></dt>
- <dd>関数の本体を構成する文。</dd>
-</dl>
+<p>以下は<strong>無名の</strong>関数式の例です (<code>name</code> が使われていない)。</p>
 
-<p>以下は<strong>無名の</strong>関数式（名前が使われていない）の例です。</p>
-
-<pre class="brush: js notranslate">var myFunction = function() {
+<pre class="brush: js">var myFunction = function() {
     statements
 }</pre>
 
-<p><strong>名前付きの</strong>関数式を作るため、定義の中で名前を提供することも可能です。</p>
+<p>定義の中で名前を提供することで、<strong>名前付きの</strong>関数式を作ることも可能です。</p>
 
-<pre class="brush: js notranslate">var myFunction = function namedFunction(){
+<pre class="brush: js">var myFunction = function namedFunction(){
     statements
 }
 </pre>
 
 <p>名前付きの関数式を作ることのメリットの 1 つは、エラーに遭遇したとき、スタックトレースがその関数の名前を含めるため、エラーの発生源をより容易に特定できるということです。</p>
 
-<p>ここまで見てきたように、どちらの例も <code>function</code> キーワードから開始されていません。<code>function</code> から開始せずに関数を含んでいる文が関数式です。</p>
+<p>ここまで見てきたように、どちらの例も <code>function</code> キーワードから開始されていません。 <code>function</code> から開始せずに関数を含んでいる文が関数式です。</p>
 
-<p>関数を一度だけ使うときの一般的なパターンが {{glossary("IIFE", "IIFE (Immediately Invokable Function Expression)")}} です。</p>
+<p>関数を一度だけ使われるとき、一般的なパターンが <a
+      href="/ja/docs/Glossary/IIFE">即時実行関数式 (IIFE, Immediately Invoked Function Expression)</a> です。</p>
 
-<pre class="brush: js notranslate">(function() {
+<pre class="brush: js">(function() {
     statements
 })();</pre>
 
-<p>即時関数は、関数を宣言した直後に実行する関数式です。</p>
+<p>即時実行関数式は、関数を宣言した直後に実行する関数式です。</p>
 
-<h3 id="The_generator_function_declaration_function*_statement" name="The_generator_function_declaration_function*_statement">ジェネレーター関数宣言 (<code>function*</code> 文)</h3>
+<h3 id="The_generator_function_declaration_function*_statement">ジェネレーター関数宣言 (<code>function*</code> 文)</h3>
 
-<p>ジェネレーター関数の宣言のための特別な構文です（詳細は {{jsxref('Statements/function*', 'function* 文')}} を参照してください）。</p>
+<p>ジェネレーター関数の宣言のための特別な構文です (詳細は {{jsxref('Statements/function*', 'function* 文')}} を参照してください)。</p>
 
-<pre class="syntaxbox notranslate">function* <em>name</em>([<em>param</em>[, <em>param</em>[, ... <em>param</em>]]]) {
-   <em>statements</em>
+<pre class="brush: js">function* <var>name</var>([<var>param</var>[, <var>param</var>[, ... <var>param</var>]]]) {
+   <var>statements</var>
 }
 </pre>
 
 <dl>
- <dt><code>name</code></dt>
- <dd>関数名。</dd>
-</dl>
+  <dt><code><var>name</var></code></dt>
+  <dd>関数名。</dd>
+  <dt><code><var>param</var></code></dt>
+  <dd>関数に渡される引数の名前です。</dd>
+  <dt><code><var>statements</var></code></dt>
+  <dd>関数の本体を構成する文。</dd>
+ </dl>
 
-<dl>
- <dt><code>param</code></dt>
- <dd>関数に渡される引数の名前です。</dd>
-</dl>
+<h3 id="The_generator_function_expression_function*_expression">ジェネレーター関数式 (<code>function*</code> 式)</h3>
 
-<dl>
- <dt><code>statements</code></dt>
- <dd>関数の本体を構成する文。</dd>
-</dl>
+<p>ジェネレーター関数式は、ジェネレーター関数宣言と似ており、同じ構文を持っています （詳細は {{jsxref('Operators/function*', 'function* 式')}} を参照してください）。</p>
 
-<h3 id="The_generator_function_expression_function*_expression" name="The_generator_function_expression_function*_expression">ジェネレーター関数式 (<code>function*</code> 演算子)</h3>
-
-<p>ジェネレーター関数式は、ジェネレーター関数宣言と似ており、同じ構文を持っています （詳細は {{jsxref('Operators/function*', 'function* 演算子')}} を参照してください）。</p>
-
-<pre class="syntaxbox notranslate">function* [<em>name</em>]([<em>param</em>[, <em>param</em>[, ... <em>param</em>]]]) {
-   <em>statements</em>
+<pre class="brush: js">function* [<var>name</var>]([<var>param</var>[, <var>param</var>[, ... <var>param</var>]]]) {
+   <var>statements</var>
 }
 </pre>
 
 <dl>
- <dt><code>name</code></dt>
- <dd>関数名。省略する事ができ、その場合関数は無名関数と見なされます。</dd>
+  <dt><code><var>name</var></code></dt>
+  <dd>関数名。省略することができ、その場合関数は無名関数と見なされます。</dd>
+  <dt><code><var>param</var></code></dt>
+  <dd>関数に渡される引数の名前です。</dd>
+  <dt><code><var>statements</var></code></dt>
+  <dd>関数の本体を構成する文です。</dd>
 </dl>
 
-<dl>
- <dt><code>param</code></dt>
- <dd>関数に渡される引数の名前です。</dd>
- <dt><code>statements</code></dt>
- <dd>関数の本体を構成する文。</dd>
-</dl>
+<h3 id="The_arrow_function_expression_>">アロー関数式 (=&gt;)</h3>
 
-<h3 id="The_arrow_function_expression_>" name="The_arrow_function_expression_>">アロー関数式 (=&gt;)</h3>
+<p>アロー関数式はより短い構文で、 <code>this</code> 値を語彙的に結合します (詳細は<a href="/ja/docs/Web/JavaScript/Reference/Functions/Arrow_functions">アロー関数</a>を参照)。</p>
 
-<p>アロー関数式は短縮構文を持ち、また関数の this 値を語彙的に束縛します (詳細は<a href="/ja/docs/JavaScript/Reference/arrow_functions">アロー関数</a>を参照):</p>
-
-<pre class="syntaxbox notranslate">([param[, param]]) =&gt; {
+<pre class="brush: js">([param[, param]]) =&gt; {
    statements
 }
 
@@ -188,175 +171,175 @@ param =&gt; expression
 </pre>
 
 <dl>
- <dt><code>param</code></dt>
- <dd>引数の名前。引数が 0 個の場合は <code>()</code> で示すことが必要です。引数が 1 個の場合のみ、<span class="mw-headline" id="Parentheses_.28_.29">丸括弧</span>は必須ではありません。(例えば <code>foo =&gt; 1</code>)</dd>
- <dt><code>statements または expression</code></dt>
- <dd>複数の文は中括弧で括らなければなりません。単一の式では、中括弧は必須ではありません。式は、関数の暗黙的な戻り値でもあります。</dd>
+  <dt><code><var>param</var></code></dt>
+ <dd>引数の名前。引数が 0 個の場合は <code>()</code> で示すことが必要です。引数が 1 個の場合のみ、丸括弧は必須ではありません。(例えば <code>foo =&gt; 1</code>)</dd>
+  <dt><code><var>statements</var></code> または <code><var>expression</var></code></dt>
+ <dd>複数の文は中括弧で括らなければなりません。単一の式では、中括弧は必須ではありません。式は、関数の暗黙的な返値でもあります。</dd>
 </dl>
 
-<h3 id="The_Function_constructor" name="The_Function_constructor"><code>Function</code> コンストラクタ</h3>
+<h3 id="The_Function_constructor"><code>Function</code> コンストラクター</h3>
 
 <div class="note">
-<p><strong>メモ:</strong> <code>Function</code> コンストラクターによる関数の生成は推奨されません。これは、文字列として関数本体が必要で、JS エンジンによる最適化を妨げたり、他の問題を引き起こしたりする場合があるためです。</p>
+<p><strong>注:</strong> <code>Function</code> コンストラクターによる関数の生成は推奨されません。これは、文字列として関数本体が必要であり、JS エンジンによる最適化を妨げたり、他の問題を引き起こしたりする場合があるためです。</p>
 </div>
 
-<p>他の全てのオブジェクトと同じように、<code>new</code> 演算子を使って {{jsxref("Function")}} オブジェクトを作成する事ができます。</p>
+<p>他のすべてのオブジェクトと同じように、<code>new</code> 演算子を使って {{jsxref("Function")}} オブジェクトを作成することができます。</p>
 
-<pre class="syntaxbox notranslate">new Function (<em>arg1</em>, <em>arg2</em>, ... <em>argN</em>, <em>functionBody</em>)
+<pre class="brush: js">new Function (<var>arg1</var>, <var>arg2</var>, ... <var>argN</var>, <var>functionBody</var>)
 </pre>
 
 <dl>
- <dt><code>arg1, arg2, ... arg<em>N</em></code></dt>
- <dd>関数で仮引数名として使われる、0 個以上の名前。それぞれが、妥当な JavaScript 識別子に相当する文字列、もしくはそういった文字列のカンマで分割されたリストでなくてはなりません。</dd>
+  <dt><code><var>arg1</var>, <var>arg2</var>, ... <var>argN</var></code></dt>
+  <dd>関数で仮引数名として使われる、0 個以上の名前。それぞれが、妥当な JavaScript 識別子に相当する文字列、もしくはそういった文字列のカンマで分割されたリストでなくてはなりません。</dd>
+  <dt><code><var>functionBody</var></code></dt>
+  <dd>関数定義を構成する JavaScript 文を含む文字列。</dd>
 </dl>
 
-<dl>
- <dt><code>functionBody</code></dt>
- <dd>関数定義を構成する JavaScript 文を含む文字列。</dd>
-</dl>
+<p><code>Function</code> コンストラクターを関数として (<code>new</code> 演算子を使わずに) 呼び出しても、コンストラクターとして呼び出すのと同じ効果があります。</p>
 
-<p><code>Function</code> コンストラクタを関数として (<code>new</code> 演算子を使わずに) 呼び出しても、コンストラクタとして呼び出すのと同じ効果があります。</p>
-
-<h3 id="The_GeneratorFunction_constructor" name="The_GeneratorFunction_constructor"><code>GeneratorFunction</code> コンストラクタ</h3>
+<h3 id="The_GeneratorFunction_constructor"><code>GeneratorFunction</code> コンストラクター</h3>
 
 <div class="note">
-<p><strong>メモ:</strong> <code>GeneratorFunction</code> はグローバルオブジェクトではありませんが、ジェネレーター関数のインスタンスから得ることができます（詳細は {{jsxref("GeneratorFunction")}} を参照してください）。</p>
+<p><strong>注:</strong> <code>GeneratorFunction</code> はグローバルオブジェクトではありませんが、ジェネレーター関数のインスタンスから得ることができます (詳細は {{jsxref("GeneratorFunction")}} を参照してください)。</p>
 </div>
 
 <div class="note">
-<p><strong>メモ:</strong> <code>GeneratorFunction</code> コンストラクタによる関数の生成は推奨されません。これは、文字列として関数本体が必要で、JS エンジンによる最適化を妨げたり、他の問題を引き起こしたりする場合があるためです。</p>
+<p><strong>注:</strong> <code>GeneratorFunction</code> コンストラクターによる関数の生成は推奨されません。これは、文字列として関数本体が必要で、JS エンジンによる最適化を妨げたり、他の問題を引き起こしたりする場合があるためです。</p>
 </div>
 
-<p>他の全てのオブジェクトと同じように、<code>new</code> 演算子を使って {{jsxref("GeneratorFunction")}} オブジェクトを作成する事ができます。</p>
+<p>他のすべてのオブジェクトと同じように、 <code>new</code> 演算子を使って {{jsxref("GeneratorFunction")}} オブジェクトを作成することができます。</p>
 
-<pre class="syntaxbox notranslate">new GeneratorFunction (<em>arg1</em>, <em>arg2</em>, ... <em>argN</em>, <em>functionBody</em>)
+<pre class="brush: js">new GeneratorFunction (<var>arg1</var>, <var>arg2</var>, ... <var>argN</var>, <var>functionBody</var>)
 </pre>
 
 <dl>
- <dt><code>arg1, arg2, ... arg<em>N</em></code></dt>
- <dd>関数で仮引数名として使われる、0 個以上の名前。それぞれが、妥当な JavaScript 識別子に相当する文字列、もしくはそういった文字列のカンマで分割されたリストでなくてはなりません。例えば "<code>x</code>" 、"<code>theValue</code>"、もしくは "<code>a,b</code>" などです。</dd>
+  <dt><code><var>arg1</var>, <var>arg2</var>, ... <var>argN</var></code></dt>
+  <dd>関数で仮引数名として使われる、0 個以上の名前。それぞれが、妥当な JavaScript 識別子に相当する文字列、もしくはそういった文字列のカンマで分割されたリストでなくてはなりません。例えば "<code>x</code>"、"<code>theValue</code>"、"<code>a,b</code>" などです。</dd>
+  <dt><code><var>functionBody</var></code></dt>
+  <dd>関数定義を構成する JavaScript 文を含む文字列です。</dd>
 </dl>
 
-<dl>
- <dt><code>functionBody</code></dt>
- <dd>関数定義を構成する JavaScript 文を含む文字列。</dd>
-</dl>
+<p><code>Function</code> コンストラクターを関数として (<code>new</code> 演算子を使わずに) 呼び出しても、コンストラクターとして呼び出すのと同じ効果があります。</p>
 
-<p><code>Function</code> コンストラクタを関数として (<code>new</code> 演算子を使わずに) 呼び出しても、コンストラクタとして呼び出すのと同じ効果があります。</p>
+<h2 id="Function_parameters">関数の引数</h2>
 
-<h2 id="The_arguments_object" name="The_arguments_object">関数の引数</h2>
+<h3 id="Default_parameters">デフォルト引数</h3>
 
-<h3 id="Default_parameters" name="Default_parameters">デフォルト引数</h3>
+<p>関数のデフォルト引数で、関数に値が渡されなかった場合や <code>undefined</code> が渡された場合に、既定値で初期化される形式上の引数を指定できます。詳細は<a href="/ja/docs/Web/JavaScript/Reference/Functions/Default_parameters">デフォルト引数</a>を参照してください。</p>
 
-<p>関数のデフォルト引数は、関数に値が渡されない場合や <code>undefined</code> が渡される場合に、デフォルト値で初期化される形式上の引数を指定できます。詳細は<a href="/ja/docs/Web/JavaScript/Reference/Functions_and_function_scope/Default_parameters">デフォルト引数</a>を参照してください。</p>
+<h3 id="Rest_parameters">残余引数</h3>
 
-<h3 id="Rest_parameters" name="Rest_parameters">Rest parameters</h3>
+<p>残余引数とは、不特定多数の引数を配列として受け取る構文です。詳細は<a href="/ja/docs/Web/JavaScript/Reference/Functions/rest_parameters">残余引数</a>を参照してください。</p>
 
-<p>rest parameters とは、不特定多数の引数を配列として受け取る構文です。詳細は <a href="/ja/docs/Web/JavaScript/Reference/Functions_and_function_scope/rest_parameters">rest parameters</a> を参照してください。</p>
+<h2 id="The_arguments_object"><code>arguments</code> オブジェクト</h2>
 
-<h2 id="The_arguments_object" name="The_arguments_object"><code>arguments</code> オブジェクト</h2>
-
-<p><code>arguments</code> オブジェクトを使って、関数内部で関数の引数を参照することができます。<a href="/ja/docs/JavaScript/Reference/Functions/arguments" title="Ja/JavaScript/Reference/Functions/arguments">arguments</a> を参照してください。</p>
+<p><code>arguments</code> オブジェクトを使って、関数内部で関数の引数を参照することができます。<a href="/ja/docs/Web/JavaScript/Reference/Functions/arguments">arguments</a> を参照してください。</p>
 
 <ul>
- <li><code><a href="/ja/docs/JavaScript/Reference/Functions_and_function_scope/arguments">arguments</a></code>: 現在実行中の関数に渡された引数を格納する配列状オブジェクト。</li>
- <li><code><a href="/ja/docs/JavaScript/Reference/Functions_and_function_scope/arguments/callee">arguments.callee</a></code> : 現在実行中の関数。</li>
- <li><code><a href="/ja/docs/JavaScript/Reference/Functions_and_function_scope/arguments/caller">arguments.caller</a></code> : 現在実行中の関数を実行した関数。</li>
- <li><code><a href="/ja/docs/JavaScript/Reference/Functions_and_function_scope/arguments/length">arguments.length</a></code>: 関数に渡された引数の数。</li>
+  <li>
+    <code><a href="/ja/docs/Web/JavaScript/Reference/Functions/arguments">arguments</a></code>:
+    現在実行中の関数に渡された引数を格納する配列状オブジェクト。</li>
+  <li>
+    <code><a href="/ja/docs/Web/JavaScript/Reference/Functions/arguments/callee">arguments.callee</a></code> :
+    現在実行中の関数。</li>
+  <li>
+    <code><a href="/ja/docs/Web/JavaScript/Reference/Functions/arguments/caller">arguments.caller</a></code> :
+    現在実行中の関数を実行した関数。</li>
+  <li>
+    <code><a href="/ja/docs/Web/JavaScript/Reference/Functions/arguments/length">arguments.length</a></code>:
+    関数に渡された引数の数。</li>
 </ul>
 
-<h2 id="Scope_and_the_function_stack" name="Scope_and_the_function_stack">メソッドを定義する</h2>
+<h2 id="Defining_method_functions">メソッドを定義する</h2>
 
-<h3 id="Getter_and_setter_functions" name="Getter_and_setter_functions">getter と setter 関数</h3>
+<h3 id="Getter_and_setter_functions">ゲッターおよびセッター関数</h3>
 
-<p>新しいプロパティの追加をサポートする、どの標準ビルトインオブジェクトあるいはユーザー定義オブジェクトにも、getter（accessor メソッド）や setter （mutator メソッド）を定義することができます。getter と setter を定義するための構文は、オブジェクトリテラル構文を使用します。</p>
+<p>ゲッター (アクセサーメソッド) およびセッター (ミューテーターメソッド) は、標準組み込みオブジェクトでもユーザー定義オブジェクトでも、新しいプロパティの追加に対応していれば定義することができます。ゲッターとセッターを定義するための構文は、オブジェクトリテラル構文を使用します。</p>
 
 <dl>
- <dt><a href="/ja/docs/Web/JavaScript/Reference/Functions/get">get</a></dt>
- <dd>
- <p>オブジェクトのプロパティを、そのプロパティが検索されたときに呼び出される関数に束縛します。</p>
- </dd>
- <dt><a href="/ja/docs/Web/JavaScript/Reference/Functions/set">set</a></dt>
- <dd>オブジェクトのプロパティを、そのプロパティに代入しようとしたときに呼び出される関数に束縛します。</dd>
+  <dt><a href="/ja/docs/Web/JavaScript/Reference/Functions/get">get</a></dt>
+  <dd>オブジェクトのプロパティを、そのプロパティが検索されたときに呼び出される関数に束縛します。</dd>
+  <dt><a href="/ja/docs/Web/JavaScript/Reference/Functions/set">set</a></dt>
+  <dd>あるオブジェクトのプロパティを、そのプロパティに代入しようとしたときに呼び出される関数に結びつけます。</dd>
 </dl>
 
-<h3 id="Method_definition_syntax" name="Method_definition_syntax">メソッド定義構文</h3>
+<h3 id="Method_definition_syntax">メソッド定義構文</h3>
 
-<p>ECMAScript 2015 からは、独自のメソッドを、getter と setter に似た、より短い構文で定義することができます。詳細は<a href="/ja/docs/Web/JavaScript/Reference/Functions/Method_definitions">メソッド定義</a>を参照してください。</p>
+<p>ECMAScript 2015 からは、独自のメソッドを、ゲッターとセッターに似たより短い構文で定義することができます。詳細は<a href="/ja/docs/Web/JavaScript/Reference/Functions/Method_definitions">メソッド定義</a>を参照してください。</p>
 
-<pre class="brush: js notranslate">var obj = {
+<pre class="brush: js">var obj = {
   foo() {},
   bar() {}
 };</pre>
 
-<h2 id="Function_constructor_vs._function_declaration_vs._function_expression" name="Function_constructor_vs._function_declaration_vs._function_expression">コンストラクタか関数宣言か関数式か</h2>
+<h2 id="Constructor_vs._declaration_vs._expression">コンストラクターか関数宣言か関数式か</h2>
 
 <p>以下のものを比較してみて下さい。</p>
 
-<p><code>Function</code> コンストラクタによって定義され、変数 <code>multiply</code> に代入された関数:</p>
+<p><code>Function</code> <em>コンストラクター</em>によって定義され、変数 <code>multiply</code> に代入された関数です。</p>
 
-<pre class="brush: js notranslate">var multiply = new Function('x', 'y', 'return x * y');</pre>
+<pre class="brush: js">var multiply = new Function('x', 'y', 'return x * y');</pre>
 
-<p><code>multiply</code> と命名された関数の <em>関数宣言:</em></p>
+<p><code>multiply</code> と命名された関数の<em>関数宣言</em>です。</p>
 
-<pre class="brush: js notranslate">function multiply(x, y) {
+<pre class="brush: js">function multiply(x, y) {
    return x * y;
 } // ここにセミコロンは必要ありません
 </pre>
 
-<p>変数 <code>multiply</code> に代入された、無名関数の<em>関数式:</em></p>
+<p>変数 <code>multiply</code> に代入された、無名関数の<em>関数式</em>です。</p>
 
-<pre class="brush: js notranslate">var multiply = function(x, y) {
+<pre class="brush: js">var multiply = function(x, y) {
    return x * y;
 };
 </pre>
 
-<p>変数 <code>multiply</code> に代入された、<code>func_name</code> と命名された関数式:</p>
+<p>変数 <code>multiply</code> に代入された、<code>func_name</code> と命名された関数式です。</p>
 
-<pre class="brush: js notranslate">var multiply = function func_name(x, y) {
+<pre class="brush: js">var multiply = function func_name(x, y) {
    return x * y;
 };
 </pre>
 
-<h3 id="Differences" name="Differences">相違点</h3>
+<h3 id="Differences">相違点</h3>
 
-<p>これらは全ておおよそ同じ働きをしますが、いくつか微妙に異なる点があります。</p>
+<p>これらはすべて、おおよそ同じ働きをしますが、いくつか微妙に異なる点があります。</p>
 
-<p>関数名と関数が代入された変数の間には違いがあります。関数名は変える事ができませんが、関数が代入された変数は再代入する事ができます。関数名は関数本体の内部でのみ使用する事ができます。関数本体の外側でそれを使用しようとするとエラー (その関数名がそれより前に <code>var</code> 文によって宣言されていれば <code>undefined</code> ) になります。例えば、</p>
+<p>関数名と関数が代入された変数の間には違いがあります。関数名は変えることができませんが、関数が代入された変数は再代入することができます。関数名は関数本体の内部でのみ使用することができます。関数本体の外側でそれを使用しようとするとエラー (その関数名がそれより前に <code>var</code> 文によって宣言されていれば <code>undefined</code> ) になります。例えば、</p>
 
-<pre class="brush: js notranslate">var y = function x() {};
-alert(x); // エラーを投げる
+<pre class="brush: js">var y = function x() {};
+alert(x); // エラーが発生する
 </pre>
 
-<p>関数名は <a href="/ja/docs/JavaScript/Reference/Global_Objects/Function/toString" title="ja/JavaScript/Reference/Global_Objects/Function/toString"><code>Function</code> の toString メソッド</a>によってシリアライズしたときにも現れます。</p>
+<p>関数名は <a href="/ja/docs/Web/JavaScript/Reference/Global_Objects/Function/toString"><code>Function</code> の toString メソッド</a>によってシリアライズしたときにも現れます。</p>
 
-<p>一方、関数が代入された変数はそのスコープ内でのみ有効で、そのスコープは関数が宣言されたスコープを含んでいる事が保証されています。</p>
+<p>一方、関数が代入された変数はそのスコープ内でのみ有効で、そのスコープは関数が宣言されたスコープを含んでいることが保証されています。</p>
 
-<p>4 つめの例にあるように、関数名はその関数が代入される変数と違っていても構いません。お互いの間に関連性は有りません。関数宣言は同時にその関数名と同じ名前の変数を作成します。よって、関数式で定義されたものと違って、関数宣言で定義された関数は定義されたスコープ内でその名前によってアクセスできます。</p>
+<p>4 つ目の例にあるように、関数名はその関数が代入される変数と違っていても構いません。互いの間に関連性はありません。関数宣言は同時にその関数名と同じ名前の変数を作成します。よって、関数式で定義されたものと違って、関数宣言で定義された関数は定義されたスコープ内でも、その名前によってアクセスできます。</p>
 
-<p><code>new Function</code> によって定義された関数は関数名を持ちません。しかし、JavaScript エンジンの <a href="/ja/docs/SpiderMonkey" title="ja/SpiderMonkey">SpiderMonkey</a> では、その関数をシリアライズされた形式にすると "anonymous" という名前を持っているかのように表示されます。例えば、<code>alert(new Function())</code> はこのように出力されます。</p>
+<p><code>new Function</code> によって定義された関数は関数名を持ちません。しかし、JavaScript エンジンの <a href="/ja/docs/Mozilla/Projects/SpiderMonkey">SpiderMonkey</a> では、その関数をシリアライズされた形式にすると "anonymous" という名前を持っているかのように表示されます。例えば、<code>alert(new Function())</code> はこのように出力されます。</p>
 
-<pre class="brush: js notranslate">function anonymous() {
+<pre class="brush: js">function anonymous() {
 }
 </pre>
 
 <p>この関数は実際には名前を持っていないので、<code>anonymous</code> は関数内部でアクセスできる変数ではありません。例えば、次の文はエラーになります。</p>
 
-<pre class="brush: js notranslate">var foo = new Function("alert(anonymous);");
+<pre class="brush: js">var foo = new Function("alert(anonymous);");
 foo();
 </pre>
 
-<p>関数式や <code>Function</code> コンストラクタで定義されたものとは違い、関数宣言で定義された関数は、関数自体が宣言される前に使用する事ができます。例えば、</p>
+<p>関数式や <code>Function</code> コンストラクターで定義されたものとは違い、関数宣言で定義された関数は、関数自体が宣言される前に使用することができます。例えば、</p>
 
-<pre class="brush: js notranslate">foo(); // FOO! とアラートされる
+<pre class="brush: js">foo(); // FOO! とアラート表示
 function foo() {
    alert('FOO!');
 }
 </pre>
 
-<p>関数式で定義された関数は現在のスコープを継承します。つまり、関数がクロージャを形成します。一方、<code>Function</code> コンストラクタで定義された関数は (あらゆる関数が継承する) グローバルスコープ以外はどんなスコープも継承しません。</p>
+<p>関数式で定義された関数は現在のスコープを継承します。つまり、関数がクロージャを形成します。一方、<code>Function</code> コンストラクターで定義された関数は (あらゆる関数が継承する) グローバルスコープ以外はどんなスコープも継承しません。</p>
 
-<pre class="brush: js notranslate">/*
+<pre class="brush: js">/*
  * Declare and initialize a variable 'p' (global)
  * and a function 'myFunc' (to change the scope) inside which
  * declare a varible with same name 'p' (current) and
@@ -392,21 +375,21 @@ myFunc();
  */
 </pre>
 
-<p>関数式と関数宣言で定義された関数は一度しか解析されませんが、<code>Function</code> コンストラクタで定義された関数はそうではありません。つまり、<code>Function</code> コンストラクタに渡された関数本体を表す文字列が、評価されるたびに必ず解析されます。関数式は毎回クロージャを作成しますが、関数本体は再解析されないので、"<code>new Function(...)</code>" よりは関数式の方がまだ高速です。したがって <code>Function</code> コンストラクタはできる限り避けるべきでしょう。</p>
+<p>関数式と関数宣言で定義された関数は一度しか解析されませんが、<code>Function</code> コンストラクターで定義された関数はそうではありません。つまり、<code>Function</code> コンストラクターに渡された関数本体を表す文字列が、評価されるたびに必ず解析されます。関数式は毎回クロージャを作成しますが、関数本体は再解析されないので、"<code>new Function(...)</code>" よりは関数式の方がまだ高速です。したがって <code>Function</code> コンストラクターはできる限り避けるべきでしょう。</p>
 
-<p>ただし、<code>Function</code> コンストラクタの文字列を解析することで生成された関数内で入れ子にされている関数式や関数宣言は、繰り返し解析されないことに注意してください。例えば:</p>
+<p>ただし、<code>Function</code> コンストラクターの文字列を解析することで生成された関数内で入れ子にされている関数式や関数宣言は、繰り返し解析されないことに注意してください。例えば、</p>
 
-<pre class="brush: js notranslate">var foo = (new Function("var bar = \'FOO!\';\nreturn(function() {\n\talert(bar);\n});"))();
+<pre class="brush: js">var foo = (new Function("var bar = \'FOO!\';\nreturn(function() {\n\talert(bar);\n});"))();
 foo(); // 関数本体の文字列で "function() {\n\talert(bar);\n}" の部分は再解析されません</pre>
 
-<p>関数宣言はとても簡単に (しばしば意図せずに) 関数式に変化します。関数宣言は以下のような時には関数宣言ではなくなります。</p>
+<p>関数宣言はとても簡単に (しばしば意図せずに) 関数式に変化します。関数宣言は以下のようなときには関数宣言ではなくなります。</p>
 
 <ul>
- <li>式の一部になった時</li>
- <li>関数またはスクリプト自体の「{{ 原語併記("ソース要素", "source element") }}」でなくなった時。「ソース要素」はスクリプトや関数本体の中で入れ子にされていない文の事です。</li>
+ <li>式の一部になったとき</li>
+ <li>関数またはスクリプト自体の「ソース要素 (source element)」でなくなったとき。「ソース要素」はスクリプトや関数本体の中で入れ子にされていない文の事です。</li>
 </ul>
 
-<pre class="brush: js notranslate">var x = 0;               // ソース要素
+<pre class="brush: js">var x = 0;               // ソース要素
 if (x === 0) {           // ソース要素
    x = 10;               // ソース要素ではない
    function boo() {}     // ソース要素ではない
@@ -421,9 +404,9 @@ function foo() {         // ソース要素
 }
 </pre>
 
-<h3 id="Examples" name="Examples">例</h3>
+<h3 id="Examples">例</h3>
 
-<pre class="brush: js notranslate">// 関数宣言
+<pre class="brush: js">// 関数宣言
 function foo() {}
 
 // 関数式
@@ -432,12 +415,10 @@ function foo() {}
 // 関数式
 x = function hello() {}
 
-
 if (x) {
    // 関数式
    function world() {}
 }
-
 
 // 関数宣言
 function a() {
@@ -450,11 +431,11 @@ function a() {
 }
 </pre>
 
-<h2 id="Block-level_functions" name="Block-level_functions">ブロックレベル関数</h2>
+<h2 id="Block-level_functions">ブロックレベル関数</h2>
 
-<p>ES2015 で始まった <a href="/ja/docs/Web/JavaScript/Strict_mode">strict モード</a>では、ブロック内の関数はそのブロックに新しいスコープを形成します。ES2015 より前では、ブロックレベル関数は strict モードでは禁止されています。</p>
+<p><a href="/ja/docs/Web/JavaScript/Reference/Strict_mode">strict モード</a>では ES2015 から、ブロック内の関数はそのブロックに新しいスコープを形成します。 ES2015 より前では、ブロックレベル関数は strict モードでは禁止されています。</p>
 
-<pre class="brush: js notranslate">'use strict';
+<pre class="brush: js">'use strict';
 
 function f() {
   return 1;
@@ -471,13 +452,13 @@ f() === 1; // true
 // 非 strict モードでは f() === 2
 </pre>
 
-<h3 id="Conditionally_defining_a_function" name="Conditionally_defining_a_function">非 strict コードにおけるブロックレベル関数</h3>
+<h3 id="Block-level_functions_in_non-strict_code">非 strict コードにおけるブロックレベル関数</h3>
 
-<p>一言、使わないでください。</p>
+<p>一言で言えば、使わないでください。</p>
 
 <p>非 strict コードでは、ブロック内の関数宣言は奇妙な動作をします。次の例を見てください。</p>
 
-<pre class="brush: js notranslate">if (shouldDefineZero) {
+<pre class="brush: js">if (shouldDefineZero) {
    function zero() {     // 危険: 互換性リスク
       console.log("This is zero.");
    }
@@ -486,11 +467,11 @@ f() === 1; // true
 
 <p>ES2015 では <code>shouldDefineZero</code> が false の場合、このブロックが実行されることはないので、<code>zero</code> は決して定義されないとされています。しかし、これは標準において新しいパーツです。歴史的には、このことは仕様とならないまま残されていました。いくつかのブラウザーでは、ブロックが実行されてもされなくても、<code>zero</code> を定義したでしょう。</p>
 
-<p><a href="/ja/docs/Web/JavaScript/Reference/Strict_mode">strict モード</a>では、ES2015 をサポートする全てのブラウザーは、これを同じように扱います。<code>zero</code> は <code>shouldDefineZero</code> が true の場合のみ定義され、かつ <code>if</code> ブロックのスコープに限られます。</p>
+<p><a href="/ja/docs/Web/JavaScript/Reference/Strict_mode">strict モード</a>では、ES2015 に対応するブラウザーはすべて、これを同じように扱います。 <code>zero</code> は <code>shouldDefineZero</code> が true の場合のみ定義され、かつ <code>if</code> ブロックのスコープに限られます。</p>
 
 <p>条件付きで関数を定義するより安全な方法は、変数に関数式を代入することです。</p>
 
-<pre class="brush: js notranslate">var zero;
+<pre class="brush: js">var zero;
 if (shouldDefineZero) {
    zero = function() {
       console.log("This is zero.");
@@ -498,13 +479,13 @@ if (shouldDefineZero) {
 }
 </pre>
 
-<h2 id="例">例</h2>
+<h2 id="Examples_2">例</h2>
 
-<h3 id="Returning_a_formatted_number" name="Returning_a_formatted_number">フォーマットされた数値を返す</h3>
+<h3 id="Returning_a_formatted_number">整形された数値を返す</h3>
 
 <p>次の関数は、数値の先頭にゼロを足して固定長にした形で表される文字列を返します。</p>
 
-<pre class="brush: js notranslate">// この関数は先頭にゼロを足して固定長にした文字列を返す
+<pre class="brush: js">// この関数は先頭にゼロを足して固定長にした文字列を返す
 function padZeros(num, totalLen) {
    var numStr = num.toString();             // 戻り値を文字列に初期化する
    var numZeros = totalLen - numStr.length; // ゼロの数を計算する
@@ -517,17 +498,17 @@ function padZeros(num, totalLen) {
 
 <p>次の文で padZeros 関数を呼び出します。</p>
 
-<pre class="brush: js notranslate">var result;
+<pre class="brush: js">var result;
 result = padZeros(42,4); // "0042" を返す
 result = padZeros(42,2); // "42" を返す
 result = padZeros(5,4);  // "0005" を返す
 </pre>
 
-<h3 id="Determining_whether_a_function_exists" name="Determining_whether_a_function_exists">関数が存在するかどうか確認する</h3>
+<h3 id="Determining_whether_a_function_exists">関数が存在するかどうか確認する</h3>
 
-<p><code>typeof</code> 演算子を使うと関数が存在するかどうかを確かめる事ができます。次の例では、<code>window</code> オブジェクトが <code>noFunc</code> という関数のプロパティを持つかどうかを確かめるためのテストが行われます。もし持っていたら、それが使われます。そうでなければ、他の行動が取られます。</p>
+<p><code>typeof</code> 演算子を使うと関数が存在するかどうかを確かめることができます。次の例では、<code>window</code> オブジェクトが <code>noFunc</code> という関数のプロパティを持つかどうかを確かめるためのテストが行われます。もし持っていたら、それが使われます。そうでなければ、他の行動が取られます。</p>
 
-<pre class="brush: js notranslate"> if ('function' == typeof window.noFunc) {
+<pre class="brush: js"> if ('function' == typeof window.noFunc) {
    // noFunc() を使う
  } else {
    // 何か他のことをする
@@ -536,40 +517,40 @@ result = padZeros(5,4);  // "0005" を返す
 
 <p><code>if</code> のテストの中で、<code>noFunc</code> への参照が使われているのに注目してください。関数名の後に括弧 "()" が無いので、実際の関数は呼ばれません。</p>
 
-<h2 id="Specifications" name="Specifications">仕様</h2>
+<h2 id="Specifications">仕様書</h2>
 
 <table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">仕様書</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-function-definitions', 'Function definitions')}}</td>
-  </tr>
- </tbody>
+  <thead>
+    <tr>
+      <th scope="col">仕様書</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{SpecName('ESDraft', '#sec-function-definitions', 'Function definitions')}}</td>
+    </tr>
+  </tbody>
 </table>
 
-<h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
-
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、<a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
+<h2 id="Browser_compatibility">ブラウザーの互換性</h2>
 
 <p>{{Compat("javascript.functions")}}</p>
 
-<h2 id="See_also" name="See_also">関連情報</h2>
+<h2 id="See_also">関連情報</h2>
 
 <ul>
- <li>{{jsxref("Statements/function", "function 文")}}</li>
- <li>{{jsxref("Operators/function", "function 演算子")}}</li>
- <li>{{jsxref("Statements/function*", "function* 文")}}</li>
- <li>{{jsxref("Operators/function*", "function* 演算子")}}</li>
- <li>{{jsxref("Function")}}</li>
- <li>{{jsxref("GeneratorFunction", "ジェネレーター関数")}}</li>
- <li>{{jsxref("Functions/Arrow_functions", "アロー関数")}}</li>
- <li>{{jsxref("Functions/Default_parameters", "デフォルト引数")}}</li>
- <li>{{jsxref("Functions/rest_parameters", "Rest parameters")}}</li>
- <li>{{jsxref("Functions/arguments", "arguments オブジェクト")}}</li>
- <li>{{jsxref("Functions/get", "getter")}}</li>
- <li>{{jsxref("Functions/set", "setter")}}</li>
- <li>{{jsxref("Functions/Method_definitions", "メソッド定義")}}</li>
- <li><a href="/ja/docs/Web/JavaScript/Reference/Functions_and_function_scope">関数と関数スコープ</a></li>
+  <li>{{jsxref("Statements/function", "function 文")}}</li>
+  <li>{{jsxref("Operators/function", "function 式")}}</li>
+  <li>{{jsxref("Statements/function*", "function* 文")}}</li>
+  <li>{{jsxref("Operators/function*", "function* 式")}}</li>
+  <li>{{jsxref("Function")}}</li>
+  <li>{{jsxref("GeneratorFunction", "ジェネレーター関数")}}</li>
+  <li>{{jsxref("Functions/Arrow_functions", "アロー関数")}}</li>
+  <li>{{jsxref("Functions/Default_parameters", "デフォルト引数")}}</li>
+  <li>{{jsxref("Functions/rest_parameters", "残余引数")}}</li>
+  <li>{{jsxref("Functions/arguments", "arguments オブジェクト")}}</li>
+  <li>{{jsxref("Functions/get", "getter")}}</li>
+  <li>{{jsxref("Functions/set", "setter")}}</li>
+  <li>{{jsxref("Functions/Method_definitions", "メソッド定義")}}</li>
+  <li><a href="/ja/docs/Web/JavaScript/Reference/Functions">関数と関数スコープ</a></li>
 </ul>

--- a/files/ja/web/javascript/reference/functions/index.html
+++ b/files/ja/web/javascript/reference/functions/index.html
@@ -8,13 +8,14 @@ tags:
   - JavaScript
   - Parameter
   - parameters
+browser-compat: javascript.functions
 translation_of: Web/JavaScript/Reference/Functions
 ---
 <div>{{jsSidebar("Functions")}}</div>
 
 <p>一般的に言うと、関数とは外部 (再帰の場合は内部) から <em>呼び出す</em> ことのできる「サブプログラム」です。プログラムそのもののように、関数は関数本体 (<em>function body</em>) と呼ばれる連続した文で構成されます。値を関数に <em>渡す</em> ことができ、関数は値を<em>返す</em>ことができます。</p>
 
-<p>JavaScript において、関数は第一級オブジェクトです。すなわち、関数はオブジェクトであり、他のあらゆるオブジェクトと同じように操作したり渡したりすることができます。具体的には、関数は <code><a href="/ja/docs/Web/JavaScript/Reference/Global_Objects/Function" title="Ja/JavaScript/Reference/Global_Objects/Function">Function</a></code> オブジェクトです。</p>
+<p>JavaScript において、関数は第一級オブジェクトです。すなわち、関数はオブジェクトであり、他のあらゆるオブジェクトと同じように操作したり渡したりすることができます。具体的には、関数は <code><a href="/ja/docs/Web/JavaScript/Reference/Global_Objects/Function">Function</a></code> オブジェクトです。</p>
 
 <p>より詳細な例や解説については、<a href="/ja/docs/Web/JavaScript/Guide/Functions">JavaScript の関数のガイド</a>を参照してください。</p>
 
@@ -534,7 +535,7 @@ result = padZeros(5,4);  // "0005" を返す
 
 <h2 id="Browser_compatibility">ブラウザーの互換性</h2>
 
-<p>{{Compat("javascript.functions")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">関連情報</h2>
 

--- a/files/ja/web/opensearch/index.html
+++ b/files/ja/web/opensearch/index.html
@@ -1,146 +1,161 @@
 ---
-title: Creating OpenSearch plugins for Firefox
+title: OpenSearch 記述形式
 slug: Web/OpenSearch
 tags:
   - Add-ons
+  - Guide
+  - OpenSearch
+  - Search
   - Search plugins
+  - Web
+  - Web Standards
 translation_of: Web/OpenSearch
 original_slug: Creating_OpenSearch_plugins_for_Firefox
 ---
-<h2 id="OpenSearch" name="OpenSearch">OpenSearch</h2>
-<p><a href="/ja/Firefox_2_for_developers" title="ja/Firefox_2_for_developers">Firefox 2</a> は検索プラグインとして <a class="external" href="http://opensearch.org/">OpenSearch</a> 記述フォーマットをサポートしています。<a class="external" href="http://www.opensearch.org/Specifications/OpenSearch/1.1#OpenSearch_description_document">OpenSearch 記述シンタックス</a>を使ったプラグインは IE 7 と Firefox で互換性があります。このため、ウェブでの利用で推奨されたフォーマットです。</p>
-<p>Firefox は{{ 訳語("検索サジェスト", "search suggestions") }}と <code>SearchForm</code> 要素のような <a class="external" href="http://www.opensearch.org/Specifications/OpenSearch/1.1#OpenSearch_description_document">OpenSearch 記述シンタックス</a>に含まれていない追加の検索機能もサポートします。この記事では Firefox 特有の機能をサポートした OpenSearch 互換の検索プラグインの作成にフォーカスをあてていきます。</p>
-<p>OpenSearch 記述ファイルは<a href="#.E6.A4.9C.E7.B4.A2.E3.83.97.E3.83.A9.E3.82.B0.E3.82.A4.E3.83.B3.E3.81.AE.E8.87.AA.E5.8B.95.E6.A4.9C.E5.87.BA">検索プラグインの自動検出</a>に書かれているように通知でき、<a href="/ja/Adding_search_engines_from_web_pages" title="ja/Adding_search_engines_from_web_pages">Web ページから検索エンジンを追加する</a>に書かれているようにプログラム的にインストールできます。</p>
-<h2 id="OpenSearch_.E8.A8.98.E8.BF.B0.E3.83.95.E3.82.A1.E3.82.A4.E3.83.AB" name="OpenSearch_.E8.A8.98.E8.BF.B0.E3.83.95.E3.82.A1.E3.82.A4.E3.83.AB">OpenSearch 記述ファイル</h2>
-<p>検索エンジンを記述した XML ファイルはとてもシンプルで、以下の基本的なテンプレートに従います。あなたが書いている検索エンジンに応じて、斜体になっている箇所をカスタマイズする必要があります。</p>
-<pre class="eval">&lt;OpenSearchDescription xmlns="<span class="nowiki">http://a9.com/-/spec/opensearch/1.1/</span>"
-                       xmlns:moz="<span class="nowiki">http://www.mozilla.org/2006/browser/search/</span>"&gt;
-&lt;ShortName&gt;<em>engineName</em>&lt;/ShortName&gt;
-&lt;Description&gt;<em>engineDescription</em>&lt;/Description&gt;
-&lt;InputEncoding&gt;<em>inputEncoding</em>&lt;/InputEncoding&gt;
-&lt;Image width="16" height="16"&gt;data:image/x-icon;base64,<em>imageData</em>&lt;/Image&gt;
-&lt;Url type="text/html" method="<em>method</em>" template="<em>searchURL</em>"&gt;
-  &lt;Param name="<em>paramName1</em>" value="<em>paramValue1</em>"/&gt;
-  ...
-  &lt;Param name="<em>paramNameN</em>" value="<em>paramValueN</em>"/&gt;
-&lt;/Url&gt;
-&lt;Url type="application/x-suggestions+json" template="<em>suggestionURL</em>"/&gt;
-&lt;moz:SearchForm&gt;<em>searchFormURL</em>&lt;/moz:SearchForm&gt;
-&lt;/OpenSearchDescription&gt;
+<p>{{AddonSidebar}}</p>
+
+<p><span class="seoSummary"><strong><a href="https://github.com/dewitt/opensearch" rel="external">OpenSearch 記述形式</a></strong>は、ウェブサイトが自分自身のために検索エンジンを記述し、ブラウザーやその他のクライアントアプリケーションがその検索エンジンを使用できるようにするものです。 OpenSearch は、(少なくとも) Firefox、Edge、Internet Explorer、Safari、Chrome が対応しています。(他のブラウザーのドキュメントへのリンクは<a href="#reference_material">参考資料</a>をご覧ください。)</p>
+
+<p>また、Firefox では、検索候補や <code>&lt;SearchForm&gt;</code> 要素など、OpenSearch 規格にない追加機能にも対応しています。この記事では、これらの Firefox の追加機能に対応した OpenSearch 互換の検索プラグインの作成に焦点を当てます。</p>
+
+<p>OpenSearch 記述ファイルは、<a href="#autodiscovery_of_search_plugins">検索プラグインの自動検出</a>で説明されているように通知することができ、<a href="/ja/docs/Web/OpenSearch">ウェブページからの検索エンジンの追加</a>で説明されているようにプログラムでインストールすることができます。</p>
+
+<h2 id="OpenSearch_description_file">OpenSearch 記述ファイル</h2>
+
+<p>検索エンジンを記述する XML ファイルはとてもシンプルで、以下の基本的なテンプレートに従います。書いている検索エンジンに応じて、 <em>[角括弧]</em> で囲まれた部分をカスタマイズする必要があります。</p>
+
+<pre class="brush: xml">&lt;OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
+                       xmlns:moz="http://www.mozilla.org/2006/browser/search/"&gt;
+  &lt;ShortName&gt;<mark><strong>[SNK]</strong></mark>&lt;/ShortName&gt;
+  &lt;Description&gt;<mark><strong>[Search engine full name and summary]</strong></mark>&lt;/Description&gt;
+  &lt;InputEncoding&gt;<mark><strong>[UTF-8]</strong></mark>&lt;/InputEncoding&gt;
+  &lt;Image width="16" height="16" type="image/x-icon"&gt;<mark><strong>[https://example.com/favicon.ico]</strong></mark>&lt;/Image&gt;
+  &lt;Url type="text/html" template="<mark><strong>[searchURL]</strong></mark>"&gt;
+    &lt;Param name="<mark><strong>[key name]</strong></mark>" value="{searchTerms}"/&gt;
+    &lt;!-- other Params if you need them… --&gt;
+    &lt;Param name="<mark><strong>[other key name]</strong></mark>" value="<mark><strong>[parameter value]</strong></mark>"/&gt;
+  &lt;/Url&gt;
+  &lt;Url type="application/x-suggestions+json" template="<mark><strong>[suggestionURL]</strong></mark>"/&gt;
+  &lt;moz:SearchForm&gt;<mark><strong>[https://example.com/search]</strong></mark>&lt;/moz:SearchForm&gt;
+&lt;/OpenSearchDescription&gt;</pre>
+
+<dl>
+ <dt>ShortName</dt>
+ <dd>検索エンジンの短い名前です。 HTML やその他のマークアップを使用しない、 <string>16 文字以下</string>のプレーンテキストでなければなりません。</dd>
+ <dt>Description</dt>
+ <dd>検索エンジンの簡単な説明です。 <strong>1024 文字以下</strong>のプレーンテキストで、 HTML やその他のマークアップは使用しないでください。</dd>
+ <dt>InputEncoding</dt>
+  <dd>検索エンジンへ送信する入力欄に使用する<a href="/ja/docs/Glossary/character_encoding">文字エンコーディング</a>です。</dd>
+ <dt>Image</dt>
+ <dd>
+ <p>検索エンジンのアイコンの URI です。可能であれば、 16×16 の画像を <code>image/x-icon</code> 形式で (<code>/favicon.ico</code> など)、 および 64×64 の画像を <code>image/jpeg</code> または <code>image/png</code> 形式で含めてください。</p>
+
+ <p>この URI には <a href="/ja/docs/Web/HTTP/Basics_of_HTTP/Data_URIs"><code>data:</code> URI スキーム</a>を使用することもできます。 (<code>data:</code> URI はアイコンファイルから <a class="external" href="http://software.hixie.ch/utilities/cgi/data/data">The <code>data:</code> URI kitchen</a> で生成することができます。)</p>
+
+ <pre class="brush: xml">&lt;Image height="16" width="16" type="image/x-icon"&gt;https://example.com/favicon.ico&lt;/Image&gt;
+  &lt;!-- or --&gt;
+&lt;Image height="16" width="16"&gt;data:image/x-icon;base64,AAABAAEAEBAAA … DAAA=&lt;/Image&gt;
 </pre>
-<dl>
-  <dt>
-    <strong>ShortName</strong></dt>
-  <dd>
-    検索エンジンの短い名前。</dd>
+
+ <p>Firefox はアイコンを <a href="https://ja.wikipedia.org/wiki/Base64">base64</a> <code>data:</code> URI としてキャッシュします (検索プラグインは<a href="/ja/docs/Mozilla/Profile_Manager">プロファイル</a>の <code>searchplugins/</code> フォルダーに格納されます)。これを行う際に、 <code>http:</code> および <code>https:</code> URL は <code>data:</code> URI に変換されます。</p>
+
+ <div class="note"><strong>注:</strong> リモートからアイコンを読み込む際 (すなわち、  <code>data:</code> URI とは対照的に <code>https://</code> URI からの場合)、 Firefox は<strong>10 KB</strong>より大きなアイコンを拒否します。</div>
+
+ <p><img alt="Firefox の検索ボックスに表示される Google の検索候補" class="internal" src="searchsuggestionsample.png"></p>
+ </dd>
+ <dt>Url</dt>
+ <dd>検索に使う 1 つまたは複数の URL を記述します。 <code>template</code> 属性は検索クエリーのベース URL を指定します。</dd>
+ <dd>Firefox は 3 種類の URL に対応しています。</dd>
+ <ul>
+  <li><code>type="text/html"</code> は実際の検索結果そのものの URL を指定します。</li>
+  <li><code>type="application/x-suggestions+json"</code> は検索候補を読み取るための URL を指定します。 Firefox 63 以降では、 <code>type="application/json"</code> をこの別名として受け付けます。</li>
+  <li><code>type="application/x-moz-keywordsearch"</code> はロケーションバーに入力されるキーワード検索の際に使用する URL を指定します。これは Firefox のみが対応しています。</li>
+ </ul>
+
+ <p>これらの種類の URL では、ユーザーが検索バーやロケーションバーに入力した検索語に置き換えらえる <code>{searchTerms}</code> を使うことができます。対応している他の動的な検索引数は <a class="external" href="http://www.opensearch.org/Specifications/OpenSearch/1.1/Draft_3#OpenSearch_1.1_parameters">OpenSearch 1.1 引数</a>に記述されています。</p>
+
+ <p>検索候補については、 <code>application/x-suggestions+json</code> URL テンプレートを使用して候補リストを <a href="/ja/docs/Glossary/JSON">JSON</a> 形式で読み取ります。サーバー上で検索候補の対応を実装する方法の詳細は <a href="/ja/docs/Archive/Add-ons/Supporting_search_suggestions_in_search_plugins">検索プラグインでの検索候補の対応</a>を参照してください。</p>
+ </dd>
+ <dt>Param</dt>
+ <dd>検索クエリと一緒に渡さなければならない引数を、キー／値のペアで指定します。値を指定する際に、 <code>{searchTerms}</code> を使用すると、ユーザーが検索バーに入力した検索語を挿入することができます。</dd>
+ <dt>moz:SearchForm</dt>
+<dd>プラグインのサイトの検索ページを開くための URL。これは Firefox にユーザーが直接ウェブサイトを訪れる方法を提供します。</dd>
+ <dd>
+ <div class="note"><strong>注意:</strong> この要素は Firefox 特有で OpenSearch 仕様の一部ではないため、この要素に対応していない他のユーザーエージェントが安全に無視できるようにするために、上の例では "<code>moz:</code>" XML 名前空間接頭辞を使っています。</div>
+ </dd>
 </dl>
-<dl>
-  <dt>
-    <strong>Description</strong></dt>
-  <dd>
-    検索エンジンの簡単な説明。</dd>
-</dl>
-<dl>
-  <dt>
-    <strong>InputEncoding</strong></dt>
-  <dd>
-    検索エンジンがデータの入力に使っているエンコーディング。</dd>
-</dl>
-<dl>
-  <dt>
-    <strong>Image</strong></dt>
-  <dd>
-    検索エンジンを表す Base-64 でエンコードされた 16x16 のアイコン。ここに置くためのデータを作成するのに使える便利なツールの一つはここで見付かります: <a class="external" href="http://software.hixie.ch/utilities/cgi/data/data">The data: URI kitchen</a>。</dd>
-</dl>
-<dl>
-  <dt>
-    <strong>Url</strong></dt>
-  <dd>
-    検索に使う 1 つまたは複数の URL を記述します。<code>method</code> 属性は結果を得るために <code>GET</code> と <code>POST</code> リクエストのどちらを使うか指定します。<code>template</code> 属性は検索クエリのベースとなる URL を指定します。</dd>
-  <dd>
-    <div class="note">
-      <strong>注意:</strong> Internet Explorer 7 は <code>POST</code> リクエストをサポートしていません。</div>
-  </dd>
-</dl>
-<dl>
-  <dd>
-    Firefox がサポートしている URL タイプは 2 つです:</dd>
-</dl>
-<ul>
-  <li><code>type="text/html"</code> は実際の検索結果そのものの URL を設定するために使われます。</li>
-  <li><code>type="application/x-suggestions+json"</code> は検索サジェストを得るために使われる URL を設定するために使われます。</li>
-</ul>
-<dl>
-  <dd>
-    どちらの URL のタイプでも、ユーザが検索バーに入力した検索語句に置き換えられる <code>{searchTerms}</code> を使うことができます。サポートしている他の動的な検索パラメータは <a class="external" href="http://www.opensearch.org/Specifications/OpenSearch/1.1/Draft_3#OpenSearch_1.1_parameters">OpenSearch 1.1 パラメータ</a>に記述されています。</dd>
-</dl>
-<dl>
-  <dd>
-    検索サジェストのクエリに指定された URL のテンプレートは JavaScript Object Notation (JSON) フォーマットで補完リストを取得するために使われます。サーバ上で検索サジェストのサポートを実装する方法の詳細は <a href="/ja/Supporting_search_suggestions_in_search_plugins" title="ja/Supporting_search_suggestions_in_search_plugins">検索プラグインでの検索サジェストのサポート</a>を見てください。</dd>
-</dl>
-<p><img alt="Image:SearchSuggestionSample.png" class="internal" src="/@api/deki/files/1794/=SearchSuggestionSample.png"></p>
-<dl>
-  <dt>
-    <strong>Param</strong></dt>
-  <dd>
-    検索クエリともに通過させるために必要なキー/値のペアのパラメータです。この値を指定する際にはユーザが検索バーに入力した検索語句を挿入するための <code>{searchTerms}</code> を使うことができます。</dd>
-  <dd>
-    <div class="note">
-      <strong>注意:</strong> Internet Explorer 7 はこの要素をサポートしていません。</div>
-  </dd>
-</dl>
-<dl>
-  <dt>
-    <strong>SearchForm</strong></dt>
-  <dd>
-    プラグインのサイトの検索ページを開くための URL。これは Firefox にユーザが直接 Web サイトを訪れる方法を提供します。</dd>
-  <dd>
-    <div class="note">
-      <strong>注意:</strong> この要素は Firefox 特有で OpenSearch 仕様の一部ではないため、この要素をサポートしていない他のユーザエージェントが安全に無視できるようにするために、上の例では "<code>moz:</code>" XML 名前空間接頭辞を使っています。</div>
-  </dd>
-</dl>
-<h2 id=".E6.A4.9C.E7.B4.A2.E3.83.97.E3.83.A9.E3.82.B0.E3.82.A4.E3.83.B3.E3.81.AE.E8.A8.B3.E8.AA.9E.E8.87.AA.E5.8B.95.E6.A4.9C.E5.87.BAAutodiscovery" name=".E6.A4.9C.E7.B4.A2.E3.83.97.E3.83.A9.E3.82.B0.E3.82.A4.E3.83.B3.E3.81.AE.E8.A8.B3.E8.AA.9E.E8.87.AA.E5.8B.95.E6.A4.9C.E5.87.BAAutodiscovery">検索プラグインの{{ 訳語("自動検出", "Autodiscovery") }}</h2>
-<p>検索プラグインを提供しているウェブサイトは Firefox ユーザがプラグインを簡単にダウンロードしてインストールできるように通知することができます。</p>
-<p>自動検出をサポートするには、ウェブページの <code>&lt;HEAD&gt;</code> セクションに単に一行追加するだけです。</p>
-<pre class="eval">&lt;link rel="search" type="application/opensearchdescription+xml" title="<em>searchTitle</em>" href="<em>pluginURL</em>"&gt;
+
+<h2 id="Autodiscovery_of_search_plugins">検索プラグインの自動検出</h2>
+
+<p>検索プラグインを提供しているウェブサイトは、 Firefox ユーザがプラグインを簡単にダウンロードしてインストールできるように通知することができます。</p>
+
+<p>自動検出に対応するには、それぞれのプラグインの <code>&lt;link&gt;</code> 要素をウェブページの <code>&lt;head&gt;</code> セクションにします。</p>
+
+<pre class="brush: html; highlight[3-4]">&lt;link rel="search"
+      type="application/opensearchdescription+xml"
+      title="<mark><strong>searchTitle</strong></mark>"
+      href="<mark><strong>pluginURL</strong></mark>"&gt;
 </pre>
-<p>斜体の項目を以下で説明されているように置き換えてください。</p>
+
+<p>太字の項目を以下の説明のように置き換えてください。</p>
+
 <dl>
-  <dt>
-    <strong>searchTitle</strong></dt>
-  <dd>
-    "MDC を検索" や 'Yahoo! 検索" のような実行する検索の名前です。この値は、プラグインファイルの ShortName と一致させる必要があります。</dd>
+ <dt>searchTitle</dt>
+ <dd>"MDC を検索" や 'Yahoo! 検索" のような実行する検索の名前です。この値は、プラグインファイルの <code>&lt;ShortName&gt;</code> と一致させる必要があります。</dd>
+ <dt>pluginURL</dt>
+ <dd>ブラウザーがダウンロードできる XML 検索プラグインの URL です。</dd>
 </dl>
-<dl>
-  <dt>
-    <strong>pluginURL</strong></dt>
-  <dd>
-    ブラウザがダウンロードできる XML 検索プラグインの URL です。</dd>
-</dl>
-<p>もしあなたのサイトが複数の検索プラグインを提供しているなら、それら全ての自動検出をサポートすることができます。例:</p>
-<pre class="eval">&lt;link rel="search" type="application/opensearchdescription+xml" title="MySite: 著者" href="<a class="external" href="http://www.mysite.com/mysiteauthor.xml" rel="freelink">http://www.mysite.com/mysiteauthor.xml</a>"&gt;
-&lt;link rel="search" type="application/opensearchdescription+xml" title="MySite: タイトル" href="<a class="external" href="http://www.mysite.com/mysitetitle.xml" rel="freelink">http://www.mysite.com/mysitetitle.xml</a>"&gt;
+
+<p>もしサイトが複数の検索プラグインを提供しているなら、すべてを自動検出させることができます。例を示します。</p>
+
+<pre class="brush: html">&lt;link rel="search" type="application/opensearchdescription+xml"
+      title="MySite: 著者" href="http://example.com/mysiteauthor.xml"&gt;
+
+&lt;link rel="search" type="application/opensearchdescription+xml"
+      title="MySite: タイトル" href="http://example.com/mysitetitle.xml"&gt;
 </pre>
-<p>この方法であなたのサイトは著者による検索とタイトルによる検索を行うプラグインを別々のものとしてを提供することができます。</p>
-<h2 id=".E3.83.88.E3.83.A9.E3.83.96.E3.83.AB.E3.82.B7.E3.83.A5.E3.83.BC.E3.83.86.E3.82.A3.E3.83.B3.E3.82.B0.E3.81.AE.E3.83.92.E3.83.B3.E3.83.88" name=".E3.83.88.E3.83.A9.E3.83.96.E3.83.AB.E3.82.B7.E3.83.A5.E3.83.BC.E3.83.86.E3.82.A3.E3.83.B3.E3.82.B0.E3.81.AE.E3.83.92.E3.83.B3.E3.83.88">トラブルシューティングのヒント</h2>
-<p>検索プラグインの XML に問題があると、検出されたプラグインを Firefox 2 に追加する際にエラーが発生するでしょう。エラーメッセージは完全な参考になるわけではありません、しかし、以下のヒントが問題を探す手助けになるでしょう。</p>
+
+<p>この方法で、著者とタイトルによる検索を行うプラグインをサイトで提供することができます。</p>
+
+<div class="note">
+<p>Firefox では、検索プラグインで提供されたアイコンがある場合は、検索ボックスのアイコンが変化して示します。 (画像を参照。緑のプラスの記号です。) そのため、ユーザーのインターフェイスで検索ボックスが非表示になっている場合、これを示すことは<em>ありません</em>。<em>一般に、この動作はブラウザーによって異なります</em>。</p>
+<img alt="Firefox での検索プラグインの見え方" src="new.png"></div>
+
+<h2 id="Supporting_automatic_updates_for_OpenSearch_plugins">OpenSearch プラグインの自動更新の対応</h2>
+
+<p>OpenSearch プラグインは自動的に更新することができます。 <code>Url</code> 拡張要素を <code>type="application/opensearchdescription+xml"</code> および <code>rel="self"</code> を付けて設置してください。 <code>template</code> 属性には、自動的に更新する OpenSearch 文書の URL を設定してください。</p>
+
+<p>例:</p>
+
+<pre class="brush: xml">&lt;Url type="application/opensearchdescription+xml"
+     rel="self"
+     template="https://example.com/mysearchdescription.xml" /&gt;
+</pre>
+
+<div class="note"><strong>注:</strong> 現時点で、 <a class="external" href="https://addons.mozilla.org">addons.mozilla.org</a> (AMO) は OpenSearch プラグインの自動更新に対応していません。自分の検索プラグインを AMO に登録したい場合は、送信前に自動更新機能を削除してください。</div>
+
+<h2 id="Troubleshooting_Tips">トラブルシューティングのヒント</h2>
+
+<p>検索プラグインの XML に問題があると、検出されたプラグインをに追加する際にエラーが発生します。エラーメッセージが参考にならない場合、以下のヒントが問題を探す手助けになる可能性があります。</p>
+
 <ul>
-  <li>検索プラグインが{{ 原語併記("整形式", "well formed") }}か確認してください。</li>
+ <li>サーバーは OpenSearch プラグインを、 <code>Content-Type: application/opensearchdescription+xml</code> を使用して提供するべきです。</li>
+ <li>検索プラグインの XML が整形式であることを確認してください。ファイルを直接 Firefox に読み込むことでチェックすることができます。アンパーサンド (&amp;) を <code>template</code> の URL の中では <code>&amp;amp;</code> にエスケープしなければなりません。タグは最後にスラッシュをまたは対応する終了タグで閉じる必要があります。</li>
+ <li><code>xmlns</code> 属性は重要です。 — これがないと、 "Firefox could not download the search plugin" というエラーメッセージが出る可能性があります。</li>
+ <li><code>text/html</code> の URL を含める<strong>必要があります</strong>。 Atom または <a href="/ja/docs/Glossary/RSS">RSS</a> の URL 型のみを含む検索プラグインは (有効なものですが、 Firefox は対応していません)、 "could not download the search plugin" エラーを引き起こします。</li>
+ <li>リモートで取得されるファビコンは 10KB 以上でなければなりません ({{ Bug(361923) }} を参照)。</li>
 </ul>
-<p>ファイルを Firefox に直接読みこませることによって確認できます。テンプレート URL の中のアンパサンド(&amp;)は &amp;amp; でエスケープされている必要があり、タグは最後のスラッシュか一致する終了タグで閉じられている必要があります。</p>
+
+<p>さらに、検索プラグインサービスはプラグイン開発者に役立つであろうログの仕組みを提供します。 <code>about:config</code> を使い '<code>browser.search.log</code>' を <code>true</code> に設定してください。検索プラグインが追加されるとログ情報が Firefox の<a href="/ja/docs/Archive/Mozilla/Error_console">エラーコンソール</a> (ツール ➤ エラーコンソール)に表示されます。</p>
+
+<h2 id="Reference_Material">参考資料</h2>
+
 <ul>
-  <li><code>xmlns</code> 属性が重要です。<code>xmlns</code> 属性無しでは "Firefox は次の場所から検索エンジンをダウンロードできませんでした:(URL)" というエラーメッセージを受け取るでしょう。</li>
-  <li><code>text/html</code> URL を含めなくては<strong>ならない</strong> ことに注意してください — Atom や <a href="/ja/RSS" title="ja/RSS">RSS</a> URL タイプしか含まない検索エンジン(それは妥当なのですが、Firefox はサポートしていません) は "検索エンジンをダウンロードできませんでした"というエラーを引き起こします。</li>
-</ul>
-<p><br>
-  さらに、検索プラグインサービスはプラグイン開発者が使うであろうログの仕組みを提供します。<em>about:config</em> を使い '<code>browser.search.log</code>' を <code>true</code> にしてください。検索プラグインが追加されるとログ情報が Firefox の<a href="/ja/JavaScript_Console" title="ja/JavaScript_Console">エラーコンソール</a>(ツール -&gt; エラーコンソール)に表示されます。</p>
-<h2 id=".E5.8F.82.E8.80.83.E8.B3.87.E6.96.99" name=".E5.8F.82.E8.80.83.E8.B3.87.E6.96.99">参考資料</h2>
-<ul>
-  <li><a class="external" href="http://opensearch.a9.com/">OpenSearch ドキュメント</a></li>
-  <li>Technorati.com には <a class="external" href="http://technorati.com/osd.xml">動作する osd.xml</a> があります。</li>
-  <li>自動検出の更なる問題は bugzilla {{ Bug(340208) }}</li>
-  <li><a class="external" href="http://en.wikipedia.org/wiki/Data:_URI_scheme"><code>data:&lt;code&gt; URI スキーマ</code></a></li>
-  <li><a class="external" href="http://searchy.protecus.de/">Searchy</a> - あなた自身のを<a class="external" href="http://searchy.protecus.de/en/add2.php">作成</a>、あるいは<a class="external" href="http://searchy.protecus.de/en/searchbox-add-ons.php">検索プラグインのリスト</a>を利用する</li>
-  <li><a class="external" href="http://www.searchplugins.net">searchplugins.net</a> - OpenSearch プラグインの作成(日本語不可, POSTメソッド可) <a class="external" href="http://www.searchplugins.net/pluginlist.aspx">作成された検索プラグインのリスト</a></li>
-  <li><a class="external" href="http://ready.to/search/jp/">Ready2Search</a> - OpenSearch プラグインの作成(日本語可, GETメソッドのみ) <a class="external" href="http://ready.to/search/make/">Ready2Searchでの検索プラグイン作成</a>,<a class="external" href="http://ready.to/search/list/#setind">カテゴリー別の検索設定インデックス</a></li>
+ <li><a href="https://github.com/dewitt/opensearch">OpenSearch ドキュメント</a></li>
+ <li><a href="https://developer.apple.com/library/archive/releasenotes/General/WhatsNewInSafari/Articles/Safari_8_0.html">Safari 8.0 リリースノート: Quick Website Search</a></li>
+ <li><a href="https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/browser-features/search-provider-discovery">Microsoft Edge 開発ガイド: Search provider discovery</a></li>
+ <li><a href="https://www.chromium.org/tab-to-search">The Chromium Projects: Tab to Search</a></li>
+ <li>imdb.com には <a class="external" href="https://m.media-amazon.com/images/G/01/imdb/images/imdbsearch-3349468880._CB470047351_.xml">動作する <code>osd.xml</code></a> があります</li>
+ <li><a class="external" href="http://www.7is7.com/software/firefox/opensearch.html">OpenSearch Plugin Generator</a></li>
+ <li><a class="external" href="http://ready.to/search/jp/">Ready2Search</a> - OpenSearch プラグインの作成 (日本語可, GETメソッドのみ)。 <a class="external" href="http://ready.to/search/make/en_make_plugin.htm">Customized Search through Ready2Search</a></li>
 </ul>

--- a/files/ja/web/opensearch/index.html
+++ b/files/ja/web/opensearch/index.html
@@ -1,161 +1,146 @@
 ---
-title: OpenSearch 記述形式
+title: Creating OpenSearch plugins for Firefox
 slug: Web/OpenSearch
 tags:
   - Add-ons
-  - Guide
-  - OpenSearch
-  - Search
   - Search plugins
-  - Web
-  - Web Standards
 translation_of: Web/OpenSearch
 original_slug: Creating_OpenSearch_plugins_for_Firefox
 ---
-<p>{{AddonSidebar}}</p>
-
-<p><span class="seoSummary"><strong><a href="https://github.com/dewitt/opensearch" rel="external">OpenSearch 記述形式</a></strong>は、ウェブサイトが自分自身のために検索エンジンを記述し、ブラウザーやその他のクライアントアプリケーションがその検索エンジンを使用できるようにするものです。 OpenSearch は、(少なくとも) Firefox、Edge、Internet Explorer、Safari、Chrome が対応しています。(他のブラウザーのドキュメントへのリンクは<a href="#reference_material">参考資料</a>をご覧ください。)</p>
-
-<p>また、Firefox では、検索候補や <code>&lt;SearchForm&gt;</code> 要素など、OpenSearch 規格にない追加機能にも対応しています。この記事では、これらの Firefox の追加機能に対応した OpenSearch 互換の検索プラグインの作成に焦点を当てます。</p>
-
-<p>OpenSearch 記述ファイルは、<a href="#autodiscovery_of_search_plugins">検索プラグインの自動検出</a>で説明されているように通知することができ、<a href="/ja/docs/Web/OpenSearch">ウェブページからの検索エンジンの追加</a>で説明されているようにプログラムでインストールすることができます。</p>
-
-<h2 id="OpenSearch_description_file">OpenSearch 記述ファイル</h2>
-
-<p>検索エンジンを記述する XML ファイルはとてもシンプルで、以下の基本的なテンプレートに従います。書いている検索エンジンに応じて、 <em>[角括弧]</em> で囲まれた部分をカスタマイズする必要があります。</p>
-
-<pre class="brush: xml">&lt;OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
-                       xmlns:moz="http://www.mozilla.org/2006/browser/search/"&gt;
-  &lt;ShortName&gt;<mark><strong>[SNK]</strong></mark>&lt;/ShortName&gt;
-  &lt;Description&gt;<mark><strong>[Search engine full name and summary]</strong></mark>&lt;/Description&gt;
-  &lt;InputEncoding&gt;<mark><strong>[UTF-8]</strong></mark>&lt;/InputEncoding&gt;
-  &lt;Image width="16" height="16" type="image/x-icon"&gt;<mark><strong>[https://example.com/favicon.ico]</strong></mark>&lt;/Image&gt;
-  &lt;Url type="text/html" template="<mark><strong>[searchURL]</strong></mark>"&gt;
-    &lt;Param name="<mark><strong>[key name]</strong></mark>" value="{searchTerms}"/&gt;
-    &lt;!-- other Params if you need them… --&gt;
-    &lt;Param name="<mark><strong>[other key name]</strong></mark>" value="<mark><strong>[parameter value]</strong></mark>"/&gt;
-  &lt;/Url&gt;
-  &lt;Url type="application/x-suggestions+json" template="<mark><strong>[suggestionURL]</strong></mark>"/&gt;
-  &lt;moz:SearchForm&gt;<mark><strong>[https://example.com/search]</strong></mark>&lt;/moz:SearchForm&gt;
-&lt;/OpenSearchDescription&gt;</pre>
-
+<h2 id="OpenSearch" name="OpenSearch">OpenSearch</h2>
+<p><a href="/ja/Firefox_2_for_developers" title="ja/Firefox_2_for_developers">Firefox 2</a> は検索プラグインとして <a class="external" href="http://opensearch.org/">OpenSearch</a> 記述フォーマットをサポートしています。<a class="external" href="http://www.opensearch.org/Specifications/OpenSearch/1.1#OpenSearch_description_document">OpenSearch 記述シンタックス</a>を使ったプラグインは IE 7 と Firefox で互換性があります。このため、ウェブでの利用で推奨されたフォーマットです。</p>
+<p>Firefox は{{ 訳語("検索サジェスト", "search suggestions") }}と <code>SearchForm</code> 要素のような <a class="external" href="http://www.opensearch.org/Specifications/OpenSearch/1.1#OpenSearch_description_document">OpenSearch 記述シンタックス</a>に含まれていない追加の検索機能もサポートします。この記事では Firefox 特有の機能をサポートした OpenSearch 互換の検索プラグインの作成にフォーカスをあてていきます。</p>
+<p>OpenSearch 記述ファイルは<a href="#.E6.A4.9C.E7.B4.A2.E3.83.97.E3.83.A9.E3.82.B0.E3.82.A4.E3.83.B3.E3.81.AE.E8.87.AA.E5.8B.95.E6.A4.9C.E5.87.BA">検索プラグインの自動検出</a>に書かれているように通知でき、<a href="/ja/Adding_search_engines_from_web_pages" title="ja/Adding_search_engines_from_web_pages">Web ページから検索エンジンを追加する</a>に書かれているようにプログラム的にインストールできます。</p>
+<h2 id="OpenSearch_.E8.A8.98.E8.BF.B0.E3.83.95.E3.82.A1.E3.82.A4.E3.83.AB" name="OpenSearch_.E8.A8.98.E8.BF.B0.E3.83.95.E3.82.A1.E3.82.A4.E3.83.AB">OpenSearch 記述ファイル</h2>
+<p>検索エンジンを記述した XML ファイルはとてもシンプルで、以下の基本的なテンプレートに従います。あなたが書いている検索エンジンに応じて、斜体になっている箇所をカスタマイズする必要があります。</p>
+<pre class="eval">&lt;OpenSearchDescription xmlns="<span class="nowiki">http://a9.com/-/spec/opensearch/1.1/</span>"
+                       xmlns:moz="<span class="nowiki">http://www.mozilla.org/2006/browser/search/</span>"&gt;
+&lt;ShortName&gt;<em>engineName</em>&lt;/ShortName&gt;
+&lt;Description&gt;<em>engineDescription</em>&lt;/Description&gt;
+&lt;InputEncoding&gt;<em>inputEncoding</em>&lt;/InputEncoding&gt;
+&lt;Image width="16" height="16"&gt;data:image/x-icon;base64,<em>imageData</em>&lt;/Image&gt;
+&lt;Url type="text/html" method="<em>method</em>" template="<em>searchURL</em>"&gt;
+  &lt;Param name="<em>paramName1</em>" value="<em>paramValue1</em>"/&gt;
+  ...
+  &lt;Param name="<em>paramNameN</em>" value="<em>paramValueN</em>"/&gt;
+&lt;/Url&gt;
+&lt;Url type="application/x-suggestions+json" template="<em>suggestionURL</em>"/&gt;
+&lt;moz:SearchForm&gt;<em>searchFormURL</em>&lt;/moz:SearchForm&gt;
+&lt;/OpenSearchDescription&gt;
+</pre>
 <dl>
- <dt>ShortName</dt>
- <dd>検索エンジンの短い名前です。 HTML やその他のマークアップを使用しない、 <string>16 文字以下</string>のプレーンテキストでなければなりません。</dd>
- <dt>Description</dt>
- <dd>検索エンジンの簡単な説明です。 <strong>1024 文字以下</strong>のプレーンテキストで、 HTML やその他のマークアップは使用しないでください。</dd>
- <dt>InputEncoding</dt>
-  <dd>検索エンジンへ送信する入力欄に使用する<a href="/ja/docs/Glossary/character_encoding">文字エンコーディング</a>です。</dd>
- <dt>Image</dt>
- <dd>
- <p>検索エンジンのアイコンの URI です。可能であれば、 16×16 の画像を <code>image/x-icon</code> 形式で (<code>/favicon.ico</code> など)、 および 64×64 の画像を <code>image/jpeg</code> または <code>image/png</code> 形式で含めてください。</p>
-
- <p>この URI には <a href="/ja/docs/Web/HTTP/Basics_of_HTTP/Data_URIs"><code>data:</code> URI スキーム</a>を使用することもできます。 (<code>data:</code> URI はアイコンファイルから <a class="external" href="http://software.hixie.ch/utilities/cgi/data/data">The <code>data:</code> URI kitchen</a> で生成することができます。)</p>
-
- <pre class="brush: xml">&lt;Image height="16" width="16" type="image/x-icon"&gt;https://example.com/favicon.ico&lt;/Image&gt;
-  &lt;!-- or --&gt;
-&lt;Image height="16" width="16"&gt;data:image/x-icon;base64,AAABAAEAEBAAA … DAAA=&lt;/Image&gt;
-</pre>
-
- <p>Firefox はアイコンを <a href="https://ja.wikipedia.org/wiki/Base64">base64</a> <code>data:</code> URI としてキャッシュします (検索プラグインは<a href="/ja/docs/Mozilla/Profile_Manager">プロファイル</a>の <code>searchplugins/</code> フォルダーに格納されます)。これを行う際に、 <code>http:</code> および <code>https:</code> URL は <code>data:</code> URI に変換されます。</p>
-
- <div class="note"><strong>注:</strong> リモートからアイコンを読み込む際 (すなわち、  <code>data:</code> URI とは対照的に <code>https://</code> URI からの場合)、 Firefox は<strong>10 KB</strong>より大きなアイコンを拒否します。</div>
-
- <p><img alt="Firefox の検索ボックスに表示される Google の検索候補" class="internal" src="searchsuggestionsample.png"></p>
- </dd>
- <dt>Url</dt>
- <dd>検索に使う 1 つまたは複数の URL を記述します。 <code>template</code> 属性は検索クエリーのベース URL を指定します。</dd>
- <dd>Firefox は 3 種類の URL に対応しています。</dd>
- <ul>
-  <li><code>type="text/html"</code> は実際の検索結果そのものの URL を指定します。</li>
-  <li><code>type="application/x-suggestions+json"</code> は検索候補を読み取るための URL を指定します。 Firefox 63 以降では、 <code>type="application/json"</code> をこの別名として受け付けます。</li>
-  <li><code>type="application/x-moz-keywordsearch"</code> はロケーションバーに入力されるキーワード検索の際に使用する URL を指定します。これは Firefox のみが対応しています。</li>
- </ul>
-
- <p>これらの種類の URL では、ユーザーが検索バーやロケーションバーに入力した検索語に置き換えらえる <code>{searchTerms}</code> を使うことができます。対応している他の動的な検索引数は <a class="external" href="http://www.opensearch.org/Specifications/OpenSearch/1.1/Draft_3#OpenSearch_1.1_parameters">OpenSearch 1.1 引数</a>に記述されています。</p>
-
- <p>検索候補については、 <code>application/x-suggestions+json</code> URL テンプレートを使用して候補リストを <a href="/ja/docs/Glossary/JSON">JSON</a> 形式で読み取ります。サーバー上で検索候補の対応を実装する方法の詳細は <a href="/ja/docs/Archive/Add-ons/Supporting_search_suggestions_in_search_plugins">検索プラグインでの検索候補の対応</a>を参照してください。</p>
- </dd>
- <dt>Param</dt>
- <dd>検索クエリと一緒に渡さなければならない引数を、キー／値のペアで指定します。値を指定する際に、 <code>{searchTerms}</code> を使用すると、ユーザーが検索バーに入力した検索語を挿入することができます。</dd>
- <dt>moz:SearchForm</dt>
-<dd>プラグインのサイトの検索ページを開くための URL。これは Firefox にユーザーが直接ウェブサイトを訪れる方法を提供します。</dd>
- <dd>
- <div class="note"><strong>注意:</strong> この要素は Firefox 特有で OpenSearch 仕様の一部ではないため、この要素に対応していない他のユーザーエージェントが安全に無視できるようにするために、上の例では "<code>moz:</code>" XML 名前空間接頭辞を使っています。</div>
- </dd>
+  <dt>
+    <strong>ShortName</strong></dt>
+  <dd>
+    検索エンジンの短い名前。</dd>
 </dl>
-
-<h2 id="Autodiscovery_of_search_plugins">検索プラグインの自動検出</h2>
-
-<p>検索プラグインを提供しているウェブサイトは、 Firefox ユーザがプラグインを簡単にダウンロードしてインストールできるように通知することができます。</p>
-
-<p>自動検出に対応するには、それぞれのプラグインの <code>&lt;link&gt;</code> 要素をウェブページの <code>&lt;head&gt;</code> セクションにします。</p>
-
-<pre class="brush: html; highlight[3-4]">&lt;link rel="search"
-      type="application/opensearchdescription+xml"
-      title="<mark><strong>searchTitle</strong></mark>"
-      href="<mark><strong>pluginURL</strong></mark>"&gt;
-</pre>
-
-<p>太字の項目を以下の説明のように置き換えてください。</p>
-
 <dl>
- <dt>searchTitle</dt>
- <dd>"MDC を検索" や 'Yahoo! 検索" のような実行する検索の名前です。この値は、プラグインファイルの <code>&lt;ShortName&gt;</code> と一致させる必要があります。</dd>
- <dt>pluginURL</dt>
- <dd>ブラウザーがダウンロードできる XML 検索プラグインの URL です。</dd>
+  <dt>
+    <strong>Description</strong></dt>
+  <dd>
+    検索エンジンの簡単な説明。</dd>
 </dl>
-
-<p>もしサイトが複数の検索プラグインを提供しているなら、すべてを自動検出させることができます。例を示します。</p>
-
-<pre class="brush: html">&lt;link rel="search" type="application/opensearchdescription+xml"
-      title="MySite: 著者" href="http://example.com/mysiteauthor.xml"&gt;
-
-&lt;link rel="search" type="application/opensearchdescription+xml"
-      title="MySite: タイトル" href="http://example.com/mysitetitle.xml"&gt;
-</pre>
-
-<p>この方法で、著者とタイトルによる検索を行うプラグインをサイトで提供することができます。</p>
-
-<div class="note">
-<p>Firefox では、検索プラグインで提供されたアイコンがある場合は、検索ボックスのアイコンが変化して示します。 (画像を参照。緑のプラスの記号です。) そのため、ユーザーのインターフェイスで検索ボックスが非表示になっている場合、これを示すことは<em>ありません</em>。<em>一般に、この動作はブラウザーによって異なります</em>。</p>
-<img alt="Firefox での検索プラグインの見え方" src="new.png"></div>
-
-<h2 id="Supporting_automatic_updates_for_OpenSearch_plugins">OpenSearch プラグインの自動更新の対応</h2>
-
-<p>OpenSearch プラグインは自動的に更新することができます。 <code>Url</code> 拡張要素を <code>type="application/opensearchdescription+xml"</code> および <code>rel="self"</code> を付けて設置してください。 <code>template</code> 属性には、自動的に更新する OpenSearch 文書の URL を設定してください。</p>
-
-<p>例:</p>
-
-<pre class="brush: xml">&lt;Url type="application/opensearchdescription+xml"
-     rel="self"
-     template="https://example.com/mysearchdescription.xml" /&gt;
-</pre>
-
-<div class="note"><strong>注:</strong> 現時点で、 <a class="external" href="https://addons.mozilla.org">addons.mozilla.org</a> (AMO) は OpenSearch プラグインの自動更新に対応していません。自分の検索プラグインを AMO に登録したい場合は、送信前に自動更新機能を削除してください。</div>
-
-<h2 id="Troubleshooting_Tips">トラブルシューティングのヒント</h2>
-
-<p>検索プラグインの XML に問題があると、検出されたプラグインをに追加する際にエラーが発生します。エラーメッセージが参考にならない場合、以下のヒントが問題を探す手助けになる可能性があります。</p>
-
+<dl>
+  <dt>
+    <strong>InputEncoding</strong></dt>
+  <dd>
+    検索エンジンがデータの入力に使っているエンコーディング。</dd>
+</dl>
+<dl>
+  <dt>
+    <strong>Image</strong></dt>
+  <dd>
+    検索エンジンを表す Base-64 でエンコードされた 16x16 のアイコン。ここに置くためのデータを作成するのに使える便利なツールの一つはここで見付かります: <a class="external" href="http://software.hixie.ch/utilities/cgi/data/data">The data: URI kitchen</a>。</dd>
+</dl>
+<dl>
+  <dt>
+    <strong>Url</strong></dt>
+  <dd>
+    検索に使う 1 つまたは複数の URL を記述します。<code>method</code> 属性は結果を得るために <code>GET</code> と <code>POST</code> リクエストのどちらを使うか指定します。<code>template</code> 属性は検索クエリのベースとなる URL を指定します。</dd>
+  <dd>
+    <div class="note">
+      <strong>注意:</strong> Internet Explorer 7 は <code>POST</code> リクエストをサポートしていません。</div>
+  </dd>
+</dl>
+<dl>
+  <dd>
+    Firefox がサポートしている URL タイプは 2 つです:</dd>
+</dl>
 <ul>
- <li>サーバーは OpenSearch プラグインを、 <code>Content-Type: application/opensearchdescription+xml</code> を使用して提供するべきです。</li>
- <li>検索プラグインの XML が整形式であることを確認してください。ファイルを直接 Firefox に読み込むことでチェックすることができます。アンパーサンド (&amp;) を <code>template</code> の URL の中では <code>&amp;amp;</code> にエスケープしなければなりません。タグは最後にスラッシュをまたは対応する終了タグで閉じる必要があります。</li>
- <li><code>xmlns</code> 属性は重要です。 — これがないと、 "Firefox could not download the search plugin" というエラーメッセージが出る可能性があります。</li>
- <li><code>text/html</code> の URL を含める<strong>必要があります</strong>。 Atom または <a href="/ja/docs/Glossary/RSS">RSS</a> の URL 型のみを含む検索プラグインは (有効なものですが、 Firefox は対応していません)、 "could not download the search plugin" エラーを引き起こします。</li>
- <li>リモートで取得されるファビコンは 10KB 以上でなければなりません ({{ Bug(361923) }} を参照)。</li>
+  <li><code>type="text/html"</code> は実際の検索結果そのものの URL を設定するために使われます。</li>
+  <li><code>type="application/x-suggestions+json"</code> は検索サジェストを得るために使われる URL を設定するために使われます。</li>
 </ul>
-
-<p>さらに、検索プラグインサービスはプラグイン開発者に役立つであろうログの仕組みを提供します。 <code>about:config</code> を使い '<code>browser.search.log</code>' を <code>true</code> に設定してください。検索プラグインが追加されるとログ情報が Firefox の<a href="/ja/docs/Archive/Mozilla/Error_console">エラーコンソール</a> (ツール ➤ エラーコンソール)に表示されます。</p>
-
-<h2 id="Reference_Material">参考資料</h2>
-
+<dl>
+  <dd>
+    どちらの URL のタイプでも、ユーザが検索バーに入力した検索語句に置き換えられる <code>{searchTerms}</code> を使うことができます。サポートしている他の動的な検索パラメータは <a class="external" href="http://www.opensearch.org/Specifications/OpenSearch/1.1/Draft_3#OpenSearch_1.1_parameters">OpenSearch 1.1 パラメータ</a>に記述されています。</dd>
+</dl>
+<dl>
+  <dd>
+    検索サジェストのクエリに指定された URL のテンプレートは JavaScript Object Notation (JSON) フォーマットで補完リストを取得するために使われます。サーバ上で検索サジェストのサポートを実装する方法の詳細は <a href="/ja/Supporting_search_suggestions_in_search_plugins" title="ja/Supporting_search_suggestions_in_search_plugins">検索プラグインでの検索サジェストのサポート</a>を見てください。</dd>
+</dl>
+<p><img alt="Image:SearchSuggestionSample.png" class="internal" src="/@api/deki/files/1794/=SearchSuggestionSample.png"></p>
+<dl>
+  <dt>
+    <strong>Param</strong></dt>
+  <dd>
+    検索クエリともに通過させるために必要なキー/値のペアのパラメータです。この値を指定する際にはユーザが検索バーに入力した検索語句を挿入するための <code>{searchTerms}</code> を使うことができます。</dd>
+  <dd>
+    <div class="note">
+      <strong>注意:</strong> Internet Explorer 7 はこの要素をサポートしていません。</div>
+  </dd>
+</dl>
+<dl>
+  <dt>
+    <strong>SearchForm</strong></dt>
+  <dd>
+    プラグインのサイトの検索ページを開くための URL。これは Firefox にユーザが直接 Web サイトを訪れる方法を提供します。</dd>
+  <dd>
+    <div class="note">
+      <strong>注意:</strong> この要素は Firefox 特有で OpenSearch 仕様の一部ではないため、この要素をサポートしていない他のユーザエージェントが安全に無視できるようにするために、上の例では "<code>moz:</code>" XML 名前空間接頭辞を使っています。</div>
+  </dd>
+</dl>
+<h2 id=".E6.A4.9C.E7.B4.A2.E3.83.97.E3.83.A9.E3.82.B0.E3.82.A4.E3.83.B3.E3.81.AE.E8.A8.B3.E8.AA.9E.E8.87.AA.E5.8B.95.E6.A4.9C.E5.87.BAAutodiscovery" name=".E6.A4.9C.E7.B4.A2.E3.83.97.E3.83.A9.E3.82.B0.E3.82.A4.E3.83.B3.E3.81.AE.E8.A8.B3.E8.AA.9E.E8.87.AA.E5.8B.95.E6.A4.9C.E5.87.BAAutodiscovery">検索プラグインの{{ 訳語("自動検出", "Autodiscovery") }}</h2>
+<p>検索プラグインを提供しているウェブサイトは Firefox ユーザがプラグインを簡単にダウンロードしてインストールできるように通知することができます。</p>
+<p>自動検出をサポートするには、ウェブページの <code>&lt;HEAD&gt;</code> セクションに単に一行追加するだけです。</p>
+<pre class="eval">&lt;link rel="search" type="application/opensearchdescription+xml" title="<em>searchTitle</em>" href="<em>pluginURL</em>"&gt;
+</pre>
+<p>斜体の項目を以下で説明されているように置き換えてください。</p>
+<dl>
+  <dt>
+    <strong>searchTitle</strong></dt>
+  <dd>
+    "MDC を検索" や 'Yahoo! 検索" のような実行する検索の名前です。この値は、プラグインファイルの ShortName と一致させる必要があります。</dd>
+</dl>
+<dl>
+  <dt>
+    <strong>pluginURL</strong></dt>
+  <dd>
+    ブラウザがダウンロードできる XML 検索プラグインの URL です。</dd>
+</dl>
+<p>もしあなたのサイトが複数の検索プラグインを提供しているなら、それら全ての自動検出をサポートすることができます。例:</p>
+<pre class="eval">&lt;link rel="search" type="application/opensearchdescription+xml" title="MySite: 著者" href="<a class="external" href="http://www.mysite.com/mysiteauthor.xml" rel="freelink">http://www.mysite.com/mysiteauthor.xml</a>"&gt;
+&lt;link rel="search" type="application/opensearchdescription+xml" title="MySite: タイトル" href="<a class="external" href="http://www.mysite.com/mysitetitle.xml" rel="freelink">http://www.mysite.com/mysitetitle.xml</a>"&gt;
+</pre>
+<p>この方法であなたのサイトは著者による検索とタイトルによる検索を行うプラグインを別々のものとしてを提供することができます。</p>
+<h2 id=".E3.83.88.E3.83.A9.E3.83.96.E3.83.AB.E3.82.B7.E3.83.A5.E3.83.BC.E3.83.86.E3.82.A3.E3.83.B3.E3.82.B0.E3.81.AE.E3.83.92.E3.83.B3.E3.83.88" name=".E3.83.88.E3.83.A9.E3.83.96.E3.83.AB.E3.82.B7.E3.83.A5.E3.83.BC.E3.83.86.E3.82.A3.E3.83.B3.E3.82.B0.E3.81.AE.E3.83.92.E3.83.B3.E3.83.88">トラブルシューティングのヒント</h2>
+<p>検索プラグインの XML に問題があると、検出されたプラグインを Firefox 2 に追加する際にエラーが発生するでしょう。エラーメッセージは完全な参考になるわけではありません、しかし、以下のヒントが問題を探す手助けになるでしょう。</p>
 <ul>
- <li><a href="https://github.com/dewitt/opensearch">OpenSearch ドキュメント</a></li>
- <li><a href="https://developer.apple.com/library/archive/releasenotes/General/WhatsNewInSafari/Articles/Safari_8_0.html">Safari 8.0 リリースノート: Quick Website Search</a></li>
- <li><a href="https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/browser-features/search-provider-discovery">Microsoft Edge 開発ガイド: Search provider discovery</a></li>
- <li><a href="https://www.chromium.org/tab-to-search">The Chromium Projects: Tab to Search</a></li>
- <li>imdb.com には <a class="external" href="https://m.media-amazon.com/images/G/01/imdb/images/imdbsearch-3349468880._CB470047351_.xml">動作する <code>osd.xml</code></a> があります</li>
- <li><a class="external" href="http://www.7is7.com/software/firefox/opensearch.html">OpenSearch Plugin Generator</a></li>
- <li><a class="external" href="http://ready.to/search/jp/">Ready2Search</a> - OpenSearch プラグインの作成 (日本語可, GETメソッドのみ)。 <a class="external" href="http://ready.to/search/make/en_make_plugin.htm">Customized Search through Ready2Search</a></li>
+  <li>検索プラグインが{{ 原語併記("整形式", "well formed") }}か確認してください。</li>
+</ul>
+<p>ファイルを Firefox に直接読みこませることによって確認できます。テンプレート URL の中のアンパサンド(&amp;)は &amp;amp; でエスケープされている必要があり、タグは最後のスラッシュか一致する終了タグで閉じられている必要があります。</p>
+<ul>
+  <li><code>xmlns</code> 属性が重要です。<code>xmlns</code> 属性無しでは "Firefox は次の場所から検索エンジンをダウンロードできませんでした:(URL)" というエラーメッセージを受け取るでしょう。</li>
+  <li><code>text/html</code> URL を含めなくては<strong>ならない</strong> ことに注意してください — Atom や <a href="/ja/RSS" title="ja/RSS">RSS</a> URL タイプしか含まない検索エンジン(それは妥当なのですが、Firefox はサポートしていません) は "検索エンジンをダウンロードできませんでした"というエラーを引き起こします。</li>
+</ul>
+<p><br>
+  さらに、検索プラグインサービスはプラグイン開発者が使うであろうログの仕組みを提供します。<em>about:config</em> を使い '<code>browser.search.log</code>' を <code>true</code> にしてください。検索プラグインが追加されるとログ情報が Firefox の<a href="/ja/JavaScript_Console" title="ja/JavaScript_Console">エラーコンソール</a>(ツール -&gt; エラーコンソール)に表示されます。</p>
+<h2 id=".E5.8F.82.E8.80.83.E8.B3.87.E6.96.99" name=".E5.8F.82.E8.80.83.E8.B3.87.E6.96.99">参考資料</h2>
+<ul>
+  <li><a class="external" href="http://opensearch.a9.com/">OpenSearch ドキュメント</a></li>
+  <li>Technorati.com には <a class="external" href="http://technorati.com/osd.xml">動作する osd.xml</a> があります。</li>
+  <li>自動検出の更なる問題は bugzilla {{ Bug(340208) }}</li>
+  <li><a class="external" href="http://en.wikipedia.org/wiki/Data:_URI_scheme"><code>data:&lt;code&gt; URI スキーマ</code></a></li>
+  <li><a class="external" href="http://searchy.protecus.de/">Searchy</a> - あなた自身のを<a class="external" href="http://searchy.protecus.de/en/add2.php">作成</a>、あるいは<a class="external" href="http://searchy.protecus.de/en/searchbox-add-ons.php">検索プラグインのリスト</a>を利用する</li>
+  <li><a class="external" href="http://www.searchplugins.net">searchplugins.net</a> - OpenSearch プラグインの作成(日本語不可, POSTメソッド可) <a class="external" href="http://www.searchplugins.net/pluginlist.aspx">作成された検索プラグインのリスト</a></li>
+  <li><a class="external" href="http://ready.to/search/jp/">Ready2Search</a> - OpenSearch プラグインの作成(日本語可, GETメソッドのみ) <a class="external" href="http://ready.to/search/make/">Ready2Searchでの検索プラグイン作成</a>,<a class="external" href="http://ready.to/search/list/#setind">カテゴリー別の検索設定インデックス</a></li>
 </ul>


### PR DESCRIPTION
- 「原語併記」マクロを廃止 (https://github.com/mozilla-japan/translation/issues/547 関連)
- 2021/02/20 時点の英語版に同期