### PR TITLE
Delete duplicate line in Array.prototype.fill()

### DIFF
--- a/files/ru/web/javascript/reference/global_objects/array/fill/index.html
+++ b/files/ru/web/javascript/reference/global_objects/array/fill/index.html
@@ -61,7 +61,6 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Array/fill
 [1, 2, 3].fill(4, 1, 2);         // [1, 4, 3]
 [1, 2, 3].fill(4, 1, 1);         // [1, 2, 3]
 [1, 2, 3].fill(4, 3, 3);         // [1, 2, 3]
-[1, 2, 3].fill(4, 3, 3);         // [1, 2, 3]
 [1, 2, 3].fill(4, -3, -2);       // [4, 2, 3]
 [1, 2, 3].fill(4, NaN, NaN);     // [1, 2, 3]
 [1, 2, 3].fill(4, 3, 5);         // [1, 2, 3]


### PR DESCRIPTION
Fixes #638: deletes duplicate string `[1, 2, 3].fill(4, 3, 3); // [1, 2, 3]`.