### PR TITLE
Web/OpenSearch を更新

### DIFF
--- a/files/ja/web/opensearch/index.html
+++ b/files/ja/web/opensearch/index.html
@@ -1,146 +1,161 @@
 ---
-title: Creating OpenSearch plugins for Firefox
+title: OpenSearch 記述形式
 slug: Web/OpenSearch
 tags:
   - Add-ons
+  - Guide
+  - OpenSearch
+  - Search
   - Search plugins
+  - Web
+  - Web Standards
 translation_of: Web/OpenSearch
 original_slug: Creating_OpenSearch_plugins_for_Firefox
 ---
-<h2 id="OpenSearch" name="OpenSearch">OpenSearch</h2>
-<p><a href="/ja/Firefox_2_for_developers" title="ja/Firefox_2_for_developers">Firefox 2</a> は検索プラグインとして <a class="external" href="http://opensearch.org/">OpenSearch</a> 記述フォーマットをサポートしています。<a class="external" href="http://www.opensearch.org/Specifications/OpenSearch/1.1#OpenSearch_description_document">OpenSearch 記述シンタックス</a>を使ったプラグインは IE 7 と Firefox で互換性があります。このため、ウェブでの利用で推奨されたフォーマットです。</p>
-<p>Firefox は{{ 訳語("検索サジェスト", "search suggestions") }}と <code>SearchForm</code> 要素のような <a class="external" href="http://www.opensearch.org/Specifications/OpenSearch/1.1#OpenSearch_description_document">OpenSearch 記述シンタックス</a>に含まれていない追加の検索機能もサポートします。この記事では Firefox 特有の機能をサポートした OpenSearch 互換の検索プラグインの作成にフォーカスをあてていきます。</p>
-<p>OpenSearch 記述ファイルは<a href="#.E6.A4.9C.E7.B4.A2.E3.83.97.E3.83.A9.E3.82.B0.E3.82.A4.E3.83.B3.E3.81.AE.E8.87.AA.E5.8B.95.E6.A4.9C.E5.87.BA">検索プラグインの自動検出</a>に書かれているように通知でき、<a href="/ja/Adding_search_engines_from_web_pages" title="ja/Adding_search_engines_from_web_pages">Web ページから検索エンジンを追加する</a>に書かれているようにプログラム的にインストールできます。</p>
-<h2 id="OpenSearch_.E8.A8.98.E8.BF.B0.E3.83.95.E3.82.A1.E3.82.A4.E3.83.AB" name="OpenSearch_.E8.A8.98.E8.BF.B0.E3.83.95.E3.82.A1.E3.82.A4.E3.83.AB">OpenSearch 記述ファイル</h2>
-<p>検索エンジンを記述した XML ファイルはとてもシンプルで、以下の基本的なテンプレートに従います。あなたが書いている検索エンジンに応じて、斜体になっている箇所をカスタマイズする必要があります。</p>
-<pre class="eval">&lt;OpenSearchDescription xmlns="<span class="nowiki">http://a9.com/-/spec/opensearch/1.1/</span>"
-                       xmlns:moz="<span class="nowiki">http://www.mozilla.org/2006/browser/search/</span>"&gt;
-&lt;ShortName&gt;<em>engineName</em>&lt;/ShortName&gt;
-&lt;Description&gt;<em>engineDescription</em>&lt;/Description&gt;
-&lt;InputEncoding&gt;<em>inputEncoding</em>&lt;/InputEncoding&gt;
-&lt;Image width="16" height="16"&gt;data:image/x-icon;base64,<em>imageData</em>&lt;/Image&gt;
-&lt;Url type="text/html" method="<em>method</em>" template="<em>searchURL</em>"&gt;
-  &lt;Param name="<em>paramName1</em>" value="<em>paramValue1</em>"/&gt;
-  ...
-  &lt;Param name="<em>paramNameN</em>" value="<em>paramValueN</em>"/&gt;
-&lt;/Url&gt;
-&lt;Url type="application/x-suggestions+json" template="<em>suggestionURL</em>"/&gt;
-&lt;moz:SearchForm&gt;<em>searchFormURL</em>&lt;/moz:SearchForm&gt;
-&lt;/OpenSearchDescription&gt;
+<p>{{AddonSidebar}}</p>
+
+<p><span class="seoSummary"><strong><a href="https://github.com/dewitt/opensearch" rel="external">OpenSearch 記述形式</a></strong>は、ウェブサイトが自分自身のために検索エンジンを記述し、ブラウザーやその他のクライアントアプリケーションがその検索エンジンを使用できるようにするものです。 OpenSearch は、(少なくとも) Firefox、Edge、Internet Explorer、Safari、Chrome が対応しています。(他のブラウザーのドキュメントへのリンクは<a href="#reference_material">参考資料</a>をご覧ください。)</p>
+
+<p>また、Firefox では、検索候補や <code>&lt;SearchForm&gt;</code> 要素など、OpenSearch 規格にない追加機能にも対応しています。この記事では、これらの Firefox の追加機能に対応した OpenSearch 互換の検索プラグインの作成に焦点を当てます。</p>
+
+<p>OpenSearch 記述ファイルは、<a href="#autodiscovery_of_search_plugins">検索プラグインの自動検出</a>で説明されているように通知することができ、<a href="/ja/docs/Web/OpenSearch">ウェブページからの検索エンジンの追加</a>で説明されているようにプログラムでインストールすることができます。</p>
+
+<h2 id="OpenSearch_description_file">OpenSearch 記述ファイル</h2>
+
+<p>検索エンジンを記述する XML ファイルはとてもシンプルで、以下の基本的なテンプレートに従います。書いている検索エンジンに応じて、 <em>[角括弧]</em> で囲まれた部分をカスタマイズする必要があります。</p>
+
+<pre class="brush: xml">&lt;OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
+                       xmlns:moz="http://www.mozilla.org/2006/browser/search/"&gt;
+  &lt;ShortName&gt;<mark><strong>[SNK]</strong></mark>&lt;/ShortName&gt;
+  &lt;Description&gt;<mark><strong>[Search engine full name and summary]</strong></mark>&lt;/Description&gt;
+  &lt;InputEncoding&gt;<mark><strong>[UTF-8]</strong></mark>&lt;/InputEncoding&gt;
+  &lt;Image width="16" height="16" type="image/x-icon"&gt;<mark><strong>[https://example.com/favicon.ico]</strong></mark>&lt;/Image&gt;
+  &lt;Url type="text/html" template="<mark><strong>[searchURL]</strong></mark>"&gt;
+    &lt;Param name="<mark><strong>[key name]</strong></mark>" value="{searchTerms}"/&gt;
+    &lt;!-- other Params if you need them… --&gt;
+    &lt;Param name="<mark><strong>[other key name]</strong></mark>" value="<mark><strong>[parameter value]</strong></mark>"/&gt;
+  &lt;/Url&gt;
+  &lt;Url type="application/x-suggestions+json" template="<mark><strong>[suggestionURL]</strong></mark>"/&gt;
+  &lt;moz:SearchForm&gt;<mark><strong>[https://example.com/search]</strong></mark>&lt;/moz:SearchForm&gt;
+&lt;/OpenSearchDescription&gt;</pre>
+
+<dl>
+ <dt>ShortName</dt>
+ <dd>検索エンジンの短い名前です。 HTML やその他のマークアップを使用しない、 <string>16 文字以下</string>のプレーンテキストでなければなりません。</dd>
+ <dt>Description</dt>
+ <dd>検索エンジンの簡単な説明です。 <strong>1024 文字以下</strong>のプレーンテキストで、 HTML やその他のマークアップは使用しないでください。</dd>
+ <dt>InputEncoding</dt>
+  <dd>検索エンジンへ送信する入力欄に使用する<a href="/ja/docs/Glossary/character_encoding">文字エンコーディング</a>です。</dd>
+ <dt>Image</dt>
+ <dd>
+ <p>検索エンジンのアイコンの URI です。可能であれば、 16×16 の画像を <code>image/x-icon</code> 形式で (<code>/favicon.ico</code> など)、 および 64×64 の画像を <code>image/jpeg</code> または <code>image/png</code> 形式で含めてください。</p>
+
+ <p>この URI には <a href="/ja/docs/Web/HTTP/Basics_of_HTTP/Data_URIs"><code>data:</code> URI スキーム</a>を使用することもできます。 (<code>data:</code> URI はアイコンファイルから <a class="external" href="http://software.hixie.ch/utilities/cgi/data/data">The <code>data:</code> URI kitchen</a> で生成することができます。)</p>
+
+ <pre class="brush: xml">&lt;Image height="16" width="16" type="image/x-icon"&gt;https://example.com/favicon.ico&lt;/Image&gt;
+  &lt;!-- or --&gt;
+&lt;Image height="16" width="16"&gt;data:image/x-icon;base64,AAABAAEAEBAAA … DAAA=&lt;/Image&gt;
 </pre>
-<dl>
-  <dt>
-    <strong>ShortName</strong></dt>
-  <dd>
-    検索エンジンの短い名前。</dd>
+
+ <p>Firefox はアイコンを <a href="https://ja.wikipedia.org/wiki/Base64">base64</a> <code>data:</code> URI としてキャッシュします (検索プラグインは<a href="/ja/docs/Mozilla/Profile_Manager">プロファイル</a>の <code>searchplugins/</code> フォルダーに格納されます)。これを行う際に、 <code>http:</code> および <code>https:</code> URL は <code>data:</code> URI に変換されます。</p>
+
+ <div class="note"><strong>注:</strong> リモートからアイコンを読み込む際 (すなわち、  <code>data:</code> URI とは対照的に <code>https://</code> URI からの場合)、 Firefox は<strong>10 KB</strong>より大きなアイコンを拒否します。</div>
+
+ <p><img alt="Firefox の検索ボックスに表示される Google の検索候補" class="internal" src="searchsuggestionsample.png"></p>
+ </dd>
+ <dt>Url</dt>
+ <dd>検索に使う 1 つまたは複数の URL を記述します。 <code>template</code> 属性は検索クエリーのベース URL を指定します。</dd>
+ <dd>Firefox は 3 種類の URL に対応しています。</dd>
+ <ul>
+  <li><code>type="text/html"</code> は実際の検索結果そのものの URL を指定します。</li>
+  <li><code>type="application/x-suggestions+json"</code> は検索候補を読み取るための URL を指定します。 Firefox 63 以降では、 <code>type="application/json"</code> をこの別名として受け付けます。</li>
+  <li><code>type="application/x-moz-keywordsearch"</code> はロケーションバーに入力されるキーワード検索の際に使用する URL を指定します。これは Firefox のみが対応しています。</li>
+ </ul>
+
+ <p>これらの種類の URL では、ユーザーが検索バーやロケーションバーに入力した検索語に置き換えらえる <code>{searchTerms}</code> を使うことができます。対応している他の動的な検索引数は <a class="external" href="http://www.opensearch.org/Specifications/OpenSearch/1.1/Draft_3#OpenSearch_1.1_parameters">OpenSearch 1.1 引数</a>に記述されています。</p>
+
+ <p>検索候補については、 <code>application/x-suggestions+json</code> URL テンプレートを使用して候補リストを <a href="/ja/docs/Glossary/JSON">JSON</a> 形式で読み取ります。サーバー上で検索候補の対応を実装する方法の詳細は <a href="/ja/docs/Archive/Add-ons/Supporting_search_suggestions_in_search_plugins">検索プラグインでの検索候補の対応</a>を参照してください。</p>
+ </dd>
+ <dt>Param</dt>
+ <dd>検索クエリと一緒に渡さなければならない引数を、キー／値のペアで指定します。値を指定する際に、 <code>{searchTerms}</code> を使用すると、ユーザーが検索バーに入力した検索語を挿入することができます。</dd>
+ <dt>moz:SearchForm</dt>
+<dd>プラグインのサイトの検索ページを開くための URL。これは Firefox にユーザーが直接ウェブサイトを訪れる方法を提供します。</dd>
+ <dd>
+ <div class="note"><strong>注意:</strong> この要素は Firefox 特有で OpenSearch 仕様の一部ではないため、この要素に対応していない他のユーザーエージェントが安全に無視できるようにするために、上の例では "<code>moz:</code>" XML 名前空間接頭辞を使っています。</div>
+ </dd>
 </dl>
-<dl>
-  <dt>
-    <strong>Description</strong></dt>
-  <dd>
-    検索エンジンの簡単な説明。</dd>
-</dl>
-<dl>
-  <dt>
-    <strong>InputEncoding</strong></dt>
-  <dd>
-    検索エンジンがデータの入力に使っているエンコーディング。</dd>
-</dl>
-<dl>
-  <dt>
-    <strong>Image</strong></dt>
-  <dd>
-    検索エンジンを表す Base-64 でエンコードされた 16x16 のアイコン。ここに置くためのデータを作成するのに使える便利なツールの一つはここで見付かります: <a class="external" href="http://software.hixie.ch/utilities/cgi/data/data">The data: URI kitchen</a>。</dd>
-</dl>
-<dl>
-  <dt>
-    <strong>Url</strong></dt>
-  <dd>
-    検索に使う 1 つまたは複数の URL を記述します。<code>method</code> 属性は結果を得るために <code>GET</code> と <code>POST</code> リクエストのどちらを使うか指定します。<code>template</code> 属性は検索クエリのベースとなる URL を指定します。</dd>
-  <dd>
-    <div class="note">
-      <strong>注意:</strong> Internet Explorer 7 は <code>POST</code> リクエストをサポートしていません。</div>
-  </dd>
-</dl>
-<dl>
-  <dd>
-    Firefox がサポートしている URL タイプは 2 つです:</dd>
-</dl>
-<ul>
-  <li><code>type="text/html"</code> は実際の検索結果そのものの URL を設定するために使われます。</li>
-  <li><code>type="application/x-suggestions+json"</code> は検索サジェストを得るために使われる URL を設定するために使われます。</li>
-</ul>
-<dl>
-  <dd>
-    どちらの URL のタイプでも、ユーザが検索バーに入力した検索語句に置き換えられる <code>{searchTerms}</code> を使うことができます。サポートしている他の動的な検索パラメータは <a class="external" href="http://www.opensearch.org/Specifications/OpenSearch/1.1/Draft_3#OpenSearch_1.1_parameters">OpenSearch 1.1 パラメータ</a>に記述されています。</dd>
-</dl>
-<dl>
-  <dd>
-    検索サジェストのクエリに指定された URL のテンプレートは JavaScript Object Notation (JSON) フォーマットで補完リストを取得するために使われます。サーバ上で検索サジェストのサポートを実装する方法の詳細は <a href="/ja/Supporting_search_suggestions_in_search_plugins" title="ja/Supporting_search_suggestions_in_search_plugins">検索プラグインでの検索サジェストのサポート</a>を見てください。</dd>
-</dl>
-<p><img alt="Image:SearchSuggestionSample.png" class="internal" src="/@api/deki/files/1794/=SearchSuggestionSample.png"></p>
-<dl>
-  <dt>
-    <strong>Param</strong></dt>
-  <dd>
-    検索クエリともに通過させるために必要なキー/値のペアのパラメータです。この値を指定する際にはユーザが検索バーに入力した検索語句を挿入するための <code>{searchTerms}</code> を使うことができます。</dd>
-  <dd>
-    <div class="note">
-      <strong>注意:</strong> Internet Explorer 7 はこの要素をサポートしていません。</div>
-  </dd>
-</dl>
-<dl>
-  <dt>
-    <strong>SearchForm</strong></dt>
-  <dd>
-    プラグインのサイトの検索ページを開くための URL。これは Firefox にユーザが直接 Web サイトを訪れる方法を提供します。</dd>
-  <dd>
-    <div class="note">
-      <strong>注意:</strong> この要素は Firefox 特有で OpenSearch 仕様の一部ではないため、この要素をサポートしていない他のユーザエージェントが安全に無視できるようにするために、上の例では "<code>moz:</code>" XML 名前空間接頭辞を使っています。</div>
-  </dd>
-</dl>
-<h2 id=".E6.A4.9C.E7.B4.A2.E3.83.97.E3.83.A9.E3.82.B0.E3.82.A4.E3.83.B3.E3.81.AE.E8.A8.B3.E8.AA.9E.E8.87.AA.E5.8B.95.E6.A4.9C.E5.87.BAAutodiscovery" name=".E6.A4.9C.E7.B4.A2.E3.83.97.E3.83.A9.E3.82.B0.E3.82.A4.E3.83.B3.E3.81.AE.E8.A8.B3.E8.AA.9E.E8.87.AA.E5.8B.95.E6.A4.9C.E5.87.BAAutodiscovery">検索プラグインの{{ 訳語("自動検出", "Autodiscovery") }}</h2>
-<p>検索プラグインを提供しているウェブサイトは Firefox ユーザがプラグインを簡単にダウンロードしてインストールできるように通知することができます。</p>
-<p>自動検出をサポートするには、ウェブページの <code>&lt;HEAD&gt;</code> セクションに単に一行追加するだけです。</p>
-<pre class="eval">&lt;link rel="search" type="application/opensearchdescription+xml" title="<em>searchTitle</em>" href="<em>pluginURL</em>"&gt;
+
+<h2 id="Autodiscovery_of_search_plugins">検索プラグインの自動検出</h2>
+
+<p>検索プラグインを提供しているウェブサイトは、 Firefox ユーザがプラグインを簡単にダウンロードしてインストールできるように通知することができます。</p>
+
+<p>自動検出に対応するには、それぞれのプラグインの <code>&lt;link&gt;</code> 要素をウェブページの <code>&lt;head&gt;</code> セクションにします。</p>
+
+<pre class="brush: html; highlight[3-4]">&lt;link rel="search"
+      type="application/opensearchdescription+xml"
+      title="<mark><strong>searchTitle</strong></mark>"
+      href="<mark><strong>pluginURL</strong></mark>"&gt;
 </pre>
-<p>斜体の項目を以下で説明されているように置き換えてください。</p>
+
+<p>太字の項目を以下の説明のように置き換えてください。</p>
+
 <dl>
-  <dt>
-    <strong>searchTitle</strong></dt>
-  <dd>
-    "MDC を検索" や 'Yahoo! 検索" のような実行する検索の名前です。この値は、プラグインファイルの ShortName と一致させる必要があります。</dd>
+ <dt>searchTitle</dt>
+ <dd>"MDC を検索" や 'Yahoo! 検索" のような実行する検索の名前です。この値は、プラグインファイルの <code>&lt;ShortName&gt;</code> と一致させる必要があります。</dd>
+ <dt>pluginURL</dt>
+ <dd>ブラウザーがダウンロードできる XML 検索プラグインの URL です。</dd>
 </dl>
-<dl>
-  <dt>
-    <strong>pluginURL</strong></dt>
-  <dd>
-    ブラウザがダウンロードできる XML 検索プラグインの URL です。</dd>
-</dl>
-<p>もしあなたのサイトが複数の検索プラグインを提供しているなら、それら全ての自動検出をサポートすることができます。例:</p>
-<pre class="eval">&lt;link rel="search" type="application/opensearchdescription+xml" title="MySite: 著者" href="<a class="external" href="http://www.mysite.com/mysiteauthor.xml" rel="freelink">http://www.mysite.com/mysiteauthor.xml</a>"&gt;
-&lt;link rel="search" type="application/opensearchdescription+xml" title="MySite: タイトル" href="<a class="external" href="http://www.mysite.com/mysitetitle.xml" rel="freelink">http://www.mysite.com/mysitetitle.xml</a>"&gt;
+
+<p>もしサイトが複数の検索プラグインを提供しているなら、すべてを自動検出させることができます。例を示します。</p>
+
+<pre class="brush: html">&lt;link rel="search" type="application/opensearchdescription+xml"
+      title="MySite: 著者" href="http://example.com/mysiteauthor.xml"&gt;
+
+&lt;link rel="search" type="application/opensearchdescription+xml"
+      title="MySite: タイトル" href="http://example.com/mysitetitle.xml"&gt;
 </pre>
-<p>この方法であなたのサイトは著者による検索とタイトルによる検索を行うプラグインを別々のものとしてを提供することができます。</p>
-<h2 id=".E3.83.88.E3.83.A9.E3.83.96.E3.83.AB.E3.82.B7.E3.83.A5.E3.83.BC.E3.83.86.E3.82.A3.E3.83.B3.E3.82.B0.E3.81.AE.E3.83.92.E3.83.B3.E3.83.88" name=".E3.83.88.E3.83.A9.E3.83.96.E3.83.AB.E3.82.B7.E3.83.A5.E3.83.BC.E3.83.86.E3.82.A3.E3.83.B3.E3.82.B0.E3.81.AE.E3.83.92.E3.83.B3.E3.83.88">トラブルシューティングのヒント</h2>
-<p>検索プラグインの XML に問題があると、検出されたプラグインを Firefox 2 に追加する際にエラーが発生するでしょう。エラーメッセージは完全な参考になるわけではありません、しかし、以下のヒントが問題を探す手助けになるでしょう。</p>
+
+<p>この方法で、著者とタイトルによる検索を行うプラグインをサイトで提供することができます。</p>
+
+<div class="note">
+<p>Firefox では、検索プラグインで提供されたアイコンがある場合は、検索ボックスのアイコンが変化して示します。 (画像を参照。緑のプラスの記号です。) そのため、ユーザーのインターフェイスで検索ボックスが非表示になっている場合、これを示すことは<em>ありません</em>。<em>一般に、この動作はブラウザーによって異なります</em>。</p>
+<img alt="Firefox での検索プラグインの見え方" src="new.png"></div>
+
+<h2 id="Supporting_automatic_updates_for_OpenSearch_plugins">OpenSearch プラグインの自動更新の対応</h2>
+
+<p>OpenSearch プラグインは自動的に更新することができます。 <code>Url</code> 拡張要素を <code>type="application/opensearchdescription+xml"</code> および <code>rel="self"</code> を付けて設置してください。 <code>template</code> 属性には、自動的に更新する OpenSearch 文書の URL を設定してください。</p>
+
+<p>例:</p>
+
+<pre class="brush: xml">&lt;Url type="application/opensearchdescription+xml"
+     rel="self"
+     template="https://example.com/mysearchdescription.xml" /&gt;
+</pre>
+
+<div class="note"><strong>注:</strong> 現時点で、 <a class="external" href="https://addons.mozilla.org">addons.mozilla.org</a> (AMO) は OpenSearch プラグインの自動更新に対応していません。自分の検索プラグインを AMO に登録したい場合は、送信前に自動更新機能を削除してください。</div>
+
+<h2 id="Troubleshooting_Tips">トラブルシューティングのヒント</h2>
+
+<p>検索プラグインの XML に問題があると、検出されたプラグインをに追加する際にエラーが発生します。エラーメッセージが参考にならない場合、以下のヒントが問題を探す手助けになる可能性があります。</p>
+
 <ul>
-  <li>検索プラグインが{{ 原語併記("整形式", "well formed") }}か確認してください。</li>
+ <li>サーバーは OpenSearch プラグインを、 <code>Content-Type: application/opensearchdescription+xml</code> を使用して提供するべきです。</li>
+ <li>検索プラグインの XML が整形式であることを確認してください。ファイルを直接 Firefox に読み込むことでチェックすることができます。アンパーサンド (&amp;) を <code>template</code> の URL の中では <code>&amp;amp;</code> にエスケープしなければなりません。タグは最後にスラッシュをまたは対応する終了タグで閉じる必要があります。</li>
+ <li><code>xmlns</code> 属性は重要です。 — これがないと、 "Firefox could not download the search plugin" というエラーメッセージが出る可能性があります。</li>
+ <li><code>text/html</code> の URL を含める<strong>必要があります</strong>。 Atom または <a href="/ja/docs/Glossary/RSS">RSS</a> の URL 型のみを含む検索プラグインは (有効なものですが、 Firefox は対応していません)、 "could not download the search plugin" エラーを引き起こします。</li>
+ <li>リモートで取得されるファビコンは 10KB 以上でなければなりません ({{ Bug(361923) }} を参照)。</li>
 </ul>
-<p>ファイルを Firefox に直接読みこませることによって確認できます。テンプレート URL の中のアンパサンド(&amp;)は &amp;amp; でエスケープされている必要があり、タグは最後のスラッシュか一致する終了タグで閉じられている必要があります。</p>
+
+<p>さらに、検索プラグインサービスはプラグイン開発者に役立つであろうログの仕組みを提供します。 <code>about:config</code> を使い '<code>browser.search.log</code>' を <code>true</code> に設定してください。検索プラグインが追加されるとログ情報が Firefox の<a href="/ja/docs/Archive/Mozilla/Error_console">エラーコンソール</a> (ツール ➤ エラーコンソール)に表示されます。</p>
+
+<h2 id="Reference_Material">参考資料</h2>
+
 <ul>
-  <li><code>xmlns</code> 属性が重要です。<code>xmlns</code> 属性無しでは "Firefox は次の場所から検索エンジンをダウンロードできませんでした:(URL)" というエラーメッセージを受け取るでしょう。</li>
-  <li><code>text/html</code> URL を含めなくては<strong>ならない</strong> ことに注意してください — Atom や <a href="/ja/RSS" title="ja/RSS">RSS</a> URL タイプしか含まない検索エンジン(それは妥当なのですが、Firefox はサポートしていません) は "検索エンジンをダウンロードできませんでした"というエラーを引き起こします。</li>
-</ul>
-<p><br>
-  さらに、検索プラグインサービスはプラグイン開発者が使うであろうログの仕組みを提供します。<em>about:config</em> を使い '<code>browser.search.log</code>' を <code>true</code> にしてください。検索プラグインが追加されるとログ情報が Firefox の<a href="/ja/JavaScript_Console" title="ja/JavaScript_Console">エラーコンソール</a>(ツール -&gt; エラーコンソール)に表示されます。</p>
-<h2 id=".E5.8F.82.E8.80.83.E8.B3.87.E6.96.99" name=".E5.8F.82.E8.80.83.E8.B3.87.E6.96.99">参考資料</h2>
-<ul>
-  <li><a class="external" href="http://opensearch.a9.com/">OpenSearch ドキュメント</a></li>
-  <li>Technorati.com には <a class="external" href="http://technorati.com/osd.xml">動作する osd.xml</a> があります。</li>
-  <li>自動検出の更なる問題は bugzilla {{ Bug(340208) }}</li>
-  <li><a class="external" href="http://en.wikipedia.org/wiki/Data:_URI_scheme"><code>data:&lt;code&gt; URI スキーマ</code></a></li>
-  <li><a class="external" href="http://searchy.protecus.de/">Searchy</a> - あなた自身のを<a class="external" href="http://searchy.protecus.de/en/add2.php">作成</a>、あるいは<a class="external" href="http://searchy.protecus.de/en/searchbox-add-ons.php">検索プラグインのリスト</a>を利用する</li>
-  <li><a class="external" href="http://www.searchplugins.net">searchplugins.net</a> - OpenSearch プラグインの作成(日本語不可, POSTメソッド可) <a class="external" href="http://www.searchplugins.net/pluginlist.aspx">作成された検索プラグインのリスト</a></li>
-  <li><a class="external" href="http://ready.to/search/jp/">Ready2Search</a> - OpenSearch プラグインの作成(日本語可, GETメソッドのみ) <a class="external" href="http://ready.to/search/make/">Ready2Searchでの検索プラグイン作成</a>,<a class="external" href="http://ready.to/search/list/#setind">カテゴリー別の検索設定インデックス</a></li>
+ <li><a href="https://github.com/dewitt/opensearch">OpenSearch ドキュメント</a></li>
+ <li><a href="https://developer.apple.com/library/archive/releasenotes/General/WhatsNewInSafari/Articles/Safari_8_0.html">Safari 8.0 リリースノート: Quick Website Search</a></li>
+ <li><a href="https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/browser-features/search-provider-discovery">Microsoft Edge 開発ガイド: Search provider discovery</a></li>
+ <li><a href="https://www.chromium.org/tab-to-search">The Chromium Projects: Tab to Search</a></li>
+ <li>imdb.com には <a class="external" href="https://m.media-amazon.com/images/G/01/imdb/images/imdbsearch-3349468880._CB470047351_.xml">動作する <code>osd.xml</code></a> があります</li>
+ <li><a class="external" href="http://www.7is7.com/software/firefox/opensearch.html">OpenSearch Plugin Generator</a></li>
+ <li><a class="external" href="http://ready.to/search/jp/">Ready2Search</a> - OpenSearch プラグインの作成 (日本語可, GETメソッドのみ)。 <a class="external" href="http://ready.to/search/make/en_make_plugin.htm">Customized Search through Ready2Search</a></li>
 </ul>


### PR DESCRIPTION
- 2021/03/17 時点の英語版に同期
- 「訳語」マクロを削除 (https://github.com/mozilla-japan/translation/issues/547 の対応)