### PR TITLE
/ja/docs/Glossary/HSTSとHPKPの見出し位置修正

### DIFF
--- a/files/ja/glossary/hpkp/index.html
+++ b/files/ja/glossary/hpkp/index.html
@@ -8,7 +8,6 @@ translation_of: Glossary/HPKP
 ---
 <p><strong>HPKP</strong> (HTTP公開鍵ピンニング、 HTTP Public Key Pinning) は、偽造された証明書による {{Glossary("MITM")}} 攻撃のリスクを減らすために、特定の暗号化公開鍵を特定のウェブサーバーに関連付けるようにウェブクライアントに指示するセキュリティ機能です。</p>
 
-<div>
 <h2 id="Learn_more" name="Learn_more">より詳しく知る</h2>
 
 <ul>
@@ -17,4 +16,3 @@ translation_of: Glossary/HPKP
  <li><a href="https://tools.ietf.org/html/rfc7469">RFC 7469</a> （英語）</li>
  <li>Wikipedia 上の <a href="https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning">HTTP Public Key Pinning</a> （英語）</li>
 </ul>
-</div>

--- a/files/ja/glossary/hsts/index.html
+++ b/files/ja/glossary/hsts/index.html
@@ -10,7 +10,6 @@ translation_of: Glossary/HSTS
 
 <p>言い換えれば、URL でプロトコルを HTTP から HTTPS に変更するだけで、より安全に動作することをブラウザーに伝え、すべてのリクエストに対してそれを行うようにブラウザーに依頼します。</p>
 
-<div>
 <h2 id="Learn_more" name="Learn_more">より詳しく知る</h2>
 
 <ul>
@@ -18,4 +17,3 @@ translation_of: Glossary/HSTS
  <li>OWASP の記事: <a href="https://www.owasp.org/index.php/HTTP_Strict_Transport_Security">HTTP Strict Transport Security</a></li>
  <li>Wikipedia 上の {{Interwiki("wikipedia", "HTTP Strict Transport Security")}}</li>
 </ul>
-</div>


### PR DESCRIPTION
「より詳しく知る」の前にdivタグが入っていることで  
見かけ上の見出しの位置がおかしくなっているため修正。

本来：コンテンツタイトル→本文→より詳しく知る→参考リンク  
現状：コンテンツタイトル→より詳しく知る→本文→参考リンク

https://developer.mozilla.org/ja/docs/Glossary/HPKP  
https://developer.mozilla.org/ja/docs/Glossary/HSTS