### PR TITLE
scrollIntoView block defaults to start

### DIFF
--- a/files/ru/web/api/element/scrollintoview/index.html
+++ b/files/ru/web/api/element/scrollintoview/index.html
@@ -30,7 +30,7 @@ element.scrollIntoView(<em>scrollIntoViewOptions</em>); // аргумент ти
  <dd>Определяет анимацию скролла. Принимает значение <code>"auto"</code> или <code>"smooth"</code>. По умолчанию <code>"auto"</code>.</dd>
  <dt><code>block</code> {{optional_inline}}</dt>
  <dd>Вертикальное выравнивание.<br>
- Одно из значений: <code>"start"</code>, <code>"center"</code>, <code>"end"</code> или <code>"nearest"</code>. По умолчанию <code>"center"</code>.</dd>
+ Одно из значений: <code>"start"</code>, <code>"center"</code>, <code>"end"</code> или <code>"nearest"</code>. По умолчанию <code>"start"</code>.</dd>
  <dt><code>inline</code> {{optional_inline}}</dt>
  <dd>Горизонтальное выравнивание.<br>
  Одно из значений: <code>"start"</code>, <code>"center"</code>, <code>"end"</code> или <code>"nearest"</code>. По умолчанию <code>"nearest"</code>.</dd>


### PR DESCRIPTION
To be inline with english version: https://github.com/mdn/content/blob/9e37d3346613c49d74657ff0dbfac20ef3a780d6/files/en-us/web/api/element/scrollintoview/index.html#L56

[Russian](https://developer.mozilla.org/ru/docs/Web/API/Element/scrollIntoView#%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D1%8B) vs [English](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView#parameters):

<img width="1099" alt="Screenshot 2021-04-28 at 13 30 18" src="https://user-images.githubusercontent.com/640669/116396258-d9712e00-a82d-11eb-8e6a-2df169f10c44.png">
