### PR TITLE
Mozilla/Add-ons/WebExtensions/API/browsingData を更新

### DIFF
--- a/files/ja/mozilla/add-ons/webextensions/api/browsingdata/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/browsingdata/index.html
@@ -2,6 +2,7 @@
 title: browsingData
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData
 tags:
+  - API
   - Add-ons
   - Extensions
   - Non-standard
@@ -12,19 +13,19 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/browsingData
 ---
 <div>{{AddonSidebar}}</div>
 
-<div>拡張機能がユーザーのブラウズ中に蓄積したデータをクリアできるようにします。</div>
+<div>拡張機能がユーザーの閲覧中に蓄積したデータをクリアできるようにします。</div>
 
-<p> <code>browsingData</code> APIでは、ブラウズデータは下記の型に分けられます:</p>
+<p><code>browsingData</code> API では、閲覧データは下記の型に分けられます。</p>
 
 <ul>
- <li>{{原語併記("browser cache", "ブラウザーキャッシュ")}}</li>
- <li>cookies</li>
- <li>{{原語併記("downloads", "ダウンロードデータ")}}</li>
- <li>{{原語併記("history", "履歴")}}</li>
- <li>{{原語併記("local storage", "ローカルストレージ")}}</li>
- <li>{{原語併記("plugin data", "プラグインのデータ")}}</li>
- <li>{{原語併記("saved form data", "保存したフォームデータ")}}</li>
- <li>{{原語併記("saved passwords", "保存したパスワード")}}</li>
+	<li>browser cache (ブラウザーキャッシュ)</li>
+	<li>cookies</li>
+	<li>downloads (ダウンロードデータ)</li>
+	<li>history (履歴)</li>
+	<li>local storage (ローカルストレージ)</li>
+	<li>plugin data (プラグインのデータ)</li>
+	<li>saved form data (保存したフォームデータ)</li>
+	<li>saved passwords (保存したパスワード)</li>
 </ul>
 
 <p>これらの型の組み合わせを削除するのに {{WebExtAPIRef("browsingData.remove()")}} 関数を使用できます。それぞれのデータ型を削除する専用関数もあり、例えば {{WebExtAPIRef("browsingData.removePasswords()", "removePasswords()")}}, {{WebExtAPIRef("browsingData.removeHistory()", "removeHistory()")}} などです。</p>
@@ -32,56 +33,56 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/browsingData
 <p>すべての <code>browsingData.remove[X]()</code> 関数は {{WebExtAPIRef("browsingData.RemovalOptions")}} オブジェクトを取って、これをデータ削除のその他2つの側面を管理するのに使うことができます:</p>
 
 <ul>
- <li>データ削除を過去どれだけ遡れるのか</li>
- <li>通常のウェブページか、ホストされたウェブアプリも含めてデータ削除するのかのいずれか。このオプションは Firefox ではまだサポートされていないことに注意してください。</li>
+	<li>データ削除を過去どれだけ遡れるのか</li>
+	<li>通常のウェブページか、ホストされたウェブアプリも含めてデータ削除するのかのいずれか。このオプションは Firefox ではまだサポートされていないことに注意してください。</li>
 </ul>
 
 <p>最後に、この API の {{WebExtAPIRef("browsingData.settings()")}} 関数で、ブラウザー組み込みの「履歴消去」機能の現在の設定値を取得できます。</p>
 
-<p>この API を使うには、"browsingData" の <a href="https://developer.mozilla.org/ja/Add-ons/WebExtensions/manifest.json/permissions#API_permissions">API パーミッション</a>が必要です。</p>
+<p>この API を使うには、"browsingData" の <a href="/ja/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#api_permissions">API パーミッション</a>が必要です。</p>
 
-<h2 id="Types" name="Types">型</h2>
-
-<dl>
- <dt>{{WebExtAPIRef("browsingData.DataTypeSet")}}</dt>
- <dd>削除データの型を指定するオブジェクト: 例えば、history, downloads, passwords, など</dd>
- <dt>{{WebExtAPIRef("browsingData.RemovalOptions")}}</dt>
- <dd>データ削除するのにどれくらい以前に遡るのか、通常のウェブブラウジング/ホスト型アプリ/アドオンのどのデータを削除するのかを指定するオブジェクト。</dd>
-</dl>
-
-<h2 id="Methods" name="Methods">メソッド</h2>
+<h2 id="Types">型</h2>
 
 <dl>
- <dt>{{WebExtAPIRef("browsingData.remove()")}}</dt>
- <dd>指定された型のブラウジングデータを削除する</dd>
- <dt>{{WebExtAPIRef("browsingData.removeCache()")}}</dt>
- <dd>ブラウザーキャッシュを消去する</dd>
- <dt>{{WebExtAPIRef("browsingData.removeCookies()")}}</dt>
- <dd>cookies を削除する</dd>
- <dt>{{WebExtAPIRef("browsingData.removeDownloads()")}}</dt>
- <dd>ダウンロード済みのファイルを削除する</dd>
- <dt>{{WebExtAPIRef("browsingData.removeFormData()")}}</dt>
- <dd>保存されたフォームデータを消去する</dd>
- <dt>{{WebExtAPIRef("browsingData.removeHistory()")}}</dt>
- <dd>ブラウザー履歴を消去する</dd>
- <dt>{{WebExtAPIRef("browsingData.removeLocalStorage()")}}</dt>
- <dd>ウェブサイトが作成した <a href="/ja/docs/Web/API/Window/localStorage">local storage</a> を消去する</dd>
- <dt>{{WebExtAPIRef("browsingData.removePasswords()")}}</dt>
- <dd>パスワードを消去する</dd>
- <dt>{{WebExtAPIRef("browsingData.removePluginData()")}}</dt>
- <dd>プラグインに関連するデータを消去する</dd>
- <dt>{{WebExtAPIRef("browsingData.settings()")}}</dt>
- <dd>ブラウザーの「履歴消去」機能の現在の設定値を得る</dd>
+	<dt>{{WebExtAPIRef("browsingData.DataTypeSet")}}</dt>
+	<dd>削除データの型を指定するオブジェクト。例えば、history, downloads, passwords, など</dd>
+	<dt>{{WebExtAPIRef("browsingData.RemovalOptions")}}</dt>
+	<dd>データ削除するのにどれくらい以前に遡るのか、通常のウェブ閲覧/ホスト型アプリ/アドオンのどのデータを削除するのかを指定するオブジェクト。</dd>
 </dl>
 
-<h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
+<h2 id="Methods">メソッド</h2>
 
-<p>{{Compat("webextensions.api.browsingData", 1, 1)}}</p>
+<dl>
+	<dt>{{WebExtAPIRef("browsingData.remove()")}}</dt>
+	<dd>指定された型の閲覧データを削除する</dd>
+	<dt>{{WebExtAPIRef("browsingData.removeCache()")}}</dt>
+	<dd>ブラウザーキャッシュを消去する</dd>
+	<dt>{{WebExtAPIRef("browsingData.removeCookies()")}}</dt>
+	<dd>cookies を削除する</dd>
+	<dt>{{WebExtAPIRef("browsingData.removeDownloads()")}}</dt>
+	<dd>ダウンロード済みのファイルを削除する</dd>
+	<dt>{{WebExtAPIRef("browsingData.removeFormData()")}}</dt>
+	<dd>保存されたフォームデータを消去する</dd>
+	<dt>{{WebExtAPIRef("browsingData.removeHistory()")}}</dt>
+	<dd>ブラウザー履歴を消去する</dd>
+	<dt>{{WebExtAPIRef("browsingData.removeLocalStorage()")}}</dt>
+	<dd>ウェブサイトが作成した <a href="/ja/docs/Web/API/Window/localStorage">local storage</a> を消去する</dd>
+	<dt>{{WebExtAPIRef("browsingData.removePasswords()")}}</dt>
+	<dd>パスワードを消去する</dd>
+	<dt>{{WebExtAPIRef("browsingData.removePluginData()")}}</dt>
+	<dd>プラグインに関連するデータを消去する</dd>
+	<dt>{{WebExtAPIRef("browsingData.settings()")}}</dt>
+	<dd>ブラウザーの「履歴消去」機能の現在の設定値を得る</dd>
+</dl>
+
+<h2 id="Browser_compatibility">ブラウザーの互換性</h2>
+
+<p>{{Compat("webextensions.api.browsingData", 2)}}</p>
 
 <div class="hidden note">
-<p>"Chrome 非互換性" 部分は <a href="/ja/docs/Template:WebExtChromeCompat">WebExtChromeCompat</a> マクロを使って <a href="https://developer.mozilla.org/ja/Add-ons/WebExtensions/Chrome_incompatibilities"> https://developer.mozilla.org/ja/Add-ons/WebExtensions/Chrome_incompatibilities</a> からインクルードされています。</p>
+<p>"Chrome の非互換性" 部分は <a href="/ja/docs/Template:WebExtChromeCompat">WebExtChromeCompat</a> マクロを使って <a href="/ja/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities"> https://developer.mozilla.org/ja/Add-ons/WebExtensions/Chrome_incompatibilities</a> からインクルードされています。</p>
 
-<p>このコンテンツを更新するには、<a href="https://developer.mozilla.org/ja/Add-ons/WebExtensions/Chrome_incompatibilities">https://developer.mozilla.org/ja/Add-ons/WebExtensions/Chrome_incompatibilities</a> を編集して、ページを shift+再読みして変更を確認します。</p>
+<p>このコンテンツを更新するには、<a href="/ja/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities">https://developer.mozilla.org/ja/Add-ons/WebExtensions/Chrome_incompatibilities</a> を編集して、ページを shift+再読みして変更を確認します。</p>
 </div>
 
 <p>{{WebExtExamples("h2")}}</p>
@@ -91,8 +92,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/browsingData
 <p>この API は Chromium の <a href="https://developer.chrome.com/extensions/browsingData"><code>chrome.browsingData</code></a> API に基づいています。</p>
 
 <p>Microsoft Edge での実装状況は Microsoft Corporation から提供されたものであり、ここでは Creative Commons Attribution 3.0 United States License に従っています。</p>
-
-<p> </p>
 </div>
 
 <div class="hidden">


### PR DESCRIPTION
- 2021/01/29 時点の英語版に同期
- 原語併記マクロを削除 (https://github.com/mozilla-japan/translation/issues/547)