### PR TITLE
Mozilla/Add-ons/WebExtensions/Examples を更新

### DIFF
--- a/files/ja/mozilla/add-ons/webextensions/examples/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/examples/index.html
@@ -10,20 +10,24 @@ translation_of: Mozilla/Add-ons/WebExtensions/Examples
 
 <p>拡張機能の開発方法を分かりやすく説明するため、シンプルな拡張機能のサンプルを集めたリポジトリ <a href="https://github.com/mdn/webextensions-examples">https://github.com/mdn/webextensions-examples</a> を公開しています。この記事では、そのリポジトリで使われている WebExtension API について説明します。</p>
 
-<p>これらのサンプルは Firefox Nightly で動作します。ほとんどのものがよりバージョン番号の小さい Firefox でも動作しますが、拡張機能の manifest.json に指定されている <code><a href="/ja/Add-ons/WebExtensions/manifest.json/applications">strict_min_version</a></code> キーを確認してください。</p>
+<p>これらのサンプルは Firefox Nightly で動作します。ほとんどのものがより早期の Firefox でも動作しますが、拡張機能の manifest.json に指定されている <code><a href="/ja/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings">strict_min_version</a></code> キーを確認してください。</p>
 
-<p>試してみたい方には、3 つの選択肢があります:</p>
-
-<ol>
- <li>リポジトリを clone し、アドオンをソースディレクトリーから直接読み込む方法。<a href="https://developer.mozilla.org/ja/Add-ons/WebExtensions/Temporary_Installation_in_Firefox">{{原語併記("Load Temporary Add-on", "一時的にアドオンを読み込み")}}</a> 機能を使います。Firefox を再起動するまで拡張機能は読み込まれたままです。</li>
- <li>リポジトリを clone し、<a href="https://developer.mozilla.org/ja/Add-ons/WebExtensions/Getting_started_with_web-ext">web-ext</a> コマンドラインツールを使って その拡張機能がインストールされた状態で Firefox を起動する。</li>
- <li>リポジトリを clone し、<a href="https://github.com/mdn/webextensions-examples/tree/master/build">build</a> ディレクトリーに移動する。ここにはすべてのサンプルのビルドされ署名されたバージョンが置かれています。Firefox のメニュー ファイル/ファイルを開く から開いて、拡張機能をインストールすることができます。<a href="https://addons.mozilla.org/en-US/firefox/">addons.mozilla.org</a> からインストールしたのと同じ状態になります。</li>
-</ol>
-
-<div class="blockIndicator warning">
-<p><strong>重要</strong>: この例の WebExtension を AMO (addons.mozilla.org)に投稿しないでください、WebExtension のサンプルを実行するのに署名をする必要はありません。単に上記の手順に従ってください。</p>
+<div class="notecard warning">
+<p>いくつかの例では、特定のドメインまたはページでのみ動作します。制限事項の詳細は、各サンプルの readme ファイルに記載されています。どの例も既定ではプライベートブラウジングウィンドウでは動作しません。詳細は「<a href="https://support.mozilla.org/en-US/kb/extensions-private-browsing#w_enabling-or-disabling-extensions-in-private-windows">プライベートブラウジングでの拡張機能</a>」をご覧ください。</p>
 </div>
 
-<p>リポジトリにコントリビュートしたい方は、是非とも <a href="https://github.com/mdn/webextensions-examples/blob/master/CONTRIBUTING.md">pull request</a> を送ってください！</p>
+<p>これらの例を試してみる場合は、リポジトリをクローンしてから下記のようにしてください。</p>
+
+<ol>
+ <li>一時的なアドオンを読み込む (<a href="https://extensionworkshop.com/documentation/develop/temporary-installation-in-firefox/">Load Temporary Add-on</a>) 機能を使用する。拡張機能は Firefox を再起動するまで読み込まれたままになります。</li>
+ <li>コマンドラインで拡張機能のソースフォルダーを開き、 <a href="https://extensionworkshop.com/documentation/develop/getting-started-with-web-ext/">web-ext</a> を使用して拡張機能を実行する。拡張機能は Firefox を再起動するまで読み込まれたままになります。</li>
+ <li>Firefox で <strong>ファイル</strong> &gt; <strong>ファイルを開く</strong> を使用し、 <a href="https://github.com/mdn/webextensions-examples/tree/master/build">build</a> フォルダーにある例を探す。 <code>build</code> フォルダーにはビルドされ署名されたバージョンのすべての例が置いてあります。これは例を永続的にインストールします。</li>
+</ol>
+
+<div class="warning">
+<p><strong>重要</strong>: この例の WebExtension を addons.mozilla.org (AMO) に投稿しないでください、WebExtension の例を実行するのに署名をする必要はありません。単に上記の手順に従ってください。</p>
+</div>
+
+<p>リポジトリに貢献したい方は、是非とも <a href="https://github.com/mdn/webextensions-examples/blob/master/CONTRIBUTING.md">pull request</a> を送ってください！</p>
 
 <p>{{WebExtAllExamples}}</p>


### PR DESCRIPTION
- 2021/02/01 時点の英語版に同期
- 原語併記マクロを削除 (https://github.com/mozilla-japan/translation/issues/547)