### PR TITLE
Web/API/CanvasRenderingContext2D/font を更新

### DIFF
--- a/files/ja/web/api/canvasrenderingcontext2d/font/index.html
+++ b/files/ja/web/api/canvasrenderingcontext2d/font/index.html
@@ -2,116 +2,78 @@
 title: CanvasRenderingContext2D.font
 slug: Web/API/CanvasRenderingContext2D/font
 tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - Property
-  - Reference
+- API
+- Canvas
+- CanvasRenderingContext2D
+- Property
+- Reference
 translation_of: Web/API/CanvasRenderingContext2D/font
 ---
 <div>{{APIRef}}</div>
 
-<p>Canvas 2D API の <code><strong>CanvasRenderingContext2D.font</strong></code> プロパティは、テキストを描画するときに用いられる現在のテキストスタイルを指定します。この文字列は <a href="/ja/docs/Web/CSS/font" title="CSS/font">CSS font</a> {{ 原語併記("記述子", "specifier") }} と同じ構文を用います。デフォルトフォントは 10px の{{ 原語併記("サンセリフ", "sans-serif") }} です。</p>
+<p><strong><code>CanvasRenderingContext2D.font</code></strong> は Canvas 2D API のプロパティで、テキストを描画するときに用いられる現在のテキストスタイルを指定します。この文字列は <a href="/ja/docs/Web/CSS/font">CSS font</a> の記述子と同じ構文を用います。</p>
 
-<h2 id="Syntax" name="Syntax">構文</h2>
+<h2 id="Syntax">構文</h2>
 
-<pre class="syntaxbox"><var><em>ctx</em>.font = value;</var>
+<pre class="brush: js"><em>ctx</em>.font = <em>value</em>;
 </pre>
 
-<h3 id="Options" name="Options">オプション</h3>
+<h3 id="Options">オプション</h3>
 
 <dl>
  <dt><code>value</code></dt>
- <dd>CSS {{cssxref("font")}} の値としてパースされる {{domxref("DOMString")}}。デフォルトのフォントは 10px sans-serif です。</dd>
+ <dd>{{domxref("DOMString")}} で、 CSS の {{cssxref("font")}} の値として解釈されるものです。既定のフォントは 10px sans-serif です。</dd>
 </dl>
 
-<h2 id="Examples" name="Examples">例</h2>
+<h2 id="Examples">例</h2>
 
-<h3 id="Using_the_font_property" name="Using_the_font_property"><code>font</code> プロパティの使用例</h3>
+<h3 id="Using_a_custom_font">カスタムフォントの使用</h3>
 
-<p>さまざまなフォントサイズやフォントファミリーを設定するために <code>font</code> プロパティを使用する、シンプルなコードスニペットです。</p>
+<p>この例では、 <code>font</code> プロパティを使用して、カスタムフォントの太さ、大きさ、ファミリーを指定します。</p>
 
-<h4 id="HTML" name="HTML">HTML</h4>
+<h4 id="HTML">HTML</h4>
 
 <pre class="brush: html">&lt;canvas id="canvas"&gt;&lt;/canvas&gt;
 </pre>
 
-<h4 id="JavaScript" name="JavaScript">JavaScript</h4>
+<h4 id="JavaScript">JavaScript</h4>
 
-<pre class="brush: js">var canvas = document.getElementById("canvas");
-var ctx = canvas.getContext("2d");
+<pre class="brush: js">const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
 
-ctx.font = "48px serif";
-ctx.strokeText("Hello world", 50, 100);
+ctx.font = 'bold 48px serif';
+ctx.strokeText('Hello world', 50, 100);
 </pre>
 
-<p>以下のコードを編集すると、canvas の変更個所をその場で確認できます:</p>
+<h4 id="Result">結果</h4>
 
-<div class="hidden">
-<h6 id="Playable_code" name="Playable_code">Playable code</h6>
+<p>{{ EmbedLiveSample('Using_a_custom_font', 700, 180) }}</p>
 
-<pre class="brush: html">&lt;canvas id="canvas" width="400" height="200" class="playable-canvas"&gt;&lt;/canvas&gt;
-&lt;div class="playable-buttons"&gt;
-  &lt;input id="edit" type="button" value="編集" /&gt;
-  &lt;input id="reset" type="button" value="リセット" /&gt;
-&lt;/div&gt;
-&lt;textarea id="code" class="playable-code"&gt;
-ctx.font = "48px serif";
-ctx.strokeText("Hello world", 50, 100);&lt;/textarea&gt;
-</pre>
-
-<pre class="brush: js">var canvas = document.getElementById("canvas");
-var ctx = canvas.getContext("2d");
-var textarea = document.getElementById("code");
-var reset = document.getElementById("reset");
-var edit = document.getElementById("edit");
-var code = textarea.value;
-
-function drawCanvas() {
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
-  eval(textarea.value);
-}
-
-reset.addEventListener("click", function() {
-  textarea.value = code;
-  drawCanvas();
-});
-
-edit.addEventListener("click", function() {
-  textarea.focus();
-})
-
-textarea.addEventListener("input", drawCanvas);
-window.addEventListener("load", drawCanvas);
-</pre>
-</div>
-
-<p>{{EmbedLiveSample('Playable_code', 700, 360)}}</p>
-
-<h3 id="Loading_fonts_with_the_CSS_Font_Loading_API" name="Loading_fonts_with_the_CSS_Font_Loading_API">CSS Font Loading API でフォントを読み込む</h3>
+<h3 id="Loading_fonts_with_the_CSS_Font_Loading_API">CSS Font Loading API でフォントを読み込む</h3>
 
 <p>{{domxref("FontFace")}} API の助力により、canvas で使用する前にフォントを明示的に読み込むことができます。</p>
 
-<pre class="brush: js">var f = new FontFace("test", "url(x)");
-  f.load().then(function() {
-    // canvas コンテキストでフォントを使用する準備ができた
+<pre class="brush: js">let f = new FontFace('test', 'url(x)');
+
+f.load().then(function() {
+  // canvas コンテキストでフォントを使用する準備ができた
 });</pre>
 
-<h2 id="Specifications" name="Specifications">仕様</h2>
+<h2 id="Specifications">仕様書</h2>
 
 <table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">仕様書</th>
-   <th scope="col">策定状況</th>
-   <th scope="col">コメント</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "scripting.html#dom-context-2d-font", "CanvasRenderingContext2D.font")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td> </td>
-  </tr>
- </tbody>
+  <tbody>
+    <tr>
+      <th scope="col">仕様書</th>
+      <th scope="col">状態</th>
+      <th scope="col">備考</th>
+    </tr>
+    <tr>
+      <td>{{SpecName('HTML WHATWG', "scripting.html#dom-context-2d-font", "CanvasRenderingContext2D.font")}}</td>
+      <td>{{Spec2('HTML WHATWG')}}</td>
+      <td></td>
+    </tr>
+  </tbody>
 </table>
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
@@ -121,10 +83,12 @@ window.addEventListener("load", drawCanvas);
 <h2 id="Gecko-specific_notes" name="Gecko-specific_notes">Gecko 固有の注意事項</h2>
 
 <ul>
- <li>Firefox など Gecko ベースのブラウザではこのプロパティのほかに、非標準かつ非推奨の <code>ctx.mozTextStyle</code> を実装しています。これは使用しないでください。</li>
+  <li>Firefox など Gecko ベースのブラウザーでは、このプロパティのほかに標準外かつ非推奨の <code>ctx.mozTextStyle</code> を定義しています。代わりに <code>ctx.font</code> を使用してください。</li>
+  <li>Gecko では、システムフォントをキャンバスの 2D コンテキストの {{domxref("CanvasRenderingContext2D.font", "font")}} (例えば <code>menu</code>) の値として設定した場合、フォントの値を取得しても期待したフォントが返されない (何も返されない) ことがありました。これは、Firefox 57 でリリースされた Firefox の並列 CSS エンジン <a href="https://wiki.mozilla.org/Quantum/Stylo">Quantum/Stylo</a> で修正されました (bug 1374885)。</li>
+
 </ul>
 
-<h2 id="See_also" name="See_also">関連情報</h2>
+<h2 id="See_also">関連情報</h2>
 
 <ul>
  <li>このメソッドを定義するインターフェイスである {{domxref("CanvasRenderingContext2D")}}</li>


### PR DESCRIPTION
- 2021/02/20 時点の英語版に同期
- 原語併記マクロを廃止 (https://github.com/mozilla-japan/translation/issues/547)