### PR TITLE
Web/API/GeolocationCoordinates を更新

### DIFF
--- a/files/ja/web/api/geolocationcoordinates/index.html
+++ b/files/ja/web/api/geolocationcoordinates/index.html
@@ -3,71 +3,67 @@ title: GeolocationCoordinates
 slug: Web/API/GeolocationCoordinates
 tags:
   - API
-  - Coordinates
   - Geolocation API
+  - GeolocationCoordinates
   - Interface
   - Secure context
 translation_of: Web/API/GeolocationCoordinates
 ---
-<div>
 <div>{{securecontext_header}}{{APIRef("Geolocation API")}}</div>
 
-<div><strong>{{原語併記("GeolocationCoordinates", "座標")}}</strong> インターフェイスは地球上におけるデバイスの位置と高度、およびそれぞれの測位精度を表します。</div>
-</div>
+<div><strong><code>GeolocationCoordinates</code></strong> インターフェイスは、地球上における端末の位置と高度、およびそれぞれの測位精度を表します。</div>
 
-<h2 id="Properties" name="Properties">プロパティ</h2>
+<h2 id="Properties">プロパティ</h2>
 
 <p><em><code>GeolocationCoordinates</code> インターフェイスが継承するプロパティはありません。</em></p>
 
 <dl>
  <dt>{{domxref("GeolocationCoordinates.latitude")}} {{readonlyInline}} {{securecontext_inline}}</dt>
- <dd>このオブジェクトが示す緯度を十進度で表す、<code>double</code> 型の値を返します。</dd>
+ <dd>この位置の緯度を十進数の角度で表す <code>double</code> 型の値を返します。</dd>
  <dt>{{domxref("GeolocationCoordinates.longitude")}} {{readonlyInline}} {{securecontext_inline}}</dt>
- <dd>このオブジェクトが示す経度を十進度で表す、<code>double</code> 型の値で返します。</dd>
+ <dd>この位置の経度を十進数の角度で表す <code>double</code> 型の値を返します。</dd>
  <dt>{{domxref("GeolocationCoordinates.altitude")}} {{readonlyInline}} {{securecontext_inline}}</dt>
- <dd>このオブジェクトが示す高度 (海面からの距離) をメートル単位で表す、<code>double</code> 型の値を返します。この情報を取得できない場合は <code>null</code> が返ります。</dd>
+ <dd>この位置の海面からの相対的な高度をメートル単位で表す <code>double</code> 型の値を返します。実装がこのデータを提供できない場合、この値は <code>null</code> になることがあります。</dd>
  <dt>{{domxref("GeolocationCoordinates.accuracy")}} {{readonlyInline}} {{securecontext_inline}}</dt>
  <dd><code>latitude</code> および <code>longitude</code> プロパティの精度をメートル単位で表す、<code>double</code> 型の値を返します。</dd>
  <dt>{{domxref("GeolocationCoordinates.altitudeAccuracy")}} {{readonlyInline}} {{securecontext_inline}}</dt>
  <dd><code>altitude</code> プロパティの精度をメートル単位で表す、<code>double</code> 型の値を返します。このプロパティは <code>null</code> になることがあります。</dd>
  <dt>{{domxref("GeolocationCoordinates.heading")}} {{readonlyInline}} {{securecontext_inline}}</dt>
- <dd>デバイスの移動方向を真北から何度離れているかで表す、<code>double</code> 型の値を返します。真北を指す <code>0</code> 度から時計回りに、東が <code>90</code> 度、西は <code>270</code> 度となります。<code>speed</code> プロパティの値が <code>0</code> の時、 <code>heading</code> は常に <code><a href="/ja/docs/JavaScript/Reference/Global_Objects/NaN" title='/ja/docs/JavaScript/Reference/Global_Objects/NaN"'>NaN</a></code> になります。もし <code>heading</code> の情報を取得できない場合は <code>null</code> が返ります。</dd>
+ <dd>端末が向かっている方向を表す <code>double</code> 型の値を返します。この値は、端末の向きが真北からどれだけ離れているかを、角度で表します。 <code>0</code> は真北を表し、方向は時計回りに定められます (すなわち、東は <code>90</code> 度、西は <code>270</code> 度です)。 <code>speed</code> が <code>0</code> の場合、 <code>heading</code> は <code><a href="/ja/docs/Web/JavaScript/Reference/Global_Objects/NaN">NaN</a></code> になります。もし <code>heading</code> の情報を取得できない場合は、この値は <code>null</code> になります。</dd>
  <dt>{{domxref("GeolocationCoordinates.speed")}} {{readonlyInline}} {{securecontext_inline}}</dt>
- <dd>デバイスの移動速度をメートル毎秒で表す、<code>double</code> 型の値を返します。このプロパティは <code>null</code> になることがあります。</dd>
+ <dd>端末の移動速度をメートル毎秒で表す <code>double</code> 型の値を返します。このプロパティは <code>null</code> になることがあります。</dd>
 </dl>
 
-<h2 id="Methods" name="Methods">メソッド</h2>
+<h2 id="Methods">メソッド</h2>
 
 <p><em><code>GeolocationCoordinates</code> インターフェイスが実装・継承するメソッドはありません。</em></p>
 
-<h2 id="Specifications" name="Specifications">仕様</h2>
+<h2 id="Specifications">仕様書</h2>
 
 <table class="standard-table">
  <thead>
   <tr>
    <th scope="col">仕様書</th>
-   <th scope="col">策定状況</th>
-   <th scope="col">コメント</th>
+   <th scope="col">状態</th>
+   <th scope="col">備考</th>
   </tr>
  </thead>
  <tbody>
   <tr>
    <td>{{SpecName('Geolocation', '#coordinates_interface', 'GeolocationCoordinates')}}</td>
    <td>{{Spec2('Geolocation')}}</td>
-   <td>初期定義</td>
+   <td>初回定義</td>
   </tr>
  </tbody>
 </table>
 
-<h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザー実装状況</h2>
-
-
+<h2 id="Browser_compatibility">ブラウザーの互換性</h2>
 
 <p>{{Compat("api.GeolocationCoordinates")}}</p>
 
-<h2 id="See_also" name="See_also">関連情報</h2>
+<h2 id="See_also">関連情報</h2>
 
 <ul>
- <li><a href="https://wiki.developer.mozilla.org/ja/docs/Web/API/Geolocation_API/Using">Geolocation API の利用</a></li>
- <li>{{domxref("Geolocation")}} インターフェイス</li>
+ <li><a href="/ja/docs/Web/API/Geolocation_API/Using_the_Geolocation_API">Geolocation API の使用</a></li>
+ <li>{{domxref("Geolocation")}}</li>
 </ul>


### PR DESCRIPTION
- 2021/03/12 時点の英語版に同期
- 原語併記マクロを削除 (https://github.com/mozilla-japan/translation/issues/547)