### PR TITLE
Web/API/NavigatorID/appVersion を更新

### DIFF
--- a/files/ja/web/api/navigatorid/appversion/index.html
+++ b/files/ja/web/api/navigatorid/appversion/index.html
@@ -1,35 +1,64 @@
 ---
-title: window.navigator.appVersion
+title: NavigatorID.appVersion
 slug: Web/API/NavigatorID/appVersion
 tags:
-  - DOM
-  - DOM_0
-  - Gecko
-  - Gecko DOM Reference
-  - 要更新
+- API
+- Deprecated
+- NavigatorID
+- Property
+- Reference
+- appVersion
 translation_of: Web/API/NavigatorID/appVersion
 ---
-<div>
- {{ApiRef}}</div>
-<h2 id="Summary" name="Summary">概要</h2>
-<p>ブラウザのバージョンを表す文字列を返します。</p>
-<div class="note">
- <strong>Note:</strong> Do not rely on this property to return the correct browser version. In Gecko-based browsers (like Firefox) and WebKit-based browsers (like Chrome and Safari) the returned value starts with "5.0" followed by platform information. In Opera 10 and newer the returned version does not match the actual browser version, either.</div>
-<h2 id="Syntax" name="Syntax">構文</h2>
-<pre class="syntaxbox">window.navigator.appVersion
+<p>{{APIRef("HTML DOM")}} {{Deprecated_Header}}</p>
+
+<p>"<code>4.0</code>" またはそのブラウザーのバージョン情報を表す文字列のどちらかを返します。</p>
+
+<div class="notecard note">
+  <h4>注</h4>
+  <p>このプロパティがブラウザーの正しいバージョンを返すことを期待しないでください。</p>
+</div>
+
+<h2 id="Syntax">構文</h2>
+
+<pre class="brush: js">window.navigator.appVersion
 </pre>
-<h3 id="Parameters" name="Parameters">戻り値</h3>
-<ul>
- <li><code>ver</code> は、ブラウザのバージョン番号を表す文字列です。</li>
-</ul>
-<h2 id="Example" name="Example">例</h2>
-<pre class="brush:js">alert("ご使用中のブラウザのバージョンナンバー（※推定値）: " + navigator.appVersion);
+
+<h3 id="Returned_value">値</h3>
+
+<p>"<code>4.0</code>" またはそのブラウザーのバージョン情報を表す文字列のどちらかです。</p>
+
+<h2 id="Example">例</h2>
+
+<pre class="brush: js">alert("このブラウザーのバージョンは " + navigator.appVersion + " と報告されています。");
 </pre>
-<h2 id="Notes" name="Notes">注記</h2>
-<p>window.navigator.userAgent プロパティもバージョン番号を含んでいる場合があります（※例："Mozilla/5.0 (Windows; U; Win98; en-US; rv:0.9.2) Gecko/20010725 Netscape 6/6.1"）。しかしユーザエージェントを表す文字列を変更し、他のブラウザ、プラットフォーム、あるいは、ユーザエージェントであるかのように "{{原語併記("偽装", "spoof")}}" することは容易であり、またブラウザベンダ自身のこれらのプロパティ対する扱いも無軌道なものであるということは、覚えておくべきです。 window.navigator.appVersion と window.navigator.userAgent プロパティは、"{{原語併記("ブラウザ判別", "browser sniffing")}}" のコードで非常にしばしば用いられます。例えば、使用中のブラウザの種類を調べ、それに従いページを調整するスクリプトなどです。</p>
-<p>The <code>window.navigator.appVersion</code>, <code>window.navigator.appName</code> and <code>window.navigator.userAgent</code> properties have been used in "browser sniffing" code: scripts that attempt to find out what kind of browser you are using and adjust pages accordingly. This lead to the current situation, where browsers had to return fake values from these properties in order not to be locked out of some websites.</p>
-<h2 id="Specification" name="Specification">仕様</h2>
-<ul>
- <li><a class="external" href="http://www.w3.org/TR/html5/timers.html#navigator" title="http://www.w3.org/TR/html5/timers.html#navigator">HTML5: System state and capabilities: the Navigator object</a></li>
-</ul>
-<p>元々は DOM Level 0 に含まれてるものでした（※即ち、仕様書に含まれていなかった）。現在では HTML5 仕様書に含まれています。</p>
+
+<h2 id="Notes">注</h2>
+
+<p><code>window.navigator.userAgent</code> プロパティもバージョン番号を含んでいる場合がありますが ("<code>Mozilla/5.0 (Windows; U; Win98; en-US; rv:0.9.2) Gecko/20010725 Netscape 6/6.1</code>" など)、ユーザーエージェント文字列を変更したり、他のブラウザー、プラットフォーム、ユーザーエージェントに「偽装」したり、ブラウザーベンダー自身がこれらのプロパティに無頓着であったりすることを意識しておいてください。</p>
+
+<p><code>window.navigator.appVersion</code>, <code>window.navigator.appName</code>, <code>window.navigator.userAgent</code> の各プロパティは、「ブラウザー推定」 (browser sniffing) コード、すなわち使用しているブラウザーを検出し、それに従ってページを調整しようとするスクリプトで使われてきました。これにより、一部のウェブサイトから拒否されないようにするために、ブラウザーがこれらのプロパティで偽の情報を返さなければならないという現在の状況が発生したのです。</p>
+
+<h2 id="Specifications">仕様書</h2>
+
+<table class="standard-table">
+  <thead>
+    <tr>
+      <th scope="col">仕様書</th>
+      <th scope="col">状態</th>
+      <th scope="col">備考</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{SpecName('HTML WHATWG', '#dom-navigator-appversion',
+        'NavigatorID.appVersion')}}</td>
+      <td>{{Spec2('HTML WHATWG')}}</td>
+      <td>初回定義</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="Browser_compatibility">ブラウザーの互換性</h2>
+
+<p>{{Compat("api.NavigatorID.appVersion")}}</p>


### PR DESCRIPTION
- 2021/04/20 時点の英語版に同期
- 原語併記マクロを廃止 (https://github.com/mozilla-japan/translation/issues/547)