### PR TITLE
[FIX] typo err (#659), Promise

### DIFF
--- a/files/ko/web/javascript/guide/using_promises/index.html
+++ b/files/ko/web/javascript/guide/using_promises/index.html
@@ -27,7 +27,7 @@ translation_of: Web/JavaScript/Guide/Using_promises
 
 <code>createAudioFileAsync(audioSettings, successCallback, failureCallback);</code></pre>
 
-<p>…모던한 함수들은 위와 같이 콜백들을 전달지 않고 콜백을 붙여 사용할 수 있게 Promise를 반환해줍니다.</p>
+<p>…모던한 함수들은 위와 같이 콜백들을 전달하지 않고 콜백을 붙여 사용할 수 있게 Promise를 반환해줍니다.</p>
 
 <p>만약 <code>createAudioFileAsync()</code> 함수가 Promise를 반환해주도록 수정해본다면, 다음과 같이 간단하게 사용되어질 수 있습니다.</p>
 


### PR DESCRIPTION
> URL = https://developer.mozilla.org/ko/docs/Web/JavaScript/Guide/Using_promises
> 콜백들을 전달지 않고 -> 콜백들을 전달하지 않고

issue #659 수정 완료 