### PR TITLE
[FIX] typo err, book_inst to book_instance, django (#702)

### DIFF
--- a/files/ko/learn/server-side/django/forms/index.html
+++ b/files/ko/learn/server-side/django/forms/index.html
@@ -341,8 +341,8 @@ def renew_book_librarian(request, pk):
         # 폼이 유효한지 체크한다:
         if book_renewal_form.is_valid():
             # book_renewal_form.cleaned_data 데이타를 요청받은대로 처리한다(여기선 그냥 모델 due_back 필드에 써넣는다)
-            book_inst.due_back = book_renewal_form.cleaned_data['renewal_date']
-            book_inst.save()
+            book_instance.due_back = book_renewal_form.cleaned_data['renewal_date']
+            book_instance.save()
 
             # 새로운 URL로 보낸다:
             return HttpResponseRedirect(reverse('all-borrowed') )


### PR DESCRIPTION
issue #702

This Korean document has a wrong-named variable that the English one doesn't have. I find it the English version had corrected it but Korean ver. has not.

The final code example of locallibrary/catalog/views.py uses 'book_inst'(yellow highlight) instead of 'book_instance' which was initialized earlier using 'get_object_or_404(BookInstance, pk=pk)' (red highlight). It causes the "Unresolved reference 'book_inst'" error on Pycharm. And since the code is used twice, the two parts of the document need to be corrected.

안녕하세요. https://developer.mozilla.org/ko/docs/Learn/Server-side/Django/Forms
'Django 튜토리얼 파트 9: 폼(form)으로 작업하기' 문서 중 'View 작성하기' 부분의 3,4번째 코드가 잘못된 변수명을 사용하고 있습니다.
사용되어야하는 변수명은 위에서 'get_object_or_404(BookInstance, pk=pk)' 가 할당된 book_instance 변수인데, book_inst 라는 변수명의 변수를 사용하고 있습니다. 영문판에서는 고쳐져있지만, 한국어판만 잘못된 변수명을 사용하고 있습니다.

---

book_inst -----> book_instance
book_inst 가 book_instance로 수정되어야합니다.