### PR TITLE
Web/Accessibility/ARIA/Web_applications_and_ARIA_FAQ を更新

### DIFF
--- a/files/ja/web/accessibility/aria/web_applications_and_aria_faq/index.html
+++ b/files/ja/web/accessibility/aria/web_applications_and_aria_faq/index.html
@@ -1,5 +1,5 @@
 ---
-title: Web アプリケーションと ARIA の FAQ
+title: ウェブアプリケーションと ARIA の FAQ
 slug: Web/Accessibility/ARIA/Web_applications_and_ARIA_FAQ
 tags:
   - ARIA
@@ -7,26 +7,27 @@ tags:
   - Guide
 translation_of: Web/Accessibility/ARIA/Web_applications_and_ARIA_FAQ
 ---
-<h2 id="What_is_ARIA" name="What_is_ARIA">ARIA とは何か?</h2>
+<h2 id="What_is_ARIA">ARIA とは何か</h2>
 
-<p>WAI-ARIA は、<a href="http://www.w3.org/" title="http://www.w3.org/">W3C</a> の <a href="http://www.w3.org/WAI/" title="http://www.w3.org/WAI/">Web Accessibility Initiative</a> による、<a href="http://www.w3.org/WAI/intro/aria.php" title="http://www.w3.org/WAI/intro/aria.php">{{原語併記("アクセシブルなリッチインターネットアプリケーション", "Accessible Rich Internet Applications")}}</a> の仕様です。ARIA は Web アプリケーションやウィジェットを、スクリーンリーダーや拡大鏡といった支援技術を使用するユーザを含む幅広いユーザに対してアクセシブルにする手段を提供します。</p>
+<p>WAI-ARIA は、
+<a href="https://www.w3.org/">W3C</a> の <a href="https://www.w3.org/WAI/"">Web Accessibility Initiative</a> による、<a href="https://www.w3.org/WAI/intro/aria.php" title="http://www.w3.org/WAI/intro/aria.php">Accessible Rich Internet Applications</a> の仕様です。 ARIA はウェブアプリケーションやウィジェットを、画面リーダーや拡大鏡などの支援技術を使用するユーザーを含む幅広いユーザーに対して、よりアクセス可能にする手段を提供します。</p>
 
-<p>ARIA はメニュー、スライダー、ツリー、ダイアログといった多くの一般的なユーザインターフェイスの役割、状態、機能性を示す付加的な意味を与えます。また作者がページ上の目印、部分、グリッドを設定することを支援する、付加的な構造情報も与えます。ARIA は動的で JavaScript 駆動のアプリケーションやウィジェットを、さまざまなデスクトップベースの支援技術と対話可能にします。</p>
+<p>ARIA はメニュー、スライダー、ツリー、ダイアログといった多くの一般的なユーザーインターフェイスの役割、状態、機能性を示す付加的な意味を与えます。また作者がページ上の目印、部分、グリッドを設定することを支援する、付加的な構造情報も与えます。ARIA は動的で JavaScript 駆動のアプリケーションやウィジェットを、さまざまなデスクトップベースの支援技術と対話可能にします。</p>
 
-<p>ARIA でアクセシブルなウィジェットを作成する方法について詳しくは、<a href="/ja/docs/Accessibility/An_overview_of_accessible_web_applications_and_widgets" title="Accessibility/An overview of accessible web applications and widgets">アクセシブルな Web アプリケーションやウィジェットの概要</a>をご覧ください。</p>
+<p>ARIA でアクセス可能なウィジェットを作成する方法について詳しくは、<a href="/ja/docs/Web/Accessibility/An_overview_of_accessible_web_applications_and_widgets">アクセス可能なウェブアプリケーションやウィジェットの概要</a>をご覧ください。</p>
 
-<h2 id="Where_is_ARIA_Supported" name="Where_is_ARIA_Supported">ARIA はどこでサポートされていますか?</h2>
+<h2 id="Where_is_ARIA_Supported">ARIA はどこで対応されているのか</h2>
 
-<p>ARIA は比較的新しい仕様ですが、サポートは進んでいます。多種多様なよく使用されるブラウザ、支援技術、JavaScript ツールキットやアプリケーションが ARIAをサポートしています。しかし、多くのユーザはいまだにこれらの古いバージョンを使用しているでしょう。古いブラウザや支援技術を良好にサポートするために、先進的な拡張方法 (例えばマークアップに直接ではなく JavaScript を使用して ARIA を追加する) を使用して ARIA を実装したいと考えるでしょう。</p>
+<p>ARIA は比較的新しい仕様ですが、対応は進みつつあります。多種多様なよく使用されるブラウザー、支援技術、JavaScript ツールキットやアプリケーションが ARIA に対応しています。しかし、多くのユーザーがこれらの技術の古いバージョンを使用している可能性があります。古いブラウーザーや支援技術を良好にサポートするためには、先進的な拡張方法 (例えばマークアップに直接ではなく JavaScript を使用して ARIA を追加する) を使用して ARIA を実装したいと考えるでしょう。</p>
 
-<h3 id="Browsers" name="Browsers">ブラウザ</h3>
+<h3 id="Browsers">ブラウザー</h3>
 
-<p>ARIA は以下のブラウザでサポートされています:</p>
+<p>ARIA は以下のブラウザーが対応しています。</p>
 
 <table class="standard-table">
  <tbody>
   <tr>
-   <th>ブラウザ</th>
+   <th>ブラウザー</th>
    <th>最低バージョン</th>
    <th>備考</th>
   </tr>
@@ -36,53 +37,53 @@ translation_of: Web/Accessibility/ARIA/Web_applications_and_ARIA_FAQ
    <td>NVDA、JAWS 10 以降、Orca で動作</td>
   </tr>
   <tr>
-   <td><a href="http://dev.chromium.org/developers/design-documents/accessibility#TOC-WAI-ARIA-Support" title="http://dev.chromium.org/developers/design-documents/accessibility#TOC-WAI-ARIA-Support">Chrome</a></td>
+   <td><a href="https://dev.chromium.org/developers/design-documents/accessibility#TOC-WAI-ARIA-Support">Chrome</a></td>
    <td>最新</td>
-   <td>Chrome 15 現在、スクリーンリーダーは試験にサポート</td>
+   <td>Chrome 15 時点では、画面リーダーは実験的な対応</td>
   </tr>
   <tr>
    <td>Safari</td>
    <td>4 以降</td>
-   <td>Safari 5 のサポートはとても向上しています。<br>
-    Live region のサポートは、iOS5 または OS X Lion の VoiceOver と Safari 5 が必要です。</td>
+   <td>Safari 5 での対応はとても改善されています。<br>
+    Live region の対応は、iOS5 または OS X Lion の VoiceOver と Safari 5 が必要です。</td>
   </tr>
   <tr>
-   <td><a href="http://www.opera.com/docs/specs/presto28/wai-aria/roleattributes/" title="http://www.opera.com/docs/specs/presto28/wai-aria/roleattributes/">Opera</a></td>
+   <td><a href="https://www.opera.com/docs/specs/presto28/wai-aria/roleattributes/">Opera</a></td>
    <td>9.5 以降</td>
-   <td>OS X では VoiceOver が必要です。TBD: 現在の状況はどうでしょうか?</td>
+   <td>OS X では VoiceOver が必要です。 TBD: 現在の状況はどうでしょうか?</td>
   </tr>
   <tr>
-   <td><a href="http://msdn.microsoft.com/en-us/library/cc891505%28v=vs.85%29.aspx" title="http://msdn.microsoft.com/en-us/library/cc891505(v=vs.85).aspx">Internet Explorer</a></td>
+   <td><a href="https://msdn.microsoft.com/en-us/library/cc891505%28v=vs.85%29.aspx">Internet Explorer</a></td>
    <td>8 以降</td>
    <td>JAWS 10 以降や NVDA で動作します。NVDA では live region をサポートしません。<br>
-    IE9 のサポートはとても向上しています。</td>
+    IE9 での対応はとても改善されています。</td>
   </tr>
  </tbody>
 </table>
 
-<p>以前のバージョンでは ARIA の一部の機能しかサポートしない場合があります。より詳しいブラウザ実装状況の表を、複数の情報源から得られます:</p>
+<p>以前のバージョンでは ARIA の一部の機能しか対応していない場合があります。より詳しいブラウザーの互換性の表は、複数の情報源から得ることができます。</p>
 
 <ul>
- <li><a href="http://caniuse.com/wai-aria" title="http://caniuse.com/wai-aria">caniuse.com</a></li>
- <li><a href="http://www.paciellogroup.com/blog/2012/02/rough-guide-browsers-operating-systems-and-screen-reader-support/" title="http://www.paciellogroup.com/blog/2012/02/rough-guide-browsers-operating-systems-and-screen-reader-support/">The Paciello Group</a></li>
+ <li><a href="https://caniuse.com/wai-aria">caniuse.com</a></li>
+ <li><a href="https://www.paciellogroup.com/blog/2012/02/rough-guide-browsers-operating-systems-and-screen-reader-support/">The Paciello Group</a></li>
 </ul>
 
-<h3 id="Assistive_Technologies" name="Assistive_Technologies">支援技術</h3>
+<h3 id="Assistive_Technologies">支援技術</h3>
 
-<p>支援技術は ARIA を順次採用しています。それらが搭載しているものは:</p>
+<p>支援技術は ARIA を順次採用してきています。その中の一部を紹介します。</p>
 
 <table class="standard-table">
  <tbody>
   <tr>
    <th>支援技術</th>
    <th>基本的な ARIA の最低バージョン</th>
-   <th>live region および alert サポートの最低バージョン</th>
+   <th>live region および alert の対応の最低バージョン</th>
   </tr>
   <tr>
    <td>NVDA</td>
    <td>2010.2<br>
     (NVDA のアップグレードは常に無償です)</td>
-   <td>Firefox 向けは 2011.1 でサポートしました。2011.2 の時点で IE の live region サポートはありません。</td>
+   <td>Firefox 向けは 2011.1 で対応しました。2011.2 の時点で IE の live region の対応はありません。</td>
   </tr>
   <tr>
    <td>Orca</td>
@@ -104,23 +105,23 @@ translation_of: Web/Accessibility/ARIA/Web_applications_and_ARIA_FAQ
   <tr>
    <td>Window-Eyes</td>
    <td>7</td>
-   <td>現在 live region はサポートしていません。</td>
+   <td>現在 live region には対応していません。</td>
   </tr>
   <tr>
    <td>ZoomText</td>
    <td>?</td>
-   <td>現在 live region はサポートしていません。</td>
+   <td>現在 live region には対応していません。</td>
   </tr>
  </tbody>
 </table>
 
-<p>注記: これらツールの過去のバージョンは、ARIA の実装が部分的あるいはバグがある場合があります。</p>
+<p>注: これらツールの過去のバージョンは、ARIA の実装が部分的あるいはバグがある場合があります。</p>
 
-<p>JAWS 10 時点の、JAWS の ARIA サポートに関する注記については、Paciello Group による記事をご覧ください: <a href="http://www.paciellogroup.com/blog/2010/10/jaws-support-for-aria/" title="http://www.paciellogroup.com/blog/2010/10/jaws-support-for-aria/">JAWS Support for ARIA</a>。</p>
+<p>JAWS 10 時点の、JAWS の ARIA 対応に関する注については、Paciello Group による記事、 <a href="https://www.paciellogroup.com/blog/2010/10/jaws-support-for-aria/">JAWS Support for ARIA</a> をご覧ください。</p>
 
-<h3 id="JavaScript_Toolkits" name="JavaScript_Toolkits">JavaScript ツールキット</h3>
+<h3 id="JavaScript_Toolkits">JavaScript ツールキット</h3>
 
-<p>ARIA のロール、ステート、プロパティは、以下のような多くのポピュラーな JavaScript ユーザインターフェイスツールキットに追加されています:</p>
+<p>ARIA のロール、ステート、プロパティは、以下のような多くのポピュラーな JavaScript ユーザーインターフェイスツールキットに追加されています:</p>
 
 <ul>
  <li>Dojo/Dijit</li>
@@ -129,26 +130,26 @@ translation_of: Web/Accessibility/ARIA/Web_applications_and_ARIA_FAQ
  <li>Google Closure</li>
  <li>Google Web Toolkit</li>
  <li>BBC Glow</li>
- <li>Yahoo!User Interface Library (YUI)</li>
+ <li>Yahoo! User Interface Library (YUI)</li>
 </ul>
 
 <p>JavaScript ツールキットのアクセシビリティに関する詳細情報:</p>
 
 <ul>
- <li>Steve Faulkner 氏による <a href="http://www.paciellogroup.com/blog/2009/07/wai-aria-implementation-in-javascript-ui-libraries/" title="http://www.paciellogroup.com/blog/2009/07/wai-aria-implementation-in-javascript-ui-libraries/">WAI-ARIA Implementation in JavaScript UI Libraries</a></li>
+ <li>Steve Faulkner 氏による <a href="https://www.paciellogroup.com/blog/2009/07/wai-aria-implementation-in-javascript-ui-libraries/">WAI-ARIA Implementation in JavaScript UI Libraries</a></li>
 </ul>
 
-<h2 id="Can_you_show_me_an_example_of_ARIA_in_action" name="Can_you_show_me_an_example_of_ARIA_in_action">ARIA の実例を見せていただけますか?</h2>
+<h2 id="Can_you_show_me_an_example_of_ARIA_in_action">ARIA の実例を見せていただけますか</h2>
 
-<p>はい。こちらがプログレスバーのウィジェットのマークアップです:</p>
+<p id="aria-in-action">はい。こちらがプログレスバーのウィジェットのマークアップです。</p>
 
 <pre class="brush:html;">&lt;div id="percent-loaded" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" /&gt;</pre>
 
-<p>このプログレスバーは <code>&lt;div&gt;</code> を使用して作られており、あまり説明的ではありません。残念ながら HTML 4 で開発者が使用できる、より意味があるタグはありませんので、ARIA のロールやプロパティを含めることが必要です。これらは、要素に属性を追加することによって指定します。この例では <code>role="progressbar"</code> 属性で、要素が実際は JavaScript で動作するプログレスバーウィジェットであることをブラウザに伝えます。<strong>aria-valuemin</strong> 属性や <strong>aria-valuemax</strong> 属性はプログレスバーの最小値と最大値を、<strong>aria-valuenow</strong> 属性は現在の状態を示します。</p>
+<p>このプログレスバーは <code>&lt;div&gt;</code> を使用して作られており、あまり説明的ではありません。残念ながら HTML 4 では開発者が使用できる、より意味がある要素はありませんので、ARIA のロールやプロパティを含めることが必要です。これらは、要素に属性を追加することによって指定します。この例では <code>role="progressbar"</code> 属性で、要素が実際は JavaScript で動作するプログレスバーウィジェットであることをブラウザーに伝えます。<strong>aria-valuemin</strong> 属性や <strong>aria-valuemax</strong> 属性はプログレスバーの最小値と最大値を、 <strong>aria-valuenow</strong> 属性は現在の状態を示します。</p>
 
-<p>ARIA の属性はマークアップ内に直接置くほかに、以下のような JavaScript コードを使用して要素へ追加および動的な更新を行うこともできます:</p>
+<p>ARIA の属性はマークアップ内に直接置くほかに、以下のような JavaScript コードを使用して要素へ追加および動的な更新を行うこともできます。</p>
 
-<pre class="brush: javascript" id="line96">// DOM でプログレスバーである &lt;div&gt; を探します。
+<pre class="brush: js">// DOM でプログレスバーである &lt;div&gt; を探します。
 var progressBar = document.getElementById("percent-loaded");
 
 // どのようなウィジェットであるかを支援技術がわかるように、ARIA のロールやステートを設定します。
@@ -159,60 +160,59 @@ progressBar.setAttribute("aria-valuemax", 100);
 // プログレスバーの値を更新するたびに呼び出すことが可能な関数を作成します。
 function updateProgress(percentComplete) {
   progressBar.setAttribute("aria-valuenow", percentComplete);
-}
-</pre>
+}</pre>
 
-<h2 id="ARIA_を追加するとページのスタイルや動作が変わりますか">ARIA を追加するとページのスタイルや動作が変わりますか?</h2>
+<h2 id="Will_adding_ARIA_change_my_page_styles_or_behavior">ARIA を追加するとページのスタイルや動作が変わりますか</h2>
 
-<p>いいえ。ARIA は支援技術の API を使用可能にするだけであり、DOM やスタイルに関するブラウザのネイティブ機能には影響を与えません。ブラウザから見ると、ネイティブな HTML は要素のセマンティックな意味や動作を定義するものであり、ARIA の属性は AT API のサポートを支援するレイヤーとして機能します。ARIA の属性は他の HTML 属性と同様にスタイルを変更しませんが、CSS は要素のセレクタとして ARIA の属性を活用できます。これは、ARIA が有効なウィジェットにスタイルを設定するうえで便利な仕組みです。</p>
+<p>いいえ。ARIA は支援技術の API を使用可能にするだけであり、DOM やスタイルに関するブラウザーのネイティブ機能には影響を与えません。ブラウザーから見ると、ネイティブな HTML は要素のセマンティックな意味や動作を定義するものであり、ARIA の属性は AT API のサポートを支援するレイヤーとして機能します。ARIA の属性は他の HTML 属性と同様にスタイルを変更しませんが、CSS は要素のセレクタとして ARIA の属性を活用できます。これは、ARIA が有効なウィジェットにスタイルを設定するうえで便利な仕組みです。</p>
 
 <pre class="brush: css">.tab-panel[aria-hidden="true"] {
-  display: none;
-  }
+  display: none;
+  }
 
 .tab-panel[aria-hidden="false"] {
-  display: block;
-  }
+  display: block;
+  }
 </pre>
 
-<h2 id="What_about_validation" name="What_about_validation">検証はどうなりますか?</h2>
+<h2 id="What_about_validation">検証はどうなりますか</h2>
 
-<p><strong>role</strong> 属性や <strong>aria-</strong> 接頭辞がついた属性のような、ARIA で導入された新たな属性は、HTML 4 や XHTML 4 の正式な一部分ではありません。その結果、ARIA を含むページは <a href="http://validator.w3.org/" title="http://validator.w3.org/">W3C の Markup Validator</a> のようなツールで検証してはいけません。</p>
+<p><strong>role</strong> 属性や <strong>aria-</strong> 接頭辞がついた属性のような、ARIA で導入された新たな属性は、 HTML 4 や XHTML 4 の正式な一部分ではありません。その結果、ARIA を含むページは <a href="https://validator.w3.org/">W3C の Markup Validator</a> のようなツールで検証してはいけません。</p>
 
-<p>第一にこの問題の解決策になり得ることは、ARIA のロールやステートをマークアップ内に直接置くのを避けることです。代わりに、前出の <a href="#Can_you_show_me_an_example_of_ARIA_in_action" title="#Can_you_show_me_an_example_of_ARIA_in_action">ARIA の実例を見せていただけますか?</a> への回答で示したように、JavaScript を使用してページへ動的に ARIA を追加してください。それでも理論上、ページは妥当ではありませんが、すべての静的な検証は正しく合格するでしょう。</p>
+<p>第一にこの問題の解決策になり得ることは、ARIA のロールやステートをマークアップ内に直接置くのを避けることです。代わりに、前出の <a href="#aria-in-action">ARIA の実例を見せていただけますか?</a> への回答で示したように、JavaScript を使用してページへ動的に ARIA を追加してください。それでも理論上、ページは妥当ではありませんが、すべての静的な検証は正しく合格するでしょう。</p>
 
 <p>別の代案は HTML5 の doctype を使用することで、これは ARIA のサポートが組み込まれています。W3C の HTML5 validator は、あなたの HTML5 ページにおける ARIA の誤った使い方も発見するでしょう。</p>
 
-<h2 id="How_does_HTML5_relate_to_ARIA" name="How_does_HTML5_relate_to_ARIA">HTML5 と ARIA との関係は?</h2>
+<h2 id="How_does_HTML5_relate_to_ARIA">HTML5 と ARIA との関係は?</h2>
 
-<p>HTML5 では、役に立つ多くのセマンティックなタグを HTML に導入しました。新たな <code>&lt;progress&gt;</code> 要素のようにいくつかのタグは、ARIA で使用可能なロールと正に重複します。ARIA にも存在する HTML5 タグをブラウザがサポートする場合は、通常その要素に ARIA のロールやステートも追加する必要はありません。ARIA には HTML5 で使用できない多くのロール、ステート、プロパティが含まれており、それらは HTML5 を使用する開発者にとって引き続き有用でしょう。詳細情報として、Steve Faulkner 氏が <a href="http://www.paciellogroup.com/blog/2010/04/html5-and-the-myth-of-wai-aria-redundance/" title="http://www.paciellogroup.com/blog/2010/04/html5-and-the-myth-of-wai-aria-redundance/">HTML5 と ARIA の関係について良い概説</a>を記述しました。</p>
+<p>HTML5 では、役に立つ多くのセマンティックな要素を HTML に導入しました。これの要素のうちの一部は、新たな <code>&lt;progress&gt;</code> 要素のように、 ARIA で使用可能なロールに直接対応します。ブラウザーが ARIA にも存在する HTML5 要素に対応している場合は、通常その要素に ARIA のロールやステートも追加する必要はありません。ARIA には HTML5 で使用できない多くのロール、ステート、プロパティが含まれており、それらは HTML5 を使用する開発者にとって引き続き有用でしょう。詳細情報として、Steve Faulkner 氏が <a href="https://www.paciellogroup.com/blog/2010/04/html5-and-the-myth-of-wai-aria-redundance/">HTML5 と ARIA の関係について良い概説</a>を記述しました。</p>
 
-<h4 id="Degrading_Gracefully_from_HTML5_to_ARIA" name="Degrading_Gracefully_from_HTML5_to_ARIA">HTML5 から ARIA への円滑な退行</h4>
+<h4 id="Degrading_Gracefully_from_HTML5_to_ARIA">HTML5 から ARIA へのグレイスフルデグラデーション</h4>
 
-<p>HTML5 を理解しないブラウザにコンテンツを提供するときに、必要なところで ARIA の使用へ円滑に退行したいと考えるでしょう。よってプログレスバーの例で言うと、<code>&lt;progressbar&gt;</code> タグがサポートされていない場合は <code>role="progressbar"</code> へ円滑に退行できます。</p>
+<p>HTML5 が利用できないブラウザーにコンテンツを提供するときに、必要なところで ARIA の使用へグレイスフルデグラデーションを行いたいと考えるでしょう。プログレスバーの例で言うと、 <code>&lt;progressbar&gt;</code> 要素に対応していない場合は <code>role="progressbar"</code> へグレイスフルデグラデーションできます。</p>
 
-<p>こちらが、HTML5 のプログレスバーを使用するマークアップの例です:</p>
+<p>こちらが、HTML5 のプログレスバーを使用するマークアップの例です。</p>
 
-<pre class="brush: html" id="line96">&lt;!DOCTYPE html&gt;
+<pre class="brush: html">&lt;!DOCTYPE html&gt;
 &lt;html&gt;
   &lt;head&gt;&lt;title&gt;Gracefully degrading progress bar&lt;/title&gt;&lt;/head&gt;
   &lt;body&gt;
     &lt;progress id="progress-bar" value="0" max="100"&gt;0% complete&lt;/progress&gt;
     &lt;button id="update-button"&gt;Update&lt;/button&gt;
- &lt;/body&gt;
+ &lt;/body&gt;
 &lt;/html&gt;
 </pre>
 
-<p>そして、こちらが古いブラウザでもプログレスバーが動作するようにする JavaScript コードです:</p>
+<p>そして、こちらが古いブラウザーでもプログレスバーが動作するようにする JavaScript コードです。</p>
 
-<pre class="brush: javascript" id="line96">var progressBar = document.getElementById("progress-bar");
+<pre class="brush: js">var progressBar = document.getElementById("progress-bar");
 
-// ブラウザが HTML5 の &lt;progress&gt; タグをサポートするかを確認します。
+// ブラウザーが HTML5 の &lt;progress&gt; 要素に対応しているかを確認します。
 var supportsHTML5Progress = (typeof (HTMLProgressElement) !== "undefined");
 
 function setupProgress() {
   if (!supportsHTML5Progress) {
-    // HTML5 の &lt;progress&gt; がブラウザでサポートされていないので、
+    // HTML5 の &lt;progress&gt; にブラウザーが対応していないので、
     // ARIA のロールやステートを要素に追加します。
     progressBar.setAttribute("role", "progressbar");
     progressBar.setAttribute("aria-valuemin", 0);
@@ -222,11 +222,11 @@ function setupProgress() {
 
 function updateProgress(percentComplete) {
   if (!supportsHTML5Progress) {
-    // HTML5 の &lt;progress&gt; がブラウザでサポートされていないので、
+    // HTML5 の &lt;progress&gt; にブラウザーが対応していないので、
     // aria-valuenow 属性の更新が必要です。
     progressBar.setAttribute("aria-valuenow", percentComplete);
   } else {
-    // HTML5 の &lt;progress&gt; がサポートされているので、代わりに value 属性を更新します。
+    // HTML5 の &lt;progress&gt; に対応しているので、代わりに value 属性を更新します。
     progressBar.setAttribute("value", percentComplete);
   }
 
@@ -234,9 +234,9 @@ function updateProgress(percentComplete) {
 }
 
 function initDemo() {
-  setupProgress(); // プログレスバーの設定。
+  setupProgress(); // プログレスバーの設定。
 
-  // click ハンドラをボタンに割り当てます。これはプログレスバーを 75% に更新します。
+  // click ハンドラーをボタンに割り当てます。これはプログレスバーを 75% に更新します。
   document.getElementById("update-button").addEventListener("click", function (e) {
     updateProgress(75);
     e.preventDefault();
@@ -245,58 +245,59 @@ function initDemo() {
 initDemo();
 </pre>
 
-<h2 id="How_do_assistive_technologies_work" name="How_do_assistive_technologies_work">支援技術はどのように動作しますか?</h2>
+<h2 id="How_do_assistive_technologies_work">支援技術はどのように動作しますか?</h2>
 
-<p>支援技術は、アプリケーションのユーザインターフェイスのロール、ステート、構造を表すよう特に設計された、各オペレーティングシステムに組み込まれた API を使用します。例えば、スクリーンリーダーはテキスト読み上げエンジンでユーザインターフェイスを読むために、拡大鏡はスクリーンで重要またはアクティブな領域を強調するために、オンスクリーンキーボードはそのときの状況や UI コントロールに対してもっとも効率的なキーボードレイアウトを提供するために、この API を使用します。さらに支援技術はたいてい、ページのセマンティクスや属性を理解するために、この API を通してページの DOM にアクセスします。</p>
+<p>支援技術は、アプリケーションのユーザーインターフェイスのロール、ステート、構造を表すよう特に設計された、各オペレーティングシステムに組み込まれた API を使用します。例えば、画面リーダーはテキスト読み上げエンジンでユーザーインターフェイスを読むために、拡大鏡はスクリーンで重要またはアクティブな領域を強調するために、オンスクリーンキーボードはそのときの状況や UI コントロールに対してもっとも効率的なキーボードレイアウトを提供するために、この API を使用します。さらに支援技術はたいてい、ページのセマンティクスや属性を理解するために、この API を通してページの DOM にアクセスします。</p>
 
-<p>ARIA は DOM の世界とデスクトップの世界との間を橋渡しします。ブラウザは ARIA が有効な要素を、ネイティブなウィジェットであるかのように支援技術の API に公開します。その結果ユーザは潜在的により一貫したユーザ体験を得て、そこでは Web の動的な JavaScript で動作するウィジェットが、デスクトップで同等のウィジェットに匹敵します。</p>
+<p>ARIA は DOM の世界とデスクトップの世界との間を橋渡しします。ブラウザーは ARIA が有効な要素を、ネイティブなウィジェットであるかのように支援技術の API に公開します。その結果ユーザーは潜在的により一貫したユーザー体験を得て、そこではウェブの動的な JavaScript で動作するウィジェットが、デスクトップで同等のウィジェットに匹敵します。</p>
 
-<h2 id="How_do_I_test_my_use_of_ARIA_Are_there_any_tools_available_for_free" name="How_do_I_test_my_use_of_ARIA_Are_there_any_tools_available_for_free">私の ARIA の使い方の確認方法は? 自由に使用できるツールはありますか?</h2>
+<h2 id="How_do_I_test_my_use_of_ARIA_Are_there_any_tools_available_for_free">私の ARIA の使い方の確認方法は? 自由に使用できるツールはありますか?</h2>
 
-<p>動作中の ARIA のテストを支援する、調査ツールやデバッグツールがいくつかあります:</p>
+<p>動作中の ARIA のテストを支援する、調査ツールやデバッグツールがいくつかあります。</p>
 
 <ul>
  <li>Windows で Object Inspector</li>
  <li>OS X で Accessibility Inspector</li>
  <li>Linux で AccProbe</li>
  <li>Firebug の DOM Inspector</li>
- <li><a href="http://code.google.com/p/ainspector/" title="http://code.google.com/p/ainspector/">Accessibility Inspector for Firebug</a></li>
+ <li><a href="https://code.google.com/p/ainspector/">Accessibility Inspector for Firebug</a></li>
+ <li>The Audits tab in Chrome DevTools</li>
 </ul>
 
-<p>ARIA の実践的なテストに使用できる、フリーまたはオープンソースのスクリーンリーダーもいくつかあります。以下のようなものです:</p>
+<p>ARIA の実践的なテストに使用できる、フリーまたはオープンソースの画面リーダーもいくつかあります。以下のようなものです:</p>
 
 <ul>
- <li>Linux 向けの <a href="http://live.gnome.org/Orca" title="http://live.gnome.org/Orca">Orca</a></li>
- <li>Windows 向けの <a href="http://www.nvda-project.org/" title="http://www.nvda-project.org/">NVDA</a></li>
- <li>OS X 内蔵の <a href="http://www.apple.com/accessibility/voiceover/" title="http://www.apple.com/accessibility/voiceover/">VoiceOver</a></li>
+ <li>Linux 向けの <a href="https://live.gnome.org/Orca">Orca</a></li>
+ <li>Windows 向けの <a href="https://www.nvda-project.org/">NVDA</a></li>
+ <li>OS X 内蔵の <a href="https://www.apple.com/accessibility/voiceover/">VoiceOver</a></li>
 </ul>
 
-<p>スクリーンリーダーでテストを行うときは、2 つのポイントを覚えておいてください:</p>
+<p>画面リーダーでテストを行うときは、2 つのポイントを覚えておいてください。</p>
 
 <ol>
- <li>スクリーンリーダーのユーザとの軽いテストでは、実際のユーザのフィードバック、テスト、および支援の代替にはなりません。</li>
- <li>スクリーンリーダーのサポートだけがアクセシビリティではありません。さまざまなユーザビリティやアクセシビリティの手法を試しましょう。</li>
+ <li>画面リーダーのユーザーと気軽にテストしても、実際のユーザーからのフィードバックやテスト、ヘルプにはかないません。</li>
+ <li>画面リーダーのサポートだけがアクセシビリティではありません。様々なユーザビリティとアクセシビリティの手法でテストしてみてください。</li>
 </ol>
 
-<p>ARIA が有効なアプリケーションやウィジェット向けの、その他の有用なテストツールや手法です:</p>
+<p>ARIA が有効なアプリケーションやウィジェット向けの、その他の有用なテストツールや手法です。</p>
 
 <ul>
- <li><a href="http://yaccessibilityblog.com/library/test-aria-focus-bookmarklets.html" title="http://yaccessibilityblog.com/library/test-aria-focus-bookmarklets.html">Yahoo!'s ARIA bookmarklets</a></li>
- <li>Fluid Project の <a href="http://wiki.fluidproject.org/display/fluid/Simple+Accessibility+Review+Protocol" title="http://wiki.fluidproject.org/display/fluid/Simple+Accessibility+Review+Protocol">simple accessibility evaluation techniques</a></li>
+ <li><a href="https://yaccessibilityblog.com/library/test-aria-focus-bookmarklets.html">Yahoo!'s ARIA bookmarklets</a></li>
+ <li>Fluid Project の <a href="https://wiki.fluidproject.org/display/fluid/Simple+Accessibility+Review+Protocol">simple accessibility evaluation techniques</a></li>
 </ul>
 
-<h2 id="Where_do_ARIA_discussions_happen" name="Where_do_ARIA_discussions_happen">ARIA の議論はどこで行われていますか?</h2>
+<h2 id="Where_do_ARIA_discussions_happen">ARIA の議論はどこで行われていますか?</h2>
 
 <ul>
- <li><a href="http://lists.w3.org/Archives/Public/wai-xtech/" title="http://lists.w3.org/Archives/Public/wai-xtech/">Wai-xtech mailing list</a> -- ARIA 仕様の議論を保持しています。</li>
- <li><a href="http://groups.google.com/group/free-aria" title="http://groups.google.com/group/free-aria">Free-ARIA google group</a> -- フリーなツールやリソースの開発者およびユーザ向けです。</li>
+ <li><a href="https://lists.w3.org/Archives/Public/wai-xtech/">Wai-xtech mailing list</a> -- ARIA 仕様で議論されてきたことを保持しています。</li>
+ <li><a href="https://groups.google.com/group/free-aria">Free-ARIA google group</a> -- 無料のツールやリソースの開発者およびユーザー向けです。</li>
 </ul>
 
-<h2 id="Where_can_I_learn_more_about_ARIA" name="Where_can_I_learn_more_about_ARIA">ARIA についてより詳しく学ぶには?</h2>
+<h2 id="Where_can_I_learn_more_about_ARIA">ARIA についてより詳しく学ぶには</h2>
 
 <ul>
- <li><a href="/ja/docs/Accessibility/An_overview_of_accessible_web_applications_and_widgets" title="Accessibility/An overview of accessible web applications and widgets">アクセシブルな Web アプリケーションやウィジェットの概要</a></li>
- <li><a href="/ja/docs/Accessibility/Accessible_forms" title="Accessibility/Accessible forms">Accessible forms</a></li>
- <li>W3C の <a href="http://www.w3.org/WAI/aria/faq" title="http://www.w3.org/WAI/aria/faq">WAI-ARIA Frequently Asked Questions</a></li>
- <li>WebAIM の <a href="http://webaim.org/techniques/aria/" title="http://webaim.org/techniques/aria/">Accessibility of Rich Internet Applications</a></li>
+ <li><a href="/ja/docs/Web/Accessibility/An_overview_of_accessible_web_applications_and_widgets">アクセス可能なウェブアプリケーションやウィジェットの概要</a></li>
+ <li><a href="/ja/docs/Web/Accessibility/ARIA/forms">Accessible forms</a></li>
+ <li>W3C の <a href="https://www.w3.org/WAI/aria/faq">WAI-ARIA Frequently Asked Questions</a></li>
+ <li>WebAIM の <a href="https://webaim.org/techniques/aria/">Accessibility of Rich Internet Applications</a></li>
 </ul>


### PR DESCRIPTION
- 2021/04/29 時点の英語版に同期
- 原語併記マクロを廃止 (https://github.com/mozilla-japan/translation/issues/547)