### PR TITLE
[FIX] parse err for method, property, sharedarraybuffer(#329)

### DIFF
--- a/files/ko/web/javascript/reference/global_objects/sharedarraybuffer/index.html
+++ b/files/ko/web/javascript/reference/global_objects/sharedarraybuffer/index.html
@@ -88,11 +88,17 @@ worker.postMessage(sab);
 
 <h3 id="속성_2">속성</h3>
 
-<p>{{page('en-US/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/prototype','Properties')}}</p>
+<dl>
+  <dt><a href="/ko/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/byteLength"></a><code>SharedArrayBuffer.prototype.byteLength</code></a></dt>
+  <dd>배열의 크기 (바이트)입니다. 이것은 배열이 구성 될 때 설정되며 변경할 수 없습니다. 읽기 전용입니다.</dd>
+</dl>
 
 <h3 id="메소드">메소드</h3>
 
-<p>{{page('en-US/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/prototype','Methods')}}</p>
+<dl>
+  <dt><a href="/ko/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/slice"></a><code>SharedArrayBuffer.prototype.slice(begin, end)</code></a></dt>
+  <dd>Returns a new <code>SharedArrayBuffer</code> whose contents are a copy of this <code>SharedArrayBuffer</code>'s bytes from <code>begin</code>, inclusive, up to <code>end</code>, exclusive. <code>begin</code> 또는 <code>end</code> 중 하나가 음수이면 처음부터가 아니라 배열 끝의 인덱스를 참조합니다.</dd>
+</dl>
 
 <h2 id="명세">명세</h2>
 


### PR DESCRIPTION
fix parse err #329 

<img src="https://user-images.githubusercontent.com/22424891/116814608-ca271300-ab94-11eb-9bc9-394f11afd6a1.png" height="150px" />

delete macro #692 

---
- 기타 사항
![image](https://user-images.githubusercontent.com/22424891/116822690-374d9f00-abbb-11eb-9df8-8c437e849e53.png)

#728 원래 순번인데 제가 실수로 잘못 작업해서 직접 추가했습니다.. fork한 main 브랜치가 원래 main 브랜치보다 뒤에있어도 squash and merge를 하기때문에 아무작업없이 merge해줘도 되네요..! ㅠㅜ