### PR TITLE
[FIX] Content bug (#744), Primitive

### DIFF
--- a/files/ko/glossary/primitive/index.html
+++ b/files/ko/glossary/primitive/index.html
@@ -19,7 +19,7 @@ translation_of: Glossary/Primitive
 
 <h3 id="JavaScript">JavaScript</h3>
 
-<pre class="brush: js line-numbers  language-js notranslate" dir="rtl">// 문자열 메서드는 문자열을 변형하지 않음
+<pre class="brush: js">// 문자열 메서드는 문자열을 변형하지 않음
 var bar = "baz";
 console.log(bar);        // baz
 bar.toUpperCase();

--- a/files/ko/web/javascript/guide/grammar_and_types/index.html
+++ b/files/ko/web/javascript/guide/grammar_and_types/index.html
@@ -99,7 +99,7 @@ console.log("c 값은 " + c); // ReferenceError 예외 던짐
 let x;
 console.log('x 값은 ' + x); // x 값은 undefined
 
-console.oog('y 값은 ' + y); // ReferenceError 예외 던짐
+console.log('y 값은 ' + y); // ReferenceError 예외 던짐
 let y;
 </pre>
 


### PR DESCRIPTION
issue #744

---
## What page(s) did you find the problem on?
[https://developer.mozilla.org/ko/docs/Glossary/Primitive](https://developer.mozilla.org/ko/docs/Glossary/Primitive)

## Specific page section or heading?
예제
다음 예제는 원시 값이 불변함을 이해할 때 도움이 됩니다.
JavaScript

## What is the problem?
Contents is flipped

<img width="903" alt="스크린샷 2021-05-02 오후 6 23 29" src="https://user-images.githubusercontent.com/42544600/116808401-807a0080-ab73-11eb-9f33-67cbbed3ec40.png">

## What did you expect to see?
Code's direction will be shown correctly

## Did you test this? If so, how?
Mac OS(Big Sur), Chrome/Safari occurred


