### PR TITLE
[FIX] macros, en-US update, nullish operator

### DIFF
--- a/files/ko/web/javascript/reference/operators/nullish_coalescing_operator/index.html
+++ b/files/ko/web/javascript/reference/operators/nullish_coalescing_operator/index.html
@@ -5,9 +5,11 @@ translation_of: Web/JavaScript/Reference/Operators/Nullish_coalescing_operator
 ---
 <p>{{JSSidebar("Operators")}}</p>
 
-<p><strong>널 병합 연산자 (<code>??</code>)</strong> 는 왼쪽 피연산자가 {{jsxref("null")}} 또는 {{jsxref("undefined")}}일 때 오른쪽 피연산자를 반환하고, 그렇지 않으면 왼쪽 피연산자를 반환하는 논리 연산자이다.</p>
+<p><strong>널 병합 연산자 (<code>??</code>)</strong> 는 왼쪽 피연산자가 <a href="/ko/docs/Web/JavaScript/Reference/Global_Objects/null">null</a> 또는 <a href="/ko/docs/Web/JavaScript/Reference/Global_Objects/undefined">undefined</a>일 때 오른쪽 피연산자를 반환하고, 그렇지 않으면 왼쪽 피연산자를 반환하는 논리 연산자이다.</p>
 
 <p>이는 왼쪽 피연산자가 <code>null</code> 또는 <code>undefined</code> 뿐만 아니라 <em><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Description">falsy</a> </em>값에 해당할 경우 오른쪽 피연산자를 반환하는 <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_OR_2">논리 연산자 OR (<code>||</code>)</a>와는 대조된다. 다시 말해 만약 어떤 변수 foo에게 <em><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Description">falsy</a> </em>값( <code>''</code> 또는 <code>0</code>)을 포함한 값을 제공하기 위해 <code>||</code>을 사용하는 것을 고려했다면 예기치 않는 동작이 발생할 수 있다. 하단에 더 많은 예제가 있다.</p>
+
+<p> 널 병합 연산자는 <a href="/ko/docs/Web/JavaScript/Reference/Operators/Operator_Precedence">연산자 우선 순위</a>가 다섯번째로 낮은데, <code>||</code> 의 바로 아래이며 <a href="/ko/docs/Web/JavaScript/Reference/Operators/Conditional_Operator">조건부 (삼항) 연산자</a>의 바로 위이다. </p>
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-nullishcoalescingoperator.html")}}</div>
 


### PR DESCRIPTION
- 수정 사항
  - macros
  - en-US페이지와 비교해서 3 번째 문단 누락 

---

#626 에서 
![image](https://user-images.githubusercontent.com/22424891/117273703-55efb680-ae97-11eb-8bfa-f2cb5ecdb161.png)
suggestion을 누르지않아 머지되지않아서 반영이 되지않아 같은 내용 새로 PR 올렸습니다.

@nKiNk  suggestion 된줄 알았는데 적용안돼있었네요 제가 확인했어야했는데 실수했습니댜 ㅠㅠ 다시 확인하고 머지해주실 수 있나요?ㅠㅠ

