### PR TITLE
Fix a typo in the example for CacheStorage.keys()

### DIFF
--- a/files/fr/web/api/cachestorage/delete/index.html
+++ b/files/fr/web/api/cachestorage/delete/index.html
@@ -39,7 +39,7 @@ translation_of: Web/API/CacheStorage/delete
 
 <p>Dans ce fragment de code, nous attendons un évènement, et bloquons avec un {{domxref("ExtendableEvent.waitUntil","waitUntil()")}}, qui nettoie les anciens, inutilisés, caches avant que le nouveau service worker soit activé. Nous avons ici une liste blanche contenant le nom du cache que nous voulons garder. Nous retournons les clés des caches dans l'objet {{domxref("CacheStorage")}} utilisant {{domxref("CacheStorage.keys")}}, pour ensuite vérifier que chaque clé est dans la liste blance. Sinon, nous la supprimons avec <code>delete().</code></p>
 
-<pre class="brush: js">then.addEventListener('activate', function(event) {
+<pre class="brush: js">this.addEventListener('activate', function(event) {
   var cacheWhitelist = ['v2'];
 
   event.waitUntil(

--- a/files/fr/web/api/cachestorage/keys/index.html
+++ b/files/fr/web/api/cachestorage/keys/index.html
@@ -37,7 +37,7 @@ translation_of: Web/API/CacheStorage/keys
 
 <p>Dans ce fragment de code, nous attendons un évènement, et bloquons avec un {{domxref("ExtendableEvent.waitUntil","waitUntil()")}}, qui nettoie les anciens caches, inutilisés, avant que le nouveau service worker soit activé. Nous avons ici une liste blanche contenant le nom du cache que nous voulons garder. Nous retournons les clés des caches dans l'objet {{domxref("CacheStorage")}} utilisant {{domxref("CacheStorage.keys")}}, pour ensuite vérifier que chaque clé est dans la liste blance. Sinon, nous la supprimons avec <code>delete().</code></p>
 
-<pre class="brush: js">then.addEventListener('activate', function(event) {
+<pre class="brush: js">this.addEventListener('activate', function(event) {
   var cacheWhitelist = ['v2'];
 
   event.waitUntil(

--- a/files/ja/web/api/cachestorage/keys/index.html
+++ b/files/ja/web/api/cachestorage/keys/index.html
@@ -37,7 +37,7 @@ translation_of: Web/API/CacheStorage/keys
 
 <p>このコードスニペットでは、{{domxref("ServiceWorkerGlobalScope.onactivate", "activate")}} イベントを待機してから、新しいサービスワーカーがアクティブ化される前に、古い未使用のキャッシュをクリアする {{domxref("ExtendableEvent.waitUntil","waitUntil()")}} ブロックを実行します。 ここに、保持したいキャッシュの名前を含むホワイトリスト（<code>cacheWhitelist</code>）があります。 <code>keys()</code> を使用して {{domxref("CacheStorage")}} オブジェクトのキャッシュのキーを返し、各キーをチェックしてホワイトリストにあるかどうかを確認します。 ない場合は、{{domxref("CacheStorage.delete()")}} を使用して削除します。</p>
 
-<pre class="brush: js">then.addEventListener('activate', function(event) {
+<pre class="brush: js">this.addEventListener('activate', function(event) {
   var cacheWhitelist = ['v2'];
 
   event.waitUntil(

--- a/files/ja/web/api/serviceworkerglobalscope/onactivate/index.html
+++ b/files/ja/web/api/serviceworkerglobalscope/onactivate/index.html
@@ -25,7 +25,7 @@ ServiceWorkerGlobalScope.addEventListener('activate', function(event) { ... });<
 
 <p>次のスニペットは、<a href="/ja/docs/Web/API/ServiceWorker_API/Using_Service_Workers#Updating_your_service_worker">Using Service Workers</a> のものです; 詳細はそちらを見てください。</p>
 
-<pre class="brush: js">then.addEventListener('activate', function(event) {
+<pre class="brush: js">this.addEventListener('activate', function(event) {
   var cacheWhitelist = ['v2'];
 
   event.waitUntil(

--- a/files/zh-cn/web/api/cachestorage/keys/index.html
+++ b/files/zh-cn/web/api/cachestorage/keys/index.html
@@ -26,7 +26,7 @@ translation_of: Web/API/CacheStorage/keys
 
 <p>在此代码片段中，我们监听{{domxref("ServiceWorkerGlobalScope.onactivate", "activate")}} 事件，然后运行一个 {{domxref("ExtendableEvent.waitUntil","waitUntil()")}} 方法，该方法在新的 service worker 被激活之前清除老的、无用的cache。 这里我们设置一个包含缓存名称的白名单。 通过使用 <code>keys()方法</code> 来返回{{domxref("CacheStorage")}} 对象中的keys集合，然后检查缓存key是否在白名单中，如果不存在，则使用 {{domxref("CacheStorage.delete")}} 方法来删除该缓存。</p>
 
-<pre class="brush: js">then.addEventListener('activate', function(event) {
+<pre class="brush: js">this.addEventListener('activate', function(event) {
   var cacheWhitelist = ['v2'];
 
   event.waitUntil(


### PR DESCRIPTION
Follow-up to https://github.com/mdn/content/pull/4790 on the main repo.
