### PR TITLE
Web/JavaScript/Guide/Expressions_and_Operators を更新

### DIFF
--- a/files/ja/web/javascript/guide/expressions_and_operators/index.html
+++ b/files/ja/web/javascript/guide/expressions_and_operators/index.html
@@ -7,13 +7,13 @@ tags:
   - Guide
   - JavaScript
   - Operators
-  - 'l10n:priority'
+  - l10n:priority
   - 演算子
 translation_of: Web/JavaScript/Guide/Expressions_and_Operators
 ---
 <div>{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Functions", "Web/JavaScript/Guide/Numbers_and_dates")}}</div>
 
-<p class="summary">この章では 代入、比較、算術、ビット、論理、文字列、三項演算子などに関わる JavaScript の式 (expression) や演算子 (operator) について説明しています。</p>
+<p class="summary">この章では JavaScript の式 (expression) や演算子 (operator) について、代入、比較、算術、ビット、論理、文字列、三項演算子などを説明しています。</p>
 
 <p>演算子と式について網羅した詳しいリストは<a href="/ja/docs/Web/JavaScript/Reference/Operators">リファレンス</a>でもご覧いただけます。</p>
 
@@ -22,167 +22,163 @@ translation_of: Web/JavaScript/Guide/Expressions_and_Operators
 <p>JavaScript では以下の種類の演算子を使用できます。この節では演算子の優先順位についての説明も含めて演算子について説明します。</p>
 
 <ul>
- <li>{{web.link("#Assignment_operators", "代入演算子")}}</li>
- <li>{{web.link("#Comparison_operators", "比較演算子")}}</li>
- <li>{{web.link("#Arithmetic_operators", "算術演算子")}}</li>
- <li>{{web.link("#Bitwise_operators", "ビット演算子")}}</li>
- <li>{{web.link("#Logical_operators", "論理演算子")}}</li>
- <li>{{web.link("#String_operators", "文字列演算子")}}</li>
- <li>{{web.link("#Conditional_(ternary)_operator", "条件（三項）演算子")}}</li>
- <li>{{web.link("#Comma_operator", "カンマ演算子")}}</li>
- <li>{{web.link("#Unary_operators", "単項演算子")}}</li>
- <li>{{web.link("#Relational_operators", "関係演算子")}}</li>
+ <li><a href="#assignment_operators">代入演算子</a></li>
+ <li><a href="#comparison_operators">比較演算子</a></li>
+ <li><a href="#arithmetic_operators">算術演算子</a></li>
+ <li><a href="#bitwise_operators">ビット演算子</a></li>
+ <li><a href="#logical_operators">論理演算子</a></li>
+ <li><a href="#string_operators">文字列演算子</a></li>
+ <li><a href="#conditional_ternary_operator">条件（三項）演算子</a></li>
+ <li><a href="#comma_operator">カンマ演算子</a></li>
+ <li><a href="#unary_operators">単項演算子</a></li>
+ <li><a href="#relational_operators">関係演算子</a></li>
 </ul>
 
-<p>JavaScript は<em>二項演算子</em>や<em>単項演算子</em>を実装しており、さらには三項演算子や条件演算子も実装しています。二項演算子は以下のような形で演算子 (operator) を一つ、その前後となるようにオペランド (operand) が二つ必要となります。</p>
+<p>JavaScript は<em>二項演算子</em>や<em>単項演算子</em>を実装しており、さらには特殊な三項演算子である条件演算子も実装しています。二項演算子は以下のような形で演算子 (operator) を一つ、その前後となるようにオペランド (operand) が二つ必要となります。</p>
 
-<pre class="syntaxbox notranslate"><em>operand1</em> <em>operator</em> <em>operand2</em>
+<pre class="brush: js"><em>operand1</em> <em>operator</em> <em>operand2</em>
 </pre>
 
 <p>例えば <code>3+4</code> や <code>x*y</code> です。</p>
 
 <p>単項演算子は演算子の前後いずれかに、一つのオペランドが必要です。</p>
 
-<pre class="syntaxbox notranslate">operator operand</pre>
+<pre class="brush: js"><em>operator</em> <em>operand</em>
+</pre>
 
 <p>もしくは</p>
 
-<pre class="syntaxbox notranslate">operand operator</pre>
+<pre class="brush: js"><em>operand</em> <em>operator</em>
+</pre>
 
 <p>例えば <code>x++</code> や <code>++x</code> です。</p>
 
-<h3 id="Assignment_operators" name="Assignment_operators">代入演算子</h3>
+<h3 id="Assignment_operators">代入演算子</h3>
 
-<p>代入演算子は右オペランドの値を元に、左のオペランドへ値を代入するものです。簡単なものでは equal (<code>=</code>) があり、右オペランドの値を左オペランドへ代入します。つまり、<code>x = y</code> では <code>y</code> の値を <code>x</code> へ代入することになります。</p>
+<p>代入演算子は右オペランドの値を元に、左のオペランドへ値を代入するものです。簡単なものではイコール (<code>=</code>) があり、右オペランドの値を左オペランドへ代入します。つまり、 <code>x = y</code> では <code>y</code> の値を <code>x</code> へ代入することになります。</p>
 
 <p>次の表にまとめられているように演算子を省略した複合代入演算子というものもあります。</p>
 
 <table class="standard-table">
- <caption>複合代入演算子</caption>
- <thead>
-  <tr>
-   <th>名称</th>
-   <th>略記演算子</th>
-   <th>意味</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Assignment">代入</a></td>
-   <td><code>x = y</code></td>
-   <td><code>x = y</code></td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Addition_assignment">加算代入</a></td>
-   <td><code>x += y</code></td>
-   <td><code>x = x + y</code></td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Subtraction_assignment">減算代入</a></td>
-   <td><code>x -= y</code></td>
-   <td><code>x = x - y</code></td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Multiplication_assignment">乗算代入</a></td>
-   <td><code>x *= y</code></td>
-   <td><code>x = x * y</code></td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Division_assignment">除算代入</a></td>
-   <td><code>x /= y</code></td>
-   <td><code>x = x / y</code></td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Remainder_assignment">剰余代入</a></td>
-   <td><code>x %= y</code></td>
-   <td><code>x = x % y</code></td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Exponentiation_assignment">べき乗代入</a></td>
-   <td><code>x **= y</code></td>
-   <td><code>x = x ** y</code></td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Left_shift_assignment">左シフト代入</a></td>
-   <td><code>x &lt;&lt;= y</code></td>
-   <td><code>x = x &lt;&lt; y</code></td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Right_shift_assignment">右シフト代入</a></td>
-   <td><code>x &gt;&gt;= y</code></td>
-   <td><code>x = x &gt;&gt; y</code></td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift_assignment">符号なし右シフト代入</a></td>
-   <td><code>x &gt;&gt;&gt;= y</code></td>
-   <td><code>x = x &gt;&gt;&gt; y</code></td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Bitwise_AND_assignment">ビット論理積 (AND) 代入</a></td>
-   <td><code>x &amp;= y</code></td>
-   <td><code>x = x &amp; y</code></td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Bitwise_XOR_assignment">ビット排他的論理和 (XOR) 代入</a></td>
-   <td><code>x ^= y</code></td>
-   <td><code>x = x ^ y</code></td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Bitwise_OR_assignment">ビット論理和 (OR) 代入</a></td>
-   <td><code>x |= y</code></td>
-   <td><code>x = x | y</code></td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Logical_AND_assignment">論理積代入</a></td>
-   <td><code>x &amp;&amp;= y</code></td>
-   <td><code>x &amp;&amp; (x = y)</code></td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Logical_OR_assignment">論理和代入</a></td>
-   <td><code>x ||= y</code></td>
-   <td><code>x || (x = y)</code></td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Logical_nullish_assignment">Null 合体代入</a></td>
-   <td><code>x ??= y</code></td>
-   <td><code>x ?? (x = y)</code></td>
-  </tr>
- </tbody>
+  <caption>複合代入演算子</caption>
+  <thead>
+    <tr>
+      <th>名称</th>
+      <th>略記演算子</th>
+      <th>意味</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Assignment">代入</a></td>
+      <td><code>x = y</code></td>
+      <td><code>x = y</code></td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Addition_assignment">加算代入</a></td>
+      <td><code>x += y</code></td>
+      <td><code>x = x + y</code></td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Subtraction_assignment">減算代入</a></td>
+      <td><code>x -= y</code></td>
+      <td><code>x = x - y</code></td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Multiplication_assignment">乗算代入</a></td>
+      <td><code>x *= y</code></td>
+      <td><code>x = x * y</code></td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Division_assignment">除算代入</a></td>
+      <td><code>x /= y</code></td>
+      <td><code>x = x / y</code></td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Remainder_assignment">剰余代入</a></td>
+      <td><code>x %= y</code></td>
+      <td><code>x = x % y</code></td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Exponentiation_assignment">べき乗代入</a></td>
+      <td><code>x **= y</code></td>
+      <td><code>x = x ** y</code></td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Left_shift_assignment">左シフト代入</a></td>
+      <td><code>x &lt;&lt;= y</code></td>
+      <td><code>x = x &lt;&lt; y</code></td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Right_shift_assignment">右シフト代入</a></td>
+      <td><code>x &gt;&gt;= y</code></td>
+      <td><code>x = x &gt;&gt; y</code></td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift_assignment">符号なし右シフト代入</a></td>
+      <td><code>x &gt;&gt;&gt;= y</code></td>
+      <td><code>x = x &gt;&gt;&gt; y</code></td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Bitwise_AND_assignment">ビット論理積 (AND) 代入</a></td>
+      <td><code>x &amp;= y</code></td>
+      <td><code>x = x &amp; y</code></td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Bitwise_XOR_assignment">ビット排他的論理和 (XOR) 代入</a></td>
+      <td><code>x ^= y</code></td>
+      <td><code>x = x ^ y</code></td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Bitwise_OR_assignment">ビット論理和 (OR) 代入</a></td>
+      <td><code>x |= y</code></td>
+      <td><code>x = x | y</code></td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Logical_AND_assignment">論理積代入</a></td>
+      <td><code>x &amp;&amp;= y</code></td>
+      <td><code>x &amp;&amp; (x = y)</code></td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Logical_OR_assignment">論理和代入</a></td>
+      <td><code>x ||= y</code></td>
+      <td><code>x || (x = y)</code></td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Logical_nullish_assignment">Null 合体代入</a></td>
+      <td><code>x ??= y</code></td>
+      <td><code>x ?? (x = y)</code></td>
+    </tr>
+  </tbody>
 </table>
 
-<h4 id="Destructuring" name="Destructuring">戻り値と連鎖</h4>
+<h4 id="Return_value_and_chaining">返値と連鎖</h4>
 
-<p>ほとんどの式と同様に、<code>x = y</code> のような代入には戻り値があります。戻り値は式の代入やロギング等により取得することができます。</p>
+<p>ほとんどの式と同様に、 <code>x = y</code> のような代入には返値があります。返値は式の代入やロギング等により取得することができます。</p>
 
-<pre class="notranslate">const z = (x = y); // 右記と等価 const z = x = y;
+<pre>const z = (x = y); // const z = x = y; と等価
 
-console.log(z); // 代入 x = y の戻り値をログする。
-console.log(x = y); // または、戻り値を直接ログする。</pre>
+console.log(z); // 代入 x = y の返値をログする。
+console.log(x = y); // または、返値を直接ログする。</pre>
 
-<p>戻り値は上の表の「意味」列の <code>=</code> 記号の右側の式と一致します。つまり <code>(x = y)</code> は <code>y</code> を返し、<code>(x += y)</code> は加算 <code>x + y</code> の結果を返し、<code>(x **= y)</code> はべき乗 <code>x ** y</code> の結果を返します。</p>
+<p>返値は上の表の「意味」列の <code>=</code> 記号の右側の式と一致します。つまり <code>(x = y)</code> は <code>y</code> を返し、<code>(x += y)</code> は加算 <code>x + y</code> の結果を返し、　<code>(x **= y)</code> はべき乗 <code>x ** y</code> の結果を返します。</p>
 
-<p>論理代入、<code>(x &amp;&amp;= y)</code> 、<code>(x ||= y)</code> および <code>(x ??= y)</code> の場合、戻り値は代入を除いた論理演算の結果であり、それぞれ <code>x &amp;&amp; y</code> 、<code>x || y</code> および <code>x ?? y</code> を返します。</p>
+<p>論理代入、<code>(x &amp;&amp;= y)</code> 、<code>(x ||= y)</code> および <code>(x ??= y)</code> の場合、返値は代入を除いた論理演算の結果であり、それぞれ <code>x &amp;&amp; y</code> 、<code>x || y</code> および <code>x ?? y</code> を返します。</p>
 
-<p>戻り値は常に演算<em>前</em>のオペランドの値に基づくことに注意してください。</p>
+<p>返値は常に演算<em>前</em>のオペランドの値に基づくことに注意してください。</p>
 
 <p>これらの式を連鎖させると、それぞれの代入は<strong>右から左に</strong>評価されます。以下の例で考えてみましょう。</p>
 
 <ul>
  <li><code>w = z = x = y</code> は <code>w = (z = (x = y))</code> または <code>x = y; z = y; w = y</code> と等価です</li>
- <li><code>z += x *= y</code> は <code>z += (x *= y)</code> または <code>tmp = x * y; x *= y; z += tmp</code>（<code>tmp</code> がないことを除く）と等価です</li>
+ <li><code>z += x *= y</code> は <code>z += (x *= y)</code> または <code>tmp = x * y; x *= y; z += tmp</code> (<code>tmp</code> がないことを除く) と等価です</li>
 </ul>
 
-<h4 id="Destructuring" name="Destructuring">分割代入</h4>
+<h4 id="Destructuring">分割代入</h4>
 
 <p>より複雑な代入方法、<a href="/ja/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment">分割代入</a>構文は、配列やオブジェクトのリテラル構造を反映した構文を用いて、配列やオブジェクトからデータを抽出することができる JavaScript の式です。</p>
 
-<ul>
-</ul>
-
-<ul>
-</ul>
-
-<pre class="brush: js notranslate">var foo = ['one', 'two', 'three'];
+<pre class="brush: js">var foo = ['one', 'two', 'three'];
 
 // 分割を行わない代入
 var one   = foo[0];
@@ -192,320 +188,321 @@ var three = foo[2];
 // 分割代入
 var [one, two, three] = foo;</pre>
 
-<h3 id="Comparison_operators" name="Comparison_operators">比較演算子</h3>
+<h3 id="Comparison_operators">比較演算子</h3>
 
-<p><a href="/ja/docs/Web/JavaScript/Reference/Operators/Comparison_Operators">比較演算子</a>は被演算子を比較して、その結果が真であるかに基づいて論理値を返します。被演算子には数値、文字列、論理値、オブジェクトを使用できます。文字列は Unicode を用い、標準的な辞書順に基づいて比較されます。ほとんどの場合、2 つの被演算子が異なる型ならば JavaScript はその被演算子を比較に適した型に変換しようとします。こうした挙動により、一般的に被演算子は数値的に比較される結果となります。このルールの唯一の例外は <code>===</code> および <code>!==</code> で、これらは「厳密に」等値か否かを判断し、等値性をチェックする前に被演算子を適合する型に変換しません。次の表では、以下のサンプルコードで定義された変数を前提として比較演算子を説明していきます。</p>
+<p><a href="/ja/docs/Web/JavaScript/Reference/Operators">比較演算子</a>はオペランドを比較して、その結果が真であるかに基づいて論理値を返します。オペランドには数値、文字列、論理値、オブジェクトを使用できます。文字列は Unicode を用い、標準的な辞書順に基づいて比較されます。ほとんどの場合、2 つのオペランドが異なる型ならば JavaScript はそのオペランドを比較に適した型に変換しようとします。こうした挙動により、一般的にオペランドは数値的に比較される結果となります。このルールの唯一の例外は <code>===</code> および <code>!==</code> で、これらは「厳密に」等値か否かを判断し、等値性をチェックする前にオペランドを適合する型に変換しません。次の表では、以下のサンプルコードで定義された変数を前提として比較演算子を説明していきます。</p>
 
-<pre class="brush: js notranslate">var var1 = 3;
+<pre class="brush: js">var var1 = 3;
 var var2 = 4;
 </pre>
 
 <table class="standard-table">
- <caption>比較演算子</caption>
- <thead>
-  <tr>
-   <th scope="col">演算子</th>
-   <th scope="col">説明</th>
-   <th scope="col">true を返す例</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Equality">等価</a> (<code>==</code>)</td>
-   <td>被演算子が等しい場合に <code>true</code> を返します。</td>
-   <td><code>3 == var1</code>
-    <p><code>"3" == var1</code></p>
-    <code>3 == '3'</code></td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Inequality">不等価</a> (<code>!=</code>)</td>
-   <td>被演算子が等しくない場合に <code>true</code> を返します。</td>
-   <td><code>var1 != 4<br>
-    var2 != "3"</code></td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Strict_equality">厳密等価</a> (<code>===</code>)</td>
-   <td>被演算子が等しく、かつ同じ型である場合に <code>true</code> を返します。{{jsxref("Object.is")}} や <a href="/ja/docs/Web/JavaScript/Equality_comparisons_and_sameness" title="/ja/docs/Web/JavaScript/Guide/Sameness">JavsScript での等価</a>も参照してください。</td>
-   <td><code>3 === var1</code></td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Strict_inequality">厳密不等価</a> (<code>!==</code>)</td>
-   <td>被演算子が等しくなく、かつ/または同じ型でない場合に <code>true</code> を返します。</td>
-   <td><code>var1 !== "3"<br>
-    3 !== '3'</code></td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Greater_than">より大きい</a> (<code>&gt;</code>)</td>
-   <td>左の被演算子が右の被演算子よりも大きい場合に <code>true</code> を返します。</td>
-   <td><code>var2 &gt; var1<br>
-    "12" &gt; 2</code></td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Greater_than_or_equal">以上</a> (<code>&gt;=</code>)</td>
-   <td>左の被演算子が右の被演算子以上である場合に <code>true</code> を返します。</td>
-   <td><code>var2 &gt;= var1<br>
-    var1 &gt;= 3</code></td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Less_than">より小さい</a> (<code>&lt;</code>)</td>
-   <td>左の被演算子が右の被演算子よりも小さい場合に <code>true</code> を返します。</td>
-   <td><code>var1 &lt; var2<br>
-    "2" &lt; 12</code></td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Less_than_or_equal">以下</a> (<code>&lt;=</code>)</td>
-   <td>左の被演算子が右の被演算子以下である場合に <code>true</code> を返します。</td>
-   <td><code>var1 &lt;= var2<br>
-    var2 &lt;= 5</code></td>
-  </tr>
- </tbody>
+  <caption>比較演算子</caption>
+  <thead>
+    <tr>
+      <th scope="col">演算子</th>
+      <th scope="col">説明</th>
+      <th scope="col">true を返す例</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators#equality">等価</a> (<code>==</code>)</td>
+      <td>オペランドが等しい場合に <code>true</code> を返します。</td>
+      <td><code>3 == var1</code>
+        <p><code>"3" == var1</code></p>
+        <code>3 == '3'</code></td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators#inequality">不等価</a> (<code>!=</code>)</td>
+      <td>オペランドが等しくない場合に <code>true</code> を返します。</td>
+      <td><code>var1 != 4<br>
+        var2 != "3"</code></td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators#identity">厳密等価</a> (<code>===</code>)</td>
+      <td>オペランドが等しく、かつ同じ型である場合に <code>true</code> を返します。{{jsxref("Object.is")}} や <a href="/ja/docs/Web/JavaScript/Equality_comparisons_and_sameness">JavsScript での等価</a>も参照してください。</td>
+      <td><code>3 === var1</code></td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators#nonidentity">厳密不等価</a> (<code>!==</code>)</td>
+      <td>オペランドが等しくなく、かつ/または同じ型でない場合に <code>true</code> を返します。</td>
+      <td><code>var1 !== "3"<br>
+        3 !== '3'</code></td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators#greater_than_operator">より大きい</a> (<code>&gt;</code>)</td>
+      <td>左のオペランドが右のオペランドよりも大きい場合に <code>true</code> を返します。</td>
+      <td><code>var2 &gt; var1<br>
+        "12" &gt; 2</code></td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators#greater_than_or_equal_operator">以上</a> (<code>&gt;=</code>)</td>
+      <td>左のオペランドが右のオペランド以上である場合に <code>true</code> を返します。</td>
+      <td><code>var2 &gt;= var1<br>
+        var1 &gt;= 3</code></td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators#less_than_operator">より小さい</a> (<code>&lt;</code>)</td>
+      <td>左のオペランドが右のオペランドよりも小さい場合に <code>true</code> を返します。</td>
+      <td><code>var1 &lt; var2<br>
+        "2" &lt; 12</code></td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators#less_than_or_equal_operator">以下</a> (<code>&lt;=</code>)</td>
+      <td>左のオペランドが右のオペランド以下である場合に <code>true</code> を返します。</td>
+      <td><code>var1 &lt;= var2<br>
+        var2 &lt;= 5</code></td>
+    </tr>
+  </tbody>
 </table>
 
 <div class="note">
-<p><strong>メモ: </strong>(<strong>=&gt;</strong>) は演算子ではなく、<a href="/docs/Web/JavaScript/Reference/Functions/Arrow_functions">アロー関数</a>を表す記法です。</p>
+<p><strong>メモ:</strong> (<strong>=&gt;</strong>) は演算子ではなく、<a href="/ja/docs/Web/JavaScript/Reference/Functions/Arrow_functions">アロー関数</a>を表す記法です。</p>
 </div>
 
-<h3 id="Arithmetic_operators" name="Arithmetic_operators">算術演算子</h3>
+<h3 id="Arithmetic_operators">算術演算子</h3>
 
-<p><a href="/ja/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators">算術演算子</a>は被演算子として数値（リテラルまたは変数）をとり、1 つの数値を返します。標準的な算術演算子は、加算 (<code>+</code>)、減算 (<code>-</code>)、乗算 (<code>*</code>)、除算 (<code>/</code>) です。これらの演算子は、他のほとんどのプログラミング言語で浮動小数点数を用いた場合と同じように機能します（特に、0 で除算をすると {{jsxref("Infinity")}} になることに注意してください）。例えば以下のようになります。</p>
+<p><a href="/ja/docs/Web/JavaScript/Reference/Operators">算術演算子</a>はオペランドとして数値 (リテラルまたは変数) をとり、1 つの数値を返します。標準的な算術演算子は、加算 (<code>+</code>)、減算 (<code>-</code>)、乗算 (<code>*</code>)、除算 (<code>/</code>) です。これらの演算子は、他のほとんどのプログラミング言語で浮動小数点数を用いた場合と同じように機能します (特に、0 で除算をすると {{jsxref("Infinity")}} になることに注意してください)。例えば以下のようになります。</p>
 
-<pre class="brush: js notranslate">1 / 2; // 0.5
+<pre class="brush: js">1 / 2; // 0.5
 1 / 2 == 1.0 / 2.0; // true になります
 </pre>
 
-<p>標準的な算術演算子に加え、さらに JavaScript では、以下の表で示す算術演算子も使用できます。</p>
+<p>標準的な算術演算子 (<code>+</code>, <code>-</code>,
+  <code>*</code>, <code>/</code>) に加え、さらに JavaScript では、以下の表で示す算術演算子も使用できます。</p>
 
 <table class="fullwidth-table">
- <caption>算術演算子</caption>
- <thead>
-  <tr>
-   <th scope="col">演算子</th>
-   <th scope="col">説明</th>
-   <th scope="col">例</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Remainder">剰余</a> (<code>%</code>)</td>
-   <td>二項演算子です。2 つの被演算子で除算したときの、整数の余りを返します。</td>
-   <td>12 % 5 は 2 を返します。</td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Increment">インクリメント</a> (<code>++</code>)</td>
-   <td>単項演算子です。被演算子に 1 を加えます。前置演算子 (<code>++x</code>) として用いると、被演算子に 1 を加えた後にその値を返します。後置演算子 (<code>x++</code>) として用いると、被演算子に 1 を加える前にその値を返します。</td>
-   <td><code>x</code> が 3 の場合、<code>++x</code> は <code>x</code> に 4 を設定して 4 を返します。一方、<code>x++</code> は 3 を返したあと <code>x</code> に 4 を設定します。</td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Decrement">デクリメント</a> (<code>--</code>)</td>
-   <td>単項演算子です。被演算子から 1 を引きます。戻り値はインクリメント演算子のものと同様です。</td>
-   <td><code>x</code> が 3 の場合、<code>--x</code> は <code>x</code> に 2 を設定して 2 を返します。一方、<code>x--</code> は 3 を返したあと <code>x</code> に 2 を設定します。</td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Unary_negation">単項符号反転</a> (<code>-</code>)</td>
-   <td>単項演算子です。被演算子の符号を反転して、その値を返します。</td>
-   <td><code>x</code> が 3 のとき、<code>-x</code> は -3 を返します。</td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Unary_plus">単項プラス</a> (<code>+</code>)</td>
-   <td>単項演算子です。数値でない被演算子の数値への変換を試みます。</td>
-   <td><code>+"3"</code> は <code>3</code> を返します。<br>
-    <code>+true</code> は <code>1</code> を返します。</td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation">べき乗演算子</a> (<code>**</code>) {{experimental_inline}}</td>
-   <td><code>基数部</code>を<code>指数部</code>乗したものを計算します、つまり、<code>基数部<sup>指数部</sup></code> となります。</td>
-   <td><code>2 ** 3</code> は <code>8</code> を返します。<br>
-    <code>10 ** -1</code> は <code>0.1</code> を返します。</td>
-  </tr>
- </tbody>
+  <caption>算術演算子</caption>
+  <thead>
+    <tr>
+      <th scope="col">演算子</th>
+      <th scope="col">説明</th>
+      <th scope="col">例</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators#remainder">剰余</a> (<code>%</code>)</td>
+      <td>二項演算子です。2 つのオペランドで除算したときの、整数の余りを返します。</td>
+      <td>12 % 5 は 2 を返します。</td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators#increment">インクリメント</a> (<code>++</code>)</td>
+      <td>単項演算子です。オペランドに 1 を加えます。前置演算子 (<code>++x</code>) として用いると、オペランドに 1 を加えた後にその値を返します。後置演算子 (<code>x++</code>) として用いると、オペランドに 1 を加える前にその値を返します。</td>
+      <td><code>x</code> が 3 の場合、<code>++x</code> は <code>x</code> に 4 を設定して 4 を返します。一方、<code>x++</code> は 3 を返したあと <code>x</code> に 4 を設定します。</td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators#decrement">デクリメント</a> (<code>--</code>)</td>
+      <td>単項演算子です。オペランドから 1 を引きます。返値はインクリメント演算子のものと同様です。</td>
+      <td><code>x</code> が 3 の場合、<code>--x</code> は <code>x</code> に 2 を設定して 2 を返します。一方、<code>x--</code> は 3 を返したあと <code>x</code> に 2 を設定します。</td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators#unary_negation">単項符号反転</a> (<code>-</code>)</td>
+      <td>単項演算子です。オペランドの符号を反転して、その値を返します。</td>
+      <td><code>x</code> が 3 のとき、<code>-x</code> は -3 を返します。</td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators#unary_plus">単項プラス</a> (<code>+</code>)</td>
+      <td>単項演算子です。数値でないオペランドの数値への変換を試みます。</td>
+      <td><code>+"3"</code> は <code>3</code> を返します。<br>
+        <code>+true</code> は <code>1</code> を返します。</td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators#exponentiation">べき乗演算子</a> (<code>**</code>) {{experimental_inline}}</td>
+      <td><code>基数部</code>を<code>指数部</code>乗したものを計算します、つまり、<code>基数部<sup>指数部</sup></code> となります。</td>
+      <td><code>2 ** 3</code> は <code>8</code> を返します。<br>
+        <code>10 ** -1</code> は <code>0.1</code> を返します。</td>
+    </tr>
+  </tbody>
 </table>
 
-<h3 id="Bitwise_operators" name="Bitwise_operators">ビット演算子</h3>
+<h3 id="Bitwise_operators">ビット演算子</h3>
 
-<p><a href="/ja/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators">ビット演算子</a>はその被演算子を 10進数や 16進数や 8進数ではなく、32 個のビットの集合（0 と 1）として扱います。例えば、10進数の 9 の 2進表現は 1001 です。ビット演算子はこのように 2進表現にした上で演算を行いますが、JavaScript において標準的な 10進数表現の数値を返します。</p>
+<p><a href="/ja/docs/Web/JavaScript/Reference/Operators">ビット演算子</a>はそのオペランドを 10 進数や 16 進数や 8 進数ではなく、 32 個のビットの集合 (0 と 1) として扱います。例えば、 10 進数の 9 の 2進表現は 1001 です。ビット演算子はこのように  2 進表現にした上で演算を行いますが、JavaScript において標準的な  10 進数表現の数値を返します。</p>
 
 <p>次の表は JavaScript のビット演算子の概要です。</p>
 
 <table class="standard-table">
- <caption>ビット演算子</caption>
- <thead>
-  <tr>
-   <th scope="col">演算子</th>
-   <th scope="col" style="width: 5em;">使用法</th>
-   <th scope="col">説明</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_AND">ビット論理積</a> (AND)</td>
-   <td><code>a &amp; b</code></td>
-   <td>被演算子の対応するビットがともに 1 である各ビットについて 1 を返します。</td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_OR">ビット論理和</a> (OR)</td>
-   <td><code>a | b</code></td>
-   <td>被演算子の対応するビットがともに 0 である各ビットについて 0 を返します。</td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_XOR">ビット排他的論理和</a> (XOR)</td>
-   <td><code>a ^ b</code></td>
-   <td>被演算子の対応するビットが同じ各ビットについて 0 を返します。<br>
-    [被演算子の対応するビットが異なる各ビットについて 1 を返します。]</td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_NOT">ビット否定</a> (NOT)</td>
-   <td><code>~ a</code></td>
-   <td>被演算子の各ビットを反転します。</td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Left_shift">左シフト</a></td>
-   <td><code>a &lt;&lt; b</code></td>
-   <td>
-    <p>2進表現の <code>a</code> を <code>b</code> ビット分だけ左にシフトします。右から 0 で詰めます。</p>
-   </td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Right_shift">符号維持右シフト</a></td>
-   <td><code>a &gt;&gt; b</code></td>
-   <td>2進表現の <code>a</code> を <code>b</code> ビット分だけ右にシフトします。溢れたビットは破棄します。</td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Unsigned_right_shift">ゼロ埋め右シフト</a></td>
-   <td><code>a &gt;&gt;&gt; b</code></td>
-   <td>2進表現の <code>a</code> を <code>b</code> ビット分だけ右にシフトします。溢れたビットは破棄し、左から 0 で詰めます。</td>
-  </tr>
- </tbody>
+  <caption>ビット演算子</caption>
+  <thead>
+    <tr>
+      <th scope="col">演算子</th>
+      <th scope="col">使用法</th>
+      <th scope="col">説明</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Bitwise_AND">ビット論理積</a> (AND)</td>
+      <td><code>a &amp; b</code></td>
+      <td>オペランドの対応するビットがともに 1 である各ビットについて 1 を返します。</td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Bitwise_OR">ビット論理和</a> (OR)</td>
+      <td><code>a | b</code></td>
+      <td>オペランドの対応するビットがともに 0 である各ビットについて 0 を返します。</td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Bitwise_XOR">ビット排他的論理和</a> (XOR)</td>
+      <td><code>a ^ b</code></td>
+      <td>オペランドの対応するビットが同じ各ビットについて 0 を返します。<br>
+        [オペランドの対応するビットが異なる各ビットについて 1 を返します。]</td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Bitwise_NOT">ビット否定</a> (NOT)</td>
+      <td><code>~ a</code></td>
+      <td>オペランドの各ビットを反転します。</td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Left_shift">左シフト</a></td>
+      <td><code>a &lt;&lt; b</code></td>
+      <td>
+        <p>2 進表現の <code>a</code> を <code>b</code> ビット分だけ左にシフトします。右から 0 で詰めます。</p>
+      </td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Right_shift">符号維持右シフト</a></td>
+      <td><code>a &gt;&gt; b</code></td>
+      <td>2 進表現の <code>a</code> を <code>b</code> ビット分だけ右にシフトします。溢れたビットは破棄します。</td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift">ゼロ埋め右シフト</a></td>
+      <td><code>a &gt;&gt;&gt; b</code></td>
+      <td>2 進表現の <code>a</code> を <code>b</code> ビット分だけ右にシフトします。溢れたビットは破棄し、左から 0 で詰めます。</td>
+    </tr>
+  </tbody>
 </table>
 
-<h4 id="Bitwise_Logical_Operators" name="Bitwise_Logical_Operators">ビット論理演算子</h4>
+<h4 id="Bitwise_Logical_Operators">ビット論理演算子</h4>
 
 <p>概念上、ビット論理演算子は以下のように機能します。</p>
 
 <ul>
- <li>被演算子の値は 32 ビットの整数に変換され、0 もしくは 1 からなるビット列として表現されます。32 ビットを超える数値は、32 ビットを超えた部分が捨てられます。次の例では、32 ビットを超える整数が、32 ビットの整数に変換されています。
-<pre class="notranslate">変換前: 1110<code> </code>0110<code> </code>1111<code> </code>1010<code> </code>0000<code> </code>0000<code> </code>0000<code> </code>0110<code> </code>0000<code> </code>0000<code> </code>0001
-変換後:               1010<code> </code>0000<code> </code>0000<code> </code>0000<code> </code>0110<code> </code>0000<code> </code>0000<code> </code>0001</pre>
+ <li>オペランドの値は 32 ビットの整数に変換され、0 もしくは 1 からなるビット列として表現されます。32 ビットを超える数値は、32 ビットを超えた部分が捨てられます。次の例では、32 ビットを超える整数が、32 ビットの整数に変換されています。
+    <pre>変換前: 1110 0110 1111 1010 0000 0000 0000 0110 0000 0000 0001
+変換後:                1010 0000 0000 0000 0110 0000 0000 0001</pre>
  </li>
- <li>第1被演算子の各ビットは第2被演算子の対応する各ビットと対になります。第1 ビットと第1 ビット、第2 ビットと第2 ビット、以下同様に。</li>
+ <li>第 1 オペランドの各ビットは第 2 オペランドの対応する各ビットと対になります。第 1 ビットと第 1 ビット、第 2 ビットと第 2 ビット、以下同様に。</li>
  <li>演算子は各ビットのペアに適用され、結果はビットごとに構成されます。</li>
 </ul>
 
-<p>例えば 9 の 2進表現は 1001 で、15 の 2進表現は 1111 です。したがって、ビット演算子がこれらの値に適用されたときの結果は以下のようになります。</p>
+<p>例えば 9 の 2 進表現は 1001 で、15 の 2 進表現は 1111 です。したがって、ビット演算子がこれらの値に適用されたときの結果は以下のようになります。</p>
 
 <table class="standard-table">
- <caption>ビット演算子の例</caption>
- <thead>
-  <tr>
-   <th scope="col">演算式</th>
-   <th scope="col">結果</th>
-   <th scope="col">2進数での説明</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><code>15 &amp; 9</code></td>
-   <td><code>9</code></td>
-   <td><code>1111 &amp; 1001 = 1001</code></td>
-  </tr>
-  <tr>
-   <td><code>15 | 9</code></td>
-   <td><code>15</code></td>
-   <td><code>1111 | 1001 = 1111</code></td>
-  </tr>
-  <tr>
-   <td><code>15 ^ 9</code></td>
-   <td><code>6</code></td>
-   <td><code>1111 ^ 1001 = 0110</code></td>
-  </tr>
-  <tr>
-   <td><code>~15</code></td>
-   <td><code>-16</code></td>
-   <td><code>~</code><code>00000000...</code><code>00001111 = </code><code>1111</code><code>1111</code><code>...</code><code>11110000</code></td>
-  </tr>
-  <tr>
-   <td><code>~9</code></td>
-   <td><code>-10</code></td>
-   <td><code>~</code><code>00000000</code><code>...</code><code>0000</code><code>1001 = </code><code>1111</code><code>1111</code><code>...</code><code>1111</code><code>0110</code></td>
-  </tr>
- </tbody>
+  <caption>ビット演算子の例</caption>
+  <thead>
+    <tr>
+      <th scope="col">演算式</th>
+      <th scope="col">結果</th>
+      <th scope="col">2 進数での説明</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>15 &amp; 9</code></td>
+      <td><code>9</code></td>
+      <td><code>1111 &amp; 1001 = 1001</code></td>
+    </tr>
+    <tr>
+      <td><code>15 | 9</code></td>
+      <td><code>15</code></td>
+      <td><code>1111 | 1001 = 1111</code></td>
+    </tr>
+    <tr>
+      <td><code>15 ^ 9</code></td>
+      <td><code>6</code></td>
+      <td><code>1111 ^ 1001 = 0110</code></td>
+    </tr>
+    <tr>
+      <td><code>~15</code></td>
+      <td><code>-16</code></td>
+      <td><code>~ 0000 0000 ... 0000 1111 = 1111 1111 ... 1111 0000</code></td>
+    </tr>
+    <tr>
+      <td><code>~9</code></td>
+      <td><code>-10</code></td>
+      <td><code>~ 0000 0000 ... 0000 1001 = 1111 1111 ... 1111 0110</code></td>
+    </tr>
+  </tbody>
 </table>
 
-<p>ビット否定演算子を使うと 32 ビットすべてが反転し、その値の最上位（最左）ビットは負数を表す 1 に設定される（2 の補数表現）ことに注意してください。<code>~x</code> は <code>-x - 1</code> と同じ値に評価されます。</p>
+<p>ビット否定演算子を使うと 32 ビットすべてが反転し、その値の最上位 (最も左の) ビットは (2 の補数表現で) 負数を表す 1 に設定されることに注意してください。 <code>~x</code> は <code>-x - 1</code> と同じ値に評価されます。</p>
 
-<h4 id="Bitwise_Shift_Operators" name="Bitwise_Shift_Operators">ビットシフト演算子</h4>
+<h4 id="Bitwise_Shift_Operators">ビットシフト演算子</h4>
 
-<p>ビットシフト演算子は 2 つの被演算子をとります。第1被演算子はシフトされる数を指定し、第2被演算子は、第1被演算子をシフトさせるビット数を指定します。シフト演算の方向は使用する演算子によって決まります。</p>
+<p>ビットシフト演算子は 2 つのオペランドをとります。第 1 オペランドはシフトされる数を指定し、第 2 オペランドは、第 1 オペランドをシフトさせるビット数を指定します。シフト演算の方向は使用する演算子によって決まります。</p>
 
-<p>シフト演算子はその被演算子を 32 ビット整数に変換し、左の被演算子と同じ型で結果を返します。</p>
+<p>シフト演算子はそのオペランドを 32 ビット整数に変換し、結果を {{jsxref("Number")}} または {{jsxref("BigInt")}} のどちらかで返します。特に、左のオペランドの型が {{jsxref("BigInt")}} であった場合、 {{jsxref("BigInt")}} を返します。それ以外の場合は {{jsxref("Number")}} を返します。</p>
 
 <p>シフト演算子の種類は次表のとおりです。</p>
 
 <table class="fullwidth-table">
- <caption>ビットシフト演算子</caption>
- <thead>
-  <tr>
-   <th scope="col" style="width: 9em;">演算子</th>
-   <th scope="col">説明</th>
-   <th scope="col">例</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#&lt;&lt;_(Left_shift)">左シフト</a><br>
-    (<code>&lt;&lt;</code>)</td>
-   <td>この演算子は、第1被演算子を指定したビット数分だけ左にシフトします。左に溢れたビットは破棄されます。0 のビットを右から詰めます。</td>
-   <td><code>9&lt;&lt;2</code> の結果は 36 になります。1001 を 2 ビット左にシフトすると 100100 になり、これは 36 となるからです。</td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#>>_(Sign-propagating_right_shift)">符号維持右シフト</a> (<code>&gt;&gt;</code>)</td>
-   <td>この演算子は、第1被演算子を指定したビット数分だけ右にシフトします。右に溢れたビットは破棄されます。左端のビットのコピーを左から詰めます。</td>
-   <td><code>9&gt;&gt;2</code> の結果は 2 になります。1001 を 2 ビット右にシフトすると 10 であり、これは 2 となるからです。同様に、<code>-9&gt;&gt;2</code> の結果は、符号が維持されるため -3 になります。</td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#>>>_(Zero-fill_right_shift)">ゼロ埋め右シフト (<code>&gt;&gt;&gt;</code>)</a></td>
-   <td>この演算子は、第1被演算子を指定したビット数分だけ右にシフトします。右に溢れたビットは破棄されます。0 のビットを左から詰めます。</td>
-   <td><code>19&gt;&gt;&gt;2</code> の結果は 4 になります。10011 を 2 ビット右にシフトすると 100 になり、これは 4 となるからです。非負数では、0 埋め右シフトと符号を維持した右シフトは同じ結果になります。</td>
-  </tr>
- </tbody>
+  <caption>ビットシフト演算子</caption>
+  <thead>
+    <tr>
+      <th scope="col">演算子</th>
+      <th scope="col">説明</th>
+      <th scope="col">例</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Left_shift">左シフト</a><br>
+        (<code>&lt;&lt;</code>)</td>
+      <td>この演算子は、第 1 オペランドを指定したビット数分だけ左にシフトします。左に溢れたビットは破棄されます。0 のビットを右から詰めます。</td>
+      <td><code>9&lt;&lt;2</code> の結果は 36 になります。1001 を 2 ビット左にシフトすると 100100 になり、これは 36 となるからです。</td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Right_shift">符号維持右シフト</a> (<code>&gt;&gt;</code>)</td>
+      <td>この演算子は、第 1 オペランドを指定したビット数分だけ右にシフトします。右にあふれたビットは破棄されます。左端のビットのコピーを左から入れます。</td>
+      <td><code>9&gt;&gt;2</code> の結果は 2 になります。1001 を 2 ビット右にシフトすると 10 であり、これは 2 となるからです。同様に、<code>-9&gt;&gt;2</code> は符号が維持されるため -3 になります。</td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift">ゼロ埋め右シフト</a> (<code>&gt;&gt;&gt;</code>)</td>
+      <td>この演算子は、第 1 オペランドを指定したビット数分だけ右にシフトします。右に溢れたビットは破棄されます。0 のビットを左から詰めます。</td>
+      <td><code>19&gt;&gt;&gt;2</code> の結果は 4 になります。10011 を 2 ビット右にシフトすると 100 になり、これは 4 となるからです。非負数では、0 埋め右シフトと符号を維持した右シフトは同じ結果になります。</td>
+    </tr>
+  </tbody>
 </table>
 
-<h3 id="Logical_operators" name="Logical_operators">論理演算子</h3>
+<h3 id="Logical_operators">論理演算子</h3>
 
-<p><a href="/ja/docs/Web/JavaScript/Reference/Operators/Logical_Operators">論理演算子</a>では、基本的に{{原語併記("ブール値","Boolean value")}}（論理）値を用います。つまりブール値を取ると、ブール値を返します。しかし <code>&amp;&amp;</code> および <code>||</code> 演算子については、実際には指定された被演算子の一方の値を返します。そのため、非ブール値とともに論理演算子が使われた場合、非ブール値を返す可能性があります。次表で論理演算子について説明します。</p>
+<p>論理演算子では、基本的にブール値 (論理値) を用います。その場合は論理値を返します。しかし、 <code>&amp;&amp;</code> および <code>||</code> 演算子については、実際には指定されたオペランドの一方の値を返します。そのため、これらの演算子で論理値以外が使用された場合、論理値以外を返すことがあります。論理演算子は次の表で説明します。</p>
 
 <table class="fullwidth-table">
- <caption>論理演算子</caption>
- <thead>
-  <tr>
-   <th scope="col" style="width: 8em;">演算子</th>
-   <th scope="col" style="width: 10em;">使用法</th>
-   <th scope="col">説明</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_AND">論理積 (AND)</a> (<code>&amp;&amp;</code>)</td>
-   <td><code>expr1 &amp;&amp; expr2</code></td>
-   <td><code>expr1</code> を false と見ることができる場合は、<code>expr1</code> を返します。そうでない場合は <code>expr2</code> を返します。したがってブール値を用いた場合、両被演算子が true であれば <code>&amp;&amp;</code> は true を返し、そうでなければ false を返します。</td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_OR">論理和 (OR)</a> (<code>||</code>)</td>
-   <td><code>expr1 || expr2</code></td>
-   <td><code>expr1</code> を true と見ることができる場合は、<code>expr1</code> を返します。そうでない場合は <code>expr2</code> を返します。したがってブール値を用いた場合、どちらかの被演算子が true であれば <code>||</code> は true を返し、両方とも false であれば false を返します。</td>
-  </tr>
-  <tr>
-   <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_NOT">論理否定 (NOT)</a> (<code>!</code>)</td>
-   <td><code>!expr</code></td>
-   <td>単一の被演算子を true と見ることができる場合は、false を返します。そうでない場合は true を返します。</td>
-  </tr>
+  <caption>論理演算子</caption>
+  <thead>
+    <tr>
+      <th scope="col">演算子</th>
+      <th scope="col">使用法</th>
+      <th scope="col">説明</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Logical_AND">論理積 (AND)</a> (<code>&amp;&amp;</code>)</td>
+      <td><code>expr1 &amp;&amp; expr2</code></td>
+      <td><code>expr1</code> を false と見ることができる場合は、<code>expr1</code> を返します。そうでない場合は <code>expr2</code> を返します。したがって論理値を用いた場合、両オペランドが true であれば <code>&amp;&amp;</code> は true を返し、そうでなければ false を返します。</td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Logical_OR">論理和 (OR)</a> (<code>||</code>)</td>
+      <td><code>expr1 || expr2</code></td>
+      <td><code>expr1</code> を true と見ることができる場合は、<code>expr1</code> を返します。そうでない場合は <code>expr2</code> を返します。したがって論理値を用いた場合、どちらかのオペランドが true であれば <code>||</code> は true を返し、両方とも false であれば false を返します。</td>
+    </tr>
+    <tr>
+      <td><a href="/ja/docs/Web/JavaScript/Reference/Operators/Logical_NOT">論理否定 (NOT)</a> (<code>!</code>)</td>
+      <td><code>!expr</code></td>
+      <td>単一のオペランドを true と見ることができる場合は、false を返します。そうでない場合は true を返します。</td>
+    </tr>
  </tbody>
 </table>
 
-<p>false に変換される式としては、null、0、NaN、空文字列 ("")、undefined に評価される式が挙げられます。</p>
+<p><code>false</code> に変換される式としては、null、0、NaN、空文字列 ("")、undefined に評価される式が挙げられます。</p>
 
 <p>以下のコードで <code>&amp;&amp;</code> (論理 AND) 演算子の例を示します。</p>
 
-<pre class="brush: js notranslate">var a1 =  true &amp;&amp; true;     // t &amp;&amp; t は true を返す
+<pre class="brush: js">var a1 =  true &amp;&amp; true;     // t &amp;&amp; t は true を返す
 var a2 =  true &amp;&amp; false;    // t &amp;&amp; f は false を返す
 var a3 = false &amp;&amp; true;     // f &amp;&amp; t は false を返す
 var a4 = false &amp;&amp; (3 == 4); // f &amp;&amp; f は false を返す
@@ -516,7 +513,7 @@ var a7 = 'Cat' &amp;&amp; false;    // t &amp;&amp; f は false を返す
 
 <p>以下のコードで || (論理 OR) 演算子の例を示します。</p>
 
-<pre class="brush: js notranslate">var o1 =  true || true;     // t || t は true を返す
+<pre class="brush: js">var o1 =  true || true;     // t || t は true を返す
 var o2 = false || true;     // f || t は true を返す
 var o3 =  true || false;    // t || f は true を返す
 var o4 = false || (3 == 4); // f || f は false を返す
@@ -527,62 +524,63 @@ var o7 = 'Cat' || false;    // t || f は Cat を返す
 
 <p>以下のコードで !(論理 NOT) 演算子の例を示します。</p>
 
-<pre class="brush: js notranslate">var n1 = !true;  // !t は false を返す
+<pre class="brush: js">var n1 = !true;  // !t は false を返す
 var n2 = !false; // !f は true を返す
 var n3 = !'Cat'; // !t は false を返す
 </pre>
 
-<h4 id="Short-Circuit_Evaluation" name="Short-Circuit_Evaluation">短絡評価</h4>
+<h4 id="Short-Circuit_Evaluation">短絡評価</h4>
 
-<p>論理式は左から右に評価されるため、以下のルールを用いた「{{原語併記("短絡","short-circuit")}}」評価によるテストが実行できます。</p>
+<p>複数の論理式が左から右へ評価される際に、以下の規則で「短絡」 (short-sircuit) 評価ができるかどうかが確認されます。</p>
 
 <ul>
- <li><code>false</code> &amp;&amp; <em>anything</em> は false へと短絡評価されます。</li>
- <li><code>true</code> || <em>anything</em> は true へと短絡評価されます。</li>
+ <li><code>false</code> &amp;&amp; <em>何か</em> は false へと短絡評価されます。</li>
+ <li><code>true</code> || <em>何か</em> は true へと短絡評価されます。</li>
 </ul>
 
 <p>論理的なルールにより、これらの評価が常に正確であることが保証されます。上記の式で <em>anything</em> の部分は評価されないため、どのようにしても副作用が生じないことに注意してください。</p>
 
-<p>2 番目のケースでは、最新のコードで <code>||</code> のように機能する新しい <a href="/ja/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator">Null 合体演算子</a> (<code>??</code>) を使用できますが、最初の式が "<a href="/ja/docs/Glossary/Nullish">nullish</a>"、つまり <a href="/ja/docs/Web/JavaScript/Reference/Global_Objects/null"><code>null</code></a> または <a href="/ja/docs/Web/JavaScript/Reference/Global_Objects/undefined"><code>undefined</code></a> の場合にのみ 2 番目の式を返すことに注意してください。したがって、<code>''</code> や <code>0</code> などの値が最初の式の有効な値である場合は、デフォルトを提供することをお勧めします。</p>
+<p>なお、 2 番目のケースについては、新しいコードでにおいて新しい <a href="/ja/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator">Null 合体演算子</a> (<code>??</code>) が使用できますが、これは最初の式が "<a href="/ja/docs/Glossary/Nullish">nullish</a>"、つまり <a href="/ja/docs/Web/JavaScript/Reference/Global_Objects/null" title="null という値は、いかなるオブジェクトの値も意図的に存在しないことを表します。これは、 JavaScriptのプリミティブな値のひとつで、論理演算では偽値として扱われます。"><code>null</code></a> または <a href="/ja/docs/Web/JavaScript/Reference/Global_Objects/undefined" title="グローバル undefined プロパティは、プリミティブ値 undefined を表します。これは、 JavaScript のプリミティブ型のひとつです。"><code>undefined</code></a> である場合のみ 2 番目の式を返します。したがって、 1 番目の式で <code>''</code> や <code>0</code> などを有効な値として扱う場合に、既定値を提供する代替策とすることをお勧めします。</p>
 
-<h3 id="String_operators" name="String_operators">文字列演算子</h3>
+<h3 id="String_operators">文字列演算子</h3>
 
-<p>文字列に対して使用することができる演算子には、比較演算子に加えて、2 つの文字列を結合する結合演算子 (+) があり、2 つの被演算子の文字列を結合した文字列を返します。</p>
+<p>文字列に対して使用することができる演算子には、比較演算子に加えて、2 つの文字列を結合する結合演算子 (+) があり、2 つのオペランドの文字列を結合した文字列を返します。</p>
 
 <p>例えば、</p>
 
-<pre class="brush: js notranslate">console.log('my ' + 'string'); // 文字列 "my string" がログに表示される。</pre>
+<pre class="brush: js">console.log('my ' + 'string'); // 文字列 "my string" がログに表示される。</pre>
 
 <p>短縮表記した代入演算子 += も文字列の結合に使用できます。</p>
 
 <p>例えば、</p>
 
-<pre class="brush: js notranslate">var mystring = 'alpha';
+<pre class="brush: js">var mystring = 'alpha';
 mystring += 'bet'; // "alphabet" と評価されて、mystring にその値を代入します。</pre>
 
-<h3 id="Conditional_ternary_operator" name="Conditional_(ternary)_operator">条件（三項）演算子</h3>
+<h3 id="Conditional_ternary_operator">条件（三項）演算子</h3>
 
-<p><a href="/ja/docs/Web/JavaScript/Reference/Operators/Conditional_Operator">条件演算子</a>は JavaScript で唯一 3 つの被演算子を取る演算子です。条件に基づいて 2 つの値のうち 1 つを選択します。構文は以下の通りです。</p>
+<p><a href="/ja/docs/Web/JavaScript/Reference/Operators/Conditional_Operator">条件演算子</a>は JavaScript で唯一 3 つのオペランドを取る演算子です。条件に基づいて 2 つの値のうちの 1 つを選択します。構文は以下の通りです。</p>
 
-<pre class="syntaxbox notranslate"><em>条件</em> ? <em>値1</em> : <em>値2</em>
+<pre class="brush: js"><em>条件</em> ? <em>値 1</em> : <em>値 2</em>
 </pre>
 
-<p><code>条件</code>が真の場合、演算子は<code>値1</code> の値を選択します。そうでない場合、<code>値2</code> の値を選択します。標準的な演算子を使用できる場所ならどこでも条件演算子を使用できます。</p>
+<p><code>条件</code>が真の場合、演算子は<code>値 1</code> の値を選択します。そうでない場合、<code>値 2</code> の値を選択します。標準的な演算子を使用できる場所ならどこでも条件演算子を使用できます。</p>
 
 <p>例えば、</p>
 
-<pre class="brush: js notranslate">var status = (age &gt;= 18) ? 'adult' : 'minor';
+<pre class="brush: js">var status = (age &gt;= 18) ? 'adult' : 'minor';
 </pre>
 
 <p>この文では、<code>age</code> が 18 以上の場合、変数 <code>status</code> に "adult" の値が代入されます。そうでない場合 <code>status</code> には "minor" が代入されます。</p>
 
-<h3 id="Comma_operator" name="Comma_operator">カンマ演算子</h3>
+<h3 id="Comma_operator">カンマ演算子</h3>
 
-<p><a href="/ja/docs/Web/JavaScript/Reference/Operators/Comma_Operator">カンマ演算子</a> (<code>,</code>) は両側の被演算子を単純に評価し、最後の被演算子の値を返します。この演算子は主に <code>for</code> ループ内で使用され、これによりループのたびに複数の変数を更新できます。</p>
+<p><a href="/ja/docs/Web/JavaScript/Reference/Operators/Comma_Operator">カンマ演算子</a>（,）は、オペランドの両方を評価し、最後のオペランドの値を返します。この演算子は、主に<code>for</code> ループの中で、繰り返しのたびに複数の変数を更新するために使用されます。多くの場合、2つの独立したステートメントを代わりに使用することができ、また使用すべきです。
+ (<code>,</code>) は両側のオペランドを単純に評価し、最後のオペランドの値を返します。この演算子は主に <code>for</code> ループ内で使用され、これによりループのたびに複数の変数を更新できます。</p>
 
-<p>例えば、一辺が 10 要素の 2 次元配列 <code>a</code> があったとして、以下のコードでカンマ演算子を用いて 2 つの変数を同時にインクリメントしています。このコードでは配列の対角成分の値を出力します。</p>
+<p>例えば、一辺が 10 要素の 2 次元配列 <code>a</code> があったとして、以下のコードでカンマ演算子を用いて 2 つの変数を同時に更新しています。このコードでは配列の対角成分の値を出力します。</p>
 
-<pre class="brush: js notranslate">var x = [0,1,2,3,4,5,6,7,8,9]
+<pre class="brush: js">var x = [0,1,2,3,4,5,6,7,8,9]
 var a = [x, x, x, x, x];
 
 for (var i = 0, j = 9; i &lt;= j; i++, j--)
@@ -590,15 +588,15 @@ for (var i = 0, j = 9; i &lt;= j; i++, j--)
   console.log('a[' + i + '][' + j + ']= ' + a[i][j]);
 </pre>
 
-<h3 id="Unary_operators" name="Unary_operators">単項演算子</h3>
+<h3 id="Unary_operators">単項演算子</h3>
 
-<p>単項演算は被演算子を 1 つだけ取る演算です。</p>
+<p>単項演算はオペランドを 1 つだけ取る演算です。</p>
 
-<h4 id="delete" name="delete"><code>delete</code></h4>
+<h4 id="delete"><code>delete</code></h4>
 
 <p><code><a href="/ja/docs/Web/JavaScript/Reference/Operators/delete">delete</a></code> 演算子はオブジェクトやオブジェクトのプロパティ、配列の指定されたインデックスの要素を削除します。構文は以下のとおりです。</p>
 
-<pre class="brush: js notranslate">delete object.property;
+<pre class="brush: js">delete object.property;
 delete object[propertyKey];
 delete objectName[index];
 delete property; // legal only within a with statement
@@ -606,13 +604,11 @@ delete property; // legal only within a with statement
 
 <p>ここで <code>object</code> はオブジェクトの名前を、<code>property</code> は既存のプロパティを、<code>propertyKey</code> は配列の要素の位置を示す整数をそれぞれ表しています。</p>
 
-<p>4番目の形式は <code><a href="/ja/docs/Web/JavaScript/Reference/Statements/with">with</a></code> 文内でのみ有効で、これはあるオブジェクトからプロパティを削除します。</p>
+<p>4番目の形式は <code><a href="/ja/docs/Web/JavaScript/Reference/Statements/with">with</a></code> 文の中でのみ有効で、オブジェクトからプロパティを削除し、グローバルオブジェクトのプロパティに対しても削除します。</p>
 
-<p><code>delete</code> を用いて暗黙的に宣言された変数を削除できますが、<code>var</code> 文で宣言された変数は削除できません。</p>
+<p><code>delete</code> 演算子が成功すると、オブジェクトからそのプロパティが削除されます。その後、このプロパティにアクセスしようとしても、結果は <code>undefined</code> になります。 <code>delete</code> 演算子は、操作が可能な場合は <code>true</code> を返し、操作が不可能な場合は <code>false</code> を返します。</p>
 
-<p><code>delete</code> 演算が成功すると、そのプロパティや要素には <code>undefined</code> がセットされます。また、演算が可能だった場合に <code>delete</code> 演算子は <code>true</code> を返します。演算が不可能である場合は <code>false</code> を返します。</p>
-
-<pre class="brush: js notranslate">x = 42; // 暗黙のうちに window.x を作成
+<pre class="brush: js">x = 42; // 暗黙のうちに window.x を作成
 var y = 43;
 var myobj = {h: 4}; // プロパティ h を持つオブジェクトを作成
 
@@ -622,23 +618,24 @@ delete Math.PI; // false を返す (定義済みプロパティは削除不可�
 delete myobj.h; // true を返す (ユーザー定義プロパティは削除可能)
 </pre>
 
-<h5 id="Deleting_array_elements" name="Deleting_array_elements">配列要素の削除</h5>
+<h5 id="Deleting_array_elements">配列要素の削除</h5>
 
-<p>配列は単なるオブジェクトの集まりであるため、技術的には各要素を削除することが可能です。しかしそれは悪しき慣例とみなされており、使用しないでください。配列の要素を削除したとき、配列の長さは影響を受けず、他の要素は再インデックスされません。この振る舞いを達成するのであれば、単に要素を <code>undefined</code> で上書きするほうがはるかに良い方法です。実際に配列を操作するためには、<code><a href="https://wiki.developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Array/splice">splice</a></code> のようなさまざまな配列のメソッドを使用してください。</p>
+<p>配列は単なるオブジェクトの集まりであるため、技術的には各要素を <code>delete</code> することが可能です。しかしそれは悪しき慣例とみなされており、使用しないでください。配列の要素を削除しても、配列の length は影響を受けず、他の要素の添字も付けなおされません。このようなことをするのであれば、単に要素を <code>undefined</code> で上書きするほうがはるかに良い方法です。実際に配列を操作するためには、 <code><a href="/ja/docs/Web/JavaScript/Reference/Global_Objects/Array/splice">splice</a></code> のようなさまざまな配列のメソッドを使用してください。
+</p>
 
-<h4 id="typeof" name="typeof"><code>typeof</code></h4>
+<h4 id="typeof"><code>typeof</code></h4>
 
-<p><a href="https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Operators/typeof"><code>typeof</code> 演算子</a>は次の方法のうち、どちらかの方法で使用します。</p>
+<p><a href="/ja/docs/Web/JavaScript/Reference/Operators/typeof"><code>typeof</code> 演算子</a>は次の方法のうち、どちらかの方法で使用します。</p>
 
-<pre class="syntaxbox notranslate">typeof 被演算子
-typeof (被演算子)
+<pre class="brush: js">typeof オペランド
+typeof (オペランド)
 </pre>
 
-<p><code>typeof</code> 演算子は、未評価の被演算子の型を指す文字列を返します。<code>被演算子</code>には返される型を調べる対象となる文字列、キーワード、オブジェクトを指定します。括弧はあってもなくてもかまいません。</p>
+<p><code>typeof</code> 演算子は、未評価のオペランドの型を指す文字列を返します。<code>オペランド</code>には返される型を調べる対象となる文字列、キーワード、オブジェクトを指定します。括弧はあってもなくてもかまいません。</p>
 
 <p>以下の変数を定義することにしましょう。</p>
 
-<pre class="brush: js notranslate">var myFun = new Function('5 + 2');
+<pre class="brush: js">var myFun = new Function('5 + 2');
 var shape = 'round';
 var size = 1;
 var foo = ['Apple', 'Mango', 'Orange'];
@@ -647,7 +644,7 @@ var today = new Date();
 
 <p><code>typeof</code> 演算子は、変数の型に応じて以下の値を返します。</p>
 
-<pre class="brush: js notranslate">typeof myFun;       // "function" を返す
+<pre class="brush: js">typeof myFun;       // "function" を返す
 typeof shape;       // "string" を返す
 typeof size;        // "number" を返す
 typeof foo;         // "object" を返す
@@ -657,66 +654,66 @@ typeof doesntExist; // "undefined" を返す
 
 <p><code>true</code> や <code>null</code> というキーワードに対して、<code>typeof</code> 演算子は以下の結果を返します。</p>
 
-<pre class="brush: js notranslate">typeof true; // "boolean" を返す
+<pre class="brush: js">typeof true; // "boolean" を返す
 typeof null; // "object" を返す
 </pre>
 
-<p>数値や文字列に対して、<code>typeof</code> 演算子は以下の結果を返します。</p>
+<p>数値や文字列に対して、 <code>typeof</code> 演算子は以下の結果を返します。</p>
 
-<pre class="brush: js notranslate">typeof 62;            // "number" を返す
+<pre class="brush: js">typeof 62;            // "number" を返す
 typeof 'Hello world'; // "string" を返す
 </pre>
 
-<p>プロパティ値に対して、<code>typeof</code> 演算子はプロパティが持つ値の型を返します。</p>
+<p>プロパティ値に対して、 <code>typeof</code> 演算子はプロパティが持つ値の型を返します。</p>
 
-<pre class="brush: js notranslate">typeof document.lastModified; // "string" を返す
+<pre class="brush: js">typeof document.lastModified; // "string" を返す
 typeof window.length;         // "number" を返す
 typeof Math.LN2;              // "number" を返す
 </pre>
 
-<p>メソッドや関数に対して、<code>typeof</code> 演算子は以下の結果を返します。</p>
+<p>メソッドや関数に対して、 <code>typeof</code> 演算子は以下の結果を返します。</p>
 
-<pre class="brush: js notranslate">typeof blur;        // "function" を返す
+<pre class="brush: js">typeof blur;        // "function" を返す
 typeof eval;        // "function" を返す
 typeof parseInt;    // "function" を返す
 typeof shape.split; // "function" を返す
 </pre>
 
-<p>定義済みオブジェクトに対して、<code>typeof</code> 演算子は以下の結果を返します。</p>
+<p>定義済みオブジェクトに対して、 <code>typeof</code> 演算子は以下の結果を返します。</p>
 
-<pre class="brush: js notranslate">typeof Date;     // "function" を返す
+<pre class="brush: js">typeof Date;     // "function" を返す
 typeof Function; // "function" を返す
 typeof Math;     // "object" を返す
 typeof Option;   // "function" を返す
 typeof String;   // "function" を返す
 </pre>
 
-<h4 id="void" name="void"><code>void</code></h4>
+<h4 id="void"><code>void</code></h4>
 
 <p><a href="/ja/docs/Web/JavaScript/Reference/Operators/void"><code>void</code> 演算子</a>は以下のどちらかの方法で使用します。</p>
 
-<pre class="syntaxbox notranslate">void (式)
+<pre class="brush: js">void (式)
 void 式
 </pre>
 
 <p><code>void</code> 演算子は、値を返さずに評価する式を指定します。<code>式</code>は評価する JavaScript の式となります。式の周りの括弧はあってもなくてもかまいませんが、使用する方が見た目がよいです。</p>
 
-<h3 id="Relational_operators" name="Relational_operators">関係演算子</h3>
+<h3 id="Relational_operators">関係演算子</h3>
 
-<p>関係演算子は被演算子を比較し、比較結果が真かどうかに基づいて <code>Boolean</code> の値を返します。</p>
+<p>関係演算子はオペランドを比較し、比較結果が真かどうかに基づいて論理値を返します。</p>
 
-<h4 id="in" name="in"><code>in</code></h4>
+<h4 id="in"><code>in</code></h4>
 
 <p><a href="/ja/docs/Web/JavaScript/Reference/Operators/in"><code>in</code> 演算子</a>は、指定したプロパティが指定のオブジェクトにある場合に <code>true</code> を返します。構文は以下のとおりです。</p>
 
-<pre class="syntaxbox notranslate">プロパティ名または数値 in オブジェクト名
+<pre class="brush: js">プロパティ名または数値 in オブジェクト名
 </pre>
 
 <p>ここで <code>プロパティ名または数値</code>はプロパティ名または配列のインデックスを表す文字列、数値または記号式を、<code>オブジェクト名</code>はオブジェクトの名前をそれぞれ表します。</p>
 
 <p>次の例で <code>in</code> 演算子の使用法を示します。</p>
 
-<pre class="brush:js notranslate">// 配列
+<pre class="brush:js">// 配列
 var trees = ['redwood', 'bay', 'cedar', 'oak', 'maple'];
 0 in trees;        // true を返す
 3 in trees;        // true を返す
@@ -736,166 +733,168 @@ var mycar = { make: 'Honda', model: 'Accord', year: 1998 };
 'model' in mycar; // returns true
 </pre>
 
-<h4 id="instanceof" name="instanceof"><code>instanceof</code></h4>
+<h4 id="instanceof"><code>instanceof</code></h4>
 
 <p><a href="/ja/docs/Web/JavaScript/Reference/Operators/instanceof"><code>instanceof</code> 演算子</a>は、指定されたオブジェクトが指定されたオブジェクトの種類である場合に <code>true</code> を返します。構文は以下のとおりです。</p>
 
-<pre class="syntaxbox notranslate">オブジェクト名 instanceof オブジェクト型
+<pre class="brush: js">オブジェクト名 instanceof オブジェクト型
 </pre>
 
-<p>ここで<code>オブジェクト名</code>は<code>オブジェクト型</code>と比較するオブジェクトの名前を、<code>オブジェクト型</code>は {{jsxref("Date")}} や {{jsxref("Array")}} のようなオブジェクトの種類をそれぞれ表します。</p>
+<p>ここで<code>オブジェクト名</code>は<code>オブジェクト型</code>と比較するオブジェクトの名前を、<code>オブジェクト型</code>は {{jsxref("Date")}} や {{jsxref("Array")}} のようなオブジェクトの型をそれぞれ表します。</p>
 
-<p>実行時にオブジェクトの種類を確認する必要があるときは <code>instanceof</code> を使用してください。例えば例外を受け取るとき、発生した例外の種類に応じて、別々の例外を扱うコードに分岐することができます。</p>
+<p>実行時にオブジェクトの型を確認する必要があるときは <code>instanceof</code> を使用してください。例えば例外を受け取るとき、発生した例外の型に応じて、別々の例外を扱うコードに分岐することができます。</p>
 
 <p>例えば次のコードでは、<code>instanceof</code> を使用して <code>theDay</code> が <code>Date</code> オブジェクトであるかを判断しています。<code>theDay</code> は <code>Date</code> オブジェクトであるため、<code>if</code> 文中の文が実行されます。</p>
 
-<pre class="brush: js notranslate">var theDay = new Date(1995, 12, 17);
+<pre class="brush: js">var theDay = new Date(1995, 12, 17);
 if (theDay instanceof Date) {
   // 実行する文
 }
 </pre>
 
-<h3 id="Operator_precedence" name="Operator_precedence">演算子の優先順位</h3>
+<h3 id="Operator_precedence">演算子の優先順位</h3>
 
 <p>演算子の<em>優先順位</em>によって、式評価の際に演算子が適用される順番が定義されています。括弧を用いることで演算子の優先順位を上書きすることができます。</p>
 
 <p>次の表では演算子の優先順位を、高いものから低い順に並べています。</p>
 
 <table class="standard-table">
- <caption>演算子の優先順位</caption>
- <thead>
-  <tr>
-   <th scope="col">演算子の種類</th>
-   <th scope="col">対応する演算子</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>メンバー</td>
-   <td><code>. []</code></td>
-  </tr>
-  <tr>
-   <td>インスタンスの呼び出し/作成</td>
-   <td><code>() new</code></td>
-  </tr>
-  <tr>
-   <td>否定/インクリメント</td>
-   <td><code>! ~ - + ++ -- typeof void delete</code></td>
-  </tr>
-  <tr>
-   <td>乗算/除算</td>
-   <td><code>* / %</code></td>
-  </tr>
-  <tr>
-   <td>加算/減算</td>
-   <td><code>+ -</code></td>
-  </tr>
-  <tr>
-   <td>ビットシフト</td>
-   <td><code>&lt;&lt; &gt;&gt; &gt;&gt;&gt;</code></td>
-  </tr>
-  <tr>
-   <td>関係</td>
-   <td><code>&lt; &lt;= &gt; &gt;= in instanceof</code></td>
-  </tr>
-  <tr>
-   <td>等値</td>
-   <td><code>== != === !==</code></td>
-  </tr>
-  <tr>
-   <td>ビット論理積</td>
-   <td><code>&amp;</code></td>
-  </tr>
-  <tr>
-   <td>ビット排他的論理和</td>
-   <td><code>^</code></td>
-  </tr>
-  <tr>
-   <td>ビット論理和</td>
-   <td><code>|</code></td>
-  </tr>
-  <tr>
-   <td>論理積</td>
-   <td><code>&amp;&amp;</code></td>
-  </tr>
-  <tr>
-   <td>論理和</td>
-   <td><code>||</code></td>
-  </tr>
-  <tr>
-   <td>条件</td>
-   <td><code>?:</code></td>
-  </tr>
-  <tr>
-   <td>代入</td>
-   <td><code>= += -= *= /= %= &lt;&lt;= &gt;&gt;= &gt;&gt;&gt;= &amp;= ^= |= &amp;&amp;= ||= ??= </code></td>
-  </tr>
-  <tr>
-   <td>カンマ</td>
-   <td><code>,</code></td>
-  </tr>
- </tbody>
+  <caption>演算子の優先順位</caption>
+  <thead>
+    <tr>
+      <th scope="col">演算子の種類</th>
+      <th scope="col">対応する演算子</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>メンバー</td>
+      <td><code>. []</code></td>
+    </tr>
+    <tr>
+      <td>呼び出し/インスタンスの作成</td>
+      <td><code>() new</code></td>
+    </tr>
+    <tr>
+      <td>否定/インクリメント</td>
+      <td><code>! ~ - + ++ -- typeof void delete</code></td>
+    </tr>
+    <tr>
+      <td>乗算/除算</td>
+      <td><code>* / %</code></td>
+    </tr>
+    <tr>
+      <td>加算/減算</td>
+      <td><code>+ -</code></td>
+    </tr>
+    <tr>
+      <td>ビットシフト</td>
+      <td><code>&lt;&lt; &gt;&gt; &gt;&gt;&gt;</code></td>
+    </tr>
+    <tr>
+      <td>関係</td>
+      <td><code>&lt; &lt;= &gt; &gt;= in instanceof</code></td>
+    </tr>
+    <tr>
+      <td>等値</td>
+      <td><code>== != === !==</code></td>
+    </tr>
+    <tr>
+      <td>ビット論理積</td>
+      <td><code>&amp;</code></td>
+    </tr>
+    <tr>
+      <td>ビット排他的論理和</td>
+      <td><code>^</code></td>
+    </tr>
+    <tr>
+      <td>ビット論理和</td>
+      <td><code>|</code></td>
+    </tr>
+    <tr>
+      <td>論理積</td>
+      <td><code>&amp;&amp;</code></td>
+    </tr>
+    <tr>
+      <td>論理和</td>
+      <td><code>||</code></td>
+    </tr>
+    <tr>
+      <td>条件</td>
+      <td><code>?:</code></td>
+    </tr>
+    <tr>
+      <td>代入</td>
+      <td>
+        <code>= += -= *= /= %= &lt;&lt;= &gt;&gt;= &gt;&gt;&gt;= &amp;= ^= |= &amp;&amp;= ||= ??= </code>
+      </td>
+    </tr>
+    <tr>
+      <td>カンマ</td>
+      <td><code>,</code></td>
+    </tr>
+  </tbody>
 </table>
 
-<p>それぞれの演算子についてのリンクを含むこの表の詳細版に関しては <a href="/ja/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#Table">JavaScript リファレンス</a>を参照してください。</p>
+<p>それぞれの演算子についてのリンクを含むこの表の詳細版に関しては <a href="/ja/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#table">JavaScript リファレンス</a>を参照してください。</p>
 
-<h2 id="Expressions" name="Expressions">式</h2>
+<h2 id="Expressions">式</h2>
 
-<p><em>式</em>とは、ある値へと決定される有効なコードの単位のことです。</p>
+<p><em>式</em>とは、ある値へと決定されるあらゆる有効なコードの単位のことです。</p>
 
-<p>文法的に正しい式は必ず何らかの値に決定されますが、概念的に、副作用の有無によって 2種類にわけられます。代入演算は副作用のあるものの代表です。副作用の無いものは、式そのものが評価されその値が決定されます。</p>
+<p>構文的に有効な式は、すべて何らかの値に解決しますが、概念的には、副作用のある式 (例えば、変数に値を代入する式) と、ある意味で評価して値に解決する式の 2 種類があります。</p>
 
 <p><code>x = 7</code> という式が前者の例です。この式では <code>x</code> に 7 という値を代入するのに = <em>演算子</em>を使っています。この式自体は 7 と評価されます。</p>
 
-<p><code>3 + 4</code> という式は後者の例です。この式では 3 と 4 を加算するのに + 演算子を使っており、計算結果の 7 を変数に代入していません。<br>
- <br>
- JavaScript には、以下の種類の式があります。</p>
+<p><code>3 + 4</code> という式は後者の例です。この式では 3 と 4 を加算するのに + 演算子を使っており、計算結果の 7 を変数に代入していません。</p>
+
+<p>JavaScript には、以下の種類の式があります。</p>
 
 <ul>
- <li>算術式 : 評価結果は数値になります。例えば 3.14159 など。（一般に<a href="https://developer.mozilla.org/ja/docs/Web/JavaScript/Guide/Expressions_and_Operators#Arithmetic_operators">算術演算子</a>を使用します）</li>
- <li>文字列式 : 評価結果は文字列になります。例えば "Fred" や "234" など。（一般に<a href="https://developer.mozilla.org/ja/docs/Web/JavaScript/Guide/Expressions_and_Operators#String_operators">文字列演算子</a>を使用します）</li>
- <li>論理式 : 評価結果は true または false になります。（よく<a href="https://developer.mozilla.org/ja/docs/Web/JavaScript/Guide/Expressions_and_Operators#Logical_operators">論理演算子</a>を用います）</li>
+ <li>算術式 : 評価結果は数値になります。例えば 3.14159 など。 (一般に<a href="#arithmetic_operators">算術演算子</a>を使用します。)</li>
+ <li>文字列式 : 評価結果は文字列になります。例えば "Fred" や "234" など。 (一般に<a href="#string_operators">文字列演算子</a>を使用します。)</li>
+ <li>論理式 : 評価結果は true または false になります。 (よく<a href="#logical_operators">論理演算子</a>を用います)</li>
  <li>基本式 : JavaScript にある基本のキーワードと一般的な式です。</li>
  <li>左辺式 : 代入先になるような式です。</li>
 </ul>
 
-<h3 id="Primary_expressions" name="Primary_expressions">基本式</h3>
+<h3 id="Primary_expressions">基本式</h3>
 
 <p>JavaScript における基本のキーワードと一般的な式です。</p>
 
-<h4 id="this" name="this"><code>this</code></h4>
+<h4 id="this"><code>this</code></h4>
 
-<p><a href="https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Operators/this"><code>this</code> キーワード</a>を使用することで現在のオブジェクトを参照できます。一般的に <code>this</code> は、あるメソッド内で呼び出されるオブジェクトを参照します。<code>this</code> の使用法は以下のとおりです。</p>
+<p><a href="/ja/docs/Web/JavaScript/Reference/Operators/this"><code>this</code> キーワード</a>を使用することで、現在のオブジェクトを参照できます。一般的に <code>this</code> は、メソッド内の呼び出しオブジェクトを指します。 <code>this</code> は、ドット表記またはブラケット表記で使用します。</p>
 
-<pre class="syntaxbox notranslate">this['propertyName']
+<pre class="brush: js">this['propertyName']
 this.propertyName
 </pre>
 
-<p>オブジェクトと上限および下限の値を渡し、そのオブジェクトの <code>value</code> プロパティを検証する <code>validate</code> という関数があるとしましょう。</p>
+<p><code>validate</code> という関数があり、オブジェクトと上限と下限の値を渡すことでオブジェクトの <code>value</code> プロパティを検証するものであるとしましょう。</p>
 
-<pre class="brush: js notranslate">function validate(obj, lowval, hival) {
+<pre class="brush: js">function validate(obj, lowval, hival) {
   if ((obj.value &lt; lowval) || (obj.value &gt; hival))
     console.log('Invalid Value!');
 }
 </pre>
 
-<p>次の例のように、各フォーム要素の <code>onChange</code> イベントハンドラにおいて <code>validate</code> を呼び出し、その関数にフォーム要素を渡すのに <code>this</code> を使うことができます。</p>
+<p>次の例のように、各フォーム要素の <code>onChange</code> イベントハンドラーにおいて <code>validate</code> を呼び出し、その関数にフォーム要素を渡すのに <code>this</code> を使うことができます。</p>
 
-<pre class="brush: html notranslate">&lt;p&gt;Enter a number between 18 and 99:&lt;/p&gt;
+<pre class="brush: html">&lt;p&gt;Enter a number between 18 and 99:&lt;/p&gt;
 &lt;input type="text" name="age" size=3 onChange="validate(this, 18, 99);"&gt;
 </pre>
 
-<h4 id="Grouping_operator" name="Grouping_operator">グループ化演算子</h4>
+<h4 id="Grouping_operator">グループ化演算子</h4>
 
 <p>グループ化演算子 <code>( )</code> は式内での評価の優先順位を制御します。例えば、加算が最初に評価されるよう、最初に行われる演算を乗算と除算から加算と減算へと上書きすることができます。</p>
 
-<pre class="brush:js notranslate">var a = 1;
+<pre class="brush:js">var a = 1;
 var b = 2;
 var c = 3;
 
-// デフォルトの優先順位
+// 既定の優先順位
 a + b * c     // 7
-// デフォルトではこのように評価される
+// 既定ではこのように評価される
 a + (b * c)   // 7
 
 // 優先順位を上書きし、
@@ -906,23 +905,24 @@ a + (b * c)   // 7
 a * c + b * c // 9
 </pre>
 
-<h3 id="Left-hand-side_expressions" name="Left-hand-side_expressions">左辺式</h3>
+<h3 id="Left-hand-side_expressions">左辺式</h3>
 
 <p>左辺値は、代入する宛先です。</p>
 
-<h4 id="new" name="new"><code>new</code></h4>
+<h4 id="new"><code>new</code></h4>
 
-<p><a href="/ja/docs/Web/JavaScript/Reference/Operators/new"><code>new</code> 演算子</a>は、ユーザー定義オブジェクトやビルトインオブジェクトのインスタンス作成に使用します。<code>new</code> の使用法は以下のとおりです。</p>
+<p><a href="/ja/docs/Web/JavaScript/Reference/Operators/new"><code>new</code> 演算子</a>を使用すると、いずれかのユーザー定義オブジェクト型や組み込みオブジェクト型のインスタンスを生成することができます。 <code>new</code> の使用法は以下のとおりです。</p>
 
-<pre class="brush: js notranslate">var オブジェクト名 = new objectType([引数1, 引数2, ..., 引数N]);
+<pre class="brush: js">var オブジェクト名 = new objectType([引数1, 引数2, ..., 引数N]);
 </pre>
 
-<h4 id="super" name="super">super</h4>
+<h4 id="super">super</h4>
 
 <p><a href="/ja/docs/Web/JavaScript/Reference/Operators/super">super キーワード</a>は自分の親のオブジェクトに関数を呼び出すのに使います。これは下の例のように、<a href="/ja/docs/Web/JavaScript/Reference/Classes">クラス</a>と共に使って親のコンストラクタを呼び出すのに便利です。</p>
 
-<pre class="syntaxbox notranslate">super([引数]); // 親のコンストラクタを呼び出す。
+<pre class="brush: js">super([引数]); // 親のコンストラクターを呼び出す。
 super.親の関数([引数]);
 </pre>
 
-<div>{{PreviousNext("Web/JavaScript/Guide/Functions", "Web/JavaScript/Guide/Numbers_and_dates")}}</div>
+<div>{{PreviousNext("Web/JavaScript/Guide/Functions",
+  "Web/JavaScript/Guide/Numbers_and_dates")}}</div>


### PR DESCRIPTION
- 2021/04/28 時点の英語版に同期
- 原語併記マクロを削除 (https://github.com/mozilla-japan/translation/issues/547)