### PR TITLE
I found a spelling error.

### DIFF
--- a/files/ja/learn/javascript/objects/object-oriented_js/index.html
+++ b/files/ja/learn/javascript/objects/object-oriented_js/index.html
@@ -76,7 +76,7 @@ translation_of: Learn/JavaScript/Objects/Object-oriented_JS
 
 <p>JavaScript では、オブジェクトやその機能を定義し初期化するために<strong>コンストラクター関数</strong>と呼ばれる特殊な関数を使用します。これは便利です。なぜならオブジェクトをいくつ作成することになるか分からない状況に出くわすでしょうから。コンストラクターは必要な数のオブジェクトを効率的な方法で作成し、必要に応じてデータや関数を付加する手段を提供します。</p>
 
-<p>JavaScript でコンストラクターを通じてクラスを作り、そこからオブジェクトのインスタンスを生成するところを見ていきましょう。まずは、最初のオブジェクトの記事で見た <a href="https://github.com/mdn/learning-area/blob/master/javascript/oojs/introduction/oojs.html">oojs.html</a> ファイルの新しいコピーを、ローカルに作成したおいてください。</p>
+<p>JavaScript でコンストラクターを通じてクラスを作り、そこからオブジェクトのインスタンスを生成するところを見ていきましょう。まずは、最初のオブジェクトの記事で見た <a href="https://github.com/mdn/learning-area/blob/master/javascript/oojs/introduction/oojs.html">oojs.html</a> ファイルの新しいコピーを、ローカルに作成しておいてください。</p>
 
 <h3 id="A_simple_example" name="A_simple_example">シンプルな例</h3>
 


### PR DESCRIPTION
Thanks for the great article.
I have found one spelling mistake in this article.

In this context, it seems like "て" is more appropriate than "た".