### PR TITLE
[ko] translate react_getting_started title

### DIFF
--- a/files/ko/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.html
+++ b/files/ko/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.html
@@ -1,5 +1,5 @@
 ---
-title: Getting started with React
+title: React 시작하기
 slug: >-
   Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_getting_started
 tags:


### PR DESCRIPTION
`/ko/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_getting_started` 문서의 Title에 대해서 한국어 번역을 하였습니다.