### PR TITLE
[Fix] delete dir="rtl"

### DIFF
--- a/files/ja/web/javascript/reference/operators/this/index.html
+++ b/files/ja/web/javascript/reference/operators/this/index.html
@@ -135,7 +135,7 @@ new Bad(); // 参照エラー</pre>
 
 <h3 id="関数コンテキスト内の_this">関数コンテキスト内の this</h3>
 
-<pre class="brush:js notranslate" dir="rtl">// オブジェクトを call や apply の最初の引数として渡すと、this がそれに結び付けられます
+<pre class="brush:js notranslate">// オブジェクトを call や apply の最初の引数として渡すと、this がそれに結び付けられます
 var obj = {a: 'Custom'};
 
 // このプロパティはグローバルオブジェクトに設定されます


### PR DESCRIPTION
dir="rtl"により、コード例のスタイルが崩れていると思います。