### PR TITLE
fix typo

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/promise/then/index.html
+++ b/files/ja/web/javascript/reference/global_objects/promise/then/index.html
@@ -161,7 +161,7 @@ p2.then(function(value) {
 });
 </pre>
 
-<p><code>then</code> の引数として渡した関数が拒絶された Promise が返した場合や、例外 (エラー) が発生した場合は、拒絶された Promise を返します。</p>
+<p><code>then</code> の引数として渡した関数が拒絶された Promise を返した場合や、例外 (エラー) が発生した場合は、拒絶された Promise を返します。</p>
 
 <pre class="brush: js notranslate">Promise.resolve()
   .then(() =&gt; {


### PR DESCRIPTION
Fixed a typo in "Promise が返した場合や", changing to "Promise を返した場合や".