### PR TITLE
fix: typo in history api (lang:ja)

### DIFF
--- a/files/ja/web/api/history_api/index.html
+++ b/files/ja/web/api/history_api/index.html
@@ -12,7 +12,7 @@ translation_of: Web/API/History_API
 ---
 <div>{{DefaultAPISidebar("History API")}}</div>
 
-<p>DOM の {{DOMxRef("Window")}} オブジェクトは、ブラウザーのセッション履歴 (<a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/history">WebExtensions history</a> と混同しないように) へのアクセスを {{DOMxRef("Window.history","history")}} オブジェクトを介して提供しています。このオブジェクトは、ユーザーの履歴の中を前のページや後のページへ移動したり、履歴スタックの中を称さしたりするのに便利なメソッドやプロパティが提供されています。</p>
+<p>DOM の {{DOMxRef("Window")}} オブジェクトは、ブラウザーのセッション履歴 (<a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/API/history">WebExtensions history</a> と混同しないように) へのアクセスを {{DOMxRef("Window.history","history")}} オブジェクトを介して提供しています。このオブジェクトは、ユーザーの履歴の中を前のページや後のページへ移動したり、履歴スタックの中を操作したりするのに便利なメソッドやプロパティが提供されています。</p>
 
 <h2 id="Concepts_and_usage" name="Concepts_and_usage">概念と使用方法</h2>
 


### PR DESCRIPTION
- Fix typo in https://developer.mozilla.org/ja/docs/Web/API/History_API
- 称さ → 操作 (原文 : manipulate)