### PR TITLE
Mozilla/Firefox/Releases/42 の更新

### DIFF
--- a/files/ja/mozilla/firefox/releases/42/index.html
+++ b/files/ja/mozilla/firefox/releases/42/index.html
@@ -2,28 +2,33 @@
 title: Firefox 42 for developers
 slug: Mozilla/Firefox/Releases/42
 tags:
+  - '42'
   - Firefox
+  - Mozilla
   - Release
   - Release Notes
 translation_of: Mozilla/Firefox/Releases/42
 ---
-<p>Firefox 42 は、米国時間 2015 年 11 月 3 日にリリースされました。このページでは、開発者に影響する Firefox 42 の変更点をまとめています。</p>
+<div>{{FirefoxSidebar}}</div>
 
-<h2 id="Changes_for_Web_developers" name="Changes_for_Web_developers">Web 開発者向けの変更点一覧</h2>
+<div class="column-container zone-callout"><a href="https://www.mozilla.org/firefox/developer/" style="float: right; margin-bottom: 20px; padding: 10px; text-align: center; border-radius: 4px; display: inline-block; background-color: #81BC2E; white-space: nowrap; color: white; text-shadow: 0px 1px 0px rgba(0, 0, 0, 0.25); box-shadow: 0px 1px 0px 0px rgba(0, 0, 0, 0.2), 0px -1px 0px 0px rgba(0, 0, 0, 0.3) inset;">Firefox の最新の開発者向け機能をテストするには、<br>
+Firefox Developer Edition をインストールしてください</a> Firefox 42 は、米国時間 2015 年 11 月 3 日にリリースされました。この記事では、ウェブ開発者だけでなく、 Firefox や Gecko の開発者やアドオン開発者にとっても有益な主な変更点を紹介します。</div>
 
-<h3 id="Developer_Tools" name="Developer_Tools">開発者ツール</h3>
+<h2 id="Changes_for_Web_developers">ウェブ開発者向けの変更点一覧</h2>
+
+<h3 id="Developer_Tools">開発者ツール</h3>
 
 <p>ハイライト:</p>
 
 <ul>
  <li><a href="/ja/docs/Tools/Remote_Debugging/Debugging_Firefox_for_Android_over_Wifi">Wi-Fi 経由で Android 版 Firefox のデバッグを行う</a></li>
- <li><a href="/ja/docs/Tools/WebIDE/Setting_up_runtimes#Configuring_Simulators">WebIDE で Firefox OS シミュレータの設定を行う</a></li>
- <li><a href="/ja/docs/Tools/Page_Inspector/How_to/Edit_CSS_filters#Saving_filter_presets">CSS filter のプリセット</a></li>
+ <li><a href="/ja/docs/Tools/WebIDE/Setting_up_runtimes#Configuring_Simulators">WebIDE で Firefox OS シミュレーターの設定を行う</a></li>
+ <li><a href="/ja/docs/Tools/Page_Inspector/How_to/Edit_CSS_filters#saving_filter_presets">CSS filter のプリセット</a></li>
 </ul>
 
 <p><a class="external external-icon" href="https://bugzilla.mozilla.org/buglist.cgi?resolution=FIXED&amp;classification=Client%20Software&amp;chfieldto=2015-08-10&amp;query_format=advanced&amp;chfield=resolution&amp;chfieldfrom=2015-06-29&amp;chfieldvalue=FIXED&amp;bug_status=RESOLVED&amp;bug_status=VERIFIED&amp;component=Developer%20Tools&amp;component=Developer%20Tools%3A%203D%20View&amp;component=Developer%20Tools%3A%20Canvas%20Debugger&amp;component=Developer%20Tools%3A%20Console&amp;component=Developer%20Tools%3A%20Debugger&amp;component=Developer%20Tools%3A%20Framework&amp;component=Developer%20Tools%3A%20Graphic%20Commandline%20and%20Toolbar&amp;component=Developer%20Tools%3A%20Inspector&amp;component=Developer%20Tools%3A%20Memory&amp;component=Developer%20Tools%3A%20Netmonitor&amp;component=Developer%20Tools%3A%20Object%20Inspector&amp;component=Developer%20Tools%3A%20Performance%20Tools%20%28Profiler%2FTimeline%29&amp;component=Developer%20Tools%3A%20Responsive%20Mode&amp;component=Developer%20Tools%3A%20Scratchpad&amp;component=Developer%20Tools%3A%20Source%20Editor&amp;component=Developer%20Tools%3A%20Storage%20Inspector&amp;component=Developer%20Tools%3A%20Style%20Editor&amp;component=Developer%20Tools%3A%20User%20Stories&amp;component=Developer%20Tools%3A%20Web%20Audio%20Editor&amp;component=Developer%20Tools%3A%20WebGL%20Shader%20Editor&amp;component=Developer%20Tools%3A%20WebIDE&amp;product=Firefox&amp;list_id=12478437">Firefox 41 から Firefox 42 の間に解決した開発ツール関連のバグ一覧</a>。</p>
 
-<h3 id="CSS" name="CSS">CSS</h3>
+<h3 id="CSS">CSS</h3>
 
 <ul>
  <li>rtl 表記の文字で、{{cssxref('writing-mode')}} の縦書きをサポートしました ({{bug(1131451)}})。</li>
@@ -33,28 +38,28 @@ translation_of: Mozilla/Firefox/Releases/42
  <li>{{cssxref("float")}} とマージンの相殺の動作に関する古くからのバグを、いくつか修正しました ({{bug(478834)}}, {{bug(538194)}}, and {{bug(451791)}})。</li>
 </ul>
 
-<h3 id="HTML" name="HTML">HTML</h3>
+<h3 id="HTML">HTML</h3>
 
 <ul>
  <li>{{HTMLElement("img")}} ({{bug(1166910)}})、{{htmlElement("iframe")}} ({{bug(1175736)}})、{{HTMLElement("a")}} および {{HTMLElement("area")}} ({{bug(1174913)}}) 要素の {{htmlattrxref("referrer", "input")}} 属性を実験的にサポートしました。<code>network.http.enablePerElementReferrer</code> の既定値が <code>false</code> であるため、デフォルトでは効力がありません。</li>
 </ul>
 
-<h3 id="JavaScript" name="JavaScript">JavaScript</h3>
+<h3 id="JavaScript">JavaScript</h3>
 
 <ul>
  <li>{{jsxref("Reflect")}} オブジェクトを実装しました ({{bug(987514)}})。</li>
- <li>{{jsxref("Proxy")}} {{jsxref("Global_Objects/Proxy/handler/ownKeys", "handler.ownKeys()")}} トラップの実装を、ES2015 の確定仕様に準拠するよう更新しました ({{bug(1049662)}})。</li>
+ <li>{{jsxref("Proxy")}} {{jsxref("Global_Objects/Proxy/Proxy/ownKeys", "handler.ownKeys()")}} トラップの実装を、ES2015 の確定仕様に準拠するよう更新しました ({{bug(1049662)}})。</li>
  <li>{{jsxref('Operators', 'new')}} を伴わずに {{jsxref("Map")}}、{{jsxref("Set")}}、{{jsxref("WeakMap")}} を呼び出すと {{jsxref("TypeError")}} が発生するようになりました ({{bug(1083752)}})。</li>
 </ul>
 
-<h3 id="InterfacesAPIsDOM" name="InterfacesAPIsDOM">インターフェイス/API/DOM</h3>
+<h3 id="InterfacesAPIsDOM">インターフェイス/API/DOM</h3>
 
-<h4 id="DOM_HTML_DOM" name="DOM_HTML_DOM">DOM &amp; HTML DOM</h4>
+<h4 id="DOM_HTML_DOM">DOM &amp; HTML DOM</h4>
 
 <ul>
  <li>{{HTMLattrxref('id', 'img')}} を伴う画像が、{{domxref("Window")}} インターフェイスのプロパティのリストに入らないようになりました。<code>&lt;img id="login"&gt;</code> は <code>window.login</code> としてアクセスできません。この動作は Firefox 26 で導入しており、その後変更された仕様書に合致させるために削除しました ({{bug(959992)}})。</li>
  <li>{{domxref('MouseEvent.offsetX')}} および {{domxref('MouseEvent.offsetY')}} を追加しました ({{bug(69787)}})。</li>
- <li>{{domxref("HTMLInputElement")}} インターフェイスを、ディレクトリのアップロードを扱うよう実験的に拡張しました ({{bug(1164310)}})。以下 4 つのメンバーは、設定項目 <code>dom.input.dirpicker</code> を <code>true</code> に設定すると使用できます:
+ <li>{{domxref("HTMLInputElement")}} インターフェイスを、ディレクトリのアップロードを扱うよう実験的に拡張しました ({{bug(1164310)}})。以下 4 つのメンバーは、設定項目 <code>dom.input.dirpicker</code> を <code>true</code> に設定すると使用できます。
   <ul>
    <li>{{domxref("HTMLInputElement.directory")}}</li>
    <li>{{domxref("HTMLInputElement.isFilesAndDirectoriesSupported")}}</li>
@@ -66,16 +71,16 @@ translation_of: Mozilla/Firefox/Releases/42
  <li><code>HTMLMediaElement.mozSrcObject</code> を {{domxref('HTMLMediaElement.srcObject')}} に改名しました ({{bug(1175523)}})。</li>
 </ul>
 
-<h4 id="Service_Workers" name="Service_Workers">Service Worker</h4>
+<h4 id="Service_Workers">Service Worker</h4>
 
 <ul>
  <li>{{domxref('Request.context')}} を削除しました ({{bug(1188062)}})。</li>
- <li>デスクトップ版 Firefox で <a href="/ja/docs/Web/API/Push_API">Push API</a> をデフォルトで有効にしました ({{bug(1153499)}}) が、Nightly/Dev Edition/Beta チャンネルのみで有効です。コンシューマの UX およびデバッグ機能が適切に実装されるまで、Release チャンネルではデフォルトで無効化しています ({{bug(1207875)}})。なお、<a>about:config</a> の設定項目 <code>dom.push.enabled</code> で有効化できます。</li>
+ <li>デスクトップ版 Firefox で <a href="/ja/docs/Web/API/Push_API">Push API</a> をデフォルトで有効にしました ({{bug(1153499)}}) が、Nightly/Dev Edition/Beta チャンネルのみで有効です。コンシューマーの UX およびデバッグ機能が適切に実装されるまで、Release チャンネルではデフォルトで無効化しています ({{bug(1207875)}})。なお、<a>about:config</a> の設定項目 <code>dom.push.enabled</code> で有効化できます。</li>
  <li>{{domxref("PushManager.hasPermission()")}} メソッドが仕様書で非推奨になり、{{domxref("PushManager.permissionState()")}} メソッドに置き換えられました。Firefox でこれを反映するように、実装を更新しました ({{bug("1183853")}})。</li>
  <li><a href="/ja/docs/Web/API/Notifications_API">Notifications API</a> で、Service Worker に関する追加実装を行いました ({{bug(1114554)}})。ただし、Release 版では無効化しています。</li>
 </ul>
 
-<h4 id="Web_Animations_API" name="Web_Animations_API">Web Animations API</h4>
+<h4 id="Web_Animations_API">Web Animations API</h4>
 
 <p><a href="/ja/docs/Web/API/Web_Animations_API">Web Animations API</a> の実験的な実装で、サポート範囲が広がりました:</p>
 
@@ -86,9 +91,9 @@ translation_of: Mozilla/Firefox/Releases/42
  <li>{{domxref('AnimationPlaybackEvent')}} インターフェイスを実装して、{{domxref('Animation')}} で {{event('cancel')}} および {{event('finish')}} イベントが発生するようになりました ({{bug(1178664)}})。</li>
 </ul>
 
-<h4 id="Web_Components" name="Web_Components">Web Components</h4>
+<h4 id="Web_Components">Web Components</h4>
 
-<p><a href="/ja/docs/Web/Web_Components/Shadow_DOM">Shadow DOM</a> の実験的な実装を変更しました:</p>
+<p><a href="/ja/docs/Web/Web_Components/Shadow_DOM">Shadow DOM</a> の実験的な実装を変更しました。</p>
 
 <ul>
  <li>{{domxref('ShadowRoot')}} で {{domxref('Node.cloneNode()')}} を実行しようとすると、<code>DataCloneError</code> 例外が発生します ({{bug(1176757)}})。</li>
@@ -96,94 +101,95 @@ translation_of: Mozilla/Firefox/Releases/42
  <li>{{domxref('ShadowRoot')}} を引数として {{domxref('Document.adoptNode()')}} を実行すると、<code>HierarchyRequestError</code> 例外が発生します ({{bug(1177991)}})。</li>
 </ul>
 
-<h4 id="WebGL" name="WebGL">WebGL</h4>
+<h4 id="WebGL">WebGL</h4>
 
 <ul>
  <li>WebGL2 の {{domxref('WebGLTransformFeedback')}} を実装しました ({{bug(1048724)}})。</li>
- <li><code>WEBGL_debug_renderer_info</code> 拡張をデフォルトで有効にしました ({{bug(1171228)}})。</li>
  <li>WebGL2 のコンテキストを得るため、{{domxref('HTMLCanvasElement.getContext()')}} は以前の <code>experimental-webgl2</code> に代わり <code>webgl2</code> を使用するようになりました ({{bug(1187174)}})。</li>
 </ul>
 
-<h4 id="WebRTC" name="WebRTC">WebRTC</h4>
+<h4 id="WebRTC">WebRTC</h4>
 
 <ul>
+ <li>{{domxref("RTCPeerConnection.createOffer()")}} のオプションデータ型である {{domxref("RTCOfferOptions")}} が、より仕様に近くなるように更新されました。他の変更点としては、 {{domxref("RTCOfferAnswerOptions.voiceActivityDetection", "voiceActivityDetection")}} オプションを提供する {{domxref("RTCOfferAnswerOptions")}} 辞書をベースにしたことです。</li>
+ <li>{{domxref("RTCAnswerOptions")}} 辞書が追加されました。これは、 {{DOMxRef("RTCPeerConnection.createAnswer", "createAnswer()")}} の <code>options</code> 引数に使用される型です。</li>
  <li><code>RTCICECandidatePairStats.mozPriority</code> を {{domxref('RTCICECandidatePairStats.priority')}} に改名しました ({{bug(1184426)}})。</li>
 </ul>
 
-<h4 id="New_APIs" name="New_APIs">新規 API</h4>
+<h4 id="New_APIs">新規 API</h4>
 
 <ul>
  <li>{{domxref("ImageBitmap")}} インターフェイスおよび {{domxref("ImageBitmapFactories.createImageBitmap","createImageBitmap()")}} メソッドを実装しました。これらは通常の window スクリプトおよび Web workers で有効であり、window や worker のコンテキスト間で効率よく画像を渡すことができます ({{bug(1044102)}})。</li>
 </ul>
 
-<h4 id="Miscellaneous" name="Miscellaneous">その他</h4>
+<h4 id="Miscellaneous">その他</h4>
 
 <ul>
  <li>{{domxref('IDBCursorWithValue')}} インターフェイスが <a href="/ja/docs/Web/API/Web_Workers_API">Web workers</a> で使用可能になりました ({{bug(1188115)}})。</li>
- <li><a href="/ja/docs/Web/API/Web_Workers_API">Web workers</a> が発したエラーイベントが{{原語併記("伝播", "bubble")}}しないようになりました ({{bug(1188141)}})。</li>
+ <li><a href="/ja/docs/Web/API/Web_Workers_API">Web workers</a> が発したエラーイベントがバブリングしないようになりました ({{bug(1188141)}})。</li>
  <li><a href="/ja/docs/Web/API/Media_Source_Extensions_API">Media Source Extensions</a> (MSE) がホワイトリストに記載されたサイトだけでなく、すべての Web サイトで有効になりました ({{bug(1185611)}})。</li>
  <li>非標準かつ非推奨である {{domxref('Window.mozRequestAnimationFrame()')}} を削除しました ({{bug(909154)}})。代わりに、標準の {{domxref('Window.requestAnimationFrame()')}} を使用してください。</li>
  <li>音声合成 (text-to-speech) を Windows 向けのデスクトップ版 Firefox に実装しました。ただし、<code>about:config</code> の <code>media.webspeech.synth.enabled</code> フラグで無効化しています ({{bug("1003457")}})。詳しくは <a href="/ja/docs/Web/API/Web_Speech_API">Web Speech API</a> をご覧ください。</li>
 </ul>
 
-<h3 id="MathML" name="MathML">MathML</h3>
+<h3 id="MathML">MathML</h3>
 
 <p><em>変更なし。</em></p>
 
-<h3 id="SVG" name="SVG">SVG</h3>
+<h3 id="SVG">SVG</h3>
 
 <p><em>変更なし。</em></p>
 
-<h3 id="AudioVideo" name="AudioVideo">Audio/Video</h3>
+<h3 id="AudioVideo">Audio/Video</h3>
 
 <p><em>変更なし。</em></p>
 
-<h2 id="HTTP" name="HTTP">HTTP</h2>
+<h2 id="HTTP">HTTP</h2>
 
 <ul>
  <li>Firefox 41 まで、HTTP/2 レスポンスに含まれる未定義または無効な疑似ヘッダフィールドを、誤って受け入れていました。これが修正され、Firefox 42 より受け入れる疑似ヘッダフィールドは仕様書に従い <em>:status</em> のみになります。独自のフィールドを含むレスポンスヘッダは、異常なものであると判断します ({{bug(1136727)}})。</li>
 </ul>
 
-<h2 id="Networking" name="Networking">ネットワーク</h2>
+<h2 id="Networking">ネットワーク</h2>
 
 <ul>
- <li>CSP の <code><a href="/Web/Security/CSP/CSP_policy_directives#upgrade-insecure-requests">upgrade-insecure-requests</a></code> ディレクティブを実装しました ({{bug(1139297)}})。</li>
+ <li>CSP の <code><a href="/docs/docs/Web/HTTP/Headers/Content-Security-Policy#upgrade-insecure-requests">upgrade-insecure-requests</a></code> ディレクティブを実装しました ({{bug(1139297)}})。</li>
 </ul>
 
-<h2 id="Security" name="Security">セキュリティ</h2>
+<h2 id="Security">セキュリティ</h2>
 
 <ul>
  <li>有効期間が 39 か月を超える EV 証明書は、DV 証明書として判断および取り扱われるようになりました ({{bug(1145679)}})。</li>
 </ul>
 
-<h2 id="Changes_for_add-on_and_Mozilla_developers" name="Changes_for_add-on_and_Mozilla_developers">アドオン開発者と Mozilla 開発者向けの変更点</h2>
+<h2 id="Changes_for_add-on_and_Mozilla_developers">アドオン開発者と Mozilla 開発者向けの変更点</h2>
 
-<h3 id="Interfaces" name="Interfaces">インターフェイス</h3>
+<h3 id="Interfaces">インターフェイス</h3>
 
-<h4 id="nsIContentPolicy" name="nsIContentPolicy">nsIContentPolicy</h4>
+<h4 id="nsIContentPolicy">nsIContentPolicy</h4>
 
 <ul>
  <li>Gecko 内部やアドオンのコードがさまざまなタイプの要求をより区別できるようにするため、<code><strong>TYPE_EMBED</strong></code> 定数を <code><a href="/ja/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIContentPolicy" title="">nsIContentPolicy</a></code> に追加しました。以前はこのような場合に、<code><strong>TYPE_OBJECT</strong></code> を使用していました ({{bug(1148030)}})。</li>
  <li>同様に、<strong><code>TYPE_SUBDOCUMENT</code></strong> 定数を <code><strong>TYPE_FRAME</strong></code> および <strong><code>TYPE_IFRAME</code></strong> に分割しました ({{bug(1148044)}})。</li>
 </ul>
 
-<h3 id="XUL" name="XUL">XUL</h3>
+<h3 id="XUL">XUL</h3>
 
 <p><em>変更なし。</em></p>
 
-<h3 id="JavaScript_code_modules" name="JavaScript_code_modules">JavaScript コードモジュール</h3>
+<h3 id="JavaScript_code_modules">JavaScript コードモジュール</h3>
 
 <p><em>変更なし。</em></p>
 
-<h3 id="XPCOM" name="XPCOM">XPCOM</h3>
+<h3 id="XPCOM">XPCOM</h3>
 
 <p><em>変更なし。</em></p>
 
-<h3 id="Other" name="Other">その他</h3>
+<h3 id="Other">その他</h3>
 
 <p><em>変更なし。</em></p>
 
-<h2 id="See_also" name="See_also">関連情報</h2>
+<h2 id="See_also">関連情報</h2>
 
 <ul>
  <li><a href="http://www.mozilla.jp/firefox/42.0/releasenotes/">Firefox 42 リリースノート</a></li>
@@ -191,6 +197,6 @@ translation_of: Mozilla/Firefox/Releases/42
  <li><a href="https://dev.mozilla.jp/2015/10/firefox-42-addon-compatibility/">Firefox 42 アドオン互換性情報</a></li>
 </ul>
 
-<h2 id="Older_versions" name="Older_versions">過去のバージョン</h2>
+<h2 id="Older_versions">過去のバージョン</h2>
 
 <p>{{Firefox_for_developers('41')}}</p>


### PR DESCRIPTION
- 2021/03/03 時点の英語版に同期
- 原語併記マクロを削除 (https://github.com/mozilla-japan/translation/issues/547)