### PR TITLE
fix: typo in border-radius api (lang:fr)

### DIFF
--- a/files/fr/web/css/border-radius/index.html
+++ b/files/fr/web/css/border-radius/index.html
@@ -37,8 +37,8 @@ translation_of: Web/CSS/border-radius
 /* On utilise le même rayon pour les quatre angles */
 border-radius: 10px;
 
-/* 1. coin en haut à gauche et en bas à droite     */
-/* 2. puis coin en haut à droit et en bas à gauche */
+/* 1. coin en haut à gauche et en bas à droite      */
+/* 2. puis coin en haut à droite et en bas à gauche */
 border-radius: 10px 5%;
 
 /* 1. coin en haut à gauche                    */
@@ -58,8 +58,8 @@ border-radius: 1px 0 3px 4px;
 border-radius: 10px 5% / 20px;
 
 /* rayons horizontaux puis <strong>/</strong> puis rayons verticaux */
-/* 1. coin en haut à gauche et en bas à droite     */
-/* 2. puis coin en haut à droit et en bas à gauche */
+/* 1. coin en haut à gauche et en bas à droite      */
+/* 2. puis coin en haut à droite et en bas à gauche */
 border-radius: 10px 5% / 20px 30px;
 
 /* rayons horizontaux puis <strong>/</strong> puis rayons verticaux */


### PR DESCRIPTION
Fix typo in https://developer.mozilla.org/fr/docs/Web/CSS/border-radius, from "en haut à droit" to "en haut à droite".
