### PR TITLE
Web/XPath/Axes を更新

### DIFF
--- a/files/ja/web/xpath/axes/index.html
+++ b/files/ja/web/xpath/axes/index.html
@@ -1,5 +1,5 @@
 ---
-title: Axes
+title: 軸
 slug: Web/XPath/Axes
 tags:
   - Transforming_XML_with_XSLT
@@ -9,39 +9,37 @@ tags:
   - XSLT_Reference
 translation_of: Web/XPath/Axes
 ---
-<p>{{ XsltRef() }} <a href="ja/XPath">XPath</a> 仕様では 13 種類の{{ 訳語("軸", "Axis") }}が定められています。軸はコンテクストノードとの関連性を表し、ツリー上でのノードのコンテクストノードからの相対的な位置を示すのに用いられます。以下は XPath で利用できる 13 種類の軸のごく簡単な説明と、<a href="/ja/docs/Mozilla/Gecko">Gecko</a> における対応状況を示したものです。</p>
+<p>{{ XsltRef() }} <a href="/ja/docs/Web/XPath">XPath</a> 仕様では 13 種類の軸 (Axis) が定められています。軸はコンテキストノードとの関連性を表し、ツリー上でのノードのコンテキストノードからの相対的な位置を示すのに用いられます。</p>
 
-<p>XPath 式の使用に関するより詳しい情報は、<a href="ja/Transforming_XML_with_XSLT">XSLT による XML の変換</a>の記事の最後の<a href="ja/Transforming_XML_with_XSLT/For_Further_Reading">より詳しい読み物</a>の節を参照して下さい。</p>
+<p>XPath 式の使用に関するより詳しい情報は、 <a href="/ja/docs/Web/XSLT/Transforming_XML_with_XSLT">XSLT による XML の変換</a>の記事の最後の<a href="/en-US/docs/Web/XSLT/Transforming_XML_with_XSLT#for_further_reading">さらなる読み物</a>の節を参照してください。また、<a href="https://www.w3.org/TR/xpath-30/#axes">XPath 仕様書の 'axes' の節</a>も参照してください。</p>
 
 <dl>
  <dt><a href="/ja/docs/Web/XPath/Axes/ancestor">ancestor</a></dt>
- <dd>コンテクストノードの親ノードからルートノードまでの全ての祖先を示します。</dd>
+ <dd>コンテキストノードの親ノードからルートノードまでのすべての祖先を示します。</dd>
  <dt><a href="/ja/docs/Web/XPath/Axes/ancestor-or-self">ancestor-or-self</a></dt>
- <dd>コンテクストノードと、その全てのルートノードを含む祖先を示します。</dd>
+ <dd>コンテキストノードと、そのすべてのルートノードを含む祖先を示します。</dd>
  <dt><a href="/ja/docs/Web/XPath/Axes/attribute">attribute</a></dt>
- <dd>コンテクストノードの属性を示します。属性を持つのは要素のみです。この軸はアットマーク (<code>@</code>) によって省略できます。</dd>
+ <dd>コンテキストノードの属性を示します。属性を持つのは要素のみです。この軸はアットマーク (<code>@</code>) によって省略できます。</dd>
  <dt><a href="/ja/docs/Web/XPath/Axes/child">child</a></dt>
- <dd>コンテクストノードの子を示します。 XPath 式で軸が指定されていなければ、デフォルトでこの軸が指定されていると認識されます。子を持つのはルートノードか要素ノードのみなので、他のノードでこの軸を使用しても何も選択されません。</dd>
+ <dd>コンテキストノードの子を示します。 XPath 式で軸が指定されていなければ、デフォルトでこの軸が指定されていると認識されます。子を持つのはルートノードか要素ノードのみなので、他のノードでこの軸を使用しても何も選択されません。</dd>
  <dt><a href="/ja/docs/Web/XPath/Axes/descendant">descendant</a></dt>
- <dd>コンテクストノードの全ての子と、その全ての子と、そのまた全ての･･･というように示します。属性ノードと名前空間ノードは<strong>含まれません</strong>。 <code>attribute</code> ノードの <code>parent</code> は要素ノードですが、<code>attribute</code> ノードはその要素ノードの子ではないからです。</dd>
+ <dd>コンテキストノードのすべての子と、そのすべての子と、そのまたすべての･･･というように示します。属性ノードと名前空間ノードは<strong>含まれません</strong>。 <code>attribute</code> ノードの <code>parent</code> は要素ノードですが、<code>attribute</code> ノードはその要素ノードの子ではないからです。</dd>
  <dt><a href="/ja/docs/Web/XPath/Axes/descendant-or-self">descendant-or-self</a></dt>
- <dd>コンテクストノードと、その全ての子孫を示します。属性ノードと名前空間ノードは<strong>含まれません</strong>。 <code>attribute</code> ノードの <code>parent</code> は要素ノードですが、<code>attribute</code> ノードはその要素ノードの子ではないからです。</dd>
+ <dd>コンテキストノードと、そのすべての子孫を示します。属性ノードと名前空間ノードは<strong>含まれません</strong>。 <code>attribute</code> ノードの <code>parent</code> は要素ノードですが、<code>attribute</code> ノードはその要素ノードの子ではないからです。</dd>
  <dt><a href="/ja/docs/Web/XPath/Axes/following">following</a></dt>
- <dd>コンテクストノードの後に現れる、<code>descendant</code>、<code>attribute</code>、<code>namespace</code> ノードを除く全てのノードを示します。</dd>
+ <dd>コンテキストノードの後に現れる、<code>descendant</code>、<code>attribute</code>、<code>namespace</code> ノードを除くすべてのノードを示します。</dd>
  <dt><a href="/ja/docs/Web/XPath/Axes/following-sibling">following-sibling</a></dt>
- <dd>コンテクストノードと同じ親を持ち、ソース文書内でコンテクストノードの後に現れる全てのノードを示します。</dd>
+ <dd>コンテキストノードと同じ親を持ち、ソース文書内でコンテキストノードの後に現れるすべてのノードを示します。</dd>
  <dt><a href="/ja/docs/Web/XPath/Axes/namespace">namespace</a><em>(サポート対象外)</em></dt>
- <dd>コンテクストノードのスコープ内にある全てのノードを示します。この場合、コンテクストノードは要素ノードでなければなりません。</dd>
+ <dd>コンテキストノードのスコープ内にあるすべてのノードを示します。この場合、コンテキストノードは要素ノードでなければなりません。</dd>
  <dt><a href="/ja/docs/Web/XPath/Axes/parent">parent</a></dt>
- <dd>コンテクストノードの親である単一のノードを示します。この軸は 2 つのピリオド (<code>..</code>) によって省略できます。</dd>
+ <dd>コンテキストノードの親である単一のノードを示します。この軸は 2 つのピリオド (<code>..</code>) によって省略できます。</dd>
  <dt><a href="/ja/docs/Web/XPath/Axes/preceding">preceding</a></dt>
- <dd>文書内でコンテクストノードの前に現れる、 <code>ancestor</code>、 <code>attribute</code> 、 <code>namespace</code> ノードを除く全てのノードを示します。</dd>
+ <dd>文書内でコンテキストノードの前に現れる、 <code>ancestor</code>、 <code>attribute</code> 、 <code>namespace</code> ノードを除くすべてのノードを示します。</dd>
  <dt><a href="/ja/docs/Web/XPath/Axes/preceding-sibling">preceding-sibling</a></dt>
- <dd>コンテクストノードと同じ親を持ち、ソース文書内でコンテクストノードの前に現れる全てのノードを示します。</dd>
+ <dd>コンテキストノードと同じ親を持ち、ソース文書内でコンテキストノードの前に現れるすべてのノードを示します。</dd>
  <dt><a href="/ja/docs/Web/XPath/Axes/self">self</a></dt>
- <dd>コンテクストノード自身を示します。 この軸はピリオド (<code>.</code>) によって省略できます。</dd>
+ <dd>コンテキストノード自身を示します。 この軸はピリオド (<code>.</code>) によって省略できます。</dd>
 </dl>
-
-<div class="noinclude"> </div>
 
 <p>{{QuickLinksWithSubpages("/ja/docs/Web/XPath")}}</p>


### PR DESCRIPTION
2021/02/22 時点の英語版に同期
- 「訳語」マクロを廃止 (https://github.com/mozilla-japan/translation/issues/547)