### PR TITLE
Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy を更新

### DIFF
--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.html
@@ -29,35 +29,35 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/content_security_pol
  </tbody>
 </table>
 
-<p>拡張機能はデフォルトでCSP(content security policy)が適用されています。デフォルトのポリシーの場合、ソースは <a href="/ja/docs/Web/HTML/Element/script">&lt;script&gt;</a> タグ及び <a href="/ja/docs/Web/HTML/Element/object">&lt;object&gt;</a> タグからのみロードできるように制限されており、 <code><a href="/ja/docs/Web/JavaScript/Reference/Global_Objects/eval">eval()</a></code>のような潜在的に安全でない慣習(バッドプラクティス)は制限されます。この実装のより詳細は <a href="/ja/Add-ons/WebExtensions/Content_Security_Policy#Default_content_security_policy">Default content security policy</a>を見てください。</p>
+<p>拡張機能には、既定でコンテンツセキュリティポリシー (CSP) が適用されます。既定のポリシーでは、 <a href="/ja/docs/Web/HTML/Element/script">&lt;script&gt;</a> や <a href="/ja/docs/Web/HTML/Element/object">&lt;object&gt;</a> リソースを読み込むソースを制限し、 <code><a href="/ja/docs/Web/JavaScript/Reference/Global_Objects/eval">eval()</a></code> のような潜在的に安全でない可能性がある行為を禁止しています。この実装のより詳細は<a href="/ja/docs/Mozilla/Add-ons/WebExtensions/Content_Security_Policy#default_content_security_policy">既定のコンテンツセキュリティポリシー</a>を見てください。</p>
 
-<p><code>"content_security_policy"</code> manifestキーを使用して、アドオンのセキュリティを緩くしたり逆にもっと制限することができます。  このキーは、Content-Security-Policy HTTPヘッダーと同じ方法で指定されます。 CSP  の文法の一般的な記述は<a href="/ja/docs/Web/HTTP/CSP">CSPを使用する</a>を見てください。</p>
+<p><code>"content_security_policy"</code> manifest キーを使用して、アドオンのセキュリティを緩くしたり逆にもっと制限することができます。  このキーは、 HTTP の Content-Security-Policy ヘッダーと同じ方法で指定されます。 CSP の構文の一般的な説明は <a href="/ja/docs/Web/HTTP/CSP">CSP の使用</a>を見てください。</p>
 
-<p>例として以下のような使用方法が可能です：</p>
+<p>例として以下のような使用方法が可能です。</p>
 
 <ul>
- <li>拡張機能にパッケージ外からスクリプトやオブジェクトの読み込みを許可する、その方法は URL を{{CSP("script-src")}} や {{CSP("object-src")}} ディレクティブで指定する</li>
- <li>拡張機能にインラインスクリプトの実行を許可する、その方法は<a href="/ja/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#Unsafe_inline_script"> <code>"script-src"</code> ディレクティブでスクリプトのハッシュを指定する</a></li>
- <li>拡張機能に <code>eval()</code> やそれに類する機能を許可する、その方法は <code>'unsafe-eval'</code> を {{CSP("script-src")}} ディレクティブの中に入れる</li>
- <li>その他のコンテンツを許可されたソースのみ、例えば画像やスタイルシートのみに制限する、適切な<a href="/ja/docs/Web/HTTP/Headers/Content-Security-Policy">ポリシーディレクティブ</a>を使って。</li>
+ <li>URL を{{CSP("script-src")}} や {{CSP("object-src")}} ディレクティブで指定することで、拡張機能にパッケージ外からスクリプトやオブジェクトの読み込みを許可する。</li>
+ <li><a href="/ja/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script"> <code>"script-src"</code> ディレクティブでスクリプトのハッシュを指定する</a>ことで、拡張機能にインラインスクリプトの実行を許可する。</li>
+ <li>拡張機能に <code>eval()</code> や類似する機能を許可するために、 <code>'unsafe-eval'</code> を {{CSP("script-src")}} ディレクティブの中に入れる</li>
+ <li>適切な<a href="/ja/docs/Web/HTTP/Headers/Content-Security-Policy">ポリシーディレクティブ</a>を使うことで、その他のコンテンツを許可されたソースのみ、例えば画像やスタイルシートのみに制限する。</li>
 </ul>
 
 <p>指定できるポリシーには以下のような制限があります。</p>
 
 <ul>
- <li>ポリシーは少なくとも {{CSP("script-src")}} ディレクティブ及び {{CSP("object-src")}} ディレクティブを含む必要があり、 {{CSP("script-src")}} ディレクティブは <code>'self'</code>キーワードを含まなければならない。</li>
- <li>外部のソースを使用する場合は<code>https:</code> スキームを使用しなければならない。</li>
- <li><a href="https://publicsuffix.org/list/">public suffix list</a> 内のドメインのリモートリソースはワイルドカードを使用禁止(よって "*.co.uk" と "*.blogspot.com" は許可されないが、 "*.foo.blogspot.com" は許可される)。</li>
+ <li>ポリシーは少なくとも {{CSP("script-src")}} および {{CSP("object-src")}} ディレクティブを含む必要があり、 {{CSP("script-src")}} ディレクティブは <code>'self'</code> キーワードを含まなければならない。</li>
+ <li>外部のソースを使用する場合は <code>https:</code> スキームを使用しなければならない。</li>
+ <li><a href="https://publicsuffix.org/list/">public suffix list</a> 内のドメインのリモートリソースはワイルドカードを使用禁止 (よって "*.co.uk" と "*.blogspot.com" は許可されないが、 "*.foo.blogspot.com" は許可される)。</li>
  <li>すべてのソースはホストを指定しなければならない。</li>
- <li><code>blob:</code>, <code>filesystem:</code>, <code>moz-extension:</code>, <code>https:</code> スキームのリソースのみ指定することができる。</li>
- <li><code>'none'</code>, <code>'self'</code>, <code>'unsafe-eval'</code> <a href="/ja/docs/Web/HTTP/Headers/Content-Security-Policy/default-src#Sources">キーワード</a>のみ指定することができる。{{訳注("chromeと同様unsafe-inlineは許可されない")}}</li>
+ <li><code>blob:</code>, <code>filesystem:</code>, <code>moz-extension:</code>, <code>https:</code> スキームのリソースのみ指定することができる。</li>
+ <li><a href="/ja/docs/Web/HTTP/Headers/Content-Security-Policy/default-src#sources">キーワード</a>は <code>'none'</code>, <code>'self'</code>, <code>'unsafe-eval'</code> のみ許可されている。</li>
 </ul>
 
-<h2 id="例">例</h2>
+<h2 id="Example">例</h2>
 
-<h3 id="有効な例">有効な例</h3>
+<h3 id="Valid_examples">有効な例</h3>
 
-<p>"https://example.com" からのリモートスクリプトを許可: (<em>注</em> <a href="#exampleNote_1">1</a><sup><a href="#exampleNote_1"> </a></sup>を見よ)</p>
+<p>"https://example.com" からのリモートスクリプトを許可: <sup>(<em>注</em> <a href="#examplenote_1">1</a> を参照)</sup></p>
 
 <pre class="brush: json no-line-numbers">"content_security_policy": "script-src 'self' https://example.com; object-src 'self'"</pre>
 
@@ -65,11 +65,11 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/content_security_pol
 
 <pre class="brush: json no-line-numbers">"content_security_policy": "script-src 'self' https://*.jquery.com; object-src 'self'"</pre>
 
-<p><a href="/ja/Add-ons/WebExtensions/Content_Security_Policy#eval%28%29_and_friends"><code>eval()</code> and friends</a>を許可:</p>
+<p><a href="/ja/docs/Mozilla/Add-ons/WebExtensions/Content_Security_Policy#eval%28%29_and_friends"><code>eval()</code> や類似する機能</a>を許可:</p>
 
 <pre class="brush: json no-line-numbers">"content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self';"</pre>
 
-<p>次のインラインスクリプトを許可: <code>"&lt;script&gt;alert('Hello, world.');&lt;/script&gt;"</code>:</p>
+<p>インラインスクリプト <code>"&lt;script&gt;alert('Hello, world.');&lt;/script&gt;"</code> を許可:</p>
 
 <pre class="brush: json no-line-numbers">"content_security_policy": "script-src 'self' 'sha256-qznLcsROx4GACP2dm0UCKCzCG+HiZ1guq6ZZDob/Tng='; object-src 'self'"</pre>
 
@@ -82,40 +82,34 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/content_security_pol
 <pre class="brush: json no-line-numbers">"content_security_policy": "default-src 'self'"
 </pre>
 
-<h3 id="無効な例">無効な例</h3>
+<h3 id="Invalid_examples">無効な例</h3>
 
-<p><code>"object-src"</code> ディレクティブが省略されているポリシー:</p>
+<p><code>"object-src"</code> ディレクティブが省略されているポリシー:</p>
 
 <pre class="brush: json no-line-numbers">"content_security_policy": "script-src 'self' https://*.jquery.com;"</pre>
 
-<p> <code>"script-src"</code> ディレクティブにおいて <code>"self"</code> キーワードが入っていないポリシー:</p>
+<p> <code>"script-src"</code> ディレクティブにおいて <code>"self"</code> キーワードが入っていないポリシー:</p>
 
 <pre class="brush: json no-line-numbers">"content_security_policy": "script-src https://*.jquery.com; object-src 'self'"</pre>
 
 <p>リモートソーススキームが <code>https</code> ではない:</p>
 
-<pre class="brush: json no-line-numbers">"content_security_policy": "script-src 'self' <strong>http</strong>://code.jquery.com; object-src 'self'"</pre>
+<pre class="brush: json no-line-numbers">"content_security_policy": "script-src 'self' http://code.jquery.com; object-src 'self'"</pre>
 
 <p>ワイルドカードを通常のドメインに使用している:</p>
 
-<pre class="brush: json no-line-numbers">"content_security_policy": "script-src 'self' https://<strong>*.blogspot.com</strong>; object-src 'self'"</pre>
+<pre class="brush: json no-line-numbers">"content_security_policy": "script-src 'self' https://*.blogspot.com; object-src 'self'"</pre>
 
-<p>リモートソーススキームは https だがホストがない:</p>
+<p>リモートソーススキームは https だがホスト名がない:</p>
 
 <pre class="brush: json no-line-numbers">"content_security_policy": "script-src 'self' https:; object-src 'self'"</pre>
 
-<p>ディレクティブに現在サポートしていない <code>'unsafe-inline'</code>キーワードが含まれている:</p>
+<p>ディレクティブに現在サポートしていない <code>'unsafe-inline'</code>キーワードが含まれている:</p>
 
 <pre class="brush: json no-line-numbers">"content_security_policy": "script-src 'self' 'unsafe-inline'; object-src 'self'"</pre>
 
-<p><span id="exampleNote_1">1. 注<em>記: 有効な例は正しい CSP のキーの使い方を表しますが、'unsafe-eval', 'unsafe-inline', リモートスクリプト、リモートソースを CSP に指定する拡張機能は</em></span><span><em>、主なセキュリティの問題から、addons.mozilla.org に載せる拡張機能には許可されません。</em></span></p>
+<p><span id="exampleNote_1">1. <em>注: 有効な例は正しい CSP のキーの使い方を表しますが、'unsafe-eval', 'unsafe-inline', リモートスクリプト、リモートソースを CSP に指定する拡張機能は、主なセキュリティの問題から、addons.mozilla.org に載せる拡張機能には許可されません。</em></span></p>
 
-<h2 id="ブラウザ互換性">ブラウザ互換性</h2>
-
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
-<p> </p>
+<h2 id="Browser_compatibility">ブラウザーの互換性</h2>
 
 <p>{{Compat("webextensions.manifest.content_security_policy")}}</p>
-
-<p> </p>


### PR DESCRIPTION
- 2021/05/18 時点の英語版に同期
- 訳注マクロを削除 (https://github.com/mozilla-japan/translation/issues/547)