### PR TITLE
[FEAT] add Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/content-bug.md
+++ b/.github/ISSUE_TEMPLATE/content-bug.md
@@ -1,0 +1,33 @@
+---
+name: Content bug
+about: "Use this template to notify us of a content bug that needs fixing"
+labels: "needs-triage"
+assignees:
+title: "Content bug: <TITLE OF PROBLEM>"
+---
+
+## What page(s) did you find the problem on?
+
+<!-- include the URL or URLs where you found the problem. If it is a widespread
+problem over many pages, just give us a couple of example URLs rather than the
+whole lot  -->
+
+## Specific page section or heading?
+
+<!-- include the specific heading underneath which the problem can be found, if
+relevant, to help us locate the problem more easily  -->
+
+## What is the problem?
+
+<!-- include a description of the problem — is some text misspelt, or
+inaccurate? Does an example not work? Is the document missing some information?
+Is something just weird?  -->
+
+## What did you expect to see?
+
+<!-- If you have an idea of what the solution to your problem is, please
+provide details here. If you don't know, then that's OK   -->
+
+## Did you test this? If so, how?
+
+<!-- Please provide any steps you took to test the problem, if appropriate  -->

--- a/.github/ISSUE_TEMPLATE/new-content-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/new-content-suggestion.md
@@ -1,0 +1,27 @@
+---
+name: New content suggestion
+about: "Use this template to suggest new larger areas of work that you think the MDN writers should work on"
+labels: "Opportunity assessment"
+assignees: chrisdavidmills
+title: "Content suggestion: <TITLE OF SUGGESTION>"
+---
+
+## What is the new suggestion?
+<!-- include a short description of the content work suggestion  -->
+
+## Why is it important or useful?
+<!-- Tell us why the idea is important or useful. Include any information you
+can think of that would be useful, for example:
+
+How many pages are likely to be needed?
+How much time do you think this work should take? A few hours? A week? A month?
+Will the work enable learners or professionals to achieve their goals better?
+Does it address critical needs in the web industry?
+Is the work an operational necessity, i.e. is not having it a security risk?
+Does the content help make the web more ethical?
+ -->
+
+## Other supporting information
+
+<!-- include any other useful supporting information, such as spec URL,
+explainer URL, link to further supporting information  -->


### PR DESCRIPTION
As the issue was raised, I received an inquiry because the form was not set to report the problem. https://github.com/mdn/translated-content/issues/907

We really needed some templates to help people file issues. I imported the issue template of the content repo. https://github.com/mdn/content/pull/2906

How about adding it?