### PR TITLE
fix a reference to non-existent article

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/bigint64array/index.html
+++ b/files/ja/web/javascript/reference/global_objects/bigint64array/index.html
@@ -59,7 +59,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/BigInt64Array
  <dt>{{jsxref("TypedArray.copyWithin", "BigInt64Array.prototype.copyWithin()")}}</dt>
  <dd>配列内の配列要素のシーケンスをコピーします。{{jsxref("Array.prototype.copyWithin()")}} も参照してください。</dd>
  <dt>{{jsxref("TypedArray.entries", "BigInt64Array.prototype.entries()")}}</dt>
- <dd>配列の各インデックスのキーと値のペアを含む、新しい <code>Array Iterator</code> オブジェクトを返します。{{jsxref("Array.prototype.entry()")}} も参照してください。</dd>
+ <dd>配列の各インデックスのキーと値のペアを含む、新しい <code>Array Iterator</code> オブジェクトを返します。{{jsxref("Array.prototype.entries()")}} も参照してください。</dd>
  <dt>{{jsxref("TypedArray.every", "BigInt64Array.prototype.every()")}}</dt>
  <dd>配列のすべての要素が、関数で指定されたテストに合格するかどうかをテストします。{{jsxref("Array.prototype.every()")}} も参照してください。</dd>
  <dt>{{jsxref("TypedArray.fill", "BigInt64Array.prototype.fill()")}}</dt>


### PR DESCRIPTION
changed reference destination, from `Array.prototype.entry` to `Array.prototype.entries`.