### PR TITLE
[FIX] typo err

### DIFF
--- a/files/ko/web/http/caching/index.html
+++ b/files/ko/web/http/caching/index.html
@@ -34,7 +34,7 @@ translation_of: Web/HTTP/Caching
 <ul>
  <li>검색(retrieval) 요청의 성공적인 결과: HTML 문서, 이미지 혹은 파일과 같은 리소스를 포함하는 {{HTTPMethod("GET")}} 요청에 대한 {{HTTPStatus(200)}} (OK) 응답.</li>
  <li>영구적인 리다이렉트: {{HTTPStatus(301)}} (Moved Permanently) 응답.</li>
- <li>오류 응답: a {{HTTPStatus(404)}} (Not Found) 결과 페이지.</li>
+ <li>오류 응답: {{HTTPStatus(404)}} (Not Found) 결과 페이지.</li>
  <li>완전하지 않은 결과: {{HTTPStatus(206)}} (Partial Content) 응답.</li>
  <li>캐시 키로 사용하기에 적절한 무언가가 정의된 경우의 {{HTTPMethod("GET")}} 이외의 응답.</li>
 </ul>


### PR DESCRIPTION
동결 해제에 따른 https://github.com/mdn/translated-content/pull/295 에 대한 PR

English 'a' typing was not deleted during translation.

#### origin

```html
<li>오류 응답: a {{HTTPStatus(404)}} (Not Found) 결과 페이지.</li>
```

---


#### change
```html
<li>오류 응답: {{HTTPStatus(404)}} (Not Found) 결과 페이지.</li>
```

#296 