### PR TITLE
[FIX] document.execcommand deprecated #151

### DIFF
--- a/files/ko/web/api/document/execcommand/index.html
+++ b/files/ko/web/api/document/execcommand/index.html
@@ -10,7 +10,7 @@ tags:
   - editor
 translation_of: Web/API/Document/execCommand
 ---
-<div>{{ApiRef("DOM")}}</div>
+<div>{{ApiRef("DOM")}}{{deprecated_header}}</div>
 
 <p>HTML 문서가 <code>designMode</code>로 전환되면 문서에서 <code>execCommand</code> 메서드를 사용할 수 있게 되는데 이것을 이용해서 문서의 편집 가능한 영역을 변경할 수 있습니다. 대부분의 명령어는 문서의 선택 영역에 영향(<em>볼드, 이탤릭 등</em>)을 미치고 나머지는 새 요소를 추가(링크 추가)하거나 전체 줄에 영향(들여쓰기)을 미칩니다. <code>contentEditable</code>을 사용할 때에 <code>execCommand()</code>를 호출하면 현재 활성화된 편집 요소에 영향을 미칩니다.</p>
 

--- a/files/ko/web/api/document/execcommand/index.html
+++ b/files/ko/web/api/document/execcommand/index.html
@@ -1,6 +1,13 @@
 ---
 title: Document.execCommand()
 slug: Web/API/Document/execCommand
+tags:
+  - API
+  - DOM
+  - Method
+  - NeedsExample
+  - Reference
+  - editor
 translation_of: Web/API/Document/execCommand
 ---
 <div>{{ApiRef("DOM")}}</div>


### PR DESCRIPTION
The korean page was out of date. In order to tackle #151, I've handled deprecated.

document.execcommand가 deprecated 됨에 따라 deprecated 안내 추가.

![image](https://user-images.githubusercontent.com/22424891/118975763-49974d80-b9af-11eb-9152-b1937158f33e.png)
