### PR TITLE
Web/JavaScript/Reference/Global_Objects/isNaN を更新

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/isnan/index.html
+++ b/files/ja/web/javascript/reference/global_objects/isnan/index.html
@@ -5,57 +5,58 @@ tags:
   - JavaScript
   - Method
   - Reference
+browser-compat: javascript.builtins.isNaN
 translation_of: Web/JavaScript/Reference/Global_Objects/isNaN
 ---
 <div>{{jsSidebar("Objects")}}</div>
 
-<p><code><strong>isNaN()</strong></code> 関数は引数が {{jsxref("NaN")}} (非数) かどうかを判定します。<code>isNaN</code> 関数の型強制は<a href="#Description">興味深いルール</a>を持つことに注意してください。値が非数かどうかを判定する代用方法として、ECMAScript 2015 で定義されている {{jsxref("Number.isNaN()")}} が使用できます。</p>
+<p><code><strong>isNaN()</strong></code> 関数は引数が {{jsxref("NaN")}} (非数) かどうかを判定します。<code>isNaN</code> 関数の型強制は<a href="#confusing_special-case_behavior">意外なもの</a>になる可能性があるため、他の {{jsxref("Number.isNaN()")}} を使用した方が良いかもしれません。</p>
 
 <div>{{EmbedInteractiveExample("pages/js/globalprops-isnan.html")}}</div>
 
-<h2 id="Syntax" name="Syntax">構文</h2>
+<h2 id="Syntax">構文</h2>
 
-<pre class="syntaxbox notranslate">isNaN(<var>value</var>)</pre>
+<pre class="brush: js">isNaN(value)</pre>
 
-<h3 id="Parameters" name="Parameters">引数</h3>
+<h3 id="Parameters">引数</h3>
 
 <dl>
- <dt><code>value</code></dt>
- <dd>テストされる値。</dd>
+  <dt><code>value</code></dt>
+  <dd>テストされる値。</dd>
 </dl>
 
-<h3 id="Return_value" name="Return_value">返値</h3>
+<h3 id="Return_value">返値</h3>
 
-<p>もし引数が {{jsxref("NaN")}} であるならば <strong><code>true</code></strong> を返し, そうでなければ <strong><code>false</code></strong> を返します。</p>
+<p>渡された値が {{jsxref("NaN")}} である場合は <strong><code>true</code></strong> を返し, そうでなければ <strong><code>false</code></strong> を返します。</p>
 
-<h2 id="Description" name="Description">解説</h2>
+<h2 id="Description">解説</h2>
 
-<h3 id="The_necessity_of_an_isNaN_function" name="The_necessity_of_an_isNaN_function">isNaN 関数の必要性</h3>
+<h3 id="The_necessity_of_an_isNaN_function">isNaN 関数の必要性</h3>
 
-<p>JavaScript にあるその他すべての値とは違い、ある数値が {{jsxref("NaN")}} であるかの判定に等値性評価演算子（== と ===）を使用することはできません。なぜなら <code>NaN == NaN</code> と <code>NaN === NaN</code> はどちらも <code>false</code> と評価されるからです。そこで、<code>isNaN</code> が必要となります。</p>
+<p>JavaScript のその他すべての値とは違い、等値性評価演算子（== と ===）を {{jsxref("NaN")}} に対して使用してその値が <code>NaN</code> であるかどうかを判定することはできません。 <code>NaN == NaN</code> と <code>NaN === NaN</code> はどちらも <code>false</code> と評価されるからです。そこで、<code>isNaN</code> が必要となります。</p>
 
-<h3 id="Origin_of_NaN_values" name="Origin_of_NaN_values">NaN 値の生成条件</h3>
+<h3 id="Origin_of_NaN_values">NaN 値の生成条件</h3>
 
-<p><code>NaN</code> の値は算術演算の結果が<strong>未定義</strong>か<strong>表現不可能な</strong>値となった時に生成されます。こうした値が常にオーバーフロー状態を表現するわけではありません。<code>NaN</code> はプリミティブな数値が利用不可能といった、非数値を数値へと型強制した結果生成されることもあります。</p>
+<p><code>NaN</code> の値は、算術演算の結果が<em>未定義</em>または<em>表現不可能</em>な値となった時に生成されます。こうした値が常にオーバーフロー状態を表現するとは限りません。<code>NaN</code> はプリミティブな数値が利用不可能といった、非数値を数値へと型強制した結果として生成されることもあります。</p>
 
-<p>例えば、ゼロをゼロ除算した場合の結果は <code>NaN</code> になりますが、その他の数をゼロ除算した場合は異なります。</p>
+<p>例えば、ゼロをゼロで除算した場合の結果は <code>NaN</code> になりますが、その他の数をゼロで除算した場合は異なります。</p>
 
-<h3 id="Confusing_special-case_behavior" name="Confusing_special-case_behavior">特殊な場合における厄介な動作</h3>
+<h3 id="Confusing_special-case_behavior">特殊な場合における厄介な動作</h3>
 
-<p><code>isNaN</code> 関数の定義はごく初期のバージョン以降、数値ではない引数における振る舞いが分かりにくいものとなっていました。<code>isNaN</code> 関数の引数が<a href="http://es5.github.com/#x8.5" title="http://es5.github.com/#x8.5">数値型</a>ではない場合、その値はまず数へと型強制されます。その結果の値はその後 {{jsxref("NaN")}} かどうかがテストされます。このようにして、数値型に型強制される際に結果が NaN ではない数値となる非数値（とりわけ型強制されると 0 や 1 の値になる空文字列や真偽値プリミティブ）に対しては、予想外なことに "false" が返されます{{訳注("「NaN でない」という結果から「数値である」と誤って解釈されてしまう")}}。無論、例えば空文字列は「数ではありません」。この混乱は、"not a number" （数ではない）というこの用語が IEEE-754 浮動小数点数定義で表現された数において特別な意味があるという事実に起因しています。この関数は、「この値を数値型に型強制した場合、IEEE-754 における 'Not A Number' という値になりますか？」という質問に答えるものとして解釈すべきです。</p>
+<p><code>isNaN</code> 関数の定義はごく初期のバージョン以降、数値ではない引数における振る舞いが分かりにくいものとなっていました。 <code>isNaN</code> 関数の引数が<a href="http://es5.github.com/#x8.5">数値型</a>ではない場合、その値はまず数へと型強制されます。その結果の値はその後 {{jsxref("NaN")}} かどうかがテストされます。このようにして、数値型に型強制される際に結果が NaN ではない数値となる非数値 (とりわけ型強制されると 0 や 1 の値になる空文字列や論理値プリミティブ) に対しては、予想外なことに "false" が返されます。無論、例えば空文字列は「数ではありません」。この混乱は、 "not a number" (数ではない) というこの用語が IEEE-754 浮動小数点数定義で表現された数においては特別な意味を持っていることに起因しています。この関数は、「この値を数値型に型強制した場合、IEEE-754 における 'Not A Number' という値になりますか？」という質問に答えるものとして解釈すべきです。</p>
 
-<p>ECMAScript 2015 では {{jsxref("Number.isNaN()")}} 関数が存在します。<code>Number.isNaN(x)</code> は <code>x</code> が <code>NaN</code> かどうかをテストする確実な方法です。しかしながら <code>Number.isNaN</code> においても、<code>NaN</code> の意味は単純ではない明確な数値的意味を持つ "not a number" のままです。<code>Number.isNaN</code> が利用できない場合、<code>x</code> が <code>NaN</code> かどうかを確実にテストする代わりの方法として <code>(x != x)</code> という式があります。この式の結果は信頼性のない <code>isNaN</code> が引き起こす誤検出の影響を受けません。</p>
+<p>ECMAScript 2015 では {{jsxref("Number.isNaN()")}} 関数が存在します。<code>Number.isNaN(x)</code> は <code>x</code> が <code>NaN</code> かどうかをテストする確実な方法です。しかしながら <code>Number.isNaN</code> においても、<code>NaN</code> の意味は明確な数値的意味を持つ "not a number" のままです。<code>Number.isNaN</code> が利用できない場合、<code>x</code> が <code>NaN</code> かどうかを確実にテストする代わりの方法として <code>(x != x)</code> という式があります。この式の結果は信頼性のない <code>isNaN</code> が引き起こす誤検出の影響を受けません。</p>
 
-<p><code>isNaN</code> に対する polyfill の一つの例は以下のようになります（この polyfill は <code>NaN</code> が自分自身と常に等しくならないという特徴を利用しています）：</p>
+<p><code>isNaN</code> のポリフィルは以下のようになります (このポリフィルは <code>NaN</code> が自分自身と常に等しくならないという特徴を利用しています)。</p>
 
-<pre class="brush: js notranslate">var isNaN = function(value) {
-    var n = Number(value);
+<pre class="brush: js">const isNaN = function(value) {
+    const n = Number(value);
     return n !== n;
 };</pre>
 
-<h2 id="Examples" name="Examples">例</h2>
+<h2 id="Examples">例</h2>
 
-<pre class="brush: js notranslate">isNaN(NaN);       // true
+<pre class="brush: js">isNaN(NaN);       // true
 isNaN(undefined); // true
 isNaN({});        // true
 
@@ -80,36 +81,23 @@ isNaN('blabla');   // true: "blabla" が数値に変換される。
                    // 数値への変換が失敗し NaN が返される。
 </pre>
 
-<h3 id="Useful_special-case_behavior" name="Useful_special-case_behavior">特殊な場合における便利な動作</h3>
+<h3 id="Useful_special-case_behavior">特殊な場合における便利な動作</h3>
 
 <p><code>isNaN()</code> のふるまいを考慮した別の使用方法があります。<code>isNaN(x)</code> が <code>false</code> を返す場合、<code>NaN</code> を返すことなく算術式内で <code>x</code> を使用できます。<code>true</code> を返す場合、<code>x</code> を使用すると全ての算術式で <code>NaN</code> を返すことになります。これはつまり、JavaScript において <code>isNaN(x) == true</code> という式は、<code>x - 0</code> という式が <code>NaN</code> を返すかどうか、というケースと同等である（JavaScript では <code>x - 0 == NaN</code> は常に false を返すため、このことを確認できませんが）ということです。実際、<code>isNaN(x)</code>、<code>isNaN(x - 0)</code>、<code>isNaN(Number(x))</code>、<code>Number.isNaN(x - 0)</code>、そして <code>Number.isNaN(Number(x))</code> は常に同じ値を返し、JavaScript では <code>isNaN(x)</code> がこれらの条件を表す最も短い形式となります。</p>
 
-<p>例えばこの動作を使って、ある関数への引数が算術処理可能か（数値として利用できるか）どうかをテストするのに利用し、そうでない場合はデフォルト値などを与えるようにできます。この方法によりコンテキスト次第で値を暗黙的に変換する汎用性の高い JavaScript 関数を作成できます。</p>
+<p>例えばこの動作を使って、ある関数への引数が算術処理可能か (数値として利用できるか) どうかをテストするのに利用し、そうでない場合は既定値などを与えるようにできます。この方法によりコンテキスト次第で値を暗黙的に変換する汎用性の高い JavaScript 関数を作成できます。</p>
 
-<h2 id="Specifications" name="Specifications">仕様書</h2>
+<h2 id="Specifications">仕様書</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">仕様書</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-isnan-number', 'isNaN')}}</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
-<h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
+<h2 id="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
+<p>{{Compat}}</p>
 
-<p>{{Compat("javascript.builtins.isNaN")}}</p>
-
-<h2 id="See_also" name="See_also">関連情報</h2>
+<h2 id="See_also">関連情報</h2>
 
 <ul>
- <li>{{jsxref("NaN")}}</li>
- <li>{{jsxref("Number.isNaN()")}}</li>
+  <li>{{jsxref("NaN")}}</li>
+  <li>{{jsxref("Number.isNaN()")}}</li>
 </ul>


### PR DESCRIPTION
- 2021/05/05 時点の英語版に同期
- 訳注マクロを削除 (https://github.com/mozilla-japan/translation/issues/547 )。訳注として意味を超えた補足説明になっていたため、訳注全体を削除。