### PR TITLE
typo: French typo in role="presentation" page

### DIFF
--- a/files/fr/web/accessibility/aria/aria_techniques/using_the_presentation_role/index.html
+++ b/files/fr/web/accessibility/aria/aria_techniques/using_the_presentation_role/index.html
@@ -13,7 +13,7 @@ original_slug: Accessibilité/ARIA/Techniques_ARIA/Utiliser_le_role_presentation
 <h2 id="Description">Description</h2>
 
 <div class="summary">
-<p>Le rôle <code>presentation</code> est utilisé pour retirer toute représentation sémantique pour un élément donnée ainsi que pour ses descendants. Par exemple, un tableau utilisé pour la mise en page pourrait avoir un rôle <code>presentation</code> appliqué sur l'élément <code>table</code> pour retirer la sémantique de l'élément en lui-même ainsi que tout ses sous-éléments, comme l'en-tête de tableau ou même les données de tableau elles-mêmes.</p>
+<p>Le rôle <code>presentation</code> est utilisé pour retirer toute représentation sémantique pour un élément donné ainsi que pour ses descendants. Par exemple, un tableau utilisé pour la mise en page pourrait avoir un rôle <code>presentation</code> appliqué sur l'élément <code>table</code> pour retirer la sémantique de l'élément en lui-même ainsi que tout ses sous-éléments, comme l'en-tête de tableau ou même les données de tableau elles-mêmes.</p>
 </div>
 
 <h2 id="Effets_possibles_sur_les_agents_utilisateurs_et_les_technologies_d’assistance">Effets possibles sur les agents utilisateurs et les technologies d’assistance</h2>


### PR DESCRIPTION
To validate the change, you can check [here](https://www.linguee.fr/francais-anglais/traduction/un+%C3%A9l%C3%A9ment+donn%C3%A9.html) for more examples with the same wording