### PR TITLE
[ja]Fix `iframe`

### DIFF
--- a/files/ja/web/html/element/iframe/index.html
+++ b/files/ja/web/html/element/iframe/index.html
@@ -196,12 +196,12 @@ translation_of: Web/HTML/Element/iframe
 
 <h3 id="Example1" name="Example1">シンプルな &lt;iframe&gt;</h3>
 
-<p><code>&lt;iframe&gt;</code> の例です。フレームを作成した後に、ユーザーがボタンをクリックすると、タイトルをアラートで表示します。</p>
+<p>この例では、<a href="https://example.org">https://example.org</a>のページを <code>&lt;iframe&gt;</code> で埋め込みます。</p>
 
 <h4 id="HTML">HTML</h4>
 
 <div id="htmlOutputWrapper">
-<pre class="brush: html notranslate">&lt;iframe src="https://mdn-samples.mozilla.org/snippets/html/iframe-simple-contents.html"
+<pre class="brush: html notranslate">&lt;iframe src="https://example.org"
             title="iframe Example 1" width="400" height="300"&gt;
 &lt;/iframe&gt;</pre>
 </div>


### PR DESCRIPTION
Related: https://github.com/mdn/content/pull/4961

https://developer.mozilla.org/ja/docs/Web/HTML/Element/iframe

**before**

<img width="800" alt="スクリーンショット 2021-05-22 8 54 18" src="https://user-images.githubusercontent.com/50798936/119208000-531dd400-badb-11eb-8d13-27c799729f56.png">

**after**

<img width="779" alt="スクリーンショット 2021-05-22 8 55 07" src="https://user-images.githubusercontent.com/50798936/119208025-6fba0c00-badb-11eb-98ba-29f22be22fb4.png">
