### PR TITLE
Mozilla/Firefox/Releases 以下の各ファイルから英語版章題マクロを削除

### DIFF
--- a/files/ja/mozilla/firefox/releases/2/updating_extensions/index.html
+++ b/files/ja/mozilla/firefox/releases/2/updating_extensions/index.html
@@ -1,5 +1,5 @@
 ---
-title: Updating extensions for Firefox 2
+title: Firefox 2 のための拡張機能の更新
 slug: Mozilla/Firefox/Releases/2/Updating_extensions
 tags:
   - Add-ons
@@ -7,32 +7,40 @@ tags:
 translation_of: Mozilla/Firefox/Releases/2/Updating_extensions
 original_slug: Updating_extensions_for_Firefox_2
 ---
-<p>この記事は、開発者が彼らの拡張機能を更新して Firefox 2 で動作させるために役立つ情報を提供しています。
-</p><p>{{ 英語版章題("Step 1: Update the install manifest") }}
+<div>{{FirefoxSidebar}}</div><p>この記事は、 Firefox 2 で正しく動作するように拡張機能を更新したい開発者にとって有益な情報を提供します。
+
+<h2 id="Step_1:_Update_the_install_manifest">ステップ 1: インストール定義ファイルの更新</h2>
+
+<p>最初のステップ -- ほとんどの拡張機能で唯一必要なこと -- は、<a href="ja/Install_Manifests">インストール定義</a>ファイル install.rdf を更新し、Firefox 2 との互換性を持たせることです。
 </p>
-<h2 id=".E3.82.B9.E3.83.86.E3.83.83.E3.83.97_1:_.E3.82.A4.E3.83.B3.E3.82.B9.E3.83.88.E3.83.BC.E3.83.AB.E5.AE.9A.E7.BE.A9.E3.83.95.E3.82.A1.E3.82.A4.E3.83.AB.E3.81.AE.E6.9B.B4.E6.96.B0" name=".E3.82.B9.E3.83.86.E3.83.83.E3.83.97_1:_.E3.82.A4.E3.83.B3.E3.82.B9.E3.83.88.E3.83.BC.E3.83.AB.E5.AE.9A.E7.BE.A9.E3.83.95.E3.82.A1.E3.82.A4.E3.83.AB.E3.81.AE.E6.9B.B4.E6.96.B0">ステップ 1: インストール定義ファイルの更新</h2>
-<p>最初のステップ -- ほとんどの拡張機能で唯一必要なこと -- は、<a href="ja/Install_Manifests">インストール定義</a>ファイル &lt;tt&gt;install.rdf&lt;/tt&gt; を更新し、Firefox 2 との互換性を持たせることです。
-</p><p>単純に、Firefox の最大互換バージョンを指示する行を探します (次のように Firefox 1.5 向けになっています):
-</p>
-<pre class="eval"> <span class="nowiki">&lt;em:maxVersion&gt;1.5.0.*&lt;/em:maxVersion&gt;</span>
+
+<p>単純に、Firefox の最大互換バージョンを指示する行を探します (次のように Firefox 1.5 向けになっています)。</p>
+
+<pre class="eval"> &lt;em:maxVersion&gt;1.5.0.*&lt;/em:maxVersion&gt;
 </pre>
-<p>これを変更して Firefox 2 と互換性を持たせます:
-</p>
-<pre class="eval"> <span class="nowiki">&lt;em:maxVersion&gt;2.0.0.*&lt;/em:maxVersion&gt;</span>
+
+<p>これを変更して Firefox 2 と互換性を持たせます。</p>
+
+<pre class="eval"> &lt;em:maxVersion&gt;2.0.0.*&lt;/em:maxVersion&gt;
 </pre>
-<p>そして、拡張機能を再インストールしてみます。
-</p><p>{{ 英語版章題("Step 2: Update XUL overlays") }}
-</p>
-<h2 id=".E3.82.B9.E3.83.86.E3.83.83.E3.83.97_2:_XUL_.E3.82.AA.E3.83.BC.E3.83.90.E3.83.BC.E3.83.AC.E3.82.A4.E3.81.AE.E6.9B.B4.E6.96.B0" name=".E3.82.B9.E3.83.86.E3.83.83.E3.83.97_2:_XUL_.E3.82.AA.E3.83.BC.E3.83.90.E3.83.BC.E3.83.AC.E3.82.A4.E3.81.AE.E6.9B.B4.E6.96.B0">ステップ 2: XUL オーバーレイの更新</h2>
+
+<p>そして、拡張機能を再インストールします。</p>
+
+<h2 id="Step_2:_Update_XUL_overlays">ステップ 2: XUL オーバーレイの更新</h2>
+
 <p>Firefox 2 はデフォルトのテーマに変更を加えています。さらに、一部のユーザインタフェース要素が変更、または移動されているため、あなたの拡張機能の XUL オーバーレイに依存する部分が影響を受けます。
-</p><p>拡張機能の XUL オーバーレイに影響する変更箇所について学ぶには、<a href="ja/Theme_changes_in_Firefox_2">Firefox 2 におけるテーマの変更点</a>の記事に目を通してください。
-</p><p>{{ 英語版章題("Step 3: Test") }}
 </p>
-<h2 id=".E3.82.B9.E3.83.86.E3.83.83.E3.83.97_3:_.E3.83.86.E3.82.B9.E3.83.88" name=".E3.82.B9.E3.83.86.E3.83.83.E3.83.97_3:_.E3.83.86.E3.82.B9.E3.83.88">ステップ 3: テスト</h2>
+
+<p>拡張機能の XUL オーバーレイに影響する変更箇所について学ぶには、<a href="ja/Theme_changes_in_Firefox_2">Firefox 2 におけるテーマの変更点</a>の記事に目を通してください。
+</p>
+
+<h2 id="Step_3:_Test">ステップ 3: テスト</h2>
+
 <p>公式にリリースする前に、必ず拡張機能を Firefox 2 上でテストしてください。最後にすることは、Firefox のリリース時に起こる問題報告のラッシュに、あなたの拡張機能の新バージョンが責任を持つことです。
-</p><p>{{ 英語版章題("Step 4: Release") }}
 </p>
-<h2 id=".E3.82.B9.E3.83.86.E3.83.83.E3.83.97_4:_.E3.83.AA.E3.83.AA.E3.83.BC.E3.82.B9" name=".E3.82.B9.E3.83.86.E3.83.83.E3.83.97_4:_.E3.83.AA.E3.83.AA.E3.83.BC.E3.82.B9">ステップ 4: リリース</h2>
-<p><a class=" external" href="http://addons.mozilla.org" rel="freelink">http://addons.mozilla.org</a> 上のあなたの拡張機能のエントリを更新してください。ユーザが更新を見つけられるようになります。
-</p><p>さらに、あなたの拡張機能のインストール定義ファイルで <code><a href="ja/Install_Manifests#updateURL">updateURL</a></code> を提供している場合は、必ず update manifest を更新し、Firefox が自動的に拡張機能の新バージョンを見つけられるようにしてください。こうすることによって、ユーザが Firefox 2 にアップグレードした後で最初にあなたの拡張機能を実行した時、新バージョンを自動的にインストールさせることができます。
-</p>{{ languages( { "en": "en/Updating_extensions_for_Firefox_2", "fr": "fr/Mise_\u00e0_jour_des_extensions_pour_Firefox_2", "ko": "ko/Updating_extensions_for_Firefox_2", "pl": "pl/Aktualizacja_rozszerze\u0144_do_Firefoksa_2" } ) }}
+
+<h2 id="Step_4:_Release">ステップ 4: リリース</h2>
+
+<p><a class=" external" href="https://addons.mozilla.org" rel="freelink">http://addons.mozilla.org</a> 上のあなたの拡張機能のエントリーを更新してください。ユーザが更新を見つけられるようになります。</p>
+
+<p>さらに、あなたの拡張機能のインストール定義ファイルで <code><a href="ja/Install_Manifests#updateURL">updateURL</a></code> を提供している場合は、必ず update manifest を更新し、Firefox が自動的に拡張機能の新バージョンを見つけられるようにしてください。こうすることによって、ユーザが Firefox 2 にアップグレードした後で最初にあなたの拡張機能を実行した時、新バージョンを自動的にインストールさせることができます。</p>

--- a/files/ja/mozilla/firefox/releases/3.5/index.html
+++ b/files/ja/mozilla/firefox/releases/3.5/index.html
@@ -1,75 +1,69 @@
 ---
-title: Firefox 3.5 for developers
+title: Firefox 3.5 開発者向け情報
 slug: Mozilla/Firefox/Releases/3.5
 tags:
   - CSS
   - Firefox
   - Firefox 3.5
+  - Gecko
+  - Gecko 1.9.1
   - HTML
   - JavaScript
   - Storage
   - XUL
 translation_of: Mozilla/Firefox/Releases/3.5
 ---
-<p><a class="external" href="http://mozilla.jp/" title="http://mozilla.jp/">Firefox 3.5</a> では数多くの新機能が導入され、また、幅広い種類のWeb 標準に対するサポートが追加および改善されます。この記事は主な変更点をカバーする記事へのリンクを伴う広範囲に及ぶ一覧を提供します。</p>
+<div>{{FirefoxSidebar}}</div><p><a class="external" href="https://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/firefox/3.5/releasenotes/">Firefox 3.5</a> (<em>2009 年 7 月 30 日にリリース</em>) では数多くの新機能が導入され、また、幅広い種類のウェブ標準に対するサポートが追加および改善されます。この記事は主な変更点をカバーする記事へのリンクを伴う広範囲に及ぶ一覧を提供します。</p>
 
-<div>{{ 英語版章題("New developer features in Firefox 3.5") }}</div>
+<h2 id="New_developer_features_in_Firefox_3.5">Firefox 3.5 の開発者向け新機能</h2>
 
-<h2 id="Firefox_3.5_の開発者向け新機能">Firefox 3.5 の開発者向け新機能</h2>
+<h3 id="For_web_site_and_application_developers">ウェブサイトとアプリケーション開発者向け</h3>
 
-<div>{{ 英語版章題("For web site and application developers") }}</div>
-
-<h3 id="Web_サイトと_Web_アプリケーション開発者向け">Web サイトと Web アプリケーション開発者向け</h3>
-
-<div>{{ 英語版章題("HTML5 support") }}</div>
-
-<h4 id="HTML5_サポート">HTML5 サポート</h4>
+<h4 id="HTML_5_support">HTML 5 サポート</h4>
 
 <dl>
- <dt><a href="/ja/docs/Using_audio_and_video_in_Firefox" title="Using audio and video in Firefox">Using audio and video in Firefox</a></dt>
- <dd>Firefox 3.5 では HTML5 の <a href="/ja/docs/HTML/Element/Audio" title="HTML/Element/Audio">audio</a> および <a href="/ja/docs/HTML/Element/Video" title="HTML/Element/Video">video</a> 要素がサポートされます。</dd>
- <dt><a href="/ja/docs/Offline_resources_in_Firefox" title="Offline resources in Firefox">Offline resources in Firefox</a></dt>
- <dd>Firefox 3.5 では HTML5 のオフラインリソース仕様をすべてサポートしています。</dd>
- <dt><a href="/ja/docs/DragDrop/Drag_and_Drop" title="DragDrop/Drag and Drop">ドラッグ＆ドロップ</a></dt>
- <dd>HTML5 のドラッグ＆ドロップ API によって Web サイト内および Web サイト間のアイテムのドラッグ＆ドロップがサポートされます。これにより、拡張や Mozilla ベースアプリケーションに対してもより単純な API が提供されます</dd>
+ <dt><a class="internal" href="/ja/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content">Firefox での音声と動画の使用</a></dt>
+ <dd>Firefox 3.5 では HTML 5 の <a href="/ja/docs/Web/HTML/Element/audio">audio</a> および <a href="/ja/docs/Web/HTML/Element/video">video</a> 要素がサポートされます。</dd>
+ <dt><a href="/ja/docs/Web/HTML/Using_the_application_cache">Firefox でのオフラインリソース</a></dt>
+ <dd>Firefox 3.5 では HTML 5 のオフラインリソース仕様をすべてサポートしています。</dd>
+ <dt><a href="/ja/docs/Web/API/HTML_Drag_and_Drop_API">ドラッグ＆ドロップ</a></dt>
+ <dd>HTML5 のドラッグ＆ドロップ API によってウェブサイト内およびウェブサイト間のアイテムのドラッグ＆ドロップがサポートされます。これにより、拡張や Mozilla ベースアプリケーションに対してもより単純な API が提供されます</dd>
 </dl>
 
-<div>{{ 英語版章題("Newly-supported CSS features") }}</div>
-
-<h4 id="新しくサポートされる_CSS_の機能">新しくサポートされる CSS の機能</h4>
+<h4 id="Newly-supported_CSS_features">新しくサポートされる CSS の機能</h4>
 
 <dl>
- <dt><a href="/ja/docs/CSS/@font-face" title="CSS/@font-face">ダウンロードフォントのサポート</a></dt>
+ <dt><a class="internal" href="/ja/docs/Web/CSS/@font-face">ダウンロードフォントのサポート</a></dt>
  <dd>新しい @規則である {{ cssxref("@font-face") }} を利用して Web ページでダウンロードフォントを提供できます。これにより、ページ作者が期待する通りにサイトが描画されるようになります。</dd>
- <dt><a href="/ja/docs/CSS/Media_queries" title="CSS/Media queries">CSS メディアクエリー</a></dt>
+ <dt><a class="internal" href="/ja/docs/Web/CSS/Media_queries">CSS メディアクエリー</a></dt>
  <dd>Firefox 3.5 では CSS メディアクエリーをサポートしています。これはメディア依存スタイルシートを拡張するものです。</dd>
- <dt>{{ cssxref(":before") }} および {{ cssxref(":after") }} の CSS 2.1 への更新</dt>
- <dd><code>:before</code> および <code>:after</code> 疑似要素が CSS 2.1 サポートを満たすように更新されました。<code>position</code>、<code>float</code>、<code>list-style-*</code>、そして、いくつかの <code>display</code> プロパティのサポートが追加されています。</dd>
+ <dt>{{ cssxref("::before") }} および {{ cssxref("::after") }} の CSS 2.1 への更新</dt>
+ <dd><code>::before</code> および <code>::after</code> 擬似要素が CSS 2.1 サポートを満たすように更新されました。<code>position</code>、<code>float</code>、<code>list-style-*</code>、そして、いくつかの <code>display</code> プロパティのサポートが追加されています。</dd>
  <dt>長さの単位 <code>ch</code></dt>
- <dd>単位 <code>ch</code> が通常の<a href="/ja/docs/CSS/Length" title="CSS/length">長さの単位</a>として任意の場所で使えるようになりました。"1 ch" は文字 '0' の横幅です。</dd>
+ <dd>単位 <code>ch</code> が通常の<a class="internal" href="/ja/docs/Web/CSS/length#units">長さの単位</a>として任意の場所で使えるようになりました。"1 ch" は文字 '0' の横幅です。</dd>
  <dt>{{ cssxref("opacity") }}</dt>
  <dd>標準の <code>opacity</code> プロパティの先行実装である <code>-moz-opacity</code> という CSS への Mozilla 拡張が削除されました。</dd>
  <dt>{{ cssxref("text-shadow") }}</dt>
  <dd>Web コンテンツにテキストとテキスト装飾に適用される影付き効果を指定できる <code>text-shadow</code> プロパティがサポートされました。</dd>
- <dt>{{ cssxref("word-wrap") }}</dt>
+ <dt>{{ cssxref("overflow-wrap") }}</dt>
  <dd>この新しくサポートされたプロパティはコンテンツに単語内で改行するかどうかを指定できます。これは単語内で改行しないと 1 行に収まらないときに発生する文字あふれを防ぐためのものです。</dd>
  <dt><code>white-space</code> プロパティが値 <code>pre-line</code> をサポート</dt>
  <dd>{{ cssxref("white-space") }} プロパティの値に <code>pre-line</code> を指定できるようになりました。</dd>
- <dt>{{ cssxref("-moz-box-shadow") }}</dt>
- <dt>{{ cssxref("-moz-border-image") }}</dt>
- <dt>{{ cssxref("-moz-column-rule") }}</dt>
- <dt>{{ cssxref("-moz-column-rule-width") }}</dt>
- <dt>{{ cssxref("-moz-column-rule-style") }}</dt>
- <dt>{{ cssxref("-moz-column-rule-color") }}</dt>
+ <dt><code>-moz-box-shadow</code></dt>
+ <dt><code>-moz-border-image</code></dt>
+ <dt><code>-moz-column-rule</code></dt>
+ <dt><code>-moz-column-rule-width</code></dt>
+ <dt><code>-moz-column-rule-style</code></dt>
+ <dt><code>-moz-column-rule-color</code></dt>
  <dd>Firefox 3.5 ではこれらの CSS への Mozilla 拡張に対するサポートが追加されます。</dd>
  <dt>{{ cssxref("color_value#Mozilla_Extensions","-moz-nativehyperlinktext") }} カラー値</dt>
- <dd>この新しいカラー値はユーザのシステムのデフォルトのハイパーリンクの色を表します。</dd>
+ <dd>この新しいカラー値はユーザーのシステムのデフォルトのハイパーリンクの色を表します。</dd>
  <dt>{{ cssxref("-moz-window-shadow") }} プロパティおよび {{ cssxref(":-moz-system-metric(mac-graphite-theme)") }}<code> </code>擬似クラス</dt>
  <dd>これらの新しい CSS 機能はテーマ作成を手助けするために追加されました。</dd>
- <dt>{{ cssxref("-moz-appearance") }} 向けの新しい値</dt>
+ <dt><code>-moz-appearance</code> 向けの新しい値</dt>
  <dd><code>-moz-win-glass</code> および <code>-moz-mac-unified-toolbar</code> という値が <code>-moz-appearance</code> 向けに追加されました。</dd>
- <dt><a href="/ja/docs/CSS/Using_CSS_transforms" title="CSS/Using CSS transforms">CSS transforms の利用</a></dt>
- <dd>Firefox 3.5 では CSS Transform がサポートされます。詳細は {{ cssxref("-moz-transform") }} および {{ cssxref("-moz-transform-origin") }} を参照してください。</dd>
+ <dt><a href="/ja/docs/Web/CSS/CSS_Transforms/Using_CSS_transforms">CSS transforms の使用</a></dt>
+ <dd>Firefox 3.5 では CSS transform がサポートされます。詳細は {{ cssxref("-moz-transform") }} および {{ cssxref("-moz-transform-origin") }} を参照してください。</dd>
  <dt>{{ cssxref(":nth-child") }}</dt>
  <dt>{{ cssxref(":nth-last-child") }}</dt>
  <dt>{{ cssxref(":nth-of-type") }}</dt>
@@ -77,178 +71,154 @@ translation_of: Mozilla/Firefox/Releases/3.5
  <dt>{{ cssxref(":first-of-type") }}</dt>
  <dt>{{ cssxref(":last-of-type") }}</dt>
  <dt>{{ cssxref(":only-of-type") }}</dt>
- <dd>これらのセレクタがすべて Firefox 3.5 で新たにサポートされます。</dd>
+ <dd>これらのセレクターがすべて Firefox 3.5 で新たにサポートされます。</dd>
 </dl>
 
-<div>{{ 英語版章題("New DOM features") }}</div>
-
-<h4 id="新しい_DOM_の機能">新しい DOM の機能</h4>
+<h4 id="New_DOM_features">新しい DOM の機能</h4>
 
 <dl>
- <dt><a href="/ja/docs/DOM/Storage#localStorage" title="DOM/Storage#localStorage">localStorage</a></dt>
+ <dt><a class="internal" href="/ja/docs/Web/API/Web_Storage_API#localstorage">localStorage</a></dt>
  <dd>Firefox 3.5 では Web Storage の <code>localStorage</code> プロパティをサポートします。これは Web アプリケーションがクライアントのコンピュータ上にローカルにデータを保存する方法を提供します。</dd>
- <dt><a href="/ja/docs/Using_web_workers" title="Using web workers">Web Workers の使用</a></dt>
+ <dt><a class="internal" href="/ja/docs/Web/API/Web_Workers_API/Using_web_workers">Web Workers の使用</a></dt>
  <dd>Firefox 3.5 では Web アプリケーションでの簡単なマルチスレッドサポートを可能にする Web Workers をサポートします。</dd>
- <dt><a href="/ja/docs/Using_geolocation" title="Using geolocation">ジオロケーションの使用</a></dt>
- <dd>Firefox 3.5 では Geolocation API をサポートします。これにより Web アプリケーションはユーザの現在位置についての情報を提供するプロバイダがインストールされ有効化されていれば、その情報を保持することができます。</dd>
- <dt><a href="/ja/docs/DOM/Locating_DOM_elements_using_selectors" title="DOM/Locating DOM elements using selectors">セレクタを使用した DOM 要素の指定</a></dt>
+ <dt><a class="internal" href="/ja/docs/Web/API/Geolocation_API">位置情報の使用</a></dt>
+ <dd>Firefox 3.5 では Geolocation API をサポートします。これによりウェブアプリケーションはユーザの現在位置についての情報を提供するプロバイダがインストールされ有効化されていれば、その情報を保持することができます。</dd>
+ <dt><a class="internal" href="/ja/docs/Web/API/Document_object_model/Locating_DOM_elements_using_selectors">セレクターを使用した DOM 要素の指定</a></dt>
  <dd>Selectors API により与えられた選択ルールにマッチする要素を指定するために文書を検索できます。</dd>
- <dt><a href="/ja/docs/DOM/Mouse_gesture_events" title="DOM/Mouse gesture events">マウスジェスチャイベント</a></dt>
+ <dt><a class="internal" href="/ja/docs/Web/Events/Mouse_gesture_events">マウスジェスチャイベント</a></dt>
  <dd>Firefox 3.5 はトラックパッドスワイプのようなマウスジェスチャイベントをサポートします。</dd>
- <dt><a href="/ja/docs/DOM/NodeIterator" title="DOM/NodeIterator">NodeIterator オブジェクト</a></dt>
+ <dt><a class="internal" href="/ja/docs/Web/API/NodeIterator">NodeIterator オブジェクト</a></dt>
  <dd><code>NodeIterator</code> オブジェクトは DOM サブツリーのノードのリストを繰り返し処理するためのサポートを提供します。</dd>
- <dt><a href="/ja/docs/Gecko-Specific_DOM_Events#MozAfterPaint" title="Gecko-Specific DOM Events#MozAfterPaint">MozAfterPaint イベント</a></dt>
+ <dt><a class="internal" href="/ja/docs/Gecko-Specific_DOM_Events#MozAfterPaint">MozAfterPaint イベント</a></dt>
  <dd>この新しい DOM イベントはウィンドウで塗り直し後に送られます。</dd>
- <dt><a href="/ja/docs/Gecko-Specific_DOM_Events#MozMousePixelScroll" title="Gecko-Specific DOM Events#MozMousePixelScroll">MozMousePixelScroll イベント</a></dt>
+ <dt><a class="internal" href="/ja/docs/Gecko-Specific_DOM_Events#MozMousePixelScroll">MozMousePixelScroll イベント</a></dt>
  <dd>この新しい DOM イベントにより行ベースのスクロールイベントの代わりにピクセルベースのマウススクロールホイールイベントを検知できます。</dd>
 </dl>
 
-<div>{{ 英語版章題("New JavaScript features") }}</div>
-
-<h4 id="新しい_JavaScript_の機能">新しい JavaScript の機能</h4>
+<h4 id="New_JavaScript_features">新しい JavaScript の機能</h4>
 
 <dl>
- <dt><a href="/ja/docs/New_in_JavaScript_1.8.1" title="New in JavaScript 1.8.1">JavaScript 1.8.1 の新機能</a></dt>
+ <dt><a class="internal" href="/ja/docs/Web/JavaScript/New_in_JavaScript/1.8.1">JavaScript 1.8.1 の新機能</a></dt>
  <dd>JavaScript 1.8.1 における変更のすべての概要。</dd>
- <dt><a href="/ja/docs/Core_JavaScript_1.5_Reference/Global_Objects/Object/GetPrototypeOf" title="Core JavaScript 1.5 Reference/Global Objects/Object/GetPrototypeOf">Object.getPrototypeOf()</a></dt>
+ <dt><a class="internal" href="/ja/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf">Object.getPrototypeOf()</a></dt>
  <dd>このメソッドは指定されたオブジェクトのプロトタイプを返します。</dd>
- <dt><a href="/ja/docs/Using_native_JSON" title="Using_native_JSON">ネイティブ JSON の使用</a></dt>
+ <dt><a class="internal" href="/ja/docs/conflicting/Web/JavaScript/Reference/Global_Objects/JSON">ネイティブ JSON の使用</a></dt>
  <dd>Firefox 3.5 は JSON をネイティブでサポートします。</dd>
  <dt>String オブジェクトの新しい trim メソッド</dt>
- <dd>String オブジェクトに <a href="/ja/docs/Core_JavaScript_1.5_Reference/Global_Objects/String/Trim" title="Core JavaScript 1.5 Reference/Global Objects/String/Trim">trim()</a>、<a href="/ja/docs/Core_JavaScript_1.5_Reference/Global_Objects/String/TrimLeft" title="Core JavaScript 1.5 Reference/Global Objects/String/TrimLeft">trimLeft()</a>、そして <a href="/ja/docs/Core_JavaScript_1.5_Reference/Global_Objects/String/TrimRight" title="Core JavaScript 1.5 Reference/Global Objects/String/TrimRight">trimRight()</a> メソッドが定義されました。</dd>
+ <dd>String オブジェクトに <a class="internal" href="/ja/docs/Web/JavaScript/Reference/Global_Objects/String/trim" rel="internal">trim()</a>、<a class="internal" href="/ja/docs/Web/JavaScript/Reference/Global_Objects/String/trimStart" rel="internal">trimLeft()</a>、そして <a class="internal" href="/ja/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd" rel="internal">trimRight()</a> メソッドが定義されました。</dd>
 </dl>
 
-<div>{{ 英語版章題("Networking") }}</div>
-
-<h4 id="ネットワーク機能">ネットワーク機能</h4>
+<h4 id="Networking">ネットワーク機能</h4>
 
 <dl>
- <dt><a href="/ja/docs/HTTP_access_control" title="HTTP access control">HTTP 向けのクロスサイトアクセスコントロール</a></dt>
- <dd>Firefox 3.5 では、サーバーがサポートする場合に、<code><a href="/ja/docs/XMLHttpRequest" title="XMLHttpRequest">XMLHttpRequest</a></code> によるものも含む HTTP リクエストでドメインを超える動作が可能になりました。</dd>
- <dt><code><a href="/ja/docs/Using_XMLHttpRequest#Monitoring%20progress" title="Using XMLHttpRequest#Monitoring progress">XMLHttpRequest</a></code><a href="/ja/docs/Using_XMLHttpRequest#Monitoring%20progress" title="Using XMLHttpRequest#Monitoring progress"> のための Progress イベント</a></dt>
+ <dt><a href="/ja/docs/Web/HTTP/CORS">HTTP 向けのクロスサイトアクセスコントロール</a></dt>
+ <dd>Firefox 3.5 では、サーバーがサポートする場合に、<a class="internal" href="/ja/docs/Web/API/XMLHttpRequest"><code>XMLHttpRequest</code></a> によるものも含む HTTP リクエストでドメインを超える動作が可能になりました。</dd>
+ <dt><code><a class="internal" href="/ja/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#monitoring_progress">XMLHttpRequest</a></code><a href="/ja/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#monitoring_progress"> のための Progress イベント</a></dt>
  <dd>Progress イベントが拡張がリクエストの進捗を監視できるようにするために提供されるようになりました。</dd>
  <dt>同期 <code>XMLHttpRequest</code>サポートの改善</dt>
- <dd><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=340345" title="https://bugzilla.mozilla.org/show_bug.cgi?id=340345">DOM Timeout</a> と <a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=333198" title="https://bugzilla.mozilla.org/show_bug.cgi?id=333198">Input Events</a> が同期 <code>XMLHttpRequest中に抑制されるようになりました。</code></dd>
- <dt><a href="/ja/docs/Controlling_DNS_prefetching" title="Controlling DNS prefetching">DNS プリフェッチの制御</a></dt>
+ <dd><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=340345">DOM Timeout</a> と <a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=333198">Input Events</a> が同期 <code>XMLHttpRequest中に抑制されるようになりました。</code></dd>
+ <dt><a href="/ja/docs/Web/HTTP/Headers/X-DNS-Prefetch-Control">DNS プリフェッチの制御</a></dt>
  <dd>Firefox 3.5 では DNS プリフェッチが提供され、それにより現在のページに含まれるリンクのドメイン名解決が事前に行われ、リンクが実際にクリックされたときの時間を節約しま す。この記事では Web サイト側でプリフェッチを無効にする、もしくは、プリフェッチの動作を調整する方法について説明しています。</dd>
 </dl>
 
-<div>{{ 英語版章題("New SVG features") }}</div>
-
-<h4 id="新しい_Canvas_の機能">新しい Canvas の機能</h4>
+<h4 id="New_Canvas_features">新しい Canvas の機能</h4>
 
 <dl>
- <dt><code><a href="/ja/docs/Drawing_text_using_a_canvas" title="Drawing text using a canvas">Canvas</a></code><a href="/ja/docs/Drawing_text_using_a_canvas" title="Drawing text using a canvas"> 要素向けの HTML5 テキスト API</a></dt>
+ <dt><code><a href="/ja/docs/Web/API/Canvas_API/Tutorial/Drawing_text">Canvas</a></code><a href="/ja/docs/Web/API/Canvas_API/Tutorial/Drawing_text"> 要素向けの HTML5 テキスト API</a></dt>
  <dd>Canvas 要素が HTML5 テキスト API をサポートするようになりました。</dd>
- <dt><code><a href="/ja/docs/Canvas_tutorial/Applying_styles_and_colors#Shadows" title="Canvas tutorial/Applying styles and colors#Shadows">Canvas</a></code><a href="/ja/docs/Canvas_tutorial/Applying_styles_and_colors#Shadows" title="Canvas tutorial/Applying styles and colors#Shadows"> での影付き効果</a></dt>
+ <dt><code><a href="/ja/docs/Canvas_tutorial/Applying_styles_and_colors#Shadows">Canvas</a></code><a href="/ja/docs/Canvas_tutorial/Applying_styles_and_colors#Shadows"> での影付き効果</a></dt>
  <dd>Canvas での影付き効果がサポートされるようになりました。</dd>
- <dt><a href="/ja/docs/HTML/Canvas/Pixel_manipulation_with_canvas#Creating_an_ImageData_object" title="En/HTML/Canvas/Pixel manipulation with canvas#Creating an ImageData object"><code>createImageData()</code></a></dt>
+ <dt><a href="/ja/docs/HTML/Canvas/Pixel_manipulation_with_canvas#Creating_an_ImageData_object"><code>createImageData()</code></a></dt>
  <dd>Canvas の <code>createImageData()</code> メソッドがサポートされるようになりました。こ<code>のメソッドを利用することで、ImageData</code> オブジェクトを必要なときに自動的に作成させるのではなく、コードで明示的に作成することができます。オブジェクトを作成する必要性を無くすことができるので、このメソッドで他の <code>ImageData</code> を扱うメソッドのパフォーマンスを改善することができます。</dd>
  <dt><code>moz-opaque</code> 属性</dt>
  <dd><code>moz-opaque</code> DOM 属性が追加されたことにより、Canvas は半透明な要素があるかどうか知ることができます。Canvas が半透明な要素がないことを知った場合、ペインティングパフォーマンスが最適化されます。</dd>
 </dl>
 
-<div>{{ 英語版章題("New SVG features") }}</div>
-
-<h4 id="新しい_SVG_の機能">新しい SVG の機能</h4>
+<h4 id="New_SVG_features">新しい SVG の機能</h4>
 
 <dl>
- <dt><a href="/ja/docs/Applying_SVG_effects_to_HTML_content" title="Applying SVG effects to HTML content">HTML の内容への SVG 効果の適用</a></dt>
+ <dt><a href="/ja/docs/Web/SVG/Applying_SVG_effects_to_HTML_content">HTML の内容への SVG 効果の適用</a></dt>
  <dd>SVG 効果を HTML および XHTML の内容に適用できるようになりました。この記事はその方法について説明しています。</dd>
 </dl>
 
-<div>{{ 英語版章題("Miscellaneous new features") }}</div>
-
-<h4 id="雑多な新機能">雑多な新機能</h4>
+<h4 id="Miscellaneous_new_features">その他の新機能</h4>
 
 <dl>
- <dt><a href="/ja/docs/ICC_color_correction_in_Firefox" title="ICC color correction in Firefox">Firefox での ICC カラー補正</a></dt>
+ <dt><a href="/ja/docs/ICC_color_correction_in_Firefox">Firefox での ICC カラー補正</a></dt>
  <dd>Firefox 3.5 では タグ付けられた画像に対して ICC カラー補正がサポートされています。</dd>
- <dt><a href="/ja/docs/HTML/Element/Script" title="HTML/Element/Script">script</a> 要素で defer 属性がサポート</dt>
+ <dt><a href="/ja/docs/Web/HTML/Element/script">script</a> 要素で defer 属性がサポート</dt>
  <dd>この属性はスクリプトが実行し終わるの待たずにブラウザにパースし描画し続けることを選択させます。</dd>
 </dl>
 
-<div>{{ 英語版章題("Other improvements") }}</div>
-
-<h3 id="その他の改善">その他の改善</h3>
+<h3 id="Other_improvements">その他の改善</h3>
 
 <ul>
- <li>Text ノードの <a href="/ja/docs/DOM/Text.wholeText" title="DOM/Text.wholeText"><code>wholeText</code></a> プロパティ と <code><a href="/ja/docs/DOM/Text.replaceWholeText" title="DOM/Text.replaceWholeText">replaceWholeText()</a></code> メソッドが実装されました。</li>
- <li><code><a href="/ja/docs/DOM/Element.children" title="DOM/Element.children">element.children</a></code> プロパティが追加されました。これは与えられた要素の子要素の<em>コレクション</em>を返します。</li>
- <li>DOM <a href="/ja/docs/DOM/element" title="DOM/Element">Element</a> オブジェクトで Element Traversal API がサポートされました。</li>
- <li>HTML document ノードを <code><a href="/ja/docs/DOM/Node.CloneNode" title="DOM/Node.cloneNode">cloneNode()</a></code> を用いて複製できるようになりました。</li>
- <li>非標準であるDOM の <code>getBoxObjectFor()</code> メソッドが削除されました。代わりとして <a href="/ja/docs/DOM/element.getBoundingClientRect" title="DOM/Element.getBoundingClientRect"><code>getBoundingClientRect()</code></a> を利用すべきです。</li>
+ <li>Text ノードの <code><a class="internal" href="/en-US/docs/Web/API/Text/wholeText" rel="internal">wholeText</a></code> プロパティ と <code><a class="internal" href="/en-US/docs/Web/API/Text/replaceWholeText" rel="internal">replaceWholeText()</a></code> メソッドが実装されました。</li>
+ <li><code><a class="internal" href="/en-US/docs/Web/API/Element/children" rel="internal">element.children</a></code> プロパティが追加されました。これは与えられた要素の子要素の<em>コレクション</em>を返します。</li>
+ <li>{{ domxref("element.contentEditable") }} プロパティに対応するようになり、編集可能な要素に対応するようになりました。</li>
+ <li>DOM <a class="internal" href="/en-US/docs/Web/API/Element" rel="internal">Element</a> オブジェクトで Element Traversal API がサポートされました。</li>
+ <li>HTML document ノードを <a class="internal" href="/en-US/docs/Web/API/Node/cloneNode"><code>cloneNode()</code></a> を用いて複製できるようになりました。</li>
+ <li>非標準であるDOM の <code>getBoxObjectFor()</code> メソッドが削除されました。代わりとして <a class="internal" href="/en-US/docs/Web/API/Element/getBoundingClientRect"><code>getBoundingClientRect()</code></a> を利用すべきです。</li>
  <li>伝達された DOM イベントを再伝達できるようになりました。これにより Firefox 3.5 は Acid 3 test 30 をパスします。</li>
  <li>DOM 2 Range ハンドリングが改善されました。</li>
- <li>非 Chrome スコープにおいて、例外でキャッチされるオブジェクトがスローされたオブジェクトを含む <a href="/ja/docs/XPConnect" title="XPConnect">XPConnect</a> ラッパーではなく実際にスローされたオブジェクトになりました。</li>
+ <li>非 Chrome スコープにおいて、例外でキャッチされるオブジェクトがスローされたオブジェクトを含む <a class="internal" href="/en-US/docs/XPConnect">XPConnect</a> ラッパーではなく実際にスローされたオブジェクトになりました。</li>
  <li>SVG ID 参照が動的な変更に対応するようになりました。</li>
  <li>SVG フィルターが <code>foreignObject</code> でも動作するようになりました。</li>
- <li>互換性のために <code>GetSVGDocument()</code> メソッドが <a href="/ja/docs/HTML/Element/object" title="HTML/Element/object">object</a> および <a href="/ja/docs/HTML/Element/iframe" title="HTML/Element/iframe">iframe</a> 要素に追加されました。</li>
- <li>JavaScript においてオブジェクトおよび配列の初期化子によるプロパティの暗黙的な設定ではセッターの定義を行わないようになりました。詳細は <a href="/web-tech/2009/04/29/object-and-array-initializers-should-not-invoke-setters-when-evaluated" title="https://developer.mozilla.org/editor/fckeditor/core/editor/web-tech/2009/04/29/object-and-array-initializers-should-not-invoke-setters-when-evaluated/">オブジェクトおよび配列の初期化子は評価時にセッターの定義を行うべきではない</a> というブログ投稿を参照してください。</li>
+ <li>互換性のために <code>GetSVGDocument()</code> メソッドが <a class="internal" href="/en-US/docs/Web/HTML/Element/object"><code>object</code></a> および <a class="internal" href="/en-US/docs/Web/HTML/Element/iframe"><code>iframe</code></a> 要素に追加されました。</li>
+ <li>JavaScript においてオブジェクトおよび配列の初期化子によるプロパティの暗黙的な設定ではセッターの定義を行わないようになりました。詳細は <a href="/web-tech/2009/04/29/object-and-array-initializers-should-not-invoke-setters-when-evaluated" title="web-tech/2009/04/29/object-and-array-initializers-should-not-invoke-setters-when-evaluated/">オブジェクトおよび配列の初期化子は評価時にセッターの定義を行うべきではない</a> というブログ投稿を参照してください。</li>
  <li><code>gDownloadLastDir.path</code> 変数は、パスではなく {{ interface("nsIFile") }} を参照しているので、 <code>gDownloadLastDir.file</code> に名称変更されました。</li>
+ <li><code>gDownloadLastDirPath</code> 変数は、パスではなく {{ interface("nsIFile") }} を参照しているので、 <code>gDownloadLastDirFile</code> に名称変更されました。</li>
  <li>Firefox 3.5 から、<code>XPCNativeWrapper</code> オートメーションを得る Chrome パッケージでの <code>data:</code> バインディングを利用することはできなくなります。</li>
 </ul>
 
-<div>{{ 英語版章題("For XUL and add-on developers") }}</div>
+<h3 id="For_XUL_and_add-on_developers">XUL とアドオン開発者向け</h3>
 
-<h3 id="XUL_とアドオン開発者向け">XUL とアドオン開発者向け</h3>
+<p>拡張開発者であるなら、<a href="/ja/docs/Mozilla/Firefox/Releases/3.5/Updating_extensions" title="Updating extensions for Firefox 3.1">Firefox 3.5 向けに拡張を更新する</a> から読み始めるべきです。その記事ではあなたの拡張に影響しうる変更を知る上で役立つ概観を提供しています。</p>
 
-<p>拡張開発者であるなら、<a href="/ja/docs/Updating_extensions_for_Firefox_3.1" title="Updating extensions for Firefox 3.1">Firefox 3.5 向けに拡張を更新する</a> から読み始めるべきです。その記事ではあなたの拡張に影響しうる変更を知る上で役立つ概観を提供しています。</p>
-
-<div>{{ 英語版章題("New components and functionality") }}</div>
-
-<h4 id="新しいコンポーネントと機能">新しいコンポーネントと機能</h4>
+<h4 id="New_components_and_functionality">新しいコンポーネントと機能</h4>
 
 <dl>
- <dt><a href="/ja/docs/Supporting_private_browsing_mode" title="Supporting private browsing mode">プライベートブラウジングモードのサポート</a></dt>
+ <dt><a class="internal" href="/en-US/Supporting_private_browsing_mode">プライベートブラウジングモードのサポート</a></dt>
  <dd>Firefox 3.5 ではプライベートブラウジングモードが提供されます。これはユーザの活動を記録しません。拡張はこの記事で挙げるガイドラインに従ってプライベートブラウジングをサポートすることができます。</dd>
- <dt><a href="/ja/docs/Security_changes_in_Firefox_3.5" title="Security changes in Firefox 3.5">Firefox 3.5 でのセキュリティの変更</a></dt>
+ <dt><a class="internal" href="/en-US/Security_changes_in_Firefox_3.5">Firefox 3.5 でのセキュリティの変更</a></dt>
  <dd>この記事は Firefox 3.5 でのセキュリティ関連の変更をカバーしています。</dd>
- <dt><a href="/ja/docs/Theme_changes_in_Firefox_3.5" title="Theme changes in Firefox 3.5">Firefox 3.5 でのテーマの変更</a></dt>
+ <dt><a class="internal" href="/en-US/Theme_changes_in_Firefox_3.5">Firefox 3.5 でのテーマの変更</a></dt>
  <dd>この記事は Firefox 3.5 でのテーマ関連の変更をカバーしています。</dd>
- <dt><a href="/ja/docs/Monitoring_WiFi_access_points" title="Monitoring WiFi access points">WiFi アクセスポイントのモニタリング</a></dt>
+ <dt><a class="internal" href="/en-US/Monitoring_WiFi_access_points">WiFi アクセスポイントのモニタリング</a></dt>
  <dd>UniversalXPConnect 特権を持つコードで有効なアクセスポイントの一覧がモニタリング可能になり、個々の SSIDs、MAC アドレス、シグナル強度の情報が取得できます。 これを Geolocation と連携して用いることで WiFi ベースのロケーションサービスを提供できます。</dd>
 </dl>
 
-<div>{{ 英語版章題("Notable changes and improvements") }}</div>
-
-<h4 id="注目すべき変更と改善">注目すべき変更と改善</h4>
+<h4 id="Notable_changes_and_improvements">注目すべき変更と改善</h4>
 
 <ul>
- <li>XUL <code><a href="../../../../en/XUL/textbox" rel="internal">textbox</a></code> ウィジェットが検索フィールドとして利用するための <code><a href="../../../../en/XUL/Attribute/textbox.type" rel="internal">search</a></code> type を提供するようになりました。</li>
- <li>ウィンドウ間のタブのドラッグ＆ドロップのサポートのために、<code><a href="/ja/docs/XUL/browser" rel="internal" title="XUL/browser">browser</a></code> ウィジェットに <code><span class="lang lang-en"><a href="/ja/docs/XUL/Method/SwapDocShells" title="XUL/Method/swapDocShells">swapDocShells()</a></span></code>メソッドが定義されました。</li>
- <li><code><a href="/ja/docs/XUL/panel" rel="internal" title="XUL/panel">panel</a></code>　要素に <code><span class="lang lang-en"><a href="/ja/docs/XUL/Attribute/panel.level" rel="internal" title="XUL/Attribute/panel.level">level</a></span></code>属性が追加されました。 これは panel を他のアプリケーションの手前に表示するか、単純に panel が含まれるウィンドウの手前に表示するかどうかを指定できます。</li>
- <li>XUL 要素が<code> clientHeight</code><span style="font-family: monospace;">、</span><code>clientWidth</code><span style="font-family: monospace;">、</span><code>scrollHeight</code>、および <code>scrollWidth </code>プロパティをサポートするようになりました。</li>
- <li><code><a href="/ja/docs/XUL/keyset" title="XUL/Keyset">keyset</a></code> 要素に <code>disabled</code> 属性が追加されました。</li>
- <li>加えて、<code>keyset</code> 要素はノードの <code><a href="/ja/docs/DOM/Node.removeChild" title="DOM/Node.removeChild">removeChild()</a></code> メソッドを用いて削除可能になりました。</li>
- <li>{{ Interface("mozIStorageStatement") }} には <code>initialize()</code> メソッドがありましたが、削除されました。利用者は新しいステートメントオブジェクトを得るための代替として {{ Ifmethod("mozIStorageConnection", "createStatement") }} メソッドを使うべきです。</li>
- <li><a href="/ja/docs/Storage" title="Storage">Storage</a> API が非同期リクエストのサポートを提供するようになりました。</li>
- <li>{{ Interface("nsICookie2") }} インターフェースに新しく <code>creationTime</code> 属性が追加され、Cookie が作成された時間を取得できるようになりました。</li>
- <li>プロトコルが登録することを許可されることを保証するために Chrome 登録の間にチェックされる{{ Interface("nsIProtocolHandler") }} へのフラグが追加されました (<code>URI_IS_LOCAL_RESOURCE</code>)。</li>
+ <li>XUL <code><a class="internal" href="/en-US/docs/XUL/textbox" rel="internal">textbox</a></code> ウィジェットが検索フィールドとして利用するための <code><a class="internal" href="/en-US/docs/XUL/Attribute/textbox.type" rel="internal">search</a></code> type を提供するようになりました。</li>
+ <li>ウィンドウ間のタブのドラッグ＆ドロップのサポートのために、<a class="internal" href="/en-US/docs/XUL/browser"><code>browser</code></a> ウィジェットに <a class="internal" href="/en-US/XUL/Method/SwapDocShells"><code>swapDocShells()</code></a> メソッドが定義されました。</li>
+ <li><a class="internal" href="/en-US/docs/XUL/panel"><code>panel</code></a> 要素に <a class="internal" href="/en-US/docs/XUL/Attribute/panel.level"><code>level</code></a> 属性が追加されました。 これは panel を他のアプリケーションの手前に表示するか、単純に panel が含まれるウィンドウの手前に表示するかどうかを指定できます。</li>
+ <li>XUL 要素が <code>clientHeight</code>、<code>clientWidth</code>、<code>scrollHeight</code>、<code>scrollWidth </code> プロパティをサポートするようになりました。</li>
+ <li><a class="internal" href="/en-US/docs/XUL/keyset"><code>keyset</code></a>s now include a <code>disabled</code> 要素に <code>disabled</code> 属性が追加されました。</li>
+ <li>加えて、 <code>keyset</code> 要素はノードの <a class="internal" href="/en-US/docs/Web/API/Node/removeChild"><code>removeChild()</code></a> メソッドを用いて削除可能になりました。</li>
+ <li><code><a href="/en-US/docs/mozIStorageStatement" rel="internal">mozIStorageStatement</a></code> には <code>initialize()</code> メソッドがありましたが、削除されました。利用者は新しいステートメントオブジェクトを得るための代替として <code><a href="/en-US/docs/mozIStorageConnection#createStatement()" rel="internal">createStatement()</a></code> メソッドを使うべきです。</li>
+ <li><a class="internal" href="/en-US/docs/Storage">Storage</a> API が非同期リクエストのサポートを提供するようになりました。</li>
+ <li><a class="internal" href="/en-US/docs/XPCOM_Interface_Reference/nsICookie2"><code>nsICookie2</code></a> インターフェースに新しく <code>creationTime</code> 属性が追加され、Cookie が作成された時間を取得できるようになりました。</li>
+ <li>プロトコルが登録することを許可されることを保証するために Chrome 登録の間にチェックされる <code><a class="internal" href="/en-US/docs/nsIProtocolHandler" rel="internal">nsIProtocolHandler</a></code> へのフラグが追加されました (<code>URI_IS_LOCAL_RESOURCE</code>)。</li>
  <li>Linux で Firefox がプラグインを探すために <code>/usr/lib/mozilla/plugins</code> を見るようになりました。以前にサポートされていた場所も同様に検索対象です。</li>
- <li>プラグイン API がプライベートブラウジングモードのサポートを含むために更新されました。これにより、<code>NPNprivateModeBool</code> を用いているプライベートブラウジングモードの状態を調べるために、<a href="/ja/docs/NPN_GetValue" title="NPN GetValue">NPN_GetValue()</a> を使用できるようになりました。</li>
+ <li>プラグイン API がプライベートブラウジングモードのサポートを含むために更新されました。これにより、<code>NPNprivateModeBool</code> を用いているプライベートブラウジングモードの状態を調べるために、 <a class="internal" href="/en-US/docs/NPN_GetValue"><code>NPN_GetValue()</code></a> を使用できるようになりました。</li>
 </ul>
 
-<div>{{ 英語版章題("New features for end users") }}</div>
+<h2 id="New_features_for_end_users">エンドユーザ向け新機能</h2>
 
-<h2 id="エンドユーザ向け新機能">エンドユーザ向け新機能</h2>
-
-<div>{{ 英語版章題("User experience") }}</div>
-
-<h3 id="ユーザエクスペリエンス">ユーザエクスペリエンス</h3>
+<h3 id="User_experience">ユーザーエクスペリエンス</h3>
 
 <dl>
  <dt>ロケーションアウェアブラウジング</dt>
- <dd>あなたが選択するなら、Firefox 3.5 が Web サイトと現在の位置についての情報を共有することを許可できます。Firefox 3.5 はあなたが接続しているネットワークについての情報をあなたの位置を共有するために用いることができます。もちろん、プライバシーを確保するために、そう する前にあなたに許可を求めます。</dd>
+ <dd>選択次第で、 Firefox 3.5 がウェブサイトと現在の位置についての情報を共有できるようになります。 Firefox 3.5 は接続しているネットワークについての情報を位置を共有するために用いることができます。もちろん、プライバシーを確保するために、そうする前に許可を求めます。</dd>
  <dt>オープンなオーディオとビデオのサポート</dt>
  <dd>Firefox 3.5 は、オーディオのための WAV 同様、オープンな Ogg フォーマットを用いた埋め込みビデオおよびオーディオをサポートします。プラグインは必要なく、何かあるいはどうやってもあなたのプラットフォームで利用出来ないものをインストールする必要があるという旨のエラーメッセージに混乱することはありません。</dd>
  <dt>ローカルデータストレージ</dt>
- <dd>Web アプリケーションはあなたのコンピュータにデータを保存するために Web Storage のローカルストレージ機能を利用できるようになります。これはサイト設定からより複雑なデータまであらゆるものにとって素晴らしく役立つものです。</dd>
+ <dd>ウェブアプリケーションはあなたのコンピュータにデータを保存するために Web Storage のローカルストレージ機能を利用できるようになります。これはサイト設定からより複雑なデータまであらゆるものにとって素晴らしく役立つものです。</dd>
 </dl>
 
-<div>{{ 英語版章題("Security and privacy") }}</div>
-
-<h3 id="セキュリティとプライバシー">セキュリティとプライバシー</h3>
+<h3 id="Security_and_privacy">セキュリティとプライバシー</h3>
 
 <dl>
  <dt>プライベートブラウジング</dt>
@@ -257,17 +227,15 @@ translation_of: Mozilla/Firefox/Releases/3.5
  <dd>プライバシー設定画面はユーザがプライベート情報をより細かくコントロールできるようにするために完全にデザインし直されました。ユー ザは履歴、Cookie、ダウンロード、フォーム入力のような情報を保持、破棄するかどうか選択できます。 さらに、ユーザは履歴とブックマークの内容をそれぞれアドレスバーの自動サジェストに含むかどうか指定できます。 ですから、アドレスバーでタイプ中に意図せずプライベートな Web アドレスがポップアップすることを防ぐことができます。</dd>
 </dl>
 
-<div>{{ 英語版章題("Performance") }}</div>
-
-<h3 id="パフォーマンス">パフォーマンス</h3>
+<h3 id="Performance">パフォーマンス</h3>
 
 <dl>
  <dt>より速い JavaScript パフォーマンス</dt>
- <dd>新しい TraceMonkey JavaScript エンジンを持つ Firefox 3.5 では "AJAX" の "J" である、JavaScript が劇的にスピードアップしています。Web アプリケーションは Firefox 3 よりももっとより速くなります。</dd>
+ <dd>新しい TraceMonkey JavaScript エンジンを持つ Firefox 3.5 では "AJAX" の "J" である、JavaScript が劇的にスピードアップしています。ウェブアプリケーションは Firefox 3 よりももっとより速くなります。</dd>
  <dt>より速いページレンダリング</dt>
- <dd>"Speculative parsing（投機的解釈）" のような技術のおかげで、 Firefox 3.5 では Web コンテンツがより速く描画されます。あなたのユーザは「Firefox 3.5 ではコンテンツがより速く描画される」ということ以外は知る必要がありません。</dd>
+ <dd>"Speculative parsing（投機的解釈）" のような技術のおかげで、 Firefox 3.5 ではウェブコンテンツがより速く描画されます。ユーザーは「Firefox 3.5 ではコンテンツがより速く描画される」ということ以外は知る必要がありません。</dd>
 </dl>
 
-<h2 id="See_also" name="See_also">参照</h2>
+<h2 id="See_also">関連情報</h2>
 
 <div>{{Firefox_for_developers('3')}}</div>

--- a/files/ja/mozilla/firefox/releases/3/dom_improvements/index.html
+++ b/files/ja/mozilla/firefox/releases/3/dom_improvements/index.html
@@ -1,5 +1,5 @@
 ---
-title: DOM improvements in Firefox 3
+title: Firefox 3 での DOM の改良
 slug: Mozilla/Firefox/Releases/3/DOM_improvements
 tags:
   - DOM
@@ -7,23 +7,26 @@ tags:
 translation_of: Mozilla/Firefox/Releases/3/DOM_improvements
 original_slug: DOM_improvements_in_Firefox_3
 ---
-<p>Firefox 3 では、特に、他のブラウザによる独自 DOM 拡張 のサポートに関するものを含む、多くの <a href="ja/DOM">Document Object Model</a> (DOM) 実装が追加されました。この記事は、これらの実装の一覧と詳細なドキュメントへのリンクを提供します。 </p>
-<ul><li>Internet Explorer の <code><a href="ja/DOM/element.clientTop">clientTop</a></code> と <code><a href="ja/DOM/element.clientLeft">clientLeft</a></code> DOM 拡張がサポートされました。
-</li><li><code><a href="ja/DOM/window.fullScreen">window.fullScreen</a></code> プロパティは、たとえ Web コンテンツから読み出されても常に正確に計算されるようになりました。以前は不正確に <code>false</code> を返していたでしょう。({{ Bug(127013) }})
-</li><li> <code><a href="ja/DOM/element.getClientRects">getClientRects</a></code> と <code><a href="ja/DOM/element.getBoundingClientRect">getBoundingClientRect</a></code> DOM 拡張がサポートされました。({{ Bug(174397) }} を参照)
-</li><li> Internet Explorer の <code><a href="ja/DOM/document.elementFromPoint">elementFromPoint</a></code> DOM 拡張がサポートされました。 ({{ Bug(199692) }})
-</li><li> Internet Explorer の <code><a href="ja/DOM/element.oncut">oncut</a></code>、<code><a href="ja/DOM/element.oncopy">oncopy</a></code>、 <code><a href="ja/DOM/element.onpaste">onpaste</a></code> DOM 拡張がサポートされました ({{ Bug(280959) }})。
-</li><li>特権コード限定のゲッタ <code>Node.nodePrincipal</code>、<code>Node.baseURIObject</code>、<code><a href="ja/DOM/document.documentURIObject">document.documentURIObject</a></code> が追加されました。Chrome コードは、(<code><a href="ja/XPCNativeWrapper">XPCNativeWrapper</a></code> の <code>wrappedJSObject</code> などの) ラップされていないコンテンツオブジェクトに対して、これらのプロパティに触れては (取得または設定をしては) いけません。詳細は {{ Bug(324464) }} を参照してください。
-</li><li> Web Applications 1.0 (HTML5) の <code><a href="ja/DOM/document.getElementsByClassName">getElementsByClassName()</a></code> DOM メソッドがサポートされました。
-</li><li> Web Applications 1.0 (HTML5) の <code><a href="ja/DOM/window.postMessage">window.postMessage</a></code> DOM メソッドがサポートされました。このメソッドは、制限された、同じドメインに限らないウィンドウ間でのクライアントサイド通信を行う選択フォームを可能にします。 </li><li> アクセラレーションキーが押された場合、<code>keypress</code> イベントの <code>charCode</code> の値は ASCII 文字に変更されます。それ以外の場合、<code>charCode</code> はそのままの文字です（&lt;kbd&gt;Shift&lt;/kbd&gt; 状態を除く）。<a href="ja/Gecko_Keypress_Event">Gecko Keypress Event</a> を参照してください。
-</li></ul>
-<p>{{ 英語版章題("See also") }}
-</p>
-<h3 id=".E5.8F.82.E7.85.A7" name=".E5.8F.82.E7.85.A7">参照</h3>
-<ul><li><a href="ja/Firefox_3_for_developers">Firefox 3 for developers</a>
-</li><li><a href="ja/CSS_improvements_in_Firefox_3">CSS improvements in Firefox 3</a>
-</li><li><a href="ja/DOM">DOM</a>
-</li></ul>
-<div class="noinclude">
-</div>
-{{ languages( { "en": "en/DOM_improvements_in_Firefox_3", "es": "es/Mejoras_DOM_en_Firefox_3", "fr": "fr/Am\u00e9liorations_DOM_dans_Firefox_3", "pl": "pl/Poprawki_DOM_w_Firefoksie_3" } ) }}
+<div>{{FirefoxSidebar}}</div>
+
+<p>Firefox 3 では、特に、他のブラウザによる独自 DOM 拡張 のサポートに関するものを含む、多くの <a href="/ja/docs/Web/API/Document_Object_Model">Document Object Model</a> (DOM) 実装が追加されました。この記事は、これらの実装の一覧と詳細なドキュメントへのリンクを提供します。 </p>
+
+<ul>
+ <li>Internet Explorer の <code><a href="/ja/docs/Web/API/Element/clientTop">clientTop</a></code> と <code><a href="/ja/docs/Web/API/Element/clientLeft">clientLeft</a></code> DOM 拡張がサポートされました。</li>
+ <li><code><a href="/ja/docs/Web/API/Window/fullScreen">window.fullScreen</a></code> プロパティは、たとえウェブコンテンツから読み出されても常に正確に計算されるようになりました。以前は不正確に <code>false</code> を返していたでしょう。({{ Bug(127013) }})</li>
+ <li><code><a href="/ja/docs/Web/API/Element/getClientRects">getClientRects</a></code> と <code><a href="/ja/docs/Web/API/Element/getBoundingClientRect">getBoundingClientRect</a></code> DOM 拡張がサポートされました。({{ Bug(174397) }} を参照)</li>
+ <li>Internet Explorer の <code><a href="/ja/docs/Web/API/Document/elementFromPoint">elementFromPoint</a></code> DOM 拡張がサポートされました。 ({{ Bug(199692) }})</li>
+ <li> Internet Explorer の <code><a href="/ja/docs/Web/API/HTMLElement/oncut">oncut</a></code>、<code><a href="/ja/docs/Web/API/HTMLElement/oncopy">oncopy</a></code>、 <code><a href="/ja/docs/Web/API/HTMLElement/onpaste">onpaste</a></code> DOM 拡張がサポートされました ({{ Bug(280959) }})。</li>
+ <li>特権コード限定のゲッター <code>Node.nodePrincipal</code>、<code>Node.baseURIObject</code>、<code><a href="/ja/docs/Web/API/Document/documentURIObject">document.documentURIObject</a></code> が追加されました。Chrome コードは、(<code><a href="/ja/XPCNativeWrapper">XPCNativeWrapper</a></code> の <code>wrappedJSObject</code> などの) ラップされていないコンテンツオブジェクトに対して、これらのプロパティに触れては (取得または設定をしては) いけません。詳細は {{ Bug(324464) }} を参照してください。</li>
+ <li>Web Applications 1.0 (HTML5) の <code><a href="/ja/docs/Web/API/Document/getElementsByClassName">getElementsByClassName()</a></code> DOM メソッドがサポートされました。</li>
+ <li> Web Applications 1.0 (HTML5) の <code><a href="/ja/docs/Web/API/Window/postMessage">window.postMessage</a></code> DOM メソッドがサポートされました。このメソッドは、制限された、同じドメインに限らないウィンドウ間でのクライアントサイド通信を行う選択フォームを可能にします。 </li>
+ <li> アクセラレーションキーが押された場合、<code>keypress</code> イベントの <code>charCode</code> の値は ASCII 文字に変更されます。それ以外の場合、 <code>charCode</code> はそのままの文字です (<kbd>Shift</kbd> 状態を除く)。<a href="/ja/Gecko_Keypress_Event">Gecko Keypress Event</a> を参照してください。</li>
+</ul>
+
+<h3 id="See_also">関連情報</h3>
+
+<ul>
+ <li><a href="/ja/Firefox_3_for_developers">Firefox 3 for developers</a></li>
+ <li><a href="/ja/docs/CSS_improvements_in_Firefox_3">CSS improvements in Firefox 3</a></li>
+ <li><a href="/ja/docs/Web/API/Document_Object_Model">DOM</a></li>
+</ul>

--- a/files/ja/mozilla/firefox/releases/3/full_page_zoom/index.html
+++ b/files/ja/mozilla/firefox/releases/3/full_page_zoom/index.html
@@ -1,40 +1,44 @@
 ---
-title: Full page zoom
+title: フルページズーム
 slug: Mozilla/Firefox/Releases/3/Full_page_zoom
 tags:
+  - Extensions
   - Firefox 3
+  - XUL
 translation_of: Mozilla/Firefox/Releases/3/Full_page_zoom
 original_slug: Full_page_zoom
 ---
-<p>フルページズーム (あるいは単にフルズーム) は <a href="ja/Firefox_3_for_developers">Firefox 3</a> の新機能です。
-</p><p>{{ 英語版章題("Example (XUL:browser)") }}
-</p>
-<h3 id=".E4.BE.8B_.28XUL:browser.29" name=".E4.BE.8B_.28XUL:browser.29"> 例 (XUL:browser) </h3>
-<p>以下の例は、現在フォーカスがあたっているブラウザウィンドウでの利用をデモしています。これは Firefox 拡張機能での典型的な利用方法です。
-</p>
-<pre>var zoom = 1.5;
-var docViewer = getBrowser().selectedBrowser.markupDocumentViewer;
-docViewer.fullZoom = zoom;
+<div>{{FirefoxSidebar}}</div>
+
+<p>フルページズーム (あるいは単にフルズーム) は <a href="/ja/docs/Mozilla/Firefox/Releases/3">Firefox 3</a> の新機能です。</p>
+
+<h3 id="Example_.28XUL:browser.29">例 (XUL:browser)</h3>
+
+<p>以下の例は、現在フォーカスがあたっているブラウザーウィンドウでの利用をデモしています。これは Firefox 拡張機能での典型的な利用方法です。</p>
+
+<pre>var zoom = ZoomManager.getZoomForBrowser(gBrowser.selectedBrowser);
+ZoomManager.enlarge();
+ZoomManager.setZoomForBrowser(gBrowser.selectedBrowser, ZoomManager.MIN);
 </pre>
-<p>{{ 英語版章題("Example (XUL:iframe)") }}
-</p>
-<h3 id=".E4.BE.8B_.28XUL:iframe.29" name=".E4.BE.8B_.28XUL:iframe.29"> 例 (XUL:iframe) </h3>
-<p>フルズーム機能を <a href="ja/XUL/iframe">XUL:iframe</a> でも同様に使用することができます。しかし、iframe には markupDocumentViewer プロパティがないため、最初に以下のようにする必要があります:
-</p>
+
+<h3 id="Example_.28XUL:iframe.29">例 (XUL:iframe)</h3>
+
+<p>注: これはおそらく古いものです。</p>
+
+<p>フルズーム機能を <a href="/ja/docs/XUL/iframe">XUL:iframe</a> でも同様に使用することができます。しかし、iframe には markupDocumentViewer プロパティがないため、最初に以下のようにする必要があります。</p>
+
 <pre>var zoom = 1.5;
 var iframe = document.getElementById("authorFrame");
 var contViewer = iframe.docShell.contentViewer;
 var docViewer = contViewer.QueryInterface(Components.interfaces.nsIMarkupDocumentViewer);
 docViewer.fullZoom = zoom;
 </pre>
-<p>{{ 英語版章題("References") }}
-</p>
-<h3 id=".E5.8F.82.E8.80.83.E8.B3.87.E6.96.99" name=".E5.8F.82.E8.80.83.E8.B3.87.E6.96.99"> 参考資料 </h3>
-<ul><li>Ted Mielczarek による Page zoom extension <a class="external" href="http://ted.mielczarek.org/code/mozilla/fullpagezoom.xpi">fullpagezoom.xpi</a> 最新の Firefox 3.0 ナイトリー用
-</li><li>Daniel Glazman による <a class="link-https" href="https://addons.mozilla.org/en-US/firefox/addon/6489">Glazoom extension</a> Firefox 3.0 用
-</li><li>フルズームに関する <a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=4821">bugzilla のバグ</a>
-</li><li><a class="external" href="http://www.xulplanet.com/references/xpcomref/ifaces/nsIMarkupDocumentViewer.html">nsIMarkupDocumentViewer</a> インタフェースのドキュメンテーション (現在 fullZoom についての言及はありません)。
-</li></ul>
-<div class="noinclude">
-</div>
-{{ languages( { "en": "en/Full_page_zoom", "es": "es/Zoom_a_p\u00e1gina_completa", "fr": "fr/Zoom_pleine_page" } ) }}
+
+<h3 id="References">参考資料</h3>
+
+<ul>
+ <li>Ted Mielczarek による Page zoom extension <a class="external" href="https://ted.mielczarek.org/code/mozilla/fullpagezoom.xpi">fullpagezoom.xpi</a> 最新の Firefox 3.0 ナイトリー用</li>
+ <li>Daniel Glazman による <a class="link-https" href="https://addons.mozilla.org/en-US/firefox/addon/6489">Glazoom extension</a> Firefox 3.0 用</li>
+ <li>フルズームに関する <a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=4821">bugzilla のバグ</a></li>
+ <li>{{ Interface("nsIMarkupDocumentViewer") }} Interface documentation.</li>
+</ul>

--- a/files/ja/mozilla/firefox/releases/3/notable_bugs_fixed/index.html
+++ b/files/ja/mozilla/firefox/releases/3/notable_bugs_fixed/index.html
@@ -1,33 +1,35 @@
 ---
-title: Notable bugs fixed in Firefox 3
+title: Firefox 3 で修正された重要なバグ
 slug: Mozilla/Firefox/Releases/3/Notable_bugs_fixed
 tags:
   - Firefox 3
 translation_of: Mozilla/Firefox/Releases/3/Notable_bugs_fixed
 original_slug: Notable_bugs_fixed_in_Firefox_3
 ---
-<p>この記事は、ドキュメントで必ずしも明白に説明されていない、Firefox 3 で修正された重要なバグの修正の一覧を提供します。
-</p>
-<ul><li>オーバーレイをパース中にエラーが発生した場合、オーバーレイは適用されません。パースエラーがエラーコンソールへ記録されます。 ({{ Bug(335755) }})
-</li><li>バグが修正され、メニューやメニューに似た要素に対して適用された場合でもバインディングの内部に <code>&lt;menupopup&gt;</code> 要素を設置できるようになりました。({{ Bug(345896) }})
-</li><li>ボタンの <code>dlgType</code> プロパティが正しく動作するようになりました。 ({{ Bug(308591) }})
-</li><li>{{ Domxref("event.initEvent") }} の引数 <code>canBubble</code> が正しく動作するようになり、浮上しないイベントを発生させられるようになりました。 ({{ Bug(330190) }})
-</li><li><code>DOMAttrModified</code> イベントが名前空間付きの属性を適切に処理するようになりました。 ({{ Bug(362391) }})
-</li><li><code>&lt;?xml-stylesheet ?&gt;</code> のようなXML処理命令が、 XUL 文書の DOM へと追加されるようになりました。したがって、 {{ Domxref("document.firstChild") }} が必ずしもルート要素であることを保証しないことになります。代わりに {{ Domxref("document.documentElement") }} を使用してください。また、 <code>&lt;?xml-stylesheet ?&gt;</code> や <code>&lt;?xul-overlay ?&gt;</code> 処理命令は、文書の前置き以外の場所では効果を発揮しないようになりました。 ({{ Bug(319654) }})
-</li><li>XUL 要素や文書に対する <code>getElementsByAttributeNS</code> 関数が追加されました。 ({{ Bug(239976) }})
-</li><li>XUL 文書から要素を移動したり削除したりしても、イベントリスナが保持されます。 ({{ Bug(286619) }})
-</li><li>変異イベントが非表示ドキュメントでも発生するようになりました。 ({{ Bug(201236) }})
-</li><li>要素が間違った順番で描画されることによるさまざまな問題が修正されました。 ({{ Bug(317375) }})
-</li><li><code><a href="ja/DOM/element.getElementsByTagName">getElementsByTagName()</a></code> が、タグ名に名前空間接頭辞を含む要素を持つサブツリーにおいて正しく動作するように修正されました。 ({{ Bug(206053) }}).
-</li><li><code>DOMNodeInserted</code> および <code>DOMNodeRemoved</code> イベントが正しいノードに適用されるようになりました。 ({{ Bug(367164) }}).
-</li><li> 正規表現の特殊文字である <code>\d</code> が Basic Latin アルファベット の数字（<code>{{ mediawiki.external('0-9') }}</code> と同じ）だけにマッチするように修正されました。 ({{ Bug(378738) }})
-</li><li>image-sniffing-services カテゴリにより、拡張機能として実装された画像デコーダが正しくない MIME タイプで送られた画像を正しくデコードできるようになります（{{ Bug(391667) }}）。
-</li></ul>
-<p>{{ 英語版章題("See also") }}
-</p>
-<h3 id=".E5.8F.82.E7.85.A7" name=".E5.8F.82.E7.85.A7">参照</h3>
-<ul><li> <a href="ja/Firefox_3_for_developers">Firefox 3 for developers</a>
-</li></ul>
-<div class="noinclude">
-</div>
-{{ languages( { "en": "en/Notable_bugs_fixed_in_Firefox_3", "es": "es/Bugs_importantes_solucionados_en_Firefox_3", "fr": "fr/Bugs_importants_corrig\u00e9s_dans_Firefox_3", "pl": "pl/Istotne_b\u0142\u0119dy_poprawione_w_Firefoksie_3" } ) }}
+<div>{{FirefoxSidebar}}</div>
+
+<p>この記事は、ドキュメントで必ずしも明白に説明されていない、Firefox 3 で修正された重要なバグの修正の一覧を提供します。</p>
+
+<ul>
+ <li>オーバーレイをパース中にエラーが発生した場合、オーバーレイは適用されません。パースエラーがエラーコンソールへ記録されます。 ({{ Bug(335755) }})</li>
+ <li>バグが修正され、メニューやメニューに似た要素に対して適用された場合でもバインディングの内部に <code>&lt;menupopup&gt;</code> 要素を設置できるようになりました。({{ Bug(345896) }})</li>
+ <li>ボタンの <code>dlgType</code> プロパティが正しく動作するようになりました。 ({{ Bug(308591) }})</li>
+ <li>{{ Domxref("event.initEvent") }} の引数 <code>canBubble</code> が正しく動作するようになり、浮上しないイベントを発生させられるようになりました。 ({{ Bug(330190) }})</li>
+ <li><code>DOMAttrModified</code> イベントが名前空間付きの属性を適切に処理するようになりました。 ({{ Bug(362391) }})</li>
+ <li><code>&lt;?xml-stylesheet ?&gt;</code> のようなXML処理命令が、 XUL 文書の DOM へと追加されるようになりました。したがって、 {{ Domxref("document.firstChild") }} が必ずしもルート要素であることを保証しないことになります。代わりに {{ Domxref("document.documentElement") }} を使用してください。また、 <code>&lt;?xml-stylesheet ?&gt;</code> や <code>&lt;?xul-overlay ?&gt;</code> 処理命令は、文書の前置き以外の場所では効果を発揮しないようになりました。 ({{ Bug(319654) }})</li>
+ <li>XUL 要素や文書に対する <span id="m-getElementsByAttributeNS"><code><a href="/ja/docs/Mozilla/Tech/XUL/Method/getElementsByAttributeNS">getElementsByAttributeNS()</a></code></span> 関数が追加されました。 ({{ Bug(239976) }})</li>
+ <li>XUL 文書から要素を移動したり削除したりしても、イベントリスナが保持されます。 ({{ Bug(286619) }})</li>
+ <li>変異イベントが非表示ドキュメントでも発生するようになりました。 ({{ Bug(201236) }})</li>
+ <li>要素が間違った順番で描画されることによるさまざまな問題が修正されました。 ({{ Bug(317375) }})</li>
+ <li><code><a href="/ja/docs/Web/API/Element/getElementsByTagName">getElementsByTagName()</a></code> が、タグ名に名前空間接頭辞を含む要素を持つサブツリーにおいて正しく動作するように修正されました。 ({{ Bug(206053) }}).</li>
+ <li><code>DOMNodeInserted</code> および <code>DOMNodeRemoved</code> イベントが正しいノードに適用されるようになりました。 ({{ Bug(367164) }}).</li>
+ <li>正規表現の特殊文字である <code>\d</code> が Basic Latin アルファベット の数字（<code>{{ mediawiki.external('0-9') }}</code> と同じ）だけにマッチするように修正されました。 ({{ Bug(378738) }})</li>
+ <li>image-sniffing-services カテゴリにより、拡張機能として実装された画像デコーダが正しくない MIME タイプで送られた画像を正しくデコードできるようになります（{{ Bug(391667) }}）。</li>
+ <li>フォームコントロール上で右クリックしても、既定ではコンテキストメニューを表示しないようになりました ({{ Bug(404536) }}。この機能を個別に有効にする方法については、<a class="internal" href="/ja/docs/Offering%20a%20context%20menu%20for%20form%20controls">フォームコントロールにコンテキストメニューを提供する</a>を参照してください。</li>
+</ul>
+
+<h3 id="See_also">関連情報</h3>
+
+<ul>
+ <li> <a href="/ja/docs/Mozilla/Firefox/Releases/3">Firefox 3 for developers</a></li>
+</ul>

--- a/files/ja/mozilla/firefox/releases/3/svg_improvements/index.html
+++ b/files/ja/mozilla/firefox/releases/3/svg_improvements/index.html
@@ -1,5 +1,5 @@
 ---
-title: SVG improvements in Firefox 3
+title: Firefox 3 における SVG の改良
 slug: Mozilla/Firefox/Releases/3/SVG_improvements
 tags:
   - Firefox 3
@@ -7,50 +7,49 @@ tags:
 translation_of: Mozilla/Firefox/Releases/3/SVG_improvements
 original_slug: SVG_improvements_in_Firefox_3
 ---
-<p>Firefox 3 では、以前のバージョンの Firefox よりも改善された <a href="ja/SVG">Scalable Vector Graphics</a> (SVG) サポートが追加されました。これらの機能は、別の場所で文書化されていますが、この記事は、便利な一覧を提供することで、どの機能が Firefox 3 で追加されたのかを判別しやすくします。
-</p>
-<ul><li><code>foreignObject</code> 要素のサポート ({{ Bug(326966) }}, <a class="external" href="http://www.w3.org/TR/SVG11/extend.html#ForeignObjectElement">仕様</a>, <a class="external" href="http://weblogs.mozillazine.org/roc/archives/2006/06/the_future_is_now.html">参考</a>) </li><li><code>pattern</code> 要素のサポート (<a class="external" href="http://www.w3.org/TR/SVG11/pservers.html#PatternElement">仕様</a>)
-</li><li><code>mask</code> 要素のサポート (<a class="external" href="http://www.w3.org/TR/SVG11/masking.html#MaskElement">仕様</a>)
-</li><li>SVG フィルタのサポート (<a class="external" href="http://www.w3.org/TR/SVG11/filters.html">仕様</a>)
-<ul><li><code>filter</code>
-</li><li><code>feDistantLight</code>
-</li><li><code>fePointLight</code>
-</li><li><code>feSpotLight</code>
-</li><li><code>feBlend</code>
-</li><li><code>feColorMatrix</code>
-</li><li><code>feConvolveMatrix</code>
-</li><li><code>feComponentTransfer</code>, <code>feFuncR</code>, <code>feFuncG</code>, <code>feFuncB</code>, <code>feFuncA</code>
-</li><li><code>feComposite</code>
-</li><li><code>feConvolveMatrix</code>
-</li><li><code>feDiffuseLighting</code>
-</li><li><code>feDistantLight</code>
-</li><li><code>feFlood</code>
-</li><li><code>feGaussianBlur</code>
-</li><li><code>feMerge</code>, <code>feMergeNode</code>
-</li><li><code>feMorphology</code>
-</li><li><code>feOffset</code>
-</li><li><code>fePointLight</code>
-</li><li><code>feSpecularLighting</code>
-</li><li><code>feTurbulence</code>
-</li><li><code>feTile</code>
-</li></ul>
-</li><li><code>&lt;a&gt;</code> element handling in SVG has had several bugs fixed; see {{ Bug(267664) }}, {{ Bug(268135) }}, {{ Bug(316248) }}, {{ Bug(317270) }} and {{ Bug(320724) }}.
-</li><li>The SVG DOM Methods <code>getNumberOfChars()</code>, <code>getComputedTextLength()</code>, <code>getSubStringLength()</code>, <code>getStartPositionOfChar()</code>, <code>getEndPositionOfChar()</code>, <code>getRotationOfChar()</code>, and <code>getCharNumAtPosition()</code> have been implemented.
-</li><li><code>xml:space</code> 属性の実装 (<a class="external" href="http://www.w3.org/TR/SVG/text.html#WhiteSpace">仕様</a>)
-</li><li>fallback <code>fill</code>/<code>stroke</code> are now supported (<a class="external" href="http://www.w3.org/TR/SVG/painting.html#SpecifyingPaint">spec</a>)
-</li><li> <code>em</code> and <code>ex</code> units are now supported for indicating lengths ({{ Bug(305859) }}).
-</li></ul>
-<p>{{ 英語版章題("See also") }}
-</p>
-<h3 id=".E5.8F.82.E7.85.A7" name=".E5.8F.82.E7.85.A7">参照</h3>
-<ul><li> <a href="ja/SVG">SVG</a>
-</li><li> <a href="ja/SVG_in_Firefox">SVG in Firefox</a>
-</li><li> <a href="ja/Firefox_3_for_developers">Firefox 3 for developers</a>
-</li></ul>
-<p><br>
-</p><p><br>
-</p><p><br>
-</p>
-<div class="noinclude">
-</div>
-{{ languages( { "en": "en/SVG_improvements_in_Firefox_3", "es": "es/Mejoras_SVG_en_Firefox_3", "fr": "fr/Am\u00e9liorations_SVG_dans_Firefox_3", "pl": "pl/Poprawki_SVG_w_Firefoksie_3" } ) }}
+<div>{{FirefoxSidebar}}</div>
+<p>Firefox 3 では、以前のバージョンの Firefox よりも改善された <a href="/ja/docs/Web/SVG">Scalable Vector Graphics</a> (SVG) サポートが追加されました。これらの機能は、別の場所で文書化されていますが、この記事は、便利な一覧を提供することで、どの機能が Firefox 3 で追加されたのかを判別しやすくします。</p>
+<ul>
+  <li><code>foreignObject</code> 要素のサポート ({{ Bug(326966) }}, <a class="external" href="https://www.w3.org/TR/SVG11/extend.html#ForeignObjectElement">仕様</a>, <a class="external" href="http://weblogs.mozillazine.org/roc/archives/2006/06/the_future_is_now.html">参考</a>) </li>
+  <li><code>pattern</code> 要素のサポート (<a class="external" href="https://www.w3.org/TR/SVG11/pservers.html#PatternElement">仕様</a>)</li>
+  <li><code>mask</code> 要素のサポート (<a class="external" href="https://www.w3.org/TR/SVG11/masking.html#MaskElement">仕様</a>)</li>
+  <li>SVG フィルタのサポート (<a class="external" href="https://www.w3.org/TR/SVG11/filters.html">仕様</a>)
+    <ul>
+      <li><code>filter</code></li>
+      <li><code>feDistantLight</code></li>
+      <li><code>fePointLight</code></li>
+      <li><code>feSpotLight</code></li>
+      <li><code>feBlend</code></li>
+      <li><code>feColorMatrix</code></li>
+      <li><code>feConvolveMatrix</code></li>
+      <li><code>feComponentTransfer</code>, <code>feFuncR</code>, <code>feFuncG</code>, <code>feFuncB</code>, <code>feFuncA</code></li>
+      <li><code>feComposite</code></li>
+      <li><code>feConvolveMatrix</code></li>
+      <li><code>feDiffuseLighting</code></li>
+      <li><code>feDisplacementMap</code></li>
+      <li><code>feDistantLight</code></li>
+      <li><code>feFlood</code></li>
+      <li><code>feGaussianBlur</code></li>
+      <li><code>feImage</code></li>
+      <li><code>feMerge</code>, <code>feMergeNode</code></li>
+      <li><code>feMorphology</code></li>
+      <li><code>feOffset</code></li>
+      <li><code>fePointLight</code></li>
+      <li><code>feSpecularLighting</code></li>
+      <li><code>feTurbulence</code></li>
+      <li><code>feTile</code></li>
+    </ul>
+  </li>
+  <li><code>&lt;a&gt;</code> element handling in SVG has had several bugs fixed; see {{ Bug(267664) }}, {{ Bug(268135) }}, {{ Bug(316248) }}, {{ Bug(317270) }} and {{ Bug(320724) }}.</li>
+  <li>The SVG DOM Methods <code>getNumberOfChars()</code>, <code>getComputedTextLength()</code>, <code>getSubStringLength()</code>, <code>getStartPositionOfChar()</code>, <code>getEndPositionOfChar()</code>, <code>getRotationOfChar()</code>, and <code>getCharNumAtPosition()</code> have been implemented.</li>
+  <li><code>xml:space</code> 属性の実装 (<a class="external" href="https://www.w3.org/TR/SVG/text.html#WhiteSpace">仕様</a>)</li>
+  <li>fallback <code>fill</code>/<code>stroke</code> are now supported (<a class="external" href="https://www.w3.org/TR/SVG/painting.html#SpecifyingPaint">spec</a>)</li>
+  <li><code>em</code> and <code>ex</code> units are now supported for indicating lengths ({{ Bug(305859) }}).</li>
+</ul>
+
+<h2 id="See_also">関連情報</h2>
+<ul>
+  <li><a href="/ja/docs/Web/SVG">SVG</a></li>
+  <li><a href="/ja/docs/Web/SVG/SVG_1.1_Support_in_Firefox">SVG in Firefox</a></li>
+  <li><a href="/ja/docs/Mozilla/Firefox/Releases/3">Firefox 3 for developers</a></li>
+</ul>

--- a/files/ja/mozilla/firefox/releases/3/updating_web_applications/index.html
+++ b/files/ja/mozilla/firefox/releases/3/updating_web_applications/index.html
@@ -1,108 +1,94 @@
 ---
-title: Updating web applications for Firefox 3
+title: Firefox 3 のためのウェブアプリケーションの更新
 slug: Mozilla/Firefox/Releases/3/Updating_web_applications
 tags:
   - Firefox 3
-  - 要更新
 translation_of: Mozilla/Firefox/Releases/3/Updating_web_applications
 original_slug: Updating_web_applications_for_Firefox_3
 ---
+<div>{{FirefoxSidebar}}</div>
+
 <p>来たる Firefox 3 では、あなたが利用したいであろう新機能と同様に、ウェブサイトやウェブアプリケーションに影響するであろう多くの変更が施されています。この記事は Firefox 3 を最大限活用するためにあなたのコンテンツを更新する作業の出発点となるでしょう。</p>
 
-<p>{{ 英語版章題("DOM changes") }}</p>
+<h2 id="DOM_changes">DOM の変更</h2>
 
-<h3 id="DOM_.E3.81.AE.E5.A4.89.E6.9B.B4" name="DOM_.E3.81.AE.E5.A4.89.E6.9B.B4">DOM の変更</h3>
-
-<p></p><p>外部ドキュメントからのノードは、現在のドキュメントに挿入する前に <a href="/ja/docs/Web/API/Document/importNode" title="外部ドキュメントからノードのコピーを作成し、現在のドキュメントに挿入できるようにします。"><code>document.importNode()</code></a> を使ってクローンを作る (あるいは
-    <a href="/ja/docs/Web/API/Document/adoptNode" title="外部ドキュメントからノードを取り込みます。ノードとそのサブツリーは、(もしあれば) 元あったドキュメントから削除され、ownerDocument が現在のドキュメントに変更されます。そして、そのノードが現在のドキュメントに挿入できるようになります。"><code>document.adoptNode()</code></a> を使って取り込む) べきです。<a href="/ja/docs/Web/API/Node/ownerDocument" title="ownerDocument プロパティは、指定ノードを内包するノードツリーのトップレベルのドキュメントオブジェクトを返します。"><code>Node.ownerDocument</code></a> 問題の詳細については
-    <a class="external" href="http://www.w3.org/DOM/faq.html#ownerdoc" rel="noopener">W3C DOM FAQ</a> を参照してください。</p>
+<p></p><p>外部ドキュメントからのノードは、現在のドキュメントに挿入する前に <a href="/ja/docs/Web/API/Document/importNode" title="外部ドキュメントからノードのコピーを作成し、現在のドキュメントに挿入できるようにします。"><code>document.importNode()</code></a> を使ってクローンを作る (あるいは <a href="/ja/docs/Web/API/Document/adoptNode" title="外部ドキュメントからノードを取り込みます。ノードとそのサブツリーは、(もしあれば) 元あったドキュメントから削除され、ownerDocument が現在のドキュメントに変更されます。そして、そのノードが現在のドキュメントに挿入できるようになります。"><code>document.adoptNode()</code></a> を使って取り込む) べきです。<a href="/ja/docs/Web/API/Node/ownerDocument" title="ownerDocument プロパティは、指定ノードを内包するノードツリーのトップレベルのドキュメントオブジェクトを返します。"><code>Node.ownerDocument</code></a> 問題の詳細については <a class="external" href="https://www.w3.org/DOM/faq.html#ownerdoc" rel="noopener">W3C DOM FAQ</a> を参照してください。</p>
 
     <p>Firefox では現在このルールを強制していません。Firefox 3 の開発中には強制していた時期もありましたが、このルールを強制すると多くのサイトが機能しなくなってしまうため取りやめになりました。
-    将来的な互換性を高めるため、Web 開発者にはこのルールに従ってコードを修正することを推奨します。</p><p></p>
+    将来的な互換性を高めるため、ウェブ開発者にはこのルールに従ってコードを修正することを推奨します。</p>
 
-<p>{{ 英語版章題("HTML changes") }}</p>
+<h2 id="HTML_changes">HTML の変更</h2>
 
-<h3 id="HTML_.E3.81.AE.E5.A4.89.E6.9B.B4" name="HTML_.E3.81.AE.E5.A4.89.E6.9B.B4">HTML の変更</h3>
+<h3 id="Changes_to_character_set_inheritance">文字セット継承に対する変更</h3>
 
-<p>{{ 英語版章題("Changes to character set inheritance") }}</p>
+<p>Firefox 3 では、frame や iframe が親の文字セットを継承できてしまうセキュリティ上のバグが修正されています。これにより、場合によっては問題が起こる可能性があります。フレームが親文字タセットを継承できるのは、フレームと親がともに同じサーバーから読み込まれている場合に限られます。もしあなたのページが、他のサーバーから読み込まれたフレームが同じ文字セットを継承することを前提に作られているなら、フレームの HTML を更新して文字セットを明確に指定するべきです。</p>
 
-<h4 id=".E3.82.AD.E3.83.A3.E3.83.A9.E3.82.AF.E3.82.BF.E3.82.BB.E3.83.83.E3.83.88.E7.B6.99.E6.89.BF.E3.81.AB.E5.AF.BE.E3.81.99.E3.82.8B.E5.A4.89.E6.9B.B4" name=".E3.82.AD.E3.83.A3.E3.83.A9.E3.82.AF.E3.82.BF.E3.82.BB.E3.83.83.E3.83.88.E7.B6.99.E6.89.BF.E3.81.AB.E5.AF.BE.E3.81.99.E3.82.8B.E5.A4.89.E6.9B.B4">キャラクタセット継承に対する変更</h4>
+<h3 id="Change_to_the_SCRIPT_element">SCRIPT 要素に対する変更</h3>
 
-<p>Firefox 3 では、frame や iframe が親のキャラクタセットを継承できてしまうセキュリティ上のバグが修正されています。これにより、場合によっては問題が起こる可能性があります。フレームが親のキャラクタセットを継承できるのは、フレームと親がともに同じサーバーから読み込まれている場合に限られます。もしあなたのページが、他のサーバーから読み込まれたフレームが同じキャラクタセットを継承することを前提に作られているなら、フレームの HTML を更新してキャラクタセットを明確に指定するべきです。</p>
+<p><code>text/html</code> 文書における <code>&lt;script&gt;</code> 要素は、たとえ 間に内容を含めなくても、HTML 4 文書における 閉じ タグである <code>&lt;/script&gt;</code> を必要とするようになりました。以前のバージョンの Firefox では、以下のようにすることが可能でした。：</p>
 
-<p>{{ 英語版章題("Change to the SCRIPT element") }}</p>
-
-<h4 id="SCRIPT_.E8.A6.81.E7.B4.A0.E3.81.AB.E5.AF.BE.E3.81.99.E3.82.8B.E5.A4.89.E6.9B.B4" name="SCRIPT_.E8.A6.81.E7.B4.A0.E3.81.AB.E5.AF.BE.E3.81.99.E3.82.8B.E5.A4.89.E6.9B.B4">SCRIPT 要素に対する変更</h4>
-
-<p><code>text/html</code> 文書における <span class="nowiki">&lt;script&gt;</span> 要素は、たとえ 間に内容を含めなくても、HTML 4 文書における 閉じ タグである <span class="nowiki">&lt;/script&gt;</span> を必要とするようになりました。以前のバージョンの Firefox では、以下のようにすることが可能でした。：</p>
-
-<pre class="eval">&lt;script ... /&gt;
+<pre>&lt;script ... /&gt;
 </pre>
 
-<p>今バージョンからマークアップは HTML の仕様に従わなければならず（それが実際に HTML である場合）、以下のように実際に閉じなければなりません。：</p>
+<p>今バージョンからマークアップは HTML の仕様に従わなければならず (それが実際に HTML である場合)、以下のように実際に閉じなければなりません。</p>
 
-<pre class="eval">&lt;script ...&gt;&lt;/script&gt;
+<pre>&lt;script ...&gt;&lt;/script&gt;
 </pre>
 
 <p>これは互換性とセキュリティの両方を改善します。</p>
 
-<p>{{ 英語版章題("CSS changes") }}</p>
+<h2 id="CSS_changes">CSS の変更</h2>
 
-<h3 id="CSS_.E3.81.AE.E5.A4.89.E6.9B.B4" name="CSS_.E3.81.AE.E5.A4.89.E6.9B.B4">CSS の変更</h3>
-
-<p>{{ 英語版章題("Change to font-size based on em, ex units") }}</p>
-
-<h4 id="em.E3.80.81ex_.E5.8D.98.E4.BD.8D.E3.81.AB.E5.9F.BA.E3.81.A5.E3.81.84.E3.81.9F_font-size_.E3.81.AB.E5.AF.BE.E3.81.99.E3.82.8B.E5.A4.89.E6.9B.B4" name="em.E3.80.81ex_.E5.8D.98.E4.BD.8D.E3.81.AB.E5.9F.BA.E3.81.A5.E3.81.84.E3.81.9F_font-size_.E3.81.AB.E5.AF.BE.E3.81.99.E3.82.8B.E5.A4.89.E6.9B.B4">em、ex 単位に基づいた font-size に対する変更</h4>
+<h3 id="Change_to_font-size_based_on_em_ex_units">em、ex 単位に基づいた font-size に対する変更</h3>
 
 <p>em、ex 単位での font-size の値はユーザの最小フォントサイズ設定の影響を受けていました。例えば、フォントが最小フォントサイズより大きく表示されるなら、em と ex 単位で font-size を指定されたフォントは最小フォントサイズ設定に従って拡大されるでしょう。これは割合に基づいたフォントサイズの振る舞いと矛盾していました。</p>
 
 <p>em 及び ex 単位での font-size の値は、ユーザの最小フォントサイズの影響を受けることなく、"意図されたフォントサイズ" に基づくようになりました。言い換えれば、フォントサイズは常にデザイナーの意図に従って計算され、その後に最小フォントサイズのための調整が行われるようになったということです。</p>
 
-<p>デモは <a class="link-https" href="https://bugzilla.mozilla.org/attachment.cgi?id=322943" rel="freelink">https://bugzilla.mozilla.org/attachment.cgi?id=322943</a> を参照してください（違いを知るためには最小フォントサイズを 6 以上にして見る必要があります。二つの箱のカスケードは Firefox 2 では異なった振る舞いをします。なぜなら、em ベースのフォントサイズは最小フォントサイズの "影響を受ける" からです）。</p>
+<p>{{Bug(434718)}}、特にその <a class="link-https" href="https://bugzilla.mozilla.org/attachment.cgi?id=322943">添付ファイル 322943</a> をデモとしてを参照してください (違いを見るためには、最小フォントサイズ >= 6 で見る必要があります)。 (<span class="comment">これはバグテンプレートについて言っているのではありません。このリンクは Bugzilla のバグではなく、Bugzilla の添付ファイルを指しています。添付ファイルの番号をバグ番号として使用すると、意味を成しません。) Firefox 2 では、em ベースのフォントサイズが最小フォントサイズに「跳ね返る」ため、2 つのボックスカスケードの動作が異なります)。</p>
 
-<p>{{ 英語版章題("Security changes") }}</p>
+<h2 id="Security_changes">セキュリティに関する変更</h2>
 
-<h3 id=".E3.82.BB.E3.82.AD.E3.83.A5.E3.83.AA.E3.83.86.E3.82.A3.E3.81.AB.E9.96.A2.E3.81.99.E3.82.8B.E5.A4.89.E6.9B.B4" name=".E3.82.BB.E3.82.AD.E3.83.A5.E3.83.AA.E3.83.86.E3.82.A3.E3.81.AB.E9.96.A2.E3.81.99.E3.82.8B.E5.A4.89.E6.9B.B4">セキュリティに関する変更</h3>
+<h3 id="Chrome_access">クロームへのアクセス</h3>
 
-<p>{{ 英語版章題("Chrome access") }}</p>
+<p>Firefox のこれまでのバージョンでは、ウェブページは <code>chrome://</code> プロトコルを使ってクロームからスクリプトや画像を読み込むことが可能でした。特に、このような仕様によって、アドオンがインストールされているかどうかをサイトが判別することが可能でした。これは、ブラウザにセキュリティ機能を追加するアドオンを回避して、ユーザのセキュリティを侵害するのに利用される恐れがありました。</p>
 
-<h4 id=".E3.82.AF.E3.83.AD.E3.83.BC.E3.83.A0.E3.81.B8.E3.81.AE.E3.82.A2.E3.82.AF.E3.82.BB.E3.82.B9" name=".E3.82.AF.E3.83.AD.E3.83.BC.E3.83.A0.E3.81.B8.E3.81.AE.E3.82.A2.E3.82.AF.E3.82.BB.E3.82.B9">クロームへのアクセス</h4>
+<p>Firefox 3 では、ウェブコンテンツは <code><a class="external" rel="freelink">chrome://browser/</a></code> および <code><a class="external" rel="freelink">chrome://toolkit/</a></code> 以下にあるコンテンツに限ってアクセスできます。これらのファイルはウェブコンテンツからアクセスされることを意図したものです。他のクロームコンテンツはすべて、ウェブからのアクセスが禁止されます。</p>
 
-<p>Firefox のこれまでのバージョンでは、Web ページは <code><a class="external" rel="freelink">chrome://</a></code> プロトコルを使ってクロームからスクリプトや画像を読み込むことが可能でした。特に、このような仕様によって、アドオンがインストールされているかどうかをサイトが判別することが可能でした。これは、ブラウザにセキュリティ機能を追加するアドオンを回避して、ユーザのセキュリティを侵害するのに利用される恐れがありました。</p>
+<p>ただし、拡張機能が、内部のコンテンツをウェブからアクセス可能にする方法があります。その方法とは、以下のように、<code>chrome.manifest</code> ファイルに特別なフラグを指定することです。</p>
 
-<p>Firefox 3 では、Web コンテンツは <code><a class="external" rel="freelink">chrome://browser/</a></code> および <code><a class="external" rel="freelink">chrome://toolkit/</a></code> 以下にあるコンテンツに限ってアクセスできます。これらのファイルは Web コンテンツからアクセスされることを意図したものです。他のクロームコンテンツはすべて、Web からのアクセスが禁止されます。</p>
+<pre>content mypackage location/ contentaccessible=yes
+</pre>
 
-<p>ただし、拡張機能が、内部のコンテンツを Web からアクセス可能にする方法があります。その方法とは、以下のように、<code>chrome.manifest</code> ファイルに特別なフラグを指定することです。</p>
-
-<p>content mypackage location/ contentaccessible=yes</p>
-
-<p>これは頻繁に必要となるものではありませんが、Web からのアクセスが必要な、まれなケースのために用意されています。Firefox はユーザに拡張が <code>contentaccessible</code> フラグをこのような方法で用いることで潜在的セキュリティリスクになることを警告するかもしれないことに注意してください。</p>
+<p>これは頻繁に必要となるものではありませんが、ウェブからのアクセスが必要な、まれなケースのために用意されています。Firefox はユーザに拡張が <code>contentaccessible</code> フラグをこのような方法で用いることで潜在的セキュリティリスクになることを警告するかもしれないことに注意してください。</p>
 
 <div class="note"><strong>注意:</strong> Firefox 2 では <code>contentaccessible</code> フラグが認識されない (フラグを含む行全体が無視されてしまう) ことから、アドオンを Firefox 2 と Firefox 3 の両方に対応させたい場合は、以下のように指定します。
 
-<pre class="eval">content mypackage location/
+<pre>content mypackage location/
 content mypackage location/ contentaccessible=yes
 </pre>
 </div>
 
-<p>{{ 英語版章題("File upload fields") }}</p>
+<h3 id="File_upload_fields">ファイルアップロードフィールド</h3>
 
-<h4 id=".E3.83.95.E3.82.A1.E3.82.A4.E3.83.AB.E3.82.A2.E3.83.83.E3.83.97.E3.83.AD.E3.83.BC.E3.83.89.E7.94.A8.E3.83.95.E3.82.A9.E3.83.BC.E3.83.A0.E9.A0.85.E7.9B.AE" name=".E3.83.95.E3.82.A1.E3.82.A4.E3.83.AB.E3.82.A2.E3.83.83.E3.83.97.E3.83.AD.E3.83.BC.E3.83.89.E7.94.A8.E3.83.95.E3.82.A9.E3.83.BC.E3.83.A0.E9.A0.85.E7.9B.AE">ファイルアップロード用フォーム項目</h4>
+<p>Firefox のこれまでのバージョンでは、ユーザがファイルをアップロードするために送信する際、そのファイルのフルパスがウェブアプリケーションに公開されてしまう場合がありました。このプライバシーの懸念は、Firefox 3 で、ファイル名のみをウェブアプリケーションに公開するよう仕様を変更することで解決されました。</p>
 
-<p>Firefox のこれまでのバージョンでは、ユーザがファイルをアップロードするために送信する際、そのファイルのフルパスが Web アプリケーションに公開されてしまう場合がありました。このプライバシーの懸念は、Firefox 3 で、ファイル名のみをWeb アプリケーションに公開するよう仕様を変更することで解決されました。</p>
+<h3 id="Using_remote_JARs_in_frames">フレーム内でのリモート JAR の使用</h3>
 
-<p>{{ 英語版章題("JavaScript changes") }}</p>
+<p>他のドメインから読み込んだ JAR ファイル内のコードの使用は、フレーム内では許可されなくなりました。これによって<a href="https://www.mozilla.org/security/announce/2008/mfsa2008-23.html">潜在的な攻撃ベクトル</a>を軽減することができます。</p>
 
-<h3 id="JavaScript_.E3.81.AE.E5.A4.89.E6.9B.B4" name="JavaScript_.E3.81.AE.E5.A4.89.E6.9B.B4">JavaScript の変更</h3>
+<h3 id="Changes_to_same-origin_policy_for_file_URIs">file: URI の同一オリジンポリシーの変更</h3>
 
-<p>Firefox 3 は <a href="ja/New_in_JavaScript_1.8">JavaScript 1.8</a> をサポートします。あなたの Web サイトや Web アプリケーションの更新が必要となりうる重要な変更点としては、時代遅れであり非標準の <code>Script</code> オブジェクトがサポートされなくなることが挙げられます。これは <code><span class="nowiki">&lt;script&gt;</span></code> タグではなく、標準化されることのなかった JavaScript オブジェクトのことです。どちらにしてもあなたが使用していた可能性は低いでしょうから、これが問題になることは恐らくないでしょう。</p>
+<p>file: URI の同一オリジンポリシーが Firefox 3 で変更されました。これはコンテンツに影響する可能性があります。詳しくは <a href="/jas/docs/Same-origin_policy_for_file:_URIs" title="Same-origin policy for file: URIs">file: URI の同一オリジンポリシー</a>を参照してください。</p>
 
-<p>{{ 英語版章題("See also") }}</p>
+<h2 id="JavaScript_changes">JavaScript の変更</h2>
 
-<h3 id=".E5.8F.82.E8.80.83" name=".E5.8F.82.E8.80.83">参考</h3>
+<p>Firefox 3 は <a href="/ja/docs/New_in_JavaScript_1.8">JavaScript 1.8</a> をサポートします。ウェブサイトやウェブアプリケーションの更新が必要となりうる重要な変更点としては、時代遅れであり非標準の <code>Script</code> オブジェクトがサポートされなくなることが挙げられます。これは <code>&lt;script&gt;</code> タグではなく、標準化されることのなかった JavaScript オブジェクトのことです。どちらにしても使用していた可能性は低いでしょうから、これが問題になることは恐らくないでしょう。</p>
+
+<h2 id="See_also">関連情報</h2>
 
 <ul>
- <li><a href="ja/Firefox_3_for_developers">開発者のための Firefox 3</a></li>
- <li><a href="ja/New_in_JavaScript_1.8">New in JavaScript 1.8</a></li>
- <li><a href="ja/Updating_extensions_for_Firefox_3">拡張機能を Firefox 3 のためにアップデート</a></li>
+ <li><a href="/ja/docs/Mozilla/Firefox/Releases/3">開発者向け Firefox 3</a></li>
+ <li><a href="/ja/docs/New_in_JavaScript_1.8" title="New_in_JavaScript_1.8">JavaScript 1.8 の新機能</a></li>
+ <li><a href="/ja/docs/Mozilla/Firefox/Releases/3/Updating_extensions">Updating extensions for Firefox 3 のための拡張機能の更新</a></li>
 </ul>


### PR DESCRIPTION
- 英語版章題マクロを削除 (https://github.com/mozilla-japan/translation/issues/547)
- それぞれのファイルを 2021/05/25 時点での最新の英語版に同期。ただし、古い情報なので最小限の修正にとどめた。