### PR TITLE
Web/API/NavigatorPlugins/mimeTypes を更新

### DIFF
--- a/files/ja/web/api/navigatorplugins/mimetypes/index.html
+++ b/files/ja/web/api/navigatorplugins/mimetypes/index.html
@@ -2,32 +2,62 @@
 title: mimeTypes
 slug: Web/API/NavigatorPlugins/mimeTypes
 tags:
-  - DOM
-  - DOM_0
-  - Gecko
-  - Gecko DOM Reference
+- API
+- Property
+- Reference
 translation_of: Web/API/NavigatorPlugins/mimeTypes
 ---
-<p> </p>
-<p>{{ ApiRef() }} {{ 英語版章題("Summary") }}</p>
-<h3 id=".E6.A6.82.E8.A6.81" name=".E6.A6.82.E8.A6.81">概要</h3>
-<p><code><a class="external" href="http://www.xulplanet.com/references/objref/MimeTypeArray.html">MimeTypeArray</a></code> オブジェクトを返します。このオブジェクトは、ブラウザが認識する MIME タイプを表す <code><a class="external" href="http://www.xulplanet.com/references/objref/MimeType.html">MimeType</a></code> オブジェクトのリストを含んでいます。</p>
-<p>{{ 英語版章題("Syntax") }}</p>
-<h3 id="Syntax">構文</h3>
-<pre class="eval"><i>mimeTypes</i> = navigator.mimeTypes;
+<div>{{ ApiRef("HTML DOM") }}{{deprecated_header}}</div>
+
+<p>{{domxref("MimeTypeArray")}} オブジェクトを返します。これにはブラウザーが解釈する MIME タイプを表す {{domxref("MimeType")}} のリストが入っています。</p>
+
+<div class="note">
+	<p><strong>注</strong>: 最新のバージョンのブラウザーでは、 {{domxref("MimeTypeArray")}} オブジェクトの名前付きプロパティは列挙可能ではなくなっています。</p>
+</div>
+
+<h2 id="Syntax">構文</h2>
+
+<pre class="brush: js">var <var>mimeTypes</var>[] = navigator.mimeTypes;
 </pre>
-<p><code>mimeTypes</code> は、<code><a class="external" href="http://www.xulplanet.com/references/objref/MimeTypeArray.html">MimeTypeArray</a></code> オブジェクトです。このオブジェクトは、<code>length</code> プロパティを持ち、また、<code>item(index)</code> 及び <code>namedItem(name)</code> メソッドを持っています。</p>
-<p>{{ 英語版章題("Example") }}</p>
-<h3 id=".E4.BE.8B" name=".E4.BE.8B">例</h3>
-<pre>  alert(window.navigator.mimeTypes.item(0).description); // "Mozilla Default Plug-in" などをダイアログで表示します。
+
+<p><code>mimeTypes</code> は <code>MimeTypeArray</code> オブジェクトであり、これは <code>length</code> プロパティと <code>item(index)</code> および <code>namedItem(name)</code> メソッドを持っています。</p>
+
+<h2 id="Example">例</h2>
+
+<pre class="brush:js">function isJavaPresent() {
+  return 'application/x-java-applet' in navigator.mimeTypes;
+}
+
+function getJavaPluginDescription() {
+  var mimetype = navigator.mimeTypes['application/x-java-applet'];
+  if (mimetype === undefined) {
+    // no Java plugin present
+    return undefined;
+  }
+  return mimetype.enabledPlugin.description;
+}
 </pre>
-<p>{{ 英語版章題("Notes") }}</p>
-<h3 id="Notes">注</h3>
-<p>例における mimeTypes プロパティの 0 番目の要素（"Mozilla Default Plug-in" <code>MimeType</code> オブジェクト）の <code>type</code> プロパティの値は、<code>"image/x-macpaint"</code> のような 典型的な MIME 形式ではなく、<code>*</code> という値 です。</p>
-<p>{{ 英語版章題("Specification") }}</p>
-<h3 id=".E4.BB.95.E6.A7.98" name=".E4.BB.95.E6.A7.98">仕様</h3>
-<p>{{ DOM0() }}</p>
-<p> </p>
-<div class="noinclude">
-  </div>
-<p>{{ languages( { "en": "en/DOM/window.navigator.mimeTypes", "pl": "pl/DOM/window.navigator.mimeTypes" } ) }}</p>
+
+<h2 id="Specifications">仕様書</h2>
+
+<table class="standard-table">
+	<thead>
+		<tr>
+			<th scope="col">仕様書</th>
+			<th scope="col">状態</th>
+			<th scope="col">備考</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>{{SpecName('HTML WHATWG', '#dom-navigator-mimetypes',
+				'NavigatorPlugins.mimeTypes')}}</td>
+			<td>{{Spec2('HTML WHATWG')}}</td>
+			<td>初回定義</td>
+		</tr>
+	</tbody>
+</table>
+
+<h2 id="Browser_compatibility">ブラウザーの互換性</h2>
+
+<p>{{Compat("api.NavigatorPlugins.mimeTypes")}}</p>


### PR DESCRIPTION
- 英語版章題マクロを除去 (https://github.com/mozilla-japan/translation/issues/547)
- 2021/03/08 時点の英語版に同期