### PR TITLE
Web/API/Window/defaultStatus を更新

### DIFF
--- a/files/ja/web/api/window/defaultstatus/index.html
+++ b/files/ja/web/api/window/defaultstatus/index.html
@@ -1,38 +1,54 @@
 ---
-title: defaultStatus
+title: Window.defaultStatus
 slug: Web/API/Window/defaultStatus
 tags:
-  - DOM
-  - DOM_0
-  - Gecko
-  - Gecko DOM Reference
-  - 要更新
+  - API
+  - HTML DOM
+  - NeedsCompatTable
+  - NeedsExample
+  - NeedsMarkupWork
+  - NeedsSpecTable
+  - Deprecated
+  - Property
+  - Reference
+  - Window
 translation_of: Web/API/Window/defaultStatus
 ---
-<p>{{ ApiRef() }} {{ 英語版章題("Summary") }}</p>
-<h3 id=".E6.A6.82.E8.A6.81" name=".E6.A6.82.E8.A6.81">概要</h3>
+<p>{{APIRef()}}{{deprecated_header}}</p>
+
+<div class="note notebox">
+  <p><strong>注:</strong>このメソッドは Firefox 23 以降で削除されました。</p>
+</div>
+
+<h2 id="Summary">概要</h2>
+
 <p>与えられたウィンドウのステータスバーのテキストを取得/設定します。</p>
-<p>{{ 英語版章題("Syntax") }}</p>
-<h3 id="Syntax">構文</h3>
-<pre class="eval"><i>sMsg</i> = window.defaultStatus
-window.defaultStatus =<i>sMsg</i>
+
+<h2 id="Syntax">構文</h2>
+
+<pre class="eval"><em>var sMsg</em> = window.defaultStatus;
+window.defaultStatus = <em>sMsg;</em>
 </pre>
-<p>{{ 英語版章題("Parameters") }}</p>
-<h3 id="Arguments">引数</h3>
+
+<h3 id="Parameters">引数</h3>
+
 <ul>
- <li><code>sMsg</code> は、ステータスバーでデフォルトで表示されるテキストを含む文字列です。</li>
+ <li><code>sMsg</code> は、ステータスバーで既定で表示されるテキストを含む文字列です。</li>
 </ul>
-<p>{{ 英語版章題("Example") }}</p>
-<h3 id=".E4.BE.8B" name=".E4.BE.8B">例</h3>
+
+<h2 id="Example">例</h2>
+
 <pre>&lt;html&gt;
  &lt;body onload="window.defaultStatus='hello!';"/&gt;
   &lt;button onclick="window.confirm('Are you sure you want to quit?');"&gt;confirm&lt;/button&gt;
  &lt;/body&gt;
-&lt;/htm&gt;
+&lt;/html&gt;
 </pre>
-<p>{{ 英語版章題("Notes") }}</p>
-<h3 id="Notes">注</h3>
-<p>一度開いたウィンドウのステータスバーのテキストを設定するには、<a href="ja/DOM/window.status">window.status</a> を使用してください。</p>
-<p>{{ 英語版章題("Specification") }}</p>
-<h3 id=".E4.BB.95.E6.A7.98" name=".E4.BB.95.E6.A7.98">仕様</h3>
-<p>{{ DOM0() }}</p>
+
+<h2 id="Notes">注</h2>
+
+<p>一度開いたウィンドウのステータスバーのテキストを設定するには、 {{domxref("window.status")}} を使用してください。</p>
+
+<h2 id="Specifications">仕様書</h2>
+
+<p>HTML5</p>


### PR DESCRIPTION
- 英語版章題マクロを除去 (https://github.com/mozilla-japan/translation/issues/547)
- 2021/03/18 時点の英語版に同期