### PR TITLE
Web/API/Window/pkcs11 の更新

### DIFF
--- a/files/ja/web/api/window/pkcs11/index.html
+++ b/files/ja/web/api/window/pkcs11/index.html
@@ -1,29 +1,46 @@
 ---
-title: window.pkcs11
+title: Window.pkcs11
 slug: Web/API/Window/pkcs11
 tags:
-  - DOM
-  - DOM_0
-  - Gecko
-  - Gecko DOM Reference
+  - API
+  - HTML DOM
+  - NeedsExample
+  - NeedsMarkupWork
+  - NeedsSpecTable
+  - Deprecated
+  - Property
+  - Reference
   - Window
-  - 要更新
 translation_of: Web/API/Window/pkcs11
 ---
-<p>{{ ApiRef() }} {{ 英語版章題("Summary") }}</p>
-<h3 id=".E6.A6.82.E8.A6.81" name=".E6.A6.82.E8.A6.81">概要</h3>
-<p><a href="ja/Pkcs11_protocol">pcks11 プロトコル</a> に関連するドライバや他のソフトウェアをインストールするために用いられる <b>pkcs11</b> オブジェクトを返します。</p>
-<p>{{ 英語版章題("Syntax") }}</p>
-<h3 id="Syntax">構文</h3>
-<pre class="eval"><i>objRef</i> = window.pkcs11
+<p>{{APIRef()}}{{deprecated_header}}</p>
+
+<h2 id="Summary">概要</h2>
+
+<p><code>pkcs11</code> オブジェクトを返し案す。これは <a href="/ja/docs/Pkcs11_protocol">pkcs11 プロトコル</a>に関連付けられたドライバーやその他のソフトウェアをインストールするために使用されます。 <code>pkcs11</code> に対応していない場合、このプロパティは <code>null</code> を返します。</p>
+
+<div class="note">
+<p><strong>注:</strong> このプロパティはセキュリティ上の理由から、 Gecko 1.9.0.14 (Firefox 3.0.14) 以降で <code>null</code> を返すようになり、 Gecko 29.0 {{geckoRelease(29)}}) で<strong>削除されました</strong>。 PKCS11 モジュールのインストールに関する詳細情報は、 <a href="/ja/docs/PKCS11_Module_Installation">PKCS11 モジュールのインストール</a>を参照してください。このプロパティが削除された理由の詳細については、 {{ Bug(326628) }} にを参照してください。</p>
+</div>
+
+<h2 id="Syntax">構文</h2>
+
+<pre class="eval"><em>objRef</em> = window.pkcs11
 </pre>
-<p>{{ 英語版章題("Example") }}</p>
-<h3 id=".E4.BE.8B" name=".E4.BE.8B">例</h3>
+
+<h2 id="Example">例</h2>
+
 <pre> window.pkcs11.addModule(sMod, secPath, 0, 0);
 </pre>
-<p>{{ 英語版章題("Notes") }}</p>
-<h3 id="Notes">注</h3>
-<p>pcks11 オブジェクトの扱い方についてのさらなる情報は、<a href="ja/NsIDOMPkcs11">nsIDOMPkcs11</a> を参照してください。</p>
-<p>{{ 英語版章題("Specification") }}</p>
-<h3 id=".E4.BB.95.E6.A7.98" name=".E4.BB.95.E6.A7.98">仕様</h3>
-<p>{{ DOM0() }}</p>
+
+<h2 id="Notes">注</h2>
+
+<p><code>pkcs11</code> オブジェクトの操作方法について詳しい情報は、 {{interface("nsIDOMPkcs11")}} を参照してください。</p>
+
+<h2 id="Specifications">仕様書</h2>
+
+<p>仕様書にはありません。</p>
+
+<h2 id="Browser_compatibility">ブラウザーの互換性</h2>
+
+<p>{{Compat("api.Window.pkcs11")}}</p>


### PR DESCRIPTION
- 英語版章題マクロを削除 (https://github.com/mozilla-japan/translation/issues/547)
- 2021/05/18 時点の英語版に同期