### PR TITLE
Remove feature that's no longer experimental and rework intro

### DIFF
--- a/files/fr/mozilla/firefox/experimental_features/index.html
+++ b/files/fr/mozilla/firefox/experimental_features/index.html
@@ -1532,7 +1532,7 @@ translation_of: Mozilla/Firefox/Experimental_features
 
 <h4 id="execution_context_selector">Sélecteur pour le contexte d'exécution</h4>
 
-<p>Cette fonctionnalité affiche un bouton sur la ligne de commande de la console qui permet de changer le contexte dans lequel l'expression saisie est exécutée. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1605154">le bug 1605154</a> and <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1605153">le bug 1605153</a> pour plus de détails.</p>
+<p>Cette fonctionnalité affiche un bouton sur la ligne de commande de la console qui permet de changer le contexte dans lequel l'expression saisie est exécutée. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1605154">le bug 1605154</a> et <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1605153">le bug 1605153</a> pour plus de détails.</p>
 
 <table class="standard-table">
  <thead>

--- a/files/fr/mozilla/firefox/experimental_features/index.html
+++ b/files/fr/mozilla/firefox/experimental_features/index.html
@@ -5,669 +5,1739 @@ tags:
   - Experimental
   - Firefox
   - Preferences
-  - fonctionnalités
+  - features
 translation_of: Mozilla/Firefox/Experimental_features
 ---
 <div>{{FirefoxSidebar}}</div>
 
-<p class="summary">Afin de tester les nouvelles fonctionnalités, Mozilla publie chaque jour une version test du navigateur Firefox , <a href="https://nightly.mozilla.org/">Firefox Nightly</a>. Les fonctionnalités expérimentales, par exemple l'implantation de standards de plateforme Web, sont disponibles. Cette page liste les procédures qui sont données par les versions Nightly de Firefox avec les informations pour les activer si nécessaire. Vous pouvez tester vos sites Web et les applications avant que ces procédures soient mises en mise à jour en ligne et vous assurer ainsi que tout fonctionnera avec le potentiel de la dernière technologie Web.</p>
+<p>Cette page détaille les fonctionnalités expérimentales ou partiellement implémentées présentes dans Firefox. Cela inclut les fonctionnalités concernées par les standards web très récents ou en cours de construction. Les informations de cette page permettent de savoir quelles versions contiennent ces fonctionnalités, si elles sont activées par défaut et la <em>préférence</em> qui peut être utilisée pour les activer ou les désactiver. Cela vous permet de tester les fonctionnalités avant leur sortie « générale ».</p>
 
-<p>Les nouvelles fonctionnalités apparaissent d'abord dans la version <a href="https://nightly.mozilla.org/">Nightly</a> de Firefox, où elles sont souvent activées par défaut. Elles arrivent ensuite dans <a href="https://www.mozilla.org/fr/firefox/developer/">Firefox Developer Edition</a> et finalement dans la version finale. Une fois qu'une fonctionnalité est activée par défaut dans une version publiée, elle n'est plus expérimentale et doit être retirée de la liste.</p>
+<p>Les nouvelles fonctionnalités sont d'abord introduites dans <a href="https://nightly.mozilla.org/">Firefox Nightly</a> où elles sont activées par défaut la plupart du temps. Elles passent ensuite sur la version <a href="https://www.mozilla.org/fr/firefox/developer/">Firefox Developer Edition</a> puis enfin dans la version finale (<i>release</i>). Lorsqu'une fonctionnalité est activée par défaut dans une version <i>release</i>, elle n'est plus considérée comme expérimentale et devrait être retiré de cette liste.</p>
 
-<p>Les fonctionnalités expérimentales peuvent être activées ou désactivées à l'aide de <a href="https://support.mozilla.org/fr/kb/editeur-configuration-firefox">l'éditeur de configuration de Firefox</a> (entrez <code>about:config</code> dans la barre d'adresse de Firefox) en modifiant les <em>préférences</em> associées énumérées ci-dessous.</p>
+<p>Les fonctionnalités expérimentales peuvent être activées ou désactivées via <a href="https://support.mozilla.org/fr/kb/about-config-editor-firefox">l'éditeur de configuration Firefox</a> (accessible en saisissant <code>about:config</code> dans la barre d'adresse de Firefox) en modifiant la ou les <em>préférence(s)</em> indiquées ci-après.</p>
 
-<h2 id="HTML">HTML</h2>
+<h2 id="html">HTML</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Fonctionnalités</th>
-   <th scope="col">Firefox Nightly</th>
-   <th scope="col">Firefox Developer Edition</th>
-   <th scope="col">Firefox Beta</th>
-   <th scope="col">Firefox Release</th>
-   <th scope="col">Nom de la préférence</th>
-  </tr>
-  <tr>
-   <td><strong>{{HTMLElement("dialog")}}</strong><br>
-    Elément de dialogue incluant les DOM APIs pour intéragir avec. L'implementation de modules de dialogues et l'accessibilité restent manquants.</td>
-   <td>Activé<br>
-    <sub>(disponible depuis 53)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 53)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 53)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 53)</sub></td>
-   <td>
-    <p><code>dom.dialog_element.enabled</code></p>
-   </td>
-  </tr>
-  <tr>
-   <td>
-    <p><strong>Attribut global : inputmode</strong></p>
+<h3 id="element_&lt;dialog&gt;">L'élément &lt;dialog&gt;</h3>
 
-    <p>Notre implémentation de cet attribut a été mis à jour conformément à la spécification WHATWG ({{bug(1509527)}}), cependant il nous reste des modifications à faire pour le rendre disponible à l'édition (contenteditable). Plus de détail : {{bug(1205133)}}</p>
-   </td>
-   <td>
-    <p>Activé<br>
-     <sub>(disponible depuis 75)</sub></p>
-   </td>
-   <td>
-    <p>Désactivé<br>
-     <sub>(disponible depuis 75)</sub></p>
-   </td>
-   <td>
-    <p>Désactivé<br>
-     <sub>(disponible depuis 75)</sub></p>
-   </td>
-   <td>
-    <p>Désactivé<br>
-     <sub>(disponible depuis 75)</sub></p>
-   </td>
-   <td><code>dom.forms.inputmode</code></td>
-  </tr>
- </thead>
-</table>
-
-<h2 id="CSS">CSS</h2>
+<p>L'élément HTML <a href="/fr/docs/Web/HTML/Element/dialog"><code>&lt;dialog&gt;</code></a> et les API du DOM associées permettent de créer des boîtes de dialogue modales en HTML. L'implémentation actuelle manque de finesse mais permet les fonctionnalités de base. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=840640">le bug 840640</a> pour plus de détails.</p>
 
 <table class="standard-table">
  <thead>
   <tr>
-   <th scope="col">Fonctionnalité</th>
-   <th scope="col">Firefox Nightly</th>
-   <th scope="col">Firefox Developer Edition</th>
-   <th scope="col">Firefox Beta</th>
-   <th scope="col">Firefox Release</th>
-   <th scope="col">Préférence</th>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <td><strong>Sous-réseaux</strong></td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td><code>layout.css.grid-template-subgrid-value.enabled</code></td>
-  </tr>
-  <tr>
-   <td><strong>Afficher les caractères de contrôle errants en CSS sous forme de cases hexadécimales.</strong><br>
-    Cette fonction apporte les caractères de contrôle (Unicode category Cc) à part <em>tab</em> (<code>U+0009</code>), <em>line feed</em> (<code>U+000A</code>), <em>form feed</em> (<code>U+000C</code>), et <em>carriage return</em> (<code>U+000D</code>) comme une case hexadécimale lorsqu'ils ne sont pas attendus.</td>
-   <td>43</td>
-   <td>43</td>
-   <td><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1329613">Désactivé</a></td>
-   <td><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1329613">Désactivé</a></td>
-   <td><code>layout.css.control-characters.enabled</code> or <code>layout.css.control-characters.visible</code></td>
-  </tr>
-  <tr>
-   <td><strong>Masques CSS positionnés</strong><br>
-    A subset of CSS Masks that includes <a href="/en-US/docs/Web/CSS/CSS_Masks">longhand properties of CSS Masks</a>, as well as a change in the shorthand property</td>
-   <td>51</td>
-   <td>51</td>
+   <th scope="row">Nightly</th>
    <td>53</td>
-   <td><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1251161">Désactivé</a></td>
-   <td>Controllé par un flag de (MOZ_ENABLE_MASK_AS_SHORTHAND).</td>
+   <td>Oui</td>
   </tr>
   <tr>
-   <td>
-    <p><strong>La propriété de</strong> <strong><code>paramètres de variation de poilce</code></strong><br>
-     The {{cssxref("font-variation-settings")}} provides low-level control over OpenType or TrueType font typographic features, by specifying the four letter axis names of the features you want to vary, along with their variation values.</p>
-   </td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 53)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 53)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 53)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 53)</sub></td>
-   <td>
-    <p><code>layout.css.font-variations.enabled</code><br>
-     Functions only in Mac OS Sierra (and later).<br>
-     <br>
-     For the downloadable fonts on axis-praxis, you also need <code>gfx.downloadable_fonts.keep_variation_tables</code> (in Firefox 54 and later)</p>
-   </td>
+   <th scope="row">Developer Edition</th>
+   <td>53</td>
+   <td>Non</td>
   </tr>
   <tr>
-   <td><strong>La propriété CSS de <code>touch-action</code></strong><br>
-    La propriété CSS {{cssxref("touch-action")}} fait partie de la spécification {{SpecName("Pointer Events")}} et vous permet de spécifier de quelle façon un utilisateur peut manipuler un objet de façon tactile.</td>
+   <th scope="row">Beta</th>
+   <td>53</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>53</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>dom.dialog_element.enabled</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h3 id="global_attribute_inputmode">Attribut global inputmode</h3>
+
+<p>L'implémentation de l'attribut global <code><a href="/fr/docs/Web/HTML/Global_attributes/inputmode">inputmode</a></code> a été mise à jour afin de suivre la spécification WHATWG (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1509527">le bug 1509527</a>), mais d'autres changements sont encore nécessaires (par exemple, le rendre disponible pour le contenu <code>contenteditable</code>), voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1205133">le bug 1205133</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>75</td>
+   <td>Oui</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>75</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>75</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>75</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>dom.forms.inputmode</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h3 id="inert_attribute">Attribut inert</h3>
+
+<p>La propriété <a href="/fr/docs/Web/API/HTMLElement/inert"><code>HTMLElement.inert</code></a> de <a href="/fr/docs/Web/API/HTMLElement"><code>HTMLElement</code></a> est un booléen qui, lorsqu'il est présent, peut permettre au navigateur d'ignorer l'élément pour les technologies d'assistance, la recherche sur la page et la sélection de texte. Pour plus de détails sur cette fonctionnalité, voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1655722">le bug 1655722</a>.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>81</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>81</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>81</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>81</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>html5.inert.enabled</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h3 id="layout_for_input_typesearch">Disposition pour les champs input de type search</h3>
+
+<p>La mise en forme des éléments <code>input type="search"</code> a été mise à jour. Il y a désormais une icône qui apparaît après une saisie pour permettre d'effacer le champ. Ce comportement permet de rejoindre celui des autres navigateurs. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=558594">le bug 558594</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>81</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>81</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>81</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>81</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>layout.forms.input-type-search.enabled</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="css">CSS</h2>
+
+<h3 id="display_stray_control_characters_in_css_as_hex_boxes">Affichage des caractères de contrôle (rectangle avec valeur hexadécimale)</h3>
+
+<p>Cette fonctionnalité affiche les caractères de contrôle (catégorie Unicode Cc) autres que <em>tab</em> (<code>U+0009</code>), <em>saut de ligne</em> (<code>U+000A</code>), <em>saut de page</em> (<code>U+000C</code>) et <em>retour chariot</em> (<code>U+000D</code>) sous la forme d'un rectangle avec leur valeur hexadécimale à l'intérieur lorsque ces caractères sont inattendus. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1099557">le bug 1099557</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>43</td>
+   <td>Oui</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>43</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>43</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>43</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>layout.css.control-characters.enabled</code> ou <code>layout.css.control-characters.visible</code></th>
+  </tr>
+ </tbody>
+</table>
+
+
+<h3 id="property_initial-letter">Propriété initial-letter</h3>
+
+<p>La propriété CSS <a href="/fr/docs/Web/CSS/initial-letter"><code>initial-letter</code></a> fait partie du module de spécification <a href="https://drafts.csswg.org/css-inline/">CSS3 Inline</a> et permet d'indiquer l'élévation (entre autres) des lettres initiales. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1223880">le bug 1223880</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
    <td>50</td>
-   <td>—</td>
-   <td>—</td>
-   <td>—</td>
-   <td><code>layout.css.touch_action.enabled</code></td>
-  </tr>
-  <tr id="shape-outside">
-   <td>
-    <p><strong>The <code>shape-outside</code> CSS property</strong><br>
-     The {{cssxref("shape-outside")}} CSS property is part of the {{SpecName("CSS Shapes")}} specification and allows you to specify a float area causing inline contents to wrap around a shape.</p>
-
-    <p>Firefox currently implements the <code>&lt;shape-box&gt;</code> values ({{bug(1309467)}}) as well as the <code>circle()</code> ({{bug(1311244)}}), <code>ellipse()</code> ({{bug(1326406)}}), and <code>polygon()</code> ({{bug(1326409)}}) functions. {{cssxref("shape-outside")}} is animatable since Firefox 57 ({{bug(1289049)}}).</p>
-   </td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 53)</sub></td>
-   <td>—</td>
-   <td>—</td>
-   <td>—</td>
-   <td><code>layout.css.shape-outside.enabled</code></td>
-  </tr>
-  <tr>
-   <td><strong>The <code>contain</code> CSS property</strong><br>
-    The {{cssxref("contain")}} CSS property is part of the {{SpecName("CSS Containment")}} specification and allows you to indicate that an element and its contents are independent of the rest of the document tree, allowing {{Glossary("User agent", "user agents")}} to optimize the rendering of a page.</td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 45)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 45)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 45)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 45)</sub></td>
-   <td><code>layout.css.contain.enabled</code></td>
-  </tr>
-  <tr id="column-span">
-   <td>
-    <p><strong>The <code>column-span</code> CSS property</strong><br>
-     The {{cssxref("column-span")}} CSS property is part of the {{SpecName("CSS3 Multicol")}} specification and allows you to specify how many columns an element spans across.</p>
-
-    <p>Firefox currently only parses the property ({{bug(1339298)}}), it's not actually implemented yet ({{bug(616436)}}).</p>
-   </td>
-   <td>Désactivé<br>
-    <sub>(reconnu depuis 55, mais pas encore implémenté)</sub></td>
-   <td>—</td>
-   <td>—</td>
-   <td>—</td>
-   <td><code>layout.css.column-span.enabled</code></td>
-  </tr>
-  <tr>
-   <td><strong>The <code>frames()</code> timing function</strong><br>
-    See <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/single-transition-timing-function#The_frames()_class_of_timing-functions">The frames() class of timing-functions</a> for more details.</td>
-   <td>Activé</td>
-   <td><sub>N/A</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 55)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis55)</sub></td>
-   <td>Non</td>
-  </tr>
- </tbody>
-</table>
-
-<h2 id="JavaScript">JavaScript</h2>
-
-<p id="ECMAScript_2016">Voir aussi <a href="/en-US/docs/Web/JavaScript/New_in_JavaScript/ECMAScript_Next_support_in_Mozilla">ECMAScript Next support</a> pour l'implémentation de fonctionnalités du ECMA Script 2016 et postérieur, qui ne sont pas expérimentales et ainsi disponibles sans préférences dans Firefox Release.</p>
-
-<p>Désactivé</p>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Focntionnalité</th>
-   <th scope="col">Firefox Nightly</th>
-   <th scope="col">Firefox Developer Edition</th>
-   <th scope="col">Firefox Beta</th>
-   <th scope="col">Firefox Release</th>
-   <th scope="col">Préférence</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><strong>Ajouts à l'objet <code>ArrayBuffer</code> </strong><br>
-    Ajoute {{jsxref("ArrayBuffer.transfer()")}} qui renvoie un nouvel <code>ArrayBuffer</code> dont les données ont été récupérées de <code>oldBuffer</code>(<a href="https://gist.github.com/lukewagner/2735af7eea411e18cf20">spec</a>).</td>
-   <td>36</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
    <td>Non</td>
   </tr>
   <tr>
-   <td><strong>Objets TypedObject</strong> (<a href="https://github.com/dslomov-chromium/typed-objects-es7">spec</a>)</td>
-   <td>Activé</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td>Non</td>
-  </tr>
-  <tr>
-   <td><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD">SIMD</a> (<a href="https://github.com/johnmccutchan/ecmascript_simd">specification and polyfill</a>)</td>
-   <td>Activé</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td>Non</td>
-  </tr>
-  <tr>
-   <td><strong>Modules ECMAScript</strong><br>
-    Allows you to use native ECMAScript modules, for example defining modules with <code>&lt;script type="module"&gt;</code>, defining fallback scripts with <code>&lt;script nomodule&gt;</code>, and <a href="/en-US/docs/Web/JavaScript/Reference/Statements/import">importing</a> code features that have been <a href="/en-US/docs/Web/JavaScript/Reference/Statements/export">exported</a> from modules.</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td><code>dom.moduleScripts.enabled</code></td>
-  </tr>
- </tbody>
-</table>
-
-<h2 id="APIs">APIs</h2>
-
-<h3 id="Canvas_WebGL">Canvas &amp; WebGL</h3>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Fonctionnalité</th>
-   <th scope="col">Firefox Nightly</th>
-   <th scope="col">Firefox Developer Edition</th>
-   <th scope="col">Firefox Beta</th>
-   <th scope="col">Firefox Release</th>
-   <th scope="col">Préfrence</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><strong><code>WEBGL_debug_renderer_info</code> extension</strong><br>
-    The {{domxref("WEBGL_debug_renderer_info")}} extension allows you to transmit information useful to help debugging problems to the server.</td>
-   <td>42</td>
-   <td>42</td>
-   <td><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=742798">Désactivé</a></td>
-   <td><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=742798">Désactivé</a></td>
-   <td><code>webgl.enable-debug-renderer-info</code></td>
-  </tr>
-  <tr>
-   <td><strong>OffscreenCanvas</strong><br>
-    The {{domxref("OffscreenCanvas")}} interface provides a canvas that can be rendered off screen. It is available in both the window and <a href="/en-US/docs/Web/API/Web_Workers_API">worker</a> contexts.</td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 44)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 44)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 44)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 44)</sub></td>
-   <td><code>gfx.offscreencanvas.enabled</code></td>
-  </tr>
-  <tr>
-   <td><strong><a href="/en-US/docs/Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility">Hit regions</a></strong><br>
-    Whether the mouse coordinates are within a particular area on the canvas is a common problem to solve. The hit region API allows you define an area of your canvas and provides another possibility to expose interactive content on a canvas to accessibility tools.</td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 30)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 30)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 30)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 30)</sub></td>
-   <td><code>canvas.hitregions.enabled</code></td>
-  </tr>
-  <tr>
-   <td><strong><a href="/en-US/docs/Web/API/Streams_API">Streams API</a></strong><br>
-    Allows JavaScript to programmatically access streams of data received over the network and process them as desired by the developer.</td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 57)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 57)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 57)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 57)</sub></td>
-   <td><code>dom.streams.enabled</code> and <code>javascript.options.streams</code></td>
-  </tr>
- </tbody>
-</table>
-
-<h3 id="DOM">DOM</h3>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Fonctionnalité</th>
-   <th scope="col">Firefox Nightly</th>
-   <th scope="col">Firefox Developer Edition</th>
-   <th scope="col">Firefox Beta</th>
-   <th scope="col">Firefox Release</th>
-   <th scope="col">Préférence</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><strong>WebVR API 1.1 on Mac</strong><br>
-    The <a href="/en-US/docs/Web/API/WebVR_API">WebVR API</a> allows you to control and use virtual reality devices.</td>
-   <td>Activé</td>
-   <td>Activé</td>
-   <td>Activé</td>
-   <td>Désactivé</td>
-   <td><code>dom.vr.enabled</code></td>
-  </tr>
-  <tr>
-   <td><strong>Gamepad extensions</strong><br>
-    <a href="/en-US/docs/Web/API/Gamepad_API#Experimental_Gamepad_extensions">The Gamepad Extensions</a> provide access to additional functionality such as pose information in the case of WebVR controllers, and haptic actuator control (e.g. controller vibration hardware).</td>
-   <td>Activé</td>
-   <td>Activé</td>
-   <td>Activé</td>
-   <td>Désactivé</td>
-   <td><code>dom.gamepad-extensions.enabled</code></td>
-  </tr>
-  <tr>
-   <td><strong>FlyWeb</strong><br>
-    <a href="https://flyweb.github.io/">FlyWeb</a> is a project at Mozilla focused on bringing a new set of APIs to the browser for advertising and discovering local-area web servers.</td>
-   <td>51</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td><code>dom.flyweb.enabled</code></td>
-  </tr>
-  <tr>
-   <td><code><strong>HTMLMediaElement.seekToNextFrame()</strong></code><br>
-    Part of an experimentation process around support non-real-time access to media for tasks including filtering, editing, and so forth, the {{domxref("HTMLMediaElement.seekToNextFrame()")}} advances the the current play position to the next frame in the media.</td>
-   <td>49<br>
-    <sub>(Mise à jour fondamentale  dans la version 50)</sub></td>
-   <td>49<br>
-    <sub>(Mise à jour fondamentale   dans la version 50)</sub></td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td><code>media.seekToNextFrame.enabled</code></td>
-  </tr>
-  <tr>
-   <td><strong><code>GeometryUtils.getBoxQuads()</code></strong> ({{bug(917755)}})</td>
-   <td>31</td>
-   <td>31</td>
-   <td><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1107559">Désactivé</a></td>
-   <td><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1107559">Désactivé</a></td>
-   <td><code>layout.css.getBoxQuads.enabled</code></td>
-  </tr>
-  <tr>
-   <td><strong><code>GeometryUtils.convertPointFromNode()</code></strong>,<br>
-    <strong><code>GeometryUtils.RectFromNode()</code></strong>, and<br>
-    <code><strong>GeometryUtils.convertQuadFromNode()</strong></code><br>
-    ({{bug(918189)}})</td>
-   <td>31</td>
-   <td>31</td>
-   <td><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1107559">Désactivé</a></td>
-   <td><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1107559">Désactivé</a></td>
-   <td><code>layout.css.convertFromNode.enabled</code></td>
-  </tr>
-  <tr>
-   <td><strong><code>Node.rootNode</code></strong><br>
-    The {{domxref("Node.rootNode")}} property returns a {{domxref("Node")}} object representing the topmost node in the tree, or the current node if it's the topmost node in the tree.<br>
-    <em>This feature is kept experimental as its naming poses Web compatibility problems. It will be renamed in the future.</em></td>
-   <td>48</td>
-   <td>48</td>
-   <td><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1107559">Désactivé</a></td>
-   <td><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1107559">Désactivé</a></td>
-   <td><code>dom.node.rootNode.enabled</code></td>
-  </tr>
-  <tr>
-   <td><strong>WebVTT Regions API</strong><br>
-    <a href="/en-US/docs/Web/API/Web_Video_Text_Tracks_Format">WebVTT</a> regions are parts of the video viewport that provide a rendering area for WebVTT cues. The {{domxref("VTTRegion")}} is the interface exposing the WebVTT cues.<br>
-    <em>This interface is considered to be in flux and isn't therefore activated in any version by default.</em></td>
-   <td>Désactivé<br>
-    <sub>(Implementation expériemnatle depuis la version 30)</sub></td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td><code>media.webvtt.regions.enabled</code></td>
-  </tr>
-  <tr>
-   <td><strong>Support for audio and video tracks</strong><br>
-    Implements {{domxref("HTMLMediaElement.audioTracks")}} and {{domxref("HTMLMediaElement.videoTracks")}}.<br>
-    <em>Firefox doesn't support multiple audio or video tracks, preventing the most common use cases for these properties to work properly. That's why these properties are not activated by default in any version.</em></td>
-   <td>Désactivé<br>
-    <sub>(Implementation expériemnatle depuis la version 33)</sub></td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td><code>media.track.enabled</code></td>
-  </tr>
-  <tr>
-   <td><strong>Better value for <code>Event.timestamp</code></strong><br>
-    The property {{domxref("Event.timestamp")}} is returning a {{domxref("DOMHighResTimeStamp")}}, which is now relative to the Unix epoch.</td>
-   <td>32 (Windows)<br>
-    43 (Linux)</td>
-   <td>32 (Windows)<br>
-    43 (Linux)</td>
-   <td><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1107559">Désactivé</a></td>
-   <td><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1107559">Désactivé</a></td>
-   <td><code>media.track.enabled</code></td>
-  </tr>
-  <tr id="pointer-events">
-   <td><strong>Pointer Events</strong></td>
+   <th scope="row">Developer Edition</th>
    <td>50</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td><code>dom.w3c_pointer_events.enabled</code></td>
-  </tr>
-  <tr>
-   <td><strong>Pointer Events {{domxref("PointerEvent.tangentialPressure")}} and {{domxref("PointerEvent.twist")}}</strong></td>
-   <td>54</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td><code>dom.w3c_pointer_events.enabled</code></td>
-  </tr>
-  <tr>
-   <td><strong>Intersection Observer API</strong><br>
-    The {{domxref("Intersection Observer API")}} allows you to configure a callback that is called whenever one item, called a target, intersects either the device viewport or a specified element called.</td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 53)</sub></td>
-   <td>—</td>
-   <td>—</td>
-   <td>—</td>
-   <td><code>dom.IntersectionObserver.enabled</code></td>
-  </tr>
-  <tr>
-   <td><strong><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API: KeyframeEffect and KeyframeEffectReadOnly</a></strong><br>
-    The {{domxref("KeyframEffectReadOnly()", "KeyframeEffectReadOnly.KeyframeEffectReadOnly()")}} and {{domxref("KeyframeEffect()", "KeyframeEffect.KeyframeEffect()")}} constructors can be used to clone existing {{domxref("KeyframeEffectReadOnly")}} object instances by being given the object to clone as their only parameter (see {{bug(1273784)}}.)</td>
-   <td>52</td>
-   <td>52</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
    <td>Non</td>
   </tr>
   <tr>
-   <td><strong>{{domxref("PromiseRejectionEvent")}} and related features</strong><br>
-    Providing a way to monitor and more finely control the rejection of Promises.<br>
-     </td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 55)</sub></td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td><code>dom.promise_rejection_events.enabled</code></td>
+   <th scope="row">Beta</th>
+   <td>50</td>
+   <td>Non</td>
   </tr>
   <tr>
-   <td><strong><a href="/en-US/docs/Web/API/Payment_Request_API">Payment Request API</a></strong><br>
-    Provides a web API for handling web-based payments.</td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 55)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 55)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 55)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 55)</sub></td>
-   <td><code>dom.payments.request.enabled</code></td>
+   <th scope="row">Release</th>
+   <td>50</td>
+   <td>Non</td>
   </tr>
   <tr>
-   <td><strong>Basic Card Payment API</strong><br>
-    Provides dictionaries that define data structures describing card payment types and payment responses for use in the Payment Request API. See {{domxref("BasicCardRequest")}} and {{domxref("BasicCardResponse")}}.</td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 56)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 56)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 56)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 56)</sub></td>
-   <td><code>dom.payments.request.enabled</code></td>
-  </tr>
-  <tr>
-   <td>The proprietary {{domxref("Window.content")}} property is now only available to chrome (privileged) code, and not available to the web anymore ({{bug(864845)}}).</td>
-   <td>Activé<br>
-    <sub>(depuis 57)</sub></td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td></td>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>layout.css.initial-letter.enabled</code></th>
   </tr>
  </tbody>
 </table>
 
-<h3 id="WebRTC">WebRTC</h3>
+<h3 id="property_aspect-ratio">Propriété aspect-ratio</h3>
+
+<p>La propriété CSS <a href="/fr/docs/Web/CSS/aspect-ratio"><code>aspect-ratio</code></a> est décrite dans le module de spécification <a href="https://drafts.csswg.org/css-sizing-4/">CSS4 Sizing</a> et permet de créer des boîtes qui respectent des proportions (<i>aspect ratio</i> en anglais) données. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1639963">le bug 1639963</a> et <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1646096">le bug 1646096</a> pour plus de détails.</p>
 
 <table class="standard-table">
  <thead>
   <tr>
-   <th scope="col">Fonctionnalité</th>
-   <th scope="col">Firefox Nightly</th>
-   <th scope="col">Firefox Developer Edition</th>
-   <th scope="col">Firefox Beta</th>
-   <th scope="col">Firefox Release</th>
-   <th scope="col">Préférence</th>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
   </tr>
  </thead>
  <tbody>
   <tr>
-   <td><strong>TCP ICE candidates</strong><br>
-    ICE candidates that use TCP rather than UDP are considered during ICE negotiation.</td>
-   <td>
-    <p>Désactivé<br>
-     41</p>
-
-    <p>Désactivé<br>
-     54</p>
-   </td>
-   <td>Désactivé<br>
-    41</td>
-   <td>Désactivé<br>
-    41</td>
-   <td>Désactivé<br>
-    41</td>
-   <td><code>media.peerconnection.ice.tcp</code></td>
+   <th scope="row">Nightly</th>
+   <td>81</td>
+   <td>Oui</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>81</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>81</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>81</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>layout.css.aspect-ratio.enabled</code></th>
   </tr>
  </tbody>
 </table>
 
-<h2 id="Outils_de_développeurs">Outils de développeurs</h2>
+<h3 id="descriptor_size_adjust">Descripteur size-adjust</h3>
+
+<p>Le descripteur CSS <a href="/fr/docs/Web/CSS/@font-face/size-adjust"><code>@font-face/size-adjust</code></a> est décrit dans le module de spécification <a href="https://drafts.csswg.org/css-fonts-5/">CSS5 Fonts</a> et définit un facteur de multiplication pour les contours des glyphes et les métriques associées à la police. Cela facilite l'harmonisation lorsqu'on utilise plusieurs polices qui sont affichées avec le même corps. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1698495">le bug 1698495</a> pour plus de détails.</p>
 
 <table class="standard-table">
  <thead>
   <tr>
-   <th scope="col">Fonctionnalité</th>
-   <th scope="col">Firefox Nightly</th>
-   <th scope="col">Firefox Developer Edition</th>
-   <th scope="col">Firefox Beta</th>
-   <th scope="col">Firefox Release</th>
-   <th scope="col">Préférence</th>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
   </tr>
  </thead>
  <tbody>
-  <tr id="new-debugger-frontend">
-   <td><strong>Debugger rewrite in HTML</strong></td>
-   <td>52</td>
-   <td>52</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td><code>devtools.debugger.new-debugger-frontend</code></td>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>89</td>
+   <td>Oui</td>
   </tr>
-  <tr id="new-console-frontend">
-   <td><strong>Console rewrite in HTML</strong></td>
-   <td>52</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td><code>devtools.webconsole.new-frontend-enabled</code></td>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>89</td>
+   <td>Non</td>
   </tr>
-  <tr id="performance-tool-options">
-   <td><strong>Experimental Performance tool options</strong><br>
-    Enables options in the UI for JIT optimizations, memory, etc.</td>
-   <td>41</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td><code>devtools.performance.ui.experimental</code></td>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>89</td>
+   <td>Non</td>
   </tr>
-  <tr id="layout-side-panel">
-   <td><strong>Layout side panel</strong><br>
-    The Layout side panel allows to inspect and manage different CSS layout types like <a href="/en-US/docs/Web/CSS/CSS_Grid_Layout">CSS Grid Layout</a>.</td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 52)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponbile depuis 52)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 52)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 52)</sub></td>
-   <td><code>devtools.layoutview.enabled</code></td>
+  <tr>
+   <th scope="row">Release</th>
+   <td>89</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>layout.css.size-adjust.enabled</code></th>
   </tr>
  </tbody>
 </table>
 
-<h2 id="Sécurité">Sécurité</h2>
+<h3 id="single_numbers_as_aspect_ratio_in_media_queries">Nombres seuls pour les proportions dans les requêtes média</h3>
+
+<p>Il s'agit ici de la prise en charge permettant d'utiliser un seul nombre (<a href="/fr/docs/Web/CSS/number"><code>number</code></a>) pour exprimer le <a href="/fr/docs/Web/CSS/ratio">ratio</a> lors de la définition d'une <a href="/fr/docs/Web/CSS/Media_Queries">requête média</a>. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1565562">le bug 1565562</a> pour plus de détails.</p>
 
 <table class="standard-table">
  <thead>
   <tr>
-   <th scope="col">Fonctionnalité</th>
-   <th scope="col">Firefox Nightly</th>
-   <th scope="col">Firefox Developer Edition</th>
-   <th scope="col">Firefox Beta</th>
-   <th scope="col">Firefox Release</th>
-   <th scope="col">Préférence</th>
-  </tr>
-  <tr>
-   <td><strong>TLS 1.3</strong></td>
-   <td>Activé</td>
-   <td>Activé</td>
-   <td>Désactivé</td>
-   <td>Désactivé</td>
-   <td><code>security.tls.version.max</code> to <code>4</code></td>
-  </tr>
-  <tr>
-   <td><strong>Blocking data URL navigations on the top-level window</strong><br>
-    We are experimenting with blocking <code>data:</code> URLs on the top-level window. See <a href="https://www.fxsitecompat.com/en-CA/docs/2017/data-url-navigations-on-top-level-window-will-be-blocked/">Data URL navigations on top level window will be blocked</a> for a detailed explanation.</td>
-   <td>Activé</td>
-   <td>n/a</td>
-   <td>Activé</td>
-   <td>Désactivé</td>
-   <td><code>security.data_uri.block_toplevel<br>
-    _data_uri_navigations</code></td>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
   </tr>
  </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>70</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>70</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>70</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>70</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>layout.css.aspect-ratio-number.enabled</code></th>
+  </tr>
+ </tbody>
 </table>
 
-<h2 id="Autre">Autre</h2>
+<h3 id="property_backdrop-filter">Propriété backdrop-filter</h3>
+
+<p>La propriété <a href="/fr/docs/Web/CSS/backdrop-filter"><code>backdrop-filter</code></a> permet d'appliquer des effets de filtre à la zone située derrière un élément. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1178765">le bug 1178765</a> pour plus de détails.</p>
 
 <table class="standard-table">
  <thead>
   <tr>
-   <th scope="col">Fonctionnalité</th>
-   <th scope="col">Firefox Nightly</th>
-   <th scope="col">Firefox Developer Edition</th>
-   <th scope="col">Firefox Beta</th>
-   <th scope="col">Firefox Release</th>
-   <th scope="col">Préférence</th>
-  </tr>
-  <tr>
-   <td><a href="https://support.mozilla.org/t5/Other/How-to-add-a-shortcut-to-a-website-on-Android/ta-p/21992"><strong>Ajouter à l'écran d'accueil</strong></a><br>
-    The <code>icons</code>, <code>name</code>, <code>short_name</code>, and <code>theme_color</code> fields of the <a href="/en-US/docs/Web/Manifest">Web App Manifest</a> (if present) can now be as the source of the homescreen/apps window icons, apps window title, homescreen icon title, and apps window color (respectively) for "Add to home screen" (Firefox Mobile only).</td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 53)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 53)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 53)</sub></td>
-   <td>Désactivé<br>
-    <sub>(disponible depuis 52)</sub></td>
-   <td><code>manifest.install.enabled</code></td>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
   </tr>
  </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>70</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>70</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>70</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>70</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>layout.css.backdrop-filter.enabled</code></th>
+  </tr>
+ </tbody>
 </table>
 
-<h2 id="Voir_Aussi">Voir Aussi</h2>
+<h3 id="grid_masonry_layout">Grilles : disposition en maçonnerie</h3>
+
+<p>Cette fonctionnalité ajoute la prise en charge pour <a href="/fr/docs/Web/CSS/CSS_Grid_Layout/Masonry_Layout">les dispositions « en maçonnerie »</a> basées sur les grilles où un axe est organisé avec une disposition donnée et où l'autre suit une disposition de grille normale. Cela permet aux développeuses et développeurs de créer plus facilement des dispositions pour des galeries. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1607954">le bug 1607954</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>77</td>
+   <td>Oui</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>77</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>77</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>77</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>layout.css.grid-template-masonry-value.enabled</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h3 id="media_feature_prefers-contrast">Caractéristique média prefers-contrast</h3>
+
+<p>La caractéristique média <code><a href="/fr/docs/Web/CSS/@media/prefers-contrast">prefers-contrast</a></code> est utilisée afin de déterminer si une utilisatrice ou un utilisateur indiqué une préférence pour un contraste élevé ou non. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1506364">le bug 1506364</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>80</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>80</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>80</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>80</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2">
+    <p><code>layout.css.prefers-contrast.enabled</code></p>
+   </th>
+  </tr>
+ </tbody>
+</table>
+
+<h3 id="property_math-style">Propriété math-style </h3>
+
+<p>La propriété <a href="/fr/docs/Web/CSS/math-style"><code>math-style</code></a> indique si les équations MathML doivent être affichées avec une hauteur normale ou compacte. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1665975">le bug 1665975</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>83</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>83</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>83</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>83</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>layout.css.math-style.enabled</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="javascript">JavaScript</h2>
+
+<h3 id="relative_indexing_method">Méthode at() pour l'indexation relative</h3>
+
+<p>La méthode <code>at()</code> qui permet d'utiliser une indexation relative a été ajoutée aux objets <code><a href="/fr/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a></code>, <code><a href="/fr/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></code> et <code><a href="/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray">TypedArray</a></code>. L'utilisation d'un entier positif comme argument renverra l'élément situé à cet index tandis qu'un entier négatif permettra de récupérer un élément à partir de la fin du tableau ou de la chaîne. Ainsi <code>1</code> fournira le deuxième élément tandis que <code>-1</code> renverra le dernier élément. Voir <code><a href="/fr/docs/Web/JavaScript/Reference/Global_Objects/Array/at">Array.prototype.at()</a></code>, <code><a href="/fr/docs/Web/JavaScript/Reference/Global_Objects/String/at">String.prototype.at()</a></code> et <code><a href="/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/at">TypedArray.prototype.at()</a></code> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>85</td>
+   <td>Oui</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>85</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>85</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>85</td>
+   <td>Non</td>
+  </tr>
+ </tbody>
+</table>
+
+<h3 id="private_class_fields">Champs de classe privés</h3>
+
+<p>Voir la page <a href="/fr/docs/Web/JavaScript/Reference/Classes/Private_class_fields">sur les champs de classe privés</a> pour plus d'informations.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>81</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>81</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>81</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>81</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Noms des préférences</th>
+   <th colspan="2"><code>javascript.options.experimental.private_fields<br>
+    javascript.options.experimental.private_methods</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="apis">Fonctionnalités des API Web</h2>
+
+<h3 id="graphics_canvas_webgl_and_webgpu">Graphismes : Canvas, WebGL, WebGPU</h3>
+
+<h4 id="canvasrenderingcontext2d.createConicGradient">CanvasRenderingContext2D.createConicGradient()</h4>
+
+<p>L'interface <a href="/fr/docs/Web/API/CanvasRenderingContext2D"><code>CanvasRenderingContext2D</code></a> rattachée à l'API <a href="/fr/docs/Web/API/Canvas_API"><code>Canvas</code></a> fournit désormais une méthode <a href="/fr/docs/Web/API/CanvasRenderingContext2D/createConicGradient"><code>createConicGradient()</code></a>. Celle-ci renvoie une valeur <a href="/fr/docs/Web/API/CanvasGradient"><code>CanvasGradient</code></a> à la façon des méthodes existantes pour les <a href="/fr/docs/Web/API/CanvasRenderingContext2D/createLinearGradient">dégradés linéaires</a> et <a href="/fr/docs/Web/API/CanvasRenderingContext2D/createRadialGradient">radiaux</a> mais pour les dégradés coniques. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1627014">le bug 1627014</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>86</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>86</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>86</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>86</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>canvas.createConicGradient.enabled</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h4 id="interface_offscreencanvas">Interface OffscreenCanvas</h4>
+
+<p>L'interface <a href="/fr/docs/Web/API/OffscreenCanvas"><code>OffscreenCanvas</code></a> fournit un canevas dont le rendu est effectué en dehors de l'écran. Il est disponible dans les contextes de la fenêtre et des <a href="/fr/docs/Web/API/Web_Workers_API">workers</a>. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1390089">le bug 1390089</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>44</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>44</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>44</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>44</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>gfx.offscreencanvas.enabled</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h4 id="hit_regions">API Hit Regions</h4>
+
+<p>Déterminer si les coordonnées de la souris sont situées dans une région donnée d'un canevas est un problème courant. L'API Hit Regions permet de définir une zone du canevas et fournit d'autres outils pour exposer le contenu interactif d'un canevas aux outils d'accessibilité.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>30</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>30</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>30</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>30</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>canvas.hitregions.enabled</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h4 id="webgpu_api">WebGPU API</h4>
+
+<p>Cette nouvelle API fournit une prise en charge bas niveau pour les calculs et le rendu graphique en utilisant le GPU de l'appareil. <a href="https://gpuweb.github.io/gpuweb/">La spécification</a> est toujours en cours d'écriture. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1602129">le bug 1602129</a> pour l'état de l'implémentation pour cette API.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>73</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>73</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>73</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>73</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>dom.webgpu.enabled</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h3 id="html_dom_api">API HTML DOM</h3>
+
+<h4 id="htmlmediaelement_method_setsinkid">Méthode setSinkId() pour HTMLMediaElement</h4>
+
+<p><a href="/fr/docs/Web/API/HTMLMediaElement/setSinkId"><code>HTMLMediaElement.setSinkId()</code></a> permet de définir l'identifiant d'un « sink » d'un appareil de sortie audio sur un <a href="/fr/docs/Web/API/HTMLMediaElement"><code>HTMLMediaElement</code></a> ce qui permet de modifier l'endroit où l'audio sort. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=934425">le bug 934425</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>64</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>64</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>64</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>64</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>media.setsinkid.enabled</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h4 id="htmlmediaelement_properties_audiotracks_and_videotracks">Propriétés audioTracks et videoTracks pour HTMLMediaElement</h4>
+
+<p>Cette fonctionnalité ajoute les propriétés <a href="/fr/docs/Web/API/HTMLMediaElement/audioTracks"><code>HTMLMediaElement.audioTracks</code></a> et <a href="/fr/docs/Web/API/HTMLMediaElement/videoTracks"><code>HTMLMediaElement.videoTracks</code></a> aux éléments HTML qui sont des médias. Toutefois, comme Firefox ne prend actuellement pas en charge les pistes audio et vidéo multiples, les cas d'usage de ces propriétés ne fonctionnent pas et elles sont donc désactivées par défaut. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1057233">le bug 1057233</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>33</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>33</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>33</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>33</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>media.track.enabled</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h3 id="dom">DOM</h3>
+
+<h4 id="clipboarditem">ClipboardItem</h4>
+
+<p>L'interface <a href="/fr/docs/Web/API/ClipboardItem"><code>ClipboardItem</code></a>, rattachée à l'API <a href="/fr/docs/Web/API/Clipboard_API"><code>Clipboard API</code></a> est désormais prise en charge et <a href="/fr/docs/Web/API/Clipboard/write"><code>Clipboard.write()</code></a> accepte une série d'<a href="/fr/docs/Web/API/ClipboardItem">éléments de presse-papier (<code>ClipboardItem</code>)</a> plutôt que l'implémentation précédente avec des objets <a href="/fr/docs/Web/API/DataTransfer">DataTransfer</a>. Elle est disponible avec la préférence <code>dom.events.asyncClipboard.clipboardItem</code> qui était précédemment intitulée <code>dom.events.asyncClipboard.dataTransfer</code>. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1619947">le bug 1619947</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>87</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>87</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>87</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>87</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code><strong>dom.events.asyncClipboard.clipboardItem</strong></code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h4 id="html_sanitizer_api">API HTML Sanitizer</h4>
+
+<p>L'API <a href="/fr/docs/Web/API/HTML_Sanitizer_API"><code>HTML Sanitizer</code></a> permet aux développeuses et développeurs de prendre en entrée des chaînes de caractères HTML non sécurisées et de les nettoyer afin de pouvoir les insérer dans le DOM d'un document. Les éléments par défaut pour chaque propriété de configuration sont toujours en cours d'étude. Pour cette raison, le paramètre de configuration n'a pas été implémenté. Voir <a href="/fr/docs/Web/API/Sanitizer/sanitizer">la documentation du constructeur</a> pour plus d'informations et <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1673309">le bug 1673309</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>84</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>84</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>84</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>84</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code><strong>dom.security.sanitizer.enabled</strong></code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h4 id="document_property_autoplaypolicy">Propriété autoplayPolicy pour Document</h4>
+
+<p>La propriété <a href="/fr/docs/Web/API/Document/autoplayPolicy"><code>autoplayPolicy</code></a>, rattachée à <a href="/fr/docs/Web/API/Document"><code>document</code></a>, renvoie une chaîne de caractères indiquant la façon dont le navigateur gère les requêtes pour la lecture automatique des médias (déclenchée avec l'utilisation de la propriété <a href="/fr/docs/Web/API/HTMLMediaElement/autoplay"><code>autoplay</code></a> ou via le déclenchement de la lecture depuis du code JavaScript). La spécification de cette API est en cours d'écriture. La valeur de cette propriété évolue selon les actions de l'utilisateur, leurs préférences/configurations et de l'état du navigateur. Les valeurs possibles sont <code>allowed</code> (la lecture automatique est possible), <code>allowed-muted</code> (la lecture automatique est possible mais sans audio), et <code>disallowed</code> (la lecture automatique n'est pas possible). Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1506289">le bug 1506289</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>66</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>66</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>66</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>66</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>dom.media.autoplay.autoplay-policy-api</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h4 id="geometryutils_methods_convertpointfromnode_convertrectfromnode_and_convertquadfromnode">Méthodes convertPointFromNode(), convertRectFromNode(), et convertQuadFromNode() pour GeometryUtils</h4>
+
+<p>Les méthodes <code>convertPointFromNode()</code>, <code>convertRectFromNode()</code>, et <code></code>convertQuadFromNode()</code> effectuent la correspondance entre un point, un rectangle ou un quadrilatère donné et le <a href="/fr/docs/Web/API/Node"><code>Node</code></a> depuis lequel ils sont appelés vers un autre nœud. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=918189">le bug 918189</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>31</td>
+   <td>Oui</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>31</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>31</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>31</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>layout.css.getBoxQuads.enabled</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h4 id="geometryutils_method_getboxquads">Méthode getBoxQuads() pour GeometryUtils</h4>
+
+<p>La méthode <code>getBoxQuads()</code> pour <code>GeometryUtils</code> renvoie les boîtes CSS d'un objet <a href="/fr/docs/Web/API/Node"><code>Node</code></a> relatif à un autre nœud ou à la zone d'affichage. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=917755">le bug 917755</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>31</td>
+   <td>Oui</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>31</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>31</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>31</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>layout.css.convertFromNode.enable</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h3 id="payment_request_api">API Payment Request</h3>
+
+<h4 id="primary_payment_handling">Gestion de la méthode de paiement principale</h4>
+
+<p>L'API <a href="/fr/docs/Web/API/Payment_Request_API">Payment Request</a> permet de gérer les paiements au sein de contenu ou d'application web. En raison d'un bug lors des tests de l'interface utilisateur, il a été décidé de suspendre la sortie de cette API tant que des discussions sont en cours sur des changements potentiels à cette API. Le travail est en cours. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1318984">le bug 1318984</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>55</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>55</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>55</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>55</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>dom.payments.request.enabled</code> et <code>dom.payments.request.supportedRegions</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h4 id="basic_card_api">API Basic Card</h4>
+
+<p>Il s'agit d'étendre l'API <a href="/fr/docs/Web/API/Payment_Request_API">Payment Request</a> avec des dictionnaires définissant les structures de données qui décrivent les types de cartes de paiement et les réponses de paiement. Voir <a href="/fr/docs/Web/API/BasicCardRequest"><code>BasicCardRequest</code></a> et <a href="/fr/docs/Web/API/BasicCardResponse"><code>BasicCardResponse</code></a>.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>56</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>56</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>56</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>56</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>dom.payments.request.enabled</code> and<br>
+    <code>dom.payments.request.supportedRegions</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h3 id="visual_viewport_api">API Visual Viewport</h3>
+
+<p>L'API <a href="/fr/docs/Web/API/Visual_Viewport_API">Visual Viewport</a> (qu'on peut traduire en « zone d'affichage visuelle ») donne accès à des informations décrivant la position de <a href="/fr/docs/Glossary/visual_viewport">la zone d'affichage visuelle</a> relative au document et à la zone de contenu de la fenêtre. Elle contient également des évènements pour surveiller les évolutions. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1550390">le bug 1550390</a> pour plus de détails. Il n'est pas prévu de fournir cette API sur la version pour ordinateur de bureau, voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1551302">le bug 1551302</a> si besoin.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>63</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>63</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>63</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>63</td>
+   <td>À partir de Firefox 68, sur Android uniquement</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>dom.visualviewport.enabled</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h3 id="constructable_stylesheets">Constructeur pour les feuilles de style</h3>
+
+<p>Cette fonctionnalité ajoute un constructeur pour l'interface <a href="/fr/docs/Web/API/CSSStyleSheet"><code>CSSStyleSheet</code></a> et d'autres modifications permettant de créer de nouvelles feuilles de style sans avoir à ajouter la feuille au HTML. Cela permet de créer des feuilles de style réutilisables beaucoup plus facilement afin de les utiliser avec <a href="/fr/docs/Web/Web_Components/Using_shadow_DOM">Shadow DOM</a>. L'implémentation actuelle n'est pas encore terminée. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1520690">le bug 1520690</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>73</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>73</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>73</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>73</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>layout.css.constructable-stylesheets.enabled</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h3 id="webrtc_and_media">WebRTC et média</h3>
+
+<p>Les fonctionnalités expérimentales qui suivent incluent celles relatives aux API suivantes <a href="/fr/docs/Web/API/WebRTC_API">WebRTC</a>, <a href="/fr/docs/Web/API/Web_Audio_API">Web Audio</a>, <a href="/fr/docs/Web/API/Media_Source_Extensions_API">Media Source Extensions</a>, <a href="/fr/docs/Web/API/Encrypted_Media_Extensions_API">Encrypted Media Extensions</a>, et <a href="/fr/docs/Web/API/Media_Streams_API">Media Capture and Streams</a>.</p>
+
+<h4 id="asynchronous_sourcebuffer_add_and_remove">Méthodes asynchrones pour l'ajout et le retrait sur SourceBuffer</h4>
+
+<p>Cette fonctionnalité ajoute les méthodes <a href="/fr/docs/Web/API/SourceBuffer/appendBufferAsync"><code>appendBufferAsync()</code></a> et <a href="/fr/docs/Web/API/SourceBuffer/removeAsync"><code>removeAsync()</code></a> qui fonctionnent avec des promesses et permettent d'ajouter et de retirer des tampons de source média à l'interface <a href="/fr/docs/Web/API/SourceBuffer"><code>SourceBuffer</code></a>. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1280613">le bug 1280613</a> et <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=778617">le bug 778617</a> pour plus d'informations.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>62</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>62</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>62</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>62</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>media.mediasource.experimental.enabled</code></th>
+  </tr>
+ </tbody>
+</table>
+
+
+<h4 id="avif_av1_image_file_format_support">Prise en charge du format AVIF (AV1 Image File)</h4>
+
+<p>Avec cette fonctionnalité, Firefox prend en charge le format <a href="/fr/docs/Web/Media/Formats/Image_types#avif">AV1 Image File (AVIF)</a>. Il s'agit d'un format d'image tirant parti des algorithmes de compression vidéo AV1 pour réduire la taille des images. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1443863">le bug 1443863</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>77</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>77</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>77</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>77</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>image.avif.enabled</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h4 id="av1_support_for_firefox_on_android">Prise en charge d'AV1 pour Firefox sur Android</h4>
+
+<p>Cette fonctionnalité permet à Firefox sur Android d'utiliser <a href="/fr/docs/Web/Media/Formats/Video_codecs#av1">le format AV1</a>. Cette fonctionnalité est disponible pour les versions <i>nightly</i> pour Firefox sur Android à partir de la version 81. Elle est activée par défaut.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>81</td>
+   <td>Oui</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>—</td>
+   <td>—</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>—</td>
+   <td>—</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>—</td>
+   <td>—</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2">—</th>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="security_and_privacy">Sécurité et confidentialité</h2>
+
+<h4 id="block_plain_text_requests_from_flash_on_encrypted_pages">Block plain text requests from Flash on encrypted pages</h4>
+
+<p>Afin d'atténuer le risque d'attaque de l'homme du milieu (MitM) pour le contenu Flash sur les pages chiffrées, une préférence a été ajoutée afin de traiter <code>OBJECT_SUBREQUEST</code> comme du contenu actif. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1190623">le bug 1190623</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>59</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>59</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>59</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>59</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>security.mixed_content.block_object_subrequest</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h4 id="insecure_page_labeling">Indication des pages non-sécurisées</h4>
+
+<p>Les deux préférences suivantes permettent d'ajouter un libellé « Non-sécurisé » dans la barre d'adresse à côté de l'icône de cadenas lorsqu'une page est chargée de façon non-sécurisée (via <a href="/fr/docs/Glossary/HTTP">HTTP</a> plutôt qu'avec <a href="/fr/docs/Glossary/https">HTTPS</a>). Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1335970">le bug 1335970</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>60</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>60</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>60</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>60</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>security.insecure_connection_text.enabled</code> pour la navigation en mode normale, <code>security.insecure_connection_text.pbmode.enabled</code> pour la navigation en mode privé</th>
+  </tr>
+ </tbody>
+</table>
+
+<h4 id="upgrading_mixed_display_content">Mise à niveau pour les médias chargés avec une sécurité mixte</h4>
+
+<p>Lorsque la préférence correspondante est activée, Firefox passe les requêtes des contenus média HTTP en HTTPS pour les pages sécurisées. L'objectif est d'éviter des conditions de contenu mixte où du contenu serait chargé de façon sécurisée tandis qu'un autre contenu serait chargé de façon non-sécurisée. Si la bascule en HTTPS échoue (par exemple si l'hôte qui sert le média ne prend pas en charge HTTPS), le média n'est pas chargé. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1435733">le bug 1435733</a >pour plus de détails.</p>
+
+<p>Cela modifie également l'avertissement de la console : si la mise à niveau réussit, un message indiquant que la requête a été mise à niveau est affiché plutôt qu'un avertissement.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>84</td>
+   <td>Oui</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>60</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>60</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>60</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>security.mixed_content.upgrade_display_content</code></th>
+  </tr>
+ </tbody>
+</table>
+
+
+<h4 id="feature_policy">En-tête Feature-Policy</h4>
+
+<p><a href="/fr/docs/Web/HTTP/Feature_Policy">Feature-Policy</a> est un en-tête HTTP qui permet de choisir l'activation, la désactivation ou certaines des fonctionnalités et API dans le navigateur. Cet en-tête est similaire au CSP mais permet de contrôler des fonctionnalités plutôt que des traits liés à la sécurité.</p>
+
+<div class="notecard note">
+  <h4>Note</h4>
+  <p>L'en-tête <code>Feature-Policy</code> a été renommé en <code>Permissions-Policy</code> dans la spécification. Cet article sera mis à jour afin de refléter ce changement.</p>
+</div>
+
+<table class="standard-table">
+  <thead>
+   <tr>
+    <th scope="col" style="vertical-align: bottom;">Canal</th>
+    <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+    <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+   </tr>
+  </thead>
+  <tbody>
+   <tr>
+    <th scope="row">Nightly</th>
+    <td>65</td>
+    <td>Non</td>
+   </tr>
+   <tr>
+    <th scope="row">Developer Edition</th>
+    <td>65</td>
+    <td>Non</td>
+   </tr>
+   <tr>
+    <th scope="row">Beta</th>
+    <td>65</td>
+    <td>Non</td>
+   </tr>
+   <tr>
+    <th scope="row">Release</th>
+    <td>65</td>
+    <td>Non</td>
+   </tr>
+   <tr>
+    <th scope="row">Nom de la préférence</th>
+    <th colspan="2"><code>dom.security.featurePolicy.header.enabled</code></th>
+   </tr>
+  </tbody>
+ </table>
+
+<h2 id="developer_tools">Outils de développement</h2>
+
+<h4 id="execution_context_selector">Sélecteur pour le contexte d'exécution</h4>
+
+<p>Cette fonctionnalité affiche un bouton sur la ligne de commande de la console qui permet de changer le contexte dans lequel l'expression saisie est exécutée. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1605154">le bug 1605154</a> and <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1605153">le bug 1605153</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>75</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>75</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>75</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>75</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>devtools.webconsole.input.context</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h4 id="mobile_gesture_support_in_responsive_design_mode">Prise en charge des gestes mobiles en vue adaptative</h4>
+
+<p>Les gestes à la souris peuvent être utilisés pour simuler des gestes tactiles sur mobiles comme le défilement, le zoom en pinçant, l'appui long ou l'appui double. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1621781">le bug 1621781</a>, <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1245183">le bug 1245183</a>, et <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1401304">le bug 1401304</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>76<sup>[1]</sup></td>
+   <td>Oui</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>76<sup>[1]</sup></td>
+   <td>Oui</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>76<sup>[1]</sup></td>
+   <td>Oui</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>76<sup>[1]</sup></td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2">n/a</th>
+  </tr>
+ </tbody>
+</table>
+
+<p>[1] La prise en charge pour le geste de double toucher a été ajouté avec Firefox 76. Les autres gestes ont été ajoutés avec Firefox 79.</p>
+
+<h4 id="server-sent_events_in_Network_Monitor">Évènements émis par le serveur dans le moniteur réseau</h4>
+
+<p>Cette fonctionnalité permet au moniteur réseau d'afficher des informations sur <a href="/fr/docs/Web/API/Server-sent_events">les évènements émis par le serveur</a>. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1405706">le bug 1405706</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>80</td>
+   <td>Oui</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>80</td>
+   <td>Oui</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>80</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>80</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>devtools.netmonitor.features.serverSentEvents</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h4 id="css_browser_compatibility_tooltips">Bulles d'informations pour la compatibilité CSS des navigateurs</h4>
+
+<p>La vue pour les règles CSS peut afficher des bulles d'informations pour la compatibilité des navigateurs pour les propriétés qui ont des problèmes connus. Pour plus d'informations, voir : <a href="/fr/docs/Tools/Page_Inspector/How_to/Examine_and_edit_HTML#browser_compat_warnings">Examiner et éditer le HTML &gt; Avertissements de compatibilité navigateur</a>.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>81</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>81</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>81</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>81</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>devtools.inspector.ruleview.inline-compatibility-warning.enabled</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="ui">Interface utilisateur (UI)</h2>
+
+<h4 id="desktop_zooming">Zoom (version bureau)</h4>
+
+<p>Cette fonctionnalité permet, pour les ordinateurs de bureau, un zoom doux avec le geste de pincement sans qu'il y ait de redessin de l'écran, à la façon des appareils mobiles. Voir <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1245183">le bug 1245183</a> et <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1620055">le bug 1620055</a> pour plus de détails.</p>
+
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col" style="vertical-align: bottom;">Canal</th>
+   <th scope="col" style="vertical-align: bottom;">Ajouté dans la version</th>
+   <th scope="col" style="vertical-align: bottom;">Activé par défaut</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <th scope="row">Nightly</th>
+   <td>42</td>
+   <td>Oui</td>
+  </tr>
+  <tr>
+   <th scope="row">Developer Edition</th>
+   <td>42</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Beta</th>
+   <td>42</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Release</th>
+   <td>42</td>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Nom de la préférence</th>
+   <th colspan="2"><code>apz.allow_zooming</code> et pour Windows : <code>apz.windows.use_direct_manipulation</code></th>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="see_also">Voir aussi</h2>
 
 <ul>
- <li><a href="/en-US/docs/Mozilla/Firefox/Releases">Firefox developer release notes</a></li>
+ <li><a href="/fr/docs/Mozilla/Firefox/Releases">Les notes de version pour Firefox destinées aux développeuses et développeurs</a></li>
  <li><a href="https://nightly.mozilla.org/">Firefox Nightly</a></li>
- <li><a href="https://www.mozilla.org/en-US/firefox/developer/">Firefox Developer Edition</a></li>
+ <li><a href="https://www.mozilla.org/fr/firefox/developer/">Firefox Developer Edition</a></li>
 </ul>

--- a/files/fr/mozilla/firefox/experimental_features/index.html
+++ b/files/fr/mozilla/firefox/experimental_features/index.html
@@ -12,7 +12,9 @@ translation_of: Mozilla/Firefox/Experimental_features
 
 <p class="summary">Afin de tester les nouvelles fonctionnalités, Mozilla publie chaque jour une version test du navigateur Firefox , <a href="https://nightly.mozilla.org/">Firefox Nightly</a>. Les fonctionnalités expérimentales, par exemple l'implantation de standards de plateforme Web, sont disponibles. Cette page liste les procédures qui sont données par les versions Nightly de Firefox avec les informations pour les activer si nécessaire. Vous pouvez tester vos sites Web et les applications avant que ces procédures soient mises en mise à jour en ligne et vous assurer ainsi que tout fonctionnera avec le potentiel de la dernière technologie Web.</p>
 
-<p>Pour tester les nouveautés, téléchargez <a href="https://nightly.mozilla.org/">Firefox Nightly</a> ou <a href="https://www.mozilla.org/en-US/firefox/developer/">Firefox Developer Edition</a>.</p>
+<p>Les nouvelles fonctionnalités apparaissent d'abord dans la version <a href="https://nightly.mozilla.org/">Nightly</a> de Firefox, où elles sont souvent activées par défaut. Elles arrivent ensuite dans <a href="https://www.mozilla.org/fr/firefox/developer/">Firefox Developer Edition</a> et finalement dans la version finale. Une fois qu'une fonctionnalité est activée par défaut dans une version publiée, elle n'est plus expérimentale et doit être retirée de la liste.</p>
+
+<p>Les fonctionnalités expérimentales peuvent être activées ou désactivées à l'aide de <a href="https://support.mozilla.org/fr/kb/editeur-configuration-firefox">l'éditeur de configuration de Firefox</a> (entrez <code>about:config</code> dans la barre d'adresse de Firefox) en modifiant les <em>préférences</em> associées énumérées ci-dessous.</p>
 
 <h2 id="HTML">HTML</h2>
 
@@ -64,30 +66,6 @@ translation_of: Mozilla/Firefox/Experimental_features
      <sub>(disponible depuis 75)</sub></p>
    </td>
    <td><code>dom.forms.inputmode</code></td>
-  </tr>
-  <tr>
-   <td>
-    <p><strong>&lt;link rel="preload"&gt;</strong></p>
-
-    <p>L'attribut {{htmlattrxref ("rel", "link")}} de l'élément {{HTMLElement ("link")}} est destiné à améliorer les performances en vous permettant de télécharger des ressources plus tôt dans le cycle de vie de la page, en vous assurant qu'elles sont disponibles plus tôt et sont moins susceptibles de bloquer le rendu de la page. Lisez le contenu de <a href="https://wiki.developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content">préchargement avec rel = "preload"</a> pour plus de détails. Plus de détails sur l'état de cette fonctionnalité : {{bug (1639607)}}.</p>
-   </td>
-   <td>
-    <p>Activé<br>
-     <sub>(disponible depuis 78)</sub></p>
-   </td>
-   <td>
-    <p>Activé<br>
-     <sub>(disponible depuis 78)</sub></p>
-   </td>
-   <td>
-    <p>Activé<br>
-     <sub>(disponible depuis 78)</sub></p>
-   </td>
-   <td>
-    <p>Désactivé<br>
-     <sub>(disponible depuis 78)</sub></p>
-   </td>
-   <td><code>network.preload</code></td>
   </tr>
  </thead>
 </table>


### PR DESCRIPTION
The network.preload setting is enabled in stable since FF78.

The introduction has been extended to match the english version.