### PR TITLE
Fix sample in scroll-snap-type page

### DIFF
--- a/files/ru/web/css/scroll-snap-type/index.html
+++ b/files/ru/web/css/scroll-snap-type/index.html
@@ -219,7 +219,7 @@ html, body, .holster {
 
 <h3 id="Результат">Результат</h3>
 
-<p>{{EmbedLiveSample("Пример", "100%", "1630")}}</p>
+<p>{{EmbedLiveSample("Example", "100%", "1630")}}</p>
 
 <h2 id="Спецификация">Спецификация</h2>
 


### PR DESCRIPTION
Исправил отображение примера указанного в https://github.com/mdn/translated-content/issues/986.

Решение аналогично https://github.com/mdn/translated-content/pull/1088.