### PR TITLE
use plain Compat macro

### DIFF
--- a/files/ja/web/css/blend-mode/index.html
+++ b/files/ja/web/css/blend-mode/index.html
@@ -393,7 +393,7 @@ translation_of: Web/CSS/blend-mode
 
 <div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
 
-<p>{{Compat("css.types.blend-mode")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>
 


### PR DESCRIPTION
This now works because of https://github.com/mdn/yari/pull/3955
So if the en-US document has a `browser-compat` key in its front-matter, so will the Japanese document. 