### PR TITLE
use plain Compat macro (sample, fr)

### DIFF
--- a/files/fr/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.html
+++ b/files/fr/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.html
@@ -97,7 +97,7 @@ usedOptions.month;           // "numeric"</pre>
 
 <div class="hidden">Ce tableau de compatibilité a été généré à partir de données structurées. Si vous souhaitez contribuer à ces données, n'hésitez pas à envoyer une <em>pull request</em> sur <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>.</div>
 
-<p>{{Compat("javascript.builtins.Intl.DateTimeFormat.resolvedOptions")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="Voir_aussi">Voir aussi</h2>
 

--- a/files/fr/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.html
+++ b/files/fr/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.html
@@ -2,33 +2,32 @@
 title: Intl.DateTimeFormat.prototype.resolvedOptions()
 slug: Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions
 tags:
-  - Internationalisation
+  - DateTimeFormat
+  - Internationalization
   - Intl
   - JavaScript
-  - Méthode
+  - Localization
+  - Method
   - Prototype
   - Reference
-  - i18n
 translation_of: Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions
 original_slug: Web/JavaScript/Reference/Objets_globaux/Intl/DateTimeFormat/resolvedOptions
 ---
 <div>{{JSRef}}</div>
 
-<p>La méthode <code><strong>Intl.DateTimeFormat.prototype.resolvedOptions()</strong></code> renvoie un nouvel objet dont les propriétés reflètent les options de format et de locale pour les heures et dates, calculées pendant l'initialisation de l'objet {{jsxref("DateTimeFormat", "Intl.DateTimeFormat")}}.</p>
+<p>La méthode <code><strong>Intl.DateTimeFormat.prototype.resolvedOptions()</strong></code> renvoie un nouvel objet dont les propriétés reflètent les options de format et de locale pour les heures et dates, calculées pendant l'initialisation de l'objet <a href="/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat"><code>Intl.DateTimeFormat</code></a>.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-resolvedoptions.html")}}</div>
 
-<p class="hidden">Le code source de cet exemple interactif est disponible dans un dépôt GitHub. Si vous souhaitez contribuez à ces exemples, n'hésitez pas à cloner <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> et à envoyer une <em>pull request</em> !</p>
+<h2 id="syntax">Syntaxe</h2>
 
-<h2 id="Syntaxe">Syntaxe</h2>
+<pre class="brush: js">resolvedOptions()</pre>
 
-<pre class="syntaxbox"><var>dateTimeFormat</var>.resolvedOptions()</pre>
+<h3 id="return_value">Valeur de retour</h3>
 
-<h3 id="Valeur_de_retour">Valeur de retour</h3>
+<p>Un nouvel objet dont les propriétés reflètent les options de format et de locale pour les heures et dates, calculées pendant l'initialisation de l'objet <a href="/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat"><code>Intl.DateTimeFormat</code></a>.</p>
 
-<p>Un nouvel objet dont les propriétés reflètent les options de format et de locale pour les heures et dates, calculées pendant l'initialisation de l'objet {{jsxref("DateTimeFormat", "Intl.DateTimeFormat")}}</p>
-
-<h2 id="Description">Description</h2>
+<h2 id="description">Description</h2>
 
 <p>La valeur renvoyée par cette méthode contient les propriétés suivantes :</p>
 
@@ -40,23 +39,16 @@ original_slug: Web/JavaScript/Reference/Objets_globaux/Intl/DateTimeFormat/resol
  <dt><code>numberingSystem</code></dt>
  <dd>Les valeurs demandées pour les extensions Unicode <code>"ca"</code> et <code>"nu"</code> ou leurs valeurs par défaut.</dd>
  <dt><code>timeZone</code></dt>
- <dd>La valeur fournie par l'argument <code>options</code> pour cette propriété ou {{jsxref("undefined")}} (qui représente le fuseau horaire de l'environnement) si aucune valeur n'a été fournie. Les applications ne doivent pas s'appuyer sur ce dernier cas. En effet, de futures versions pourraient renvoyer une chaîne de caractères représentant le fuseau horaire de l'environnement et non pas <code>undefined</code>.</dd>
+ <dd>La valeur fournie par l'argument <code>options</code> pour cette propriété ou <a href="/fr/docs/Web/JavaScript/Reference/Global_Objects/undefined"><code>undefined</code></a> (qui représente le fuseau horaire de l'environnement) si aucune valeur n'a été fournie. Les applications ne doivent pas s'appuyer sur ce dernier cas. En effet, de futures versions pourraient renvoyer une chaîne de caractères représentant le fuseau horaire de l'environnement et non pas <code>undefined</code>.</dd>
  <dt><code>hour12</code></dt>
  <dd>La valeur fournie pour cette propriété dans l'argument <code>options</code>.</dd>
- <dt><code>weekday</code></dt>
- <dt><code>era</code></dt>
- <dt><code>year</code></dt>
- <dt><code>month</code></dt>
- <dt><code>day</code></dt>
- <dt><code>hour</code></dt>
- <dt><code>minute</code></dt>
- <dt><code>second</code></dt>
- <dt><code>timeZoneName</code></dt>
+ <dt><code>weekday</code>, <code>era</code>, <code>year</code>, <code>month</code>, <code>day</code>, <code>hour</code>, <code>minute</code>, <code>second</code>, <code>timeZoneName</code></dt>
  <dd>Les valeurs qui correspondent entre les propriétés de l'argument <code>options</code> et les combinaisons disponibles dans l'environnement pour les formats de date et d'heure pour la locale. Certaines de ces propriétés peuvent ne pas être présentes, cela indique que les composants indiqués ne seront pas représentés.</dd>
 </dl>
 
-<h2 id="Exemples">Exemples</h2>
+<h2 id="examples">Exemples</h2>
 
+<h3 id="using_the_resolvedoptions_method">Utiliser la méthode resolvedOptions()</h3>
 <pre class="brush: js">var germanFakeRegion = new Intl.DateTimeFormat("de-XX", { timeZone: "UTC" });
 var usedOptions = germanFakeRegion.resolvedOptions();
 
@@ -66,41 +58,16 @@ usedOptions.numberingSystem; // "latn"
 usedOptions.timeZone;        // "UTC"
 usedOptions.month;           // "numeric"</pre>
 
-<h2 id="Spécifications">Spécifications</h2>
+<h2 id="specifications">Spécifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Spécification</th>
-   <th scope="col">État</th>
-   <th scope="col">Commentaires</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ES Int 1.0', '#sec-12.3.3', 'Intl.DateTimeFormat.prototype.resolvedOptions')}}</td>
-   <td>{{Spec2('ES Int 1.0')}}</td>
-   <td>Définition initiale.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('ES Int 2.0', '#sec-Intl.DateTimeFormat.prototype.resolvedOptions', 'Intl.DateTimeFormat.prototype.resolvedOptions')}}</td>
-   <td>{{Spec2('ES Int 2.0')}}</td>
-   <td> </td>
-  </tr>
-  <tr>
-   <td>{{SpecName('ES Int Draft', '#sec-Intl.DateTimeFormat.prototype.resolvedOptions', 'Intl.DateTimeFormat.prototype.resolvedOptions')}}</td>
-   <td>{{Spec2('ES Int Draft')}}</td>
-   <td> </td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
-<h2 id="Compatibilité_des_navigateurs">Compatibilité des navigateurs</h2>
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
 
-<div class="hidden">Ce tableau de compatibilité a été généré à partir de données structurées. Si vous souhaitez contribuer à ces données, n'hésitez pas à envoyer une <em>pull request</em> sur <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>.</div>
+<div>{{Compat}}</div>
 
-<p>{{Compat}}</p>
-
-<h2 id="Voir_aussi">Voir aussi</h2>
+<h2 id="see_also">Voir aussi</h2>
 
 <ul>
- <li>{{jsxref("DateTimeFormat", "Intl.DateTimeFormat")}}</li>
+ <li><a href="/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat"><code>Intl.DateTimeFormat</code></a></li>
 </ul>


### PR DESCRIPTION
Thanks to https://github.com/mdn/yari/pull/3955 we can no use just `{{Compat}}` instead of `{{Compat("that.bcd.compat.id")}}` if the en-US parent document as a `browser-compat` key in the front matter, which I think it does for every single JS reference page. 

This PR is just a demo to prove that. 