### PR TITLE
Web/HTML/Link_types 以下のファイル5つを新規翻訳

### DIFF
--- a/files/ja/web/html/link_types/dns-prefetch/index.html
+++ b/files/ja/web/html/link_types/dns-prefetch/index.html
@@ -1,0 +1,23 @@
+---
+title: 'リンク種別: dns-prefetch'
+slug: Web/HTML/Link_types/dns-prefetch
+tags:
+  - Attribute
+  - HTML
+  - Link
+  - Link types
+  - Reference
+browser-compat: html.elements.link.rel.dns-prefetch
+translation_of: Web/HTML/Link_types/dns-prefetch
+---
+<p><span class="seoSummary"><strong><code>dns-prefetch</code></strong> キーワードを {{HTMLElement("link")}} 要素の {{HTMLAttrxRef("rel", "link")}} 属性に指定すると、ユーザーがターゲットリソースのオリジンにあるリソースを必要としている可能性が高く、したがってブラウザーがそのオリジンの DNS 解決を先取りして実行することでユーザーの使い勝手が向上する可能性が高いというヒントをブラウザーに与えます。</span></p>
+
+<p>詳しくは <a href="/ja/docs/Web/Performance/dns-prefetch">dns-prefetch の使用</a>を参照してください。</p>
+
+<h2 id="Specifications">仕様書</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">ブラウザーの互換性</h2>
+
+<p>{{Compat}}</p>

--- a/files/ja/web/html/link_types/manifest/index.html
+++ b/files/ja/web/html/link_types/manifest/index.html
@@ -1,0 +1,23 @@
+---
+title: 'リンク種別: manifest'
+slug: Web/HTML/Link_types/manifest
+tags:
+  - App
+  - Attribute
+  - HTML
+  - Link
+  - Link types
+  - Manifest
+  - Reference
+browser-compat: html.elements.link.rel.manifest
+translation_of: Web/HTML/Link_types/manifest
+---
+<p><span class="seoSummary"><strong><code>manifest</code></strong> キーワードを {{HTMLElement("link")}} 要素の {{HTMLAttrxRef("rel", "link")}} 属性に指定すると、ターゲットリソースが<a href="/ja/docs/Web/Manifest">ウェブアプリマニフェスト</a>であることを示します。</span></p>
+
+<h2 id="Specifications">仕様書</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">ブラウザーの互換性</h2>
+
+<p>{{Compat}}</p>

--- a/files/ja/web/html/link_types/modulepreload/index.html
+++ b/files/ja/web/html/link_types/modulepreload/index.html
@@ -1,0 +1,21 @@
+---
+title: 'リンク種別: modulepreload'
+slug: Web/HTML/Link_types/modulepreload
+tags:
+  - Attribute
+  - HTML
+  - Link
+  - Link types
+  - Reference
+browser-compat: html.elements.link.rel.modulepreload
+translation_of: Web/HTML/Link_types/modulepreload
+---
+<p><span class="seoSummary"><strong><code>modulepreload</code></strong> キーワードを {{HTMLElement("link")}} 要素の {{HTMLAttrxRef("rel", "link")}} 属性に指定すると、<a href="/ja/docs/Web/JavaScript/Guide/Modules">モジュールスクリプト</a>とその依存関係を先取りして取得し、後で評価するために文書のモジュールマップに保存するための宣言的な方法を提供します。</span></p>
+
+<h2 id="Specifications">仕様書</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">ブラウザーの互換性</h2>
+
+<p>{{Compat}}</p>

--- a/files/ja/web/html/link_types/noopener/index.html
+++ b/files/ja/web/html/link_types/noopener/index.html
@@ -1,0 +1,29 @@
+---
+title: 'リンク種別: noopener'
+slug: Web/HTML/Link_types/noopener
+tags:
+  - Attribute
+  - HTML
+  - Link types
+  - Reference
+browser-compat: html.elements.a.rel.noopener
+translation_of: Web/HTML/Link_types/noopener
+---
+<p><span class="seoSummary"><strong><code>noopener</code></strong> キーワードを  {{HTMLElement("a")}}, {{HTMLElement("area")}}, {{HTMLElement("form")}} の各要素の <code><a href="/ja/docs/Web/HTML/Attributes/rel">rel</a></code> 属性に指定すると、ターゲットリソースへ移動する際、開いた元の文書へのアクセスを新しい閲覧コンテキストに許可しないことをブラウザーに指示します。開かれたウィンドウの {{DOMxRef("Window.opener")}} プロパティプロパティは設定されません (<code>null</code> を返します)。</span></p>
+
+<p>これは、信頼されていないリンクを開くときに特に有効で、 {{DOMxRef("Window.opener")}} プロパティを介して発信元の文書を改ざんできないようにするためです (詳細は <a href="https://mathiasbynens.github.io/rel-noopener/">rel=noopener について</a>を参照してください)。ただし、 HTTP の <code>Referer</code> ヘッダーは (<code>noreferrer</code> を同時に使用しない限り) 提供されます。</p>
+
+<p>なお、 <code>noopener</code> を使用した場合、ターゲット名に <code>_top</code>, <code>_self</code>, <code>_parent</code> 以外の空でない名前を使用すると、新しいウィンドウやタブを開くかどうかの判断において、すべて <code>_blank</code> と同様に扱われます。</p>
+
+<div class="notecard note">
+ <h4>補足</h4>
+ <p><code>target="_blank"</code> を <code>&lt;a&gt;</code> 要素に設定すると、暗黙的に <code>rel</code> の動作が <code>rel="noopener"</code> を設定した場合と同様、 <code>window.opener</code> を設定しないようになりました。対応状況については<a href="/ja/docs/Web/HTML/Element/a#browser_compatibility">ブラウザーの互換性</a>を参照してください。</p>
+</div>
+
+<h2 id="Specifications">仕様書</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">ブラウザーの互換性</h2>
+
+<p>{{Compat}}</p>

--- a/files/ja/web/html/link_types/noreferrer/index.html
+++ b/files/ja/web/html/link_types/noreferrer/index.html
@@ -1,0 +1,20 @@
+---
+title: 'リンク種別: noreferrer'
+slug: Web/HTML/Link_types/noreferrer
+tags:
+  - Attribute
+  - HTML
+  - Link types
+  - Reference
+browser-compat: html.elements.a.rel.noreferrer
+translation_of: Web/HTML/Link_types/noreferrer
+---
+<p><span class="seoSummary"><strong><code>noreferrer</code></strong> キーワードを  {{HTMLElement("a")}}, {{HTMLElement("area")}}, {{HTMLElement("form")}} の各要素の <code><a href="/ja/docs/Web/HTML/Attributes/rel">rel</a></code> 属性に指定すると、ターゲットリソースへ移動する際、 {{HTTPHeader("Referer")}} ヘッダーを省略してリファラー情報が漏洩しないようにブラウザーに指示します。それに加えて、 <code><a href="/ja/docs/Web/HTML/Link_types/noopener">noopener</a></code> キーワードを設定しているかのように動作します。</span></p>
+
+<h2 id="Specifications">仕様書</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">ブラウザーの互換性</h2>
+
+<p>{{Compat}}</p>


### PR DESCRIPTION
2021/06/04 時点の英語版に基づき以下の文書を翻訳
- dns-prefetch
- manifest
- modulepreload
- noopener
- noreferrer