### PR TITLE
fix: remove duplicated link, change terms

### DIFF
--- a/files/ru/web/css/css_grid_layout/index.html
+++ b/files/ru/web/css/css_grid_layout/index.html
@@ -3,9 +3,9 @@ title: CSS Grid Layout
 slug: Web/CSS/CSS_Grid_Layout
 translation_of: Web/CSS/CSS_Grid_Layout
 ---
-<p><strong>CSS Grid layout</strong> отлично подходит для того, чтобы разделить страницу на основные области или определить взаимосвязь размера, позиционирования и уровня между частями контента, состоящего из HTML примитивов.</p>
+<p><strong>CSS Grid Layout</strong> отлично подходит для того, чтобы разделить страницу на основные области или определить взаимосвязь размера, позиционирования и уровня между частями контента, состоящего из HTML примитивов.</p>
 
-<p>Как и таблицы (&lt;table&gt;), grid layout позволяет выравнивать элементы в столбцы и строки. Тем не менее, с помощью CSS grid работать с элементами гораздо проще, чем с таблицами. Например, дочерние элементы grid-контейнера могут наслаиваться друг на друга как  и другие элементы при помощи CSS.</p>
+<p>Как и таблицы (&lt;table&gt;), Grid Layout позволяет выравнивать элементы в столбцы и строки. Тем не менее, с помощью CSS Grid работать с элементами гораздо проще, чем с таблицами. Например, дочерние элементы Grid-контейнера могут наслаиваться друг на друга как  и другие элементы при помощи CSS.</p>
 
 <h2 id="Basic_Example" name="Basic_Example">Базовый пример</h2>
 
@@ -137,7 +137,6 @@ translation_of: Web/CSS/CSS_Grid_Layout
  <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout">Связь Grid Layout с другими методами компоновки</a></li>
  <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines">И</a><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines">спользование</a><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines"> именованных линий</a></li>
  <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas">Шаблон области сетки</a></li>
- <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines">И</a><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines">спользование</a><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines"> именованных линий</a></li>
  <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Auto-placement_in_CSS_Grid_Layout">Авторазмещение в CSS Grid Layout</a></li>
  <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout">Выравнивание блока в CSS Grid Layout</a></li>
  <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid,_Logical_Values_and_Writing_Modes">CSS Сетка, логические Значения и Режимы Редактирования</a></li>

--- a/files/ru/web/css/css_grid_layout/index.html
+++ b/files/ru/web/css/css_grid_layout/index.html
@@ -5,7 +5,7 @@ translation_of: Web/CSS/CSS_Grid_Layout
 ---
 <p><strong>CSS Grid Layout</strong> отлично подходит для того, чтобы разделить страницу на основные области или определить взаимосвязь размера, позиционирования и уровня между частями контента, состоящего из HTML примитивов.</p>
 
-<p>Как и таблицы (&lt;table&gt;), Grid Layout позволяет выравнивать элементы в столбцы и строки. Тем не менее, с помощью CSS Grid работать с элементами гораздо проще, чем с таблицами. Например, дочерние элементы Grid-контейнера могут наслаиваться друг на друга как  и другие элементы при помощи CSS.</p>
+<p>Как и таблицы (&lt;table&gt;), grid layout позволяет выравнивать элементы в столбцы и строки. Тем не менее, с помощью CSS grid работать с элементами гораздо проще, чем с таблицами. Например, дочерние элементы grid-контейнера могут наслаиваться друг на друга как  и другие элементы при помощи CSS.</p>
 
 <h2 id="Basic_Example" name="Basic_Example">Базовый пример</h2>
 
@@ -133,16 +133,19 @@ translation_of: Web/CSS/CSS_Grid_Layout
 
 <div class="index">
 <ul>
- <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Базовая концепция Grid Layout</a></li>
+ <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Базовая концепция Grid Layout</a></li>
  <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout">Связь Grid Layout с другими методами компоновки</a></li>
- <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines">И</a><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines">спользование</a><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines"> именованных линий</a></li>
+ <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid">Расположение элементов по грид-линиям с помощью CSS Grid</a></li>
  <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas">Шаблон области сетки</a></li>
- <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Auto-placement_in_CSS_Grid_Layout">Авторазмещение в CSS Grid Layout</a></li>
- <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout">Выравнивание блока в CSS Grid Layout</a></li>
+ <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines">Использование именованных линий</a></li>
+ <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Auto-placement_in_CSS_Grid_Layout">Авторазмещение в CSS Grid Layout</a></li>
+ <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout">Выравнивание блока в CSS Grid Layout</a></li>
  <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid,_Logical_Values_and_Writing_Modes">CSS Сетка, логические Значения и Режимы Редактирования</a></li>
  <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Layout_and_Accessibility">CSS Grid Layout и доступность</a></li>
  <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_and_Progressive_Enhancement">CSS Grid and progressive enhancement</a></li>
  <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Realising_common_layouts_using_CSS_Grid_">Реализация общих макетов используя CSS Grid</a></li>
+ <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Subgrid">Subgrid</a></li>
+ <li><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Masonry_Layout">Masonry Layout</a>{{Experimental_Inline}}</li>
 </ul>
 </div>
 


### PR DESCRIPTION
- remove duplicated link in "Руководства" section
- change CSS Grid Layout terms in the article  in the same style (with capital fitst letter of a term)