### PR TITLE
Fix typo in pt-br boolean  glossary

### DIFF
--- a/files/pt-br/glossary/boolean/index.html
+++ b/files/pt-br/glossary/boolean/index.html
@@ -4,7 +4,7 @@ slug: Glossary/Boolean
 translation_of: Glossary/Boolean
 original_slug: Glossario/Booleano
 ---
-<p>Um <strong>booleano</strong>, em ciência da computação, é um tipo de dado lógico que pode ter apenas um de dois valores possíveis: <code>verdadeiro</code> ou <code>falso</code>. Por exemplo, em JavaScript, condicionais booleanas são usadas para decidir quais trechos do cógigo serão executados ou repetidas.</p>
+<p>Um <strong>booleano</strong>, em ciência da computação, é um tipo de dado lógico que pode ter apenas um de dois valores possíveis: <code>verdadeiro</code> ou <code>falso</code>. Por exemplo, em JavaScript, condicionais booleanas são usadas para decidir quais trechos do código serão executados ou repetidas.</p>
 
 <p> </p>
 


### PR DESCRIPTION
- English: Fixed a  typo in pt-br boolean glossary.
  - Typo: `cógigo` -> `código`


- Portuguese (Português): Corrigido erro de digitação no glossário sobre booleanos em português.
  - Erro de digitação: `cógigo` -> `código`