### PR TITLE
[ko] Fix typo in 'Track the score and win'

### DIFF
--- a/files/ko/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.html
+++ b/files/ko/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.html
@@ -15,7 +15,7 @@ original_slug: Games/Tutorials/순수한_자바스크립트를_이용한_2D_벽�
 <p>{{PreviousNext("Games/Tutorials/2D_Breakout_game_pure_JavaScript/Collision_detection", "Games/Tutorials/2D_Breakout_game_pure_JavaScript/Mouse_controls")}}</p>
 
 <div class="summary">
-<p>이번 단계는  <a href="/ko/docs/Games/Tutorials/2D_Breakout_game_pure_JavaScript">Gamedev Canvas tutorial</a>의 8번째 단계입니다. <a href="https://github.com/end3r/Gamedev-Canvas-workshop/blob/gh-pages/lesson08.html">Gamedev-Canvas-workshop/lesson8.html</a>에서 이번 단계의 소스 코드를 확인할 수 있습니다.</p>
+<p>이번 단계는 <a href="/ko/docs/Games/Tutorials/2D_Breakout_game_pure_JavaScript">Gamedev Canvas tutorial</a>의 8번째 단계입니다. <a href="https://github.com/end3r/Gamedev-Canvas-workshop/blob/gh-pages/lesson08.html">Gamedev-Canvas-workshop/lesson8.html</a>에서 이번 단계의 소스 코드를 확인할 수 있습니다.</p>
 </div>
 
 <p><span class="seoSummary">벽돌 깨기 기능은 잘 작동합니다. 하지만 더 나은 게임이 되기 위해서, 유저가 벽돌을 깰 때마다 점수를 얻고, 그 점수를 기록하는 점수 기능을 만들 수 있습니다.</span></p>
@@ -91,7 +91,7 @@ original_slug: Games/Tutorials/순수한_자바스크립트를_이용한_2D_벽�
 <p>{{JSFiddleEmbed("https://jsfiddle.net/yumetodo/2m74vr9r/1/","","395")}}</p>
 
 <div class="note">
-<p><strong>추가학습</strong>: 벽돌을 깰 때마다 얻는 점수를 늘리고, 게임 클리어 시 최종 점수를 경고창에 표시해 봅시다.</p>
+<p><strong>추가 학습</strong>: 벽돌을 깰 때마다 얻는 점수를 늘리고, 게임 클리어 시 최종 점수를 경고창에 표시해 봅시다.</p>
 </div>
 
 <h2 id="다음_단계">다음 단계</h2>


### PR DESCRIPTION
https://developer.mozilla.org/ko/docs/Games/Tutorials/2D_Breakout_game_pure_JavaScript/Track_the_score_and_win

#987 브랜치 정리하는 과정에서 실수로 커밋 한개를 체리픽 안 했었는데 관련하여 pr합니다.

해당 커밋은 그냥 작은 오탈자 수정사항 2개 있었던 것으로 보이는데 하나는 #987 리뷰되는 동안 리뷰어님께서 수정해 주셨고 이번 pr에서 나머지 하나 (띄어쓰기 한 칸 삭제) 수정했고, 덧붙여 추가적으로 새롭게 띄어쓰기 한 칸 추가했습니다.