### PR TITLE
Firefox 89 for developers を翻訳

### DIFF
--- a/files/ja/mozilla/firefox/releases/89/index.html
+++ b/files/ja/mozilla/firefox/releases/89/index.html
@@ -1,0 +1,87 @@
+---
+title: Firefox 89 for developers
+slug: Mozilla/Firefox/Releases/89
+tags:
+  - '89'
+  - Firefox
+  - Mozilla
+  - Release
+---
+<p>{{FirefoxSidebar}}</p>
+
+<p class="summary">このページでは、開発者に影響する Firefox 89 の変更点をまとめています。Firefox 89 は、米国時間 2021 年 6 月 1 日にリリースされました。</p>
+
+<div class="note notecard">
+  <h4>注記</h4>
+  <p>Mozilla Hacks の <a href="https://hacks.mozilla.org/2021/06/looking-fine-with-firefox-89/">Looking fine with Firefox 89</a> もご覧ください。</p>
+</div>
+
+<h2 id="Changes_for_web_developers" name="Changes_for_web_developers">ウェブ開発者向けの変更点一覧</h2>
+
+<h3 id="Developer_Tools" name="Developer_Tools">開発者ツール</h3>
+
+<p><em>変更なし。</em></p>
+
+<h3 id="HTML" name="HTML">HTML</h3>
+
+<p><em>変更なし。</em></p>
+
+<h3 id="CSS" name="CSS">CSS</h3>
+
+<ul>
+  <li>{{cssxref("@media/forced-colors","forced-colors")}} メディア特性を実装しました ({{bug(1659511)}})。</li>
+  <li><code>@font-face</code> の {{cssxref("@font-face/ascent-override", "ascent-override")}}、{{cssxref("@font-face/descent-override", "descent-override")}}、{{cssxref("@font-face/line-gap-override", "line-gap-override")}} ディスクリプターを実装しました ({{bug(1681691)}} および {{bug(1704494)}})。</li>
+  <li>{{cssxref("image-set()","image-set()")}} の <code>type()</code> 関数を実装しました ({{bug(1695404)}})。</li>
+</ul>
+
+<h3 id="JavaScript" name="JavaScript">JavaScript</h3>
+
+<ul>
+  <li>トップレベルの <a href="/ja/docs/Web/JavaScript/Reference/Operators/await#top-level-await"><code>await</code></a> をデフォルトで有効にしました ({{bug(1681046)}})。</li>
+  <li>64 ビットシステムで、長さが 2GB-1 より大きい (最大 8GB) <a href="/ja/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer">ArrayBuffer</a> を作成できるようになりました ({{bug(1703505)}})。</li>
+</ul>
+
+<h3 id="HTTP" name="HTTP">HTTP</h3>
+
+<p><em>変更なし。</em></p>
+
+<h3 id="APIs" name="APIs">API</h3>
+
+<h4 id="DOM" name="DOM">DOM</h4>
+
+<ul>
+  <li>{{domxref("PerformanceEventTiming")}} をデフォルトで有効にしました ({{bug(1701029)}})。</li>
+  <li>{{htmlelement("input")}} および {{htmlelement("textarea")}} 要素の内容物を、デフォルトで {{domxref("Document.execCommand()")}} コマンドを使用して操作できるようになりました。<a href="/ja/docs/Web/HTML/Global_attributes/contenteditable"><code>contentEditable</code></a> などの冗長な回避策なしに、編集履歴の維持やほかのブラウザとの同等性を提供します ({{bug(1220696)}})。</li>
+</ul>
+
+<h4 id="removals_media" name="removals_media">廃止</h4>
+
+<ul>
+  <li>以下のセンサーイベントおよび関連するハンドラーを削除しました (主にほかの主要なブラウザーエンジンとの互換性を向上するため、またプライバシー侵害の懸念に対処するため):
+     <ul>
+       <li>{{domxref("DeviceProximityEvent")}} および <code>window.ondeviceproximity</code> イベントハンドラー ({{bug(1699707)}})。</li>
+       <li>{{domxref("UserProximityEvent")}} および <code>window.onuserproximity</code>) イベントハンドラー ({{bug(1699707)}})。</li>
+       <li>{{domxref("DeviceLightEvent")}} および <code>window.ondevicelight</code> イベントハンドラー ({{bug(1701824)}})。</li>
+     </ul></li>
+ </ul>
+
+<h3 id="webdriver_conformance_marionette" name="webdriver_conformance_marionette">WebDriver conformance (Marionette)</h3>
+
+<h4 id="removals_webdriver" name="removals_webdriver">廃止</h4>
+<ul>
+  <li>WebDriver 仕様書に含まれていない <code>rotatable</code> 能力を使用できなくなりました ({{bug(1697630)}})。</li>
+</ul>
+
+<h2 id="Changes_for_add-on_developers" name="Changes_for_add-on_developers">アドオン開発者向けの変更点</h2>
+
+<ul>
+  <li><a href="/ja/docs/Web/JavaScript/Guide/Modules#dynamic_module_loading">動的な JS モジュールの読み込み</a> が、WebExtension のコンテンツスクリプトで動作するようになりました ({{bug(1536094)}})。</li>
+  <li><a href="/ja/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources">web_accessible_resources</a> に記載した拡張機能のリソースが、要求の CORS モードにかかわらず読み込まれるようになりました ({{bug(1694679)}})。</li>
+  <li>Firefox の UI を再設計したため、{{WebExtAPIRef("theme")}} API の使用に影響があります。<code>tab_background_separator</code> および <code>toolbar_field_separator</code> プロパティをサポートしなくなりました。<code>tab_line</code> および <code>toolbar_vertical_separator</code> の動作が変わりました。詳しくは <a href="https://blog.mozilla.org/addons/2021/04/19/changes-to-themeable-areas-of-firefox-in-version-89/">Changes to themeable areas of Firefox in version 89</a> をご覧ください。</li>
+  <li>{{WebExtAPIRef("pageAction")}} ボタンをアドレスバーにピン止めおよびピン止め解除することができなくなりました。デフォルトで三点リーダーアイコンのメニューが表示されないためです ({{bug(1691454)}})。この結果、<code><a href="/ja/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action">page_action</a></code> マニフェストキーの <code>pinned</code> プロパティは効果がなくなりました ({{bug(1703537)}})。</li>
+  <li>{{WebExtAPIRef("pageAction")}} ボタンから、コンテキストメニューの "アドレスバーから削除" 項目を削除しました ({{bug(1704474)}})。この機能の代替手段について {{bug(1712556)}} をご覧ください。</li>
+</ul>
+
+<h2 id="Older_versions" name="Older_versions">過去のバージョン</h2>
+
+<p>{{Firefox_for_developers(88)}}</p>

--- a/files/ja/mozilla/firefox/releases/89/index.html
+++ b/files/ja/mozilla/firefox/releases/89/index.html
@@ -16,17 +16,17 @@ tags:
   <p>Mozilla Hacks の <a href="https://hacks.mozilla.org/2021/06/looking-fine-with-firefox-89/">Looking fine with Firefox 89</a> もご覧ください。</p>
 </div>
 
-<h2 id="Changes_for_web_developers" name="Changes_for_web_developers">ウェブ開発者向けの変更点一覧</h2>
+<h2 id="Changes_for_web_developers">ウェブ開発者向けの変更点一覧</h2>
 
-<h3 id="Developer_Tools" name="Developer_Tools">開発者ツール</h3>
-
-<p><em>変更なし。</em></p>
-
-<h3 id="HTML" name="HTML">HTML</h3>
+<h3 id="Developer_Tools">開発者ツール</h3>
 
 <p><em>変更なし。</em></p>
 
-<h3 id="CSS" name="CSS">CSS</h3>
+<h3 id="HTML">HTML</h3>
+
+<p><em>変更なし。</em></p>
+
+<h3 id="CSS">CSS</h3>
 
 <ul>
   <li>{{cssxref("@media/forced-colors","forced-colors")}} メディア特性を実装しました ({{bug(1659511)}})。</li>
@@ -34,45 +34,45 @@ tags:
   <li>{{cssxref("image-set()","image-set()")}} の <code>type()</code> 関数を実装しました ({{bug(1695404)}})。</li>
 </ul>
 
-<h3 id="JavaScript" name="JavaScript">JavaScript</h3>
+<h3 id="JavaScript">JavaScript</h3>
 
 <ul>
   <li>トップレベルの <a href="/ja/docs/Web/JavaScript/Reference/Operators/await#top-level-await"><code>await</code></a> をデフォルトで有効にしました ({{bug(1681046)}})。</li>
   <li>64 ビットシステムで、長さが 2GB-1 より大きい (最大 8GB) <a href="/ja/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer">ArrayBuffer</a> を作成できるようになりました ({{bug(1703505)}})。</li>
 </ul>
 
-<h3 id="HTTP" name="HTTP">HTTP</h3>
+<h3 id="HTTP">HTTP</h3>
 
 <p><em>変更なし。</em></p>
 
-<h3 id="APIs" name="APIs">API</h3>
+<h3 id="APIs">API</h3>
 
-<h4 id="DOM" name="DOM">DOM</h4>
+<h4 id="DOM">DOM</h4>
 
 <ul>
   <li>{{domxref("PerformanceEventTiming")}} をデフォルトで有効にしました ({{bug(1701029)}})。</li>
-  <li>{{htmlelement("input")}} および {{htmlelement("textarea")}} 要素の内容物を、デフォルトで {{domxref("Document.execCommand()")}} コマンドを使用して操作できるようになりました。<a href="/ja/docs/Web/HTML/Global_attributes/contenteditable"><code>contentEditable</code></a> などの冗長な回避策なしに、編集履歴の維持やほかのブラウザとの同等性を提供します ({{bug(1220696)}})。</li>
+  <li>{{htmlelement("input")}} および {{htmlelement("textarea")}} 要素の内容物を、デフォルトで {{domxref("Document.execCommand()")}} コマンドを使用して操作できるようになりました。<a href="/ja/docs/Web/HTML/Global_attributes/contenteditable"><code>contentEditable</code></a> などの冗長な回避策なしに、編集履歴の維持やほかのブラウザーとの同等性を提供します ({{bug(1220696)}})。</li>
 </ul>
 
-<h4 id="removals_media" name="removals_media">廃止</h4>
+<h4 id="removals_media">廃止</h4>
 
 <ul>
   <li>以下のセンサーイベントおよび関連するハンドラーを削除しました (主にほかの主要なブラウザーエンジンとの互換性を向上するため、またプライバシー侵害の懸念に対処するため):
      <ul>
        <li>{{domxref("DeviceProximityEvent")}} および <code>window.ondeviceproximity</code> イベントハンドラー ({{bug(1699707)}})。</li>
        <li>{{domxref("UserProximityEvent")}} および <code>window.onuserproximity</code>) イベントハンドラー ({{bug(1699707)}})。</li>
-       <li>{{domxref("DeviceLightEvent")}} および <code>window.ondevicelight</code> イベントハンドラー ({{bug(1701824)}})。</li>
+       <li><code>DeviceLightEvent</code> および <code>window.ondevicelight</code> イベントハンドラー ({{bug(1701824)}})。</li>
      </ul></li>
  </ul>
 
-<h3 id="webdriver_conformance_marionette" name="webdriver_conformance_marionette">WebDriver conformance (Marionette)</h3>
+<h3 id="webdriver_conformance_marionette">WebDriver conformance (Marionette)</h3>
 
-<h4 id="removals_webdriver" name="removals_webdriver">廃止</h4>
+<h4 id="removals_webdriver">廃止</h4>
 <ul>
   <li>WebDriver 仕様書に含まれていない <code>rotatable</code> 能力を使用できなくなりました ({{bug(1697630)}})。</li>
 </ul>
 
-<h2 id="Changes_for_add-on_developers" name="Changes_for_add-on_developers">アドオン開発者向けの変更点</h2>
+<h2 id="Changes_for_add-on_developers">アドオン開発者向けの変更点</h2>
 
 <ul>
   <li><a href="/ja/docs/Web/JavaScript/Guide/Modules#dynamic_module_loading">動的な JS モジュールの読み込み</a> が、WebExtension のコンテンツスクリプトで動作するようになりました ({{bug(1536094)}})。</li>
@@ -82,6 +82,6 @@ tags:
   <li>{{WebExtAPIRef("pageAction")}} ボタンから、コンテキストメニューの "アドレスバーから削除" 項目を削除しました ({{bug(1704474)}})。この機能の代替手段について {{bug(1712556)}} をご覧ください。</li>
 </ul>
 
-<h2 id="Older_versions" name="Older_versions">過去のバージョン</h2>
+<h2 id="Older_versions">過去のバージョン</h2>
 
 <p>{{Firefox_for_developers(88)}}</p>


### PR DESCRIPTION
Jun 3, 2021 の英語版に対応 (不要な変更を含まないPull Requestを再作成)