### PR TITLE
mozilla 内にある browser-compat-data に関する非表示の指示を削除

### DIFF
--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodetype/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodetype/index.html
@@ -28,8 +28,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNodeType
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザー実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.BookmarkTreeNodeType", 10)}}</p>
 
 <div class="hidden">

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.html
@@ -29,8 +29,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNodeUnmo
 <p>NEEDFIX: "WebExtExamples" マクロでエラーがでているため確認と修正が必要</p>
 </div>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.bookmarks.BookmarkTreeNodeUnmodifiable")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/api/browseraction/colorarray/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/browseraction/colorarray/index.html
@@ -20,8 +20,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/browserAction/ColorArray
 
 <h2 id="ブラウザ互換性">ブラウザ互換性</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserAction.ColorArray")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/api/browseraction/disable/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/browseraction/disable/index.html
@@ -23,8 +23,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/browserAction/disable
 
 <h2 id="ブラウザ互換性">ブラウザ互換性</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserAction.disable")}}</p>
 
 <h2 id="例">例</h2>

--- a/files/ja/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.html
@@ -45,8 +45,6 @@ browser.browserAction.onClicked.hasListener(listener)
 
 <h2 id="ブラウザ互換性">ブラウザ互換性</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserAction.onClicked")}}</p>
 
 <h2 id="例">例</h2>

--- a/files/ja/mozilla/add-ons/webextensions/api/browsersettings/newtabpageoverride/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/browsersettings/newtabpageoverride/index.html
@@ -11,8 +11,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/browserSettings/newTabPageOver
 
 <h2 id="ブラウザー実装状況">ブラウザー実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browserSettings.newTabPageOverride", 10)}}</p>
 
 <h2 id="例">例</h2>

--- a/files/ja/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.html
@@ -40,8 +40,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/browsingData/removeCache
 
 <h2 id="ブラウザ実装状況">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.browsingData.removeCache")}}</p>
 
 <h2 id="例">例</h2>

--- a/files/ja/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.html
@@ -40,8 +40,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/clipboard/setImageData
 
 <h2 id="ブラウザ互換性">ブラウザ互換性</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.clipboard.setImageData", 10)}}</p>
 
 <h2 id="例">例</h2>

--- a/files/ja/mozilla/add-ons/webextensions/api/contentscripts/register/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/contentscripts/register/index.html
@@ -71,8 +71,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/contentScripts/register
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザー実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.contentScripts.register", 10)}}</p>
 
 <h2 id="Examples" name="Examples">例</h2>

--- a/files/ja/mozilla/add-ons/webextensions/api/cookies/cookie/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/cookies/cookie/index.html
@@ -48,8 +48,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/cookies/Cookie
 
 <h2 id="ブラウザ実装状況">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.cookies.Cookie")}}</p>
 
 <h2 id="例">例</h2>

--- a/files/ja/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.html
@@ -89,8 +89,6 @@ original_slug: Mozilla/Add-ons/WebExtensions/API/devtools.inspectedWindow/eval
 
 <p>{{Compat("webextensions.api.devtools.inspectedWindow.eval")}}</p>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <h2 id="例">例</h2>
 
 <p>This tests whether jQuery is defined in the inspected window, and logs the result. Note that this wouldn't work in a content script, because even if jQuery were defined, the content script would not see it.</p>

--- a/files/ja/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.html
@@ -35,8 +35,6 @@ browser.runtime.onMessage.addListener(handleMessage);</pre>
 
 <p>{{Compat("webextensions.api.devtools.inspectedWindow.tabId")}}</p>
 
-<p class="hidden">このページの互換性テーブルは構造化データから生成されます。データに貢献したい場合は、<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックして、プルリクエストを送信してください。</p>
-
 <p>{{WebExtExamples}}</p>
 
 <div class="note"><strong>謝辞</strong>

--- a/files/ja/mozilla/add-ons/webextensions/api/downloads/download/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/downloads/download/index.html
@@ -58,8 +58,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/downloads/download
 
 <h2 id="ブラウザ実装状況">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p> </p>
 
 <p>{{Compat("webextensions.api.downloads.download")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.html
@@ -30,8 +30,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/extensionTypes/ImageDetails
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザー実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.extensionTypes.ImageDetails")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/api/extensiontypes/runat/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/extensiontypes/runat/index.html
@@ -31,8 +31,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/extensionTypes/RunAt
 
 <h2 id="ブラウザー実装状況">ブラウザー実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.extensionTypes.RunAt")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/api/find/find/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/find/find/index.html
@@ -124,8 +124,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/find/find
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.find.find", 10)}}</p>
 
 <h2 id="Examples">Examples</h2>

--- a/files/ja/mozilla/add-ons/webextensions/api/history/historyitem/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/history/historyitem/index.html
@@ -38,8 +38,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/history/HistoryItem
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.history.HistoryItem")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/api/history/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/history/index.html
@@ -87,8 +87,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/history
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.history")}}</p>
 
 <p>{{WebExtExamples("h2")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.html
@@ -54,8 +54,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/i18n/detectLanguage
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.i18n.detectLanguage")}}</p>
 
 <h2 id="Examples" name="Examples">例</h2>

--- a/files/ja/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.html
@@ -34,8 +34,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/i18n/getAcceptLanguages
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.i18n.getAcceptLanguages")}}</p>
 
 <h2 id="Examples" name="Examples">例</h2>

--- a/files/ja/mozilla/add-ons/webextensions/api/i18n/getmessage/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/i18n/getmessage/index.html
@@ -47,8 +47,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/i18n/getMessage
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.i18n.getMessage")}}</p>
 
 <h2 id="Examples" name="Examples">例</h2>

--- a/files/ja/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.html
@@ -32,8 +32,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/i18n/getUILanguage
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.i18n.getUILanguage")}}</p>
 
 <h2 id="Examples" name="Examples">例</h2>

--- a/files/ja/mozilla/add-ons/webextensions/api/i18n/languagecode/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/i18n/languagecode/index.html
@@ -23,8 +23,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/i18n/LanguageCode
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.i18n.LanguageCode")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.html
@@ -35,8 +35,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/identity/getRedirectURL
 
 <h2 id="ブラウザ互換性">ブラウザ互換性</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.identity.getRedirectURL")}}</p>
 
 <h2 id="例">例</h2>

--- a/files/ja/mozilla/add-ons/webextensions/api/menus/onclicked/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/menus/onclicked/index.html
@@ -50,8 +50,6 @@ browser.menus.onClicked.hasListener(listener)
 
 <h2 id="ブラウザ互換性">ブラウザ互換性</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.menus.onClicked", 10)}}</p>
 
 <h2 id="例">例</h2>

--- a/files/ja/mozilla/add-ons/webextensions/api/notifications/create/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/notifications/create/index.html
@@ -40,8 +40,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/notifications/create
 
 <h2 id="ブラウザ互換性">ブラウザ互換性</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.notifications.create")}}</p>
 
 <h2 id="例">例</h2>

--- a/files/ja/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.html
@@ -45,8 +45,6 @@ browser.pageAction.onClicked.hasListener(listener)
 
 <h2 id="ブラウザ互換性">ブラウザ互換性</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.pageAction.onClicked")}}</p>
 
 <h2 id="例">例</h2>

--- a/files/ja/mozilla/add-ons/webextensions/api/runtime/messagesender/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/runtime/messagesender/index.html
@@ -41,8 +41,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/runtime/MessageSender
 
 <h2 id="ブラウザー実装状況">ブラウザー実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.MessageSender")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/api/runtime/onmessage/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/runtime/onmessage/index.html
@@ -133,8 +133,6 @@ browser.runtime.onMessage.hasListener(listener)
 
 <h2 id="ブラウザー実装状況">ブラウザー実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.onMessage")}}</p>
 
 <h2 id="使用例">使用例</h2>

--- a/files/ja/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.html
@@ -36,8 +36,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/runtime/openOptionsPage
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザー実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.openOptionsPage")}}</p>
 
 <h2 id="Examples" name="Examples">例</h2>

--- a/files/ja/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.html
@@ -87,8 +87,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage
 
 <h2 id="ブラウザー実装状況">ブラウザー実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.runtime.sendMessage")}}</p>
 
 <h2 id="使用例">使用例</h2>

--- a/files/ja/mozilla/add-ons/webextensions/api/storage/storagearea/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/storage/storagearea/index.html
@@ -28,8 +28,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea
 
 <h2 id="ブラウザ実装状況">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.storage.StorageArea")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/api/storage/storagechange/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/storage/storagechange/index.html
@@ -32,8 +32,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/storage/StorageChange
 
 <h2 id="ブラウザ実装状況">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.storage.StorageChange")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/api/storage/sync/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/storage/sync/index.html
@@ -42,8 +42,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/storage/sync
 
 <h2 id="ブラウザ実装状況">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.storage.sync")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/api/tabs/create/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/tabs/create/index.html
@@ -67,8 +67,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/tabs/create
 
 <h2 id="ブラウザー互換状況">ブラウザー互換状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.tabs.create", 10)}}</p>
 
 <h2 id="例">例</h2>

--- a/files/ja/mozilla/add-ons/webextensions/api/tabs/duplicate/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/tabs/duplicate/index.html
@@ -29,8 +29,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/tabs/duplicate
 
 <h2 id="ブラウザ実装状況">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.tabs.duplicate")}}</p>
 
 <h2 id="例">例</h2>

--- a/files/ja/mozilla/add-ons/webextensions/api/tabs/query/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/tabs/query/index.html
@@ -69,8 +69,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/tabs/query
 
 <h2 id="ブラウザ実装状況">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.tabs.query", 10)}}</p>
 
 <h2 id="例">例</h2>

--- a/files/ja/mozilla/add-ons/webextensions/api/tabs/remove/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/tabs/remove/index.html
@@ -29,8 +29,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/tabs/remove
 
 <h2 id="ブラウザ実装状況">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.tabs.remove")}}</p>
 
 <h2 id="例">例</h2>

--- a/files/ja/mozilla/add-ons/webextensions/api/tabs/tab/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/tabs/tab/index.html
@@ -83,8 +83,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/tabs/Tab
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.tabs.Tab", 10)}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/browser_compatibility_for_manifest.json/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/browser_compatibility_for_manifest.json/index.html
@@ -9,8 +9,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/Browser_compatibility_for_manifest
 ---
 <div>{{AddonSidebar}}</div>
 
-<div class="hidden">このページの互換性テーブルは積み上げられたデータから生成されています。そのデータに貢献したいのであれば、<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックし、プルリクエストを送ってください。</div>
-
 <p>{{Compat("webextensions.manifest",2)}}</p>
 
 <div class="note"><strong>謝辞</strong>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/author/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/author/index.html
@@ -39,6 +39,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/author
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.author")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/background/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/background/index.html
@@ -110,6 +110,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/background
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.background", 10)}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.html
@@ -86,6 +86,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_set
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.browser_specific_settings")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/chrome_settings_overrides/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/chrome_settings_overrides/index.html
@@ -131,6 +131,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_over
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.chrome_settings_overrides", 10)}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/chrome_url_overrides/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/chrome_url_overrides/index.html
@@ -92,6 +92,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/chrome_url_overrides
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.chrome_url_overrides")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/commands/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/commands/index.html
@@ -181,6 +181,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/commands
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.commands")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.html
@@ -224,6 +224,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts
 
 <h2 id="ブラウザ実装状況">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.content_scripts")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/default_locale/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/default_locale/index.html
@@ -39,6 +39,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/default_locale
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.default_locale")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/description/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/description/index.html
@@ -39,6 +39,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/description
 
 <h2 id="ブラウザ実装状況">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.description")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/developer/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/developer/index.html
@@ -47,6 +47,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/developer
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.developer")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/devtools_page/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/devtools_page/index.html
@@ -37,6 +37,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/devtools_page
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.devtools_page")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/homepage_url/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/homepage_url/index.html
@@ -41,6 +41,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/homepage_url
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.homepage_url")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/icons/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/icons/index.html
@@ -73,6 +73,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/icons
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.icons")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/incognito/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/incognito/index.html
@@ -65,6 +65,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/incognito
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.incognito")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/manifest_version/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/manifest_version/index.html
@@ -40,6 +40,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/manifest_version
 
 <h2 id="ブラウザ実装状況">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.manifest_version")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/name/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/name/index.html
@@ -41,6 +41,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/name
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.name")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/omnibox/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/omnibox/index.html
@@ -45,6 +45,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/omnibox
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.omnibox")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.html
@@ -93,6 +93,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザー実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.optional_permissions")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/options_ui/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/options_ui/index.html
@@ -98,6 +98,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/options_ui
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.options_ui")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.html
@@ -82,6 +82,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/protocol_handlers
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザー実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.protocol_handlers")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/short_name/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/short_name/index.html
@@ -39,6 +39,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/short_name
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.short_name")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/sidebar_action/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/sidebar_action/index.html
@@ -128,6 +128,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.sidebar_action")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/theme/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/theme/index.html
@@ -917,8 +917,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/theme
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザー実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.theme", 10)}}</p>
 
 <h3 id="Chrome_compatibility" name="Chrome_compatibility">Chrome compatibility</h3>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/version/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/version/index.html
@@ -48,6 +48,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/version
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.version")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/version_name/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/version_name/index.html
@@ -35,6 +35,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/version_name
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.version_name")}}</p>

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.html
@@ -95,6 +95,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resou
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.web_accessible_resources")}}</p>


### PR DESCRIPTION
https://github.com/mdn/translated-content/issues/1008