### PR TITLE
web/svg 内にある browser-compat-data に関する非表示の指示を一括削除

### DIFF
--- a/files/ja/web/svg/attribute/alignment-baseline/index.html
+++ b/files/ja/web/svg/attribute/alignment-baseline/index.html
@@ -156,8 +156,6 @@ text{
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("svg.attributes.presentation.alignment-baseline")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/svg/attribute/id/index.html
+++ b/files/ja/web/svg/attribute/id/index.html
@@ -89,8 +89,6 @@ translation_of: Web/SVG/Attribute/id
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("svg.attributes.style.class")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/svg/attribute/marker-mid/index.html
+++ b/files/ja/web/svg/attribute/marker-mid/index.html
@@ -90,8 +90,6 @@ translation_of: Web/SVG/Attribute/marker-mid
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("svg.attributes.presentation.marker-mid")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/svg/attribute/onclick/index.html
+++ b/files/ja/web/svg/attribute/onclick/index.html
@@ -80,6 +80,4 @@ translation_of: Web/SVG/Attribute/onclick
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("svg.attributes.events.global.onclick")}}</p>

--- a/files/ja/web/svg/attribute/writing-mode/index.html
+++ b/files/ja/web/svg/attribute/writing-mode/index.html
@@ -74,8 +74,6 @@ translation_of: Web/SVG/Attribute/writing-mode
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("svg.attributes.presentation.writing-mode")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/svg/element/a/index.html
+++ b/files/ja/web/svg/element/a/index.html
@@ -145,6 +145,4 @@ svg|a:hover, svg|a:active {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("svg.elements.a")}}</p>

--- a/files/ja/web/svg/element/animate/index.html
+++ b/files/ja/web/svg/element/animate/index.html
@@ -97,7 +97,5 @@ translation_of: Web/SVG/Element/animate
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
 <div>
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("svg.elements.animate")}}</p>
 </div>

--- a/files/ja/web/svg/element/animatemotion/index.html
+++ b/files/ja/web/svg/element/animatemotion/index.html
@@ -109,8 +109,6 @@ translation_of: Web/SVG/Element/animateMotion
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("svg.elements.animateMotion")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/svg/element/animatetransform/index.html
+++ b/files/ja/web/svg/element/animatetransform/index.html
@@ -94,6 +94,4 @@ translation_of: Web/SVG/Element/animateTransform
 
 <h2 id="ブラウザ互換性">ブラウザ互換性</h2>
 
-<div class="hidden">このページの互換表は構造化データにより作られました。データにコントリビュートしたければ <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックしてプルリクエストを送ってください。</div>
-
 <p>{{Compat("svg.elements.animateTransform")}}</p>

--- a/files/ja/web/svg/element/fecolormatrix/index.html
+++ b/files/ja/web/svg/element/fecolormatrix/index.html
@@ -188,8 +188,6 @@ A' | 0 0 0 1 0 |
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("svg.elements.feColorMatrix")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/svg/element/fedropshadow/index.html
+++ b/files/ja/web/svg/element/fedropshadow/index.html
@@ -99,6 +99,4 @@ translation_of: Web/SVG/Element/feDropShadow
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("svg.elements.feDropShadow")}}</p>

--- a/files/ja/web/svg/element/g/index.html
+++ b/files/ja/web/svg/element/g/index.html
@@ -82,6 +82,4 @@ translation_of: Web/SVG/Element/g
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<div class="hidden">このページの実装状況表は構造化されたデータから生成されたものです。もし、あなたがこのデータに貢献したい場合は、<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>を確認し、我々にプルリクエストを送って下さい。</div>
-
 <p>{{Compat("svg.elements.g")}}</p>

--- a/files/ja/web/svg/element/hatchpath/index.html
+++ b/files/ja/web/svg/element/hatchpath/index.html
@@ -61,8 +61,6 @@ translation_of: Web/SVG/Element/hatchpath
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("svg.elements.hatchpath")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/svg/element/image/index.html
+++ b/files/ja/web/svg/element/image/index.html
@@ -97,6 +97,4 @@ translation_of: Web/SVG/Element/image
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("svg.elements.image")}}</p>

--- a/files/ja/web/svg/element/line/index.html
+++ b/files/ja/web/svg/element/line/index.html
@@ -95,8 +95,6 @@ translation_of: Web/SVG/Element/line
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("svg.elements.line")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/svg/element/mask/index.html
+++ b/files/ja/web/svg/element/mask/index.html
@@ -100,8 +100,6 @@ translation_of: Web/SVG/Element/mask
 
 <h2 id="ブラウザの互換性">ブラウザの互換性</h2>
 
-<div class="hidden">このページの互換性テーブルは構造化データから生成されます。データに貢献したい場合は <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックしてプルリクエストを送ってください。</div>
-
 <p>{{Compat("svg.elements.mask")}}</p>
 
 <h2 id="あわせて参照">あわせて参照</h2>

--- a/files/ja/web/svg/element/path/index.html
+++ b/files/ja/web/svg/element/path/index.html
@@ -95,8 +95,6 @@ translation_of: Web/SVG/Element/path
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
-<div class="hidden">このページの実装状況表は、構造化されたデータから生成されています。もしこのデータに貢献したい場合は、<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>を確認し、我々にプルリクエストを送って下さい。</div>
-
 <p>{{Compat("svg.elements.path")}}</p>
 
 <h2 id="関連情報">関連情報</h2>

--- a/files/ja/web/svg/element/svg/index.html
+++ b/files/ja/web/svg/element/svg/index.html
@@ -120,6 +120,4 @@ translation_of: Web/SVG/Element/svg
 
 <h2 id="ブラウザの実装状況">ブラウザの実装状況</h2>
 
-<div class="hidden">このページの実装状況表は構造化されたデータから生成されています。もし、あなたがこのデータに貢献したい場合は、<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>を確認し、我々にプルリクエストを送って下さい。</div>
-
 <p>{{Compat("svg.elements.svg")}}</p>

--- a/files/ja/web/svg/element/switch/index.html
+++ b/files/ja/web/svg/element/switch/index.html
@@ -93,6 +93,4 @@ translation_of: Web/SVG/Element/switch
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("svg.elements.switch")}}</p>

--- a/files/ja/web/svg/element/tspan/index.html
+++ b/files/ja/web/svg/element/tspan/index.html
@@ -106,6 +106,4 @@ translation_of: Web/SVG/Element/tspan
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("svg.elements.tspan")}}</p>


### PR DESCRIPTION
https://github.com/mdn/translated-content/issues/1008