### PR TITLE
web/manifest 内にある browser-compat-data に関する非表示の指示を一括削除

### DIFF
--- a/files/ja/web/manifest/background_color/index.html
+++ b/files/ja/web/manifest/background_color/index.html
@@ -66,6 +66,4 @@ translation_of: Web/Manifest/background_color
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("html.manifest.background_color")}}</p>

--- a/files/ja/web/manifest/categories/index.html
+++ b/files/ja/web/manifest/categories/index.html
@@ -69,6 +69,4 @@ translation_of: Web/Manifest/categories
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("html.manifest.categories")}}</p>

--- a/files/ja/web/manifest/description/index.html
+++ b/files/ja/web/manifest/description/index.html
@@ -68,6 +68,4 @@ translation_of: Web/Manifest/description
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("html.manifest.description")}}</p>

--- a/files/ja/web/manifest/dir/index.html
+++ b/files/ja/web/manifest/dir/index.html
@@ -82,6 +82,4 @@ translation_of: Web/Manifest/dir
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("html.manifest.dir")}}</p>

--- a/files/ja/web/manifest/display/index.html
+++ b/files/ja/web/manifest/display/index.html
@@ -109,6 +109,4 @@ translation_of: Web/Manifest/display
 <p><strong>注:</strong> Firefox バージョン 47 では、 <code>display</code> の値は <code>browser</code> のみに対応しています。 <code>minimal-ui</code>, <code>standalone</code> , <code>fullscreen</code> は Firefox 57 で追加されました。</p>
 </div>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("html.manifest.display")}}</p>

--- a/files/ja/web/manifest/iarc_rating_id/index.html
+++ b/files/ja/web/manifest/iarc_rating_id/index.html
@@ -65,8 +65,6 @@ translation_of: Web/Manifest/iarc_rating_id
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("html.manifest.iarc_rating_id")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/manifest/icons/index.html
+++ b/files/ja/web/manifest/icons/index.html
@@ -119,6 +119,4 @@ translation_of: Web/Manifest/icons
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("html.manifest.icons")}}</p>

--- a/files/ja/web/manifest/lang/index.html
+++ b/files/ja/web/manifest/lang/index.html
@@ -60,6 +60,4 @@ translation_of: Web/Manifest/lang
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("html.manifest.lang")}}</p>

--- a/files/ja/web/manifest/name/index.html
+++ b/files/ja/web/manifest/name/index.html
@@ -68,6 +68,4 @@ translation_of: Web/Manifest/name
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("html.manifest.name")}}</p>

--- a/files/ja/web/manifest/orientation/index.html
+++ b/files/ja/web/manifest/orientation/index.html
@@ -83,6 +83,4 @@ translation_of: Web/Manifest/orientation
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("html.manifest.orientation")}}</p>

--- a/files/ja/web/manifest/prefer_related_applications/index.html
+++ b/files/ja/web/manifest/prefer_related_applications/index.html
@@ -63,6 +63,4 @@ translation_of: Web/Manifest/prefer_related_applications
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("html.manifest.prefer_related_applications")}}</p>

--- a/files/ja/web/manifest/related_applications/index.html
+++ b/files/ja/web/manifest/related_applications/index.html
@@ -94,6 +94,4 @@ translation_of: Web/Manifest/related_applications
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("html.manifest.related_applications")}}</p>

--- a/files/ja/web/manifest/scope/index.html
+++ b/files/ja/web/manifest/scope/index.html
@@ -75,6 +75,4 @@ translation_of: Web/Manifest/scope
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("html.manifest.scope")}}</p>

--- a/files/ja/web/manifest/screenshots/index.html
+++ b/files/ja/web/manifest/screenshots/index.html
@@ -70,6 +70,4 @@ translation_of: Web/Manifest/screenshots
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("html.manifest.screenshots")}}</p>

--- a/files/ja/web/manifest/short_name/index.html
+++ b/files/ja/web/manifest/short_name/index.html
@@ -71,6 +71,4 @@ translation_of: Web/Manifest/short_name
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("html.manifest.short_name")}}</p>

--- a/files/ja/web/manifest/start_url/index.html
+++ b/files/ja/web/manifest/start_url/index.html
@@ -72,6 +72,4 @@ translation_of: Web/Manifest/start_url
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("html.manifest.start_url")}}</p>

--- a/files/ja/web/manifest/theme_color/index.html
+++ b/files/ja/web/manifest/theme_color/index.html
@@ -61,6 +61,4 @@ translation_of: Web/Manifest/theme_color
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("html.manifest.theme_color")}}</p>


### PR DESCRIPTION
https://github.com/mdn/translated-content/issues/1008