### PR TITLE
web/api/h-m* の browser-compat-data に関する非表示の指示を一括削除

### DIFF
--- a/files/ja/web/api/headers/headers/index.html
+++ b/files/ja/web/api/headers/headers/index.html
@@ -59,8 +59,6 @@ secondHeadersObj.get('Content-Type'); // Would return 'image/jpeg' — it inheri
 
 <h2 id="ブラウザの対応">ブラウザの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力したいのであれば、 <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p><br>
  {{Compat("api.Headers.headers")}}</p>
 

--- a/files/ja/web/api/history/back/index.html
+++ b/files/ja/web/api/history/back/index.html
@@ -61,8 +61,6 @@ translation_of: Web/API/History/back
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.History.back")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/history/go/index.html
+++ b/files/ja/web/api/history/go/index.html
@@ -76,8 +76,6 @@ history.go(0);</pre>
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.History.go")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/history/index.html
+++ b/files/ja/web/api/history/index.html
@@ -73,8 +73,6 @@ translation_of: Web/API/History
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.History")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/history_api/index.html
+++ b/files/ja/web/api/history_api/index.html
@@ -110,8 +110,6 @@ history.go(2)  // alerts "location: http://example.com/example.html?page=3, stat
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.History")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/html_dom_api/index.html
+++ b/files/ja/web/api/html_dom_api/index.html
@@ -471,8 +471,6 @@ nameField.addEventListener("input", event =&gt; {
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
 <div>
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement")}}</p>
 </div>
 

--- a/files/ja/web/api/htmlaudioelement/index.html
+++ b/files/ja/web/api/htmlaudioelement/index.html
@@ -113,8 +113,6 @@ flush.addEventListener('loadeddata',() =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility"><em>ブラウザーの対応</em></h2>
 
-<p class="hidden"><em>このページの互換性一覧表は構造化データから生成されています。データに協力したいのであれば、 <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</em></p>
-
 <p><em>{{Compat("api.HTMLAudioElement")}}</em></p>
 
 <h2 id="See_also" name="See_also"><em>関連情報</em></h2>

--- a/files/ja/web/api/htmlbuttonelement/index.html
+++ b/files/ja/web/api/htmlbuttonelement/index.html
@@ -150,8 +150,6 @@ translation_of: Web/API/HTMLButtonElement
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLButtonElement")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlcollection/index.html
+++ b/files/ja/web/api/htmlcollection/index.html
@@ -79,8 +79,6 @@ elem1 = document.forms["named.item.with.periods"];</pre>
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLCollection")}}</p>
 
 <h2 id="関連情報">関連情報</h2>

--- a/files/ja/web/api/htmldetailselement/toggle_event/index.html
+++ b/files/ja/web/api/htmldetailselement/toggle_event/index.html
@@ -121,6 +121,4 @@ chapters.forEach((chapter) =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLDetailsElement.toggle_event")}}</p>

--- a/files/ja/web/api/htmldialogelement/cancel_event/index.html
+++ b/files/ja/web/api/htmldialogelement/cancel_event/index.html
@@ -109,8 +109,6 @@ closeButton.addEventListener('click', () =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLDialogElement.cancel_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmldialogelement/index.html
+++ b/files/ja/web/api/htmldialogelement/index.html
@@ -136,8 +136,6 @@ translation_of: Web/API/HTMLDialogElement
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLDialogElement")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmldocument/index.html
+++ b/files/ja/web/api/htmldocument/index.html
@@ -45,6 +45,4 @@ translation_of: Web/API/HTMLDocument
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザー実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.HTMLDocument")}}</p>

--- a/files/ja/web/api/htmlelement/accesskeylabel/index.html
+++ b/files/ja/web/api/htmlelement/accesskeylabel/index.html
@@ -71,8 +71,6 @@ node.onclick = function () {
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
 <div>
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement.accessKeyLabel")}}</p>
 </div>
 

--- a/files/ja/web/api/htmlelement/animationcancel_event/index.html
+++ b/files/ja/web/api/htmlelement/animationcancel_event/index.html
@@ -168,8 +168,6 @@ applyAnimation.addEventListener('click', () =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement.animationcancel_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlelement/animationend_event/index.html
+++ b/files/ja/web/api/htmlelement/animationend_event/index.html
@@ -166,8 +166,6 @@ applyAnimation.addEventListener('click', () =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement.animationend_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlelement/animationiteration_event/index.html
+++ b/files/ja/web/api/htmlelement/animationiteration_event/index.html
@@ -168,8 +168,6 @@ applyAnimation.addEventListener('click', () =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement.animationiteration_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlelement/animationstart_event/index.html
+++ b/files/ja/web/api/htmlelement/animationstart_event/index.html
@@ -165,8 +165,6 @@ applyAnimation.addEventListener('click', () =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement.animationstart_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlelement/beforeinput_event/index.html
+++ b/files/ja/web/api/htmlelement/beforeinput_event/index.html
@@ -102,8 +102,6 @@ function updateValue(e) {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement.beforeinput_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlelement/change_event/index.html
+++ b/files/ja/web/api/htmlelement/change_event/index.html
@@ -138,8 +138,6 @@ function updateValue(e) {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement.change_event")}}</p>
 
 <p>すべてのブラウザーにおいて、特定の操作で <code>change</code> イベントが発生するかどうかが同じであるとは限りません。例えば、 Gecko では {{HTMLElement("select")}} 要素をキーボードで操作すると、 <code>change</code> イベントは Enter を押すか <code>&lt;select&gt;</code> からフォーカスが離れるまで発生しませんでした ({{bug("126379")}} を参照)。ただし、 Firefox 63 (Quantum) からは、すべての主要なブラウザーと同じ動作になりました。</p>

--- a/files/ja/web/api/htmlelement/click/index.html
+++ b/files/ja/web/api/htmlelement/click/index.html
@@ -65,8 +65,6 @@ function myFunction() {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は、構造化データから生成されています。データに貢献したい方は、https://github.com/mdn/browser-compat-data をチェックしてプルリクエストを送ってください。</div>
-
 <p>{{Compat("api.HTMLElement.click")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlelement/contenteditable/index.html
+++ b/files/ja/web/api/htmlelement/contenteditable/index.html
@@ -48,8 +48,6 @@ translation_of: Web/API/HTMLElement/contentEditable
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement.contentEditable")}}</p>
 
 <p>Internet Explorer では、<code>contenteditable</code> を {{htmlelement("table")}}、{{htmlelement("col")}}、{{htmlelement("colgroup")}}、{{htmlelement("tbody")}}、{{htmlelement("td")}}、{{htmlelement("tfoot")}}、{{htmlelement("th")}}、{{htmlelement("thead")}}、および {{htmlelement("tr")}} 要素に直接適用することはできません。 コンテンツを編集可能な {{htmlelement("span")}} または {{htmlelement("div")}} 要素を、表の個々のセル内に配置できます。</p>

--- a/files/ja/web/api/htmlelement/dir/index.html
+++ b/files/ja/web/api/htmlelement/dir/index.html
@@ -72,8 +72,6 @@ parg.dir = "rtl";
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement.dir")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlelement/index.html
+++ b/files/ja/web/api/htmlelement/index.html
@@ -266,8 +266,6 @@ translation_of: Web/API/HTMLElement
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、<a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlelement/innertext/index.html
+++ b/files/ja/web/api/htmlelement/innertext/index.html
@@ -79,8 +79,6 @@ innerTextOutput.value = source.innerText;</pre>
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement.innerText")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlelement/input_event/index.html
+++ b/files/ja/web/api/htmlelement/input_event/index.html
@@ -83,8 +83,6 @@ function updateValue(e) {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement.input_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlelement/iscontenteditable/index.html
+++ b/files/ja/web/api/htmlelement/iscontenteditable/index.html
@@ -73,8 +73,6 @@ document.getElementById('infoText2').innerHTML += document.getElementById('myTex
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement.isContentEditable")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlelement/offsetleft/index.html
+++ b/files/ja/web/api/htmlelement/offsetleft/index.html
@@ -78,8 +78,6 @@ if (tOLeft &gt; 5) {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement.offsetLeft")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlelement/offsetparent/index.html
+++ b/files/ja/web/api/htmlelement/offsetparent/index.html
@@ -58,6 +58,4 @@ translation_of: Web/API/HTMLElement/offsetParent
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement.offsetParent")}}</p>

--- a/files/ja/web/api/htmlelement/oncopy/index.html
+++ b/files/ja/web/api/htmlelement/oncopy/index.html
@@ -66,8 +66,6 @@ editor.onpaste = logPaste;</pre>
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement.oncopy")}}</p>
 
 <p>Firefox 13 から、この機能は設定 <code>dom.event.clipboardevents.enabled</code> で制御されます。既定値は <code>true</code> ですが無効化できます。</p>

--- a/files/ja/web/api/htmlelement/onpaste/index.html
+++ b/files/ja/web/api/htmlelement/onpaste/index.html
@@ -73,8 +73,6 @@ document.getElementById("editor").addEventListener("paste", pasteIntercept, fals
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<p class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力したいのであれば、 <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</p>
-
 <p>{{Compat("api.HTMLElement.onpaste")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlelement/pointermove_event/index.html
+++ b/files/ja/web/api/htmlelement/pointermove_event/index.html
@@ -75,8 +75,6 @@ para.onpointermove = (event) =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement.pointermove_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlelement/transitioncancel_event/index.html
+++ b/files/ja/web/api/htmlelement/transitioncancel_event/index.html
@@ -81,8 +81,6 @@ transition.ontransitioncancel = () =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement.transitioncancel_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlelement/transitionend_event/index.html
+++ b/files/ja/web/api/htmlelement/transitionend_event/index.html
@@ -79,8 +79,6 @@ transition.ontransitionend = () =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement.transitionend_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlelement/transitionrun_event/index.html
+++ b/files/ja/web/api/htmlelement/transitionrun_event/index.html
@@ -128,8 +128,6 @@ el.addEventListener('transitionend', function() {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement.transitionrun_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlelement/transitionstart_event/index.html
+++ b/files/ja/web/api/htmlelement/transitionstart_event/index.html
@@ -120,8 +120,6 @@ transition.addEventListener('transitionend', function() {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザー実装状況</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、<a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement.transitionstart_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlfieldsetelement/index.html
+++ b/files/ja/web/api/htmlfieldsetelement/index.html
@@ -94,8 +94,6 @@ translation_of: Web/API/HTMLFieldSetElement
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLFieldSetElement")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlformelement/index.html
+++ b/files/ja/web/api/htmlformelement/index.html
@@ -255,8 +255,6 @@ f.submit();                               // Call the form's submit() method
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、<a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLFormElement")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlformelement/reset_event/index.html
+++ b/files/ja/web/api/htmlformelement/reset_event/index.html
@@ -99,8 +99,6 @@ form.addEventListener('reset', logReset);</pre>
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
 <div>
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLFormElement.reset_event")}}</p>
 </div>
 

--- a/files/ja/web/api/htmlformelement/submit_event/index.html
+++ b/files/ja/web/api/htmlformelement/submit_event/index.html
@@ -111,8 +111,6 @@ form.addEventListener('submit', logSubmit);</pre>
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
 <div>
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLFormElement.submit_event")}}</p>
 </div>
 

--- a/files/ja/web/api/htmliframeelement/srcdoc/index.html
+++ b/files/ja/web/api/htmliframeelement/srcdoc/index.html
@@ -34,6 +34,4 @@ document.body.appendChild(iframe);</pre>
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLIFrameElement.srcdoc")}}</p>

--- a/files/ja/web/api/htmlinputelement/index.html
+++ b/files/ja/web/api/htmlinputelement/index.html
@@ -416,8 +416,6 @@ translation_of: Web/API/HTMLInputElement
 <h2 id="Browser_compatibility">ブラウザーの互換性</h2>
 
 <div>
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLInputElement")}}</p>
 </div>
 

--- a/files/ja/web/api/htmlinputelement/invalid_event/index.html
+++ b/files/ja/web/api/htmlinputelement/invalid_event/index.html
@@ -99,8 +99,6 @@ function logValue(e) {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLInputElement.invalid_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlinputelement/select/index.html
+++ b/files/ja/web/api/htmlinputelement/select/index.html
@@ -71,8 +71,6 @@ translation_of: Web/API/HTMLInputElement/select
 
 <h2 id="ブラウザの互換性">ブラウザの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は、構造化データから生成されています。データに貢献したい方は、https://github.com/mdn/browser-compat-data をチェックしてプルリクエストを送ってください。</div>
-
 <p>{{Compat("api.HTMLInputElement.select")}}</p>
 
 <h2 id="あわせて参照">あわせて参照</h2>

--- a/files/ja/web/api/htmlinputelement/webkitdirectory/index.html
+++ b/files/ja/web/api/htmlinputelement/webkitdirectory/index.html
@@ -127,8 +127,6 @@ translation_of: Web/API/HTMLInputElement/webkitdirectory
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLInputElement.webkitdirectory")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlmapelement/index.html
+++ b/files/ja/web/api/htmlmapelement/index.html
@@ -65,8 +65,6 @@ translation_of: Web/API/HTMLMapElement
 
 <h2 id="ブラウザの互換性">ブラウザの互換性</h2>
 
-<div class="hidden">このページの互換性テーブルは構造化データから生成されます。データに貢献したい場合は <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックして、プルリクエストを送ってください。</div>
-
 <p>{{Compat("api.HTMLMapElement")}}</p>
 
 <h2 id="あわせて参照">あわせて参照</h2>

--- a/files/ja/web/api/htmlmediaelement/abort_event/index.html
+++ b/files/ja/web/api/htmlmediaelement/abort_event/index.html
@@ -74,8 +74,6 @@ video.appendChild(source);</pre>
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLMediaElement.abort_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlmediaelement/error_event/index.html
+++ b/files/ja/web/api/htmlmediaelement/error_event/index.html
@@ -74,8 +74,6 @@ video.appendChild(source);</pre>
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLMediaElement.error_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlmediaelement/index.html
+++ b/files/ja/web/api/htmlmediaelement/index.html
@@ -270,8 +270,6 @@ translation_of: Web/API/HTMLMediaElement
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLMediaElement")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlmediaelement/loadeddata_event/index.html
+++ b/files/ja/web/api/htmlmediaelement/loadeddata_event/index.html
@@ -99,8 +99,6 @@ video.onloadeddata = (event) =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLMediaElement.loadeddata_event")}}</p>
 
 <h2 id="Related_Events" name="Related_Events">関連イベント</h2>

--- a/files/ja/web/api/htmlmediaelement/loadstart_event/index.html
+++ b/files/ja/web/api/htmlmediaelement/loadstart_event/index.html
@@ -149,8 +149,6 @@ loadVideo.addEventListener('click', () =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLMediaElement.loadstart_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlmediaelement/pause_event/index.html
+++ b/files/ja/web/api/htmlmediaelement/pause_event/index.html
@@ -104,8 +104,6 @@ video.onpause = (event) =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLMediaElement.pause_event")}}</p>
 
 <h2 id="Related_Events" name="Related_Events">関連イベント</h2>

--- a/files/ja/web/api/htmlmediaelement/playbackrate/index.html
+++ b/files/ja/web/api/htmlmediaelement/playbackrate/index.html
@@ -62,8 +62,6 @@ console.log(obj.playbackRate); // Expected Output: 1</pre>
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLMediaElement.playbackRate")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlmediaelement/playing_event/index.html
+++ b/files/ja/web/api/htmlmediaelement/playing_event/index.html
@@ -92,8 +92,6 @@ video.onplaying = (event) =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLMediaElement.playing_event")}}</p>
 
 <h2 id="Related_Events" name="Related_Events">関連イベント</h2>

--- a/files/ja/web/api/htmlmediaelement/progress_event/index.html
+++ b/files/ja/web/api/htmlmediaelement/progress_event/index.html
@@ -149,8 +149,6 @@ loadVideo.addEventListener('click', () =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLMediaElement.progress_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlmediaelement/timeupdate_event/index.html
+++ b/files/ja/web/api/htmlmediaelement/timeupdate_event/index.html
@@ -93,8 +93,6 @@ video.ontimeupdate = (event) =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLMediaElement.timeupdate_event")}}</p>
 
 <h2 id="Related_Events" name="Related_Events">関連イベント</h2>

--- a/files/ja/web/api/htmlmediaelement/volumechange_event/index.html
+++ b/files/ja/web/api/htmlmediaelement/volumechange_event/index.html
@@ -95,8 +95,6 @@ video.onvolumechange = (event) =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLMediaElement.volumechange_event")}}</p>
 
 <h2 id="Related_Events" name="Related_Events">関連イベント</h2>

--- a/files/ja/web/api/htmlmediaelement/waiting_event/index.html
+++ b/files/ja/web/api/htmlmediaelement/waiting_event/index.html
@@ -94,8 +94,6 @@ video.onwaiting = (event) =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLMediaElement.waiting_event")}}</p>
 
 <h2 id="Related_Events" name="Related_Events">関連イベント</h2>

--- a/files/ja/web/api/htmlobjectelement/checkvalidity/index.html
+++ b/files/ja/web/api/htmlobjectelement/checkvalidity/index.html
@@ -54,6 +54,4 @@ translation_of: Web/API/HTMLObjectElement/checkValidity
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLObjectElement.checkValidity")}}</p>

--- a/files/ja/web/api/htmlorforeignelement/dataset/index.html
+++ b/files/ja/web/api/htmlorforeignelement/dataset/index.html
@@ -133,8 +133,6 @@ el.dataset.someDataAttr = 'mydata';
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement.dataset")}}</p>
 
 <div class="hidden">Please change the compat macro's paramter to <code>api.HTMLOrForeignElement.dataset</code> after BCD is updated.</div>

--- a/files/ja/web/api/htmlorforeignelement/index.html
+++ b/files/ja/web/api/htmlorforeignelement/index.html
@@ -47,8 +47,6 @@ translation_of: Web/API/HTMLOrForeignElement
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLOrForeignElement")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlorforeignelement/tabindex/index.html
+++ b/files/ja/web/api/htmlorforeignelement/tabindex/index.html
@@ -74,8 +74,6 @@ b1.tabIndex = 1;
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLElement.tabIndex")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmloutputelement/index.html
+++ b/files/ja/web/api/htmloutputelement/index.html
@@ -103,8 +103,6 @@ translation_of: Web/API/HTMLOutputElement
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLOutputElement")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlselectelement/options/index.html
+++ b/files/ja/web/api/htmlselectelement/options/index.html
@@ -73,6 +73,4 @@ translation_of: Web/API/HTMLSelectElement/options
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLSelectElement.options")}}</p>

--- a/files/ja/web/api/htmlslotelement/assignedelements/index.html
+++ b/files/ja/web/api/htmlslotelement/assignedelements/index.html
@@ -62,7 +62,5 @@ let elements = slots.assignedElements({flatten: true});
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
 <div>
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLSlotElement.assignedElements")}}</p>
 </div>

--- a/files/ja/web/api/htmlslotelement/assignednodes/index.html
+++ b/files/ja/web/api/htmlslotelement/assignednodes/index.html
@@ -69,6 +69,4 @@ slots[1].addEventListener('slotchange', function(e) {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLSlotElement.assignedNodes")}}</p>

--- a/files/ja/web/api/htmlslotelement/index.html
+++ b/files/ja/web/api/htmlslotelement/index.html
@@ -58,6 +58,4 @@ slots[1].addEventListener('slotchange', function(e) {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLSlotElement")}}</p>

--- a/files/ja/web/api/htmlsourceelement/index.html
+++ b/files/ja/web/api/htmlsourceelement/index.html
@@ -69,8 +69,6 @@ translation_of: Web/API/HTMLSourceElement
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<p class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力したいのであれば、 <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</p>
-
 <p>{{Compat("api.HTMLSourceElement")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlspanelement/index.html
+++ b/files/ja/web/api/htmlspanelement/index.html
@@ -56,8 +56,6 @@ translation_of: Web/API/HTMLSpanElement
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLSpanElement")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/htmlstyleelement/media/index.html
+++ b/files/ja/web/api/htmlstyleelement/media/index.html
@@ -89,6 +89,4 @@ alert('InlineStyle: ' + document.getElementById('InlineStyle').media); // 'scree
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<p class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力したいのであれば、 <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</p>
-
 <p>{{Compat("api.HTMLStyleElement.media")}}</p>

--- a/files/ja/web/api/htmltextareaelement/index.html
+++ b/files/ja/web/api/htmltextareaelement/index.html
@@ -337,6 +337,4 @@ translation_of: Web/API/HTMLTextAreaElement
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.HTMLTextAreaElement")}}</p>

--- a/files/ja/web/api/htmlvideoelement/index.html
+++ b/files/ja/web/api/htmlvideoelement/index.html
@@ -125,8 +125,6 @@ translation_of: Web/API/HTMLVideoElement
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">このページの互換性表は、構造化データから生成されています。データに貢献したい方は、https://github.com/mdn/browser-compat-data をチェックしてプルリクエストを送ってください。</div>
-
 <p>{{Compat("api.HTMLVideoElement")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/ja/web/api/idbcursor/continue/index.html
+++ b/files/ja/web/api/idbcursor/continue/index.html
@@ -112,8 +112,6 @@ translation_of: Web/API/IDBCursor/continue
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.IDBCursor.continue")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/idbenvironment/index.html
+++ b/files/ja/web/api/idbenvironment/index.html
@@ -58,8 +58,6 @@ function openDB() {
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザ実装状況</h2>
 
 <div>
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.IDBEnvironment")}}</p>
 </div>
 

--- a/files/ja/web/api/idbfactory/index.html
+++ b/files/ja/web/api/idbfactory/index.html
@@ -91,8 +91,6 @@ DBOpenRequest.onsuccess = function(event) {
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの実装状況</h2>
 
 <div>
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("api.IDBFactory")}}</p>
 </div>
 

--- a/files/ja/web/api/idbfactory/open/index.html
+++ b/files/ja/web/api/idbfactory/open/index.html
@@ -138,8 +138,6 @@ DBOpenRequest.onsuccess = function(event) {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<p class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</p>
-
 <p>{{Compat("api.IDBFactory.open")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/idbtransaction/complete_event/index.html
+++ b/files/ja/web/api/idbtransaction/complete_event/index.html
@@ -118,8 +118,6 @@ DBOpenRequest.onsuccess = event =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.IDBTransaction.complete_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/idbtransaction/index.html
+++ b/files/ja/web/api/idbtransaction/index.html
@@ -224,8 +224,6 @@ function addData() {
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
 <div>
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <div>{{Compat("api.IDBTransaction")}}</div>
 </div>
 

--- a/files/ja/web/api/intersection_observer_api/index.html
+++ b/files/ja/web/api/intersection_observer_api/index.html
@@ -584,8 +584,6 @@ window.addEventListener("load", (event) =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.IntersectionObserver")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/intersectionobserver/disconnect/index.html
+++ b/files/ja/web/api/intersectionobserver/disconnect/index.html
@@ -49,8 +49,6 @@ translation_of: Web/API/IntersectionObserver/disconnect
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.IntersectionObserver.disconnect")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/intersectionobserver/index.html
+++ b/files/ja/web/api/intersectionobserver/index.html
@@ -83,6 +83,4 @@ intersectionObserver.observe(document.querySelector('.scrollerFooter'));</pre>
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<p class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</p>
-
 <p>{{Compat("api.IntersectionObserver")}}</p>

--- a/files/ja/web/api/intersectionobserver/intersectionobserver/index.html
+++ b/files/ja/web/api/intersectionobserver/intersectionobserver/index.html
@@ -83,6 +83,4 @@ translation_of: Web/API/IntersectionObserver/IntersectionObserver
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザー実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.IntersectionObserver.IntersectionObserver")}}</p>

--- a/files/ja/web/api/intersectionobserver/observe/index.html
+++ b/files/ja/web/api/intersectionobserver/observe/index.html
@@ -59,8 +59,6 @@ translation_of: Web/API/IntersectionObserver/observe
 <div>
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザー実装状況</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.IntersectionObserver.observe")}}</p>
 </div>
 

--- a/files/ja/web/api/intersectionobserver/takerecords/index.html
+++ b/files/ja/web/api/intersectionobserver/takerecords/index.html
@@ -61,8 +61,6 @@ translation_of: Web/API/IntersectionObserver/takeRecords
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.IntersectionObserver.takeRecords")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/intersectionobserverentry/index.html
+++ b/files/ja/web/api/intersectionobserverentry/index.html
@@ -49,6 +49,4 @@ translation_of: Web/API/IntersectionObserverEntry
 
 <h2 id="ブラウザの互換性">ブラウザの互換性</h2>
 
-<p class="hidden">このページの互換性テーブルは構造化データから生成されます。データに貢献したい場合は <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックして、プルリクエストを送信してください。</p>
-
 <p>{{Compat("api.IntersectionObserverEntry")}}</p>

--- a/files/ja/web/api/keyboardevent/code/index.html
+++ b/files/ja/web/api/keyboardevent/code/index.html
@@ -215,6 +215,4 @@ let spaceship = document.getElementById("spaceship");
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.KeyboardEvent.code")}}</p>

--- a/files/ja/web/api/keyboardevent/index.html
+++ b/files/ja/web/api/keyboardevent/index.html
@@ -324,8 +324,6 @@ document.addEventListener('keyup', (event) =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.KeyboardEvent")}}</p>
 
 <h3 id="Compatibility_notes" name="Compatibility_notes">互換性のメモ</h3>

--- a/files/ja/web/api/keyboardevent/key/index.html
+++ b/files/ja/web/api/keyboardevent/key/index.html
@@ -229,6 +229,4 @@ btnClearConsole.addEventListener('click', (e) =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.KeyboardEvent.key")}}</p>

--- a/files/ja/web/api/keyboardevent/keycode/index.html
+++ b/files/ja/web/api/keyboardevent/keycode/index.html
@@ -55,8 +55,6 @@ translation_of: Web/API/KeyboardEvent/keyCode
 
 <h2 id="ブラウザの互換性">ブラウザの互換性</h2>
 
-<div class="hidden">このページの互換性表は、構造化データから生成されています。データに貢献したい方は、<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックしてプルリクエストを送ってください。</div>
-
 <p>{{Compat("api.KeyboardEvent.keyCode")}}</p>
 
 <h2 id="keyCodeの値">keyCodeの値</h2>

--- a/files/ja/web/api/localfilesystem/index.html
+++ b/files/ja/web/api/localfilesystem/index.html
@@ -207,8 +207,6 @@ window.requestFileSystem(window.PERSISTENT, 1024*1024,onInitFs,errorHandler);
 
 <h2 id="Browser_Compatibility" name="Browser_Compatibility">ブラウザの互換性</h2>
 
-<div class="hidden">このページの互換表は構造化データから生成されます。データに貢献したい場合は <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックし、プルリクエストを送信してください。</div>
-
 <p>{{Compat("api.LocalFileSystem")}}</p>
 
 <h2 id="あわせて参照">あわせて参照</h2>

--- a/files/ja/web/api/localfilesystemsync/index.html
+++ b/files/ja/web/api/localfilesystemsync/index.html
@@ -175,8 +175,6 @@ var fs = requestFileSystemSync(TEMPORARY, 1024*1024 /*1MB*/);</pre>
 
 <h2 id="Browser_Compatibility" name="Browser_Compatibility">ブラウザの互換性</h2>
 
-<div class="hidden">このページの互換性テーブルは構造化データから生成されます。データに貢献したい場合は <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックして、プルリクエストを送ってください。</div>
-
 <p>{{Compat("api.LocalFileSystemSync")}}</p>
 
 <h2 id="あわせて参照">あわせて参照</h2>

--- a/files/ja/web/api/location/index.html
+++ b/files/ja/web/api/location/index.html
@@ -97,8 +97,6 @@ console.log(url.origin);    // https://developer.mozilla.org:8080
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Location")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/location/reload/index.html
+++ b/files/ja/web/api/location/reload/index.html
@@ -47,8 +47,6 @@ translation_of: Web/API/Location/reload
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Location.reload")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/long_tasks_api/index.html
+++ b/files/ja/web/api/long_tasks_api/index.html
@@ -102,16 +102,12 @@ observer.observe({entryTypes: ["longtask"]});
 <h3 id="PerformanceLongTaskTiming" name="PerformanceLongTaskTiming"><code>PerformanceLongTaskTiming</code></h3>
 
 <div>
-<div class="hidden">このページの互換性テーブルは構造化データから生成されます。データに貢献したい場合は <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックして、プルリクエストを送ってください。</div>
-
 <p>{{Compat("api.PerformanceLongTaskTiming")}}</p>
 </div>
 
 <h3 id="TaskAttributionTiming" name="TaskAttributionTiming"><code>TaskAttributionTiming</code></h3>
 
 <div>
-<div class="hidden">このページの互換性テーブルは構造化データから生成されます。データに貢献したい場合は <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックして、プルリクエストを送ってください。</div>
-
 <p>{{Compat("api.TaskAttributionTiming")}}</p>
 </div>
 

--- a/files/ja/web/api/mediadevices/getusermedia/index.html
+++ b/files/ja/web/api/mediadevices/getusermedia/index.html
@@ -336,8 +336,6 @@ var constraints = { video: { facingMode: (front? "user" : "environment") } };
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.MediaDevices.getUserMedia")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/mediadevices/index.html
+++ b/files/ja/web/api/mediadevices/index.html
@@ -117,8 +117,6 @@ function errorMsg(msg, error) {
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
 <div>
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.MediaDevices")}}</p>
 </div>
 

--- a/files/ja/web/api/mediaquerylist/index.html
+++ b/files/ja/web/api/mediaquerylist/index.html
@@ -102,8 +102,6 @@ mql.addEventListener(screenTest);</pre>
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.MediaQueryList")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/mediaquerylist/matches/index.html
+++ b/files/ja/web/api/mediaquerylist/matches/index.html
@@ -75,8 +75,6 @@ addMQListener(window.matchMedia("(orientation:landscape)"),
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.MediaQueryList.matches")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/mediaquerylist/media/index.html
+++ b/files/ja/web/api/mediaquerylist/media/index.html
@@ -83,8 +83,6 @@ document.querySelector(".mq-value").innerText = mql.media;
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.MediaQueryList.media")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/mediaquerylist/onchange/index.html
+++ b/files/ja/web/api/mediaquerylist/onchange/index.html
@@ -59,8 +59,6 @@ mql.addEventListener( "change", (e) =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.MediaQueryList.onchange")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/mediasession/index.html
+++ b/files/ja/web/api/mediasession/index.html
@@ -89,6 +89,4 @@ function pause() {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<p class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</p>
-
 <p>{{Compat("api.MediaSession")}}</p>

--- a/files/ja/web/api/mediasource/index.html
+++ b/files/ja/web/api/mediasource/index.html
@@ -72,8 +72,6 @@ translation_of: Web/API/MediaSource
 
 <h2 id="ブラウザの互換性">ブラウザの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <div>{{Compat("api.MediaSource")}}</div>
 
 <h2 id="関連項目">関連項目</h2>

--- a/files/ja/web/api/mediastream/index.html
+++ b/files/ja/web/api/mediastream/index.html
@@ -117,8 +117,6 @@ translation_of: Web/API/MediaStream
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.MediaStream")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/mediastream/mediastream/index.html
+++ b/files/ja/web/api/mediastream/mediastream/index.html
@@ -62,8 +62,6 @@ translation_of: Web/API/MediaStream/MediaStream
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.MediaStream.MediaStream")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/mediastream_image_capture_api/index.html
+++ b/files/ja/web/api/mediastream_image_capture_api/index.html
@@ -72,15 +72,11 @@ track.applyConstraints({ advanced : [{ zoom: zoom.value }] });
 <h3 id="ImageCapture"><code>ImageCapture</code></h3>
 
 <div>
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.ImageCapture")}}</p>
 
 <h3 id="PhotoCapabilities"><code>PhotoCapabilities</code></h3>
 
 <div>
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.PhotoCapabilities")}}</p>
 </div>
 </div>

--- a/files/ja/web/api/mediastream_recording_api/using_the_mediastream_recording_api/index.html
+++ b/files/ja/web/api/mediastream_recording_api/using_the_mediastream_recording_api/index.html
@@ -261,8 +261,6 @@ mediaRecorder.ondataavailable = function(e) {
 
 <h3 id="MediaRecorder" name="MediaRecorder"><code>MediaRecorder</code></h3>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.MediaRecorder")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/mediastreamtrack/index.html
+++ b/files/ja/web/api/mediastreamtrack/index.html
@@ -120,8 +120,6 @@ translation_of: Web/API/MediaStreamTrack
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.MediaStreamTrack")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/mediastreamtrack/mute_event/index.html
+++ b/files/ja/web/api/mediastreamtrack/mute_event/index.html
@@ -92,8 +92,6 @@ musicTrack.mute = event = &gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.MediaStreamTrack.mute_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/mediastreamtrack/unmute_event/index.html
+++ b/files/ja/web/api/mediastreamtrack/unmute_event/index.html
@@ -90,8 +90,6 @@ musicTrack.mute = event = &gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.MediaStreamTrack.unmute_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/mediatracksupportedconstraints/facingmode/index.html
+++ b/files/ja/web/api/mediatracksupportedconstraints/facingmode/index.html
@@ -78,8 +78,6 @@ if (navigator.mediaDevices.getSupportedConstraints().facingMode) {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.MediaTrackSupportedConstraints.facingMode")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/messagechannel/port1/index.html
+++ b/files/ja/web/api/messagechannel/port1/index.html
@@ -69,8 +69,6 @@ function handleMessage(e) {
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
 <div>
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.MessageChannel.port1")}}</p>
 </div>
 

--- a/files/ja/web/api/messageevent/index.html
+++ b/files/ja/web/api/messageevent/index.html
@@ -122,8 +122,6 @@ myWorker.port.onmessage = function(e) {
 
 <h2 id="ブラウザの互換性">ブラウザの互換性</h2>
 
-<div class="hidden">このページの互換表は構造化データから生成されます。データに貢献したい場合は <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックし、プルリクエストを送信してください。</div>
-
 <p>{{Compat("api.MessageEvent")}}</p>
 
 <h2 id="関連情報">関連情報</h2>

--- a/files/ja/web/api/mouseevent/index.html
+++ b/files/ja/web/api/mouseevent/index.html
@@ -184,8 +184,6 @@ document.getElementById("button").addEventListener('click', simulateClick);</pre
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.MouseEvent")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/mouseevent/mouseevent/index.html
+++ b/files/ja/web/api/mouseevent/mouseevent/index.html
@@ -128,8 +128,6 @@ translation_of: Web/API/MouseEvent/MouseEvent
 
 <h2 id="ブラウザの互換性">ブラウザの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は、構造化データから生成されています。データに貢献したい方は、https://github.com/mdn/browser-compat-data をチェックしてプルリクエストを送ってください。</div>
-
 <p>{{Compat("api.MouseEvent.MouseEvent")}}</p>
 
 <h2 id="ポリフィル">ポリフィル</h2>


### PR DESCRIPTION
https://github.com/mdn/translated-content/issues/1008