### PR TITLE
web/api/r-v* の browser-compat-data に関する非表示の指示を一括削除

### DIFF
--- a/files/ja/web/api/range/index.html
+++ b/files/ja/web/api/range/index.html
@@ -136,8 +136,6 @@ translation_of: Web/API/Range
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Range")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/request/index.html
+++ b/files/ja/web/api/request/index.html
@@ -159,8 +159,6 @@ const bodyUsed = request.bodyUsed;
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Request")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/request/request/index.html
+++ b/files/ja/web/api/request/request/index.html
@@ -149,8 +149,6 @@ var myRequest = new Request('flowers.jpg', myInit);
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<p class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力したいのであれば、 <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</p>
-
 <p>{{Compat("api.Request.Request")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/resizeobserver/index.html
+++ b/files/ja/web/api/resizeobserver/index.html
@@ -75,8 +75,6 @@ resizeObserver.observe(document.querySelector('.box:nth-child(2)'));</pre>
 
 <h2 id="ブラウザの互換性">ブラウザの互換性</h2>
 
-<div class="hidden">このページの互換性テーブルは構造化データから生成されます。データに貢献したい場合は <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックして、プルリクエストを送ってください。</div>
-
 <p>{{Compat("api.ResizeObserver")}}</p>
 
 <h2 id="あわせて参照">あわせて参照</h2>

--- a/files/ja/web/api/resizeobserver/resizeobserver/index.html
+++ b/files/ja/web/api/resizeobserver/resizeobserver/index.html
@@ -81,6 +81,4 @@ resizeObserver.observe(divElem);</pre>
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.ResizeObserver.ResizeObserver")}}</p>

--- a/files/ja/web/api/resizeobserverentry/contentrect/index.html
+++ b/files/ja/web/api/resizeobserverentry/contentrect/index.html
@@ -68,6 +68,4 @@ resizeObserver.observe(divElem);</pre>
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.ResizeObserverEntry.contentRect")}}</p>

--- a/files/ja/web/api/resizeobserverentry/index.html
+++ b/files/ja/web/api/resizeobserverentry/index.html
@@ -65,6 +65,4 @@ resizeObserver.observe(document.querySelector('.box:nth-child(2)'));</pre>
 
 <h2 id="ブラウザの互換性">ブラウザの互換性</h2>
 
-<div class="hidden">このページの互換性テーブルは構造化データから生成されます。データに貢献したい場合は <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックして、プルリクエストを送ってください。</div>
-
 <p>{{Compat("api.ResizeObserverEntry")}}</p>

--- a/files/ja/web/api/rtcpeerconnection/index.html
+++ b/files/ja/web/api/rtcpeerconnection/index.html
@@ -358,8 +358,6 @@ translation_of: Web/API/RTCPeerConnection
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.RTCPeerConnection")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/rtcsessiondescription/index.html
+++ b/files/ja/web/api/rtcsessiondescription/index.html
@@ -118,8 +118,6 @@ translation_of: Web/API/RTCSessionDescription
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力したいのであれば、 <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.RTCSessionDescription")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/screen/availheight/index.html
+++ b/files/ja/web/api/screen/availheight/index.html
@@ -69,8 +69,6 @@ translation_of: Web/API/Screen/availHeight
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Screen.availHeight")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/screen/availleft/index.html
+++ b/files/ja/web/api/screen/availleft/index.html
@@ -40,6 +40,4 @@ window.moveTo(setX, setY);
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Screen.availLeft")}}</p>

--- a/files/ja/web/api/screen/availtop/index.html
+++ b/files/ja/web/api/screen/availtop/index.html
@@ -33,6 +33,4 @@ window.moveTo(setX, setY);
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Screen.availTop")}}</p>

--- a/files/ja/web/api/screen/colordepth/index.html
+++ b/files/ja/web/api/screen/colordepth/index.html
@@ -48,8 +48,6 @@ if ( window.screen.colorDepth &lt; 8) {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Screen.colorDepth")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/screen/height/index.html
+++ b/files/ja/web/api/screen/height/index.html
@@ -53,6 +53,4 @@ translation_of: Web/API/Screen/height
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Screen.height")}}</p>

--- a/files/ja/web/api/screen/index.html
+++ b/files/ja/web/api/screen/index.html
@@ -95,6 +95,4 @@ translation_of: Web/API/Screen
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Screen")}}</p>

--- a/files/ja/web/api/screen/left/index.html
+++ b/files/ja/web/api/screen/left/index.html
@@ -23,8 +23,6 @@ translation_of: Web/API/Screen/left
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Screen.left")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/screen/lockorientation/index.html
+++ b/files/ja/web/api/screen/lockorientation/index.html
@@ -101,8 +101,6 @@ if (screen.lockOrientationUniversal(["landscape-primary", "landscape-secondary"]
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Screen.lockOrientation")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/screen/mozbrightness/index.html
+++ b/files/ja/web/api/screen/mozbrightness/index.html
@@ -25,6 +25,4 @@ translation_of: Web/API/Screen/mozBrightness
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Screen.mozBrightness")}}</p>

--- a/files/ja/web/api/screen/mozenabled/index.html
+++ b/files/ja/web/api/screen/mozenabled/index.html
@@ -25,6 +25,4 @@ translation_of: Web/API/Screen/mozEnabled
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Screen.mozEnabled")}}</p>

--- a/files/ja/web/api/screen/onorientationchange/index.html
+++ b/files/ja/web/api/screen/onorientationchange/index.html
@@ -46,8 +46,6 @@ translation_of: Web/API/Screen/onorientationchange
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Screen.onorientationchange")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/screen/pixeldepth/index.html
+++ b/files/ja/web/api/screen/pixeldepth/index.html
@@ -49,8 +49,6 @@ if ( window.screen.pixelDepth &gt; 8 ) {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Screen.pixelDepth")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/screen/top/index.html
+++ b/files/ja/web/api/screen/top/index.html
@@ -26,8 +26,6 @@ translation_of: Web/API/Screen/top
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Screen.left")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/screen/unlockorientation/index.html
+++ b/files/ja/web/api/screen/unlockorientation/index.html
@@ -60,8 +60,6 @@ if (unlockOrientation()) {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Screen.unlockOrientation")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/screen/width/index.html
+++ b/files/ja/web/api/screen/width/index.html
@@ -52,6 +52,4 @@ if (window.screen.width &gt;= 1024 &amp;&amp; window.screen.height &gt;= 768) {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Screen.height")}}</p>

--- a/files/ja/web/api/scrolltooptions/index.html
+++ b/files/ja/web/api/scrolltooptions/index.html
@@ -74,6 +74,4 @@ translation_of: Web/API/ScrollToOptions
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.ScrollToOptions", 10)}}</p>

--- a/files/ja/web/api/serviceworkerglobalscope/index.html
+++ b/files/ja/web/api/serviceworkerglobalscope/index.html
@@ -138,8 +138,6 @@ translation_of: Web/API/ServiceWorkerGlobalScope
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.ServiceWorkerGlobalScope")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/serviceworkerglobalscope/notificationclick_event/index.html
+++ b/files/ja/web/api/serviceworkerglobalscope/notificationclick_event/index.html
@@ -100,8 +100,6 @@ translation_of: Web/API/ServiceWorkerGlobalScope/notificationclick_event
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.ServiceWorkerGlobalScope.push_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/serviceworkerglobalscope/onpush/index.html
+++ b/files/ja/web/api/serviceworkerglobalscope/onpush/index.html
@@ -72,8 +72,6 @@ self.addEventListener('push', function(PushEvent) { ... })
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザー実装状況</h2>
 
 <div>
-<div class="hidden">このページの互換性テーブルは構造化データから作成されています。データに貢献したい場合、<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックし、プルリクエストを送ってください。</div>
-
 <p>{{Compat("api.ServiceWorkerGlobalScope.onpush")}}</p>
 </div>
 

--- a/files/ja/web/api/serviceworkerglobalscope/onpushsubscriptionchange/index.html
+++ b/files/ja/web/api/serviceworkerglobalscope/onpushsubscriptionchange/index.html
@@ -52,8 +52,6 @@ translation_of: Web/API/ServiceWorkerGlobalScope/onpushsubscriptionchange
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザー実装状況</h2>
 
 <div>
-<div class="hidden">このページの互換性テーブルは構造化データから作成されています。データに貢献したい場合、<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックし、プルリクエストを送ってください。</div>
-
 <p>{{Compat("api.ServiceWorkerGlobalScope.onpushsubscriptionchange")}}</p>
 </div>
 

--- a/files/ja/web/api/serviceworkerglobalscope/push_event/index.html
+++ b/files/ja/web/api/serviceworkerglobalscope/push_event/index.html
@@ -80,8 +80,6 @@ translation_of: Web/API/ServiceWorkerGlobalScope/push_event
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.ServiceWorkerGlobalScope.push_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/serviceworkerglobalscope/pushsubscriptionchange_event/index.html
+++ b/files/ja/web/api/serviceworkerglobalscope/pushsubscriptionchange_event/index.html
@@ -104,8 +104,6 @@ translation_of: Web/API/ServiceWorkerGlobalScope/pushsubscriptionchange_event
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.ServiceWorkerGlobalScope.pushsubscriptionchange_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/serviceworkerregistration/pushmanager/index.html
+++ b/files/ja/web/api/serviceworkerregistration/pushmanager/index.html
@@ -69,8 +69,6 @@ navigator.serviceWorker.register('serviceworker.js').then(
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性テーブルは構造化データから作成されています。データに貢献したい場合、<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックし、プルリクエストを送ってください。</div>
-
 <p>{{Compat("api.ServiceWorkerRegistration.pushManager")}}</p>
 
 <h2 id="See_also" name="See_also">関連項目</h2>

--- a/files/ja/web/api/shadowroot/delegatesfocus/index.html
+++ b/files/ja/web/api/shadowroot/delegatesfocus/index.html
@@ -45,6 +45,4 @@ let hostElem = shadow.delegatesFocus;</pre>
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.ShadowRoot.delegatesFocus")}}</p>

--- a/files/ja/web/api/shadowroot/index.html
+++ b/files/ja/web/api/shadowroot/index.html
@@ -108,6 +108,4 @@ attributeChangedCallback(name, oldValue, newValue) {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.ShadowRoot")}}</p>

--- a/files/ja/web/api/shadowroot/innerhtml/index.html
+++ b/files/ja/web/api/shadowroot/innerhtml/index.html
@@ -38,6 +38,4 @@ shadow.innerHTML = '&lt;strong&gt;This element should be more important!&lt;/str
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.ShadowRoot.innerHTML")}}</p>

--- a/files/ja/web/api/sharedworkerglobalscope/connect_event/index.html
+++ b/files/ja/web/api/sharedworkerglobalscope/connect_event/index.html
@@ -88,8 +88,6 @@ translation_of: Web/API/SharedWorkerGlobalScope/connect_event
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.SharedWorkerGlobalScope.connect_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/sharedworkerglobalscope/index.html
+++ b/files/ja/web/api/sharedworkerglobalscope/index.html
@@ -118,8 +118,6 @@ translation_of: Web/API/SharedWorkerGlobalScope
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.SharedWorkerGlobalScope")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/speechrecognition/audiostart_event/index.html
+++ b/files/ja/web/api/speechrecognition/audiostart_event/index.html
@@ -74,8 +74,6 @@ recognition.addEventListener('audiostart', function() {
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
 <div>
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.SpeechRecognition.audiostart_event")}}</p>
 </div>
 

--- a/files/ja/web/api/storage/clear/index.html
+++ b/files/ja/web/api/storage/clear/index.html
@@ -58,8 +58,6 @@ translation_of: Web/API/Storage/clear
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Storage.clear")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/storage/removeitem/index.html
+++ b/files/ja/web/api/storage/removeitem/index.html
@@ -66,8 +66,6 @@ translation_of: Web/API/Storage/removeItem
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Storage.removeItem")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/storagemanager/estimate/index.html
+++ b/files/ja/web/api/storagemanager/estimate/index.html
@@ -90,8 +90,6 @@ translation_of: Web/API/StorageManager/estimate
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.StorageManager.estimate")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/streams_api/index.html
+++ b/files/ja/web/api/streams_api/index.html
@@ -135,8 +135,6 @@ translation_of: Web/API/Streams_API
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <h3 id="ReadableStream" name="ReadableStream">ReadableStream</h3>
 
 <p>{{Compat("api.ReadableStream")}}</p>

--- a/files/ja/web/api/stylesheetlist/index.html
+++ b/files/ja/web/api/stylesheetlist/index.html
@@ -58,6 +58,4 @@ translation_of: Web/API/StyleSheetList
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.StyleSheetList")}}</p>

--- a/files/ja/web/api/subtlecrypto/digest/index.html
+++ b/files/ja/web/api/subtlecrypto/digest/index.html
@@ -129,8 +129,6 @@ console.log(digestHex);
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.SubtleCrypto.digest")}}</p>
 
 <div class="blockIndicator note">

--- a/files/ja/web/api/text/splittext/index.html
+++ b/files/ja/web/api/text/splittext/index.html
@@ -106,8 +106,6 @@ p.insertBefore(u, bar);
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<p class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</p>
-
 <p>{{Compat("api.Text.splitText")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/textdecoder/index.html
+++ b/files/ja/web/api/textdecoder/index.html
@@ -96,8 +96,6 @@ console.log(win1251decoder.decode(bytes)); // Привет, мир!
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
 <div>
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.TextDecoder")}}</p>
 </div>
 

--- a/files/ja/web/api/textencoder/encode/index.html
+++ b/files/ja/web/api/textencoder/encode/index.html
@@ -66,8 +66,6 @@ resultPara.textContent += encoded;</pre>
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
 <div>
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.TextEncoder.encode")}}</p>
 </div>
 

--- a/files/ja/web/api/textencoder/encoding/index.html
+++ b/files/ja/web/api/textencoder/encoding/index.html
@@ -43,8 +43,6 @@ translation_of: Web/API/TextEncoder/encoding
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
 <div>
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.TextEncoder.encoding")}}</p>
 </div>
 

--- a/files/ja/web/api/textencoder/index.html
+++ b/files/ja/web/api/textencoder/index.html
@@ -140,8 +140,6 @@ console.log(view); // Uint8Array(3) [226, 130, 172]
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
 <div>
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.TextEncoder")}}</p>
 </div>
 

--- a/files/ja/web/api/textencoder/textencoder/index.html
+++ b/files/ja/web/api/textencoder/textencoder/index.html
@@ -61,8 +61,6 @@ translation_of: Web/API/TextEncoder/TextEncoder
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
 <div>
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.TextEncoder.TextEncoder")}}</p>
 </div>
 

--- a/files/ja/web/api/texttrack/cuechange_event/index.html
+++ b/files/ja/web/api/texttrack/cuechange_event/index.html
@@ -97,8 +97,6 @@ textTrackElem.oncuechange = (event) =&gt; {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.TextTrack.cuechange_event")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/texttrack/index.html
+++ b/files/ja/web/api/texttrack/index.html
@@ -87,8 +87,6 @@ translation_of: Web/API/TextTrack
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.TextTrack")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/texttrack/mode/index.html
+++ b/files/ja/web/api/texttrack/mode/index.html
@@ -92,8 +92,6 @@ translation_of: Web/API/TextTrack/mode
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
 <div>
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.TextTrack.mode")}}</p>
 </div>
 

--- a/files/ja/web/api/texttrackcue/index.html
+++ b/files/ja/web/api/texttrackcue/index.html
@@ -61,6 +61,4 @@ translation_of: Web/API/TextTrackCue
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden"><strong><strong>The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</strong></strong></div>
-
 <p>未定</p>

--- a/files/ja/web/api/touch/clientx/index.html
+++ b/files/ja/web/api/touch/clientx/index.html
@@ -76,6 +76,4 @@ src.addEventListener('touchend', function(e) {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Touch.clientY")}}</p>

--- a/files/ja/web/api/touch/clienty/index.html
+++ b/files/ja/web/api/touch/clienty/index.html
@@ -76,6 +76,4 @@ src.addEventListener('touchend', function(e) {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Touch.clientY")}}</p>

--- a/files/ja/web/api/touch/identifier/index.html
+++ b/files/ja/web/api/touch/identifier/index.html
@@ -59,6 +59,4 @@ translation_of: Web/API/Touch/identifier
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Touch.identifier")}}</p>

--- a/files/ja/web/api/touch/index.html
+++ b/files/ja/web/api/touch/index.html
@@ -98,8 +98,6 @@ translation_of: Web/API/Touch
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
 <div>
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Touch")}}</p>
 </div>
 

--- a/files/ja/web/api/touch_events/index.html
+++ b/files/ja/web/api/touch_events/index.html
@@ -332,8 +332,6 @@ document.addEventListener("DOMContentLoaded", startup);</pre>
 
 <p>すべての種類の端末でタッチとマウスの両方に対応するには、代わりに<a href="/ja/docs/Web/API/Pointer_events">ポインターイベント</a>を使用してください。</p>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Touch")}}</p>
 
 <h3 id="Firefox_touch_events_and_multiprocess_e10s" name="Firefox_touch_events_and_multiprocess_e10s">Firefox のタッチイベントとマルチプロセス (e10s)</h3>

--- a/files/ja/web/api/touchevent/index.html
+++ b/files/ja/web/api/touchevent/index.html
@@ -136,8 +136,6 @@ translation_of: Web/API/TouchEvent
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.TouchEvent")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/touchlist/index.html
+++ b/files/ja/web/api/touchlist/index.html
@@ -62,8 +62,6 @@ translation_of: Web/API/TouchList
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.TouchList")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/transferable/index.html
+++ b/files/ja/web/api/transferable/index.html
@@ -57,8 +57,6 @@ translation_of: Web/API/Transferable
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
 <div>
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Transferable")}}</p>
 </div>
 

--- a/files/ja/web/api/transformstream/index.html
+++ b/files/ja/web/api/transformstream/index.html
@@ -157,8 +157,6 @@ responses.reduce(
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.TransformStream")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/transitionevent/index.html
+++ b/files/ja/web/api/transitionevent/index.html
@@ -77,8 +77,6 @@ translation_of: Web/API/TransitionEvent
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.TransitionEvent")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/url/createobjecturl/index.html
+++ b/files/ja/web/api/url/createobjecturl/index.html
@@ -86,8 +86,6 @@ translation_of: Web/API/URL/createObjectURL
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<p class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力したいのであれば、 <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</p>
-
 <p>{{Compat("api.URL.createObjectURL")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/url/index.html
+++ b/files/ja/web/api/url/index.html
@@ -139,8 +139,6 @@ console.log(parsedUrl.searchParams.get("id")); // "123"
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.URL")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/url_api/index.html
+++ b/files/ja/web/api/url_api/index.html
@@ -123,8 +123,6 @@ try {
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
 <div>
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.URL")}}</p>
 </div>
 

--- a/files/ja/web/api/urlsearchparams/index.html
+++ b/files/ja/web/api/urlsearchparams/index.html
@@ -122,8 +122,6 @@ searchParams3.has("query") // true
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、<a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.URLSearchParams")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/userproximityevent/index.html
+++ b/files/ja/web/api/userproximityevent/index.html
@@ -40,8 +40,6 @@ translation_of: Web/API/UserProximityEvent
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの対応</h2>
 
-<p class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</p>
-
 <p>{{Compat("api.UserProximityEvent")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/vibration_api/index.html
+++ b/files/ja/web/api/vibration_api/index.html
@@ -91,8 +91,6 @@ function startPersistentVibrate(duration, interval) {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.Navigator.vibrate")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>

--- a/files/ja/web/api/videotracklist/index.html
+++ b/files/ja/web/api/videotracklist/index.html
@@ -111,6 +111,4 @@ function updateTrackCount(event) {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<div class="hidden">このページの互換性一覧表は構造化データから生成されています。データに協力していただけるのであれば、 <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> をチェックアウトしてプルリクエストを送信してください。</div>
-
 <p>{{Compat("api.VideoTrackList")}}</p>


### PR DESCRIPTION
https://github.com/mdn/translated-content/issues/1008