### PR TITLE
[zh-cn] 更新“操作符优先级”

### DIFF
--- a/files/zh-cn/web/javascript/reference/operators/operator_precedence/index.html
+++ b/files/zh-cn/web/javascript/reference/operators/operator_precedence/index.html
@@ -2,350 +2,486 @@
 title: 运算符优先级
 slug: Web/JavaScript/Reference/Operators/Operator_Precedence
 tags:
+  - 指南
   - JavaScript
   - 优先级
-  - 运算符
 translation_of: Web/JavaScript/Reference/Operators/Operator_Precedence
 ---
 <div>{{jsSidebar("Operators")}}</div>
 
-<p><span class="st">运算符的优先级决定了表达式中运算执行的先后顺序</span>，优先级高的运算符最先被执行。</p>
+<p><strong>运算符的优先级</strong>决定了表达式中运算执行的先后顺序。优先级高的运算符会作为优先级低的运算符的操作符。</p>
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-operatorprecedence.html")}}</div>
 
 
+<h2 id="Precedence_And_Associativity">优先级和结合性</h2>
 
-<h2 id="Associativity" name="Associativity">关联性</h2>
+<p>考虑由下面的表示法描述的表达式。其中，OP<sub>1</sub> 和 OP<sub>2</sub> 都是操作符的占位符。</p>
 
-<p>关联性决定了拥有相同优先级的运算符的执行顺序。考虑下面这个表达式：</p>
+<pre class="brush: js">a OP<sub>1</sub> b OP<sub>2</sub> c</pre>
 
-<pre class="notranslate">a OP b OP c;
+<p>如果 <code>OP<sub>1</sub></code> 和 <code>OP<sub>2</sub></code> 具有不同的优先级（见下表），则优先级最高的运算符先执行，不用考虑结合性。观察乘法如何具有比加法更高的优先级并首先执行，即使加法是首先写入代码的。</p>
+
+<pre class="brush: js">console.log(3 + 10 * 2);   // 输出 23
+console.log(3 + (10 * 2)); // 输出 23 因为这里的括号是多余的
+console.log((3 + 10) * 2); // 输出 26 因为括号改变了优先级
 </pre>
 
-<p>左关联（左到右）相当于把左边的子表达式加上小括号<code>(a OP b) OP c</code>，右关联（右到左）相当于<code>a OP (b OP c)</code>。赋值运算符是右关联的，所以你可以这么写：</p>
+<p>左结合（左到右）相当于把左边的子表达式加上小括号 <code>(a OP b) OP c</code>，右结合（右到左）相当于 <code>a OP (b OP c)</code>。赋值运算符是右结合的，所以你可以这么写：</p>
 
-<pre class="notranslate">a = b = 5; </pre>
+<pre class="notranslate">a = b = 5; // 相当于 a = (b = 5);
+</pre>
 
-<p>结果 <code>a</code> 和 <code>b</code> 的值都会成为5。这是因为赋值运算符的返回结果就是赋值运算符右边的那个值，具体过程是：<code>b</code>被赋值为5，然后<code>a</code>也被赋值为 <code>b=5</code> 的返回值，也就是5。</p>
+<p>预期结果是 <code>a</code> 和 <code>b</code> 的值都会成为 5。这是因为赋值运算符的返回结果就是赋值运算符右边的那个值，具体过程是：首先 <code>b</code> 被赋值为5，然后 <code>a</code> 也被赋值为 <code>b = 5</code> 的返回值，也就是 5。</p>
+
+<p>另一个例子是，只有幂运算符是右结合的，而其他算术运算符都是左结合的。有趣的是，无论结合性和优先级如何，求值顺序总是从左到右。</p>
+
+<table class="standard-table">
+    <tbody>
+        <tr>
+            <td>代码</td>
+            <td>输出</td>
+        </tr>
+        <tr>
+            <td>
+                <pre class="brush: js">
+function echo(name, num) {
+    console.log("Evaluating the " + name + " side");
+    return num;
+}
+// 注意这里的除法运算符 (/)
+console.log(echo("left", 6) / echo("right", 2));
+</pre>
+            </td>
+            <td>
+                <pre class="brush: plain">
+Evaluating the left side
+Evaluating the right side
+3
+</pre>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <pre class="brush: js">
+function echo(name, num) {
+    console.log("Evaluating the " + name + " side");
+    return num;
+}
+// 注意这里的幂运算符 (**)
+console.log(echo("left", 2) ** echo("right", 3));</pre>
+            </td>
+            <td>
+                <pre class="brush: plain">
+Evaluating the left side
+Evaluating the right side
+8</pre>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+<p>当有多个具有相同优先级的运算符时，结合性的差异就会发挥作用。仅使用一个或多个不同优先级的运算符时，结合性不会影响输出，如上面的例子所示。在下面的示例中，观察当使用多个相同运算符时关联性如何影响输出。</p>
+
+<table class="standard-table">
+    <tbody>
+        <tr>
+            <td>代码</td>
+            <td>输出</td>
+        </tr>
+        <tr>
+            <td>
+                <pre class="brush: js">
+function echo(name, num) {
+    console.log("Evaluating the " + name + " side");
+    return num;
+}
+// 注意这里的除法运算符 (/)
+console.log(echo("left", 6) / echo("middle", 2) / echo("right", 3));
+</pre>
+            </td>
+            <td>
+                <pre class="brush: plain">
+Evaluating the left side
+Evaluating the middle side
+Evaluating the right side
+1
+</pre>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <pre class="brush: js">
+function echo(name, num) {
+    console.log("Evaluating the " + name + " side");
+    return num;
+}
+// 注意这里的幂运算符 (**)
+console.log(echo("left", 2) ** echo("middle", 3) ** echo("right", 2));
+</pre>
+            </td>
+            <td>
+                <pre class="brush: plain">
+Evaluating the left side
+Evaluating the middle side
+Evaluating the right side
+512
+</pre>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <pre class="brush: js">
+function echo(name, num) {
+    console.log("Evaluating the " + name + " side");
+    return num;
+}
+// 注意这里左边和中间的被包围的求幂表达式
+console.log((echo("left", 2) ** echo("middle", 3)) ** echo("right", 2));</pre>
+            </td>
+            <td>
+                <pre class="brush: plain">
+Evaluating the left side
+Evaluating the middle side
+Evaluating the right side
+64</pre>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+<p>观察上面的代码片段，<code>6 / 3 / 2</code> 与
+    <code>(6 / 3) / 2</code> 是相同的，因为除法是左结合的。而幂运算符是右结合的，所以 <code>2 ** 3 ** 2</code> 与
+    <code>2 ** (3 ** 2)</code> 是相同的。因此，<code>(2 ** 3) ** 2</code> 会更改执行顺序，并导致输出上表中的 64。</p>
+
+<p>请记住，判断执行顺序，优先级在结合性之前。所以，混合求除法和幂，求幂会先于除法。例如，
+    <code>2 ** 3 / 3 ** 2</code> 结果是 0.8888888888888888 因为它相当于
+    <code>(2 ** 3) / (3 ** 2)</code>。</p>
+
+<h3 id="Note_on_grouping_and_short-circuiting">分组和短路的注意事项</h3>
+
+<p>在下表中，<strong>分组（Grouping）</strong>具有最高优先级。然而，这并不意味着总是优先对分组符号 <code>( … )</code> 内的表达式进行求值，尤其是涉及短路时。</p>
+
+<p>短路是条件求值的术语。例如，在表达式
+    <code>a &amp;&amp; (b + c)</code> 中，如果 <code>a</code> 为 {{Glossary("falsy")}}，那么即使 <code>(b + c)</code> 在圆括号中，也不会被求值。我们可以说逻辑或运算符（“OR”）是“短路的”。除了逻辑或运算符外，其他短路运算符还包括逻辑与（“AND”）、空值合并、可选链和条件（三元）运算符。下面有更多例子：</p>
+
+<pre class="brush: js">a || (b * c);  // 首先对 `a` 求值，如果 `a` 为真值则直接返回 `a`
+a &amp;&amp; (b &lt; c);  // 首先对 `a` 求值，如果 `a` 为虚值则直接返回 `a`
+a ?? (b || c); // 首先对 `a` 求值，如果 `a` 不是 `null` 或 `undefined` 则直接返回 `a`
+a?.b.c;        // 首先对 `a` 求值，如果 `a` 是 `null` 或 `undefined` 则直接返回 `undefined`
+</pre>
 
 <h2 id="示例">示例</h2>
 
-<pre class="brush: js notranslate">3 &gt; 2 &amp;&amp; 2 &gt; 1
-// return true
+<pre class="brush: js">3 &gt; 2 &amp;&amp; 2 &gt; 1
+// 返回 true
 
 3 &gt; 2 &gt; 1
-// 返回 false，因为 3 &gt; 2 是 true，并且 true &gt; 1 is false
+// 返回 false，因为 3 &gt; 2 是 true，然后 true 会在比较运算符中
+// 被隐式转换为 1，因此 true &gt; 1 会变为 1 &gt; 1，结果是 false
 // 加括号可以更清楚：(3 &gt; 2) &gt; 1
 </pre>
 
-<h2 id="Table" name="Table">汇总表</h2>
+<h2 id="Table">汇总表</h2>
 
-<p>下面的表将所有运算符按照优先级的不同从高（20）到低（1）排列。</p>
+<p>下面的表格将所有运算符按照优先级的不同从高（21）到低（1）排列。</p>
+
+<p>请注意，下表中故意不包含<a href="/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax">展开语法（Spread syntax）</a> —— 原因可以引用<a href="https://stackoverflow.com/a/48656377">Stack Overflow 上的一个回答</a>，“<a href="https://stackoverflow.com/q/44934828/1048572">展开语法不是一个运算符</a>，因此没有优先级。它是数组字面量和函数调用（和对象字面量）语法的一部分。”</p>
 
 <table class="fullwidth-table">
- <tbody>
-  <tr>
-   <th>优先级</th>
-   <th>运算类型</th>
-   <th>关联性</th>
-   <th>运算符</th>
-  </tr>
-  <tr>
-   <td>21</td>
-   <td>{{jsxref("Operators/Grouping", "圆括号")}}</td>
-   <td>n/a（不相关）</td>
-   <td><code>( … )</code></td>
-  </tr>
-  <tr>
-   <td rowspan="5">20</td>
-   <td>{{jsxref("Operators/Property_Accessors","成员访问", "#点符号表示法")}}</td>
-   <td>从左到右</td>
-   <td><code>… . …</code></td>
-  </tr>
-  <tr>
-   <td>{{jsxref("Operators/Property_Accessors","需计算的成员访问", "#括号表示法")}}</td>
-   <td>从左到右</td>
-   <td><code>… [ … ]</code></td>
-  </tr>
-  <tr>
-   <td>{{jsxref("Operators/new","new")}} (带参数列表)</td>
-   <td>n/a</td>
-   <td><code>new … ( … )</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Guide/Functions" title="JavaScript/Reference/Operators/Special_Operators/function_call">函数调用</a></td>
-   <td>从左到右</td>
-   <td><code>… ( <var>… </var>)</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Optional_chaining">可选链（Optional chaining）</a></td>
-   <td>从左到右</td>
-   <td><code>?.</code></td>
-  </tr>
-  <tr>
-   <td rowspan="1">19</td>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/new" title="JavaScript/Reference/Operators/Special_Operators/new_Operator">new</a> (无参数列表)</td>
-   <td>从右到左</td>
-   <td><code>new …</code></td>
-  </tr>
-  <tr>
-   <td rowspan="2">18</td>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Increment" title="JavaScript/Reference/Operators/Arithmetic_Operators">后置递增</a>(运算符在后)</td>
-   <td colspan="1" rowspan="2">n/a<br>
-     </td>
-   <td><code>… ++</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Decrement" title="JavaScript/Reference/Operators/Arithmetic_Operators">后置递减</a>(运算符在后)</td>
-   <td><code>… --</code></td>
-  </tr>
-  <tr>
-   <td colspan="1" rowspan="10">17</td>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_NOT">逻辑非</a></td>
-   <td colspan="1" rowspan="10">从右到左</td>
-   <td><code>! …</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_NOT" title="JavaScript/Reference/Operators/Bitwise_Operators">按位非</a></td>
-   <td><code>~ …</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Unary_plus" title="JavaScript/Reference/Operators/Arithmetic_Operators">一元加法</a></td>
-   <td><code>+ …</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Unary_negation" title="JavaScript/Reference/Operators/Arithmetic_Operators">一元减法</a></td>
-   <td><code>- …</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Increment" title="JavaScript/Reference/Operators/Arithmetic_Operators">前置递增</a></td>
-   <td><code>++ …</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Decrement" title="JavaScript/Reference/Operators/Arithmetic_Operators">前置递减</a></td>
-   <td><code>-- …</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/typeof" title="JavaScript/Reference/Operators/Special_Operators/typeof_Operator">typeof</a></td>
-   <td><code>typeof …</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/void" title="JavaScript/Reference/Operators/Special_Operators/void_Operator">void</a></td>
-   <td><code>void …</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/delete" title="JavaScript/Reference/Operators/Special_Operators/delete_Operator">delete</a></td>
-   <td><code>delete …</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await">await</a></td>
-   <td><code>await …</code></td>
-  </tr>
-  <tr>
-   <td>16</td>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation" title="JavaScript/Reference/Operators/Arithmetic_Operators">幂</a></td>
-   <td>从右到左</td>
-   <td><code>… ** …</code></td>
-  </tr>
-  <tr>
-   <td rowspan="3">15</td>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Multiplication" title="JavaScript/Reference/Operators/Arithmetic_Operators">乘法</a></td>
-   <td colspan="1" rowspan="3">从左到右<br>
-     </td>
-   <td><code>… * …</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Division" title="JavaScript/Reference/Operators/Arithmetic_Operators">除法</a></td>
-   <td><code>… / …</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Remainder" title="JavaScript/Reference/Operators/Arithmetic_Operators">取模</a></td>
-   <td><code>… % …</code></td>
-  </tr>
-  <tr>
-   <td rowspan="2">14</td>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Addition" title="JavaScript/Reference/Operators/Arithmetic_Operators">加法</a></td>
-   <td colspan="1" rowspan="2">从左到右<br>
-     </td>
-   <td><code>… + …</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Subtraction" title="JavaScript/Reference/Operators/Arithmetic_Operators">减法</a></td>
-   <td><code>… - …</code></td>
-  </tr>
-  <tr>
-   <td rowspan="3">13</td>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators" title="JavaScript/Reference/Operators/Bitwise_Operators">按位左移</a></td>
-   <td colspan="1" rowspan="3">从左到右</td>
-   <td><code>… &lt;&lt; …</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators" title="JavaScript/Reference/Operators/Bitwise_Operators">按位右移</a></td>
-   <td><code>… &gt;&gt; …</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators" title="JavaScript/Reference/Operators/Bitwise_Operators">无符号右移</a></td>
-   <td><code>… &gt;&gt;&gt; …</code></td>
-  </tr>
-  <tr>
-   <td rowspan="6">12</td>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Less_than_operator" title="JavaScript/Reference/Operators/Comparison_Operators">小于</a></td>
-   <td colspan="1" rowspan="6">从左到右</td>
-   <td><code>… &lt; …</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Less_than__or_equal_operator" title="JavaScript/Reference/Operators/Comparison_Operators">小于等于</a></td>
-   <td><code>… &lt;= …</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Greater_than_operator" title="JavaScript/Reference/Operators/Comparison_Operators">大于</a></td>
-   <td><code>… &gt; …</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Greater_than_or_equal_operator" title="JavaScript/Reference/Operators/Comparison_Operators">大于等于</a></td>
-   <td><code>… &gt;= …</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/in" title="JavaScript/Reference/Operators/Special_Operators/in_Operator">in</a></td>
-   <td><code>… in …</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/instanceof" title="JavaScript/Reference/Operators/Special_Operators/instanceof_Operator">instanceof</a></td>
-   <td><code>… instanceof …</code></td>
-  </tr>
-  <tr>
-   <td rowspan="4">11</td>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Equality" title="JavaScript/Reference/Operators/Comparison_Operators">等号</a></td>
-   <td colspan="1" rowspan="4">从左到右<br>
-     </td>
-   <td><code>… == …</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Inequality" title="JavaScript/Reference/Operators/Comparison_Operators">非等号</a></td>
-   <td><code>… != …</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Identity" title="JavaScript/Reference/Operators/Comparison_Operators">全等号</a></td>
-   <td><code>… === …</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Nonidentity" title="JavaScript/Reference/Operators/Comparison_Operators">非全等号</a></td>
-   <td><code>… !== …</code></td>
-  </tr>
-  <tr>
-   <td>10</td>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_AND" title="JavaScript/Reference/Operators/Bitwise_Operators">按位与</a></td>
-   <td>从左到右</td>
-   <td><code>… &amp; …</code></td>
-  </tr>
-  <tr>
-   <td>9</td>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_XOR" title="JavaScript/Reference/Operators/Bitwise_Operators">按位异或</a></td>
-   <td>从左到右</td>
-   <td><code>… ^ …</code></td>
-  </tr>
-  <tr>
-   <td>8</td>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_OR" title="JavaScript/Reference/Operators/Bitwise_Operators">按位或</a></td>
-   <td>从左到右</td>
-   <td><code>… | …</code></td>
-  </tr>
-  <tr>
-   <td>7</td>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_AND" title="JavaScript/Reference/Operators/Logical_Operators">逻辑与</a></td>
-   <td>从左到右</td>
-   <td><code>… &amp;&amp; …</code></td>
-  </tr>
-  <tr>
-   <td>6</td>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_OR" title="JavaScript/Reference/Operators/Logical_Operators">逻辑或</a></td>
-   <td>从左到右</td>
-   <td><code>… || …</code></td>
-  </tr>
-  <tr>
-   <td>5</td>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator" title="JavaScript/Reference/Operators/Nullish_coalescing_operator">空值合并</a></td>
-   <td>从左到右</td>
-   <td><code>… ?? …</code></td>
-  </tr>
-  <tr>
-   <td>4</td>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Conditional_Operator" title="JavaScript/Reference/Operators/Special_Operators/Conditional_Operator">条件运算符</a></td>
-   <td>从右到左</td>
-   <td><code>… ? … : …</code></td>
-  </tr>
-  <tr>
-   <td rowspan="16">3</td>
-   <td rowspan="16"><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Assignment_Operators" title="JavaScript/Reference/Operators/Assignment_Operators">赋值</a></td>
-   <td rowspan="16">从右到左</td>
-   <td><code>… = …</code></td>
-  </tr>
-  <tr>
-   <td><code>… += …</code></td>
-  </tr>
-  <tr>
-   <td><code>… -= …</code></td>
-  </tr>
-  <tr>
-   <td><code>… **= …</code></td>
-  </tr>
-  <tr>
-   <td><code>… *= …</code></td>
-  </tr>
-  <tr>
-   <td><code>… /= …</code></td>
-  </tr>
-  <tr>
-   <td><code>… %= …</code></td>
-  </tr>
-  <tr>
-   <td><code>… &lt;&lt;= …</code></td>
-  </tr>
-  <tr>
-   <td><code>… &gt;&gt;= …</code></td>
-  </tr>
-  <tr>
-   <td><code>… &gt;&gt;&gt;= …</code></td>
-  </tr>
-  <tr>
-   <td><code>… &amp;= …</code></td>
-  </tr>
-  <tr>
-   <td><code>… ^= …</code></td>
-  </tr>
-  <tr>
-   <td><code>… |= …</code></td>
-  </tr>
-  <tr>
-   <td><code>… &amp;&amp;= …</code></td>
-  </tr>
-  <tr>
-   <td><code>… ||= …</code></td>
-  </tr>
-  <tr>
-   <td><code>… ??= …</code></td>
-  </tr>
-  <tr>
-   <td colspan="1" rowspan="2">2</td>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/yield" title="JavaScript/Reference/Operators/yield">yield</a></td>
-   <td colspan="1" rowspan="2">从右到左</td>
-   <td><code>yield …</code></td>
-  </tr>
-  <tr>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/yield*" title="JavaScript/Reference/Operators/yield">yield*</a></td>
-   <td><code>yield* …</code></td>
-  </tr>
-  <tr>
-   <td>1</td>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Spread_operator" title="JavaScript/Reference/Operators/Spread_operator">展开运算符</a></td>
-   <td>n/a</td>
-   <td><code>...</code> …</td>
-  </tr>
-  <tr>
-   <td>0</td>
-   <td><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Operators/Comma_Operator" title="JavaScript/Reference/Operators/Comma_Operator">逗号</a></td>
-   <td>从左到右</td>
-   <td><code>… , …</code></td>
-  </tr>
- </tbody>
+    <tbody>
+        <tr>
+            <th>优先级</th>
+            <th>运算符类型</th>
+            <th>结合性</th>
+            <th>运算符</th>
+        </tr>
+        <tr>
+            <td>21</td>
+            <td>{{jsxref("Operators/Grouping", "分组", "", 1)}}</td>
+            <td>n/a（不相关）</td>
+            <td><code>( … )</code></td>
+        </tr>
+        <tr>
+            <td rowspan="5">20</td>
+            <td>{{jsxref("Operators/Property_Accessors", "成员访问", "#Dot_notation", 1)}}</td>
+            <td>从左到右</td>
+            <td><code>… . …</code></td>
+        </tr>
+        <tr>
+            <td>{{jsxref("Operators/Property_Accessors", "需计算的成员访问", "#Bracket_notation", 1)}}</td>
+            <td>从左到右</td>
+            <td><code>… [ … ]</code></td>
+        </tr>
+        <tr>
+            <td>{{jsxref("Operators/new","new")}}（带参数列表）</td>
+            <td>n/a</td>
+            <td><code>new … ( … )</code></td>
+        </tr>
+        <tr>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Guide/Functions">函数调用</a></td>
+            <td>从左到右</td>
+            <td><code>… ( <var>… </var>)</code></td>
+        </tr>
+        <tr>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Optional_chaining">可选链（Optional chaining）</a></td>
+            <td>从左到右</td>
+            <td><code>?.</code></td>
+        </tr>
+        <tr>
+            <td>19</td>
+            <td>{{jsxref("Operators/new","new")}}（无参数列表）</td>
+            <td>从右到左</td>
+            <td><code>new …</code></td>
+        </tr>
+        <tr>
+            <td rowspan="2">18</td>
+            <td>{{jsxref("Operators","后置递增","#Increment", 1)}}</td>
+            <td rowspan="2">n/a</td>
+            <td><code>… ++</code></td>
+        </tr>
+        <tr>
+            <td>{{jsxref("Operators","后置递减","#Decrement", 1)}}</td>
+            <td><code>… --</code></td>
+        </tr>
+        <tr>
+            <td rowspan="10">17</td>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Logical_NOT">逻辑非 (!)</a></td>
+            <td rowspan="10">从右到左</td>
+            <td><code>! …</code></td>
+        </tr>
+        <tr>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Bitwise_NOT">按位非 (~)</a></td>
+            <td><code>~ …</code></td>
+        </tr>
+        <tr>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Unary_plus">一元加法 (+)</a></td>
+            <td><code>+ …</code></td>
+        </tr>
+        <tr>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Unary_negation">一元减法 (-)</a></td>
+            <td><code>- …</code></td>
+        </tr>
+        <tr>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators#increment">前置递增</a></td>
+            <td><code>++ …</code></td>
+        </tr>
+        <tr>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators#decrement">前置递减</a></td>
+            <td><code>-- …</code></td>
+        </tr>
+        <tr>
+            <td>{{jsxref("Operators/typeof", "typeof")}}</td>
+            <td><code>typeof …</code></td>
+        </tr>
+        <tr>
+            <td>{{jsxref("Operators/void", "void")}}</td>
+            <td><code>void …</code></td>
+        </tr>
+        <tr>
+            <td>{{jsxref("Operators/delete", "delete")}}</td>
+            <td><code>delete …</code></td>
+        </tr>
+        <tr>
+            <td>{{jsxref("Operators/await", "await")}}</td>
+            <td><code>await …</code></td>
+        </tr>
+        <tr>
+            <td>16</td>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Exponentiation">幂 (**)</a></td>
+            <td>从右到左</td>
+            <td><code>… ** …</code></td>
+        </tr>
+        <tr>
+            <td rowspan="3">15</td>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Multiplication">乘法 (*)</a></td>
+            <td rowspan="3">从左到右</td>
+            <td><code>… * …</code></td>
+        </tr>
+        <tr>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Division">除法 (/)</a></td>
+            <td><code>… / …</code></td>
+        </tr>
+        <tr>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Remainder">取余 (%)</a></td>
+            <td><code>… % …</code></td>
+        </tr>
+        <tr>
+            <td rowspan="2">14</td>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Addition">加法 (+)</a></td>
+            <td rowspan="2">从左到右</td>
+            <td><code>… + …</code></td>
+        </tr>
+        <tr>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Subtraction">减法 (-)</a></td>
+            <td><code>… - …</code></td>
+        </tr>
+        <tr>
+            <td rowspan="3">13</td>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Left_shift">按位左移 (&lt;&lt;)</a></td>
+            <td rowspan="3">从左到右</td>
+            <td><code>… &lt;&lt; …</code></td>
+        </tr>
+        <tr>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Right_shift">按位右移 (&gt;&gt;)</a></td>
+            <td><code>… &gt;&gt; …</code></td>
+        </tr>
+        <tr>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift">无符号右移 (&gt;&gt;&gt;)</a></td>
+            <td><code>… &gt;&gt;&gt; …</code></td>
+        </tr>
+        <tr>
+            <td rowspan="6">12</td>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Less_than">小于 (&lt;)</a></td>
+            <td rowspan="6">从左到右</td>
+            <td><code>… &lt; …</code></td>
+        </tr>
+        <tr>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Less_than_or_equal">小于等于 (&lt;=)</a></td>
+            <td><code>… &lt;= …</code></td>
+        </tr>
+        <tr>
+            <td><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than">大于 (&gt;)</a></td>
+            <td><code>… &gt; …</code></td>
+        </tr>
+        <tr>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Greater_than_or_equal">大于等于 (&gt;=)</a></td>
+            <td><code>… &gt;= …</code></td>
+        </tr>
+        <tr>
+            <td>{{jsxref("Operators/in", "in")}}</td>
+            <td><code>… in …</code></td>
+        </tr>
+        <tr>
+            <td>{{jsxref("Operators/instanceof", "instanceof")}}</td>
+            <td><code>… instanceof …</code></td>
+        </tr>
+        <tr>
+            <td rowspan="4">11</td>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Equality">相等 (==)</a></td>
+            <td rowspan="4">从左到右</td>
+            <td><code>… == …</code></td>
+        </tr>
+        <tr>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Inequality">不相等 (!=)</a></td>
+            <td><code>… != …</code></td>
+        </tr>
+        <tr>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Strict_equality">一致/严格相等 (===)</a></td>
+            <td><code>… === …</code></td>
+        </tr>
+        <tr>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Strict_inequality">不一致/严格不相等 (!==)</a></td>
+            <td><code>… !== …</code></td>
+        </tr>
+        <tr>
+            <td>10</td>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Bitwise_AND">按位与 (&amp;)</a></td>
+            <td>从左到右</td>
+            <td><code>… &amp; …</code></td>
+        </tr>
+        <tr>
+            <td>9</td>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Bitwise_XOR">按位异或 (^)</a></td>
+            <td>从左到右</td>
+            <td><code>… ^ …</code></td>
+        </tr>
+        <tr>
+            <td>8</td>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Bitwise_OR">按位或 (|)</a></td>
+            <td>从左到右</td>
+            <td><code>… | …</code></td>
+        </tr>
+        <tr>
+            <td>7</td>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Logical_AND">逻辑与 (&amp;&amp;)</a></td>
+            <td>从左到右</td>
+            <td><code>… &amp;&amp; …</code></td>
+        </tr>
+        <tr>
+            <td>6</td>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Logical_OR">逻辑或 (||)</a></td>
+            <td>从左到右</td>
+            <td><code>… || …</code></td>
+        </tr>
+        <tr>
+            <td>5</td>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator">空值合并 (??)</a></td>
+            <td>从左到右</td>
+            <td><code>… ?? …</code></td>
+        </tr>
+        <tr>
+            <td>4</td>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Conditional_Operator">条件（三元）运算符</a></td>
+            <td>从右到左</td>
+            <td><code>… ? … : …</code></td>
+        </tr>
+        <tr>
+            <td rowspan="16">3</td>
+            <td rowspan="16"><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators#assignment_operators">赋值</a></td>
+            <td rowspan="16">从右到左</td>
+            <td><code>… = …</code></td>
+        </tr>
+        <tr>
+            <td><code>… += …</code></td>
+        </tr>
+        <tr>
+            <td><code>… -= …</code></td>
+        </tr>
+        <tr>
+            <td><code>… **= …</code></td>
+        </tr>
+        <tr>
+            <td><code>… *= …</code></td>
+        </tr>
+        <tr>
+            <td><code>… /= …</code></td>
+        </tr>
+        <tr>
+            <td><code>… %= …</code></td>
+        </tr>
+        <tr>
+            <td><code>… &lt;&lt;= …</code></td>
+        </tr>
+        <tr>
+            <td><code>… &gt;&gt;= …</code></td>
+        </tr>
+        <tr>
+            <td><code>… &gt;&gt;&gt;= …</code></td>
+        </tr>
+        <tr>
+            <td><code>… &amp;= …</code></td>
+        </tr>
+        <tr>
+            <td><code>… ^= …</code></td>
+        </tr>
+        <tr>
+            <td><code>… |= …</code></td>
+        </tr>
+        <tr>
+            <td><code>… &amp;&amp;= …</code></td>
+        </tr>
+        <tr>
+            <td><code>… ||= …</code></td>
+        </tr>
+        <tr>
+            <td><code>… ??= …</code></td>
+        </tr>
+        <tr>
+            <td rowspan="2">2</td>
+            <td>{{jsxref("Operators/yield", "yield")}}</td>
+            <td rowspan="2">从右到左</td>
+            <td><code>yield …</code></td>
+        </tr>
+        <tr>
+            <td>{{jsxref("Operators/yield*", "yield*")}}</td>
+            <td><code>yield* …</code></td>
+        </tr>
+        <tr>
+            <td>1</td>
+            <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Comma_Operator">逗号 / 序列</a></td>
+            <td>从左到右</td>
+            <td><code>… , …</code></td>
+        </tr>
+    </tbody>
 </table>


### PR DESCRIPTION
- 修正操作符 `%` 的中文名称为“取余”
- 修正操作符 `==`/`!=`/`===`/`!==` 的中文名称，与指向的页面保持一致
- 同步英文版
  - 新增内容
  - 展开语法（Spread syntax）从操作符优先级表格移除，并解释原因
  - 表格、链接等 html 格式