### PR TITLE
remove hidden bcd table from 'es'

### DIFF
--- a/files/es/mdn/structures/compatibility_tables/index.html
+++ b/files/es/mdn/structures/compatibility_tables/index.html
@@ -468,7 +468,7 @@ y envíanos una solicitud de extracción.
 <p>Otro ejemplo, la tabla de compatibilidad para la propiedad {{domxref("VRDisplay.capabilities")}} se genera usando <code>\{{Compat("api.VRDisplay.capabilities")}}</code>. La llamada a la macro genera la siguiente tabla (y el correspondiente conjunto de notas):</p>
 
 <hr>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("api.VRDisplay.capabilities")}}</p>
 

--- a/files/es/mozilla/add-ons/webextensions/api/storage/local/index.html
+++ b/files/es/mozilla/add-ons/webextensions/api/storage/local/index.html
@@ -46,8 +46,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/storage/local
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.storage.local")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/es/mozilla/add-ons/webextensions/api/storage/sync/index.html
+++ b/files/es/mozilla/add-ons/webextensions/api/storage/sync/index.html
@@ -34,8 +34,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/storage/sync
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.api.storage.sync")}}</p>
 
 <p>{{WebExtExamples}}</p>

--- a/files/es/mozilla/add-ons/webextensions/browser_support_for_javascript_apis/index.html
+++ b/files/es/mozilla/add-ons/webextensions/browser_support_for_javascript_apis/index.html
@@ -7,8 +7,6 @@ translation_of: Mozilla/Add-ons/WebExtensions/Browser_support_for_JavaScript_API
 
 <p>{{WebExtAllCompatTables}}</p>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <div class="note"><strong>Acknowledgements</strong>
 
 <p>Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.</p>

--- a/files/es/mozilla/add-ons/webextensions/manifest.json/icons/index.html
+++ b/files/es/mozilla/add-ons/webextensions/manifest.json/icons/index.html
@@ -69,6 +69,4 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/icons
 
 <h2 id="Compatibilidad">Compatibilidad</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("webextensions.manifest.icons")}}</p>

--- a/files/es/mozilla/add-ons/webextensions/manifest.json/index.html
+++ b/files/es/mozilla/add-ons/webextensions/manifest.json/index.html
@@ -42,7 +42,7 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json
 
 <p>Para un resumen extendido de las llaves y sub-llaves ver la <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_compatibility_for_manifest.json"> tabla completa de compatibilidad de <code>manifest.json</code> en navegadores</a>.</p>
 
-<div class="hidden">La tabla de compatibilidad está generada desde datos estructurados. Si quieres colaborar visita <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y solicita un <em>pull request</em>.</div>
+
 
 <p>{{Compat("webextensions.manifest")}}</p>
 

--- a/files/es/orphaned/web/javascript/reference/operators/pipeline_operator/index.html
+++ b/files/es/orphaned/web/javascript/reference/operators/pipeline_operator/index.html
@@ -66,7 +66,7 @@ double(increment(double(double(5)))); // 42
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. Si quieres contribuir a estos datos, por favor consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y mándanos una pull request.</div>
+
 
 <p>{{Compat("javascript.operators.pipeline")}}</p>
 </div>

--- a/files/es/web/api/audiobuffer/index.html
+++ b/files/es/web/api/audiobuffer/index.html
@@ -96,7 +96,7 @@ source.start();
 <h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidades en esta página está generada por una data estructurada. Si te gustaria contribuir incluyendo data, por favor reviza <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envianos un pull request.</div>
+
 
 <p>{{Compat("api.AudioBuffer")}}</p>
 </div>

--- a/files/es/web/api/beforeunloadevent/index.html
+++ b/files/es/web/api/beforeunloadevent/index.html
@@ -53,8 +53,6 @@ window.addEventListener("beforeunload", function( event ) {
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
 <div>
-<div class="hidden">La table de compatibilidad en esta página se genera a partir de los datos estructurados. Si le gustaría contrubuir con los datos, por favor revise <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos un un pull request.</div>
-
 <p>{{Compat("api.BeforeUnloadEvent")}}</p>
 </div>
 

--- a/files/es/web/api/body/formdata/index.html
+++ b/files/es/web/api/body/formdata/index.html
@@ -59,7 +59,7 @@ translation_of: Web/API/Body/formData
 
 <h2 id="Compatibilidad_en_navegadores">Compatibilidad en navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página es generada por datos estructurados. Si te gustaría contribuir con los datos, por favor revisar <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos un pull request.</div>
+
 
 <p>{{Compat("api.Body.formData")}}</p>
 

--- a/files/es/web/api/canvasrenderingcontext2d/getimagedata/index.html
+++ b/files/es/web/api/canvasrenderingcontext2d/getimagedata/index.html
@@ -90,7 +90,7 @@ console.log(ctx.getImageData(50, 50, 100, 100));
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, visite <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos una solicitud de extracción.</div>
+
 
 <p>{{Compat("api.CanvasRenderingContext2D.getImageData")}}</p>
 

--- a/files/es/web/api/canvasrenderingcontext2d/rotate/index.html
+++ b/files/es/web/api/canvasrenderingcontext2d/rotate/index.html
@@ -126,7 +126,7 @@ ctx.fillRect(80, 60, 140, 30);
 
 <h2 id="Compatibilidad_con_exploradores">Compatibilidad con exploradores</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si desea contribuir a estos datos, vaya a <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y haga un pull request.</div>
+
 
 <p>{{Compat("api.CanvasRenderingContext2D.rotate")}}</p>
 

--- a/files/es/web/api/clipboard_api/index.html
+++ b/files/es/web/api/clipboard_api/index.html
@@ -58,7 +58,7 @@ original_slug: Web/API/API_del_portapapeles
 
 <h3 id="ClipboardEvent">ClipboardEvent</h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
 
 <p>{{Compat("api.ClipboardEvent")}}</p>
 

--- a/files/es/web/api/comment/index.html
+++ b/files/es/web/api/comment/index.html
@@ -64,7 +64,7 @@ translation_of: Web/API/Comment
 
 <h2 id="Compatibilidad_entre_navegadores">Compatibilidad entre navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si desea contribuir a los datos, consulte <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos un pull request.</div>
+
 
 <p>{{Compat("api.Comment")}}</p>
 

--- a/files/es/web/api/console/timeend/index.html
+++ b/files/es/web/api/console/timeend/index.html
@@ -45,7 +45,7 @@ translation_of: Web/API/Console/timeEnd
 <h2 id="Compatibilidad_con_Navegadores">Compatibilidad con Navegadores</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad en esta página es generada automáticamente. Si deseas contribuir con información, por favor visita <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envianos un pull request.</div>
+
 
 <p>{{Compat("api.Console.timeEnd")}}</p>
 </div>

--- a/files/es/web/api/crypto/index.html
+++ b/files/es/web/api/crypto/index.html
@@ -54,7 +54,7 @@ translation_of: Web/API/Crypto
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si desea contribuir a los datos, por favor, compruebe <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y enviarnos un pull request.</div>
+
 
 <p>{{Compat("api.Crypto")}}</p>
 </div>

--- a/files/es/web/api/document/adoptnode/index.html
+++ b/files/es/web/api/document/adoptnode/index.html
@@ -50,7 +50,7 @@ iframeImages.forEach(function(imgEl) {
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados .Si desea contribuir con los datos, por favor ingrese a  <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envie una solicitud para adicionar los datos.</div>
+
 
 <p>{{Compat("api.Document.adoptNode")}}</p>
 

--- a/files/es/web/api/document/createattribute/index.html
+++ b/files/es/web/api/document/createattribute/index.html
@@ -81,7 +81,7 @@ console.log(nodo.getAttribute("miAtributo")); // "nuevoVal"
 
 <h2 id="Compatibilidad_del_buscador">Compatibilidad del buscador</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página es generada desde estructuras de datos. Sí le gustaría contribuir con estos datos, por favor revisar <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y enviarnos un pull request.</div>
+
 
 <p>{{Compat("api.Document.createAttribute")}}</p>
 

--- a/files/es/web/api/document/embeds/index.html
+++ b/files/es/web/api/document/embeds/index.html
@@ -43,6 +43,6 @@ translation_of: Web/API/Document/embeds
 
 <h2 id="Compatibilidad_con_Navegadores">Compatibilidad con Navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de structured data. Si usted quiere contribuir, por favor visite <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos un pull request.</div>
+
 
 <div>{{Compat("api.Document.embeds")}}</div>

--- a/files/es/web/api/document/exitfullscreen/index.html
+++ b/files/es/web/api/document/exitfullscreen/index.html
@@ -59,7 +59,7 @@ translation_of: Web/API/Document/exitFullscreen
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, consulte <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos un pull request.</div>
+
 
 <p>{{Compat("api.Document.exitFullscreen")}}</p>
 

--- a/files/es/web/api/dragevent/index.html
+++ b/files/es/web/api/dragevent/index.html
@@ -101,7 +101,7 @@ translation_of: Web/API/DragEvent
 
 <h2 id="Compatibilidad_entre_navegadores">Compatibilidad entre navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta pagina es generado desde datos estructurados. Si gustas contribuir a los datos, por favor revisa <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos un solicitud de cambios.</div>
+
 
 <p>{{Compat("api.DragEvent")}}</p>
 

--- a/files/es/web/api/element/computedstylemap/index.html
+++ b/files/es/web/api/element/computedstylemap/index.html
@@ -94,6 +94,6 @@ for (const [prop, val] of allComputedStyles) {
 
 <h2 id="Compatibilidad_con_navedadores">Compatibilidad con navedadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página es generada desde datos estructurados, por favor revisa <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una "pull request".</div>
+
 
 <p>{{Compat("api.Element.computedStyleMap")}}</p>

--- a/files/es/web/api/gamepad_api/index.html
+++ b/files/es/web/api/gamepad_api/index.html
@@ -83,7 +83,7 @@ translation_of: Web/API/Gamepad_API
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad es generada de datos estructurados. Si desea contribuir a los datos, por favor, echa un vistazo <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envienos una pull request.</div>
+
 
 <p>{{Compat("api.Gamepad")}}</p>
 

--- a/files/es/web/api/geolocationposition/index.html
+++ b/files/es/web/api/geolocationposition/index.html
@@ -51,7 +51,7 @@ translation_of: Web/API/GeolocationPosition
 
 <h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página está generada a partir de datos estructurados. Si quieres contribuir con datos, por favor, revisa <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una pull request.</div>
+
 
 <p>{{Compat("api.Position")}}</p>
 

--- a/files/es/web/api/globaleventhandlers/index.html
+++ b/files/es/web/api/globaleventhandlers/index.html
@@ -258,7 +258,7 @@ translation_of: Web/API/GlobalEventHandlers
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("api.GlobalEventHandlers")}}</p>
 </div>

--- a/files/es/web/api/globaleventhandlers/onclose/index.html
+++ b/files/es/web/api/globaleventhandlers/onclose/index.html
@@ -46,7 +46,5 @@ translation_of: Web/API/GlobalEventHandlers/onclose
 <h2 id="Compatibilidad_con_Navegadores">Compatibilidad con Navegadores</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad en esta pagina es generada de datos estructurados. Si te gustaría contribuir a los datos, por favor haz check out de <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envianos una petición pull.</div>
-
 <p>{{Compat("api.GlobalEventHandlers.onclose")}}</p>
 </div>

--- a/files/es/web/api/history/length/index.html
+++ b/files/es/web/api/history/length/index.html
@@ -45,7 +45,7 @@ translation_of: Web/API/History/length
 
 <h2 id="Compatibilidad_de_Navegadores">Compatibilidad de Navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página es generada desde datos estructurados. Si te gustaría contribuir a los datos, por favor revisa <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una <em>pull request</em>.</div>
+
 
 <p>{{Compat("api.History.length")}}</p>
 

--- a/files/es/web/api/history/pushstate/index.html
+++ b/files/es/web/api/history/pushstate/index.html
@@ -85,7 +85,7 @@ history.pushState(state, title, url)</pre>
 
 <h2 id="Compatibilidad_en_Navegadores">Compatibilidad en Navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta páginas es generada desde datos estructurados. Si te gustaría contribuir a los datos, por favor revisa <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una <em>pull request</em>.</div>
+
 
 <p>{{Compat("api.History.pushState")}}</p>
 

--- a/files/es/web/api/htmlcanvaselement/todataurl/index.html
+++ b/files/es/web/api/htmlcanvaselement/todataurl/index.html
@@ -147,7 +147,7 @@ function quitarColor() {
 
 <h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera de datos estructurados. Si te gustaría contribuir a los datos, por favor revisa <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y haznos una pull request.</div>
+
 
 <p>{{Compat("api.HTMLCanvasElement.toDataURL")}}</p>
 

--- a/files/es/web/api/htmlelement/click/index.html
+++ b/files/es/web/api/htmlelement/click/index.html
@@ -40,8 +40,6 @@ translation_of: Web/API/HTMLElement/click
 
 <h2 id="Compatibilidad_en_navegadores">Compatibilidad en navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. Si desea contribuir a los datos, consulte <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos un pull request.</div>
-
 <p>{{Compat("api.HTMLElement.click")}}</p>
 
 

--- a/files/es/web/api/htmlelement/offsetparent/index.html
+++ b/files/es/web/api/htmlelement/offsetparent/index.html
@@ -47,6 +47,6 @@ translation_of: Web/API/HTMLElement/offsetParent
 
 <h2 id="Compatibility" name="Compatibility">Compatibilidad de Browser</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página es generada desde datos estructurados. Si gusta contribuir a los datos, por favor revise <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos un pull request.</div>
+
 
 <p>{{Compat("api.HTMLElement.offsetParent")}}</p>

--- a/files/es/web/api/htmlheadelement/index.html
+++ b/files/es/web/api/htmlheadelement/index.html
@@ -61,7 +61,7 @@ translation_of: Web/API/HTMLHeadElement
 
 <h2 id="Compatibilidad_con_Navegadores">Compatibilidad con Navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página es generada a partir de datos estructurados. Si desea contribuir con los datos, por favor consulte <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos una solicitud.</div>
+
 
 <p>{{Compat("api.HTMLHeadElement")}}</p>
 

--- a/files/es/web/api/htmllabelelement/index.html
+++ b/files/es/web/api/htmllabelelement/index.html
@@ -68,7 +68,7 @@ translation_of: Web/API/HTMLLabelElement
 <h2 id="Compatibilidad_de_Navegador_Web">Compatibilidad de Navegador Web</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad en esta página es generada por datos estructurados. si ud. desea contribuir a estos datos, por favor ingrese al siguiente link: <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envienos un requerimeinto (pull request)</div>
+
 
 <p>{{Compat("api.HTMLLabelElement")}}</p>
 </div>

--- a/files/es/web/api/htmlmediaelement/index.html
+++ b/files/es/web/api/htmlmediaelement/index.html
@@ -208,7 +208,7 @@ translation_of: Web/API/HTMLMediaElement
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, visite <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos una solicitud de extracción.</div>
+
 
 <p>{{Compat("api.HTMLMediaElement")}}</p>
 

--- a/files/es/web/api/htmlmediaelement/loadeddata_event/index.html
+++ b/files/es/web/api/htmlmediaelement/loadeddata_event/index.html
@@ -93,7 +93,7 @@ video.onloadeddata = (event) =&gt; {
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, consulte <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos una solicitud de extracción.</div>
+
 
 <p>{{Compat("api.HTMLMediaElement.loadeddata_event")}}</p>
 

--- a/files/es/web/api/htmlmediaelement/pause/index.html
+++ b/files/es/web/api/htmlmediaelement/pause/index.html
@@ -47,6 +47,6 @@ translation_of: Web/API/HTMLMediaElement/pause
 
 <h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, consulte <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos un pull request.</div>
+
 
 <p>{{Compat("api.HTMLMediaElement.pause")}}</p>

--- a/files/es/web/api/htmlmediaelement/paused/index.html
+++ b/files/es/web/api/htmlmediaelement/paused/index.html
@@ -45,7 +45,7 @@ console.log(obj.paused); // true
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página es generada a partir de datos estructurados. Si te gustaría contribuir con la información, por favor verifícalo en  <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envianos un pull request.</div>
+
 
 <p>{{Compat("api.HTMLMediaElement.paused")}}</p>
 

--- a/files/es/web/api/htmlmediaelement/play/index.html
+++ b/files/es/web/api/htmlmediaelement/play/index.html
@@ -110,7 +110,7 @@ function handlePlayButton() {
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, consulte <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos un pull request.</div>
+
 
 <p>{{Compat("api.HTMLMediaElement.play")}}</p>
 

--- a/files/es/web/api/htmlselectelement/checkvalidity/index.html
+++ b/files/es/web/api/htmlselectelement/checkvalidity/index.html
@@ -42,8 +42,6 @@ translation_of: Web/API/HTMLSelectElement/checkValidity
 
 <h2 id="Compatibilidad_en_navegadores">Compatibilidad en navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.HTMLSelectElement.checkValidity")}}</p>
 
 <h2 id="Ver también" name="Ver también">Ver también</h2>

--- a/files/es/web/api/htmlselectelement/index.html
+++ b/files/es/web/api/htmlselectelement/index.html
@@ -141,8 +141,6 @@ console.log(select.options[select.selectedIndex].value) // Second
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.HTMLSelectElement")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/es/web/api/htmlselectelement/setcustomvalidity/index.html
+++ b/files/es/web/api/htmlselectelement/setcustomvalidity/index.html
@@ -41,8 +41,6 @@ translation_of: Web/API/HTMLSelectElement/setCustomValidity
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("api.HTMLSelectElement.setCustomValidity")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/es/web/api/imagebitmaprenderingcontext/index.html
+++ b/files/es/web/api/imagebitmaprenderingcontext/index.html
@@ -25,7 +25,7 @@ translation_of: Web/API/ImageBitmapRenderingContext
 <h2 id="Compatibilidad_del_Buscador">Compatibilidad del Buscador</h2>
 
 <div>
-<div class="hidden">La compatibilidad de la tabla en esta página es generada de datos estructurales. Si quiere contribuir en los datos, cheque <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos un "pull request" (requicisión).</div>
+
 
 <p>{{Compat("api.ImageBitmapRenderingContext")}}</p>
 </div>

--- a/files/es/web/api/location/reload/index.html
+++ b/files/es/web/api/location/reload/index.html
@@ -63,7 +63,7 @@ reload.addEventListener('click', _ =&gt; { // el _ es para indicar la ausencia d
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, consulte <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos una solicitud de extracción.</div>
+
 
 <p>{{Compat("api.Location.reload")}}</p>
 

--- a/files/es/web/api/mutationobserver/mutationobserver/index.html
+++ b/files/es/web/api/mutationobserver/mutationobserver/index.html
@@ -93,6 +93,6 @@ observer.observe(targetNode, observerOptions);</pre>
 
 <h2 id="Compatibilidad">Compatibilidad</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página ha sido generada utilizando datos estructurados. Si desea contribuir, compruebe nuestra <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data </a>y envienos una petición de actualizacion</div>
+
 
 <p>{{Compat("api.MutationObserver.MutationObserver")}}</p>

--- a/files/es/web/api/network_information_api/index.html
+++ b/files/es/web/api/network_information_api/index.html
@@ -74,13 +74,13 @@ if (connection) {
 
 <h3 id="NetworkInformation">NetworkInformation</h3>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si usted desea contribuir con datos, por favor acceda a <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos una solicitud de pull.</div>
+
 
 <p>{{Compat("api.NetworkInformation")}}</p>
 
 <h3 id="Navigator.connection">Navigator.connection</h3>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si usted desea contribuir con datos, por favor acceda a <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos una solicitud de pull.</div>
+
 
 <p>{{Compat("api.Navigator.connection")}}</p>
 

--- a/files/es/web/api/nodelist/foreach/index.html
+++ b/files/es/web/api/nodelist/foreach/index.html
@@ -120,7 +120,7 @@ list.forEach(
 
 <h2 id="Compatibilidad_en_Navegadores">Compatibilidad en Navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidades en esta página es generada con datos estructurados. Si quisieras contribuir a los datos, revisa<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>y envíanos una solicitud de pull.</div>
+
 
 <p>{{Compat("api.NodeList.forEach")}}</p>
 

--- a/files/es/web/api/payment_request_api/index.html
+++ b/files/es/web/api/payment_request_api/index.html
@@ -118,7 +118,7 @@ translation_of: Web/API/Payment_Request_API
 <h3 id="Interfaz_PaymentRequest">Interfaz PaymentRequest</h3>
 
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, consulte https://github.com/mdn/browser-compat-data y envíenos un "pull request".</div>
+
 
 <p>{{Compat("api.PaymentRequest", 0)}}</p>
 </div>

--- a/files/es/web/api/response/response/index.html
+++ b/files/es/web/api/response/response/index.html
@@ -62,7 +62,7 @@ var miRespuesta = new Response(miBlob,opciones);</pre>
 
 <h2 id="Compatibilidad_en_navegadores">Compatibilidad en navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página está generada a partir de datos estructurados. Si deseas contribuir a los datos, por favor échale un vistazo a <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos un pull request.</div>
+
 
 <p>{{Compat("api.Response.Response")}}</p>
 

--- a/files/es/web/api/response/status/index.html
+++ b/files/es/web/api/response/status/index.html
@@ -60,7 +60,7 @@ fetch(myRequest).then(function(response) {
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. Si desea contribuir a los datos, consulte <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos una solicitud de extracción.</div>
+
 
 <p>{{Compat("api.Response.status")}}</p>
 

--- a/files/es/web/api/subtlecrypto/digest/index.html
+++ b/files/es/web/api/subtlecrypto/digest/index.html
@@ -119,7 +119,7 @@ console.log(digestHex);
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si desea contribuir a los datos, por favor, revise <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos un pull request.</div>
+
 
 <p>{{Compat("api.SubtleCrypto.digest")}}</p>
 

--- a/files/es/web/api/texttrack/cuechange_event/index.html
+++ b/files/es/web/api/texttrack/cuechange_event/index.html
@@ -98,8 +98,6 @@ textTrackElem.oncuechange = (event) =&gt; {
 
 <h2 id="Compatibilidad_de_los_navegadores">Compatibilidad de los navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página está generada desde datos estructurados. Si quieres contribuir a los datos, por favor visita <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una pull request.</div>
-
 <p>{{Compat("api.TextTrack.cuechange_event")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/api/url/port/index.html
+++ b/files/es/web/api/url/port/index.html
@@ -44,8 +44,6 @@ var result = url.port; // Devuelve:'80'
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, consulte https://github.com/mdn/browser-compat-data y envíenos una solicitud de extracción.</div>
-
 <p>{{Compat("api.URL.port")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/api/url/url/index.html
+++ b/files/es/web/api/url/url/index.html
@@ -88,8 +88,6 @@ var d = new URL('/en-US/docs', b);                     // =
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, consulte https://github.com/mdn/browser-compat-data y envíenos una solicitud de extracción.</div>
-
 <p>{{Compat("api.URL.URL")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/api/urlsearchparams/urlsearchparams/index.html
+++ b/files/es/web/api/urlsearchparams/urlsearchparams/index.html
@@ -72,7 +72,7 @@ var params4 = new URLSearchParams({"foo" : 1 , "bar" : 2});
 <h2 id="Compatibilidad_de_browsers">Compatibilidad de browsers</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad en esta página es generada desde datos estructurados. Si te gustaría contribuir a estos datos, por favor clona el repositorio <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos un pull request.</div>
+
 
 <p>{{Compat("api.URLSearchParams.URLSearchParams")}}</p>
 </div>

--- a/files/es/web/api/web_speech_api/index.html
+++ b/files/es/web/api/web_speech_api/index.html
@@ -106,7 +106,7 @@ translation_of: Web/API/Web_Speech_API
 
 <h3 id="SpeechSynthesis"><code>SpeechSynthesis</code></h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
 
 <p>{{Compat("api.SpeechSynthesis", 0)}}</p>
 

--- a/files/es/web/api/webvtt_api/index.html
+++ b/files/es/web/api/webvtt_api/index.html
@@ -888,7 +888,7 @@ Sur les &lt;i.foreignphrase&gt;&lt;lang en&gt;playground&lt;/lang&gt;&lt;/i&gt;,
 <h3 id="TextTrack_interface"><code>TextTrack</code> interface</h3>
 
 <div>
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
 
 <p>{{Compat("api.TextTrack", 0)}}</p>
 

--- a/files/es/web/api/window/innerheight/index.html
+++ b/files/es/web/api/window/innerheight/index.html
@@ -68,8 +68,6 @@ var alturaViewport = self.innerHeight;
 <p><br>
  <font face="x-locale-heading-primary, zillaslab, Palatino, Palatino Linotype, x-locale-heading-secondary, serif"><span style="font-size: 37.3333px;"><strong>Compatibilidad del navegador</strong></span></font></p>
 
-<p class="hidden"><span class="seoSummary">La compatibilidad de la tabla en esta pagina es generada por la estructura de datos. Si tú gustas contribuir, por favor dirigete a <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envia un pull Request</span></p>
-
 <h2 id="Tambien_me_intersa">Tambien me intersa</h2>
 
 <ul>

--- a/files/es/web/api/xmlhttprequest/timeout/index.html
+++ b/files/es/web/api/xmlhttprequest/timeout/index.html
@@ -62,6 +62,6 @@ xhr.send(null);</pre>
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, consulte <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos un <em>pull request</em>.</div>
+
 
 <p>{{Compat("api.XMLHttpRequest.timeout")}}</p>

--- a/files/es/web/css/@font-face/font-display/index.html
+++ b/files/es/web/css/@font-face/font-display/index.html
@@ -91,6 +91,4 @@ font-display: optional;</pre>
 
 <h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, por favor visite <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una petición de actualización.</div>
-
 <p>{{Compat("css.at-rules.font-face.font-display")}}</p>

--- a/files/es/web/css/_colon_focus-visible/index.html
+++ b/files/es/web/css/_colon_focus-visible/index.html
@@ -116,7 +116,7 @@ custom-button:focus-visible {
 
 <h2 id="Compatibilidad_de_navegador">Compatibilidad de navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si desea contribuir a los datos, por favor, visite <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos una solicitud de extracción.</div>
+
 
 <p>{{Compat("css.selectors.focus-visible")}}</p>
 

--- a/files/es/web/css/_colon_focus-within/index.html
+++ b/files/es/web/css/_colon_focus-within/index.html
@@ -83,7 +83,7 @@ input {
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. ISi deseas contribuir con los datos, consulta https://github.com/mdn/browser-compat-data y envíanos un <em>pull request</em>.</div>
+
 
 <p>{{Compat("css.selectors.focus-within")}}</p>
 

--- a/files/es/web/css/_colon_nth-last-of-type/index.html
+++ b/files/es/web/css/_colon_nth-last-of-type/index.html
@@ -84,7 +84,7 @@ p:nth-last-of-type(4n) {
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página es generada a partir de datos estructurados. Si quieres contribuir a estos datos, por favor mira <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos un pull request.</div>
+
 
 <p>{{Compat("css.selectors.nth-last-of-type")}}</p>
 </div>

--- a/files/es/web/css/_doublecolon_cue/index.html
+++ b/files/es/web/css/_doublecolon_cue/index.html
@@ -101,8 +101,6 @@ translation_of: 'Web/CSS/::cue'
 
 <h2 id="Compatibilidad_con_los_navegadores">Compatibilidad con los navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página está generada desde datos estructurados. Si quieres contribuir a los datos, por favor visita <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una pull request.</div>
-
 <p>{{Compat("css.selectors.cue")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/css/background-position-x/index.html
+++ b/files/es/web/css/background-position-x/index.html
@@ -113,8 +113,6 @@ background-position-x: unset;
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("css.properties.background-position-x")}}</p>
 
 <h2 id="See_also" name="See_also">See also</h2>

--- a/files/es/web/css/background-repeat/index.html
+++ b/files/es/web/css/background-repeat/index.html
@@ -238,7 +238,7 @@ div {
 
 <h2 id="Compatibilidad_en_navegadores">Compatibilidad en navegadores</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta página está generada a partir de datos esrtucturados. Si quieres contribuir a estos datos, por favor revisa <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y mándanos una solicitud.</p>
+
 
 <p>{{Compat("css.properties.background-repeat")}}</p>
 

--- a/files/es/web/css/border-block-color/index.html
+++ b/files/es/web/css/border-block-color/index.html
@@ -74,7 +74,7 @@ border-block-color: #F5F6F7;
 
 <h2 id="Compatibilidad_en_navegadores">Compatibilidad en navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, visite <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos un pull request.</div>
+
 
 <p>{{Compat("css.properties.border-block-color")}}</p>
 

--- a/files/es/web/css/border-right/index.html
+++ b/files/es/web/css/border-right/index.html
@@ -104,6 +104,4 @@ border-right: medium dashed green;
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">Compatibilitidad del navegador</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("css.properties.border-right")}}</p>

--- a/files/es/web/css/border-top-color/index.html
+++ b/files/es/web/css/border-top-color/index.html
@@ -92,7 +92,7 @@ border-top-color: unset;
 
 <h2 id="Compatibilidad_entre_navegadores">Compatibilidad entre navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta pagina es generada desde una estructura de datos. Si usted le gustaria contribuir con los datos, por favor chequee <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envienos la información.</div>
+
 
 <p>{{Compat("css.properties.border-top-color")}}</p>
 

--- a/files/es/web/css/box-shadow/index.html
+++ b/files/es/web/css/box-shadow/index.html
@@ -164,7 +164,7 @@ But still, like air, I'll rise.<span class="tag token"><span class="tag token"><
 
 <h2 id="Compatibilidad_de_los_navegadores">Compatibilidad de los navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página es generada de datos estructurados. Si desea contribuir a esta información, por favor revise <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíe sus pull request.</div>
+
 
 <p>{{Compat("css.properties.box-shadow")}}</p>
 

--- a/files/es/web/css/env()/index.html
+++ b/files/es/web/css/env()/index.html
@@ -19,7 +19,7 @@ translation_of: Web/CSS/env()
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad en esta página es generada a partir de datos estructurados. Si quiere contribuir a estos datos, por favor revisar <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y enviarnos una  pull request.</div>
+
 
 <p>{{Compat("css.properties.custom-property.env")}}</p>
 </div>

--- a/files/es/web/css/grid-auto-columns/index.html
+++ b/files/es/web/css/grid-auto-columns/index.html
@@ -142,7 +142,9 @@ grid-auto-columns: unset;
 
 <h2 id="Compatibilidad_con_Navegadores">Compatibilidad con Navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página se genera de datos estructurados. Si deseas contribuir conn los datos échale un vistazo a <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y solicita descargar el contenido. {{Compat("css.properties.grid-auto-columns")}}</div>
+
+
+{{Compat("css.properties.grid-auto-columns")}}
 
 <h2 id="Vea_también">Vea también</h2>
 

--- a/files/es/web/css/inset-block-end/index.html
+++ b/files/es/web/css/inset-block-end/index.html
@@ -86,8 +86,6 @@ inset-block-end: unset;
 
 <h2 id="Compatibilidad_en_navegadores">Compatibilidad en navegadores</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("css.properties.inset-block-end")}}</p>
 
 <h2 id="Mira_también">Mira también</h2>

--- a/files/es/web/css/inset-block-start/index.html
+++ b/files/es/web/css/inset-block-start/index.html
@@ -86,8 +86,6 @@ inset-block-start: unset;
 
 <h2 id="Compatibilidad_en_navegadores">Compatibilidad en navegadores</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("css.properties.inset-block-start")}}</p>
 
 <h2 id="Mira_también">Mira también</h2>

--- a/files/es/web/css/inset-inline-end/index.html
+++ b/files/es/web/css/inset-inline-end/index.html
@@ -86,8 +86,6 @@ inset-inline-end: unset;
 
 <h2 id="Compatibilidad_en_navegadores">Compatibilidad en navegadores</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("css.properties.inset-inline-end")}}</p>
 
 <h2 id="Mira_también">Mira también</h2>

--- a/files/es/web/css/inset-inline-start/index.html
+++ b/files/es/web/css/inset-inline-start/index.html
@@ -86,8 +86,6 @@ inset-inline-start: unset;
 
 <h2 id="Compatibilidad_en_navegadores">Compatibilidad en navegadores</h2>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
-
 <p>{{Compat("css.properties.inset-inline-start")}}</p>
 
 <h2 id="Mira_también">Mira también</h2>

--- a/files/es/web/css/media_queries/index.html
+++ b/files/es/web/css/media_queries/index.html
@@ -96,7 +96,7 @@ translation_of: Web/CSS/Media_Queries
 
 <h3 id="media_rule">@media rule</h3>
 
-<div class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, visite <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data </a>y envíenos una solicitud de extracción.</div>
+
 
 <p>{{Compat("css.at-rules.media")}}</p>
 

--- a/files/es/web/css/minmax()/index.html
+++ b/files/es/web/css/minmax()/index.html
@@ -140,7 +140,7 @@ minmax(auto, 300px)
 
 <h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página se generó desde datos estructurados. Si quieres contribuir a los datos, por favor revisa <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos un pull request..</div>
+
 
 <p>{{Compat("css.properties.grid-template-columns.minmax")}}</p>
 

--- a/files/es/web/css/position/index.html
+++ b/files/es/web/css/position/index.html
@@ -300,6 +300,6 @@ dd + dd {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">Compatibilidad</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página es generada por una data estructurada. Si deseas contribuir a la data, por favor entra a <a href="https://github.com/mdn/browser-compat-data" rel="noopener">https://github.com/mdn/browser-compat-data</a> y envíanos un pull request.</div>
+
 
 <p>{{Compat("css.properties.position")}}</p>

--- a/files/es/web/css/transition-duration/index.html
+++ b/files/es/web/css/transition-duration/index.html
@@ -325,7 +325,7 @@ var intervalID = window.setInterval(updateTransition, 7000);
 
 <h2 id="Compatibilidad_con_Navegadores">Compatibilidad con Navegadores</h2>
 
-<div class="hidden">La compatibilidad de la tabla se genera a partir de datos estructurados. Si usted quiere contribuir con estos datos, por favor va a <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos un pull request.</div>
+
 
 <p>{{Compat("css.properties.transition-duration")}}</p>
 

--- a/files/es/web/css/widows/index.html
+++ b/files/es/web/css/widows/index.html
@@ -100,7 +100,7 @@ p:first-child {
 <h2 id="Compatibilidad_entre_navegadores">Compatibilidad entre navegadores</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad en esta pagina esta generada desde una estrutura de datos. Si usted puede contribuir con los datos, por favor verifique aqui <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envie una solicitud de extracción. </div>
+
 
 <p>{{Compat("css.properties.widows")}}</p>
 </div>

--- a/files/es/web/html/attributes/accept/index.html
+++ b/files/es/web/html/attributes/accept/index.html
@@ -158,7 +158,7 @@ original_slug: Web/HTML/Atributos/accept
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("html.elements.attribute.accept")}}</p>
 

--- a/files/es/web/html/attributes/min/index.html
+++ b/files/es/web/html/attributes/min/index.html
@@ -117,7 +117,7 @@ original_slug: Web/HTML/Atributos/min
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("html.elements.attributes.min")}}</p>
 

--- a/files/es/web/html/attributes/minlength/index.html
+++ b/files/es/web/html/attributes/minlength/index.html
@@ -58,7 +58,7 @@ input:invalid:focus {
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("html.elements.attribute.minlength")}}</p>
 

--- a/files/es/web/html/element/body/index.html
+++ b/files/es/web/html/element/body/index.html
@@ -159,7 +159,7 @@ original_slug: Web/HTML/Elemento/body
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data"> https://github.com/mdn/browser-compat- datos </a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("html.elements.body")}}</p>
 

--- a/files/es/web/html/element/button/index.html
+++ b/files/es/web/html/element/button/index.html
@@ -179,7 +179,7 @@ original_slug: Web/HTML/Elemento/button
 
 <h2 id="Soporte" name="Soporte">Soporte</h2>
 
-<div class="hidden">La tabla de compatibilidad se genera automáticamente con datos estructurados. Si te gustaría colaborar puedes encontrar más información por <a href="https://github.com/mdn/browser-compat-data">acá y enviarnos un pull request</a>.</div>
+
 
 <p>{{Compat("html.elements.button")}}</p>
 

--- a/files/es/web/html/element/datalist/index.html
+++ b/files/es/web/html/element/datalist/index.html
@@ -88,7 +88,7 @@ original_slug: Web/HTML/Elemento/datalist
 
 <h2 id="Compatibilidad_con_los_distintos_navegadoresEdit">Compatibilidad con los distintos navegadores<a class="button section-edit only-icon" href="https://developer.mozilla.org/es/docs/Web/HTML/Elemento/option$edit#Compatibilidad_con_los_distintos_navegadores" rel="nofollow, noindex"><span>Edit</span></a></h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, visite https://github.com/mdn/browser-compat-data y envíenos una solicitud de extracción.</div>
+
 
 <p>{{Compat("html.elements.datalist")}}</p>
 

--- a/files/es/web/html/element/dd/index.html
+++ b/files/es/web/html/element/dd/index.html
@@ -100,7 +100,7 @@ original_slug: Web/HTML/Elemento/dd
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página es generada desde datos estructurados. Si desea contribuir, por favor revise <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíe una solicitud de extracción (pull request).</div>
+
 
 <p>{{Compat("html.elements.dd")}}</p>
 

--- a/files/es/web/html/element/dl/index.html
+++ b/files/es/web/html/element/dl/index.html
@@ -208,7 +208,7 @@ original_slug: Web/HTML/Elemento/dl
 
 <h2 id="Compatibilidad_Web">Compatibilidad Web</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página es generada con datos estructurados. Si desea contribuir a la información, por favor revise <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envie una petición de extración (pull request).</div>
+
 
 <p>{{Compat("html.elements.dl")}}</p>
 

--- a/files/es/web/html/element/dt/index.html
+++ b/files/es/web/html/element/dt/index.html
@@ -93,7 +93,7 @@ original_slug: Web/HTML/Elemento/dt
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatiblidad es esta página es generada desde estructuras de datos. Si desea contribuir a la información, por favor revise <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíe su petición de extracción (pull request).</div>
+
 
 <p>{{Compat("html.elements.dt")}}</p>
 

--- a/files/es/web/html/element/input/email/index.html
+++ b/files/es/web/html/element/input/email/index.html
@@ -397,7 +397,7 @@ label::after {
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a class="external" href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("html.elements.input.input-email")}}</p>
 

--- a/files/es/web/html/element/input/text/index.html
+++ b/files/es/web/html/element/input/text/index.html
@@ -458,7 +458,7 @@ input:valid+span:after {
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("html.elements.input.input-text")}}</p>
 

--- a/files/es/web/html/element/nav/index.html
+++ b/files/es/web/html/element/nav/index.html
@@ -96,7 +96,7 @@ original_slug: Web/HTML/Elemento/nav
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, visite <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos una solicitud de extracción.</div>
+
 
 <p>{{Compat("html.elements.nav")}}</p>
 

--- a/files/es/web/html/element/q/index.html
+++ b/files/es/web/html/element/q/index.html
@@ -110,7 +110,7 @@ original_slug: Web/HTML/Elemento/q
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{ Compat("html.elements.q") }}</p>
 

--- a/files/es/web/html/element/source/index.html
+++ b/files/es/web/html/element/source/index.html
@@ -115,7 +115,7 @@ original_slug: Web/HTML/Elemento/source
 
 <h2 id="Compaibilidad_entre_navegadores">Compaibilidad entre navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, consulte <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos una solicitud de pull.</div>
+
 
 <p>{{Compat("html.elements.source")}}</p>
 

--- a/files/es/web/html/element/time/index.html
+++ b/files/es/web/html/element/time/index.html
@@ -160,7 +160,7 @@ original_slug: Web/HTML/Elemento/time
 
 <h2 id="Compatibilidad_de_los_navegadores">Compatibilidad de los navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página es generada con información estructurada. Si desea contribuir, por favor revise <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíe su pull request.</div>
+
 
 <p>{{Compat("html.elements.time")}}</p>
 

--- a/files/es/web/html/element/track/index.html
+++ b/files/es/web/html/element/track/index.html
@@ -168,8 +168,6 @@ original_slug: Web/HTML/Elemento/track
 
 <h2 id="Compatibilidad_con_los_navegadores">Compatibilidad con los navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página está generada desde datos estructurados. Si quieres contribuir a los datos, por favor visita <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una pull request.</div>
-
 <p>{{Compat("html.elements.track")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/html/global_attributes/autocapitalize/index.html
+++ b/files/es/web/html/global_attributes/autocapitalize/index.html
@@ -46,6 +46,6 @@ original_slug: Web/HTML/Atributos_Globales/autocapitalize
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("html.global_attributes.autocapitalize")}}</p>

--- a/files/es/web/html/global_attributes/index.html
+++ b/files/es/web/html/global_attributes/index.html
@@ -189,7 +189,7 @@ original_slug: Web/HTML/Atributos_Globales
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("html.global_attributes")}}</p>
 

--- a/files/es/web/html/global_attributes/is/index.html
+++ b/files/es/web/html/global_attributes/is/index.html
@@ -55,7 +55,7 @@ customElements.define('word-count', WordCount, { extends: 'p' });</pre>
 
 <h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página es generada desde datos estructurados. Si desea contribuir a estos datos, por favor clone el repositorio <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos un pull request.</div>
+
 
 <p>{{Compat("html.global_attributes.is")}}</p>
 

--- a/files/es/web/html/global_attributes/slot/index.html
+++ b/files/es/web/html/global_attributes/slot/index.html
@@ -36,7 +36,7 @@ original_slug: Web/HTML/Atributos_Globales/slot
 
 <h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página es generada a partir de datos estructurados. Si le gustaría contribuir con estos datos, por favor clone el repositorio <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos un pull request.</div>
+
 
 <p>{{Compat("html.global_attributes.slot")}}</p>
 

--- a/files/es/web/http/csp/index.html
+++ b/files/es/web/http/csp/index.html
@@ -174,7 +174,7 @@ translation_of: Web/HTTP/CSP
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<p class="hidden"><span class="tlid-translation translation"><span title="">La tabla de compatibilidad en esta página se genera a partir de datos estructurados.</span> <span title="">Si desea contribuir con los datos, visite </span></span> <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a><span class="tlid-translation translation"><span title=""> y envíenos una solicitud de extracción.</span></span></p>
+
 
 <p>{{Compat("http.headers.csp")}}</p>
 

--- a/files/es/web/http/headers/accept-charset/index.html
+++ b/files/es/web/http/headers/accept-charset/index.html
@@ -72,7 +72,7 @@ Accept-Charset: utf-8, iso-8859-1;q=0.5, *;q=0.1
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<p class="hidden">La compatibilidad de la tabla en esta página es generada de una data estructurada. Si quieres contribuir con la Data, por favor revisa: <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos tu solicitud.</p>
+
 
 <p>{{Compat("http.headers.Accept-Charset")}}</p>
 

--- a/files/es/web/http/headers/accept-ranges/index.html
+++ b/files/es/web/http/headers/accept-ranges/index.html
@@ -58,8 +58,6 @@ Accept-Ranges: none</pre>
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http/headers/accept-ranges")}}</p>
 
 <h2 id="Vea_también">Vea también</h2>

--- a/files/es/web/http/headers/accept/index.html
+++ b/files/es/web/http/headers/accept/index.html
@@ -86,7 +86,7 @@ Accept: text/html, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8
 
 <h2 id="Compatibilidad_con_Navegadores">Compatibilidad con Navegadores</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta página es generada desde datos estructurados. Si quieres contribuir con los datos, por favor visita <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envía un pull request.</p>
+
 
 <p>{{Compat("http.headers.Accept")}}</p>
 

--- a/files/es/web/http/headers/access-control-allow-credentials/index.html
+++ b/files/es/web/http/headers/access-control-allow-credentials/index.html
@@ -87,8 +87,6 @@ xhr.send(null);</pre>
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Access-Control-Allow-Credentials")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/http/headers/access-control-allow-headers/index.html
+++ b/files/es/web/http/headers/access-control-allow-headers/index.html
@@ -66,8 +66,6 @@ translation_of: Web/HTTP/Headers/Access-Control-Allow-Headers
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Access-Control-Allow-Headers")}}</p>
 
 <h2 id="Notas_de_compatibilidad">Notas de compatibilidad</h2>

--- a/files/es/web/http/headers/access-control-allow-methods/index.html
+++ b/files/es/web/http/headers/access-control-allow-methods/index.html
@@ -55,8 +55,6 @@ translation_of: Web/HTTP/Headers/Access-Control-Allow-Methods
 
 <h2 id="Compatibilidad_de_navegador">Compatibilidad de navegador</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Access-Control-Allow-Methods")}}</p>
 
 <h2 id="Notas_de_compatibilidad">Notas de compatibilidad</h2>

--- a/files/es/web/http/headers/access-control-allow-origin/index.html
+++ b/files/es/web/http/headers/access-control-allow-origin/index.html
@@ -86,7 +86,7 @@ Vary: Origin</pre>
 
 <h2 id="Compatibilidad_del_Navegador">Compatibilidad del Navegador</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta página es generada a partir de datos estructurados. Si deseas contribuir a los datos, por favor mira <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y mándanos un pull request.</p>
+
 
 <p>{{Compat("http.headers.Access-Control-Allow-Origin")}}</p>
 

--- a/files/es/web/http/headers/access-control-expose-headers/index.html
+++ b/files/es/web/http/headers/access-control-expose-headers/index.html
@@ -91,8 +91,6 @@ Access-Control-Expose-Headers: *</pre>
 
 <h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Access-Control-Expose-Headers")}}</p>
 
 <h2 id="Notas_de_compatibilidad">Notas de compatibilidad</h2>

--- a/files/es/web/http/headers/age/index.html
+++ b/files/es/web/http/headers/age/index.html
@@ -63,8 +63,6 @@ translation_of: Web/HTTP/Headers/Age
 
 <h2 id="Compatibilidad_de_Navegadores">Compatibilidad de Navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Age")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/http/headers/cache-control/index.html
+++ b/files/es/web/http/headers/cache-control/index.html
@@ -226,7 +226,7 @@ Cache-Control: no-cache, max-age=0, stale-while-revalidate=300
 
 <h2 id="Compatibilidad_de_los_navegadores">Compatibilidad de los navegadores</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, visite <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos una solicitud de extracción.</p>
+
 
 <p>{{Compat("http.headers.Cache-Control")}}</p>
 

--- a/files/es/web/http/headers/content-disposition/index.html
+++ b/files/es/web/http/headers/content-disposition/index.html
@@ -123,7 +123,7 @@ valor2
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta página es generada a partir de datos estructurados. Si te gustaría contribuir, por favor revisa <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos un pull request.</p>
+
 
 <p>{{Compat("http.headers.Content-Disposition")}}</p>
 

--- a/files/es/web/http/headers/content-encoding/index.html
+++ b/files/es/web/http/headers/content-encoding/index.html
@@ -85,7 +85,7 @@ Content-Encoding: br
 
 <h2 id="Compatibilidad_con_los_navegadores">Compatibilidad con los navegadores</h2>
 
-<p class="hidden">La tabla de compatibilidad de esta página es generada a partir de una estructura de datos. Si quieres contribuir a estos datos, por favor, lee  <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos un pull request.</p>
+
 
 <p>{{Compat("http/headers/content-encoding")}}</p>
 

--- a/files/es/web/http/headers/content-length/index.html
+++ b/files/es/web/http/headers/content-length/index.html
@@ -49,7 +49,7 @@ translation_of: Web/HTTP/Headers/Content-Length
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<p class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, visite <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos una solicitud de extracción.</p>
+
 
 <p>{{Compat("http.headers.Content-Length")}}</p>
 

--- a/files/es/web/http/headers/content-location/index.html
+++ b/files/es/web/http/headers/content-location/index.html
@@ -145,8 +145,6 @@ Content-Location: /mis-recibos/38
 
 <h2 id="Compatibilidad_en_navegadores">Compatibilidad en navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Content-Location")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/http/headers/content-security-policy/index.html
+++ b/files/es/web/http/headers/content-security-policy/index.html
@@ -237,8 +237,6 @@ Content-Security-Policy: default-src https:
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.headers.csp.Content-Security-Policy")}}</p>
 
 <h2 id="Mirar_tambien">Mirar tambien</h2>

--- a/files/es/web/http/headers/content-type/index.html
+++ b/files/es/web/http/headers/content-type/index.html
@@ -97,7 +97,7 @@ Content-Type: text/plain
 
 <h2 id="Compatibilidad_de_navegador">Compatibilidad de navegador</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta pagina es generada desde datos estructurados Si quieres contribuir con el dato, por favor ingresa a <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envianos un <strong>pull request</strong>.</p>
+
 
 <p>{{Compat("http.headers.Content-Type")}}</p>
 

--- a/files/es/web/http/headers/cookie/index.html
+++ b/files/es/web/http/headers/cookie/index.html
@@ -62,7 +62,7 @@ Cookie: nombre=valor; nombre2=valor2...nombreN=valorN;</pre>
 
 <h2 id="Compatibilidad_en_navegadores">Compatibilidad en navegadores</h2>
 
-<p class="hidden">La tabla de compatibilidad en este sitio es generada desde datos estructurada. Si quieres contribuir con estos datos, por favor visita <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envianos una solicitud pull.</p>
+
 
 <p>{{Compat("http.headers.Cookie")}}</p>
 

--- a/files/es/web/http/headers/digest/index.html
+++ b/files/es/web/http/headers/digest/index.html
@@ -127,7 +127,7 @@ console.log(digestHex);
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si desea contribuir a los datos, por favor, revise <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos un pull request.</div>
+
 
 <p>{{Compat("api.SubtleCrypto.digest")}}</p>
 

--- a/files/es/web/http/headers/etag/index.html
+++ b/files/es/web/http/headers/etag/index.html
@@ -81,8 +81,6 @@ ETag: W/"0815"</pre>
 
 <h2 id="Compatibilidad_con_Navegadores">Compatibilidad con Navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.headers.ETag")}}</p>
 
 <h2 id="Vea_también">Vea también</h2>

--- a/files/es/web/http/headers/expires/index.html
+++ b/files/es/web/http/headers/expires/index.html
@@ -69,8 +69,6 @@ translation_of: Web/HTTP/Headers/Expires
 
 <h2 id="Compatibilidad_en_Navegadores">Compatibilidad en Navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Expires")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/http/headers/host/index.html
+++ b/files/es/web/http/headers/host/index.html
@@ -63,8 +63,6 @@ translation_of: Web/HTTP/Headers/Host
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Host")}}</p>
 
 <h2 id="Véase_también">Véase también</h2>

--- a/files/es/web/http/headers/keep-alive/index.html
+++ b/files/es/web/http/headers/keep-alive/index.html
@@ -81,8 +81,6 @@ Server: Apache
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Keep-Alive")}}</p>
 
 <h2 id="Mirar_tambien">Mirar tambien</h2>

--- a/files/es/web/http/headers/link/index.html
+++ b/files/es/web/http/headers/link/index.html
@@ -68,7 +68,7 @@ translation_of: Web/HTTP/Headers/Link
 
 <h2 id="Compatibilidad_del_navegador"><span class="tlid-translation translation" lang="es"><span title="">Compatibilidad del navegador</span></span></h2>
 
-<div class="hidden"><span class="tlid-translation translation" lang="es"><span title="">La tabla de compatibilidad en esta página se genera a partir de datos estructurados.</span> <span title="">Si desea contribuir con los datos, consulte </span></span> <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> <span class="tlid-translation translation" lang="es"><span title="">y envíanos un</span></span> pull request.</div>
+
 
 <p>{{Compat("http.headers.Link")}}</p>
 

--- a/files/es/web/http/headers/origin/index.html
+++ b/files/es/web/http/headers/origin/index.html
@@ -70,7 +70,7 @@ Origin: &lt;esquema&gt; "://" &lt;nombre de host&gt; [ ":" &lt;puerto&gt; ]
 
 <h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta página es generada a partir de datos estructurados. Si quieres contribuir, por favor revisa<a href="https://github.com/mdn/browser-compat-data"> https://github.com/mdn/browser-compat-data</a> y mándanos un pull request.</p>
+
 
 <p>{{Compat("http.headers.Origin")}}</p>
 

--- a/files/es/web/http/headers/pragma/index.html
+++ b/files/es/web/http/headers/pragma/index.html
@@ -63,8 +63,6 @@ translation_of: Web/HTTP/Headers/Pragma
 
 <h2 id="Compatibilidad_de_navegadores"><font><font>Compatibilidad de navegadores</font></font></h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Pragma")}}</p>
 
 <h2 id="Véase_también"><font><font>Véase también</font></font></h2>

--- a/files/es/web/http/headers/referer/index.html
+++ b/files/es/web/http/headers/referer/index.html
@@ -72,8 +72,6 @@ translation_of: Web/HTTP/Headers/Referer
 
 <h2 id="Compatibilidad_entre_navegadores">Compatibilidad entre navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Referer")}}</p>
 
 <h2 id="Véase_también">Véase también</h2>

--- a/files/es/web/http/headers/referrer-policy/index.html
+++ b/files/es/web/http/headers/referrer-policy/index.html
@@ -196,8 +196,6 @@ Referrer-Policy: unsafe-url
 
 <h2 id="Compatibilidad_entre_navegadores">Compatibilidad entre navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Referrer-Policy")}}</p>
 
 <div class="note">

--- a/files/es/web/http/headers/server/index.html
+++ b/files/es/web/http/headers/server/index.html
@@ -55,7 +55,7 @@ translation_of: Web/HTTP/Headers/Server
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<p class="hidden">La tabla de compatibilidad es generada a partir de datos estructurados. Si quisieras contribuir dirígete a <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos un pull request.</p>
+
 
 <p>{{Compat("http.headers.Server")}}</p>
 

--- a/files/es/web/http/headers/set-cookie/index.html
+++ b/files/es/web/http/headers/set-cookie/index.html
@@ -198,8 +198,6 @@ Set-Cookie: __Host-id=1; Secure; Path=/; domain=example.com
 
 <h2 id="Compatibilidad_de_los_navegadores">Compatibilidad de los navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Set-Cookie", 5)}}</p>
 
 <h2 id="Notas_de_compatibilidad">Notas de compatibilidad</h2>

--- a/files/es/web/http/headers/strict-transport-security/index.html
+++ b/files/es/web/http/headers/strict-transport-security/index.html
@@ -98,8 +98,6 @@ Strict-Transport-Security: max-age=&lt;expire-time&gt;; preload
 
 <h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http/headers/strict-transport-security")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/http/headers/transfer-encoding/index.html
+++ b/files/es/web/http/headers/transfer-encoding/index.html
@@ -100,8 +100,6 @@ Network\r\n
 
 <h2 id="Compatibilidad_con_el_Navegador">Compatibilidad con el Navegador</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Transfer-Encoding")}}</p>
 
 <h2 id="Ver_además">Ver además:</h2>

--- a/files/es/web/http/headers/user-agent/index.html
+++ b/files/es/web/http/headers/user-agent/index.html
@@ -125,7 +125,7 @@ Mozilla/5.0 (Macintosh; Intel Mac OS X <em>x.y</em>; rv:42.0) Gecko/20100101 F
 
 <h2 id="Compatibilidad_entre_navegadores">Compatibilidad entre navegadores</h2>
 
-<p class="hidden">La tabla de compatibilidad mostrada en esta página es genereada de información estructurada. Si gusta contribuir con esta información entra a <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data y </a>y envienos una solicitud</p>
+
 
 <p>{{Compat("http.headers.User-Agent")}}</p>
 

--- a/files/es/web/http/headers/vary/index.html
+++ b/files/es/web/http/headers/vary/index.html
@@ -62,8 +62,6 @@ Vary: &lt;header-name&gt;, &lt;header-name&gt;, ...
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.headers.Vary")}}</p>
 
 <h2 id="Notas_de_Compatibilidad">Notas de Compatibilidad</h2>

--- a/files/es/web/http/headers/x-content-type-options/index.html
+++ b/files/es/web/http/headers/x-content-type-options/index.html
@@ -67,8 +67,6 @@ translation_of: Web/HTTP/Headers/X-Content-Type-Options
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.headers.X-Content-Type-Options")}}</p>
 
 <h2 id="Vea_también">Vea también</h2>

--- a/files/es/web/http/headers/x-frame-options/index.html
+++ b/files/es/web/http/headers/x-frame-options/index.html
@@ -114,7 +114,7 @@ X-Frame-Options: ALLOW-FROM https://example.com/
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta página es generada a partir de data estructurada. Si desea contribuir a la data, favor ingrese a <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos un pull request.</p>
+
 
 <p>{{Compat("http.headers.X-Frame-Options")}}</p>
 

--- a/files/es/web/http/headers/x-xss-protection/index.html
+++ b/files/es/web/http/headers/x-xss-protection/index.html
@@ -71,8 +71,6 @@ X-XSS-Protection: 1; report=&lt;reporting-uri&gt;
 
 <h2 id="Compatibilidad_de_los_navegadores">Compatibilidad de los navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.headers.X-XSS-Protection")}}</p>
 
 <h2 id="Vea_también">Vea también</h2>

--- a/files/es/web/http/methods/connect/index.html
+++ b/files/es/web/http/methods/connect/index.html
@@ -73,8 +73,6 @@ Proxy-Authorization: basic aGVsbG86d29ybGQ=</pre>
 
 <h2 id="Compatibilidad_entre_navegadores">Compatibilidad entre navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.methods.CONNECT")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/http/methods/get/index.html
+++ b/files/es/web/http/methods/get/index.html
@@ -58,7 +58,7 @@ translation_of: Web/HTTP/Methods/GET
 
 <h2 id="Compatibilidad_con_Navegadores">Compatibilidad con Navegadores</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, consulte <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos una solicitud.</p>
+
 
 <p>{{Compat("http.methods.GET")}}</p>
 

--- a/files/es/web/http/methods/index.html
+++ b/files/es/web/http/methods/index.html
@@ -58,7 +58,7 @@ translation_of: Web/HTTP/Methods
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta página es generada a partir de datos estructurados. Si desea contribuir con estos datos de compatibilidad, por favor escriba una solicitud de extracción a través de la siguiente dirección: <a href="https://github.com/mdn/browser-compat-data/blob/master/http/methods.json">https://github.com/mdn/browser-compat-data/blob/master/http/methods.json</a>.</p>
+
 
 <p>{{Compat("http/methods")}}</p>
 

--- a/files/es/web/http/methods/post/index.html
+++ b/files/es/web/http/methods/post/index.html
@@ -112,8 +112,6 @@ value2</pre>
 
 <h2 id="Navegadores_compatibles">Navegadores compatibles</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.methods.POST")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/http/methods/put/index.html
+++ b/files/es/web/http/methods/put/index.html
@@ -88,8 +88,6 @@ Content-Location: /existente.html
 
 <h2 id="Navegadores_compatibles">Navegadores compatibles</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.methods.PUT")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/http/methods/trace/index.html
+++ b/files/es/web/http/methods/trace/index.html
@@ -62,8 +62,6 @@ translation_of: Web/HTTP/Methods/TRACE
 
 <h2 id="Compatibilidad_con_Buscadores">Compatibilidad con Buscadores </h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.methods.TRACE")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/http/status/100/index.html
+++ b/files/es/web/http/status/100/index.html
@@ -35,8 +35,6 @@ translation_of: Web/HTTP/Status/100
 
 <h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.status.100")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/http/status/200/index.html
+++ b/files/es/web/http/status/200/index.html
@@ -43,7 +43,7 @@ translation_of: Web/HTTP/Status/200
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<p class="hidden">La tabla de compatibilidades en esta página se genera desde datos estructurados. Si quiere contribuir a con datos, porfavor vaya a <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos una pull request.</p>
+
 
 <p>{{Compat("http.status.200")}}</p>
 

--- a/files/es/web/http/status/201/index.html
+++ b/files/es/web/http/status/201/index.html
@@ -30,7 +30,7 @@ translation_of: Web/HTTP/Status/201
 
 <h2 id="Compatibilidad_entre_navegadores"><font><font>Compatibilidad entre navegadores</font></font></h2>
 
-<p class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, visite https://github.com/mdn/browser-compat-data y envíenos una solicitud de extracción.</p>
+
 
 <p>{{Compat("http.status.201")}}</p>
 

--- a/files/es/web/http/status/206/index.html
+++ b/files/es/web/http/status/206/index.html
@@ -65,8 +65,6 @@ Content-Range: bytes 4590-7999/8000
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.status.206")}}</p>
 
 <h2 id="Mira_también">Mira también</h2>

--- a/files/es/web/http/status/302/index.html
+++ b/files/es/web/http/status/302/index.html
@@ -37,8 +37,6 @@ translation_of: Web/HTTP/Status/302
 
 <h2 id="Compatibilidad_navegadores">Compatibilidad navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.status.302")}}</p>
 
 <h2 id="Mira_también">Mira también</h2>

--- a/files/es/web/http/status/304/index.html
+++ b/files/es/web/http/status/304/index.html
@@ -38,8 +38,6 @@ translation_of: Web/HTTP/Status/304
 
 <h2 id="Compatibilidad_en_navegadores">Compatibilidad en navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.status.304")}}</p>
 
 <h2 id="Notas_de_compatibilidad">Notas de compatibilidad</h2>

--- a/files/es/web/http/status/401/index.html
+++ b/files/es/web/http/status/401/index.html
@@ -38,7 +38,7 @@ WWW-Authenticate: Basic realm="Access to staging site"</pre>
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<p class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si usted desea contribuir con los datos, consulte: <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envienos una Pull Request.</p>
+
 
 <p>{{Compat("http.status.401")}}</p>
 

--- a/files/es/web/http/status/403/index.html
+++ b/files/es/web/http/status/403/index.html
@@ -38,7 +38,7 @@ Date: Wed, 21 Oct 2015 07:28:00 GMT
 
 <h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, consulte https://github.com/mdn/browser-compat-data y envíanos una Pull Request.</p>
+
 
 <p>{{Compat("http.status.403")}}</p>
 

--- a/files/es/web/http/status/404/index.html
+++ b/files/es/web/http/status/404/index.html
@@ -50,8 +50,6 @@ translation_of: Web/HTTP/Status/404
 
 <h2 id="Compatibilidad_con_Navegadores">Compatibilidad con Navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.status.404")}}</p>
 
 <h2 id="Vea_también">Vea también</h2>

--- a/files/es/web/http/status/418/index.html
+++ b/files/es/web/http/status/418/index.html
@@ -33,7 +33,7 @@ translation_of: Web/HTTP/Status/418
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<p class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, por favor, eche un vistazo a <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos un pull request.</p>
+
 
 <p>{{Compat("http.status.418")}}</p>
 

--- a/files/es/web/http/status/500/index.html
+++ b/files/es/web/http/status/500/index.html
@@ -34,6 +34,6 @@ translation_of: Web/HTTP/Status/500
 
 <p><span class="tlid-translation translation"><span title="">La información que se muestra a continuación se ha extraído del MDN de GitHub.</span></span> (<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).</p>
 
-<p class="hidden"><span class="tlid-translation translation"><span title="">La tabla de compatibilidad en esta página se genera a partir de datos estructurados.</span> <span title="">Si desea contribuir a los datos, por favor revise</span></span> <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> <span class="tlid-translation translation"><span title="">y envíenos una solicitud pull.</span></span></p>
+
 
 <p>{{Compat("http.status.500")}}</p>

--- a/files/es/web/http/status/502/index.html
+++ b/files/es/web/http/status/502/index.html
@@ -36,8 +36,6 @@ translation_of: Web/HTTP/Status/502
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.status.502")}}</p>
 
 <h2 id="Vea_también">Vea también</h2>

--- a/files/es/web/http/status/503/index.html
+++ b/files/es/web/http/status/503/index.html
@@ -43,7 +43,7 @@ translation_of: Web/HTTP/Status/503
 
 <p>La información mostrada abajo ha sido obtenida desde el GitHub de MDN (<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).</p>
 
-<p class="hidden">La tabla de compatibilidad en esta página es generada desde datos estructurados. Si quieres contribuir a estos datos, por favor consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</p>
+
 
 <p>{{Compat("http.status.503")}}</p>
 

--- a/files/es/web/http/status/504/index.html
+++ b/files/es/web/http/status/504/index.html
@@ -36,8 +36,6 @@ translation_of: Web/HTTP/Status/504
 
 <p>La información que se muestra a continuación fue extraída de la de cuenta de Github de MDN (<a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>).</p>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("http.status.504")}}</p>
 
 <h2 id="Vea_también">Vea también</h2>

--- a/files/es/web/javascript/guide/regular_expressions/index.html
+++ b/files/es/web/javascript/guide/regular_expressions/index.html
@@ -442,7 +442,7 @@ function testInfo(phoneInput) {
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.builtins.RegExp")}}</p>
 </div>

--- a/files/es/web/javascript/reference/classes/public_class_fields/index.html
+++ b/files/es/web/javascript/reference/classes/public_class_fields/index.html
@@ -376,7 +376,7 @@ new ClassWithPrivateAccessor();
 
 <h3 id="Campos_privados_de_clase">Campos privados de clase</h3>
 
-<div class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</div>
+
 
 <p>{{Compat("javascript.classes.private_class_fields")}}</p>
 

--- a/files/es/web/javascript/reference/functions/arguments/index.html
+++ b/files/es/web/javascript/reference/functions/arguments/index.html
@@ -218,7 +218,7 @@ func(); // undefined</pre>
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.functions.arguments")}}</p>
 

--- a/files/es/web/javascript/reference/functions/arrow_functions/index.html
+++ b/files/es/web/javascript/reference/functions/arrow_functions/index.html
@@ -519,7 +519,7 @@ setTimeout( () =&gt; {
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.functions.arrow_functions")}}</p>
 </div>

--- a/files/es/web/javascript/reference/functions/default_parameters/index.html
+++ b/files/es/web/javascript/reference/functions/default_parameters/index.html
@@ -223,7 +223,7 @@ f()  // 6</pre>
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.functions.default_parameters")}}</p>
 </div>

--- a/files/es/web/javascript/reference/global_objects/aggregateerror/index.html
+++ b/files/es/web/javascript/reference/global_objects/aggregateerror/index.html
@@ -76,7 +76,7 @@ original_slug: Web/JavaScript/Referencia/Objetos_globales/AggregateError
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.builtins.AggregateError")}}</p>
 </div>

--- a/files/es/web/javascript/reference/global_objects/array/index.html
+++ b/files/es/web/javascript/reference/global_objects/array/index.html
@@ -433,7 +433,7 @@ console.table(valores)</pre>
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página es generada desde datos estructurados. Si te gustaría contribuir a los datos, por favor visite <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envianos una solicitud de extracción(pull request).</div>
+
 
 <p>{{Compat("javascript.builtins.Array")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/boolean/boolean/index.html
+++ b/files/es/web/javascript/reference/global_objects/boolean/boolean/index.html
@@ -64,7 +64,7 @@ var bObjProto = new Boolean({});</pre>
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.builtins.Boolean.Boolean")}}</p>
 </div>

--- a/files/es/web/javascript/reference/global_objects/boolean/index.html
+++ b/files/es/web/javascript/reference/global_objects/boolean/index.html
@@ -113,7 +113,7 @@ var bObjProto = new Boolean({});
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.builtins.Boolean")}}</p>
 </div>

--- a/files/es/web/javascript/reference/global_objects/date/getseconds/index.html
+++ b/files/es/web/javascript/reference/global_objects/date/getseconds/index.html
@@ -72,8 +72,6 @@ console.log(seconds); // 30
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("javascript.builtins.Date.getSeconds")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/es/web/javascript/reference/global_objects/date/setmonth/index.html
+++ b/files/es/web/javascript/reference/global_objects/date/setmonth/index.html
@@ -67,7 +67,7 @@ console.log(endOfMonth); //Wed Mar 02 2016 00:00:00
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, consulte <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos una solicitud de extracción.</p>
+
 
 <p>{{Compat("javascript.builtins.Date.setMonth")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/date/todatestring/index.html
+++ b/files/es/web/javascript/reference/global_objects/date/todatestring/index.html
@@ -76,7 +76,7 @@ console.log(d.toDateString()); // logs Wed Jun 28 1993
 
 <h2 id="Compatibilidad_entre_navegadores">Compatibilidad entre navegadores</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta página es generada a partir de datos estructurados. Si quisieras contrubuir con esos datos, por favor revisa <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y genera un pull request.</p>
+
 
 <p>{{Compat("javascript.builtins.Date.toDateString")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/date/tojson/index.html
+++ b/files/es/web/javascript/reference/global_objects/date/tojson/index.html
@@ -49,7 +49,7 @@ console.log(jsonDate); //2015-10-26T07:46:36.611Z
 
 <h2 id="Compatibilidad_en_buscadores">Compatibilidad en buscadores</h2>
 
-<p class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, consulte <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envienos un pull request.</p>
+
 
 <p>{{Compat("javascript.builtins.Date.toJSON")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/date/tolocaledatestring/index.html
+++ b/files/es/web/javascript/reference/global_objects/date/tolocaledatestring/index.html
@@ -146,7 +146,7 @@ console.log(date.toLocaleDateString('en-US', options));
 
 <h2 id="Compatibilidad_con_el_navegador">Compatibilidad con el navegador</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta página es generada desde una estructura de datos. Si usted desea contribuir a los datos, por favor compruebe <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos una solicitud de extracción (pull request).</p>
+
 
 <p>{{Compat("javascript.builtins.Date.toLocaleDateString")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/date/tolocalestring/index.html
+++ b/files/es/web/javascript/reference/global_objects/date/tolocalestring/index.html
@@ -150,8 +150,6 @@ console.log(date.toLocaleString('en-US', { hour12: false }));
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("javascript.builtins.Date.toLocaleString")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/es/web/javascript/reference/global_objects/date/tolocaletimestring/index.html
+++ b/files/es/web/javascript/reference/global_objects/date/tolocaletimestring/index.html
@@ -138,8 +138,6 @@ console.log(date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }))
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("javascript.builtins.Date.toLocaleTimeString")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/javascript/reference/global_objects/date/toutcstring/index.html
+++ b/files/es/web/javascript/reference/global_objects/date/toutcstring/index.html
@@ -93,8 +93,6 @@ var UTCstring = today.toUTCString(); // Wed, 14 Jun 2017 07:00:00 GMT
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("javascript.builtins.Date.toUTCString")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/javascript/reference/global_objects/error/error/index.html
+++ b/files/es/web/javascript/reference/global_objects/error/error/index.html
@@ -57,7 +57,7 @@ const y = new Error('¡Fui construido con la palabra clave "new"!') </pre>
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.builtins.Error.Error")}}</p>
 </div>

--- a/files/es/web/javascript/reference/global_objects/error/filename/index.html
+++ b/files/es/web/javascript/reference/global_objects/error/filename/index.html
@@ -34,7 +34,7 @@ throw e;
 
 <div>
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.builtins.Error.fileName")}}</p>
 </div>

--- a/files/es/web/javascript/reference/global_objects/error/index.html
+++ b/files/es/web/javascript/reference/global_objects/error/index.html
@@ -207,7 +207,7 @@ try {
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.builtins.Error")}}</p>
 </div>

--- a/files/es/web/javascript/reference/global_objects/error/name/index.html
+++ b/files/es/web/javascript/reference/global_objects/error/name/index.html
@@ -45,7 +45,7 @@ throw e;
 
 <div>
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.builtins.Error.name")}}</p>
 </div>

--- a/files/es/web/javascript/reference/global_objects/error/tosource/index.html
+++ b/files/es/web/javascript/reference/global_objects/error/tosource/index.html
@@ -44,7 +44,7 @@ original_slug: Web/JavaScript/Referencia/Objetos_globales/Error/toSource
 
 <div>
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.builtins.Error.toSource")}}</p>
 </div>

--- a/files/es/web/javascript/reference/global_objects/error/tostring/index.html
+++ b/files/es/web/javascript/reference/global_objects/error/tostring/index.html
@@ -87,7 +87,7 @@ console.log(e.toString()); // 'hola'
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.builtins.Error.toString")}}</p>
 </div>

--- a/files/es/web/javascript/reference/global_objects/function/function/index.html
+++ b/files/es/web/javascript/reference/global_objects/function/function/index.html
@@ -75,7 +75,7 @@ adder(2, 6);
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.builtins.Function.Function")}}</p>
 </div>

--- a/files/es/web/javascript/reference/global_objects/function/index.html
+++ b/files/es/web/javascript/reference/global_objects/function/index.html
@@ -101,7 +101,7 @@ console.log(f2());          // 20
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.builtins.Function")}}</p>
 </div>

--- a/files/es/web/javascript/reference/global_objects/generator/return/index.html
+++ b/files/es/web/javascript/reference/global_objects/generator/return/index.html
@@ -91,7 +91,7 @@ g.return(1); // { value: 1, done: true }
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad en esta página es generada a partir de datos estructurados. Si quieres contribuir a estos datos, por favor visita <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y manda un pull request.</div>
+
 
 <p>{{Compat("javascript.builtins.Generator.return")}}</p>
 </div>

--- a/files/es/web/javascript/reference/global_objects/internalerror/index.html
+++ b/files/es/web/javascript/reference/global_objects/internalerror/index.html
@@ -83,7 +83,7 @@ loop(0);
 
 <div>
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.builtins.InternalError")}}</p>
 </div>

--- a/files/es/web/javascript/reference/global_objects/internalerror/internalerror/index.html
+++ b/files/es/web/javascript/reference/global_objects/internalerror/internalerror/index.html
@@ -43,7 +43,7 @@ original_slug: >-
 
 <div>
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.builtins.InternalError.InternalError")}}</p>
 </div>

--- a/files/es/web/javascript/reference/global_objects/intl/relativetimeformat/index.html
+++ b/files/es/web/javascript/reference/global_objects/intl/relativetimeformat/index.html
@@ -96,7 +96,7 @@ rtf.formatToParts(100, "day");
 
 <h2 id="Compatibilidad_en_navegadores">Compatibilidad en navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad es generada a partir de datos estructurados. Si quieres contribuir, por favor, revisa <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una Pull Request.</div>
+
 
 <p>{{Compat("javascript.builtins.Intl.RelativeTimeFormat")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/map/get/index.html
+++ b/files/es/web/javascript/reference/global_objects/map/get/index.html
@@ -65,7 +65,7 @@ miMapa.get('baz');  // Devuelve undefined.
 
 <h2 id="Compatiblidad_con_navegadores">Compatiblidad con navegadores</h2>
 
-<div class="hidden">La tabla de compatiblidad en esta página es generada desde datos estructurados. Si quieres contribuir a los datos, por favor mira <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envianos una solicitud de pull request.</div>
+
 
 <p>{{Compat("javascript.builtins.Map.get")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/math/acos/index.html
+++ b/files/es/web/javascript/reference/global_objects/math/acos/index.html
@@ -84,8 +84,6 @@ Math.acos(2);   // NaN
 
 <h2 id="Compatibilidad_con_navegador">Compatibilidad con navegador</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("javascript.builtins.Math.acos")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/javascript/reference/global_objects/math/acosh/index.html
+++ b/files/es/web/javascript/reference/global_objects/math/acosh/index.html
@@ -80,7 +80,7 @@ Math.acosh(2);   // 1.3169578969248166
 
 <h2 id="Compatibilidad_de_navegador">Compatibilidad de navegador</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta página es generada de datos estructurados. Si desea contribuir a los datos, por favor, revise <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos una solicitud de edición.</p>
+
 
 <p>{{Compat("javascript.builtins.Math.acosh")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/math/asinh/index.html
+++ b/files/es/web/javascript/reference/global_objects/math/asinh/index.html
@@ -76,7 +76,7 @@ Math.asinh(0);  // 0
 
 <h2 id="Compatibilidades_de_buscadores">Compatibilidades de buscadores</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta página se genera a partir de datos estructurados. Si desea contribuir con los datos, consulte <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos un pull request.</p>
+
 
 <p>{{Compat("javascript.builtins.Math.asinh")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/math/atan/index.html
+++ b/files/es/web/javascript/reference/global_objects/math/atan/index.html
@@ -92,7 +92,7 @@ Math.atan(y / x);
 
 <h2 id="Compatibilidad_con_el_navegador">Compatibilidad con el navegador</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta página es generada apartir de datos estructurados. Si quieres contribuir a los datos, por favor consulte <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos una <em>pull request</em>.</p>
+
 
 <p>{{Compat("javascript.builtins.Math.atan")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/math/atanh/index.html
+++ b/files/es/web/javascript/reference/global_objects/math/atanh/index.html
@@ -73,8 +73,6 @@ Math.atanh(2);   // NaN
 
 <h2 id="Compatibilidad_entre_navegadores">Compatibilidad entre navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("javascript.builtins.Math.atanh")}}</p>
 
 <h2 id="Puedes_leer">Puedes leer</h2>

--- a/files/es/web/javascript/reference/global_objects/math/cbrt/index.html
+++ b/files/es/web/javascript/reference/global_objects/math/cbrt/index.html
@@ -79,7 +79,7 @@ Math.cbrt(2);  // 1.2599210498948732
 
 <h2 id="Compatibilidad">Compatibilidad</h2>
 
-<div class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a></div>
+
 
 <div class="hidden">
 

--- a/files/es/web/javascript/reference/global_objects/math/cos/index.html
+++ b/files/es/web/javascript/reference/global_objects/math/cos/index.html
@@ -59,7 +59,7 @@ Math.cos(2 * Math.PI); // 1
 
 <h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta página es generada desde datos estructurados. Si te gustaría contribuir a los datos, por favor revisa <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos un pull request.</p>
+
 
 <p>{{Compat("javascript.builtins.Math.cos")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/math/expm1/index.html
+++ b/files/es/web/javascript/reference/global_objects/math/expm1/index.html
@@ -73,7 +73,7 @@ Math.expm1(1);  // 1.718281828459045
 
 <h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página es generada de información estructurada. Sí le gustaría contribuir a la información, por favor consulte <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos un pull request.</div>
+
 
 <p>{{Compat("javascript.builtins.Math.expm1")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/math/fround/index.html
+++ b/files/es/web/javascript/reference/global_objects/math/fround/index.html
@@ -189,8 +189,6 @@ if (!Math.fround) Math.fround = function(x) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("javascript.builtins.Math.fround")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/es/web/javascript/reference/global_objects/math/hypot/index.html
+++ b/files/es/web/javascript/reference/global_objects/math/hypot/index.html
@@ -112,8 +112,6 @@ Math.hypot(-3);          // 3, lo mismo que Math.abs(-3)
 
 <h2 id="Compatibilidad_en_navegadores">Compatibilidad en navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("javascript.builtins.Math.hypot")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/javascript/reference/global_objects/math/ln10/index.html
+++ b/files/es/web/javascript/reference/global_objects/math/ln10/index.html
@@ -72,8 +72,6 @@ getNatLog10(); // 2.302585092994046
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("javascript.builtins.Math.LN10")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/javascript/reference/global_objects/math/ln2/index.html
+++ b/files/es/web/javascript/reference/global_objects/math/ln2/index.html
@@ -71,8 +71,6 @@ getNatLog2(); // 0.6931471805599453</pre>
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("javascript.builtins.Math.LN2")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/javascript/reference/global_objects/math/log/index.html
+++ b/files/es/web/javascript/reference/global_objects/math/log/index.html
@@ -98,8 +98,6 @@ Math.log(10); // 2.302585092994046
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("javascript.builtins.Math.log")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/es/web/javascript/reference/global_objects/math/log2/index.html
+++ b/files/es/web/javascript/reference/global_objects/math/log2/index.html
@@ -82,8 +82,6 @@ Math.log2(1024); // 10
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("javascript.builtins.Math.log2")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/es/web/javascript/reference/global_objects/math/tan/index.html
+++ b/files/es/web/javascript/reference/global_objects/math/tan/index.html
@@ -67,7 +67,7 @@ original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/tan
 
 <h2 id="Compatibilidad_con_el_navegador">Compatibilidad con el navegador</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta página es generada a partir de datos estructurados. Si quieres contribuir a los datos, por favor consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>, y envíanos un <em>Pull Request</em>.</p>
+
 
 <p>{{Compat("javascript.builtins.Math.tan")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/math/tanh/index.html
+++ b/files/es/web/javascript/reference/global_objects/math/tanh/index.html
@@ -81,7 +81,7 @@ Math.tanh(1);        // 0.7615941559557649
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<p class="hidden">La compatibilidad de la tabla en esta pagina esta generada desde una structura data. Si quiers contribuir a la data, visita  <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envianos un propuesta.</p>
+
 
 <p>{{Compat("javascript.builtins.Math.tanh")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/number/isfinite/index.html
+++ b/files/es/web/javascript/reference/global_objects/number/isfinite/index.html
@@ -77,8 +77,6 @@ Number.isFinite(null);      // false, retornaría true con la función
 
 <h2 id="Compatibilidad_de_navegador">Compatibilidad de navegador</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("javascript.builtins.Number.isFinite")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/javascript/reference/global_objects/number/issafeinteger/index.html
+++ b/files/es/web/javascript/reference/global_objects/number/issafeinteger/index.html
@@ -87,8 +87,6 @@ Number.isSafeInteger(3.0);                  // true
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("javascript.builtins.Number.isSafeInteger")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/javascript/reference/global_objects/number/max_safe_integer/index.html
+++ b/files/es/web/javascript/reference/global_objects/number/max_safe_integer/index.html
@@ -57,7 +57,7 @@ Math.pow(2, 53) - 1     // 9007199254740991
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta página está generada con base en información estructurada. Si quieres contribuir a dicha información, por favor revisa  <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos un 'pull request'.</p>
+
 
 <p>{{Compat("javascript.builtins.Number.MAX_SAFE_INTEGER")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/number/nan/index.html
+++ b/files/es/web/javascript/reference/global_objects/number/nan/index.html
@@ -48,8 +48,6 @@ original_slug: Web/JavaScript/Referencia/Objetos_globales/Number/NaN
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("javascript.builtins.Number.NaN")}}</p>
 
 <h2 id="Tambien_mira">Tambien mira</h2>

--- a/files/es/web/javascript/reference/global_objects/number/parsefloat/index.html
+++ b/files/es/web/javascript/reference/global_objects/number/parsefloat/index.html
@@ -65,8 +65,6 @@ original_slug: Web/JavaScript/Referencia/Objetos_globales/Number/parseFloat
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("javascript.builtins.Number.parseFloat")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/javascript/reference/global_objects/number/tolocalestring/index.html
+++ b/files/es/web/javascript/reference/global_objects/number/tolocalestring/index.html
@@ -145,8 +145,6 @@ console.log(num.toLocaleString(undefined, {minimumFractionDigits: 2, maximumFrac
 
 <h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("javascript.builtins.Number.toLocaleString")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/javascript/reference/global_objects/number/toprecision/index.html
+++ b/files/es/web/javascript/reference/global_objects/number/toprecision/index.html
@@ -90,8 +90,6 @@ console.log((1234.5).toPrecision(2)); // logs '1.2e+3'
 
 <h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("javascript.builtins.Number.toPrecision")}}</p>
 
 <h2 id="Vea_También">Vea También</h2>

--- a/files/es/web/javascript/reference/global_objects/number/valueof/index.html
+++ b/files/es/web/javascript/reference/global_objects/number/valueof/index.html
@@ -71,7 +71,7 @@ console.log(typeof num);    // número
 
 <h2 id="Compatibilidad_con_navegador">Compatibilidad con navegador</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta página es generada desde datos estructurados. Si deseas contribuir con los datos, por favor, revisa <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud.</p>
+
 
 <p>{{Compat("javascript.builtins.Number.valueOf")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/object/getownpropertydescriptors/index.html
+++ b/files/es/web/javascript/reference/global_objects/object/getownpropertydescriptors/index.html
@@ -104,7 +104,7 @@ subclass.prototype = Object.create(
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad en esta página es generada a partir de datos estructurados. Si quisieras contribuir con los datos, por favor vaya a <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> mándenos una petición pull.</div>
+
 
 <p>{{Compat("javascript.builtins.Object.getOwnPropertyDescriptors")}}</p>
 </div>

--- a/files/es/web/javascript/reference/global_objects/promise/catch/index.html
+++ b/files/es/web/javascript/reference/global_objects/promise/catch/index.html
@@ -172,7 +172,7 @@ p2.then(function (value) {
 
 <h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
 
-<p class="hidden">To contribute to this compatibility data, please write a pull request against this repository: <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>.</p>
+
 
 <p>{{Compat("javascript.builtins.promise.catch")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/promise/finally/index.html
+++ b/files/es/web/javascript/reference/global_objects/promise/finally/index.html
@@ -83,7 +83,7 @@ fetch(myRequest).then(function(response) {
 
 <h2 id="Compatibilidad_en_navegador">Compatibilidad en navegador</h2>
 
-<p class="hidden">To contribute to this compatibility data, please write a pull request against this repository: <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>.</p>
+
 
 <p>{{Compat("javascript.builtins.Promise.finally")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/promise/index.html
+++ b/files/es/web/javascript/reference/global_objects/promise/index.html
@@ -203,7 +203,7 @@ function testPromise() {
 
 <h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
 
-<p class="hidden">To contribute to this compatibility data, please write a pull request against this file: <a href="https://github.com/mdn/browser-compat-data/blob/master/javascript/promise.json">https://github.com/mdn/browser-compat-data/blob/master/javascript/promise.json</a>.</p>
+
 
 <p>{{Compat("javascript/promise")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/promise/reject/index.html
+++ b/files/es/web/javascript/reference/global_objects/promise/reject/index.html
@@ -69,7 +69,7 @@ original_slug: Web/JavaScript/Referencia/Objetos_globales/Promise/reject
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">To contribute to this compatibility data, please write a pull request against this repository: <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>.</p>
+
 
 <p>{{Compat("javascript.builtins.Promise.reject")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/promise/resolve/index.html
+++ b/files/es/web/javascript/reference/global_objects/promise/resolve/index.html
@@ -140,7 +140,7 @@ p3.then(function(v) {
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<p class="hidden">Para contribuir a esta información de compatibilidad, porfavor haz una <em>pull request</em> contra este repositorio: <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a>.</p>
+
 
 <p>{{Compat("javascript.builtins.Promise.resolve")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/promise/then/index.html
+++ b/files/es/web/javascript/reference/global_objects/promise/then/index.html
@@ -291,7 +291,7 @@ p3.then(funcion(v) {
 
 <h2 id="Compatibilidad_en_navegador">Compatibilidad en navegador</h2>
 
-<p class="hidden">Para contribuir a la compatibilidad de estos datos, realiza una pull request sobre éste archivo: <a href="https://github.com/mdn/browser-compat-data/blob/master/javascript/promise.json">https://github.com/mdn/browser-compat-data/blob/master/javascript/promise.json</a>.</p>
+
 
 <p>{{Compat("javascript/promise","Promise.prototype.then")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/referenceerror/index.html
+++ b/files/es/web/javascript/reference/global_objects/referenceerror/index.html
@@ -88,7 +88,7 @@ original_slug: Web/JavaScript/Referencia/Objetos_globales/ReferenceError
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.builtins.ReferenceError")}}</p>
 </div>

--- a/files/es/web/javascript/reference/global_objects/regexp/index.html
+++ b/files/es/web/javascript/reference/global_objects/regexp/index.html
@@ -231,7 +231,7 @@ console.log(/[^.]+/.exec(url)[0].substr(7)) // registra 'xxx'
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.builtins.RegExp")}}</p>
 </div>

--- a/files/es/web/javascript/reference/global_objects/regexp/regexp/index.html
+++ b/files/es/web/javascript/reference/global_objects/regexp/regexp/index.html
@@ -101,7 +101,7 @@ new RegExp('ab+c', 'i') // constructor
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.builtins.RegExp.RegExp")}}</p>
 </div>

--- a/files/es/web/javascript/reference/global_objects/set/@@iterator/index.html
+++ b/files/es/web/javascript/reference/global_objects/set/@@iterator/index.html
@@ -74,7 +74,7 @@ for (const v of mySet) {
 
 <h2 id="Compatibilidad_en_navegadores">Compatibilidad en navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página está generada a partir de datos estructurados. Si quieres contribuir con ello, por favor comprueba <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una pull request.</div>
+
 
 <p>{{Compat("javascript.builtins.Set.@@iterator")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/set/entries/index.html
+++ b/files/es/web/javascript/reference/global_objects/set/entries/index.html
@@ -60,7 +60,7 @@ console.log(setIter.next().value); // ["baz", "baz"]
 
 <h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página ha sido generada a partir de datos estructurados. Si te apetece contribuir, comprueba <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envianos una pull request.</div>
+
 
 <p>{{Compat("javascript.builtins.Set.entries")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/set/index.html
+++ b/files/es/web/javascript/reference/global_objects/set/index.html
@@ -218,7 +218,7 @@ console.log([...mySet]); // Muestra lo mismo utilizando myArray</pre>
 
 <h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página es generada desde información estructurada. Si desea contribuir, por favor revise la información en <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envie un pull request/merge request.</div>
+
 
 <p>{{Compat("javascript.builtins.Set")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/string/codepointat/index.html
+++ b/files/es/web/javascript/reference/global_objects/string/codepointat/index.html
@@ -114,8 +114,6 @@ if (!String.prototype.codePointAt) {
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("javascript.builtins.String.codePointAt")}}</p>
 
 <h2 id="See_also">See also</h2>

--- a/files/es/web/javascript/reference/global_objects/string/index.html
+++ b/files/es/web/javascript/reference/global_objects/string/index.html
@@ -371,7 +371,7 @@ for (let i = 0, n = inputValues.length; i &lt; n; ++i) {
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.builtins.String")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/string/localecompare/index.html
+++ b/files/es/web/javascript/reference/global_objects/string/localecompare/index.html
@@ -149,8 +149,6 @@ console.log('ä'.localeCompare('a', 'sv', { sensitivity: 'base' })); // a positi
 
 <h2 id="Compatibilidad_con_el_navegador">Compatibilidad con el navegador</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("javascript.builtins.String.localeCompare")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/javascript/reference/global_objects/string/matchall/index.html
+++ b/files/es/web/javascript/reference/global_objects/string/matchall/index.html
@@ -122,7 +122,7 @@ array[1];
 
 <h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
 
-<p class="hidden">The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
+
 
 <p>{{Compat("javascript.builtins.String.matchAll")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/string/normalize/index.html
+++ b/files/es/web/javascript/reference/global_objects/string/normalize/index.html
@@ -115,7 +115,7 @@ str.normalize('NFKD'); // '\u0073\u0323\u0307'
 
 <h2 id="Compatibilidad_de_Navegadores">Compatibilidad de Navegadores</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta página es generada desde datos estructurados. Si quiere contribuir a estos datos, por favor hágalo utilizando éste repositorio <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos un pull request.</p>
+
 
 <p>{{Compat("javascript.builtins.String.normalize")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/string/raw/index.html
+++ b/files/es/web/javascript/reference/global_objects/string/raw/index.html
@@ -100,8 +100,6 @@ String.raw({
 
 <h2 id="Compatibilidad_de_navegador">Compatibilidad de navegador</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("javascript.builtins.String.raw")}}</p>
 
 <h2 id="Tambien_ver">Tambien ver</h2>

--- a/files/es/web/javascript/reference/global_objects/string/tolocalelowercase/index.html
+++ b/files/es/web/javascript/reference/global_objects/string/tolocalelowercase/index.html
@@ -101,7 +101,7 @@ let locales = ['tr', 'TR', 'tr-TR', 'tr-u-co-search', 'tr-x-turkish'];
 
 <h2 id="Compatibilidad_entre_navegadores">Compatibilidad entre navegadores</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta pádina se gnera desde datos estructurados. Si quieres contribuir a estos datos, por favor obtén <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una pull request.</p>
+
 
 <p>{{Compat("javascript.builtins.String.toLocaleLowerCase")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/string/tolocaleuppercase/index.html
+++ b/files/es/web/javascript/reference/global_objects/string/tolocaleuppercase/index.html
@@ -88,8 +88,6 @@ let locales = ['lt', 'LT', 'lt-LT', 'lt-u-co-phonebk', 'lt-x-lietuva'];
 
 <h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("javascript.builtins.String.toLocaleUpperCase")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/javascript/reference/global_objects/string/tosource/index.html
+++ b/files/es/web/javascript/reference/global_objects/string/tosource/index.html
@@ -46,7 +46,7 @@ original_slug: Web/JavaScript/Referencia/Objetos_globales/String/toSource
 
 <h2 id="Compatibilidad_entre_navegadores">Compatibilidad entre navegadores</h2>
 
-<p class="hidden">La tabla de compatibilidad en esta página es generada desde datos estructurados. Si deseas contribuir a los datos, por favor visita <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envianos un pull request.</p>
+
 
 <p>{{Compat("javascript.builtins.String.toSource")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/string/trimend/index.html
+++ b/files/es/web/javascript/reference/global_objects/string/trimend/index.html
@@ -71,8 +71,6 @@ console.log(str);        // '   foo'
 
 <h2 id="Compatibilidad_en_Navegadores">Compatibilidad en Navegadores</h2>
 
-<p class="hidden">The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> and send us a pull request.</p>
-
 <p>{{Compat("javascript.builtins.String.trimEnd")}}</p>
 
 <h2 id="Ver_también">Ver también</h2>

--- a/files/es/web/javascript/reference/global_objects/typedarray/index.html
+++ b/files/es/web/javascript/reference/global_objects/typedarray/index.html
@@ -304,7 +304,7 @@ Int8Array.prototype.foo = 'bar';
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.builtins.TypedArray")}}</p>
 

--- a/files/es/web/javascript/reference/global_objects/urierror/index.html
+++ b/files/es/web/javascript/reference/global_objects/urierror/index.html
@@ -120,7 +120,7 @@ original_slug: Web/JavaScript/Referencia/Objetos_globales/URIError
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad en esta página se genera a partir de los datos estructurados. Si desea contribuir con los datos, visite <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenes una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.builtins.URIError")}}</p>
 </div>

--- a/files/es/web/javascript/reference/global_objects/webassembly/index.html
+++ b/files/es/web/javascript/reference/global_objects/webassembly/index.html
@@ -107,7 +107,7 @@ fetch('simple.wasm').then(response =&gt;
 <h2 id="Browser_compatibility" name="Browser_compatibility">Compatibilidad de Navegadores</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad en esta página es generado desde datos estructurados. Si deseas contribuir a esta información, por favor revisa <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envía una solicitud.</div>
+
 
 <p>{{Compat("javascript.builtins.WebAssembly")}}</p>
 </div>

--- a/files/es/web/javascript/reference/lexical_grammar/index.html
+++ b/files/es/web/javascript/reference/lexical_grammar/index.html
@@ -640,7 +640,7 @@ a + b;
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.grammar")}}</p>
 

--- a/files/es/web/javascript/reference/operators/addition/index.html
+++ b/files/es/web/javascript/reference/operators/addition/index.html
@@ -59,7 +59,7 @@ false + false // 0
 
 <h2 id="Compatibilidad_de_Explorador">Compatibilidad de Explorador</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página es generada desde datos estructurados. Si quieres contribuir a estos datos, por favor revisa <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envía un pull request.</div>
+
 
 <p>{{Compat("javascript.operators.addition")}}</p>
 

--- a/files/es/web/javascript/reference/operators/await/index.html
+++ b/files/es/web/javascript/reference/operators/await/index.html
@@ -89,7 +89,7 @@ f3();</pre>
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página es generada a partir de información estructurada. Si quisieras contribuir a esta información, por favor visita <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos un pull request.</div>
+
 
 <p>{{Compat("javascript.operators.await")}}</p>
 </div>

--- a/files/es/web/javascript/reference/operators/destructuring_assignment/index.html
+++ b/files/es/web/javascript/reference/operators/destructuring_assignment/index.html
@@ -430,7 +430,7 @@ const {self, prot} = obj;
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
 <div>
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.operators.destructuring")}}</p>
 </div>

--- a/files/es/web/javascript/reference/operators/function_star_/index.html
+++ b/files/es/web/javascript/reference/operators/function_star_/index.html
@@ -73,7 +73,7 @@ original_slug: Web/JavaScript/Referencia/Operadores/function*
 
 <h2 id="Compatibilidad_con_navegadores">Compatibilidad con navegadores</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página es generada desde datos estructurados. Si usted desea contribuir a esos datos, por favor revise <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos un pull request.</div>
+
 
 <p>{{Compat("javascript.operators.function_star")}}</p>
 

--- a/files/es/web/javascript/reference/operators/index.html
+++ b/files/es/web/javascript/reference/operators/index.html
@@ -270,7 +270,7 @@ original_slug: Web/JavaScript/Referencia/Operadores
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.operators")}}</p>
 

--- a/files/es/web/javascript/reference/operators/new/index.html
+++ b/files/es/web/javascript/reference/operators/new/index.html
@@ -167,7 +167,7 @@ var car2 = new Car('Nissan', '300ZX', 1992, ken);
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.operators.new")}}</p>
 

--- a/files/es/web/javascript/reference/operators/spread_syntax/index.html
+++ b/files/es/web/javascript/reference/operators/spread_syntax/index.html
@@ -232,7 +232,7 @@ var array = [...obj]; // TypeError: obj is not iterable
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad en esta página es generada a partir de datos estructurados. Si quieres contribuir con esta información, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud (pull).</div>
+
 
 <p>{{Compat("javascript.operators.spread")}}</p>
 

--- a/files/es/web/javascript/reference/operators/yield/index.html
+++ b/files/es/web/javascript/reference/operators/yield/index.html
@@ -117,7 +117,7 @@ console.log(generatorFunc.next(10).value); // 26</pre>
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.operators.yield")}}</p>
 

--- a/files/es/web/javascript/reference/statements/for-await...of/index.html
+++ b/files/es/web/javascript/reference/statements/for-await...of/index.html
@@ -134,7 +134,7 @@ getResponseSize('https://jsonplaceholder.typicode.com/photos');</pre>
 
 <h2 id="Compatibilidad_de_Navegadores">Compatibilidad de Navegadores</h2>
 
-<div class="hidden">La tabla de compatiblidad de esta página es generada a partir de datos estructurados. Si te gustaría contribuir a estos datos, por favor clona <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos un pull request.</div>
+
 
 <p>{{Compat("javascript.statements.for_await_of")}}</p>
 

--- a/files/es/web/javascript/reference/statements/for...in/index.html
+++ b/files/es/web/javascript/reference/statements/for...in/index.html
@@ -116,7 +116,7 @@ for (const prop in obj) {
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.statements.for_in")}}</p>
 

--- a/files/es/web/javascript/typed_arrays/index.html
+++ b/files/es/web/javascript/typed_arrays/index.html
@@ -258,7 +258,7 @@ normalArray.constructor === Array;
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si deseas contribuir con los datos, consulta <a href="https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíanos una solicitud de extracción.</div>
+
 
 <p>{{Compat("javascript.builtins.Int8Array")}}</p>
 

--- a/files/es/web/svg/element/a/index.html
+++ b/files/es/web/svg/element/a/index.html
@@ -140,6 +140,6 @@ svgns|a:hover, svgns|a:active {
 
 <h2 id="Compatibilidad_del_navegador">Compatibilidad del navegador</h2>
 
-<div class="hidden">La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si desea contribuir a los datos, haz un check out de <a href="https://ssl.microsofttranslator.com/bv.aspx?from=&amp;to=es&amp;a=https://github.com/mdn/browser-compat-data">https://github.com/mdn/browser-compat-data</a> y envíenos un pull request.</div>
+
 
 <p>{{Compat("svg.elements.a")}}</p>


### PR DESCRIPTION
There are Soooo many variations of the "same string" in Spanish. I extended [my Python script](https://gist.github.com/peterbe/8e64574dcfea77b73f60d0c5da9e07b2) to be "machine learning" so it interactively asks for each suspicious line and adds that to the list of needles. 
