### PR TITLE
[ko] Synchronize primitive documents with en-us documents.

### DIFF
--- a/files/ko/glossary/primitive/index.html
+++ b/files/ko/glossary/primitive/index.html
@@ -7,7 +7,7 @@ tags:
   - JavaScript
 translation_of: Glossary/Primitive
 ---
-<p>{{Glossary("JavaScript")}}에서 <strong>원시 값</strong>(primitive, 또는 원시 자료형)이란 {{Glossary("object", "객체")}}가 아니면서 {{glossary("method", "메서드")}}도 가지지 않는 데이터입니다. 원시 값에는 6종류, {{Glossary("string")}}, {{Glossary("number")}}, {{glossary("bigint")}}, {{Glossary("boolean")}}, {{Glossary("undefined")}}, {{Glossary("symbol")}}이 존재합니다. 겉보기엔 원시 값처럼 보이는 {{glossary("null")}}도 있지만, 사실 모든 {{jsxref("Object")}}, 모든 구조화된 자료형은 <a href="/ko/docs/Learn/JavaScript/Objects/Inheritance">프로토타입 체인</a>에 따라 null의 자손입니다.</p>
+<p>{{Glossary("JavaScript")}}에서 <strong>원시 값</strong>(primitive, 또는 원시 자료형)이란 {{Glossary("object", "객체")}}가 아니면서 {{glossary("method", "메서드")}}도 가지지 않는 데이터입니다. 원시 값에는 7종류, {{Glossary("string")}}, {{Glossary("number")}}, {{glossary("bigint")}}, {{Glossary("boolean")}}, {{Glossary("undefined")}}, {{Glossary("symbol")}}, 그리고 {{glossary("null")}}이 존재합니다. 
 
 <p>대부분의 경우, 원시 값은 언어 구현체의 가장 저급(low level) 단계에서 나타냅니다.</p>
 


### PR DESCRIPTION
- [Primitive / ko](https://developer.mozilla.org/ko/docs/Glossary/Primitive) 문서를 [Primitive / en-us](https://developer.mozilla.org/en-US/docs/Glossary/Primitive) 문서와 동기화 했습니다.
- 참고 자료
   -  [ECMAScript® 2022 Language Specification](https://tc39.es/ecma262/#host)
![image](https://user-images.githubusercontent.com/61097373/122854511-cb7feb00-d34e-11eb-8221-1ef54d14b5df.png)
