### PR TITLE
Add some redirection for fr Intl link

### DIFF
--- a/files/fr/_redirects.txt
+++ b/files/fr/_redirects.txt
@@ -4790,6 +4790,9 @@
 /fr/docs/Web/JavaScript/Reference/Fonctions_et_portee_des_fonctions/arguments/length	/fr/docs/Web/JavaScript/Reference/Functions/arguments/length
 /fr/docs/Web/JavaScript/Reference/Fonctions_et_portee_des_fonctions/paramètres_du_reste	/fr/docs/Web/JavaScript/Reference/Functions/rest_parameters
 /fr/docs/Web/JavaScript/Reference/Gabarit_chaînes_caractères	/fr/docs/Web/JavaScript/Reference/Template_literals
+/fr/docs/Web/JavaScript/Reference/Global_Objects/Collator	/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator
+/fr/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat	/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat
+/fr/docs/Web/JavaScript/Reference/Global_Objects/ListFormat	/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat
 /fr/docs/Web/JavaScript/Reference/Global_Objects/Map	/fr/docs/orphaned/Web/JavaScript/Reference/Global_Objects/Map
 /fr/docs/Web/JavaScript/Reference/Global_Objects/Map/@@iterator	/fr/docs/orphaned/Web/JavaScript/Reference/Global_Objects/Map/@@iterator
 /fr/docs/Web/JavaScript/Reference/Global_Objects/Map/@@species	/fr/docs/orphaned/Web/JavaScript/Reference/Global_Objects/Map/@@species
@@ -4804,6 +4807,9 @@
 /fr/docs/Web/JavaScript/Reference/Global_Objects/Map/set	/fr/docs/orphaned/Web/JavaScript/Reference/Global_Objects/Map/set
 /fr/docs/Web/JavaScript/Reference/Global_Objects/Map/size	/fr/docs/orphaned/Web/JavaScript/Reference/Global_Objects/Map/size
 /fr/docs/Web/JavaScript/Reference/Global_Objects/Map/values	/fr/docs/orphaned/Web/JavaScript/Reference/Global_Objects/Map/values
+/fr/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat	/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat
+/fr/docs/Web/JavaScript/Reference/Global_Objects/PluralRules	/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules
+/fr/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat	/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat
 /fr/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/clear	/fr/docs/orphaned/Web/JavaScript/Reference/Global_Objects/WeakSet/clear
 /fr/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Global/prototype	/fr/docs/conflicting/Web/JavaScript/Reference/Global_Objects/WebAssembly/Global
 /fr/docs/Web/JavaScript/Reference/Grammaire_lexicale	/fr/docs/Web/JavaScript/Reference/Lexical_grammar


### PR DESCRIPTION
Hello :)

Currently on the french translations for `Intl` in the Sidebar, the links do not lead to the right page as you can see in the gif below
![IntlMdnNotRedirected](https://user-images.githubusercontent.com/17161484/123540048-3a898500-d73d-11eb-88ed-4180dc80c59a.gif)

Actually the URLs in the sidebar are redirect to new ones with `.../Global_Objects/Intl/...` in the path.
In the PR I just added the redirection for the sidebar url because the pages for method are not translated yet (link to en-US version). I think it would be better if they are added when translating the pages. But if you think it should be added in this PR, I can add them ;)

Have a good day