### PR TITLE
[PT-BR] Fixing RTL code snippet example

### DIFF
--- a/files/pt-br/web/api/element/classlist/index.html
+++ b/files/pt-br/web/api/element/classlist/index.html
@@ -34,7 +34,7 @@ translation_of: Web/API/Element/classList
 
 <h2 id="Exemplos">Exemplos</h2>
 
-<pre class="brush: js" dir="rtl">// div é uma referência de objeto para um elemento &lt;div&gt; com class = "foo bar"
+<pre class="brush: js" dir="ltr">// div é uma referência de objeto para um elemento &lt;div&gt; com class = "foo bar"
 div.classList.remove("foo");
 div.classList.add("anotherclass");
 


### PR DESCRIPTION
[en] Reading direction error in code snippet.

[pt] Orientação de leitura incorreta no code snippet de exemplo. Alteração da propriedade responsável (rtl --> ltr).