### PR TITLE
Javascript/refrence 의 int8array 추가 외

### DIFF
--- a/files/ko/web/javascript/reference/global_objects/array/index.html
+++ b/files/ko/web/javascript/reference/global_objects/array/index.html
@@ -8,6 +8,7 @@ tags:
   - JavaScript
   - Reference
 translation_of: Web/JavaScript/Reference/Global_Objects/Array
+browser-compat: javascript.builtins.Array
 ---
 <div>{{JSRef}}</div>
 
@@ -358,7 +359,7 @@ var myArray = myRe.exec('cdbBdbsbz');
  <dt>{{jsxref("Array.prototype.find()")}}</dt>
  <dd>주어진 판별 콜백을 만족하는 첫 번째 요소를 반환합니다. 만족하는 요소가 없으면 <code>undefined</code>를 반환합니다.</dd>
  <dt>{{jsxref("Array.prototype.findIndex()")}}</dt>
- <dd>주어진 판별 콜백을 만족하는 첫 번째 요소의 인덱스를 반환합니다. 만족하는 요소가 없으면 <code>undefined</code>를 반환합니다.</dd>
+ <dd>주어진 판별 콜백을 만족하는 첫 번째 요소의 인덱스를 반환합니다. 만족하는 요소가 없으면 <code>-1</code>를 반환합니다.</dd>
  <dt>{{jsxref("Array.prototype.forEach()")}}</dt>
  <dd>배열의 각각의 요소에 대해 콜백을 호출합니다.</dd>
  <dt>{{jsxref("Array.prototype.keys()")}}</dt>
@@ -461,26 +462,13 @@ console.table(values)</pre>
 
 <p>(첫번째 열은 (인덱스))</p>
 
-<h2 id="명세">명세</h2>
+<h2 id="Specifications">명세</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Initial publication</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-array-objects', 'Array')}}</td>
-   <td>ECMAScript 1</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
-<h2 id="브라우저_호환성">브라우저 호환성</h2>
+<h2 id="Browser_compatibility">브라우저 호환성</h2>
 
-
-
-<p>{{Compat("javascript.builtins.Array")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="같이_보기">같이 보기</h2>
 

--- a/files/ko/web/javascript/reference/global_objects/int8array/index.html
+++ b/files/ko/web/javascript/reference/global_objects/int8array/index.html
@@ -1,0 +1,160 @@
+---
+title: Int8Array
+slug: Web/JavaScript/Reference/Global_Objects/Int8Array
+tags:
+  - Class
+  - Int8Array
+  - JavaScript
+  - TypedArray
+  - TypedArrays
+  - Polyfill
+browser-compat: javascript.builtins.Int8Array
+---
+<div>{{JSRef}}</div>
+
+<p>
+  <strong><code>Int8Array</code></strong> 타입 배열은 2의 보수 8비트 부호있는 정수의 배열을 나타냅니다. 내용은 <code>0</code>으로 초기화됩니다. 
+  설정된 후에는 객체의 메서드 또는 표준 배열 인덱스 구문(즉, 대괄호 표기법 사용)을 사용하여 배열의 요소를 참조할 수 있습니다.
+</p>
+
+<h2 id="Constructor">생성자</h2>
+
+<dl>
+ <dt>{{jsxref("Global_Objects/Int8Array/Int8Array", "Int8Array()")}}</dt>
+ <dd>세로운 <code>Int8Array</code> 객체를 만듭니다.</dd>
+</dl>
+
+<h2 id="Static_properties">정적 속성</h2>
+
+<dl>
+ <dt>{{jsxref("TypedArray.BYTES_PER_ELEMENT", "Int8Array.BYTES_PER_ELEMENT")}}</dt>
+ <dd>요소 크기의 숫자 값을 반환합니다. <code>Int8Array</code>의 경우 <code>1</code> 입니다.</dd>
+ <dt>{{jsxref("TypedArray.name", "Int8Array.name")}}</dt>
+ <dd>생성자 이름의 문자열 값을 반환합니다. <code>Int8Array</code> 타입의 경우 "<code>Int8Array</code>"입니다.</dd>
+</dl>
+
+<h2 id="Static_methods">정적 메서드</h2>
+
+<dl>
+ <dt>{{jsxref("TypedArray.from", "Int8Array.from()")}}</dt>
+ <dd>배열과 유사하거나 순회가능한 객체로부터 새로운 <code>Int8Array</code>을 생성합니다. {{jsxref("Array.from()")}}을 참고하세요.</dd>
+ <dt>{{jsxref("TypedArray.of", "Int8Array.of()")}}</dt>
+ <dd>가변 인자를 사용하여 <code>Int8Array</code>를 생성합니다. {{jsxref("Array.of()")}}를 참고하세요.</dd>
+</dl>
+
+<h2 id="Instance_properties">인스턴스 속성</h2>
+
+<dl>
+ <dt>{{jsxref("TypedArray.prototype.buffer", "Int8Array.prototype.buffer")}}</dt>
+ <dd><code>Int8Array</code>에서 참조하는 {{jsxref("ArrayBuffer")}}를 반환합니다. 생성 시 고정되기 때문에 <strong>읽기 전용</strong>입니다.</dd>
+ <dt>{{jsxref("TypedArray.prototype.byteLength", "Int8Array.prototype.byteLength")}}</dt>
+ <dd>{{jsxref("ArrayBuffer")}}의 시작부터 <code>Int8Array</code>의 길이(바이트)를 반환합니다.. 생성 시 고정되기 때문에 <strong>읽기 전용</strong>입니다.</dd>
+ <dt>{{jsxref("TypedArray.prototype.byteOffset", "Int8Array.prototype.byteOffset")}}</dt>
+ <dd>{{jsxref("ArrayBuffer")}}의 시작부터 <code>Int8Array</code>의 오프셋(바이트)를 반환합니다. 생성 시 고정되기 때문에 <strong>읽기 전용</strong>입니다.</dd>
+ <dt>{{jsxref("TypedArray.prototype.length", "Int8Array.prototype.length")}}</dt>
+ <dd><code>Int8Array</code>내에 있는 요소 수를 반환합니다. 생성 시 고정되기 때문에 <strong>읽기 전용</strong>입니다.</dd>
+</dl>
+
+<h2 id="Instance_methods">인스턴스 메서드</h2>
+
+<dl>
+ <dt>{{jsxref("TypedArray.copyWithin", "Int8Array.prototype.copyWithin()")}}</dt>
+ <dd>배열 내의 지정된 요소들을 동일한 배열 내에서 복사합니다. {{jsxref("Array.prototype.copyWithin()")}}를 참고하세요.</dd>
+ <dt>{{jsxref("TypedArray.entries", "Int8Array.prototype.entries()")}}</dt>
+ <dd>배열의 각 인덱스에 대한 키/값 쌍을 포함하는 새로운 <em>배열 반복자</em> 객체를 반환합니다. {{jsxref("Array.prototype.entries()")}}를 참고하세요.</dd> 
+ <dt>{{jsxref("TypedArray.every", "Int8Array.prototype.every()")}}</dt>
+ <dd>배열의 모든 요소가 주어진 판별 콜백을 만족할 경우 true를 반환합니다. {{jsxref("Array.prototype.every()")}}를 참고하세요.</dd>
+ <dt>{{jsxref("TypedArray.fill", "Int8Array.prototype.fill()")}}</dt>
+ <dd>배열 안의 시작 인덱스부터 끝 인덱스까지의 요소값을 지정된 정적 값으로 채웁니다. {{jsxref("Array.prototype.fill()")}}를 참고하세요.</dd>
+ <dt>{{jsxref("TypedArray.filter", "Int8Array.prototype.filter()")}}</dt>
+ <dd>지정한 필터링 콜백의 반환 결과가 <code>true</code>인 요소만 모은 새로운 배열을 반환합니다. {{jsxref("Array.prototype.filter()")}}를 참고하세요.</dd>
+ <dt>{{jsxref("TypedArray.find", "Int8Array.prototype.find()")}}</dt>
+ <dd>주어진 판별 콜백을 만족하는 첫 번째 요소를 반환합니다. 만족하는 요소가 없으면 <code>undefined</code>를 반환합니다. {{jsxref("Array.prototype.find()")}}를 참고하세요.</dd>
+ <dt>{{jsxref("TypedArray.findIndex", "Int8Array.prototype.findIndex()")}}</dt>
+ <dd>주어진 판별 콜백을 만족하는 첫 번째 요소의 인덱스를 반환합니다. 만족하는 요소가 없으면 <code>-1</code>을 반환합니다. {{jsxref("Array.prototype.findIndex()")}}를 참고하세요.</dd>
+ <dt>{{jsxref("TypedArray.forEach", "Int8Array.prototype.forEach()")}}</dt>
+ <dd>배열의 각각의 요소에 대해 콜백을 호출합니다. {{jsxref("Array.prototype.forEach()")}}를 참고하세요.</dd>
+ <dt>{{jsxref("TypedArray.includes", "Int8Array.prototype.includes()")}}</dt>
+ <dd>배열이 주어진 값을 포함하는지 판별해 <code>true</code> 또는 <code>false</code>를 반환합니다. {{jsxref("Array.prototype.includes()")}}를 참고하세요.</dd>
+ <dt>{{jsxref("TypedArray.indexOf", "Int8Array.prototype.indexOf()")}}</dt>
+ <dd>배열에서 주어진 값과 일치하는 제일 앞의 인덱스를 반환합니다. 없으면 <code>-1</code>을 반환합니다. {{jsxref("Array.prototype.indexOf()")}}를 참고하세요.</dd>
+ <dt>{{jsxref("TypedArray.join", "Int8Array.prototype.join()")}}</dt>
+ <dd>배열의 모든 요소를 문자열로 합칩니다. {{jsxref("Array.prototype.join()")}}을 참고하세요.</dd>
+ <dt>{{jsxref("TypedArray.keys", "Int8Array.prototype.keys()")}}</dt>
+ <dd>배열의 각 인덱스에 대한 키를 가지는 새로운 <em>배열 반복자</em> 객체를 반환합니다. {{jsxref("Array.prototype.keys()")}}를 참고하세요.</dd>
+ <dt>{{jsxref("TypedArray.lastIndexOf", "Int8Array.prototype.lastIndexOf()")}}</dt>
+ <dd>배열에서 주어진 값과 일치하는 제일 뒤의 인덱스를 반환합니다. 없으면 <code>-1</code>을 반환합니다. {{jsxref("Array.prototype.lastIndexOf()")}}를 참고하세요.</dd>
+ <dt>{{jsxref("TypedArray.map", "Int8Array.prototype.map()")}}</dt>
+ <dd>배열의 모든 요소 각각에 대하여 주어진 콜백 함수를 호출하고, 그 반환값을 모은 새로운 배열을 반환합니다. {{jsxref("Array.prototype.map()")}}을 참고하세요.</dd>
+ <dt>{{jsxref("TypedArray.reduce", "Int8Array.prototype.reduce()")}}</dt>
+ <dd>주어진 콜백 함수를 가산기와 요소 각각에 대해 왼쪽에서 오른쪽으로 호출하여 하나의 값으로 줄인(reduce) 결과를 반환합니다. {{jsxref("Array.prototype.reduce()")}}를 참고하세요.</dd>
+ <dt>{{jsxref("TypedArray.reduceRight", "Int8Array.prototype.reduceRight()")}}</dt>
+ <dd>주어진 콜백 함수를 가산기와 요소 각각에 대해 오른쪽에서 왼쪽으로 호출하여 하나의 값으로 줄인(reduce) 결과를 반환합니다. {{jsxref("Array.prototype.reduceRight()")}}를 참고하세요.</dd>
+ <dt>{{jsxref("TypedArray.reverse", "Int8Array.prototype.reverse()")}}</dt>
+ <dd>배열의 요소 순서를 반전시킵니다. 첫 번째가 마지막이 되고 마지막이 첫 번째가 됩니다. {{jsxref("Array.prototype.reverse()")}}를 참고하세요.</dd>
+ <dt>{{jsxref("TypedArray.set", "Int8Array.prototype.set()")}}</dt>
+ <dd>주어진 배열의 여러 값을 읽어서 배열의 여러 값을 저장합니다.</dd>
+ <dt>{{jsxref("TypedArray.slice", "Int8Array.prototype.slice()")}}</dt>
+ <dd>배열의 일부를 추출한 새 배열을 반환합니다. {{jsxref("Array.prototype.slice()")}}를 참고하세요.</dd>
+ <dt>{{jsxref("TypedArray.some", "Int8Array.prototype.some()")}}</dt>
+ <dd>배열의 어떤 요소가 주어진 판별 콜백을 만족할 경우 <code>true</code>를 반환합니다. {{jsxref("Array.prototype.some()")}}을 참고하세요.</dd>
+ <dt>{{jsxref("TypedArray.sort", "Int8Array.prototype.sort()")}}</dt>
+ <dd>배열의 요소를 정렬하고 그 배열을 반환합니다. {{jsxref("Array.prototype.sort()")}}를 참고하세요.</dd>
+ <dt>{{jsxref("TypedArray.subarray", "Int8Array.prototype.subarray()")}}</dt>
+ <dd>주어진 시작 요소와 끝 요소의 인덱스로부터 새로운 <code>Int8Array</code> 객체를 생성합니다.</dd>
+ <dt>{{jsxref("TypedArray.values", "Int8Array.prototype.values()")}}</dt>
+ <dd>배열의 각 인덱스에 대한 값을 가지는 새로운 <em>배열 반복자</em> 객체를 반환합니다.{{jsxref("Array.prototype.values()")}}를 참고하세요.</dd>
+ <dt>{{jsxref("TypedArray.toLocaleString", "Int8Array.prototype.toLocaleString()")}}</dt>
+ <dd>배열과 그 요소를 나타내는 지역화된 문자열을 반환합니다. {{jsxref("Array.prototype.toLocaleString()")}}을 참고하세요.</dd>
+ <dt>{{jsxref("TypedArray.toString", "Int8Array.prototype.toString()")}}</dt>
+ <dd>배열과 그 요소를 나타내는 문자열을 반환합니다. {{jsxref("Array.prototype.toString()")}}을 참고하세요.</dd>
+ <dt>{{jsxref("TypedArray.@@iterator", "Int8Array.prototype[@@iterator]()")}}</dt>
+ <dd>배열의 각 인덱스에 대한 값을 가지는 새로운 <em>배열 반복자</em> 객체를 반환합니다.</dd>
+</dl>
+
+<h2 id="Examples">예제</h2>
+
+<h3 id="Different_ways_to_create_an_Int8Array">Int8Array를 생성하는 여러 방법</h3>
+
+<pre class="brush: js">// 숫자로부터
+var int8 = new Int8Array(2);
+int8[0] = 42;
+console.log(int8[0]); // 42
+console.log(int8.length); // 2
+console.log(int8.BYTES_PER_ELEMENT); // 1
+
+// 배열로부터
+var arr = new Int8Array([21,31]);
+console.log(arr[1]); // 31
+
+// 다른 TypedArray로부터
+var x = new Int8Array([21, 31]);
+var y = new Int8Array(x);
+console.log(y[0]); // 21
+
+// ArrayBuffer로부터
+var buffer = new ArrayBuffer(8);
+var z = new Int8Array(buffer, 1, 4);
+
+// 순회로부터
+var iterable = function*(){ yield* [1,2,3]; }();
+var int8 = new Int8Array(iterable);
+// Int8Array[1, 2, 3]
+</pre>
+
+<h2 id="Specifications">명세</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">브라우저 호환성</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">같이 보기</h2>
+
+<ul>
+ <li><code>Int8Array</code>의 폴리필은 <a href="https://github.com/zloirock/core-js#ecmascript-typed-arrays"><code>core-js</code></a> 여기서 참조할 수 있습니다.</li>
+ <li><a href="/ko/docs/Web/JavaScript/Typed_arrays">JavaScript typed arrays</a></li>
+ <li>{{jsxref("ArrayBuffer")}}</li>
+ <li>{{jsxref("DataView")}}</li>
+</ul>


### PR DESCRIPTION
`인스턴스 메서드`의 각 메서드는 2~3개 빼곤 `Array.prototype` 의 내용을 그대로 들고왔기 때문에 전부다 살펴보시기 보다는 
처음부터 `인스턴스 속성`까지만 살펴보심이 좋을 것 같습니다.

 `Array.prototype`에 없는 인스턴스 메서드는 `set()`, `subarray()` 입니다.

나머지 `uint8array`, `int16array` 등은 모두 이와 비슷하기 때문에 이 글에 대한 리뷰를 잘 해주시면 나머지 문서는 빠르게 추가할 수 있을걸로
생각합니다. 

그 밖에 array 전체 설명-`findIndex()`에 대한 요약에서 반환값을 잘못 명시한 중요한 오번역이 있어서 같이 수정했습니다.