### PR TITLE
Неточность(непонятка)

### DIFF
--- a/files/ru/web/css/initial_value/index.html
+++ b/files/ru/web/css/initial_value/index.html
@@ -9,7 +9,7 @@ translation_of: Web/CSS/initial_value
 
 <p>Для <a href="/ru/docs/Web/CSS/inheritance#Inherited_properties" title="en/CSS/inheritance#Inherited_properties">наследуемых</a>, начальное значение установлено <strong>только</strong> для корневого элемента, если не указано никакого значения для элемента.</p>
 
-<p>Для <a href="/ru/docs/Web/CSS/inheritance#Non-inherited_properties" title="en/CSS/inheritance#Non-inherited_properties">ненаследуемых свойств</a> используется начальное значение для <strong>любого</strong> элемента, даже когда значение для элемента не указано.</p>
+<p>Для <a href="/ru/docs/Web/CSS/inheritance#Non-inherited_properties" title="en/CSS/inheritance#Non-inherited_properties">ненаследуемых свойств</a> используется начальное значение для <strong>каждого</strong> элемента, даже когда значение для элемента не указано.</p>
 
 <p>Ключевое слово <code><a href="/ru/docs/Web/CSS/initial" title="en/CSS/initial">initial</a></code> добавлено в CSS3, чтобы предоставить авторам возможность явно указывать это первоначальное значение.</p>
 


### PR DESCRIPTION
Может лучше перевести так в данном месте(Для ненаследуемых свойств используется начальное значение для ЛЮБОГО ЭЛЕМЕНТА -> КАЖДОГО ЭЛЕМЕНТА)?

Или же дословно ДЛЯ ВСЕХ ЭЛЕМЕНТОВ(used on all elements).

Просто читал раза три и только тогда понял, что имеется ввиду, и то, пока не зашел в оригинал и в спецификацию, до конца не убедился, что верно понял.