### PR TITLE
Update text in index.html

### DIFF
--- a/files/ru/mdn/contribute/feedback/index.html
+++ b/files/ru/mdn/contribute/feedback/index.html
@@ -17,13 +17,7 @@ translation_of: MDN/Contribute/Feedback
 
 <h2 id="Обновление_документации">Обновление документации</h2>
 
-<p>Прежде всего, если вы увидели проблему с документацией, вы всегда можете исправить её самостоятельно.</p>
-
-<ol>
- <li><a href="/ru/docs/MDN/Contribute/Howto/Create_an_MDN_account">Войдите</a> через <a href="https://github.com/">Github</a>.</li>
- <li>Нажмите синюю кнопку <strong>Редактировать</strong> на любой странице, чтобы открыть <a href="/ru/docs/MDN/Contribute/Editor">редактор</a>.</li>
- <li>Нажмите кнопку <strong>Опубликовать</strong>, когда закончите вносить изменения.</li>
-</ol>
+<p>Прежде всего, если вы увидели проблему с документацией, вы всегда можете исправить её самостоятельно. Начните с чтения <a href="https://github.com/mdn/content/#making-contributions">этой информации</a></p>
 
 <p>Документация здесь в wiki формате, она курируется командой волонтёров и оплачиваемых сотрудников, так что не стесняйтесь — ваша грамматика не обязана быть идеальной. Если вы сделаете ошибку - мы её устраним; без вреда!</p>
 
@@ -32,7 +26,6 @@ translation_of: MDN/Contribute/Feedback
 <ul>
  <li><a href="/ru/docs/Project:Getting_started" title="/ru/docs/Project:Getting_started">Начало работы</a> для идей о вещах, которые вы можете сделать.</li>
  <li><a href="/ru/docs/MDN/Contribute">Вклад в MDN</a></li>
- <li><a href="/ru/docs/MDN/Contribute/Editor" title="/en-US/docs/Project:MDN_editing_interface">Интерфейс редактора MDN </a></li>
 </ul>
 
 <h2 id="Присоединение_к_беседе">Присоединение к беседе</h2>


### PR DESCRIPTION
I suppose that links to MDN WYSIWYG are deprecated because manual from this link (https://developer.mozilla.org/ru/docs/orphaned/MDN/Editor) located in "orphanded" folder. So in this pull request i deleted list with steps about using WYSIWYG and added link to GitHub information about making contributions.