### PR TITLE
fix: 정규식 match 메소드 오타 수정

### DIFF
--- a/files/ko/web/javascript/guide/regular_expressions/index.html
+++ b/files/ko/web/javascript/guide/regular_expressions/index.html
@@ -357,7 +357,7 @@ original_slug: Web/JavaScript/Guide/정규식
   </tr>
   <tr>
    <td>{{jsxref("String.match", "match")}}</td>
-   <td>대응되는 문자열을 찾는 <code style="font-style: normal;">RegExp</code><span style="background-color: rgba(212, 221, 228, 0.14902);"> 메소드입니다</span>. 정보를 가지고 있는 배열을 반환합니다. 대응되는 문자열을 찾지 못했다면 null을 반환합니다.</td>
+   <td>대응되는 문자열을 찾는 <code style="font-style: normal;">String</code><span style="background-color: rgba(212, 221, 228, 0.14902);"> 메소드입니다</span>. 정보를 가지고 있는 배열을 반환합니다. 대응되는 문자열을 찾지 못했다면 null을 반환합니다.</td>
   </tr>
   <tr>
    <td>{{jsxref("String.search", "search")}}</td>


### PR DESCRIPTION
`ko/docs/Web/JavaScript/Guide/Regular_Expressions` match 메소드 설명 부분 오타 수정