### PR TITLE
[ko] fix: lever to level, typo err, /docs/Web/API/Touch_events

### DIFF
--- a/files/ko/web/api/touch_events/index.html
+++ b/files/ko/web/api/touch_events/index.html
@@ -9,7 +9,7 @@ translation_of: Web/API/Touch_events
 
 <p>터치 이벤트 인터페이스는 상대적으로 low-level API이며 multi-touch interaction등의 다양한 동작을 특정해 트리거 할 수 있습니다. multi-touch interaction은 한 손가락이 터치패드에 처음 닫는 순간 시작합니다. 이후 다른 손가락들이 터치패드에 닿고 선택적으로 터치패드를 가로지를 수도 있습니다. interaction은 손가락들이 터치패드에서 떨어지면 끝납니다. interaction동안에 어플리케이션은 touch start, move, end 이벤트들을 받습니다.</p>
 
-<p>Touch events는 동시에 여러 손가락으로 동시에 혹은 여러 지점에 터치 할 수 있다는 것만 제외하면 마우스 이벤트와 유사합니다. 터치이벤트 인터페이스는 현재 액션과 터치 지점을 캡슐화 합니다. single touch로 대표되는 interface는 터치된 정보등을 포함합니다.</p>
+<p>터치 이벤트는 동시에 여러 손가락으로 동시에 혹은 여러 지점에 터치 할 수 있다는 것만 제외하면 마우스 이벤트와 유사합니다. {{domxref("TouchEvent")}} 인터페이스는 현재 액션과 터치 지점을 캡슐화 합니다. single touch로 대표되는 {{domxref("Touch")}} 인터페이스는 브라우저의 뷰포트와 관련된 접촉 지점의 위치와 같은 것들의 정보등을 포함합니다.</p>
 
 <h2 id="Definitions">Definitions</h2>
 

--- a/files/ko/web/api/touch_events/index.html
+++ b/files/ko/web/api/touch_events/index.html
@@ -3,15 +3,11 @@ title: Touch events
 slug: Web/API/Touch_events
 translation_of: Web/API/Touch_events
 ---
-<div>{{DefaultAPISidebar("Touch Events(터치이벤트)")}}</div>
+<p>{{DefaultAPISidebar("Touch Events")}}</p>
 
-<div>일부분만 번역함.</div>
+<p><span class="seoSummary">터치를 기반으로 한 양질의 서비스를 제공하기 위해, Touch Events(터치이벤트)는 터치로 인한 움직임을 감지할 능력을 제공합니다.</span></p>
 
-<div> </div>
-
-<p> 터치를 기반으로 한 양질의 서비스를 제공하기 위해, Touch Events(터치이벤트)는 터치로 인한 움직임을 감지할 능력을 제공합니다.</p>
-
-<p>터치 이벤트 인터페이스는 상대적으로 low-lever API이며 multi-touch interaction등의 다양한 동작을 특정해 트리거 할 수 있습니다. multi-touch interaction은 한 손가락이 터치패드에 처음 닫는 순간 시작합니다. 이후 다른 손가락들이 터치패드에 닿고 선택적으로 터치패드를 가로지를 수도 있습니다. interaction은 손가락들이 터치패드에서 떨어지면 끝납니다. interaction동안에 어플리케이션은 touch start, move, end 이벤트들을 받습니다.</p>
+<p>터치 이벤트 인터페이스는 상대적으로 low-level API이며 multi-touch interaction등의 다양한 동작을 특정해 트리거 할 수 있습니다. multi-touch interaction은 한 손가락이 터치패드에 처음 닫는 순간 시작합니다. 이후 다른 손가락들이 터치패드에 닿고 선택적으로 터치패드를 가로지를 수도 있습니다. interaction은 손가락들이 터치패드에서 떨어지면 끝납니다. interaction동안에 어플리케이션은 touch start, move, end 이벤트들을 받습니다.</p>
 
 <p>Touch events는 동시에 여러 손가락으로 동시에 혹은 여러 지점에 터치 할 수 있다는 것만 제외하면 마우스 이벤트와 유사합니다. 터치이벤트 인터페이스는 현재 액션과 터치 지점을 캡슐화 합니다. single touch로 대표되는 interface는 터치된 정보등을 포함합니다.</p>
 


### PR DESCRIPTION
issue: #1449

따로 추가 번역은 하지 않았습니다.

MDN URL: https://developer.mozilla.org/ko/docs/Web/API/Touch_events

## issue 내용 요약

low-lever 오타

=> low-level로 수정

## 변경사항

- issue 해결
- 3문단 마지막줄 `{{domxref("TouchEvent")}}`, `{{domxref("Touch")}}` 추가.

## result (yari)

![image](https://user-images.githubusercontent.com/22424891/124933831-28fa8400-e03f-11eb-8e76-a0dcf7d8c8c5.png)
