### PR TITLE
fix: the pre label 'dir' attribute

### DIFF
--- a/files/zh-cn/web/javascript/reference/operators/instanceof/index.html
+++ b/files/zh-cn/web/javascript/reference/operators/instanceof/index.html
@@ -113,7 +113,7 @@ myDate instanceof String;   // 返回 false</pre>
 
 <p>下面的代码创建了一个类型 <code>Car</code>，以及该类型的对象实例 <code>mycar</code>. <code>instanceof</code> 运算符表明了这个 <code>mycar</code> 对象既属于 <code>Car</code> 类型，又属于 <code>Object</code> 类型。</p>
 
-<pre class="brush: js notranslate" dir="rtl">function Car(make, model, year) {
+<pre class="brush: js notranslate">function Car(make, model, year) {
   this.make = make;
   this.model = model;
   this.year = year;


### PR DESCRIPTION
the pre label  used 'dir="rtl"' attribute, cause code written from the right to the left