### PR TITLE
Update index.html (destructuring)

### DIFF
--- a/files/ko/web/javascript/reference/operators/destructuring_assignment/index.html
+++ b/files/ko/web/javascript/reference/operators/destructuring_assignment/index.html
@@ -64,10 +64,10 @@ console.log(z); // 2
 
 <pre class="brush: js">var foo = ["one", "two", "three"];
 
-var [one, two, three] = foo;
-console.log(one); // "one"
-console.log(two); // "two"
-console.log(three); // "three"
+var [red, yellow, green] = foo;
+console.log(red); // "one"
+console.log(yellow); // "two"
+console.log(green); // "three"
 </pre>
 
 <h3 id="선언에서_분리한_할당">선언에서 분리한 할당</h3>


### PR DESCRIPTION
index.html line 67~70 (Kor version)
original example 
<pre class="brush: js">var foo = ["one", "two", "three"];

var [one, two three] = foo;

this example is not intuitive,  it looks same.
but in English example, there are some differences in example.

for other newbies like me, fix this plz!!