### PR TITLE
Remove hidden/noinclude from JS docs

### DIFF
--- a/files/ko/web/javascript/a_re-introduction_to_javascript/index.html
+++ b/files/ko/web/javascript/a_re-introduction_to_javascript/index.html
@@ -1034,6 +1034,4 @@ y(7) // 27을 돌려줌
 </ul>
 </div>
 
-<div class="noinclude"></div>
-
 <p>{{ languages( { "en": "en/A_re-introduction_to_JavaScript", "fr": "fr/Une_reintroduction_a_JavaScript", "it": "it/Una_re-introduzione_a_Javascript", "ja": "ja/A_re-introduction_to_JavaScript", "pl": "pl/JavaScript/Na_pocz?tek", "zh-cn": "cn/A_re-introduction_to_JavaScript" } ) }}</p>

--- a/files/ko/web/javascript/guide/functions/index.html
+++ b/files/ko/web/javascript/guide/functions/index.html
@@ -653,7 +653,3 @@ var p = new Person();</pre>
 </dl>
 
 <p>{{PreviousNext("Web/JavaScript/Guide/Loops_and_iteration", "Web/JavaScript/Guide/Expressions_and_Operators")}}</p>
-
-<div class="itanywhere-activator" style="left: 154px; top: 13819.2px; display: none;" title="Google Translator Anywhere"></div>
-
-<div class="itanywhere-activator" class="hidden" title="Google Translator Anywhere"></div>

--- a/files/ko/web/javascript/reference/classes/extends/index.html
+++ b/files/ko/web/javascript/reference/classes/extends/index.html
@@ -13,10 +13,6 @@ translation_of: Web/JavaScript/Reference/Classes/extends
 
 <p>{{EmbedInteractiveExample("pages/js/classes-extends.html", "taller")}}</p>
 
-<div class="hidden">
-<p>The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</p>
-</div>
-
 <h2 id="구문">구문</h2>
 
 <pre class="syntaxbox">class ChildClass extends ParentClass { ... }</pre>

--- a/files/ko/web/javascript/reference/classes/public_class_fields/index.html
+++ b/files/ko/web/javascript/reference/classes/public_class_fields/index.html
@@ -144,10 +144,6 @@ console.log(sub.subInstanceField)
 
 <p>{{EmbedInteractiveExample("pages/js/classes-static.html")}}</p>
 
-<div class="hidden">
-<p>The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</p>
-</div>
-
 <p>The static methods are added to the class constructor with {{jsxref("Global_Objects/Object/defineProperty", "Object.defineProperty()")}} at class evaluation time. These methods are writable, non-enumerable, and configurable.</p>
 
 <h3 id="Public_instance_methods">Public instance methods</h3>

--- a/files/ko/web/javascript/reference/classes/static/index.html
+++ b/files/ko/web/javascript/reference/classes/static/index.html
@@ -15,10 +15,6 @@ translation_of: Web/JavaScript/Reference/Classes/static
 
 <p>{{EmbedInteractiveExample("pages/js/classes-static.html")}}</p>
 
-<div class="hidden">
-<p>The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</p>
-</div>
-
 <h2 id="문법">문법</h2>
 
 <pre class="syntaxbox">static methodName() { ... }</pre>

--- a/files/ko/web/javascript/reference/functions/default_parameters/index.html
+++ b/files/ko/web/javascript/reference/functions/default_parameters/index.html
@@ -15,10 +15,6 @@ translation_of: Web/JavaScript/Reference/Functions/Default_parameters
 
 <p>{{EmbedInteractiveExample("pages/js/functions-default.html")}}</p>
 
-<div class="hidden">
-<p>위의 상호작용가능한 예제의 소스는 깃허브 저장소에 저장됩니다. 상호작용 예제 프로젝트에 기여하고 싶다면 <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> 를 클론(clone)하여 풀 리퀘스트(pull request) 를 보내주세요.</p>
-</div>
-
 <h2 id="구문">구문</h2>
 
 <pre class="brush: js notranslate">

--- a/files/ko/web/javascript/reference/functions/rest_parameters/index.html
+++ b/files/ko/web/javascript/reference/functions/rest_parameters/index.html
@@ -14,12 +14,6 @@ translation_of: Web/JavaScript/Reference/Functions/rest_parameters
 
 <p>{{EmbedInteractiveExample("pages/js/functions-restparameters.html")}}</p>
 
-<div class="hidden">
-<p>The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</p>
-</div>
-
-<p> </p>
-
 <h2 id="구문">구문</h2>
 
 <pre class="brush: js">function f(a, b, ...theArgs) {

--- a/files/ko/web/javascript/reference/global_objects/array/entries/index.html
+++ b/files/ko/web/javascript/reference/global_objects/array/entries/index.html
@@ -16,10 +16,6 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Array/entries
 
 <p>{{EmbedInteractiveExample("pages/js/array-entries.html")}}</p>
 
-<div class="hidden">
-<p>The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</p>
-</div>
-
 <h2 id="구문">구문</h2>
 
 <pre class="syntaxbox notranslate"><code><var>arr</var>.entries()</code>

--- a/files/ko/web/javascript/reference/global_objects/array/flatmap/index.html
+++ b/files/ko/web/javascript/reference/global_objects/array/flatmap/index.html
@@ -14,10 +14,6 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Array/flatMap
 
 <p><code><strong>flatMap()</strong></code> 메서드는 먼저 매핑함수를 사용해 각 엘리먼트에 대해 map 수행 후, 결과를 새로운 배열로 평탄화합니다. 이는 깊이 1의 <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat">flat</a> 이 뒤따르는 <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map">map</a> 과 동일하지만, <code>flatMap</code> 은 아주 유용하며 둘을 하나의 메소드로 병합할 때 조금 더 효율적입니다.</p>
 
-<p class="hidden">\{{EmbedInteractiveExample("pages/js/array-flatmap.html")}}</p>
-
-
-
 <h2 id="구문">구문</h2>
 
 <pre class="syntaxbox"><var>arr</var>.flatMap(<var>callback(currentValue[, index[, array]])</var>[, <var>thisArg</var>])</pre>

--- a/files/ko/web/javascript/reference/global_objects/array/slice/index.html
+++ b/files/ko/web/javascript/reference/global_objects/array/slice/index.html
@@ -15,8 +15,6 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Array/slice
 
 <div>{{EmbedInteractiveExample("pages/js/array-slice.html")}}</div>
 
-<p class="hidden">The source for this interactive demo is stored in a GitHub repository. If you'd like to contribute to the interactive demo project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</p>
-
 <h2 id="구문">구문</h2>
 
 <pre class="syntaxbox"><var>arr</var>.slice([<em>begin</em>[, <em>end</em>]])

--- a/files/ko/web/javascript/reference/global_objects/function/apply/index.html
+++ b/files/ko/web/javascript/reference/global_objects/function/apply/index.html
@@ -18,10 +18,6 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Function/apply
 
 <p>{{EmbedInteractiveExample("pages/js/function-apply.html")}}</p>
 
-<div class="hidden">
-<p>The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</p>
-</div>
-
 <h2 id="구문">구문</h2>
 
 <pre class="syntaxbox"><code><var>func</var>.apply(<var>thisArg, </var>[<var>argsArray</var>])</code></pre>

--- a/files/ko/web/javascript/reference/global_objects/infinity/index.html
+++ b/files/ko/web/javascript/reference/global_objects/infinity/index.html
@@ -15,8 +15,6 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Infinity
 
 <div>{{EmbedInteractiveExample("pages/js/globalprops-infinity.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
-
 <h2 id="설명">설명</h2>
 
 <p><code>Infinity</code>는 전역 객체의 속성입니다. 즉, 전역 스코프의 변수입니다.</p>

--- a/files/ko/web/javascript/reference/global_objects/intl/datetimeformat/index.html
+++ b/files/ko/web/javascript/reference/global_objects/intl/datetimeformat/index.html
@@ -143,7 +143,7 @@ Intl.DateTimeFormat.call(<var>this</var>[, <var>locales</var>[, <var>options</va
   </dd>
  </dl>
 
- <p class="noinclude">각 구성요소 속성의 기본값은 {{jsxref("undefined")}}입니다. 그러나 모든 속성이 {{jsxref("undefined")}}일 경우, <code>year</code>, <code>month</code>, <code>day</code>는 <code>"numeric"</code>으로 취급합니다.</p>
+ <p>각 구성요소 속성의 기본값은 {{jsxref("undefined")}}입니다. 그러나 모든 속성이 {{jsxref("undefined")}}일 경우, <code>year</code>, <code>month</code>, <code>day</code>는 <code>"numeric"</code>으로 취급합니다.</p>
  </dd>
 </dl>
 

--- a/files/ko/web/javascript/reference/global_objects/intl/numberformat/index.html
+++ b/files/ko/web/javascript/reference/global_objects/intl/numberformat/index.html
@@ -15,8 +15,6 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat
 
 <div>{{EmbedInteractiveExample("pages/js/intl-numberformat.html")}}</div>
 
-<p class="hidden">상호작용 가능한 예제의 소스는 GitHub 리포지토리에 보관되어 있습니다. 상호작용 예제 프로젝트에 기여하고 싶으시다면, <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>를 클론한 후 풀 리퀘스트를 보내주세요.</p>
-
 <h2 id="구문">구문</h2>
 
 <pre class="syntaxbox">new Intl.NumberFormat([<var>locales</var>[, <var>options</var>]])

--- a/files/ko/web/javascript/reference/global_objects/math/sinh/index.html
+++ b/files/ko/web/javascript/reference/global_objects/math/sinh/index.html
@@ -11,8 +11,6 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Math/sinh
 
 <div>{{EmbedInteractiveExample("pages/js/math-sinh.html")}}</div>
 
-<p class="hidden">이 대화식 예제의 소스는 GitHub Repository에 저장됩니다. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</p>
-
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="syntaxbox"><code>Math.sinh(<var>x</var>)</code></pre>

--- a/files/ko/web/javascript/reference/global_objects/math/sqrt1_2/index.html
+++ b/files/ko/web/javascript/reference/global_objects/math/sqrt1_2/index.html
@@ -11,8 +11,6 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Math/SQRT1_2
 
 <div>{{EmbedInteractiveExample("pages/js/math-sqrt1_2.html", "shorter")}}</div>
 
-<p class="hidden">이 상호적인 예시의 소스는 깃헙에 저장되어 있습니다. 만약 상호적인 예시 프로젝트에 기여하고 싶으시다면, <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>를 클론한 후, 풀 리퀘스트를 보내주시기 바랍니다.</p>
-
 <div>{{js_property_attributes(0, 0, 0)}}</div>
 
 <h2 id="설명">설명</h2>

--- a/files/ko/web/javascript/reference/global_objects/number/isnan/index.html
+++ b/files/ko/web/javascript/reference/global_objects/number/isnan/index.html
@@ -15,8 +15,6 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Number/isNaN
 
 <div>{{EmbedInteractiveExample("pages/js/number-isnan.html", "taller")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
-
 <h2 id="구문">구문</h2>
 
 <pre class="syntaxbox">Number.isNaN(v<var>alue</var>)</pre>

--- a/files/ko/web/javascript/reference/global_objects/object/assign/index.html
+++ b/files/ko/web/javascript/reference/global_objects/object/assign/index.html
@@ -19,10 +19,6 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Object/assign
 
 <p>{{EmbedInteractiveExample("pages/js/object-assign.html")}}</p>
 
-<div class="hidden">
-<p>The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</p>
-</div>
-
 <h2 id="구문">구문</h2>
 
 <pre class="syntaxbox">Object.assign(<var>target</var>, ...<var>sources</var>)</pre>

--- a/files/ko/web/javascript/reference/global_objects/object/values/index.html
+++ b/files/ko/web/javascript/reference/global_objects/object/values/index.html
@@ -9,8 +9,6 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Object/values
 
 <div>{{EmbedInteractiveExample("pages/js/object-values.html")}}</div>
 
-<p class="hidden">샘플 소스는 GitHub에 저장되어 있습니다. 샘플 소스에 대해서 컨트리뷰트하고 싶다면, <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>  프로젝트를 클론하고, 풀 리퀘스트를 보내주세요. </p>
-
 <h2 id="Syntax">Syntax</h2>
 
 <pre class="syntaxbox">Object.values(<var>obj</var>)</pre>

--- a/files/ko/web/javascript/reference/global_objects/promise/all/index.html
+++ b/files/ko/web/javascript/reference/global_objects/promise/all/index.html
@@ -14,8 +14,6 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Promise/all
 
 <div>{{EmbedInteractiveExample("pages/js/promise-all.html")}}</div>
 
-<p class="hidden">해당 예제의 소스 코드는 GitHub 리포지토리에 저장되어 있습니다. 인터랙티브 데모 프로젝트에 기여하고 싶다면 <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> 를 클론하고 pull request를 보내 주세요.</p>
-
 <h2 id="구문">구문</h2>
 
 <pre class="syntaxbox">Promise.all(<var>iterable</var>);

--- a/files/ko/web/javascript/reference/global_objects/promise/index.html
+++ b/files/ko/web/javascript/reference/global_objects/promise/index.html
@@ -107,16 +107,18 @@ myFirstPromise.then((successMessage) =&gt; {
 
 <h3 id="고급_예제">고급 예제</h3>
 
-<div class="hidden">
-<pre class="brush: html notranslate">&lt;button id="btn"&gt;프로미스 만들기!&lt;/button&gt;
-&lt;div id="log"&gt;&lt;/div&gt;</pre>
-</div>
-
 <p>다음의 작은 예제는 <code>Promise</code>의 동작 방식을 보여줍니다. <code>testPromise()</code> 함수는 {{HTMLElement("button")}}을 클릭할 때마다 호출되며, {{domxref("window.setTimeout()")}}을 사용해 1~3초의 무작위 간격 이후 프로미스 횟수(1부터 시작하는 숫자)로 이행하는 프로미스를 생성합니다. <code>Promise()</code> 생성자는 프로미스를 만드는 데 쓰입니다.</p>
 
 <p>프로미스 이행은 {{jsxref("Promise.prototype.then()","p1.then()")}}을 사용하는 이행 콜백 세트를 통해 단순히 로그에 남습니다. 약간의 로그를 통해, 함수의 동기 부분이 비동기적 프로미스의 완료와 어떻게 분리되어 있는지 확인할 수 있습니다.</p>
 
-<pre class="brush: js notranslate">'use strict';
+<h4>HTML</h4>
+
+<pre class="brush: html">&lt;button id="btn"&gt;프로미스 만들기!&lt;/button&gt;
+&lt;div id="log"&gt;&lt;/div&gt;</pre>
+
+<h4>JavaScript</h4>
+
+<pre class="brush: js">'use strict';
 var promiseCount = 0;
 
 function testPromise() {
@@ -159,17 +161,15 @@ function testPromise() {
     log.insertAdjacentHTML('beforeend', thisPromiseCount +
         ') 프로미스 생성 (&lt;small&gt;동기적 코드 종료&lt;/small&gt;)&lt;br/&gt;');
 }
-</pre>
 
-<div class="hidden">
-<pre class="brush: js notranslate">if ("Promise" in window) {
+if ("Promise" in window) {
   var btn = document.getElementById("btn");
   btn.addEventListener("click", testPromise);
 } else {
   log = document.getElementById('log');
   log.innerHTML = "Live example not available as your browser doesn't support the &lt;code&gt;Promise&lt;code&gt; interface.";
-}</pre>
-</div>
+}
+</pre>
 
 <p>이 예제는 버튼을 클릭하면 실행됩니다. <code>Promise</code>를 지원하는 브라우저가 필요합니다. 짧은 시간 안에 버튼을 여러 번 클릭하여, 서로 다른 프로미스가 번갈아 이행되는 것을 볼 수도 있습니다.</p>
 

--- a/files/ko/web/javascript/reference/global_objects/promise/promise/index.html
+++ b/files/ko/web/javascript/reference/global_objects/promise/promise/index.html
@@ -14,8 +14,6 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Promise/Promise
 
 <div>{{EmbedInteractiveExample("pages/js/promise-constructor.html")}}</div>
 
-<p class="hidden">The source for this interactive demo is stored in a GitHub repository. If you'd like to contribute to the interactive demo project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</p>
-
 <h2 id="구문">구문</h2>
 
 <pre class="syntaxbox">new Promise(<var>executor</var>)</pre>

--- a/files/ko/web/javascript/reference/global_objects/promise/race/index.html
+++ b/files/ko/web/javascript/reference/global_objects/promise/race/index.html
@@ -15,8 +15,6 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Promise/race
 
 <div>{{EmbedInteractiveExample("pages/js/promise-race.html")}}</div>
 
-<p class="hidden">해당 예제의 소스 코드는 GitHub 리포지토리에 저장되어 있습니다. 인터랙티브 데모 프로젝트에 기여하고 싶다면 <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> 를 클론하고 pull request를 보내 주세요.</p>
-
 <h2 id="구문">구문</h2>
 
 <pre class="syntaxbox">Promise.race(<em>iterable</em>);</pre>

--- a/files/ko/web/javascript/reference/global_objects/promise/resolve/index.html
+++ b/files/ko/web/javascript/reference/global_objects/promise/resolve/index.html
@@ -19,10 +19,6 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Promise/resolve
 
 <div>{{EmbedInteractiveExample("pages/js/promise-resolve.html")}}</div>
 
-<div class="hidden">
-<p>The source for this interactive demo is stored in a GitHub repository. If you'd like to contribute to the interactive demo project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</p>
-</div>
-
 <h2 id="구문">구문</h2>
 
 <pre class="syntaxbox"><var>Promise.resolve(value)</var>;

--- a/files/ko/web/javascript/reference/global_objects/promise/then/index.html
+++ b/files/ko/web/javascript/reference/global_objects/promise/then/index.html
@@ -15,8 +15,6 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Promise/then
 
 <div>{{EmbedInteractiveExample("pages/js/promise-then.html")}}</div>
 
-<p class="hidden">해당 예제의 소스 코드는 GitHub 리포지토리에 저장되어 있습니다. 인터랙티브 데모 프로젝트에 기여하고 싶다면 <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> 를 클론하고 pull request를 보내 주세요.</p>
-
 <div class="note">
 <p>매개변수 중 하나 이상을 생략했거나 함수가 아닌 값을 전달한 경우, <code>then</code>은 핸들러가 없는 것이 되지만 오류를 발생하지는 않습니다. <code>then</code> 바로 이전의 <code>Promise</code>가 <code>then</code>에 핸들러가 없는 상태로 완료(이행이나 거부)했을 경우, 추가 핸들러가 없는 <code>Promise</code>가 생성되며, 원래 <code>Promise</code>의 마지막 상태를 그대로 물려받습니다.</p>
 </div>

--- a/files/ko/web/javascript/reference/global_objects/sharedarraybuffer/index.html
+++ b/files/ko/web/javascript/reference/global_objects/sharedarraybuffer/index.html
@@ -19,10 +19,6 @@ translation_of: Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer
 
 <p>{{EmbedInteractiveExample("pages/js/sharedarraybuffer-constructor.html")}}</p>
 
-<div class="hidden">
-<p>The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</p>
-</div>
-
 <h2 id="구문">구문</h2>
 
 <pre class="syntaxbox">new SharedArrayBuffer(length)

--- a/files/ko/web/javascript/reference/global_objects/string/startswith/index.html
+++ b/files/ko/web/javascript/reference/global_objects/string/startswith/index.html
@@ -31,7 +31,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/String/startsWith
 
 <p>문자열이 검색 문자열로 시작하면 <code>true</code>, 아니면 <code>false</code>.</p>
 
-<h2 id="설명"><span class="hidden"> </span><span class="hidden"> </span>설명</h2>
+<h2 id="설명">설명</h2>
 
 <p><code>startsWith</code> 메소드로 어떤 문자열이 다른 문자열로 시작하는지 확인 할 수 있습니다. 대소문자를 구분합니다.</p>
 

--- a/files/ko/web/javascript/reference/global_objects/undefined/index.html
+++ b/files/ko/web/javascript/reference/global_objects/undefined/index.html
@@ -14,8 +14,6 @@ translation_of: Web/JavaScript/Reference/Global_Objects/undefined
 
 <div>{{EmbedInteractiveExample("pages/js/globalprops-undefined.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
-
 <h2 id="구문">구문</h2>
 
 <pre class="syntaxbox notranslate">undefined</pre>

--- a/files/ko/web/javascript/reference/operators/equality/index.html
+++ b/files/ko/web/javascript/reference/operators/equality/index.html
@@ -9,8 +9,6 @@ translation_of: Web/JavaScript/Reference/Operators/Equality
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-equality.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
-
 <h2 id="문법">문법</h2>
 
 <pre class="syntaxbox notranslate">x == y

--- a/files/ko/web/javascript/reference/operators/nullish_coalescing_operator/index.html
+++ b/files/ko/web/javascript/reference/operators/nullish_coalescing_operator/index.html
@@ -13,9 +13,6 @@ translation_of: Web/JavaScript/Reference/Operators/Nullish_coalescing_operator
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-nullishcoalescingoperator.html")}}</div>
 
-<p class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.<br>
- 이 예제의 추가는 <a href="https://github.com/mdn/interactive-examples/pull/1482#issuecomment-553841750">PR #1482</a>를 참조해라.</p>
-
 <h2 id="문법">문법</h2>
 
 <pre class="syntaxbox notranslate"><var>leftExpr</var> ?? <var>rightExpr</var>

--- a/files/ko/web/javascript/reference/operators/object_initializer/index.html
+++ b/files/ko/web/javascript/reference/operators/object_initializer/index.html
@@ -21,10 +21,6 @@ translation_of: Web/JavaScript/Reference/Operators/Object_initializer
 
 <p>{{EmbedInteractiveExample("pages/js/expressions-objectinitializer.html", "taller")}}</p>
 
-<div class="hidden">
-<p>The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</p>
-</div>
-
 <h2 id="구문">구문</h2>
 
 <pre class="brush: js notranslate">var o = {};

--- a/files/ko/web/javascript/reference/operators/optional_chaining/index.html
+++ b/files/ko/web/javascript/reference/operators/optional_chaining/index.html
@@ -13,10 +13,6 @@ translation_of: Web/JavaScript/Reference/Operators/Optional_chaining
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-optionalchainingoperator.html")}}</div>
 
-<div></div>
-
-<p class="hidden">이 대화식 예제의 소스는 GitHub repository에 저장된다. 만약 너가 대화식 예제 프로젝트에 기여하려면, <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>를 복제(clone)하고 풀 리퀘스트를 보내라.</p>
-
 <h2 id="문법">문법</h2>
 
 <pre class="syntaxbox"><var>obj</var>?.<var>prop</var>

--- a/files/ko/web/javascript/reference/operators/typeof/index.html
+++ b/files/ko/web/javascript/reference/operators/typeof/index.html
@@ -14,8 +14,6 @@ translation_of: Web/JavaScript/Reference/Operators/typeof
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-typeof.html")}}</div>
 
-<p class="hidden">이 예제 소스는 GitHub repository에 존재합니다. 만약 이 예제에 기여하고 싶다면 <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>를 클론해서 pull request를 보내주세요.</p>
-
 <h2 id="구문">구문</h2>
 
 <p><code>typeof</code> 연산자는 피연산자 앞에 위치합니다.</p>

--- a/files/ko/web/javascript/reference/statements/async_function/index.html
+++ b/files/ko/web/javascript/reference/statements/async_function/index.html
@@ -13,15 +13,9 @@ translation_of: Web/JavaScript/Reference/Statements/async_function
 
 <p><code><strong>async function</strong></code> 선언은 {{jsxref("Global_Objects/AsyncFunction","AsyncFunction")}}객체를 반환하는 하나의 비동기 함수를 정의합니다. 비동기 함수는 이벤트 루프를 통해 비동기적으로 작동하는 함수로, 암시적으로 {{jsxref("Promise")}}를 사용하여 결과를 반환합니다. 그러나 비동기 함수를 사용하는 코드의 구문과 구조는, 표준 동기 함수를 사용하는것과 많이 비슷합니다.</p>
 
-<div class="noinclude">
 <p>또한 {{jsxref("Operators/async_function", "async function expression", "", 1)}}을 사용해서 async function을 선언할 수 있습니다.</p>
-</div>
 
 <div>{{EmbedInteractiveExample("pages/js/statement-async.html", "taller")}}</div>
-
-<div class="hidden">
-<p>이 데모에 대한 소스가 여기에 있다. 기여하고싶다면 다음의 주소에서 Clone하고 pull request하라 : <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a></p>
-</div>
 
 <h2 id="Syntax">Syntax</h2>
 

--- a/files/ko/web/javascript/reference/statements/class/index.html
+++ b/files/ko/web/javascript/reference/statements/class/index.html
@@ -16,11 +16,7 @@ translation_of: Web/JavaScript/Reference/Statements/class
 
 <div>{{EmbedInteractiveExample("pages/js/statement-class.html")}}</div>
 
-
-
-<div class="noinclude">
 <p>{{jsxref("Operators/class", "클래스 표현", "", 1)}}을 사용하여 클래스를 정의할 수도 있습니다. 표현식과 달리 선언문으로는 같은 클래스를 다시 선언하면 오류가 발생합니다.</p>
-</div>
 
 <h2 id="구문">구문</h2>
 

--- a/files/ko/web/javascript/reference/statements/do...while/index.html
+++ b/files/ko/web/javascript/reference/statements/do...while/index.html
@@ -13,8 +13,6 @@ translation_of: Web/JavaScript/Reference/Statements/do...while
 
 <div>{{EmbedInteractiveExample("pages/js/statement-dowhile.html")}}</div>
 
-<div class="hidden">이 예제의 소스는 GitHub 저장소에 저장됩니다. 만약 이 프로젝트에 기여하고 싶으시다면, <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> 를 복사하고 저희에게 pull request 를 보내주십시오.</div>
-
 <h2 id="문법">문법</h2>
 
 <pre class="syntaxbox notranslate">do<em>구문</em>

--- a/files/ko/web/javascript/reference/statements/if...else/index.html
+++ b/files/ko/web/javascript/reference/statements/if...else/index.html
@@ -13,8 +13,6 @@ translation_of: Web/JavaScript/Reference/Statements/if...else
 
 <div>{{EmbedInteractiveExample("pages/js/statement-ifelse.html")}}</div>
 
-<div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
-
 <h2 id="구문">구문</h2>
 
 <pre class="syntaxbox">if (<em>condition</em>)


### PR DESCRIPTION
mdn/content#3755 와 같습니다.

`class="noinclude"` 제거와 더불어 mdn/content#3718 과 동일한 변경점도 포함합니다. 그 외에는 설령 매크로가 고장난 상태더라도 수정하지 않았습니다.