### PR TITLE
 [ja] fix: typo of global_objects date index

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/date/index.html
+++ b/files/ja/web/javascript/reference/global_objects/date/index.html
@@ -17,7 +17,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Date
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary">JavaScript の <strong><code>Date</code></strong> オブジェクトは、単一の瞬間の時刻をプラットフォームに依存しない形式で表します。</span> <code>Date</code> オブジェクトは協定世界時 (UTC) の1970年1月1日からの経過ミリ秒数を表現する <code>Number</code> 含んでいます。</p>
+<p><span class="seoSummary">JavaScript の <strong><code>Date</code></strong> オブジェクトは、単一の瞬間の時刻をプラットフォームに依存しない形式で表します。</span> <code>Date</code> オブジェクトは協定世界時 (UTC) の1970年1月1日からの経過ミリ秒数を表現する <code>Number</code> の値を含んでいます。</p>
 
 <h2 id="Description" name="Description">解説</h2>
 


### PR DESCRIPTION
# What was wrong/why is this fix needed? (quick summary only)
以前 #1508 でマージされた変更と同じですが，その後[こちらのコミット](https://github.com/mdn/translated-content/commit/abbf5910d201761681df167db2523f140ec39de2)で取り消されてしまったので再度PRを提出いたします

# Issue number (if there is an associated issue)
no issue
