### PR TITLE
remove all 'cke_pastebin' mentions

### DIFF
--- a/files/de/web/api/keyboardevent/keycode/index.html
+++ b/files/de/web/api/keyboardevent/keycode/index.html
@@ -3181,5 +3181,3 @@ translation_of: Web/API/KeyboardEvent/keyCode
 <p>Starting Gecko 21 (and older than 15), OEM specific key values are available on the keyCode attribute only on Windows. So they are not useful for usual web applications. They are useful only for intranet applications or in similar situations.</p>
 
 <p>See "<a href="http://msdn.microsoft.com/en-us/library/aa452679.aspx" title="http://msdn.microsoft.com/en-us/library/aa452679.aspx">Manufacturer-specific Virtual-Key Codes (Windows CE 5.0)</a>" in MSDN for the detail.</p>
-
-<div id="cke_pastebin" style="position: absolute; top: 1308.5px; width: 1px; height: 1px; overflow: hidden; left: -1000px;"> </div>

--- a/files/es/web/api/websockets_api/writing_websocket_server/index.html
+++ b/files/es/web/api/websockets_api/writing_websocket_server/index.html
@@ -241,5 +241,3 @@ for (int i = 0; i &lt; encoded.Length; i++) {
 <ul>
  <li><a href="/es/docs/WebSockets/Writing_WebSocket_servers">Escribiendo servidores WebSocket</a></li>
 </ul>
-
-<div id="cke_pastebin" style="position: absolute; top: 2209.23px; width: 1px; height: 1px; overflow: hidden; left: -1000px;"> </div>

--- a/files/fr/web/api/imagedata/data/index.html
+++ b/files/fr/web/api/imagedata/data/index.html
@@ -47,5 +47,3 @@ imagedata.data; // Uint8ClampedArray[40000]
  <li>{{domxref("ImageData.height")}}</li>
  <li>{{domxref("ImageData.width")}}</li>
 </ul>
-
-<div id="cke_pastebin" style="position: absolute; top: 459.5px; width: 1px; height: 1px; overflow: hidden; left: -1000px;"> </div>

--- a/files/fr/web/api/websockets_api/writing_a_websocket_server_in_java/index.html
+++ b/files/fr/web/api/websockets_api/writing_a_websocket_server_in_java/index.html
@@ -215,5 +215,3 @@ for (int i = 0; i &lt; encoded.length; i++) {
 <ul>
  <li><a href="/fr/docs/WebSockets/Writing_WebSocket_servers">Écriture de serveurs WebSocket</a></li>
 </ul>
-
-<div id="cke_pastebin" style="position: absolute; top: 2209.23px; width: 1px; height: 1px; overflow: hidden; left: -1000px;"> </div>

--- a/files/ja/web/api/keyboardevent/keycode/index.html
+++ b/files/ja/web/api/keyboardevent/keycode/index.html
@@ -3175,5 +3175,3 @@ translation_of: Web/API/KeyboardEvent/keyCode
 <p>Starting Gecko 21 (and older than 15), OEM specific key values are available on the keyCode attribute only on Windows. So they are not useful for usual web applications. They are useful only for intranet applications or in similar situations.</p>
 
 <p>See "<a href="http://msdn.microsoft.com/en-us/library/aa452679.aspx" title="http://msdn.microsoft.com/en-us/library/aa452679.aspx">Manufacturer-specific Virtual-Key Codes (Windows CE 5.0)</a>" in MSDN for the detail.</p>
-
-<div id="cke_pastebin"></div>

--- a/files/ja/web/api/websockets_api/writing_a_websocket_server_in_java/index.html
+++ b/files/ja/web/api/websockets_api/writing_a_websocket_server_in_java/index.html
@@ -217,5 +217,3 @@ for (int i = 0; i &lt; encoded.length; i++) {
 <ul>
  <li><a href="/ja/docs/WebSockets-840092-dup/Writing_WebSocket_servers">Writing WebSocket servers</a></li>
 </ul>
-
-<div id="cke_pastebin" style="position: absolute; top: 2209.23px; width: 1px; height: 1px; overflow: hidden; left: -1000px;"> </div>

--- a/files/ja/web/api/websockets_api/writing_websocket_server/index.html
+++ b/files/ja/web/api/websockets_api/writing_websocket_server/index.html
@@ -269,5 +269,3 @@ for (int i = 0; i &lt; encoded.Length; i++) {
 <ul>
  <li><a href="/ja/docs/WebSockets-840092-dup/Writing_WebSocket_servers">Writing WebSocket servers</a></li>
 </ul>
-
-<div id="cke_pastebin" style="position: absolute; top: 2209.23px; width: 1px; height: 1px; overflow: hidden; left: -1000px;"><em> </em></div>

--- a/files/pt-br/web/api/websockets_api/writing_websocket_server/index.html
+++ b/files/pt-br/web/api/websockets_api/writing_websocket_server/index.html
@@ -234,5 +234,3 @@ for (int i = 0; i &lt; encoded.Length; i++) {
 <ul>
  <li><a href="/en-US/docs/WebSockets/Writing_WebSocket_servers">Writing WebSocket servers</a></li>
 </ul>
-
-<div id="cke_pastebin" style="position: absolute; top: 2209.23px; width: 1px; height: 1px; overflow: hidden; left: -1000px;"> </div>

--- a/files/pt-br/web/javascript/reference/global_objects/number/index.html
+++ b/files/pt-br/web/javascript/reference/global_objects/number/index.html
@@ -217,5 +217,3 @@ Number('100a')    // NaN
  <li>{{jsxref("Global_Objects/NaN", "NaN")}}</li>
  <li>O objeto global {{jsxref("Global_Objects/Math", "Math")}}</li>
 </ul>
-
-<div id="cke_pastebin" style="position: absolute; top: 2173.92px; width: 1px; height: 1px; overflow: hidden; left: -1000px;"> </div>

--- a/files/zh-cn/web/api/imagedata/data/index.html
+++ b/files/zh-cn/web/api/imagedata/data/index.html
@@ -91,5 +91,3 @@ imagedata.data; // Uint8ClampedArray[40000]
  <li>{{domxref("ImageData.height")}}</li>
  <li>{{domxref("ImageData.width")}}</li>
 </ul>
-
-<div id="cke_pastebin" style="position: absolute; top: 459.5px; width: 1px; height: 1px; overflow: hidden; left: -1000px;"> </div>

--- a/files/zh-cn/web/api/imagedata/height/index.html
+++ b/files/zh-cn/web/api/imagedata/height/index.html
@@ -90,5 +90,3 @@ imagedata.height; // 100
 <ul>
  <li>{{domxref("ImageData.width")}}</li>
 </ul>
-
-<div id="cke_pastebin" style="position: absolute; top: 459.5px; width: 1px; height: 1px; overflow: hidden; left: -1000px;"> </div>

--- a/files/zh-cn/web/api/imagedata/imagedata/index.html
+++ b/files/zh-cn/web/api/imagedata/imagedata/index.html
@@ -62,5 +62,3 @@ translation_of: Web/API/ImageData/ImageData
 <ul>
  <li>{{domxref("CanvasRenderingContext2D.createImageData()")}}, the creator method that can be used outside workers.</li>
 </ul>
-
-<div id="cke_pastebin" style="position: absolute; top: 459.5px; width: 1px; height: 1px; overflow: hidden; left: -1000px;"></div>

--- a/files/zh-cn/web/api/imagedata/width/index.html
+++ b/files/zh-cn/web/api/imagedata/width/index.html
@@ -90,5 +90,3 @@ imagedata.width // 100
 <ul>
  <li>{{domxref("ImageData.height")}}</li>
 </ul>
-
-<div id="cke_pastebin" style="position: absolute; top: 459.5px; width: 1px; height: 1px; overflow: hidden; left: -1000px;"> </div>

--- a/files/zh-cn/web/api/keyboardevent/keycode/index.html
+++ b/files/zh-cn/web/api/keyboardevent/keycode/index.html
@@ -3216,5 +3216,3 @@ translation_of: Web/API/KeyboardEvent/keyCode
 <p>从gecko 21（并且早于15）开始，仅在Windows上的keycode属性上提供OEM特定的键值。因此，它们对于通常的Web应用程序不有用。它们仅对内部网应用程序或类似情况有用。</p>
 
 <p>查看MSDN上的"<a href="http://msdn.microsoft.com/en-us/library/aa452679.aspx" title="http://msdn.microsoft.com/en-us/library/aa452679.aspx">Manufacturer-specific Virtual-Key Codes (Windows CE 5.0)</a>"了解更多</p>
-
-<div id="cke_pastebin" style="position: absolute; top: 1308.5px; width: 1px; height: 1px; overflow: hidden; left: -1000px;"></div>

--- a/files/zh-cn/web/api/path2d/path2d/index.html
+++ b/files/zh-cn/web/api/path2d/path2d/index.html
@@ -220,5 +220,3 @@ window.addEventListener("load", drawCanvas);
 <ul>
  <li>{{domxref("Path2D")}}, 这个构造函数属于此接口。</li>
 </ul>
-
-<div id="cke_pastebin" style="position: absolute; top: 459.5px; width: 1px; height: 1px; overflow: hidden; left: -1000px;"> </div>

--- a/files/zh-cn/web/api/websockets_api/writing_a_websocket_server_in_java/index.html
+++ b/files/zh-cn/web/api/websockets_api/writing_a_websocket_server_in_java/index.html
@@ -197,5 +197,3 @@ public class WebSocket {
 <ul>
  <li><a href="/zh-CN/docs/WebSockets/Writing_WebSocket_servers">Writing WebSocket servers</a></li>
 </ul>
-
-<div id="cke_pastebin" style="position: absolute; top: 2209.23px; width: 1px; height: 1px; overflow: hidden; left: -1000px;"></div>

--- a/files/zh-cn/web/api/websockets_api/writing_websocket_server/index.html
+++ b/files/zh-cn/web/api/websockets_api/writing_websocket_server/index.html
@@ -269,5 +269,3 @@ for (int i = 0; i &lt; encoded.Length; i++) {
 <ul>
  <li><a href="/en-US/docs/WebSockets/Writing_WebSocket_servers">编写 WebSocket 服务器</a></li>
 </ul>
-
-<div id="cke_pastebin" style="position: absolute; top: 2209.23px; width: 1px; height: 1px; overflow: hidden; left: -1000px;"><em> </em></div>

--- a/files/zh-cn/web/javascript/typed_arrays/index.html
+++ b/files/zh-cn/web/javascript/typed_arrays/index.html
@@ -168,5 +168,3 @@ normalArray.constructor === Array;</pre>
  <li><a href="http://www.html5rocks.com/en/tutorials/webgl/typed_arrays">Typed Arrays: Binary Data in the Browser</a></li>
  <li>{{Glossary("Endianness")}}</li>
 </ul>
-
-<div id="cke_pastebin" style="position: absolute; top: 617.817px; width: 1px; height: 1px; overflow: hidden; left: -1000px;"> </div>

--- a/files/zh-tw/web/api/canvas_api/tutorial/applying_styles_and_colors/index.html
+++ b/files/zh-tw/web/api/canvas_api/tutorial/applying_styles_and_colors/index.html
@@ -663,5 +663,3 @@ var ptrn = ctx.createPattern(img,'repeat');
 <p>{{EmbedLiveSample("A_shadowed_text_example", "180", "100", "https://mdn.mozillademos.org/files/2505/shadowed-string.png")}}</p>
 
 <p>{{PreviousNext("Web/Guide/HTML/Canvas_tutorial/Using_images", "Web/Guide/HTML/Canvas_tutorial/Transformations")}}</p>
-
-<div id="cke_pastebin" style="position: absolute; top: 12776.2px; width: 1px; height: 1px; overflow: hidden; left: -1000px;"> </div>


### PR DESCRIPTION
No idea what this is about but the "cke" is probably a relic from the distant past when we used "CKEditor" in the Wiki. 