### PR TITLE
[ko] Work done for 'BaseAudioContext' article.

### DIFF
--- a/files/ko/web/api/baseaudiocontext/index.html
+++ b/files/ko/web/api/baseaudiocontext/index.html
@@ -50,7 +50,7 @@ browser-compat: api.BaseAudioContext
 
 <dl>
  <dt>{{domxref("BaseAudioContext.createAnalyser()")}}</dt>
- <dd>오디오 시간과 주파수 데이터를 드러내고 예를 들자면 데이터 시각화를 생성하는 데 사용될 수 있는 {{domxref("AnalyserNode")}}를 생성합니다.</dd>
+ <dd>오디오 시간과 주파수 데이터를 드러내고 데이터 시각화를 생성하는 데 사용될 수 있는 {{domxref("AnalyserNode")}}를 생성합니다.</dd>
  <dt>{{domxref("BaseAudioContext.createBiquadFilter()")}}</dt>
  <dd>high-pass, low-pass, band-pass와 같은 몇몇 다른 흔한 필터 유형으로 설정 가능한 2차 필터를 나타내는 {{domxref("BiquadFilterNode")}}를 생성합니다.</dd>
  <dt>{{domxref("BaseAudioContext.createBuffer()")}}</dt>

--- a/files/ko/web/api/baseaudiocontext/index.html
+++ b/files/ko/web/api/baseaudiocontext/index.html
@@ -46,7 +46,7 @@ browser-compat: api.BaseAudioContext
 
 <h2 id="Methods">메서드</h2>
 
-<p><em>또한 </em>{{domxref("EventTarget")}} 인터페이스로부터의 메서드를 구현합니다.</p>
+<p><em>또한 {{domxref("EventTarget")}} 인터페이스로부터의 메서드를 구현합니다.</em></p>
 
 <dl>
  <dt>{{domxref("BaseAudioContext.createAnalyser()")}}</dt>

--- a/files/ko/web/api/baseaudiocontext/index.html
+++ b/files/ko/web/api/baseaudiocontext/index.html
@@ -64,7 +64,7 @@ browser-compat: api.BaseAudioContext
  <dt>{{domxref("BaseAudioContext.createChannelSplitter()")}}</dt>
  <dd>오디오 스트림의 각 채널에 접근하고 별도로 그것들을 처리하기 위해 사용되는 {{domxref("ChannelSplitterNode")}}를 생성합니다.</dd>
  <dt>{{domxref("BaseAudioContext.createConvolver()")}}</dt>
- <dd>오디오 그래프에 예를 들자면 잔향(reverberation) 효과와 같은 콘볼루션 이펙트를 적용하기 위해 사용될 수 있는 {{domxref("ConvolverNode")}}를 생성합니다.</dd>
+ <dd>오디오 그래프에 잔향(reverberation) 효과와 같은 콘볼루션 이펙트를 적용하기 위해 사용될 수 있는 {{domxref("ConvolverNode")}}를 생성합니다.</dd>
  <dt>{{domxref("BaseAudioContext.createDelay()")}}</dt>
  <dd>들어오는 오디오 시그널을 특정한 양으로 연기하기 위해 사용되는 {{domxref("DelayNode")}}를 생성합니다. 이 노드는 또한 Web Audio API 그래프에서 피드백 루프를 생성하는 데 유용합니다.</dd>
  <dt>{{domxref("BaseAudioContext.createDynamicsCompressor()")}}</dt>

--- a/files/ko/web/api/baseaudiocontext/index.html
+++ b/files/ko/web/api/baseaudiocontext/index.html
@@ -95,7 +95,7 @@ browser-compat: api.BaseAudioContext
 
 <pre class="brush: js">const audioContext = new AudioContext();</pre>
 
-<p>크로스 브라우저를 위한 다른 형태:</p>
+<p>크로스 브라우저를 위한 다른 형태</p>
 
 <pre class="brush: js">const AudioContext = window.AudioContext || window.webkitAudioContext;
 const audioContext = new AudioContext();

--- a/files/ko/web/api/baseaudiocontext/index.html
+++ b/files/ko/web/api/baseaudiocontext/index.html
@@ -91,7 +91,7 @@ browser-compat: api.BaseAudioContext
 
 <h2 id="Examples">예제</h2>
 
-<p>기본적인 오디오 컨텍스트 선언:</p>
+<p>기본적인 오디오 컨텍스트 선언</p>
 
 <pre class="brush: js">const audioContext = new AudioContext();</pre>
 

--- a/files/ko/web/api/baseaudiocontext/index.html
+++ b/files/ko/web/api/baseaudiocontext/index.html
@@ -68,7 +68,7 @@ browser-compat: api.BaseAudioContext
  <dt>{{domxref("BaseAudioContext.createDelay()")}}</dt>
  <dd>들어오는 오디오 신호를 지연시키기 위해 사용되는 {{domxref("DelayNode")}}를 생성합니다. 이 노드는 Web Audio API 그래프에서 피드백 루프를 생성하는 데 유용합니다.</dd>
  <dt>{{domxref("BaseAudioContext.createDynamicsCompressor()")}}</dt>
- <dd>음향 압축(acoustic compression)을 오디오 시그널에 적용하기 위해 사용될 수 있는 {{domxref("DynamicsCompressorNode")}}를 생성합니다.</dd>
+ <dd>음향 압축(acoustic compression)을 오디오 신호에 적용하기 위해 사용될 수 있는 {{domxref("DynamicsCompressorNode")}}를 생성합니다.</dd>
  <dt>{{domxref("BaseAudioContext.createGain()")}}</dt>
  <dd>오디오 그래프의 전반적인 볼륨을 제어하기 위해 사용될 수 있는 {{domxref("GainNode")}}를 생성합니다.</dd>
  <dt>{{domxref("BaseAudioContext.createIIRFilter()")}}</dt>

--- a/files/ko/web/api/baseaudiocontext/index.html
+++ b/files/ko/web/api/baseaudiocontext/index.html
@@ -66,7 +66,7 @@ browser-compat: api.BaseAudioContext
  <dt>{{domxref("BaseAudioContext.createConvolver()")}}</dt>
  <dd>오디오 그래프에 잔향(reverberation) 효과와 같은 콘볼루션 이펙트를 적용하기 위해 사용될 수 있는 {{domxref("ConvolverNode")}}를 생성합니다.</dd>
  <dt>{{domxref("BaseAudioContext.createDelay()")}}</dt>
- <dd>들어오는 오디오 시그널을 특정한 양으로 연기하기 위해 사용되는 {{domxref("DelayNode")}}를 생성합니다. 이 노드는 또한 Web Audio API 그래프에서 피드백 루프를 생성하는 데 유용합니다.</dd>
+ <dd>들어오는 오디오 신호를 지연시키기 위해 사용되는 {{domxref("DelayNode")}}를 생성합니다. 이 노드는 Web Audio API 그래프에서 피드백 루프를 생성하는 데 유용합니다.</dd>
  <dt>{{domxref("BaseAudioContext.createDynamicsCompressor()")}}</dt>
  <dd>음향 압축(acoustic compression)을 오디오 시그널에 적용하기 위해 사용될 수 있는 {{domxref("DynamicsCompressorNode")}}를 생성합니다.</dd>
  <dt>{{domxref("BaseAudioContext.createGain()")}}</dt>

--- a/files/ko/web/api/baseaudiocontext/index.html
+++ b/files/ko/web/api/baseaudiocontext/index.html
@@ -14,7 +14,7 @@ browser-compat: api.BaseAudioContext
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
-<p class="summary"><span class="seoSummary"><a href="/ko/docs/Web/API/Web_Audio_API">Web Audio API</a>의 <code>BaseAudioContext</code> 인터페이스는, 각각 {{domxref("AudioContext")}} 와 {{domxref("OfflineAudioContext")}}에 의해 표현되는, 온라인과 오프라인 오디오 프로세싱 그래프에 대한 기본 정의로 작동합니다. <code>BaseAudioContext</code>는 직접적으로 사용될 수 없습니다 — 이 두 가지 상속되는 인터페이스 중 하나를 통해 이것의 기능들을 사용할 수 있습니다.</p>
+<p class="summary"><span class="seoSummary"><a href="/ko/docs/Web/API/Web_Audio_API">Web Audio API</a>의 <code>BaseAudioContext</code> 인터페이스는 {{domxref("AudioContext")}} 와 {{domxref("OfflineAudioContext")}}에 의해 표현되는 온라인과 오프라인 오디오 프로세싱 그래프에 대한 기본 정의로 작동합니다. <code>BaseAudioContext</code>는 직접적으로 사용될 수 없습니다. 대신 위에서 언급한 두 상속 인터페이스를 통해 <code>BaseAudioContext</code>의 기능을 사용할 수 있습니다.</p>
 
 <p><code>BaseAudioContext</code>는 이벤트의 타겟이 될 수 있는데, 따라서 이것은 {{domxref("EventTarget")}} 인터페이스를 구현합니다.</p>
 

--- a/files/ko/web/api/baseaudiocontext/index.html
+++ b/files/ko/web/api/baseaudiocontext/index.html
@@ -58,7 +58,7 @@ browser-compat: api.BaseAudioContext
  <dt>{{domxref("BaseAudioContext.createBufferSource()")}}</dt>
  <dd>{{ domxref("AudioBuffer") }} 객체 내부에 포함된 오디오 데이터를 재생하거나 조작하기 위해 사용될 수 있는 {{domxref("AudioBufferSourceNode")}}를 생성합니다. {{ domxref("AudioBuffer") }}들은 {{domxref("BaseAudioContext/createBuffer", "AudioContext.createBuffer()")}}를 사용해 생성되거나 성공적으로 오디오 트랙을 디코드했을 때 {{domxref("BaseAudioContext/decodeAudioData", "AudioContext.decodeAudioData()")}}에 의해 반환됩니다.</dd>
  <dt>{{domxref("BaseAudioContext.createConstantSource()")}}</dt>
- <dd>샘플이 모두 같은 값을 가지고 있는 모노럴의(한 채널의) 사운드 시그널을 계속적으로 출력하는 오디오 소스인 {{domxref("ConstantSourceNode")}} 객체를 생성합니다.</dd>
+ <dd>샘플이 모두 같은 값을 가지고 있는 모노럴의(한 채널의) 사운드 신호를 계속적으로 출력하는 오디오 소스인 {{domxref("ConstantSourceNode")}} 객체를 생성합니다.</dd>
  <dt>{{domxref("BaseAudioContext.createChannelMerger()")}}</dt>
  <dd>다수의 오디오 스트림으로부터 하나의 오디오 스트림에 채널을 결합하기 위해 사용되는 {{domxref("ChannelMergerNode")}}를 생성합니다.</dd>
  <dt>{{domxref("BaseAudioContext.createChannelSplitter()")}}</dt>

--- a/files/ko/web/api/baseaudiocontext/index.html
+++ b/files/ko/web/api/baseaudiocontext/index.html
@@ -1,0 +1,122 @@
+---
+title: BaseAudioContext
+slug: Web/API/BaseAudioContext
+tags:
+  - API
+  - Audio
+  - BaseAudioContext
+  - Context
+  - Interface
+  - Reference
+  - Web Audio API
+  - sound
+browser-compat: api.BaseAudioContext
+---
+<div>{{APIRef("Web Audio API")}}</div>
+
+<p class="summary"><span class="seoSummary"><a href="/ko/docs/Web/API/Web_Audio_API">Web Audio API</a>의 <code>BaseAudioContext</code> 인터페이스는, 각각 {{domxref("AudioContext")}} 와 {{domxref("OfflineAudioContext")}}에 의해 표현되는, 온라인과 오프라인 오디오 프로세싱 그래프에 대한 기본 정의로 작동합니다. <code>BaseAudioContext</code>는 직접적으로 사용될 수 없습니다 — 이 두 가지 상속되는 인터페이스 중 하나를 통해 이것의 기능들을 사용할 수 있습니다.</p>
+
+<p><code>BaseAudioContext</code>는 이벤트의 타겟이 될 수 있는데, 따라서 이것은 {{domxref("EventTarget")}} 인터페이스를 구현합니다.</p>
+
+<p>{{InheritanceDiagram}}</p>
+
+<h2 id="Properties">속성</h2>
+
+<dl>
+ <dt>{{domxref("BaseAudioContext.audioWorklet")}} {{experimental_inline}} {{readonlyInline}} {{securecontext_inline}}</dt>
+ <dd>{{domxref("AudioWorklet")}} 객체를 반환하는데, 이는 {{domxref("AudioWorkletProcessor")}} 인터페이스를 구현하는 JavaScript 코드가 오디오 데이터를 처리하기 위해 백그라운드에서 실행되는 {{domxref("AudioNode")}}들을 생성하고 관리하는 데 쓰일 수 있습니다.</dd>
+ <dt>{{domxref("BaseAudioContext.currentTime")}} {{readonlyInline}}</dt>
+ <dd>스케쥴링에 사용되는 초 단위로 계속 증가하는 하드웨어 시간을 나타내는 double을 반환합니다. 이는 <code>0</code>에서 시작합니다.</dd>
+ <dt>{{domxref("BaseAudioContext.destination")}} {{readonlyInline}}</dt>
+ <dd>컨텍스트 내의 모든 오디오의 최종 도착지를 나타내는 {{domxref("AudioDestinationNode")}}를 반환합니다. 이것은 오디오를 렌더링하는 장치로 생각될 수 있습니다.</dd>
+ <dt>{{domxref("BaseAudioContext.listener")}} {{readonlyInline}}</dt>
+ <dd>3D 공간화에 사용되는 {{domxref("AudioListener")}} 객체를 반환합니다.</dd>
+ <dt>{{domxref("BaseAudioContext.sampleRate")}} {{readonlyInline}}</dt>
+ <dd>이 컨텍스트 내의 모든 노드에 의해 사용되는 샘플 레이트(초당 샘플)를 나타내는 float을 반환합니다. {{domxref("AudioContext")}}의 샘플 레이트는 변경될 수 없습니다.</dd>
+ <dt>{{domxref("BaseAudioContext.state")}} {{readonlyInline}}</dt>
+ <dd><code>AudioContext</code>의 현재 상태를 반환합니다.</dd>
+</dl>
+
+<h3 id="Event_handlers">이벤트 처리기</h3>
+
+<dl>
+ <dt>{{domxref("BaseAudioContext.onstatechange")}}</dt>
+ <dd>{{event("statechange")}} 유형의 이벤트가 발생되었을 때 실행되는 이벤트 처리기입니다. 이것은 상태 변화 메서드({{domxref("AudioContext.suspend")}}, {{domxref("AudioContext.resume")}}, 또는 {{domxref("AudioContext.close")}}) 중 하나의 호출에 기인해 <code>AudioContext</code>의 상태가 변경되었을 때 발생됩니다.</dd>
+</dl>
+
+<h2 id="Methods">메서드</h2>
+
+<p><em>또한 </em>{{domxref("EventTarget")}} 인터페이스로부터의 메서드를 구현합니다.</p>
+
+<dl>
+ <dt>{{domxref("BaseAudioContext.createAnalyser()")}}</dt>
+ <dd>오디오 시간과 주파수 데이터를 드러내고 예를 들자면 데이터 시각화를 생성하는 데 사용될 수 있는 {{domxref("AnalyserNode")}}를 생성합니다.</dd>
+ <dt>{{domxref("BaseAudioContext.createBiquadFilter()")}}</dt>
+ <dd>high-pass, low-pass, band-pass와 같은 몇몇 다른 흔한 필터 유형으로 설정 가능한 2차 필터를 나타내는 {{domxref("BiquadFilterNode")}}를 생성합니다.</dd>
+ <dt>{{domxref("BaseAudioContext.createBuffer()")}}</dt>
+ <dd>데이터를 넣거나 {{ domxref("AudioBufferSourceNode") }}를 통해 재생될 수 있는 새로운 빈 {{ domxref("AudioBuffer") }} 객체를 생성합니다.</dd>
+ <dt>{{domxref("BaseAudioContext.createBufferSource()")}}</dt>
+ <dd>{{ domxref("AudioBuffer") }} 객체 내부에 포함된 오디오 데이터를 재생하거나 조작하기 위해 사용될 수 있는 {{domxref("AudioBufferSourceNode")}}를 생성합니다. {{ domxref("AudioBuffer") }}들은 {{domxref("BaseAudioContext/createBuffer", "AudioContext.createBuffer()")}}를 사용해 생성되거나 성공적으로 오디오 트랙을 디코드했을 때 {{domxref("BaseAudioContext/decodeAudioData", "AudioContext.decodeAudioData()")}}에 의해 반환됩니다.</dd>
+ <dt>{{domxref("BaseAudioContext.createConstantSource()")}}</dt>
+ <dd>샘플이 모두 같은 값을 가지고 있는 모노럴의(한 채널의) 사운드 시그널을 계속적으로 출력하는 오디오 소스인 {{domxref("ConstantSourceNode")}} 객체를 생성합니다.</dd>
+ <dt>{{domxref("BaseAudioContext.createChannelMerger()")}}</dt>
+ <dd>다수의 오디오 스트림으로부터 하나의 오디오 스트림에 채널을 결합하기 위해 사용되는 {{domxref("ChannelMergerNode")}}를 생성합니다.</dd>
+ <dt>{{domxref("BaseAudioContext.createChannelSplitter()")}}</dt>
+ <dd>오디오 스트림의 각 채널에 접근하고 별도로 그것들을 처리하기 위해 사용되는 {{domxref("ChannelSplitterNode")}}를 생성합니다.</dd>
+ <dt>{{domxref("BaseAudioContext.createConvolver()")}}</dt>
+ <dd>오디오 그래프에 예를 들자면 잔향(reverberation) 효과와 같은 콘볼루션 이펙트를 적용하기 위해 사용될 수 있는 {{domxref("ConvolverNode")}}를 생성합니다.</dd>
+ <dt>{{domxref("BaseAudioContext.createDelay()")}}</dt>
+ <dd>들어오는 오디오 시그널을 특정한 양으로 연기하기 위해 사용되는 {{domxref("DelayNode")}}를 생성합니다. 이 노드는 또한 Web Audio API 그래프에서 피드백 루프를 생성하는 데 유용합니다.</dd>
+ <dt>{{domxref("BaseAudioContext.createDynamicsCompressor()")}}</dt>
+ <dd>음향 압축(acoustic compression)을 오디오 시그널에 적용하기 위해 사용될 수 있는 {{domxref("DynamicsCompressorNode")}}를 생성합니다.</dd>
+ <dt>{{domxref("BaseAudioContext.createGain()")}}</dt>
+ <dd>오디오 그래프의 전반적인 볼륨을 제어하기 위해 사용될 수 있는 {{domxref("GainNode")}}를 생성합니다.</dd>
+ <dt>{{domxref("BaseAudioContext.createIIRFilter()")}}</dt>
+ <dd>몇몇 다른 흔한 필터 유형으로 설정 가능한 2차 필터를 나타내는 {{domxref("IIRFilterNode")}}를 생성합니다.</dd>
+ <dt>{{domxref("BaseAudioContext.createOscillator()")}}</dt>
+ <dd>주기적인 파형을 나타내는 소스인 {{domxref("OscillatorNode")}}를 생성합니다. 이것은 기본적으로 음색을 생성합니다.</dd>
+ <dt>{{domxref("BaseAudioContext.createPanner()")}}</dt>
+ <dd>들어오는 오디오 스트림을 3D 공간에서 공간화하기 위해 사용되는 {{domxref("PannerNode")}}를 생성합니다.</dd>
+ <dt>{{domxref("BaseAudioContext.createPeriodicWave()")}}</dt>
+ <dd>{{ domxref("OscillatorNode") }}의 출력을 결정하기 위해 사용될 수 있는 주기적인 파형을 정의하는 데 쓰이는 {{domxref("PeriodicWave")}}를 생성합니다.</dd>
+ <dt>{{domxref("BaseAudioContext.createScriptProcessor()")}} {{deprecated_inline}}</dt>
+ <dd>JavaScript를 통한 직접적인 오디오 프로세싱을 위해 사용될 수 있는 {{domxref("ScriptProcessorNode")}}를 생성합니다.</dd>
+ <dt>{{domxref("BaseAudioContext.createStereoPanner()")}}</dt>
+ <dd>오디오 소스에 스테레오 패닝을 적용하기 위해 사용될 수 있는 {{domxref("StereoPannerNode")}}를 생성합니다.</dd>
+ <dt>{{domxref("BaseAudioContext.createWaveShaper()")}}</dt>
+ <dd>비선형 변형(non-linear distortion) 효과를 구현하기 위해 사용되는 {{domxref("WaveShaperNode")}}를 생성합니다.</dd>
+ <dt>{{domxref("BaseAudioContext.decodeAudioData()")}}</dt>
+ <dd>비동기적으로 {{domxref("ArrayBuffer")}}에 포함된 오디오 파일 데이터를 디코드합니다. 이 경우, ArrayBuffer는 보통 <code>arraybuffer</code>에 <code>responseType</code>을 설정한 후 {{domxref("XMLHttpRequest")}}의 <code>response</code> 특성으로부터 로딩됩니다. 이 메서드는 오디오 파일의 조각이 아니라, 오직 완전한 파일에서만 작동합니다.</dd>
+</dl>
+
+<h2 id="Examples">예제</h2>
+
+<p>기본적인 오디오 컨텍스트 선언:</p>
+
+<pre class="brush: js">const audioContext = new AudioContext();</pre>
+
+<p>크로스 브라우저를 위한 다른 형태:</p>
+
+<pre class="brush: js">const AudioContext = window.AudioContext || window.webkitAudioContext;
+const audioContext = new AudioContext();
+
+const oscillatorNode = audioContext.createOscillator();
+const gainNode = audioContext.createGain();
+const finish = audioContext.destination;
+</pre>
+
+<h2 id="Specifications">명세</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">브라우저 호환성</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">같이 보기</h2>
+
+<ul>
+ <li><a href="/ko/docs/Web/API/Web_Audio_API/Using_Web_Audio_API">Web Audio API 사용하기</a></li>
+ <li>{{domxref("AudioContext")}}</li>
+ <li>{{domxref("OfflineAudioContext")}}</li>
+</ul>


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext

en-US 문서를 content폴더에서 가져와 전문 번역하였습니다.

※ 본 문서의 일부 내용이 한국어로 번역된 이전 버전의 AudioContext 문서에 포함되어 있었고 이에 따라 기 번역된 내용이 다소 있는 것으로 보여, 작업 중에 기존 번역을 조금 참고하였습니다. (#1627 참조)