### PR TITLE
Fix incorrect colon in the font-display page

### DIFF
--- a/files/zh-cn/web/css/@font-face/font-display/index.html
+++ b/files/zh-cn/web/css/@font-face/font-display/index.html
@@ -29,11 +29,11 @@ translation_of: Web/CSS/@font-face/font-display
 <h2 id="语法">语法</h2>
 
 <pre class="brush: css">/* 关键字值 */
-font-display：auto;
-font-display：block;
-font-display：swap;
-font-display：fallback;
-font-display：optional;</pre>
+font-display: auto;
+font-display: block;
+font-display: swap;
+font-display: fallback;
+font-display: optional;</pre>
 
 <h3 id="属性值">属性值</h3>
 
@@ -57,12 +57,12 @@ font-display：optional;</pre>
 <h2 id="例子">例子</h2>
 
 <pre class="brush: css">@ font-face {
-  font-family：ExampleFont;
-  src：url（/path/to/fonts/examplefont.woff）format（'woff'），
+  font-family: ExampleFont;
+  src: url（/path/to/fonts/examplefont.woff）format（'woff'），
        url（/path/to/fonts/examplefont.eot）format（'eot'）;
-  font-weight：400;
-  font-style：normal;
-  font-display：fallback;
+  font-weight: 400;
+  font-style: normal;
+  font-display: fallback;
 }</pre>
 
 <h2 id="规范">规范</h2>


### PR DESCRIPTION
The colon in the example is incorrect, should fix “：”to“ :” .