### PR TITLE
Web/API/Window/status を更新

### DIFF
--- a/files/ja/web/api/window/status/index.html
+++ b/files/ja/web/api/window/status/index.html
@@ -1,23 +1,30 @@
 ---
-title: window.status
+title: Window.status
 slug: Web/API/Window/status
 tags:
-  - DOM
-  - DOM_0
-  - Gecko
-  - Gecko DOM Reference
+- API
+- HTML DOM
+- NeedsExample
+- NeedsSpecTable
+- Property
+- Reference
+- Window
+browser-compat: api.Window.status
 translation_of: Web/API/Window/status
 ---
-<div>
- {{ApiRef}}</div>
-<h2 id="Summary" name="Summary">概要</h2>
-<p>ブラウザの下部にあるステータスバー内にテキストを設定するか、もしくは、直前に設定されていたテキストを返します。</p>
-<p>このプロパティは、Firefox、及び、いくつかの他のブラウザのデフォルト設定では動作しません。つまり、<code>window.status</code> を設定しても、ステータスバーに表示されているテキストには何の効果もないということです。ステータスバーのテキストを変更するスクリプトを許可するには、ユーザは、<code>about:config</code> 画面で、<code>dom.disable_window_status_change</code> の設定を <code>false</code> にしなければなりません。</p>
-<div class="geckoVersionNote">
- <p>{{gecko_callout_heading("1.9.1")}}</p>
- <p>Starting in Gecko 1.9.1 {{geckoRelease("1.9.1")}}, users can let websites change the status text by enabling the "Change status bar" preference in the Advanced options panel.</p>
- </div>
-<h2 id="Syntax" name="Syntax">構文</h2>
-<pre class="syntaxbox"><var>string</var> =<i>window</i>.status; //取得<i>window</i>.status = <var>string</var>; //設定</pre>
-<h2 id="Specification" name="Specification">仕様</h2>
-<p>{{DOM0}}</p>
+<div>{{APIRef}} {{Deprecated_Header}}</div>
+
+<p><span class="seoSummary"><code><strong>status</strong></code> は {{domxref("Window")}} インターフェイスのプロパティで、もともとブラウザーウィンドウの最下部にあるステータスバーのテキストを設定するためのものでした。しかし、 HTML 標準は <code>window.status</code> に設定してもステータスバーに表示されるテキストには影響させないよう要求しています。</span></p>
+
+<h2 id="Syntax">構文</h2>
+
+<pre
+  class="brush: js"><em>window</em>.status = <em>string</em>; var <em>value = window</em>.status;</pre>
+
+<h2 id="Specifications">仕様書</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">ブラウザーの互換性</h2>
+
+<p>{{Compat}}</p>


### PR DESCRIPTION
- 2021/07/23 時点の英語版に同期
- gecko_callout_heading を削除 (https://github.com/mdn/translated-content/pull/612 の対応)