### PR TITLE
Fix typo in French translation of Breadcrumb glossary entry

### DIFF
--- a/files/fr/glossary/breadcrumb/index.html
+++ b/files/fr/glossary/breadcrumb/index.html
@@ -19,4 +19,4 @@ original_slug: Glossaire/Breadcrumb
 
 <p><a href="/">MDN</a> &gt; <a href="/fr/docs/Glossaire">Glossaire</a> &gt; Breadcrumb</p>
 
-<p>Les fil d'Ariane permettent aux utilisateurs de connaître leur emplacement sur un site Web. Ce type de navigation, s'il est effectué correctement, aide les utilisateurs à savoir où ils se trouvent sur un site et comment ils y sont arrivés. Ils peuvent également aider un utilisateur à revenir là où il était auparavant et réduire le nombre de clics nécessaires pour accéder à une page de niveau supérieur.</p>
+<p>Les fils d'Ariane permettent aux utilisateurs de connaître leur emplacement sur un site Web. Ce type de navigation, s'il est effectué correctement, aide les utilisateurs à savoir où ils se trouvent sur un site et comment ils y sont arrivés. Ils peuvent également aider un utilisateur à revenir là où il était auparavant et réduire le nombre de clics nécessaires pour accéder à une page de niveau supérieur.</p>


### PR DESCRIPTION
This PR fixes a small typo in the French translation of "Breadcrumb" glossary entry.
"Les fil d'ariane" => "Les fils d'ariane"