### PR TITLE
Fix a small typo in the French version of the "Breadcrumb_Navigation" layout cookbook entry

### DIFF
--- a/files/fr/web/css/layout_cookbook/breadcrumb_navigation/index.html
+++ b/files/fr/web/css/layout_cookbook/breadcrumb_navigation/index.html
@@ -9,7 +9,7 @@ original_slug: Web/CSS/Layout_cookbook/Navigation_Breadcrumb
 ---
 <div>{{CSSRef}}</div>
 
-<p class="summary">La navigation avec un fil d'Ariane (<em>breadcrumb</em>) permet à un utilisateur de comprendre l'emplacement auquel il se trouve au sein du site web en fournissant un fil d'Ariane qui permette de revenir à la page de départ.</p>
+<p class="summary">La navigation avec un fil d'Ariane (<em>breadcrumb</em>) permet à un utilisateur de comprendre l'emplacement auquel il se trouve au sein du site web en fournissant un fil d'Ariane permettant de revenir à la page de départ.</p>
 
 <p><img alt="Links displayed inline with separators" src="https://mdn.mozillademos.org/files/16228/breadcrumb-navigation.png" style="height: 108px; width: 1268px;"></p>
 


### PR DESCRIPTION
This PR fixes a small typo in the French version of the "Breadcrumb_Navigation" layout cookbook entry.
Before: "[…] en fournissant un fil d'Ariane qui permette de revenir à la page de départ"
After: "[…] en fournissant un fil d'Ariane permettant de revenir à la page de départ"