### PR TITLE
correcting label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -21,7 +21,7 @@ l10n-ko:
 l10n-pl:
   - files/pl/**/*
 
-l10n-pr-br:
+l10n-pt-br:
   - files/pt-br/**/*
 
 l10n-ru:


### PR DESCRIPTION
Auto label assigns `pr-br` instead of `pt-br` which this fixes