### PR TITLE
null is different than 0

### DIFF
--- a/files/fr/web/api/formdata/get/index.html
+++ b/files/fr/web/api/formdata/get/index.html
@@ -32,7 +32,7 @@ translation_of: Web/API/FormData/get
 
 <h3 id="Valeur_retournée">Valeur retournée</h3>
 
-<p>Un {{domxref("FormDataEntryValue")}} contenant la valeur. Si la clé n'existe pas, la méthode renvoie zéro.</p>
+<p>Un {{domxref("FormDataEntryValue")}} contenant la valeur. Si la clé n'existe pas, la méthode renvoie null.</p>
 
 <h2 id="Exemple">Exemple</h2>
 


### PR DESCRIPTION
Si la clé n'existe pas, la méthode renvoie null pas 0. Ceci est bien visible dans https://developer.mozilla.org/en-US/docs/Web/API/FormData/get