### PR TITLE
PR test should build based on possible index.md too

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: technote-space/get-diff-action@v4.2
         id: git_diff_content
         with:
-          PATTERNS: files/**/*.html
+          PATTERNS: files/**/*.+(html|md)
           SET_ENV_NAME: GIT_DIFF_CONTENT
 
       - name: Build changed content


### PR DESCRIPTION
`pr-test.yml` for translated-content is based on that for mdn/content, which [has a fix already for possible `index.md` files](https://github.com/mdn/content/blob/a4edee7f6efb876d94912b4853d44ab61b0b3b80/.github/workflows/pr-test.yml#L61)