### PR TITLE
French translation for `accent-color` CSS property reference

### DIFF
--- a/files/fr/web/css/accent-color/index.html
+++ b/files/fr/web/css/accent-color/index.html
@@ -12,7 +12,7 @@ tags:
 - accent-color
 - 'recipe:css-property'
 browser-compat: css.properties.accent-color
-translation_of: Web/CSS/actual_value
+translation_of: Web/CSS/accent-color
 ---
 <div>{{CSSRef}}{{SeeCompatTable}}</div>
 

--- a/files/fr/web/css/accent-color/index.html
+++ b/files/fr/web/css/accent-color/index.html
@@ -6,7 +6,7 @@ translation_of: Web/CSS/accent-color
 ---
 <div>{{CSSRef}}{{SeeCompatTable}}</div>
 
-<p>La propriété <a href="/fr/docs/Web/CSS">CSS</a> <strong><code>accent-color</code></strong> définit la couleur d'accentuation ({{Glossary("accent")}}) des éléments. Une accentuation est présent sur des éléments HTML tels que des {{HTMLElement("input")}} de type <code><a href="/fr/docs/Web/HTML/Element/input/checkbox">checkbox</a></code> ou <code><a href="/fr/docs/Web/HTML/Element/input/radio">radio</a></code>.</p>
+<p>La propriété <a href="/fr/docs/Web/CSS">CSS</a> <strong><code>accent-color</code></strong> définit la couleur d'accentuation ({{Glossary("accent")}}) des éléments. Une accentuation est présente sur des éléments HTML tels que des {{HTMLElement("input")}} de type <code><a href="/fr/docs/Web/HTML/Element/input/checkbox">checkbox</a></code> ou <code><a href="/fr/docs/Web/HTML/Element/input/radio">radio</a></code>.</p>
 
 <h2 id="Syntax">Syntaxe</h2>
 

--- a/files/fr/web/css/accent-color/index.html
+++ b/files/fr/web/css/accent-color/index.html
@@ -1,0 +1,98 @@
+---
+title: accent-color
+slug: Web/CSS/accent-color
+tags:
+- CSS
+- CSS Property
+- CSS User Interface
+- HTML Colors
+- Input
+- Reference
+- Styling HTML
+- accent-color
+- 'recipe:css-property'
+browser-compat: css.properties.accent-color
+translation_of: Web/CSS/actual_value
+---
+<div>{{CSSRef}}{{SeeCompatTable}}</div>
+
+<p>La propriété <a href="/fr/docs/Web/CSS">CSS</a> <strong><code>accent-color</code></strong> définit la couleur d’accentuation ({{Glossary("accent")}}) des éléments. Une accentuation est présent sur des éléments HTML tels que des {{HTMLElement("input")}} de type <code><a href="/fr/docs/Web/HTML/Element/input/checkbox">checkbox</a></code> ou <code><a href="/fr/docs/Web/HTML/Element/input/radio">radio</a></code>.</p>
+
+<h2 id="Syntax">Syntaxe</h2>
+
+<pre class="brush: css no-line-numbers">/* Valeurs avec un mot-clé */
+accent-color: auto;
+
+/* Valeurs de &lt;color&gt; */
+accent-color: red;
+accent-color: #5729e9;
+accent-color: rgb(0, 200, 0);
+accent-color: hsl(228, 4%, 24%);
+
+/* Valeurs globales */
+accent-color: inherit;
+accent-color: initial;
+accent-color: revert;
+accent-color: unset;</pre>
+
+<h3 id="Values">Valeurs</h3>
+
+<dl>
+  <dt><code>auto</code></dt>
+  <dd>Représente une couleur déterminée par l’agent utilisateur, qui devrait correspondre à la couleur d’accentuation de la plateforme, s’il y en a une.
+  </dd>
+  <dt>{{cssxref("&lt;color&gt;")}}</dt>
+  <dd>Spécifie la couleur à utiliser en tant que couleur d’accentuation.</dd>
+</dl>
+
+<h2 id="Formal_definition">Définition formelle</h2>
+
+<p>{{cssinfo}}</p>
+
+<h2 id="Formal_syntax">Syntaxe formelle</h2>
+
+{{csssyntax}}
+
+<h2 id="Examples">Exemples</h2>
+
+<h3 id="Setting_a_custom_accent_color">Définir une couleur d’accentuation personnalisée</h3>
+
+<h4 id="HTML">HTML</h4>
+
+<pre class="brush: html">&lt;input type="checkbox" checked /&gt;
+&lt;input type="checkbox" class="custom" checked /&gt;</pre>
+
+<h4 id="CSS">CSS</h4>
+
+<pre class="brush: css">input {
+  accent-color: auto;
+  display: block;
+  width: 30px;
+  height: 30px;
+}
+
+input.custom {
+  accent-color: rebeccapurple;
+}
+</pre>
+
+<h4 id="Result">Résultat</h4>
+
+<p>{{EmbedLiveSample('Setting_a_custom_accent_color', 500, 200)}}</p>
+
+<h2 id="Specifications">Spécifications</h2>
+
+{{Specifications}}
+
+<h2 id="Browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">Voir aussi</h2>
+
+<ul>
+  <li>L’élément {{HTMLElement("input")}}</li>
+  <li><a href="/fr/docs/Web/HTML/Applying_color">Appliquer des couleurs aux éléments HTML grâce à CSS</a></li>
+  <li>Le type de donnée {{cssxref("&lt;color&gt;")}}</li>
+  <li>Les autres propriétés relatives aux couleurs : {{cssxref("color")}}, {{cssxref("background-color")}}, {{cssxref("border-color")}}, {{cssxref("outline-color")}}, {{cssxref("text-decoration-color")}}, {{cssxref("text-emphasis-color")}}, {{cssxref("text-shadow")}}, {{cssxref("caret-color")}} et {{cssxref("column-rule-color")}}</li>
+</ul>

--- a/files/fr/web/css/accent-color/index.html
+++ b/files/fr/web/css/accent-color/index.html
@@ -1,22 +1,12 @@
 ---
 title: accent-color
 slug: Web/CSS/accent-color
-tags:
-- CSS
-- CSS Property
-- CSS User Interface
-- HTML Colors
-- Input
-- Reference
-- Styling HTML
-- accent-color
-- 'recipe:css-property'
 browser-compat: css.properties.accent-color
 translation_of: Web/CSS/accent-color
 ---
 <div>{{CSSRef}}{{SeeCompatTable}}</div>
 
-<p>La propriété <a href="/fr/docs/Web/CSS">CSS</a> <strong><code>accent-color</code></strong> définit la couleur d’accentuation ({{Glossary("accent")}}) des éléments. Une accentuation est présent sur des éléments HTML tels que des {{HTMLElement("input")}} de type <code><a href="/fr/docs/Web/HTML/Element/input/checkbox">checkbox</a></code> ou <code><a href="/fr/docs/Web/HTML/Element/input/radio">radio</a></code>.</p>
+<p>La propriété <a href="/fr/docs/Web/CSS">CSS</a> <strong><code>accent-color</code></strong> définit la couleur d'accentuation ({{Glossary("accent")}}) des éléments. Une accentuation est présent sur des éléments HTML tels que des {{HTMLElement("input")}} de type <code><a href="/fr/docs/Web/HTML/Element/input/checkbox">checkbox</a></code> ou <code><a href="/fr/docs/Web/HTML/Element/input/radio">radio</a></code>.</p>
 
 <h2 id="Syntax">Syntaxe</h2>
 
@@ -39,10 +29,10 @@ accent-color: unset;</pre>
 
 <dl>
   <dt><code>auto</code></dt>
-  <dd>Représente une couleur déterminée par l’agent utilisateur, qui devrait correspondre à la couleur d’accentuation de la plateforme, s’il y en a une.
+  <dd>Représente une couleur déterminée par l'agent utilisateur, qui devrait correspondre à la couleur d'accentuation de la plateforme, s'il y en a une.
   </dd>
   <dt>{{cssxref("&lt;color&gt;")}}</dt>
-  <dd>Spécifie la couleur à utiliser en tant que couleur d’accentuation.</dd>
+  <dd>Spécifie la couleur à utiliser en tant que couleur d'accentuation.</dd>
 </dl>
 
 <h2 id="Formal_definition">Définition formelle</h2>
@@ -51,11 +41,11 @@ accent-color: unset;</pre>
 
 <h2 id="Formal_syntax">Syntaxe formelle</h2>
 
-{{csssyntax}}
+<p>{{csssyntax}}</p>
 
 <h2 id="Examples">Exemples</h2>
 
-<h3 id="Setting_a_custom_accent_color">Définir une couleur d’accentuation personnalisée</h3>
+<h3 id="Setting_a_custom_accent_color">Définir une couleur d'accentuation personnalisée</h3>
 
 <h4 id="HTML">HTML</h4>
 
@@ -82,7 +72,7 @@ input.custom {
 
 <h2 id="Specifications">Spécifications</h2>
 
-{{Specifications}}
+<p>{{Specifications}}</p>
 
 <h2 id="Browser_compatibility">Compatibilité des navigateurs</h2>
 
@@ -91,7 +81,7 @@ input.custom {
 <h2 id="See_also">Voir aussi</h2>
 
 <ul>
-  <li>L’élément {{HTMLElement("input")}}</li>
+  <li>L'élément {{HTMLElement("input")}}</li>
   <li><a href="/fr/docs/Web/HTML/Applying_color">Appliquer des couleurs aux éléments HTML grâce à CSS</a></li>
   <li>Le type de donnée {{cssxref("&lt;color&gt;")}}</li>
   <li>Les autres propriétés relatives aux couleurs : {{cssxref("color")}}, {{cssxref("background-color")}}, {{cssxref("border-color")}}, {{cssxref("outline-color")}}, {{cssxref("text-decoration-color")}}, {{cssxref("text-emphasis-color")}}, {{cssxref("text-shadow")}}, {{cssxref("caret-color")}} et {{cssxref("column-rule-color")}}</li>


### PR DESCRIPTION
This PR aims to create a French translation for `accent-color` CSS property reference.