### PR TITLE
remove link 'title' attributes that's just the 'href' (ja)

### DIFF
--- a/files/ja/learn/forms/how_to_build_custom_form_controls/index.html
+++ b/files/ja/learn/forms/how_to_build_custom_form_controls/index.html
@@ -97,12 +97,12 @@ original_slug: Learn/Forms/How_to_build_custom_form_widgets
 
 <p>一般的に、新しい操作を設計するのは、標準を作成するに十分なリーチを持った、とても大きな産業プレイヤーだけの選択肢です。例えば、Apple は 2001年に iPod にスクロールホイールを導入しました。完全に新しい操作方法のデバイスを導入するのに成功するマーケットシェアがありましたが、たいていのデバイス会社はそうはいきません。</p>
 
-<p>新しいユーザーインタラクションを発明しないのがベストです。インタラクションを追加する場合、設計段階で時間を使うのが重要です。動作の定義が貧弱であったり定義もれがあったりした場合、いったんユーザーが使い始めると動作を再定義するのが非常に困難になると思われますので、設計段階に時間をかけることは賢明です。もし疑っているのでしたら、他の人に意見を聞きましょう。また予算を持っているのでしたら、<a href="http://en.wikipedia.org/wiki/Usability_testing" rel="external" title="http://en.wikipedia.org/wiki/Usability_testing">ユーザーテストの実施</a>をためらってはいけません。このプロセスは、UX デザインと呼ばれます。この点について詳しく学びたいのでしたら、以下の役に立つリソースをご覧になるとよいでしょう:</p>
+<p>新しいユーザーインタラクションを発明しないのがベストです。インタラクションを追加する場合、設計段階で時間を使うのが重要です。動作の定義が貧弱であったり定義もれがあったりした場合、いったんユーザーが使い始めると動作を再定義するのが非常に困難になると思われますので、設計段階に時間をかけることは賢明です。もし疑っているのでしたら、他の人に意見を聞きましょう。また予算を持っているのでしたら、<a href="http://en.wikipedia.org/wiki/Usability_testing" rel="external">ユーザーテストの実施</a>をためらってはいけません。このプロセスは、UX デザインと呼ばれます。この点について詳しく学びたいのでしたら、以下の役に立つリソースをご覧になるとよいでしょう:</p>
 
 <ul>
- <li><a href="http://www.uxmatters.com/" rel="external" title="http://www.uxmatters.com/">UXMatters.com</a></li>
- <li><a href="http://uxdesign.com/" rel="external" title="http://uxdesign.com/">UXDesign.com</a></li>
- <li><a href="http://uxdesign.smashingmagazine.com/" rel="external" title="http://uxdesign.smashingmagazine.com/">The UX Design section of SmashingMagazine</a></li>
+ <li><a href="http://www.uxmatters.com/" rel="external">UXMatters.com</a></li>
+ <li><a href="http://uxdesign.com/" rel="external">UXDesign.com</a></li>
+ <li><a href="http://uxdesign.smashingmagazine.com/" rel="external">The UX Design section of SmashingMagazine</a></li>
 </ul>
 
 <div class="note">
@@ -338,7 +338,7 @@ original_slug: Learn/Forms/How_to_build_custom_form_widgets
  <li>スクリプトが読み込まれません。これはよくあるケースのひとつであり、特にネットワークの信頼性が低いモバイル環境で発生します。</li>
  <li>スクリプトに不具合があります。この可能性は常に考慮すべきです。</li>
  <li>スクリプトがサードパーティのスクリプトと競合しています。これは、トラッキングのスクリプトやユーザーが使用するブックマークレットとの間で発生する可能性があります。</li>
- <li>スクリプトがブラウザーの拡張機能 (Firefox の <a href="https://addons.mozilla.org/fr/firefox/addon/noscript/" rel="external" title="https://addons.mozilla.org/fr/firefox/addon/noscript/">NoScript</a> 拡張機能や Chrome の <a href="https://chrome.google.com/webstore/detail/notscripts/odjhifogjcknibkahlpidmdajjpkkcfn" rel="external" title="https://chrome.google.com/webstore/detail/notscripts/odjhifogjcknibkahlpidmdajjpkkcfn">NotScripts</a> 拡張機能など) と競合したり、拡張機能の影響を受けたりしています。</li>
+ <li>スクリプトがブラウザーの拡張機能 (Firefox の <a href="https://addons.mozilla.org/fr/firefox/addon/noscript/" rel="external" title="https://addons.mozilla.org/fr/firefox/addon/noscript/">NoScript</a> 拡張機能や Chrome の <a href="https://chrome.google.com/webstore/detail/notscripts/odjhifogjcknibkahlpidmdajjpkkcfn" rel="external">NotScripts</a> 拡張機能など) と競合したり、拡張機能の影響を受けたりしています。</li>
  <li>ユーザーが古いブラウザーを使用しており、必要な機能のいずれかがサポートされていません。これは、最先端の API を使用するときに頻繁に発生します。</li>
  <li>ユーザーは JavaScript が完全にダウンロード、解析、実行される前にコンテンツを操作します。</li>
 </ul>
@@ -757,7 +757,7 @@ window.addEventListener('load', function () {
 
 <p>スクリーンリーダーにオフスクリーンselectに焦点をあてて他のスタイルを無視するようにした法が簡単に見えますが、これはアクセシブルな解決策ではありません。スクリーンリーダーは盲目の人だけのものではありません。低視力や、完全な視力の人もこれを使います。このため、スクリーンリーダーをオフスクリーン要素だけに焦点をあてるようにはできません。</p>
 
-<p>以下がこれらの変更を施した最終結果です (<a href="http://www.nvda-project.org/" rel="external" title="http://www.nvda-project.org/">NVDA</a> や <a href="http://www.apple.com/accessibility/voiceover/" rel="external" title="http://www.apple.com/accessibility/voiceover/">VoiceOver</a> などの支援技術でコントロールを使用してみても、よい感触を得られるでしょう):</p>
+<p>以下がこれらの変更を施した最終結果です (<a href="http://www.nvda-project.org/" rel="external">NVDA</a> や <a href="http://www.apple.com/accessibility/voiceover/" rel="external" title="http://www.apple.com/accessibility/voiceover/">VoiceOver</a> などの支援技術でコントロールを使用してみても、よい感触を得られるでしょう):</p>
 
 <table>
  <thead>
@@ -865,10 +865,10 @@ window.addEventListener('load', function () {
 <p>自分でコーディングする前に検討するとよいライブラリをいくつか紹介します:</p>
 
 <ul>
- <li><a href="http://jqueryui.com/" rel="external" title="http://jqueryui.com/">jQuery UI</a></li>
+ <li><a href="http://jqueryui.com/" rel="external">jQuery UI</a></li>
  <li><a href="https://www.webaxe.org/accessible-custom-select-dropdowns">AXE accessible custom select dropdowns</a></li>
- <li><a href="https://github.com/marghoobsuleman/ms-Dropdown" rel="external" title="https://github.com/marghoobsuleman/ms-Dropdown">msDropDown</a></li>
- <li><a href="http://www.emblematiq.com/lab/niceforms/" rel="external" title="http://www.emblematiq.com/lab/niceforms/">Nice Forms</a></li>
+ <li><a href="https://github.com/marghoobsuleman/ms-Dropdown" rel="external">msDropDown</a></li>
+ <li><a href="http://www.emblematiq.com/lab/niceforms/" rel="external">Nice Forms</a></li>
 </ul>
 
 <p>ラジオボタン、独自JavaScript 、またはサードパーティライブラリで代替コントロールを作る場合、アクセシブルかつ機能への耐性を高めましょう。すなわち Web 標準の実装状況がまちまちである、多様なブラウザーで良好に動作できるようにすることが必要です。楽しんでください!</p>

--- a/files/ja/learn/forms/how_to_structure_a_web_form/index.html
+++ b/files/ja/learn/forms/how_to_structure_a_web_form/index.html
@@ -51,7 +51,7 @@ original_slug: Learn/Forms/How_to_structure_an_HTML_form
 
 <p>{{HTMLElement("fieldset")}} 要素は、スタイルや意味付けのために、同じ目的を持つウィジェットのグループの作成に便利です。{{HTMLElement("fieldset")}} 要素は、<code>&lt;fieldset&gt;</code> タグのすぐ下に {{HTMLElement("legend")}} 要素を入れてラベルを付与できます。{{HTMLElement("legend")}} 要素は、{{HTMLElement("fieldset")}} 要素の目的を正式に説明します。</p>
 
-<p>多くの支援技術は {{HTMLElement("legend")}} 要素を、対応する {{HTMLElement("fieldset")}} 要素内にある各ウィジェットのラベルの一部であるかのように扱うでしょう。例えば <a href="http://www.freedomscientific.com/products/fs/jaws-product-page.asp" rel="external" title="http://www.freedomscientific.com/products/fs/jaws-product-page.asp">Jaws</a> や <a href="http://www.nvda-project.org/" rel="external" title="http://www.nvda-project.org/">NVDA</a> といったスクリーンリーダーは、各ウィジェットのラベルを読み上げる前に legend の内容を読み上げます。</p>
+<p>多くの支援技術は {{HTMLElement("legend")}} 要素を、対応する {{HTMLElement("fieldset")}} 要素内にある各ウィジェットのラベルの一部であるかのように扱うでしょう。例えば <a href="http://www.freedomscientific.com/products/fs/jaws-product-page.asp" rel="external" title="http://www.freedomscientific.com/products/fs/jaws-product-page.asp">Jaws</a> や <a href="http://www.nvda-project.org/" rel="external">NVDA</a> といったスクリーンリーダーは、各ウィジェットのラベルを読み上げる前に legend の内容を読み上げます。</p>
 
 <p>以下に小さなサンプルを挙げます:</p>
 

--- a/files/ja/learn/forms/html_forms_in_legacy_browsers/index.html
+++ b/files/ja/learn/forms/html_forms_in_legacy_browsers/index.html
@@ -159,7 +159,7 @@ input[type="button"] {
 
 <h3 id="The_Modernizr_library">Modernizr ライブラリー</h3>
 
-<p>欠けている API を提供することで、すばらしい "ポリフィル" が大きな助けになるケースが多数あります。<a href="https://remysharp.com/2010/10/08/what-is-a-polyfill/" rel="external" title="http://remysharp.com/2010/10/08/what-is-a-polyfill/">ポリフィル</a>は、古いブラウザにおける機能性の "穴を埋める" 小さな JavaScript コードです。ポリフィルは任意の機能のサポート状況を改善するために使用できますが、JavaScript 向けに使用するのは CSS や HTML 向けより低リスクです。JavaScript が動作しない可能性は多数あります(ネットワークの問題、スクリプトの競合 など)。しかし JavaScript については、控えめな JavaScript を念頭に置いて取り組む場合はポリフィルが欠けたとしても、重大な問題にはなりません。</p>
+<p>欠けている API を提供することで、すばらしい "ポリフィル" が大きな助けになるケースが多数あります。<a href="https://remysharp.com/2010/10/08/what-is-a-polyfill/" rel="external">ポリフィル</a>は、古いブラウザにおける機能性の "穴を埋める" 小さな JavaScript コードです。ポリフィルは任意の機能のサポート状況を改善するために使用できますが、JavaScript 向けに使用するのは CSS や HTML 向けより低リスクです。JavaScript が動作しない可能性は多数あります(ネットワークの問題、スクリプトの競合 など)。しかし JavaScript については、控えめな JavaScript を念頭に置いて取り組む場合はポリフィルが欠けたとしても、重大な問題にはなりません。</p>
 
 <p>欠けている API に対してポリフィルを適用する最善の方法は、<a href="https://modernizr.com" rel="external">Modernizr</a> ライブラリー、およびそこからスピンオフしたプロジェクトである <a href="https://yepnopejs.com" rel="external">YepNope</a> を使用することです。Modernizr は、機能が利用できるかを確認して適宜対応を行えるようにするためのライブラリーです。YepNope は、条件付きで読み込みを行うライブラリーです。</p>
 

--- a/files/ja/learn/forms/your_first_form/index.html
+++ b/files/ja/learn/forms/your_first_form/index.html
@@ -51,8 +51,8 @@ translation_of: Learn/Forms/Your_first_form
 <p>フォームの設計は、サイトやアプリケーションを構築する際の大事なステップです。フォームのユーザー体験まで扱うと本記事の対象を超えてしまいますが、そこまで踏み込みたい場合は以下の記事をご覧ください。</p>
 
 <ul>
- <li>Smashing Magazine に<a href="http://uxdesign.smashingmagazine.com/tag/forms/" rel="external" title="http://uxdesign.smashingmagazine.com/tag/forms/">フォームの UX に関するよい記事</a>がありますが、もっとも重要な記事は <a href="http://uxdesign.smashingmagazine.com/2011/11/08/extensive-guide-web-form-usability/" rel="external" title="http://uxdesign.smashingmagazine.com/2011/11/08/extensive-guide-web-form-usability/">Extensive Guide To Web Form Usability</a> でしょう。</li>
- <li>UXMatters もまた、<a href="http://www.uxmatters.com/mt/archives/2010/03/pagination-in-web-forms-evaluating-the-effectiveness-of-web-forms.php" title="http://www.uxmatters.com/mt/archives/2010/03/pagination-in-web-forms-evaluating-the-effectiveness-of-web-forms.php">複数ページのフォーム</a>といった複雑なことへの<a href="http://www.uxmatters.com/mt/archives/2012/05/7-basic-best-practices-for-buttons.php" rel="external" title="http://www.uxmatters.com/mt/archives/2012/05/7-basic-best-practices-for-buttons.php">基本的なベストプラクティス</a>から良いアドバイスを得られる、思慮深いリソースです。</li>
+ <li>Smashing Magazine に<a href="http://uxdesign.smashingmagazine.com/tag/forms/" rel="external" title="http://uxdesign.smashingmagazine.com/tag/forms/">フォームの UX に関するよい記事</a>がありますが、もっとも重要な記事は <a href="http://uxdesign.smashingmagazine.com/2011/11/08/extensive-guide-web-form-usability/" rel="external">Extensive Guide To Web Form Usability</a> でしょう。</li>
+ <li>UXMatters もまた、<a href="http://www.uxmatters.com/mt/archives/2010/03/pagination-in-web-forms-evaluating-the-effectiveness-of-web-forms.php" title="http://www.uxmatters.com/mt/archives/2010/03/pagination-in-web-forms-evaluating-the-effectiveness-of-web-forms.php">複数ページのフォーム</a>といった複雑なことへの<a href="http://www.uxmatters.com/mt/archives/2012/05/7-basic-best-practices-for-buttons.php" rel="external">基本的なベストプラクティス</a>から良いアドバイスを得られる、思慮深いリソースです。</li>
 </ul>
 
 <p>本記事では、シンプルな連絡フォームを作成します。簡単に図を描いてみましょう。</p>

--- a/files/ja/mozilla/firefox/releases/11/index.html
+++ b/files/ja/mozilla/firefox/releases/11/index.html
@@ -86,7 +86,7 @@ translation_of: Mozilla/Firefox/Releases/11
 <p>以下のインタフェースは、不要になったため削除されました:</p>
 <ul>
   <li>{{ interface("nsICharsetResolver") }}</li>
-  <li>{{ interface("nsIDOMNSElement") }}、詳しくは <a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=707576" title="https://bugzilla.mozilla.org/show_bug.cgi?id=707576">bug707576</a> をご覧いただき、代わりに {{ interface("nsIDOMElement") }} を使用してください。</li>
+  <li>{{ interface("nsIDOMNSElement") }}、詳しくは <a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=707576">bug707576</a> をご覧いただき、代わりに {{ interface("nsIDOMElement") }} を使用してください。</li>
 </ul>
 <h3 id="テーマに関する変更">テーマに関する変更</h3>
 <ul>

--- a/files/ja/mozilla/firefox/releases/13/index.html
+++ b/files/ja/mozilla/firefox/releases/13/index.html
@@ -72,7 +72,7 @@ translation_of: Mozilla/Firefox/Releases/13
 
 <ul>
  <li>{{ MathMLElement("mtable") }} 要素で <code>width</code> 属性をサポートしました ({{ bug("722880") }})。</li>
- <li>数学的なテキストで <a class="external" href="http://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/otf/" rel="external" title="http://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/otf/">MathJax fonts</a> をデフォルトフォントとして使用するようになりました。詳しくは <a href="/en/Mozilla_MathML_Project/Fonts" title="Fonts for Mozilla's MathML engine">Fonts for Mozilla's MathML engine</a> をご覧ください。</li>
+ <li>数学的なテキストで <a class="external" href="http://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/otf/" rel="external">MathJax fonts</a> をデフォルトフォントとして使用するようになりました。詳しくは <a href="/en/Mozilla_MathML_Project/Fonts" title="Fonts for Mozilla's MathML engine">Fonts for Mozilla's MathML engine</a> をご覧ください。</li>
 </ul>
 
 <h3 id="Developer_tools">Developer tools</h3>

--- a/files/ja/mozilla/firefox/releases/14/index.html
+++ b/files/ja/mozilla/firefox/releases/14/index.html
@@ -38,7 +38,7 @@ translation_of: Mozilla/Firefox/Releases/14
 <h3 id="CSS">CSS</h3>
 
 <ul>
- <li>{{ cssxref("text-transform") }} と {{ cssxref("font-variant") }} CSS プロパティが <code>i</code> → <code>İ</code> および <code>ı</code> → <code>I </code>という <a class="external" href="http://en.wikipedia.org/wiki/Turkic_languages" title="http://en.wikipedia.org/wiki/Turkic_languages">テュルク諸語</a> (<a class="external" href="http://ja.wikipedia.org/wiki/%E3%83%86%E3%83%A5%E3%83%AB%E3%82%AF%E8%AB%B8%E8%AA%9E" title="http://ja.wikipedia.org/wiki/%E3%83%86%E3%83%A5%E3%83%AB%E3%82%AF%E8%AB%B8%E8%AA%9E">日本語版</a>) 固有の文字対応の組を正しく扱うように修正されました。</li>
+ <li>{{ cssxref("text-transform") }} と {{ cssxref("font-variant") }} CSS プロパティが <code>i</code> → <code>İ</code> および <code>ı</code> → <code>I </code>という <a class="external" href="http://en.wikipedia.org/wiki/Turkic_languages">テュルク諸語</a> (<a class="external" href="http://ja.wikipedia.org/wiki/%E3%83%86%E3%83%A5%E3%83%AB%E3%82%AF%E8%AB%B8%E8%AA%9E" title="http://ja.wikipedia.org/wiki/%E3%83%86%E3%83%A5%E3%83%AB%E3%82%AF%E8%AB%B8%E8%AA%9E">日本語版</a>) 固有の文字対応の組を正しく扱うように修正されました。</li>
  <li>オランダ語の IJ という連字が <code>text-transform: capitalization<code> </code></code>で正しく扱われるようになりました。類似のものとして、ギリシャ文字の <code>Σ</code> には、2つの小文字 <code>σ</code> と <code>ς</code> がありますが、これらが<code> text-transform: lowercase</code> で正しく扱われるようになりました。</li>
  <li>ドラフト標準から削除されたため、<code>skew()</code> 関数のサポートが {{ cssxref("transform") }} プロパティから削除されました。</li>
 </ul>
@@ -74,7 +74,7 @@ translation_of: Mozilla/Firefox/Releases/14
 <h3 class="editable" id="インタフェース"><span>インタフェース</span></h3>
 
 <ul>
- <li>{{ interface("nsILocalFile") }} インタフェースは {{ interface("nsIFile") }} にマージされました。 (<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=682360" title="https://bugzilla.mozilla.org/show_bug.cgi?id=682360">bug 682360</a>).</li>
+ <li>{{ interface("nsILocalFile") }} インタフェースは {{ interface("nsIFile") }} にマージされました。 (<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=682360">bug 682360</a>).</li>
  <li>ブックマークをインポートするための {{ interface("nsIPlacesImportExportService") }} におけるメソッドは <code><a href="/en/JavaScript_code_modules/BookmarkHTMLUtils.jsm" title="en/JavaScript_code_modules/BookmarkHTMLUtils.jsm">BookmarkHTMLUtils.jsm</a></code> JavaScript コードモジュールの利用を促すために削除されました。</li>
  <li>{{ interface("nsIDOMGeoPositionAddress") }} インターフェースは削除されました。</li>
 </ul>
@@ -82,7 +82,7 @@ translation_of: Mozilla/Firefox/Releases/14
 <h3 id="スペルチェック">スペルチェック</h3>
 
 <ul>
- <li>辞書の名前が完全な <a class="external" href="http://tools.ietf.org/html/bcp47" title="http://tools.ietf.org/html/bcp47">BCP 47</a> 言語タグで解釈されるようになりました (<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=730209" title="https://bugzilla.mozilla.org/show_bug.cgi?id=730209">bug 730209</a>, <a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=741842" title="https://bugzilla.mozilla.org/show_bug.cgi?id=741842">bug 741842</a>)。開発者は辞書名での言語名をハードコーディングしないようにしてください。</li>
+ <li>辞書の名前が完全な <a class="external" href="http://tools.ietf.org/html/bcp47" title="http://tools.ietf.org/html/bcp47">BCP 47</a> 言語タグで解釈されるようになりました (<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=730209" title="https://bugzilla.mozilla.org/show_bug.cgi?id=730209">bug 730209</a>, <a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=741842">bug 741842</a>)。開発者は辞書名での言語名をハードコーディングしないようにしてください。</li>
 </ul>
 
 <h2 id="See_also" name="See_also">関連記事</h2>

--- a/files/ja/mozilla/firefox/releases/15/index.html
+++ b/files/ja/mozilla/firefox/releases/15/index.html
@@ -16,7 +16,7 @@ translation_of: Mozilla/Firefox/Releases/15
 <ul>
  <li>{{HTMLElement("font")}} 要素の <code>size</code> 属性が HTML5 仕様に従って扱われるようになりました。つまり、<code>10</code> より大きい、または、<code>-10</code> より小さい整数はすべて <code>10</code> か <code>-10</code> であるとみなされるようになりました。</li>
  <li><code>&lt;font&gt;</code> 要素の <code>font-weight</code> および <code>point-size</code> 属性のサポートが削除されました。これらは非標準であり、Gecko はそれらをサポートする唯一のレンダリングエンジンでした。</li>
- <li>{{HTMLElement("audio")}} および {{HTMLElement("video")}} 要素のための Ogg コンテナで音声向けの <a class="external" href="http://www.opus-codec.org/" title="http://www.opus-codec.org/">Opus コーデック</a> がサポートされました。</li>
+ <li>{{HTMLElement("audio")}} および {{HTMLElement("video")}} 要素のための Ogg コンテナで音声向けの <a class="external" href="http://www.opus-codec.org/">Opus コーデック</a> がサポートされました。</li>
  <li>{{HTMLElement("source")}} 要素で <code>media</code> 属性がサポートされました。</li>
  <li>{{HTMLElement("audio")}} および {{HTMLElement("video")}} 要素で <code>played</code> 属性がサポートされました。この属性の値はこれまで再生したメディアの時間を一覧化した {{domxref("TimeRanges")}} オブジェクトです。</li>
 </ul>
@@ -34,15 +34,15 @@ translation_of: Mozilla/Firefox/Releases/15
 <h3 id="DOM">DOM</h3>
 
 <ul>
- <li>DOM Events Level 3 のメソッドであり、<code>Ctrl</code> <code><code>や</code> Shift </code>のような、モディファイアキーの状態を調べることができる、<a href="/ja/docs/DOM/KeyboardEvent#getModifierState%28%29" title="https://developer.mozilla.org/ja/docs/DOM/KeyboardEvent#getModifierState%28%29"><code>KeyboardEvent.getModifierState()</code></a> と <a href="/ja/docs/DOM/MouseEvent#getModifierState%28%29" title="https://developer.mozilla.org/ja/docs/DOM/MouseEvent#getModifierState%28%29"><code>MouseEvent.getModifierState()</code></a>　が実装されました（bugs <a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=630811" title="https://bugzilla.mozilla.org/show_bug.cgi?id=630811">630811</a> および <a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=731878" title="https://bugzilla.mozilla.org/show_bug.cgi?id=731878">731878</a>）。ただし、その挙動は最新の D3E 草案に従っています。そのため、モディファイアキー名のいくつかが IE と異なります（{{bug("769190")}}）。</li>
+ <li>DOM Events Level 3 のメソッドであり、<code>Ctrl</code> <code><code>や</code> Shift </code>のような、モディファイアキーの状態を調べることができる、<a href="/ja/docs/DOM/KeyboardEvent#getModifierState%28%29" title="https://developer.mozilla.org/ja/docs/DOM/KeyboardEvent#getModifierState%28%29"><code>KeyboardEvent.getModifierState()</code></a> と <a href="/ja/docs/DOM/MouseEvent#getModifierState%28%29" title="https://developer.mozilla.org/ja/docs/DOM/MouseEvent#getModifierState%28%29"><code>MouseEvent.getModifierState()</code></a>　が実装されました（bugs <a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=630811" title="https://bugzilla.mozilla.org/show_bug.cgi?id=630811">630811</a> および <a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=731878">731878</a>）。ただし、その挙動は最新の D3E 草案に従っています。そのため、モディファイアキー名のいくつかが IE と異なります（{{bug("769190")}}）。</li>
  <li>マウスイベントで、<a href="/ja/docs/DOM/MouseEvent" title="DOM/MouseEvent"><code>MouseEvent.buttons</code></a> 属性を用いたマウスボタンの状態を調べるためのサポートが実装されました。</li>
  <li>キーボードイベントで、 <a href="/ja/docs/DOM/KeyboardEvent#Attributes_location" title="https://developer.mozilla.org/ja/docs/DOM/KeyboardEvent#Attributes_location">KeyboardEvent.location</a> 属性を用いたキーの位置（標準、モディファイアキーの左もしくは右、テンキー上）を調べるためのサポートが実装されました（{{bug("166240")}}）。</li>
  <li><code>KeyboardEvent.keycode</code> の結果が Windows/Linux/Mac でほぼ同じであった従来のルールよりも優れたルールから算出されるようになりました。そして、それらは アラビア文字、キリル文字, タイ文字などのような、Linux と Mac での非 ASCII 入力可能レイアウトでも利用可能です。<a href="/ja/docs/DOM/KeyboardEvent#Virtual_key_codes" title="DOM/KeyboardEvent#Virtual_key_codes">仮想キーコードのための文書</a>を参照してください。</li>
  <li><a href="/ja/docs/DOM/range.detach" title="https://developer.mozilla.org/ja/docs/DOM/range.detach"><code>range.detach()</code></a> メソッドは何もしないように変更されました。恐らく、将来的に削除されるでしょう。</li>
- <li><code>HTMLVideoElement.mozHasAudio()<code><code><code> </code></code></code>メソッドが実装されました。与えられた video 要素に関連づけられた音声トラックがあるかどうかを示します（<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=480376" title="https://bugzilla.mozilla.org/show_bug.cgi?id=480376">bug </a><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=480376" title="https://bugzilla.mozilla.org/show_bug.cgi?id=480376">480376</a>）。</code></li>
- <li><code>Performance</code> API に新しいメソッド <code>now()</code> が追加されました。このメソッドは <code>DOMHighResTimeStamp</code> 型の高解像度タイマをサポートします（<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=539095" title="https://bugzilla.mozilla.org/show_bug.cgi?id=539095">bug 539095</a>）。</li>
+ <li><code>HTMLVideoElement.mozHasAudio()<code><code><code> </code></code></code>メソッドが実装されました。与えられた video 要素に関連づけられた音声トラックがあるかどうかを示します（<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=480376">bug </a><a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=480376">480376</a>）。</code></li>
+ <li><code>Performance</code> API に新しいメソッド <code>now()</code> が追加されました。このメソッドは <code>DOMHighResTimeStamp</code> 型の高解像度タイマをサポートします（<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=539095">bug 539095</a>）。</li>
  <li><a href="/ja/docs/API/WebSMS" title="API/WebSMS">WebSMS API</a> が更新され、SMS テキストメッセージが既読か未読かのどちらかを示す <code>read</code> 属性がサポートされました。</li>
- <li><a class="link-https" href="https://wiki.mozilla.org/WebAPI/FileHandleAPI" title="https://wiki.mozilla.org/WebAPI/FileHandleAPI">FileHandle API</a> が実装されました。</li>
+ <li><a class="link-https" href="https://wiki.mozilla.org/WebAPI/FileHandleAPI">FileHandle API</a> が実装されました。</li>
  <li><a href="/ja/docs/DOM/Blob" title="DOM/Blob"><code>Blob</code></a> コンストラクタが <code><var>blobParts</var></code> 引数の値として <code>ArrayBuffer</code> に加えて <code>ArrayBufferView</code> を取れるようになりました。 (<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=752402">bug 752402</a>)</li>
  <li><a href="http://www.w3.org/TR/ambient-light/" title="http://www.w3.org/TR/ambient-light/">Ambient Light Events Working Draft</a> で策定された {{domxref("DeviceLightEvent")}} が実装されました。</li>
  <li>{{domxref("DeviceProximityEvent")}} および {{domxref("UserProximityEvent")}} <a href="http://www.w3.org/TR/proximity/" title="http://www.w3.org/TR/proximity/">Proximity Events</a> が実装されました。</li>
@@ -53,9 +53,9 @@ translation_of: Mozilla/Firefox/Releases/15
 
 <ul>
  <li>Typed Arrays 仕様由来の <a href="/ja/docs/javascript_typed_arrays/DataView" title="JavaScript_typed_arrays/DataView"><code>DataView</code></a> インタフェースのサポートが追加されました。これは <a href="/ja/docs/javascript_typed_arrays/ArrayBuffer" title="JavaScript_typed_arrays/ArrayBuffer"><code>ArrayBuffer</code></a> に含まれるデータへの低レベルアクセスを提供します。</li>
- <li>ECMAScript Harmony の <code>Number.isNaN</code> のサポートが追加されました。(<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=749818" title="https://bugzilla.mozilla.org/show_bug.cgi?id=749818">bug 749818</a>)</li>
- <li>ECMAScript Harmony のデフォルトパラメータが追加されました。 (<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=757676" title="https://bugzilla.mozilla.org/show_bug.cgi?id=757676">bug 757676</a>)</li>
- <li>ECMAScript Harmony のレストパラメータが追加されました。 (<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=574132" title="https://bugzilla.mozilla.org/show_bug.cgi?id=574132">bug 574132</a>)</li>
+ <li>ECMAScript Harmony の <code>Number.isNaN</code> のサポートが追加されました。(<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=749818">bug 749818</a>)</li>
+ <li>ECMAScript Harmony のデフォルトパラメータが追加されました。 (<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=757676">bug 757676</a>)</li>
+ <li>ECMAScript Harmony のレストパラメータが追加されました。 (<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=574132">bug 574132</a>)</li>
 </ul>
 
 <h3 id="WebGL">WebGL</h3>
@@ -67,7 +67,7 @@ translation_of: Mozilla/Firefox/Releases/15
 <h3 id="MathML">MathML</h3>
 
 <ul>
- <li>数学演算記号で {{cssxref("@font-face")}} で指定したダウンローダブルフォントを利用できるようになりました。これにより、<a class="link-https" href="https://addons.mozilla.org/en-US/firefox/addon/mathml-fonts/" title="https://addons.mozilla.org/en-US/firefox/addon/mathml-fonts/">MathML-fonts アドオン</a> で引き伸ばされた演算記号が正常に表示されるようになります。</li>
+ <li>数学演算記号で {{cssxref("@font-face")}} で指定したダウンローダブルフォントを利用できるようになりました。これにより、<a class="link-https" href="https://addons.mozilla.org/en-US/firefox/addon/mathml-fonts/">MathML-fonts アドオン</a> で引き伸ばされた演算記号が正常に表示されるようになります。</li>
  <li>{{MathMLElement("maction")}} の <code>selection</code> 属性が <code>actiontype</code> 属性の値が <code>toggle</code> のときにのみ考慮されるようになりました。</li>
  <li><a class="external" href="http://www.w3.org/TR/MathML3/chapter3.html#id.3.3.4.2.1" title="http://www.w3.org/TR/MathML3/chapter3.html#id.3.3.4.2.1"><span id="summary_alias_container"><span id="short_desc_nonedit_display">非推奨の名前付き空白バインディング</span></span></a> が削除されました（{{bug("673759")}}）。</li>
  <li><a href="/ja/docs/MathML/Attributes/Values" title="Values">Length</a> と {{MathMLElement("mpadded")}} の値でサポートされる構文が MathML3 仕様で指定されたものにより近くなりました。</li>

--- a/files/ja/mozilla/firefox/releases/16/index.html
+++ b/files/ja/mozilla/firefox/releases/16/index.html
@@ -27,15 +27,15 @@ translation_of: Mozilla/Firefox/Releases/16
  <li>標準の、接頭辞無しのバージョンの <a href="/ja/docs/CSS/Using_CSS_Animations" title="/ja/docs/CSS/Using_CSS_Animations">CSS Animations</a> が使えるようになりました。(<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=762302">bug 762302</a>)</li>
  <li>アニメーションの方向の逆転（{{ cssxref("animation-direction") }} プロパティの <code>reverse</code> と <code>alternate-reverse</code> キーワード）のサポートが追加されました。(<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=655920">bug 655920</a>)</li>
  <li>CSS の {{cssxref("height")}} および {{cssxref("width")}} プロパティのアニメーションが可能になりました。</li>
- <li>{{ cssxref("animation-duration") }} および {{ cssxref("transition-duration") }} の CSS プロパティが、負の値を拒絶するようになりました (さらに、そのような値はもはや <code>0s</code> として扱われません)。(<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=773102" title="https://bugzilla.mozilla.org/show_bug.cgi?id=773102">bug 773102</a>)</li>
+ <li>{{ cssxref("animation-duration") }} および {{ cssxref("transition-duration") }} の CSS プロパティが、負の値を拒絶するようになりました (さらに、そのような値はもはや <code>0s</code> として扱われません)。(<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=773102">bug 773102</a>)</li>
  <li>標準の、接頭辞無しのバージョンの <a href="/ja/docs/CSS/Using_CSS_transforms" title="/ja/docs/CSS/Using_CSS_transforms">CSS Transforms</a> が使えるようになりました。(<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=745523">bug 745523</a>)</li>
  <li>標準の、接頭辞無しのバージョンの <a href="/ja/docs/CSS/Using_CSS_gradients" title="/ja/docs/CSS/Using_CSS_gradients">CSS Gradients</a> が使えるようになりました。接頭辞付きのバージョンから構文がかなり変わっていますので、よく学んでおくとよいでしょう。 (<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=752187">bug 752187</a>)</li>
  <li>{{ cssxref("box-sizing", "-moz-box-sizing") }} の実装がテーブルのセルにも適用されるように更新されました。(<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=338554">bug 338554</a>)</li>
- <li>標準の、接頭辞無しの {{ cssxref("calc") }} が使えるようになりました。(<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=771678" title="https://bugzilla.mozilla.org/show_bug.cgi?id=771678">bug 771678</a>)</li>
- <li>{{cssxref("&lt;resolution&gt;")}} CSS データタイプが拡張され、<code>dppx</code> がサポートされるようになりました。(<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=741644" title="https://bugzilla.mozilla.org/show_bug.cgi?id=741644">bug 741644</a>)</li>
- <li>画面上で、<a href="/ja/docs/CSS/Media_queries" title="/ja/docs/CSS/Media_queries">メディアクエリ</a> のために、<code>dppx</code>、<code>dpi</code>、および <code>dpcm</code> が物理単位ではなく、CSS ピクセル単位で再表現されるようになりました。 (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=771390" title="https://bugzilla.mozilla.org/show_bug.cgi?id=771390">bug 771390</a>)</li>
- <li>特定の状態にある {{HTMLElement("meter")}} 要素へのアクセスやスタイル付けを行うため、新たに 3 つの疑似クラス <code>:-moz-meter-optimum</code>、<code>:-moz-meter-sub-optimum</code>、<code>:-moz-meter-sub-sub-optimum</code> を追加しました。(<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=660238" title="https://bugzilla.mozilla.org/show_bug.cgi?id=660238">bug 660238</a>)</li>
- <li>{{cssxref("-moz-appearance")}} プロパティが新たに 2 つの値を取り入れました : <code>meterbar</code> および <code>meterchunk</code>。これらは、{{HTMLElement("meter")}} 要素内部のコンポーネントを表します。(<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=659999" title="https://bugzilla.mozilla.org/show_bug.cgi?id=659999">bug 659999</a>)</li>
+ <li>標準の、接頭辞無しの {{ cssxref("calc") }} が使えるようになりました。(<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=771678">bug 771678</a>)</li>
+ <li>{{cssxref("&lt;resolution&gt;")}} CSS データタイプが拡張され、<code>dppx</code> がサポートされるようになりました。(<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=741644">bug 741644</a>)</li>
+ <li>画面上で、<a href="/ja/docs/CSS/Media_queries" title="/ja/docs/CSS/Media_queries">メディアクエリ</a> のために、<code>dppx</code>、<code>dpi</code>、および <code>dpcm</code> が物理単位ではなく、CSS ピクセル単位で再表現されるようになりました。 (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=771390">bug 771390</a>)</li>
+ <li>特定の状態にある {{HTMLElement("meter")}} 要素へのアクセスやスタイル付けを行うため、新たに 3 つの疑似クラス <code>:-moz-meter-optimum</code>、<code>:-moz-meter-sub-optimum</code>、<code>:-moz-meter-sub-sub-optimum</code> を追加しました。(<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=660238">bug 660238</a>)</li>
+ <li>{{cssxref("-moz-appearance")}} プロパティが新たに 2 つの値を取り入れました : <code>meterbar</code> および <code>meterchunk</code>。これらは、{{HTMLElement("meter")}} 要素内部のコンポーネントを表します。(<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=659999">bug 659999</a>)</li>
  <li>{{cssxref("min-width")}} および {{cssxref("min-height")}} で、flex item のための <code>auto</code> キーワードをサポートしました (他のアイテムでは <code>0</code> と解釈します)。({{bug("763689")}})</li>
 </ul>
 
@@ -48,7 +48,7 @@ translation_of: Mozilla/Firefox/Releases/16
  <li>Vibration API が接頭辞なしになりました。</li>
  <li>現在も接頭辞付きの <code>mozKeyboard</code> である {{domxref("Keyboard")}} インタフェースが、{{domxref("Keyboard.setSelectedOption()")}} および {{domxref("Keyboard.setValue()")}} メソッドと {{domxref("Keyboard.onfocuschange")}} プロパティを持つようになりました。</li>
  <li><code>Window.java</code> および <code>Window.packages</code> 属性を削除しました。これらは文書化されたことがなく、おそらく皆さんは使用していないでしょう!</li>
- <li>{{ domxref("CSSNamespaceRule") }} に結びつけられている <code>CSSRule.type</code> を、<code>UNKNOWN_RULE</code> (<code>0</code>) から <code>NAMESPACE_RULE</code> (<code>10</code>) に更新しました。(<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=765590" title="https://bugzilla.mozilla.org/show_bug.cgi?id=765590">bug 765590</a>)</li>
+ <li>{{ domxref("CSSNamespaceRule") }} に結びつけられている <code>CSSRule.type</code> を、<code>UNKNOWN_RULE</code> (<code>0</code>) から <code>NAMESPACE_RULE</code> (<code>10</code>) に更新しました。(<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=765590">bug 765590</a>)</li>
  <li>WebSMS API: {{domxref("SmsRequest")}} は、より一般的な {{domxref("DOMRequest")}} に置き換えられました。</li>
  <li>非標準の {{domxref("Element.scrollTopMax")}} および {{domxref("Element.scrollLeftMax")}} 読み取り専用プロパティが追加されました ({{bug(766937)}})。</li>
  <li>{{domxref("Blob.blob", "Blob()")}} の第 2 引数に <code>null</code> または <code>undefined</code> をセットした場合、空ディレクトリとして扱われるようになりました ({{bug(7691119)}})。</li>
@@ -58,7 +58,7 @@ translation_of: Mozilla/Firefox/Releases/16
 
 <ul>
  <li><a href="/ja/docs/JavaScript/Reference/Global_Objects/Number" title="/ja/docs/JavaScript/Reference/Global_Objects/Number"><code>Number</code></a> オブジェクトに <code>isFinite()</code>、<code>toInteger()</code>、<code>isInteger()</code> メソッドを追加しました。(<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=761480">bug 761480</a>, <a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=761495">bug 761495</a>)</li>
- <li>Harmony の <a href="http://wiki.ecmascript.org/doku.php?id=harmony:spread" title="http://wiki.ecmascript.org/doku.php?id=harmony:spread">spread 演算子</a>を <a href="/ja/docs/JavaScript/Reference/Global_Objects/Array" title="/ja/docs/JavaScript/Reference/Global_Objects/Array"><code>Array</code></a> オブジェクトに追加しました。(<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=574130">bug 574130</a>)</li>
+ <li>Harmony の <a href="http://wiki.ecmascript.org/doku.php?id=harmony:spread">spread 演算子</a>を <a href="/ja/docs/JavaScript/Reference/Global_Objects/Array" title="/ja/docs/JavaScript/Reference/Global_Objects/Array"><code>Array</code></a> オブジェクトに追加しました。(<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=574130">bug 574130</a>)</li>
  <li>実験的な {{jsxref("TypedArray.prototype.move()")}} メソッドが追加されました (Aurora および Nightly チャンネルのみで利用可能) ({{bug(730873)}})。</li>
 </ul>
 

--- a/files/ja/mozilla/firefox/releases/17/index.html
+++ b/files/ja/mozilla/firefox/releases/17/index.html
@@ -21,16 +21,16 @@ translation_of: Mozilla/Firefox/Releases/17
 <h3 id="CSS">CSS</h3>
 
 <ul>
- <li><a href="http://dev.w3.org/csswg/css3-conditional/" title="http://dev.w3.org/csswg/css3-conditional/">CSS3 Conditional Rules 仕様書</a>で定義されている {{ cssxref("@supports") }} @-規則をサポートしました。これは既定で無効にされています。開発者の方は、<code>layout.css.supports-rule.enabled</code> を true に設定することで試すことができます (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=649740" title="https://bugzilla.mozilla.org/show_bug.cgi?id=649740">bug 649740</a>)。</li>
- <li>要素の表記方向を基にした要素選択を可能にする、CSS Selectors Level 4 の {{ cssxref(":dir", ":dir()") }} 疑似クラスをサポートしました。(<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=562169" title="https://bugzilla.mozilla.org/show_bug.cgi?id=562169">bug 562169</a>)</li>
- <li>CSS の{{ cssxref("unicode-bidi") }} プロパティで新たに規定された値である <code>isolate-override</code> をサポートしました。(<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=774335" title="https://bugzilla.mozilla.org/show_bug.cgi?id=774335">bug 774335</a>)</li>
+ <li><a href="http://dev.w3.org/csswg/css3-conditional/" title="http://dev.w3.org/csswg/css3-conditional/">CSS3 Conditional Rules 仕様書</a>で定義されている {{ cssxref("@supports") }} @-規則をサポートしました。これは既定で無効にされています。開発者の方は、<code>layout.css.supports-rule.enabled</code> を true に設定することで試すことができます (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=649740">bug 649740</a>)。</li>
+ <li>要素の表記方向を基にした要素選択を可能にする、CSS Selectors Level 4 の {{ cssxref(":dir", ":dir()") }} 疑似クラスをサポートしました。(<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=562169">bug 562169</a>)</li>
+ <li>CSS の{{ cssxref("unicode-bidi") }} プロパティで新たに規定された値である <code>isolate-override</code> をサポートしました。(<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=774335">bug 774335</a>)</li>
  <li>{{ cssxref("box-sizing") }} の接頭辞付き実装が、{{ cssxref("min-height") }} および {{ cssxref("max-height") }} を考慮するようになりました。接頭辞が不要な実装に近づくステップのひとつです。({{bug("308801")}})</li>
 </ul>
 
 <h3 id="DOM">DOM</h3>
 
 <ul>
- <li><a href="http://dev.w3.org/csswg/css3-conditional/" title="http://dev.w3.org/csswg/css3-conditional/">CSS3 Conditional Rules 仕様書</a>で定義されている {{ domxref("CSSSupportsRule") }} インタフェースをサポートしました。(<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=649740" title="https://bugzilla.mozilla.org/show_bug.cgi?id=649740">bug 649740</a>)</li>
+ <li><a href="http://dev.w3.org/csswg/css3-conditional/" title="http://dev.w3.org/csswg/css3-conditional/">CSS3 Conditional Rules 仕様書</a>で定義されている {{ domxref("CSSSupportsRule") }} インタフェースをサポートしました。(<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=649740">bug 649740</a>)</li>
  <li>{{ domxref("WheelEvent") }} オブジェクトおよび  <code>wheel</code> イベントをサポートしました ({{ bug("719320") }})。</li>
  <li>Linux において DOM Meta キーを再びサポートしました ({{bug("751749")}})。</li>
  <li>{{ domxref("HTMLMediaElement") }} で、新たなメソッド <code>mozGetMetadata</code> をサポートしました ({{bug("763010")}})。これは、再生しているメディアのリソースから得たメタデータを {key: value} の組として表すプロパティを持つ、JavaScript オブジェクトを返します。</li>
@@ -40,7 +40,7 @@ translation_of: Mozilla/Firefox/Releases/17
 <h3 id="JavaScript">JavaScript</h3>
 
 <ul>
- <li><a href="/ja/docs/JavaScript/Reference/Global_Objects/String"><code>String</code></a> オブジェクトが Harmony の <code>startsWith</code>、<code>endsWith</code>、および <code>contains</code> メソッドを提供します。(<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=772733" title="https://bugzilla.mozilla.org/show_bug.cgi?id=772733">bug 772733</a>)</li>
+ <li><a href="/ja/docs/JavaScript/Reference/Global_Objects/String"><code>String</code></a> オブジェクトが Harmony の <code>startsWith</code>、<code>endsWith</code>、および <code>contains</code> メソッドを提供します。(<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=772733">bug 772733</a>)</li>
  <li>strawman <a href="/ja/docs/JavaScript/Reference/Global_Objects/ParallelArray" title="/ja/docs/JavaScript/Reference/Global_Objects/ParallelArray"><code>ParallelArray</code></a> オブジェクトが試験的に実装されました。({{ bug("778559") }})</li>
  <li><code><a href="/ja/docs/JavaScript/Reference/Global_Objects/Map" title="/ja/docs/JavaScript/Reference/Global_Objects/Map">Map</a></code>/<code><a href="/ja/docs/JavaScript/Reference/Global_Objects/Set" title="/ja/docs/JavaScript/Reference/Global_Objects/Set">Set</a></code> のイテレートをサポートしました。({{ bug("725909") }})</li>
  <li>Web コンテンツでは、デフォルトで <a href="/ja/docs/E4X" title="/ja/docs/E4X">E4X</a> を無効にしました。({{ bug("778851") }})</li>

--- a/files/ja/mozilla/firefox/releases/19/index.html
+++ b/files/ja/mozilla/firefox/releases/19/index.html
@@ -47,7 +47,7 @@ translation_of: Mozilla/Firefox/Releases/19
 
 <h3 id="XForms">XForms</h3>
 
-<p>Firefox 19 で、<a href="/ja/docs/XForms" title="/ja/docs/XForms">XForms</a> のサポートを<a href="http://www.philipp-wagner.com/blog/2011/07/the-future-of-mozilla-xforms/" title="http://www.philipp-wagner.com/blog/2011/07/the-future-of-mozilla-xforms/"><strong>削除しました</strong></a>。</p>
+<p>Firefox 19 で、<a href="/ja/docs/XForms" title="/ja/docs/XForms">XForms</a> のサポートを<a href="http://www.philipp-wagner.com/blog/2011/07/the-future-of-mozilla-xforms/"><strong>削除しました</strong></a>。</p>
 
 <h2 id="Changes_for_add-on_and_Mozilla_developers" name="Changes_for_add-on_and_Mozilla_developers">アドオン開発者と Mozilla 開発者向けの変更点</h2>
 

--- a/files/ja/mozilla/firefox/releases/20/index.html
+++ b/files/ja/mozilla/firefox/releases/20/index.html
@@ -30,7 +30,7 @@ translation_of: Mozilla/Firefox/Releases/20
 
 <ul>
  <li><a href="/ja/docs/CSS/Using_CSS_flexible_boxes" title="/ja/docs/CSS/Using_CSS_flexible_boxes">CSS Flexbox</a> がデフォルトで、プレリリースビルドのみ (Beta を除く) で利用可能になりました。Release ビルドでは、about:config で設定を変更することで利用できます。</li>
- <li><a href="https://dvcs.w3.org/hg/FXTF/raw-file/tip/masking/index.html" title="https://dvcs.w3.org/hg/FXTF/raw-file/tip/masking/index.html">CSS Masking specification</a> より、<code>mask-type</code> プロパティをサポートしました ({{bug("793617")}})。</li>
+ <li><a href="https://dvcs.w3.org/hg/FXTF/raw-file/tip/masking/index.html">CSS Masking specification</a> より、<code>mask-type</code> プロパティをサポートしました ({{bug("793617")}})。</li>
 </ul>
 
 <h3 id="DOM">DOM</h3>

--- a/files/ja/mozilla/firefox/releases/22/index.html
+++ b/files/ja/mozilla/firefox/releases/22/index.html
@@ -21,7 +21,7 @@ translation_of: Mozilla/Firefox/Releases/22
 <h3 id="JavaScript">JavaScript</h3>
 
 <ul>
- <li><a href="http://asmjs.org/spec/latest/" title="http://asmjs.org/spec/latest/">Asm.js</a> の最適化が有効になり、パフォーマンス向上のために C/C++ アプリケーションを JavaScript のサブセットにコンパイルすることが可能になります。</li>
+ <li><a href="http://asmjs.org/spec/latest/">Asm.js</a> の最適化が有効になり、パフォーマンス向上のために C/C++ アプリケーションを JavaScript のサブセットにコンパイルすることが可能になります。</li>
  <li>ES6 の <a href="/ja/docs/JavaScript/Reference/arrow_functions">Arrow Function</a> 構文を実装しました ({{bug(846406)}})。</li>
  <li>新しい <a href="/ja/docs/Web/JavaScript/Reference/Global_Objects/Object/is">Object.is</a> 関数が追加されました ({{bug(839979)}})。</li>
 </ul>
@@ -30,7 +30,7 @@ translation_of: Mozilla/Firefox/Releases/22
 
 <ul>
  <li><code>XMLHttpRequest</code> の <code>multipart</code> プロパティおよび <code>XMLHttpRequest</code> の <code>multipart/x-mixed-replace</code> レスポンスのサポートを削除しました。これは Gecko だけの機能であり、標準化されませんでした。<a href="/ja/docs/Server-sent_events" title="/ja/docs/Server-sent_events">Server-Sent Events</a>、<a href="/ja/docs/WebSockets" title="/ja/docs/WebSockets">Web Sockets</a>、あるいは progress イベントをもとに <code>responseText</code> を調べることを、代わりに使用できます。</li>
- <li><a href="http://notifications.spec.whatwg.org/" title="http://notifications.spec.whatwg.org/">Web Notifications</a> をサポートしました ({{bug(782211)}})。</li>
+ <li><a href="http://notifications.spec.whatwg.org/">Web Notifications</a> をサポートしました ({{bug(782211)}})。</li>
  <li>{{domxref("XMLHttpRequest/FormData", "FormData")}} の <code>append</code> メソッドが、省略可能な第 3 引数 <code>filename</code> を受け入れるようになりました ({{bug(690659)}})。</li>
  <li>{{domxref("Node.isSupported")}} を削除しました ({{bug(801562)}})。</li>
  <li>{{domxref("Node.setUserData")}} および {{domxref("Node.getUserData")}} を web content 向けには削除、chrome content 向けには非推奨としました ({{bug(842372)}})。</li>
@@ -58,16 +58,16 @@ translation_of: Mozilla/Firefox/Releases/22
 <ul>
  <li>{{interface('nsITreeView')}} のメソッド {{ifmethod('nsITreeView','getCellProperties')}}、{{ifmethod('nsITreeView','getColumnProperties')}} および {{ifmethod('nsITreeView','getRowProperties')}} から、引数 <code>properties</code> を削除しました。これらのメソッドは空白で区切られたプロパティ名の文字列を返すようになります。({{bug('407956')}})</li>
  <li>{{ifmethod('inIDOMUtils', 'getCSSPropertyNames')}} メソッドを実装しました。これはサポートしているすべての <a href="/ja/docs/CSS/CSS_Reference" title="CSS/CSS_Reference">CSS プロパティ</a>名を返します。</li>
- <li>さらなる変更点については <a href="https://blog.mozilla.org/addons/2013/06/03/compatibility-for-firefox-22/" title="https://blog.mozilla.org/addons/2013/06/03/compatibility-for-firefox-22/">こちら</a> (<a href="https://dev.mozilla.jp/2013/06/firefox-22-addon-compatibility/" title="https://dev.mozilla.jp/2013/06/firefox-22-addon-compatibility/">日本語訳</a>) をご覧ください。</li>
+ <li>さらなる変更点については <a href="https://blog.mozilla.org/addons/2013/06/03/compatibility-for-firefox-22/">こちら</a> (<a href="https://dev.mozilla.jp/2013/06/firefox-22-addon-compatibility/" title="https://dev.mozilla.jp/2013/06/firefox-22-addon-compatibility/">日本語訳</a>) をご覧ください。</li>
 </ul>
 
 <h3 id="Firefox_開発ツール">Firefox 開発ツール</h3>
 
 <ul>
- <li><a href="https://hacks.mozilla.org/2013/04/developer-tools-update-firefox-22/" title="https://hacks.mozilla.org/2013/04/developer-tools-update-firefox-22/">フォントインスペクタ</a>が、コンピュータ内のどのフォントがページに適用されているかを表示します。</li>
+ <li><a href="https://hacks.mozilla.org/2013/04/developer-tools-update-firefox-22/">フォントインスペクタ</a>が、コンピュータ内のどのフォントがページに適用されているかを表示します。</li>
  <li>ハイライト表示によるフィードバックで、ページのどの領域がいつ再描画されたかを示します。</li>
  <li>開発ツールをブラウザの下側だけでなく、右側にもドッキング可能になりました。</li>
- <li>開発ツール内の一部ペインを <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=875727" title="https://bugzilla.mozilla.org/show_bug.cgi?id=875727">XUL から HTML</a> に切り替えました。例えば CSS ルールビューアは、<span class="comment-copy"><code>cssruleview.xul</code></span> ではなく chrome://browser/content/devtools/cssruleview.xhtml になりました。load listener を読み込んでこれらの HTML ドキュメントを変更するには、ペインの機能を拡張するために直接オーバーレイを追加するのではなく、外側の XUL ドキュメントにオーバーレイやスクリプトを追加します。</li>
+ <li>開発ツール内の一部ペインを <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=875727">XUL から HTML</a> に切り替えました。例えば CSS ルールビューアは、<span class="comment-copy"><code>cssruleview.xul</code></span> ではなく chrome://browser/content/devtools/cssruleview.xhtml になりました。load listener を読み込んでこれらの HTML ドキュメントを変更するには、ペインの機能を拡張するために直接オーバーレイを追加するのではなく、外側の XUL ドキュメントにオーバーレイやスクリプトを追加します。</li>
  <li>デバッガで、スタックトレースが上側にパンくずリストのように表示されるようになりました。またスクリプト一覧がパネルの左側に表示されるようになりました。</li>
 </ul>
 

--- a/files/ja/mozilla/firefox/releases/23/index.html
+++ b/files/ja/mozilla/firefox/releases/23/index.html
@@ -81,7 +81,7 @@ translation_of: Mozilla/Firefox/Releases/23
 <ul>
  <li><a href="http://www.mozilla.jp/firefox/23.0/releasenotes/">Firefox 23 リリースノート</a></li>
  <li><a href="https://www.fxsitecompat.com/ja/versions/23/">Firefox 23 サイト互換性情報</a></li>
- <li><a href="https://dev.mozilla.jp/2013/07/firefox-23-addon-compatibility/" title="https://dev.mozilla.jp/2013/07/firefox-23-addon-compatibility/">Firefox 23 アドオン互換性情報</a></li>
+ <li><a href="https://dev.mozilla.jp/2013/07/firefox-23-addon-compatibility/">Firefox 23 アドオン互換性情報</a></li>
 </ul>
 
 <h3 id="Older_versions" name="Older_versions">過去のバージョン</h3>

--- a/files/ja/mozilla/firefox/releases/24/index.html
+++ b/files/ja/mozilla/firefox/releases/24/index.html
@@ -50,7 +50,7 @@ translation_of: Mozilla/Firefox/Releases/24
 <ul>
  <li>ネットワークインスペクタで、コンテンツタイプ (CSS/画像/フォント など) による絞り込みと、絞り込み結果についてサイズや読み込み時間を確認できるようになりました。</li>
  <li>左側にある開発ツールのオプションパネルで、JavaScript を一時的に無効化/有効化できるようになりました。</li>
- <li>拡張機能の開発者は chrome レベルのスクリプトに対して、新たに<a href="http://www.robodesign.ro/mihai/blog/the-browser-console-is-replacing-the-error-console" title="http://www.robodesign.ro/mihai/blog/the-browser-console-is-replacing-the-error-console">ブラウザコンソール</a>を使用できるようになりました (エラーコンソールを置き換えます)。</li>
+ <li>拡張機能の開発者は chrome レベルのスクリプトに対して、新たに<a href="http://www.robodesign.ro/mihai/blog/the-browser-console-is-replacing-the-error-console">ブラウザコンソール</a>を使用できるようになりました (エラーコンソールを置き換えます)。</li>
 </ul>
 
 <h3 id="MathML" name="MathML">MathML</h3>

--- a/files/ja/mozilla/firefox/releases/27/index.html
+++ b/files/ja/mozilla/firefox/releases/27/index.html
@@ -49,7 +49,7 @@ translation_of: Mozilla/Firefox/Releases/27
 <p><a href="/ja/docs/Web/JavaScript/ECMAScript_6_support_in_Mozilla" title="Web/JavaScript/ECMAScript_6_support_in_Mozilla">EcmaScript 6</a> (Harmony) の実装が続いています!</p>
 
 <ul>
- <li>Harmony の <a href="http://wiki.ecmascript.org/doku.php?id=harmony:spread" title="http://wiki.ecmascript.org/doku.php?id=harmony:spread">spread operator</a> を、関数呼び出しでサポートしました ({{bug("762363")}})。</li>
+ <li>Harmony の <a href="http://wiki.ecmascript.org/doku.php?id=harmony:spread">spread operator</a> を、関数呼び出しでサポートしました ({{bug("762363")}})。</li>
  <li>数学関数 {{jsxref("Global_Objects/Math/hypot", "Math.hypot()")}} を実装しました ({{bug("896264")}})。</li>
  <li><code>yield*</code> 演算子を実装しました ({{bug(666396)}})。</li>
  <li><code>MapIterator</code>、<code>SetIterator</code>、<code>ArrayIterator</code> の各オブジェクトが、仕様書に一致するようになりました ({{bug("881226")}})。</li>

--- a/files/ja/mozilla/firefox/releases/3.5/icc_color_correction_in_firefox/index.html
+++ b/files/ja/mozilla/firefox/releases/3.5/icc_color_correction_in_firefox/index.html
@@ -91,14 +91,14 @@ translation_of: Mozilla/Firefox/Releases/3.5/ICC_color_correction_in_Firefox
 
 <h3 id="警告">警告</h3>
 
-<p>Firefox 3.5で導入された新しいQCMSカラーマネジメントシステムは、バージョン4ではなく、ICC カラープロファイルのバージョン2のみをサポートしています。画像が暗すぎることがあります。<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=488800" title="https://bugzilla.mozilla.org/show_bug.cgi?id=488800">bug 488800</a> と<a class="external external-icon" href="http://www.color.org/version4html.xalter" title="http://www.color.org/version4html.xalter">ICC version 4 profile test</a> を参照してください。</p>
+<p>Firefox 3.5で導入された新しいQCMSカラーマネジメントシステムは、バージョン4ではなく、ICC カラープロファイルのバージョン2のみをサポートしています。画像が暗すぎることがあります。<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=488800">bug 488800</a> と<a class="external external-icon" href="http://www.color.org/version4html.xalter" title="http://www.color.org/version4html.xalter">ICC version 4 profile test</a> を参照してください。</p>
 
 <h2 id="関連情報">関連情報</h2>
 
 <ul>
- <li><a class="external" href="http://bholley.wordpress.com/2008/09/12/so-many-colors/" title="http://bholley.wordpress.com/2008/09/12/so-many-colors/">So Many Colors</a> (blog post)</li>
- <li><a class="external" href="http://www.dria.org/wordpress/archives/2008/04/29/633/" title="http://www.dria.org/wordpress/archives/2008/04/29/633/">Firefox 3: Color profile support</a> (blog post)</li>
- <li><a class="external" href="http://ejohn.org/blog/color-profiles/" title="http://ejohn.org/blog/color-profiles/">Color Profiles in Firefox 3</a> (blog post)</li>
+ <li><a class="external" href="http://bholley.wordpress.com/2008/09/12/so-many-colors/">So Many Colors</a> (blog post)</li>
+ <li><a class="external" href="http://www.dria.org/wordpress/archives/2008/04/29/633/">Firefox 3: Color profile support</a> (blog post)</li>
+ <li><a class="external" href="http://ejohn.org/blog/color-profiles/">Color Profiles in Firefox 3</a> (blog post)</li>
  <li><a class="external" href="http://www.color.org/" title="http://www.color.org/">International Color Consortium</a></li>
 </ul>
 

--- a/files/ja/mozilla/firefox/releases/3.6/index.html
+++ b/files/ja/mozilla/firefox/releases/3.6/index.html
@@ -153,7 +153,7 @@ translation_of: Mozilla/Firefox/Releases/3.6
 
 <dl>
  <dt><a href="/ja/docs/Themes/Lightweight_themes" title="Themes/Lightweight themes">軽量テーマ</a></dt>
- <dd>Firefox 3.6 は軽量テーマをサポートします。これは作成するのが簡単なテーマで、ブラウザウィンドウの上部（URL バーとボタンバー）と下部（ステータスバー）に単純に画像を適用します。これは既存の <a class="external" href="http://www.getpersonas.com/" title="http://www.getpersonas.com/">Personas</a> テーマ構造の Firefox への統合です。</dd>
+ <dd>Firefox 3.6 は軽量テーマをサポートします。これは作成するのが簡単なテーマで、ブラウザウィンドウの上部（URL バーとボタンバー）と下部（ステータスバー）に単純に画像を適用します。これは既存の <a class="external" href="http://www.getpersonas.com/">Personas</a> テーマ構造の Firefox への統合です。</dd>
 </dl>
 
 <h3 id="その他">その他</h3>

--- a/files/ja/tools/3d_view/index.html
+++ b/files/ja/tools/3d_view/index.html
@@ -21,7 +21,7 @@ original_slug: Tools/Page_Inspector/3D_view
 
 <p>ビューをクリックしてドラッグすると、ページの DOM 階層構造の 3D 表示を別の視点から見たり、構造を確認しやすくするために回転することや向きの変更ができます。オフスクリーンの要素が見えるようになりますので、見えているコンテンツに対して要素がどこに配置されているかを確認できます。また要素をクリックすると、その HTML を <a href="/ja/docs/Tools/Page_Inspector/UI_Tour#HTML_pane">HTML パネル</a> や <a href="/ja/docs/Tools/Page_Inspector/UI_Tour#CSS_pane" title="Style panel">スタイルパネル</a> で参照できます。逆にパンくずリストで要素をクリックすると、3D ビュー内で選択されている要素を変更できます。</p>
 
-<p>ページ調査ツールに 3D ビューボタンが表示されない場合は、使用しているグラフィックドライバを更新する必要があるかもしれません。詳しくは、<a class="link-https" href="https://wiki.mozilla.org/Blocklisting/Blocked_Graphics_Drivers" title="https://wiki.mozilla.org/Blocklisting/Blocked_Graphics_Drivers">ブロックリストに登録されたドライバのページ</a>をご覧ください。</p>
+<p>ページ調査ツールに 3D ビューボタンが表示されない場合は、使用しているグラフィックドライバを更新する必要があるかもしれません。詳しくは、<a class="link-https" href="https://wiki.mozilla.org/Blocklisting/Blocked_Graphics_Drivers">ブロックリストに登録されたドライバのページ</a>をご覧ください。</p>
 
 <h2 id="Controlling_the_3D_view" name="Controlling_the_3D_view">3D ビューのコントロール</h2>
 

--- a/files/ja/tools/debugger/how_to/access_debugging_in_add-ons/index.html
+++ b/files/ja/tools/debugger/how_to/access_debugging_in_add-ons/index.html
@@ -23,4 +23,4 @@ translation_of: Tools/Debugger/How_to/Access_debugging_in_add-ons
  <li>chrome://browser/content/devtools/debugger-panes.js</li>
 </ul>
 
-<p>残念ながらデバッグを行っている範囲内のウォッチ/式を評価する API や、デバッグを行っている範囲内の変数として参照されている、ページ内の要素をハイライトする API はまだありません。(現在作業中であり、バグ <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=653545" title="https://bugzilla.mozilla.org/show_bug.cgi?id=653545">653545</a> をご覧ください)</p>
+<p>残念ながらデバッグを行っている範囲内のウォッチ/式を評価する API や、デバッグを行っている範囲内の変数として参照されている、ページ内の要素をハイライトする API はまだありません。(現在作業中であり、バグ <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=653545">653545</a> をご覧ください)</p>

--- a/files/ja/tools/firefox_os_1.1_simulator/index.html
+++ b/files/ja/tools/firefox_os_1.1_simulator/index.html
@@ -50,7 +50,7 @@ translation_of: Tools/Firefox_OS_1.1_Simulator
 <p>Simulator は、Firefox のアドオンとしてパッケージ化および頒布しています。インストール方法は以下のとおりです:</p>
 
 <ol>
- <li>Firefox で <a href="https://addons.mozilla.org/firefox/addon/firefox-os-simulator/" title="https://addons.mozilla.org/firefox/addon/firefox-os-simulator/">addons.mozilla.org 内の Simulator のページ</a>を訪れてください。</li>
+ <li>Firefox で <a href="https://addons.mozilla.org/firefox/addon/firefox-os-simulator/">addons.mozilla.org 内の Simulator のページ</a>を訪れてください。</li>
  <li>"Firefox に追加" をクリックしてください。</li>
  <li>アドオンをダウンロードすると確認のメッセージが表示されますので、"今すぐインストール" をクリックしてください。</li>
 </ol>
@@ -252,7 +252,7 @@ translation_of: Tools/Firefox_OS_1.1_Simulator
 
 <h3 id="Network_Monitor" name="Network_Monitor">ネットワークモニター</h3>
 
-<p>新たなネットワークモニターのおかげで、アプリが開始したすべてのネットワークリクエストのステータス、ヘッダ、コンテンツ、タイミングを、ユーザフレンドリーなインターフェイスで分析できます。(<a href="https://hacks.mozilla.org/2013/06/network-monitor-now-in-firefox-beta/" title="https://hacks.mozilla.org/2013/06/network-monitor-now-in-firefox-beta/">ネットワークモニターについて詳しく学びます</a>)</p>
+<p>新たなネットワークモニターのおかげで、アプリが開始したすべてのネットワークリクエストのステータス、ヘッダ、コンテンツ、タイミングを、ユーザフレンドリーなインターフェイスで分析できます。(<a href="https://hacks.mozilla.org/2013/06/network-monitor-now-in-firefox-beta/">ネットワークモニターについて詳しく学びます</a>)</p>
 
 <h2 id="Receipts" name="Receipts"><a name="Simulator-receipts">レシート</a></h2>
 
@@ -299,7 +299,7 @@ translation_of: Tools/Firefox_OS_1.1_Simulator
 
 <h3 id="Troubleshooting_on_Linux" name="Troubleshooting_on_Linux">Linux でのトラブルシューティング</h3>
 
-<p>udev ルールを作成した後にデバイスを接続できない場合は、<a href="https://github.com/mozilla/r2d2b2g/issues/515" title="https://github.com/mozilla/r2d2b2g/issues/515">こちらのバグ</a>をご覧ください。</p>
+<p>udev ルールを作成した後にデバイスを接続できない場合は、<a href="https://github.com/mozilla/r2d2b2g/issues/515">こちらのバグ</a>をご覧ください。</p>
 
 <h2 id="Limitations_of_the_Simulator" name="Limitations_of_the_Simulator"><a name="Limitations">Simulator の制限事項</a></h2>
 

--- a/files/ja/tools/page_inspector/how_to/use_the_inspector_api/index.html
+++ b/files/ja/tools/page_inspector/how_to/use_the_inspector_api/index.html
@@ -12,7 +12,7 @@ translation_of: Tools/Page_Inspector/How_to/Use_the_Inspector_API
 
 <h3 id="window.inspector" name="window.inspector">window.inspector</h3>
 
-<p><a href="http://mxr.mozilla.org/mozilla-central/source/browser/devtools/inspector/inspector-panel.js" title="http://mxr.mozilla.org/mozilla-central/source/browser/devtools/inspector/inspector-panel.js">inspector-panel.js</a> で定義しています。属性と関数:</p>
+<p><a href="http://mxr.mozilla.org/mozilla-central/source/browser/devtools/inspector/inspector-panel.js">inspector-panel.js</a> で定義しています。属性と関数:</p>
 
 <ul>
  <li>.selection - インスペクターで選択したものに関する情報:

--- a/files/ja/tools/remote_debugging/firefox_for_android/index.html
+++ b/files/ja/tools/remote_debugging/firefox_for_android/index.html
@@ -19,13 +19,13 @@ translation_of: Tools/Remote_Debugging/Firefox_for_Android
 
 <ul>
  <li>Firefox 15 以降を実行するデスクトップまたはノート型コンピュータ</li>
- <li>Android 版 Firefox 15 以降を実行している、<a href="https://support.mozilla.org/ja/kb/will-firefox-work-my-mobile-device" title="https://support.mozilla.org/ja/kb/will-firefox-work-my-mobile-device">Android 版 Firefox が動作する</a> Android デバイス</li>
+ <li>Android 版 Firefox 15 以降を実行している、<a href="https://support.mozilla.org/ja/kb/will-firefox-work-my-mobile-device">Android 版 Firefox が動作する</a> Android デバイス</li>
  <li>2 つのデバイスを接続する USB ケーブル</li>
 </ul>
 
 <h3 id="ADB_setup" name="ADB_setup">ADB のセットアップ</h3>
 
-<p>次に <a href="https://developer.android.com/tools/help/adb.html" title="https://developer.android.com/tools/help/adb.html">adb</a> コマンドラインツールを使用して、デスクトップと Android デバイスが相互に対話できるようにしなければなりません。</p>
+<p>次に <a href="https://developer.android.com/tools/help/adb.html">adb</a> コマンドラインツールを使用して、デスクトップと Android デバイスが相互に対話できるようにしなければなりません。</p>
 
 <h4 class="note" id="Android_デバイスで行う作業">Android デバイスで行う作業</h4>
 

--- a/files/ja/tools/view_source/index.html
+++ b/files/ja/tools/view_source/index.html
@@ -49,7 +49,7 @@ original_slug: View_source
 
 <h3 id="Error_reporter_≠_validator" name="Error_reporter_≠_validator">エラー報告機能は検証ツールではない</h3>
 
-<p>ソース表示はパース処理のエラーを報告するだけであり、HTML の妥当性のエラーは<strong>報告しません</strong>。たとえば、{{HTMLElement("ul")}} 要素の子要素に {{HTMLElement("div")}} 要素を挿入することはパースエラーではありませんが、<strong>妥当な HTML でもありません</strong>。そのため、ソース表示ではこのエラーを報告しません。HTML が妥当かを確認したい場合は HTML 検証ツール、例えば <a href="http://validator.w3.org/" title="http://validator.w3.org/">W3C が提供するツール</a> を使用しましょう。</p>
+<p>ソース表示はパース処理のエラーを報告するだけであり、HTML の妥当性のエラーは<strong>報告しません</strong>。たとえば、{{HTMLElement("ul")}} 要素の子要素に {{HTMLElement("div")}} 要素を挿入することはパースエラーではありませんが、<strong>妥当な HTML でもありません</strong>。そのため、ソース表示ではこのエラーを報告しません。HTML が妥当かを確認したい場合は HTML 検証ツール、例えば <a href="http://validator.w3.org/">W3C が提供するツール</a> を使用しましょう。</p>
 
 <h3 id="Not_all_parse_errors_are_reported" name="Not_all_parse_errors_are_reported">報告されないエラーがある</h3>
 

--- a/files/ja/tools/web_console/remoting/index.html
+++ b/files/ja/tools/web_console/remoting/index.html
@@ -17,11 +17,11 @@ translation_of: Tools/Web_Console/remoting
 
 <h2 id="WebConsoleActor_と_WebConsoleClient"><code>WebConsoleActor</code> と <code>WebConsoleClient</code></h2>
 
-<p><code>WebConsoleActor</code> は、<a href="http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/webconsole/" title="http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/webconsole/"><code>toolkit/devtools/webconsole</code></a> フォルダの <a href="http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/webconsole/dbg-webconsole-actors.js" title="http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/webconsole/dbg-webconsole-actors.js"><code>dbg-webconsole-actors.js</code></a> にあります。</p>
+<p><code>WebConsoleActor</code> は、<a href="http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/webconsole/"><code>toolkit/devtools/webconsole</code></a> フォルダの <a href="http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/webconsole/dbg-webconsole-actors.js" title="http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/webconsole/dbg-webconsole-actors.js"><code>dbg-webconsole-actors.js</code></a> にあります。</p>
 
-<p><code>WebConsoleClient</code> は (<a href="http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/webconsole/" title="http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/webconsole/"><code>toolkit/devtools/webconsole</code></a> の) <a href="http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/webconsole/WebConsoleClient.jsm" title="http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/webconsole/WebConsoleClient.jsm"><code>WebConsoleClient.jsm</code></a> にあり、Web コンソールアクターで作業するときにWeb コンソールで使用されます。</p>
+<p><code>WebConsoleClient</code> は (<a href="http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/webconsole/" title="http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/webconsole/"><code>toolkit/devtools/webconsole</code></a> の) <a href="http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/webconsole/WebConsoleClient.jsm"><code>WebConsoleClient.jsm</code></a> にあり、Web コンソールアクターで作業するときにWeb コンソールで使用されます。</p>
 
-<p>デバッガが Web コンソールコードでどのように使用されているかを確認するには、<a href="http://mxr.mozilla.org/mozilla-central/source/browser/devtools/webconsole/webconsole.js" title="http://mxr.mozilla.org/mozilla-central/source/browser/devtools/webconsole/webconsole.js"><code>browser/devtools/webconsole/webconsole.js</code></a> を開き、<code>WebConsoleConnectionProxy</code> を検索します。</p>
+<p>デバッガが Web コンソールコードでどのように使用されているかを確認するには、<a href="http://mxr.mozilla.org/mozilla-central/source/browser/devtools/webconsole/webconsole.js"><code>browser/devtools/webconsole/webconsole.js</code></a> を開き、<code>WebConsoleConnectionProxy</code> を検索します。</p>
 
 <p>新しい Web コンソールアクターは次のとおりです。</p>
 
@@ -109,7 +109,7 @@ debuggerClient.attachConsole(tab.consoleActor, listeners, onAttachConsole)
 <p>タブナビゲーションイベントを待ち受けるには、指定したタブのタブアクターにアタッチする必要もあります。<code>tabNavigated</code> 通知はタブのアクターから来ます。</p>
 
 <div class="warning">
-<p>Firefox 20 以前では、Web コンソールの実行者は<code>LocationChange</code>リスナを提供し、<code>locationChanged</code> 通知を関連付けました。これはもはや当てはまりません。Web コンソールクライアントが <code>tabNavigated</code> 通知を再利用 (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=792062" title="https://bugzilla.mozilla.org/show_bug.cgi?id=792062">bug 792062</a>) できるように変更しました。</p>
+<p>Firefox 20 以前では、Web コンソールの実行者は<code>LocationChange</code>リスナを提供し、<code>locationChanged</code> 通知を関連付けました。これはもはや当てはまりません。Web コンソールクライアントが <code>tabNavigated</code> 通知を再利用 (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=792062">bug 792062</a>) できるように変更しました。</p>
 </div>
 
 <p>ページナビゲーションが開始されると、次のパケットがタブアクターから送信されます。</p>
@@ -296,13 +296,13 @@ debuggerClient.attachConsole(tab.consoleActor, listeners, onAttachConsole)
 
 <p><a href="/ja/docs/Web/API/console"><code>window.console</code> API</a> 呼び出しは、Gecko を通して内部メッセージを送信します。これにより、各呼び出しに必要な処理を実行できます。Web コンソールのアクターは、これらのメッセージをリモートデバッグクライアントに送信します。</p>
 
-<p><a href="https://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/debugger/server/dbg-script-actors.js" title="https://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/debugger/server/dbg-script-actors.js">dbg-script-actors.js</a> の <code>ObjectActor</code> を <code>ThreadActor</code> なしで使用すると、ページスクリプトの速度低下を避けることができます。デバッガはターゲットページで JavaScript の実行を非最適化します。Web コンソールの<a href="https://searchfox.org/mozilla-central/source/devtools/docs/backend/protocol.md">オブジェクトアクタの有効期間</a>は、デバッガ内のこれらのオブジェクトの存続期間とは異なります。通常、一時停止またはスレッドごとです。 Web コンソールは <code>ObjectActors</code> の有効期間を手動で管理します。</p>
+<p><a href="https://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/debugger/server/dbg-script-actors.js">dbg-script-actors.js</a> の <code>ObjectActor</code> を <code>ThreadActor</code> なしで使用すると、ページスクリプトの速度低下を避けることができます。デバッガはターゲットページで JavaScript の実行を非最適化します。Web コンソールの<a href="https://searchfox.org/mozilla-central/source/devtools/docs/backend/protocol.md">オブジェクトアクタの有効期間</a>は、デバッガ内のこれらのオブジェクトの存続期間とは異なります。通常、一時停止またはスレッドごとです。 Web コンソールは <code>ObjectActors</code> の有効期間を手動で管理します。</p>
 
 <div class="warning">
-<p>Firefox 23以前は、プロトコルを通じてJavaScriptオブジェクトを操作するために、別のアクタ<code>(WebConsoleObjectActor</code>)を使用しました。<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=783499" title="https://bugzilla.mozilla.org/show_bug.cgi?id=783499">bug 783499</a>では、デバッガから<code>ObjectActor</code>を再利用するためにいくつかの変更を行いました。</p>
+<p>Firefox 23以前は、プロトコルを通じてJavaScriptオブジェクトを操作するために、別のアクタ<code>(WebConsoleObjectActor</code>)を使用しました。<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=783499">bug 783499</a>では、デバッガから<code>ObjectActor</code>を再利用するためにいくつかの変更を行いました。</p>
 </div>
 
-<p>コンソール API メッセージは <a href="https://developer.mozilla.org/en-US/docs/XPCOM_Interface_Reference/nsIObserverService" title="/en-US/docs/XPCOM_Interface_Reference/nsIObserverService"><code>nsIObserverService</code></a> を経由します。コンソールオブジェクトの実装は <a href="http://mxr.mozilla.org/mozilla-central/source/dom/base/ConsoleAPI.js" title="http://mxr.mozilla.org/mozilla-central/source/dom/base/ConsoleAPI.js"><code>dom/base/ConsoleAPI.js</code></a> にあります。</p>
+<p>コンソール API メッセージは <a href="https://developer.mozilla.org/en-US/docs/XPCOM_Interface_Reference/nsIObserverService" title="/en-US/docs/XPCOM_Interface_Reference/nsIObserverService"><code>nsIObserverService</code></a> を経由します。コンソールオブジェクトの実装は <a href="http://mxr.mozilla.org/mozilla-central/source/dom/base/ConsoleAPI.js"><code>dom/base/ConsoleAPI.js</code></a> にあります。</p>
 
 <p>サーバーで受信したコンソールメッセージごとに、次の <code>consoleAPICall</code> パケットをクライアントに送信します。</p>
 
@@ -336,7 +336,7 @@ debuggerClient.attachConsole(tab.consoleActor, listeners, onAttachConsole)
 
 <p><code>private</code> フラグは、コンソール API 呼び出しがプライベートウィンドウ/タブ (Firefox 24 で追加されたもの) から来ているかどうかを示します。</p>
 
-<p>オブザーバーサービスから受け取ったコンソールイベントオブジェクトには小さな違いがあるように、コンソール API 呼び出しメソッドに応じて、オブジェクトの小さなバリエーションがあります。これらの相違点を確認するには、コンソール API 実装の <a href="http://mxr.mozilla.org/mozilla-central/source/dom/base/ConsoleAPI.js" title="http://mxr.mozilla.org/mozilla-central/source/dom/base/ConsoleAPI.js">dom/base/ConsoleAPI.js</a> を参照してください。</p>
+<p>オブザーバーサービスから受け取ったコンソールイベントオブジェクトには小さな違いがあるように、コンソール API 呼び出しメソッドに応じて、オブジェクトの小さなバリエーションがあります。これらの相違点を確認するには、コンソール API 実装の <a href="http://mxr.mozilla.org/mozilla-central/source/dom/base/ConsoleAPI.js">dom/base/ConsoleAPI.js</a> を参照してください。</p>
 
 <h3 id="JavaScript_評価">JavaScript 評価</h3>
 
@@ -594,7 +594,7 @@ debuggerClient.attachConsole(tab.consoleActor, listeners, onAttachConsole)
 </pre>
 
 <div class="note">
-<p>Firefox19より提供開始：上記のパケットのすべてのヘッダーとCookieの値に対して、値が非常に長い場合は<a href="https://wiki.mozilla.org/Remote_Debugging_Protocol#Objects" title="https://wiki.mozilla.org/Remote_Debugging_Protocol#Objects"><code>LongStringActor</code> grips</a>を使用します。 これにより、ネットワーク帯域幅の使い過ぎを避けることができます。</p>
+<p>Firefox19より提供開始：上記のパケットのすべてのヘッダーとCookieの値に対して、値が非常に長い場合は<a href="https://wiki.mozilla.org/Remote_Debugging_Protocol#Objects"><code>LongStringActor</code> grips</a>を使用します。 これにより、ネットワーク帯域幅の使い過ぎを避けることができます。</p>
 </div>
 
 <p><code>getRequestPostData</code> パケット:</p>
@@ -668,9 +668,9 @@ debuggerClient.attachConsole(tab.consoleActor, listeners, onAttachConsole)
 
 <ul>
  <li>Firefox 18: 初期バージョン。</li>
- <li>Firefox 19: <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=787981" title="https://bugzilla.mozilla.org/show_bug.cgi?id=787981">bug 787981</a> - いくつかの場所で <code>LongStringActor</code> の使用法を追加しました。</li>
- <li>Firefox 20: <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=792062" title="https://bugzilla.mozilla.org/show_bug.cgi?id=792062">bug 792062</a> - removed <code>locationChanged</code> packet and updated the <code>tabNavigated</code> packet for tab actors.</li>
- <li>Firefox 23: <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=783499" title="https://bugzilla.mozilla.org/show_bug.cgi?id=783499">bug 783499</a> - removed the <code>WebConsoleObjectActor</code>. Now the Web Console uses the JavaScript debugger API and the <code>ObjectActor</code>.</li>
+ <li>Firefox 19: <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=787981">bug 787981</a> - いくつかの場所で <code>LongStringActor</code> の使用法を追加しました。</li>
+ <li>Firefox 20: <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=792062">bug 792062</a> - removed <code>locationChanged</code> packet and updated the <code>tabNavigated</code> packet for tab actors.</li>
+ <li>Firefox 23: <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=783499">bug 783499</a> - removed the <code>WebConsoleObjectActor</code>. Now the Web Console uses the JavaScript debugger API and the <code>ObjectActor</code>.</li>
  <li>Firefox 23: added the <code>bindObjectActor</code> and <code>frameActor</code> options to the <code>evaluateJS</code> request packet.</li>
  <li>Firefox 24: new <code>private</code> flags for the console actor notifications, <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=874061">bug 874061</a>. Also added the <code>lastPrivateContextExited</code> notification for the global console actor.</li>
  <li>Firefox 24: new <code>isXHR</code> flag for the <code>networkEvent</code> notification, <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=859046">bug 859046</a>.</li>
@@ -681,6 +681,6 @@ debuggerClient.attachConsole(tab.consoleActor, listeners, onAttachConsole)
 
 <h2 id="まとめ">まとめ</h2>
 
-<p>この文書の執筆時点では、この文書は <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=768096" title="https://bugzilla.mozilla.org/show_bug.cgi?id=768096">バグ 768096</a> で行った作業とそれに続く変更をまとめたものです。このドキュメントを最新の状態に保つよう努めています。これがあなたの役立つことを願っています。</p>
+<p>この文書の執筆時点では、この文書は <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=768096">バグ 768096</a> で行った作業とそれに続く変更をまとめたものです。このドキュメントを最新の状態に保つよう努めています。これがあなたの役立つことを願っています。</p>
 
 <p>Webコンソールサーバーを変更する場合は、このドキュメントを更新してください。 ありがとうございました！</p>


### PR DESCRIPTION
The `title` tooltip on links is useful if it's just the same as the URL. 
I think the old Wiki used to by-default put these in. 