### PR TITLE
French translation for CSS `:past` pseudo class reference

### DIFF
--- a/files/fr/web/css/_colon_past/index.html
+++ b/files/fr/web/css/_colon_past/index.html
@@ -1,0 +1,66 @@
+---
+title: ':past'
+slug: 'Web/CSS/:past'
+browser-compat: css.selectors.past
+translation_of: Web/CSS/:past
+---
+<p>{{CSSRef}}</p>
+
+<p>Le sélecteur de <a href="/fr/docs/Web/CSS/Pseudo-classes">pseudo-classe</a> <a href="/fr/docs/Web/CSS">CSS</a> <strong><code>:future</code></strong> est une pseudo-classe agissant dans la dimension temporelle qui cible n'importe quel élément apparaissant entièrement avant un élément correspondant à {{cssxref(":current")}}. Ce sélecteur peut par exemple servir dans le cas d'une vidéo ayant des sous-titres affichés à l'aide du format <a href="/fr/docs/Web/API/WebVTT_API">WebVTT</a>.</p>
+
+<pre class="brush: css">:past(p, span) {
+  display: none;
+}</pre>
+
+<h2 id="syntax">Syntaxe</h2>
+
+<p>{{csssyntax}}</p>
+
+<h2 id="examples">Exemples</h2>
+
+<h3 id="css">CSS</h3>
+
+<pre class="brush: css">:past(p, span) {
+  display: none;
+}</pre>
+
+<h3 id="html">HTML</h3>
+
+<pre class="brush: html">&lt;video controls preload="metadata"&gt;
+  &lt;source src="video.mp4" type="video/mp4" /&gt;
+  &lt;source src="video.webm" type="video/webm" /&gt;
+  &lt;track label="Français" kind="subtitles" srclang="fr" src="subtitles.vtt" default&gt;
+&lt;/video&gt;</pre>
+
+<h3 id="webvtt">WebVTT </h3>
+
+<pre>FICHIER WEBVTT
+
+1
+00:00:03.500 --&gt; 00:00:05.000
+Voici le premier sous-titre
+
+2
+00:00:06.000 --&gt; 00:00:09.000
+Voici le second sous-titre
+
+3
+00:00:11.000 --&gt; 00:00:19.000
+Voici le troisième sous-titre
+</pre>
+
+<h2 id="specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="see_also">Voir aussi</h2>
+
+<ul>
+	<li><a href="/fr/docs/Web/API/WebVTT_API">Web Video Text Tracks Format (WebVTT)</a></li>
+	<li>{{cssxref(":current")}}</li>
+	<li>{{cssxref(":future")}}</li>
+</ul>

--- a/files/fr/web/css/_colon_past/index.html
+++ b/files/fr/web/css/_colon_past/index.html
@@ -6,7 +6,7 @@ translation_of: Web/CSS/:past
 ---
 <p>{{CSSRef}}</p>
 
-<p>Le sélecteur de <a href="/fr/docs/Web/CSS/Pseudo-classes">pseudo-classe</a> <a href="/fr/docs/Web/CSS">CSS</a> <strong><code>:future</code></strong> est une pseudo-classe agissant dans la dimension temporelle qui cible n'importe quel élément apparaissant entièrement avant un élément correspondant à {{cssxref(":current")}}. Ce sélecteur peut par exemple servir dans le cas d'une vidéo ayant des sous-titres affichés à l'aide du format <a href="/fr/docs/Web/API/WebVTT_API">WebVTT</a>.</p>
+<p>Le sélecteur de <a href="/fr/docs/Web/CSS/Pseudo-classes">pseudo-classe</a> <a href="/fr/docs/Web/CSS">CSS</a> <strong><code>:past</code></strong> est une pseudo-classe agissant dans la dimension temporelle qui cible n'importe quel élément apparaissant entièrement avant un élément correspondant à {{cssxref(":current")}}. Ce sélecteur peut par exemple servir dans le cas d'une vidéo ayant des sous-titres affichés à l'aide du format <a href="/fr/docs/Web/API/WebVTT_API">WebVTT</a>.</p>
 
 <pre class="brush: css">:past(p, span) {
   display: none;
@@ -32,7 +32,7 @@ translation_of: Web/CSS/:past
   &lt;track label="Français" kind="subtitles" srclang="fr" src="subtitles.vtt" default&gt;
 &lt;/video&gt;</pre>
 
-<h3 id="webvtt">WebVTT </h3>
+<h3 id="webvtt">WebVTT</h3>
 
 <pre>FICHIER WEBVTT
 
@@ -60,7 +60,7 @@ Voici le troisième sous-titre
 <h2 id="see_also">Voir aussi</h2>
 
 <ul>
-	<li><a href="/fr/docs/Web/API/WebVTT_API">Web Video Text Tracks Format (WebVTT)</a></li>
-	<li>{{cssxref(":current")}}</li>
-	<li>{{cssxref(":future")}}</li>
+  <li><a href="/fr/docs/Web/API/WebVTT_API">Web Video Text Tracks Format (WebVTT)</a></li>
+  <li>{{cssxref(":current")}}</li>
+  <li>{{cssxref(":future")}}</li>
 </ul>


### PR DESCRIPTION
This PR aims to create a French translation for CSS `:past` pseudo class reference.