### PR TITLE
French translation for CSS ::target-text pseudo element reference

### DIFF
--- a/files/fr/web/css/_doublecolon_target-text/index.html
+++ b/files/fr/web/css/_doublecolon_target-text/index.html
@@ -6,7 +6,7 @@ translation_of: 'Web/CSS/::target-text'
 ---
 <div>{{CSSRef}}{{SeeCompatTable}}</div>
 
-<p>Le <a href="/fr/docs/Web/CSS/Pseudo-elements">pseudo-élément</a> <a href="/en-US/docs/Web/CSS">CSS</a> <strong><code>::target-text</code></strong> représente le texte vers lequel l'écran vient de défiler, dans le cas ou le  navigateur supporte les fragments <code>scroll-to-text</code>. Il permet aux auteurs de mettre en valeur cette section de texte.</p>
+<p>Le <a href="/fr/docs/Web/CSS/Pseudo-elements">pseudo-élément</a> <a href="/en-US/docs/Web/CSS">CSS</a> <strong><code>::target-text</code></strong> représente le texte vers lequel l'écran vient de défiler, dans le cas où le  navigateur prend en charge les fragments <code>scroll-to-text</code>. Il permet aux auteurs de mettre en valeur cette section de texte.</p>
 
 <pre class="brush: css no-line-numbers">::target-text {
   background-color: pink;

--- a/files/fr/web/css/_doublecolon_target-text/index.html
+++ b/files/fr/web/css/_doublecolon_target-text/index.html
@@ -1,0 +1,43 @@
+---
+title: '::target-text'
+slug: 'Web/CSS/::target-text'
+browser-compat: css.selectors.target-text
+translation_of: 'Web/CSS/::target-text'
+---
+<div>{{CSSRef}}{{SeeCompatTable}}</div>
+
+<p>Le <a href="/fr/docs/Web/CSS/Pseudo-elements">pseudo-élément</a> <a href="/en-US/docs/Web/CSS">CSS</a> <strong><code>::target-text</code></strong> représente le texte vers lequel l'écran vient de défiler, dans le cas ou le  navigateur supporte les fragments <code>scroll-to-text</code>. Il permet aux auteurs de mettre en valeur cette section de texte.</p>
+
+<pre class="brush: css no-line-numbers">::target-text {
+  background-color: pink;
+}</pre>
+
+<h2 id="syntax">Syntaxe</h2>
+
+<p>{{csssyntax}}</p>
+
+<h2 id="examples">Exemples</h2>
+
+<h3 id="highlighting_scroll-to-text">Mise en valeur de scroll-to-text</h3>
+
+<pre class="brush: css no-line-numbers">::target-text {
+  background-color: rebeccapurple;
+  color: white;
+  font-weight: bold;
+}</pre>
+
+<p>Pour voir ce code CSS en action, suivez ce lien vers la <a href="https://mdn.github.io/css-examples/target-text/index.html#:~:text=From%20the%20foregoing%20remarks%20we%20may%20gather%20an%20idea%20of%20the%20importance">démonstration de scroll-to-text</a>.</p>
+
+<h2 id="specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">Voir aussi</h2>
+
+<ul>
+ <li><a href="https://web.dev/text-fragments/">Text fragments (en anglais)</a></li>
+</ul>


### PR DESCRIPTION
This PR aims to create a French translation for CSS `::target-text` pseudo element reference.