### PR TITLE
French translation for CSS `:target-within` pseudo class reference

### DIFF
--- a/files/fr/web/css/_colon_target-within/index.html
+++ b/files/fr/web/css/_colon_target-within/index.html
@@ -30,14 +30,12 @@ div:target-within {
 &lt;ol&gt;
  &lt;li&gt;&lt;a href="#p1"&gt;Aller au premier paragraphe !&lt;/a&gt;&lt;/li&gt;
  &lt;li&gt;&lt;a href="#p2"&gt;Aller au second paragraphe !&lt;/a&gt;&lt;/li&gt;
-
 &lt;/ol&gt;
 
 &lt;article&gt;
-
-&lt;h3&gt;Mon bel article&lt;/h3&gt;
-&lt;p id="p1"&gt;Vous pouvez cibler &lt;i&gt;ce paragraphe&lt;/i&gt; en utilisant un fragment d'URL. Cliquez sur le lien ci-dessus pour essayer !&lt;/p&gt;
-&lt;p id="p2"&gt;Ceci est &lt;i&gt;un autre paragraphe&lt;/i&gt;, également accessible depuis les liens ci-dessus. N'est-ce pas savoureux ?&lt;/p&gt;
+  &lt;h3&gt;Mon bel article&lt;/h3&gt;
+  &lt;p id="p1"&gt;Vous pouvez cibler &lt;i&gt;ce paragraphe&lt;/i&gt; en utilisant un fragment d'URL. Cliquez sur le lien ci-dessus pour essayer !&lt;/p&gt;
+  &lt;p id="p2"&gt;Ceci est &lt;i&gt;un autre paragraphe&lt;/i&gt;, également accessible depuis les liens ci-dessus. N'est-ce pas savoureux ?&lt;/p&gt;
 &lt;/article&gt;
 </pre>
 
@@ -55,7 +53,7 @@ p:target::before {
   margin-right: .25em;
 }
 
-/* Style des élément en italique à l'intérieur de l'élément cible */
+/* Style des éléments en italique à l'intérieur de l'élément cible */
 p:target i {
   color: red;
 }</pre>

--- a/files/fr/web/css/_colon_target-within/index.html
+++ b/files/fr/web/css/_colon_target-within/index.html
@@ -1,0 +1,79 @@
+---
+title: ':target-within'
+slug: Web/CSS/:target-within
+browser-compat: css.selectors.target-within
+translation_of: 'Web/CSS/:target-within'
+---
+<div>{{CSSRef}}{{SeeCompatTable}}</div>
+
+<p>La <a href="/fr/docs/Web/CSS/Pseudo-classes">pseudo-classe</a> <a href="/en-US/docs/Web/CSS">CSS</a> <strong><code>:target-within</code></strong> représente un élément ciblé ou qui <em>contient</em> un élément ciblé. Un élément ciblé est un élément unique disposant d'un <code><a href="/fr/docs/Web/HTML/Global_attributes#attr-id">id</a></code> correspondant au fragment de l'URL. En d'autres termes, il représente un élément qui correspond lui-même à la pseudo-classe {{CSSxRef(":target")}} ou qui a un descendant correspondant à <code>:target</code> (cela inclut les descendants des <a href="/fr/docs/Web/Web_Components/Using_shadow_DOM">arbres fantômes</a>).</p>
+
+<pre class="brush: css no-line-numbers">/* Sélectionne une &lt;div&gt; lorsqu'un de ses descendants est une cible */
+div:target-within {
+  background: cyan;
+}
+</pre>
+
+<h2 id="syntax">Syntaxe</h2>
+
+<p>{{CSSSyntax}}</p>
+
+<h2 id="examples">Exemples</h2>
+
+<h3 id="highlighting_an_article">Mise en avant d'un article</h3>
+
+<p>La pseudo-classe <code>:target-within</code> peut être utilisée pour mettre en avant un article si quoi que ce soit dans son contenu a été mis en lien. La pseudo-classe <code>:target</code> est aussi utilisée pour montrer l'élément qui a été ciblé.</p>
+
+<h4 id="html">HTML</h4>
+
+<pre class="brush: html">&lt;h3&gt;Table des matières&lt;/h3&gt;
+&lt;ol&gt;
+ &lt;li&gt;&lt;a href="#p1"&gt;Aller au premier paragraphe !&lt;/a&gt;&lt;/li&gt;
+ &lt;li&gt;&lt;a href="#p2"&gt;Aller au second paragraphe !&lt;/a&gt;&lt;/li&gt;
+
+&lt;/ol&gt;
+
+&lt;article&gt;
+
+&lt;h3&gt;Mon bel article&lt;/h3&gt;
+&lt;p id="p1"&gt;Vous pouvez cibler &lt;i&gt;ce paragraphe&lt;/i&gt; en utilisant un fragment d'URL. Cliquez sur le lien ci-dessus pour essayer !&lt;/p&gt;
+&lt;p id="p2"&gt;Ceci est &lt;i&gt;un autre paragraphe&lt;/i&gt;, également accessible depuis les liens ci-dessus. N'est-ce pas savoureux ?&lt;/p&gt;
+&lt;/article&gt;
+</pre>
+
+<h4 id="css">CSS</h4>
+
+<pre class="brush: css">article:target-within {
+  background-color: gold;
+}
+
+/* Ajout d'un pseudo élément à l'intérieur de l'élément cible */
+p:target::before {
+  font: 70% sans-serif;
+  content: &quot;►&quot;;
+  color: limegreen;
+  margin-right: .25em;
+}
+
+/* Style des élément en italique à l'intérieur de l'élément cible */
+p:target i {
+  color: red;
+}</pre>
+
+<h4 id="result">Résultat</h4>
+
+<div>{{EmbedLiveSample('examples', 500, 300)}}</div>
+
+<h2 id="specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="See_also">Voir aussi</h2>
+
+<ul>
+ <li>{{CSSxRef(":target")}}</li>
+</ul>

--- a/files/fr/web/css/_colon_target-within/index.html
+++ b/files/fr/web/css/_colon_target-within/index.html
@@ -6,7 +6,7 @@ translation_of: 'Web/CSS/:target-within'
 ---
 <div>{{CSSRef}}{{SeeCompatTable}}</div>
 
-<p>La <a href="/fr/docs/Web/CSS/Pseudo-classes">pseudo-classe</a> <a href="/en-US/docs/Web/CSS">CSS</a> <strong><code>:target-within</code></strong> représente un élément ciblé ou qui <em>contient</em> un élément ciblé. Un élément ciblé est un élément unique disposant d'un <code><a href="/fr/docs/Web/HTML/Global_attributes#attr-id">id</a></code> correspondant au fragment de l'URL. En d'autres termes, il représente un élément qui correspond lui-même à la pseudo-classe {{CSSxRef(":target")}} ou qui a un descendant correspondant à <code>:target</code> (cela inclut les descendants des <a href="/fr/docs/Web/Web_Components/Using_shadow_DOM">arbres fantômes</a>).</p>
+<p>La <a href="/fr/docs/Web/CSS/Pseudo-classes">pseudo-classe</a> <a href="/fr/docs/Web/CSS">CSS</a> <strong><code>:target-within</code></strong> représente un élément ciblé ou qui <em>contient</em> un élément ciblé. Un élément ciblé est un élément unique disposant d'un <code><a href="/fr/docs/Web/HTML/Global_attributes#attr-id">id</a></code> correspondant au fragment de l'URL. En d'autres termes, il représente un élément qui correspond lui-même à la pseudo-classe {{CSSxRef(":target")}} ou qui a un descendant correspondant à <code>:target</code> (cela inclut les descendants des <a href="/fr/docs/Web/Web_Components/Using_shadow_DOM">arbres fantômes</a>).</p>
 
 <pre class="brush: css no-line-numbers">/* Sélectionne une &lt;div&gt; lorsqu'un de ses descendants est une cible */
 div:target-within {


### PR DESCRIPTION
This PR aims to create a French translation for CSS `:target-within` pseudo class reference.