### PR TITLE
Fix a small typo in the French translation of the Sticky Footer Layout page

### DIFF
--- a/files/fr/web/css/layout_cookbook/sticky_footers/index.html
+++ b/files/fr/web/css/layout_cookbook/sticky_footers/index.html
@@ -28,7 +28,7 @@ original_slug: Web/CSS/Layout_cookbook/Bas_de_page_adhérant
 <p>{{EmbedGHLiveSample("css-examples/css-cookbook/sticky-footer.html", '100%', 720)}}</p>
 
 <div class="note">
-<p><strong>Note :</strong> <a href="https://github.com/mdn/css-examples/blob/master/css-cookbook/sticky-footer--download.html">Télécharger cet example</a></p>
+<p><strong>Note :</strong> <a href="https://github.com/mdn/css-examples/blob/master/css-cookbook/sticky-footer--download.html">Télécharger cet exemple</a></p>
 </div>
 
 <div class="note">


### PR DESCRIPTION
This PR fixes a small typo in the French translation of the Sticky Footer Layout Cookbook page
Example => Exemple