### PR TITLE
fix: using javascript page not found

### DIFF
--- a/files/fr/_redirects.txt
+++ b/files/fr/_redirects.txt
@@ -3084,6 +3084,7 @@
 /fr/docs/Mozilla/Add-ons/WebExtensions/Incompatibilités_Chrome	/fr/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities
 /fr/docs/Mozilla/Add-ons/WebExtensions/Intercepter_requêtes_HTTP	/fr/docs/Mozilla/Add-ons/WebExtensions/Intercept_HTTP_requests
 /fr/docs/Mozilla/Add-ons/WebExtensions/Travailler_avec_l_API_Tabs	/fr/docs/Mozilla/Add-ons/WebExtensions/Working_with_the_Tabs_API
+/fr/docs/Mozilla/Add-ons/WebExtensions/Using_the_JavaScript_APIs	/fr/docs/Mozilla/Add-ons/WebExtensions/API
 /fr/docs/Mozilla/Add-ons/WebExtensions/construction_extension_cross_browser	/fr/docs/Mozilla/Add-ons/WebExtensions/Build_a_cross_browser_extension
 /fr/docs/Mozilla/Add-ons/WebExtensions/extension_des_outils_de_developpement	/fr/docs/Mozilla/Add-ons/WebExtensions/Extending_the_developer_tools
 /fr/docs/Mozilla/Add-ons/WebExtensions/inserer_en_toute_securite_du_contenu_externe_dans_une_page	/fr/docs/Mozilla/Add-ons/WebExtensions/Safely_inserting_external_content_into_a_page
@@ -3103,7 +3104,6 @@
 /fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/elements_menu_contextuel	/fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/Context_menu_items
 /fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/pages_web_incluses	/fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/Extension_pages
 /fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/panneaux_devtools	/fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/devtools_panels
-/fr/docs/Mozilla/Add-ons/WebExtensions/Using_the_JavaScript_APIs	/fr/docs/Mozilla/Add-ons/WebExtensions/API
 /fr/docs/Mozilla/Firefox/Versions	/fr/docs/Mozilla/Firefox/Releases
 /fr/docs/Mozilla/Firefox/Versions/1.5	/fr/docs/Mozilla/Firefox/Releases/1.5
 /fr/docs/Mozilla/Firefox/Versions/11	/fr/docs/Mozilla/Firefox/Releases/11

--- a/files/fr/_redirects.txt
+++ b/files/fr/_redirects.txt
@@ -3103,6 +3103,7 @@
 /fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/elements_menu_contextuel	/fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/Context_menu_items
 /fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/pages_web_incluses	/fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/Extension_pages
 /fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/panneaux_devtools	/fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/devtools_panels
+/fr/docs/Mozilla/Add-ons/WebExtensions/Using_the_JavaScript_APIs    /fr/docs/Mozilla/Add-ons/WebExtensions/API
 /fr/docs/Mozilla/Firefox/Versions	/fr/docs/Mozilla/Firefox/Releases
 /fr/docs/Mozilla/Firefox/Versions/1.5	/fr/docs/Mozilla/Firefox/Releases/1.5
 /fr/docs/Mozilla/Firefox/Versions/11	/fr/docs/Mozilla/Firefox/Releases/11

--- a/files/fr/_redirects.txt
+++ b/files/fr/_redirects.txt
@@ -3103,7 +3103,7 @@
 /fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/elements_menu_contextuel	/fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/Context_menu_items
 /fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/pages_web_incluses	/fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/Extension_pages
 /fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/panneaux_devtools	/fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/devtools_panels
-/fr/docs/Mozilla/Add-ons/WebExtensions/Using_the_JavaScript_APIs    /fr/docs/Mozilla/Add-ons/WebExtensions/API
+/fr/docs/Mozilla/Add-ons/WebExtensions/Using_the_JavaScript_APIs	/fr/docs/Mozilla/Add-ons/WebExtensions/API
 /fr/docs/Mozilla/Firefox/Versions	/fr/docs/Mozilla/Firefox/Releases
 /fr/docs/Mozilla/Firefox/Versions/1.5	/fr/docs/Mozilla/Firefox/Releases/1.5
 /fr/docs/Mozilla/Firefox/Versions/11	/fr/docs/Mozilla/Firefox/Releases/11

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/sendrequest/index.html
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/sendrequest/index.html
@@ -30,7 +30,7 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/extension/sendRequest
 )
 </pre>
 
-<p>Cette API est également disponible en tant que <code>browser.extension.sendRequest()</code> dans une <a href="/en-US/Add-ons/WebExtensions/Using_the_JavaScript_APIs#Callbacks_and_promises">version qui renvoie une promise</a>.</p>
+<p>Cette API est également disponible en tant que <code>browser.extension.sendRequest()</code> dans une <a href="/en-US/Add-ons/WebExtensions/API#Callbacks_and_promises">version qui renvoie une promise</a>.</p>
 
 <h3 id="Paramètres">Paramètres</h3>
 

--- a/files/fr/mozilla/add-ons/webextensions/what_next_/index.html
+++ b/files/fr/mozilla/add-ons/webextensions/what_next_/index.html
@@ -53,7 +53,7 @@ original_slug: Mozilla/Add-ons/WebExtensions/que_faire_ensuite
 <p>Maintenant, vous savez ce qui nous attend, il est temps de plonger dans plus de détails sur le développement de l'extension du navigateur. Dans les sections suivantes, vous découvrirez :</p>
 
 <ul>
- <li>En savoir plus sur les concepts fondamentaux des extensions de navigateur, en commençant par les détails sur l'<a href="/fr/Add-ons/WebExtensions/Using_the_JavaScript_APIs">utilisation des APIs Javascript</a>.</li>
+ <li>En savoir plus sur les concepts fondamentaux des extensions de navigateur, en commençant par les détails sur l'<a href="/fr/Add-ons/WebExtensions/API">utilisation des APIs Javascript</a>.</li>
  <li>Un guide des <a href="/fr/Add-ons/WebExtensions/user_interface">composants de l'interface utilisateur</a> disponibles pour les extensions de votre navigateur.</li>
  <li>Une collection de guides pratiques sur la réalisation des tâches clés dans vos extensions ou l'utilisation des API JavaScript.</li>
  <li>Un guide de référence complet sur les <a href="/fr/docs/Mozilla/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs">APIs JavaScript</a>.</li>


### PR DESCRIPTION
This PR fixes https://github.com/mdn/translated-content/issues/1692

I went ahead and copied what the japan version does for `_redirects.txt` file and applied the new page to the other references in French