### PR TITLE
Modify the second step of new operator

### DIFF
--- a/files/zh-cn/web/javascript/reference/operators/new/index.html
+++ b/files/zh-cn/web/javascript/reference/operators/new/index.html
@@ -39,7 +39,7 @@ translation_of: Web/JavaScript/Reference/Operators/new
 
 <ol>
  <li>创建一个空的简单JavaScript对象（即<code><strong>{}</strong></code>）；</li>
- <li>链接该对象（设置该对象的<font face="consolas, Liberation Mono, courier, monospace"><span style="background-color: rgba(220, 220, 220, 0.5);"><strong>constructor</strong></span></font>）到另一个对象 ；</li>
+ <li>为步骤1新创建的对象添加属性<font face="consolas, Liberation Mono, courier, monospace"><span style="background-color: rgba(220, 220, 220, 0.5);"><strong>__proto__</strong></span></font>，将该属性链接至构造函数的原型对象 ；</li>
  <li>将步骤1新创建的对象作为<code><strong>this</strong></code>的上下文 ；</li>
  <li>如果该函数没有返回对象，则返回<code><strong>this</strong></code>。</li>
 </ol>


### PR DESCRIPTION
Hi, I make a modification about the description of the second step on the page about `new` operator.
The orignal one was confused me because of the two 对象. According to the English version, I make this change to match that one.
Please let me know if there are any question. Thanks.

您好，我对 `new` 操作符中的第二步描述做了修改。
原始版本中的两个“对象”存在歧义，在我第一次阅读时理解很困难。对照英文版本，我做了对应的修改进行匹配。
如果该 PR 存在哪些问题，请联系我。谢谢~