### PR TITLE
fix: word translation

### DIFF
--- a/files/pt-br/web/html/element/meta/index.html
+++ b/files/pt-br/web/html/element/meta/index.html
@@ -53,7 +53,7 @@ translation_of: Web/HTML/Element/meta
   <li>Autores não devem usar codificações incompatíveis com ASCII (<br>
    isto é, aqueles que não mapeiam os pontos de código de 8 bits 0x20 a 0x7E para os pontos de código Unicode 0x0020 a 0x007E), pois representam um risco de segurança: navegadores que não os suportam podem interpretar conteúdo maligno como Elementos HTML. Esse é o caso de pelo menos os seguintes caracteres: JIS_C6226-1983, JIS_X0212-1990, HZ-GB-2312, JOHAB, a família ISO-2022 e a família EBCDIC.</li>
   <li>Autores não devem usar CESU-8, UTF-7, BOCU-1 e SCSU, also falling in that category and not intended to be used on the web. Cross-scripting attacks with some of these encodings have been documented.</li>
-  <li>Autores não devem usar UTF-32 pois nem todos algorítimos de codificção HTML5 conseguem distingui-lo do UTF-16.</li>
+  <li>Autores não devem usar UTF-32 pois nem todos algorítimos de codificação HTML5 conseguem distingui-lo do UTF-16.</li>
  </ul>
 
  <div class="note"><strong>Notas:</strong>

--- a/files/pt-br/web/html/element/meta/index.html
+++ b/files/pt-br/web/html/element/meta/index.html
@@ -51,7 +51,7 @@ translation_of: Web/HTML/Element/meta
  <ul>
   <li>Autores são encorajados a usar UTF-8.</li>
   <li>Autores não devem usar codificações incompatíveis com ASCII (<br>
-   isto é, aqueles que não mapeiam os pontos de código de 8 bits 0x20 a 0x7E para os pontos de código Unicode 0x0020 a 0x007E), pois representam um risco de segurança: navegadores que não os suportam podem interpretar conteúdo benigno como Elementos HTML. Esse é o caso de pelo menos os seguintes caracteres: JIS_C6226-1983, JIS_X0212-1990, HZ-GB-2312, JOHAB, a família ISO-2022 e a família EBCDIC.</li>
+   isto é, aqueles que não mapeiam os pontos de código de 8 bits 0x20 a 0x7E para os pontos de código Unicode 0x0020 a 0x007E), pois representam um risco de segurança: navegadores que não os suportam podem interpretar conteúdo maligno como Elementos HTML. Esse é o caso de pelo menos os seguintes caracteres: JIS_C6226-1983, JIS_X0212-1990, HZ-GB-2312, JOHAB, a família ISO-2022 e a família EBCDIC.</li>
   <li>Autores não devem usar CESU-8, UTF-7, BOCU-1 e SCSU, also falling in that category and not intended to be used on the web. Cross-scripting attacks with some of these encodings have been documented.</li>
   <li>Autores não devem usar UTF-32 pois nem todos algorítimos de codificção HTML5 conseguem distingui-lo do UTF-16.</li>
  </ul>


### PR DESCRIPTION
"benigno" to "maligno"
Regarding the use of ASCII incompatible charsets

edit: fixed a typo on the same file "codificção" > "codificação"