### PR TITLE
French translation for the `descent-override` CSS descriptor reference

### DIFF
--- a/files/fr/web/css/@font-face/descent-override/index.html
+++ b/files/fr/web/css/@font-face/descent-override/index.html
@@ -6,7 +6,7 @@ translation_of: 'Web/CSS/@font-face/descent-override'
 ---
 <p>{{CSSRef}}</p>
 
-<p>Le descripteur CSS <strong><code>descent-override</code></strong> définit la mesure du jambage inférieur (descendant) de la police. La mesure du jambage inférieur correspond à la distance verticale par rapport à la hauteur d'X (hauteur du caractère bas de casse, à l'exclusion des jambages inférieurs et supérieurs) que CSS doit utiliser pour agencer les boîtes dans un contexte de formatage en ligne.</p>
+<p>Le descripteur CSS <strong><code>descent-override</code></strong> définit la mesure du jambage inférieur (descendant) de la police (voir la <a class="external" href="https://fr.wikipedia.org/wiki/Jambage">définition de jambage</a>). La mesure du jambage inférieur correspond à la distance verticale par rapport à la hauteur d'X (hauteur du caractère bas de casse, à l'exclusion des jambages inférieurs et supérieurs) que CSS doit utiliser pour agencer les boîtes dans un contexte de formatage en ligne.</p>
 
 <h2 id="syntax">Syntaxe</h2>
 
@@ -19,7 +19,7 @@ descent-override: 90%;</pre>
   <dt><code>normal</code></dt>
   <dd>La valeur par défaut. La mesure du jambage inférieur est obtenue à partir du fichier de police.</dd>
   <dt><code>&lt;percentage&gt;</code></dt>
-  <dd>Une valeur exprimée en {{cssxref("&lt;percentage&gt;", "&lt;pourcentage&gt;")}}.</dd>
+  <dd>Une valeur exprimée en pourcentage (type {{cssxref("&lt;percentage&gt;")}}) qui traduit l'augmentation ou la réduction par rapport à la taille de la police ({{cssxref("font-size")}}.</dd>
 </dl>
 
 <h2 id="formal_definition">Définition formelle</h2>

--- a/files/fr/web/css/@font-face/descent-override/index.html
+++ b/files/fr/web/css/@font-face/descent-override/index.html
@@ -1,0 +1,74 @@
+---
+title: descent-override
+slug: Web/CSS/@font-face/descent-override
+browser-compat: css.at-rules.font-face.descent-override
+translation_of: 'Web/CSS/@font-face/descent-override'
+---
+<p>{{CSSRef}}</p>
+
+<p>Le descripteur CSS <strong><code>descent-override</code></strong> définit la mesure du jambage inférieur (descendant) de la police. La mesure du jambage inférieur correspond à la distance verticale par rapport à la hauteur d'X (hauteur du caractère bas de casse, à l'exclusion des jambages inférieurs et supérieurs) que CSS doit utiliser pour agencer les boîtes dans un contexte de formatage en ligne.</p>
+
+<h2 id="syntax">Syntaxe</h2>
+
+<pre class="brush: css">descent-override: normal;
+descent-override: 90%;</pre>
+
+<h3 id="values">Valeurs</h3>
+
+<dl>
+  <dt><code>normal</code></dt>
+  <dd>La valeur par défaut. La mesure du jambage inférieur est obtenue à partir du fichier de police.</dd>
+  <dt><code>&lt;percentage&gt;</code></dt>
+  <dd>Une valeur exprimée en {{cssxref("&lt;percentage&gt;", "&lt;pourcentage&gt;")}}.</dd>
+</dl>
+
+<h2 id="formal_definition">Définition formelle</h2>
+
+<p>{{cssinfo}}</p>
+
+<h2 id="formal_syntax">Syntaxe formelle</h2>
+
+<p>{{csssyntax}}</p>
+
+<h2 id="examples">Exemples</h2>
+
+<h3 id="overriding_metrics_of_a_fallback_font">Surcharge de la mesure d'une police de recours</h3>
+
+<p>La propriété <code>descent-override</code> peut aider à la surcharge de la mesure d'une police de secours pour qu'elle corresponde mieux à celle de la police principale.</p>
+
+<pre class="brush: css">@font-face {
+  font-family: web-font;
+  src: url("https://example.com/font.woff");
+}
+
+@font-face {
+  font-family: local-font;
+  src: local(Local Font);
+  descent-override: 125%;
+}</pre>
+
+<h2 id="specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="see_also">Voir aussi</h2>
+
+<ul>
+ <li>{{cssxref("@font-face/ascent-override", "ascent-override")}}</li>
+ <li>{{cssxref("@font-face/font-display", "font-display")}}</li>
+ <li>{{cssxref("@font-face/font-family", "font-family")}}</li>
+ <li>{{cssxref("@font-face/font-weight", "font-weight")}}</li>
+ <li>{{cssxref("@font-face/font-style", "font-style")}}</li>
+ <li>{{cssxref("@font-face/font-stretch", "font-stretch")}}</li>
+ <li>{{cssxref("@font-face/font-variant", "font-variant")}}</li>
+ <li>{{cssxref("font-feature-settings", "font-feature-settings")}}</li>
+ <li>{{cssxref("@font-face/font-variation-settings", "font-variation-settings")}}</li>
+ <li>{{cssxref("@font-face/line-gap-override", "line-gap-override")}}</li>
+ <li>{{cssxref("@font-face/src", "src")}}</li>
+ <li>{{cssxref("@font-face/size-adjust", "size-adjust")}}</li>
+ <li>{{cssxref("@font-face/unicode-range", "unicode-range descriptor")}}</li>
+</ul>


### PR DESCRIPTION
This PR adds a French translation for the `descent-override` CSS descriptor reference.
See also #1752 

Please note that I asked a question about the best practice for `cssxref` references translation here: https://matrix.to/#/!pGdhkeiUTYDIWuskqX:mozilla.org/$bdvXKWkU1RyybuAjp0JmacC9RK8I2r7sF6yuhtIIFZM?via=mozilla.org&via=t2bot.io&via=matrix.org