### PR TITLE
French API reference: various typo fixes

### DIFF
--- a/files/fr/orphaned/web/reference/api/index.html
+++ b/files/fr/orphaned/web/reference/api/index.html
@@ -4,9 +4,9 @@ slug: orphaned/Web/Reference/API
 translation_of: Web/Reference/API
 original_slug: Web/Reference/API
 ---
-<p><span class="seoSummary">Le Web offre une grande variété d'API pour effectuer diverses tâches utiles. Ceux-ci peuvent être accessibles en utilisant le code JavaScript, et vous permettent de faire tout ce que vous voulez, depuis des ajustements mineurs sur un {{domxref ("window")}} ou un {{domxref ("element")}}, jusqu'à générer des effets graphiques et sonores complexes en utilisant des API telles que <a href="/fr/docs/Web/WebGL">WebGL</a> et <a href="/fr/docs/Web/API/Web_Audio_API">Web Audio</a> .</span></p>
+<p><span class="seoSummary">Le Web offre une grande variété d'API pour effectuer diverses tâches utiles. Celles-ci peuvent être accessibles en utilisant le code JavaScript, et vous permettent de faire tout ce que vous voulez, depuis des ajustements mineurs sur un {{domxref ("window")}} ou un {{domxref ("element")}}, jusqu'à générer des effets graphiques et sonores complexes en utilisant des API telles que <a href="/fr/docs/Web/WebGL">WebGL</a> et <a href="/fr/docs/Web/API/Web_Audio_API">Web Audio</a>.</span></p>
 
-<p>Chaque interface individuelle dans toutes les API est listée dans l'<a href="/fr/docs/Web/API">index.</a></p>
+<p>Chaque interface individuelle dans toutes les API est listée dans l'<a href="/fr/docs/Web/API">index</a>.</p>
 
 <p>Il y a aussi une <a href="/fr/docs/Web/Events">liste de tous les événements disponibles</a> dans la référence des événements.</p>
 
@@ -26,8 +26,8 @@ original_slug: Web/Reference/API
 <p>En plus de ces API qui sont disponibles pour n'importe quel site Web ou application, de plus puissantes API Mozilla sont disponibles pour les applications privilégiées et certifiées.</p>
 
 <dl>
- <dt>API privilégiés</dt>
- <dd>Une application privilégiée est une application installée, a laquelle l'utilisateur a donné des droits spécifiques. Les API privilégiés comprennent : <a href="/fr/docs/Web/API/TCP_Socket_API" title="WebAPI / TCP_Socket">API Socket TCP</a>,  <a href="/fr/docs/Web/API/Contacts_API" title="WebAPI / contacts">API Contacts</a>, <a href="/fr/docs/Web/API/Device_Storage_API" title="WebAPI / Device_Storage_API">API de stockage de l'appareil</a>, <a href="/fr/docs/WebAPI/Browser" title="DOM / Using_the_Browser_API">API du navigateur</a>,</dd>
+ <dt>API privilégiées</dt>
+ <dd>Une application privilégiée est une application installée, à laquelle l'utilisateur a donné des droits spécifiques. Les API privilégiées comprennent : <a href="/fr/docs/Web/API/TCP_Socket_API" title="WebAPI / TCP_Socket">API Socket TCP</a>,  <a href="/fr/docs/Web/API/Contacts_API" title="WebAPI / contacts">API Contacts</a>, <a href="/fr/docs/Web/API/Device_Storage_API" title="WebAPI / Device_Storage_API">API de stockage de l'appareil</a>, <a href="/fr/docs/WebAPI/Browser" title="DOM / Using_the_Browser_API">API du navigateur</a>,</dd>
  <dt>API certifiées</dt>
  <dd>Une application certifiée est une application de bas niveau effectuant des opérations critiques sur un système d'exploitation comme Firefox OS. L'application moins privilégiée interagit avec ces applications en utilisant des <a href="/fr/docs/Web/API/Web_Activities" title="WebAPI / Web_Activities">Activités Web</a>. Les API certifiés comprennent : <a href="/fr/docs/WebAPI/WebBluetooth" title="WebAPI / WebBluetooth">API Bluetooth</a>, <a href="/fr/docs/WebAPI/Mobile_Connection" title="WebAPI / Mobile_Connection">API de connexion mobile</a>, <a href="/fr/docs/WebAPI/Network_Stats" title="WebAPI / Network_Stats">API Statistiques réseau</a>, <a href="/fr/docs/Web/Guide/Telephony" title="WebAPI / WebTelephony">téléphonie</a>, <a href="/fr/docs/WebAPI/WebSMS" title="WebAPI / WebSMS">SMS par Internet</a>, <a href="/fr/docs/WebAPI/WiFi_Information" title="WebAPI / WiFi_Information">API Informations WiFi</a>, <a href="/fr/docs/WebAPI/Camera" title="WebAPI / caméra">API de l'appareil photo</a>, <a href="/fr/docs/WebAPI/Power_Management" title="WebAPI / Power_Management">API de gestion de l'alimentation</a>, <a href="/fr/docs/Web/API/Settings_API" title="WebAPI / Paramètres">API Paramètres</a>, <a href="/fr/docs/WebAPI/Idle" title="WebAPI / Device_Storage_API">API veille</a>, <a href="/fr/docs/Web/API/Permissions_API" title="WebAPI / Autorisations">API Autorisations</a>, <a href="/fr/docs/Web/API/Time_and_Clock_API" title="WebAPI / Time_and_Clock">API Horloge</a>.</dd>
 </dl>
@@ -45,7 +45,7 @@ original_slug: Web/Reference/API
  <li><a class="external" href="http://groups.google.com/group/mozilla.dev.webapi/feeds">comme un flux Web</a></li>
 </ul>
 
-<p>Aussi, n'oubliez pas de vous joindre à la discussion en direct dans le <a href="irc://irc.mozilla.org/webapi">WebAPI #</a> canal <a class="external" href="https://wiki.mozilla.org/IRC">IRC</a> .</p>
+<p>Aussi, n'oubliez pas de vous joindre à la discussion en direct dans le canal <a class="external" href="https://wiki.mozilla.org/IRC">IRC</a> <a href="irc://irc.mozilla.org/webapi">#WebAPI</a>.</p>
 
 <h2 class="Related_Topics" id="Rubriques_connexes">Rubriques connexes</h2>
 


### PR DESCRIPTION
This PR fixes various typos on the French API reference page.