### PR TITLE
修正指向维基百科的链接 (fix broken link to wikipedia)

### DIFF
--- a/files/zh-cn/web/http/status/451/index.html
+++ b/files/zh-cn/web/http/status/451/index.html
@@ -18,7 +18,7 @@ translation_of: Web/HTTP/Status/451
 
 <h2 id="示例">示例</h2>
 
-<p>这个响应示例来自 IETF RFC 规范（见下文），其中提到了英国戏剧电影{{interwiki("wikipedia", "Monty_Python's_Life_of_Brian", "Monty Python's Life of Brian")}} （《蒙提·派森之布莱恩的一生》）。</p>
+<p>这个响应示例来自 IETF RFC 规范（见下文），其中提到了英国戏剧电影{{interwiki("wikipedia", "蒙提·派森之布莱恩的一生", "Monty Python's Life of Brian")}} （《蒙提·派森之布莱恩的一生》）。</p>
 
 <p>注意 {{HTTPHeader("Link")}} 首部中可能会包含一个 <code>rel="blocked-by"</code> 字段，用于标明为该资源无法提供负责的主体，例如颁布法令将资源删除的个人或组织的名称。</p>
 


### PR DESCRIPTION
正确的链接地址应为：<https://zh.wikipedia.org/wiki/蒙提·派森之布莱恩的一生>