### PR TITLE
(ru): Fix typo on "Request header" page at glossary

### DIFF
--- a/files/ru/glossary/request_header/index.html
+++ b/files/ru/glossary/request_header/index.html
@@ -6,7 +6,7 @@ tags:
 translation_of: Glossary/Request_header
 original_slug: Глоссарий/Request_header
 ---
-<p><strong>Заголовок запроса</strong> - {{Glossary("header", "HTTP header")}} который используется в  HTTP-запросе и который не относиться к содержимому сообщения. Заголовки запроса, такие как {{HTTPHeader("Accept")}}, {{HTTPHeader("Accept-Language", "Accept-*")}} или {{HTTPHeader("If-Modified-Since", "If-*")}} позволяют выполнять условные запросы; другие, такие как {{HTTPHeader("Cookie")}}, {{HTTPHeader("User-Agent")}} или {{HTTPHeader("Referer")}} уточняют контекст, чтобы сервер мог адаптировать ответ.</p>
+<p><strong>Заголовок запроса</strong> - {{Glossary("header", "HTTP header")}} который используется в  HTTP-запросе и который не относится к содержимому сообщения. Заголовки запроса, такие как {{HTTPHeader("Accept")}}, {{HTTPHeader("Accept-Language", "Accept-*")}} или {{HTTPHeader("If-Modified-Since", "If-*")}} позволяют выполнять условные запросы; другие, такие как {{HTTPHeader("Cookie")}}, {{HTTPHeader("User-Agent")}} или {{HTTPHeader("Referer")}} уточняют контекст, чтобы сервер мог адаптировать ответ.</p>
 
 <p>Не все заголовки, появляющиеся в запросе, являются <em>заголовками запроса</em>. Например, {{HTTPHeader("Content-Length")}}, появляющийся в запросе {{HTTPMethod("POST")}}, на самом деле является {{Glossary("entity header", "заголовки сущности")}}, ссылающимся на размер тела сообщения запроса. Однако в таком контексте эти заголовки сущности часто называют заголовками запроса.</p>
 


### PR DESCRIPTION
Fixed typo in относиться word