### PR TITLE
French translation of the HTMLIFrameElement `contentdocument` reference

### DIFF
--- a/files/fr/web/api/htmliframeelement/contentdocument/index.html
+++ b/files/fr/web/api/htmliframeelement/contentdocument/index.html
@@ -4,7 +4,7 @@ slug: Web/API/HTMLIFrameElement/contentDocument
 browser-compat: api.HTMLIFrameElement.contentDocument
 translation_of: 'HTMLIFrameElement.contentDocument'
 ---
-<p>Si l'iframe et le document parent de l'<i lang="en">iframe</i> sont de la <a href="/fr/docs/Web/Security/Same-origin_policy">même origine</a>, <code>HTMLIFrameElement.contentDocument</code> retourne un <a href="/fr/docs/Web/API/Document" title="L'interface « Document » représente toute page web chargée dans le navigateur en tant que point d'entrée dans le contenu de la page, à savoir l'arbre DOM."><code>Document</code></a> (c'est à dire le document actif dans le contexte de navigation imbriqué du cadre. Sinon, il retourne <code>null</code>).</p>
+<p>Si l'<i lang="en">iframe</i> et le document parent de l'<i lang="en">iframe</i> sont de la <a href="/fr/docs/Web/Security/Same-origin_policy">même origine</a>, <code>HTMLIFrameElement.contentDocument</code> retourne un <a href="/fr/docs/Web/API/Document" title="L'interface « Document » représente toute page web chargée dans le navigateur en tant que point d'entrée dans le contenu de la page, à savoir l'arbre DOM."><code>Document</code></a> (c'est à dire le document actif dans le contexte de navigation imbriqué du cadre. Sinon, il retourne <code>null</code>).</p>
 
 <h2 id="example_of_contentDocument">Exemples</code></h2>
 

--- a/files/fr/web/api/htmliframeelement/contentdocument/index.html
+++ b/files/fr/web/api/htmliframeelement/contentdocument/index.html
@@ -4,9 +4,9 @@ slug: Web/API/HTMLIFrameElement/contentDocument
 browser-compat: api.HTMLIFrameElement.contentDocument
 translation_of: 'HTMLIFrameElement.contentDocument'
 ---
-<p>Si l'<i lang="en">iframe</i> et le document parent de l'<i lang="en">iframe</i> sont de la <a href="/fr/docs/Web/Security/Same-origin_policy">même origine</a>, <code>HTMLIFrameElement.contentDocument</code> retourne un <a href="/fr/docs/Web/API/Document" title="L'interface « Document » représente toute page web chargée dans le navigateur en tant que point d'entrée dans le contenu de la page, à savoir l'arbre DOM."><code>Document</code></a> (c'est à dire le document actif dans le contexte de navigation imbriqué du cadre. Sinon, il retourne <code>null</code>).</p>
+<p>Si l'<i lang="en">iframe</i> et le document parent de l'<i lang="en">iframe</i> sont de la <a href="/fr/docs/Web/Security/Same-origin_policy">même origine</a>, <code>HTMLIFrameElement.contentDocument</code> retourne un <a href="/fr/docs/Web/API/Document" title="L'interface « Document » représente toute page web chargée dans le navigateur en tant que point d'entrée dans le contenu de la page, à savoir l'arbre DOM."><code>Document</code></a> (c'est à dire le document actif dans le contexte de navigation imbriqué du cadre). Sinon, il retourne <code>null</code>.</p>
 
-<h2 id="example_of_contentDocument">Exemples</code></h2>
+<h2 id="examples">Exemples</code></h2>
 
 <pre class="brush: js">var iframeDocument = document.getElementsByTagName("iframe")[0].contentDocument;
 

--- a/files/fr/web/api/htmliframeelement/contentdocument/index.html
+++ b/files/fr/web/api/htmliframeelement/contentdocument/index.html
@@ -4,9 +4,9 @@ slug: Web/API/HTMLIFrameElement/contentDocument
 browser-compat: api.HTMLIFrameElement.contentDocument
 translation_of: 'HTMLIFrameElement.contentDocument'
 ---
-<p>Si l'iframe et le document parent de l'iframe sont de la <a href="/fr/docs/Web/Security/Same-origin_policy">même origine</a>, <code>HTMLIFrameElement.contentDocument</code> retourne un <a href="/fr/docs/Web/API/Document" title="L'interface « Document » représente toute page web chargée dans le navigateur en tant que point d'entrée dans le contenu de la page, à savoir l'arbre DOM."><code>Document</code></a> (c'est à dire le document actif dans le contexte de navigation imbriqué du cadre. Sinon, il retourne <code>null</code>.</p>
+<p>Si l'iframe et le document parent de l'<i lang="en">iframe</i> sont de la <a href="/fr/docs/Web/Security/Same-origin_policy">même origine</a>, <code>HTMLIFrameElement.contentDocument</code> retourne un <a href="/fr/docs/Web/API/Document" title="L'interface « Document » représente toute page web chargée dans le navigateur en tant que point d'entrée dans le contenu de la page, à savoir l'arbre DOM."><code>Document</code></a> (c'est à dire le document actif dans le contexte de navigation imbriqué du cadre. Sinon, il retourne <code>null</code>).</p>
 
-<h2 id="example_of_contentDocument">Exemple d'utilisation de <code>contentDocument</code></h2>
+<h2 id="example_of_contentDocument">Exemples</code></h2>
 
 <pre class="brush: js">var iframeDocument = document.getElementsByTagName("iframe")[0].contentDocument;
 

--- a/files/fr/web/api/htmliframeelement/contentdocument/index.html
+++ b/files/fr/web/api/htmliframeelement/contentdocument/index.html
@@ -1,0 +1,22 @@
+---
+title: HTMLIFrameElement.contentDocument
+slug: Web/API/HTMLIFrameElement/contentDocument
+browser-compat: api.HTMLIFrameElement.contentDocument
+translation_of: 'HTMLIFrameElement.contentDocument'
+---
+<p>Si l'iframe et le document parent de l'iframe sont de la <a href="/fr/docs/Web/Security/Same-origin_policy">même origine</a>, <code>HTMLIFrameElement.contentDocument</code> retourne un <a href="/fr/docs/Web/API/Document" title="L'interface « Document » représente toute page web chargée dans le navigateur en tant que point d'entrée dans le contenu de la page, à savoir l'arbre DOM."><code>Document</code></a> (c'est à dire le document actif dans le contexte de navigation imbriqué du cadre. Sinon, il retourne <code>null</code>.</p>
+
+<h2 id="example_of_contentDocument">Exemple d'utilisation de <code>contentDocument</code></h2>
+
+<pre class="brush: js">var iframeDocument = document.getElementsByTagName("iframe")[0].contentDocument;
+
+iframeDocument.body.style.backgroundColor = "blue";
+// Cela passe la couleur d'arrière-plan de l'iframe en bleu.</pre>
+
+<h2 id="specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>


### PR DESCRIPTION
This PR creates the French translation of the HTMLIFrameElement `contentdocument` reference.