### PR TITLE
Remove some headers from CORS-safelisted request-header

### DIFF
--- a/files/de/web/http/cors/index.html
+++ b/files/de/web/http/cors/index.html
@@ -82,11 +82,6 @@ translation_of: Web/HTTP/CORS
    <li>{{HTTPHeader("Accept-Language")}}</li>
    <li>{{HTTPHeader("Content-Language")}}</li>
    <li>{{HTTPHeader("Content-Type")}} (but note the additional requirements below)</li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#dpr">DPR</a></code></li>
-   <li>{{HTTPHeader("Downlink")}}</li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#save-data">Save-Data</a></code></li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#viewport-width">Viewport-Width</a></code></li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#width">Width</a></code></li>
   </ul>
  </li>
  <li>The only allowed values for the {{HTTPHeader("Content-Type")}} header are:

--- a/files/fr/web/http/cors/index.html
+++ b/files/fr/web/http/cors/index.html
@@ -75,11 +75,6 @@ translation_of: Web/HTTP/CORS
    <li>{{HTTPHeader("Accept-Language")}}</li>
    <li>{{HTTPHeader("Content-Language")}}</li>
    <li>{{HTTPHeader("Content-Type")}} (cf. les contraintes supplémentaires ci-après)</li>
-   <li>{{HTTPHeader("Last-Event-ID")}}</li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#dpr">DPR</a></code></li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#save-data">Save-Data</a></code></li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#viewport-width">Viewport-Width</a></code></li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#width">Width</a></code></li>
   </ul>
  </li>
  <li>Les seules valeurs autorisées pour l'en-tête {{HTTPHeader("Content-Type")}} sont :

--- a/files/ja/web/http/cors/index.html
+++ b/files/ja/web/http/cors/index.html
@@ -80,11 +80,6 @@ translation_of: Web/HTTP/CORS
    <li>{{HTTPHeader("Accept-Language")}}</li>
    <li>{{HTTPHeader("Content-Language")}}</li>
    <li>{{HTTPHeader("Content-Type")}} (但し、下記の要件を満たすもの)</li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#dpr">DPR</a></code></li>
-   <li>{{HTTPHeader("Downlink")}}</li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#save-data">Save-Data</a></code></li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#viewport-width">Viewport-Width</a></code></li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#width">Width</a></code></li>
   </ul>
  </li>
  <li>{{HTTPHeader("Content-Type")}} ヘッダーでは以下の値のみが許可されています。

--- a/files/ko/web/http/cors/index.html
+++ b/files/ko/web/http/cors/index.html
@@ -73,11 +73,6 @@ translation_of: Web/HTTP/CORS
    <li>{{HTTPHeader("Accept-Language")}}</li>
    <li>{{HTTPHeader("Content-Language")}}</li>
    <li>{{HTTPHeader("Content-Type")}} (아래의 추가 요구 사항에 유의하세요.)</li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#dpr">DPR</a></code></li>
-   <li>{{HTTPHeader("Downlink")}}</li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#save-data">Save-Data</a></code></li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#viewport-width">Viewport-Width</a></code></li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#width">Width</a></code></li>
   </ul>
  </li>
  <li>{{HTTPHeader("Content-Type")}} 헤더는 다음의 값들만 허용됩니다.

--- a/files/pt-br/web/http/cors/index.html
+++ b/files/pt-br/web/http/cors/index.html
@@ -74,11 +74,6 @@ original_slug: Web/HTTP/Controle_Acesso_CORS
    <li>{{HTTPHeader("Accept-Language")}}</li>
    <li>{{HTTPHeader("Content-Language")}}</li>
    <li>{{HTTPHeader("Content-Type")}} (porém observe os requisitos adicionais abaixo)</li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#dpr">DPR</a></code></li>
-   <li>{{HTTPHeader("Downlink")}}</li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#save-data">Save-Data</a></code></li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#viewport-width">Viewport-Width</a></code></li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#width">Width</a></code></li>
   </ul>
  </li>
  <li>Os únicos valores permitidos para o {{HTTPHeader("Content-Type")}} do cabeçalho são:

--- a/files/ru/web/http/cors/index.html
+++ b/files/ru/web/http/cors/index.html
@@ -68,11 +68,6 @@ translation_of: Web/HTTP/CORS
    <li>{{HTTPHeader("Accept-Language")}}</li>
    <li>{{HTTPHeader("Content-Language")}}</li>
    <li>{{HTTPHeader("Content-Type")}} (но учитывайте примечание ниже)</li>
-   <li>{{HTTPHeader("Last-Event-ID")}}</li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#dpr">DPR</a></code></li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#save-data">Save-Data</a></code></li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#viewport-width">Viewport-Width</a></code></li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#width">Width</a></code></li>
   </ul>
  </li>
  <li>Допустимыми значениями заголовка {{HTTPHeader("Content-Type")}} являются:

--- a/files/zh-cn/web/http/cors/index.html
+++ b/files/zh-cn/web/http/cors/index.html
@@ -81,11 +81,6 @@ original_slug: Web/HTTP/Access_control_CORS
    <li>{{HTTPHeader("Accept-Language")}}</li>
    <li>{{HTTPHeader("Content-Language")}}</li>
    <li>{{HTTPHeader("Content-Type")}} （需要注意额外的限制）</li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#dpr">DPR</a></code></li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#downlink">Downlink</a></code></li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#save-data">Save-Data</a></code></li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#viewport-width">Viewport-Width</a></code></li>
-   <li><code><a href="http://httpwg.org/http-extensions/client-hints.html#width">Width</a></code></li>
   </ul>
  </li>
  <li>{{HTTPHeader("Content-Type")}} 的值仅限于下列三者之一：


### PR DESCRIPTION
Thank you for your great work. Your translations always help me.

I found that the cors pages don't follow [the English page](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) and the [spec](https://fetch.spec.whatwg.org/#cors-safelisted-request-header).
CORS-safelisted request-headers are now only `Accept`, `Accept-Language`, `Content-Language`, `Content-Type`. The others were dropped.

The English page was fixed in https://github.com/mdn/content/pull/411.