### PR TITLE
[Ko] replace clientHeight example with image

### DIFF
--- a/files/ko/web/api/element/clientheight/index.html
+++ b/files/ko/web/api/element/clientheight/index.html
@@ -21,21 +21,7 @@ translation_of: Web/API/Element/clientHeight
 
 <h2 id="Example" name="Example">예</h2>
 
-<div id="offsetContainer" style="margin: 26px 0px; background-color: rgb(255, 255, 204); border: 4px dashed black; color: black; position: absolute; left: 260px;">
-<div id="idDiv" style="margin: 24px 29px; border: 24px black solid; padding: 0px 28px; width: 199px; height: 102px; overflow: auto; background-color: white; font-size: 13px!important; font-family: Arial, sans-serif;">
-<p id="PaddingTopLabel" style="text-align: center; font-style: italic; font-weight: bold; font-size: 13px!important; font-family: Arial, sans-serif; margin: 0px;">padding-top</p>
-
-<p>Gentle, individualistic and very loyal, Birman cats fall between Siamese and Persian in character. If you admire cats that are non aggressive, that enjoy being with humans and tend to be on the quiet side, you may well find that Birman cats are just the felines for you.</p>
-
-<p><span style="float: right;"><img alt="Image:BirmanCat.jpg"></span>All Birmans have colorpointed features, dark coloration of the face, ears, legs and tail.</p>
-
-<p>Cat image and text coming from <a class="external" href="http://www.best-cat-art.com/" rel="freelink">http://www.best-cat-art.com/</a></p>
-
-<p id="PaddingBottomLabel" style="text-align: center; font-style: italic; font-weight: bold; font-size: 13px!important; font-family: Arial, sans-serif; margin: 0px;">padding-bottom</p>
-</div>
-<strong style="color: blue; font-family: Arial,sans-serif; font-size: 13px!important; font-weight: bold; left: -32px; position: absolute; top: 85px;">Left</strong><strong style="color: blue; font-family: Arial,sans-serif; font-size: 13px!important; font-weight: bold; left: 170px; position: absolute; top: -20px;">Top</strong><strong style="color: blue; font-family: Arial,sans-serif; font-size: 13px!important; font-weight: bold; left: 370px; position: absolute; top: 85px;">Right</strong><strong style="color: blue; font-family: Arial,sans-serif; font-size: 13px!important; font-weight: bold; left: 164px; position: absolute; top: 203px;">Bottom</strong><em>margin-top</em><em>margin-bottom</em><em>border-top</em><em>border-bottom</em></div>
-
-<p style="margin-top: 270px;"> </p>
+<p><img alt="Image:Dimensions-client.png" src="https://developer.mozilla.org/@api/deki/files/185/=Dimensions-client.png"/></p>
 
 <h2 id="Specification" name="Specification">스펙 정의</h2>
 


### PR DESCRIPTION

Replace a broken-looking example with an image, such as en-US.

#### ko
- https://developer.mozilla.org/en-US/docs/Web/API/Element/clientHeight

#### en-US
- https://developer.mozilla.org/ko/docs/Web/API/Element/clientHeight
