### PR TITLE
fix: Math.atan2, Math.ceil, Math.pow and Math.round

### DIFF
--- a/files/pt-br/web/javascript/equality_comparisons_and_sameness/index.html
+++ b/files/pt-br/web/javascript/equality_comparisons_and_sameness/index.html
@@ -400,7 +400,7 @@ function attemptMutation(v)
 </dl>
 
 <dl>
- <dd>É possível que um -0 para ser introduzido em uma expressão como um valor de retorno desses métodos, em alguns casos, mesmo quando nenhum -0 exista como um dos parâmetros. Por exemplo, usando <a href="/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Math/pow" title="/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Math/pow">Math.pow</a> para levantar -<a href="/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Infinity" title="/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Infinity">Infinity</a> para o poder de qualquer, expoente ímpar negativo avaliada como -0. Consulte a documentação para os métodos individuais.</dd>
+ <dd>É possível que um -0 para ser introduzido em uma expressão como um valor de retorno desses métodos, em alguns casos, mesmo quando nenhum -0 exista como um dos parâmetros. Por exemplo, usando <a href="/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Math/pow" title="/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Math/pow">Math.pow</a> para levantar -<a href="/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Infinity" title="/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Infinity">Infinity</a> a potência de qualquer número, expoente ímpar negativo avaliada como -0. Consulte a documentação para os métodos individuais.</dd>
 </dl>
 
 <dl>


### PR DESCRIPTION
Corrige tradução da descrição dos métodos Math.atan2, Math.ceil, Math.pow e Math.round quando utilizado Objetct.is