### PR TITLE
Fix md conversion reports: code

### DIFF
--- a/files/fr/web/javascript/guide/regular_expressions/character_classes/index.html
+++ b/files/fr/web/javascript/guide/regular_expressions/character_classes/index.html
@@ -116,21 +116,21 @@ original_slug: Web/JavaScript/Guide/Expressions_régulières/Classes_de_caractè
    <td>Correspond au caractère NULL (U+0000). Il ne doit pas être suivi d'un autre chiffre car <code>\0&lt;chiffres&gt;</code> est une <a href="/fr/docs/Web/JavaScript/Guide/Types_et_grammaire#Les_caractères_d'échappement">séquence d'échappement</a> pour les nombres en notation octale (si besoin d'utiliser un chiffre ensuite, on pourra utiliser la forme <code>\x00</code>, cf. ci-après).</td>
   </tr>
   <tr>
-   <td><code>\c<em>X</em></code></td>
+   <td><code>\cX</code></td>
    <td>
     <p>Correspond au caractère de contrôle où <code><em>X</em></code> est une lettre entre A et Z. Correspond au caractèlres de contrôle correspondant entre <code>U+0001</code>-<code>U+001F</code>. Ainsi, <code>/\cM/</code> correspondra au caractère controle-M au sein d'une chaîne de caractères soit <code>"\r"</code> pour <code>"\r\n"</code>.</p>
    </td>
   </tr>
   <tr>
-   <td><code>\x<em>hh</em></code></td>
+   <td><code>\xhh</code></td>
    <td>Correspond au caractère dont le code hexadécimal est hh (deux chiffres hexadécimaux).</td>
   </tr>
   <tr>
-   <td><code>\u<em>hhhh</em></code></td>
+   <td><code>\uhhhh</code></td>
    <td>Correspond au caractère dont le code est hhhh (quatre chiffres hexadécimaux).</td>
   </tr>
   <tr>
-   <td><code>\u<em>{hhhh}</em></code><em> </em>ou<code> <em>\u{hhhhh}</em></code></td>
+   <td><code>\u{hhhh}</code> ou <code>\u{hhhhh}</code></td>
    <td>(Uniquement actif quand le marqueur <code>u</code> est activé) Correspond au caractère dont la valeur Unicode est <code>hhhh</code> (en chiffre hexadécimaux).</td>
   </tr>
   <tr>

--- a/files/fr/web/javascript/guide/regular_expressions/groups_and_ranges/index.html
+++ b/files/fr/web/javascript/guide/regular_expressions/groups_and_ranges/index.html
@@ -25,7 +25,7 @@ original_slug: Web/JavaScript/Guide/Expressions_régulières/Groupes_et_interval
  </thead>
  <tbody>
   <tr>
-   <td><code><em>x</em>|<em>y</em></code></td>
+   <td><code>x|y</code></td>
    <td>
     <p>Correspond à 'x' ou 'y'.</p>
 
@@ -33,16 +33,14 @@ original_slug: Web/JavaScript/Guide/Expressions_régulières/Groupes_et_interval
    </td>
   </tr>
   <tr>
-   <td><code>[xyz]<br>
-    [a-c]</code></td>
+   <td><code>[xyz]</code> ou <code>[a-c]</code></td>
    <td>Un ensemble de caractère. Ce type de motif correspond pour n'importe quel caractètre présent entre les crochets, y compris les <a href="/fr/docs/Web/JavaScript/Guide/Types_et_grammaire#Les_caractères_d'échappement">séquences d'échappement</a>. Les caractères spéciaux comme le point (.) et l'astérisque ne sont pas considérés comme spéciaux au sein d'un ensemble et n'ont donc pas besoin d'être échappés. Il est possible de donner un ensemble sur un intervalle de caractères en utilisant un tiret (-), comme le montre l'exemple qui suit.<br>
     <br>
     Le motif <code>[a-d]</code>,  aura les mêmes correspondances que <code>[abcd]</code>, correspondant au 'b' de "bulle" et au 'c' de "ciel". Les motifis <code>/[a-z.]+/ </code>et <code>/[\w.]+/</code> correspondront pour la chaîne entirère : "Adre.ss.e".</td>
   </tr>
   <tr>
    <td>
-    <p><code>[^xyz]<br>
-     [^a-c]</code></p>
+    <p><code>[^xyz]</code> ou <code>[^a-c]</code></p>
    </td>
    <td>
 
@@ -57,7 +55,7 @@ original_slug: Web/JavaScript/Guide/Expressions_régulières/Groupes_et_interval
    </td>
   </tr>
   <tr>
-   <td><code>(<em>x</em>)</code></td>
+   <td><code>(x)</code></td>
    <td>
     <p>Correspond à 'x' et garde la correspondance en mémoire. Les parenthèses permettent de <em>capturer </em>l'expression dans un « groupe ».<br>
      <br>
@@ -69,7 +67,7 @@ original_slug: Web/JavaScript/Guide/Expressions_régulières/Groupes_et_interval
    </td>
   </tr>
   <tr>
-   <td><code>\<em>n</em></code></td>
+   <td><code>\n</code></td>
    <td>
     <p>Avec <code><em>n</em></code> un entier positif. Cela permet de faire référence à la dernière sous-chaîne qui correspond au n-ième groupe entre parenthèses de l'expression rationnelle (en comptant les parenthèses gauche). Ainsi, <code>/apple(,)\sorange\1/</code> correspondra à "apple, orange," dans "apple, orange, cherry, peach".</p>
    </td>

--- a/files/fr/web/javascript/guide/regular_expressions/index.html
+++ b/files/fr/web/javascript/guide/regular_expressions/index.html
@@ -351,7 +351,7 @@ original_slug: Web/JavaScript/Guide/Expressions_régulières
    </td>
   </tr>
   <tr>
-   <td><code>\<em>n</em></code></td>
+   <td><code>\n</code></td>
    <td>
     <p>Soit <em>n</em> un entier strictement positif, cela fait référence au groupe de la n-ième expression entre parenthèses (en comptant les parenthèses ouvrantes).</p>
 

--- a/files/fr/web/javascript/guide/regular_expressions/quantifiers/index.html
+++ b/files/fr/web/javascript/guide/regular_expressions/quantifiers/index.html
@@ -24,7 +24,7 @@ original_slug: Web/JavaScript/Guide/Expressions_régulières/Quantificateurs
  </thead>
  <tbody>
   <tr>
-   <td><code><em>x</em>*</code></td>
+   <td><code>x*</code></td>
    <td>
     <p>Correspond à l'expression précédente qui est répétée 0 ou plusieurs fois. Équivalent à <code>{0,}</code></p>
 
@@ -32,7 +32,7 @@ original_slug: Web/JavaScript/Guide/Expressions_régulières/Quantificateurs
    </td>
   </tr>
   <tr>
-   <td><code><em>x</em>+</code></td>
+   <td><code>x+</code></td>
    <td>
     <p>Correspond à l'expression précédente qui est répétée une ou plusieurs fois. C'est équivalent à <code>{1,}</code>.</p>
 
@@ -40,7 +40,7 @@ original_slug: Web/JavaScript/Guide/Expressions_régulières/Quantificateurs
    </td>
   </tr>
   <tr>
-   <td><code><em>x</em>?</code></td>
+   <td><code>x?</code></td>
    <td>
     <p>Correspond à l'expression précédente qui est présente une fois ou pas du tout. C'est équivalent à <code>{0,1}</code>.<br>
      <br>
@@ -52,7 +52,7 @@ original_slug: Web/JavaScript/Guide/Expressions_régulières/Quantificateurs
    </td>
   </tr>
   <tr>
-   <td><code><em>x</em>{<em>n</em>}</code></td>
+   <td><code>x{n}</code></td>
    <td>
     <p>Correspond pour exactement n occurences de l'expression précédente. N doit être un entier positif.<br>
      <br>
@@ -60,7 +60,7 @@ original_slug: Web/JavaScript/Guide/Expressions_régulières/Quantificateurs
    </td>
   </tr>
   <tr>
-   <td><code><em>x</em>{<em>n</em>,}</code></td>
+   <td><code>x{n,}</code></td>
    <td>
     <p>Correspond lorsqu'il y a au moins <code>n</code> occurences de l'expression précédente. <code>n</code> doit être un entier positif.</p>
 
@@ -68,7 +68,7 @@ original_slug: Web/JavaScript/Guide/Expressions_régulières/Quantificateurs
    </td>
   </tr>
   <tr>
-   <td><code><em>x</em>{<em>n</em>,<em>m</em>}</code></td>
+   <td><code>x{n,m}</code></td>
    <td>
     <p>Lorsque <code>n</code> et <code>m</code> sont des entiers positifs, cela correspond à au moins <code>n</code> occurences de l'expression précédente et à au plus <code>m</code> occurrences. Lorsque <code>m</code> n'est pas utilisé, la valeur par défaut correspondante sera l'infini.</p>
 
@@ -77,12 +77,12 @@ original_slug: Web/JavaScript/Guide/Expressions_régulières/Quantificateurs
   </tr>
   <tr>
    <td>
-    <p><code><em>x</em>*?</code><br>
-     <code><em>x</em>+?</code><br>
-     <code><em>x</em>??</code><br>
-     <code><em>x</em>{n}?</code><br>
-     <code><em>x</em>{n,}?</code><br>
-     <code><em>x</em>{n,m}?</code></p>
+    <p><code>x*?</code><br>
+     <code>x+?</code><br>
+     <code>x??</code><br>
+     <code>x{n}?</code><br>
+     <code>x{n,}?</code><br>
+     <code>x{n,m}?</code></p>
    </td>
    <td>
     <p>Correspond à l'expression précédente qui est présente une fois ou pas du tout. C'est équivalent à <code>{0,1}</code>.<br>

--- a/files/fr/web/javascript/reference/errors/illegal_character/index.html
+++ b/files/fr/web/javascript/reference/errors/illegal_character/index.html
@@ -61,7 +61,7 @@ var toto = "truc";
 // SyntaxError: illegal character
 </pre>
 
-<p>Dans ce cas, il suffit de rajouter la quote pour <code><strong>'</strong>#333'</code>.</p>
+<p>Dans ce cas, il suffit de rajouter la quote pour <code>'#333'</code>.</p>
 
 <pre class="brush: js example-good">var couleurs = ['#000', '#333', '#666'];</pre>
 

--- a/files/fr/web/javascript/reference/functions/index.html
+++ b/files/fr/web/javascript/reference/functions/index.html
@@ -185,7 +185,7 @@ param =&gt; expression
 </pre>
 
 <dl>
- <dt><code>arg1, arg2, ... arg<em>N</em></code></dt>
+ <dt><code>arg1, arg2, ... argN</code></dt>
  <dd>Plusieurs (zéro ou plus) noms qui seront utilisés par la fonction comme noms d'arguments formels. Chaque nom doit être une chaîne de caractères valide au sens d'un identifiant JavaScript ou alors être une liste de telles chaînes séparées par des virgules. On aura les exemples suivants : "<code>x</code>", "<code>laValeur</code>", ou "<code>a,b</code>".</dd>
  <dt><code>corpsDeLaFonction</code></dt>
  <dd>Une chaîne de caractères contenant les instructions JavaScript définissant la fonction.</dd>

--- a/files/fr/web/javascript/reference/global_objects/array/array/index.html
+++ b/files/fr/web/javascript/reference/global_objects/array/array/index.html
@@ -23,7 +23,7 @@ new Array(<var>longueurTableau</var>)</pre>
 <h3 id="Paramètres">Paramètres</h3>
 
 <dl>
- <dt><code>element<em>N</em></code></dt>
+ <dt><code>elementN</code></dt>
  <dd>Un tableau JavaScript est initialisé avec les éléments indiqués à moins qu'un seul argument ne soit passé (cf. <code>longueurTableau</code> ci-après). On notera que ce cas au limite ne s'applique qu'avec le constructeur <code>Array</code>. Si on utilise la forme littérale (avec les crochets), on peut initialiser un tableau avec un seul élément.</dd>
  <dt><code>longueurTableau</code></dt>
  <dd>Si le seul argument passé au constructeur <code>Array</code> est un entier entre 0 et 2^32-1 (inclus), le constructeur renverra un tableau dont la propriété <code>length</code> vaut ce nombre. <strong>Note :</strong> le tableau contiendra des éléments vides (à ne pas confondre avec des éléments qui vaudraient <code>undefined</code>). Si l'argument est un autre nombre, une exception {{jsxref("RangeError")}} sera levée.</dd>

--- a/files/fr/web/javascript/reference/global_objects/function/arguments/index.html
+++ b/files/fr/web/javascript/reference/global_objects/function/arguments/index.html
@@ -13,7 +13,7 @@ original_slug: Web/JavaScript/Reference/Objets_globaux/Function/arguments
 ---
 <div>{{JSRef}} {{Deprecated_header}}</div>
 
-<p>La propriété <code><strong><em>function</em>.arguments</strong></code> fait référence à un objet dont la structure est semblable à celle d'un tableau dont les éléments correspondent aux arguments passés à une fonction. En lieu et place, il faut désormais utiliser {{jsxref("Fonctions/arguments", "arguments")}}. Cette propriété est interdite en mode stricte à cause de <a href="https://www.ecma-international.org/ecma-262/6.0/#sec-addrestrictedfunctionproperties">l'optimisation de la queue des appels (<em>tail call optimization</em>)</a>.</p>
+<p>La propriété <code><strong>function.arguments</strong></code> fait référence à un objet dont la structure est semblable à celle d'un tableau dont les éléments correspondent aux arguments passés à une fonction. En lieu et place, il faut désormais utiliser {{jsxref("Fonctions/arguments", "arguments")}}. Cette propriété est interdite en mode stricte à cause de <a href="https://www.ecma-international.org/ecma-262/6.0/#sec-addrestrictedfunctionproperties">l'optimisation de la queue des appels (<em>tail call optimization</em>)</a>.</p>
 
 <h2 id="Description">Description</h2>
 

--- a/files/fr/web/javascript/reference/global_objects/function/caller/index.html
+++ b/files/fr/web/javascript/reference/global_objects/function/caller/index.html
@@ -11,7 +11,7 @@ original_slug: Web/JavaScript/Reference/Objets_globaux/Function/caller
 ---
 <div>{{JSRef}} {{non-standard_header}}</div>
 
-<p>La propriété <code><strong><em>function</em>.caller</strong></code> renvoie la fonction qui a appelé la fonction donnée. Cette propriété est interdite en mode strict.</p>
+<p>La propriété <code><strong>function.caller</strong></code> renvoie la fonction qui a appelé la fonction donnée. Cette propriété est interdite en mode strict.</p>
 
 <h2 id="Description">Description</h2>
 

--- a/files/fr/web/javascript/reference/global_objects/function/displayname/index.html
+++ b/files/fr/web/javascript/reference/global_objects/function/displayname/index.html
@@ -12,7 +12,7 @@ original_slug: Web/JavaScript/Reference/Objets_globaux/Function/displayName
 ---
 <div>{{JSRef}} {{Non-standard_header}}</div>
 
-<p>La propriété <code><strong><em>function</em>.displayName</strong></code> renvoie le nom affiché de la fonction.</p>
+<p>La propriété <code><strong>function.displayName</strong></code> renvoie le nom affiché de la fonction.</p>
 
 <h2 id="Description">Description</h2>
 

--- a/files/fr/web/javascript/reference/global_objects/function/index.html
+++ b/files/fr/web/javascript/reference/global_objects/function/index.html
@@ -24,7 +24,7 @@ original_slug: Web/JavaScript/Reference/Objets_globaux/Function
 <h3 id="Paramètres">Paramètres</h3>
 
 <dl>
- <dt><code>arg1, arg2, ... arg<em>N</em></code></dt>
+ <dt><code>arg1, arg2, ... argN</code></dt>
  <dd>Les noms utilisés par la fonction pour les arguments formellement déclarés. Chacun doit être une chaîne de caractères correspondant à un identifiant JavaScript valide (ou une liste de telles chaînes séparées par des virgules). Par exemple : "<code>x</code>", "<code>uneValeur</code>", ou "<code>a,b</code>".</dd>
  <dt><code>corpsFonction</code></dt>
  <dd>Une chaîne de caractères qui contient les instructions JavaScript définissant la fonction.</dd>

--- a/files/fr/web/javascript/reference/global_objects/function/name/index.html
+++ b/files/fr/web/javascript/reference/global_objects/function/name/index.html
@@ -12,7 +12,7 @@ original_slug: Web/JavaScript/Reference/Objets_globaux/Function/name
 ---
 <div>{{JSRef}}</div>
 
-<p>La propriété <code><strong><em>function</em>.name</strong></code> est une propriété en lecture seule qui renvoie le nom de la fonction courante ou <code>"anonymous"</code> si celle-ci a été créée de façon anonyme.</p>
+<p>La propriété <code><strong>function.name</strong></code> est une propriété en lecture seule qui renvoie le nom de la fonction courante ou <code>"anonymous"</code> si celle-ci a été créée de façon anonyme.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/function-name.html")}}</div>
 

--- a/files/fr/web/javascript/reference/global_objects/object/index.html
+++ b/files/fr/web/javascript/reference/global_objects/object/index.html
@@ -24,7 +24,7 @@ new Object([<var>valeur</var>])</pre>
 <h3 id="Paramètres">Paramètres</h3>
 
 <dl>
- <dt><code>paireNomValeur1, paireNomValeur2, ... paireNomValeur<em>N</em></code></dt>
+ <dt><code>paireNomValeur1, paireNomValeur2, ... paireNomValeurN</code></dt>
  <dd>Paires de noms (chaînes) et de valeurs (toutes valeurs) où le nom est séparé de la valeur par deux points (:).</dd>
  <dt><code>valeur</code></dt>
  <dd>Toute valeur.</dd>

--- a/files/fr/web/javascript/reference/global_objects/string/fromcharcode/index.html
+++ b/files/fr/web/javascript/reference/global_objects/string/fromcharcode/index.html
@@ -24,7 +24,7 @@ original_slug: Web/JavaScript/Reference/Objets_globaux/String/fromCharCode
 <h3 id="Paramètres">Paramètres</h3>
 
 <dl>
- <dt><code>num1, ..., num<em>N</em></code></dt>
+ <dt><code>num1, ..., numN</code></dt>
  <dd>Une séquence de nombres représentant des points de code UTF-16 entre 0 et 65535 (<code>0xFFFF</code>). Les nombres supérieurs à <code>0xFFFF</code> sont tronqués.</dd>
 </dl>
 

--- a/files/fr/web/javascript/reference/global_objects/string/replace/index.html
+++ b/files/fr/web/javascript/reference/global_objects/string/replace/index.html
@@ -74,7 +74,7 @@ original_slug: Web/JavaScript/Reference/Objets_globaux/String/replace
    <td>Insère la partie de la chaîne de caractère qui suit la sous-chaîne en correspondance.</td>
   </tr>
   <tr>
-   <td><code>$<em>n</em></code></td>
+   <td><code>$n</code></td>
    <td>
     <p>Où <code><em>n</em></code> est un entier positif inférieur à 100. Insère la <em>n</em> ième chaîne de sous-correspondance entre parenthèses, à condition que le premier argument ait été un objet {{jsxref("RegExp")}}. Notez que ceci est réalisé en indices base 1.</p>
    </td>

--- a/files/fr/web/javascript/reference/global_objects/typedarray/name/index.html
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/name/index.html
@@ -12,7 +12,7 @@ original_slug: Web/JavaScript/Reference/Objets_globaux/TypedArray/name
 ---
 <div>{{JSRef}}</div>
 
-<p>La propriété <code><strong><em>TypedArray</em>.name</strong></code> est une chaîne de caractères représentant le nom du constructeur du tableau typé.</p>
+<p>La propriété <code><strong>TypedArray.name</strong></code> est une chaîne de caractères représentant le nom du constructeur du tableau typé.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/typedarray-name.html")}}</div>
 

--- a/files/fr/web/javascript/reference/global_objects/typedarray/of/index.html
+++ b/files/fr/web/javascript/reference/global_objects/typedarray/of/index.html
@@ -12,7 +12,7 @@ original_slug: Web/JavaScript/Reference/Objets_globaux/TypedArray/of
 ---
 <div>{{JSRef}}</div>
 
-<p>La méthode <code><strong><em>TypedArray</em>.of()</strong></code> crée un nouvel objet {{jsxref("TypedArray", "TypedArray", "#Les_objets_TypedArray")}} à partir d'un nombre variable d'arguments. Cette méthode est similaire à {{jsxref("Array.of()")}}.</p>
+<p>La méthode <code><strong>TypedArray.of()</strong></code> crée un nouvel objet {{jsxref("TypedArray", "TypedArray", "#Les_objets_TypedArray")}} à partir d'un nombre variable d'arguments. Cette méthode est similaire à {{jsxref("Array.of()")}}.</p>
 
 <h2 id="Syntaxe">Syntaxe</h2>
 
@@ -35,7 +35,7 @@ BigUint64Array</pre>
 <h3 id="Paramètres">Paramètres</h3>
 
 <dl>
- <dt><code>élément<em>N</em></code></dt>
+ <dt><code>élémentN</code></dt>
  <dd>Les éléments avec lesquels on souhaite construire le nouveau tableau typé.</dd>
 </dl>
 


### PR DESCRIPTION
Follow-up of #1574 where the markdown conversion report mentioned `<code>` elements.

N.B. I wasn't able to easily spot or see them in the report and used https://github.com/mdn/content/pull/6880 to search the codebase for similar elements.