### PR TITLE
modified incorrect term, URL into URI

### DIFF
--- a/files/ko/web/http/headers/referer/index.html
+++ b/files/ko/web/http/headers/referer/index.html
@@ -44,7 +44,7 @@ translation_of: Web/HTTP/Headers/Referer
 
 <dl>
  <dt>&lt;url&gt;</dt>
- <dd>현재 요청된 페이지의 링크 이전의 웹 페이지의 절대 혹은 부분 주소. URL 프래그먼트(예를 들어, "#section")는 포함되지 않습니다.</dd>
+ <dd>현재 요청된 페이지의 링크 이전의 웹 페이지의 절대 혹은 부분 주소. URI 프래그먼트(예를 들어, "#section")는 포함되지 않습니다.</dd>
 </dl>
 
 <h2 id="예제">예제</h2>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

"Note that the fragment identifier (and the "#" that precedes it) is not considered part of the URL."
[RFC1808, 2.1. URL Syntactic Components](https://datatracker.ietf.org/doc/html/rfc1808#section-2.1)

Following the RFC3986, URI would be a more appropriate term for the "fragment"
[RFC3986, 3. Syntax Components](https://datatracker.ietf.org/doc/html/rfc3986#section-3)