### PR TITLE
Web/API/XRReferenceSpaceEventInit を正規版の位置に移動

### DIFF
--- a/files/ja/_redirects.txt
+++ b/files/ja/_redirects.txt
@@ -3759,9 +3759,6 @@
 /ja/docs/Web/API/WorkerGlobalScope/caches	/ja/docs/Web/API/WindowOrWorkerGlobalScope/caches
 /ja/docs/Web/API/XMLHttpRequest/openRequest	/ja/docs/orphaned/Web/API/XMLHttpRequest/openRequest
 /ja/docs/Web/API/XRHandedness	/ja/docs/conflicting/Web/API/XRInputSource/handedness
-/ja/docs/Web/API/XRReferenceSpaceEventInit	/ja/docs/conflicting/Web/API/XRReferenceSpaceEvent/XRReferenceSpaceEvent
-/ja/docs/Web/API/XRReferenceSpaceEventInit/referenceSpace	/ja/docs/conflicting/Web/API/XRReferenceSpaceEvent/XRReferenceSpaceEvent_0f733d39fd3094010931f093b9045686
-/ja/docs/Web/API/XRReferenceSpaceEventInit/transform	/ja/docs/conflicting/Web/API/XRReferenceSpaceEvent/XRReferenceSpaceEvent_7dfb381c892055a0c91980d537a86c6b
 /ja/docs/Web/API/XRReferenceSpaceType	/ja/docs/Web/API/XRSession/requestReferenceSpace
 /ja/docs/Web/API/XRSessionMode	/ja/docs/orphaned/Web/API/XRSessionMode
 /ja/docs/Web/API/XRTargetRayMode	/ja/docs/conflicting/Web/API/XRInputSource/targetRayMode

--- a/files/ja/_wikihistory.json
+++ b/files/ja/_wikihistory.json
@@ -25978,6 +25978,24 @@
       "Wind1808"
     ]
   },
+  "Web/API/XRReferenceSpaceEventInit": {
+    "modified": "2020-11-08T02:10:47.628Z",
+    "contributors": [
+      "Wind1808"
+    ]
+  },
+  "Web/API/XRReferenceSpaceEventInit/referenceSpace": {
+    "modified": "2020-11-08T19:13:54.683Z",
+    "contributors": [
+      "Wind1808"
+    ]
+  },
+  "Web/API/XRReferenceSpaceEventInit/transform": {
+    "modified": "2020-11-08T19:23:29.842Z",
+    "contributors": [
+      "Wind1808"
+    ]
+  },
   "Web/API/XRRigidTransform": {
     "modified": "2020-12-09T01:29:36.634Z",
     "contributors": [
@@ -48469,24 +48487,6 @@
   },
   "conflicting/Web/API/XRInputSource/targetRayMode": {
     "modified": "2020-12-08T09:23:22.538Z",
-    "contributors": [
-      "Wind1808"
-    ]
-  },
-  "conflicting/Web/API/XRReferenceSpaceEvent/XRReferenceSpaceEvent": {
-    "modified": "2020-11-08T02:10:47.628Z",
-    "contributors": [
-      "Wind1808"
-    ]
-  },
-  "conflicting/Web/API/XRReferenceSpaceEvent/XRReferenceSpaceEvent_0f733d39fd3094010931f093b9045686": {
-    "modified": "2020-11-08T19:13:54.683Z",
-    "contributors": [
-      "Wind1808"
-    ]
-  },
-  "conflicting/Web/API/XRReferenceSpaceEvent/XRReferenceSpaceEvent_7dfb381c892055a0c91980d537a86c6b": {
-    "modified": "2020-11-08T19:23:29.842Z",
     "contributors": [
       "Wind1808"
     ]

--- a/files/ja/web/api/xrreferencespaceeventinit/index.html
+++ b/files/ja/web/api/xrreferencespaceeventinit/index.html
@@ -1,6 +1,6 @@
 ---
 title: XRReferenceSpaceEventInit
-slug: conflicting/Web/API/XRReferenceSpaceEvent/XRReferenceSpaceEvent
+slug: Web/API/XRReferenceSpaceEventInit
 tags:
   - API
   - AR
@@ -20,7 +20,6 @@ tags:
   - XRReferenceSpaceEventInit
   - augmented
 translation_of: Web/API/XRReferenceSpaceEventInit
-original_slug: Web/API/XRReferenceSpaceEventInit
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
 

--- a/files/ja/web/api/xrreferencespaceeventinit/referencespace/index.html
+++ b/files/ja/web/api/xrreferencespaceeventinit/referencespace/index.html
@@ -1,7 +1,6 @@
 ---
 title: XRReferenceSpaceEventInit.referenceSpace
-slug: >-
-  conflicting/Web/API/XRReferenceSpaceEvent/XRReferenceSpaceEvent_0f733d39fd3094010931f093b9045686
+slug: Web/API/XRReferenceSpaceEventInit/referenceSpace
 tags:
   - API
   - AR
@@ -19,7 +18,6 @@ tags:
   - augmented
   - referenceSpace
 translation_of: Web/API/XRReferenceSpaceEventInit/referenceSpace
-original_slug: Web/API/XRReferenceSpaceEventInit/referenceSpace
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
 

--- a/files/ja/web/api/xrreferencespaceeventinit/transform/index.html
+++ b/files/ja/web/api/xrreferencespaceeventinit/transform/index.html
@@ -1,7 +1,6 @@
 ---
 title: XRReferenceSpaceEventInit.transform
-slug: >-
-  conflicting/Web/API/XRReferenceSpaceEvent/XRReferenceSpaceEvent_7dfb381c892055a0c91980d537a86c6b
+slug: Web/API/XRReferenceSpaceEventInit/transform
 tags:
   - API
   - AR
@@ -19,7 +18,6 @@ tags:
   - augmented
   - transform
 translation_of: Web/API/XRReferenceSpaceEventInit/transform
-original_slug: Web/API/XRReferenceSpaceEventInit/transform
 ---
 <p>{{APIRef("WebXR Device API")}}{{SecureContext_header}}</p>
 


### PR DESCRIPTION
- Web/API/XRReferenceSpaceEventInit が conflicting にあったが、英語版に合わせて正規版の位置に移動した。
- https://github.com/mdn/translated-content/issues/1831 の修正