### PR TITLE
Rewording of the `first_meaningful_paint` French glossary item

### DIFF
--- a/files/fr/glossary/first_meaningful_paint/index.html
+++ b/files/fr/glossary/first_meaningful_paint/index.html
@@ -9,5 +9,5 @@ original_slug: Glossaire/first_meaningful_paint
 <h2 id="Voir_aussi">Voir aussi</h2>
 
 <ul>
-  <li><a href="/fr/docs/Glossaire/First_contentful_paint"><i lang="en">First contentful paint</i></a></li>
+  <li><a href="fr/docs/Glossary/First_contentful_paint"><i lang="en">First contentful paint</i></a></li>
 </ul>

--- a/files/fr/glossary/first_meaningful_paint/index.html
+++ b/files/fr/glossary/first_meaningful_paint/index.html
@@ -1,17 +1,13 @@
 ---
 title: First Meaningful Paint
 slug: Glossary/first_meaningful_paint
-tags:
-  - Glossaire
-  - Performance Web
-  - Reference
 translation_of: Glossary/first_meaningful_paint
 original_slug: Glossaire/first_meaningful_paint
 ---
-<p><strong>First Meaningful Paint</strong> (FMP) est la peinture après laquelle le plus grand changement de mise en page au-dessus du pli s'est produit et les polices Web se sont chargées. C'est quand la réponse à "Est-ce utile?" devient "oui", lors de la première finition significative de la peinture.</p>
+<p>L'indicateur <strong lang="en">First Meaningful Paint</strong> (FMP) correspond à la peinture (<i lang="en">paint</i> en anglais) intervenant après laquelle le plus grand changement de mise en page situé au-dessus de la ligne de flottaison s'est produit et après le chargement des polices. C'est lorsque la réponse à la question «&nbsp;La page est elle utilisable&nbsp;? » devient «&nbsp;oui&nbsp;», lors de la première finition significative de la peinture.</p>
 
 <h2 id="Voir_aussi">Voir aussi</h2>
 
 <ul>
- <li><a href="/fr/docs/Glossaire/First_contentful_paint">First contentful paint</a></li>
+  <li><a href="/fr/docs/Glossaire/First_contentful_paint"><i lang="en">First contentful paint</i></a></li>
 </ul>


### PR DESCRIPTION
This PR rewords the `first_meaningful_paint` French glossary item.