### PR TITLE
Rewording of the French translation of the `first_contentful_paint` glossary item

### DIFF
--- a/files/fr/glossary/first_contentful_paint/index.html
+++ b/files/fr/glossary/first_contentful_paint/index.html
@@ -11,6 +11,6 @@ original_slug: Glossaire/First_contentful_paint
 <h2 id="Voir_aussi">Voir aussi</h2>
 
 <ul>
-  <li><a href="/fr/docs/Glossaire/first_meaningful_paint"><i lang="en">First Meaningful Paint</i></a></li>
+  <li><a href="/fr/docs/Glossary/first_meaningful_paint"><i lang="en">First Meaningful Paint</i></a></li>
   <li><a href="https://w3c.github.io/paint-timing/#first-contentful-paint"><i lang="en">Paint Timing specification</i> (W3C, en anglais)</a></li>
 </ul>

--- a/files/fr/glossary/first_contentful_paint/index.html
+++ b/files/fr/glossary/first_contentful_paint/index.html
@@ -1,21 +1,16 @@
 ---
 title: First contentful paint
 slug: Glossary/First_contentful_paint
-tags:
-  - Glossaire
-  - Performance
-  - Performance Web
-  - Reference
 translation_of: Glossary/First_contentful_paint
 original_slug: Glossaire/First_contentful_paint
 ---
-<p><strong>First Contentful Paint</strong> (FCP) est lorsque le navigateur rend le premier bit de contenu du DOM, fournissant le premier retour à l'utilisateur que la page est en cours de chargement. La question "Est-ce que ça se passe?" est "oui" lorsque la première peinture contentieuse est terminée.</p>
+<p>Le <strong lang="en">First Contentful Paint</strong> (FCP) est un indicateur du moment où le navigateur restitue le premier bit de contenu du DOM, fournissant le premier retour à l'internaute que la page est en cours de chargement. La réponse à la question «&nbsp;Est-ce que quelque chose se passe&nbsp;?&nbsp;» devient «&nbsp;oui&nbsp;» lorsque la première peinture du contenu est terminée.</p>
 
-<p><dfn>L'horodatage First Contentful Paint</dfn> correspond au premier rendu par le navigateur d'un texte, d'une image (y compris les images d'arrière-plan), d'un canevas non blanc ou d'un SVG. Cela exclut tout contenu des iframes, mais inclut le texte avec des polices Web en attente. C'est la première fois que les utilisateurs peuvent commencer à consommer du contenu de page.</p>
+<p><dfn>L'horodatage <i lang="en">First Contentful Paint</i></dfn> correspond au premier rendu par le navigateur d'un texte, d'une image (y compris les images d'arrière-plan), d'un canevas non blanc ou d'un SVG. Cela exclut le contenu des iframes, mais inclut le texte avec des polices web en attente de chargement. C'est le moment où les internautes pourront commencer à consulter le contenu de la page pour la première fois.</p>
 
 <h2 id="Voir_aussi">Voir aussi</h2>
 
 <ul>
- <li><a href="/fr/docs/Glossaire/first_meaningful_paint">First Meaningful Paint</a></li>
- <li><a href="https://w3c.github.io/paint-timing/#first-contentful-paint">Paint Timing specification</a></li>
+  <li><a href="/fr/docs/Glossaire/first_meaningful_paint"><i lang="en">First Meaningful Paint</i></a></li>
+  <li><a href="https://w3c.github.io/paint-timing/#first-contentful-paint"><i lang="en">Paint Timing specification</i> (W3C, en anglais)</a></li>
 </ul>


### PR DESCRIPTION
This PR rewords the French translation of the `first_contentful_paint` glossary item