### PR TITLE
links en-US to pt-BR

### DIFF
--- a/files/pt-br/web/javascript/reference/functions/rest_parameters/index.html
+++ b/files/pt-br/web/javascript/reference/functions/rest_parameters/index.html
@@ -22,11 +22,11 @@ translation_of: Web/JavaScript/Reference/Functions/rest_parameters
 
 <h3 id="Diferença_entre_rest_parameters_e_arguments_object">Diferença entre <em>rest parameters</em> e <em><code>arguments</code> object</em></h3>
 
-<p>Há três diferenças principais entre <em>rest parameters</em> e os <a href="/en-US/docs/Web/JavaScript/Reference/Functions/arguments" title="arguments"><code>arguments</code></a> objects:</p>
+<p>Há três diferenças principais entre <em>rest parameters</em> e os <a href="/pt-BR/docs/Web/JavaScript/Reference/Functions/arguments" title="arguments"><code>arguments</code></a> objects:</p>
 
 <ul>
  <li><em>rest parameters</em> são os únicos que não foram atribuidos a um nome separado, enquanto os <code>arguments</code> object contêm todos os argumentos passados para a função;</li>
- <li>o objeto <code>arguments</code> não é um array, enquanto  rest parameters são instâncias <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array" title="Array"><code>Array</code></a>,  isso significa que métodos como <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort" title="Array sort method"><code>sort</code></a>, <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map" title="Array map method"><code>map</code></a>, <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach" title="Array forEach method"><code>forEach</code></a> ou <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/pop" title="Array pop method"><code>pop</code></a> podem ser aplicados diretamente;</li>
+ <li>o objeto <code>arguments</code> não é um array, enquanto  rest parameters são instâncias <a href="/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Array" title="Array"><code>Array</code></a>,  isso significa que métodos como <a href="/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Array/sort" title="Array sort method"><code>sort</code></a>, <a href="/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Array/map" title="Array map method"><code>map</code></a>, <a href="/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach" title="Array forEach method"><code>forEach</code></a> ou <a href="/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Array/pop" title="Array pop method"><code>pop</code></a> podem ser aplicados diretamente;</li>
  <li> o objeto <code>arguments</code> possui a funcionalidade adicional de especificar ele mesmo (como a propriedade <code>callee</code>). </li>
 </ul>
 
@@ -169,10 +169,10 @@ console.log(sortArguments(5,3,7,1));
 <h2 id="Veja_também">Veja também</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Functions/arguments" title="arguments">Arguments object</a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array" title="Array">Array</a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Functions" title="Functions and function scope">Functions</a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Spread_operator" title="spread operator">Spread Operator</a></li>
+ <li><a href="/pt-BR/docs/Web/JavaScript/Reference/Functions/arguments" title="arguments">Arguments object</a></li>
+ <li><a href="/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Array" title="Array">Array</a></li>
+ <li><a href="/pt-BR/docs/Web/JavaScript/Reference/Functions" title="Functions and function scope">Functions</a></li>
+ <li><a href="/pt-BR/docs/Web/JavaScript/Reference/Operators/Spread_operator" title="spread operator">Spread Operator</a></li>
  <li><a class="external" href="http://wiki.ecmascript.org/doku.php?id=harmony:rest_parameters">Original proposal at ecmascript.org</a></li>
  <li><a class="external" href="http://javascriptweblog.wordpress.com/2011/01/18/javascripts-arguments-object-and-beyond/">JavaScript arguments object and beyond</a></li>
 </ul>


### PR DESCRIPTION
It would be helpful if links direct the reader to the page in the same language they are reading. So, as he is reading in Portuguese, if he clicks on a link, he will be taken to the article in Portuguese.