### PR TITLE
[Fr] replaced broken element styles with images on ClientLeft page

### DIFF
--- a/files/fr/web/api/element/clientleft/index.html
+++ b/files/fr/web/api/element/clientleft/index.html
@@ -2,7 +2,7 @@
 title: element.clientLeft
 slug: Web/API/Element/clientLeft
 tags:
-  - Référence_du_DOM_Gecko
+- Référence_du_DOM_Gecko
 translation_of: Web/API/Element/clientLeft
 ---
 <p>{{ ApiRef() }}</p>
@@ -13,21 +13,9 @@ translation_of: Web/API/Element/clientLeft
 <pre class="eval">var <var>gauche</var> = <var>element</var>.clientLeft;
 </pre>
 <h3 id="Exemple" name="Exemple">Exemple</h3>
-<div id="offsetContainer" style="margin: 26px 0px; background-color: rgb(255, 255, 204); border: 4px dashed black; color: black; position: absolute; left: 260px;">
- <div id="idDiv" style="margin: 24px 29px; border: 24px black solid; padding: 0px 28px; width: 199px; height: 102px; overflow: auto; background-color: white; font-size: 13px!important; font-family: Arial, sans-serif;">
-  <p id="PaddingTopLabel" style="text-align: center; font-style: italic; font-weight: bold; font-size: 13px!important; font-family: Arial, sans-serif; margin: 0px;">padding-top</p>
-  <p>Gentle, individualistic and very loyal, Birman cats fall between Siamese and Persian in character. If you admire cats that are non aggressive, that enjoy being with humans and tend to be on the quiet side, you may well find that Birman cats are just the felines for you.</p>
-  <p><span style="float: right;"><img alt="Image:BirmanCat.jpg"></span>All Birmans have colorpointed features, dark coloration of the face, ears, legs and tail.</p>
-  <p>Cat image and text coming from <a class="external" href="http://www.best-cat-art.com/">www.best-cat-art.com</a></p>
-  <p id="PaddingBottomLabel" style="text-align: center; font-style: italic; font-weight: bold; font-size: 13px!important; font-family: Arial, sans-serif; margin: 0px;">padding-bottom</p>
- </div>
- <span style="position: absolute; left: -32px; top: 85px; color: blue; font-weight: bold; font-size: 13px!important; font-family: Arial, sans-serif;">Left</span><span style="position: absolute; left: 170px; top: -24px; color: blue; font-weight: bold; font-size: 13px!important; font-family: Arial, sans-serif;">Top</span><span style="position: absolute; left: 370px; top: 85px; color: blue; font-weight: bold; font-size: 13px!important; font-family: Arial, sans-serif;">Right</span><span style="position: absolute; left: 164px; top: 203px; color: blue; font-weight: bold; font-size: 13px!important; font-family: Arial, sans-serif;">Bottom</span><span style="position: absolute; left: 143px; top: 5px; font-style: italic; font-weight: bold; font-size: 13px!important; font-family: Arial, sans-serif;">margin-top</span><span style="position: absolute; left: 138px; top: 175px; font-style: italic; font-weight: bold; font-size: 13px!important; font-family: Arial, sans-serif;">margin-bottom</span><span style="position: absolute; left: 143px; top: 27px; color: white; font-style: italic; font-weight: bold; font-size: 13px!important; font-family: Arial, sans-serif;">border-top</span><span style="position: absolute; left: 138px; top: 153px; color: white; font-style: italic; font-weight: bold; font-size: 13px!important; font-family: Arial, sans-serif;">border-bottom</span><span class="comment">{{ mediawiki.external('if IE') }}&gt;&lt;span id="MrgLeft" style="position: absolute; left: 8px; top: 65px; font: bold 13px Arial, sans-serif !important; writing-mode: tb-rl;"&gt;margin-left&lt;/span&gt;&lt;span id="BrdLeft" style="position: absolute; left: 33px; top: 65px; color: white; font: bold 13px Arial, sans-serif !important; writing-mode: tb-rl;"&gt;border-left&lt;/span&gt;&lt;span id="PdgLeft" style="position: absolute; left: 55px; top: 65px; font: bold 13px Arial, sans-serif !important; writing-mode: tb-rl;"&gt;padding-left&lt;/span&gt;&lt;span id="PdgRight" style="position: absolute; left: 275px; top: 60px; color: black; font: bold 13px Arial, sans-serif !important; writing-mode: tb-rl; white-space: nowrap;"&gt;padding-right&lt;/span&gt;&lt;span id="BrdRight" style="position: absolute; left: 310px; top: 65px; color: white; font: bold 13px Arial, sans-serif !important; writing-mode: tb-rl;"&gt;border-right&lt;/span&gt;&lt;span id="MrgRight" style="position: absolute; left: 340px; top: 65px; font: bold 13px Arial, sans-serif !important; writing-mode: tb-rl;"&gt;margin-right&lt;/span&gt;&lt;!{{ mediawiki.external('endif') }}</span></div>
-<p style="margin-top: 270px;"><img alt="Image:clientLeft.png"></p>
-<p><img alt="Position de la barre de défilement verticale lorsque la propriété layout.scrollbar.side est à 1 ou 3"></p>
-<p>Lorsque la préférence <a class="external" href="http://kb.mozillazine.org/Layout.scrollbar.side">
- <i>
-  layout.scrollbar.side</i>
- </a> est à 1 ou 3 et que la direction du texte est de droite à gauche (RTL), <b>la barre de défilement vertical sera placée à gauche</b> et cela influencera la manière dont <code>clientLeft</code> est calculée.</p>
+
+<p><img alt="Image:Dimensions-client.png" src="https://developer.mozilla.org/@api/deki/files/185/=Dimensions-client.png"/></p>
+
 <h3 id="Sp.C3.A9cification" name="Sp.C3.A9cification">Spécification</h3>
 <p>Ne fait partie d'aucune spécification du W3C.</p>
 <h3 id="Notes" name="Notes">Notes</h3>
@@ -35,7 +23,7 @@ translation_of: Web/API/Element/clientLeft
 <p>La position de la barre de défilement vertical lorsque la direction du texte sur l'élément est de droite à gauche dépendra de la préférence <a class="external" href="http://kb.mozillazine.org/Layout.scrollbar.side">
  <i>
   layout.scrollbar.side</i>
- </a>.</p>
+</a>.</p>
 <h3 id="R.C3.A9f.C3.A9rences" name="R.C3.A9f.C3.A9rences">Références</h3>
 <ul>
  <li><a class="external" href="http://msdn.microsoft.com/workshop/author/dhtml/reference/properties/clientleft.asp?frame=true">

--- a/files/fr/web/api/element/clientleft/index.html
+++ b/files/fr/web/api/element/clientleft/index.html
@@ -1,41 +1,49 @@
 ---
-title: element.clientLeft
+title: Element.clientLeft
 slug: Web/API/Element/clientLeft
-tags:
-- Référence_du_DOM_Gecko
 translation_of: Web/API/Element/clientLeft
+browser-compat: api.Element.clientLeft
 ---
-<p>{{ ApiRef() }}</p>
-<h3 id="R.C3.A9sum.C3.A9" name="R.C3.A9sum.C3.A9">Résumé</h3>
-<p>La largeur de la bordure gauche d'un élément en pixels. Celle-ci comprend la largeur de la barre de défilement verticale si la direction de l'élément est de droite à gauche et si un débordement provoque l'apparition d'une barre de défilement vertical sur la gauche. Les marges et le remplissage gauche (padding) ne font pas partie de <code>clientLeft</code>. Cette propriété est en lecture seule.</p>
-<p>Les applications basées sur <a href="fr/Gecko">Gecko</a> gèrent <code>clientLeft</code> à partir de Gecko 1.9 (<a href="fr/Firefox_3">Firefox 3</a>, implémentation dans le {{ Bug(111207) }}). Cette propriété n'est pas disponible dans Firefox 2 et les versions précédentes.</p>
-<h3 id="Syntaxe" name="Syntaxe">Syntaxe</h3>
-<pre class="eval">var <var>gauche</var> = <var>element</var>.clientLeft;
+<div>{{APIRef("DOM")}}</div>
+
+<p>La propriété en lecture seule <strong><code>Element.clientLeft</code></strong> représente la largeur de la bordure gauche d'un élément, exprimée en pixels. Cette largeur inclut l'éventuelle largeur de la barre de défilement verticale si le texte se lit de droite à gauche et s'il y a un dépassement entraînant l'apparition d'une barre de défilement à gauche. <code>clientLeft</code> n'inclut pas la marge gauche ou le remplissage (<i lang="en">padding</i>) à gauche.</p>
+
+<p>Lorsque la préférence <a href="http://kb.mozillazine.org/Layout.scrollbar.side"><code>layout.scrollbar.side</code></a> est paramétrée à 1 ou à 3 et que la direction du texte est de droite à gauche, <strong>alors la barre de défilement verticale est placée à gauche</strong> et ce placement aura donc un impact sur la valeur de <code>clientLeft</code>.</p>
+
+<div class="note">
+  <p><strong>Note :</strong> Cette propriété sera arrondie en une valeur entière. Si vous souhaitez utiliser une valeur décimale, vous pouvez utiliser <a href="/fr/docs/Web/API/Element/getBoundingClientRect"><code>element.getBoundingClientRect()</code></a>. </p>
+</div>
+
+<div class="note">
+  <p><strong>Note :</strong> Lorsqu'un élément se voit appliquer <code>display: inline</code>, <code>clientLeft</code> renvoie <code>0</code>, quelle que soit la bordure de l'élément.</p>
+</div>
+
+<h2 id="syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+var left = element.clientLeft;
 </pre>
-<h3 id="Exemple" name="Exemple">Exemple</h3>
 
-<p><img alt="Image:Dimensions-client.png" src="https://developer.mozilla.org/@api/deki/files/185/=Dimensions-client.png"/></p>
+<h2 id="example">Exemple</h2>
 
-<h3 id="Sp.C3.A9cification" name="Sp.C3.A9cification">Spécification</h3>
-<p>Ne fait partie d'aucune spécification du W3C.</p>
-<h3 id="Notes" name="Notes">Notes</h3>
-<p><code>clientLeft</code> faisait au départ partie du modèle objet DHTML de Microsoft Internet Explorer.</p>
-<p>La position de la barre de défilement vertical lorsque la direction du texte sur l'élément est de droite à gauche dépendra de la préférence <a class="external" href="http://kb.mozillazine.org/Layout.scrollbar.side">
- <i>
-  layout.scrollbar.side</i>
-</a>.</p>
-<h3 id="R.C3.A9f.C3.A9rences" name="R.C3.A9f.C3.A9rences">Références</h3>
-<ul>
- <li><a class="external" href="http://msdn.microsoft.com/workshop/author/dhtml/reference/properties/clientleft.asp?frame=true">
-  <i>
-   clientLeft definition</i>
-  sur MSDN</a></li>
- <li><a class="external" href="http://msdn.microsoft.com/workshop/author/om/measuring.asp">
-  <i>
-   Measuring Element Dimension and Location</i>
-  sur MSDN</a></li>
-</ul>
-<p> </p>
-<div class="noinclude">
-  </div>
-<p>{{ languages( { "en": "en/DOM/element.clientLeft", "es": "es/DOM/element.clientLeft", "ja": "ja/DOM/element.clientLeft", "pl": "pl/DOM/element.clientLeft" } ) }}</p>
+<div id="offsetContainer" style="margin: 40px 50px 50px; background-color: rgb(255, 255, 204); border: 4px dashed black; color: black; position: relative; display: inline-block;"> <div id="idDiv" style="margin: 24px 29px; border: 24px black solid; padding: 0px 28px; width: 199px; height: 102px; overflow: auto; background-color: white; font-size: 13px!important; font-family: Arial, sans-serif;"> <p id="PaddingTopLabel" style="text-align: center; font-style: italic; font-weight: bold; font-size: 13px!important; font-family: Arial, sans-serif; margin: 0px;"> padding-top</p>
+ <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. </p>
+ <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+ <p id="PaddingBottomLabel" style="text-align: center; font-style: italic; font-weight: bold; font-size: 13px!important; font-family: Arial, sans-serif; margin: 0px;"> padding-bottom</p> </div> <strong style="color: blue; font-family: arial,sans-serif; font-size: 13px!important; font-weight: bold; left: -32px; position: absolute; top: 85px;">Left</strong> <strong style="color: blue; font-family: arial,sans-serif; font-size: 13px!important; font-weight: bold; left: 170px; position: absolute; top: -24px;">Top</strong> <strong style="color: blue; font-family: arial,sans-serif; font-size: 13px!important; font-weight: bold; left: 370px; position: absolute; top: 85px;">Right</strong> <strong style="color: blue; font-family: arial,sans-serif; font-size: 13px!important; font-weight: bold; left: 164px; position: absolute; top: 203px;">Bottom</strong> <em>margin-top</em> <em>margin-bottom</em> <em>border-top</em> <em>border-bottom</em>
+</div>
+
+<h2 id="specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="Notes">Notes</h2>
+
+<p><code>clientLeft</code> fut introduit avec le modèle d'objet DHTML d'Internet Explorer.</p>
+
+<p>La position de la barre de défilement verticale pour les textes écrits de droite à gauche dépend de la préférence <a href="http://kb.mozillazine.org/Layout.scrollbar.side"><code>layout.scrollbar.side</code></a>.</p>
+
+<p>Les applications utilisant le moteur Gecko prennent en charge <code>clientLeft</code> depuis Gecko 1.9 (Firefox 3 l'implémente avec <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=111207">le bug 111207</a>). Cette propriété n'est pas prise en charge pour Firefox 2 et les versions antérieures.</p>


### PR DESCRIPTION
Replaced a broken-looking example with an image.

#### fr Broken ClientLeft page:
- https://developer.mozilla.org/fr/docs/Web/API/Element/clientLeft