### PR TITLE
fix wrong translation 显示/显式 of "implicit"

### DIFF
--- a/files/zh-cn/web/javascript/reference/strict_mode/index.html
+++ b/files/zh-cn/web/javascript/reference/strict_mode/index.html
@@ -11,7 +11,7 @@ translation_of: Web/JavaScript/Reference/Strict_mode
 
 <div class="note">有时你会看到非严格模式，被称为“<strong><a href="https://developer.mozilla.org/docs/Glossary/Sloppy_mode" id="sloppyModeId333">sloppy mode</a></strong>”。这不是一个官方术语，但以防万一，你应该意识到这一点。</div>
 
-<div><a class="external" href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">ECMAScript 5</a>的<strong>严格模式</strong>是采用具有限制性JavaScript变体的一种方式，从而使代码显式地脱离“马虎模式/稀松模式/懒散模式“（sloppy）模式。</div>
+<div><a class="external" href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">ECMAScript 5</a>的<strong>严格模式</strong>是采用具有限制性JavaScript变体的一种方式，从而使代码隐式地脱离“马虎模式/稀松模式/懒散模式“（sloppy）模式。</div>
 
 <div>严格模式不仅仅是一个子集：它的产生是为了形成与正常代码不同的语义。</div>
 

--- a/files/zh-cn/web/javascript/reference/strict_mode/index.html
+++ b/files/zh-cn/web/javascript/reference/strict_mode/index.html
@@ -11,7 +11,7 @@ translation_of: Web/JavaScript/Reference/Strict_mode
 
 <div class="note">有时你会看到非严格模式，被称为“<strong><a href="https://developer.mozilla.org/docs/Glossary/Sloppy_mode" id="sloppyModeId333">sloppy mode</a></strong>”。这不是一个官方术语，但以防万一，你应该意识到这一点。</div>
 
-<div><a class="external" href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">ECMAScript 5</a>的<strong>严格模式</strong>是采用具有限制性JavaScript变体的一种方式，从而使代码显示地 脱离“马虎模式/稀松模式/懒散模式“（sloppy）模式。</div>
+<div><a class="external" href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">ECMAScript 5</a>的<strong>严格模式</strong>是采用具有限制性JavaScript变体的一种方式，从而使代码显式地脱离“马虎模式/稀松模式/懒散模式“（sloppy）模式。</div>
 
 <div>严格模式不仅仅是一个子集：它的产生是为了形成与正常代码不同的语义。</div>
 


### PR DESCRIPTION
显 or 示 both means "display", when they are put together 显示 refers to "display".

隐 or 隐藏 both means something hidden, under the surface.

显式 refers to "explicit", which means something is obvious and direct. Oppositely, 隐式 refers to "implicit".

For example:
- explicit time integration 显式积分
- implicit time integration 隐式积分

I checked with the [original documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode), where the statement is

> thereby **implicitly** opting-out of "sloppy mode". 

the translation here should be

> 从而**隐含**地选择退出 "sloppy mode"。

or more sensibly and accurately be

> 从而**隐式**地脱离 "sloppy mode"。

To coordinate with the current translation, the whole sentence should be

> JavaScript's strict mode, introduced in ECMAScript 5, is a way to opt in to a restricted variant of JavaScript, thereby ***implicitly*** opting-out of "sloppy mode". 
>
> ECMAScript 5的严格模式是采用具有限制性JavaScript变体的一种方式，从而使代码***隐式地***脱离“马虎模式/稀松模式/懒散模式“（sloppy）模式。