### PR TITLE
Update files/zh-cn/web/css/vertical-align/index.html

### DIFF
--- a/files/zh-cn/web/css/vertical-align/index.html
+++ b/files/zh-cn/web/css/vertical-align/index.html
@@ -18,7 +18,7 @@ translation_of: Web/CSS/vertical-align
 <p>vertical-align属性可被用于两种环境：</p>
 
 <ul>
- <li>使行内元素盒模型与其行内元素容器垂直对齐。例如，用于垂直对齐一行文本的内的图片{{HTMLElement("img")}}：</li>
+ <li>使行内元素盒模型与其行内元素容器垂直对齐。例如，用于垂直对齐一行文本内的图片{{HTMLElement("img")}}：</li>
 </ul>
 
 <div id="vertical-align-inline">


### PR DESCRIPTION
原句中「用于垂直对齐一行文本的内的图片」中第一个「的」字应删去