### PR TITLE
[fr] french translation for /code_splitting/index.html id:145

### DIFF
--- a/files/fr/glossary/code_splitting/index.html
+++ b/files/fr/glossary/code_splitting/index.html
@@ -3,7 +3,7 @@ title: Code splitting
 slug: Glossary/Code_splitting
 translation_of: Glossary/Code_splitting
 ---
-<p><strong>Le code splitting</strong> est le fractionnement du code en divers bundles ou composants qui peuvent ensuite être chargés à la demande ou en parallèle.</p>
+<p><strong>Le code splitting</strong> (en français <i lang="fr">division de code</i>) est le fractionnement du code en divers bundles ou composants qui peuvent ensuite être chargés à la demande ou en parallèle.</p>
 
 <p>Au fur et à mesure qu'une application devient de plus en plus complexe ou est maintenue, la taille en octets des fichiers ou bundles CSS et JavaScripts augmente, en particulier à mesure que le nombre et la taille des bibliothèques tierces incluses augmentent. Pour éviter d'avoir à télécharger des fichiers gigantesques, les scripts peuvent être divisés en plusieurs fichiers plus petits. Ensuite, les fonctionnalités requises au chargement de la page peuvent être téléchargées immédiatement avec des scripts supplémentaires <a href="/fr/docs/Glossary/Lazy_load">chargés passivement</a> une fois que la page ou l'application soit interactive, améliorant ainsi les performances. Bien que la quantité totale de code soit la même (et peut-être même quelques octets plus grande), la quantité de code nécessaire lors du chargement initial peut être réduite.</p>
 

--- a/files/fr/glossary/code_splitting/index.html
+++ b/files/fr/glossary/code_splitting/index.html
@@ -1,18 +1,18 @@
 ---
-title: Code splitting
+title: La division du code
 slug: Glossary/Code_splitting
 translation_of: Glossary/Code_splitting
 ---
-<p><strong>Le code splitting</strong> (en français <i lang="fr">division de code</i>) est le fractionnement du code en divers bundles ou composants qui peuvent ensuite être chargés à la demande ou en parallèle.</p>
+<p>La <strong>division du code</strong> (« <i>code splitting</i> » en Anglais) est le fractionnement du code en divers bundles ou composants qui peuvent ensuite être chargés à la demande ou en parallèle.</p>
 
-<p>Au fur et à mesure qu'une application devient de plus en plus complexe ou est maintenue, la taille en octets des fichiers ou bundles CSS et JavaScripts augmente, en particulier à mesure que le nombre et la taille des bibliothèques tierces incluses augmentent. Pour éviter d'avoir à télécharger des fichiers gigantesques, les scripts peuvent être divisés en plusieurs fichiers plus petits. Ensuite, les fonctionnalités requises au chargement de la page peuvent être téléchargées immédiatement avec des scripts supplémentaires <a href="/fr/docs/Glossary/Lazy_load">chargés passivement</a> une fois que la page ou l'application soit interactive, améliorant ainsi les performances. Bien que la quantité totale de code soit la même (et peut-être même quelques octets plus grande), la quantité de code nécessaire lors du chargement initial peut être réduite.</p>
+<p>Au fur et à mesure qu'une application devient de plus en plus complexe ou est maintenue, la taille en octets des fichiers ou bundles CSS et JavaScripts augmente, en particulier à mesure que le nombre et la taille des bibliothèques tierces incluses augmentent. Pour éviter d'avoir à télécharger des fichiers gigantesques, les scripts peuvent être divisés en plusieurs fichiers plus petits. Ensuite, les fonctionnalités requises au chargement de la page peuvent être téléchargées immédiatement avec des scripts supplémentaires <a href="/fr/docs/Glossary/Lazy_load">chargés passivement</a> une fois que la page ou l'application soit interactive, améliorant ainsi les performances. Bien que la quantité totale de code soit la même (et peut-être même quelques octets plus grands), la quantité de code nécessaire lors du chargement initial peut être réduite.</p>
 
-<p>Le code splitting est une fonctionnalité prise en charge par les contructeurs (bundlers) comme <a href="https://webpack.js.org/">Webpack</a> et <a href="http://browserify.org/">Browserify</a> qui peut créer plusieurs bundles pouvant être chargés dynamiquement au moment de l'exécution.</p>
+<p>Le code splitting est une fonctionnalité prise en charge par les contructeurs (bundlers) comme <a href="https://webpack.js.org/">Webpack</a> et <a href="https://browserify.org/">Browserify</a> qui peut créer plusieurs bundles pouvant être chargés dynamiquement au moment de l'exécution.</p>
 
-<h2 id="Voir_aussi">Voir aussi</h2>
+<h2 id="see_also">Voir aussi</h2>
 
 <ul>
- <li>Bundling</li>
+ <li>Regroupement</li>
  <li><a href="/fr/docs/Web/Performance/Lazy_loading">Lazy loading</a></li>
  <li><a href="/fr/docs/Glossary/HTTP_2">HTTP/2</a></li>
  <li><a href="/fr/docs/Glossary/Tree_shaking">Tree shaking</a></li>

--- a/files/fr/glossary/code_splitting/index.html
+++ b/files/fr/glossary/code_splitting/index.html
@@ -1,26 +1,19 @@
 ---
 title: Code splitting
 slug: Glossary/Code_splitting
-tags:
-  - Glossary
-  - Reference
-  - Web Performance
-  - code splitting
-  - latency
 translation_of: Glossary/Code_splitting
-original_slug: Glossaire/Code_splitting
 ---
-<p><span class="seoSummary"><strong>Le code splitting</strong> est le fractionnement du code en divers bundles ou composants qui peuvent ensuite être chargés à la demande ou en parallèle.</span></p>
+<p><strong>Le code splitting</strong> est le fractionnement du code en divers bundles ou composants qui peuvent ensuite être chargés à la demande ou en parallèle.</p>
 
-<p>Au fur et à mesure qu'une application devient de plus en plus complexe ou est maintenue, la taille en octets des fichiers ou bundles CSS et JavaScripts augmente, en particulier à mesure que le nombre et la taille des bibliothèques tierces incluses augmentent. Pour éviter d'avoir à télécharger des fichiers gigantesques, les scripts peuvent être divisés en plusieurs fichiers plus petits. Ensuite, les fonctionnalités requises au chargement de la page peuvent être téléchargées immédiatement avec des scripts supplémentaires <a href="/en-US/docs/Glossary/Lazy_load">chargés passivement</a> une fois que la page ou l'application soit interactive, améliorant ainsi les performances. Bien que la quantité totale de code soit la même (et peut-être même quelques octets plus grande), la quantité de code nécessaire lors du chargement initial peut être réduite.</p>
+<p>Au fur et à mesure qu'une application devient de plus en plus complexe ou est maintenue, la taille en octets des fichiers ou bundles CSS et JavaScripts augmente, en particulier à mesure que le nombre et la taille des bibliothèques tierces incluses augmentent. Pour éviter d'avoir à télécharger des fichiers gigantesques, les scripts peuvent être divisés en plusieurs fichiers plus petits. Ensuite, les fonctionnalités requises au chargement de la page peuvent être téléchargées immédiatement avec des scripts supplémentaires <a href="/fr/docs/Glossary/Lazy_load">chargés passivement</a> une fois que la page ou l'application soit interactive, améliorant ainsi les performances. Bien que la quantité totale de code soit la même (et peut-être même quelques octets plus grande), la quantité de code nécessaire lors du chargement initial peut être réduite.</p>
 
-<p>Le code splitting est une fonctionnalité prise en charge par les bundlers comme <a href="https://webpack.js.org/">Webpack</a> et <a href="http://browserify.org/">Browserify</a> qui peut créer plusieurs bundles pouvant être chargés dynamiquement au moment de l'exécution.</p>
+<p>Le code splitting est une fonctionnalité prise en charge par les contructeurs (bundlers) comme <a href="https://webpack.js.org/">Webpack</a> et <a href="http://browserify.org/">Browserify</a> qui peut créer plusieurs bundles pouvant être chargés dynamiquement au moment de l'exécution.</p>
 
 <h2 id="Voir_aussi">Voir aussi</h2>
 
 <ul>
  <li>Bundling</li>
- <li><a href="/en-US/docs/Web/Performance/Lazy_loading">Lazy loading</a></li>
- <li><a href="/en-US/docs/Glossary/HTTP_2">HTTP/2</a></li>
- <li><a href="/en-US/docs/Glossary/Tree_shaking">Tree shaking</a></li>
+ <li><a href="/fr/docs/Web/Performance/Lazy_loading">Lazy loading</a></li>
+ <li><a href="/fr/docs/Glossary/HTTP_2">HTTP/2</a></li>
+ <li><a href="/fr/docs/Glossary/Tree_shaking">Tree shaking</a></li>
 </ul>

--- a/files/fr/glossary/code_splitting/index.html
+++ b/files/fr/glossary/code_splitting/index.html
@@ -1,0 +1,26 @@
+---
+title: Code splitting
+slug: Glossary/Code_splitting
+tags:
+  - Glossary
+  - Reference
+  - Web Performance
+  - code splitting
+  - latency
+translation_of: Glossary/Code_splitting
+original_slug: Glossaire/Code_splitting
+---
+<p><span class="seoSummary"><strong>Le code splitting</strong> est le fractionnement du code en divers bundles ou composants qui peuvent ensuite être chargés à la demande ou en parallèle.</span></p>
+
+<p>Au fur et à mesure qu'une application devient de plus en plus complexe ou est maintenue, la taille en octets des fichiers ou bundles CSS et JavaScripts augmente, en particulier à mesure que le nombre et la taille des bibliothèques tierces incluses augmentent. Pour éviter d'avoir à télécharger des fichiers gigantesques, les scripts peuvent être divisés en plusieurs fichiers plus petits. Ensuite, les fonctionnalités requises au chargement de la page peuvent être téléchargées immédiatement avec des scripts supplémentaires <a href="/en-US/docs/Glossary/Lazy_load">chargés passivement</a> une fois que la page ou l'application soit interactive, améliorant ainsi les performances. Bien que la quantité totale de code soit la même (et peut-être même quelques octets plus grande), la quantité de code nécessaire lors du chargement initial peut être réduite.</p>
+
+<p>Le code splitting est une fonctionnalité prise en charge par les bundlers comme <a href="https://webpack.js.org/">Webpack</a> et <a href="http://browserify.org/">Browserify</a> qui peut créer plusieurs bundles pouvant être chargés dynamiquement au moment de l'exécution.</p>
+
+<h2 id="Voir_aussi">Voir aussi</h2>
+
+<ul>
+ <li>Bundling</li>
+ <li><a href="/en-US/docs/Web/Performance/Lazy_loading">Lazy loading</a></li>
+ <li><a href="/en-US/docs/Glossary/HTTP_2">HTTP/2</a></li>
+ <li><a href="/en-US/docs/Glossary/Tree_shaking">Tree shaking</a></li>
+</ul>


### PR DESCRIPTION
Propose french translation for [files/en-us/glossary/code_splitting/index.html id:145](https://tristantheb.github.io/history-content/#145)