### PR TITLE
Firefox 91 for developers を翻訳

### DIFF
--- a/files/ja/mozilla/firefox/releases/91/index.html
+++ b/files/ja/mozilla/firefox/releases/91/index.html
@@ -1,0 +1,73 @@
+---
+title: Firefox 91 for developers
+slug: Mozilla/Firefox/Releases/91
+tags:
+  - '91'
+  - Firefox
+  - Mozilla
+  - Release
+---
+<p>{{FirefoxSidebar}}</p>
+
+<p class="summary">このページでは、開発者に影響する Firefox 91 の変更点をまとめています。Firefox 91 は 2021 年 8 月 10 日にリリースされました。</p>
+
+<div class="note notecard">
+  <h4>補足</h4>
+  <p>Mozilla Hacks の <a href="https://hacks.mozilla.org/2021/08/hopping-on-firefox-91/">Hopping on Firefox 91</a> もご覧ください。</p>
+</div>
+
+<h2 id="Changes_for_web_developers">ウェブ開発者向けの変更点一覧</h2>
+
+
+<h3 id="HTML" name="HTML">HTML</h3>
+
+<p>変更なし。</p>
+
+<h3 id="CSS" name="CSS">CSS</h3>
+
+<ul>
+  <li>{{cssxref("@counter-style/pad")}} ディスクリプターが負符号を扱う方法を修正しました ({{bug(1714445)}})。</li>
+  <li><code>-moz-tab-size</code> プロパティの接頭辞を削除して、標準化された {{cssxref("tab-size")}} にしました。また、接頭辞つきのプロパティを別名として維持します ({{bug(737785)}})。</li>
+</ul>
+
+<h4 id="removals_css">廃止</h4>
+
+<ul>
+  <li>非標準の {{cssxref("-moz-outline-radius")}} プロパティを削除しました ({{bug(1715984)}})。このプロパティは Firefox 88 からウェブ開発者が使用できず、このバージョンで完全に廃止しました。</li>
+</ul>
+
+<h3 id="JavaScript">JavaScript</h3>
+
+<ul>
+  <li>{{jsxref("Intl/DateTimeFormat/formatRange", "Intl.DateTimeFormat.prototype.formatRange()")}} および {{jsxref("Intl/DateTimeFormat/formatRangeToParts", "Intl.DateTimeFormat.prototype.formatRangeToParts()")}} を、Release ビルドでサポートしました。<code>formatRange()</code> メソッドは、2 つの {{jsxref("Date")}} オブジェクトの間の期間をローカライズおよび整形した文字列で返します (例: "21/01/05 – 21/01/10")。<code>formatRangeToParts()</code> メソッドは、整形された期間のロケール固有の<em>部品</em>を持つ配列を返します ({{bug(1653024)}})。</li>
+  <li>{{jsxref("Intl/DateTimeFormat/DateTimeFormat", "Intl.DateTimeFormat() コンストラクター")}} が、タイムゾーンの表示方法を整形するための <code>timeZoneName</code> オプションを新たに 4 種類受け入れるようになりました。これにはローカライズされた GMT 形式の <code>shortOffset</code> および <code>longOffset</code> と、一般的な非ロケーション形式の <code>shortGeneric</code> および <code>longGeneric</code> が含まれます ({{bug(1653024)}})。</li>
+  <li>{{jsxref("Global_Objects/Error/Error", "Error() コンストラクター")}} が、<code>option</code> 引数の値として <code>cause</code> をとれるようになりました。これはコードがエラーをキャッチして、元のエラーやスタックトレースを持つ新たなバージョン、または変更したバージョンのエラーを発生させることができます ({{bug(1653024)}})。</li>
+ </ul>
+
+
+<h3 id="HTTP">HTTP</h3>
+
+<ul>
+  <li><a href="/ja/docs/Web/API/Gamepad_API">Gamepad API</a> が <a href="/ja/docs/Web/Security/Secure_Contexts">安全なコンテキスト</a> を要求するようになりました ({{bug(1704005)}})。</li>
+</ul>
+
+<h3 id="APIs">API</h3>
+
+<h4 id="DOM">DOM</h4>
+
+<ul>
+  <li><a href="/ja/docs/Web/API/Visual_Viewport_API">Visual Viewport API</a> がデスクトップ版 Firefox でデフォルトで有効になりました (Android 版 Firefox はバージョン 68 で有効にしていました)。この API はドキュメントに対する {{Glossary("visual viewport", "視覚的ビューポート")}} の位置を表す情報へ、ウィンドウのコンテンツエリアと同様にアクセスする手段を提供します。また、ビューポートの変更を監視できるイベントも提供します ({{bug(1551302)}}).</li>
+  <li><a href="/ja/docs/Web/API/Gamepad_API">Gamepad API</a> が {{httpheader('Feature-Policy/gamepad','Feature-Policy: gamepad')}} で保護されるようになりました。<a href="/ja/docs/Web/HTTP/Feature_Policy">機能ポリシー</a> で拒否された場合は、{{domxref('Navigator.getGamepads()')}} を呼び出すと <code>SecurityError</code> {{domxref('DOMException')}} が発生して、{{event("gamepadconnected")}} および {{event("gamepaddisconnected")}} イベントは発生しません。既定の <code>allowlist</code> は <code>*</code> です。この既定値は、仕様書に合わせるため将来のリリースで <code>self</code> に更新する予定です ({{bug(1704005)}})。</li>
+  <li>最近の仕様書の更新に準拠するため、および他の主要なブラウザーとの互換性を向上させるために、<code>Window.clientInformation</code> を {{domxref("Window.navigator")}} の別名として追加しました ({{bug(1717072)}})。</li>
+</ul>
+
+
+<h3 id="webdriver_conformance_marionette">WebDriver conformance (Marionette)</h3>
+<ul>
+  <li>ポップアップウィンドウで開いたユーザープロンプトで、<code>WebDriver:AcceptAlert</code> および <code>WebDriver:DismissAlert</code> コマンドがハングアップを起こす不具合を修正しました ({{bug(1721982)}})。</li>
+  <li><code>webSocketUrl</code> 特性の不適切な取り扱いを修正しました。<code>webSocketUrl</code> が未サポートでしたが <code>true</code> を返していました ({{bug(1713775)}})。</li>
+</ul>
+
+<h2 id="Older_versions">過去のバージョン</h2>
+
+<p>{{Firefox_for_developers(90)}}</p>

--- a/files/ja/mozilla/firefox/releases/91/index.html
+++ b/files/ja/mozilla/firefox/releases/91/index.html
@@ -19,11 +19,11 @@ tags:
 <h2 id="Changes_for_web_developers">ウェブ開発者向けの変更点一覧</h2>
 
 
-<h3 id="HTML" name="HTML">HTML</h3>
+<h3 id="HTML">HTML</h3>
 
 <p>変更なし。</p>
 
-<h3 id="CSS" name="CSS">CSS</h3>
+<h3 id="CSS">CSS</h3>
 
 <ul>
   <li>{{cssxref("@counter-style/pad")}} ディスクリプターが負符号を扱う方法を修正しました ({{bug(1714445)}})。</li>


### PR DESCRIPTION
Aug 13, 2021 の英語版に対応。