### PR TITLE
fix(l10n-ja): modify typo in values_and_units

### DIFF
--- a/files/ja/learn/css/building_blocks/values_and_units/index.html
+++ b/files/ja/learn/css/building_blocks/values_and_units/index.html
@@ -313,7 +313,7 @@ translation_of: Learn/CSS/Building_blocks/Values_and_units
 <ul>
  <li><strong>色相(Hue)</strong>: 色のベースとなるシェード。これは 0 から 360 の値を取り、色相環の角度を表します。</li>
  <li><strong>彩度(Saturation)</strong>: 色がどれだけ飽和しているか? これは 0–100% の値を取り、0 は色がなく (グレーのシェードに見える)、100% はフルカラーの飽和となります。</li>
- <li><strong>(Lightness)</strong>: 色がどれだけ明るいのか? こりは 0–100% の値を取り、0 は明度がなく (完全な黒に見える)、100% はフルの明度です (完全な白となる)。</li>
+ <li><strong>輝度(Lightness)</strong>: 色がどれだけ明るいのか? これは 0–100% の値を取り、0 は明度がなく (完全な黒に見える)、100% はフルの明度です (完全な白となる)。</li>
 </ul>
 
 <p>RGB の例を HSL の色に更新すると次のようになります:</p>


### PR DESCRIPTION
## Overview
I found a typo in `values_and_units` (CSS page) and modified it in this PR.

## Changes in this PR
- `(Lightness)`→`輝度(Lightness)`
- `こりは`→`これは`