### PR TITLE
fix web/api/canvasrenderingcontext2d/setlinedash/

### DIFF
--- a/files/ja/web/api/canvasrenderingcontext2d/setlinedash/index.html
+++ b/files/ja/web/api/canvasrenderingcontext2d/setlinedash/index.html
@@ -25,7 +25,7 @@ translation_of: Web/API/CanvasRenderingContext2D/setLineDash
 
 <h2 id="例">例</h2>
 
-<h3 id="簡単な例">簡単な例</h3>
+<h3 id="Basic_example">簡単な例</h3>
 
 <p>この例では、<code>setLineDash()</code>メソッドを使用して、実線の上に破線を描画します。</p>
 
@@ -58,7 +58,7 @@ ctx.stroke();
 
 <p>{{ EmbedLiveSample('Basic_example', 700, 180) }}</p>
 
-<h3 id="いくつかの一般的な模様">いくつかの一般的な模様</h3>
+<h3 id="Some_common_patterns">いくつかの一般的な模様</h3>
 
 <p>この例は、さまざまな一般的な破線のパターンを示しています。</p>
 


### PR DESCRIPTION
* fix [Content bug: Web/CSS/flex-shrinkでLive sampleが動作していない #2029](https://github.com/mdn/translated-content/issues/2029)