### PR TITLE
fix typo `Navigator.devicememory`

### DIFF
--- a/files/ja/web/api/navigator/index.html
+++ b/files/ja/web/api/navigator/index.html
@@ -32,7 +32,7 @@ translation_of: Web/API/Navigator
  <dt>{{domxref("Navigator.credentials")}} {{readonlyInline}}</dt>
  <dd>ログインやログアウトの成功といったイベントが発生したときに、資格情報を要求してユーザーエージェントへ通知する手段を提供する {{domxref("CredentialsContainer")}} インターフェイスを返します。</dd>
  <dt>{{domxref("Navigator.deviceMemory")}} {{readonlyInline}} {{experimental_inline}}</dt>
- <dd>端末のメモリーをギガバイト単位で返します。この値は 2 の階乗の最も近い値を 1024 で割った概算値です。</dd>
+ <dd>端末のメモリーをギガバイト単位で返します。この値は 2 の累乗に最も近い値を 1024 で割った概算値です。</dd>
  <dt>{{domxref("Navigator.doNotTrack")}} {{readonlyInline}} {{experimental_inline}}</dt>
  <dd>ユーザーの do-not-track 設定の値を返します。この値が "yes" であるとき、ウェブサイトやアプリケーションはユーザーを追跡するべきではありません。</dd>
  <dt>{{domxref("Navigator.geolocation")}} {{readonlyInline}}</dt>


### PR DESCRIPTION
"power of 2" を2の階乗と誤訳していたため2の累乗と修正しました。