### PR TITLE
Fix typo in Portuguese translation

### DIFF
--- a/files/pt-br/web/api/websockets_api/writing_websocket_client_applications/index.html
+++ b/files/pt-br/web/api/websockets_api/writing_websocket_client_applications/index.html
@@ -180,4 +180,4 @@ function sendText() {
 
 <h2 id="Considerações_de_segurança">Considerações de segurança</h2>
 
-<p>WebSockets não devem ser utilizados em um contexto de um ambiente misto, isto é, você não deveria abrir uma conexão não-segura a partir de uma página previamente carregada utilizando HTTPS, ou vice-versa. A maioria dos browsers atuamente apenas permitem conexões seguras pelo Websocke, e não mais suportam contextos diferentes desse.</p>
+<p>WebSockets não devem ser utilizados em um contexto de um ambiente misto, isto é, você não deveria abrir uma conexão não-segura a partir de uma página previamente carregada utilizando HTTPS, ou vice-versa. A maioria dos browsers atuamente apenas permitem conexões seguras pelo Websocket, e não mais suportam contextos diferentes desse.</p>


### PR DESCRIPTION
Fix Portuguese translation in "Writing WebSocket client applications".

Update `Websocke` to `Websocket`

Link: https://developer.mozilla.org/pt-BR/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications

