### PR TITLE
replace half-width symbol to full-width symbol

### DIFF
--- a/files/zh-cn/web/http/methods/index.html
+++ b/files/zh-cn/web/http/methods/index.html
@@ -14,15 +14,15 @@ translation_of: Web/HTTP/Methods
 ---
 <p>{{HTTPSidebar}}</p>
 
-<p>HTTP 定义了一组<strong>请求方法</strong>, 以表明要对给定资源执行的操作。指示针对给定资源要执行的期望动作. 虽然他们也可以是名词, 但这些请求方法有时被称为HTTP动词. 每一个请求方法都实现了不同的语义, 但一些共同的特征由一组共享：: 例如一个请求方法可以是 {{glossary("safe")}}, {{glossary("idempotent")}}, 或 {{glossary("cacheable")}}.</p>
+<p>HTTP 定义了一组<strong>请求方法</strong>，以表明要对给定资源执行的操作。指示针对给定资源要执行的期望动作。虽然他们也可以是名词, 但这些请求方法有时被称为HTTP动词。每一个请求方法都实现了不同的语义，但一些共同的特征由一组共享：例如一个请求方法可以是 {{glossary("safe")}}, {{glossary("idempotent")}}, 或 {{glossary("cacheable")}}。</p>
 
 <dl>
  <dt><code><a href="/en-US/docs/Web/HTTP/Methods/GET">GET</a></code></dt>
- <dd>GET方法请求一个指定资源的表示形式. 使用GET的请求应该只被用于获取数据.</dd>
+ <dd>GET方法请求一个指定资源的表示形式，使用GET的请求应该只被用于获取数据。</dd>
  <dt><code><a href="/en-US/docs/Web/HTTP/Methods/HEAD">HEAD</a></code></dt>
- <dd>HEAD方法请求一个与GET请求的响应相同的响应，但没有响应体.</dd>
+ <dd>HEAD方法请求一个与GET请求的响应相同的响应，但没有响应体。</dd>
  <dt><code><a href="/en-US/docs/Web/HTTP/Methods/POST">POST</a></code></dt>
- <dd>POST方法用于将实体提交到指定的资源，通常导致在服务器上的状态变化或副作用. </dd>
+ <dd>POST方法用于将实体提交到指定的资源，通常导致在服务器上的状态变化或副作用。</dd>
  <dt><code><a href="/en-US/docs/Web/HTTP/Methods/PUT">PUT</a></code></dt>
  <dd>PUT方法用请求有效载荷替换目标资源的所有当前表示。</dd>
  <dt><code><a href="/en-US/docs/Web/HTTP/Methods/DELETE">DELETE</a></code></dt>


### PR DESCRIPTION
there is some mix use of half-width symbol

this PR replaced half-width symbol (`,` `.`) to full-width symbol (`，` `。`)