### PR TITLE
amend mistranslation in Korean (오역 수정)

### DIFF
--- a/files/ko/web/api/element/tagname/index.html
+++ b/files/ko/web/api/element/tagname/index.html
@@ -5,7 +5,7 @@ translation_of: Web/API/Element/tagName
 ---
 <div>{{ApiRef("DOM")}}</div>
 
-<p><span class="seoSummary">{{domxref("Element")}} 인터페이스의 <strong><code>tagName</code></strong> 읽기 전용 속성은 요소에 호출된 태그 명을 가져온다.</span> 예를 들면, 만약 {{HTMLElement("img")}} 요소일 경우, 해당 요소의 <code>tagName</code> 속성의 내용은 <code>"IMG"</code> 가 된다 (XML/XHTML 및 HTML 문서에서 대소문자가 다르게 나올 수 있다).</p>
+<p><span class="seoSummary">{{domxref("Element")}} 인터페이스의 <strong><code>tagName</code></strong> 읽기 전용 속성은 요소에 호출된 태그 명을 가져온다.</span> 예를 들면, 만약 {{HTMLElement("img")}} 요소일 경우, 해당 요소의 <code>tagName</code> 속성의 내용은 <code>"IMG"</code> 가 된다 (이것은 HTML인 경우에 대한 내용이고, XML/XHTML 문서에서는 대소문자가 다르게 나올 수 있다).</p>
 
 <h2 id="구문">구문</h2>
 


### PR DESCRIPTION
원문
>For example, if the element is an <img>, its tagName property is "IMG" _(for HTML documents; it may be cased differently for XML/XHTML documents)_.

기존 번역문
>예를 들면, 만약 <img> 요소일 경우, 해당 요소의 tagName 속성의 내용은 "IMG" 가 된다 _(XML/XHTML 및 HTML 문서에서 대소문자가 다르게 나올 수 있다)_.

수정한 번역문
>예를 들면, 만약 <img> 요소일 경우, 해당 요소의 tagName 속성의 내용은 "IMG" 가 된다 _(이것은 HTML인 경우에 대한 내용이고, XML/XHTML 문서에서는 대소문자가 다르게 나올 수 있다)_.