### PR TITLE
escape title with colon

### DIFF
--- a/files/fr/web/mathml/examples/deriving_the_quadratic_formula/index.html
+++ b/files/fr/web/mathml/examples/deriving_the_quadratic_formula/index.html
@@ -1,5 +1,5 @@
 ---
-title: MathML : Dériver la formule quadratique
+title: 'MathML: Dériver la formule quadratique'
 slug: Web/MathML/Examples/Deriving_the_Quadratic_Formula
 translation_of: Web/MathML/Examples/Deriving_the_Quadratic_Formula
 original_slug: Web/MathML/Exemples/Dériver_la_Formule_Quadratique


### PR DESCRIPTION
Adds back the quotes around the title that includes a `:` character. Reverts part of #2153 that broke the production build (cc @borispinatel).
