### PR TITLE
FIX | Corrected a small typo in the Russian translation

### DIFF
--- a/files/ru/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.html
+++ b/files/ru/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.html
@@ -80,7 +80,7 @@ var abyte = filestream.charCodeAt(x) &amp; 0xff; // throw away high-order byte (
 
 <h2 id="Получение_бинарных_данных_из_различных_источников">Получение бинарных данных из различных источников</h2>
 
-<p>Библиотека <a href="https://github.com/jDataView/jBinary">jBinary</a> для работы с бинарными данными в JavaScript позволяет загрузить данные из любого источника, автоматически определяя лучший способ для этого в текущем броузере или Node.js:</p>
+<p>Библиотека <a href="https://github.com/jDataView/jBinary">jBinary</a> для работы с бинарными данными в JavaScript позволяет загрузить данные из любого источника, автоматически определяя лучший способ для этого в текущем браузере или Node.js:</p>
 
 <pre class="brush: js notranslate">jBinary.load(url).then(function (binary) {
   // здесь аргумент `binary` может использовться для обработки данных


### PR DESCRIPTION
Corrected a typo in the word `броузер` in the Russian translation, the correct word should be `браузер`.