### PR TITLE
Fix an external link on using_the_aria-invalid_attribute/index.html in JP

### DIFF
--- a/files/ja/web/accessibility/aria/aria_techniques/using_the_aria-invalid_attribute/index.html
+++ b/files/ja/web/accessibility/aria/aria_techniques/using_the_aria-invalid_attribute/index.html
@@ -96,7 +96,7 @@ translation_of: Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-invalid_at
 
 <h4 id="Working_Examples" name="Working_Examples">動作する例</h4>
 
-<p><a class="external" href="http://www.oaa-accessibility.org/examplep/alert1/"><code>alert</code> ロールの例</a>（<code>aria-invalid</code> 属性を使用）</p>
+<p><a href="https://www.w3.org/WAI/WCAG21/working-examples/aria-invalid-data-format/">正しくない形式の値を強調するために aria-invalid を使ったフォームの例</a></p>
 
 <h3 id="Notes" name="Notes">注</h3>
 


### PR DESCRIPTION
Since the external link to the working example is outdated, users who click on the link will be sent to a dangerous site. I fixed it to use an example of W3 as the US page.