### PR TITLE
Fix typo in Portuguese translation

### DIFF
--- a/files/pt-br/web/javascript/reference/operators/super/index.html
+++ b/files/pt-br/web/javascript/reference/operators/super/index.html
@@ -97,7 +97,7 @@ new Derived().delete(); // ReferenceError: invalid delete involving 'super'. </p
 
 <h3 id="Super.prop_não_pode_sobrescrever_propriedades_não_editáveis"><code>Super.prop</code> não pode sobrescrever propriedades não editáveis</h3>
 
-<p><code>super</code>Whennão pode sobrescrever o valor de uma propriedade quando esta houver sido definida como não editável ('writable: false') com, e.g., {{jsxref("Object.defineProperty")}}.</p>
+<p><code>super</code>não pode sobrescrever o valor de uma propriedade quando esta houver sido definida como não editável ('writable: false') com, e.g., {{jsxref("Object.defineProperty")}}.</p>
 
 <pre class="brush: js">class X {
   constructor() {


### PR DESCRIPTION
Fix Portuguese translation in "super".

Update `Whennão` to `Não`

Link: https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Operators/super