### PR TITLE
Remove note from replaceAll() pt-br docs

### DIFF
--- a/files/pt-br/web/javascript/reference/global_objects/string/replaceall/index.html
+++ b/files/pt-br/web/javascript/reference/global_objects/string/replaceall/index.html
@@ -14,8 +14,6 @@ translation_of: Web/JavaScript/Reference/Global_Objects/String/replaceAll
 ---
 <div>{{JSRef}}</div>
 
-<div class="blockIndicator note"><strong>Nota</strong>: A partir de Agosto de 2020, o método <code>replaceAll()</code> continuará sendo suportado pelo Firefox, mas não pelo Chrome. Ele estará disponível somente no Chrome 85.</div>
-
 <p>O método <code>replaceAll()</code> retorna uma nova string com todas as ocorrências de um padrão substituídas por uma substituição. O padrão pode ser uma string ou uma {{jsxref ("RegExp")}}, e a substituição pode ser uma string ou uma função a ser chamada para cada ocorrência.<br>
  <br>
  A <em>string</em> original é mantida sem modificação.</p>


### PR DESCRIPTION
This note can make some people think that replaceAll is not supported by Chrome, which is not true.

This note is not present on the English version, so I think it is fine to remove.