### PR TITLE
Typo : 'Using Date.parse() の使用' -> 'Date.parse()の使用'

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/date/parse/index.html
+++ b/files/ja/web/javascript/reference/global_objects/date/parse/index.html
@@ -107,7 +107,7 @@ Date.parse('foo-bar 2014');
 
 <h2 id="Examples" name="Examples">例</h2>
 
-<h3 id="Using_Date.parse" name="Using_Date.parse">Using <code>Date.parse()</code> の使用</h3>
+<h3 id="Using_Date.parse" name="Using_Date.parse"><code>Date.parse()</code> の使用</h3>
 
 <p>以下の呼び出しはすべて <code>1546300800000</code> を返します。最初のものは ES5 によれば UTC 時刻を意味し、それ以外は ISO 日付仕様 (<code>Z</code> および <code>+00:00</code>) に従って UTC をタイムゾーンを指定しています。</p>
 


### PR DESCRIPTION
原文 `Using Date.parse()` を `Using Date.parse() の使用` と訳すのは誤りだと感じたので、`Date.parse() の使用` に修正しました。

▶ [原文のDateページ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#using_date.parse)
▶ [現日本語訳のDateページ](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#using_date.parse)