### PR TITLE
Revamps WS landing page - translates WS interface subpages - fixes #2139

### DIFF
--- a/files/fr/web/api/websocket/binarytype/index.html
+++ b/files/fr/web/api/websocket/binarytype/index.html
@@ -15,7 +15,7 @@ var binaryType = aWebSocket.binaryType;
 
 <h2 id="value">Valeur</h2>
 
-<p>Une chaîne de caractères <a href="/fr/docs/Web/API/DOMString"><code>DOMString</code></a> ayant l'une de ces deux valeurs:</p>
+<p>Une chaîne de caractères <a href="/fr/docs/Web/API/DOMString"><code>DOMString</code></a> ayant l'une de ces deux valeurs :</p>
 
 <dl>
   <dt><code>"blob"</code></dt>

--- a/files/fr/web/api/websocket/binarytype/index.html
+++ b/files/fr/web/api/websocket/binarytype/index.html
@@ -1,0 +1,54 @@
+---
+title: WebSocket.binaryType
+slug: Web/API/WebSocket/binaryType
+browser-compat: api.WebSocket.binaryType
+---
+<p>{{APIRef("Web Sockets API")}}</p>
+
+<p>La propriété <strong><code>WebSocket.binaryType</code></strong> contrôle le type de données binaires reçues via la connexion WebSocket.</p>
+
+<h2 id="syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+var binaryType = aWebSocket.binaryType;
+</pre>
+
+<h2 id="value">Valeur</h2>
+
+<p>Une chaîne de caractères <a href="/fr/docs/Web/API/DOMString"><code>DOMString</code></a> ayant l'une de ces deux valeurs:</p>
+
+<dl>
+  <dt><code>"blob"</code></dt>
+  <dd>Utilise des objets <a href="/fr/docs/Web/API/Blob"><code>Blob</code></a> pour les données binaires. Il s'agit de la valeur par défaut.</dd>
+  <dt><code>"arraybuffer"</code></dt>
+  <dd>Utilise des objets <a href="/fr/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer"><code>ArrayBuffer</code></a> pour les données binaires.
+  </dd>
+</dl>
+
+<h2 id="examples">Exemples</h2>
+
+<pre class="brush: js">
+// On crée une connexion WebSocket connection.
+const socket = new WebSocket("ws://localhost:8080");
+// On change le type de données binaires de "blob" à "arraybuffer"
+socket.binaryType = "arraybuffer";
+
+// On écoute les différents messages
+socket.addEventListener("message", function (event) {
+  if(event.data instanceof ArrayBuffer) {
+    // Frame de données binaires
+    const view = new DataView(event.data);
+    console.log(view.getInt32(0));
+  } else {
+    // Frame textuelle
+    console.log(event.data);
+  }
+});</pre>
+
+<h2 id="specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>

--- a/files/fr/web/api/websocket/bufferedamount/index.html
+++ b/files/fr/web/api/websocket/bufferedamount/index.html
@@ -1,0 +1,26 @@
+---
+title: WebSocket.bufferedAmount
+slug: Web/API/WebSocket/bufferedAmount
+browser-compat: api.WebSocket.bufferedAmount
+---
+<p>{{APIRef("Web Sockets API")}}</p>
+
+<p>La propriété en lecture seule <strong><code>WebSocket.bufferedAmount</code></strong> renvoie le nombre d'octets de données qui ont été placées dans la queue via des appels à <a href="/fr/docs/Web/API/WebSocket/send"><code>send()</code></a> mais qui n'ont pas encore été transmises sur le réseau. Cette valeur est réinitialisée à zéro lorsque toutes les données ont été envoyées. Cette valeur n'est pas remise à zéro lorsque la connexion est fermée. Des appels successifs à <a href="/fr/docs/Web/API/WebSocket/send"><code>send()</code></a> feront croître cette valeur.</p>
+
+<h2 id="syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+var bufferedAmount = aWebSocket.bufferedAmount;
+</pre>
+
+<h2 id="value">Valeur</h2>
+
+<p>Un nombre au format <code>unsigned long</code>.</p>
+
+<h2 id="specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>

--- a/files/fr/web/api/websocket/close/index.html
+++ b/files/fr/web/api/websocket/close/index.html
@@ -1,0 +1,45 @@
+---
+title: WebSocket.close()
+slug: Web/API/WebSocket/close
+browser-compat: api.WebSocket.close
+---
+<p>{{APIRef("Web Sockets API")}}</p>
+
+<p>La méthode <strong><code>WebSocket.close()</code></strong> ferme la connexion <a href="/fr/docs/Web/API/WebSocket"><code>WebSocket</code></a> ou interrompt l'éventuelle tentative de connexion. Si la connexion est déjà fermée (état <code>CLOSED</code>), cette méthode ne fait rien.</p>
+
+<h2 id="syntax">Syntaxe</h2>
+
+<pre class="brush: js">WebSocket.close();</pre>
+<pre class="brush: js">WebSocket.close(code);</pre>
+<pre class="brush: js">WebSocket.close(reason);</pre>
+<pre class="brush: js">WebSocket.close(code, reason);</pre>
+
+<h3 id="parameters">Paramètres</h3>
+
+<dl>
+  <dt><code>code</code> {{optional_inline}}</dt>
+  <dd>Une valeur numérique indiquant le code de statut qui explique pourquoi la connexion est fermée. Si ce paramètre n'est pas fourni, 1005 sera la valeur par défaut. Voir <a href="/fr/docs/Web/API/CloseEvent#status_codes">la liste des codes de statut</a> de <a href="/fr/docs/Web/API/CloseEvent"><code>CloseEvent</code></a> pour les valeurs autorisées.</dd>
+  <dt><code>reason</code> {{optional_inline}}</dt>
+  <dd>Une chaîne de caractères, lisible et compréhensible par un humain qui explique pourquoi la connexion est fermée. Cette chaîne ne doit pas être plus longue que 123 octets de texte UTF-8 (attention, <strong>cela ne signifie pas</strong> 123 caractères).</dd>
+</dl>
+
+<h3 id="exceptions_thrown">Exceptions levées</h3>
+
+<dl>
+  <dt><code>INVALID_ACCESS_ERR</code></dt>
+  <dd>Un code invalide a été fourni avec <code>code</code>.</dd>
+  <dt><code>SYNTAX_ERR</code></dt>
+  <dd>La chaîne de caractères pour <code>reason</code> est trop longue ou contient des <i lang="en">surrogates</i> non appairés.</dd>
+</dl>
+
+<div class="note">
+  <p><strong>Note :</strong> Avant Gecko 8.0, cette méthode ne prenait en charge aucun paramètre.</p>
+</div>
+
+<h2 id="specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>

--- a/files/fr/web/api/websocket/close_event/index.html
+++ b/files/fr/web/api/websocket/close_event/index.html
@@ -1,72 +1,61 @@
 ---
-title: close
+title: 'WebSocket : évènement close'
 slug: Web/API/WebSocket/close_event
+browser-compat: api.WebSocket.close_event
 translation_of: Web/API/WebSocket/close_event
 ---
-<p>Le gestionnaire de fermuture (<strong>close</strong>) est exécuté lorsqu'une connexion avec un socket Web est fermée.</p>
+<div>{{APIRef}}</div>
 
-<h2 id="Informations_générales">Informations générales</h2>
+<p>L'évènement <code>close</code> est déclenché lorsqu'une connexion avec une <code>WebSocket</code> est fermée.</p>
 
-<dl>
- <dt style="float: left; text-align: right; width: 120px;">Spécification</dt>
- <dd style="margin: 0 0 0 120px;"><a class="external" href="http://www.w3.org/TR/websockets/">WebSocket</a></dd>
- <dt style="float: left; text-align: right; width: 120px;">Interface</dt>
- <dd style="margin: 0 0 0 120px;">Event</dd>
- <dt style="float: left; text-align: right; width: 120px;">Propagation</dt>
- <dd style="margin: 0 0 0 120px;">Non</dd>
- <dt style="float: left; text-align: right; width: 120px;">Annulable</dt>
- <dd style="margin: 0 0 0 120px;">Non</dd>
- <dt style="float: left; text-align: right; width: 120px;">Cible</dt>
- <dd style="margin: 0 0 0 120px;"><a href="/en-US/docs/WebSockets/WebSockets_reference/WebSocket" title="/en-US/docs/WebSockets/WebSockets_reference/WebSocket">WebSocket</a></dd>
- <dt style="float: left; text-align: right; width: 120px;">Action par défaut</dt>
- <dd style="margin: 0 0 0 120px;">Aucune</dd>
-</dl>
-
-<h2 id="Propriétés">Propriétés</h2>
-
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Property</th>
-   <th scope="col">Type</th>
-   <th scope="col">Description</th>
-  </tr>
- </thead>
+<table class="properties">
  <tbody>
   <tr>
-   <td><code>target</code> {{readonlyInline}}</td>
-   <td>{{domxref("EventTarget")}}</td>
-   <td>The event target (the topmost target in the DOM tree).</td>
+   <th scope="row">Bouillonne/Remonte</th>
+   <td>Non</td>
   </tr>
   <tr>
-   <td><code>type</code> {{readonlyInline}}</td>
-   <td>{{domxref("DOMString")}}</td>
-   <td>The type of event.</td>
+   <th scope="row">Annulable</th>
+   <td>Non</td>
   </tr>
   <tr>
-   <td><code>bubbles</code> {{readonlyInline}}</td>
-   <td>{{jsxref("Boolean")}}</td>
-   <td>Whether the event normally bubbles or not.</td>
+   <th scope="row">Interface</th>
+   <td><a href="/fr/docs/Web/API/CloseEvent"><code>CloseEvent</code></a></td>
   </tr>
   <tr>
-   <td><code>cancelable</code> {{readonlyInline}}</td>
-   <td>{{jsxref("Boolean")}}</td>
-   <td>Whether the event is cancellable or not.</td>
+   <th scope="row">Propriété de gestionnaire d'évènement correspondante</th>
+   <td><a href="/fr/docs/Web/API/WebSocket/onclose"><code>onclose</code></a></td>
   </tr>
  </tbody>
 </table>
 
-<h2 id="Evénements_liés">Evénements liés</h2>
+<h2 id="examples">Exemples</h2>
+
+<p>On peut vouloir savoir lorsque la connexion a été fermée afin de mettre à jour l'interface utilisateur ou, éventuellement, pour sauvegarder des données à propos de la connexion. Soit une variable <code>socketExemple</code> qui fait référence à une connexion WebSocket ouverte, le fragment de code suivant gère la situation où la socket a été fermée :</p>
+
+<pre class="brush: js">socketExemple.addEventListener('close', (event) =&gt; {
+  console.log('La connexion a été fermée avec succès.');
+});</pre>
+
+<p>On peut effectuer les mêmes actions avec la propriété de gestion d'évènement correspondante :</p>
+
+<pre class="brush: js">socketExemple.onclose = function (event) {
+  console.log('La connexion a été fermée avec succès.');
+};</pre>
+
+<h2 id="specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="Voir aussi">Voir aussi</h2>
 
 <ul>
- <li>{{event("open")}}</li>
- <li>{{event("close")}}</li>
- <li>{{event("error")}}</li>
- <li>{{event("message")}}</li>
-</ul>
-
-<h2 id="Voir_aussi">Voir aussi</h2>
-
-<ul>
- <li><a href="/fr/docs/WebSockets/Writing_WebSocket_client_applications">Ecrire des applications client WebSocket</a></li>
+ <li><a href="/fr/docs/Web/API/WebSocket/error_event">WebSocket : évènement <code>error</code></a></li>
+ <li><a href="/fr/docs/Web/API/WebSocket/message_event">WebSocket : évènement <code>message</code></a></li>
+ <li><a href="/fr/docs/Web/API/WebSocket/open_event">WebSocket : évènement <code>open</code></a></li>
+ <li><a href="/fr/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications">Écrire des applications clientes WebSocket</a></li>
 </ul>

--- a/files/fr/web/api/websocket/error_event/index.html
+++ b/files/fr/web/api/websocket/error_event/index.html
@@ -1,0 +1,57 @@
+---
+title: 'WebSocket : évènement error'
+slug: Web/API/WebSocket/error_event
+browser-compat: api.WebSocket.error_event
+---
+<div>{{APIRef}}</div>
+
+<p>L'évènement <code>error</code> est déclenché lorsqu'une connexion avec une <code>WebSocket</code> a été fermée à cause d'une erreur (par exemple lorsque des données n'ont pu être envoyées).</p>
+
+<table class="properties">
+ <tbody>
+  <tr>
+   <th scope="row">Bouillonne/Remonte</th>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Annulable</th>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Interface</th>
+   <td><a href="/fr/docs/Web/API/Event"><code>Event</code></a></td>
+  </tr>
+  <tr>
+   <th scope="row">Propriété de gestionnaire d'évènement correspondante</th>
+   <td><a href="/fr/docs/Web/API/WebSocket/onerror"><code>onerror</code></a></td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="examples">Exemples</h2>
+
+<pre class="brush: js">
+// On crée une connexion WebSocket
+const socket = new WebSocket('ws://localhost:8080');
+
+// On écoute les éventuelles erreurs
+socket.addEventListener('error', function (event) {
+  console.log('Erreur WebSocket : ', event);
+});</pre>
+
+<h2 id="specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="see_also">Voir aussi</h2>
+
+<ul>
+  <li><a href="/fr/docs/Web/API/WebSocket/close_event">WebSocket : évènement <code>close</code></a></li>
+ <li><a href="/fr/docs/Web/API/WebSocket/message_event">WebSocket : évènement <code>message</code></a></li>
+ <li><a href="/fr/docs/Web/API/WebSocket/open_event">WebSocket : évènement <code>open</code></a></li>
+ <li><a href="/fr/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications">Écrire des applications clientes WebSocket</a></li>
+</ul>

--- a/files/fr/web/api/websocket/extensions/index.html
+++ b/files/fr/web/api/websocket/extensions/index.html
@@ -1,0 +1,26 @@
+---
+title: WebSocket.extensions
+slug: Web/API/WebSocket/extensions
+browser-compat: api.WebSocket.extensions
+---
+<p>{{APIRef("Web Sockets API")}}</p>
+
+<p>La propriété en lecture seule <strong><code>WebSocket.extensions</code></strong> renvoie les extensions sélectionnées par le serveur. Actuellement, cette propriété vaut une chaîne de caractères vide ou la liste des extensions négociées par la connexion.</p>
+
+<h2 id="syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+var extensions = aWebSocket.extensions;
+</pre>
+
+<h2 id="value">Valeur</h2>
+
+<p>Une chaîne de caractères <a href="/fr/docs/Web/API/DOMString"><code>DOMString</code></a>.</p>
+
+<h2 id="specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>

--- a/files/fr/web/api/websocket/index.html
+++ b/files/fr/web/api/websocket/index.html
@@ -1,298 +1,125 @@
 ---
 title: WebSocket
 slug: Web/API/WebSocket
-tags:
-  - API
-  - WebSocket
-  - WebSockets
+browser-compat: api.WebSocket
 translation_of: Web/API/WebSocket
 ---
-<p>{{APIRef("Web Sockets API")}}{{ SeeCompatTable() }}</p>
+<div>{{APIRef("Web Sockets API")}}</div>
 
-<p>L'objet WebSocket fournit une API permettant la création et la gestion d'une <span style="background-color: rgba(212, 221, 228, 0.14902); font-size: 14.4444446563721px; line-height: 23.3333339691162px;">connexion</span> <a href="/en/WebSockets" title="en/WebSockets">WebSocket</a> avec un serveur, ainsi que l'émission et la réception de données par l'intermédiaire de cette <span style="background-color: rgba(212, 221, 228, 0.14902); font-size: 14.4444446563721px; line-height: 23.3333339691162px;">connexion</span>.</p>
+<p>L'objet <code>WebSocket</code> fournit l'API qui permet de créer et de gérer une connexion <a href="/fr/docs/Web/API/WebSockets_API">WebSocket</a> à un serveur ainsi que d'envoyer et de recevoir des données sur cette connexion.</p>
 
-<p>Le constructeur WebSocket accepte deux paramètres, un paramètre obligatoire et un facultatif:</p>
+<p>Pour construire un objet <code>WebSocket</code>, on utilisera le constructeur <code><a href="/fr/docs/Web/API/WebSocket/WebSocket">WebSocket()</a></code>.</p>
 
-<pre>WebSocket WebSocket(
-  in DOMString url,
-  in optional DOMString protocols
-);
+<p>{{AvailableInWorkers}}</p>
 
-WebSocket WebSocket(
-  in DOMString url,
-  in optional DOMString[] protocols
-);
-</pre>
+<h2 id="constructor">Constructeur</h2>
 
 <dl>
- <dt><code>url</code></dt>
- <dd>URL à laquelle se connecter; ce devrait être l'URL à laquelle le serveur WebSocket répondra.</dd>
- <dt><code>protocols</code> {{ optional_inline() }}</dt>
- <dd>Une chaîne de caractères spécifiant un protocole, ou <span style="font-size: 14.4444446563721px; line-height: 23.3333339691162px;">un tableau de chaîne de caractères (plusieurs protocoles)</span>. Ces chaînes sont utilisées pour indiquer les sous-protocoles, afin qu'un même serveur puisse implémenter de multiples sous-protocoles WebSocket (par exemple, vous pourriez souhaiter qu'un serveur soit capable de gérer différents types d'intéractions en fonction du protocole spécifié). Si vous ne passez aucune chaîne de caractères pour le(s) protocole(s), une chaîne vide est utilisée.</dd>
+ <dt><a href="/fr/docs/Web/API/WebSocket/WebSocket"><code>WebSocket(url[, protocols])</code></a></dt>
+ <dd>Renvoie un nouvel objet <code>WebSocket</code>.</dd>
 </dl>
 
-<p>Le constructeur peut lancer des exceptions:</p>
-
-<dl>
- <dt><code>SECURITY_ERR</code></dt>
- <dd>Le port vers lequel la <span style="background-color: rgba(212, 221, 228, 0.14902); font-size: 14.4444446563721px; line-height: 23.3333339691162px;">connexion</span> est tentée est actuellement bloqué.</dd>
-</dl>
-
-<dl>
-</dl>
-
-<h2 id="Method_overview" name="Method_overview">Vue d'ensemble des méthodes</h2>
+<h2 id="constants">Constantes</h2>
 
 <table class="standard-table">
  <tbody>
   <tr>
-   <td><code>void <a href="#close()">close</a>(in optional unsigned long code, in optional DOMString reason);</code></td>
+   <td class="header">Constante</td>
+   <td class="header">Valeur</td>
   </tr>
   <tr>
-   <td><code>void <a href="#send()">send</a>(in DOMString data);</code></td>
-  </tr>
- </tbody>
-</table>
-
-<h2 id="Attributes" name="Attributes">Attributs</h2>
-
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td class="header">Attribut</td>
-   <td class="header">Type</td>
-   <td class="header">Description</td>
-  </tr>
-  <tr>
-   <td><code>binaryType</code></td>
-   <td>{{DOMXref("DOMString")}}</td>
-   <td>Une chaîne de caractères indiquant le type de données binaires transmises par la connexion. Les valeurs possibles sont soit "blob" si des objets DOM {{ domxref("Blob") }} sont utilisés ou "arraybuffer" si des objets <a href="/en/JavaScript_typed_arrays/ArrayBuffer" title="en/JavaScript typed arrays/ArrayBuffer"><code>ArrayBuffer</code></a> sont utilisés.</td>
-  </tr>
-  <tr>
-   <td><code>bufferedAmount</code></td>
-   <td><code><a href="/en/unsigned_long" title="en/unsigned long">unsigned long</a></code></td>
-   <td>Le nombre d'octets de données mis en fil d'attente (n'étant pas encore transmis sur le réseau) en effectuant des appels à {{ manch("send") }}. Cette valeur n'est pas remise à zéro quand la connexion est fermée; elle continue d'augmenter si les appels à {{ manch("send") }} persistent. <strong>Lecture seule.</strong></td>
-  </tr>
-  <tr>
-   <td><code>extensions</code></td>
-   <td>{{DOMXref("DOMString")}}</td>
-   <td>Extensions sélectionnées par le serveur. Actuellement, c'est une chaîne de caractères vide ou une liste des extensions telle que décidée par la connexion.</td>
-  </tr>
-  <tr>
-   <td><code>onclose</code></td>
-   <td>{{DOMXref("EventListener")}}</td>
-   <td>Un gestionnaire d'évènement à appeler quand la valeur de l'attribut <code>readyState</code> de la connexion WebSocket devient <code>CLOSED</code>. Le gestionnaire reçoit un évènement <a href="/en/WebSockets/WebSockets_reference/CloseEvent" title="en/WebSockets/WebSockets reference/CloseEvent"><code>CloseEvent</code></a> nommé "close".</td>
-  </tr>
-  <tr>
-   <td><code>onerror</code></td>
-   <td>{{DOMXref("EventListener")}}</td>
-   <td><span style="background-color: rgba(212, 221, 228, 0.14902); font-size: 14.4444446563721px; line-height: 23.3333339691162px;">Un gestionnaire d'évènement à appeler quand une erreur survient</span>. L'évènement est un évènement de base, nommé "error".</td>
-  </tr>
-  <tr>
-   <td><code>onmessage</code></td>
-   <td>{{DOMXref("EventListener")}}</td>
-   <td><span style="background-color: rgba(212, 221, 228, 0.14902); font-size: 14.4444446563721px; line-height: 23.3333339691162px;">Un gestionnaire d'évènement à appeler</span> quand un message émis par le serveur est reçu. Le gestionnaire reçoit un évènement <a href="/en/WebSockets/WebSockets_reference/MessageEvent" title="en/WebSockets/WebSockets reference/MessageEvent"><code>MessageEvent</code></a> nommé "message".</td>
-  </tr>
-  <tr>
-   <td><code>onopen</code></td>
-   <td>{{DOMXref("EventListener")}}</td>
-   <td><span style="background-color: rgba(212, 221, 228, 0.14902); font-size: 14.4444446563721px; line-height: 23.3333339691162px;">Un gestionnaire d'évènement à appeler</span> quand la valeur de l'attribut <code>readyState</code> de la connexion WebSocket devient <code>OPEN</code>; cela indique que la connexion est prête à recevoir et émettre des données. L'évènement est un évènement de base nommé "open".</td>
-  </tr>
-  <tr>
-   <td><code>protocol</code></td>
-   <td>{{DOMXref("DOMString")}}</td>
-   <td>Une chaîne de caractères indiquant le nom du sous-protocole que le serveur a choisi; ce sera l'une des chaînes spécifiées dans le paramètre <code>protocols</code> lors de la création de l'objet WebSocket.</td>
-  </tr>
-  <tr>
-   <td><code>readyState</code></td>
-   <td><code><a href="/en/unsigned_short" title="en/unsigned short">unsigned short</a></code></td>
-   <td>Le statut (actuel) de la connexion; c'est une  valeur de {{ anch("Constantes de statut") }}. <strong>Lecture Seule.</strong></td>
-  </tr>
-  <tr>
-   <td><code>url</code></td>
-   <td>{{DOMXref("DOMString")}}</td>
-   <td>L'URL telle que déterminée par le constructeur. C'est toujours une URL absolue. <strong>Lecture Seule.</strong></td>
-  </tr>
- </tbody>
-</table>
-
-<h2 id="Constants" name="Constants">Constantes</h2>
-
-<h3 id="Constantes_de_statut">Constantes de statut</h3>
-
-<p>Ces constantes sont utilisées par l'attribut <code>readyState</code> pour décrire le statut de la connexion WebSocket.</p>
-
-<table class="standard-table">
- <tbody>
-  <tr>
-   <td class="header">Constant</td>
-   <td class="header">Value</td>
-   <td class="header">Description</td>
-  </tr>
-  <tr>
-   <td><code>CONNECTING</code></td>
+   <td><code>WebSocket.CONNECTING</code></td>
    <td><code>0</code></td>
-   <td>La connexion n'est pas encore établie.</td>
   </tr>
   <tr>
-   <td><code>OPEN</code></td>
+   <td><code>WebSocket.OPEN</code></td>
    <td><code>1</code></td>
-   <td>La connexion est établie et prête pour la communication.</td>
   </tr>
   <tr>
-   <td><code>CLOSING</code></td>
+   <td><code>WebSocket.CLOSING</code></td>
    <td><code>2</code></td>
-   <td>La connexion est en train de se fermer.</td>
   </tr>
   <tr>
-   <td><code>CLOSED</code></td>
+   <td><code>WebSocket.CLOSED</code></td>
    <td><code>3</code></td>
-   <td>La connexion est fermée ou n'a pas pu être établie.</td>
   </tr>
  </tbody>
 </table>
 
-<h2 id="Methods" name="Methods">Méthodes</h2>
-
-<h3 id="close()" name="close()">close()</h3>
-
-<p>Ferme la connexion Websocket ou abandonne la tentative de connexion. Si la connexion est déjà fermée (statut <code>CLOSED)</code>, cette méthode est sans effet.</p>
-
-<pre class="eval">void close(
-  in optional unsigned short code,
-  in optional DOMString reason
-);
-</pre>
-
-<h6 id="Parameters" name="Parameters">Paramètres</h6>
+<h2 id="properties">Propriétés</h2>
 
 <dl>
- <dt><code>code</code> {{ optional_inline() }}</dt>
- <dd>Une valeur numérique indiquant le code du statut décrivant pourquoi la connexion est fermée. Si ce paramètre n'est pas spécifié, une valeur par défaut de 1000 est utilisée (indiquant une fermeture standard de "transaction terminée"). Voir la <a href="/en/WebSockets/WebSockets_reference/CloseEvent#Status_codes" title="en/WebSockets/WebSockets reference/CloseEvent#Status codes">liste des codes de statut</a> sur la page de l'évènement <a href="/en/WebSockets/WebSockets_reference/CloseEvent" title="en/WebSockets/WebSockets reference/CloseEvent"><code>CloseEvent</code></a> pour les valeurs autorisées.</dd>
- <dt><code>reason</code> {{ optional_inline() }}</dt>
- <dd>Une chaîne de caractère <em>humainement-compréhensible</em> expliquant pourquoi la connexion est fermée. Cette chaîne ne doit pas excéder 123 octets <span style="font-size: 14.4444446563721px; line-height: 23.3333339691162px;">(et non </span><strong style="font-size: 14.4444446563721px; line-height: 23.3333339691162px;">pas</strong><span style="font-size: 14.4444446563721px; line-height: 23.3333339691162px;"> caractères) </span>de texte UTF-8.</dd>
+ <dt><a href="/fr/docs/Web/API/WebSocket/binaryType"><code>WebSocket.binaryType</code></a></dt>
+ <dd>Le type de données binaire utilisé par la connexion.</dd>
+ <dt><a href="/fr/docs/Web/API/WebSocket/bufferedAmount"><code>WebSocket.bufferedAmount</code></a> {{readonlyinline}}</dt>
+ <dd>Le nombre d'octets de données dans la queue.</dd>
+ <dt><a href="/fr/docs/Web/API/WebSocket/extensions"><code>WebSocket.extensions</code></a> {{readonlyinline}}</dt>
+ <dd>Les extensions sélectionnées par le serveur.</dd>
+ <dt><a href="/fr/docs/Web/API/WebSocket/onclose"><code>WebSocket.onclose</code></a></dt>
+ <dd>Un gestionnaire d'évènement à appeler lorsque la connexion est fermée.</dd>
+ <dt><a href="/fr/docs/Web/API/WebSocket/onerror"><code>WebSocket.onerror</code></a></dt>
+ <dd>Un gestionnaire d'évènement à appeler en cas d'erreur.</dd>
+ <dt><a href="/fr/docs/Web/API/WebSocket/onmessage"><code>WebSocket.onmessage</code></a></dt>
+ <dd>Un gestionnaire d'évènement à appeler lors de la réception d'un message du serveur.</dd>
+ <dt><a href="/fr/docs/Web/API/WebSocket/onopen"><code>WebSocket.onopen</code></a></dt>
+ <dd>Un gestionnaire d'évènement à appeler lorsque la connexion est ouverte.</dd>
+ <dt><a href="/fr/docs/Web/API/WebSocket/protocol"><code>WebSocket.protocol</code></a> {{readonlyinline}}</dt>
+ <dd>Le sous-protocole sélectionné par le serveur.</dd>
+ <dt><a href="/fr/docs/Web/API/WebSocket/readyState"><code>WebSocket.readyState</code></a> {{readonlyinline}}</dt>
+ <dd>L'état courant de la connexion.</dd>
+ <dt><a href="/fr/docs/Web/API/WebSocket/url"><code>WebSocket.url</code></a> {{readonlyinline}}</dt>
+ <dd>L'URL absolue de la WebSocket.</dd>
 </dl>
 
-<h6 id="Exceptions_lancées">Exceptions lancées</h6>
+<h2 id="methods">Méthodes</h2>
 
 <dl>
- <dt><code>INVALID_ACCESS_ERR</code></dt>
- <dd>Un code invalide a été spécifié.</dd>
- <dt><code>SYNTAX_ERR</code></dt>
- <dd>La chaîne de caractères (paramètre <strong>reason</strong>) est trop longue ou contient des données invalides.</dd>
+ <dt><a href="/fr/docs/Web/API/WebSocket/close"><code>WebSocket.close([code[, reason]])</code></a></dt>
+ <dd>Ferme la connexion.</dd>
+ <dt><a href="/fr/docs/Web/API/WebSocket/send"><code>WebSocket.send(data)</code></a></dt>
+ <dd>Ajoute des données à transmettre à la queue.</dd>
 </dl>
 
-<h6 id="Notes">Notes</h6>
+<h2 id="events">Évènements</h2>
 
-<p>Concernant Gecko: Cette méthode ne supporte aucun paramètre avant Gecko 8.0 {{ geckoRelease("8.0") }}.</p>
-
-<h3 id="send()" name="send()">send()</h3>
-
-<p>Émet des données vers le serveur via la connexion WebSocket.</p>
-
-<pre class="eval">void send(
-  in DOMString data
-);
-
-void send(
-  in ArrayBuffer data
-);
-
-void send(
-  in Blob data
-);
-</pre>
-
-<h6 id="Parameters" name="Parameters">Paramètres</h6>
+<p>Vous pouvez écouter ces évènements en utilisant la méthode <code>addEventListener()</code> ou en affectant un gestionnaire d'évènement à la propriété <code>on<em>nomevenement</em></code> de cette interface.</p>
 
 <dl>
- <dt><code>data</code></dt>
- <dd>Une chaîne de caractères à envoyer au serveur.</dd>
+ <dt><a href="/fr/docs/Web/API/WebSocket/close_event"><code>close</code></a></dt>
+ <dd>Déclenché lorsqu'une connexion avec une <code>WebSocket</code> est fermée. Également disponible avec la propriété <a href="/fr/docs/Web/API/WebSocket/onclose"><code>onclose</code></a>.</dd>
+ <dt><a href="/fr/docs/Web/API/WebSocket/error_event"><code>error</code></a></dt>
+ <dd>Déclenché lorsqu'une connexion avec une <code>WebSocket</code> a été fermée à cause d'une erreur, par exemple lorsque des données n'ont pu être envoyées. Également disponible avec la propriété <a href="/fr/docs/Web/API/WebSocket/onerror"><code>onerror</code></a>.</dd>
+ <dt><a href="/fr/docs/Web/API/WebSocket/message_event"><code>message</code></a></dt>
+ <dd>Déclenché lorsque des données sont reçues via une <code>WebSocket</code>. Également disponible avec la propriété <a href="/fr/docs/Web/API/WebSocket/onmessage"><code>onmessage</code></a>.</dd>
+ <dt><a href="/fr/docs/Web/API/WebSocket/open_event"><code>open</code></a></dt>
+ <dd>Déclenché lorsqu'une connexion avec une <code>WebSocket</code> est ouverte. Également disponible avec la propriété <a href="/fr/docs/Web/API/WebSocket/onopen"><code>onopen</code></a>.</dd>
 </dl>
 
-<h6 id="Exceptions_lancées_2">Exceptions lancées</h6>
+<h2 id="examples">Exemples</h2>
 
-<dl>
- <dt><code>INVALID_STATE_ERR</code></dt>
- <dd>La connexion n'est pas actuellent ouverte (valeur de l'attribut <em>readyState</em> <code>OPEN)</code>.</dd>
- <dt><code>SYNTAX_ERR</code></dt>
- <dd>La chaîne de caractères contient des données invalides.</dd>
-</dl>
+<pre class="brush: js">// Créer une connexion WebSocket
+const socket = new WebSocket('ws://localhost:8080');
 
-<h6 id="Remarques">Remarques</h6>
+// La connexion est ouverte
+socket.addEventListener('open', function (event) {
+ socket.send('Coucou le serveur !');
+});
 
-<div class="note">
-<p><strong>Note:</strong> L'implémentation de la méthode <code>send()</code> dans Gecko diffère quelques peu des spécifications dans {{Gecko("6.0")}}; Gecko retourne une valeur booléenne (<code>boolean)</code> indiquant si la connexion est toujours ouverte (et, par extension, que les données ont bien été mise en fil d'émission ou émises); cette différence est corrigée dans {{Gecko("8.0")}}.</p>
+// Écouter les messages
+socket.addEventListener('message', function (event) {
+  console.log('Voici un message du serveur', event.data);
+});</pre>
 
-<p>Sur {{Gecko("11.0")}}, le support d'<code><a href="/en/JavaScript_typed_arrays/ArrayBuffer" title="en/JavaScript typed arrays/ArrayBuffer">ArrayBuffer</a></code> est implémenté, mais pas le type de données {{ domxref("Blob") }}.</p>
-</div>
+<h2 id="specifications">Spécifications</h2>
 
-<h2 id="See_also" name="See_also">Exemple</h2>
+<p>{{Specifications}}</p>
 
-<pre class="brush: js">var socket = null;
-try {
-    // Connexion vers un serveur HTTP
-    // prennant en charge le protocole WebSocket ("ws://").
-    socket = new WebSocket("ws://localhost");
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
 
-    // ----- OU -----
+<p>{{Compat}}</p>
 
-    // Connexion vers un serveur HTTPS
-    // prennant en charge le protocole WebSocket over SSL ("wss://").
-    socket = new WebSocket("wss://localhost");
-} catch (exception) {
-    console.error(exception);
-}
-
-// Récupération des erreurs.
-// Si la connexion ne s'établie pas,
-// l'erreur sera émise ici.
-socket.onerror = function(error) {
-    console.error(error);
-};
-
-// Lorsque la connexion est établie.
-socket.onopen = function(event) {
-    console.log("Connexion établie.");
-
-    // Lorsque la connexion se termine.
-    this.onclose = function(event) {
-        console.log("Connexion terminé.");
-    };
-
-    // Lorsque le serveur envoi un message.
-    this.onmessage = function(event) {
-        console.log("Message:", event.data);
-    };
-
-    // Envoi d'un message vers le serveur.
-    this.send("Hello world!");
-};
-</pre>
-
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th>Specification</th>
-   <th>Status</th>
-   <th>Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Websockets", "#the-websocket-interface", "WebSocket")}}</td>
-   <td>{{Spec2("Websockets")}}</td>
-   <td>Definition initiale</td>
-  </tr>
- </tbody>
-</table>
-
-<h2 id="Browser_compatibility">Compatibilité des navigateurs</h2>
-
-<p>{{Compat("api.WebSocket")}}</p>
-
-<h2 id="See_also">Voir aussi</h2>
+<h2 id="see_also">Voir aussi</h2>
 
 <ul>
-  <li><a href="/fr/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications">Écrire des applications client WebSocket</a></li>
+ <li><a href="/fr/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications">Écrire des applications clientes WebSocket</a></li>
 </ul>

--- a/files/fr/web/api/websocket/message_event/index.html
+++ b/files/fr/web/api/websocket/message_event/index.html
@@ -1,0 +1,57 @@
+---
+title: 'WebSocket : évènement message'
+slug: Web/API/WebSocket/message_event
+browser-compat: api.WebSocket.message_event
+---
+<div>{{APIRef}}</div>
+
+<p>L'évènement <code>message</code> est déclenché lorsque des données sont reçues via une <code>WebSocket</code>.</p>
+
+<table class="properties">
+ <tbody>
+  <tr>
+   <th scope="row">Bouillonne/Remonte</th>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Annulable</th>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Interface</th>
+   <td><a href="/fr/docs/Web/API/MessageEvent"><code>MessageEvent</code></a></td>
+  </tr>
+  <tr>
+    <th scope="row">Propriété de gestionnaire d'évènement correspondante</th>
+    <td><a href="/fr/docs/Web/API/WebSocket/onmessage"><code>onmessage</code></a></td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="examples">Exemples</h2>
+
+<pre class="brush: js">
+// Crée une connexion WebSocket
+const socket = new WebSocket('ws://localhost:8080');
+
+// Écoute les différents messages
+socket.addEventListener('message', function (event) {
+    console.log('Message reçu du serveur ', event.data);
+});</pre>
+
+<h2 id="specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="see_also">Voir aussi</h2>
+
+<ul>
+  <li><a href="/fr/docs/Web/API/WebSocket/close_event">WebSocket : évènement <code>close</code></a></li>
+  <li><a href="/fr/docs/Web/API/WebSocket/error_event">WebSocket : évènement <code>error</code></a></li>
+  <li><a href="/fr/docs/Web/API/WebSocket/open_event">WebSocket : évènement <code>open</code></a></li>
+  <li><a href="/fr/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications">Écrire des applications clientes WebSocket</a></li>
+ </ul>

--- a/files/fr/web/api/websocket/onclose/index.html
+++ b/files/fr/web/api/websocket/onclose/index.html
@@ -1,0 +1,27 @@
+---
+title: WebSocket.onclose
+slug: Web/API/WebSocket/onclose
+browser-compat: api.WebSocket.onclose
+---
+<p>{{APIRef("Web Sockets API")}}</p>
+
+<p>La propriété <code><strong>WebSocket.onclose</strong></code> est un <a href="/fr/docs/Web/Events/Event_handlers">gestionnaire d'évènement</a> invoqué lorsque l'état <a href="/fr/docs/Web/API/WebSocket/readyState"><code>readyState</code></a> de la connexion WebSocket change de valeur pour passer à <a href="/fr/docs/Web/API/WebSocket/readyState"><code>CLOSED</code></a>. Ce gestionnaire est appelé avec un paramètre <a href="/fr/docs/Web/API/CloseEvent"><code>CloseEvent</code></a>.</p>
+
+<h2 id="syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+unWebSocket.onclose = function(event) {
+  console.log("La WebSocket est désormais fermée.");
+};</pre>
+
+<h2 id="value">Valeur</h2>
+
+<p>Une fonction <a href="/fr/docs/Web/API/EventListener"><code>EventListener</code></a>.</p>
+
+<h2 id="specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>

--- a/files/fr/web/api/websocket/onerror/index.html
+++ b/files/fr/web/api/websocket/onerror/index.html
@@ -1,0 +1,35 @@
+---
+title: WebSocket.onerror
+slug: Web/API/WebSocket/onerror
+browser-compat: api.WebSocket.onerror
+---
+<div>{{APIRef("Web Sockets API")}}</div>
+
+<p>La propriété <code><strong>onerror</strong></code> de l'interface <a href="/fr/docs/Web/API/WebSocket"><code>WebSocket</code></a> est un gestionnaire d'évènement qui est appelé lorsqu'une erreur se produit sur la connexion WebSocket.</p>
+
+<p>Il est également possible d'ajouter un gestionnaire d'évènement <code>error</code> avec la méthode <a href="/fr/docs/Web/API/EventTarget/addEventListener"><code>addEventListener()</code></a>.</p>
+
+<h2 id="syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+webSocket.onerror = eventHandler;
+</pre>
+
+<h3 id="value">Valeur</h3>
+
+<p>Une fonction ou un <a href="/fr/docs/Web/Events/Event_handlers">gestionnaire d'évènement</a> qui est exécuté lorsqu'un évènement <code>error</code> se produit sur la connexion WebSocket.</p>
+
+<h2 id="example">Exemple</h2>
+
+<pre class="brush: js">
+webSocket.onerror = function(event) {
+  console.error("Erreur WebSocket observée :", event);
+};</pre>
+
+<h2 id="specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>

--- a/files/fr/web/api/websocket/onmessage/index.html
+++ b/files/fr/web/api/websocket/onmessage/index.html
@@ -1,0 +1,27 @@
+---
+title: WebSocket.onmessage
+slug: Web/API/WebSocket/onmessage
+browser-compat: api.WebSocket.onmessage
+---
+<div>{{APIRef("Web Sockets API")}}</div>
+
+<p>La propriété <strong><code>WebSocket.onmessage</code></strong> est un <a href="/fr/docs/Web/Events/Event_handlers">gestionnaire d'évènement</a> qui est appelé lorsqu'un message est reçu depuis le serveur. Ce gestionnaire est appelé avec un évènement <a href="/fr/docs/Web/API/MessageEvent"><code>MessageEvent</code></a> en paramètre.</p>
+
+<h2 id="syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+unWebSocket.onmessage = function(event) {
+  console.debug("Message WebSocket reçu :", event);
+};</pre>
+
+<h2 id="value">Valeur</h2>
+
+<p>Un objet <a href="/fr/docs/Web/API/EventListener"><code>EventListener</code></a>.</p>
+
+<h2 id="specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>

--- a/files/fr/web/api/websocket/onopen/index.html
+++ b/files/fr/web/api/websocket/onopen/index.html
@@ -1,0 +1,27 @@
+---
+title: WebSocket.onopen
+slug: Web/API/WebSocket/onopen
+browser-compat: api.WebSocket.onopen
+---
+<div>{{APIRef("Web Sockets API")}}</div>
+
+<p>La propriété <strong><code>WebSocket.onopen</code></strong> est un <a href="/fr/docs/Web/Events/Event_handlers">gestionnaire d'évènement</a> qui est appelé lorsque l'état (<a href="/fr/docs/Web/API/WebSocket/readyState"><code>readyState</code></a>) de la connexion <a href="/fr/docs/Web/API/WebSocket"><code>WebSocket</code></a> passe à <code>1</code>, indiquant que la connexion est prête pour l'envoi et la réception de données. Lorsqu'il est appelé, ce gestionnaire d'évènement reçoit un objet <a href="/fr/docs/Web/API/Event"><code>Event</code></a> en paramètre.</p>
+
+<h2 id="syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+uneWebSocket.onopen = function(event) {
+  console.log("La WebSocket est désormais ouverte.");
+};</pre>
+
+<h2 id="value">Valeur</h2>
+
+<p>Un objet <a href="/fr/docs/Web/API/EventListener"><code>EventListener</code></a>.</p>
+
+<h2 id="specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>

--- a/files/fr/web/api/websocket/open_event/index.html
+++ b/files/fr/web/api/websocket/open_event/index.html
@@ -1,0 +1,57 @@
+---
+title: 'WebSocket : évènement open'
+slug: Web/API/WebSocket/open_event
+browser-compat: api.WebSocket.open_event
+---
+<div>{{APIRef}}</div>
+
+<p>L'évènement <code>open</code> est déclenché lorsqu'une connexion avec une <code>WebSocket</code> est ouverte.</p>
+
+<table class="properties">
+ <tbody>
+  <tr>
+   <th scope="row">Bouillonne/Remonte</th>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Annulable</th>
+   <td>Non</td>
+  </tr>
+  <tr>
+   <th scope="row">Interface</th>
+   <td><a href="/fr/docs/Web/API/Event"><code>Event</code></a></td>
+  </tr>
+  <tr>
+   <th scope="row">Propriété de gestionnaire d'évènement correspondante</th>
+   <td><a href="/fr/docs/Web/API/WebSocket/onopen"><code>onopen</code></a></td>
+  </tr>
+ </tbody>
+</table>
+
+<h2 id="examples">Exemples</h2>
+
+<pre class="brush: js">
+// Crée une connexion WebSocket
+const socket = new WebSocket('ws://localhost:8080');
+
+// La connexion est ouverte
+socket.addEventListener('open', (event) =&gt; {
+  socket.send('Coucou serveur !');
+});</pre>
+
+<h2 id="specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>
+
+<h2 id="see_also">Voir aussi</h2>
+
+<ul>
+  <li><a href="/fr/docs/Web/API/WebSocket/close_event">WebSocket : évènement <code>close</code></a></li>
+  <li><a href="/fr/docs/Web/API/WebSocket/error_event">WebSocket : évènement <code>error</code></a></li>
+  <li><a href="/fr/docs/Web/API/WebSocket/message_event">WebSocket : évènement <code>message</code></a></li>
+  <li><a href="/fr/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications">Écrire des applications clientes WebSocket</a></li>
+ </ul>

--- a/files/fr/web/api/websocket/protocol/index.html
+++ b/files/fr/web/api/websocket/protocol/index.html
@@ -1,0 +1,26 @@
+---
+title: WebSocket.protocol
+slug: Web/API/WebSocket/protocol
+browser-compat: api.WebSocket.protocol
+---
+<p>{{APIRef("Web Sockets API")}}</p>
+
+<p>La propriété en lecture seule <strong><code>WebSocket.protocol</code></strong> renvoie le nom du sous protocole sélectionné par le serveur. Cette valeur sera l'une des chaînes de caractères du paramètre <code>protocols</code> utilisé lors de la création de l'objet <a href="/fr/docs/Web/API/WebSocket"><code>WebSocket</code></a> ou la chaîne vide si aucune connexion n'est établie.</p>
+
+<h2 id="syntax">Syntax</h2>
+
+<pre class="brush: js">
+var protocol = uneWebSocket.protocol;
+</pre>
+
+<h2 id="value">Valeur</h2>
+
+<p>Une chaîne de caractères <a href="/fr/docs/Web/API/DOMString"><code>DOMString</code></a>.</p>
+
+<h2 id="specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>

--- a/files/fr/web/api/websocket/readystate/index.html
+++ b/files/fr/web/api/websocket/readystate/index.html
@@ -1,0 +1,56 @@
+---
+title: WebSocket.readyState
+slug: Web/API/WebSocket/readyState
+browser-compat: api.WebSocket.readyState
+---
+<p>{{APIRef("Web Sockets API")}}</p>
+
+<p>La propriété en lecture seule <strong><code>WebSocket.readyState</code></strong> renvoie l'état courant de la connexion <a href="/fr/docs/Web/API/WebSocket"><code>WebSocket</code></a>.</p>
+
+<h2 id="syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+var readyState = uneWebSocket.readyState;
+</pre>
+
+<h2 id="value">Valeur</h2>
+
+<p>Cette propriété peut valoir l'une des valeurs de type <code>unsigned short</code> suivantes :</p>
+
+<table class="standard-table">
+  <tbody>
+    <tr>
+      <td class="header">Valeur</td>
+      <td class="header">État</td>
+      <td class="header">Description</td>
+    </tr>
+    <tr>
+      <td><code>0</code></td>
+      <td><code>CONNECTING</code></td>
+      <td>La socket a été créée. La connexion n'est pas encore ouverte.</td>
+    </tr>
+    <tr>
+      <td><code>1</code></td>
+      <td><code>OPEN</code></td>
+      <td>La connexion est ouverte et prête pour la communication.</td>
+    </tr>
+    <tr>
+      <td><code>2</code></td>
+      <td><code>CLOSING</code></td>
+      <td>La connexion est en cours de fermeture.</td>
+    </tr>
+    <tr>
+      <td><code>3</code></td>
+      <td><code>CLOSED</code></td>
+      <td>La connexion est fermée ou n'a pas pu être ouverte.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>

--- a/files/fr/web/api/websocket/send/index.html
+++ b/files/fr/web/api/websocket/send/index.html
@@ -1,0 +1,55 @@
+---
+title: WebSocket.send()
+slug: Web/API/WebSocket/send
+browser-compat: api.WebSocket.send
+---
+<p>{{APIRef("Web Sockets API")}}</p>
+
+<p>La méthode <strong><code>WebSocket.send()</code></strong> rajoute les données indiquées à la queue pour transmission au serveur via la connexion WebSocket, augmentant ainsi la valeur de <code>bufferedAmount</code> du nombre d'octets nécessaires pour les données. Si les données ne peuvent être envoyées (par exemple parce qu'elles doivent être mises en tampon mais que la mémoire tampon est pleine), la socket est fermée automatiquement.</p>
+
+<h2 id="syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+WebSocket.send("Coucou serveur !");
+</pre>
+
+<h3 id="parameters">Paramètres</h3>
+
+<dl>
+  <dt><code>data</code></dt>
+  <dd>Les données à envoyer au serveur. La valeur peut avoir un des types suivants :
+    <dl>
+      <dt><a href="/fr/docs/Web/API/USVString"><code>USVString</code></a></dt>
+      <dd>Une chaîne de caractères. Cette chaîne est ajoutée au tampon au format UTF-8 et la valeur de <code>bufferedAmount</code> est augmentée du nombre d'octets nécessaires pour représenter cette chaîne de caractères UTF-8.</dd>
+      <dt><a href="/fr/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer"><code>ArrayBuffer</code></a></dt>
+      <dd>Les données binaires peuvent aussi être envoyées avec un tableau typé. Son contenu binaire est mis en tampon et la valeur de <code>bufferedAmount</code> est augmentée du nombre d'octets nécessaires.</dd>
+      <dt><a href="/fr/docs/Web/API/Blob"><code>Blob</code></a></dt>
+      <dd>Lorsqu'une valeur <code>Blob</code> est fournie, les données brutes du blob sont rajoutées à la queue pour être transmises dans une <i lang="en">frame</i> binaire. La valeur de <code>bufferedAmount</code> est augmentée du nombre d'octets utilisés pour représenter ces données brutes.</dd>
+      <dt><a href="/fr/docs/Web/API/ArrayBufferView"><code>ArrayBufferView</code></a></dt>
+      <dd>Il est possible d'envoyer n'importe quel objet étant <a href="/fr/docs/Web/JavaScript/Typed_arrays">un tableau typé JavaScript</a> sous la forme d'une <i lang="en">frame</i> binaire. Le contenu des données binaires est rajouté à la queue dans le tampon et la valeur de <code>bufferedAmount</code> est augmentée du nombre d'octets correspondant.</dd>
+    </dl>
+  </dd>
+</dl>
+
+<h3 id="exceptions_thrown">Exceptions levées</h3>
+
+<dl>
+  <dt><code>INVALID_STATE_ERR</code></dt>
+  <dd>La connexion n'est pas ouverte actuellement.</dd>
+  <dt><code>SYNTAX_ERR</code></dt>
+  <dd>Les données sont une chaîne de caractères pour laquelle il existe des <i lang="en">surrogates</i> non appairés.</dd>
+</dl>
+
+<div class="note">
+  <p><strong>Note :</strong> Pour Gecko 6.0, l'implémentation de <code>send()</code> varie de la spécification : le moteur renvoie un booléen indiquant si la connexion est toujours ouverte (par extension, cela indique si les données ont été correctement rajoutées à la queue ou transmises). Ce comportement a été corrigé avec Gecko 8.0.</p>
+
+  <p>Avec Gecko 11.0, la prise en charge des <a href="/fr/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer"><code>ArrayBuffer</code></a> est implémentée mais pas celle pour les objets <a href="/fr/docs/Web/API/Blob"><code>Blob</code></a>.</p>
+</div>
+
+<h2 id="specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>

--- a/files/fr/web/api/websocket/url/index.html
+++ b/files/fr/web/api/websocket/url/index.html
@@ -1,0 +1,26 @@
+---
+title: WebSocket.url
+slug: Web/API/WebSocket/url
+browser-compat: api.WebSocket.url
+---
+<p>{{APIRef("Web Sockets API")}}</p>
+
+<p>La propriété en lecture seule <strong><code>WebSocket.url</code></strong> renvoie l'URL absolue de la <a href="/fr/docs/Web/API/WebSocket"><code>WebSocket</code></a> telle que résolue par le constructeur.</p>
+
+<h2 id="syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+var url = aWebSocket.url;
+</pre>
+
+<h2 id="value">Valeur</h2>
+
+<p>Une chaîne de caractères <a href="/fr/docs/Web/API/DOMString"><code>DOMString</code></a>.</p>
+
+<h2 id="specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>

--- a/files/fr/web/api/websocket/websocket/index.html
+++ b/files/fr/web/api/websocket/websocket/index.html
@@ -1,0 +1,42 @@
+---
+title: WebSocket()
+slug: Web/API/WebSocket/WebSocket
+browser-compat: api.WebSocket.WebSocket
+---
+<p>{{APIRef("Web Sockets API")}}</p>
+
+<p>Le constructeur <code><strong>WebSocket()</strong></code> renvoie un nouvel objet <a href="/fr/docs/Web/API/WebSocket"><code>WebSocket</code></a>.</p>
+
+<h2 id="syntax">Syntaxe</h2>
+
+<pre class="brush: js">
+var <em>aWebSocket</em> = new WebSocket(<em>url</em> [, protocols]);
+</pre>
+
+<h3 id="parameters">Paramètres</h3>
+
+<dl>
+  <dt><code>url</code></dt>
+  <dd>L'URL à laquelle se connecter. Cela devrait être l'URL à laquelle le serveur WebSocket répondra.</dd>
+  <dt><code>protocols</code> {{optional_inline}}</dt>
+  <dd>Une valeur qui est une chaîne de caractères représentant un seul protocole ou un tableau de chaînes de caractères représentant une liste de protocoles. Ces chaînes de caractères indiquent des sous-protocoles : un serveur donné pourra implémenter différents sous-protocoles WebSocket (on peut vouloir qu'un serveur soit capable de gérér différents types d'interaction selon le <code>protocol</code> indiqué).
+  </dd>
+  <dd>Si cette valeur est absence, c'est un tableau vide qui est utilisé par défaut : <code>[]</code>.</dd>
+</dl>
+
+<h3 id="exceptions_thrown">Exceptions levées</h3>
+
+<dl>
+  <dt><code>SECURITY_ERR</code></dt>
+  <dd>Le port ciblé par la tentative de connexion est bloqué.</dd>
+  <dt><a href="/fr/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError">SyntaxError</a></dt>
+  <dd>L'URL est invalide.</dd>
+</dl>
+
+<h2 id="specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="browser_compatibility">Compatibilité des navigateurs</h2>
+
+<p>{{Compat}}</p>


### PR DESCRIPTION
#2139 mentioned a source page which was obsolete (vs en-US) and a target page which was not translated. I've translated the whole interface and revamped the two existing pages to take care of this issue.