### PR TITLE
Fixed parameters of console.time and console.timeEnd

### DIFF
--- a/files/pt-br/web/api/console/index.html
+++ b/files/pt-br/web/api/console/index.html
@@ -52,9 +52,9 @@ translation_of: Web/API/Console
 <p> </p>
 
 <dl>
- <dt>{{domxref("console.time()", "console.time(name)")}}</dt>
- <dd>Inicia um contador de tempo com o nome especificado no parâmetro <em>name</em>. Até 10.000 contadores de tempo podem ser rodados por página.</dd>
- <dt>{{domxref("console.timeEnd()", "console.timeEnd(name)")}}</dt>
+ <dt>{{domxref("console.time()", "console.time(label)")}}</dt>
+ <dd>Inicia um contador de tempo com o nome especificado no parâmetro <em>label</em>. Até 10.000 contadores de tempo podem ser rodados por página.</dd>
+ <dt>{{domxref("console.timeEnd()", "console.timeEnd(label)")}}</dt>
  <dd>Interrompe o contador de tempo especificado e emite o tempo e registros do contador de tempo em milisegundos desde o seu início. Veja {{anch("Contadores de Tempo")}}.</dd>
  <dt>{{domxref("console.trace()")}}</dt>
  <dd>Emite um traçado de pilha. See {{anch("Traçados de pilha")}}.</dd>

--- a/files/pt-br/web/api/console/time/index.html
+++ b/files/pt-br/web/api/console/time/index.html
@@ -15,13 +15,13 @@ translation_of: Web/API/Console/time
 
 <h2 id="Syntax" name="Syntax">Sintaxe</h2>
 
-<pre class="syntaxbox">console.time(<em>cronometroNome</em>);
+<pre class="syntaxbox">console.time(<em>label</em>);
 </pre>
 
 <h2 id="Parâmetros">Parâmetros</h2>
 
 <dl>
- <dt><code>cronometroNome</code></dt>
+ <dt><code>label</code></dt>
  <dd>O nome para dar ao novo cronômetro. Ele identificará o cronômetro; use o mesmo quando chamar {{ domxref("console.timeEnd()") }} para parar o cronômetro e obter o tempo na saída do console.</dd>
 </dl>
 

--- a/files/pt-br/web/api/console/timeend/index.html
+++ b/files/pt-br/web/api/console/timeend/index.html
@@ -18,13 +18,13 @@ translation_of: Web/API/Console/timeEnd
 
 <h2 id="Syntax" name="Syntax">Sintaxe</h2>
 
-<pre class="syntaxbox">console.timeEnd(<var>timerName</var>);
+<pre class="syntaxbox">console.timeEnd(<var>label</var>);
 </pre>
 
 <h3 id="Parametros">Parametros</h3>
 
 <dl>
- <dt><code>timerName</code></dt>
+ <dt><code>label</code></dt>
  <dd>O nome do temporizador a ser interrompido. Uma vez interrompido, o tempo decorrido é automaticamente apresentado no <a href="/en-US/docs/Tools/Web_Console" title="Web Console">Web Console</a>.</dd>
 </dl>
 


### PR DESCRIPTION
The correct parameter of `console.time()` and `console.timeEnd()` is `label`.

I fixed it in this PR.