### PR TITLE
Il n'y a pas d'opérateur d'identité en ECMAScript

### DIFF
--- a/files/fr/web/javascript/reference/operators/index.md
+++ b/files/fr/web/javascript/reference/operators/index.md
@@ -143,7 +143,7 @@ Le résultat de l'évaluation fournie par un opérateur d'égalité est toujours
 - [`!=`](/fr/docs/Web/JavaScript/Reference/Operators/Inequality)
   - : L'opérateur d'inégalité.
 - [`===`](/fr/docs/Web/JavaScript/Reference/Operators/Strict_equality)
-  - : L'opérateur d'identité.
+  - : L'opérateur d'égalité stricte.
 - [`!==`](/fr/docs/Web/JavaScript/Reference/Operators/Strict_inequality)
   - : L'opérateur d'inégalité stricte.
 


### PR DESCRIPTION
Pour éviter les confusions pour les développeurs venant d'autres langages où il pourrait exister un opérateur d'identité.

(L'opérateur d'inégalité stricte a d'ailleurs déjà été corrigé)