### PR TITLE
A function has no argument limits.

### DIFF
--- a/files/pt-br/web/javascript/reference/functions/index.html
+++ b/files/pt-br/web/javascript/reference/functions/index.html
@@ -77,7 +77,7 @@ function minhaFuncao(objeto) {
 
 <dl>
  <dt><code>param</code></dt>
- <dd>O nome de um argumento a ser passado para a função. Uma função pode ter até 255 argumentos.</dd>
+ <dd>O nome de um argumento a ser passado para a função.</dd>
 </dl>
 
 <dl>
@@ -101,7 +101,7 @@ function minhaFuncao(objeto) {
 
 <dl>
  <dt><code>param</code></dt>
- <dd>O nome de um argumento a ser passado para a função. Uma função pode ter até 255 argumentos.</dd>
+ <dd>O nome de um argumento a ser passado para a função.</dd>
 </dl>
 
 <dl>


### PR DESCRIPTION
In the English version it doesn't say anything about argument limits in a function, so it would be correct to remove that part.