### PR TITLE
Fix parenthesis typo in <code> block

### DIFF
--- a/files/pl/web/javascript/reference/global_objects/function/tostring/index.html
+++ b/files/pl/web/javascript/reference/global_objects/function/tostring/index.html
@@ -32,7 +32,7 @@ original_slug: Web/JavaScript/Referencje/Obiekty/Function/toString
 
 <p>JavaScript wywołuje metodę <code>toString()</code> automatycznie, gdy {{jsxref("Function")}} jest reprezentowana jako wartość tekstowa lub kiedy <code>Function</code> jest odsyłana do połączenia łańcuchów znaków.</p>
 
-<p>Dla obiektów {{jsxref("Function")}}, wbudowana metoda <code>toString)=</code> dekompiluje funkcję z powrotem do kodu JavaScript, który tę funkcję definiuje. Łańcuch znaków zawiera słowa kluczowe <code>function</code>, listę argumentów, nawiasy klamrowe oraz ciało funkcji.</p>
+<p>Dla obiektów {{jsxref("Function")}}, wbudowana metoda <code>toString()</code> dekompiluje funkcję z powrotem do kodu JavaScript, który tę funkcję definiuje. Łańcuch znaków zawiera słowa kluczowe <code>function</code>, listę argumentów, nawiasy klamrowe oraz ciało funkcji.</p>
 
 <p>Załóżmy na przykład, że masz poniższy kod, który definiuje obiektowy typ <code>Dog</code> i tworzy <code>theDog</code>, obiekt typu <code>Dog</code>:</p>
 


### PR DESCRIPTION
I've found this small typo while reading about Function.prototype.toString() in Polish.
Not a big issue, although it's worth fixing while I'm at it :)