### PR TITLE
Fix content property description

### DIFF
--- a/files/ru/web/html/element/template/index.html
+++ b/files/ru/web/html/element/template/index.html
@@ -47,7 +47,7 @@ translation_of: Web/HTML/Element/template
 <h2 id="Атрибуты">Атрибуты</h2>
 
 <p>Элемент может иметь <a href="/en-US/docs/Web/HTML/Global_attributes">общие атрибуты</a>.</p>
-  
+
 <p>Однако у <a href="/en-US/docs/Web/API/HTMLTemplateElement"><code>HTMLTemplateElement</code></a> есть свойство <code>content</code>, которое возвращает доступный только для чтения <a href="/ru/docs/Web/API/DocumentFragment"><code>DocumentFragment</code></a>, содержащий DOM-поддерево шаблона. Обратите внимание, что прямое испоользование значения <a href="/en-US/docs/Web/API/HTMLTemplateElement/content" title="content"><code>content</code></a> может привести к непредсказуемому поведению.</p>
 
 <h2 id="Примеры">Примеры</h2>

--- a/files/ru/web/html/element/template/index.html
+++ b/files/ru/web/html/element/template/index.html
@@ -47,8 +47,8 @@ translation_of: Web/HTML/Element/template
 <h2 id="Атрибуты">Атрибуты</h2>
 
 <p>Элемент может иметь <a href="/en-US/docs/Web/HTML/Global_attributes">общие атрибуты</a>.</p>
-
-<p>Также есть доступный только для чтения атрибут <code>content</code>, который предоставляет доступ к содержимому шаблона. Проверка на наличие этого атрибута является распространённым способом определить, поддерживает ли браузер элемент <code>&lt;template&gt;</code>.</p>
+  
+<p>Однако у <a href="/en-US/docs/Web/API/HTMLTemplateElement"><code>HTMLTemplateElement</code></a> есть свойство <code>content</code>, которое возвращает доступный только для чтения <a href="/ru/docs/Web/API/DocumentFragment"><code>DocumentFragment</code></a>, содержащий DOM-поддерево шаблона. Обратите внимание, что прямое испоользование значения <a href="/en-US/docs/Web/API/HTMLTemplateElement/content" title="content"><code>content</code></a> может привести к непредсказуемому поведению.</p>
 
 <h2 id="Примеры">Примеры</h2>
 


### PR DESCRIPTION
It’s called attribute which is not correct and may cause (well, already caused) problems. Since it’s located in the Attributes section, it sounds like it’s `<template content>`, but it’s `HTMLTemplateElement.content`.