### PR TITLE
update link attributes translate for zh-CN

### DIFF
--- a/files/zh-cn/web/html/element/link/index.html
+++ b/files/zh-cn/web/html/element/link/index.html
@@ -60,7 +60,7 @@ translation_of: Web/HTML/Element/link
 
 <dl>
  <dt>{{htmlattrdef("as")}}</dt>
- <dd>该属性仅在<code>&lt;link&gt;</code>元素设置了 <code>rel="preload"</code> 时才能使用。它规定了<code>&lt;link&gt;元素</code>加载的内容的类型，对于内容的优先级、请求匹配、正确的<a href="/zh-CN/docs/Web/HTTP/CSP">内容安全策略</a>的选择以及正确的 {{httpheader("Accept")}}请求头的设置，这个属性是必需的。</dd>
+ <dd>该属性仅在<code>&lt;link&gt;</code>元素设置了 <code>rel="preload"</code> 或者 <code>rel="prefetch"</code> 时才能使用。它规定了<code>&lt;link&gt;元素</code>加载的内容的类型，对于内容的优先级、请求匹配、正确的<a href="/zh-CN/docs/Web/HTTP/CSP">内容安全策略</a>的选择以及正确的 {{httpheader("Accept")}}请求头的设置，这个属性是必需的。</dd>
  <dt>
  <table>
   <thead>


### PR DESCRIPTION
Attributes as  is only used when rel="preload" or rel="prefetch" has been set on the <link> element.  But the translation missed 'prefetch' .