### PR TITLE
Tools以下の文書内のリンクURLを正規化

### DIFF
--- a/files/ja/tools/browser_console/index.html
+++ b/files/ja/tools/browser_console/index.html
@@ -54,7 +54,7 @@ translation_of: Tools/Browser_Console
 
 <ul>
  <li><a href="/ja/docs/Tools/Web_Console#HTTP_requests" title="Tools/Web_Console#HTTP_requests">HTTP 要求</a></li>
- <li><a href="/ja/docs/Tools/Web_Console#Warnings_and_errors" title="Tools/Web_Console#Warnings_and_errors">警告とエラー</a> (JavaScript、CSS、セキュリティの警告やエラー、および <a href="https://developer.mozilla.org/ja/docs/Web/API/console" title="Web/API/console">console</a> API を使用して JavaScript コードから明示的に記録されるメッセージを含みます)</li>
+ <li><a href="/ja/docs/Tools/Web_Console#Warnings_and_errors" title="Tools/Web_Console#Warnings_and_errors">警告とエラー</a> (JavaScript、CSS、セキュリティの警告やエラー、および <a href="/ja/docs/Web/API/console" title="Web/API/console">console</a> API を使用して JavaScript コードから明示的に記録されるメッセージを含みます)</li>
  <li><a href="/ja/docs/Tools/Web_Console#Input.2Foutput_messages" title="Tools/Web_Console#Input.2Foutput_messages">入力/出力メッセージ</a>: コマンドラインからブラウザーに送信したコマンドと、そのコマンドの実行結果</li>
 </ul>
 

--- a/files/ja/tools/deprecated_tools/index.html
+++ b/files/ja/tools/deprecated_tools/index.html
@@ -92,7 +92,7 @@ translation_of: Tools/Deprecated_tools
 
 <p>The Web Audio Editor allowed you to examine an audio context constructed in the page and provided a visualization of its graph. This gave a high-level view of its operation, and enabled you to ensure that all the nodes are connected in the way you expect. It was possible to edit the AudioParam properties for each node in the graph. Some non-AudioParam properties, like an OscillatorNode's type property, were displayed and editable as well. It was deprecated due to lack of use.</p>
 
-<p>More details about the <a href="/en-US/docs/Tools/Web_Audio_Editor">Web Audio Editor</a></p>
+<p>More details about the <a href="/ja/docs/Tools/Web_Audio_Editor">Web Audio Editor</a></p>
 
 <p><img alt="" src="https://mdn.mozillademos.org/files/16548/webAudio_tool.png" style="border: 1px solid black; display: block; margin: 0 auto; width: 800px;"></p>
 
@@ -110,7 +110,7 @@ translation_of: Tools/Deprecated_tools
 
 <p>The Shader Editor allowed users to examine and edit the source of the WebGL vertex and fragment shaders. It was deprecated due to low usage and maintenance costs.</p>
 
-<p>More details about the <a href="/en-US/docs/Tools/Shader_Editor">Shader Editor</a></p>
+<p>More details about the <a href="/ja/docs/Tools/Shader_Editor">Shader Editor</a></p>
 
 <p><img alt="" src="https://mdn.mozillademos.org/files/16547/shaderEditor_tool.png" style="border: 1px solid black; display: block; margin: 0 auto; width: 800px;"></p>
 

--- a/files/ja/tools/firefox_os_simulator_clone/index.html
+++ b/files/ja/tools/firefox_os_simulator_clone/index.html
@@ -17,7 +17,7 @@ translation_of: Tools/Firefox_OS_Simulator_clone
 
 <p><span style="line-height: 1.5;">シミュレータをインストールするには、<a href="/ja/docs/Tools/WebIDE#Adding_a_Simulator">WebIDE の Manage Simulators ペイン</a> (Firefox 33 以降で利用可能) を使用します。複数のバージョンが用意されており、それらをすべてインストールすることをお勧めします。</span></p>
 
-<p>Simulator を起動するには、WebIDE のランタイムリストから選択します。詳細については、<a href="https://developer.mozilla.org/docs/Tools/WebIDE#Selecting_a_runtime">WebIDE のマニュアル</a>を参照してください。Simulator が実行されると、実際のデバイスと同様に WebIDE を使用して Simulator をデバッグすることで、デバッグができます。</p>
+<p>Simulator を起動するには、WebIDE のランタイムリストから選択します。詳細については、<a href="/ja/docs/Tools/WebIDE#Selecting_a_runtime">WebIDE のマニュアル</a>を参照してください。Simulator が実行されると、実際のデバイスと同様に WebIDE を使用して Simulator をデバッグすることで、デバッグができます。</p>
 
 <p>アプリケーションマネージャ (WebIDE より前の古いツール) を使用している場合は、次のボタンを使用してシミュレータをインストールできます。</p>
 
@@ -62,14 +62,14 @@ translation_of: Tools/Firefox_OS_Simulator_clone
 <p>サポートしているハードウェアがデスクトップ上で利用できないため、デバイス上で動作する特定の API はシミュレータ上では機能しません。ジオロケーションなどの一部の API のシミュレーションを実装し、今後のリリースでさらに追加する予定です。ただし、現時点では、次の API はサポートされていません。それらを使用すると、エラーがスローされたり、正しくない結果が返される可能性があります</p>
 
 <ul>
- <li><a href="/en-US/WebAPI/WebTelephony" title="/en-US/WebAPI/WebTelephony">Telephony</a></li>
- <li><a href="/en-US/docs/WebAPI/WebSMS" title="/en-US/docs/WebAPI/WebSMS">WebSMS</a></li>
- <li><a href="/en-US/docs/WebAPI/WebBluetooth" title="/en-US/docs/WebAPI/WebBluetooth">WebBluetooth</a></li>
- <li><a href="/en-US/docs/WebAPI/Using_Light_Events" title="/en-US/docs/WebAPI/Using_Light_Events">Ambient Light</a></li>
- <li><a href="/en-US/docs/WebAPI/Proximity" title="/en-US/docs/WebAPI/Proximity">Proximity</a></li>
- <li><a href="/en-US/docs/WebAPI/Network_Information" title="/en-US/docs/WebAPI/Network_Information">Network Information</a></li>
- <li><a href="/en-US/docs/Online_and_offline_events" title="/en-US/docs/Online_and_offline_events">navigator.onLine and offline events</a></li>
- <li><a href="/en-US/docs/WebAPI/Vibration" title="/en-US/docs/WebAPI/Vibration">Vibration</a></li>
+ <li><a href="/ja/WebAPI/WebTelephony" title="/en-US/WebAPI/WebTelephony">Telephony</a></li>
+ <li><a href="/ja/docs/WebAPI/WebSMS" title="/en-US/docs/WebAPI/WebSMS">WebSMS</a></li>
+ <li><a href="/ja/docs/WebAPI/WebBluetooth" title="/en-US/docs/WebAPI/WebBluetooth">WebBluetooth</a></li>
+ <li><a href="/ja/docs/WebAPI/Using_Light_Events" title="/en-US/docs/WebAPI/Using_Light_Events">Ambient Light</a></li>
+ <li><a href="/ja/docs/WebAPI/Proximity" title="/en-US/docs/WebAPI/Proximity">Proximity</a></li>
+ <li><a href="/ja/docs/WebAPI/Network_Information" title="/en-US/docs/WebAPI/Network_Information">Network Information</a></li>
+ <li><a href="/ja/docs/Online_and_offline_events" title="/en-US/docs/Online_and_offline_events">navigator.onLine and offline events</a></li>
+ <li><a href="/ja/docs/WebAPI/Vibration" title="/en-US/docs/WebAPI/Vibration">Vibration</a></li>
 </ul>
 
 <h2 id="ヘルプの利用"><a name="Simulator-help"></a>ヘルプの利用</h2>

--- a/files/ja/tools/index.html
+++ b/files/ja/tools/index.html
@@ -18,10 +18,10 @@ translation_of: Tools
 
 <div class="column-container">
 <p>Firefox で利用できるウェブ開発ツールを使う上での情報を探すのに、あなたはうってつけの場所に来ています — このページは主要ツールと追加ツールすべての詳細な情報、Android 用 Firefox への接続やデバッグのやり方といったより詳しい情報、開発ツールの拡張のやり方、ブラウザー全体のデバッグのやり方へのリンクを提供します。</p>
-サイドバーにあるリンクを探索して、ページまで読み進めてください。開発ツールに関してのフィードバックや質問があれば、我々のメーリングリストか IRC チャンネル (<a href="https://developer.mozilla.org/ja/docs/Tools#Join_the_Developer_tools_community">ページ最下部のコミュニティリンク</a>をご覧ください) にメッセージを送ってください。もし文書に関しての明確なフィードバックや質問があれば、<a href="https://discourse.mozilla.org/c/mdn">MDN discourse</a> が投書するのに良いサイトです。<br>
+サイドバーにあるリンクを探索して、ページまで読み進めてください。開発ツールに関してのフィードバックや質問があれば、我々のメーリングリストか IRC チャンネル (<a href="/ja/docs/Tools#Join_the_Developer_tools_community">ページ最下部のコミュニティリンク</a>をご覧ください) にメッセージを送ってください。もし文書に関しての明確なフィードバックや質問があれば、<a href="https://discourse.mozilla.org/c/mdn">MDN discourse</a> が投書するのに良いサイトです。<br>
 
 <div class="note">
-<p><strong>注記</strong>: もしウェブ開発や開発ツールの使用について初心者ならば、<a href="https://developer.mozilla.org/ja/docs/Learn">ウェブ開発を学ぶ</a> が役に立つでしょう — 良いスタートラインとして <a href="https://developer.mozilla.org/ja/docs/Learn/Getting_started_with_the_web">ウェブ入門</a> と <a href="https://developer.mozilla.org/ja/docs/Learn/Common_questions/What_are_browser_developer_tools">ブラウザー開発者ツールとは？</a> をご覧ください。</p>
+<p><strong>注記</strong>: もしウェブ開発や開発ツールの使用について初心者ならば、<a href="/ja/docs/Learn">ウェブ開発を学ぶ</a> が役に立つでしょう — 良いスタートラインとして <a href="/ja/docs/Learn/Getting_started_with_the_web">ウェブ入門</a> と <a href="/ja/docs/Learn/Common_questions/What_are_browser_developer_tools">ブラウザー開発者ツールとは？</a> をご覧ください。</p>
 </div>
 </div>
 
@@ -107,7 +107,7 @@ translation_of: Tools
 </div>
 
 <div class="note">
-<p><strong>注</strong>: 開発ツールの入っている UI の総称は<a href="https://developer.mozilla.org/ja/docs/Tools/Tools_Toolbox">ツールボックス</a>です。</p>
+<p><strong>注</strong>: 開発ツールの入っている UI の総称は<a href="/ja/docs/Tools/Tools_Toolbox">ツールボックス</a>です。</p>
 </div>
 
 <div class="column-container">
@@ -142,7 +142,7 @@ translation_of: Tools
  <dd>ページの DOM 属性や関数などを調査します。</dd>
  <dt><a href="/ja/docs/Tools/GCLI">開発ツールバー</a></dt>
  <dd>開発ツール用のコマンドラインインターフェイスです。</dd>
- <dt><a href="https://developer.mozilla.org/ja/docs/Tools/Accessibility_inspector">アクセシビリティインスペクター</a></dt>
+ <dt><a href="/ja/docs/Tools/Accessibility_inspector">アクセシビリティインスペクター</a></dt>
  <dd>ページのアクセシビリティツリーへのアクセス手段を提供し、何が足りないのかや注意が必要なのかを確認できるようにします。</dd>
  <dt><a href="/ja/docs/Tools/Eyedropper">スポイト</a></dt>
  <dd>ページ内の色を選択します。</dd>
@@ -156,9 +156,9 @@ translation_of: Tools
  <dd>オーディオコンテキストでオーディオノードのグラフの調査や、それらのパラメーターの変更を行います。</dd>
  <dt><a href="/ja/docs/Tools/Taking_screenshots">スクリーンショットを撮影</a></dt>
  <dd>ページ全体またはひとつの要素のスクリーンショットを撮影します。</dd>
- <dt><a href="https://developer.mozilla.org/ja/docs/Tools/Measure_a_portion_of_the_page">ページの一部分を計測する</a></dt>
+ <dt><a href="/ja/docs/Tools/Measure_a_portion_of_the_page">ページの一部分を計測する</a></dt>
  <dd>ウェブページの特定のエリアを計測します。</dd>
- <dt><a href="https://developer.mozilla.org/ja/docs/Tools/Rulers">定規</a></dt>
+ <dt><a href="/ja/docs/Tools/Rulers">定規</a></dt>
  <dd>ウェブページ上に水平、垂直な定規を重ねます。</dd>
 </dl>
 </div>

--- a/files/ja/tools/network_monitor/request_list/index.html
+++ b/files/ja/tools/network_monitor/request_list/index.html
@@ -280,7 +280,7 @@ translation_of: Tools/Network_Monitor/request_list
  <li>Save Image As (only for images)</li>
  <li>Edit and Resend</li>
  <li>Open in New Tab</li>
- <li>Start <a href="/en-US/docs/Tools/Network_Monitor#Performance_analysis">Performance Analysis</a> for the page</li>
+ <li>Start <a href="/ja/docs/Tools/Network_Monitor#Performance_analysis">Performance Analysis</a> for the page</li>
 </ul>
 
 <h4 id="Edit_and_Resend">Edit and Resend</h4>

--- a/files/ja/tools/page_inspector/3-pane_mode/index.html
+++ b/files/ja/tools/page_inspector/3-pane_mode/index.html
@@ -15,12 +15,12 @@ translation_of: Tools/Page_Inspector/3-pane_mode
 
 <h2 id="機能の概要">機能の概要</h2>
 
-<p>Firefox 62以降では、<a href="/en-US/docs/Tools/Page_Inspector">ページインスペクター</a> に新しいモード (<strong>3ペインモード</strong>) が用意されています。これを有効にすると、同時に以下を見ることができます：</p>
+<p>Firefox 62以降では、<a href="/ja/docs/Tools/Page_Inspector">ページインスペクター</a> に新しいモード (<strong>3ペインモード</strong>) が用意されています。これを有効にすると、同時に以下を見ることができます：</p>
 
 <ul>
- <li>The <a href="/en-US/docs/Tools/Page_Inspector/How_to/Examine_and_edit_HTML">HTML pane</a> on the left hand side, as usual.</li>
- <li>The <a href="/en-US/docs/Tools/Page_Inspector/How_to/Examine_and_edit_CSS#Examine_CSS_rules">CSS Rules</a> in the middle in their own separate pane, rather than as a tab.</li>
- <li>The other CSS related features — such as <a href="/en-US/docs/Tools/Page_Inspector/How_to/Examine_and_edit_CSS#Examine_computed_CSS">Computed styles view</a>, <a href="/en-US/docs/Tools/Page_Inspector/How_to/Work_with_animations">Animations view</a>, and <a href="/en-US/docs/Tools/Page_Inspector/How_to/View_fonts">Fonts view</a> — in tabs on the right hand side, as usual.</li>
+ <li>The <a href="/ja/docs/Tools/Page_Inspector/How_to/Examine_and_edit_HTML">HTML pane</a> on the left hand side, as usual.</li>
+ <li>The <a href="/ja/docs/Tools/Page_Inspector/How_to/Examine_and_edit_CSS#Examine_CSS_rules">CSS Rules</a> in the middle in their own separate pane, rather than as a tab.</li>
+ <li>The other CSS related features — such as <a href="/ja/docs/Tools/Page_Inspector/How_to/Examine_and_edit_CSS#Examine_computed_CSS">Computed styles view</a>, <a href="/ja/docs/Tools/Page_Inspector/How_to/Work_with_animations">Animations view</a>, and <a href="/ja/docs/Tools/Page_Inspector/How_to/View_fonts">Fonts view</a> — in tabs on the right hand side, as usual.</li>
 </ul>
 
 <p><img alt="The firefox page inspector in 3 pane mode, with HTML pane on left, CSS rules pane in center, and CSS tool tabs on right" src="https://mdn.mozillademos.org/files/15935/3-pane-view-final.png" style="border-style: solid; border-width: 1px; display: block; height: 259px; margin: 0px auto; width: 1195px;"></p>

--- a/files/ja/tools/performance/call_tree/index.html
+++ b/files/ja/tools/performance/call_tree/index.html
@@ -46,7 +46,7 @@ translation_of: Tools/Performance/Call_Tree
 <p>現在のバージョンのコールツリーでは、これらが最も重要な列です。<em>Self Cost </em>が比較的高い関数は、実行に時間がかかり、頻繁に呼び出されるため、最適化の候補となります。</p>
 
 <div class="note">
-<p><a href="https://developer.mozilla.org/ja/docs/Tools/Performance/Call_Tree$edit#Using_an_inverted_aka_Bottom-Up_Call_Tree">The inverted call tree</a> は、これらの <em>Self Cost </em>値に集中する良い方法です。</p>
+<p><a href="/ja/docs/Tools/Performance/Call_Tree$edit#Using_an_inverted_aka_Bottom-Up_Call_Tree">The inverted call tree</a> は、これらの <em>Self Cost </em>値に集中する良い方法です。</p>
 </div>
 
 <p>このスクリーンショットは、私たちがすでに知っていると思われるものを示しています。バブルソートは非常に非効率的なアルゴリズムです。 バブルソートは選択ソートの約6倍、クイックソートの13倍です。</p>

--- a/files/ja/tools/remote_debugging/firefox_for_android/index.html
+++ b/files/ja/tools/remote_debugging/firefox_for_android/index.html
@@ -3,7 +3,7 @@ title: Android 版 Firefox のリモートデバッグ
 slug: Tools/Remote_Debugging/Firefox_for_Android
 translation_of: Tools/Remote_Debugging/Firefox_for_Android
 ---
-<div>{{ToolsSidebar}}</div><p>このガイドでは、<a href="/ja/docs/Mozilla/Firefox_for_Android">Android 版 Firefox</a> で実行しているコードを USB 経由で調査あるいはデバッグするために、<a href="/docs/Tools/Remote_Debugging">リモートデバッグ</a>を使用する方法を説明します。</p>
+<div>{{ToolsSidebar}}</div><p>このガイドでは、<a href="/ja/docs/Mozilla/Firefox_for_Android">Android 版 Firefox</a> で実行しているコードを USB 経由で調査あるいはデバッグするために、<a href="/ja/docs/Tools/Remote_Debugging">リモートデバッグ</a>を使用する方法を説明します。</p>
 
 <div class="note">
 <p>最近、Android 版 Firefox に開発ツールを接続する方法を大幅にシンプル化しました。デスクトップ版 の Firefox 36 以降および Android 版の Firefox 35 以降を使用している場合は、本記事の代わりに<a href="/ja/docs/Tools/Remote_Debugging/Debugging_Firefox_for_Android_with_WebIDE">新しい方法をご確認ください</a>。</p>

--- a/files/ja/tools/remote_debugging/index.html
+++ b/files/ja/tools/remote_debugging/index.html
@@ -16,6 +16,6 @@ translation_of: Tools/Remote_Debugging
 
 <ul>
  <li><a href="/ja/docs/Tools/Remote_Debugging/Debugging_Firefox_Desktop">デスクトップ版 Firefox</a></li>
- <li>Android 版 Firefox を<a href="/docs/Tools/about:debugging">USB 経由</a>で</li>
+ <li>Android 版 Firefox を<a href="/ja/docs/Tools/about:debugging">USB 経由</a>で</li>
  <li><a href="/ja/docs/Tools/Remote_Debugging/Thunderbird">Thunderbird</a></li>
 </ul>

--- a/files/ja/tools/tips/index.html
+++ b/files/ja/tools/tips/index.html
@@ -82,7 +82,7 @@ translation_of: Tools/Tips
   <br>
   <code>Screen Shot date at time.png</code><br>
   <br>
-  --fullpage パラメーターはオプションです。それを含めると、スクリーンショットはブラウザウィンドウに表示されるセクションだけでなくページ全体になります。ファイル名にも -fullpage が付加されます。<a href="https://developer.mozilla.org/en-US/docs/Tools/Web_Console/Helpers">Web コンソールヘルパー</a>の全てのパラメータを参照してください。</li>
+  --fullpage パラメーターはオプションです。それを含めると、スクリーンショットはブラウザウィンドウに表示されるセクションだけでなくページ全体になります。ファイル名にも -fullpage が付加されます。<a href="/ja/docs/Tools/Web_Console/Helpers">Web コンソールヘルパー</a>の全てのパラメータを参照してください。</li>
 </ul>
 
 <p>コンソールの出力:</p>

--- a/files/ja/tools/web_audio_editor/index.html
+++ b/files/ja/tools/web_audio_editor/index.html
@@ -10,7 +10,7 @@ translation_of: Tools/Web_Audio_Editor
 <div> </div>
 
 <div class="blockIndicator note">
-<p>注意：このツールは廃止予定であり、まもなくFirefoxから削除される予定です。 詳しくは、<a href="https://developer.mozilla.org/en-US/docs/Tools/Deprecated_tools">非推奨ツール</a>を参照してください。</p>
+<p>注意：このツールは廃止予定であり、まもなくFirefoxから削除される予定です。 詳しくは、<a href="/ja/docs/Tools/Deprecated_tools">非推奨ツール</a>を参照してください。</p>
 </div>
 
 <p><a href="/ja/docs/Web/API/Web_Audio_API/Using_Web_Audio_API">Web Audio API</a> を使うとき、開発者は {{domxref ("AudioContext")}} を生成します。そのコンテキストでは、以下のようないくつもの {{domxref ("AudioNode")}} を構築します:</p>

--- a/files/ja/tools/web_console/helpers/index.html
+++ b/files/ja/tools/web_console/helpers/index.html
@@ -27,7 +27,7 @@ translation_of: Tools/Web_Console/Helpers
  <dt id="$_"><code>$_</code></dt>
  <dd>コンソールのコマンドラインで最後に実行した式の結果を保持します。例えば "2+2 &lt;enter&gt;" と入力した後に "$_ &lt;enter&gt;" と入力すると、コンソールは 4 と出力します。</dd>
  <dt id="$x"><code>$x(xpath, element, resultType)</code></dt>
- <dd><code>element</code> のコンテキストで <a href="/ja/docs/XPath">XPath</a> <code>xpath</code> 式を評価し、一致するノードの配列を返します。 未指定の場合、<code>element</code> のデフォルトは <code>document</code> です。<code>resultType</code>には戻り値の型を指定します。取りうる値は <a href="https://developer.mozilla.org/ja/docs/Web/API/XPathResult#Constants">XPathResult定数</a>か <code>"number"</code>、 <code>"string"</code>、 <code>"bool"</code>、 <code>"node"</code>、 <code>"nodes"</code> のいずれかです。指定されなかった場合、 <code>ANY_TYPE</code> になります。</dd>
+ <dd><code>element</code> のコンテキストで <a href="/ja/docs/XPath">XPath</a> <code>xpath</code> 式を評価し、一致するノードの配列を返します。 未指定の場合、<code>element</code> のデフォルトは <code>document</code> です。<code>resultType</code>には戻り値の型を指定します。取りうる値は <a href="/ja/docs/Web/API/XPathResult#Constants">XPathResult定数</a>か <code>"number"</code>、 <code>"string"</code>、 <code>"bool"</code>、 <code>"node"</code>、 <code>"nodes"</code> のいずれかです。指定されなかった場合、 <code>ANY_TYPE</code> になります。</dd>
  <dt id="keys"><code>keys()</code></dt>
  <dd>オブジェクトを与えると、そのオブジェクトのキー (またはプロパティ名) の一覧を返します。これは <a href="/ja/docs/Web/JavaScript/Reference/Global_Objects/Object/keys"><code>Object.keys</code></a> のショートカットです。</dd>
  <dt id="values"><code>values()</code></dt>

--- a/files/ja/tools/web_console/remoting/index.html
+++ b/files/ja/tools/web_console/remoting/index.html
@@ -262,7 +262,7 @@ debuggerClient.attachConsole(tab.consoleActor, listeners, onAttachConsole)
 
 <h2 id="ページエラー">ページエラー</h2>
 
-<p>ページエラーは <a href="/ja/docs/XPCOM_Interface_Reference/nsIConsoleService" title="/en-US/docs/XPCOM_Interface_Reference/nsIConsoleService"><code>nsIConsoleService</code></a> から発生します。許可される各ページエラーは <a href="https://developer.mozilla.org/en-US/docs/XPCOM_Interface_Reference/nsIScriptError" title="/en-US/docs/XPCOM_Interface_Reference/nsIScriptError"><code>nsIScriptError</code></a> オブジェクトです。</p>
+<p>ページエラーは <a href="/ja/docs/XPCOM_Interface_Reference/nsIConsoleService" title="/en-US/docs/XPCOM_Interface_Reference/nsIConsoleService"><code>nsIConsoleService</code></a> から発生します。許可される各ページエラーは <a href="/ja/docs/XPCOM_Interface_Reference/nsIScriptError" title="/en-US/docs/XPCOM_Interface_Reference/nsIScriptError"><code>nsIScriptError</code></a> オブジェクトです。</p>
 
 <p><code>pageError</code> パケットは次のとおりです。</p>
 
@@ -302,7 +302,7 @@ debuggerClient.attachConsole(tab.consoleActor, listeners, onAttachConsole)
 <p>Firefox 23以前は、プロトコルを通じてJavaScriptオブジェクトを操作するために、別のアクタ<code>(WebConsoleObjectActor</code>)を使用しました。<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=783499">bug 783499</a>では、デバッガから<code>ObjectActor</code>を再利用するためにいくつかの変更を行いました。</p>
 </div>
 
-<p>コンソール API メッセージは <a href="https://developer.mozilla.org/en-US/docs/XPCOM_Interface_Reference/nsIObserverService" title="/en-US/docs/XPCOM_Interface_Reference/nsIObserverService"><code>nsIObserverService</code></a> を経由します。コンソールオブジェクトの実装は <a href="http://mxr.mozilla.org/mozilla-central/source/dom/base/ConsoleAPI.js"><code>dom/base/ConsoleAPI.js</code></a> にあります。</p>
+<p>コンソール API メッセージは <a href="/ja/docs/XPCOM_Interface_Reference/nsIObserverService" title="/en-US/docs/XPCOM_Interface_Reference/nsIObserverService"><code>nsIObserverService</code></a> を経由します。コンソールオブジェクトの実装は <a href="http://mxr.mozilla.org/mozilla-central/source/dom/base/ConsoleAPI.js"><code>dom/base/ConsoleAPI.js</code></a> にあります。</p>
 
 <p>サーバーで受信したコンソールメッセージごとに、次の <code>consoleAPICall</code> パケットをクライアントに送信します。</p>
 


### PR DESCRIPTION
- /en-US へのリンクを /ja へのリンクに修正
- /ja が付いていないものに /ja を付加
- MDN内のリンクが完全URLの場合、 /ja/docs からのURLに修正