### PR TITLE
Update block-level-elements' doc in ZH-CN

### DIFF
--- a/files/zh-cn/web/html/block-level_elements/index.html
+++ b/files/zh-cn/web/html/block-level_elements/index.html
@@ -8,7 +8,7 @@ tags:
   - 指南
 translation_of: Web/HTML/Block-level_elements
 ---
-<p>HTML（超文本标记语言）中元素大多数都是“块级”元素或<a href="/zh-CN/docs/HTML/Inline_elements" title="/zh-CN/docs/HTML/Inline_elements">行内元素</a>。块级元素占据其父元素（容器）的整个空间，因此创建了一个“块”。这篇文章帮助解释这个概念。</p>
+<p>HTML（超文本标记语言）中元素大多数都是“块级”元素或<a href="/zh-CN/docs/HTML/Inline_elements" title="/zh-CN/docs/HTML/Inline_elements">行内元素</a>。块级元素占据其父元素（容器）的整个水平空间，垂直空间等于其内容高度，因此创建了一个“块”。这篇文章帮助解释这个概念。</p>
 
 <p>通常浏览器会在块级元素前后另起一个新行。下面的例子表明了块级元素的作用：</p>
 


### PR DESCRIPTION
Update block-level-elements' doc in Chinese (Simplified).
更新了中文块级元素的文档
翻译错误
A Block-level element occupies the entire horizontal space of its parent element (container), and vertical space equal to the height of its contents, thereby creating a "block".
错翻译为：块级元素占据其父元素（容器）的整个空间，因此创建了一个“块”。