### PR TITLE
Fixed "hight" to "height"

### DIFF
--- a/files/ru/web/html/element/img/index.html
+++ b/files/ru/web/html/element/img/index.html
@@ -29,7 +29,7 @@ translation_of: Web/HTML/Element/img
 
 <ul>
  <li>управление Referrer/CORS в целях безопасности. Смотрите ниже атрибуты <code>crossorigin</code> и <code>referrerpolicy</code>;</li>
- <li>настройка {{glossary("Intrinsic Size", "внутреннего размера")}} с использованием <code>width</code> и <code>hight</code>, которые полезны, когда вы хотите задать пространство занимаемое изображением, чтобы обеспечить стабильность макета страницы перед его загрузкой;</li>
+ <li>настройка {{glossary("Intrinsic Size", "внутреннего размера")}} с использованием <code>width</code> и <code>height</code>, которые полезны, когда вы хотите задать пространство занимаемое изображением, чтобы обеспечить стабильность макета страницы перед его загрузкой;</li>
  <li>адаптивные изображения рекомендуется использовать с атрибутами <code>sizes</code> и <code>srcset</code> (смотрите также элемент {{htmlelement("picture")}} и наше руководство "<a href="/ru/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images">Адаптивные изображения</a>").</li>
 </ul>
 


### PR DESCRIPTION
Fixed `hight` to `height`, because it's right attr title of `<img>` html-tag.