### PR TITLE
Firefox 91 for developers を更新

### DIFF
--- a/files/ja/mozilla/firefox/releases/91/index.html
+++ b/files/ja/mozilla/firefox/releases/91/index.html
@@ -41,7 +41,7 @@ tags:
 <ul>
   <li>{{jsxref("Intl/DateTimeFormat/formatRange", "Intl.DateTimeFormat.prototype.formatRange()")}} および {{jsxref("Intl/DateTimeFormat/formatRangeToParts", "Intl.DateTimeFormat.prototype.formatRangeToParts()")}} を、Release ビルドでサポートしました。<code>formatRange()</code> メソッドは、2 つの {{jsxref("Date")}} オブジェクトの間の期間をローカライズおよび整形した文字列で返します (例: "21/01/05 – 21/01/10")。<code>formatRangeToParts()</code> メソッドは、整形された期間のロケール固有の<em>部品</em>を持つ配列を返します ({{bug(1653024)}})。</li>
   <li>{{jsxref("Intl/DateTimeFormat/DateTimeFormat", "Intl.DateTimeFormat() コンストラクター")}} が、タイムゾーンの表示方法を整形するための <code>timeZoneName</code> オプションを新たに 4 種類受け入れるようになりました。これにはローカライズされた GMT 形式の <code>shortOffset</code> および <code>longOffset</code> と、一般的な非ロケーション形式の <code>shortGeneric</code> および <code>longGeneric</code> が含まれます ({{bug(1653024)}})。</li>
-  <li>{{jsxref("Global_Objects/Error/Error", "Error() コンストラクター")}} が、<code>option</code> 引数の値として <code>cause</code> をとれるようになりました。これはコードがエラーをキャッチして、元のエラーやスタックトレースを持つ新たなバージョン、または変更したバージョンのエラーを発生させることができます ({{bug(1653024)}})。</li>
+  <li>{{jsxref("Global_Objects/Error/Error", "Error() コンストラクター")}} が、<code>option</code> 引数の値として <code>cause</code> をとれるようになりました。これはコードがエラーをキャッチして、元のエラーやスタックトレースを持つ新たなバージョン、または変更したバージョンのエラーを発生させることができます ({{bug(1679653)}})。</li>
  </ul>
 
 


### PR DESCRIPTION
Aug 31, 2021 の英語版に対応。