### PR TITLE
[zh-cn] Fix a typo.

### DIFF
--- a/files/zh-cn/web/css/_doublecolon_first-letter/index.html
+++ b/files/zh-cn/web/css/_doublecolon_first-letter/index.html
@@ -5,7 +5,7 @@ translation_of: 'Web/CSS/::first-letter'
 ---
 <p>{{ CSSRef() }}</p>
 
-<p id="概述"><a href="/en/CSS" title="CSS">CSS</a> <a href="/en/CSS/Pseudo-elements" title="Pseudo-elements">伪元素</a> <code>::first-letter会</code>选中某 <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Visual_formatting_model#Block-level_elements_and_block_boxes">block-level element</a>（块级元素）第一行的第一个字母，并且文字所处的行之前没有其他内容（如图片和内联的表格） 。</p>
+<p id="概述"><a href="/en/CSS" title="CSS">CSS</a> <a href="/en/CSS/Pseudo-elements" title="Pseudo-elements">伪元素</a> <code>::first-letter</code>会选中某 <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Visual_formatting_model#Block-level_elements_and_block_boxes">block-level element</a>（块级元素）第一行的第一个字母，并且文字所处的行之前没有其他内容（如图片和内联的表格） 。</p>
 
 <pre><code>/* Selects the first letter of a &lt;p&gt; */
 p::first-letter {

--- a/files/zh-cn/web/css/_doublecolon_first-letter/index.html
+++ b/files/zh-cn/web/css/_doublecolon_first-letter/index.html
@@ -30,7 +30,7 @@ p::first-letter {
 
 <p> </p>
 
-<p>只有一小部分CSS可以在包含<code>使用了::first-letter</code> 伪元素选择器的CSS规则集声明块内运用:</p>
+<p>只有一小部分CSS可以在包含使用了<code>::first-letter</code> 伪元素选择器的CSS规则集声明块内运用:</p>
 
 <ul>
  <li>所有的字体属性 : {{ Cssxref("font") }}, {{ Cssxref("font-style") }}, {{cssxref("font-feature-settings")}}, {{cssxref("font-kerning")}}, {{cssxref("font-language-override")}}, {{cssxref("font-stretch")}}, {{cssxref("font-synthesis")}}, {{ Cssxref("font-variant") }}, {{cssxref("font-variant-alternates")}}, {{cssxref("font-variant-caps")}}, {{cssxref("font-variant-east-asian")}}, {{cssxref("font-variant-ligatures")}}, {{cssxref("font-variant-numeric")}}, {{cssxref("font-variant-position")}}, {{ Cssxref("font-weight") }}, {{ Cssxref("font-size") }}, {{cssxref("font-size-adjust")}}, {{ Cssxref("line-height") }} 以及 {{ Cssxref("font-family") }}.</li>

--- a/files/zh-cn/web/css/_doublecolon_first-line/index.html
+++ b/files/zh-cn/web/css/_doublecolon_first-line/index.html
@@ -9,7 +9,7 @@ translation_of: 'Web/CSS/::first-line'
 
 <p>和其他所有的 伪元素一样，::first-line 不能匹配任何真实存在的html元素。</p>
 
-<p> ::first-line 伪元素只能在块容器中,所以,<code>::first-line伪元素</code>只能在一个display值为block, <code>inline-block</code>, <code>table-cell</code> 或者 <code>table-caption中有用</code>.。在其他的类型中，<code>::first-line</code> 是不起作用的.</p>
+<p> ::first-line 伪元素只能在块容器中,所以,<code>::first-line</code>伪元素只能在一个display值为block, <code>inline-block</code>, <code>table-cell</code> 或者 <code>table-caption</code>中有用.。在其他的类型中，<code>::first-line</code> 是不起作用的.</p>
 
 <p> </p>
 
@@ -17,7 +17,7 @@ translation_of: 'Web/CSS/::first-line'
 
 <p> </p>
 
-<p>在一个使用了 <code>::first-line 伪元素的选择器中，</code>只有很小的一部分css属性能被使用：</p>
+<p>在一个使用了 <code>::first-line</code> 伪元素的选择器中，只有很小的一部分css属性能被使用：</p>
 
 <ul>
  <li>所有和字体有关的属性：{{Cssxref("font")}}, {{cssxref("font-kerning")}}, {{Cssxref("font-style")}}, {{Cssxref("font-variant")}}, {{cssxref("font-variant-numeric")}}, {{cssxref("font-variant-position")}}, {{cssxref("font-variant-east-asian")}}, {{cssxref("font-variant-caps")}}, {{cssxref("font-variant-alternates")}}, {{cssxref("font-variant-ligatures")}}, {{cssxref("font-synthesis")}}, {{cssxref("font-feature-settings")}}, {{cssxref("font-language-override")}}, {{Cssxref("font-weight")}}, {{Cssxref("font-size")}}, {{cssxref("font-size-adjust")}}, {{cssxref("font-stretch")}}, and {{Cssxref("font-family")}}</li>

--- a/files/zh-cn/web/javascript/a_re-introduction_to_javascript/index.html
+++ b/files/zh-cn/web/javascript/a_re-introduction_to_javascript/index.html
@@ -327,7 +327,7 @@ do {
 <pre class="brush: js notranslate">var allowed = (age &gt; 18) ? "yes" : "no";
 </pre>
 
-<p>在需要多重分支时可以使用  <code>基于一个数字或字符串的switch</code> 语句：</p>
+<p>在需要多重分支时可以使用基于一个数字或字符串的 <code>switch</code> 语句：</p>
 
 <pre class="brush: js notranslate">switch(action) {
     case 'draw':


### PR DESCRIPTION
“会” should be out of `<code></code>`