### PR TITLE
[ko]  improve video tag autoplay attribute translation

### DIFF
--- a/files/ko/web/html/element/video/index.html
+++ b/files/ko/web/html/element/video/index.html
@@ -32,7 +32,7 @@ translation_of: Web/HTML/Element/video
 <dl>
  <dt>{{htmlattrdef("autoplay")}}</dt>
  <dd>부울 속성(boolean); 해당 속성이 지정된 경우 비디오가 데이터 로드를 완료하기 위해 중지하지 않고 재생할 수 있는 가장 빠른 시점에 재생되기 시작합니다.<br/>
-autoplay를 비활성화시킬 때 autoplay="false"는 동작하지 않습니다. <video> 태그 내부에 autoplay 속성이 존재한다면 비디오가 자동재생 됩니다. autoplay를 비활성화하려면 해당 속성을 완전히 제거해야 합니다.
+autoplay를 비활성화시킬 때 autoplay="false"는 동작하지 않습니다. <code>&lt;video&gt;</code>태그 내부에 autoplay 속성이 존재한다면 비디오가 자동재생 됩니다. autoplay를 비활성화하려면 해당 속성을 완전히 제거해야 합니다.
 </dd>
  
  <dt>{{htmlattrdef("buffered")}}</dt>

--- a/files/ko/web/html/element/video/index.html
+++ b/files/ko/web/html/element/video/index.html
@@ -31,7 +31,10 @@ translation_of: Web/HTML/Element/video
 
 <dl>
  <dt>{{htmlattrdef("autoplay")}}</dt>
- <dd>부울(boolean) 속성. 이 값이 설정되면, 데이터 로딩이 완료되지 않더라도 재생 가능한 시점에 자동으로 재생이 시작됩니다.</dd>
+ <dd>부울 속성(boolean); 해당 속성이 지정된 경우 비디오가 데이터 로드를 완료하기 위해 중지하지 않고 재생할 수 있는 가장 빠른 시점에 재생되기 시작합니다.<br/>
+autoplay를 비활성화시킬 때 autoplay="false"는 동작하지 않습니다. <video> 태그 내부에 autoplay 속성이 존재한다면 비디오가 자동재생 됩니다. autoplay를 비활성화하려면 해당 속성을 완전히 제거해야 합니다.
+</dd>
+ 
  <dt>{{htmlattrdef("buffered")}}</dt>
  <dd>미디어의 어느 시간대가 버퍼에 들어 있는지 확인할 수 있는 속성입니다. 이 속성은 {{domxref("TimeRanges")}} 객체를 포함합니다.</dd>
  <dt>{{htmlattrdef("controls")}}</dt>

--- a/files/ko/web/javascript/reference/functions/arrow_functions/index.html
+++ b/files/ko/web/javascript/reference/functions/arrow_functions/index.html
@@ -17,7 +17,7 @@ original_slug: Web/JavaScript/Reference/Functions/애로우_펑션
 <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this">this</a>나 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/super">super</a>에 대한 바인딩이 없고, <a href="https://developer.mozilla.org/en-US/docs/Glossary/Method">methods</a> 로 사용될 수 없습니다.</li>
 <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target">new.target</a>키워드가 없습니다.</li>
 <li>일반적으로 스코프를 지정할 때 사용하는 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call">call</a>, <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply">apply</a>, <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind">bind</a> methods를 이용할 수 없습니다.</li>
-<li>생성자<a href="https://developer.mozilla.org/en-US/docs/Glossary/Constructor">(Constructor)</a>로 사용할 수 없습니다.</li>
+<li>생성자<a href="https://developer.mozilla.org/ko/docs/Glossary/Constructor">(Constructor)</a>로 사용할 수 없습니다.</li>
 <li><a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Operators/yield">yield</a>를 화살표 함수 내부에서 사용할 수 없습니다.</li>
 </ul>
 

--- a/files/ko/web/javascript/reference/functions/arrow_functions/index.html
+++ b/files/ko/web/javascript/reference/functions/arrow_functions/index.html
@@ -16,7 +16,7 @@ original_slug: Web/JavaScript/Reference/Functions/애로우_펑션
 <ul>
 <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this">this</a>나 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/super">super</a>에 대한 바인딩이 없고, <a href="https://developer.mozilla.org/en-US/docs/Glossary/Method">methods</a> 로 사용될 수 없습니다.</li>
 <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target">new.target</a>키워드가 없습니다.</li>
-<li>일반적으로 스코프를 지정할 때 사용하는 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call">call</a>, <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply">apply</a>, <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind">bind</a> methods를 이용할 수 없습니다.</li>
+<li>일반적으로 스코프를 지정할 때 사용하는 <a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Function/call">call</a>, <a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Function/apply">apply</a>, <a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Function/bind">bind</a> methods를 이용할 수 없습니다.</li>
 <li>생성자<a href="https://developer.mozilla.org/ko/docs/Glossary/Constructor">(Constructor)</a>로 사용할 수 없습니다.</li>
 <li><a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Operators/yield">yield</a>를 화살표 함수 내부에서 사용할 수 없습니다.</li>
 </ul>

--- a/files/ko/web/javascript/reference/functions/arrow_functions/index.html
+++ b/files/ko/web/javascript/reference/functions/arrow_functions/index.html
@@ -14,7 +14,7 @@ original_slug: Web/JavaScript/Reference/Functions/애로우_펑션
 
 <p>화살표 함수 표현(<strong>arrow function expression</strong>)은 <a href="/ko/docs/Web/JavaScript/Reference/Operators/function">전통적인 함수표현(function)</a>의 간편한 대안입니다.  하지만, 화살표 함수는 몇 가지 제한점이 있고 모든 상황에 사용할 수는 없습니다.</p>
 <ul>
-<li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this">this</a>나 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/super">super</a>에 대한 바인딩이 없고, <a href="https://developer.mozilla.org/en-US/docs/Glossary/Method">methods</a> 로 사용될 수 없습니다.</li>
+<li><a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Operators/this">this</a>나 <a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Operators/super">super</a>에 대한 바인딩이 없고, <a href="https://developer.mozilla.org/ko/docs/Glossary/Method">methods</a> 로 사용될 수 없습니다.</li>
 <li><a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Operators/new.target">new.target</a>키워드가 없습니다.</li>
 <li>일반적으로 스코프를 지정할 때 사용하는 <a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Function/call">call</a>, <a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Function/apply">apply</a>, <a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Function/bind">bind</a> methods를 이용할 수 없습니다.</li>
 <li>생성자<a href="https://developer.mozilla.org/ko/docs/Glossary/Constructor">(Constructor)</a>로 사용할 수 없습니다.</li>

--- a/files/ko/web/javascript/reference/functions/arrow_functions/index.html
+++ b/files/ko/web/javascript/reference/functions/arrow_functions/index.html
@@ -17,7 +17,7 @@ original_slug: Web/JavaScript/Reference/Functions/애로우_펑션
 <li><a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Operators/this">this</a>나 <a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Operators/super">super</a>에 대한 바인딩이 없고, <a href="https://developer.mozilla.org/ko/docs/Glossary/Method">methods</a> 로 사용될 수 없습니다.</li>
 <li><a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Operators/new.target">new.target</a>키워드가 없습니다.</li>
 <li>일반적으로 스코프를 지정할 때 사용하는 <a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Function/call">call</a>, <a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Function/apply">apply</a>, <a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Function/bind">bind</a> methods를 이용할 수 없습니다.</li>
-<li>생성자<a href="https://developer.mozilla.org/ko/docs/Glossary/Constructor">(Constructor)</a>로 사용할 수 없습니다.</li>
+<li>생성자<a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Classes/constructor">(Constructor)</a>로 사용할 수 없습니다.</li>
 <li><a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Operators/yield">yield</a>를 화살표 함수 내부에서 사용할 수 없습니다.</li>
 </ul>
 

--- a/files/ko/web/javascript/reference/functions/arrow_functions/index.html
+++ b/files/ko/web/javascript/reference/functions/arrow_functions/index.html
@@ -18,7 +18,7 @@ original_slug: Web/JavaScript/Reference/Functions/애로우_펑션
 <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target">new.target</a>키워드가 없습니다.</li>
 <li>일반적으로 스코프를 지정할 때 사용하는 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call">call</a>, <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply">apply</a>, <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind">bind</a> methods를 이용할 수 없습니다.</li>
 <li>생성자<a href="https://developer.mozilla.org/en-US/docs/Glossary/Constructor">(Constructor)</a>로 사용할 수 없습니다.</li>
-<li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/yield">yield</a>를 화살표 함수 내부에서 사용할 수 없습니다.</li>
+<li><a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Operators/yield">yield</a>를 화살표 함수 내부에서 사용할 수 없습니다.</li>
 </ul>
 
 <p>{{EmbedInteractiveExample("pages/js/functions-arrow.html")}}</p>

--- a/files/ko/web/javascript/reference/functions/arrow_functions/index.html
+++ b/files/ko/web/javascript/reference/functions/arrow_functions/index.html
@@ -15,7 +15,7 @@ original_slug: Web/JavaScript/Reference/Functions/애로우_펑션
 <p>화살표 함수 표현(<strong>arrow function expression</strong>)은 <a href="/ko/docs/Web/JavaScript/Reference/Operators/function">전통적인 함수표현(function)</a>의 간편한 대안입니다.  하지만, 화살표 함수는 몇 가지 제한점이 있고 모든 상황에 사용할 수는 없습니다.</p>
 <ul>
 <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this">this</a>나 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/super">super</a>에 대한 바인딩이 없고, <a href="https://developer.mozilla.org/en-US/docs/Glossary/Method">methods</a> 로 사용될 수 없습니다.</li>
-<li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target">new.target</a>키워드가 없습니다.</li>
+<li><a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Operators/new.target">new.target</a>키워드가 없습니다.</li>
 <li>일반적으로 스코프를 지정할 때 사용하는 <a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Function/call">call</a>, <a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Function/apply">apply</a>, <a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Function/bind">bind</a> methods를 이용할 수 없습니다.</li>
 <li>생성자<a href="https://developer.mozilla.org/ko/docs/Glossary/Constructor">(Constructor)</a>로 사용할 수 없습니다.</li>
 <li><a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Operators/yield">yield</a>를 화살표 함수 내부에서 사용할 수 없습니다.</li>


### PR DESCRIPTION
[번역 개선]
 autoplay속성 중 일부 생략된 정보를 문장에 포함 시켰습니다.

before:

autoplay
부울(boolean) 속성. 이 값이 설정되면, 데이터 로딩이 완료되지 않더라도 재생 가능한 시점에 자동으로 재생이 시작됩니다.

after:

부울 속성(boolean); 해당 속성이 지정된 경우 비디오가 데이터 로드를 완료하기 위해 중지하지 않고 재생할 수 있는 가장 빠른 시점에 재생되기 시작합니다.
autoplay를 비활성화시킬 때 autoplay="false"는 동작하지 않습니다. ```<video>``` 태그 내부에 autoplay 속성이 존재한다면 비디오가 자동재생 됩니다. autoplay를 비활성화하려면 해당 속성을 완전히 제거해야 합니다.