### PR TITLE
[ko] translated /React_getting_started the first paragraph

### DIFF
--- a/files/ko/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.html
+++ b/files/ko/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.html
@@ -37,7 +37,7 @@ tags:
 
 <h2 id="Hello_React">Hello React</h2>
 
-<p>As its official tagline states, <a href="https://reactjs.org/">React</a> is a library for building user interfaces. React is not a framework – it's not even exclusive to the web. It's used with other libraries to render to certain environments. For instance, <a href="https://reactnative.dev/">React Native</a> can be used to build mobile applications; <a href="https://facebook.github.io/react-360/">React 360</a> can be used to build virtual reality applications; and there are other possibilities besides.</p>
+<p>공식 소개문구에 명시되어 있듯이, <a href="https://reactjs.org/">React</a>는 유저 인터페이스를 만드는데 사용되는 라이브러리입니다. React는 프레임워크가 아닐뿐더러, 웹 환경에만 국한된 도구도 아닙니다. 특정 환경에 렌더링되기 위해서는 다른 라이브러리들이 함께 사용되는데, 예를 들어 모바일 애플리케이션을 빌드하는데 사용되는 <a href="https://reactnative.dev/">React Native</a>, 가상현실 애플리케이션을 빌드하는데 사용되는 <a href="https://facebook.github.io/react-360/">React 360</a>가 있고, 그 외에도 다양한 환경에서 활용이 가능합니다.</p>
 
 <p>To build for the web, developers use React in tandem with <a href="https://reactjs.org/docs/react-dom.html">ReactDOM</a>. React and ReactDOM are often discussed in the same spaces as — and utilized to solve the same problems as — other true web development frameworks. When we refer to React as a "framework", we’re working with that colloquial understanding.</p>
 


### PR DESCRIPTION
'files/ko/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.html' 의 본문 첫단락을 번역했습니다.