### PR TITLE
[FIX] Remove mispositioned phrase.

### DIFF
--- a/files/ko/web/http/cors/index.html
+++ b/files/ko/web/http/cors/index.html
@@ -11,8 +11,6 @@ tags:
   - 동일 출처
 translation_of: Web/HTTP/CORS
 ---
-<div>이에 대한 응답으로 서버는 Access-Control-Allow-Origin 헤더를 다시 보냅니다.{{HTTPSidebar}}</div>
-
 <p><strong>교차 출처 리소스 공유</strong>(Cross-Origin Resource Sharing, {{Glossary("CORS")}})는 추가 {{Glossary("HTTP")}} 헤더를 사용하여, 한 {{glossary("origin", "출처")}}에서 실행 중인 웹 애플리케이션이 다른 출처의 선택한 자원에 접근할 수 있는 권한을 부여하도록 브라우저에 알려주는 체제입니다. 웹 애플리케이션은 리소스가 자신의 출처(도메인, 프로토콜, 포트)와 다를 때 교차 출처 HTTP 요청을 실행합니다.</p>
 
 <p>교차 출처 요청의 예시: <code>https://domain-a.com</code>의 프론트 엔드 JavaScript 코드가 {{domxref("XMLHttpRequest")}}를 사용하여 <code>https://domain-b.com/data.json</code>을 요청하는 경우.</p>


### PR DESCRIPTION
CORS 문서 최상단에 문맥과 맞지 않으면서 불완전한 문장이 있어 삭제했습니다.