### PR TITLE
fix typo on Web/JavaScript

### DIFF
--- a/files/ja/web/javascript/reference/functions/arrow_functions/index.html
+++ b/files/ja/web/javascript/reference/functions/arrow_functions/index.html
@@ -217,7 +217,7 @@ console.log(result) // result 106
 var result = add.bind(obj) // "obj" としてスコープを確立
 console.log(result(1, 2, 3)) // result 106</pre>
 
-<p>アロー関数では、 <code>add</code> 関数は基本的に <code>window</code> (グローバル) スコープで作成されているので、 <code>this</code> は windows だと仮定されます。</p>
+<p>アロー関数では、 <code>add</code> 関数は基本的に <code>window</code> (グローバル) スコープで作成されているので、 <code>this</code> は window だと仮定されます。</p>
 
 <pre class="brush: js">// ----------------------
 // アロー関数の例


### PR DESCRIPTION
原文にあわせ、"window"に修正する変更です。