### PR TITLE
fix typo in javascript/reference/classes page [ru]

### DIFF
--- a/files/ru/web/javascript/reference/classes/index.html
+++ b/files/ru/web/javascript/reference/classes/index.html
@@ -31,7 +31,7 @@ translation_of: Web/JavaScript/Reference/Classes
 
 <h4 id="Подъём_hoisting">Подъём (hoisting)</h4>
 
-<p>Разница между <em>объявлением функции</em> (<em>function declaration</em>) и <em>объявлением класса</em> (<em>class declaration</em>) в том, что <em>объявление функции</em> совершает подъём ({{Glossary("Hoisting", "hoisted")}}), в то время как <em>объявление класса</em> — нет. Поэтому вначале необходимо объявить ваш класс и только затем работать с ним, а код же вроде следующего сгенерирует исключение типа {{jsxref("ReferenceError")}}:</p>
+<p>Разница между <em>объявлением функции</em> (<em>function declaration</em>) и <em>объявлением класса</em> (<em>class declaration</em>) в том, что <em>объявление функции</em> совершает подъём ({{Glossary("Hoisting", "hoisting")}}), в то время как <em>объявление класса</em> — нет. Поэтому вначале необходимо объявить ваш класс и только затем работать с ним, а код же вроде следующего сгенерирует исключение типа {{jsxref("ReferenceError")}}:</p>
 
 <pre class="brush: js notranslate"><code>var p = new Rectangle(); // ReferenceError
 


### PR DESCRIPTION
исправление опечатки hoisted -> hoisting в разделе «Подъём»