### PR TITLE
[zh-cn] Fix a typo in web_workers_api.

### DIFF
--- a/files/zh-cn/web/api/web_workers_api/index.html
+++ b/files/zh-cn/web/api/web_workers_api/index.html
@@ -22,7 +22,7 @@ translation_of: Web/API/Web_Workers_API
 
 <p>主线程和 worker 线程相互之间使用 <code>postMessage()</code> 方法来发送信息, 并且通过 <code>onmessage</code> 这个 event handler来接收信息（传递的信息包含在 {{event("Message")}} 这个事件的<code>data</code>属性内) 。数据的交互方式为传递副本，而不是直接共享数据。</p>
 
-<p>worker 可以另外生成新的 worker，这些 worker 与它们父页面的宿主相同。 此外，worker 可以通过 <a class="internal" href="/en/DOM/XMLHttpRequest" title="En/XMLHttpRequest"><code>XMLHttpRequest</code></a> 来访问网络，只不过 <code>XMLHttpRequest</code> 的 <code>responseXML</code> 和 <code>channel</code> 这两个属性的值将总是 <code>null 。</code></p>
+<p>worker 可以另外生成新的 worker，这些 worker 与它们父页面的宿主相同。 此外，worker 可以通过 <a class="internal" href="/en/DOM/XMLHttpRequest" title="En/XMLHttpRequest"><code>XMLHttpRequest</code></a> 来访问网络，只不过 <code>XMLHttpRequest</code> 的 <code>responseXML</code> 和 <code>channel</code> 这两个属性的值将总是 <code>null</code> 。</p>
 
 <p>除了专用 worker 之外，还有一些其他种类的 worker ：</p>
 


### PR DESCRIPTION
I found this typo when I was reading the corresponding doc page. 
Here is the fix 😸: