### PR TITLE
zh-CN: update browser compatibility of Using_Fetch

### DIFF
--- a/files/zh-cn/web/api/fetch_api/using_fetch/index.html
+++ b/files/zh-cn/web/api/fetch_api/using_fetch/index.html
@@ -376,7 +376,7 @@ fetch("/login", {
 
 
 
-<p>{{Compat("api.WindowOrWorkerGlobalScope.fetch")}}</p>
+<p>{{Compat("api.fetch")}}</p>
 
 <h2 id="参见">参见</h2>
 


### PR DESCRIPTION
Current version shows "No compatibility data found for api.WindowOrWorkerGlobalScope.fetch."
See also the en-US ver at https://github.com/mdn/content/blob/7f9d01caf27ae773785543bf03a7ff1bde7e45b8/files/en-us/web/api/fetch_api/using_fetch/index.md