### PR TITLE
Fix incorrect translation

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/globalthis/index.html
+++ b/files/zh-cn/web/javascript/reference/global_objects/globalthis/index.html
@@ -40,7 +40,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/globalThis
 
 <h3 id="命名">命名</h3>
 
-<p>并没有采用一些更常见的命名方式类似 <code>self</code> 和 <code>global</code> 是因为考虑到向后兼容，为了避免影响到现存代码的正常工作。 更多相关信息可以查看 <a href="https://github.com/tc39/proposal-global/blob/master/NAMING.md">language proposal's "naming" document</a> 。</p>
+<p>并没有采用一些更常见的命名方式，如 <code>self</code> 和 <code>global</code>，这是为了避免影响现存代码的兼容性。更多相关信息可以查看 <a href="https://github.com/tc39/proposal-global/blob/master/NAMING.md">language proposal's "naming" document</a> 。</p>
 
 <h2 id="示例">示例</h2>
 

--- a/files/zh-cn/web/javascript/reference/global_objects/globalthis/index.html
+++ b/files/zh-cn/web/javascript/reference/global_objects/globalthis/index.html
@@ -40,7 +40,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/globalThis
 
 <h3 id="命名">命名</h3>
 
-<p>并没有采用一些更常见的命名方式类似 <code>self</code> 和 <code>global</code> 是因为考虑到前向兼容，为了避免影响到现存代码的正常工作。 更多相关信息可以查看 <a href="https://github.com/tc39/proposal-global/blob/master/NAMING.md">language proposal's "naming" document</a> 。</p>
+<p>并没有采用一些更常见的命名方式类似 <code>self</code> 和 <code>global</code> 是因为考虑到向后兼容，为了避免影响到现存代码的正常工作。 更多相关信息可以查看 <a href="https://github.com/tc39/proposal-global/blob/master/NAMING.md">language proposal's "naming" document</a> 。</p>
 
 <h2 id="示例">示例</h2>
 


### PR DESCRIPTION
1. 避免影响现存代码的兼容应为「向后兼容（Backward Combability）」（原文只有「break compatibility with existing code」，但为了汉语习惯还应说明向后）。
2. 习惯上不使用单独「前/后向兼容」说法，而多见于「向前/后兼容」「前/后向兼容性」「前/后向兼容(形容词)+${名词}」，故「前向兼容」这种说法本身就是不规范的。