### PR TITLE
统一比较运算符相关页面的术语；对一些未翻译的内容补充了翻译。

### DIFF
--- a/files/zh-cn/web/javascript/reference/operators/equality/index.html
+++ b/files/zh-cn/web/javascript/reference/operators/equality/index.html
@@ -1,52 +1,50 @@
 ---
-title: 相等（==）
+title: 等于（==）
 slug: Web/JavaScript/Reference/Operators/Equality
 tags:
   - JavaScript
   - Reference
 translation_of: Web/JavaScript/Reference/Operators/Equality
-original_slug: Web/JavaScript/Reference/Operators/相等
 ---
 <div>{{jsSidebar("Operators")}}</div>
 
-<p>等于运算符（<code>==</code>）检查其两个操作数是否相等，并返回<code>Boolean</code>结果。与<a href="/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality">严格相等</a>运算符（<code>===</code>）不同，它会尝试强制类型转换并且比较不同类型的操作数。</p>
+<p>等于运算符（<code>==</code>）检查其两个操作数是否相等，并返回<code>Boolean</code>结果。与<a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Strict_equality">全等运算符</a>（<code>===</code>）不同，它会尝试强制类型转换并且比较不同类型的操作数。</p>
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-equality.html")}}</div>
 
 <h2 id="语法">语法</h2>
 
-<pre class="syntaxbox notranslate">x == y
-</pre>
+<pre class="syntaxbox notranslate">x == y</pre>
 
 <h2 id="描述">描述</h2>
 
-<p>相等运算符（<code>==</code>和<code>!=</code>）使用<a href="http://www.ecma-international.org/ecma-262/5.1/#sec-11.9.3">抽象相等比较算法</a>比较两个操作数。可以大致概括如下：</p>
+<p>等于运算符（<code>==</code>和<code>!=</code>）使用“抽象相等比较算法”（<a href="http://www.ecma-international.org/ecma-262/5.1/#sec-11.9.3">Abstract Equality Comparison Algorithm</a>）比较两个操作数，大致可概括如下：</p>
 
 <ul>
- <li>如果两个操作数都是对象，则仅当两个操作数都引用同一个对象时才返回<code>true</code>。</li>
- <li>如果一个操作数是<code>null</code>，另一个操作数是<code>undefined</code>，则返回<code>true</code>。</li>
- <li>如果两个操作数是不同类型的，就会尝试在比较之前将它们转换为相同类型：
-  <ul>
-   <li>当数字与字符串进行比较时，会尝试将字符串转换为数字值。</li>
-   <li>如果操作数之一是<code>Boolean</code>，则将布尔操作数转换为1或0。
-    <ul>
-     <li>如果是<code>true</code>，则转换为<code>1</code>。</li>
-     <li>如果是 <code>false</code>，则转换为<code>0</code>。</li>
-    </ul>
-   </li>
-   <li>如果操作数之一是对象，另一个是数字或字符串，会尝试使用对象的<code>valueOf()</code>和<code>toString()</code>方法将对象转换为原始值。</li>
-  </ul>
- </li>
- <li>如果操作数具有相同的类型，则将它们进行如下比较：
-  <ul>
-   <li><code>String</code>：<code>true</code>仅当两个操作数具有相同顺序的相同字符时才返回。</li>
-   <li><code>Number</code>：<code>true</code>仅当两个操作数具有相同的值时才返回。<code>+0</code>并被<code>-0</code>视为相同的值。如果任一操作数为<code>NaN</code>，则返回<code>false</code>。</li>
-   <li><code>Boolean</code>：<code>true</code>仅当操作数为两个<code>true</code>或两个<code>false</code>时才返回<code>true</code>。</li>
-  </ul>
- </li>
+    <li>如果两个操作数都是对象，则仅当两个操作数都引用同一个对象时才返回<code>true</code>。</li>
+    <li>如果一个操作数是<code>null</code>，另一个操作数是<code>undefined</code>，则返回<code>true</code>。</li>
+    <li>如果两个操作数是不同类型的，就会尝试在比较之前将它们转换为相同类型：
+        <ul>
+            <li>当数字与字符串进行比较时，会尝试将字符串转换为数字值。</li>
+            <li>如果操作数之一是<code>Boolean</code>，则将布尔操作数转换为1或0。
+                <ul>
+                    <li>如果是<code>true</code>，则转换为<code>1</code>。</li>
+                    <li>如果是<code>false</code>，则转换为<code>0</code>。</li>
+                </ul>
+            </li>
+            <li>如果操作数之一是对象，另一个是数字或字符串，会尝试使用对象的<code>valueOf()</code>和<code>toString()</code>方法将对象转换为原始值。</li>
+        </ul>
+    </li>
+    <li>如果操作数具有相同的类型，则将它们进行如下比较：
+        <ul>
+            <li><code>String</code>：<code>true</code>仅当两个操作数具有相同顺序的相同字符时才返回。</li>
+            <li><code>Number</code>：<code>true</code>仅当两个操作数具有相同的值时才返回。<code>+0</code>并被<code>-0</code>视为相同的值。如果任一操作数为<code>NaN</code>，则返回<code>false</code>。</li>
+            <li><code>Boolean</code>：<code>true</code>仅当操作数为两个<code>true</code>或两个<code>false</code>时才返回<code>true</code>。</li>
+        </ul>
+    </li>
 </ul>
 
-<p>此运算符与<a href="/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality">严格等于</a>（<code>===</code>）运算符之间最显着的区别在于，严格等于运算符不尝试类型转换。相反，严格相等运算符始终将不同类型的操作数视为不同。</p>
+<p>此运算符与<a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Strict_equality">全等运算符</a>（<code>===</code>）之间最显着的区别在于，全等运算符不尝试类型转换。相反，全等运算符始终将不同类型的操作数视为不同。</p>
 
 <h2 id="例子">例子</h2>
 
@@ -95,22 +93,22 @@ console.log(string4 == string4); // true</pre>
 <h3 id="比较日期和字符串">比较日期和字符串</h3>
 
 <pre class="brush: js notranslate">const d = new Date('December 17, 1995 03:24:00');
-const s = d.toString(); // for example: "Sun Dec 17 1995 03:24:00 GMT-0800 (Pacific Standard Time)"
+const s = d.toString(); // 如: "Sun Dec 17 1995 03:24:00 GMT-0800 (Pacific Standard Time)"
 console.log(d == s);    //true</pre>
 
-<h2 id="技术指标">技术指标</h2>
+<h2 id="相关规范">相关规范</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">规范</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-equality-operators', 'Equality operators')}}</td>
-  </tr>
- </tbody>
+    <thead>
+        <tr>
+            <th scope="col">规范</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>{{SpecName('ESDraft', '#sec-equality-operators', 'Equality operators')}}</td>
+        </tr>
+    </tbody>
 </table>
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
@@ -120,7 +118,7 @@ console.log(d == s);    //true</pre>
 <h2 id="参见">参见</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Inequality">不等式运算符</a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality">严格相等运算符</a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality">严格的不等式运算符</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Inequality">不等运算符</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Strict_equality">全等运算符</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Strict_inequality">不全等运算符</a></li>
 </ul>

--- a/files/zh-cn/web/javascript/reference/operators/greater_than/index.html
+++ b/files/zh-cn/web/javascript/reference/operators/greater_than/index.html
@@ -1,5 +1,5 @@
 ---
-title: 大于运算符 (>)
+title: 大于 (>)
 slug: Web/JavaScript/Reference/Operators/Greater_than
 translation_of: Web/JavaScript/Reference/Operators/Greater_than
 ---
@@ -9,19 +9,17 @@ translation_of: Web/JavaScript/Reference/Operators/Greater_than
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-greater-than.html")}}</div>
 
-
-
 <h2 id="语法">语法</h2>
 
 <pre class="syntaxbox notranslate">x &gt; y</pre>
 
 <h2 id="描述">描述</h2>
 
-<p>操作数之间按照 <a class="external external-icon" href="https://tc39.es/ecma262/#sec-abstract-relational-comparison" rel="noopener">Abstract Relational Comparison</a> 算法进行比较。进一步了解该算法，请参考 <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Less_than">小于</a> 运算符的相关文档.</p>
+<p>操作数之间按照 <a class="external external-icon" href="https://tc39.es/ecma262/#sec-abstract-relational-comparison" rel="noopener">Abstract Relational Comparison</a> 算法进行比较。进一步了解该算法，请参考 <a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Less_than">小于</a>运算符的相关文档.</p>
 
 <h2 id="例子">例子</h2>
 
-<h3 id="字符串的比较">字符串的比较</h3>
+<h3 id="字符串的比较">字符串间的比较</h3>
 
 <pre class="brush: js notranslate">console.log("a" &gt; "b");        // false
 console.log("a" &gt; "a");        // false
@@ -45,12 +43,12 @@ console.log("3" &gt; 5n);         // false</pre>
 console.log(3 &gt; 3);            // false
 console.log(3 &gt; 5);            // false</pre>
 
-<h3 id="数字和_BigInt_数据的比较">数字和 BigInt 数据的比较</h3>
+<h3 id="数字与BigInt数据的比较">数字与 BigInt 数据的比较</h3>
 
 <pre class="brush: js notranslate">console.log(5n &gt; 3);           // true
 console.log(3 &gt; 5n);           // false</pre>
 
-<h3 id="Boolean_null_undefined_NaN的比较">Boolean, null, undefined, NaN的比较</h3>
+<h3 id="Boolean_null_undefined_NaN的比较">Boolean, null, undefined, NaN 间的比较</h3>
 
 <pre class="brush: js notranslate">console.log(true &gt; false);     // true
 console.log(false &gt; true);     // false
@@ -67,29 +65,27 @@ console.log(3 &gt; undefined);    // false
 console.log(3 &gt; NaN);          // false
 console.log(NaN &gt; 3);          // false</pre>
 
-<h2 id="规范">规范</h2>
+<h2 id="相关规范">相关规范</h2>
 
 <table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">规范</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-relational-operators', 'Relational operators')}}</td>
-  </tr>
- </tbody>
+    <tbody>
+        <tr>
+            <th scope="col">规范</th>
+        </tr>
+        <tr>
+            <td>{{SpecName('ESDraft', '#sec-relational-operators', 'Relational operators')}}</td>
+        </tr>
+    </tbody>
 </table>
 
-<h2 id="浏览器兼容">浏览器兼容</h2>
-
-
+<h2 id="浏览器兼容性">浏览器兼容性</h2>
 
 <p>{{Compat("javascript.operators.greater_than")}}</p>
 
 <h2 id="参考">参考</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than_or_equal">Greater than or equal operator</a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Less_than">Less than operator</a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Less_than_or_equal">Less than or equal operator</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Greater_than_or_equal">大于等于运算符</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Less_than">小于运算符</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Less_than_or_equal">小于等于运算符</a></li>
 </ul>

--- a/files/zh-cn/web/javascript/reference/operators/greater_than_or_equal/index.html
+++ b/files/zh-cn/web/javascript/reference/operators/greater_than_or_equal/index.html
@@ -1,34 +1,32 @@
 ---
-title: 大于或等于
+title: 大于等于（>=）
 slug: Web/JavaScript/Reference/Operators/Greater_than_or_equal
 translation_of: Web/JavaScript/Reference/Operators/Greater_than_or_equal
 ---
 <div>{{jsSidebar("Operators")}}</div>
 
-<p>The greater than or equal operator (<code>&gt;=</code>) returns <code>true</code> if the left operand is greater than or equal to the right operand, and <code>false</code> otherwise.</p>
+<p>大于等于运算符（<code>&gt;=</code>）在左边的操作数大于或等于右边的操作数时返回 <code>true</code>，否则返回 <code>false</code>。</p>
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-greater-than-or-equal.html")}}</div>
 
-
-
-<h2 id="Syntax">Syntax</h2>
+<h2 id="语法">语法</h2>
 
 <pre class="syntaxbox notranslate"> x &gt;= y</pre>
 
-<h2 id="Description">Description</h2>
+<h2 id="描述">描述</h2>
 
-<p>The operands are compared using the <a class="external external-icon" href="https://tc39.es/ecma262/#sec-abstract-relational-comparison" rel="noopener">Abstract Relational Comparison</a> algorithm. See the documentation for the <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Less_than">Less than</a> operator for a summary of this algorithm.</p>
+<p>操作数之间按照 <a class="external external-icon" href="https://tc39.es/ecma262/#sec-abstract-relational-comparison" rel="noopener">Abstract Relational Comparison</a> 算法进行比较。进一步了解该算法，请参考 <a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Less_than">小于运算符</a>的相关文档.</p>
 
-<h2 id="Examples">Examples</h2>
+<h2 id="例子">例子</h2>
 
-<h3 id="String_to_string_comparison">String to string comparison</h3>
+<h3 id="字符串间的比较">字符串间的比较</h3>
 
 <pre class="brush: js notranslate">console.log("a" &gt;= "b");     // false
 console.log("a" &gt;= "a");     // true
 console.log("a" &gt;= "3");     // true
 </pre>
 
-<h3 id="String_to_number_comparison">String to number comparison</h3>
+<h3 id="字符串与数字的比较">字符串与数字的比较</h3>
 
 <pre class="brush: js notranslate">console.log("5" &gt;= 3);       // true
 console.log("3" &gt;= 3);       // true
@@ -37,19 +35,19 @@ console.log("3" &gt;= 5);       // false
 console.log("hello" &gt;= 5);   // false
 console.log(5 &gt;= "hello");   // false</pre>
 
-<h3 id="Number_to_Number_comparison">Number to Number comparison</h3>
+<h3 id="数字间的比较">数字间的比较</h3>
 
 <pre class="brush: js notranslate">console.log(5 &gt;= 3);         // true
 console.log(3 &gt;= 3);         // true
 console.log(3 &gt;= 5);         // false</pre>
 
-<h3 id="Number_to_BigInt_comparison">Number to BigInt comparison</h3>
+<h3 id="数字与BigInt数据的比较<">数字与 BigInt 数据的比较</h3>
 
 <pre class="brush: js notranslate">console.log(5n &gt;= 3);        // true
 console.log(3 &gt;= 3n);        // true
 console.log(3 &gt;= 5n);        // false</pre>
 
-<h3 id="Comparing_Boolean_null_undefined_NaN">Comparing Boolean, null, undefined, NaN</h3>
+<h3 id="Boolean_null_undefined_NaN的比较">Boolean, null, undefined, NaN 的比较</h3>
 
 <pre class="brush: js notranslate">console.log(true &gt;= false);  // true
 console.log(true &gt;= true);   // true
@@ -67,29 +65,27 @@ console.log(3 &gt;= undefined); // false
 console.log(3 &gt;= NaN);       // false
 console.log(NaN &gt;= 3);       // false</pre>
 
-<h2 id="Specifications">Specifications</h2>
+<h2 id="相关规范">相关规范</h2>
 
 <table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-relational-operators', 'Relational operators')}}</td>
-  </tr>
- </tbody>
+    <tbody>
+        <tr>
+            <th scope="col">规范</th>
+        </tr>
+        <tr>
+            <td>{{SpecName('ESDraft', '#sec-relational-operators', 'Relational operators')}}</td>
+        </tr>
+    </tbody>
 </table>
 
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-
+<h2 id="浏览器兼容性">浏览器兼容性</h2>
 
 <p>{{Compat("javascript.operators.greater_than_or_equal")}}</p>
 
-<h2 id="See_also">See also</h2>
+<h2 id="参见">参见</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than">Greater than operator</a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Less_than">Less than operator</a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Less_than_or_equal">Less than or equal operator</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Greater_than">大于运算符</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Less_than">小于运算符</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Less_than_or_equal">小于等于运算符</a></li>
 </ul>

--- a/files/zh-cn/web/javascript/reference/operators/inequality/index.html
+++ b/files/zh-cn/web/javascript/reference/operators/inequality/index.html
@@ -1,5 +1,5 @@
 ---
-title: 不等于 (!=)
+title: 不等（!=）
 slug: Web/JavaScript/Reference/Operators/Inequality
 tags:
   - JavaScript
@@ -10,37 +10,37 @@ translation_of: Web/JavaScript/Reference/Operators/Inequality
 ---
 <div>{{jsSidebar("Operators")}}</div>
 
-<p>不等于运算符 (<code>!=</code>) 检查其两个操作数是否不相等，并返回布尔结果。 与严格的不等式运算符不同，它尝试转换和比较不同类型的操作数。</p>
+<p>不等运算符 (<code>!=</code>) 检查其两个操作数是否不相等，并返回布尔结果。 与不全等运算符不同，它尝试转换和比较不同类型的操作数。</p>
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-inequality.html")}}</div>
 
-<p class="hidden"><font><font>该交互式示例的源代码存储在GitHub存储库中。</font><font>如果您想为交互式示例项目做出贡献，请克隆</font></font><a href="https://github.com/mdn/interactive-examples"><font><font>https://github.com/mdn/interactive-examples</font></font></a><font><font>并向我们​​发送请求请求。</font></font></p>
+<p class="hidden">该交互式示例的源代码存储在GitHub存储库中。如果您想为交互式示例项目做出贡献，请克隆<a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a>并向我们发送请求请求。</p>
 
 <h2 id="语法">语法</h2>
 
 <pre class="syntaxbox notranslate">x != y</pre>
 
-<h2 id="描述"><font><font>描述</font></font></h2>
+<h2 id="描述">描述</h2>
 
-<p><font><font>不等式运算符检查其操作数是否不相等。</font><font>这是</font></font><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Equality"><font><font>等于</font></font></a><font><font>运算符</font><font>的取反，</font><font>因此以下两行将始终给出相同的结果：</font></font> </p>
+<p>不等式运算符检查其操作数是否不相等。这是<a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Equality">等于</a>运算符的取反，因此以下两行将始终给出相同的结果：</p>
 
 <pre class="brush: js notranslate">x != y
 
 !(x == y)</pre>
 
-<p><font><font>有关比较算法的详细信息，请参见</font></font><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Equality"><font><font>等于</font></font></a><font><font>运算符</font><font>的页面</font><font>。</font></font></p>
+<p>有关比较算法的详细信息，请参见<a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Equality">等于</a>运算符的页面。</p>
 
-<p><font><font>与等于运算符一样，不等于运算符将尝试转换和比较不同类型的操作数：</font></font></p>
+<p>与等于运算符一样，不等运算符将尝试转换和比较不同类型的操作数：</p>
 
 <pre class="brush: js notranslate">3 != "3"; // false</pre>
 
-<p><font><font>为避免这种情况，并要求将不同类型视为不同，请使用</font></font><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Strict_inequality"><font><font>严格的不等于</font></font></a><font><font>运算符：</font></font></p>
+<p>为避免这种情况，并要求将不同类型视为不同，请使用<a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Strict_inequality">不全等</a>运算符：</p>
 
 <pre class="brush: js notranslate">3 !== "3"; // true</pre>
 
-<h2 id="例子"><font><font>例子</font></font></h2>
+<h2 id="例子">例子</h2>
 
-<h3 id="没有类型转换的比较"><font><font>没有类型转换的比较</font></font></h3>
+<h3 id="没有类型转换的比较">没有类型转换的比较</h3>
 
 <pre class="brush: js notranslate">1 != 2;              // true
 "hello" != "hola";   // true
@@ -48,7 +48,7 @@ translation_of: Web/JavaScript/Reference/Operators/Inequality
 1 != 1;              // false
 "hello" != "hello";  // false</pre>
 
-<h3 id="与类型转换比较"><font><font>与类型转换比较</font></font></h3>
+<h3 id="与类型转换比较">与类型转换比较</h3>
 
 <pre class="brush: js notranslate">"1" !=  1;            // false
 1 != "1";             // false
@@ -64,7 +64,7 @@ const number2 = new Number(3);
 number1 != 3;         // false
 number1 != number2;   // true</pre>
 
-<h3 id="对象比较"><font><font>对象比较</font></font></h3>
+<h3 id="对象比较">对象比较</h3>
 
 <pre class="brush: js notranslate">const object1 = {"key": "value"}
 const object2 = {"key": "value"};
@@ -72,33 +72,28 @@ const object2 = {"key": "value"};
 object1 != object2 // true
 object2 != object2 // false</pre>
 
-<h2 id="规范"><font><font>规范</font></font></h2>
+<h2 id="相关规范">相关规范</h2>
 
 <table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-equality-operators', 'Equality operators')}}</td>
-  </tr>
- </tbody>
+    <tbody>
+        <tr>
+            <th scope="col">规范</th>
+        </tr>
+        <tr>
+            <td>{{SpecName('ESDraft', '#sec-equality-operators', 'Equality operators')}}</td>
+        </tr>
+    </tbody>
 </table>
 
-<h2 id="浏览器兼容性"><font><font>浏览器兼容性</font></font></h2>
-
-
+<h2 id="浏览器兼容性">浏览器兼容性</h2>
 
 <p>{{Compat("javascript.operators.inequality")}}</p>
 
 <h2 id="参见">参见</h2>
 
 <ul>
- <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Equality">Equality operator</a></li>
- <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Strict_equality">Strict equality operator</a></li>
- <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Strict_inequality">Strict inequality operator</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Equality">等于运算符</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Strict_equality">全等运算符</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Strict_inequality">不全等运算符</a></li>
 </ul>
 
-<div id="gtx-trans" style="position: absolute; left: 16px; top: 1743.2px;">
-<div class="gtx-trans-icon"></div>
-</div>

--- a/files/zh-cn/web/javascript/reference/operators/less_than/index.html
+++ b/files/zh-cn/web/javascript/reference/operators/less_than/index.html
@@ -1,48 +1,46 @@
 ---
-title: Less than (<)
+title: 小于 (<)
 slug: Web/JavaScript/Reference/Operators/Less_than
 translation_of: Web/JavaScript/Reference/Operators/Less_than
 ---
 <div>{{jsSidebar("Operators")}}</div>
 
-<p>The less than operator (<code>&lt;</code>) returns <code>true</code> if the left operand is less than the right operand, and <code>false</code> otherwise.</p>
+<p>当左边的操作数小于右边的操作数时，小于运算符（<code>&lt;</code>）返回 <code>true</code>，否则返回 <code>false</code>。</p>
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-less-than.html")}}</div>
-
-
 
 <h2 id="语法">语法</h2>
 
 <pre class="syntaxbox notranslate"> x &lt; y</pre>
 
-<h2 id="Description">Description</h2>
+<h2 id="描述">描述</h2>
 
-<p>The operands are compared using the <a href="https://tc39.es/ecma262/#sec-abstract-relational-comparison">Abstract Relational Comparison</a> algorithm, which is roughly summarised below:</p>
+<p>操作数之间按照 <a class="external external-icon" href="https://tc39.es/ecma262/#sec-abstract-relational-comparison" rel="noopener">Abstract Relational Comparison</a> 算法进行比较，大致可概括如下：</p>
 
 <ul>
- <li>First, objects are converted to primitives using <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive">Symbol.ToPrimitive</a></code> with the <code>hint</code> parameter be <code>'number'</code>.</li>
- <li>If both values are strings, they are compared as strings, based on the values of the Unicode code points they contain.</li>
- <li>Otherwise JavaScript attempts to convert non-numeric types to numeric values:
-  <ul>
-   <li>Boolean values <code>true</code> and <code>false</code> are converted to 1 and 0 respectively.</li>
-   <li><code>null</code> is converted to 0.</li>
-   <li><code>undefined</code> is converted to <code>NaN</code>.</li>
-   <li>Strings are converted based on the values they contain, and are converted as <code>NaN</code> if they do not contain numeric values.</li>
-  </ul>
- </li>
- <li>If either value is <code><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN">NaN</a></code>, the operator returns <code>false</code>.</li>
- <li>Otherwise the values are compared as numeric values.</li>
+    <li>首先，用带有 <code>hint</code> 参数的 <code><a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive">Symbol.ToPrimitive</a></code>将对象转换成原始值。</li>
+    <li>如果两个值都是字符串，则根据它们包含的 Unicode 代码位的值，将它们作为字符串进行比较。</li>
+    <li>否则 Javascript 会尝试将非数字类型转换成数字值：
+        <ul>
+            <li>布尔值 <code>true</code> 和 <code>false</code> 会被各自转换成 1 和 0。</li>
+            <li><code>null</code> 会被转换成 0。</li>
+            <li><code>undefined</code> 会被转换成 <code>NaN</code>。</li>
+            <li>字符串根据它们包含的值进行转换，如果它们不包含数字值则会被转换成 <code>NaN</code>。</li>
+        </ul>
+    </li>
+    <li>如果任一值为 <code><a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/NaN">NaN</a></code>，运算符会返回 <code>false</code>.</li>
+    <li>其它情况下，值被作为数字值比较。</li>
 </ul>
 
-<h2 id="Examples">Examples</h2>
+<h2 id="例子">例子</h2>
 
-<h3 id="String_to_string_comparison">String to string comparison</h3>
+<h3 id="字符串间的比较">字符串间的比较</h3>
 
 <pre class="brush: js notranslate">console.log("a" &lt; "b");        // true
 console.log("a" &lt; "a");        // false
 console.log("a" &lt; "3");        // false</pre>
 
-<h3 id="String_to_number_comparison">String to number comparison</h3>
+<h3 id="字符串和数字的比较">字符串和数字的比较</h3>
 
 <pre class="brush: js notranslate">console.log("5" &lt; 3);          // false
 console.log("3" &lt; 3);          // false
@@ -54,18 +52,18 @@ console.log(5 &lt; "hello");      // false
 console.log("5" &lt; 3n);         // false
 console.log("3" &lt; 5n);         // true</pre>
 
-<h3 id="Number_to_Number_comparison">Number to Number comparison</h3>
+<h3 id="数字间的比较">数字间的比较</h3>
 
 <pre class="brush: js notranslate">console.log(5 &lt; 3);            // false
 console.log(3 &lt; 3);            // false
 console.log(3 &lt; 5);            // true</pre>
 
-<h3 id="Number_to_BigInt_comparison">Number to BigInt comparison</h3>
+<h3 id="数字与BigInt数据的比较">数字与 BigInt 数据的比较</h3>
 
 <pre class="brush: js notranslate">console.log(5n &lt; 3);           // false
 console.log(3 &lt; 5n);           // true</pre>
 
-<h3 id="Comparing_Boolean_null_undefined_NaN">Comparing Boolean, null, undefined, NaN</h3>
+<h3 id="Boolean_null_undefined_NaN的比较">Boolean, null, undefined, NaN 的比较</h3>
 
 <pre class="brush: js notranslate">console.log(true &lt; false);     // false
 console.log(false &lt; true);     // true
@@ -76,35 +74,33 @@ console.log(true &lt; 1);         // false
 console.log(null &lt; 0);         // false
 console.log(null &lt; 1);         // true
 
-console.log(undefined &lt; 3);    // false
-console.log(3 &lt; undefined);    // false
+console.log(undefined &lt; 3);         // false
+console.log(3 &lt; undefined);         // false
 
 console.log(3 &lt; NaN);          // false
 console.log(NaN &lt; 3);          // false</pre>
 
-<h2 id="Specifications">Specifications</h2>
+<h2 id="相关规范">相关规范</h2>
 
 <table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-relational-operators', 'Relational operators')}}</td>
-  </tr>
- </tbody>
+    <tbody>
+        <tr>
+            <th scope="col">规范</th>
+        </tr>
+        <tr>
+            <td>{{SpecName('ESDraft', '#sec-relational-operators', 'Relational operators')}}</td>
+        </tr>
+    </tbody>
 </table>
 
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-
+<h2 id="浏览器兼容性">浏览器兼容性</h2>
 
 <p>{{Compat("javascript.operators.less_than")}}</p>
 
-<h2 id="See_also">See also</h2>
+<h2 id="参见">参见</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than">Greater than operator</a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than_or_equal">Greater than or equal operator</a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Less_than_or_equal">Less than or equal operator</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Greater_than">大于运算符</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Greater_than_or_equal">大于等于运算符</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Less_than_or_equal">小于等于运算符</a></li>
 </ul>

--- a/files/zh-cn/web/javascript/reference/operators/less_than_or_equal/index.html
+++ b/files/zh-cn/web/javascript/reference/operators/less_than_or_equal/index.html
@@ -1,34 +1,34 @@
 ---
-title: 小于或等于
+title: 小于等于（<=）
 slug: Web/JavaScript/Reference/Operators/Less_than_or_equal
 translation_of: Web/JavaScript/Reference/Operators/Less_than_or_equal
 ---
 <div>{{jsSidebar("Operators")}}</div>
 
-<p>The less than or equal operator (<code>&lt;=</code>) returns <code>true</code> if the left operand is less than or equal to the right operand, and <code>false</code> otherwise.</p>
+<p>小于等于运算符（<code>&lt;=</code>）在左边的操作数小于或等于右边的操作数时返回 <code>true</code>，否则返回 <code>false</code>。</p>
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-less-than-or-equal.html")}}</div>
 
 <div class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</div>
 
-<h2 id="Syntax">Syntax</h2>
+<h2 id="语法">语法</h2>
 
 <pre class="syntaxbox notranslate"> x &lt;= y</pre>
 
-<h2 id="Description">Description</h2>
+<h2 id="描述">描述</h2>
 
-<p>The operands are compared using the <a class="external external-icon" href="https://tc39.es/ecma262/#sec-abstract-relational-comparison" rel="noopener">Abstract Relational Comparison</a> algorithm. See the documentation for the <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Less_than">Less than</a> operator for a summary of this algorithm.</p>
+<p>操作数之间按照 <a class="external external-icon" href="https://tc39.es/ecma262/#sec-abstract-relational-comparison" rel="noopener">Abstract Relational Comparison</a> 算法进行比较。进一步了解该算法，请参考 <a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Less_than">小于运算符</a>的相关文档.</p>
 
-<h2 id="Examples">Examples</h2>
+<h2 id="例子">例子</h2>
 
-<h3 id="String_to_string_comparison">String to string comparison</h3>
+<h3 id="字符串间的比较">字符串间的比较</h3>
 
 <pre class="brush: js notranslate">console.log("a" &lt;= "b");     // true
 console.log("a" &lt;= "a");     // true
 console.log("a" &lt;= "3");     // false
 </pre>
 
-<h3 id="String_to_number_comparison">String to number comparison</h3>
+<h3 id="字符串与数字的比较">字符串与数字的比较</h3>
 
 <pre class="brush: js notranslate">console.log("5" &lt;= 3);       // false
 console.log("3" &lt;= 3);       // true
@@ -37,19 +37,19 @@ console.log("3" &lt;= 5);       // true
 console.log("hello" &lt;= 5);   // false
 console.log(5 &lt;= "hello");   // false</pre>
 
-<h3 id="Number_to_Number_comparison">Number to Number comparison</h3>
+<h3 id="数字间的比较">数字间的比较</h3>
 
 <pre class="brush: js notranslate">console.log(5 &lt;= 3);         // false
 console.log(3 &lt;= 3);         // true
 console.log(3 &lt;= 5);         // true</pre>
 
-<h3 id="Number_to_BigInt_comparison">Number to BigInt comparison</h3>
+<h3 id="数字与BigInt数据的比较<">数字与 BigInt 数据的比较</h3>
 
 <pre class="brush: js notranslate">console.log(5n &lt;= 3);        // false
 console.log(3 &lt;= 3n);        // true
 console.log(3 &lt;= 5n);        // true</pre>
 
-<h3 id="Comparing_Boolean_null_undefined_NaN">Comparing Boolean, null, undefined, NaN</h3>
+<h3 id="Boolean_null_undefined_NaN的比较">Boolean, null, undefined, NaN 的比较</h3>
 
 <pre class="brush: js notranslate">console.log(true &lt;= false);  // false
 console.log(true &lt;= true);   // true
@@ -67,31 +67,29 @@ console.log(3 &lt;= undefined); // false
 console.log(3 &lt;= NaN);       // false
 console.log(NaN &lt;= 3);       // false</pre>
 
-<h2 id="Specifications">Specifications</h2>
+<h2 id="相关规范">相关规范</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-relational-operators', 'Relational operators')}}</td>
-  </tr>
- </tbody>
+    <thead>
+        <tr>
+            <th scope="col">规范</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>{{SpecName('ESDraft', '#sec-relational-operators', 'Relational operators')}}</td>
+        </tr>
+    </tbody>
 </table>
 
-<h2 id="Browser_compatibility">Browser compatibility</h2>
-
-
+<h2 id="浏览器兼容性">浏览器兼容性</h2>
 
 <p>{{Compat("javascript.operators.less_than_or_equal")}}</p>
 
-<h2 id="See_also">See also</h2>
+<h2 id="参见">参见</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than">Greater than operator</a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than_or_equal">Greater than or equal operator</a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Less_than">Less than operator</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Greater_than">大于运算符</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Greater_than_or_equal">大于等于运算符</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Less_than">小于运算符</a></li>
 </ul>

--- a/files/zh-cn/web/javascript/reference/operators/strict_equality/index.html
+++ b/files/zh-cn/web/javascript/reference/operators/strict_equality/index.html
@@ -1,11 +1,11 @@
 ---
-title: Strict equality (===)
+title: 全等（===）
 slug: Web/JavaScript/Reference/Operators/Strict_equality
 translation_of: Web/JavaScript/Reference/Operators/Strict_equality
 ---
 <div>{{jsSidebar("Operators")}}</div>
 
-<p>全等运算符 (===) 会检查它的两个操作数是否相等，并且返回一个布尔值结果。与相等运算符不同，全等运算符总是认为不同类型的操作数是不同的。</p>
+<p>全等运算符 (===) 会检查它的两个操作数是否相等，并且返回一个布尔值结果。与<a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Equality">等于运算符</a>不同，全等运算符总是认为不同类型的操作数是不同的。</p>
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-strict-equality.html")}}</div>
 
@@ -20,20 +20,20 @@ translation_of: Web/JavaScript/Reference/Operators/Strict_equality
 <p>全等运算符（<code>===</code>和 <code>!==</code>）使用<a class="external external-icon" href="http://www.ecma-international.org/ecma-262/5.1/#sec-11.9.6" rel="noopener">全等比较算法</a>来比较两个操作数。</p>
 
 <ul>
- <li>如果操作数的类型不同，则返回 <code>false</code>。</li>
- <li>如果两个操作数都是对象，只有当它们指向同一个对象时才返回 <code>true</code>。</li>
- <li>如果两个操作数都为 <code>null</code>，或者两个操作数都为 <code>undefined</code>，返回 <code>true</code>。</li>
- <li>如果两个操作数有任意一个为 <code>NaN</code>，返回 <code>false</code>。</li>
- <li>否则，比较两个操作数的值：
-  <ul>
-   <li>数字类型必须拥有相同的数值。<code>+0</code> 和 <code>-0</code> 会被认为是相同的值。</li>
-   <li>字符串类型必须拥有相同顺序的相同字符。</li>
-   <li>布尔运算符必须同时为 <code>true</code> 或同时为 <code>false</code>。</li>
-  </ul>
- </li>
+    <li>如果操作数的类型不同，则返回 <code>false</code>。</li>
+    <li>如果两个操作数都是对象，只有当它们指向同一个对象时才返回 <code>true</code>。</li>
+    <li>如果两个操作数都为 <code>null</code>，或者两个操作数都为 <code>undefined</code>，返回 <code>true</code>。</li>
+    <li>如果两个操作数有任意一个为 <code>NaN</code>，返回 <code>false</code>。</li>
+    <li>否则，比较两个操作数的值：
+        <ul>
+            <li>数字类型必须拥有相同的数值。<code>+0</code> 和 <code>-0</code> 会被认为是相同的值。</li>
+            <li>字符串类型必须拥有相同顺序的相同字符。</li>
+            <li>布尔运算符必须同时为 <code>true</code> 或同时为 <code>false</code>。</li>
+        </ul>
+    </li>
 </ul>
 
-<p>全等运算符与<a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Equality">相等运算符</a>（<code>==</code>）最显著的区别是，如果操作数的类型不同，<code>== </code>运算符会在比较之前尝试将它们转换为相同的类型。</p>
+<p>全等运算符与<a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Equality">等于运算符</a>（<code>==</code>）最显著的区别是，如果操作数的类型不同，<code>==</code>运算符会在比较之前尝试将它们转换为相同的类型。</p>
 
 <h2 id="例子">例子</h2>
 
@@ -71,31 +71,29 @@ const object2 = {
 console.log(object1 === object2);  // false
 console.log(object1 === object1);  // true</pre>
 
-<h2 id="Specifications">Specifications</h2>
+<h2 id="相关规范">相关规范</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-equality-operators', 'Equality operators')}}</td>
-  </tr>
- </tbody>
+    <thead>
+        <tr>
+            <th scope="col">规范</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>{{SpecName('ESDraft', '#sec-equality-operators', 'Equality operators')}}</td>
+        </tr>
+    </tbody>
 </table>
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 
-
-
 <p>{{Compat("javascript.operators.strict_equality")}}</p>
 
-<h2 id="See_also">See also</h2>
+<h2 id="参见">参见</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Equality">Equality operator</a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Inequality">Inequality operator</a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality">Strict inequality operator</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Equality">等于运算符</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Inequality">不等运算符</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Strict_inequality">不全等运算符</a></li>
 </ul>

--- a/files/zh-cn/web/javascript/reference/operators/strict_inequality/index.html
+++ b/files/zh-cn/web/javascript/reference/operators/strict_inequality/index.html
@@ -1,11 +1,11 @@
 ---
-title: 严格不相等 (!==)
+title: 不全等（!==）
 slug: Web/JavaScript/Reference/Operators/Strict_inequality
 translation_of: Web/JavaScript/Reference/Operators/Strict_inequality
 ---
 <div>{{jsSidebar("Operators")}}</div>
 
-<p><span>严格不等式操作符(!==)检查它的两个对象是否不相等，返回一个布尔结果。与不等式运算符不同，严格不等式运算符总是认为不同类型的对象是不同的。</span></p>
+<p>不全等运算符（!==）检查它的两个对象是否不相等，返回一个布尔结果。与不等运算符不同，不全等运算符总是认为不同类型的对象是不同的。</p>
 
 <div>{{EmbedInteractiveExample("pages/js/expressions-strict-equality.html")}}</div>
 
@@ -17,15 +17,15 @@ translation_of: Web/JavaScript/Reference/Operators/Strict_inequality
 
 <h2 id="描述">描述</h2>
 
-<p><span>严格不等式运算符检查其对象是否不相等。它是严格相等运算符的否定，因此下面两行总是会给出相同的结果:</span></p>
+<p>不全等运算符检查其对象是否不相等。它是全等运算符的否定，因此下面两行总是会给出相同的结果:</p>
 
 <pre class="brush: js notranslate">x !== y
 
 !(x === y)</pre>
 
-<p><span>有关比较算法的详细信息，请参阅严格相等运算符的页面。</span></p>
+<p>有关比较算法的详细信息，请参阅全等运算符的页面。</p>
 
-<p><span>与严格相等运算符一样，严格不等运算符始终认为不同类型的对象是不同的</span>:</p>
+<p>与全等运算符一样，不全等运算符始终认为不同类型的对象是不同的</span>:</p>
 
 <pre class="brush: js notranslate">3 !== "3"; // true</pre>
 
@@ -65,31 +65,29 @@ const object2 = {
 console.log(object1 !== object2);  // true
 console.log(object1 !== object1);  // false</pre>
 
-<h2 id="规范">规范</h2>
+<h2 id="相关规范">相关规范</h2>
 
 <table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-equality-operators', 'Equality operators')}}</td>
-  </tr>
- </tbody>
+    <thead>
+        <tr>
+            <th scope="col">规范</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>{{SpecName('ESDraft', '#sec-equality-operators', 'Equality operators')}}</td>
+        </tr>
+    </tbody>
 </table>
 
-<h2 id="浏览器兼容">浏览器兼容</h2>
-
-
+<h2 id="浏览器兼容性">浏览器兼容性</h2>
 
 <p>{{Compat("javascript.operators.strict_inequality")}}</p>
 
-<h2 id="See_also">See also</h2>
+<h2 id="参见">参见</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Equality">Equality operator</a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Inequality">Inequality operator</a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality">Strict equality operator</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Equality">全等运算符</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Inequality">不等运算符</a></li>
+    <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Operators/Strict_equality">不全等运算符</a></li>
 </ul>


### PR DESCRIPTION
主要对“比较运算符”相关页面的标题及引用关键词的术语做了统一，如下所示：

1. **Equality (==)** 译为 **等于（==）**
2. **Inequality (!=)** 译为 **不等（!=）**
3. **Strict equality (===)** 译为 **全等（===）**
4. **Strict inequality (!==)**  译为 **不全等（!==）**
5. **Greater than (>)** 译为 **大于（>）**
6. **Greater than or equal (>=)** 译为 **大于等于（>=）**
7. **Less than (<)** 译为 **小于（<）**
8. **Less than or equal (<=)** 译为 **小于等于（<=）**

此外，还对一些未翻译的内容做了补充翻译，修正了一些内部链接，修整了一下代码格式。