### PR TITLE
Remove link to "chrisdavidmills/push-api-demo" repo because not available on Github

### DIFF
--- a/files/ru/web/api/push_api/index.html
+++ b/files/ru/web/api/push_api/index.html
@@ -105,7 +105,6 @@ translation_of: Web/API/Push_API
 
 <ul>
  <li><a href="/en-US/docs/Web/API/Push_API/Using_the_Push_API">Using the Push API</a></li>
- <li><a href="https://github.com/chrisdavidmills/push-api-demo">Push API Demo</a>, на Github</li>
  <li><a href="http://updates.html5rocks.com/2015/03/push-notificatons-on-the-open-web">Push Notifications on the Open Web</a>, Matt Gaunt</li>
  <li><a href="/en-US/docs/Web/API/Service_Worker_API">Service Worker API</a></li>
 </ul>


### PR DESCRIPTION
"chrisdavidmills/push-api-demo" repo does not available on Github