### PR TITLE
Web/Security/Same-origin_policy を更新

### DIFF
--- a/files/ja/web/security/same-origin_policy/index.html
+++ b/files/ja/web/security/same-origin_policy/index.html
@@ -124,7 +124,7 @@ translation_of: Web/Security/Same-origin_policy
  <li>CSS を <code>&lt;link rel="stylesheet" href="..."&gt;</code> で使用する場合。 CSS は<a href="https://scarybeastsecurity.blogspot.com/2009/12/generic-cross-browser-cross-domain.html">緩い構文規則</a>を持っているため、オリジンをまたぐ CSS には適切な <code>Content-Type</code> ヘッダーを付加することが必要です。制約はブラウザーにより異なり、ブラウザーごとの詳細は <a href="https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/gg622939(v=vs.85)?redirectedfrom=MSDN">Internet Explorer</a>, <a href="https://www.mozilla.org/en-US/security/advisories/mfsa2010-46/">Firefox</a>, <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=9877">Chrome</a>, <a href="https://support.apple.com/kb/HT4070">Safari</a> (<a href="https://support.apple.com/kb/HT4070?viewlocale=ja_JP">日本語訳</a>) (CVE-2010-0051 までスクロールしてください), <a href="https://security.opera.com/cross-domain-data-theft-with-css-load-opera-security-advisories/">Opera</a> の各項目を参照してください。</li>
  <li>{{htmlelement("img")}} で表示された画像。</li>
  <li>{{htmlelement("video")}} および {{htmlelement("audio")}} で再生されたメディア。</li>
- <li>{{htmlelement("object")}} または {{htmlelement("embed")}} で埋め込まれた外部リソースを。</li>
+ <li>{{htmlelement("object")}} または {{htmlelement("embed")}} で埋め込まれた外部リソース。</li>
  <li>{{cssxref("@font-face")}} が適用されたフォント。異なるオリジンのフォントを許容するブラウザーもありますが、同一オリジンを要求するものもあります。</li>
  <li>{{htmlelement("iframe")}} に関連するあらゆること。このような形のオリジン間のやりとりを防ぐため、サイトに {{HTTPHeader("X-Frame-Options")}} ヘッダーを使用することができます。</li>
 </ul>


### PR DESCRIPTION
「を」がついていると次に文章が続くように読めてしまうため、不要と思われる余分な文字を削除しました。

# Contexts
https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#cross-origin_network_access
> External resources embedded with `<object>` and `<embed>`.