### PR TITLE
Fix link from english page to french

### DIFF
--- a/files/fr/learn/common_questions/how_does_the_internet_work/index.html
+++ b/files/fr/learn/common_questions/how_does_the_internet_work/index.html
@@ -93,6 +93,6 @@ original_slug: Apprendre/Fonctionnement_Internet
 
 <ul>
  <li><a href="/fr/Apprendre/Commencer_avec_le_web/Le_fonctionnement_du_Web">Le fonctionnement du Web</a></li>
- <li><a href="/en-US/docs/Learn/page_vs_site_vs_server_vs_search_engine">Comprendre la différence entre une page web, un site web, un serveur web et un moteur de recherche</a></li>
+ <li><a href="/fr/docs/Learn/Common_questions/Pages_sites_servers_and_search_engines">Comprendre la différence entre une page web, un site web, un serveur web et un moteur de recherche</a></li>
  <li><a href="/fr/Apprendre/Comprendre_noms_de_domaine">Comprendre les noms de domaine</a></li>
 </ul>


### PR DESCRIPTION
The link "Comprendre la différence entre une page web, un site web, un serveur web et un moteur de recherche" in the [Étapes suivantes](https://developer.mozilla.org/fr/docs/Learn/Common_questions/How_does_the_Internet_work#%C3%A9tapes_suivantes) section pointed to the English page instead of the French one.