### PR TITLE
Fix typo

### DIFF
--- a/files/es/web/javascript/reference/operators/spread_syntax/index.html
+++ b/files/es/web/javascript/reference/operators/spread_syntax/index.html
@@ -1,5 +1,5 @@
 ---
-title: Sintáxis Spread
+title: Sintaxis Spread
 slug: Web/JavaScript/Reference/Operators/Spread_syntax
 tags:
   - ECMAScript6


### PR DESCRIPTION
Remove tilde from «Sintáxis»