### PR TITLE
訳を修正

### DIFF
--- a/files/ja/web/html/element/link/index.html
+++ b/files/ja/web/html/element/link/index.html
@@ -93,7 +93,7 @@ translation_of: Web/HTML/Element/link
      <p>fetch, XHR</p>
 
      <div class="blockIndicator note">
-     <p>この値は <code>&lt;link&gt;</code> に crossorigin 属性をつけるために必要です。</p>
+     <p>この値では <code>&lt;link&gt;</code> に crossorigin 属性が必要です。</p>
      </div>
     </td>
    </tr>


### PR DESCRIPTION
より直感的な日本語に修正しました

> This value also requires `<link>` to contain the crossorigin attribute.