### PR TITLE
Remove confusing text in the example

### DIFF
--- a/files/zh-cn/web/api/document/createtextnode/index.html
+++ b/files/zh-cn/web/api/document/createtextnode/index.html
@@ -32,7 +32,9 @@ translation_of: Web/API/Document/createTextNode
 &lt;/head&gt;
 
 &lt;body&gt;
-  &lt;button value="createTextNode"&gt;createTextNode&lt;/button&gt;
+  &lt;button value="YES! "&gt;YES! &lt;/button&gt;
+  &lt;button value="NO! "&gt;NO! &lt;/button&gt;
+  &lt;button value="WE CAN! "&gt;WE CAN! &lt;/button&gt;
 
   &lt;hr /&gt;
 

--- a/files/zh-cn/web/api/document/createtextnode/index.html
+++ b/files/zh-cn/web/api/document/createtextnode/index.html
@@ -32,10 +32,7 @@ translation_of: Web/API/Document/createTextNode
 &lt;/head&gt;
 
 &lt;body&gt;
-  &lt;button value="好耶！"&gt;好耶！&lt;/button&gt;
-  &lt;button value="坏耶！"&gt;坏耶！&lt;/button&gt;
-  &lt;button value="Rikka! "&gt;Rikka!&lt;/button&gt;
-  &lt;button value="日卡卡！"&gt;日卡卡！&lt;/button&gt;
+  &lt;button value="createTextNode"&gt;createTextNode&lt;/button&gt;
 
   &lt;hr /&gt;
 


### PR DESCRIPTION
Remove confusing text on the buttons, examples which contain the content of personal preference should not be shown.