### PR TITLE
Fix typo

### DIFF
--- a/files/pt-br/web/javascript/reference/operators/function/index.html
+++ b/files/pt-br/web/javascript/reference/operators/function/index.html
@@ -13,7 +13,7 @@ translation_of: Web/JavaScript/Reference/Operators/function
 ---
 <div>{{jsSidebar("Operators")}}</div>
 
-<p>A palavara-chave <strong><code>function</code></strong> pode ser usada para definir uma função dentro de uma expressão.</p>
+<p>A palavra-chave <strong><code>function</code></strong> pode ser usada para definir uma função dentro de uma expressão.</p>
 
 <h2 id="Sintaxe">Sintaxe</h2>
 


### PR DESCRIPTION
Summary
Fixed a small typo pt-br in docs Web/JavaScript/Reference/Operators/function

Motivation
Making the document easier to read through correct wording.

Supporting details
N/A

Related issues
N/A

- [ ] Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error