### PR TITLE
Fix #2711 / applied fixes for breaking changes in actions/github-script

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/github-script@v5
         with:
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},
@@ -48,7 +48,7 @@ jobs:
               );
             }
             var matchArtifact = matchArtifacts[0];
-            var download = await github.actions.downloadArtifact({
+            var download = await github.rest.actions.downloadArtifact({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 artifact_id: matchArtifact.id,


### PR DESCRIPTION
This intends to be a fix for https://github.com/mdn/translated-content/issues/2711

There are breaking changes in v5: https://github.com/actions/github-script#breaking-changes-in-v5
The two endpoints used by github.actions are described in this doc: 
https://octokit.github.io/rest.js/v18#actions-list-workflow-run-artifacts

So "in theory" I'm pretty confident with this fix.
:warning: However, this is not something I tested locally, @mdn/core-dev  if you have a process for this kind of changes, I'll be happy to follow

Please note that, a priori, similar actions should be undertaken for mdn/content for https://github.com/mdn/content/pull/9295