### PR TITLE
Fix typo in code sample for JS Ref typeof page

### DIFF
--- a/files/fr/web/javascript/reference/operators/typeof/index.md
+++ b/files/fr/web/javascript/reference/operators/typeof/index.md
@@ -144,7 +144,7 @@ typeof maFonction; // renverra "function"
 
 var maDonnee = 99;
 
-typeof maDonnee + 'Toto';   // renverra 'number Toto'
+typeof maDonnee + ' Toto';   // renverra 'number Toto'
 typeof (maDonnee + 'Toto'); // renverra 'string'
 ```
 

--- a/files/fr/web/javascript/reference/operators/typeof/index.md
+++ b/files/fr/web/javascript/reference/operators/typeof/index.md
@@ -1,12 +1,9 @@
 ---
 title: L'opérateur typeof
 slug: Web/JavaScript/Reference/Operators/typeof
-tags:
-  - JavaScript
-  - Operator
-  - Reference
 translation_of: Web/JavaScript/Reference/Operators/typeof
 original_slug: Web/JavaScript/Reference/Opérateurs/L_opérateur_typeof
+browser-compat: javascript.operators.typeof
 ---
 {{jsSidebar("Operators")}}
 
@@ -16,32 +13,37 @@ L'opérateur **`typeof`** renvoie une chaîne qui indique le type de son opéran
 
 ## Syntaxe
 
-L'opérateur `typeof` est suivi de son opérande :
+L'opérateur `typeof` est suivi de son opérande&nbsp;:
 
-    typeof operande
+```js
+typeof operande
+typeof(operande)
+```
 
 ### Paramètre
 
-`operande` est une expression qui représente la valeur dont on souhaite obtenir le type.
+- `operande`
+  - : Une expression représentant l'objet ou la valeur [primitive](/fr/docs/Glossary/Primitive) dont on souhaite obtenir le type.
 
 ## Description
 
-Le tableau qui suit liste les résultats possibles de l'opérateur `typeof`. Pour plus d'informations sur les types et valeurs primitives en JavaScript, voir la page sur [les types et structures de données JavaScript](/fr/docs/Web/JavaScript/Structures_de_données#Les_valeurs_primitives).
+Le tableau qui suit liste les résultats possibles de l'opérateur `typeof`. Pour plus d'informations sur les types et valeurs primitives en JavaScript, voir la page sur [les types et structures de données JavaScript](/fr/docs/Web/JavaScript/Data_structures).
 
-| Type                                                                             | Résultat                                    |
-| -------------------------------------------------------------------------------- | ------------------------------------------- |
-| indéfini                                                                         | `"undefined"`                               |
-| nul                                                                              | `"object" `(voir ci-après)                  |
-| booléen                                                                          | `"boolean"`                                 |
-| nombre                                                                           | `"number"`                                  |
-| grand entier                                                                     | `"bigint"`                                  |
-| chaîne de caractère                                                              | `"string"`                                  |
-| symbole (nouveauté d'ECMAScript 6 / 2015)                                        | `"symbol"`                                  |
-| objet de l'environnement (fourni par l'environnement dans lequel est utilisé JS) | _Résultat différent selon l'implémentation_ |
-| Objet Function (au sens ECMA-262, un objet qui implémente [[Call]])              | `"function"`                                |
-| Tout autre objet                                                                 | `"object"`                                  |
+| Type                                                                                              | Résultat                   |
+| ------------------------------------------------------------------------------------------------- | -------------------------- |
+| [indéfini](/fr/docs/Glossary/undefined)                                                           | `"undefined"`              |
+| [nul](/fr/docs/Glossary/Null)                                                                     | `"object" `(voir ci-après) |
+| [booléen](/fr/docs/Glossary/Boolean)                                                              | `"boolean"`                |
+| [nombre](/fr/docs/Glossary/Number)                                                                | `"number"`                 |
+| [grand entier (nouveauté d'ECMAScript 2020)](/fr/docs/Glossary/BigInt)                            | `"bigint"`                 |
+| [chaîne de caractère](/fr/docs/Glossary/String)                                                   | `"string"`                 |
+| [symbole (nouveauté d'ECMAScript 6 / 2015)](/fr/docs/Glossary/Symbol)                             | `"symbol"`                 |
+| [objet Function (au sens ECMA-262, un objet qui implémente [[Call]])](/fr/docs/Glossary/Function) | `"function"`               |
+| Tout autre objet                                                                                  | `"object"`                 |
 
 ## Exemples
+
+### Usage simple
 
 ```js
 // Pour les nombres
@@ -52,6 +54,8 @@ typeof Math.LN2 === 'number';
 typeof Infinity === 'number';
 typeof NaN === 'number'; // Bien que littéralement ce soit "Not-A-Number"…
 typeof Number('1') === 'number'; // Number essaie de convertir l'argument en nombre
+typeof Number('chaussure') === 'number'; // cela vaut également pour les valeurs qui ne peuvent pas être converties
+
 
 // Grand entier
 typeof 42n === 'bigint';
@@ -59,10 +63,10 @@ typeof 42n === 'bigint';
 // Les chaînes de caractères
 typeof "" === 'string';
 typeof "bla" === 'string';
+typeof `gabarit de chaîne` === 'string';
 typeof "1" === 'string'; // on a ici un nombre écrit sous forme d'une chaîne
 typeof (typeof 1) === 'string'; // typeof renvoie toujours une chaîne
 typeof String(1) === 'string'; // String convertit n'importe quelle valeur en chaîne
-
 
 // Les booléens
 typeof true === 'boolean';
@@ -70,17 +74,15 @@ typeof false === 'boolean';
 typeof Boolean(1) === 'boolean'; // Boolean convertit n'importe quelle valeur en son équivalent logique
 typeof !!(1) === 'boolean'; // deux appels à l'opérateur ! (le NON logique) sont équivalents à Boolean()
 
-
 // Les symboles
 typeof Symbol() === 'symbol'
-typeof Symbol('foo') === 'symbol'
+typeof Symbol('toto') === 'symbol'
 typeof Symbol.iterator === 'symbol'
-
 
 // Indéfini
 typeof undefined === 'undefined';
-typeof blabla === 'undefined'; // pour une variable indéfinie
-
+typeof variableDeclareeMaisIndefinie === 'undefined';
+typeof variableNonDeclaree === 'undefined';
 
 // Les objets
 typeof {a:1} === 'object';
@@ -105,9 +107,7 @@ typeof class C {} === 'function';
 typeof Math.sin === 'function';
 ```
 
-## Informations supplémentaires
-
-### `null`
+### `typeof null`
 
 ```js
 // Cela est valable depuis les commencements de JavaScript
@@ -116,22 +116,22 @@ typeof null === 'object';
 
 Lors de la première implémentation de JavaScript, les valeurs JavaScript étaient représentées avec une étiquette de type et une valeur. Pour les objets, l'étiquette de type était 0. `null` était représenté par la valeur NULL (0x00 pour la plupart des plates-formes). Par conséquent, l'étiquette de type de `null` valait 0, d'où le comportement de `typeof` ([source](https://www.2ality.com/2013/10/typeof-null.html)).
 
-Un correctif fut proposé pour ECMAScript mais il fut [refusé](https://web.archive.org/web/20160331031419/http://wiki.ecmascript.org:80/doku.php?id=harmony:typeof_null). Avec cette version, on aurait eu `typeof null === 'null'`.
+Un correctif fut proposé pour ECMAScript, mais il fut [refusé](https://web.archive.org/web/20160331031419/http://wiki.ecmascript.org:80/doku.php?id=harmony:typeof_null). Avec cette version, on aurait eu `typeof null === 'null'`.
 
 ### Utiliser l'opérateur `new`
 
 ```js
 // Tous les constructeurs doivent être employés
 // avec le mot-clé "new"
-var maChaine = new String("toto");
-var monNombre = new Number(100);
+let maChaine = new String("toto");
+let monNombre = new Number(100);
 
 typeof maChaine;  // renverra "object"
 typeof monNombre; // renverra "object"
 
 // En revanche avec le constructeur Function,
 // on aura :
-var maFonction = new Function();
+let maFonction = new Function();
 typeof maFonction; // renverra "function"
 ```
 
@@ -142,10 +142,10 @@ typeof maFonction; // renverra "function"
 // déterminer le type de données d'une expression
 // complète
 
-var maDonnee = 99;
+let maDonnee = 99;
 
 typeof maDonnee + ' Toto';   // renverra 'number Toto'
-typeof (maDonnee + 'Toto'); // renverra 'string'
+typeof (maDonnee + ' Toto'); // renverra 'string'
 ```
 
 ### Expressions rationnelles
@@ -157,11 +157,11 @@ typeof /s/ === 'function'; // Chrome 1 à 12 : Non conforme à ECMAScript 5.1
 typeof /s/ === 'object';   // À partir de Firefox 5 : Conforme à ECMAScript 5.1
 ```
 
-### Zone morte temporaire (_Temporal Dead Zone_ / TDZ)
+### Erreurs et zone morte temporaire (_Temporal Dead Zone_ / TDZ)
 
 Avant ECMAScript 2015 (ES6), `typeof` retournait toujours une chaîne de caractères, quel que soit l'opérande utilisé. On ne pouvait pas avoir d'erreur en utilisant `typeof`.
 
-Avec l'apparition des opérateurs [`let`](/fr/docs/Web/JavaScript/Reference/Instructions/let) et [`const`](/fr/docs/Web/JavaScript/Reference/Instructions/const), si on utilise `typeof` sur des variables déclarées avec ces opérateurs (ou avec une classe) avant leur déclaration, cela déclenchera une erreur {{jsxref("ReferenceError")}}. Si on utilise `typeof` sur une variable déclarée avec `var` avant la déclaration, cela renverra `undefined`. Les variables déclarées avec `let` et `const` sont en fait placées dans une *[zone morte temporaire ](</fr/docs/Web/JavaScript/Reference/Instructions/let#Zone_morte_temporaire_(Temporal_Dead_Zone_TDZ)_et_les_erreurs_liées_à_let>)*entre le début du bloc et leur initialisation et dans cette zone, tout accès à la variable produit une erreur.
+Avec l'apparition des opérateurs [`let`](/fr/docs/Web/JavaScript/Reference/Statements/let) et [`const`](/fr/docs/Web/JavaScript/Reference/Statements/const), si on utilise `typeof` sur des variables déclarées avec ces opérateurs (ou avec une classe) avant leur déclaration, cela déclenchera une erreur [`ReferenceError`](/fr/docs/Web/JavaScript/Reference/Global_Objects/ReferenceError). Si on utilise `typeof` sur une variable déclarée avec `var` avant la déclaration, cela renverra `undefined`. Les variables déclarées avec `let` et `const` sont en fait placées dans une *[zone morte temporaire ](/fr/docs/Web/JavaScript/Reference/Statements/let)*entre le début du bloc et leur initialisation et dans cette zone, tout accès à la variable produit une erreur.
 
 ```js
 typeof variableGlobaleNonDeclaree === "undefined";
@@ -178,27 +178,20 @@ class maClasse{};
 
 ### Exceptions
 
-Tous les navigateurs actuels exposent un objet non-standard {{domxref("document.all")}} dont le type est `"undefined"`.
+Tous les navigateurs actuels exposent un objet non-standard [`document.all`](/fr/docs/Web/API/document/all) dont le type est `undefined`.
 
 ```js
 typeof document.all === "undefined";
 ```
 
-Bien que la spécification requière que les objets exostiques aient des types différents, ces types doivent être des chaînes différentes des chaînes existantes pour les objets standards. À ce titre, le type de `document.all` représente une violation « volontaire » du standard ECMAScript original.
+Bien que la spécification requière que les objets exotiques aient des types différents, ces types doivent être des chaînes différentes des chaînes existantes pour les objets standards. À ce titre, le type de `document.all` représente une violation « volontaire » du standard ECMAScript original.
 
 ## Spécifications
 
-| Spécification                                                                                | État                         | Commentaires                                          |
-| -------------------------------------------------------------------------------------------- | ---------------------------- | ----------------------------------------------------- |
-| {{SpecName('ESDraft', '#sec-typeof-operator', 'Opérateur typeof')}} | {{Spec2('ESDraft')}} |                                                       |
-| {{SpecName('ES6', '#sec-typeof-operator', 'Opérateur typeof')}}         | {{Spec2('ES6')}}         |                                                       |
-| {{SpecName('ES5.1', '#sec-11.4.3', 'Opérateur typeof')}}                 | {{Spec2('ES5.1')}}     |                                                       |
-| {{SpecName('ES3', '#sec-11.4.3', 'Opérateur typeof')}}                     | {{Spec2('ES3')}}         |                                                       |
-| {{SpecName('ES1', '#sec-11.4.3', 'Opérateur typeof')}}                     | {{Spec2('ES1')}}         | Définition initiale, implémentée avec JavaScript 1.1. |
-
+{{Specifications}}
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.operators.typeof")}}
+{{Compat}}
 
 ## Notes spécifiques à IE
 
@@ -208,8 +201,15 @@ Pour les versions 6, 7 et 8 d'Internet Explorer, les objets de l'environnement h
 typeof alert === 'object'
 ```
 
+Certaines propriétés non-standard d'IE renvoient d'autres valeurs ([tc39/ecma262#1440
+(commentaire)](https://github.com/tc39/ecma262/issues/1440#issuecomment-461963872)):
+
+```js
+typeof window.external.AddSearchProvider === "unknown";
+typeof window.external.IsSearchProviderInstalled === "unknown";
+```
+
 ## Voir aussi
 
-- L'opérateur {{jsxref("Opérateurs/instanceof","instanceof")}}
-- [Discussion es-discuss sur l'évolution de `typeof` avec ECMAScript 2015 et `let`](http://es-discourse.com/t/why-typeof-is-no-longer-safe/15)
+- L'opérateur [`instanceof`](/fr/docs/Web/JavaScript/Reference/Operators/instanceof)
 - [À propos du non-respect volontaire du standard avec le type de `document.all`](https://github.com/tc39/ecma262/issues/668)


### PR DESCRIPTION
Hello,
in console :
var maDonnee = 99;
typeof maDonnee + 'Toto';

prints 'numberToto' // without space