### PR TITLE
[ko] Translation done of 'Tools for analyzing Web Audio usage' document.

### DIFF
--- a/files/ko/web/api/web_audio_api/tools/index.html
+++ b/files/ko/web/api/web_audio_api/tools/index.html
@@ -1,5 +1,5 @@
 ---
-title: Tools for analyzing Web Audio usage
+title: Web Audio 사용을 분석하기 위한 도구들
 slug: Web/API/Web_Audio_API/Tools
 tags:
   - API
@@ -14,28 +14,28 @@ tags:
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
-<p>While working on your Web Audio API code, you may find that you need tools to analyze the graph of nodes you create or to otherwise debug your work. This article discusses tools available to help you do that.</p>
+<p>Web Audio API 코드를 작성하는 중에, 여러분은 여러분이 만든 노드의 그래프를 분석하거나 그게 아니라면 여러분의 작업을 디버그할 도구가 필요하다고 생각했을 지도 모릅니다. 이 글은 여러분을 도울 이용 가능한 도구들에 대해 이야기합니다.</p>
 
 <h2 id="Chrome">Chrome</h2>
 
-<p>A handy web audio inspector can be found in the <a href="https://chrome.google.com/webstore/detail/web-audio-inspector/cmhomipkklckpomafalojobppmmidlgl">Chrome Web Store</a>.</p>
+<p><a href="https://chrome.google.com/webstore/detail/web-audio-inspector/cmhomipkklckpomafalojobppmmidlgl">Chrome Web Store</a>에서 찾을 수 있는 유용한 web audio 검사기.</p>
 
 <h2 id="Edge">Edge</h2>
 
-<p><em>Add information for developers using Microsoft Edge.</em></p>
+<p><em>Microsoft Edge를 사용하는 개발자들을 위한 정보를 추가해 주세요.</em></p>
 
 <h2 id="Firefox">Firefox</h2>
 
-<p>Firefox offers a native <a href="/en-US/docs/Tools/Web_Audio_Editor">Web Audio Editor</a>.</p>
+<p>Firefox는 네이티브 <a href="/en-US/docs/Tools/Web_Audio_Editor">Web Audio 에디터</a>를 제공합니다.</p>
 
 <h2 id="Safari">Safari</h2>
 
-<p><em>Add information for developers working in Safari.</em></p>
+<p><em>Safari에서 작업하는 개발자들을 위한 정보를 추가해 주세요.</em></p>
 
-<h2 id="See_also">See also</h2>
+<h2 id="See_also">같이 보기</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/API/Web_Audio_API">Web Audio API</a></li>
- <li><a href="/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API">Using the Web Audio API</a></li>
- <li><a href="/en-US/docs/Web/Apps/Fundamentals/Audio_and_video_delivery/Web_Audio_API_cross_browser">Writing Web Audio API code that works in every browser</a></li>
+ <li><a href="/ko/docs/Web/API/Web_Audio_API">Web Audio API</a></li>
+ <li><a href="/ko/docs/Web/API/Web_Audio_API/Using_Web_Audio_API">Web Audio API 사용하기</a></li>
+ <li><a href="/ko/docs/Web/Guide/Audio_and_video_delivery/Web_Audio_API_cross_browser">모든 브라우저에서 작동하는 Web Audio API 코드 작성하기</a></li>
 </ul>


### PR DESCRIPTION
https://developer.mozilla.org/ko/docs/Web/API/Web_Audio_API/Tools
위 문서를 번역하였습니다.

I translated [this document](https://developer.mozilla.org/ko/docs/Web/API/Web_Audio_API/Tools) into Korean.

※ 영문판은 .md인데 본 pr은 .html인 이유: https://github.com/mdn/translated-content/pull/1609#issuecomment-894433453 md로 업데이트되기 전에 제가 html을 ko폴더로 옮겼기 때문입니다. 단, 어차피 내용은 똑같으므로 문제는 없을 것으로 사료됩니다.