### PR TITLE
[ko] Translation done of 'Migrating from webkitAudioContext' document

### DIFF
--- a/files/ko/web/api/web_audio_api/migrating_from_webkitaudiocontext/index.html
+++ b/files/ko/web/api/web_audio_api/migrating_from_webkitaudiocontext/index.html
@@ -1,5 +1,5 @@
 ---
-title: Migrating from webkitAudioContext
+title: webkitAudioContext에서 이주하기
 slug: Web/API/Web_Audio_API/Migrating_from_webkitAudioContext
 tags:
   - API
@@ -12,49 +12,49 @@ tags:
   - porting
   - webkitAudioContext
 ---
-<p>The Web Audio API went through many iterations before reaching its current state. It was first implemented in WebKit, and some of its older parts were not immediately removed as they were replaced in the specification, leading to many sites using non-compatible code. <span class="seoSummary">In this article, we cover the differences in Web Audio API since it was first implemented in WebKit and how to update your code to use the modern Web Audio API.</span></p>
+<p>Web Audio API는 현 상태에 이르기까지 많은 반복을 거쳤습니다. 이것은 처음에 WebKit에서 구현되었고, 이것의 낡은 부분들의 일부는 그것들이 명세에서 대체되는 동안 즉시 제거되지 않았는데, 이는 많은 사이트들이 비호환되는 코드를 사용하는 것으로 이어졌습니다. <span class="seoSummary">이 글에서, 우리는 Web Audio API가 WebKit에서 처음 구현된 이후로의 Web Audio API에서의 차이를 다루고 현대 Web Audio API를 사용하기 위해 어떻게 코드를 업데이트해야 되는지를 다룹니다.</span></p>
 
-<p>The Web Audio standard was first implemented in <a href="http://webkit.org/">WebKit</a>, and the implementation was built in parallel with the work on the <a href="https://dvcs.w3.org/hg/audio/raw-file/tip/webaudio/specification.html">specification</a> of the API. As the specification evolved and changes were made to the spec, some of the old implementation pieces were not removed from the WebKit (and Blink) implementations due to backwards compatibility reasons.</p>
+<p>Web Audio 표준은 <a href="https://webkit.org/">WebKit</a>에서 처음 구현되었고, 이 구현은 API의 <a href="https://dvcs.w3.org/hg/audio/raw-file/tip/webaudio/specification.html">명세</a>에서의 작업과 동시에 개발되었습니다. 명세가 진화하고 변화가 만들어짐에 따라, 낡은 구현 부분들 중 일부는 이전 호환성의 이유에 기인해 WebKit (그리고 Blink) 구현에서 제거되지 않았습니다.</p>
 
-<p>New engines implementing the Web Audio spec (such as Gecko) will only implement the official, final version of the specification, which means that code using <code>webkitAudioContext</code> or old naming conventions in the Web Audio specification may not immediately work out of the box in a compliant Web Audio implementation.  This article attempts to summarize the areas where developers are likely to encounter these problems and provide examples on how to port such code to standards based {{domxref("AudioContext")}}, which will work across different browser engines.</p>
+<p>Web Audio 명세를 구현하는 (Gecko와 같은) 새로운 엔진들은 오직 명세의 공식, 최종 버전만을 구현하는데, 이것이 의미하는 바는 <code>webkitAudioContext</code>나 Web Audio 명세에서의 오래된 명명 규칙을 사용하는 코드는 Web Audio 구현을 따르는 것에서 별도의 조작 없이 즉시 작동하지 않을지도 모른다는 것입니다. 이 글은 개발자들이 이런 문제들을 만날 가능성이 있는 영역들을 요약하기를 시도하고 어떻게 그런 코드를 각각 다른 브라우저 엔진들에서 작동할 {{domxref("AudioContext")}}에 기반한 표준으로 이동할지에 대한 예제들을 제공합니다.</p>
 
 <div class="note">
-<p><strong>Note</strong>: There is a library called <a href="https://github.com/cwilso/webkitAudioContext-MonkeyPatch">webkitAudioContext monkeypatch</a>, which automatically fixes some of these changes to make most code targeting <code>webkitAudioContext</code> to work on the standards based <code>AudioContext</code> out of the box, but it currently doesn't handle all of the cases below.  Please consult the <a href="https://github.com/cwilso/webkitAudioContext-MonkeyPatch/blob/gh-pages/README.md">README file</a> for that library to see a list of APIs that are automatically handled by it.</p>
+<p><strong>참고</strong>: <a href="https://github.com/cwilso/webkitAudioContext-MonkeyPatch">webkitAudioContext monkeypatch</a>라 불리는 라이브러리가 있는데, 이는 <code>webkitAudioContext</code>를 겨냥하는 대부분의 코드를 별도의 조작 없이 <code>AudioContext</code>에 기반한 표준에서 작동하게 만들기 위해 이 변화들 중 일부를 자동적으로 수정하지만, 이것은 현재 아래의 모든 경우들을 다루지 않고 있습니다. 이것에 의해 자동적으로 다뤄지는 API들의 목록을 보기 위해서는 이 라이브러리의 <a href="https://github.com/cwilso/webkitAudioContext-MonkeyPatch/blob/gh-pages/README.md">README 파일</a>을 참고해 보세요.</p>
 </div>
 
-<h2 id="Changes_to_the_creator_methods">Changes to the creator methods</h2>
+<h2 id="Changes_to_the_creator_methods">생성자 메서드에서의 변화</h2>
 
-<p>Three of the creator methods on <code>webkitAudioContext</code> have been renamed in {{domxref("AudioContext")}}.</p>
+<p><code>webkitAudioContext</code>의 세 가지 생성자 메서드가 {{domxref("AudioContext")}}에서 재명명되었습니다.</p>
 
 <ul>
- <li><code>createGainNode()</code> has been renamed to {{domxref("createGain")}}.</li>
- <li><code>createDelayNode()</code> has been renamed to {{domxref("createDelay")}}.</li>
- <li><code>createJavaScriptNode()</code> has been renamed to {{domxref("createScriptProcessor")}}.</li>
+ <li><code>createGainNode()</code>는 {{domxref("createGain")}}으로 바뀌었습니다.</li>
+ <li><code>createDelayNode()</code>는 {{domxref("createDelay")}}로 바뀌었습니다.</li>
+ <li><code>createJavaScriptNode()</code>는 {{domxref("createScriptProcessor")}}로 바뀌었습니다.</li>
 </ul>
 
-<p>These are simple renames that were made in order to improve the consistency of these method names on {{domxref("AudioContext")}}.  If your code uses either of these names, like in the example below :</p>
+<p>이것들은 {{domxref("AudioContext")}}에서 이 메서드명들의 일관성을 개선시키기 위해 만들어진 단순한 개명입니다. 만약 여러분의 코드가, 아래의 예시처럼 이 이름중에 어느 것이라도 사용하고 있다면:</p>
 
-<pre class="brush: js">// Old method names
+<pre class="brush: js">// 오래된 메서드명들
 var gain = context.createGainNode();
 var delay = context.createDelayNode();
 var js = context.createJavascriptNode(1024);
 </pre>
 
-<p>you can rename the methods to look like this:</p>
+<p>여러분은 다음과 같이 보이도록 메서드의 이름을 변경할 수 있습니다:</p>
 
-<pre class="brush: js">// New method names
+<pre class="brush: js">// 새로운 메서드명들
 var gain = context.createGain();
 var delay = context.createDelay();
 var js = context.createScriptProcessor(1024);
 </pre>
 
-<p>The semantics of these methods remain the same in the renamed versions.</p>
+<p>이 메서드명들의 의미는 새로 이름붙혀진 버전에서도 동일합니다.</p>
 
-<h2 id="Changes_to_starting_and_stopping_nodes">Changes to starting and stopping nodes</h2>
+<h2 id="Changes_to_starting_and_stopping_nodes">노드를 시작하고 멈추는 것에 대한 변화</h2>
 
-<p>In <code>webkitAudioContext</code>, there are two ways to start and stop {{domxref("AudioBufferSourceNode")}} and {{domxref("OscillatorNode")}}: the <code>noteOn()</code> and <code>noteOff()</code> methods, and the <code>start()</code> and <code>stop()</code> methods.  ({{domxref("AudioBufferSourceNode ")}}has yet another way of starting output: the <code>noteGrainOn()</code> method.)  The <code>noteOn()</code>/<code>noteGrainOn()</code>/<code>noteOff()</code> methods were the original way to start/stop output in these nodes, and in the newer versions of the specification, the <code>noteOn()</code> and <code>noteGrainOn()</code> methods were consolidated into a single <code>start()</code> method, and the <code>noteOff()</code> method was renamed to the <code>stop()</code> method.</p>
+<p><code>webkitAudioContext</code>에서, {{domxref("AudioBufferSourceNode")}}와 {{domxref("OscillatorNode")}}를 시작하거나 멈추는 두 가지 방법이 있습니다: <code>noteOn()</code>과 <code>noteOff()</code> 메서드와, <code>start()</code>와 <code>stop()</code> 메서드입니다. ({{domxref("AudioBufferSourceNode ")}}는 아직 출력을 시작하는 다른 방법을 가지고 있습니다: <code>noteGrainOn()</code> 메서드입니다.) <code>noteOn()</code>/<code>noteGrainOn()</code>/<code>noteOff()</code> 메서드는 이 노드들에서 출력을 시작/정지하는 원래의 방법이었으나, 명세의 새로운 버전에서 <code>noteOn()</code>과 <code>noteGrainOn()</code> 메서드는 하나의 <code>start()</code> 메서드로 통합되었고, <code>noteOff()</code> 메서드는 <code>stop()</code> 메서드로 이름이 바뀌었습니다.</p>
 
-<p>In order to port your code, you can just rename the method that you're using.  For example, if you have code like the below:</p>
+<p>여러분의 코드를 변경하기 위해서는, 여러분은 단지 사용한 메서드의 이름만 변경하시면 됩니다. 예를 들어, 만약 여러분이 아래와 같은 코드를 가지고 있다면:</p>
 
 <pre class="brush: js">var osc = context.createOscillator();
 osc.noteOn(1);
@@ -65,7 +65,7 @@ src.noteGrainOn(1, 0.25);
 src.noteOff(2);
 </pre>
 
-<p>you can change it like this in order to port it to the standard AudioContext API:</p>
+<p>표준 AudioContext API로 변경하기 위해서 다음과 같이 변경할 수 있습니다:</p>
 
 <pre class="brush: js">var osc = context.createOscillator();
 osc.start(1);
@@ -75,13 +75,13 @@ var src = context.createBufferSource();
 src.start(1, 0.25);
 src.stop(2);</pre>
 
-<h2 id="Remove_synchronous_buffer_creation">Remove synchronous buffer creation</h2>
+<h2 id="Remove_synchronous_buffer_creation">동기 버퍼 생성 제거</h2>
 
-<p>In the old WebKit implementation of Web Audio, there were two versions of <code>createBuffer()</code>, one which created an initially empty buffer, and one which took an existing {{domxref("ArrayBuffer")}} containing encoded audio, decoded it and returned the result in the form of an {{domxref("AudioBuffer")}}.  The latter version of <code>createBuffer()</code> was potentially expensive, because it had to decode the audio buffer synchronously, and with the buffer being arbitrarily large, it could take a lot of time for this method to complete its work, and no other part of your web page's code could execute in the mean time.</p>
+<p>Web Audio의 오래된 WebKit 구현에서, <code>createBuffer()</code>의 두 가지 버전이 있었는데, 하나는 초기적으로 빈 버퍼를 생성했고, 하나는 인코드된 오디오를 포함하고 있는 존재하는 {{domxref("ArrayBuffer")}}를 취해, 그것을 디코드해 {{domxref("AudioBuffer")}}의 형태로 결과를 반환했습니다. <code>createBuffer()</code>의 후기 버전은 잠재적으로 비용이 많이 들었는데, 왜냐하면 이것은 오디오 버퍼를 동기적으로 디코드하고, 버퍼가 임의적으로 큰 채로, 이 메서드가 작업을 완료하는 데 많은 시간을 취할 수 있었고, 그 동안 웹 페이지의 어떤 다른 부분의 코드도 실행될 수 없었기 때문입니다.</p>
 
-<p>Because of these problems, this version of the <code>createBuffer()</code> method has been removed, and you should use the asynchronous <code>decodeAudioData()</code> method instead.</p>
+<p>이런 문제들 때문에, <code>createBuffer()</code> 메서드의 이 버전은 제거되었고, 여러분은 대신 비동기적 <code>decodeAudioData()</code> 메서드를 사용해야 합니다.</p>
 
-<p>The example below shows old code which downloads an audio file over the network, and then decoded it using <code>createBuffer()</code>:</p>
+<p>아래의 예제는 네트워크를 통해 오디오 파일을 다운로드받고, <code>createBuffer()</code>를 사용해 그것을 디코드하는 낡은 코드를 보여줍니다.</p>
 
 <pre class="brush: js">var xhr = new XMLHttpRequest();
 xhr.open("GET", "/path/to/audio.ogg", true);
@@ -90,14 +90,14 @@ xhr.send();
 xhr.onload = function() {
   var decodedBuffer = context.createBuffer(xhr.response, false);
   if (decodedBuffer) {
-    // Decoding was successful, do something useful with the audio buffer
+    // 디코딩은 성공적이었습니다, 오디오 버퍼로 무언가 유용한 걸 하십시오
   } else {
-    alert("Decoding the audio buffer failed");
+    alert("오디오 버퍼 디코딩 실패");
   }
 };
 </pre>
 
-<p>Converting this code to use <code>decodeAudioData()</code> is relatively simple, as can be seen below:</p>
+<p>아래에서 보이는 것처럼, <code>decodeAudioData()</code>를 사용하기 위해 이 코드를 전환하는 것은 비교적 단순합니다:</p>
 
 <pre class="brush: js">var xhr = new XMLHttpRequest();
 xhr.open("GET", "/path/to/audio.ogg", true);
@@ -105,130 +105,130 @@ xhr.responseType = "arraybuffer";
 xhr.send();
 xhr.onload = function() {
   context.decodeAudioData(xhr.response, function onSuccess(decodedBuffer) {
-    // Decoding was successful, do something useful with the audio buffer
+    // 디코딩은 성공적이었습니다, 오디오 버퍼로 무언가 유용한 걸 하십시오
   }, function onFailure() {
-    alert("Decoding the audio buffer failed");
+    alert("오디오 버퍼 디코딩 실패");
   });
 };</pre>
 
-<p>Note that the <code>decodeAudioData()</code> method is asynchronous, which means that it will return immediately, and then when the decoding finishes, one of the success or failure callback functions will get called depending on whether the audio decoding was successful.  This means that you may need to restructure your code to run the part which happened after the <code>createBuffer()</code> call in the success callback, as you can see in the example above.</p>
+<p><code>decodeAudioData()</code> 메서드는 비동기적인데, 이는 이것이 즉시 반환할 것이고, 디코딩이 끝나면, 성공 혹은 실패 콜백 함수 중 하나가 오디오 디코딩이 성공적이었느냐에 따라 호출될 것임을 의미한다는 것에 주목하십시오. 위의 예제에서 보이다시피, 성공 콜백에서의 <code>createBuffer()</code> 호출 이후에 발생되는 부분을 실행하기 위해 여러분은 코드를 재구조화할 필요가 있을 지도 모릅니다.</p>
 
-<h2 id="Renaming_of_AudioParam.setTargetValueAtTime">Renaming of AudioParam.setTargetValueAtTime</h2>
+<h2 id="Renaming_of_AudioParam.setTargetValueAtTime">AudioParam.setTargetValueAtTime의 재명명</h2>
 
-<p>The <code>setTargetValueAtTime()</code> method on the {{domxref("AudioParam")}} interface has been renamed to <code>setTargetAtTime()</code>.  This is also a simple rename to improve the understandability of the API, and the semantics of the method are the same.  If your code is using <code>setTargetValueAtTime()</code>, you can rename it to use <code>setTargetAtTime()</code>. For example, if we have code that looks like this:</p>
+<p>{{domxref("AudioParam")}} 인터페이스의 <code>setTargetValueAtTime()</code> 메서드는 <code>setTargetAtTime()</code>으로 이름이 바뀌었습니다. 이것은 또한 API의 이해성을 개선하기 위한 단순한 개명이고, 메서드의 의미는 동일합니다. 만약 여러분의 코드가 <code>setTargetValueAtTime()</code>를 사용하고 있다면, <code>setTargetAtTime()</code>으로 이름을 바꿀 수 있습니다. 예를 들자면, 만약 우리가 다음과 같은 코드를 가지고 있다면:</p>
 
 <pre class="brush: js">  var gainNode = context.createGain();
   gainNode.gain.setTargetValueAtTime(0.0, 10.0, 1.0);
 </pre>
 
-<p>you can rename the method, and be compliant with the standard, like so:</p>
+<p>다음과 같이, 여러분은 메서드의 이름을 바꿀 수 있고, 표준을 따를 수 있습니다:</p>
 
 <pre class="brush: js">  var gainNode = context.createGain();
   gainNode.gain.setTargetAtTime(0.0, 10.0, 1.0);
 </pre>
 
-<h2 id="Enumerated_values_that_changed">Enumerated values that changed</h2>
+<h2 id="Enumerated_values_that_changed">변경된 열거형 값들</h2>
 
-<p>The original <code>webkitAudioContext</code> API used C-style number based enumerated values in the API.  Those values have since been changed to use the Web IDL based enumerated values, which should be familiar because they are similar to things like the {{domxref("HTMLInputElement")}} property {{domxref("HTMLInputElement.type", "type")}}.</p>
+<p>원래의 <code>webkitAudioContext</code> API는 C-스타일 숫자 기반의 열거형 값들을 API에서 사용했습니다. 이 값들은 Web IDL 기반의 열거형 값들을 사용하는 것으로 변경되었는데, 이것들은 {{domxref("HTMLInputElement")}} 속성 {{domxref("HTMLInputElement.type", "type")}}과 같은 것들과 비슷하기 때문에 친숙할지도 모릅니다.</p>
 
 <h3 id="OscillatorNode.type">OscillatorNode.type</h3>
 
-<p>{{domxref("OscillatorNode")}}'s type property has been changed to use Web IDL enums.  Old code using <code>webkitAudioContext</code> can be ported to standards based {{domxref("AudioContext")}} like below:</p>
+<p>{{domxref("OscillatorNode")}}의 type 속성은 Web IDL 열거형을 사용하는 것으로 변경되었습니다. <code>webkitAudioContext</code>를 사용하는 오래된 코드는 아래처럼 {{domxref("AudioContext")}} 기반의 표준으로 변경될 수 있습니다:</p>
 
-<pre class="brush: js">// Old webkitAudioContext code:
+<pre class="brush: js">// 오래된 webkitAudioContext 코드:
 var osc = context.createOscillator();
-osc.type = osc.SINE;     // sine waveform
-osc.type = osc.SQUARE;   // square waveform
-osc.type = osc.SAWTOOTH; // sawtooth waveform
-osc.type = osc.TRIANGLE; // triangle waveform
+osc.type = osc.SINE;     // sine 파형
+osc.type = osc.SQUARE;   // square 파형
+osc.type = osc.SAWTOOTH; // sawtooth 파형
+osc.type = osc.TRIANGLE; // triangle 파형
 osc.setWaveTable(table);
-var isCustom = (osc.type == osc.CUSTOM); // isCustom will be true
+var isCustom = (osc.type == osc.CUSTOM); // isCustom은 true일 것입니다
 
-// New standard AudioContext code:
+// 새로운 표준 AudioContext 코드:
 var osc = context.createOscillator();
-osc.type = "sine";       // sine waveform
-osc.type = "square";     // square waveform
-osc.type = "sawtooth";   // sawtooth waveform
-osc.type = "triangle";   // triangle waveform
-osc.setPeriodicWave(table);  // Note: setWaveTable has been renamed to setPeriodicWave!
-var isCustom = (osc.type == "custom"); // isCustom will be true
+osc.type = "sine";       // sine 파형
+osc.type = "square";     // square 파형
+osc.type = "sawtooth";   // sawtooth 파형
+osc.type = "triangle";   // triangle 파형
+osc.setPeriodicWave(table);  // 참고: setWaveTable은 setPeriodicWave로 이름이 바뀌었습니다!
+var isCustom = (osc.type == "custom"); // isCustom은 true일 것입니다
 </pre>
 
 <h3 id="BiquadFilterNode.type">BiquadFilterNode.type</h3>
 
-<p>{{domxref("BiquadFilterNode")}}'s type property has been changed to use Web IDL enums.  Old code using <code>webkitAudioContext</code> can be ported to standards based {{domxref("AudioContext")}} like below:</p>
+<p>{{domxref("BiquadFilterNode")}}의 type 속성은 Web IDL 열거형을 사용하는 것으로 변경되었습니다. <code>webkitAudioContext</code>를 사용하는 오래된 코드는 아래처럼 {{domxref("AudioContext")}} 기반의 표준으로 변경될 수 있습니다.</p>
 
-<pre class="brush: js">// Old webkitAudioContext code:
+<pre class="brush: js">// 오래된 webkitAudioContext 코드:
 var filter = context.createBiquadFilter();
-filter.type = filter.LOWPASS;   // lowpass filter
-filter.type = filter.HIGHPASS;  // highpass filter
-filter.type = filter.BANDPASS;  // bandpass filter
-filter.type = filter.LOWSHELF;  // lowshelf filter
-filter.type = filter.HIGHSHELF; // highshelf filter
-filter.type = filter.PEAKING;   // peaking filter
-filter.type = filter.NOTCH;     // notch filter
-filter.type = filter.ALLPASS;   // allpass filter
+filter.type = filter.LOWPASS;   // lowpass 필터
+filter.type = filter.HIGHPASS;  // highpass 필터
+filter.type = filter.BANDPASS;  // bandpass 필터
+filter.type = filter.LOWSHELF;  // lowshelf 필터
+filter.type = filter.HIGHSHELF; // highshelf 필터
+filter.type = filter.PEAKING;   // peaking 필터
+filter.type = filter.NOTCH;     // notch 필터
+filter.type = filter.ALLPASS;   // allpass 필터
 
-// New standard AudioContext code:
+// 새로운 표준 AudioContext 코드:
 var filter = context.createBiquadFilter();
-filter.type = "lowpass";        // lowpass filter
-filter.type = "highpass";       // highpass filter
-filter.type = "bandpass";       // bandpass filter
-filter.type = "lowshelf";       // lowshelf filter
-filter.type = "highshelf";      // highshelf filter
-filter.type = "peaking";        // peaking filter
-filter.type = "notch";          // notch filter
-filter.type = "allpass";        // allpass filter
+filter.type = "lowpass";        // lowpass 필터
+filter.type = "highpass";       // highpass 필터
+filter.type = "bandpass";       // bandpass 필터
+filter.type = "lowshelf";       // lowshelf 필터
+filter.type = "highshelf";      // highshelf 필터
+filter.type = "peaking";        // peaking 필터
+filter.type = "notch";          // notch 필터
+filter.type = "allpass";        // allpass 필터
 </pre>
 
 <h3 id="PannerNode.panningModel">PannerNode.panningModel</h3>
 
-<p>{{domxref("PannerNode")}}'s panningModel property has been changed to use Web IDL enums.  Old code using <code>webkitAudioContext</code> can be ported to standards based {{domxref("AudioContext")}} like below:</p>
+<p>{{domxref("PannerNode")}}의 panningModel 속성은 Web IDL 열거형을 사용하는 것으로 변경되었습니다. <code>webkitAudioContext</code>를 사용하는 오래된 코드는 아래처럼 {{domxref("AudioContext")}} 기반의 표준으로 변경될 수 있습니다:</p>
 
-<pre class="brush: js">// Old webkitAudioContext code:
+<pre class="brush: js">// 오래된 webkitAudioContext 코드:
 var panner = context.createPanner();
-panner.panningModel = panner.EQUALPOWER;  // equalpower panning
-panner.panningModel = panner.HRTF;        // HRTF panning
+panner.panningModel = panner.EQUALPOWER;  // equalpower 패닝
+panner.panningModel = panner.HRTF;        // HRTF 패닝
 
 // New standard AudioContext code:
 var panner = context.createPanner();
-panner.panningModel = "equalpower";       // equalpower panning
-panner.panningModel = "HRTF";             // HRTF panning
+panner.panningModel = "equalpower";       // equalpower 패닝
+panner.panningModel = "HRTF";             // HRTF 패닝
 </pre>
 
 <h3 id="PannerNode.distanceModel">PannerNode.distanceModel</h3>
 
-<p>{{domxref("PannerNode")}}'s <code>distanceModel</code> property has been changed to use Web IDL enums.  Old code using <code>webkitAudioContext</code> can be ported to standards based {{domxref("AudioContext")}} like below:</p>
+<p>{{domxref("PannerNode")}}의 <code>distanceModel</code> 속성은 Web IDL 열거형을 사용하는 것으로 변경되었습니다. <code>webkitAudioContext</code>를 사용하는 오래된 코드는 아래와 같이 {{domxref("AudioContext")}} 기반의 표준으로 변경될 수 있습니다:</p>
 
-<pre class="brush: js">// Old webkitAudioContext code:
+<pre class="brush: js">// 오래된 webkitAudioContext 코드:
 var panner = context.createPanner();
-panner.distanceModel = panner.LINEAR_DISTANCE;      // linear distance model
-panner.distanceModel = panner.INVERSE_DISTANCE;     // inverse distance model
-panner.distanceModel = panner.EXPONENTIAL_DISTANCE; // exponential distance model
+panner.distanceModel = panner.LINEAR_DISTANCE;      // linear distance 모델
+panner.distanceModel = panner.INVERSE_DISTANCE;     // inverse distance 모델
+panner.distanceModel = panner.EXPONENTIAL_DISTANCE; // exponential distance 모델
 
-// Mew standard AudioContext code:
+// 새로운 표준 AudioContext 코드:
 var panner = context.createPanner();
-panner.distanceModel = "linear";                    // linear distance model
-panner.distanceModel = "inverse";                   // inverse distance model
-panner.distanceModel = "exponential";               // exponential distance model
+panner.distanceModel = "linear";                    // linear distance 모델
+panner.distanceModel = "inverse";                   // inverse distance 모델
+panner.distanceModel = "exponential";               // exponential distance 모델
 </pre>
 
-<h2 id="Gain_control_moved_to_its_own_node_type">Gain control moved to its own node type</h2>
+<h2 id="Gain_control_moved_to_its_own_node_type">Gain 제어는 이것만의 노드 유형으로 이동됨</h2>
 
-<p>The Web Audio standard now controls all gain using the {{domxref("GainNode")}}. Instead of setting a <code>gain</code> property directly on an audio source, you connect the source to a gain node and then control the gain using that node's <code>gain</code> parameter.</p>
+<p>Web Audio 표준은 이제 모든 gain을 {{domxref("GainNode")}}를 사용하여 제어합니다. <code>gain</code> 속성을 직접 음원에 설정하는 대신, 여러분은 소스를 gain 노드에 연결하고 이 노드의 <code>gain</code> 매개변수를 사용하여 gain을 제어합니다.</p>
 
 <h3 id="AudioBufferSourceNode">AudioBufferSourceNode</h3>
 
-<p>The <code>gain</code> attribute of {{domxref("AudioBufferSourceNode")}} has been removed.  The same functionality can be achieved by connecting the {{domxref("AudioBufferSourceNode")}} to a gain node.  See the following example:</p>
+<p>{{domxref("AudioBufferSourceNode")}}의 <code>gain</code> 특성은 제거되었습니다. 같은 기능은 {{domxref("AudioBufferSourceNode")}}를 gain 노드에 연결함으로써 달성될 수 있습니다. 아래의 예제를 참고하세요:</p>
 
-<pre class="brush: js">// Old webkitAudioContext code:
+<pre class="brush: js">// 오래된 webkitAudioContext 코드:
 var src = context.createBufferSource();
 src.buffer = someBuffer;
 src.gain.value = 0.5;
 src.connect(context.destination);
 src.noteOn(0);
 
-// New standard AudioContext code:
+// 새로운 표준 AudioContext 코드:
 var src = context.createBufferSource();
 src.buffer = someBuffer;
 var gain = context.createGain();
@@ -240,16 +240,16 @@ src.start(0);
 
 <h3 id="AudioBuffer">AudioBuffer</h3>
 
-<p>The <code>gain</code> attribute of {{domxref("AudioBuffer")}} has been removed.  The same functionality can be achieved by connecting the {{domxref("AudioBufferSourceNode")}} that owns the buffer to a gain node.  See the following example:</p>
+<p>{{domxref("AudioBuffer")}}의 <code>gain</code> 특성은 제거되었습니다. 같은 기능은 버퍼를 소유한 {{domxref("AudioBufferSourceNode")}}를 gain 노드에 연결함으로써 달성될 수 있습니다. 아래의 예제를 참고하세요:</p>
 
-<pre class="brush: js">// Old webkitAudioContext code:
+<pre class="brush: js">// 오래된 webkitAudioContext 코드:
 var src = context.createBufferSource();
 src.buffer = someBuffer;
 src.buffer.gain = 0.5;
 src.connect(context.destination);
 src.noteOn(0);
 
-// New standard AudioContext code:
+// 새로운 표준 AudioContext 코드:
 var src = context.createBufferSource();
 src.buffer = someBuffer;
 var gain = context.createGain();
@@ -259,39 +259,39 @@ gain.connect(context.destination);
 src.start(0);
 </pre>
 
-<h2 id="Removal_of_AudioBufferSourceNode.looping">Removal of AudioBufferSourceNode.looping</h2>
+<h2 id="Removal_of_AudioBufferSourceNode.looping">AudioBufferSourceNode.looping의 제거</h2>
 
-<p>The <code>looping</code> attribute of {{domxref("AudioBufferSourceNode")}} has been removed.  This attribute was an alias of the <code>loop</code> attribute, so you can just use the <code>loop</code> attribute instead. Instead of having code like this:</p>
+<p>{{domxref("AudioBufferSourceNode")}}의 <code>looping</code> 특성은 제거되었습니다. 이 특성은 <code>loop</code> 특성의 별명이어서, 여러분은 단지 <code>loop</code> 특성을 대신 사용할 수 있습니다. 이것과 같은 코드를 가지는 대신:</p>
 
 <pre class="brush: js">var source = context.createBufferSource();
 source.looping = true;
 </pre>
 
-<p>you can change it to respect the last version of the specification:</p>
+<p>명세의 최근 버전을 준수하기 위해 여러분은 이것을 변경할 수 있습니다:</p>
 
 <pre class="brush: js">var source = context.createBufferSource();
 source.loop = true;
 </pre>
 
-<p>Note, the <code>loopStart</code> and <code>loopEnd</code> attributes are not supported in <code>webkitAudioContext</code>.</p>
+<p>참고: <code>loopStart</code>와 <code>loopEnd</code> 특성은 <code>webkitAudioContext</code>에서 지원되지 않습니다.</p>
 
-<h2 id="Changes_to_determining_playback_state">Changes to determining playback state</h2>
+<h2 id="Changes_to_determining_playback_state">재생 상태 결정에 대한 변화</h2>
 
-<p>The <code>playbackState</code> attribute of {{domxref("AudioBufferSourceNode")}} and {{domxref("OscillatorNode")}} has been removed.  Depending on why you used this attribute, you can use the following techniques to get the same information:</p>
+<p>{{domxref("AudioBufferSourceNode")}}와 {{domxref("OscillatorNode")}}의 <code>playbackState</code> 특성은 제거되었습니다. 여러분이 이 특성을 사용하는 이유에 따라, 여러분은 같은 정보를 얻기 위해 다음의 기법들을 사용할 수 있습니다.</p>
 
 <ul>
- <li>If you need to compare this attribute to <code>UNSCHEDULED_STATE</code>, you can basically remember whether you've called <code>start()</code> on the node or not.</li>
- <li>If you need to compare this attribute to <code>SCHEDULED_STATE</code>, you can basically remember whether you've called <code>start()</code> on the node or not.  You can compare the value of {{domxref("AudioContext.currentTime")}} to the first argument passed to <code>start()</code> to know whether playback has started or not.</li>
- <li>If you need to compare this attribute to <code>PLAYING_STATE</code>, you can compare the value of {{domxref("AudioContext.currentTime")}} to the first argument passed to <code>start()</code> to know whether playback has started or not.</li>
- <li>If you need to know when playback of the node is finished (which is the most significant use case of <code>playbackState</code>), there is a new ended event which you can use to know when playback is finished.  Please see this code example:</li>
+ <li>만약 여러분이 이 특성을 <code>UNSCHEDULED_STATE</code>과 비교할 필요가 있다면, 여러분은 기본적으로 여러분이 노드의 <code>start()</code>를 호출했는지 아닌지를 기억할 수 있습니다.</li>
+ <li>만약 여러분이 이 특성을 <code>SCHEDULED_STATE</code>와 비교할 필요가 있다면, 여러분은 기본적으로 여러분이 노드의 <code>start()</code>를 호출했는지 아닌지를 기억할 수 있습니다. 재생이 시작되었는지 아닌지를 알기 위해 여러분은 {{domxref("AudioContext.currentTime")}}의 값을 <code>start()</code>에 전달된 첫번째 매개변수와 비교할 수 있습니다.</li>
+ <li>만약 여러분이 이 특성을 <code>PLAYING_STATE</code>와 비교할 필요가 있다면, 재생이 시작되었는지 아닌지를 알기 위해 여러분은 {{domxref("AudioContext.currentTime")}}의 값을 <code>start()</code>에 전달된 첫번째 매개변수와 비교할 수 있습니다.</li>
+ <li>만약 여러분이 언제 노드의 재생이 끝나는지를 알 필요가 있다면 (이는 <code>playbackState</code>의 가장 중요한 사용 경우입니다), 여러분이 언제 재생이 끝나는지를 알기 위해 사용할 수 있는 새로운 ended 이벤트가 있습니다. 다음의 코드 예제를 봐 주세요:</li>
 </ul>
 
-<pre class="brush: js">// Old webkitAudioContext code:
+<pre class="brush: js">// 오래된 webkitAudioContext 코드:
 var src = context.createBufferSource();
-// Some time later...
+// 얼마 후...
 var isFinished = (src.playbackState == src.FINISHED_STATE);
 
-// New AudioContext code:
+// 새로운 AudioContext 코드:
 var src = context.createBufferSource();
 function endedHandler(event) {
   isFinished = true;
@@ -300,32 +300,32 @@ var isFinished = false;
 src.onended = endedHandler;
 </pre>
 
-<p>The exact same changes have been applied to both {{domxref("AudioBufferSourceNode")}} and {{domxref("OscillatorNode")}}, so you can apply the same techniques to both kinds of nodes.</p>
+<p>정확히 같은 변화가 {{domxref("AudioBufferSourceNode")}}와 {{domxref("OscillatorNode")}} 모두에 적용되었으므로, 여러분은 같은 기법을 두 종류의 노드에 적용할 수 있습니다.</p>
 
-<h2 id="Removal_of_AudioContext.activeSourceCount">Removal of AudioContext.activeSourceCount</h2>
+<h2 id="Removal_of_AudioContext.activeSourceCount">AudioContext.activeSourceCount의 제거</h2>
 
-<p>The <code>activeSourceCount</code> attribute has been removed from {{domxref("AudioContext")}}.  If you need to count the number of playing source nodes, you can maintain the count by handling the ended event on the source nodes, as shown above.</p>
+<p><code>activeSourceCount</code> 특성이 {{domxref("AudioContext")}}에서 제거되었습니다. 만약 여러분이 재생되고 있는 소스 노드의 수를 셀 필요가 있다면, 여러분은 위에서 보이는 것처럼, 소스 노드들의 ended 이벤트를 다룸으로써 카운트를 유지할 수 있습니다.</p>
 
-<p>Code using the <code>activeSourceCount</code> attribute of the {{domxref("AudioContext")}}, like this snippet:</p>
+<p>이 코드처럼, {{domxref("AudioContext")}}의 <code>activeSourceCount</code> 특성을 사용하는 코드:</p>
 
 <pre class="brush: js">  var src0 = context.createBufferSource();
   var src1 = context.createBufferSource();
-  // Set buffers and other parameters...
+  // 버퍼와 다른 매개변수들을 설정합니다...
   src0.start(0);
   src1.start(0);
-  // Some time later...
+  // 얼마 후...
   console.log(context.activeSourceCount);
 </pre>
 
-<p>could be rewritten like that:</p>
+<p>다음과 같이 재작성될 수 있습니다:</p>
 
-<pre class="brush: js">  // Array to track the playing source nodes:
+<pre class="brush: js">  // 재생되고 있는 소스 노드를 추적할 배열:
   var sources = [];
-  // When starting the source, put it at the end of the array,
-  // and set a handler to make sure it gets removed when the
-  // AudioBufferSourceNode reaches its end.
-  // First argument is the AudioBufferSourceNode to start, other arguments are
-  // the argument to the |start()| method of the AudioBufferSourceNode.
+  // 소스를 시작할 때, 이것을 배열의 끝에 넣고,
+  // AudioBufferSourceNode가 끝에 도달했을 때
+  // 이것이 확실히 제거되도록 이벤트 처리기를 설정합니다.
+  // 첫번째 매개변수는 시작할 AudioBufferSourceNode이고,
+  // 다른 매개변수들은 AudioBufferSourceNode의 |start()|에의 매개변수입니다.
   function startSource() {
     var src = arguments[0];
     var startArgs = Array.prototype.slice.call(arguments, 1);
@@ -340,42 +340,42 @@ src.onended = endedHandler;
   }
   var src0 = context.createBufferSource();
   var src0 = context.createBufferSource();
-  // Set buffers and other parameters...
+  // 버퍼와 다른 매개변수들을 설정합니다...
   startSource(src0, 0);
   startSource(src1, 0);
-  // Some time later, query the number of sources...
+  // 얼마 후, 소스의 수를 확인합니다...
   console.log(activeSources());
 </pre>
 
-<h2 id="Renaming_of_WaveTable">Renaming of WaveTable</h2>
+<h2 id="Renaming_of_WaveTable">WaveTable의 재명명</h2>
 
-<p>The {{domxref("WaveTable")}} interface has been renamed to {{domxref("PeriodicWave")}}.  Here is how you can port old code using <code>WaveTable</code> to the standard AudioContext API:</p>
+<p>{{domxref("WaveTable")}} 인터페이스는 {{domxref("PeriodicWave")}}로 이름이 바뀌었습니다. 여기 <code>WaveTable</code>를 사용하는 낡은 코드를 어떻게 표준 AudioContext API로 옮기는지에 대한 방법이 있습니다.</p>
 
-<pre class="brush: js">// Old webkitAudioContext code:
+<pre class="brush: js">// 오래된 webkitAudioContext 코드:
 var osc = context.createOscillator();
 var table = context.createWaveTable(realArray, imaginaryArray);
 osc.setWaveTable(table);
 
-// New standard AudioContext code:
+// 새로운 표준 AudioContext 코드:
 var osc = context.createOscillator();
 var table = context.createPeriodicWave(realArray, imaginaryArray);
 osc.setPeriodicWave(table);
 </pre>
 
-<h2 id="Removal_of_some_of_the_AudioParam_read-only_attributes">Removal of some of the AudioParam read-only attributes</h2>
+<h2 id="Removal_of_some_of_the_AudioParam_read-only_attributes">AudioParam의 몇몇 읽기 전용 특성들의 제거</h2>
 
-<p>The following read-only attributes have been removed from AudioParam: <code>name</code>, <code>units</code>, <code>minValue</code>, and <code>maxValue</code>.  These used to be informational attributes.  Here is some information on how you can get these values if you need them:</p>
+<p>다음의 읽기 전용 특성들은 AudioParam으로부터 제거되었습니다: <code>name</code>, <code>units</code>, <code>minValue</code>, <code>maxValue</code>. 이것들은 정보를 제공하는 특성들이었습니다. 여기 어떻게 여러분이 이 값들을 만약 필요하다면 얻는지에 대한 정보가 있습니다.</p>
 
 <ul>
- <li>The <code>name</code> attribute is a string representing the name of the {{domxref("AudioParam")}} object.  For example, the name of {{domxref("GainNode.gain")}} is <code>"gain"</code>.  You can track where the {{domxref("AudioParam")}} object is coming from in your code if you need this information.</li>
- <li>The <code>minValue</code> and <code>maxValue</code> attributes are read-only values representing the nominal range for the {{domxref("AudioParam")}}.  For example, for {{domxref("GainNode") }}, these values are 0 and 1, respectively.  Note that these bounds are not enforced by the engine, and are merely used for informational purposes.  As an example, it's perfectly valid to set a gain value to 2, or even -1.  In order to find out these nominal values, you can consult the <a href="https://dvcs.w3.org/hg/audio/raw-file/tip/webaudio/specification.html">specification</a>.</li>
- <li>The <code>units</code> attribute as implemented in <code>webkitAudioContext</code> implementations is unused, and always returns 0.  There is no reason why you should need this attribute.</li>
+ <li><code>name</code> 특성은 {{domxref("AudioParam")}} 객체의 이름을 나타내는 문자열입니다. 예를 들자면, {{domxref("GainNode.gain")}}의 이름은 <code>"gain"</code>입니다. 만약 여러분이 이 정보가 필요하다면 코드에서 어디서 {{domxref("AudioParam")}} 객체가 오는지 추적할 수 있습니다.</li>
+ <li><code>minValue</code>와 <code>maxValue</code> 특성은 {{domxref("AudioParam")}}의 명목상의 범위를 나타내는 읽기 전용 값입니다. 예를 들자면, {{domxref("GainNode") }}에 대해서, 이 값들은 각각 0과 1입니다. 이 경계는 엔진에 의해 강요되지 않고, 단지 정보를 제공하는 목적에서 사용된다는 것에 주목하십시오. 예제로써, gain 값을 2나, 심지어 -1로 설정하는 것은 완전히 유효합니다. 이 명목상의 값들을 찾기 위해서, 여러분은 <a href="https://dvcs.w3.org/hg/audio/raw-file/tip/webaudio/specification.html">명세</a>를 참고할 수 있습니다.</li>
+ <li><code>webkitAudioContext</code> 구현에서 구현된 <code>units</code> 특성은 사용된 적이 없고, 항상 0을 반환합니다. 여러분이 이 특성이 필요할지도 모르는 이유는 없습니다.</li>
 </ul>
 
-<h2 id="Removal_of_MediaElementAudioSourceNode.mediaElement">Removal of MediaElementAudioSourceNode.mediaElement</h2>
+<h2 id="Removal_of_MediaElementAudioSourceNode.mediaElement">MediaElementAudioSourceNode.mediaElement의 제거</h2>
 
-<p>The <code>mediaElement</code> attribute of {{domxref("MediaElementAudioSourceNode")}} has been removed.  You can keep a reference to the media element used to create this node if you need to access it later.</p>
+<p>{{domxref("MediaElementAudioSourceNode")}}의 <code>mediaElement</code> 특성은 제거되었습니다. 만약 여러분이 나중에 이것에 접근할 필요가 있다면 여러분은 이 노드를 생성하기 위해 사용된 미디어 요소에 대한 참조를 유지할 수 있습니다.</p>
 
-<h2 id="Removal_of_MediaStreamAudioSourceNode.mediaStream">Removal of MediaStreamAudioSourceNode.mediaStream</h2>
+<h2 id="Removal_of_MediaStreamAudioSourceNode.mediaStream">MediaStreamAudioSourceNode.mediaStream의 제거</h2>
 
-<p>The <code>mediaStream</code> attribute of {{domxref("MediaStreamAudioSourceNode")}} has been removed.  You can keep a reference to the media stream used to create this node if you need to access it later.</p>
+<p>{{domxref("MediaStreamAudioSourceNode")}}의 <code>mediaStream</code> 특성은 제거되었습니다. 만약 여러분이 나중에 이것에 접근할 필요가 있다면 여러분은 이 노드를 생성하기 위해 사용된 미디어 스트림에 대한 참조를 유지할 수 있습니다.</p>


### PR DESCRIPTION
https://developer.mozilla.org/ko/docs/Web/API/Web_Audio_API/Migrating_from_webkitAudioContext
문서를 번역하였습니다.

I translated [this document](https://developer.mozilla.org/ko/docs/Web/API/Web_Audio_API/Migrating_from_webkitAudioContext) into Korean.

※ 영문판은 .md인데 본 pr은 .html인 이유: https://github.com/mdn/translated-content/pull/1609#issuecomment-894433453 md로 업데이트되기 전에 제가 html을 ko폴더로 옮겼기 때문입니다. 단, 어차피 내용은 똑같으므로 문제는 없을 것으로 사료됩니다.