### PR TITLE
[ja] Changed hgroup section from deprecated to warning

### DIFF
--- a/files/ja/web/html/element/hgroup/index.html
+++ b/files/ja/web/html/element/hgroup/index.html
@@ -11,7 +11,12 @@ tags:
   - Web
 translation_of: Web/HTML/Element/hgroup
 ---
-<div>{{HTMLRef}}{{deprecated_header}}</div>
+<div>{{HTMLRef}}</div>
+
+<div class="notecard warning">
+  <p><strong>警告:</strong><code>&lt;hgroup&gt;</code> は支援技術にサポートされていないため、使用すべきではありません。使用すると、中にある見出し要素の認識に悪影響を与えます。</p>
+  <p>詳細については、以下の<a href="#usage_notes">使用上の注意</a>を参照してください。</p>
+</div>
 
 <p><strong>HTML の <code>&lt;hgroup&gt;</code> 要素</strong>は、文書のセクションの、複数レベルの見出しを表します。これは <code><a href="/ja/docs/Web/HTML/Element/Heading_Elements">&lt;h1&gt;–&lt;h6&gt;</a></code> 要素のセットをグループ化します。</p>
 


### PR DESCRIPTION
The Japanese version of the `hgroup` page is deprecated, but in the original this part was changed to a warning at https://github.com/mdn/content/pull/4977.
This PR is a Japanese translation of it.