### PR TITLE
Fix: correction of a link name

### DIFF
--- a/files/zh-cn/web/api/htmlelement/outertext/index.html
+++ b/files/zh-cn/web/api/htmlelement/outertext/index.html
@@ -11,7 +11,7 @@ translation_of: Web/API/HTMLElement/outerText
 
 <h2 id="概要">概要</h2>
 
-<p><strong><code>HTMLElement.outerText</code></strong>是一个非标准的属性。作为一个获得器，它返回与{{domxref("Node.innerText")}}一致的值。 作为一个设置器，它将删除当前节点并将其替换为给定的文本。</p>
+<p><strong><code>HTMLElement.outerText</code></strong>是一个非标准的属性。作为一个获得器，它返回与{{domxref("HTMLElement.innerText")}}一致的值。 作为一个设置器，它将删除当前节点并将其替换为给定的文本。</p>
 
 <h2 id="范例"><font face="x-locale-heading-primary, zillaslab, Palatino, Palatino Linotype, x-locale-heading-secondary, serif"><span style="font-size: 40px;"><strong>范例</strong></span></font></h2>
 


### PR DESCRIPTION
Click on this link to jump to the content is `HTMLElement.innerText`, so the name of the link should be `HTMLElement.innerText` instead of `Node.innerText`.