### PR TITLE
Firefox 93 for developers を翻訳

### DIFF
--- a/files/ja/mozilla/firefox/releases/93/index.html
+++ b/files/ja/mozilla/firefox/releases/93/index.html
@@ -1,0 +1,88 @@
+---
+title: Firefox 93 for developers
+slug: Mozilla/Firefox/Releases/93
+tags:
+  - '93'
+  - Firefox
+  - Mozilla
+  - Release
+---
+<p>{{FirefoxSidebar}}{{draft}}</p>
+
+<p class="summary">このページでは、開発者に影響する Firefox 93 の変更点をまとめています。Firefox 93 は、2021 年 10 月 5 日にリリースされました。</p>
+
+<h2 id="Changes_for_web_developers">ウェブ開発者向けの変更点一覧</h2>
+
+<h3 id="HTML">HTML</h3>
+
+<ul>
+  <li>ARIA の <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/meter_role">meter</a></code> ロールを実装しました ({{bug(1727616)}})。</li>
+  <li><a href="/docs/Web/HTML/Element/input/datetime-local"><code>&lt;input type="datetime-local"&gt;</code></a> の UI を実装しました ({{bug(1283388)}})。</li>
+</ul>
+
+<h3 id="CSS">CSS</h3>
+
+<ul>
+  <li>{{cssxref("font-synthesis")}} プロパティで <code>small-caps</code> キーワードをサポートしました ({{bug(1706080)}})。</li>
+</ul>
+
+<h3 id="JavaScript">JavaScript</h3>
+
+<ul>
+  <li><a href="/ja/docs/Web/JavaScript/Reference/Classes/Class_static_initialization_blocks">クラスの <code>static</code> 初期化ブロック</a> をサポートしました。{{jsxref("Classes/static", "静的")}} プロパティの初期化を、より柔軟に行えます ({{bug(1725689)}})。</li>
+  <li>{{domxref("createImageBitmap()")}} メソッドに、<code>options</code> オブジェクトを使用して <code>imageOrientation</code> および <code>premultiplyAlpha</code> プロパティを渡すことが可能になりました ({{bug(1367251)}})。</li>
+  <li>実装でサポートされている値をコードが列挙することを可能にする、{{jsxref("Intl.supportedValuesOf()")}} をサポートしました。これは、例えば欠けているカテゴリーの値に対するポリフィルだけをダウンロードするために使用できます ({{bug(1670033)}})。</li>
+</ul>
+
+<h3 id="HTTP">HTTP</h3>
+
+<ul>
+  <li>ダイジェストを使用する <a href="/ja/docs/Web/HTTP/Authentication">HTTP 認証</a> で SHA-256 アルゴリズムをサポートしました。これは、以前から使用できた MD5 アルゴリズムより安全な認証を可能にします ({{bug(1682995)}})。</li>
+  <li><em>画像</em> について、既定の HTTP {{HTTPHeader("ACCEPT")}} ヘッダーを <code>image/avif,image/webp,*/*</code> に変更しました (<a href="/ja/docs/Web/Media/Formats/Image_types#avif_画像">AVIF</a> 画像形式のサポートを追加した結果として) ({{bug(1682995)}})。</li>
+</ul>
+
+<h3 id="APIs">API</h3>
+
+<ul>
+  <li>{{domxref("ElementInternals.shadowRoot")}} および {{domxref("HTMLElement.attachInternals")}} をサポートしました ({{bug(1723521)}})。</li>
+  <li>{{domxref("ResizeObserver.Observe()")}} の値 <code>device-pixel-content-box</code> をサポートしました ({{bug(1587973)}})。</li>
+  <li>{{domxref("reportError()")}} グローバル関数をサポートしました。これはスクリプトがコンソールやグローバルイベントハンドラーへエラーを報告できるようにして、キャッチされなかった JavaScript の例外をエミュレートするものです ({{bug(1722448)}})。</li>
+</ul>
+
+<h4 id="Events">イベント</h4>
+
+<ul>
+  <li>{{domxref("GlobalEventHandlers.onsecuritypolicyviolation","onsecuritypolicyviolation")}} グローバルイベントハンドラープロパティをサポートしました。これは、<a href="/ja/docs/Web/HTTP/CSP">Content Security Policy</a> の違反があるときに発生する <a href="/ja/docs/Web/API/Element/securitypolicyviolation_event"><code>securitypolicyviolation</code></a> イベントを処理するハンドラーを割り当てるために使用できます ({{bug(1727302)}})。</li>
+  <li>{{domxref("GlobalEventHandlers.onslotchange","GlobalEventHandlers")}} および {{domxref("ShadowRoot.onslotchange","ShadowRoot")}} で <code>onslotchange</code> イベントハンドラープロパティをサポートしました。これは、スロットに含まれているノードが変更されたときに {{HTMLElement("slot")}} 要素で発生する <a href="/ja/docs/Web/API/HTMLSlotElement/slotchange_event"><code>slotchange</code></a> イベントを処理するハンドラーを割り当てるために使用できます ({{bug(1501983)}})。</li>
+</ul>
+
+<h4 id="removals">廃止</h4>
+
+<ul>
+  <li>{{domxref("KeyboardEvent.initKeyEvent()")}} を設定項目 <code>dom.keyboardevent.init_key_event.enabled</code> で制御するようにして、既定で無効にしました。このメソッドは、他のブラウザーが現在サポートしているどの仕様でも提供されていません ({{bug(1717760)}})。</li>
+</ul>
+
+
+<h3 id="webdriver_conformance_marionette">WebDriver conformance (Marionette)</h3>
+
+<ul>
+  <li><code>WebDriver:Print</code> が大きなドキュメントで失敗していた不具合を修正しました ({{bug(1721982)}})。</li>
+</ul>
+
+
+<h2 id="Changes_for_add-on_developers">アドオン開発者向けの変更点</h2>
+
+<ul>
+  <li><code>windowId</code> を明示したとき、{{WebExtAPIRef("extension.getViews")}} にサイドバーが含まれるようになりました ({{bug(1612390)}})。</li>
+</ul>
+
+
+<h2 id="Other">その他</h2>
+
+<ul>
+  <li><a href="/ja/docs/Web/Media/Formats/Image_types#avif_画像">AVIF</a> 画像のサポートを、デフォルトで有効化しました ({{bug(1682995)}})。この形式は圧縮率が優れており、また特許の制限がありません (これは <a href="http://aomedia.org/">Alliance for Open Media</a> が開発しています)。Firefox はフルレンジおよびリミテッドレンジの両方の色空間をサポートして静的画像を表示でき、画像の変形や回転も可能です。設定項目 <a href="/ja/docs/Mozilla/Firefox/Experimental_features#avif_compliance_strictness">image.avif.compliance_strictness</a> で、仕様へどの程度厳密に従うかを調節できます。アニメーション画像は未サポートです。</li>
+</ul>
+
+<h2 id="Older_versions">過去のバージョン</h2>
+
+<p>{{Firefox_for_developers(92)}}</p>


### PR DESCRIPTION
Oct 15, 2021 の英語版に対応。
pull request を再作成しました。