### PR TITLE
API/Element/mouseenter_event を修正

### DIFF
--- a/files/ja/web/api/element/mouseenter_event/index.html
+++ b/files/ja/web/api/element/mouseenter_event/index.html
@@ -53,7 +53,7 @@ translation_of: Web/API/Element/mouseenter_event
 <div style="text-align: center;"><img alt="mouseover.png" class="default internal" src="/@api/deki/files/5909/=mouseover.png"></div>
 DOM ツリーの最も深い要素に1つの <code>mouseover</code> イベントが送信され、ハンドラーによってキャンセルされるかルートに達するまで階層を上にバブリングします。</div>
 
-<p>深い階層では、数多くの <code>mouseenter</code> イベントが送信され、とても重くなり、著しい性能の問題を引き起こすことがあります。このような場合は <code>mouseover</code> イベントを待ち受けした方が優れています。</p>
+<p>深い階層では、数多くの <code>mouseover</code> イベントが送信され、とても重くなり、著しい性能の問題を引き起こすことがあります。このような場合は <code>mouseenter</code> イベントを待ち受けした方が優れています。</p>
 
 <p>対応する (マウスがコンテンツ領域から出たときに要素に発生する) <code>mouseleave</code> と組み合わせると、 <code>mouseenter</code> イベントは CSS の {{cssxref(':hover')}} 疑似クラスととても似た方法で動作します。</p>
 


### PR DESCRIPTION
翻訳ミスがあります。
`mouseover`と`mouseenter`が逆になっています。

[en]
With deep hierarchies, the number of mouseover events sent can be quite huge and cause significant performance problems. In such cases, it is better to listen for mouseenter events.

[ja] 誤り (current text)
深い階層では、数多くの mouseenter イベントが送信され、とても重くなり、著しい性能の問題を引き起こすことがあります。このような場合は mouseover イベントを待ち受けした方が優れています。