### PR TITLE
Fix typo in padding-inline-end fr doc

### DIFF
--- a/files/fr/web/css/padding-inline-end/index.md
+++ b/files/fr/web/css/padding-inline-end/index.md
@@ -10,7 +10,7 @@ translation_of: Web/CSS/padding-inline-end
 ---
 {{CSSRef}}{{SeeCompatTable}}
 
-La propriété** `padding-inline-end`** définit le décalage avec la fin de la zone de remplissage d'un élément, selon le mode d'écriture, la directionnalité et l'orientation du texte. Elle correspond à la propriété {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}} ou {{cssxref("padding-left")}} selon les valeurs définies pour {{cssxref("writing-mode")}}, {{cssxref("direction")}} et {{cssxref("text-orientation")}}.
+La propriété **`padding-inline-end`** définit le décalage avec la fin de la zone de remplissage d'un élément, selon le mode d'écriture, la directionnalité et l'orientation du texte. Elle correspond à la propriété {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}} ou {{cssxref("padding-left")}} selon les valeurs définies pour {{cssxref("writing-mode")}}, {{cssxref("direction")}} et {{cssxref("text-orientation")}}.
 
 Les autres parties « logiques » du remplissage sont définies grâce aux propriétés {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}} et {{cssxref("padding-inline-start")}}.
 

--- a/files/fr/web/css/padding-inline-end/index.md
+++ b/files/fr/web/css/padding-inline-end/index.md
@@ -10,7 +10,7 @@ translation_of: Web/CSS/padding-inline-end
 ---
 {{CSSRef}}{{SeeCompatTable}}
 
-La propriété** `padding-inline-end`** définit le décalage avec la fin de la zone de remplissage d'un élément, selon le mode d'écriture, la directionnalité et l'orientation du texte. Elle correspond à la propriété {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}} ou {{cssxref("padding-left")}} slon les valeurs définies poru {{cssxref("writing-mode")}}, {{cssxref("direction")}} et {{cssxref("text-orientation")}}.
+La propriété** `padding-inline-end`** définit le décalage avec la fin de la zone de remplissage d'un élément, selon le mode d'écriture, la directionnalité et l'orientation du texte. Elle correspond à la propriété {{cssxref("padding-top")}}, {{cssxref("padding-right")}}, {{cssxref("padding-bottom")}} ou {{cssxref("padding-left")}} selon les valeurs définies pour {{cssxref("writing-mode")}}, {{cssxref("direction")}} et {{cssxref("text-orientation")}}.
 
 Les autres parties « logiques » du remplissage sont définies grâce aux propriétés {{cssxref("padding-block-start")}}, {{cssxref("padding-block-end")}} et {{cssxref("padding-inline-start")}}.
 


### PR DESCRIPTION
Hello,

Just fix a quick typo on the `padding-inline-end` fr doc:
![image](https://user-images.githubusercontent.com/17161484/138915507-323f7928-71ef-4300-bf7d-3861cb3fda61.png)

Into:
![image](https://user-images.githubusercontent.com/17161484/138915432-6de18f15-52f9-4168-aee5-d025dd32a02e.png)

Have a good day :)
