### PR TITLE
Date の誤訳を修正

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/date/index.html
+++ b/files/ja/web/javascript/reference/global_objects/date/index.html
@@ -23,7 +23,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Date
 
 <h3 id="The_ECMAScript_epoch_and_timestamps" name="The_ECMAScript_epoch_and_timestamps">ECMAScript Epoch とタイムスタンプ</h3>
 
-<p>JavaScript の日時は、基本的に協定世界時 (UTC) の1970年1月1日深夜0時からの経過ミリ秒数で指定されます。この日付と時刻は、コンピューターに記録される日付と時刻の値の主な基準値である <strong>UNIX Epoch </strong>と同じです。</p>
+<p>JavaScript の日時は、基本的に協定世界時 (UTC) の1970年1月1日深夜0時からの経過ミリ秒数で指定されます。この日付と時刻は、コンピューターに記録される日付と時刻の値の主な基準値である <strong>UNIX Epoch</strong> (UTC の1970年1月1日深夜0時からの経過秒数) とは異なります。</p>
 
 <div class="blockIndicator note">
 <p><strong>注:</strong> Date オブジェクトの中心となる時間値は UTC ですが、日付と時刻、またはその一部を取得する基本的なメソッドは、すべて地方時 (ホストシステムなど) のタイムゾーンとオフセットで動作することを覚えておくことが重要です。</p>

--- a/files/ja/web/javascript/reference/global_objects/date/index.html
+++ b/files/ja/web/javascript/reference/global_objects/date/index.html
@@ -23,7 +23,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Date
 
 <h3 id="The_ECMAScript_epoch_and_timestamps" name="The_ECMAScript_epoch_and_timestamps">ECMAScript Epoch とタイムスタンプ</h3>
 
-<p>JavaScript の日時は、基本的に協定世界時 (UTC) の1970年1月1日深夜0時からの経過ミリ秒数で指定されます。この日付と時刻は、コンピューターに記録される日付と時刻の値の主な基準値である <strong>UNIX Epoch</strong> (UTC の1970年1月1日深夜0時からの経過秒数) とは異なります。</p>
+<p>JavaScript の日時は、基本的に協定世界時 (UTC) の 1970 年 1 月 1 日深夜 0 時からの経過ミリ秒数で指定されます。この日付と時刻は、コンピューターに記録される日付と時刻の値の主な基準値である <strong>UNIX Epoch</strong> (UTC の 1970 年 1 月 1 日深夜 0 時からの経過秒数) とは異なります。</p>
 
 <div class="blockIndicator note">
 <p><strong>注:</strong> Date オブジェクトの中心となる時間値は UTC ですが、日付と時刻、またはその一部を取得する基本的なメソッドは、すべて地方時 (ホストシステムなど) のタイムゾーンとオフセットで動作することを覚えておくことが重要です。</p>


### PR DESCRIPTION
原文では "This date and time are not the same as the UNIX epoch" となっている箇所が
"UNIX Epoch と同じです" と翻訳されてしまっていたため修正しました。

原文: https://github.com/mdn/content/blob/cf607d68522cd35ee7670782d3ee3a361eaef2e4/files/en-us/web/javascript/reference/global_objects/date/index.md?plain=1#L24