### PR TITLE
Fixing parity with English page as per modulo/remainder equivalence (JS Reintro)

### DIFF
--- a/files/fr/web/javascript/a_re-introduction_to_javascript/index.md
+++ b/files/fr/web/javascript/a_re-introduction_to_javascript/index.md
@@ -263,7 +263,7 @@ JavaScript possède une différence importante quant aux autres langages de prog
 
 ## Les opérateurs
 
-Les opérateurs numériques en JavaScript sont `+`, `-`, `*`, `/` et `%` (qui est [l'opérateur de reste, à ne pas confondre avec le « modulo » mathématique](</fr/docs/conflicting/Web/JavaScript/Reference/Operators#remainder_()>)). Les valeurs sont affectées à l'aide de `=` et il existe également des opérateurs d'affectation combinés comme `+=` et `-=`. Ils sont équivalents à `x = x opérateur y`.
+Les opérateurs numériques en JavaScript sont `+`, `-`, `*`, `/` et `%` (qui est [l'opérateur de reste, qui est le même que le « modulo » mathématique](</fr/docs/conflicting/Web/JavaScript/Reference/Operators#remainder_()>)). Les valeurs sont affectées à l'aide de `=` et il existe également des opérateurs d'affectation combinés comme `+=` et `-=`. Ils sont équivalents à `x = x opérateur y`.
 
 ```js
 x += 5;


### PR DESCRIPTION
Sous le titre "Les opérateurs", il est dit en français "... et % (qui est l'opérateur de reste, à ne pas confondre avec le « modulo » mathématique)." alors qu'en anglais il est dit "... and % which is the remainder operator (which is the same as modulo.)"; ceci représente une contradiction entre le texte en français et le texte en anglais; le premier dit "à ne pas confondre" alors que le deuxième dit "is the same"!
Donc, je propose la traduction suivante: "qui est le même que le « modulo » mathématique"; ceci en supposant que le texte anglais est juste.