### PR TITLE
fix Compat data in css contain 

### DIFF
--- a/files/ja/web/css/contain/index.html
+++ b/files/ja/web/css/contain/index.html
@@ -198,7 +198,7 @@ article {
 
 <h2 id="Browser_compatibility" name="Browser_compatibility">ブラウザーの互換性</h2>
 
-<p>{{Compat("css.types.global_keywords.initial")}}</p>
+<p>{{Compat("css.properties.contain")}}</p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>
 


### PR DESCRIPTION
Fixed Compat Data.
- correct 
en:
https://developer.mozilla.org/en-US/docs/Web/CSS/contain#browser_compatibility

- incorrect
ja:
https://developer.mozilla.org/ja/docs/Web/CSS/contain#browser_compatibility