### PR TITLE
Add a code example

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/promise/resolve/index.html
+++ b/files/zh-cn/web/javascript/reference/global_objects/promise/resolve/index.html
@@ -18,6 +18,16 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Promise/resolve
 <div class="blockIndicator warning">
 <p>警告：不要在解析为自身的thenable 上调用<code>Promise.resolve</code>。这将导致无限递归，因为它试图展平无限嵌套的promise。一个例子是将它与Angular中的异步管道一起使用。在<a href="https://angular.io/guide/template-syntax#avoid-side-effects">此处</a>了解更多信息。</p>
 </div>
+<div>例如下例代码</div>
+<pre class="brush: js">
+let thenable = {
+  then: (resolve, reject) => {
+    resolve(thenable)
+  }
+}
+
+Promise.resolve(thenable)  //这会造成一个死循环
+</pre>
 
 <div>{{EmbedInteractiveExample("pages/js/promise-resolve.html")}}</div>
 


### PR DESCRIPTION
A code example is added to the warning content at the beginning of the article. 

This example can clearly show its meaning.

 Why should I give this example? Because when I first read it, I found it difficult to imagine and understand this concept.

please accept