### PR TITLE
fix: "propriedadr" adjusted to "propriedade".

### DIFF
--- a/files/pt-br/web/html/element/dl/index.html
+++ b/files/pt-br/web/html/element/dl/index.html
@@ -112,7 +112,7 @@ translation_of: Web/HTML/Element/dl
 
 <p>Não use este elemento,  (nor {{ HTMLElement("ul") }} elements), para criar meramente um recuo em uma página. Embora ele funcione, está é uma má prática e obscurece o significado da lista de definição.</p>
 
-<p>Para mudar a indentação de um termo, use a propriedadr <a href="/en/CSS" title="en/CSS">CSS</a> <a href="/en/CSS/margin" title="en/CSS/margin">margin</a>.</p>
+<p>Para mudar a indentação de um termo, use a propriedade <a href="/en/CSS" title="en/CSS">CSS</a> <a href="/en/CSS/margin" title="en/CSS/margin">margin</a>.</p>
 
 <h2 id="Browser_Compatibility" name="Browser_Compatibility">Compatibilidade de navegadores</h2>
 


### PR DESCRIPTION
Just a simple word error correction. Where is "propriedadr" should be "propriedade".