### PR TITLE
Fixed gramatic issue on Global Attributes: `title`

### DIFF
--- a/files/pt-br/web/html/global_attributes/title/index.html
+++ b/files/pt-br/web/html/global_attributes/title/index.html
@@ -25,7 +25,7 @@ translation_of: Web/HTML/Global_attributes/title
 <p>O atributo <strong>title</strong> pode conter várias linhas. Cada <code>U+000A LINE FEED</code> (<code>LF</code>) inserida representa uma nova linha. Alguns cuidados devem ser tomados, como a seguir:</p>
 
 <pre class="brush: html">&lt;p&gt;Novas linhas em título devem ser levadas em conta, como este &lt;abbr title="Este é um
-título de multiplas linhas"&gt;examplo&lt;/abbr&gt;.&lt;/p&gt;
+título de multiplas linhas"&gt;exemplo&lt;/abbr&gt;.&lt;/p&gt;
 </pre>
 
 <p>Este exemplo define um título de duas linhas.</p>


### PR DESCRIPTION
Fixed gramatic issue on `title` attribute example text in `pt-BR`.

The correct word to represent example in Portuguese is `exemplo` and on website there's `examplo`.