### PR TITLE
fix: [ja,ko,es,ru] update codes on Node.js server without a framework

### DIFF
--- a/files/es/learn/server-side/node_server_without_framework/index.html
+++ b/files/es/learn/server-side/node_server_without_framework/index.html
@@ -34,27 +34,28 @@ http.createServer(function (request, response) {
 
     var extname = String(path.extname(filePath)).toLowerCase();
     var mimeTypes = {
-        '.html': 'text/html',
+        '.html': 'text/html',
         '.js': 'text/javascript',
         '.css': 'text/css',
         '.json': 'application/json',
         '.png': 'image/png',
         '.jpg': 'image/jpg',
         '.gif': 'image/gif',
+        '.svg': 'image/svg+xml',
         '.wav': 'audio/wav',
         '.mp4': 'video/mp4',
         '.woff': 'application/font-woff',
         '.ttf': 'application/font-ttf',
         '.eot': 'application/vnd.ms-fontobject',
         '.otf': 'application/font-otf',
-        '.svg': 'application/image/svg+xml'
+        '.wasm': 'application/wasm'
     };
 
     var contentType = mimeTypes[extname] || 'application/octet-stream';
 
     fs.readFile(filePath, function(error, content) {
         if (error) {
-            if(error.code == 'ENOENT'){
+            if(error.code == 'ENOENT') {
                 fs.readFile('./404.html', function(error, content) {
                     response.writeHead(404, { 'Content-Type': 'text/html' });
                     response.end(content, 'utf-8');
@@ -63,7 +64,6 @@ http.createServer(function (request, response) {
             else {
                 response.writeHead(500);
                 response.end('Sorry, check with the site admin for error: '+error.code+' ..\n');
-                response.end();
             }
         }
         else {

--- a/files/es/learn/server-side/node_server_without_framework/index.html
+++ b/files/es/learn/server-side/node_server_without_framework/index.html
@@ -33,7 +33,6 @@ http.createServer(function (request, response) {
     }
 
     var extname = String(path.extname(filePath)).toLowerCase();
-    var contentType = 'text/html';
     var mimeTypes = {
         '.html': 'text/html',
         '.js': 'text/javascript',
@@ -51,13 +50,13 @@ http.createServer(function (request, response) {
         '.svg': 'application/image/svg+xml'
     };
 
-    contentType = mimeTypes[extname] || 'application/octet-stream';
+    var contentType = mimeTypes[extname] || 'application/octet-stream';
 
     fs.readFile(filePath, function(error, content) {
         if (error) {
             if(error.code == 'ENOENT'){
                 fs.readFile('./404.html', function(error, content) {
-                    response.writeHead(200, { 'Content-Type': contentType });
+                    response.writeHead(404, { 'Content-Type': 'text/html' });
                     response.end(content, 'utf-8');
                 });
             }

--- a/files/ja/learn/server-side/node_server_without_framework/index.html
+++ b/files/ja/learn/server-side/node_server_without_framework/index.html
@@ -43,20 +43,21 @@ http.createServer(function (request, response) {
 
     var extname = String(path.extname(filePath)).toLowerCase();
     var mimeTypes = {
-        '.html': 'text/html',
+        '.html': 'text/html',
         '.js': 'text/javascript',
         '.css': 'text/css',
         '.json': 'application/json',
         '.png': 'image/png',
         '.jpg': 'image/jpg',
         '.gif': 'image/gif',
+        '.svg': 'image/svg+xml',
         '.wav': 'audio/wav',
         '.mp4': 'video/mp4',
         '.woff': 'application/font-woff',
         '.ttf': 'application/font-ttf',
         '.eot': 'application/vnd.ms-fontobject',
         '.otf': 'application/font-otf',
-        '.svg': 'application/image/svg+xml'
+        '.wasm': 'application/wasm'
     };
 
     var contentType = mimeTypes[extname] || 'application/octet-stream';
@@ -72,7 +73,6 @@ http.createServer(function (request, response) {
             else {
                 response.writeHead(500);
                 response.end('Sorry, check with the site admin for error: '+error.code+' ..\n');
-                response.end();
             }
         }
         else {
@@ -98,11 +98,13 @@ var path = require('path');
 <pre class="brush: js language-js">http.createServer(function (request, response) {
     ...
 }).listen(8125);
+console.log('Server running at http://127.0.0.1:8125/');
 </pre>
 
 <p>次の4行では、要求があったURLから、ファイルへのパスを決定します。ファイル名が明示されていないときは、デフォルト名を使うようにします。</p>
 
-<pre class="brush: js">var filePath = '.' + request.url;
+<pre class="brush: js">console.log('request ', request.url);
+var filePath = '.' + request.url;
 if (filePath == './') {
     filePath = './index.html';
 }
@@ -112,7 +114,8 @@ if (filePath == './') {
 
 <p>次に、要求されたファイルの拡張子を調べ、以下に定義する<a href="/ja/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIMEタイプ</a>のどれかと一致したら、そのタイプを使います。一致しない場合には、デフォルトのタイプ<code>application/octet-stream</code>を使うようにします。.</p>
 
-<pre class="brush: js">var mimeTypes = {
+<pre class="brush: js">var extname = String(path.extname(filePath)).toLowerCase();
+var mimeTypes = {
     '.html': 'text/html',
     '.js': 'text/javascript',
     '.css': 'text/css',
@@ -120,13 +123,14 @@ if (filePath == './') {
     '.png': 'image/png',
     '.jpg': 'image/jpg',
     '.gif': 'image/gif',
+    '.svg': 'image/svg+xml',
     '.wav': 'audio/wav',
     '.mp4': 'video/mp4',
     '.woff': 'application/font-woff',
     '.ttf': 'application/font-ttf',
     '.eot': 'application/vnd.ms-fontobject',
     '.otf': 'application/font-otf',
-    '.svg': 'application/image/svg+xml'
+    '.wasm': 'application/wasm'
 };
 
 var contentType = mimeTypes[extname] || 'application/octet-stream';
@@ -139,7 +143,16 @@ var contentType = mimeTypes[extname] || 'application/octet-stream';
 });
 </pre>
 
-<p>関数のなかで最初にやることは、起こりうるエラーへの対応です。一番多いのは、存在しないファイルを要求された場合（<code>ENOENT</code>）で、エラーコード404に対応するページを返してやります。</p>
+<p>関数のなかで最初にやることは、起こりうるエラーへの対応です。</p>
+
+<pre class="brush: js">if (error) {
+  ..
+} else {
+  ..
+}
+</pre>
+
+<p>一番多いのは、存在しないファイルを要求された場合（<code>ENOENT</code>）で、エラーコード404に対応するページを返してやります。</p>
 
 <pre class="brush: js">if(error.code == 'ENOENT') {
     fs.readFile('./404.html', function(error, content) {
@@ -150,7 +163,6 @@ var contentType = mimeTypes[extname] || 'application/octet-stream';
 else {
     response.writeHead(500);
     response.end('Sorry, check with the site admin for error: '+error.code+' ..\n');
-    response.end();
 }</pre>
 
 <p>何もエラーが検出されなかったら、MIME型をヘッダーに付けて、要求されたファイルを返してやります。</p>

--- a/files/ja/learn/server-side/node_server_without_framework/index.html
+++ b/files/ja/learn/server-side/node_server_without_framework/index.html
@@ -65,7 +65,7 @@ http.createServer(function (request, response) {
         if (error) {
             if(error.code == 'ENOENT') {
                 fs.readFile('./404.html', function(error, content) {
-                    response.writeHead(200, { 'Content-Type': contentType });
+                    response.writeHead(404, { 'Content-Type': 'text/html' });
                     response.end(content, 'utf-8');
                 });
             }
@@ -143,7 +143,7 @@ var contentType = mimeTypes[extname] || 'application/octet-stream';
 
 <pre class="brush: js">if(error.code == 'ENOENT') {
     fs.readFile('./404.html', function(error, content) {
-        response.writeHead(200, { 'Content-Type': contentType });
+        response.writeHead(404, { 'Content-Type': 'text/html' });
         response.end(content, 'utf-8');
     });
 }

--- a/files/ko/learn/server-side/node_server_without_framework/index.html
+++ b/files/ko/learn/server-side/node_server_without_framework/index.html
@@ -19,7 +19,7 @@ original_slug: Node_server_without_framework
 
 <p>다음은 짧고 간단한 정적 파일 nodejs 서버입니다.</p>
 
-<pre>var http = require('http');
+<pre class="brush: js">var http = require('http');
 var fs = require('fs');
 var path = require('path');
 
@@ -31,7 +31,6 @@ http.createServer(function (request, response) {
         filePath = './index.html';
 
     var extname = String(path.extname(filePath)).toLowerCase();
-    var contentType = 'text/html';
     var mimeTypes = {
         '.html': 'text/html',
         '.js': 'text/javascript',
@@ -49,13 +48,13 @@ http.createServer(function (request, response) {
         '.svg': 'application/image/svg+xml'
     };
 
-    contentType = mimeTypes[extname] || 'application/octet-stream';
+    var contentType = mimeTypes[extname] || 'application/octet-stream';
 
     fs.readFile(filePath, function(error, content) {
         if (error) {
             if(error.code == 'ENOENT'){
                 fs.readFile('./404.html', function(error, content) {
-                    response.writeHead(200, { 'Content-Type': contentType });
+                    response.writeHead(404, { 'Content-Type': 'text/html' });
                     response.end(content, 'utf-8');
                 });
             }

--- a/files/ko/learn/server-side/node_server_without_framework/index.html
+++ b/files/ko/learn/server-side/node_server_without_framework/index.html
@@ -27,32 +27,34 @@ http.createServer(function (request, response) {
     console.log('request ', request.url);
 
     var filePath = '.' + request.url;
-    if (filePath == './')
+    if (filePath == './') {
         filePath = './index.html';
+    }
 
     var extname = String(path.extname(filePath)).toLowerCase();
     var mimeTypes = {
-        '.html': 'text/html',
+        '.html': 'text/html',
         '.js': 'text/javascript',
         '.css': 'text/css',
         '.json': 'application/json',
         '.png': 'image/png',
         '.jpg': 'image/jpg',
         '.gif': 'image/gif',
+        '.svg': 'image/svg+xml',
         '.wav': 'audio/wav',
         '.mp4': 'video/mp4',
         '.woff': 'application/font-woff',
         '.ttf': 'application/font-ttf',
         '.eot': 'application/vnd.ms-fontobject',
         '.otf': 'application/font-otf',
-        '.svg': 'application/image/svg+xml'
+        '.wasm': 'application/wasm'
     };
 
     var contentType = mimeTypes[extname] || 'application/octet-stream';
 
     fs.readFile(filePath, function(error, content) {
         if (error) {
-            if(error.code == 'ENOENT'){
+            if(error.code == 'ENOENT') {
                 fs.readFile('./404.html', function(error, content) {
                     response.writeHead(404, { 'Content-Type': 'text/html' });
                     response.end(content, 'utf-8');
@@ -61,7 +63,6 @@ http.createServer(function (request, response) {
             else {
                 response.writeHead(500);
                 response.end('Sorry, check with the site admin for error: '+error.code+' ..\n');
-                response.end();
             }
         }
         else {

--- a/files/ru/learn/server-side/node_server_without_framework/index.html
+++ b/files/ru/learn/server-side/node_server_without_framework/index.html
@@ -37,27 +37,28 @@ http.createServer(function (request, response) {
 
     var extname = String(path.extname(filePath)).toLowerCase();
     var mimeTypes = {
-        '.html': 'text/html',
+        '.html': 'text/html',
         '.js': 'text/javascript',
         '.css': 'text/css',
         '.json': 'application/json',
         '.png': 'image/png',
         '.jpg': 'image/jpg',
         '.gif': 'image/gif',
+        '.svg': 'image/svg+xml',
         '.wav': 'audio/wav',
         '.mp4': 'video/mp4',
         '.woff': 'application/font-woff',
         '.ttf': 'application/font-ttf',
         '.eot': 'application/vnd.ms-fontobject',
         '.otf': 'application/font-otf',
-        '.svg': 'application/image/svg+xml'
+        '.wasm': 'application/wasm'
     };
 
     var contentType = mimeTypes[extname] || 'application/octet-stream';
 
     fs.readFile(filePath, function(error, content) {
         if (error) {
-            if(error.code == 'ENOENT'){
+            if(error.code == 'ENOENT') {
                 fs.readFile('./404.html', function(error, content) {
                     response.writeHead(404, { 'Content-Type': 'text/html' });
                     response.end(content, 'utf-8');
@@ -66,7 +67,6 @@ http.createServer(function (request, response) {
             else {
                 response.writeHead(500);
                 response.end('Sorry, check with the site admin for error: '+error.code+' ..\n');
-                response.end();
             }
         }
         else {

--- a/files/ru/learn/server-side/node_server_without_framework/index.html
+++ b/files/ru/learn/server-side/node_server_without_framework/index.html
@@ -36,7 +36,6 @@ http.createServer(function (request, response) {
     }
 
     var extname = String(path.extname(filePath)).toLowerCase();
-    var contentType = 'text/html';
     var mimeTypes = {
         '.html': 'text/html',
         '.js': 'text/javascript',
@@ -54,13 +53,13 @@ http.createServer(function (request, response) {
         '.svg': 'application/image/svg+xml'
     };
 
-    contentType = mimeTypes[extname] || 'application/octet-stream';
+    var contentType = mimeTypes[extname] || 'application/octet-stream';
 
     fs.readFile(filePath, function(error, content) {
         if (error) {
             if(error.code == 'ENOENT'){
                 fs.readFile('./404.html', function(error, content) {
-                    response.writeHead(200, { 'Content-Type': contentType });
+                    response.writeHead(404, { 'Content-Type': 'text/html' });
                     response.end(content, 'utf-8');
                 });
             }


### PR DESCRIPTION
1. fixed 404 process code [all]
`response.writeHead(200, { 'Content-Type': contentType });` -> `response.writeHead(404, { 'Content-Type': 'text/html' });`
2. fixed `var contentType = 'text/html';` [es,ko,ru]
3. fixed code on korean page doen't show correctly [ko]
`<pre>` -> `<pre class="brush: js">`