### PR TITLE
[Ko] fix cors link

### DIFF
--- a/files/ko/web/http/cors/index.html
+++ b/files/ko/web/http/cors/index.html
@@ -143,7 +143,7 @@ Content-Type: application/xml
 
 <h3 id="프리플라이트_요청">프리플라이트 요청</h3>
 
-<p>"preflighted" request는 위에서 논의한 <a href="/ko/docs/Web/HTTP/Access_control_CORS$edit#Simple_requests">“simple requests”</a> 와는 달리, 먼저 {{HTTPMethod("OPTIONS")}} 메서드를 통해 다른 도메인의 리소스로 HTTP 요청을 보내 실제 요청이 전송하기에 안전한지 확인합니다. Cross-site 요청은 유저 데이터에 영향을 줄 수 있기 때문에 이와같이 미리 전송(preflighted)합니다.</p>
+<p>"preflighted" request는 위에서 논의한 <a href="/ko/docs/Web/HTTP/CORS#단순_요청simple_requests">“simple requests”</a> 와는 달리, 먼저 {{HTTPMethod("OPTIONS")}} 메서드를 통해 다른 도메인의 리소스로 HTTP 요청을 보내 실제 요청이 전송하기에 안전한지 확인합니다. Cross-site 요청은 유저 데이터에 영향을 줄 수 있기 때문에 이와같이 미리 전송(preflighted)합니다.</p>
 
 <p>다음은 preflighted 할 요청의 예제입니다.</p>
 

--- a/files/ko/web/http/cors/index.html
+++ b/files/ko/web/http/cors/index.html
@@ -55,7 +55,7 @@ translation_of: Web/HTTP/CORS
 
 <h3 id="단순_요청Simple_requests">단순 요청(Simple requests)</h3>
 
-<p>일부요청은 <a href="/ko/docs/Web/HTTP/Access_control_CORS$edit#Preflighted_requests">CORS preflight</a> 를 트리거하지 않습니다. {{SpecName ( 'Fetch')}} 명세(CORS를 정의한)는 이 용어를 사용하지 않지만, 이 기사에서는 "simple requests"라고 하겠습니다. "simple requests"는 <strong>다음 조건을 모두 충족하는 요청입니다:</strong></p>
+<p>일부요청은 <a href="/ko/docs/Glossary/Preflight_request">CORS preflight</a> 를 트리거하지 않습니다. {{SpecName ( 'Fetch')}} 명세(CORS를 정의한)는 이 용어를 사용하지 않지만, 이 기사에서는 "simple requests"라고 하겠습니다. "simple requests"는 <strong>다음 조건을 모두 충족하는 요청입니다:</strong></p>
 
 <ul>
  <li>다음 중 하나의 메서드


### PR DESCRIPTION
[교차 출처 리소스 공유 (CORS)](https://developer.mozilla.org/ko/docs/Web/HTTP/CORS) 문서에 링크가 잘못 설정되어 동작하지 않던 문제를 수정하였습니다. 😄 