### PR TITLE
Add 0n in the falsy values (to match with English version)

### DIFF
--- a/files/zh-cn/glossary/truthy/index.html
+++ b/files/zh-cn/glossary/truthy/index.html
@@ -8,7 +8,7 @@ tags:
   - 术语
 translation_of: Glossary/Truthy
 ---
-<p>在 {{Glossary("JavaScript")}} 中，<strong>truthy</strong>（真值）指的是在{{Glossary("Boolean", "布尔值")}}上下文中，转换后的值为真的值。所有值都是真值，除非它们被定义为 {{Glossary("Falsy", "假值")}}（即除 <code>false</code>、<code>0</code>、<code>""</code>、<code>null</code>、<code>undefined</code> 和 <code>NaN</code> 以外皆为真值）。</p>
+<p>在 {{Glossary("JavaScript")}} 中，<strong>truthy</strong>（真值）指的是在{{Glossary("Boolean", "布尔值")}}上下文中，转换后的值为真的值。所有值都是真值，除非它们被定义为 {{Glossary("Falsy", "假值")}}（即除 <code>false</code>、<code>0</code>、<code>""</code>、<code>null</code>、<code>undefined</code>、<code>0n</code> 和 <code>NaN</code> 以外皆为真值）。</p>
 
 <p>{{Glossary("JavaScript")}} 在布尔值上下文中使用强制类型转换（{{Glossary("Type_Conversion", "coercion")}}）。</p>
 


### PR DESCRIPTION
Fixes [#10395](https://github.com/mdn/content/issues/10395)

Add 0n in the falsy values (to match with [English version](https://developer.mozilla.org/en-US/docs/Glossary/Truthy))
```diff
- （即除 <code>false</code>、<code>0</code>、<code>""</code>、<code>null</code>、<code>undefined</code> 和 <code>NaN</code> 以外皆为真值）
+ （即除 <code>false</code>、<code>0</code>、<code>""</code>、<code>null</code>、<code>undefined</code>、<code>0n</code> 和 <code>NaN</code> 以外皆为真值）
```