### PR TITLE
docs : abortSignal 문서 경어체로 수정

### DIFF
--- a/files/ko/web/api/abortsignal/index.html
+++ b/files/ko/web/api/abortsignal/index.html
@@ -12,37 +12,37 @@ translation_of: Web/API/AbortSignal
 ---
 <div>{{APIRef("DOM")}}{{SeeCompatTable}}</div>
 
-<p><strong><code>AbortSignal</code></strong> 인터페이스는 DOM 요청(Fetch와 같은)과 통신하고 필요한 경우 {{domxref("AbortController")}} 객체를 통해 취소할 수 있게 해주는 신호 객체를 나타낸다.</p>
+<p><strong><code>AbortSignal</code></strong> 인터페이스는 DOM 요청(Fetch와 같은)과 통신하고 필요한 경우 {{domxref("AbortController")}} 객체를 통해 취소할 수 있게 해주는 신호 객체를 나타냅니다.</p>
 
 <h2 id="프로퍼티">프로퍼티</h2>
 
-<p><em>AbortSignal 인터페이스는 또한 부모 인터페이스 {{domxref("EventTarget")}}으로부터 프로퍼티를 상속받는다.</em></p>
+<p><em>AbortSignal 인터페이스는 또한 부모 인터페이스 {{domxref("EventTarget")}}으로부터 프로퍼티를 상속받습니다.</em></p>
 
 <dl>
  <dt>{{domxref("AbortSignal.aborted")}} {{readonlyInline}}</dt>
- <dd>신호가 통신하는 요청이 취소되었는지(<code>true</code>) 그렇지 않은지(<code>false</code>)를 나타내는 {{domxref("Boolean")}}.</dd>
+ <dd>신호가 통신하는 요청이 취소되었는지(<code>true</code>) 그렇지 않은지(<code>false</code>)를 나타내는 {{domxref("Boolean")}}입니다.</dd>
 </dl>
 
 <h2 id="이벤트">이벤트</h2>
 
-<p><code><a href="/ko/docs/Web/API/EventTarget/addEventListener">addEventListener()</a></code>를 사용하거나 이 인터페이스의 <code>on<em>eventname</em></code> 프로퍼티로 이벤트 리스너를 할당하여 이벤트를 리슨한다.</p>
+<p><code><a href="/ko/docs/Web/API/EventTarget/addEventListener">addEventListener()</a></code>를 사용하거나 이 인터페이스의 <code>on<em>eventname</em></code> 프로퍼티로 이벤트 리스너를 할당하여 이벤트를 리슨합니다.</p>
 
 <dl>
  <dt><code><a href="/en-US/docs/Web/API/AbortSignal/abort_event">abort</a></code></dt>
- <dd>신호가 통신하는 요청이 취소되었을 때 호출된다. <code><a href="/ko/docs/Web/API/AbortSignal/onabort">onabort</a></code> 프로퍼티를 통해서도 사용이 가능하다.</dd>
+ <dd>신호가 통신하는 요청이 취소되었을 때 호출됩니다. <code><a href="/ko/docs/Web/API/AbortSignal/onabort">onabort</a></code> 프로퍼티를 통해서도 사용이 가능합니다.</dd>
 </dl>
 
 <h2 id="메소드">메소드</h2>
 
-<p><em>AbortSignal 인터페이스는 부모인 {{domxref("EventTarget")}}로부터 메소드를 상속받는다.</em></p>
+<p><em>AbortSignal 인터페이스는 부모인 {{domxref("EventTarget")}}로부터 메소드를 상속받습니다.</em></p>
 
 <h2 id="예제">예제</h2>
 
-<p>다음 스니펫에서는 <a href="/ko/docs/Web/API/Fetch_API">Fetch API</a>를 사용해 비디오를 다운로드하는 것을 목표로 한다.</p>
+<p>다음 스니펫에서는 <a href="/ko/docs/Web/API/Fetch_API">Fetch API</a>를 사용해 비디오를 다운로드하는 것을 목표로 합니다.</p>
 
-<p>먼저 {{domxref("AbortController.AbortController","AbortController()")}} 생성자를 사용해 컨트롤러를 {{domxref("AbortController.signal")}} 프로퍼티를 사용해 {{domxref("AbortSignal")}} 객체와 관계된 참조를 얻는다.</p>
+<p>먼저 {{domxref("AbortController.AbortController","AbortController()")}} 생성자를 사용해 컨트롤러를 {{domxref("AbortController.signal")}} 프로퍼티를 사용해 {{domxref("AbortSignal")}} 객체와 관계된 참조를 얻습니다.</p>
 
-<p><a href="/ko/docs/Web/API/WindowOrWorkerGlobalScope/fetch">Fetch 요청</a>을 시작할 때, 요청의 옵션 객체 내부에 <code>AbortSignal</code> 옵션을 전달한다(아래의 <code>{signal}</code> 참고). 이것은 신호와 컨트롤러를 fetch 요청과 관계짓고, 아래의 두 번째 이벤트 리스너에서 보여주듯이 {{domxref("AbortController.abort()")}}를 호출하여 이를 취소할 수 있게한다.</p>
+<p><a href="/ko/docs/Web/API/WindowOrWorkerGlobalScope/fetch">Fetch 요청</a>을 시작할 때, 요청의 옵션 객체 내부에 <code>AbortSignal</code> 옵션을 전달합니다(아래의 <code>{signal}</code> 참고). 이것은 신호와 컨트롤러를 fetch 요청과 관계짓고, 아래의 두 번째 이벤트 리스너에서 보여주듯이 {{domxref("AbortController.abort()")}}를 호출하여 이를 취소할 수 있게 합니다.</p>
 
 <pre class="brush: js">var controller = new AbortController();
 var signal = controller.signal;
@@ -67,14 +67,14 @@ function fetchVideo() {
 }</pre>
 
 <div class="note">
-<p><strong>노트</strong>: <code>abort()</code>가 호출되면, <code>fetch()</code> promise는 <code dir="ltr">AbortError</code>과 함께 reject된다.</p>
+<p><strong>노트</strong>: <code>abort()</code>가 호출되면, <code>fetch()</code> promise는 <code dir="ltr">AbortError</code>과 함께 reject됩니다.</p>
 </div>
 
 <div class="warning">
-<p>현재 버전의 Firefox는 <code>DOMException</code>으로 promise를 reject한다.</p>
+<p>현재 버전의 Firefox는 <code>DOMException</code>으로 promise를 reject합니다.</p>
 </div>
 
-<p>동작하는 완전한 예제는 GitHub에서 확인 할 수 있다 — <a href="https://github.com/mdn/dom-examples/tree/master/abort-api">abort-api</a> 참고(<a href="https://mdn.github.io/dom-examples/abort-api/">라이브 실행도 확인할 수 있다</a>).</p>
+<p>동작하는 완전한 예제는 GitHub에서 확인 할 수 있습니다 — <a href="https://github.com/mdn/dom-examples/tree/master/abort-api">abort-api</a> 참고(<a href="https://mdn.github.io/dom-examples/abort-api/">라이브 실행도 확인할 수 있습니다</a>).</p>
 
 <h2 id="명세">명세</h2>
 


### PR DESCRIPTION
/ko/docs/Web/API/AbortSignal 문서를 편집했습니다.
Mozilla의 한국어 문서 번역 스타일 가이드에 맞추어
AbortSignal 페이지를 경어체로 수정했습니다.