### PR TITLE
fix typo

### DIFF
--- a/files/pt-br/web/css/white-space/index.html
+++ b/files/pt-br/web/css/white-space/index.html
@@ -131,7 +131,7 @@ white-space: inherit
 <div id="compat-mobile"> </div>
 
 <p>[1] Internet Explorer 5.5+ suporta {{Cssxref("word-wrap")}}<code>: break-word;</code><br>
- O código à seguir permite quebras de linhas dentro de elementos <span style="font-family: consolas,monaco,andale mono,monospace;">pre:</span></p>
+ O código a seguir permite quebras de linhas dentro de elementos <span style="font-family: consolas,monaco,andale mono,monospace;">pre:</span></p>
 
 <pre class="brush: css">pre {
   word-wrap: break-word;      /* IE 5.5-7 */


### PR DESCRIPTION
### Reason:

The expression "**a seguir**" is written with "**a**" not "**à**". Small change but makes it correct.