### PR TITLE
Updated URI in index.html

### DIFF
--- a/files/pt-br/glossary/falsy/index.html
+++ b/files/pt-br/glossary/falsy/index.html
@@ -18,7 +18,7 @@ if (NaN)
 if ('')
 if (document.all) [1]</pre>
 
-<p>[1] <code>document.all </code>tem sido utilizado para a detecção do navegador no passado e a especificação <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/obsolete.html#dom-document-all">HTML define uma violação intencional</a> do padrão ECMAScript aqui para manter a compatibilidade com código legado (<code>if (document.all) { // Internet Explorer code here }</code> ou usando <code>document.all</code> sem verificar sua presença em primeiro lugar: <code>document.all.foo</code>).</p>
+<p>[1] <code>document.all </code>tem sido utilizado para a detecção do navegador no passado e a especificação <a href="https://html.spec.whatwg.org/multipage/obsolete.html#dom-document-all">HTML define uma violação intencional</a> do padrão ECMAScript aqui para manter a compatibilidade com código legado (<code>if (document.all) { // Internet Explorer code here }</code> ou usando <code>document.all</code> sem verificar sua presença em primeiro lugar: <code>document.all.foo</code>).</p>
 
 <h2 id="Aprender_mais">Aprender mais</h2>
 


### PR DESCRIPTION
The URI `http://www.whatwg.org/specs/web-apps/current-work/multipage/obsolete.html#dom-document-all` was changed and it is redirecting to `https://html.spec.whatwg.org/multipage/obsolete.html#dom-document-all`.

To avoid redirection, I placed the new URI in the `href`.