### PR TITLE
大文字小文字の修正

### DIFF
--- a/files/ja/web/api/treewalker/index.html
+++ b/files/ja/web/api/treewalker/index.html
@@ -1,6 +1,6 @@
 ---
-title: treeWalker
-slug: Web/API/treeWalker
+title: TreeWalker
+slug: Web/API/TreeWalker
 tags:
   - API
   - DOM


### PR DESCRIPTION
treeWalker → TreeWalker

[他のAPI](https://developer.mozilla.org/ja/docs/Web/API)や[英語版](https://developer.mozilla.org/en-US/docs/Web/API/Treewalker)も大文字開始でした
