### PR TITLE
Remove etc, added a more explanatory phrase for beginners and spell check

### DIFF
--- a/files/pt-br/mdn/contribute/getting_started/index.html
+++ b/files/pt-br/mdn/contribute/getting_started/index.html
@@ -32,7 +32,7 @@ tags:
 
 <h3 id="Step_3_Do_the_task">Passo 3: Faça a tarefa</h3>
 
-<p>Assim que decidir que tipo de tarefa você quer fazer, procure uma página específica, exemplo de código, etc. para trabalhar e faça!</p>
+<p>Assim que decidir que tipo de tarefa você quer fazer, procure uma página específica, exemplo de código e quaisquer outros recursos para trabalhar e faça!</p>
 
 <h3 id="Step_4_Ask_for_help">Passo 4: Peça ajuda</h3>
 

--- a/files/pt-br/mdn/contribute/getting_started/index.html
+++ b/files/pt-br/mdn/contribute/getting_started/index.html
@@ -32,7 +32,7 @@ tags:
 
 <h3 id="Step_3_Do_the_task">Passo 3: Faça a tarefa</h3>
 
-<p>Assim que decidir que tipo de tarefa você quer fazer, procure uma página específica, exemplo de código e quaisquer outros recursos para trabalhar e faça!</p>
+<p>Assim que decidir que tipo de tarefa você quer fazer, procure uma página específica, exemplo de código e quaisquer outros recursos disponíveis para trabalhar e faça!</p>
 
 <h3 id="Step_4_Ask_for_help">Passo 4: Peça ajuda</h3>
 

--- a/files/pt-br/mdn/contribute/getting_started/index.html
+++ b/files/pt-br/mdn/contribute/getting_started/index.html
@@ -51,7 +51,7 @@ tags:
 <p>Nós esperamos que os contribuidores do MDN tenham uma certa quantidade de conhecimento prévio antes de começar a trabalhar no conteúdo. Se você é novo nos tópicos a seguir, nós aconselhamos que você visite os links fornecidos para te ajudar a começar mais rapidamente:</p>
 
 <ul>
-  <li>Tecnologias Web: Se você é novo com HTML, CSS, JavaScript, etc., confira nossos tutorias para <a href="/pt-BR/docs/Learn">Aprender desenvolvimento web</a>.</li>
+  <li>Tecnologias Web: Se você é novo com HTML, CSS, JavaScript, etc., confira nossos tutoriais para <a href="/pt-BR/docs/Learn">Aprender desenvolvimento web</a>.</li>
   <li>Código aberto: Se você nunca contribuiu com um projeto de código aberto antes, leia <a href="/pt-BR/docs/MDN/Contribute/Open_source_etiquette">Etiqueta básica para projetos de código aberto</a>.</li>
   <li>Git e GitHub: Se você não está familiarizado com estas ferramentas, <a href="/pt-BR/docs/MDN/Contribute/GitHub_beginners">GitHub para iniciantes</a> vai te ajudar a começar.</li>
   <li>Estrutura de repositórios do MDN: Se você não está certo sobre qual repositório editar para mudar diferentes partes do conteúdo do MDN, <a href="/pt-BR/docs/MDN/Contribute/Where_is_everything">Onde está tudo no MDN?</a> será seu ponto de entrada para os lugares certos.</li>


### PR DESCRIPTION
## Description
Português Brasileiro 🇧🇷 
Removi a expressão "etc" (Et Cetera, _do latim_) e substitui por "quaisquer outros recursos disponíveis", acredito que para iniciantes dê a ideia de que podem, de fato, aproveitar tudo que o repositório tem a oferecer.
E também corrigi a escrita da palavra "tutoriais", provável erro de digitação no momento de tradução.