### PR TITLE
(ru) Fix link at "First-class Functions" page

### DIFF
--- a/files/ru/glossary/first-class_function/index.html
+++ b/files/ru/glossary/first-class_function/index.html
@@ -27,8 +27,7 @@ dog(3); //Эту функцию можно вызвать через перем�
 <h3 id="Общее_представление">Общее представление</h3>
 
 <ul>
- <li>{{Interwiki("wikipedia", "First-class functions", "First-class functions")}} on Wikipedia</li>  
-  above must https://ru.wikipedia.org/wiki/First-class_functions for russian but unknow how insert right
+ <li>{{Interwiki("wikipedia", "Функции_первого_класса", "Функции первого класса")}} на Википедии</li>
 </ul>
 
 <p> </p>

--- a/files/ru/glossary/first-class_function/index.html
+++ b/files/ru/glossary/first-class_function/index.html
@@ -27,7 +27,8 @@ dog(3); //Эту функцию можно вызвать через перем�
 <h3 id="Общее_представление">Общее представление</h3>
 
 <ul>
- <li>{{Interwiki("wikipedia", "First-class functions", "First-class functions")}} on Wikipedia</li>
+ <li>{{Interwiki("wikipedia", "First-class functions", "First-class functions")}} on Wikipedia</li>  
+  above must https://ru.wikipedia.org/wiki/First-class_functions for russian but unknow how insert right
 </ul>
 
 <p> </p>


### PR DESCRIPTION
…tps://ru.wikipedia.org/wiki/First-class_functions

link to First-class functions not exist for ru. subdomain of wiki. Right link must this: https://ru.wikipedia.org/wiki/Функции_ первого_ класса

I don't know how insert to row 30:
{{Interwiki("wikipedia", "First-class functions", "First-class functions")}}