### PR TITLE
[ko] translation modified and additional modification

### DIFF
--- a/files/ko/web/api/analysernode/getbytefrequencydata/index.html
+++ b/files/ko/web/api/analysernode/getbytefrequencydata/index.html
@@ -80,13 +80,6 @@ function draw() {
 
 draw();</pre>
 
-<h2 id="Parameters_2">매개변수</h2>
-
-<dl>
- <dt>array</dt>
- <dd>주파수 영역 데이터가 복사될 {{domxref("Uint8Array")}}.</dd>
-</dl>
-
 <h2 id="Specifications">명세</h2>
 
 {{Specifications}}

--- a/files/ko/web/api/analysernode/getfloattimedomaindata/index.html
+++ b/files/ko/web/api/analysernode/getfloattimedomaindata/index.html
@@ -81,14 +81,6 @@ function draw() {
 
 draw();</pre>
 
-
-<h2 id="Parameters_2">매개변수</h2>
-
-<dl>
- <dt>array</dt>
- <dd>시간 영역 데이터가 복사될 {{domxref("Float32Array")}}.</dd>
-</dl>
-
 <h2 id="Specifications">명세</h2>
 
 {{Specifications}}

--- a/files/ko/web/api/audioparam/settargetattime/index.md
+++ b/files/ko/web/api/audioparam/settargetattime/index.md
@@ -23,9 +23,9 @@ var paramRef = param.setTargetAtTime(target, startTime, timeConstant);
 ### 매개변수
 
 - target
-  - : 주어진 시작 시간에 매개변수가 변화를 시작할 값.
+  - : 주어진 시작 시간에 파라미터가 변화를 시작할 값.
 - startTime
-  - : {{domxref("BaseAudioContext/currentTime", "AudioContext.currentTime")}}과 같은 시간 좌표계에서 지수적 변화가 시작될 시간. 만약 이 값이 `AudioContext.currentTime` 보다 작거나 같다면, 매개변수는 즉시 변화를 시작할 것입니다.
+  - : {{domxref("BaseAudioContext/currentTime", "AudioContext.currentTime")}}과 같은 시간 좌표계에서 지수적 변화가 시작될 시간. 만약 이 값이 `AudioContext.currentTime` 보다 작거나 같다면, 파라미터는 즉시 변화를 시작할 것입니다.
 - timeConstant
   - : target 값을 향한 지수적 접근의 시간 상수 값 (초 단위로 주어짐). 이 값이 클수록, 변화는 더 느려질 것입니다.
 

--- a/files/ko/web/api/audioparam/value/index.md
+++ b/files/ko/web/api/audioparam/value/index.md
@@ -27,7 +27,7 @@ audioParam.value = newValue;
 
 ### 값
 
-현재 시간에서의 매개변수의 값을 나타내는 부동점 {{jsxref("Number")}}. 이 값은 {{domxref("AudioParam.minValue", "minValue")}}와 {{domxref("AudioParam.maxValue",
+현재 시간에서의 파라미터의 값을 나타내는 부동점 {{jsxref("Number")}}. 이 값은 {{domxref("AudioParam.minValue", "minValue")}}와 {{domxref("AudioParam.maxValue",
   "maxValue")}} 속성에 의해 명시된 값 사이에 있을 것입니다.
 
 ## 사용 일람
@@ -45,7 +45,7 @@ source.playbackRate.value = rate;
 console.log(source.playbackRate.value === rate);
 ```
 
-출력된 로그는 `false` 일 것인데, 왜냐하면 playback rate 매개변수 `rate` 는 5.3에 가장 가까운 32비트 부동점 number로 전환되고, 이 값은 5.300000190734863이기 때문입니다. 한 가지 해결 방법은 `value` 를 설정할 때 다음과 같이 {{jsxref("Math.fround()")}} 메서드를 사용하는 것인데, 이 메서드는 명시된 64비트 JavaScript 값과 같은 단일 정밀도 값을 반환합니다.
+출력된 로그는 `false` 일 것인데, 왜냐하면 playback rate 파라미터 `rate` 는 5.3에 가장 가까운 32비트 부동점 number로 전환되고, 이 값은 5.300000190734863이기 때문입니다. 한 가지 해결 방법은 `value` 를 설정할 때 다음과 같이 {{jsxref("Math.fround()")}} 메서드를 사용하는 것인데, 이 메서드는 명시된 64비트 JavaScript 값과 같은 단일 정밀도 값을 반환합니다.
 
     const source = new AudioBufferSourceNode(...);
     const rate = Math.fround(5.3);
@@ -57,20 +57,20 @@ console.log(source.playbackRate.value === rate);
 ### 시간에 따라 변화하는 속성의 값
 
 `AudioParam` 의 `value` 는 고정되어 있을 수도 있고 시간에 따라 달라질 수도 있습니다. 이는 `value` getter에 의해 반영되는데, 이것은 오디오 렌더링 엔진의 가장 최근의 **render
-quantum** , 즉 오디오 버퍼가 처리되고 갱신되는 순간에서의 매개변수의 값을 반환합니다. 오디오 버퍼를 처리하는 것에 덧붙여, 각각의 render quantum은 현재 시간과 설정된 시간 기반의 매개변수 값이 변화한다면 필요할 때 각 `AudioParam` 의 `value` 를 갱신합니다.
+quantum** , 즉 오디오 버퍼가 처리되고 갱신되는 순간에서의 파라미터의 값을 반환합니다. 오디오 버퍼를 처리하는 것에 덧붙여, 각각의 render quantum은 현재 시간과 설정된 시간 기반의 파라미터 값이 변화한다면 필요할 때 각 `AudioParam` 의 `value` 를 갱신합니다.
 
-매개변수를 처음 생성했을 때, 매개변수의 값은 {{domxref("AudioParam.defaultValue")}}에 의해 주어지는 기본 값으로 설정됩니다. 이것은 0.0초에서의 이 매개변수의 값이고, 값이 변경되는 첫번째 render quantum 전까지 계속 유지될 것입니다.
+파라미터를 처음 생성했을 때, 파라미터의 값은 {{domxref("AudioParam.defaultValue")}}에 의해 주어지는 기본 값으로 설정됩니다. 이것은 0.0초에서의 이 파라미터의 값이고, 값이 변경되는 첫번째 render quantum 전까지 계속 유지될 것입니다.
 
-각 render quantum 도중에, 브라우저는 매개변수의 값을 관리하는 것에 관련된 다음의 일들을 합니다.
+각 render quantum 도중에, 브라우저는 파라미터의 값을 관리하는 것에 관련된 다음의 일들을 합니다.
 
-- 만약 `value` setter가 사용되었다면, 매개변수의 값은 주어진 값으로 변경됩니다.
+- 만약 `value` setter가 사용되었다면, 파라미터의 값은 주어진 값으로 변경됩니다.
 - 만약 현재 시간이 {{domxref("AudioParam.setValueAtTime", "setValueAtTime()")}}의 이전 호출에 의해 명시된 시간과 같거나 초과한다면, `value` 는 `setValueAtTime()` 에 전달된 값으로 변경됩니다.
 - 만약 graduated나 ramped 방식의 값 변경 메서드가 호출되었고 현재 시간이 graduated된 변화가 발생해야 하는 시간 범위 내에 있다면, 값은 적절한 알고리즘에 기반해 갱신됩니다. ramped나 graduated 값 변화 메서드에는 {{domxref("AudioParam.linearRampToValueAtTime",
     "linearRampToValueAtTime()")}}, {{domxref("AudioParam.setTargetAtTime",
     "setTargetAtTime()")}}, {{domxref("AudioParam.setValueCurveAtTime",
     "setValueCurveAtTime()")}}이 있습니다.
 
-이렇게 하여, 매개변수의 `value` 는 시간에 따른 매개변수의 상태를 정밀하게 반영하도록 유지됩니다.
+이렇게 하여, 파라미터의 `value` 는 시간에 따른 파라미터의 상태를 정밀하게 반영하도록 유지됩니다.
 
 ## 예제
 

--- a/files/ko/web/api/audioworkletnode/audioworkletnode/index.md
+++ b/files/ko/web/api/audioworkletnode/audioworkletnode/index.md
@@ -43,7 +43,7 @@ var node = new AudioWorkletNode(context, name, options);
     - `outputChannelCount` {{optional_inline}}
       - : 각 출력에 대한 채널의 숫자를 정의하는 **배열**. 예를 들자면, _outputChannelCount: \[n, m]_ 은 첫번째 출력의 채널 숫자를 _n_ 으로 그리고 두번째 출력을 _m_ 으로 명시합니다. 배열의 길이는 반드시 `numberOfOutputs`과 일치해야 합니다.
     - `parameterData` {{optional_inline}}
-      - : `key`가 사용자 정의 매개변수의 이름이고 `value`가 이것의 초기 값인 채로, (노드의 {{domxref("AudioWorkletNode.parameters", "parameters")}} 속성에 있는) 이 노드에 있는 사용자 정의 {{domxref("AudioParam")}} 객체의 초기 값을 포함하는 객체.
+      - : `key`가 사용자 정의 파라미터의 이름이고 `value`가 이것의 초기 값인 채로, (노드의 {{domxref("AudioWorkletNode.parameters", "parameters")}} 속성에 있는) 이 노드에 있는 사용자 정의 {{domxref("AudioParam")}} 객체의 초기 값을 포함하는 객체.
     - `processorOptions` {{optional_inline}}
       - : 근본적인 {{domxref("AudioWorkletProcessor")}}의 사용자 정의 초기화를 위해 사용될 수 있는 모든 추가적인 데이터.
 
@@ -60,7 +60,7 @@ var node = new AudioWorkletNode(context, name, options);
 - `IndexSizeError` {{domxref("DOMException")}}
   - : `options.outputChannelCount` 배열의 길이가 `options.numberOfOutputs`와 일치하지 않습니다.
 
-## 사용 시 참고할 점
+## 사용 일람
 
 각기 다른 `options` 매개변수 값들은 다음의 영향을 가질 수 있습니다.
 

--- a/files/ko/web/api/audioworkletnode/parameters/index.md
+++ b/files/ko/web/api/audioworkletnode/parameters/index.md
@@ -53,7 +53,7 @@ class WhiteNoiseProcessor extends AudioWorkletProcessor {
       for (let i = 0; i < channel.length; i++) {
         channel[i] = (Math.random() * 2 - 1) *
           (parameters['customGain'].length > 1 ? parameters['customGain'][i] : parameters['customGain'][0])
-        // 참고: 매개변수는 128개의 값 (각 128 샘플에 대한 하나의 값) 을 가진 배열을 포함하지만,
+        // 참고: 파라미터는 128개의 값 (각 128 샘플에 대한 하나의 값) 을 가진 배열을 포함하지만,
         // 만약 그 순간에 자동화가 스케쥴되어 있지 않다면
         // 모든 128개의 샘플에 대해 사용될 하나의 값을 포함할 수도 있습니다.
       }

--- a/files/ko/web/api/audioworkletprocessor/audioworkletprocessor/index.md
+++ b/files/ko/web/api/audioworkletprocessor/audioworkletprocessor/index.md
@@ -40,7 +40,7 @@ new AudioWorkletProcessor(options);
     - `outputChannelCount` {{optional_inline}}
       - : 각 출력에 대한 채널의 수를 정의하는 **배열**. 예를 들자면, _outputChannelCount: \[n, m]_ 은 첫번째 출력의 채널의 수를 _n_ 으로, 두번째 출력을 _m_ 으로 명시합니다. 배열의 길이는 반드시 `numberOfOutputs` 와 일치해야 합니다.
     - `parameterData` {{optional_inline}}
-      - : `key` 가 사용자 정의 매개변수의 이름이고 `value` 가 이것의 초기 값인 채로, (이 노드의 {{domxref("AudioWorkletNode.parameters", "parameters")}} 속성에 있는) 이 노드의 사용자 정의 {{domxref("AudioParam")}}의 초기 값들을 포함하는 객체.
+      - : `key` 가 사용자 정의 파라미터의 이름이고 `value` 가 이것의 초기 값인 채로, (이 노드의 {{domxref("AudioWorkletNode.parameters", "parameters")}} 속성에 있는) 이 노드의 사용자 정의 {{domxref("AudioParam")}}의 초기 값들을 포함하는 객체.
     - `processorOptions` {{optional_inline}}
       - : 근본적인 {{domxref("AudioWorkletProcessor")}}의 사용자 정의 초기화에 사용될 수 있는 모든 추가적인 데이터
 

--- a/files/ko/web/api/web_audio_api/advanced_techniques/index.html
+++ b/files/ko/web/api/web_audio_api/advanced_techniques/index.html
@@ -31,7 +31,7 @@ tags:
 
 <p>재생될 수 있는 네 가지의 다른 음, 또는 소리가 있습니다. 각 소리는 네 개의 버튼을 가지고 있는데, 이는 음악의 한 마디에 있는 네 개의 비트를 나타냅니다. 이것들이 활성화되었을 때 노트는 소리를 낼 것입니다. 악기가 재생될 때, 이것은 이 비트들의 세트를 가로질러 이동하고 마디를 반복할 것입니다.</p>
 
-<p>각 소리들은 또한 해당 소리를 수정할 수 있는 슬라이더를 가지고 있는데, 이는 이펙트나 우리가 이 소리들을 만들기 위해 사용한 각 기법의 특정한 매개변수를 조작할 수 있게 해 줍니다. 우리가 사용하는 이 기법들은:</p>
+<p>각 소리들은 또한 해당 소리를 수정할 수 있는 슬라이더를 가지고 있는데, 이는 이펙트나 우리가 이 소리들을 만들기 위해 사용한 각 기법의 특정한 파라미터를 조작할 수 있게 해 줍니다. 우리가 사용하는 이 기법들은:</p>
 
 <table class="standard-table">
  <thead>
@@ -141,7 +141,7 @@ releaseControl.addEventListener('input', function() {
 
 <p>이것은 정말로 유용합니다 — 이제 우리는 gain 값에 audio param 메서드의 힘을 사용할 수 있습니다. 우리는 특정한 시간에 값을 설정할 수 있거나, {{domxref("AudioParam.linearRampToValueAtTime")}}과 같은 메서드로 시간에 <strong>따라</strong> 이것을 변화시킬 수 있습니다.</p>
 
-<p>우리의 attack과 release에 대해, 우리는 위에서 언급된 <code>linearRampToValueAtTime</code> 메서드를 사용할 것입니다. 이것은 두 개의 매개변수를 취합니다 — 변화시키고 있는 매개변수에 설정하기 원하는 값 (이 경우 gain) 그리고 언제 이것을 하고 싶은지. 우리의 경우 <strong>언제</strong>는 우리의 입력에 의해 제어됩니다. 그래서 아래의 예제에서 gain은 attack 범위 입력이 설정된 시간에 따라 선형 비율로 1까지 증가됩니다. 비슷하게 release의 경우, release 입력이 설정된 시간에 걸쳐 선형 비율로 gain은 0으로 설정됩니다.</p>
+<p>우리의 attack과 release에 대해, 우리는 위에서 언급된 <code>linearRampToValueAtTime</code> 메서드를 사용할 것입니다. 이것은 두 개의 매개변수를 취합니다 — 변화시키고 있는 파라미터에 설정하기 원하는 값 (이 경우 gain) 그리고 언제 이것을 하고 싶은지. 우리의 경우 <strong>언제</strong>는 우리의 입력에 의해 제어됩니다. 그래서 아래의 예제에서 gain은 attack 범위 입력이 설정된 시간에 따라 선형 비율로 1까지 증가됩니다. 비슷하게 release의 경우, release 입력이 설정된 시간에 걸쳐 선형 비율로 gain은 0으로 설정됩니다.</p>
 
 <pre class="brush: js">let sweepLength = 2;
 function playSweep(time) {
@@ -210,7 +210,7 @@ osc.stop(time + pulseTime);</pre>
 &lt;label for="lfo"&gt;LFO&lt;/label&gt;
 &lt;input name="lfo" id="lfo" type="range" min="20" max="40" value="30" step="1" /&gt;</pre>
 
-<p>이전처럼, 우리는 range 입력 값이 사용자에 의해 변화되었을 때 매개변수에 변화를 줄 것입니다.</p>
+<p>이전처럼, 우리는 range 입력 값이 사용자에 의해 변화되었을 때 파라미터에 변화를 줄 것입니다.</p>
 
 <pre class="brush: js">let pulseHz = 880;
 const hzControl = document.querySelector('#hz');

--- a/files/ko/web/api/web_audio_api/controlling_multiple_parameters_with_constantsourcenode/index.html
+++ b/files/ko/web/api/web_audio_api/controlling_multiple_parameters_with_constantsourcenode/index.html
@@ -1,5 +1,5 @@
 ---
-title: ConstantSourceNode로 다수의 매개변수 제어하기
+title: ConstantSourceNode로 다수의 파라미터 제어하기
 slug: Web/API/Web_Audio_API/Controlling_multiple_parameters_with_ConstantSourceNode
 tags:
   - Audio
@@ -13,17 +13,17 @@ tags:
 ---
 <div>{{APIRef("Web Audio API")}}</div>
 
-<p><span class="seoSummary">이 글은 다수의 매개변수가 같은 값을 공유하도록 매개변수들을 함께 연결하기 위해 어떻게 {{domxref("ConstantSourceNode")}}를 사용하는지를 설명합니다. 이 값은 {{domxref("ConstantSourceNode.offset")}} 매개변수의 값을 설정함으로써 변경될 수 있습니다.</span></p>
+<p><span class="seoSummary">이 글은 다수의 파라미터가 같은 값을 공유하도록 파라미터들을 함께 연결하기 위해 어떻게 {{domxref("ConstantSourceNode")}}를 사용하는지를 설명합니다. 이 값은 {{domxref("ConstantSourceNode.offset")}} 파라미터의 값을 설정함으로써 변경될 수 있습니다.</span></p>
 
-<p>간혹 다수의 오디오 매개변수들이 같은 값을 공유할 수 있도록, 심지어 값이 어떤 방법으로 변경되는 동안일지라도, 연결시켜두고 싶을 때가 있습니다. 예를 들자면, 한 세트의 오실레이터들이 있고, 이 두 개가 하나의 설정 가능한 볼륨을 공유할 필요가 있거나, 특정한 입력에 적용되나 모든 입력에는 적용되지 않는 필터가 있을 수도 있습니다. 반복문을 사용하여 각각의 영향받는 {{domxref("AudioParam")}}의 값을 한번에 하나씩 변경할 수도 있겠지만, 여기에는 두 가지 문제점이 있습니다. 첫째는, 곧 보게 되겠지만, 작성할 필요가 없는 추가적인 코드의 작성입니다. 그리고 둘째는, 그 반복은 스레드 (메인 스레드일 가능성이 높음) 의 소중한 CPU 시간을 사용합니다. 이런 작업을 이에 최적화되어 있으며 여러분의 코드보다 더욱 적합한 우선도에서 실행할 수 있는 오디오 렌더링 스레드에 넘길 수 있는 방법이 있습니다.</p>
+<p>간혹 다수의 오디오 파라미터들이 같은 값을 공유할 수 있도록, 심지어 값이 어떤 방법으로 변경되는 동안일지라도, 연결시켜두고 싶을 때가 있습니다. 예를 들자면, 한 세트의 오실레이터들이 있고, 이 두 개가 하나의 설정 가능한 볼륨을 공유할 필요가 있거나, 특정한 입력에 적용되나 모든 입력에는 적용되지 않는 필터가 있을 수도 있습니다. 반복문을 사용하여 각각의 영향받는 {{domxref("AudioParam")}}의 값을 한번에 하나씩 변경할 수도 있겠지만, 여기에는 두 가지 문제점이 있습니다. 첫째는, 곧 보게 되겠지만, 작성할 필요가 없는 추가적인 코드의 작성입니다. 그리고 둘째는, 그 반복은 스레드 (메인 스레드일 가능성이 높음) 의 소중한 CPU 시간을 사용합니다. 이런 작업을 이에 최적화되어 있으며 여러분의 코드보다 더욱 적합한 우선도에서 실행할 수 있는 오디오 렌더링 스레드에 넘길 수 있는 방법이 있습니다.</p>
 
 <p>그 해결책이란 간단한데, 바로 첫눈에는 그다지 유용해 보이지 않는 오디오 노드 유형 {{domxref("ConstantSourceNode")}}을 사용하는 것입니다.</p>
 
 <h2 id="The_technique">기법</h2>
 
-<p>이 방법은 듣기엔 어려워 보이지만 사실은 굉장히 쉽습니다. {{domxref("ConstantSourceNode")}}를 생성하고 항상 일치하는 값을 갖도록 연결된 모든 {{domxref("AudioParam")}}에 이 노드를 연결합니다. <code>ConstantSourceNode</code>의 {{domxref("ConstantSourceNode.offset", "offset")}} 값은 모든 출력으로 바로 전달되므로, 이 노드는 그 값을 각각의 연결된 매개변수에 보내는 스플리터 역할을 합니다.</p>
+<p>이 방법은 듣기엔 어려워 보이지만 사실은 굉장히 쉽습니다. {{domxref("ConstantSourceNode")}}를 생성하고 항상 일치하는 값을 갖도록 연결된 모든 {{domxref("AudioParam")}}에 이 노드를 연결합니다. <code>ConstantSourceNode</code>의 {{domxref("ConstantSourceNode.offset", "offset")}} 값은 모든 출력으로 바로 전달되므로, 이 노드는 그 값을 각각의 연결된 파라미터에 보내는 스플리터 역할을 합니다.</p>
 
-<p>아래의 그림은 이 과정이 어떻게 작동하는지 보여줍니다. 입력값 <code>N</code>은 {{domxref("ConstantSourceNode.offset")}} 속성의 값으로 설정됩니다. <code>ConstantSourceNode</code>는 필요한 만큼 많은 출력을 가질 수 있습니다. 아래 그림의 경우, <code>ConstantSourceNode</code>를 세 개의 노드에 연결했습니다. 두 개의 {{domxref("GainNode")}}와 {{domxref("StereoPannerNode")}}입니다. 그래서 <code>N</code>은 명시된 매개변수의 값이 됩니다 ({{domxref("GainNode")}}의 {{domxref("GainNode.gain", "gain")}}, {{domxref("StereoPannerNode")}}의 pan).</p>
+<p>아래의 그림은 이 과정이 어떻게 작동하는지 보여줍니다. 입력값 <code>N</code>은 {{domxref("ConstantSourceNode.offset")}} 속성의 값으로 설정됩니다. <code>ConstantSourceNode</code>는 필요한 만큼 많은 출력을 가질 수 있습니다. 아래 그림의 경우, <code>ConstantSourceNode</code>를 세 개의 노드에 연결했습니다. 두 개의 {{domxref("GainNode")}}와 {{domxref("StereoPannerNode")}}입니다. 그래서 <code>N</code>은 명시된 파라미터의 값이 됩니다 ({{domxref("GainNode")}}의 {{domxref("GainNode.gain", "gain")}}, {{domxref("StereoPannerNode")}}의 pan).</p>
 
 <p><img alt="어떻게 ConstantSourceNode가 입력 매개변수를 다수의 노드에 공유하기 위해 사용될 수 있는지를 보여주는 SVG 그림." src="customsourcenode-as-splitter.svg"></p>
 
@@ -214,9 +214,9 @@ window.addEventListener("load", setup, false);
   constantNode.offset.value = volumeControl.value;
 }</pre>
 
-<p>이 간단한 함수는 두 노드의 gain을 제어합니다. 우리가 해야 하는 것은 {{domxref("ConstantSourceNode")}}의 {{domxref("ConstantSourceNode.offset", "offset")}} 매개변수의 값을 설정하는 것 뿐입니다. 이 값은 노드의 상수 출력 값이 되는데, 이는 노드의 모든 출력에 전달되고, 이 출력이라 함은, 위에서 설정되었다시피 <code>gainNode2</code>와 <code>gainNode3</code>입니다.</p>
+<p>이 간단한 함수는 두 노드의 gain을 제어합니다. 우리가 해야 하는 것은 {{domxref("ConstantSourceNode")}}의 {{domxref("ConstantSourceNode.offset", "offset")}} 파라미터의 값을 설정하는 것 뿐입니다. 이 값은 노드의 상수 출력 값이 되는데, 이는 노드의 모든 출력에 전달되고, 이 출력이라 함은, 위에서 설정되었다시피 <code>gainNode2</code>와 <code>gainNode3</code>입니다.</p>
 
-<p>이것이 아주 간단한 예제이긴 하지만, 다수의 연결된 노드에서 재생되는 다수의 연결된 매개변수를 가진 32개의 오실레이터 신시사이저를 상상해 보십시오. 그것들 모두를 조정하기 위해 연산의 수를 줄일 수 있음은 코드의 크기와 성능 양 쪽 모두에 대해 매우 유용함을 증명할 것입니다.</p>
+<p>이것이 아주 간단한 예제이긴 하지만, 다수의 연결된 노드에서 재생되는 다수의 연결된 파라미터를 가진 32개의 오실레이터 신시사이저를 상상해 보십시오. 그것들 모두를 조정하기 위해 연산의 수를 줄일 수 있음은 코드의 크기와 성능 양 쪽 모두에 대해 매우 유용함을 증명할 것입니다.</p>
 
 <h4 id="오실레이터_재생하기">오실레이터 재생하기</h4>
 

--- a/files/ko/web/api/web_audio_api/index.html
+++ b/files/ko/web/api/web_audio_api/index.html
@@ -264,7 +264,7 @@ translation_of: Web/API/Web_Audio_API
 <ul>
 	<li><a href="https://github.com/bit101/tones">Tones</a>: Web Audio API를 사용하여 특정한 음색/음을 재생하는 간단한 라이브러리</li>
 	<li><a href="https://tonejs.github.io/">Tone.js</a>: 브라우저에서 상호작용을 하는 음악을 생성하기 위한 프레임워크</li>
-	<li><a href="https://github.com/goldfire/howler.js/">howler.js</a>: 다른 유용한 기능들을 제공할 뿐만 아니라, <a href="https://webaudio.github.io/web-audio-api/">Web Audio API</a>을 기본으로 하고 <a href="https://www.whatwg.org/specs/web-apps/current-work/#the-audio-element">HTML5 Audio</a>을 대비책으로 가지는 JS 오디오 라이브러리</li>
+	<li><a href="https://github.com/goldfire/howler.js/">howler.js</a>: 다른 유용한 기능들을 제공할 뿐만 아니라, <a href="https://webaudio.github.io/web-audio-api/">Web Audio API</a>을 기본으로 하고 <a href="https://www.whatwg.org/specs/web-apps/current-work/#the-audio-element">HTML5 Audio</a>를 대비책으로 가지는 JS 오디오 라이브러리</li>
 	<li><a href="https://github.com/mattlima/mooog">Mooog</a>: jQuery 스타일의 AudioNode 체이닝, mixer 스타일의 전송/반환, 등등</li>
 	<li><a href="https://korilakkuma.github.io/XSound/">XSound</a>: 신시사이저, 이펙트, 시각화, 레코딩 등을 위한 Web Audio API 라이브러리</li>
 	<li><a class="external external-icon" href="https://github.com/chrisjohndigital/OpenLang">OpenLang</a>: 다른 소스로부터 하나의 파일에 비디오와 오디오를 레코드하고 결합시키기 위한 Web Audio API를 사용하는 HTML5 비디오 language lab 웹 애플리케이션 (<a class="external external-icon" href="https://github.com/chrisjohndigital/OpenLang">GitHub에 있는 소스</a>)</li>

--- a/files/ko/web/api/web_audio_api/index.html
+++ b/files/ko/web/api/web_audio_api/index.html
@@ -264,7 +264,7 @@ translation_of: Web/API/Web_Audio_API
 <ul>
 	<li><a href="https://github.com/bit101/tones">Tones</a>: Web Audio API를 사용하여 특정한 음색/음을 재생하는 간단한 라이브러리</li>
 	<li><a href="https://tonejs.github.io/">Tone.js</a>: 브라우저에서 상호작용을 하는 음악을 생성하기 위한 프레임워크</li>
-	<li><a href="https://github.com/goldfire/howler.js/">howler.js</a>: 다른 유용한 기능들을 제공할 뿐만 아니라, <a href="https://webaudio.github.io/web-audio-api/">Web Audio API</a>을 기본으로 하고 <a href="https://www.whatwg.org/specs/web-apps/current-work/#the-audio-element">HTML5 Audio</a>에 대안을 제공하는 JS 오디오 라이브러리</li>
+	<li><a href="https://github.com/goldfire/howler.js/">howler.js</a>: 다른 유용한 기능들을 제공할 뿐만 아니라, <a href="https://webaudio.github.io/web-audio-api/">Web Audio API</a>을 기본으로 하고 <a href="https://www.whatwg.org/specs/web-apps/current-work/#the-audio-element">HTML5 Audio</a>을 대비책으로 가지는 JS 오디오 라이브러리</li>
 	<li><a href="https://github.com/mattlima/mooog">Mooog</a>: jQuery 스타일의 AudioNode 체이닝, mixer 스타일의 전송/반환, 등등</li>
 	<li><a href="https://korilakkuma.github.io/XSound/">XSound</a>: 신시사이저, 이펙트, 시각화, 레코딩 등을 위한 Web Audio API 라이브러리</li>
 	<li><a class="external external-icon" href="https://github.com/chrisjohndigital/OpenLang">OpenLang</a>: 다른 소스로부터 하나의 파일에 비디오와 오디오를 레코드하고 결합시키기 위한 Web Audio API를 사용하는 HTML5 비디오 language lab 웹 애플리케이션 (<a class="external external-icon" href="https://github.com/chrisjohndigital/OpenLang">GitHub에 있는 소스</a>)</li>

--- a/files/ko/web/api/web_audio_api/migrating_from_webkitaudiocontext/index.html
+++ b/files/ko/web/api/web_audio_api/migrating_from_webkitaudiocontext/index.html
@@ -215,7 +215,7 @@ panner.distanceModel = "exponential";               // exponential distance 모�
 
 <h2 id="Gain_control_moved_to_its_own_node_type">Gain 제어는 이것만의 노드 유형으로 이동됨</h2>
 
-<p>Web Audio 표준은 이제 모든 gain을 {{domxref("GainNode")}}를 사용하여 제어합니다. <code>gain</code> 속성을 직접 음원에 설정하는 대신, 여러분은 소스를 gain 노드에 연결하고 이 노드의 <code>gain</code> 매개변수를 사용하여 gain을 제어합니다.</p>
+<p>Web Audio 표준은 이제 모든 gain을 {{domxref("GainNode")}}를 사용하여 제어합니다. <code>gain</code> 속성을 직접 음원에 설정하는 대신, 여러분은 소스를 gain 노드에 연결하고 이 노드의 <code>gain</code> 파라미터를 사용하여 gain을 제어합니다.</p>
 
 <h3 id="AudioBufferSourceNode">AudioBufferSourceNode</h3>
 

--- a/files/ko/web/api/web_audio_api/using_web_audio_api/index.html
+++ b/files/ko/web/api/web_audio_api/using_web_audio_api/index.html
@@ -48,7 +48,7 @@ translation_of: Web/API/Web_Audio_API/Using_Web_Audio_API
 
 <p>Web Audio API로 무엇인가를 하기 위해서는 오디오 컨텍스트의 인스턴스를 생성할 필요가 있습니다. 이는 우리에게 API의 모든 기능에 접근할 수 있게 합니다.</p>
 
-<pre class="brush: js">// for legacy browsers
+<pre class="brush: js">// 레거시 브라우저를 위해
 const AudioContext = window.AudioContext || window.webkitAudioContext;
 
 const audioContext = new AudioContext();
@@ -73,10 +73,10 @@ const audioContext = new AudioContext();
 
 <p>Web Audio API로 얻을 수 있는 모든 것을 사용하려면 이 요소에서 소스를 가져와 우리가 만든 컨텍스트에 연결해야 합니다. 운 좋게도 이걸 할 수 있는 메서드가 있습니다 — {{domxref("AudioContext.createMediaElementSource")}}입니다:</p>
 
-<pre class="brush: js">// get the audio element
+<pre class="brush: js">// 오디오 요소를 얻습니다
 const audioElement = document.querySelector('audio');
 
-// pass it into the audio context
+// 오디오 요소를 오디오 컨텍스트에 전달합니다
 const track = audioContext.createMediaElementSource(audioElement);
 </pre>
 
@@ -112,17 +112,17 @@ const track = audioContext.createMediaElementSource(audioElement);
 
 <p>이제 우리는 재생과 정지 기능을 추가할 수 있습니다.</p>
 
-<pre class="brush: js">// select our play button
+<pre class="brush: js">// 재생 버튼을 선택합니다
 const playButton = document.querySelector('button');
 
 playButton.addEventListener('click', function() {
 
-    // check if context is in suspended state (autoplay policy)
+    // 컨텍스트가 연기된(suspended) 상태에 있는지 검사합니다 (자동 재생 정책)
     if (audioContext.state === 'suspended') {
         audioContext.resume();
     }
 
-    // play or pause track depending on state
+    // 상태에 따라 트랙을 재생하거나 정지합니다
     if (this.dataset.playing === 'false') {
         audioElement.play();
         this.dataset.playing = 'true';
@@ -180,7 +180,7 @@ volumeControl.addEventListener('input', function() {
 </pre>
 
 <div class="note">
-<p><strong>참고</strong>: 노드 객체의 값 (예: <code>GainNode.gain</code>)은 간단한 값이 아닙니다; 실제로는 {{domxref("AudioParam")}} 유형의 객체입니다 — 이것들은 매개변수라고 불립니다. 이것이 우리가 단순히 <code>gain</code>에 직접 값을 설정하기보다, <code>GainNode.gain</code>의 <code>value</code> 속성을 설정해야만 하는 이유입니다. 예를 들자면, 매개변수에 설정된 기간 동안 사이에 변화하는 특정한 값들의 집합을 전달하는 것을 감안하며, 이는 이것들이 더욱 유연하게 될 수 있게 합니다.</p>
+<p><strong>참고</strong>: 노드 객체의 값 (예: <code>GainNode.gain</code>)은 단순한 값이 아닙니다. 이 값은 실제로는 {{domxref("AudioParam")}} 유형의 객체입니다 — 이것은 파라미터라고 불립니다. 이것이 바로 <code>gain</code>에 직접 값을 설정하기보다, <code>GainNode.gain</code>의 <code>value</code> 속성을 설정해야 하는 이유입니다. 이렇게 함은 이 객체가 좀 더 유연해 질 수 있게 하는데, 예를 들자면 파라미터에 주어진 시간 사이에서 변화시킬 값들의 집합을 전달하는 것을 고려해 볼 수 있겠습니다.</p>
 </div>
 
 <p>좋습니다, 이제 사용자는 트랙의 볼륨을 업데이트할 수 있습니다! gain 노드는 만약 여러분이 무음 기능을 추가하기를 원한다면 사용하기에 완벽한 노드입니다.</p>


### PR DESCRIPTION
지금까지 번역했던 Web Audio API 문서 중 parameter 번역이 올바르게 되지 않았던 문서들을 수정한 pr입니다.
This is a pr that modifies some documents which have a wrongly translated term for 'parameter' among Web Audio API documents I have translated until now.

● 적절치 못한 맥락에서 사용되었던 'parameter'의 번역 수정 (단, 맥락 상 매개변수가 옳아 보이는 곳에서는 사용을 유지했습니다.)
- #1535
- #1609
- #2800
- #2815
- #2830
- #2886
- #2933
- #2949
- #3075

● 추가적인 수정 (additional modification)
- Using the Web Audio API: 주석 번역, 기존 번역 조금 수정
- Web Audio API: 기존 번역 조금 수정 (처음 번역 당시 'falls back' 을 뭐라고 번역해야 할 지 모르겠어서 여쭤본 후 '대안을 제시하는' 을 추천받아 그렇게 번역하였으나 지금 다시 보니 맥락 상 '대비책으로 가지는' 이 적절해 보여 수정하였습니다)
- AnalyserNode.getByteFrequencyData(): 중복되는 parameter 단락 삭제 (관련 content 레포지토리 pr: https://github.com/mdn/content/pull/10615)
- AnalyserNode.getFloatTimeDomainData(): 중복되는 parameter 단락 삭제 (관련 content 레포지토리 pr: 상동)
- AudioWorkletNode(): 사용시 참고할 점 → 사용 일람 (변경근거: docs/ko/translation-guide.md)