### PR TITLE
[ko] Fix typo RegExp.prototype.text 수정

### DIFF
--- a/files/ko/web/javascript/reference/global_objects/regexp/exec/index.html
+++ b/files/ko/web/javascript/reference/global_objects/regexp/exec/index.html
@@ -18,7 +18,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/exec
 
 <p>(캡처 그룹을 포함한) 문자열 내의 다수 일치를 수행할 수 있는 보다 간편한 신규 메서드,  {{jsxref("String.prototype.matchAll()")}}이 제안된 상태입니다.</p>
 
-<p>단순히 <code>true</code>/<code>false</code>가 필요한 경우 {{jsxref("RegExp.prototype.text()")}} 메서드 혹은 {{jsxref("String.prototype.search()")}}를 사용하세요.</p>
+<p>단순히 <code>true</code>/<code>false</code>가 필요한 경우 {{jsxref("RegExp.prototype.test()")}} 메서드 혹은 {{jsxref("String.prototype.search()")}}를 사용하세요.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/regexp-prototype-exec.html")}}</div>
 


### PR DESCRIPTION
#3134 

### 오타

* 번역자께서 `RegExp.prototype.test`메소드를 의미하고 작성하셨지만, `RegExp.prototype.text`로 오타가 난 것 같습니다.

### 수정

* <strike>`RegExp.prototype.text`</strike> -> `RegExp.prototype.test`로 수정하였습니다.