### PR TITLE
Fix: Ordered List Wrong Attribute

### DIFF
--- a/files/fr/web/html/element/ol/index.md
+++ b/files/fr/web/html/element/ol/index.md
@@ -164,7 +164,7 @@ Le HTML ci-dessus affichera :
 ### Utilisation des chiffres romains
 
 ```html
-<ol start="i">
+<ol type="i">
   <li>Introduction</li>
   <li>Liste des Greffes</li>
   <li>Conclusion</li>


### PR DESCRIPTION
`<ol start="i">` should be `<ol type="i">` in order to display Roman numeral type