### PR TITLE
”无效的 JavaScript 标识符作为属性名称“一节输出值有误

### DIFF
--- a/files/zh-cn/web/javascript/reference/operators/destructuring_assignment/index.html
+++ b/files/zh-cn/web/javascript/reference/operators/destructuring_assignment/index.html
@@ -370,7 +370,7 @@ rest; // { c: 30, d: 40 }</pre>
 <pre class="brush: js">const foo = { 'fizz-buzz': true };
 const { 'fizz-buzz': fizzBuzz } = foo;
 
-console.log(fizzBuzz); // "true"
+console.log(fizzBuzz); // true
 </pre>
 
 <h3 id="解构对象时会查找原型链（如果属性不在对象自身，将从原型链中查找）">解构对象时会查找原型链（如果属性不在对象自身，将从原型链中查找）</h3>


### PR DESCRIPTION
输出值应是 boolean true，不是字符串 "true"