### PR TITLE
Learn/Tools_and_testing/Understanding_client-side_tools のリンク誤りを修正

### DIFF
--- a/files/ja/learn/tools_and_testing/understanding_client-side_tools/index.html
+++ b/files/ja/learn/tools_and_testing/understanding_client-side_tools/index.html
@@ -18,11 +18,11 @@ tags:
 <p class="summary">クライアントサイドツールには、なかなか難しいものもありますが、この記事シリーズでは、いくつかの一般的なクライアントサイドツールの種類について、その目的を示し、一緒に連携させることができるツール、パッケージマネージャを使ったインストール方法、
   コマンドラインでの制御を説明します。最後にツールチェーンの例を示して、生産性を高める方法を説明します。</p>
 
-<p class="summary"><strong><a href="/jp/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Overview">"クライアントサイドツールの概要"で今すぐ始めましょう</a></strong></p>
+<p class="summary"><strong><a href="/ja/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Overview">"クライアントサイドツールの概要"で今すぐ始めましょう</a></strong></p>
 
 <h2 id="Prerequisites">前提条件</h2>
 
-<p>ここで紹介しているツールを使う前に、まずはコアの<a href="/jp/docs/Learn/HTML">HTML</a>、<a href="/jp/docs/Learn/CSS">CSS</a>、<a href="/jp/docs/Learn/JavaScript">JavaScript</a>の基礎を学習することをお勧めします。</p>
+<p>ここで紹介しているツールを使う前に、まずはコアの<a href="/ja/docs/Learn/HTML">HTML</a>、<a href="/ja/docs/Learn/CSS">CSS</a>、<a href="/ja/docs/Learn/JavaScript">JavaScript</a>の基礎を学習することをお勧めします。</p>
 
 <div class="callout">
   <h4 id="Looking_to_become_a_front-end_web_developer">フロントエンドのウェブ開発者を目指している方へ</h4>
@@ -36,14 +36,14 @@ tags:
 <h2 id="Guides">ガイド</h2>
 
 <dl>
- <dt><a href="/jp/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Overview">1. クライアントサイドツールの概要</a></dt>
+ <dt><a href="/ja/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Overview">1. クライアントサイドツールの概要</a></dt>
  <dd>この記事では、最新のウェブツールの概要、どのような種類のツールがあるのか、どこでウェブアプリ開発のライフサイクルを見つけるのか、そして個々のツールのヘルプを見つける方法について説明します。</dd>
- <dt><a href="/jp/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Command_line">2. コマンドライン集中コース</a></dt>
+ <dt><a href="/ja/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Command_line">2. コマンドライン集中コース</a></dt>
  <dd>開発プロセスにおいて、ターミナル (または"コマンドライン") で何らかのコマンドを実行する必要があることは間違いありません。この記事では、ターミナルの紹介、ターミナルに入力する基本的なコマンド、コマンドを連鎖させる方法、独自のコマンドライン・インターフェース (CLI) ツールを追加する方法について説明します。</dd>
- <dt><a href="/jp/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Package_management">3. パッケージ管理の基本</a></dt>
+ <dt><a href="/ja/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Package_management">3. パッケージ管理の基本</a></dt>
  <dd>この記事では、プロジェクトツールの依存関係をインストールしたり、最新の状態に保つなど、自分のプロジェクトでどのようにパッケージマネージャを使用できるかを理解するために、パッケージマネージャーについて詳しく説明していきます。</dd>
- <dt><a href="/jp/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Introducing_complete_toolchain">4. ツールチェーンの紹介</a></dt>
+ <dt><a href="/ja/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Introducing_complete_toolchain">4. ツールチェーンの紹介</a></dt>
  <dd>このシリーズの最後の数回では、サンプルケーススタディのツールチェーンを構築するプロセスを通じて、ツールに関する知識を確実なものにします。開発環境を構築し、変換ツールを導入し、実際にアプリをNetlifyにデプロイするプロセスを紹介します。</dd>
- <dt><a href="/jp/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Deployment">5. アプリのデプロイ</a></dt>
+ <dt><a href="/ja/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Deployment">5. アプリのデプロイ</a></dt>
  <dd>シリーズの最終回では、前回の記事で構築したツールチェーンの例を使い、サンプルアプリをデプロイできるようにしていきます。コードをGitHubにプッシュし、Netlifyを使ってデプロイし、簡単なテストを組み込む方法も紹介します。</dd>
 </dl>


### PR DESCRIPTION
jp となっているのを ja に修正