### PR TITLE
ダイアログ要素にformを用いた際のreturnValueの記述の修正

### DIFF
--- a/files/ja/web/html/element/dialog/index.html
+++ b/files/ja/web/html/element/dialog/index.html
@@ -67,7 +67,7 @@ translation_of: Web/HTML/Element/dialog
 <h2 id="Usage_notes" name="Usage_notes">使用上の注意</h2>
 
 <ul>
- <li>{{HTMLElement("form")}} 要素は <code>method="dialog"</code> 属性が指定されていれば、ダイアログを閉じることができます。そのようなフォームが送信されると、 {{domxref("HTMLDialogElement.returnValue", "returnValue")}} プロパティがフォーム送信するために使用されたボタンの <code>value</code> に設定されて、ダイアログが閉じられます。</li>
+ <li>{{HTMLElement("form")}} 要素は <code>method="dialog"</code> 属性が指定されていれば、ダイアログを閉じることができます。そのようなフォームが送信されると、 {{domxref("HTMLDialogElement.returnValue", "returnValue")}} プロパティにフォーム送信するために使用されたボタンの <code>value</code> が設定されて、ダイアログが閉じられます。</li>
  <li>CSS の {{cssxref('::backdrop')}} 擬似要素を使用して、 <code>&lt;dialog&gt;</code> 要素が {{domxref("HTMLDialogElement.showModal()")}} で表示されたときの背後のスタイルを設定することができます。例えば、モーダルダイアログの背後にある操作できないコンテンツを暗くするなどです。</li>
 </ul>
 


### PR DESCRIPTION
formを用いた場合の動作に関する注意点として、「returnValueプロパティが...buttonのvalueに設定されて、...」とありますが、現在の記載では、returnValueの値がbuttonのvalueへ代入されるように読めてしまうと思います。

この修正では、returnValueに対してbuttonのvalue値が代入されることを明確にすることを意図しています。

確認いただけたらと思います。