### PR TITLE
Remove `shortcut` from the example for favicon

### DIFF
--- a/files/ja/web/html/element/link/index.html
+++ b/files/ja/web/html/element/link/index.html
@@ -259,7 +259,7 @@ translation_of: Web/HTML/Element/link
 &lt;!-- 高解像度でない iPhone, iPod Touch, Android 2.1 以降の端末 --&gt;
 &lt;link rel="apple-touch-icon-precomposed" href="favicon57.png"&gt;
 &lt;!-- 基本的なファビコン --&gt;
-&lt;link rel="shortcut icon" href="favicon32.png"&gt;</pre>
+&lt;link rel="icon" href="favicon32.png"&gt;</pre>
 
 <h3 id="メディアクエリのついた条件付きのリソース読み込み">メディアクエリのついた条件付きのリソース読み込み</h3>
 


### PR DESCRIPTION
As described in MDN itself, web authors must no longer use `shortcut` as the link type.

> Warning: The shortcut link type is often seen before icon, but this link type is non-conforming, ignored and web authors must not use it anymore.

https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types