### PR TITLE
Update fr CSS -gap docs

### DIFF
--- a/files/fr/web/css/column-gap/index.md
+++ b/files/fr/web/css/column-gap/index.md
@@ -1,15 +1,12 @@
 ---
 title: column-gap (grid-column-gap)
 slug: Web/CSS/column-gap
-tags:
-  - CSS
-  - Propriété
-  - Reference
 translation_of: Web/CSS/column-gap
+browser-compat: css.properties.column-gap
 ---
 {{CSSRef}}
 
-La propriété **`column-gap`** permet de définir la taille des espaces ({{glossary("gutters", "gouttières")}}) entre les colonnes d'un élément.
+La propriété **`column-gap`** permet de définir la taille des espaces ([gouttières](/fr/docs/Glossary/Gutters)) entre les colonnes d'un élément.
 
 {{EmbedInteractiveExample("pages/css/column-gap.html")}}
 
@@ -41,12 +38,16 @@ column-gap: unset;
 
 - `normal`
   - : Un mot-clé qui indique qu'on souhaite utiliser l'espacement par défaut créé par le navigateur. Pour les dispositions en colonnes, cette valeur correspond à `1em`, sinon elle correspond à `0`.
-- {{CSSxRef("&lt;length&gt;")}}
-  - : Une valeur de longueur (type {{CSSxRef("&lt;length&gt;")}}) qui définit la taille de l'espace entre les colonnes. Cette valeur peut être nulle mais ne doit pas être négative.
-- {{CSSxRef("&lt;percentage&gt;")}}
-  - : Une valeur de pourcentage (type {{CSSxRef("&lt;percentage&gt;")}}) qui définit la taille de l'espace entre les colonnes. Cette valeur peut être nulle mais ne doit pas être négative.
+- [`<length>`](/fr/docs/Web/CSS/length)
+  - : Une valeur de longueur (type [`<length>`](/fr/docs/Web/CSS/length)) qui définit la taille de l'espace entre les colonnes. Cette valeur peut être nulle mais ne doit pas être négative.
+- [`<percentage>`](/fr/docs/Web/CSS/percentage)
+  - : Une valeur de pourcentage (type [`<percentage>`](/fr/docs/Web/CSS/percentage)) qui définit la taille de l'espace entre les colonnes. Cette valeur peut être nulle mais ne doit pas être négative.
 
-### Syntaxe formelle
+## Définition formelle
+
+{{cssinfo}}
+
+## Syntaxe formelle
 
 {{csssyntax}}
 
@@ -82,7 +83,7 @@ column-gap: unset;
 
 #### Résultat
 
-{{EmbedLiveSample("Disposition_flexible","auto","120px")}}
+{{EmbedLiveSample("","auto","130px")}}
 
 ### Disposition en grille
 
@@ -115,7 +116,7 @@ column-gap: unset;
 
 #### Résultat
 
-{{EmbedLiveSample("Disposition_en_grille", "auto", "120px")}}
+{{EmbedLiveSample("","auto", "130px")}}
 
 ### Disposition multi-colonnes
 
@@ -140,13 +141,11 @@ column-gap: unset;
 
 #### Résultat
 
-{{EmbedLiveSample("Disposition_en_colonnes", "auto", "120px")}}
+{{EmbedLiveSample("", "auto", "130px")}}
 
 ## Spécifications
 
 {{Specifications("css.properties.column-gap.grid_context")}}
-
-{{cssinfo}}
 
 ## Compatibilité des navigateurs
 
@@ -154,6 +153,6 @@ column-gap: unset;
 
 ## Voir aussi
 
-- Les autres propriétés relatives aux gouttières : {{CSSxRef("row-gap")}}, {{CSSxRef("gap")}}
-- Guide sur les grilles : _[Les concepts de base des grilles CSS : les gouttières](/fr/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout#les_gouttières)_
-- Guide sur la disposition multi-colonnes : _[Mettre en forme les colonnes](/fr/docs/Web/CSS/CSS_Columns/Styling_Columns)_
+- Les autres propriétés relatives aux gouttières&nbsp;: [`row-gap`](/fr/docs/Web/CSS/row-gap), [`gap`](/fr/docs/Web/CSS/gap)
+- Guide sur les grilles&nbsp;: _[Les concepts de base des grilles CSS&nbsp;: les gouttières](/fr/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout#les_gouttières)_
+- Guide sur la disposition multi-colonnes&nbsp;: _[Mettre en forme les colonnes](/fr/docs/Web/CSS/CSS_Columns/Styling_Columns)_

--- a/files/fr/web/css/column-gap/index.md
+++ b/files/fr/web/css/column-gap/index.md
@@ -1,5 +1,5 @@
 ---
-title: column-gap
+title: column-gap (grid-column-gap)
 slug: Web/CSS/column-gap
 tags:
   - CSS
@@ -9,13 +9,11 @@ translation_of: Web/CSS/column-gap
 ---
 {{CSSRef}}
 
-La propriété **`column-gap`** permet de définir l'espace entre les colonnes d'un élément.
+La propriété **`column-gap`** permet de définir la taille des espaces ({{glossary("gutters", "gouttières")}}) entre les colonnes d'un élément.
 
-{{EmbedInteractiveExample("pages/css/column-gap.html")}}{{EmbedInteractiveExample("pages/css/grid-column-gap.html")}}
+{{EmbedInteractiveExample("pages/css/column-gap.html")}}
 
-La propriété `column-gap` était initialement définie dans le module de spécification [_Multi-column Layout_ (disposition en colonnes)](/fr/docs/Web/CSS/Colonnes_CSS). Cette définition a depuis été élargie afin de pouvoir être utilisée dans les différents modes de disposition et fait désormais partie du module de spécification _[Box Alignment](/fr/docs/Web/CSS/CSS_Box_Alignment)_. Cette propriété peut être utilisée pour les dispositions en colonnes, les dispositions flexibles ou les disposition en grille.
-
-> **Note :** Le module de spécification _[CSS Grid Layout](/fr/docs/Web/CSS/CSS_Grid_Layout)_ définissait initialement la propriété `grid-column-gap`. Cette version préfixée a été remplacée par `column-gap`. Toutefois, à des fins de compatibilité envers les navigateurs qui ne prendraient pas en charge cette évolution, mieux vaut utiliser les deux versions (voir l'exemple interactif ci-avant).
+La propriété `column-gap` était initialement définie dans le module de spécification [Colonnes CSS](/fr/docs/Web/CSS/CSS_Columns). Cette définition a depuis été élargie afin de pouvoir être utilisée dans les différents modes de disposition et fait désormais partie du module de spécification [_Box Alignment_ (alignement des boîtes en CSS)](/fr/docs/Web/CSS/CSS_Box_Alignment). Cette propriété peut être utilisée pour les dispositions multi-colonnes, les dispositions flexibles et les dispositions en grille.
 
 ## Syntaxe
 
@@ -35,6 +33,7 @@ column-gap: 3%;
 /* Valeurs globales */
 column-gap: inherit;
 column-gap: initial;
+column-gap: revert;
 column-gap: unset;
 ```
 
@@ -42,10 +41,10 @@ column-gap: unset;
 
 - `normal`
   - : Un mot-clé qui indique qu'on souhaite utiliser l'espacement par défaut créé par le navigateur. Pour les dispositions en colonnes, cette valeur correspond à `1em`, sinon elle correspond à `0`.
-- `<length>`
-  - : Une valeur de longueur (type {{cssxref("&lt;length&gt;")}}) qui définit la taille de l'espace entre les colonnes. Cette valeur peut être nulle mais ne doit pas être négative.
-- `<percentage>`
-  - : Une valeur de pourcentage (type {{cssxref("&lt;percentage&gt;")}} qui définit la taille de l'espace entre les colonnes. Cette valeur peut être nulle mais ne doit pas être négative.
+- {{CSSxRef("&lt;length&gt;")}}
+  - : Une valeur de longueur (type {{CSSxRef("&lt;length&gt;")}}) qui définit la taille de l'espace entre les colonnes. Cette valeur peut être nulle mais ne doit pas être négative.
+- {{CSSxRef("&lt;percentage&gt;")}}
+  - : Une valeur de pourcentage (type {{CSSxRef("&lt;percentage&gt;")}}) qui définit la taille de l'espace entre les colonnes. Cette valeur peut être nulle mais ne doit pas être négative.
 
 ### Syntaxe formelle
 
@@ -54,8 +53,6 @@ column-gap: unset;
 ## Exemples
 
 ### Disposition flexible
-
-{{SeeCompatTable}}
 
 #### HTML
 
@@ -77,7 +74,7 @@ column-gap: unset;
 }
 
 #flexbox > div {
-  border: 1opx solid green;
+  border: 1px solid green;
   background-color: lime;
   flex: auto;
 }
@@ -86,31 +83,6 @@ column-gap: unset;
 #### Résultat
 
 {{EmbedLiveSample("Disposition_flexible","auto","120px")}}
-
-### Disposition en colonnes
-
-#### HTML
-
-```html
-<p class="content-box">
-  Un texte sur plusieurs colonnes avec une gouttière
-  de 40px paramétrée grâce à la propriété `column-gap`.
-  C'est plutôt pas mal comme effet non ?
-</p>
-```
-
-#### CSS
-
-```css
-.content-box {
-  column-count: 3;
-  column-gap: 40px;
-}
-```
-
-#### Résultat
-
-{{EmbedLiveSample("Disposition_en_colonnes", "auto", "120px")}}
 
 ### Disposition en grille
 
@@ -136,13 +108,8 @@ column-gap: unset;
 }
 
 #grid > div {
+  border: 1px solid green;
   background-color: lime;
-}
-```
-
-```css hidden
-#grid {
-  grid-column-gap: 20px;
 }
 ```
 
@@ -150,34 +117,43 @@ column-gap: unset;
 
 {{EmbedLiveSample("Disposition_en_grille", "auto", "120px")}}
 
+### Disposition multi-colonnes
+
+#### HTML
+
+```html
+<p class="content-box">
+  Un texte sur plusieurs colonnes avec une gouttière
+  de 40px paramétrée grâce à la propriété `column-gap`.
+  C'est plutôt pas mal comme effet non ?
+</p>
+```
+
+#### CSS
+
+```css
+.content-box {
+  column-count: 3;
+  column-gap: 40px;
+}
+```
+
+#### Résultat
+
+{{EmbedLiveSample("Disposition_en_colonnes", "auto", "120px")}}
+
 ## Spécifications
 
-| Spécification                                                                            | État                                     | Commentaires                                                              |
-| ---------------------------------------------------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------- |
-| {{SpecName("CSS3 Box Alignment", "#column-row-gap", "column-gap")}} | {{Spec2("CSS3 Box Alignment")}} | Applique cette propriété aux grilles et aux boîtes flexibles (_flexbox_). |
-| {{SpecName("CSS3 Grid", "#gutters", "column-gap")}}                     | {{Spec2("CSS3 Grid")}}             | Définition de l'impact de cette propriété sur les dispositions en grille. |
-| {{SpecName("CSS3 Multicol", "#column-gap", "column-gap")}}             | {{Spec2("CSS3 Multicol")}}     | Définition initiale.                                                      |
+{{Specifications("css.properties.column-gap.grid_context")}}
 
 {{cssinfo}}
 
 ## Compatibilité des navigateurs
 
-### Prise en charge pour les dispositions flexibles
-
-{{Compat("css.properties.column-gap.flex_context")}}
-
-### Prise en charge pour les dispositions en grille
-
-{{Compat("css.properties.column-gap.grid_context")}}
-
-### Prise en charge pour les dispositions en colonnes
-
-{{Compat("css.properties.column-gap.multicol_context")}}
+{{Compat}}
 
 ## Voir aussi
 
-- {{cssxref("row-gap")}}
-- {{cssxref("gap")}}
-- Guide sur les boîtes flexibles : _[Concepts de base des flexbox](/fr/docs/Web/CSS/Disposition_flexbox_CSS/Concepts_de_base_flexbox)_
-- Guide sur les grilles : _[Concepts de base des grilles : les gouttières](/fr/docs/Web/CSS/CSS_Grid_Layout/Les_concepts_de_base#Les_gouttières)_
+- Les autres propriétés relatives aux gouttières : {{CSSxRef("row-gap")}}, {{CSSxRef("gap")}}
+- Guide sur les grilles : _[Les concepts de base des grilles CSS : les gouttières](/fr/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout#les_gouttières)_
 - Guide sur la disposition multi-colonnes : _[Mettre en forme les colonnes](/fr/docs/Web/CSS/CSS_Columns/Styling_Columns)_

--- a/files/fr/web/css/gap/index.md
+++ b/files/fr/web/css/gap/index.md
@@ -5,11 +5,9 @@ translation_of: Web/CSS/gap
 ---
 {{CSSRef}}
 
-La propriété **`gap`** est [une propriété raccourcie](/fr/docs/Web/CSS/Propriétés_raccourcies) pour {{cssxref("row-gap")}} et {{cssxref("column-gap")}} qui permet de définir les espaces entre les lignes et entre les colonnes d'une grille.
+La propriété **`gap`** est [une propriété raccourcie](/fr/docs/Web/CSS/Shorthand_properties) pour {{CSSxRef("row-gap")}} et {{CSSxRef("column-gap")}} qui permet de définir les espaces (les {{glossary("gutters", "gouttières")}}) entre les lignes et entre les colonnes d'une grille.
 
 {{EmbedInteractiveExample("pages/css/gap.html")}}
-
-> **Note :** La propriété {{cssxref("grid-gap")}} a initialement été définie dans le module de spécification [CSS Grid Layout](/fr/docs/Web/CSS/CSS_Grid_Layout). Cette version préfixée a été remplacée par `gap`. Toutefois, à des fins de compatibilité envers les navigateurs qui n'implémentent pas encore la version non-préfixée, mieux vaut utiliser les deux versions.
 
 ## Syntaxe
 
@@ -33,7 +31,7 @@ gap: 3vmin 2vmax;
 gap: 0.5cm 2mm;
 
 /* Une ou deux valeurs proportionnelles */
-/* Type <percentage>             */
+/* Type <percentage>                    */
 gap: 16% 100%;
 gap: 21px 82%;
 
@@ -44,19 +42,20 @@ gap: calc(20px + 10%) calc(10% - 5px);
 /* Valeurs globales */
 gap: inherit;
 gap: initial;
+gap: revert;
 gap: unset;
 ```
 
-Cette propriété est définie avec une valeur `<'row-gap'>`, éventuellement suivi d'une valeur `<'column-gap'>`. Si `<'column-gap'>` n'est pas utilisée, la valeur utilisée sera la même que `<'row-gap'>`.
+Cette propriété est définie avec une valeur `<'row-gap'>`, éventuellement suivi d'une valeur `<'column-gap'>`. Si `<'column-gap'>` n'est pas défini, la valeur utilisée sera la même que `<'row-gap'>`.
 
 `<'row-gap'>` et `<'column-gap'>` sont des valeurs de type `<length>` ou `<percentage>`.
 
 ### Valeurs
 
-- `<length>`
-  - : La largeur de l'espace entre les lignes et/ou entre les colonnes (cf. {{cssxref("&lt;length&gt;")}} pour les valeurs utilisables).
-- `<percentage>`
-  - : La largeur de l'espace entre les lignes et/ou entre les colonnes en fonction de la taille de l'élément englobant (cf. {{cssxref("&lt;percentage&gt;")}} pour les valeurs utilisables).
+- {{CSSxRef("&lt;length&gt;")}}
+  - : La largeur de l'espace entre les pistes de grille.
+- {{CSSxRef("&lt;percentage&gt;")}}
+  - : La largeur de l'espace entre les pistes de grille en fonction de la taille de l'élément englobant.
 
 ### Syntaxe formelle
 
@@ -65,8 +64,6 @@ Cette propriété est définie avec une valeur `<'row-gap'>`, éventuellement su
 ## Exemples
 
 ### Disposition flexible
-
-{{SeeCompatTable}}
 
 #### HTML
 
@@ -105,7 +102,7 @@ Cette propriété est définie avec une valeur `<'row-gap'>`, éventuellement su
 
 {{EmbedLiveSample("Disposition_flexible", "auto", "120px")}}
 
-### Grilles CSS
+### Disposition en grille
 
 #### HTML
 
@@ -149,14 +146,14 @@ Cette propriété est définie avec une valeur `<'row-gap'>`, éventuellement su
 
 {{EmbedLiveSample("Grilles_CSS", "auto", "120px")}}
 
-### Multi-colonnes
+### Disposition multi-colonnes
 
 #### HTML
 
 ```html
 <p class="content-box">
-  voici un texte en multi-colonne sur des colonnes avec
-  une gouttière de 40 pixels créée grâce à la propriété
+  Voici un texte en multi-colonne sur des colonnes avec
+  une gouttière de 40px créée grâce à la propriété
   CSS <code>gap</code>. Est-ce que c'est pas trop génial ?
 </p>
 ```
@@ -176,31 +173,15 @@ Cette propriété est définie avec une valeur `<'row-gap'>`, éventuellement su
 
 ## Spécifications
 
-| Spécification                                                                | État                                     | Commentaires         |
-| ---------------------------------------------------------------------------- | ---------------------------------------- | -------------------- |
-| {{SpecName("CSS3 Box Alignment", "#propdef-gap", "gap")}} | {{Spec2("CSS3 Box Alignment")}} | Définition initiale. |
+{{Specifications("css.properties.gap.grid_context")}}
 
 {{cssinfo}}
 
 ## Compatibilité des navigateurs
 
-### Prise en charge pour les dispositions flexibles
-
-{{Compat("css.properties.gap.flex_context")}}
-
-### Prise en charge pour les grilles CSS
-
-{{Compat("css.properties.gap.grid_context")}}
-
-### Prise en charge pour les dispositions multi-colonnes
-
-{{Compat("css.properties.gap.multicol_context")}}
+{{Compat}}
 
 ## Voir aussi
 
-- Les versions standards, sans préfixe, des propriétés associées :
-
-  - {{cssxref("row-gap")}},
-  - {{cssxref("column-gap")}},
-
-- [Guide : les concepts de base : les gouttières](/fr/docs/Web/CSS/CSS_Grid_Layout/Les_concepts_de_base#Les_gouttières)
+- Les autres propriétés relatives aux gouttières : {{CSSxRef("row-gap")}}, {{CSSxRef("column-gap")}}
+- Guide sur les grilles : _[Les concepts de base des grilles CSS : les gouttières](/fr/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout#les_gouttières)_

--- a/files/fr/web/css/gap/index.md
+++ b/files/fr/web/css/gap/index.md
@@ -2,10 +2,11 @@
 title: gap (grid-gap)
 slug: Web/CSS/gap
 translation_of: Web/CSS/gap
+browser-compat: css.properties.gap
 ---
 {{CSSRef}}
 
-La propriété **`gap`** est [une propriété raccourcie](/fr/docs/Web/CSS/Shorthand_properties) pour {{CSSxRef("row-gap")}} et {{CSSxRef("column-gap")}} qui permet de définir les espaces (les {{glossary("gutters", "gouttières")}}) entre les lignes et entre les colonnes d'une grille.
+La propriété **`gap`** est [une propriété raccourcie](/fr/docs/Web/CSS/Shorthand_properties) pour [`row-gap`](/fr/docs/Web/CSS/row-gap) et [`column-gap`](/fr/docs/Web/CSS/column-gap) qui permet de définir les espaces (les [gouttières](/fr/docs/Glossary/Gutters)) entre les lignes et entre les colonnes d'une grille.
 
 {{EmbedInteractiveExample("pages/css/gap.html")}}
 
@@ -52,12 +53,16 @@ Cette propriété est définie avec une valeur `<'row-gap'>`, éventuellement su
 
 ### Valeurs
 
-- {{CSSxRef("&lt;length&gt;")}}
+- [`<length>`](/fr/docs/Web/CSS/length)
   - : La largeur de l'espace entre les pistes de grille.
-- {{CSSxRef("&lt;percentage&gt;")}}
+- [`<percentage>`](/fr/docs/Web/CSS/percentage)
   - : La largeur de l'espace entre les pistes de grille en fonction de la taille de l'élément englobant.
 
-### Syntaxe formelle
+## Définition formelle
+
+{{cssinfo}}
+
+## Syntaxe formelle
 
 {{csssyntax}}
 
@@ -100,7 +105,7 @@ Cette propriété est définie avec une valeur `<'row-gap'>`, éventuellement su
 
 #### Résultat
 
-{{EmbedLiveSample("Disposition_flexible", "auto", "120px")}}
+{{EmbedLiveSample("", "auto", "230px")}}
 
 ### Disposition en grille
 
@@ -144,7 +149,7 @@ Cette propriété est définie avec une valeur `<'row-gap'>`, éventuellement su
 
 #### Résultat
 
-{{EmbedLiveSample("Grilles_CSS", "auto", "120px")}}
+{{EmbedLiveSample("", "auto", "230px")}}
 
 ### Disposition multi-colonnes
 
@@ -169,13 +174,11 @@ Cette propriété est définie avec une valeur `<'row-gap'>`, éventuellement su
 
 #### Résultat
 
-{{EmbedLiveSample("Multi-colonnes", "auto", "120px")}}
+{{EmbedLiveSample("", "auto", "120px")}}
 
 ## Spécifications
 
 {{Specifications("css.properties.gap.grid_context")}}
-
-{{cssinfo}}
 
 ## Compatibilité des navigateurs
 
@@ -183,5 +186,5 @@ Cette propriété est définie avec une valeur `<'row-gap'>`, éventuellement su
 
 ## Voir aussi
 
-- Les autres propriétés relatives aux gouttières : {{CSSxRef("row-gap")}}, {{CSSxRef("column-gap")}}
-- Guide sur les grilles : _[Les concepts de base des grilles CSS : les gouttières](/fr/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout#les_gouttières)_
+- Les autres propriétés relatives aux gouttières&nbsp;: [`row-gap`](/fr/docs/Web/CSS/row-gap), [`column-gap`](/fr/docs/Web/CSS/column-gap)
+- Guide sur les grilles&nbsp;: _[Les concepts de base des grilles CSS&nbsp;: les gouttières](/fr/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout#les_gouttières)_

--- a/files/fr/web/css/row-gap/index.md
+++ b/files/fr/web/css/row-gap/index.md
@@ -1,11 +1,8 @@
 ---
 title: row-gap (grid-row-gap)
 slug: Web/CSS/row-gap
-tags:
-  - CSS
-  - Propriété
-  - Reference
 translation_of: Web/CSS/row-gap
+browser-compat: css.properties.row-gap
 ---
 {{CSSRef}}
 
@@ -36,10 +33,14 @@ row-gap: unset;
 
 ### Valeurs
 
-- {{CSSxRef("&lt;length-percentage&gt;")}}
-  - : La largeur de la « gouttière » placée entre les lignes de la grille. Les valeurs exprimées en pourcentages ({{CSSxRef("&lt;percentage&gt;")}}) sont relatives aux dimensions de l'élément.
+- [`<length-percentage>`](/fr/docs/Web/CSS/length-percentage)
+  - : La largeur de la « gouttière » placée entre les lignes de la grille. Les valeurs exprimées en pourcentages ([`<percentage>`](/fr/docs/Web/CSS/percentage)) sont relatives aux dimensions de l'élément.
 
-### Syntaxe formelle
+## Formal definition
+
+{{cssinfo}}
+
+## Syntaxe formelle
 
 {{csssyntax}}
 
@@ -81,7 +82,7 @@ row-gap: unset;
 
 #### Résultat
 
-{{EmbedLiveSample('Disposition_flexible', "auto", "120px")}}
+{{EmbedLiveSample('', "auto", "240px")}}
 
 ### Disposition en grille
 
@@ -113,13 +114,11 @@ row-gap: unset;
 
 #### Résultat
 
-{{EmbedLiveSample('Disposition_sur_une_grille', 'auto', 120)}}
+{{EmbedLiveSample('', 'auto', '240px')}}
 
 ## Spécifications
 
 {{Specifications("css.properties.row-gap.grid_context")}}
-
-{{cssinfo}}
 
 ## Compatibilité des navigateurs
 
@@ -127,5 +126,5 @@ row-gap: unset;
 
 ## Voir aussi
 
-- Les autres propriétés relatives aux gouttières : {{CSSxRef("column-gap")}}, {{CSSxRef("gap")}}
-- Guide sur les grilles : _[Les concepts de base des grilles CSS : les gouttières](/fr/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout#les_gouttières)_
+- Les autres propriétés relatives aux gouttières&nbsp;: [`column-gap`](/fr/docs/Web/CSS/column-gap), [`gap`](/fr/docs/Web/CSS/gap)
+- Guide sur les grilles&nbsp;: _[Les concepts de base des grilles CSS&nbsp;: les gouttières](/fr/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout#les_gouttières)_

--- a/files/fr/web/css/row-gap/index.md
+++ b/files/fr/web/css/row-gap/index.md
@@ -9,7 +9,7 @@ translation_of: Web/CSS/row-gap
 ---
 {{CSSRef}}
 
-La propriété **`row-gap`** définit la taille des espaces ({{glossary("gutters", "gouttières")}}) entre les pistes de grille d'un élément.
+La propriété **`row-gap`** définit la taille des espaces ({{glossary("gutters", "gouttières")}}) entre les lignes d'un élément.
 
 {{EmbedInteractiveExample("pages/css/row-gap.html")}}
 

--- a/files/fr/web/css/row-gap/index.md
+++ b/files/fr/web/css/row-gap/index.md
@@ -9,11 +9,9 @@ translation_of: Web/CSS/row-gap
 ---
 {{CSSRef}}
 
-La propriété **`row-gap`** définit la taille des gouttières entre les lignes d'un élément.
+La propriété **`row-gap`** définit la taille des espaces ({{glossary("gutters", "gouttières")}}) entre les pistes de grille d'un élément.
 
-{{EmbedInteractiveExample("pages/css/grid-row-gap.html")}}
-
-> **Note :** La propriété {{cssxref("grid-row-gap")}} a d'abord été définie avec le module de spécification [CSS Grid Layout](/fr/docs/Web/CSS/CSS_Grid_Layout). Cette propriété préfixée a ensuite été remplacée par `row-gap` dans le module [CSS Alignment](/fr/docs/Web/CSS/CSS_Box_Alignment) afin d'être généralisée à d'autres modes de disposition. Toutefois, à des fins de compatibilité envers les navigateurs qui n'implémentent pas encore la version non-préfixée, mieux vaut utiliser les deux versions.
+{{EmbedInteractiveExample("pages/css/row-gap.html")}}
 
 ## Syntaxe
 
@@ -26,19 +24,20 @@ row-gap: 3vmin;
 row-gap: 0.5cm;
 
 /* Valeurs proportionnelles */
-/* Type <pourcentage> */
+/* Type <pourcentage>       */
 row-gap: 10%;
 
 /* Valeurs globales */
 row-gap: inherit;
 row-gap: initial;
+row-gap: revert;
 row-gap: unset;
 ```
 
 ### Valeurs
 
-- `<pourcentage-largeur>`
-  - : La largeur de la « gouttière » placée entre les lignes de la grille. Les valeurs exprimées en pourcentages sont relatives aux dimensions de l'élément.
+- {{CSSxRef("&lt;length-percentage&gt;")}}
+  - : La largeur de la « gouttière » placée entre les lignes de la grille. Les valeurs exprimées en pourcentages ({{CSSxRef("&lt;percentage&gt;")}}) sont relatives aux dimensions de l'élément.
 
 ### Syntaxe formelle
 
@@ -47,26 +46,6 @@ row-gap: unset;
 ## Exemples
 
 ### Disposition flexible
-
-{{SeeCompatTable}}
-
-#### CSS
-
-```css
-#flexbox {
-  display: flex;
-  flex-wrap: wrap;
-  width: 300px;
-  row-gap: 20px;
-}
-
-#flexbox > div {
-  background-color: lime;
-  flex: 1 1 auto;
-  width: 100px;
-  height: 50px;
-}
-```
 
 #### HTML
 
@@ -81,33 +60,30 @@ row-gap: unset;
 </div>
 ```
 
+#### CSS
+
+```css
+#flexbox {
+  display: flex;
+  flex-wrap: wrap;
+  width: 300px;
+  row-gap: 20px;
+}
+
+#flexbox > div {
+  border: 1px solid green;
+  background-color: lime;
+  flex: 1 1 auto;
+  width: 100px;
+  height: 50px;
+}
+```
+
 #### Résultat
 
 {{EmbedLiveSample('Disposition_flexible', "auto", "120px")}}
 
-### Disposition sur une grille
-
-#### CSS
-
-```css hidden
-#grid {
-  grid-row-gap: 20px;
-}
-```
-
-```css
-#grid {
-  display: grid;
-  height: 200px;
-  grid-template-columns: 200px;
-  grid-template-rows: repeat(3, 1fr);
-  row-gap: 20px;
-}
-
-#grid > div {
-  background-color: lime;
-}
-```
+### Disposition en grille
 
 #### HTML
 
@@ -119,34 +95,37 @@ row-gap: unset;
 </div>
 ```
 
+#### CSS
+```css
+#grid {
+  display: grid;
+  height: 200px;
+  grid-template-columns: 200px;
+  grid-template-rows: repeat(3, 1fr);
+  row-gap: 20px;
+}
+
+#grid > div {
+  border: 1px solid green;
+  background-color: lime;
+}
+```
+
 #### Résultat
 
 {{EmbedLiveSample('Disposition_sur_une_grille', 'auto', 120)}}
 
 ## Spécifications
 
-| Spécification                                                                            | État                                     | Commentaires         |
-| ---------------------------------------------------------------------------------------- | ---------------------------------------- | -------------------- |
-| {{SpecName("CSS3 Box Alignment", "#propdef-row-gap", "row-gap")}} | {{Spec2("CSS3 Box Alignment")}} | Définition initiale. |
+{{Specifications("css.properties.row-gap.grid_context")}}
 
 {{cssinfo}}
 
 ## Compatibilité des navigateurs
 
-### Prise en charge pour les dispositions flexibles
-
-{{Compat("css.properties.row-gap.flex_context")}}
-
-### Prise en charge pour les grilles
-
-{{Compat("css.properties.row-gap.grid_context")}}
+{{Compat}}
 
 ## Voir aussi
 
-- Les versions sans préfixe des propriétés :
-
-  - {{cssxref("column-gap")}}
-  - {{cssxref("gap")}}
-
-- [Guide : les concepts de base : les gouttières](/fr/docs/Web/CSS/CSS_Grid_Layout/Les_concepts_de_base#Les_gouttières)
-- [Guide : les concepts de base des boîtes flexibles (flexbox)](/fr/docs/Web/CSS/Disposition_flexbox_CSS/Concepts_de_base_flexbox)
+- Les autres propriétés relatives aux gouttières : {{CSSxRef("column-gap")}}, {{CSSxRef("gap")}}
+- Guide sur les grilles : _[Les concepts de base des grilles CSS : les gouttières](/fr/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout#les_gouttières)_


### PR DESCRIPTION
Mise à jour des pages sur les propriétés CSS `-gap` :
- `column-gap`, `row-gap`, `gap`
- Mise à jour en fonction de la page anglaise et des évolutions de la spécification
- Correction de la source du *EmbedInteractiveExample* (s'il y a lieu)
- Quelques modifications afin d'assurer la cohérence