### PR TITLE
Fix return type for document.querySelector() in zh-CN

### DIFF
--- a/files/zh-cn/web/api/document/queryselector/index.html
+++ b/files/zh-cn/web/api/document/queryselector/index.html
@@ -11,7 +11,7 @@ translation_of: Web/API/Document/querySelector
 ---
 <div>{{ ApiRef("DOM") }}</div>
 
-<p>文档对象模型{{domxref("Document")}}引用的<code><strong>querySelector()</strong></code>方法返回文档中与指定选择器或选择器组匹配的第一个 {{domxref("HTMLElement")}}对象。 如果找不到匹配项，则返回<code>null</code>。</p>
+<p>文档对象模型{{domxref("Document")}}引用的<code><strong>querySelector()</strong></code>方法返回文档中与指定选择器或选择器组匹配的第一个 {{domxref("Element")}}对象。 如果找不到匹配项，则返回<code>null</code>。</p>
 
 <div class="note">
 <p><strong>提示</strong>: 匹配是使用深度优先先序遍历，从文档标记中的第一个元素开始，并按子节点的顺序依次遍历。</p>
@@ -34,7 +34,7 @@ translation_of: Web/API/Document/querySelector
 
 <h3 id="返回值">返回值</h3>
 
-<p>表示文档中与指定的一组CSS选择器匹配的第一个元素,一个 {{domxref("HTMLElement")}}对象。如果没有匹配到，则返回null。</p>
+<p>表示文档中与指定的一组CSS选择器匹配的第一个元素,一个 {{domxref("Element")}}对象。如果没有匹配到，则返回null。</p>
 
 <p>如果您需要与指定选择器匹配的所有元素的列表，则应该使用{{domxref("Document.querySelectorAll", "querySelectorAll()")}} 。</p>
 

--- a/files/zh-cn/web/api/document/queryselector/index.html
+++ b/files/zh-cn/web/api/document/queryselector/index.html
@@ -49,7 +49,7 @@ translation_of: Web/API/Document/querySelector
 
 <p>如果选择器是一个 ID，并且这个 ID 在文档中错误地使用了多次，那么返回第一个匹配该 ID 的元素。</p>
 
-<p>CSS 伪类不会返回任何元素，见 <a href="http://www.w3.org/TR/selectors-api/#grammar">Selectors API</a> 中的相关规定。</p>
+<p>CSS 伪类不会返回任何元素，见 <a href="https://www.w3.org/TR/selectors-api/#grammar">Selectors API</a> 中的相关规定。</p>
 
 <h3 id="转义特殊字符">转义特殊字符</h3>
 
@@ -111,16 +111,13 @@ translation_of: Web/API/Document/querySelector
 
 <h2 id="Browser_Compatibility" name="Browser_Compatibility">浏览器兼容性</h2>
 
-
-
 <p>{{Compat("api.Document.querySelector")}}</p>
 
 <h2 id="See_also" name="See_also">相关链接</h2>
 
 <ul>
- <li><a href="/zh-CN/docs/Web/API/Document_object_model/Locating_DOM_elements_using_selectors">Locating DOM elements using selectors</a></li>
+ <li><a href="/zh-CN/docs/Web/API/Document_Object_Model/Locating_DOM_elements_using_selectors">Locating DOM elements using selectors</a></li>
  <li>{{domxref("Element.querySelector()")}}</li>
  <li>{{domxref("Document.querySelectorAll()")}}</li>
  <li>{{domxref("Element.querySelectorAll()")}}</li>
- <li><a href="https://developer.mozilla.org/en-US/docs/Code_snippets/QuerySelector">Code snippets for querySelecto</a>r</li>
 </ul>


### PR DESCRIPTION
### Summary

Fixes the return type of `document.querySelector()` in _zh-CN_



### Return type:

Before -> `HTMLElement`
After -> `Element` 
as per [specs](https://dom.spec.whatwg.org/#ref-for-dom-parentnode-queryselector%E2%91%A0)


Fixes #3440 