### PR TITLE
Add autocorrect-lint GitHub Action

### DIFF
--- a/.autocorrectignore
+++ b/.autocorrectignore
@@ -1,0 +1,3 @@
+**/*
+!files/zh-cn/web/html/**/*
+

--- a/.github/workflows/autocorrect-lint.yml
+++ b/.github/workflows/autocorrect-lint.yml
@@ -1,0 +1,16 @@
+name: AutoCorrect Lint
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: AutoCorrect
+        uses: huacnlee/autocorrect-action@v1.5.5


### PR DESCRIPTION
1. Add a GitHub Lint Action by use AutoCorrect for check copywriting.
2. A `.autocorrectignore` file to configure that which files wants to use AutoCorrect lint.
3. #3834 
4. #3835

[AutoCorrect](https://github.com/huacnlee/autocorrect) also supports for Korean and Japanese, is not enabled in current, I just updated the Chinese as a example for first PR review.

## Current issues

https://developer.mozilla.org/zh-CN/docs/Learn/HTML

- Red: Incorrect
- Green: Correct

<img width="848" alt="截屏2021-12-30 11 55 12" src="https://user-images.githubusercontent.com/5518/147720794-654958e7-6f15-47ca-bce2-8293992608b5.png">
