### PR TITLE
[ko] Improve translation for class hoisting

### DIFF
--- a/files/ko/web/javascript/reference/classes/index.html
+++ b/files/ko/web/javascript/reference/classes/index.html
@@ -24,12 +24,14 @@ translation_of: Web/JavaScript/Reference/Classes
 
 <h4 id="Hoisting">Hoisting</h4>
 
-<p><strong>함수 선언</strong>과 <strong>클래스 선언</strong>의 중요한 차이점은 함수 선언의 경우 {{Glossary("Hoisting", "호이스팅")}}이 일어나지만, 클래스 선언은 그렇지 않다는 것입니다. 클래스를 사용하기 위해서는 클래스를 먼저 선언 해야 합니다. 그렇지 않으면, 다음 코드는 {{jsxref("ReferenceError")}}를 던질 것입니다. :</p>
+<p><strong>함수 선언</strong>과 <strong>클래스 선언</strong>의 중요한 차이점은 험수의 경우 정의하기 하기 전에 호출할 수 있지만, 클래스는 반드시 정의한 뒤에 사용할 수 있다는 점입니다. 다음 코드는 {{jsxref("ReferenceError")}}를 던질 것입니다.</p>
 
 <pre class="brush: js example-bad notranslate">const p = new Rectangle(); // ReferenceError
 
 class Rectangle {}
 </pre>
+
+<p>예외가 발생하는 이유는 클래스가 {{Glossary("Hoisting", "호이스팅")}}될 때 초기화는 되지 않기 때문입니다.</p>
 
 <h3 id="Class_표현식">Class 표현식</h3>
 


### PR DESCRIPTION
- 클래스 문서의 호이스팅 문단에 [원문](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes#hoisting)과 달리 '클래스는 호이스팅이 되지 않는다'고 착각할 수 있는 번역이 있어서 수정했습니다.
- 첫 기여라서 https://github.com/mdn/translated-content/issues/827 를 참고해 작업했습니다. 리뷰 남겨주시면 반영하도록 하겠습니다 :)