### PR TITLE
Missed typo for follow-up of #3571

### DIFF
--- a/files/zh-cn/learn/html/introduction_to_html/advanced_text_formatting/index.html
+++ b/files/zh-cn/learn/html/introduction_to_html/advanced_text_formatting/index.html
@@ -51,7 +51,7 @@ translation_of: Learn/HTML/Introduction_to_HTML/Advanced_text_formatting
     &lt;dd&gt;戏剧中，为渲染幽默或戏剧性效果而进行的场景之外的补充注释念白，只面向观众，内容一般都是角色的感受、想法、以及一些背景信息等。&lt;/dd&gt;
 &lt;/dl&gt;</pre>
 
-<p>浏览器的默认样式会在<strong>描述列表的描述部分</strong>（description description）和<strong>描述术语</strong>（description terms）之间产生缩进。MDN非常严密地遵循这一惯例，同时也鼓励关于术语的其他更多的定义（but also embolden the terms for extra definition）。</p>
+<p>浏览器的默认样式会在<strong>描述列表的描述部分</strong>（description definition）和<strong>描述术语</strong>（description terms）之间产生缩进。MDN非常严密地遵循这一惯例，同时也鼓励关于术语的其他更多的定义（but also embolden the terms for extra definition）。</p>
 
 <p>下面是前述代码的显示结果：</p>
 


### PR DESCRIPTION
Missed second occurrence of #3559 at line 54: description description -> description definition