### PR TITLE
Update index.html

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/function/length/index.html
+++ b/files/zh-cn/web/javascript/reference/global_objects/function/length/index.html
@@ -17,7 +17,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Function/length
 
 <h2 id="Description" name="Description">描述</h2>
 
-<p><code>length</code> 是函数对象的一个属性值，指该函数有多少个必须要传入的参数，即形参的个数。</p>
+<p><code>length</code> 是函数对象的一个属性值，指该函数期望传入的参数数量，即形参的个数。</p>
 
 <p>形参的数量不包括剩余参数个数，仅包括第一个具有默认值之前的参数个数。</p>
 


### PR DESCRIPTION
“指该函数有多少个必须要传入的参数”改为“指该函数期望传入的参数数量”
翻译成“必须要传入”跟实际含义不符。原文“and indicates how many arguments the function expects,”