### PR TITLE
[fix] : entity references where shouldn't be used

### DIFF
--- a/files/ja/web/css/flex-grow/index.md
+++ b/files/ja/web/css/flex-grow/index.md
@@ -31,7 +31,7 @@ flex-grow: revert;
 flex-grow: unset;
 ```
 
-`flex-grow` プロパティは単一の `[&lt;number&gt;](#&lt;number>)` として指定します。
+`flex-grow` プロパティは単一の `<number>` として指定します。
 
 ### 値
 


### PR DESCRIPTION
I couldn't figure out what the clause starting with "#" in the brackets meant before the change, but it seemed unnecessary from the original English version.
Am I making the right decision?