### PR TITLE
[pt-BR] Fix small typo

### DIFF
--- a/files/pt-br/web/css/@import/index.html
+++ b/files/pt-br/web/css/@import/index.html
@@ -59,7 +59,7 @@ translation_of: Web/CSS/@import
   <tr>
    <td>{{SpecName('CSS2.1', 'cascade.html#at-import', '@import')}}</td>
    <td>{{Spec2('CSS2.1')}}</td>
-   <td>Adicionado suporte para {{cssxref("&lt;string&gt;")}} para denotar a URL de uma folha de  estilo,<br>
+   <td>Adicionado suporte para {{cssxref("&lt;string&gt;")}} para denotar a URL de uma folha de estilo,<br>
     e obrigatoriedade da regra <code>@import</code> no início do documento CSS.</td>
   </tr>
   <tr>
@@ -109,7 +109,7 @@ translation_of: Web/CSS/@import
    <th>Safari Mobile</th>
   </tr>
   <tr>
-   <td>Suorte básico</td>
+   <td>Suporte básico</td>
    <td>{{CompatVersionUnknown}}</td>
    <td>{{CompatVersionUnknown}}</td>
    <td>5.5</td>


### PR DESCRIPTION
- Replace "Suorte" with "Suporte" on the `compat-mobile` table.
- Remove extra space on the Comentário column of the Especificações table.