### PR TITLE
[ko] fix typo to correct a term, `구현`

### DIFF
--- a/files/ko/web/api/window/beforeunload_event/index.html
+++ b/files/ko/web/api/window/beforeunload_event/index.html
@@ -37,7 +37,7 @@ translation_of: Web/API/Window/beforeunload_event
 
 <p>명세에 따라, 확인 대화 상자를 표시하려면 이벤트의 {{domxref("Event.preventDefault()", "preventDefault()")}}를 호출해야 합니다.</p>
 
-<p>다만, 모든 브라우저가 위의 방법을 지원하는 것은 아니므로 아래의 두 가지 구형 방법을 사용해야 할 수도 있습니다.</p>
+<p>다만, 모든 브라우저가 위의 방법을 지원하는 것은 아니므로 아래의 두 가지 구현 방법을 사용해야 할 수도 있습니다.</p>
 
 <ul>
  <li>이벤트의 <code>returnValue</code> 속성에 문자열 할당</li>


### PR DESCRIPTION
[번역된 beforeunload 이벤트](https://developer.mozilla.org/ko/docs/Web/API/Window/beforeunload_event)문서에서 아래 단어를 수정합니다.

- [구형](https://korean.dict.naver.com/koendict/#/entry/koen/244b1f6160054f1f8b4b834b3a597e19) -> [구현](https://korean.dict.naver.com/koendict/#/entry/koen/8c2f76fd2bfd4d4882e8e2fc6bc5e378)


