### PR TITLE
Update index.html

### DIFF
--- a/files/ru/web/javascript/reference/global_objects/reflect/index.html
+++ b/files/ru/web/javascript/reference/global_objects/reflect/index.html
@@ -5,7 +5,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Reflect
 ---
 <div>{{JSRef}}</div>
 
-<p><strong>Reflect</strong> - это встроенный объект, который предоставляет методы для перехватывания JavaScript операций. Эти методы аналогичны методам <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler">proxy handler</a>`ов. <code>Reflect</code> - это не функциональный, а простой объект, он не является сконструированным.</p>
+<p><strong>Reflect</strong> - это встроенный объект, который предоставляет методы для перехватываемых JavaScript операций. Эти методы аналогичны методам <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler">proxy handler</a>`ов. <code>Reflect</code> - это не функциональный, а простой объект, он не является сконструированным.</p>
 
 <h2 id="Описание">Описание</h2>
 


### PR DESCRIPTION
Фатальная ошибка в переводе, которая в корне мешает правильному пониманию истинной сути объекта Reflect.
В оригинале: _Reflect is a built-in object that provides methods for **interceptable** JavaScript operations;_ 

interceptable JavaScript operations - перехватываемые JS операторы, т.е. те которые мы можем перехватить использовав Proxy
А так по описанию получается что Reflect == Proxy, что, конечно же в корне не так.
Как раз таки Proxy используется для перехвата операций, а Reflect позволяет работать с этими операциями в определенной форме, но никак не перехватывать