### PR TITLE
fix variable name to match the original [ja]

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/ja/web/javascript/reference/global_objects/array/reduce/index.md
@@ -411,7 +411,7 @@ let allbooks = friends.reduce(function(previousValue, currentValue) {
 
 ### 配列内の重複要素を除去する
 
-> **Note:** {{jsxref("Set")}} と {{jsxref("Array.from()")}} に対応している環境を使っている場合は、`let orderedArray = Array.from(new Set(myArray))` を使うことで重複要素を除去された配列を取得することができます。
+> **Note:** {{jsxref("Set")}} と {{jsxref("Array.from()")}} に対応している環境を使っている場合は、`let arrayWithNoDuplicates = Array.from(new Set(myArray))` を使うことで重複要素を除去された配列を取得することができます。
 
 ```js
 let myArray = ['a', 'b', 'a', 'b', 'c', 'e', 'e', 'c', 'd', 'd', 'd', 'd']


### PR DESCRIPTION
## 概要
前回の同期時点での英語版と比較して変数名と差分があったので揃えました。


original: https://github.com/mdn/content/blob/260094b613de640ff7eff377ffb0a0ef072016eb/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md?plain=1#L425-L428