### PR TITLE
时其 -> 使其

### DIFF
--- a/files/zh-cn/web/css/css_flow_layout/intro_to_formatting_contexts/index.html
+++ b/files/zh-cn/web/css/css_flow_layout/intro_to_formatting_contexts/index.html
@@ -23,7 +23,7 @@ translation_of: Web/CSS/CSS_Flow_Layout/Intro_to_formatting_contexts
 <p>除了文档的根元素({{HTMLElement("html")}}) 之外，还将在以下情况下创建一个新的BFC：</p>
 
 <ul>
- <li>使用{{cssxref("float")}} 时其浮动的元素</li>
+ <li>使用{{cssxref("float")}} 使其浮动的元素</li>
  <li>绝对定位的元素 (包含 {{cssxref("position", "position: fixed", "#fixed")}} 或{{cssxref("position", "position: sticky", "#sticky")}}</li>
  <li>使用以下属性的元素 {{cssxref("display", "display: inline-block", "#inline-block")}}</li>
  <li>表格单元格或使用 <code>display: table-cell</code>, 包括使用 <code>display: table-*</code> 属性的所有表格单元格</li>


### PR DESCRIPTION
将 “使用float 时其浮动的元素”  中的 "时其” 改为 “使其”。
结合英文mdn文档 “elements made to float using float” 应知此处“时其”为笔误， 原意应为“使其”。