### PR TITLE
[l10n-ja] for ... in: or ... in という表記修正

### DIFF
--- a/files/ja/web/javascript/reference/statements/for...in/index.html
+++ b/files/ja/web/javascript/reference/statements/for...in/index.html
@@ -142,7 +142,7 @@ for (var i = 0 in obj) {
  <li>{{jsxref("Statements/for...of", "for...of")}} - プロパティ値に対して繰り返す同様の文</li>
  <li>{{jsxref("Statements/for_each...in", "for each...in")}} - <code>for...in</code> に似ていますが、プロパティ名そのものではなく、オブジェクトのプロパティの値に対して反復します。(廃止されました)</li>
  <li>{{jsxref("Statements/for", "for")}}</li>
- <li><a href="/ja/docs/Web/JavaScript/Guide/Iterators_and_Generators">ジェネレーター式</a> (<code>or...in</code> を使っている)</li>
+ <li><a href="/ja/docs/Web/JavaScript/Guide/Iterators_and_Generators">ジェネレーター式</a> (<code>for...in</code> を使っている)</li>
  <li><a href="/ja/docs/Web/JavaScript/Enumerability_and_ownership_of_properties">プロパティの列挙可能性と所有権</a></li>
  <li>{{jsxref("Object.getOwnPropertyNames()")}}</li>
  <li>{{jsxref("Object.prototype.hasOwnProperty()")}}</li>

--- a/files/ja/web/javascript/reference/statements/for...in/index.html
+++ b/files/ja/web/javascript/reference/statements/for...in/index.html
@@ -142,7 +142,7 @@ for (var i = 0 in obj) {
  <li>{{jsxref("Statements/for...of", "for...of")}} - プロパティ値に対して繰り返す同様の文</li>
  <li>{{jsxref("Statements/for_each...in", "for each...in")}} - <code>for...in</code> に似ていますが、プロパティ名そのものではなく、オブジェクトのプロパティの値に対して反復します。(廃止されました)</li>
  <li>{{jsxref("Statements/for", "for")}}</li>
- <li><a href="/ja/docs/Web/JavaScript/Guide/Iterators_and_Generators">ジェネレーター式</a> (<code>for...in</code> を使っている)</li>
+ <li><a href="/ja/docs/Web/JavaScript/Guide/Iterators_and_Generators">ジェネレーター式</a> (<code>for...of</code> とあわせて利用できます)</li>
  <li><a href="/ja/docs/Web/JavaScript/Enumerability_and_ownership_of_properties">プロパティの列挙可能性と所有権</a></li>
  <li>{{jsxref("Object.getOwnPropertyNames()")}}</li>
  <li>{{jsxref("Object.prototype.hasOwnProperty()")}}</li>


### PR DESCRIPTION
Japanese version of `for ... in` had a typo and possibly a mistranslation in link to `Iterators_and_Generators`