### PR TITLE
fix: title err

### DIFF
--- a/files/ko/web/api/htmlelement/innertext/index.html
+++ b/files/ko/web/api/htmlelement/innertext/index.html
@@ -1,5 +1,5 @@
 ---
-title: Node.innerText
+title: HTMLElement.innerText
 slug: Web/API/HTMLElement/innerText
 tags:
   - API


### PR DESCRIPTION
#3460 잘못된 제목을 수정하였습니다. `Node.innerText` → `HTMLElement.innerText`