### PR TITLE
fix: Issue with 'async function'page syntax code error

### DIFF
--- a/files/ko/web/javascript/reference/statements/async_function/index.html
+++ b/files/ko/web/javascript/reference/statements/async_function/index.html
@@ -19,7 +19,7 @@ translation_of: Web/JavaScript/Reference/Statements/async_function
 
 <h2 id="Syntax">Syntax</h2>
 
-<pre class="syntaxbox notranslate" dir="rtl">async function <em>name</em>([<em>param</em>[, <em>param</em>[, ... <em>param</em>]]]) {
+<pre class="syntaxbox notranslate">async function <em>name</em>([<em>param</em>[, <em>param</em>[, ... <em>param</em>]]]) {
     <em>statements</em>
 }
 </pre>


### PR DESCRIPTION
https://github.com/mdn/translated-content/issues/3851 텍스트 정렬 수정했습니다 :) 

AS-IS
<img width="935" alt="Screen Shot 2022-01-30 at 3 44 29 PM" src="https://user-images.githubusercontent.com/42081098/151689669-ffb795b1-6eda-4342-931e-b1ad8dead68f.png">

TO-BE
<img width="938" alt="Screen Shot 2022-01-30 at 3 44 42 PM" src="https://user-images.githubusercontent.com/42081098/151689673-dadb7097-5423-4edd-bac7-0eb70ae966a4.png">