### PR TITLE
Fix a misspell in the pt-BR version

### DIFF
--- a/files/pt-br/web/javascript/reference/functions/set/index.html
+++ b/files/pt-br/web/javascript/reference/functions/set/index.html
@@ -57,7 +57,7 @@ translation_of: Web/JavaScript/Reference/Functions/set
 }
 </pre>
 
-<p>Observer que <em>current </em>não está definido e qualquer tentativa de acesso irá resultar em <em>undefined</em>.</p>
+<p>Observe que <em>current</em> não está definido e qualquer tentativa de acesso irá resultar em <em>undefined</em>.</p>
 
 <h3 id="Removendo_um_setter_com_o_operador_delete">Removendo um setter com o operador <code>delete</code></h3>
 


### PR DESCRIPTION
This PR fixes a misspell in the `pt-BR` version of the `web/javascript/reference/functions/set` page.