### PR TITLE
remove all summary class in javascript

### DIFF
--- a/files/ko/web/javascript/guide/control_flow_and_error_handling/index.html
+++ b/files/ko/web/javascript/guide/control_flow_and_error_handling/index.html
@@ -9,7 +9,7 @@ translation_of: Web/JavaScript/Guide/Control_flow_and_error_handling
 ---
 <p>{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Grammar_and_types", "Web/JavaScript/Guide/Loops_and_iteration")}}</p>
 
-<p class="summary">JavaScript는 어플리케이션 상의 상호작용을 통합하는데 사용할 수 있는 일련의 문법, 특히 제어흐름 문을 지원합니다. 이 장에서는 이러한 문법의 개요를 제공합니다.</p>
+<p >JavaScript는 어플리케이션 상의 상호작용을 통합하는데 사용할 수 있는 일련의 문법, 특히 제어흐름 문을 지원합니다. 이 장에서는 이러한 문법의 개요를 제공합니다.</p>
 
 <p><a href="/en-US/docs/Web/JavaScript/Reference/Statements">JavaScript reference</a>는 이 장의 문법에 대한 철저하고 자세한 내용은 포함하고 있습니다. 세미콜론 (;) 은 JavaScript 코드 상에서 문장을 나누는데 사용됩니다. </p>
 

--- a/files/ko/web/javascript/guide/details_of_the_object_model/index.html
+++ b/files/ko/web/javascript/guide/details_of_the_object_model/index.html
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Guide/객체_모델의_세부사항
 ---
 <div>{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Working_with_Objects", "Web/JavaScript/Guide/Iterators_and_Generators")}}</div>
 
-<p class="summary">자바스크립트는 클래스 기반이 아닌 prototype에 기초한 객체 기반 언어 입니다. 이런 차이점으로 인해, 객체들의 계층 구조의 생성과 속성 및 속성 값의 상속을 어떻게 구현해야 하는지에 대한 부분이 덜 분명할 수 있습니다. 이번 장에서는 이런 상황을 명확하게 하고자 합니다. </p>
+<p >자바스크립트는 클래스 기반이 아닌 prototype에 기초한 객체 기반 언어 입니다. 이런 차이점으로 인해, 객체들의 계층 구조의 생성과 속성 및 속성 값의 상속을 어떻게 구현해야 하는지에 대한 부분이 덜 분명할 수 있습니다. 이번 장에서는 이런 상황을 명확하게 하고자 합니다. </p>
 
 <p>이번 장에선 이미 자바스크립트를 어느 정도 알고 있고, 간단한 객체를 생성하는 함수들을 사용해보았다는 가정하에 진행합니다.</p>
 

--- a/files/ko/web/javascript/guide/expressions_and_operators/index.html
+++ b/files/ko/web/javascript/guide/expressions_and_operators/index.html
@@ -17,7 +17,7 @@ translation_of: Web/JavaScript/Guide/Expressions_and_Operators
   "Web/JavaScript/Guide/Numbers_and_dates")}}
 </div>
 
-<p class="summary">
+<p >
   이 장은 JavaScript의 표현식과 할당, 비교, 산술, 비트 계산, 논리, 문자열, 삼항 등 여러 가지 연산자를 설명합니다.
 </p>
 

--- a/files/ko/web/javascript/guide/functions/index.html
+++ b/files/ko/web/javascript/guide/functions/index.html
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Guide/함수
 ---
 <div>{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Loops_and_iteration", "Web/JavaScript/Guide/Expressions_and_Operators")}}</div>
 
-<p class="summary">함수는 JavaScript에서 기본적인 구성 블록 중의 하나입니다. 함수는 작업을 수행하거나 값을 계산하는 문장 집합 같은 자바스크립트 절차입니다. 함수를 사용하려면 함수를 호출하고자 하는 범위 내에서 함수를 정의해야만 합니다.</p>
+<p >함수는 JavaScript에서 기본적인 구성 블록 중의 하나입니다. 함수는 작업을 수행하거나 값을 계산하는 문장 집합 같은 자바스크립트 절차입니다. 함수를 사용하려면 함수를 호출하고자 하는 범위 내에서 함수를 정의해야만 합니다.</p>
 
 <p>세부 사항에 대해서는 <a href="/ko/docs/Web/JavaScript/Reference/Functions">exhaustive reference chapter about JavaScript functions</a>를 참조하세요.</p>
 

--- a/files/ko/web/javascript/guide/grammar_and_types/index.html
+++ b/files/ko/web/javascript/guide/grammar_and_types/index.html
@@ -10,7 +10,7 @@ original_slug: Web/JavaScript/Guide/Values,_variables,_and_literals
 ---
 <div>{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/소개", "Web/JavaScript/Guide/Control_flow_and_error_handling")}}</div>
 
-<p class="summary">이 장은 JavaScript의 기본 문법과 변수 선언, 자료형 및 리터럴을 다룹니다.</p>
+<p >이 장은 JavaScript의 기본 문법과 변수 선언, 자료형 및 리터럴을 다룹니다.</p>
 
 <h2 id="기본">기본</h2>
 

--- a/files/ko/web/javascript/guide/index.html
+++ b/files/ko/web/javascript/guide/index.html
@@ -10,7 +10,7 @@ translation_of: Web/JavaScript/Guide
 ---
 <div>{{jsSidebar("JavaScript Guide")}}</div>
 
-<p class="summary">JavaScript 안내서에서 <a href="/ko/docs/Web/JavaScript">JavaScript</a> 언어 개요와 사용법을 알아보세요. 언어 기능에 대해 상세한 정보가 필요하면 <a href="/ko/docs/Web/JavaScript/Reference">JavaScript 참고서</a>를 방문하세요.</p>
+<p >JavaScript 안내서에서 <a href="/ko/docs/Web/JavaScript">JavaScript</a> 언어 개요와 사용법을 알아보세요. 언어 기능에 대해 상세한 정보가 필요하면 <a href="/ko/docs/Web/JavaScript/Reference">JavaScript 참고서</a>를 방문하세요.</p>
 
 <h2 id="목차">목차</h2>
 

--- a/files/ko/web/javascript/guide/indexed_collections/index.html
+++ b/files/ko/web/javascript/guide/indexed_collections/index.html
@@ -5,7 +5,7 @@ translation_of: Web/JavaScript/Guide/Indexed_collections
 ---
 <div>{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Regular_Expressions", "Web/JavaScript/Guide/Keyed_Collections")}}</div>
 
-<p class="summary">이번장에서는 인덱스값에 의해 정렬이 되는 데이터 자료구조에 대해 소개합니다.  배열과 유사 배열 생성자인 {{jsxref("Array")}} 객체와 {{jsxref("TypedArray")}} 객체 같은 생성자들을 포함합니다. </p>
+<p >이번장에서는 인덱스값에 의해 정렬이 되는 데이터 자료구조에 대해 소개합니다.  배열과 유사 배열 생성자인 {{jsxref("Array")}} 객체와 {{jsxref("TypedArray")}} 객체 같은 생성자들을 포함합니다. </p>
 
 <h2 id="배열_객체">배열 객체</h2>
 

--- a/files/ko/web/javascript/guide/introduction/index.html
+++ b/files/ko/web/javascript/guide/introduction/index.html
@@ -11,7 +11,7 @@ original_slug: Web/JavaScript/Guide/소개
 ---
 <div>{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide", "Web/JavaScript/Guide/Grammar_and_types")}}</div>
 
-<p class="summary">이 장은 JavaScript를 소개하고 그 일부 기초 개념을 다룹니다.</p>
+<p >이 장은 JavaScript를 소개하고 그 일부 기초 개념을 다룹니다.</p>
 
 <h2 id="무엇을_미리_알고_있어야_하나요">무엇을 미리 알고 있어야 하나요?</h2>
 

--- a/files/ko/web/javascript/guide/iterators_and_generators/index.html
+++ b/files/ko/web/javascript/guide/iterators_and_generators/index.html
@@ -9,7 +9,7 @@ translation_of: Web/JavaScript/Guide/Iterators_and_Generators
 ---
 <div>{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Using_promises", "Web/JavaScript/Guide/Meta_programming")}}</div>
 
-<p class="summary">컬렉션 내 각 항목 처리는 매우 흔한 연산입니다. JavaScript는 간단한 {{jsxref("Statements/for","for")}} 루프에서 {{jsxref("Global_Objects/Array/map","map()")}} 및 {{jsxref("Global_Objects/Array/filter","filter()")}}에 이르기까지, 컬렉션을 반복하는 많은 방법을 제공합니다. 반복기(iterator) 및 생성기(generator)는 반복 개념을 핵심 언어 내로 바로 가져와 {{jsxref("Statements/for...of","for...of")}} 루프의 동작(behavior)을 사용자 정의하는 메커니즘을 제공합니다.</p>
+<p >컬렉션 내 각 항목 처리는 매우 흔한 연산입니다. JavaScript는 간단한 {{jsxref("Statements/for","for")}} 루프에서 {{jsxref("Global_Objects/Array/map","map()")}} 및 {{jsxref("Global_Objects/Array/filter","filter()")}}에 이르기까지, 컬렉션을 반복하는 많은 방법을 제공합니다. 반복기(iterator) 및 생성기(generator)는 반복 개념을 핵심 언어 내로 바로 가져와 {{jsxref("Statements/for...of","for...of")}} 루프의 동작(behavior)을 사용자 정의하는 메커니즘을 제공합니다.</p>
 
 <p>자세한 내용은, 다음을 참조하세요:</p>
 

--- a/files/ko/web/javascript/guide/keyed_collections/index.html
+++ b/files/ko/web/javascript/guide/keyed_collections/index.html
@@ -5,7 +5,7 @@ translation_of: Web/JavaScript/Guide/Keyed_collections
 ---
 <div>{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Indexed_Collections", "Web/JavaScript/Guide/Working_with_Objects")}}</div>
 
-<p class="summary">이번 장에서는 입력된 키값을 기준으로 정렬되는 데이터의 집합(자료 구조)에 대해 소개 할 것이다. Map과 Set은 입력된 순서대로 반복적으로 접근 가능한 요소들을 포함하고 있다. </p>
+<p >이번 장에서는 입력된 키값을 기준으로 정렬되는 데이터의 집합(자료 구조)에 대해 소개 할 것이다. Map과 Set은 입력된 순서대로 반복적으로 접근 가능한 요소들을 포함하고 있다. </p>
 
 <h2 id="Maps">Maps</h2>
 

--- a/files/ko/web/javascript/guide/loops_and_iteration/index.html
+++ b/files/ko/web/javascript/guide/loops_and_iteration/index.html
@@ -5,7 +5,7 @@ translation_of: Web/JavaScript/Guide/Loops_and_iteration
 ---
 <div>{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Control_flow_and_error_handling", "Web/JavaScript/Guide/Functions")}}</div>
 
-<p class="summary">루프는 어떤 것을 반복적으로 시행할때 빠르고 간편한 방법을 제공합니다. <a href="/en-US/docs/Web/JavaScript/Guide">JavaScript Guide</a>의 이 항목은 JavaScript 에서 사용이 가능한 서로 다른 여러가지 반복문을 소개합니다.</p>
+<p >루프는 어떤 것을 반복적으로 시행할때 빠르고 간편한 방법을 제공합니다. <a href="/en-US/docs/Web/JavaScript/Guide">JavaScript Guide</a>의 이 항목은 JavaScript 에서 사용이 가능한 서로 다른 여러가지 반복문을 소개합니다.</p>
 
 <p>반복문을 게임의 컴퓨터화된 버전이라고 생각해 보세요. 누군가에게 한 방향으로 X만큼 가게 시키고 다른 방향으로 Y만큼 더 가게 한다고 생각해 보십시오. 예를들어, "동쪽으로 5만큼 가세요"는 다음과 같이 반복문으로 표현 될 수 있습니다.</p>
 

--- a/files/ko/web/javascript/guide/meta_programming/index.html
+++ b/files/ko/web/javascript/guide/meta_programming/index.html
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Guide/메타_프로그래밍
 ---
 <div>{{jsSidebar("JavaScript Guide")}} {{Previous("Web/JavaScript/Guide/Iterators_and_Generators")}}</div>
 
-<p class="summary">Starting with ECMAScript 2015, JavaScript gains support for the {{jsxref("Proxy")}} and {{jsxref("Reflect")}} objects allowing you to intercept and define custom behavior for fundamental language operations (e.g. property lookup, assignment, enumeration, function invocation, etc). With the help of these two objects you are able to program at the meta level of JavaScript.</p>
+<p >Starting with ECMAScript 2015, JavaScript gains support for the {{jsxref("Proxy")}} and {{jsxref("Reflect")}} objects allowing you to intercept and define custom behavior for fundamental language operations (e.g. property lookup, assignment, enumeration, function invocation, etc). With the help of these two objects you are able to program at the meta level of JavaScript.</p>
 
 <h2 id="Proxies">Proxies</h2>
 

--- a/files/ko/web/javascript/guide/numbers_and_dates/index.html
+++ b/files/ko/web/javascript/guide/numbers_and_dates/index.html
@@ -7,7 +7,7 @@ translation_of: Web/JavaScript/Guide/Numbers_and_dates
 ---
 <div>{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Expressions_and_Operators", "Web/JavaScript/Guide/Text_formatting")}}</div>
 
-<p><span class="seoSummary">이 장에서는 JavaScript에서 숫자와 날짜를 사용하기 위한 개념과 객체, 함수에 대해 소개합니다.</span> 그리고 숫자를 10진법, 2진법, 16진법 등의 다양한 형태로 표현하는 방법과 더불어 {{jsxref("Math")}} 객체를 사용해 다양한 수학 연산을 수행하는 방법을 알 수 있습니다.</p>
+<p><span >이 장에서는 JavaScript에서 숫자와 날짜를 사용하기 위한 개념과 객체, 함수에 대해 소개합니다.</span> 그리고 숫자를 10진법, 2진법, 16진법 등의 다양한 형태로 표현하는 방법과 더불어 {{jsxref("Math")}} 객체를 사용해 다양한 수학 연산을 수행하는 방법을 알 수 있습니다.</p>
 
 <h2 id="숫자">숫자</h2>
 

--- a/files/ko/web/javascript/guide/regular_expressions/index.html
+++ b/files/ko/web/javascript/guide/regular_expressions/index.html
@@ -9,7 +9,7 @@ original_slug: Web/JavaScript/Guide/정규식
 ---
 <div>{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Text_formatting", "Web/JavaScript/Guide/Indexed_collections")}}</div>
 
-<p class="summary">정규 표현식은 문자열에 나타는 특정 문자 조합과 대응시키기 위해 사용되는 패턴입니다. 자바스크립트에서, 정규 표현식 또한 객체입니다.  이 패턴들은 {{jsxref("RegExp")}}의 {{jsxref("RegExp.exec", "exec")}} 메소드와 {{jsxref("RegExp.test", "test")}} 메소드  ,그리고 {{jsxref("String")}}의  {{jsxref("String.match", "match")}}메소드 , {{jsxref("String.replace", "replace")}}메소드 , {{jsxref("String.search", "search")}}메소드 ,  {{jsxref("String.split", "split")}} 메소드와 함께 쓰입니다 . 이 장에서는 자바스크립트의 정규식에 대하여 설명합니다.</p>
+<p >정규 표현식은 문자열에 나타는 특정 문자 조합과 대응시키기 위해 사용되는 패턴입니다. 자바스크립트에서, 정규 표현식 또한 객체입니다.  이 패턴들은 {{jsxref("RegExp")}}의 {{jsxref("RegExp.exec", "exec")}} 메소드와 {{jsxref("RegExp.test", "test")}} 메소드  ,그리고 {{jsxref("String")}}의  {{jsxref("String.match", "match")}}메소드 , {{jsxref("String.replace", "replace")}}메소드 , {{jsxref("String.search", "search")}}메소드 ,  {{jsxref("String.split", "split")}} 메소드와 함께 쓰입니다 . 이 장에서는 자바스크립트의 정규식에 대하여 설명합니다.</p>
 
 <h2 id="정규_표현식_만들기">정규 표현식 만들기</h2>
 

--- a/files/ko/web/javascript/guide/text_formatting/index.html
+++ b/files/ko/web/javascript/guide/text_formatting/index.html
@@ -5,7 +5,7 @@ translation_of: Web/JavaScript/Guide/Text_formatting
 ---
 <div>{{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Numbers_and_dates", "Web/JavaScript/Guide/Regular_Expressions")}}</div>
 
-<p class="summary">이 장에서는 JavaScript에서 문자열과 텍스트로 작업하는 방법을 소개합니다.</p>
+<p >이 장에서는 JavaScript에서 문자열과 텍스트로 작업하는 방법을 소개합니다.</p>
 
 <h2 id="문자열">문자열</h2>
 

--- a/files/ko/web/javascript/guide/using_promises/index.html
+++ b/files/ko/web/javascript/guide/using_promises/index.html
@@ -8,7 +8,7 @@ translation_of: Web/JavaScript/Guide/Using_promises
 ---
 <div>{{jsSidebar("JavaScript Guide")}}{{PreviousNext("Web/JavaScript/Guide/Details_of_the_Object_Model", "Web/JavaScript/Guide/Iterators_and_Generators")}}</div>
 
-<p class="summary">{{jsxref("Promise")}}는 비동기 작업의 최종 완료 또는 실패를 나타내는 객체입니다. 대부분 여러분은 이미 만들어진 promise를 사용했었기 때문에 이 가이드에서는 어떻게 promise를 만드는지 설명하기에 앞서 promise의 사용법에 대해 설명합니다.</p>
+<p >{{jsxref("Promise")}}는 비동기 작업의 최종 완료 또는 실패를 나타내는 객체입니다. 대부분 여러분은 이미 만들어진 promise를 사용했었기 때문에 이 가이드에서는 어떻게 promise를 만드는지 설명하기에 앞서 promise의 사용법에 대해 설명합니다.</p>
 
 <p>기본적으로 promise는 함수에 콜백을 전달하는 대신에, 콜백을 첨부하는 방식의 객체입니다.<br>
   </p>

--- a/files/ko/web/javascript/reference/global_objects/array/reduce/index.html
+++ b/files/ko/web/javascript/reference/global_objects/array/reduce/index.html
@@ -12,7 +12,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Array/Reduce
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary"><code><strong>reduce()</strong></code><strong> </strong>메서드는 배열의 각 요소에 대해 주어진 <strong>리듀서</strong>(reducer) 함수를 실행하고, 하나의 결과값을 반환합니다.</span></p>
+<p><span ><code><strong>reduce()</strong></code><strong> </strong>메서드는 배열의 각 요소에 대해 주어진 <strong>리듀서</strong>(reducer) 함수를 실행하고, 하나의 결과값을 반환합니다.</span></p>
 
 <div>{{EmbedInteractiveExample("pages/js/array-reduce.html")}}</div>
 

--- a/files/ko/web/javascript/reference/global_objects/date/getday/index.html
+++ b/files/ko/web/javascript/reference/global_objects/date/getday/index.html
@@ -11,7 +11,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Date/getDay
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary"><strong><code>getDay()</code></strong> 메서드는 주어진 날짜의 현지 시간 기준 요일을 반환합니다. 0은 일요일을 나타냅니다.</span> 현재의 일을 반환하려면 {{jsxref("Date.prototype.getDate()")}}를 사용하세요.</p>
+<p><span ><strong><code>getDay()</code></strong> 메서드는 주어진 날짜의 현지 시간 기준 요일을 반환합니다. 0은 일요일을 나타냅니다.</span> 현재의 일을 반환하려면 {{jsxref("Date.prototype.getDate()")}}를 사용하세요.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/date-getday.html")}}</div>
 

--- a/files/ko/web/javascript/reference/global_objects/encodeuri/index.html
+++ b/files/ko/web/javascript/reference/global_objects/encodeuri/index.html
@@ -10,7 +10,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/encodeURI
 ---
 <div>{{jsSidebar("Objects")}}</div>
 
-<p><span class="seoSummary"><code><strong>encodeURI()</strong></code> 함수는 {{glossary("URI")}}의 특정한 문자를 UTF-8로 인코딩해 하나, 둘, 셋, 혹은 네 개의 연속된 이스케이프 문자로 나타냅니다.</span> (두 개의 대리 문자로 이루어진 문자만 이스케이프 문자 네 개로 변환됩니다.)</p>
+<p><span ><code><strong>encodeURI()</strong></code> 함수는 {{glossary("URI")}}의 특정한 문자를 UTF-8로 인코딩해 하나, 둘, 셋, 혹은 네 개의 연속된 이스케이프 문자로 나타냅니다.</span> (두 개의 대리 문자로 이루어진 문자만 이스케이프 문자 네 개로 변환됩니다.)</p>
 
 <div>{{EmbedInteractiveExample("pages/js/globalprops-encodeuri.html")}}</div>
 

--- a/files/ko/web/javascript/reference/global_objects/encodeuricomponent/index.html
+++ b/files/ko/web/javascript/reference/global_objects/encodeuricomponent/index.html
@@ -9,7 +9,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/encodeURIComponent
 ---
 <div>{{jsSidebar("Objects")}}</div>
 
-<p><span class="seoSummary"><code><strong>encodeURIComponent()</strong></code> 함수는 {{glossary("URI")}}의 특정한 문자를 UTF-8로 인코딩해 하나, 둘, 셋, 혹은 네 개의 연속된 이스케이프 문자로 나타냅니다.</span> (두 개의 대리 문자로 이루어진 문자만 이스케이프 문자 네 개로 변환됩니다.)</p>
+<p><span ><code><strong>encodeURIComponent()</strong></code> 함수는 {{glossary("URI")}}의 특정한 문자를 UTF-8로 인코딩해 하나, 둘, 셋, 혹은 네 개의 연속된 이스케이프 문자로 나타냅니다.</span> (두 개의 대리 문자로 이루어진 문자만 이스케이프 문자 네 개로 변환됩니다.)</p>
 
 <div>{{EmbedInteractiveExample("pages/js/globalprops-encodeuricomponent.html")}}</div>
 

--- a/files/ko/web/javascript/reference/global_objects/function/index.html
+++ b/files/ko/web/javascript/reference/global_objects/function/index.html
@@ -9,7 +9,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Function
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary"><strong><code>Function</code> 생성자</strong>는 새 <code>Function</code> 객체를 만듭니다.</span> 이 생성자를 직접 호출하여 동적으로 함수를 생성할 수도 있으나, 보안 문제 및 {{jsxref("eval")}}과 유사한(그러나 훨씬 덜 심각한) 성능 문제가 발생할 수 있습니다. 하지만 <code>eval</code>과 달리, <code>Function</code> 생성자는 전역 범위로 한정된 함수만 생성합니다.</p>
+<p><span ><strong><code>Function</code> 생성자</strong>는 새 <code>Function</code> 객체를 만듭니다.</span> 이 생성자를 직접 호출하여 동적으로 함수를 생성할 수도 있으나, 보안 문제 및 {{jsxref("eval")}}과 유사한(그러나 훨씬 덜 심각한) 성능 문제가 발생할 수 있습니다. 하지만 <code>eval</code>과 달리, <code>Function</code> 생성자는 전역 범위로 한정된 함수만 생성합니다.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/function-constructor.html")}}</div>
 

--- a/files/ko/web/javascript/reference/global_objects/intl/locale/index.html
+++ b/files/ko/web/javascript/reference/global_objects/intl/locale/index.html
@@ -12,7 +12,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Intl/Locale
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary">The <strong><code>Intl.Locale</code></strong> constructor is a standard built-in property of the Intl object that represents a Unicode locale identifier.</span></p>
+<p><span >The <strong><code>Intl.Locale</code></strong> constructor is a standard built-in property of the Intl object that represents a Unicode locale identifier.</span></p>
 
 <p>{{EmbedInteractiveExample("pages/js/intl-locale.html")}}</p>
 

--- a/files/ko/web/javascript/reference/global_objects/intl/locale/language/index.html
+++ b/files/ko/web/javascript/reference/global_objects/intl/locale/language/index.html
@@ -7,7 +7,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Intl/Locale/language
 
 <div></div>
 
-<p><span class="seoSummary"><strong><code>Intl.Locale.prototype.language</code></strong> 속성은 locale과 관련된 언어를 반환하는 접근자 속성입니다.</span></p>
+<p><span ><strong><code>Intl.Locale.prototype.language</code></strong> 속성은 locale과 관련된 언어를 반환하는 접근자 속성입니다.</span></p>
 
 <h2 id="Description">Description</h2>
 

--- a/files/ko/web/javascript/reference/global_objects/json/parse/index.html
+++ b/files/ko/web/javascript/reference/global_objects/json/parse/index.html
@@ -11,7 +11,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/JSON/parse
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary"><strong><code>JSON.parse()</code></strong> 메서드는 JSON 문자열의 구문을 분석하고, 그 결과에서 JavaScript 값이나 객체를 생성합니다.</span> 선택적으로, <code>reviver</code> 함수를 인수로 전달할 경우, 결과를 반환하기 전에 변형할 수 있습니다.</p>
+<p><span ><strong><code>JSON.parse()</code></strong> 메서드는 JSON 문자열의 구문을 분석하고, 그 결과에서 JavaScript 값이나 객체를 생성합니다.</span> 선택적으로, <code>reviver</code> 함수를 인수로 전달할 경우, 결과를 반환하기 전에 변형할 수 있습니다.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/json-parse.html")}}</div>
 

--- a/files/ko/web/javascript/reference/global_objects/json/stringify/index.html
+++ b/files/ko/web/javascript/reference/global_objects/json/stringify/index.html
@@ -10,7 +10,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/JSON/stringify
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary"><strong><code>JSON.stringify()</code></strong> 메서드는 JavaScript 값이나 객체를 JSON 문자열로 변환합니다.</span> 선택적으로, <code>replacer</code>를 함수로 전달할 경우 변환 전 값을 변형할 수 있고, 배열로 전달할 경우 지정한 속성만 결과에 포함합니다.</p>
+<p><span ><strong><code>JSON.stringify()</code></strong> 메서드는 JavaScript 값이나 객체를 JSON 문자열로 변환합니다.</span> 선택적으로, <code>replacer</code>를 함수로 전달할 경우 변환 전 값을 변형할 수 있고, 배열로 전달할 경우 지정한 속성만 결과에 포함합니다.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/json-stringify.html")}}</div>
 

--- a/files/ko/web/javascript/reference/global_objects/math/cbrt/index.html
+++ b/files/ko/web/javascript/reference/global_objects/math/cbrt/index.html
@@ -11,7 +11,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Math/cbrt
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary"><strong><code>Math.cbrt()</code></strong> 함수는 주어진 수의 세제곱근을 반환합니다.</span> 즉,</p>
+<p><span ><strong><code>Math.cbrt()</code></strong> 함수는 주어진 수의 세제곱근을 반환합니다.</span> 즉,</p>
 
 <p><math display="block"><semantics><mrow><mstyle mathvariant="monospace"><mrow><mi>M</mi><mi>a</mi><mi>t</mi><mi>h</mi><mo>.</mo><mi>c</mi><mi>b</mi><mi>r</mi><mi>t</mi><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo></mrow></mstyle><mo>=</mo><mroot><mi>x</mi><mn>3</mn></mroot><mo>=</mo><mtext>the unique</mtext><mspace width="thickmathspace"></mspace><mi>y</mi><mspace width="thickmathspace"></mspace><mtext>such that</mtext><mspace width="thickmathspace"></mspace><msup><mi>y</mi><mn>3</mn></msup><mo>=</mo><mi>x</mi></mrow><annotation encoding="TeX">\mathtt{Math.cbrt(x)} = \sqrt[3]{x} = \text{the unique} \; y \; \text{such that} \; y^3 = x</annotation></semantics></math></p>
 

--- a/files/ko/web/javascript/reference/global_objects/math/index.html
+++ b/files/ko/web/javascript/reference/global_objects/math/index.html
@@ -9,7 +9,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Math
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary"><strong><code>Math</code></strong>는 수학적인 상수와 함수를 위한 속성과 메서드를 가진 내장 객체입니다.</span> 함수 객체가 아닙니다.</p>
+<p><span ><strong><code>Math</code></strong>는 수학적인 상수와 함수를 위한 속성과 메서드를 가진 내장 객체입니다.</span> 함수 객체가 아닙니다.</p>
 
 <p><code>Math</code>는 {{jsxref("Number")}} 자료형만 지원하며 {{jsxref("BigInt")}}와는 사용할 수 없습니다.</p>
 

--- a/files/ko/web/javascript/reference/global_objects/number/isnan/index.html
+++ b/files/ko/web/javascript/reference/global_objects/number/isnan/index.html
@@ -11,7 +11,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Number/isNaN
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary"><strong><code>Number.isNaN()</code></strong> 메서드는 주어진 값이 {{jsxref("NaN")}}인지 판별합니다.</span> 기존부터 존재한 전역 {{jsxref("isNaN", "isNaN()")}} 함수의 더 엄격한 버전입니다.</p>
+<p><span ><strong><code>Number.isNaN()</code></strong> 메서드는 주어진 값이 {{jsxref("NaN")}}인지 판별합니다.</span> 기존부터 존재한 전역 {{jsxref("isNaN", "isNaN()")}} 함수의 더 엄격한 버전입니다.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/number-isnan.html", "taller")}}</div>
 

--- a/files/ko/web/javascript/reference/global_objects/object/freeze/index.html
+++ b/files/ko/web/javascript/reference/global_objects/object/freeze/index.html
@@ -17,7 +17,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Object/freeze
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary"><code><strong>Object.freeze()</strong></code> 메서드는 객체를 <strong>동결</strong>합니다. 동결된 객체는 더 이상 변경될 수 없습니다. 즉, 동결된 객체는 새로운 속성을 추가하거나 존재하는 속성을 제거하는 것을 방지하며 존재하는 속성의 불변성, 설정 가능성(configurability), 작성 가능성이 변경되는 것을 방지하고, 존재하는 속성의 값이 변경되는 것도 방지합니다.</span> 또한, 동결 객체는 그 프로토타입이 변경되는것도 방지합니다. <code>freeze()</code>는 전달된 동일한 객체를 반환합니다.</p>
+<p><span ><code><strong>Object.freeze()</strong></code> 메서드는 객체를 <strong>동결</strong>합니다. 동결된 객체는 더 이상 변경될 수 없습니다. 즉, 동결된 객체는 새로운 속성을 추가하거나 존재하는 속성을 제거하는 것을 방지하며 존재하는 속성의 불변성, 설정 가능성(configurability), 작성 가능성이 변경되는 것을 방지하고, 존재하는 속성의 값이 변경되는 것도 방지합니다.</span> 또한, 동결 객체는 그 프로토타입이 변경되는것도 방지합니다. <code>freeze()</code>는 전달된 동일한 객체를 반환합니다.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/object-freeze.html")}}</div>
 

--- a/files/ko/web/javascript/reference/global_objects/object/keys/index.html
+++ b/files/ko/web/javascript/reference/global_objects/object/keys/index.html
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Object.keys
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary"><code><strong>Object.keys()</strong></code> 메소드는 주어진 객체의 속성 이름들을 일반적인 반복문과
+<p><span ><code><strong>Object.keys()</strong></code> 메소드는 주어진 객체의 속성 이름들을 일반적인 반복문과
      동일한 순서로 순회되는 열거할 수 있는 배열로 반환합니다.
     </span></p>
 

--- a/files/ko/web/javascript/reference/global_objects/reflect/isextensible/index.html
+++ b/files/ko/web/javascript/reference/global_objects/reflect/isextensible/index.html
@@ -11,7 +11,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Reflect/isExtensible
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary"><code><strong>Reflect</strong></code><strong><code>.isExtensible()</code></strong> 정적 메서드는 객체의 확장 가능 여부, 즉 속성을 추가할 수 있는지 판별합니다.</span> {{jsxref("Object.isExtensible()")}}과 유사하지만 {{anch("Object.isExtensible()과의 차이", "차이점")}}도 있습니다.</p>
+<p><span ><code><strong>Reflect</strong></code><strong><code>.isExtensible()</code></strong> 정적 메서드는 객체의 확장 가능 여부, 즉 속성을 추가할 수 있는지 판별합니다.</span> {{jsxref("Object.isExtensible()")}}과 유사하지만 {{anch("Object.isExtensible()과의 차이", "차이점")}}도 있습니다.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/reflect-isextensible.html", "taller")}}</div>
 

--- a/files/ko/web/javascript/reference/global_objects/reflect/preventextensions/index.html
+++ b/files/ko/web/javascript/reference/global_objects/reflect/preventextensions/index.html
@@ -11,7 +11,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Reflect/preventExtension
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary"><code><strong>Reflect.preventExtensions()</strong></code> 정적 메서드는 새로운 속성을 객체에 추가하지 못하도록 완전히 막습니다. 즉, 미래의 객체 확장을 막습니다.</span> {{jsxref("Object.preventExtensions()")}}와 유사하지만 {{anch("Object.preventExtensions()와의 차이점", "차이점")}}도 있습니다.</p>
+<p><span ><code><strong>Reflect.preventExtensions()</strong></code> 정적 메서드는 새로운 속성을 객체에 추가하지 못하도록 완전히 막습니다. 즉, 미래의 객체 확장을 막습니다.</span> {{jsxref("Object.preventExtensions()")}}와 유사하지만 {{anch("Object.preventExtensions()와의 차이점", "차이점")}}도 있습니다.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/reflect-preventextensions.html")}}</div>
 

--- a/files/ko/web/javascript/reference/global_objects/reflect/setprototypeof/index.html
+++ b/files/ko/web/javascript/reference/global_objects/reflect/setprototypeof/index.html
@@ -11,7 +11,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Reflect/setPrototypeOf
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary"><code><strong>Reflect</strong></code><strong><code>.setPrototypeOf()</code></strong> 정적 메서드는 주어진 객체의 프로토타입(내부 <code>[[Prototype]]</code> 속성)을 다른 객체나 {{jsxref("null")}}로 바꿉니다.</span> 반환 값을 제외하면 {{jsxref("Object.setPrototypeOf()")}} 메서드와 같습니다.</p>
+<p><span ><code><strong>Reflect</strong></code><strong><code>.setPrototypeOf()</code></strong> 정적 메서드는 주어진 객체의 프로토타입(내부 <code>[[Prototype]]</code> 속성)을 다른 객체나 {{jsxref("null")}}로 바꿉니다.</span> 반환 값을 제외하면 {{jsxref("Object.setPrototypeOf()")}} 메서드와 같습니다.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/reflect-setprototypeof.html")}}</div>
 

--- a/files/ko/web/javascript/reference/global_objects/string/startswith/index.html
+++ b/files/ko/web/javascript/reference/global_objects/string/startswith/index.html
@@ -12,7 +12,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/String/startsWith
 ---
 <div>{{JSRef}}</div>
 
-<p><span class="seoSummary"><strong><code>startsWith()</code></strong></span><span class="seoSummary"> 메소드는 어떤 문자열이 특정 문자로 시작하는지 확인하여 결과를 <code>true</code> 혹은 <code>false</code>로 반환합니다.</span></p>
+<p><span ><strong><code>startsWith()</code></strong></span><span > 메소드는 어떤 문자열이 특정 문자로 시작하는지 확인하여 결과를 <code>true</code> 혹은 <code>false</code>로 반환합니다.</span></p>
 
 <h2 id="구문">구문</h2>
 

--- a/files/ko/web/javascript/reference/statements/switch/index.html
+++ b/files/ko/web/javascript/reference/statements/switch/index.html
@@ -5,7 +5,7 @@ translation_of: Web/JavaScript/Reference/Statements/switch
 ---
 <div>{{jsSidebar("Statements")}}</div>
 
-<p><span class="seoSummary">The <strong><code>switch</code> statement</strong> evaluates an <a href="/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators">expression</a>, matching the expression's value to a <code>case</code> clause, and executes <a href="/en-US/docs/Web/JavaScript/Reference/Statements">statements</a> associated with that case, as well as statements in cases that follow the matching case.</span></p>
+<p><span >The <strong><code>switch</code> statement</strong> evaluates an <a href="/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators">expression</a>, matching the expression's value to a <code>case</code> clause, and executes <a href="/en-US/docs/Web/JavaScript/Reference/Statements">statements</a> associated with that case, as well as statements in cases that follow the matching case.</span></p>
 
 <div>{{EmbedInteractiveExample("pages/js/statement-switch.html")}}</div>
 


### PR DESCRIPTION
#2895 `seoSummary`와 `summary`클래스를 모두 제거했습니다.

pr규칙에 따르면 한 pc당 변경파일 개수가 20개를 넘지 않아야 하지만, 이번 pr은 간단한 변경으로 판단되었고, 호찬님의 동의를 얻어 35개의 파일을 한번에 수정 하였습니다. 다음번엔 되도록 규칙을 지키도록 하겠습니다 리뷰어님ㅠ🙏