### PR TITLE
SVG/index.htmlのSVG/Tutorialへのリンク掲示位置を変更

### DIFF
--- a/files/ja/web/svg/index.html
+++ b/files/ja/web/svg/index.html
@@ -28,7 +28,7 @@ translation_of: Web/SVG
 
 <p>SVG は1999年から <a href="https://www.w3.org/">World Wide Web Consortium (W3C)</a> によって開発されています。</p>
 
-<p><a href="/ja/docs/Web/SVG/Tutorial">SVG教本</a>も参照してください</p>
+<p><a href="/ja/docs/Web/SVG/Tutorial">SVG教本</a>も参照してください。</p>
 
 <h2 id="Documentation">ドキュメント</h2>
 

--- a/files/ja/web/svg/index.html
+++ b/files/ja/web/svg/index.html
@@ -18,7 +18,7 @@ translation_of: Web/SVG
 ---
 <div>{{SVGRef}}</div>
 
-<h2><a href="/ja/docs/Web/SVG/Tutorial">SVG を始めましょう</a></h2>
+<h2 id="Getting_started_with_svg">SVG を始めましょう</h2>
 
 <p class="summary" style="border-top-width: 0; padding-top: 0;"><span class="seoSummary"><strong>Scalable Vector Graphics (SVG)</strong> は、二次元ベースの<a class="external" href="https://ja.wikipedia.org/wiki/ベクタ形式">ベクター形式</a>のための <a href="/ja/docs/Web/XML" title="XML">XML</a> に基づくマークアップ言語です。そのため、どんな大きさでもきれいにレンダリングできる画像を記述するためのテキストベースのオープンなウェブ標準であり、特に他のウェブ標準、例えば <a href="/ja/docs/Web/CSS">CSS</a>, <a href="/ja/docs/Web/API/Document_Object_Model">DOM</a>, <a href="/ja/docs/Web/JavaScript">JavaScript</a>, <a href="/ja/docs/Web/SVG/SVG_animation_with_SMIL">SMIL</a> などとうまく機能するように設計されています。 SVG は本質的に、グラフィックに対するもので、テキストに対する <a href="/ja/docs/Web/HTML">HTML</a> のような位置づけです。</span></p>
 
@@ -27,6 +27,8 @@ translation_of: Web/SVG
 <p>旧来の {{Glossary("JPEG")}} や {{Glossary("PNG")}} のようなビットマップ画像形式と比較して、 SVG 形式のベクター画像は、品質を損なうことなく任意の大きさでレンダリングすることができ、テキストを更新することで、グラフィックエディターを使用せずに簡単にローカライズすることができます。適切なライブラリを使用すれば、 SVG ファイルをその場でローカライズすることも可能です。</p>
 
 <p>SVG は1999年から <a href="https://www.w3.org/">World Wide Web Consortium (W3C)</a> によって開発されています。</p>
+
+<p><a href="/ja/docs/Web/SVG/Tutorial">SVG教本</a>も参照してください</p>
 
 <h2 id="Documentation">ドキュメント</h2>
 


### PR DESCRIPTION
SVG/Tutorialへのリンクがヘッダーにあるのは規則的でなく少々わかりづらいと感じたため、英語版を参照しヘッダーから段落末尾に移動しました  
段落末尾に文言を追加し、ヘッダー要素の入れ子になっていたリンク要素を削除しています  
また、他に倣ってヘッダー要素にidを追加しています