### PR TITLE
[FIX] corrige erro de digitação

### DIFF
--- a/files/pt-br/web/javascript/reference/statements/const/index.html
+++ b/files/pt-br/web/javascript/reference/statements/const/index.html
@@ -11,7 +11,7 @@ translation_of: Web/JavaScript/Reference/Statements/const
 ---
 <div>{{jsSidebar("Statements")}}</div>
 
-<p>Constantes possuem escopo de bloco, semelhantes às variáveis declaradas usando o palavra-chave <code><a href="/en-US/docs/Web/JavaScript/Reference/Statements/let">let</a></code>. O valor de uma constante não pode ser alterado por uma atribuição, e ela não pod ser redeclarada.</p>
+<p>Constantes possuem escopo de bloco, semelhantes às variáveis declaradas usando o palavra-chave <code><a href="/en-US/docs/Web/JavaScript/Reference/Statements/let">let</a></code>. O valor de uma constante não pode ser alterado por uma atribuição, e ela não pode ser redeclarada.</p>
 
 <div>{{EmbedInteractiveExample("pages/js/statement-const.html")}}</div>
 


### PR DESCRIPTION
A palavra "pode" estava escrita como "pod"