### PR TITLE
fix text-overflow zh live example broken

### DIFF
--- a/files/zh-cn/web/css/text-overflow/index.html
+++ b/files/zh-cn/web/css/text-overflow/index.html
@@ -106,7 +106,7 @@ text-overflow: unset;</code></pre>
 
 <h3 id="Result">Result</h3>
 
-<p>{{EmbedLiveSample('Examples', 300, 220, '', 'Web/CSS/text-overflow')}}</p>
+<p>{{EmbedLiveSample('One-value_syntax', 600, 430)}}</p>
 
 <table>
  <thead>


### PR DESCRIPTION
fix issue #4011 text-overflow zh version live example broken