### PR TITLE
Remove warning statement

### DIFF
--- a/files/ru/web/javascript/reference/global_objects/promise/any/index.html
+++ b/files/ru/web/javascript/reference/global_objects/promise/any/index.html
@@ -7,10 +7,6 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Promise/any
 
 <p><code>Метод Promise.any()</code> принимает итерируемый объект содержащий объекты промисов {{JSxRef("Promise")}}. Как только один из промисов (<code>Promise)</code> выполнится успешно (<code>fullfill</code>), метод возвратит единственный объект <code>Promise</code> со значением выполненного промиса. Если ни один из промисов не завершится успешно (если все промисы завершатся с ошибкой, т.е. <code>rejected</code>), тогда возвращённый объект Promise будет отклонён (<code>rejected</code>) с одним из значений: массив содержащий причины ошибки (отклонения), или {{JSxRef("AggregateError")}} — подкласс {{JSxRef("Error")}}, который объединяет выброшенные ошибки вместе. По существу, метод <code>Promise.any()</code> является противоположностью для {{JSxRef("Promise.all()")}}.</p>
 
-<div class="blockIndicator warning">
-<p><strong>Warning!</strong> The <code>Promise.any()</code> method is experimental and not fully supported by all browsers. It is currently in the <a href="https://github.com/tc39/proposal-promise-any" rel="external">TC39 Candidate stage (Stage 3)</a>.</p>
-</div>
-
 <h2 id="Синтаксис">Синтаксис</h2>
 
 <pre>Promise.any(<var>iterable</var>);</pre>


### PR DESCRIPTION
12th edition of ECMA-262 was released at June 2021, so warning can be deleted.
Link on current cpecification with `Promise.any` in it:
https://tc39.es/ecma262/#sec-promise.any