### PR TITLE
fix embed live sample macro error at 'div' page

### DIFF
--- a/files/ko/web/html/element/div/index.html
+++ b/files/ko/web/html/element/div/index.html
@@ -85,14 +85,14 @@ translation_of: Web/HTML/Element/div
 
 <h4 id="HTML">HTML</h4>
 
-<pre class="notranslate">&lt;div class="shadowbox"&gt;
+<pre class="brush: html notranslate">&lt;div class="shadowbox"&gt;
   &lt;p&gt;Here's a very interesting note displayed in a
   lovely shadowed box.&lt;/p&gt;
 &lt;/div&gt;</pre>
 
 <h4 id="CSS">CSS</h4>
 
-<pre class="notranslate">.shadowbox {
+<pre class="brush: css notranslate">.shadowbox {
   width: 15em;
   border: 1px solid #333;
   box-shadow: 8px 8px 5px #444;


### PR DESCRIPTION
#2848 `div` 페이지의 embed live sample macro error를 수정했습니다.

![image](https://user-images.githubusercontent.com/69508345/153442217-e88e6098-dc6d-4d73-92f5-a5abb16a1655.png)
