### PR TITLE
Fix typo `border-radius` in Japanese

### DIFF
--- a/files/ja/web/css/border-radius/index.md
+++ b/files/ja/web/css/border-radius/index.md
@@ -117,7 +117,7 @@ border-radius: unset;
     </tr>
     <tr>
       <td><em>右下</em></td>
-      <td><img alt="bottom-rigth.png" src="bottom-right.png" /></td>
+      <td><img alt="bottom-right.png" src="bottom-right.png" /></td>
       <td>
         要素ボックスの右下の隅の境界に使用される半径を記述する {{cssxref("&lt;length&gt;")}} または {{cssxref("&lt;percentage&gt;")}} です。3 つまたは 4 つの値の構文でのみ使用されます。
       </td>

--- a/files/ja/web/css/border-radius/index.md
+++ b/files/ja/web/css/border-radius/index.md
@@ -117,7 +117,7 @@ border-radius: unset;
     </tr>
     <tr>
       <td><em>右下</em></td>
-      <td><img alt="bottom-rigth.png" src="bottom-rigth.png" /></td>
+      <td><img alt="bottom-rigth.png" src="bottom-right.png" /></td>
       <td>
         要素ボックスの右下の隅の境界に使用される半径を記述する {{cssxref("&lt;length&gt;")}} または {{cssxref("&lt;percentage&gt;")}} です。3 つまたは 4 つの値の構文でのみ使用されます。
       </td>


### PR DESCRIPTION
Fix typo `border-radius` in Japanese.

![image](https://user-images.githubusercontent.com/47806818/153614705-705d9597-1a14-4593-b3dc-3605e362c8a8.png)
