### PR TITLE
Replace エキスポート with エクスポート in ja

### DIFF
--- a/files/ja/glossary/tree_shaking/index.html
+++ b/files/ja/glossary/tree_shaking/index.html
@@ -5,7 +5,7 @@ translation_of: Glossary/Tree_shaking
 ---
 <p><strong>Tree shaking</strong> とは実行されないコードを削除することで、JavaScriptの文脈で利用される用語です。</p>
 
-<p>Tree shaking は ES2015 の <a href="/ja/docs/Web/JavaScript/Reference/Statements/import">import</a> 文と <a href="/ja/docs/Web/JavaScript/Reference/Statements/export">export</a> 文を利用して、エキスポートされたコードが他の JavaScript ファイルで利用されているかどうかを判定します。</p>
+<p>Tree shaking は ES2015 の <a href="/ja/docs/Web/JavaScript/Reference/Statements/import">import</a> 文と <a href="/ja/docs/Web/JavaScript/Reference/Statements/export">export</a> 文を利用して、エクスポートされたコードが他の JavaScript ファイルで利用されているかどうかを判定します。</p>
 
 <p>モダンな JavaScript アプリケーションの開発では、<a href="https://webpack.js.org/">webpack</a> や <a href="https://github.com/rollup/rollup">Rollup</a> のようなモジュールバンドラーが複数の JavaScript ファイルを 1 つにまとめられます。この際に tree shaking が行われます。Tree shaking は、コードの構造を整理してファイルサイズを小さくできる、といった点で製品としてリリースする前の重要な処理となっています。</p>
 


### PR DESCRIPTION
Fix inconsistent wording.
exportは多くのページでエクスポートと訳されているため修正しました。