### PR TITLE
Update indexddb-cache.html URL

### DIFF
--- a/files/zh-cn/webassembly/caching_modules/index.html
+++ b/files/zh-cn/webassembly/caching_modules/index.html
@@ -153,4 +153,4 @@ instantiateCachedURL(wasmCacheVersion, 'test.wasm').then(instance =&gt;
   console.error("Failure to instantiate: " + err)
 );</pre>
 
-<p>你可以在GitHub上找到这个例子的源代码 <a href="https://github.com/mdn/webassembly-examples/blob/master/other-examples/indexeddb-cache.html">indexeddb-cache.html</a> (或者<a href="https://mdn.github.io/webassembly-examples/other-examples/indexeddb-cache.html">实时运行</a>)。</p>
+<p>你可以在GitHub上找到这个例子的源代码 <a href="https://github.com/mdn/webassembly-examples/blob/gh-pages/other-examples/indexeddb-cache.html">indexeddb-cache.html</a><!--  (或者<a href="https://mdn.github.io/webassembly-examples/other-examples/indexeddb-cache.html">实时运行</a>) -->。</p>


### PR DESCRIPTION
In the web assembly examples repository, 'indexeddb-cache.html' is no longer in the main branch, and the URL needs to be changed to guide the user. 'https://mdn.github.io/webassembly-examples/other-examples/indexeddb-cache.html' is not valid.