### PR TITLE
Fix typos in l10n-fr, l10n-ja and l10n-zh files

### DIFF
--- a/files/fr/glossary/real_user_monitoring/index.md
+++ b/files/fr/glossary/real_user_monitoring/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Glossary/Real_User_Monitoring
 original_slug: Glossaire/Real_User_Monitoring
 ---
-Le **Real User Monitoring** ou RUM mesure les performances d'une page à partir des machines des utilisateurs réels. Généralement, un script tiers injecte un script sur chaque page pour mesurer et rapporter les données de chargement de page pour chaque demande effectuée. Cette technique surveille les interactions réelles des utilisateurs d'une apllication. Dans RUM, le script tiers collecte des mesures de performances à partir des navigateurs des utilisateurs réels. RUM permet d'identifer comment une application est utilisée, y compris la répartition géographique des utilisateurs et l'impact de cette distribution sur l'expérience de l'utilisateur final.
+Le **Real User Monitoring** ou RUM mesure les performances d'une page à partir des machines des utilisateurs réels. Généralement, un script tiers injecte un script sur chaque page pour mesurer et rapporter les données de chargement de page pour chaque demande effectuée. Cette technique surveille les interactions réelles des utilisateurs d'une apllication. Dans RUM, le script tiers collecte des mesures de performances à partir des navigateurs des utilisateurs réels. RUM permet d'identifier comment une application est utilisée, y compris la répartition géographique des utilisateurs et l'impact de cette distribution sur l'expérience de l'utilisateur final.
 
 ## Voir aussi
 

--- a/files/ja/web/javascript/reference/global_objects/intl/locale/language/index.html
+++ b/files/ja/web/javascript/reference/global_objects/intl/locale/language/index.html
@@ -22,7 +22,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Intl/Locale/language
 
 <h2 id="Examples" name="Examples">例</h2>
 
-<h3 id="Setting_the_script_in_the_locale_identifer_string_argument" name="Setting_the_script_in_the_locale_identifer_string_argument">ロケール識別子の文字列引数で言語を設定</h3>
+<h3 id="Setting_the_script_in_the_locale_identifier_string_argument" name="Setting_the_script_in_the_locale_identifier_string_argument">ロケール識別子の文字列引数で言語を設定</h3>
 
 <p>有効な Unicode 言語識別子となるためには、文字列は言語サブタグで始めなければなりません。 {{jsxref("Locale/Locale", "Locale")}} コンストラクターの主要な引数には、有効な Unicode ロケール識別子がなければならないので、コンストラクターを使用する際には必ず言語サブタグを持つ識別子を渡さなければなりません。</p>
 

--- a/files/ja/web/javascript/reference/global_objects/intl/locale/region/index.html
+++ b/files/ja/web/javascript/reference/global_objects/intl/locale/region/index.html
@@ -22,7 +22,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Intl/Locale/region
 
 <h2 id="Examples" name="Examples">例</h2>
 
-<h3 id="Setting_the_region_in_the_locale_identifer_string_argument" name="Setting_the_region_in_the_locale_identifer_string_argument">ロケール識別子の文字列引数で地域を設定</h3>
+<h3 id="Setting_the_region_in_the_locale_identifier_string_argument" name="Setting_the_region_in_the_locale_identifier_string_argument">ロケール識別子の文字列引数で地域を設定</h3>
 
 <p>地域は、有効な Unicode 言語識別子文字列の３番目の部分であり、これを {{jsxref("Locale/Locale", "Locale")}} コンストラクターに渡すロケール識別子文字列に追加することで設定することができます。なお、地域はロケール識別子の必須項目ではありません。</p>
 

--- a/files/ja/web/javascript/reference/global_objects/intl/locale/script/index.html
+++ b/files/ja/web/javascript/reference/global_objects/intl/locale/script/index.html
@@ -22,7 +22,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Intl/Locale/script
 
 <h2 id="Examples" name="Examples">例</h2>
 
-<h3 id="Setting_the_script_in_the_locale_identifer_string_argument" name="Setting_the_script_in_the_locale_identifer_string_argument">ロケール識別子の文字列引数で文字体系を設定</h3>
+<h3 id="Setting_the_script_in_the_locale_identifier_string_argument" name="Setting_the_script_in_the_locale_identifier_string_argument">ロケール識別子の文字列引数で文字体系を設定</h3>
 
 <p>文字体系は、有効な Unicode 言語識別子文字列の２番目の部分であり、これを {{jsxref("Locale/Locale", "Locale")}} コンストラクターに渡すロケール識別子文字列に追加することで設定することができます。なお、文字体系はロケール識別子の必須項目ではありません。</p>
 

--- a/files/zh-tw/web/javascript/reference/global_objects/null/index.html
+++ b/files/zh-tw/web/javascript/reference/global_objects/null/index.html
@@ -13,7 +13,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/null
 
 <h2 id="描述">描述</h2>
 
-<p>The value <code>null</code> is written with a literal, <code>null</code> (it's not an identifer for a property of the global object like {{jsxref("Global_Objects/undefined","undefined")}} can be). In APIs, <code>null</code> is often retrieved in place where an object can be expected but no object is relevant. When checking for null or undefined beware of the <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators">differences between equality (==) and identity (===) operators</a> (type-conversion is performed with the former).</p>
+<p>The value <code>null</code> is written with a literal, <code>null</code> (it's not an identifier for a property of the global object like {{jsxref("Global_Objects/undefined","undefined")}} can be). In APIs, <code>null</code> is often retrieved in place where an object can be expected but no object is relevant. When checking for null or undefined beware of the <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators">differences between equality (==) and identity (===) operators</a> (type-conversion is performed with the former).</p>
 
 <pre class="brush: js">// foo does not exist. It is not defined and has never been initialized:
 &gt; foo


### PR DESCRIPTION
### Overview

Modified `identifer` to `identifier` in all files.