### PR TITLE
Update translation more accuratly for Korean

### DIFF
--- a/files/ko/web/javascript/reference/global_objects/generator/index.html
+++ b/files/ko/web/javascript/reference/global_objects/generator/index.html
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Generator
 ---
 <div>{{JSRef}}</div>
 
-<p><code><strong>Generator</strong></code> 객체는 {{jsxref("Statements/function*", "generator function", "", 1)}} 으로부터 반환된 값이며 <a href="/en-US/docs/Web/JavaScript/Guide/The_Iterator_protocol">반복자와 반복자 프로토콜</a>을 준수합니다.</p>
+<p><code><strong>Generator</strong></code> 객체는 {{jsxref("Statements/function*", "generator function", "", 1)}} 으로부터 반환된 값이며 <a href="/ko/docs/Web/JavaScript/Reference/Iteration_protocols#iterable">이터러블 프로토콜</a>과 <a href="/ko/docs/Web/JavaScript/Reference/Iteration_protocols#iterator">이터레이터 프로토콜</a>을 준수합니다.</p>
 
 <h2 id="문법">문법</h2>
 


### PR DESCRIPTION
# Problem
translation problem in below page
https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Generator

translation as 반복자와 반복자 프로토콜 for "[iterable protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) and the [iterator protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterator_protocol)" is not accurate for Korean

반복자와 반복자 프로토콜은 한국인이 이해할 수 없습니다

# Suggestion
changed more accuratly as below code

## as-is
```html
<p><code><strong>Generator</strong></code> 객체는 {{jsxref("Statements/function*", "generator function", "", 1)}} 으로부터 반환된 값이며 <a href="/en-US/docs/Web/JavaScript/Guide/The_Iterator_protocol">반복자와 반복자 프로토콜</a>을 준수합니다.</p>
```

## to-be
```html
<p><code><strong>Generator</strong></code> 객체는 {{jsxref("Statements/function*", "generator function", "", 1)}} 으로부터 반환된 값이며 <a href="/ko/docs/Web/JavaScript/Reference/Iteration_protocols#iterable">이터러블 프로토콜</a>과 <a href="/ko/docs/Web/JavaScript/Reference/Iteration_protocols#iterator">이터레이터 프로토콜</a>을 준수합니다.</p>
```