### PR TITLE
大なり小なり記号がHTMLエンティティになっていたので記号 < > に修正

### DIFF
--- a/files/ja/web/css/font-variant/index.md
+++ b/files/ja/web/css/font-variant/index.md
@@ -47,15 +47,15 @@ font-variant: unset;
   - : 通常のフォントフェイスを定義します。それぞれの個別指定プロパティは通常の初期値になります。 `font-variant` の個別指定プロパティは、 {{cssxref("font-variant-caps")}}, {{cssxref("font-variant-numeric")}}, {{cssxref("font-variant-alternates")}}, {{cssxref("font-variant-ligatures")}}, {{cssxref("font-variant-east-asian")}} です。
 - `none`
   - : {{cssxref("font-variant-ligatures")}} を `none` に、その他の個別指定プロパティを `normal` に、それぞれの初期値を設定します。
-- `&lt;common-lig-values&gt;`, `&lt;discretionary-lig-values&gt;`, `&lt;historical-lig-values&gt;`, `&lt;contextual-alt-values&gt;`
+- `<common-lig-values>`, `<discretionary-lig-values>`, `<historical-lig-values>`, `<contextual-alt-values>`
   - : 個別指定の {{cssxref("font-variant-ligatures")}} プロパティに関するキーワードを指定します。指定可能な値は、 `common-ligatures`, `no-common-ligatures`, `discretionary-ligatures`, `no-discretionary-ligatures`, `historical-ligatures`, `no-historical-ligatures`, `contextual`, `no-contextual` です。
 - `stylistic()`, `historical-forms`, `styleset()`, `character-variant()`, `swash()`, `ornaments()`, `annotation()`
   - : 個別指定の {{cssxref("font-variant-alternates")}} プロパティに関するキーワードや関数を指定します。
 - `small-caps`, `all-small-caps`, `petite-caps`, `all-petite-caps`, `unicase`, `titling-caps`
   - : 個別指定の {{cssxref("font-variant-caps")}} プロパティに関するキーワードや関数を指定します。
-- `&lt;numeric-figure-values&gt;`, `&lt;numeric-spacing-values&gt;`, `&lt;numeric-fraction-values&gt;`, `ordinal`, `slashed-zero`
+- `<numeric-figure-values>`, `<numeric-spacing-values>`, `<numeric-fraction-values>`, `ordinal`, `slashed-zero`
   - : 個別指定の {{cssxref("font-variant-numeric")}} プロパティに関するキーワードを指定します。指定可能な値は、 `lining-nums`, `oldstyle-nums`, `proportional-nums`, `tabular-nums`, `diagonal-fractions`, `stacked-fractions`, `ordinal`, `slashed-zero` です。
-- `&lt;east-asian-variant-values&gt;`, `&lt;east-asian-width-values&gt;`, `ruby`
+- `<east-asian-variant-values>`, `<east-asian-width-values>`, `ruby`
   - : 個別指定の {{cssxref("font-variant-east-asian")}} プロパティに関するキーワードを指定します。指定可能な値は、 `jis78`, `jis83`, `jis90`, `jis04`, `simplified`, `traditional`, `full-width`, `proportional-width`, `ruby` です。
 
 ## 公式定義


### PR DESCRIPTION
修正範囲は「値」の説明セクションのみが該当。

- https://github.com/mozilla-japan/translation/issues/580