### PR TITLE
助詞の修正

### DIFF
--- a/files/ja/web/css/_colon_target/index.md
+++ b/files/ja/web/css/_colon_target/index.md
@@ -87,7 +87,7 @@ p:target i {
 
 ### 純粋な CSS のライトボックス
 
-`:target` 擬似クラスを使用して JavaScript を使わずにライトボックスを作成することができます。この技術はページ内の最初は非表示の要素をリンクを作ることができることを利用しています。いったん対象となれば、 CSS で `display` を変更して表示させます。
+`:target` 擬似クラスを使用して JavaScript を使わずにライトボックスを作成することができます。この技術はページ内の最初は非表示の要素にリンクを作ることができることを利用しています。いったん対象となれば、 CSS で `display` を変更して表示させます。
 
 > **Note:** `:target` 擬似クラスを使用した純粋な CSS のライトボックスのもっと完全な版は、 [GitHub で利用できます](https://github.com/madmurphy/takefive.css/) ([デモ](https://madmurphy.github.io/takefive.css/))。
 

--- a/files/ja/web/css/_colon_target/index.md
+++ b/files/ja/web/css/_colon_target/index.md
@@ -87,7 +87,7 @@ p:target i {
 
 ### 純粋な CSS のライトボックス
 
-`:target` 擬似クラスを使用して JavaScript を使わずにライトボックスを作成することができます。この技術はページ内の最初は非表示の要素にリンクを作ることができることを利用しています。いったん対象となれば、 CSS で `display` を変更して表示させます。
+`:target` 擬似クラスを使用して JavaScript を使わずにライトボックスを作成することができます。このテクニックはページ内の最初は非表示の要素にリンクを作ることができることを利用しています。いったん対象となれば、 CSS で `display` を変更して表示させます。
 
 > **Note:** `:target` 擬似クラスを使用した純粋な CSS のライトボックスのもっと完全な版は、 [GitHub で利用できます](https://github.com/madmurphy/takefive.css/) ([デモ](https://madmurphy.github.io/takefive.css/))。
 


### PR DESCRIPTION
原文は
> This technique relies on the ability of anchor links to point to elements that are initially hidden on the page. 

で、日本語に不自然さを感じたための修正です。

mozilla-japan/translation#582