### PR TITLE
Undeprecate and update fr Battery Status API

### DIFF
--- a/files/fr/web/api/battery_status_api/index.md
+++ b/files/fr/web/api/battery_status_api/index.md
@@ -1,33 +1,29 @@
 ---
 title: API Battery Status
-slug: Web/API/Battery_status_API
-tags:
-  - API
-  - Aperçu
-  - Guide
-  - Obsolete
+slug: Web/API/Battery_Status_API
 translation_of: Web/API/Battery_Status_API
+browser-compat: api.BatteryManager
 ---
-{{DefaultAPISidebar("Battery API")}}{{Obsolete_Header}}
+{{DefaultAPISidebar("Battery API")}}
 
-L'**API _Battery Status_**, souvent mentionnée sous le nom **Battery API**, fournit des informations sur le niveau de charge du système et permet d'envoyer des événements pour prévenir d'un changement du niveau de charge de la batterie. Cela peut être utilisé pour ajuster la consommation d'une application et la réduire pour réduire l'utilisation de la batterie lorsque son niveau de charge est bas ou encore de sauvegarder les données quand la batterie est bientôt vide.
+L'**API <i lang="en">Battery Status</i>**, souvent mentionnée sous le nom **<i lang="en">Battery API</i>** (l'API <i lang="en">Battery</i>), fournit des informations sur le niveau de charge du système et permet d'envoyer des événements pour prévenir d'un changement du niveau de charge de la batterie. Cela peut être utilisé pour ajuster la consommation d'une application et la réduire pour réduire l'utilisation de la batterie lorsque son niveau de charge est bas ou encore de sauvegarder les données quand la batterie est bientôt vide.
 
-L'API Battery Status API étend l'interface {{domxref("window.navigator")}} avec la propriété {{domxref("window.navigator.battery")}}, méthode qui renvoie une promesse, résolue par l'objet {{domxref("BatteryManager")}}. Cet objet permet d'ajouter des nouveaux événements pour superviser l'état de la batterie.
+> **Note :** Cette API *n'est pas disponible* dans les [Web Workers](/fr/docs/Web/API/Web_Workers_API) (elle n'est pas exposée via [`WorkerNavigator`](/fr/docs/Web/API/WorkerNavigator)).
 
-## Exemples
+## Interfaces
 
-Dans cet exemple, on cherche à surveiller les changements, à la fois du statut de la charge (est-ce que l'équipement est branché et se recharge ou est ce que l'équipement est alimenté par sa batterie) et des changements du niveau de charge dans le temps.
+- [`BatteryManager`](/fr/docs/Web/API/WorkerNavigator)
+  - : Fournit des informations sur le niveau de charge du système.
+- [`navigator.getBattery()`](/fr/docs/Web/API/Navigator/getBattery) {{ReadOnlyInline}}
+  - : Renvoie un objet [`Promise`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Promise) dont la valeur de résolution est un objet `BatteryManager`.
 
-Cela se fait en surveillant les événements :
+## Exemple
 
-- {{event("chargingchange")}}: changement de l'êtat de charge
-- {{event("levelchange")}}: changement du niveau de batterie
-- {{event("chargingtimechange")}}: évolution de l'estimation du temps de recharge
-- {{event("dischargingtimechange")}}: évolution de l'estimation d'autonomie sur batterie
+Dans cet exemple, on cherche à surveiller les changements, à la fois du statut de la charge (est-ce que l'équipement est branché et se recharge ou est ce que l'équipement est alimenté par sa batterie) et des changements du niveau de charge dans le temps. Cela se fait en surveillant les événements [`chargingchange`](/fr/docs/Web/API/BatteryManager/chargingchange_event), [`levelchange`](/fr/docs/Web/API/BatteryManager/levelchange_event), [`chargingtimechange`](/fr/docs/Web/API/BatteryManager/chargingtimechange_event) et [`dischargingtimechange`](/fr/docs/Web/API/BatteryManager/dischargingtimechange_event).
 
 ```js
-navigator.getBattery().then(function(battery) {
-  function updateAllBatteryInfo(){
+navigator.getBattery().then(battery => {
+  function updateAllBatteryInfo() {
     updateChargeInfo();
     updateLevelInfo();
     updateChargingInfo();
@@ -35,54 +31,51 @@ navigator.getBattery().then(function(battery) {
   }
   updateAllBatteryInfo();
 
-  battery.addEventListener('chargingchange', function(){
+  battery.addEventListener('chargingchange', () => {
     updateChargeInfo();
   });
-  function updateChargeInfo(){
+  function updateChargeInfo() {
     console.log("Battery en charge ? "
                 + (battery.charging ? "Oui" : "Non"));
   }
 
-  battery.addEventListener('levelchange', function(){
+  battery.addEventListener('levelchange', () => {
     updateLevelInfo();
   });
-  function updateLevelInfo(){
-    console.log("Niveau de batterie: "
+  function updateLevelInfo() {
+    console.log("Niveau de batterie : "
                 + battery.level * 100 + "%");
   }
 
-  battery.addEventListener('chargingtimechange', function(){
+  battery.addEventListener('chargingtimechange', () => {
     updateChargingInfo();
   });
-  function updateChargingInfo(){
-    console.log("Temps avant charge de la batterie: "
+  function updateChargingInfo() {
+    console.log("Temps avant charge de la batterie : "
                  + battery.chargingTime + " secondes");
   }
 
-  battery.addEventListener('dischargingtimechange', function(){
+  battery.addEventListener('dischargingtimechange', () => {
     updateDischargingInfo();
   });
-  function updateDischargingInfo(){
-    console.log("Autonomie sur batterie: "
+  function updateDischargingInfo() {
+    console.log("Autonomie sur batterie : "
                  + battery.dischargingTime + " secondes");
   }
 
 });
 ```
 
-Voir aussi [l'exemple de la spécification](http://www.w3.org/TR/battery-status/#examples).
+Voir aussi [l'exemple de la spécification](https://www.w3.org/TR/battery-status/#examples).
 
 ## Spécifications
 
-| Spécification                        | État                             | Commentaires         |
-| ------------------------------------ | -------------------------------- | -------------------- |
-| {{SpecName("Battery API")}} | {{Spec2("Battery API")}} | Définition initiale. |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.BatteryManager")}}
+{{Compat}}
 
 ## Voir aussi
 
-- [Récupérer les informations relatives à la batterie - article et démonstration](/en-US/Apps/Build/gather_and_modify_data/retrieving_battery_status_information)
-- [Billet de blog sur Hacks - Utiliser l'API Battery (en anglais)](http://hacks.mozilla.org/2012/02/using-the-battery-api-part-of-webapi/)
+- [Billet de blog sur Hacks — Utiliser l'API <i lang="en">Battery</i> (en anglais)](https://hacks.mozilla.org/2012/02/using-the-battery-api-part-of-webapi/)

--- a/files/fr/web/api/battery_status_api/index.md
+++ b/files/fr/web/api/battery_status_api/index.md
@@ -12,7 +12,7 @@ L'**API <i lang="en">Battery Status</i>**, souvent mentionnée sous le nom **<i 
 
 ## Interfaces
 
-- [`BatteryManager`](/fr/docs/Web/API/WorkerNavigator)
+- [`BatteryManager`](/fr/docs/Web/API/BatteryManager)
   - : Fournit des informations sur le niveau de charge du système.
 - [`navigator.getBattery()`](/fr/docs/Web/API/Navigator/getBattery) {{ReadOnlyInline}}
   - : Renvoie un objet [`Promise`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Promise) dont la valeur de résolution est un objet `BatteryManager`.

--- a/files/fr/web/api/batterymanager/charging/index.md
+++ b/files/fr/web/api/batterymanager/charging/index.md
@@ -2,49 +2,43 @@
 title: BatteryManager.charging
 slug: Web/API/BatteryManager/charging
 translation_of: Web/API/BatteryManager/charging
+browser-compat: api.BatteryManager.charging
 ---
-{{obsolete_header}}{{APIRef("Battery API")}}
+{{APIRef("Battery API")}}
 
-Une valeur booléenne indiquant si la batterie de l'équipement est en train d'être chargée.
+La propriété **`BatteryManager.charging`** est une valeur booléenne indiquant si la batterie de l'équipement est en train d'être chargée. Lorsque sa valeur change, l'évènement [`chargingchange`](/fr/docs/Web/API/BatteryManager/chargingchange_event) est déclenché.
 
-## Syntax
-
-    var charging = battery.charging
-
-`charging` indique si `battery`, qui est un objet du type {{domxref("BatteryManager")}}, est en charge; si la batterie est en charge, la variable a la valeur `true`. Sinon, dans le cas de la décharge, la variable a la valeurvaux `false`.
+Si la batterie est en charge, la variable a la valeur `true`. Sinon, dans le cas de la décharge, la variable vaut `false`.
 
 ## Exemple
 
 ### Code HTML
 
 ```html
-<div id="charging">(&ecirc;tat de charge inconnu)</div>
+<div id="charging">(état de charge inconnu)</div>
 ```
 
 ### Code JavaScript
 
 ```js
-navigator.getBattery().then(function(battery) {
+navigator.getBattery().then(battery => {
+  const charging = battery.charging;
 
-    var charging = battery.charging;
-
-    document.querySelector('#charging').textContent = charging ;
+  document.querySelector('#charging').textContent = charging;
 });
 ```
 
-{{ EmbedLiveSample('Exemple', '100%', 30) }}
+{{EmbedLiveSample('Exemple', '100%', 30)}}
 
 ## Spécifications
 
-| Specification                        | Status                           | Comment             |
-| ------------------------------------ | -------------------------------- | ------------------- |
-| {{SpecName("Battery API")}} | {{Spec2("Battery API")}} | Définition initiale |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.BatteryManager.charging")}}
+{{Compat}}
 
 ## Voir aussi
 
-- {{domxref("BatteryManager")}}
-- {{domxref("Navigator.getBattery")}}
+- [`BatteryManager`](/fr/docs/Web/API/BatteryManager)
+- [`navigator.getBattery()`](/fr/docs/Web/API/Navigator/getBattery)

--- a/files/fr/web/api/batterymanager/charging/index.md
+++ b/files/fr/web/api/batterymanager/charging/index.md
@@ -12,13 +12,13 @@ Si la batterie est en charge, la variable a la valeur `true`. Sinon, dans le cas
 
 ## Exemple
 
-### Code HTML
+### HTML
 
 ```html
 <div id="charging">(état de charge inconnu)</div>
 ```
 
-### Code JavaScript
+### JavaScript
 
 ```js
 navigator.getBattery().then(battery => {
@@ -28,7 +28,9 @@ navigator.getBattery().then(battery => {
 });
 ```
 
-{{EmbedLiveSample('Exemple', '100%', 30)}}
+### Résultat
+
+{{EmbedLiveSample('', '100%', 30)}}
 
 ## Spécifications
 

--- a/files/fr/web/api/batterymanager/chargingtime/index.md
+++ b/files/fr/web/api/batterymanager/chargingtime/index.md
@@ -12,13 +12,13 @@ La propriété **`BatteryManager.chargingTime`** indique le temps, en secondes, 
 
 ## Exemple
 
-### Code HTML
+### HTML
 
 ```html
 <div id="chargingTime">(temps de charge inconnu)</div>
 ```
 
-### Code JavaScript
+### JavaScript
 
 ```js
 navigator.getBattery().then(battery => {
@@ -28,7 +28,9 @@ navigator.getBattery().then(battery => {
 });
 ```
 
-{{EmbedLiveSample('Exemple', '100%', 30)}}
+### Résultat
+
+{{EmbedLiveSample('', '100%', 30)}}
 
 ## Spécifications
 

--- a/files/fr/web/api/batterymanager/chargingtime/index.md
+++ b/files/fr/web/api/batterymanager/chargingtime/index.md
@@ -2,20 +2,13 @@
 title: BatteryManager.chargingTime
 slug: Web/API/BatteryManager/chargingTime
 translation_of: Web/API/BatteryManager/chargingTime
+browser-compat: api.BatteryManager.chargingTime
 ---
-{{obsolete_header}}
-
 {{APIRef("Battery API")}}
 
-Indique le temps, en secondes, qu'il reste jusqu'à que la batterie soit rechargée.
+La propriété **`BatteryManager.chargingTime`** indique le temps, en secondes, qu'il reste jusqu'à que la batterie soit rechargée, ou vaut `0` si la batterie est déjà rechargée. Si la batterie est en décharge, la variable vaut [`Infinity`](/fr/docs/JavaScript/Reference/Global_Objects/Infinity). Lorsque sa valeur change, l'évènement [`chargingtimechange`](/fr/docs/Web/API/BatteryManager/chargingtimechange_event) est déclenché.
 
-> **Note :** Même si le temps retourné devrait être précis à la seconde, les navigateurs arrondissent cette valeur (typiquement à 15 minutes près) afin de limiter l'identification et le suivi des utilisateurs.
-
-## Syntaxe
-
-    var time = battery.chargingTime
-
-`time` est le temps restant en secondes jusqu'à que `battery`, qui est un objet de type {{domxref("BatteryManager")}}, soit rechargée, ou vaut 0 si la batterie est déjà rechargée. Si la batterie est en décharge, la variable vaut [`Infinity`](/en-US/docs/JavaScript/Reference/Global_Objects/Infinity).
+> **Note :** Même si le temps retourné devrait être précis à la seconde, les navigateurs arrondissent cette valeur (typiquement à 15 minutes près) pour des raisons de confidentialité.
 
 ## Exemple
 
@@ -28,27 +21,24 @@ Indique le temps, en secondes, qu'il reste jusqu'à que la batterie soit recharg
 ### Code JavaScript
 
 ```js
-navigator.getBattery().then(function(battery) {
+navigator.getBattery().then(battery => {
+  const time = battery.chargingTime;
 
-   var time = battery.chargingTime;
-
-   document.querySelector('#chargingTime').textContent = battery.chargingTime;
+  document.querySelector('#chargingTime').textContent = battery.chargingTime;
 });
 ```
 
-{{ EmbedLiveSample('Exemple', '100%', 30) }}
+{{EmbedLiveSample('Exemple', '100%', 30)}}
 
 ## Spécifications
 
-| Specification                        | Status                           | Comment             |
-| ------------------------------------ | -------------------------------- | ------------------- |
-| {{SpecName("Battery API")}} | {{Spec2("Battery API")}} | Définition initiale |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.BatteryManager.chargingTime")}}
+{{Compat}}
 
 ## Voir aussi
 
-- {{domxref("BatteryManager")}}
-- {{domxref("Navigator.getBattery")}}
+- [`BatteryManager`](/fr/docs/Web/API/BatteryManager)
+- [`navigator.getBattery()`](/fr/docs/Web/API/Navigator/getBattery)

--- a/files/fr/web/api/batterymanager/dischargingtime/index.md
+++ b/files/fr/web/api/batterymanager/dischargingtime/index.md
@@ -12,13 +12,13 @@ La propriété **`BatteryManager.dischargingTime`** indique le temps, en seconde
 
 ## Exemple
 
-### Code HTML
+### HTML
 
 ```html
 <div id="dischargingTime">(temps de décharge inconnu)</div>
 ```
 
-### Code JavaScript
+### JavaScript
 
 ```js
 navigator.getBattery().then(battery => {
@@ -28,7 +28,9 @@ navigator.getBattery().then(battery => {
 });
 ```
 
-{{EmbedLiveSample('Exemple', '100%', 30)}}
+### Résultat
+
+{{EmbedLiveSample('', '100%', 30)}}
 
 ## Spécifications
 

--- a/files/fr/web/api/batterymanager/dischargingtime/index.md
+++ b/files/fr/web/api/batterymanager/dischargingtime/index.md
@@ -2,51 +2,43 @@
 title: BatteryManager.dischargingTime
 slug: Web/API/BatteryManager/dischargingTime
 translation_of: Web/API/BatteryManager/dischargingTime
+browser-compat: api.BatteryManager.dischargingTime
 ---
-{{obsolete_header}}{{APIRef("Battery API")}}
+{{APIRef("Battery API")}}
 
-Indique le temps, en secondes, qu'il reste jusqu'à que la batterie soit déchargée.
+La propriété **`BatteryManager.dischargingTime`** indique le temps, en secondes, qu'il reste jusqu'à que la batterie soit déchargée, ou vaut [`Infinity`](/fr/docs/JavaScript/Reference/Global_Objects/Infinity) si la batterie est en train d'être chargée ou si le système ne parvient pas à calculer un temps restant. Lorsque sa valeur change, l'évènement [`dischargingtimechange`](/fr/docs/Web/API/BatteryManager/dischargingtimechange_event) est déclenché.
 
-> **Note :** Même si le temps retourné devrait être précis à la seconde, les navigateurs arrondissent cette valeur (typiquement à 15 minutes près) afin de limiter l'identification et le suivi des utilisateurs.
-
-## Syntax
-
-    var time = battery.dischargingTime
-
-`time` est le temps restant en secondes jusqu'à que `battery`, qui est un objet de type {{domxref("BatteryManager")}}, soit complètement déchargée. La variable vaut [`Infinity`](/en-US/docs/JavaScript/Reference/Global_Objects/Infinity) si la batterie est en train d'être chargée ou si le système ne parvient pas à calculer un temps restant.
+> **Note :** Même si le temps retourné devrait être précis à la seconde, les navigateurs arrondissent cette valeur (typiquement à 15 minutes près) pour des raisons de confidentialité.
 
 ## Exemple
 
 ### Code HTML
 
 ```html
-<div id="dischargingTime">(temps de d&eacute;charge inconnu)</div>
+<div id="dischargingTime">(temps de décharge inconnu)</div>
 ```
 
 ### Code JavaScript
 
 ```js
-navigator.getBattery().then(function(battery) {
+navigator.getBattery().then(battery => {
+  const time = battery.dischargingTime;
 
-    var time = battery.dischargingTime;
-
-    document.querySelector('#dischargingTime').textContent = battery.dischargingTime;
+  document.querySelector('#dischargingTime').textContent = battery.dischargingTime;
 });
 ```
 
-{{ EmbedLiveSample('Exemple', '100%', 30) }}
+{{EmbedLiveSample('Exemple', '100%', 30)}}
 
 ## Spécifications
 
-| Specification                        | Status                           | Comment             |
-| ------------------------------------ | -------------------------------- | ------------------- |
-| {{SpecName("Battery API")}} | {{Spec2("Battery API")}} | Définition initiale |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.BatteryManager.dischargingTime")}}
+{{Compat}}
 
 ## Voir aussi
 
-- {{domxref("BatteryManager")}}
-- {{domxref("Navigator.getBattery")}}
+- [`BatteryManager`](/fr/docs/Web/API/BatteryManager)
+- [`navigator.getBattery()`](/fr/docs/Web/API/Navigator/getBattery)

--- a/files/fr/web/api/batterymanager/index.md
+++ b/files/fr/web/api/batterymanager/index.md
@@ -1,60 +1,50 @@
 ---
 title: BatteryManager
 slug: Web/API/BatteryManager
-tags:
-  - Mobile
-  - batterie
-  - gestion
-  - niveau
 translation_of: Web/API/BatteryManager
+browser-compat: api.BatteryManager
 ---
-{{ApiRef()}}
+{{APIRef()}}
 
-## Sommaire
+L'interface `BatteryManager` fournit des moyens pour obtenir des informations sur le niveau de charge de la batterie du système. La méthode [`navigator.getBattery()`](/fr/docs/Web/API/Navigator/getBattery) renvoie un objet `Promise` dont la valeur de résolution est une interface `BatteryManager`.
 
-L'interface `BatteryManager `fournit des moyens pour obtenir des informations sur le niveau de charge de la batterie du système.
-
-La propriété {{domxref ("window.navigator.battery", "navigator.battery")}} retourne une instance de l'interface `BatteryManager `que vous pouvez utiliser pour interagir avec l'API d'état de la batterie.
+{{InheritanceDiagram}}
 
 ## Propriétés
 
-- {{domxref("BatteryManager.charging")}} {{ReadOnlyInline}}
-  - : Un Boolean indiquant si oui ou non la batterie est actuellement en cours de charge.
-- {{domxref("BatteryManager.chargingTime")}} {{ReadOnlyInline}}
-  - : Un nombre qui représente le temps restant en secondes jusqu'à ce que la batterie soit complètement chargée, ou 0 si la batterie est complètement chargée.
-- {{domxref("BatteryManager.dischargingTime")}} {{ReadOnlyInline}}
+- [`BatteryManager.charging`](/fr/docs/Web/API/BatteryManager/charging) {{ReadOnlyInline}}
+  - : Une valeur booléenne indiquant si la batterie est actuellement en cours de charge.
+- [`BatteryManager.chargingTime`](/fr/docs/Web/API/BatteryManager/chargingTime) {{ReadOnlyInline}}
+  - : Un nombre qui représente le temps restant en secondes jusqu'à ce que la batterie soit complètement chargée, ou `0` si la batterie est complètement chargée.
+- [`BatteryManager.dischargingTime`](/fr/docs/Web/API/BatteryManager/dischargingTime) {{ReadOnlyInline}}
   - : Un nombre qui représente le temps restant en secondes jusqu'à ce que la batterie soit complètement déchargée et le système suspendu.
-- {{domxref("BatteryManager.level")}} {{ReadOnlyInline}}
-  - : Un nombre qui représente le niveau de charge de la batterie du système adapté à une valeur comprise entre 0.0 et 1.0.
-
-### Gestionnaires d'Evenements
-
-- {{domxref("BatteryManager.onchargingchange")}}
-  - : Un gestionnaire pour le changement de la présence ou non du chargeur.
-- {{domxref("BatteryManager.onchargingtimechange")}}
-  - : Un gestionnaire pour la mise à jour du temps de charge
-- {{domxref("BatteryManager.ondischargingtimechange")}}
-  - : Un gestionnaire pour la mise à jour du temps de décharge
-- {{domxref("BatteryManager.onlevelchange")}}
-  - : Un gestionnaire pour la mise à jour pour les changement du niveau de batterie
+- [`BatteryManager.level`](/fr/docs/Web/API/BatteryManager/level) {{ReadOnlyInline}}
+  - : Un nombre qui représente le niveau de charge de la batterie du système adapté à une valeur comprise entre `0.0` et `1.0`.
 
 ## Méthodes
 
-Hérite de {{domxref("EventTarget")}}:
+*`BatteryManager` hérite des méthodes de son interface parente&nbsp;:* [`EventTarget`](/fr/docs/Web/API/EventTarget).
 
-{{page("/en-US/docs/Web/API/EventTarget","Methods")}}
+## Évènements
+
+- [`chargingchange`](/fr/docs/Web/API/BatteryManager/chargingchange_event)
+  - : Se déclenche lorsque l'état de charge de la batterie (la propriété [`charging`](/fr/docs/Web/API/BatteryManager/charging)) est mis à jour.
+- [`chargingtimechange`](/fr/docs/Web/API/BatteryManager/chargingtimechange_event)
+  - : Se déclenche lorsque le temps de recharge de la batterie (la propriété [`chargingTime`](/fr/docs/Web/API/BatteryManager/chargingTime)) est mis à jour.
+- [`dischargingtimechange`](/fr/docs/Web/API/BatteryManager/dischargingtimechange_event)
+  - : Se déclenche lorsque le temps de décharge de la batterie (la propriété [`dischargingTime`](/fr/docs/Web/API/BatteryManager/dischargingTime)) est mis à jour.
+- [`levelchange`](/fr/docs/Web/API/BatteryManager/levelchange_event)
+  - : Se déclenche lorsque le niveau de charge de la batterie (la propriété [`level`](/fr/docs/Web/API/BatteryManager/level)) est mis à jour.
 
 ## Spécifications
 
-| Spécification                        | Statut                           | Commentaire            |
-| ------------------------------------ | -------------------------------- | ---------------------- |
-| {{SpecName('Battery API')}} | {{Spec2('Battery API')}} | Spécification initale. |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.BatteryManager")}}
+{{Compat}}
 
 ## Voir aussi
 
-- {{ domxref("navigator.getBattery","navigator.getBattery") }}
-- La [Battery Status API](/en-US/docs/WebAPI/Battery_Status)
+- [L'API <i lang="en">Battery Status</i>](/fr/docs/Web/API/Battery_Status_API)
+- [`navigator.getBattery()`](/fr/docs/Web/API/Navigator/getBattery)

--- a/files/fr/web/api/batterymanager/level/index.md
+++ b/files/fr/web/api/batterymanager/level/index.md
@@ -2,18 +2,11 @@
 title: BatteryManager.level
 slug: Web/API/BatteryManager/level
 translation_of: Web/API/BatteryManager/level
+browser-compat: api.BatteryManager.level
 ---
-{{obsolete_header}}{{APIRef("Battery API")}}
+{{APIRef("Battery API")}}
 
-Indique le niveau de charge de la batterie en tant que valeur comprise entre `0.0` (déchargée) et `1.0` (rechargée).
-
-## Syntaxe
-
-    var level = battery.level
-
-`level` est un nombre représentant le niveau de charge de la batterie en tant que valeur comprise entre `0.0` et `1.0`. Une veleur de `0.0` signifie que `battery`, qui est un objet de type {{domxref("BatteryManager")}}, est vide, et que le système est sur le point d'être désactivé. Une valeur de `1.0` signifie que la batterie est pleine.
-
-La valeur `1.0` est aussi retournée si le système n'est pas capable de déterminer son niveau de charge ou si le système n'est pas alimenté par une batterie.
+La propriété **`BatteryManager.level`** indique le niveau de charge de la batterie en tant que valeur comprise entre `0.0` et `1.0`. Une valeur de `0.0` signifie que la batterie est vide et que le système est sur le point d'être désactivé. Une valeur de `1.0` signifie que la batterie est pleine. La valeur `1.0` est aussi retournée si le système n'est pas capable de déterminer son niveau de charge ou si le système n'est pas alimenté par une batterie. Lorsque sa valeur change, l'évènement [`levelchange`](/fr/docs/Web/API/BatteryManager/levelchange_event) est déclenché.
 
 ## Exemple
 
@@ -26,27 +19,24 @@ La valeur `1.0` est aussi retournée si le système n'est pas capable de déterm
 ### Code JavaScript
 
 ```js
-navigator.getBattery().then(function(battery) {
+navigator.getBattery().then(battery => {
+  const level = battery.level;
 
-    var level = battery.level;
-
-    document.querySelector('#level').textContent = level;
+  document.querySelector('#level').textContent = level;
 });
 ```
 
-{{ EmbedLiveSample('Exemple', '100%', 30, '', 'Web/API/BatteryManager/level') }}
+{{EmbedLiveSample('Exemple', '100%', 30, '', 'Web/API/BatteryManager/level')}}
 
 ## Spécifications
 
-| Specification                        | Status                           | Comment             |
-| ------------------------------------ | -------------------------------- | ------------------- |
-| {{SpecName("Battery API")}} | {{Spec2("Battery API")}} | Définition initiale |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.BatteryManager.level")}}
+{{Compat}}
 
 ## Voir aussi
 
-- {{domxref("BatteryManager")}}
-- {{domxref("Navigator.getBattery")}}
+- [`BatteryManager`](/fr/docs/Web/API/BatteryManager)
+- [`navigator.getBattery()`](/fr/docs/Web/API/Navigator/getBattery)

--- a/files/fr/web/api/batterymanager/level/index.md
+++ b/files/fr/web/api/batterymanager/level/index.md
@@ -10,13 +10,13 @@ La propriété **`BatteryManager.level`** indique le niveau de charge de la batt
 
 ## Exemple
 
-### Code HTML
+### HTML
 
 ```html
 <div id="level">(niveau de batterie inconnu)</div>
 ```
 
-### Code JavaScript
+### JavaScript
 
 ```js
 navigator.getBattery().then(battery => {
@@ -26,7 +26,9 @@ navigator.getBattery().then(battery => {
 });
 ```
 
-{{EmbedLiveSample('Exemple', '100%', 30, '', 'Web/API/BatteryManager/level')}}
+### Résultat
+
+{{EmbedLiveSample('', '100%', 30, '', 'Web/API/BatteryManager/level')}}
 
 ## Spécifications
 


### PR DESCRIPTION
Cette PR met à jour les pages documentant l'API Battery Status, qui n'est plus obsolète (voir mdn/content#13129)