### PR TITLE
Add Korean meaning of 'assertion' in ko translate guide

### DIFF
--- a/docs/ko/translation-guide.md
+++ b/docs/ko/translation-guide.md
@@ -280,6 +280,7 @@ A value of 0.01 was used for the value to ramp down to in the last function rath
 | 용어 | 번역 | 기타 |
 | --- | --- | --- |
 | Application | 애플리케이션 | |
+| Assertion | 어설션 | |
 | Attribute | 특성 | |
 | Boolean | 불리언 | |
 | Class | 클래스 | |


### PR DESCRIPTION
PR 리뷰 중 #4065 에서 이전 번역문에 `assertion`을 `가정`으로 번역한 흔적이 있었습니다.

[Microsoft Terminogy](https://www.microsoft.com/en-us/language/Search?&searchTerm=assertion&langID=457&Source=true&productid=0)를 찾아본 결과 단어를 그대로 발음한 `어설션`을 사용하는게 더욱 적절하다고 생각해 이를 추가했습니다. (대다수의 사람들도 `assertion`을 따로 번역하지 않고 발음 그대로 사용했던 것으로 알고있습니다)

이 PR이 approve된 이후에는 assertion을 번역한 내용을 수정할 예정입니다.