### PR TITLE
強調箇所を統一させる

### DIFF
--- a/files/ja/web/guide/ajax/index.html
+++ b/files/ja/web/guide/ajax/index.html
@@ -27,7 +27,7 @@ translation_of: Web/Guide/AJAX
  <ul>
   <li><a href="/ja/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#handling_responses">サーバーのレスポンスの分析と操作</a></li>
   <li><a href="/ja/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#monitoring_progress">リクエストの進捗のモニタリング</a></li>
-  <li><a href="/ja/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#submitting_forms_and_uploading_files">フォームの送信とバイナリーファイルのアップロード</a> – <em>純粋な</em> Ajax、もしくは {{domxref("FormData")}} オブジェクトを使用します</li>
+  <li><a href="/ja/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#submitting_forms_and_uploading_files">フォームの送信とバイナリーファイルのアップロード</a> – <em>純粋な Ajax</em>、もしくは {{domxref("FormData")}} オブジェクトを使用します</li>
   <li><a href="/ja/docs/Web/API/Worker">ウェブワーカー</a>内部における Ajax の使用</li>
  </ul>
  </dd>


### PR DESCRIPTION
### 修正内容

「純粋な Ajax」が強調する文言とされているようでしたが、一部揃っていなかったので修正しました。
https://github.com/mdn/translated-content/blob/681ea6909006505f92ae06c7c4fe78af002f9f69/files/ja/web/guide/ajax/index.html#L38-L39