### PR TITLE
user_input_methods の contenteditable の日本語訳を追加

### DIFF
--- a/files/ja/web/guide/user_input_methods/index.html
+++ b/files/ja/web/guide/user_input_methods/index.html
@@ -148,16 +148,16 @@ if (elem.requestFullscreen) {
 <p><strong>注</strong>: You can find more information in the <a href="/ja/docs/Web/Guide/HTML/Drag_and_drop">MDN Drag &amp; Drop documentation</a>.</p>
 </div>
 
-<h4 id="contentEditable" name="contentEditable">contentEditable</h4>
+<h4 id="contentEditable" name="contentEditable">コンテンツを編集可能にする</h4>
 
-<p>In open web apps any DOM element can be made directly editable using the <a href="/ja/docs/Web/HTML/Global_attributes#contenteditable"><code>contenteditable</code></a> attribute.</p>
+<p><a href="/ja/docs/Web/HTML/Global_attributes#contenteditable"><code>contenteditable</code></a> 属性を使うことで、開いているウェブアプリのあらゆる DOM 要素を直接編集することができます。</p>
 
 <pre class="brush: html notranslate">&lt;div contenteditable="true"&gt;
-    This text can be edited by the user.
+    このテキストは閲覧者が編集することができます。
 &lt;/div&gt;</pre>
 
 <div class="note">
-<p><strong>注</strong>: Compatibility information, examples and other resources can be found in the <a href="/ja/docs/Web/Guide/HTML/Content_Editable">Content Editable guide</a>.</p>
+<p><strong>注</strong>: 互換性や例、その他リソースに関する情報は <a href="/ja/docs/Web/Guide/HTML/Content_Editable">コンテンツを編集可能にするガイド</a>で確認することができます。</p>
 </div>
 
 <h2 id="Examples" name="Examples">例</h2>
@@ -167,8 +167,8 @@ if (elem.requestFullscreen) {
  <dd>This example tracks multiple touch points at a time, allowing the user to draw in a <code>{{htmlelement("canvas")}}</code> with more than one finger at a time. It will only work on a browser that supports touch events.</dd>
  <dt><strong><a href="/ja/docs/Web/API/Pointer_Lock_API#example">Simple pointer lock demo</a></strong></dt>
  <dd>We've written a simple pointer lock demo to show you how to use it to set up a simple control system. The demo uses JavaScript to draw a ball inside a <code>{{htmlelement("canvas")}}</code> element. When you click the canvas, pointer lock is then used to remove the mouse pointer and allow you to move the ball directly using the mouse.</dd>
- <dt><strong><a href="http://html5demos.com/contenteditable">contentEditable demo</a></strong></dt>
- <dd>This is a working example showing how contenteditable can be used to create an editable document section, the state of which is then saved using <a href="/ja/docs/Web/Guide/API/DOM/Storage">LocalStorage</a>.</dd>
+ <dt><strong><a href="http://html5demos.com/contenteditable">コンテンツを編集可能にするデモ</a></strong></dt>
+ <dd>このデモは、編集可能なドキュメントセクションを作成することに利用できる contenteditable がどのように動くか表示しており、その状態はその後 <a href="/ja/docs/Web/Guide/API/DOM/Storage">ローカルストレージ</a>を使い保存されます。</dd>
 </dl>
 
 <h2 id="Tutorials" name="Tutorials">チュートリアル</h2>
@@ -191,7 +191,7 @@ if (elem.requestFullscreen) {
  <li><a href="/ja/docs/Web/API/CSS_Object_Model/Managing_screen_orientation">画面回転 API</a></li>
  <li><a href="/ja/docs/Web/Guide/API/DOM/Using_full_screen_mode">全画面 API</a></li>
  <li><a href="/ja/docs/Web/Guide/HTML/Drag_and_drop">ドラッグ＆ドロップ</a></li>
- <li><a href="/ja/docs/Web/Guide/HTML/Content_Editable">Content Editable</a></li>
+ <li><a href="/ja/docs/Web/Guide/HTML/Content_Editable">コンテンツを編集可能にする</a></li>
  <li><a href="/ja/Firefox_OS/Platform/Keyboard_events_in_Firefox_OS_TV">Keyboard events in Firefox OS TV</a></li>
  <li><a href="/ja/docs/Mozilla/Firefox_OS/TVs_connected_devices/TV_remote_control_navigation">Implementing TV remote control navigation</a></li>
 </ul>


### PR DESCRIPTION
### PR 内容

contenteditable のページは既に日本語訳されていましたが、web/guide/user_input_methods ではまだ訳されていなかったので contenteditable に関する箇所の訳を追加しました。
基本的にこちらのページの表現と揃えました。
https://developer.mozilla.org/ja/docs/Web/Guide/HTML/Editable_content

