### PR TITLE
web/guide ページの英単語の前後に半角空白を追加

### DIFF
--- a/files/ja/web/guide/index.html
+++ b/files/ja/web/guide/index.html
@@ -42,7 +42,7 @@ translation_of: Web/Guide
  </dd>
  <dt class="landingPageList"><a href="/ja/docs/JavaScript" title="JavaScript">JavaScript</a></dt>
  <dd class="landingPageList">
- <p>JavaScriptは、ウェブアプリケーションの作成に使われる強力なスクリプト言語です。</p>
+ <p>JavaScript は、ウェブアプリケーションの作成に使われる強力なスクリプト言語です。</p>
  </dd>
  <dt class="landingPageList"><a href="/ja/docs/Web/Guide/Localizations_and_character_encodings">Localizations and character encodings</a></dt>
  <dd class="landingPageList">
@@ -72,7 +72,7 @@ translation_of: Web/Guide
  <p>WOFF (Web Open Font Format) はウェブ上で誰もが使えるフリーのフォントファイルフォーマットです。</p>
  </dd>
  <dt class="landingPageList"><a href="/ja/docs/Web/Guide/Unicode_Bidrectional_Text_Algorithm">Unicode Bidirectional Text Algorithm (BiDi)</a></dt>
- <dd class="landingPageList">Unicode® BiDi アルゴリズムはUnicode文章の標準の一つで、ブラウザーが Unicode の文章をレンダリングするにあたってどのように文字を整理すべきかを定めています。このガイドではこのアルゴリズムの概要を説明し、また、特に適切に多言語対応させたい時に、どういう風に制作コンテンツに適用すべきかを説明しています。</dd>
+ <dd class="landingPageList">Unicode® BiDi アルゴリズムは Unicode 文章の標準の一つで、ブラウザーが Unicode の文章をレンダリングするにあたってどのように文字を整理すべきかを定めています。このガイドではこのアルゴリズムの概要を説明し、また、特に適切に多言語対応させたい時に、どういう風に制作コンテンツに適用すべきかを説明しています。</dd>
  <dt class="landingPageList"><a href="/ja/docs/Web/Guide/Using_FormData_Objects">FormData オブジェクトの使用</a></dt>
  <dd class="landingPageList">
  <p><a href="/ja/DOM/XMLHttpRequest/FormData"><code>FormData</code></a> オブジェクトは、<code>XMLHttpRequest</code> を使用して送信するためのキーと値のペアのセットを収集可能にします。本来はフォームデータの送信に使用することを想定していましたが、キーのついたデータを伝送するためにフォームとは独立して使用することもできます。伝送されるデータは、フォームのエンコードタイプが "multipart/form-data" に設定されている場合に、<code>submit()</code> メソッドで送信する際に使用するデータと同じ形式です。</p>


### PR DESCRIPTION
### 修正内容

web/guide ページで、一部英単語の前後に半角空白が入っていない箇所があったので追加しました。