### PR TITLE
learn/javascript/first_step の英単語の前後に半角空白を追加

### DIFF
--- a/files/ja/learn/javascript/first_steps/index.html
+++ b/files/ja/learn/javascript/first_steps/index.html
@@ -24,7 +24,7 @@ translation_of: Learn/JavaScript/First_steps
 <p class="summary">最初の JavaScript のモジュールでは、初めて JavaScript を書く実践的な経験を体験する前に、「JavaScript とは何？」や「どのようなもの？」や「何ができる？」といったような基本的な質問に答えます。その後変数や文字列、 数値、配列といったような言語の内容をお話します。</p>
 
 <div class="callout">
-<h3 id="フロントエンドのWeb開発者になりたいですか？">フロントエンドのWeb開発者になりたいですか？</h3>
+<h3 id="フロントエンドのWeb開発者になりたいですか？">フロントエンドの Web 開発者になりたいですか？</h3>
 
 <p>私たちはあなたがあなたの目標に向かって取り組むために必要なすべての重要な情報を含むコースをまとめました。</p>
 
@@ -79,6 +79,6 @@ translation_of: Learn/JavaScript/First_steps
 
 <dl>
  <dt><a href="https://learnjavascript.online/">Learn JavaScript</a></dt>
- <dd>短いレッスンとインタラクティブなテストを使用して、自動化された評価に基づいた、インタラクティブな環境でJavaScriptを学びます。<br>
+ <dd>短いレッスンとインタラクティブなテストを使用して、自動化された評価に基づいた、インタラクティブな環境で JavaScript を学びます。<br>
  最初の40レッスンは無料で、コース全体を少額の1回払いで利用できます。</dd>
 </dl>


### PR DESCRIPTION
### 修正内容

learn/javascript/first_step ページで、一部英単語の前後に半角空白が入っていない箇所があったので追加しました。