### PR TITLE
Update accessibility/aria/index.html [es]

### DIFF
--- a/files/es/web/accessibility/aria/index.html
+++ b/files/es/web/accessibility/aria/index.html
@@ -64,7 +64,7 @@ translation_of: Web/Accessibility/ARIA
      <dd>Need a slider, a menu, or another kind of widget? Find resources here.</dd>
      <dt><a class="external" href="http://www.paciellogroup.com/blog/2009/07/wai-aria-implementation-in-javascript-ui-libraries/">Librerías de UI JavaScript con soporte</a> <a class="external" href="http://www.paciellogroup.com/blog/2009/07/wai-aria-implementation-in-javascript-ui-libraries/">ARIA</a></dt>
      <dd>Si necesita comenzar un nuevo proyecto, elija una librería de controles UI que incluya soporte ARIA. Advertencia: esto es del 2009 -- el contenido debe moverse a una página MDN donde pueda actualizarse.</dd>
-     <dt><a class="external" href="http://dl.dropbox.com/u/573324/CSUN2012/index.html">Accessibility of HTML5 and Rich Internet Applications - CSUN 2012 Workshop Materials</a></dt>
+     <dt><a class="external" href="https://www.slideshare.net/stevefaulkner/accessibility-of-html5-and-rich-internet-applications-csun-2012.html">Accessibility of HTML5 and Rich Internet Applications - CSUN 2012 Workshop Materials</a></dt>
      <dd>Incluye diapositivas y ejemplos.</dd>
     </dl>
    </td>


### PR DESCRIPTION
Fix broken link.
Change the link of "Accessibility of HTML5 and Rich Internet Applications - CSUN 2012 Workshop Materials"
Old link (broken): http://dl.dropbox.com/u/573324/CSUN2012/index.html
New link (online): https://www.slideshare.net/stevefaulkner/accessibility-of-html5-and-rich-internet-applications