### PR TITLE
(ru) Fix typo at <time> element page

### DIFF
--- a/files/ru/web/html/element/time/index.html
+++ b/files/ru/web/html/element/time/index.html
@@ -3,7 +3,7 @@ title: <time>
 slug: Web/HTML/Element/time
 translation_of: Web/HTML/Element/time
 ---
-<p><strong>Элемент HTML</strong> <strong><code>&lt;time&gt;</code></strong> используется для представления либо времени в 24-х часовом формате, либо точной даты по <a class="external" href="http://ru.wikipedia.org/wiki/%D0%93%D1%80%D0%B8%D0%B3%D0%BE%D1%80%D0%B8%D0%B0%D0%BD%D1%81%D0%BA%D0%B8%D0%B9_%D0%BA%D0%B0%D0%BB%D0%B5%D0%BD%D0%B4%D0%B0%D1%80%D1%8C">Григорианскому календарю</a> (с опциональным указанием времени и часового пояса).</p>
+<p><strong>Элемент HTML</strong> <strong><code>&lt;time&gt;</code></strong> используется для представления либо времени в 24-часовом формате, либо точной даты по <a class="external" href="http://ru.wikipedia.org/wiki/%D0%93%D1%80%D0%B8%D0%B3%D0%BE%D1%80%D0%B8%D0%B0%D0%BD%D1%81%D0%BA%D0%B8%D0%B9_%D0%BA%D0%B0%D0%BB%D0%B5%D0%BD%D0%B4%D0%B0%D1%80%D1%8C">Григорианскому календарю</a> (с опциональным указанием времени и часового пояса).</p>
 
 <p>Этот элемент предназначен для представления дат и времени в машиночитаемом формате. Это облегчает клиентским приложениям добавление событий в календарь пользователя. </p>
 

--- a/files/ru/web/html/element/time/index.html
+++ b/files/ru/web/html/element/time/index.html
@@ -3,7 +3,7 @@ title: <time>
 slug: Web/HTML/Element/time
 translation_of: Web/HTML/Element/time
 ---
-<p><strong>Элемент HTML</strong> <strong><code>&lt;time&gt;</code></strong> используется для представления либо времени в 24-рехчасовом формате, либо точной даты по <a class="external" href="http://ru.wikipedia.org/wiki/%D0%93%D1%80%D0%B8%D0%B3%D0%BE%D1%80%D0%B8%D0%B0%D0%BD%D1%81%D0%BA%D0%B8%D0%B9_%D0%BA%D0%B0%D0%BB%D0%B5%D0%BD%D0%B4%D0%B0%D1%80%D1%8C">Григорианскому календарю</a> (с опциональным указанием времени и часового пояса).</p>
+<p><strong>Элемент HTML</strong> <strong><code>&lt;time&gt;</code></strong> используется для представления либо времени в 24-х часовом формате, либо точной даты по <a class="external" href="http://ru.wikipedia.org/wiki/%D0%93%D1%80%D0%B8%D0%B3%D0%BE%D1%80%D0%B8%D0%B0%D0%BD%D1%81%D0%BA%D0%B8%D0%B9_%D0%BA%D0%B0%D0%BB%D0%B5%D0%BD%D0%B4%D0%B0%D1%80%D1%8C">Григорианскому календарю</a> (с опциональным указанием времени и часового пояса).</p>
 
 <p>Этот элемент предназначен для представления дат и времени в машиночитаемом формате. Это облегчает клиентским приложениям добавление событий в календарь пользователя. </p>
 


### PR DESCRIPTION
Fixed a typo in the time tag guide.