### PR TITLE
Correção de erro de digitação (Linha 26)

### DIFF
--- a/files/pt-br/web/javascript/reference/global_objects/function/index.html
+++ b/files/pt-br/web/javascript/reference/global_objects/function/index.html
@@ -23,7 +23,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Function
 
 <dl>
  <dt><code>arg1, arg2, ... arg<em>N</em></code></dt>
- <dd>Nomes para serem usandos pela função como nomes formais de argumentos. Cada um deve ser uma string que corresponde para uma válida identidade JavaScript ou uma lista de certas strings separadas com uma <span class="short_text" id="result_box" lang="pt"><span class="hps">vírgula; por exemplo "x", "theValue". our "a,b".</span></span></dd>
+ <dd>Nomes para serem usados pela função como nomes formais de argumentos. Cada um deve ser uma string que corresponde para uma válida identidade JavaScript ou uma lista de certas strings separadas com uma <span class="short_text" id="result_box" lang="pt"><span class="hps">vírgula; por exemplo "x", "theValue". our "a,b".</span></span></dd>
  <dt><code>functionBody</code></dt>
  <dd>Uma string que contém as <span id="result_box" lang="pt"><span class="hps">instruções </span></span>JavaScript que <span id="result_box" lang="pt"><span class="hps">compõem </span></span><span class="short_text" id="result_box" lang="pt"><span class="hps">a definição da função.</span></span></dd>
 </dl>


### PR DESCRIPTION
Corrigi um erro de digitação, o verbo usar estava escrito no gerúndio (usandos) e o correto no contexto da frase era (usados).