### PR TITLE
minor formatting typo

### DIFF
--- a/files/fr/web/html/element/rp/index.md
+++ b/files/fr/web/html/element/rp/index.md
@@ -11,7 +11,7 @@ translation_of: Web/HTML/Element/rp
 ---
 {{HTMLRef}}
 
-L'élément HTML **`<rp>` **est utilisé pour fournir ce qui fera office de parenthèse aux navigateurs qui ne prennent pas en charge les annotations Ruby.
+L'élément HTML **`<rp>`** est utilisé pour fournir ce qui fera office de parenthèse aux navigateurs qui ne prennent pas en charge les annotations Ruby.
 
 Les annotations Ruby permettent d'afficher la prononciation des caractères d'Asie orientale, notamment lors de l'usage de caractères furigana Japonais ou bopomofo Taïwanais.
 


### PR DESCRIPTION
I noticed that:
<img width="159" alt="rp with bold star characters showing" src="https://user-images.githubusercontent.com/18131787/155899092-a6fb1ddf-0916-4387-8822-8373515ebb87.png">


probably should look more like:
**`<rp>`**
(bolded, and without the star characters)