### PR TITLE
Fix for typo in link of index.md

### DIFF
--- a/files/fr/mdn/contribute/feedback/index.md
+++ b/files/fr/mdn/contribute/feedback/index.md
@@ -58,4 +58,4 @@ Comme évoqué plus haut, n'hésitez pas à contribuer vous-même pour corriger 
 
 ### Problèmes sur le site
 
-Si vous rencontrez un problème avec le site ou avez de nouvelles idées pour celui-ci, vous pouvez [créer un ticket à l'équipe de développement de MDN](hhttps://github.com/mdn/yari/issues).
+Si vous rencontrez un problème avec le site ou avez de nouvelles idées pour celui-ci, vous pouvez [créer un ticket à l'équipe de développement de MDN](https://github.com/mdn/yari/issues).


### PR DESCRIPTION
Fixed a typo in the link leading to opening an issue on Github on the French version of index.md