### PR TITLE
Fix typo in files/ko/web/javascript/reference/classes/index.html

### DIFF
--- a/files/ko/web/javascript/reference/classes/index.html
+++ b/files/ko/web/javascript/reference/classes/index.html
@@ -24,7 +24,7 @@ translation_of: Web/JavaScript/Reference/Classes
 
 <h4 id="Hoisting">Hoisting</h4>
 
-<p><strong>함수 선언</strong>과 <strong>클래스 선언</strong>의 중요한 차이점은 험수의 경우 정의하기 하기 전에 호출할 수 있지만, 클래스는 반드시 정의한 뒤에 사용할 수 있다는 점입니다. 다음 코드는 {{jsxref("ReferenceError")}}를 던질 것입니다.</p>
+<p><strong>함수 선언</strong>과 <strong>클래스 선언</strong>의 중요한 차이점은 함수의 경우 정의하기 하기 전에 호출할 수 있지만, 클래스는 반드시 정의한 뒤에 사용할 수 있다는 점입니다. 다음 코드는 {{jsxref("ReferenceError")}}를 던질 것입니다.</p>
 
 <pre class="brush: js example-bad ">const p = new Rectangle(); // ReferenceError
 


### PR DESCRIPTION
- `험수` to `함수` in line 27
- [error page](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Classes)

<img width="833" alt="스크린샷 2022-03-03 오후 1 39 14" src="https://user-images.githubusercontent.com/54893898/156497274-d3ec2f5a-8dd5-4218-8d93-dc04ab748aed.png">

