### PR TITLE
Correção de palavra (linha 101)

### DIFF
--- a/files/pt-br/learn/css/css_layout/flexbox/index.html
+++ b/files/pt-br/learn/css/css_layout/flexbox/index.html
@@ -98,7 +98,7 @@ translation_of: Learn/CSS/CSS_layout/Flexbox
 
 <pre class="brush: css">flex-direction: column;</pre>
 
-<p>Você verá que isso organiza os elementos no laioute de coluna, assim como eles estavam antes de adicionarmos qualquer regra CSS. Antes de você seguir, remova essa declaração do seu exemplo.</p>
+<p>Você verá que isso organiza os elementos no layout de coluna, assim como eles estavam antes de adicionarmos qualquer regra CSS. Antes de você seguir, remova essa declaração do seu exemplo.</p>
 
 <div class="note">
 <p><strong>Nota</strong>: Você também pode arranjar itens flexíveis em direção reversa usando os valores <code>row-reverse</code> e <code>column-reverse</code>. Experimente usar esses valores no seu exemplo também!</p>


### PR DESCRIPTION
Corrigi uma palavra traduzida incorretamente, a palavra layout estava escrita da seguinte maneira: "laioute".