### PR TITLE
user_input_methods のマウスの英文を消し忘れていたので対応

### DIFF
--- a/files/ja/web/guide/user_input_methods/index.html
+++ b/files/ja/web/guide/user_input_methods/index.html
@@ -57,7 +57,6 @@ window.addEventListener("keyup", handleKeyUp, true);</pre>
 
 <p>ユーザーがマウスのようなポインティングデバイスと関わっている時に発生するイベントは {{domxref("MouseEvent")}} DOM インターフェースによって表されます。一般的なマウスイベントは、<a href="/ja/docs/Web/Reference/Events/click"><code>click イベント</code></a>、<a href="/ja/docs/Web/API/Element/dblclick_event"><code>dblclick イベント</code></a>、<a href="/ja/docs/Web/API/Element/mouseup_event"><code>mouseup イベント</code></a>、そして <a href="/ja/docs/Web/Reference/Events/mousedown"><code>mousedown イベント</code></a>を含みます。マウスイベントインターフェースが使用している全てのイベントの一覧は、<a href="/ja/docs/Web/Reference/Events">イベントリファレンス</a>に記載されています。</p>
 
-<p>When the input device is a mouse, you can also control user input through the Pointer Lock API and implement Drag &amp; Drop (see below).</p>
 <p>入力デバイスがマウスの場合、ユーザー入力を Pointer Lock API やドラッグ＆ドロップ API の実装でも制御できます (下記を参照してください)。</p>
 
 <h4 id="Finger_touch" name="Finger_touch">指でのタッチ</h4>


### PR DESCRIPTION
### PR 内容

すみません、user_input_methods のマウスの英文の一部を消し忘れていたので対応しました。