### PR TITLE
Fix typo: エラーイベントページ

### DIFF
--- a/files/ja/web/api/element/error_event/index.html
+++ b/files/ja/web/api/element/error_event/index.html
@@ -43,7 +43,7 @@ translation_of: Web/API/Element/error_event
  </tbody>
 </table>
 
-<p>イベントオブジェ久は、ユーザーインターフェイス要素から生成された場合は {{domxref("UIEvent")}} のインスタンスとなり、それ以外の場合は {{domxref("Event")}} となります。</p>
+<p>イベントオブジェクトは、ユーザーインターフェイス要素から生成された場合は {{domxref("UIEvent")}} のインスタンスとなり、それ以外の場合は {{domxref("Event")}} となります。</p>
 
 <h2 id="Examples" name="Examples">例</h2>
 


### PR DESCRIPTION
### PR 内容

「Element: error イベント」ページの日本語訳のtypoを修正しました。
