### PR TITLE
Add missing constructor document in evalerror

### DIFF
--- a/files/es/web/javascript/reference/global_objects/evalerror/evalerror/index.md
+++ b/files/es/web/javascript/reference/global_objects/evalerror/evalerror/index.md
@@ -21,7 +21,7 @@ new EvalError(message, fileName, lineNumber)
 - `message` {{optional_inline}}
   - : Descripción del error humanamente legible
 - `fileName` {{optional_inline}}
-  - : El nombre del archivo que contiene el código que causó la excepción.
+  - : El nombre del archivo que contiene el código que causó la excepción
 - `lineNumber` {{optional_inline}}
   - : El número de línea del código que causó la excepción
 

--- a/files/es/web/javascript/reference/global_objects/evalerror/evalerror/index.md
+++ b/files/es/web/javascript/reference/global_objects/evalerror/evalerror/index.md
@@ -58,3 +58,4 @@ try {
 
 - {{jsxref("Error")}}
 - {{jsxref("Global_Objects/eval", "eval()")}}
+

--- a/files/es/web/javascript/reference/global_objects/evalerror/evalerror/index.md
+++ b/files/es/web/javascript/reference/global_objects/evalerror/evalerror/index.md
@@ -1,0 +1,60 @@
+---
+title: EvalError() constructor
+slug: Web/JavaScript/Reference/Global_Objects/EvalError/EvalError
+browser-compat: javascript.builtins.EvalError.EvalError
+---
+{{JSRef}}
+
+El constructor **`EvalError`** crea un nuevo error relacionado con la función global {{jsxref("Global_Objects/eval", "eval()")}}. Esta excepción ya no es lanzada por JavaScript, sin embargo el objeto `EvalError` permanece por compatibilidad.
+
+## Sintaxis
+
+```js
+new EvalError()
+new EvalError(message)
+new EvalError(message, fileName)
+new EvalError(message, fileName, lineNumber)
+```
+
+### Parámetros
+
+- `message` {{optional_inline}}
+  - : Descripción del error humanamente legible
+- `fileName` {{optional_inline}}
+  - : El nombre del archivo que contiene el código que causó la excepción.
+- `lineNumber` {{optional_inline}}
+  - : El número de línea del código que causó la excepción
+
+## Ejemplos
+
+El objeto `EvalError` no se utiliza en la especificación actual de ECMAScript y por lo tanto no será lanzado por el tiempo de ejecución. Sin embargo, el objeto en sí se mantiene para la compatibilidad con versiones anteriores de la especificación.
+
+### Creación de un EvalError
+
+```js
+try {
+  throw new EvalError('Hello', 'someFile.js', 10);
+} catch (e) {
+
+  console.log(e instanceof EvalError); // true
+  console.log(e.message);              // "Hello"
+  console.log(e.name);                 // "EvalError"
+  console.log(e.fileName);             // "someFile.js"
+  console.log(e.lineNumber);           // 10
+  console.log(e.columnNumber);         // 0
+  console.log(e.stack);                // "@Scratchpad/2:2:9\n"
+}
+```
+
+## Especificaciones
+
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
+
+## Véase también
+
+- {{jsxref("Error")}}
+- {{jsxref("Global_Objects/eval", "eval()")}}


### PR DESCRIPTION
NOTA: En la versión en inglés, este archivo también está dentro de una carpeta llamada `evalerror`.