### PR TITLE
Web/API/Event/isTrustedを新規翻訳

### DIFF
--- a/files/ja/web/api/event/istrusted/index.md
+++ b/files/ja/web/api/event/istrusted/index.md
@@ -1,0 +1,40 @@
+---
+title: Event.isTrusted
+slug: Web/API/Event/isTrusted
+tags:
+  - Property
+  - Read-only
+  - Reference
+  - プロパティ
+  - 読み取り専用
+browser-compat: api.Event.isTrusted
+translation_of: Web/API/Event/isTrusted
+---
+{{APIRef("DOM")}}
+
+**`isTrusted`** は {{domxref("Event")}} インターフェイスの読み取り専用プロパティで、
+boolean値をとり、イベントがユーザーアクションによって生成された場合は `true` を、
+イベントがスクリプトによって作成・更新された、または {{domxref("EventTarget.dispatchEvent()")}}
+を通して配信された場合は `false` になります。
+
+## Value
+
+boolean値。
+
+## Example
+
+```js
+if (e.isTrusted) {
+  /* The event is trusted */
+} else {
+  /* The event is not trusted */
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
Web/API/Event/isTrustedを翻訳しました

`https://github.com/mdn/content/tree/main/files/en-us/web/api/event/istrusted/index.md`
から元ファイルをコピーし、書き換えました。
en最終commitは https://github.com/mdn/content/commit/6d3eeab29e34989a308df547f3eb486ca34e8854 (2021/10/23 )
