### PR TITLE
(ru) Replace 'obsolete_inline' to 'deprecated_inline' at HTMLDocument page

### DIFF
--- a/files/ru/web/api/document/index.html
+++ b/files/ru/web/api/document/index.html
@@ -81,9 +81,9 @@ translation_of: Web/API/Document
  <dd>Returns a list of the style sheet sets available on the document.</dd>
  <dt>{{domxref("Document.xmlEncoding")}} {{Deprecated_inline}}</dt>
  <dd>Returns the encoding as determined by the XML declaration.</dd>
- <dt>{{domxref("Document.xmlStandalone")}} {{obsolete_inline("10.0")}}</dt>
+ <dt>{{domxref("Document.xmlStandalone")}} {{Deprecated_inline}}</dt>
  <dd>Returns <code>true</code> if the XML declaration specifies the document to be standalone (<em>e.g.,</em> An external part of the DTD affects the document's content), else <code>false</code>.</dd>
- <dt>{{domxref("Document.xmlVersion")}} {{obsolete_inline("10.0")}}</dt>
+ <dt>{{domxref("Document.xmlVersion")}} {{Deprecated_inline}}</dt>
  <dd>Returns the version number as specified in the XML declaration or <code>"1.0"</code> if the declaration is absent.</dd>
 </dl>
 
@@ -375,13 +375,13 @@ translation_of: Web/API/Document
 <p>Mozilla also define some non-standard methods:</p>
 
 <dl>
- <dt>{{domxref("Document.execCommandShowHelp")}} {{obsolete_inline("14.0")}}</dt>
+ <dt>{{domxref("Document.execCommandShowHelp")}} {{deprecated_inline}}</dt>
  <dd>This method never did anything and always threw an exception, so it was removed in Gecko 14.0 {{geckoRelease("14.0")}}.</dd>
- <dt>{{domxref("Document.getBoxObjectFor")}} {{obsolete_inline}}</dt>
+ <dt>{{domxref("Document.getBoxObjectFor")}} {{deprecated_inline}}</dt>
  <dd>Use the {{domxref("Element.getBoundingClientRect()")}} method instead.</dd>
  <dt>{{domxref("Document.loadOverlay")}}</dt>
  <dd>Loads a <a href="/en-US/docs/XUL_Overlays" title="XUL_Overlays">XUL overlay</a> dynamically. This only works in XUL documents.</dd>
- <dt>{{domxref("document.queryCommandText")}} {{obsolete_inline("14.0")}}</dt>
+ <dt>{{domxref("document.queryCommandText")}} {{deprecated_inline}}</dt>
  <dd>This method never did anything but throw an exception, and was removed in Gecko 14.0 {{geckoRelease("14.0")}}.</dd>
 </dl>
 
@@ -390,7 +390,7 @@ translation_of: Web/API/Document
 <p>Microsoft defines some non-standard properties:</p>
 
 <dl>
- <dt>{{domxref("document.fileSize")}}* {{non-standard_inline}} {{obsolete_inline}}</dt>
+ <dt>{{domxref("document.fileSize")}}* {{Non-standard_Inline}} {{deprecated_inline}}</dt>
  <dd>Returns size in bytes of the document. Starting with Internet Explorer 11, that property is no longer supported. See <a href="http://msdn.microsoft.com/en-us/library/ms533752%28v=VS.85%29.aspx">MSDN</a>.</dd>
  <dt><span style="font-weight: normal; line-height: 1.5;">Internet Explorer does not support all methods from the <code>Node</code> interface in the <code>Document</code> interface:</span></dt>
 </dl>


### PR DESCRIPTION
The layout does not work correctly