### PR TITLE
Create parallel redirects for Mozilla/Firefox/Privacy in other accepted locales

### DIFF
--- a/files/de/_redirects.txt
+++ b/files/de/_redirects.txt
@@ -394,6 +394,17 @@
 /de/docs/Mozilla/Add-ons/WebExtensions/Beispiele	/de/docs/Mozilla/Add-ons/WebExtensions/Examples
 /de/docs/Mozilla/Add-ons/WebExtensions/Deine_erste_WebErweiterung	/de/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension
 /de/docs/Mozilla/Add-ons/WebExtensions/Deine_zweite_Erweiterung	/de/docs/Mozilla/Add-ons/WebExtensions/Your_second_WebExtension
+/de/docs/Mozilla/Firefox/Privacy	/de/docs/Web/Privacy
+/de/docs/Mozilla/Firefox/Privacy/Redirect_tracking_protection	/de/docs/Web/Privacy/Redirect_tracking_protection
+/de/docs/Mozilla/Firefox/Privacy/State_Partitioning	/de/docs/Web/Privacy/State_Partitioning
+/de/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy	/de/docs/Web/Privacy/Storage_Access_Policy
+/de/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors	/de/docs/Web/Privacy/Storage_Access_Policy/Errors
+/de/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedAll	/de/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedAll
+/de/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedByPermission	/de/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedByPermission
+/de/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedForeign	/de/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedForeign
+/de/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedTracker	/de/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedTracker
+/de/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookiePartitionedForeign	/de/docs/Web/Privacy/Storage_Access_Policy/Errors/CookiePartitionedForeign
+/de/docs/Mozilla/Firefox/Privacy/Tracking_Protection	/de/docs/Web/Privacy/Tracking_Protection
 /de/docs/Online_and_offline_events	/de/docs/orphaned/Web/API/NavigatorOnLine/Online_and_offline_events
 /de/docs/OpenSearch_Plugin_für_Firefox_erstellen	/de/docs/Web/OpenSearch
 /de/docs/SVG	/de/docs/Web/SVG

--- a/files/es/_redirects.txt
+++ b/files/es/_redirects.txt
@@ -1237,6 +1237,17 @@
 /es/docs/Mozilla/Add-ons/WebExtensions/Tu_primera_WebExtension	/es/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension
 /es/docs/Mozilla/Add-ons/WebExtensions/Tutorial	/es/docs/Mozilla/Add-ons/WebExtensions/Your_second_WebExtension
 /es/docs/Mozilla/Add-ons/WebExtensions/user_interface/Accion_navegador	/es/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_action
+/es/docs/Mozilla/Firefox/Privacy	/es/docs/Web/Privacy
+/es/docs/Mozilla/Firefox/Privacy/Redirect_tracking_protection	/es/docs/Web/Privacy/Redirect_tracking_protection
+/es/docs/Mozilla/Firefox/Privacy/State_Partitioning	/es/docs/Web/Privacy/State_Partitioning
+/es/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy	/es/docs/Web/Privacy/Storage_Access_Policy
+/es/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors	/es/docs/Web/Privacy/Storage_Access_Policy/Errors
+/es/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedAll	/es/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedAll
+/es/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedByPermission	/es/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedByPermission
+/es/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedForeign	/es/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedForeign
+/es/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedTracker	/es/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedTracker
+/es/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookiePartitionedForeign	/es/docs/Web/Privacy/Storage_Access_Policy/Errors/CookiePartitionedForeign
+/es/docs/Mozilla/Firefox/Privacy/Tracking_Protection	/es/docs/Web/Privacy/Tracking_Protection
 /es/docs/Plantillas_en_Firefox_3	/es/docs/Mozilla/Firefox/Releases/3/Templates
 /es/docs/Portada	/es/docs/Web
 /es/docs/Preguntas_frecuentes_sobre_CSS	/es/docs/Learn/CSS/Howto/CSS_FAQ

--- a/files/fr/_redirects.txt
+++ b/files/fr/_redirects.txt
@@ -3109,6 +3109,17 @@
 /fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/elements_menu_contextuel	/fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/Context_menu_items
 /fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/pages_web_incluses	/fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/Extension_pages
 /fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/panneaux_devtools	/fr/docs/Mozilla/Add-ons/WebExtensions/user_interface/devtools_panels
+/fr/docs/Mozilla/Firefox/Privacy	/fr/docs/Web/Privacy
+/fr/docs/Mozilla/Firefox/Privacy/Redirect_tracking_protection	/fr/docs/Web/Privacy/Redirect_tracking_protection
+/fr/docs/Mozilla/Firefox/Privacy/State_Partitioning	/fr/docs/Web/Privacy/State_Partitioning
+/fr/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy	/fr/docs/Web/Privacy/Storage_Access_Policy
+/fr/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors	/fr/docs/Web/Privacy/Storage_Access_Policy/Errors
+/fr/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedAll	/fr/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedAll
+/fr/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedByPermission	/fr/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedByPermission
+/fr/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedForeign	/fr/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedForeign
+/fr/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedTracker	/fr/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedTracker
+/fr/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookiePartitionedForeign	/fr/docs/Web/Privacy/Storage_Access_Policy/Errors/CookiePartitionedForeign
+/fr/docs/Mozilla/Firefox/Privacy/Tracking_Protection	/fr/docs/Web/Privacy/Tracking_Protection
 /fr/docs/Mozilla/Firefox/Versions	/fr/docs/Mozilla/Firefox/Releases
 /fr/docs/Mozilla/Firefox/Versions/1.5	/fr/docs/Mozilla/Firefox/Releases/1.5
 /fr/docs/Mozilla/Firefox/Versions/11	/fr/docs/Mozilla/Firefox/Releases/11

--- a/files/ja/_redirects.txt
+++ b/files/ja/_redirects.txt
@@ -2795,6 +2795,17 @@
 /ja/docs/Mozilla/Add-ons/WebExtensions/manifest.json/applications	/ja/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings
 /ja/docs/Mozilla/Add-ons/WebExtensions/デバッグ	https://extensionworkshop.com/documentation/develop/debugging/
 /ja/docs/Mozilla/Add-ons/WebExtensions/前提条件	/ja/docs/Mozilla/Add-ons/WebExtensions/Prerequisites
+/ja/docs/Mozilla/Firefox/Privacy	/ja/docs/Web/Privacy
+/ja/docs/Mozilla/Firefox/Privacy/Redirect_tracking_protection	/ja/docs/Web/Privacy/Redirect_tracking_protection
+/ja/docs/Mozilla/Firefox/Privacy/State_Partitioning	/ja/docs/Web/Privacy/State_Partitioning
+/ja/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy	/ja/docs/Web/Privacy/Storage_Access_Policy
+/ja/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors	/ja/docs/Web/Privacy/Storage_Access_Policy/Errors
+/ja/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedAll	/ja/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedAll
+/ja/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedByPermission	/ja/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedByPermission
+/ja/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedForeign	/ja/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedForeign
+/ja/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedTracker	/ja/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedTracker
+/ja/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookiePartitionedForeign	/ja/docs/Web/Privacy/Storage_Access_Policy/Errors/CookiePartitionedForeign
+/ja/docs/Mozilla/Firefox/Privacy/Tracking_Protection	/ja/docs/Web/Privacy/Tracking_Protection
 /ja/docs/Mozilla/Firefox/Releases/Firefox_47_for_developers	/ja/docs/Mozilla/Firefox/Releases/47
 /ja/docs/Mozilla_Addons_FAQ_(external)	https://addons.mozilla.org/faq.php
 /ja/docs/NPAPI/Constants	/ja/docs/Glossary/Plugin

--- a/files/ko/_redirects.txt
+++ b/files/ko/_redirects.txt
@@ -370,6 +370,17 @@
 /ko/docs/Mozilla/Add-ons/WebExtensions/API/contextMenus/create	/ko/docs/Mozilla/Add-ons/WebExtensions/API/menus/create
 /ko/docs/Mozilla/Add-ons/WebExtensions/API/contextMenus/getTargetElement	/ko/docs/Mozilla/Add-ons/WebExtensions/API/menus/getTargetElement
 /ko/docs/Mozilla/Add-ons/WebExtensions/API/contextMenus/onShown	/ko/docs/Mozilla/Add-ons/WebExtensions/API/menus/onShown
+/ko/docs/Mozilla/Firefox/Privacy	/ko/docs/Web/Privacy
+/ko/docs/Mozilla/Firefox/Privacy/Redirect_tracking_protection	/ko/docs/Web/Privacy/Redirect_tracking_protection
+/ko/docs/Mozilla/Firefox/Privacy/State_Partitioning	/ko/docs/Web/Privacy/State_Partitioning
+/ko/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy	/ko/docs/Web/Privacy/Storage_Access_Policy
+/ko/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors	/ko/docs/Web/Privacy/Storage_Access_Policy/Errors
+/ko/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedAll	/ko/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedAll
+/ko/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedByPermission	/ko/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedByPermission
+/ko/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedForeign	/ko/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedForeign
+/ko/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedTracker	/ko/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedTracker
+/ko/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookiePartitionedForeign	/ko/docs/Web/Privacy/Storage_Access_Policy/Errors/CookiePartitionedForeign
+/ko/docs/Mozilla/Firefox/Privacy/Tracking_Protection	/ko/docs/Web/Privacy/Tracking_Protection
 /ko/docs/Mozilla/애드온들	/ko/docs/Mozilla/Add-ons
 /ko/docs/Mozilla/애드온들/AMO/Policy/Featured	https://extensionworkshop.com/documentation/publish/recommended-extensions/
 /ko/docs/Mozilla/애드온들/Listing	https://extensionworkshop.com/documentation/develop/create-an-appealing-listing/

--- a/files/pl/_redirects.txt
+++ b/files/pl/_redirects.txt
@@ -1356,6 +1356,17 @@
 /pl/docs/MDN/rozpocznij_mdn	/pl/docs/MDN/Contribute/Getting_started
 /pl/docs/MathML	/pl/docs/Web/MathML
 /pl/docs/Mozilla/Add-ons/WebExtensions/Twój_pierwszy_WebExtension	/pl/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension
+/pl/docs/Mozilla/Firefox/Privacy	/pl/docs/Web/Privacy
+/pl/docs/Mozilla/Firefox/Privacy/Redirect_tracking_protection	/pl/docs/Web/Privacy/Redirect_tracking_protection
+/pl/docs/Mozilla/Firefox/Privacy/State_Partitioning	/pl/docs/Web/Privacy/State_Partitioning
+/pl/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy	/pl/docs/Web/Privacy/Storage_Access_Policy
+/pl/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors	/pl/docs/Web/Privacy/Storage_Access_Policy/Errors
+/pl/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedAll	/pl/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedAll
+/pl/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedByPermission	/pl/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedByPermission
+/pl/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedForeign	/pl/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedForeign
+/pl/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedTracker	/pl/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedTracker
+/pl/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookiePartitionedForeign	/pl/docs/Web/Privacy/Storage_Access_Policy/Errors/CookiePartitionedForeign
+/pl/docs/Mozilla/Firefox/Privacy/Tracking_Protection	/pl/docs/Web/Privacy/Tracking_Protection
 /pl/docs/Narzędzia	/pl/docs/Tools
 /pl/docs/Narzędzia/Debugger	/pl/docs/Tools/Debugger
 /pl/docs/Narzędzia/Debugger/How_to	/pl/docs/Tools/Debugger/How_to

--- a/files/pt-br/_redirects.txt
+++ b/files/pt-br/_redirects.txt
@@ -447,6 +447,17 @@
 /pt-BR/docs/Mozilla/Add-ons/WebExtensions/sua_primeira_WebExtension	/pt-BR/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension
 /pt-BR/docs/Mozilla/Add-ons/WebExtensions/user_interface/Itens_do_menu_de_contexto	/pt-BR/docs/Mozilla/Add-ons/WebExtensions/user_interface/Context_menu_items
 /pt-BR/docs/Mozilla/Firefox/Novas_funcionalidades	/pt-BR/docs/Mozilla/Firefox/Experimental_features
+/pt-BR/docs/Mozilla/Firefox/Privacy	/pt-BR/docs/Web/Privacy
+/pt-BR/docs/Mozilla/Firefox/Privacy/Redirect_tracking_protection	/pt-BR/docs/Web/Privacy/Redirect_tracking_protection
+/pt-BR/docs/Mozilla/Firefox/Privacy/State_Partitioning	/pt-BR/docs/Web/Privacy/State_Partitioning
+/pt-BR/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy	/pt-BR/docs/Web/Privacy/Storage_Access_Policy
+/pt-BR/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors	/pt-BR/docs/Web/Privacy/Storage_Access_Policy/Errors
+/pt-BR/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedAll	/pt-BR/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedAll
+/pt-BR/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedByPermission	/pt-BR/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedByPermission
+/pt-BR/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedForeign	/pt-BR/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedForeign
+/pt-BR/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedTracker	/pt-BR/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedTracker
+/pt-BR/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookiePartitionedForeign	/pt-BR/docs/Web/Privacy/Storage_Access_Policy/Errors/CookiePartitionedForeign
+/pt-BR/docs/Mozilla/Firefox/Privacy/Tracking_Protection	/pt-BR/docs/Web/Privacy/Tracking_Protection
 /pt-BR/docs/Mozilla/Firefox/Releases/3/Zoom_de_página_inteira	/pt-BR/docs/Mozilla/Firefox/Releases/3/Full_page_zoom
 /pt-BR/docs/Quirks_Mode_and_Standards_Mode	/pt-BR/docs/Web/HTML/Quirks_Mode_and_Standards_Mode
 /pt-BR/docs/SVG	/pt-BR/docs/Web/SVG

--- a/files/ru/_redirects.txt
+++ b/files/ru/_redirects.txt
@@ -283,6 +283,17 @@
 /ru/docs/MDN_at_ten	/ru/docs/MDN/At_ten
 /ru/docs/Mozilla/Add-ons/WebExtensions/Интернационализация	/ru/docs/Mozilla/Add-ons/WebExtensions/Internationalization
 /ru/docs/Mozilla/Add-ons/WebExtensions/модификация_веб_страницы	/ru/docs/Mozilla/Add-ons/WebExtensions/Modify_a_web_page
+/ru/docs/Mozilla/Firefox/Privacy	/ru/docs/Web/Privacy
+/ru/docs/Mozilla/Firefox/Privacy/Redirect_tracking_protection	/ru/docs/Web/Privacy/Redirect_tracking_protection
+/ru/docs/Mozilla/Firefox/Privacy/State_Partitioning	/ru/docs/Web/Privacy/State_Partitioning
+/ru/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy	/ru/docs/Web/Privacy/Storage_Access_Policy
+/ru/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors	/ru/docs/Web/Privacy/Storage_Access_Policy/Errors
+/ru/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedAll	/ru/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedAll
+/ru/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedByPermission	/ru/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedByPermission
+/ru/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedForeign	/ru/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedForeign
+/ru/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedTracker	/ru/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedTracker
+/ru/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookiePartitionedForeign	/ru/docs/Web/Privacy/Storage_Access_Policy/Errors/CookiePartitionedForeign
+/ru/docs/Mozilla/Firefox/Privacy/Tracking_Protection	/ru/docs/Web/Privacy/Tracking_Protection
 /ru/docs/Plugins/Roadmap	/ru/docs/Glossary/Plugin
 /ru/docs/Plugins/План	/ru/docs/Glossary/Plugin
 /ru/docs/Quirks_Mode_and_Standards_Mode	/ru/docs/Web/HTML/Quirks_Mode_and_Standards_Mode

--- a/files/zh-cn/_redirects.txt
+++ b/files/zh-cn/_redirects.txt
@@ -1155,6 +1155,17 @@
 /zh-CN/docs/Mozilla/Add-ons/WebExtensions/匹配模板	/zh-CN/docs/Mozilla/Add-ons/WebExtensions/Match_patterns
 /zh-CN/docs/Mozilla/Add-ons/WebExtensions/实现一个设置页面	/zh-CN/docs/Mozilla/Add-ons/WebExtensions/Implement_a_settings_page
 /zh-CN/docs/Mozilla/Add-ons/WebExtensions/构建一个跨浏览器的扩展插件	/zh-CN/docs/Mozilla/Add-ons/WebExtensions/Build_a_cross_browser_extension
+/zh-CN/docs/Mozilla/Firefox/Privacy	/zh-CN/docs/Web/Privacy
+/zh-CN/docs/Mozilla/Firefox/Privacy/Redirect_tracking_protection	/zh-CN/docs/Web/Privacy/Redirect_tracking_protection
+/zh-CN/docs/Mozilla/Firefox/Privacy/State_Partitioning	/zh-CN/docs/Web/Privacy/State_Partitioning
+/zh-CN/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy	/zh-CN/docs/Web/Privacy/Storage_Access_Policy
+/zh-CN/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors	/zh-CN/docs/Web/Privacy/Storage_Access_Policy/Errors
+/zh-CN/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedAll	/zh-CN/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedAll
+/zh-CN/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedByPermission	/zh-CN/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedByPermission
+/zh-CN/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedForeign	/zh-CN/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedForeign
+/zh-CN/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedTracker	/zh-CN/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedTracker
+/zh-CN/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookiePartitionedForeign	/zh-CN/docs/Web/Privacy/Storage_Access_Policy/Errors/CookiePartitionedForeign
+/zh-CN/docs/Mozilla/Firefox/Privacy/Tracking_Protection	/zh-CN/docs/Web/Privacy/Tracking_Protection
 /zh-CN/docs/Mozilla/附加组件	/zh-CN/docs/Mozilla/Add-ons
 /zh-CN/docs/Mozilla_event_reference	/zh-CN/docs/Web/Events
 /zh-CN/docs/Mozilla_event_reference/DOMContentLoaded_(event)	/zh-CN/docs/Web/API/Window/DOMContentLoaded_event

--- a/files/zh-tw/_redirects.txt
+++ b/files/zh-tw/_redirects.txt
@@ -489,6 +489,17 @@
 /zh-TW/docs/Mozilla/Add-ons/WebExtensions/用戶介面/快捷選單項	/zh-TW/docs/Mozilla/Add-ons/WebExtensions/user_interface/Context_menu_items
 /zh-TW/docs/Mozilla/Add-ons/WebExtensions/用戶介面/開發工具面板	/zh-TW/docs/Mozilla/Add-ons/WebExtensions/user_interface/devtools_panels
 /zh-TW/docs/Mozilla/Add-ons/WebExtensions/用戶體驗最佳實踐	https://extensionworkshop.com/documentation/develop/user-experience-best-practices/
+/zh-TW/docs/Mozilla/Firefox/Privacy	/zh-TW/docs/Web/Privacy
+/zh-TW/docs/Mozilla/Firefox/Privacy/Redirect_tracking_protection	/zh-TW/docs/Web/Privacy/Redirect_tracking_protection
+/zh-TW/docs/Mozilla/Firefox/Privacy/State_Partitioning	/zh-TW/docs/Web/Privacy/State_Partitioning
+/zh-TW/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy	/zh-TW/docs/Web/Privacy/Storage_Access_Policy
+/zh-TW/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors	/zh-TW/docs/Web/Privacy/Storage_Access_Policy/Errors
+/zh-TW/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedAll	/zh-TW/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedAll
+/zh-TW/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedByPermission	/zh-TW/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedByPermission
+/zh-TW/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedForeign	/zh-TW/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedForeign
+/zh-TW/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookieBlockedTracker	/zh-TW/docs/Web/Privacy/Storage_Access_Policy/Errors/CookieBlockedTracker
+/zh-TW/docs/Mozilla/Firefox/Privacy/Storage_Access_Policy/Errors/CookiePartitionedForeign	/zh-TW/docs/Web/Privacy/Storage_Access_Policy/Errors/CookiePartitionedForeign
+/zh-TW/docs/Mozilla/Firefox/Privacy/Tracking_Protection	/zh-TW/docs/Web/Privacy/Tracking_Protection
 /zh-TW/docs/Mozilla/Firefox/Releases/2/Firefox_2_的安全功能	/zh-TW/docs/Mozilla/Firefox/Releases/2/Security_changes
 /zh-TW/docs/Mozilla/Firefox/Releases/2/新增消息來源閱讀工具	/zh-TW/docs/Mozilla/Firefox/Releases/2/Adding_feed_readers_to_Firefox
 /zh-TW/docs/Mozilla/Firefox/Releases/3/Firefox_3_Dom_Improvements	/zh-TW/docs/Mozilla/Firefox/Releases/3/DOM_improvements


### PR DESCRIPTION
This allows the green box that suggests the EN version of an article to work on these pages in these locales.
Supported locales taken from the mdn/yari repo.
Redirects found by searching the en-us/_redirects.txt file in the mdn/content repo.