### PR TITLE
fix: Update HTTP

### DIFF
--- a/files/ko/web/http/index.html
+++ b/files/ko/web/http/index.html
@@ -12,7 +12,7 @@ translation_of: Web/HTTP
 ---
 <div>{{HTTPSidebar}}</div>
 
-<p class="summary"><strong><dfn>하이퍼텍스트 전송 프로토콜(HTTP)</dfn></strong><dfn>은 HTML과 같은 하이퍼미디어 문서를 전송하기위한 </dfn><a href="https://en.wikipedia.org/wiki/Application_Layer">애플리케이션 레이어</a> 프로토콜입니다. 웹 브라우저와 웹 서버간의 커뮤니케이션을위해 디자인되었지만, 다른 목적으로도 사용될 수 있습니다. HTTP는 클라이언트가 요청을 생성하기 위한 연결을 연다음 응답을 받을때 까지 대기하는 전통적인 <a href="https://en.wikipedia.org/wiki/Client%E2%80%93server_model">클라이언트-서버 모델</a>을 따릅니다. HTTP는 <a href="https://en.wikipedia.org/wiki/Stateless_protocol">무상태 프로토콜</a>이며, 이는 서버가 두 요청간에 어떠한 데이터(상태)도 유지하지 않음을 의미합니다. 일반적으로 안정적인 <a href="https://en.wikipedia.org/wiki/Transport_Layer">전송 레이어</a>로 UDP와 달리 메세지를 잃지 않는 프로토콜인 TCP/IP 레이어를 기반으로 사용 합니다. <a href="https://en.wikipedia.org/wiki/Reliable_User_Datagram_Protocol">RUDP</a> — 안정적인 업데이트인 UDP의 적합한 대안 입니다.</p>
+<p class="summary"><strong><dfn>하이퍼텍스트 전송 프로토콜(HTTP)</dfn></strong><dfn>은 HTML과 같은 하이퍼미디어 문서를 전송하기위한 </dfn><a href="https://en.wikipedia.org/wiki/Application_Layer">애플리케이션 레이어</a> 프로토콜입니다. 웹 브라우저와 웹 서버간의 커뮤니케이션을위해 디자인되었지만, 다른 목적으로도 사용될 수 있습니다. HTTP는 클라이언트가 요청을 생성하기 위한 연결을 연다음 응답을 받을때 까지 대기하는 전통적인 <a href="https://en.wikipedia.org/wiki/Client%E2%80%93server_model">클라이언트-서버 모델</a>을 따릅니다. HTTP는 <a href="https://en.wikipedia.org/wiki/Stateless_protocol">무상태 프로토콜</a>이며, 이는 서버가 두 요청간에 어떠한 데이터(상태)도 유지하지 않음을 의미합니다.</p>
 
 <div class="column-container">
 <div class="column-half">
@@ -22,7 +22,7 @@ translation_of: Web/HTTP
 
 <dl>
  <dt><a href="/ko/docs/Web/HTTP/Overview">HTTP 개요</a></dt>
- <dd>클라이언트-서버 프로토콜의 기본 기능들: 할 수 있는 것과 의도된 용도.</dd>
+ <dd>클라이언트-서버 프로토콜의 기본 기능들. 할 수 있는 것과 의도된 용도.</dd>
  <dt><a href="/ko/docs/Web/HTTP/Caching">HTTP 캐시</a></dt>
  <dd>캐싱은 빠른 웹 사이트를 위해 아주 중요합니다. 이 글은 여러 캐싱 방법과 HTTP 헤더를 사용하여 이를 제어하는 방법을 설명합니다.</dd>
  <dt><a href="/ko/docs/Web/HTTP/Cookies">HTTP 쿠키</a></dt>
@@ -32,8 +32,10 @@ translation_of: Web/HTTP
 </dl>
 
 <dl>
+  <dt><a href="/ko/docs/Web/HTTP/Client_hints">클라이언트 힌트</a></dt>
+  <dd><strong>클라이언트 힌트</strong>는 서버가 클라이언트로부터 디바이스, 네트워크, 사용자 및 사용자 에이전트별 기본 설정에 대한 정보를 사전에 요청하기 위해 사용할 수 있는 응답 헤더의 집합입니다. 이에 따라 서버는 클라이언트가 제공하는 정보에 기반하여 전송할 리소스를 결정할 수 있습니다. </dd>
  <dt><a href="/ko/docs/Web/HTTP/Basics_of_HTTP/Evolution_of_HTTP">HTTP의 진화</a></dt>
- <dd>초기 버전의 HTTP와 최신 HTTP/2 이후의 변경 사항에 대한 간략한 설명입니다.</dd>
+ <dd>초기 버전의 HTTP와 현대의 HTTP/2 및 새로 등장한 HTTP/3 이후 버전 간의 변경 사항에 대한 간략한 설명입니다.</dd>
  <dt><a href="https://wiki.mozilla.org/Security/Guidelines/Web_Security">Mozilla 웹 보안 가이드라인</a></dt>
  <dd>안전한 웹 어플리케이션을 생성하는 운영 팀에 도움이되는 팁 모음입니다.</dd>
 </dl>
@@ -57,9 +59,9 @@ translation_of: Web/HTTP
  <dt><a href="/ko/docs/Web/HTTP/Headers">HTTP 헤더</a></dt>
  <dd>HTTP 메시지 헤더는 리소스 또는 서버나 클라이언트의 동작을 설명하는데 사용됩니다. 커스텀 등록 헤더는 <code>X-</code>를 앞에 붙여 추가할 수 있습니다. 그 외에는 원본 컨텐츠가 <a href="https://tools.ietf.org/html/rfc4229">RFC 4229</a>에서 정의된 <a href="https://www.iana.org/assignments/message-headers/message-headers.xhtml#perm-headers">IANA 레지스트리</a>에 있습니다.</dd>
  <dt><a href="/ko/docs/Web/HTTP/Methods">HTTP 요청 메서드</a></dt>
- <dd>HTTP로 수행할 수 있는 여러 작업: {{HTTPMethod("GET")}}, {{HTTPMethod("POST")}} 요청 및 덜 자주 사용되는 {{HTTPMethod("OPTIONS")}}, {{HTTPMethod("DELETE")}}, {{HTTPMethod("TRACE")}} 요청.</dd>
- <dt><a href="/ko/docs/Web/HTTP/Response_codes">HTTP 상태 응답 코드</a></dt>
- <dd>HTTP 응답 코드는 지정한 HTTP 요청이 성공적으로 완료되었는지를 나타냅니다. 응답은 다섯 가지 클래스로 그룹핑됩니다: 정보성 응답, 성공 응답, 리다이렉트, 클라이언트 에러, 서버 에러.</dd>
+ <dd>HTTP로 수행할 수 있는 여러 작업. {{HTTPMethod("GET")}}, {{HTTPMethod("POST")}} 요청 및 덜 자주 사용되는 {{HTTPMethod("OPTIONS")}}, {{HTTPMethod("DELETE")}}, {{HTTPMethod("TRACE")}} 요청.</dd>
+ <dt><a href="/ko/docs/Web/HTTP/Status">HTTP 상태 응답 코드</a></dt>
+ <dd>HTTP 응답 코드는 지정한 HTTP 요청이 성공적으로 완료되었는지를 나타냅니다. 응답은 다섯 가지 클래스로 그룹핑됩니다. 정보성 응답, 성공 응답, 리다이렉트, 클라이언트 에러, 서버 에러.</dd>
 </dl>
 
 <dl>


### PR DESCRIPTION
**HTTP** 문서의 
- 개요에서 TCP관련 부분을 삭제했습니다.
- 클라이언트 힌트에 대한 내용을 추가했습니다.
- HTTP 진화에서 HTTP3을 추가했습니다.
- HTTP 상태 응답 코드의 링크를 수정했습니다.
- 번역가이드에 맞춰 `:`를 `.`으로 수정했습니다.