### PR TITLE
Errores en el texto

### DIFF
--- a/files/es/web/css/position/index.html
+++ b/files/es/web/css/position/index.html
@@ -93,7 +93,7 @@ translation_of: Web/CSS/position
 
 <h3 id="Absolute_positioning" name="Absolute_positioning">Posicionamiento absoluto</h3>
 
-<p>Los elementos posicionados relativamente se mantienen en el flujo normal del documento. Por el contrario, un elemento posicionado absolutamente es removido del flujoñ de esta manera, los demás elementos se posicionan como si el mismo no existiera. El elemento posicionado absolutamente se posiciona relativamente a su<em>ancestro posicionado más cercano</em> (es decir, el ancestro más cercano que no es <code>static</code>). Si no hay ningún ancestro posicionado se ubica relativo al <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/All_About_The_Containing_Block">bloque contenedor</a> inicial. En el ejemplo siguiente, la caja "Two" no tiene un ancestro posicionado, por lo tanto se posiciona relativo al <code>&lt;body&gt;</code> del documento.</p>
+<p>Los elementos posicionados relativamente se mantienen en el flujo normal del documento. Por el contrario, un elemento posicionado absolutamente es removido del flujo de esta manera, los demás elementos se posicionan como si el mismo no existiera. El elemento posicionado absolutamente se posiciona relativamente a su <em>ancestro posicionado más cercano</em> (es decir, el ancestro más cercano que no es <code>static</code>). Si no hay ningún ancestro posicionado se ubica relativo al <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/All_About_The_Containing_Block">bloque contenedor</a> inicial. En el ejemplo siguiente, la caja "Two" no tiene un ancestro posicionado, por lo tanto se posiciona relativo al <code>&lt;body&gt;</code> del documento.</p>
 
 <h4 id="HTML_2">HTML</h4>
 


### PR DESCRIPTION
En la descripción de position absolute en vez de flujo ponía flujoñ y un poco después dos palabras estaban juntas, era necesario añadir un espacio(su<em>ancestro => su 
 <em>ancestro).