### PR TITLE
fix: Typo fix

### DIFF
--- a/files/pt-br/learn/common_questions/set_up_a_local_testing_server/index.html
+++ b/files/pt-br/learn/common_questions/set_up_a_local_testing_server/index.html
@@ -38,7 +38,7 @@ original_slug: Learn/Common_questions/Como_configurar_um_servidor_de_testes_loca
 
 <p>Ao longo da maior parte da área de aprendizagem, nós lhe dissemos apenas para abrir seus exemplos diretamente no navegador  —  Isto pode ser feito atráves de um duplo clique no arquivo HTML, arrastando e soltando o arquivo na janela do navegador ou escolhendo Arquivo &gt; Abrir<em>...</em> e navegando para o arquivo HTML. Existem muitas maneiras de realizar isso.</p>
 
-<p>Se o caminho do endereço web começa com <code>file://</code> seguido pelo caminho para o arquivo no seu disco rígido local, um arquivo local está sendo utilizado. No entanto, se você ver um dos nossos exemplos hospedado no GitHub (ou um exemplo em algum outro servidor remoto), o enderço web começará com <code>http://</code> ou <code>https://</code>, para mostrar que o arquivo foi recebido via HTTP.</p>
+<p>Se o caminho do endereço web começa com <code>file://</code> seguido pelo caminho para o arquivo no seu disco rígido local, um arquivo local está sendo utilizado. No entanto, se você ver um dos nossos exemplos hospedado no GitHub (ou um exemplo em algum outro servidor remoto), o endereço web começará com <code>http://</code> ou <code>https://</code>, para mostrar que o arquivo foi recebido via HTTP.</p>
 
 <h2 id="O_problema_com_o_teste_de_arquivos_locais">O problema com o teste de arquivos locais</h2>
 


### PR DESCRIPTION
Fixing a typo error at the line 41:

old: {enderço}
new: {endereço}

Refereed to the issue/fixes #4292