### PR TITLE
fix: wrong symbols and redundant words

### DIFF
--- a/files/zh-cn/web/javascript/data_structures/index.html
+++ b/files/zh-cn/web/javascript/data_structures/index.html
@@ -97,8 +97,8 @@ foo = true;  // foo is a Boolean now
 <p>不同于类 C 语言，JavaScript 字符串是不可更改的。这意味着字符串一旦被创建，就不能被修改。但是，可以基于对原始字符串的操作来创建新的字符串。例如：</p>
 
 <ul>
- <li>获取一个字符串的子串可通过选择个别字母或者使用 {{jsxref("String.substr()")}}.</li>
- <li>两个字符串的连接使用连接操作符 (<code>+</code>) 或者 {{jsxref("String.concat()")}}.</li>
+ <li>获取一个字符串的子串可通过选择个别字母或者使用 {{jsxref("String.substr()")}}。</li>
+ <li>两个字符串的连接使用连接操作符 (<code>+</code>) 或者 {{jsxref("String.concat()")}}。</li>
 </ul>
 
 <h4 id="注意代码中的“字符串类型”！">注意代码中的“字符串类型”！</h4>
@@ -117,11 +117,11 @@ foo = true;  // foo is a Boolean now
 
 <h3 id="符号类型">符号类型</h3>
 
-<p>符号(Symbols)是 ECMAScript 第6版新定义的。符号类型是唯一的并且是不可修改的, 并且也可以用来作为 Object 的 key 的值(如下). 在某些语言当中也有类似的原子类型(Atoms). 你也可以认为为它们是 C 里面的枚举类型. 更多细节请看 {{Glossary("Symbol")}} 和 {{jsxref("Symbol")}} 。</p>
+<p>符号(Symbols)是 ECMAScript 第6版新定义的。符号类型是唯一且不可修改的, 并且可以用来当作为 Object 的 key 的值(如下)，在某些语言当中也有类似的原子类型(Atoms)，你也可以认为它们是 C 里面的枚举类型，更多细节请看 {{Glossary("Symbol")}} 和 {{jsxref("Symbol")}}。</p>
 
 <h2 id="对象">对象</h2>
 
-<p>在计算机科学中, 对象是指内存中的可以被 {{Glossary("Identifier", "标识符")}}引用的一块区域.</p>
+<p>在计算机科学中, 对象是指内存中的可以被 {{Glossary("Identifier", "标识符")}}引用的一块区域。</p>
 
 <h3 id="属性">属性</h3>
 


### PR DESCRIPTION
- Use full-angle symbols instead of half-angle symbols.
- Optimized statement description