### PR TITLE
add missing node data type of DOM

### DIFF
--- a/files/ko/web/api/document_object_model/introduction/index.html
+++ b/files/ko/web/api/document_object_model/introduction/index.html
@@ -92,6 +92,12 @@ p_list = doc.getElementsByTagName("para");
    </td>
   </tr>
   <tr>
+    <td><code>Node</code></td>
+    <td>
+      <p><code>document</code> 내에 있는 모든 객체는 일종의 노드입니다. 이 객체는 HTML 문서에서, element 노드가 될 수 있지만 text 노드나 attribute노드가 될 수도 있습니다.</p>
+    </td>
+  </tr>
+  <tr>
    <td><code>element</code></td>
    <td>
     <p><code>element</code> 는 DOM API 의 member 에 의해 return 된 element 또는 <code>element</code> type 의 node 를 의미한다. <a href="/ko/docs/Web/API/Document/createElement">document.createElement()</a> method 가 <code>node</code> 를 참조하는 object 를 리턴한다고 말하는 대신, 이 method 가 DOM 안에서 생생되는 <code>element</code> 를 리턴한다고 좀 더 단순하게 말할 수 있다. <code>element</code> 객체들은 DOM <code>Element</code> interface 와 함께 좀 더 기본적인 <code>Node</code> interface 를 구현한 것이기 때문에 이 reference 에는 두 가지가 모두 포함되었다고 생각하면 된다.</p>


### PR DESCRIPTION
 [DOM 소개 페이지](https://developer.mozilla.org/ko/docs/Web/API/Document_Object_Model/Introduction)에 DOM의 데이터 타입설명에 Node에 대한 설명이 누락되어 추가했습니다.

추가적으로 한글번역 문서에서는 `<td>`태그 안에 `<p>` 태그가 삽입되어있지만, [mdn/content 문서](https://github.com/mdn/content/blob/main/files/en-us/web/api/document_object_model/introduction/index.md)에는 <p>태그가 존재하지않는데,  어떻게 작업하는게 좋을까요?🙄


### 참고
> #### [ko]

```html
 <tbody>
  <tr>
   <td><code>document</code></td>
   <td>
    <p>member 가 document type 의 object 를 리턴할 때(예를 들어 element의 <strong><code>ownerDocument</code></strong> 
    ...
    ...
```
> #### [us](https://github.com/mdn/content/blob/main/files/en-us/web/api/document_object_model/introduction/index.md?plain=1#L120)

```html
<tbody>
    <tr>
      <td>{{domxref("Document")}}</td>
      <td>
        When a member returns an object of type <code>document</code> (e.g., the
        <code>ownerDocument</code> property of an element returns the
        <code>document</code> to which it belongs), this object is the root
        <code>document</code> object itself. The
        <a href="/en-US/docs/Web/API/Document"
          >DOM <code>document</code> Reference</a
        >
       ... 
       ... 
```


