### PR TITLE
Update index.html

### DIFF
--- a/files/pt-br/learn/tools_and_testing/client-side_javascript_frameworks/index.html
+++ b/files/pt-br/learn/tools_and_testing/client-side_javascript_frameworks/index.html
@@ -1,5 +1,5 @@
 ---
-title: Understanding client-side JavaScript frameworks
+title: Entendendo frameworks JavaScript do lado do cliente
 slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks
 tags:
   - Beginner
@@ -37,10 +37,10 @@ translation_of: Learn/Tools_and_testing/Client-side_JavaScript_frameworks
 <h2 id="Guias_de_introdução">Guias de introdução</h2>
 
 <dl>
- <dt><a href="/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Introduction">1.trodução a frameworks para client-side</a></dt>
- <dd>( begin our look at frameworks with a general overview of the area, looking at a brief history of JavaScript and frameworks, why frameworks exist and what they give us, how to start thinking about choosing a framework to learn, and what alternatives there are to client-side frameworks.</dd>
+ <dt><a href="/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Introduction">1.Introdução a frameworks para client-side</a></dt>
+ <dd>Nós iniciamos nosso olhar sobre frameworks com uma visão geral da área, olhando para uma breve história do JavaScript e frameworks, por que frameworks existem e o que eles nos fornecem, como começar a pensar na escolha de um framework para aprender e quais alternativas de frameworks para o lado do cliente existem.</dd>
  <dt><a href="/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Main_features">2.Principais recursos para frameworks</a></dt>
- <dd>Each major JavaScript framework has a different approach to updating the DOM, handling browser events, and providing an enjoyable developer experience. This article will explore the main features of “the big 4” frameworks, looking at how frameworks tend to work from a high level and the differences between them.</dd>
+ <dd>Cada framework JavaScript principal tem uma abordagem diferente para atualizar o DOM, manipular eventos do navegador e fornecer uma experiência agradável de desenvolvimento. Este artigo explorará os principais recursos dos "quatro maiores" frameworks, observando como eles tendem a funcionar a partir de um nível superficial e as diferenças entre si.</dd>
 </dl>
 
 <h2 id="React_tutorials">React tutorials</h2>


### PR DESCRIPTION
Adding some missing translates:
- title
- sentence at line 41
- sentence at line 43

Fixing:
- sentence at line 40

I use the pattern that I see on another pages, translating _client-side_ to _para o lado do cliente_