### PR TITLE
Correção da explicação sobre os parâmetros

### DIFF
--- a/files/pt-br/web/javascript/reference/global_objects/array/reduce/index.html
+++ b/files/pt-br/web/javascript/reference/global_objects/array/reduce/index.html
@@ -42,7 +42,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Array/Reduce
 
 <dl>
  <dt><code>acumulador</code></dt>
- <dd>É o valor inicial (ou o valor do callback anterior). Este valor inicia com o <font face="Consolas, Liberation Mono, Courier, monospace"><code>valorInicial</code></font> e será retornado na ultima iteração.</dd>
+ <dd>É o valor inicial (ou o valor do callback anterior). Este valor inicia com o <font face="Consolas, Liberation Mono, Courier, monospace"><code>valorInicial</code></font> e será retornado na última iteração.</dd>
 </dl>
 
 <dl>

--- a/files/pt-br/web/javascript/reference/global_objects/array/reduce/index.html
+++ b/files/pt-br/web/javascript/reference/global_objects/array/reduce/index.html
@@ -40,9 +40,15 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Array/Reduce
  <dd>Função que é executada em cada valor no array (exceto no primeiro, se nenhum <font face="Consolas, Liberation Mono, Courier, monospace"><code>valorInicial</code></font> for passado); recebe quatro argumentos:</dd>
 </dl>
 
-<p><strong><font face="Consolas, Liberation Mono, Courier, monospace"><code>acumulador</code></font></strong></p>
+<dl>
+ <dt><code>acumulador</code></dt>
+ <dd>É o valor inicial (ou o valor do callback anterior). Este valor inicia com o <font face="Consolas, Liberation Mono, Courier, monospace"><code>valorInicial</code></font> e será retornado na ultima iteração.</dd>
+</dl>
 
-<p>Opcional. O índice do elemento atual que está sendo processado no array. Começa a partir do index <code>0</code> se um <font face="Consolas, Liberation Mono, Courier, monospace"><code>valorInicial</code> </font>for fornecido. Do contrário, começa do index <code>1</code>.</p>
+<dl>
+ <dt><code>valorAtual</code></dt>
+ <dd>Opcional. O índice do elemento atual que está sendo processado no array. Começa a partir do index <code>0</code> se um <font face="Consolas, Liberation Mono, Courier, monospace"><code>valorInicial</code> </font>for fornecido. Do contrário, começa do index <code>1</code>.</dd>
+</dl>
 
 <dl>
  <dt><code>valorInicial</code></dt>


### PR DESCRIPTION
PT-BR: 
1. Faltou ser explicado como funciona o parâmetro "acumulador".
2. A explicação do parâmetro "valorAtual" estava sem o título dentro da tag "dt".

EN-US:
1. It has not been explained how the "_acumulador_" parameter works.
2. The explanation of the "_valorAtual_" parameter was without the title inside the "dt" tag.