### PR TITLE
Remove unwanted macros in `zh-CN`

### DIFF
--- a/files/zh-cn/conflicting/web/api/mouseevent/pagey/index.html
+++ b/files/zh-cn/conflicting/web/api/mouseevent/pagey/index.html
@@ -87,4 +87,3 @@ function showCoords(evt){
 </pre>
 <h3 id="Specification" name="Specification">规范</h3>
 <p>不属于任何公开的标准.</p>
-<p>{{ languages( {"pl": "pl/DOM/event.pageY","en": "en/DOM/event.pageY" } ) }}</p>

--- a/files/zh-cn/games/anatomy/index.html
+++ b/files/zh-cn/games/anatomy/index.html
@@ -10,8 +10,6 @@ translation_of: Games/Anatomy
 ---
 <div>{{GamesSidebar}}</div>
 
-<p>{{IncludeSubnav("/en-US/docs/Games")}}</p>
-
 <div class="summary">
 <p>本文从技术角度分析了一般电子游戏的结构和工作流程，就此介绍主循环是如何运行的。它有助于初学者了解在现代游戏开发领域构建游戏时需要什么，以及如何将JavaScript这样的Web标准工具作为自己的工具使用。游戏开发经验丰富但不熟悉Web开发的开发者也能从中受益。</p>
 </div>

--- a/files/zh-cn/games/examples/index.html
+++ b/files/zh-cn/games/examples/index.html
@@ -5,7 +5,7 @@ tags:
   - 游戏
 translation_of: Games/Examples
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/zh-CN/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p class="summary">这个页面列出了许多令人印象深刻的web技术演示，你可以从中获得灵感和乐趣。这里证明了可以利用JavaScript，WebGL和相关的技术做些什么。前两个部分列出了可以玩的游戏，其中在第二个部分中列出的演示不一定是可交互的或是游戏。</p>
 

--- a/files/zh-cn/games/introduction/index.html
+++ b/files/zh-cn/games/introduction/index.html
@@ -10,8 +10,6 @@ original_slug: Games/简介
 ---
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/zh-CN/docs/Games")}}</div>
-
 <p>现代的web已经高速发展成为一个可行可靠的平台，它不仅能够用来创建高质量的酷炫游戏，同时也能够用来发布和传播这些游戏。</p>
 
 <p>采用现代网页技术和较新的浏览器，完全有可能做出令人印象深刻的顶级页面游戏。它能够制作的游戏种类可以和桌面端以及原生系统相当。我们这里所说的，并不是很久之前就采用Flash®制作出的简单卡牌游戏或者多人社交游戏。而是牛逼的3D 动作射击游戏，RPG 游戏等等。得益于 <a href="/zh-CN/docs/JavaScript" title="/zh-CN/docs/JavaScript">JavaScript</a> 实时编译技术性能的大幅提升，以及新开放的 API。在制作运行在浏览器（或者是基于类似 <a href="/zh-CN/docs/Mozilla/Firefox_OS" title="/zh-CN/docs/Mozilla/Firefox_OS">Firefox OS</a> 的 <a href="/zh-CN/docs/HTML/HTML5" title="/zh-CN/docs/HTML/HTML5">HTML5</a>技术支持的设备）上的游戏时，我们不用妥协。</p>

--- a/files/zh-cn/games/introduction_to_html5_game_development/index.html
+++ b/files/zh-cn/games/introduction_to_html5_game_development/index.html
@@ -7,7 +7,7 @@ tags:
 translation_of: Games/Introduction_to_HTML5_Game_Development_(summary)
 original_slug: Games/Introduction_to_HTML5_Game_Gevelopment_(summary)
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/zh-CN/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <div>
 <h2 style="line-height: 30px;" id="优点">优点</h2>

--- a/files/zh-cn/games/techniques/2d_collision_detection/index.html
+++ b/files/zh-cn/games/techniques/2d_collision_detection/index.html
@@ -3,7 +3,7 @@ title: 2D collision detection
 slug: Games/Techniques/2D_collision_detection
 translation_of: Games/Techniques/2D_collision_detection
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <div class="summary">
 <p>检测2D游戏中的碰撞算法，依赖于可碰撞物体的形状（例如：矩形与矩形，矩形与圆形，圆形与圆形）。通常情况下，你使用的的简单通用形状，会被称为“hitbox”的实体所覆盖，尽管发生的碰撞并不是像素完美契合的，它看起来也足够好，而且可跨多个实体执行碰撞。本文提供了一系列较为通用的2D游戏中碰撞侦测技术。</p>

--- a/files/zh-cn/games/techniques/async_scripts/index.html
+++ b/files/zh-cn/games/techniques/async_scripts/index.html
@@ -3,7 +3,7 @@ title: asm.js的异步脚本
 slug: Games/Techniques/Async_scripts
 translation_of: Games/Techniques/Async_scripts
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/zh-CN/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <div class="summary">
 <p><span class="seoSummary">每个中型或大型游戏都应编译<a href="https://developer.mozilla.org/en-US/docs/Games/Tools/asm.js">asm.js</a>代码作为异步脚本的一部分，以便浏览器能够最大限度地灵活地优化编译过程。 在Gecko中，异步编译允许JavaScript引擎在游戏加载时缓存主线程的asm.js，并缓存生成的机器代码，这样游戏就不需要在随后的加载中编译（从Firefox 28开始）。 要查看差异，请切换<code>javascript.options.parallel_parsing</code> in <code>about:config</code>.</span></p>

--- a/files/zh-cn/games/techniques/index.html
+++ b/files/zh-cn/games/techniques/index.html
@@ -10,8 +10,6 @@ translation_of: Games/Techniques
 ---
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 <div class="summary">
 <p><span class="seoSummary">这个页面为想要使用开放的网页技术来开发游戏的人列举出了必要的核心技术。</span></p>
 </div>

--- a/files/zh-cn/games/tools/index.html
+++ b/files/zh-cn/games/tools/index.html
@@ -10,7 +10,7 @@ tags:
   - TopicStub
 translation_of: Games/Tools
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <div class="summary">
 <p><span class="seoSummary">On this page you can find links to our game development tools articles, which eventually aims to cover frameworks, compilers, and debugging tools.</span></p>

--- a/files/zh-cn/games/tutorials/2d_breakout_game_phaser/animations_and_tweens/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_phaser/animations_and_tweens/index.html
@@ -15,8 +15,6 @@ translation_of: Games/Tutorials/2D_breakout_game_Phaser/Animations_and_tweens
 ---
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Extra_lives", "Games/Workflows/2D_Breakout_game_Phaser/Buttons")}}</p>
 
 <div class="summary">

--- a/files/zh-cn/games/tutorials/2d_breakout_game_phaser/bounce_off_the_walls/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_phaser/bounce_off_the_walls/index.html
@@ -12,7 +12,7 @@ tags:
   - bouncing
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Bounce_off_the_walls
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Physics", "Games/Workflows/2D_Breakout_game_Phaser/Player_paddle_and_controls")}}</p>
 

--- a/files/zh-cn/games/tutorials/2d_breakout_game_phaser/build_the_brick_field/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_phaser/build_the_brick_field/index.html
@@ -11,7 +11,7 @@ tags:
   - Tutorial
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Build_the_brick_field
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Game_over", "Games/Workflows/2D_Breakout_game_Phaser/Collision_detection")}}</p>
 

--- a/files/zh-cn/games/tutorials/2d_breakout_game_phaser/buttons/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_phaser/buttons/index.html
@@ -12,7 +12,7 @@ tags:
   - Tutorial
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Buttons
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Animations_and_tweens", "Games/Workflows/2D_Breakout_game_Phaser/Randomizing_gameplay")}}</p>
 

--- a/files/zh-cn/games/tutorials/2d_breakout_game_phaser/collision_detection/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_phaser/collision_detection/index.html
@@ -12,7 +12,7 @@ tags:
   - collision detection
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Collision_detection
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Build_the_brick_field", "Games/Workflows/2D_Breakout_game_Phaser/The_score")}}</p>
 

--- a/files/zh-cn/games/tutorials/2d_breakout_game_phaser/extra_lives/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_phaser/extra_lives/index.html
@@ -12,7 +12,7 @@ tags:
   - lives
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Extra_lives
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Win_the_game", "Games/Workflows/2D_Breakout_game_Phaser/Animations_and_tweens")}}</p>
 

--- a/files/zh-cn/games/tutorials/2d_breakout_game_phaser/game_over/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_phaser/game_over/index.html
@@ -12,7 +12,7 @@ tags:
   - game over
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Game_over
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Player_paddle_and_controls", "Games/Workflows/2D_Breakout_game_Phaser/Build_the_brick_field")}}</p>
 

--- a/files/zh-cn/games/tutorials/2d_breakout_game_phaser/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_phaser/index.html
@@ -7,7 +7,7 @@ tags:
   - 游戏
 translation_of: Games/Tutorials/2D_breakout_game_Phaser
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{Next("Games/Workflows/2D_Breakout_game_Phaser/Initialize_the_framework")}}</p>
 

--- a/files/zh-cn/games/tutorials/2d_breakout_game_phaser/initialize_the_framework/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_phaser/initialize_the_framework/index.html
@@ -12,7 +12,7 @@ tags:
   - 游戏
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Initialize_the_framework
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/zh-CN/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Tutorials/2D_Breakout_game_Phaser", "Games/Tutorials/2D_Breakout_game_Phaser/Scaling")}}</p>
 

--- a/files/zh-cn/games/tutorials/2d_breakout_game_phaser/load_the_assets_and_print_them_on_screen/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_phaser/load_the_assets_and_print_them_on_screen/index.html
@@ -14,7 +14,7 @@ tags:
 translation_of: >-
   Games/Tutorials/2D_breakout_game_Phaser/Load_the_assets_and_print_them_on_screen
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Scaling", "Games/Workflows/2D_Breakout_game_Phaser/Move the ball")}}</p>
 

--- a/files/zh-cn/games/tutorials/2d_breakout_game_phaser/move_the_ball/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_phaser/move_the_ball/index.html
@@ -12,7 +12,7 @@ tags:
   - moving
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Move_the_ball
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Load_the_assets_and_print_them_on_screen", "Games/Workflows/2D_Breakout_game_Phaser/Physics")}}</p>
 

--- a/files/zh-cn/games/tutorials/2d_breakout_game_phaser/physics/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_phaser/physics/index.html
@@ -12,7 +12,7 @@ tags:
   - physics
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Physics
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Move_the_ball", "Games/Workflows/2D_Breakout_game_Phaser/Bounce_off_the_walls")}}</p>
 

--- a/files/zh-cn/games/tutorials/2d_breakout_game_phaser/player_paddle_and_controls/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_phaser/player_paddle_and_controls/index.html
@@ -11,7 +11,7 @@ tags:
   - Tutorial
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Player_paddle_and_controls
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Bounce_off_the_walls", "Games/Workflows/2D_Breakout_game_Phaser/Game_over")}}</p>
 

--- a/files/zh-cn/games/tutorials/2d_breakout_game_phaser/randomizing_gameplay/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_phaser/randomizing_gameplay/index.html
@@ -11,7 +11,7 @@ tags:
   - Tutorial
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Randomizing_gameplay
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{Previous("Games/Workflows/2D_Breakout_game_Phaser/Buttons")}}</p>
 

--- a/files/zh-cn/games/tutorials/2d_breakout_game_phaser/scaling/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_phaser/scaling/index.html
@@ -11,7 +11,7 @@ tags:
   - Tutorial
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Scaling
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/zh-CN/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Tutorials/2D_Breakout_game_Phaser/Initialize_the_framework", "Games/Tutorials/2D_Breakout_game_Phaser/Load_the_assets_and_print_them_on_screen")}}</p>
 

--- a/files/zh-cn/games/tutorials/2d_breakout_game_phaser/the_score/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_phaser/the_score/index.html
@@ -12,7 +12,7 @@ tags:
   - scoring
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/The_score
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Collision_detection", "Games/Workflows/2D_Breakout_game_Phaser/Win_the_game")}}</p>
 

--- a/files/zh-cn/games/tutorials/2d_breakout_game_phaser/win_the_game/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_phaser/win_the_game/index.html
@@ -12,7 +12,7 @@ tags:
   - winning
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Win_the_game
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/The_score", "Games/Workflows/2D_Breakout_game_Phaser/Extra_lives")}}</p>
 

--- a/files/zh-cn/games/tutorials/2d_breakout_game_pure_javascript/bounce_off_the_walls/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_pure_javascript/bounce_off_the_walls/index.html
@@ -3,7 +3,7 @@ title: 反弹的墙壁
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Bounce_off_the_walls
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Bounce_off_the_walls
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_pure_JavaScript/Move_the_ball", "Games/Workflows/2D_Breakout_game_pure_JavaScript/Paddle_and_keyboard_controls")}}</p>
 

--- a/files/zh-cn/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.html
@@ -3,7 +3,7 @@ title: Build the brick field
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Build_the_brick_field
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Build_the_brick_field
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_pure_JavaScript/Game_over", "Games/Workflows/2D_Breakout_game_pure_JavaScript/Collision_detection")}}</p>
 

--- a/files/zh-cn/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.html
@@ -3,7 +3,7 @@ title: 撞击处理
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Collision_detection
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Collision_detection
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_pure_JavaScript/Build_the_brick_field", "Games/Workflows/2D_Breakout_game_pure_JavaScript/Track_the_score_and_win")}}</p>
 

--- a/files/zh-cn/games/tutorials/2d_breakout_game_pure_javascript/create_the_canvas_and_draw_on_it/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_pure_javascript/create_the_canvas_and_draw_on_it/index.html
@@ -7,8 +7,6 @@ translation_of: >-
 ---
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_pure_JavaScript", "Games/Workflows/2D_Breakout_game_pure_JavaScript/Move_the_ball")}}</p>
 
 <div class="summary">

--- a/files/zh-cn/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.html
@@ -14,8 +14,6 @@ original_slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/收尾工作
 ---
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 <p>{{Previous("Games/Workflows/2D_Breakout_game_pure_JavaScript/Mouse_controls")}}</p>
 
 <div class="summary">

--- a/files/zh-cn/games/tutorials/2d_breakout_game_pure_javascript/game_over/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_pure_javascript/game_over/index.html
@@ -5,8 +5,6 @@ translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Game_over
 ---
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_pure_JavaScript/Paddle_and_keyboard_controls", "Games/Workflows/2D_Breakout_game_pure_JavaScript/Build_the_brick_field")}}</p>
 
 <div class="summary">

--- a/files/zh-cn/games/tutorials/2d_breakout_game_pure_javascript/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_pure_javascript/index.html
@@ -12,7 +12,7 @@ tags:
   - Tutorial
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{Next("Games/Workflows/2D_Breakout_game_pure_JavaScript/Create_the_Canvas_and_draw_on_it")}}</p>
 

--- a/files/zh-cn/games/tutorials/2d_breakout_game_pure_javascript/mouse_controls/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_pure_javascript/mouse_controls/index.html
@@ -14,8 +14,6 @@ original_slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/鼠标控制
 ---
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_pure_JavaScript/Track_the_score_and_win", "Games/Workflows/2D_Breakout_game_pure_JavaScript/Finishing_up")}}</p>
 
 <div class="summary">

--- a/files/zh-cn/games/tutorials/2d_breakout_game_pure_javascript/move_the_ball/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_pure_javascript/move_the_ball/index.html
@@ -12,7 +12,7 @@ tags:
   - movement
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Move_the_ball
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <div>{{PreviousNext("Games/Workflows/2D_Breakout_game_pure_JavaScript/Create_the_Canvas_and_draw_on_it", "Games/Workflows/2D_Breakout_game_pure_JavaScript/Bounce_off_the_walls")}}</div>
 

--- a/files/zh-cn/games/tutorials/2d_breakout_game_pure_javascript/paddle_and_keyboard_controls/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_pure_javascript/paddle_and_keyboard_controls/index.html
@@ -3,7 +3,7 @@ title: 球板及键盘控制
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Paddle_and_keyboard_controls
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Paddle_and_keyboard_controls
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_pure_JavaScript/Bounce_off_the_walls", "Games/Workflows/2D_Breakout_game_pure_JavaScript/Game_over")}}</p>
 

--- a/files/zh-cn/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.html
+++ b/files/zh-cn/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.html
@@ -3,7 +3,7 @@ title: 跟踪得分和获胜
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Track_the_score_and_win
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Track_the_score_and_win
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>{{PreviousNext("Games/Workflows/2D_Breakout_game_pure_JavaScript/Collision_detection", "Games/Workflows/2D_Breakout_game_pure_JavaScript/Mouse_controls")}}</p>
 

--- a/files/zh-cn/games/tutorials/html5_gamedev_phaser_device_orientation/index.html
+++ b/files/zh-cn/games/tutorials/html5_gamedev_phaser_device_orientation/index.html
@@ -5,8 +5,6 @@ translation_of: Games/Tutorials/HTML5_Gamedev_Phaser_Device_Orientation
 ---
 <div>{{GamesSidebar}}</div>
 
-<div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 <div class="summary">
 <p>在本教程中，我们将介绍构建 HTML5 移动游戏的过程。 本游戏使用 <a href="https://developer.mozilla.org/en-US/Apps/Build/gather_and_modify_data/responding_to_device_orientation_changes">Device Orientation</a> 和 <a href="https://developer.mozilla.org/en-US/docs/Web/Guide/API/Vibration">Vibration </a><strong>APIs</strong> 来增强游戏玩法，并使用 <a class="external external-icon" href="http://phaser.io/">Phaser</a> 框架构建。 为了充分理解本教程建议您先学习基础的JavaScript 知识。</p>
 </div>

--- a/files/zh-cn/games/tutorials/index.html
+++ b/files/zh-cn/games/tutorials/index.html
@@ -11,7 +11,7 @@ tags:
   - Workflows
 translation_of: Games/Tutorials
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
+<div>{{GamesSidebar}}</div>
 
 <p>This page contains multiple tutorial series that highlight different workflows for effectively creating different types of web games.</p>
 

--- a/files/zh-cn/glossary/asynchronous/index.html
+++ b/files/zh-cn/glossary/asynchronous/index.html
@@ -34,5 +34,3 @@ original_slug: Glossary/异步
  <li><a href="/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Fetching_data">Fetching data from the server</a> (Learning Area) 从服务器获取数据</li>
  <li>{{glossary("Synchronous")}} 同步</li>
 </ul>
-
-<p>{{IncludeSubnav("/en-US/docs/Glossary")}}</p>

--- a/files/zh-cn/learn/common_questions/available_text_editors/index.html
+++ b/files/zh-cn/learn/common_questions/available_text_editors/index.html
@@ -4,7 +4,6 @@ slug: Learn/Common_questions/Available_text_editors
 translation_of: Learn/Common_questions/Available_text_editors
 original_slug: Learn/Common_questions/实用文本编辑器
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
 
 <div class="summary">
 <p>在这篇文章中我们强调了关于web开发者安装文本编辑器的一些考虑事项。</p>

--- a/files/zh-cn/learn/common_questions/common_web_layouts/index.html
+++ b/files/zh-cn/learn/common_questions/common_web_layouts/index.html
@@ -9,7 +9,6 @@ tags:
   - 设计
 translation_of: Learn/Common_questions/Common_web_layouts
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
 
 <div class="summary">
 <p>当你设计自己站点时，最好已经对常见的web页面布局所包含的内容有过构思。</p>

--- a/files/zh-cn/learn/html/howto/author_fast-loading_html_pages/index.html
+++ b/files/zh-cn/learn/html/howto/author_fast-loading_html_pages/index.html
@@ -208,7 +208,3 @@ original_slug: Web/Guide/HTML/Tips_for_authoring_fast-loading_HTML_pages
  <li>注意：This reprinted article was originally part of the DevEdge site.</li>
 </ul>
 </div>
-
-<div class="noinclude"></div>
-
-<p>{{ languages( { "en": "en/Tips_for_Authoring_Fast-loading_HTML_Pages", "ja": "ja/Tips_for_Authoring_Fast-loading_HTML_Pages", "pl": "pl/Porady_odno\u015bnie_tworzenia_szybko_\u0142aduj\u0105cych_si\u0119_stron_HTML" } ) }}</p>

--- a/files/zh-cn/mdn/contribute/getting_started/index.html
+++ b/files/zh-cn/mdn/contribute/getting_started/index.html
@@ -8,7 +8,7 @@ tags:
   - 初学者
 translation_of: MDN/Contribute/Getting_started
 ---
-<div>{{MDNSidebar}}{{IncludeSubnav("/zh-CN/docs/MDN")}}</div>
+<div>{{MDNSidebar}}</div>
 
 <p id="What_is_MDN.3F"><span class="seoSummary">我们是一个开放包容的开发者社区群体，目标是为更美好的互联网提供资源，无关浏览器或平台。任何人都可以参与到我们中来，你的每一分贡献都会让我们更强大。与我们一起，持续推动互联网技术向更伟大的方向革新——就在这里，与你一起。</span></p>
 

--- a/files/zh-cn/mdn/contribute/howto/write_for_seo/index.html
+++ b/files/zh-cn/mdn/contribute/howto/write_for_seo/index.html
@@ -11,7 +11,7 @@ tags:
   - 搜索引擎优化
 translation_of: MDN/Contribute/Howto/Write_for_SEO
 ---
-<div>{{MDNSidebar}}</div><div>{{IncludeSubnav("/zh-CN/docs/MDN")}}{{draft("为了更好的将MDN的文档符合SEO要求，我们在此提供了一些提升MDN搜索引擎优化的技术建议。本文是由MDN的志愿者们整理翻译完成的。 ")}}</div>
+<div>{{MDNSidebar}}</div><div>{{draft("为了更好的将MDN的文档符合SEO要求，我们在此提供了一些提升MDN搜索引擎优化的技术建议。本文是由MDN的志愿者们整理翻译完成的。")}}</div>
 
 <p><span class="seoSummary">本指南涵盖了我们对内容的基础要求、推荐和实践参考，以确保搜索引擎可以更好的对我们的内容进行分类和索引，同时确保用户可以轻松地获取到所需的内容。</span></p>
 

--- a/files/zh-cn/mdn/contribute/index.html
+++ b/files/zh-cn/mdn/contribute/index.html
@@ -7,7 +7,7 @@ tags:
   - MDN Meta
 translation_of: MDN/Contribute
 ---
-<div>{{MDNSidebar}}</div><div>{{IncludeSubnav("/zh-CN/docs/MDN")}}</div>
+<div>{{MDNSidebar}}</div>
 
 <p>欢迎！当你来到了这里，说明你已经迈出了成为 MDN 贡献者的第一步！</p>
 

--- a/files/zh-cn/mdn/guidelines/does_this_belong_on_mdn/index.html
+++ b/files/zh-cn/mdn/guidelines/does_this_belong_on_mdn/index.html
@@ -4,7 +4,7 @@ slug: MDN/Guidelines/Does_this_belong_on_MDN
 translation_of: MDN/Guidelines/Does_this_belong_on_MDN
 original_slug: MDN/Guidelines/Rules_Of_MDN_Documenting
 ---
-<div>{{MDNSidebar}}</div><div>{{IncludeSubnav("/zh-CN/docs/MDN")}}</div>
+<div>{{MDNSidebar}}</div>
 
 <p><span class="seoSummary">如果你正准备记录什么信息，你可能想知道是否要将这些信息放入MDN。 更进一步地，你可能想在你的源代码中维护文档，并将文档写入</span><a href="https://wiki.mozilla.org/">Mozilla wiki</a>，或者写入某Git仓库的readme文件中。<span class="seoSummary"> 本文的目的是帮助你确认你的内容是否适合MDN。</span></p>
 

--- a/files/zh-cn/mdn/guidelines/index.html
+++ b/files/zh-cn/mdn/guidelines/index.html
@@ -9,7 +9,7 @@ tags:
   - TopicStub
 translation_of: MDN/Guidelines
 ---
-<div>{{MDNSidebar}}</div><div>{{IncludeSubnav("/zh-CN/docs/MDN")}}</div>
+<div>{{MDNSidebar}}</div>
 
 <p><span class="seoSummary">代码示例与其它内容应当被表示为适当的形式，这些指南提供了 MDN 文档应当如何被编写并被格式化的规范，以及我们的代码示例与其它内容应当如何被表示的详情说明。</span>你可以通过遵循这些指南来确保自己编写的内容是清晰易用的。</p>
 

--- a/files/zh-cn/mdn/guidelines/writing_style_guide/index.html
+++ b/files/zh-cn/mdn/guidelines/writing_style_guide/index.html
@@ -16,8 +16,6 @@ original_slug: MDN/Guidelines/Style_guide
 ---
 <div>{{MDNSidebar}}</div>
 
-<p>{{IncludeSubnav("/zh-CN/docs/MDN")}}</p>
-
 <p><span class="seoSummary">为了提供更加组织化、标准化且易于阅读的文档，MDN Web 文档写作规范明确了文本的组织方式、拼写规则、固定格式等内容，不过这些内容只是指导性的而不是严格的规定，</span>因为比起格式我们对内容更感兴趣，所以没有必要在参与贡献之前强迫自己学习本规范。但是如果有一位勤劳的志愿者在之后编辑了你的文档使它更加符合本规范，也请不要感到惊讶或难过。</p>
 
 <p>如果你正在寻找一个特定类型的页面应该如何构建的相关细节，请参阅<a href="/zh-CN/docs/MDN/Contribute/Content/Layout" title="MDN页面布局指南">MDN Web 文档页面布局规范</a>。</p>

--- a/files/zh-cn/mdn/structures/compatibility_tables/index.html
+++ b/files/zh-cn/mdn/structures/compatibility_tables/index.html
@@ -10,8 +10,6 @@ translation_of: MDN/Structures/Compatibility_tables
 ---
 <div>{{MDNSidebar}}</div>
 
-<div>{{IncludeSubnav("/zh-CN/docs/MDN")}}</div>
-
 <p class="summary"><span class="seoSummary">MDN 为我们的开放网页文档提供了兼容性表格的标准格式; 它是对比所有浏览器之间，包含 DOM，HTML，CSS，JavaScript，SVG 等技术的文档。</span>本文将介绍如何使用我们的功能将兼容性数据添加到MDN页面。</p>
 
 <div class="warning syntaxbox">

--- a/files/zh-cn/mdn/structures/index.html
+++ b/files/zh-cn/mdn/structures/index.html
@@ -11,8 +11,6 @@ translation_of: MDN/Structures
 ---
 <div>{{MDNSidebar}}</div>
 
-<div>{{IncludeSubnav("/zh-CN/docs/MDN")}}</div>
-
 <p>在MDN里有各式各样的重复使用的文档结构，来使MDN文章中的内容有一致性的表现。这里的文章描述了这些结构。因此作为一名MDN的作者，你可以确认、应用并修改成适合于你写、编辑或翻译的文档。</p>
 
 <p>{{LandingPageListSubPages()}}</p>

--- a/files/zh-cn/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.html
+++ b/files/zh-cn/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.html
@@ -43,9 +43,9 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_set
 
 <ul>
  <li><code>id</code>即<a href="https://developer.mozilla.org/zh-CN/Add-ons/Install_Manifests#id">extension ID</a>。从Firefox 48起为可选项，在此之前为强制必须项。参看<a href="/zh-CN/docs/Mozilla/Add-ons/WebExtensions/WebExtensions_and_the_Add-on_ID">WebExtensions and the Add-on ID</a>来确认何时需要定义附加组件ID。</li>
- <li><code>strict_min_version</code>: Gecko所能支持的最小版本号。不允许使用"*"来定义版本号。默认值为 "42a1"。{{gecko_minversion_inline("45")}}</li>
- <li><code>strict_max_version</code>: Gecko所能支持的最大版本号。如果安装或运行附加组件的Firefox版本号高于这个最大版本号，附加组件将不能运行或不允许被安装。默认值为"*"，意思为不对最大版本号做检查。{{gecko_minversion_inline("45")}}</li>
- <li><code>update_url</code>为链接到<a href="/zh-CN/Add-ons/Updates">add-on update manifest</a>的链接。注意链接必须以"https"开头。这是为了使你自己就能够管理附加组件的更新(如不通过AMO)。{{gecko_minversion_inline("45")}}</li>
+ <li><code>strict_min_version</code>: Gecko所能支持的最小版本号。不允许使用"*"来定义版本号。默认值为 "42a1"。</li>
+ <li><code>strict_max_version</code>: Gecko所能支持的最大版本号。如果安装或运行附加组件的Firefox版本号高于这个最大版本号，附加组件将不能运行或不允许被安装。默认值为"*"，意思为不对最大版本号做检查。</li>
+ <li><code>update_url</code>为链接到<a href="/zh-CN/Add-ons/Updates">add-on update manifest</a>的链接。注意链接必须以"https"开头。这是为了使你自己就能够管理附加组件的更新(如不通过AMO)。</li>
 </ul>
 
 <h2 id="Chrome不兼容性">Chrome不兼容性</h2>

--- a/files/zh-cn/mozilla/firefox/releases/3/index.html
+++ b/files/zh-cn/mozilla/firefox/releases/3/index.html
@@ -307,4 +307,3 @@ translation_of: Mozilla/Firefox/Releases/3
  <li><a href="/cn/Firefox_2_for_developers" title="cn/Firefox_2_for_developers">Firefox 2 for developers</a></li>
  <li><a href="/cn/Firefox_1.5_for_developers" title="cn/Firefox_1.5_for_developers">Firefox 1.5 for developers</a></li>
 </ul>
-<p>{{ languages( { "es": "es/Firefox_3_para_desarrolladores", "fr": "fr/Firefox_3_pour_les_d\u00e9veloppeurs", "ja": "ja/Firefox_3_for_developers", "zh-tw": "zh_tw/Firefox_3_for_developers", "zh-cn": "cn/Firefox_3_for_developers", "ko": "ko/Firefox_3_for_developers", "pl": "pl/Firefox_3_dla_programist\u00f3w", "pt": "pt/Firefox_3_para_desenvolvedores" } ) }}</p>

--- a/files/zh-cn/tools/3d_view/index.html
+++ b/files/zh-cn/tools/3d_view/index.html
@@ -97,5 +97,3 @@ original_slug: Tools/Page_Inspector/3D_view
  <li><a href="/zh-cn/Tools" title="Tools">Tools</a></li>
  <li><a class="external" href="http://hacks.mozilla.org/2011/12/new-developer-tools-in-firefox-11-aurora/">New Developer Tools in Firefox 11 Aurora</a> (blog post)</li>
 </ul>
-
-<p>{{ languages( { "ja": "ja/Tools/Page_Inspector/3D_view", "en": "en/Tools/Page_Inspector/3D_view"} ) }}</p>

--- a/files/zh-cn/tools/style_editor/index.html
+++ b/files/zh-cn/tools/style_editor/index.html
@@ -111,9 +111,7 @@ translation_of: Tools/Style_Editor
 
 <p>{{ Page ("zh-CN/docs/tools/Keyboard_shortcuts", "source-editor") }}</p>
 
-<p>{{ languages( { "zh": "zh-CN/Tools/Style_Editor"} ) }}</p>
-
-<h2 id="Subnav">Subnav </h2>
+<h2 id="Subnav">Subnav</h2>
 
 <ol>
  <li><a href="#">Creating</a>

--- a/files/zh-cn/tools/web_console/helpers/index.html
+++ b/files/zh-cn/tools/web_console/helpers/index.html
@@ -30,10 +30,10 @@ translation_of: Tools/Web_Console/Helpers
  <dd>清除控制台输出区域。</dd>
  <dt><code>clearHistory()</code></dt>
  <dd>就像一个普通的命令行一样，控制台命令行记住你曾经输入的命令（<a href="/zh-CN/docs/Tools/Web_Console#Command_history">remembers the commands you've typed</a>）。使用该函数来清除控制台的键入命令历史记录。</dd>
- <dt> <code>copy()</code></dt>
+ <dt><code>copy()</code></dt>
  <dd>将其中的参数部分复制到剪贴板。如果参数是一个字符串，则复制它的字面内容。如果参数是一个DOM节点，则复制它的 <code><a href="/zh-CN/docs/Web/API/Element/outerHTML">outerHTML</a></code> 。否则，就针对该参数调用 <code><a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify">JSON.stringify </a></code>方法，然后将结果复制到剪贴板。</dd>
  <dt><code>help()</code> {{Deprecated_Inline(62)}}</dt>
- <dt><code>:help</code> {{Gecko_MinVersion_Inline(62)}}</dt>
+ <dt><code>:help</code></dt>
  <dd>显示帮助文本。事实上，在经过一个令人愉快的递归后，会把你带到这个页面。</dd>
  <dt><code>inspect()</code></dt>
  <dd>提供一个对象，为它生成一份 <a href="/zh-CN/docs/Tools/Web_Console/Rich_output">rich output</a>。一旦选择了输出区域中的对象，就可以使用键盘上的箭头按键来浏览对象详情。</dd>

--- a/files/zh-cn/web/api/animation/starttime/index.html
+++ b/files/zh-cn/web/api/animation/starttime/index.html
@@ -19,4 +19,3 @@ original_slug: Web/API/Window/mozAnimationStartTIme
  <li>{{ domxref("window.requestAnimationFrame()") }}</li>
  <li>{{ domxref("window.onmozbeforepaint") }}</li>
 </ul>
-<p>{{ languages( { "en":"en/DOM/window.mozAnimationStartTime" } ) }}</p>

--- a/files/zh-cn/web/api/animation/starttime/index.html
+++ b/files/zh-cn/web/api/animation/starttime/index.html
@@ -5,7 +5,7 @@ translation_of: Web/API/Window/mozAnimationStartTime
 original_slug: Web/API/Window/mozAnimationStartTIme
 ---
 <p>{{ ApiRef() }}</p>
-<p>{{ gecko_minversion_header("2.0") }}{{ non-standard_header() }}</p>
+<p>{{ non-standard_header() }}</p>
 <h3 id="Summary" name="Summary">概述</h3>
 <p>Returns the time, in milliseconds since the epoch, at which animations started now should be considered to have started. This value should be used instead of, for example, <code><a href="/zh-cn/JavaScript/Reference/Global_Objects/Date/now" title="zh-cn/JavaScript/Reference/Global Objects/Date/now">Date.now()</a></code>, because this value will be the same for all animations started in this window during this refresh interval, allowing them to remain in sync with one another.</p>
 <p>This also allows JavaScript-based animations to remain synchronized with CSS transitions and SMIL animations triggered during the same refresh interval.</p>

--- a/files/zh-cn/web/api/attr/namespaceuri/index.html
+++ b/files/zh-cn/web/api/attr/namespaceuri/index.html
@@ -30,7 +30,7 @@ translation_of: Web/API/Attr/namespaceURI
  属性的命名空间URI在属性创建时被冻结。</p>
 
 <p>在Firefox 3.5及更早版本中，HTML文档中HTML属性的命名空间URI为null。<br>
- 在后来的版本中，遵照HTML5，就像在XHTML中一样是<code><a class="external" href="https://www.w3.org/1999/xhtml" rel="freelink">https://www.w3.org/1999/xhtml</a></code>{{gecko_minversion_inline("1.9.2")}}</p>
+ 在后来的版本中，遵照HTML5，就像在XHTML中一样是<code><a class="external" href="https://www.w3.org/1999/xhtml" rel="freelink">https://www.w3.org/1999/xhtml</a></code></p>
 
 <p>您可以使用DOM Level 2方法 {{domxref("Element.setAttributeNS")}}创建具有指定namespaceURI的属性。</p>
 

--- a/files/zh-cn/web/api/blob/size/index.html
+++ b/files/zh-cn/web/api/blob/size/index.html
@@ -15,4 +15,3 @@ for (var i = 0; i &lt; files.length; i++)
     alert(files[i].name + "文件的大小为 " + files[i].size + " 字节");
 }
 </pre>
-<p>{{ languages( {"en": "en/DOM/File.size" } ) }}</p>

--- a/files/zh-cn/web/api/canvas_api/a_basic_ray-caster/index.html
+++ b/files/zh-cn/web/api/canvas_api/a_basic_ray-caster/index.html
@@ -54,5 +54,3 @@ translation_of: Web/API/Canvas_API/A_basic_ray-caster
  <li><a class="external" href="http://developer.apple.com/documentation/AppleApplications/Reference/SafariJSRef/Classes/Canvas.html">苹果Canvas文档</a></li>
  <li><a class="external" href="http://www.whatwg.org/specs/web-apps/current-work/#dynamic">WhatWG Canvas Specification</a></li>
 </ul>
-
-<p>{{ languages( { "fr": "fr/Un_raycaster_basique", "ja": "ja/A_Basic_RayCaster", "pl": "pl/Prosty_RayCaster" } ) }}</p>

--- a/files/zh-cn/web/api/canvasrenderingcontext2d/index.html
+++ b/files/zh-cn/web/api/canvasrenderingcontext2d/index.html
@@ -377,17 +377,17 @@ ctx.stroke();</pre>
 
 <dl>
  <dt>{{non-standard_inline}} <code>CanvasRenderingContext2D.mozCurrentTransform</code></dt>
- <dd>设置或获取当前的变换矩阵， 参见{{domxref("CanvasRenderingContext2D.currentTransform")}}.  {{ gecko_minversion_inline("7.0") }}</dd>
+ <dd>设置或获取当前的变换矩阵， 参见{{domxref("CanvasRenderingContext2D.currentTransform")}}.</dd>
  <dt>{{non-standard_inline}} <code>CanvasRenderingContext2D.mozCurrentTransformInverse</code></dt>
- <dd>设置或获取当前翻转的变换矩阵。  {{ gecko_minversion_inline("7.0") }}</dd>
+ <dd>设置或获取当前翻转的变换矩阵。</dd>
  <dt>{{non-standard_inline}} <code>CanvasRenderingContext2D.mozFillRule</code></dt>
  <dd>应用的 <a class="external external-icon" href="http://cairographics.org/manual/cairo-cairo-t.html#cairo-fill-rule-t" title="http://cairographics.org/manual/cairo-cairo-t.html#cairo-fill-rule-t">填充规则</a> 。 必须是 <code>evenodd</code> 或者 <code>nonzero</code> (默认)。</dd>
  <dt>{{non-standard_inline}} <code>CanvasRenderingContext2D.mozImageSmoothingEnabled</code></dt>
  <dd>参见 {{domxref("CanvasRenderingContext2D.imageSmoothingEnabled")}}.</dd>
  <dt>{{non-standard_inline}} {{deprecated_inline}} <code>CanvasRenderingContext2D.mozDash</code></dt>
- <dd>描述相互交替的线段和间距长度的数组 {{ gecko_minversion_inline("7.0") }}。 使用 {{domxref("CanvasRenderingContext2D.getLineDash()")}} 和 {{domxref("CanvasRenderingContext2D.setLineDash()")}} 替代。</dd>
+ <dd>描述相互交替的线段和间距长度的数组。 使用 {{domxref("CanvasRenderingContext2D.getLineDash()")}} 和 {{domxref("CanvasRenderingContext2D.setLineDash()")}} 替代。</dd>
  <dt>{{non-standard_inline}} {{deprecated_inline}} <code>CanvasRenderingContext2D.mozDashOffset</code></dt>
- <dd>描述线段数组在线上从哪里开始。 {{ gecko_minversion_inline("7.0") }}。 使用 {{domxref("CanvasRenderingContext2D.lineDashOffset")}} 替代。</dd>
+ <dd>描述线段数组在线上从哪里开始。使用 {{domxref("CanvasRenderingContext2D.lineDashOffset")}} 替代。</dd>
  <dt>{{non-standard_inline}} {{deprecated_inline}} <code>CanvasRenderingContext2D.mozTextStyle</code></dt>
  <dd>在 Gecko 1.9 中引入， 不赞成使用的 {{domxref("CanvasRenderingContext2D.font")}} 属性。</dd>
  <dt>{{non-standard_inline}} {{obsolete_inline}} <code>CanvasRenderingContext2D.mozDrawText()</code></dt>

--- a/files/zh-cn/web/api/console/group/index.html
+++ b/files/zh-cn/web/api/console/group/index.html
@@ -22,4 +22,3 @@ translation_of: Web/API/Console/group
 <ul>
  <li><a class="external" href="http://www.opera.com/dragonfly/documentation/console/">Opera Dragonfly documentation: Console</a></li>
 </ul>
-<p>{{ languages( {"en": "en/DOM/console.group" } ) }}</p>

--- a/files/zh-cn/web/api/console/groupcollapsed/index.html
+++ b/files/zh-cn/web/api/console/groupcollapsed/index.html
@@ -22,4 +22,3 @@ translation_of: Web/API/Console/groupCollapsed
 <ul>
  <li><a class="external" href="http://www.opera.com/dragonfly/documentation/console/">Opera Dragonfly documentation: Console</a></li>
 </ul>
-<p>{{ languages( { "en": "en/DOM/console.groupCollapsed" } ) }}</p>

--- a/files/zh-cn/web/api/console/log/index.html
+++ b/files/zh-cn/web/api/console/log/index.html
@@ -45,5 +45,3 @@ console.log(`temp的值为: ${temp}`)
  <li><a class="external" href="http://msdn.microsoft.com/library/gg589530">MSDN: Using the F12 Tools Console to View Errors and Status</a></li>
  <li><a href="http://nodejs.org/docs/latest/api/console.html#console_console_log_data">NodeJS: Console API</a></li>
 </ul>
-
-<p>{{ languages( {"en": "en/DOM/console.log" } ) }}</p>

--- a/files/zh-cn/web/api/cssstylerule/style/index.html
+++ b/files/zh-cn/web/api/cssstylerule/style/index.html
@@ -36,8 +36,6 @@ translation_of: Web/API/CSSStyleRule/style
 
 <p><a class="external" href="http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleRule-style">DOM Level 2 CSS: style</a></p>
 
-<p>{{ languages( {"en": "en/DOM/CSSStyleRule/style" } ) }}</p>
-
 <h3 id="Specification" name="Specification">浏览器兼容性</h3>
 
 <p>{{Compat("api.CSSStyleRule.style")}}</p>

--- a/files/zh-cn/web/api/document/afterscriptexecute_event/index.html
+++ b/files/zh-cn/web/api/document/afterscriptexecute_event/index.html
@@ -7,7 +7,7 @@ tags:
 translation_of: Web/API/Document/onafterscriptexecute
 original_slug: Web/API/Document/onafterscriptexecute
 ---
-<div>{{ApiRef}}{{gecko_minversion_header("2")}}</div>
+<div>{{ApiRef}}</div>
 
 <h2 id="概述">概述</h2>
 

--- a/files/zh-cn/web/api/document/anchors/index.html
+++ b/files/zh-cn/web/api/document/anchors/index.html
@@ -82,5 +82,3 @@ translation_of: Web/API/Document/anchors
 <h3 id="Specification" name="Specification">规范</h3>
 
 <p><a class="external" href="http://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-7577272">DOM Level 2 HTML: anchors</a></p>
-
-<p>{{ languages( { "es": "es/DOM/document.anchors", "pl": "pl/DOM/document.anchors", "ja": "ja/DOM/document.anchors" , "en": "en/DOM/document.anchors" } ) }}</p>

--- a/files/zh-cn/web/api/document/applets/index.html
+++ b/files/zh-cn/web/api/document/applets/index.html
@@ -14,4 +14,3 @@ translation_of: Web/API/Document/applets
 </pre>
 <h3 id="Specification" name="Specification">规范</h3>
 <p><a class="external" href="http://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-85113862">DOM Level 2 HTML: applets</a></p>
-<p>{{ languages( { "es": "es/DOM/document.applets", "pl": "pl/DOM/document.applets", "en": "en/DOM/document.applets" } ) }}</p>

--- a/files/zh-cn/web/api/document/beforescriptexecute_event/index.html
+++ b/files/zh-cn/web/api/document/beforescriptexecute_event/index.html
@@ -7,7 +7,7 @@ tags:
 translation_of: Web/API/Document/onbeforescriptexecute
 original_slug: Web/API/Document/onbeforescriptexecute
 ---
-<div>{{ApiRef}}{{gecko_minversion_header("2")}}</div>
+<div>{{ApiRef}}</div>
 
 <h2 id="概述">概述</h2>
 

--- a/files/zh-cn/web/api/document/contenttype/index.html
+++ b/files/zh-cn/web/api/document/contenttype/index.html
@@ -14,4 +14,3 @@ translation_of: Web/API/Document/contentType
 <p>该属性的返回值是浏览器检测到的,不一定是直接读取HTTP响应头中的或者HTML中meta标签指定的值.</p>
 <h3 id="Specification" name="Specification">规范</h3>
 <p>非标准属性,仅<a href="/zh-cn/Gecko" title="zh-cn/Gecko">Gecko</a>支持.</p>
-<p>{{ languages( {"en": "en/DOM/document.contentType" } ) }}</p>

--- a/files/zh-cn/web/api/document/createcomment/index.html
+++ b/files/zh-cn/web/api/document/createcomment/index.html
@@ -30,4 +30,3 @@ alert(new XMLSerializer().serializeToString(docu));
 </ul>
 <h3 id="Specification" name="Specification">规范</h3>
 <p><a class="external" href="http://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#method-createComment">createComment</a></p>
-<p>{{ languages( {"en": "en/DOM/document.createComment" } ) }}</p>

--- a/files/zh-cn/web/api/document/createevent/index.html
+++ b/files/zh-cn/web/api/document/createevent/index.html
@@ -116,7 +116,7 @@ elem.dispatchEvent(event);
    <td><a href="/en-US/docs/DOM/event.initKeyEvent" title="DOM/event.initKeyEvent">event.initKeyEvent</a> (Gecko-specific; the DOM 3 Events working draft uses <code>initKeyboardEvent</code> instead)</td>
   </tr>
   <tr>
-   <td>Custom event module {{gecko_minversion_inline("6.0")}}</td>
+   <td>Custom event module</td>
    <td><code>"CustomEvent"</code></td>
    <td><a href="/en-US/docs/DOM/CustomEvent" title="DOM/event.initKeyEvent">event.initCustomEvent</a></td>
   </tr>
@@ -142,7 +142,7 @@ elem.dispatchEvent(event);
   </tr>
   <tr>
    <td rowspan="4">-</td>
-   <td><code>"MessageEvent"{{Gecko_minversion_inline(1.9)}}</code></td>
+   <td><code>"MessageEvent"</code></td>
    <td><a href="/en-US/docs/DOM/event.initMessageEvent" title="DOM/event.initMessageEvent">event.initMessageEvent</a></td>
   </tr>
   <tr>

--- a/files/zh-cn/web/api/document/createexpression/index.html
+++ b/files/zh-cn/web/api/document/createexpression/index.html
@@ -16,4 +16,3 @@ translation_of: Web/API/Document/createExpression
 <p>{{ Fx_minversion_note("3") }}</p>
 <h3 id="Return" name="Return">返回值</h3>
 <p><a href="/zh-cn/XPathExpression" title="zh-cn/XPathExpression">XPathExpression</a></p>
-<p>{{ languages( {"en": "en/DOM/document.createExpression" } ) }}</p>

--- a/files/zh-cn/web/api/document/defaultview/index.html
+++ b/files/zh-cn/web/api/document/defaultview/index.html
@@ -29,5 +29,3 @@ translation_of: Web/API/Document/defaultView
  <li><a class="external" href="http://www.w3.org/TR/DOM-Level-2-Views/views.html#Views-DocumentView-defaultView">DOM Level 2 Views: defaultView</a></li>
  <li><a class="external" href="http://www.w3.org/TR/DOM-Level-3-Views/">DOM Level 3 Views</a> (Only developed to Working Group Note and not implemented)</li>
 </ul>
-
-<p>{{ languages( {"pl": "pl/DOM/document.defaultView","en": "en/DOM/document.defaultView" } ) }}</p>

--- a/files/zh-cn/web/api/document/documenturiobject/index.html
+++ b/files/zh-cn/web/api/document/documenturiobject/index.html
@@ -23,4 +23,3 @@ if (uriObj.schemeIs('http')) {
 </pre>
 <h3 id="Specification" name="Specification">规范</h3>
 <p>不属于任何公开的规范.</p>
-<p>{{ languages( { "es": "es/DOM/document.documentURIObject", "fr": "fr/DOM/document.documentURIObject", "ja": "ja/DOM/document.documentURIObject", "en": "en/DOM/document.documentURIObject" } ) }}</p>

--- a/files/zh-cn/web/api/document/forms/index.html
+++ b/files/zh-cn/web/api/document/forms/index.html
@@ -57,5 +57,3 @@ var selectFormElement = document.forms[index].elements[index];
 <ul>
  <li><a href="/zh-cn/DOM/HTMLFormElement" title="zh-cn/DOM/form">DOM:form</a></li>
 </ul>
-
-<p>{{ languages( { "ja": "ja/DOM/document.forms", "pl": "pl/DOM/document.forms" , "en": "en/DOM/document.forms" } ) }}</p>

--- a/files/zh-cn/web/api/document/index.html
+++ b/files/zh-cn/web/api/document/index.html
@@ -264,7 +264,7 @@ translation_of: Web/API/Document
  <dd>Returns a clone of a node from an external document.</dd>
  <dt>{{DOMxRef("Document.normalizeDocument()")}} {{Obsolete_Inline}}</dt>
  <dd>Replaces entities, normalizes text nodes, etc.</dd>
- <dt>{{DOMxRef("Document.releaseCapture()")}} {{Non-standard_Inline}} {{gecko_minversion_inline("2.0")}}</dt>
+ <dt>{{DOMxRef("Document.releaseCapture()")}} {{Non-standard_Inline}}</dt>
  <dd>Releases the current mouse capture if it's on an element in this document.</dd>
  <dt>{{DOMxRef("Document.releaseEvents()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}</dt>
  <dd>详见 {{DOMxRef("Window.releaseEvents()")}}。</dd>

--- a/files/zh-cn/web/api/document/laststylesheetset/index.html
+++ b/files/zh-cn/web/api/document/laststylesheetset/index.html
@@ -10,7 +10,7 @@ tags:
   - 文档
 translation_of: Web/API/Document/lastStyleSheetSet
 ---
-<div>{{APIRef("DOM")}}{{gecko_minversion_header("1.9")}}{{obsolete_header}}</div>
+<div>{{APIRef("DOM")}}{{obsolete_header}}</div>
 
 <p><strong><code>Document.lastStyleSheetSet</code></strong> 返回最后一个启用的样式表集合。当 {{domxref("document.selectedStyleSheetSet")}} 属性发生变化时，这个属性的值就会随之发生变化。</p>
 

--- a/files/zh-cn/web/api/document/preferredstylesheetset/index.html
+++ b/files/zh-cn/web/api/document/preferredstylesheetset/index.html
@@ -3,7 +3,7 @@ title: Document.preferredStyleSheetSet
 slug: Web/API/Document/preferredStyleSheetSet
 translation_of: Web/API/Document/preferredStyleSheetSet
 ---
-<div>{{APIRef("DOM")}}{{gecko_minversion_header("1.9")}}</div>
+<div>{{APIRef("DOM")}}</div>
 
 <p><strong><code>preferredStyleSheetSet</code></strong> 属性会依网页作者的喜好回传阶层样式集。</p>
 

--- a/files/zh-cn/web/api/document/queryselectorall/index.html
+++ b/files/zh-cn/web/api/document/queryselectorall/index.html
@@ -177,5 +177,3 @@ inner.length; // 0
  <li>{{domxref("ParentNode.querySelector()")}} and {{domxref("ParentNode.querySelectorAll()")}}</li>
  <li><a href="/en-US/docs/Code_snippets/QuerySelector" title="Code_snippets/QuerySelector">Code snippets for <code>querySelector()</code></a></li>
 </ul>
-
-<p>{{ languages( { "en": "en/DOM/Document.querySelectorAll"} ) }}</p>

--- a/files/zh-cn/web/api/document/readystate/index.html
+++ b/files/zh-cn/web/api/document/readystate/index.html
@@ -13,7 +13,7 @@ tags:
   - 属性
 translation_of: Web/API/Document/readyState
 ---
-<p>{{APIRef("DOM")}}{{ gecko_minversion_header("1.9.2") }}</p>
+<p>{{APIRef("DOM")}}</p>
 
 <p><strong><code>Document.readyState</code> </strong>属性描述了{{ domxref("document") }} 的加载状态。</p>
 

--- a/files/zh-cn/web/api/document/releasecapture/index.html
+++ b/files/zh-cn/web/api/document/releasecapture/index.html
@@ -3,7 +3,7 @@ title: document.releaseCapture
 slug: Web/API/Document/releaseCapture
 translation_of: Web/API/Document/releaseCapture
 ---
-<p>{{ ApiRef() }}{{ gecko_minversion_header("2.0") }}</p>
+<p>{{ ApiRef() }}</p>
 <h3 id="Summary" name="Summary">概述</h3>
 <p>如果该 document 中的一个元素之上当前启用了鼠标捕获，则释放鼠标捕获。通过调用 {{ domxref("element.setCapture()") }} 实现在一个元素上启用鼠标捕获。</p>
 <h3 id="Syntax" name="Syntax">语法</h3>

--- a/files/zh-cn/web/api/document/selectedstylesheetset/index.html
+++ b/files/zh-cn/web/api/document/selectedstylesheetset/index.html
@@ -3,7 +3,7 @@ title: Document.selectedStyleSheetSet
 slug: Web/API/Document/selectedStyleSheetSet
 translation_of: Web/API/Document/selectedStyleSheetSet
 ---
-<p>{{ APIRef("DOM") }}{{ gecko_minversion_header("1.9") }}</p>
+<p>{{ APIRef("DOM") }}</p>
 
 <p>表示当前使用的样式表集合的名称</p>
 

--- a/files/zh-cn/web/api/document/stylesheetsets/index.html
+++ b/files/zh-cn/web/api/document/stylesheetsets/index.html
@@ -5,7 +5,7 @@ tags:
   - Document.styleSheetSets
 translation_of: Web/API/Document/styleSheetSets
 ---
-<div>{{APIRef("DOM")}}{{gecko_minversion_header("1.9")}}</div>
+<div>{{APIRef("DOM")}}</div>
 
 <p>返回一个所有当前可用样式表集的实时列表。</p>
 

--- a/files/zh-cn/web/api/document/tooltipnode/index.html
+++ b/files/zh-cn/web/api/document/tooltipnode/index.html
@@ -11,4 +11,3 @@ translation_of: Web/API/Document/tooltipNode
 </pre>
 <h3 id="Specification" name="Specification">规范</h3>
 <p>只能在XUL中使用.不属于任何规范.定义在{{ Source("dom/public/idl/xul/nsIDOMXULDocument.idl#59", "nsIDOMXULDocument.idl") }}.</p>
-<p>{{ languages( {"zh-cn": "zh-cn/DOM/document.tooltipNode" } ) }}</p>

--- a/files/zh-cn/web/api/document/url/index.html
+++ b/files/zh-cn/web/api/document/url/index.html
@@ -14,4 +14,3 @@ translation_of: Web/API/Document/URL
 <p>{{ domxref("document.documentURI") }} 也返回与该属性相同的值,不过它在非HTML文档中也可以使用.</p>
 <h3 id="Specification" name="Specification">规范</h3>
 <p><a class="external" href="http://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-46183437">DOM Level 2 HTML: URL</a></p>
-<p>{{ languages( { "es": "es/DOM/document.URL", "ja": "ja/DOM/document.URL", "pl": "pl/DOM/document.URL", "en": "en/DOM/document.URL" } ) }}</p>

--- a/files/zh-cn/web/api/document/writeln/index.html
+++ b/files/zh-cn/web/api/document/writeln/index.html
@@ -22,4 +22,3 @@ translation_of: Web/API/Document/writeln
  <strong>Note:</strong> <strong>document.writeln</strong> (like <strong>document.write</strong>) does not work in XHTML documents (you'll get a "Operation is not supported" (<code>NS_ERROR_DOM_NOT_SUPPORTED_ERR</code>) error on the error console). This is the case if opening a local file with a .xhtml file extension or for any document served with an application/xhtml+xml MIME type. More information is available in the <a class="external" href="http://www.w3.org/MarkUp/2004/xhtml-faq#docwrite" title="http://www.w3.org/MarkUp/2004/xhtml-faq#docwrite">W3C XHTML FAQ</a>.</div>
 <h3 id="Specification" name="Specification">规范</h3>
 <p><a class="external" href="http://www.w3.org/TR/2000/WD-DOM-Level-2-HTML-20001113/html.html#ID-35318390">writeln </a></p>
-<p>{{ languages( { "ja": "ja/DOM/document.writeln", "pl": "pl/DOM/document.writeln" } ) }}</p>

--- a/files/zh-cn/web/api/document_object_model/how_to_create_a_dom_tree/index.html
+++ b/files/zh-cn/web/api/document_object_model/how_to_create_a_dom_tree/index.html
@@ -141,5 +141,3 @@ doc.appendChild(peopleElem);
  <li><a class="internal" href="/en/Parsing_and_serializing_XML" title="en/Parsing_and_serializing_XML">Parsing and serializing XML</a></li>
  <li><a class="internal" href="/en/DOM/XMLHttpRequest" title="en/XMLHttpRequest">XMLHttpRequest</a></li>
 </ul>
-
-<p>{{ languages( { "fr": "fr/Comment_cr\u00e9er_un_arbre_DOM", "ja": "ja/How_to_create_a_DOM_tree", "zh-cn": "zh-cn/How_to_create_a_DOM_tree" } ) }}</p>

--- a/files/zh-cn/web/api/document_object_model/locating_dom_elements_using_selectors/index.html
+++ b/files/zh-cn/web/api/document_object_model/locating_dom_elements_using_selectors/index.html
@@ -7,8 +7,6 @@ tags:
   - 使用选择器定位DOM元素
 translation_of: Web/API/Document_object_model/Locating_DOM_elements_using_selectors
 ---
-<div>{{ gecko_minversion_header("1.9.1") }}</div>
-
 <p>Selectors API提供了通过与一组选择器匹配来快速轻松地从DOM检索  <a href="https://developer.mozilla.org/en-US/docs/DOM/element" title="en-US/docs/DOM/Element"><code>Element</code></a>节点的方法。这比以前的技术要快得多，其中有必要使用JavaScript代码中的循环来定位您需要查找的特定项目。</p>
 
 <h2 id="NodeSelector_接口">NodeSelector 接口</h2>

--- a/files/zh-cn/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.html
+++ b/files/zh-cn/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.html
@@ -335,6 +335,3 @@ mybody.appendChild(currenttext);
 &lt;/script&gt;
 &lt;/html&gt;
 </pre>
-
-<div class="noinclude"></div>
-{{ languages( { "en": "en/Traversing_an_HTML_table_with_JavaScript_and_DOM_Interfaces", "fr": "fr/Explorer_un_tableau_HTML_avec_des_interfaces_DOM_et_JavaScript", "ja": "ja/Traversing_an_HTML_table_with_JavaScript_and_DOM_Interfaces" } ) }}</div>

--- a/files/zh-cn/web/api/domimplementation/createhtmldocument/index.html
+++ b/files/zh-cn/web/api/domimplementation/createhtmldocument/index.html
@@ -88,5 +88,3 @@ translation_of: Web/API/DOMImplementation/createHTMLDocument
 <ul>
  <li><a class="external" href="http://www.whatwg.org/html/#dom-domhtmlimplementation-createhtmldocument" title="http://www.whatwg.org/html/#dom-domhtmlimplementation-createhtmldocument"><code>createHTMLDocument</code> specification</a></li>
 </ul>
-
-<p>{{ languages( { "en": "en/DOM/DOMImplementation.createHTMLDocument" } ) }}</p>

--- a/files/zh-cn/web/api/domtokenlist/index.html
+++ b/files/zh-cn/web/api/domtokenlist/index.html
@@ -9,7 +9,7 @@ tags:
   - Renference
 translation_of: Web/API/DOMTokenList
 ---
-<p>{{APIRef}}{{ gecko_minversion_header("1.9.2") }}</p>
+<p>{{APIRef}}</p>
 
 <p><code><strong>DOMTokenList</strong></code> 接口表示一组空格分隔的标记（tokens）。如由 {{ domxref("Element.classList") }}、{{domxref("HTMLLinkElement.relList")}}、{{domxref("HTMLAnchorElement.relList")}} 或 {{domxref("HTMLAreaElement.relList")}} 返回的一组值。它和 JavaScript {{jsxref("Array")}} 对象一样，索引从 0 开始。<code>DOMTokenList</code> 总是区分大小写（case-sensitive）。</p>
 

--- a/files/zh-cn/web/api/element/index.html
+++ b/files/zh-cn/web/api/element/index.html
@@ -51,7 +51,7 @@ translation_of: Web/API/Element
  <dt>{{DOMxRef("Element.namespaceURI")}} {{readonlyInline}}</dt>
  <dd>元素对应的 namespace URI ，如果没有则返回 <code>null</code>
  <div class="note">
- <p><strong>Note:</strong> In Firefox 3.5 and earlier, HTML elements are in no namespace. In later versions, HTML elements are in the <code><a class="linkification-ext external" href="http://www.w3.org/1999/xhtml">http://www.w3.org/1999/xhtml</a></code> namespace in both HTML and XML trees. {{ gecko_minversion_inline("1.9.2")}}</p>
+ <p><strong>Note:</strong> In Firefox 3.5 and earlier, HTML elements are in no namespace. In later versions, HTML elements are in the <code><a class="linkification-ext external" href="http://www.w3.org/1999/xhtml">http://www.w3.org/1999/xhtml</a></code> namespace in both HTML and XML trees.</p>
  </div>
  </dd>
  <dt>{{DOMxRef("NonDocumentTypeChildNode.nextElementSibling")}} {{readOnlyInline}}</dt>

--- a/files/zh-cn/web/api/element/matches/index.html
+++ b/files/zh-cn/web/api/element/matches/index.html
@@ -58,7 +58,7 @@ translation_of: Web/API/Element/matches
 <h2 id="异常">异常</h2>
 
 <dl>
- <dt><code>SYNTAX_ERR</code> {{ gecko_minversion_inline("2.0") }}</dt>
+ <dt><code>SYNTAX_ERR</code></dt>
  <dd>如果给定的css选择器无效. 在 Gecko 2.0之前,该方法会返回<code>false,2.0之后</code>,会直接抛出异常.</dd>
 </dl>
 

--- a/files/zh-cn/web/api/element/namespaceuri/index.html
+++ b/files/zh-cn/web/api/element/namespaceuri/index.html
@@ -28,7 +28,7 @@ translation_of: Web/API/Element/namespaceURI
 
 <p>这不是一个计算值，它是基于范围内的名称空间声明检查的名称空间查找的结果。节点命名空间在节点创建时被冻结。</p>
 
-<p>在Firefox 3.5 以及之前的版本， HTML文档中的HTML元素的名称空间URI为 <code>null</code>。 在更早的版本中, 符合HTML5， 它是<code><a class="external" href="http://www.w3.org/1999/xhtml" rel="freelink">http://www.w3.org/1999/xhtml</a></code> 如 XHTML。{{gecko_minversion_inline("1.9.2")}}</p>
+<p>在Firefox 3.5 以及之前的版本， HTML文档中的HTML元素的名称空间URI为 <code>null</code>。 在更早的版本中, 符合HTML5， 它是<code><a class="external" href="http://www.w3.org/1999/xhtml" rel="freelink">http://www.w3.org/1999/xhtml</a></code> 如 XHTML。</p>
 
 <p>您可以使用DOM Level 2方法指定的<code>namespaceURI</code>创建一个元素 <a href="/en-US/docs/Web/API/Document/createElementNS" title="Document.createElementNS">document.createElementNS</a>。</p>
 

--- a/files/zh-cn/web/api/element/nextelementsibling/index.html
+++ b/files/zh-cn/web/api/element/nextelementsibling/index.html
@@ -100,5 +100,3 @@ if(!("nextElementSibling" in document.documentElement)){
  <li><a class="internal" href="/zh-cn/DOM/Element.lastElementChild" title="zh-cn/DOM/Element.lastElementChild"><code>lastElementChild</code></a></li>
  <li><a class="internal" href="/zh-cn/DOM/Element.previousElementSibling" title="zh-cn/DOM/Element.previousElementSibling"><code>previousElementSibling</code></a></li>
 </ul>
-
-<p>{{ languages( {"en": "en/DOM/element.nextElementSibling" } ) }}</p>

--- a/files/zh-cn/web/api/element/nextelementsibling/index.html
+++ b/files/zh-cn/web/api/element/nextelementsibling/index.html
@@ -4,8 +4,6 @@ slug: Web/API/Element/nextElementSibling
 translation_of: Web/API/NonDocumentTypeChildNode/nextElementSibling
 original_slug: Web/API/NonDocumentTypeChildNode/nextElementSibling
 ---
-<p>{{ gecko_minversion_header("1.9.1") }}</p>
-
 <p>{{ ApiRef() }}</p>
 
 <h2 id="Summary" name="Summary">概述</h2>

--- a/files/zh-cn/web/api/element/setcapture/index.html
+++ b/files/zh-cn/web/api/element/setcapture/index.html
@@ -3,7 +3,7 @@ title: element.setCapture
 slug: Web/API/Element/setCapture
 translation_of: Web/API/Element/setCapture
 ---
-<p>{{ ApiRef() }}{{ gecko_minversion_header("2.0") }}</p>
+<p>{{ ApiRef() }}</p>
 
 <h3 id="Summary" name="Summary">概要</h3>
 

--- a/files/zh-cn/web/api/element/tagname/index.html
+++ b/files/zh-cn/web/api/element/tagname/index.html
@@ -28,4 +28,3 @@ alert(span.tagName);
  <li><a class="external" href="http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-104682815">DOM Level 2 Core: tagName</a></li>
  <li><a class="external" href="http://www.whatwg.org/specs/web-apps/current-work/multipage/dom.html#apis-in-html-documents">HTML 5: APIs in HTML documents</a></li>
 </ul>
-<p>{{ languages( { "es": "es/DOM/element.tagName", "fr": "fr/DOM/element.tagName", "ja": "ja/DOM/element.tagName", "pl": "pl/DOM/element.tagName","en": "en/DOM/element.tagName" } ) }}</p>

--- a/files/zh-cn/web/api/event/bubbles/index.html
+++ b/files/zh-cn/web/api/event/bubbles/index.html
@@ -24,4 +24,3 @@ translation_of: Web/API/Event/bubbles
 </pre>
 <h3 id="规范">规范</h3>
 <p><a class="external" href="http://dvcs.w3.org/hg/domcore/raw-file/tip/Overview.html#dom-event-bubbles" title="http://dvcs.w3.org/hg/domcore/raw-file/tip/Overview.html#dom-event-bubbles">event.bubbles</a></p>
-<p>{{ languages( { "es": "es/DOM/event.bubbles", "ja": "ja/DOM/event.bubbles", "pl": "pl/DOM/event.bubbles" , "zh-cn": "zh-cn/DOM/event.bubbles" } ) }}</p>

--- a/files/zh-cn/web/api/file/index.html
+++ b/files/zh-cn/web/api/file/index.html
@@ -33,7 +33,7 @@ translation_of: Web/API/File
 <dl>
  <dt>{{domxref("File.lastModified")}} {{readonlyinline}}</dt>
  <dd>返回当前 <code>File</code> 对象所引用文件最后修改时间，自 UNIX 时间起始值（1970年1月1日 00:00:00 UTC）以来的毫秒数。</dd>
- <dt>{{domxref("File.lastModifiedDate")}} {{readonlyinline}} {{deprecated_inline}} {{gecko_minversion_inline("15.0")}}</dt>
+ <dt>{{domxref("File.lastModifiedDate")}} {{readonlyinline}} {{deprecated_inline}}</dt>
  <dd>返回当前 <code>File</code> 对象所引用文件最后修改时间的 <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a></code> 对象。</dd>
  <dt>{{domxref("File.name")}} {{readonlyinline}}</dt>
  <dd>返回当前 <code>File</code> 对象所引用文件的名字。</dd>

--- a/files/zh-cn/web/api/fileerror/index.html
+++ b/files/zh-cn/web/api/fileerror/index.html
@@ -73,5 +73,3 @@ translation_of: Web/API/FileError
  <li>{{ domxref("Blob") }}</li>
  <li>{{ spec("http://www.w3.org/TR/FileAPI/#FileErrorInterface", "Specification: FileAPI FileError", "WD") }}</li>
 </ul>
-
-<p>{{ languages( {"en": "en/DOM/FileError" } ) }}</p>

--- a/files/zh-cn/web/api/filelist/index.html
+++ b/files/zh-cn/web/api/filelist/index.html
@@ -8,7 +8,7 @@ tags:
   - 文件
 translation_of: Web/API/FileList
 ---
-<div>{{APIRef("File API")}}{{gecko_minversion_header("1.9")}}</div>
+<div>{{APIRef("File API")}}</div>
 
 <p>一个 FileList 对象通常来自于一个 HTML {{HTMLElement("input")}} 元素的 <code>files</code> 属性，你可以通过这个对象访问到用户所选择的文件。该类型的对象还有可能来自用户的拖放操作，查看 <a href="/zh-CN/docs/DragDrop/DataTransfer" title="DragDrop/DataTransfer"><code>DataTransfer</code></a> 对象了解详情。</p>
 

--- a/files/zh-cn/web/api/filereader/index.html
+++ b/files/zh-cn/web/api/filereader/index.html
@@ -90,7 +90,7 @@ translation_of: Web/API/FileReader
 <dl>
  <dt>{{domxref("FileReader.abort()")}}</dt>
  <dd>中止读取操作。在返回时，<code>readyState</code>属性为<code>DONE</code>。</dd>
- <dt>{{domxref("FileReader.readAsArrayBuffer()")}} {{gecko_minversion_inline("7.0")}}</dt>
+ <dt>{{domxref("FileReader.readAsArrayBuffer()")}}</dt>
  <dd>开始读取指定的 {{domxref("Blob")}}中的内容, 一旦完成, result 属性中保存的将是被读取文件的 {{domxref("ArrayBuffer")}} 数据对象.</dd>
  <dt>{{domxref("FileReader.readAsBinaryString()")}} {{non-standard_inline}}</dt>
  <dd>开始读取指定的{{ domxref("Blob") }}中的内容。一旦完成，<code>result</code>属性中将包含所读取文件的原始二进制数据。</dd>

--- a/files/zh-cn/web/api/filereadersync/index.html
+++ b/files/zh-cn/web/api/filereadersync/index.html
@@ -17,16 +17,16 @@ translation_of: Web/API/FileReaderSync
 <table class="standard-table">
  <tbody>
   <tr>
-   <td><code>ArrayBuffer <a href="https://developer.mozilla.org/en/DOM/FileReaderSync#readAsArrayBuffer()" title="en/DOM/FileReaderSync#readAsArrayBuffer()">readAsArrayBuffer</a>(Blob blob);</code>{{ gecko_minversion_inline("8.0") }}</td>
+   <td><code>ArrayBuffer <a href="https://developer.mozilla.org/en/DOM/FileReaderSync#readAsArrayBuffer()" title="en/DOM/FileReaderSync#readAsArrayBuffer()">readAsArrayBuffer</a>(Blob blob);</code></td>
   </tr>
   <tr>
-   <td><code>DOMString <a href="/zh-cn/DOM/FileReaderSync#readAsBinaryString()" title="zh-cn/DOM/FileReaderSync#readAsBinaryString()">readAsBinaryString</a>(Blob blob);</code>{{ gecko_minversion_inline("8.0") }}</td>
+   <td><code>DOMString <a href="/zh-cn/DOM/FileReaderSync#readAsBinaryString()" title="zh-cn/DOM/FileReaderSync#readAsBinaryString()">readAsBinaryString</a>(Blob blob);</code></td>
   </tr>
   <tr>
-   <td><code>DOMString</code><code> </code><code><a href="/zh-cn/DOM/FileReaderSync#readAsText()" title="zh-cn/DOM/FileReaderSync#readAsText()">readAsText</a></code><code>(Blob blob, optional DOMString encoding);</code>{{ gecko_minversion_inline("8.0") }}</td>
+   <td><code>DOMString</code><code> </code><code><a href="/zh-cn/DOM/FileReaderSync#readAsText()" title="zh-cn/DOM/FileReaderSync#readAsText()">readAsText</a></code><code>(Blob blob, optional DOMString encoding);</code></td>
   </tr>
   <tr>
-   <td><code>DOMString <a href="/zh-cn/DOM/FileReaderSync#readAsDataURL()" title="zh-cn/DOM/FileReaderSync#readAsDataURL()">readAsDataURL</a>(Blob blob);</code>{{ gecko_minversion_inline("8.0") }}</td>
+   <td><code>DOMString <a href="/zh-cn/DOM/FileReaderSync#readAsDataURL()" title="zh-cn/DOM/FileReaderSync#readAsDataURL()">readAsDataURL</a>(Blob blob);</code></td>
   </tr>
  </tbody>
 </table>

--- a/files/zh-cn/web/api/globaleventhandlers/onblur/index.html
+++ b/files/zh-cn/web/api/globaleventhandlers/onblur/index.html
@@ -77,5 +77,3 @@ border: solid blue 2px;
 <h3 id="Specification" name="Specification">规范</h3>
 
 <p>DOM Level 0不属于任何规范.</p>
-
-<p>{{ languages( {"fr": "fr/DOM/element.onblur","en": "en/DOM/element.onblur" } ) }}</p>

--- a/files/zh-cn/web/api/globaleventhandlers/onchange/index.html
+++ b/files/zh-cn/web/api/globaleventhandlers/onchange/index.html
@@ -39,5 +39,3 @@ translation_of: Web/API/GlobalEventHandlers/onchange
 <h3 id="See_Also" name="See_Also">相关链接</h3>
 
 <p><a class="external" href="http://www.w3.org/TR/DOM-Level-2-Events/events.html#Events-eventgroupings-htmlevents">DOM Level 2: HTML event types</a></p>
-
-<p>{{ languages( { "fr": "fr/DOM/element.onchange" ,"en": "en/DOM/element.onchange" } ) }}</p>

--- a/files/zh-cn/web/api/globaleventhandlers/ondblclick/index.html
+++ b/files/zh-cn/web/api/globaleventhandlers/ondblclick/index.html
@@ -67,5 +67,3 @@ border: solid blue 2px;
 <h3 id="规范">规范</h3>
 
 <p>不属于任何公开的规范.</p>
-
-<p>{{ languages( { "fr": "fr/DOM/element.ondblclick","zh-cn": "zh-cn/DOM/element.ondblclick" } ) }}</p>

--- a/files/zh-cn/web/api/globaleventhandlers/onerror/index.html
+++ b/files/zh-cn/web/api/globaleventhandlers/onerror/index.html
@@ -37,8 +37,8 @@ translation_of: Web/API/GlobalEventHandlers/onerror
  <li><code>message</code>：错误信息（字符串）。可用于HTML <code>onerror=""</code>处理程序中的<code>event</code>。</li>
  <li><code>source</code>：发生错误的脚本URL（字符串）</li>
  <li><code>lineno</code>：发生错误的行号（数字）</li>
- <li><code>colno</code>：发生错误的列号（数字）{{gecko_minversion_inline("31.0")}}</li>
- <li><code>error</code>：<a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Error对象</a>（对象）{{gecko_minversion_inline("31.0")}}</li>
+ <li><code>colno</code>：发生错误的列号（数字）</li>
+ <li><code>error</code>：<a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Error对象</a>（对象）</li>
 </ul>
 
 <p>若该函数返回<code>true</code>，则阻止执行默认事件处理函数。</p>

--- a/files/zh-cn/web/api/globaleventhandlers/onfocus/index.html
+++ b/files/zh-cn/web/api/globaleventhandlers/onfocus/index.html
@@ -23,5 +23,3 @@ translation_of: Web/API/GlobalEventHandlers/onfocus
 <h3 id="规范">规范</h3>
 
 <p>不属于任何公开的规范.</p>
-
-<p>{{ languages( { "fr": "fr/DOM/element.onfocus","en": "en/DOM/element.onfocus" } ) }}</p>

--- a/files/zh-cn/web/api/globaleventhandlers/onkeydown/index.html
+++ b/files/zh-cn/web/api/globaleventhandlers/onkeydown/index.html
@@ -21,5 +21,3 @@ translation_of: Web/API/GlobalEventHandlers/onkeydown
 <h3 id="规范">规范</h3>
 
 <p>不属于任何公开的规范.</p>
-
-<p>{{ languages( { "fr": "fr/DOM/element.onkeydown", "pl": "pl/DOM/element.onkeydown", "en": "en/DOM/element.onkeydown" } ) }}</p>

--- a/files/zh-cn/web/api/globaleventhandlers/onkeyup/index.html
+++ b/files/zh-cn/web/api/globaleventhandlers/onkeyup/index.html
@@ -27,5 +27,3 @@ translation_of: Web/API/GlobalEventHandlers/onkeyup
 <h3 id="规范">规范</h3>
 
 <p>不属于任何公开的规范.</p>
-
-<p>{{ languages( { "fr": "fr/DOM/element.onkeyup", "pl": "pl/DOM/element.onkeyup", "en": "en/DOM/element.onkeyup" } ) }}</p>

--- a/files/zh-cn/web/api/globaleventhandlers/onmousedown/index.html
+++ b/files/zh-cn/web/api/globaleventhandlers/onmousedown/index.html
@@ -21,5 +21,3 @@ translation_of: Web/API/GlobalEventHandlers/onmousedown
 <h3 id="规范">规范</h3>
 
 <p>不属于任何公开的规范.</p>
-
-<p>{{ languages( { "fr": "fr/DOM/element.onmousedown", "pl": "pl/DOM/element.onmousedown", "en": "en/DOM/element.onmousedown" } ) }}</p>

--- a/files/zh-cn/web/api/globaleventhandlers/onmousemove/index.html
+++ b/files/zh-cn/web/api/globaleventhandlers/onmousemove/index.html
@@ -154,5 +154,3 @@ document.onmouseup = dragUp;
 <h3 id="规范">规范</h3>
 
 <p>不属于任何公开的规范.</p>
-
-<p>{{ languages( { "pl": "pl/DOM/element.onmousemove", "fr": "fr/DOM/element.onmousemove", "en": "en/DOM/element.onmousemove" } ) }}</p>

--- a/files/zh-cn/web/api/globaleventhandlers/onmouseout/index.html
+++ b/files/zh-cn/web/api/globaleventhandlers/onmouseout/index.html
@@ -63,5 +63,3 @@ translation_of: Web/API/GlobalEventHandlers/onmouseout
 <h3 id="规范">规范</h3>
 
 <p>DOM Level 0 不属于任何规范.</p>
-
-<p>{{ languages( {"fr": "fr/DOM/element.onmouseout","en": "en/DOM/element.onmouseout" } ) }}</p>

--- a/files/zh-cn/web/api/globaleventhandlers/onmouseover/index.html
+++ b/files/zh-cn/web/api/globaleventhandlers/onmouseover/index.html
@@ -62,5 +62,3 @@ translation_of: Web/API/GlobalEventHandlers/onmouseover
 <h3 id="规范">规范</h3>
 
 <p>DOM Level 0 不属于任何规范.</p>
-
-<p>{{ languages( { "pl": "pl/DOM/element.onmouseover", "fr": "fr/DOM/element.onmouseover" , "en": "en/DOM/element.onmouseover" } ) }}</p>

--- a/files/zh-cn/web/api/globaleventhandlers/onmouseup/index.html
+++ b/files/zh-cn/web/api/globaleventhandlers/onmouseup/index.html
@@ -21,5 +21,3 @@ translation_of: Web/API/GlobalEventHandlers/onmouseup
 <h3 id="规范">规范</h3>
 
 <p>不属于任何公开的规范.</p>
-
-<p>{{ languages( { "fr": "fr/DOM/element.onmouseup" ,"en": "en/DOM/element.onmouseup" } ) }}</p>

--- a/files/zh-cn/web/api/globaleventhandlers/onresize/index.html
+++ b/files/zh-cn/web/api/globaleventhandlers/onresize/index.html
@@ -67,5 +67,3 @@ function resize()
   </tr>
  </tbody>
 </table>
-
-<p>{{ languages( {"en": "en/DOM/window.onresize" } ) }}</p>

--- a/files/zh-cn/web/api/globaleventhandlers/onselect/index.html
+++ b/files/zh-cn/web/api/globaleventhandlers/onselect/index.html
@@ -55,5 +55,3 @@ function selectText()
 <h3 id="Specification" name="Specification">规范</h3>
 
 <p>不属于任何公开规范.</p>
-
-<p>{{ languages( {"en": "en/DOM/window.onselect" } ) }}</p>

--- a/files/zh-cn/web/api/hashchangeevent/index.html
+++ b/files/zh-cn/web/api/hashchangeevent/index.html
@@ -24,9 +24,9 @@ translation_of: Web/API/HashChangeEvent
 <p><em> 这个接口也从 {{domxref("Event")}} 中继承属性。</em></p>
 
 <dl>
- <dt>{{domxref("HashChangeEvent.newURL")}} {{readonlyInline}} {{gecko_minversion_inline("6.0")}}</dt>
+ <dt>{{domxref("HashChangeEvent.newURL")}} {{readonlyInline}}</dt>
  <dd>window即将导航到达的新 URL。</dd>
- <dt>{{domxref("HashChangeEvent.oldURL")}} {{readonlyInline}} {{gecko_minversion_inline("6.0")}}</dt>
+ <dt>{{domxref("HashChangeEvent.oldURL")}} {{readonlyInline}}</dt>
  <dd>window此前导航到达过的URL。</dd>
 </dl>
 

--- a/files/zh-cn/web/api/history/index.html
+++ b/files/zh-cn/web/api/history/index.html
@@ -14,9 +14,9 @@ translation_of: Web/API/History
 <dl>
  <dt>{{domxref("History.length")}} {{readOnlyInline}}</dt>
  <dd>返回一个整数，该整数表示会话历史中元素的数目，包括当前加载的页。例如，在一个新的选项卡加载的一个页面中，这个属性返回1。</dd>
- <dt>{{domxref("History.scrollRestoration")}} {{experimental_inline}}</dt>
+ <dt>{{domxref("History.scrollRestoration")}} {{experimental_inline}}</dt>
  <dd>允许Web应用程序在历史导航上显式地设置默认滚动恢复行为。此属性可以是自动的（auto）或者手动的（manual）。</dd>
- <dt>{{domxref("History.state")}} {{readOnlyInline}} {{ gecko_minversion_inline("2.0") }}</dt>
+ <dt>{{domxref("History.state")}} {{readOnlyInline}}</dt>
  <dd>返回一个表示历史堆栈顶部的状态的值。这是一种可以不必等待{{event("popstate")}} 事件而查看状态的方式。</dd>
 </dl>
 
@@ -27,19 +27,19 @@ translation_of: Web/API/History
 <dl>
  <dt>{{domxref("History.back()")}}</dt>
  <dd>在浏览器历史记录里前往上一页, 用户可点击浏览器左上角的返回(译者注：←)按钮模拟此方法. 等价于 <code>history.go(-1)</code>.
- <div class="note"><strong>Note:</strong> 当浏览器会话历史记录处于第一页时调用此方法没有效果，而且也不会报错。</div>
+ <div class="note"><strong>Note:</strong> 当浏览器会话历史记录处于第一页时调用此方法没有效果，而且也不会报错。</div>
  </dd>
  <dt>{{domxref("History.forward()")}}</dt>
  <dd>在浏览器历史记录里前往下一页，用户可点击浏览器左上角的前进(译者注：→)按钮模拟此方法. 等价于 <code>history.go(1)</code>.
- <div class="note"><strong>Note:</strong> 当浏览器历史栈处于最顶端时( 当前页面处于最后一页时 )调用此方法没有效果也不报错。</div>
+ <div class="note"><strong>Note:</strong> 当浏览器历史栈处于最顶端时( 当前页面处于最后一页时 )调用此方法没有效果也不报错。</div>
  </dd>
  <dt>{{domxref("History.go()")}}</dt>
  <dd>通过当前页面的相对位置从浏览器历史记录( 会话记录 )加载页面。比如：参数为-1的时候为上一页，参数为1的时候为下一页. 当整数参数超出界限时( 译者注:原文为When <code><em>integerDelta</em></code> is out of bounds )，例如: 如果当前页为第一页，前面已经没有页面了，我传参的值为-1，那么这个方法没有任何效果也不会报错。调用没有参数的 <code>go() </code>方法或者参数值为0时，重新载入当前页面。( 这点与支持字符串作为url参数的IE有点不同)。</dd>
- <dt>{{domxref("History.pushState()")}} {{ gecko_minversion_inline("2.0") }}</dt>
+ <dt>{{domxref("History.pushState()")}}</dt>
  <dd>按指定的名称和URL（如果提供该参数）将数据push进会话历史栈，数据被DOM进行不透明处理；你可以指定任何可以被序列化的javascript对象。注意到Firefox现在忽略了这个title参数，更多的信息，请看<a href="/zh-CN/docs/Web/API/History_API" title="en/DOM/Manipulating the browser history">manipulating the browser history</a>。
  <div class="note"><strong>Note:</strong> 在 Gecko 2.0 {{ geckoRelease("2.0") }} 到 Gecko 5.0 {{ geckoRelease("5.0") }}中， 被传递的对象使用JSON进行序列化. 从 Gecko 6.0 {{ geckoRelease("6.0") }}开始，使用<a href="/en/DOM/The_structured_clone_algorithm">结构化克隆算法</a>进行序列化。这样，就可以让更多类型的对象被安全地传输。</div>
  </dd>
- <dt>{{domxref("History.replaceState()")}} {{ gecko_minversion_inline("2.0") }}</dt>
+ <dt>{{domxref("History.replaceState()")}}</dt>
  <dd>按指定的数据，名称和URL(如果提供该参数)，更新历史栈上最新的入口。这个数据被DOM 进行了不透明处理。你可以指定任何可以被序列化的javascript对象。注意到Firefox现在忽略了这个title参数，更多的信息，请看<a href="/zh-CN/docs/Web/API/History_API" title="en/DOM/Manipulating the browser history">manipulating the browser history</a>。
  <div class="note"><strong>Note:</strong> 在 Gecko 2.0 {{ geckoRelease("2.0") }} 到 Gecko 5.0 {{ geckoRelease("5.0") }} 中, the passed object is serialized using JSON. Starting in Gecko 6.0 {{ geckoRelease("6.0") }}, the object is serialized using <a href="/en/DOM/The_structured_clone_algorithm" title="en/DOM/The structured clone algorithm">the structured clone algorithm</a>. This allows a wider variety of objects to be safely passed.</div>
  </dd>

--- a/files/zh-cn/web/api/history_api/index.html
+++ b/files/zh-cn/web/api/history_api/index.html
@@ -54,9 +54,7 @@ translation_of: Web/API/History_API
 
 <h2 id="添加和修改历史记录中的条目">添加和修改历史记录中的条目</h2>
 
-<p>{{ gecko_minversion_header("2") }}</p>
-
-<p>HTML5引入了 <a href="/en-US/docs/Web/API/History/pushState">history.pushState()</a> 和 <a href="/en-US/docs/Web/API/History_API#The_replaceState()_method">history.replaceState()</a> 方法，它们分别可以添加和修改历史记录条目。这些方法通常与{{ domxref("window.onpopstate") }} 配合使用。</p>
+<p>HTML5 引入了 <a href="/en-US/docs/Web/API/History/pushState">history.pushState()</a> 和 <a href="/en-US/docs/Web/API/History_API#The_replaceState()_method">history.replaceState()</a> 方法，它们分别可以添加和修改历史记录条目。这些方法通常与{{ domxref("window.onpopstate") }} 配合使用。</p>
 
 <p>使用 <code>history.pushState()</code> 可以改变referrer，它在用户发送 <a href="/en/DOM/XMLHttpRequest" title="en/XMLHttpRequest"><code>XMLHttpRequest</code></a> 请求时在HTTP头部使用，改变state后创建的 <a href="/en/DOM/XMLHttpRequest" title="en/XMLHttpRequest"><code>XMLHttpRequest</code></a> 对象的referrer都会被改变。因为referrer是标识创建  <code><a href="/en/DOM/XMLHttpRequest" title="en/XMLHttpRequest">XMLHttpRequest</a></code> 对象时 <code>this</code> 所代表的window对象中document的URL。</p>
 

--- a/files/zh-cn/web/api/history_api/working_with_the_history_api/index.html
+++ b/files/zh-cn/web/api/history_api/working_with_the_history_api/index.html
@@ -7,8 +7,6 @@ translation_of: Web/API/History_API/Working_with_the_History_API
 
 <h2 id="添加和修改历史记录">添加和修改历史记录</h2>
 
-<p>{{ gecko_minversion_header("2") }}</p>
-
 <p>Using {{DOMxRef("History.pushState","pushState()")}} changes the referrer that gets used in the HTTP header for {{domxref("XMLHttpRequest")}} objects created after you change the state. The referrer will be the URL of the document whose window is <code>this</code> at the time of creation of the {{domxref("XMLHttpRequest")}} object.</p>
 
 <h3 id="pushState方法实例"><a id="Example_of_pushState_method" name="Example_of_pushState_method">pushState()方法实例</a></h3>

--- a/files/zh-cn/web/api/html_drag_and_drop_api/recommended_drag_types/index.html
+++ b/files/zh-cn/web/api/html_drag_and_drop_api/recommended_drag_types/index.html
@@ -218,5 +218,3 @@ dataProvider.prototype = {
  <li><a class="internal" href="/Web/Guide/HTML/Dragging_and_Dropping_Multiple_Items" title="Dragging and Dropping Multiple Items">Dragging and Dropping Multiple Items</a></li>
  <li><a href="https://html.spec.whatwg.org/multipage/interaction.html#dnd" title="Drag and Drop Standard">HTML5 Living Standard: Drag and Drop</a></li>
 </ul>
-
-<p>{{ languages( { "ja": "Ja/DragDrop/Recommended_Drag_Types" } ) }}</p>

--- a/files/zh-cn/web/api/htmlelement/dir/index.html
+++ b/files/zh-cn/web/api/htmlelement/dir/index.html
@@ -44,5 +44,3 @@ parg.dir = "rtl";
 <h3 id="Specification" name="Specification">规范</h3>
 
 <p><a class="external" href="http://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-52460740">W3C DOM Level 2 HTML: dir</a></p>
-
-<p>{{ languages( { "ja": "ja/DOM/element.dir", "fr": "fr/DOM/element.dir", "pl": "pl/DOM/element.dir", "en": "en/DOM/element.dir" } ) }}</p>

--- a/files/zh-cn/web/api/htmlelement/index.html
+++ b/files/zh-cn/web/api/htmlelement/index.html
@@ -140,7 +140,7 @@ translation_of: Web/API/HTMLElement
    <td> </td>
   </tr>
   <tr>
-   <td>{{domxref("HTMLElement.spellcheck")}}{{ gecko_minversion_inline("1.9")}}</td>
+   <td>{{domxref("HTMLElement.spellcheck")}}</td>
    <td>{{domxref("Boolean")}}</td>
    <td> </td>
   </tr>

--- a/files/zh-cn/web/api/htmlelement/oncopy/index.html
+++ b/files/zh-cn/web/api/htmlelement/oncopy/index.html
@@ -41,4 +41,3 @@ translation_of: Web/API/HTMLElement/oncopy
  <li><code><a href="/zh-cn/DOM/element.oncut" title="zh-cn/DOM/element.oncut">oncut</a></code></li>
  <li><code><a href="/zh-cn/DOM/element.onpaste" title="zh-cn/DOM/element.onpaste">onpaste</a></code></li>
 </ul>
-<p>{{ languages( { "ja": "ja/DOM/element.oncopy", "en": "en/DOM/element.oncopy" } ) }}</p>

--- a/files/zh-cn/web/api/htmlelement/oncut/index.html
+++ b/files/zh-cn/web/api/htmlelement/oncut/index.html
@@ -43,4 +43,3 @@ translation_of: Web/API/HTMLElement/oncut
  <li><code><a href="/zh-cn/DOM/element.oncopy" title="zh-cn/DOM/element.oncopy">oncopy</a></code></li>
  <li><code><a href="/zh-cn/DOM/element.onpaste" title="zh-cn/DOM/element.onpaste">onpaste</a></code></li>
 </ul>
-<p>{{ languages( { "ja": "ja/DOM/element.oncut" ,"en": "en/DOM/element.oncut" } ) }}</p>

--- a/files/zh-cn/web/api/htmlelement/onpaste/index.html
+++ b/files/zh-cn/web/api/htmlelement/onpaste/index.html
@@ -54,4 +54,3 @@ translation_of: Web/API/HTMLElement/onpaste
  <li><code><a href="/zh-cn/DOM/element.oncopy" title="zh-cn/DOM/element.oncopy">oncopy</a></code></li>
  <li><code><a href="/zh-cn/DOM/element.oncut" title="zh-cn/DOM/element.oncut">oncut</a></code></li>
 </ul>
-<p>{{ languages( {"ja": "ja/DOM/element.onpaste" ,"en": "en/DOM/element.onpaste" } ) }}</p>

--- a/files/zh-cn/web/api/htmlformelement/reset/index.html
+++ b/files/zh-cn/web/api/htmlformelement/reset/index.html
@@ -16,4 +16,3 @@ translation_of: Web/API/HTMLFormElement/reset
 <p>运行该方法和点击表单的重置按钮是一样的效果.</p>
 <h3 id="Specification" name="Specification">规范</h3>
 <p><a class="external" href="http://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-76767677">DOM Level 2 HTML: reset</a></p>
-<p>{{ languages( {"pl": "pl/DOM/form.reset" ,"en": "en/DOM/form.reset" } ) }}</p>

--- a/files/zh-cn/web/api/htmlselectelement/index.html
+++ b/files/zh-cn/web/api/htmlselectelement/index.html
@@ -25,7 +25,7 @@ translation_of: Web/API/HTMLSelectElement
 
 <dl>
  <dt>{{domxref("HTMLSelectElement.autofocus")}}</dt>
- <dd>A {{jsxref("Boolean")}} reflecting the {{htmlattrxref("autofocus", "select")}} HTML attribute, which indicates whether the control should have input focus when the page loads, unless the user overrides it, for example by typing in a different control. Only one form-associated element in a document can have this attribute specified. {{gecko_minversion_inline("2.0")}}</dd>
+ <dd>A {{jsxref("Boolean")}} reflecting the {{htmlattrxref("autofocus", "select")}} HTML attribute, which indicates whether the control should have input focus when the page loads, unless the user overrides it, for example by typing in a different control. Only one form-associated element in a document can have this attribute specified.</dd>
  <dt>{{domxref("HTMLSelectElement.disabled")}}</dt>
  <dd>A {{jsxref("Boolean")}} reflecting the {{htmlattrxref("disabled", "select")}} HTML attribute, which indicates whether the control is disabled. If it is disabled, it does not accept clicks.</dd>
  <dt>{{domxref("HTMLSelectElement.form")}}{{ReadOnlyInline}}</dt>
@@ -41,7 +41,7 @@ translation_of: Web/API/HTMLSelectElement
  <dt>{{domxref("HTMLSelectElement.options")}}{{ReadOnlyInline}}</dt>
  <dd>An {{domxref("HTMLOptionsCollection")}} representing the set of {{HTMLElement("option")}} ({{domxref("HTMLOptionElement")}}) elements contained by this element.</dd>
  <dt>{{domxref("HTMLSelectElement.required")}}</dt>
- <dd>A {{jsxref("Boolean")}} reflecting the {{htmlattrxref("required", "select")}} HTML attribute, which indicates whether the user is required to select a value before submitting the form. {{gecko_minversion_inline("2.0")}}</dd>
+ <dd>A {{jsxref("Boolean")}} reflecting the {{htmlattrxref("required", "select")}} HTML attribute, which indicates whether the user is required to select a value before submitting the form.</dd>
  <dt>{{domxref("HTMLSelectElement.selectedIndex")}}</dt>
  <dd>A <code>long</code> reflecting the index of the first selected {{HTMLElement("option")}} element. The value <code>-1</code> indicates no element is selected.</dd>
  <dt>{{domxref("HTMLSelectElement.selectedOptions")}}{{ReadOnlyInline}}</dt>

--- a/files/zh-cn/web/api/htmltextareaelement/index.html
+++ b/files/zh-cn/web/api/htmltextareaelement/index.html
@@ -128,7 +128,7 @@ translation_of: Web/API/HTMLTextAreaElement
    <td></td>
   </tr>
   <tr>
-   <td><code>wrap</code> {{gecko_minversion_inline("2.0")}}</td>
+   <td><code>wrap</code></td>
    <td><code><em>string</em>:</code> Returns / Sets the {{htmlattrxref("wrap", "textarea")}} HTML attribute, indicating how the control wraps text.</td>
   </tr>
  </tbody>

--- a/files/zh-cn/web/api/keyboardevent/code/index.html
+++ b/files/zh-cn/web/api/keyboardevent/code/index.html
@@ -1493,7 +1493,7 @@ let spaceship = document.getElementById("spaceship");
  <thead>
   <tr>
    <th scope="row">Virtual keycode</th>
-   <th colspan="1" rowspan="1" scope="col">Gecko {{gecko_minversion_inline("32.0")}}</th>
+   <th colspan="1" rowspan="1" scope="col">Gecko (32)</th>
    <th rowspan="1" scope="col">Chromium (48)</th>
   </tr>
  </thead>
@@ -2085,7 +2085,7 @@ let spaceship = document.getElementById("spaceship");
  <thead>
   <tr>
    <th scope="row">scancode (hardware_keycode)</th>
-   <th scope="col">Gecko {{gecko_minversion_inline("32.0")}}</th>
+   <th scope="col">Gecko (32)</th>
    <th scope="col">Chromium (44)</th>
   </tr>
  </thead>
@@ -2722,47 +2722,47 @@ let spaceship = document.getElementById("spaceship");
   </tr>
   <tr>
    <th scope="row"><code>0x0089</code></th>
-   <td style="background-color: rgb(255, 255, 204);">"Again" {{gecko_minversion_inline("38.0")}}</td>
+   <td style="background-color: rgb(255, 255, 204);">"Again"</td>
    <td style="background-color: rgb(255, 255, 204);"><code>""</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x008A</code></th>
-   <td style="background-color: rgb(255, 255, 204);"><code>"Props"</code> {{gecko_minversion_inline("38.0")}}</td>
+   <td style="background-color: rgb(255, 255, 204);"><code>"Props"</code></td>
    <td style="background-color: rgb(255, 255, 204);"><code>""</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x008B</code></th>
-   <td><code>"Undo"</code> {{gecko_minversion_inline("38.0")}}</td>
+   <td><code>"Undo"</code></td>
    <td><code>"Undo"</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x008C</code></th>
-   <td style="background-color: rgb(255, 255, 204);"><code>"Select"</code> {{gecko_minversion_inline("38.0")}}</td>
+   <td style="background-color: rgb(255, 255, 204);"><code>"Select"</code></td>
    <td style="background-color: rgb(255, 255, 204);"><code>""</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x008D</code></th>
-   <td><code>"Copy"</code> {{gecko_minversion_inline("38.0")}}</td>
+   <td><code>"Copy"</code></td>
    <td><code>"Copy"</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x008E</code></th>
-   <td style="background-color: rgb(255, 255, 204);"><code>"Open"</code> {{gecko_minversion_inline("38.0")}}</td>
+   <td style="background-color: rgb(255, 255, 204);"><code>"Open"</code></td>
    <td style="background-color: rgb(255, 255, 204);"><code>""</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x008F</code></th>
-   <td><code>"Paste"</code> {{gecko_minversion_inline("38.0")}}</td>
+   <td><code>"Paste"</code></td>
    <td><code>"Paste"</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x0090</code></th>
-   <td style="background-color: rgb(255, 255, 204);"><code>"Find"</code> {{gecko_minversion_inline("38.0")}}</td>
+   <td style="background-color: rgb(255, 255, 204);"><code>"Find"</code></td>
    <td style="background-color: rgb(255, 255, 204);"><code>""</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x0091</code></th>
-   <td><code>"Cut"</code> {{gecko_minversion_inline("38.0")}}</td>
+   <td><code>"Cut"</code></td>
    <td><code>"Cut"</code></td>
   </tr>
   <tr>
@@ -3006,7 +3006,7 @@ let spaceship = document.getElementById("spaceship");
  <thead>
   <tr>
    <th scope="row">scancode</th>
-   <th scope="col">Gecko {{gecko_minversion_inline("32.0")}}</th>
+   <th scope="col">Gecko (32)</th>
   </tr>
  </thead>
  <tbody>
@@ -3586,39 +3586,39 @@ let spaceship = document.getElementById("spaceship");
   </tr>
   <tr>
    <th scope="row"><code>0x0081</code></th>
-   <td>"Again" {{gecko_minversion_inline("38.0")}}</td>
+   <td>"Again"</td>
   </tr>
   <tr>
    <th scope="row"><code>0x0082</code></th>
-   <td><code>"Props"</code> {{gecko_minversion_inline("38.0")}}</td>
+   <td><code>"Props"</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x0083</code></th>
-   <td><code>"Undo"</code> {{gecko_minversion_inline("38.0")}}</td>
+   <td><code>"Undo"</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x0084</code></th>
-   <td><code>"Select"</code> {{gecko_minversion_inline("38.0")}}</td>
+   <td><code>"Select"</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x0085</code></th>
-   <td><code>"Copy"</code> {{gecko_minversion_inline("38.0")}}</td>
+   <td><code>"Copy"</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x0086</code></th>
-   <td><code>"Open"</code> {{gecko_minversion_inline("38.0")}}</td>
+   <td><code>"Open"</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x0087</code></th>
-   <td><code>"Paste"</code> {{gecko_minversion_inline("38.0")}}</td>
+   <td><code>"Paste"</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x0088</code></th>
-   <td><code>"Find"</code> {{gecko_minversion_inline("38.0")}}</td>
+   <td><code>"Find"</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x0089</code></th>
-   <td><code>"Cut"</code> {{gecko_minversion_inline("38.0")}}</td>
+   <td><code>"Cut"</code></td>
   </tr>
   <tr>
    <th scope="row"><code>0x008A</code></th>

--- a/files/zh-cn/web/api/keyboardevent/keycode/index.html
+++ b/files/zh-cn/web/api/keyboardevent/keycode/index.html
@@ -2293,7 +2293,7 @@ translation_of: Web/API/KeyboardEvent/keyCode
   <tr>
    <td><code>DOM_VK_EISU</code></td>
    <td style="white-space: nowrap;">0x 16 (22)</td>
-   <td>"英数" key on Japanese Mac keyboard. {{gecko_minversion_inline("15.0")}}</td>
+   <td>"英数" key on Japanese Mac keyboard.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_JUNJA</code></td>
@@ -2468,7 +2468,7 @@ translation_of: Web/API/KeyboardEvent/keyCode
   <tr>
    <td><code>DOM_VK_COLON</code></td>
    <td style="white-space: nowrap;">0x3A (58)</td>
-   <td>Colon (":") key. {{gecko_minversion_inline("15.0")}}</td>
+   <td>Colon (":") key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_SEMICOLON</code></td>
@@ -2478,7 +2478,7 @@ translation_of: Web/API/KeyboardEvent/keyCode
   <tr>
    <td><code>DOM_VK_LESS_THAN</code></td>
    <td style="white-space: nowrap;">0x3C (60)</td>
-   <td>Less-than ("&lt;") key. {{gecko_minversion_inline("15.0")}}</td>
+   <td>Less-than ("&lt;") key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_EQUALS</code></td>
@@ -2488,17 +2488,17 @@ translation_of: Web/API/KeyboardEvent/keyCode
   <tr>
    <td><code>DOM_VK_GREATER_THAN</code></td>
    <td style="white-space: nowrap;">0x3E (62)</td>
-   <td>Greater-than ("&gt;") key. {{gecko_minversion_inline("15.0")}}</td>
+   <td>Greater-than ("&gt;") key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_QUESTION_MARK</code></td>
    <td style="white-space: nowrap;">0x3F (63)</td>
-   <td>Question mark ("?") key. {{gecko_minversion_inline("15.0")}}</td>
+   <td>Question mark ("?") key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_AT</code></td>
    <td style="white-space: nowrap;">0x40 (64)</td>
-   <td>Atmark ("@") key. {{gecko_minversion_inline("15.0")}}</td>
+   <td>Atmark ("@") key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_A</code></td>
@@ -2633,7 +2633,7 @@ translation_of: Web/API/KeyboardEvent/keyCode
   <tr>
    <td><code>DOM_VK_WIN</code></td>
    <td style="white-space: nowrap;">0x5B (91)</td>
-   <td>Windows logo key on Windows. Or Super or Hyper key on Linux. {{gecko_minversion_inline("15.0")}}</td>
+   <td>Windows logo key on Windows. Or Super or Hyper key on Linux.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_CONTEXT_MENU</code></td>
@@ -2858,127 +2858,127 @@ translation_of: Web/API/KeyboardEvent/keyCode
   <tr>
    <td><code>DOM_VK_WIN_OEM_FJ_JISHO</code></td>
    <td style="white-space: nowrap;">0x92 (146)</td>
-   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for "Dictionary" key on Fujitsu OASYS. {{gecko_minversion_inline("21.0")}}</td>
+   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for "Dictionary" key on Fujitsu OASYS.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_WIN_OEM_FJ_MASSHOU</code></td>
    <td style="white-space: nowrap;">0x93 (147)</td>
-   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for "Unregister word" key on Fujitsu OASYS. {{gecko_minversion_inline("21.0")}}</td>
+   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for "Unregister word" key on Fujitsu OASYS.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_WIN_OEM_FJ_TOUROKU</code></td>
    <td style="white-space: nowrap;">0x94 (148)</td>
-   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for "Register word" key on Fujitsu OASYS. {{gecko_minversion_inline("21.0")}}</td>
+   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for "Register word" key on Fujitsu OASYS.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_WIN_OEM_FJ_LOYA</code></td>
    <td style="white-space: nowrap;">0x95 (149)</td>
-   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for "Left OYAYUBI" key on Fujitsu OASYS. {{gecko_minversion_inline("21.0")}}</td>
+   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for "Left OYAYUBI" key on Fujitsu OASYS.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_WIN_OEM_FJ_ROYA</code></td>
    <td style="white-space: nowrap;">0x96 (150)</td>
-   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for "Right OYAYUBI" key on Fujitsu OASYS. {{gecko_minversion_inline("21.0")}}</td>
+   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for "Right OYAYUBI" key on Fujitsu OASYS.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_CIRCUMFLEX</code></td>
    <td style="white-space: nowrap;">0xA0 (160)</td>
-   <td>Circumflex ("^") key. {{gecko_minversion_inline("15.0")}}</td>
+   <td>Circumflex ("^") key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_EXCLAMATION</code></td>
    <td style="white-space: nowrap;">0xA1 (161)</td>
-   <td>Exclamation ("!") key. {{gecko_minversion_inline("15.0")}}</td>
+   <td>Exclamation ("!") key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_DOUBLE_QUOTE</code></td>
    <td style="white-space: nowrap;">0xA3 (162)</td>
-   <td>Double quote (""") key. {{gecko_minversion_inline("15.0")}}</td>
+   <td>Double quote (""") key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_HASH</code></td>
    <td style="white-space: nowrap;">0xA3 (163)</td>
-   <td>Hash ("#") key. {{gecko_minversion_inline("15.0")}}</td>
+   <td>Hash ("#") key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_DOLLAR</code></td>
    <td style="white-space: nowrap;">0xA4 (164)</td>
-   <td>Dollar sign ("$") key. {{gecko_minversion_inline("15.0")}}</td>
+   <td>Dollar sign ("$") key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_PERCENT</code></td>
    <td style="white-space: nowrap;">0xA5 (165)</td>
-   <td>Percent ("%") key. {{gecko_minversion_inline("15.0")}}</td>
+   <td>Percent ("%") key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_AMPERSAND</code></td>
    <td style="white-space: nowrap;">0xA6 (166)</td>
-   <td>Ampersand ("&amp;") key. {{gecko_minversion_inline("15.0")}}</td>
+   <td>Ampersand ("&amp;") key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_UNDERSCORE</code></td>
    <td style="white-space: nowrap;">0xA7 (167)</td>
-   <td>Underscore ("_") key. {{gecko_minversion_inline("15.0")}}</td>
+   <td>Underscore ("_") key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_OPEN_PAREN</code></td>
    <td style="white-space: nowrap;">0xA8 (168)</td>
-   <td>Open parenthesis ("(") key. {{gecko_minversion_inline("15.0")}}</td>
+   <td>Open parenthesis ("(") key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_CLOSE_PAREN</code></td>
    <td style="white-space: nowrap;">0xA9 (169)</td>
-   <td>Close parenthesis (")") key. {{gecko_minversion_inline("15.0")}}</td>
+   <td>Close parenthesis (")") key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_ASTERISK</code></td>
    <td style="white-space: nowrap;">0xAA (170)</td>
-   <td>Asterisk ("*") key. {{gecko_minversion_inline("15.0")}}</td>
+   <td>Asterisk ("*") key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_PLUS</code></td>
    <td style="white-space: nowrap;">0xAB (171)</td>
-   <td>Plus ("+") key. {{gecko_minversion_inline("15.0")}}</td>
+   <td>Plus ("+") key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_PIPE</code></td>
    <td style="white-space: nowrap;">0xAC (172)</td>
-   <td>Pipe ("|") key. {{gecko_minversion_inline("15.0")}}</td>
+   <td>Pipe ("|") key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_HYPHEN_MINUS</code></td>
    <td style="white-space: nowrap;">0xAD (173)</td>
-   <td>Hyphen-US/docs/Minus ("-") key. {{gecko_minversion_inline("15.0")}}</td>
+   <td>Hyphen-US/docs/Minus ("-") key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_OPEN_CURLY_BRACKET</code></td>
    <td style="white-space: nowrap;">0xAE (174)</td>
-   <td>Open curly bracket ("{") key. {{gecko_minversion_inline("15.0")}}</td>
+   <td>Open curly bracket ("{") key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_CLOSE_CURLY_BRACKET</code></td>
    <td style="white-space: nowrap;">0xAF (175)</td>
-   <td>Close curly bracket ("}") key. {{gecko_minversion_inline("15.0")}}</td>
+   <td>Close curly bracket ("}") key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_TILDE</code></td>
    <td style="white-space: nowrap;">0xB0 (176)</td>
-   <td>Tilde ("~") key. {{gecko_minversion_inline("15.0")}}</td>
+   <td>Tilde ("~") key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_VOLUME_MUTE</code></td>
    <td style="white-space: nowrap;">0xB5 (181)</td>
-   <td>Audio mute key. {{gecko_minversion_inline("21.0")}}</td>
+   <td>Audio mute key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_VOLUME_DOWN</code></td>
    <td style="white-space: nowrap;">0xB6 (182)</td>
-   <td>Audio volume down key {{gecko_minversion_inline("21.0")}}</td>
+   <td>Audio volume down key</td>
   </tr>
   <tr>
    <td><code>DOM_VK_VOLUME_UP</code></td>
    <td style="white-space: nowrap;">0xB7 (183)</td>
-   <td>Audio volume up key {{gecko_minversion_inline("21.0")}}</td>
+   <td>Audio volume up key</td>
   </tr>
   <tr>
    <td><code>DOM_VK_COMMA</code></td>
@@ -3028,127 +3028,127 @@ translation_of: Web/API/KeyboardEvent/keyCode
   <tr>
    <td><code>DOM_VK_ALTGR</code></td>
    <td style="white-space: nowrap;">0xE1 (225)</td>
-   <td>AltGr key (Level 3 Shift key or Level 5 Shift key) on Linux. {{gecko_minversion_inline("15.0")}}</td>
+   <td>AltGr key (Level 3 Shift key or Level 5 Shift key) on Linux.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_WIN_ICO_HELP</code></td>
    <td style="white-space: nowrap;">0xE3 (227)</td>
-   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This is (was?) used for Olivetti ICO keyboard.{{gecko_minversion_inline("21.0")}}</td>
+   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This is (was?) used for Olivetti ICO keyboard.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_WIN_ICO_00</code></td>
    <td style="white-space: nowrap;">0xE4 (228)</td>
-   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This is (was?) used for Olivetti ICO keyboard.{{gecko_minversion_inline("21.0")}}</td>
+   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This is (was?) used for Olivetti ICO keyboard.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_WIN_ICO_CLEAR</code></td>
    <td style="white-space: nowrap;">0xE6 (230)</td>
-   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This is (was?) used for Olivetti ICO keyboard.{{gecko_minversion_inline("21.0")}}</td>
+   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This is (was?) used for Olivetti ICO keyboard.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_WIN_OEM_RESET</code></td>
    <td style="white-space: nowrap;">0xE9 (233)</td>
-   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.{{gecko_minversion_inline("21.0")}}</td>
+   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_WIN_OEM_JUMP</code></td>
    <td style="white-space: nowrap;">0xEA (234)</td>
-   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.{{gecko_minversion_inline("21.0")}}</td>
+   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_WIN_OEM_PA1</code></td>
    <td style="white-space: nowrap;">0xEB (235)</td>
-   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.{{gecko_minversion_inline("21.0")}}</td>
+   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_WIN_OEM_PA2</code></td>
    <td style="white-space: nowrap;">0xEC (236)</td>
-   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.{{gecko_minversion_inline("21.0")}}</td>
+   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_WIN_OEM_PA3</code></td>
    <td style="white-space: nowrap;">0xED (237)</td>
-   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.{{gecko_minversion_inline("21.0")}}</td>
+   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_WIN_OEM_WSCTRL</code></td>
    <td style="white-space: nowrap;">0xEE (238)</td>
-   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.{{gecko_minversion_inline("21.0")}}</td>
+   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_WIN_OEM_CUSEL</code></td>
    <td style="white-space: nowrap;">0xEF (239)</td>
-   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.{{gecko_minversion_inline("21.0")}}</td>
+   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_WIN_OEM_ATTN</code></td>
    <td style="white-space: nowrap;">0xF0 (240)</td>
-   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.{{gecko_minversion_inline("21.0")}}</td>
+   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_WIN_OEM_FINISH</code></td>
    <td style="white-space: nowrap;">0xF1 (241)</td>
-   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.{{gecko_minversion_inline("21.0")}}</td>
+   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_WIN_OEM_COPY</code></td>
    <td style="white-space: nowrap;">0xF2 (242)</td>
-   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.{{gecko_minversion_inline("21.0")}}</td>
+   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_WIN_OEM_AUTO</code></td>
    <td style="white-space: nowrap;">0xF3 (243)</td>
-   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.{{gecko_minversion_inline("21.0")}}</td>
+   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_WIN_OEM_ENLW</code></td>
    <td style="white-space: nowrap;">0xF4 (244)</td>
-   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.{{gecko_minversion_inline("21.0")}}</td>
+   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_WIN_OEM_BACKTAB</code></td>
    <td style="white-space: nowrap;">0xF5 (245)</td>
-   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.{{gecko_minversion_inline("21.0")}}</td>
+   <td>An <a href="#OEM_specific_keys_on_Windows" title="#OEM_specific_keys_on_Windows">OEM specific key on Windows</a>. This was used for Nokia/Ericsson's device.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_ATTN</code></td>
    <td style="white-space: nowrap;">0xF6 (246)</td>
-   <td>Attn (Attention) key of IBM midrange computers, e.g., AS/400. {{gecko_minversion_inline("21.0")}}</td>
+   <td>Attn (Attention) key of IBM midrange computers, e.g., AS/400.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_CRSEL</code></td>
    <td style="white-space: nowrap;">0xF7 (247)</td>
-   <td>CrSel (Cursor Selection) key of IBM 3270 keyboard layout. {{gecko_minversion_inline("21.0")}}</td>
+   <td>CrSel (Cursor Selection) key of IBM 3270 keyboard layout.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_EXSEL</code></td>
    <td style="white-space: nowrap;">0xF8 (248)</td>
-   <td>ExSel (Extend Selection) key of IBM 3270 keyboard layout. {{gecko_minversion_inline("21.0")}}</td>
+   <td>ExSel (Extend Selection) key of IBM 3270 keyboard layout.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_EREOF</code></td>
    <td style="white-space: nowrap;">0xF9 (249)</td>
-   <td>Erase EOF key of IBM 3270 keyboard layout. {{gecko_minversion_inline("21.0")}}</td>
+   <td>Erase EOF key of IBM 3270 keyboard layout.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_PLAY</code></td>
    <td style="white-space: nowrap;">0xFA (250)</td>
-   <td>Play key of IBM 3270 keyboard layout. {{gecko_minversion_inline("21.0")}}</td>
+   <td>Play key of IBM 3270 keyboard layout.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_ZOOM</code></td>
    <td style="white-space: nowrap;">0xFB (251)</td>
-   <td>Zoom key. {{gecko_minversion_inline("21.0")}}</td>
+   <td>Zoom key.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_PA1</code></td>
    <td style="white-space: nowrap;">0xFD (253)</td>
-   <td>PA1 key of IBM 3270 keyboard layout. {{gecko_minversion_inline("21.0")}}</td>
+   <td>PA1 key of IBM 3270 keyboard layout.</td>
   </tr>
   <tr>
    <td><code>DOM_VK_WIN_OEM_CLEAR</code></td>
    <td style="white-space: nowrap;">0xFE (254)</td>
-   <td>Clear key, but we're not sure the meaning difference from <code>DOM_VK_CLEAR</code>. {{gecko_minversion_inline("21.0")}}</td>
+   <td>Clear key, but we're not sure the meaning difference from <code>DOM_VK_CLEAR</code>.</td>
   </tr>
  </tbody>
 </table>

--- a/files/zh-cn/web/api/keyboardevent/location/index.html
+++ b/files/zh-cn/web/api/keyboardevent/location/index.html
@@ -57,7 +57,7 @@ translation_of: Web/API/KeyboardEvent/location
    <td>
     <p>The key was a button on a game controller or a joystick on a mobile device.</p>
 
-    <div class="note"><strong>Note: </strong>Gecko never fires trusted key events with <code>DOM_KEY_LOCATION_JOYSTICK</code> except on Android. Starting 18, native key events on Android may have this value. {{gecko_minversion_inline("18.0")}} However, at {{gecko("38")}}, this is dropped.</div>
+    <div class="note"><strong>Note: </strong>Gecko never fires trusted key events with <code>DOM_KEY_LOCATION_JOYSTICK</code> except on Android. Starting 18, native key events on Android may have this value. However, at {{gecko("38")}}, this is dropped.</div>
    </td>
   </tr>
  </tbody>

--- a/files/zh-cn/web/api/mouseevent/index.html
+++ b/files/zh-cn/web/api/mouseevent/index.html
@@ -29,7 +29,7 @@ translation_of: Web/API/MouseEvent
  <dd>当鼠标事件触发的时，如果<kbd>alt</kbd> 键被按下，返回true;</dd>
  <dt>{{domxref("MouseEvent.button")}} {{readonlyinline}}</dt>
  <dd>当鼠标事件触发的时，如果鼠标按钮被按下（如果有的话），将会返回一个数值。</dd>
- <dt>{{domxref("MouseEvent.buttons")}} {{readonlyinline}} {{gecko_minversion_inline("15.0")}}</dt>
+ <dt>{{domxref("MouseEvent.buttons")}} {{readonlyinline}}</dt>
  <dd>
  <p>当鼠标事件触发的时，如果多个鼠标按钮被按下（如果有的话），将会返回一个或者多个代表鼠标按钮的数字。</p>
  </dd>

--- a/files/zh-cn/web/api/mouseevent/mozinputsource/index.html
+++ b/files/zh-cn/web/api/mouseevent/mozinputsource/index.html
@@ -7,8 +7,6 @@ translation_of: Web/API/MouseEvent/mozInputSource
 ---
 <p>{{ APIRef() }}</p>
 
-<p>{{ gecko_minversion_header("2.0") }}</p>
-
 <p>{{ Non-standard_header() }}</p>
 
 <p>{{domxref("MouseEvent")}}中的<strong><code>MouseEvent.mozInputSource</code></strong>是只读属性，它提供触发事件的设备信息。例如，当一个鼠标事件发生时，你能根据<strong><code>MouseEvent.mozInputSource</code></strong>属性判断该事件是由鼠标还是由触屏设备触发的（这将影响到你对于事件发生坐标解释的精确度）。</p>

--- a/files/zh-cn/web/api/navigator/index.html
+++ b/files/zh-cn/web/api/navigator/index.html
@@ -133,7 +133,7 @@ translation_of: Web/API/Navigator
  <dd>Invokes the native sharing mechanism of the current platform.</dd>
  <dt>{{domxref("NavigatorID.taintEnabled()")}} {{deprecated_inline("1.7.8")}} {{obsolete_inline("9.0")}} {{experimental_inline}}</dt>
  <dd>Returns <code>false</code>. JavaScript taint/untaint functions removed in JavaScript 1.2.</dd>
- <dt>{{domxref("Navigator.vibrate()")}} {{gecko_minversion_inline("11.0")}}</dt>
+ <dt>{{domxref("Navigator.vibrate()")}}</dt>
  <dd>Causes vibration on devices with support for it. Does nothing if vibration support isn't available.</dd>
 </dl>
 

--- a/files/zh-cn/web/api/navigator/mozislocallyavailable/index.html
+++ b/files/zh-cn/web/api/navigator/mozislocallyavailable/index.html
@@ -36,7 +36,3 @@ if (available) {
 <h3 id="Specification" name="Specification">规范</h3>
 
 <p>无规范; 这里有一些可用信息: <a class="external" href="http://www.campd.org/stuff/Offline%20Cache.html">将资源标记为离线可用</a>.</p>
-
-<p> </p>
-
-<p>{{ languages( { "fr": "fr/DOM/window.navigator.isLocallyAvailable", "en": "en/DOM/window.navigator.isLocallyAvailable", "ja": "ja/DOM/window.navigator.mozIsLocallyAvailable" } ) }}</p>

--- a/files/zh-cn/web/api/navigator/oscpu/index.html
+++ b/files/zh-cn/web/api/navigator/oscpu/index.html
@@ -80,5 +80,3 @@ translation_of: Web/API/Navigator/oscpu
 <h3 id="Specification" name="Specification">规范</h3>
 
 <p>{{ DOM0() }}</p>
-
-<p>{{ languages( { "ja": "ja/DOM/window.navigator.oscpu", "en": "en/DOM/window.navigator.oscpu", "pl": "pl/DOM/window.navigator.oscpu" } ) }}</p>

--- a/files/zh-cn/web/api/navigator/vendor/index.html
+++ b/files/zh-cn/web/api/navigator/vendor/index.html
@@ -33,5 +33,3 @@ translation_of: Web/API/Navigator/vendor
 <h3 id="Specification" name="Specification">规范</h3>
 
 <p>{{ DOM0() }}</p>
-
-<p>{{ languages( { "ja": "ja/DOM/window.navigator.vendor" ,"en": "en/DOM/window.navigator.vendor" } ) }}</p>

--- a/files/zh-cn/web/api/navigator/vendorsub/index.html
+++ b/files/zh-cn/web/api/navigator/vendorsub/index.html
@@ -33,5 +33,3 @@ translation_of: Web/API/Navigator/vendorSub
 <h3 id="Specification" name="Specification">规范</h3>
 
 <p>{{ DOM0() }}</p>
-
-<p>{{ languages( {"ja": "ja/DOM/window.navigator.vendorSub","en": "en/DOM/window.navigator.vendorSub" } ) }}</p>

--- a/files/zh-cn/web/api/node/baseuri/index.html
+++ b/files/zh-cn/web/api/node/baseuri/index.html
@@ -65,5 +65,3 @@ translation_of: Web/API/Node/baseURI
  <li><code><a href="https://developer.mozilla.org/en-US/docs/XML/xml:base">xml:base</a></code> 属性（XML 文档）</li>
  <li>{{domxref("Node.baseURIObject")}} - a variant of this API for Mozilla add-ons and internal code. Returns the base URL as an {{interface("nsIURI")}}.</li>
 </ul>
-
-<p>{{ languages( {"en": "en/DOM/Node.baseURI" } ) }}</p>

--- a/files/zh-cn/web/api/node/firstchild/index.html
+++ b/files/zh-cn/web/api/node/firstchild/index.html
@@ -74,5 +74,3 @@ translation_of: Web/API/Node/firstChild
 <p><a class="external" href="http://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#attribute-firstChild">DOM Level 1 Core: firstChild</a></p>
 
 <p><a class="external" href="http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-169727388">DOM Level 2 Core: firstChild</a></p>
-
-<p>{{ languages( { "fr": "fr/DOM/element.firstChild", "ja": "ja/DOM/element.firstChild", "pl": "pl/DOM/element.firstChild", "en": "en/DOM/Node.firstChild" } ) }}</p>

--- a/files/zh-cn/web/api/node/isdefaultnamespace/index.html
+++ b/files/zh-cn/web/api/node/isdefaultnamespace/index.html
@@ -23,4 +23,3 @@ alert(el.isDefaultNamespace(XULNS)); // true
  <li><a class="external" href="http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-isDefaultNamespace">DOM Level 3 Core: isDefaultNamespace</a></li>
  <li><a href="/zh-cn/Code_snippets/IsDefaultNamespace" title="zh-cn/Code_snippets/IsDefaultNamespace">Code snippets: isDefaultNamespace</a></li>
 </ul>
-<p>{{ languages( {"en": "en/DOM/Node.isDefaultNamespace" } ) }}</p>

--- a/files/zh-cn/web/api/node/lookupnamespaceuri/index.html
+++ b/files/zh-cn/web/api/node/lookupnamespaceuri/index.html
@@ -15,5 +15,3 @@ translation_of: Web/API/Node/lookupNamespaceURI
  <li><a class="external" href="http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-lookupNamespaceURI" rel="freelink">http://www.w3.org/TR/DOM-Level-3-Cor...upNamespaceURI</a></li>
  <li><a href="/zh-cn/Code_snippets/LookupNamespaceURI" title="zh-cn/Code_snippets/LookupNamespaceURI">Code snippets: lookupNamespaceURI</a></li>
 </ul>
-
-<p>{{ languages( { "en": "en/DOM/Node.lookupNamespaceURI" } ) }}</p>

--- a/files/zh-cn/web/api/node/lookupprefix/index.html
+++ b/files/zh-cn/web/api/node/lookupprefix/index.html
@@ -15,5 +15,3 @@ translation_of: Web/API/Node/lookupPrefix
  <li><a class="external" href="http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-lookupNamespacePrefix" rel="freelink">http://www.w3.org/TR/DOM-Level-3-Cor...amespacePrefix</a></li>
  <li><a href="/En/Code_snippets/LookupPrefix" title="En/Code_snippets/LookupPrefix">Code snippets: lookupPrefix</a></li>
 </ul>
-
-<p>{{ languages( { "en": "en/DOM/Node.lookupPrefix" } ) }}</p>

--- a/files/zh-cn/web/api/node/parentnode/index.html
+++ b/files/zh-cn/web/api/node/parentnode/index.html
@@ -26,4 +26,3 @@ translation_of: Web/API/Node/parentNode
 
 <h2 id="Specification" name="Specification">规范</h2>
 <p><a class="external" href="http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-1060184317">DOM Level 2 Core: Node.parentNode</a></p>
-<p>{{ languages( { "it": "it/DOM/element.parentNode", "ja": "ja/DOM/element.parentNode", "fr": "fr/DOM/element.parentNode", "pl": "pl/DOM/element.parentNode" , "en": "en/DOM/Node.parentNode" } ) }}</p>

--- a/files/zh-cn/web/api/node/previoussibling/index.html
+++ b/files/zh-cn/web/api/node/previoussibling/index.html
@@ -5,8 +5,6 @@ translation_of: Web/API/Node/previousSibling
 ---
 <p>{{ APIRef() }}</p>
 
-<p>{{ languages( { "fr": "fr/DOM/element.previousSibling", "ja": "ja/DOM/element.previousSibling", "pl": "pl/DOM/element.previousSibling", "en": "en/DOM/Node.previousSibling" } ) }}</p>
-
 <h3 id="Summary" name="Summary">概述</h3>
 
 <p>返回当前节点的前一个兄弟节点,没有则返回<code>null.</code></p>

--- a/files/zh-cn/web/api/nodelist/item/index.html
+++ b/files/zh-cn/web/api/nodelist/item/index.html
@@ -27,4 +27,3 @@ var firstTable = tables.item(1); // 或者简写为tables[1],返回一个文档�
 <h3 id="Specification" name="Specification">规范</h3>
 <p><a class="external" href="http://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#method-item">DOM Level 1 Core: NodeList.item()</a></p>
 <p><a class="external" href="http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-844377136">DOM Level 2 Core: NodeList.item()</a></p>
-<p>{{ languages( {"en": "en/DOM/NodeList.item" } ) }}</p>

--- a/files/zh-cn/web/api/screen/availleft/index.html
+++ b/files/zh-cn/web/api/screen/availleft/index.html
@@ -22,4 +22,3 @@ window.moveTo(setX, setY);
 <p>[2] [1] - 左侧屏幕 <em>availLeft</em> 返回该屏幕的 <strong>-width</strong>，右侧屏幕返回 <strong>0</strong></p>
 <h3 id="Specification" name="Specification">规范</h3>
 <p>DOM Level 0。不属于任何规范。</p>
-<p>{{ languages( { "ja": "ja/DOM/window.screen.availLeft" } ) }}</p>

--- a/files/zh-cn/web/api/screen/availtop/index.html
+++ b/files/zh-cn/web/api/screen/availtop/index.html
@@ -18,6 +18,3 @@ window.moveTo(setX, setY);
 <p>大多数情况下，该属性返回 0。</p>
 <h3 id="Specification" name="Specification">规范</h3>
 <p>DOM Level 0。不属于任何规范。</p>
-<div class="noinclude">
-  </div>
-<p>{{ languages( { "ja": "ja/DOM/window.screen.availTop" } ) }}</p>

--- a/files/zh-cn/web/api/screen/index.html
+++ b/files/zh-cn/web/api/screen/index.html
@@ -38,9 +38,9 @@ translation_of: Web/API/Screen
  <dd>返回最上边界到当前屏幕的像素值。</dd>
  <dt>{{domxref("Screen.width")}}</dt>
  <dd>返回屏幕的宽度。</dd>
- <dt>{{domxref("Screen.mozEnabled")}} {{gecko_minversion_inline("12.0")}}</dt>
+ <dt>{{domxref("Screen.mozEnabled")}}</dt>
  <dd>布尔值。如果设置为false将关闭设备的屏幕。</dd>
- <dt>{{domxref("Screen.mozBrightness")}} {{gecko_minversion_inline("12.0")}}</dt>
+ <dt>{{domxref("Screen.mozBrightness")}}</dt>
  <dd>控制设备屏幕的亮度。期望参数是0-1.0之间的浮点数。</dd>
 </dl>
 

--- a/files/zh-cn/web/api/selection/index.html
+++ b/files/zh-cn/web/api/selection/index.html
@@ -87,7 +87,7 @@ window.alert(selObj); </pre>
  <dd>将当前的选区折叠为一个点。</dd>
  <dt>{{domxref("Selection/extend","extend")}}</dt>
  <dd>将选区的焦点移动到一个特定的位置。</dd>
- <dt>{{domxref("Selection/modify","modify")}} {{gecko_minversion_inline("2.0")}}</dt>
+ <dt>{{domxref("Selection/modify","modify")}}</dt>
  <dd>修改当前的选区。</dd>
  <dt>{{domxref("Selection/collapseToStart","collapseToStart")}}</dt>
  <dd>将当前的选区折叠到起始点。</dd>

--- a/files/zh-cn/web/api/selection/iscollapsed/index.html
+++ b/files/zh-cn/web/api/selection/iscollapsed/index.html
@@ -11,6 +11,3 @@ translation_of: Web/API/Selection/isCollapsed
 </pre>
 <h3 id="Notes" name="Notes">注意</h3>
 <p>即使是一个被折叠了的选区，其 rangeCount的结果也可能大于0。<span style="font-family: 'Courier New', 'Andale Mono', monospace; line-height: 1.5;">sel.getRangeAt(0)会在选区被折叠的情况下返回一个值。</span></p>
-<div class="noinclude">
-  </div>
-<p>{{ languages( { "es": "es/DOM/Selection/isCollapsed", "it": "it/DOM/Selection/isCollapsed", "pl": "pl/DOM/Selection/isCollapsed" } ) }}</p>

--- a/files/zh-cn/web/api/selection/removerange/index.html
+++ b/files/zh-cn/web/api/selection/removerange/index.html
@@ -32,6 +32,3 @@ if(s.rangeCount &gt; 1) {
  }
 }
 </pre>
-<div class="noinclude">
-  </div>
-<p>{{ languages( { "es": "es/DOM/Selection/removeRange", "it": "it/DOM/Selection/removeRange", "pl": "pl/DOM/Selection/removeRange" } ) }}</p>

--- a/files/zh-cn/web/api/stylesheet/href/index.html
+++ b/files/zh-cn/web/api/stylesheet/href/index.html
@@ -49,5 +49,3 @@ translation_of: Web/API/StyleSheet/href
 <h3 id="Specification" name="Specification">规范</h3>
 
 <p><a class="external" href="http://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/stylesheets.html#StyleSheets-StyleSheet-href">stylesheet.href </a></p>
-
-<p>{{ languages( {"en": "en/DOM/StyleSheet/href" } ) }}</p>

--- a/files/zh-cn/web/api/text/iselementcontentwhitespace/index.html
+++ b/files/zh-cn/web/api/text/iselementcontentwhitespace/index.html
@@ -26,4 +26,3 @@ ws.isElementContentWhitespace; /* 返回true */
 <ul>
  <li><a class="internal" href="/zh-cn/DOM/Text" title="zh-cn/DOM/Text"><code>Text</code></a></li>
 </ul>
-<p>{{ languages( { "en": "en/DOM/Text.isElementContentWhitespace" } ) }}</p>

--- a/files/zh-cn/web/api/text/replacewholetext/index.html
+++ b/files/zh-cn/web/api/text/replacewholetext/index.html
@@ -5,7 +5,7 @@ translation_of: Web/API/Text/replaceWholeText
 ---
 <p>{{ ApiRef() }}</p>
 <p>{{ Obsolete_header() }}</p>
-<p>{{ gecko_minversion_header("1.9.1") }}</p>
+
 <h3 id="Summary" name="Summary">Summary</h3>
 <p><strong>replaceWholeText</strong> replaces the text of the node and all of its logically adjacent text nodes with the specified text.  The replaced nodes are removed, including the current node, unless it was the recipient of the replacement text.</p>
 <div class="warning">

--- a/files/zh-cn/web/api/text/replacewholetext/index.html
+++ b/files/zh-cn/web/api/text/replacewholetext/index.html
@@ -33,4 +33,3 @@ translation_of: Web/API/Text/replaceWholeText
  <li><code><a class="internal" href="/zh-cn/DOM/Text.wholeText" title="zh-cn/DOM/Text.wholeText">text.wholeText</a></code></li>
  <li><a class="internal" href="/zh-cn/DOM/Text" title="zh-cn/DOM/Text"><code>Text</code></a></li>
 </ul>
-<p>{{ languages( {"en": "en/DOM/text.replaceWholeText" } ) }}</p>

--- a/files/zh-cn/web/api/timeranges/start/index.html
+++ b/files/zh-cn/web/api/timeranges/start/index.html
@@ -5,8 +5,6 @@ translation_of: Web/API/TimeRanges/start
 ---
 <p>{{APIRef("DOM")}}</p>
 
-<p>{{gecko_minversion_header("2.0")}}</p>
-
 <p>返回指定时间范围的开始偏移量。</p>
 
 <h2 id="语法">语法</h2>

--- a/files/zh-cn/web/api/uievent/ischar/index.html
+++ b/files/zh-cn/web/api/uievent/ischar/index.html
@@ -20,4 +20,3 @@ translation_of: Web/API/UIEvent/isChar
 <p>一些常用的组合键可能会触发键盘事件,但是不会产生任何字符(例如:CTRL + ALT + ?).在这种情况下,isChar返回false.isChar常用于判断用户在一个文本输入框内输入的是否为一个字符.</p>
 <h3 id="Specification" name="Specification">规范</h3>
 <p>不属于任何公开的规范</p>
-<p>{{ languages( {"pl": "pl/DOM/event.isChar","en": "en/DOM/event.isChar" } ) }}</p>

--- a/files/zh-cn/web/api/validitystate/index.html
+++ b/files/zh-cn/web/api/validitystate/index.html
@@ -9,7 +9,7 @@ tags:
   - 输入
 translation_of: Web/API/ValidityState
 ---
-<div>{{APIRef("HTML DOM")}} {{gecko_minversion_header("2.0")}}</div>
+<div>{{APIRef("HTML DOM")}}</div>
 
 <p>DOM接口 <code>ValidityState</code> 代表一个元素可有的有效性状态（<em>validity states</em>），其与约束验证（constraint validation）相关。这些状态一起解释了当元素值无效时，它的值为什么不能通过验证。</p>
 

--- a/files/zh-cn/web/api/webgl_api/by_example/basic_scissoring/index.html
+++ b/files/zh-cn/web/api/webgl_api/by_example/basic_scissoring/index.html
@@ -3,7 +3,6 @@ title: Basic scissoring
 slug: Web/API/WebGL_API/By_example/Basic_scissoring
 translation_of: Web/API/WebGL_API/By_example/Basic_scissoring
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
 
 <p>{{PreviousNext("Learn/WebGL/By_example/Color_masking","Learn/WebGL/By_example/Canvas_size_and_WebGL")}}</p>
 

--- a/files/zh-cn/web/api/webgl_api/by_example/boilerplate_1/index.html
+++ b/files/zh-cn/web/api/webgl_api/by_example/boilerplate_1/index.html
@@ -3,8 +3,6 @@ title: Boilerplate 1
 slug: Web/API/WebGL_API/By_example/Boilerplate_1
 translation_of: Web/API/WebGL_API/By_example/Boilerplate_1
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{PreviousNext("Learn/WebGL/By_example/Canvas_size_and_WebGL","Learn/WebGL/By_example/Scissor_animation")}}</p>
 
 <div id="boilerplate-1">

--- a/files/zh-cn/web/api/webgl_api/by_example/canvas_size_and_webgl/index.html
+++ b/files/zh-cn/web/api/webgl_api/by_example/canvas_size_and_webgl/index.html
@@ -3,8 +3,6 @@ title: Canvas size and WebGL
 slug: Web/API/WebGL_API/By_example/Canvas_size_and_WebGL
 translation_of: Web/API/WebGL_API/By_example/Canvas_size_and_WebGL
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{PreviousNext("Learn/WebGL/By_example/Basic_scissoring","Learn/WebGL/By_example/Boilerplate_1")}}</p>
 
 <div class="summary">

--- a/files/zh-cn/web/api/webgl_api/by_example/clearing_by_clicking/index.html
+++ b/files/zh-cn/web/api/webgl_api/by_example/clearing_by_clicking/index.html
@@ -3,8 +3,6 @@ title: Clearing by clicking
 slug: Web/API/WebGL_API/By_example/Clearing_by_clicking
 translation_of: Web/API/WebGL_API/By_example/Clearing_by_clicking
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{PreviousNext("Learn/WebGL/By_example/Clearing_with_colors","Learn/WebGL/By_example/Simple_color_animation")}}</p>
 
 <div id="clearing-by-clicking">

--- a/files/zh-cn/web/api/webgl_api/by_example/clearing_with_colors/index.html
+++ b/files/zh-cn/web/api/webgl_api/by_example/clearing_with_colors/index.html
@@ -3,8 +3,6 @@ title: 清除画布
 slug: Web/API/WebGL_API/By_example/Clearing_with_colors
 translation_of: Web/API/WebGL_API/By_example/Clearing_with_colors
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{PreviousNext("Learn/WebGL/By_example/Detect_WebGL","Learn/WebGL/By_example/Clearing_by_clicking")}}</p>
 
 <div id="clearing-with-colors">

--- a/files/zh-cn/web/api/webgl_api/by_example/color_masking/index.html
+++ b/files/zh-cn/web/api/webgl_api/by_example/color_masking/index.html
@@ -3,8 +3,6 @@ title: Color masking
 slug: Web/API/WebGL_API/By_example/Color_masking
 translation_of: Web/API/WebGL_API/By_example/Color_masking
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{PreviousNext("Learn/WebGL/By_example/Simple_color_animation","Learn/WebGL/By_example/Basic_scissoring")}}</p>
 
 <div id="color-masking">

--- a/files/zh-cn/web/api/webgl_api/by_example/detect_webgl/index.html
+++ b/files/zh-cn/web/api/webgl_api/by_example/detect_webgl/index.html
@@ -3,8 +3,6 @@ title: 检测WebGL
 slug: Web/API/WebGL_API/By_example/Detect_WebGL
 translation_of: Web/API/WebGL_API/By_example/Detect_WebGL
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{PreviousNext("Learn/WebGL/By_example","Learn/WebGL/By_example/Clearing_with_colors")}}</p>
 
 <div id="detect-webgl">

--- a/files/zh-cn/web/api/webgl_api/by_example/hello_glsl/index.html
+++ b/files/zh-cn/web/api/webgl_api/by_example/hello_glsl/index.html
@@ -3,8 +3,6 @@ title: Hello GLSL
 slug: Web/API/WebGL_API/By_example/Hello_GLSL
 translation_of: Web/API/WebGL_API/By_example/Hello_GLSL
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{PreviousNext("Learn/WebGL/By_example/Raining_rectangles","Learn/WebGL/By_example/Hello_vertex_attributes")}}</p>
 
 <div id="hello-glsl">

--- a/files/zh-cn/web/api/webgl_api/by_example/index.html
+++ b/files/zh-cn/web/api/webgl_api/by_example/index.html
@@ -3,8 +3,6 @@ title: WebGL 的例子
 slug: Web/API/WebGL_API/By_example
 translation_of: Web/API/WebGL_API/By_example
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{Next("Learn/WebGL/By_example/Detect_WebGL")}}</p>
 
 <div id="webgl-by-example">

--- a/files/zh-cn/web/api/webgl_api/by_example/scissor_animation/index.html
+++ b/files/zh-cn/web/api/webgl_api/by_example/scissor_animation/index.html
@@ -3,8 +3,6 @@ title: Scissor animation
 slug: Web/API/WebGL_API/By_example/Scissor_animation
 translation_of: Web/API/WebGL_API/By_example/Scissor_animation
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{PreviousNext("Learn/WebGL/By_example/Boilerplate_1","Learn/WebGL/By_example/Raining_rectangles")}}</p>
 
 <div id="scissor-animation">

--- a/files/zh-cn/web/api/webgl_api/by_example/simple_color_animation/index.html
+++ b/files/zh-cn/web/api/webgl_api/by_example/simple_color_animation/index.html
@@ -3,8 +3,6 @@ title: Simple color animation
 slug: Web/API/WebGL_API/By_example/Simple_color_animation
 translation_of: Web/API/WebGL_API/By_example/Simple_color_animation
 ---
-<div>{{IncludeSubnav("/en-US/Learn")}}</div>
-
 <p>{{PreviousNext("Learn/WebGL/By_example/Clearing_by_clicking","Learn/WebGL/By_example/Color_masking")}}</p>
 
 <div id="simple-color-animation">
@@ -17,9 +15,9 @@ translation_of: Web/API/WebGL_API/By_example/Simple_color_animation
 <div id="simple-color-animation-intro">
 <h3 id="通过填充实现色彩动画">通过填充实现色彩动画</h3>
 
-<p>本案例使用{{Glossary("WebGL")}}来实现简单的色彩动画和用户交互效果, 用户可以通过按按钮来开始/暂停/重新开始动画.</p>
+<p>本案例使用{{Glossary("WebGL")}}来实现简单的色彩动画和用户交互效果，用户可以通过按按钮来开始/暂停/重新开始动画.</p>
 
-<p>我们把 {{Glossary("WebGL")}}函数放在一个定时循环器里(<code>setInterval</code>)  .通过监听点击事件来让用户开始/暂停动画.并通过定时器来循环执行绘制指令(通常是逐帧动画,这次我们设置为逐秒动画) </p>
+<p>我们把 {{Glossary("WebGL")}}函数放在一个定时循环器里(<code>setInterval</code>)。通过监听点击事件来让用户开始/暂停动画.并通过定时器来循环执行绘制指令(通常是逐帧动画,这次我们设置为逐秒动画) </p>
 </div>
 
 <div id="simple-color-animation-source">

--- a/files/zh-cn/web/api/window/confirm/index.html
+++ b/files/zh-cn/web/api/window/confirm/index.html
@@ -41,9 +41,9 @@ translation_of: Web/API/Window/confirm
 
 <p><a href="/en-US/Chrome" title="Chrome">Mozilla Chrome</a> 的用户(比如Firefox插件开发者)应该使用{{interface("nsIPromptService")}}这个方法.</p>
 
-<p>Chrome浏览器版本 {{CompatChrome(46.0)}} 开始屏蔽内部{{htmlelement("iframe")}}元素, 除非用户在沙箱内开启了<code>allow-modal选项.</code></p>
+<p>Chrome 浏览器版本 {{CompatChrome(46.0)}} 开始屏蔽内部{{htmlelement("iframe")}}元素, 除非用户在沙箱内开启了<code>allow-modal选项.</code></p>
 
-<p>在{{gecko_minversion_inline("23.0")}}内核中, 参数是可选的.</p>
+<p>在 gecko (23) 内核中, 参数是可选的.</p>
 
 <h2 id="Specification" name="Specification">兼容性</h2>
 

--- a/files/zh-cn/web/api/window/content/index.html
+++ b/files/zh-cn/web/api/window/content/index.html
@@ -22,6 +22,3 @@ translation_of: Web/API/Window/content
  <li><a href="zh-CN/Working_with_windows_in_chrome_code">Working with windows in chrome code</a></li>
  <li>When accessing content documents from privileged code, be aware of <a href="zh-CN/XPCNativeWrapper">XPCNativeWrappers</a>.</li>
 </ul>
-<div class="noinclude">
-  </div>
-<p>{{ languages( { "fr": "fr/DOM/window.content", "ja": "ja/DOM/window.content", "pl": "pl/DOM/window.content" } ) }}</p>

--- a/files/zh-cn/web/api/window/focus/index.html
+++ b/files/zh-cn/web/api/window/focus/index.html
@@ -37,5 +37,3 @@ translation_of: Web/API/Window/focus
   </tr>
  </tbody>
 </table>
-
-<p>{{ languages( { "ja": "ja/DOM/window.focus", "pl": "pl/DOM/window.focus" } ) }}</p>

--- a/files/zh-cn/web/api/window/index.html
+++ b/files/zh-cn/web/api/window/index.html
@@ -103,9 +103,9 @@ translation_of: Web/API/Window
  <dd>返回嵌入窗口的元素，如果未嵌入窗口，则返回null。</dd>
  <dt>{{domxref("Window.frames")}} {{readOnlyInline}}</dt>
  <dd>返回当前窗口中所有子窗体的数组。</dd>
- <dt>{{domxref("Window.fullScreen")}} {{gecko_minversion_inline("1.9")}}</dt>
+ <dt>{{domxref("Window.fullScreen")}}</dt>
  <dd>此属性表示窗口是否以全屏显示。</dd>
- <dt>{{domxref("Window.globalStorage")}} {{gecko_minversion_inline("1.8.1")}} {{Non-standard_inline}} {{Obsolete_inline("gecko13")}}</dt>
+ <dt>{{domxref("Window.globalStorage")}} {{Non-standard_inline}} {{Obsolete_inline("gecko13")}}</dt>
  <dd>Gecko 13 (Firefox 13) 开始废弃。使用 {{domxref("Window.localStorage")}} 替代它。<br>
  原本是：用于存储跨页面数据的多重存储对象。</dd>
  <dt>{{domxref("Window.history")}} {{ReadOnlyInline}}</dt>
@@ -122,19 +122,19 @@ translation_of: Web/API/Window
  <dd>获取、设置 window 对象的 location, 或者当前的 URL.</dd>
  <dt>{{domxref("Window.locationbar")}} {{ReadOnlyInline}}</dt>
  <dd>返回 locationbar 对象，其可视性可以在窗口中切换。</dd>
- <dt>{{domxref("Window.localStorage")}} {{readOnlyInline}}{{gecko_minversion_inline("1.9.1")}}</dt>
+ <dt>{{domxref("Window.localStorage")}} {{readOnlyInline}}</dt>
  <dd>返回用来存储只能在创建它的源下访问的数据的本地存储对象的引用</dd>
  <dt>{{domxref("Window.menubar")}} {{ReadOnlyInline}}</dt>
  <dd>返回菜单条对象，它的可视性可以在窗口中切换</dd>
- <dt>{{domxref("Window.messageManager")}} {{gecko_minversion_inline("2.0")}}</dt>
+ <dt>{{domxref("Window.messageManager")}}</dt>
  <dd>返回窗口的 <a href="/en-US/docs/The_message_manager">message manager</a> 对象。</dd>
- <dt>{{domxref("Window.mozAnimationStartTime")}} {{ReadOnlyInline}} {{gecko_minversion_inline("2.0")}} {{Deprecated_inline}}</dt>
+ <dt>{{domxref("Window.mozAnimationStartTime")}} {{ReadOnlyInline}} {{Deprecated_inline}}</dt>
  <dd>返回当前动画循环开始经过的毫秒数</dd>
- <dt>{{domxref("Window.mozInnerScreenX")}} {{ReadOnlyInline}} {{non-standard_inline}} {{gecko_minversion_inline("1.9.2")}}</dt>
+ <dt>{{domxref("Window.mozInnerScreenX")}} {{ReadOnlyInline}} {{non-standard_inline}}</dt>
  <dd>Returns the horizontal (X) coordinate of the top-left corner of the window's viewport, in screen coordinates. This value is reported in CSS pixels. See <code>mozScreenPixelsPerCSSPixel</code> in {{interface("nsIDOMWindowUtils")}} for a conversion factor to adapt to screen pixels if needed.</dd>
- <dt>{{domxref("Window.mozInnerScreenY")}} {{ReadOnlyInline}} {{non-standard_inline}} {{gecko_minversion_inline("1.9.2")}}</dt>
+ <dt>{{domxref("Window.mozInnerScreenY")}} {{ReadOnlyInline}} {{non-standard_inline}}</dt>
  <dd>Returns the vertical (Y) coordinate of the top-left corner of the window's viewport, in screen coordinates. This value is reported in CSS pixels. See <code>mozScreenPixelsPerCSSPixel</code> for a conversion factor to adapt to screen pixels if needed.</dd>
- <dt>{{domxref("Window.mozPaintCount")}} {{non-standard_inline}} {{ReadOnlyInline}} {{gecko_minversion_inline("2.0")}}</dt>
+ <dt>{{domxref("Window.mozPaintCount")}} {{non-standard_inline}} {{ReadOnlyInline}}</dt>
  <dd>Returns the number of times the current document has been rendered to the screen in this window. This can be used to compute rendering performance.</dd>
  <dt>{{domxref("Window.name")}}</dt>
  <dd>获取/设置窗口的名称。</dd>
@@ -264,7 +264,7 @@ translation_of: Web/API/Window
  <dd>Returns the selection object representing the selected item(s).</dd>
  <dt>{{domxref("Window.home()")}} {{Non-standard_inline}} {{obsolete_inline}}</dt>
  <dd>Returns the browser to the home page.</dd>
- <dt>{{domxref("Window.matchMedia()")}} {{gecko_minversion_inline("6.0")}}</dt>
+ <dt>{{domxref("Window.matchMedia()")}}</dt>
  <dd>Returns a {{domxref("MediaQueryList")}} object representing the specified media query string.</dd>
  <dt>{{domxref("Window.maximize()")}}</dt>
  <dd>{{todo("NeedsContents")}}</dd>
@@ -286,7 +286,7 @@ translation_of: Web/API/Window
  <dd>返回用户在提示对话框中输入的文本。</dd>
  <dt>{{domxref("Window.releaseEvents()")}} {{Non-standard_inline}} {{Deprecated_inline}}</dt>
  <dd>释放捕获特定类型事件的窗口。</dd>
- <dt>{{domxref("Window.requestAnimationFrame()")}} {{gecko_minversion_inline("2.0")}}</dt>
+ <dt>{{domxref("Window.requestAnimationFrame()")}}</dt>
  <dd>告诉浏览器一个动画正在进行中，请求浏览器为下一个动画帧重新绘制窗口。</dd>
  <dt>{{domxref("Window.requestIdleCallback()")}} {{experimental_inline}}</dt>
  <dd>启用在浏览器空闲期间对任务进行调度。</dd>
@@ -371,9 +371,9 @@ translation_of: Web/API/Window
  <dd>An event handler property dispatched before a user is prompted to save a web site to a home screen on mobile.</dd>
  <dt>{{domxref("Window.ondevicelight")}}</dt>
  <dd>An event handler property for any ambient light levels changes</dd>
- <dt>{{domxref("Window.ondevicemotion")}} {{gecko_minversion_inline("6.0")}}</dt>
+ <dt>{{domxref("Window.ondevicemotion")}}</dt>
  <dd>Called if accelerometer detects a change (For mobile devices)</dd>
- <dt>{{domxref("Window.ondeviceorientation")}} {{gecko_minversion_inline("6.0")}}</dt>
+ <dt>{{domxref("Window.ondeviceorientation")}}</dt>
  <dd>Called when the orientation is changed (For mobile devices)</dd>
  <dt>{{domxref("Window.ondeviceorientationabsolute")}} {{non-standard_inline}} Chrome only</dt>
  <dd>An event handler property for any device orientation changes.</dd>
@@ -383,7 +383,7 @@ translation_of: Web/API/Window
  <dd>Represents an event handler that will run when a gamepad is connected (when the {{event('gamepadconnected')}} event fires).</dd>
  <dt>{{domxref("Window.ongamepaddisconnected")}}</dt>
  <dd>Represents an event handler that will run when a gamepad is disconnected (when the {{event('gamepaddisconnected')}} event fires).</dd>
- <dt>{{domxref("Window.onmozbeforepaint")}} {{gecko_minversion_inline("2.0")}}</dt>
+ <dt>{{domxref("Window.onmozbeforepaint")}}</dt>
  <dd>An event handler property for the <code>MozBeforePaint</code> event, which is sent before repainting the window if the event has been requested by a call to the {{domxref("Window.mozRequestAnimationFrame()")}} method.</dd>
  <dt>{{domxref("Window.onpaint")}}</dt>
  <dd>An event handler property for paint events on the window.</dd>
@@ -434,7 +434,7 @@ translation_of: Web/API/Window
  <dd>Called when a resource fails to load OR when an error occurs at runtime. See {{event("error")}} event.</dd>
  <dt>{{domxref("GlobalEventHandlers.onfocus")}}</dt>
  <dd>Called after the window receives or regains focus. See {{event("focus")}} events.</dd>
- <dt>{{domxref("WindowEventHandlers.onhashchange")}} {{gecko_minversion_inline("1.9.2")}}</dt>
+ <dt>{{domxref("WindowEventHandlers.onhashchange")}}</dt>
  <dd>An event handler property for {{event('hashchange')}} events on the window; called when the part of the URL after the hash mark ("#") changes.</dd>
  <dt>{{domxref("GlobalEventHandlers.oninput")}}</dt>
  <dd>Called when the value of an &lt;input&gt; element changes</dd>
@@ -468,7 +468,7 @@ translation_of: Web/API/Window
  <dd>Called when the user navigates away from the page, before the onunload event. See {{event("pagehide")}} event.</dd>
  <dt>{{domxref("WindowEventHandlers.onpageshow")}}</dt>
  <dd>Called after all resources and the DOM are fully loaded. See {{event("pageshow")}} event.</dd>
- <dt>{{domxref("WindowEventHandlers.onpopstate")}} {{gecko_minversion_inline("2.0")}}</dt>
+ <dt>{{domxref("WindowEventHandlers.onpopstate")}}</dt>
  <dd>Called when a back button is pressed.</dd>
  <dt>{{domxref("GlobalEventHandlers.onreset")}}</dt>
  <dd>Called when a form is reset</dd>

--- a/files/zh-cn/web/api/window/mozinnerscreenx/index.html
+++ b/files/zh-cn/web/api/window/mozinnerscreenx/index.html
@@ -13,7 +13,7 @@ tags:
   - 接口
 translation_of: Web/API/Window/mozInnerScreenX
 ---
-<div>{{APIRef}}{{gecko_minversion_header("1.9.2")}}</div>
+<div>{{APIRef}}</div>
 
 <h2 id="概要">概要</h2>
 

--- a/files/zh-cn/web/api/window/mozinnerscreeny/index.html
+++ b/files/zh-cn/web/api/window/mozinnerscreeny/index.html
@@ -13,7 +13,7 @@ tags:
   - 接口
 translation_of: Web/API/Window/mozInnerScreenY
 ---
-<div>{{APIRef}}{{gecko_minversion_header("1.9.2")}}</div>
+<div>{{APIRef}}</div>
 
 <h2 id="概要">概要</h2>
 

--- a/files/zh-cn/web/api/window/mozpaintcount/index.html
+++ b/files/zh-cn/web/api/window/mozpaintcount/index.html
@@ -3,7 +3,7 @@ title: Window.mozPaintCount
 slug: Web/API/Window/mozPaintCount
 translation_of: Web/API/Window/mozPaintCount
 ---
-<div>{{APIRef}} {{gecko_minversion_header("2.0")}}</div>
+<div>{{APIRef}}</div>
 
 <p>返回当前文档渲染到屏幕上所需的时间。</p>
 

--- a/files/zh-cn/web/api/window/opendialog/index.html
+++ b/files/zh-cn/web/api/window/opendialog/index.html
@@ -68,4 +68,3 @@ retVals.delivery = "immediate";
 <p>See also <a class="external" href="http://groups.google.com/group/netscape.public.dev.xul/msg/02075a1736406b40">. (</a><a href="cn/Code_snippets/Dialogs_and_Prompts#Passing_arguments_and_displaying_a_dialog">Another example</a>).</p>
 <h3 id="Specification" name="Specification">Specification</h3>
 <p>{{ DOM0() }}</p>
-<p>{{ languages( { "pl": "pl/DOM/window.openDialog" } ) }}</p>

--- a/files/zh-cn/web/api/window/opener/index.html
+++ b/files/zh-cn/web/api/window/opener/index.html
@@ -29,8 +29,6 @@ translation_of: Web/API/Window/opener
 
 <p>{{ DOM0() }}</p>
 
-<p>{{ languages( { "fr": "fr/DOM/window.opener", "ja": "ja/DOM/window.opener", "pl": "pl/DOM/window.opener", "en": "en/DOM/window.opener" } ) }}</p>
-
 <h3 id="浏览器兼容性">浏览器兼容性</h3>
 
 <p>{{Compat("api.Window.opener")}}</p>

--- a/files/zh-cn/web/api/window/parent/index.html
+++ b/files/zh-cn/web/api/window/parent/index.html
@@ -35,5 +35,3 @@ translation_of: Web/API/Window/parent
 <h3 id="Specification" name="Specification">规范</h3>
 
 <p>{{ DOM0() }}</p>
-
-<p>{{ languages( { "fr": "fr/DOM/window.parent", "ja": "ja/DOM/window.parent" , "en": "en/DOM/window.parent"} ) }}</p>

--- a/files/zh-cn/web/api/window/print/index.html
+++ b/files/zh-cn/web/api/window/print/index.html
@@ -17,4 +17,3 @@ translation_of: Web/API/Window/print
  <li><a class="internal" href="/zh-cn/DOM/window.onbeforeprint" title="zh-cn/DOM/window.onbeforeprint"><code>window.onbeforeprint</code></a></li>
  <li><a class="internal" href="/zh-cn/DOM/window.onafterprint" title="zh-cn/DOM/window.onafterprint"><code>window.onafterprint</code></a></li>
 </ol>
-<p>{{ languages( { "ja": "ja/DOM/window.print", "it": "it/DOM/window.print" , "en": "en/DOM/window.print" } ) }}</p>

--- a/files/zh-cn/web/api/window/prompt/index.html
+++ b/files/zh-cn/web/api/window/prompt/index.html
@@ -50,5 +50,3 @@ prompt和alert以及类似的对话框都是模态窗口，它们会阻止用户
 <h3 id="See_also" name="See_also">相关链接</h3>
 
 <p><a href="/zh-cn/DOM/window.alert" title="zh-cn/DOM/window.alert">alert</a>, <a href="/zh-cn/DOM/window.confirm" title="zh-cn/DOM/window.confirm">confirm</a></p>
-
-<p>{{ languages( { "fr": "fr/DOM/window.prompt", "ja": "ja/DOM/window.prompt", "pl": "pl/DOM/window.prompt", "en": "en/DOM/window.prompt" } ) }}</p>

--- a/files/zh-cn/web/api/window/scrollbypages/index.html
+++ b/files/zh-cn/web/api/window/scrollbypages/index.html
@@ -36,5 +36,3 @@ window.scrollByPages(-1);
 <h3 id="Specification" name="Specification"><code>规范</code></h3>
 
 <p><code>DOM Level 0 不属于任何标准</code></p>
-
-<p><code>{{ languages( { "ja": "ja/DOM/window.scrollByPages", "pl": "pl/DOM/window.scrollByPages", "en": "en/DOM/window.scrollByPages" } ) }}</code></p>

--- a/files/zh-cn/web/api/window/sidebar/index.html
+++ b/files/zh-cn/web/api/window/sidebar/index.html
@@ -31,7 +31,7 @@ translation_of: Web/API/Window/sidebar
    <td>Installs a search engine. See <a href="/en-US/docs/Adding_search_engines_from_web_pages" title="Adding_search_engines_from_web_pages">Adding search engines from web pages</a> for details.</td>
   </tr>
   <tr>
-   <td><code>addMicrosummaryGenerator(<var>generatorURL</var>)</code> {{gecko_minversion_inline("1.8.1")}} {{Obsolete_inline(6)}}</td>
+   <td><code>addMicrosummaryGenerator(<var>generatorURL</var>)</code> {{Obsolete_inline(6)}}</td>
    <td>Installs a microsummary generator.</td>
   </tr>
  </tbody>

--- a/files/zh-cn/web/api/windoweventhandlers/onhashchange/index.html
+++ b/files/zh-cn/web/api/windoweventhandlers/onhashchange/index.html
@@ -63,12 +63,12 @@ window.onhashchange = locationHashChanged;
    <td class="header">描述</td>
   </tr>
   <tr>
-   <td><code>newURL</code> {{ gecko_minversion_inline("6.0") }}</td>
+   <td><code>newURL</code></td>
    <td><code>DOMString</code></td>
    <td>当前页面新的URL</td>
   </tr>
   <tr>
-   <td><code>oldURL</code> {{ gecko_minversion_inline("6.0") }}</td>
+   <td><code>oldURL</code></td>
    <td><code>DOMString</code></td>
    <td>当前页面旧的URL</td>
   </tr>

--- a/files/zh-cn/web/api/windoweventhandlers/onpopstate/index.html
+++ b/files/zh-cn/web/api/windoweventhandlers/onpopstate/index.html
@@ -65,5 +65,3 @@ history.go(2);  // 弹出 "location: http://example.com/example.html?page=3, sta
  <li>{{ domxref("window.history") }}</li>
  <li><a href="/zh-cn/DOM/Manipulating_the_browser_history" title="zh-cn/DOM/Manipulating the browser history">Manipulating the browser history</a></li>
 </ul>
-
-<p>{{ languages( {"en": "en/DOM/window.onpopstate" } ) }}</p>

--- a/files/zh-cn/web/api/windoweventhandlers/onpopstate/index.html
+++ b/files/zh-cn/web/api/windoweventhandlers/onpopstate/index.html
@@ -6,8 +6,6 @@ original_slug: Web/API/Window/onpopstate
 ---
 <p>{{ ApiRef() }}</p>
 
-<p>{{ gecko_minversion_header("2") }}</p>
-
 <h3 id="Summary" name="Summary">概述</h3>
 
 <p><code>window.onpopstate</code>是<code>popstate</code>事件在window对象上的事件处理程序.</p>

--- a/files/zh-cn/web/api/windoweventhandlers/onunload/index.html
+++ b/files/zh-cn/web/api/windoweventhandlers/onunload/index.html
@@ -57,8 +57,6 @@ function unloadPage()
 
 <p>{{ DOM0() }}</p>
 
-<p>{{ languages( {"en": "en/DOM/window.onunload" } ) }}</p>
-
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 
 <p>{{Compat("api.WindowEventHandlers.onunload")}}</p>

--- a/files/zh-cn/web/api/xmldocument/load/index.html
+++ b/files/zh-cn/web/api/xmldocument/load/index.html
@@ -31,5 +31,3 @@ xmlDoc.load('querydata.xml');
 <ul>
  <li><a class="external" href="http://www.w3.org/TR/2003/WD-DOM-Level-3-LS-20030619/load-save.html#LS-DocumentLS">Old W3C Working Draft of the DOM Level 3 Load &amp; Save module</a></li>
 </ul>
-
-<p>{{ languages( {"en": "en/DOM/document.load" } ) }}</p>

--- a/files/zh-cn/web/api/xmlhttprequest/index.html
+++ b/files/zh-cn/web/api/xmlhttprequest/index.html
@@ -61,7 +61,7 @@ translation_of: Web/API/XMLHttpRequest
  <dt>{{domxref("XMLHttpRequest.timeout")}}</dt>
  <dd>一个无符号长整型（<code>unsigned long</code>）数字，表示该请求的最大请求时间（毫秒），若超出该时间，请求会自动终止。</dd>
  <dt>{{domxref("XMLHttpRequestEventTarget.ontimeout")}}</dt>
- <dd>当请求超时调用的 {{event("Event_handlers", "event handler")}}。{{ gecko_minversion_inline(" 12.0 ")}}</dd>
+ <dd>当请求超时调用的 {{event("Event_handlers", "event handler")}}。</dd>
  <dt>{{domxref("XMLHttpRequest.upload")}} {{readonlyinline}}</dt>
  <dd>{{domxref("XMLHttpRequestUpload")}}，代表上传进度。</dd>
  <dt>{{domxref("XMLHttpRequest.withCredentials")}}</dt>
@@ -79,7 +79,7 @@ translation_of: Web/API/XMLHttpRequest
  <dd>一个布尔值，如果为真，则在请求时不会强制执行同源策略。</dd>
  <dt>{{domxref("XMLHttpRequest.mozBackgroundRequest")}}</dt>
  <dd>一个布尔值，它指示对象是否是后台服务器端的请求。</dd>
- <dt>{{domxref("XMLHttpRequest.mozResponseArrayBuffer")}}{{gecko_minversion_inline("2.0")}} {{obsolete_inline("6")}} {{ReadOnlyInline}}</dt>
+ <dt>{{domxref("XMLHttpRequest.mozResponseArrayBuffer")}} {{obsolete_inline("6")}} {{ReadOnlyInline}}</dt>
  <dd>一个 {{jsxref("ArrayBuffer")}}，把请求的响应作为一个 JavaScript TypedArray。</dd>
  <dt>{{domxref("XMLHttpRequest.multipart")}}{{obsolete_inline("22")}}</dt>
  <dd><strong>这是一个 Gecko 专有属性，是一个布尔值，已在 Firefox/Gecko 22 中被删除。</strong>请考虑使用 <a href="/en-US/docs/Web/API/Server-sent_events">Server-Sent Event</a>、<a href="/en-US/docs/Web/API/WebSockets_API">Web Socket</a>、或来自进度事件的 <code>responseText</code> 代替。</dd>

--- a/files/zh-cn/web/api/xmlhttprequest/synchronous_and_asynchronous_requests/index.html
+++ b/files/zh-cn/web/api/xmlhttprequest/synchronous_and_asynchronous_requests/index.html
@@ -233,5 +233,3 @@ function logData() {
  <li><a href="https://developer.mozilla.org/en-US/docs/AJAX" title="/en-US/docs/AJAX">AJAX</a></li>
  <li><code><a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon">navigator.sendBeacon</a></code></li>
 </ul>
-
-<p>{{ languages( {"en": "en/DOM/XMLHttpRequest/Synchronous_and_Asynchronous_Requests" } ) }}</p>

--- a/files/zh-cn/web/api/xmlhttprequest/timeout/index.html
+++ b/files/zh-cn/web/api/xmlhttprequest/timeout/index.html
@@ -8,7 +8,7 @@ translation_of: Web/API/XMLHttpRequest/timeout
 ---
 <div>{{APIRef('XMLHttpRequest')}}</div>
 
-<p><code><strong>XMLHttpRequest.timeout</strong></code> 是一个无符号长整型数，代表着一个请求在被自动终止前所消耗的毫秒数。默认值为 0，意味着没有超时。超时并不应该用在一个 {{Glossary('document environment')}} 中的同步 XMLHttpRequests  请求中，否则将会抛出一个 <code>InvalidAccessError</code> 类型的错误。当超时发生， <a href="/zh-CN/docs/Web/Events/timeout">timeout</a> 事件将会被触发。{{gecko_minversion_inline("12.0")}}</p>
+<p><code><strong>XMLHttpRequest.timeout</strong></code> 是一个无符号长整型数，代表着一个请求在被自动终止前所消耗的毫秒数。默认值为 0，意味着没有超时。超时并不应该用在一个 {{Glossary('document environment')}} 中的同步 XMLHttpRequests  请求中，否则将会抛出一个 <code>InvalidAccessError</code> 类型的错误。当超时发生， <a href="/zh-CN/docs/Web/Events/timeout">timeout</a> 事件将会被触发。</p>
 
 <div class="note">
 <p><strong>注意</strong>：你不能在拥有的window中，给同步请求使用超时。</p>

--- a/files/zh-cn/web/api/xmlhttprequest/xmlhttprequest/index.html
+++ b/files/zh-cn/web/api/xmlhttprequest/xmlhttprequest/index.html
@@ -39,7 +39,7 @@ translation_of: Web/API/XMLHttpRequest/XMLHttpRequest
 <h3 id="参数（非标准）">参数（非标准）</h3>
 
 <dl>
- <dt><code>objParameters</code> {{gecko_minversion_inline("16.0")}}</dt>
+ <dt><code>objParameters</code></dt>
  <dd>有两个属性可以设置：
  <dl>
   <dt><code>mozAnon</code></dt>

--- a/files/zh-cn/web/css/appearance/index.html
+++ b/files/zh-cn/web/css/appearance/index.html
@@ -1481,7 +1481,7 @@ translation_of: Web/CSS/appearance
 			<td> </td>
 		</tr>
 		<tr>
-			<td>{{gecko_minversion_inline("2.0")}} <code>-moz-win-borderless-glass</code></td>
+			<td><code>-moz-win-borderless-glass</code></td>
 			<td>
 			<div id="sampleWinBorderlessGlass" class="hidden">
 			<pre class="brush:css">
@@ -1551,7 +1551,7 @@ translation_of: Web/CSS/appearance
 			<td><strong>仅支持 Vista 及更高版本的 Windows 系统。</strong>此工具栏样式是为了用于通讯和生产方面的应用程序，与之对应的前景色为 <code>-moz-win-communicationstext</code>。</td>
 		</tr>
 		<tr>
-			<td>{{gecko_minversion_inline("6.0")}} <code>-moz-win-exclude-glass</code></td>
+			<td><code>-moz-win-exclude-glass</code></td>
 			<td>
 			<div id="sampleWinExcludeGlass" class="hidden">
 			<pre class="brush:css">

--- a/files/zh-cn/web/css/at-rule/index.html
+++ b/files/zh-cn/web/css/at-rule/index.html
@@ -57,5 +57,3 @@ translation_of: Web/CSS/At-rule
  </tbody>
 </table>
 </div>
-
-<p>{{ languages( { "ja": "ja/CSS/At-rule" } ) }}</p>

--- a/files/zh-cn/web/css/color_value/index.html
+++ b/files/zh-cn/web/css/color_value/index.html
@@ -1241,11 +1241,11 @@ translation_of: Web/CSS/color_value
   </dd>
   <dt>-moz-Combobox</dt>
   <dd>
-  <p>{{Gecko_minversion_inline("1.9.2")}} Background color for combo-boxes. Should be used with the <code>-moz-ComboboxText</code> foreground color. In versions prior to 1.9.2, use <code>-moz-Field</code> instead.</p>
+  <p>Background color for combo-boxes. Should be used with the <code>-moz-ComboboxText</code> foreground color. In versions prior to 1.9.2, use <code>-moz-Field</code> instead.</p>
   </dd>
   <dt>-moz-ComboboxText</dt>
   <dd>
-  <p>{{Gecko_minversion_inline("1.9.2")}} Text color for combo-boxes. Should be used with the <code>-moz-Combobox</code> background color. In versions prior to 1.9.2, use <code>-moz-FieldText</code> instead.</p>
+  <p>Text color for combo-boxes. Should be used with the <code>-moz-Combobox</code> background color. In versions prior to 1.9.2, use <code>-moz-FieldText</code> instead.</p>
   </dd>
   <dt>-moz-Dialog</dt>
   <dd>
@@ -1258,15 +1258,15 @@ translation_of: Web/CSS/color_value
   <dt>-moz-dragtargetzone</dt>
   <dt>-moz-EvenTreeRow</dt>
   <dd>
-  <p>{{gecko_minversion_inline("1.9")}} Background color for even-numbered rows in a tree. Should be used with the <code>-moz-FieldText</code> foreground color. In Gecko versions prior to 1.9, use <code>-moz-Field</code>. See also <code>-moz-OddTreeRow</code>.</p>
+  <p>Background color for even-numbered rows in a tree. Should be used with the <code>-moz-FieldText</code> foreground color. In Gecko versions prior to 1.9, use <code>-moz-Field</code>. See also <code>-moz-OddTreeRow</code>.</p>
   </dd>
   <dt>-moz-html-CellHighlight</dt>
   <dd>
-  <p>{{gecko_minversion_inline("1.9")}} Background color for highlighted item in HTML {{HTMLElement("select")}}s. Should be used with the <code>-moz-html-CellHighlightText</code> foreground color. Prior to Gecko 1.9, use <code>-moz-CellHighlight</code>.</p>
+  <p>Background color for highlighted item in HTML {{HTMLElement("select")}}s. Should be used with the <code>-moz-html-CellHighlightText</code> foreground color. Prior to Gecko 1.9, use <code>-moz-CellHighlight</code>.</p>
   </dd>
   <dt>-moz-html-CellHighlightText</dt>
   <dd>
-  <p>{{gecko_minversion_inline("1.9")}} Text color for highlighted items in HTML {{HTMLElement("select")}}s. Should be used with the <code>-moz-html-CellHighlight</code> background color. Prior to Gecko 1.9, use <code>-moz-CellHighlightText</code>.</p>
+  <p>Text color for highlighted items in HTML {{HTMLElement("select")}}s. Should be used with the <code>-moz-html-CellHighlight</code> background color. Prior to Gecko 1.9, use <code>-moz-CellHighlightText</code>.</p>
   </dd>
   <dt>-moz-mac-accentdarkestshadow</dt>
   <dt>-moz-mac-accentdarkshadow</dt>
@@ -1277,11 +1277,9 @@ translation_of: Web/CSS/color_value
   <dt>-moz-mac-accentregularshadow</dt>
   <dt>-moz-mac-chrome-active</dt>
   <dd>
-  <p>{{Gecko_minversion_inline("1.9.1")}}</p>
   </dd>
   <dt>-moz-mac-chrome-inactive</dt>
   <dd>
-  <p>{{Gecko_minversion_inline("1.9.1")}}</p>
   </dd>
   <dt>-moz-mac-focusring</dt>
   <dt>-moz-mac-menuselect</dt>
@@ -1297,7 +1295,7 @@ translation_of: Web/CSS/color_value
   </dd>
   <dt>-moz-MenuBarText</dt>
   <dd>
-  <p>{{Gecko_minversion_inline("1.9.2")}} Text color in menu bars. Often similar to <code>MenuText</code>. Should be used on top of <code>Menu</code> background.</p>
+  <p>Text color in menu bars. Often similar to <code>MenuText</code>. Should be used on top of <code>Menu</code> background.</p>
   </dd>
   <dt>-moz-MenuBarHoverText</dt>
   <dd>
@@ -1305,29 +1303,27 @@ translation_of: Web/CSS/color_value
   </dd>
   <dt>-moz-nativehyperlinktext</dt>
   <dd>
-  <p>{{Gecko_minversion_inline("1.9.1")}} Default platform hyperlink color.</p>
+  <p>Default platform hyperlink color.</p>
   </dd>
   <dt>-moz-OddTreeRow</dt>
   <dd>
-  <p>{{gecko_minversion_inline("1.9")}} Background color for odd-numbered rows in a tree. Should be used with the <code>-moz-FieldText</code> foreground color. In Gecko versions prior to 1.9, use <code>-moz-Field</code>. See also <code>-moz-EvenTreeRow</code>.</p>
+  <p>Background color for odd-numbered rows in a tree. Should be used with the <code>-moz-FieldText</code> foreground color. In Gecko versions prior to 1.9, use <code>-moz-Field</code>. See also <code>-moz-EvenTreeRow</code>.</p>
   </dd>
   <dt>-moz-win-communicationstext</dt>
   <dd>
-  <p>{{gecko_minversion_inline("1.9")}} Should be used for text in objects with <code>{{cssxref("-moz-appearance")}}: -moz-win-communications-toolbox;</code>.</p>
+  <p>Should be used for text in objects with <code>{{cssxref("-moz-appearance")}}: -moz-win-communications-toolbox;</code>.</p>
   </dd>
   <dt>-moz-win-mediatext</dt>
   <dd>
-  <p>{{gecko_minversion_inline("1.9")}} Should be used for text in objects with <code>{{cssxref("-moz-appearance")}}: -moz-win-media-toolbox</code>.</p>
+  <p>Should be used for text in objects with <code>{{cssxref("-moz-appearance")}}: -moz-win-media-toolbox</code>.</p>
   </dd>
   <dt>-moz-win-accentcolor</dt>
   <dd>
-  <p>{{gecko_minversion_inline("56")}}<br>
-   Used to access the Windows 10 custom accent color that you can set on the start menu, taskbar, title bars, etc.</p>
+  <p>Used to access the Windows 10 custom accent color that you can set on the start menu, taskbar, title bars, etc.</p>
   </dd>
   <dt>-moz-win-accentcolortext</dt>
   <dd>
-  <p>{{gecko_minversion_inline("56")}}<br>
-   Used to access the color of text placed over the Windows 10 custom accent color in the start menu, taskbar, title bars, etc.</p>
+  <p>Used to access the color of text placed over the Windows 10 custom accent color in the start menu, taskbar, title bars, etc.</p>
   </dd>
  </dl>
  </div>
@@ -1344,11 +1340,11 @@ translation_of: Web/CSS/color_value
  </dd>
  <dt>-moz-default-background-color</dt>
  <dd>
- <p>{{Gecko_minversion_inline("5.0")}} User's preference for the document background color.</p>
+ <p>User's preference for the document background color.</p>
  </dd>
  <dt>-moz-default-color</dt>
  <dd>
- <p>{{Gecko_minversion_inline("5.0")}} User's preference for the text color.</p>
+ <p>User's preference for the text color.</p>
  </dd>
  <dt>-moz-hyperlinktext</dt>
  <dd>

--- a/files/zh-cn/web/css/css_lists_and_counters/consistent_list_indentation/index.html
+++ b/files/zh-cn/web/css/css_lists_and_counters/consistent_list_indentation/index.html
@@ -103,5 +103,3 @@ original_slug: Web/Guide/CSS/Consistent_list_indentation
  <li>Note: This reprinted article was originally part of the DevEdge site.</li>
 </ul>
 </div>
-
-<p>{{ languages( { "fr": "fr/Indentation_homog\u00e8ne_des_listes" } ) }}</p>

--- a/files/zh-cn/web/css/css_positioning/understanding_z_index/adding_z-index/index.html
+++ b/files/zh-cn/web/css/css_positioning/understanding_z_index/adding_z-index/index.html
@@ -156,4 +156,3 @@ span.bold { font-weight: bold; }
   <li>Last Updated Date: July 9th, 2005</li>
  </ul>
 </div>
-<p>{{ languages( { "fr": "fr/CSS/Comprendre_z-index/Ajout_de_z-index" } ) }}</p>

--- a/files/zh-cn/web/css/css_positioning/understanding_z_index/stacking_without_z-index/index.html
+++ b/files/zh-cn/web/css/css_positioning/understanding_z_index/stacking_without_z-index/index.html
@@ -158,5 +158,3 @@ span.bold { font-weight: bold; }
  <li>Last Updated Date: July 9th, 2005</li>
 </ul>
 </div>
-
-<p>{{ languages( { "fr": "fr/CSS/Comprendre_z-index/Empilement_sans_z-index" } ) }}</p>

--- a/files/zh-cn/web/css/visibility/index.html
+++ b/files/zh-cn/web/css/visibility/index.html
@@ -71,5 +71,3 @@ tr.col   { visibility: collapse; } /* 折叠 class 设为 col 的行        */
 <h3 id=".E5.8F.82.E8.A7.81" name=".E5.8F.82.E8.A7.81">参见</h3>
 
 <p>{{ Cssxref("display") }}</p>
-
-<p>{{ languages( { "en": "en/CSS/visibility", "fr": "fr/CSS/visibility", "pl": "pl/Dokumentacja_CSS/W\u0142asno\u015bci_szablonu" } ) }}</p>

--- a/files/zh-cn/web/css/webkit_extensions/index.html
+++ b/files/zh-cn/web/css/webkit_extensions/index.html
@@ -242,4 +242,3 @@ translation_of: Web/CSS/WebKit_Extensions
   <li>{{ Cssxref("-moz-window-shadow") }}</li>
  </ul>
 </div>
-<p>{{ languages( { "en": "en/CSS/CSS_Reference/Webkit_Extensions"} ) }}</p>

--- a/files/zh-cn/web/events/index.html
+++ b/files/zh-cn/web/events/index.html
@@ -1308,13 +1308,13 @@ translation_of: Web/Events
    <td>An element is about to lose focus (bubbles).</td>
   </tr>
   <tr>
-   <td>{{Event("fullscreenchange")}}{{gecko_minversion_inline("9")}}</td>
+   <td>{{Event("fullscreenchange")}}</td>
    <td>{{DOMxRef("Event")}}</td>
    <td><a href="https://dvcs.w3.org/hg/fullscreen/raw-file/tip/Overview.html#api">Full Screen</a></td>
    <td>An element was turned to fullscreen mode or back to normal mode.</td>
   </tr>
   <tr>
-   <td>{{Event("fullscreenerror")}}{{gecko_minversion_inline("9")}}</td>
+   <td>{{Event("fullscreenerror")}}</td>
    <td>{{DOMxRef("Event")}}</td>
    <td><a href="https://dvcs.w3.org/hg/fullscreen/raw-file/tip/Overview.html#api">Full Screen</a></td>
    <td>It was impossible to switch to fullscreen mode for technical reasons or because the permission was denied.</td>

--- a/files/zh-cn/web/exslt/index.html
+++ b/files/zh-cn/web/exslt/index.html
@@ -87,6 +87,3 @@ EXSLT is a set of extensions to <a href="en/XSLT">XSLT</a>. There are a number o
 </li></ul>
 <p><br>
 </p>
-<div class="noinclude">
-</div>
-{{ languages( { "es": "es/EXSLT", "fr": "fr/EXSLT", "ja": "ja/EXSLT", "pl": "pl/EXSLT" } ) }}

--- a/files/zh-cn/web/exslt/regexp/match/index.html
+++ b/files/zh-cn/web/exslt/regexp/match/index.html
@@ -63,7 +63,3 @@ Part 5 = /en/docs/Firefox_3_for_developers
 <h3 id="Gecko_support" name="Gecko_support">Gecko support</h3>
 
 <p>Supported in Gecko 1.9 and later.</p>
-
-<div class="noinclude"> </div>
-
-<p>{{ languages( { "es": "es/EXSLT/regexp/match", "fr": "fr/EXSLT/regexp/match" } ) }}</p>

--- a/files/zh-cn/web/html/element/ul/index.html
+++ b/files/zh-cn/web/html/element/ul/index.html
@@ -210,5 +210,3 @@ translation_of: Web/HTML/Element/ul
   </ul>
  </li>
 </ul>
-
-<p>{{ languages({ "en":"en/HTML/Element/ul", "de":"de/HTML/Element/ul", "ja":"ja/HTML/Element/ul", "pl":"pl/HTML/Element/ul"}) }}</p>

--- a/files/zh-cn/web/http/headers/index.html
+++ b/files/zh-cn/web/http/headers/index.html
@@ -87,49 +87,49 @@ translation_of: Web/HTTP/Headers
   <tr>
    <td><code><a href="/en-US/docs/HTTP_access_control#Access-Control-Allow-Credentials" title="https://developer.mozilla.org/En/HTTP_access_control#Access-Control-Allow-Credentials">Access-Control-Allow-Credentials</a></code></td>
    <td></td>
-   <td><a href="/en-US/docs/HTTP_access_control" title="En/HTTP access control">HTTP Access Control</a> and <a href="/en-US/docs/Server-Side_Access_Control" title="En/Server-Side Access Control">Server Side Access Control</a>{{ gecko_minversion_inline("1.9.1") }}</td>
+   <td><a href="/en-US/docs/HTTP_access_control" title="En/HTTP access control">HTTP Access Control</a> and <a href="/en-US/docs/Server-Side_Access_Control" title="En/Server-Side Access Control">Server Side Access Control</a></td>
    <td><a class="external" href="http://www.w3.org/TR/cors/">W3C Cross-Origin Resource Sharing</a></td>
   </tr>
   <tr>
    <td><code><a href="/en-US/docs/HTTP_access_control#Access-Control-Allow-Origin" title="https://developer.mozilla.org/En/HTTP_access_control#Access-Control-Allow-Origin">Access-Control-Allow-Origin</a></code></td>
    <td></td>
-   <td><a href="/en-US/docs/HTTP_access_control" title="En/HTTP access control">HTTP Access Control</a> and <a href="/en-US/docs/Server-Side_Access_Control" title="En/Server-Side Access Control">Server Side Access Control</a>{{ gecko_minversion_inline("1.9.1") }}</td>
+   <td><a href="/en-US/docs/HTTP_access_control" title="En/HTTP access control">HTTP Access Control</a> and <a href="/en-US/docs/Server-Side_Access_Control" title="En/Server-Side Access Control">Server Side Access Control</a></td>
    <td><a class="external" href="http://www.w3.org/TR/cors/">W3C Cross-Origin Resource Sharing</a></td>
   </tr>
   <tr>
    <td><code><a href="/en-US/docs/HTTP_access_control#Access-Control-Allow-Methods" title="https://developer.mozilla.org/En/HTTP_access_control#Access-Control-Allow-Methods">Access-Control-Allow-Methods</a></code></td>
    <td></td>
-   <td><a href="/en-US/docs/HTTP_access_control" title="En/HTTP access control">HTTP Access Control</a> and <a href="/en-US/docs/Server-Side_Access_Control" title="En/Server-Side Access Control">Server Side Access Control</a>{{ gecko_minversion_inline("1.9.1") }}</td>
+   <td><a href="/en-US/docs/HTTP_access_control" title="En/HTTP access control">HTTP Access Control</a> and <a href="/en-US/docs/Server-Side_Access_Control" title="En/Server-Side Access Control">Server Side Access Control</a></td>
    <td><a class="external" href="http://www.w3.org/TR/cors/">W3C Cross-Origin Resource Sharing</a></td>
   </tr>
   <tr>
    <td><code><a href="/en-US/docs/HTTP_access_control#Access-Control-Allow-Headers" title="https://developer.mozilla.org/En/HTTP_access_control#Access-Control-Allow-Headers">Access-Control-Allow-Headers</a></code></td>
    <td></td>
-   <td><a href="/en-US/docs/HTTP_access_control" title="En/HTTP access control">HTTP Access Control</a> and <a href="/en-US/docs/Server-Side_Access_Control" title="En/Server-Side Access Control">Server Side Access Control</a>{{ gecko_minversion_inline("1.9.1") }}</td>
+   <td><a href="/en-US/docs/HTTP_access_control" title="En/HTTP access control">HTTP Access Control</a> and <a href="/en-US/docs/Server-Side_Access_Control" title="En/Server-Side Access Control">Server Side Access Control</a></td>
    <td><a class="external" href="http://www.w3.org/TR/cors/">W3C Cross-Origin Resource Sharing</a></td>
   </tr>
   <tr>
    <td><code><a href="/en-US/docs/HTTP_access_control#Access-Control-Max-Age" title="https://developer.mozilla.org/En/HTTP_access_control#Access-Control-Max-Age">Access-Control-Max-Age</a></code></td>
    <td></td>
-   <td><a href="/en-US/docs/HTTP_access_control" title="En/HTTP access control">HTTP Access Control</a> and <a href="/en-US/docs/Server-Side_Access_Control" title="En/Server-Side Access Control">Server Side Access Control</a>{{ gecko_minversion_inline("1.9.1") }}</td>
+   <td><a href="/en-US/docs/HTTP_access_control" title="En/HTTP access control">HTTP Access Control</a> and <a href="/en-US/docs/Server-Side_Access_Control" title="En/Server-Side Access Control">Server Side Access Control</a></td>
    <td><a class="external" href="http://www.w3.org/TR/cors/">W3C Cross-Origin Resource Sharing</a></td>
   </tr>
   <tr>
    <td><code><a href="/en-US/docs/HTTP_access_control#Access-Control-Expose-Header" title="en/HTTP access control#Access-Control-Expose-Header">Access-Control-Expose-Headers</a></code></td>
    <td></td>
-   <td><a href="/en-US/docs/HTTP_access_control" title="En/HTTP access control">HTTP Access Control</a> and <a href="/en-US/docs/Server-Side_Access_Control" title="En/Server-Side Access Control">Server Side Access Control</a>{{ gecko_minversion_inline("2") }}</td>
+   <td><a href="/en-US/docs/HTTP_access_control" title="En/HTTP access control">HTTP Access Control</a> and <a href="/en-US/docs/Server-Side_Access_Control" title="En/Server-Side Access Control">Server Side Access Control</a></td>
    <td><a class="external" href="http://www.w3.org/TR/cors/">W3C Cross-Origin Resource Sharing</a></td>
   </tr>
   <tr>
    <td><code><a href="/en-US/docs/HTTP_access_control#Access-Control-Request-Method" title="https://developer.mozilla.org/En/HTTP_access_control#Access-Control-Request-Method">Access-Control-Request-Method</a></code></td>
    <td></td>
-   <td><a href="/en-US/docs/HTTP_access_control" title="En/HTTP access control">HTTP Access Control</a> and <a href="/en-US/docs/Server-Side_Access_Control" title="En/Server-Side Access Control">Server Side Access Control</a>{{ gecko_minversion_inline("1.9.1") }}</td>
+   <td><a href="/en-US/docs/HTTP_access_control" title="En/HTTP access control">HTTP Access Control</a> and <a href="/en-US/docs/Server-Side_Access_Control" title="En/Server-Side Access Control">Server Side Access Control</a></td>
    <td><a class="external" href="http://www.w3.org/TR/cors/">W3C Cross-Origin Resource Sharing</a></td>
   </tr>
   <tr>
    <td><code><a href="/en-US/docs/HTTP_access_control#Access-Control-Request-Headers" title="https://developer.mozilla.org/En/HTTP_access_control#Access-Control-Request-Headers">Access-Control-Request-Headers</a></code></td>
    <td></td>
-   <td><a href="/en-US/docs/HTTP_access_control" title="En/HTTP access control">HTTP Access Control</a> and <a href="/en-US/docs/Server-Side_Access_Control" title="En/Server-Side Access Control">Server Side Access Control</a>{{ gecko_minversion_inline("1.9.1") }}</td>
+   <td><a href="/en-US/docs/HTTP_access_control" title="En/HTTP access control">HTTP Access Control</a> and <a href="/en-US/docs/Server-Side_Access_Control" title="En/Server-Side Access Control">Server Side Access Control</a></td>
    <td><a class="external" href="http://www.w3.org/TR/cors/">W3C Cross-Origin Resource Sharing</a></td>
   </tr>
   <tr>
@@ -339,7 +339,7 @@ translation_of: Web/HTTP/Headers
   <tr>
    <td><code><a href="/en-US/docs/HTTP_access_control#Origin" title="https://developer.mozilla.org/En/HTTP_access_control#Origin">Origin</a></code></td>
    <td></td>
-   <td><a href="/en-US/docs/HTTP_access_control" title="En/HTTP access control">HTTP Access Control</a> and <a href="/en-US/docs/Server-Side_Access_Control" title="En/Server-Side Access Control">Server Side Access Control</a>{{ gecko_minversion_inline("1.9.1") }}</td>
+   <td><a href="/en-US/docs/HTTP_access_control" title="En/HTTP access control">HTTP Access Control</a> and <a href="/en-US/docs/Server-Side_Access_Control" title="En/Server-Side Access Control">Server Side Access Control</a></td>
    <td>More recently defined in the <a href="https://fetch.spec.whatwg.org/#http-extensions">Fetch spec</a> (see <a href="/en-US/docs/Web/API/Fetch_API">Fetch API</a>.) Originally defined in <a class="external" href="http://www.w3.org/TR/cors/">W3C Cross-Origin Resource Sharing</a></td>
   </tr>
   <tr>

--- a/files/zh-cn/web/http/headers/user-agent/firefox/index.html
+++ b/files/zh-cn/web/http/headers/user-agent/firefox/index.html
@@ -20,7 +20,7 @@ translation_of: Web/HTTP/Headers/User-Agent/Firefox
  <li><strong><em>Gecko/geckotrail</em></strong> 标明浏览器基于 Gecko。</li>
  <li>在桌面端，<em><strong>geckotrail</strong></em> 的值恒为"20100101"。</li>
  <li><em><strong>Firefox/firefoxversion</strong></em> 标明浏览器是 Firefox，并提供了版本号（如"<em>17.0"</em>）。</li>
- <li>{{ gecko_minversion_inline("10.0") }} 自从移动版Firefox 10开始，<em><strong>geckotrail</strong></em>与<strong><em>firefoxversion</em></strong>保持一致。</li>
+ <li>自从移动版Firefox 10开始，<em><strong>geckotrail</strong></em>与<strong><em>firefoxversion</em></strong>保持一致。</li>
 </ul>
 
 <div class="note">（如果你必须检测浏览器引擎，而不是去做特征检测的话）推荐使用"<em>Gecko</em>"与"<em>rv:</em>"字符串来检测基于 Gecko 的浏览器。因为一些浏览器的 UA 中也包含有"<em>like Gecko</em>"字段。</div>

--- a/files/zh-cn/web/mathml/attribute/index.html
+++ b/files/zh-cn/web/mathml/attribute/index.html
@@ -8,7 +8,7 @@ translation_of: Web/MathML/Attribute
 <p>注意：</p>
 
 <ul>
- <li>MathML的 {{ MathMLElement("mstyle") }} 和 {{ MathMLElement("math") }} {{ gecko_minversion_inline("7.0") }} 元素接受所有 MathML 的描述元素。</li>
+ <li>MathML的 {{ MathMLElement("mstyle") }} 和 {{ MathMLElement("math") }} 元素接受所有 MathML 的描述元素。</li>
  <li>请参阅MathML中值（<a href="/en-US/docs/MathML/Attributes/Values" title="/en-US/docs/MathML/Attributes/Values">values</a>）和单位的注释值。</li>
 </ul>
 
@@ -16,7 +16,7 @@ translation_of: Web/MathML/Attribute
  <thead>
   <tr>
    <th>名（Name）</th>
-   <th><span class="hidden"> </span><span class="hidden"> </span>元素接受的属性（Elements accepting attribute）<span class="hidden"> </span><span class="hidden"> </span></th>
+   <th>元素接受的属性（Elements accepting attribute）</th>
    <th>描述（Description）</th>
   </tr>
  </thead>

--- a/files/zh-cn/web/svg/svg_1.1_support_in_firefox/index.html
+++ b/files/zh-cn/web/svg/svg_1.1_support_in_firefox/index.html
@@ -34,7 +34,7 @@ translation_of: Web/SVG/SVG_1.1_Support_in_Firefox
        <li>Unimplemented bindings: getIntersectionList, getEnclosureList, checkIntersection, checkEnclosure, deselectAll</li>
        <li>Recently implemented bindings:
         <ul>
-         <li>getElementById {{gecko_minversion_inline("11")}}, useCurrentView {{gecko_minversion_inline("15")}}</li>
+         <li>getElementById, useCurrentView</li>
         </ul>
        </li>
       </ul>
@@ -209,11 +209,11 @@ translation_of: Web/SVG/SVG_1.1_Support_in_Firefox
     <ul>
      <li>已实现</li>
      <li>Various presentation attributes don't work (alignment-baseline, baseline-shift, dominant-baseline, kerning, letter-spacing, word-spacing, writing-mode, glyph-orientation-horizontal, glyph-orientation-vertical)</li>
-     <li>Recently implemented presentation attributes: direction, unicode-bidi, font-variant, text-decoration {{gecko_minversion_inline("25")}}</li>
+     <li>Recently implemented presentation attributes: direction, unicode-bidi, font-variant, text-decoration</li>
      <li>SVGTextElement
       <ul>
-       <li>Recently imlemented bindings: selectSubString {{gecko_minversion_inline("25")}}</li>
-       <li>Recently implemented attributes: textLength, lengthAdjust {{gecko_minversion_inline("25")}}</li>
+       <li>Recently imlemented bindings: selectSubString</li>
+       <li>Recently implemented attributes: textLength, lengthAdjust</li>
       </ul>
      </li>
     </ul>
@@ -225,11 +225,11 @@ translation_of: Web/SVG/SVG_1.1_Support_in_Firefox
     <ul>
      <li>已实现</li>
      <li>Various presentation attributes don't work (alignment-baseline, baseline-shift, dominant-baseline, kerning, letter-spacing, word-spacing, writing-mode, glyph-orientation-horizontal, glyph-orientation-vertical)</li>
-     <li>Recently implemented presentation attributes: direction, unicode-bidi, font-variant, text-decoration {{gecko_minversion_inline("25")}}</li>
+     <li>Recently implemented presentation attributes: direction, unicode-bidi, font-variant, text-decoration</li>
      <li>SVGTSpanElement
       <ul>
-       <li>Recently implemented bindings: selectSubString{{gecko_minversion_inline("25")}}</li>
-       <li>Recently implemented attributes: textLength, lengthAdjust {{gecko_minversion_inline("25")}}</li>
+       <li>Recently implemented bindings: selectSubString</li>
+       <li>Recently implemented attributes: textLength, lengthAdjust</li>
       </ul>
      </li>
     </ul>
@@ -248,7 +248,7 @@ translation_of: Web/SVG/SVG_1.1_Support_in_Firefox
    <td>
     <ul>
      <li>已实现</li>
-     <li>Recently implemented bindings: selectSubString{{gecko_minversion_inline("25")}}</li>
+     <li>Recently implemented bindings: selectSubString</li>
     </ul>
    </td>
   </tr>
@@ -374,7 +374,7 @@ translation_of: Web/SVG/SVG_1.1_Support_in_Firefox
    <td>
     <ul>
      <li>已实现</li>
-     <li>Of the pseudo-inputs, <code>SourceGraphic</code>, <code>SourceAlpha</code>, <code>FillPaint</code> {{gecko_minversion_inline("17")}} and <code>StrokePaint</code> {{gecko_minversion_inline("17")}} are implemented.</li>
+     <li>Of the pseudo-inputs, <code>SourceGraphic</code>, <code>SourceAlpha</code>, <code>FillPaint</code> and <code>StrokePaint</code> are implemented.</li>
      <li>Use of an unimplemented pseudo-input or filter element will cause the filter to be ignored and the referring graphic to be drawn without any filter.</li>
     </ul>
    </td>
@@ -601,7 +601,7 @@ translation_of: Web/SVG/SVG_1.1_Support_in_Firefox
    <td><a href="http://www.w3.org/TR/SVG11/linking.html#ViewElement">view</a></td>
    <td>
     <ul>
-     <li>Implemented in Gecko 15.0 ({{Bug(512525)}}). {{gecko_minversion_inline("15.0")}}.</li>
+     <li>Implemented in Gecko 15.0 ({{Bug(512525)}}).</li>
     </ul>
    </td>
   </tr>

--- a/files/zh-cn/web/svg/tutorial/getting_started/index.html
+++ b/files/zh-cn/web/svg/tutorial/getting_started/index.html
@@ -92,5 +92,3 @@ Vary: Accept-Encoding</pre>
 <p>服务器配置错误是SVG加载失败的常见原因，所以一定要确保你的服务器配置正确。如果不能把服务器配置成给SVG文件发送正确的响应头，这时Firefox很有可能把该文件的标记显示成文本或乱码，甚至会要求查看者选择打开文件的应用程序。</p>
 
 <p>{{ PreviousNext("Web/SVG/Tutorial/Introduction", "Web/SVG/Tutorial/Positions") }}</p>
-
-<p>{{ languages( { "fr": "fr/SVG/Tutoriel/Premiers_pas", "ja": "ja/SVG/Tutorial/Getting_Started" } ) }}</p>

--- a/files/zh-cn/web/svg/tutorial/index.html
+++ b/files/zh-cn/web/svg/tutorial/index.html
@@ -54,5 +54,3 @@ translation_of: Web/SVG/Tutorial
 <h5 id="在SVG中创建字体">在SVG中创建字体</h5>
 
 <p>待定</p>
-
-<p>{{ languages( { "de": "de/SVG/Tutorial", "fr": "fr/SVG/Tutoriel", "ja": "ja/SVG/Tutorial", "pl": "pl/SVG/Przewodnik", "zh-CN":"zh-CN/SVG/Tutorial" } ) }}</p>

--- a/files/zh-cn/web/svg/tutorial/introduction/index.html
+++ b/files/zh-cn/web/svg/tutorial/introduction/index.html
@@ -39,5 +39,3 @@ translation_of: Web/SVG/Tutorial/Introduction
 <p>另外还有一些关于SVG打印规格的项目，增加对多页面和颜色管理的支持，但是这项工作已经终止。</p>
 
 <p>{{ PreviousNext("Web/SVG/Tutorial", "Web/SVG/Tutorial/Getting_Started") }}</p>
-
-<p>{{ languages( { "de": "de/SVG/Tutorial/Einführung", "fr": "fr/SVG/Tutoriel/Introduction", "ja": "ja/SVG/Tutorial/Introduction", "zh-CN": "zh-CN/SVG/Tutorial/Introduction" } ) }}</p>

--- a/files/zh-cn/web/xpath/axes/index.html
+++ b/files/zh-cn/web/xpath/axes/index.html
@@ -66,6 +66,3 @@ translation_of: Web/XPath/Axes
  <dd>
   Indicates the context node itself. It can be abbreviated as a single period (<code>.</code>).</dd>
 </dl>
-<div class="noinclude">
-  </div>
-<p>{{ languages( { "es": "es/XPath/Ejes", "fr": "fr/XPath/Axes", "ja": "ja/XPath/Axes", "en": "en/XPath/Axes", "pl": "pl/XPath/Osie" } ) }}</p>

--- a/files/zh-cn/web/xslt/element/index.html
+++ b/files/zh-cn/web/xslt/element/index.html
@@ -51,4 +51,3 @@ original_slug: Web/XSLT/Elements
  <li><a href="/cn/XSLT/when" title="cn/XSLT/when">xsl:when</a></li>
  <li><a href="/cn/XSLT/with-param" title="cn/XSLT/with-param">xsl:with-param</a></li>
 </ul>
-<p>{{ languages( { "en": "en/XSLT/Elements", "fr": "fr/XSLT/\u00c9l\u00e9ments", "ja": "ja/XSLT/Elements", "pl": "pl/XSLT/Elementy" } ) }}</p>

--- a/files/zh-cn/web/xslt/index.html
+++ b/files/zh-cn/web/xslt/index.html
@@ -74,7 +74,3 @@ translation_of: Web/XSLT
 <p><span class="comment">Categories</span></p>
 
 <p><span class="comment">Interwiki Language Links</span></p>
-
-<p> </p>
-
-<p>{{ languages( { "en": "en/XSLT", "es": "es/XSLT", "fr": "fr/XSLT", "it": "it/XSLT", "ja": "ja/XSLT", "ko": "ko/XSLT", "pl": "pl/XSLT", "pt": "pt/XSLT" } ) }}</p>

--- a/files/zh-cn/web/xslt/transforming_xml_with_xslt/index.html
+++ b/files/zh-cn/web/xslt/transforming_xml_with_xslt/index.html
@@ -343,4 +343,3 @@ translation_of: Web/XSLT/Transforming_XML_with_XSLT
   <li>Note: This reprinted article was originally part of the DevEdge site.</li>
  </ul>
 </div>
-<p>{{ languages( { "es": "es/Transformando_XML_con_XSLT", "fr": "fr/Transformations_XML_avec_XSLT", "pl": "pl/Transformacje_XML_z_XSLT", "ko": "ko/Transforming_XML_with_XSLT" } ) }}</p>


### PR DESCRIPTION
As a part of #4579

Refer #4593 , remove the following macros:

- `gecko_minversion_header`
- `gecko_minversion_inline`
- `IncludeSubnav`
- `languages`
