### PR TITLE
fix: PR rules

### DIFF
--- a/docs/ko/translation-guide.md
+++ b/docs/ko/translation-guide.md
@@ -26,7 +26,8 @@ MDN의 모든 로케일은 `en-us`를 기준으로 변역이 진행되고 있습
 ### PR 규칙
 
 - `ko-locale`에 존재하지 않는 새로운 파일에 대한 번역을 진행할 때, **파일 전체 번역**을 원칙으로 합니다. (단, [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)와 같이 분량이 많은 파일에 대해서는 부분 번역을 허용합니다. 이때, 번역되지 않은 부분은 `en-us locale` 원본으로 대체합니다.)
-- `PR`의 `Merge` 우선 순위는 먼저 PR을 생성한 순서대로 우선권을 갖습니다. 리뷰어는 우선 순위가 있는 PR을 먼저 병합하는것을 원칙으로 합니다. 따라서, 번역을 진행하기 전에, `Draft PR`을 먼저 생성하는 것을 권장합니다. [ko-locale PR 목록](https://github.com/mdn/translated-content/pulls?q=is%3Apr+is%3Aopen+label%3Al10n-ko+)
+- `PR`의 `Merge` 우선 순위는 관련 이슈에서 가장 처음 언급된 `PR`이 병합 우선권을 갖습니다. 리뷰어는 우선 순위가 있는 PR을 먼저 병합하는것을 원칙으로 합니다. 따라서, 번역을 진행하기 전에, `PR`과 관련된 이슈가 없다면 이슈를 생성하는 것을 권장합니다. [ko-locale PR 목록](https://github.com/mdn/translated-content/pulls?q=is%3Apr+is%3Aopen+label%3Al10n-ko+)
+- 위 규칙들로 우선 순위를 정하기 힘든 경우 리뷰어는 기여자에게 충돌 해결을 요청 드릴 수 있습니다. 이 경우에는 충돌 해결 후 병합을 진행합니다.
 
 ### ko-locale 현황판
 


### PR DESCRIPTION
- **AS IS**
  - PR 생성 순서로 병합 우선순위 부여
- **TO BE**
  - 관련 ISSUE에서 먼저 언급된 PR 순서로 병합 우선 순위 부여

기존의 방식으로 진행하면, 리뷰어 입장에서 PR을 추적하기 힘들어서 선행 PR을 놓칠 수 있습니다. ISSUE 로 병합 우선순위를 관리하는것이 좋아보입니다. 해당 규칙에 대해 의견 있으시면 알려주세요 :)

명시된 규칙으로 정할 수 없는 예외 경우가 많아서 항목 하나를 더 추가했습니다. 

@yechoi42 관련 이슈(https://github.com/mdn/translated-content/issues/3842)로 추가 리뷰어 지정했습니다.

@mdn/yari-content-ko