### PR TITLE
Remove Thimble links.

### DIFF
--- a/files/zh-cn/learn/accessibility/index.html
+++ b/files/zh-cn/learn/accessibility/index.html
@@ -14,7 +14,7 @@ translation_of: Learn/Accessibility
 <p>为了充分理解这个模块,你至少需要读过 <a href="/zh-CN/docs/Learn/HTML">HTML</a>, <a href="/zh-CN/docs/Learn/CSS">CSS</a>, 和 <a href="/zh-CN/docs/Learn/JavaScript">JavaScript</a>  各个话题的前两个模块, 或者有可能的话, 在你学习相关联的技术话题时也把可访问性相关的内容学习了, 这样会更好。</p>
 
 <div class="note">
-<p><strong>注意</strong>: 如果在你所使用的设备上你不能建立自己的文件,你可以使用在线编码平台运行大多数样例代码, 比如 <a href="http://jsbin.com/">JSBin</a> 或者 <a href="https://thimble.mozilla.org/">Thimble</a>.</p>
+<p><strong>注意</strong>: 如果在你所使用的设备上你不能建立自己的文件,你可以使用在线编码平台运行大多数样例代码, 比如 <a href="http://jsbin.com/">JSBin</a> 或者 <a href="https://glitch.com/">Glitch</a>.</p>
 </div>
 
 <h2 id="参考指南">参考指南</h2>

--- a/files/zh-cn/learn/css/building_blocks/a_cool_looking_box/index.html
+++ b/files/zh-cn/learn/css/building_blocks/a_cool_looking_box/index.html
@@ -32,7 +32,7 @@ original_slug: Learn/CSS/Styling_boxes/A_cool_looking_box
 </ul>
 
 <div class="note">
-<p><strong>提醒</strong>：或者你也可以用<a href="http://jsbin.com/" rel="noopener">JSBin</a>或<a href="https://thimble.mozilla.org/" rel="noopener">Thimble</a>这样的网站来做这个评估，把链接里的HTML和CSS代码贴到这些在线编辑器里就行。如果你在用的在线编辑器没有独立的CSS面板的话，把CSS代码放到HTML文档头部的<code>&lt;style&gt;</code>元素里就好。</p>
+<p><strong>提醒</strong>：或者你也可以用<a href="http://jsbin.com/" rel="noopener">JSBin</a>或<a href="https://glitch.com/" rel="noopener">Glitch</a>这样的网站来做这个评估，把链接里的HTML和CSS代码贴到这些在线编辑器里就行。如果你在用的在线编辑器没有独立的CSS面板的话，把CSS代码放到HTML文档头部的<code>&lt;style&gt;</code>元素里就好。</p>
 </div>
 
 <h2 id="项目简介">项目简介</h2>

--- a/files/zh-cn/learn/css/building_blocks/creating_fancy_letterheaded_paper/index.html
+++ b/files/zh-cn/learn/css/building_blocks/creating_fancy_letterheaded_paper/index.html
@@ -33,7 +33,7 @@ original_slug: Learn/CSS/Styling_boxes/Creating_fancy_letterheaded_paper
 </ul>
 
 <div class="note">
-<p><strong>提醒</strong>：或者你也可以用<a href="http://jsbin.com/">JSBin</a>或<a href="https://thimble.mozilla.org/">Thimble</a>这样的网站来做这个评估，把链接里的HTML和CSS代码贴到这些在线编辑器里就行。如果你在用的在线编辑器没有独立的CSS面板的话，把CSS代码放到HTML文档头部的<code>&lt;style&gt;</code>元素里就好。</p>
+<p><strong>提醒</strong>：或者你也可以用<a href="http://jsbin.com/">JSBin</a>或<a href="https://glitch.com/">Glitch</a>这样的网站来做这个评估，把链接里的HTML和CSS代码贴到这些在线编辑器里就行。如果你在用的在线编辑器没有独立的CSS面板的话，把CSS代码放到HTML文档头部的<code>&lt;style&gt;</code>元素里就好。</p>
 </div>
 
 <h2 id="项目简介">项目简介</h2>

--- a/files/zh-cn/learn/css/building_blocks/fundamental_css_comprehension/index.html
+++ b/files/zh-cn/learn/css/building_blocks/fundamental_css_comprehension/index.html
@@ -38,7 +38,7 @@ original_slug: Learn/CSS/Introduction_to_CSS/Fundamental_CSS_comprehension
 </ul>
 
 <div class="note">
-<p><strong>注意</strong>: 另外, 你可以使用一个网站比如 <a class="external external-icon" href="http://jsbin.com/">JSBin</a> 或 <a class="external external-icon" href="https://thimble.mozilla.org/">Thimble</a> 来做你的测验。你可以复制 HTML 和 CSS 到其中一个在线编辑器中，以及使用这个 <a href="http://mdn.github.io/learning-area/css/introduction-to-css/fundamental-css-comprehension/chris.jpg">this URL</a> 来让 <code>&lt;img&gt;</code> 显示图片。如果你使用的在线编辑器无法让你链接 CSS 文件 (没有单独的 CSS 面板)，你也可以将 CSS 直接放入<code>&lt;style&gt;</code> 元素中。</p>
+<p><strong>注意</strong>: 另外, 你可以使用一个网站比如 <a class="external external-icon" href="http://jsbin.com/">JSBin</a> 或 <a class="external external-icon" href="https://glitch.com/">Glitch</a> 来做你的测验。你可以复制 HTML 和 CSS 到其中一个在线编辑器中，以及使用这个 <a href="http://mdn.github.io/learning-area/css/introduction-to-css/fundamental-css-comprehension/chris.jpg">this URL</a> 来让 <code>&lt;img&gt;</code> 显示图片。如果你使用的在线编辑器无法让你链接 CSS 文件 (没有单独的 CSS 面板)，你也可以将 CSS 直接放入<code>&lt;style&gt;</code> 元素中。</p>
 </div>
 
 <h2 id="项目概要">项目概要</h2>

--- a/files/zh-cn/learn/css/building_blocks/index.html
+++ b/files/zh-cn/learn/css/building_blocks/index.html
@@ -21,9 +21,9 @@ translation_of: Learn/CSS/Building_blocks
 </ol>
 
 <div class="note">
-<p><strong>注意：</strong>如果你此刻正使用一台电脑/笔记本/其他设备，而你无法创建自己的文件，那你可以在诸如JSBin或Thimble等网络编辑程序上尝试（多数）程序案例。 </p>
+<p><strong>注意：</strong>如果你此刻正使用一台电脑/笔记本/其他设备，而你无法创建自己的文件，那你可以在诸如JSBin或Glitch等网络编辑程序上尝试（多数）程序案例。 </p>
 </div>
-
+G
 <h2 id="指南">指南</h2>
 
 <p>本模块包含以下文章，这些文章覆盖了绝大部分CSS语言基础。在学习这些文章的过程中，会有很多练习题供你检验自己的理解程度。</p>

--- a/files/zh-cn/learn/css/css_layout/index.html
+++ b/files/zh-cn/learn/css/css_layout/index.html
@@ -34,7 +34,7 @@ translation_of: Learn/CSS/CSS_layout
 </ol>
 
 <div class="note">
-<p><span style="font-size: 14px;"><strong>提示</strong></span>: 如果你在一台电脑/平板电脑/其他设备上工作，而你没有能力创建自己的文件，你可以尝试（大部分）在线编码程序中的代码示例，如  <a href="http://jsbin.com/">JSBin</a> 或 <a href="https://thimble.mozilla.org/">Thimble</a> 。</p>
+<p><span style="font-size: 14px;"><strong>提示</strong></span>: 如果你在一台电脑/平板电脑/其他设备上工作，而你没有能力创建自己的文件，你可以尝试（大部分）在线编码程序中的代码示例，如  <a href="http://jsbin.com/">JSBin</a> 或 <a href="https://glitch.com/">Glitch</a> 。</p>
 </div>
 
 <h2 id="指南">指南</h2>

--- a/files/zh-cn/learn/css/first_steps/index.html
+++ b/files/zh-cn/learn/css/first_steps/index.html
@@ -23,7 +23,7 @@ translation_of: Learn/CSS/First_steps
 </ol>
 
 <div class="note">
-<p><strong>注意</strong>： 如果你工作在一个无权创建自己文件的电脑/平板/其他设备上，你需要在一个在线编程工具上试验 （大多数）代码示例，如  <a href="http://jsbin.com/">JSBin</a> 或者 <a href="https://thimble.mozilla.org/">Thimble</a> 等。</p>
+<p><strong>注意</strong>： 如果你工作在一个无权创建自己文件的电脑/平板/其他设备上，你需要在一个在线编程工具上试验 （大多数）代码示例，如  <a href="http://jsbin.com/">JSBin</a> 或者 <a href="https://glitch.com/">Glitch</a> 等。</p>
 </div>
 
 <h2 id="指南">指南</h2>

--- a/files/zh-cn/learn/css/styling_text/index.html
+++ b/files/zh-cn/learn/css/styling_text/index.html
@@ -27,7 +27,7 @@ original_slug: Learn/CSS/为文本添加样式
 <p>在开始这一模块之前，您应当像 <a href="/zh-CN/docs/Learn/HTML/Introduction_to_HTML">HTML 介绍</a> 模块中所探讨的，已经熟悉了基本的HTML，以及像 <a href="/zh-CN/docs/Learn/CSS/Introduction_to_CSS">CSS 介绍</a> 中所详述的，对自己的 CSS 基础感觉还满意。</p>
 
 <div class="note">
-<p><strong>注意</strong>: 如果您所使用的是不能创建自己的文件的电脑、平板电脑或其他设备的话，您可以在一个在线编码程序 <a href="http://jsbin.com/">JSBin</a> 或 <a href="https://thimble.mozilla.org/">Thimble</a> 中尝试（大部分的）代码例子。</p>
+<p><strong>注意</strong>: 如果您所使用的是不能创建自己的文件的电脑、平板电脑或其他设备的话，您可以在一个在线编码程序 <a href="http://jsbin.com/">JSBin</a> 或 <a href="https://glitch.com/">Glitch</a> 中尝试（大部分的）代码例子。</p>
 </div>
 
 <h2 id="导引">导引</h2>

--- a/files/zh-cn/learn/css/styling_text/typesetting_a_homepage/index.html
+++ b/files/zh-cn/learn/css/styling_text/typesetting_a_homepage/index.html
@@ -40,7 +40,7 @@ original_slug: Learn/CSS/为文本添加样式/Typesetting_a_homepage
 </ul>
 
 <div class="note">
-<p><strong>注意</strong>: 或者，你可以使用像 <a class="external external-icon" href="http://jsbin.com/">JSBin</a> 或 <a class="external external-icon" href="https://thimble.mozilla.org/">Thimble</a> 的网站完成你的测评。你可以把HTML和CSS粘贴到在线编辑器中，并使用<a href="http://mdn.github.io/learning-area/css/styling-text/typesetting-a-homepage-start/external-link-52.png">this URL</a>指定背景图像。如果你使用的在线编辑器没有单独的CSS面板，你可以将其放在HTML文件的&lt;style&gt;元素中。</p>
+<p><strong>注意</strong>: 或者，你可以使用像 <a class="external external-icon" href="http://jsbin.com/">JSBin</a> 或 <a class="external external-icon" href="https://glitch.com/">Glitch</a> 的网站完成你的测评。你可以把HTML和CSS粘贴到在线编辑器中，并使用<a href="http://mdn.github.io/learning-area/css/styling-text/typesetting-a-homepage-start/external-link-52.png">this URL</a>指定背景图像。如果你使用的在线编辑器没有单独的CSS面板，你可以将其放在HTML文件的&lt;style&gt;元素中。</p>
 </div>
 
 <h2 id="项目简介">项目简介</h2>

--- a/files/zh-cn/learn/getting_started_with_the_web/publishing_your_website/index.html
+++ b/files/zh-cn/learn/getting_started_with_the_web/publishing_your_website/index.html
@@ -58,7 +58,7 @@ translation_of: Learn/Getting_started_with_the_web/Publishing_your_website
 
 <p>不同于大部分其它托管服务，这类工具通常是免费的，不过你只能使用有限的功能。</p>
 
-<h3 id="使用像_Thimble_的基于_Web_的集成开发环境">使用像 Thimble 的基于 Web 的集成开发环境</h3>
+<h3 id="使用像_CodePen_这样基于_Web_的集成开发环境">使用像 CodePen 这样基于 Web 的集成开发环境</h3>
 
 <p>有许多web应用能够仿真一个网站开发环境。你可以在这种应用——通常只有一个标签页——里输入 HTML、CSS 和 JavaScript 代码然后像显示网页一样显示代码的结果。通常这些工具都很简单，对学习很有帮助，而且至少有免费的基本功能，它们在一个独特的网址显示你提交的网页。不过，这些应用的基础功能很有限，而且应用通常不提供空间来存储图像等内容。</p>
 
@@ -66,7 +66,7 @@ translation_of: Learn/Getting_started_with_the_web/Publishing_your_website
 
 <ul>
  <li><a href="https://jsfiddle.net/">JSFiddle</a></li>
- <li><a href="https://thimble.webmaker.org/">Thimble</a></li>
+ <li><a href="https://glitch.com/">Glitch</a></li>
  <li><a href="http://jsbin.com/">JSBin</a></li>
  <li><a href="https://codepen.io/">CodePen</a></li>
 </ul>

--- a/files/zh-cn/learn/html/introduction_to_html/marking_up_a_letter/index.html
+++ b/files/zh-cn/learn/html/introduction_to_html/marking_up_a_letter/index.html
@@ -33,7 +33,7 @@ translation_of: Learn/HTML/Introduction_to_HTML/Marking_up_a_letter
 
 <h2 id="起点">起点</h2>
 
-<p>开始测验之前，请先<a href="https://github.com/roy-tian/learning-area/tree/master/html/introduction-to-html/marking-up-a-letter-start">下载信件的起始文本和CSS代码</a>。然后用文本编辑器（用 <a class="external-icon external" href="http://jsbin.com/">JSBin</a> 或 <a class="external-icon external" href="https://thimble.mozilla.org/">himble</a> 等在线编辑工具亦可）创建一个新的 <code>.html</code> 文件来进行测验。</p>
+<p>开始测验之前，请先<a href="https://github.com/roy-tian/learning-area/tree/master/html/introduction-to-html/marking-up-a-letter-start">下载信件的起始文本和CSS代码</a>。然后用文本编辑器（用 <a class="external-icon external" href="http://jsbin.com/">JSBin</a> 或 <a class="external-icon external" href="https://glitch.com/">Glitch</a> 等在线编辑工具亦可）创建一个新的 <code>.html</code> 文件来进行测验。</p>
 
 <h2 id="项目概要">项目概要</h2>
 

--- a/files/zh-cn/learn/html/introduction_to_html/structuring_a_page_of_content/index.html
+++ b/files/zh-cn/learn/html/introduction_to_html/structuring_a_page_of_content/index.html
@@ -39,7 +39,7 @@ translation_of: Learn/HTML/Introduction_to_HTML/Structuring_a_page_of_content
  <li>页面中使用的图片。</li>
 </ul>
 
-<p>可在电脑上创建示例，也可以用 <a class="external external-icon" href="http://jsbin.com/">JSBin</a> 或 <a class="external external-icon" href="https://thimble.mozilla.org/">Thimble</a> 等网站来完成测验。</p>
+<p>可在电脑上创建示例，也可以用 <a class="external external-icon" href="http://jsbin.com/">JSBin</a> 或 <a class="external external-icon" href="https://glitch.com/">Glitch</a> 等网站来完成测验。</p>
 
 <h2 id="项目简介">项目简介</h2>
 

--- a/files/zh-cn/learn/html/multimedia_and_embedding/index.html
+++ b/files/zh-cn/learn/html/multimedia_and_embedding/index.html
@@ -15,7 +15,7 @@ translation_of: Learn/HTML/Multimedia_and_embedding
 <p>在你开始本模块之前，你应该已经拥有了关于HTML基础的合理知识，就是之前在<a href="https://developer.mozilla.org/zh-CN/docs/learn/HTML/Introduction_to_HTML">HTML介绍</a>中所述。如果你还没有看过那个模块（或者类似的），先去看看，然后再回来吧！</p>
 
 <div class="note">
-<p><span style="font-size: 14px;"><strong>提示</strong></span>: 如果你在电脑/平板电脑/其他设备上不能创建你自己的代码文件，你可以尝试在在线代码编辑网站例如<a href="https://jsbin.com/">JSBin</a>或者<a href="https://thimble.mozilla.org/">Thimble</a>来运行（大部分的）代码示例。</p>
+<p><span style="font-size: 14px;"><strong>提示</strong></span>: 如果你在电脑/平板电脑/其他设备上不能创建你自己的代码文件，你可以尝试在在线代码编辑网站例如<a href="https://jsbin.com/">JSBin</a>或者<a href="https://glitch.com/">Glitch</a>来运行（大部分的）代码示例。</p>
 </div>
 
 <h2 id="指南">指南</h2>

--- a/files/zh-cn/learn/html/tables/index.html
+++ b/files/zh-cn/learn/html/tables/index.html
@@ -22,7 +22,7 @@ translation_of: Learn/HTML/Tables
 <p>在你开始这一模块之前，你需要已经了解了HTML的基础知识——看<a href="/zh-CN/docs/Learn/HTML/Introduction_to_HTML">Introduction to HTML</a>.</p>
 
 <div class="note">
-<p><strong>Note</strong>: 如果你是在计算机/平板电脑等其他你无法创建文件的设备上的话，你可以尝试在在线代码编辑平台上运行代码例如 <a href="http://jsbin.com/">JSBin</a> 或 <a href="https://thimble.mozilla.org/">Thimble</a>.</p>
+<p><strong>Note</strong>: 如果你是在计算机/平板电脑等其他你无法创建文件的设备上的话，你可以尝试在在线代码编辑平台上运行代码例如 <a href="http://jsbin.com/">JSBin</a> 或 <a href="https://glitch.com/">Glitch</a>.</p>
 </div>
 
 <h2 id="向导">向导</h2>

--- a/files/zh-cn/learn/html/tables/structuring_planet_data/index.html
+++ b/files/zh-cn/learn/html/tables/structuring_planet_data/index.html
@@ -27,7 +27,7 @@ translation_of: Learn/HTML/Tables/Structuring_planet_data
 <p>要进行本测验，将 <a href="https://github.com/roy-tian/learning-area/blob/master/html/tables/assessment-start/blank-template.html">blank-template.html</a>, <a href="https://github.com/roy-tian/learning-area/blob/master/html/tables/assessment-start/minimal-table.css">minimal-table.css</a> 和 <a href="https://github.com/roy-tian/learning-area/blob/master/html/tables/assessment-start/planets-data.txt">planets-data.txt</a> 拷贝到本地。</p>
 
 <div class="note">
-<p><strong>注意</strong>: 另外， 你可以使用 <a class="external external-icon" href="https://jsbin.com/">JSBin</a> 或 <a class="external external-icon" href="https://thimble.mozilla.org/">Thimble</a> 来做你的测验。你可以把 HTML, CSS 和 JavaScript 粘贴到其中一个网上编辑器里。如果你使用的网上编辑器不支持 JavaScript/CSS 文件链接到 HTML 中使用，那么也可以使用 <code>&lt;script&gt;</code>/<code>&lt;style&gt;</code> 元素将它们直接写在你的 HTML 页面里。</p>
+<p><strong>注意</strong>: 另外， 你可以使用 <a class="external external-icon" href="https://jsbin.com/">JSBin</a> 或 <a class="external external-icon" href="https://glitch.com/">Glitch</a> 来做你的测验。你可以把 HTML, CSS 和 JavaScript 粘贴到其中一个网上编辑器里。如果你使用的网上编辑器不支持 JavaScript/CSS 文件链接到 HTML 中使用，那么也可以使用 <code>&lt;script&gt;</code>/<code>&lt;style&gt;</code> 元素将它们直接写在你的 HTML 页面里。</p>
 </div>
 
 <h2 id="项目概要">项目概要</h2>

--- a/files/zh-cn/learn/javascript/asynchronous/index.html
+++ b/files/zh-cn/learn/javascript/asynchronous/index.html
@@ -31,7 +31,7 @@ original_slug: learn/JavaScript/异步
 <p>如果你还不熟悉异步编程的概念，请从 <a href="/en-US/docs/Learn/JavaScript/Asynchronous/Concepts">通用异步编程概念</a>开始. 如果熟悉的话，可以直接从<a href="/en-US/docs/Learn/JavaScript/Asynchronous/Introducing">介绍异步JavaScript</a> 开始.</p>
 
 <div class="note">
-<p><strong>Note</strong>: 如果在当前阅读本文档而使用的电子设备（电脑/平板/其他）上，你没有权限生成自己的文件，你可以使用 <a href="http://jsbin.com/">JSBin</a> or <a href="https://thimble.mozilla.org/">Thimble</a> 在线编程工具来尝试文章里面的代码示例</p>
+<p><strong>Note</strong>: 如果在当前阅读本文档而使用的电子设备（电脑/平板/其他）上，你没有权限生成自己的文件，你可以使用 <a href="http://jsbin.com/">JSBin</a> or <a href="https://glitch.com/">Glitch</a> 在线编程工具来尝试文章里面的代码示例</p>
 </div>
 
 <h2 id="指南">指南</h2>

--- a/files/zh-cn/learn/javascript/building_blocks/image_gallery/index.html
+++ b/files/zh-cn/learn/javascript/building_blocks/image_gallery/index.html
@@ -35,7 +35,7 @@ original_slug: learn/JavaScript/Building_blocks/相片走廊
 <p><a href="https://raw.githubusercontent.com/roy-tian/learning-area/master/javascript/building-blocks/gallery/gallery-start.zip">下载压缩包</a> 并在本地解压。</p>
 
 <div class="note">
-<p><strong>注</strong>：你还可以使用类似 <a class="external external-icon" href="http://jsbin.com/">JSBin</a> 或 <a class="external external-icon" href="https://thimble.mozilla.org/">Thimble</a> 这些在线编辑器来完成测验。你可以把 HTML、CSS 和 JavaScript 代码复制过去。如果你选的工具没有独立的 JavaScript/CSS 板面，可以随时在 HTML 页面中添加 <code>&lt;script&gt;</code>/<code>&lt;style&gt;</code> 元素。</p>
+<p><strong>注</strong>：你还可以使用类似 <a class="external external-icon" href="http://jsbin.com/">JSBin</a> 或 <a class="external external-icon" href="https://glitch.com/">Glitch</a> 这些在线编辑器来完成测验。你可以把 HTML、CSS 和 JavaScript 代码复制过去。如果你选的工具没有独立的 JavaScript/CSS 板面，可以随时在 HTML 页面中添加 <code>&lt;script&gt;</code>/<code>&lt;style&gt;</code> 元素。</p>
 </div>
 
 <h2 id="项目简介">项目简介</h2>

--- a/files/zh-cn/learn/javascript/building_blocks/index.html
+++ b/files/zh-cn/learn/javascript/building_blocks/index.html
@@ -25,7 +25,7 @@ translation_of: Learn/JavaScript/Building_blocks
 <p>在开始这部分模块之前, 你应该熟悉基本的HTML和CSS, 并且已经看完我们之前的模块：<a href="/zh-CN/docs/Learn/JavaScript/First_steps">JavaScript 第一步</a>。</p>
 
 <div class="note">
-<p><strong>注</strong>: 如果你在使用无法创建自己文件的电脑/平板/其他设备,你可以试试在线编辑器，例如 <a href="http://jsbin.com/">JSBin</a> 或 <a href="https://thimble.mozilla.org/">Thimble</a>.</p>
+<p><strong>注</strong>: 如果你在使用无法创建自己文件的电脑/平板/其他设备,你可以试试在线编辑器，例如 <a href="http://jsbin.com/">JSBin</a> 或 <a href="https://glitch.com/">Glitch</a>.</p>
 </div>
 
 <h2 id="指南">指南</h2>

--- a/files/zh-cn/learn/javascript/client-side_web_apis/index.html
+++ b/files/zh-cn/learn/javascript/client-side_web_apis/index.html
@@ -24,7 +24,7 @@ translation_of: Learn/JavaScript/Client-side_web_APIs
 <p>若你知道 <a href="https://developer.mozilla.org/en-US/docs/Learn/HTML">HTML</a> 和 <a href="https://developer.mozilla.org/en-US/docs/Learn/CSS">CSS</a> 的基本知识，也会对理解这个单元的内容大有裨益。</p>
 
 <div class="note">
-<p>注意：如果你正在使用一台无法创建你自身文件的电脑、平板或其他设备，你可以尝试使用一些在线网页编辑器如<a href="http://jsbin.com/">JSBin</a>或者<a href="https://thimble.mozilla.org/">Thimble</a>，来尝试编辑一些代码示例。</p>
+<p>注意：如果你正在使用一台无法创建你自身文件的电脑、平板或其他设备，你可以尝试使用一些在线网页编辑器如<a href="http://jsbin.com/">JSBin</a>或者<a href="https://glitch.com/">Glitch</a>，来尝试编辑一些代码示例。</p>
 </div>
 
 <h2 id="向导">向导</h2>

--- a/files/zh-cn/learn/javascript/first_steps/index.html
+++ b/files/zh-cn/learn/javascript/first_steps/index.html
@@ -23,7 +23,7 @@ translation_of: Learn/JavaScript/First_steps
 </ul>
 
 <div class="note">
-<p><strong>注意：</strong>如果你无法在你使用的电脑/平板/其他设备上创建自己的文件，尝试使用在线编程应用来运行（大部分）代码示例，例如 <a href="http://jsbin.com/">JSBin</a> 和 <a href="https://thimble.mozilla.org/">Thimble</a>。</p>
+<p><strong>注意：</strong>如果你无法在你使用的电脑/平板/其他设备上创建自己的文件，尝试使用在线编程应用来运行（大部分）代码示例，例如 <a href="http://jsbin.com/">JSBin</a> 和 <a href="https://glitch.com/">Glitch</a>。</p>
 </div>
 
 <h2 id="学习指南">学习指南</h2>

--- a/files/zh-cn/learn/javascript/first_steps/silly_story_generator/index.html
+++ b/files/zh-cn/learn/javascript/first_steps/silly_story_generator/index.html
@@ -39,7 +39,7 @@ translation_of: Learn/JavaScript/First_steps/Silly_story_generator
 <p>测验开始之前需要下载并保存 <a class="external external-icon" href="https://github.com/roy-tian/learning-area/blob/master/javascript/introduction-to-js-1/assessment-start/index.html">index.html</a>、<a class="external external-icon" href="https://github.com/roy-tian/learning-area/blob/master/javascript/introduction-to-js-1/assessment-start/style.css">style.css</a>、<a class="external external-icon" href="https://github.com/roy-tian/learning-area/blob/master/javascript/introduction-to-js-1/assessment-start/raw-text.txt">raw-text.txt</a>。</p>
 
 <div class="note">
-<p><strong>注：</strong> 你还可以用类似 <a class="external external-icon" href="http://jsbin.com/">JSBin</a> 或 <a class="external external-icon" href="https://thimble.mozilla.org/">Thimble</a> 这些在线编辑器来完成测验。你可以把 HTML、CSS 及 JavaScript 代码复制过去。如果你选的工具没有独立的 JavaScript 版面，可以随时在 HTML 页面中添加 <code>&lt;script&gt;</code> 元素。</p>
+<p><strong>注：</strong> 你还可以用类似 <a class="external external-icon" href="http://jsbin.com/">JSBin</a> 或 <a class="external external-icon" href="https://glitch.com/">Glitch</a> 这些在线编辑器来完成测验。你可以把 HTML、CSS 及 JavaScript 代码复制过去。如果你选的工具没有独立的 JavaScript 版面，可以随时在 HTML 页面中添加 <code>&lt;script&gt;</code> 元素。</p>
 </div>
 
 <h2 id="项目简介">项目简介</h2>

--- a/files/zh-cn/learn/javascript/objects/adding_bouncing_balls_features/index.html
+++ b/files/zh-cn/learn/javascript/objects/adding_bouncing_balls_features/index.html
@@ -34,7 +34,7 @@ original_slug: Learn/JavaScript/Objects/向“弹跳球”演示程序添加新�
 <p>请先下载 <a class="external external-icon" href="https://github.com/roy-tian/learning-area/blob/master/javascript/oojs/bouncing-balls/index.html">index.html</a>、<a class="external external-icon" href="https://github.com/roy-tian/learning-area/blob/master/javascript/oojs/bouncing-balls/style.css">style.css</a> 和 <a class="external external-icon" href="https://github.com/roy-tian/learning-area/blob/master/javascript/oojs/bouncing-balls/main.js">main.js</a> 三个文件。</p>
 
 <div class="note">
-<p><strong>注：</strong>也可以使用 <a class="external external-icon" href="http://jsbin.com/">JSBin</a> 或 <a class="external external-icon" href="https://thimble.mozilla.org/">Thimble</a> 这样的网站来进行测验。 你可以选择其中一个将HTML，CSS 和JavaScript 粘贴过去。 如果你的版本没有单独的 JavaScript / CSS 板块，可以把它们嵌入 HTML 页面内的 <code>&lt;script&gt;</code>/<code>&lt;style&gt;</code> 元素。</p>
+<p><strong>注：</strong>也可以使用 <a class="external external-icon" href="http://jsbin.com/">JSBin</a> 或 <a class="external external-icon" href="https://glitch.com/">Glitch</a> 这样的网站来进行测验。 你可以选择其中一个将HTML，CSS 和JavaScript 粘贴过去。 如果你的版本没有单独的 JavaScript / CSS 板块，可以把它们嵌入 HTML 页面内的 <code>&lt;script&gt;</code>/<code>&lt;style&gt;</code> 元素。</p>
 </div>
 
 <h2 id="项目简介">项目简介</h2>

--- a/files/zh-cn/learn/javascript/objects/index.html
+++ b/files/zh-cn/learn/javascript/objects/index.html
@@ -23,7 +23,7 @@ translation_of: Learn/JavaScript/Objects
 <p>详细了解 JavaScript 对象之前，你应当已经对 JavaScript 基础有所熟悉。尝试这个模块之前，请通读 <a href="/zh-CN/docs/Learn/JavaScript/First_steps">JavaScript 第一步</a> 和 <a href="/zh-CN/docs/Learn/JavaScript/Building_blocks">JavaScript基础要件 </a></p>
 
 <div class="note">
-<p><strong>注意</strong>：如果您无法在当前使用的电脑/平板/其他设备上创建自己的文件，可以使用在线编程网站如 <a href="http://jsbin.com/">JSBin</a> 或 <a href="https://thimble.mozilla.org/">Thimble</a>，来试验文章中的（大多数）代码。</p>
+<p><strong>注意</strong>：如果您无法在当前使用的电脑/平板/其他设备上创建自己的文件，可以使用在线编程网站如 <a href="http://jsbin.com/">JSBin</a> 或 <a href="https://glitch.com/">Glitch</a>，来试验文章中的（大多数）代码。</p>
 </div>
 
 <h2 id="指南">指南</h2>

--- a/files/zh-cn/mdn/contribute/howto/create_an_interactive_exercise_to_help_learning_the_web/index.html
+++ b/files/zh-cn/mdn/contribute/howto/create_an_interactive_exercise_to_help_learning_the_web/index.html
@@ -12,7 +12,7 @@ original_slug: MDN/Contribute/Howto/学习_交互_在线_起步_开始
 ---
 <div>{{MDNSidebar}}</div><p>动态的内容对于学习 Web 来说是重要的。 她能让学习的人更加积极主动。 这可以是练习，实例，任务，评价等等。总之，任何有助于学习理解的东西都行。</p>
 
-<p>这儿还没有能够直接创建动态的实例内容。但是一些第三方工具可以帮助你创建（如： <a href="https://jsfiddle.net/" rel="external">JSFiddle</a>，<a href="https://codepen.io/">CodePen</a>，<a href="http://dabblet.com/">Dabblet</a>，等），你可以将其链接放在 MDN 文章中。另外，你可以使用 WebMaker 项目的 <a href="https://thimble.mozilla.org/" rel="external">Thimble</a> 来创造更加高级的内容。</p>
+<p>这儿还没有能够直接创建动态的实例内容。但是一些第三方工具可以帮助你创建（如： <a href="https://jsfiddle.net/" rel="external">JSFiddle</a>，<a href="https://codepen.io/">CodePen</a>，<a href="http://dabblet.com/">Dabblet</a>，等），你可以将其链接放在 MDN 文章中。</p>
 
 <p>目前，MDN 虽然没有能够轻易创建动态实例内容的工具。不过，如果你是工程师，可以使用当前 MDN 提供的功能创建自定义的主动学习内容，下面内容将告诉你如何操作。</p>
 


### PR DESCRIPTION
Thimble is not available since early 2020, replace it with Glitch.