### PR TITLE
Fix typo

### DIFF
--- a/files/ko/learn/getting_started_with_the_web/index.html
+++ b/files/ko/learn/getting_started_with_the_web/index.html
@@ -16,7 +16,7 @@ translation_of: Learn/Getting_started_with_the_web
 <div>{{LearnSidebar}}</div>
 
 <div class="summary">
-<p><em>Web과 함께 시작하기(Getting stated with the Web)</em>는 여러분에게 웹 개발의 실질적인 측면을 소개하는 간결한 시리즈입니다. 여러분은 간단한 웹페이지를 만들 때 필요한 도구를 설치하고 여러분의 코드를 게시할 것입니다.</p>
+<p><em>Web과 함께 시작하기(Getting started with the Web)</em>는 여러분에게 웹 개발의 실질적인 측면을 소개하는 간결한 시리즈입니다. 여러분은 간단한 웹페이지를 만들 때 필요한 도구를 설치하고 여러분의 코드를 게시할 것입니다.</p>
 </div>
 
 <h2 id="당신의_첫_번째_웹사이트_줄거리">당신의 첫 번째 웹사이트 줄거리</h2>


### PR DESCRIPTION
Web과 함께 시작하기 아래의 본문 첫줄 Web과 함께 시작하기(Getting stated with the Web) 에서 `stated` 를 `started`로 수정

Fixes #4813