### PR TITLE
fix: fr grid-auto-columns example preview and css

### DIFF
--- a/files/fr/web/css/grid-auto-columns/index.md
+++ b/files/fr/web/css/grid-auto-columns/index.md
@@ -99,7 +99,7 @@ grid-auto-columns: unset;
 
 ```css
 #grid {
-  width: 100px;
+  height: 100px;
   display: grid;
   grid-template-areas: "a a";
   grid-gap: 10px;

--- a/files/fr/web/css/grid-auto-columns/index.md
+++ b/files/fr/web/css/grid-auto-columns/index.md
@@ -123,7 +123,7 @@ grid-auto-columns: unset;
 
 ### Résultat
 
-{{EmbedLiveSample("Exemples", "410px", "100px")}}
+{{EmbedLiveSample("Exemples", "410px", "140px")}}
 
 ## Spécifications
 


### PR DESCRIPTION
Fix example preview in **french** translation for **grid-auto-columns**

Before : 
![image](https://user-images.githubusercontent.com/43471126/159965769-931a102b-db35-436e-a72a-ee783c9e1ba7.png)
After : 
![image](https://user-images.githubusercontent.com/43471126/159965856-1ea393c4-7169-4333-8b5c-7501b948b8da.png)
