### PR TITLE
fix: fix PreviousNext links

### DIFF
--- a/files/zh-cn/web/javascript/guide/details_of_the_object_model/index.html
+++ b/files/zh-cn/web/javascript/guide/details_of_the_object_model/index.html
@@ -757,4 +757,4 @@ dennis.hobby == "scuba"
 
 <p><code>dennis</code> 对象不会继承这个新属性。</p>
 
-<div>{{ PreviousNext("JavaScript/Guide/Predefined_Core_Objects", "JavaScript/Guide/Using_promises") }}</div>
+<div>{{ PreviousNext("Web/JavaScript/Guide/Working_with_Objects", "Web/JavaScript/Guide/Using_promises")}}</div>


### PR DESCRIPTION
The previous and next page links of the Details_of_the_Object_Model page are error.I fixed it.