### PR TITLE
Correção da explicação dos parâmetros do reduce()

### DIFF
--- a/files/pt-br/web/javascript/reference/global_objects/array/reduce/index.html
+++ b/files/pt-br/web/javascript/reference/global_objects/array/reduce/index.html
@@ -37,16 +37,22 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Array/Reduce
 
 <dl>
  <dt><code>callback</code></dt>
- <dd>Função que é executada em cada valor no array (exceto no primeiro, se nenhum <font face="Consolas, Liberation Mono, Courier, monospace"><code>valorInicial</code></font> for passado); recebe quatro argumentos:</dd>
+ <dd>Função que é executada em cada valor no array (exceto no primeiro, se nenhum <font face="Consolas, Liberation Mono, Courier, monospace"><code>valorInicial</code></font> for passado); recebe quatro argumentos:</dd>
 </dl>
 
-<p><strong><font face="Consolas, Liberation Mono, Courier, monospace"><code>acumulador</code></font></strong></p>
+<dl>
+ <dt><code>acumulador</code></dt>
+ <dd>É o valor inicial (ou o valor do callback anterior). Este valor inicia com o <font face="Consolas, Liberation Mono, Courier, monospace"><code>valorInicial</code></font> e será retornado na última iteração.</dd>
+</dl>
 
-<p>Opcional. O índice do elemento atual que está sendo processado no array. Começa a partir do index <code>0</code> se um <font face="Consolas, Liberation Mono, Courier, monospace"><code>valorInicial</code> </font>for fornecido. Do contrário, começa do index <code>1</code>.</p>
+<dl>
+ <dt><code>valorAtual</code></dt>
+ <dd>Opcional. O índice do elemento atual que está sendo processado no array. Começa a partir do index <code>0</code> se um <font face="Consolas, Liberation Mono, Courier, monospace"><code>valorInicial</code> </font>for fornecido. Do contrário, começa do index <code>1</code>.</dd>
+</dl>
 
 <dl>
  <dt><code>valorInicial</code></dt>
- <dd>Opcional. Valor a ser usado como o primeiro argumento da primeira chamada da função <code>callback</code>. Se nenhum <code>valorInicial</code> é fornecido, o primeiro elemento do array será usado como o valor inicial do <font face="Consolas, Liberation Mono, Courier, monospace"><code>acumulador</code></font> e o <code>valorAtual</code> não será lido. Chamar <code>reduce()</code> em uma array vazia sem valor inicial retornará um erro.</dd>
+ <dd>Opcional. Valor a ser usado como o primeiro argumento da primeira chamada da função <code>callback</code>. Se nenhum <code>valorInicial</code> é fornecido, o primeiro elemento do array será usado como o valor inicial do <font face="Consolas, Liberation Mono, Courier, monospace"><code>acumulador</code></font> e o <code>valorAtual</code> não será lido. Chamar <code>reduce()</code> em uma array vazia sem valor inicial retornará um erro.</dd>
 </dl>
 
 <h3 id="Valor_retornado">Valor retornado</h3>


### PR DESCRIPTION
PT-BR: 
1. Faltou ser explicado como funciona o parâmetro "acumulador".
2. A explicação do parâmetro "valorAtual" estava sem o título dentro da tag "dt".

EN-US:
1. It has not been explained how the "_acumulador_" parameter works.
2. The explanation of the "_valorAtual_" parameter was without the title inside the "dt" tag.