### PR TITLE
[ko] correct isnan contents

### DIFF
--- a/files/ko/web/javascript/reference/global_objects/isnan/index.html
+++ b/files/ko/web/javascript/reference/global_objects/isnan/index.html
@@ -33,7 +33,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/isNaN
 
 <h3 id="isNaN_함수의_필요성"><code>isNaN</code> 함수의 필요성</h3>
 
-<p>JavaScript의 다른 모든 값과 달리, {{jsxref("NaN")}}은 같음 연산(<code>==</code>, <code>===</code>)을 사용해 판별할 수 없습니다. <code>NaN == NaN</code>, <code>NaN === NaN</code>이기 때문입니다. 그래서 <code>NaN</code>을 판별하는 함수가 필요합니다.</p>
+<p>JavaScript의 다른 모든 값과 달리, {{jsxref("NaN")}}은 같음 연산(<code>==</code>, <code>===</code>)을 사용해 판별할 수 없습니다. <code>NaN == NaN</code>, <code>NaN === NaN</code>은 <code>false</code>로 평가되기 때문입니다. 그래서 <code>NaN</code>을 판별하는 함수가 필요합니다.</p>
 
 <h3 id="NaN_값의_기원"><code>NaN</code> 값의 기원</h3>
 


### PR DESCRIPTION
문서 `/ko/web/javascript/reference/global_objects/isnan`의 번역을 수정하였습니다.

기존에 NaN 간 비교가 가능하다고 작성되어 있어, 이를 불가능한 것으로 수정했습니다.
아래는 원문입니다.

> Unlike all other possible values in JavaScript, it is not possible to use the equality operators (== and ===) to compare a value against [NaN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN) to determine whether the value is NaN or not, because both NaN == NaN and NaN === NaN evaluate to false.