### PR TITLE
Update `String.prototype.match()` zh-cn document.

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/string/match/index.html
+++ b/files/zh-cn/web/javascript/reference/global_objects/string/match/index.html
@@ -33,7 +33,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/String/match
 <p>如上所述，匹配的结果包含如下所述的附加特性。</p>
 
 <ul>
- <li><code>groups</code>: 一个捕获组数组 或 {{jsxref("undefined")}}（如果没有定义命名捕获组）。</li>
+ <li><code>groups</code>: 一个命名捕获组对象，其键是捕获组名称，值是捕获组，如果未定义命名捕获组，则为 {{jsxref("undefined")}}。有关详细信息，请参阅[组合范围](/zh-CN/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges)。</li>
  <li><code>index</code>: 匹配的结果的开始位置</li>
  <li><code>input</code>: 搜索的字符串.</li>
 </ul>

--- a/files/zh-cn/web/javascript/reference/global_objects/string/match/index.html
+++ b/files/zh-cn/web/javascript/reference/global_objects/string/match/index.html
@@ -33,7 +33,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/String/match
 <p>如上所述，匹配的结果包含如下所述的附加特性。</p>
 
 <ul>
- <li><code>groups</code>: 一个命名捕获组对象，其键是捕获组名称，值是捕获组，如果未定义命名捕获组，则为 {{jsxref("undefined")}}。有关详细信息，请参阅[组合范围](/zh-CN/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges)。</li>
+ <li><code>groups</code>: 一个命名捕获组对象，其键是捕获组名称，值是捕获组，如果未定义命名捕获组，则为 {{jsxref("undefined")}}。有关详细信息，请参阅<a href="/zh-CN/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges">组和范围</a>。</li>
  <li><code>index</code>: 匹配的结果的开始位置</li>
  <li><code>input</code>: 搜索的字符串.</li>
 </ul>


### PR DESCRIPTION
There is a [reference](https://github.com/mdn/content/blob/80ff77cb991d091c1e9d05a6c829444f90d60233/files/en-us/web/javascript/reference/global_objects/string/match/index.md?plain=1#L57) of `Groups and Ranges` in the original document, but not in the Chinese version, so I added it.