### PR TITLE
Clarify meaning of `Strict` attribute of `SameSite` cookie policy

### DIFF
--- a/files/fr/web/http/headers/set-cookie/samesite/index.md
+++ b/files/fr/web/http/headers/set-cookie/samesite/index.md
@@ -22,7 +22,7 @@ Les cookies sont transférables depuis le site actuel vers des sites de niveaux 
 
 ### `Strict`
 
-Les cookies ne seront envoyés qu'avec les requêtes effectuées sur le domaine de même niveau, et ne seront pas envoyées sur les requêtes vers des sites tiers.
+Les cookies ne seront envoyés qu'avec les requêtes effectuées sur le domaine de même niveau, et ne seront pas envoyées sur les requêtes provenant de sites tiers.
 
 ### `None`
 


### PR DESCRIPTION
It make more sense to explain `Strict` policy using `provenant de` rather than `vers`.

English original text:
```
Cookies will only be sent in a first-party context and not be sent along with requests initiated by third party websites.
```