### PR TITLE
fix: use images in `mdn/content`

### DIFF
--- a/files/zh-cn/learn/html/multimedia_and_embedding/responsive_images/index.html
+++ b/files/zh-cn/learn/html/multimedia_and_embedding/responsive_images/index.html
@@ -8,7 +8,7 @@ translation_of: Learn/HTML/Multimedia_and_embedding/Responsive_images
 <div>{{PreviousMenuNext("Learn/HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web", "Learn/HTML/Multimedia_and_embedding/Mozilla_splash_page", "Learn/HTML/Multimedia_and_embedding")}}</div>
 
 <div>
-<p class="summary">在这篇文章中我们将学习关于响应式图片——一种可以在不同的屏幕尺寸和分辨率的设备上都能良好工作以及其他特性的图片，并且看看HTML提供了什么工具来帮助实现它们。响应式图片仅仅只是响应式web设计的一部分（奠定了响应式web设计的良好基础），我们会在未来的<a href="/en-US/docs/Learn/CSS">CSS topic</a>模块中学到更多关于这一主题的知识。</p>
+<p class="summary">在这篇文章中我们将学习关于响应式图片——一种可以在不同的屏幕尺寸和分辨率的设备上都能良好工作以及其他特性的图片，并且看看HTML提供了什么工具来帮助实现它们。响应式图片仅仅只是响应式web设计的一部分（奠定了响应式web设计的良好基础），我们会在未来的<a href="/zh-CN/docs/Learn/CSS">CSS topic</a>模块中学到更多关于这一主题的知识。</p>
 </div>
 
 <table class="learn-box nostripe standard-table">
@@ -28,7 +28,7 @@ translation_of: Learn/HTML/Multimedia_and_embedding/Responsive_images
 
 <p>让我们来看一个典型的场景。一个典型的网站可能会有一张页首图片，这让访问者看起来感到愉快。图片下面可能会添加一些内容图像。页首图像的跨度可能是整个页首的宽度。而内容图像会适应内容纵列的某处。此处有个简单的例子：</p>
 
-<p><img alt="Our example site as viewed on a wide screen - here the first image works ok, as it is big enough to see the detail in the center." src="https://mdn.mozillademos.org/files/12940/picture-element-wide.png"></p>
+<p><img alt="Our example site as viewed on a wide screen - here the first image works ok, as it is big enough to see the detail in the center." src="picture-element-wide.png"></p>
 
 <p>这个网页在宽屏设备上表现良好，例如笔记本电脑或台式机（你可以<a href="https://mdn.github.io/learning-area/html/multimedia-and-embedding/responsive-images/not-responsive.html">查看在线演示</a>并且在GitHub上查看<a href="https://github.com/mdn/learning-area/blob/master/html/multimedia-and-embedding/responsive-images/not-responsive.html">源代码</a>）。我们不会在这一节课中讨论CSS，除了下面提到的那些：</p>
 
@@ -40,7 +40,7 @@ translation_of: Learn/HTML/Multimedia_and_embedding/Responsive_images
 
 <p>然而，当你尝试在一个狭小的屏幕设备上查看本页面时，问题就会产生。网页的页眉看起来还可以，但是页眉这张图片占据了屏幕的一大部分的高度，在这个尺寸下，你很难看到在第一张图片内容里的人。</p>
 
-<p><img alt="Our example site as viewed on a narrow screen; the first image has shrunk to the point where it is hard to make out the detail on it." src="https://mdn.mozillademos.org/files/12936/non-responsive-narrow.png"></p>
+<p><img alt="Our example site as viewed on a narrow screen; the first image has shrunk to the point where it is hard to make out the detail on it." src="non-responsive-narrow.png"></p>
 
 <p>一个改进的方法是，当网站在狭窄的屏幕上观看时，显示一幅图片的包含了重要细节的裁剪版本，第二个被裁剪的图片会在像平板电脑这样的中等宽度的屏幕设备上显示，这就是众所周知的<strong>美术设计问题（art direction problem）</strong>。</p>
 
@@ -91,7 +91,7 @@ translation_of: Learn/HTML/Multimedia_and_embedding/Responsive_images
 <p><code><strong>sizes</strong></code>定义了一组媒体条件（例如屏幕宽度）并且指明当某些媒体条件为真时，什么样的图片尺寸是最佳选择—我们在之前已经讨论了一些提示。在这种情况下，在每个逗号之前，我们写：</p>
 
 <ol>
- <li>一个<strong>媒体条件</strong>（<code>(max-width:480px)</code>）——你会在 <a href="/en-US/docs/Learn/CSS">CSS topic</a>中学到更多的。但是现在我们仅仅讨论的是媒体条件描述了屏幕可能处于的状态。在这里，我们说“当可视窗口的宽度是480像素或更少”。</li>
+ <li>一个<strong>媒体条件</strong>（<code>(max-width:480px)</code>）——你会在 <a href="/zh-CN/docs/Learn/CSS">CSS topic</a>中学到更多的。但是现在我们仅仅讨论的是媒体条件描述了屏幕可能处于的状态。在这里，我们说“当可视窗口的宽度是480像素或更少”。</li>
  <li>一个空格</li>
  <li>当媒体条件为真时，图像将填充的<strong>槽的宽度</strong>（<code>440px</code>）</li>
 </ol>
@@ -119,7 +119,7 @@ translation_of: Learn/HTML/Multimedia_and_embedding/Responsive_images
 
 <h3 id="一些有用的开发工具">一些有用的开发工具</h3>
 
-<p>这里有一些在浏览器中的非常实用的<a href="/en-US/docs/Learn/Common_questions/What_are_browser_developer_tools">开发者工具</a>用来帮助制定重要的槽宽度，以及其他你可能会用到的场景。当我在设置槽宽度的时候，我先加载了示例中的无响应的版本（<code>not-responsive.html</code>），然后进入 <a href="/zh-CN/docs/Tools/Responsive_Design_Mode">响应设计视图</a> （<em>Tools &gt; Web Developer &gt; Responsive Design View），</em>这个工具允许你在不同设备的屏幕宽度场景下查看网页的布局。</p>
+<p>这里有一些在浏览器中的非常实用的<a href="/zh-CN/docs/Learn/Common_questions/What_are_browser_developer_tools">开发者工具</a>用来帮助制定重要的槽宽度，以及其他你可能会用到的场景。当我在设置槽宽度的时候，我先加载了示例中的无响应的版本（<code>not-responsive.html</code>），然后进入 <a href="/zh-CN/docs/Tools/Responsive_Design_Mode">响应设计视图</a> （<em>Tools &gt; Web Developer &gt; Responsive Design View），</em>这个工具允许你在不同设备的屏幕宽度场景下查看网页的布局。</p>
 
 <p>我设置我的视图宽度为 320px，然后再改为 480px；每一次宽度的改变我就进入 <a href="/zh-CN/docs/Tools/Page_Inspector">DOM 检查 </a>，点击我们感兴趣的 {{htmlelement("img")}} 元素，然后在显示屏右侧的 Box Model 视图选项卡中查看它的大小。 你应该会看到，这种无响应式的做法会让你的图片在不同屏幕宽度下有着固定的宽度。</p>
 
@@ -159,7 +159,7 @@ translation_of: Learn/HTML/Multimedia_and_embedding/Responsive_images
 
 <pre class="brush: html notranslate">&lt;img src="elva-800w.jpg" alt="Chris standing up holding his daughter Elva"&gt;</pre>
 
-<p>让我们改用 {{htmlelement("picture")}}！就像<a href="/en-US/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content"><code>&lt;video&gt;</code>和<code>&lt;audio&gt;</code></a>，{{htmlelement("picture")}}素包含了一些{{htmlelement("source")}}元素，它使浏览器在不同资源间做出选择，紧跟着的是最重要的{{htmlelement("img")}}元素。<a href="https://mdn.github.io/learning-area/html/multimedia-and-embedding/responsive-images/responsive.html">responsive.html</a> 的代码如下：</p>
+<p>让我们改用 {{htmlelement("picture")}}！就像<a href="/zh-CN/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content"><code>&lt;video&gt;</code>和<code>&lt;audio&gt;</code></a>，{{htmlelement("picture")}}素包含了一些{{htmlelement("source")}}元素，它使浏览器在不同资源间做出选择，紧跟着的是最重要的{{htmlelement("img")}}元素。<a href="https://mdn.github.io/learning-area/html/multimedia-and-embedding/responsive-images/responsive.html">responsive.html</a> 的代码如下：</p>
 
 <pre class="brush: html notranslate">&lt;picture&gt;
   &lt;source media="(max-width: 799px)" srcset="elva-480w-close-portrait.jpg"&gt;
@@ -176,7 +176,7 @@ translation_of: Learn/HTML/Multimedia_and_embedding/Responsive_images
 
 <p>这样的代码允许我们在宽屏和窄屏上都能显示合适的图片，像下面展示的一样：</p>
 
-<p><img alt="Our example site as viewed on a wide screen - here the first image works ok, as it is big enough to see the detail in the center." src="https://mdn.mozillademos.org/files/12940/picture-element-wide.png"><img alt="Our example site as viewed on a narrow screen with the picture element used to switch the first image to a portrait close up of the detail, making it a lot more useful on a narrow screen" src="https://mdn.mozillademos.org/files/12938/picture-element-narrow.png"></p>
+<p><img alt="Our example site as viewed on a wide screen - here the first image works OK, as it is big enough to see the detail in the center." src="picture-element-wide.png"><img alt="Our example site as viewed on a narrow screen with the picture element used to switch the first image to a portrait close up of the detail, making it a lot more useful on a narrow screen" src="picture-element-narrow.png"></p>
 
 <div class="note">
 <p><strong>注意</strong>: 你应该仅仅当在美术设计场景下使用media属性；当你使用media时，不要在sizes属性中也提供媒体条件。</p>
@@ -230,10 +230,10 @@ translation_of: Learn/HTML/Multimedia_and_embedding/Responsive_images
 
 <ul>
  <li><strong>美术设计</strong>：当你想为不同布局提供不同剪裁的图片——比如在桌面布局上显示完整的、横向图片，而在手机布局上显示一张剪裁过的、突出重点的纵向图片，可以用 {{htmlelement("picture")}} 元素来实现。</li>
- <li><strong>分辨率切换</strong>：当你想要为窄屏提供更小的图片时，因为小屏幕不需要像桌面端显示那么大的图片；以及你想为高/低分辨率屏幕提供不同分辨率的图片时，都可以通过 <a href="/en-US/docs/Learn/HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web">vector graphics</a> (SVG images)、 {{htmlattrxref("srcset", "img")}} 以及 {{htmlattrxref("sizes", "img")}} 属性来实现。</li>
+ <li><strong>分辨率切换</strong>：当你想要为窄屏提供更小的图片时，因为小屏幕不需要像桌面端显示那么大的图片；以及你想为高/低分辨率屏幕提供不同分辨率的图片时，都可以通过 <a href="/zh-CN/docs/Learn/HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web">vector graphics</a> (SVG images)、 {{htmlattrxref("srcset", "img")}} 以及 {{htmlattrxref("sizes", "img")}} 属性来实现。</li>
 </ul>
 
-<p>此时整个<a href="/en-US/docs/Learn/HTML/Multimedia_and_embedding">多媒体与嵌入</a> 模块接近尾声！在继续下一个模块之前，你现在唯一要做的就是尝试我们的多媒体评估，看看你做得怎样。玩的开心。</p>
+<p>此时整个<a href="/zh-CN/docs/Learn/HTML/Multimedia_and_embedding">多媒体与嵌入</a> 模块接近尾声！在继续下一个模块之前，你现在唯一要做的就是尝试我们的多媒体评估，看看你做得怎样。玩的开心。</p>
 
 <h2 id="另请参阅">另请参阅</h2>
 


### PR DESCRIPTION
Fixes #4865

The src of images will fallback to `en-US` which may not be visible in pr preview.

![image](https://user-images.githubusercontent.com/15844309/161406841-3a918ec7-fdde-4f0c-b81c-e45f13928049.png)

This image cannot be found in `mdn/content`, a content update is needed(line 126): https://github.com/mdn/translated-content/pull/4953/files#diff-025df0f5ea82797877b6907435afab97e2abfccfafc97ef14636c4b528f5f338L126-L127