### PR TITLE
Замена var -> const, баг про minute и second

### DIFF
--- a/files/ru/web/javascript/reference/global_objects/date/tolocaletimestring/index.html
+++ b/files/ru/web/javascript/reference/global_objects/date/tolocaletimestring/index.html
@@ -23,7 +23,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
 <div>{{page('/ru/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat', 'Parameters')}}</div>
 <p>Значением по умолчанию для каждой компоненты даты-времени является {{jsxref("Global_Objects/undefined", "undefined")}}, однако, если все свойства <code>hour</code>, <code>minute</code> и <code>second</code> равны {{jsxref("Global_Objects/undefined", "undefined")}}, то их значения предполагаются равными <code>"numeric"</code>.</p>
 <p>При создании <code>minute</code> и <code>second</code> как отдельные переменные в браузере Chrome, параметр <code>"2-digit"</code> не работает.</p>
-<pre class="brush: js">const date = new Date('December 1, 1995 03:01:03');
+<pre class="brush: js">const date = new Date('December 1, 1995 03:01:02');
 
     const hour = date.toLocaleTimeString('ru', { hour:'2-digit',});
     const minute = date.toLocaleTimeString('ru', { minute:'2-digit'});

--- a/files/ru/web/javascript/reference/global_objects/date/tolocaletimestring/index.html
+++ b/files/ru/web/javascript/reference/global_objects/date/tolocaletimestring/index.html
@@ -22,12 +22,12 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
 <p>Проверьте раздел <a href="#Browser_compatibility">Совместимость с браузерами</a>, чтобы увидеть, какие браузеры поддерживают аргументы <code>locales</code> и <code>options</code>, и <a href="#Example:_Checking_for_support_for_locales_and_options_arguments">Пример: проверка поддержки аргументов <code>locales</code> и <code>options</code></a> для определения этой возможности.</p>
 <div>{{page('/ru/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat', 'Parameters')}}</div>
 <p>Значением по умолчанию для каждой компоненты даты-времени является {{jsxref("Global_Objects/undefined", "undefined")}}, однако, если все свойства <code>hour</code>, <code>minute</code> и <code>second</code> равны {{jsxref("Global_Objects/undefined", "undefined")}}, то их значения предполагаются равными <code>"numeric"</code>.</p>
-
+<p>При создании <code>minute</code> и <code>second</code> как отдельные переменные, параметр <code>"2-digit"</code> не работает.</p>
 <h2 id="Examples">Примеры</h2>
 
 <h3 id="Example:_Using_toLocaleTimeString">Пример: использование метода <code>toLocaleTimeString()</code></h3>
 <p>При базовом использовании без указания локали возвращается строка, отформатированная в соответствии с локалью и опциями по умолчанию.</p>
-<pre class="brush: js">var date = new Date(Date.UTC(2012, 11, 12, 3, 0, 0));
+<pre class="brush: js">const date = new Date(Date.UTC(2012, 11, 12, 3, 0, 0));
 
 // Вывод toLocaleTimeString() без аргументов зависит от реализации,
 // локали по умолчанию и часового пояса по умолчанию
@@ -49,7 +49,7 @@ console.log(date.toLocaleTimeString());
 
 <h3 id="Example:_Using_locales">Пример: использование аргумента <code>locales</code></h3>
 <p>Этот пример показывает некоторые локализованные форматы времени. Для получения формата языка, используемого в пользовательском интерфейсе вашего приложения, убедитесь, что вы указали этот язык (и, возможно, несколько запасных языков) через аргумент <code>locales</code>:</p>
-<pre class="brush: js">var date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
+<pre class="brush: js">const date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
 
 // Форматирование ниже предполагает, что местный часовой пояс равен
 // America/Los_Angeles для локали США
@@ -78,10 +78,10 @@ console.log(date.toLocaleTimeString(['ban', 'id']));
 
 <h3 id="Example:_Using_options">Пример: использование аргумента <code>options</code></h3>
 <p>Результат, предоставляемый методом <code>toLocaleTimeString()</code>, может быть настроен с помощью аргумента <code>options</code>:</p>
-<pre class="brush: js">var date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
+<pre class="brush: js">const date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
 
 // Приложение может захотеть использовать UTC и показать это
-var options = { timeZone: 'UTC', timeZoneName: 'short' };
+const options = { timeZone: 'UTC', timeZoneName: 'short' };
 console.log(date.toLocaleTimeString('en-US', options));
 // → "3:00:00 AM GMT"
 

--- a/files/ru/web/javascript/reference/global_objects/date/tolocaletimestring/index.html
+++ b/files/ru/web/javascript/reference/global_objects/date/tolocaletimestring/index.html
@@ -22,16 +22,6 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
 <p>Проверьте раздел <a href="#Browser_compatibility">Совместимость с браузерами</a>, чтобы увидеть, какие браузеры поддерживают аргументы <code>locales</code> и <code>options</code>, и <a href="#Example:_Checking_for_support_for_locales_and_options_arguments">Пример: проверка поддержки аргументов <code>locales</code> и <code>options</code></a> для определения этой возможности.</p>
 <div>{{page('/ru/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat', 'Parameters')}}</div>
 <p>Значением по умолчанию для каждой компоненты даты-времени является {{jsxref("Global_Objects/undefined", "undefined")}}, однако, если все свойства <code>hour</code>, <code>minute</code> и <code>second</code> равны {{jsxref("Global_Objects/undefined", "undefined")}}, то их значения предполагаются равными <code>"numeric"</code>.</p>
-<p>При создании <code>minute</code> и <code>second</code> как отдельные переменные в браузере Chrome, параметр <code>"2-digit"</code> не работает.</p>
-<pre class="brush: js">const date = new Date('December 1, 1995 03:01:02');
-
-    const hour = date.toLocaleTimeString('ru', { hour:'2-digit',});
-    const minute = date.toLocaleTimeString('ru', { minute:'2-digit'});
-    const second = date.toLocaleTimeString('ru', { second:'2-digit'});
-
-    //В браузере Chrome не работает '2-digit' для minute и second
-    console.log(hour, minute, second); //03 1 2 , в Firefox проблем нет и выведет 03 01 02
-</pre>
 
 <h2 id="Examples">Примеры</h2>
 

--- a/files/ru/web/javascript/reference/global_objects/date/tolocaletimestring/index.html
+++ b/files/ru/web/javascript/reference/global_objects/date/tolocaletimestring/index.html
@@ -22,7 +22,17 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
 <p>Проверьте раздел <a href="#Browser_compatibility">Совместимость с браузерами</a>, чтобы увидеть, какие браузеры поддерживают аргументы <code>locales</code> и <code>options</code>, и <a href="#Example:_Checking_for_support_for_locales_and_options_arguments">Пример: проверка поддержки аргументов <code>locales</code> и <code>options</code></a> для определения этой возможности.</p>
 <div>{{page('/ru/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat', 'Parameters')}}</div>
 <p>Значением по умолчанию для каждой компоненты даты-времени является {{jsxref("Global_Objects/undefined", "undefined")}}, однако, если все свойства <code>hour</code>, <code>minute</code> и <code>second</code> равны {{jsxref("Global_Objects/undefined", "undefined")}}, то их значения предполагаются равными <code>"numeric"</code>.</p>
-<p>При создании <code>minute</code> и <code>second</code> как отдельные переменные, параметр <code>"2-digit"</code> не работает.</p>
+<p>При создании <code>minute</code> и <code>second</code> как отдельные переменные в браузере Chrome, параметр <code>"2-digit"</code> не работает.</p>
+<pre class="brush: js">const date = new Date('December 1, 1995 03:01:03');
+
+    const hour = date.toLocaleTimeString('ru', { hour:'2-digit',});
+    const minute = date.toLocaleTimeString('ru', { minute:'2-digit'});
+    const second = date.toLocaleTimeString('ru', { second:'2-digit'});
+
+    //В браузере Chrome не работает '2-digit' для minute и second
+    console.log(hour, minute, second); //03 1 2 , в Firefox проблем нет и выведет 03 01 02
+</pre>
+
 <h2 id="Examples">Примеры</h2>
 
 <h3 id="Example:_Using_toLocaleTimeString">Пример: использование метода <code>toLocaleTimeString()</code></h3>


### PR DESCRIPTION
При создании minute и second как отдельные переменные, параметр "2-digit" не работает, добавить пример кода в примечание?

const date = new Date('December 1, 1995 03:01:03');

const hour = date.toLocaleTimeString('ru', { hour:'2-digit',});
const minute = date.toLocaleTimeString('ru', { minute:'2-digit'});
const second = date.toLocaleTimeString('ru', { second:'2-digit'});

console.log(hour, minute, second);

https://jsfiddle.net/mor_ozzy/5vcs7wkL/4/