### PR TITLE
fix incorrect translation of "round"

### DIFF
--- a/files/zh-cn/web/api/element/scrollheight/index.md
+++ b/files/zh-cn/web/api/element/scrollheight/index.md
@@ -19,7 +19,7 @@ translation_of: Web/API/Element/scrollHeight
 `scrollHeight` 的值等于该元素在不使用滚动条的情况下为了适应视口中所用内容所需的最小高度。没有垂直滚动条的情况下，scrollHeight值与元素视图填充所有内容所需要的最小值{{domxref("Element.clientHeight", "clientHeight")}}相同。包括元素的padding，但不包括元素的border和margin。`scrollHeight` 也包括 {{cssxref("::before")}} 和 {{cssxref("::after")}}这样的伪元素。
 如果元素的内容不需要垂直滚动条就可以容纳，则其 `scrollHeight` 等于{{domref("Element.clientHeight", "clientHeight")}}
 
-> **备注：** 属性将会对值四舍五入取整。如果需要小数值，使用
+> **备注：** 属性将会对值取整。如果需要小数值，使用
 > {{ domxref("Element.getBoundingClientRect()") }}.
 
 ## 值


### PR DESCRIPTION
### "english" original content

<img width="775" alt="image" src="https://user-images.githubusercontent.com/7148809/161691422-ecb1528e-5f09-4f14-90a7-4f551221e30e.png">

### "zh-cn" content translates the "round" into "四舍五入取整"

<img width="521" alt="image" src="https://user-images.githubusercontent.com/7148809/161691821-ed98744d-5244-407f-ac6e-0a1b8ccf399f.png">

### but the actual behavior in chrome is `Math.floor`

![image](https://user-images.githubusercontent.com/7148809/161692011-ddfdeb80-7550-42b2-87c9-fab01a7d33cc.png)
