### PR TITLE
Remove menu from paragraph

### DIFF
--- a/files/fr/web/api/node/previoussibling/index.md
+++ b/files/fr/web/api/node/previoussibling/index.md
@@ -29,7 +29,7 @@ alert(document.getElementById("b2").previousSibling.id); // "b1"
 
 Les navigateurs basés sur Gecko insèrent des nœuds texte dans un document pour représenter des espaces
 vides dans le balisage source. Par conséquent, un nœud obtenu par exemple via [`Node.firstChild`](/fr/docs/Web/API/Node/firstChild) ou
-[`Node.previousSibling`](/fr/docs/Web/API/Node/previousSibling "{{APIRef("DOM")}}") peut faire référence à un nœud texte contenant des espaces plutôt qu'au véritable élément
+[`Node.previousSibling`](/fr/docs/Web/API/Node/previousSibling) peut faire référence à un nœud texte contenant des espaces plutôt qu'au véritable élément
 que l'auteur comptait obtenir.
 
 Consultez [Gestion des espaces dans le DOM](/fr/docs/Gestion_des_espaces_dans_le_DOM)


### PR DESCRIPTION
In French translation, a menu/summary is in middle of a paragraph. With "{{APIRef("DOM")}}" deletion, this menu disappear. I don't know what means this expression.