### PR TITLE
Update wrong translate in Korean

### DIFF
--- a/files/ko/web/css/height/index.html
+++ b/files/ko/web/css/height/index.html
@@ -47,7 +47,7 @@ height: unset;
  <dt><code>content-box</code> {{experimental_inline}}</dt>
  <dd>앞선 {{cssxref("&lt;length&gt;")}} 또는 {{cssxref("&lt;percentage&gt;")}}가 요소의 콘텐츠 박스에 적용.</dd>
  <dt><code>auto</code></dt>
- <dd>브라우저가 요소의 너비를 계산하고 선택.</dd>
+ <dd>브라우저가 요소의 높이를 계산하고 선택.</dd>
  <dt><code>fill</code> {{experimental_inline}}</dt>
  <dd>글쓰기 방향에 따라 <code>fill-available</code> 인라인 크기 또는 <code>fill-available</code> 블록 크기를 사용.</dd>
  <dt><code>max-content</code> {{experimental_inline}}</dt>
@@ -55,12 +55,12 @@ height: unset;
  <dt><code>min-content</code> {{experimental_inline}}</dt>
  <dd>본질적인 최소 높이.</dd>
  <dt><code>available</code> {{experimental_inline}}</dt>
- <dd>컨테이닝 블록 너비에서 수평 여백, 테두리, 패딩을 제외한 값.</dd>
+ <dd>컨테이닝 블록 높이에서 수평 여백, 테두리, 패딩을 제외한 값.</dd>
  <dt><code>fit-content</code> {{experimental_inline}}</dt>
  <dd>다음 중 더 큰 값.
  <ul>
-  <li>본질적인 최소 너비</li>
-  <li>본질적인 선호 너비와 사용 가능한 너비 중 작은 값</li>
+  <li>본질적인 최소 높이</li>
+  <li>본질적인 선호 높이와 사용 가능한 높이 중 작은 값</li>
  </ul>
  </dd>
 </dl>


### PR DESCRIPTION
I update wrong translate in Korean word. This page is about `height` but in some places the Korean word `width(너비)` is used.