### PR TITLE
Firefox 99 for developersを翻訳

### DIFF
--- a/files/ja/mozilla/firefox/releases/99/index.md
+++ b/files/ja/mozilla/firefox/releases/99/index.md
@@ -1,0 +1,54 @@
+---
+title: Firefox 99 for developers
+slug: Mozilla/Firefox/Releases/99
+tags:
+  - '99'
+  - Firefox
+  - Mozilla
+  - Release
+---
+{{FirefoxSidebar}}
+
+このページでは、開発者に影響する Firefox 99 の変更点をまとめています。Firefox 99 は、米国時間 2022 年 4 月 5 日にリリースされました。
+
+## ウェブ開発者向けの変更点一覧
+
+### HTML
+
+変更なし。
+
+### CSS
+
+変更なし。
+
+### JavaScript
+
+変更なし。
+
+### API
+
+- {{domxref("navigator.pdfViewerEnabled")}} を有効になり、PDF ファイルへ移動するときにブラウザーが PDF のインライン表示をサポートしているか判断するために推奨される方法になりました。
+  PDF ビューアーのサポートを推測するために非推奨の {{domxref("navigator.plugins")}} および {{domxref("navigator.mimeTypes")}} プロパティを使用してるサイトは、現時点で `pdfViewerEnabled` が提供するシグナルと一致するハードコードされた疑似的な値が返るとしても、新しいプロパティに移行するべきです ({{bug(1720353)}})。
+
+#### Media、WebRTC、Web Audio
+
+- [`RTCPeerConnection.setConfiguration()`](/ja/docs/Web/API/RTCPeerConnection/setConfiguration) メソッドをサポートしました。
+  特に、サイトで設定をネットワークの状態の変化に合わせることを可能にします ({{bug(1253706)}})。
+
+#### 廃止
+
+- [Network Information API](/ja/docs/Web/API/Network_Information_API) は以前 Android (限定) で有効化していましたが、すべてのプラットフォームでデフォルトで無効になりました。
+  この API は、フィンガープリンティングに使用されると思われるかなりの量のユーザー情報を公開するため、削除する過程にあります 
+  ({{bug(1720353)}})。
+
+
+### WebDriver conformance (Marionette)
+
+- `WebDriver:ElementSendKeys` コマンドのキーシーケンスの一部で、Shift キーが適切に制御されない不具合を修正しました ({{bug(1757636)}})。
+
+## アドオン開発者向けの変更点一覧
+
+
+## 過去のバージョン
+
+{{Firefox_for_developers(98)}}

--- a/files/ja/mozilla/firefox/releases/99/index.md
+++ b/files/ja/mozilla/firefox/releases/99/index.md
@@ -27,7 +27,7 @@ tags:
 
 ### API
 
-- {{domxref("navigator.pdfViewerEnabled")}} を有効になり、PDF ファイルへ移動するときにブラウザーが PDF のインライン表示をサポートしているか判断するために推奨される方法になりました。
+- {{domxref("navigator.pdfViewerEnabled")}} が有効になり、PDF ファイルへ移動するときにブラウザーが PDF のインライン表示をサポートしているか判断するために推奨される方法になりました。
   PDF ビューアーのサポートを推測するために非推奨の {{domxref("navigator.plugins")}} および {{domxref("navigator.mimeTypes")}} プロパティを使用してるサイトは、現時点で `pdfViewerEnabled` が提供するシグナルと一致するハードコードされた疑似的な値が返るとしても、新しいプロパティに移行するべきです ({{bug(1720353)}})。
 
 #### Media、WebRTC、Web Audio


### PR DESCRIPTION
Apr 5, 2022の英語版に対応。