### PR TITLE
fix: typo in service worker

### DIFF
--- a/files/ko/web/api/serviceworker/index.html
+++ b/files/ko/web/api/serviceworker/index.html
@@ -15,7 +15,7 @@ translation_of: Web/API/ServiceWorker
 ---
 <div>{{APIRef("Service Workers API")}}</div>
 
-<p><a href="/ko/docs/Web/API/Service_Worker_API">Service Worker API</a>의 <strong><code>ServiceWorker</code></strong> 인터페이스는 서비스 워커로의 참조를 제공합니다. 다수의{{glossary("browsing context", "브라우징 맥락")}}(e.g. 페이지, 다른 워커, 등등)는 고유한<code> ServiceWorker</code> 객체를 통해 동일한 서비스 워커와 연결할 수 있습니다.</p>
+<p><a href="/ko/docs/Web/API/Service_Worker_API">Service Worker API</a>의 <strong><code>ServiceWorker</code></strong> 인터페이스는 서비스 워커로의 참조를 제공합니다. 다수의 {{glossary("browsing context", "브라우징 맥락")}}(e.g. 페이지, 다른 워커, 등등)는 고유한<code> ServiceWorker</code> 객체를 통해 동일한 서비스 워커와 연결할 수 있습니다.</p>
 
 <p><code>ServiceWorker</code> 객체는 {{domxref("ServiceWorkerRegistration.active")}} 속성과 {{domxref("ServiceWorkerContainer.controller")}} 속성으로 접근할 수 있습니다. <code>controller</code>는 활성화되어 페이지를 통제 중인 서비스 워커입니다.</p>
 


### PR DESCRIPTION
다수의브라우징 맥락 -> 다수의 브라우징 맥락
which needs space