### PR TITLE
 Typo in Russian version

### DIFF
--- a/files/ru/web/css/_colon_defined/index.html
+++ b/files/ru/web/css/_colon_defined/index.html
@@ -5,7 +5,7 @@ translation_of: 'Web/CSS/:defined'
 ---
 <div>{{ CSSRef }}</div>
 
-<p><span class="seoSummary"><a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">псевдокласс</a> <strong><code>:defined</code></strong> находит любой элемент, который был определён, включая любой стандартный элемент встроенный в браузер и <a href="/ru/docs/Web/Web_Components/Использование_пользовательских_элементов">пользовательские элементы</a> (то есть определённые с помощью метода {{domxref("CustomElementRegistry.define()")}}).</span></p>
+<p><span class="seoSummary"><a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">псевдокласс</a> <strong><code>:defined</code></strong> находит любой элемент, который был определён, включая любой стандартный элемент, встроенный в браузер, и <a href="/ru/docs/Web/Web_Components/Использование_пользовательских_элементов">пользовательские элементы</a> (то есть определённые с помощью метода {{domxref("CustomElementRegistry.define()")}}).</span></p>
 
 <pre class="brush: css no-line-numbers">/* Находит любой элемент, который был определён */
 :defined {

--- a/files/ru/web/css/_colon_defined/index.html
+++ b/files/ru/web/css/_colon_defined/index.html
@@ -5,7 +5,7 @@ translation_of: 'Web/CSS/:defined'
 ---
 <div>{{ CSSRef }}</div>
 
-<p><span class="seoSummary"><a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">псевдокласс</a> <strong><code>:defined</code></strong> находит любой элемент, который был определён, включая любой стандартный встроенные в браузер элемент и <a href="/ru/docs/Web/Web_Components/Использование_пользовательских_элементов">пользовательские элементы</a> (то есть определённые с помощью метода {{domxref("CustomElementRegistry.define()")}}).</span></p>
+<p><span class="seoSummary"><a href="/en-US/docs/Web/CSS">CSS</a> <a href="/en-US/docs/Web/CSS/Pseudo-classes">псевдокласс</a> <strong><code>:defined</code></strong> находит любой элемент, который был определён, включая любой стандартный элемент встроенный в браузер и <a href="/ru/docs/Web/Web_Components/Использование_пользовательских_элементов">пользовательские элементы</a> (то есть определённые с помощью метода {{domxref("CustomElementRegistry.define()")}}).</span></p>
 
 <pre class="brush: css no-line-numbers">/* Находит любой элемент, который был определён */
 :defined {


### PR DESCRIPTION
eng version: "This includes any standard element built in to the browser,"
rus version: "который был определён, включая любой стандартный встроенные в браузер элемент"