### PR TITLE
Eliminada letra 's' sobrante

### DIFF
--- a/files/es/learn/css/first_steps/how_css_works/index.html
+++ b/files/es/learn/css/first_steps/how_css_works/index.html
@@ -30,7 +30,7 @@ original_slug: Learn/CSS/First_steps/Como_funciona_CSS
  <li>El navegador carga el HTML (por ejemplo, lo recibe de la red).</li>
  <li>Convierte el {{Glossary("HTML")}} en un {{Glossary("DOM")}} (<em>Modelo de objetos del documento</em>). El DOM representa el documento en la memoria del ordenador. Lo explicaremos más detalladamente en la sección siguiente.</li>
  <li>Entonces, el navegador va a buscar la mayor parte de los recursos vinculados al documento HTML, como las imágenes y los videos incrustados... ¡y también el CSS vinculado! JavaScript aparece un poco más adelante en el proceso, pero no vamos a hablar de ello aún para evitar complicar las cosas.</li>
- <li>El navegador analiza el CSS y ordena en diferentes «cubos» las diferentes reglas según el tipo de selector. Por ejemplo, elemento, clase, ID, y así sucesivamente. Para cada tipo de selector que encuentres, calcula qué reglas deben aplicarse y a qué nodos en el DOM se les aplica el estilo según corresponda (este paso intermedio se llama árbol de renderización).</li>
+ <li>El navegador analiza el CSS y ordena en diferentes «cubos» las diferentes reglas según el tipo de selector. Por ejemplo, elemento, clase, ID, y así sucesivamente. Para cada tipo de selector que encuentre, calcula qué reglas deben aplicarse y a qué nodos en el DOM se les aplica el estilo según corresponda (este paso intermedio se llama árbol de renderización).</li>
  <li>El árbol de renderización presenta la estructura en que los nodos deben aparecer después de aplicarle las reglas.</li>
  <li>En la pantalla se muestra el aspecto visual de la página (esta etapa se llama pintura).</li>
 </ol>


### PR DESCRIPTION
Como el texto está hablando del "Navegador", si se deja la letra 's' se interpreta como que se está hablando del usuario. Lo que creo que está mal.