### PR TITLE
remove the deprecated macro `{{anch}}` from `Commonly-used_macros`

### DIFF
--- a/files/zh-cn/mdn/structures/macros/commonly-used_macros/index.html
+++ b/files/zh-cn/mdn/structures/macros/commonly-used_macros/index.html
@@ -39,15 +39,6 @@ original_slug: MDN/Structures/Macros/Custom_macros
   </ul>
 </ol>
 
-<h3 id="Links_to_in-page_sections">链接到页内章节</h3>
-
-<p>{{TemplateLink("anch")}} 可用于创建指向当前文章中其他小节的链接。它和 Glossary 有一个相同作用的可选参数可在翻译时使用。</p>
-
-<ul>
-  <li><code>\{{anch("Linking to pages in references","链接到 MDN 的参考文档页面")}}</code></li>
-  <li><p>实际效果：<a href="#Linking_to_pages_in_references">链接到 MDN 的参考文档页面</a></p></li>
-</ul>
-
 <h3 id="Linking_to_pages_in_references">链接到 MDN 的参考文档页面</h3>
 
 <p>下面列出的宏可链接到 MDN 站内不同技术领域的参考文档，如 Javascript,、CSS、HTML、elements、SVG 等。</p>


### PR DESCRIPTION
Reference: mdn/content#13814