### PR TITLE
Update ru/web/svg/tutorial/tools_for_svg

### DIFF
--- a/files/ru/web/svg/tutorial/tools_for_svg/index.html
+++ b/files/ru/web/svg/tutorial/tools_for_svg/index.html
@@ -1,5 +1,5 @@
 ---
-title: Tools for SVG
+title: Работа с SVG
 slug: Web/SVG/Tutorial/Tools_for_SVG
 translation_of: Web/SVG/Tutorial/Tools_for_SVG
 ---
@@ -7,7 +7,7 @@ translation_of: Web/SVG/Tutorial/Tools_for_SVG
 
 <p>Теперь, когда мы рассмотрели основы SVG, мы рассмотрим некоторые инструменты для работы с SVG файлами.</p>
 
-<h3 id="Browser_support">Browser support</h3>
+<h3 id="Browser_support">Поддержка браузерами</h3>
 
 <p>As of Internet Explorer 9, all major browsers support SVG: IE 9, Mozilla Firefox, Safari, Google Chrome and Opera. Mobile devices with Webkit-based browsers also support SVG. On older or smaller devices, chances are that SVG Tiny is supported.</p>
 
@@ -65,8 +65,8 @@ translation_of: Web/SVG/Tutorial/Tools_for_SVG
 
 <p>In GIS (Geographic Information System) applications SVG is often used as both storage and rendering format. See <a class="external" href="http://carto.net">carto.net</a> for details.</p>
 
-<h2 id="More_tools!">More tools!</h2>
+<h2 id="More_tools!">Больше программ!</h2>
 
-<p>The W3C offers a <a class="external" href="http://www.w3.org/Graphics/SVG/WG/wiki/Implementations">list of programs</a> that support SVG.</p>
+<p>W3C предлагает <a class="external" href="http://www.w3.org/Graphics/SVG/WG/wiki/Implementations">список программ</a>, которые поддерживают SVG.</p>
 
 <p>{{ PreviousNext("Web/SVG/Tutorial/SVG_Image_Tag") }}</p>


### PR DESCRIPTION
https://developer.mozilla.org/ru/docs/Web/SVG/Tutorial/Tools_for_SVG

- Название статьи было изменено с "Tools for SVG" на "Работа с SVG"
- Заголовок раздела "Browser Support" был изменён на "Поддержка браузерами"
- Был переведён раздел "More tools!"