### PR TITLE
Fix typo and missing tag

### DIFF
--- a/files/pt-br/web/css/_colon_root/index.html
+++ b/files/pt-br/web/css/_colon_root/index.html
@@ -7,7 +7,7 @@ translation_of: 'Web/CSS/:root'
 
 <h2 id="Sumário">Sumário</h2>
 
-<p>A <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-classe CSS</a>  <strong><code>:root</code></strong> se equipara à raíz de uma árvore, que por sua vez representa o documento. Aplicado ao HTML, <code>:root</code> representa o elemento {{HTMLElement("html")}}  e é identico ao seletor html, exceto que sua <a href="/pt-BR/docs/Web/CSS/Specificity">especificidade</a> é mais alta.</p>
+<p>A <a href="/en-US/docs/Web/CSS/Pseudo-classes">pseudo-classe CSS</a>  <strong><code>:root</code></strong> se equipara à raiz de uma árvore, que por sua vez representa o documento. Aplicado ao HTML, <code>:root</code> representa o elemento {{HTMLElement("html")}}  e é identico ao seletor <code>html</code>, exceto que sua <a href="/pt-BR/docs/Web/CSS/Specificity">especificidade</a> é mais alta.</p>
 
 <h2 id="Sintaxe">Sintaxe</h2>
 


### PR DESCRIPTION
There is a typo in the word "raíz", which does not have an acute accent.

Also, the reference to the html selector is missing a `<code>` tag, in comparison to the original content in English.