### PR TITLE
Remove h3-gecko-minversion from French pages

### DIFF
--- a/files/fr/web/api/console/group/index.md
+++ b/files/fr/web/api/console/group/index.md
@@ -26,11 +26,9 @@ Création d'un nouveau groupe en ligne dans la [console Web](/en-US/docs/Tools/W
 - `label`
   - : donne une étiquette au groupe. Facultatif. (Chrome 59 testé). Ne fonctionne pas avec` ``console.groupEnd()`.
 
-{{h3_gecko_minversion("Using groups in the console", "9.0")}}
+## Exemples
 
 Vous pouvez utiliser des groupes imbriqués pour organiser votre sortie en associant visuellement les messages correspondants. Pour créer un nouveau bloc imbriqué, appelez `console.group ()`. La méthode `console.groupCollapsed ()` est similaire, mais le nouveau bloc est réduit et nécessite de cliquer sur un bouton de divulgation pour le lire.
-
-> **Note :** De Gecko 9 jusqu'à Gecko 51, la méthode `groupCollapsed()` n'était pas identique à `group()`. Les groupes réduits sont entièrement pris en charge depuis Gecko 52. Voir {{bug("1088360")}}.
 
 Pour sortir du groupe courant, appeler `console.groupEnd()`. Par exemple, étant donné ce code :
 

--- a/files/fr/web/api/console/index.md
+++ b/files/fr/web/api/console/index.md
@@ -172,11 +172,9 @@ console.log("This is %cMy stylish message", "color: yellow; font-style: italic; 
 
 > **Note :** Un certain nombre de propriétés CSS sont supportées par ce style; vous devriez expérimenter et voir lesquels s'avèrent utiles.
 
-{{h3_gecko_minversion("Using groups in the console", "9.0")}}
+### Utiliser des groupes dans la console
 
 Vous pouvez utiliser des groupes imbriqués pour vous aider à vous repérer dans l'affichage. Pour créer un nouveau bloc, appelez `console.group()`. La méthode `console.groupCollapsed()` est similaire, mais elle crée un bloc qui sera réduit.
-
-> **Note :** "Collapsed groups" ne sont pas supportés pour l'instant dans Gecko; La méthode `groupCollapsed()` est la même que `group()` en ce moment.
 
 Pour quitter le groupe dans lequel on est, appeler `console.groupEnd()`. Par exemple, examinez ce code :
 
@@ -197,7 +195,7 @@ L'affichage ressemblera à ceci :
 
 ![Démonstration de groupes imbriqués dans la console Firefox](console_groups_demo.png)
 
-{{h3_gecko_minversion("Timers", "10.0")}}
+### Chronométrage
 
 Pour calculer la durée d'une opération spécifique, Gecko 10 a amené le supports des chronomètres dans l'objet `console`.  pour démarrer un chronomètre, appelez la méthode ` console.time``() ` en lui donnant un seul paramètre, son nom. Pour arrêter le chronomètre et obtenir le temps écoulé en millisecondes, utilisez la méthode `console.timeEnd()`, en passant à nouveau le nom du chronomètre comme paramètre. Une seule page peut faire tourner un maximum de 10.000 chronomètres.
 

--- a/files/fr/web/css/@media/-moz-device-pixel-ratio/index.md
+++ b/files/fr/web/css/@media/-moz-device-pixel-ratio/index.md
@@ -9,7 +9,7 @@ tags:
   - Non-standard
 translation_of: Web/CSS/@media/-moz-device-pixel-ratio
 ---
-{{cssref}} {{Non-standard_header}} {{Deprecated_header}}{{h3_gecko_minversion("-moz-device-pixel-ratio", "2.0")}} {{deprecated_inline("16")}}
+{{cssref}} {{Non-standard_header}} {{Deprecated_header}}
 
 La [caractéristique média](/fr/docs/Web/CSS/Media_Queries/Using_media_queries#ciblfer_des_caract%c3%a9ristiques_m%c3%a9dia) **`-moz-device-pixel-ratio`**, associée à [`@media`](/fr/docs/Web/CSS/@media "The @media CSS at-rule lets you specify declarations that depend on the condition of a media query. The rule may be placed at the top level of your code or nested inside any other conditional group at-rule."), est une caractéristique propre à Gecko et peut être utilisée pour appliquer certains styles en fonctions du nombres de pixels physiques par pixel CSS.
 


### PR DESCRIPTION
The `{{h3_gecko_minversion}}` is/will be deprecated in mdn/yari#5995. This PR removes the macro (and some notes about Gecko that are not in en-US) from French files