### PR TITLE
Use ### instead of deprecated {{h3_gecko_minversion}} macro from console.group

### DIFF
--- a/files/ko/web/api/console/group/index.md
+++ b/files/ko/web/api/console/group/index.md
@@ -11,6 +11,7 @@ tags:
 browser-compat: api.console.group
 translation_of: Web/API/Console/group
 ---
+
 {{APIRef("Console API")}}
 
 **`console.group()`** 메서드는 [웹 콘솔](/ko/docs/Tools/Web_Console) 로그에 새로운 인라인 그룹을 만듭니다. 이는 {{domxref("console.groupEnd()")}}가 호출될 때까지 모든 다음 출력을 추가 수준으로 들여씁니다.
@@ -28,7 +29,7 @@ console.group([label]);
 - `label`
   - : 그룹의 레이블입니다. 이 매개변수는 선택사항입니다. (Chrome 59에서 테스트됨) `console.groupEnd()`와 함께 작동하지 않습니다.
 
-{{h3_gecko_minversion("콘솔에서 그룹 사용하기", "9.0")}}
+### 콘솔에서 그룹 사용하기
 
 중첩 그룹을 사용하여 관련 메시지를 시각적으로 연결하여 출력을 구성할 수 있습니다. 새 중첩 블록을 만들려면 `console.group()`을 호출하세요. `console.groupCollapsed()` 메서드와 비슷하지만 새 블록이 접혀 있고 이를 읽으려면 공개 버튼을 클릭해야 합니다.
 
@@ -55,7 +56,7 @@ console.log("Back to the outer level");
 ![A screenshot of messages nested in the console output.](nesting.png)
 
 자세한 내용은 {{domxref("console")}} 문서의 [콘솔 그룹 사용하기](/ko/docs/Web/API/console#콘솔_그룹_사용하기)를 참조하세요.
- 
+
 ## 명세
 
 {{Specifications}}


### PR DESCRIPTION
deprecated된 매크로 대신 ###으로 수정했습니다.
#5145 