### PR TITLE
Remove two last occurrences of TODO macro

### DIFF
--- a/files/de/web/css/align-items/index.html
+++ b/files/de/web/css/align-items/index.html
@@ -65,7 +65,7 @@ align-items: unset;
 
 <h2 id="Beispiele">Beispiele</h2>
 
-<p>{{ TODO() }}</p>
+<p>TBD</p>
 
 <h2 id="Specifications" name="Specifications">Spezifikationen</h2>
 

--- a/files/ko/mdn/guidelines/writing_style_guide/index.html
+++ b/files/ko/mdn/guidelines/writing_style_guide/index.html
@@ -776,8 +776,6 @@ var toolkitProfileService = Components.classes["@mozilla.org/toolkit/profile-ser
  <dd>A list of links to landing pages for other, related, technologies of relevance. The heading should use the class "Related_Topics".</dd>
 </dl>
 
-<p><strong>{{TODO("Finish this once we finalize the landing page standards")}}</strong></p>
-
 <h2 id="Using_and_inserting_images">Using and inserting images</h2>
 
 <p>It's sometimes helpful to provide an image in an article you create or modify, especially if the article is very technical.</p>


### PR DESCRIPTION
This PR removes the last 2 occurrences of the `{{TODO}}` macro in the whole of mdn (mdn/content and mdn/translated-content).

After this is merged, we can actually delete the macro from mdn/yari !