### PR TITLE
remove deprecated `{{Interface}}` macro from zh-CN

### DIFF
--- a/files/zh-cn/mozilla/firefox/releases/12/index.html
+++ b/files/zh-cn/mozilla/firefox/releases/12/index.html
@@ -130,15 +130,15 @@ translation_of: Mozilla/Firefox/Releases/12
 <h3 id="Interface_changes">Interface changes</h3>
 
 <ul>
- <li>The <code>nsIScreen_MOZILLA_2_0_BRANCH</code> interface has been merged into {{interface("nsIScreen")}}. The APIs defined in that interface (for controlling minimum screen brightness) had not previously been documented, but now they are.</li>
- <li>The {{interface("nsIScriptError2")}} interface has been merged into {{interface("nsIScriptError")}}.</li>
+ <li>The <code>nsIScreen_MOZILLA_2_0_BRANCH</code> interface has been merged into <code>nsIScreen</code>. The APIs defined in that interface (for controlling minimum screen brightness) had not previously been documented, but now they are.</li>
+ <li>The <code>nsIScriptError2</code> interface has been merged into <code>nsIScriptError</code>.</li>
  <li>{{ifmethod("nsIDownloadManager", "addDownload")}} is now handled asynchronously rather than synchronously.</li>
- <li>The {{ifmethod("imgIContainerObserver", "frameChanged")}} method now receives as its first parameter an {{interface("imgIRequest")}} object identifying the corresponding request.</li>
+ <li>The {{ifmethod("imgIContainerObserver", "frameChanged")}} method now receives as its first parameter an <code>imgIRequest</code> object identifying the corresponding request.</li>
  <li>The {{ifmethod("nsIDOMWindowUtils", "sendTouchEvent")}} method has been added to allow synthesizing touch events.</li>
  <li>You can now scroll the specified content to the vertical center of the view by specifying <code>SCROLL_CENTER_VERTICALLY</code> as the scroll constant when calling {{ifmethod("nsISelectionController", "scrollSelectionIntoView")}}.</li>
  <li>The new {{ifattribute("nsIMemoryMultiReporter", "explicitNonHeap")}} attribute has been added; this is a more efficient way to obtain the sum of all of the multi-reporter's measurements that have a path that starts with "explicit" <strong>and</strong> are of the kind <code>KIND_NONHEAP</code>.</li>
  <li>The {{ifattribute("nsIDOMWindowUtils", "paintingSuppressed")}} attribute has been added; this boolean value indicates whether or not painting is currently suppressed on the window. This is used on mobile to prevent bouncy rendering that occurs when attempts to draw the page begin before enough content is available to do so smoothly.</li>
- <li>The <code>nsIDocCharset</code> and <code>nsIDocumentCharsetInfo</code> interfaces have been merged into {{interface("nsIDocShell")}}. As part of this work, the old <code>forcedDetector</code> attribute has been removed; it never did anything.</li>
+ <li>The <code>nsIDocCharset</code> and <code>nsIDocumentCharsetInfo</code> interfaces have been merged into <code>nsIDocShell</code>. As part of this work, the old <code>forcedDetector</code> attribute has been removed; it never did anything.</li>
 </ul>
 
 <h3 id="SpiderMonkey">SpiderMonkey</h3>

--- a/files/zh-cn/mozilla/firefox/releases/14/index.html
+++ b/files/zh-cn/mozilla/firefox/releases/14/index.html
@@ -82,9 +82,9 @@ translation_of: Mozilla/Firefox/Releases/14
 <h3 class="editable" id="接口"><span>接口</span></h3>
 
 <ul>
- <li>{{ interface("nsILocalFile") }}接口被合并到{{ interface("nsIFile") }}接口中. (<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=682360">bug 682360</a>).</li>
- <li>The methods in {{ interface("nsIPlacesImportExportService") }} for importing bookmarks have all been removed in favor of the <code><a href="/zh-cn/JavaScript_code_modules/BookmarkHTMLUtils.jsm">BookmarkHTMLUtils.jsm</a></code> JavaScript code module.</li>
- <li>{{ interface("nsIDOMGeoPositionAddress") }} 接口已被移除.</li>
+ <li><code>nsILocalFile</code>接口被合并到<code>nsIFile</code>接口中. (<a class="link-https" href="https://bugzilla.mozilla.org/show_bug.cgi?id=682360">bug 682360</a>).</li>
+ <li>The methods in <code>nsIPlacesImportExportService</code> for importing bookmarks have all been removed in favor of the <code><a href="/zh-cn/JavaScript_code_modules/BookmarkHTMLUtils.jsm">BookmarkHTMLUtils.jsm</a></code> JavaScript code module.</li>
+ <li><code>nsIDOMGeoPositionAddress</code> 接口已被移除.</li>
 </ul>
 
 <h3 id="拼写检查">拼写检查</h3>

--- a/files/zh-cn/mozilla/firefox/releases/15/index.html
+++ b/files/zh-cn/mozilla/firefox/releases/15/index.html
@@ -92,20 +92,20 @@ translation_of: Mozilla/Firefox/Releases/15
 <h3 id="接口变更">接口变更</h3>
 
 <dl>
- <dt>{{ interface("nsIDOMWindowUtils") }}</dt>
+ <dt><code>nsIDOMWindowUtils</code></dt>
  <dd><code>aModifiers</code> of <code>sendMouseEvent()</code>, <code>sendTouchEvent()</code>, <code>sendMouseEventToWindow()</code>, <code>sendMouseScrollEvent()</code> and <code>sendKeyEvent()</code> supports all modifier keys which are supported by <a href="/zh-cn/DOM/KeyboardEvent#getModifierState%28%29" title="https://developer.mozilla.org/zh-cn/DOM/KeyboardEvent#getModifierState%28%29"><code>KeyboardEvent.getModifierState()</code></a>. Use <code>MODIFIER_*</code> values. And now the 5th parameter of <code>sendKeyEvent()</code> is changed from <code>boolean</code> to <code>unsigned long</code>. For backward compatibility, if caller passes <code>true</code> or <code>false</code> to it, the behavior isn't changed. This change allows callers to specify the key's location.</dd>
- <dt>{{ interface("nsIBrowserHistory") }}</dt>
+ <dt><code>nsIBrowserHistory</code></dt>
  <dd>The <code>hidePage()</code> method was never implemented, and has been removed entirely in this release. The <code>addPageWithDetails()</code> method has also been removed as part of the ongoing work to make all <a href="/zh-cn/Places" title="zh-cn/Places">Places</a> APIs asynchronous; use {{ ifmethod("mozIAsyncHistory", "updatePlaces") }} instead. Also, the <code>count</code> attribute was removed; it had not returned an actual count in some time (instead, it was simply indicating whether or not any entries existed). You can use {{ ifattribute("nsINavHistoryService", "hasHistoryEntries") }} instead.</dd>
- <dt>{{interface("inIDOMUtils")}}</dt>
+ <dt><code>inIDOMUtils</code></dt>
  <dd>The {{ifmethod("inlDOMUtils", "parseStyleSheet")}} method has been added and allows the (re-)parsing of Cascading Style Sheets.</dd>
- <dt>{{interface("nsIINIParserWriter")}}</dt>
+ <dt><code>nsIINIParserWriter</code></dt>
  <dd>The {{ifmethod("nsIINIParserWriter", "writeFile")}} method now accepts a <code>flags</code>property. This currently offers only one option: you can now tell it to write the file in UTF-16 format instead of UTF-8, for better compatibility with Windows and certain installers.</dd>
 </dl>
 
 <h4 id="新增接口">新增接口</h4>
 
 <dl>
- <dt>{{ interface("nsISpeculativeConnect") }}</dt>
+ <dt><code>nsISpeculativeConnect</code></dt>
  <dd>Provides a way to hint to the networking layer that you are likely to ask to open a connection to a given URI sometime in the near future. This lets the network layer begin the sometimes high-latency process of opening a new network connection ahead of time.</dd>
 </dl>
 
@@ -114,7 +114,7 @@ translation_of: Mozilla/Firefox/Releases/15
 <p>The following interfaces have been removed.</p>
 
 <ul>
- <li>{{ interface("nsIGlobalHistory") }}</li>
+ <li><code>nsIGlobalHistory</code></li>
 </ul>
 
 <h2 id="相关链接">相关链接</h2>

--- a/files/zh-cn/mozilla/firefox/releases/16/index.html
+++ b/files/zh-cn/mozilla/firefox/releases/16/index.html
@@ -107,7 +107,7 @@ translation_of: Mozilla/Firefox/Releases/16
 
 <h3 id="修改接口">修改接口</h3>
 
-<p>{{interface("nsIPrivateDOMEvent")}} has been merged into {{interface("nsIDOMEvent")}}. ({{bug("761613")}})</p>
+<p><code>nsIPrivateDOMEvent</code> has been merged into <code>nsIDOMEvent</code>. ({{bug("761613")}})</p>
 
 <h4 id="新增接口">新增接口</h4>
 

--- a/files/zh-cn/mozilla/firefox/releases/18/index.html
+++ b/files/zh-cn/mozilla/firefox/releases/18/index.html
@@ -46,21 +46,21 @@ translation_of: Mozilla/Firefox/Releases/18
 <h3 id="接口变更">接口变更</h3>
 <dl>
   <dt>
-    {{ interface("nsIStreamListener") }}</dt>
+    <code>nsIStreamListener</code></dt>
   <dd>
     <code>onDataAvailable()</code>方法的第四个参数(aOffset)类型改为无符号长整型. ({{bug("784912")}})</dd>
   <dt>
-    {{ interface("nsIUploadChannel") }}</dt>
+    <code>nsIUploadChannel</code></dt>
   <dd>
     <code>setUploadStream()支持了超过</code>2GB大小的content-length ({{bug("790617")}})</dd>
   <dt>
-    {{ interface("nsIEditor") }}</dt>
+    <code>nsIEditor</code></dt>
   <dd>
-    <code>删除了addEditorObserver()</code>,使用<code>setEditorObserver()</code>来替代, <code>removeEditorObserver()</code>不再需要一个{{ interface("nsIEditorObserver") }}参数({{bug("785091")}})</dd>
+    <code>删除了addEditorObserver()</code>,使用<code>setEditorObserver()</code>来替代, <code>removeEditorObserver()</code>不再需要一个<code>nsIEditorObserver</code>参数({{bug("785091")}})</dd>
 </dl>
 <dl>
   <dt>
-    {{ interface("nsIHttpProtocolHandler") }}</dt>
+    <code>nsIHttpProtocolHandler</code></dt>
   <dd>
     <code>http-on-modify-request</code> observers are no longer guaranteed to be called synchronously during<br>
     <code>nsIChannel.asyncOpen(). </code>For observers that need to be called during <code>asyncOpen</code>(), the new <code>http-on-opening-request</code> observer topic has been added. ({{bug("800799")}})</dd>
@@ -69,7 +69,7 @@ translation_of: Mozilla/Firefox/Releases/18
 <h4 id="移除接口">移除接口</h4>
 <p>下面的接口已经被移除.</p>
 <ul>
-  <li>{{ interface("nsIEditorObserver") }}</li>
+  <li><code>nsIEditorObserver</code></li>
 </ul>
 <h2 id="相关链接">相关链接</h2>
 <ul>

--- a/files/zh-cn/mozilla/firefox/releases/19/index.html
+++ b/files/zh-cn/mozilla/firefox/releases/19/index.html
@@ -57,9 +57,9 @@ translation_of: Mozilla/Firefox/Releases/19
 <h3 id="接口变化">接口变化</h3>
 
 <dl>
- <dt>{{interface("nsIImgLoadingContent")}}</dt>
- <dd>The parameter (aObserver) of <code>addObserver()</code> method changes from {{interface("imgIDecoderObserver")}} to {{interface("imgINotificationObserver")}}. The <code>notify()</code> method of {{interface("imgINotificationObserver")}} is not scriptable, so you need to use <code>createScriptedObserver()</code> from {{interface("imgITools")}}.</dd>
- <dt>{{interface("nsIChannel")}}</dt>
+ <dt><code>nsIImgLoadingContent</code></dt>
+ <dd>The parameter (aObserver) of <code>addObserver()</code> method changes from <code>imgIDecoderObserver</code> to <code>imgINotificationObserver</code>. The <code>notify()</code> method of <code>imgINotificationObserver</code> is not scriptable, so you need to use <code>createScriptedObserver()</code> from <code>imgITools</code>.</dd>
+ <dt><code>nsIChannel</code></dt>
  <dd> <code>contentLength</code> 属性的类型由<code> long</code> 改成 <code>int64_t</code>.</dd>
 </dl>
 

--- a/files/zh-cn/mozilla/firefox/releases/22/index.html
+++ b/files/zh-cn/mozilla/firefox/releases/22/index.html
@@ -61,7 +61,7 @@ translation_of: Mozilla/Firefox/Releases/22
 <h2 id="附加组件和Mozilla开发者需要注意的变化">附加组件和Mozilla开发者需要注意的变化</h2>
 
 <ul>
- <li>移除了下面这些方法中的<code>properties</code>参数: {{ifmethod('nsITreeView','getCellProperties')}}, {{ifmethod('nsITreeView','getColumnProperties')}} and {{ifmethod('nsITreeView','getRowProperties')}} methods of {{interface('nsITreeView')}}. These methods should now return a string of space-separated property names. ({{bug('407956')}})</li>
+ <li>移除了下面这些方法中的<code>properties</code>参数: {{ifmethod('nsITreeView','getCellProperties')}}, {{ifmethod('nsITreeView','getColumnProperties')}} and {{ifmethod('nsITreeView','getRowProperties')}} methods of <code>nsITreeView</code>. These methods should now return a string of space-separated property names. ({{bug('407956')}})</li>
  <li>The {{ifmethod('inIDOMUtils', 'getCSSPropertyNames')}} method has been implemented and will return all supported <a href="https://developer.mozilla.org/en-US/docs/CSS/CSS_Reference" title="/en-US/docs/CSS/CSS_Reference">CSS property</a> names.</li>
  <li>See <a href="https://blog.mozilla.org/addons/2013/06/03/compatibility-for-firefox-22/">here </a>for more changes.</li>
 </ul>

--- a/files/zh-cn/mozilla/firefox/releases/3/index.html
+++ b/files/zh-cn/mozilla/firefox/releases/3/index.html
@@ -163,7 +163,7 @@ translation_of: Mozilla/Firefox/Releases/3
 </dl>
 <dl>
  <dd>
-  Firefox 3 offers the new {{ Interface("nsIIdleService") }} interface, which lets extensions determine how long it's been since the user last pressed a key or moved their mouse.</dd>
+  Firefox 3 offers the new <code>nsIIdleService</code> interface, which lets extensions determine how long it's been since the user last pressed a key or moved their mouse.</dd>
 </dl>
 <dl>
  <dt>
@@ -187,7 +187,7 @@ translation_of: Mozilla/Firefox/Releases/3
 </dl>
 <dl>
  <dd>
-  Firefox 3 provides the new {{ Interface("nsIThreadManager") }} interface, along with new interfaces for threads and thread events, which provides a convenient way to create and manage threads in your code.</dd>
+  Firefox 3 provides the new <code>nsIThreadManager</code> interface, along with new interfaces for threads and thread events, which provides a convenient way to create and manage threads in your code.</dd>
 </dl>
 <dl>
  <dt>

--- a/files/zh-cn/mozilla/firefox/releases/32/index.html
+++ b/files/zh-cn/mozilla/firefox/releases/32/index.html
@@ -138,7 +138,7 @@ translation_of: Mozilla/Firefox/Releases/32
 <h3 id="XPCOM">XPCOM</h3>
 
 <ul>
- <li>The {{interface("nsIUDPSocket")}} interface now provides multicast support through the addition of the new {{ifattribute("nsIUDPSocket", "multicastLoopback")}}, {{ifattribute("nsIUDPSocket", "multicastInterface")}}, and {{ifattribute("nsIUDPSocket", "multicastInterfaceAddr")}} attributes, as well as the {{ifmethod("nsIUDPSocket", "joinMulticast")}} and {{ifmethod("nsIUDPSocket", "leaveMulticast")}} methods.</li>
+ <li>The <code>nsIUDPSocket</code> interface now provides multicast support through the addition of the new {{ifattribute("nsIUDPSocket", "multicastLoopback")}}, {{ifattribute("nsIUDPSocket", "multicastInterface")}}, and {{ifattribute("nsIUDPSocket", "multicastInterfaceAddr")}} attributes, as well as the {{ifmethod("nsIUDPSocket", "joinMulticast")}} and {{ifmethod("nsIUDPSocket", "leaveMulticast")}} methods.</li>
 </ul>
 
 <p> </p>

--- a/files/zh-cn/web/api/document/index.html
+++ b/files/zh-cn/web/api/document/index.html
@@ -551,7 +551,7 @@ translation_of: Web/API/Document
  <dt>{{DOMxRef("document.currentScript")}} {{Non-standard_Inline}}</dt>
  <dd>返回 {{HTMLElement("script")}} element that is currently executing.</dd>
  <dt>{{DOMxRef("document.documentURIObject")}}</dt>
- <dd>(<strong>Mozilla add-ons only!</strong>) 返回 {{Interface("nsIURI")}} object representing the URI of the document. This property only has special meaning in privileged JavaScript code (with UniversalXPConnect privileges).</dd>
+ <dd>(<strong>Mozilla add-ons only!</strong>) 返回 <code>nsIURI</code> object representing the URI of the document. This property only has special meaning in privileged JavaScript code (with UniversalXPConnect privileges).</dd>
  <dt>{{DOMxRef("document.popupNode")}}</dt>
  <dd>返回 node upon which a popup was invoked.</dd>
  <dt>{{DOMxRef("document.tooltipNode")}}</dt>

--- a/files/zh-cn/web/api/file/index.html
+++ b/files/zh-cn/web/api/file/index.html
@@ -84,8 +84,8 @@ translation_of: Web/API/File
 
 <ul>
  <li>在 Gecko 中，你可以从 Chrome 代码中使用这个 API。详细内容参见 <a href="https://developer.mozilla.org/en-US/docs/Extensions/Using_the_DOM_File_API_in_chrome_code">Using the DOM File API in chrome code</a>。若要从 chrome 代码, JSM 和引导范围中使用它，你必须使用 <code><a href="https://developer.mozilla.org/en-US/docs/Components.utils.importGlobalProperties">Cu.importGlobalProperties</a>(['File']);</code> 来导入它。</li>
- <li>从Gecko 6.0 {{geckoRelease("6.0")}} 开始，在特权代码（比如扩展中的代码）中，可以将一个 {{interface("nsIFile")}} 对象传入 <code>File</code> 构造函数，从而生成一个 File 对象。</li>
- <li>从Gecko 8.0 {{geckoRelease("8.0")}} 开始，在 XPCOM 组件代码中，你可以直接使用 <code>new File</code> 来创建一个 <code>File</code> 对象，而不需要像以前那样必须实例化一个 {{interface("nsIDOMFile")}} 对象。<code>File</code> 对象和 {{domxref("Blob")}} 相反，使用第二个参数作为文件名。文件名可以是任意的字符串。
+ <li>从Gecko 6.0 {{geckoRelease("6.0")}} 开始，在特权代码（比如扩展中的代码）中，可以将一个 <code>nsIFile</code> 对象传入 <code>File</code> 构造函数，从而生成一个 File 对象。</li>
+ <li>从Gecko 8.0 {{geckoRelease("8.0")}} 开始，在 XPCOM 组件代码中，你可以直接使用 <code>new File</code> 来创建一个 <code>File</code> 对象，而不需要像以前那样必须实例化一个 <code>nsIDOMFile</code> 对象。<code>File</code> 对象和 {{domxref("Blob")}} 相反，使用第二个参数作为文件名。文件名可以是任意的字符串。
   <pre class="syntaxbox">new File( Array parts, String filename, BlobPropertyBag properties);
 </pre>
  </li>

--- a/files/zh-cn/web/api/htmlelement/paste_event/index.html
+++ b/files/zh-cn/web/api/htmlelement/paste_event/index.html
@@ -49,7 +49,7 @@ original_slug: Web/API/HTMLElement/onpaste
 <h3 id="Specification" name="Specification">规范</h3>
 <p>不属于任何公开的规范.</p>
 <h3 id="Notes_2" name="Notes_2">备注</h3>
-<p>没有任何DOM方法可以使用来获取将要粘贴的剪切板中的文字,你可以使用XPCOM接口{{ Interface("nsIClipboard") }}来进行这样的操作.</p>
+<p>没有任何DOM方法可以使用来获取将要粘贴的剪切板中的文字,你可以使用XPCOM接口<code>nsIClipboard</code>来进行这样的操作.</p>
 <h3 id="See_also" name="See_also">相关链接</h3>
 <ul>
  <li><code><a href="/zh-cn/DOM/element.oncopy" title="zh-cn/DOM/element.oncopy">oncopy</a></code></li>

--- a/files/zh-cn/web/api/node/baseuri/index.html
+++ b/files/zh-cn/web/api/node/baseuri/index.html
@@ -63,5 +63,5 @@ translation_of: Web/API/Node/baseURI
 <ul>
  <li>{{HTMLElement("base")}} 元素（HTML）</li>
  <li><code><a href="https://developer.mozilla.org/en-US/docs/XML/xml:base">xml:base</a></code> 属性（XML 文档）</li>
- <li>{{domxref("Node.baseURIObject")}} - a variant of this API for Mozilla add-ons and internal code. Returns the base URL as an {{interface("nsIURI")}}.</li>
+ <li>{{domxref("Node.baseURIObject")}} - a variant of this API for Mozilla add-ons and internal code. Returns the base URL as an <code>nsIURI</code>.</li>
 </ul>

--- a/files/zh-cn/web/api/node/index.html
+++ b/files/zh-cn/web/api/node/index.html
@@ -33,7 +33,7 @@ translation_of: Web/API/Node
 
 <dl>
  <dt>{{DOMxRef("Node.baseURIObject")}} {{Non-standard_inline}}</dt>
- <dd>(不适用于网页内容) 只读的 {{ Interface("nsIURI") }} 对象表示元素的base URI.</dd>
+ <dd>(不适用于网页内容) 只读的 <code>nsIURI</code> 对象表示元素的base URI.</dd>
  <dt>{{DOMxRef("Node.childNodes")}}{{ReadOnlyInline}}</dt>
  <dd>返回一个包含了该节点所有子节点的实时的{{DOMxRef("NodeList")}}。{{DOMxRef("NodeList")}} 是动态变化的。如果该节点的子节点发生了变化，{{DOMxRef("NodeList")}}对象就会自动更新。 </dd>
  <dt>{{DOMxRef("Node.firstChild")}} {{ReadonlyInline}}</dt>
@@ -135,7 +135,7 @@ translation_of: Web/API/Node
  </div>
  </dd>
  <dt>{{DOMxRef("Node.nodePrincipal")}} {{Non-standard_inline}}{{Obsolete_Inline("gecko46")}}</dt>
- <dd>返回节点优先级 {{Interface("nsIPrincipal")}} 。</dd>
+ <dd>返回节点优先级 <code>nsIPrincipal</code> 。</dd>
  <dt>{{DOMxRef("Node.prefix")}} {{Obsolete_Inline}}{{ReadOnlyInline}}</dt>
  <dd>返回一个节点命名空间的前缀 {{DOMxRef("DOMString")}} , 当前缀不存在时返回 <code>null</code> 。</dd>
  <dt>{{DOMxRef("Node.rootNode")}} {{Obsolete_Inline}}{{ReadOnlyInline}}</dt>

--- a/files/zh-cn/web/api/selection/index.html
+++ b/files/zh-cn/web/api/selection/index.html
@@ -194,7 +194,7 @@ var range  = selObj.getRangeAt(0);</code></pre>
 <h3 id="Gecko_备注">Gecko 备注</h3>
 
 <ul>
- <li>Gecko/Firefox 提供了其他功能，仅适用于Chrome（内置及插件）代码。 这些定义在 {{Interface("nsISelectionPrivate")}} 中。</li>
+ <li>Gecko/Firefox 提供了其他功能，仅适用于Chrome（内置及插件）代码。 这些定义在 <code>nsISelectionPrivate</code> 中。</li>
  <li>Mozilla 实现源代码：{{Source("dom/webidl/Selection.webidl")}}</li>
  <li>在Firefox 29之前，{{domxref("Selection.selectionLanguageChange()")}}{{Obsolete_Inline("gecko29")}} 都会暴露在Web内容中。</li>
 </ul>

--- a/files/zh-cn/web/api/storageevent/index.html
+++ b/files/zh-cn/web/api/storageevent/index.html
@@ -14,7 +14,7 @@ translation_of: Web/API/StorageEvent
 <p>{{InheritanceDiagram}}</p>
 
 <div class="note">
-<p><strong>Note:</strong> 尽管这个事件已经早在 {{ Gecko("2.0") }}时就已存在,但是并不符合规范. 老的事件模型直到 {{ interface("nsIDOMStorageEventObsolete") }} 确定才被表现出来.</p>
+<p><strong>Note:</strong> 尽管这个事件已经早在 {{ Gecko("2.0") }}时就已存在,但是并不符合规范. 老的事件模型直到 <code>nsIDOMStorageEventObsolete</code> 确定才被表现出来.</p>
 </div>
 
 <h2 id="方法描述">方法描述</h2>
@@ -57,7 +57,7 @@ translation_of: Web/API/StorageEvent
   </tr>
   <tr>
    <td><code>storageArea</code></td>
-   <td><code>{{ Interface("nsIDOMStorage") }}</code></td>
+   <td><code><code>nsIDOMStorage</code></code></td>
    <td>被操作的storage对象。<strong>（只读）</strong></td>
   </tr>
   <tr>

--- a/files/zh-cn/web/api/storageevent/index.html
+++ b/files/zh-cn/web/api/storageevent/index.html
@@ -57,7 +57,7 @@ translation_of: Web/API/StorageEvent
   </tr>
   <tr>
    <td><code>storageArea</code></td>
-   <td><code><code>nsIDOMStorage</code></code></td>
+   <td><code>nsIDOMStorage</code></td>
    <td>被操作的storage对象。<strong>（只读）</strong></td>
   </tr>
   <tr>

--- a/files/zh-cn/web/api/window/confirm/index.html
+++ b/files/zh-cn/web/api/window/confirm/index.html
@@ -39,7 +39,7 @@ translation_of: Web/API/Window/confirm
 
 <p><span class="comment">The following text is shared between this article, DOM:window.prompt and DOM:window.alert</span>对话框是弹出式(modal)的(也即alert样式, 译者注). 直到这个对话框被点击后, 后面的脚本才会运行. 请勿滥用此功能, 这里列出了很多个理由: <a href="http://alistapart.com/article/neveruseawarning">请放弃使用对话框来确认信息</a>.</p>
 
-<p><a href="/en-US/Chrome" title="Chrome">Mozilla Chrome</a> 的用户(比如Firefox插件开发者)应该使用{{interface("nsIPromptService")}}这个方法.</p>
+<p><a href="/en-US/Chrome" title="Chrome">Mozilla Chrome</a> 的用户(比如Firefox插件开发者)应该使用<code>nsIPromptService</code>这个方法.</p>
 
 <p>Chrome 浏览器版本 {{CompatChrome(46.0)}} 开始屏蔽内部{{htmlelement("iframe")}}元素, 除非用户在沙箱内开启了<code>allow-modal选项.</code></p>
 

--- a/files/zh-cn/web/api/window/index.html
+++ b/files/zh-cn/web/api/window/index.html
@@ -78,7 +78,7 @@ translation_of: Web/API/Window
  <dt>{{domxref("Window.devicePixelRatio")}} {{non-standard_inline}} {{ReadOnlyInline}}</dt>
  <dd>返回当前显示器的物理像素和设备独立像素的比例。</dd>
  <dt>{{domxref("Window.dialogArguments")}} {{ReadOnlyInline}}</dt>
- <dd>获取在调用 {{domxref("window.showModalDialog()")}} 时传递给窗口的参数（如果它是一个对话框）。这是一个 {{Interface("nsIArray")}}。</dd>
+ <dd>获取在调用 {{domxref("window.showModalDialog()")}} 时传递给窗口的参数（如果它是一个对话框）。这是一个 <code>nsIArray</code>。</dd>
  <dt>{{domxref("Window.directories")}} {{obsolete_inline}}</dt>
  <dd>{{domxref("window.personalbar")}} 的另一种形式。</dd>
  <dt>{{domxref("Window.document")}} {{ReadOnlyInline}}</dt>
@@ -131,7 +131,7 @@ translation_of: Web/API/Window
  <dt>{{domxref("Window.mozAnimationStartTime")}} {{ReadOnlyInline}} {{Deprecated_inline}}</dt>
  <dd>返回当前动画循环开始经过的毫秒数</dd>
  <dt>{{domxref("Window.mozInnerScreenX")}} {{ReadOnlyInline}} {{non-standard_inline}}</dt>
- <dd>Returns the horizontal (X) coordinate of the top-left corner of the window's viewport, in screen coordinates. This value is reported in CSS pixels. See <code>mozScreenPixelsPerCSSPixel</code> in {{interface("nsIDOMWindowUtils")}} for a conversion factor to adapt to screen pixels if needed.</dd>
+ <dd>Returns the horizontal (X) coordinate of the top-left corner of the window's viewport, in screen coordinates. This value is reported in CSS pixels. See <code>mozScreenPixelsPerCSSPixel</code> in <code>nsIDOMWindowUtils</code> for a conversion factor to adapt to screen pixels if needed.</dd>
  <dt>{{domxref("Window.mozInnerScreenY")}} {{ReadOnlyInline}} {{non-standard_inline}}</dt>
  <dd>Returns the vertical (Y) coordinate of the top-left corner of the window's viewport, in screen coordinates. This value is reported in CSS pixels. See <code>mozScreenPixelsPerCSSPixel</code> for a conversion factor to adapt to screen pixels if needed.</dd>
  <dt>{{domxref("Window.mozPaintCount")}} {{non-standard_inline}} {{ReadOnlyInline}}</dt>

--- a/files/zh-cn/web/api/xmlhttprequest/index.html
+++ b/files/zh-cn/web/api/xmlhttprequest/index.html
@@ -72,7 +72,7 @@ translation_of: Web/API/XMLHttpRequest
 
 <dl>
  <dt>{{domxref("XMLHttpRequest.channel")}}{{ReadOnlyInline}}</dt>
- <dd>一个 {{Interface("nsIChannel")}}，对象在执行请求时使用的通道。</dd>
+ <dd>一个 <code>nsIChannel</code>，对象在执行请求时使用的通道。</dd>
  <dt>{{domxref("XMLHttpRequest.mozAnon")}}{{ReadOnlyInline}}</dt>
  <dd>一个布尔值，如果为真，请求将在没有 cookie 和身份验证 header 头的情况下发送。</dd>
  <dt>{{domxref("XMLHttpRequest.mozSystem")}}{{ReadOnlyInline}}</dt>

--- a/files/zh-cn/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.html
+++ b/files/zh-cn/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.html
@@ -126,7 +126,7 @@ req.sendAsBinary(aBody);
 
 <p>第五行使用<code>sendAsBinary()</code>方法发送这个请求.</p>
 
-<p>你也可以通过将一个{{ interface("nsIFileInputStream") }}对象实例传给<a class="internal" href="/zh-cn/DOM/XMLHttpRequest#send()" title="/zh-cn/XMLHttpRequest#send()"><code>send()</code></a>方法来发送二进制内容,这样的话,你不需要自己去设置<code>Content-Length请求头</code>的大小,程序会自动设置:</p>
+<p>你也可以通过将一个<code>nsIFileInputStream</code>对象实例传给<a class="internal" href="/zh-cn/DOM/XMLHttpRequest#send()" title="/zh-cn/XMLHttpRequest#send()"><code>send()</code></a>方法来发送二进制内容,这样的话,你不需要自己去设置<code>Content-Length请求头</code>的大小,程序会自动设置:</p>
 
 <pre class="brush: js notranslate">// 新建一个文件流.
 var stream = Components.classes["@mozilla.org/network/file-input-stream;1"]


### PR DESCRIPTION
As a part of #5193.

Done this job by running script [here](https://gist.github.com/yin1999/279f6f1b2f50794fb38f28b96cd38771).