### PR TITLE
Glossary/ITU の翻訳

### DIFF
--- a/files/ja/glossary/itu/index.md
+++ b/files/ja/glossary/itu/index.md
@@ -1,0 +1,19 @@
+---
+title: ITU
+slug: Glossary/ITU
+tags:
+  - Glossary
+  - ITU
+  - Standardization
+  - organization
+---
+The International Telecommunication Union (ITU) is the organization authorized by the United Nations to establish standards and rules for telecommunication, including telegraph, radio, telephony and the internet.
+
+From defining rules for ensuring transmissions get to where they need to go to and creating the "SOS" alert signal used in Morse code, the ITU has long played a key role in how we use technology to exchange information and ideas.
+
+In the Internet Age, the ITU's role of establishing standards for video and audio data formats used for streaming, teleconferencing, and other purposes. For example, the ITU and the Moving Picture Experts Group (MPEG) worked together to develop and publish, as well as to maintain, the various MPEG specifications, such as MPEG-2 (ITU H.262), AVC (ITU H.264), and HEVC (ITU H.265).
+
+## See also
+
+- [ITU web site](https://www.itu.int/)
+- [ITU history portal](https://www.itu.int/en/history/Pages/ITUsHistory.aspx)

--- a/files/ja/glossary/itu/index.md
+++ b/files/ja/glossary/itu/index.md
@@ -1,5 +1,5 @@
 ---
-title: ITU
+title: ITU (国際電気通信連合)
 slug: Glossary/ITU
 tags:
   - Glossary
@@ -7,13 +7,13 @@ tags:
   - Standardization
   - organization
 ---
-The International Telecommunication Union (ITU) is the organization authorized by the United Nations to establish standards and rules for telecommunication, including telegraph, radio, telephony and the internet.
+ITU (International Telecommunication Union、国際電気通信連合) は、国際連合に認可された組織であり、電信、無線通信、電話、そしてインターネットなどの遠距離通信に関する標準やルールを制定します。
 
-From defining rules for ensuring transmissions get to where they need to go to and creating the "SOS" alert signal used in Morse code, the ITU has long played a key role in how we use technology to exchange information and ideas.
+送信内容が必要な場所へ届くようにするためのルールの定義や、モールス信号で使用される「SOS」の警報信号の作成に始まり、テクノロジーを使用して情報や考えをやり取りする方法について、ITU は長い間重要な役割を果たしてきました。
 
-In the Internet Age, the ITU's role of establishing standards for video and audio data formats used for streaming, teleconferencing, and other purposes. For example, the ITU and the Moving Picture Experts Group (MPEG) worked together to develop and publish, as well as to maintain, the various MPEG specifications, such as MPEG-2 (ITU H.262), AVC (ITU H.264), and HEVC (ITU H.265).
+インターネットの時代における ITU の役割は、ストリーミングやテレカンファレンスなどさまざまな目的で用いられる動画や音声のデータ形式の標準を制定することです。例えば、MPEG-2 (ITU H.262)、AVC (ITU H.264)、HEVC (ITU H.265) などのさまざまな MPEG の仕様の開発、公開、保守は、ITU と Moving Picture Experts Group (MPEG) が協力して行っています。
 
-## See also
+## 関連情報
 
-- [ITU web site](https://www.itu.int/)
-- [ITU history portal](https://www.itu.int/en/history/Pages/ITUsHistory.aspx)
+- [ITU のウェブサイト](https://www.itu.int/)
+- [ITU の歴史ポータルサイト](https://www.itu.int/en/history/Pages/ITUsHistory.aspx)


### PR DESCRIPTION
mozilla-japan/translation#602

- 組織の日本語の正式名称は下記ページを参考にしました。
https://www.soumu.go.jp/g-ict/international_organization/itu/

- 組織名の表記方法は下記記事を参考にしました。
https://developer.mozilla.org/ja/docs/Glossary/ISO

- 最後の段落の文章 (In the Internet Age, ... and other purposes.) の原文が不完全なようにも思われましたが、前後の文脈から補って翻訳を作成しました。