### PR TITLE
Fix Japanese translation for WindowOrWorkerGlobalScope.fetch()

### DIFF
--- a/files/ja/web/api/fetch/index.html
+++ b/files/ja/web/api/fetch/index.html
@@ -135,7 +135,7 @@ fetch(myRequest, myInit).then(function(response) {
 
 <pre class="brush: js notranslate">let myRequest = new Request('flowers.jpg', myInit);</pre>
 
-<p><code><var>init</var></code> の <code><var>init</var></code> としてオブジェクトリテラルを使用することもできます。</p>
+<p><code><var>init</var></code> の <code><var>headers</var></code> でオブジェクトリテラルを使用することもできます。</p>
 
 <pre class="brush: js notranslate">const myInit = {
   method: 'GET',


### PR DESCRIPTION
Original text:

> You can also use an object literal as headers in init.

https://github.com/mdn/content/blob/dad1bb01d2c72cec1bc6fe89fb044911c404c669/files/en-us/web/api/fetch/index.md?plain=1#L326-L327