### PR TITLE
修改“语句和声明 > for...of”中迭代器关闭的情况的说明

### DIFF
--- a/files/zh-cn/web/javascript/reference/statements/for...of/index.html
+++ b/files/zh-cn/web/javascript/reference/statements/for...of/index.html
@@ -136,7 +136,7 @@ for (let paragraph of articleParagraphs) {
 
 <h3 id="关闭迭代器">关闭迭代器</h3>
 
-<p>对于<code>for...of</code>的循环，可以由<code>break</code>, <code>throw  continue </code>   或<code>return</code>终止。在这些情况下，迭代器关闭。</p>
+<p>对于<code>for...of</code>的循环，可以由 <code>break</code>, <code>throw</code> 或 <code>return</code> 终止。在这些情况下，迭代器关闭。</p>
 
 <pre class="brush: js">function* foo(){
   yield 1;


### PR DESCRIPTION
`continue` 不会关闭迭代器，它只是终止当前迭代中的语句执行。参考链接：https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/continue 以及 https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of#closing_iterators