### PR TITLE
[ko] translate ko/docs/Web/HTML/Element/Video crossorigin

### DIFF
--- a/files/ko/web/html/element/video/index.html
+++ b/files/ko/web/html/element/video/index.html
@@ -45,7 +45,7 @@ autoplay를 비활성화시킬 때 autoplay="false"는 동작하지 않습니다
   <dt>anonymous</dt>
   <dd>CORS(<code>Origin:</code> HTTP 헤더 사용)를 수행 합니다. 하지만 credential가 전송되지 않습니다. (즉, cookie, X.509 certificate, HTTP 기본 인증이 전송되지 않습니다). 서버가 원본 사이트에 credentials를 제공하지 않는 경우 (즉, <code>Access-Control-Allow-Origin:</code> HTTP 헤더를 설정하지 않음으로써), 이미지가 오염되고 사용이 제한됩니다.</dd>
   <dt>use-credentials</dt>
-  <dd>credential을 포함한 CORS를 (<code>Origin:</code> HTTP 헤더 사용) 수행 합니다. (즉, cookie, certificate, HTTP 기본 인증이 수행됩니다.) 서버가 원본 사이트에 credentials를 제공하지 않는 경우 (즉, <code>Access-Control-Allow-Origin:</code> HTTP 헤더를 설정하지 않음으로써), 이미지가 <em>오염</em>되고 사용이 제한됩니다.</dd>
+  <dd>credential을 포함한 CORS를 (<code>Origin:</code> HTTP 헤더 사용) 수행 합니다. (즉, cookie, certificate, HTTP 기본 인증이 수행됩니다.) 서버가 원본 사이트에 credentials를 제공하지 않는 경우 (즉, <code>Access-Control-Allow-Origin:</code> HTTP 헤더를 설정하지 않음으로써), 이미지가 오염되고 사용이 제한됩니다.</dd>
  </dl>
  crossorigin이 존재하지 않는 경우, CORS 요청 없이 (즉, <code>Origin:</code> HTTP 헤더를 사용 보내지 않고), 리소스를 가져와 {{HTMLElement('canvas')}} 요소에 오염되는 것을 방지합니다. 값을 설정하지 않을 경우 <strong>anonymous</strong>가 사용 됩니다. 추가 정보는 <a href="/en-US/docs/HTML/CORS_settings_attributes" title="CORS settings attributes">CORS settings attributes</a> 를 참조하십시오.
  <dt>{{htmlattrdef("height")}}</dt>

--- a/files/ko/web/html/element/video/index.html
+++ b/files/ko/web/html/element/video/index.html
@@ -40,7 +40,7 @@ autoplay를 비활성화시킬 때 autoplay="false"는 동작하지 않습니다
  <dt>{{htmlattrdef("controls")}}</dt>
  <dd>이 속성이 존재하면, 소리 조절(volume), 동영상 탐색(seek), 일시 정지(pause)/재시작(resume)을 할 수 있는 컨트롤러를 제공합니다.</dd>
  <dt>{{htmlattrdef("crossorigin")}}</dt>
- <dd>crossorigin 속성은 CORS를 사용해서 관련 이미지를 패치해야 하는지 여부를 나타냅니다. <a href="/en-US/docs/CORS_Enabled_Image" title="CORS_Enabled_Image">CORS-enabled resources</a> 는 {{HTMLElement("canvas")}} 요소에서 재사용 될 수 있으며 <em>오염</em>되지 않습니다. 허용되는 값은 다음과 같습니다:
+ <dd>crossorigin 속성은 CORS를 사용해서 관련 이미지를 패치해야 하는지 여부를 나타냅니다. <a href="/en-US/docs/CORS_Enabled_Image" title="CORS_Enabled_Image">CORS-enabled resources</a> 는 {{HTMLElement("canvas")}} 요소에서 재사용 될 수 있으며 오염되지 않습니다. 허용되는 값은 다음과 같습니다:
  <dl>
   <dt>anonymous</dt>
   <dd>CORS(<code>Origin:</code> HTTP 헤더 사용)를 수행 합니다. 하지만 credential가 전송되지 않습니다. (즉, cookie, X.509 certificate, HTTP 기본 인증이 전송되지 않습니다). 서버가 원본 사이트에 credentials를 제공하지 않는 경우 (즉, <code>Access-Control-Allow-Origin:</code> HTTP 헤더를 설정하지 않음으로써), 이미지가 <em>오염</em>되고 사용이 제한됩니다.</dd>

--- a/files/ko/web/html/element/video/index.html
+++ b/files/ko/web/html/element/video/index.html
@@ -43,7 +43,7 @@ autoplay를 비활성화시킬 때 autoplay="false"는 동작하지 않습니다
  <dd>crossorigin 속성은 CORS를 사용해서 관련 이미지를 패치해야 하는지 여부를 나타냅니다. <a href="/en-US/docs/CORS_Enabled_Image" title="CORS_Enabled_Image">CORS-enabled resources</a> 는 {{HTMLElement("canvas")}} 요소에서 재사용 될 수 있으며 오염되지 않습니다. 허용되는 값은 다음과 같습니다:
  <dl>
   <dt>anonymous</dt>
-  <dd>CORS(<code>Origin:</code> HTTP 헤더 사용)를 수행 합니다. 하지만 credential가 전송되지 않습니다. (즉, cookie, X.509 certificate, HTTP 기본 인증이 전송되지 않습니다). 서버가 원본 사이트에 credentials를 제공하지 않는 경우 (즉, <code>Access-Control-Allow-Origin:</code> HTTP 헤더를 설정하지 않음으로써), 이미지가 <em>오염</em>되고 사용이 제한됩니다.</dd>
+  <dd>CORS(<code>Origin:</code> HTTP 헤더 사용)를 수행 합니다. 하지만 credential가 전송되지 않습니다. (즉, cookie, X.509 certificate, HTTP 기본 인증이 전송되지 않습니다). 서버가 원본 사이트에 credentials를 제공하지 않는 경우 (즉, <code>Access-Control-Allow-Origin:</code> HTTP 헤더를 설정하지 않음으로써), 이미지가 오염되고 사용이 제한됩니다.</dd>
   <dt>use-credentials</dt>
   <dd>credential을 포함한 CORS를 (<code>Origin:</code> HTTP 헤더 사용) 수행 합니다. (즉, cookie, certificate, HTTP 기본 인증이 수행됩니다.) 서버가 원본 사이트에 credentials를 제공하지 않는 경우 (즉, <code>Access-Control-Allow-Origin:</code> HTTP 헤더를 설정하지 않음으로써), 이미지가 <em>오염</em>되고 사용이 제한됩니다.</dd>
  </dl>

--- a/files/ko/web/html/element/video/index.html
+++ b/files/ko/web/html/element/video/index.html
@@ -40,14 +40,14 @@ autoplay를 비활성화시킬 때 autoplay="false"는 동작하지 않습니다
  <dt>{{htmlattrdef("controls")}}</dt>
  <dd>이 속성이 존재하면, 소리 조절(volume), 동영상 탐색(seek), 일시 정지(pause)/재시작(resume)을 할 수 있는 컨트롤러를 제공합니다.</dd>
  <dt>{{htmlattrdef("crossorigin")}}</dt>
- <dd>This enumerated attribute indicates if the fetching of the related image must be done using CORS or not. <a href="/en-US/docs/CORS_Enabled_Image" title="CORS_Enabled_Image">CORS-enabled resources</a> can be reused in the {{HTMLElement("canvas")}} element without being <em>tainted</em>. The allowed values are:
+ <dd>crossorigin 속성은 CORS를 사용해서 관련 이미지를 패치해야 하는지 여부를 나타냅니다. <a href="/en-US/docs/CORS_Enabled_Image" title="CORS_Enabled_Image">CORS-enabled resources</a> 는 {{HTMLElement("canvas")}} 요소에서 재사용 될 수 있으며 <em>오염</em>되지 않습니다. 허용되는 값은 다음과 같습니다:
  <dl>
   <dt>anonymous</dt>
-  <dd>A cross-origin request (i.e. with <code>Origin:</code> HTTP header) is performed. But no credential is sent (i.e. no cookie, no X.509 certificate and no HTTP Basic authentication is sent). If the server does not give credentials to the origin site (by not setting the <code>Access-Control-Allow-Origin:</code> HTTP header), the image will be <em>tainted</em> and its usage restricted..</dd>
+  <dd>CORS(<code>Origin:</code> HTTP 헤더 사용)를 수행 합니다. 하지만 credential가 전송되지 않습니다. (즉, cookie, X.509 certificate, HTTP 기본 인증이 전송되지 않습니다). 서버가 원본 사이트에 credentials를 제공하지 않는 경우 (즉, <code>Access-Control-Allow-Origin:</code> HTTP 헤더를 설정하지 않음으로써), 이미지가 <em>오염</em>되고 사용이 제한됩니다.</dd>
   <dt>use-credentials</dt>
-  <dd>A cross-origin request (i.e. with <code>Origin:</code> HTTP header) is performed with credential is sent (i.e. a cookie, a certificate and HTTP Basic authentication is performed). If the server does not give credentials to the origin site (through <code>Access-Control-Allow-Credentials:</code> HTTP header), the image will be <em>tainted</em> and its usage restricted.</dd>
+  <dd>credential을 포함한 CORS를 (<code>Origin:</code> HTTP 헤더 사용) 수행 합니다. (즉, cookie, certificate, HTTP 기본 인증이 수행됩니다.) 서버가 원본 사이트에 credentials를 제공하지 않는 경우 (즉, <code>Access-Control-Allow-Origin:</code> HTTP 헤더를 설정하지 않음으로써), 이미지가 <em>오염</em>되고 사용이 제한됩니다.</dd>
  </dl>
- When not present, the resource is fetched without a CORS request (i.e. without sending the <code>Origin:</code> HTTP header), preventing its non-tainted used in {{HTMLElement('canvas')}} elements. If invalid, it is handled as if the enumerated keyword <strong>anonymous</strong> was used. See <a href="/en-US/docs/HTML/CORS_settings_attributes" title="CORS settings attributes">CORS settings attributes</a> for additional information.</dd>
+ crossorigin이 존재하지 않는 경우, CORS 요청 없이 (즉, <code>Origin:</code> HTTP 헤더를 사용 보내지 않고), 리소스를 가져와 {{HTMLElement('canvas')}} 요소에 오염되는 것을 방지합니다. 값을 설정하지 않을 경우 <strong>anonymous</strong>가 사용 됩니다. 추가 정보는 <a href="/en-US/docs/HTML/CORS_settings_attributes" title="CORS settings attributes">CORS settings attributes</a> 를 참조하십시오.
  <dt>{{htmlattrdef("height")}}</dt>
  <dd>비디오의 출력 영역 높이이며, CSS 픽셀 단위 입니다.</dd>
  <dt>{{htmlattrdef("loop")}}</dt>


### PR DESCRIPTION
1. /ko/docs/Web/HTML/Element/Video 문서를 번역하였습니다

[before]

![번역작업](https://user-images.githubusercontent.com/70947883/165481514-c6d6c544-ef0e-42e7-b0d9-eee20bf3436a.JPG)

[after]
![image](https://user-images.githubusercontent.com/70947883/165481416-1fb9fd4f-cadf-4ab5-b83b-227287b4c4a5.png)

