### PR TITLE
修改关于自增操作符的描述

### DIFF
--- a/files/zh-cn/web/javascript/reference/operators/increment/index.html
+++ b/files/zh-cn/web/javascript/reference/operators/increment/index.html
@@ -22,9 +22,9 @@ translation_of: Web/JavaScript/Reference/Operators/Increment
 
 <h2 id="描述">描述</h2>
 
-<p>如使用后置（Postfix）自增，操作符在操作数后（例如  <code><var>x</var>++</code>）， 操作数将在自增前返回。</p>
+<p>如使用后置（Postfix）自增，操作符在操作数后（例如  <code><var>x</var>++</code>）， 操作数会加一，然后返回加一之前的值。</p>
 
-<p>如使用前置（Prefix）自增，操作符在操作数前（例如 <code>++<var>x</var></code>）， 操作数将先自增后返回。</p>
+<p>如使用前置（Prefix）自增，操作符在操作数前（例如 <code>++<var>x</var></code>）， 操作数会加一，然后返回加一之后的值。</p>
 
 <h2 id="示例">示例</h2>
 


### PR DESCRIPTION
原来的翻译不是很清楚，没有写明自增和返回值这两者发生的先后顺序，根据 `ECMA` 规范：https://tc39.es/ecma262/#sec-postfix-increment-operator 以及 https://tc39.es/ecma262/#sec-prefix-increment-operator
可以看到，不管是后置自增还是前置自增，都是先完成了自增（第 `5` 步），然后才返回值（第 `6` 步）。
举个例子：

```js
let num = 0;
num = num++;
console.log(num); // 0
```

在执行上面的 `num = num++;` 这行语句时，后置自增操作符会先对 `num` 进行加一，然后返回 `num` 加一前的值，也就是初始值 `0`，再赋值给 `num`，所以最后 `num` 的值就还是 `0` 了。