### PR TITLE
remove-h3_gecko_minversion-es

### DIFF
--- a/files/es/web/api/console/index.html
+++ b/files/es/web/api/console/index.html
@@ -159,7 +159,7 @@ console.info("Mi primer carro fue un ", car, ". El objeto es: ", someObject);</p
 
 <div><img alt="" src="https://mdn.mozillademos.org/files/7739/console-style.png" style="display: block; height: 52px; margin-left: auto; margin-right: auto; width: 293px;"></div>
 
-<div>{{h3_gecko_minversion("Usando grupos en la consola", "9.0")}}</div>
+<h3>Usando grupos en la consola</h3>
 
 <p>Puedes usar grupos anidades para ayudar a organizar la salida visualmente combinando material relacionado. Para crear un nuevo bloque anidado, se debe usar <code>console.group(). El método console.groupCollapsed() es similar, pero crea el nuevo bloque colapsado, requiriendo el uso de un "botón de mostrar" para abrirlo y leerlo.</code></p>
 
@@ -185,7 +185,7 @@ console.debug("Back to the outer level");
 
 <p><img alt="nesting.png" class="default internal" src="/@api/deki/files/6082/=nesting.png"></p>
 
-<div>{{h3_gecko_minversion("Timers", "10.0")}}</div>
+<h3>Timers</h3>
 
 <p>En orden para calcular la duración de una operación específica, Geco 10 introdujo soporte de contadores (timers del inglés) en el objeto console. Para iniciar un contador, usa el método <code>console.time</code><code>()</code> , pasándole como parámetro un nombre. Para detener un contador, y obtener el tiempo transcurrido en milisegúndos, solo usa el método <code>console.timeEnd(), nuevamente pasándole el nombre del contador como parámetro. Se pueden ejecutar hasta 10000 (diez mil) contadores simultáneamente en una página.</code></p>
 

--- a/files/es/web/api/setinterval/index.html
+++ b/files/es/web/api/setinterval/index.html
@@ -321,7 +321,7 @@ if (document.all &amp;&amp; !window.setInterval.isPolyfill) {
 
 <pre class="brush:js notranslate">var intervalID = setInterval(function(arg1) {}.bind(undefined, 10), 1000);</pre>
 
-<p>{{h3_gecko_minversion("Inactive tabs", "5.0")}}</p>
+<h3>Inactive tabs</h3>
 
 <p>A partir de Gecko 5.0 {{geckoRelease("5.0")}}, los intervalos no se disparan más de una vez por segundo en las pestañas inactivas.</p>
 

--- a/files/es/web/css/media_queries/using_media_queries/index.html
+++ b/files/es/web/css/media_queries/using_media_queries/index.html
@@ -387,7 +387,7 @@ media_feature: width | min-width | max-width
 
 <p>Mozilla ofrece varias funciones especificas de Gecko. Algunas de estas pueden ser propuestas como funcines oficiales.</p>
 
-<p>{{ h3_gecko_minversion("-moz-images-in-menus", "1.9.2") }}</p>
+<h3>-moz-images-in-menus</h3>
 
 <p><strong>Valor</strong><strong>:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Medio</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -395,7 +395,7 @@ media_feature: width | min-width | max-width
 
 <p>Si el dispositivo acepta que haya imágenes en menús, el valor es 1; de otro modo sera 0. Esto corresponde a la <a href="/es/docs/Web/CSS/Pseudo-classes" title="Pseudo-classes">pseudoclase</a>: {{ cssxref(":-moz-system-metric(images-in-menus)") }}.</p>
 
-<p>{{ h3_gecko_minversion("-moz-mac-graphite-theme", "1.9.2") }}</p>
+<h3>-moz-mac-graphite-theme</h3>
 
 <p><strong>Valor</strong><strong>:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Medio</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -405,7 +405,7 @@ media_feature: width | min-width | max-width
 
 <p>Esto corresponde a la <a href="/es/docs/Web/CSS/Pseudo-classes" title="Pseudo-classes">pseudoclase</a>: {{ cssxref(":-moz-system-metric(mac-graphite-theme)") }}.</p>
 
-<p>{{ h3_gecko_minversion("-moz-maemo-classic", "1.9.2") }}</p>
+<h3>-moz-maemo-classic</h3>
 
 <p><strong>Valor</strong><strong>:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Medio</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -415,7 +415,7 @@ media_feature: width | min-width | max-width
 
 <p>Esto corresponde a la <a href="/es/docs/Web/CSS/Pseudo-classes" title="Pseudo-classes">pseudoclase</a>: {{ cssxref(":-moz-system-metric(maemo-classic)") }}</p>
 
-<p>{{ h3_gecko_minversion("-moz-device-pixel-ratio", "2.0") }}</p>
+<h3>-moz-device-pixel-ratio</h3>
 
 <p><strong>Valor</strong><strong>:</strong> {{cssxref("&lt;number&gt;")}}<br>
  <strong style="font-weight: bold;">Medio</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -442,7 +442,7 @@ media_feature: width | min-width | max-width
 
 <div class="note">Nota: Esta funcion multimedia tambien esta implementada en Webkit como <span style="font-family: courier new;">-webkit-device-pixel-ratio</span>. Los prefijos minimos y maximos de esta funcion implementados por Gecko se llaman asi: <span style="font-family: courier new;">min--moz-device-pixel-ratio</span> y <span style="font-family: courier new;">max--moz-device-pixel-ratio</span>; y los mismos prefijos implementados por Webkit se llaman asi: <span style="font-family: courier new;">-webkit-min-device-pixel-ratio</span> y <span style="font-family: courier new;">-webkit-max-device-pixel-ratio</span>.</div>
 
-<p>{{ h3_gecko_minversion("-moz-os-version", "25.0") }}</p>
+<h3>-moz-os-version</h3>
 
 <p><strong>Valor</strong><strong>:</strong> <code>windows-xp</code> | <code>windows-vista</code> | <code>windows-win7</code> | <code>windows-win8</code><br>
  <strong style="font-weight: bold;">Medio</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -460,7 +460,7 @@ media_feature: width | min-width | max-width
 
 <p>Esto se hace para permitir a los skins y a algunos códigos funcionen mejor con el sistema operativo en el que se ejecutan.</p>
 
-<p>{{ h3_gecko_minversion("-moz-scrollbar-end-backward", "1.9.2") }}</p>
+<h3>-moz-scrollbar-end-backward</h3>
 
 <p><strong>Valor</strong><strong>:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Medio</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -470,7 +470,7 @@ media_feature: width | min-width | max-width
 
 <p>Esto corresponde a la <a href="/es/docs/Web/CSS/Pseudo-classes" title="Pseudo-classes">pseudoclase</a>: {{ cssxref(":-moz-system-metric(scrollbar-end-backward)") }}.</p>
 
-<p>{{ h3_gecko_minversion("-moz-scrollbar-end-forward", "1.9.2") }}</p>
+<h3>-moz-scrollbar-end-forward</h3>
 
 <p><strong>Valor</strong><strong>:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Medio</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -480,7 +480,7 @@ media_feature: width | min-width | max-width
 
 <p>Esto corresponde a la <a href="/es/docs/Web/CSS/Pseudo-classes" title="Pseudo-classes">pseudoclase</a>: {{ cssxref(":-moz-system-metric(scrollbar-end-forward)") }}.</p>
 
-<p>{{ h3_gecko_minversion("-moz-scrollbar-start-backward", "1.9.2") }}</p>
+<h3>-moz-scrollbar-start-backward</h3>
 
 <p><strong>Valor</strong><strong>:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Medio</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -490,7 +490,7 @@ media_feature: width | min-width | max-width
 
 <p>Esto corresponde a la <a href="/es/docs/Web/CSS/Pseudo-classes" title="Pseudo-classes">pseudoclase</a>: {{ cssxref(":-moz-system-metric(scrollbar-start-backward)") }}.</p>
 
-<p>{{ h3_gecko_minversion("-moz-scrollbar-start-forward", "1.9.2") }}</p>
+<h3>-moz-scrollbar-start-forward</h3>
 
 <p><strong>Valor</strong><strong>:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Medio</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -500,7 +500,7 @@ media_feature: width | min-width | max-width
 
 <p>Esto corresponde a la <a href="/es/docs/Web/CSS/Pseudo-classes" title="Pseudo-classes">pseudoclase</a>: {{ cssxref(":-moz-system-metric(scrollbar-start-forward)") }}.</p>
 
-<p>{{ h3_gecko_minversion("-moz-scrollbar-thumb-proportional", "1.9.2") }}</p>
+<h3>-moz-scrollbar-thumb-proportional</h3>
 
 <p><strong>Valor</strong><strong>:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Medio</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -510,7 +510,7 @@ media_feature: width | min-width | max-width
 
 <p>Esto corresponde a la <a href="/es/docs/Web/CSS/Pseudo-classes" title="Pseudo-classes">pseudoclase</a>: {{ cssxref(":-moz-system-metric(scrollbar-thumb-proportional)") }}.</p>
 
-<p>{{ h3_gecko_minversion("-moz-touch-enabled", "1.9.2") }}</p>
+<h3>-moz-touch-enabled</h3>
 
 <p><strong>Valor</strong><strong>:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Medio</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -524,7 +524,7 @@ media_feature: width | min-width | max-width
 
 <p>Usted puede usar esto para renderizar sus botones un poco mas grandes, Por Ejemplo, si el usuario se encuentra en una pantalla táctil, esto hará los botones mas fáciles de usar con los dedos.</p>
 
-<p>{{ h3_gecko_minversion("-moz-windows-classic", "1.9.2") }}</p>
+<h3>-moz-windows-classic</h3>
 
 <p><strong>Valor</strong><strong>:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Medio</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -534,7 +534,7 @@ media_feature: width | min-width | max-width
 
 <p>Esto corresponde a la <a href="/es/docs/Web/CSS/Pseudo-classes" title="Pseudo-classes">pseudoclase</a>: {{ cssxref(":-moz-system-metric(windows-classic)") }}.</p>
 
-<p>{{ h3_gecko_minversion("-moz-windows-compositor", "1.9.2") }}</p>
+<h3>-moz-windows-compositor</h3>
 
 <p><strong>Valor</strong><strong>:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Medio</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -544,7 +544,7 @@ media_feature: width | min-width | max-width
 
 <p>Esto corresponde a la <a href="/es/docs/Web/CSS/Pseudo-classes" title="Pseudo-classes">pseudoclase</a>: {{ cssxref(":-moz-system-metric(windows-compositor)") }}.</p>
 
-<p>{{ h3_gecko_minversion("-moz-windows-default-theme", "1.9.2") }}</p>
+<h3>-moz-windows-default-theme</h3>
 
 <p><strong>Valor</strong><strong>:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Medio</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -554,7 +554,7 @@ media_feature: width | min-width | max-width
 
 <p>Esto corresponde a la <a href="/es/docs/Web/CSS/Pseudo-classes" title="Pseudo-classes">pseudoclase</a>: {{ cssxref(":-moz-system-metric(windows-default-theme)") }}.</p>
 
-<p>{{ h3_gecko_minversion("-moz-windows-theme", "2.0") }}</p>
+<h3>-moz-windows-theme</h3>
 
 <p><strong>Valor</strong><strong>:</strong> <code>aero</code> | <code>luna-blue</code> | <code>luna-olive</code> | <code>luna-silver</code> | <code>royale</code> | <code>generic</code> | <code>zune</code><br>
  <strong style="font-weight: bold;">Medio</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>

--- a/files/es/web/http/cors/index.html
+++ b/files/es/web/http/cors/index.html
@@ -320,7 +320,7 @@ Content-Type: text/plain
 
 <p>Si el servidor especifica un host de origen en vez de "*", entonces se debe incluir <span style="font-family: courier new,andale mono,monospace; line-height: 1.5;">Origin</span><span style="line-height: 1.5;"> en el encabezado de respuesta </span><span style="font-family: courier new,andale mono,monospace; line-height: 1.5;">Vary </span><span style="line-height: 1.5;">para indicar a los clientes que las respuestas del servidor difieren basándose en el valor del encabezado de respuesta</span><span style="line-height: 1.5;"> </span><span style="font-family: courier new,andale mono,monospace; line-height: 1.5;">Origin.</span></p>
 
-<p>{{ h3_gecko_minversion("Access-Control-Expose-Headers", "2.0") }}</p>
+<h3>Access-Control-Expose-Headers</h3>
 
 <p>Esta cabecera permite una <em>whitelist</em> de cabeceras del servidor que los exploradores tienen permitido acceder. Por ejemplo:</p>
 


### PR DESCRIPTION
Remove the `h3_gecko_minversion` macro in `es` locale

Note: replaced with `<h3>` instead of `###` due to the `html` format. working on update and reformat content...