### PR TITLE
zh-cn: closures: fix link text format | 中文 (简体): 闭包: 修复链接文本格式

### DIFF
--- a/files/zh-cn/web/javascript/closures/index.html
+++ b/files/zh-cn/web/javascript/closures/index.html
@@ -132,7 +132,7 @@ document.getElementById('size-16').onclick = size16;
 
 <p>而 JavaScript 没有这种原生支持，但我们可以使用闭包来模拟私有方法。私有方法不仅仅有利于限制对代码的访问：还提供了管理全局命名空间的强大能力，避免非核心的方法弄乱了代码的公共接口部分。</p>
 
-<p>下面的示例展现了如何使用闭包来定义公共函数，并令其可以访问私有函数和变量。这个方式也称为 <a class="external" href="http://www.google.com/search?q=javascript+module+pattern" title="http://www.google.com/search?q=javascript+module+pattern">模块模式（module pattern）：</a></p>
+<p>下面的示例展现了如何使用闭包来定义公共函数，并令其可以访问私有函数和变量。这个方式也称为<a class="external" href="http://www.google.com/search?q=javascript+module+pattern" title="http://www.google.com/search?q=javascript+module+pattern">模块模式（module pattern）</a>：</p>
 
 <pre class="brush: js">var Counter = (function() {
   var privateCounter = 0;


### PR DESCRIPTION
Hello. I changed the link text format of an external link. Before the change:
你好，我修改了一个外部链接的链接文本格式。修改前是这样：

> <p>下面的示例展现了如何使用闭包来定义公共函数，并令其可以访问私有函数和变量。这个方式也称为 <a class="external" href="http://www.google.com/search?q=javascript+module+pattern" title="http://www.google.com/search?q=javascript+module+pattern">模块模式（module pattern）：</a></p>

After:
修改后是：

> <p>下面的示例展现了如何使用闭包来定义公共函数，并令其可以访问私有函数和变量。这个方式也称为<a class="external" href="http://www.google.com/search?q=javascript+module+pattern" title="http://www.google.com/search?q=javascript+module+pattern">模块模式（module pattern）</a>：</p>
