### PR TITLE
[ko] fix: css/:root 잘못된 번역 수정

### DIFF
--- a/files/ko/web/css/_colon_root/index.html
+++ b/files/ko/web/css/_colon_root/index.html
@@ -12,7 +12,7 @@ translation_of: 'Web/CSS/:root'
 ---
 <div>{{CSSRef}}</div>
 
-<p><a href="/ko/docs/Web/CSS">CSS</a> <strong><code>:root</code></strong> <a href="/ko/docs/Web/CSS/Pseudo-classes">의사 클래스</a>는 문서 트리의 루트 요소를 선택합니다 HTML의 루트 요소는 {{htmlelement("html")}} 요소이므로, <code>:root</code>의 <a href="/ko/docs/Web/CSS/Specificity">명시도</a>가 더 낮다는 점을 제외하면 <code>html</code> 선택자와 똑같습니다.</p>
+<p><a href="/ko/docs/Web/CSS">CSS</a> <strong><code>:root</code></strong> <a href="/ko/docs/Web/CSS/Pseudo-classes">의사 클래스</a>는 문서 트리의 루트 요소를 선택합니다 HTML의 루트 요소는 {{htmlelement("html")}} 요소이므로, <code>:root</code>의 <a href="/ko/docs/Web/CSS/Specificity">명시도</a>가 더 높다는 점을 제외하면 <code>html</code> 선택자와 똑같습니다.</p>
 
 <pre class="brush: css no-line-numbers notranslate">/* 문서의 루트 요소 선택
    HTML에서는 &lt;html&gt; */


### PR DESCRIPTION
`ko/docs/Web/CSS/:root` 문서에서 `:root` 의 명시도가 `html` 태그에 비해 더 낮다는 번역을 `:root` 의 명시도가 더 높다는 설명으로 수정하였습니다.