### PR TITLE
refactor: remove deprecated {{h3_gecko_minversion}} in pt-br

### DIFF
--- a/files/pt-br/web/api/console/index.html
+++ b/files/pt-br/web/api/console/index.html
@@ -175,7 +175,7 @@ console.debug("Back to the outer level");
 
 <p><img alt="nesting.png" class="default internal" src="/@api/deki/files/6082/=nesting.png"></p>
 
-<h3>Timers</h3>
+<h3>Temporizadores</h3>
 
 <p>In order to calculate the duration of a specific operation, Gecko 10 introduced the support of timers in the <code>console</code> object. To start a timer, call the <code>console.time</code><code>()</code> method, giving it a name as only parameter. To stop the timer, and to get the elapsed time in miliseconds, just call the <code>console.timeEnd()</code> method, again passing the timer's name as the parameter. Up to 10,000 timers can run simultaneously on a given page.</p>
 

--- a/files/pt-br/web/api/console/index.html
+++ b/files/pt-br/web/api/console/index.html
@@ -149,7 +149,7 @@ console.info("Meu primeiro carro era um ", carro, ". O objeto é: ", algumObjeto
 
 <div><img alt="" src="https://mdn.mozillademos.org/files/7739/console-style.png" style="display: block; height: 52px; margin-left: auto; margin-right: auto; width: 293px;"></div>
 
-<div>{{h3_gecko_minversion("Using groups in the console", "9.0")}}</div>
+<h3>Usando grupos no console</h3>
 
 <p>You can use nested groups to help organize your output by visually combining related material. To create a new nested block, call <code>console.group()</code>. The <code>console.groupCollapsed()</code> method is similar, but creates the new block collapsed, requiring the use of a disclosure button to open it for reading.</p>
 
@@ -175,7 +175,7 @@ console.debug("Back to the outer level");
 
 <p><img alt="nesting.png" class="default internal" src="/@api/deki/files/6082/=nesting.png"></p>
 
-<div>{{h3_gecko_minversion("Timers", "10.0")}}</div>
+<h3>Timers</h3>
 
 <p>In order to calculate the duration of a specific operation, Gecko 10 introduced the support of timers in the <code>console</code> object. To start a timer, call the <code>console.time</code><code>()</code> method, giving it a name as only parameter. To stop the timer, and to get the elapsed time in miliseconds, just call the <code>console.timeEnd()</code> method, again passing the timer's name as the parameter. Up to 10,000 timers can run simultaneously on a given page.</p>
 

--- a/files/pt-br/web/api/datatransfer/index.html
+++ b/files/pt-br/web/api/datatransfer/index.html
@@ -148,7 +148,7 @@ translation_of: Web/API/DataTransfer
 
 <p>Guarda uma lista dos tipos de formato dos dados que estão armazenados para o primeiro ítem, na mesma ordem que os dados foram adicionados. Uma lista vazia será retornada caso nenhum dado tenha sido adicionado.</p>
 
-<p>{{ h3_gecko_minversion("mozCursor", "1.9.1", "mozCursor") }}</p>
+<h3>mozCursor</h3>
 
 <p>O estado do cursor de drag. Isto é usado principalmente para controlar o cursor durante a guia de drag.</p>
 

--- a/files/pt-br/web/api/setinterval/index.html
+++ b/files/pt-br/web/api/setinterval/index.html
@@ -307,9 +307,9 @@ if (document.all &amp;&amp; !window.setInterval.isPolyfill) {
 
 <pre class="brush:js">var intervalID = setInterval(function(arg1) {}.bind(undefined, 10), 1000);</pre>
 
-<p>{{h3_gecko_minversion("Inactive tabs", "5.0")}}</p>
+<h3>Abas inativas</h3>
 
-<p>Starting in Gecko 5.0 {{geckoRelease("5.0")}}, intervals are clamped to fire no more often than once per second in inactive tabs.</p>
+<p>Iniciado no Gecko 5.0 {{geckoRelease("5.0")}}, intervalos são fixados para disparar não mais do que uma vez por segundo em abas inativas.</p>
 
 <h2 id="O_problema_do_this">O problema do "<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this"><code>this</code></a>"</h2>
 

--- a/files/pt-br/web/css/media_queries/using_media_queries/index.html
+++ b/files/pt-br/web/css/media_queries/using_media_queries/index.html
@@ -360,7 +360,7 @@ media_feature: width | min-width | max-width
 
 <p>Mozilla oferece várias <em>media features</em> para específicos <em>Gecko</em> . Algumas dessas podem ser sugeridas como <em>media features</em> oficiais.</p>
 
-<p>{{ h3_gecko_minversion("-moz-images-in-menus", "1.9.2") }}</p>
+<h3>-moz-images-in-menus</h3>
 
 <p><strong>Valor:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Mídia</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -368,7 +368,7 @@ media_feature: width | min-width | max-width
 
 <p>Se o dispositivo permite aparecer imagens nos menus, o valor é 1; caso contrário, o valor é 0. Isto corresponde ao {{ cssxref(":-moz-system-metric(images-in-menus)") }} CSS <a href="/en-US/docs/CSS/Pseudo-classes" title="Pseudo-classes">pseudo-class</a>.</p>
 
-<p>{{ h3_gecko_minversion("-moz-mac-graphite-theme", "1.9.2") }}</p>
+<h3>-moz-mac-graphite-theme</h3>
 
 <p><strong>Valor:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Mídia</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -378,7 +378,7 @@ media_feature: width | min-width | max-width
 
 <p>Isto corresponde ao {{ cssxref(":-moz-system-metric(mac-graphite-theme)") }} CSS <a href="/en-US/docs/CSS/Pseudo-classes" title="Pseudo-classes">pseudo-class</a>.</p>
 
-<p>{{ h3_gecko_minversion("-moz-maemo-classic", "1.9.2") }}</p>
+<h3>-moz-maemo-classic</h3>
 
 <p><strong>Valor:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Mídia</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -388,7 +388,7 @@ media_feature: width | min-width | max-width
 
 <p>Isto corresponde ao {{ cssxref(":-moz-system-metric(maemo-classic)") }} CSS <a href="/en-US/docs/CSS/Pseudo-classes" title="Pseudo-classes">pseudo-class</a>.</p>
 
-<p>{{ h3_gecko_minversion("-moz-device-pixel-ratio", "2.0") }} {{ deprecated_inline("gecko&amp;16") }}</p>
+<h3>-moz-device-pixel-ratio</h3>
 
 <p><strong>Valor:</strong> {{cssxref("&lt;number&gt;")}}<br>
  <strong style="font-weight: bold;">Mídia</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -415,7 +415,7 @@ media_feature: width | min-width | max-width
 
 <div class="note"><strong>Nota</strong>: Esta <em>media feature</em> é também implementada pelo Webkit e pelo <a href="https://msdn.microsoft.com/en-us/library/ie/dn760733(v=vs.85).aspx">IE 11 para Windows Phone 8.1</a>como <span style="font-family: courier new;">-webkit-device-pixel-ratio</span>. Os prefixos min e max implementados pelo Gecko são nomeados <span style="font-family: courier new;">min--moz-device-pixel-ratio</span> e <span style="font-family: courier new;">max--moz-device-pixel-ratio</span>; mas os mesmos prefixos implementados pelo Webkit são chamados <span style="font-family: courier new;">-webkit-min-device-pixel-ratio</span> e <span style="font-family: courier new;">-webkit-max-device-pixel-ratio</span>.</div>
 
-<p>{{ h3_gecko_minversion("-moz-os-version", "25.0") }}</p>
+<h3>-moz-os-version</h3>
 
 <p><strong>Valor:</strong> <code>windows-xp</code> | <code>windows-vista</code> | <code>windows-win7</code> | <code>windows-win8</code><br>
  <strong style="font-weight: bold;">Mídia</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -432,7 +432,7 @@ media_feature: width | min-width | max-width
 
 <p>Isto é fornecido pelas <em>skins das aplicações</em> e outros códigos do chrome para serem capazes de se adaptar para funcionar bem com a versão atual do sistema operacional.</p>
 
-<p>{{ h3_gecko_minversion("-moz-scrollbar-end-backward", "1.9.2") }}</p>
+<h3>-moz-scrollbar-end-backward</h3>
 
 <p><strong>Valor:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Mídia</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -442,7 +442,7 @@ media_feature: width | min-width | max-width
 
 <p>Isto corresponde ao {{ cssxref(":-moz-system-metric(scrollbar-end-backward)") }} CSS <a href="/en-US/docs/CSS/Pseudo-classes" title="Pseudo-classes">pseudo-class</a>.</p>
 
-<p>{{ h3_gecko_minversion("-moz-scrollbar-end-forward", "1.9.2") }}</p>
+<h3>-moz-scrollbar-end-forward</h3>
 
 <p><strong>Valor:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Mídia</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -452,7 +452,7 @@ media_feature: width | min-width | max-width
 
 <p>Isto corresponde ao {{ cssxref(":-moz-system-metric(scrollbar-end-forward)") }} CSS <a href="/en-US/docs/CSS/Pseudo-classes" title="Pseudo-classes">pseudo-class</a>.</p>
 
-<p>{{ h3_gecko_minversion("-moz-scrollbar-start-backward", "1.9.2") }}</p>
+<h3>-moz-scrollbar-start-backward</h3>
 
 <p><strong>Valor:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Mídia</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -462,7 +462,7 @@ media_feature: width | min-width | max-width
 
 <p>Isto corresponde ao {{ cssxref(":-moz-system-metric(scrollbar-start-backward)") }} CSS <a href="/en-US/docs/CSS/Pseudo-classes" title="Pseudo-classes">pseudo-class</a>.</p>
 
-<p>{{ h3_gecko_minversion("-moz-scrollbar-start-forward", "1.9.2") }}</p>
+<h3>-moz-scrollbar-start-forward</h3>
 
 <p><strong>Valor:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Mídia</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -472,7 +472,7 @@ media_feature: width | min-width | max-width
 
 <p>Isto corresponde ao {{ cssxref(":-moz-system-metric(scrollbar-start-forward)") }} CSS <a href="/en-US/docs/CSS/Pseudo-classes" title="Pseudo-classes">pseudo-class</a>.</p>
 
-<p>{{ h3_gecko_minversion("-moz-scrollbar-thumb-proportional", "1.9.2") }}</p>
+<h3>-moz-scrollbar-thumb-proportional</h3>
 
 <p><strong>Valor:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Mídia</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -482,7 +482,7 @@ media_feature: width | min-width | max-width
 
 <p>Isto corresponde ao {{ cssxref(":-moz-system-metric(scrollbar-thumb-proportional)") }} CSS <a href="/en-US/docs/CSS/Pseudo-classes" title="Pseudo-classes">pseudo-class</a>.</p>
 
-<p>{{ h3_gecko_minversion("-moz-touch-enabled", "1.9.2") }}</p>
+<h3>-moz-touch-enabled</h3>
 
 <p><strong>Valor:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Mídia</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -496,7 +496,7 @@ media_feature: width | min-width | max-width
 
 <p>You might use this to render your buttons slightly larger, for example, if the user is on a touch-screen device, to make them more finger-friendly.</p>
 
-<p>{{ h3_gecko_minversion("-moz-windows-classic", "1.9.2") }}</p>
+<h3>-moz-windows-classic</h3>
 
 <p><strong>Valor:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Mídia</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -506,7 +506,7 @@ media_feature: width | min-width | max-width
 
 <p>Isto corresponde ao {{ cssxref(":-moz-system-metric(windows-classic)") }} CSS <a href="/en-US/docs/CSS/Pseudo-classes" title="Pseudo-classes">pseudo-class</a>.</p>
 
-<p>{{ h3_gecko_minversion("-moz-windows-compositor", "1.9.2") }}</p>
+<h3>-moz-windows-compositor</h3>
 
 <p><strong>Valor:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Mídia</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -516,7 +516,7 @@ media_feature: width | min-width | max-width
 
 <p>Isto corresponde ao {{ cssxref(":-moz-system-metric(windows-compositor)") }} CSS <a href="/en-US/docs/CSS/Pseudo-classes" title="Pseudo-classes">pseudo-class</a>.</p>
 
-<p>{{ h3_gecko_minversion("-moz-windows-default-theme", "1.9.2") }}</p>
+<h3>-moz-windows-default-theme</h3>
 
 <p><strong>Valor:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Mídia</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -526,7 +526,7 @@ media_feature: width | min-width | max-width
 
 <p>Isto corresponde ao {{ cssxref(":-moz-system-metric(windows-default-theme)") }} CSS <a href="/en-US/docs/CSS/Pseudo-classes" title="Pseudo-classes">pseudo-class</a>.</p>
 
-<p>{{ h3_gecko_minversion("-moz-windows-glass", "21.0") }}</p>
+<h3>-moz-windows-glass</h3>
 
 <p><strong>Valor:</strong> {{cssxref("&lt;integer&gt;")}}<br>
  <strong style="font-weight: bold;">Mídia</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>
@@ -534,7 +534,7 @@ media_feature: width | min-width | max-width
 
 <p>If the user is using Windows Glass theme, this is 1; otherwise it's 0. Note that this only exists for Windows 7 and earlier.</p>
 
-<p>{{ h3_gecko_minversion("-moz-windows-theme", "2.0") }}</p>
+<h3>-moz-windows-theme</h3>
 
 <p><strong>Valor:</strong> <code>aero</code> | <code>luna-blue</code> | <code>luna-olive</code> | <code>luna-silver</code> | <code>royale</code> | <code>generic</code> | <code>zune</code><br>
  <strong style="font-weight: bold;">Mídia</strong><strong>:</strong> {{cssxref("Media/Visual")}}<br>


### PR DESCRIPTION
Remove the h3_gecko_minversion macro in pt-br locale. 

Issue for this PR https://github.com/mdn/translated-content/issues/5145