### PR TITLE
当imgUrl为null时，并不会触发onerrror

### DIFF
--- a/files/zh-cn/web/html/element/img/index.html
+++ b/files/zh-cn/web/html/element/img/index.html
@@ -47,7 +47,7 @@ translation_of: Web/HTML/Element/img
 <p>如果在加载或渲染图像时发生错误，且设置了至少一个 {{htmlattrxref("onerror")}} 事件处理器来处理 {{event("error")}} 事件，那么设置的事件处理器就会被调用。这样的错误可能发生在各种不同的情况下，包括：</p>
 
 <ul>
- <li><code>src</code> 属性的属性值为空（<code>""</code>）或者 <code>null</code>。</li>
+ <li><code>src</code> 属性的属性值为空（<code>""</code></li>
  <li><code>src</code> 属性的 {{glossary("URL")}} 和用户正在浏览的页面的 URL 完全相同。</li>
  <li>图像出于某些原因损坏了，从而无法加载。</li>
  <li>图像的元数据被破坏了，无法检索它的分辨率/宽高，而且在 <code>&lt;img&gt;</code> 元素的属性中没有指定宽度和/或高度。</li>


### PR DESCRIPTION
当imgUrl为null时，并不会触发onerrror，只有为“”时才会触发