### PR TITLE
remove deprecated `{{Interface}}` macro from ru

### DIFF
--- a/files/ru/mozilla/firefox/releases/3.5/index.html
+++ b/files/ru/mozilla/firefox/releases/3.5/index.html
@@ -227,8 +227,8 @@ original_slug: Firefox_3.5_для_разработчика
  <li>SVG filters now work for <code>foreignObject</code>.</li>
  <li>The <code>GetSVGDocument()</code> method has been added to <a class="internal" href="/en/HTML/Element/object" title="en/HTML/Element/Object"><code>object</code></a> and <a class="internal" href="/en/HTML/Element/iframe" title="en/HTML/Element/Iframe"><code>iframe</code></a> elements for compatibility.</li>
  <li>Implicit setting of properties in object and array initializers no longer execute setters in JavaScript. See the blog post <a class="internal" href="/web-tech/2009/04/29/object-and-array-initializers-should-not-invoke-setters-when-evaluated" title="web-tech/2009/04/29/object-and-array-initializers-should-not-invoke-setters-when-evaluated">Object and array initializers should not invoke setters when evaluated</a> for details.</li>
- <li>The <code>gDownloadLastDir.path</code> variable has been renamed to <code>gDownloadLastDir.file</code> since it refers to an {{ interface("nsIFile") }}, not a path.</li>
- <li>The <code>gDownloadLastDirPath</code> variable has been renamed to <code>gDownloadLastDirFile</code> since it refers to an {{ interface("nsIFile") }}, not a path.</li>
+ <li>The <code>gDownloadLastDir.path</code> variable has been renamed to <code>gDownloadLastDir.file</code> since it refers to an <code>nsIFile</code>, not a path.</li>
+ <li>The <code>gDownloadLastDirPath</code> variable has been renamed to <code>gDownloadLastDirFile</code> since it refers to an <code>nsIFile</code>, not a path.</li>
  <li>Starting in Firefox 3.5, you can no longer use <code>data:</code> bindings in chrome packages that get <code>XPCNativeWrapper</code> automation.</li>
 </ul>
 <h3 id="Для_разработчиков_дополнений">Для разработчиков дополнений</h3>

--- a/files/ru/mozilla/firefox/releases/3/index.html
+++ b/files/ru/mozilla/firefox/releases/3/index.html
@@ -182,13 +182,13 @@ original_slug: Firefox_3_for_developers
  <dt>
   <a href="/en/nsIIdleService" title="en/nsIIdleService">Idle service</a></dt>
  <dd>
-  Firefox 3 offers the new {{ Interface("nsIIdleService") }} interface, which lets extensions determine how long it's been since the user last pressed a key or moved their mouse.</dd>
+  Firefox 3 offers the new <code>nsIIdleService</code> interface, which lets extensions determine how long it's been since the user last pressed a key or moved their mouse.</dd>
 </dl>
 <dl>
  <dt>
   <a href="/en/nsIZipWriter" title="en/nsIZipWriter">ZIP writer</a></dt>
  <dd>
-  The new {{ Interface("nsIZipWriter") }} interface lets extensions create ZIP archives.</dd>
+  The new <code>nsIZipWriter</code> interface lets extensions create ZIP archives.</dd>
 </dl>
 <dl>
  <dt>
@@ -206,7 +206,7 @@ original_slug: Firefox_3_for_developers
  <dt>
   <a href="/en/The_Thread_Manager" title="en/The_Thread_Manager">The Thread Manager</a></dt>
  <dd>
-  Firefox 3 provides the new {{ Interface("nsIThreadManager") }} interface, along with new interfaces for threads and thread events, which provides a convenient way to create and manage threads in your code.</dd>
+  Firefox 3 provides the new <code>nsIThreadManager</code> interface, along with new interfaces for threads and thread events, which provides a convenient way to create and manage threads in your code.</dd>
 </dl>
 <dl>
  <dt>
@@ -218,7 +218,7 @@ original_slug: Firefox_3_for_developers
  <dt>
   <a href="/en/nsIJSON" title="en/nsIJSON">The <code>nsIJSON</code> interface</a></dt>
  <dd>
-  Firefox 3 offers the new {{ Interface("nsIJSON") }} interface, which offers high-performance encoding and decoding of <a href="/en/JSON" title="en/JSON">JSON</a> strings.</dd>
+  Firefox 3 offers the new <code>nsIJSON</code> interface, which offers high-performance encoding and decoding of <a href="/en/JSON" title="en/JSON">JSON</a> strings.</dd>
 </dl>
 <dl>
  <dt>

--- a/files/ru/web/api/datatransfer/index.html
+++ b/files/ru/web/api/datatransfer/index.html
@@ -334,7 +334,7 @@ translation_of: Web/API/DataTransfer
 
 <p>Data should be added in order of preference, with the most specific format added first and the least specific format added last. If data of the given format already exists, it is replaced in the same position as the old data.</p>
 
-<p>The data should be either a string, a primitive boolean or number type (which will be converted into a string) or an {{ interface("nsISupports") }}.</p>
+<p>The data should be either a string, a primitive boolean or number type (which will be converted into a string) or an <code>nsISupports</code>.</p>
 
 <div class="note"><strong>Note:</strong> This method is Gecko-specific.</div>
 

--- a/files/ru/web/api/document/documenturiobject/index.html
+++ b/files/ru/web/api/document/documenturiobject/index.html
@@ -7,7 +7,7 @@ translation_of: Web/API/Document/documentURIObject
 ---
 <p>{{ ApiRef("DOM") }}</p>
 
-<p><code><strong>Document.documentURIObject</strong></code> свойство только для чтения возвращает {{ Interface("nsIURI") }} объект представляющий URI <a href="/en-US/docs/">документа</a>.</p>
+<p><code><strong>Document.documentURIObject</strong></code> свойство только для чтения возвращает <code>nsIURI</code> объект представляющий URI <a href="/en-US/docs/">документа</a>.</p>
 
 <p>Это работает только для привилегированных  (UniversalXPConnect) скриптов, включая расширенный код. Для веб содержания это свойство не имеет какого-либо специального значения и может быть использовано так же как и любое другое обычное свойство.</p>
 

--- a/files/ru/web/api/document/index.html
+++ b/files/ru/web/api/document/index.html
@@ -365,7 +365,7 @@ translation_of: Web/API/Document
  <dt>{{domxref("document.currentScript")}} {{gecko_minversion_inline("2.0")}}</dt>
  <dd>Returns the {{HTMLElement("script")}} element that is currently executing.</dd>
  <dt>{{domxref("document.documentURIObject")}} {{gecko_minversion_inline("1.9")}}</dt>
- <dd>(<strong>Mozilla add-ons only!</strong>) Returns the {{Interface("nsIURI")}} object representing the URI of the document. This property only has special meaning in privileged JavaScript code (with UniversalXPConnect privileges).</dd>
+ <dd>(<strong>Mozilla add-ons only!</strong>) Returns the <code>nsIURI</code> object representing the URI of the document. This property only has special meaning in privileged JavaScript code (with UniversalXPConnect privileges).</dd>
  <dt>{{domxref("document.popupNode")}}</dt>
  <dd>Returns the node upon which a popup was invoked.</dd>
  <dt>{{domxref("document.tooltipNode")}}</dt>

--- a/files/ru/web/api/eventsource/index.html
+++ b/files/ru/web/api/eventsource/index.html
@@ -32,17 +32,17 @@ translation_of: Web/API/EventSource
   </tr>
   <tr>
    <td><code>onerror</code></td>
-   <td><code>{{ Interface("nsIDOMEventListener") }}</code></td>
+   <td><code><code>nsIDOMEventListener</code></code></td>
    <td>JavaScript-функция, вызываемая при появлении ошибки</td>
   </tr>
   <tr>
    <td><code>onmessage</code></td>
-   <td><code>{{ Interface("nsIDOMEventListener") }}</code></td>
+   <td><code><code>nsIDOMEventListener</code></code></td>
    <td>JavaScript-функция, вызываемая при приходе сообщения без поля <code>event</code></td>
   </tr>
   <tr>
    <td><code>onopen</code></td>
-   <td><code>{{ Interface("nsIDOMEventListener") }}</code></td>
+   <td><code><code>nsIDOMEventListener</code></code></td>
    <td>JavaScript-функция, вызываемая после открытия соединения</td>
   </tr>
   <tr>

--- a/files/ru/web/api/eventsource/index.html
+++ b/files/ru/web/api/eventsource/index.html
@@ -32,17 +32,17 @@ translation_of: Web/API/EventSource
   </tr>
   <tr>
    <td><code>onerror</code></td>
-   <td><code><code>nsIDOMEventListener</code></code></td>
+   <td><code>nsIDOMEventListener</code></td>
    <td>JavaScript-функция, вызываемая при появлении ошибки</td>
   </tr>
   <tr>
    <td><code>onmessage</code></td>
-   <td><code><code>nsIDOMEventListener</code></code></td>
+   <td><code>nsIDOMEventListener</code></td>
    <td>JavaScript-функция, вызываемая при приходе сообщения без поля <code>event</code></td>
   </tr>
   <tr>
    <td><code>onopen</code></td>
-   <td><code><code>nsIDOMEventListener</code></code></td>
+   <td><code>nsIDOMEventListener</code></td>
    <td>JavaScript-функция, вызываемая после открытия соединения</td>
   </tr>
   <tr>

--- a/files/ru/web/api/file/index.html
+++ b/files/ru/web/api/file/index.html
@@ -54,8 +54,8 @@ translation_of: Web/API/File
 
 <ul>
  <li>В Gecko, вы можете использовать этот API изнутри chrome code. Смотрите <a href="/en-US/docs/Extensions/Using_the_DOM_File_API_in_chrome_code">Использование DOM File API в chrome code</a>, чтобы узнать больше. Чтобы использовать API в chrome code, JSM и Bootstrap, вы должны импортировать его используя <code><a href="/en-US/docs/Components.utils.importGlobalProperties">Cu.importGlobalProperties</a>(['File']);</code></li>
- <li>Начиная с Gecko 6.0 {{geckoRelease("6.0")}}, привелигированный код (такой как расширение) может передавать объект {{interface("nsIFile")}} в DOM <code>File</code> конструктор для указания файла в справку.</li>
- <li>Начиная с Gecko 8.0 {{geckoRelease("8.0")}}, вы можете использовать <code>new File</code> чтобы создать <code>объект File</code> из XPCOM компонентного кода вместо создания экземпляра {{interface("nsIDOMFile")}} объекта напрямую. Конструктор принимает {{domxref("Blob")}}, второй аргумент - имя файла. Имя файла может быть любой строкой.
+ <li>Начиная с Gecko 6.0 {{geckoRelease("6.0")}}, привелигированный код (такой как расширение) может передавать объект <code>nsIFile</code> в DOM <code>File</code> конструктор для указания файла в справку.</li>
+ <li>Начиная с Gecko 8.0 {{geckoRelease("8.0")}}, вы можете использовать <code>new File</code> чтобы создать <code>объект File</code> из XPCOM компонентного кода вместо создания экземпляра <code>nsIDOMFile</code> объекта напрямую. Конструктор принимает {{domxref("Blob")}}, второй аргумент - имя файла. Имя файла может быть любой строкой.
   <pre class="syntaxbox">File File(
   Array parts,
   String filename,

--- a/files/ru/web/api/node/baseuri/index.html
+++ b/files/ru/web/api/node/baseuri/index.html
@@ -58,5 +58,5 @@ translation_of: Web/API/Node/baseURI
 <ul>
  <li>{{HTMLElement("base")}} element (HTML)</li>
  <li><code><a href="/en-US/docs/XML/xml:base">xml:base</a></code> атрибуты (XML документы).</li>
- <li>{{domxref("Node.baseURIObject")}} - вариант этого  API для Mozilla дополнений и внутреннего кода. Возвращает базовый URL как {{interface("nsIURI")}}.</li>
+ <li>{{domxref("Node.baseURIObject")}} - вариант этого  API для Mozilla дополнений и внутреннего кода. Возвращает базовый URL как <code>nsIURI</code>.</li>
 </ul>

--- a/files/ru/web/api/node/index.html
+++ b/files/ru/web/api/node/index.html
@@ -22,7 +22,7 @@ translation_of: Web/API/Node
  <dt>{{domxref("Node.baseURI")}} {{readonlyInline}}</dt>
  <dd>Возвращает {{domxref("DOMString")}} показывающие основной URL. Понятие основного URL изменяется из одного языка в другой; В HTML, это соответствует протоколу , доменному имени и структуре каталогов, все до последнего<code> '/'</code>.</dd>
  <dt>{{domxref("Node.baseURIObject")}} {{Non-standard_inline()}}</dt>
- <dd>(Не доступно для веб-контента.) Только для чтения. Объект {{ Interface("nsIURI") }}, представляющий базовый URI элемента.</dd>
+ <dd>(Не доступно для веб-контента.) Только для чтения. Объект <code>nsIURI</code>, представляющий базовый URI элемента.</dd>
  <dt>{{domxref("Node.childNodes")}} {{readonlyInline}}</dt>
  <dd>Возвращает живой {{domxref("NodeList")}}, содержащий всех потомков данного узла. Живой {{domxref("NodeList")}} означает то, что если потомки <code>узла</code> изменяются, объект {{domxref("NodeList")}} автоматически обновляется.</dd>
  <dt>{{domxref("Node.firstChild")}} {{readonlyInline}}</dt>
@@ -39,7 +39,7 @@ translation_of: Web/API/Node
  <dt>{{domxref("Node.nodeName")}} {{readonlyInline}}</dt>
  <dd>Возвращает {{domxref("DOMString")}} содержащий имя <code>узла</code>. Структура имени будет отличаться от типа имени. Например, {{domxref("HTMLElement")}} будет содержать имя соответствующего тега:<code> 'audio'</code> для {{domxref("HTMLAudioElement")}}, узел {{domxref("Text")}} будет строкой <code>'#text'</code> или узел {{domxref("Document")}} будет строкой<code> '#document'</code>.</dd>
  <dt>{{domxref("Node.nodePrincipal")}} {{Non-standard_inline()}}</dt>
- <dd>{{ Interface("nsIPrincipal") }} представляет основной узел.</dd>
+ <dd><code>nsIPrincipal</code> представляет основной узел.</dd>
  <dt>{{domxref("Node.nodeType")}}{{readonlyInline}}</dt>
  <dd>Возвращает беззнаковое короткое число <code>(unsigned short</code>) представляющее тип узла. Возможные значения:
  <table class="standard-table">

--- a/files/ru/web/api/selection/index.html
+++ b/files/ru/web/api/selection/index.html
@@ -149,7 +149,7 @@ var range  = selObj.getRangeAt(0);</pre>
 <h2 id="Gecko_notes">Gecko notes</h2>
 
 <ul>
- <li>Gecko/Firefox provide additional features, available to chrome (internal and add-on) code only. These are defined in {{interface("nsISelectionPrivate")}}.</li>
+ <li>Gecko/Firefox provide additional features, available to chrome (internal and add-on) code only. These are defined in <code>nsISelectionPrivate</code>.</li>
  <li>Mozilla source code: {{source("dom/webidl/Selection.webidl")}}</li>
  <li>{{obsolete_inline("gecko29")}} {{domxref("Selection.selectionLanguageChange()")}} used to be exposed to the web content until Firefox 29</li>
 </ul>

--- a/files/ru/web/api/window/alert/index.html
+++ b/files/ru/web/api/window/alert/index.html
@@ -35,7 +35,7 @@ translation_of: Web/API/Window/alert
 
 <p>Окна сообщений - модальные, они препятствуют получению пользователем доступа к другим частям страницы до тех пор, пока окно не будет закрыто. По этой причине, вам не следует злоупотреблять этой функцией.</p>
 
-<p><span class="comment">The following text is shared between this article, DOM:window.prompt and DOM:window.confirm</span> Пользователи<a href="/en-US/Chrome" title="Chrome"> Mozilla Chrome</a> (например, расширения для Firefox) должны использовать метод {{interface("nsIPromptService")}}.</p>
+<p><span class="comment">The following text is shared between this article, DOM:window.prompt and DOM:window.confirm</span> Пользователи<a href="/en-US/Chrome" title="Chrome"> Mozilla Chrome</a> (например, расширения для Firefox) должны использовать метод <code>nsIPromptService</code>.</p>
 
 <p>Начиная с Chrome {{CompatChrome(46.0)}} этот метод заблокирован в {{htmlelement("iframe")}} пока атрибут sandbox не установлен в значение <code>allow-modal</code>.</p>
 

--- a/files/ru/web/api/window/confirm/index.html
+++ b/files/ru/web/api/window/confirm/index.html
@@ -33,7 +33,7 @@ translation_of: Web/API/Window/confirm
 
 <p>Окна сообщений - модальные, они препятствуют получению пользователем доступа к другим частям страницы до тех пор, пока окно не будет закрыто. По этой причине, вам не следует злоупотреблять этой функцией. Более того, существуют более веские причины <a href="http://alistapart.com/article/neveruseawarning">избегать использования диалоговых окон для подтверждения действий пользователя</a>.</p>
 
-<p>Пользователям <a href="/en-US/Chrome" title="Chrome">Mozilla Chrome</a> (например, расширений Firefox) следует использовать методы {{interface("nsIPromptService")}} как альтернативу.</p>
+<p>Пользователям <a href="/en-US/Chrome" title="Chrome">Mozilla Chrome</a> (например, расширений Firefox) следует использовать методы <code>nsIPromptService</code> как альтернативу.</p>
 
 <p>Начиная с Chrome {{CompatChrome(46.0)}} этот метод заблокирован в {{htmlelement("iframe")}} до тех пор, пока атрибут sandbox не установлен в значение <code>allow-modal</code>.</p>
 

--- a/files/ru/web/api/window/index.html
+++ b/files/ru/web/api/window/index.html
@@ -37,7 +37,7 @@ translation_of: Web/API/Window
  <dt>{{domxref("Window.devicePixelRatio")}} {{non-standard_inline}}{{ReadOnlyInline}}</dt>
  <dd>Возвращает соотношение между физическими пикселями и пикселями на дисплее текущего устройства.</dd>
  <dt>{{domxref("Window.dialogArguments")}} {{ReadOnlyInline}}</dt>
- <dd>Получает аргументы, переданные в окно (если это диалоговое окно) в момент вызова {{domxref("window.showModalDialog()")}}. Это {{Interface("nsIArray")}}.</dd>
+ <dd>Получает аргументы, переданные в окно (если это диалоговое окно) в момент вызова {{domxref("window.showModalDialog()")}}. Это <code>nsIArray</code>.</dd>
  <dt>{{domxref("Window.directories")}} {{obsolete_inline}}</dt>
  <dd>Синоним {{domxref("window.personalbar")}}</dd>
  <dt>{{domxref("Window.document")}} {{ReadOnlyInline}}</dt>
@@ -73,7 +73,7 @@ translation_of: Web/API/Window
  <dt>{{domxref("Window.mozAnimationStartTime")}} {{ReadOnlyInline}}{{gecko_minversion_inline("2.0")}}</dt>
  <dd>Время в миллисекундах с момента начала цикла данной анимации.</dd>
  <dt>{{domxref("Window.mozInnerScreenX")}} {{ReadOnlyInline}}{{non-standard_inline}}{{gecko_minversion_inline("1.9.2")}}</dt>
- <dd>Возвращает горизонтальную (X) координату верхнего левого угла окна просмотра в экранных координатах. Значение возвращается в CSS-пикселях. Смотри <code>mozScreenPixelsPerCSSPixel</code> в {{interface("nsIDOMWindowUtils")}} для конвертирования и адаптирования к экранным пикселям, если необходимо.</dd>
+ <dd>Возвращает горизонтальную (X) координату верхнего левого угла окна просмотра в экранных координатах. Значение возвращается в CSS-пикселях. Смотри <code>mozScreenPixelsPerCSSPixel</code> в <code>nsIDOMWindowUtils</code> для конвертирования и адаптирования к экранным пикселям, если необходимо.</dd>
  <dt>{{domxref("Window.mozInnerScreenY")}} {{ReadOnlyInline}} {{non-standard_inline}}{{gecko_minversion_inline("1.9.2")}}</dt>
  <dd>Возвращает вертикальные (Y) координаты верхнего левого угла окна просмотра в экранных координатах. Значение возвращается в CSS-пикселях. Смотри <code>mozScreenPixelsPerCSSPixel</code> для конвертирования и адаптирования к экранным пикселям, если необходимо.</dd>
  <dt>{{domxref("Window.mozPaintCount")}} {{non-standard_inline}}{{ReadOnlyInline}} {{gecko_minversion_inline("2.0")}}</dt>

--- a/files/ru/web/api/window/prompt/index.html
+++ b/files/ru/web/api/window/prompt/index.html
@@ -46,7 +46,7 @@ var sign = window.prompt('Are you feeling lucky', 'sure'); // открывает
 
 <p>Пожалуйста, обратите внимание, что результатом является строка. Это значит, что вы должны определять значение заданное пользователем. Например, если ответ должен быть Number, вы должны привести значение к Number: <span style="background-color: #f6f6f2; font-family: courier new,andale mono,monospace; font-size: 12px; line-height: normal;">var aNumber = Number(window.prompt("Type a number", "")); </span></p>
 
-<p>Пользователи <a href="/Mozilla/Firefox" title="Firefox">Mozilla Firefox</a> (например, расширений Firefox) должны использовать методы {{interface("nsIPromptService")}}.</p>
+<p>Пользователи <a href="/Mozilla/Firefox" title="Firefox">Mozilla Firefox</a> (например, расширений Firefox) должны использовать методы <code>nsIPromptService</code>.</p>
 
 <p>Начиная с Chrome {{CompatChrome(46.0)}}, этот метод блокируется внутри объекта {{htmlelement("iframe")}}, пока атрибут sandbox не будет установлен в значение <code>allow-modal</code>.</p>
 

--- a/files/ru/web/api/xmlhttprequest/index.html
+++ b/files/ru/web/api/xmlhttprequest/index.html
@@ -282,7 +282,7 @@ translation_of: Web/API/XMLHttpRequest
   </tr>
   <tr id="channel">
    <td><code>channel</code> {{ReadOnlyInline()}}</td>
-   <td>{{Interface("nsIChannel")}}</td>
+   <td><code>nsIChannel</code></td>
    <td>The channel used by the object when performing the request. This is <code>null</code> if the channel hasn't been created yet. In the case of a multi-part request, this is the initial channel, not the different parts in the multi-part request. <strong>Requires elevated privileges to access.</strong></td>
   </tr>
   <tr id="mozAnon">
@@ -557,7 +557,7 @@ if (!XMLHttpRequest.prototype.sendAsBinary) {
 <ul>
  <li class="note">By default, Firefox 3 limits the number of <code>XMLHttpRequest</code> connections per server to 6 (previous versions limit this to 2 per server). Some interactive web sites may keep an <code>XMLHttpRequest</code> connection open, so opening multiple sessions to such sites may result in the browser hanging in such a way that the window no longer repaints and controls don't respond. This value can be changed by editing the <code>network.http.max-persistent-connections-per-server</code> preference in <code><a class="linkification-ext" href="/about:config" title="Linkification: about:config">about:config</a></code>.</li>
  <li class="note">From {{ gecko("7.0") }} headers set by {{ manch("setRequestHeader") }} are sent with the request when following a redirect. Previously these headers would not be sent.</li>
- <li class="note"><code>XMLHttpRequest</code> is implemented in Gecko using the {{ interface("nsIXMLHttpRequest") }}, {{ interface("nsIXMLHttpRequestEventTarget") }}, and {{ interface("nsIJSXMLHttpRequest") }} interfaces.</li>
+ <li class="note"><code>XMLHttpRequest</code> is implemented in Gecko using the <code>nsIXMLHttpRequest</code>, <code>nsIXMLHttpRequestEventTarget</code>, and <code>nsIJSXMLHttpRequest</code> interfaces.</li>
  <li class="note">When a request reaches its timeout value, a "timeout" event is raised.</li>
 </ul>
 
@@ -565,7 +565,7 @@ if (!XMLHttpRequest.prototype.sendAsBinary) {
 
 <p><code>onreadystatechange</code> as a property of the <code>XMLHttpRequest</code> instance is supported in all browsers.</p>
 
-<p>Since then, a number of additional event handlers were implemented in various browsers (<code>onload</code>, <code>onerror</code>, <code>onprogress</code>, etc.). These are supported in Firefox. In particular, see {{ interface("nsIXMLHttpRequestEventTarget") }} and <a href="/en/DOM/XMLHttpRequest/Using_XMLHttpRequest" title="En/XMLHttpRequest/Using_XMLHttpRequest">Using XMLHttpRequest</a>.</p>
+<p>Since then, a number of additional event handlers were implemented in various browsers (<code>onload</code>, <code>onerror</code>, <code>onprogress</code>, etc.). These are supported in Firefox. In particular, see <code>nsIXMLHttpRequestEventTarget</code> and <a href="/en/DOM/XMLHttpRequest/Using_XMLHttpRequest" title="En/XMLHttpRequest/Using_XMLHttpRequest">Using XMLHttpRequest</a>.</p>
 
 <p>More recent browsers, including Firefox, also support listening to the <code>XMLHttpRequest</code> events via standard <code><a href="/en/DOM/element.addEventListener" title="element.addEventListener">addEventListener</a></code> APIs in addition to setting <code>on*</code> properties to a handler function.</p>
 

--- a/files/ru/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.html
+++ b/files/ru/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.html
@@ -146,7 +146,7 @@ req.sendAsBinary(aBody);
 
 <div class="note"><strong>Примечание:</strong> Нестандартный метод <code>sendAsBinary</code> начиная с Gecko 31 {{ geckoRelease(31) }} считается устаревшим и скоро будет удалён. Вместо него, как показывалось выше, можно использовать стандартный метод <code>send(Blob data)</code>.</div>
 
-<p>Кроме того, чтобы отправить бинарные данные можно передать экземпляр {{interface("nsIFileInputStream")}} в метод <a href="/en-US/docs/DOM/XMLHttpRequest#send()" title="XMLHttpRequest#send()"><code>send()</code></a>. В этом случае заголовок <code>Content-Length</code> заполнять явно необязательно, поскольку информация получается из потока автоматически:</p>
+<p>Кроме того, чтобы отправить бинарные данные можно передать экземпляр <code>nsIFileInputStream</code> в метод <a href="/en-US/docs/DOM/XMLHttpRequest#send()" title="XMLHttpRequest#send()"><code>send()</code></a>. В этом случае заголовок <code>Content-Length</code> заполнять явно необязательно, поскольку информация получается из потока автоматически:</p>
 
 <pre class="brush: js">// Создание потока из файла.
 var stream = Components.classes["@mozilla.org/network/file-input-stream;1"]

--- a/files/ru/web/html/element/input/radio/index.html
+++ b/files/ru/web/html/element/input/radio/index.html
@@ -307,5 +307,5 @@ button:active {
 
 <ul>
  <li>{{HTMLElement("input")}} and the {{domxref("HTMLInputElement")}} interface that implements it.</li>
- <li>{{interface("RadioNodeList")}}: the interface that describes a list of radio buttons</li>
+ <li><code>RadioNodeList</code>: the interface that describes a list of radio buttons</li>
 </ul>


### PR DESCRIPTION
As a part of #5193.

Done this job by running script [here](https://gist.github.com/yin1999/279f6f1b2f50794fb38f28b96cd38771).