### PR TITLE
Remove mention about h1_gecko_minversion and h2_gecko_minversion

### DIFF
--- a/files/es/mdn/structures/macros/other/index.html
+++ b/files/es/mdn/structures/macros/other/index.html
@@ -166,7 +166,4 @@ original_slug: MDN/Structures/Macros/Otras
  <li>{{TemplateLink("unimplemented_inline")}} inserta una marca en línea de "no implementado" para evitar el uso de, por ejemplo, una función, método o propiedad que aún no está implementada. <strong>Reemplazo</strong>: Utiliza la tabla de compatibilidad de navegadores para indicar esta información.</li>
  <li>{{TemplateLink("gecko_callout_heading")}} incluye un cuadro de llamada específico de la versión de Gecko.</li>
  <li>{{TemplateLink("fx_minversion_note")}} crea una nota sobre una versión mínima de Firefox.</li>
- <li>
-  <p>{{TemplateLink("h1_gecko_minversion")}}, {{TemplateLink("h2_gecko_minversion")}} y {{TemplateLink("h3_gecko_minversion")}} te permiten insertar encabezados (h1, h2 y h3) que se incluyen a la derecha al final de la línea, una insignia que indica la versión de Gecko (y las versiones correspondientes de la aplicación) a la que se aplica la sección.</p>
- </li>
 </ul>


### PR DESCRIPTION
These 2 macros are no more used anywhere on mdn and are about to be deleted. Let's remove the last mention of them.

(This page is completely outdated and list numerous removed macros)