### PR TITLE
Firefox 99 for developersを更新

### DIFF
--- a/files/ja/mozilla/firefox/releases/99/index.md
+++ b/files/ja/mozilla/firefox/releases/99/index.md
@@ -39,15 +39,13 @@ tags:
 
 - [Network Information API](/ja/docs/Web/API/Network_Information_API) は以前 Android (限定) で有効化していましたが、すべてのプラットフォームでデフォルトで無効になりました。
   この API は、フィンガープリンティングに使用されると思われるかなりの量のユーザー情報を公開するため、削除する過程にあります 
-  ({{bug(1720353)}})。
-
+  ({{bug(1637922)}})。
 
 ### WebDriver conformance (Marionette)
 
 - `WebDriver:ElementSendKeys` コマンドのキーシーケンスの一部で、Shift キーが適切に制御されない不具合を修正しました ({{bug(1757636)}})。
 
 ## アドオン開発者向けの変更点一覧
-
 
 ## 過去のバージョン
 


### PR DESCRIPTION
Apr 13, 2022の英語版に対応。