### PR TITLE
Corrected the "Operator precedence Table"

### DIFF
--- a/files/ru/web/javascript/reference/operators/operator_precedence/index.html
+++ b/files/ru/web/javascript/reference/operators/operator_precedence/index.html
@@ -41,7 +41,9 @@ translation_of: Web/JavaScript/Reference/Operators/Operator_Precedence
 
 <h2 id="Table">Таблица</h2>
 
-<p>Данная таблица упорядочена с самого высокого приоритета (20) до самого низкого (1).</p>
+<p>Операторы упорядочены с самого высокого (19) до самого низкого (1) приоритета.</p>
+
+Обратите внимание, что [spread-оператор (...)](/ru/docs/Web/JavaScript/Reference/Operators/Spread_syntax) намеренно не включен в таблицу, потому что он вообще не является оператором и правильно говорить <code>spread-синтаксис</code>. Подробнее можно почитать в [ответе на Stack Overflow (en)](https://stackoverflow.com/a/44934830/15378287).
 
 <table class="fullwidth-table">
  <tbody>
@@ -52,20 +54,20 @@ translation_of: Web/JavaScript/Reference/Operators/Operator_Precedence
    <th>Конкретные операторы</th>
   </tr>
   <tr>
-   <td>20</td>
+   <td>19</td>
    <td>{{jsxref("Operators/Grouping", "Группировка")}}</td>
    <td>не определено</td>
    <td><code>( … )</code></td>
   </tr>
+
   <tr>
-   <td rowspan="4">19</td>
+   <td rowspan="5">18</td>
    <td>{{jsxref("Operators/Property_Accessors", "Доступ к свойствам", "#Dot_notation")}}</td>
-   <td>слева направо</td>
+   <td rowspan="2">слева направо</td>
    <td><code>… . …</code></td>
   </tr>
   <tr>
    <td>{{jsxref("Operators/Property_Accessors", "Доступ к свойствам с возможностью вычисления","#Bracket_notation")}}</td>
-   <td>слева направо</td>
    <td><code>… [ … ]</code></td>
   </tr>
   <tr>
@@ -75,17 +77,23 @@ translation_of: Web/JavaScript/Reference/Operators/Operator_Precedence
   </tr>
   <tr>
    <td><a href="/ru/docs/Web/JavaScript/Guide/Functions">Вызов функции</a></td>
-   <td>слева направо</td>
+   <td rowspan="2">слева направо</td>
    <td><code>… ( <var>… </var>)</code></td>
   </tr>
   <tr>
-   <td>18</td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Optional_chaining">Оператор опциональной последовательности (?.)</a></td>
+   <td><code>?.</code></td>
+  </tr>
+
+  <tr>
+   <td>17</td>
    <td>{{jsxref("Operators/new","new")}} (без списка аргументов)</td>
    <td>справа налево</td>
    <td><code>new …</code></td>
   </tr>
+
   <tr>
-   <td rowspan="2">17</td>
+   <td rowspan="2">16</td>
    <td>{{jsxref("Operators/Arithmetic_Operators","Постфиксный инкремент","#Increment")}}</td>
    <td rowspan="2">не определено</td>
    <td><code>… ++</code></td>
@@ -94,14 +102,15 @@ translation_of: Web/JavaScript/Reference/Operators/Operator_Precedence
    <td>{{jsxref("Operators/Arithmetic_Operators","Постфиксный декремент","#Decrement")}}</td>
    <td><code>… --</code></td>
   </tr>
+
   <tr>
-   <td rowspan="10">16</td>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_NOT">Логическое отрицание</a></td>
+   <td rowspan="10">15</td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_NOT">Логическое отрицание (!)</a></td>
    <td rowspan="10">справа налево</td>
    <td><code>! …</code></td>
   </tr>
   <tr>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_NOT">Побитовое отрицание</a></td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_NOT">Побитовое отрицание (~)</a></td>
    <td><code>~ …</code></td>
   </tr>
   <tr>
@@ -136,66 +145,71 @@ translation_of: Web/JavaScript/Reference/Operators/Operator_Precedence
    <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/await">await</a></td>
    <td><code>await …</code></td>
   </tr>
+
   <tr>
-   <td>15</td>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation">Возведение в степень</a></td>
+   <td>14</td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation">Возведение в степень (**)</a></td>
    <td>справа налево</td>
    <td><code>… ** …</code></td>
   </tr>
+
   <tr>
-   <td rowspan="3">14</td>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Multiplication">Умножение</a></td>
+   <td rowspan="3">13</td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Multiplication">Умножение (*)</a></td>
    <td rowspan="3">слева направо</td>
    <td><code>… * …</code></td>
   </tr>
   <tr>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Division">Деление</a></td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Division">Деление (/)</a></td>
    <td><code>… / …</code></td>
   </tr>
   <tr>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Remainder">Остаток</a></td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Remainder">Остаток от деления (%)</a></td>
    <td><code>… % …</code></td>
   </tr>
+
   <tr>
-   <td rowspan="2">13</td>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Addition">Сложение</a></td>
+   <td rowspan="2">12</td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Addition">Сложение (+)</a></td>
    <td rowspan="2">слева направо</td>
    <td><code>… + …</code></td>
   </tr>
   <tr>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Subtraction">Вычитание</a></td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Subtraction">Вычитание (-)</a></td>
    <td><code>… - …</code></td>
   </tr>
+
   <tr>
-   <td rowspan="3">12</td>
-   <td><a href="https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators">Побитовый сдвиг влево</a></td>
+   <td rowspan="3">11</td>
+   <td><a href="https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators">Побитовый сдвиг влево (<<)</a></td>
    <td rowspan="3">слева направо</td>
    <td><code>… &lt;&lt; …</code></td>
   </tr>
   <tr>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators">Побитовый сдвиг вправо</a></td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators">Побитовый сдвиг вправо (>>)</a></td>
    <td><code>… &gt;&gt; …</code></td>
   </tr>
   <tr>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators">Сдвиг вправо с заполнением нулей</a></td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators">Сдвиг вправо с заполнением нулей (>>>)</a></td>
    <td><code>… &gt;&gt;&gt; …</code></td>
   </tr>
+
   <tr>
-   <td rowspan="6">11</td>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Less_than_operator">Меньше</a></td>
+   <td rowspan="6">10</td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Less_than_operator">Меньше (<)</a></td>
    <td rowspan="6">слева направо</td>
    <td><code>… &lt; …</code></td>
   </tr>
   <tr>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Less_than__or_equal_operator">Меньше или равно</a></td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Less_than__or_equal_operator">Меньше или равно (<=)</a></td>
    <td><code>… &lt;= …</code></td>
   </tr>
   <tr>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Greater_than_operator">Больше</a></td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Greater_than_operator">Больше (>)</a></td>
    <td><code>… &gt; …</code></td>
   </tr>
   <tr>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Greater_than_or_equal_operator">Больше или равно</a></td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Greater_than_or_equal_operator">Больше или равно (>=)</a></td>
    <td><code>… &gt;= …</code></td>
   </tr>
   <tr>
@@ -206,64 +220,76 @@ translation_of: Web/JavaScript/Reference/Operators/Operator_Precedence
    <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/instanceof">instanceof</a></td>
    <td><code>… instanceof …</code></td>
   </tr>
+
   <tr>
-   <td rowspan="4">10</td>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Equality">Равно</a></td>
+   <td rowspan="4">9</td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Equality">Равенство (==)</a></td>
    <td rowspan="4">слева направо</td>
    <td><code>… == …</code></td>
   </tr>
   <tr>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Inequality">Не равно</a></td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Inequality">Неравенство (!=)</a></td>
    <td><code>… != …</code></td>
   </tr>
   <tr>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Identity">Строго равно</a></td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Identity">Строгое равенство (===)</a></td>
    <td><code>… === …</code></td>
   </tr>
   <tr>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Nonidentity">Строго не равно</a></td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Nonidentity">Строгое неравенство (!==)</a></td>
    <td><code>… !== …</code></td>
   </tr>
+
   <tr>
-   <td>9</td>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_AND">Побитовое «И»</a></td>
+   <td>8</td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_AND">Побитовое «И» (&)</a></td>
    <td>слева направо</td>
    <td><code>… &amp; …</code></td>
   </tr>
+
   <tr>
-   <td>8</td>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_XOR">Побитовое исключающее «ИЛИ»</a></td>
+   <td>7</td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_XOR">Побитовое исключающее «ИЛИ» (^)</a></td>
    <td>слева направо</td>
    <td><code>… ^ …</code></td>
   </tr>
+
   <tr>
-   <td>7</td>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_OR">Побитовое «ИЛИ»</a></td>
+   <td>6</td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_OR">Побитовое «ИЛИ» (|)</a></td>
    <td>слева направо</td>
    <td><code>… | …</code></td>
   </tr>
+
   <tr>
-   <td>6</td>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_AND">Логическое «И»</a></td>
+   <td>5</td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_AND">Логическое «И» (&&)</a></td>
    <td>слева направо</td>
    <td><code>… &amp;&amp; …</code></td>
   </tr>
+
   <tr>
-   <td>5</td>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_OR">Логическое «ИЛИ»</a></td>
-   <td>слева направо</td>
+   <td rowspan="2">4</td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_OR">Логическое «ИЛИ» (||)</a></td>
+   <td rowspan="2">слева направо</td>
    <td><code>… || …</code></td>
   </tr>
   <tr>
-   <td>4</td>
-   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Conditional_Operator">Условный</a></td>
+   <td><a href="ru/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator">Оператор нулевого слияния (??)</a></td>
+   <td><code>… ?? …</code></td>
+  </tr>
+
+  <tr>
+   <td>3</td>
+   <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Conditional_Operator">Условный (тернарный) оператор</a></td>
    <td>справа налево</td>
    <td><code>… ? … : …</code></td>
   </tr>
+
   <tr>
-   <td rowspan="13">3</td>
-   <td rowspan="13"><a href="/ru/docs/Web/JavaScript/Reference/Operators/Assignment_Operators">Присваивание</a></td>
-   <td rowspan="13">справа налево</td>
+   <td rowspan="18">2</td>
+   <td rowspan="16"><a href="/ru/docs/Web/JavaScript/Reference/Operators/Assignment_Operators">Присваивание</a></td>
+   <td rowspan="16">справа налево</td>
    <td><code>… = …</code></td>
   </tr>
   <tr>
@@ -303,7 +329,15 @@ translation_of: Web/JavaScript/Reference/Operators/Operator_Precedence
    <td><code>… |= …</code></td>
   </tr>
   <tr>
-   <td rowspan="2">2</td>
+   <td><code>… &#x26;&#x26;= …</code></td>
+  </tr>
+  <tr>
+   <td><code>… ||= …</code></td>
+  </tr>
+  <tr>
+   <td><code>… ??= …</code></td>
+  </tr>
+  <tr>
    <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/yield">yield</a></td>
    <td rowspan="2">справа налево</td>
    <td><code>yield …</code></td>
@@ -312,6 +346,7 @@ translation_of: Web/JavaScript/Reference/Operators/Operator_Precedence
    <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/yield*">yield*</a></td>
    <td><code>yield* …</code></td>
   </tr>
+
   <tr>
    <td>1</td>
    <td><a href="/ru/docs/Web/JavaScript/Reference/Operators/Comma_Operator">Запятая / Последовательность</a></td>


### PR DESCRIPTION
🇷🇺 Заметил, что на сайте устаревшая версия Таблицы – поехали приоритеты, плюс не хватает новых операторов.
Вдобавок дополнил описание уточнением про `spread-синтаксис`.

🇺🇸 I noticed that the current version of the Table is outdated – most priorities are not correct, and some new operators are missed.
In addition, I've updated the description with a nore regards `spread-syntax`.