### PR TITLE
remove `{{exception}}` macro from zh-CN

### DIFF
--- a/files/zh-cn/mdn/contribute/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.html
+++ b/files/zh-cn/mdn/contribute/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.html
@@ -205,7 +205,7 @@ interface SpeechSynthesis {
 
 <p><span>In some cases, like when some values are illegal, setting a new value can lead to an exception being raised. This is marked using the <code>[SetterThrows]</code> annotation. When this happens, the Syntax section of the property page <em>must</em> have an Exceptions subsection. The list of exceptions and the conditions to have them thrown are listed, as textual information, in the specification of that API.</span></p>
 
-<p><span>Note that some exceptions are not explicitly marked but are defined by the JavaScript bindings. <a href="http://heycam.github.io/webidl/#es-enumeration">Trying to set an illegal enumerated value</a> (mapped to a JavaScript {{jsxref('String')}}) raises a {{exception('TypeError')}} exception. This must be documented, but is only implicitly marked in the WebIDL document.</span></p>
+<p><span>Note that some exceptions are not explicitly marked but are defined by the JavaScript bindings. <a href="http://heycam.github.io/webidl/#es-enumeration">Trying to set an illegal enumerated value</a> (mapped to a JavaScript {{jsxref('String')}}) raises a {{jsxref('TypeError')}} exception. This must be documented, but is only implicitly marked in the WebIDL document.</span></p>
 
 <p><span>It is uncommon to have getters throwing exceptions, though it happens in a few cases. In this case the <code>[GetterThrows]</code> annotation is used. Here also, the Syntax section of the property page <em>must</em> have an Exceptions subsection.</span></p>
 
@@ -326,7 +326,7 @@ interface SpeechSynthesis {
 
 <p><span>Some methods can throw exceptions. This is marked using the <code>[Throws]</code> annotation. When this happens, the Syntax section of the method page <em>must</em> have an Exceptions subsection. The list of exceptions and the conditions to have them thrown are listed, as textual information, in the specification of that API.</span></p>
 
-<p><span>Note that some exceptions are not explicitly marked but are defined by the JavaScript bindings. <a href="http://heycam.github.io/webidl/#es-enumeration">Trying to set an illegal enumerated value</a> (mapped to a JavaScript {{jsxref('String')}}) as a parameter will raise a {{exception('TypeError')}} exception. This must be documented, but it is only implicitly marked in the WebIDL document.</span></p>
+<p><span>Note that some exceptions are not explicitly marked but are defined by the JavaScript bindings. <a href="http://heycam.github.io/webidl/#es-enumeration">Trying to set an illegal enumerated value</a> (mapped to a JavaScript {{jsxref('String')}}) as a parameter will raise a {{jsxref('TypeError')}} exception. This must be documented, but it is only implicitly marked in the WebIDL document.</span></p>
 
 <p><span>Have a look at one of these <a href="https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey#Exceptions"><em>Exceptions</em> sections</a>.</span></p>
 

--- a/files/zh-cn/web/api/crypto/getrandomvalues/index.html
+++ b/files/zh-cn/web/api/crypto/getrandomvalues/index.html
@@ -30,9 +30,10 @@ original_slug: Web/API/RandomSource/getRandomValues
 
 <h3 id="异常事件">异常事件</h3>
 
-<ul>
- <li>如果请求的长度超过 65536 字节，则异常事件 {{domxref("DOMException")}} {{exception("QuotaExceededError")}} 被抛出。</li>
-</ul>
+<dl>
+ <dt><code>QuotaExceededError</code> {{domxref("DOMException")}}</dt>
+ <dd>如果请求的长度超过 65536 字节，则抛出该异常。</dd>
+</dl>
 
 <h2 id="例子">例子</h2>
 

--- a/files/zh-cn/web/api/element/closest/index.html
+++ b/files/zh-cn/web/api/element/closest/index.html
@@ -34,9 +34,10 @@ translation_of: Web/API/Element/closest
 
 <h3 id="异常">异常</h3>
 
-<ul>
- <li>如果传入的选择器不合法，则抛出 {{exception("SyntaxError")}} 异常。</li>
-</ul>
+<dl>
+ <dt><code>SyntaxError</code> {{domxref("DOMException")}}</dt>
+ <dd>如果选择器不合法，则抛出该异常。</dd>
+</dl>
 
 <h2 id="示例">示例</h2>
 

--- a/files/zh-cn/web/api/offlineaudiocontext/suspend/index.html
+++ b/files/zh-cn/web/api/offlineaudiocontext/suspend/index.html
@@ -28,14 +28,17 @@ translation_of: Web/API/OfflineAudioContext/suspend
 
 <p>发生任何异常，promise就会拒绝.</p>
 
-<p>如果帧数出现下列情况，就会抛出错误{{exception("InvalidStateError")}}:</p>
-
-<ul>
- <li>一个负值</li>
- <li>小于或等于当前时间</li>
- <li>大于或等于渲染的总渲染时间</li>
- <li>is scheduled by another suspend for the same time</li>
-</ul>
+<dl>
+ <dt><code>InvalidStateError</code> {{domxref("DOMException")}}</dt>
+ <dd>如果帧数出现下列情况，则抛出该异常：
+  <ul>
+   <li>一个负值</li>
+   <li>小于或等于当前时间</li>
+   <li>大于或等于渲染的总渲染时间</li>
+   <li>is scheduled by another suspend for the same time</li>
+  </ul>
+ </dd>
+</dl>
 
 <h2 id="Specifications">Specifications</h2>
 


### PR DESCRIPTION
As a part of mdn/mdn-community#64