### PR TITLE
remove `{{LearnBox}}` macro from zh-CN

### DIFF
--- a/files/zh-cn/glossary/index.md
+++ b/files/zh-cn/glossary/index.md
@@ -16,8 +16,6 @@ Web 技术文档和代码中含有大量的术语和缩写。本术语表给出�
 
 > **备注：** 编辑术语表是一项永无止境的工作，你可以[添加新的条目](/zh-CN/docs/MDN/Contribute/Howto/Write_a_new_entry_in_the_Glossary)或改进、完善现有条目。
 
-{{LearnBox({"title":"学习一个新术语："})}}
-
 <section id="Quick_links">
  <ol>
   <li><strong><a href="/zh-CN/docs/Glossary">MDN Web 文档术语</a></strong>{{ListSubpagesForSidebar("/zh-CN/docs/Glossary", 1)}}</li>

--- a/files/zh-cn/learn/index.md
+++ b/files/zh-cn/learn/index.md
@@ -44,8 +44,6 @@ translation_of: Learn
 
 > **备注：** 可在 [词汇表](/zh-CN/docs/Glossary) 中查询术语。此外，如果你对 Web 开发有具体问题，可以尝试在 [常见问题](/zh-CN/docs/Learn/Common_questions) 寻找答案。
 
-{{LearnBox({"title":"随机术语"})}}
-
 ## 涵盖的主题
 
 以下是 MDN 学习区涵盖的所有主题列表：


### PR DESCRIPTION
As a part of mdn/mdn-community#65.