### PR TITLE
fix: Typo fix

### DIFF
--- a/files/pt-br/web/api/setinterval/index.html
+++ b/files/pt-br/web/api/setinterval/index.html
@@ -8,7 +8,7 @@ original_slug: Web/API/WindowOrWorkerGlobalScope/setInterval
 
 <div> </div>
 
-<p>O método <strong><code>setInterval() </code></strong>oferecido das interfaces {{domxref("Window")}} e {{domxref("Worker")}}, repetem chamadas de funções or executam trechos de código, com um tempo de espera fixo entre cada chamada. Isso retorna um ID único para o intervalo, podendo remove-lo mais tarde apenas o chamando {{domxref("WindowOrWorkerGlobalScope.clearInterval", "clearInterval()")}}. Este metodo é definido pelo mixin {{domxref("WindowOrWorkerGlobalScope")}}.</p>
+<p>O método <strong><code>setInterval() </code></strong>oferecido das interfaces {{domxref("Window")}} e {{domxref("Worker")}}, repetem chamadas de funções ou executam trechos de código, com um tempo de espera fixo entre cada chamada. Isso retorna um ID único para o intervalo, podendo remove-lo mais tarde apenas o chamando {{domxref("WindowOrWorkerGlobalScope.clearInterval", "clearInterval()")}}. Este metodo é definido pelo mixin {{domxref("WindowOrWorkerGlobalScope")}}.</p>
 
 <h2 id="Sintaxe.">Sintaxe.</h2>
 


### PR DESCRIPTION
Fixing a typo error at line 11:
old: {or}
new: {ou}