### PR TITLE
build(node): bump to node 14

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "14"
 
       - name: Lint markdown files
         run: |

--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "14"
 
       - name: Cache node_modules
         uses: actions/cache@v2.1.6

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "14"
 
       - name: Cache node_modules
         uses: actions/cache@v2.1.6

--- a/.github/workflows/sync-translated-content.yml
+++ b/.github/workflows/sync-translated-content.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "14"
 
       - name: Cache node_modules
         uses: actions/cache@v2.1.6


### PR DESCRIPTION
Original title: _follow-up of https://github.com/mdn/yari/pull/6183 / Bump Node version in GH Actions workflows_

GitHub Actions are failing since a little while because of Node version prerequisites (see https://github.com/mdn/translated-content/runs/6353455919?check_suite_focus=true) . I saw https://github.com/mdn/yari/pull/6183/ and assumed it was related and that it would be a good thing for those workflows to "follow".

Please let me know if something more is needed.