### PR TITLE
pl: replace all remaining {{(m)anch}} calls with anchor tags

### DIFF
--- a/files/pl/learn/javascript/first_steps/a_first_splash/index.html
+++ b/files/pl/learn/javascript/first_steps/a_first_splash/index.html
@@ -440,7 +440,7 @@ greeting;</pre>
 
 <pre class="brush: js">name = name + ' says hello!';</pre>
 
-<p>Kiedy dokonujemy sprawdzenia prawda / fałsz (na przykład w instrukcjach warunkowych - zobacz {{anch("Instrukcje warunkowe", "poniżej")}}) używamy <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators">operatorów porównania</a>. Na przykład:</p>
+<p>Kiedy dokonujemy sprawdzenia prawda / fałsz (na przykład w instrukcjach warunkowych - zobacz <a href="#instrukcje_warunkowe">poniżej</a>) używamy <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators">operatorów porównania</a>. Na przykład:</p>
 
 <table class="standard-table">
  <thead>

--- a/files/pl/web/api/canvas_api/tutorial/drawing_shapes/index.html
+++ b/files/pl/web/api/canvas_api/tutorial/drawing_shapes/index.html
@@ -179,7 +179,7 @@ original_slug: Web/API/Canvas_API/Tutorial/rysowanie_ksztaltow
 <p>If you'd like to see the connecting lines, you can remove the lines that call <code>moveTo()</code>.</p>
 
 <div class="note">
-<p><strong>Note:</strong> To learn more about the <code>arc()</code> function, see the {{anch("Arcs")}} below.</p>
+<p><strong>Note:</strong> To learn more about the <code>arc()</code> function, see the <a href="#arcs">Arcs</a> below.</p>
 </div>
 
 <h3 id="Lines">Lines</h3>
@@ -390,7 +390,7 @@ original_slug: Web/API/Canvas_API/Tutorial/rysowanie_ksztaltow
 
 <h3 id="Rectangles">Rectangles</h3>
 
-<p>In addition to the three methods we saw in {{anch("Drawing rectangles")}}, which draw rectangular shapes directly to the canvas, there's also the <code>rect()</code> method, which adds a rectangular path to a currently open path.</p>
+<p>In addition to the three methods we saw in <a href="#drawing_rectangles">Drawing rectangles</a>, which draw rectangular shapes directly to the canvas, there's also the <code>rect()</code> method, which adds a rectangular path to a currently open path.</p>
 
 <dl>
  <dt>{{domxref("CanvasRenderingContext2D.bezierCurveTo", "rect(x, y, width, height)")}}</dt>

--- a/files/pl/web/api/console/index.html
+++ b/files/pl/web/api/console/index.html
@@ -9,7 +9,7 @@ translation_of: Web/API/Console
 
 <p>The <code>console</code> can be accessed from any global object, {{domxref("Window")}} on browsing scopes, {{domxref("WorkerGlobalScope")}} and its specific variants in workers.</p>
 
-<p>This page documents the {{anch("Methods")}} available on the <code>console</code> object and gives a few {{anch("Usage")}} examples.</p>
+<p>This page documents the <a href="#methods">Methods</a> available on the <code>console</code> object and gives a few <a href="#usage">Usage</a> examples.</p>
 
 <h2 id="Methods">Methods</h2>
 

--- a/files/pl/web/api/cssrule/index.html
+++ b/files/pl/web/api/cssrule/index.html
@@ -10,7 +10,7 @@ translation_of: Web/API/CSSRule
 ---
 <p>{{ ApiRef() }}</p>
 <p>Obiekt <code>CSSRule</code> reprezentuje pojedynczy arkusz stylu CSS. To może być pojedyncza reguła arkusza stylów CSS. Może być częścią listy <a href="pl/DOM/stylesheet">stylesheet</a> <a href="pl/DOM/stylesheet.cssRules">cssRules</a>.</p>
-<p>Jest tu kilka rodzajów reguł. Wszystkie one dzielą kilka wspólnych własności interfejsu {{ Anch("CSSRule") }} i większość posiada pewne specyficzne własności oraz typy reguł.</p>
+<p>Jest tu kilka rodzajów reguł. Wszystkie one dzielą kilka wspólnych własności interfejsu <a href="#cssrule">CSSRule</a> i większość posiada pewne specyficzne własności oraz typy reguł.</p>
 <table class="fullwidth-table">
  <tbody>
   <tr>
@@ -20,37 +20,37 @@ translation_of: Web/API/CSSRule
   </tr>
   <tr>
    <td><code>CSSRule.STYLE_RULE</code></td>
-   <td>{{ Anch("CSSStyleRule") }}</td>
+   <td><a href="#cssstylerule">CSSStyleRule</a></td>
    <td> </td>
   </tr>
   <tr>
    <td><code>CSSRule.MEDIA_RULE</code></td>
-   <td>{{ Anch("CSSMediaRule") }}</td>
+   <td><a href="#cssmediarule">CSSMediaRule</a></td>
    <td> </td>
   </tr>
   <tr>
    <td><code>CSSRule.FONT_FACE_RULE</code></td>
-   <td>{{ Anch("CSSFontFaceRule") }}</td>
+   <td><a href="#cssfontfacerule">CSSFontFaceRule</a></td>
    <td> </td>
   </tr>
   <tr>
    <td><code>CSSRule.PAGE_RULE</code></td>
-   <td>{{ Anch("CSSPageRule") }}</td>
+   <td><a href="#csspagerule">CSSPageRule</a></td>
    <td> </td>
   </tr>
   <tr>
    <td><code>CSSRule.IMPORT_RULE</code></td>
-   <td>{{ Anch("CSSImportRule") }}</td>
+   <td><a href="#cssimportrule">CSSImportRule</a></td>
    <td> </td>
   </tr>
   <tr>
    <td><code>CSSRule.CHARSET_RULE</code></td>
-   <td>{{ Anch("CSSCharsetRule") }}</td>
+   <td><a href="#csscharsetrule">CSSCharsetRule</a></td>
    <td> </td>
   </tr>
   <tr>
    <td><code>CSSRule.UNKNOWN_RULE</code></td>
-   <td>{{ Anch("CSSUnknownRule") }}</td>
+   <td><a href="#cssunknownrule">CSSUnknownRule</a></td>
    <td> </td>
   </tr>
  </tbody>

--- a/files/pl/web/api/document/createevent/index.html
+++ b/files/pl/web/api/document/createevent/index.html
@@ -16,7 +16,7 @@ translation_of: Web/API/Document/createEvent
 </pre>
 <ul>
  <li><code>zdarzenie</code> to utworzony obiekt <a href="pl/DOM/event">Event</a>.</li>
- <li><code>typ</code> to ciąg oznaczający typ tworzonego zdarzenia. Możliwe typy to m.in.: <code>"UIEvents"</code>, <code>"MouseEvents"</code>, <code>"MutationEvents"</code>, i <code>"HTMLEvents"</code>. Zob. {{ Anch("Uwagi") }}.</li>
+ <li><code>typ</code> to ciąg oznaczający typ tworzonego zdarzenia. Możliwe typy to m.in.: <code>"UIEvents"</code>, <code>"MouseEvents"</code>, <code>"MutationEvents"</code>, i <code>"HTMLEvents"</code>. Zob. <a href="#uwagi">Uwagi</a>.</li>
 </ul>
 <h3 id="Przyk.C5.82ad" name="Przyk.C5.82ad">Przykład</h3>
 <p><a href="/pl/docs/DOM/dispatchEvent_-_przyk%C5%82ad" title="/pl/docs/DOM/dispatchEvent_-_przyk%C5%82ad">dispatchEvent - przykład [pl]</a></p>

--- a/files/pl/web/api/document/execcommand/index.html
+++ b/files/pl/web/api/document/execcommand/index.html
@@ -28,7 +28,7 @@ translation_of: Web/API/Document/execCommand
 
 <dl>
  <dt><code>aCommandName</code></dt>
- <dd>Typu {{domxref("DOMString")}} - określanazwę polecenia do wykonania. Zobacz {{anch("Commands")}}, aby wyświetlić listę poleceń.</dd>
+ <dd>Typu {{domxref("DOMString")}} - określanazwę polecenia do wykonania. Zobacz <a href="#commands">Commands</a>, aby wyświetlić listę poleceń.</dd>
  <dt><code>aShowDefaultUI</code></dt>
  <dd>Typu {jsxref("Boolean")}} - wskazuje czy domyślny interfejs użytkownika powinien być pokazany. Nie jest implementowane przez Mozillę.</dd>
  <dt><code>aValueArgument</code></dt>

--- a/files/pl/web/api/document/title/index.html
+++ b/files/pl/web/api/document/title/index.html
@@ -15,7 +15,7 @@ translation_of: Web/API/Document/title
 <pre class="eval"><i>tytul</i> =<i>document</i>.title;
 </pre>
 <ul>
- <li><code>tytul</code> jest łańcuchem znaków zawierającym tytuł dokumentu. Jeśli tytuł został nadpisany poprzez ustawienie <code>document.title</code>, zwraca tę wartość. W przeciwnym wypadku zwraca tytuł określony w znaczniku (zobacz poniższe {{ Anch("Uwagi") }}).</li>
+ <li><code>tytul</code> jest łańcuchem znaków zawierającym tytuł dokumentu. Jeśli tytuł został nadpisany poprzez ustawienie <code>document.title</code>, zwraca tę wartość. W przeciwnym wypadku zwraca tytuł określony w znaczniku (zobacz poniższe <a href="#uwagi">Uwagi</a>).</li>
 </ul>
 <pre class="eval"><i>document</i>.title =<i>nowyTytul</i>;
 </pre>

--- a/files/pl/web/api/element/getattributens/index.html
+++ b/files/pl/web/api/element/getattributens/index.html
@@ -10,7 +10,7 @@ translation_of: Web/API/Element/getAttributeNS
 ---
 <p>{{ ApiRef() }}</p>
 <h3 id="Podsumowanie" name="Podsumowanie">Podsumowanie</h3>
-<p><code>getAttributeNS</code> zwraca ciąg z wartością atrybutu o podanej nazwie i przestrzeni nazw. Jeśli nie ma atrybutu o takiego atrybutu, zwrócone zostanie <code>null</code> bądź <code>""</code> (pust ciąg) - zob. {{ Anch("Uwagi") }}.</p>
+<p><code>getAttributeNS</code> zwraca ciąg z wartością atrybutu o podanej nazwie i przestrzeni nazw. Jeśli nie ma atrybutu o takiego atrybutu, zwrócone zostanie <code>null</code> bądź <code>""</code> (pust ciąg) - zob. <a href="#uwagi">Uwagi</a>.</p>
 <h3 id="Sk.C5.82adnia" name="Sk.C5.82adnia">Składnia</h3>
 <pre class="eval"><i>wartośćAtr</i> =<i>element</i>.getAttributeNS(<i>przestrzeńNazw</i>,<i>nazwa</i>)
 </pre>

--- a/files/pl/web/api/element/localname/index.html
+++ b/files/pl/web/api/element/localname/index.html
@@ -17,7 +17,7 @@ original_slug: Web/API/Node/localName
 </pre>
 <h3 id="Parametry" name="Parametry">Parametry</h3>
 <ul>
- <li><code>nazwa</code> to ciąg z lokalną nazwą węzła (zobacz {{ Anch("Uwagi") }} poniżej, aby dowiedzieć się więcej)</li>
+ <li><code>nazwa</code> to ciąg z lokalną nazwą węzła (zobacz <a href="#uwagi">Uwagi</a> poniżej, aby dowiedzieć się więcej)</li>
 </ul>
 <h3 id="Przyk.C5.82ad" name="Przyk.C5.82ad">Przykład</h3>
 <p>(Musi obsługiwać treść XML typu, jak &lt;tt&gt;text/xml&lt;/tt&gt; lub &lt;tt&gt;application/xhtml+xml&lt;/tt&gt;.)</p>

--- a/files/pl/web/api/file/index.html
+++ b/files/pl/web/api/file/index.html
@@ -15,7 +15,7 @@ translation_of: Web/API/File
 
 <p>The <strong><code>File</code></strong> interface provides information about files and allows JavaScript in a web page to access their content.</p>
 
-<p><code>File</code> objects are generally retrieved from a {{domxref("FileList")}} object returned as a result of a user selecting files using the {{HTMLElement("input")}} element, from a drag and drop operation's {{domxref("DataTransfer")}} object, or from the <code>mozGetAsFile()</code> API on an {{domxref("HTMLCanvasElement")}}. In Gecko, privileged code can create <code>File</code> objects representing any local file without user interaction (see {{anch("Implementation notes")}} for more information.)</p>
+<p><code>File</code> objects are generally retrieved from a {{domxref("FileList")}} object returned as a result of a user selecting files using the {{HTMLElement("input")}} element, from a drag and drop operation's {{domxref("DataTransfer")}} object, or from the <code>mozGetAsFile()</code> API on an {{domxref("HTMLCanvasElement")}}. In Gecko, privileged code can create <code>File</code> objects representing any local file without user interaction (see <a href="#implementation_notes">Implementation notes</a> for more information.)</p>
 
 <p>A <code>File</code> object is a specific kind of a {{domxref("Blob")}}, and can be used in any context that a Blob can. In particular, {{domxref("FileReader")}}, {{domxref("URL.createObjectURL()")}}, {{domxref("ImageBitmapFactories.createImageBitmap()", "createImageBitmap()")}}, and {{domxref("XMLHttpRequest", "", "send()")}} accept both <code>Blob</code>s and <code>File</code>s.</p>
 

--- a/files/pl/web/api/notification/index.html
+++ b/files/pl/web/api/notification/index.html
@@ -84,7 +84,7 @@ original_slug: Web/API/powiadomienie
 
 <h4 id="Przestarzała_obsługa">Przestarzała obsługa</h4>
 
-<p>Pokazana obsługa zdarzeń jest nadal wspierana w  sekcji poniższej {{anch("browser compatibility")}},ale nie pokazane w obecnej specyfikacji. I w związku z tym, aby bezpiecznie założyć, że są przestarzałe mogą przestać działać w przyszłych wersjach przeglądarek.</p>
+<p>Pokazana obsługa zdarzeń jest nadal wspierana w  sekcji poniższej <a href="#browser_compatibility">browser compatibility</a>,ale nie pokazane w obecnej specyfikacji. I w związku z tym, aby bezpiecznie założyć, że są przestarzałe mogą przestać działać w przyszłych wersjach przeglądarek.</p>
 
 <dl>
  <dt>{{domxref("Notification.onclose")}}</dt>

--- a/files/pl/web/html/element/abbr/index.html
+++ b/files/pl/web/html/element/abbr/index.html
@@ -64,7 +64,7 @@ translation_of: Web/HTML/Element/abbr
  <li>Jeśli używany jest skrót i chcesz zapewnić rozszerzenie lub definicję poza obiegiem treści dokumentu, użyj <code>&lt;abbr&gt;</code> z odpowiednim atrybutem {{htmlattrxref("title")}}.</li>
  <li>Aby zdefiniować skrót, który może być nieznany czytelnikowi, należy przedstawić termin używając <code>&lt;abbr&gt;</code> oraz atrybutu <code>title</code> lub tekstu liniowego podającego definicję.</li>
  <li>W przypadku, gdy należy zwrócić uwagę semantycznie na obecność skrótu w tekście, przydatny jest element <code>&lt;abbr&gt;</code>. To z kolei może być użyte do celów stylizacyjnych lub skryptowych.</li>
- <li>Możesz użyć <code>&lt;abbr&gt;</code> w porozumieniu z {{HTMLElement("dfn")}} aby ustalić definicje terminów, które są skrótami lub akronimami. Zobacz przykład {{anch("Definiowanie skrótu")}} poniżej.</li>
+ <li>Możesz użyć <code>&lt;abbr&gt;</code> w porozumieniu z {{HTMLElement("dfn")}} aby ustalić definicje terminów, które są skrótami lub akronimami. Zobacz przykład <a href="#definiowanie_skrótu">Definiowanie skrótu</a> poniżej.</li>
 </ul>
 
 <h3 id="Uwagi_gramatyczne">Uwagi gramatyczne</h3>

--- a/files/pl/web/html/element/details/index.html
+++ b/files/pl/web/html/element/details/index.html
@@ -69,7 +69,7 @@ translation_of: Web/HTML/Element/details
 <p>{{EmbedLiveSample("Przykład")}}</p>
 
 <div class="note">
-<p><strong>Note:</strong> Jeżeli rezultat nie działa u Ciebie poprawnie, zobacz {{anch("kompatybilność z przeglądarkami")}}, aby sprawdzić, czy Twoja przegladarka wspiera ten element.</p>
+<p><strong>Note:</strong> Jeżeli rezultat nie działa u Ciebie poprawnie, zobacz <a href="#kompatybilność_z_przeglądarkami">kompatybilność z przeglądarkami</a>, aby sprawdzić, czy Twoja przegladarka wspiera ten element.</p>
 </div>
 
 <h2 id="Przykład_z_ostylowaniem">Przykład z ostylowaniem</h2>

--- a/files/pl/web/javascript/guide/grammar_and_types/index.html
+++ b/files/pl/web/javascript/guide/grammar_and_types/index.html
@@ -284,12 +284,12 @@ y = 42 + " jest odpowiedzią" // "42 jest odpowiedzią"
 <p>Literałów używa się w celu przedstawiania wartości w języku JavaScript. Są one ustalonymi wartościami (a nie zmiennymi), które <em>dosłownie</em> podajesz w swoim skrypcie. Ten fragment opisuje następujące typy literałów:</p>
 
 <ul>
- <li>{{anch("Literały tablicowe")}}</li>
- <li>{{anch("Literały boolowskie")}}</li>
- <li>{{anch("Literały zmiennoprzecinkowe")}}</li>
- <li>{{anch("Literały całkowite")}}</li>
- <li>{{anch("Literały obiektowe")}}</li>
- <li>{{anch("Literały znakowe")}}</li>
+ <li><a href="#literały_tablicowe">Literały tablicowe</a></li>
+ <li><a href="#literały_boolowskie">Literały boolowskie</a></li>
+ <li><a href="#literały_zmiennoprzecinkowe">Literały zmiennoprzecinkowe</a></li>
+ <li><a href="#literały_całkowite">Literały całkowite</a></li>
+ <li><a href="#literały_obiektowe">Literały obiektowe</a></li>
+ <li><a href="#literały_znakowe">Literały znakowe</a></li>
 </ul>
 
 <h3 id="Literały_tablicowe">Literały tablicowe</h3>
@@ -539,7 +539,7 @@ console.log(foo["2"]); // dwa
   </tr>
   <tr>
    <td><code>\u<em>XXXX</em></code></td>
-   <td>Znak w formacie Unicode wyznaczony przez cztery liczby w formacie heksadecymalnym. Przykładowo \u00A9 w tym formacie reprezentuje symbol praw autorskich, więcej informacji na ten temat znajdziesz w  {{anch("Unicode escape sequences")}}.</td>
+   <td>Znak w formacie Unicode wyznaczony przez cztery liczby w formacie heksadecymalnym. Przykładowo \u00A9 w tym formacie reprezentuje symbol praw autorskich, więcej informacji na ten temat znajdziesz w  <a href="#unicode_escape_sequences">Unicode escape sequences</a>.</td>
   </tr>
  </tbody>
 </table>

--- a/files/pl/web/javascript/guide/loops_and_iteration/index.html
+++ b/files/pl/web/javascript/guide/loops_and_iteration/index.html
@@ -21,14 +21,14 @@ for (step = 0; step &lt; 5; step++) {
 <p>Wyrażenia dla pętli obsługiwane w JavaScript:</p>
 
 <ul>
- <li>{{anch("for")}}</li>
- <li>{{anch("do...while")}}</li>
- <li>{{anch("while")}}</li>
- <li>{{anch("label")}}</li>
- <li>{{anch("break")}}</li>
- <li>{{anch("continue")}}</li>
- <li>{{anch("for...in")}}</li>
- <li>{{anch("for...of")}}</li>
+ <li><a href="#for">for</a></li>
+ <li><a href="#do...while">do...while</a></li>
+ <li><a href="#while">while</a></li>
+ <li><a href="#label">label</a></li>
+ <li><a href="#break">break</a></li>
+ <li><a href="#continue">continue</a></li>
+ <li><a href="#for...in">for...in</a></li>
+ <li><a href="#for...of">for...of</a></li>
 </ul>
 
 <h2 id="for"><code>for</code></h2>

--- a/files/pl/web/javascript/reference/global_objects/date/tolocaledatestring/index.html
+++ b/files/pl/web/javascript/reference/global_objects/date/tolocaledatestring/index.html
@@ -25,7 +25,7 @@ original_slug: Web/JavaScript/Referencje/Obiekty/Date/toLocaleDateString
 
 <h3 id="Parametry" name="Parametry">Parametry</h3>
 
-<p>Check the {{anch("Browser compatibility")}} section to see which browsers support the <code>locales</code> and <code>options</code> arguments, and the <a href="https://developer.mozilla.org/pl/docs/Web/JavaScript/Referencje/Obiekty/Date/toLocaleDateString$edit#Example:_Checking_for_support_for_locales_and_options_arguments">Example: Checking for support for <code>locales</code> and <code>options</code> arguments</a> for feature detection.</p>
+<p>Check the <a href="#browser_compatibility">Browser compatibility</a> section to see which browsers support the <code>locales</code> and <code>options</code> arguments, and the <a href="https://developer.mozilla.org/pl/docs/Web/JavaScript/Referencje/Obiekty/Date/toLocaleDateString$edit#Example:_Checking_for_support_for_locales_and_options_arguments">Example: Checking for support for <code>locales</code> and <code>options</code> arguments</a> for feature detection.</p>
 
 <div>{{page('/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat', 'Parameters')}}</div>
 

--- a/files/pl/web/javascript/reference/global_objects/function/apply/index.html
+++ b/files/pl/web/javascript/reference/global_objects/function/apply/index.html
@@ -22,7 +22,7 @@ original_slug: Web/JavaScript/Referencje/Obiekty/Function/apply
  <dt><code>thisArg</code></dt>
  <dd>Optional. The value of <code>this</code> provided for the call to <em><code>func</code></em>. Note that <code>this</code> may not be the actual value seen by the method: if the method is a function in {{jsxref("Strict_mode", "non-strict mode", "", 1)}} code, {{jsxref("null")}} and {{jsxref("undefined")}} will be replaced with the global object, and primitive values will be boxed.</dd>
  <dt><code>argsArray</code></dt>
- <dd>Optional. An array-like object, specifying the arguments with which <em><code>fun</code></em> should be called, or {{jsxref("null")}} or {{jsxref("undefined")}} if no arguments should be provided to the function. Starting with ECMAScript 5 these arguments can be a generic array-like object instead of an array. See below for {{anch("Browser_compatibility", "browser compatibility")}} information.</dd>
+ <dd>Optional. An array-like object, specifying the arguments with which <em><code>fun</code></em> should be called, or {{jsxref("null")}} or {{jsxref("undefined")}} if no arguments should be provided to the function. Starting with ECMAScript 5 these arguments can be a generic array-like object instead of an array. See below for <a href="#browser_compatibility">browser compatibility</a> information.</dd>
 </dl>
 
 <h3 id="Zwracana_wartość">Zwracana wartość</h3>


### PR DESCRIPTION
This PR is a part of #4614 that removes all remaining calls to the now-deprecated `{{anch}}`  and `{{manch}}` macros and replacing them with anchor tags or Markdown links, using the script from https://github.com/mdn/content/pull/13802.
