### PR TITLE
pt-br: replace all remaining {{(m)anch}} calls with anchor tags

### DIFF
--- a/files/pt-br/conflicting/web/api/eventtarget/addeventlistener/index.html
+++ b/files/pt-br/conflicting/web/api/eventtarget/addeventlistener/index.html
@@ -40,7 +40,7 @@ original_slug: Web/API/EventListener
 
 <h3 id="Remarks" name="Remarks">Observaçōes</h3>
 
-<p>Conforme a interface for marcada com a flag <code><span class="nowiki">[function]</span></code>, todos os objetos <a href="/en/JavaScript/Reference/Global_Objects/Function" title="en/Core_JavaScript_1.5_Reference/Global_Objects/Function">Function</a> automaticamente implementtam essa interface. Chamar o método {{ manch("handleEvent") }} em uma dessas implementaçōes automaticamente invoca a função.</p>
+<p>Conforme a interface for marcada com a flag <code><span class="nowiki">[function]</span></code>, todos os objetos <a href="/en/JavaScript/Reference/Global_Objects/Function" title="en/Core_JavaScript_1.5_Reference/Global_Objects/Function">Function</a> automaticamente implementtam essa interface. Chamar o método <a href="#handleevent">handleEvent</a> em uma dessas implementaçōes automaticamente invoca a função.</p>
 
 <h2 id="See_also" name="See_also">Veja também</h2>
 

--- a/files/pt-br/web/api/blob/index.html
+++ b/files/pt-br/web/api/blob/index.html
@@ -110,7 +110,7 @@ reader.readAsArrayBuffer(blob);</pre>
 
 <h3 id="Notas_para_Gecko">Notas para Gecko</h3>
 
-<p>Anterior ao Gecko 12.0 {{ geckoRelease("12.0") }}, havia um bug que afetava o comportamento do {{ manch("slice") }}; que não funcionava para as posições <code>start</code> e <code>end</code> fora do intervalo de valores assinados como 64-bit; este bug foi corrigido para dar suporte a valores assinados como 64-bit.</p>
+<p>Anterior ao Gecko 12.0 {{ geckoRelease("12.0") }}, havia um bug que afetava o comportamento do <a href="#slice">slice</a>; que não funcionava para as posições <code>start</code> e <code>end</code> fora do intervalo de valores assinados como 64-bit; este bug foi corrigido para dar suporte a valores assinados como 64-bit.</p>
 
 <h2 id="Chrome_Code_-_Disponibilidade_de_Escopo">Chrome Code - Disponibilidade de Escopo</h2>
 

--- a/files/pt-br/web/api/websocket/index.html
+++ b/files/pt-br/web/api/websocket/index.html
@@ -71,7 +71,7 @@ WebSocket WebSocket(
    <td><code>bufferedAmount</code></td>
    <td><code>unsigned long</code></td>
    <td>
-    <p>O número de bites de dados que tem sid consultado usando chamadas para {{manch("send")}} mas não ainda para a rede.Estes valor reseta para zero uma vez que todos os dados tem sido mandados.Este valor não reseta para zero quando a conexão está fechada, se você continuar chamando {{manch("send")}}, isto continuará escalando. <strong>Leitura online</strong></p>
+    <p>O número de bites de dados que tem sid consultado usando chamadas para <a href="#send">send</a> mas não ainda para a rede.Estes valor reseta para zero uma vez que todos os dados tem sido mandados.Este valor não reseta para zero quando a conexão está fechada, se você continuar chamando <a href="#send">send</a>, isto continuará escalando. <strong>Leitura online</strong></p>
    </td>
   </tr>
   <tr>

--- a/files/pt-br/web/api/xmlhttprequest/index.html
+++ b/files/pt-br/web/api/xmlhttprequest/index.html
@@ -522,7 +522,7 @@ if (!XMLHttpRequest.prototype.sendAsBinary) {
 
 <ul>
  <li class="note">Por padrão, o Firefox 3 limita o número de XMLHttpRequest conexões por servidor a 6 (versões anteriores limitar esta para 2 por servidor). Alguns sites interativos podem manter um XMLHttpRequest conexão aberta, de modo que a abertura de várias sessões para esses sites pode resultar no navegador pendurado de tal forma que a janela já não repaints e controles não respondem. Este valor pode ser alterado através da edição do network.http.max-persistent-connections-per-server preferência no <code><a class="linkification-ext" href="/about:config" title="Linkification: about:config">about:config</a></code>.</li>
- <li class="note">Do Gecko 7 cabeçalhos estabelecidos pela {{ manch("setRequestHeader") }} asão enviados com o pedido, quando na sequência de um redirecionamento. Anteriormente, estes cabeçalhos não iria ser enviado.</li>
+ <li class="note">Do Gecko 7 cabeçalhos estabelecidos pela <a href="#setrequestheader">setRequestHeader</a> asão enviados com o pedido, quando na sequência de um redirecionamento. Anteriormente, estes cabeçalhos não iria ser enviado.</li>
  <li class="note"><code>XMLHttpRequest é implementado em Gecko usando os</code> <code>nsIXMLHttpRequest</code>, <code>nsIXMLHttpRequestEventTarget</code>, e <code>nsIJSXMLHttpRequest</code> interfaces.</li>
 </ul>
 


### PR DESCRIPTION
This PR is a part of #4614 that removes all remaining calls to the now-deprecated `{{anch}}`  and `{{manch}}` macros and replacing them with anchor tags or Markdown links, using the script from https://github.com/mdn/content/pull/13802. Fixes #4715.