### PR TITLE
es: replace old browser compat/specification tables

### DIFF
--- a/files/es/conflicting/web/api/geolocation/getcurrentposition/index.html
+++ b/files/es/conflicting/web/api/geolocation/getcurrentposition/index.html
@@ -7,6 +7,7 @@ tags:
   - Referencia
 translation_of: Web/API/PositionOptions
 original_slug: Web/API/PositionOptions
+browser-compat: api.Geolocation.getCurrentPosition
 ---
 <p>{{APIRef("Geolocation API")}}</p>
 
@@ -31,76 +32,11 @@ original_slug: Web/API/PositionOptions
 
 <h2 id="Especificaciones">Especificaciones</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Especificación</th>
-   <th scope="col">Estatus</th>
-   <th scope="col">Comentario</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('Geolocation', '#positionoptions', 'PositionOptions')}}</td>
-   <td>{{Spec2('Geolocation')}}</td>
-   <td>Especificación inicial.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
-<h2 id="Compatibilidad_de_navegador">Compatibilidad de navegador</h2>
+<h2 id="Compatibilidad_de_Navegadores">Compatibilidad de Navegadores</h2>
 
-<p>{{ CompatibilityTable() }}</p>
-
-<div id="compat-desktop">
-<table class="compat-table">
- <tbody>
-  <tr>
-   <th>Característica</th>
-   <th>Chrome</th>
-   <th>Firefox (Gecko)</th>
-   <th>Internet Explorer</th>
-   <th>Opera</th>
-   <th>Safari</th>
-  </tr>
-  <tr>
-   <td>Soporte básico</td>
-   <td>5</td>
-   <td>{{CompatGeckoDesktop("1.9.1")}}</td>
-   <td>9</td>
-   <td>10.60<br>
-    Removed in 15.0<br>
-    Reintroduced in 16.0</td>
-   <td>5</td>
-  </tr>
- </tbody>
-</table>
-</div>
-
-<div id="compat-mobile">
-<table class="compat-table">
- <tbody>
-  <tr>
-   <th>Característica</th>
-   <th>Android</th>
-   <th>Chrome for Android</th>
-   <th>Firefox Mobile (Gecko)</th>
-   <th>IE Mobile</th>
-   <th>Opera Mobile</th>
-   <th>Safari Mobile</th>
-  </tr>
-  <tr>
-   <td>Soporte básico</td>
-   <td>{{CompatUnknown()}}</td>
-   <td>{{CompatUnknown()}}</td>
-   <td>{{CompatGeckoMobile("4")}}</td>
-   <td>{{CompatUnknown()}}</td>
-   <td>10.60</td>
-   <td>{{CompatUnknown()}}</td>
-  </tr>
- </tbody>
-</table>
-</div>
+{{Compat}}
 
 <h2 id="Ver_también">Ver también</h2>
 

--- a/files/es/orphaned/web/api/navigatorlanguage/index.html
+++ b/files/es/orphaned/web/api/navigatorlanguage/index.html
@@ -10,6 +10,7 @@ tags:
   - TopicStub
 translation_of: Web/API/NavigatorLanguage
 original_slug: Web/API/NavigatorLanguage
+browser-compat: api.NavigatorLanguage
 ---
 <p>{{APIRef("HTML DOM")}}</p>
 
@@ -32,115 +33,13 @@ original_slug: Web/API/NavigatorLanguage
 
 <p><em>The </em><em><code>NavigatorLanguage</code></em><em> interface neither implements, nor inherit any method.</em></p>
 
-<h2 id="Specifications">Specifications</h2>
+<h2 id="Especificaciones">Especificaciones</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#navigatorlanguage', 'NavigatorLanguage')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Since the {{SpecName('HTML5 W3C')}} snapshot, the <code>languages</code> property has been added.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', '#navigatorlanguage', 'NavigatorLanguage')}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Initial specification; snapshot of  an early version{{SpecName('HTML WHATWG')}}.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
-<h2 id="Browser_compatibility">Browser compatibility</h2>
+<h2 id="Compatibilidad_de_Navegadores">Compatibilidad de Navegadores</h2>
 
-<p>{{ CompatibilityTable() }}</p>
-
-<div id="compat-desktop">
-<table class="compat-table">
- <tbody>
-  <tr>
-   <th>Feature</th>
-   <th>Chrome</th>
-   <th>Firefox (Gecko)</th>
-   <th>Internet Explorer</th>
-   <th>Opera</th>
-   <th>Safari</th>
-  </tr>
-  <tr>
-   <td>Basic support</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-  </tr>
-  <tr>
-   <td><code>languages</code></td>
-   <td>37</td>
-   <td>{{CompatGeckoDesktop("32")}}</td>
-   <td>{{CompatNo}}</td>
-   <td>24</td>
-   <td>{{CompatNo}}</td>
-  </tr>
-  <tr>
-   <td>on {{domxref("WorkerNavigator")}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatGeckoDesktop("35")}}</td>
-   <td>{{CompatNo}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatNo}}</td>
-  </tr>
- </tbody>
-</table>
-</div>
-
-<div id="compat-mobile">
-<table class="compat-table">
- <tbody>
-  <tr>
-   <th>Feature</th>
-   <th>Android</th>
-   <th>Chrome for Android</th>
-   <th>Firefox Mobile (Gecko)</th>
-   <th>IE Mobile</th>
-   <th>Opera Mobile</th>
-   <th>Safari Mobile</th>
-  </tr>
-  <tr>
-   <td>Basic support</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-  </tr>
-  <tr>
-   <td><code>languages</code></td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}} </td>
-   <td>{{CompatGeckoMobile("32")}}</td>
-   <td>{{CompatNo}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatNo}}</td>
-  </tr>
-  <tr>
-   <td>on {{domxref("WorkerNavigator")}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatGeckoMobile("35")}}</td>
-   <td>{{CompatNo}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatNo}}</td>
-  </tr>
- </tbody>
-</table>
-</div>
+{{Compat}}
 
 <h2 id="See_also">See also</h2>
 

--- a/files/es/orphaned/web/api/navigatorlanguage/language/index.html
+++ b/files/es/orphaned/web/api/navigatorlanguage/language/index.html
@@ -13,6 +13,7 @@ tags:
   - Solo lectura
 translation_of: Web/API/NavigatorLanguage/language
 original_slug: Web/API/NavigatorLanguage/language
+browser-compat: api.NavigatorLanguage.language
 ---
 <div>{{APIRef("HTML DOM")}}</div>
 
@@ -36,95 +37,11 @@ original_slug: Web/API/NavigatorLanguage/language
 
 <h2 id="Especificaciones">Especificaciones</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Especificación</th>
-   <th scope="col">Estado</th>
-   <th scope="col">Comentario</th>
-  </tr>
-  <tr>
-   <td>{{ SpecName('HTML5.1', '#dom-navigator-language', 'NavigatorLanguage.language') }}</td>
-   <td>{{ Spec2('HTML5.1') }}</td>
-   <td>Definición inicial</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
-<h2 id="Compatibilidad_en_navegadores">Compatibilidad en navegadores</h2>
+<h2 id="Compatibilidad_de_Navegadores">Compatibilidad de Navegadores</h2>
 
-<p>{{CompatibilityTable}}</p>
-
-<div id="compat-desktop">
-<table class="compat-table">
- <tbody>
-  <tr>
-   <th>Característica</th>
-   <th>Chrome</th>
-   <th>Firefox (Gecko)</th>
-   <th>Internet Explorer</th>
-   <th>Opera</th>
-   <th>Safari</th>
-  </tr>
-  <tr>
-   <td>Soporte básico</td>
-   <td>{{CompatVersionUnknown}}<sup>[1]</sup></td>
-   <td>{{CompatGeckoDesktop("1.0")}}<sup>[2]</sup><br>
-    {{CompatGeckoDesktop("5.0")}}<sup>[3]</sup></td>
-   <td>11.0<sup>[4]</sup></td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-  </tr>
-  <tr>
-   <td>sobre {{domxref("WorkerNavigator")}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatGeckoDesktop("35")}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-  </tr>
- </tbody>
-</table>
-</div>
-
-<div id="compat-mobile">
-<table class="compat-table">
- <tbody>
-  <tr>
-   <th>Característica</th>
-   <th>Android</th>
-   <th>Firefox Mobile (Gecko)</th>
-   <th>IE Mobile</th>
-   <th>Opera Mobile</th>
-   <th>Safari Mobile</th>
-  </tr>
-  <tr>
-   <td>Soporte básico</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatGeckoMobile(1.0)}}</td>
-   <td>{{CompatNo}}<sup>[4]</sup></td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-  </tr>
-  <tr>
-   <td>sobre {{domxref("WorkerNavigator")}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatGeckoDesktop("35")}}</td>
-   <td>{{CompatNo}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-  </tr>
- </tbody>
-</table>
-</div>
-
-<p>[1] Devuelve el lenguaje configurado para la interfaz del navegador, no el valor de la <strong><code>Accept-Language</code></strong> <a href="/en-US/docs/Web/HTTP/Headers">HTTP header</a>.</p>
-
-<p>[2] Antes de Gecko 2.0 {{geckoRelease("2.0")}}, el valor de esta propiedad fue también parte de la cadena de <strong>user agent</strong>, como se informa en {{domxref("window.navigator.userAgent", "navigator.userAgent")}}.</p>
-
-<p>[3] A partir de  Gecko 5.0 {{geckoRelease("5.0")}}, el valor de esta propiedad está basada en el valor de la <strong><code>Accept-Language</code></strong> <a href="en-US/docs/Web/HTTP/Headers">HTTP header</a>.</p>
-
-<p>[4] Otras propiedades disponibles (no estandarizadas) son: <code><a href="http://msdn.microsoft.com/en-us/library/ie/ms534713.aspx">userLanguage</a></code> y <code><a href="http://msdn.microsoft.com/en-us/library/ie/ms533542.aspx">browserLanguage</a></code>.</p>
+{{Compat}}
 
 <h2 id="Ver_también">Ver también</h2>
 

--- a/files/es/orphaned/web/api/navigatoronline/index.html
+++ b/files/es/orphaned/web/api/navigatoronline/index.html
@@ -8,6 +8,7 @@ tags:
   - TopicStub
 translation_of: Web/API/NavigatorOnLine
 original_slug: Web/API/NavigatorOnLine
+browser-compat: api.NavigatorOnLine
 ---
 <p>{{APIRef("HTML DOM")}}</p>
 
@@ -28,104 +29,13 @@ original_slug: Web/API/NavigatorOnLine
 
 <p><em>The </em><em><code>NavigatorOnLine</code></em><em> interface neither implements, nor inherit any method.</em></p>
 
-<h2 id="Specifications">Specifications</h2>
+<h2 id="Especificaciones">Especificaciones</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#navigatoronline', 'NavigatorOnLine')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change from the latest snapshot, {{SpecName('HTML5 W3C')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', '#navigatoronline', 'NavigatorOnLine')}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Snapshot of {{SpecName('HTML WHATWG')}} with its initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
-<h2 id="Browser_compatibility">Browser compatibility</h2>
+<h2 id="Compatibilidad_de_Navegadores">Compatibilidad de Navegadores</h2>
 
-<p>{{ CompatibilityTable() }}</p>
-
-<div id="compat-desktop">
-<table class="compat-table">
- <tbody>
-  <tr>
-   <th>Feature</th>
-   <th>Chrome</th>
-   <th>Edge</th>
-   <th>Firefox (Gecko)</th>
-   <th>Internet Explorer</th>
-   <th>Opera</th>
-   <th>Safari</th>
-  </tr>
-  <tr>
-   <td>Basic support</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-  </tr>
-  <tr>
-   <td>on {{domxref("WorkerNavigator")}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatGeckoDesktop(29)}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-  </tr>
- </tbody>
-</table>
-</div>
-
-<div id="compat-mobile">
-<table class="compat-table">
- <tbody>
-  <tr>
-   <th>Feature</th>
-   <th>Android</th>
-   <th>Chrome for Android</th>
-   <th>Edge</th>
-   <th>Firefox Mobile (Gecko)</th>
-   <th>IE Mobile</th>
-   <th>Opera Mobile</th>
-   <th>Safari Mobile</th>
-  </tr>
-  <tr>
-   <td>Basic support</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-  </tr>
-  <tr>
-   <td>on {{domxref("WorkerNavigator")}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatGeckoMobile(29)}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-  </tr>
- </tbody>
-</table>
-</div>
+{{Compat}}
 
 <h2 id="See_also">See also</h2>
 

--- a/files/es/orphaned/web/api/navigatoronline/online/index.html
+++ b/files/es/orphaned/web/api/navigatoronline/online/index.html
@@ -3,6 +3,7 @@ title: Navigator.onLine
 slug: orphaned/Web/API/NavigatorOnLine/onLine
 translation_of: Web/API/NavigatorOnLine/onLine
 original_slug: Web/API/NavigatorOnLine/onLine
+browser-compat: api.NavigatorOnLine.onLine
 ---
 <div>{{ApiRef("HTML DOM")}}</div>
 
@@ -48,111 +49,11 @@ window.addEventListener('online', function(e) { console.log('online'); });
 
 <h2 id="Especificaciones">Especificaciones</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Especificación</th>
-   <th scope="col">Estado</th>
-   <th scope="col">Comentario</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "browsers.html#navigator.online", "navigator.onLine")}}</td>
-   <td>{{Spec2("HTML WHATWG")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
-<h2 id="Compatibilidad_de_navegadores">Compatibilidad de navegadores</h2>
+<h2 id="Compatibilidad_de_Navegadores">Compatibilidad de Navegadores</h2>
 
-<p>{{CompatibilityTable}}</p>
-
-<div id="compat-desktop">
-<table class="compat-table">
- <tbody>
-  <tr>
-   <th>Feature</th>
-   <th>Chrome</th>
-   <th>Edge</th>
-   <th>Firefox (Gecko)</th>
-   <th>Internet Explorer</th>
-   <th>Opera</th>
-   <th>Safari (WebKit)</th>
-  </tr>
-  <tr>
-   <td>Basic support</td>
-   <td>{{CompatVersionUnknown}}<sup>[1]</sup></td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatGeckoDesktop(1.9.1)}}<sup>[2]</sup><br>
-    {{CompatGeckoDesktop(2.0)}}<sup>[4]</sup></td>
-   <td>8<sup>[3]</sup></td>
-   <td>{{CompatNo}}<sup>[2]</sup></td>
-   <td>5.0.4</td>
-  </tr>
-  <tr>
-   <td>on {{domxref("WorkerNavigator")}}</td>
-   <td>Yes</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatGeckoDesktop(29)}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-  </tr>
- </tbody>
-</table>
-</div>
-
-<div id="compat-mobile">
-<table class="compat-table">
- <tbody>
-  <tr>
-   <th>Feature</th>
-   <th>Android</th>
-   <th>Edge</th>
-   <th>Firefox Mobile (Gecko)</th>
-   <th>IE Phone</th>
-   <th>Opera Mobile</th>
-   <th>Safari Mobile</th>
-   <th>BlackBerry</th>
-  </tr>
-  <tr>
-   <td>Basic support</td>
-   <td>2.2<sup>[5]</sup></td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatGeckoMobile(1.9.1)}}<sup>[2]</sup></td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>
-    <p>7<br>
-     10</p>
-   </td>
-  </tr>
-  <tr>
-   <td>on {{domxref("WorkerNavigator")}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatGeckoMobile(29)}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-  </tr>
- </tbody>
-</table>
-</div>
-
-<p>[1] Earlier versions of Chrome incorrectly return <code>true</code> when a tab is first opened, but it starts reporting the correct connectivity status after the first network event. Windows: 11, Mac: 14, Chrome OS: 13, Linux: Always returns <code>true</code>. For history, see <a href="http://crbug.com/7469">crbug.com/7469</a>.</p>
-
-<p>[2] Since Firefox 4, and Opera 11.10, the browser returns <code>true</code> when "Work Offline" mode is disabled and <code>false</code> when it is enabled, regardless of actual connectivity.</p>
-
-<p>[3] in Internet Explorer 8 "online" and "offline" events are raised on the <code>document.body</code>; under IE 9 they are raised on both <code>document.body</code> and <code>window</code>.</p>
-
-<p>[4] Since Firefox 41, on OS X and Windows, the returned values follow the actual network connectivity, unless "Work offline" mode is selected (where it will always return <code>false</code>).</p>
-
-<p>[5] Faulty in a WebView component, see Issue <a href="http://code.google.com/p/android/issues/detail?id=16760">bug 16760</a>.</p>
+{{Compat}}
 
 <h2 id="Notas">Notas</h2>
 

--- a/files/es/web/api/fileerror/index.html
+++ b/files/es/web/api/fileerror/index.html
@@ -2,6 +2,7 @@
 title: FileError
 slug: Web/API/FileError
 translation_of: Web/API/FileError
+browser-compat: api.FileError
 ---
 <p>{{APIRef("File System API")}}{{obsolete_header()}}</p>
 
@@ -124,63 +125,13 @@ translation_of: Web/API/FileError
  </tbody>
 </table>
 
-<h2 id="Browser_Compatibility" name="Browser_Compatibility">Browser compatibility</h2>
+<h2 id="Especificaciones">Especificaciones</h2>
 
-<p>{{ CompatibilityTable() }}</p>
+{{Specifications}}
 
-<div id="compat-desktop">
-<table class="compat-table">
- <tbody>
-  <tr>
-   <th>Feature</th>
-   <th>Chrome</th>
-   <th>Firefox (Gecko)</th>
-   <th>Internet Explorer</th>
-   <th>Opera</th>
-   <th>Safari (WebKit)</th>
-  </tr>
-  <tr>
-   <td>Basic support</td>
-   <td>13{{ property_prefix("webkit") }}</td>
-   <td>{{ CompatNo() }}</td>
-   <td>{{ CompatNo() }}</td>
-   <td>{{ CompatNo() }}</td>
-   <td>{{ CompatNo() }}</td>
-  </tr>
- </tbody>
-</table>
-</div>
+<h2 id="Compatibilidad_de_Navegadores">Compatibilidad de Navegadores</h2>
 
-<div id="compat-mobile">
-<table class="compat-table">
- <tbody>
-  <tr>
-   <th>Feature</th>
-   <th>Android</th>
-   <th>Chrome for Android</th>
-   <th>Firefox Mobile (Gecko)</th>
-   <th>IE Phone</th>
-   <th>Opera Mobile</th>
-   <th>Safari Mobile</th>
-  </tr>
-  <tr>
-   <td>Basic support</td>
-   <td>{{ CompatNo() }}</td>
-   <td>0.16{{ property_prefix("webkit") }}</td>
-   <td>{{ CompatNo() }}</td>
-   <td>{{ CompatNo() }}</td>
-   <td>{{ CompatNo() }}</td>
-   <td>{{ CompatNo() }}</td>
-  </tr>
- </tbody>
-</table>
-</div>
-
-<h3 id="Gecko_notes">Gecko notes</h3>
-
-<ul>
- <li>The <code>FileError</code> interface has been removed starting with Gecko 13 {{ geckoRelease("13.0") }}. Instead the more general {{ domxref("DOMError") }} interface is used and returned by {{ domxref("FileReader", "FileReader.error") }}.</li>
-</ul>
+{{Compat}}
 
 <h2 id="See_also">See also</h2>
 

--- a/files/es/web/html/global_attributes/dir/index.html
+++ b/files/es/web/html/global_attributes/dir/index.html
@@ -7,6 +7,7 @@ tags:
   - Referencia
 translation_of: Web/HTML/Global_attributes/dir
 original_slug: Web/HTML/Atributos_Globales/dir
+browser-compat: html.global_attributes.dir
 ---
 <p class="note">{{HTMLSidebar("Global_attributes")}}</p>
 
@@ -33,89 +34,11 @@ original_slug: Web/HTML/Atributos_Globales/dir
 
 <h2 id="Especificaciones">Especificaciones</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Especificación</th>
-   <th scope="col">Estatus</th>
-   <th scope="col">Comentario</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "dom.html#the-dir-attribute", "dir")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Sin cambio desde el último snapshot, {{SpecName('HTML5.1')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "dom.html#the-dir-attribute", "dir")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>Snapshot de  {{SpecName('HTML WHATWG')}}, sin cambio desde  {{SpecName('HTML5 W3C')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C', "dom.html#the-dir-attribute", "dir")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Snapshot de {{SpecName('HTML WHATWG')}}, desde  {{SpecName('HTML4.01')}} añadió el valor auto y ahora es un verdadero atributo global .</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML4.01', "dirlang.html#h-8.2", "dir")}}</td>
-   <td>{{Spec2('HTML4.01')}}</td>
-   <td>Soportado en todos los elementos pero no en {{HTMLElement("applet")}}, {{HTMLElement("base")}}, {{HTMLElement("basefont")}}, {{HTMLElement("bdo")}}, {{HTMLElement("br")}}, {{HTMLElement("frame")}}, {{HTMLElement("frameset")}}, {{HTMLElement("iframe")}}, {{HTMLElement("param")}}, y {{HTMLElement("script")}}.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
-<h2 id="Compatibilidad_en_exploradores">Compatibilidad en exploradores</h2>
+<h2 id="Compatibilidad_de_Navegadores">Compatibilidad de Navegadores</h2>
 
-{{Compat("html.global_attributes.dir")}}
-
-<h2 id="CompatibilityTable()"><span style="font-size: 14px; font-weight: normal; line-height: 1.5;">{{ CompatibilityTable() }}</span></h2>
-
-<div id="compat-desktop">
-<table class="compat-table">
- <tbody>
-  <tr>
-   <th>Caracteristica</th>
-   <th>Chrome</th>
-   <th>Firefox (Gecko)</th>
-   <th>Internet Explorer</th>
-   <th>Opera</th>
-   <th>Safari</th>
-  </tr>
-  <tr>
-   <td>Soporte básico</td>
-   <td>{{ CompatVersionUnknown() }}</td>
-   <td>{{ CompatVersionUnknown() }}</td>
-   <td>{{ CompatVersionUnknown() }}</td>
-   <td>{{ CompatVersionUnknown() }}</td>
-   <td>{{ CompatVersionUnknown() }}</td>
-  </tr>
- </tbody>
-</table>
-</div>
-
-<div id="compat-mobile">
-<table class="compat-table">
- <tbody>
-  <tr>
-   <th>Caracterísitica</th>
-   <th>Android</th>
-   <th>Chrome for Android</th>
-   <th>Firefox Mobile (Gecko)</th>
-   <th>IE Mobile</th>
-   <th>Opera Mobile</th>
-   <th>Safari Mobile</th>
-  </tr>
-  <tr>
-   <td>Soporte básico</td>
-   <td>{{ CompatVersionUnknown() }}</td>
-   <td>{{ CompatVersionUnknown() }}</td>
-   <td>{{ CompatVersionUnknown() }}</td>
-   <td>{{ CompatVersionUnknown() }}</td>
-   <td>{{ CompatVersionUnknown() }}</td>
-   <td>{{ CompatVersionUnknown() }}</td>
-  </tr>
- </tbody>
-</table>
-</div>
+{{Compat}}
 
 <h2 id="See_also">See also</h2>
 

--- a/files/es/web/html/global_attributes/draggable/index.html
+++ b/files/es/web/html/global_attributes/draggable/index.html
@@ -8,6 +8,7 @@ tags:
   - Referencia
 translation_of: Web/HTML/Global_attributes/draggable
 original_slug: Web/HTML/Atributos_Globales/draggable
+browser-compat: html.global_elements.draggable
 ---
 <p class="note">{{HTMLSidebar("Global_attributes")}}{{SeeCompatTable}}</p>
 
@@ -28,81 +29,11 @@ original_slug: Web/HTML/Atributos_Globales/draggable
 
 <h2 id="Especificaciones">Especificaciones</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Especificación</th>
-   <th scope="col">Estatus</th>
-   <th scope="col">Comentario</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', "interaction.html#the-draggable-attribute", "draggable")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Sin cambio desde el último snapshot, {{SpecName('HTML5.1')}}</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', "editing.html#the-draggable-attribute", "draggable")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>Snapshot de {{SpecName('HTML WHATWG')}}, definición inicial .</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
-<h2 id="Compatibilidad_en_exploradores">Compatibilidad en exploradores</h2>
+<h2 id="Compatibilidad_de_Navegadores">Compatibilidad de Navegadores</h2>
 
-{{Compat("html.global_attributes.draggable")}}
-
-<h2 id="CompatibilityTable()"><span style="font-size: 14px; font-weight: normal; line-height: 1.5;">{{ CompatibilityTable() }}</span></h2>
-
-<div id="compat-desktop">
-<table class="compat-table">
- <tbody>
-  <tr>
-   <th>Caracterísitica</th>
-   <th>Chrome</th>
-   <th>Firefox (Gecko)</th>
-   <th>Internet Explorer</th>
-   <th>Opera</th>
-   <th>Safari</th>
-  </tr>
-  <tr>
-   <td>Soporte básico</td>
-   <td>{{ CompatVersionUnknown() }}</td>
-   <td>{{ CompatGeckoDesktop("1.8.1") }}</td>
-   <td>{{ CompatVersionUnknown() }}</td>
-   <td>{{ CompatVersionUnknown() }}</td>
-   <td>{{ CompatVersionUnknown() }}</td>
-  </tr>
- </tbody>
-</table>
-</div>
-
-<div id="compat-mobile">
-<table class="compat-table">
- <tbody>
-  <tr>
-   <th>Caracterísitica</th>
-   <th>Android</th>
-   <th>Chrome for Android</th>
-   <th>Firefox Mobile (Gecko)</th>
-   <th>IE Mobile</th>
-   <th>Opera Mobile</th>
-   <th>Safari Mobile</th>
-  </tr>
-  <tr>
-   <td>Soporte básico</td>
-   <td>{{ CompatVersionUnknown() }}</td>
-   <td>{{ CompatVersionUnknown() }}</td>
-   <td>{{ CompatGeckoMobile("1.8.1") }}</td>
-   <td>{{ CompatVersionUnknown() }}</td>
-   <td>{{ CompatVersionUnknown() }}</td>
-   <td>{{ CompatVersionUnknown() }}</td>
-  </tr>
- </tbody>
-</table>
-</div>
-
-<p> </p>
+{{Compat}}
 
 <p><span style="font-size: 30.002px; letter-spacing: -1px; line-height: 30.002px;"><strong>Ver también</strong></span></p>
 

--- a/files/es/web/javascript/reference/global_objects/date/getmilliseconds/index.html
+++ b/files/es/web/javascript/reference/global_objects/date/getmilliseconds/index.html
@@ -7,6 +7,7 @@ tags:
   - Prototipo
 translation_of: Web/JavaScript/Reference/Global_Objects/Date/getMilliseconds
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Date/getMilliseconds
+browser-compat: javascript.builtins.Date.getMilliseconds
 ---
 <div>{{JSRef}}</div>
 
@@ -62,59 +63,13 @@ var milisegundos = ahora.getMilliseconds();
  </tbody>
 </table>
 
+<h2 id="Especificaciones">Especificaciones</h2>
+
+{{Specification}}
+
 <h2 id="Compatibilidad_en_Navegadores">Compatibilidad en Navegadores</h2>
 
-{{Compat("javascript.builtins.Date.getMilliseconds")}}
-
-<h2 id="CompatibilityTable">{{CompatibilityTable}}</h2>
-
-<div id="compat-desktop">
-<table class="compat-table">
- <tbody>
-  <tr>
-   <th>Feature</th>
-   <th>Chrome</th>
-   <th>Firefox (Gecko)</th>
-   <th>Internet Explorer</th>
-   <th>Opera</th>
-   <th>Safari</th>
-  </tr>
-  <tr>
-   <td>Basic support</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-  </tr>
- </tbody>
-</table>
-</div>
-
-<div id="compat-mobile">
-<table class="compat-table">
- <tbody>
-  <tr>
-   <th>Feature</th>
-   <th>Android</th>
-   <th>Chrome for Android</th>
-   <th>Firefox Mobile (Gecko)</th>
-   <th>IE Mobile</th>
-   <th>Opera Mobile</th>
-   <th>Safari Mobile</th>
-  </tr>
-  <tr>
-   <td>Basic support</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-   <td>{{CompatVersionUnknown}}</td>
-  </tr>
- </tbody>
-</table>
-</div>
+{{Compat}}
 
 <h2 id="Vea_también">Vea también</h2>
 

--- a/files/es/web/javascript/reference/statements/let/index.html
+++ b/files/es/web/javascript/reference/statements/let/index.html
@@ -11,6 +11,7 @@ tags:
   - sentencias
 translation_of: Web/JavaScript/Reference/Statements/let
 original_slug: Web/JavaScript/Referencia/Sentencias/let
+browser-compat: javascript.statements.let
 ---
 <div>{{jsSidebar("Statements")}}</div>
 
@@ -257,136 +258,11 @@ console.log(a); // 5</pre>
 
 <h2 id="Especificaciones">Especificaciones</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Especificación</th>
-   <th scope="col">Estado</th>
-   <th scope="col">Comentarios</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ES2015', '#sec-let-and-const-declarations', 'Let and Const Declarations')}}</td>
-   <td>{{Spec2('ES2015')}}</td>
-   <td>Definición initial. No especifica expresiones ni declaraciones let.</td>
-  </tr>
- </tbody>
-</table>
+{{Specification}}
 
 <h2 id="Compatibilidad_en_navegadores">Compatibilidad en navegadores</h2>
 
-{{Compat("javascript.statements.let")}}
-
-<h2 id="CompatibilityTable"><span style="font-size: 14px; font-weight: normal; line-height: 1.5;">{{CompatibilityTable}}</span></h2>
-
-<div id="compat-desktop">
-<table class="compat-table">
- <tbody>
-  <tr>
-   <th>Característica</th>
-   <th>Chrome</th>
-   <th>Firefox (Gecko)</th>
-   <th>Internet Explorer</th>
-   <th>Opera</th>
-   <th>Safari</th>
-  </tr>
-  <tr>
-   <td>Soporte básico</td>
-   <td>
-    <p class="p1">{{CompatChrome(41.0)}}</p>
-   </td>
-   <td>{{ CompatGeckoDesktop("1.8.1") }} [1]</td>
-   <td>11</td>
-   <td>17</td>
-   <td>{{CompatUnknown}}</td>
-  </tr>
-  <tr>
-   <td>Zona muerta temporal</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{ CompatGeckoDesktop("35") }} [1]</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-  </tr>
-  <tr>
-   <td>Expresión<code> let</code> {{non-standard_inline}}</td>
-   <td>{{CompatNo}}</td>
-   <td>{{ CompatGeckoDesktop("1.8.1") }}-{{ CompatGeckoDesktop("40") }} [1]</td>
-   <td>{{CompatNo}}</td>
-   <td>{{CompatNo}}</td>
-   <td>{{CompatNo}}</td>
-  </tr>
-  <tr>
-   <td>Bloque<code> let</code> {{non-standard_inline}}</td>
-   <td>{{CompatNo}}</td>
-   <td>{{ CompatGeckoDesktop("1.8.1") }} [1]</td>
-   <td>{{CompatNo}}</td>
-   <td>{{CompatNo}}</td>
-   <td>{{CompatNo}}</td>
-  </tr>
- </tbody>
-</table>
-</div>
-
-<div id="compat-mobile">
-<table class="compat-table">
- <tbody>
-  <tr>
-   <th>Característica</th>
-   <th>Android</th>
-   <th>Chrome para Android</th>
-   <th>Firefox Mobile (Gecko)</th>
-   <th>IE Mobile</th>
-   <th>Opera Mobile</th>
-   <th>Safari Mobile</th>
-  </tr>
-  <tr>
-   <td>Soporte básico</td>
-   <td>{{CompatUnknown}}</td>
-   <td>
-    <p class="p1">{{CompatChrome(41.0)}}</p>
-   </td>
-   <td>{{ CompatGeckoMobile("1.8.1") }} [1]</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-  </tr>
-  <tr>
-   <td>Zona muerta temporal</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{ CompatGeckoMobile("35") }} [1]</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-   <td>{{CompatUnknown}}</td>
-  </tr>
-  <tr>
-   <td>Expresión<code> let</code> {{non-standard_inline}}</td>
-   <td>{{CompatNo}}</td>
-   <td>{{CompatNo}}</td>
-   <td>{{ CompatGeckoMobile("1.8.1") }}-{{ CompatGeckoMobile("40") }}[1]</td>
-   <td>{{CompatNo}}</td>
-   <td>{{CompatNo}}</td>
-   <td>{{CompatNo}}</td>
-  </tr>
-  <tr>
-   <td>Bloque<code> let</code> {{non-standard_inline}}</td>
-   <td>{{CompatNo}}</td>
-   <td>{{CompatNo}}</td>
-   <td>{{ CompatGeckoMobile("1.8.1") }} [1]</td>
-   <td>{{CompatNo}}</td>
-   <td>{{CompatNo}}</td>
-   <td>{{CompatNo}}</td>
-  </tr>
- </tbody>
-</table>
-</div>
-
-<h3 id="Notas_específicas_a_Firefox">Notas específicas a Firefox</h3>
-
-<ul>
- <li>[1]: Solo disponible para bloques de codigo HTML dentro de una etiqueta <code>&lt;script&gt; type="application/javascript;version=1.7"&gt;</code> (o de una versión mayor). Es necesario tomar en cuenta que esta es una característica no estándar, esto puede crear conflictos con otros navegadores. Las etiquetas <a href="https://developer.mozilla.org/en-US/docs/XUL">XUL</a> tienen acceso a esas características sin necesidad de dicho bloque. Ver<span style="line-height: 1.5;">{{bug(932513)}}.</span></li>
- <li>Conformidad con ES2015 para <code>let</code> en SpIderMonkey es monitoreado en {{bug(950547)}} y extensiones no-standar seran eliminadas en el futuro {{bug(1023609)}}.</li>
-</ul>
+{{Compat}}
 
 <h2 id="Ver_también">Ver también</h2>
 


### PR DESCRIPTION
This PR removes all of the old-style compatibility and specification tables from Spanish translations, replacing them with new compatibility tables from BCD.  This includes conflicting and orphaned files, but does not include `WindowOrWorkerGlobalScope` because I plan to delete it entirely in a separate PR.
