### PR TITLE
Remove `{{wiki.localize}}` macro from `fr`

### DIFF
--- a/files/fr/web/exslt/exsl/index.md
+++ b/files/fr/web/exslt/exsl/index.md
@@ -1,6 +1,15 @@
 ---
-title: exsl
+title: Common (exsl)
 slug: Web/EXSLT/exsl
 translation_of: Web/EXSLT/exsl
 ---
-{{wiki.localize('System.API.page-generated-for-subpage')}}
+{{XSLTRef}}{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}
+
+Le paquet EXSLT <i lang="en">Common</i> fournit des fonctionnalités de base qui étendent celles de XSLT. L'espace de noms pour ce paquet est `http://exslt.org/common`.
+
+{{SubpagesWithSummaries}}
+
+## Compatibilité des navigateurs
+
+{{Compat("xslt.exslt.exsl")}}
+

--- a/files/fr/web/exslt/math/index.md
+++ b/files/fr/web/exslt/math/index.md
@@ -1,6 +1,14 @@
 ---
-title: math
+title: Math (math)
 slug: Web/EXSLT/math
 translation_of: Web/EXSLT/math
 ---
-{{wiki.localize('System.API.page-generated-for-subpage')}}
+{{XSLTRef}}{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}
+
+Le paquet EXSLT Math fournit des fonctions pour manipuler des valeurs numériques et comparer des nœuds. L'espace de noms pour ce paquet est `http://exslt.org/math`.
+
+{{SubpagesWithSummaries}}
+
+## Compatibilité des navigateurs
+
+{{Compat("xslt.exslt.math")}}

--- a/files/fr/web/exslt/set/index.md
+++ b/files/fr/web/exslt/set/index.md
@@ -1,6 +1,14 @@
 ---
-title: set
+title: Sets (set)
 slug: Web/EXSLT/set
 translation_of: Web/EXSLT/set
 ---
-{{wiki.localize('System.API.page-generated-for-subpage')}}
+{{XSLTRef}}{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}
+
+Le paquet EXSLT <i lang="en">Sets</i> fournit des fonctions pour manipuler des ensembles. L'espace de noms pour ces fonctions est `http://exslt.org/sets`.
+
+{{SubpagesWithSummaries}}
+
+## Compatibilité des navigateurs
+
+{{Compat("xslt.exslt.set")}}

--- a/files/fr/web/exslt/str/index.md
+++ b/files/fr/web/exslt/str/index.md
@@ -1,6 +1,14 @@
 ---
-title: str
+title: Strings (str)
 slug: Web/EXSLT/str
 translation_of: Web/EXSLT/str
 ---
-{{wiki.localize('System.API.page-generated-for-subpage')}}
+{{XSLTRef}}{{QuickLinksWithSubpages("/fr/docs/Web/EXSLT")}}
+
+Le paquet EXSLT <i lang="en">Strings</i> fournit des fonctions pour la manipulation de chaînes de caractères. L'espace de noms pour ce paquet est `http://exslt.org/strings`.
+
+{{SubpagesWithSummaries}}
+
+## Compatibilité des navigateurs
+
+{{Compat("xslt.exslt.str")}}


### PR DESCRIPTION
I updated the 4 small pages which had this one.