### PR TITLE
Remove `{{h3_gecko_minversion}}` for inactive locales

### DIFF
--- a/files/de/web/api/console/index.html
+++ b/files/de/web/api/console/index.html
@@ -180,10 +180,6 @@ console.info("My first car was a", car, ". The object is:", someObject);</pre>
 <p><strong>Hinweis:</strong> Es werden etliche CSS-Eigenschaften von diesem Stil unterstützt. Sie sollten experimentieren und sehen, welche sich als nützlich erweisen.</p>
 </div>
 
-<div> </div>
-
-<div>{{h3_gecko_minversion("Gruppen in der Konsole verwenden", "9.0")}}</div>
-
 <p>Sie können verschachtelte Gruppen verwenden, um Ihre Ausgabe zu organisieren, indem Sie verwandtes Material visuell kombinieren. Um einen neuen verschachtelten Block zu erstellen, rufen Sie <code>console.group()</code> auf. Die Methode <code>console.groupCollapsed()</code> ist ähnlich, erstellt den neuen Block jedoch zusammengeklappt und erfordert die Verwendung einer Schaltfläche zum Öffnen.</p>
 
 <div class="note"><strong>Hinweis:</strong> Minimierte Gruppen werden in Gecko noch nicht unterstützt. Die Methode <code>groupCollapsed()</code> ist zu diesem Zeitpunkt die gleiche wie <code>group()</code>.</div>
@@ -205,8 +201,6 @@ console.debug("Back to the outer level");
 <p>Die Ausgabe sieht folgendermaßen aus:</p>
 
 <p><img alt="nesting.png" class="default internal" src="/@api/deki/files/6082/=nesting.png"></p>
-
-<div>{{h3_gecko_minversion("Timer", "10.0")}}</div>
 
 <p>Um die Dauer einer bestimmten Operation zu berechnen, hat Gecko 10 die Unterstützung von Timern im <code>console</code>-Objekt eingeführt. Um einen Timer zu starten, rufen Sie die Methode <code>console.time</code><code>()</code> auf und geben Sie ihm als einzigen Parameter einen Namen. Um den Timer zu stoppen und die verstrichene Zeit in Millisekunden abzurufen, rufen Sie einfach die Methode <code>console.timeEnd()</code> auf und übergeben den Namen des Timers erneut als Parameter. Auf einer Seite können bis zu 10.000 Timer gleichzeitig ausgeführt werden.</p>
 

--- a/files/pl/web/api/console/index.html
+++ b/files/pl/web/api/console/index.html
@@ -139,8 +139,6 @@ console.info("My first car was a", car, ". The object is: ", someObject);</pre>
 
 <div><img alt="" src="https://mdn.mozillademos.org/files/7739/console-style.png" style="display: block; height: 52px; margin-left: auto; margin-right: auto; width: 293px;"></div>
 
-<div>{{h3_gecko_minversion("Using groups in the console", "9.0")}}</div>
-
 <p>You can use nested groups to help organize your output by visually combining related material. To create a new nested block, call <code>console.group()</code>. The <code>console.groupCollapsed()</code> method is similar, but creates the new block collapsed, requiring the use of a disclosure button to open it for reading.</p>
 
 <div class="note"><strong>Note:</strong> Collapsed groups are not supported yet in Gecko; the <code>groupCollapsed()</code> method is the same as <code>group()</code> at this time.</div>
@@ -164,8 +162,6 @@ console.debug("Back to the outer level");
 <p>The output looks like this:</p>
 
 <p><img alt="nesting.png" class="default internal" src="/@api/deki/files/6082/=nesting.png"></p>
-
-<div>{{h3_gecko_minversion("Timers", "10.0")}}</div>
 
 <p>In order to calculate the duration of a specific operation, Gecko 10 introduced the support of timers in the <code>console</code> object. To start a timer, call the <code>console.time</code><code>()</code> method, giving it a name as only parameter. To stop the timer, and to get the elapsed time in miliseconds, just call the <code>console.timeEnd()</code> method, again passing the timer's name as the parameter. Up to 10,000 timers can run simultaneously on a given page.</p>
 


### PR DESCRIPTION
Follow-up of https://github.com/mdn/translated-content/issues/5145 for `de` and `pl` which had occurrences of it.