### PR TITLE
zh-cn: Update html_basics/index.html

### DIFF
--- a/files/zh-cn/learn/getting_started_with_the_web/html_basics/index.html
+++ b/files/zh-cn/learn/getting_started_with_the_web/html_basics/index.html
@@ -147,7 +147,7 @@ translation_of: Learn/Getting_started_with_the_web/HTML_basics
 <p>可以尝试在 {{htmlelement("img")}} 元素上面添加一个合适的标题。</p>
 
 <div class="blockIndicator note">
-<p>注：可以发现 MDN 网站上 第一级标题的主题是隐藏的。不要使用标题元素来加大、加粗字体，因为标题对于 <a href="/zh-CN/docs/learn/Accessibility">无障碍访问</a> 和 <a href="/zh-CN/docs/learn/HTML/Introduction_to_HTML/HTML_text_fundamentals#为什么我们需要结构化">搜索引擎优化</a> 等问题非常有意义。要保持页面结构清晰，标题整洁，不要发生标题级别跳跃。</p>
+<p>注：你可以看到第一级标题是有隐式的主题样式。不要使用标题元素来加大、加粗字体，因为标题对于 <a href="/zh-CN/docs/learn/Accessibility">无障碍访问</a> 和 <a href="/zh-CN/docs/learn/HTML/Introduction_to_HTML/HTML_text_fundamentals#为什么我们需要结构化">搜索引擎优化</a> 等问题非常有意义。要保持页面结构清晰，标题整洁，不要发生标题级别跳跃。</p>
 </div>
 
 <h3 id="段落（Paragraph）">段落（Paragraph）</h3>


### PR DESCRIPTION
change note in zh-cn/learn/getting_started_with_the_web/html_basics
page link: [HTML_basics#标记文本](https://developer.mozilla.org/zh-CN/docs/Learn/Getting_started_with_the_web/HTML_basics#%E6%A0%87%E8%AE%B0%E6%96%87%E6%9C%AC)

我认为 "可以发现 MDN 网站上 第一级标题的主题是隐藏的" 这个描述会被误解为 "第一级标题是隐藏了的"。

这个pr的更改对照英文版本 "Note: You'll see that your heading level 1 has an implicit style."，将"implicit style"翻译为"隐式的主题样式"。