### PR TITLE
Remove `{{DiscussionList}}` from fr (excl. `conflicting`)

### DIFF
--- a/files/fr/web/guide/ajax/index.md
+++ b/files/fr/web/guide/ajax/index.md
@@ -3,259 +3,50 @@ title: AJAX
 slug: Web/Guide/AJAX
 translation_of: Web/Guide/AJAX
 ---
-**AJAX (Asynchronous JavaScript + XML)** n'est pas une technologie en soi, mais un terme désignant une «&nbsp;nouvelle&nbsp;» approche utilisant un ensemble de technologies existantes, dont&nbsp;: [HTML](/fr/HTML "fr/HTML") ou [XHTML](/fr/XHTML "fr/XHTML"), [les feuilles de styles CSS](/fr/CSS "fr/CSS"), [JavaScript](/fr/JavaScript "fr/JavaScript"), [le modèle objet de document](/fr/DOM "fr/DOM") (DOM), [XML](/fr/XML "fr/XML"), [XSLT](/fr/XSLT "fr/XSLT"), et l'[objet XMLHttpRequest](/fr/XMLHttpRequest "fr/XMLHttpRequest"). Lorsque ces technologies sont combinées dans le modèle AJAX, les applications Web sont capables de réaliser des mises à jour rapides et incrémentielles de l'interface utilisateur sans devoir recharger la page entière du navigateur. Les applications fonctionnent plus rapidement et sont plus réactives aux actions de l'utilisateur.
 
-#### **Quand utiliser (ou non) AJAX ?**
+**AJAX (<i lang="en">Asynchronous JavaScript + XML</i>)** n'est pas une technologie en soi, mais un terme désignant une «&nbsp;nouvelle&nbsp;» approche utilisant un ensemble de technologies existantes, dont&nbsp;: [HTML](/fr/docs/Web/HTML) ou [XHTML](/fr/docs/Glossary/XHTML), [CSS](/fr/docs/Web/CSS), [JavaScript](/fr/docs/Web/JavaScript), [DOM](/fr/docs/Web/API/Document_Object_Model), [XML](/fr/docs/Web/XML), [XSLT](/fr/docs/Web/XSLT), et surtout [l'objet `XMLHttpRequest`](/fr/docs/Web/API/XMLHttpRequest). Lorsque ces technologies sont combinées dans le modèle AJAX, les applications web sont capables de réaliser des mises à jour rapides et incrémentales de l'interface utilisateur sans devoir recharger la page entière dans le navigateur. Les applications fonctionnent plus rapidement et sont plus réactives aux actions de l'utilisatrice ou de l'utilisateur.
 
-S'il n'y a pas de "bonne réponse", quelques éléments généraux sont à garder à mémoire :
+Bien que le X de AJAX signifie XML, c'est le format [`JSON`](/fr/docs/Glossary/JSON) qui est le plus souvent utilisé aujourd'hui à la place de XML, du fait de sa proximité avec JavaScript et de sa légèreté par rapport à XML. Autrement dit, tant JSON que XML peuvent être utilisés comme format afin d'empaqueter des données en AJAX.
 
-- La méthode AJAX peut être résumée comme un compromis : elle évite un rechargement complet de la page mais **n'autorise pas davantage** que ce qu'apporte une requête HTTP GET ou POST (ou HEAD) classique. Les échanges sont plutôt lourds car, même pour peu d'éléments, le navigateur **doit** envoyer des entêtes et négocier la transaction.
-  La méthode est alors intérressante pour tous les sites où le contenu est changé peu fréquemment et reste prévisible : un blog, un forum, etc. où c'est l'utilisateur qui décide de changer le contenu (_le serveur ne peut pas être à l'initiative, sauf à faire des requêtes régulièrement mais il serait alors préférable de passer par les [WebSockets](https://developer.mozilla.org/fr/docs/WebSockets)_).
-- La méthode AJAX a comme qualité de rester dans les standards HTTP, en plus d'être du côté client : c'est donc une méthode qui est **totalement** transparente dans les échanges standards entre un client et un serveur, donc avec tous les langages de programmes qui supportent une connexion socket classique. C'est important à garder à l'esprit dans des environnements mixtes : un serveur Apache / PHP pour la génération de pages maîtresses et un contenu déployé dans un autre langage.
-  Ne pas confondre *possible* et *souhaitable*&nbsp;: AJAX **peut** négocier avec plusieurs domaines différents ou (des ports différents dans un même domaine). Cependant pour des [raisons de sécurité](https://developer.mozilla.org/fr/docs/HTTP/Access_control_CORS) les possibilités sont restreintes voire impossibles. La méthode AJAX est donc dépendante de ce qu'autorise ou permet le navigateur du client.
-- La méthode AJAX est connue et reconnue, pouvant être utilisées à large échelle dans des bibliothèques comme [JQuery](https://fr.wikipedia.org/wiki/JQuery), dont l'intérêt de ces bibliothéques est d'accélérer la vitesse de développement. De plus l'utilisation de Javascript permet d'accéder aux ressources du DOM de la page et des données reçues si elles sont au format XML, permettant la sérialisation dans la plupart des situations.
-  Cependant AJAX rencontre aussi les difficultés liées à la grande hétérogénité des navigateurs (implantation différente de JS, donc _in fine_ des possibilités AJAX), des règles de sécurité, etc. Comme pour CSS, AJAX peut être vu comme un "plus" dans la navigation (_voir le principe de [dégradation élégante](https://fr.wikipedia.org/wiki/Am%C3%A9lioration_progressive)_) mais ne doit pas être vu comme une finalité au risque, sinon, de se couper d'une partie des utilisateurs.
+## Documentation
 
-<table>
-  <tbody>
-    <tr>
-      <td>
-        <h2 class="Documentation" id="Documentation">Documentation</h2>
-        <dl>
-          <dt>
-            <a href="/fr/AJAX/Premiers_pas" title="fr/AJAX/Premiers_pas"
-              >AJAX:Premiers pas</a
-            >
-          </dt>
-          <dd>
-            <small
-              >Cet article vous guide à travers les bases d'AJAX et vous donne
-              deux exemples simples pour commencer.</small
-            >
-          </dd>
-        </dl>
-        <dl>
-          <dt>
-            <a
-              class="external"
-              href="http://www.webreference.com/programming/ajax_tech/"
-              >Techniques AJAX alternatives</a
-            >
-          </dt>
-          <dd>
-            <small
-              >La plupart des articles sur AJAX se concentrent sur l'utilisation
-              de XMLHttp comme moyen de communication, mais les techniques AJAX
-              ne s'arrêtent pas à XMLHttp. Il y en a bien d'autres.</small
-            >
-          </dd>
-        </dl>
-        <dl>
-          <dt>
-            <a
-              class="external"
-              href="http://www.adaptivepath.com/publications/essays/archives/000385.php"
-              >Ajax: A New Approach to Web Applications (en)</a
-            >
-          </dt>
-          <dd>
-            <small
-              >Jesse James Garrett, du site
-              <a class="external" href="http://www.adaptivepath.com"
-                >adaptive path</a
-              >, a écrit cet article en février 2005, introduisant le terme AJAX
-              et les concepts liés.</small
-            >
-          </dd>
-        </dl>
-        <dl>
-          <dt>
-            <a
-              class="external"
-              href="http://www.onlamp.com/pub/a/onlamp/2005/05/19/xmlhttprequest.html"
-              >A Simpler Ajax Path</a
-            >
-          </dt>
-          <dd>
-            <small
-              >«&nbsp;Comme on le remarquera, il est assez facile de tirer parti de
-              l'objet XMLHttpRequest pour faire se comporter une application Web
-              un peu plus comme une application traditionnelle, tout en
-              continuant à utiliser des outils comme des formulaires Web pour
-              collecter les entrées de l'utilisateur.&nbsp;»</small
-            >
-          </dd>
-        </dl>
-        <dl>
-          <dt>
-            <a
-              class="external"
-              href="http://www.contentwithstyle.co.uk/Articles/38/fixing-the-back-button-and-enabling-bookmarking-for-ajax-apps"
-              >Fixing the Back Button and Enabling Bookmarking for AJAX Apps</a
-            >
-          </dt>
-          <dd>
-            <small
-              >Cet article rédigé par Mike Stenhouse détaille certaines méthodes
-              utilisables pour rendre fonctionnel le bouton Précédent et réparer
-              les problèmes causés au marquage des pages lorsque des
-              applications sont développées avec les outils AJAX.</small
-            >
-          </dd>
-        </dl>
-        <dl>
-          <dt>
-            <a
-              class="external"
-              href="http://alexbosworth.backpackit.com/pub/67688"
-              >Ajax Mistakes</a
-            >
-          </dt>
-          <dd>
-            <small
-              >Cet article d'Alex Bosworth attire l'attention sur certaines
-              erreurs que les développeurs d'applications AJAX peuvent
-              faire.</small
-            >
-          </dd>
-        </dl>
-        <dl>
-          <dt>
-            <a class="external" href="http://www.xul.fr/xml-ajax.html"
-              >Tutoriel</a
-            >
-            avec des exemples.
-          </dt>
-        </dl>
-        <dl>
-          <dt>
-            <a class="external" href="http://www.w3.org/TR/XMLHttpRequest/"
-              >La spécification XMLHttpRequest</a
-            >-
-            <a class="external" href="http://www.xul.fr/XMLHttpRequest.html"
-              >(Traduction française)</a
-            >
-          </dt>
-          <dd><small>Brouillon de travail du W3C</small></dd>
-        </dl>
-      </td>
-      <td>
-        <h2 class="Community" id="Communauté">Communauté</h2>
-        <ul>
-          <li>
-            Voir les forums de Mozilla…
-            {{ DiscussionList("dev-ajax", "mozilla.dev.ajax") }}
-          </li>
-        </ul>
-        <h2 class="Tools" id="Outils">Outils</h2>
-        <ul>
-          <li>
-            <a class="external" href="http://www.ajaxprojects.com"
-              >Toolkits et frameworks</a
-            >
-          </li>
-          <li>
-            <a class="external" href="http://www.getfirebug.com/"
-              >Firebug — Outil de développement AJAX/Web</a
-            >
-          </li>
-          <li>
-            <a
-              class="external"
-              href="http://blog.monstuff.com/archives/000252.html"
-              >Outils de débogage AJAX</a
-            >
-          </li>
-          <li>
-            <a
-              class="external"
-              href="http://www.osflash.org/doku.php?id=flashjs"
-              >Kit d'intégration Flash/AJAX</a
-            >
-          </li>
-          <li>
-            <a class="external" href="http://xkr.us/code/javascript/XHConn/"
-              >Une bibliothèque d'interface XMLHTTP simple</a
-            >
-          </li>
-          <li>
-            <a
-              class="external"
-              href="http://chandlerproject.org/Projects/AjaxLibraries"
-              >Bibliothèques AJAX</a
-            >
-          </li>
-        </ul>
-        <h2 id="Exemples">Exemples</h2>
-        <ul>
-          <li>
-            <a
-              class="external"
-              href="http://www.dhtmlgoodies.com/index.html?whichScript=ajax-poller"
-              >AJAX poller script</a
-            >
-          </li>
-          <li>
-            <a
-              class="external"
-              href="http://www.ajaxprojects.com/ajax/tutorialdetails.php?itemid=9"
-              >Ajax Chat Tutorial</a
-            >
-          </li>
-          <li>
-            <a class="external" href="http://www.funwithjustin.com/ajax-toybox/"
-              >Ajax Toybox</a
-            >
-          </li>
-          <li>
-            <a
-              class="external"
-              href="http://www.ajaxprojects.com/ajax/tutorialdetails.php?itemid=13"
-              >RSS Ticker with AJAX</a
-            >
-          </li>
-          <li>
-            <a
-              class="external"
-              href="http://www.jamesdam.com/ajax_login/login.html#login"
-              >AJAX Login System using XMLHttpRequest</a
-            >
-          </li>
-          <li>
-            <a
-              class="external"
-              href="http://www.thinkvitamin.com/features/ajax/create-your-own-ajax-effects"
-              >Create your own Ajax effects</a
-            >
-          </li>
-          <li>
-            <a
-              class="external"
-              href="http://codinginparadise.org/weblog/2005/08/ajax-creating-huge-bookmarklets.html"
-              >AJAX: Creating Huge Bookmarklets</a
-            >
-          </li>
-          <li>
-            <a class="external" href="http://www.hotajax.org"
-              >Hot!Ajax: many cool examples</a
-            >
-          </li>
-        </ul>
-        <h2 class="Related_Topics" id="Sujets_liés">Sujets liés</h2>
-        <dl>
-          <dd>
-            <a href="/fr/HTML" title="fr/HTML">HTML</a>,
-            <a href="/fr/XHTML" title="fr/XHTML">XHTML</a>,
-            <a href="/fr/CSS" title="fr/CSS">Feuilles de style (CSS)</a>,
-            <a href="/fr/DOM" title="fr/DOM">Modèle objet de document (DOM)</a>,
-            <a href="/fr/JavaScript" title="fr/JavaScript">JavaScript</a>,
-            <a href="/fr/XML" title="fr/XML">XML</a>,
-            <a href="/fr/XSLT" title="fr/XSLT">XSLT</a> ,
-            <a href="/fr/DHTML" title="fr/DHTML">DHTML</a>,
-            <a href="/fr/HTML/Canvas" title="fr/HTML/Canvas">Canvas</a>
-          </dd>
-        </dl>
-      </td>
-    </tr>
-  </tbody>
-</table>
+- [Démarrer](/fr/docs/Web/Guide/AJAX/Getting_Started)
+  - : Cet article vous guide parmi les notions de base d'AJAX et fournit deux exemples pour mettre le pied à l'étrier.
+- [Utiliser l'API `XMLHttpRequest`](/fr/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest)
+
+  - : L'API [`XMLHttpRequest`](/fr/docs/Web/API/XMLHttpRequest) est au cœur d'AJAX. Dans cet article, plusieurs techniques sont abordées&nbsp;:
+
+    - [Analyser et manipuler la réponse du serveur](/fr/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#gérer_les_réponses)
+    - [Surveiller l'avancement d'une requête](/fr/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#surveiller_la_progression)
+    - [Soumettre des formulaires et uploader des fichiers binaires](/fr/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#envoyer_des_formulaires_et_uploader_des_fichiers) en AJAX pur ou en utilisant des objets [`FormData`](/fr/docs/Web/API/FormData)
+    - Utiliser AJAX avec les [<i lang="en">web workers</i>](/fr/docs/Web/API/Worker)
+
+- [API Fetch](/fr/docs/Web/API/Fetch_API)
+  - : L'API `Fetch` fournit une interface permettant de récupérer (<i lang="en">fetch</i> en anglais) des ressources. Elle ressemble à celle exposée par [`XMLHTTPRequest`](/fr/docs/Web/API/XMLHttpRequest), mais fournit des fonctionnalités plus flexibles et puissantes.
+- [Évènements émis par le serveur](/fr/docs/Web/API/Server-sent_events)
+  - : Généralement, c'est la page web qui initie une requête vers le serveur afin de recevoir de nouvelles données. Avec les évènements émis par le serveur, un serveur peut envoyer de nouvelles données à une page web à tout moment, via des messages. Ces derniers peuvent être traités par la page web comme des [évènements](/fr/docs/Web/API/Event) contenant des données. Voir aussi&nbsp;: [Utiliser les évènements émis par le serveur](/fr/docs/Web/API/Server-sent_events/Using_server-sent_events).
+- [Exemple de navigation avec un site utilisant AJAX pur](/fr/docs/Web/API/History_API/Example)
+  - : Cet article contient un exemple fonctionnel minimaliste d'un site web composé de trois pages et qui utilise AJAX.
+- [Envoyer et recevoir des données binaires](/fr/docs/Web/API/XMLHttpRequest/Sending_and_Receiving_Binary_Data)
+  - : La propriété `responseType` de l'objet `XMLHttpRequest` peut être modifiée afin de changer le type de réponse attendu du serveur. Les valeurs possibles sont la chaîne vide (la valeur par défaut), `arraybuffer`, `blob`, `document`, `json`, et `text`. La propriété `response` contiendra le corps de l'entité selon la valeur de `responseType`, ce pourra donc être un objet `ArrayBuffer`, `Blob`, `Document`, `JSON`, ou une chaîne de caractères. Cet article aborde quelques techniques d'entrée/sortie AJAX. 
+- [XML](/fr/docs/Web/XML)
+  - : Le langage **XML (<i lang="en">Extensible Markup Language</i>)** est un langage balisé qui permet de créer des formats pour des données particulières. Il s'agit d'un sous-ensemble simplifié de SGML, capable de décrire différentes sortes de données. Son principal objectif est de faciliter le partage de données entre différents systèmes, notamment ceux connectés par Internet.
+- [Analyser et sérialiser du XML](/fr/docs/Web/Guide/Parsing_and_serializing_XML)
+  - : Dans cet article, on voit comment analyser un document XML à partir d'une chaîne de caractères, d'un fichier ou via JavaScript. On voit également comment sérialiser des documents XML en chaînes de caractères, en arbres d'objets JavaScript ou en fichiers.
+- [XPath](/fr/docs/Web/XPath)
+  - : XPath signifie **<i lang="en">XML Path</i>**, c'est-à-dire un langage pour décrire des chemins dans un document XML. Il s'agit d'une syntaxe non-XML qui permet de cibler différentes parties d'un document [XML](/fr/docs/Web/XML). On peut aussi l'utiliser pour tester certains nœuds d'un document afin de déterminer s'ils suivent un motif donné ou non.
+- L'API [`FileReader`](/fr/docs/Web/API/FileReader)
+  - : L'API `FileReader` permet aux applications web de lire le contenu de fichiers (ou de tampons de données brutes) stockés sur l'ordinateur de la personne de façon asynchrone, en utilisant des objets [`File`](/fr/docs/Web/API/File) ou [`Blob`](/fr/docs/Web/API/Blob) pour représenter le fichier ou les données à lire. On peut obtenir des objets `File` depuis un objet [`FileList`](/fr/docs/Web/API/FileList) qui pourra être produit à partir d'un élément [`<input>`](/fr/docs/Web/HTML/Element/Input) de sélection de fichiers, à partir d'un objet [`DataTransfer`](/fr/docs/Web/API/DataTransfer) d'une opération de glisser/déposer.
+- [HTML et `XMLHttpRequest`](/fr/docs/Web/API/XMLHttpRequest/HTML_in_XMLHttpRequest)
+  - : [La spécification pour l'API `XMLHttpRequest`](https://xhr.spec.whatwg.org/) ajoute la capacité d'analyser du HTML à [`XMLHttpRequest`](/fr/docs/Web/API/XMLHttpRequest) (initialement limité à l'analyse de XML). Cette fonctionnalité permet aux applications web d'obtenir une ressource HTML comme un DOM analysé en utilisant `XMLHttpRequest`.
+
+## Outils
+
+- [axios](https://github.com/axios/axios)
+  - : Un client [HTTP](/fr/docs/Glossary/HTTP) utilisant les [promesses](/fr/docs/Web/JavaScript/Reference/Global_Objects/Promise) et qui utilise `XMLHttpRequest` en interne.
+
+## Voir aussi
+
+- [AJAX&nbsp;: une nouvelle approche pour les applications web (en anglais)](https://www.semanticscholar.org/paper/Ajax%3A-A-New-Approach-to-Web-Applications-Garrett/c440ae765ff19ddd3deda24a92ac39cef9570f1e?p2df)
+  - Un article écrit par Jesse James Garrett en février 2005 qui introduit AJAX et les concepts associés.
+- [La spécification de `XMLHttpRequest` au sein du standard évolutif WHATWG](https://xhr.spec.whatwg.org/)

--- a/files/fr/web/guide/ajax/index.md
+++ b/files/fr/web/guide/ajax/index.md
@@ -3,6 +3,7 @@ title: AJAX
 slug: Web/Guide/AJAX
 translation_of: Web/Guide/AJAX
 ---
+## Démarrer avec AJAX
 
 **AJAX (<i lang="en">Asynchronous JavaScript + XML</i>)** n'est pas une technologie en soi, mais un terme désignant une «&nbsp;nouvelle&nbsp;» approche utilisant un ensemble de technologies existantes, dont&nbsp;: [HTML](/fr/docs/Web/HTML) ou [XHTML](/fr/docs/Glossary/XHTML), [CSS](/fr/docs/Web/CSS), [JavaScript](/fr/docs/Web/JavaScript), [DOM](/fr/docs/Web/API/Document_Object_Model), [XML](/fr/docs/Web/XML), [XSLT](/fr/docs/Web/XSLT), et surtout [l'objet `XMLHttpRequest`](/fr/docs/Web/API/XMLHttpRequest). Lorsque ces technologies sont combinées dans le modèle AJAX, les applications web sont capables de réaliser des mises à jour rapides et incrémentales de l'interface utilisateur sans devoir recharger la page entière dans le navigateur. Les applications fonctionnent plus rapidement et sont plus réactives aux actions de l'utilisatrice ou de l'utilisateur.
 

--- a/files/fr/web/mathml/index.md
+++ b/files/fr/web/mathml/index.md
@@ -17,7 +17,7 @@ Vous trouverez ici des liens vers la documentation, les exemples et les outils p
   - : Des informations sur les attributs MathML qui modifient l'apparence ou le comportement des éléments.
 - [Exemples avec MathML](/fr/docs/Web/MathML/Examples)
   - : Des fragments de code MathML ainsi que des exemples pour comprendre son fonctionnement.
-- [Éditer du MathML](/docs/Web/MathML/Authoring)
+- [Éditer du MathML](/fr/docs/Web/MathML/Authoring)
   - : Des conseils sur l'édition de document en MathML&nbsp;: quels éditeurs à utiliser et comment intégrer le code produit dans du contenu web.
 
 ## Obtenir de l'aide de la communauté
@@ -31,9 +31,9 @@ Vous trouverez ici des liens vers la documentation, les exemples et les outils p
 
 - [Le validateur W3C](https://validator.w3.org)
 - [L'ensemble d'extensions Mathzilla pour Firefox](https://addons.mozilla.org/firefox/collections/fred_wang/mathzilla/)
-- [TeXZilla](https://github.com/fred-wang/TeXZilla) - Convertisseur Javascript de LaTeX à MathML ([démo](http://fred-wang.github.io/TeXZilla/), [extension Firefox](https://addons.mozilla.org/fr/firefox/addon/texzilla/), [utilisation dans une page web, un programme JavaScript, etc.](https://github.com/fred-wang/TeXZilla/wiki/Using-TeXZilla))
+- [TeXZilla](https://github.com/fred-wang/TeXZilla) — convertisseur JavaScript de LaTeX à MathML ([démo](http://fred-wang.github.io/TeXZilla/), [extension Firefox](https://addons.mozilla.org/fr/firefox/addon/texzilla/), [utilisation dans une page web, un programme JavaScript, etc.](https://github.com/fred-wang/TeXZilla/wiki/Using-TeXZilla))
 - [LaTeXML](https://math.nist.gov/~BMiller/LaTeXML/) qui permet de transformer des documents LaTeX en pages HTML+MathML.
-- [MathJax](http://www.mathjax.org/) - Moteur de rendu de Javascript pour les formules mathématiques, compatible avec tous les navigateurs. Pour forcer MathJax à utiliser le MathML natif, essayez [cette extension Firefox](https://addons.mozilla.org/fr/firefox/addon/native-mathml/), ou [cette extension pour Safari](https://fred-wang.github.io/mathjax-native-mathml-safari/mathjax-native-mathml.safariextz) ou [ce script GreaseMonkey](https://openuserjs.org/scripts/fred.wang/MathJax_Native_MathML/).
+- [MathJax](https://www.mathjax.org/) — moteur de rendu de JavaScript pour les formules mathématiques, compatible avec tous les navigateurs. Pour forcer MathJax à utiliser le MathML natif, essayez [cette extension Firefox](https://addons.mozilla.org/fr/firefox/addon/native-mathml/), ou [cette extension pour Safari](https://fred-wang.github.io/mathjax-native-mathml-safari/mathjax-native-mathml.safariextz) ou [ce script GreaseMonkey](https://openuserjs.org/scripts/fred.wang/MathJax_Native_MathML/).
 
 ## Sujets connexes
 

--- a/files/fr/web/mathml/index.md
+++ b/files/fr/web/mathml/index.md
@@ -1,53 +1,45 @@
 ---
 title: MathML
 slug: Web/MathML
-tags:
-  - Landing
-  - MathML
-  - Reference
-  - Web
-  - XML
 translation_of: Web/MathML
 ---
-**Mathematical Markup Language (MathML)** est un dialecte de [XML](/fr/docs/XML) permettant de décrire des formules mathématiques à la fois dans leur structure et dans leur contenu.
+{{MathMLRef}}
 
-Vous trouverez ici des liens vers la documentation, les exemples et les outils permettant de travailler avec cette technologie. Pour un bref aperçu, veuillez consulter [la présentation pour le Mozilla Summit Innovation Fair de 2013 (en)](http://fred-wang.github.io/MozSummitMathML/index.html).
+**Mathematical Markup Language (MathML)** est un dialecte de [XML](/fr/docs/Web/XML) permettant de décrire des formules mathématiques à la fois dans leur structure et dans leur contenu.
 
-## Documentations à propos de MathML
+Vous trouverez ici des liens vers la documentation, les exemples et les outils permettant de travailler avec cette technologie. Pour un bref aperçu, veuillez consulter [la présentation pour le Mozilla Summit Innovation Fair de 2013 (en anglais)](https://fred-wang.github.io/MozSummitMathML/index.html).
+
+## Référence MathML
 
 - [Référence des éléments MathML](/fr/docs/Web/MathML/Element)
   - : Des informations précises sur chaque élément MathML et leurs compatibilités avec les différents navigateurs.
 - [Référence des attributs MathML](/fr/docs/Web/MathML/Attribute)
   - : Des informations sur les attributs MathML qui modifient l'apparence ou le comportement des éléments.
 - [Exemples avec MathML](/fr/docs/Web/MathML/Examples)
-  - : Des fragments de code MathML ainsi que des exemples pour comprendre comment ça fonctionne.
+  - : Des fragments de code MathML ainsi que des exemples pour comprendre son fonctionnement.
 - [Éditer du MathML](/docs/Web/MathML/Authoring)
-  - : Des conseils sur l'édition de document en MathML : quels éditeurs à utiliser et comment intégrer le code produit dans du contenu web.
+  - : Des conseils sur l'édition de document en MathML&nbsp;: quels éditeurs à utiliser et comment intégrer le code produit dans du contenu web.
 
 ## Obtenir de l'aide de la communauté
 
-- Les forums de Mozilla
-  {{ DiscussionList("dev-tech-mathml", "mozilla.dev.tech.mathml") }}
-- [Les salons IRC](irc://irc.mozilla.org/%23mathml)
-- [Le Wiki utilisé par les contributeurs de Mozilla](https://wiki.mozilla.org/MathML:Home_Page)
-- [La page d'accueil de W3C Math](http://www.w3.org/Math/)
-- [Les archives mail de www-math w3.org](http://lists.w3.org/Archives/Public/www-math/)
+- [Le groupe Google mozilla.dev.tech.mathml](https://groups.google.com/g/mozilla.dev.tech.mathml)
+- [Le wiki utilisé par les contributeurs de Mozilla](https://wiki.mozilla.org/MathML:Home_Page)
+- [La page d'accueil de W3C Math](https://www.w3.org/Math/)
+- [Les archives mail de www-math w3.org](https://lists.w3.org/Archives/Public/www-math/)
 
-## Outils facilitant le développement avec MathML
+## Outils
 
-- [Le validateur W3C](http://validator.w3.org)
-- [L'extension FireMath pour Firefox](https://addons.mozilla.org/de/firefox/addon/8969/)
+- [Le validateur W3C](https://validator.w3.org)
 - [L'ensemble d'extensions Mathzilla pour Firefox](https://addons.mozilla.org/firefox/collections/fred_wang/mathzilla/)
-- [TeXZilla](https://github.com/fred-wang/TeXZilla) - Convertisseur Javascript de LaTeX à MathML ([demo](http://fred-wang.github.io/TeXZilla/), [Firefox OS webapp](http://r-gaia-cs.github.io/TeXZilla-webapp/), [Firefox add-on](https://addons.mozilla.org/en-US/firefox/addon/texzilla/), [utilisation dans une page Web Page, un programme JS etc](https://github.com/fred-wang/TeXZilla/wiki/Using-TeXZilla))
-- [LaTeXML](http://dlmf.nist.gov/LaTeXML/) - Transformez vos documents LaTeX en pages HTML+MathML.
-- [Web Equation](http://webdemo.visionobjects.com/equation.html) - Transformez des équations manuscrites en MathML ou LaTeX
-- [Mathjax](http://www.mathjax.org/) - Moteur de rendu de Javascript pour les formules mathématiques, compatible avec tous les navigateurs. Pour forcer MathJax à utiliser le MathML natif, essayez cette [extension pour Safari](http://fred-wang.github.io/mathjax-native-mathml-safari/mathjax-native-mathml.safariextz) ou ce [script GreaseMonkey](https://openuserjs.org/scripts/fred.wang/MathJax_Native_MathML/).
+- [TeXZilla](https://github.com/fred-wang/TeXZilla) - Convertisseur Javascript de LaTeX à MathML ([démo](http://fred-wang.github.io/TeXZilla/), [extension Firefox](https://addons.mozilla.org/fr/firefox/addon/texzilla/), [utilisation dans une page web, un programme JavaScript, etc.](https://github.com/fred-wang/TeXZilla/wiki/Using-TeXZilla))
+- [LaTeXML](https://math.nist.gov/~BMiller/LaTeXML/) qui permet de transformer des documents LaTeX en pages HTML+MathML.
+- [MathJax](http://www.mathjax.org/) - Moteur de rendu de Javascript pour les formules mathématiques, compatible avec tous les navigateurs. Pour forcer MathJax à utiliser le MathML natif, essayez [cette extension Firefox](https://addons.mozilla.org/fr/firefox/addon/native-mathml/), ou [cette extension pour Safari](https://fred-wang.github.io/mathjax-native-mathml-safari/mathjax-native-mathml.safariextz) ou [ce script GreaseMonkey](https://openuserjs.org/scripts/fred.wang/MathJax_Native_MathML/).
 
-## Sujets liés
+## Sujets connexes
 
-- [CSS](/fr/docs/CSS)
+- [CSS](/fr/docs/Web/CSS)
 - [HTML](/fr/docs/Web/HTML)
-- [SVG](/fr/docs/SVG)
+- [SVG](/fr/docs/Web/SVG)
 
 ## Compatibilité des navigateurs
 

--- a/files/fr/web/svg/index.md
+++ b/files/fr/web/svg/index.md
@@ -5,6 +5,8 @@ translation_of: Web/SVG
 ---
 {{SVGRef}}
 
+## Démarrer avec SVG
+
 **SVG (pour <i lang="en">Scalable Vector Graphics</i> en anglais, soit «&nbsp;graphiques vectoriels adaptables&nbsp;»**) est un langage construit à partir de [XML](/fr/docs/Web/XML) et qui permet de décrire des [graphiques vectoriels](https://fr.wikipedia.org/wiki/Image_vectorielle) en deux dimensions.
 
 Il s'agit d'un format texte, standardisé de façon ouverte pour le Web, pour décrire des images qui peuvent être affichées nettement à n'importe quelle taille et qui est conçu pour fonctionner avec les autres technologies web standard comme [CSS](/fr/docs/Web/CSS), [DOM](/fr/docs/Web/API/Document_Object_Model), [JavaScript](/fr/docs/Web/JavaScript), et [SMIL](/fr/docs/Web/SVG/SVG_animation_with_SMIL). D'une certaine façon, SVG est aux graphiques ce que [HTML](/fr/docs/Web/HTML) est au texte.
@@ -15,7 +17,7 @@ Contrairement aux images matricielles classiques aux formats [JPEG](/fr/docs/Glo
 
 SVG a été développé par le [W3C (World Wide Web Consortium)](https://www.w3.org/) depuis 1999.
 
-Voir aussi [le tutoriel SVG](/fr/docs/Web/SVG/Tutorial)
+Voir aussi [le tutoriel SVG](/fr/docs/Web/SVG/Tutorial).
 
 ## Documentation
 

--- a/files/fr/web/svg/index.md
+++ b/files/fr/web/svg/index.md
@@ -1,90 +1,42 @@
 ---
-title: SVG
+title: SVG (Scalable Vector Graphics)
 slug: Web/SVG
-tags:
-  - Graphiques 2D
-  - Images
-  - Images 2D
-  - Images Extensibles
-  - Images Vectorielles
-  - Reference
-  - SVG
-  - Web
-  - l10n:priority
-  - Ícones
 translation_of: Web/SVG
 ---
 {{SVGRef}}
 
-**SVG (Scalable Vector Graphics)** est un langage de balisage [XML](/fr/docs/Web/XML) décrivant des [images vectorielles](https://fr.wikipedia.org/wiki/Image_vectorielle) bidimensionnelles. On pourrait dire que SVG est aux images ce qu'[HTML](/fr/docs/Web/HTML) est au texte.
+**SVG (pour <i lang="en">Scalable Vector Graphics</i> en anglais, soit «&nbsp;graphiques vectoriels adaptables&nbsp;»**) est un langage construit à partir de [XML](/fr/docs/Web/XML) et qui permet de décrire des [graphiques vectoriels](https://fr.wikipedia.org/wiki/Image_vectorielle) en deux dimensions.
 
-**[Premiers pas](/fr/SVG/Tutoriel "fr/SVG/Tutoriel")** ce tutoriel vous aidera à débuter en SVG.
+Il s'agit d'un format texte, standardisé de façon ouverte pour le Web, pour décrire des images qui peuvent être affichées nettement à n'importe quelle taille et qui est conçu pour fonctionner avec les autres technologies web standard comme [CSS](/fr/docs/Web/CSS), [DOM](/fr/docs/Web/API/Document_Object_Model), [JavaScript](/fr/docs/Web/JavaScript), et [SMIL](/fr/docs/Web/SVG/SVG_animation_with_SMIL). D'une certaine façon, SVG est aux graphiques ce que [HTML](/fr/docs/Web/HTML) est au texte.
 
-SVG est une [recommandation du W3C](http://www.w3.org/Graphics/SVG/) et est basé sur XML. Il est explicitement conçu pour fonctionner avec d'autres standards du [W3C](http://www.w3.org/) comme [CSS](/fr/CSS "fr/CSS"), [DOM](/fr/DOM "fr/DOM") et [SMIL](http://www.w3.org/AudioVideo/).
+Les images SVG et leur comportement sont définies dans des fichiers texte [XML](/fr/docs/Web/XML). Cela signifie qu'on peut rechercher dans ces textes, les indexer, réaliser des opérations scriptées, les compresser. De plus, cela signifie aussi qu'on peut en créer ou en éditer avec n'importe quel éditeur de texte ou avec des logiciels de dessin.
 
-SVG est un format d'images vectorielles. Les images vectorielles peuvent être redimensionnées sans perte de qualité, tandis que ce n'est pas possible avec des images matricielles (bitmap).
+Contrairement aux images matricielles classiques aux formats [JPEG](/fr/docs/Glossary/jpeg) ou [PNG](/fr/docs/Glossary/PNG), les images SVG peuvent être affichées à n'importe quelle taille sans perte de qualité. De plus, on peut les localiser en adaptant le texte qu'elles contiennent, sans avoir nécessairement besoin d'un éditeur graphique. Avec des bibliothèques logicielles adaptées, les fichiers SVG peuvent être traduits à la volée.
 
-SVG est une norme développée par le [World Wide Web Consortium (W3C)](https://www.w3.org/) depuis 1999.
+SVG a été développé par le [W3C (World Wide Web Consortium)](https://www.w3.org/) depuis 1999.
+
+Voir aussi [le tutoriel SVG](/fr/docs/Web/SVG/Tutorial)
 
 ## Documentation
 
-- [Référence des éléments SVG](/fr/SVG/Element "fr/SVG/Element")
-  - : Obtenir des informations sur les éléments SVG.
-- [Référence des attributs SVG](/fr/docs/Web/SVG/Attribute "/fr/docs/Web/SVG/Attribute")
-  - : Obtenir des informations sur les attributs SVG.
-- [Référence de l'interface DOM SVG](/fr/docs/Référence_du_DOM_Gecko#Interfaces_SVG "/fr/docs/Référence_du_DOM_Gecko#Interfaces_SVG")
-  - : Les détails sur l'API DOM SVG pour intéragir avec Javascript.
-- [SVG dans Firefox](/fr/SVG_dans_Firefox "fr/SVG_dans_Firefox")
-  - : Cet article décrit les caractéristiques et le comportement du sous-ensemble de la spécification SVG 1.1 actuellement implémenté dans Firefox 2.
-- [SVG documentation tierce](http://svground.fr/)
-  - : Une référence francophone du format SVG sous forme de tutoriels.
-- [SVG Authoring Guidelines](http://jwatt.org/svg/authoring/) (en anglais)
-  - : jwatt traite des erreurs les plus courantes commises dans le contenu SVG, et explique ce que les auteurs peuvent faire pour les corriger.
-- [Projet SVG de Mozilla](/fr/docs/Mozilla/Mozilla_SVG_Project "fr/Projet_SVG_de_Mozilla")
-  - : Une présentation du projet SVG de Mozilla (à traduire de [en:Mozilla SVG Project](/fr/Mozilla_SVG_Project "en/Mozilla_SVG_Project")).
-- [Mozilla SVG Project FAQ](http://www.mozilla.org/projects/svg/faq.html)
-  - : Cette FAQ est le résultat de recherches au sein du groupe mozilla.dev.tech.svg et des forums de MozillaZine pour connaître les questions les plus souvent posées à propos de SVG dans Mozilla.
-- Autres ressources
-
-  - : Voici d'autres articles à propos de SVG sur MDN&nbsp;:
-
-    - [Un tutoriel](/fr/docs/Web/SVG/Tutoriel "/fr/docs/Web/SVG/Tutoriel")
-    - [Une introduction à SVG dans HTML](/fr/docs/Introduction_à_SVG_dans_HTML "/fr/docs/Introduction_à_SVG_dans_HTML")
-
-## Communauté
-
-- Voir les forums Mozilla... {{DiscussionList("dev-tech-svg", "mozilla.dev.tech.svg")}}
+- [Référence des éléments SVG](/fr/docs/Web/SVG/Element)
+  - : Des informations à propos de chaque élément SVG.
+- [Référence des attributs SVG](/fr/docs/Web/SVG/Attribute)
+  - : Des informations à propos de chaque attribut SVG.
+- [Référence du DOM SVG](/fr/docs/Web/API/Document_Object_Model#interfaces_svg)
+  - : Des informations quant à l'API DOM exposée par SVG, qui permet des interactions avec JavaScript.
+- [Appliquer des effets SVG à du contenu HTML](/fr/docs/Web/SVG/Applying_SVG_effects_to_HTML_content)
+  - : SVG peut fonctionner avec [HTML](/fr/docs/Glossary/HTML), [CSS](/fr/docs/Glossary/CSS), et [JavaScript](/fr/docs/Glossary/JavaScript). On pourra utiliser SVG pour [améliorer de façon progressive une page ou une application web](/fr/docs/Web/SVG/Tutorial/SVG_In_HTML_Introduction).
 
 ## Outils
 
-- [SVG Test Suite](http://www.w3.org/Graphics/SVG/Test/)
-- [Validateur SVG](http://validator.w3.org/) (jusqu'à 1.1 seulement)
-- D'autres ressources connexes : [XML](/fr/docs/Web/XML "/fr/docs/XML"), [CSS](/fr/docs/CSS), [DOM](/fr/docs/DOM), [Canvas](/fr/docs/HTML/Canvas)
+- [Suite de tests SVG](https://github.com/w3c/svgwg/wiki/Testing)
+- [Validateur de balisage](https://validator.w3.org/#validate_by_input)
 
 ## Exemples
 
-- [Galerie d'art SVG](http://plurib.us/1shot/2007/svg_gallery/)
-- [carto.net](http://www.carto.net/papers/svg/samples/)
-- Google [Maps](http://maps.google.com) (tracé des routes) et Google [Docs](http://docs.google.com) (graphiques des tableurs)
-- [Menus « bulles » SVG](http://starkravingfinkle.org/projects/demo/svg-bubblemenu-in-html.xml)
-- Présentation [SVG et Mozilla](https://jwatt.org/blog/2009/11/16/slides-and-demos-from-svg-open-2009) lors de SVG Open 2009
-- [SVG comme image](/fr/docs/Web/SVG/SVG_en_tant_qu_image)
+- [Bonnes pratiques pour l'édition de SVG (en anglais)](https://jwatt.org/svg/authoring/)
+- [SVG comme image](/fr/docs/Web/SVG/SVG_as_an_Image)
 - [Animation SVG avec SMIL](/fr/docs/Web/SVG/SVG_animation_with_SMIL)
-
-### Animation et interaction
-
-Comme HTML, SVG dispose d'un modèle de document (DOM) et d'évènements, et est accessible depuis JavaScript. Ceci permet aux développeurs de créer des animations riches et des images interactives.
-
-- [svg-wow.org](http://svg-wow.org/)
-- Extension Firefox ([Grafox](http://schepers.cc/grafox/)) pour ajouter la gestion d'un sous-ensemble des animations SMIL
-- Manipulation interactive de [photos](http://people.mozilla.com/~vladimir/demos/photos.svg)
-- [Transformations HTML](http://starkravingfinkle.org/blog/2007/07/firefox-3-svg-foreignobject/) utilisant `foreignObject` de SVG
-
-### Cartes, graphiques, jeux et expérimentations 3D
-
-Bien qu'un peu de SVG puisse contribuer à améliorer le contenu du web, voici quelques exemples d'utilisation poussée du SVG.
-
-- Un [Tetris en SVG](http://www.codedread.com/yastframe.php) et [Connect 4](http://www.treebuilder.de/svg/connect4.svg)
-- Jeu [Find the State](http://dev.w3.org/SVG/tools/svgweb/samples/svg-files/USStates.svg)
-- [Boîte 3D](http://www.treebuilder.de/default.asp?file=441875.xml) et [boîtes 3D](http://www.treebuilder.de/default.asp?file=206524.xml)
-- [jVectorMap](http://jvectormap.com/) (pour représenter des cartes interactives avec des données) (en anglais)
+- [Galerie d'art SVG](https://www1.plurib.us/svg_gallery/)
+- [D3](https://d3js.org) (une bibliothèque JavaScript qui permet de visualiser des données avec HTML, SVG, et CSS)


### PR DESCRIPTION
I'll take care of `conflicting/*` pages (2 of them actually) in a separate PR.