### PR TITLE
update some translations

### DIFF
--- a/files/zh-cn/learn/tools_and_testing/client-side_javascript_frameworks/vue_styling/index.html
+++ b/files/zh-cn/learn/tools_and_testing/client-side_javascript_frameworks/vue_styling/index.html
@@ -481,7 +481,7 @@ body {
    <li><a href="/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_resources"><font><font>Vue资源</font></font></a></li>
   </ul>
  </li>
- <li><font><font>斯维尔特</font></font>
+ <li><font><font>Svelte</font></font>
   <ul>
    <li><a href="/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_getting_started"><font><font>Svelte入门</font></font></a></li>
    <li><a href="/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_Todo_list_beginning"><font><font>启动我们的Svelte Todo列表应用</font></font></a></li>


### PR DESCRIPTION
In the real development documentation, we are still keep using Svelte not "斯维尔特". It's better for learners to keep using technical terms.