### PR TITLE
Corrected links formatting in the operator precedence table (ru)

### DIFF
--- a/files/ru/web/javascript/reference/operators/operator_precedence/index.html
+++ b/files/ru/web/javascript/reference/operators/operator_precedence/index.html
@@ -43,7 +43,7 @@ translation_of: Web/JavaScript/Reference/Operators/Operator_Precedence
 
 <p>Операторы упорядочены с самого высокого (19) до самого низкого (1) приоритета.</p>
 
-Обратите внимание, что [spread-оператор (...)](/ru/docs/Web/JavaScript/Reference/Operators/Spread_syntax) намеренно не включен в таблицу, потому что он вообще не является оператором и правильно говорить <code>spread-синтаксис</code>. Подробнее можно почитать в [ответе на Stack Overflow (en)](https://stackoverflow.com/a/44934830/15378287).
+Обратите внимание, что <a href="/ru/docs/Web/JavaScript/Reference/Operators/Spread_syntax">spread-оператор (<code>...</code>)</a> намеренно не включен в таблицу, потому что он вообще не является оператором и правильно говорить <code>spread-синтаксис</code>. Подробнее можно почитать в <a href="https://stackoverflow.com/a/44934830/15378287">ответе на Stack Overflow (en)</a>.
 
 <table class="fullwidth-table">
  <tbody>


### PR DESCRIPTION
Чуть накосячил вот [тут](https://github.com/mdn/translated-content/pull/5422#pullrequestreview-965007463), выкатываю фикс.

Made a bit of a mess [here](https://github.com/mdn/translated-content/pull/5422#pullrequestreview-965007463), rolling out the fix.