### PR TITLE
[FEAT] delete background-color a word at object_prototype page

### DIFF
--- a/files/ko/learn/javascript/objects/object_prototypes/index.html
+++ b/files/ko/learn/javascript/objects/object_prototypes/index.html
@@ -183,7 +183,7 @@ person3.bio()</pre>
 
 <h2 id="프로토타입_수정하기">프로토타입 수정하기</h2>
 
-<p><code><font face="Open Sans, arial, x-locale-body, sans-serif"><span style="background-color: #ffffff;">생성자의 </span></font>prototype</code> 속성을 수정하는 법에 대해 알아봅시다(프로토타입에 메소드를 추가하면 해당 생성자로 생성된 모든 객체에서 사용 가능합니다).</p>
+<p><code><font face="Open Sans, arial, x-locale-body, sans-serif">생성자의 </font>prototype</code> 속성을 수정하는 법에 대해 알아봅시다(프로토타입에 메소드를 추가하면 해당 생성자로 생성된 모든 객체에서 사용 가능합니다).</p>
 
 <ol>
  <li><a href="http://mdn.github.io/learning-area/javascript/oojs/introduction/oojs-class-further-exercises.html">oojs-class-further-exercises.html</a> 예제로 돌아가서 <a href="https://github.com/mdn/learning-area/blob/master/javascript/oojs/introduction/oojs-class-further-exercises.html">source code</a>를 다운 받으세요. 기존 코드에 아래 샘플 코드를 추가하여 <code>prototype</code> 속성에 새 메소드를 추가하세요:


### PR DESCRIPTION
ko/docs/Learn/JavaScript/Objects/Object_prototypes#프로토타입_수정하기 에 첫번째 문단 '생성자의 prototype속성...'의 생성자 라는 단어의 background-color가 있어서 dark-mode시에 보이지 않아서 제거해주었습니다.