### PR TITLE
[ko] correcting MDN_getting_started typing mistake

### DIFF
--- a/files/ko/mdn/contribute/getting_started/index.html
+++ b/files/ko/mdn/contribute/getting_started/index.html
@@ -84,7 +84,7 @@ translation_of: MDN/Contribute/Getting_started
  <li><a href="/ko/docs/MDN/About/Promote">여러분의 웹사이트에 MDN 홍보하기</a> (5분)</li>
  <li>더이상 사용하지 않는 <a href="/ko/docs/MDN/Contribute/Howto/Remove__Experimental__Macros">"실험적인" 메크로 제거하기</a> (5-30분)</li>
  <li><a href="/ko/docs/MDN/Contribute/Howto/Do_a_technical_review">기술 리뷰</a> (30분)</li>
- <li><a href="/ko/docs/MDN/Contribute/Contribute_to_docs_that_are_currently_needed">주요한 주제에 해대 새로운 글 작성 </a>(1시간 이상)</li>
+ <li><a href="/ko/docs/MDN/Contribute/Contribute_to_docs_that_are_currently_needed">주요한 주제에 대해 새로운 글 작성 </a>(1시간 이상)</li>
  <li><a href="/ko/docs/MDN/Contribute/Howto/Create_an_interactive_exercise_to_help_learning_the_web">사람들이 웹 학습에 도움을 줄 상호작용하는 예제 작성</a> (1시간 이상)</li>
  <li><a href="http://www.joshmatthews.net/bugsahoy/?mdn=1">Bugs Ahoy의 MDN 카테고리</a>에 <a href="/ko/docs/MDN/Contribute/Howto/Resolve_a_mentored_developer_doc_request">문서 버그 고치기</a> (1시간 이상)</li>
 </ul>

--- a/files/ko/mdn/contribute/getting_started/index.html
+++ b/files/ko/mdn/contribute/getting_started/index.html
@@ -84,7 +84,6 @@ translation_of: MDN/Contribute/Getting_started
  <li><a href="/ko/docs/MDN/About/Promote">여러분의 웹사이트에 MDN 홍보하기</a> (5분)</li>
  <li>더이상 사용하지 않는 <a href="/ko/docs/MDN/Contribute/Howto/Remove__Experimental__Macros">"실험적인" 메크로 제거하기</a> (5-30분)</li>
  <li><a href="/ko/docs/MDN/Contribute/Howto/Do_a_technical_review">기술 리뷰</a> (30분)</li>
- <li><a href="/ko/docs/MDN/Contribute/Contribute_to_docs_that_are_currently_needed">주요한 주제에 대해 새로운 글 작성 </a>(1시간 이상)</li>
  <li><a href="/ko/docs/MDN/Contribute/Howto/Create_an_interactive_exercise_to_help_learning_the_web">사람들이 웹 학습에 도움을 줄 상호작용하는 예제 작성</a> (1시간 이상)</li>
  <li><a href="http://www.joshmatthews.net/bugsahoy/?mdn=1">Bugs Ahoy의 MDN 카테고리</a>에 <a href="/ko/docs/MDN/Contribute/Howto/Resolve_a_mentored_developer_doc_request">문서 버그 고치기</a> (1시간 이상)</li>
 </ul>


### PR DESCRIPTION
'ko/docs/MDN/Contribute/Getting_started' 문서에서 오타를 발견하여 수정했습니다.
git 사용이 처음이라 branch명을 한글로 설정했다 바꾸었더니 commit이 두 번 된 것으로 보이는데 괜찮을까요?