### PR TITLE
replace standard-table with macros (Part 1)

### DIFF
--- a/files/zh-cn/web/api/abortcontroller/abort/index.html
+++ b/files/zh-cn/web/api/abortcontroller/abort/index.html
@@ -58,20 +58,7 @@ function fetchVideo() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#dom-abortcontroller-abort', 'abort()')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/zh-cn/web/api/abortcontroller/abortcontroller/index.html
+++ b/files/zh-cn/web/api/abortcontroller/abortcontroller/index.html
@@ -58,20 +58,7 @@ function fetchVideo() {
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#dom-abortcontroller-abortcontroller', 'AbortController()')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/zh-cn/web/api/abortcontroller/index.html
+++ b/files/zh-cn/web/api/abortcontroller/index.html
@@ -74,20 +74,7 @@ function fetchVideo() {
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#interface-abortcontroller', 'AbortController')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容">浏览器兼容</h2>
 

--- a/files/zh-cn/web/api/abortcontroller/index.html
+++ b/files/zh-cn/web/api/abortcontroller/index.html
@@ -19,14 +19,14 @@ original_slug: Web/API/FetchController
 
 <dl>
  <dt>{{domxref("AbortController.AbortController()")}}</dt>
- <dd><font>创建一个新的</font> <code>AbortController</code> <font>对象实例。</font></dd>
+ <dd>创建一个新的 <code>AbortController</code> 对象实例。</dd>
 </dl>
 
 <h2 id="属性">属性</h2>
 
 <dl>
  <dt>{{domxref("AbortController.signal")}} {{readonlyInline}}</dt>
- <dd><font>返回一个</font> {{domxref("AbortSignal")}} <font>对象实例，</font>它可以用来 with/abort 一个 Web(网络)请求。</dd>
+ <dd>返回一个 {{domxref("AbortSignal")}} 对象实例，它可以用来 with/abort 一个 Web(网络)请求。</dd>
 </dl>
 
 <h2 id="方法">方法</h2>
@@ -38,11 +38,11 @@ original_slug: Web/API/FetchController
 
 <h2 id="示例">示例</h2>
 
-<p><font>在下面的代码片段中，我们想通过</font> <a href="https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API">Fetch API</a> 下载一段视频。</p>
+<p>在下面的代码片段中，我们想通过 <a href="https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API">Fetch API</a> 下载一段视频。</p>
 
-<p><font>我们先使用</font> {{domxref("AbortController.AbortController","AbortController()")}} 构造函数<font>创建一个控制器，然后使用</font> {{domxref("AbortController.signal")}} 属性<font>获取其关联</font> {{domxref("AbortSignal")}} 对象的引用。</p>
+<p>我们先使用 {{domxref("AbortController.AbortController","AbortController()")}} 构造函数创建一个控制器，然后使用 {{domxref("AbortController.signal")}} 属性获取其关联 {{domxref("AbortSignal")}} 对象的引用。</p>
 
-<p>当一个 <a href="https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch">fetch request</a> 初始化，我们把 <code>AbortSignal</code> 作为一个选项传递到到请求对象（如下 <code>{ signal }</code>）。这将 <code>signal<code> 和 <code>controller<code> 与这个 <code>fetch request</code> 相关联，然后允许我们通过调用 {{domxref("AbortController.abort()")}} 中止请求，如下第二个事件监听函数。</p>
+<p>当一个 <a href="https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch">fetch request</a> 初始化，我们把 <code>AbortSignal</code> 作为一个选项传递到到请求对象（如下 <code>{ signal }</code>）。这将 <code>signal</code> 和 <code>controller</code> 与这个 <code>fetch request</code> 相关联，然后允许我们通过调用 {{domxref("AbortController.abort()")}} 中止请求，如下第二个事件监听函数。</p>
 
 <pre class="brush: js notranslate">const controller = new AbortController();
 let signal = controller.signal;
@@ -78,17 +78,11 @@ function fetchVideo() {
 
 <h2 id="浏览器兼容">浏览器兼容</h2>
 
-
-
-<p>{{Compat("api.AbortController")}}</p>
+{{Compat}}
 
 <h2 id="参见">参见</h2>
 
 <ul>
  <li><a href="https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API">Fetch API</a></li>
- <li><a href="https://developers.google.com/web/updates/2017/09/abortable-fetch">Abortable Fetch</a> by Jake Archibald</li>
+ <li><a href="https://developers.google.com/web/updates/2017/09/abortable-fetch">Abortable Fetch</a> by Jake Archibald</li>
 </ul>
-
-<div id="gtx-trans" style="position: absolute; left: 542px; top: 1890px;">
-<div class="gtx-trans-icon"></div>
-</div>

--- a/files/zh-cn/web/api/abortsignal/abort_event/index.html
+++ b/files/zh-cn/web/api/abortsignal/abort_event/index.html
@@ -34,20 +34,7 @@ signal.onabort = function() {
 
 <h2 id="规格">规格</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">规格</th>
-   <th scope="col">状态</th>
-   <th scope="col">标注</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#dom-abortsignal-aborted', 'onabort')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>初始定义</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/abortsignal/aborted/index.html
+++ b/files/zh-cn/web/api/abortsignal/aborted/index.html
@@ -29,20 +29,7 @@ signal.aborted ? console.log('Request has been aborted') : console.log('Request 
 
 <h2 id="规格">规格</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">规格</th>
-   <th scope="col">状态</th>
-   <th scope="col">备注</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#dom-abortsignal-onabort', 'onabort')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>初始定义</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/abortsignal/index.html
+++ b/files/zh-cn/web/api/abortsignal/index.html
@@ -78,20 +78,7 @@ function fetchVideo() {
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#interface-AbortSignal', 'AbortSignal')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/accelerometer/index.html
+++ b/files/zh-cn/web/api/accelerometer/index.html
@@ -44,25 +44,7 @@ accelerometer.start();</pre>
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Generic Sensor')}}</td>
-   <td>{{Spec2('Generic Sensor')}}</td>
-   <td>Defines sensors in general.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('Accelerometer','#accelerometer-interface','Accelerometer')}}</td>
-   <td>{{Spec2('Accelerometer')}}</td>
-   <td> </td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/zh-cn/web/api/ambientlightsensor/ambientlightsensor/index.html
+++ b/files/zh-cn/web/api/ambientlightsensor/ambientlightsensor/index.html
@@ -24,20 +24,7 @@ translation_of: Web/API/AmbientLightSensor/AmbientLightSensor
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('AmbientLight','#dom-ambientlightsensor-ambientlightsensor','AmbinentLightSensor()')}}</td>
-   <td>{{Spec2('AmbientLight')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/ambientlightsensor/illuminance/index.html
+++ b/files/zh-cn/web/api/ambientlightsensor/illuminance/index.html
@@ -23,20 +23,7 @@ original_slug: Web/API/AmbientLightSensor/reading
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('AmbientLight')}}</td>
-   <td>{{Spec2('AmbientLight')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/ambientlightsensor/index.html
+++ b/files/zh-cn/web/api/ambientlightsensor/index.html
@@ -25,20 +25,7 @@ translation_of: Web/API/AmbientLightSensor
 
 <pre class="brush: js">// TBD</pre>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('AmbientLight','#ambient-light-sensor-interface','AmbientLightSensor')}}</td>
-   <td>{{Spec2('AmbientLight')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/ambientlightsensor/index.html
+++ b/files/zh-cn/web/api/ambientlightsensor/index.html
@@ -25,6 +25,8 @@ translation_of: Web/API/AmbientLightSensor
 
 <pre class="brush: js">// TBD</pre>
 
+<h2 id="规范">规范</h2>
+
 {{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>

--- a/files/zh-cn/web/api/analysernode/analysernode/index.html
+++ b/files/zh-cn/web/api/analysernode/analysernode/index.html
@@ -35,20 +35,7 @@ translation_of: Web/API/AnalyserNode/AnalyserNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API','#the-analysernode-interface','AnalyserNode')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_Compatibility">Browser Compatibility</h2>
 

--- a/files/zh-cn/web/api/analysernode/fftsize/index.html
+++ b/files/zh-cn/web/api/analysernode/fftsize/index.html
@@ -81,20 +81,7 @@ function draw() {
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#widl-AnalyserNode-fftSize', 'fftSize')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td> </td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/analysernode/frequencybincount/index.html
+++ b/files/zh-cn/web/api/analysernode/frequencybincount/index.html
@@ -64,20 +64,7 @@ draw();</pre>
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#widl-AnalyserNode-frequencyBinCount', 'frequencyBinCount')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td> </td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/analysernode/getbytefrequencydata/index.html
+++ b/files/zh-cn/web/api/analysernode/getbytefrequencydata/index.html
@@ -74,20 +74,7 @@ draw();</pre>
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#widl-AnalyserNode-getByteFrequencyData-void-Uint8Array-array', 'getByteFrequencyData()')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td> </td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/analysernode/getbytetimedomaindata/index.html
+++ b/files/zh-cn/web/api/analysernode/getbytetimedomaindata/index.html
@@ -81,20 +81,7 @@ function draw() {
 
 <h2 id="规格">规格</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#widl-AnalyserNode-getByteTimeDomainData-void-Uint8Array-array', 'getByteTimeDomainData()')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td> </td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/analysernode/getfloatfrequencydata/index.html
+++ b/files/zh-cn/web/api/analysernode/getfloatfrequencydata/index.html
@@ -112,20 +112,7 @@ draw();
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">规范</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#widl-AnalyserNode-getFloatFrequencyData-void-Float32Array-array', 'getFloatFrequencyData()')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/analysernode/index.html
+++ b/files/zh-cn/web/api/analysernode/index.html
@@ -155,20 +155,7 @@ draw();</pre>
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#the-analysernode-interface', 'AnalyserNode')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/analysernode/smoothingtimeconstant/index.html
+++ b/files/zh-cn/web/api/analysernode/smoothingtimeconstant/index.html
@@ -75,20 +75,7 @@ draw();</pre>
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#widl-AnalyserNode-smoothingTimeConstant', 'smoothingTimeConstant')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td> </td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/angle_instanced_arrays/index.html
+++ b/files/zh-cn/web/api/angle_instanced_arrays/index.html
@@ -54,20 +54,7 @@ translation_of: Web/API/ANGLE_instanced_arrays
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ANGLE_instanced_arrays', '', 'ANGLE_instanced_arrays')}}</td>
-   <td>{{Spec2('ANGLE_instanced_arrays')}}</td>
-   <td>初始定义。</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/animation/animation/index.html
+++ b/files/zh-cn/web/api/animation/animation/index.html
@@ -31,20 +31,7 @@ translation_of: Web/API/Animation/Animation
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Animations', '#dom-animation-animation', 'animation()' )}}</td>
-   <td>{{Spec2('Web Animations')}}</td>
-   <td>Editor's draft.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器支持">浏览器支持</h2>
 

--- a/files/zh-cn/web/api/animation/cancel/index.html
+++ b/files/zh-cn/web/api/animation/cancel/index.html
@@ -34,20 +34,7 @@ translation_of: Web/API/Animation/cancel
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Animations', '#dom-animation-cancel', 'Animation.cancel()' )}}</td>
-   <td>{{Spec2('Web Animations')}}</td>
-   <td>Editor's draft.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容">浏览器兼容</h2>
 

--- a/files/zh-cn/web/api/animation/cancel_event/index.html
+++ b/files/zh-cn/web/api/animation/cancel_event/index.html
@@ -36,20 +36,7 @@ original_slug: Web/API/Animation/oncancel
 
 <h2 id="标准">标准</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">标准</th>
-   <th scope="col">状态</th>
-   <th scope="col">备注</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Animations', '#dom-animation-oncancel', 'Animation.oncancel' )}}</td>
-   <td>{{Spec2('Web Animations')}}</td>
-   <td>编辑草案中。</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/animation/currenttime/index.html
+++ b/files/zh-cn/web/api/animation/currenttime/index.html
@@ -34,20 +34,7 @@ element.currentTime =<em> someValue;</em></pre>
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">规范</th>
-   <th scope="col">状态</th>
-   <th scope="col">说明</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Animations', '#dom-animation-currenttime', 'currentTime')}}</td>
-   <td>{{Spec2("Web Animations")}}</td>
-   <td> </td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器支持">浏览器支持</h2>
 

--- a/files/zh-cn/web/api/animation/effect/index.html
+++ b/files/zh-cn/web/api/animation/effect/index.html
@@ -24,20 +24,7 @@ animation.effect = new KeyframeEffect({ opacity: [ 1, 0 ] }, 300);
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Animations', '#dom-animation-effect', 'Animation.effect' )}}</td>
-   <td>{{Spec2('Web Animations')}}</td>
-   <td>Editor's draft.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器支持">浏览器支持</h2>
 

--- a/files/zh-cn/web/api/animation/finish/index.html
+++ b/files/zh-cn/web/api/animation/finish/index.html
@@ -64,20 +64,7 @@ translation_of: Web/API/Animation/finish
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Animations', '#dom-animation-finish', 'finish()')}}</td>
-   <td>{{Spec2("Web Animations")}}</td>
-   <td> </td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/animation/finished/index.html
+++ b/files/zh-cn/web/api/animation/finished/index.html
@@ -40,20 +40,7 @@ translation_of: Web/API/Animation/finished
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Animations', '#dom-animation-finished', 'Animation.finished' )}}</td>
-   <td>{{Spec2('Web Animations')}}</td>
-   <td>Editor's draft.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器支持">浏览器支持</h2>
 

--- a/files/zh-cn/web/api/animation/id/index.html
+++ b/files/zh-cn/web/api/animation/id/index.html
@@ -33,20 +33,7 @@ animation.<em>id</em> = "newId";
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">规范</th>
-   <th scope="col">状态</th>
-   <th scope="col">说明</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Animations', '#dom-animation-id', 'Animation.id' )}}</td>
-   <td>{{Spec2('Web Animations')}}</td>
-   <td>Editor's draft.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器支持">浏览器支持</h2>
 

--- a/files/zh-cn/web/api/animation/index.html
+++ b/files/zh-cn/web/api/animation/index.html
@@ -92,20 +92,7 @@ translation_of: Web/API/Animation
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("Web Animations", "#the-animation-interface", "Animation")}}</td>
-   <td>{{Spec2("Web Animations")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/animation/play/index.html
+++ b/files/zh-cn/web/api/animation/play/index.html
@@ -56,20 +56,7 @@ cake.addEventListener("touchstart", growAlice, false);
 
 <h2 id="标准">标准</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Animations', '#dom-animation-play', 'play()')}}</td>
-   <td>{{Spec2("Web Animations")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/animation/playstate/index.html
+++ b/files/zh-cn/web/api/animation/playstate/index.html
@@ -74,20 +74,7 @@ tears.forEach(function(el) {
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">格式</th>
-   <th scope="col">状态</th>
-   <th scope="col">注解</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Animations', '#play-state', 'playState')}}</td>
-   <td>{{Spec2("Web Animations")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/animationevent/animationevent/index.html
+++ b/files/zh-cn/web/api/animationevent/animationevent/index.html
@@ -31,22 +31,7 @@ translation_of: Web/API/AnimationEvent/AnimationEvent
 
 <h2 id="标准">标准</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('CSS3 Animations', '#AnimationEvent-interface', 'AnimationEvent()') }}</td>
-   <td>{{ Spec2('CSS3 Animations')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/animationevent/animationname/index.html
+++ b/files/zh-cn/web/api/animationevent/animationname/index.html
@@ -13,22 +13,7 @@ translation_of: Web/API/AnimationEvent/animationName
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('CSS3 Animations', '#AnimationEvent-animationName', 'AnimationEvent.animationName') }}</td>
-   <td>{{ Spec2('CSS3 Animations')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/zh-cn/web/api/animationevent/index.html
+++ b/files/zh-cn/web/api/animationevent/index.html
@@ -44,22 +44,7 @@ translation_of: Web/API/AnimationEvent
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{ SpecName('CSS3 Animations', '#AnimationEvent-interface', 'AnimationEvent') }}</td>
-   <td>{{ Spec2('CSS3 Animations') }}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/zh-cn/web/api/animationtimeline/index.html
+++ b/files/zh-cn/web/api/animationtimeline/index.html
@@ -16,20 +16,7 @@ translation_of: Web/API/AnimationTimeline
 
 <h2 id="规格"><font><font>规格</font></font></h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col"><font><font>规范</font></font></th>
-   <th scope="col"><font><font>状态</font></font></th>
-   <th scope="col"><font><font>评论</font></font></th>
-  </tr>
-  <tr>
-   <td><font><font>{{SpecName('Web Animations','#the-animationtimeline-interface','AnimationTimeline')}}</font></font></td>
-   <td><font><font>{{Spec2('Web Animations')}}</font></font></td>
-   <td><font><font>编辑者草稿。</font></font></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性"><font><font>浏览器兼容性</font></font></h2>
 

--- a/files/zh-cn/web/api/atob/index.html
+++ b/files/zh-cn/web/api/atob/index.html
@@ -34,32 +34,7 @@ let decodedData = window.atob(encodedData);    // 解码
 
 <h2 id="Specification" name="Specification">规范</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('HTML WHATWG', '#dom-windowbase64-atob', 'WindowBase64.atob()')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>No change since the latest snapshot, {{SpecName("HTML5.1")}}.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1', '#dom-windowbase64-atob', 'WindowBase64.atob()')}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td>Snapshot of {{SpecName("HTML WHATWG")}}. No change.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5 W3C", "#dom-windowbase64-atob", "WindowBase64.atob()")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Snapshot of {{SpecName("HTML WHATWG")}}. Creation of <code>WindowBase64</code> (properties were on the target before it).</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_Compatibility" name="Browser_Compatibility">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/attr/localname/index.html
+++ b/files/zh-cn/web/api/attr/localname/index.html
@@ -49,22 +49,7 @@ element.addEventListener("click", function() {
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">规范</th>
-   <th scope="col">状态</th>
-   <th scope="col">备注</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#dom-attr-localname', 'Attr.localName')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/attr/namespaceuri/index.html
+++ b/files/zh-cn/web/api/attr/namespaceuri/index.html
@@ -42,22 +42,7 @@ translation_of: Web/API/Attr/namespaceURI
 
 <h2 id="规格">规格</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">规格</th>
-   <th scope="col">状态</th>
-   <th scope="col">注释</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("DOM4", "#dom-element-namespaceuri", "Element.namespaceuri")}}</td>
-   <td>{{Spec2("DOM4")}}</td>
-   <td>初始定义</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/attr/prefix/index.html
+++ b/files/zh-cn/web/api/attr/prefix/index.html
@@ -29,27 +29,7 @@ translation_of: Web/API/Attr/prefix
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">规范</th>
-   <th scope="col">状态</th>
-   <th scope="col">备注</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('DOM WHATWG', '#dom-attr-prefix', 'Attr: prefix')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName("DOM4", "#dom-attr-prefix", "Attr.prefix")}}</td>
-   <td>{{Spec2("DOM4")}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/audiobuffer/audiobuffer/index.html
+++ b/files/zh-cn/web/api/audiobuffer/audiobuffer/index.html
@@ -35,20 +35,7 @@ var audioBuffer = new AudioBuffer(context[, options]);</pre>
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API','#AudioBuffer','AudioBuffer')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/audiobuffer/copyfromchannel/index.html
+++ b/files/zh-cn/web/api/audiobuffer/copyfromchannel/index.html
@@ -33,20 +33,7 @@ myArrayBuffer.copyFromChannel(anotherArray,1,0);
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#widl-AudioBuffer-copyFromChannel-void-Float32Array-destination-long-channelNumber-unsigned-long-startInChannel', 'copyFromChannel')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td> </td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/audiobuffer/duration/index.html
+++ b/files/zh-cn/web/api/audiobuffer/duration/index.html
@@ -47,20 +47,7 @@ button.onclick = function() {
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#widl-AudioBuffer-duration', 'duration')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td> </td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/audiobuffer/getchanneldata/index.html
+++ b/files/zh-cn/web/api/audiobuffer/getchanneldata/index.html
@@ -72,20 +72,7 @@ button.onclick = function() {
 
 <h2 id="Specification">Specification</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#dom-audiobuffer-getchanneldata', 'getChannelData')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td> </td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 

--- a/files/zh-cn/web/api/audiobuffer/index.html
+++ b/files/zh-cn/web/api/audiobuffer/index.html
@@ -79,20 +79,7 @@ button.onclick = function() {
 
 <h2 id="规格参数">规格参数</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">规格参数</th>
-   <th scope="col">状态</th>
-   <th scope="col">注释</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#the-audiobuffer-interface', 'AudioBuffer')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/audiobuffer/length/index.html
+++ b/files/zh-cn/web/api/audiobuffer/length/index.html
@@ -48,20 +48,7 @@ button.onclick = function() {
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#widl-AudioBuffer-length', 'length')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td> </td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/audiobuffer/numberofchannels/index.html
+++ b/files/zh-cn/web/api/audiobuffer/numberofchannels/index.html
@@ -51,20 +51,7 @@ button.onclick = function() {
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#widl-AudioBuffer-numberOfChannels', 'numberOfChannels')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td> </td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/audiobuffer/samplerate/index.html
+++ b/files/zh-cn/web/api/audiobuffer/samplerate/index.html
@@ -51,20 +51,7 @@ button.onclick = function() {
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#widl-AudioBuffer-sampleRate', 'sampleRate')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td> </td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/audiobuffersourcenode/audiobuffersourcenode/index.html
+++ b/files/zh-cn/web/api/audiobuffersourcenode/audiobuffersourcenode/index.html
@@ -40,20 +40,7 @@ translation_of: Web/API/AudioBufferSourceNode/AudioBufferSourceNode
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API','#AudioBufferSourceNode','AudioBufferSourceNode()')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_Compatibility">Browser Compatibility</h2>
 

--- a/files/zh-cn/web/api/audiobuffersourcenode/buffer/index.html
+++ b/files/zh-cn/web/api/audiobuffersourcenode/buffer/index.html
@@ -51,22 +51,7 @@ button.onclick = function() {
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("Web Audio API", "#widl-AudioBufferSourceNode-buffer", "buffer")}}</td>
-   <td>{{Spec2("Web Audio API")}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/audiobuffersourcenode/index.html
+++ b/files/zh-cn/web/api/audiobuffersourcenode/index.html
@@ -128,20 +128,7 @@ button.onclick = function() {
 
 <h2 id="规范">规范</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#the-audiobuffersourcenode-interface', 'AudioBufferSourceNode')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td> </td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="浏览器兼容性">浏览器兼容性</h2>
 

--- a/files/zh-cn/web/api/audiobuffersourcenode/start/index.html
+++ b/files/zh-cn/web/api/audiobuffersourcenode/start/index.html
@@ -54,20 +54,7 @@ translation_of: Web/API/AudioBufferSourceNode/start
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#widl-AudioBufferSourceNode-start-void-double-when-double-offset-double-duration', 'start()')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td> </td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 


### PR DESCRIPTION
It's a try to replace standard-table with `{{Specifications}}` macros. Using script [here](https://gist.github.com/yin1999/c718218df49661031280de7eca10ba13).
