### PR TITLE
fix: typo error in zh-cn console_api

### DIFF
--- a/files/zh-cn/web/api/console_api/index.html
+++ b/files/zh-cn/web/api/console_api/index.html
@@ -9,7 +9,7 @@ translation_of: Web/API/Console_API
 
 <h2 id="概念和用法"><font><font>概念和用法</font></font></h2>
 
-<p>Console API最初是一个专有的API,不同的浏览器以自己的试下方式来实现它. <a href="https://console.spec.whatwg.org/">Console API </a> 规范统一了这个API的行为, 并且所有现代浏览器最终都决定实现这种行为 — 尽管一些实现仍然有自己的附加专有功能. 了解这些请查看:</p>
+<p>Console API最初是一个专有的API,不同的浏览器以自己的实现方式来实现它. <a href="https://console.spec.whatwg.org/">Console API </a> 规范统一了这个API的行为, 并且所有现代浏览器最终都决定实现这种行为 — 尽管一些实现仍然有自己的附加专有功能. 了解这些请查看:</p>
 
 <ul>
  <li><a href="https://developers.google.com/chrome-developer-tools/docs/console-api">Google Chrome DevTools implementation</a></li>


### PR DESCRIPTION
typo "不同的浏览器以自己的**试下**方式来实现它" -> "不同的浏览器以自己的**实现**方式来实现它"