### PR TITLE
build(node): bump to node 16

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "16"
 
       - name: Lint markdown files
         run: |

--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "16"
 
       - name: Cache node_modules
         uses: actions/cache@v2.1.6

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "16"
 
       - name: Cache node_modules
         uses: actions/cache@v2.1.6

--- a/.github/workflows/sync-translated-content.yml
+++ b/.github/workflows/sync-translated-content.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "16"
 
       - name: Cache node_modules
         uses: actions/cache@v2.1.6


### PR DESCRIPTION
follow-up of mdn/yari#6357

Fixes #5850.

The github action was failing in the recent pr (expected node version `>=16`). See: https://github.com/mdn/translated-content/runs/6620227563?check_suite_focus=true

```
yarn install v1.22.18
[1/[5](https://github.com/mdn/translated-content/runs/6620227563?check_suite_focus=true#step:6:6)] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
error @mdn/yari@1.0.1: The engine "node" is incompatible with this module. Expected version ">=1[6](https://github.com/mdn/translated-content/runs/6620227563?check_suite_focus=true#step:6:7).0.0". Got "14.1[9](https://github.com/mdn/translated-content/runs/6620227563?check_suite_focus=true#step:6:10).2"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Error: Process completed with exit code 1.
```
