### PR TITLE
(ru) Fix code selection into “new operator” article

### DIFF
--- a/files/ru/web/javascript/reference/operators/new/index.html
+++ b/files/ru/web/javascript/reference/operators/new/index.html
@@ -42,7 +42,7 @@ translation_of: Web/JavaScript/Reference/Operators/new
 
 <ol>
  <li>Создаётся новый объект, наследующий <code><em>Foo</em>.prototype.</code></li>
- <li>Вызывается конструктор — функция <code><em>Foo</em></code> с указанными аргументами и <code><a href="/en-US/docs/Web/JavaScript/Reference/Operators/this">this</a>, привязанным к только что созданному объекту</code>. <code>new F<em>oo</em></code> эквивалентно <code>new </code><em>F<code>oo</code></em><code>()</code>, то есть если аргументы не указаны, Foo вызывается без аргументов.</li>
+ <li>Вызывается конструктор — функция <code><em>Foo</em></code> с указанными аргументами и <code><a href="/en-US/docs/Web/JavaScript/Reference/Operators/this">this</a></code>, привязанным к только что созданному объекту. <code>new <em>Foo</em></code> эквивалентно <code>new <em>Foo</em>()</code>, то есть если аргументы не указаны, <code><em>Foo</em></code> вызывается без аргументов.</li>
  <li>Результатом выражения new становится объект, возвращённый конструктором. Если конструктор не возвращает объект явно, используется объект из п. 1. (Обычно конструкторы не возвращают значение, но они могут делать это, если нужно переопределить обычный процесс создания объектов.)</li>
 </ol>
 


### PR DESCRIPTION
https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Operators/new

<img width="770" alt="image" src="https://user-images.githubusercontent.com/25146266/170730265-910f23eb-dd72-4b12-a049-94146e5fedc2.png">