### PR TITLE
chore: update actions/cache to v3

### DIFF
--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: "16"
 
       - name: Cache node_modules
-        uses: actions/cache@v3.0.2
+        uses: actions/cache@v3
         id: cached-node_modules
         with:
           path: |

--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -73,7 +73,7 @@ jobs:
 
       # See https://www.peterbe.com/plog/install-python-poetry-github-actions-faster
       - name: Load cached ~/.local
-        uses: actions/cache@v3.0.2
+        uses: actions/cache@v3
         with:
           path: ~/.local
           key: dotlocal-${{ runner.os }}-${{ hashFiles('.github/workflows/pr-review-companion.yml') }}
@@ -86,7 +86,7 @@ jobs:
 
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v3.0.2
+        uses: actions/cache@v3
         with:
           path: yari/deployer/.venv
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('.github/workflows/pr-review-companion.yml') }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: "16"
 
       - name: Cache node_modules
-        uses: actions/cache@v3.0.2
+        uses: actions/cache@v3
         id: cached-node_modules
         with:
           path: |

--- a/.github/workflows/sync-translated-content.yml
+++ b/.github/workflows/sync-translated-content.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: "16"
 
       - name: Cache node_modules
-        uses: actions/cache@v3.0.2
+        uses: actions/cache@v3
         id: cached-node_modules
         with:
           path: |


### PR DESCRIPTION
Update to latest version, and unpin it to the latest to reduce the number of Dependabot PRs to bump