### PR TITLE
update links in glossary for zh-CN

### DIFF
--- a/files/zh-cn/glossary/accessibility/index.html
+++ b/files/zh-cn/glossary/accessibility/index.html
@@ -13,20 +13,20 @@ translation_of: Glossary/Accessibility
 <h3 id="常规知识">常规知识</h3>
 
 <ul>
- <li><a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility">Accessibility resources at MDN</a></li>
+ <li><a href="/zh-CN/docs/Web/Accessibility">Accessibility resources at MDN</a></li>
  <li>{{Interwiki("wikipedia", "Web accessibility")}} on Wikipedia</li>
 </ul>
 
 <h3 id="学习_web_accessibility">学习 web accessibility</h3>
 
 <ul>
- <li><a href="http://webaim.org/" rel="external">Web Accessibility In Mind</a></li>
+ <li><a href="https://webaim.org/">Web Accessibility In Mind</a></li>
 </ul>
 
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="/en-US/docs/Web/Accessibility/ARIA">The ARIA documentation on MDN</a></li>
- <li><a href="http://www.w3.org/WAI/" rel="external">The Web Accessibility Initiative homepage</a></li>
- <li><a href="http://www.w3.org/TR/wai-aria/" rel="external">The WAI-ARIA recommendation</a></li>
+ <li><a href="/zh-CN/docs/Web/Accessibility/ARIA">The ARIA documentation on MDN</a></li>
+ <li><a href="https://www.w3.org/WAI/">The Web Accessibility Initiative homepage</a></li>
+ <li><a href="https://www.w3.org/TR/wai-aria/">The WAI-ARIA recommendation</a></li>
 </ul>

--- a/files/zh-cn/glossary/ajax/index.html
+++ b/files/zh-cn/glossary/ajax/index.html
@@ -26,6 +26,6 @@ translation_of: Glossary/AJAX
 <ul>
  <li>{{DOMxRef("XMLHttpRequest")}} 对象</li>
  <li>{{DOMxRef("Fetch API")}} </li>
- <li><a href="zh-CN/docs/Web/Guide/AJAX">MDN 上的 AJAX 文档</a></li>
- <li><a href="/en-US/docs/Web/API/Fetch_API/Using_Fetch">使用Fetch API</a></li>
+ <li><a href="/zh-CN/docs/Web/Guide/AJAX">MDN 上的 AJAX 文档</a></li>
+ <li><a href="/zh-CN/docs/Web/API/Fetch_API/Using_Fetch">使用Fetch API</a></li>
 </ul>

--- a/files/zh-cn/glossary/algorithm/index.html
+++ b/files/zh-cn/glossary/algorithm/index.html
@@ -34,5 +34,5 @@ original_slug: Glossary/算法
 
 <ul>
  <li><a href="https://www.toptal.com/developers/sorting-algorithms">Explanations of sorting algorithms</a></li>
- <li><a href="http://bigocheatsheet.com/">Explanations of algorithmic complexity</a></li>
+ <li><a href="https://bigocheatsheet.com/">Explanations of algorithmic complexity</a></li>
 </ul>

--- a/files/zh-cn/glossary/api/index.html
+++ b/files/zh-cn/glossary/api/index.html
@@ -10,10 +10,10 @@ translation_of: Glossary/API
 <p>例如：</p>
 
 <ul>
- <li><a href="https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia">getUserMedia API</a> 能被用于从用户的摄像头采集音视频。接下来开发者可以任意使用这些音视频，例如记录视频和音频、在视频会议中向其他用户广播，或者从视频中截图。</li>
- <li><a href="/en-US/docs/Web/API/Geolocation">Geolocation API</a> 能被用于从用户的可用的任意定位设备（如 GPS）获取位置信息，然后可以再用 <a href="https://developers.google.com/maps/">Google Maps APIs</a> 将这些位置信息用于在一个自定义的地图上标记出用户的位置和展示用户所在地区的旅游景点。</li>
+ <li><a href="/zh-CN/docs/Web/API/MediaDevices/getUserMedia">getUserMedia API</a> 能被用于从用户的摄像头采集音视频。接下来开发者可以任意使用这些音视频，例如记录视频和音频、在视频会议中向其他用户广播，或者从视频中截图。</li>
+ <li><a href="/zh-CN/docs/Web/API/Geolocation">Geolocation API</a> 能被用于从用户的可用的任意定位设备（如 GPS）获取位置信息，然后可以再用 <a href="https://developers.google.com/maps/">Google Maps APIs</a> 将这些位置信息用于在一个自定义的地图上标记出用户的位置和展示用户所在地区的旅游景点。</li>
  <li><a href="https://dev.twitter.com/overview/api">Twitter APIs</a> 能被用于从用户的 twitter 账户获取数据，然后可以在一个网页上展示他们最近的 tweet 。</li>
- <li><a href="/en-US/docs/Web/API/Web_Animations_API">Web Animations API</a> 能被用于制作一个网页中的动画，例如让网页中的图片移动或旋转。</li>
+ <li><a href="/zh-CN/docs/Web/API/Web_Animations_API">Web Animations API</a> 能被用于制作一个网页中的动画，例如让网页中的图片移动或旋转。</li>
 </ul>
 
 <h2 id="了解更多">了解更多</h2>
@@ -27,5 +27,5 @@ translation_of: Glossary/API
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="https://developer.mozilla.org/en-US/docs/Web/API">Web API 参考</a></li>
+ <li><a href="/zh-CN/docs/Web/API">Web API 参考</a></li>
 </ul>

--- a/files/zh-cn/glossary/apple_safari/index.html
+++ b/files/zh-cn/glossary/apple_safari/index.html
@@ -5,7 +5,7 @@ translation_of: Glossary/Apple_Safari
 ---
 <p> </p>
 
-<p><a href="http://www.apple.com/safari/">Safari</a>是苹果公司开发的{{Glossary("Browser","Web browser")}}，与Mac OS X 和iOS绑定。它基于开源的<a href="http://www.webkit.org/">WebKit</a>引擎。</p>
+<p><a href="https://www.apple.com/safari/">Safari</a>是苹果公司开发的{{Glossary("Browser","Web browser")}}，与Mac OS X 和iOS绑定。它基于开源的<a href="https://www.webkit.org/">WebKit</a>引擎。</p>
 
 <h2 id="了解更多">了解更多</h2>
 
@@ -13,13 +13,13 @@ translation_of: Glossary/Apple_Safari
 
 <ul>
  <li>维基百科上的{{Interwiki("wikipedia", "Safari (web browser)", "Safari")}} </li>
- <li><a href="http://www.apple.com/safari/" rel="external">Safari on apple.com</a></li>
+ <li><a href="https://www.apple.com/safari/">Safari on apple.com</a></li>
 </ul>
 
 <h3 id="技术信息">技术信息</h3>
 
 <ul>
- <li><a href="http://www.webkit.org/">The WebKit project</a></li>
- <li><a href="http://nightly.webkit.org/" rel="external">WebKit nightly build</a></li>
- <li><a href="https://bugs.webkit.org/" rel="external">Reporting a bug for Safari</a></li>
+ <li><a href="https://www.webkit.org/">The WebKit project</a></li>
+ <li><a href="https://nightly.webkit.org/">WebKit nightly build</a></li>
+ <li><a href="https://bugs.webkit.org/">Reporting a bug for Safari</a></li>
 </ul>

--- a/files/zh-cn/glossary/argument/index.html
+++ b/files/zh-cn/glossary/argument/index.html
@@ -9,18 +9,18 @@ translation_of: Glossary/Argument
 ---
 <p> </p>
 
-<p><strong>argument </strong>是一个作为函数输入的<a href="https://developer.mozilla.org/en-US/docs/Glossary/value" title="价值：技术审查完成。">值</a>（<a href="https://developer.mozilla.org/en-US/docs/Glossary/primitive">原始数据</a>或<a href="https://developer.mozilla.org/en-US/docs/Glossary/object" title="object：Object是指包含用于处理数据的数据和指令的数据结构。 对象有时候是指现实世界的东西，例如赛车游戏中的汽车或地图对象。 JavaScript，Java，C ++，Python和Ruby是面向对象编程语言的例子。">对象</a>）。</p>
+<p><strong>argument </strong>是一个作为函数输入的<a href="/zh-CN/docs/Glossary/value">值</a>（<a href="/zh-CN/docs/Glossary/primitive">原始数据</a>或<a href="/zh-CN/docs/Glossary/object">对象</a>）。</p>
 
 <h2 id="学到更多">学到更多</h2>
 
 <h3 id="基本知识">基本知识</h3>
 
 <ul>
- <li><a href="https://en.wikipedia.org/wiki/Parameter_(computer_programming)" title="Difference between Parameter and Argument">Parameter 和 Argument 之间的差异</a> - 维基百科</li>
+ <li><a href="https://en.wikipedia.org/wiki/Parameter_(computer_programming)">Parameter 和 Argument 之间的差异</a> - 维基百科</li>
 </ul>
 
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="https://developer.mozilla.org/en-US/docs/Glossary/JavaScript" title="JavaScript：JavaScript（JS）是一种编程语言，主要用于客户端来动态地脚本化网页，但也常常是服务器端的。">JavaScript 中</a>的 <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments" title="arguments对象是与传递给函数的参数相对应的类Array对象。">arguments</a></code> 对象</li>
+ <li><a href="/zh-CN/docs/Glossary/JavaScript">JavaScript 中</a>的 <code><a href="/zh-CN/docs/Web/JavaScript/Reference/Functions/arguments">arguments</a></code> 对象</li>
 </ul>

--- a/files/zh-cn/glossary/aria/index.html
+++ b/files/zh-cn/glossary/aria/index.html
@@ -13,5 +13,5 @@ translation_of: Glossary/ARIA
 <h2 id="更多">更多</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/Accessibility/ARIA">ARIA </a></li>
+ <li><a href="/zh-CN/docs/Web/Accessibility/ARIA">ARIA </a></li>
 </ul>

--- a/files/zh-cn/glossary/arpa/index.html
+++ b/files/zh-cn/glossary/arpa/index.html
@@ -14,6 +14,6 @@ original_slug: Glossary/地址路由参数域
 <h3 id="通用知识库">通用知识库</h3>
 
 <ul>
- <li><a href="http://www.iana.org/domains/arpa">官方网站</a></li>
+ <li><a href="https://www.iana.org/domains/arpa">官方网站</a></li>
  <li>{{Interwiki("wikipedia", ".arpa")}}，来自维基百科</li>
 </ul>

--- a/files/zh-cn/glossary/asynchronous/index.html
+++ b/files/zh-cn/glossary/asynchronous/index.html
@@ -16,13 +16,13 @@ original_slug: Glossary/异步
 
  <p>对人类来说，电子邮件就是一种异步通信方式；发送者发送了一封邮件，接着接收者会在方便时读取和回复该邮件，而不是马上这样做。双方可以继续随时发送和接收信息，而无需双方安排何时进行操作。</p>
 
- <p>在软件进行异步通信时，一个程序可能会向另一软件（如服务器）请求信息，并在等待回复的同时继续执行其他操作。例如，<a href="/en-US/docs/Web/Guide/AJAX">AJAX</a>(Asynchronous JavaScript and {{Glossary("XML")}})编程技术（现在通常简写为"Ajax"，不过现在的应用不常用XML，而是用{{Glossary("JSON")}}）就是这样一种机制，它通过HTTP从服务器请求较少的数据，当结果可被返回时才返回结果，而不是立即返回。</p>
+ <p>在软件进行异步通信时，一个程序可能会向另一软件（如服务器）请求信息，并在等待回复的同时继续执行其他操作。例如，<a href="/zh-CN/docs/Web/Guide/AJAX">AJAX</a>(Asynchronous JavaScript and {{Glossary("XML")}})编程技术（现在通常简写为"Ajax"，不过现在的应用不常用XML，而是用{{Glossary("JSON")}}）就是这样一种机制，它通过HTTP从服务器请求较少的数据，当结果可被返回时才返回结果，而不是立即返回。</p>
  </dd>
  <dt>软件设计</dt>
  <dd>
  <p>异步软件设计通过构建代码扩展了异步的概念，按照这种设计编写的代码使得程序能够要求一个任务与先前的一个（或多个）任务一起执行，而无需为了等待它们完成而停止执行。 当后来的任务完成时，程序将使用约定好的机制通知先前的任务，以便让它知道任务已经完成，以及如果有结果存在的话，这个结果是可用的。</p>
 
- <p>还有许多用来实现异步软件的编程技术。查看文章<a href="/en-US/docs/Learn/JavaScript/Asynchronous">Asynchronous JavaScript</a>来了解它们吧。</p>
+ <p>还有许多用来实现异步软件的编程技术。查看文章<a href="/zh-CN/docs/Learn/JavaScript/Asynchronous">Asynchronous JavaScript</a>来了解它们吧。</p>
  </dd>
 </dl>
 
@@ -31,6 +31,6 @@ original_slug: Glossary/异步
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Fetching_data">Fetching data from the server</a> (Learning Area) 从服务器获取数据</li>
+ <li><a href="/zh-CN/docs/Learn/JavaScript/Client-side_web_APIs/Fetching_data">Fetching data from the server</a> (Learning Area) 从服务器获取数据</li>
  <li>{{glossary("Synchronous")}} 同步</li>
 </ul>

--- a/files/zh-cn/glossary/attribute/index.html
+++ b/files/zh-cn/glossary/attribute/index.html
@@ -6,13 +6,13 @@ tags:
   - HTML
 translation_of: Glossary/Attribute
 ---
-<p><strong>Attribute</strong> （标签属性）用于拓展HTML  <a href="https://developer.mozilla.org/en-US/docs/Glossary/tag" title="tag: In HTML a tag is used for creating an element.  The name of an HTML element is the name used in angle brackets such as &lt;p> for paragraph.  Note that the end tag's name is preceded by a slash character, &quot;&lt;/p>&quot;, and that in empty elements the end tag is neither required nor allowed. If attributes are not mentioned, default values are used in each case.">tag</a>， 可改变标签行为或提供元数据，属性总是以<code>name = value</code>的格式（属性的识别码后接与之相关的值）</p>
+<p><strong>Attribute</strong> （标签属性）用于拓展HTML  <a href="/zh-CN/docs/Glossary/tag"> for paragraph.  Note that the end tag's name is preceded by a slash character, &quot;&lt;/p>&quot;, and that in empty elements the end tag is neither required nor allowed. If attributes are not mentioned, default values are used in each case.">tag</a>， 可改变标签行为或提供元数据，属性总是以<code>name = value</code>的格式（属性的识别码后接与之相关的值）</p>
 
 <h2 id="深入了解">深入了解</h2>
 
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="/en-US/docs/Web/HTML/Attributes">HTML attribute reference</a></li>
- <li>关于 HTML's <a href="/en-US/docs/Web/HTML/Global_attributes">global attributes</a> 的信息</li>
+ <li><a href="/zh-CN/docs/Web/HTML/Attributes">HTML attribute reference</a></li>
+ <li>关于 HTML's <a href="/zh-CN/docs/Web/HTML/Global_attributes">global attributes</a> 的信息</li>
 </ul>

--- a/files/zh-cn/glossary/base64/index.html
+++ b/files/zh-cn/glossary/base64/index.html
@@ -6,7 +6,7 @@ original_slug: Web/API/WindowBase64/Base64_encoding_and_decoding
 ---
 <p><strong>Base64 </strong>是一组相似的<a href="https://en.wikipedia.org/wiki/Binary-to-text_encoding">二进制到文本</a>（binary-to-text）的编码规则，使得二进制数据在解释成 radix-64 的表现形式后能够用 ASCII 字符串的格式表示出来。<em>Base64</em> 这个词出自一种 <a href="https://en.wikipedia.org/wiki/MIME#Content-Transfer-Encoding">MIME 数据传输编码</a>。 </p>
 
-<p>Base64编码普遍应用于需要通过被设计为处理文本数据的媒介上储存和传输二进制数据而需要编码该二进制数据的场景。这样是为了保证数据的完整并且不用在传输过程中修改这些数据。Base64 也被一些应用（包括使用 <a href="https://en.wikipedia.org/wiki/MIME">MIME</a> 的电子邮件）和在 <a href="/zh-CN/docs/XML">XML</a> 中储存复杂数据时使用。 </p>
+<p>Base64编码普遍应用于需要通过被设计为处理文本数据的媒介上储存和传输二进制数据而需要编码该二进制数据的场景。这样是为了保证数据的完整并且不用在传输过程中修改这些数据。Base64 也被一些应用（包括使用 <a href="https://en.wikipedia.org/wiki/MIME">MIME</a> 的电子邮件）和在 <a href="/zh-CN/docs/Web/XML">XML</a> 中储存复杂数据时使用。 </p>
 
 <p>在 JavaScript 中，有两个函数被分别用来处理解码和编码 <em>base64</em> 字符串：</p>
 
@@ -17,7 +17,7 @@ original_slug: Web/API/WindowBase64/Base64_encoding_and_decoding
 
 <p><code>atob()</code> 函数能够解码通过base-64编码的字符串数据。相反地，<code>btoa()</code> 函数能够从二进制数据“字符串”创建一个base-64编码的ASCII字符串。</p>
 
-<p><code>atob()</code> 和 <code>btoa()</code> 均使用字符串。如果你想使用 <code><a href="/en-US/docs/Web/API/ArrayBuffer">ArrayBuffers</a></code>，请参阅后文。</p>
+<p><code>atob()</code> 和 <code>btoa()</code> 均使用字符串。如果你想使用 <code><a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer">ArrayBuffers</a></code>，请参阅后文。</p>
 
 <h4 id="编码尺寸增加">编码尺寸增加</h4>
 
@@ -34,9 +34,9 @@ original_slug: Web/API/WindowBase64/Base64_encoding_and_decoding
     <h2 class="Documentation" id="Documentation" name="Documentation">文档</h2>
 
     <dl>
-     <dt><a href="https://developer.mozilla.org/en-US/docs/data_URIs" title="https://developer.mozilla.org/en-US/docs/data_URIs"><code>data</code> URIs</a></dt>
-     <dd><small><code>data</code> URIs, 定义于 <a class="external" href="http://tools.ietf.org/html/rfc2397" title="http://tools.ietf.org/html/rfc2397">RFC 2397</a>，用于在文档内嵌入小的文件。</small></dd>
-     <dt><a href="https://en.wikipedia.org/wiki/Base64" title="https://en.wikipedia.org/wiki/Base64">Base64</a></dt>
+     <dt><a href="/zh-CN/docs/Web/HTTP/Basics_of_HTTP/Data_URLs"><code>data</code> URIs</a></dt>
+     <dd><small><code>data</code> URIs, 定义于 <a href="https://tools.ietf.org/html/rfc2397">RFC 2397</a>，用于在文档内嵌入小的文件。</small></dd>
+     <dt><a href="https://en.wikipedia.org/wiki/Base64">Base64</a></dt>
      <dd><small>维基百科上关于 Base64 的文章。</small></dd>
      <dt>{{domxref("WindowBase64.atob","atob()")}}</dt>
      <dd><small>解码一个Base64字符串。</small></dd>
@@ -44,14 +44,14 @@ original_slug: Web/API/WindowBase64/Base64_encoding_and_decoding
      <dd><small>从一个字符串或者二进制数据编码一个Base64字符串。</small></dd>
      <dt><a href="#The_.22Unicode_Problem.22">"Unicode 问题"</a></dt>
      <dd><small>在大多数浏览器里里，在一个Unicode字符串上调用btoa()会造成一个<code>Character Out Of Range异常。这一段写了一些解决方案。</code></small></dd>
-     <dt><a href="/en-US/docs/URIScheme" title="/en-US/docs/URIScheme">URIScheme</a></dt>
+     <dt><a href="/zh-CN/docs/URIScheme">URIScheme</a></dt>
      <dd><small>Mozilla支持的URI schemes列表。</small></dd>
-     <dt><a href="/en-US/docs/Web/JavaScript/Typed_arrays/StringView" title="/en-US/docs/Web/JavaScript/Typed_arrays/StringView"><code>StringView</code></a></dt>
+     <dt><a href="/zh-CN/docs/Web/JavaScript/Typed_arrays/StringView"><code>StringView</code></a></dt>
      <dd>这篇文章发布了一个我们做的库，目的在于：
      <ul>
-      <li>为字符串创建一个类C接口 (i.e. array of characters codes —<a href="/en-US/docs/Web/JavaScript/Typed_arrays/ArrayBufferView" title="/en-US/docs/Web/JavaScript/Typed_arrays/ArrayBufferView"> <code>ArrayBufferView</code></a> in JavaScript) ，基于JavaScript <a href="/en-US/docs/Web/JavaScript/Typed_arrays/ArrayBuffer" title="/en-US/docs/Web/JavaScript/Typed_arrays/ArrayBuffer"><code>ArrayBuffer</code></a> 接口。</li>
+      <li>为字符串创建一个类C接口 (i.e. array of characters codes —<a href="/zh-CN/docs/Web/API/ArrayBufferView"> <code>ArrayBufferView</code></a> in JavaScript) ，基于JavaScript <a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer"><code>ArrayBuffer</code></a> 接口。</li>
       <li>为类字符串对象(目前为止为: <code>stringView</code>s) 创建一系列方法，它们<strong>严格按照数字数组</strong>工作，而不是不可变的字符串。</li>
-      <li>可用于其它Unicode编码，和默认的 <code><a href="/en-US/docs/Web/API/DOMString" title="/en-US/docs/Web/API/DOMString">DOMStrings</a>不同。</code></li>
+      <li>可用于其它Unicode编码，和默认的 <code><a href="/zh-CN/docs/Web/API/DOMString">DOMStrings</a>不同。</code></li>
      </ul>
      </dd>
     </dl>
@@ -62,21 +62,21 @@ original_slug: Web/API/WindowBase64/Base64_encoding_and_decoding
 
     <ul>
      <li><a href="#Solution_.232_.E2.80.93_rewriting_atob()_and_btoa()_using_TypedArrays_and_UTF-8">Rewriting <code>atob()</code> and <code>btoa()</code> using <code>TypedArray</code>s and UTF-8</a></li>
-     <li><a href="/en-US/docs/Web/JavaScript/Typed_arrays/StringView" title="/en-US/docs/Web/JavaScript/Typed_arrays/StringView"><code>StringView</code> – a C-like representation of strings based on typed arrays</a></li>
+     <li><a href="/zh-CN/docs/Web/JavaScript/Typed_arrays/StringView"><code>StringView</code> – a C-like representation of strings based on typed arrays</a></li>
     </ul>
 
 
     <h2 class="Related_Topics" id="Related_Topics" name="Related_Topics">相关文章</h2>
 
     <ul>
-     <li><a href="/en-US/docs/Web/JavaScript/Typed_arrays/ArrayBuffer"><code>ArrayBuffer</code></a></li>
-     <li><a href="/en-US/docs/Web/JavaScript/Typed_arrays">Typed arrays</a></li>
-     <li><a href="/en-US/docs/Web/JavaScript/Typed_arrays/ArrayBufferView">ArrayBufferView</a></li>
-     <li><a href="/en-US/docs/Web/JavaScript/Typed_arrays/Uint8Array"><code>Uint8Array</code></a></li>
-     <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Typed_arrays/StringView" title="/en-US/docs/Web/JavaScript/Typed_arrays/StringView"><code>StringView</code> – a C-like representation of strings based on typed arrays</a></li>
-     <li><a href="/en-US/docs/Web/API/DOMString" title="/en-US/docs/Web/API/DOMString"><code>DOMString</code></a></li>
-     <li><a href="/en-US/docs/URI" title="/en-US/docs/URI"><code>URI</code></a></li>
-     <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI" title="/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI"><code>encodeURI()</code></a></li>
+     <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer"><code>ArrayBuffer</code></a></li>
+     <li><a href="/zh-CN/docs/Web/JavaScript/Typed_arrays">Typed arrays</a></li>
+     <li><a href="/zh-CN/docs/Web/API/ArrayBufferView">ArrayBufferView</a></li>
+     <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array"><code>Uint8Array</code></a></li>
+     <li><a href="/zh-CN/docs/Web/JavaScript/Typed_arrays/StringView"><code>StringView</code> – a C-like representation of strings based on typed arrays</a></li>
+     <li><a href="/zh-CN/docs/Web/API/DOMString"><code>DOMString</code></a></li>
+     <li><a href="/zh-CN/docs/Glossary/URI"><code>URI</code></a></li>
+     <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/encodeURI"><code>encodeURI()</code></a></li>
     </ul>
    </td>
   </tr>
@@ -85,7 +85,7 @@ original_slug: Web/API/WindowBase64/Base64_encoding_and_decoding
 
 <h2 id="Unicode_问题">Unicode 问题</h2>
 
-<p>由于 <a href="/en-US/docs/Web/API/DOMString" title="/en-US/docs/Web/API/DOMString"><code>DOMString</code></a> 是16位编码的字符串，所以如果有字符超出了8位ASCII编码的字符范围时，在大多数的浏览器中对Unicode字符串调用 <code>window.btoa</code> 将会造成一个 <code>Character Out Of Range</code> 的异常。有很多种方法可以解决这个问题：</p>
+<p>由于 <a href="/zh-CN/docs/Web/API/DOMString"><code>DOMString</code></a> 是16位编码的字符串，所以如果有字符超出了8位ASCII编码的字符范围时，在大多数的浏览器中对Unicode字符串调用 <code>window.btoa</code> 将会造成一个 <code>Character Out Of Range</code> 的异常。有很多种方法可以解决这个问题：</p>
 
 <ul>
  <li><a href="#Solution_1_–_JavaScript's_UTF-16_>_base64">the first method</a> consists in encoding JavaScript's native UTF-16 strings directly into base64 (fast, portable, clean)</li>
@@ -97,7 +97,7 @@ original_slug: Web/API/WindowBase64/Base64_encoding_and_decoding
 
 <h3 id="Solution_1_–_JavaScripts_UTF-16_>_base64">Solution #1 – JavaScript's UTF-16 =&gt; base64</h3>
 
-<p>A very fast and widely useable way to solve the unicode problem is by encoding JavaScript native UTF-16 strings directly into base64. Please visit the URL <code>data:text/plain;charset=utf-16;base64,OCY5JjomOyY8Jj4mPyY=</code> for a demonstration (copy the data uri, open a new tab, paste the data URI into the address bar, then press enter to go to the page). This method is particularly efficient because it does not require any type of conversion, except mapping a string into an array. The following code is also useful to get an <a href="/en-US/docs/Web/JavaScript/Typed_arrays/ArrayBuffer">ArrayBuffer</a> from a <em>Base64</em> string and/or viceversa (<a href="#Appendix_to_Solution_1_Decode_a_Base64_string_to_Uint8Array_or_ArrayBuffer" title="Appendix to Solution #1: Decode a Base64 string to Uint8Array or ArrayBuffer">see below</a>).</p>
+<p>A very fast and widely useable way to solve the unicode problem is by encoding JavaScript native UTF-16 strings directly into base64. Please visit the URL <code>data:text/plain;charset=utf-16;base64,OCY5JjomOyY8Jj4mPyY=</code> for a demonstration (copy the data uri, open a new tab, paste the data URI into the address bar, then press enter to go to the page). This method is particularly efficient because it does not require any type of conversion, except mapping a string into an array. The following code is also useful to get an <a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer">ArrayBuffer</a> from a <em>Base64</em> string and/or viceversa (<a href="#Appendix_to_Solution_1_Decode_a_Base64_string_to_Uint8Array_or_ArrayBuffer">see below</a>).</p>
 
 <pre class="brush: js notranslate">"use strict";
 
@@ -218,9 +218,9 @@ alert(sDecodedString); // "☸☹☺☻☼☾☿"</pre>
 
 <p>The produced string is fully portable, although represented as UTF-16. If you prefer UTF-8, see <a href="#Solution_2_–_JavaScript's_UTF-16_>_UTF-8_>_base64">the next solution</a>.</p>
 
-<h4 id="Appendix_to_Solution_1_Decode_a_Base64_string_to_Uint8Array_or_ArrayBuffer">Appendix to <a href="#Solution_1_–_JavaScript's_UTF-16_>_base64">Solution #1</a>: Decode a <em>Base64</em> string to <a href="/en-US/docs/Web/JavaScript/Typed_arrays/Uint8Array">Uint8Array</a> or <a href="/en-US/docs/Web/JavaScript/Typed_arrays/ArrayBuffer">ArrayBuffer</a></h4>
+<h4 id="Appendix_to_Solution_1_Decode_a_Base64_string_to_Uint8Array_or_ArrayBuffer">Appendix to <a href="#Solution_1_–_JavaScript's_UTF-16_>_base64">Solution #1</a>: Decode a <em>Base64</em> string to <a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array">Uint8Array</a> or <a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer">ArrayBuffer</a></h4>
 
-<p>The functions above let us also create <a href="/en-US/docs/Web/JavaScript/Typed_arrays/Uint8Array">uint8Arrays</a> or <a href="/en-US/docs/Web/JavaScript/Typed_arrays/ArrayBuffer">arrayBuffers</a> from <em>base64</em>-encoded strings:</p>
+<p>The functions above let us also create <a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array">uint8Arrays</a> or <a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer">arrayBuffers</a> from <em>base64</em>-encoded strings:</p>
 
 <pre class="brush: js notranslate">var myArray = base64DecToArr("QmFzZSA2NCDigJQgTW96aWxsYSBEZXZlbG9wZXIgTmV0d29yaw=="); // "Base 64 \u2014 Mozilla Developer Network" (as UTF-8)
 
@@ -228,13 +228,13 @@ var myBuffer = base64DecToArr("QmFzZSA2NCDigJQgTW96aWxsYSBEZXZlbG9wZXIgTmV0d29ya
 
 alert(myBuffer.byteLength);</pre>
 
-<div class="note"><strong>Note:</strong> The function <code>base64DecToArr(sBase64[, <em>nBlockSize</em>])</code> returns an <a href="/en-US/docs/Web/JavaScript/Typed_arrays/Uint8Array"><code>uint8Array</code></a> of bytes. If your aim is to build a buffer of 16-bit / 32-bit / 64-bit raw data, use the <code>nBlockSize</code> argument, which is the number of bytes which the <code>uint8Array.buffer.bytesLength</code> property must result to be a multiple of (<code>1</code> or omitted for ASCII, binary content, <a href="https://developer.mozilla.org/en-US/docs/Web/API/DOMString/Binary">binary strings</a>, UTF-8-encoded strings; <code>2</code> for UTF-16 strings; <code>4</code> for UTF-32 strings).</div>
+<div class="note"><strong>Note:</strong> The function <code>base64DecToArr(sBase64[, <em>nBlockSize</em>])</code> returns an <a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array"><code>uint8Array</code></a> of bytes. If your aim is to build a buffer of 16-bit / 32-bit / 64-bit raw data, use the <code>nBlockSize</code> argument, which is the number of bytes which the <code>uint8Array.buffer.bytesLength</code> property must result to be a multiple of (<code>1</code> or omitted for ASCII, binary content, <a href="/zh-CN/docs/Web/API/DOMString/Binary">binary strings</a>, UTF-8-encoded strings; <code>2</code> for UTF-16 strings; <code>4</code> for UTF-32 strings).</div>
 
-<p>For a more complete library, see <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Typed_arrays/StringView" title="/en-US/docs/Web/JavaScript/Typed_arrays/StringView"><code>StringView</code> – a C-like representation of strings based on typed arrays</a> (source code <a href="https://github.com/madmurphy/stringview.js">available on GitHub</a>).</p>
+<p>For a more complete library, see <a href="/zh-CN/docs/Web/JavaScript/Typed_arrays/StringView"><code>StringView</code> – a C-like representation of strings based on typed arrays</a> (source code <a href="https://github.com/madmurphy/stringview.js">available on GitHub</a>).</p>
 
 <h3 id="Solution_2_–_JavaScripts_UTF-16_>_UTF-8_>_base64">Solution #2 – JavaScript's UTF-16 =&gt; UTF-8 =&gt; base64</h3>
 
-<p>This solution consists in converting a JavaScript's native UTF-16 string into a UTF-8 string and then encoding the latter into base64. This also grants that converting a pure ASCII string to base64 always produces the same output as the native <a href="https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/btoa" title="The documentation about this has not yet been written; please consider contributing!"><code>btoa()</code></a>.</p>
+<p>This solution consists in converting a JavaScript's native UTF-16 string into a UTF-8 string and then encoding the latter into base64. This also grants that converting a pure ASCII string to base64 always produces the same output as the native <a href="/zh-CN/docs/Web/API/btoa"><code>btoa()</code></a>.</p>
 
 <pre class="brush: js notranslate">"use strict";
 
@@ -436,7 +436,7 @@ alert(sMyOutput); // "Base 64 — Mozilla Developer Network"</pre>
 
 <h3 id="Solution_3_–_JavaScripts_UTF-16_>_binary_string_>_base64">Solution #3 – JavaScript's UTF-16 =&gt; binary string =&gt; base64</h3>
 
-<p>The following is the fastest and most compact possible approach. The output is exactly the same produced by <a href="#Solution_1_–_JavaScript's_UTF-16_>_base64">Solution #1</a> (UTF-16 encoded strings), but instead of rewriting {{domxref("WindowBase64.atob","atob()")}} and {{domxref("WindowBase64.btoa","btoa()")}} it uses the native ones. This is made possible by the fact that instead of using typed arrays as encoding/decoding inputs this solution uses <a href="/en-US/docs/Web/API/DOMString/Binary">binary strings</a> as an intermediate format. It is a “dirty” workaround in comparison to <a href="#Solution_1_–_JavaScript's_UTF-16_>_base64">Solution #1</a> (<a href="/en-US/docs/Web/API/DOMString/Binary">binary strings</a> are a grey area), however it works pretty well and requires only a few lines of code.</p>
+<p>The following is the fastest and most compact possible approach. The output is exactly the same produced by <a href="#Solution_1_–_JavaScript's_UTF-16_>_base64">Solution #1</a> (UTF-16 encoded strings), but instead of rewriting {{domxref("WindowBase64.atob","atob()")}} and {{domxref("WindowBase64.btoa","btoa()")}} it uses the native ones. This is made possible by the fact that instead of using typed arrays as encoding/decoding inputs this solution uses <a href="/zh-CN/docs/Web/API/DOMString/Binary">binary strings</a> as an intermediate format. It is a “dirty” workaround in comparison to <a href="#Solution_1_–_JavaScript's_UTF-16_>_base64">Solution #1</a> (<a href="/zh-CN/docs/Web/API/DOMString/Binary">binary strings</a> are a grey area), however it works pretty well and requires only a few lines of code.</p>
 
 <pre class="brush: js notranslate">"use strict";
 
@@ -522,7 +522,7 @@ b64DecodeUnicode('Cg=='); // "\n"
 
 <h3 id="Solution_5_–_rewrite_the_DOMs_atob_and_btoa_using_JavaScripts_TypedArrays_and_UTF-8">Solution #5 – rewrite the DOMs <code>atob()</code> and <code>btoa()</code> using JavaScript's <code>TypedArray</code>s and UTF-8</h3>
 
-<p>Use a <a href="/en-US/docs/Web/API/TextEncoder">TextEncoder</a> polyfill such as <a href="https://github.com/inexorabletash/text-encoding">TextEncoding</a> (also includes legacy windows, mac, and ISO encodings), <a href="https://github.com/coolaj86/TextEncoderLite">TextEncoderLite</a>, combined with a <a href="https://github.com/feross/buffer">Buffer</a> and a Base64 implementation such as <a href="https://github.com/beatgammit/base64-js">base64-js</a> or <a href="https://github.com/waitingsong/base64">TypeScript version of </a>base64-js for both modern browsers and Node.js.</p>
+<p>Use a <a href="/zh-CN/docs/Web/API/TextEncoder">TextEncoder</a> polyfill such as <a href="https://github.com/inexorabletash/text-encoding">TextEncoding</a> (also includes legacy windows, mac, and ISO encodings), <a href="https://github.com/coolaj86/TextEncoderLite">TextEncoderLite</a>, combined with a <a href="https://github.com/feross/buffer">Buffer</a> and a Base64 implementation such as <a href="https://github.com/beatgammit/base64-js">base64-js</a> or <a href="https://github.com/waitingsong/base64">TypeScript version of </a>base64-js for both modern browsers and Node.js.</p>
 
 <p>When a native <code>TextEncoder</code> implementation is not available, the most light-weight solution would be to use <a href="#Solution_3_–_JavaScript's_UTF-16_>_binary_string_>_base64">Solution #3</a> because in addition to being much faster, <a href="#Solution_3_–_JavaScript's_UTF-16_>_binary_string_>_base64">Solution #3</a> also works in IE9 "out of the box." Alternatively, use <a href="https://github.com/coolaj86/TextEncoderLite">TextEncoderLite</a> with <a href="https://github.com/beatgammit/base64-js">base64-js</a>. Use the browser implementation when you can.</p>
 
@@ -550,7 +550,7 @@ function Base64Decode(str, encoding = 'utf-8') {
 
 <ul>
  <li>第一个是转义(escape)整个字符串然后编码这个它；</li>
- <li>第二个是把UTF-16的 <a href="/en-US/docs/Web/API/DOMString" title="/en-US/docs/Web/API/DOMString"><code>DOMString</code></a> 转码为UTF-8的字符数组然后编码它。</li>
+ <li>第二个是把UTF-16的 <a href="/zh-CN/docs/Web/API/DOMString"><code>DOMString</code></a> 转码为UTF-8的字符数组然后编码它。</li>
 </ul>
 
 <h3 id="方案_1_–_编码之前转义escape字符串">方案 #1 – 编码之前转义(escape)字符串</h3>
@@ -583,22 +583,22 @@ b64DecodeUnicode('Cg=='); // "\n"</code></pre>
 
 <p>最简单，最轻量级的解决方法就是使用 <a href="https://github.com/coolaj86/TextEncoderLite/blob/master/index.js">TextEncoderLite</a> 和 <a href="https://github.com/beatgammit/base64-js/blob/master/index.js">base64-js</a>.</p>
 
-<p>想要更完整的库的话，参见 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Typed_arrays/StringView" title="/en-US/docs/Web/JavaScript/Typed_arrays/StringView"><code>StringView</code> – a C-like representation of strings based on typed arrays</a>.</p>
+<p>想要更完整的库的话，参见 <a href="/zh-CN/docs/Web/JavaScript/Typed_arrays/StringView"><code>StringView</code> – a C-like representation of strings based on typed arrays</a>.</p>
 
 <h2 id="参见">参见</h2>
 
 <ul>
  <li>{{domxref("WindowBase64.atob","atob()")}}</li>
  <li>{{domxref("WindowBase64.btoa","btoa()")}}</li>
- <li><a href="/en-US/docs/data_URIs" title="/en-US/docs/data_URIs"><code>data</code> URIs</a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Typed_arrays/ArrayBuffer">ArrayBuffer</a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Typed_arrays">TypedArrays</a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Typed_arrays/ArrayBufferView">ArrayBufferView</a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Typed_arrays/Uint8Array">Uint8Array</a></li>
- <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Typed_arrays/StringView" title="/en-US/docs/Web/JavaScript/Typed_arrays/StringView"><code>StringView</code> – a C-like representation of strings based on typed arrays</a></li>
- <li><a href="/en-US/docs/Web/API/DOMString" title="/en-US/docs/Web/API/DOMString">DOMString</a></li>
- <li><a href="/en-US/docs/URI" title="/en-US/docs/URI"><code>URI</code></a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI" title="/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI"><code>encodeURI()</code></a></li>
- <li><a href="/en-US/docs/XPCOM_Interface_Reference/nsIURIFixup" title="/en-US/docs/XPCOM_Interface_Reference/nsIURIFixup"><code>nsIURIFixup()</code></a></li>
- <li><a href="https://en.wikipedia.org/wiki/Base64" title="https://en.wikipedia.org/wiki/Base64"><code>Base64 on Wikipedia</code></a></li>
+ <li><a href="/zh-CN/docs/Web/HTTP/Basics_of_HTTP/Data_URLs"><code>data</code> URIs</a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer">ArrayBuffer</a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Typed_arrays">TypedArrays</a></li>
+ <li><a href="/zh-CN/docs/Web/API/ArrayBufferView">ArrayBufferView</a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array">Uint8Array</a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Typed_arrays/StringView"><code>StringView</code> – a C-like representation of strings based on typed arrays</a></li>
+ <li><a href="/zh-CN/docs/Web/API/DOMString">DOMString</a></li>
+ <li><a href="/zh-CN/docs/Glossary/URI"><code>URI</code></a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/encodeURI"><code>encodeURI()</code></a></li>
+ <li><a href="/zh-CN/docs/XPCOM_Interface_Reference/nsIURIFixup"><code>nsIURIFixup()</code></a></li>
+ <li><a href="https://en.wikipedia.org/wiki/Base64"><code>Base64 on Wikipedia</code></a></li>
 </ul>

--- a/files/zh-cn/glossary/baseline/index.html
+++ b/files/zh-cn/glossary/baseline/index.html
@@ -21,5 +21,5 @@ original_slug: Glossary/基线
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li>MDN 上的 CSS 盒对齐 <a href="/en-US/docs/Web/CSS/CSS_Box_Alignment#Types_of_alignment">CSS Box Alignment</a> </li>
+ <li>MDN 上的 CSS 盒对齐 <a href="/zh-CN/docs/Web/CSS/CSS_Box_Alignment#Types_of_alignment">CSS Box Alignment</a> </li>
 </ul>

--- a/files/zh-cn/glossary/bezier_curve/index.html
+++ b/files/zh-cn/glossary/bezier_curve/index.html
@@ -26,7 +26,7 @@ original_slug: Glossary/Bézier_curve
 <h3 id="学习使用贝塞尔曲线">学习使用贝塞尔曲线</h3>
 
 <ul>
- <li><a href="/en-US/docs/Web/CSS/timing-function#The_cubic-bezier()_class_of_timing_functions">Cubic Bézier timing functions in CSS</a></li>
+ <li><a href="/zh-CN/docs/Web/CSS/easing-function#The_cubic-bezier()_class_of_timing_functions">Cubic Bézier timing functions in CSS</a></li>
  <li>{{SVGAttr("keySplines")}} SVG attribute</li>
- <li><a href="/en-US/docs/Web/CSS/Tools/Cubic_Bezier_Generator">Cubic Bézier Generator</a></li>
+ <li><a href="/zh-CN/docs/Web/CSS/Tools/Cubic_Bezier_Generator">Cubic Bézier Generator</a></li>
 </ul>

--- a/files/zh-cn/glossary/bidi/index.html
+++ b/files/zh-cn/glossary/bidi/index.html
@@ -19,5 +19,5 @@ translation_of: Glossary/BiDi
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="/en-US/Apps/Build/Localization/Developing_Bidi_Apps">开发Bidi应用</a></li>
+ <li><a href="/zh-CN/Apps/Build/Localization/Developing_Bidi_Apps">开发Bidi应用</a></li>
 </ul>

--- a/files/zh-cn/glossary/bigint/index.html
+++ b/files/zh-cn/glossary/bigint/index.html
@@ -21,6 +21,6 @@ translation_of: Glossary/BigInt
 <h3 id="参阅">参阅</h3>
 
 <ul>
- <li>JavaScript 数据结构: <a href="/en-US/docs/Web/JavaScript/Data_structures#BigInt_type">BigInt</a></li>
+ <li>JavaScript 数据结构: <a href="/zh-CN/docs/Web/JavaScript/Data_structures#BigInt_type">BigInt</a></li>
  <li>JavaScript 全局对象 {{jsxref("BigInt")}}</li>
 </ul>

--- a/files/zh-cn/glossary/blink/index.html
+++ b/files/zh-cn/glossary/blink/index.html
@@ -12,7 +12,7 @@ translation_of: Glossary/Blink
 <h3 id="常识">常识</h3>
 
 <ul>
- <li>Blink 项目 <a href="http://www.chromium.org/blink">主页</a>（英文）</li>
- <li>Wikipedia上的信息：<a href="http://en.wikipedia.org/wiki/Blink_%28layout_engine%29">Blink</a></li>
- <li>Blink 的 <a href="http://www.chromium.org/blink/developer-faq">FAQ</a> （英文）</li>
+ <li>Blink 项目 <a href="https://www.chromium.org/blink">主页</a>（英文）</li>
+ <li>Wikipedia上的信息：<a href="https://en.wikipedia.org/wiki/Blink_%28layout_engine%29">Blink</a></li>
+ <li>Blink 的 <a href="https://www.chromium.org/blink/developer-faq">FAQ</a> （英文）</li>
 </ul>

--- a/files/zh-cn/glossary/block/css/index.html
+++ b/files/zh-cn/glossary/block/css/index.html
@@ -16,5 +16,5 @@ translation_of: Glossary/Block/CSS
 <h3 id="General_knowledge">General knowledge</h3>
 
 <ul>
- <li><a href="/en-US/docs/Web/Guide/CSS/Visual_formatting_model">Visual formatting model</a></li>
+ <li><a href="/zh-CN/docs/Web/CSS/Visual_formatting_model">Visual formatting model</a></li>
 </ul>

--- a/files/zh-cn/glossary/block/scripting/index.html
+++ b/files/zh-cn/glossary/block/scripting/index.html
@@ -14,5 +14,5 @@ translation_of: Glossary/Block/Scripting
 <h3 id="了解关于">了解关于</h3>
 
 <ul>
- <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/block">JavaScript函数块声明</a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Statements/block">JavaScript函数块声明</a></li>
 </ul>

--- a/files/zh-cn/glossary/boolean/index.html
+++ b/files/zh-cn/glossary/boolean/index.html
@@ -44,5 +44,5 @@ for(var i=0; i&lt;4; i++) {
 
 <ul>
  <li>标准全局对象: {{jsxref("Boolean")}}</li>
- <li><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Data_structures">JavaScript 数据类型和数据结构</a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Data_structures">JavaScript 数据类型和数据结构</a></li>
 </ul>

--- a/files/zh-cn/glossary/browser/index.html
+++ b/files/zh-cn/glossary/browser/index.html
@@ -12,14 +12,14 @@ original_slug: Glossary/浏览器
 
 <ul>
  <li>维基百科上的{{Interwiki("wikipedia", "浏览器")}} </li>
- <li><a href="http://www.evolutionoftheweb.com/?hl=zh-cn" rel="external">网络的演变</a></li>
+ <li><a href="http://www.evolutionoftheweb.com/?hl=zh-cn">网络的演变</a></li>
 </ul>
 
 <h3 id="下载一个浏览器">下载一个浏览器</h3>
 
 <ul>
- <li><a href="http://www.mozilla.org/en-US/firefox/features/">Mozilla Firefox</a></li>
- <li><a href="http://www.google.com/chrome/" rel="external">Google Chrome</a></li>
- <li><a href="http://windows.microsoft.com/en-US/internet-explorer/browser-ie" rel="external">Microsoft Internet Explorer</a></li>
- <li><a href="http://www.opera.com/" rel="external">Opera Browser</a></li>
+ <li><a href="https://www.mozilla.org/en-US/firefox/features/">Mozilla Firefox</a></li>
+ <li><a href="https://www.google.com/chrome/">Google Chrome</a></li>
+ <li><a href="https://windows.microsoft.com/en-US/internet-explorer/browser-ie">Microsoft Internet Explorer</a></li>
+ <li><a href="https://www.opera.com/">Opera Browser</a></li>
 </ul>

--- a/files/zh-cn/glossary/canvas/index.html
+++ b/files/zh-cn/glossary/canvas/index.html
@@ -19,14 +19,14 @@ translation_of: Glossary/Canvas
 <h3 id="学习资源">学习资源</h3>
 
 <ul>
- <li><a href="/zh-CN/docs/Web/Guide/HTML/Canvas_tutorial">查看MDN上的canvas教程</a></li>
+ <li><a href="/zh-CN/docs/Web/API/Canvas_API/Tutorial">查看MDN上的canvas教程</a></li>
 </ul>
 
 <h3 id="技术信息">技术信息</h3>
 
 <ul>
  <li>MDN 上关于 HTML5 {{HTMLElement("canvas")}} 元素的信息</li>
- <li><a href="/zh-CN/docs/HTML/Canvas">MDN 上关于 Canvas 的常规信息</a></li>
+ <li><a href="/zh-CN/docs/Web/API/Canvas_API">MDN 上关于 Canvas 的常规信息</a></li>
  <li>画布 2D 绘图 API：{{domxref("CanvasRenderingContext2D")}}</li>
- <li><a href="http://www.w3.org/TR/2dcontext/" rel="external">Canvas 2D API 规格</a></li>
+ <li><a href="https://www.w3.org/TR/2dcontext/">Canvas 2D API 规格</a></li>
 </ul>

--- a/files/zh-cn/glossary/certified/index.html
+++ b/files/zh-cn/glossary/certified/index.html
@@ -12,12 +12,12 @@ translation_of: Glossary/Certified
 <h3 id="一般性知识">一般性知识</h3>
 
 <ul>
- <li><a href="https://developer.mozilla.org/en-US/Learn/tutorial/Information_Security_Basics">信息安全教程</a></li>
+ <li><a href="/zh-CN/Learn/tutorial/Information_Security_Basics">信息安全教程</a></li>
  <li>维基百科中的{{Interwiki("wikipedia", "Professional_certification_(computer_technology)#Information_systems_security", "证书")}}</li>
 </ul>
 
 <h3 id="Firefox_OS">Firefox OS</h3>
 
 <ul>
- <li>Firefox OS中内置软件有时也被称为已认证软件：在<a href="/en-US/Apps/Build/App_permissions">应用权限</a>中了解更多。</li>
+ <li>Firefox OS中内置软件有时也被称为已认证软件：在<a href="/zh-CN/Apps/Build/App_permissions">应用权限</a>中了解更多。</li>
 </ul>

--- a/files/zh-cn/glossary/character_set/index.html
+++ b/files/zh-cn/glossary/character_set/index.html
@@ -17,7 +17,7 @@ translation_of: Glossary/character_set
    <li>{{Interwiki("wikipedia", "Mojibake")}}</li>
   </ol>
  </li>
- <li><a href="/en-US/docs/Glossary">Glossary</a>
+ <li><a href="/zh-CN/docs/Glossary">Glossary</a>
   <ol>
    <li>{{Glossary("Character")}}</li>
    <li>{{Glossary("Unicode")}}</li>

--- a/files/zh-cn/glossary/chrome/index.html
+++ b/files/zh-cn/glossary/chrome/index.html
@@ -12,5 +12,5 @@ translation_of: Glossary/Chrome
 <h2 id="了解更多">了解更多</h2>
 
 <ul>
- <li><a href="http://www.nngroup.com/articles/browser-and-gui-chrome/">浏览器和 GUI Chrome</a> </li>
+ <li><a href="https://www.nngroup.com/articles/browser-and-gui-chrome/">浏览器和 GUI Chrome</a> </li>
 </ul>

--- a/files/zh-cn/glossary/class/index.html
+++ b/files/zh-cn/glossary/class/index.html
@@ -12,8 +12,8 @@ tags:
 <h3 id="General_knowledge">基本知识</h3>
 
 <ul>
- <li><a href="/en-US/docs/Web/JavaScript/Guide/Details_of_the_Object_Model#Class-based_vs._prototype-based_languages">Class-based vs. prototype-based programming languages</a> (like JavaScript)</li>
- <li><a href="/en-US/docs/Learn/JavaScript/Objects#The_Class">Using functions as classes in JavaScript</a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Guide/Details_of_the_Object_Model#Class-based_vs._prototype-based_languages">Class-based vs. prototype-based programming languages</a> (like JavaScript)</li>
+ <li><a href="/zh-CN/docs/Learn/JavaScript/Objects#The_Class">Using functions as classes in JavaScript</a></li>
  <li><a href="https://en.wikipedia.org/wiki/Class-based_programming">Class-based programming</a> on Wikipedia</li>
  <li><a href="https://en.wikipedia.org/wiki/Object-oriented_programming">Object-oriented programming</a> on Wikipedia</li>
 </ul>

--- a/files/zh-cn/glossary/code_splitting/index.html
+++ b/files/zh-cn/glossary/code_splitting/index.html
@@ -11,15 +11,15 @@ translation_of: Glossary/Code_splitting
 ---
 <p><strong>代码分割（Code splitting ）</strong>是将代码划分为可以按需/同时加载的多个 bundles 或组件。</p>
 
-<p>随着应用程序日趋复杂，或仅是对其进行简单的维护，CSS 和 JavaScripts 文件以及 bundles 的大小都会随之增加，尤其是所包含的第三方库的数量和大小的增长。为了避免下载巨大的文件，可以将脚本拆分为多个较小的文件。当前页面所需的代码能够立即加载，而另外的脚本可以在与页面或应用交互后懒加载（<a href="/en-US/docs/Glossary/Lazy_load">lazy loaded</a>），页面性能因此提升。虽然代码的总量仍然相同（甚至可能大了几个字节），但是初次加载所需的代码数量减少了。</p>
+<p>随着应用程序日趋复杂，或仅是对其进行简单的维护，CSS 和 JavaScripts 文件以及 bundles 的大小都会随之增加，尤其是所包含的第三方库的数量和大小的增长。为了避免下载巨大的文件，可以将脚本拆分为多个较小的文件。当前页面所需的代码能够立即加载，而另外的脚本可以在与页面或应用交互后懒加载（<a href="/zh-CN/docs/Glossary/Lazy_load">lazy loaded</a>），页面性能因此提升。虽然代码的总量仍然相同（甚至可能大了几个字节），但是初次加载所需的代码数量减少了。</p>
 
-<p>代码分割是由 <a href="https://webpack.js.org/">Webpack</a> 和 <a href="http://browserify.org/">Browserify</a> 等打包工具所支持的一项功能，这些打包工具能够创建在运行时动态加载的多个 bundles。</p>
+<p>代码分割是由 <a href="https://webpack.js.org/">Webpack</a> 和 <a href="https://browserify.org/">Browserify</a> 等打包工具所支持的一项功能，这些打包工具能够创建在运行时动态加载的多个 bundles。</p>
 
 <h2 id="另请参见">另请参见</h2>
 
 <ul>
  <li>Bundling</li>
- <li><a href="/en-US/docs/Learn/Performance/Lazy_loading">Lazy loading</a></li>
- <li><a href="/en-US/docs/Glossary/HTTP_2">HTTP/2</a></li>
- <li><a href="/en-US/docs/Glossary/Tree_shaking">Tree shaking</a></li>
+ <li><a href="/zh-CN/docs/Web/Performance/Lazy_loading">Lazy loading</a></li>
+ <li><a href="/zh-CN/docs/Glossary/HTTP_2">HTTP/2</a></li>
+ <li><a href="/zh-CN/docs/Glossary/Tree_shaking">Tree shaking</a></li>
 </ul>

--- a/files/zh-cn/glossary/codec/index.html
+++ b/files/zh-cn/glossary/codec/index.html
@@ -16,5 +16,5 @@ translation_of: Glossary/Codec
 <h3 id="Technical_reference">Technical reference</h3>
 
 <ul>
- <li><a href="/en-US/docs/Web/HTML/Supported_media_formats">Media formats supported by the HTML audio and video elements</a></li>
+ <li><a href="/zh-CN/docs/Web/Media/Formats">Media formats supported by the HTML audio and video elements</a></li>
 </ul>

--- a/files/zh-cn/glossary/compile/index.html
+++ b/files/zh-cn/glossary/compile/index.html
@@ -25,5 +25,5 @@ original_slug: Glossary/编译
 
 <ul>
  <li><a href="https://medium.com/basecs/a-deeper-inspection-into-compilation-and-interpretation-d98952ebc842">Base CS Introduction on Compilers</a></li>
- <li><a href="http://stackoverflow.com/a/1672/133203">A big list of learning material on StackOverflow</a></li>
+ <li><a href="https://stackoverflow.com/a/1672/133203">A big list of learning material on StackOverflow</a></li>
 </ul>

--- a/files/zh-cn/glossary/control_flow/index.html
+++ b/files/zh-cn/glossary/control_flow/index.html
@@ -34,11 +34,11 @@ translation_of: Glossary/Control_flow
 <h3 id="Technical_reference">Technical reference</h3>
 
 <ul>
- <li><a href="/en-US/docs/Web/JavaScript/Reference#Control_flow">JavaScript Reference - Control flow</a> on MDN</li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Reference#Control_flow">JavaScript Reference - Control flow</a> on MDN</li>
 </ul>
 
 <h3 id="Learn_about_it">Learn about it</h3>
 
 <ul>
- <li><a href="/en-US/docs/Web/JavaScript/Guide/Statements">Statements (Control flow)</a> on MDN</li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Guide/Control_flow_and_error_handling">Statements (Control flow)</a> on MDN</li>
 </ul>

--- a/files/zh-cn/glossary/cookie/index.html
+++ b/files/zh-cn/glossary/cookie/index.html
@@ -7,7 +7,7 @@ translation_of: Glossary/Cookie
 
 <p>Cookie 用于个性化用户的体验。可能包含用户在访问网站时的参数或输入。用户可以自定义浏览器来接受，拒绝或删除 Cookie。</p>
 
-<p><code>Cookie 可以在服务器级别设置和修改，使用 Set-Cookie</code> <a href="/en-US/docs/Web/HTTP/Cookies">HTTP header</a>, 或者在 JavaScript 中用 <code><a href="/en-US/docs/Web/API/Document/cookie">document.cookie</a></code>.</p>
+<p><code>Cookie 可以在服务器级别设置和修改，使用 Set-Cookie</code> <a href="/zh-CN/docs/Web/HTTP/Cookies">HTTP header</a>, 或者在 JavaScript 中用 <code><a href="/zh-CN/docs/Web/API/Document/cookie">document.cookie</a></code>.</p>
 
 <h2 id="了解更多">了解更多</h2>
 

--- a/files/zh-cn/glossary/cors/index.html
+++ b/files/zh-cn/glossary/cors/index.html
@@ -15,7 +15,7 @@ translation_of: Glossary/CORS
 <h3 id="总体了解">总体了解</h3>
 
 <ul>
- <li>MDN上的 <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS">Cross-Origin Resource Sharing (CORS)</a></li>
+ <li>MDN上的 <a href="/zh-CN/docs/Web/HTTP/CORS">Cross-Origin Resource Sharing (CORS)</a></li>
  <li>维基百科上的 {{Interwiki("wikipedia", "Cross-origin resource sharing")}}</li>
 </ul>
 

--- a/files/zh-cn/glossary/crawler/index.html
+++ b/files/zh-cn/glossary/crawler/index.html
@@ -18,7 +18,7 @@ translation_of: Glossary/Crawler
 
 <section id="Quick_links">
 <ol>
- <li><a href="/en-US/docs/">MDN网络文档术语表</a>
+ <li><a href="/zh-CN/docs/">MDN网络文档术语表</a>
 
   <ol>
    <li>{{Glossary("Search engine")}}</li>

--- a/files/zh-cn/glossary/cross-site_scripting/index.html
+++ b/files/zh-cn/glossary/cross-site_scripting/index.html
@@ -40,6 +40,6 @@ translation_of: Glossary/Cross-site_scripting
 <ul>
  <li>{{Interwiki("wikipedia", "Cross-site scripting")}} on Wikipedia</li>
  <li><a href="https://www.owasp.org/index.php/XSS">Cross-site scripting on OWASP</a></li>
- <li><a href="http://www.acunetix.com/blog/web-security-zone/articles/dom-xss-explained/">Another article about Cross-site scripting</a></li>
+ <li><a href="https://www.acunetix.com/blog/web-security-zone/articles/dom-xss-explained/">Another article about Cross-site scripting</a></li>
  <li><a href="https://secure.wphackedhelp.com/blog/wordpress-xss-attack/">XSS Attack – Exploit &amp; Protection</a></li>
 </ul>

--- a/files/zh-cn/glossary/cross_axis/index.html
+++ b/files/zh-cn/glossary/cross_axis/index.html
@@ -32,14 +32,14 @@ original_slug: Glossary/交叉轴
 <h3 id="拓展阅读">拓展阅读</h3>
 
 <ul>
- <li>CSS 弹性容器指南：<em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox">Basic Concepts of Flexbox</a></em></li>
- <li>CSS 弹性容器指南：<em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container">Aligning items in a flex container</a></em></li>
- <li>CSS 弹性容器指南：<em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Mastering_Wrapping_of_Flex_Items">Mastering wrapping of flex items</a></em></li>
+ <li>CSS 弹性容器指南：<em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox">Basic Concepts of Flexbox</a></em></li>
+ <li>CSS 弹性容器指南：<em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container">Aligning items in a flex container</a></em></li>
+ <li>CSS 弹性容器指南：<em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Mastering_Wrapping_of_Flex_Items">Mastering wrapping of flex items</a></em></li>
 </ul>
 
 <section id="Quick_links">
 <ol>
- <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
+ <li><a href="/zh-CN/docs/Glossary">MDN Web Docs Glossary</a>
 
   <ol>
    <li>{{Glossary("Cross Axis")}}</li>

--- a/files/zh-cn/glossary/csp/index.html
+++ b/files/zh-cn/glossary/csp/index.html
@@ -22,5 +22,5 @@ translation_of: Glossary/CSP
 <h3 id="技术知识">技术知识</h3>
 
 <ul>
- <li><a href="/en-US/docs/Web/Security/CSP">Content Security Policy documentation on MDN</a></li>
+ <li><a href="/zh-CN/docs/Web/HTTP/CSP">Content Security Policy documentation on MDN</a></li>
 </ul>

--- a/files/zh-cn/glossary/csrf/index.html
+++ b/files/zh-cn/glossary/csrf/index.html
@@ -21,5 +21,5 @@ translation_of: Glossary/CSRF
 <ul>
  <li>{{Interwiki("wikipedia", "跨站请求伪造")}} on Wikipedia</li>
  <li><a href="https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet">防御方法</a></li>
- <li><a href="/en-US/Learn/tutorial/Information_Security_Basics">MDN 安全手册</a></li>
+ <li><a href="/zh-CN/Learn/tutorial/Information_Security_Basics">MDN 安全手册</a></li>
 </ul>

--- a/files/zh-cn/glossary/css/index.html
+++ b/files/zh-cn/glossary/css/index.html
@@ -29,7 +29,7 @@ p {
 <h3 id="基础知识">基础知识</h3>
 
 <ul>
- <li><a href="https://developer.mozilla.org/zh-CN/Learn/CSS">CSS 教程</a></li>
+ <li><a href="/zh-CN/Learn/CSS">CSS 教程</a></li>
  <li>维基百科 {{interwiki("wikipedia", "CSS")}} 词条</li>
 </ul>
 
@@ -37,5 +37,5 @@ p {
 
 <ul>
  <li><a href="/zh-CN/docs/Web/CSS">MDN CSS 文档</a></li>
- <li><a href="http://www.w3.org/Style/CSS/current-work" rel="external">W3 CSS 工作组的当前工作</a></li>
+ <li><a href="https://www.w3.org/Style/CSS/current-work">W3 CSS 工作组的当前工作</a></li>
 </ul>

--- a/files/zh-cn/glossary/css_preprocessor/index.html
+++ b/files/zh-cn/glossary/css_preprocessor/index.html
@@ -18,8 +18,8 @@ translation_of: Glossary/CSS_preprocessor
 <p>这里是一些最流行的CSS预处理器:</p>
 
 <ul>
- <li><a href="http://sass-lang.com/">Sass</a></li>
- <li><a href="http://lesscss.org/">LESS</a></li>
- <li><a href="http://stylus-lang.com/">Stylus</a></li>
- <li><a href="http://postcss.org/">PostCSS</a></li>
+ <li><a href="https://sass-lang.com/">Sass</a></li>
+ <li><a href="https://lesscss.org/">LESS</a></li>
+ <li><a href="https://stylus-lang.com/">Stylus</a></li>
+ <li><a href="https://postcss.org/">PostCSS</a></li>
 </ul>

--- a/files/zh-cn/glossary/css_selector/index.html
+++ b/files/zh-cn/glossary/css_selector/index.html
@@ -73,10 +73,10 @@ div.warning {
  </li>
  <li>关系选择器
   <ol>
-   <li><a href="/zh-CN/docs/Web/CSS/Adjacent_sibling_selectors">邻近兄弟元素选择器</a> <code>A + B</code></li>
-   <li><a href="/zh-CN/docs/Web/CSS/General_sibling_selectors">兄弟元素选择器</a> <code>A ~ B</code></li>
-   <li><a href="/zh-CN/docs/Web/CSS/Child_selectors">直接子元素选择器</a> <code>A &gt; B</code></li>
-   <li><a href="/zh-CN/docs/Web/CSS/Descendant_selectors">后代元素选择器</a> <code>A B</code></li>
+   <li><a href="/zh-CN/docs/Web/CSS/Adjacent_sibling_combinator">邻近兄弟元素选择器</a> <code>A + B</code></li>
+   <li><a href="/zh-CN/docs/Web/CSS/General_sibling_combinator">兄弟元素选择器</a> <code>A ~ B</code></li>
+   <li><a href="/zh-CN/docs/Web/CSS/Child_combinator">直接子元素选择器</a> <code>A &gt; B</code></li>
+   <li><a href="/zh-CN/docs/Web/CSS/Descendant_combinator">后代元素选择器</a> <code>A B</code></li>
   </ol>
  </li>
  <li>伪选择器 (Pseudo)

--- a/files/zh-cn/glossary/data_structure/index.html
+++ b/files/zh-cn/glossary/data_structure/index.html
@@ -5,9 +5,7 @@ translation_of: Glossary/Data_structure
 ---
 <p><strong>数据结构</strong> 是让数据更好地被使用的一种数据组织方式。</p>
 
-<h2 id="了解更多Edit">了解更多<a href="/zh-CN/docs/Glossary/Accessibility$edit#Learn_more">Edit</a></h2>
-
-<h3 class="highlight-spanned" id="总体了解">总体了解</h3>
+<h2 id="参见">参见</h2>
 
 <ul>
  <li>维基百科上的 {{interwiki("wikipedia", "Data_structure", "Data structure")}}</li>

--- a/files/zh-cn/glossary/data_structure/index.html
+++ b/files/zh-cn/glossary/data_structure/index.html
@@ -5,7 +5,7 @@ translation_of: Glossary/Data_structure
 ---
 <p><strong>数据结构</strong> 是让数据更好地被使用的一种数据组织方式。</p>
 
-<h2 id="了解更多Edit">了解更多<a class="button section-edit only-icon" href="https://developer.mozilla.org/en-US/docs/Glossary/Accessibility$edit#Learn_more" rel="nofollow, noindex">Edit</a></h2>
+<h2 id="了解更多Edit">了解更多<a href="/zh-CN/docs/Glossary/Accessibility$edit#Learn_more">Edit</a></h2>
 
 <h3 class="highlight-spanned" id="总体了解">总体了解</h3>
 

--- a/files/zh-cn/glossary/decryption/index.html
+++ b/files/zh-cn/glossary/decryption/index.html
@@ -16,5 +16,5 @@ translation_of: Glossary/Decryption
 <h3 class="highlight-spanned" id="技术索引">技术索引</h3>
 
 <ul>
- <li><a href="/en-US/docs/Encryption_and_Decryption">Encryption and Decryption</a></li>
+ <li><a href="/zh-CN/docs/Encryption_and_Decryption">Encryption and Decryption</a></li>
 </ul>

--- a/files/zh-cn/glossary/developer_tools/index.html
+++ b/files/zh-cn/glossary/developer_tools/index.html
@@ -23,7 +23,7 @@ translation_of: Glossary/Developer_Tools
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="https://developer.mozilla.org/en-US/docs/Tools">Firefox Developer Tools</a> on MDN</li>
+ <li><a href="https://firefox-source-docs.mozilla.org/devtools-user/index.html">Firefox Developer Tools</a> on MDN</li>
  <li><a href="https://getfirebug.com/">Firebug</a> (former developer tool for Firefox)</li>
  <li><a href="https://developer.chrome.com/devtools">Chrome DevTools</a> on chrome.com</li>
  <li><a href="https://developer.apple.com/library/content/documentation/AppleApplications/Conceptual/Safari_Developer_Guide/Introduction/Introduction.html#//apple_ref/doc/uid/TP40007874-CH1-SW1">Safari Web Inspector</a> on apple.com</li>

--- a/files/zh-cn/glossary/dns/index.html
+++ b/files/zh-cn/glossary/dns/index.html
@@ -16,6 +16,6 @@ translation_of: Glossary/DNS
 <h3 id="常识">常识</h3>
 
 <ul>
- <li><a href="/en-US/Learn/Understanding_domain_names">理解域名</a></li>
+ <li><a href="/zh-CN/Learn/Understanding_domain_names">理解域名</a></li>
  <li>在维基百科上的 {{interwiki("wikipedia", "Domain_Name_System", "Domain Name System")}} （DNS）</li>
 </ul>

--- a/files/zh-cn/glossary/doctype/index.html
+++ b/files/zh-cn/glossary/doctype/index.html
@@ -17,11 +17,11 @@ translation_of: Glossary/Doctype
 
 <ul>
  <li>{{interwiki("wikipedia", "Document_type_declaration", "Document Type Declaration")}} 维基百科的解释</li>
- <li><a href="/en-US/docs/Quirks_Mode_and_Standards_Mode">Quirks Mode and Standards Mode</a> 怪异模式（兼容模式）和标准模式</li>
+ <li><a href="/zh-CN/docs/Web/HTML/Quirks_Mode_and_Standards_Mode">Quirks Mode and Standards Mode</a> 怪异模式（兼容模式）和标准模式</li>
 </ul>
 
 <h3 id="技术参考"><strong>技术参考</strong></h3>
 
 <ul>
- <li><a href="/en-US/docs/Web/API/Document/doctype">Document.doctype</a>, 一个返回 doctype 的 JavaScript 方法</li>
+ <li><a href="/zh-CN/docs/Web/API/Document/doctype">Document.doctype</a>, 一个返回 doctype 的 JavaScript 方法</li>
 </ul>

--- a/files/zh-cn/glossary/document_directive/index.html
+++ b/files/zh-cn/glossary/document_directive/index.html
@@ -7,7 +7,7 @@ tags:
   - 安全
 translation_of: Glossary/Document_directive
 ---
-<p><strong>{{Glossary("CSP")}} 文档指令（document directives）</strong> 出现于 {{HTTPHeader("Content-Security-Policy")}} 首部，支配着应用安全策略的文档的属性或者 <a href="/en-US/docs/Web/API/Web_Workers_API">worker</a> 运行环境的特征。</p>
+<p><strong>{{Glossary("CSP")}} 文档指令（document directives）</strong> 出现于 {{HTTPHeader("Content-Security-Policy")}} 首部，支配着应用安全策略的文档的属性或者 <a href="/zh-CN/docs/Web/API/Web_Workers_API">worker</a> 运行环境的特征。</p>
 
 <p>文档指令不将 {{CSP("default-src")}} 指令作为回退机制。</p>
 

--- a/files/zh-cn/glossary/dom/index.html
+++ b/files/zh-cn/glossary/dom/index.html
@@ -26,6 +26,6 @@ translation_of: Glossary/DOM
 
 <ul>
  <li><a href="/zh-CN/docs/Web/API/Document_Object_Model">MDN DOM文档</a></li>
- <li><a href="http://www.w3.org/DOM/DOMTR" rel="external">W3C上的多种DOM规范</a></li>
+ <li><a href="https://www.w3.org/DOM/DOMTR">W3C上的多种DOM规范</a></li>
 </ul>
 </div>

--- a/files/zh-cn/glossary/domain_sharding/index.html
+++ b/files/zh-cn/glossary/domain_sharding/index.html
@@ -16,7 +16,7 @@ translation_of: Glossary/Domain_sharding
 <h2 id="See_Also">See Also</h2>
 
 <ul>
- <li><a href="/en-US/docs/Archive/Security/SSL_and_TLS">Transport Layer Security (TLS)</a></li>
- <li><a href="/en-US/docs/Glossary/DNS">DNS</a></li>
- <li><a href="/en-US/docs/Glossary/HTTP_2">HTTP/2</a></li>
+ <li><a href="/zh-CN/docs/Archive/Security/SSL_and_TLS">Transport Layer Security (TLS)</a></li>
+ <li><a href="/zh-CN/docs/Glossary/DNS">DNS</a></li>
+ <li><a href="/zh-CN/docs/Glossary/HTTP_2">HTTP/2</a></li>
 </ul>

--- a/files/zh-cn/glossary/dynamic_programming_language/index.html
+++ b/files/zh-cn/glossary/dynamic_programming_language/index.html
@@ -11,7 +11,7 @@ translation_of: Glossary/Dynamic_programming_language
 <p>这正好与静态编程语言相反，在静态编程语言的运行阶段，一般是无法执行这些改变的。</p>
 
 <div class="note">
-<p>注意，尽管静态/动态编程语言和 <a href="/en-US/docs/Glossary/Dynamic_typing">静态/动态类型</a>有一定的联系，但是两者并不是同义词。</p>
+<p>注意，尽管静态/动态编程语言和 <a href="/zh-CN/docs/Glossary/Dynamic_typing">静态/动态类型</a>有一定的联系，但是两者并不是同义词。</p>
 </div>
 
 <h2 id="了解更多">了解更多</h2>

--- a/files/zh-cn/glossary/ecma/index.html
+++ b/files/zh-cn/glossary/ecma/index.html
@@ -9,11 +9,11 @@ translation_of: Glossary/ECMA
 ---
 <p><strong>Ecma International</strong>（正式名称是 <em>European Computer Manufacturers Association，欧洲计算机制造商协会</em>）是一个开发计算机硬件、通信和程序语言标准的非盈利组织。</p>
 
-<p>在网络上该组织因维护 {{Glossary("JavaScript")}} 语言的核心规范 <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">the ECMA-262 specification</a>（即 {{Glossary("ECMAScript")}}）而为人所知。</p>
+<p>在网络上该组织因维护 {{Glossary("JavaScript")}} 语言的核心规范 <a href="https://www.ecma-international.org/publications/standards/Ecma-262.htm">the ECMA-262 specification</a>（即 {{Glossary("ECMAScript")}}）而为人所知。</p>
 
 <h2 id="了解更多">了解更多</h2>
 
 <ul>
  <li>Wikipedia 页面 {{interwiki("wikipedia", "Ecma_International", "Ecma International")}}</li>
- <li><a href="http://www.ecma-international.org/">The Ecma International web site</a></li>
+ <li><a href="https://www.ecma-international.org/">The Ecma International web site</a></li>
 </ul>

--- a/files/zh-cn/glossary/ecmascript/index.html
+++ b/files/zh-cn/glossary/ecmascript/index.html
@@ -3,7 +3,7 @@ title: ECMAScript
 slug: Glossary/ECMAScript
 translation_of: Glossary/ECMAScript
 ---
-<p><strong>ECMAScript </strong>是 {{glossary("JavaScript")}} 所基于的脚本语言。<a href="http://www.ecma-international.org">Ecma 国际组织</a> 负责将ECMAScript 标准化。</p>
+<p><strong>ECMAScript </strong>是 {{glossary("JavaScript")}} 所基于的脚本语言。<a href="https://www.ecma-international.org">Ecma 国际组织</a> 负责将ECMAScript 标准化。</p>
 
 <h2 id="了解更多">了解更多</h2>
 

--- a/files/zh-cn/glossary/empty_element/index.html
+++ b/files/zh-cn/glossary/empty_element/index.html
@@ -10,7 +10,7 @@ original_slug: Glossary/空元素
 ---
 <p>一个<strong>空元素（empty element）</strong>可能是 HTML，SVG，或者 MathML 里的一个不能存在子节点（例如内嵌的元素或者元素内的文本）的{{Glossary("element")}}。</p>
 
-<p><a href="http://www.w3.org/html/wg/drafts/html/CR/">HTML</a>，<a href="http://www.w3.org/TR/SVG2/">SVG</a> 和 <a href="http://www.w3.org/Math/draft-spec/">MathML</a> 的规范都详细定义了每个元素能包含的具体内容（define very precisely what each element can contain）。许多组合是没有任何语义含义的，比如一个 {{HTMLElement("audio")}} 元素嵌套在一个 {{HTMLElement("hr")}} 元素里。</p>
+<p><a href="https://www.w3.org/html/wg/drafts/html/CR/">HTML</a>，<a href="https://www.w3.org/TR/SVG2/">SVG</a> 和 <a href="https://www.w3.org/Math/draft-spec/">MathML</a> 的规范都详细定义了每个元素能包含的具体内容（define very precisely what each element can contain）。许多组合是没有任何语义含义的，比如一个 {{HTMLElement("audio")}} 元素嵌套在一个 {{HTMLElement("hr")}} 元素里。</p>
 
 <p>在 HTML 中，通常在一个空元素上使用一个闭标签是无效的。例如， <code>&lt;input type="text"&gt;&lt;/input&gt;</code> 的闭标签是无效的 HTML。</p>
 

--- a/files/zh-cn/glossary/endianness/index.html
+++ b/files/zh-cn/glossary/endianness/index.html
@@ -27,7 +27,7 @@ translation_of: Glossary/Endianness
 <ul>
  <li>{{jsxref("ArrayBuffer")}}</li>
  <li>{{jsxref("DataView")}}</li>
- <li><a href="/en-US/docs/Web/JavaScript/Typed_arrays">Typed Arrays</a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Typed_arrays">Typed Arrays</a></li>
  <li>Wikipedia 上的 {{Interwiki("wikipedia", "Endianness")}}</li>
  <li>{{Glossary("Data structure")}}</li>
 </ul>

--- a/files/zh-cn/glossary/entity_header/index.html
+++ b/files/zh-cn/glossary/entity_header/index.html
@@ -6,7 +6,7 @@ tags:
 translation_of: Glossary/Entity_header
 ---
 <div class="notecard note">
-<p>当前的 HTTP/1.1 规范中不再提及实体、实体报头和实体的体。这中的有些字段现在被称为表示头字段（<a href="https://datatracker.ietf.org/doc/html/rfc7231#section-3" rel="noopener">RFC 7231, section 3: Representations</a>）。</p>
+<p>当前的 HTTP/1.1 规范中不再提及实体、实体报头和实体的体。这中的有些字段现在被称为表示头字段（<a href="https://datatracker.ietf.org/doc/html/rfc7231#section-3">RFC 7231, section 3: Representations</a>）。</p>
 </div>
 
 <p>实体报头是描述了一个 HTTP 消息有效载荷（即关于消息主体的元数据）的 HTTP 报头，见 {{glossary("header", "HTTP header")}}。实体报头包括 {{HTTPHeader("Content-Length")}}、{{HTTPHeader("Content-Language")}}、{{HTTPHeader("Content-Encoding")}}、{{HTTPHeader("Content-Type")}} 和 {{HTTPHeader("Expires")}} 等。实体报头可能同时存在于 HTTP 请求和响应信息中。</p>
@@ -25,5 +25,5 @@ Content-Length: 128</pre>
 <h3 id="技术知识">技术知识</h3>
 
 <ul>
- <li><a href="/en-US/docs/Web/HTTP/Headers">所有 HTTP 报头列表</a></li>
+ <li><a href="/zh-CN/docs/Web/HTTP/Headers">所有 HTTP 报头列表</a></li>
 </ul>

--- a/files/zh-cn/glossary/falsy/index.html
+++ b/files/zh-cn/glossary/falsy/index.html
@@ -21,39 +21,39 @@ translation_of: Glossary/Falsy
  <tbody>
   <tr>
    <td><code>false</code></td>
-   <td><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Future_reserved_keywords_in_older_standards">false</a> 关键字</td>
+   <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Lexical_grammar#Future_reserved_keywords_in_older_standards">false</a> 关键字</td>
   </tr>
   <tr>
    <td>0</td>
-   <td>数值 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type">zero</a></td>
+   <td>数值 <a href="/zh-CN/docs/Web/JavaScript/Data_structures#Number_type">zero</a></td>
    <td></td>
   </tr>
   <tr>
    <td>-0</td>
-   <td>数值 负 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type">zero</a></td>
+   <td>数值 负 <a href="/zh-CN/docs/Web/JavaScript/Data_structures#Number_type">zero</a></td>
    <td></td>
   </tr>
   <tr>
    <td>0n</td>
-   <td>当 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt">BigInt</a> 作为布尔值使用时, 遵从其作为数值的规则. <code>0n</code> 是 <em>falsy </em>值.</td>
+   <td>当 <a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/BigInt">BigInt</a> 作为布尔值使用时, 遵从其作为数值的规则. <code>0n</code> 是 <em>falsy </em>值.</td>
   </tr>
   <tr>
    <td>"", '', ``</td>
    <td>
-    <p>这是一个空字符串 (字符串的长度为零). JavaScript 中的字符串可用双引号 <code><strong>""</strong></code>, 单引号 <code>''</code>, 或 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals">模板字面量</a> <strong><code>``</code></strong> 定义。</p>
+    <p>这是一个空字符串 (字符串的长度为零). JavaScript 中的字符串可用双引号 <code><strong>""</strong></code>, 单引号 <code>''</code>, 或 <a href="/zh-CN/docs/Web/JavaScript/Reference/Template_literals">模板字面量</a> <strong><code>``</code></strong> 定义。</p>
    </td>
   </tr>
   <tr>
    <td>{{Glossary("null")}}</td>
-   <td><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/null">null</a> - 缺少值</td>
+   <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/null">null</a> - 缺少值</td>
   </tr>
   <tr>
    <td>{{Glossary("undefined")}}</td>
-   <td><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined">undefined</a> - 原始值</td>
+   <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/undefined">undefined</a> - 原始值</td>
   </tr>
   <tr>
    <td>{{Glossary("NaN")}}</td>
-   <td><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN">NaN </a>- 非数值</td>
+   <td><a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/NaN">NaN </a>- 非数值</td>
   </tr>
  </tbody>
 </table>
@@ -83,7 +83,7 @@ if (document.all)
 // ↪ false</code></pre>
 
 <div class="note">
-<p><code>document.all</code> 在过去被用于浏览器检测，是 <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/obsolete.html#dom-document-all">HTML 规范在此定义了</a>故意与 ECMAScript 标准相违背的（译者注：<code>document.all</code> 虽然是一个对象，但其转换为 boolean 类型是 false），以保持与历史代码的兼容性  (<code>if (document.all) { // Internet Explorer code here }</code> 或使用 <code>document.all</code> 而不先检查它的存在: <code>document.all.foo</code>).</p>
+<p><code>document.all</code> 在过去被用于浏览器检测，是 <a href="https://www.whatwg.org/specs/web-apps/current-work/multipage/obsolete.html#dom-document-all">HTML 规范在此定义了</a>故意与 ECMAScript 标准相违背的（译者注：<code>document.all</code> 虽然是一个对象，但其转换为 boolean 类型是 false），以保持与历史代码的兼容性  (<code>if (document.all) { // Internet Explorer code here }</code> 或使用 <code>document.all</code> 而不先检查它的存在: <code>document.all.foo</code>).</p>
 </div>
 
 <p>falsy 有时会写作 <strong>falsey</strong>，虽然在英语中，将一个单词转换成形容词时，通常会去掉末尾的字母 e，加上后缀 y。(noise =&gt; noisy, ice =&gt; icy, shine =&gt; shiny)</p>

--- a/files/zh-cn/glossary/first_paint/index.html
+++ b/files/zh-cn/glossary/first_paint/index.html
@@ -6,12 +6,12 @@ tags:
   - 性能
 translation_of: Glossary/First_paint
 ---
-<p><strong>First Paint</strong>，是<a href="/en-US/docs/">Paint Timing API</a>的一部分，是页面导航与浏览器将该网页的第一个像素渲染到屏幕上所用的中间时，渲染是任何与输入网页导航前的屏幕上的内容不同的内容。它回答了“发生了什么？”这个问题。</p>
+<p><strong>First Paint</strong>，是<a href="/zh-CN/docs/">Paint Timing API</a>的一部分，是页面导航与浏览器将该网页的第一个像素渲染到屏幕上所用的中间时，渲染是任何与输入网页导航前的屏幕上的内容不同的内容。它回答了“发生了什么？”这个问题。</p>
 
 <h2 id="另请参看">另请参看</h2>
 
 <ul>
- <li><a href="/en-US/docs/Glossary/first_meaningful_paint">First meaningful paint</a></li>
- <li><a href="/en-US/docs/Glossary/First_contentful_paint">First contentful paint</a></li>
- <li><a href="/en-US/docs/">Paint Timing API</a></li>
+ <li><a href="/zh-CN/docs/Glossary/first_meaningful_paint">First meaningful paint</a></li>
+ <li><a href="/zh-CN/docs/Glossary/First_contentful_paint">First contentful paint</a></li>
+ <li><a href="/zh-CN/docs/">Paint Timing API</a></li>
 </ul>

--- a/files/zh-cn/glossary/flex/index.html
+++ b/files/zh-cn/glossary/flex/index.html
@@ -7,7 +7,7 @@ translation_of: Glossary/Flex
 
 <p><code>flex</code> 属性是<code>flex-grow</code>, <code>flex-shrink</code> 和 <code>flex-basis </code>属性的简写。</p>
 
-<p>此外， <code>&lt;flex&gt;</code> 可以作为<a href="/en-US/docs/Web/CSS/flex_value">弹性长度</a>被引用在CSS Grid（栅格）布局中。</p>
+<p>此外， <code>&lt;flex&gt;</code> 可以作为<a href="/zh-CN/docs/Web/CSS/flex_value">弹性长度</a>被引用在CSS Grid（栅格）布局中。</p>
 
 <h2 id="了解更多">了解更多</h2>
 
@@ -34,11 +34,11 @@ translation_of: Glossary/Flex
 
 <ul>
  <li><em><a href="https://www.w3.org/TR/css-flexbox-1/">CSS Flexible Box Layout Module Level 1 Specification</a>（CSS 盒布局模型一级规范）</em></li>
- <li>CSS Flexbox Guide（CSS 伸缩盒子指南）: <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox">Basic Concepts of Flexbox</a>（伸缩）</em></li>
- <li>CSS Flexbox Guide（CSS 伸缩盒子指南）: <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Relationship_of_Flexbox_to_Other_Layout_Methods">Relationship of flexbox to other layout methods</a>（伸缩盒子与其他布局方法的关系）</em></li>
- <li>CSS Flexbox Guide（CSS 伸缩盒子指南）: <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container">Aligning items in a flex container</a>（伸缩容器中项的对齐）</em></li>
- <li>CSS Flexbox Guide（CSS 伸缩盒子指南）: <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Ordering_Flex_Items">Ordering flex items</a>（伸缩项的顺序）</em></li>
- <li>CSS Flexbox Guide（CSS 伸缩盒子指南）: <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Controlling_Ratios_of_Flex_Items_Along_the_Main_Ax">Controlling Ratios of flex items along the main axis</a>（控制主轴上伸缩项的比率）</em></li>
- <li>CSS Flexbox Guide（CSS 伸缩盒子指南）: <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Mastering_Wrapping_of_Flex_Items">Mastering wrapping of flex items</a>（掌握如何包装伸缩项）</em></li>
- <li>CSS Flexbox Guide（CSS 伸缩盒子指南）: <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Typical_Use_Cases_of_Flexbox">Typical use cases of flexbox</a>（伸缩盒子的典型用例）</em></li>
+ <li>CSS Flexbox Guide（CSS 伸缩盒子指南）: <em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox">Basic Concepts of Flexbox</a>（伸缩）</em></li>
+ <li>CSS Flexbox Guide（CSS 伸缩盒子指南）: <em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Relationship_of_Flexbox_to_Other_Layout_Methods">Relationship of flexbox to other layout methods</a>（伸缩盒子与其他布局方法的关系）</em></li>
+ <li>CSS Flexbox Guide（CSS 伸缩盒子指南）: <em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container">Aligning items in a flex container</a>（伸缩容器中项的对齐）</em></li>
+ <li>CSS Flexbox Guide（CSS 伸缩盒子指南）: <em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Ordering_Flex_Items">Ordering flex items</a>（伸缩项的顺序）</em></li>
+ <li>CSS Flexbox Guide（CSS 伸缩盒子指南）: <em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Controlling_Ratios_of_Flex_Items_Along_the_Main_Ax">Controlling Ratios of flex items along the main axis</a>（控制主轴上伸缩项的比率）</em></li>
+ <li>CSS Flexbox Guide（CSS 伸缩盒子指南）: <em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Mastering_Wrapping_of_Flex_Items">Mastering wrapping of flex items</a>（掌握如何包装伸缩项）</em></li>
+ <li>CSS Flexbox Guide（CSS 伸缩盒子指南）: <em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Typical_Use_Cases_of_Flexbox">Typical use cases of flexbox</a>（伸缩盒子的典型用例）</em></li>
 </ul>

--- a/files/zh-cn/glossary/flex_container/index.html
+++ b/files/zh-cn/glossary/flex_container/index.html
@@ -31,7 +31,7 @@ translation_of: Glossary/Flex_Container
 <h3 id="延伸阅读">延伸阅读</h3>
 
 <ul>
- <li>CSS Flexbox Guide（CSS 伸缩盒子指南）: <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox">Basic Concepts of Flexbox</a>（伸缩盒子的基本概念） </em></li>
- <li>CSS Flexbox Guide（CSS 伸缩盒子指南）: <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container">Aligning items in a flex container</a>（伸缩容器里的项目对齐方式）</em></li>
- <li>CSS Flexbox Guide（CSS 伸缩盒子指南）: <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Mastering_Wrapping_of_Flex_Items">Mastering wrapping of flex items</a>（掌握伸缩项如何进行换行）</em></li>
+ <li>CSS Flexbox Guide（CSS 伸缩盒子指南）: <em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox">Basic Concepts of Flexbox</a>（伸缩盒子的基本概念） </em></li>
+ <li>CSS Flexbox Guide（CSS 伸缩盒子指南）: <em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container">Aligning items in a flex container</a>（伸缩容器里的项目对齐方式）</em></li>
+ <li>CSS Flexbox Guide（CSS 伸缩盒子指南）: <em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Mastering_Wrapping_of_Flex_Items">Mastering wrapping of flex items</a>（掌握伸缩项如何进行换行）</em></li>
 </ul>

--- a/files/zh-cn/glossary/flex_item/index.html
+++ b/files/zh-cn/glossary/flex_item/index.html
@@ -24,7 +24,7 @@ translation_of: Glossary/Flex_Item
 <h3 id="延伸阅读">延伸阅读</h3>
 
 <ul>
- <li>CSS 弹性布局指南: <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox">Basic Concepts of Flexbox</a></em></li>
- <li>CSS 弹性布局指南: <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Ordering_Flex_Items">Ordering flex items</a></em></li>
- <li>CSS 弹性布局指南: <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Controlling_Ratios_of_Flex_Items_Along_the_Main_Ax">Controlling Ratios of flex items along the main axis</a></em></li>
+ <li>CSS 弹性布局指南: <em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox">Basic Concepts of Flexbox</a></em></li>
+ <li>CSS 弹性布局指南: <em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Ordering_Flex_Items">Ordering flex items</a></em></li>
+ <li>CSS 弹性布局指南: <em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Controlling_Ratios_of_Flex_Items_Along_the_Main_Ax">Controlling Ratios of flex items along the main axis</a></em></li>
 </ul>

--- a/files/zh-cn/glossary/flexbox/index.html
+++ b/files/zh-cn/glossary/flexbox/index.html
@@ -34,18 +34,18 @@ translation_of: Glossary/Flexbox
 
 <ul>
  <li><em><a href="https://www.w3.org/TR/css-flexbox-1/">CSS Flexible Box Layout Module Level 1 Specification</a></em></li>
- <li>CSS Flexbox Guide: <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox">Basic Concepts of Flexbox</a></em></li>
- <li>CSS Flexbox Guide: <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Relationship_of_Flexbox_to_Other_Layout_Methods">Relationship of flexbox to other layout methods</a></em></li>
- <li>CSS Flexbox Guide: <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container">Aligning items in a flex container</a></em></li>
- <li>CSS Flexbox Guide: <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Ordering_Flex_Items">Ordering flex items</a></em></li>
- <li>CSS Flexbox Guide: <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Controlling_Ratios_of_Flex_Items_Along_the_Main_Ax">Controlling Ratios of flex items along the main axis</a></em></li>
- <li>CSS Flexbox Guide: <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Mastering_Wrapping_of_Flex_Items">Mastering wrapping of flex items</a></em></li>
- <li>CSS Flexbox Guide: <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Typical_Use_Cases_of_Flexbox">Typical use cases of flexbox</a></em></li>
+ <li>CSS Flexbox Guide: <em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox">Basic Concepts of Flexbox</a></em></li>
+ <li>CSS Flexbox Guide: <em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Relationship_of_Flexbox_to_Other_Layout_Methods">Relationship of flexbox to other layout methods</a></em></li>
+ <li>CSS Flexbox Guide: <em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container">Aligning items in a flex container</a></em></li>
+ <li>CSS Flexbox Guide: <em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Ordering_Flex_Items">Ordering flex items</a></em></li>
+ <li>CSS Flexbox Guide: <em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Controlling_Ratios_of_Flex_Items_Along_the_Main_Ax">Controlling Ratios of flex items along the main axis</a></em></li>
+ <li>CSS Flexbox Guide: <em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Mastering_Wrapping_of_Flex_Items">Mastering wrapping of flex items</a></em></li>
+ <li>CSS Flexbox Guide: <em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Typical_Use_Cases_of_Flexbox">Typical use cases of flexbox</a></em></li>
 </ul>
 
 <section id="Quick_links">
 <ol>
- <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
+ <li><a href="/zh-CN/docs/Glossary">MDN Web Docs Glossary</a>
 
   <ol>
    <li>{{Glossary("Flex")}}</li>

--- a/files/zh-cn/glossary/forbidden_header_name/index.html
+++ b/files/zh-cn/glossary/forbidden_header_name/index.html
@@ -4,9 +4,9 @@ slug: Glossary/Forbidden_header_name
 translation_of: Glossary/Forbidden_header_name
 original_slug: Glossary/禁止修改的消息首部
 ---
-<p>禁止修改的消息首部指的是不能在代码中通过编程的方式进行修改的<a href="/en-US/docs/Web/HTTP/Headers">HTTP协议消息首部</a>。本文仅讨论相关的HTTP<strong>请求</strong>首部（关于禁止修改的响应首部，请参考 {{Glossary("Forbidden response header name")}}）。</p>
+<p>禁止修改的消息首部指的是不能在代码中通过编程的方式进行修改的<a href="/zh-CN/docs/Web/HTTP/Headers">HTTP协议消息首部</a>。本文仅讨论相关的HTTP<strong>请求</strong>首部（关于禁止修改的响应首部，请参考 {{Glossary("Forbidden response header name")}}）。</p>
 
-<p>用户代理对这些消息首部保留全部控制权，应用程序无法设置它们。 Names starting with `<code title="">Sec-</code>` are reserved for creating new headers safe from {{glossary("API","APIs")}} using <a href="/en-US/docs/Web/API/Fetch_API">Fetch</a> that grant developers control over headers, such as {{domxref("XMLHttpRequest")}}.</p>
+<p>用户代理对这些消息首部保留全部控制权，应用程序无法设置它们。 Names starting with `<code title="">Sec-</code>` are reserved for creating new headers safe from {{glossary("API","APIs")}} using <a href="/zh-CN/docs/Web/API/Fetch_API">Fetch</a> that grant developers control over headers, such as {{domxref("XMLHttpRequest")}}.</p>
 
 <p>禁止修改的消息首部包括以 Proxy- 和 Sec- 开头的消息首部，以及下面列出的消息首部：</p>
 
@@ -36,5 +36,5 @@ original_slug: Glossary/禁止修改的消息首部
 </ul>
 
 <div class="note">
-<p><strong>注意</strong>: <a href="https://fetch.spec.whatwg.org/#terminology-headers">根据最新的规范</a>，<code>User-Agent</code> 首部已经从列表中移除。更多内容请参考规范的 forbidden header name list 一节（Firefox 43 实现了对这一更改的支持）。因此，该首部已经可以用于诸如 Fetch 的 <a href="/en-US/docs/Web/API/Headers">Headers</a> 对象，XHR 的 <a href="/en-US/docs/Web/API/XMLHttpRequest#setRequestHeader%28%29">setRequestHeader()</a>? 中。</p>
+<p><strong>注意</strong>: <a href="https://fetch.spec.whatwg.org/#terminology-headers">根据最新的规范</a>，<code>User-Agent</code> 首部已经从列表中移除。更多内容请参考规范的 forbidden header name list 一节（Firefox 43 实现了对这一更改的支持）。因此，该首部已经可以用于诸如 Fetch 的 <a href="/zh-CN/docs/Web/API/Headers">Headers</a> 对象，XHR 的 <a href="/zh-CN/docs/Web/API/XMLHttpRequest#setRequestHeader%28%29">setRequestHeader()</a>? 中。</p>
 </div>

--- a/files/zh-cn/glossary/fork/index.html
+++ b/files/zh-cn/glossary/fork/index.html
@@ -30,7 +30,7 @@ translation_of: Glossary/Fork
    <li><a href="https://help.github.com/articles/fork-a-repo/">How to fork a GitHub repo</a> (fork as in a Git context)</li>
   </ol>
  </li>
- <li><a href="https://developer.mozilla.org/zh-CN/docs/Glossary">MDN 术语表</a>
+ <li><a href="/zh-CN/docs/Glossary">MDN 术语表</a>
   <ol>
    <li>{{Glossary("Fork")}}</li>
   </ol>

--- a/files/zh-cn/glossary/ftp/index.html
+++ b/files/zh-cn/glossary/ftp/index.html
@@ -12,7 +12,7 @@ translation_of: Glossary/FTP
 <h3 id="总体了解">总体了解</h3>
 
 <ul>
- <li><a href="/en-US/Learn/Upload_files_to_a_web_server">Beginner's guide to uploading files via FTP</a></li>
+ <li><a href="/zh-CN/Learn/Upload_files_to_a_web_server">Beginner's guide to uploading files via FTP</a></li>
  <li>维基百科上的 {{interwiki("wikipedia", "File Transfer Protocol", "FTP")}}
 
  </li>

--- a/files/zh-cn/glossary/function/index.html
+++ b/files/zh-cn/glossary/function/index.html
@@ -83,6 +83,6 @@ const loop = x =&gt; {
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="/en-US/docs/Web/JavaScript/Guide/Functions" title="en-US/docs/Web/JavaScript/Guide/Functions">Functions</a></li>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions">Arrow Functions</a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Guide/Functions">Functions</a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Functions/Arrow_functions">Arrow Functions</a></li>
 </ul>

--- a/files/zh-cn/glossary/garbage_collection/index.html
+++ b/files/zh-cn/glossary/garbage_collection/index.html
@@ -7,7 +7,7 @@ tags:
   - 垃圾回收
 translation_of: Glossary/Garbage_collection
 ---
-<p><strong><a href="/en-US/docs/Web/JavaScript/Memory_Management#Garbage_collection">垃圾回收</a></strong> 是一个术语，在 {{Glossary("computer programming", "计算机编程")}}中用于描述查找和删除那些不再被其他{{Glossary("object reference", "对象引用")}}的{{Glossary("object", "对象")}} 处理过程。换句话说，垃圾回收是删除任何其他对象未使用的对象的过程。 垃圾收集通常缩写为 "GC"， 是{{Glossary("JavaScript")}}中使用的{{Glossary("memory management", "内存管理")}}系统的基本组成部分。</p>
+<p><strong><a href="/zh-CN/docs/Web/JavaScript/Memory_Management#Garbage_collection">垃圾回收</a></strong> 是一个术语，在 {{Glossary("computer programming", "计算机编程")}}中用于描述查找和删除那些不再被其他{{Glossary("object reference", "对象引用")}}的{{Glossary("object", "对象")}} 处理过程。换句话说，垃圾回收是删除任何其他对象未使用的对象的过程。 垃圾收集通常缩写为 "GC"， 是{{Glossary("JavaScript")}}中使用的{{Glossary("memory management", "内存管理")}}系统的基本组成部分。</p>
 
 <h2 id="学习更多">学习更多</h2>
 <h3 id="基本知识">基本知识</h3>
@@ -20,6 +20,6 @@ translation_of: Glossary/Garbage_collection
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="/en-US/docs/Web/JavaScript/Memory_Management#Garbage_collection">Garbage collection</a> in the MDN JavaScript guide.</li>
- <li><a href="/en-US/docs/Web/JavaScript/Memory_Management">Memory management in JavaScript</a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Memory_Management#Garbage_collection">Garbage collection</a> in the MDN JavaScript guide.</li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Memory_Management">Memory management in JavaScript</a></li>
 </ul>

--- a/files/zh-cn/glossary/gecko/index.html
+++ b/files/zh-cn/glossary/gecko/index.html
@@ -27,7 +27,7 @@ translation_of: Glossary/Gecko
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="/en-US/docs/Mozilla/Gecko">The Gecko documentation on MDN</a></li>
+ <li><a href="/zh-CN/docs/Mozilla/Gecko">The Gecko documentation on MDN</a></li>
 </ul>
 
 <p><br>

--- a/files/zh-cn/glossary/git/index.html
+++ b/files/zh-cn/glossary/git/index.html
@@ -10,6 +10,6 @@ translation_of: Glossary/Git
 <h3 id="基础知识">基础知识</h3>
 
 <ul>
- <li><a href="http://git-scm.com/">Git官方网站</a></li>
+ <li><a href="https://git-scm.com/">Git官方网站</a></li>
  <li><a href="https://github.com/">GitHub</a>，一个基于Git的图形化项目网站</li>
 </ul>

--- a/files/zh-cn/glossary/global_object/index.html
+++ b/files/zh-cn/glossary/global_object/index.html
@@ -52,7 +52,7 @@ window.greeting(); // It is the same as the normal invoking: greeting();
 
 <section id="Quick_links">
 <ul>
- <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
+ <li><a href="/zh-CN/docs/Glossary">MDN Web Docs Glossary</a>
 
   <ul>
    <li>{{glossary("global scope")}}</li>

--- a/files/zh-cn/glossary/google_chrome/index.html
+++ b/files/zh-cn/glossary/google_chrome/index.html
@@ -6,7 +6,7 @@ tags:
   - 浏览器
 translation_of: Glossary/Google_Chrome
 ---
-<p>Chrome 浏览器是 Google 开发的一个免费网络{{glossary("浏览器")}}. 它基于开源项目 <a href="http://www.chromium.org/" rel="external">Chromium</a>。在 <a href="https://code.google.com/p/chromium/wiki/ChromiumBrowserVsGoogleChrome">Chromium wiki</a> 中描述了它们之间的差异。Chrome维护使用自己的渲染引擎：开源引擎{{glossary("WebKit")}}中WebCore组件的一个分支 {{glossary("Blink")}}  。注意：IOS 版本的 Chrome 使用了 IOS 平台的渲染引擎，而非 {{glossary("Blink")}}。</p>
+<p>Chrome 浏览器是 Google 开发的一个免费网络{{glossary("浏览器")}}. 它基于开源项目 <a href="https://www.chromium.org/">Chromium</a>。在 <a href="https://code.google.com/p/chromium/wiki/ChromiumBrowserVsGoogleChrome">Chromium wiki</a> 中描述了它们之间的差异。Chrome维护使用自己的渲染引擎：开源引擎{{glossary("WebKit")}}中WebCore组件的一个分支 {{glossary("Blink")}}  。注意：IOS 版本的 Chrome 使用了 IOS 平台的渲染引擎，而非 {{glossary("Blink")}}。</p>
 
 <h2 id="学习更多" style="line-height: 30px;">学习更多</h2>
 
@@ -23,12 +23,12 @@ translation_of: Glossary/Google_Chrome
 <ul>
  <li><a href="https://play.google.com/store/apps/details?id=com.android.chrome">安卓版</a></li>
  <li><a href="https://itunes.apple.com/us/app/chrome-web-browser-by-google/id535886823?mt=8">IOS 版</a></li>
- <li><a href="http://www.google.com/chrome/">电脑版</a></li>
+ <li><a href="https://www.google.com/chrome/">电脑版</a></li>
 </ul>
 
 <h3 id="对于开发者">对于开发者</h3>
 
-<p>如果你想尝试 Chrome 的最新功能，可以尝试使用 Best 版本（预发布版本）。Chrome 经常进行更新，并将 Best 与 Stable（稳定版） 并行发布。你可以在 <a href="http://goo.gl/CCPRW">Chrome Release Blog</a> 了解更多相关内容。</p>
+<p>如果你想尝试 Chrome 的最新功能，可以尝试使用 Best 版本（预发布版本）。Chrome 经常进行更新，并将 Best 与 Stable（稳定版） 并行发布。你可以在 <a href="https://goo.gl/CCPRW">Chrome Release Blog</a> 了解更多相关内容。</p>
 
 <ul>
  <li><a href="https://play.google.com/store/apps/details?id=com.chrome.dev">安卓上的 Chrome 开发者版本</a></li>

--- a/files/zh-cn/glossary/graceful_degradation/index.html
+++ b/files/zh-cn/glossary/graceful_degradation/index.html
@@ -10,7 +10,7 @@ original_slug: Glossary/优雅降级
 ---
 <p><strong>优雅降级（Graceful degradation）</strong>是一种设计理念，其核心是尝试构建可在最新浏览器中运行的现代网站/应用程序，而作为降级体验，在低版本浏览器中仍然提供必要的内容和功能。</p>
 
-<p>{{Glossary("Polyfill","Polyfill")}}可用于使用JavaScript构建缺少的功能，但应尽可能提供样式和布局等功能的可接受替代方案，例如使用CSS级联或HTML回退行为。在<a href="/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/HTML_and_CSS">处理常见的HTML和CSS问题</a>中可以找到一些很好的例子。</p>
+<p>{{Glossary("Polyfill","Polyfill")}}可用于使用JavaScript构建缺少的功能，但应尽可能提供样式和布局等功能的可接受替代方案，例如使用CSS级联或HTML回退行为。在<a href="/zh-CN/docs/Learn/Tools_and_testing/Cross_browser_testing/HTML_and_CSS">处理常见的HTML和CSS问题</a>中可以找到一些很好的例子。</p>
 
 <p>这个技术很有用，因为它让Web开发者，在专注开发最强大的网站同时，和某些未知的用户代理，在访问网站时发生的问题间达到权衡。{{Glossary("渐进增强")}}相关而不同—通常被看做优雅降级的相反行为。实际上，这两种方法都是有效的，并且通常可以相互补充。</p>
 
@@ -24,7 +24,7 @@ original_slug: Glossary/优雅降级
 
 <section id="Quick_links">
 <ul>
- <li><a href="/en-US/docs/Glossary">MDN Web 文档词汇表</a>
+ <li><a href="/zh-CN/docs/Glossary">MDN Web 文档词汇表</a>
 
   <ul>
    <li>{{Glossary("Graceful degradation")}}</li>
@@ -32,7 +32,7 @@ original_slug: Glossary/优雅降级
    <li>{{Glossary("渐进增强")}}</li>
   </ul>
  </li>
- <li><a href="/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/HTML_and_CSS">处理常见的 HTML 和 CSS 问题</a></li>
- <li><a href="/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Feature_detection">实现特性检测</a></li>
+ <li><a href="/zh-CN/docs/Learn/Tools_and_testing/Cross_browser_testing/HTML_and_CSS">处理常见的 HTML 和 CSS 问题</a></li>
+ <li><a href="/zh-CN/docs/Learn/Tools_and_testing/Cross_browser_testing/Feature_detection">实现特性检测</a></li>
 </ul>
 </section>

--- a/files/zh-cn/glossary/grid_areas/index.html
+++ b/files/zh-cn/glossary/grid_areas/index.html
@@ -5,7 +5,7 @@ tags:
   - CSS Grids
 translation_of: Glossary/Grid_Areas
 ---
-<p><strong>网格区域</strong>是网格中由一个或者多个{{glossary("grid cell", "网格单元格")}}组成的一个矩形区域。当你使用<a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid">基于网格线位置</a>放置一个项目或者使用<a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas">命名的网格区域</a>定义区域时，网格区域被创建。</p>
+<p><strong>网格区域</strong>是网格中由一个或者多个{{glossary("grid cell", "网格单元格")}}组成的一个矩形区域。当你使用<a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid">基于网格线位置</a>放置一个项目或者使用<a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas">命名的网格区域</a>定义区域时，网格区域被创建。</p>
 
 <p><img alt="Image showing a highlighted grid area" src="https://mdn.mozillademos.org/files/14771/1_Grid_Area.png" style="height: 253px; width: 380px;"></p>
 
@@ -74,7 +74,7 @@ translation_of: Glossary/Grid_Areas
 <h3 id="扩展阅读">扩展阅读</h3>
 
 <ul>
- <li>CSS Grid Layout Guide: <em><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Basic concepts of grid layout</a></em></li>
- <li>CSS Grid Layout Guide: <em><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas">Grid template areas</a></em></li>
+ <li>CSS Grid Layout Guide: <em><a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Basic concepts of grid layout</a></em></li>
+ <li>CSS Grid Layout Guide: <em><a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas">Grid template areas</a></em></li>
  <li><a href="https://drafts.csswg.org/css-grid/#grid-area-concept">Definition of Grid Areas in the CSS Grid Layout specification</a></li>
 </ul>

--- a/files/zh-cn/glossary/grid_axis/index.html
+++ b/files/zh-cn/glossary/grid_axis/index.html
@@ -8,7 +8,7 @@ translation_of: Glossary/Grid_Axis
 ---
 <p>Grid布局是一种二维布局方法，能够在行和列中布置内容。因此在任何网格中都有两个轴，横轴（即行轴，内联）和纵轴（即列轴，块）。</p>
 
-<p>沿着这些轴，可以使用<a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout">盒模型对齐规范</a>中定义的属性对项目进行行对齐和列对齐。</p>
+<p>沿着这些轴，可以使用<a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout">盒模型对齐规范</a>中定义的属性对项目进行行对齐和列对齐。</p>
 
 <p>在CSS中，纵轴是放置文本时用的轴。如果你有两个段落，它们从右到左，从上到下书写。在纵轴上，它们一个被放置在另一个下面。</p>
 
@@ -18,14 +18,14 @@ translation_of: Glossary/Grid_Axis
 
 <p><img alt="Diagram showing the inline axis in CSS Grid Layout." src="https://mdn.mozillademos.org/files/14773/7_Inline_Axis.png" style="height: 306px; width: 940px;"></p>
 
-<p>这些轴的物理方向可以根据文档的<a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid,_Logical_Values_and_Writing_Modes">写入模式</a>而改变。</p>
+<p>这些轴的物理方向可以根据文档的<a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Logical_Values_and_Writing_Modes">写入模式</a>而改变。</p>
 
 <h2 id="了解更多">了解更多</h2>
 
 <h3 id="扩展阅读">扩展阅读</h3>
 
 <ul>
- <li>CSS Grid Layout Guide: <em><a href="/zh_CN/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Grid布局的基本概念</a></em></li>
- <li>CSS Grid Layout Guide: <em><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout">Box alignment in Grid Layout</a></em></li>
- <li>CSS Grid Layout Guide: <em><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid,_Logical_Values_and_Writing_Modes">Grids, logical values and writing modes</a></em></li>
+ <li>CSS Grid Layout Guide: <em><a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Grid布局的基本概念</a></em></li>
+ <li>CSS Grid Layout Guide: <em><a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout">Box alignment in Grid Layout</a></em></li>
+ <li>CSS Grid Layout Guide: <em><a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Logical_Values_and_Writing_Modes">Grids, logical values and writing modes</a></em></li>
 </ul>

--- a/files/zh-cn/glossary/grid_cell/index.html
+++ b/files/zh-cn/glossary/grid_cell/index.html
@@ -5,7 +5,7 @@ tags:
   - CSS Grids
 translation_of: Glossary/Grid_Cell
 ---
-<p>在<a href="/en-US/docs/Web/CSS/CSS_Grid_Layout">Grid布局</a>中，<strong>网络单元格</strong>是CSS网格中的最小单元。它是四条{{glossary("grid lines","网格线")}}之间的空间，概念上非常像表格单元格。</p>
+<p>在<a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout">Grid布局</a>中，<strong>网络单元格</strong>是CSS网格中的最小单元。它是四条{{glossary("grid lines","网格线")}}之间的空间，概念上非常像表格单元格。</p>
 
 <p><img alt="Diagram showing an individual cell on the grid." src="https://mdn.mozillademos.org/files/14767/1_Grid_Cell.png" style="height: 221px; width: 332px;"></p>
 
@@ -66,6 +66,6 @@ translation_of: Glossary/Grid_Cell
 <h3 id="扩展阅读">扩展阅读</h3>
 
 <ul>
- <li>CSS Grid Layout Guide: <em><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Basic concepts of grid layout</a></em></li>
+ <li>CSS Grid Layout Guide: <em><a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Basic concepts of grid layout</a></em></li>
  <li><a href="https://drafts.csswg.org/css-grid/#grid-track-concept">Definition of Grid Cells in the CSS Grid Layout specification</a></li>
 </ul>

--- a/files/zh-cn/glossary/grid_column/index.html
+++ b/files/zh-cn/glossary/grid_column/index.html
@@ -25,5 +25,5 @@ translation_of: Glossary/Grid_Column
 <h3 id="扩展阅读">扩展阅读</h3>
 
 <ul>
- <li>CSS Grid Layout Guide: <em><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Basic concepts of grid layout</a></em></li>
+ <li>CSS Grid Layout Guide: <em><a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Basic concepts of grid layout</a></em></li>
 </ul>

--- a/files/zh-cn/glossary/grid_container/index.html
+++ b/files/zh-cn/glossary/grid_container/index.html
@@ -27,5 +27,5 @@ translation_of: Glossary/Grid_Container
 <h3 id="扩展阅读">扩展阅读</h3>
 
 <ul>
- <li>CSS 网格布局: <em><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">网格布局基本概念</a></em></li>
+ <li>CSS 网格布局: <em><a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">网格布局基本概念</a></em></li>
 </ul>

--- a/files/zh-cn/glossary/grid_lines/index.html
+++ b/files/zh-cn/glossary/grid_lines/index.html
@@ -5,7 +5,7 @@ tags:
   - CSS Grids
 translation_of: Glossary/Grid_Lines
 ---
-<p>使用<a href="/en-US/docs/Web/CSS/CSS_Grid_Layout">Grid布局</a>在显式网格中定义{{glossary("Grid tracks", "轨道")}}的同时会创建<strong>网格线</strong>。在下面的例子中，有一个三列两行的网格。它给了我们4条列线和3条行线。</p>
+<p>使用<a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout">Grid布局</a>在显式网格中定义{{glossary("Grid tracks", "轨道")}}的同时会创建<strong>网格线</strong>。在下面的例子中，有一个三列两行的网格。它给了我们4条列线和3条行线。</p>
 
 <div id="example_1">
 <div class="hidden">
@@ -48,7 +48,7 @@ translation_of: Glossary/Grid_Lines
 
 <p>{{ EmbedLiveSample('example_1', '500', '250') }}</p>
 
-<p>网格线可以用它们的编号来寻址。在从左到右的语言比如英语中，列线1将位于网格的左侧，行线1将位于其顶部。线编号遵循文档的<a href="/en-US/docs/Web/CSS/CSS_Writing_Modes">写入模式</a>，因此在从右到左的语言中，列线1行将位于网格的右侧。下面的图片展示了该网格的线编号，假设语言是从左到右的。</p>
+<p>网格线可以用它们的编号来寻址。在从左到右的语言比如英语中，列线1将位于网格的左侧，行线1将位于其顶部。线编号遵循文档的<a href="/zh-CN/docs/Web/CSS/CSS_Writing_Modes">写入模式</a>，因此在从右到左的语言中，列线1行将位于网格的右侧。下面的图片展示了该网格的线编号，假设语言是从左到右的。</p>
 
 <p><img alt="Diagram showing the grid with lines numbered." src="https://mdn.mozillademos.org/files/14763/1_diagram_numbered_grid_lines.png" style="height: 456px; width: 764px;"></p>
 </div>
@@ -169,9 +169,9 @@ translation_of: Glossary/Grid_Lines
 <h3 id="扩展阅读">扩展阅读</h3>
 
 <ul>
- <li>CSS Grid Layout Guide: <em><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Basic concepts of grid layout</a></em></li>
- <li>CSS Grid Layout Guide: <em><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid">Line-based placement with CSS Grid</a></em></li>
- <li>CSS Grid Layout Guide: <em><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines">Layout using named grid lines</a></em></li>
- <li>CSS Grid Layout Guide: <em><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid,_Logical_Values_and_Writing_Modes">CSS Grids, Logical Values and Writing Modes</a></em></li>
+ <li>CSS Grid Layout Guide: <em><a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Basic concepts of grid layout</a></em></li>
+ <li>CSS Grid Layout Guide: <em><a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid">Line-based placement with CSS Grid</a></em></li>
+ <li>CSS Grid Layout Guide: <em><a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines">Layout using named grid lines</a></em></li>
+ <li>CSS Grid Layout Guide: <em><a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Logical_Values_and_Writing_Modes">CSS Grids, Logical Values and Writing Modes</a></em></li>
  <li><a href="https://drafts.csswg.org/css-grid/#grid-line-concept">Definition of Grid Lines in the CSS Grid Layout specification</a></li>
 </ul>

--- a/files/zh-cn/glossary/grid_rows/index.html
+++ b/files/zh-cn/glossary/grid_rows/index.html
@@ -5,11 +5,11 @@ tags:
   - CSS Grids
 translation_of: Glossary/Grid_Rows
 ---
-<p><strong>网格行</strong>是<a href="/en-US/docs/Web/CSS/CSS_Grid_Layout">Grid布局</a>中的水平轨道，即两个水平网格线之间的空间。它通过属性 {{cssxref("grid-template-rows")}} 或者简写属性 {{cssxref("grid")}}， {{cssxref("grid-template")}} 定义。</p>
+<p><strong>网格行</strong>是<a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout">Grid布局</a>中的水平轨道，即两个水平网格线之间的空间。它通过属性 {{cssxref("grid-template-rows")}} 或者简写属性 {{cssxref("grid")}}， {{cssxref("grid-template")}} 定义。</p>
 
 <p>另外，当项目被放置到显示网格中创建的行外面时，可以在隐式网格中创建网格行。默认情况这些行自动调整大小，也可以使用 {{cssxref("grid-auto-rows")}} 属性指定其大小。</p>
 
-<p>在<a href="/en-US/docs/Web/CSS/CSS_Grid_Layout">Grid布局</a>中使用对齐方式时，网格行沿着横轴运行。</p>
+<p>在<a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout">Grid布局</a>中使用对齐方式时，网格行沿着横轴运行。</p>
 
 <h2 id="了解更多">了解更多</h2>
 
@@ -25,5 +25,5 @@ translation_of: Glossary/Grid_Rows
 <h3 id="扩展阅读">扩展阅读</h3>
 
 <ul>
- <li>CSS Grid Layout Guide: <em><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Basic concepts of grid layout</a></em></li>
+ <li>CSS Grid Layout Guide: <em><a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Basic concepts of grid layout</a></em></li>
 </ul>

--- a/files/zh-cn/glossary/grid_tracks/index.html
+++ b/files/zh-cn/glossary/grid_tracks/index.html
@@ -71,6 +71,6 @@ translation_of: Glossary/Grid_Tracks
 <h3 id="扩展阅读">扩展阅读</h3>
 
 <ul>
- <li>CSS Grid Layout Guide: <a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Basic concepts of grid layout</a></li>
+ <li>CSS Grid Layout Guide: <a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Basic concepts of grid layout</a></li>
  <li><a href="https://drafts.csswg.org/css-grid/#grid-track-concept">Definition of Grid Tracks in the CSS Grid Layout specification</a></li>
 </ul>

--- a/files/zh-cn/glossary/guard/index.html
+++ b/files/zh-cn/glossary/guard/index.html
@@ -3,4 +3,4 @@ title: Guard
 slug: Glossary/Guard
 translation_of: Glossary/Guard
 ---
-<p>Guard 是 {{domxref("Headers")}} 对象的新特性 (在 {{domxref("Fetch_API","Fetch spec")}} 中定义）, 限制了像 {{domxref("Headers.set","set()")}} 和 {{domxref("Headers.append","append()")}} 方法操作 header 的内容. 举个例子, <code>immutable</code> guard 意味着 headers 不能被改变. 阅读 <a href="/en-US/docs/Web/API/Fetch_API/Basic_concepts#Guard">Fetch basic concepts: guard</a>，了解更多信息</p>
+<p>Guard 是 {{domxref("Headers")}} 对象的新特性 (在 {{domxref("Fetch_API","Fetch spec")}} 中定义）, 限制了像 {{domxref("Headers.set","set()")}} 和 {{domxref("Headers.append","append()")}} 方法操作 header 的内容. 举个例子, <code>immutable</code> guard 意味着 headers 不能被改变. 阅读 <a href="/zh-CN/docs/Web/API/Fetch_API/Basic_concepts#Guard">Fetch basic concepts: guard</a>，了解更多信息</p>

--- a/files/zh-cn/glossary/gutters/index.html
+++ b/files/zh-cn/glossary/gutters/index.html
@@ -5,7 +5,7 @@ tags:
   - CSS Grids
 translation_of: Glossary/Gutters
 ---
-<p><strong>网格间距</strong>是网格轨道之间的间距，可以通过 {{cssxref("grid-column-gap")}}，{{cssxref("grid-row-gap")}} 或者 {{cssxref("grid-gap")}} 在<a href="/en-US/docs/Web/CSS/CSS_Grid_Layout">Grid布局</a>中创建。</p>
+<p><strong>网格间距</strong>是网格轨道之间的间距，可以通过 {{cssxref("grid-column-gap")}}，{{cssxref("grid-row-gap")}} 或者 {{cssxref("grid-gap")}} 在<a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout">Grid布局</a>中创建。</p>
 
 <p>在下面的例子中，由一个三列两行的网格。它的列轨道之间有20px的间距，行轨道之间有20px的间距。</p>
 
@@ -52,7 +52,7 @@ translation_of: Glossary/Gutters
 
 <p>在网格大小上，网格间距参与计算就好像规则的网格轨道一样，但是没有任何东西可以被放置到网格间距上。网格间距也像网格线一样在那个位置会增加额外的大小，因此网格项目会被放置在网格间距末的那条网格线后。</p>
 
-<p>能够导致轨道被间隔开来的，除了网格间距属性，还有margins，padding或者使用<a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout">盒模型对齐</a>中的空间分布属性。这些方法都会导致可见间距的产生，因此网格间距属性不等价于”间距大小“，除非你没有使用这些能够产生间距的方法。</p>
+<p>能够导致轨道被间隔开来的，除了网格间距属性，还有margins，padding或者使用<a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout">盒模型对齐</a>中的空间分布属性。这些方法都会导致可见间距的产生，因此网格间距属性不等价于”间距大小“，除非你没有使用这些能够产生间距的方法。</p>
 
 <h2 id="了解更多">了解更多</h2>
 
@@ -67,6 +67,6 @@ translation_of: Glossary/Gutters
 <h3 id="扩展阅读">扩展阅读</h3>
 
 <ul>
- <li>CSS Grid Layout Guide: <em><a href="/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Basic concepts of grid layout</a></em></li>
+ <li>CSS Grid Layout Guide: <em><a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout">Basic concepts of grid layout</a></em></li>
  <li><a href="https://drafts.csswg.org/css-grid/#gutters">Definition of gutters in the CSS Grid Layout specification</a></li>
 </ul>

--- a/files/zh-cn/glossary/head/index.html
+++ b/files/zh-cn/glossary/head/index.html
@@ -13,5 +13,5 @@ translation_of: Glossary/Head
 
 <ul>
  <li>MDN里的{{htmlelement("head")}}元素引用 </li>
- <li>MDN学习区域里的<a href="/en-US/docs/Learn/HTML/Introduction_to_HTML/The_HTML_head">The HTML &lt;head&gt;</a> </li>
+ <li>MDN学习区域里的<a href="/zh-CN/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML">The HTML &lt;head&gt;</a> </li>
 </ul>

--- a/files/zh-cn/glossary/hmac/index.html
+++ b/files/zh-cn/glossary/hmac/index.html
@@ -25,6 +25,6 @@ translation_of: Glossary/HMAC
 
 <ul>
  <li>
-  <p>IETF 的 <a href="http://www.ietf.org/rfc/rfc2104.txt">RFC 2104</a></p>
+  <p>IETF 的 <a href="https://www.ietf.org/rfc/rfc2104.txt">RFC 2104</a></p>
  </li>
 </ul>

--- a/files/zh-cn/glossary/hoisting/index.html
+++ b/files/zh-cn/glossary/hoisting/index.html
@@ -8,7 +8,7 @@ tags:
   - 术语表
 translation_of: Glossary/Hoisting
 ---
-<p>变量提升（Hoisting）被认为是， Javascript中执行上下文 （特别是创建和执行阶段）工作方式的一种认识。在 <a href="http://www.ecma-international.org/ecma-262/6.0/index.html">ECMAScript® 2015 Language Specification</a> 之前的JavaScript文档中找不到变量提升（Hoisting）这个词。不过，需要注意的是，开始时，这个概念可能比较难理解，甚至恼人。</p>
+<p>变量提升（Hoisting）被认为是， Javascript中执行上下文 （特别是创建和执行阶段）工作方式的一种认识。在 <a href="https://www.ecma-international.org/ecma-262/6.0/index.html">ECMAScript® 2015 Language Specification</a> 之前的JavaScript文档中找不到变量提升（Hoisting）这个词。不过，需要注意的是，开始时，这个概念可能比较难理解，甚至恼人。</p>
 
 <p>例如，从概念的字面意义上说，“变量提升”意味着变量和函数的声明会在物理层面移动到代码的最前面，但这么说并不准确。实际上变量和函数声明在代码里的位置是不会动的，而是在编译阶段被放入内存中。</p>
 

--- a/files/zh-cn/glossary/html/index.html
+++ b/files/zh-cn/glossary/html/index.html
@@ -36,12 +36,12 @@ translation_of: Glossary/HTML
 
 <ul>
  <li><a href="/zh-CN/Learn/HTML">HTML 教程</a></li>
- <li><a href="http://www.codecademy.com/en/tracks/web" rel="external">codecademy.com 上的在线教程</a></li>
+ <li><a href="https://www.codecademy.com/en/tracks/web">codecademy.com 上的在线教程</a></li>
 </ul>
 
 <h3 id="技术资料">技术资料</h3>
 
 <ul>
  <li><a href="/zh-CN/docs/Web/HTML">MDN HTML 文档</a></li>
- <li><a href="http://www.w3.org/TR/html5/" rel="external">HTML 规范</a></li>
+ <li><a href="https://www.w3.org/TR/html5/">HTML 规范</a></li>
 </ul>

--- a/files/zh-cn/glossary/html5/index.html
+++ b/files/zh-cn/glossary/html5/index.html
@@ -13,5 +13,5 @@ translation_of: Glossary/HTML5
 <h2 id="更多相关内容">更多相关内容</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/Guide/HTML/HTML5">our HTML5 guide</a></li>
+ <li><a href="/zh-CN/docs/Glossary/HTML5">our HTML5 guide</a></li>
 </ul>

--- a/files/zh-cn/glossary/http_2/index.html
+++ b/files/zh-cn/glossary/http_2/index.html
@@ -6,7 +6,7 @@ tags:
   - HTTP2
 translation_of: Glossary/HTTP_2
 ---
-<p><strong>HTTP/2</strong> 是 <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP">HTTP 网络协议</a>的一个重要版本。 HTTP / 2的主要目标是通过启用完整的请求和响应多路复用来减少 {{glossary("延迟")}}，通过有效压缩HTTP标头字段来最小化协议开销，并增加对请求优先级和服务器推送的支持。</p>
+<p><strong>HTTP/2</strong> 是 <a href="/zh-CN/docs/Web/HTTP/Basics_of_HTTP">HTTP 网络协议</a>的一个重要版本。 HTTP / 2的主要目标是通过启用完整的请求和响应多路复用来减少 {{glossary("延迟")}}，通过有效压缩HTTP标头字段来最小化协议开销，并增加对请求优先级和服务器推送的支持。</p>
 
 <p>HTTP/2 不会修改 HTTP 协议的语义。 HTTP 1.1中的所有核心概念（例如 HTTP 方法，状态码，URI 和 headers）都得以保留。 而是修改了 HTTP/2 数据在客户端和服务器之间的格式（帧）和传输方式，这两者都管理整个过程，并在新的框架层内隐藏了应用程序的复杂性。 所以，所有现有的应用程序都可以不经修改地交付。</p>
 
@@ -18,7 +18,7 @@ translation_of: Glossary/HTTP_2
    <li>{{interwiki("wikipedia", "HTTP/2", "HTTP/2")}} on Wikipedia</li>
   </ol>
  </li>
- <li><a href="/en-US/docs/Glossary">词汇表</a>
+ <li><a href="/zh-CN/docs/Glossary">词汇表</a>
   <ol>
    <li>{{glossary("HTTP")}}</li>
    <li>{{glossary("Latency")}}</li>

--- a/files/zh-cn/glossary/http_3/index.html
+++ b/files/zh-cn/glossary/http_3/index.html
@@ -13,7 +13,7 @@ translation_of: Glossary/HTTP_3
 <ol>
  <li>基础知识
   <ol>
-   <li><a href="/en-US/docs/Web/HTTP">HTTP on MDN</a></li>
+   <li><a href="/zh-CN/docs/Web/HTTP">HTTP on MDN</a></li>
    <li>{{interwiki("wikipedia", "HTTP/3", "HTTP/3")}} </li>
   </ol>
  </li>

--- a/files/zh-cn/glossary/hyperlink/index.html
+++ b/files/zh-cn/glossary/hyperlink/index.html
@@ -15,19 +15,19 @@ translation_of: Glossary/Hyperlink
 
 <ul>
  <li>{{interwiki("wikipedia", "Hyperlink", "Hyperlink")}} on Wikipedia</li>
- <li>The <a href="/en-US/docs/Web/Guide/HTML/Hyperlink">Hyperlink</a> guide on MDN</li>
+ <li>The <a href="/zh-CN/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks">Hyperlink</a> guide on MDN</li>
 </ul>
 
 <h3 id="技术资讯">技术资讯</h3>
 
 <ul>
- <li><a class="external external-icon" href="https://www.w3.org/TR/1999/REC-html401-19991224/struct/links.html">Links in HTML Documents - W3C</a></li>
- <li><a class="external external-icon" href="https://w3c.github.io/html-reference/a.html">HTML5 a - hyperlink - W3C</a></li>
+ <li><a href="https://www.w3.org/TR/1999/REC-html401-19991224/struct/links.html">Links in HTML Documents - W3C</a></li>
+ <li><a href="https://w3c.github.io/html-reference/a.html">HTML5 a - hyperlink - W3C</a></li>
 </ul>
 
 <h3 id="学习更多">学习更多</h3>
 
 <ul>
- <li><a href="/en-US/docs/Web/HTML/Element/a">MDN上的 <code>&lt;a&gt;</code></a></li>
- <li><a href="/en-US/docs/Web/HTML/Element/link">MDN上的 <code>&lt;link&gt;</code> </a></li>
+ <li><a href="/zh-CN/docs/Web/HTML/Element/a">MDN上的 <code>&lt;a&gt;</code></a></li>
+ <li><a href="/zh-CN/docs/Web/HTML/Element/link">MDN上的 <code>&lt;link&gt;</code> </a></li>
 </ul>

--- a/files/zh-cn/glossary/hypertext/index.html
+++ b/files/zh-cn/glossary/hypertext/index.html
@@ -20,5 +20,5 @@ translation_of: Glossary/Hypertext
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="http://www.ualberta.ca/dept/chemeng/AIX-43/share/man/info/C/a_doc_lib/aixuser/aix6kdov/hyperv1aix.htm">Hypertext Information Base</a></li>
+ <li><a href="https://www.ualberta.ca/dept/chemeng/AIX-43/share/man/info/C/a_doc_lib/aixuser/aix6kdov/hyperv1aix.htm">Hypertext Information Base</a></li>
 </ul>

--- a/files/zh-cn/glossary/i18n/index.html
+++ b/files/zh-cn/glossary/i18n/index.html
@@ -19,7 +19,7 @@ translation_of: Glossary/I18N
 <p>在其他方面，i18n 仍然需要许多支持</p>
 
 <ul>
- <li>字符集 （通常使用 <a href="http://searchcio-midmarket.techtarget.com/definition/Unicode">Unicode</a>）</li>
+ <li>字符集 （通常使用 <a href="https://searchcio-midmarket.techtarget.com/definition/Unicode">Unicode</a>）</li>
  <li>计量单位 （货币、°C/°F 、km/miles 等）</li>
  <li>时间和日期格式</li>
  <li>键盘布局</li>
@@ -37,8 +37,8 @@ translation_of: Glossary/I18N
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="http://www.w3.org/International/questions/qa-i18n.en#Internationalization">i18n on W3C</a></li>
- <li><a href="http://www.gala-global.org/what-internationalization">i18n on gala-global.org</a></li>
+ <li><a href="https://www.w3.org/International/questions/qa-i18n.en#Internationalization">i18n on W3C</a></li>
+ <li><a href="https://www.gala-global.org/what-internationalization">i18n on gala-global.org</a></li>
 </ul>
 
 <h3 id="学习_i18n">学习 i18n</h3>

--- a/files/zh-cn/glossary/ice/index.html
+++ b/files/zh-cn/glossary/ice/index.html
@@ -25,8 +25,8 @@ translation_of: Glossary/ICE
 <h3 id="通用知识">通用知识</h3>
 
 <ul>
- <li><a href="/en-US/docs/Web/API/WebRTC_API">WebRTC</a>, 重要的使用ICE的网络相关协议</li>
- <li><a href="/en-US/docs/Web/API/WebRTC_API/Architecture/Protocols">WebRTC 协议</a></li>
+ <li><a href="/zh-CN/docs/Web/API/WebRTC_API">WebRTC</a>, 重要的使用ICE的网络相关协议</li>
+ <li><a href="/zh-CN/docs/Web/API/WebRTC_API/Protocols">WebRTC 协议</a></li>
 </ul>
 
 <h3 id="技术参考">技术参考</h3>

--- a/files/zh-cn/glossary/indexeddb/index.html
+++ b/files/zh-cn/glossary/indexeddb/index.html
@@ -9,11 +9,11 @@ tags:
   - 术语表
 translation_of: Glossary/IndexedDB
 ---
-<p>IndexedDB 是一个用于在浏览器中储存较大数据结构的 Web {{glossary("API")}}, 并提供索引功能以实现高性能查找. 像其他基于 {{glossary("SQL")}} 的 <a href="https://en.wikipedia.org/wiki/Relational_database_management_system" title="Relational DataBase Management System">关系型数据库管理系统 (RDBMS)</a> 一样, IndexedDB 是一个事务型的数据库系统. 然而, 它是使用 {{glossary("JavaScript")}} 对象而非列数固定的表格来储存数据的.</p>
+<p>IndexedDB 是一个用于在浏览器中储存较大数据结构的 Web {{glossary("API")}}, 并提供索引功能以实现高性能查找. 像其他基于 {{glossary("SQL")}} 的 <a href="https://en.wikipedia.org/wiki/Relational_database_management_system">关系型数据库管理系统 (RDBMS)</a> 一样, IndexedDB 是一个事务型的数据库系统. 然而, 它是使用 {{glossary("JavaScript")}} 对象而非列数固定的表格来储存数据的.</p>
 
 <h2 id="了解更多">了解更多</h2>
 
 <ul>
  <li>MDN 页面 {{domxref('IndexedDB_API','IndexedDB API','',1)}}</li>
- <li><a href="http://w3c.github.io/IndexedDB/">The W3C specification for IndexedDB</a></li>
+ <li><a href="https://w3c.github.io/IndexedDB/">The W3C specification for IndexedDB</a></li>
 </ul>

--- a/files/zh-cn/glossary/input_method_editor/index.html
+++ b/files/zh-cn/glossary/input_method_editor/index.html
@@ -22,7 +22,7 @@ translation_of: Glossary/Input_method_editor
    <li>{{Interwiki("wikipedia", "Input method")}}</li>
   </ol>
  </li>
- <li><a href="/en-US/docs/Glossary">词汇表</a>
+ <li><a href="/zh-CN/docs/Glossary">词汇表</a>
   <ol>
    <li>{{Glossary("I18N")}}</li>
   </ol>

--- a/files/zh-cn/glossary/internet/index.html
+++ b/files/zh-cn/glossary/internet/index.html
@@ -12,5 +12,5 @@ translation_of: Glossary/Internet
 <h3 id="了解它">了解它</h3>
 
 <ul>
- <li><a href="/zh-CN/docs/learn/How_the_Internet_works">互联网是如何工作的</a>（给初学者的介绍）</li>
+ <li><a href="/zh-CN/docs/Learn/Common_questions/How_does_the_Internet_work">互联网是如何工作的</a>（给初学者的介绍）</li>
 </ul>

--- a/files/zh-cn/glossary/irc/index.html
+++ b/files/zh-cn/glossary/irc/index.html
@@ -10,6 +10,6 @@ translation_of: Glossary/IRC
 <h3 id="学习更多"><strong>学习更多</strong></h3>
 
 <ul>
- <li><a href="/en-US/docs/Mozilla/QA/Getting_Started_with_IRC">IRC 起步</a></li>
+ <li><a href="/zh-CN/docs/Mozilla/QA/Getting_Started_with_IRC">IRC 起步</a></li>
  <li><a href="https://wiki.mozilla.org/IRC">在Mozilla上使用IRC</a></li>
 </ul>

--- a/files/zh-cn/glossary/isp/index.html
+++ b/files/zh-cn/glossary/isp/index.html
@@ -14,6 +14,6 @@ translation_of: Glossary/ISP
 <h3 id="补充知识">补充知识</h3>
 
 <ul>
- <li><a href="https://developer.mozilla.org/zh-CN/docs/learn/How_the_Internet_works">互联网是如何工作的</a>（给初学者的说明）</li>
+ <li><a href="/zh-CN/docs/Learn/Common_questions/How_does_the_Internet_work">互联网是如何工作的</a>（给初学者的说明）</li>
  <li><a href="https://zh.wikipedia.org/wiki/%E4%BA%92%E8%81%94%E7%BD%91%E6%9C%8D%E5%8A%A1%E4%BE%9B%E5%BA%94%E5%95%86">互联网服务供应商</a>（中文维基百科）</li>
 </ul>

--- a/files/zh-cn/glossary/javascript/index.html
+++ b/files/zh-cn/glossary/javascript/index.html
@@ -6,9 +6,9 @@ tags:
   - 术语
 translation_of: Glossary/JavaScript
 ---
-<p>JavaScript (JS) 是一种编程语言，为通常用于客户端（client-side）的网页动态脚本，不过，也常通过像<a href="http://nodejs.org/" rel="external">Node.js</a>这样的包，用于服务器端（{{Glossary("Server","server")}}-side）。</p>
+<p>JavaScript (JS) 是一种编程语言，为通常用于客户端（client-side）的网页动态脚本，不过，也常通过像<a href="https://nodejs.org/">Node.js</a>这样的包，用于服务器端（{{Glossary("Server","server")}}-side）。</p>
 
-<p>不应该把JavaScript 和 <a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Guide/Introduction#JavaScript_and_Java">Java</a> 混淆。“Java” 和 “JavaScript” 都是 Oracle 公司在美国和其他国家注册的商标，但是这两种编程语言在语法、语义和使用方面都明显不同。</p>
+<p>不应该把JavaScript 和 <a href="/zh-CN/docs/Web/JavaScript/Guide/Introduction#JavaScript_and_Java">Java</a> 混淆。“Java” 和 “JavaScript” 都是 Oracle 公司在美国和其他国家注册的商标，但是这两种编程语言在语法、语义和使用方面都明显不同。</p>
 
 <p>Brendan Eich （彼时受雇于 Netscape ）为服务器端构想的语言 JavaScript ，不久便在 1995 年 9 月被加入 Netscape Navigator 2.0。JavaScript 很快获得了成功，而 <a href='{{glossary("Microsoft Internet Explorer", "Internet Explorer 3.0")}}'>Internet Explorer 3.0</a> 也在 1996 年 8 月，引入了对 JavaScript 的支持，冠以 JScript 之名。</p>
 
@@ -16,7 +16,7 @@ translation_of: Glossary/JavaScript
 
 <p>JavaScript 通常用于浏览器，使开发者能通过{{Glossary("DOM")}}来操纵网页内容、或透过{{Glossary("AJAX")}}与{{Glossary("IndexedDB")}}来操作数据；还可以用它在{{Glossary("canvas")}}上面绘图、通过各种{{Glossary("API","APIs")}}与运行浏览器的各种设备交互……等等。由于近年来的发展、以及各浏览器的{{Glossary("API","APIs")}}性能改善，JavaScript 成了世界上最常用的编程语言之一。</p>
 
-<p>最近，JavaScript 的流行程度，随着除浏览器外最流行的跨平台 JavaScript 运行环境——<a href="http://nodejs.org/">Node.js</a> 平台的成功而大大提升。Node.js 使开发者可以在 PC 上使用 JavaScript 作为脚本语言以自动化处理和构建功能完备的 {{Glossary("HTTP")}} 和 {{Glossary("Web Sockets")}} 服务器。</p>
+<p>最近，JavaScript 的流行程度，随着除浏览器外最流行的跨平台 JavaScript 运行环境——<a href="https://nodejs.org/">Node.js</a> 平台的成功而大大提升。Node.js 使开发者可以在 PC 上使用 JavaScript 作为脚本语言以自动化处理和构建功能完备的 {{Glossary("HTTP")}} 和 {{Glossary("Web Sockets")}} 服务器。</p>
 
 <h2 id="了解更多">了解更多</h2>
 
@@ -30,15 +30,15 @@ translation_of: Glossary/JavaScript
 
 <ul>
  <li>MDN 的 {{Link("/zh-CN/docs/Web/JavaScript/Guide")}} </li>
- <li><a href="http://nodeschool.io/#workshoppers">NodeSchool 的 javascripting 工坊</a></li>
- <li><a href="http://www.codecademy.com/tracks/javascript" rel="external">codecademy.com 的 JavaScript 课程</a></li>
- <li><a href="http://ejohn.org/apps/learn/" rel="external">John Resig 的 Learning Advanced JavaScript</a></li>
+ <li><a href="https://nodeschool.io/#workshoppers">NodeSchool 的 javascripting 工坊</a></li>
+ <li><a href="https://www.codecademy.com/tracks/javascript">codecademy.com 的 JavaScript 课程</a></li>
+ <li><a href="http://ejohn.org/apps/learn/">John Resig 的 Learning Advanced JavaScript</a></li>
 </ul>
 
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm" rel="external">John Resig 的 Learning Advanced JavaScript</a></li>
+ <li><a href="https://www.ecma-international.org/publications/standards/Ecma-262.htm">John Resig 的 Learning Advanced JavaScript</a></li>
  <li>MDN 的 {{Link("/en-US/docs/Web/JavaScript/reference")}} 参考文件</li>
- <li><a href="http://eloquentjavascript.net/" rel="external"><em>Eloquent JavaScript</em> </a>一书</li>
+ <li><a href="https://eloquentjavascript.net/"><em>Eloquent JavaScript</em> </a>一书</li>
 </ul>

--- a/files/zh-cn/glossary/jpeg/index.html
+++ b/files/zh-cn/glossary/jpeg/index.html
@@ -83,5 +83,5 @@ translation_of: Glossary/jpeg
 
 <ul>
  <li>在维基百科上的 {{Interwiki("wikipedia", "JPEG")}}</li>
- <li>在百度百科上的 <a href="https://baike.baidu.com/item/JPEG%E6%A0%BC%E5%BC%8F/3462770" title="JPEG-百度百科">jpeg</a></li>
+ <li>在百度百科上的 <a href="https://baike.baidu.com/item/JPEG%E6%A0%BC%E5%BC%8F/3462770">jpeg</a></li>
 </ul>

--- a/files/zh-cn/glossary/jquery/index.html
+++ b/files/zh-cn/glossary/jquery/index.html
@@ -48,7 +48,7 @@ translation_of: Glossary/jQuery
 
 <ul>
  <li>维基百科上的 {{Interwiki("wikipedia", "jQuery")}}</li>
- <li><a href="http://jquery.com/">jQuery 官方网站</a></li>
+ <li><a href="https://jquery.com/">jQuery 官方网站</a></li>
 </ul>
 
 <h3 id="技术信息">技术信息</h3>

--- a/files/zh-cn/glossary/localization/index.html
+++ b/files/zh-cn/glossary/localization/index.html
@@ -12,31 +12,31 @@ original_slug: Localization
         <h2 class="Documentation" id="Documentation">Documentation</h2>
         <dl>
           <dt>
-            <a href="/en-US/docs/Localization_Quick_Start_Guide" title="https://developer.mozilla.org/en-US/docs/Localization_Quick_Start_Guide">Localization Quick Start Guide</a></dt>
+            <a href="/zh-CN/docs/Localization_Quick_Start_Guide">Localization Quick Start Guide</a></dt>
           <dd>
             First read for volunteers wanting to start localizing.</dd>
           <dt>
-            <a href="/en-US/docs/XUL_Tutorial/Localization" title="en-US/docs/XUL_Tutorial/Localization">XUL Tutorial:Localization</a></dt>
+            <a href="/zh-CN/docs/XUL_Tutorial/Localization">XUL Tutorial:Localization</a></dt>
           <dd>
-            <a href="/en-US/docs/XUL_Tutorial" title="en-US/docs/XUL_Tutorial">XUL Tutorial</a> section on localizing XUL applications.</dd>
+            <a href="/zh-CN/docs/XUL_Tutorial">XUL Tutorial</a> section on localizing XUL applications.</dd>
           <dt>
-            <a href="/en-US/docs/Writing_localizable_code" title="en-US/docs/Writing_localizable_code">Writing localizable code</a></dt>
+            <a href="/zh-CN/docs/Writing_localizable_code">Writing localizable code</a></dt>
           <dd>
             Best practices and guidelines for programmers to play nicely with localization.</dd>
           <dt>
-            <a class="external" href="http://wiki.babelzilla.org/index.php?title=Tutorials#How_to_localize_strings_from_the_help.html_file_of_an_extension" title="http://wiki.babelzilla.org/index.php?title=Tutorials#How_to_localize_strings_from_the_help.html_file_of_an_extension">Localizing Help files</a></dt>
+            <a href="http://wiki.babelzilla.org/index.php?title=Tutorials#How_to_localize_strings_from_the_help.html_file_of_an_extension">Localizing Help files</a></dt>
           <dd>
             How to separate content from HTML to make these files more easy to localize.</dd>
           <dt>
-            <a class="external" href="http://wiki.babelzilla.org/index.php?title=Tutorials#How_to_resize_a_xul_pref_dialog_according_to_every_language" title="http://wiki.babelzilla.org/index.php?title=Tutorials#How_to_resize_a_xul_pref_dialog_according_to_every_language">Custom dialog size</a></dt>
+            <a href="http://wiki.babelzilla.org/index.php?title=Tutorials#How_to_resize_a_xul_pref_dialog_according_to_every_language">Custom dialog size</a></dt>
           <dd>
             How to adjust window sizes to fit specific localizations.</dd>
           <dt>
-            <a href="/en-US/docs/Localizing_extension_descriptions" title="en-US/docs/Localizing_extension_descriptions">Localizing extension descriptions</a></dt>
+            <a href="/zh-CN/docs/Localizing_extension_descriptions">Localizing extension descriptions</a></dt>
           <dd>
             To localize the description of an extension (the string that shows up under extension's name in the Extensions window), you need to use a special preference key to override the description specified in your install.rdf file. This article contains instructions on how to modify this preference key.</dd>
           <dt>
-            <a href="/en-US/docs/Frequently_Asked_Localization_Questions" title="en-US/docs/Frequently_Asked_Localization_Questions">Frequently Asked Localization Questions</a></dt>
+            <a href="/zh-CN/docs/Frequently_Asked_Localization_Questions">Frequently Asked Localization Questions</a></dt>
           <dd>
             Frequently asked questions about localization.</dd>
         </dl>
@@ -44,12 +44,12 @@ original_slug: Localization
       <td>
         <h2 class="Community" id="Community">Community</h2>
         <ul>
-          <li><a href="/Special:Tags?tag=Localization:Tools&amp;language=en" title="Special:Tags?tag=Localization:Tools&amp;language=en">Tools</a></li>
-          <li><a class="link-https" href="https://wiki.mozilla.org/L10n" title="https://wiki.mozilla.org/L10n">Community</a></li>
+          <li><a href="/Special:Tags?tag=Localization:Tools&amp;language=en">Tools</a></li>
+          <li><a href="https://wiki.mozilla.org/L10n">Community</a></li>
         </ul>
         <h2 class="Related_Topics" id="Related_Topics" name="Related_Topics">Related Topics</h2>
         <ul>
-          <li><a href="/en-US/docs/Extensions" title="en-US/docs/Extensions">Extensions</a>, <a href="/en-US/docs/XUL" title="en-US/docs/XUL">XUL</a></li>
+          <li><a href="/zh-CN/docs/Extensions">Extensions</a>, <a href="/zh-CN/docs/XUL">XUL</a></li>
         </ul>
       </td>
     </tr>

--- a/files/zh-cn/glossary/localization/index.html
+++ b/files/zh-cn/glossary/localization/index.html
@@ -44,7 +44,6 @@ original_slug: Localization
       <td>
         <h2 class="Community" id="Community">Community</h2>
         <ul>
-          <li><a href="/Special:Tags?tag=Localization:Tools&amp;language=en">Tools</a></li>
           <li><a href="https://wiki.mozilla.org/L10n">Community</a></li>
         </ul>
         <h2 class="Related_Topics" id="Related_Topics" name="Related_Topics">Related Topics</h2>

--- a/files/zh-cn/glossary/main_axis/index.html
+++ b/files/zh-cn/glossary/main_axis/index.html
@@ -41,9 +41,9 @@ original_slug: Glossary/主轴
 <h3 id="拓展阅读">拓展阅读</h3>
 
 <ul>
- <li>CSS 弹性容器指南： <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox">Basic Concepts of Flexbox</a></em></li>
- <li>CSS 弹性容器指南： <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container">Aligning items in a flex container</a></em></li>
- <li>CSS 弹性容器指南： <em><a href="/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Controlling_Ratios_of_Flex_Items_Along_the_Main_Ax">Controlling Ratios of flex items along the main axis</a></em></li>
+ <li>CSS 弹性容器指南： <em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox">Basic Concepts of Flexbox</a></em></li>
+ <li>CSS 弹性容器指南： <em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container">Aligning items in a flex container</a></em></li>
+ <li>CSS 弹性容器指南： <em><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Controlling_Ratios_of_Flex_Items_Along_the_Main_Ax">Controlling Ratios of flex items along the main axis</a></em></li>
 </ul>
 
 <div id="gtx-trans" style="position: absolute; left: 188px; top: 1222.14px;">

--- a/files/zh-cn/glossary/main_thread/index.html
+++ b/files/zh-cn/glossary/main_thread/index.html
@@ -5,18 +5,18 @@ translation_of: Glossary/Main_thread
 ---
 <p><strong>主线程</strong>用于浏览器处理用户事件和页面绘制等。默认情况下，浏览器在一个线程中运行一个页面中的所有 JavaScript 脚本，以及呈现布局，回流，和垃圾回收。这意味着一个长时间运行的 JavaScript 会阻塞线程，导致页面无法响应，造成不佳的用户体验。</p>
 
-<p>除非故意使用 <a href="/en-US/docs/Web/API/Web_Workers_API/Using_web_workers">web worker</a>，比如 <a href="/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers">service worker</a>，不然 JavaScript 只在线程中运行，所以脚本的运行时，很容易导致事件处理流程或绘制的延迟。主线程中运行的工作越少，就有越多的余地来处理用户事件，页面绘制和对用户保持响应。 </p>
+<p>除非故意使用 <a href="/zh-CN/docs/Web/API/Web_Workers_API/Using_web_workers">web worker</a>，比如 <a href="/zh-CN/docs/Web/API/Service_Worker_API/Using_Service_Workers">service worker</a>，不然 JavaScript 只在线程中运行，所以脚本的运行时，很容易导致事件处理流程或绘制的延迟。主线程中运行的工作越少，就有越多的余地来处理用户事件，页面绘制和对用户保持响应。 </p>
 
 <section id="Quick_links">
 <ol>
  <li>另可参考
   <ol>
-   <li><a href="/en-US/docs/Learn/JavaScript/Asynchronous">异步 JavaScript</a></li>
-   <li><a href="/en-US/docs/Web/API/Web_Workers_API">Web worker API</a></li>
-   <li><a href="/en-US/docs/Web/API/Service_Worker_API">Service worker API</a></li>
+   <li><a href="/zh-CN/docs/Learn/JavaScript/Asynchronous">异步 JavaScript</a></li>
+   <li><a href="/zh-CN/docs/Web/API/Web_Workers_API">Web worker API</a></li>
+   <li><a href="/zh-CN/docs/Web/API/Service_Worker_API">Service worker API</a></li>
   </ol>
  </li>
- <li><a href="/en-US/docs/Glossary">词汇表</a>
+ <li><a href="/zh-CN/docs/Glossary">词汇表</a>
   <ol>
    <li>{{Glossary("Thread")}}</li>
   </ol>

--- a/files/zh-cn/glossary/method/index.html
+++ b/files/zh-cn/glossary/method/index.html
@@ -15,18 +15,18 @@ translation_of: Glossary/Method
 
 <ul>
  <li>{{InterWiki("wikipedia","Method (computer programming)")}} in Wikipedia</li>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions">Defining a method in JavaScript</a> (comparison of the traditional syntax and the new shorthand)</li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Functions/Method_definitions">Defining a method in JavaScript</a> (comparison of the traditional syntax and the new shorthand)</li>
 </ul>
 
 <h3 id="Technical_reference">Technical reference</h3>
 
 <ul>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Methods_Index">List of JavaScript built-in methods</a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Reference">List of JavaScript built-in methods</a></li>
 </ul>
 
 <section id="Quick_links">
 <ul>
- <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
+ <li><a href="/zh-CN/docs/Glossary">MDN Web Docs Glossary</a>
 
   <ul>
    <li>{{Glossary("function")}}</li>
@@ -35,6 +35,6 @@ translation_of: Glossary/Method
    <li>{{Glossary("static method")}}</li>
   </ul>
  </li>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions">Defining a method in JavaScript</a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Functions/Method_definitions">Defining a method in JavaScript</a></li>
 </ul>
 </section>

--- a/files/zh-cn/glossary/microsoft_internet_explorer/index.html
+++ b/files/zh-cn/glossary/microsoft_internet_explorer/index.html
@@ -27,16 +27,16 @@ translation_of: Glossary/Microsoft_Internet_Explorer
 <h3 id="了解_Internet_Explorer" style="line-height: 24px; font-size: 1.71428571428571rem;">了解 Internet Explorer</h3>
 
 <ul>
- <li><a href="http://windows.microsoft.com/en-us/internet-explorer/download-ie">http://windows.microsoft.com/en-us/internet-explorer/download-ie</a></li>
- <li><a href="http://windows.microsoft.com/en-us/windows7/getting-started-with-internet-explorer-9">http://windows.microsoft.com/en-us/windows7/getting-started-with-internet-explorer-9</a></li>
- <li><a href="http://windows.microsoft.com/en-us/internet-explorer/internet-explorer-help">http://windows.microsoft.com/en-us/internet-explorer/internet-explorer-help</a></li>
- <li><a href="http://windows.microsoft.com/en-us/internet-explorer/make-ie-default-browser#ie=ie-11">http://windows.microsoft.com/en-us/internet-explorer/make-ie-default-browser#ie=ie-11</a></li>
+ <li><a href="https://windows.microsoft.com/en-us/internet-explorer/download-ie">http://windows.microsoft.com/en-us/internet-explorer/download-ie</a></li>
+ <li><a href="https://windows.microsoft.com/en-us/windows7/getting-started-with-internet-explorer-9">http://windows.microsoft.com/en-us/windows7/getting-started-with-internet-explorer-9</a></li>
+ <li><a href="https://windows.microsoft.com/en-us/internet-explorer/internet-explorer-help">http://windows.microsoft.com/en-us/internet-explorer/internet-explorer-help</a></li>
+ <li><a href="https://windows.microsoft.com/en-us/internet-explorer/make-ie-default-browser#ie=ie-11">http://windows.microsoft.com/en-us/internet-explorer/make-ie-default-browser#ie=ie-11</a></li>
 </ul>
 
 <h3 id="技术参考" style="line-height: 24px; font-size: 1.71428571428571rem;">技术参考</h3>
 
 <ul>
- <li><a href="http://windows.microsoft.com/en-us/internet-explorer/products/ie-8/system-requirements">http://windows.microsoft.com/en-us/internet-explorer/products/ie-8/system-requirements</a></li>
- <li><a href="http://windows.microsoft.com/en-us/internet-explorer/products/ie-9/system-requirements">http://windows.microsoft.com/en-us/internet-explorer/products/ie-9/system-requirements</a></li>
- <li><a href="http://support.microsoft.com/kb/969393">http://support.microsoft.com/kb/969393</a></li>
+ <li><a href="https://windows.microsoft.com/en-us/internet-explorer/products/ie-8/system-requirements">http://windows.microsoft.com/en-us/internet-explorer/products/ie-8/system-requirements</a></li>
+ <li><a href="https://windows.microsoft.com/en-us/internet-explorer/products/ie-9/system-requirements">http://windows.microsoft.com/en-us/internet-explorer/products/ie-9/system-requirements</a></li>
+ <li><a href="https://support.microsoft.com/kb/969393">http://support.microsoft.com/kb/969393</a></li>
 </ul>

--- a/files/zh-cn/glossary/mime_type/index.html
+++ b/files/zh-cn/glossary/mime_type/index.html
@@ -18,7 +18,7 @@ translation_of: Glossary/MIME_type
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="http://www.iana.org/assignments/media-types/media-types.xhtml">MIME types 列表</a></li>
- <li><a href="/en-US/docs/Properly_Configuring_Server_MIME_Types">正确配置服务器 MIME Types</a></li>
- <li>有关在Web环境中使用 <a href="/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME Types</a> 的详细信息。</li>
+ <li><a href="https://www.iana.org/assignments/media-types/media-types.xhtml">MIME types 列表</a></li>
+ <li><a href="/zh-CN/docs/Learn/Server-side/Configuring_server_MIME_types">正确配置服务器 MIME Types</a></li>
+ <li>有关在Web环境中使用 <a href="/zh-CN/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MIME Types</a> 的详细信息。</li>
 </ul>

--- a/files/zh-cn/glossary/mixin/index.html
+++ b/files/zh-cn/glossary/mixin/index.html
@@ -17,5 +17,5 @@ translation_of: Glossary/Mixin
 <h3 id="基础知识">基础知识</h3>
 
 <ul>
- <li>维基百科上的<a class="external external-icon" href="http://en.wikipedia.org/wiki/Mixin">Mixin</a></li>
+ <li>维基百科上的<a href="https://en.wikipedia.org/wiki/Mixin">Mixin</a></li>
 </ul>

--- a/files/zh-cn/glossary/mvc/index.html
+++ b/files/zh-cn/glossary/mvc/index.html
@@ -24,5 +24,5 @@ translation_of: Glossary/MVC
 <h3 id="Learning_MVC">Learning MVC</h3>
 
 <ul>
- <li><a href="/en-US/Apps/Fundamentals/Modern_web_app_architecture/MVC_architecture">MVC architecture</a></li>
+ <li><a href="/zh-CN/Apps/Fundamentals/Modern_web_app_architecture/MVC_architecture">MVC architecture</a></li>
 </ul>

--- a/files/zh-cn/glossary/nan/index.html
+++ b/files/zh-cn/glossary/nan/index.html
@@ -20,5 +20,5 @@ translation_of: Glossary/NaN
 <h3 id="权威的信息">权威的信息</h3>
 
 <ul>
- <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN">NaN in JavaScript</a> </li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/NaN">NaN in JavaScript</a> </li>
 </ul>

--- a/files/zh-cn/glossary/nat/index.html
+++ b/files/zh-cn/glossary/nat/index.html
@@ -16,6 +16,6 @@ translation_of: Glossary/NAT
 <h3 id="通用知识">通用知识</h3>
 
 <ul>
- <li><a href="/en-US/docs/Web/API/WebRTC_API/Architecture/Protocols">WebRTC 协议</a></li>
+ <li><a href="/zh-CN/docs/Web/API/WebRTC_API/Protocols">WebRTC 协议</a></li>
  <li>{{interwiki("wikipedia", "NAT")}} 在 Wikipedia</li>
 </ul>

--- a/files/zh-cn/glossary/null/index.html
+++ b/files/zh-cn/glossary/null/index.html
@@ -22,6 +22,6 @@ translation_of: Glossary/Null
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="/en-US/docs/Web/JavaScript/Data_structures">JavaScript数据类型和数据结构</a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Data_structures">JavaScript数据类型和数据结构</a></li>
  <li>JavaScript 全局对象: {{jsxref("null")}}</li>
 </ul>

--- a/files/zh-cn/glossary/number/index.html
+++ b/files/zh-cn/glossary/number/index.html
@@ -5,7 +5,7 @@ tags:
   - JavaScript
 translation_of: Glossary/Number
 ---
-<p>在 {{Glossary("JavaScript")}} 中, <strong>Number</strong> 是一种 定义为 <a class="external external-icon" href="http://en.wikipedia.org/wiki/Double_precision_floating-point_format">64位双精度浮点型（double-precision 64-bit floating point format） (IEEE 754)</a>的数字数据类型。在其他编程语言中，有不同的数字类型存在，比如：整型（Integers），单精度浮点型（Floats），双精度浮点型（Doubles），大数（Bignums）。</p>
+<p>在 {{Glossary("JavaScript")}} 中, <strong>Number</strong> 是一种 定义为 <a href="https://en.wikipedia.org/wiki/Double_precision_floating-point_format">64位双精度浮点型（double-precision 64-bit floating point format） (IEEE 754)</a>的数字数据类型。在其他编程语言中，有不同的数字类型存在，比如：整型（Integers），单精度浮点型（Floats），双精度浮点型（Doubles），大数（Bignums）。</p>
 
 <h2 id="了解更多">了解更多</h2>
 
@@ -20,6 +20,6 @@ translation_of: Glossary/Number
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li>JavaScript 数据结构: <a href="/en-US/docs/Web/JavaScript/Data_structures#Number_type">Number</a></li>
+ <li>JavaScript 数据结构: <a href="/zh-CN/docs/Web/JavaScript/Data_structures#Number_type">Number</a></li>
  <li>JavaScript 全局对象 {{jsxref("Number")}}</li>
 </ul>

--- a/files/zh-cn/glossary/object/index.html
+++ b/files/zh-cn/glossary/object/index.html
@@ -7,7 +7,7 @@ tags:
   - 词汇表
 translation_of: Glossary/Object
 ---
-<p><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object">对象</a> 指包含数据和用于处理数据的指令的数据结构. 对象有时也指现实世界中的一些事, 例如在赛车游戏当中一辆车或者一幅地图都可以是一个对象. {{glossary("JavaScript")}}, Java, C++, Python, 还有 Ruby 这些例子都是{{glossary("OOP","面向对象的程序设计")}} 语言.</p>
+<p><a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object">对象</a> 指包含数据和用于处理数据的指令的数据结构. 对象有时也指现实世界中的一些事, 例如在赛车游戏当中一辆车或者一幅地图都可以是一个对象. {{glossary("JavaScript")}}, Java, C++, Python, 还有 Ruby 这些例子都是{{glossary("OOP","面向对象的程序设计")}} 语言.</p>
 
 <h2 id="了解更多">了解更多</h2>
 
@@ -15,6 +15,6 @@ translation_of: Glossary/Object
 
 <ul>
  <li>{{Interwiki("wikipedia", "Object-oriented programming")}} on Wikipedia</li>
- <li>{{jsxref("Object")}} in the <a href="/en-US/docs/Web/JavaScript/Reference">JavaScript reference</a></li>
- <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Objects">Object data structures in JavaScript</a></li>
+ <li>{{jsxref("Object")}} in the <a href="/zh-CN/docs/Web/JavaScript/Reference">JavaScript reference</a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Data_structures#Objects">Object data structures in JavaScript</a></li>
 </ul>

--- a/files/zh-cn/glossary/oop/index.html
+++ b/files/zh-cn/glossary/oop/index.html
@@ -10,7 +10,7 @@ original_slug: Glossary/面向对象编程
 ---
 <p><strong>OOP</strong>（面向对象编程）是一种编程方法，其中数据封装在<strong>{{glossary("object","对象")}}</strong>中，对象本身在其上运行，而不是其组成部分。</p>
 
-<p>{{glossary("JavaScript")}} 是高度面向对象的。它遵循基于原型的模型（<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Details_of_the_Object_Model#Class-based_vs._prototype-based_languages">与基于类的模型相反</a>）。</p>
+<p>{{glossary("JavaScript")}} 是高度面向对象的。它遵循基于原型的模型（<a href="/zh-CN/docs/Web/JavaScript/Guide/Details_of_the_Object_Model#Class-based_vs._prototype-based_languages">与基于类的模型相反</a>）。</p>
 
 <h2 id="了解更多">了解更多</h2>
 
@@ -18,5 +18,5 @@ original_slug: Glossary/面向对象编程
 
 <ul>
  <li>维基百科：{{Interwiki("wikipedia", "Object-oriented programming")}}</li>
- <li><a href="/en-US/docs/Web/JavaScript/Introduction_to_Object-Oriented_JavaScript">JavaScript面向对象简介</a></li>
+ <li><a href="/zh-CN/docs/Learn/JavaScript/Objects">JavaScript面向对象简介</a></li>
 </ul>

--- a/files/zh-cn/glossary/origin/index.html
+++ b/files/zh-cn/glossary/origin/index.html
@@ -50,4 +50,4 @@ original_slug: Glossary/源
 
 <h2 id="了解更多">了解更多</h2>
 
-<p>详细信息，请看<a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Same_origin_policy_for_JavaScript" title="/en-US/docs/Web/JavaScript/Same_origin_policy_for_JavaScript">同源策略</a>。</p>
+<p>详细信息，请看<a href="/zh-CN/docs/Web/Security/Same-origin_policy">同源策略</a>。</p>

--- a/files/zh-cn/glossary/php/index.html
+++ b/files/zh-cn/glossary/php/index.html
@@ -8,7 +8,7 @@ translation_of: Glossary/PHP
 <h2 id="了解更多">了解更多</h2>
 
 <ul>
- <li><a href="http://php.net/">官方网站</a></li>
+ <li><a href="https://php.net/">官方网站</a></li>
  <li>在维基百科上的 {{Interwiki("wikipedia", "PHP")}}</li>
  <li>在Wikibooks上的 <a href="https://en.wikibooks.org/wiki/PHP_Programming">PHP</a></li>
 </ul>

--- a/files/zh-cn/glossary/preflight_request/index.html
+++ b/files/zh-cn/glossary/preflight_request/index.html
@@ -31,6 +31,6 @@ Access-Control-Max-Age: 86400</pre>
 <h2 id="参见">参见</h2>
 
 <ul>
- <li><a href="/en-US/docs/Glossary/CORS">CORS</a></li>
+ <li><a href="/zh-CN/docs/Glossary/CORS">CORS</a></li>
  <li>{{HTTPMethod("OPTIONS")}}</li>
 </ul>

--- a/files/zh-cn/glossary/primitive/index.html
+++ b/files/zh-cn/glossary/primitive/index.html
@@ -119,5 +119,5 @@ console.log(foo);   // 5</code></pre>
    <li>{{Glossary("symbol")}}</li>
   </ol>
  </li>
- <li><a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Data_structures">JavaScript 数据类型和数据结构</a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Data_structures">JavaScript 数据类型和数据结构</a></li>
 </ol>

--- a/files/zh-cn/glossary/progressive_enhancement/index.html
+++ b/files/zh-cn/glossary/progressive_enhancement/index.html
@@ -10,7 +10,7 @@ original_slug: Glossary/渐进增强
 ---
 <p><strong>渐进增强（Progressive enhancement）</strong>是一种设计理念，其核心是为尽可能多的用户提供基本内容和功能，同时进一步为现代化浏览器用户提供最佳体验，运行所有需要的代码。</p>
 
-<p><a href="/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Feature_detection">特性检测</a>通常用于确定浏览器是否可以处理高级内容，而<a href="/en-US/docs/Glossary/Polyfill">polyfill</a>通常用于使用JavaScript构建缺少的功能。</p>
+<p><a href="/zh-CN/docs/Learn/Tools_and_testing/Cross_browser_testing/Feature_detection">特性检测</a>通常用于确定浏览器是否可以处理高级内容，而<a href="/zh-CN/docs/Glossary/Polyfill">polyfill</a>通常用于使用JavaScript构建缺少的功能。</p>
 
 <p>另外请关注无障碍支持 — 尽可能提供备选方案。</p>
 

--- a/files/zh-cn/glossary/protocol/index.html
+++ b/files/zh-cn/glossary/protocol/index.html
@@ -14,7 +14,7 @@ translation_of: Glossary/Protocol
 
 <ul>
  <li>在维基百科中的 {{Interwiki("wikipedia", "通信协议")}}</li>
- <li><a href="http://www.rfc-editor.org/search/standards.php">RFC 官方互联网协议标准</a></li>
+ <li><a href="https://www.rfc-editor.org/search/standards.php">RFC 官方互联网协议标准</a></li>
 </ul>
 
 <h2 id="参见">参见</h2>

--- a/files/zh-cn/glossary/proxy_server/index.html
+++ b/files/zh-cn/glossary/proxy_server/index.html
@@ -20,6 +20,6 @@ original_slug: Glossary/代理服务器
 <h2 id="更多资料">更多资料</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/HTTP/Proxy_servers_and_tunneling">Proxy servers and tunneling </a></li>
+ <li><a href="/zh-CN/docs/Web/HTTP/Proxy_servers_and_tunneling">Proxy servers and tunneling </a></li>
  <li><a href="https://en.wikipedia.org/wiki/Proxy_server">Proxy server</a> on Wikipedia</li>
 </ul>

--- a/files/zh-cn/glossary/python/index.html
+++ b/files/zh-cn/glossary/python/index.html
@@ -13,5 +13,5 @@ translation_of: Glossary/Python
 
 <ul>
  <li>在维基百科上的 {{interwiki('wikipedia','Python')}}</li>
- <li><a href="http://www.tutorialspoint.com/python/index.htm">python的入门教程</a></li>
+ <li><a href="https://www.tutorialspoint.com/python/index.htm">python的入门教程</a></li>
 </ul>

--- a/files/zh-cn/glossary/rail/index.html
+++ b/files/zh-cn/glossary/rail/index.html
@@ -23,5 +23,5 @@ translation_of: Glossary/RAIL
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li><a href="/en-US/docs/Learn/Performance/How_long_is_too_long">Recommended Web Performance Timings: How long is too long</a></li>
+ <li><a href="/zh-CN/docs/Web/Performance/How_long_is_too_long">Recommended Web Performance Timings: How long is too long</a></li>
 </ul>

--- a/files/zh-cn/glossary/recursion/index.html
+++ b/files/zh-cn/glossary/recursion/index.html
@@ -14,5 +14,5 @@ translation_of: Glossary/Recursion
 
 <ul>
  <li>Wikipedia 页面：{{Interwiki("wikipedia", "Recursion (computer science)")}}</li>
- <li><a href="/en-US/docs/Web/JavaScript/Guide/Functions#Recursion">更多关于 JavaScript 中递归的细节</a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Guide/Functions#Recursion">更多关于 JavaScript 中递归的细节</a></li>
 </ul>

--- a/files/zh-cn/glossary/regular_expression/index.html
+++ b/files/zh-cn/glossary/regular_expression/index.html
@@ -13,12 +13,12 @@ translation_of: Glossary/Regular_expression
 
 <ul>
  <li>在维基百科上的 {{Interwiki("wikipedia", "正则表达式")}}</li>
- <li><a href="http://regexone.com/">互动教程</a></li>
- <li><a href="http://regexper.com/">虚拟化的正则表达式</a></li>
+ <li><a href="https://regexone.com/">互动教程</a></li>
+ <li><a href="https://regexper.com/">虚拟化的正则表达式</a></li>
 </ul>
 
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions">在JavaScript中写正则表达式</a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Guide/Regular_Expressions">在JavaScript中写正则表达式</a></li>
 </ul>

--- a/files/zh-cn/glossary/request_header/index.html
+++ b/files/zh-cn/glossary/request_header/index.html
@@ -9,7 +9,7 @@ original_slug: Glossary/请求头
 ---
 <p><strong>请求头</strong>是 {{glossary("header", "HTTP 头")}}的一种，它可在 HTTP 请求中使用，并且和请求主体无关 。某些请求头如 {{HTTPHeader("Accept")}}、{{HTTPHeader("Accept-Language", "Accept-*")}}、 {{HTTPHeader("If-Modified-Since", "If-*")}} 允许执行条件请求。某些请求头如：{{HTTPHeader("Cookie")}}, {{HTTPHeader("User-Agent")}} 和 {{HTTPHeader("Referer")}} 描述了请求本身以确保服务端能返回正确的响应。</p>
 
-<p>并非所有出现在请求中的 HTTP 首部都属于请求头，例如在 {{HTTPMethod("POST")}} 请求中经常出现的 <a href="https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Headers/Content-Length" title="Content-Length 是一个实体消息首部，用来指明发送给接收方的消息主体的大小，即用十进制数字表示的八位元组的数目。"><code>Content-Length</code></a> 实际上是一个代表请求主体大小的 <a href="https://developer.mozilla.org/en-US/docs/Glossary/entity_header" title="entity header: An entity header is an HTTP header describing the content of the body of the message. Entity headers are used in both, HTTP requests and responses. Headers like Content-Length, Content-Language, Content-Encoding are entity headers.">entity header</a>，虽然你也可以把它叫做请求头。</p>
+<p>并非所有出现在请求中的 HTTP 首部都属于请求头，例如在 {{HTTPMethod("POST")}} 请求中经常出现的 <a href="/zh-CN/docs/Web/HTTP/Headers/Content-Length"><code>Content-Length</code></a> 实际上是一个代表请求主体大小的 <a href="/zh-CN/docs/Glossary/entity_header">entity header</a>，虽然你也可以把它叫做请求头。</p>
 
 <p>此外，CORS 定义了一个叫做 {{glossary('simple header', 'simple headers')}} 的集合，它是请求头集合的一个子集。如果某次请求是只包含 {{glossary('simple header', 'simple header')}} 的话，则被认为是简单请求，不会触发请求预检（{{glossary("preflight request", "preflight")}}）。</p>
 

--- a/files/zh-cn/glossary/response_header/index.html
+++ b/files/zh-cn/glossary/response_header/index.html
@@ -35,5 +35,5 @@ x-frame-options: DENY</pre>
 <h3 id="相关内容">相关内容</h3>
 
 <ul>
- <li><a href="/en-US/docs/Web/HTTP/Headers">HTTP头部列表</a> </li>
+ <li><a href="/zh-CN/docs/Web/HTTP/Headers">HTTP头部列表</a> </li>
 </ul>

--- a/files/zh-cn/glossary/rest/index.html
+++ b/files/zh-cn/glossary/rest/index.html
@@ -20,8 +20,8 @@ translation_of: Glossary/REST
 <h3 id="搞懂它">搞懂它</h3>
 
 <ul>
- <li><a href="http://www.restapitutorial.com/">restapitutorial.com</a></li>
- <li><a href="http://restcookbook.com/">restcookbook.com</a></li>
+ <li><a href="https://www.restapitutorial.com/">restapitutorial.com</a></li>
+ <li><a href="https://restcookbook.com/">restcookbook.com</a></li>
 </ul>
 
 <h3 id="基础知识">基础知识</h3>

--- a/files/zh-cn/glossary/rss/index.html
+++ b/files/zh-cn/glossary/rss/index.html
@@ -22,5 +22,5 @@ translation_of: Glossary/RSS
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="http://www.rssboard.org/rss-specification">最新的 RSS 标准</a></li>
+ <li><a href="https://www.rssboard.org/rss-specification">最新的 RSS 标准</a></li>
 </ul>

--- a/files/zh-cn/glossary/sdp/index.html
+++ b/files/zh-cn/glossary/sdp/index.html
@@ -27,6 +27,6 @@ translation_of: Glossary/SDP
 <h3 id="General_knowledge">General knowledge</h3>
 
 <ul>
- <li><a href="/en-US/docs/Web/API/WebRTC_API/Architecture/Protocols">WebRTC protocols</a></li>
+ <li><a href="/zh-CN/docs/Web/API/WebRTC_API/Protocols">WebRTC protocols</a></li>
  <li>{{Interwiki("wikipedia", "Session Description Protocol")}} on Wikipedia</li>
 </ul>

--- a/files/zh-cn/glossary/semantics/index.html
+++ b/files/zh-cn/glossary/semantics/index.html
@@ -48,7 +48,7 @@ original_slug: Glossary/语义
 
 <h2 id="语义化元素">语义化元素</h2>
 
-<p>这是一些语义化的元（<a href="http://www.w3schools.com/html/html5_semantic_elements.asp" title="w3schools">source</a>）。</p>
+<p>这是一些语义化的元（<a href="https://www.w3schools.com/html/html5_semantic_elements.asp">source</a>）。</p>
 
 <ul>
  <li>{{htmlelement("article")}}</li>
@@ -69,9 +69,9 @@ original_slug: Glossary/语义
 <h2 id="了解更多">了解更多</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/HTML/Element#Inline_text_semantics">HTML element reference</a> on MDN</li>
- <li><a href="/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines#Problems_solved_by_HTML5">Using HTML sections and outlines</a> on MDN</li>
- <li><a href="http://www.w3schools.com/html/html5_semantic_elements.asp">HTML5 Semantic Elements</a> on w3schools</li>
+ <li><a href="/zh-CN/docs/Web/HTML/Element#Inline_text_semantics">HTML element reference</a> on MDN</li>
+ <li><a href="/zh-CN/docs/Web/HTML/Element/Heading_Elements#Problems_solved_by_HTML5">Using HTML sections and outlines</a> on MDN</li>
+ <li><a href="https://www.w3schools.com/html/html5_semantic_elements.asp">HTML5 Semantic Elements</a> on w3schools</li>
  <li>{{interwiki("wikipedia", "Semantics#Computer_science", "The meaning of semantics in computer science")}} on Wikipedia</li>
  <li><a href="/zh-CN/docs/Glossary">MDN Web Docs Glossary</a>
   <ul>

--- a/files/zh-cn/glossary/server/index.html
+++ b/files/zh-cn/glossary/server/index.html
@@ -26,6 +26,6 @@ translation_of: Glossary/Server
 <h3 id="常识">常识</h3>
 
 <ul>
- <li><a href="https://developer.mozilla.org/zh-CN/docs/Learn/Common_questions/What_is_a_web_server">服务器介绍</a></li>
+ <li><a href="/zh-CN/docs/Learn/Common_questions/What_is_a_web_server">服务器介绍</a></li>
  <li>维基百科上的 {{Interwiki("wikipedia", "服务器")}}</li>
 </ul>

--- a/files/zh-cn/glossary/simple_header/index.html
+++ b/files/zh-cn/glossary/simple_header/index.html
@@ -8,7 +8,7 @@ tags:
 translation_of: Glossary/Simple_header
 original_slug: Glossary/简单头部
 ---
-<p>以下的 <a href="/en-US/docs/Web/HTTP/Headers">HTTP headers</a>都可以被认为是简单头部:</p>
+<p>以下的 <a href="/zh-CN/docs/Web/HTTP/Headers">HTTP headers</a>都可以被认为是简单头部:</p>
 
 <ul>
  <li>{{HTTPHeader("Accept")}},</li>
@@ -27,12 +27,12 @@ original_slug: Glossary/简单头部
  <li>{{HTTPHeader("Width")}}</li>
 </ul>
 
-<p>当只包含简单头部时，一个请求则被视为简单请求并且在<a href="/en-US/docs/Glossary/CORS">CORS</a>中不需要发送{{glossary("preflight request")}}。</p>
+<p>当只包含简单头部时，一个请求则被视为简单请求并且在<a href="/zh-CN/docs/Glossary/CORS">CORS</a>中不需要发送{{glossary("preflight request")}}。</p>
 
 <h2 id="Learn_more">Learn more</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/HTTP/Headers">HTTP 头部</a></li>
+ <li><a href="/zh-CN/docs/Web/HTTP/Headers">HTTP 头部</a></li>
  <li>{{Glossary("Simple response header")}}</li>
  <li>{{Glossary("Forbidden header name")}}</li>
  <li>{{Glossary("Request header")}}</li>

--- a/files/zh-cn/glossary/simple_response_header/index.html
+++ b/files/zh-cn/glossary/simple_response_header/index.html
@@ -5,7 +5,7 @@ tags:
   - Simple response header
 translation_of: Glossary/Simple_response_header
 ---
-<p>一个简单的响应头（或CORS安全列表的响应头）是一个 <a href="/en-US/docs/Web/HTTP/Headers">HTTP 头 </a>，它是以下之一：</p>
+<p>一个简单的响应头（或CORS安全列表的响应头）是一个 <a href="/zh-CN/docs/Web/HTTP/Headers">HTTP 头 </a>，它是以下之一：</p>
 
 <ul>
  <li>{{HTTPHeader("Cache-Control")}}</li>
@@ -29,8 +29,8 @@ translation_of: Glossary/Simple_response_header
 <h2 id="Learn_more">Learn more</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/HTTP">HTTP</a></li>
- <li><a href="/en-US/docs/Web/HTTP/Headers">HTTP headers</a></li>
+ <li><a href="/zh-CN/docs/Web/HTTP">HTTP</a></li>
+ <li><a href="/zh-CN/docs/Web/HTTP/Headers">HTTP headers</a></li>
  <li>{{HTTPHeader("Access-Control-Expose-Headers")}}</li>
  <li>{{Glossary("CORS")}}</li>
  <li>{{Glossary("Simple header")}}</li>

--- a/files/zh-cn/glossary/sloppy_mode/index.html
+++ b/files/zh-cn/glossary/sloppy_mode/index.html
@@ -6,7 +6,7 @@ original_slug: Glossary/正常模式
 ---
 <p>因为翻译原因，正常模式也被翻译为——马虎模式/稀松模式/懒散模式</p>
 
-<p>{{Glossary("ECMAScript")}} 5 以及其后续的版本可以选择性的使用一种新模式——严格模式(<a href="/en-US/docs/Web/JavaScript/Reference/Strict_mode">strict mode</a>)，这种严格模式在多个方面改变了JavaScript的语义，从而使得当出现问题时我们更好的理解到底发生了什么。</p>
+<p>{{Glossary("ECMAScript")}} 5 以及其后续的版本可以选择性的使用一种新模式——严格模式(<a href="/zh-CN/docs/Web/JavaScript/Reference/Strict_mode">strict mode</a>)，这种严格模式在多个方面改变了JavaScript的语义，从而使得当出现问题时我们更好的理解到底发生了什么。</p>
 
 <p>常见的，非严格模式——平时我们会称之为正常模式(<strong>sloppy mode)，</strong>这并不是一个官方说法，但是你会经常见到如上的一些说法，其意义就是指代非严格模式，即正常模式。</p>
 

--- a/files/zh-cn/glossary/smtp/index.html
+++ b/files/zh-cn/glossary/smtp/index.html
@@ -3,17 +3,17 @@ title: SMTP
 slug: Glossary/SMTP
 translation_of: Glossary/SMTP
 ---
-<p><strong>SMTP</strong>（Simple Mail Transfer Protocol，简单邮件传输协议） 是用于发送的邮件的<a href="/zh-CN/docs/Glossary/Protocol">协议</a>。类似于<a href="/en-US/docs/Glossary/POP">POP3</a>和<a href="/en-US/docs/Glossary/NNTP">NNTP</a>，它是一个<a href="/zh-CN/docs/Glossary/State_machine">状态机</a>驱动的协议</p>
+<p><strong>SMTP</strong>（Simple Mail Transfer Protocol，简单邮件传输协议） 是用于发送的邮件的<a href="/zh-CN/docs/Glossary/Protocol">协议</a>。类似于<a href="/zh-CN/docs/Glossary/POP">POP3</a>和<a href="/zh-CN/docs/Glossary/NNTP">NNTP</a>，它是一个<a href="/zh-CN/docs/Glossary/State_machine">状态机</a>驱动的协议</p>
 
-<p>该协议相对简单。最复杂的部分在于添加支持不同的验证机制（<a class="external" href="http://en.wikipedia.org/wiki/Generic_Security_Services_Application_Program_Interface"><abbr title="Generic Security Services Application Program Interface">GSSAPI</abbr></a>， <a class="external" href="http://en.wikipedia.org/wiki/CRAM-MD5"><abbr title="challenge-response authentication mechanism">CRAM-MD5</abbr></a>，<a class="external" href="http://en.wikipedia.org/wiki/NTLM"><abbr title="NT LAN Manager">NTLM</abbr></a>，MSN，AUTH LOGIN，AUTH PLAIN等），处理错误响应以及在验证机制错误时进行状态回退（如服务器声明其支持某种机制但其实并不）。 </p>
+<p>该协议相对简单。最复杂的部分在于添加支持不同的验证机制（<a href="https://en.wikipedia.org/wiki/Generic_Security_Services_Application_Program_Interface"><abbr title="Generic Security Services Application Program Interface">GSSAPI</abbr></a>， <a href="https://en.wikipedia.org/wiki/CRAM-MD5"><abbr title="challenge-response authentication mechanism">CRAM-MD5</abbr></a>，<a href="https://en.wikipedia.org/wiki/NTLM"><abbr title="NT LAN Manager">NTLM</abbr></a>，MSN，AUTH LOGIN，AUTH PLAIN等），处理错误响应以及在验证机制错误时进行状态回退（如服务器声明其支持某种机制但其实并不）。 </p>
 
 <section id="Quick_links">
 <ol>
  <li><a href="/zh-CN/docs/Glossary">术语表</a>
 
   <ol>
-   <li><a href="/en-US/docs/Glossary/NNTP">NNTP</a></li>
-   <li><a href="/en-US/docs/Glossary/POP">POP3</a></li>
+   <li><a href="/zh-CN/docs/Glossary/NNTP">NNTP</a></li>
+   <li><a href="/zh-CN/docs/Glossary/POP">POP3</a></li>
    <li><a href="/zh-CN/docs/Glossary/Protocol">协议</a></li>
    <li><a href="/zh-CN/docs/Glossary/State_machine">状态机</a></li>
   </ol>

--- a/files/zh-cn/glossary/sql/index.html
+++ b/files/zh-cn/glossary/sql/index.html
@@ -19,6 +19,6 @@ translation_of: Glossary/SQL
 <h3 id="了解SQL">了解SQL</h3>
 
 <ul>
- <li><a href="http://sqlzoo.net/wiki/SQL_Tutorial">在 sqlzoo.net 学习 SQL</a></li>
- <li><a href="http://www.tutorialspoint.com/sql/">Tutorial Point</a></li>
+ <li><a href="https://sqlzoo.net/wiki/SQL_Tutorial">在 sqlzoo.net 学习 SQL</a></li>
+ <li><a href="https://www.tutorialspoint.com/sql/">Tutorial Point</a></li>
 </ul>

--- a/files/zh-cn/glossary/statement/index.html
+++ b/files/zh-cn/glossary/statement/index.html
@@ -16,7 +16,7 @@ translation_of: Glossary/Statement
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements">JavaScript statements and declarations</a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Reference/Statements">JavaScript statements and declarations</a></li>
 </ul>
 
 <ul>

--- a/files/zh-cn/glossary/string/index.html
+++ b/files/zh-cn/glossary/string/index.html
@@ -13,5 +13,5 @@ translation_of: Glossary/String
 
 <ul>
  <li>维基百科上的{{Interwiki("维基百科”，“ String（计算机科学）")}}</li>
- <li><a href="/en-US/docs/Web/JavaScript/Data_structures#String_type">JavaScript数据类型和数据结构</a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Data_structures#String_type">JavaScript数据类型和数据结构</a></li>
 </ul>

--- a/files/zh-cn/glossary/stun/index.html
+++ b/files/zh-cn/glossary/stun/index.html
@@ -17,11 +17,11 @@ translation_of: Glossary/STUN
 
 <ul>
  <li>{{Interwiki("wikipedia", "STUN")}} 在 维基百科</li>
- <li><a href="/en-US/docs/Web/API/WebRTC_API/Architecture/Protocols">WebRTC 协议</a></li>
+ <li><a href="/zh-CN/docs/Web/API/WebRTC_API/Protocols">WebRTC 协议</a></li>
 </ul>
 
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="http://tools.ietf.org/html/rfc5389">详细说明书</a></li>
+ <li><a href="https://tools.ietf.org/html/rfc5389">详细说明书</a></li>
 </ul>

--- a/files/zh-cn/glossary/svg/index.html
+++ b/files/zh-cn/glossary/svg/index.html
@@ -35,6 +35,6 @@ translation_of: Glossary/SVG
 <h3 id="技术信息">技术信息</h3>
 
 <ul>
- <li><a href="/en-US/docs/Web/SVG">SVG documentation on MDN</a></li>
- <li><a href="http://www.w3.org/TR/SVG/" rel="external">Latest SVG specification</a></li>
+ <li><a href="/zh-CN/docs/Web/SVG">SVG documentation on MDN</a></li>
+ <li><a href="https://www.w3.org/TR/SVG/">Latest SVG specification</a></li>
 </ul>

--- a/files/zh-cn/glossary/symbol/index.html
+++ b/files/zh-cn/glossary/symbol/index.html
@@ -55,6 +55,6 @@ Object.getOwnPropertySymbols(obj) // [ foo, bar ]</pre>
 
 <ul>
  <li>{{Interwiki("wikipedia", "Symbol (programming)")}} on Wikipedia</li>
- <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures">JavaScript data types and data structures</a></li>
- <li><a href="http://2ality.com/2014/12/es6-symbols.html">Symbols in ECMAScript 6</a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Data_structures">JavaScript data types and data structures</a></li>
+ <li><a href="https://2ality.com/2014/12/es6-symbols.html">Symbols in ECMAScript 6</a></li>
 </ul>

--- a/files/zh-cn/glossary/synchronous/index.html
+++ b/files/zh-cn/glossary/synchronous/index.html
@@ -18,5 +18,5 @@ translation_of: Glossary/Synchronous
 
 <ul>
  <li>{{glossary("Asynchronous")}}</li>
- <li>使用了 <a href="https://developer.mozilla.org/zh-CN/docs/Web/API/XMLHttpRequest">XMLHttpRequest()</a> {{glossary("API")}} 的<a href="/zh-CN/docs/Web/API/XMLHttpRequest/Synchronous_and_Asynchronous_Requests">同步和异步请求</a></li>
+ <li>使用了 <a href="/zh-CN/docs/Web/API/XMLHttpRequest">XMLHttpRequest()</a> {{glossary("API")}} 的<a href="/zh-CN/docs/Web/API/XMLHttpRequest/Synchronous_and_Asynchronous_Requests">同步和异步请求</a></li>
 </ul>

--- a/files/zh-cn/glossary/tag/index.html
+++ b/files/zh-cn/glossary/tag/index.html
@@ -11,13 +11,13 @@ translation_of: Glossary/Tag
 
 <ul>
  <li>维基百科上的{{Interwiki("wikipedia", "HTML element")}} </li>
- <li><a href="http://www.w3.org/History/19921103-hypertext/hypertext/WWW/MarkUp/Tags.html">HTML Tags on W3 </a></li>
+ <li><a href="https://www.w3.org/History/19921103-hypertext/hypertext/WWW/MarkUp/Tags.html">HTML Tags on W3 </a></li>
 </ul>
 
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="/en-US/docs/Learn/HTML/Introduction_to_HTML">Introduction to HTML</a></li>
+ <li><a href="/zh-CN/docs/Learn/HTML/Introduction_to_HTML">Introduction to HTML</a></li>
 </ul>
 
 <p>

--- a/files/zh-cn/glossary/tcp/index.html
+++ b/files/zh-cn/glossary/tcp/index.html
@@ -15,4 +15,4 @@ translation_of: Glossary/TCP
 <h3 id="深入"><strong>深入</strong></h3>
 <p>TCP 是互联网的基本通信语言协议。它会校验包的交付。TCP 被用于 Web 浏览器连接到互联网时以及从一个地址向另一个地址发送文件传递电子邮件。TCP 确保数据传输的可靠性，并且保证每一个字节在接收时维持它们的发送顺序。操作系统通过一个编程接口来管理TCP。TCP 使用三次握手来建立一个连接和四次握手来中断一个连接。</p>
 <h3 id="了解更多"><strong>了解更多</strong></h3>
-<p><a href="http://en.wikipedia.org/wiki/Transmission_Control_Protocol">维基百科上关于TCP的介绍</a></p>
+<p><a href="https://en.wikipedia.org/wiki/Transmission_Control_Protocol">维基百科上关于TCP的介绍</a></p>

--- a/files/zh-cn/glossary/tcp_slow_start/index.html
+++ b/files/zh-cn/glossary/tcp_slow_start/index.html
@@ -14,6 +14,6 @@ translation_of: Glossary/TCP_slow_start
 <h2 id="参阅">参阅</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/Performance/Populating_the_page:_how_browsers_work">Populating the page: how browsers work</a></li>
- <li><a href="/en-US/docs/Web/HTTP/Overview">http overview</a></li>
+ <li><a href="/zh-CN/docs/Web/Performance/How_browsers_work">Populating the page: how browsers work</a></li>
+ <li><a href="/zh-CN/docs/Web/HTTP/Overview">http overview</a></li>
 </ul>

--- a/files/zh-cn/glossary/three_js/index.html
+++ b/files/zh-cn/glossary/three_js/index.html
@@ -17,5 +17,5 @@ translation_of: Glossary/Three_js
 
 <ul>
  <li>{{Interwiki("wikipedia", "Three.js")}}维基词条</li>
- <li><a href="http://threejs.org/">three.js官网</a></li>
+ <li><a href="https://threejs.org/">three.js官网</a></li>
 </ul>

--- a/files/zh-cn/glossary/time_to_first_byte/index.html
+++ b/files/zh-cn/glossary/time_to_first_byte/index.html
@@ -4,18 +4,18 @@ slug: Glossary/time_to_first_byte
 translation_of: Glossary/time_to_first_byte
 original_slug: Glossary/第一字节时间
 ---
-<p><strong>第一字节时间</strong>（TTFB）是指从浏览器请求页面到从浏览器接收来自服务器发送的信息的第一个字节的时间。这一次包括DNS查找和使用（三次）<a href="/en-US/docs/Glossary/TCP">TCP</a>握手和<a href="/en-US/docs/Glossary/SSL_Glossary">SSL</a>握手建立连接（如果请求是通过<a href="/zh-CN/docs/Glossary/https">https</a>发出的）。</p>
+<p><strong>第一字节时间</strong>（TTFB）是指从浏览器请求页面到从浏览器接收来自服务器发送的信息的第一个字节的时间。这一次包括DNS查找和使用（三次）<a href="/zh-CN/docs/Glossary/TCP">TCP</a>握手和<a href="/zh-CN/docs/Glossary/SSL">SSL</a>握手建立连接（如果请求是通过<a href="/zh-CN/docs/Glossary/https">https</a>发出的）。</p>
 
 
 
 <p>TTFB是从请求开始到响应开始之间所用的时间，以毫秒为单位：</p>
 
-<pre class="notranslate">TTFB = <a href="/en-US/docs/Web/API/PerformanceResourceTiming/responseStart">responseStart</a> - <a href="/en-US/docs/Web/API/PerformanceResourceTiming/requestStart">requestStart</a></pre>
+<pre class="notranslate">TTFB = <a href="/zh-CN/docs/Web/API/PerformanceResourceTiming/responseStart">responseStart</a> - <a href="/zh-CN/docs/Web/API/PerformanceResourceTiming/requestStart">requestStart</a></pre>
 
 <h2 id="See_Also">See Also:</h2>
 
 <ul>
- <li><a href="/en-US/docs/Web/HTTP/Session">A typical HTTP session</a></li>
- <li><a href="/en-US/docs/Web/API/PerformanceResourceTiming">PerformanceResourceTiming</a></li>
- <li><a href="/en-US/docs/Web/API/PerformanceTiming">PerformanceTiming</a></li>
+ <li><a href="/zh-CN/docs/Web/HTTP/Session">A typical HTTP session</a></li>
+ <li><a href="/zh-CN/docs/Web/API/PerformanceResourceTiming">PerformanceResourceTiming</a></li>
+ <li><a href="/zh-CN/docs/Web/API/PerformanceTiming">PerformanceTiming</a></li>
 </ul>

--- a/files/zh-cn/glossary/tls/index.html
+++ b/files/zh-cn/glossary/tls/index.html
@@ -10,13 +10,13 @@ translation_of: Glossary/TLS
 <h3 id="基本知识">基本知识</h3>
 
 <ul>
- <li><a href="/en-US/docs/Web/Security/Transport_Layer_Security">传输层安全性协议</a></li>
- <li><a href="https://www.owasp.org/index.php/Transport_Layer_Protection_Cheat_Sheet" rel="external">OWASP: 传输层保护备忘单</a></li>
+ <li><a href="/zh-CN/docs/Web/Security/Transport_Layer_Security">传输层安全性协议</a></li>
+ <li><a href="https://www.owasp.org/index.php/Transport_Layer_Protection_Cheat_Sheet">OWASP: 传输层保护备忘单</a></li>
  <li>维基百科上的{{Interwiki("wikipedia", "Transport Layer Security")}} </li>
 </ul>
 
 <h3 id="协议规范">协议规范</h3>
 
 <ul>
- <li><a href="https://tools.ietf.org/html/rfc5246" rel="external">RFC 5246</a> (传输层安全性协议， 版本：1.2)</li>
+ <li><a href="https://tools.ietf.org/html/rfc5246">RFC 5246</a> (传输层安全性协议， 版本：1.2)</li>
 </ul>

--- a/files/zh-cn/glossary/tree_shaking/index.html
+++ b/files/zh-cn/glossary/tree_shaking/index.html
@@ -22,7 +22,7 @@ translation_of: Glossary/Tree_shaking
 <h4 id="常识">常识</h4>
 
 <ul>
- <li><a href="http://exploringjs.com/es6/ch_modules.html#_benefit-dead-code-elimination-during-bundling">"捆绑过程中死代码消除的好处"</a> 在Axel Rauschmayer的书中:“探索JS:模块”</li>
+ <li><a href="https://exploringjs.com/es6/ch_modules.html#_benefit-dead-code-elimination-during-bundling">"捆绑过程中死代码消除的好处"</a> 在Axel Rauschmayer的书中:“探索JS:模块”</li>
 </ul>
 
 <h4 id="技术参数资料">技术参数资料</h4>

--- a/files/zh-cn/glossary/turn/index.html
+++ b/files/zh-cn/glossary/turn/index.html
@@ -17,14 +17,14 @@ translation_of: Glossary/TURN
 
 <ul>
  <li>{{Interwiki("wikipedia", "TURN")}} 在 Wikipedia</li>
- <li><a href="/en-US/docs/Web/API/WebRTC_API/Architecture/Protocols">WebRTC 协议</a></li>
+ <li><a href="/zh-CN/docs/Web/API/WebRTC_API/Protocols">WebRTC 协议</a></li>
 </ul>
 
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="http://www.ietf.org/rfc/rfc5766.txt">详细说明书</a></li>
- <li><a href="http://www.ietf.org/rfc/rfc6156.txt">IPv6版 最新详细说明书</a></li>
+ <li><a href="https://www.ietf.org/rfc/rfc5766.txt">详细说明书</a></li>
+ <li><a href="https://www.ietf.org/rfc/rfc6156.txt">IPv6版 最新详细说明书</a></li>
 </ul>
 
 <ul>

--- a/files/zh-cn/glossary/type/index.html
+++ b/files/zh-cn/glossary/type/index.html
@@ -17,5 +17,5 @@ translation_of: Glossary/Type
 
 <ul>
  <li>维基百科的 {{Interwiki("wikipedia", "Data type")}}</li>
- <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures">JavaScript 的数据类型</a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Data_structures">JavaScript 的数据类型</a></li>
 </ul>

--- a/files/zh-cn/glossary/undefined/index.html
+++ b/files/zh-cn/glossary/undefined/index.html
@@ -26,5 +26,5 @@ console.log("X的值是", x)  //返回X的值是undefined</code></pre>
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures">JavaScript data types and data structures</a></li>
+ <li><a href="/zh-CN/docs/Web/JavaScript/Data_structures">JavaScript data types and data structures</a></li>
 </ul>

--- a/files/zh-cn/glossary/unicode/index.html
+++ b/files/zh-cn/glossary/unicode/index.html
@@ -13,5 +13,5 @@ translation_of: Glossary/Unicode
 
 <ul>
  <li>{{Interwiki("wikipedia", "Unicode")}} on Wikipedia</li>
- <li><a href="http://www.unicode.org/standard/principles.html">The Unicode Standard: A Technical Introduction</a></li>
+ <li><a href="https://www.unicode.org/standard/principles.html">The Unicode Standard: A Technical Introduction</a></li>
 </ul>

--- a/files/zh-cn/glossary/uri/index.html
+++ b/files/zh-cn/glossary/uri/index.html
@@ -16,7 +16,7 @@ translation_of: Glossary/URI
 
 <ul>
  <li>在维基百科上的 {{Interwiki("wikipedia", "URI")}}</li>
- <li><a href="http://tools.ietf.org/html/rfc3986">RFC 3986 on URI</a></li>
- <li><a href="/en-US/docs/Web/HTTP/data_URIs">data URIs</a></li>
- <li><a href="/en-US/docs/URI/www_vs_non-www_URLs">www vs non-www</a></li>
+ <li><a href="https://tools.ietf.org/html/rfc3986">RFC 3986 on URI</a></li>
+ <li><a href="/zh-CN/docs/Web/HTTP/Basics_of_HTTP/Data_URLs">data URIs</a></li>
+ <li><a href="/zh-CN/docs/Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs">www vs non-www</a></li>
 </ul>

--- a/files/zh-cn/glossary/urn/index.html
+++ b/files/zh-cn/glossary/urn/index.html
@@ -3,7 +3,7 @@ title: URN
 slug: Glossary/URN
 translation_of: Glossary/URN
 ---
-<p>URN（统一资源名称）是标准格式的URI，指的是资源而不指定其位置或是否存在。 这个例子来自<a href="http://www.ietf.org/rfc/rfc3986.txt">RFC3986</a>: <code> urn:oasis:names:specification:docbook:dtd:xml:4.1.2</code></p>
+<p>URN（统一资源名称）是标准格式的URI，指的是资源而不指定其位置或是否存在。 这个例子来自<a href="https://www.ietf.org/rfc/rfc3986.txt">RFC3986</a>: <code> urn:oasis:names:specification:docbook:dtd:xml:4.1.2</code></p>
 
 <h2 id="了解更多">了解更多</h2>
 

--- a/files/zh-cn/glossary/user_agent/index.html
+++ b/files/zh-cn/glossary/user_agent/index.html
@@ -24,5 +24,5 @@ translation_of: Glossary/User_agent
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li>在RFC 2616的 <a href="http://tools.ietf.org/html/rfc2616#section-14.43">User agent</a> 协议头</li>
+ <li>在RFC 2616的 <a href="https://tools.ietf.org/html/rfc2616#section-14.43">User agent</a> 协议头</li>
 </ul>

--- a/files/zh-cn/glossary/utf-8/index.html
+++ b/files/zh-cn/glossary/utf-8/index.html
@@ -13,5 +13,5 @@ translation_of: Glossary/UTF-8
 
 <ul>
  <li>{{Interwiki("wikipedia", "UTF-8")}} on Wikipedia</li>
- <li><a href="http://www.unicode.org/faq/utf_bom.html#UTF8">FAQ about UTF-8 on Unicode website</a></li>
+ <li><a href="https://www.unicode.org/faq/utf_bom.html#UTF8">FAQ about UTF-8 on Unicode website</a></li>
 </ul>

--- a/files/zh-cn/glossary/webgl/index.html
+++ b/files/zh-cn/glossary/webgl/index.html
@@ -23,12 +23,12 @@ translation_of: Glossary/WebGL
 
 <ul>
  <li>维基百科上的 {{Interwiki("wikipedia", "WebGL")}}</li>
- <li><a href="http://get.webgl.org/">检查你的设备是否支持WebGL</a></li>
+ <li><a href="https://get.webgl.org/">检查你的设备是否支持WebGL</a></li>
 </ul>
 
 <h3 id="技术信息" style="line-height: 24px;">技术信息</h3>
 
 <ul>
- <li><a href="https://developer.mozilla.org/zh-CN/docs/Web/API/WebGL_API">MDN上的WebGL参考资料</a></li>
- <li><a href="http://caniuse.com/#feat=webgl">WebGL支持列表</a></li>
+ <li><a href="/zh-CN/docs/Web/API/WebGL_API">MDN上的WebGL参考资料</a></li>
+ <li><a href="https://caniuse.com/#feat=webgl">WebGL支持列表</a></li>
 </ul>

--- a/files/zh-cn/glossary/webrtc/index.html
+++ b/files/zh-cn/glossary/webrtc/index.html
@@ -12,11 +12,11 @@ translation_of: Glossary/WebRTC
 <p>WebRTC主要由以下几个部分组成：</p>
 
 <dl>
- <dt><a href="/en-US/docs/Web/API/Navigator/getUserMedia"><code>getUserMedia</code></a></dt>
+ <dt><a href="/zh-CN/docs/Web/API/Navigator/getUserMedia"><code>getUserMedia</code></a></dt>
  <dd>为一个RTC连接获取设备的摄像头与(或)麦克风权限，并为此RTC连接接入设备的摄像头与(或)麦克风的信号。</dd>
- <dt><a href="/en-US/docs/Web/API/RTCPeerConnection"><code>RTCPeerConnection</code></a></dt>
+ <dt><a href="/zh-CN/docs/Web/API/RTCPeerConnection"><code>RTCPeerConnection</code></a></dt>
  <dd>用于配置音频或视频聊天。</dd>
- <dt><a href="/en-US/docs/Web/API/RTCDataChannel"><code>RTCDataChannel</code></a></dt>
+ <dt><a href="/zh-CN/docs/Web/API/RTCDataChannel"><code>RTCDataChannel</code></a></dt>
  <dd>用于设置两个浏览器之间的{{Glossary("P2P", "端到端")}} 数据连接。</dd>
 </dl>
 
@@ -24,6 +24,6 @@ translation_of: Glossary/WebRTC
 
 <ul>
  <li>{{Interwiki("wikipedia", "WebRTC")}} on Wikipedia</li>
- <li><a href="/en-US/docs/Web/Guide/API/WebRTC">Guide to WebRTC on MDN</a></li>
- <li><a href="http://caniuse.com/rtcpeerconnection">Browser support of WebRTC</a></li>
+ <li><a href="/zh-CN/docs/Web/API/WebRTC_API">Guide to WebRTC on MDN</a></li>
+ <li><a href="https://caniuse.com/rtcpeerconnection">Browser support of WebRTC</a></li>
 </ul>

--- a/files/zh-cn/glossary/world_wide_web/index.html
+++ b/files/zh-cn/glossary/world_wide_web/index.html
@@ -29,7 +29,7 @@ translation_of: Glossary/World_Wide_Web
 <h3 id="了解它">了解它</h3>
 
 <ul>
- <li><a href="https://developer.mozilla.org/en-US/Learn">学习网络</a></li>
+ <li><a href="/zh-CN/Learn">学习网络</a></li>
  <li><a href="https://learning.mozilla.org/web-literacy">网络素养图</a>（Web开发中所需的技能清单）</li>
 </ul>
 
@@ -37,5 +37,5 @@ translation_of: Glossary/World_Wide_Web
 
 <ul>
  <li>维基百科上的 {{Interwiki("wikipedia", "World Wide Web")}}</li>
- <li><a href="http://w3.org">W3C网站</a></li>
+ <li><a href="https://w3.org">W3C网站</a></li>
 </ul>

--- a/files/zh-cn/glossary/xhr_(xmlhttprequest)/index.html
+++ b/files/zh-cn/glossary/xhr_(xmlhttprequest)/index.html
@@ -18,5 +18,5 @@ translation_of: Glossary/XHR_(XMLHttpRequest)
 
 <ul>
  <li>{{domxref("XMLHttpRequest")}} 对象。</li>
- <li><a href="/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest">MDN 上关于如何使用 XMLHttpRequest 的文档。</a></li>
+ <li><a href="/zh-CN/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest">MDN 上关于如何使用 XMLHttpRequest 的文档。</a></li>
 </ul>

--- a/files/zh-cn/glossary/xhtml/index.html
+++ b/files/zh-cn/glossary/xhtml/index.html
@@ -12,5 +12,5 @@ original_slug: XHTML
 
 <p> </p>
 
-<p>XHTML是在2000年1月26日被国际标准组织机构W3C(World Wide web Consortium)定为一个标准的，认为是HTML的一个最新版本，并且将逐渐替换HTML。现在所有的浏览器都支持XHTML，XHTML兼容 HTML 4.0。也有人认为XHTML就是HTML4.01。如果你在学习过程中自己编写了一个符合标准的站，你可以通过W3C的验证，验证通过后你将会得到一个标志，通常是XHTML1.0认证和CSS验证。大家可以去<a href="//www.w3.org">www.w3.org</a> 这个站点去验证你的站点，如果符合那两个规则则会分别给我们两段代码加到你的网页上向别人展示说明你采用了标准建站。<br>
+<p>XHTML是在2000年1月26日被国际标准组织机构W3C(World Wide web Consortium)定为一个标准的，认为是HTML的一个最新版本，并且将逐渐替换HTML。现在所有的浏览器都支持XHTML，XHTML兼容 HTML 4.0。也有人认为XHTML就是HTML4.01。如果你在学习过程中自己编写了一个符合标准的站，你可以通过W3C的验证，验证通过后你将会得到一个标志，通常是XHTML1.0认证和CSS验证。大家可以去<a href="https://www.w3.org">www.w3.org</a> 这个站点去验证你的站点，如果符合那两个规则则会分别给我们两段代码加到你的网页上向别人展示说明你采用了标准建站。<br>
  <strong>请认真阅读XHTML相关知识和基础教程，以便您能准确的了解XHTML的新特性，以及应用技巧，还可以得到w3c的有力支持。</strong></p>

--- a/files/zh-cn/glossary/xml/index.html
+++ b/files/zh-cn/glossary/xml/index.html
@@ -12,5 +12,5 @@ translation_of: Glossary/XML
 <h2 id="了解更多">了解更多</h2>
 
 <ul>
- <li><a href="/en-US/docs/XML_Introduction">XML 介绍</a></li>
+ <li><a href="/zh-CN/docs/Web/XML/XML_introduction">XML 介绍</a></li>
 </ul>

--- a/files/zh-cn/glossary/xpath/index.html
+++ b/files/zh-cn/glossary/xpath/index.html
@@ -12,13 +12,13 @@ translation_of: Glossary/XPath
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="https://developer.mozilla.org/en-US/docs/Web/XPath">XPath documentation on MDN</a></li>
- <li><a href="http://www.w3.org/TR/xpath-30/">XPath specification</a></li>
+ <li><a href="/zh-CN/docs/Web/XPath">XPath documentation on MDN</a></li>
+ <li><a href="https://www.w3.org/TR/xpath-30/">XPath specification</a></li>
 </ul>
 
 <h3 id="基本信息">基本信息</h3>
 
 <ul>
- <li><a href="http://www.w3.org/standards/techs/xpath#w3c_all">Official website</a></li>
+ <li><a href="https://www.w3.org/standards/techs/xpath#w3c_all">Official website</a></li>
  <li>维基百科上的{{Interwiki("wikipedia", "XPath")}} </li>
 </ul>

--- a/files/zh-cn/glossary/xquery/index.html
+++ b/files/zh-cn/glossary/xquery/index.html
@@ -12,12 +12,12 @@ translation_of: Glossary/XQuery
 <h3 id="基本信息">基本信息</h3>
 
 <ul>
- <li><a href="http://www.w3.org/XML/Query/">Official website</a></li>
+ <li><a href="https://www.w3.org/XML/Query/">Official website</a></li>
  <li>维基百科上的{{Interwiki("wikipedia", "XQuery")}} </li>
 </ul>
 
 <h3 id="技术参考">技术参考</h3>
 
 <ul>
- <li><a href="/en-US/docs/XQuery">Discussion about using XQuery from Firefox</a> </li>
+ <li><a href="/zh-CN/docs/XQuery">Discussion about using XQuery from Firefox</a> </li>
 </ul>


### PR DESCRIPTION
I've created a [script](https://gist.github.com/yin1999/c868b0b840b5109a0335b54ba4598e96) to update links in l10n docs.

The modification is:

1. update links from `en-US` to `zh-CN`
2. remove prefix `https://developer.mozilla.org`
3. check for `https` when the url is in `http`
4. check redirect defined in `_redirect.txt` (en-US and locale)
5. removing all `title` (not used in markdown, removing it from html also), `rel`, `class` in `<a>` tags (Automatically added by mdn/yari)