### PR TITLE
fix: typo in ko/web/html/element/progress/index.html

### DIFF
--- a/files/ko/web/html/element/progress/index.html
+++ b/files/ko/web/html/element/progress/index.html
@@ -54,7 +54,7 @@ translation_of: Web/HTML/Element/progress
  <dt>{{ htmlattrdef("max") }}</dt>
  <dd><code>&lt;progress&gt;</code> 요소가 나타내는 작업에 필요한 작업량. 지정하는 경우, 반드시 0보다 크고 유효한 부동소수점 숫자여야 합니다. 기본값은 1입니다.</dd>
  <dt>{{ htmlattrdef("value") }}</dt>
- <dd><code>&lt;progress&gt;</code> 요소가 나타내는 작업을 완료한 양. 유효현 부동소수점 숫자여야 하고, <code>max</code> 특성을 지정한 경우 0 이상 <code>max</code> 이하, 그렇지 않으면 0 이상 1 이하여야 합니다. <code>value</code> 특성이 없으면 미결정 상태로, 현재 작업의 종료 시점을 예측할 수 없음을 나타냅니다.</dd>
+ <dd><code>&lt;progress&gt;</code> 요소가 나타내는 작업을 완료한 양. 유효한 부동소수점 숫자여야 하고, <code>max</code> 특성을 지정한 경우 0 이상 <code>max</code> 이하, 그렇지 않으면 0 이상 1 이하여야 합니다. <code>value</code> 특성이 없으면 미결정 상태로, 현재 작업의 종료 시점을 예측할 수 없음을 나타냅니다.</dd>
 </dl>
 
 <div class="note">


### PR DESCRIPTION
Fix typo '유효현' to '유효한'.