### PR TITLE
fix: references to conflicting files in fr docs

### DIFF
--- a/files/fr/learn/css/howto/create_fancy_boxes/index.md
+++ b/files/fr/learn/css/howto/create_fancy_boxes/index.md
@@ -6,7 +6,7 @@ original_slug: Apprendre/CSS/Comment/Créer_de_belles_boîtes
 ---
 Les boîtes CSS sont des blocs de base pour la construction des pages web. Créer des boîtes agréables à regarder est un défi complexe et intéressant. C'est un défi intéressant parce qu'on peut implémenter une idée de concept, de design, grâce à du code qui fonctionne. C'est un défi complexe car CSS possède à la fois plein de contraintes et de libertés. Dans cet article, nous allons voir de quoi il en retourne en dessinant quelques belles boîtes.
 
-Avant d'attaquer la partie pratique, nous vous recommandons de lire [l'article qui explique le fonctionnement du modèle de boîte CSS](/fr/docs/Learn/CSS/Building_blocks/The_box_model). Bien que ce ne soit pas strictement nécessaire, il peut également être judicieux que de lire [les bases de la disposition en CSS](/fr/docs/conflicting/Learn/CSS/CSS_layout/Introduction).
+Avant d'attaquer la partie pratique, nous vous recommandons de lire [l'article qui explique le fonctionnement du modèle de boîte CSS](/fr/docs/Learn/CSS/Building_blocks/The_box_model). Bien que ce ne soit pas strictement nécessaire, il peut également être judicieux que de lire [les bases de la disposition en CSS](/fr/docs/Learn/CSS/CSS_layout/Introduction).
 
 D'un point de vue technique, créer de belles boîtes devient beaucoup plus simple quand on connaît les propriétés de bordure (`border-*`) et d'arrière-plan (`background-*`) et les règles qui permettent de les appliquer sur une boîte donnée. Mais au delà de cet aspect technique, il s'agit aussi de laisser libre cours à votre créativité. Cela ne se fera pas en un jour et certains développeurs web passent beaucoup temps sur ces sujets.
 
@@ -73,7 +73,7 @@ Et voilà comment on obtient un cercle :
 
 ## Les arrière-plans
 
-Lorsqu'on parle de boîtes plutôt jolies, les propriétés primordiales sont [les propriétés `background-*`](/fr/docs/conflicting/Web/CSS/CSS_Backgrounds_and_Borders). Quand on manipule ces propriétés, on peut alors voir la boîte CSS comme une toile blanche qu'on pourrait peindre.
+Lorsqu'on parle de boîtes plutôt jolies, les propriétés primordiales sont [les propriétés `background-*`](/fr/docs/Web/CSS/CSS_Backgrounds_and_Borders). Quand on manipule ces propriétés, on peut alors voir la boîte CSS comme une toile blanche qu'on pourrait peindre.
 
 Avant d'aborder des exemples pratiques, revenons sur deux choses à savoir sur les arrière-plans :
 
@@ -316,4 +316,4 @@ Nous allons ici créer un effet d'ombre portée. La propriété {{cssxref("box-s
 
 ## La suite
 
-Pour de nombreux cas, on utilisera des couleurs et des images d'arrière-plans pour composer de belles boîtes. Nous vous invitons donc [à approfondir la gestion des couleurs et des images](/fr/docs/Apprendre/CSS/Comment/Gérer_les_couleurs_et_les_images). Par ailleurs, rien ne sert de créer de belles boîtes si celles-ci ne font pas partie d'une disposition bien organisée. Aussi, si vous ne l'avez pas encore lu, nous vous conseillons de parcourir [les bases de la disposition](/fr/docs/conflicting/Learn/CSS/CSS_layout/Introduction).
+Pour de nombreux cas, on utilisera des couleurs et des images d'arrière-plans pour composer de belles boîtes. Nous vous invitons donc [à approfondir la gestion des couleurs et des images](/fr/docs/Apprendre/CSS/Comment/Gérer_les_couleurs_et_les_images). Par ailleurs, rien ne sert de créer de belles boîtes si celles-ci ne font pas partie d'une disposition bien organisée. Aussi, si vous ne l'avez pas encore lu, nous vous conseillons de parcourir [les bases de la disposition](/fr/docs/Learn/CSS/CSS_layout/Introduction).

--- a/files/fr/learn/html/multimedia_and_embedding/responsive_images/index.md
+++ b/files/fr/learn/html/multimedia_and_embedding/responsive_images/index.md
@@ -19,7 +19,7 @@ Dans cet article, nous allons préciser le concept d'images adaptatives — imag
         >
         et
         <a
-          href="/fr/docs/conflicting/Learn/HTML/Multimedia_and_embedding/Images_in_HTML"
+          href="/fr/docs/Learn/HTML/Multimedia_and_embedding/Images_in_HTML"
           >comment ajouter des images statiques à une page web</a
         >.
       </td>

--- a/files/fr/web/css/index.md
+++ b/files/fr/web/css/index.md
@@ -66,7 +66,7 @@ La section [Apprendre le Web](/fr/docs/Learn/CSS) fournit différents modules qu
 - [Le service de validation CSS du W3C](https://jigsaw.w3.org/css-validator/) permet de vérifier si une feuille de style CSS est valide.
 - [Les outils de développement Firefox](/fr/docs/Tools) permettent de visualiser, d'éditer une feuille de style en direct grâce à [l'inspecteur](/fr/docs/Tools/Page_Inspector) et à [l'éditeur de styles](/fr/docs/Tools/Style_Editor).
 - [L'extension Web Developer](https://addons.mozilla.org/en-US/firefox/addon/web-developer/) permet d'éditer le code CSS des sites visités à la volée.
-- [D'autres outils](/fr/docs/conflicting/Web/CSS_c2c099599c0a58c69d1390033045f244), [guide pour les débutants](https://www.cssdebutant.com/).
+- [D'autres outils](/fr/docs/Web/CSS), [guide pour les débutants](https://www.cssdebutant.com/).
 
 ## Voir aussi
 

--- a/files/fr/web/css/zoom/index.md
+++ b/files/fr/web/css/zoom/index.md
@@ -115,5 +115,5 @@ Cette propriété n'est pas standard et est née avec Internet Explorer. Apple l
 ## Voir aussi
 
 - [L'article de CSS-Tricks sur `zoom`](https://css-tricks.com/almanac/properties/z/zoom/)
-- Le descripteur [`zoom`](/fr/docs/conflicting/Web/CSS/@viewport_e065ce90bde08c9679692adbe64f6518) pour la règle @ [`@viewport`](/fr/docs/Web/CSS/@viewport)
+- Le descripteur `zoom` pour la règle @ [`@viewport`](/fr/docs/Web/CSS/@viewport)
 - {{bug("390936")}} à propos de l'implémentation de la propriété dans Firefox

--- a/files/fr/web/javascript/a_re-introduction_to_javascript/index.md
+++ b/files/fr/web/javascript/a_re-introduction_to_javascript/index.md
@@ -263,7 +263,7 @@ JavaScript possède une différence importante quant aux autres langages de prog
 
 ## Les opérateurs
 
-Les opérateurs numériques en JavaScript sont `+`, `-`, `*`, `/` et `%` (qui est [l'opérateur de reste, à ne pas confondre avec le « modulo » mathématique](</fr/docs/conflicting/Web/JavaScript/Reference/Operators#remainder_()>)). Les valeurs sont affectées à l'aide de `=` et il existe également des opérateurs d'affectation combinés comme `+=` et `-=`. Ils sont équivalents à `x = x opérateur y`.
+Les opérateurs numériques en JavaScript sont `+`, `-`, `*`, `/` et `%` (qui est [l'opérateur de reste, à ne pas confondre avec le « modulo » mathématique](</fr/docs/Web/JavaScript/Reference/Operators#remainder_()>)). Les valeurs sont affectées à l'aide de `=` et il existe également des opérateurs d'affectation combinés comme `+=` et `-=`. Ils sont équivalents à `x = x opérateur y`.
 
 ```js
 x += 5;
@@ -272,7 +272,7 @@ x = x + 5;
 
 Vous pouvez utiliser `++` et `--` respectivement pour incrémenter et pour décrémenter. Ils peuvent être utilisés comme opérateurs préfixes ou suffixes.
 
-L'[opérateur `+`](/fr/docs/conflicting/Web/JavaScript/Reference/Operators#addition_(.2b)) permet également de concaténer des chaînes :
+L'[opérateur `+`](/fr/docs/Web/JavaScript/Reference/Operators#addition_(.2b)) permet également de concaténer des chaînes :
 
 ```js
 "coucou" + " monde"; // "coucou monde"
@@ -775,7 +775,7 @@ En JavaScript, les fonctions sont également des objets. Il est donc possible de
 
 ## Les objets personnalisés
 
-> **Note :** Pour une approche plus détaillée de la programmation orientée objet en JavaScript, voir l'[Introduction à JavaScript orienté objet](/fr/docs/conflicting/Learn/JavaScript/Objects).
+> **Note :** Pour une approche plus détaillée de la programmation orientée objet en JavaScript, voir l'[Introduction à JavaScript orienté objet](/fr/docs/Learn/JavaScript/Objects).
 
 Dans la programmation orientée objet classique, les objets sont des collections de données et de méthodes opérant sur ces données. Imaginons un objet personne avec les champs prénom et nom. Il y a deux manières d'afficher son nom complet : de la façon « prénom nom » ou de la façon « nom prénom ». À l'aide des fonctions et des objets vus précédemment, voici une manière de le faire :
 

--- a/files/fr/web/javascript/guide/working_with_objects/index.md
+++ b/files/fr/web/javascript/guide/working_with_objects/index.md
@@ -313,7 +313,7 @@ Voiture.prototype.couleur = null;
 voiture1.couleur = "noir";
 ```
 
-Pour plus d'informations, voir l'article sur [la propriété `prototype`](/fr/docs/conflicting/Web/JavaScript/Reference/Global_Objects/Function) de l'objet `Function` de la [référence JavaScript](/fr/docs/Web/JavaScript/Reference).
+Pour plus d'informations, voir l'article sur [la propriété `prototype`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Function) de l'objet `Function` de la [référence JavaScript](/fr/docs/Web/JavaScript/Reference).
 
 ## Définir des méthodes
 


### PR DESCRIPTION
Updating a few links that were hardcoded to "conflicting" copies. Should redirect to the conflicting files anyway till they are redirected