### PR TITLE
Update PR review companion to avoid error

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -121,7 +121,6 @@ jobs:
 
           poetry run deployer upload \
             --prefix="pr$PR_NUMBER" \
-            --no-redirects \
             --default-cache-control 0 \
             "$BUILD_OUT_ROOT"
 


### PR DESCRIPTION
Currently after mdn/yari#6382, the PR review companion is exiting with error code 2 because it uses the option `--no-redirects`, which is now deleted. This PR removes said option from this workflow.