### PR TITLE
Typofix: HTML entity in title

### DIFF
--- a/files/fr/learn/html/index.md
+++ b/files/fr/learn/html/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Apprendre le HTML&nbsp;: guides et didacticiels'
+title: 'Apprendre le HTML : guides et didacticiels'
 slug: Learn/HTML
 tags:
   - Apprentissage


### PR DESCRIPTION
I saw there is a problem during translation process. The main title of the document is "Apprendre le HTML&nbsp;: guides et didacticiels" Instead of "Apprendre le HTML : guides et didacticiels". 
The problem is the &nbsp; (Space code in html).