### PR TITLE
Fix unnecessary link on input/radio

### DIFF
--- a/files/ja/web/html/element/input/radio/index.html
+++ b/files/ja/web/html/element/input/radio/index.html
@@ -26,16 +26,10 @@ translation_of: Web/HTML/Element/input/radio
 
 <div>{{EmbedInteractiveExample("pages/tabbed/input-radio.html", "tabbed-standard")}}</div>
 
-<div class="hidden">このデモのソースファイルは GitHub リポジトリに格納されています。デモプロジェクトに協力したい場合は、 <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a></div>
-
-<p><a href="https://github.com/mdn/interactive-examples">をクローンしてプルリクエストを送信してください。</a></p>
-
-
-
 <div id="Basic_example">
-<p><a href="https://github.com/mdn/interactive-examples">ラジオボタンと呼ばれるのは、以下のように外見や操作方法が古い型のラジオのプッシュボタンに似ているからです。</a></p>
+<p>ラジオボタンと呼ばれるのは、以下のように外見や操作方法が古い型のラジオのプッシュボタンに似ているからです。</p>
 
-<p><a href="https://github.com/mdn/interactive-examples"><img alt="古い時代のラジオボタンの外観を示します。" src="https://mdn.mozillademos.org/files/15610/old-radio.jpg" style="height: 400px; width: 600px;" title="古い時代のラジオの写真"></a></p>
+<p><img alt="古い時代のラジオボタンの外観を示します。" src="https://mdn.mozillademos.org/files/15610/old-radio.jpg" style="height: 400px; width: 600px;" title="古い時代のラジオの写真"></p>
 </div>
 
 <div class="note">


### PR DESCRIPTION
`input type="radio`のページに置いて、
en-USの方には存在しない不要そうなリンクと文言を削除しました
