### PR TITLE
Update the resource link about module example

### DIFF
--- a/files/es/web/javascript/guide/modules/index.html
+++ b/files/es/web/javascript/guide/modules/index.html
@@ -37,7 +37,7 @@ original_slug: Web/JavaScript/Guide/Módulos
 
 <h2 id="Introducción_—_un_ejemplo">Introducción — un ejemplo</h2>
 
-<p>Para demostrar el uso de módulos, hemos creado un <a href="https://github.com/mdn/js-examples/tree/master/modules">sencillo conjunto de ejemplos</a> que puedes encontrar en GitHub. Estos ejemplos demuestran un sencillo conjunto de módulos que crean un elemento <a href="/es/docs/Web/HTML/Element/canvas" title="Usa el elemento ↑&lt;canvas>↓ de HTML con el scripting de la API de canvas o la API WebGL para dibujar gráficos y animaciones."><code>&lt;canvas&gt;</code></a> en una página web, y luego dibujan (y reportan información sobre) diferentes formas en el lienzo.</p>
+<p>Para demostrar el uso de módulos, hemos creado un <a href="https://github.com/mdn/js-examples/tree/master/module-examples">sencillo conjunto de ejemplos</a> que puedes encontrar en GitHub. Estos ejemplos demuestran un sencillo conjunto de módulos que crean un elemento <a href="/es/docs/Web/HTML/Element/canvas" title="Usa el elemento ↑&lt;canvas>↓ de HTML con el scripting de la API de canvas o la API WebGL para dibujar gráficos y animaciones."><code>&lt;canvas&gt;</code></a> en una página web, y luego dibujan (y reportan información sobre) diferentes formas en el lienzo.</p>
 
 <p>Estos son bastante triviales, pero se han mantenido deliberadamente simples para demostrar los módulos con claridad.</p>
 
@@ -47,7 +47,7 @@ original_slug: Web/JavaScript/Guide/Módulos
 
 <h2 id="Estructura_básica_de_los_ejemplos">Estructura básica de los ejemplos</h2>
 
-<p>En nuestro primer ejemplo (ve <a href="https://github.com/mdn/js-examples/tree/master/modules/basic-modules">basic-modules</a>) tenemos la siguiente estructura de archivos:</p>
+<p>En nuestro primer ejemplo (ve <a href="https://github.com/mdn/js-examples/tree/master/module-examples/basic-modules">basic-modules</a>) tenemos la siguiente estructura de archivos:</p>
 
 <pre class="notranslate">index.html
 main.js
@@ -147,7 +147,7 @@ export function draw(ctx, length, x, y, color) {
 
 <pre class="notranslate">./modules/square.js</pre>
 
-<p>Puedes ver estas líneas en acción en <code><a href="https://github.com/mdn/js-examples/blob/master/modules/basic-modules/main.js">main.js</a></code>.</p>
+<p>Puedes ver estas líneas en acción en <code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/basic-modules/main.js">main.js</a></code>.</p>
 
 <div class="blockIndicator note">
 <p><strong>Nota</strong>: En algunos sistemas de módulos, puedes omitir la extensión del archivo y el punto (por ejemplo, <code>'/modules/square'</code>). Esto no funciona en módulos de JavaScript nativos.</p>
@@ -253,7 +253,7 @@ export {function1, function2};
 import {function1 as newFunctionName,
          function2 as anotherNewFunctionName } from './modules/module.js';</pre>
 
-<p>Veamos un ejemplo real. En nuestro directorio <a href="https://github.com/mdn/js-examples/tree/master/modules/renaming">renaming</a>, verás el mismo sistema de módulos que en el ejemplo anterior, excepto que hemos agregado los módulos <code>circle.js</code> y <code>triangle.js</code> para dibujar e informar sobre círculos y triángulos.</p>
+<p>Veamos un ejemplo real. En nuestro directorio <a href="https://github.com/mdn/js-examples/tree/master/module-examples/renaming">renaming</a>, verás el mismo sistema de módulos que en el ejemplo anterior, excepto que hemos agregado los módulos <code>circle.js</code> y <code>triangle.js</code> para dibujar e informar sobre círculos y triángulos.</p>
 
 <p>Dentro de cada uno de estos módulos, tenemos características con los mismos nombres que se exportan y, por lo tanto, cada una tiene la misma instrucción <code>export</code> en la parte inferior:</p>
 
@@ -309,7 +309,7 @@ import {squareName, drawSquare, reportSquareArea, reportSquarePerimeter} from '.
 Module.function2()
 etc.</pre>
 
-<p>De nuevo, veamos un ejemplo real. Si vas a nuestro directorio <a href="https://github.com/mdn/js-examples/tree/master/modules/module-objects">module-objects</a>, verás el mismo ejemplo nuevamente, pero reescrito para aprovechar esta nueva sintaxis. En los módulos, las exportaciones están todas en la siguiente forma simple:</p>
+<p>De nuevo, veamos un ejemplo real. Si vas a nuestro directorio <a href="https://github.com/mdn/js-examples/tree/master/module-examples/module-objects">module-objects</a>, verás el mismo ejemplo nuevamente, pero reescrito para aprovechar esta nueva sintaxis. En los módulos, las exportaciones están todas en la siguiente forma simple:</p>
 
 <pre class="brush: js; notranslate">export { name, draw, reportArea, reportPerimeter };</pre>
 
@@ -333,7 +333,7 @@ Square.reportPerimeter(square1.length, reportList);</pre>
 
 <p>Como dijimos antes, también puedes exportar e importar clases; esta es otra opción para evitar conflictos en tu código, y especialmente es útil si ya tienes el código de tu módulo escrito en un estilo orientado a objetos.</p>
 
-<p>Puedes ver un ejemplo de nuestro módulo de dibujo de formas reescrito con clases ES en nuestro directorio <a href="https://github.com/mdn/js-examples/tree/master/modules/classes">classes</a>. Como ejemplo, el archivo <code><a href="https://github.com/mdn/js-examples/blob/master/modules/classes/modules/square.js">square.js</a></code> ahora contiene toda su funcionalidad en una sola clase:</p>
+<p>Puedes ver un ejemplo de nuestro módulo de dibujo de formas reescrito con clases ES en nuestro directorio <a href="https://github.com/mdn/js-examples/tree/master/module-examples/classes">classes</a>. Como ejemplo, el archivo <code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/classes/modules/square.js">square.js</a></code> ahora contiene toda su funcionalidad en una sola clase:</p>
 
 <pre class="brush: js; notranslate">class Square {
   constructor(ctx, listId, length, x, y, color) {
@@ -351,7 +351,7 @@ Square.reportPerimeter(square1.length, reportList);</pre>
 
 <pre class="brush: js; notranslate">export { Square };</pre>
 
-<p>En <code><a href="https://github.com/mdn/js-examples/blob/master/modules/classes/main.js">main.js</a></code>, lo importamos así:</p>
+<p>En <code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/classes/main.js">main.js</a></code>, lo importamos así:</p>
 
 <pre class="brush: js; notranslate">import { Square } from './modules/square.js';</pre>
 
@@ -369,7 +369,7 @@ square1.reportPerimeter();</pre>
 <pre class="brush: js; notranslate">export * from 'x.js'
 export { name } from 'x.js'</pre>
 
-<p>Para ver un ejemplo, ve nuestro directorio <a href="https://github.com/mdn/js-examples/tree/master/modules/module-aggregation">module-aggregation</a>. En este ejemplo (basado en nuestro ejemplo de clases anterior) tenemos un módulo adicional llamado <code>shapes.js</code>, que reúne toda la funcionalidad de <code>circle.js</code>, <code>square.js</code> y <code>triangle.js</code>. También hemos movido nuestros submódulos dentro de un subdirectorio dentro del directorio <code>modules</code> llamado <code>shapes</code>. Entonces, la estructura del módulo en este ejemplo es:</p>
+<p>Para ver un ejemplo, ve nuestro directorio <a href="https://github.com/mdn/js-examples/tree/master/module-examples/module-aggregation">module-aggregation</a>. En este ejemplo (basado en nuestro ejemplo de clases anterior) tenemos un módulo adicional llamado <code>shapes.js</code>, que reúne toda la funcionalidad de <code>circle.js</code>, <code>square.js</code> y <code>triangle.js</code>. También hemos movido nuestros submódulos dentro de un subdirectorio dentro del directorio <code>modules</code> llamado <code>shapes</code>. Entonces, la estructura del módulo en este ejemplo es:</p>
 
 <pre class="notranslate">modules/
   canvas.js
@@ -383,7 +383,7 @@ export { name } from 'x.js'</pre>
 
 <pre class="brush: js; notranslate">export { Square };</pre>
 
-<p>Luego viene la parte de agregación. Dentro de <code><a href="https://github.com/mdn/js-examples/blob/master/modules/module-aggregation/modules/shapes.js">shapes.js</a></code>, incluimos las siguientes líneas:</p>
+<p>Luego viene la parte de agregación. Dentro de <code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/module-aggregation/modules/shapes.js">shapes.js</a></code>, incluimos las siguientes líneas:</p>
 
 <pre class="brush: js; notranslate">export { Square } from './shapes/square.js';
 export { Triangle } from './shapes/triangle.js';
@@ -416,9 +416,9 @@ import { Triangle } from './modules/triangle.js';</pre>
     // Haz algo con el módulo.
   });</pre>
 
-<p>Veamos un ejemplo. En el directorio <a href="https://github.com/mdn/js-examples/tree/master/modules/dynamic-module-imports">dynamic-module-import</a> tenemos otro ejemplo basado en nuestro ejemplo de clases. Esta vez, sin embargo, no dibujamos nada en el lienzo cuando se carga el ejemplo. En su lugar, incluimos tres botones — "Círculo", "Cuadrado" y "Triángulo" — que, cuando se presionan, cargan dinámicamente el módulo requerido y luego lo usan para dibujar la forma asociada.</p>
+<p>Veamos un ejemplo. En el directorio <a href="https://github.com/mdn/js-examples/tree/master/module-examples/dynamic-module-imports">dynamic-module-import</a> tenemos otro ejemplo basado en nuestro ejemplo de clases. Esta vez, sin embargo, no dibujamos nada en el lienzo cuando se carga el ejemplo. En su lugar, incluimos tres botones — "Círculo", "Cuadrado" y "Triángulo" — que, cuando se presionan, cargan dinámicamente el módulo requerido y luego lo usan para dibujar la forma asociada.</p>
 
-<p>En este ejemplo, solo hemos realizado cambios en nuestros archivos <code><a href="https://github.com/mdn/js-examples/blob/master/modules/dynamic-module-imports/index.html">index.html</a></code> y <code><a href="https://github.com/mdn/js-examples/blob/master/modules/dynamic-module-imports/main.mjs">main.js</a></code> — el módulo <code>exports</code> sigue siendo el mismo que antes.</p>
+<p>En este ejemplo, solo hemos realizado cambios en nuestros archivos <code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/dynamic-module-imports/index.html">index.html</a></code> y <code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/dynamic-module-imports/main.mjs">main.js</a></code> — el módulo <code>exports</code> sigue siendo el mismo que antes.</p>
 
 <p>En <code>main.js</code> hemos tomado una referencia a cada botón usando una llamada a <a href="/es/docs/Web/API/Document/querySelector"><code>Document.querySelector()</code></a>, por ejemplo:</p>
 

--- a/files/ko/web/javascript/guide/modules/index.html
+++ b/files/ko/web/javascript/guide/modules/index.html
@@ -29,7 +29,7 @@ translation_of: Web/JavaScript/Guide/Modules
 
 <h2 id="Introducing_an_example">Introducing an example</h2>
 
-<p>모듈 사용법을 설명하기 위해 Github에 <a href="https://github.com/mdn/js-examples/tree/master/modules">간단한 예제 모음</a>을 만들었습니다. 이 예제들은 웹 페이지에 {{htmlelement("canvas")}} 요소(element)를 만들고, 캔버스에 다양한 도형을 그리고, 그린것에 대한 정보를 보고하는 간단한 모듈 집합입니다.</p>
+<p>모듈 사용법을 설명하기 위해 Github에 <a href="https://github.com/mdn/js-examples/tree/master/module-examples">간단한 예제 모음</a>을 만들었습니다. 이 예제들은 웹 페이지에 {{htmlelement("canvas")}} 요소(element)를 만들고, 캔버스에 다양한 도형을 그리고, 그린것에 대한 정보를 보고하는 간단한 모듈 집합입니다.</p>
 
 <p>이것들은 매우 사소한 것이지만, 모듈을 명확하게 설명하기 의해 의도적으로 단순하게 유지중입니다.</p>
 
@@ -39,7 +39,7 @@ translation_of: Web/JavaScript/Guide/Modules
 
 <h2 id="Basic_example_structure">Basic example structure</h2>
 
-<p>첫 번째 예제(<a href="https://github.com/mdn/js-examples/tree/master/modules/basic-modules">basic-modules</a>)를 보면 다음과 같은 파일 구조가 있습니다.</p>
+<p>첫 번째 예제(<a href="https://github.com/mdn/js-examples/tree/master/module-examples/basic-modules">basic-modules</a>)를 보면 다음과 같은 파일 구조가 있습니다.</p>
 
 <pre>index.html
 main.js
@@ -103,7 +103,7 @@ export function draw(ctx, length, x, y, color) {
 
 <pre class="brush: js">import { name, draw, reportArea, reportPerimeter } from './modules/square.js';</pre>
 
-<p><code><a href="/en-US/docs/Web/JavaScript/Reference/Statements/import">import</a></code> 문(statement)을 사용하고, 가져올 목록을 쉼표로 구분하여 나열한 뒤 괄호로 묶습니다. 그 뒤에는 from을 쓰고 모듈 파일의 경로를 작성합니다. (사이트 루트에 연관된 경로로, 우리의 <code>basic-modules</code> 예제는 <code>/js-examples/modules/basic-modules</code> 입니다) <code><a href="https://github.com/mdn/js-examples/blob/master/modules/basic-modules/main.js">main.js</a></code>에서 이러한 코드를 볼 수 있습니다.</p>
+<p><code><a href="/en-US/docs/Web/JavaScript/Reference/Statements/import">import</a></code> 문(statement)을 사용하고, 가져올 목록을 쉼표로 구분하여 나열한 뒤 괄호로 묶습니다. 그 뒤에는 from을 쓰고 모듈 파일의 경로를 작성합니다. (사이트 루트에 연관된 경로로, 우리의 <code>basic-modules</code> 예제는 <code>/js-examples/modules/basic-modules</code> 입니다) <code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/basic-modules/main.js">main.js</a></code>에서 이러한 코드를 볼 수 있습니다.</p>
 
 <p>그러나 우리는 경로를 조금 다르게 작성했습니다. 우리는 "현재 위치"를 의미하는 점(.) 구문을 사용하고 있으며, 그 다음에 찾고자하는 파일의 경로를 뒤에 써 줍니다. 이것은 상대적으로 전체 상대 경로를 작성하는 것보다 훨씬 빠르며, URL이 더 짧아 지므로 사이트 계층 구조의 다른 위치로 이동하더라도 이 예제가 계속 작동합니다.</p>
 
@@ -115,7 +115,7 @@ export function draw(ctx, length, x, y, color) {
 
 <pre><code>./modules/square.js</code></pre>
 
-<p><code><a href="https://github.com/mdn/js-examples/blob/master/modules/basic-modules/main.js">main.js</a></code>에서 이러한 코드를 볼 수 있습니다.</p>
+<p><code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/basic-modules/main.js">main.js</a></code>에서 이러한 코드를 볼 수 있습니다.</p>
 
 <div class="blockIndicator note">
 <p><strong>주의</strong>: 일부 모듈 시스템에서는 파일 확장명을 생략할 수 있습니다. (예: <code>'/modules/square'</code>). 이것은 네이티브 자바스크립트에서는 작동하지 않습니다. 또한 앞에 슬래시를 포함해야 합니다.</p>
@@ -214,7 +214,7 @@ export { function1, function2 };
 import { function1 as newFunctionName,
          function2 as anotherNewFunctionName } from './modules/module.js';</pre>
 
-<p>실제 사례를 살펴보겠습니다. <a href="https://github.com/mdn/js-examples/tree/master/modules/renaming">renaming</a> 디렉토리에서 원과 삼각형을 그리고 보고하기 위해 <code>circle.js</code> 와 <code>triangle.js</code> 모듈을 추가한다는 점만 제외하면, 앞의 예와 동일한 모듈 시스템을 볼 수 있습니다.</p>
+<p>실제 사례를 살펴보겠습니다. <a href="https://github.com/mdn/js-examples/tree/master/module-examples/renaming">renaming</a> 디렉토리에서 원과 삼각형을 그리고 보고하기 위해 <code>circle.js</code> 와 <code>triangle.js</code> 모듈을 추가한다는 점만 제외하면, 앞의 예와 동일한 모듈 시스템을 볼 수 있습니다.</p>
 
 <p>이 모듈듈 각각에는 내부적으로 동일한 이름의 기능이 있습니다. 따라서 각각 하단에 동일한 export 문(statement)이 있습니다.</p>
 
@@ -270,7 +270,7 @@ import { squareName, drawSquare, reportSquareArea, reportSquarePerimeter } from 
 Module.function2()
 etc.</pre>
 
-<p>다시 한 번 실제 사례를 살펴보겠습니다. <a href="https://github.com/mdn/js-examples/tree/master/modules/module-objects">module-objects</a> 디렉토리로 가면 같은 예제를 볼 수 있지만, 새로운 구문을 이용하기 위해 다시 작성합니다. 모듈에서 export는 모두 다음과 같은 간단한 형식으로 이루어집니다.</p>
+<p>다시 한 번 실제 사례를 살펴보겠습니다. <a href="https://github.com/mdn/js-examples/tree/master/module-examples/module-objects">module-objects</a> 디렉토리로 가면 같은 예제를 볼 수 있지만, 새로운 구문을 이용하기 위해 다시 작성합니다. 모듈에서 export는 모두 다음과 같은 간단한 형식으로 이루어집니다.</p>
 
 <pre class="brush: js">export { name, draw, reportArea, reportPerimeter };</pre>
 
@@ -294,7 +294,7 @@ Square.reportPerimeter(square1.length, reportList);</pre>
 
 <p>이전에 암시 했듯이 class를 export하거나 import 할 수도 있습니다. 이것은 코드에서 충돌을 피하기 위한 또 다른 옵션으로, 모듈 코드가 이미 객체 지향 스타일로 작성된 경우에 특히 유용합니다.</p>
 
-<p>우리의 <a href="https://github.com/mdn/js-examples/tree/master/modules/classes">classes</a> 디렉토리에서 ES 클래스로 다시 작성된 도형 그리기 모듈의 예를 볼 수 있습니다. 예를들어 <code><a href="https://github.com/mdn/js-examples/blob/master/modules/classes/modules/square.js">square.js</a></code> 파일에는 모든 기능이 단일 클래스에 포함되어 있습니다.</p>
+<p>우리의 <a href="https://github.com/mdn/js-examples/tree/master/module-examples/classes">classes</a> 디렉토리에서 ES 클래스로 다시 작성된 도형 그리기 모듈의 예를 볼 수 있습니다. 예를들어 <code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/classes/modules/square.js">square.js</a></code> 파일에는 모든 기능이 단일 클래스에 포함되어 있습니다.</p>
 
 <pre class="brush: js">class Square {
   constructor(ctx, listId, length, x, y, color) {
@@ -312,7 +312,7 @@ Square.reportPerimeter(square1.length, reportList);</pre>
 
 <pre class="brush: js">export { Square };</pre>
 
-<p><code><a href="https://github.com/mdn/js-examples/blob/master/modules/classes/main.js">main.js</a></code> 에서 우리는 다음과 같이 import 합니다.</p>
+<p><code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/classes/main.js">main.js</a></code> 에서 우리는 다음과 같이 import 합니다.</p>
 
 <pre class="brush: js">import { Square } from './modules/square.js';</pre>
 
@@ -334,7 +334,7 @@ export { name } from 'x.js'</pre>
 <p><strong>주의</strong>: 이것은 실제로 import 의 줄임말이고, 그 뒤에 export가 옵니다. 예를들면, "나는 모듈 <code>x.js</code>를 가져온 다음, 일부 또는 전부를 export 하겠다" 라는 뜻입니다.</p>
 </div>
 
-<p>예를들어 <a href="https://github.com/mdn/js-examples/tree/master/modules/module-aggregation">module-aggregation</a> 디렉토리를 참조하겠습니다. 이 예제에서는 이전 클래스 예제를 기반으로 <code>circle.js</code>, <code>square.js</code>, <code>triangle.js</code> 의 모든 기능을 함께 모으는 <code>shapes.js</code>라는 추가 모듈이 있습니다. 또한 우리는 <code>shapes</code> 모듈 디렉토리 안에 있는 서브 디렉토리 내에서 서브 모듈을 이동 시켰습니다. 이제 모듈 구조는 다음과 같습니다.</p>
+<p>예를들어 <a href="https://github.com/mdn/js-examples/tree/master/module-examples/module-aggregation">module-aggregation</a> 디렉토리를 참조하겠습니다. 이 예제에서는 이전 클래스 예제를 기반으로 <code>circle.js</code>, <code>square.js</code>, <code>triangle.js</code> 의 모든 기능을 함께 모으는 <code>shapes.js</code>라는 추가 모듈이 있습니다. 또한 우리는 <code>shapes</code> 모듈 디렉토리 안에 있는 서브 디렉토리 내에서 서브 모듈을 이동 시켰습니다. 이제 모듈 구조는 다음과 같습니다.</p>
 
 <pre>modules/
   canvas.js
@@ -348,7 +348,7 @@ export { name } from 'x.js'</pre>
 
 <pre class="brush: js">export { Square };</pre>
 
-<p>다음은 집합(aggregation) 부분입니다. <code><a href="https://github.com/mdn/js-examples/blob/master/modules/module-aggregation/modules/shapes.js">shapes.js</a></code> 안에는 다음과 같은 내용이 포함되어 있습니다.</p>
+<p>다음은 집합(aggregation) 부분입니다. <code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/module-aggregation/modules/shapes.js">shapes.js</a></code> 안에는 다음과 같은 내용이 포함되어 있습니다.</p>
 
 <pre class="brush: js">export { Square } from './shapes/square.js';
 export { Triangle } from './shapes/triangle.js';
@@ -381,9 +381,9 @@ import { Triangle } from './modules/triangle.js';</pre>
     // Do something with the module.
   });</pre>
 
-<p>예제를 보겠습니다. In the <a href="https://github.com/mdn/js-examples/tree/master/modules/dynamic-module-imports">dynamic-module-imports</a> 디렉토리에는 classes 예제를 기반으로 한 또 다른 예제가 있습니다. 이번에는 예제가 로딩될 때 캔버스에 아무것도 그리지 않습니다. 대신 우리는 세 개의 버튼("Circle", "Square", "Triangle")이 포함되어 있습니다. 이 버튼을 누르면 필요한 모듈을 동적으로 불러온 다음, 이를 사용하여 연관된 도형을 그립니다.</p>
+<p>예제를 보겠습니다. In the <a href="https://github.com/mdn/js-examples/tree/master/module-examples/dynamic-module-imports">dynamic-module-imports</a> 디렉토리에는 classes 예제를 기반으로 한 또 다른 예제가 있습니다. 이번에는 예제가 로딩될 때 캔버스에 아무것도 그리지 않습니다. 대신 우리는 세 개의 버튼("Circle", "Square", "Triangle")이 포함되어 있습니다. 이 버튼을 누르면 필요한 모듈을 동적으로 불러온 다음, 이를 사용하여 연관된 도형을 그립니다.</p>
 
-<p>이 예제에서 우리는 <a href="https://github.com/mdn/js-examples/blob/master/modules/dynamic-module-imports/index.html">index.html</a> 파일과 <a href="https://github.com/mdn/js-examples/blob/master/modules/dynamic-module-imports/main.js">main.js</a> 파일만 변경했습니다. 모듈 export는 이전과 동일하게 유지됩니다.</p>
+<p>이 예제에서 우리는 <a href="https://github.com/mdn/js-examples/blob/master/module-examples/dynamic-module-imports/index.html">index.html</a> 파일과 <a href="https://github.com/mdn/js-examples/blob/master/module-examples/dynamic-module-imports/main.js">main.js</a> 파일만 변경했습니다. 모듈 export는 이전과 동일하게 유지됩니다.</p>
 
 <p><code>main.js</code> 에서 <code><a href="/en-US/docs/Web/API/Document/querySelector">document.querySelector()</a></code> 를 사용하여 각 버튼에 대한 참조를 가져왔습니다. 예를들면 다음과 같습니다.</p>
 

--- a/files/pt-br/web/javascript/guide/modules/index.html
+++ b/files/pt-br/web/javascript/guide/modules/index.html
@@ -30,7 +30,7 @@ original_slug: Web/JavaScript/Guide/Módulos
 
 <h2 id="Apresentando_um_exemplo">Apresentando um exemplo</h2>
 
-<p>Para demonstrar o uso dos módulos, criamos um <a href="https://github.com/mdn/js-examples/tree/master/modules">conjunto simples de exemplos</a> que você pode encontrar no GitHub. Estes exemplos demonstram um conjunto simples de módulos que criam um<a href="/en-US/docs/Web/HTML/Element/canvas" title="Use the HTML &lt;canvas> element with either the canvas scripting API or the WebGL API to draw graphics and animations."><code>&lt;canvas&gt;</code></a> em uma página da Web e desenhe (e relate informações sobre) formas diferentes na tela.</p>
+<p>Para demonstrar o uso dos módulos, criamos um <a href="https://github.com/mdn/js-examples/tree/master/module-examples">conjunto simples de exemplos</a> que você pode encontrar no GitHub. Estes exemplos demonstram um conjunto simples de módulos que criam um<a href="/en-US/docs/Web/HTML/Element/canvas" title="Use the HTML &lt;canvas> element with either the canvas scripting API or the WebGL API to draw graphics and animations."><code>&lt;canvas&gt;</code></a> em uma página da Web e desenhe (e relate informações sobre) formas diferentes na tela.</p>
 
 <p>Estes são bastante triviais, mas foram mantidos deliberadamente simples para demonstrar claramente os módulos.</p>
 
@@ -40,7 +40,7 @@ original_slug: Web/JavaScript/Guide/Módulos
 
 <h2 id="Exemplo_de_uma_estrutura_básica">Exemplo de uma estrutura básica</h2>
 
-<p>No nosso primeiro exemplo (consulte <a href="https://github.com/mdn/js-examples/tree/master/modules/basic-modules">basic-modules</a>) nós temos uma estrutura de arquivos da seguinte maneira:</p>
+<p>No nosso primeiro exemplo (consulte <a href="https://github.com/mdn/js-examples/tree/master/module-examples/basic-modules">basic-modules</a>) nós temos uma estrutura de arquivos da seguinte maneira:</p>
 
 <pre class="notranslate">index.html
 main.js
@@ -140,7 +140,7 @@ export function draw(ctx, length, x, y, color) {
 
 <pre class="notranslate">./modules/square.js</pre>
 
-<p>Você pode ver essas linhas em ação em <code><a href="https://github.com/mdn/js-examples/blob/master/modules/basic-modules/main.js">main.js</a></code>.</p>
+<p>Você pode ver essas linhas em ação em <code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/basic-modules/main.js">main.js</a></code>.</p>
 
 <div class="blockIndicator note">
 <p><strong>Nota: Em alguns sistemas de módulos, você pode omitir a extensão do arquivo e o ponto</strong>(e.g. <code>'/modules/square'</code>). Isso não funciona nos módulos JavaScript nativos.</p>
@@ -247,7 +247,7 @@ export { function1, function2 };
 import { function1 as newFunctionName,
          function2 as anotherNewFunctionName } from './modules/module.js';</pre>
 
-<p>Vejamos um exemplo real. Na nossa <a href="https://github.com/mdn/js-examples/tree/master/modules/renaming">renaming</a> diretório, você verá o mesmo sistema de módulos do exemplo anterior, exceto que adicionamos <code>circle.js</code> e <code>triangle.js</code> módulos para desenhar e relatar círculos e triângulos.</p>
+<p>Vejamos um exemplo real. Na nossa <a href="https://github.com/mdn/js-examples/tree/master/module-examples/renaming">renaming</a> diretório, você verá o mesmo sistema de módulos do exemplo anterior, exceto que adicionamos <code>circle.js</code> e <code>triangle.js</code> módulos para desenhar e relatar círculos e triângulos.</p>
 
 <p>Dentro de cada um desses módulos, temos recursos com os mesmos nomes sendo exportados e, portanto, cada um tem o mesmo <code>export</code> declaração na parte inferior:</p>
 
@@ -305,7 +305,7 @@ import { squareName, drawSquare, reportSquareArea, reportSquarePerimeter } from 
 Module.function2()
 etc.</pre>
 
-<p>Novamente, vejamos um exemplo real. Se você for ao nosso <a href="https://github.com/mdn/js-examples/tree/master/modules/module-objects">module-objects</a> diretório, você verá o mesmo exemplo novamente, mas reescrito para aproveitar essa nova sintaxe. Nos módulos, as exportações são todas da seguinte forma simples:</p>
+<p>Novamente, vejamos um exemplo real. Se você for ao nosso <a href="https://github.com/mdn/js-examples/tree/master/module-examples/module-objects">module-objects</a> diretório, você verá o mesmo exemplo novamente, mas reescrito para aproveitar essa nova sintaxe. Nos módulos, as exportações são todas da seguinte forma simples:</p>
 
 <pre class="brush: js; notranslate">export { name, draw, reportArea, reportPerimeter };</pre>
 
@@ -329,7 +329,7 @@ Square.reportPerimeter(square1.length, reportList);</pre>
 
 <p>Como sugerimos anteriormente, você também pode exportar e importar classes; essa é outra opção para evitar conflitos no seu código e é especialmente útil se você já tiver o código do módulo gravado em um estilo orientado a objetos.</p>
 
-<p>Você pode ver um exemplo do nosso módulo de desenho de forma reescrito com as classes ES em nosso <a href="https://github.com/mdn/js-examples/tree/master/modules/classes">classes</a> diretório. Como exemplo, o <code><a href="https://github.com/mdn/js-examples/blob/master/modules/classes/modules/square.js">square.js</a></code> O arquivo agora contém todas as suas funcionalidades em uma única classe:</p>
+<p>Você pode ver um exemplo do nosso módulo de desenho de forma reescrito com as classes ES em nosso <a href="https://github.com/mdn/js-examples/tree/master/module-examples/classes">classes</a> diretório. Como exemplo, o <code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/classes/modules/square.js">square.js</a></code> O arquivo agora contém todas as suas funcionalidades em uma única classe:</p>
 
 <pre class="brush: js; notranslate">class Square {
   constructor(ctx, listId, length, x, y, color) {
@@ -365,7 +365,7 @@ square1.reportPerimeter();</pre>
 <pre class="brush: js; notranslate">export * from 'x.js'
 export { name } from 'x.js'</pre>
 
-<p>Por exemplo, veja nosso <a href="https://github.com/mdn/js-examples/tree/master/modules/module-aggregation">module-aggregation</a> diretório. Neste exemplo (com base no exemplo de classes anteriores), temos um módulo extra chamado shapes.js, que agrega toda a funcionalidade de circle.js, square.js e triangle.js juntos. Também movemos nossos submódulos para dentro de um subdiretório dentro do diretório modules chamado shapes. Portanto, a estrutura do módulo neste exemplo é:</p>
+<p>Por exemplo, veja nosso <a href="https://github.com/mdn/js-examples/tree/master/module-examples/module-aggregation">module-aggregation</a> diretório. Neste exemplo (com base no exemplo de classes anteriores), temos um módulo extra chamado shapes.js, que agrega toda a funcionalidade de circle.js, square.js e triangle.js juntos. Também movemos nossos submódulos para dentro de um subdiretório dentro do diretório modules chamado shapes. Portanto, a estrutura do módulo neste exemplo é:</p>
 
 <pre class="notranslate">modules/
   canvas.js
@@ -412,9 +412,9 @@ import { Triangle } from './modules/triangle.js';</pre>
     // Do something with the module.
   });</pre>
 
-<p>Vejamos um exemplo. No <a href="https://github.com/mdn/js-examples/tree/master/modules/dynamic-module-imports">dynamic-module-imports</a> diretório, temos outro exemplo baseado em nosso exemplo de classes. Desta vez, no entanto, não estamos desenhando nada na tela quando o exemplo é carregado. Em vez disso, incluímos trêsbuttons — "Circle", "Square", e "Triangle" — que, quando pressionado, carrega dinamicamente o módulo necessário e, em seguida, usa-o para desenhar os shape.</p>
+<p>Vejamos um exemplo. No <a href="https://github.com/mdn/js-examples/tree/master/module-examples/dynamic-module-imports">dynamic-module-imports</a> diretório, temos outro exemplo baseado em nosso exemplo de classes. Desta vez, no entanto, não estamos desenhando nada na tela quando o exemplo é carregado. Em vez disso, incluímos trêsbuttons — "Circle", "Square", e "Triangle" — que, quando pressionado, carrega dinamicamente o módulo necessário e, em seguida, usa-o para desenhar os shape.</p>
 
-<p>Neste exemplo, fizemos apenas alterações em nossa <code><a href="https://github.com/mdn/js-examples/blob/master/modules/dynamic-module-imports/index.html">index.html</a></code> e <code><a href="https://github.com/mdn/js-examples/blob/master/modules/dynamic-module-imports/main.mjs">main.js</a></code> arquivos - as exportações do módulo permanecem as mesmas de antes.</p>
+<p>Neste exemplo, fizemos apenas alterações em nossa <code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/dynamic-module-imports/index.html">index.html</a></code> e <code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/dynamic-module-imports/main.mjs">main.js</a></code> arquivos - as exportações do módulo permanecem as mesmas de antes.</p>
 
 <p>No main.js, pegamos uma referência a cada botão usando um<a href="/en-US/docs/Web/API/Document/querySelector"><code>Document.querySelector()</code></a> chamada, por exemplo:</p>
 

--- a/files/ru/web/javascript/guide/modules/index.html
+++ b/files/ru/web/javascript/guide/modules/index.html
@@ -29,7 +29,7 @@ translation_of: Web/JavaScript/Guide/Modules
 
 <h2 id="Пример_использования_модулей">Пример использования модулей</h2>
 
-<p>Для того, чтобы продемонстрировать использование модулей, мы создали <a href="https://github.com/mdn/js-examples/tree/master/modules">простой набор примеров</a>, который вы можете найти на GitHub.
+<p>Для того, чтобы продемонстрировать использование модулей, мы создали <a href="https://github.com/mdn/js-examples/tree/master/module-examples">простой набор примеров</a>, который вы можете найти на GitHub.
   В этих примерах мы создаём элемент <a href="/en-US/docs/Web/HTML/Element/canvas" title="Используйте HTML &lt;canvas> элемент вместе с Canvas API или с WebGL API для отрисовки графики и анимаций."><code>&lt;canvas&gt;</code></a>
   на веб-странице и затем рисуем различные фигуры на нём (и выводим информацию об этом).</p>
 
@@ -41,7 +41,7 @@ translation_of: Web/JavaScript/Guide/Modules
 
 <h2 id="Базовая_структура_примера">Базовая структура примера</h2>
 
-<p>В первом примере (см. директорию <a href="https://github.com/mdn/js-examples/tree/master/modules/basic-modules">basic-modules</a>) у нас следующая структура файлов:</p>
+<p>В первом примере (см. директорию <a href="https://github.com/mdn/js-examples/tree/master/module-examples/basic-modules">basic-modules</a>) у нас следующая структура файлов:</p>
 
 <pre>index.html
 main.js
@@ -146,7 +146,7 @@ export function draw(ctx, length, x, y, color) {
 
 <pre>./modules/square.js</pre>
 
-<p>Вы можете найти подобные строки кода в файле <code><a href="https://github.com/mdn/js-examples/blob/master/modules/basic-modules/main.js">main.js</a></code>.</p>
+<p>Вы можете найти подобные строки кода в файле <code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/basic-modules/main.js">main.js</a></code>.</p>
 
 <div class="blockIndicator note">
 <p><strong>Примечание</strong>: В некоторых модульных системах вы можете опустить расширение файла и начальные <code>/</code>, <code>./</code>, or <code>../</code> (например <code>'modules/square'</code>). Это не работает в нативных JavaScript-модулях.</p>
@@ -268,7 +268,7 @@ export { function1, function2 };
 import { function1 as newFunctionName,
          function2 as anotherNewFunctionName } from './modules/module.js';</pre>
 
-<p>Давайте посмотрим на реальный пример. В нашей <a href="https://github.com/mdn/js-examples/tree/master/modules/renaming">renaming</a> директории
+<p>Давайте посмотрим на реальный пример. В нашей <a href="https://github.com/mdn/js-examples/tree/master/module-examples/renaming">renaming</a> директории
   вы увидите ту же модульную систему, что и в предыдущем примере,
   за исключением того, что мы добавили модули <code>circle.js</code> и <code>triangle.js</code> для рисования кругов и треугольников и создания отчетов по ним.</p>
 
@@ -331,7 +331,7 @@ Module.function2()
 </pre>
 и т.д.
 
-<p>Опять же, давайте посмотрим на реальный пример. Если вы посмотрите на нашу директорию <a href="https://github.com/mdn/js-examples/tree/master/modules/module-objects">module-objects</a>,
+<p>Опять же, давайте посмотрим на реальный пример. Если вы посмотрите на нашу директорию <a href="https://github.com/mdn/js-examples/tree/master/module-examples/module-objects">module-objects</a>,
   вы снова увидите тот же самый пример, но переписанный с учётом преимуществ этого нового синтаксиса.
   В модулях все экспорты представлены в следующей простой форме:</p>
 
@@ -357,8 +357,8 @@ Square.reportPerimeter(square1.length, reportList);</pre>
 
 <p>Как мы намекали ранее, вы также можете экспортировать и импортировать классы — это ещё один способ избежать конфликтов в вашем коде, и он особенно полезен, если у вас уже есть код модуля, написанный в объектно-ориентированном стиле.</p>
 
-<p>Вы можете увидеть пример нашего модуля для рисования фигур, переписанного с помощью классов ES в нашей <a href="https://github.com/mdn/js-examples/tree/master/modules/classes">classes</a> директории.
-  В качестве примера, файл <code><a href="https://github.com/mdn/js-examples/blob/master/modules/classes/modules/square.js">square.js</a></code> теперь содержит всю свою функциональность в одном классе:</p>
+<p>Вы можете увидеть пример нашего модуля для рисования фигур, переписанного с помощью классов ES в нашей <a href="https://github.com/mdn/js-examples/tree/master/module-examples/classes">classes</a> директории.
+  В качестве примера, файл <code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/classes/modules/square.js">square.js</a></code> теперь содержит всю свою функциональность в одном классе:</p>
 
 <pre class="brush: js;">class Square {
   constructor(ctx, listId, length, x, y, color) {
@@ -376,7 +376,7 @@ Square.reportPerimeter(square1.length, reportList);</pre>
 
 <pre class="brush: js;">export { Square };</pre>
 
-<p>Далее в <code><a href="https://github.com/mdn/js-examples/blob/master/modules/classes/main.js">main.js</a></code>, мы импортируем его так:</p>
+<p>Далее в <code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/classes/main.js">main.js</a></code>, мы импортируем его так:</p>
 
 <pre class="brush: js;">import { Square } from './modules/square.js';</pre>
 
@@ -396,7 +396,7 @@ square1.reportPerimeter();</pre>
 <pre class="brush: js;">export * from 'x.js'
 export { name } from 'x.js'</pre>
 
-<p>Для примера посмотрите на нашу директорию <a href="https://github.com/mdn/js-examples/tree/master/modules/module-aggregation">module-aggregation</a>.
+<p>Для примера посмотрите на нашу директорию <a href="https://github.com/mdn/js-examples/tree/master/module-examples/module-aggregation">module-aggregation</a>.
   В этом примере (на основе нашего предыдущего примера с классами) у нас есть дополнительный модуль с именем <code>shapes.js</code>,
   который собирает функциональность <code>circle.js</code>, <code>square.js</code> и <code>triangle.js</code> вместе.
   Мы также переместили наши подмодули в дочернюю директорию внутри директории <code>modules</code> под названием <code>shape</code>.
@@ -415,7 +415,7 @@ export { name } from 'x.js'</pre>
 <pre class="brush: js;">export { Square };</pre>
 
 <p>Далее идет агрегирование.
-  Внутри <code><a href="https://github.com/mdn/js-examples/blob/master/modules/module-aggregation/modules/shapes.js">shapes.js</a></code>, мы добавляем следующие строки:</p>
+  Внутри <code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/module-aggregation/modules/shapes.js">shapes.js</a></code>, мы добавляем следующие строки:</p>
 
 <pre class="brush: js;">export { Square } from './shapes/square.js';
 export { Triangle } from './shapes/triangle.js';
@@ -452,11 +452,11 @@ import { Triangle } from './modules/triangle.js';</pre>
   });</pre>
 
 <p>Давайте посмотрим на пример.
-  В директории <a href="https://github.com/mdn/js-examples/tree/master/modules/dynamic-module-imports">dynamic-module-imports</a> у нас есть ещё один пример, основанный на примере наших классов.
+  В директории <a href="https://github.com/mdn/js-examples/tree/master/module-examples/dynamic-module-imports">dynamic-module-imports</a> у нас есть ещё один пример, основанный на примере наших классов.
   Однако на этот раз мы ничего не рисуем на холсте при загрузке страницы.
   Вместо этого мы добавляем на страницу три кнопки — «Circle», «Square» и «Triangle», которые при нажатии динамически загружают требуемый модуль, а затем используют его для рисования указанной фигуры.</p>
 
-<p>В этом примере мы внесли изменения только в наши <code><a href="https://github.com/mdn/js-examples/blob/master/modules/dynamic-module-imports/index.html">index.html</a></code> и <code><a href="https://github.com/mdn/js-examples/blob/master/modules/dynamic-module-imports/main.mjs">main.js</a></code> — экспорт модуля остается таким же, как и раньше.</p>
+<p>В этом примере мы внесли изменения только в наши <code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/dynamic-module-imports/index.html">index.html</a></code> и <code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/dynamic-module-imports/main.mjs">main.js</a></code> — экспорт модуля остается таким же, как и раньше.</p>
 
 <p>Далее в <code>main.js</code> мы взяли ссылку на каждую кнопку, используя вызов <a href="/en-US/docs/Web/API/Document/querySelector"><code>document.querySelector()</code></a>:</p>
 

--- a/files/zh-cn/web/javascript/guide/modules/index.html
+++ b/files/zh-cn/web/javascript/guide/modules/index.html
@@ -35,7 +35,7 @@ translation_of: Web/JavaScript/Guide/Modules
 
 <h2 id="介绍一个例子">介绍一个例子</h2>
 
-<p>为了演示模块的使用，我们创建了一个 <a href="https://github.com/mdn/js-examples/tree/master/modules">simple set of examples</a> ，你可以在 Github 上找到。这个例子演示了一个简单的模块的集合用来在 web 页面上创建了一个 {{htmlelement("canvas")}} 标签，在 canvas 上绘制 (并记录有关的信息) 不同形状。</p>
+<p>为了演示模块的使用，我们创建了一个 <a href="https://github.com/mdn/js-examples/tree/master/module-examples">simple set of examples</a> ，你可以在 Github 上找到。这个例子演示了一个简单的模块的集合用来在 web 页面上创建了一个 {{htmlelement("canvas")}} 标签，在 canvas 上绘制 (并记录有关的信息) 不同形状。</p>
 
 <p>这的确有点简单，但是保持足够简单能够清晰地演示模块。</p>
 
@@ -45,7 +45,7 @@ translation_of: Web/JavaScript/Guide/Modules
 
 <h2 id="基本的示例文件的结构">基本的示例文件的结构</h2>
 
-<p>在我们的第一个例子 (see <a href="https://github.com/mdn/js-examples/tree/master/modules/basic-modules">basic-modules</a>) 文件结构如下：</p>
+<p>在我们的第一个例子 (see <a href="https://github.com/mdn/js-examples/tree/master/module-examples/basic-modules">basic-modules</a>) 文件结构如下：</p>
 
 <pre>index.html
 main.mjs
@@ -149,7 +149,7 @@ export function draw(ctx, length, x, y, color) {
 
 <pre>./modules/square.mjs</pre>
 
-<p>你可以在 <code><a href="https://github.com/mdn/js-examples/blob/master/modules/basic-modules/main.js">main.mjs</a></code> 中看到这些。</p>
+<p>你可以在 <code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/basic-modules/main.js">main.mjs</a></code> 中看到这些。</p>
 
 <div class="note">
 <p><strong>备注：</strong>在一些模块系统中你可以忽略文件扩展名（比如 <code>'/model/squre'</code>）。这在原生 JavaScript 模块系统中不工作。<del>此外，记住你需要包含最前面的正斜杠。</del> （修订版 1889482）</p>
@@ -246,7 +246,7 @@ export { function1, function2 };
 import { function1 as newFunctionName,
          function2 as anotherNewFunctionName } from '/modules/module.mjs';</pre>
 
-<p>让我们看一个真实的例子。在我们的 <a href="https://github.com/mdn/js-examples/tree/master/modules/renaming">重命名</a> 目录中，您将看到与上一个示例中相同的模块系统，除了我们添加了 <code>circle.mjs</code> 和 <code>triangle.mjs</code> 模块以绘制和报告圆和三角形。</p>
+<p>让我们看一个真实的例子。在我们的 <a href="https://github.com/mdn/js-examples/tree/master/module-examples/renaming">重命名</a> 目录中，您将看到与上一个示例中相同的模块系统，除了我们添加了 <code>circle.mjs</code> 和 <code>triangle.mjs</code> 模块以绘制和报告圆和三角形。</p>
 
 <p>在每个模块中，我们都有 <code>export</code> 相同名称的功能，因此每个模块底部都有相同的导出语句：</p>
 
@@ -302,7 +302,7 @@ import { squareName, drawSquare, reportSquareArea, reportSquarePerimeter } from 
 Module.function2()
 etc.</pre>
 
-<p>再次，让我们看一个真实的例子。如果您转到我们的 <a href="https://github.com/mdn/js-examples/tree/master/modules/module-objects">module-objects</a> 目录，您将再次看到相同的示例，但利用上述的新语法进行重写。在模块中，导出都是以下简单形式：</p>
+<p>再次，让我们看一个真实的例子。如果您转到我们的 <a href="https://github.com/mdn/js-examples/tree/master/module-examples/module-objects">module-objects</a> 目录，您将再次看到相同的示例，但利用上述的新语法进行重写。在模块中，导出都是以下简单形式：</p>
 
 <pre class="brush: js">export { name, draw, reportArea, reportPerimeter };</pre>
 
@@ -326,7 +326,7 @@ Square.reportPerimeter(square1.length, reportList);</pre>
 
 <p>正如我们之前提到的那样，您还可以导出和导入类；这是避免代码冲突的另一种选择，如果您已经以面向对象的方式编写了模块代码，那么它尤其有用。</p>
 
-<p>您可以在我们的 <a href="https://github.com/mdn/js-examples/tree/master/modules/classes">classes</a> 目录中看到使用 ES 类重写的形状绘制模块的示例。 例如，<code><a href="https://github.com/mdn/js-examples/blob/master/modules/classes/modules/square.js">square.mjs</a></code> 文件现在包含单个类中的所有功能：</p>
+<p>您可以在我们的 <a href="https://github.com/mdn/js-examples/tree/master/module-examples/classes">classes</a> 目录中看到使用 ES 类重写的形状绘制模块的示例。 例如，<code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/classes/modules/square.js">square.mjs</a></code> 文件现在包含单个类中的所有功能：</p>
 
 <pre class="brush: js">class Square {
   constructor(ctx, listId, length, x, y, color) {
@@ -344,7 +344,7 @@ Square.reportPerimeter(square1.length, reportList);</pre>
 
 <pre class="brush: js">export { Square };</pre>
 
-<p>在 <code><a href="https://github.com/mdn/js-examples/blob/master/modules/classes/main.js">main.mjs</a></code> 中，我们像这样导入它：</p>
+<p>在 <code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/classes/main.js">main.mjs</a></code> 中，我们像这样导入它：</p>
 
 <pre class="brush: js">import { Square } from './modules/square.mjs';</pre>
 
@@ -366,7 +366,7 @@ export { name } from 'x.mjs'</pre>
 <p><strong>备注：</strong>这实际上是导入后跟导出的简写，即“我导入模块 <code>x.mjs</code>，然后重新导出部分或全部导出”。</p>
 </div>
 
-<p>有关示例，请参阅我们的 <a href="https://github.com/mdn/js-examples/tree/master/modules/module-aggregation">module-aggregation</a>。 在这个例子中（基于我们之前的类示例），我们有一个名为 <code>shapes.mjs</code> 的额外模块，它将 <code>circle.mjs</code>，<code>square.mjs</code> 和 <code>riangle.mjs</code> 中的所有功能聚合在一起。 我们还将子模块移动到名为 shapes 的 modules 目录中的子目录中。 所以模块结构现在是这样的：</p>
+<p>有关示例，请参阅我们的 <a href="https://github.com/mdn/js-examples/tree/master/module-examples/module-aggregation">module-aggregation</a>。 在这个例子中（基于我们之前的类示例），我们有一个名为 <code>shapes.mjs</code> 的额外模块，它将 <code>circle.mjs</code>，<code>square.mjs</code> 和 <code>riangle.mjs</code> 中的所有功能聚合在一起。 我们还将子模块移动到名为 shapes 的 modules 目录中的子目录中。 所以模块结构现在是这样的：</p>
 
 <pre>modules/
   canvas.mjs
@@ -380,7 +380,7 @@ export { name } from 'x.mjs'</pre>
 
 <pre class="brush: js">export { Square };</pre>
 
-<p>接下来是聚合部分。 在 <code><a href="https://github.com/mdn/js-examples/blob/master/modules/module-aggregation/modules/shapes.js">shapes.mjs</a></code> 里面，我们包括以下几行：</p>
+<p>接下来是聚合部分。 在 <code><a href="https://github.com/mdn/js-examples/blob/master/module-examples/module-aggregation/modules/shapes.js">shapes.mjs</a></code> 里面，我们包括以下几行：</p>
 
 <pre class="brush: js">export { Square } from '/js-examples/modules/module-aggregation/modules/shapes/square.mjs';
 export { Triangle } from '/js-examples/modules/module-aggregation/modules/shapes/triangle.mjs';
@@ -417,9 +417,9 @@ import { Triangle } from './modules/triangle.mjs';</pre>
     // Do something with the module.
   });</pre>
 
-<p>我们来看一个例子。在 <a href="https://github.com/mdn/js-examples/tree/master/modules/dynamic-module-imports">dynamic-module-imports</a> 目录中，我们有另一个基于类示例的示例。但是这次我们在示例加载时没有在画布上绘制任何东西。相反，我们包括三个按钮 -- “圆形”，“方形”和“三角形” -- 按下时，动态加载所需的模块，然后使用它来绘制相关的形状。</p>
+<p>我们来看一个例子。在 <a href="https://github.com/mdn/js-examples/tree/master/module-examples/dynamic-module-imports">dynamic-module-imports</a> 目录中，我们有另一个基于类示例的示例。但是这次我们在示例加载时没有在画布上绘制任何东西。相反，我们包括三个按钮 -- “圆形”，“方形”和“三角形” -- 按下时，动态加载所需的模块，然后使用它来绘制相关的形状。</p>
 
-<p>在这个例子中，我们只对 <a href="https://github.com/mdn/js-examples/blob/master/modules/dynamic-module-imports/index.html">index.html</a> 和 <a href="https://github.com/mdn/js-examples/blob/master/modules/dynamic-module-imports/main.js">main.mjs</a> 文件进行了更改 -- 模块导出保持与以前相同。</p>
+<p>在这个例子中，我们只对 <a href="https://github.com/mdn/js-examples/blob/master/module-examples/dynamic-module-imports/index.html">index.html</a> 和 <a href="https://github.com/mdn/js-examples/blob/master/module-examples/dynamic-module-imports/main.js">main.mjs</a> 文件进行了更改 -- 模块导出保持与以前相同。</p>
 
 <p>在<code>main.mjs</code>中，我们使用<code><a href="/en-US/docs/Web/API/Document/querySelector">document.querySelector()</a></code>调用获取了对每个按钮的引用，例如：</p>
 


### PR DESCRIPTION
close #5981 .
sync with https://github.com/mdn/js-examples/pull/17 and https://github.com/mdn/content/pull/16197.
use `master/modules` -> `master/module-examples`.
I don't know whether there are all updated and there are side effects. Please have a review.