### PR TITLE
Fixed typo spread across several PT-BR files

### DIFF
--- a/files/pt-br/mozilla/add-ons/webextensions/manifest.json/permissions/index.html
+++ b/files/pt-br/mozilla/add-ons/webextensions/manifest.json/permissions/index.html
@@ -17,7 +17,7 @@ original_slug: Mozilla/Add-ons/WebExtensions/manifest.json/permissões
    <td>Não</td>
   </tr>
   <tr>
-   <th scope="row">Examplo</th>
+   <th scope="row">Exemplo</th>
    <td>
     <pre class="brush: json no-line-numbers">
 "permissions": [
@@ -164,7 +164,7 @@ original_slug: Mozilla/Add-ons/WebExtensions/manifest.json/permissões
  <li>no Firefox, permite que extensões criem um <a href="/en-US/docs/Web/API/IndexedDB_API/Browser_storage_limits_and_eviction_criteria#Firefox_specifics">banco de dados IndexedDB "persistente"</a>, sem que o navegador peça ao usuário permissão no momento em que o banco de dados é criado.</li>
 </ul>
 
-<h2 id="Examplos">Examplos</h2>
+<h2 id="Exemplos">Exemplos</h2>
 
 <pre class="brush: json no-line-numbers"> "permissions": ["*://developer.mozilla.org/*"]</pre>
 

--- a/files/pt-br/orphaned/web/api/navigatorid/useragent/index.html
+++ b/files/pt-br/orphaned/web/api/navigatorid/useragent/index.html
@@ -45,7 +45,7 @@ Localização; rv: número-da-verção-de-revisão) produto/produtoSub
 Nome-do-Aplicativo versão-do-Nome-do-Aplicativo
 </pre>
 
-<h2 id="Example" name="Example">Examplo</h2>
+<h2 id="Example" name="Example">Exemplo</h2>
 
 <pre class="brush:js">alert(window.navigator.userAgent)
 // alerta "Mozilla/5.0 (Windows; U; Win98; en-US; rv:0.9.2) Gecko/20010725 Netscape6/6.1"

--- a/files/pt-br/web/accessibility/aria/aria_techniques/using_the_slider_role/index.html
+++ b/files/pt-br/web/accessibility/aria/aria_techniques/using_the_slider_role/index.html
@@ -43,9 +43,9 @@ original_slug: Web/Accessibility/ARIA/ARIA_Techniques/Usando_o_slider_role
 
 <div class="note"><strong>Note:</strong> Opinions may differ on how assistive technology should handle this technique. The information provided above is one of those opinions and therefore not normative.</div>
 
-<p id="Examples">Examplos</p>
+<p id="Examples">Exemplos</p>
 
-<h4 id="Examplo_1_Escala_numérica_simples">Examplo 1: Escala numérica simples</h4>
+<h4 id="Exemplo_1_Escala_numérica_simples">Exemplo 1: Escala numérica simples</h4>
 
 <p>In the example below, a simple slider is used to select a value between 1 and 100. The current volume is 50. The application will programmatically update the value of <code>aria-valuenow</code> in response to user input.</p>
 
@@ -70,7 +70,7 @@ original_slug: Web/Accessibility/ARIA/ARIA_Techniques/Usando_o_slider_role
 }
 </pre>
 
-<h4 id="Examplo_2_Valores_de_texto">Examplo 2: Valores de texto</h4>
+<h4 id="Exemplo_2_Valores_de_texto">Exemplo 2: Valores de texto</h4>
 
 <p>Sometimes, a slider is used to choose a value that is not, semantically, a number. In these cases, the <code>aria-valuetext</code> attribute is used to provide the appropriate text name for the currently selected value. In the example below, the slider is used to select a day of the week.</p>
 

--- a/files/pt-br/web/api/canvasrenderingcontext2d/arc/index.html
+++ b/files/pt-br/web/api/canvasrenderingcontext2d/arc/index.html
@@ -39,7 +39,7 @@ translation_of: Web/API/CanvasRenderingContext2D/arc
  <dd>Um {{jsxref("Boolean")}} opcional. Se <code>verdadeiro</code>, desenha o arco no sentido anti-horário entre os ângulos inicial e final. O padrão é <code>falso</code> (sentido horário).</dd>
 </dl>
 
-<h2 id="Examplos">Examplos</h2>
+<h2 id="Exemplos">Exemplos</h2>
 
 <h3 id="Desenhando_um_círculo_completo">Desenhando um círculo completo</h3>
 

--- a/files/pt-br/web/api/element/scrollwidth/index.html
+++ b/files/pt-br/web/api/element/scrollwidth/index.html
@@ -17,7 +17,7 @@ translation_of: Web/API/Element/scrollWidth
 
 <p><var>xScrollWidth</var> é a largura do conteúdo do <var>elemento</var> em pixels.</p>
 
-<h2 id="Example" name="Example">Examplo</h2>
+<h2 id="Example" name="Example">Exemplo</h2>
 
 <pre class="brush:html">&lt;!DOCTYPE html&gt;
 &lt;html&gt;

--- a/files/pt-br/web/api/formdata/getall/index.html
+++ b/files/pt-br/web/api/formdata/getall/index.html
@@ -26,7 +26,7 @@ translation_of: Web/API/FormData/getAll
 
 <p>Um array de {{domxref("FormDataEntryValue")}}s.</p>
 
-<h2 id="Examplo">Examplo</h2>
+<h2 id="Exemplo">Exemplo</h2>
 
 <p>A seguinte linha cria um objeto <code>FormData</code> vazio:</p>
 

--- a/files/pt-br/web/api/htmloptionelement/option/index.html
+++ b/files/pt-br/web/api/htmloptionelement/option/index.html
@@ -24,7 +24,7 @@ translation_of: Web/API/HTMLOptionElement/Option
  <dd>Um {{domxref("Boolean")}} é usado para colocar elemento {{htmlelement("option")}} no estado de selecionado; como padrão do elemento tem o estado de não selecionado. Se omitido, mesmo que o parâmetro <strong>defaultSelected </strong>for verdadeiro, o elemento {{htmlelement("option")}} não é selecionado. </dd>
 </dl>
 
-<h2 id="Examplos">Examplos</h2>
+<h2 id="Exemplos">Exemplos</h2>
 
 <h3 id="Adicionando_novas_tags_options">Adicionando novas tags options</h3>
 

--- a/files/pt-br/web/api/speechsynthesisutterance/voice/index.html
+++ b/files/pt-br/web/api/speechsynthesisutterance/voice/index.html
@@ -26,7 +26,7 @@ speechSynthesisUtteranceInstance.voice = speechSynthesisVoiceInstance;
 
 <p>Um objeto {{domxref("SpeechSynthesisVoice")}}.</p>
 
-<h2 id="Examplo">Examplo</h2>
+<h2 id="Exemplo">Exemplo</h2>
 
 <pre class="brush: js"><code class="language-js"><span class="keyword token">var</span> synth <span class="operator token">=</span> window<span class="punctuation token">.</span>speechSynthesis<span class="punctuation token">;</span>
 

--- a/files/pt-br/web/api/webvr_api/index.html
+++ b/files/pt-br/web/api/webvr_api/index.html
@@ -51,7 +51,7 @@ translation_of: Web/API/WebVR_API
  Representa um manipulador de eventos que será executado quando o estado de apresentação de um dispositivo VR mudar - isto é, vai de apresentar a não apresentar, ou vice-versa (quando o evento {{event("onvrdisplaypresentchange")}} é acionado).</p>
 </div>
 
-<h2 id="Examplos">Examplos</h2>
+<h2 id="Exemplos">Exemplos</h2>
 
 <p>Você pode encontrar uma série de exemplos nesses repositórios Github:</p>
 

--- a/files/pt-br/web/css/_colon_read-write/index.html
+++ b/files/pt-br/web/css/_colon_read-write/index.html
@@ -20,7 +20,7 @@ p:read-write {
 
 {{csssyntax}}
 
-<h2 id="Example" name="Example">Examplos</h2>
+<h2 id="Example" name="Example">Exemplos</h2>
 
 <h3 id="Confirmando_informações_do_formulário_em_controles_read-onlyread-write.">Confirmando informações do formulário em controles read-only/read-write.</h3>
 

--- a/files/pt-br/web/css/css_selectors/index.html
+++ b/files/pt-br/web/css/css_selectors/index.html
@@ -22,7 +22,7 @@ original_slug: Web/CSS/Seletores_CSS
  <strong>Exemplo:</strong> <code>input</code> corresponderá a qualquer elemento {{HTMLElement('input')}}.</dd>
  <dt><a href="/en-US/docs/Web/CSS/Class_selectors">Seletor por classe</a></dt>
  <dd>Este seletor básico escolhe elementos baseados no valor de seu atributo <code>classe</code>.<strong> Sintaxe:</strong> <code>.<em>nome-da-classe</em></code><br>
- <strong>Examplo:</strong> <code>.index</code> irá corresponder a qualquer elemento que tenha o índice de classe (provavelmente definido por um atributo class="index", ou similar).</dd>
+ <strong>Exemplo:</strong> <code>.index</code> irá corresponder a qualquer elemento que tenha o índice de classe (provavelmente definido por um atributo class="index", ou similar).</dd>
  <dt><a href="/en-US/docs/Web/CSS/ID_selectors">Seletor por ID</a></dt>
  <dd>Este seletor básico escolhe nós baseados no valor do atributo <code>id</code>. Deve existir apenas um elemento com o mesmo ID no mesmo documento.<br>
  <strong>Sintaxe:</strong> <code>#<em>nome-do-id</em></code><br>

--- a/files/pt-br/web/css/layout_cookbook/breadcrumb_navigation/index.html
+++ b/files/pt-br/web/css/layout_cookbook/breadcrumb_navigation/index.html
@@ -25,7 +25,7 @@ translation_of: Web/CSS/Layout_cookbook/Breadcrumb_Navigation
 <p>{{EmbedGHLiveSample("css-examples/css-cookbook/breadcrumb-navigation.html", '100%', 530)}}</p>
 
 <div class="note">
-<p><a href="https://github.com/mdn/css-examples/blob/master/css-cookbook/breadcrumb-navigation--download.html">Baixe esse examplo</a></p>
+<p><a href="https://github.com/mdn/css-examples/blob/master/css-cookbook/breadcrumb-navigation--download.html">Baixe esse exemplo</a></p>
 </div>
 
 <h2 id="Faça_escolhas">Faça escolhas</h2>

--- a/files/pt-br/web/css/layout_cookbook/media_objects/index.html
+++ b/files/pt-br/web/css/layout_cookbook/media_objects/index.html
@@ -48,7 +48,7 @@ translation_of: Web/CSS/Layout_cookbook/Media_objects
 <p class="codepen">{{EmbedGHLiveSample("css-examples/css-cookbook/media-objects-fallback.html", '100%', 1200)}}</p>
 
 <div class="note">
-<p class="codepen"><a href="https://github.com/mdn/css-examples/blob/master/css-cookbook/media-objects-fallback--download.html">Baixe este examplo</a></p>
+<p class="codepen"><a href="https://github.com/mdn/css-examples/blob/master/css-cookbook/media-objects-fallback--download.html">Baixe este exemplo</a></p>
 </div>
 
 <p>Depois que os elementos flutuantes se tornam itens da grade, o flutuador não se aplica mais; portanto, você não precisa fazer nada de especial para limpá-lo.</p>

--- a/files/pt-br/web/css/offset/index.html
+++ b/files/pt-br/web/css/offset/index.html
@@ -49,7 +49,7 @@ offset: url(arc.svg) 30deg / 50px 100px;
 
 {{csssyntax}}
 
-<h2 id="Examplo">Examplo</h2>
+<h2 id="Exemplo">Exemplo</h2>
 
 <h3 id="HTML">HTML</h3>
 

--- a/files/pt-br/web/css/will-change/index.html
+++ b/files/pt-br/web/css/will-change/index.html
@@ -81,7 +81,7 @@ will-change: unset;
 }
 </pre>
 
-<p>O exemplo acima adiciona a propriedade <code>will-change</code> diretamente no estilo, o que irá fazer com que o navegador mantenha a otimização em memória por muito mais tempo que o necessário e nós já vimos que isso deve ser evitado. Abaixo outro examplo mostrando como aplicar o <code>will-change</code> através de script, o que provavelmente é o que você deve fazer na maioria dos casos.</p>
+<p>O exemplo acima adiciona a propriedade <code>will-change</code> diretamente no estilo, o que irá fazer com que o navegador mantenha a otimização em memória por muito mais tempo que o necessário e nós já vimos que isso deve ser evitado. Abaixo outro exemplo mostrando como aplicar o <code>will-change</code> através de script, o que provavelmente é o que você deve fazer na maioria dos casos.</p>
 
 <pre class="brush: js">var el = document.getElementById('element');
 

--- a/files/pt-br/web/css/word-break/index.html
+++ b/files/pt-br/web/css/word-break/index.html
@@ -49,7 +49,7 @@ word-break: unset;
 
 {{csssyntax}}
 
-<h2 id="Examples" name="Examples">Examplos</h2>
+<h2 id="Examples" name="Examples">Exemplos</h2>
 
 <h3 id="Conteúdo_HTML">Conteúdo HTML</h3>
 

--- a/files/pt-br/web/html/element/bdo/index.html
+++ b/files/pt-br/web/html/element/bdo/index.html
@@ -55,7 +55,7 @@ translation_of: Web/HTML/Element/bdo
  </dd>
 </dl>
 
-<h2 id="Examplos">Examplos</h2>
+<h2 id="Exemplos">Exemplos</h2>
 
 <pre class="brush: html">&lt;!-- Muda a direção do texto --&gt;
 &lt;p&gt;Este texto ficará da esquerda para a direita.&lt;/p&gt;
@@ -64,7 +64,7 @@ translation_of: Web/HTML/Element/bdo
 
 <h3 id="Resultado">Resultado</h3>
 
-<p>{{EmbedLiveSample('Examplos')}}</p>
+<p>{{EmbedLiveSample('Exemplos')}}</p>
 
 <h2 id="Notas">Notas</h2>
 

--- a/files/pt-br/web/http/headers/set-cookie/samesite/index.html
+++ b/files/pt-br/web/http/headers/set-cookie/samesite/index.html
@@ -65,7 +65,7 @@ translation_of: Web/HTTP/Headers/Set-Cookie/SameSite
 
 <pre class="example-good notranslate">Set-Cookie: flavor=choco; <strong>SameSite=Lax</strong></pre>
 
-<h2 id="Examplo"><strong>Examplo:</strong></h2>
+<h2 id="Exemplo"><strong>Exemplo:</strong></h2>
 
 <pre class="notranslate">RewriteEngine on
 RewriteBase "/"

--- a/files/pt-br/web/javascript/reference/errors/no_variable_name/index.html
+++ b/files/pt-br/web/javascript/reference/errors/no_variable_name/index.html
@@ -18,7 +18,7 @@ SyntaxError: Unexpected token = (Chrome)</pre>
 
 <p>O nome de uma variável está faltando. Isto é provavelmente devido a um erro de sintaxe no seu código. Provavelmente uma vírgula está errada em algum lugar. Totalmente compreensível! Nomear as coisas é tão difícil.</p>
 
-<h2 id="Examplos">Examplos</h2>
+<h2 id="Exemplos">Exemplos</h2>
 
 <h3 id="Falta_um_nome_de_variável">Falta um nome de variável</h3>
 

--- a/files/pt-br/web/javascript/reference/errors/undeclared_var/index.html
+++ b/files/pt-br/web/javascript/reference/errors/undeclared_var/index.html
@@ -32,7 +32,7 @@ ReferenceError: Variável indefinida em <em>strict mode</em> (Edge)
 
 <p>Erros sobre atribuições de variáveis não declaradas ocorrem apenas em <a href="/en-US/docs/Web/JavaScript/Reference/Strict_mode">código de modo estrito</a>. Em código não-estrito, eles são silenciosamente ignorados.</p>
 
-<h2 id="Examplos">Examplos</h2>
+<h2 id="Exemplos">Exemplos</h2>
 
 <h3 id="Casos_inválidos">Casos inválidos</h3>
 

--- a/files/pt-br/web/javascript/reference/global_objects/array/lastindexof/index.html
+++ b/files/pt-br/web/javascript/reference/global_objects/array/lastindexof/index.html
@@ -26,7 +26,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf
 
 <h2 id="Exemplos">Exemplos</h2>
 
-<h3 id="Examplo_Usando_lastIndexOf">Examplo: Usando <code>lastIndexOf</code></h3>
+<h3 id="Exemplo_Usando_lastIndexOf">Exemplo: Usando <code>lastIndexOf</code></h3>
 
 <p>O seguinte exemplo utiliza <code>lastIndexOf</code> para localizar elementos em um array.</p>
 

--- a/files/pt-br/web/javascript/reference/global_objects/bigint/index.html
+++ b/files/pt-br/web/javascript/reference/global_objects/bigint/index.html
@@ -209,7 +209,7 @@ Boolean(12n)
 
 <p>{{page('/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/prototype', 'Methods')}}</p>
 
-<h2 id="Examples">Examplos </h2>
+<h2 id="Examples">Exemplos </h2>
 
 <h3 id="Calculating_Primes">Calculando números primos</h3>
 

--- a/files/pt-br/web/javascript/reference/global_objects/date/tojson/index.html
+++ b/files/pt-br/web/javascript/reference/global_objects/date/tojson/index.html
@@ -23,7 +23,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Date/toJSON
 
 <p>Instâncias de {{jsxref("Date")}} referem-se a um específico ponto no tempo. Invocar <code>toJSON()</code> retorna uma string (usando {{jsxref("Date.prototype.toISOString()", "toISOString()")}}) representando o valor do objeto {{jsxref("Date")}}. Por padrão este método é destinado a serializar objetos {{jsxref("Date")}} em serializações {{Glossary("JSON")}}.</p>
 
-<h2 id="Examplos">Examplos</h2>
+<h2 id="Exemplos">Exemplos</h2>
 
 <h3 id="Usando_toJSON()">Usando <code>toJSON()</code></h3>
 

--- a/files/pt-br/web/javascript/reference/global_objects/eval/index.html
+++ b/files/pt-br/web/javascript/reference/global_objects/eval/index.html
@@ -128,7 +128,7 @@ eval("x + y + 1"); // returns 42
 eval(z);           // returns 42
 </pre>
 
-<h3 id="Example_Using_eval_to_evaluate_a_string_of_JavaScript_statements" name="Example:_Using_eval_to_evaluate_a_string_of_JavaScript_statements">Examplo: Using <code>eval</code> to evaluate a string of JavaScript statements</h3>
+<h3 id="Example_Using_eval_to_evaluate_a_string_of_JavaScript_statements" name="Example:_Using_eval_to_evaluate_a_string_of_JavaScript_statements">Exemplo: Using <code>eval</code> to evaluate a string of JavaScript statements</h3>
 
 <p>O exemplo a seguir usa <code>eval()</code> para avaliar a string <code>str</code>. Essa string consiste de instruções JavaScript que abrem uma caixa de diálogo de alerta e atribuem ao <code>z</code> o valor de 42 se <code>x</code> for cinco, e do contrário, atribui 0 a <code>z</code>. Quando a segunda instrução é executada, <code>eval()</code> fará com que essas instruções sejam executadas e também irá avaliar o conjunto de instruções e retornará o valor atribuído a z.</p>
 

--- a/files/pt-br/web/javascript/reference/global_objects/json/stringify/index.html
+++ b/files/pt-br/web/javascript/reference/global_objects/json/stringify/index.html
@@ -135,7 +135,7 @@ JSON.stringify(obj);        // '"bar"'
 JSON.stringify({ x: obj }); // '{"x":"bar"}'
 </pre>
 
-<h3 id="Example_of_using_JSON.stringify_with_localStorage" name="Example_of_using_JSON.stringify_with_localStorage">Examplo de uso de <code>JSON.stringify()</code> com <code>localStorage</code></h3>
+<h3 id="Example_of_using_JSON.stringify_with_localStorage" name="Example_of_using_JSON.stringify_with_localStorage">Exemplo de uso de <code>JSON.stringify()</code> com <code>localStorage</code></h3>
 
 <p>No caso em que você deseja armazenar um objeto criado por seu usuário e permitir que ele seja restaurado mesmo após o fechamento do navegador, o exemplo a seguir é um modelo para a aplicabilidade de <code>JSON.stringify()</code>:</p>
 

--- a/files/pt-br/web/javascript/reference/global_objects/math/acos/index.html
+++ b/files/pt-br/web/javascript/reference/global_objects/math/acos/index.html
@@ -29,7 +29,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Math/acos
 
 <p>Porque <code>acos() é um metodo estático</code>, você sempre usará <code>Math.acos() ao invés de criar um Objecto Math(Math não é um construtor).</code></p>
 
-<h2 id="Examplos">Examplos</h2>
+<h2 id="Exemplos">Exemplos</h2>
 
 <h3 id="Usando_Math.acos()">Usando <code>Math.acos()</code></h3>
 

--- a/files/pt-br/web/javascript/reference/global_objects/object/__lookupgetter__/index.html
+++ b/files/pt-br/web/javascript/reference/global_objects/object/__lookupgetter__/index.html
@@ -28,7 +28,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__
 
 <p>Agora é possível fazer isso de um jeito uniforme usando:. {{jsxref("Object.getOwnPropertyDescriptor()")}} e  {{jsxref("Object.getPrototypeOf()")}}.</p>
 
-<h2 id="Examplos">Examplos</h2>
+<h2 id="Exemplos">Exemplos</h2>
 
 <pre class="brush: js">var obj = {
   get foo() {

--- a/files/pt-br/web/javascript/reference/global_objects/reflect/set/index.html
+++ b/files/pt-br/web/javascript/reference/global_objects/reflect/set/index.html
@@ -39,7 +39,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Reflect/set
 
 <p>O método <code>Reflect.set</code> permite que você defina uma propriedade em um objeto. Ele define a propriedade e is like the <a href="/en-US/docs/Web/JavaScript/Reference/Operators/Property_Accessors">property accessor</a> syntax as a function.</p>
 
-<h2 id="Examplos">Examplos</h2>
+<h2 id="Exemplos">Exemplos</h2>
 
 <h3 id="Usando_Reflect.set()">Usando <code>Reflect.set()</code></h3>
 

--- a/files/pt-br/web/javascript/reference/global_objects/weakmap/delete/index.html
+++ b/files/pt-br/web/javascript/reference/global_objects/weakmap/delete/index.html
@@ -26,7 +26,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WeakMap/delete
 
 <p><code>true</code> se o emento do objeto do <code>WeakMap</code> tenha sido removido com sucesso. <code>false</code> se a chave(<code>key</code>) não for encontrada no <code>WeakMap</code> ou se a chave(<font face="consolas, Liberation Mono, courier, monospace"><span style="background-color: rgba(220, 220, 220, 0.5);">key</span></font>) não for um objeto.</p>
 
-<h2 id="Examplos">Examplos</h2>
+<h2 id="Exemplos">Exemplos</h2>
 
 <h3 id="Usando_o_método_delete">Usando o método <code>delete</code> </h3>
 

--- a/files/pt-br/web/javascript/reference/statements/label/index.html
+++ b/files/pt-br/web/javascript/reference/statements/label/index.html
@@ -33,7 +33,7 @@ translation_of: Web/JavaScript/Reference/Statements/label
 <p>Labels não são comunmente utilizados em JavaScript já que estes fazem com que programas fiquei mais difíceis de ler e entender. Sempre que possível evite utilizar labels e, dependendo dos casos, prefira <a href="https://developer.mozilla.org/pt-BR/docs/JavaScript/Reference/Statements/function">chamar funções</a> ou <a href="https://developer.mozilla.org/pt-BR/docs/JavaScript/Reference/Statements/throw">lançar um erro</a>.</p>
 </div>
 
-<h2 id="Examples" name="Examples">Examplos</h2>
+<h2 id="Examples" name="Examples">Exemplos</h2>
 
 <h3 id="Example_1" name="Example_1"><code>Exemplo com continue</code></h3>
 


### PR DESCRIPTION
The Portuguese word for "Example/Examples" is "Exemplo/Exemplos". This word was misspelled as Examplo in several files.