### PR TITLE
fix: make the link's  content are the same

### DIFF
--- a/files/zh-cn/learn/css/css_layout/index.html
+++ b/files/zh-cn/learn/css/css_layout/index.html
@@ -56,7 +56,7 @@ translation_of: Learn/CSS/CSS_layout
  <dd>定位允许您从常规文档布局流程中取出元素，并使它们具有不同的行为，例如坐在另一个之上，或始终保持在浏览器视口内的同一位置。 本文解释不同的{{cssxref("position")}} 值，以及如何使用它们。</dd>
  <dt><a href="/zh-CN/docs/Learn/CSS/CSS_layout/Multiple-column_Layout">多列布局</a></dt>
  <dd>多列布局声明提供了一种多列组织内容的方式，正如你在一些报纸中看到的那样。这篇文章介绍怎么使用这一特性。</dd>
- <dt><a href="/zh-CN/docs/Learn/CSS/CSS_layout/Responsive_Design">响应式布局</a></dt>
+ <dt><a href="/zh-CN/docs/Learn/CSS/CSS_layout/Responsive_Design">响应式设计</a></dt>
  <dd>随着越来越多的屏幕尺寸出现在支持 Web 的设备上，响应式 Web 设计（RWD）的概念出现了：一组允许网页改变其布局和外观以适应不同的屏幕宽度、分辨率等的实践。这一想法改变了我们为多设备 Web 设计的方式，在本文中，我们将帮助您了解掌握它所需的主要技术。</dd>
  <dt><a href="/zh-CN/docs/Learn/CSS/CSS_layout/Media_queries">媒体查询入门指南</a></dt>
  <dd><strong>媒体查询</strong> 提供了一种仅当浏览器和设备环境与您指定的规则匹配时才应用 css 的方法，例如“viewport（视区）宽度大于 480 像素”。媒体查询是响应式 Web 设计的一个关键部分，因为它们允许您根据视区的大小创建不同的布局，但也可以用于检测有关网站运行环境的其他内容，例如用户是否使用触摸屏而不是鼠标。在本节中，您将首先了解媒体查询中使用的语法，然后在一个演示如何使简单设计具有响应性的示例中继续使用它们。</dd>


### PR DESCRIPTION
close #6191

Make the link's  content are the same.
The link is `/zh-CN/docs/Learn/CSS/CSS_layout/Responsive_Design`

https://github.com/mdn/translated-content/blob/cfdbbbc886765b2d7bf5880173de99eb8a60a7ab/files/zh-cn/learn/css/css_layout/index.html#L59

https://github.com/mdn/translated-content/blob/cfdbbbc886765b2d7bf5880173de99eb8a60a7ab/files/zh-cn/learn/css/css_layout/normal_flow/index.html#L93

https://github.com/mdn/translated-content/blob/cfdbbbc886765b2d7bf5880173de99eb8a60a7ab/files/zh-cn/learn/css/css_layout/supporting_older_browsers/index.html#L232