### PR TITLE
Remove literal `&nbsp;` from code example

### DIFF
--- a/files/fr/learn/forms/form_validation/index.md
+++ b/files/fr/learn/forms/form_validation/index.md
@@ -375,7 +375,7 @@ var email = document.getElementById("mail");
 
 email.addEventListener("keyup", function (event) {
   if(email.validity.typeMismatch) {
-    email.setCustomValidity("J'attend un e-mail, mon cher !");
+    email.setCustomValidity("J'attends un e-mail, mon cher !");
   } else {
     email.setCustomValidity("");
   }

--- a/files/fr/learn/forms/form_validation/index.md
+++ b/files/fr/learn/forms/form_validation/index.md
@@ -375,7 +375,7 @@ var email = document.getElementById("mail");
 
 email.addEventListener("keyup", function (event) {
   if(email.validity.typeMismatch) {
-    email.setCustomValidity("J'attend un e-mail, mon cher&nbsp;!");
+    email.setCustomValidity("J'attend un e-mail, mon cher !");
   } else {
     email.setCustomValidity("");
   }


### PR DESCRIPTION
Hello, the html space "& nbsp;" is display by error line 378.