### PR TITLE
Remove macro "page" on Web/Javascript [es]

### DIFF
--- a/files/es/web/javascript/reference/global_objects/date/tolocaledatestring/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/tolocaledatestring/index.md
@@ -1,14 +1,6 @@
 ---
 title: Date.prototype.toLocaleDateString()
 slug: Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString
-tags:
-  - Fecha
-  - Formato de zona horaria IANA
-  - Internacionalización
-  - JavaScript
-  - Método
-  - Prototipo
-  - Referencia
 browser-compat: javascript.builtins.Date.toLocaleDateString
 ---
 {{JSRef}}


### PR DESCRIPTION
Closes #3936

- [x] elimina las etiquetas de tolocaledatestring 
 
Hice una revisión rapida de las 19 páginas reportadas en el issue y creo que estan bien.

Muchas gracias por el apoyo!!
Sin ustedes no hubiera sido posible (sin preferencia en el orden de la mención) y vamos por más, que no?
@Vallejoanderson, @davbrito, @Graywolf9, @hectormoba, @Jalkhov 

Si alguien del @mdn/yari-content-es puede aprobar y fusionar, seria genial.