### PR TITLE
Update french index.md - attributeChangedCallback

### DIFF
--- a/files/fr/web/web_components/using_custom_elements/index.md
+++ b/files/fr/web/web_components/using_custom_elements/index.md
@@ -258,7 +258,7 @@ attributeChangedCallback(name, oldValue, newValue) {
 }
 ```
 
-Notez que, pour déclencher le rappel `attributeChangedCallback()` lorsqu'un attribut change, vous devez observer les attributs. Cela est réalisé en spécifiant le getter `static get observedAttributes()` dans la classe de l'éléments personnalisé, en incluant à l'intérieur une instruction `return` qui retourne un tableau contenant les noms des attributs que vous voulez observer :
+Notez que, pour déclencher le rappel `attributeChangedCallback()` lorsqu'un attribut change, vous devez observer les attributs. Cela est réalisé en spécifiant la méthode `static get observedAttributes()` dans la classe de l'élément personnalisé, en incluant à l'intérieur une instruction `return` qui renvoie un tableau contenant les noms des attributs que vous voulez observer&nbsp;:
 
 ```js
 static get observedAttributes() {return ['w', 'l']; }

--- a/files/fr/web/web_components/using_custom_elements/index.md
+++ b/files/fr/web/web_components/using_custom_elements/index.md
@@ -258,7 +258,7 @@ attributeChangedCallback(name, oldValue, newValue) {
 }
 ```
 
-Notez que, pour déclencher le rappel `attributeChangedCallback()` lorsqu'un attribut change, vous devez observer les attributs. Cela est réalisé en appelant le getter `observedAttributes()` dans le constructeur, en incluant à l'intérieur une instruction return qui retourne un tableau contenant les noms des attributs que vous voulez observer :
+Notez que, pour déclencher le rappel `attributeChangedCallback()` lorsqu'un attribut change, vous devez observer les attributs. Cela est réalisé en spécifiant le getter `static get observedAttributes()` dans la classe de l'éléments personnalisé, en incluant à l'intérieur une instruction `return` qui retourne un tableau contenant les noms des attributs que vous voulez observer :
 
 ```js
 static get observedAttributes() {return ['w', 'l']; }


### PR DESCRIPTION
The french translation proposed to call the method `observedAttributes()` inside the constructor whereas the english documentation propose to specify a static get method inside the custom element class.
I modified the translation to avoid misunderstanding about this specification.