### PR TITLE
Correct typing error in French version

### DIFF
--- a/files/fr/web/css/outline-color/index.md
+++ b/files/fr/web/css/outline-color/index.md
@@ -9,7 +9,7 @@ translation_of: Web/CSS/outline-color
 ---
 {{CSSRef}}
 
-La propriété **`outline-color`** permet de définir la couleur avec laquelle on trace le conteur de l'élément. Ce contour est tracé autour de [la boîte de bordure](/fr/Apprendre/CSS/Les_bases/Le_mod%C3%A8le_de_bo%C3%AEte) et peut être utilisé pour faire ressortir l'élément.
+La propriété **`outline-color`** permet de définir la couleur avec laquelle on trace le contour de l'élément. Ce contour est tracé autour de [la boîte de bordure](/fr/Apprendre/CSS/Les_bases/Le_mod%C3%A8le_de_bo%C3%AEte) et peut être utilisé pour faire ressortir l'élément.
 
 {{EmbedInteractiveExample("pages/css/outline-color.html")}}
 


### PR DESCRIPTION
Replacement of "conteur" by "contour" in french version of "outline-color" page