### PR TITLE
[RU] fix: variable declaration in example

### DIFF
--- a/files/ru/learn/forms/form_validation/index.html
+++ b/files/ru/learn/forms/form_validation/index.html
@@ -743,7 +743,7 @@ const emailRegExp = /^[a-zA-Z0-9.!#$%&amp;'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-
 function addEvent(element, event, callback) {
   let previousEventCallBack = element["on"+event];
   element["on"+event] = function (e) {
-    const output = callback(e);
+    let output = callback(e);
 
     // Колбэк, который возвращает `false`, останавливает цепочку колбэков
     // и прерывает выполнение колбэка события

--- a/files/ru/learn/forms/form_validation/index.html
+++ b/files/ru/learn/forms/form_validation/index.html
@@ -753,8 +753,8 @@ function addEvent(element, event, callback) {
       output = previousEventCallBack(e);
       if(output === false) return false;
     }
-  }
-};
+  };
+}
 
 // Теперь мы можем изменить наши критерии валидации
 // Поскольку мы не полагаемся на CSS-псевдокласс, для поля email


### PR DESCRIPTION
Исправил объявление переменной в примере с валидацией формы для старых браузеров без использования Constraint Validation API.
![image](https://user-images.githubusercontent.com/81531000/174450828-f7cf3683-411a-43f5-bd6a-fd40e005028c.png)

Ошибка в примере воспроизведется, если повесить несколько однотипных прослушивателей событий на тот же элемент. 
Например, вот так
![image](https://user-images.githubusercontent.com/81531000/174448738-68e47db4-bd8f-49b4-8187-d0d1cc60c74b.png)
в случае с `const output = callback(e);` получится:
![image](https://user-images.githubusercontent.com/81531000/174448771-1a1474ba-24be-4c04-a8b6-6d4d4e4ff54f.png)

**UPD**: убрал точку с запятой для function declaration и добавил точку с запятой для function expression.
![image](https://user-images.githubusercontent.com/81531000/174450951-5e1ce786-b950-4555-8ae2-e802fc54fe0b.png)
