### PR TITLE
chore: Run Markdownlint rules on es docs

### DIFF
--- a/files/es/web/html/element/title/index.md
+++ b/files/es/web/html/element/title/index.md
@@ -37,15 +37,15 @@ El elemento **`<title>`** [HTML](/es/docs/Web/HTML) define el título del docume
     <tr>
       <th scope="row">Omisión de etiqueta</th>
       <td>
-        Se requieren etiquetas de apertura y cierre. Tenga en cuenta que 
-        omitir <code>&#x3C;/title></code> haría que el navegador 
+        Se requieren etiquetas de apertura y cierre. Tenga en cuenta que
+        omitir <code>&#x3C;/title></code> haría que el navegador
         ignore el resto de la página.
       </td>
     </tr>
     <tr>
       <th scope="row">Padres permitidos</th>
       <td>
-        Un elemento {{ HTMLElement("head") }} que no contiene ningún 
+        Un elemento {{ HTMLElement("head") }} que no contiene ningún
         otro elemento {{ HTMLElement("title") }}.
       </td>
     </tr>
@@ -108,7 +108,6 @@ Una técnica de navegación común para los usuarios de tecnología de asistenci
 ```
 
 Si el envío de un formulario contiene errores y el envío vuelve a representar la página actual, el título se puede usar para ayudar a que los usuarios se den cuenta de cualquier error en su envío. Por ejemplo, actualice el valor de `title` de la página para reflejar cambios significativos en el estado de la página (como problemas de validación de formularios).
-
 
 ### Ejemplo
 

--- a/files/es/web/javascript/reference/global_objects/promise/index.md
+++ b/files/es/web/javascript/reference/global_objects/promise/index.md
@@ -202,7 +202,7 @@ En el ejemplo anterior, el texto interno del `<iframe>` se actualizará solo si 
     Devuelve una promesa que se resuelve después de que todas las promesas dadas se cumplan o se rechacen, con una matriz de objetos que describen el resultado de cada promesa.
 
 - {{JSxRef("Promise.any", "Promise.any(iterable)")}}
-    - : Toma un iterable de objetos `Promise` y, tan pronto como se cumple una de las promesas en el iterable, devuelve una única promesa que se resuelve con el valor de esa promesa.
+  - : Toma un iterable de objetos `Promise` y, tan pronto como se cumple una de las promesas en el iterable, devuelve una única promesa que se resuelve con el valor de esa promesa.
 - {{JSxRef("Promise.race", "Promise.race(iterable)")}}
 
   - : Espera hasta que alguna de las promesas se cumpla o se rechace.
@@ -216,7 +216,7 @@ En el ejemplo anterior, el texto interno del `<iframe>` se actualizará solo si 
 - {{JSxRef("Promise.resolve", "Promise.resolve(value)")}}
 
   - : Devuelve un nuevo objeto `Promise` que se resuelve con el valor dado. Si el valor tiene un método `then`, la promesa devuelta "seguirá" ese método, adoptando su estado eventual; de lo contrario, la promesa devuelta se cumplirá con el valor.
-    
+
     Generalmente, si no sabe si un valor es una promesa o no, {{JSxRef("Promise.resolve", "Promise.resolve(value)")}} actua en su lugar y trabaja con el valor de retorno como una promesa.
 
 ## Métodos de instancia

--- a/files/es/web/javascript/reference/operators/operator_precedence/index.md
+++ b/files/es/web/javascript/reference/operators/operator_precedence/index.md
@@ -195,7 +195,7 @@ Cortocircuitar es una jerga para la evaluación condicional. Por ejemplo, en la 
 la expresión `(b + c)` no será evaluada, incluso si está dentro de
 paréntesis. Se podría decir que el operador de conjunción lógica ("&&") está
 "cortocircuitado". Junto con la conjunción lógica, otros operadores cortocircuitados
-son la disyunción lógica ("||"), la coalescencia nula ("??"), el encadenamiento opcional ("?."), 
+son la disyunción lógica ("||"), la coalescencia nula ("??"), el encadenamiento opcional ("?."),
 y el operador condicional ternario. A continuación, algunos ejemplos.
 
 ```js


### PR DESCRIPTION
Cleanup with the .markdownlint.json config now in the repo