### PR TITLE
replace standard-table with macros for zh-TW (Part 10)

### DIFF
--- a/files/zh-tw/web/api/analysernode/getbytefrequencydata/index.html
+++ b/files/zh-tw/web/api/analysernode/getbytefrequencydata/index.html
@@ -5,11 +5,9 @@ translation_of: Web/API/AnalyserNode/getByteFrequencyData
 ---
 <p>{{ APIRef("Web Audio API") }}</p>
 
-<div>
 <p>{{ domxref("AnalyserNode") }} 介面的 <strong><code>getByteFrequencyData()</code></strong> 方法會將當前的頻率資料複製到 {{domxref("Uint8Array")}} （無號 byte 陣列）。</p>
 
 <p>如果陣列的元素數目比 {{domxref("AnalyserNode.frequencyBinCount")}} 少的話，多餘的元素會被 drop 掉。如果比需要的少的話，多餘的元素會被忽略。</p>
-</div>
 
 <h2 id="語法">語法</h2>
 
@@ -72,24 +70,11 @@ draw();</pre>
 
 <h2 id="規範">規範</h2>
 
-<table class="standard-table" style="height: 105px; width: 593px;">
- <tbody>
-  <tr>
-   <th scope="col">規範</th>
-   <th scope="col">狀態</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Web Audio API', '#widl-AnalyserNode-getByteFrequencyData-void-Uint8Array-array', 'getByteFrequencyData()')}}</td>
-   <td>{{Spec2('Web Audio API')}}</td>
-   <td> </td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
-<h2 id="瀏覽器支援度">瀏覽器支援度</h2>
+<h2 id="瀏覽器相容性">瀏覽器相容性</h2>
 
-{{Compat("api.AnalyserNode.getByteFrequencyData")}}
+{{Compat}}
 
 <h2 id="參看">參看</h2>
 

--- a/files/zh-tw/web/api/customevent/customevent/index.html
+++ b/files/zh-tw/web/api/customevent/customevent/index.html
@@ -43,28 +43,11 @@ obj.dispatchEvent(event);</pre>
 
 <h2 id="規格">規格</h2>
 
-<table class="standard-table" style="height: 49px; width: 1000px;">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('DOM WHATWG','#interface-customevent','CustomEvent()')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
-<h2 id="瀏覽器支援度">瀏覽器支援度</h2>
+<h2 id="瀏覽器相容性">瀏覽器相容性</h2>
 
-
-
-<p>{{Compat("api.CustomEvent.CustomEvent")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="添加額外參數">添加額外參數</h2>
 

--- a/files/zh-tw/web/api/document/body/index.html
+++ b/files/zh-tw/web/api/document/body/index.html
@@ -30,46 +30,13 @@ alert(document.body.id); // "newBodyElement"
 
 <p>Though <code>body</code> is settable, setting a new body on a document will effectively remove all the current children of the existing <code>&lt;body&gt;</code> element.</p>
 
-<h2 id="Specification" name="Specification">規範</h2>
+<h2 id="Specification">規範</h2>
 
-<table class="spectable standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG','dom.html#dom-document-body','Document.body')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td> </td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1','dom.html#dom-document-body','Document.body')}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td> </td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C','dom.html#dom-document-body','Document.body')}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td> </td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 HTML','html.html#ID-56360201','Document.body')}}</td>
-   <td>{{Spec2('DOM2 HTML')}}</td>
-   <td> </td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1','level-one-html.html#attribute-body','Document.body')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="瀏覽器相容性">瀏覽器相容性</h2>
 
-{{Compat("api.Document.body")}}
+{{Compat}}
 
 <h2 id="參見">參見</h2>
 

--- a/files/zh-tw/web/api/document/documentelement/index.html
+++ b/files/zh-tw/web/api/document/documentelement/index.html
@@ -27,34 +27,10 @@ for (var i = 0; i &lt; firstTier.length; i++) {
 
 <p>對於所有非空的 HTML 文件， <code>document.documentElement</code> 將會是一個 {{HTMLElement("html")}}  元素 ; 對於所有非空的 XML 文件，<code>document.documentElement</code> 則會是文件的根元素。</p>
 
-<h2 id="Specification" name="Specification">規範</h2>
+<h2 id="Specification">規範</h2>
 
-<table class="spectable standard-table">
- <tbody>
-  <tr>
-   <th scope="col">規範</th>
-   <th scope="col">狀態</th>
-   <th scope="col"> 備註</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 Core','core.html#ID-87CD092','Document.documentElement')}}</td>
-   <td>{{Spec2('DOM2 Core')}}</td>
-   <td> </td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM3 Core','core.html#ID-87CD092','Document.documentElement')}}</td>
-   <td>{{Spec2('DOM3 Core')}}</td>
-   <td> </td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM4','#dom-document-documentelement','Document.documentElement')}}</td>
-   <td>{{Spec2('DOM4')}}</td>
-   <td> </td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM WHATWG','#dom-document-documentelement','Document.documentElement')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td> </td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
+
+<h2 id="瀏覽器相容性">瀏覽器相容性</h2>
+
+{{Compat}}

--- a/files/zh-tw/web/api/document/head/index.html
+++ b/files/zh-tw/web/api/document/head/index.html
@@ -28,30 +28,7 @@ alert( document.head === document.querySelector("head") ); // true
 
 <h2 id="規範">規範</h2>
 
-<table class="spectable standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG','dom.html#dom-document-head','Document.head')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td>Initial definition.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5.1','dom.html#dom-document-head','Document.head')}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td> </td>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML5 W3C','dom.html#dom-document-head','Document.head')}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td> </td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="瀏覽器相容性">瀏覽器相容性</h2>
 

--- a/files/zh-tw/web/api/document/readystate/index.html
+++ b/files/zh-tw/web/api/document/readystate/index.html
@@ -74,30 +74,7 @@ document.onreadystatechange = function () {
 
 <h2 id="規範">規範</h2>
 
-<table class="spectable standard-table">
- <tbody>
-  <tr>
-   <th scope="col">規範</th>
-   <th scope="col">狀態</th>
-   <th scope="col">註</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML WHATWG", "#current-document-readiness", "Document readiness")}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td> </td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5.1", "#current-document-readiness", "Document readiness")}}</td>
-   <td>{{Spec2('HTML5.1')}}</td>
-   <td> </td>
-  </tr>
-  <tr>
-   <td>{{SpecName("HTML5 W3C", "#current-document-readiness", "Document readiness")}}</td>
-   <td>{{Spec2('HTML5 W3C')}}</td>
-   <td>Initial specification.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="參見">參見</h2>
 

--- a/files/zh-tw/web/api/event/event/index.html
+++ b/files/zh-tw/web/api/event/event/index.html
@@ -55,25 +55,6 @@ var ev = new Event("look", {"bubbles":true, "cancelable":false});
 document.dispatchEvent(ev);
 </pre>
 
-<h2 id="規格">規格</h2>
-
-<table class="standard-table" style="height: 49px; width: 1000px;">
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName('DOM WHATWG','#interface-event','Event()')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
-
 <h2 id="規範">規範</h2>
 
 {{Specifications}}

--- a/files/zh-tw/web/api/formdata/get/index.html
+++ b/files/zh-tw/web/api/formdata/get/index.html
@@ -41,26 +41,11 @@ formData.append('username', 'Bob');</pre>
 
 <h2 id="規範">規範</h2>
 
-<table>
- <tbody>
-  <tr>
-   <th scope="col">規範</th>
-   <th scope="col">狀態</th>
-   <th scope="col">註解</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('XMLHttpRequest','#dom-formdata-get','get()')}}</td>
-   <td>{{Spec2('XMLHttpRequest')}}</td>
-   <td> </td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="瀏覽器相容性">瀏覽器相容性</h2>
 
 {{Compat("api.FormData.get")}}
-
-<h2 id="sect1"> </h2>
 
 <h2 id="延伸閱讀">延伸閱讀</h2>
 

--- a/files/zh-tw/web/api/globaleventhandlers/onclick/index.html
+++ b/files/zh-tw/web/api/globaleventhandlers/onclick/index.html
@@ -8,11 +8,7 @@ tags:
   - Reference
 translation_of: Web/API/GlobalEventHandlers/onclick
 ---
-<div>
 <div>{{ ApiRef("HTML DOM") }}</div>
-</div>
-
-<div> </div>
 
 <p><strong>onclick</strong> 屬性回傳當前元件 <code>click</code> 事件處理器的程式碼（event handler code）。</p>
 
@@ -70,22 +66,9 @@ translation_of: Web/API/GlobalEventHandlers/onclick
 
 <p>這個屬性同一時間中只能指定一個 <code>click</code> 處理器（handler）。你也許會比較想使用 {{domxref("EventTarget.addEventListener()")}}，因為它有更多的彈性而且是 DOM 事件規範的一部份。</p>
 
-<h2 id="Specification" name="Specification">規範</h2>
+<h2 id="Specification">規範</h2>
 
-<table class="spectable standard-table">
- <tbody>
-  <tr>
-   <th scope="col">規範</th>
-   <th scope="col">狀態</th>
-   <th scope="col">備註</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onclick','onclick')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td> </td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="瀏覽器相容性">瀏覽器相容性</h2>
 

--- a/files/zh-tw/web/api/globaleventhandlers/onclose/index.html
+++ b/files/zh-tw/web/api/globaleventhandlers/onclose/index.html
@@ -30,20 +30,7 @@ translation_of: Web/API/GlobalEventHandlers/onclose
 
 <h2 id="規範">規範</h2>
 
-<table class="spectable standard-table">
- <tbody>
-  <tr>
-   <th scope="col">規範</th>
-   <th scope="col">狀態</th>
-   <th scope="col">備註</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('HTML WHATWG','webappapis.html#handler-onclose','onclose')}}</td>
-   <td>{{Spec2('HTML WHATWG')}}</td>
-   <td> </td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="瀏覽器相容性">瀏覽器相容性</h2>
 

--- a/files/zh-tw/web/api/mediasource/mediasource/index.html
+++ b/files/zh-tw/web/api/mediasource/mediasource/index.html
@@ -38,26 +38,9 @@ if ('MediaSource' in window &amp;&amp; MediaSource.isTypeSupported(mimeCodec)) {
 ...
 </pre>
 
-<h2 id="規格">規格</h2>
+<h2 id="瀏覽器相容性">瀏覽器相容性</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">規格</th>
-   <th scope="col">狀態</th>
-   <th scope="col">註釋</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('Media Source Extensions', '#mediasource', 'MediaSource')}}</td>
-   <td>{{Spec2('Media Source Extensions')}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
-
-<h2 id="相容性表格">相容性表格</h2>
-
-{{Compat("api.MediaSource.MediaSource")}}
+{{Compat}}
 
 <h2 id="相關資料">相關資料</h2>
 

--- a/files/zh-tw/web/api/node/insertbefore/index.html
+++ b/files/zh-tw/web/api/node/insertbefore/index.html
@@ -114,46 +114,11 @@ parentElement.insertBefore(newElement, theFirstChild);
 
 <h2 id="Browser_Compatibility" name="Browser_Compatibility">Browser compatibility</h2>
 
-
-
 <p>{{Compat("api.Node.insertBefore")}}</p>
 
 <h2 id="Specifications" name="Specifications">Specifications</h2>
 
-<table class="spectable standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM WHATWG','#dom-node-insertbefore','Node.insertBefore')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>Fixes errors in the insertion algorithm</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM4','#dom-node-insertbefore','Node.insertBefore')}}</td>
-   <td>{{Spec2('DOM4')}}</td>
-   <td>Describes the algorithm in more detail</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM3 Core','core.html#ID-952280727','Node.insertBefore')}}</td>
-   <td>{{Spec2('DOM3 Core')}}</td>
-   <td>No notable changes</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM2 Core','core.html#ID-952280727','Node.insertBefore')}}</td>
-   <td>{{Spec2('DOM2 Core')}}</td>
-   <td>No notable changes</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM1','level-one-core.html#method-insertBefore','Node.insertBefore')}}</td>
-   <td>{{Spec2('DOM1')}}</td>
-   <td>Introduced</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
 <h2 id="See_also" name="See_also">See also</h2>
 

--- a/files/zh-tw/web/api/node/textcontent/index.html
+++ b/files/zh-tw/web/api/node/textcontent/index.html
@@ -74,36 +74,13 @@ document.getElementById("divA").textContent = "This is some text";
 }
 </pre>
 
+<h2 id="Specifications">規範</h2>
+
+{{Specifications}}
+
 <h2 id="瀏覽器相容性">瀏覽器相容性</h2>
 
-{{Compat("api.Node.textContent")}}
-
-<h2 id="Specifications" name="Specifications">規範</h2>
-
-<table class="spectable standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM WHATWG','#dom-node-textcontent','Node.textContent')}}</td>
-   <td>{{Spec2('DOM WHATWG')}}</td>
-   <td>No changes versus DOM4</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM4','#dom-node-textcontent','Node.textContent')}}</td>
-   <td>{{Spec2('DOM4')}}</td>
-   <td> </td>
-  </tr>
-  <tr>
-   <td>{{SpecName('DOM3 Core','core.html#Node3-textContent','Node.textContent')}}</td>
-   <td>{{Spec2('DOM3 Core')}}</td>
-   <td>Introduced</td>
-  </tr>
- </tbody>
-</table>
+{{Compat}}
 
 <h2 id="參見">參見</h2>
 

--- a/files/zh-tw/web/api/webvr_api/index.html
+++ b/files/zh-tw/web/api/webvr_api/index.html
@@ -127,29 +127,13 @@ translation_of: Web/API/WebVR_API
 
 <h2 id="Specifications">Specifications</h2>
 
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName("GamepadExtensions")}}</td>
-   <td>{{Spec2("GamepadExtensions")}}</td>
-   <td>Defines the <a href="/en-US/docs/Web/API/Gamepad_API#Experimental_Gamepad_extensions">Experimental Gamepad extensions</a>.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('WebVR 1.1')}}</td>
-   <td>{{Spec2('WebVR 1.1')}}</td>
-   <td>Initial definition</td>
-  </tr>
- </tbody>
-</table>
+This API was specified in the old <a href="https://immersive-web.github.io/webvr/spec/1.1/">WebVR API</a> that has been superseded by the <a href="https://immersive-web.github.io/webxr/">WebXR Device API</a>. It is no longer on track to becoming a standard.
+
+Until all browsers have implemented the new <a href="/zh-TW/docs/Web/API/WebXR_Device_API/Fundamentals">WebXR APIs</a>, it is recommended to rely on frameworks, like <a href="https://aframe.io/">A-Frame</a>, <a href="https://www.babylonjs.com/">Babylon.js</a>, or <a href="https://threejs.org/">Three.js</a>, or a <a href="https://github.com/immersive-web/webxr-polyfill">polyfill</a>, to develop WebXR applications that will work across all browsers <a href="https://developer.oculus.com/documentation/web/port-vr-xr/">[1]</a>.
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-{{Compat("api.Navigator.getVRDisplays")}}
+{{Compat}}
 
 <h2 id="See_also">See also</h2>
 

--- a/files/zh-tw/web/api/window/navigator/index.html
+++ b/files/zh-tw/web/api/window/navigator/index.html
@@ -47,12 +47,12 @@ alert("You are using: " + sBrowser);</pre>
 
 console.log(getBrowserId());</pre>
 
-<h2 id="Specification" name="Specification">規範</h2>
+<h2 id="Specification">規範</h2>
 
-<ul>
- <li>{{SpecName("HTML5 W3C", "webappapis.html#the-navigator-object","window.navigator")}}</li>
- <li>{{SpecName("HTML5.1", "webappapis.html#the-navigator-object", "window.navigator")}}</li>
- <li>{{SpecName("HTML WHATWG", "timers.html#the-navigator-object", "window.navigator")}}</li>
-</ul>
+{{Specifications}}
+
+<h2 id="瀏覽器相容性">瀏覽器相容性</h2>
+
+{{Compat}}
 
 <h2 id="See_also" name="See_also">參見</h2>

--- a/files/zh-tw/web/css/css_selectors/index.html
+++ b/files/zh-tw/web/css/css_selectors/index.html
@@ -80,41 +80,9 @@ translation_of: Web/CSS/CSS_Selectors
 
 <h2 id="規範">規範</h2>
 
-<table>
- <thead>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td>{{SpecName("CSS4 Selectors")}}</td>
-   <td>{{Spec2("CSS4 Selectors")}}</td>
-   <td>Added the <code>||</code> column combinator, grid structural selectors, logical combinators, location, time-demensional, resource state, linguistic and UI pseudo-classes, modifier for ASCII case-sensitive and case-insensitive attribute value selection.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS3 Selectors")}}</td>
-   <td>{{Spec2("CSS3 Selectors")}}</td>
-   <td>Added the <code>~</code> general sibling combinator and tree-structural pseudo-classes.<br>
-    Made pseudo-elements use a <code>::</code> double-colon prefix. Additional attribute selectors</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS2.1", "selector.html")}}</td>
-   <td>{{Spec2("CSS2.1")}}</td>
-   <td>Added the <code>&gt;</code> child and <code>+</code> adjacent sibling combinators.<br>
-    Added the <strong>universal</strong> and <strong>attribute</strong> selectors.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName("CSS1")}}</td>
-   <td>{{Spec2("CSS1")}}</td>
-   <td>Initial definition.</td>
-  </tr>
- </tbody>
-</table>
+{{Specifications}}
 
-<p>See the <a href="/zh-TW/docs/Web/CSS/Pseudo-classes#Specifications">pseudo-class</a> and <a href="/zh-TW/docs/Web/CSS/Pseudo-elements#Specifications">pseudo-element</a> specification tables for details on those.</p>
+<p>See the <a href="/zh-TW/docs/Web/CSS/Pseudo-classes#Specifications">pseudo-class</a> and <a href="/zh-TW/docs/Web/CSS/Pseudo-elements#Specifications">pseudo-element</a> specification tables for details on those.</p>
 
 <h2 id="參見">參見</h2>
 

--- a/files/zh-tw/web/events/index.html
+++ b/files/zh-tw/web/events/index.html
@@ -1920,7 +1920,11 @@ translation_of: Web/Events
 
 <p>{{event("beforeunload")}}, {{event("localized")}}, <code><a href="/zh-TW/docs/Web/Reference/Events/message_webworker">message</a></code>, <code><a href="/zh-TW/docs/Web/Reference/Events/message_webmessaging">message</a></code>, <code><a href="/zh-TW/docs/Web/Reference/Events/message_serversentevents">message</a></code>, <a href="/zh-TW/docs/Web/Reference/Events/MozAfterPaint">MozAfterPaint</a>, {{event("moztimechange")}}, <code><a href="/zh-TW/docs/Web/Reference/Events/open_serversentevents">open</a></code>, {{event("show")}}</p>
 
-<h2 id="延伸閱讀">延伸閱讀</h2>
+<h2 id="規範">規範</h2>
+
+{{Specifications}}
+
+<h2 id="參見">參見</h2>
 
 <ul>
  <li>{{domxref("Event")}}</li>

--- a/files/zh-tw/web/javascript/data_structures/index.html
+++ b/files/zh-tw/web/javascript/data_structures/index.html
@@ -254,38 +254,6 @@ Infinity
 
 <p><code>typeof</code> 運算子可以幫助你找到你的變數型別，請閱讀〈<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof">reference page</a> 〉來取得更多細節及邊緣案例。</p>
 
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ES1')}}</td>
-   <td>{{Spec2('ES1')}}</td>
-   <td>Initial definition.</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('ES5.1', '#sec-8', 'Types')}}</td>
-   <td>{{Spec2('ES5.1')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('ES6', '#sec-ecmascript-data-types-and-values', 'ECMAScript Data Types and Values')}}</td>
-   <td>{{Spec2('ES6')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-ecmascript-data-types-and-values', 'ECMAScript Data Types and Values')}}</td>
-   <td>{{Spec2('ESDraft')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
-
 <h2 id="See_also">See also</h2>
 
 <ul>

--- a/files/zh-tw/web/javascript/reference/statements/index.html
+++ b/files/zh-tw/web/javascript/reference/statements/index.html
@@ -94,46 +94,7 @@ translation_of: Web/JavaScript/Reference/Statements
  <dd>Extends the scope chain for a statement.</dd>
 </dl>
 
-<h2 id="規範">規範</h2>
-
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">技術規格</th>
-   <th scope="col">狀態</th>
-   <th scope="col">備註</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ES1', '#sec-12', 'Statements')}}</td>
-   <td>{{Spec2('ES1')}}</td>
-   <td>Initial definition</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('ES3', '#sec-12', 'Statements')}}</td>
-   <td>{{Spec2('ES3')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('ES5.1', '#sec-12', 'Statements')}}</td>
-   <td>{{Spec2('ES5.1')}}</td>
-   <td></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('ES6', '#sec-ecmascript-language-statements-and-declarations', 'ECMAScript Language: Statements and Declarations')}}</td>
-   <td>{{Spec2('ES6')}}</td>
-   <td>New: function*, let, for...of, yield, class</td>
-  </tr>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-ecmascript-language-statements-and-declarations', 'ECMAScript Language: Statements and Declarations')}}</td>
-   <td>{{Spec2('ESDraft')}}</td>
-   <td></td>
-  </tr>
- </tbody>
-</table>
-
 <h2 id="瀏覽器相容性">瀏覽器相容性</h2>
-
-
 
 <p>{{Compat("javascript.statements")}}</p>
 

--- a/files/zh-tw/web/javascript/reference/strict_mode/index.html
+++ b/files/zh-tw/web/javascript/reference/strict_mode/index.html
@@ -328,33 +328,6 @@ function baz() { // kosher
 
 <p>The major browsers now implement strict mode. However, don't blindly depend on it since there still are numerous <a class="external" href="http://caniuse.com/use-strict" rel="external" title="caniuse.com availability of strict mode">Browser versions used in the wild that only have partial support for strict mode</a> or do not support it at all (e.g. Internet Explorer below version 10!). <em>Strict mode changes semantics.</em> Relying on those changes will cause mistakes and errors in browsers which don't implement strict mode. Exercise caution in using strict mode, and back up reliance on strict mode with feature tests that check whether relevant parts of strict mode are implemented. Finally, make sure to <em>test your code in browsers that do and don't support strict mode</em>. If you test only in browsers that don't support strict mode, you're very likely to have problems in browsers that do, and vice versa.</p>
 
-<h2 id="Specifications">Specifications</h2>
-
-<table class="standard-table">
- <tbody>
-  <tr>
-   <th scope="col">Specification</th>
-   <th scope="col">Status</th>
-   <th scope="col">Comment</th>
-  </tr>
-  <tr>
-   <td>{{SpecName('ES5.1', '#sec-10.1.1', 'Strict Mode Code')}}</td>
-   <td>{{Spec2('ES5.1')}}</td>
-   <td>Initial definition. See also: <a href="http://www.ecma-international.org/ecma-262/5.1/#sec-C">Strict mode restriction and exceptions</a></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('ES6', '#sec-strict-mode-code', 'Strict Mode Code')}}</td>
-   <td>{{Spec2('ES6')}}</td>
-   <td><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-strict-mode-of-ecmascript">Strict mode restriction and exceptions</a></td>
-  </tr>
-  <tr>
-   <td>{{SpecName('ESDraft', '#sec-strict-mode-code', 'Strict Mode Code')}}</td>
-   <td>{{Spec2('ESDraft')}}</td>
-   <td><a href="https://tc39.github.io/ecma262/#sec-strict-mode-of-ecmascript">Strict mode restriction and exceptions</a></td>
-  </tr>
- </tbody>
-</table>
-
 <h2 id="See_also">See also</h2>
 
 <ul>

--- a/files/zh-tw/webassembly/index.md
+++ b/files/zh-tw/webassembly/index.md
@@ -72,13 +72,11 @@ WebAssembly 被設計來與 JavaScript 協同工作 —— 藉由 WebAssembly �
 
 ## 規範
 
-| Specification                            | Status                               | Comment                                         |
-| ---------------------------------------- | ------------------------------------ | ----------------------------------------------- |
-| {{SpecName('WebAssembly JS')}} | {{Spec2('WebAssembly JS')}} | Initial draft definition of the JavaScript API. |
+{{Specifications}}
 
 ## 瀏覽器相容性
 
-{{Compat("javascript.builtins.WebAssembly")}}
+{{Compat}}
 
 ## 參見
 


### PR DESCRIPTION
continue #6352.

It's the last part of this progress. Other `SpecName` and `Spec2` macros should be replaced by removing conflict documents and document sync.