### PR TITLE
Update index.html

### DIFF
--- a/files/es/learn/html/introduction_to_html/the_head_metadata_in_html/index.html
+++ b/files/es/learn/html/introduction_to_html/the_head_metadata_in_html/index.html
@@ -229,7 +229,7 @@ y aplicaciones HTML5. También documenta productos Mozilla, como el sistema oper
 
 <ul>
  <li>
-  <p>El elemento {{HTMLElement("link")}} siempre debe ir dentro del {{HTMLElement("header")}} de tu documento. Este toma dos atributos, <code>rel="stylesheet"</code>, que indica que es la hoja de estilo del documento, y <code>href</code>, que contiene la ruta al archivo de la hoja de estilo:</p>
+  <p>El elemento {{HTMLElement("link")}} siempre debe ir dentro del {{HTMLElement("head")}} de tu documento. Este toma dos atributos, <code>rel="stylesheet"</code>, que indica que es la hoja de estilo del documento, y <code>href</code>, que contiene la ruta al archivo de la hoja de estilo:</p>
 
   <pre class="brush: html notranslate">&lt;link rel="stylesheet" href="my-css-file.css"&gt;</pre>
  </li>


### PR DESCRIPTION
El elemento <link> siempre debe ir dentro del <header> (incorrecto)
El elemento <link> siempre debe ir dentro del <head> (corregido)