### PR TITLE
fix the code sample to got what's expected

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/function/apply/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/function/apply/index.md
@@ -129,7 +129,7 @@ Function.prototype.construct = function (aArgs) {
 使用示例：
 
 ```js
-function MyConstructor(arguments) {
+function MyConstructor() {
   for (let nProp = 0; nProp < arguments.length; nProp++) {
     this['property' + nProp] = arguments[nProp];
   }


### PR DESCRIPTION
```JS
Function.prototype.construct = function (aArgs) {
  let oNew = Object.create(this.prototype);
  this.apply(oNew, aArgs);
  return oNew;
}

function MyConstructor(arguments) {               //  This will lead to 'console.log(myInstance.property1)' logs undefined
  for (let nProp = 0; nProp < arguments.length; nProp++) {
    this['property' + nProp] = arguments[nProp];
  }
}

let myArray = [4, 'Hello world!', false];
let myInstance = MyConstructor.construct(myArray);

console.log(myInstance.property1);                // expected logs 'Hello world!'
console.log(myInstance instanceof MyConstructor); // expected  logs 'true'
console.log(myInstance.constructor);              // expected  logs 'MyConstructor'
```