### PR TITLE
Syntax error in translate to portuguese

### DIFF
--- a/files/pt-br/web/javascript/reference/global_objects/map/entries/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/map/entries/index.md
@@ -34,7 +34,7 @@ Um novo objeto iterador {{jsxref("Map")}}.
 let myMap = new Map()
 myMap.set('0', 'foo')
 myMap.set(1, 'bar')
-myMap.set({}, 'baz)
+myMap.set({}, 'baz')
 
 let mapIter = myMap.entries()
 


### PR DESCRIPTION
Fix syntax error in translate to pt-br

[Link to doc](https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Map/entries#exemplos)