### PR TITLE
Remove `{{anch}}` for korean locale

### DIFF
--- a/files/ko/web/javascript/reference/classes/index.html
+++ b/files/ko/web/javascript/reference/classes/index.html
@@ -59,7 +59,7 @@ console.log(Rectangle.name);
 </pre>
 
 <div class="note">
-<p><strong>참고:</strong> 클래스 <strong>표현식</strong>에는 {{anch ( "Class 선언")}} 섹션에 설명된 것과 동일한 호이스팅 제한이 적용됩니다.</p>
+<p><strong>참고:</strong> 클래스 <strong>표현식</strong>에는 <a href="#class_선언">Class 선언</a> 섹션에 설명된 것과 동일한 호이스팅 제한이 적용됩니다.</p>
 </div>
 
 <h2 id="Class_body_와_메서드_정의">Class body 와 메서드 정의</h2>


### PR DESCRIPTION
Part of #4614, poking @mdn/yari-content-ko so that we can merge this soon and remove all `{{anch}}`s from `translated-content` :)