### PR TITLE
fix the broken link and update html format

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ subdirectories:
 
 If you want to add a guide to document some specific guidelines for your locale
 and it does not already appear here, you are welcome to add one, or
-[talk to the locale teams](https://github.com/mdn/translated-content/blob/docs-readme/README.md)
+[talk to the locale teams](https://github.com/mdn/translated-content/blob/main/PEERS_GUIDELINES.md#review-teams)
 about it. Similarly, if you can think of a good general guideline that you'd
 like to add here, feel free to create an issue to talk about it.
 
@@ -61,7 +61,7 @@ elements that aren't strictly necessary, for example:
 
 ```html
 <p>The
-  <code><strong>HTMLCanvasElement</strong></code><strong><code>.transferControlToOffscreen()</code></strong>
+  <strong><code>HTMLCanvasElement.transferControlToOffscreen()</code></strong>
   method transfers control to an {{domxref("OffscreenCanvas")}} object, either on the main
   thread or on a worker.</p>
 

--- a/docs/zh-cn/translation-guide.md
+++ b/docs/zh-cn/translation-guide.md
@@ -1,6 +1,6 @@
 # 针对 MDN 文档的本地化指南
 
-本文是针对简体中文（zh-CN）文档的翻译指南。如果你所使用的语言尚未有翻译指南，而你又希望新建的话，欢迎你联系[我们负责该语言的翻译团队](https://github.com/mdn/translated-content/blob/docs-readme/README.md)。
+本文是针对简体中文（zh-CN）文档的翻译指南。如果你所使用的语言尚未有翻译指南，而你又希望新建的话，欢迎你联系[我们负责该语言的翻译团队](https://github.com/mdn/translated-content/blob/main/PEERS_GUIDELINES.md#review-teams)。
 
 同样地，如果你对本文的指南有任何改进的建议，请提出问题（issue）或发起 PR。我们对此表示欢迎。下面进入简体中文翻译指南的正文部分。
 

--- a/docs/zh-tw/translation-guide.md
+++ b/docs/zh-tw/translation-guide.md
@@ -1,6 +1,6 @@
 # 針對MDN翻譯內容的一般指導原則
 
-本文是針對正體中文（zh-TW）地區的翻譯指南。如果你所在的地區尚未有文件指南，而你又想新建的話，歡迎你開始建立或聯絡[我們負責該地區的翻譯團隊](https://github.com/mdn/translated-content/blob/docs-readme/README.md)。
+本文是針對正體中文（zh-TW）地區的翻譯指南。如果你所在的地區尚未有文件指南，而你又想新建的話，歡迎你開始建立或聯絡[我們負責該地區的翻譯團隊](https://github.com/mdn/translated-content/blob/main/PEERS_GUIDELINES.md#review-teams)。
 
 同樣的，如果你對一般指導原則有一些不錯的想法想要補充，不用客氣，去發起問題（issue）來跟我們談談吧。以下進入正體中文翻譯指導原則的主要內容。
 


### PR DESCRIPTION
Fixes #6488:

- mentioned by @awxiaoxian2020, the link to locale team does not exist, so update this link to [review team](https://github.com/mdn/translated-content/blob/main/PEERS_GUIDELINES.md#review-teams).
- The html format (`<code><strong>HTMLCanvasElement</strong></code><strong><code>.transferControlToOffscreen()</code></strong>`) is not used anymore, update it to `<strong><code>HTMLCanvasElement.transferControlToOffscreen()</code></strong>` which is `` **`HTMLCanvasElement.transferControlToOffscreen()`** `` in raw markdown
