### PR TITLE
ci: add github action to check for duplicate index.* files

### DIFF
--- a/.github/workflows/pr-check_duplicates.yml
+++ b/.github/workflows/pr-check_duplicates.yml
@@ -1,0 +1,24 @@
+# This is a copy of
+# https://github.com/mdn/content/blob/main/.github/workflows/pr-check_duplicates.yml
+name: Check for duplicates
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - files/**/index.*
+      - .github/workflows/pr-check_duplicates.yml
+
+jobs:
+  check_duplicates:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check for duplicates
+        run: |
+          find files -name 'index.*' -type f -printf '%h\n' | sort | uniq -d > dupes.txt
+          cat dupes.txt
+          [ ! -s dupes.txt ]


### PR DESCRIPTION
duplicates make the yari build behave weirdly
tested locally with https://github.com/nektos/act

https://github.com/mdn/translated-content/pull/6456 and #7015/#7745 need to be merged first

I'll open the PR against the content repo after this one is merged