### PR TITLE
Update core dev team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 # ----------------------------------------------------------------------------
 # DEFAULT OWNERS
 # ----------------------------------------------------------------------------
-*    @mdn/core-yari-dev
+*    @mdn/core-dev
 
 # ----------------------------------------------------------------------------
 # DEFAULT CONTENT OWNER(S)
@@ -59,6 +59,6 @@
 # tries to change any one or more of these files should be escalated to the
 # owners specified here.
 # ----------------------------------------------------------------------------
-/.github/     @mdn/core-yari-dev
-/*            @mdn/core-yari-dev
-/*.md         @mdn/core-yari-dev @mdn/core-yari-content
+/.github/     @mdn/core-dev
+/*            @mdn/core-dev
+/*.md         @mdn/core-dev @mdn/core-yari-content


### PR DESCRIPTION
The `core-yari-dev` team no longer exists, so this PR updates the codeowners. 

N.B. Github says there are errors because it seems that `core-dev` and `core-yari-content` aren't explicitly given access to the `translated-content` repo (cc. @schalkneethling / @Rumyra)