### PR TITLE
transform

### DIFF
--- a/files/zh-cn/web/api/transformstream/index.md
+++ b/files/zh-cn/web/api/transformstream/index.md
@@ -1,0 +1,149 @@
+---
+title: TransformStream
+slug: Web/API/TransformStream
+page-type: web-api-interface
+tags:
+  - API
+  - Interface
+  - Reference
+  - Streams API
+translation_of: Web/api/TransformStream
+---
+{{APIRef("Streams")}}
+
+[Streams API](/zh-CN/docs/Web/API/Streams_API) 接口的 `TransformStream` 表示一组可转换的数据。
+
+`TransformStream` 是一个 {{glossary("Transferable objects","transferable object")}}。
+
+## 构造函数
+
+- {{domxref("TransformStream.TransformStream", "TransformStream()")}}
+  - : 从给定的处理程序中创建并且返回一个转换流对象。
+
+## 属性
+
+- {{domxref("TransformStream.readable")}} {{readonlyInline}}
+  - : 转换流的 `readable` 端。
+- {{domxref("TransformStream.writable")}} {{readonlyInline}}
+  - : 转换流的 `writable` 端。
+
+## 方法
+
+无
+
+## 示例
+
+### Anything-to-uint8array stream
+
+在下面的示例中，一个转换流通过它接受所有分块的 {{jsxref("Uint8Array")}} 值。
+
+```js
+const transformContent = {
+  start() {}, // required.
+  async transform(chunk, controller) {
+    chunk = await chunk
+    switch (typeof chunk) {
+      case 'object':
+        // just say the stream is done I guess
+        if (chunk === null) controller.terminate()
+        else if (ArrayBuffer.isView(chunk))
+          controller.enqueue(new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength))
+        else if (Array.isArray(chunk) && chunk.every(value => typeof value === 'number'))
+          controller.enqueue(new Uint8Array(chunk))
+        else if ('function' === typeof chunk.valueOf && chunk.valueOf() !== chunk)
+          this.transform(chunk.valueOf(), controller) // hack
+        else if ('toJSON' in chunk) this.transform(JSON.stringify(chunk), controller)
+        break
+      case 'symbol':
+        controller.error("Cannot send a symbol as a chunk part")
+        break
+      case 'undefined':
+        controller.error("Cannot send undefined as a chunk part")
+        break
+      default:
+        controller.enqueue(this.textencoder.encode(String(chunk)))
+        break
+    }
+  },
+  flush() { /* do any destructor work here */ }
+}
+class AnyToU8Stream extends TransformStream {
+  constructor() {
+    super({...transformContent, textencoder: new TextEncoder()})
+  }
+}
+```
+
+### Polyfilling TextEncoderStream and TextDecoderStream
+
+注意，通过原生构造函数的方式已被弃用。它旨在不受支持的平台作为一个 polyfill。
+
+```js
+const tes = {
+  start(){this.encoder = new TextEncoder()},
+  transform(chunk, controller) {
+    controller.enqueue(this.encoder.encode(chunk))
+  }
+}
+let _jstes_wm = new WeakMap(); /* info holder */
+class JSTextEncoderStream extends TransformStream {
+  constructor() {
+    let t = {...tes}
+    super(t)
+    _jstes_wm.set(this, t)
+  }
+  get encoding() {return _jstes_wm.get(this).encoder.encoding}
+}
+```
+
+类似地，`TextDecoderStream` 可以这样写:
+
+```js
+const tds = {
+  start(){
+    this.decoder = new TextDecoder(this.encoding, this.options)
+  },
+  transform(chunk, controller) {
+    controller.enqueue(this.decoder.decode(chunk, { stream: true }))
+  }
+}
+let _jstds_wm = new WeakMap(); /* info holder */
+class JSTextDecoderStream extends TransformStream {
+  constructor(encoding = 'utf-8', {...options} = {}) {
+    let t = {...tds, encoding, options}
+    super(t)
+    _jstds_wm.set(this, t)
+  }
+  get encoding() {return _jstds_wm.get(this).decoder.encoding}
+  get fatal() {return _jstds_wm.get(this).decoder.fatal}
+  get ignoreBOM() {return _jstds_wm.get(this).decoder.ignoreBOM}
+}
+```
+
+### Chaining multiple ReadableStreams together
+
+这是有用的，可以连接多个流。示例包括构建一个渐进式加载和渐进式流的 PWA。
+
+```js
+let responses = [ /* conjoined response tree */ ]
+let {readable, writable} = new TransformStream
+responses.reduce(
+  (a, res, i, arr) => a.then(() => res.pipeTo(writable, {preventClose: (i+1) !== arr.length})),
+  Promise.resolve()
+)
+```
+
+注意这种影响是不可恢复的。
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}
+
+## 参见
+
+- [WHATWG Stream Visualizer](https://whatwg-stream-visualizer.glitch.me/),用于可读、可写和转换流的基本可视化。
+- [Streams—The Definitive Guide](https://web.dev/streams/)

--- a/files/zh-cn/web/api/transformstream/index.md
+++ b/files/zh-cn/web/api/transformstream/index.md
@@ -67,6 +67,7 @@ const transformContent = {
   },
   flush() { /* do any destructor work here */ }
 }
+
 class AnyToU8Stream extends TransformStream {
   constructor() {
     super({...transformContent, textencoder: new TextEncoder()})
@@ -85,10 +86,12 @@ const tes = {
     controller.enqueue(this.encoder.encode(chunk))
   }
 }
+
 let _jstes_wm = new WeakMap(); /* info holder */
 class JSTextEncoderStream extends TransformStream {
   constructor() {
     let t = {...tes}
+
     super(t)
     _jstes_wm.set(this, t)
   }
@@ -107,10 +110,12 @@ const tds = {
     controller.enqueue(this.decoder.decode(chunk, { stream: true }))
   }
 }
+
 let _jstds_wm = new WeakMap(); /* info holder */
 class JSTextDecoderStream extends TransformStream {
   constructor(encoding = 'utf-8', {...options} = {}) {
     let t = {...tds, encoding, options}
+
     super(t)
     _jstds_wm.set(this, t)
   }
@@ -127,13 +132,14 @@ class JSTextDecoderStream extends TransformStream {
 ```js
 let responses = [ /* conjoined response tree */ ]
 let {readable, writable} = new TransformStream
+
 responses.reduce(
   (a, res, i, arr) => a.then(() => res.pipeTo(writable, {preventClose: (i+1) !== arr.length})),
   Promise.resolve()
 )
 ```
 
-注意这种影响是不可恢复的。
+注意，这种影响是不可恢复的。
 
 ## 规范
 
@@ -145,5 +151,5 @@ responses.reduce(
 
 ## 参见
 
-- [WHATWG Stream Visualizer](https://whatwg-stream-visualizer.glitch.me/),用于可读、可写和转换流的基本可视化。
+- [WHATWG Stream Visualizer](https://whatwg-stream-visualizer.glitch.me/)，用于可读、可写和转换流的基本可视化。
 - [Streams—The Definitive Guide](https://web.dev/streams/)

--- a/files/zh-cn/web/api/transformstream/index.md
+++ b/files/zh-cn/web/api/transformstream/index.md
@@ -13,7 +13,7 @@ translation_of: Web/api/TransformStream
 
 [Streams API](/zh-CN/docs/Web/API/Streams_API) 接口的 `TransformStream` 表示一组可转换的数据。
 
-`TransformStream` 是一个 {{glossary("Transferable objects","transferable object")}}。
+`TransformStream` 是一个{{glossary("Transferable objects","可转移对象")}}。
 
 ## 构造函数
 
@@ -33,9 +33,9 @@ translation_of: Web/api/TransformStream
 
 ## 示例
 
-### Anything-to-uint8array stream
+### 将任意对象转换为 uint8array 数组
 
-在下面的示例中，一个转换流通过它接受所有分块的 {{jsxref("Uint8Array")}} 值。
+在下面的示例中，一个转换流将其接收的所有分块转换为 {{jsxref("Uint8Array")}}。。
 
 ```js
 const transformContent = {
@@ -75,9 +75,9 @@ class AnyToU8Stream extends TransformStream {
 }
 ```
 
-### Polyfilling TextEncoderStream and TextDecoderStream
+### TextEncoderStream 和 TextDecoderStream 的 polyfill
 
-注意，通过原生构造函数的方式已被弃用。它旨在不受支持的平台作为一个 polyfill。
+注意，通过原生构造函数已弃用它。它旨在为不受支持的平台提供一个 polyfill。
 
 ```js
 const tes = {
@@ -125,9 +125,9 @@ class JSTextDecoderStream extends TransformStream {
 }
 ```
 
-### Chaining multiple ReadableStreams together
+### ReadableStreams 链
 
-这是有用的，可以连接多个流。示例包括构建一个渐进式加载和渐进式流的 PWA。
+这是一个连接多个流很有用的方法。示例包括构建一个渐进式加载和渐进式流的 PWA。
 
 ```js
 let responses = [ /* conjoined response tree */ ]

--- a/files/zh-cn/web/api/transformstream/index.md
+++ b/files/zh-cn/web/api/transformstream/index.md
@@ -33,7 +33,7 @@ translation_of: Web/api/TransformStream
 
 ## 示例
 
-### 将任意对象转换为 uint8array 数组
+### 将任意对象转换为 uint8 数组
 
 在下面的示例中，一个转换流将其接收的所有分块转换为 {{jsxref("Uint8Array")}}。。
 
@@ -125,7 +125,7 @@ class JSTextDecoderStream extends TransformStream {
 }
 ```
 
-### ReadableStreams 链
+### ReadableStream 链
 
 这是一个连接多个流很有用的方法。示例包括构建一个渐进式加载和渐进式流的 PWA。
 


### PR DESCRIPTION
* 示例中的标题并没有翻译,没有想到很好的翻译,标题下的文字解释应该够了
* `Polyfilling TextEncoderStream and TextDecoderStream`下的 `polyfill` 也没有翻译,不翻译会更好一点