### PR TITLE
Abreviatura para arrays

### DIFF
--- a/files/es/web/javascript/reference/global_objects/array/reverse/index.html
+++ b/files/es/web/javascript/reference/global_objects/array/reverse/index.html
@@ -17,7 +17,7 @@ original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/reverse
 
 <h2 id="Sintaxis" name="Sintaxis">Sintaxis</h2>
 
-<pre class="syntaxbox"><var>a</var>.reverse()</pre>
+<pre class="syntaxbox"><var>arr</var>.reverse()</pre>
 
 <h3 id="Valor devuelto" name="Valor devuelto">Valor devuelto</h3>
 

--- a/files/es/web/javascript/reference/global_objects/array/reverse/index.html
+++ b/files/es/web/javascript/reference/global_objects/array/reverse/index.html
@@ -17,7 +17,7 @@ original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/reverse
 
 <h2 id="Sintaxis" name="Sintaxis">Sintaxis</h2>
 
-<pre class="syntaxbox"><var>arr</var>.reverse()</pre>
+<pre class="syntaxbox">reverse()</pre>
 
 <h3 id="Valor devuelto" name="Valor devuelto">Valor devuelto</h3>
 


### PR DESCRIPTION
A lo largo de toda la documentación de Arrays se observa que en la sintaxis se usa la abreviatura "arr" y no "a" para hacer referencia al objeto sobre el cual se aplica el método