### PR TITLE
zh-CN:translate TextDecoderStream-new

### DIFF
--- a/files/zh-cn/web/api/textdecoderstream/textdecoderstream/index.md
+++ b/files/zh-cn/web/api/textdecoderstream/textdecoderstream/index.md
@@ -11,7 +11,7 @@ translation_of: Web/api/TextDecoderStream/TextDecoderStream
 ---
 {{APIRef("Encoding API")}}
 
-**`TextDecoderStream()`** 构造函数创建一个新的 {{domxref("TextDecoderStream")}} 对象，该对象用于将二进制编码的文本流转换为二进制字符串。
+**`TextDecoderStream()`** 构造函数创建一个新的 {{domxref("TextDecoderStream")}} 对象，该对象用于将二进制编码的文本流转换为字符串。
 
 ## 语法
 
@@ -23,10 +23,10 @@ new TextDecoderStream(label, options)
 ### 参数
 
 - `label`
-  - : 默认为 `utf-8` 的字符串。可能是 [任意有效的编码](/en-US/docs/Web/API/Encoding_API/Encodings)。
+  - : 默认为 `utf-8` 的字符串。可以是[任意有效的编码](/zh-CN/docs/Web/API/Encoding_API/Encodings)。
 - `options` {{optional_inline}}
 
-  - : 一个具有属性的 `TextDecoderOptions` 字典:
+  - : 一个具有属性的 `TextDecoderOptions` 对象：
 
     - `fatal`
       - : 一个布尔值，表示错误的模式。如果是 true，则在 decoder 遇到错误时抛出一个 {{domxref("DOMException")}}。默认值是 `false`。

--- a/files/zh-cn/web/api/textdecoderstream/textdecoderstream/index.md
+++ b/files/zh-cn/web/api/textdecoderstream/textdecoderstream/index.md
@@ -1,0 +1,49 @@
+---
+title: TextDecoderStream()
+slug: Web/API/TextDecoderStream/TextDecoderStream
+page-type: web-api-constructor
+tags:
+  - API
+  - Constructor
+  - Reference
+  - TextDecoderStream
+translation_of: Web/api/TextDecoderStream/TextDecoderStream
+---
+{{APIRef("Encoding API")}}
+
+**`TextDecoderStream()`** 构造函数创建一个新的 {{domxref("TextDecoderStream")}} 对象，该对象用于将二进制编码的文本流转换为二进制字符串。
+
+## 语法
+
+```js
+new TextDecoderStream(label)
+new TextDecoderStream(label, options)
+```
+
+### 参数
+
+- `label`
+  - : 默认为 `utf-8` 的字符串。可能是 [任意有效的编码](/en-US/docs/Web/API/Encoding_API/Encodings)。
+- `options` {{optional_inline}}
+
+  - : 一个具有属性的 `TextDecoderOptions` 字典:
+
+    - `fatal`
+      - : 一个布尔值，表示错误的模式。如果是 true，则在 decoder 遇到错误时抛出一个 {{domxref("DOMException")}}。默认值是 `false`。
+
+## 示例
+
+以下示例演示如何从一个 {{domxref("fetch()")}} 中获取并解码二进制数据。如果没有传递任何 `label`，数据的解码类型为 UTF-8。
+
+```js
+const response = await fetch("https://example.com");
+const stream = response.body.pipeThrough(new TextDecoderStream());
+```
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}


### PR DESCRIPTION
`dictionary`: 翻译成了字典(**直译,不知道翻译成什么好**),更广义上说是一个 object
`label`: 我看了以下链接,都是编码,所以翻译成`编码`
`decoder`: 解码. 可翻可不翻,翻译了也并不是很重要