### PR TITLE
fix[pt-BR]: color background hiding part of the description text of `import.meta`

### DIFF
--- a/files/pt-br/web/javascript/reference/operators/import.meta/index.html
+++ b/files/pt-br/web/javascript/reference/operators/import.meta/index.html
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Reference/Statements/import.meta
 ---
 <div>{{JSSidebar("Statements")}}</div>
 
-<p><code><font face="Arial, x-locale-body, sans-serif"><span style="background-color: #ffffff;">O objeto mostra o </span></font><strong>import.meta</strong></code> mostra os metadados específicos do contexto de um módulo JavaScript. Ele contém informações sobre o módulo, como a sua URL.</p>
+<p><font face="Arial, x-locale-body, sans-serif">O objeto </font><code><strong>import.meta</strong></code> mostra os metadados específicos do contexto de um módulo JavaScript. Ele contém informações sobre o módulo, como a sua URL.</p>
 
 <h2 id="Sintaxe">Sintaxe </h2>
 

--- a/files/pt-br/web/javascript/reference/operators/import.meta/index.html
+++ b/files/pt-br/web/javascript/reference/operators/import.meta/index.html
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Reference/Statements/import.meta
 ---
 <div>{{JSSidebar("Statements")}}</div>
 
-<p><font face="Arial, x-locale-body, sans-serif">O objeto </font><code><strong>import.meta</strong></code> mostra os metadados específicos do contexto de um módulo JavaScript. Ele contém informações sobre o módulo, como a sua URL.</p>
+<p>O objeto <code><strong>import.meta</strong></code> mostra os metadados específicos do contexto de um módulo JavaScript. Ele contém informações sobre o módulo, como a sua URL.</p>
 
 <h2 id="Sintaxe">Sintaxe </h2>
 


### PR DESCRIPTION
- **[fixed unexcepted behavior]** color background was hiding part of the descriptive text of `import.meta` in dark theme

<details>

![Screenshot_6](https://user-images.githubusercontent.com/70824102/176780417-27801e46-9af2-41d3-8bb3-0d3acfe0cf83.png)

</details>