### PR TITLE
update wrong translation of ES2015 Accessors

### DIFF
--- a/files/pt-br/web/javascript/reference/global_objects/object/create/index.html
+++ b/files/pt-br/web/javascript/reference/global_objects/object/create/index.html
@@ -104,8 +104,8 @@ o = Object.create(Object.prototype, {
     get: function() { return 10; },
     set: function(value) { console.log('Setting `o.bar` to', value); }
 /* com os ES5 Accessors nosso código pode ser escrito como:
-    get function() { return 10; },
-    set function(value) { console.log('setting `o.bar` to', value); } */
+    get() { return 10; },
+    set(value) { console.log('setting `o.bar` to', value); } */
   }
 });
 


### PR DESCRIPTION
The last portuguese translation forgot to remove the 'function' part in the code, this syntax is wrong in JS:

old:
 >   **get function()** { return 10; },
 >   **set function(value)** { console.log('setting `o.bar` to', value); }

new corrected:
>    **get()** { return 10; },
>    **set(value)** { console.log('setting `o.bar` to', value); }