### PR TITLE
ja: Geckoのページで不要なテキストを削除

### DIFF
--- a/files/ja/glossary/gecko/index.html
+++ b/files/ja/glossary/gecko/index.html
@@ -23,9 +23,3 @@ translation_of: Glossary/Gecko
 <ul>
  <li>Wikipedia 上の記事： {{interwiki("wikipedia", "Gecko")}}</li>
 </ul>
-
-<h3 id="Technical_Reference" name="Technical_Reference">技術リファレンス</h3>
-
-<ul>
- <li><a href="/ja/docs/Mozilla/Gecko">MDN ドキュメント ー Gecko</a></li>
-</ul>


### PR DESCRIPTION
# 1 概要
/docs/Glossary/Geckoの日本語版ページで、英語版のページでは、記載されていないテキスト「技術リファレンス」があり、またエラーが出ていたので、削除するもの。

- [対象ページの日本語版](https://developer.mozilla.org/ja/docs/Glossary/Gecko)

<img width="1503" alt="修正前" src="https://user-images.githubusercontent.com/74302915/177003038-8d334dd4-8b43-4c02-9d63-fa36a113c763.png">

- [対象ページの英語版](https://developer.mozilla.org/en-US/docs/Glossary/Gecko)

<img width="1505" alt="english page" src="https://user-images.githubusercontent.com/74302915/177003041-a3e0c893-0e2f-4053-b10e-66f72361f5cc.png">




# 2 修正内容
「技術リファレンス」の記載を削除しました
<img width="1505" alt="スクリーンショット 2022-07-02 22 26 31" src="https://user-images.githubusercontent.com/74302915/177003118-211ed7b8-3501-418c-9a46-fc2908d96f27.png">


