### PR TITLE
BookmarkTreeNodeプロパティの日本語の説明を修正

### DIFF
--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.html
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.html
@@ -39,7 +39,7 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNode
  <dt><code>unmodifiable</code> {{optional_inline}}</dt>
  <dd>{{WebExtAPIRef('bookmarks.BookmarkTreeNodeUnmodifiable')}} 型で表現される {{jsxref("string")}} です。このノードが変更不可である理由を表します。変更可能な場合には省略されます。</dd>
  <dt><code>children</code> {{optional_inline}}</dt>
- <dd>各要素がノードの子要素を表す、{{WebExtAPIRef('bookmarks.BookmarkTreeNode')}} の {{jsxref("array")}} です。リストの要素は UI に表示されているのと同じ順序で並びます。フォルダの場合は省略されます。</dd>
+ <dd>各要素がノードの子要素を表す、{{WebExtAPIRef('bookmarks.BookmarkTreeNode')}} の {{jsxref("array")}} です。リストの要素は UI に表示されているのと同じ順序で並びます。フォルダ以外の場合は省略されます。</dd>
 </dl>
 
 <div class="note">


### PR DESCRIPTION
MDN URL(en-US)：https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNode
MDN URL(ja)：https://developer.mozilla.org/ja/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNode

BookmarkTreeNodeのchildrenプロパティについて、英語では
> This field is omitted if the node isn't a folder.

日本語では
> フォルダの場合は省略されます。

と書かれているため、以下のように日本語の方を英語に合わせました。
> フォルダ以外の場合は省略されます。