### PR TITLE
[RU] fix: bigint primitive object equivalent info

### DIFF
--- a/files/ru/glossary/primitive/index.html
+++ b/files/ru/glossary/primitive/index.html
@@ -90,8 +90,9 @@ console.log(foo);   // 5
 <ul>
  <li>{{jsxref("String")}} для string примитива.</li>
  <li>{{jsxref("Number")}} для number примитива.</li>
- <li>{{jsxref("Boolean")}} для Boolean примитива.</li>
- <li>{{jsxref("Symbol")}} для Symbol примитива.</li>
+ <li>{{jsxref("BigInt")}} для bigint примитива.</li>
+ <li>{{jsxref("Boolean")}} для boolean примитива.</li>
+ <li>{{jsxref("Symbol")}} для symbol примитива.</li>
 </ul>
 
 <p>Метод <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/valueOf"><code>valueOf()</code></a> типа обёртки возвращает значение примитивного типа.</p>


### PR DESCRIPTION
В абзаце "[Обёртки примитивных типов](https://developer.mozilla.org/ru/docs/Glossary/Primitive#%D0%BE%D0%B1%D1%91%D1%80%D1%82%D0%BA%D0%B8_%D0%BF%D1%80%D0%B8%D0%BC%D0%B8%D1%82%D0%B8%D0%B2%D0%BD%D1%8B%D1%85_%D1%82%D0%B8%D0%BF%D0%BE%D0%B2_%D0%B2_javascript)":
1) Добавил элемент списка с объектным аналогом для BigInt примитива.
2) Названия примитивов в элементах списка перевёл в нижний регистр, как в [английской версии](https://developer.mozilla.org/en-US/docs/Glossary/Primitive#autoboxing_primitive_wrapper_objects_in_javascript).
![image](https://user-images.githubusercontent.com/81531000/177479968-c9ba8711-b288-4b3c-a71e-c2c75e966a55.png)
