### PR TITLE
fix: `エクスポートされたWebAssembly関数` のリンク先を日本語のドキュメントに

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/webassembly/table/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/table/index.md
@@ -58,7 +58,7 @@ var importObj = {
 };
 ```
 
-<p>最後に {{jsxref("WebAssembly.instantiateStreaming()")}} を使用して wasm モジュール (table2.wasm) をロード し、インスタンス化します。table2.wasm モジュールは2の関数を持っていて (1つは42を、もう1つは83を返す) 、インポートされたテーブルの0、1番目に両方の要素が格納されます (<a href="https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/table2.wat">text representation</a>を参照) 。そして、インスタンス化された後、テーブルの長さは2のままです。しかし、今はJSから呼び出し可能な <a href="/en-US/docs/WebAssembly/Exported_functions">エクスポートされたWebAssembly関数</a> が含まれています。</p>
+<p>最後に {{jsxref("WebAssembly.instantiateStreaming()")}} を使用して wasm モジュール (table2.wasm) をロード し、インスタンス化します。table2.wasm モジュールは2の関数を持っていて (1つは42を、もう1つは83を返す) 、インポートされたテーブルの0、1番目に両方の要素が格納されます (<a href="https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/table2.wat">text representation</a>を参照) 。そして、インスタンス化された後、テーブルの長さは2のままです。しかし、今はJSから呼び出し可能な <a href="/ja/docs/WebAssembly/Exported_functions">エクスポートされたWebAssembly関数</a> が含まれています。</p>
 
 <pre class="brush: js">WebAssembly.instantiateStreaming(fetch('table2.wasm'), importObject)
 .then(function(obj) {


### PR DESCRIPTION
[WebAssembly.Table](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table#%E6%96%B0%E3%81%97%E3%81%84_webassembly_table_%E3%82%A4%E3%83%B3%E3%82%B9%E3%82%BF%E3%83%B3%E3%82%B9%E3%81%AE%E7%94%9F%E6%88%90)内の `エクスポートされたWebAssembly関数` の飛び先が[英語のドキュメント](https://developer.mozilla.org/en-US/docs/WebAssembly/Exported_functions)に設定されているので [日本語のドキュメント](https://developer.mozilla.org/ja/docs/WebAssembly/Exported_functions)  に変更しました