### PR TITLE
fix a display problem

### DIFF
--- a/files/zh-cn/web/css/initial/index.html
+++ b/files/zh-cn/web/css/initial/index.html
@@ -10,7 +10,7 @@ translation_of: Web/CSS/initial
 ---
 <div>{{CSSRef}}</div>
 
-<p>CSS关键字 <strong><code>initial</code></strong> 将属性的初始（或默认）值应用于元素。不应将初始值与浏览器样式表指定的值混淆。它可以应用于任何CSS属性。这包括CSS简写 <code>{{cssxref("all")}}</code>，initial可用于将所有CSS属性恢复到其初始状态。</p>
+<p>CSS 关键字 <strong><code>initial</code></strong> 将属性的初始（或默认）值应用于元素。不应将初始值与浏览器样式表指定的值混淆。它可以应用于任何 CSS 属性。这包括 CSS 简写 {{cssxref("all")}}，initial 可用于将所有 CSS 属性恢复到其初始状态。</p>
 
 <div class="note">
 <p><strong>注意：</strong>在继承的属性上，初始值可能是意外的。你应该考虑使用 {{cssxref("inherit")}}, {{cssxref("unset")}}，或{{cssxref("revert")}} 关键字代替。</p>

--- a/files/zh-cn/web/css/initial/index.html
+++ b/files/zh-cn/web/css/initial/index.html
@@ -10,7 +10,7 @@ translation_of: Web/CSS/initial
 ---
 <div>{{CSSRef}}</div>
 
-<p><strong><code>initial</code></strong> <code>CSS关键字将属性的初始（或默认）值应用于元素。不应将初始值与浏览器样式表指定的值混淆。它可以应用于任何CSS属性。这包括CSS简写</code>{{cssxref("all")}}<code>，initial</code> <code>可用于将所有CSS属性恢复到其初始状态。</code></p>
+<p>CSS关键字 <strong><code>initial</code></strong> 将属性的初始（或默认）值应用于元素。不应将初始值与浏览器样式表指定的值混淆。它可以应用于任何CSS属性。这包括CSS简写 <code>{{cssxref("all")}}</code>，initial可用于将所有CSS属性恢复到其初始状态。</p>
 
 <div class="note">
 <p><strong>注意：</strong>在继承的属性上，初始值可能是意外的。你应该考虑使用 {{cssxref("inherit")}}, {{cssxref("unset")}}，或{{cssxref("revert")}} 关键字代替。</p>


### PR DESCRIPTION
Some `<code>` tags were misused in the original html file. (Below is a screenshot for the original page)
<img width="570" alt="image" src="https://user-images.githubusercontent.com/54730911/178625509-7eff892d-6509-4865-9e53-3e6cd6aefb60.png">
