### PR TITLE
Replace `src` with `img`

### DIFF
--- a/files/ja/web/web_components/using_custom_elements/index.md
+++ b/files/ja/web/web_components/using_custom_elements/index.md
@@ -96,7 +96,7 @@ icon.setAttribute('class','icon');
 icon.setAttribute('tabindex', 0);
 // アイコンを、定義された属性または既定のアイコンから挿入
 const img = icon.appendChild(document.createElement('img'));
-img.src = this.hasAttribute('src') ? this.getAttribute('src') : 'img/default.png';
+img.src = this.hasAttribute('img') ? this.getAttribute('img') : 'img/default.png';
 
 const info = wrapper.appendChild(document.createElement('span'));
 info.setAttribute('class','info');


### PR DESCRIPTION
index.htmlでimg属性を変更してもデフォルト画像が表示される状態でした。
これはmain.jsでsrc属性を使用していたためでした。
このため、`img`属性の使用に統一することで修正しました。