### PR TITLE
EmbedLiveSampleに正しいblock-idを指定する

### DIFF
--- a/files/ja/web/css/using_css_custom_properties/index.html
+++ b/files/ja/web/css/using_css_custom_properties/index.html
@@ -14,7 +14,7 @@ translation_of: Web/CSS/Using_CSS_custom_properties
 ---
 <div>{{cssref}}</div>
 
-<p><strong>カスタムプロパティ</strong> (<strong>CSS 変数</strong>や<strong>カスケード変数</strong>と呼ばれることもあります) は、 CSS の作者によって作成され、文書全体で再利用可能な特定の値を含むエンティティです。それらは、カスタムプロパティ記法 (たとえば、<strong><code>--main-color: black;</code></strong>) によって設定し、 <code>var()</code> 関数 (たとえば、 <code>color: <strong>var(--main-color)</strong>;</code>) を使ってアクセスします。</p>
+<p><strong>カスタムプロパティ</strong> (<strong>CSS 変数</strong>や<strong>カスケード変数</strong>と呼ばれることもあります) は、 CSS の作者によって作成され、文書全体で再利用可能な特定の値を含むエンティティです。それらは、カスタムプロパティ記法 (たとえば、<strong><code>--main-color: black;</code></strong>) によって設定し、 <code><a href="/ja/docs/Web/CSS/var">var()</a></code> 関数 (たとえば、 <code>color: <strong>var(--main-color)</strong>;</code>) を使ってアクセスします。</p>
 
 <p>複雑なウェブサイトには、膨大な量の CSS があり、しばしば同じ値が使われています。たとえば、同じ色が異なる場所で数百使われており、色を変更する場合、グローバルに検索し、置き換えをしなくてはなりません。カスタムプロパティを使えば、一ヶ所に値を保存しておき、複数の場所から参照することができます。更なるメリットとして、意味的な識別をしやすくなります。たとえば、 <code>--main-text-color</code> は <code>#00ff00</code> より、とりわけ同じ色がさまざまな文脈で使われる場合は理解しやすいでしょう。</p>
 

--- a/files/ja/web/css/using_css_custom_properties/index.html
+++ b/files/ja/web/css/using_css_custom_properties/index.html
@@ -100,7 +100,7 @@ translation_of: Web/CSS/Using_CSS_custom_properties
 
 <p>このようになるはずです。</p>
 
-<p>{{EmbedLiveSample("First_steps_with_custom_properties",600,180)}}</p>
+<p>{{EmbedLiveSample("sample1",600,180)}}</p>
 
 <p>CSS 中に同じ宣言が繰り返し出てくることに注意してください。いろいろな場所で背景色が <code>brown</code> に設定されています。 CSS の宣言によっては、カスケードの上流でこれを宣言し、 CSS の継承によってこの問題を自然に解決することもできます。些末なプロジェクトを除いて、常にこの手法が使えるわけではありません。 {{cssxref(":root")}} 擬似クラスでカスタムプロパティを宣言し、文書内の必要な場所で使用することで、繰り返して書く必要性を減らすことができるのです。</p>
 </div>


### PR DESCRIPTION
# 修正内容
- EmbedLiveSampleのblock-idを `sample1` に変更
- `var()` に他の言語に合わせてリンクを付与、軽微な内容でしたので同一PRに含めています。

# 対象のドキュメント
- https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties

## before
![スクリーンショット 2022-07-14 1 02 56](https://user-images.githubusercontent.com/39351982/178779930-671e6560-809f-4a09-8b3b-d919b3e3b8f1.png)

## after
![スクリーンショット 2022-07-14 1 03 20](https://user-images.githubusercontent.com/39351982/178779952-d6e16eb9-40dd-4939-ab8c-635c11ee5125.png)

