### PR TITLE
Update index.html

### DIFF
--- a/files/es/learn/common_questions/pages_sites_servers_and_search_engines/index.html
+++ b/files/es/learn/common_questions/pages_sites_servers_and_search_engines/index.html
@@ -30,9 +30,9 @@ translation_of: Learn/Common_questions/Pages_sites_servers_and_search_engines
 
 <dl>
  <dt>Página web</dt>
- <dd> Un documento que se puede mostrar en un navegador web como Firefox, Google Chrome, Microsoft Internet Explorer o Edge, o Safary de Apple, A menudo también se puede denominar "páginas web" o simplemente "páginas".</dd>
+ <dd> Un documento que se puede mostrar en un navegador web como Firefox, Google Chrome, Microsoft Internet Explorer o Edge, o Safary de Apple. A menudo se las denomina simplemente "páginas".</dd>
  <dt>Sitio web</dt>
- <dd>Es una colección de páginas web que se agrupan y normalmente se conectan de varias maneras. A menudo llamado un "sitio web" o simplemente "sitio".</dd>
+ <dd>Es una colección de páginas web agrupadas y que normalmente se conectan entre sí de varias maneras. A menudo llamados simplemente "sitios".</dd>
  <dt>Servidor web</dt>
  <dd>Una computadora que aloja un sitio web en Internet.</dd>
  <dt>Motores de búsqueda</dt>


### PR DESCRIPTION
La redacción propuesta parece preferible: ", A menudo también se puede denominar 'páginas web' o simplemente 'páginas'.", se propone modificar del siguiente modo: la coma antes de "A menudo" se cambia por un punto; la reiteración de "páginas web" no tiene sentido, porque se reitera la denomiación que se está explicando (vamos a explicar tales conceptos: pagina web... a menudo se la denomina "página web"), y lo mismo ocurre con la aclaración del párrafo siguiente, donde se da el concepto de "sitio web", y luego se reitera que a menudo se los llama "sitios web".