### PR TITLE
fix: change to more precise words

### DIFF
--- a/files/zh-cn/web/api/window/postmessage/index.html
+++ b/files/zh-cn/web/api/window/postmessage/index.html
@@ -20,13 +20,13 @@ translation_of: Web/API/Window/postMessage
 
 <h2 id="Syntax">语法</h2>
 
-<pre class="syntaxbox notranslate">otherWindow.postMessage(message, targetOrigin, [transfer]);</pre>
+<pre class="syntaxbox notranslate">targetWindow.postMessage(message, targetOrigin, [transfer]);</pre>
 
 <dl>
- <dt><code>otherWindow</code></dt>
- <dd>其他窗口的一个引用，比如 iframe 的 contentWindow 属性、执行<a href="/en-US/docs/DOM/window.open" title="DOM/window.open">window.open</a>返回的窗口对象、或者是命名过或数值索引的<a href="/en-US/docs/DOM/window.frames" title="DOM/window.frames">window.frames</a>。</dd>
+ <dt><code>targetWindow</code></dt>
+ <dd>目标窗口的一个引用，比如 iframe 的 contentWindow 属性、执行<a href="/en-US/docs/DOM/window.open" title="DOM/window.open">window.open</a>返回的窗口对象、或者是命名过或数值索引的<a href="/en-US/docs/DOM/window.frames" title="DOM/window.frames">window.frames</a>。</dd>
  <dt><code>message</code></dt>
- <dd>将要发送到其他 window 的数据。它将会被<a href="https://developer.mozilla.org/en-US/docs/DOM/The_structured_clone_algorithm">结构化克隆算法</a>序列化。这意味着你可以不受什么限制的将数据对象安全的传送给目标窗口而无需自己序列化。[<a href="https://developer.mozilla.org/en-US/docs/">1</a>]</dd>
+ <dd>将要发送到目标 window 的数据。它将会被<a href="https://developer.mozilla.org/en-US/docs/DOM/The_structured_clone_algorithm">结构化克隆算法</a>序列化。这意味着你可以不受什么限制的将数据对象安全的传送给目标窗口而无需自己序列化。[<a href="https://developer.mozilla.org/en-US/docs/">1</a>]</dd>
  <dt><code>targetOrigin</code></dt>
  <dd>通过窗口的 origin 属性来指定哪些窗口能接收到消息事件，其值可以是字符串"*"（表示无限制）或者一个 URI。在发送消息的时候，如果目标窗口的协议、主机地址或端口这三者的任意一项不匹配 targetOrigin 提供的值，那么消息就不会被发送；只有三者完全匹配，消息才会被发送。这个机制用来控制消息可以发送到哪些窗口；例如，当用 postMessage 传送密码时，这个参数就显得尤为重要，必须保证它的值与这条包含密码的信息的预期接受者的 origin 属性完全一致，来防止密码被恶意的第三方截获。<strong>如果你明确的知道消息应该发送到哪个窗口，那么请始终提供一个有确切值的 targetOrigin，而不是*。不提供确切的目标将导致数据泄露到任何对数据感兴趣的恶意站点。</strong></dd>
  <dt><code><em><strong>transfer</strong></em></code> {{optional_Inline}}</dt>


### PR DESCRIPTION
`targetWindow.postMessage(message, targetOrigin, [transfer]); `means send message to 'targetWindow'. 'Otherwindow' is confusing.