### PR TITLE
Fix typo

### DIFF
--- a/files/ko/web/api/document/index.html
+++ b/files/ko/web/api/document/index.html
@@ -26,7 +26,7 @@ translation_of: Web/API/Document
 
 <h2 id="Properties" name="Properties">속성</h2>
 
-<p><em><code>Documet</code>는 {{domxref("Node")}}와 {{domxref("EventTarget")}} 인터페이스도 상속합니다.</em></p>
+<p><em><code>Document</code>는 {{domxref("Node")}}와 {{domxref("EventTarget")}} 인터페이스도 상속합니다.</em></p>
 
 <dl>
  <dt>{{domxref("Document.anchors")}} {{readonlyinline}}</dt>
@@ -197,7 +197,7 @@ translation_of: Web/API/Document
 
 <h2 id="Methods" name="Methods">메서드</h2>
 
-<p><em><code>Documet</code>는 {{domxref("Node")}}와 {{domxref("EventTarget")}} 인터페이스도 상속합니다.</em></p>
+<p><em><code>Document</code>는 {{domxref("Node")}}와 {{domxref("EventTarget")}} 인터페이스도 상속합니다.</em></p>
 
 <dl>
  <dt>{{domxref("Document.adoptNode()")}}</dt>


### PR DESCRIPTION
'Documet'는 Node와 EventTarget 인터페이스도 상속합니다.
Documet -> Document