### PR TITLE
Fix embeded example in pt_br Dialog element

### DIFF
--- a/files/pt-br/web/html/element/dialog/index.html
+++ b/files/pt-br/web/html/element/dialog/index.html
@@ -118,7 +118,7 @@ translation_of: Web/HTML/Element/dialog
 
 <h3 id="Resultado">Resultado</h3>
 
-<p>{{EmbedLiveSample("Advanced_example", "100%", 300)}}</p>
+<p>{{EmbedLiveSample("Exemplo_Avançado", "100%", 300)}}</p>
 
 <h2 id="Especificações">Especificações</h2>
 


### PR DESCRIPTION
The ID of the Advanced Example was translated, but the reference to embed it wasn't.