### PR TITLE
Fix syntax error

### DIFF
--- a/files/pt-br/web/javascript/reference/global_objects/math/random/index.html
+++ b/files/pt-br/web/javascript/reference/global_objects/math/random/index.html
@@ -51,7 +51,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Math/random
 <pre class="brush: js">function getRandomInt(min, max) {
   min = Math.ceil(min);
   max = Math.floor(max);
-  return Math.floor(Math.random() * (max - min)) + min;
+  return Math.floor(Math.random() * (max - min) + min);
 }</pre>
 
 


### PR DESCRIPTION
Solves issue #7069 by fixing a syntax error in line 54: "function getRandomInt(min, max) { min = Math.ceil(min); max = Math.floor(max); return Math.floor(Math.random() * (max - min)) + min; }" to "function getRandomInt(min, max) { min = Math.ceil(min); max = Math.floor(max); return Math.floor(Math.random() * (max - min) + min); }" as to not make the generated number larger than max.