### PR TITLE
ci: use built-in cache

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           node-version: "16"
           cache: yarn
+          cache-dependency-path: ${{ github.workspace }}/mdn/content/yarn.lock
 
       - name: Install all yarn packages
         working-directory: ${{ github.workspace }}/mdn/content

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -31,17 +31,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "16"
-
-      - name: Cache node_modules
-        uses: actions/cache@v3
-        id: cached-node_modules
-        with:
-          path: |
-            ${{ github.workspace }}/mdn/content/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          cache: yarn
 
       - name: Install all yarn packages
-        if: steps.cached-node_modules.outputs.cache-hit != 'true'
         working-directory: ${{ github.workspace }}/mdn/content
         run: |
           yarn --frozen-lockfile
@@ -67,7 +59,7 @@ jobs:
           # Now, this gets used by the `git diff ...` inside get-diff-action.
           git config --global core.quotePath false
 
-      - uses: technote-space/get-diff-action@v6.0.1
+      - uses: technote-space/get-diff-action@v6.1.0
         id: git_diff_content
         with:
           PATTERNS: files/**/*.+(html|md)
@@ -159,7 +151,7 @@ jobs:
           # to debug JS or CSS.
           find $BUILD_OUT_ROOT/static -type f -name "*.map" | xargs rm
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ env.GIT_DIFF_CONTENT }}
         env:
           # This must match what we set in the "Build changed content" step above
@@ -168,7 +160,7 @@ jobs:
           name: build
           path: ${{ env.BUILD_OUT_ROOT }}
 
-      - uses: technote-space/get-diff-action@v6.0.1
+      - uses: technote-space/get-diff-action@v6.1.0
         with:
           PATTERNS: files/**/*.+(png|jpeg|jpg|gif|svg|webp)
           ABSOLUTE: true


### PR DESCRIPTION
Follow mdn/content#12313, setup-node will cache global cache. So the yarn cache can be reused between different Node.js version.