### PR TITLE
WebAssembly/Text_format_to_wasmの表示されなくなった画像を表示

### DIFF
--- a/files/ja/webassembly/text_format_to_wasm/index.html
+++ b/files/ja/webassembly/text_format_to_wasm/index.html
@@ -61,7 +61,7 @@ translation_of: WebAssembly/Text_format_to_wasm
 
 <p>ターミナルには次のように出力されるでしょう:</p>
 
-<p><img alt="several strings of binary with textual descriptions beside them. For example: 0000008: 01 ; section code " src="https://mdn.mozillademos.org/files/14653/assembly-output.png" style="display: block; margin: 0px auto;"></p>
+<p><img alt="several strings of binary with textual descriptions beside them. For example: 0000008: 01 ; section code " src="/en-US/docs/WebAssembly/Text_format_to_wasm/assembly-output.png" style="display: block; margin: 0px auto;"></p>
 
 <h2 id="See_also" name="See_also">関連情報</h2>
 


### PR DESCRIPTION
fixed #6919 
英語版の画像を参照する暫定対応。