### PR TITLE
Fixed and improve SC translation of `Promise.any`

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/promise/any/index.html
+++ b/files/zh-cn/web/javascript/reference/global_objects/promise/any/index.html
@@ -11,7 +11,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Promise/any
 ---
 <p>{{JSRef}}</p>
 
-<p><code>Promise.any()</code> 接收一个{{JSxRef("Promise")}}可迭代对象，只要其中的一个 <code>promise</code> 成功，就返回那个已经成功的 <code>promise</code> 。如果可迭代对象中没有一个 <code>promise</code> 成功（即所有的 <code>promises</code> 都失败/拒绝），就返回一个失败的 <code>promise </code>和{{JSxRef("Global_Objects/AggregateError", "AggregateError")}}类型的实例，它是 {{JSxRef("Error")}} 的一个子类，用于把单一的错误集合在一起。本质上，这个方法和 {{JSxRef("Promise.all()")}} 是相反的。</p>
+<p><code>Promise.any()</code> 接收一个由 {{JSxRef("Promise")}} 所组成的可迭代对象，该方法会返回一个新的 <code>promise</code>，一旦可迭代对象内的任意一个 <code>promise</code> 变成了敲定状态，那么由该方法所返回的 <code>promise</code> 就会变成敲定状态，并且它的敲定值就是可迭代对象内的首先敲定的 <code>promise</code> 的敲定值。如果可迭代对象内的 <code>promise</code> 最终都没有敲定（即所有 <code>promise</code> 都被拒绝了），那么该方法所返回的 <code>promise</code> 就会变成拒绝状态，并且它的拒因会是一个 {{JSxRef("Global_Objects/AggregateError", "AggregateError")}} 实例，这是 {{JSxRef("Error")}} 的子类，用于把单一的错误集合在一起。
 
 <div class="warning">
 <p><strong>警告：</strong><code>Promise.any()</code> 方法依然是实验性的，尚未被所有的浏览器完全支持。它当前处于 <a href="https://github.com/tc39/proposal-promise-any">TC39 第四阶段草案（Stage 4）</a></p>
@@ -31,37 +31,40 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Promise/any
 <h3 id="返回值">返回值</h3>
 
 <ul>
- <li>如果传入的参数是一个空的可迭代对象，则返回一个 <strong>已失败（already rejected）</strong> 状态的 <a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>。</li>
- <li>如果传入的参数不包含任何 <code>promise</code><var>，则返回</var>一个 <strong>异步完成</strong> （<strong>asynchronously resolved</strong>）的 <a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>。</li>
- <li>其他情况下都会返回一个<strong>处理中（pending）</strong> 的 <a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>。 只要传入的迭代对象中的任何一个 <code>promise</code> 变成成功（resolve）状态，或者其中的所有的 <code>promises</code> 都失败，那么返回的 <code>promise</code> 就会 <strong>异步地</strong>（当调用栈为空时）<strong> </strong>变成成功/失败（resolved/reject）状态。</li>
+ <li>如果传入了一个空的可迭代对象，那么就会返回一个已经被拒的 <code>promise</code></li>
+ <li>如果传入了一个不含有 <code>promise</code> 的可迭代对象，那么就会返回一个异步敲定的 <code>promise</code></li>
+ <li>其余情况下都会返回一个处于等待状态的 <code>promise</code>。如果可迭代对象中的任意一个 <code>promise</code> 敲定了，那么这个处于等待状态的 <code>promise</code> 就会异步的切换至敲定状态。如果可迭代对象中的所有 <code>promise</code> 都被拒绝了，那么这个处于等待状态的 <code>promise</code> 就会异步的切换至被拒状态。</li>
 </ul>
 
 <h2 id="说明">说明</h2>
 
-<p>这个方法用于返回第一个成功的 <code>promise</code> 。只要有一个 <code>promise</code> 成功此方法就会终止，它不会等待其他的 <code>promise</code> 全部完成。</p>
+<p>该方法用于获取首个敲定的 <code>promise</code> 的值。只要有一个 <code>promise</code> 敲定了，那么此方法就会提前结束，而不会继续等待其他的 <code>promise</code> 全部完成。</p>
 
-<p>不像 <a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Promise/all">Promise.all()</a> 会返回一组完成值那样（resolved values），我们只能得到一个成功值（假设至少有一个 <code>promise</code> 完成）。当我们只需要一个 <code>promise</code> 成功，而不关心是哪一个成功时此方法很有用的。</p>
+<p>不像 <a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Promise/all">Promise.all()</a> 会返回一组敲定值那样（resolved values），我们只能得到一个敲定值（假设至少有一个 <code>promise</code> 完成）。当我们只需要一个 <code>promise</code> 敲定，而不关心是哪一个敲定时此方法很有用的。</p>
 
-<p>同时，也不像 <a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Promise/race">Promise.race()</a> 总是返回第一个结果值（resolved/reject）那样，这个方法返回的是第一个<em> 成功的</em> 值。这个方法将会忽略掉所有被拒绝的 <code>promise</code>，直到第一个 <code>promise</code> 成功。</p>
+<p>同时，也不像 <a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Promise/race">Promise.race()</a> 总是返回第一个结果值（resolved 或 reject）那样，这个方法返回的是第一个 <em>敲定</em> 的值。这个方法将会忽略掉所有的被拒绝的 <code>promise</code>，直到第一个 <code>promise</code> 敲定。</p>
 
-<h3 id="成功（fulfillment）">成功（Fulfillment）</h3>
+<h3 id="敲定（fulfillment）">敲定（Fulfillment）</h3>
 
-<p>当任何一个被传入的 <code>promise</code> 成功的时候，无论其他的 <code>promises</code> 成功还是失败，此函数会将那个成功的 <code>promise</code> 作为返回值 。</p>
+<p>该方法所返回的 <code>promise</code> 会以可迭代对象内首个敲定的 <code>promise</code> 的敲定值来作为它自己的敲定值，或者会以可迭代对象内首个非 <code>promise</code> 值来作为它自己的敲定值，该方法不会关心其他的 <code>promise</code> 是敲定了还是被拒了。</p>
 
 <ul>
- <li>如果传入的参数是一个空的可迭代对象，这个方法将会同步返回一个已经完成的 <code>promise</code>。</li>
- <li>如果传入的任何一个 <code>promise</code> 已成功，或者传入的参数不包括任何 <code>promise</code>, 那么 <code>Promise.any</code> 返回一个异步成功的 <code>promise</code>。</li>
+ <li>如果传入的可迭代对象是非空的，那么当可迭代对象内的任意一个 <code>promise</code> 敲定后，或者当可迭代对象内存在非 <code>promise</code> 值时，该方法所返回的 <code>promise</code> 都会异步的变成敲定状态。</li>
 </ul>
 
-<h3 id="失败拒绝（rejection）">失败/拒绝（Rejection）</h3>
+<h3 id="拒绝（rejection）">拒绝（Rejection）</h3>
 
-<p>如果所有传入的 <code>promises</code> 都失败，<code>Promise.any</code> 将返回异步失败，和一个 <a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/AggregateError">AggregateError</a> 对象，它继承自 <a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>，有一个 <code>errors</code> 属性，属性值是由所有失败值填充的数组。</p>
+<p>如果可迭代对象内所有的 <code>promises</code> 都被拒绝了，那么该方法所返回的 <code>promise</code> 就会异步的切换至被拒状态，并用一个  <a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/AggregateError">AggregateError</a> 实例来作为它的拒因。<a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/AggregateError">AggregateError</a> 继承自  <a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>，它包含一个 <code>errors</code> 属性，该属性是一个用于存储拒因的数组。
+
+<ul>
+  <li>如果传入了一个空的可迭代数组，那么该方法就会返回一个已经被拒 <code>promise</code>，其拒因是一个 <a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/AggregateError">AggregateError</a> 实例，该实例的 <code>errors</code> 属性会是一个空数组。</li>
+</ul>
 
 <h2 id="示例">示例</h2>
 
 <h3 id="First_to_fulfil">First to fulfil</h3>
 
-<p>即使第一个返回的 promise 是失败的，<code>Promise.any()</code> 依然使用第一个成功状态的 promise 来返回。这与使用首个（无论 rejected 还是 fullfiled）promise 来返回的 {{jsxref("Promise.race()")}} 相反。</p>
+<p>如果可迭代数组内的任意一个 <code>promise</code> 敲定了，那么该方法所返回的 <code>promise</code> 也会切换至敲定状态，哪怕首个完成的 <code>promise</code> 是被拒的。不同的是，{{jsxref("Promise.race()")}} 所返回的 <code>promise</code> 的状态会跟随首个完成的 <code>promise</code> 的状态。</p>
 
 <pre class="brush: js">const pErr = new Promise((resolve, reject) =&gt; {
   reject("总是失败");
@@ -84,7 +87,7 @@ Promise.any([pErr, pSlow, pFast]).then((value) =&gt; {
 
 <h3 id="Rejections_with_AggregateError">Rejections with AggregateError</h3>
 
-<p>如果没有 fulfilled (成功的) promise，<code>Promise.any()</code> 返回 {{jsxref("AggregateError")}} 错误。</p>
+<p>如果所有 <code>promise</code> 都被拒绝了，那么 <code>Promise.any()</code> 所返回的 <code>promise</code> 就会切换至被拒状，并以 {{jsxref("AggregateError")}} 实例来作为拒因。</p>
 
 <pre class="brush: js">const pErr = new Promise((resolve, reject) =&gt; {
   reject('总是失败');

--- a/files/zh-cn/web/javascript/reference/global_objects/promise/any/index.html
+++ b/files/zh-cn/web/javascript/reference/global_objects/promise/any/index.html
@@ -11,7 +11,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Promise/any
 ---
 <p>{{JSRef}}</p>
 
-<p><code>Promise.any()</code> 接收一个由 {{JSxRef("Promise")}} 所组成的可迭代对象，该方法会返回一个新的 <code>promise</code>，一旦可迭代对象内的任意一个 <code>promise</code> 变成了敲定状态，那么由该方法所返回的 <code>promise</code> 就会变成敲定状态，并且它的敲定值就是可迭代对象内的首先敲定的 <code>promise</code> 的敲定值。如果可迭代对象内的 <code>promise</code> 最终都没有敲定（即所有 <code>promise</code> 都被拒绝了），那么该方法所返回的 <code>promise</code> 就会变成拒绝状态，并且它的拒因会是一个 {{JSxRef("Global_Objects/AggregateError", "AggregateError")}} 实例，这是 {{JSxRef("Error")}} 的子类，用于把单一的错误集合在一起。
+<p><code>Promise.any()</code> 接收一个由 {{JSxRef("Promise")}} 所组成的可迭代对象，该方法会返回一个新的 <code>promise</code>，一旦可迭代对象内的任意一个 <code>promise</code> 变成了兑现状态，那么由该方法所返回的 <code>promise</code> 就会变成兑现状态，并且它的兑现值就是可迭代对象内的首先兑现的 <code>promise</code> 的兑现值。如果可迭代对象内的 <code>promise</code> 最终都没有兑现（即所有 <code>promise</code> 都被拒绝了），那么该方法所返回的 <code>promise</code> 就会变成拒绝状态，并且它的拒因会是一个 {{JSxRef("Global_Objects/AggregateError", "AggregateError")}} 实例，这是 {{JSxRef("Error")}} 的子类，用于把单一的错误集合在一起。
 
 <div class="warning">
 <p><strong>警告：</strong><code>Promise.any()</code> 方法依然是实验性的，尚未被所有的浏览器完全支持。它当前处于 <a href="https://github.com/tc39/proposal-promise-any">TC39 第四阶段草案（Stage 4）</a></p>
@@ -32,24 +32,24 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Promise/any
 
 <ul>
  <li>如果传入了一个空的可迭代对象，那么就会返回一个已经被拒的 <code>promise</code></li>
- <li>如果传入了一个不含有 <code>promise</code> 的可迭代对象，那么就会返回一个异步敲定的 <code>promise</code></li>
- <li>其余情况下都会返回一个处于等待状态的 <code>promise</code>。如果可迭代对象中的任意一个 <code>promise</code> 敲定了，那么这个处于等待状态的 <code>promise</code> 就会异步的切换至敲定状态。如果可迭代对象中的所有 <code>promise</code> 都被拒绝了，那么这个处于等待状态的 <code>promise</code> 就会异步的切换至被拒状态。</li>
+ <li>如果传入了一个不含有 <code>promise</code> 的可迭代对象，那么就会返回一个异步兑现的 <code>promise</code></li>
+ <li>其余情况下都会返回一个处于等待状态的 <code>promise</code>。如果可迭代对象中的任意一个 <code>promise</code> 兑现了，那么这个处于等待状态的 <code>promise</code> 就会异步的切换至兑现状态。如果可迭代对象中的所有 <code>promise</code> 都被拒绝了，那么这个处于等待状态的 <code>promise</code> 就会异步的切换至被拒状态。</li>
 </ul>
 
 <h2 id="说明">说明</h2>
 
-<p>该方法用于获取首个敲定的 <code>promise</code> 的值。只要有一个 <code>promise</code> 敲定了，那么此方法就会提前结束，而不会继续等待其他的 <code>promise</code> 全部完成。</p>
+<p>该方法用于获取首个兑现的 <code>promise</code> 的值。只要有一个 <code>promise</code> 兑现了，那么此方法就会提前结束，而不会继续等待其他的 <code>promise</code> 全部敲定。</p>
 
-<p>不像 <a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Promise/all">Promise.all()</a> 会返回一组敲定值那样（resolved values），我们只能得到一个敲定值（假设至少有一个 <code>promise</code> 完成）。当我们只需要一个 <code>promise</code> 敲定，而不关心是哪一个敲定时此方法很有用的。</p>
+<p>不像 <a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Promise/all">Promise.all()</a> 会返回一组兑现值那样（resolved values），我们只能得到一个兑现值（假设至少有一个 <code>promise</code> 兑现）。当我们只需要一个 <code>promise</code> 兑现，而不关心是哪一个兑现时此方法很有用的。</p>
 
-<p>同时，也不像 <a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Promise/race">Promise.race()</a> 总是返回第一个结果值（resolved 或 reject）那样，这个方法返回的是第一个 <em>敲定</em> 的值。这个方法将会忽略掉所有的被拒绝的 <code>promise</code>，直到第一个 <code>promise</code> 敲定。</p>
+<p>同时，也不像 <a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Promise/race">Promise.race()</a> 总是返回第一个结果值（resolved 或 reject）那样，这个方法返回的是第一个 <em>兑现的</em> 值。这个方法将会忽略掉所有的被拒绝的 <code>promise</code>，直到第一个 <code>promise</code> 兑现。</p>
 
-<h3 id="敲定（fulfillment）">敲定（Fulfillment）</h3>
+<h3 id="兑现（fulfillment）">兑现（Fulfillment）</h3>
 
-<p>该方法所返回的 <code>promise</code> 会以可迭代对象内首个敲定的 <code>promise</code> 的敲定值来作为它自己的敲定值，或者会以可迭代对象内首个非 <code>promise</code> 值来作为它自己的敲定值，该方法不会关心其他的 <code>promise</code> 是敲定了还是被拒了。</p>
+<p>该方法所返回的 <code>promise</code> 会以可迭代对象内首个兑现的 <code>promise</code> 的兑现值来作为它自己的兑现值，或者会以可迭代对象内首个非 <code>promise</code> 值来作为它自己的兑现值，该方法不会关心其他的 <code>promise</code> 是兑现了还是被拒了。</p>
 
 <ul>
- <li>如果传入的可迭代对象是非空的，那么当可迭代对象内的任意一个 <code>promise</code> 敲定后，或者当可迭代对象内存在非 <code>promise</code> 值时，该方法所返回的 <code>promise</code> 都会异步的变成敲定状态。</li>
+ <li>如果传入的可迭代对象是非空的，那么当可迭代对象内的任意一个 <code>promise</code> 兑现后，或者当可迭代对象内存在非 <code>promise</code> 值时，该方法所返回的 <code>promise</code> 都会异步的变成兑现状态。</li>
 </ul>
 
 <h3 id="拒绝（rejection）">拒绝（Rejection）</h3>
@@ -64,7 +64,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Promise/any
 
 <h3 id="First_to_fulfil">First to fulfil</h3>
 
-<p>如果可迭代数组内的任意一个 <code>promise</code> 敲定了，那么该方法所返回的 <code>promise</code> 也会切换至敲定状态，哪怕首个完成的 <code>promise</code> 是被拒的。不同的是，{{jsxref("Promise.race()")}} 所返回的 <code>promise</code> 的状态会跟随首个完成的 <code>promise</code> 的状态。</p>
+<p>如果可迭代数组内的任意一个 <code>promise</code> 兑现了，那么该方法所返回的 <code>promise</code> 也会切换至兑现状态，哪怕首个敲定的 <code>promise</code> 是被拒的。不同的是，{{jsxref("Promise.race()")}} 所返回的 <code>promise</code> 的状态会跟随首个敲定的 <code>promise</code> 的状态。</p>
 
 <pre class="brush: js">const pErr = new Promise((resolve, reject) =&gt; {
   reject("总是失败");

--- a/files/zh-cn/web/javascript/reference/global_objects/promise/any/index.html
+++ b/files/zh-cn/web/javascript/reference/global_objects/promise/any/index.html
@@ -33,16 +33,16 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Promise/any
 <ul>
  <li>如果传入了一个空的可迭代对象，那么就会返回一个已经被拒的 <code>promise</code></li>
  <li>如果传入了一个不含有 <code>promise</code> 的可迭代对象，那么就会返回一个异步兑现的 <code>promise</code></li>
- <li>其余情况下都会返回一个处于等待状态的 <code>promise</code>。如果可迭代对象中的任意一个 <code>promise</code> 兑现了，那么这个处于等待状态的 <code>promise</code> 就会异步的切换至兑现状态。如果可迭代对象中的所有 <code>promise</code> 都被拒绝了，那么这个处于等待状态的 <code>promise</code> 就会异步的切换至被拒状态。</li>
+ <li>其余情况下都会返回一个处于等待状态的 <code>promise</code>。如果可迭代对象中的任意一个 <code>promise</code> 兑现了，那么这个处于等待状态的 <code>promise</code> 就会异步地（调用栈为空时）切换至兑现状态。如果可迭代对象中的所有 <code>promise</code> 都被拒绝了，那么这个处于等待状态的 <code>promise</code> 就会异步地切换至被拒状态。</li>
 </ul>
 
 <h2 id="说明">说明</h2>
 
 <p>该方法用于获取首个兑现的 <code>promise</code> 的值。只要有一个 <code>promise</code> 兑现了，那么此方法就会提前结束，而不会继续等待其他的 <code>promise</code> 全部敲定。</p>
 
-<p>不像 <a href="https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Promise/all">Promise.all()</a> 会返回一组兑现值那样（resolved values），我们只能得到一个兑现值（假设至少有一个 <code>promise</code> 兑现）。当我们只需要一个 <code>promise</code> 兑现，而不关心是哪一个兑现时此方法很有用的。</p>
+<p>不像 {{JSxRef("Promise.all()")}} 会返回一组兑现值那样，我们只能得到一个兑现值（假设至少有一个 <code>promise</code> 兑现）。当我们只需要一个 <code>promise</code> 兑现，而不关心是哪一个兑现时此方法很有用的。</p>
 
-<p>同时，也不像 <a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Promise/race">Promise.race()</a> 总是返回第一个结果值（resolved 或 reject）那样，这个方法返回的是第一个 <em>兑现的</em> 值。这个方法将会忽略掉所有的被拒绝的 <code>promise</code>，直到第一个 <code>promise</code> 兑现。</p>
+<p>同时，也不像 {{JSxRef("Promise.race()")}} 总是返回第一个敲定值（兑现或拒绝）那样，这个方法返回的是第一个<em>兑现的</em>值。这个方法将会忽略掉所有的被拒绝的 <code>promise</code>，直到第一个 <code>promise</code> 兑现。</p>
 
 <h3 id="兑现（fulfillment）">兑现（Fulfillment）</h3>
 
@@ -54,10 +54,10 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Promise/any
 
 <h3 id="拒绝（rejection）">拒绝（Rejection）</h3>
 
-<p>如果可迭代对象内所有的 <code>promises</code> 都被拒绝了，那么该方法所返回的 <code>promise</code> 就会异步的切换至被拒状态，并用一个  <a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/AggregateError">AggregateError</a> 实例来作为它的拒因。<a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/AggregateError">AggregateError</a> 继承自  <a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>，它包含一个 <code>errors</code> 属性，该属性是一个用于存储拒因的数组。
+<p>如果可迭代对象内所有的 <code>promises</code> 都被拒绝了，那么该方法所返回的 <code>promise</code> 就会异步的切换至被拒状态，并用一个  {{JSxRef("AggregateError")}}（继承自  {{JSxRef("Error")}}）实例来作为它的拒因。它包含一个 <code>errors</code> 属性，该属性是一个用于存储拒因的数组。
 
 <ul>
-  <li>如果传入了一个空的可迭代数组，那么该方法就会返回一个已经被拒 <code>promise</code>，其拒因是一个 <a href="/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/AggregateError">AggregateError</a> 实例，该实例的 <code>errors</code> 属性会是一个空数组。</li>
+  <li>如果传入了一个空的可迭代数组，那么该方法就会返回一个已经被拒 <code>promise</code>，其拒因是一个 <code>AggregateError</code> 实例，该实例的 <code>errors</code> 属性会是一个空数组。</li>
 </ul>
 
 <h2 id="示例">示例</h2>
@@ -87,7 +87,7 @@ Promise.any([pErr, pSlow, pFast]).then((value) =&gt; {
 
 <h3 id="Rejections_with_AggregateError">Rejections with AggregateError</h3>
 
-<p>如果所有 <code>promise</code> 都被拒绝了，那么 <code>Promise.any()</code> 所返回的 <code>promise</code> 就会切换至被拒状，并以 {{jsxref("AggregateError")}} 实例来作为拒因。</p>
+<p>如果没有 <code>promise</code> 被兑现，那么 <code>Promise.any()</code> 所返回的 <code>promise</code> 就会切换至被拒状态，并以 {{jsxref("AggregateError")}} 实例来作为拒因。</p>
 
 <pre class="brush: js">const pErr = new Promise((resolve, reject) =&gt; {
   reject('总是失败');

--- a/files/zh-cn/web/javascript/reference/global_objects/promise/any/index.html
+++ b/files/zh-cn/web/javascript/reference/global_objects/promise/any/index.html
@@ -54,7 +54,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Promise/any
 
 <h3 id="拒绝（rejection）">拒绝（Rejection）</h3>
 
-<p>如果可迭代对象内所有的 <code>promises</code> 都被拒绝了，那么该方法所返回的 <code>promise</code> 就会异步的切换至被拒状态，并用一个  {{JSxRef("AggregateError")}}（继承自  {{JSxRef("Error")}}）实例来作为它的拒因。它包含一个 <code>errors</code> 属性，该属性是一个用于存储拒因的数组。
+<p>如果可迭代对象内所有的 <code>promises</code> 都被拒绝了，那么该方法所返回的 <code>promise</code> 就会异步的切换至被拒状态，并用一个 {{JSxRef("AggregateError")}}（继承自  {{JSxRef("Error")}}）实例来作为它的拒因。它包含一个 <code>errors</code> 属性，该属性是一个用于存储拒因的数组。
 
 <ul>
   <li>如果传入了一个空的可迭代数组，那么该方法就会返回一个已经被拒 <code>promise</code>，其拒因是一个 <code>AggregateError</code> 实例，该实例的 <code>errors</code> 属性会是一个空数组。</li>


### PR DESCRIPTION
## Overview
Fixed plain errors in current translation, while also optimizing the quality of translation to improve readability.

<br />

## Fix
- The first list item in the `fulfillment` section is wrong：the item does not exist in the original English language, and the item is contrary to the specification (see the `Rejection` section).

<br />

## optimization
- use `敲定` instead of `成功`
- use `被拒` instead of `失败`
- use `敲定值` instead of `成功值`
- use `拒因` instead of `失败值`
- more clearly express the meaning of `synchronous` and `asynchronous`

<br />

## 概述
修正了一条明显的错误，同时也优化了简中版本的翻译质量，以期提高可读性。

<br />

## 校正
- `成功（fulfillment）` 小节中的第一条列表项是错误的，因为它与英文原文中的 `Rejection` 小节中的第一条列表项完全相悖了，而后者才是符合 ECMAScript 规范的。并且在英语原文的 `Fulfillment` 小节中，也根本不存在该列表项。

<br />

## 改善
- 使用 `敲定` 来替代 `成功`
- 使用 `被拒` 来替代 `失败`
- 使用 `敲定值` 来替代 `成功值`
- 使用 `拒因` 来替代 `失败值`

> 这些是语意更好的词汇。

- 另外，更明确的表达了哪些行为是 `同步` 或 `异步`的（基于英文原文）

<br />