### PR TITLE
Remove last use of {{outdated}} macro

### DIFF
--- a/files/pl/web/api/canvas_api/index.html
+++ b/files/pl/web/api/canvas_api/index.html
@@ -4,9 +4,6 @@ slug: Web/API/Canvas_API
 translation_of: Web/API/Canvas_API
 original_slug: Web/HTML/Canvas
 ---
-<div>
-  {{outdated()}}</div>
-<div>
   <p><strong>Canvas</strong> (<code>&lt;canvas&gt;</code>) jest nowym elementem <a href="/pl/docs/HTML" title="pl/docs/HTML">HTML</a>, który może być użyty do rysowania grafik przy użyciu skryptów (zazwyczaj <a href="/pl/docs/JavaScript" title="pl/docs/JavaScript">JavaScript</a>). Na przykład może być użyty do rysowania wykresów, tworzenia kompozycji fotografii lub do prostych (i <a href="/pl/docs/Prosty_RayCaster" title="pl/docs/Prosty_RayCaster">nie tylko prostych</a>) animacji.</p>
   <p>Po raz pierwszy <code>&lt;canvas&gt;</code> został przedstawiony przez Apple dla <a class="external" href="http://www.apple.com/macosx/features/dashboard/">Mac OS X Dashboard</a> i później zaimplementowany w Safari. Przeglądarki oparte o silnik <a href="/pl/docs/Gecko" title="pl/docs/Gecko">Gecko</a> począwszy od wersji 1.8 (tj. <a href="/pl/docs/Firefox_1.5_dla_programistów" title="pl/docs/Firefox_1.5_dla_programistów">Firefox 1.5</a> oraz późniejsze) obsługują ten nowy element. Również Opera 9 go wspiera. Czynione są starania, aby <code>&lt;canvas&gt;</code> był obsługiwany przez Internet Explorera (zobacz ).</p>
   <p>Element <code>&lt;canvas&gt;</code> jest częścią specyfikacji <a class="external" href="http://www.whatwg.org/specs/web-apps/current-work/">WhatWG Web applications 1.0</a> znanej także jako HTML 5.</p>


### PR DESCRIPTION
This PR removes the very last use of the `{{outdated}}` macro from MDN content.
