### PR TITLE
Remove `{{css_key_concepts}}` macro from l10n-zh

### DIFF
--- a/files/zh-cn/web/css/actual_value/index.html
+++ b/files/zh-cn/web/css/actual_value/index.html
@@ -13,9 +13,34 @@ translation_of: Web/CSS/actual_value
 
 {{Specifications}}
 
-<h2 id="相关">相关</h2>
+<h2 id="参见">参见</h2>
 
 <ul>
  <li><a href="/en-US/docs/Web/CSS/Reference">CSS Reference</a></li>
- <li>{{CSS_key_concepts}}</li>
+ <li>CSS 重要概念：
+  <ul>
+    <li><a href="/zh-CN/docs/Web/CSS/Syntax">CSS 语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/At-rule">@ 规则</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Comments">注释</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Specificity">优先级</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/inheritance">继承</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">盒模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Layout_mode">布局模式</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Visual_formatting_model">视觉格式化模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">外边距合并</a></li>
+    <li>值
+      <ul>
+        <li><a href="/zh-CN/docs/Web/CSS/initial_value">初始值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/computed_value">计算值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/resolved_value">解析值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/specified_value">指定值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/used_value">应用值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/actual_value">实际值</a></li>
+      </ul>
+    </li>
+    <li><a href="/zh-CN/docs/Web/CSS/Value_definition_syntax">属性值定义语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Shorthand_properties">简写属性</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Replaced_element">可替换元素</a></li>
+  </ul>
+ </li>
 </ul>

--- a/files/zh-cn/web/css/cascade/index.html
+++ b/files/zh-cn/web/css/cascade/index.html
@@ -156,9 +156,34 @@ translation_of: Web/CSS/Cascade
 
 {{Specifications}}
 
-<h2 id="See_also">参见</h2>
+<h2 id="参见">参见</h2>
 
 <ul>
  <li>CSS 教程中层叠知识的<a href="/zh-CN/docs/CSS/Getting_Started/Cascading_and_inheritance">介绍</a>。</li>
- <li>{{CSS_Key_Concepts()}}</li>
+ <li>CSS 重要概念：
+  <ul>
+    <li><a href="/zh-CN/docs/Web/CSS/Syntax">CSS 语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/At-rule">@ 规则</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Comments">注释</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Specificity">优先级</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/inheritance">继承</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">盒模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Layout_mode">布局模式</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Visual_formatting_model">视觉格式化模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">外边距合并</a></li>
+    <li>值
+      <ul>
+        <li><a href="/zh-CN/docs/Web/CSS/initial_value">初始值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/computed_value">计算值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/resolved_value">解析值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/specified_value">指定值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/used_value">应用值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/actual_value">实际值</a></li>
+      </ul>
+    </li>
+    <li><a href="/zh-CN/docs/Web/CSS/Value_definition_syntax">属性值定义语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Shorthand_properties">简写属性</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Replaced_element">可替换元素</a></li>
+  </ul>
+ </li>
 </ul>

--- a/files/zh-cn/web/css/comments/index.html
+++ b/files/zh-cn/web/css/comments/index.html
@@ -50,5 +50,30 @@ span {
 <h2 id="参见">参见</h2>
 
 <ul>
- <li>{{CSS_key_concepts}}</li>
+ <li>CSS 重要概念：
+  <ul>
+    <li><a href="/zh-CN/docs/Web/CSS/Syntax">CSS 语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/At-rule">@ 规则</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Comments">注释</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Specificity">优先级</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/inheritance">继承</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">盒模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Layout_mode">布局模式</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Visual_formatting_model">视觉格式化模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">外边距合并</a></li>
+    <li>值
+      <ul>
+        <li><a href="/zh-CN/docs/Web/CSS/initial_value">初始值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/computed_value">计算值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/resolved_value">解析值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/specified_value">指定值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/used_value">应用值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/actual_value">实际值</a></li>
+      </ul>
+    </li>
+    <li><a href="/zh-CN/docs/Web/CSS/Value_definition_syntax">属性值定义语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Shorthand_properties">简写属性</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Replaced_element">可替换元素</a></li>
+  </ul>
+ </li>
 </ul>

--- a/files/zh-cn/web/css/computed_value/index.html
+++ b/files/zh-cn/web/css/computed_value/index.html
@@ -27,9 +27,34 @@ translation_of: Web/CSS/computed_value
 
 {{Specifications}}
 
-<h2 id="相关">相关</h2>
+<h2 id="参见">参见</h2>
 
 <ul>
  <li>{{domxref("window.getComputedStyle")}}</li>
- <li>{{CSS_key_concepts}}</li>
+ <li>CSS 重要概念：
+  <ul>
+    <li><a href="/zh-CN/docs/Web/CSS/Syntax">CSS 语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/At-rule">@ 规则</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Comments">注释</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Specificity">优先级</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/inheritance">继承</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">盒模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Layout_mode">布局模式</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Visual_formatting_model">视觉格式化模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">外边距合并</a></li>
+    <li>值
+      <ul>
+        <li><a href="/zh-CN/docs/Web/CSS/initial_value">初始值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/computed_value">计算值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/resolved_value">解析值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/specified_value">指定值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/used_value">应用值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/actual_value">实际值</a></li>
+      </ul>
+    </li>
+    <li><a href="/zh-CN/docs/Web/CSS/Value_definition_syntax">属性值定义语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Shorthand_properties">简写属性</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Replaced_element">可替换元素</a></li>
+  </ul>
+ </li>
 </ul>

--- a/files/zh-cn/web/css/containing_block/index.html
+++ b/files/zh-cn/web/css/containing_block/index.html
@@ -261,9 +261,34 @@ p {
 
 <p>{{EmbedLiveSample('Example_5','100%','300')}}</p>
 
-<h2 id="另见">另见</h2>
+<h2 id="参见">参见</h2>
 
 <ul>
- <li>{{css_key_concepts}}</li>
+ <li>CSS 重要概念：
+  <ul>
+    <li><a href="/zh-CN/docs/Web/CSS/Syntax">CSS 语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/At-rule">@ 规则</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Comments">注释</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Specificity">优先级</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/inheritance">继承</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">盒模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Layout_mode">布局模式</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Visual_formatting_model">视觉格式化模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">外边距合并</a></li>
+    <li>值
+      <ul>
+        <li><a href="/zh-CN/docs/Web/CSS/initial_value">初始值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/computed_value">计算值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/resolved_value">解析值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/specified_value">指定值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/used_value">应用值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/actual_value">实际值</a></li>
+      </ul>
+    </li>
+    <li><a href="/zh-CN/docs/Web/CSS/Value_definition_syntax">属性值定义语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Shorthand_properties">简写属性</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Replaced_element">可替换元素</a></li>
+  </ul>
+ </li>
  <li>{{cssxref("all")}} 属性可将所有 CSS 声明重置为它所指定的状态</li>
 </ul>

--- a/files/zh-cn/web/css/css_box_model/introduction_to_the_css_box_model/index.html
+++ b/files/zh-cn/web/css/css_box_model/introduction_to_the_css_box_model/index.html
@@ -51,5 +51,30 @@ translation_of: Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model
 <h2 id="参见_2">参见</h2>
 
 <ul>
- <li>{{css_key_concepts}}</li>
+ <li>CSS 重要概念：
+  <ul>
+    <li><a href="/zh-CN/docs/Web/CSS/Syntax">CSS 语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/At-rule">@ 规则</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Comments">注释</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Specificity">优先级</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/inheritance">继承</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">盒模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Layout_mode">布局模式</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Visual_formatting_model">视觉格式化模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">外边距合并</a></li>
+    <li>值
+      <ul>
+        <li><a href="/zh-CN/docs/Web/CSS/initial_value">初始值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/computed_value">计算值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/resolved_value">解析值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/specified_value">指定值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/used_value">应用值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/actual_value">实际值</a></li>
+      </ul>
+    </li>
+    <li><a href="/zh-CN/docs/Web/CSS/Value_definition_syntax">属性值定义语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Shorthand_properties">简写属性</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Replaced_element">可替换元素</a></li>
+  </ul>
+ </li>
 </ul>

--- a/files/zh-cn/web/css/css_box_model/mastering_margin_collapsing/index.html
+++ b/files/zh-cn/web/css/css_box_model/mastering_margin_collapsing/index.html
@@ -132,5 +132,30 @@ p {
 <h2 id="参见">参见</h2>
 
 <ul>
- <li>{{css_key_concepts}}</li>
+ <li>CSS 重要概念：
+  <ul>
+    <li><a href="/zh-CN/docs/Web/CSS/Syntax">CSS 语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/At-rule">@ 规则</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Comments">注释</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Specificity">优先级</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/inheritance">继承</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">盒模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Layout_mode">布局模式</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Visual_formatting_model">视觉格式化模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">外边距合并</a></li>
+    <li>值
+      <ul>
+        <li><a href="/zh-CN/docs/Web/CSS/initial_value">初始值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/computed_value">计算值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/resolved_value">解析值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/specified_value">指定值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/used_value">应用值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/actual_value">实际值</a></li>
+      </ul>
+    </li>
+    <li><a href="/zh-CN/docs/Web/CSS/Value_definition_syntax">属性值定义语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Shorthand_properties">简写属性</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Replaced_element">可替换元素</a></li>
+  </ul>
+ </li>
 </ul>

--- a/files/zh-cn/web/css/inheritance/index.html
+++ b/files/zh-cn/web/css/inheritance/index.html
@@ -57,6 +57,31 @@ translation_of: Web/CSS/inheritance
 <ul>
  <li>控制继承：{{ cssxref("inherit") }}, {{cssxref("initial")}}, {{cssxref("unset")}}, and {{cssxref("revert")}}</li>
  <li><a href="/zh-CN/docs/Web/CSS/Cascade">CSS 层叠</a></li>
- <li><a href="https://developer.mozilla.org/zh-CN/docs/Learn/CSS/Introduction_to_CSS/Cascade_and_inheritance">层叠和继承</a></li>
- <li>{{ CSS_key_concepts() }}</li>
+ <li><a href="/zh-CN/docs/Learn/CSS/Introduction_to_CSS/Cascade_and_inheritance">层叠和继承</a></li>
+ <li>CSS 重要概念：
+  <ul>
+    <li><a href="/zh-CN/docs/Web/CSS/Syntax">CSS 语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/At-rule">@ 规则</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Comments">注释</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Specificity">优先级</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/inheritance">继承</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">盒模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Layout_mode">布局模式</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Visual_formatting_model">视觉格式化模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">外边距合并</a></li>
+    <li>值
+      <ul>
+        <li><a href="/zh-CN/docs/Web/CSS/initial_value">初始值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/computed_value">计算值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/resolved_value">解析值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/specified_value">指定值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/used_value">应用值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/actual_value">实际值</a></li>
+      </ul>
+    </li>
+    <li><a href="/zh-CN/docs/Web/CSS/Value_definition_syntax">属性值定义语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Shorthand_properties">简写属性</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Replaced_element">可替换元素</a></li>
+  </ul>
+ </li>
 </ul>

--- a/files/zh-cn/web/css/initial_value/index.html
+++ b/files/zh-cn/web/css/initial_value/index.html
@@ -27,5 +27,30 @@ translation_of: Web/CSS/initial_value
 
 <ul>
  <li>{{cssxref("initial")}}</li>
- <li>{{CSS_key_concepts}}</li>
+ <li>CSS 重要概念：
+  <ul>
+    <li><a href="/zh-CN/docs/Web/CSS/Syntax">CSS 语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/At-rule">@ 规则</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Comments">注释</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Specificity">优先级</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/inheritance">继承</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">盒模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Layout_mode">布局模式</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Visual_formatting_model">视觉格式化模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">外边距合并</a></li>
+    <li>值
+      <ul>
+        <li><a href="/zh-CN/docs/Web/CSS/initial_value">初始值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/computed_value">计算值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/resolved_value">解析值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/specified_value">指定值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/used_value">应用值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/actual_value">实际值</a></li>
+      </ul>
+    </li>
+    <li><a href="/zh-CN/docs/Web/CSS/Value_definition_syntax">属性值定义语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Shorthand_properties">简写属性</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Replaced_element">可替换元素</a></li>
+  </ul>
+ </li>
 </ul>

--- a/files/zh-cn/web/css/layout_mode/index.html
+++ b/files/zh-cn/web/css/layout_mode/index.html
@@ -12,16 +12,41 @@ translation_of: Web/CSS/Layout_mode
  <li><strong>行内布局</strong>：用来布置文本。</li>
  <li><strong>表格布局</strong>：用来布置表格。</li>
  <li><strong>定位布局</strong>：用来对那些与其他元素无交互的定位元素进行布置 。</li>
- <li><a href="https://developer.mozilla.org/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Using_CSS_flexible_boxes"><strong>弹性盒子布局</strong></a>：用来布置那些可以顺利调整大小的复杂页面。{{experimental_inline}}</li>
- <li><a href="https://developer.mozilla.org/zh-CN/docs/Web/CSS/CSS_Grid_Layout"><strong>网格布局</strong></a>：用来布置那些与一个固定网格相关的元素。{{experimental_inline}}</li>
+ <li><a href="/zh-CN/docs/Web/CSS/CSS_Flexible_Box_Layout/Using_CSS_flexible_boxes"><strong>弹性盒子布局</strong></a>：用来布置那些可以顺利调整大小的复杂页面。{{experimental_inline}}</li>
+ <li><a href="/zh-CN/docs/Web/CSS/CSS_Grid_Layout"><strong>网格布局</strong></a>：用来布置那些与一个固定网格相关的元素。{{experimental_inline}}</li>
 </ul>
 
 <div class="note">
-<p><strong><strong>注意：</strong> 并非所有 <a href="/en-US/docs/Web/CSS/Reference">CSS 属性</a> 适用于所有<em>布局模式</em>。大多数属性适用于一到两种布局模式，如果将属性设置在参与其他（原文 another，指三者或三者以上。）布局模式的元素上则会不起作用。</strong></p>
+<p><strong><strong>备注：</strong> 并非所有 <a href="/en-US/docs/Web/CSS/Reference">CSS 属性</a> 适用于所有<em>布局模式</em>。大多数属性适用于一到两种布局模式，如果将属性设置在参与其他（原文 another，指三者或三者以上。）布局模式的元素上则会不起作用。</strong></p>
 </div>
 
-<h2 id="也可以看看"><strong>也可以看看</strong></h2>
+<h2 id="参见">参见</h2>
 
 <ul>
- <li><strong>{{CSS_key_concepts}}</strong></li>
+ <li>CSS 重要概念：
+  <ul>
+    <li><a href="/zh-CN/docs/Web/CSS/Syntax">CSS 语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/At-rule">@ 规则</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Comments">注释</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Specificity">优先级</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/inheritance">继承</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">盒模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Layout_mode">布局模式</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Visual_formatting_model">视觉格式化模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">外边距合并</a></li>
+    <li>值
+      <ul>
+        <li><a href="/zh-CN/docs/Web/CSS/initial_value">初始值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/computed_value">计算值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/resolved_value">解析值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/specified_value">指定值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/used_value">应用值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/actual_value">实际值</a></li>
+      </ul>
+    </li>
+    <li><a href="/zh-CN/docs/Web/CSS/Value_definition_syntax">属性值定义语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Shorthand_properties">简写属性</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Replaced_element">可替换元素</a></li>
+  </ul>
+ </li>
 </ul>

--- a/files/zh-cn/web/css/replaced_element/index.html
+++ b/files/zh-cn/web/css/replaced_element/index.html
@@ -60,5 +60,30 @@ translation_of: Web/CSS/Replaced_element
 
 <ul>
  <li>可替换元素的 <a href="https://html.spec.whatwg.org/multipage/rendering.html#replaced-elements">HTML 规范</a></li>
- <li>{{CSS_key_concepts()}}</li>
+ <li>CSS 重要概念：
+  <ul>
+    <li><a href="/zh-CN/docs/Web/CSS/Syntax">CSS 语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/At-rule">@ 规则</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Comments">注释</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Specificity">优先级</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/inheritance">继承</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">盒模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Layout_mode">布局模式</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Visual_formatting_model">视觉格式化模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">外边距合并</a></li>
+    <li>值
+      <ul>
+        <li><a href="/zh-CN/docs/Web/CSS/initial_value">初始值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/computed_value">计算值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/resolved_value">解析值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/specified_value">指定值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/used_value">应用值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/actual_value">实际值</a></li>
+      </ul>
+    </li>
+    <li><a href="/zh-CN/docs/Web/CSS/Value_definition_syntax">属性值定义语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Shorthand_properties">简写属性</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Replaced_element">可替换元素</a></li>
+  </ul>
+ </li>
 </ul>

--- a/files/zh-cn/web/css/resolved_value/index.html
+++ b/files/zh-cn/web/css/resolved_value/index.html
@@ -15,6 +15,31 @@ translation_of: Web/CSS/resolved_value
 
 <ul>
  <li><a href="/en-US/docs/Web/CSS/Reference">CSS Reference</a></li>
- <li>{{CSS_key_concepts}}</li>
+ <li>CSS 重要概念：
+  <ul>
+    <li><a href="/zh-CN/docs/Web/CSS/Syntax">CSS 语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/At-rule">@ 规则</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Comments">注释</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Specificity">优先级</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/inheritance">继承</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">盒模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Layout_mode">布局模式</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Visual_formatting_model">视觉格式化模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">外边距合并</a></li>
+    <li>值
+      <ul>
+        <li><a href="/zh-CN/docs/Web/CSS/initial_value">初始值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/computed_value">计算值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/resolved_value">解析值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/specified_value">指定值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/used_value">应用值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/actual_value">实际值</a></li>
+      </ul>
+    </li>
+    <li><a href="/zh-CN/docs/Web/CSS/Value_definition_syntax">属性值定义语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Shorthand_properties">简写属性</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Replaced_element">可替换元素</a></li>
+  </ul>
+ </li>
  <li>{{domxref("window.getComputedStyle")}}</li>
 </ul>

--- a/files/zh-cn/web/css/specificity/index.html
+++ b/files/zh-cn/web/css/specificity/index.html
@@ -319,5 +319,30 @@ h1 {
 <ul>
  <li>Specificity Calculator: An interactive website to test and understand your own CSS rules - <a href="https://specificity.keegan.st/">https://specificity.keegan.st/</a></li>
  <li>CSS3 选择器优先级 - <a href="http://www.w3.org/TR/selectors/#specificity">http://www.w3.org/TR/selectors/#specificity</a></li>
- <li>{{CSS_Key_Concepts}}</li>
+ <li>CSS 重要概念：
+  <ul>
+    <li><a href="/zh-CN/docs/Web/CSS/Syntax">CSS 语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/At-rule">@ 规则</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Comments">注释</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Specificity">优先级</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/inheritance">继承</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">盒模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Layout_mode">布局模式</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Visual_formatting_model">视觉格式化模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">外边距合并</a></li>
+    <li>值
+      <ul>
+        <li><a href="/zh-CN/docs/Web/CSS/initial_value">初始值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/computed_value">计算值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/resolved_value">解析值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/specified_value">指定值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/used_value">应用值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/actual_value">实际值</a></li>
+      </ul>
+    </li>
+    <li><a href="/zh-CN/docs/Web/CSS/Value_definition_syntax">属性值定义语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Shorthand_properties">简写属性</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Replaced_element">可替换元素</a></li>
+  </ul>
+ </li>
 </ul>

--- a/files/zh-cn/web/css/syntax/index.html
+++ b/files/zh-cn/web/css/syntax/index.html
@@ -74,8 +74,33 @@ translation_of: Web/CSS/Syntax
  条件规则组（conditional group rules）是特殊的 at 规则，可以嵌套语句。它里面的语句只有在特定条件下才生效。<br>
  CSS1 与 CSS2.1 下，条件规则组里面只能用规则。CSS3 下还可以用一些但不是全部的 at 规则，见<a href="https://developer.mozilla.org/en/CSS/CSS3#Conditionals"><em>CSS Conditionals Level 3</em></a>。</p>
 
-<h2 id="其它">其它</h2>
+<h2 id="参见">参见</h2>
 
 <ul>
- <li>{{ CSS_key_concepts()}}</li>
+ <li>CSS 重要概念：
+  <ul>
+    <li><a href="/zh-CN/docs/Web/CSS/Syntax">CSS 语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/At-rule">@ 规则</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Comments">注释</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Specificity">优先级</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/inheritance">继承</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">盒模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Layout_mode">布局模式</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Visual_formatting_model">视觉格式化模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">外边距合并</a></li>
+    <li>值
+      <ul>
+        <li><a href="/zh-CN/docs/Web/CSS/initial_value">初始值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/computed_value">计算值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/resolved_value">解析值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/specified_value">指定值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/used_value">应用值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/actual_value">实际值</a></li>
+      </ul>
+    </li>
+    <li><a href="/zh-CN/docs/Web/CSS/Value_definition_syntax">属性值定义语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Shorthand_properties">简写属性</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Replaced_element">可替换元素</a></li>
+  </ul>
+ </li>
 </ul>

--- a/files/zh-cn/web/css/used_value/index.html
+++ b/files/zh-cn/web/css/used_value/index.html
@@ -39,6 +39,31 @@ translation_of: Web/CSS/used_value
 
 <ul>
  <li><a href="/en-US/docs/CSS_Reference">CSS Reference</a></li>
- <li>{{ CSS_key_concepts() }}</li>
+ <li>CSS 重要概念：
+  <ul>
+    <li><a href="/zh-CN/docs/Web/CSS/Syntax">CSS 语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/At-rule">@ 规则</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Comments">注释</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Specificity">优先级</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/inheritance">继承</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">盒模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Layout_mode">布局模式</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Visual_formatting_model">视觉格式化模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">外边距合并</a></li>
+    <li>值
+      <ul>
+        <li><a href="/zh-CN/docs/Web/CSS/initial_value">初始值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/computed_value">计算值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/resolved_value">解析值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/specified_value">指定值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/used_value">应用值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/actual_value">实际值</a></li>
+      </ul>
+    </li>
+    <li><a href="/zh-CN/docs/Web/CSS/Value_definition_syntax">属性值定义语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Shorthand_properties">简写属性</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Replaced_element">可替换元素</a></li>
+  </ul>
+ </li>
  <li><a href="/en-US/docs/DOM/window.getComputedStyle">window.getComputedStyle</a></li>
 </ul>

--- a/files/zh-cn/web/css/value_definition_syntax/index.html
+++ b/files/zh-cn/web/css/value_definition_syntax/index.html
@@ -401,8 +401,33 @@ translation_of: Web/CSS/Value_definition_syntax
 
 {{Specifications}}
 
-<h2 id="参考条目">参考条目</h2>
+<h2 id="参见">参见</h2>
 
 <ul>
- <li>{{ CSS_key_concepts() }}</li>
+ <li>CSS 重要概念：
+  <ul>
+    <li><a href="/zh-CN/docs/Web/CSS/Syntax">CSS 语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/At-rule">@ 规则</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Comments">注释</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Specificity">优先级</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/inheritance">继承</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">盒模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Layout_mode">布局模式</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Visual_formatting_model">视觉格式化模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">外边距合并</a></li>
+    <li>值
+      <ul>
+        <li><a href="/zh-CN/docs/Web/CSS/initial_value">初始值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/computed_value">计算值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/resolved_value">解析值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/specified_value">指定值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/used_value">应用值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/actual_value">实际值</a></li>
+      </ul>
+    </li>
+    <li><a href="/zh-CN/docs/Web/CSS/Value_definition_syntax">属性值定义语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Shorthand_properties">简写属性</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Replaced_element">可替换元素</a></li>
+  </ul>
+ </li>
 </ul>

--- a/files/zh-cn/web/css/visual_formatting_model/index.html
+++ b/files/zh-cn/web/css/visual_formatting_model/index.html
@@ -279,5 +279,30 @@ followed by more inline text.
 <h2 id="参见">参见</h2>
 
 <ul>
- <li>{{css_key_concepts}}</li>
+ <li>CSS 重要概念：
+  <ul>
+    <li><a href="/zh-CN/docs/Web/CSS/Syntax">CSS 语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/At-rule">@ 规则</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Comments">注释</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Specificity">优先级</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/inheritance">继承</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">盒模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Layout_mode">布局模式</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Visual_formatting_model">视觉格式化模型</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">外边距合并</a></li>
+    <li>值
+      <ul>
+        <li><a href="/zh-CN/docs/Web/CSS/initial_value">初始值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/computed_value">计算值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/resolved_value">解析值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/specified_value">指定值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/used_value">应用值</a></li>
+        <li><a href="/zh-CN/docs/Web/CSS/actual_value">实际值</a></li>
+      </ul>
+    </li>
+    <li><a href="/zh-CN/docs/Web/CSS/Value_definition_syntax">属性值定义语法</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Shorthand_properties">简写属性</a></li>
+    <li><a href="/zh-CN/docs/Web/CSS/Replaced_element">可替换元素</a></li>
+  </ul>
+ </li>
 </ul>

--- a/files/zh-cn/web/guide/css/block_formatting_context/index.md
+++ b/files/zh-cn/web/guide/css/block_formatting_context/index.md
@@ -10,7 +10,7 @@ translation_of: Web/Guide/CSS/Block_formatting_context
 ---
 {{ CSSRef }}
 
-**块格式化上下文（Block Formatting Context，BFC）** 是 Web 页面的可视 CSS 渲染的一部分，是块级盒子的布局过程发生的区域，也是浮动元素与其他元素交互的区域。
+**块格式化上下文**（Block Formatting Context，BFC）是 Web 页面的可视 CSS 渲染的一部分，是块级盒子的布局过程发生的区域，也是浮动元素与其他元素交互的区域。
 
 下列方式会创建块格式化上下文：
 
@@ -200,4 +200,23 @@ section {
 ## 参见
 
 - {{ cssxref("float") }}, {{ cssxref("clear") }}
-- {{ css_key_concepts }}
+- CSS 重要概念：
+  - [CSS 语法](/zh-CN/docs/Web/CSS/Syntax)
+  - [@ 规则](/zh-CN/docs/Web/CSS/At-rule)
+  - [注释](/zh-CN/docs/Web/CSS/Comments)
+  - [优先级](/zh-CN/docs/Web/CSS/Specificity)
+  - [继承](/zh-CN/docs/Web/CSS/inheritance)
+  - [盒模型](/zh-CN/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
+  - [布局模式](/zh-CN/docs/Web/CSS/Layout_mode)
+  - [视觉格式化模型](/zh-CN/docs/Web/CSS/Visual_formatting_model)
+  - [外边距合并](/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing)
+  - 值
+    - [初始值](/zh-CN/docs/Web/CSS/initial_value)
+    - [计算值](/zh-CN/docs/Web/CSS/computed_value)
+    - [解析值](/zh-CN/docs/Web/CSS/resolved_value)
+    - [指定值](/zh-CN/docs/Web/CSS/specified_value)
+    - [应用值](/zh-CN/docs/Web/CSS/used_value)
+    - [实际值](/zh-CN/docs/Web/CSS/actual_value)
+  - [属性值定义语法](/zh-CN/docs/Web/CSS/Value_definition_syntax)
+  - [简写属性](/zh-CN/docs/Web/CSS/Shorthand_properties)
+  - [可替换元素](/zh-CN/docs/Web/CSS/Replaced_element)

--- a/files/zh-tw/web/css/css_box_model/mastering_margin_collapsing/index.html
+++ b/files/zh-tw/web/css/css_box_model/mastering_margin_collapsing/index.html
@@ -88,5 +88,30 @@ translation_of: Web/CSS/CSS_Box_Model/Mastering_margin_collapsing
 
 <ul>
  <li><a href="/en-US/docs/Web/CSS/CSS_Reference">CSS Reference</a></li>
- <li>{{css_key_concepts}}</li>
+ <li>CSS 重要概念：
+  <ul>
+    <li><a href="/zh-TW/docs/Web/CSS/Syntax">CSS 語法</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/At-rule">@ 規則</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Comments">註釋</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Specificity">優先級</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/inheritance">繼承</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">盒模型</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Layout_mode">佈局模式</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Visual_formatting_model">視覺格式化模型</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">外邊距合併</a></li>
+    <li>值
+      <ul>
+        <li><a href="/zh-TW/docs/Web/CSS/initial_value">初始值</a></li>
+        <li><a href="/zh-TW/docs/Web/CSS/computed_value">計算值</a></li>
+        <li><a href="/zh-TW/docs/Web/CSS/resolved_value">解析值</a></li>
+        <li><a href="/zh-TW/docs/Web/CSS/specified_value">指定值</a></li>
+        <li><a href="/zh-TW/docs/Web/CSS/used_value">應用值</a></li>
+        <li><a href="/zh-TW/docs/Web/CSS/actual_value">實際值</a></li>
+      </ul>
+    </li>
+    <li><a href="/zh-TW/docs/Web/CSS/Value_definition_syntax">特性值定義語法</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Shorthand_properties">特性簡寫</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Replaced_element">可置換元素</a></li>
+  </ul>
+ </li>
 </ul>

--- a/files/zh-tw/web/css/inheritance/index.html
+++ b/files/zh-tw/web/css/inheritance/index.html
@@ -43,6 +43,31 @@ translation_of: Web/CSS/inheritance
 
 <ul>
  <li><a href="/en-US/docs/CSS/CSS_Reference">CSS Reference</a></li>
- <li>{{ CSS_key_concepts() }}</li>
+ <li>CSS 重要概念：
+  <ul>
+    <li><a href="/zh-TW/docs/Web/CSS/Syntax">CSS 語法</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/At-rule">@ 規則</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Comments">註釋</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Specificity">優先級</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/inheritance">繼承</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">盒模型</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Layout_mode">佈局模式</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Visual_formatting_model">視覺格式化模型</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">外邊距合併</a></li>
+    <li>值
+      <ul>
+        <li><a href="/zh-TW/docs/Web/CSS/initial_value">初始值</a></li>
+        <li><a href="/zh-TW/docs/Web/CSS/computed_value">計算值</a></li>
+        <li><a href="/zh-TW/docs/Web/CSS/resolved_value">解析值</a></li>
+        <li><a href="/zh-TW/docs/Web/CSS/specified_value">指定值</a></li>
+        <li><a href="/zh-TW/docs/Web/CSS/used_value">應用值</a></li>
+        <li><a href="/zh-TW/docs/Web/CSS/actual_value">實際值</a></li>
+      </ul>
+    </li>
+    <li><a href="/zh-TW/docs/Web/CSS/Value_definition_syntax">特性值定義語法</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Shorthand_properties">特性簡寫</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Replaced_element">可置換元素</a></li>
+  </ul>
+ </li>
  <li>{{ Cssxref("inherit") }}</li>
 </ul>

--- a/files/zh-tw/web/css/replaced_element/index.html
+++ b/files/zh-tw/web/css/replaced_element/index.html
@@ -16,5 +16,30 @@ translation_of: Web/CSS/Replaced_element
 <h2 id="另可參閱">另可參閱</h2>
 
 <ul>
- <li>{{CSS_key_concepts()}}</li>
+ <li>CSS 重要概念：
+  <ul>
+    <li><a href="/zh-TW/docs/Web/CSS/Syntax">CSS 語法</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/At-rule">@ 規則</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Comments">註釋</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Specificity">優先級</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/inheritance">繼承</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">盒模型</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Layout_mode">佈局模式</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Visual_formatting_model">視覺格式化模型</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">外邊距合併</a></li>
+    <li>值
+      <ul>
+        <li><a href="/zh-TW/docs/Web/CSS/initial_value">初始值</a></li>
+        <li><a href="/zh-TW/docs/Web/CSS/computed_value">計算值</a></li>
+        <li><a href="/zh-TW/docs/Web/CSS/resolved_value">解析值</a></li>
+        <li><a href="/zh-TW/docs/Web/CSS/specified_value">指定值</a></li>
+        <li><a href="/zh-TW/docs/Web/CSS/used_value">應用值</a></li>
+        <li><a href="/zh-TW/docs/Web/CSS/actual_value">實際值</a></li>
+      </ul>
+    </li>
+    <li><a href="/zh-TW/docs/Web/CSS/Value_definition_syntax">特性值定義語法</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Shorthand_properties">特性簡寫</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Replaced_element">可置換元素</a></li>
+  </ul>
+ </li>
 </ul>

--- a/files/zh-tw/web/css/syntax/index.html
+++ b/files/zh-tw/web/css/syntax/index.html
@@ -70,5 +70,30 @@ This leads to an important consequence: if one single basic selector is invalid,
 <h2 id="See_also">See also</h2>
 
 <ul>
- <li>{{ CSS_key_concepts()}}</li>
+ <li>CSS 重要概念：
+  <ul>
+    <li><a href="/zh-TW/docs/Web/CSS/Syntax">CSS 語法</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/At-rule">@ 規則</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Comments">註釋</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Specificity">優先級</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/inheritance">繼承</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">盒模型</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Layout_mode">佈局模式</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Visual_formatting_model">視覺格式化模型</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">外邊距合併</a></li>
+    <li>值
+      <ul>
+        <li><a href="/zh-TW/docs/Web/CSS/initial_value">初始值</a></li>
+        <li><a href="/zh-TW/docs/Web/CSS/computed_value">計算值</a></li>
+        <li><a href="/zh-TW/docs/Web/CSS/resolved_value">解析值</a></li>
+        <li><a href="/zh-TW/docs/Web/CSS/specified_value">指定值</a></li>
+        <li><a href="/zh-TW/docs/Web/CSS/used_value">應用值</a></li>
+        <li><a href="/zh-TW/docs/Web/CSS/actual_value">實際值</a></li>
+      </ul>
+    </li>
+    <li><a href="/zh-TW/docs/Web/CSS/Value_definition_syntax">特性值定義語法</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Shorthand_properties">特性簡寫</a></li>
+    <li><a href="/zh-TW/docs/Web/CSS/Replaced_element">可置換元素</a></li>
+  </ul>
+ </li>
 </ul>


### PR DESCRIPTION
Part of #7343

@irvin, please have a review on `zh-TW` translations

```html
 <li>CSS 重要概念：
  <ul>
    <li><a href="/zh-TW/docs/Web/CSS/Syntax">CSS 語法</a></li>
    <li><a href="/zh-TW/docs/Web/CSS/At-rule">@ 規則</a></li>
    <li><a href="/zh-TW/docs/Web/CSS/Comments">註釋</a></li>
    <li><a href="/zh-TW/docs/Web/CSS/Specificity">優先級</a></li>
    <li><a href="/zh-TW/docs/Web/CSS/inheritance">繼承</a></li>
    <li><a href="/zh-TW/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">盒模型</a></li>
    <li><a href="/zh-TW/docs/Web/CSS/Layout_mode">佈局模式</a></li>
    <li><a href="/zh-TW/docs/Web/CSS/Visual_formatting_model">視覺格式化模型</a></li>
    <li><a href="/zh-TW/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">外邊距合併</a></li>
    <li>值
      <ul>
        <li><a href="/zh-TW/docs/Web/CSS/initial_value">初始值</a></li>
        <li><a href="/zh-TW/docs/Web/CSS/computed_value">計算值</a></li>
        <li><a href="/zh-TW/docs/Web/CSS/resolved_value">解析值</a></li>
        <li><a href="/zh-TW/docs/Web/CSS/specified_value">指定值</a></li>
        <li><a href="/zh-TW/docs/Web/CSS/used_value">應用值</a></li>
        <li><a href="/zh-TW/docs/Web/CSS/actual_value">實際值</a></li>
      </ul>
    </li>
    <li><a href="/zh-TW/docs/Web/CSS/Value_definition_syntax">特性值定義語法</a></li>
    <li><a href="/zh-TW/docs/Web/CSS/Shorthand_properties">特性簡寫</a></li>
    <li><a href="/zh-TW/docs/Web/CSS/Replaced_element">可置換元素</a></li>
  </ul>
 </li>
```