### PR TITLE
Remove `{{css_key_concepts}}` macro from `ko`

### DIFF
--- a/files/ko/web/css/actual_value/index.html
+++ b/files/ko/web/css/actual_value/index.html
@@ -43,5 +43,30 @@ translation_of: Web/CSS/actual_value
 <h2 id="같이_보기">같이 보기</h2>
 
 <ul>
- <li>{{CSS_key_concepts}}</li>
+  <li>CSS 주요 개념
+    <ul>
+      <li><a href="/ko/docs/Web/CSS/Syntax">CSS 문법</a></li>
+      <li><a href="/ko/docs/Web/CSS/At-rule">@규칙</a></li>
+      <li><a href="/ko/docs/Web/CSS/Comments">주석</a></li>
+      <li><a href="/ko/docs/Web/CSS/Specificity">명시도</a></li>
+      <li><a href="/ko/docs/Web/CSS/inheritance">상속</a></li>
+      <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">박스 모델</a></li>
+      <li><a href="/ko/docs/Web/CSS/Layout_mode">레이아웃 모드</a></li>
+      <li><a href="/ko/docs/Web/CSS/Visual_formatting_model">시각적 서식 모델</a></li>
+      <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">마진 중첩</a></li>
+      <li>값
+        <ul>
+          <li><a href="/ko/docs/Web/CSS/initial_value">초깃값</a></li>
+          <li><a href="/ko/docs/Web/CSS/computed_value">계산값</a></li>
+          <li><a href="/ko/docs/Web/CSS/resolved_value">결정값</a></li>
+          <li><a href="/ko/docs/Web/CSS/specified_value">지정값</a></li>
+          <li><a href="/ko/docs/Web/CSS/used_value">사용값</a></li>
+          <li><a href="/ko/docs/Web/CSS/actual_value">실제값</a></li>
+        </ul>
+      </li>
+      <li><a href="/ko/docs/Web/CSS/Value_definition_syntax">값 정의 구문</a></li>
+      <li><a href="/ko/docs/Web/CSS/Shorthand_properties">단축 속성</a></li>
+      <li><a href="/ko/docs/Web/CSS/Replaced_element">대체 요소</a></li>
+    </ul>
+  </li>
 </ul>

--- a/files/ko/web/css/cascade/index.html
+++ b/files/ko/web/css/cascade/index.html
@@ -225,5 +225,30 @@ translation_of: Web/CSS/Cascade
 
 <ul>
  <li><a href="/en-US/docs/Learn/CSS/Introduction_to_CSS/Cascade_and_inheritance">A very simple introduction to the CSS cascade</a></li>
- <li>{{CSS_Key_Concepts}}</li>
+ <li>CSS 주요 개념
+  <ul>
+    <li><a href="/ko/docs/Web/CSS/Syntax">CSS 문법</a></li>
+    <li><a href="/ko/docs/Web/CSS/At-rule">@규칙</a></li>
+    <li><a href="/ko/docs/Web/CSS/Comments">주석</a></li>
+    <li><a href="/ko/docs/Web/CSS/Specificity">명시도</a></li>
+    <li><a href="/ko/docs/Web/CSS/inheritance">상속</a></li>
+    <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">박스 모델</a></li>
+    <li><a href="/ko/docs/Web/CSS/Layout_mode">레이아웃 모드</a></li>
+    <li><a href="/ko/docs/Web/CSS/Visual_formatting_model">시각적 서식 모델</a></li>
+    <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">마진 중첩</a></li>
+    <li>값
+      <ul>
+        <li><a href="/ko/docs/Web/CSS/initial_value">초깃값</a></li>
+        <li><a href="/ko/docs/Web/CSS/computed_value">계산값</a></li>
+        <li><a href="/ko/docs/Web/CSS/resolved_value">결정값</a></li>
+        <li><a href="/ko/docs/Web/CSS/specified_value">지정값</a></li>
+        <li><a href="/ko/docs/Web/CSS/used_value">사용값</a></li>
+        <li><a href="/ko/docs/Web/CSS/actual_value">실제값</a></li>
+      </ul>
+    </li>
+    <li><a href="/ko/docs/Web/CSS/Value_definition_syntax">값 정의 구문</a></li>
+    <li><a href="/ko/docs/Web/CSS/Shorthand_properties">단축 속성</a></li>
+    <li><a href="/ko/docs/Web/CSS/Replaced_element">대체 요소</a></li>
+  </ul>
+  </li>
 </ul>

--- a/files/ko/web/css/comments/index.html
+++ b/files/ko/web/css/comments/index.html
@@ -50,5 +50,30 @@ span {
 <h2 id="같이_보기">같이 보기</h2>
 
 <ul>
- <li>{{CSS_key_concepts}}</li>
+  <li>CSS 주요 개념
+    <ul>
+      <li><a href="/ko/docs/Web/CSS/Syntax">CSS 문법</a></li>
+      <li><a href="/ko/docs/Web/CSS/At-rule">@규칙</a></li>
+      <li><a href="/ko/docs/Web/CSS/Comments">주석</a></li>
+      <li><a href="/ko/docs/Web/CSS/Specificity">명시도</a></li>
+      <li><a href="/ko/docs/Web/CSS/inheritance">상속</a></li>
+      <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">박스 모델</a></li>
+      <li><a href="/ko/docs/Web/CSS/Layout_mode">레이아웃 모드</a></li>
+      <li><a href="/ko/docs/Web/CSS/Visual_formatting_model">시각적 서식 모델</a></li>
+      <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">마진 중첩</a></li>
+      <li>값
+        <ul>
+          <li><a href="/ko/docs/Web/CSS/initial_value">초깃값</a></li>
+          <li><a href="/ko/docs/Web/CSS/computed_value">계산값</a></li>
+          <li><a href="/ko/docs/Web/CSS/resolved_value">결정값</a></li>
+          <li><a href="/ko/docs/Web/CSS/specified_value">지정값</a></li>
+          <li><a href="/ko/docs/Web/CSS/used_value">사용값</a></li>
+          <li><a href="/ko/docs/Web/CSS/actual_value">실제값</a></li>
+        </ul>
+      </li>
+      <li><a href="/ko/docs/Web/CSS/Value_definition_syntax">값 정의 구문</a></li>
+      <li><a href="/ko/docs/Web/CSS/Shorthand_properties">단축 속성</a></li>
+      <li><a href="/ko/docs/Web/CSS/Replaced_element">대체 요소</a></li>
+    </ul>
+  </li>
 </ul>

--- a/files/ko/web/css/computed_value/index.html
+++ b/files/ko/web/css/computed_value/index.html
@@ -51,5 +51,30 @@ translation_of: Web/CSS/computed_value
 
 <ul>
  <li><a href="/ko/docs/Web/CSS/CSS_Reference">CSS Reference</a></li>
- <li>{{CSS_key_concepts}}</li>
+ <li>CSS 주요 개념
+  <ul>
+    <li><a href="/ko/docs/Web/CSS/Syntax">CSS 문법</a></li>
+    <li><a href="/ko/docs/Web/CSS/At-rule">@규칙</a></li>
+    <li><a href="/ko/docs/Web/CSS/Comments">주석</a></li>
+    <li><a href="/ko/docs/Web/CSS/Specificity">명시도</a></li>
+    <li><a href="/ko/docs/Web/CSS/inheritance">상속</a></li>
+    <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">박스 모델</a></li>
+    <li><a href="/ko/docs/Web/CSS/Layout_mode">레이아웃 모드</a></li>
+    <li><a href="/ko/docs/Web/CSS/Visual_formatting_model">시각적 서식 모델</a></li>
+    <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">마진 중첩</a></li>
+    <li>값
+      <ul>
+        <li><a href="/ko/docs/Web/CSS/initial_value">초깃값</a></li>
+        <li><a href="/ko/docs/Web/CSS/computed_value">계산값</a></li>
+        <li><a href="/ko/docs/Web/CSS/resolved_value">결정값</a></li>
+        <li><a href="/ko/docs/Web/CSS/specified_value">지정값</a></li>
+        <li><a href="/ko/docs/Web/CSS/used_value">사용값</a></li>
+        <li><a href="/ko/docs/Web/CSS/actual_value">실제값</a></li>
+      </ul>
+    </li>
+    <li><a href="/ko/docs/Web/CSS/Value_definition_syntax">값 정의 구문</a></li>
+    <li><a href="/ko/docs/Web/CSS/Shorthand_properties">단축 속성</a></li>
+    <li><a href="/ko/docs/Web/CSS/Replaced_element">대체 요소</a></li>
+  </ul>
+  </li>
 </ul>

--- a/files/ko/web/css/containing_block/index.html
+++ b/files/ko/web/css/containing_block/index.html
@@ -259,6 +259,31 @@ p {
 <h2 id="같이_보기">같이 보기</h2>
 
 <ul>
- <li>{{css_key_concepts}}</li>
+  <li>CSS 주요 개념
+    <ul>
+      <li><a href="/ko/docs/Web/CSS/Syntax">CSS 문법</a></li>
+      <li><a href="/ko/docs/Web/CSS/At-rule">@규칙</a></li>
+      <li><a href="/ko/docs/Web/CSS/Comments">주석</a></li>
+      <li><a href="/ko/docs/Web/CSS/Specificity">명시도</a></li>
+      <li><a href="/ko/docs/Web/CSS/inheritance">상속</a></li>
+      <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">박스 모델</a></li>
+      <li><a href="/ko/docs/Web/CSS/Layout_mode">레이아웃 모드</a></li>
+      <li><a href="/ko/docs/Web/CSS/Visual_formatting_model">시각적 서식 모델</a></li>
+      <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">마진 중첩</a></li>
+      <li>값
+        <ul>
+          <li><a href="/ko/docs/Web/CSS/initial_value">초깃값</a></li>
+          <li><a href="/ko/docs/Web/CSS/computed_value">계산값</a></li>
+          <li><a href="/ko/docs/Web/CSS/resolved_value">결정값</a></li>
+          <li><a href="/ko/docs/Web/CSS/specified_value">지정값</a></li>
+          <li><a href="/ko/docs/Web/CSS/used_value">사용값</a></li>
+          <li><a href="/ko/docs/Web/CSS/actual_value">실제값</a></li>
+        </ul>
+      </li>
+      <li><a href="/ko/docs/Web/CSS/Value_definition_syntax">값 정의 구문</a></li>
+      <li><a href="/ko/docs/Web/CSS/Shorthand_properties">단축 속성</a></li>
+      <li><a href="/ko/docs/Web/CSS/Replaced_element">대체 요소</a></li>
+    </ul>
+  </li>
  <li>모든 CSS 선언을 주어진 상태로 되돌리는 {{cssxref("all")}} 속성</li>
 </ul>

--- a/files/ko/web/css/css_box_model/introduction_to_the_css_box_model/index.html
+++ b/files/ko/web/css/css_box_model/introduction_to_the_css_box_model/index.html
@@ -66,5 +66,30 @@ translation_of: Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model
 <h2 id="같이_보기">같이 보기</h2>
 
 <ul>
- <li>{{css_key_concepts}}</li>
+  <li>CSS 주요 개념
+    <ul>
+      <li><a href="/ko/docs/Web/CSS/Syntax">CSS 문법</a></li>
+      <li><a href="/ko/docs/Web/CSS/At-rule">@규칙</a></li>
+      <li><a href="/ko/docs/Web/CSS/Comments">주석</a></li>
+      <li><a href="/ko/docs/Web/CSS/Specificity">명시도</a></li>
+      <li><a href="/ko/docs/Web/CSS/inheritance">상속</a></li>
+      <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">박스 모델</a></li>
+      <li><a href="/ko/docs/Web/CSS/Layout_mode">레이아웃 모드</a></li>
+      <li><a href="/ko/docs/Web/CSS/Visual_formatting_model">시각적 서식 모델</a></li>
+      <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">마진 중첩</a></li>
+      <li>값
+        <ul>
+          <li><a href="/ko/docs/Web/CSS/initial_value">초깃값</a></li>
+          <li><a href="/ko/docs/Web/CSS/computed_value">계산값</a></li>
+          <li><a href="/ko/docs/Web/CSS/resolved_value">결정값</a></li>
+          <li><a href="/ko/docs/Web/CSS/specified_value">지정값</a></li>
+          <li><a href="/ko/docs/Web/CSS/used_value">사용값</a></li>
+          <li><a href="/ko/docs/Web/CSS/actual_value">실제값</a></li>
+        </ul>
+      </li>
+      <li><a href="/ko/docs/Web/CSS/Value_definition_syntax">값 정의 구문</a></li>
+      <li><a href="/ko/docs/Web/CSS/Shorthand_properties">단축 속성</a></li>
+      <li><a href="/ko/docs/Web/CSS/Replaced_element">대체 요소</a></li>
+    </ul>
+  </li>
 </ul>

--- a/files/ko/web/css/initial_value/index.html
+++ b/files/ko/web/css/initial_value/index.html
@@ -47,5 +47,30 @@ translation_of: Web/CSS/initial_value
 
 <ul>
  <li><a href="/ko/docs/Web/CSS/CSS_Reference" title="CSS Reference">CSS Reference</a></li>
- <li>{{CSS_key_concepts}}</li>
+ <li>CSS 주요 개념
+  <ul>
+    <li><a href="/ko/docs/Web/CSS/Syntax">CSS 문법</a></li>
+    <li><a href="/ko/docs/Web/CSS/At-rule">@규칙</a></li>
+    <li><a href="/ko/docs/Web/CSS/Comments">주석</a></li>
+    <li><a href="/ko/docs/Web/CSS/Specificity">명시도</a></li>
+    <li><a href="/ko/docs/Web/CSS/inheritance">상속</a></li>
+    <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">박스 모델</a></li>
+    <li><a href="/ko/docs/Web/CSS/Layout_mode">레이아웃 모드</a></li>
+    <li><a href="/ko/docs/Web/CSS/Visual_formatting_model">시각적 서식 모델</a></li>
+    <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">마진 중첩</a></li>
+    <li>값
+      <ul>
+        <li><a href="/ko/docs/Web/CSS/initial_value">초깃값</a></li>
+        <li><a href="/ko/docs/Web/CSS/computed_value">계산값</a></li>
+        <li><a href="/ko/docs/Web/CSS/resolved_value">결정값</a></li>
+        <li><a href="/ko/docs/Web/CSS/specified_value">지정값</a></li>
+        <li><a href="/ko/docs/Web/CSS/used_value">사용값</a></li>
+        <li><a href="/ko/docs/Web/CSS/actual_value">실제값</a></li>
+      </ul>
+    </li>
+    <li><a href="/ko/docs/Web/CSS/Value_definition_syntax">값 정의 구문</a></li>
+    <li><a href="/ko/docs/Web/CSS/Shorthand_properties">단축 속성</a></li>
+    <li><a href="/ko/docs/Web/CSS/Replaced_element">대체 요소</a></li>
+  </ul>
+</li>
 </ul>

--- a/files/ko/web/css/layout_mode/index.html
+++ b/files/ko/web/css/layout_mode/index.html
@@ -28,5 +28,30 @@ translation_of: Web/CSS/Layout_mode
 <h2 id="같이_보기">같이 보기</h2>
 
 <ul>
- <li>{{CSS_key_concepts}}</li>
+  <li>CSS 주요 개념
+    <ul>
+      <li><a href="/ko/docs/Web/CSS/Syntax">CSS 문법</a></li>
+      <li><a href="/ko/docs/Web/CSS/At-rule">@규칙</a></li>
+      <li><a href="/ko/docs/Web/CSS/Comments">주석</a></li>
+      <li><a href="/ko/docs/Web/CSS/Specificity">명시도</a></li>
+      <li><a href="/ko/docs/Web/CSS/inheritance">상속</a></li>
+      <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">박스 모델</a></li>
+      <li><a href="/ko/docs/Web/CSS/Layout_mode">레이아웃 모드</a></li>
+      <li><a href="/ko/docs/Web/CSS/Visual_formatting_model">시각적 서식 모델</a></li>
+      <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">마진 중첩</a></li>
+      <li>값
+        <ul>
+          <li><a href="/ko/docs/Web/CSS/initial_value">초깃값</a></li>
+          <li><a href="/ko/docs/Web/CSS/computed_value">계산값</a></li>
+          <li><a href="/ko/docs/Web/CSS/resolved_value">결정값</a></li>
+          <li><a href="/ko/docs/Web/CSS/specified_value">지정값</a></li>
+          <li><a href="/ko/docs/Web/CSS/used_value">사용값</a></li>
+          <li><a href="/ko/docs/Web/CSS/actual_value">실제값</a></li>
+        </ul>
+      </li>
+      <li><a href="/ko/docs/Web/CSS/Value_definition_syntax">값 정의 구문</a></li>
+      <li><a href="/ko/docs/Web/CSS/Shorthand_properties">단축 속성</a></li>
+      <li><a href="/ko/docs/Web/CSS/Replaced_element">대체 요소</a></li>
+    </ul>
+  </li>
 </ul>

--- a/files/ko/web/css/resolved_value/index.html
+++ b/files/ko/web/css/resolved_value/index.html
@@ -35,5 +35,30 @@ translation_of: Web/CSS/resolved_value
 
 <ul>
  <li>{{domxref("window.getComputedStyle")}}</li>
- <li>{{CSS_key_concepts}}</li>
+ <li>CSS 주요 개념
+  <ul>
+    <li><a href="/ko/docs/Web/CSS/Syntax">CSS 문법</a></li>
+    <li><a href="/ko/docs/Web/CSS/At-rule">@규칙</a></li>
+    <li><a href="/ko/docs/Web/CSS/Comments">주석</a></li>
+    <li><a href="/ko/docs/Web/CSS/Specificity">명시도</a></li>
+    <li><a href="/ko/docs/Web/CSS/inheritance">상속</a></li>
+    <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">박스 모델</a></li>
+    <li><a href="/ko/docs/Web/CSS/Layout_mode">레이아웃 모드</a></li>
+    <li><a href="/ko/docs/Web/CSS/Visual_formatting_model">시각적 서식 모델</a></li>
+    <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">마진 중첩</a></li>
+    <li>값
+      <ul>
+        <li><a href="/ko/docs/Web/CSS/initial_value">초깃값</a></li>
+        <li><a href="/ko/docs/Web/CSS/computed_value">계산값</a></li>
+        <li><a href="/ko/docs/Web/CSS/resolved_value">결정값</a></li>
+        <li><a href="/ko/docs/Web/CSS/specified_value">지정값</a></li>
+        <li><a href="/ko/docs/Web/CSS/used_value">사용값</a></li>
+        <li><a href="/ko/docs/Web/CSS/actual_value">실제값</a></li>
+      </ul>
+    </li>
+    <li><a href="/ko/docs/Web/CSS/Value_definition_syntax">값 정의 구문</a></li>
+    <li><a href="/ko/docs/Web/CSS/Shorthand_properties">단축 속성</a></li>
+    <li><a href="/ko/docs/Web/CSS/Replaced_element">대체 요소</a></li>
+  </ul>
+</li>
 </ul>

--- a/files/ko/web/css/specificity/index.html
+++ b/files/ko/web/css/specificity/index.html
@@ -327,5 +327,30 @@ h1 {
 <ul>
  <li>명시도 계산기: CSS 규칙을 테스트하고 이해할 수 있는 대화형 웹사이트 - <a href="https://specificity.keegan.st/">https://specificity.keegan.st/</a></li>
  <li>CSS3 선택자 명시도 - <a class="external" href="http://www.w3.org/TR/selectors/#specificity" rel="freelink">http://www.w3.org/TR/selectors/#specificity</a></li>
- <li>{{CSS_key_concepts}}</li>
+ <li>CSS 주요 개념
+  <ul>
+    <li><a href="/ko/docs/Web/CSS/Syntax">CSS 문법</a></li>
+    <li><a href="/ko/docs/Web/CSS/At-rule">@규칙</a></li>
+    <li><a href="/ko/docs/Web/CSS/Comments">주석</a></li>
+    <li><a href="/ko/docs/Web/CSS/Specificity">명시도</a></li>
+    <li><a href="/ko/docs/Web/CSS/inheritance">상속</a></li>
+    <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">박스 모델</a></li>
+    <li><a href="/ko/docs/Web/CSS/Layout_mode">레이아웃 모드</a></li>
+    <li><a href="/ko/docs/Web/CSS/Visual_formatting_model">시각적 서식 모델</a></li>
+    <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">마진 중첩</a></li>
+    <li>값
+      <ul>
+        <li><a href="/ko/docs/Web/CSS/initial_value">초깃값</a></li>
+        <li><a href="/ko/docs/Web/CSS/computed_value">계산값</a></li>
+        <li><a href="/ko/docs/Web/CSS/resolved_value">결정값</a></li>
+        <li><a href="/ko/docs/Web/CSS/specified_value">지정값</a></li>
+        <li><a href="/ko/docs/Web/CSS/used_value">사용값</a></li>
+        <li><a href="/ko/docs/Web/CSS/actual_value">실제값</a></li>
+      </ul>
+    </li>
+    <li><a href="/ko/docs/Web/CSS/Value_definition_syntax">값 정의 구문</a></li>
+    <li><a href="/ko/docs/Web/CSS/Shorthand_properties">단축 속성</a></li>
+    <li><a href="/ko/docs/Web/CSS/Replaced_element">대체 요소</a></li>
+  </ul>
+</li>
 </ul>

--- a/files/ko/web/css/used_value/index.html
+++ b/files/ko/web/css/used_value/index.html
@@ -123,5 +123,30 @@ window.addEventListener('resize', updateAllUsedWidths);
 
 <ul>
  <li>{{domxref("window.getComputedStyle")}}</li>
- <li>{{css_key_concepts}}</li>
+ <li>CSS 주요 개념
+  <ul>
+    <li><a href="/ko/docs/Web/CSS/Syntax">CSS 문법</a></li>
+    <li><a href="/ko/docs/Web/CSS/At-rule">@규칙</a></li>
+    <li><a href="/ko/docs/Web/CSS/Comments">주석</a></li>
+    <li><a href="/ko/docs/Web/CSS/Specificity">명시도</a></li>
+    <li><a href="/ko/docs/Web/CSS/inheritance">상속</a></li>
+    <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">박스 모델</a></li>
+    <li><a href="/ko/docs/Web/CSS/Layout_mode">레이아웃 모드</a></li>
+    <li><a href="/ko/docs/Web/CSS/Visual_formatting_model">시각적 서식 모델</a></li>
+    <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">마진 중첩</a></li>
+    <li>값
+      <ul>
+        <li><a href="/ko/docs/Web/CSS/initial_value">초깃값</a></li>
+        <li><a href="/ko/docs/Web/CSS/computed_value">계산값</a></li>
+        <li><a href="/ko/docs/Web/CSS/resolved_value">결정값</a></li>
+        <li><a href="/ko/docs/Web/CSS/specified_value">지정값</a></li>
+        <li><a href="/ko/docs/Web/CSS/used_value">사용값</a></li>
+        <li><a href="/ko/docs/Web/CSS/actual_value">실제값</a></li>
+      </ul>
+    </li>
+    <li><a href="/ko/docs/Web/CSS/Value_definition_syntax">값 정의 구문</a></li>
+    <li><a href="/ko/docs/Web/CSS/Shorthand_properties">단축 속성</a></li>
+    <li><a href="/ko/docs/Web/CSS/Replaced_element">대체 요소</a></li>
+  </ul>
+</li>
 </ul>

--- a/files/ko/web/css/visual_formatting_model/index.html
+++ b/files/ko/web/css/visual_formatting_model/index.html
@@ -220,5 +220,30 @@ original_slug: Web/Guide/CSS/Visual_formatting_model
 <h2 id="참조_항목">참조 항목</h2>
 
 <ul>
- <li>{{css_key_concepts}}</li>
+  <li>CSS 주요 개념
+    <ul>
+      <li><a href="/ko/docs/Web/CSS/Syntax">CSS 문법</a></li>
+      <li><a href="/ko/docs/Web/CSS/At-rule">@규칙</a></li>
+      <li><a href="/ko/docs/Web/CSS/Comments">주석</a></li>
+      <li><a href="/ko/docs/Web/CSS/Specificity">명시도</a></li>
+      <li><a href="/ko/docs/Web/CSS/inheritance">상속</a></li>
+      <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">박스 모델</a></li>
+      <li><a href="/ko/docs/Web/CSS/Layout_mode">레이아웃 모드</a></li>
+      <li><a href="/ko/docs/Web/CSS/Visual_formatting_model">시각적 서식 모델</a></li>
+      <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">마진 중첩</a></li>
+      <li>값
+        <ul>
+          <li><a href="/ko/docs/Web/CSS/initial_value">초깃값</a></li>
+          <li><a href="/ko/docs/Web/CSS/computed_value">계산값</a></li>
+          <li><a href="/ko/docs/Web/CSS/resolved_value">결정값</a></li>
+          <li><a href="/ko/docs/Web/CSS/specified_value">지정값</a></li>
+          <li><a href="/ko/docs/Web/CSS/used_value">사용값</a></li>
+          <li><a href="/ko/docs/Web/CSS/actual_value">실제값</a></li>
+        </ul>
+      </li>
+      <li><a href="/ko/docs/Web/CSS/Value_definition_syntax">값 정의 구문</a></li>
+      <li><a href="/ko/docs/Web/CSS/Shorthand_properties">단축 속성</a></li>
+      <li><a href="/ko/docs/Web/CSS/Replaced_element">대체 요소</a></li>
+    </ul>
+  </li>
 </ul>


### PR DESCRIPTION
#7343 - ko

@hochan222 번역 리뷰 부탁드리겠습니다! 🙏
```html
<li>CSS 주요 개념
  <ul>
    <li><a href="/ko/docs/Web/CSS/Syntax">CSS 문법</a></li>
    <li><a href="/ko/docs/Web/CSS/At-rule">@규칙</a></li>
    <li><a href="/ko/docs/Web/CSS/Comments">주석</a></li>
    <li><a href="/ko/docs/Web/CSS/Specificity">명시도</a></li>
    <li><a href="/ko/docs/Web/CSS/inheritance">상속</a></li>
    <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model">박스 모델</a></li>
    <li><a href="/ko/docs/Web/CSS/Layout_mode">레이아웃 모드</a></li>
    <li><a href="/ko/docs/Web/CSS/Visual_formatting_model">시각적 서식 모델</a></li>
    <li><a href="/ko/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">마진 중첩</a></li>
    <li>값
      <ul>
        <li><a href="/ko/docs/Web/CSS/initial_value">초깃값</a></li>
        <li><a href="/ko/docs/Web/CSS/computed_value">계산값</a></li>
        <li><a href="/ko/docs/Web/CSS/resolved_value">결정값</a></li>
        <li><a href="/ko/docs/Web/CSS/specified_value">지정값</a></li>
        <li><a href="/ko/docs/Web/CSS/used_value">사용값</a></li>
        <li><a href="/ko/docs/Web/CSS/actual_value">실제값</a></li>
      </ul>
    </li>
    <li><a href="/ko/docs/Web/CSS/Value_definition_syntax">값 정의 구문</a></li>
    <li><a href="/ko/docs/Web/CSS/Shorthand_properties">단축 속성</a></li>
    <li><a href="/ko/docs/Web/CSS/Replaced_element">대체 요소</a></li>
  </ul>
</li>
```