### PR TITLE
Restore accidentally-removed #Quick_links sections (es)

### DIFF
--- a/files/es/glossary/accessibility_tree/index.md
+++ b/files/es/glossary/accessibility_tree/index.md
@@ -25,6 +25,14 @@ Hay cuatro elementos en un árbol de objeto de accesibilidad:
 
 Además, el árbol de accesibilidad usualmente contiene información sobre lo que se puede hacer con un elemento: _seguir_ un enlace, _completar_ un cuadro de texto, etc.
 
-- [Glossary](/es/docs/Glossary)
-  - {{Glossary("Accessibility")}}
-  - {{Glossary("ARIA")}}
+<section id="Quick_links">
+ <ol>
+  <li><a href="/es/docs/Glossary">Glossary</a>
+ 
+   <ol>
+    <li>{{Glossary("Accessibility")}}</li>
+    <li>{{Glossary("ARIA")}}</li>
+   </ol>
+  </li>
+ </ol>
+</section>

--- a/files/es/glossary/call_stack/index.md
+++ b/files/es/glossary/call_stack/index.md
@@ -59,12 +59,14 @@ El código del ejemplo se ejecutaría de la siguiente manera:
 
 En resumen, empezamos con una lista de la pila llamadas vacía. Cuando invocamos una función, ésta es automáticamente añadida a la pila de llamadas. Una vez ha ejecutado todo su código, también de manera automática es eliminada de la pila de llamadas. Finalmente, la pila de llamadas vuelve a estar vacía.
 
-## Saber más
-
-### Conocimiento general
-
-- {{Interwiki("wikipedia", "Pila de llamadas")}} en Wikipedia
-
-- [Glosario](/es/docs/Glossary)
-  - {{Glossary("Call stack", "Pila de llamadas")}}
-  - {{Glossary("function", "Función")}}
+<section id="Quick_links">
+ <ul>
+  <li><a href="/es/docs/Glossary">Glosario</a>
+ 
+   <ul>
+    <li>{{Glossary("Call stack", "Pila de llamadas")}}</li>
+    <li>{{Glossary("function", "Función")}}</li>
+   </ul>
+  </li>
+ </ul>
+</section>

--- a/files/es/glossary/character_set/index.md
+++ b/files/es/glossary/character_set/index.md
@@ -14,11 +14,19 @@ En épocas anteriores, los países desarrollaron sus propios conjuntos de caract
 
 Si un conjunto de caracteres se usa incorrectamente (por ejemplo, Unicode para un artículo codificado en Big5), es posible que no vean más que caracteres rotos, que se llaman {{Interwiki("wikipedia", "Mojibake")}}.
 
-## Saber más
-
-- Artículos de Wikipedia
-  - {{Interwiki("wikipedia", "Codificación_de_caracteres", "Codificación de caracteres")}}
-  - {{Interwiki("wikipedia", "Mojibake")}}
-- [Glosario](/es/docs/Glossary)
-  - {{Glossary("Character", "Caracter")}}
-  - {{Glossary("Unicode")}}
+<section id="Quick_links">
+  <ol>
+    <li>Artículos de Wikipedia
+     <ol>
+      <li>{{Interwiki("wikipedia", "Codificación_de_caracteres", "Codificación de caracteres")}}</li>
+      <li>{{Interwiki("wikipedia", "Mojibake")}}</li>
+     </ol>
+    </li>
+    <li><a href="/es/docs/Glossary">Glosario</a>
+     <ol>
+      <li>{{Glossary("Character", "Caracter")}}</li>
+      <li>{{Glossary("Unicode")}}</li>
+     </ol>
+    </li>
+  </ol>
+</section>

--- a/files/es/glossary/first-class_function/index.md
+++ b/files/es/glossary/first-class_function/index.md
@@ -92,8 +92,15 @@ Usamos parétesis dobre `()()` para invocar también a la función retornada.
 
 ### Conocimiento general
 
-- {{Interwiki("wikipedia", "First-class_function", "First-class functions")}} on Wikipedia
-- [Glosario](/es/docs/Glossary)
-   - {{glossary("Callback function")}}
-   - {{glossary("Function")}}
-   - {{glossary("Variable")}}
+<section id="Quick_links">
+ <ol>
+  <li>{{Interwiki("wikipedia", "First-class_function", "First-class functions")}} on Wikipedia</li>
+  <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
+   <ul>
+    <li>{{glossary("Callback function")}}</li>
+    <li>{{glossary("Function")}}</li>
+    <li>{{glossary("Variable")}}</li>
+   </ul>
+  </li>
+ </ol>
+</section>

--- a/files/es/glossary/identifier/index.md
+++ b/files/es/glossary/identifier/index.md
@@ -16,14 +16,17 @@ En {{Glossary("JavaScript")}}, los identificadores distinguen entre mayúsculas 
 
 Un identificador se diferencia de una cadena en que una {{Glossary("String", "cadena")}} son datos, mientras que un identificador es parte del código. En JavaScript, no hay forma de convertir identificadores en cadenas, pero a veces es posible procesar cadenas como identificadores.
 
-## Aprende más
-
-### Conocimientos generales
-
-- {{interwiki("wikipedia", "Identificador#Identificadores_en_lenguajes_informáticos", "Identificador")}} en Wikipedia
-
-- [Glosario](/es/docs/Glossary)
-  - {{Glossary("Identifier", "Identificador")}}
-  - {{Glossary("Scope", "Alcance")}}
-  - {{Glossary("String", "Cadena")}}
-  - {{Glossary("Unicode")}}
+<section id="Quick_links">
+ <ol>
+  <li><a href="/es/docs/Glossary">Glosario</a>
+ 
+   <ol>
+    <li>{{Glossary("Identifier", "Identificador")}}</li>
+    <li>{{Glossary("Scope", "Alcance")}}</li>
+    <li>{{Glossary("String", "Cadena")}}</li>
+    <li>{{Glossary("Unicode")}}</li>
+   </ol>
+  </li>
+  <li>{{interwiki("wikipedia", "Identificador#Identificadores_en_lenguajes_informáticos", "Identificador")}} en Wikipedia</li>
+ </ol>
+</section>

--- a/files/es/glossary/main_thread/index.md
+++ b/files/es/glossary/main_thread/index.md
@@ -13,10 +13,19 @@ El hilo principal es donde un navegador procesa eventos y pinturas del usuario. 
 
 A menos que use intencionalmente un trabajador web, como un trabajador de servicio, JavaScript se ejecuta en el hilo principal, por lo que es fácil que un script provoque retrasos en el procesamiento o la pintura de eventos. Cuanto menos trabajo se requiera del hilo principal, más puede responder ese hilo a los eventos del usuario, pintar y, en general, responder al usuario.
 
-## Aprende más
-
-- [Asynchronous JavaScript](/es/docs/Learn/JavaScript/Asynchronous)
-- [Web worker API](/es/docs/Web/API/Web_Workers_API)
-- [Service worker API](/es/docs/Web/API/Service_Worker_API)
-- [Glossary](/es/docs/Glossary)
-  - {{Glossary("Thread")}}
+<section id="Quick_links">
+  <ol>
+    <li>También ver
+     <ol>
+      <li><a href="/es/docs/Learn/JavaScript/Asynchronous">Asynchronous JavaScript</a></li>
+      <li><a href="/es/docs/Web/API/Web_Workers_API">Web worker API</a></li>
+      <li><a href="/es/docs/Web/API/Service_Worker_API">Service worker API</a></li>
+     </ol>
+    </li>
+    <li><a href="/es/docs/Glossary">Glossary</a>
+     <ol>
+      <li>{{Glossary("Thread")}}</li>
+     </ol>
+    </li>
+  </ol>
+</section>

--- a/files/es/glossary/php/index.md
+++ b/files/es/glossary/php/index.md
@@ -46,12 +46,18 @@ PHP (una inicialización recursiva para PHP: preprocesador de hipertexto) es un 
 ?>
 ```
 
-1.  [Official website](http://php.net/)
-2.  {{Interwiki("wikipedia", "PHP")}} en Wikipedia
-3.  [PHP](https://en.wikibooks.org/wiki/PHP_Programming) en Wikibooks
-4.  [MDN Web Docs Glossary](/en-US/docs/Glossary)
-
-    1.  {{Glossary("Java")}}
-    2.  {{Glossary("JavaScript")}}
-    3.  {{Glossary("Python")}}
-    4.  {{Glossary("Ruby")}}
+<section id="Quick_links">
+ <ol>
+  <li><a href="http://php.net/">Official website</a></li>
+  <li>{{Interwiki("wikipedia", "PHP")}} en Wikipedia</li>
+  <li><a href="https://en.wikibooks.org/wiki/PHP_Programming">PHP</a> en Wikibooks</li>
+  <li><a href="/es/docs/Glossary">MDN Web Docs Glossary</a>
+   <ol>
+    <li>{{Glossary("Java")}}</li>
+    <li>{{Glossary("JavaScript")}}</li>
+    <li>{{Glossary("Python")}}</li>
+    <li>{{Glossary("Ruby")}}</li>
+   </ol>
+  </li>
+ </ol>
+</section>

--- a/files/es/glossary/pop/index.md
+++ b/files/es/glossary/pop/index.md
@@ -13,10 +13,16 @@ translation_of: Glossary/POP
 
 Los clientes usualmente recuperan todos los mensajes y luego los eliminan del servidor, pero POP3 permite retener una copia en el servidor. Casi todos los servidores y clientes de correo actualmente soportan POP3.
 
-- [POP](https://es.wikipedia.org/wiki/Protocolo_de_oficina_de_correo) en Wikipedia
-- [RFC 1734](https://tools.ietf.org/html/rfc1734) (Especificación del mecanismo de autenticación de POP3)
-- [RFC 1939](https://tools.ietf.org/html/rfc1939) (Especificación de POP3)
-- [RFC 2449](https://tools.ietf.org/html/rfc2449) (Especificación del mecanismo de extensión de POP3)
-- [MDN Glosario de Web Docs](/es/docs/Glossary):
-
-  - [IMAP4](/es/docs/Glossary/IMAP)
+<section id="Quick_links">
+ <ul>
+  <li><a href="https://es.wikipedia.org/wiki/Protocolo_de_oficina_de_correo">POP</a> en Wikipedia</li>
+  <li><a href="https://tools.ietf.org/html/rfc1734">RFC 1734</a> (Especificación del mecanismo de autenticación de POP3)</li>
+  <li><a href="https://tools.ietf.org/html/rfc1939">RFC 1939</a> (Especificación de POP3)</li>
+  <li><a href="https://tools.ietf.org/html/rfc2449">RFC 2449</a> (Especificación del mecanismo de extensión de POP3)</li>
+  <li><a href="/es/docs/Glossary">MDN Glosario de Web Docs</a>:
+   <ul>
+    <li><a href="/es/docs/Glossary/IMAP">IMAP4</a></li>
+   </ul>
+  </li>
+ </ul>
+</section>

--- a/files/es/glossary/primitive/index.md
+++ b/files/es/glossary/primitive/index.md
@@ -94,22 +94,21 @@ A excepción de `null` y `undefined`, todos los valores primitivos tienen objeto
 
 El método {{JSxRef("Objetos_globales/Object/valueOf"," valueOf()")}} del contenedor devuelve el valor primitivo.
 
-## Aprende más
-
-### Conocimientos generales
-
-- {{JSxRef("../Data_structures", "Introducción a los tipos de datos de JavaScript")}}
-- {{Interwiki("wikipedia", "Tipo de dato primitivo")}} en Wikipedia
-
-1.  {{Link("/es/docs/Glossary")}}
-
-    1.  {{Glossary("JavaScript")}}
-    2.  {{Glossary("string")}}
-    3.  {{Glossary("number")}}
-    4.  {{Glossary("bigint")}}
-    5.  {{Glossary("boolean")}}
-    6.  {{Glossary("null")}}
-    7.  {{Glossary("undefined")}}
-    8.  {{Glossary("symbol")}}
-
-2.  {{JSxRef("../Data_structures", "Tipos de datos JavaScript")}}
+<section id="Quick_links">
+ <ol>
+  <li>{{Link("/es/docs/Glossary")}}
+ 
+   <ol>
+    <li>{{Glossary("JavaScript")}}</li>
+    <li>{{Glossary("string")}}</li>
+    <li>{{Glossary("number")}}</li>
+    <li>{{Glossary("bigint")}}</li>
+    <li>{{Glossary("boolean")}}</li>
+    <li>{{Glossary("null")}}</li>
+    <li>{{Glossary("undefined")}}</li>
+    <li>{{Glossary("symbol")}}</li>
+   </ol>
+  </li>
+  <li>{{JSxRef("../Data_structures", "Tipos de datos JavaScript")}}</li>
+ </ol>
+</section>

--- a/files/es/glossary/smtp/index.md
+++ b/files/es/glossary/smtp/index.md
@@ -13,13 +13,20 @@ translation_of: Glossary/SMTP
 
 El protocolo es relativamente simple. Las complicaciones principales incluyen soportar varios mecanismos de autenticación ([GSSAPI](http://en.wikipedia.org/wiki/Generic_Security_Services_Application_Program_Interface), [CRAM-MD5](http://en.wikipedia.org/wiki/CRAM-MD5), [NTLM](http://en.wikipedia.org/wiki/NTLM), MSN, AUTH LOGIN, AUTH PLAIN, etc.), manejo de respuestas de error, y retroceder cuando los mecanismos de autenticación fallan (p. ej., el servidor asegura que soporta un mecanismo, pero no).
 
-1.  [Glosario](/es/docs/Glossary)
-
-    1.  [NNTP](/es/docs/Glossary/NNTP)
-    2.  [POP3](/es/docs/Glossary/POP)
-    3.  [protocolo](/es/docs/Glossary/Protocol)
-    4.  [estado de máquina](/es/docs/Glossary/State_machine)
-
-2.  Artículos de Wikipedia
-
-    1.  [SMTP](https://es.wikipedia.org/wiki/Protocolo_para_transferencia_simple_de_correo)
+<section id="Quick_links">
+  <ol>
+    <li><a href="/es/docs/Glossary">Glosario</a>
+     <ol>
+      <li><a href="/es/docs/Glossary/NNTP">NNTP</a></li>
+      <li><a href="/es/docs/Glossary/POP">POP3</a></li>
+      <li><a href="/es/docs/Glossary/Protocol">protocolo</a></li>
+      <li><a href="/es/docs/Glossary/State_machine">estado de máquina</a></li>
+     </ol>
+    </li>
+    <li>Artículos de Wikipedia
+     <ol>
+      <li><a href="https://es.wikipedia.org/wiki/Protocolo_para_transferencia_simple_de_correo">SMTP</a></li>
+     </ol>
+    </li>
+  </ol>
+</section>

--- a/files/es/glossary/whitespace/index.md
+++ b/files/es/glossary/whitespace/index.md
@@ -18,20 +18,29 @@ La [_HTML Living Standard_](https://html.spec.whatwg.org/) especifica 5 caracter
 
 La [especificación del lenguaje ECMAScript® 2015](https://www.ecma-international.org/ecma-262/6.0/#sec-white-space) establece varios puntos de código Unicode como espacio en blanco: `U+0009` CARACTERES de TABULACIÓN \<TAB>, `U+000B` TABULACIÓN DE LÍNEA \<VT>, `U+000C` FORM FEED \<FF>, `U+0020` ESPACIO \<SP>, `U+00A0` ESPACIO SIN ROTURA \<NBSP>, `U+FEFF` ANCHO CERO NO -BREAK SPACE \<ZWNBSP> y otra categoría “Zs” Cualquier otro punto de código Unicode “Separador, espacio” \<USP>. Estos caracteres suelen ser innecesarios para la funcionalidad del código.
 
-1.  Especificaciones
-
-    1.  [Espacio en blanco ASCII](https://infra.spec.whatwg.org/#ascii-whitespace)
-    2.  [Especificación del lenguaje ECMAScript® 2015](https://www.ecma-international.org/ecma-262/6.0/#sec-white-space)
-
-2.  Referencias
-
-    1.  [Cómo se manejan los espacios en blanco mediante HTML, CSS y el DOM](/es/docs/Web/API/Document_Object_Model/Whitespace)
-    2.  {{cssxref("white-space")}}
-
-3.  Artículos de Wikipedia
-
-    1.  {{interwiki("wikipedia", "El caracter de espacio en blanco")}}
-
-4.  [Glosario](/es/docs/Glossary)
-
-    1.  {{Glossary("Character", "Caracter")}}
+<section id="Quick_links">
+ <ol>
+  <li>Especificaciones
+   <ol>
+    <li><a href="https://infra.spec.whatwg.org/#ascii-whitespace">Espacio en blanco ASCII</a></li>
+    <li><a href="https://www.ecma-international.org/ecma-262/6.0/#sec-white-space">Especificación del lenguaje ECMAScript® 2015</a></li>
+   </ol>
+  </li>
+  <li>Referencias
+   <ol>
+    <li><a href="/es/docs/Web/API/Document_Object_Model/Whitespace">Cómo se manejan los espacios en blanco mediante HTML, CSS y el DOM</a></li>
+    <li>{{cssxref("white-space")}}</li>
+   </ol>
+  </li>
+  <li>Artículos de Wikipedia
+   <ol>
+    <li>{{interwiki("wikipedia", "El caracter de espacio en blanco")}}</li>
+   </ol>
+  </li>
+  <li><a href="/es/docs/Glossary">Glosario</a>
+   <ol>
+    <li>{{Glossary("Character", "Caracter")}}</li>
+   </ol>
+  </li>
+ </ol>
+</section>

--- a/files/es/glossary/wrapper/index.md
+++ b/files/es/glossary/wrapper/index.md
@@ -17,8 +17,15 @@ Por ejemplo, las librerías SDK de AWS son un ejemplo de wrappers.
 
 {{Interwiki("wikipedia", "Wrapper function")}} on Wikipedia
 
-1.  [MDN Web Docs Glossary](https://developer.mozilla.org/es/docs/Glossary)
-
-    1.  {{Glossary("API")}}
-    2.  {{Glossary("Class")}}
-    3.  {{Glossary("Function")}}
+<section id="Quick_links">
+ <ol>
+  <li><a href="es/docs/Glossary">MDN Web Docs Glossary</a>
+ 
+   <ol>
+    <li>{{Glossary("API")}}</li>
+    <li>{{Glossary("Class")}}</li>
+    <li>{{Glossary("Function")}}</li>
+   </ol>
+  </li>
+ </ol>
+</section>


### PR DESCRIPTION
This PR is a follow-up to #7376 that restores the `#Quick_links` `<section>` elements.  During Markdown conversion, I didn't realize these sections were still used for the sidebars.
