### PR TITLE
[ko] replace compatibility new macro - 1

### DIFF
--- a/files/ko/conflicting/web/api/element/click_event/index.html
+++ b/files/ko/conflicting/web/api/element/click_event/index.html
@@ -69,13 +69,9 @@ function inputChange(e) {
  </tbody>
 </table>
 
-<h2 id="브라우저_호환성">브라우저 호환성</h2>
+<h2 id="Browser_compatibility">브라우저 호환성</h2>
 
-<div>
-
-
-<p>{{Compat("api.GlobalEventHandlers.onclick")}}</p>
-</div>
+{{Compat}}
 
 <h2 id="같이_보기">같이 보기</h2>
 

--- a/files/ko/conflicting/web/api/element/keydown_event/index.html
+++ b/files/ko/conflicting/web/api/element/keydown_event/index.html
@@ -56,6 +56,6 @@ function logKey(e) {
  </tbody>
 </table>
 
-<h2 id="브라우저_호환성">브라우저 호환성</h2>
+<h2 id="Browser_compatibility">브라우저 호환성</h2>
 
-<p>{{Compat("api.GlobalEventHandlers.onkeydown")}}</p>
+{{Compat}}

--- a/files/ko/conflicting/web/javascript/reference/global_objects/array/tostring/index.html
+++ b/files/ko/conflicting/web/javascript/reference/global_objects/array/tostring/index.html
@@ -56,13 +56,9 @@ alpha.toSource();
 
 <p>Not part of any standard. Implemented in JavaScript 1.3.</p>
 
-<h2 id="브라우저_호환성">브라우저 호환성</h2>
+<h2 id="Browser_compatibility">브라우저 호환성</h2>
 
-<div>
-
-
-<p>{{Compat("javascript.builtins.Array.toSource")}}</p>
-</div>
+{{Compat}}
 
 <h2 id="같이_보기">같이 보기</h2>
 

--- a/files/ko/conflicting/web/javascript/reference/global_objects/index.html
+++ b/files/ko/conflicting/web/javascript/reference/global_objects/index.html
@@ -54,9 +54,9 @@ foo(); // "hi"를 반환
 
 <p>어떤 명세에도 속하지 않습니다.</p>
 
-<h2 id="브라우저_호환성">브라우저 호환성</h2>
+<h2 id="Browser_compatibility">브라우저 호환성</h2>
 
-<p>{{Compat("javascript.builtins.uneval")}}</p>
+{{Compat}}
 
 <h2 id="같이_보기">같이 보기</h2>
 

--- a/files/ko/mozilla/add-ons/webextensions/api/contentscripts/index.html
+++ b/files/ko/mozilla/add-ons/webextensions/api/contentscripts/index.html
@@ -31,8 +31,8 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/contentScripts
  <dd>주어진 콘텐츠 스크립트를 등록한다</dd>
 </dl>
 
-<h2 id="브라우저_호환성">브라우저 호환성</h2>
+<h2 id="Browser_compatibility">브라우저 호환성</h2>
 
-<p>{{Compat("webextensions.api.contentScripts", 10, 1)}}</p>
+{{Compat}}
 
 <p>{{WebExtExamples("h2")}}</p>

--- a/files/ko/mozilla/add-ons/webextensions/api/menus/contexttype/index.html
+++ b/files/ko/mozilla/add-ons/webextensions/api/menus/contexttype/index.html
@@ -51,9 +51,9 @@ original_slug: Mozilla/Add-ons/WebExtensions/API/contextMenus/ContextType
 
 <p>"launcher"는 지원되지 않는다.</p>
 
-<h2 id="브라우저_호환성">브라우저 호환성</h2>
+<h2 id="Browser_compatibility">브라우저 호환성</h2>
 
-<p>{{Compat("webextensions.api.menus.ContextType", 10)}}</p>
+{{Compat}}
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/ko/mozilla/add-ons/webextensions/api/menus/create/index.html
+++ b/files/ko/mozilla/add-ons/webextensions/api/menus/create/index.html
@@ -111,9 +111,9 @@ original_slug: Mozilla/Add-ons/WebExtensions/API/contextMenus/create
 
 <p><code><code>integer</code></code> or <code><code>string</code></code>. The ID of the newly created item.</p>
 
-<h2 id="브라우저_호환성">브라우저 호환성</h2>
+<h2 id="Browser_compatibility">브라우저 호환성</h2>
 
-<p>{{Compat("webextensions.api.menus.create", 10)}}</p>
+{{Compat}}
 
 <h2 id="예제">예제</h2>
 

--- a/files/ko/mozilla/add-ons/webextensions/api/menus/gettargetelement/index.html
+++ b/files/ko/mozilla/add-ons/webextensions/api/menus/gettargetelement/index.html
@@ -45,11 +45,9 @@ original_slug: Mozilla/Add-ons/WebExtensions/API/contextMenus/getTargetElement
 
 <p>{{WebExtExamples}}</p>
 
-<h2 id="브라우저_호환성">브라우저 호환성</h2>
+<h2 id="Browser_compatibility">브라우저 호환성</h2>
 
-
-
-<p>{{Compat("webextensions.api.menus.getTargetElement")}}</p>
+{{Compat}}
 
 <h2 id="같이_보기">같이 보기</h2>
 

--- a/files/ko/mozilla/add-ons/webextensions/api/menus/index.html
+++ b/files/ko/mozilla/add-ons/webextensions/api/menus/index.html
@@ -141,9 +141,9 @@ browser.menus.create({
  <dd>콘텍스트 메뉴 항목이 클릭하면 발생한다.</dd>
 </dl>
 
-<h2 id="브라우저_호환성">브라우저 호환성</h2>
+<h2 id="Browser_compatibility">브라우저 호환성</h2>
 
-<p>{{ Compat("webextensions.api.menus", 1, "true") }}</p>
+{{Compat}}
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/ko/mozilla/add-ons/webextensions/api/menus/onshown/index.html
+++ b/files/ko/mozilla/add-ons/webextensions/api/menus/onshown/index.html
@@ -115,9 +115,9 @@ browser.menus.onShown.hasListener(listener)
  </dd>
 </dl>
 
-<h2 id="브라우저_호환성">브라우저 호환성</h2>
+<h2 id="Browser_compatibility">브라우저 호환성</h2>
 
-<p>{{Compat("webextensions.api.menus.onShown", 10)}}</p>
+{{Compat}}
 
 <h2 id="예제">예제</h2>
 

--- a/files/ko/mozilla/add-ons/webextensions/api/pageaction/index.html
+++ b/files/ko/mozilla/add-ons/webextensions/api/pageaction/index.html
@@ -54,9 +54,9 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/pageAction
  <dd>페이지 액션의 아이콘이 클릭되면 발생한다. 페이지 액션이 팝업이 설정되어 있으면 발생하지 않는다.</dd>
 </dl>
 
-<h2 id="브라우저_호환성">브라우저 호환성</h2>
+<h2 id="Browser_compatibility">브라우저 호환성</h2>
 
-<p>{{Compat("webextensions.api.pageAction")}}</p>
+{{Compat}}
 
 <p>{{WebExtExamples("h2")}}</p>
 

--- a/files/ko/mozilla/add-ons/webextensions/api/pageaction/show/index.html
+++ b/files/ko/mozilla/add-ons/webextensions/api/pageaction/show/index.html
@@ -30,9 +30,9 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/pageAction/show
  </dt>
 </dl>
 
-<h2 id="브라우저_호환성">브라우저 호환성</h2>
+<h2 id="Browser_compatibility">브라우저 호환성</h2>
 
-<p>{{Compat("webextensions.api.pageAction.show")}}</p>
+{{Compat}}
 
 <h2 id="예제">예제</h2>
 

--- a/files/ko/mozilla/add-ons/webextensions/api/storage/index.html
+++ b/files/ko/mozilla/add-ons/webextensions/api/storage/index.html
@@ -58,9 +58,9 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/storage
  <dd>저장소 영역의 항목에 변화가 있으면 발생한다.</dd>
 </dl>
 
-<h2 id="브라우저_호환성">브라우저 호환성</h2>
+<h2 id="Browser_compatibility">브라우저 호환성</h2>
 
-<p>{{Compat("webextensions.api.storage")}}</p>
+{{Compat}}
 
 <div class="hidden note">
 <p>The "Chrome incompatibilities" section is included from <a href="https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Chrome_incompatibilities"> https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Chrome_incompatibilities</a> using the <a href="/en-US/docs/Template:WebExtChromeCompat">WebExtChromeCompat</a> macro.</p>

--- a/files/ko/mozilla/add-ons/webextensions/api/storage/local/index.html
+++ b/files/ko/mozilla/add-ons/webextensions/api/storage/local/index.html
@@ -41,11 +41,9 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/storage/local
  <dd>저장소의 모든 항목을 지워서 비운다.</dd>
 </dl>
 
-<h2 id="브라우저_호환성">브라우저 호환성</h2>
+<h2 id="Browser_compatibility">브라우저 호환성</h2>
 
-
-
-<p>{{Compat("webextensions.api.storage.local")}}</p>
+{{Compat}}
 
 <p>{{WebExtExamples}}</p>
 

--- a/files/ko/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.html
+++ b/files/ko/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.html
@@ -33,9 +33,9 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/get
 <p>When used within a content script in Firefox versions prior to 52, the Promise returned by <code>browser.storage.local.get()</code> is fulfilled with an Array containing one Object. The Object in the Array contains the <code>keys</code> found in the storage area, as described above. The Promise is correctly fulfilled with an Object when used in the background context (background scripts, popups, options pages, etc.). When this API is used as <code>chrome.storage.local.get()</code>, it correctly passes an Object to the callback function.</p>
 </div>
 
-<h2 id="브라우저_호환성">브라우저 호환성</h2>
+<h2 id="Browser_compatibility">브라우저 호환성</h2>
 
-<p>{{Compat("webextensions.api.storage.StorageArea.get")}}</p>
+{{Compat}}
 
 <h2 id="예제">예제</h2>
 

--- a/files/ko/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.html
+++ b/files/ko/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.html
@@ -37,9 +37,9 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/set
 
 <p>반환된 <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>는 동작이 성공하면 아무런 인수없이 완료를 수행하고, 실패하면 에러 문장과 함께 거부를 수행한다.</p>
 
-<h2 id="브라우저_호환성">브라우저 호환성</h2>
+<h2 id="Browser_compatibility">브라우저 호환성</h2>
 
-<p>{{Compat("webextensions.api.storage.StorageArea.set")}}</p>
+{{Compat}}
 
 <h2 id="예제">예제</h2>
 

--- a/files/ko/mozilla/add-ons/webextensions/api/tabs/create/index.html
+++ b/files/ko/mozilla/add-ons/webextensions/api/tabs/create/index.html
@@ -65,9 +65,9 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/tabs/create
 
 <p>A <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code> that will be fulfilled with a {{WebExtAPIRef('tabs.Tab')}} object containing details about the created tab. If the tab could not be created (for example, because <code>url</code> used a privileged scheme) the promise will be rejected with an error message.</p>
 
-<h2 id="브라우저_호환성">브라우저 호환성</h2>
+<h2 id="Browser_compatibility">브라우저 호환성</h2>
 
-<p>{{Compat("webextensions.api.tabs.create", 10)}}</p>
+{{Compat}}
 
 <h2 id="예제">예제</h2>
 

--- a/files/ko/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.html
+++ b/files/ko/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.html
@@ -106,9 +106,9 @@ browser.webRequest.onBeforeRequest.hasListener(listener)
  <dd><code>string</code>. URL of the resource that triggered this request. Note that this may not be the same as the URL of the page into which the requested resource will be loaded. For example, if a document triggers a load in a different window through the <a href="/en-US/docs/Web/HTML/Element/a#attr-target">target attribute of a link</a>, or a CSS document includes an image using the <a href="/en-US/docs/Web/CSS/url#The_url()_functional_notation"><code>url()</code> functional notation</a>, then this will be the URL of the original document or of the CSS document, respectively.</dd>
 </dl>
 
-<h2 id="브라우저_호환성">브라우저 호환성</h2>
+<h2 id="Browser_compatibility">브라우저 호환성</h2>
 
-<p>{{Compat("webextensions.api.webRequest.onBeforeRequest", 10)}}</p>
+{{Compat}}
 
 <h2 id="예제">예제</h2>
 

--- a/files/ko/mozilla/add-ons/webextensions/manifest.json/page_action/index.html
+++ b/files/ko/mozilla/add-ons/webextensions/manifest.json/page_action/index.html
@@ -185,11 +185,9 @@ translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/page_action
 
 <p>아이콘, 제목, 팝업이 있는 페이지 액션으로 아이콘을 누르면 팝업이 보일 것이다.</p>
 
-<h2 id="브라우저_호환성">브라우저 호환성</h2>
+<h2 id="Browser_compatibility">브라우저 호환성</h2>
 
-
-
-<p>{{Compat("webextensions.manifest.page_action")}}</p>
+{{Compat}}
 
 <h2 id="See_also">See also</h2>
 


### PR DESCRIPTION
이슈: https://github.com/mdn/translated-content/issues/5618
내용: Replace old-style Compatibility tables with new macro

앞으로 브라우저 호환성은 아래 두가지 형식만 존재합니다.

- html
```
<h2 id="Browser_compatibility">브라우저 호환성</h2>

{{Compat}}
```
- markdown
```
## 브라우저 호환성

{{Compat}}
```