### PR TITLE
fix: typo 

### DIFF
--- a/files/ko/glossary/origin/index.html
+++ b/files/ko/glossary/origin/index.html
@@ -9,7 +9,7 @@ translation_of: Glossary/Origin
 ---
 <div>{{QuickLinksWithSubpages("/ko/docs/Glossary")}}</div>
 
-<p><span class="seoSummary">웹 콘텐츠의 <strong>출처</strong>(origin)는 접근할 때 사용하는 {{glossary("URL")}}의 스킴({{glossary("protocol", "프로토콜")}}, 호스트(도메인), 포트로 정의됩니다.</span> 두 객체의 스킴, 호스트, 포트가 모두 일치하는 경우 같은 출처를 가졌다고 말합니다.</p>
+<p><span class="seoSummary">웹 콘텐츠의 <strong>출처</strong>(origin)는 접근할 때 사용하는 {{glossary("URL")}}의 스킴({{glossary("protocol", "프로토콜")}}), 호스트(도메인), 포트로 정의됩니다.</span> 두 객체의 스킴, 호스트, 포트가 모두 일치하는 경우 같은 출처를 가졌다고 말합니다.</p>
 
 <p>일부 작업은 동일 출처 콘텐츠로 제한되나, {{glossary("CORS")}}를 통해 제한을 해제할 수 있습니다.</p>
 


### PR DESCRIPTION
')' is missing