### PR TITLE
[ko] remove span tag, webassembly

### DIFF
--- a/files/ko/webassembly/c_to_wasm/index.html
+++ b/files/ko/webassembly/c_to_wasm/index.html
@@ -35,7 +35,7 @@ translation_of: WebAssembly/C_to_wasm
 <p>이 방법은 브라우저에서 WebAssembly 코드를 실행하는 데 필요한 모든 것을 emscripten에서 생성하도록 하는 가장 간단한 방법입니다.</p>
 
 <ol>
- <li>먼저 컴파일 할 예제가 필요합니다. 다음 C 예제 코드를 복사하여 <font face="consolas, Liberation Mono, courier, monospace"><span style="background-color: rgba(220, 220, 220, 0.5);">hello.c</span></font> 파일을 만듭니다.
+ <li>먼저 컴파일 할 예제가 필요합니다. 다음 C 예제 코드를 복사하여 <font face="consolas, Liberation Mono, courier, monospace">hello.c</font> 파일을 만듭니다.
 
   <pre class="notranslate"><code>#include &lt;stdio.h&gt;
 
@@ -43,7 +43,7 @@ int main(int argc, char ** argv) {
   printf("Hello World\n");
 }</code></pre>
  </li>
- <li>terminal을 사용하여 Emscripten 컴파일 환경에서 다음의 명령어를 실행합니다. <font face="consolas, Liberation Mono, courier, monospace"><span style="background-color: rgba(220, 220, 220, 0.5);">hello.c </span></font>파일과 동일한 경로에서 실행하세요
+ <li>terminal을 사용하여 Emscripten 컴파일 환경에서 다음의 명령어를 실행합니다. <font face="consolas, Liberation Mono, courier, monospace">hello.c </font>파일과 동일한 경로에서 실행하세요
   <pre class="notranslate"><code>emcc hello.c -s WASM=1 -o hello.html</code></pre>
  </li>
 </ol>
@@ -184,7 +184,7 @@ void EMSCRIPTEN_KEEPALIVE myFunction(int argc, char ** argv) {
  </li>
 </ol>
 
-<p><code>ccall()</code><span>을 사용하여 내보낸 함수를 호출하는 방법이었습니다.</span></p>
+<p><code>ccall()</code>을 사용하여 내보낸 함수를 호출하는 방법이었습니다.</p>
 
 <h2 id="바깥_고리">바깥 고리</h2>
 

--- a/files/ko/webassembly/using_the_javascript_api/index.html
+++ b/files/ko/webassembly/using_the_javascript_api/index.html
@@ -85,7 +85,7 @@ translation_of: WebAssembly/Using_the_JavaScript_API
 
 <p><img alt="" src="https://mdn.mozillademos.org/files/15823/wasm-debug.png" style="display: block; height: 317px; margin: 0px auto; width: 1019px;"></p>
 
-<p>Firefox에서 WebAssembly를 텍스트로 보는 것 외에도 텍스트 형식을 사용하여 개발자는 WebAssembly를 디버깅할 수 있습니다(breakpoint, callstack 검사, 단일 단계 검사 등). 비디오 미리 보기는 <span class="watch-title" dir="ltr" id="eow-title" title="WebAssembly debugging with Firefox DevTools"><a href="https://www.youtube.com/watch?v=R1WtBkMeGds">WebAssembly debugging with Firefox DevTools</a></span>을 참조하십시오.</p>
+<p>Firefox에서 WebAssembly를 텍스트로 보는 것 외에도 텍스트 형식을 사용하여 개발자는 WebAssembly를 디버깅할 수 있습니다(breakpoint, callstack 검사, 단일 단계 검사 등). 비디오 미리 보기는 <a href="https://www.youtube.com/watch?v=R1WtBkMeGds">WebAssembly debugging with Firefox DevTools</a>을 참조하십시오.</p>
 
 <h2 id="메모리_인스턴스">메모리 인스턴스</h2>
 


### PR DESCRIPTION
- issue: https://github.com/mdn/translated-content/issues/2894
- 목적: markdown 변환을 위한 사전 준비
- 변경사항: span tag 삭제
- 범위: webassembly 폴더