### PR TITLE
Remove final {{draft}} macro instance

### DIFF
--- a/files/es/games/tutorials/html5_gamedev_phaser_device_orientation/index.md
+++ b/files/es/games/tutorials/html5_gamedev_phaser_device_orientation/index.md
@@ -15,8 +15,6 @@ original_slug: Games/Workflows/HTML5_Gamedev_Phaser_Device_Orientation
 ---
 {{GamesSidebar}}
 
-{{ draft() }}
-
 ## Introducción
 
 En este tutorial iremos a través del proceso de construcción de un juego en HTML5 para móviles que utilizará las _APIs_ de [Orientación para Dispositivos](/es/Apps/Build/gather_and_modify_data/responding_to_device_orientation_changes) y [Vibración](/es/docs/Web/Guide/API/Vibration) para mejorar la jugabilidad y estará construido utilizando el _framework_ [Phaser](http://phaser.io/). Se recomienda tener conocimientos básicos de JavaScript para sacar mayor provecho a este tutorial.


### PR DESCRIPTION
This PR fixes #5599 by removing the final call to the `{{draft}}` macro.
