### PR TITLE
Portuguese pronominal mistake fix

### DIFF
--- a/files/pt-br/web/javascript/reference/global_objects/promise/index.html
+++ b/files/pt-br/web/javascript/reference/global_objects/promise/index.html
@@ -9,7 +9,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Promise
 ---
 <div>{{JSRef("Global_Objects", "Promise")}}</div>
 
-<p><strong><code>Promise</code></strong> é um objeto usado para processamento assíncrono. Um <code>Promise</code> (<em>de "promessa"</em>) representa um valor que pode estar disponível agora, no futuro ou nunca.</p>
+<p><strong><code>Promise</code></strong> é um objeto usado para processamento assíncrono. Uma <code>Promise</code> (<em>de "promessa"</em>) representa um valor que pode estar disponível agora, no futuro ou nunca.</p>
 
 <div class="note">
 <p><strong>Nota:</strong> Esse artigo descreve o construtor <code>Promise,</code>os métodos e propriedades de tais objetos. Para aprender sobre como promises funcionam e como utilizá-los, é aconselhavel a leitura de <a href="/pt-BR/docs/Web/JavaScript/Guide/Usando_promises">utilizando promises</a>. O construtor é utilizado para embrulhar funções sem suporte ao conceito "promise".</p>
@@ -19,7 +19,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Promise
 
 <p>Uma <code><strong>Promise</strong></code> representa um proxy para um valor que não é necessariamente conhecido quando a promessa é criada. Isso permite a associação de métodos de tratamento para eventos da ação assíncrona num caso eventual de sucesso ou de falha. Isto permite que métodos assíncronos retornem valores como métodos síncronos: ao invés do valor final, o método assíncrono retorna uma <em>promessa</em> ao valor em algum momento no futuro.</p>
 
-<p>Um <strong><code>Promise</code></strong> está em um destes estados: </p>
+<p>Uma <strong><code>Promise</code></strong> está em um destes estados: </p>
 
 <ul>
  <li><em>pending (</em>pendente<em>)</em>: Estado inicial, que não foi realizada nem rejeitada.</li>


### PR DESCRIPTION
It was wrote "Um promise" twice and all other times "Uma promise".