### PR TITLE
Change to a more reasonable example.

### DIFF
--- a/files/zh-cn/web/guide/css/block_formatting_context/index.md
+++ b/files/zh-cn/web/guide/css/block_formatting_context/index.md
@@ -169,14 +169,14 @@ section {
 ```html
 <div class="blue"></div>
 <div class="red-outer">
-  <div class="red-inner">red inner</div>
+  <div class="orange-inner">orange inner</div>
 </div>
 ```
 
 #### CSS
 
 ```css
-.blue, .red-inner {
+.blue, .orange-inner {
   height: 50px;
   margin: 10px 0;
 }
@@ -188,6 +188,7 @@ section {
 .red-outer {
   overflow: hidden;
   background: red;
+  margin-top: 10px;
 }
 ```
 


### PR DESCRIPTION
1. 此处red-inner与red-outer背景颜色一样，导致不易看出red-inner与red-outer之间存在的上下边距，故将red-inner修改为orange-inner。
2. 此处由小标题可知，应该是为了演示BFC可以避免外边距折叠的现象，但是这里用的例子却是演示了BFC隔绝内部元素向BFC外部传递margin，与标题描述不符，故根据标题意思，为其在red-outer中添加一个margin-top用来演示BFC可以避免外边距折叠的现象。