### PR TITLE
Remove white background in text

### DIFF
--- a/files/es/web/api/url/url/index.html
+++ b/files/es/web/api/url/url/index.html
@@ -5,7 +5,7 @@ translation_of: Web/API/URL/URL
 ---
 <div>{{APIRef("URL API")}}</div>
 
-<p><code><font face="Arial, x-locale-body, sans-serif"><span style="background-color: #ffffff;">El constructor </span></font><strong>URL()</strong></code> devuelve un objeto {{domxref("URL")}} recién creado que representa la URL definida por los parámetros.</p>
+<p>El constructor <strong><code>URL()</code></strong> devuelve un objeto {{domxref("URL")}} recién creado que representa la URL definida por los parámetros.</p>
 
 <p>Si la URL base dada o la URL resultante no son URL válidas, se lanza un {{domxref("DOMException")}}  de tipo <code>SYNTAX_ERROR</code>.</p>
 


### PR DESCRIPTION
The white background prevents the text "El constructor" from being visible in the dark mode.