### PR TITLE
replace invalid link

### DIFF
--- a/files/ko/web/http/basics_of_http/choosing_between_www_and_non-www_urls/index.html
+++ b/files/ko/web/http/basics_of_http/choosing_between_www_and_non-www_urls/index.html
@@ -56,7 +56,7 @@ translation_of: Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs
 
 <h2 id="결정하기">결정하기</h2>
 
-<p class="entry-title">이것은 <a href="http://bikeshed.com/">bikeshedding</a> 이슈로 간주될 수도 있는 주관적인 주제입니다. 더 자세한 정보를 얻으려면, <a href="http://www.hyperarts.com/blog/www-vs-non-www-for-your-canonical-domain-url-which-is-best-and-why/">당신의 표준 도메인 URL을 위한 WWW vs non-WWW – 어떤 것이 최선이고 왜 그러한가?</a>를 읽어보시기 바랍니다. 더 많은 정보를 얻을 수 있습니다.</p>
+<p class="entry-title">이것은 <a href="http://bikeshed.com/">bikeshedding</a> 이슈로 간주될 수도 있는 주관적인 주제입니다. 더 자세한 정보를 얻으려면, 이 주제에 관련된 <a href="https://www.netlify.com/blog/2020/03/26/how-to-set-up-netlify-dns-custom-domains-cname-and-a-records/#options-for-bare-domains">다른</a> <a href="https://www.wpbeginner.com/beginners-guide/www-vs-non-www-which-is-better-for-wordpress-seo/">글</a>들을 읽어보시기 바랍니다.</p>
 
 <h2 id="함께_참고할_내용들">함께 참고할 내용들</h2>
 


### PR DESCRIPTION
remove invalid external link, and replace it with original contents links

기존 링크(http://www.hyperarts.com/blog/www-vs-non-www-for-your-canonical-domain-url-which-is-best-and-why/)가 원본글의 링크랑 달랐는데, 게다가 더이상 유효하지도 않아서 원본글에 있는 링크들로 대체하였습니다.