### PR TITLE
fix typos & spacing errors & fragments

### DIFF
--- a/files/ko/web/javascript/guide/indexed_collections/index.md
+++ b/files/ko/web/javascript/guide/indexed_collections/index.md
@@ -5,11 +5,11 @@ translation_of: Web/JavaScript/Guide/Indexed_collections
 ---
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Regular_Expressions", "Web/JavaScript/Guide/Keyed_Collections")}}
 
-이번장에서는 인덱스값에 의해 정렬이 되는 데이터 자료구조에 대해 소개합니다. 배열과 유사 배열 생성자인 {{jsxref("Array")}} 객체와 {{jsxref("TypedArray")}} 객체 같은 생성자들을 포함합니다.
+이번 장에서는 인덱스값에 의해 정렬이 되는 데이터 자료구조에 대해 소개합니다. 배열과 유사 배열 생성자인 {{jsxref("Array")}} 객체와 {{jsxref("TypedArray")}} 객체 같은 생성자들을 포함합니다.
 
 ## 배열 객체
 
-배열은 이름과 인덱스로 참조되는 정렬된 값들의 집합입니다. 예를 들면, 숫자로 된 사원번호를 index로하여 사원명을 가지고 있는 emp라는 배열을 가질 수 있습니다. 그래서 emp\[1]은 사원번호 1번, emp\[2]는 사원번호 2번, 이런식으로 사원번호를 인덱스 값으로 가질 수 있는 것입니다.
+배열은 이름과 인덱스로 참조되는 정렬된 값들의 집합입니다. 예를 들면, 숫자로 된 사원번호를 index로하여 사원명을 가지고 있는 emp라는 배열을 가질 수 있습니다. 그래서 emp\[1]은 사원번호 1번, emp\[2]는 사원번호 2번, 이런 식으로 사원번호를 인덱스 값으로 가질 수 있는 것입니다.
 
 자바스크립트는 명시적인 배열 데이터 형식을 가지고 있지 않습니다. 그러나 미리 정의된 배열 객체를 사용할 수 있고 배열 객체의 메서드를 개발하는 어플리케이션에서 사용되는 배열에 사용할 수 있습니다. 배열 객체는 합치기(joining), 순서 뒤집기(reversing) 그리고 정렬(sorting)과 같은 다양한 방법으로 배열을 조작하는 메서드들을 제공합니다. 정규 표현식과 함께 사용할 배열 길이와 기타 속성을 결정하는 속성이 있습니다.
 
@@ -23,7 +23,7 @@ var arr = Array(element0, element1, ..., elementN);
 var arr = [element0, element1, ..., elementN];
 ```
 
-요소0, 요소1, ..., 요소N은 배열내에 포함된 요소의 값 목록 입니다. 해당 값들이 명시되어 있을 경우, 해당 배열은 주어진 요소들을 포함하도록 초기화 됩니다. 해당 배열의 길이는 주어진 요소들의 갯수가 됩니다.
+요소0, 요소1, ..., 요소N은 배열내에 포함된 요소의 값 목록입니다. 해당 값들이 명시되어 있을 경우, 해당 배열은 주어진 요소들을 포함하도록 초기화 됩니다. 해당 배열의 길이는 주어진 요소들의 갯수가 됩니다.
 
 대괄호 문법은 일명 "배열 문자" 혹은 "배열 초기화"라고 합니다. 대괄호 문법은 다른 배열 생성 표기법 보다 짧고 일반적으로 선호하는 문법입니다. 보다 상세한 내용은 [Array literals](/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#Array_literals)를 참조하세요.
 
@@ -40,7 +40,7 @@ arr.length = arrayLength;
 
 <div class="note"><p>Note : 위의 예제 코드에서, <code>arrayLength</code>는 반드시 <code>숫자</code>여야 합니다. 그렇지 않으면 하나의 요소(주어진 값)을 가지는 배열이 생성 됩니다. <code>arr.length</code>를 호출하면 <code>arrayLength</code>가 반환이 되지만 해당 배열은 실제로 아무런 요소를 가지고 있지 않습니다. {{jsxref("Statements/for...in","for...in")}} 반복문을 실행하면 해당 배열은 아무런 요소를 반환하지 않습니다.</p></div>
 
-추가로 아래의 예제에서 볼 수 있듯이, 새로이 정의된 혹은 이미 존재하는 객체 변수의 속성으로 배열을 할당 할 수 있습니다.
+추가로 아래의 예제에서 볼 수 있듯이, 새로이 정의된 혹은 이미 존재하는 객체 변수의 속성으로 배열을 할당할 수 있습니다.
 
 ```js
 var obj = {};
@@ -63,7 +63,7 @@ var arr = [];
 arr.length = 42;
 ```
 
-만약 숫자이지만 0이 아닌 소수점을 가지는 숫자를 `Array()생성자에게 인자로 줄 경우, 범위 에러(RangeError)가 발생하게 됩니다. 아래의 예제는 범위 에러가 발생되는 상황을 보여 줍니다.`
+만약 숫자이지만 0이 아닌 소수점을 가지는 숫자를 `Array()생성자에게 인자로 줄 경우, 범위 에러(RangeError)가 발생하게 됩니다. 아래의 예제는 범위 에러가 발생하는 상황을 보여 줍니다.`
 
 ```js
 var arr = Array(9.3);  // RangeError: Invalid array length
@@ -88,7 +88,7 @@ emp[1] = 'Phil Lesh';
 emp[2] = 'August West';
 ```
 
-> **Note:** 위의 코드 예제 처럼 배열 연산자에 양의 정수가 아닌 값을 줄 경우, 배열의 요소가 대신 배열로 대변되는 객체의 속성이 생성이 됩니다.
+> **Note:** 위의 코드 예제처럼 배열 연산자에 양의 정수가 아닌 값을 줄 경우, 배열의 요소가 대신 배열로 대변되는 객체의 속성이 생성됩니다.
 
 ```js
 var arr = [];
@@ -106,7 +106,7 @@ var myArray = ['Mango', 'Apple', 'Orange'];
 
 ### 배열 요소의 참조
 
-배열의 요소를 참조하기 위해서 해당 요소의 인덱스(요소의 순서를 나타내는 )를 사용할 수 있습니다. 예를 들어, 아래와 같이 배열을 선언 하였다면
+배열의 요소를 참조하기 위해서 해당 요소의 인덱스(요소의 순서를 나타내는)를 사용할 수 있습니다. 예를 들어, 아래와 같이 배열을 선언하였다면
 
 ```js
 var myArray = ['Wind', 'Rain', 'Fire'];
@@ -114,7 +114,7 @@ var myArray = ['Wind', 'Rain', 'Fire'];
 
 배열의 첫번째 요소는 `myArray[0]로 참조할 수 있고 두번째 요소는 myArray[1]로 참조할 수 있습니다. 배열의 인덱스 값은 0부터 시작합니다.`
 
-> **Note:** 배열 연산자(대괄호)는 배열의 속성에 접근하기 위해서도 사용될 수 있습니다.(배열 또한 객체이기 때문입니다.) 예를 들면 아래와 같습니다.
+> **Note:** 배열 연산자(대괄호)는 배열의 속성에 접근하기 위해서도 사용될 수 있습니다 (배열 또한 객체이기 때문입니다). 예를 들면 아래와 같습니다.
 
 ```js
 var arr = ['one', 'two', 'three'];
@@ -124,7 +124,7 @@ arr["length"];  // 3
 
 ### 배열 길이에 대한 이해
 
-실제 구현에서, 자바스트립트의 배열은 배열에 포함된 요소들을 배열의 인덱스 값을 속성 이름으로 사용하여 표준 객체의 속성처럼 저장을 합니다. 길이 속성은 좀 특별합니다. 배열의 길이는 항상 마지막 요소의 인덱스에 1을 더한 값을 반환합니다.(다음 예제에서 Dusty는 인덱스 30번째에 위치하기때문에 cats배열의 길이는 31이 됩니다.) 기억하실 것은 자바스크립트 배열의 인덱스는 항상 1부터가 아닌 0부터 시작합니다. 이것이 의미하는 바는 배열의 길이 속성은 배열에 저장되어 있는 가장 큰 인덱스보다 1만큼 큰 값이 된다는 것입니다.
+실제 구현에서, 자바스크립트의 배열은 배열에 포함된 요소들을 배열의 인덱스 값을 속성 이름으로 사용하여 표준 객체의 속성처럼 저장합니다. 길이 속성은 좀 특별합니다. 배열의 길이는 항상 마지막 요소의 인덱스에 1을 더한 값을 반환합니다 (다음 예제에서 Dusty는 인덱스 30번째에 위치하기때문에 cats 배열의 길이는 31이 됩니다). 기억하실 것은 자바스크립트 배열의 인덱스는 항상 1부터가 아닌 0부터 시작합니다. 이것이 의미하는 바는 배열의 길이 속성은 배열에 저장되어 있는 가장 큰 인덱스보다 1만큼 큰 값이 된다는 것입니다.
 
 ```js
 var cats = [];
@@ -168,9 +168,9 @@ for (var i = 0, div; div = divs[i]; i++) {
 }
 ```
 
-위의 예제 코드의 for반복문 조건은 배열의 길이을 확인하는 작업을 피할 수 있고, div변수가 매 반복마다 현재의 요소를 가지게 됩니다.
+위의 예제 코드의 for반복문 조건은 배열의 길이를 확인하는 작업을 피할 수 있고, div 변수가 매 반복마다 현재의 요소를 가지게 됩니다.
 
-{{jsxref("Array.forEach", "forEach()")}} 메서드는 배열의 요소를 반복처리할 수 있는 또 다른 방법입니다:
+{{jsxref("Array.forEach", "forEach()")}} 메서드는 배열의 요소를 반복 처리할 수 있는 또 다른 방법입니다:
 
 ```js
 var colors = ['red', 'green', 'blue'];
@@ -192,9 +192,9 @@ color.forEach(color => console.log(color));
 // blue
 ```
 
-`forEach`에 인자로 주어진 함수는 배열의 각 요소에 대해 한번씩 실행이 되고 배열의 각 요소는 인자로 주어진 함수의 인자로 주어지게 됩니다. 할당 되지 않은 요소 값은 `forEach` 반복문에서 처리 되지 않습니다.
+`forEach`에 인자로 주어진 함수는 배열의 각 요소에 대해 한번씩 실행이 되고 배열의 각 요소는 인자로 주어진 함수의 인자로 주어지게 됩니다. 할당되지 않은 요소 값은 `forEach` 반복문에서 처리되지 않습니다.
 
-`forEach`반복문으로 배열의 요소를 반복처리할때, 배열을 정의할 때 생략된 요소는 처리대상이 되지 않는 것에 유의 하세요. 하지만 `undefined`을 생략된 요소에 할당하게 되면 undefined로 처리됩니다.
+`forEach` 반복문으로 배열의 요소를 반복 처리할 때, 배열을 정의할 때 생략된 요소는 처리 대상이 되지 않는 것에 유의하세요. 하지만 `undefined`를 생략된 요소에 할당하게 되면 undefined로 처리됩니다.
 
 ```js
 var array = ['first', 'second', , 'fourth'];
@@ -221,7 +221,7 @@ array.forEach(function(element) {
 // fourth
 ```
 
-JavaScript 요소는 표준 객체 속성으로 저장되므로 {{jsxref ( "Statements / for ... in", "for ... in")}} 루프를 사용하여 JavaScript 배열을 반복하는 것은 바람직하지 않습니다. 왜냐면 일반 요소들과 그리고 모든 열거할 수 있는 속성들이 나열이 되기 때문입니다.
+JavaScript 요소는 표준 객체 속성으로 저장되므로 {{jsxref ( "Statements / for ... in", "for ... in")}} 루프를 사용하여 JavaScript 배열을 반복하는 것은 바람직하지 않습니다. 왜냐면 일반 요소들과 그리고 모든 열거할 수 있는 속성들이 나열되기 때문입니다.
 
 ### 배열 객체의 메서드
 
@@ -235,7 +235,7 @@ myArray = myArray.concat('a', 'b', 'c');
 // myArray is now ["1", "2", "3", "a", "b", "c"]
 ```
 
-{{jsxref("Array.join", "join(delimiter = ',')")}} 메서드는 배열의 모든 요소를 주어진 구분자로 연결된 하나의 문자열을 반환 합니다.
+{{jsxref("Array.join", "join(delimiter = ',')")}} 메서드는 배열의 모든 요소를 주어진 구분자로 연결된 하나의 문자열을 반환합니다.
 
 ```js
 var myArray = new Array('Wind', 'Rain', 'Fire');
@@ -249,7 +249,7 @@ var myArray = new Array('1', '2');
 myArray.push('3'); // myArray is now ["1", "2", "3"]
 ```
 
-{{jsxref("Array.pop", "pop()")}} 메서드는 배열의 마지막 요소를 제거 하고 그 제거된 요소를 반환합니다.
+{{jsxref("Array.pop", "pop()")}} 메서드는 배열의 마지막 요소를 제거하고 그 제거된 요소를 반환합니다.
 
 ```js
 var myArray = new Array('1', '2', '3');
@@ -265,7 +265,7 @@ var first = myArray.shift();
 // myArray is now ["2", "3"], first is "1"
 ```
 
-{{jsxref("Array.shift", "unshift()")}}메서드는 하나 혹은 그 이상의 요소를 배열의 앞쪽에 추가하고 추가한 요소를 포함한 길이를 반환 합니다.
+{{jsxref("Array.shift", "unshift()")}}메서드는 하나 혹은 그 이상의 요소를 배열의 앞쪽에 추가하고 추가한 요소를 포함한 길이를 반환합니다.
 
 ```js
 var myArray = new Array('1', '2', '3');
@@ -273,7 +273,7 @@ myArray.unshift('4', '5');
 // myArray becomes ["4", "5", "1", "2", "3"]
 ```
 
-{{jsxref("Array.slice", "slice(start_index, upto_index)")}}메서드는 배열의 특정 부분을 추출하여 그 추출된 부분을 포함하는 새로운 배열을 반환 합니다. upto_index에 해당하는 요소는 포함되지 않습니다.
+{{jsxref("Array.slice", "slice(start_index, upto_index)")}}메서드는 배열의 특정 부분을 추출하여 그 추출된 부분을 포함하는 새로운 배열을 반환합니다. upto_index에 해당하는 요소는 포함되지 않습니다.
 
 ```js
 var myArray = new Array('a', 'b', 'c', 'd', 'e');
@@ -281,7 +281,7 @@ myArray = myArray.slice(1, 4); // starts at index 1 and extracts all elements
                                // until index 3, returning [ "b", "c", "d"]
 ```
 
-{{jsxref("Array.splice", "splice(index, count_to_remove, addElement1, addElement2, ...)")}} 메세드는 주어진 인덱스 요소를 포함하여 count_to_remove 갯수만큼 삭제 하고 주어진 요소로 바꿔 줍니다.
+{{jsxref("Array.splice", "splice(index, count_to_remove, addElement1, addElement2, ...)")}} 메세드는 주어진 인덱스 요소를 포함하여 count_to_remove 갯수만큼 삭제하고 주어진 요소로 바꿔 줍니다.
 
 ```js
 var myArray = new Array('1', '2', '3', '4', '5');
@@ -292,7 +292,7 @@ myArray.splice(1, 3, 'a', 'b', 'c', 'd');
 // elements in its place.
 ```
 
-{{jsxref ( "Array.reverse", "reverse ()")}} 배열의 요소를 제자리에 배치합니다. 첫 번째 배열 요소가 마지막 요소가되고 마지막 요소가 첫 번째 요소가됩니다. 배열에 대한 참조를 반환합니다.
+{{jsxref ( "Array.reverse", "reverse ()")}} 배열의 요소를 제자리에 배치합니다. 첫 번째 배열 요소가 마지막 요소가 되고 마지막 요소가 첫 번째 요소가 됩니다. 배열에 대한 참조를 반환합니다.
 
 ```js
 var myArray = new Array('1', '2', '3');
@@ -308,13 +308,13 @@ myArray.sort();
 // sorts the array so that myArray = [ "Fire", "Rain", "Wind" ]
 ```
 
-`sort()` 메서드에 어떻게 해당 배열의 요소를 정렬할 지 결정하는 콜백 함수를 인자로 줄 수 있습니다.
+`sort()` 메서드에 어떻게 해당 배열의 요소를 정렬할지 결정하는 콜백 함수를 인자로 줄 수 있습니다.
 
-콜백을 사용하는 sort 메소드 및 다른 메소드는 반복 메소드로 알려져 있습니다. 일부 메소드에서는 전체 배열을 반복하기 때문입니다. 각각은 `thisObject`라는 선택적인 두 번째 인수를 취합니다. 제공되면 `thisObject`는 콜백 함수의 본문에있는 `this` 키워드의 값이됩니다.
+콜백을 사용하는 sort 메소드 및 다른 메소드는 반복 메소드로 알려져 있습니다. 일부 메소드에서는 전체 배열을 반복하기 때문입니다. 각각은 `thisObject`라는 선택적인 두 번째 인수를 취합니다. 제공되면 `thisObject`는 콜백 함수의 본문에 있는 `this` 키워드의 값이 됩니다.
 
-제공되지 않으면 함수가 명시 적 객체 컨텍스트 외부에서 호출되는 다른 경우와 마찬가지로이 함수는 콜백으로 화살표 함수를 사용할 때 전역 객체 ({{domxref ( "window")}})를 참조합니다. 정상적인 기능은 콜백입니다.
+제공되지 않으면 함수가 명시적 객체 컨텍스트 외부에서 호출되는 다른 경우와 마찬가지로 이 함수는 콜백으로 화살표 함수를 사용할 때 전역 객체 ({{domxref ( "window")}})를 참조합니다. 정상적인 기능은 콜백입니다.
 
-콜백 함수는 배열의 요소 인 두 개의 인수로 호출됩니다.
+콜백 함수는 배열의 요소인 두 개의 인수로 호출됩니다.
 
 아래 함수는 두 값을 비교하여 세 값 중 하나를 반환합니다.
 
@@ -362,7 +362,7 @@ a.forEach(function(element) { console.log(element);} );
 // logs each item in turn
 ```
 
-{{jsxref("Array.map", "map(callback[, thisObject])")}}메서드는 배열의 모든 요소에 대해 콜백함수를 실행하고 콜백함수의 실행결과를 새로운 배열에 담아 반환합니다.
+{{jsxref("Array.map", "map(callback[, thisObject])")}}메서드는 배열의 모든 요소에 대해 콜백함수를 실행하고 콜백함수의 실행 결과를 새로운 배열에 담아 반환합니다.
 
 ```js
 var a1 = ['a', 'b', 'c'];
@@ -370,7 +370,7 @@ var a2 = a1.map(function(item) { return item.toUpperCase(); });
 console.log(a2); // logs ['A', 'B', 'C']
 ```
 
-{{jsxref("Array.filter", "filter(callback[, thisObject])")}}메서드는 배열의 모든 요소에 대해 콜백 함수가 true를 반환하는 요소를 새로운 배열에 담아 반환 합니다.
+{{jsxref("Array.filter", "filter(callback[, thisObject])")}}메서드는 배열의 모든 요소에 대해 콜백 함수가 true를 반환하는 요소를 새로운 배열에 담아 반환합니다.
 
 ```js
 var a1 = ['a', 10, 'b', 20, 'c', 30];
@@ -390,7 +390,7 @@ var a2 = [1, '2', 3];
 console.log(a2.every(isNumber)); // logs false
 ```
 
-{{jsxref("Array.some", "some(callback[, thisObject])")}}메서드는 배열의 모든 요소에 대해 콜백 함수를 실행하고 하나의 요소라도 콜백 함수의 결과가 true이면 some()메서드의 결과는 true가 됩니다.
+{{jsxref("Array.some", "some(callback[, thisObject])")}}메서드는 배열의 모든 요소에 대해 콜백 함수를 실행하고 하나의 요소라도 콜백 함수의 결과가 true이면 some() 메서드의 결과는 true가 됩니다.
 
 ```js
 function isNumber(value){
@@ -443,13 +443,13 @@ Row 3: [3,0] [3,1] [3,2] [3,3]
 
 ### 배열과 정규표현식
 
-문자열내에 정규 표현식에 일치하는 결과가 배열일 경우, 해당 배열은 정규 표현식에 일치하는 문자열들의 정보를 제공해 주는 속성들과 요소들을 반환합니다. {{jsxref ( "Global_Objects / RegExp / exec", "RegExp.exec ()")}}, {{jsxref("Global_Objects/String/match","String.match()")}}, 와 {{jsxref("Global_Objects/String/split","String.split()")}}메서드는 결과를 배열로 반환합니다. 정규식과 함께 배열을 어떻게 사용하는지에 대한 정보는 [정규표현식](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)을 참조하시면 됩니다.
+문자열 내에 정규 표현식에 일치하는 결과가 배열일 경우, 해당 배열은 정규 표현식에 일치하는 문자열들의 정보를 제공해 주는 속성들과 요소들을 반환합니다. {{jsxref ( "Global_Objects / RegExp / exec", "RegExp.exec ()")}}, {{jsxref("Global_Objects/String/match","String.match()")}}, 와 {{jsxref("Global_Objects/String/split","String.split()")}}메서드는 결과를 배열로 반환합니다. 정규식과 함께 배열을 어떻게 사용하는지에 대한 정보는 [정규표현식](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)을 참조하시면 됩니다.
 
 ### 배열과 유사한 객체 사용
 
 {{domxref ( "document.getElementsByTagName ()")}} 또는 {{jsxref ( "Functions / arguments", "arguments")}}에서 반환하는 {{domxref("NodeList")}} 객체는 함수 본문 내에서 사용할 수 있게 만들어졌으며 겉으로는 배열처럼 보이고 작동하지만 모든 메서드를 공유하지는 않습니다. arguments 객체는 {{jsxref ( "Global_Objects / Function / length", "length")}} 속성을 제공하지만 {{jsxref ( "Array.forEach", "forEach ()")}} 메소드는 구현하지 않습니다.
 
-배열 프로토 타입 메소드는 다른 배열과 유사한 객체에 대해 호출 될 수 있습니다.
+배열 프로토타입 메소드는 다른 배열과 유사한 객체에 대해 호출될 수 있습니다.
 
 ```js
 function printArguments() {
@@ -459,7 +459,7 @@ function printArguments() {
 }
 ```
 
-배열 프로토 타입 메서드는 배열과 비슷한 방식으로 문자에 순차적으로 액세스 할 수 있으므로 문자열에서도 사용할 수 있습니다.
+배열 프로토타입 메서드는 배열과 비슷한 방식으로 문자에 순차적으로 액세스 할 수 있으므로 문자열에서도 사용할 수 있습니다.
 
 ```js
 Array.prototype.forEach.call('a string', function(chr) {
@@ -469,17 +469,17 @@ Array.prototype.forEach.call('a string', function(chr) {
 
 ## 타입 배열
 
-자바스크립트 타입 배열은 배열과 유사한 객체이며 원시 이진 데이터 접근에 대한 메카니즘을 제공합니다. 이미 알고 있듯이, {{jsxref("Array")}}객체는 동적으로 크기가 커지고 작아 질 수 있으며 어떤 자바스크립트 값이라도 가질 수 있습니다. 자바스크립트 엔진은 그런 배열을 빠르게 만들기 위해 최적화를 수행합니다. 그러나 웹 어플케이션이 보다 강력해지고, 음성, 영상 조작, [웹소켓](/en-US/docs/WebSockets)을 사용하여 원시 데이터에 접근하는 등의 기능들이 추가 되면서 자바스크립트 코드가 타입배열을 가지고 빠르고 쉽게 원시 이진 데이터를 조작할 수 있는 것이 가능한 시점이 되었다는 것은 보다 명백해졌습니다.
+자바스크립트 타입 배열은 배열과 유사한 객체이며 원시 이진 데이터 접근에 대한 메카니즘을 제공합니다. 이미 알고 있듯이, {{jsxref("Array")}} 객체는 동적으로 크기가 커지고 작아질 수 있으며 어떤 자바스크립트 값이라도 가질 수 있습니다. 자바스크립트 엔진은 그런 배열을 빠르게 만들기 위해 최적화를 수행합니다. 그러나 웹 어플케이션이 보다 강력해지고, 음성, 영상 조작, [웹소켓](/en-US/docs/WebSockets)을 사용하여 원시 데이터에 접근하는 등의 기능들이 추가되면서 자바스크립트 코드가 타입배열을 가지고 빠르고 쉽게 원시 이진 데이터를 조작할 수 있는 것이 가능한 시점이 되었다는 것은 보다 명백해졌습니다.
 
 ### 버퍼와 뷰: 타입 배열 구조
 
-유연성과 효율성을 극대화 하기 위해, 자바스크립트 타입 배열을 **버퍼**와 **뷰**라는 구조로 구현되어 있습니다. 하나의 버퍼({{jsxref("ArrayBuffer")}}객체로 구현되어 있습니다.)는 하나의 데이터 덩어리를 의미하는 객체입니다. 버퍼는 구체적으로 언급할 형식이 없고, 버퍼가 담고 있는 내용에 접근할 메카니즘을 제공하지 않습니다. 버퍼에 담겨져 있는 메모리에 접근하기 위해선, 뷰를 사용해야 합니다. 하나의 뷰는 컨덱스트를 제공하는데, 컨텍스트는 데이터 형, 시작 오프셋 그리고 실제 타입배열로 변경되는 요소의 갯수를 제공합니다.
+유연성과 효율성을 극대화하기 위해, 자바스크립트 타입 배열은 **버퍼**와 **뷰**라는 구조로 구현되어 있습니다. 하나의 버퍼({{jsxref("ArrayBuffer")}}객체로 구현되어 있습니다)는 하나의 데이터 덩어리를 의미하는 객체입니다. 버퍼는 구체적으로 언급할 형식이 없고, 버퍼가 담고 있는 내용에 접근할 메카니즘을 제공하지 않습니다. 버퍼에 담겨 있는 메모리에 접근하기 위해선, 뷰를 사용해야 합니다. 하나의 뷰는 컨덱스트를 제공하는데, 컨텍스트는 데이터 형, 시작 오프셋 그리고 실제 타입배열로 변경되는 요소의 갯수를 제공합니다.
 
 ![Typed arrays in an ArrayBuffer](https://mdn.mozillademos.org/files/8629/typed_arrays.png)
 
 ### 배열버퍼
 
-{{jsxref("ArrayBuffer")}}는 일반적이고, 고정길이의 이진 데이터 버퍼를 표현하기 위해 사용되는 데이터 타입입니다. `ArrayBuffer의 내용을 직접 수정할 수는 없는 대신 타입 배열 뷰 혹은 특정 형식 그리고 해당 버퍼의 내용을 읽고 쓸수 있게 해주는`{{jsxref("DataView")}}`를 생성할 수 있습니다.`
+{{jsxref("ArrayBuffer")}}는 일반적이고, 고정길이의 이진 데이터 버퍼를 표현하기 위해 사용되는 데이터 타입입니다. `ArrayBuffer의 내용을 직접 수정할 수는 없는 대신 타입 배열 뷰 혹은 특정 형식 그리고 해당 버퍼의 내용을 읽고 쓸 수 있게 해주는`{{jsxref("DataView")}}`를 생성할 수 있습니다.`
 
 ### 타입 배열 뷰
 


### PR DESCRIPTION
This page particularly had lots of typos and spelling mistakes (the worst being `JavaStrip` - Line 127).
Please consider these changes.