### PR TITLE
ci: use built-in setup-node caching

### DIFF
--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -25,17 +25,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "16"
-
-      - name: Cache node_modules
-        uses: actions/cache@v3
-        id: cached-node_modules
-        with:
-          path: |
-            ${{ github.workspace }}/mdn/content/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          cache: 'yarn'
+          cache-dependency-path: mdn/content/yarn.lock
 
       - name: Install all yarn packages
-        if: steps.cached-node_modules.outputs.cache-hit != 'true'
         working-directory: ${{ github.workspace }}/mdn/content
         run: |
           yarn --frozen-lockfile

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -31,17 +31,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "16"
-
-      - name: Cache node_modules
-        uses: actions/cache@v3
-        id: cached-node_modules
-        with:
-          path: |
-            ${{ github.workspace }}/mdn/content/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          cache: 'yarn'
+          cache-dependency-path: mdn/content/yarn.lock
 
       - name: Install all yarn packages
-        if: steps.cached-node_modules.outputs.cache-hit != 'true'
         working-directory: ${{ github.workspace }}/mdn/content
         run: |
           yarn --frozen-lockfile

--- a/.github/workflows/sync-translated-content.yml
+++ b/.github/workflows/sync-translated-content.yml
@@ -27,17 +27,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "16"
-
-      - name: Cache node_modules
-        uses: actions/cache@v3
-        id: cached-node_modules
-        with:
-          path: |
-            ${{ github.workspace }}/mdn/content/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          cache: 'yarn'
+          cache-dependency-path: mdn/content/yarn.lock
 
       - name: Install all yarn packages
-        if: steps.cached-node_modules.outputs.cache-hit != 'true'
         working-directory: ${{ github.workspace }}/mdn/content
         run: |
           yarn --frozen-lockfile


### PR DESCRIPTION
Should be equivalent, but is one less dependency to bump/track