### PR TITLE
style(markdownlint): disable new MD051/52 rules

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -98,5 +98,7 @@
     "style": "fenced"
   },
   "MD049": false,
-  "MD050": false
+  "MD050": false,
+  "MD051": false,
+  "MD052": false
 }


### PR DESCRIPTION
These new Markdownlint rules don't play nice with the Yari generated anchor format