### PR TITLE
ja: 「関連情報」セクションのリンク先URLやリンクテキストの更新

### DIFF
--- a/files/ja/web/api/fetch_api/index.md
+++ b/files/ja/web/api/fetch_api/index.md
@@ -70,9 +70,9 @@ Fetch API は (ネットワーク越しの通信を含む) リソース取得の
 
 ## 関連情報
 
-- [Using Fetch](/ja/docs/Web/API/Fetch_API/Using_Fetch)
-- [ServiceWorker API](/ja/docs/Web/API/Service_Worker_API)
-- [HTTP access control (CORS)](/ja/docs/Web/HTTP/CORS)
+- [Fetch の使用](/ja/docs/Web/API/Fetch_API/Using_Fetch)
+- [サービスワーカー API](/ja/docs/Web/API/Service_Worker_API)
+- [HTTP アクセス制御 (CORS)](/ja/docs/Web/HTTP/CORS)
 - [HTTP](/ja/docs/Web/HTTP)
 - [Fetch のポリフィル](https://github.com/github/fetch)
 - [Fetch の基本概念](/ja/docs/Web/API/Fetch_API/Basic_concepts)

--- a/files/ja/web/http/cors/index.md
+++ b/files/ja/web/http/cors/index.md
@@ -492,10 +492,10 @@ Access-Control-Request-Headers: <field-name>[, <field-name>]*
 
 ## 関連情報
 
-- [CORS のエラー](/en-US/docs/Web/HTTP/CORS/Errors)
+- [CORS のエラー](/ja/docs/Web/HTTP/CORS/Errors)
 - [Enable CORS: I want to add CORS support to my server](https://enable-cors.org/server.html)
 - {{domxref("XMLHttpRequest")}}
-- [Fetch API](/en-US/docs/Web/API/Fetch_API)
+- [Fetch API](/ja/docs/Web/API/Fetch_API)
 - [Will it CORS?](https://httptoolkit.tech/will-it-cors) - 対話型の CORS の説明および生成
 - [How to run Chrome browser without CORS](https://alfilatov.com/posts/run-chrome-without-cors/)
 - [Using CORS with All (Modern) Browsers](https://www.telerik.com/blogs/using-cors-with-all-modern-browsers)


### PR DESCRIPTION
「関連情報」セクション内のリンクのうち、リンク先がMDN内のコンテンツであり翻訳されていながらURLやテキストがローカライズされていないものを、いくつか更新しました。
よろしくお願いいたします。