### PR TITLE
input types の BCD query を英語版に追従

### DIFF
--- a/files/ja/web/html/element/input/button/index.md
+++ b/files/ja/web/html/element/input/button/index.md
@@ -11,7 +11,6 @@ tags:
   - Input Type
   - Reference
   - button
-browser-compat: html.elements.input.type_button
 translation_of: Web/HTML/Element/input/button
 ---
 {{HTMLRef("Input_types")}}

--- a/files/ja/web/html/element/input/button/index.md
+++ b/files/ja/web/html/element/input/button/index.md
@@ -11,6 +11,7 @@ tags:
   - Input Type
   - Reference
   - button
+browser-compat: html.elements.input.type_button
 translation_of: Web/HTML/Element/input/button
 ---
 {{HTMLRef("Input_types")}}
@@ -325,7 +326,7 @@ draw();
 
 ## ブラウザーの互換性
 
-{{Compat("html.elements.input.input-button")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/html/element/input/checkbox/index.md
+++ b/files/ja/web/html/element/input/checkbox/index.md
@@ -10,6 +10,7 @@ tags:
   - フォーム
   - 入力型
   - 要素
+browser-compat: html.elements.input.type_checkbox
 translation_of: Web/HTML/Element/input/checkbox
 ---
 {{HTMLRef}}
@@ -311,7 +312,7 @@ otherCheckbox.addEventListener('change', () => {
 
 ## ブラウザーの互換性
 
-{{Compat("html.elements.input.input-checkbox")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/html/element/input/checkbox/index.md
+++ b/files/ja/web/html/element/input/checkbox/index.md
@@ -10,7 +10,6 @@ tags:
   - フォーム
   - 入力型
   - 要素
-browser-compat: html.elements.input.type_checkbox
 translation_of: Web/HTML/Element/input/checkbox
 ---
 {{HTMLRef}}

--- a/files/ja/web/html/element/input/color/index.md
+++ b/files/ja/web/html/element/input/color/index.md
@@ -9,7 +9,6 @@ tags:
   - HTML フォーム
   - Reference
   - color
-browser-compat: html.elements.input.type_color
 translation_of: Web/HTML/Element/input/color
 ---
 {{HTMLRef}}

--- a/files/ja/web/html/element/input/date/index.md
+++ b/files/ja/web/html/element/input/date/index.md
@@ -12,7 +12,7 @@ tags:
   - 入力要素
   - 入力型
   - リファレンス
-browser-compat: html.elements.input.input-date
+browser-compat: html.elements.input.type_date
 translation_of: Web/HTML/Element/input/date
 ---
 

--- a/files/ja/web/html/element/input/date/index.md
+++ b/files/ja/web/html/element/input/date/index.md
@@ -12,7 +12,6 @@ tags:
   - 入力要素
   - 入力型
   - リファレンス
-browser-compat: html.elements.input.type_date
 translation_of: Web/HTML/Element/input/date
 ---
 

--- a/files/ja/web/html/element/input/datetime-local/index.md
+++ b/files/ja/web/html/element/input/datetime-local/index.md
@@ -14,7 +14,6 @@ tags:
   - リファレンス
   - 時刻
   - datetime-local
-browser-compat: html.elements.input.type_datetime-local
 translation_of: Web/HTML/Element/input/datetime-local
 ---
 {{HTMLRef("Input_types")}}

--- a/files/ja/web/html/element/input/email/index.md
+++ b/files/ja/web/html/element/input/email/index.md
@@ -8,7 +8,6 @@ tags:
   - HTML フォーム
   - 入力型
   - リファレンス
-browser-compat: html.elements.input.type_email
 translation_of: Web/HTML/Element/input/email
 ---
 

--- a/files/ja/web/html/element/input/email/index.md
+++ b/files/ja/web/html/element/input/email/index.md
@@ -8,7 +8,7 @@ tags:
   - HTML フォーム
   - 入力型
   - リファレンス
-browser-compat: html.elements.input.input-email
+browser-compat: html.elements.input.type_email
 translation_of: Web/HTML/Element/input/email
 ---
 

--- a/files/ja/web/html/element/input/file/index.md
+++ b/files/ja/web/html/element/input/file/index.md
@@ -12,6 +12,7 @@ tags:
   - Input Type
   - Reference
   - Type
+browser-compat: html.elements.input.type_file
 translation_of: Web/HTML/Element/input/file
 ---
 {{HTMLRef("Input_types")}}
@@ -459,7 +460,7 @@ function returnFileSize(number) {
 
 ## ブラウザーの互換性
 
-{{Compat("html.elements.input.input-file")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/html/element/input/file/index.md
+++ b/files/ja/web/html/element/input/file/index.md
@@ -12,7 +12,6 @@ tags:
   - Input Type
   - Reference
   - Type
-browser-compat: html.elements.input.type_file
 translation_of: Web/HTML/Element/input/file
 ---
 {{HTMLRef("Input_types")}}

--- a/files/ja/web/html/element/input/hidden/index.md
+++ b/files/ja/web/html/element/input/hidden/index.md
@@ -10,7 +10,6 @@ tags:
   - Input Types
   - Reference
   - hidden
-browser-compat: html.elements.input.type_hidden
 translation_of: Web/HTML/Element/input/hidden
 ---
 {{HTMLRef}}

--- a/files/ja/web/html/element/input/image/index.md
+++ b/files/ja/web/html/element/input/image/index.md
@@ -14,7 +14,6 @@ tags:
   - 入力型
   - Number
   - リファレンス
-browser-compat: html.elements.input.type_image
 translation_of: Web/HTML/Element/input/image
 ---
 

--- a/files/ja/web/html/element/input/index.md
+++ b/files/ja/web/html/element/input/index.md
@@ -12,7 +12,6 @@ tags:
   - MakeBrowserAgnostic
   - リファレンス
   - ウェブ
-browser-compat: html.elements.input
 translation_of: Web/HTML/Element/input
 ---
 

--- a/files/ja/web/html/element/input/month/index.md
+++ b/files/ja/web/html/element/input/month/index.md
@@ -15,7 +15,7 @@ tags:
   - Number
   - リファレンス
   - month
-browser-compat: html.elements.input.input-month
+browser-compat: html.elements.input.type_month
 translation_of: Web/HTML/Element/input/month
 ---
 

--- a/files/ja/web/html/element/input/month/index.md
+++ b/files/ja/web/html/element/input/month/index.md
@@ -15,7 +15,6 @@ tags:
   - Number
   - リファレンス
   - month
-browser-compat: html.elements.input.type_month
 translation_of: Web/HTML/Element/input/month
 ---
 

--- a/files/ja/web/html/element/input/number/index.md
+++ b/files/ja/web/html/element/input/number/index.md
@@ -11,7 +11,7 @@ tags:
   - 入力型
   - Number
   - リファレンス
-browser-compat: html.elements.input.input-number
+browser-compat: html.elements.input.type_number
 translation_of: Web/HTML/Element/input/number
 ---
 

--- a/files/ja/web/html/element/input/number/index.md
+++ b/files/ja/web/html/element/input/number/index.md
@@ -11,7 +11,6 @@ tags:
   - 入力型
   - Number
   - リファレンス
-browser-compat: html.elements.input.type_number
 translation_of: Web/HTML/Element/input/number
 ---
 

--- a/files/ja/web/html/element/input/password/index.md
+++ b/files/ja/web/html/element/input/password/index.md
@@ -14,7 +14,6 @@ tags:
   - リファレンス
   - ウェブ
   - password
-browser-compat: html.elements.input.type_password
 translation_of: Web/HTML/Element/input/password
 ---
 

--- a/files/ja/web/html/element/input/password/index.md
+++ b/files/ja/web/html/element/input/password/index.md
@@ -14,7 +14,7 @@ tags:
   - リファレンス
   - ウェブ
   - password
-browser-compat: html.elements.input.input-password
+browser-compat: html.elements.input.type_password
 translation_of: Web/HTML/Element/input/password
 ---
 

--- a/files/ja/web/html/element/input/radio/index.md
+++ b/files/ja/web/html/element/input/radio/index.md
@@ -18,7 +18,6 @@ tags:
   - form
   - radio
   - radio button
-browser-compat: html.elements.input.type_radio
 translation_of: Web/HTML/Element/input/radio
 ---
 {{HTMLRef("Input_types")}}

--- a/files/ja/web/html/element/input/radio/index.md
+++ b/files/ja/web/html/element/input/radio/index.md
@@ -18,6 +18,7 @@ tags:
   - form
   - radio
   - radio button
+browser-compat: html.elements.input.type_radio
 translation_of: Web/HTML/Element/input/radio
 ---
 {{HTMLRef("Input_types")}}
@@ -334,7 +335,7 @@ Notice that when clicking on a radio button, there's a nice, smooth fade out/in 
 
 ## ブラウザーの互換性
 
-{{Compat("html.elements.input.input-radio")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/html/element/input/range/index.md
+++ b/files/ja/web/html/element/input/range/index.md
@@ -12,7 +12,6 @@ tags:
   - リファレンス
   - ウェブ
   - スライダー
-browser-compat: html.elements.input.type_range
 translation_of: Web/HTML/Element/input/range
 ---
 

--- a/files/ja/web/html/element/input/range/index.md
+++ b/files/ja/web/html/element/input/range/index.md
@@ -12,7 +12,7 @@ tags:
   - リファレンス
   - ウェブ
   - スライダー
-browser-compat: html.elements.input.input-range
+browser-compat: html.elements.input.type_range
 translation_of: Web/HTML/Element/input/range
 ---
 

--- a/files/ja/web/html/element/input/reset/index.md
+++ b/files/ja/web/html/element/input/reset/index.md
@@ -13,7 +13,6 @@ tags:
   - Reference
   - Reset Button
   - reset
-browser-compat: html.elements.input.type_reset
 translation_of: Web/HTML/Element/input/reset
 ---
 {{HTMLRef("Input_types")}}

--- a/files/ja/web/html/element/input/reset/index.md
+++ b/files/ja/web/html/element/input/reset/index.md
@@ -13,6 +13,7 @@ tags:
   - Reference
   - Reset Button
   - reset
+browser-compat: html.elements.input.type_reset
 translation_of: Web/HTML/Element/input/reset
 ---
 {{HTMLRef("Input_types")}}
@@ -149,7 +150,7 @@ translation_of: Web/HTML/Element/input/reset
 
 ## ブラウザーの互換性
 
-{{Compat("html.elements.input.input-reset")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/html/element/input/search/index.md
+++ b/files/ja/web/html/element/input/search/index.md
@@ -9,7 +9,6 @@ tags:
   - 入力型
   - リファレンス
   - Search
-browser-compat: html.elements.input.type_search
 translation_of: Web/HTML/Element/input/search
 ---
 

--- a/files/ja/web/html/element/input/search/index.md
+++ b/files/ja/web/html/element/input/search/index.md
@@ -9,7 +9,7 @@ tags:
   - 入力型
   - リファレンス
   - Search
-browser-compat: html.elements.input.input-search
+browser-compat: html.elements.input.type_search
 translation_of: Web/HTML/Element/input/search
 ---
 

--- a/files/ja/web/html/element/input/submit/index.md
+++ b/files/ja/web/html/element/input/submit/index.md
@@ -15,7 +15,6 @@ tags:
   - form
   - submit
   - submit button
-browser-compat: html.elements.input.type_submit
 translation_of: Web/HTML/Element/input/submit
 ---
 {{HTMLRef("Input_types")}}

--- a/files/ja/web/html/element/input/submit/index.md
+++ b/files/ja/web/html/element/input/submit/index.md
@@ -15,6 +15,7 @@ tags:
   - form
   - submit
   - submit button
+browser-compat: html.elements.input.type_submit
 translation_of: Web/HTML/Element/input/submit
 ---
 {{HTMLRef("Input_types")}}
@@ -224,7 +225,7 @@ We've included simple examples above. There isn't really anything more to say ab
 
 ## ブラウザーの互換性
 
-{{Compat("html.elements.input.input-submit")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/html/element/input/tel/index.md
+++ b/files/ja/web/html/element/input/tel/index.md
@@ -13,7 +13,7 @@ tags:
   - 入力型
   - Phone Numbers
   - リファレンス
-browser-compat: html.elements.input.input-tel
+browser-compat: html.elements.input.type_tel
 translation_of: Web/HTML/Element/input/tel
 ---
 

--- a/files/ja/web/html/element/input/tel/index.md
+++ b/files/ja/web/html/element/input/tel/index.md
@@ -13,7 +13,6 @@ tags:
   - 入力型
   - Phone Numbers
   - リファレンス
-browser-compat: html.elements.input.type_tel
 translation_of: Web/HTML/Element/input/tel
 ---
 

--- a/files/ja/web/html/element/input/text/index.md
+++ b/files/ja/web/html/element/input/text/index.md
@@ -12,7 +12,7 @@ tags:
   - Text
   - テキスト入力
   - text input
-browser-compat: html.elements.input.input-text
+browser-compat: html.elements.input.type_text
 translation_of: Web/HTML/Element/input/text
 ---
 

--- a/files/ja/web/html/element/input/text/index.md
+++ b/files/ja/web/html/element/input/text/index.md
@@ -12,7 +12,6 @@ tags:
   - Text
   - テキスト入力
   - text input
-browser-compat: html.elements.input.type_text
 translation_of: Web/HTML/Element/input/text
 ---
 

--- a/files/ja/web/html/element/input/time/index.md
+++ b/files/ja/web/html/element/input/time/index.md
@@ -13,7 +13,6 @@ tags:
   - 入力型
   - リファレンス
   - Time
-browser-compat: html.elements.input.type_time
 translation_of: Web/HTML/Element/input/time
 ---
 

--- a/files/ja/web/html/element/input/time/index.md
+++ b/files/ja/web/html/element/input/time/index.md
@@ -13,7 +13,7 @@ tags:
   - 入力型
   - リファレンス
   - Time
-browser-compat: html.elements.input.type-time
+browser-compat: html.elements.input.type_time
 translation_of: Web/HTML/Element/input/time
 ---
 

--- a/files/ja/web/html/element/input/url/index.md
+++ b/files/ja/web/html/element/input/url/index.md
@@ -15,7 +15,6 @@ tags:
   - Text
   - URL
   - control
-browser-compat: html.elements.input.type_url
 translation_of: Web/HTML/Element/input/url
 ---
 

--- a/files/ja/web/html/element/input/url/index.md
+++ b/files/ja/web/html/element/input/url/index.md
@@ -15,7 +15,7 @@ tags:
   - Text
   - URL
   - control
-browser-compat: html.elements.input.input-url
+browser-compat: html.elements.input.type_url
 translation_of: Web/HTML/Element/input/url
 ---
 

--- a/files/ja/web/html/element/input/week/index.md
+++ b/files/ja/web/html/element/input/week/index.md
@@ -14,7 +14,7 @@ tags:
   - リファレンス
   - Week
   - 週
-browser-compat: html.elements.input.input-week
+browser-compat: html.elements.input.type_week
 translation_of: Web/HTML/Element/input/week
 ---
 

--- a/files/ja/web/html/element/input/week/index.md
+++ b/files/ja/web/html/element/input/week/index.md
@@ -14,7 +14,6 @@ tags:
   - リファレンス
   - Week
   - 週
-browser-compat: html.elements.input.type_week
 translation_of: Web/HTML/Element/input/week
 ---
 


### PR DESCRIPTION
### 概要

- BCD リポジトリで query が変更された https://github.com/mdn/browser-compat-data/pull/16295
- 英語版は対応済み https://github.com/mdn/content/pull/16085

### 備考

- 22ファイルを示しましたが、color, datetime-local, hidden, image は対応済みだったので更新は18ファイルです。

### 関連

close https://github.com/mozilla-japan/translation/issues/627