### PR TITLE
html/attributes の BCD query を英語版に追従

### DIFF
--- a/files/ja/web/html/attributes/accept/index.md
+++ b/files/ja/web/html/attributes/accept/index.md
@@ -8,6 +8,7 @@ tags:
   - HTML
   - Input
   - Reference
+browser-compat: html.elements.input.accept
 translation_of: Web/HTML/Attributes/accept
 ---
 {{HTMLSidebar}}
@@ -149,7 +150,7 @@ div {
 
 ## ブラウザーの互換性
 
-{{Compat("html.elements.attribute.accept")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/html/attributes/accept/index.md
+++ b/files/ja/web/html/attributes/accept/index.md
@@ -8,7 +8,6 @@ tags:
   - HTML
   - Input
   - Reference
-browser-compat: html.elements.input.accept
 translation_of: Web/HTML/Attributes/accept
 ---
 {{HTMLSidebar}}

--- a/files/ja/web/html/attributes/autocomplete/index.md
+++ b/files/ja/web/html/attributes/autocomplete/index.md
@@ -17,7 +17,6 @@ tags:
   - form
   - パスワード
   - textarea
-browser-compat: html.global_attributes.autocomplete
 translation_of: Web/HTML/Attributes/autocomplete
 ---
 

--- a/files/ja/web/html/attributes/capture/index.md
+++ b/files/ja/web/html/attributes/capture/index.md
@@ -8,7 +8,6 @@ tags:
   - Capture
   - 制約検証
   - HTML
-browser-compat: html.elements.input.capture
 spec-urls: https://w3c.github.io/html-media-capture/#the-capture-attribute
 translation_of: Web/HTML/Attributes/capture
 ---

--- a/files/ja/web/html/attributes/capture/index.md
+++ b/files/ja/web/html/attributes/capture/index.md
@@ -8,6 +8,7 @@ tags:
   - Capture
   - 制約検証
   - HTML
+browser-compat: html.elements.input.capture
 spec-urls: https://w3c.github.io/html-media-capture/#the-capture-attribute
 translation_of: Web/HTML/Attributes/capture
 ---
@@ -56,7 +57,7 @@ translation_of: Web/HTML/Attributes/capture
 
 ## ブラウザーの互換性
 
-{{Compat("html.elements.attribute.capture")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/html/attributes/crossorigin/index.md
+++ b/files/ja/web/html/attributes/crossorigin/index.md
@@ -84,17 +84,7 @@ translation_of: Web/HTML/Attributes/crossorigin
 
 ## ブラウザーの互換性
 
-### script の crossorigin
-
-{{Compat("html.elements.script.crossorigin")}}
-
-### video の crossorigin
-
-{{Compat("html.elements.video.crossorigin")}}
-
-### link の crossorigin
-
-{{Compat("html.elements.link.crossorigin")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/html/attributes/disabled/index.md
+++ b/files/ja/web/html/attributes/disabled/index.md
@@ -7,6 +7,14 @@ tags:
   - 制約検証
   - フォーム
   - required
+browser-compat:
+  - html.elements.button.disabled
+  - html.elements.fieldset.disabled
+  - html.elements.input.disabled
+  - html.elements.optgroup.disabled
+  - html.elements.option.disabled
+  - html.elements.select.disabled
+  - html.elements.textarea.disabled
 spec-urls: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-disabled
 translation_of: Web/HTML/Attributes/disabled
 ---
@@ -111,7 +119,7 @@ Firefox は他のブラウザーとは異なり、ページを再読み込みし
 
 ## ブラウザーの互換性
 
-{{Compat("html.elements.attributes.disabled")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/html/attributes/disabled/index.md
+++ b/files/ja/web/html/attributes/disabled/index.md
@@ -7,14 +7,6 @@ tags:
   - 制約検証
   - フォーム
   - required
-browser-compat:
-  - html.elements.button.disabled
-  - html.elements.fieldset.disabled
-  - html.elements.input.disabled
-  - html.elements.optgroup.disabled
-  - html.elements.option.disabled
-  - html.elements.select.disabled
-  - html.elements.textarea.disabled
 spec-urls: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-disabled
 translation_of: Web/HTML/Attributes/disabled
 ---

--- a/files/ja/web/html/attributes/max/index.md
+++ b/files/ja/web/html/attributes/max/index.md
@@ -8,10 +8,6 @@ tags:
   - HTML
   - max
   - リファレンス
-browser-compat:
-  - html.elements.input.max
-  - html.elements.meter.max
-  - html.elements.progress.max
 spec-urls:
   - https://html.spec.whatwg.org/multipage/input.html#the-min-and-max-attributes
   - https://html.spec.whatwg.org/multipage/forms.html#the-meter-element

--- a/files/ja/web/html/attributes/max/index.md
+++ b/files/ja/web/html/attributes/max/index.md
@@ -8,10 +8,14 @@ tags:
   - HTML
   - max
   - リファレンス
+browser-compat:
+  - html.elements.input.max
+  - html.elements.meter.max
+  - html.elements.progress.max
 spec-urls:
   - https://html.spec.whatwg.org/multipage/input.html#the-min-and-max-attributes
-  - https://html.spec.whatwg.org/multipage/forms.html#the-progress-element
   - https://html.spec.whatwg.org/multipage/forms.html#the-meter-element
+  - https://html.spec.whatwg.org/multipage/forms.html#the-progress-element
 translation_of: Web/HTML/Attributes/max
 ---
 
@@ -134,7 +138,7 @@ translation_of: Web/HTML/Attributes/max
 
 ## ブラウザーの互換性
 
-{{Compat("html.elements.attribute.capture")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/html/attributes/maxlength/index.md
+++ b/files/ja/web/html/attributes/maxlength/index.md
@@ -10,6 +10,9 @@ tags:
   - リファレンス
   - maxlength
   - textarea
+browser-compat:
+  - html.elements.input.maxlength
+  - html.elements.textarea.maxlength
 spec-urls: https://html.spec.whatwg.org/multipage/input.html#attr-input-maxlength
 translation_of: Web/HTML/Attributes/maxlength
 ---
@@ -40,7 +43,7 @@ maxlength が指定されなかった場合、または無効な値が指定さ�
 
 ## ブラウザーの互換性
 
-{{Compat("html.elements.attribute.maxlength")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/html/attributes/maxlength/index.md
+++ b/files/ja/web/html/attributes/maxlength/index.md
@@ -10,9 +10,6 @@ tags:
   - リファレンス
   - maxlength
   - textarea
-browser-compat:
-  - html.elements.input.maxlength
-  - html.elements.textarea.maxlength
 spec-urls: https://html.spec.whatwg.org/multipage/input.html#attr-input-maxlength
 translation_of: Web/HTML/Attributes/maxlength
 ---

--- a/files/ja/web/html/attributes/min/index.md
+++ b/files/ja/web/html/attributes/min/index.md
@@ -8,9 +8,6 @@ tags:
   - HTML
   - min
   - Reference
-browser-compat:
-  - html.elements.input.min
-  - html.elements.meter.min
 spec-urls: https://html.spec.whatwg.org/multipage/input.html#the-min-and-max-attributes
 translation_of: Web/HTML/Attributes/min
 ---

--- a/files/ja/web/html/attributes/min/index.md
+++ b/files/ja/web/html/attributes/min/index.md
@@ -8,6 +8,9 @@ tags:
   - HTML
   - min
   - Reference
+browser-compat:
+  - html.elements.input.min
+  - html.elements.meter.min
 spec-urls: https://html.spec.whatwg.org/multipage/input.html#the-min-and-max-attributes
 translation_of: Web/HTML/Attributes/min
 ---
@@ -143,7 +146,7 @@ input:invalid {
 
 ## ブラウザーの互換性
 
-{{Compat("html.elements.attributes.min")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/html/attributes/minlength/index.md
+++ b/files/ja/web/html/attributes/minlength/index.md
@@ -10,6 +10,9 @@ tags:
   - リファレンス
   - minlength
   - textarea
+browser-compat:
+  - html.elements.input.minlength
+  - html.elements.textarea.minlength
 spec-urls: https://html.spec.whatwg.org/multipage/input.html#attr-input-minlength
 translation_of: Web/HTML/Attributes/minlength
 ---
@@ -50,7 +53,7 @@ input:invalid:focus {
 
 ## ブラウザーの互換性
 
-{{Compat("html.elements.attribute.minlength")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/html/attributes/minlength/index.md
+++ b/files/ja/web/html/attributes/minlength/index.md
@@ -10,9 +10,6 @@ tags:
   - リファレンス
   - minlength
   - textarea
-browser-compat:
-  - html.elements.input.minlength
-  - html.elements.textarea.minlength
 spec-urls: https://html.spec.whatwg.org/multipage/input.html#attr-input-minlength
 translation_of: Web/HTML/Attributes/minlength
 ---

--- a/files/ja/web/html/attributes/pattern/index.md
+++ b/files/ja/web/html/attributes/pattern/index.md
@@ -7,6 +7,7 @@ tags:
   - Constraint Validation API
   - HTML
   - Reference
+browser-compat: html.elements.input.pattern
 translation_of: Web/HTML/Attributes/pattern
 ---
 {{HTMLSidebar}}
@@ -129,7 +130,7 @@ This renders like so:
 
 ## ブラウザーの互換性
 
-{{Compat("html.elements.attributes.pattern")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/html/attributes/pattern/index.md
+++ b/files/ja/web/html/attributes/pattern/index.md
@@ -7,7 +7,6 @@ tags:
   - Constraint Validation API
   - HTML
   - Reference
-browser-compat: html.elements.input.pattern
 translation_of: Web/HTML/Attributes/pattern
 ---
 {{HTMLSidebar}}

--- a/files/ja/web/html/attributes/readonly/index.md
+++ b/files/ja/web/html/attributes/readonly/index.md
@@ -7,9 +7,6 @@ tags:
   - 制約検証
   - フォーム
   - required
-browser-compat:
-  - html.elements.input.readonly
-  - html.elements.textarea.readonly
 spec-urls: https://html.spec.whatwg.org/multipage/forms.html#attr-input-readonly
 translation_of: Web/HTML/Attributes/readonly
 ---

--- a/files/ja/web/html/attributes/readonly/index.md
+++ b/files/ja/web/html/attributes/readonly/index.md
@@ -7,6 +7,9 @@ tags:
   - 制約検証
   - フォーム
   - required
+browser-compat:
+  - html.elements.input.readonly
+  - html.elements.textarea.readonly
 spec-urls: https://html.spec.whatwg.org/multipage/forms.html#attr-input-readonly
 translation_of: Web/HTML/Attributes/readonly
 ---
@@ -80,7 +83,7 @@ readonly が付いた値を動的に変更できる唯一の方法は、スク�
 
 ## ブラウザーの互換性
 
-{{Compat("html.elements.attributes.readonly")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/html/attributes/rel/index.md
+++ b/files/ja/web/html/attributes/rel/index.md
@@ -191,17 +191,7 @@ translation_of: Web/HTML/Attributes/rel
 
 ## ブラウザーの互換性
 
-### `link` 要素の `rel` 属性
-
-{{Compat("html.elements.link.rel")}}
-
-### `a` 要素の `rel` 属性
-
-{{Compat("html.elements.a.rel")}}
-
-### `area` 要素の `rel` 属性
-
-{{Compat("html.elements.area.rel")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/html/attributes/required/index.md
+++ b/files/ja/web/html/attributes/required/index.md
@@ -73,7 +73,7 @@ translation_of: Web/HTML/Attributes/required
 
 ## ブラウザーの互換性
 
-{{Compat("html.elements.attributes.required")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/html/attributes/size/index.md
+++ b/files/ja/web/html/attributes/size/index.md
@@ -51,7 +51,7 @@ translation_of: Web/HTML/Attributes/size
 
 ## ブラウザーの互換性
 
-{{Compat("html.elements.attribute.size")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/html/attributes/step/index.md
+++ b/files/ja/web/html/attributes/step/index.md
@@ -8,6 +8,7 @@ tags:
   - HTML
   - リファレンス
   - step
+browser-compat: html.elements.input.step
 spec-urls: https://html.spec.whatwg.org/multipage/input.html#the-step-attribute
 translation_of: Web/HTML/Attributes/step
 ---
@@ -116,6 +117,10 @@ input:invalid {
 ## 仕様書
 
 {{Specifications}}
+
+## ブラウザーの互換性
+
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/html/attributes/step/index.md
+++ b/files/ja/web/html/attributes/step/index.md
@@ -8,7 +8,6 @@ tags:
   - HTML
   - リファレンス
   - step
-browser-compat: html.elements.input.step
 spec-urls: https://html.spec.whatwg.org/multipage/input.html#the-step-attribute
 translation_of: Web/HTML/Attributes/step
 ---


### PR DESCRIPTION
### 概要

- https://github.com/mdn/translated-content/pull/7901 に類似した修正です
- BCD query が attribute(s) から input に変更されているようだったので修正しました

### 備考

- required と size は英語版でも bad BCD query になっていたのでそのままです
    - 12ファイルを示していましたが、上記を除いた10ファイルを更新しました

### 関連

close https://github.com/mozilla-japan/translation/issues/628