### PR TITLE
web/api/document の BCD query を英語版に追従

### DIFF
--- a/files/ja/web/api/document/activeelement/index.md
+++ b/files/ja/web/api/document/activeelement/index.md
@@ -9,7 +9,6 @@ tags:
   - リファレンス
   - ShadowRoot
   - activeElement
-browser-compat: api.Document.activeElement
 translation_of: Web/API/DocumentOrShadowRoot/activeElement
 translation_of_original: Web/API/Document/activeElement
 original_slug: Web/API/DocumentOrShadowRoot/activeElement

--- a/files/ja/web/api/document/adoptnode/index.md
+++ b/files/ja/web/api/document/adoptnode/index.md
@@ -66,7 +66,7 @@ iframeImages.forEach(function(imgEl) {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.adoptNode")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/afterscriptexecute_event/index.md
+++ b/files/ja/web/api/document/afterscriptexecute_event/index.md
@@ -8,7 +8,6 @@ tags:
   - Reference
   - プロパティ
   - 標準外
-browser-compat: api.Document.afterscriptexecute_event
 translation_of: Web/API/Document/onafterscriptexecute
 original_slug: Web/API/Document/onafterscriptexecute
 ---

--- a/files/ja/web/api/document/afterscriptexecute_event/index.md
+++ b/files/ja/web/api/document/afterscriptexecute_event/index.md
@@ -8,6 +8,7 @@ tags:
   - Reference
   - プロパティ
   - 標準外
+browser-compat: api.Document.afterscriptexecute_event
 translation_of: Web/API/Document/onafterscriptexecute
 original_slug: Web/API/Document/onafterscriptexecute
 ---
@@ -41,7 +42,7 @@ document.addEventListener('afterscriptexecute', finished, true);
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.onafterscriptexecute")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/alinkcolor/index.md
+++ b/files/ja/web/api/document/alinkcolor/index.md
@@ -36,4 +36,4 @@ Mozilla Firefox では、このプロパティの既定値は赤 (16 進で `#ee
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.alinkColor")}}
+{{Compat}}

--- a/files/ja/web/api/document/all/index.md
+++ b/files/ja/web/api/document/all/index.md
@@ -37,4 +37,4 @@ var htmlAllCollection = document.all;
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.all")}}
+{{Compat}}

--- a/files/ja/web/api/document/anchors/index.md
+++ b/files/ja/web/api/document/anchors/index.md
@@ -8,7 +8,6 @@ tags:
   - HTML DOM
   - Property
   - Reference
-browser-compat: api.Document.anchors
 translation_of: Web/API/Document/anchors
 ---
 {{APIRef("DOM")}} {{Deprecated_Header}}

--- a/files/ja/web/api/document/applets/index.md
+++ b/files/ja/web/api/document/applets/index.md
@@ -44,4 +44,4 @@ my_java_app = document.applets[1];
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.applets")}}
+{{Compat}}

--- a/files/ja/web/api/document/beforescriptexecute_event/index.md
+++ b/files/ja/web/api/document/beforescriptexecute_event/index.md
@@ -9,7 +9,6 @@ tags:
  - Event
  - Reference
  - Non-standard
-browser-compat: api.Document.beforescriptexecute_event
 translation_of: Web/API/Document/beforescriptexecute_event
 original_slug: Web/API/Document/onbeforescriptexecute
 ---

--- a/files/ja/web/api/document/bgcolor/index.md
+++ b/files/ja/web/api/document/bgcolor/index.md
@@ -41,4 +41,4 @@ Firefox ではこのプロパティの初期値は白 (16 進表記で `#FFFFFF`
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.bgColor")}}
+{{Compat}}

--- a/files/ja/web/api/document/body/index.md
+++ b/files/ja/web/api/document/body/index.md
@@ -50,7 +50,7 @@ alert(document.body.id); // "newBodyElement"
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.body")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/caretpositionfrompoint/index.md
+++ b/files/ja/web/api/document/caretpositionfrompoint/index.md
@@ -9,6 +9,7 @@ tags:
   - Reference
   - ShadowRoot
   - caretPositionFromPoint()
+browser-compat: api.Document.caretPositionFromPoint
 translation_of: Web/API/DocumentOrShadowRoot/caretPositionFromPoint
 original_slug: Web/API/DocumentOrShadowRoot/caretPositionFromPoint
 ---
@@ -92,4 +93,4 @@ window.onload = function (){
 
 ## ブラウザーの互換性
 
-{{Compat("api.DocumentOrShadowRoot.caretPositionFromPoint")}}
+{{Compat}}

--- a/files/ja/web/api/document/caretpositionfrompoint/index.md
+++ b/files/ja/web/api/document/caretpositionfrompoint/index.md
@@ -9,7 +9,6 @@ tags:
   - Reference
   - ShadowRoot
   - caretPositionFromPoint()
-browser-compat: api.Document.caretPositionFromPoint
 translation_of: Web/API/DocumentOrShadowRoot/caretPositionFromPoint
 original_slug: Web/API/DocumentOrShadowRoot/caretPositionFromPoint
 ---

--- a/files/ja/web/api/document/caretrangefrompoint/index.md
+++ b/files/ja/web/api/document/caretrangefrompoint/index.md
@@ -11,7 +11,6 @@ tags:
   - Non-standard
   - Reference
   - caretRangeFromPoint
-browser-compat: api.Document.caretRangeFromPoint
 translation_of: Web/API/Document/caretRangeFromPoint
 ---
 {{APIRef("DOM")}}{{Non-standard_header}}

--- a/files/ja/web/api/document/characterset/index.md
+++ b/files/ja/web/api/document/characterset/index.md
@@ -9,7 +9,6 @@ tags:
   - Read-only
   - Reference
 translation_of: Web/API/Document/characterSet
-browser-compat: api.Document.characterSet
 ---
 {{ ApiRef("DOM") }}
 

--- a/files/ja/web/api/document/childelementcount/index.md
+++ b/files/ja/web/api/document/childelementcount/index.md
@@ -7,7 +7,6 @@ tags:
   - Property
   - Reference
 translation_of: Web/API/Document/childElementCount
-browser-compat: api.Document.childElementCount
 ---
 {{ APIRef("DOM") }}
 

--- a/files/ja/web/api/document/clear/index.md
+++ b/files/ja/web/api/document/clear/index.md
@@ -27,4 +27,4 @@ document.clear();
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.clear")}}
+{{Compat}}

--- a/files/ja/web/api/document/close/index.md
+++ b/files/ja/web/api/document/close/index.md
@@ -42,4 +42,4 @@ document.close();
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.close")}}
+{{Compat}}

--- a/files/ja/web/api/document/compatmode/index.md
+++ b/files/ja/web/api/document/compatmode/index.md
@@ -44,4 +44,4 @@ if (document.compatMode == "BackCompat") {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.compatMode")}}
+{{Compat}}

--- a/files/ja/web/api/document/contenttype/index.md
+++ b/files/ja/web/api/document/contenttype/index.md
@@ -37,4 +37,4 @@ contentType = document.contentType;
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.contentType")}}
+{{Compat}}

--- a/files/ja/web/api/document/cookie/index.md
+++ b/files/ja/web/api/document/cookie/index.md
@@ -228,7 +228,7 @@ Accept: */*
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.cookie")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/copy_event/index.md
+++ b/files/ja/web/api/document/copy_event/index.md
@@ -9,7 +9,6 @@ tags:
   - Reference
   - Web
   - copy
-browser-compat: api.Element.copy_event
 translation_of: Web/API/Document/copy_event
 ---
 {{APIRef}}

--- a/files/ja/web/api/document/copy_event/index.md
+++ b/files/ja/web/api/document/copy_event/index.md
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web
   - copy
+browser-compat: api.Element.copy_event
 translation_of: Web/API/Document/copy_event
 ---
 {{APIRef}}
@@ -54,7 +55,7 @@ document.addEventListener('copy', (event) => {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.copy_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/createcdatasection/index.md
+++ b/files/ja/web/api/document/createcdatasection/index.md
@@ -7,7 +7,6 @@ tags:
   - DOM
   - Method
   - Reference
-browser-compat: api.Document.createCDATASection
 translation_of: Web/API/Document/createCDATASection
 ---
 {{APIRef("DOM")}}

--- a/files/ja/web/api/document/createcomment/index.md
+++ b/files/ja/web/api/document/createcomment/index.md
@@ -43,4 +43,4 @@ alert(new XMLSerializer().serializeToString(docu));
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.createComment")}}
+{{Compat}}

--- a/files/ja/web/api/document/createdocumentfragment/index.md
+++ b/files/ja/web/api/document/createdocumentfragment/index.md
@@ -76,7 +76,7 @@ element.appendChild(fragment);
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.createDocumentFragment")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/createelement/index.md
+++ b/files/ja/web/api/document/createelement/index.md
@@ -8,7 +8,6 @@ tags:
   - メソッド
   - リファレンス
   - createElement
-browser-compat: api.Document.createElement
 translation_of: Web/API/Document/createElement
 ---
 {{APIRef("DOM")}}

--- a/files/ja/web/api/document/createelementns/index.md
+++ b/files/ja/web/api/document/createelementns/index.md
@@ -96,7 +96,7 @@ The new {{DOMxRef("Element")}}.
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.createElementNS")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/createevent/index.md
+++ b/files/ja/web/api/document/createevent/index.md
@@ -8,7 +8,6 @@ tags:
   - Reference
   - メソッド
 translation_of: Web/API/Document/createEvent
-browser-compat: api.Document.createEvent
 ---
 > **Warning:** `createEvent` とともに使用される多くのメソッド (`initCustomEvent` など) は非推奨です。代わりに [イベントのコンストラクター](/ja/docs/Web/API/CustomEvent) を使用してください。
 

--- a/files/ja/web/api/document/createexpression/index.md
+++ b/files/ja/web/api/document/createexpression/index.md
@@ -34,7 +34,7 @@ xpathExpr = document.createExpression(xpathText, namespaceURLMapper);
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.createExpression")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/createnodeiterator/index.md
+++ b/files/ja/web/api/document/createnodeiterator/index.md
@@ -75,4 +75,4 @@ while (currentNode = nodeIterator.nextNode()) {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.createNodeIterator")}}
+{{Compat}}

--- a/files/ja/web/api/document/creatensresolver/index.md
+++ b/files/ja/web/api/document/creatensresolver/index.md
@@ -43,7 +43,7 @@ nsResolver = document.createNSResolver(node);
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.createNSResolver")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/createprocessinginstruction/index.md
+++ b/files/ja/web/api/document/createprocessinginstruction/index.md
@@ -61,4 +61,4 @@ console.log(new XMLSerializer().serializeToString(doc));
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.createProcessingInstruction")}}
+{{Compat}}

--- a/files/ja/web/api/document/createrange/index.md
+++ b/files/ja/web/api/document/createrange/index.md
@@ -44,4 +44,4 @@ range.setEnd(endNode, endOffset);
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.createRange")}}
+{{Compat}}

--- a/files/ja/web/api/document/createtextnode/index.md
+++ b/files/ja/web/api/document/createtextnode/index.md
@@ -62,4 +62,4 @@ function addTextNode(text) {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.createTextNode")}}
+{{Compat}}

--- a/files/ja/web/api/document/createtouch/index.md
+++ b/files/ja/web/api/document/createtouch/index.md
@@ -85,7 +85,7 @@ var touch2 = Document.createTouch(window, target, 2, 25, 30, 45, 50);
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.createTouch")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/createtouchlist/index.md
+++ b/files/ja/web/api/document/createtouchlist/index.md
@@ -67,7 +67,7 @@ var list2 = document.createTouchList(touch1, touch2);
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.createTouchList")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/currentscript/index.md
+++ b/files/ja/web/api/document/currentscript/index.md
@@ -44,7 +44,7 @@ if (document.currentScript.async) {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.currentScript")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/cut_event/index.md
+++ b/files/ja/web/api/document/cut_event/index.md
@@ -9,7 +9,6 @@ tags:
   - Event
   - Reference
   - Web
-browser-compat: api.Element.cut_event
 translation_of: Web/API/Document/cut_event
 ---
 {{APIRef}}

--- a/files/ja/web/api/document/cut_event/index.md
+++ b/files/ja/web/api/document/cut_event/index.md
@@ -9,6 +9,7 @@ tags:
   - Event
   - Reference
   - Web
+browser-compat: api.Element.cut_event
 translation_of: Web/API/Document/cut_event
 ---
 {{APIRef}}
@@ -54,7 +55,7 @@ document.addEventListener('cut', (event) => {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.cut_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/defaultview/index.md
+++ b/files/ja/web/api/document/defaultview/index.md
@@ -8,7 +8,6 @@ tags:
   - Property
   - Reference
 translation_of: Web/API/Document/defaultView
-browser-compat: api.Document.defaultView
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/document/designmode/index.md
+++ b/files/ja/web/api/document/designmode/index.md
@@ -44,7 +44,7 @@ iframeNode.contentDocument.designMode = "on";
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.designMode")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/dir/index.md
+++ b/files/ja/web/api/document/dir/index.md
@@ -28,7 +28,7 @@ document.dir = dirStr
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.dir")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/doctype/index.md
+++ b/files/ja/web/api/document/doctype/index.md
@@ -49,4 +49,4 @@ DOM レベル 2 では、文書型宣言の編集に対応していません。
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.doctype")}}
+{{Compat}}

--- a/files/ja/web/api/document/document/index.md
+++ b/files/ja/web/api/document/document/index.md
@@ -27,4 +27,4 @@ new Document();
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.Document")}}
+{{Compat}}

--- a/files/ja/web/api/document/documentelement/index.md
+++ b/files/ja/web/api/document/documentelement/index.md
@@ -47,4 +47,4 @@ for (const child of firstTier) {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.documentElement")}}
+{{Compat}}

--- a/files/ja/web/api/document/documenturi/index.md
+++ b/files/ja/web/api/document/documenturi/index.md
@@ -49,7 +49,7 @@ document.getElementById("url").textContent = document.documentURI;
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.documentURI")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/documenturiobject/index.md
+++ b/files/ja/web/api/document/documenturiobject/index.md
@@ -43,4 +43,4 @@ if (uriObj.schemeIs('http')) {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.documentURIObject")}}
+{{Compat}}

--- a/files/ja/web/api/document/domain/index.md
+++ b/files/ja/web/api/document/domain/index.md
@@ -69,7 +69,7 @@ if (document.domain === badDomain) {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.domain")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/domcontentloaded_event/index.md
+++ b/files/ja/web/api/document/domcontentloaded_event/index.md
@@ -164,7 +164,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.DOMContentLoaded_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/drag_event/index.md
+++ b/files/ja/web/api/document/drag_event/index.md
@@ -12,7 +12,6 @@ tags:
   - Reference
   - Web
   - drag and drop
-browser-compat: api.Document.drag_event
 translation_of: Web/API/Document/drag_event
 ---
 {{APIRef}}

--- a/files/ja/web/api/document/dragend_event/index.md
+++ b/files/ja/web/api/document/dragend_event/index.md
@@ -12,7 +12,6 @@ tags:
   - Web
   - drag and drop
   - dragend
-browser-compat: api.Document.dragend_event
 translation_of: Web/API/Document/dragend_event
 ---
 {{APIRef}}

--- a/files/ja/web/api/document/dragenter_event/index.md
+++ b/files/ja/web/api/document/dragenter_event/index.md
@@ -12,7 +12,6 @@ tags:
   - Web
   - drag and drop
   - dragenter
-browser-compat: api.Document.dragenter_event
 translation_of: Web/API/Document/dragenter_event
 ---
 {{APIRef}}

--- a/files/ja/web/api/document/dragleave_event/index.md
+++ b/files/ja/web/api/document/dragleave_event/index.md
@@ -12,7 +12,6 @@ tags:
   - Web
   - drag and drop
   - dragleave
-browser-compat: api.Document.dragleave_event
 translation_of: Web/API/Document/dragleave_event
 ---
 {{APIRef}}

--- a/files/ja/web/api/document/dragover_event/index.md
+++ b/files/ja/web/api/document/dragover_event/index.md
@@ -11,7 +11,6 @@ tags:
   - Reference
   - Web
   - drag and drop
-browser-compat: api.Document.dragover_event
 translation_of: Web/API/Document/dragover_event
 ---
 {{APIRef}}

--- a/files/ja/web/api/document/dragstart_event/index.md
+++ b/files/ja/web/api/document/dragstart_event/index.md
@@ -7,7 +7,6 @@ tags:
   - Event
   - Reference
   - drag and drop
-browser-compat: api.Document.dragstart_event
 translation_of: Web/API/Document/dragstart_event
 ---
 {{APIRef}}

--- a/files/ja/web/api/document/drop_event/index.md
+++ b/files/ja/web/api/document/drop_event/index.md
@@ -10,7 +10,6 @@ tags:
   - HTML 5
   - Reference
   - drag and drop
-browser-compat: api.Document.drop_event
 translation_of: Web/API/Document/drop_event
 ---
 {{APIRef}}

--- a/files/ja/web/api/document/elementfrompoint/index.md
+++ b/files/ja/web/api/document/elementfrompoint/index.md
@@ -7,7 +7,6 @@ tags:
   - Document
   - メソッド
   - リファレンス
-browser-compat: api.Document.elementFromPoint
 translation_of: Web/API/DocumentOrShadowRoot/elementFromPoint
 translation_of_original: Web/API/Document/elementFromPoint
 original_slug: Web/API/DocumentOrShadowRoot/elementFromPoint

--- a/files/ja/web/api/document/elementsfrompoint/index.md
+++ b/files/ja/web/api/document/elementsfrompoint/index.md
@@ -12,7 +12,6 @@ tags:
   - elementsFromPoint()
   - shadow dom
   - メソッド
-browser-compat: api.Document.elementsFromPoint
 translation_of: Web/API/DocumentOrShadowRoot/elementsFromPoint
 original_slug: Web/API/DocumentOrShadowRoot/elementsFromPoint
 ---

--- a/files/ja/web/api/document/elementsfrompoint/index.md
+++ b/files/ja/web/api/document/elementsfrompoint/index.md
@@ -12,6 +12,7 @@ tags:
   - elementsFromPoint()
   - shadow dom
   - メソッド
+browser-compat: api.Document.elementsFromPoint
 translation_of: Web/API/DocumentOrShadowRoot/elementsFromPoint
 original_slug: Web/API/DocumentOrShadowRoot/elementsFromPoint
 ---
@@ -80,7 +81,7 @@ if (document.elementsFromPoint) {
 
 ## ブラウザーの互換性
 
-{{Compat("api.DocumentOrShadowRoot.elementsFromPoint")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/embeds/index.md
+++ b/files/ja/web/api/document/embeds/index.md
@@ -33,4 +33,4 @@ nodeList = document.embeds
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.embeds")}}
+{{Compat}}

--- a/files/ja/web/api/document/enablestylesheetsforset/index.md
+++ b/files/ja/web/api/document/enablestylesheetsforset/index.md
@@ -11,7 +11,6 @@ tags:
   - NeedsSpecTable
   - リファレンス
   - 非推奨
-browser-compat: api.Document.enableStyleSheetsForSet
 translation_of: Web/API/Document/enableStyleSheetsForSet
 ---
 {{APIRef("DOM")}}{{deprecated_header}}

--- a/files/ja/web/api/document/evaluate/index.md
+++ b/files/ja/web/api/document/evaluate/index.md
@@ -86,7 +86,7 @@ Results of `NODE_SNAPSHOT` types are snapshots, which are essentially lists of m
 
 ## ブラウザ互換性
 
-{{Compat("api.Document.evaluate")}}
+{{Compat}}
 
 ## 関連項目
 

--- a/files/ja/web/api/document/execcommand/index.md
+++ b/files/ja/web/api/document/execcommand/index.md
@@ -9,7 +9,6 @@ tags:
   - リファレンス
   - エディター
   - 非推奨
-browser-compat: api.Document.execCommand
 translation_of: Web/API/Document/execCommand
 ---
 {{ApiRef("DOM")}}{{deprecated_header}}

--- a/files/ja/web/api/document/exitfullscreen/index.md
+++ b/files/ja/web/api/document/exitfullscreen/index.md
@@ -61,7 +61,7 @@ document.onclick = function (event) {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.exitFullscreen")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/exitpointerlock/index.md
+++ b/files/ja/web/api/document/exitpointerlock/index.md
@@ -29,7 +29,7 @@ document.exitPointerLock();
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.exitPointerLock")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/featurepolicy/index.md
+++ b/files/ja/web/api/document/featurepolicy/index.md
@@ -32,4 +32,4 @@ var policy = iframeElement.featurePolicy
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.featurePolicy")}}
+{{Compat}}

--- a/files/ja/web/api/document/fgcolor/index.md
+++ b/files/ja/web/api/document/fgcolor/index.md
@@ -44,4 +44,4 @@ Mozilla Firefox ではこのプロパティの既定値は黒 (16 進数で `#00
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.fgColor")}}
+{{Compat}}

--- a/files/ja/web/api/document/fonts/index.md
+++ b/files/ja/web/api/document/fonts/index.md
@@ -44,7 +44,7 @@ document.fonts.ready.then(function() {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.fonts")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/forms/index.md
+++ b/files/ja/web/api/document/forms/index.md
@@ -100,7 +100,7 @@ var selectFormElement = document.forms[index].elements[index];
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.forms")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/fullscreen/index.md
+++ b/files/ja/web/api/document/fullscreen/index.md
@@ -56,7 +56,7 @@ function isDocumentInFullScreenMode() {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.fullscreen")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/fullscreenchange_event/index.md
+++ b/files/ja/web/api/document/fullscreenchange_event/index.md
@@ -70,7 +70,7 @@ document.addEventListener('fullscreenchange', (event) => {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.fullscreenchange_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/fullscreenelement/index.md
+++ b/files/ja/web/api/document/fullscreenelement/index.md
@@ -17,7 +17,6 @@ tags:
   - グラフィック
   - 全画面
   - 読み取り専用
-browser-compat: api.Document.fullscreenElement
 translation_of: Web/API/DocumentOrShadowRoot/fullscreenElement
 original_slug: Web/API/DocumentOrShadowRoot/fullscreenElement
 ---

--- a/files/ja/web/api/document/fullscreenelement/index.md
+++ b/files/ja/web/api/document/fullscreenelement/index.md
@@ -17,6 +17,7 @@ tags:
   - グラフィック
   - 全画面
   - 読み取り専用
+browser-compat: api.Document.fullscreenElement
 translation_of: Web/API/DocumentOrShadowRoot/fullscreenElement
 original_slug: Web/API/DocumentOrShadowRoot/fullscreenElement
 ---
@@ -57,7 +58,7 @@ function isVideoInFullscreen() {
 
 ## ブラウザーの互換性
 
-{{Compat("api.DocumentOrShadowRoot.fullscreenElement")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/fullscreenenabled/index.md
+++ b/files/ja/web/api/document/fullscreenenabled/index.md
@@ -52,7 +52,7 @@ function requestFullScreen() {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.fullscreenEnabled")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/fullscreenerror_event/index.md
+++ b/files/ja/web/api/document/fullscreenerror_event/index.md
@@ -63,7 +63,7 @@ requestor.requestFullscreen();
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.fullscreenerror_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/getanimations/index.md
+++ b/files/ja/web/api/document/getanimations/index.md
@@ -57,7 +57,7 @@ document.getAnimations().forEach(
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.getAnimations")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/getelementbyid/index.md
+++ b/files/ja/web/api/document/getelementbyid/index.md
@@ -119,7 +119,7 @@ var el = document.getElementById('testqq'); // el は null になります
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.getElementById")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/getelementsbyclassname/index.md
+++ b/files/ja/web/api/document/getelementsbyclassname/index.md
@@ -136,4 +136,4 @@ document.getElementById("resultArea").value = result;
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.getElementsByClassName")}}
+{{Compat}}

--- a/files/ja/web/api/document/getelementsbyname/index.md
+++ b/files/ja/web/api/document/getelementsbyname/index.md
@@ -63,7 +63,7 @@ var elements = document.getElementsByName(name);
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.getElementsByName")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/getelementsbytagname/index.md
+++ b/files/ja/web/api/document/getelementsbytagname/index.md
@@ -102,7 +102,7 @@ HTML 文書上で呼び出された場合、 `getElementsByTagName()` は処理�
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.getElementsByTagName")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/getelementsbytagnamens/index.md
+++ b/files/ja/web/api/document/getelementsbytagnamens/index.md
@@ -141,7 +141,7 @@ function getElementsByTagNameNSWrapper (ns, elName, doc, context) {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.getElementsByTagNameNS")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/getselection/index.md
+++ b/files/ja/web/api/document/getselection/index.md
@@ -9,7 +9,6 @@ tags:
   - getSelection
 translation_of: Web/API/Document/getSelection
 original_slug: Web/API/DocumentOrShadowRoot/getSelection
-browser-compat: api.Document.getSelection
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/hasfocus/index.md
+++ b/files/ja/web/api/document/hasfocus/index.md
@@ -75,7 +75,7 @@ setInterval(checkPageFocus, 300);
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.hasFocus")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/hasstorageaccess/index.md
+++ b/files/ja/web/api/document/hasstorageaccess/index.md
@@ -52,7 +52,7 @@ document.hasStorageAccess().then(hasAccess => {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.hasStorageAccess")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/head/index.md
+++ b/files/ja/web/api/document/head/index.md
@@ -54,7 +54,7 @@ var objRef = document.head;
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.head")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/height/index.md
+++ b/files/ja/web/api/document/height/index.md
@@ -11,7 +11,6 @@ tags:
   - プロパティ
   - リファレンス
   - 非推奨
-browser-compat: api.Document.height
 translation_of: Web/API/Document/height
 ---
 {{APIRef("DOM")}} {{deprecated_header}}

--- a/files/ja/web/api/document/hidden/index.md
+++ b/files/ja/web/api/document/hidden/index.md
@@ -38,4 +38,4 @@ document.addEventListener("visibilitychange", function() {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.hidden")}}
+{{Compat}}

--- a/files/ja/web/api/document/implementation/index.md
+++ b/files/ja/web/api/document/implementation/index.md
@@ -46,7 +46,7 @@ W3C's DOM Level 1 勧告では `hasFeature` メソッドのみが定義されて
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.implementation")}}
+{{Compat}}
 
 ### Gecko に特有のメモ
 

--- a/files/ja/web/api/document/importnode/index.md
+++ b/files/ja/web/api/document/importnode/index.md
@@ -10,7 +10,6 @@ tags:
   - リファレンス
   - コピー
   - importNode
-browser-compat: api.Document.importNode
 translation_of: Web/API/Document/importNode
 ---
 {{APIRef("DOM")}}

--- a/files/ja/web/api/document/index.md
+++ b/files/ja/web/api/document/index.md
@@ -7,7 +7,6 @@ tags:
   - Document
   - インターフェイス
   - リファレンス
-browser-compat: api.Document
 translation_of: Web/API/Document
 ---
 {{APIRef("DOM")}}

--- a/files/ja/web/api/document/lastmodified/index.md
+++ b/files/ja/web/api/document/lastmodified/index.md
@@ -86,4 +86,4 @@ if (isNaN(nLastVisit) || nLastModif > nLastVisit) {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.lastModified")}}
+{{Compat}}

--- a/files/ja/web/api/document/laststylesheetset/index.md
+++ b/files/ja/web/api/document/laststylesheetset/index.md
@@ -12,7 +12,6 @@ tags:
   - スタイルシート
   - lastStyleSheetSet
   - 非推奨
-browser-compat: api.Document.lastStyleSheetSet
 translation_of: Web/API/Document/lastStyleSheetSet
 ---
 {{APIRef("DOM")}}{{deprecated_header}}

--- a/files/ja/web/api/document/linkcolor/index.md
+++ b/files/ja/web/api/document/linkcolor/index.md
@@ -42,7 +42,7 @@ HTML5
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.linkColor")}}
+{{Compat}}
 
 Mozilla Firefox におけるこのプロパティの既定値は、青 (16 進数で `#0000ee`) です。
 

--- a/files/ja/web/api/document/location/index.md
+++ b/files/ja/web/api/document/location/index.md
@@ -46,7 +46,7 @@ console.log(document.location);
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.location")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/lostpointercapture_event/index.md
+++ b/files/ja/web/api/document/lostpointercapture_event/index.md
@@ -76,7 +76,7 @@ para.addEventListener('pointerdown', (event) => {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.lostpointercapture_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/open/index.md
+++ b/files/ja/web/api/document/open/index.md
@@ -89,7 +89,7 @@ document.open(type, replace)
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.open")}}
+{{Compat}}
 
 ## See also
 

--- a/files/ja/web/api/document/origin/index.md
+++ b/files/ja/web/api/document/origin/index.md
@@ -11,7 +11,6 @@ tags:
   - プロパティ
   - 読み取り専用
   - 非推奨
-browser-compat: api.Document.origin
 translation_of: Web/API/Document/origin
 ---
 {{APIRef("DOM")}}{{deprecated_header}}

--- a/files/ja/web/api/document/paste_event/index.md
+++ b/files/ja/web/api/document/paste_event/index.md
@@ -9,6 +9,7 @@ tags:
   - Web
   - paste
   - イベント
+browser-compat: api.Element.paste_event
 translation_of: Web/API/Document/paste_event
 ---
 {{APIRef}}
@@ -54,7 +55,7 @@ document.addEventListener('paste', (event) => {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.paste_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/paste_event/index.md
+++ b/files/ja/web/api/document/paste_event/index.md
@@ -9,7 +9,6 @@ tags:
   - Web
   - paste
   - イベント
-browser-compat: api.Element.paste_event
 translation_of: Web/API/Document/paste_event
 ---
 {{APIRef}}

--- a/files/ja/web/api/document/plugins/index.md
+++ b/files/ja/web/api/document/plugins/index.md
@@ -35,7 +35,7 @@ embedArrayObj = document.plugins
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.plugins")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/pointercancel_event/index.md
+++ b/files/ja/web/api/document/pointercancel_event/index.md
@@ -73,7 +73,7 @@ document.onpointercancel = (event) => {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.pointercancel_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/pointerdown_event/index.md
+++ b/files/ja/web/api/document/pointerdown_event/index.md
@@ -65,7 +65,7 @@ document.onpointerdown = (event) => {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.pointerdown_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/pointerenter_event/index.md
+++ b/files/ja/web/api/document/pointerenter_event/index.md
@@ -65,7 +65,7 @@ document.onpointerenter = (event) => {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.pointerenter_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/pointerleave_event/index.md
+++ b/files/ja/web/api/document/pointerleave_event/index.md
@@ -65,7 +65,7 @@ document.onpointerleave = (event) => {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.pointerleave_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/pointerlockchange_event/index.md
+++ b/files/ja/web/api/document/pointerlockchange_event/index.md
@@ -64,7 +64,7 @@ document.onpointerlockchange = (event) => {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.pointerlockchange_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/pointerlockelement/index.md
+++ b/files/ja/web/api/document/pointerlockelement/index.md
@@ -11,6 +11,7 @@ tags:
   - mouse lock
   - プロパティ
   - マウスロック
+browser-compat: api.Document.pointerLockElement
 translation_of: Web/API/DocumentOrShadowRoot/pointerLockElement
 original_slug: Web/API/DocumentOrShadowRoot/pointerLockElement
 ---
@@ -36,7 +37,7 @@ var element = document.pointerLockElement;
 
 ## ブラウザーの互換性
 
-{{Compat("api.DocumentOrShadowRoot.pointerLockElement")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/pointerlockelement/index.md
+++ b/files/ja/web/api/document/pointerlockelement/index.md
@@ -11,7 +11,6 @@ tags:
   - mouse lock
   - プロパティ
   - マウスロック
-browser-compat: api.Document.pointerLockElement
 translation_of: Web/API/DocumentOrShadowRoot/pointerLockElement
 original_slug: Web/API/DocumentOrShadowRoot/pointerLockElement
 ---

--- a/files/ja/web/api/document/pointerlockerror_event/index.md
+++ b/files/ja/web/api/document/pointerlockerror_event/index.md
@@ -67,7 +67,7 @@ document.onpointerlockerror = (event) => {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.pointerlockerror_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/pointermove_event/index.md
+++ b/files/ja/web/api/document/pointermove_event/index.md
@@ -67,7 +67,7 @@ document.onpointermove = (event) => {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.pointermove_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/pointerout_event/index.md
+++ b/files/ja/web/api/document/pointerout_event/index.md
@@ -65,7 +65,7 @@ document.onpointerout = (event) => {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.pointerout_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/pointerover_event/index.md
+++ b/files/ja/web/api/document/pointerover_event/index.md
@@ -68,7 +68,7 @@ document.onpointerover = (event) => {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.pointerover_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/pointerup_event/index.md
+++ b/files/ja/web/api/document/pointerup_event/index.md
@@ -67,7 +67,7 @@ document.onpointerup = (event) => {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.pointerup_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/preferredstylesheetset/index.md
+++ b/files/ja/web/api/document/preferredstylesheetset/index.md
@@ -11,7 +11,6 @@ tags:
   - リファレンス
   - Stylesheets
   - 非推奨
-browser-compat: api.Document.preferredStyleSheetSet
 translation_of: Web/API/Document/preferredStyleSheetSet
 ---
 {{APIRef("DOM")}}{{deprecated_header}}

--- a/files/ja/web/api/document/querycommandstate/index.md
+++ b/files/ja/web/api/document/querycommandstate/index.md
@@ -7,7 +7,6 @@ tags:
   - DOM
   - リファレンス
   - 非推奨
-browser-compat: api.Document.queryCommandState
 translation_of: Web/API/Document/queryCommandState
 ---
 {{ApiRef("DOM")}}{{deprecated_header}}

--- a/files/ja/web/api/document/querycommandsupported/index.md
+++ b/files/ja/web/api/document/querycommandsupported/index.md
@@ -10,7 +10,6 @@ tags:
   - リファレンス
   - エディター
   - 非推奨
-browser-compat: api.Document.queryCommandSupported
 translation_of: Web/API/Document/queryCommandSupported
 ---
 {{ApiRef("DOM")}}{{deprecated_header}}

--- a/files/ja/web/api/document/queryselector/index.md
+++ b/files/ja/web/api/document/queryselector/index.md
@@ -13,7 +13,6 @@ tags:
   - セレクター
   - querySelector
 translation_of: Web/API/Document/querySelector
-browser-compat: api.Document.querySelector
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/document/queryselectorall/index.md
+++ b/files/ja/web/api/document/queryselectorall/index.md
@@ -14,7 +14,6 @@ tags:
   - Selecting Elements
   - セレクター
   - querySelectorAll
-browser-compat: api.Document.querySelectorAll
 translation_of: Web/API/Document/querySelectorAll
 ---
 {{APIRef("DOM")}}

--- a/files/ja/web/api/document/readystate/index.md
+++ b/files/ja/web/api/document/readystate/index.md
@@ -7,7 +7,6 @@ tags:
   - HTML DOM
   - Property
   - Reference
-browser-compat: api.Document.readyState
 translation_of: Web/API/Document/readyState
 ---
 {{APIRef("DOM")}}

--- a/files/ja/web/api/document/readystatechange_event/index.md
+++ b/files/ja/web/api/document/readystatechange_event/index.md
@@ -118,7 +118,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.readystatechange_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/referrer/index.md
+++ b/files/ja/web/api/document/referrer/index.md
@@ -35,4 +35,4 @@ var referrer = document.referrer;
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.referrer")}}
+{{Compat}}

--- a/files/ja/web/api/document/releasecapture/index.md
+++ b/files/ja/web/api/document/releasecapture/index.md
@@ -7,7 +7,6 @@ tags:
   - DOM
   - Method
   - Reference
-browser-compat: api.Document.releaseCapture
 translation_of: Web/API/Document/releaseCapture
 ---
 {{ApiRef("DOM")}}

--- a/files/ja/web/api/document/requeststorageaccess/index.md
+++ b/files/ja/web/api/document/requeststorageaccess/index.md
@@ -9,7 +9,6 @@ tags:
   - Reference
   - Storage Access API
   - requestStorageAccess
-browser-compat: api.Document.requestStorageAccess
 translation_of: Web/API/Document/requestStorageAccess
 ---
 {{APIRef}}

--- a/files/ja/web/api/document/scripts/index.md
+++ b/files/ja/web/api/document/scripts/index.md
@@ -45,4 +45,4 @@ if (scripts.length) {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.scripts")}}
+{{Compat}}

--- a/files/ja/web/api/document/scroll_event/index.md
+++ b/files/ja/web/api/document/scroll_event/index.md
@@ -83,7 +83,7 @@ window.addEventListener('scroll', function(e) {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.scroll_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/scrollingelement/index.md
+++ b/files/ja/web/api/document/scrollingelement/index.md
@@ -32,4 +32,4 @@ scrollElm.scrollTop = 0;
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.scrollingElement")}}
+{{Compat}}

--- a/files/ja/web/api/document/selectedstylesheetset/index.md
+++ b/files/ja/web/api/document/selectedstylesheetset/index.md
@@ -10,7 +10,6 @@ tags:
   - リファレンス
   - スタイルシート
   - 非推奨
-browser-compat: api.Document.selectedStyleSheetSet
 translation_of: Web/API/Document/selectedStyleSheetSet
 ---
 {{APIRef("DOM")}}{{deprecated_header}}

--- a/files/ja/web/api/document/selectionchange_event/index.md
+++ b/files/ja/web/api/document/selectionchange_event/index.md
@@ -58,7 +58,7 @@ document.onselectionchange = () => {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.selectionchange_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/selectstart_event/index.md
+++ b/files/ja/web/api/document/selectstart_event/index.md
@@ -54,7 +54,7 @@ document.onselectstart = () => {
 
 ## ブラウザ互換性
 
-{{Compat("api.Document.selectstart_event")}}
+{{Compat}}
 
 ## 参照
 

--- a/files/ja/web/api/document/stylesheets/index.md
+++ b/files/ja/web/api/document/stylesheets/index.md
@@ -10,7 +10,6 @@ tags:
   - ShadowRoot
   - Stylesheets
   - shadow dom
-browser-compat: api.Document.styleSheets
 translation_of: Web/API/DocumentOrShadowRoot/styleSheets
 original_slug: Web/API/DocumentOrShadowRoot/styleSheets
 ---

--- a/files/ja/web/api/document/stylesheets/index.md
+++ b/files/ja/web/api/document/stylesheets/index.md
@@ -10,6 +10,7 @@ tags:
   - ShadowRoot
   - Stylesheets
   - shadow dom
+browser-compat: api.Document.styleSheets
 translation_of: Web/API/DocumentOrShadowRoot/styleSheets
 original_slug: Web/API/DocumentOrShadowRoot/styleSheets
 ---
@@ -45,4 +46,4 @@ function getStyleSheet(unique_title) {
 
 ## ブラウザーの互換性
 
-{{Compat("api.DocumentOrShadowRoot.styleSheets")}}
+{{Compat}}

--- a/files/ja/web/api/document/stylesheetsets/index.md
+++ b/files/ja/web/api/document/stylesheetsets/index.md
@@ -10,7 +10,6 @@ tags:
   - リファレンス
   - スタイルシート
   - 非推奨
-browser-compat: api.Document.styleSheetSets
 translation_of: Web/API/Document/styleSheetSets
 ---
 {{APIRef("DOM")}}{{deprecated_header}}

--- a/files/ja/web/api/document/title/index.md
+++ b/files/ja/web/api/document/title/index.md
@@ -65,4 +65,4 @@ XUL では、文書の読み込みが完了する前に `document.title` にア�
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.title")}}
+{{Compat}}

--- a/files/ja/web/api/document/tooltipnode/index.md
+++ b/files/ja/web/api/document/tooltipnode/index.md
@@ -29,4 +29,4 @@ XUL で定められたメソッドであり、標準仕様には含まれてい�
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.tooltipNode")}}
+{{Compat}}

--- a/files/ja/web/api/document/touchcancel_event/index.md
+++ b/files/ja/web/api/document/touchcancel_event/index.md
@@ -43,7 +43,7 @@ translation_of: Web/API/Document/touchcancel_event
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.touchcancel_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/touchend_event/index.md
+++ b/files/ja/web/api/document/touchend_event/index.md
@@ -49,7 +49,7 @@ translation_of: Web/API/Document/touchend_event
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.touchend_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/touchmove_event/index.md
+++ b/files/ja/web/api/document/touchmove_event/index.md
@@ -56,7 +56,7 @@ translation_of: Web/API/Document/touchmove_event
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.touchmove_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/touchstart_event/index.md
+++ b/files/ja/web/api/document/touchstart_event/index.md
@@ -45,7 +45,7 @@ translation_of: Web/API/Document/touchstart_event
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.touchstart_event")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/url/index.md
+++ b/files/ja/web/api/document/url/index.md
@@ -50,7 +50,7 @@ document.getElementById("url").textContent = document.URL;
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.URL")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/visibilitychange_event/index.md
+++ b/files/ja/web/api/document/visibilitychange_event/index.md
@@ -9,7 +9,6 @@ tags:
   - Visibility
   - Web
   - visibilitychange
-browser-compat: api.Document.visibilitychange_event
 translation_of: Web/API/Document/visibilitychange_event
 ---
 {{APIRef}}

--- a/files/ja/web/api/document/visibilitychange_event/index.md
+++ b/files/ja/web/api/document/visibilitychange_event/index.md
@@ -9,6 +9,7 @@ tags:
   - Visibility
   - Web
   - visibilitychange
+browser-compat: api.Document.visibilitychange_event
 translation_of: Web/API/Document/visibilitychange_event
 ---
 {{APIRef}}
@@ -64,7 +65,7 @@ document.addEventListener("visibilitychange", function() {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.visibilitychange")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/visibilitystate/index.md
+++ b/files/ja/web/api/document/visibilitystate/index.md
@@ -49,4 +49,4 @@ document.addEventListener("visibilitychange", function() {
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.visibilityState")}}
+{{Compat}}

--- a/files/ja/web/api/document/vlinkcolor/index.md
+++ b/files/ja/web/api/document/vlinkcolor/index.md
@@ -37,4 +37,4 @@ document.vlinkColor = color
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.vlinkColor")}}
+{{Compat}}

--- a/files/ja/web/api/document/width/index.md
+++ b/files/ja/web/api/document/width/index.md
@@ -11,7 +11,6 @@ tags:
   - プロパティ
   - リファレンス
   - 非推奨
-browser-compat: api.Document.width
 translation_of: Web/API/Document/width
 ---
 {{APIRef("DOM")}} {{deprecated_header}}

--- a/files/ja/web/api/document/write/index.md
+++ b/files/ja/web/api/document/write/index.md
@@ -84,7 +84,7 @@ document.write(markup);
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.write")}}
+{{Compat}}
 
 ## 関連情報
 

--- a/files/ja/web/api/document/writeln/index.md
+++ b/files/ja/web/api/document/writeln/index.md
@@ -44,4 +44,4 @@ document.writeln("<p>パスワードを入力してください:</p>");
 
 ## ブラウザーの互換性
 
-{{Compat("api.Document.writeln")}}
+{{Compat}}

--- a/files/ja/web/api/document/xmlversion/index.md
+++ b/files/ja/web/api/document/xmlversion/index.md
@@ -9,7 +9,6 @@ tags:
   - プロパティ
   - リファレンス
   - 非推奨
-browser-compat: api.Document.xmlVersion
 translation_of: Web/API/Document/xmlVersion
 ---
 {{APIRef("DOM")}}{{deprecated_header}}


### PR DESCRIPTION
### 概要

web/api/document の BCD query を英語版に追従

### 備考

日本語版で bad BCD query があったのは以下32ページですが、@ 付きの22件のURLは英語版でも bad だったので、修正できたのは10件です。

1. https://developer.mozilla.org/ja/docs/web/api/document/afterscriptexecute_event
1. https://developer.mozilla.org/ja/docs/web/api/document/caretpositionfrompoint
1. https://developer.mozilla.org/ja/docs/web/api/document/copy_event
1. https://developer.mozilla.org/ja/docs/web/api/document/cut_event
1. @ https://developer.mozilla.org/ja/docs/web/api/document/drag_event
1. @ https://developer.mozilla.org/ja/docs/web/api/document/dragend_event
1. @ https://developer.mozilla.org/ja/docs/web/api/document/dragenter_event
1. @ https://developer.mozilla.org/ja/docs/web/api/document/dragleave_event
1. @ https://developer.mozilla.org/ja/docs/web/api/document/dragover_event
1. @ https://developer.mozilla.org/ja/docs/web/api/document/dragstart_event
1. @ https://developer.mozilla.org/ja/docs/web/api/document/drop_event
1. https://developer.mozilla.org/ja/docs/web/api/document/elementsfrompoint
1. https://developer.mozilla.org/ja/docs/web/api/document/fullscreenelement
1. https://developer.mozilla.org/ja/docs/web/api/document/paste_event
1. @ https://developer.mozilla.org/ja/docs/web/api/document/pointercancel_event
1. @ https://developer.mozilla.org/ja/docs/web/api/document/pointerdown_event
1. @ https://developer.mozilla.org/ja/docs/web/api/document/pointerenter_event
1. @ https://developer.mozilla.org/ja/docs/web/api/document/pointerleave_event
1. @ https://developer.mozilla.org/ja/docs/web/api/document/pointerlockchange_event
1. https://developer.mozilla.org/ja/docs/web/api/document/pointerlockelement
1. @ https://developer.mozilla.org/ja/docs/web/api/document/pointerlockerror_event
1. @ https://developer.mozilla.org/ja/docs/web/api/document/pointermove_event
1. @ https://developer.mozilla.org/ja/docs/web/api/document/pointerout_event
1. @ https://developer.mozilla.org/ja/docs/web/api/document/pointerover_event
1. @ https://developer.mozilla.org/ja/docs/web/api/document/pointerup_event
1. @ https://developer.mozilla.org/ja/docs/web/api/document/selectstart_event
1. https://developer.mozilla.org/ja/docs/web/api/document/stylesheets
1. @ https://developer.mozilla.org/ja/docs/web/api/document/touchcancel_event
1. @ https://developer.mozilla.org/ja/docs/web/api/document/touchend_event
1. @ https://developer.mozilla.org/ja/docs/web/api/document/touchmove_event
1. @ https://developer.mozilla.org/ja/docs/web/api/document/touchstart_event
1. https://developer.mozilla.org/ja/docs/web/api/document/visibilitychange_event

### 関連

close https://github.com/mozilla-japan/translation/issues/629