### PR TITLE
[ko/update] Conditional (ternary) operator

### DIFF
--- a/files/ko/web/javascript/reference/operators/conditional_operator/index.md
+++ b/files/ko/web/javascript/reference/operators/conditional_operator/index.md
@@ -31,7 +31,7 @@ browser-compat: javascript.operators.conditional
 - `condition`
   - : 조건문으로 사용되는 표현식
 - `exprIfTrue`
-  - : `condition`이 {{Glossary("Truthy")}}한 값으로 평가될 경우 실행되는 표현식 (`true`와 같거나, `true`로 치환될 수 있는 값)
+  - : `condition`이 {{Glossary("truthy")}}한 값으로 평가될 경우 실행되는 표현식 (`true`와 같거나, `true`로 치환될 수 있는 값)
 - `exprIfFalse`
   - : `condition`이 {{Glossary("falsy")}}한 값으로 평가될 경우 실행되는 표현식 (`false`와 같거나, `false`로 치환될 수 있는 값)
 

--- a/files/ko/web/javascript/reference/operators/conditional_operator/index.md
+++ b/files/ko/web/javascript/reference/operators/conditional_operator/index.md
@@ -1,5 +1,5 @@
 ---
-title: 삼항 조건 연산자
+title: 조건 (삼항) 연산자
 slug: Web/JavaScript/Reference/Operators/Conditional_Operator
 tags:
   - Conditional
@@ -16,7 +16,7 @@ browser-compat: javascript.operators.conditional
 ---
 {{jsSidebar("Operators")}}
 
-**조건부 삼항 연산자**는 JavaScript에서 세 개의 피연산자를 취할 수 있는 유일한 연산자입니다. 맨 앞에 조건문 들어가고. 그 뒤로 물음표(`?`)와 조건이 참{{Glossary("truthy")}}이라면 실행할 식이 물음표 뒤로 들어갑니다. 바로 뒤로 콜론(`:`)이 들어가며 조건이 거짓{{Glossary("falsy")}}이라면 실행할 식이 마지막에 들어갑니다. 보통 [`if`](/ko/docs/Web/JavaScript/Reference/Statements/if...else) 명령문의 단축 형태로 쓰입니다.
+**조건 (삼항) 연산자**는 JavaScript에서 세 개의 피연산자를 받는 유일한 연산자입니다. 앞에서부터 조건문, 물음표(`?`), 조건문이 참({{Glossary("truthy")}})일 경우 실행할 표현식, 콜론(`:`), 조건문이 거짓({{Glossary("falsy")}})일 경우 실행할 표현식이 배치됩니다. 해당 연산자는 [`if...else`](/ko/docs/Web/JavaScript/Reference/Statements/if...else)문의 대체재로 빈번히 사용됩니다.
 
 {{EmbedInteractiveExample("pages/js/expressions-conditionaloperators.html")}}
 
@@ -28,16 +28,16 @@ browser-compat: javascript.operators.conditional
 
 ### 매개변수
 
-- `condition` (조건문)
-  - : 조건문으로 들어갈 표현식
-- `exprIfTrue` (참일 때 실행할 식)
-  - : `condition`이 {{Glossary("Truthy")}}일 때 실행되는 표현식입니다. (`true`일 때 치환될 값입니다).
-- `exprIfFalse` (거짓일 때 실행할 식)
-  - : `condition`이 {{Glossary("falsy")}}일 때 실행되는 표현식입니다. (`false`일 때 치환될 값입니다).
+- `condition`
+  - : 조건문으로 사용되는 표현식
+- `exprIfTrue`
+  - : `condition`이 {{Glossary("Truthy")}}한 값으로 평가될 경우 실행되는 표현식 (`true`와 같거나, `true`로 치환될 수 있는 값)
+- `exprIfFalse`
+  - : `condition`이 {{Glossary("falsy")}}한 값으로 평가될 경우 실행되는 표현식 (`false`와 같거나, `false`로 치환될 수 있는 값)
 
 ## 설명
 
-`false`외에도 `null`,`NaN`, `0`, 비어있는 문자 값 (`""`), 그리고 `undefined`으로 조건문에 false 값으로 사용 가능 합니다. 이 값들이 조건문으로 사용된다면 `exprIfFalse`이 결과로 나오게 됩니다.
+`false` 이외의 falsy한 표현식에는 `null`, `NaN`, `0`, 비어있는 문자열 (`""`), 그리고 `undefined`가 있습니다. `condition`이 이 중 하나일 경우 조건 연산자의 결괏값은 `exprIfFalse` 표현식을 실행한 결괏값입니다.
 
 ## 예제
 
@@ -51,7 +51,7 @@ console.log(beverage); // "Beer"
 
 ### null 값 처리하기
 
-이와같이 `null` 값을 처리할 때에도 일반적으로 사용됩니다.:
+`null`일 수 있는 값을 처리할 때 흔히 사용됩니다:
 
 ```js
 let greeting = person => {
@@ -63,9 +63,9 @@ console.log(greeting({name: `Alice`}));  // "Howdy, Alice"
 console.log(greeting(null));             // "Howdy, stranger"
 ```
 
-### 연속된 조건문 처리하기
+### 연결된 조건문 처리하기
 
-삼항 연산자는 `if … else if … else if … else`와 같은 "연속된 조건"을 사용할 수 있습니다.
+조건 연산자는 아래와 같이 연결해 사용할 수 있습니다. 이는 연결된 `if … else if … else if … else`와 유사합니다.
 
 ```js
 function example(…) {
@@ -74,9 +74,11 @@ function example(…) {
          : condition3 ? value3
          : value4;
 }
+```
 
-// 위의 코드는 아래의 코드와 동일합니다.
+위 코드는 아래의 연결된 `if … else`와 동등합니다.
 
+```js
 function example(…) {
     if (condition1) { return value1; }
     else if (condition2) { return value2; }


### PR DESCRIPTION
- `Conditional (ternary) operator`에 충실하게 `조건 (삼항) 연산자`로 번역했습니다.
- 조건부 연산자로 번역되는 경우도 있으나, 기존 [표현식과 연산자](https://developer.mozilla.org/ko/docs/Web/JavaScript/Guide/Expressions_and_Operators#%EC%A1%B0%EA%B1%B4_%EC%82%BC%ED%95%AD_%EC%97%B0%EC%82%B0%EC%9E%90) 문서와 통일했습니다.
- chained를 '연결된'으로 변경했습니다. 기존 [Optional chaining](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Operators/Optional_chaining) 문서 등을 참고했습니다.
- 원문을 보다 충실히 번역했습니다. (예: value that may be `null` → `null`일 수 있는 값)