### PR TITLE
Add Content-Length for Simple Response Header

### DIFF
--- a/files/zh-cn/glossary/simple_response_header/index.md
+++ b/files/zh-cn/glossary/simple_response_header/index.md
@@ -6,6 +6,7 @@ slug: Glossary/Simple_response_header
 
 - {{HTTPHeader("Cache-Control")}}
 - {{HTTPHeader("Content-Language")}}
+- {{HTTPHeader("Content-Length")}}
 - {{HTTPHeader("Content-Type")}}
 - {{HTTPHeader("Expires")}}
 - {{HTTPHeader("Last-Modified")}}


### PR DESCRIPTION
Content-Length was not part of the original set of safelisted response headers
See Also https://github.com/whatwg/fetch/pull/626