### PR TITLE
Update Glossary pages with old spec macros - `fr` - Part of #5618

### DIFF
--- a/files/fr/glossary/css_selector/index.md
+++ b/files/fr/glossary/css_selector/index.md
@@ -1,28 +1,21 @@
 ---
 title: Sélecteur CSS
 slug: Glossary/CSS_Selector
-tags:
-  - CSS
-  - Glossaire
-  - HTML
-  - Programmation
-  - Sélecteur
-  - Sélecteur CSS
-translation_of: Glossary/CSS_Selector
-original_slug: Glossaire/Sélecteur_CSS
+l10n:
+  sourceCommit: 818941994eb1765f2196c9b588314b12e7b9f66f
 ---
-Un **sélecteur CSS** est la partie de la règle CSS qui désigne les éléments d'un document concernés par la règle. Les éléments correspondants auront le style spécifié par la règle qui leur est appliqué.
+Un **sélecteur CSS** est la partie de la règle CSS qui désigne les éléments d'un document ciblés par cette règle. Les éléments correspondants se verront appliquer la mise en forme indiquée par la règle.
 
 ## Exemple
 
-Considérez ce code CSS :
+Prenons comme exemple ce fragment de code CSS&nbsp;:
 
 ```css
 p {
   color: green;
 }
 
-div.warning {
+div.avertissement {
   width: 100%;
   border: 2px solid yellow;
   color: white;
@@ -30,59 +23,56 @@ div.warning {
   padding:  0.8em 0.8em 0.6em;
 }
 
-#customized {
+#personnalise {
   font: 16px Lucida Grande, Arial, Helvetica, sans-serif;
 }
 ```
 
-Les sélecteurs sont ici `"p"` (qui applique la couleur verte au texte de tout élément {{HTMLElement ("p")}}), `"div.warning"` (qui fait que tout élément {{HTMLElement ("div")}} appartenant à la {{Glossary ("Class", "classe CSS")}} `"warning"` ressemble à une boîte d'avertissement) et `"#customized"`, qui définit la police de base de l'élément avec l'ID `"customized"` à 16 -pixel Lucida Grande ou l'une des polices de secours.
+Les sélecteurs sont ici&nbsp;:
 
-Nous pouvons ensuite appliquer ce CSS à du HTML, tel que :
+- `p`, qui cible les éléments [`<p>`](/fr/docs/Web/HTML/Element/p) et qu'on utilise ici pour que le texte de ces éléments soit vert
+- `div.avertissement`, qui cible les éléments [`<div>`](/fr/docs/Web/HTML/Element/div) avec la [classe](/fr/docs/Web/HTML/Global_attributes/class) `avertissement` pour que ceux-ci ressemblent à une boîte d'avertissement)
+- `#personnalise`, qui cible l'élément avec l'identifiant `personnalise` pour appliquer une mise en forme utilisant une police de caractères de 16 pixels, Lucida Grande ou l'une des polices de secours.
+
+Nous pouvons ensuite appliquer ce CSS à du HTML, tel que&nbsp;:
 
 ```html
-<p>This is happy text.</p>
+<p>Un texte heureux.</p>
 
-<div class="warning">
-  Be careful! There are wizards present, and they are quick to anger!
+<div class="avertissement">
+  Attention&nbsp;! Il y a des sorciers pas loin&nbsp;!
 </div>
 
-<div id="customized">
-  <p>This is happy text.</p>
+<div id="personnalise">
+  <p>Un texte heureux.</p>
 
-  <div class="warning">
-    Be careful! There are wizards present, and they are quick to anger!
+  <div class="avertissement">
+    Attention&nbsp;! Il y a des sorciers pas loin&nbsp;!
   </div>
 </div>
 ```
 
 Le contenu de la page résultant ressemble à ceci:
 
-{{EmbedLiveSample("Exemple", 640, 210)}}
+{{EmbedLiveSample("", 640, 240)}}
 
-## Pour approfondir
+## Voir aussi
 
-### Culture générale
-
-- [Apprendre sur les sélecteurs CSS](/fr/Apprendre/CSS/Introduction_%C3%A0_CSS/Les_s%C3%A9lecteurs) dans notre introduction à CSS.
-- Sélecteurs de base
-
-  - [Sélecteurs de type](/fr/docs/Web/CSS/S%C3%A9lecteurs_de_type) `elementname`
-  - [Sélecteurs de classe](/fr/docs/Web/CSS/Sélecteurs_de_classe) `.classname`
-  - [Sélecteurs d'ID](/fr/docs/Web/CSS/Reference/Sélecteurs_d'ID) `#idname`
-  - [Sélecteurs universels](/fr/docs/Web/CSS/Sélecteurs_universels) `* ns|* *|*`
-  - [Sélecteurs d'attribut](/fr/docs/Web/CSS/Reference/Sélecteurs_d'attribut) `[attr=value]`
-  - [`Sélecteurs d'état`](/fr/docs/Web/CSS/Pseudo-classes) `a:active, a:visited`
-
-- Combinaisons
-
-  - [Sélecteurs de frère adjacent](/fr/docs/Web/CSS/Adjacent_sibling_selectors) `A + B`
-  - [Sélecteurs de voisins généraux](/fr/docs/Web/CSS/Sélecteurs_de_voisins_généraux) `A ~ B`
-  - [Sélecteurs d'enfant](/fr/docs/Web/CSS/Sélecteurs_enfant) `A > B`
-  - [Sélecteurs descendants](/fr/docs/Web/CSS/Sélecteurs_descendant) `A B`
-
-- [Pseudo-éléments](/fr/docs/Web/CSS/Pseudo-éléments)
-- [Pseudo-classes](/fr/docs/Web/CSS/Pseudo-classes)
-
-### Référence technique
-
-{{SpecName("CSS3 Selectors")}}
+- [En apprendre plus sur les sélecteurs CSS](/fr/docs/Learn/CSS/Building_blocks/Selectors) dans l'introduction à CSS
+- Les sélecteurs simples
+  - [Les sélecteurs de type](/fr/docs/Web/CSS/Type_selectors) `nomelement`
+  - [Les sélecteurs de classe](/fr/docs/Web/CSS/Class_selectors) `.nomclasse`
+  - [Les sélecteurs d'identifiant](/fr/docs/Web/CSS/ID_selectors) `#nomid`
+  - [Les sélecteurs universels](/fr/docs/Web/CSS/Universal_selectors) `* ns|* *|*`
+  - [Les sélecteurs d'attribut](/fr/docs/Web/CSS/Attribute_selectors) `[attr=valeur]`
+  - [Les sélecteurs d'état](/fr/docs/Web/CSS/Pseudo-classes) `a:active, a:visited`
+- Les sélecteurs composites
+  - [Liste de sélecteurs](/fr/docs/Web/CSS/Selector_list) `A, B`
+- Les combinateurs
+  - [Sélecteurs de voisins directs](/fr/docs/Web/CSS/Adjacent_sibling_combinator) `A + B`
+  - [Sélecteurs de voisins généraux](/fr/docs/Web/CSS/General_sibling_combinator) `A ~ B`
+  - [Sélecteurs d'enfant direct](/fr/docs/Web/CSS/Child_combinator) `A > B`
+  - [Sélecteurs de descendants](/fr/docs/Web/CSS/Descendant_combinator) `A B`
+- Pseudo
+  - [Pseudo-classes](/fr/docs/Web/CSS/Pseudo-classes) `:`
+  - [Pseudo-éléments](/fr/docs/Web/CSS/Pseudo-elements) `::`

--- a/files/fr/glossary/forbidden_response_header_name/index.md
+++ b/files/fr/glossary/forbidden_response_header_name/index.md
@@ -1,19 +1,12 @@
 ---
 title: Nom d'en-tête de réponse interdit
 slug: Glossary/Forbidden_response_header_name
-tags:
-  - En-têtes
-  - Glossaire
-  - HTTP
-  - Interdit
-  - Réponses
-translation_of: Glossary/Forbidden_response_header_name
-original_slug: Glossaire/Forbidden_response_header_name
+l10n:
+  sourceCommit: 818941994eb1765f2196c9b588314b12e7b9f66f
 ---
-_Un nom d'en-tête de réponse interdit est un_ nom d'[en-tête HTTP](/fr/docs/HTTP/Headers) (\``Set-Cookie`\` ou \``Set-Cookie2`\`) qui ne peuvent être modifiés par programmation.
+Un _nom d'en-tête de réponse interdit_ nom d'[en-tête HTTP](http://localhost:5042/en-US/docs/Web/HTTP/Headers) (\``Set-Cookie`\`) qui ne peut pas être modifié par programmation.
 
-## Spécifications
+## Voir aussi
 
-| Spécification                                                                                                        | Statut                   | Commentaire |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | ----------- |
-| {{SpecName('Fetch','#forbidden-response-header-name','forbidden-response-header-name')}} | {{Spec2('Fetch')}} |             |
+- [Spécification de l'API `Fetch`&nbsp;: nom d'en-tête de réponse interdit](https://fetch.spec.whatwg.org/#forbidden-response-header-name)
+- [Page du glossaire sur le nom d'en-tête interdit](/fr/docs/Glossary/Forbidden_header_name)

--- a/files/fr/glossary/forbidden_response_header_name/index.md
+++ b/files/fr/glossary/forbidden_response_header_name/index.md
@@ -4,7 +4,7 @@ slug: Glossary/Forbidden_response_header_name
 l10n:
   sourceCommit: 818941994eb1765f2196c9b588314b12e7b9f66f
 ---
-Un _nom d'en-tête de réponse interdit_ nom d'[en-tête HTTP](http://localhost:5042/en-US/docs/Web/HTTP/Headers) (\``Set-Cookie`\`) qui ne peut pas être modifié par programmation.
+Un _nom d'en-tête de réponse interdit_ est un nom d'[en-tête HTTP](/fr/docs/Web/HTTP/Headers) (`Set-Cookie`) qui ne peut pas être modifié par programmation.
 
 ## Voir aussi
 

--- a/files/fr/glossary/mathml/index.md
+++ b/files/fr/glossary/mathml/index.md
@@ -1,23 +1,14 @@
 ---
 title: MathML
 slug: Glossary/MathML
-tags:
-  - CodingScripting
-  - Glossaire
-  - MathML
-  - Mathematical Markup Language
-  - XML
-translation_of: Glossary/MathML
-original_slug: Glossaire/MathML
+l10n:
+  sourceCommit: 818941994eb1765f2196c9b588314b12e7b9f66f
 ---
-**MathML** (une application {{glossary("XML")}}) est un standard ouvert destiné à représenter des formules mathématiques dans des pages web. En 1998, MathML était d'abord une recommandation du W3C pour représenter des formules mathématiques dans le {{glossary("navigateur")}}. MathML a également d'autres applications parmi lesquelles les informations scientifiques et la synthèse vocale.
+**MathML** (une application [XML](/fr/docs/Glossary/XML)) est un standard ouvert destiné à représenter des formules mathématiques dans des pages web. En 1998, MathML était d'abord une recommandation du W3C pour représenter des formules mathématiques dans le [navigateur](/fr/docs/Glossary/Browser). MathML a également d'autres applications parmi lesquelles le contenu scientifique et la synthèse vocale.
 
-## Pour approfondir
+## Voir aussi
 
-### Culture générale
-
-- [MathML](https://fr.wikipedia.org/wiki/MathML) sur Wikipédia
-
-### Référence technique
-
-- {{spec("http://www.w3.org/Math/whatIsMathML.html", "MathML", "REC")}}
+- [MathML sur Wikipédia](https://fr.wikipedia.org/wiki/MathML)
+- [La section MathML sur MDN](/fr/docs/Web/MathML)
+- [L'édition de documents MathML](/fr/docs/Web/MathML/Authoring)
+- [Ce qu'est le MathML (en anglais)](https://www.w3.org/Math/whatIsMathML.html)

--- a/files/fr/glossary/site/index.md
+++ b/files/fr/glossary/site/index.md
@@ -12,18 +12,18 @@ Pour cette définition plus précise, un site est déterminé selon la portion d
 
 En prenant cette définition, `support.mozilla.org` et `developer.mozilla.org` font partie du même site, car `mozilla.org` est un domaine enregistrable.
 
-Dans certains contextes, le schéma rentre également en considération pour distinguer les sites (dans ce cas, on a alors `http://vpl.ca` et `https://vpl.ca` qui sont deux sites différents). Ajouter le schéma à la définition permet d'éviter qu'un site non-sécurisé (en HTTP) soit traité de la même façon qu'un site sécurisé (en HTTPS). Cette définition plus stricte est appliquée par les règles de gestion des cookies [`SameSite`](/fr/docs/Web/HTTP/Headers/Set-Cookie/SameSite) cookies.
+Dans certains contextes, le schéma rentre également en considération pour distinguer les sites (dans ce cas, on a alors `http://vpl.ca` et `https://vpl.ca` qui sont deux sites différents). Ajouter le schéma à la définition permet d'éviter qu'un site non-sécurisé (en HTTP) soit traité de la même façon qu'un site sécurisé (en HTTPS). Cette définition plus stricte est appliquée par les règles de gestion des cookies [`SameSite`](/fr/docs/Web/HTTP/Headers/Set-Cookie/SameSite).
 
 ## Exemples
 
-Pour les deux URL qui suivent, on a le même site, car le domaine enregistrable est le même _mozilla.org_ (les noms d'hôte et chemins de fichier différents n'ont pas d'importance)&nbsp;:
+Pour les deux URL qui suivent, on a le même site, car le domaine enregistrable, `mozilla.org`, est le même (les noms d'hôte et chemins de fichier différents n'ont pas d'importance)&nbsp;:
 
 - `https://developer.mozilla.org/fr/docs/`
 - `https://support.mozilla.org/fr/`
 
 Là encore, ce sont les mêmes sites, car le schéma et le port ne sont pas pertinents&nbsp;:
 
-- `http://example.com:8080`
+- `https://example.com:8080`
 - `https://example.com`
 
 Ici, ce ne sont pas les mêmes sites, car les domaines enregistrables des deux URL sont différents&nbsp;:

--- a/files/fr/glossary/site/index.md
+++ b/files/fr/glossary/site/index.md
@@ -1,20 +1,22 @@
 ---
 title: Site
 slug: Glossary/Site
-tags:
-  - Glossaire
-  - Sécurité
-  - WebMécanique
-translation_of: Glossary/Site
-original_slug: Glossaire/Site
+l10n:
+  sourceCommit: 818941994eb1765f2196c9b588314b12e7b9f66f
 ---
-Le _site_ d'un élément de contenu Web est déterminé par le _domaine enregistrable_ de l'hôte au sein de l'origine. Ceci est calculé en consultant une _liste de suffixes publics_ pour trouver la partie de l'hôte qui est comptée comme _suffixe public_ (par exemple, `com`, `org` ou `co.uk`).
+De façon informelle, un _site_ est un site web, c'est-à-dire un ensemble de pages web, servies depuis un même domaine, et maintenues par une seule organisation.
 
-Le concept de _site_ est utilisé dans les [cookies SameSite](/fr/docs/Web/HTTP/Headers/Set-Cookie#Directives), ainsi que dans la [politique de ressources inter-origines](</fr/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP)>) d'une application Web.
+Les navigateurs doivent parfois distinguer précisément les différents sites. Par exemple, un navigateur ne doit partager des cookies [`SameSite`](/fr/docs/Web/HTTP/Headers/Set-Cookie/SameSite) que pour le même site que celui qui a écrit ces cookies.
+
+Pour cette définition plus précise, un site est déterminé selon la portion du nom de domaine qui est _le domaine enregistrable_. Le domaine enregistrable se termine par un suffixe parmi ceux de [la liste des suffixes publics](https://publicsuffix.org/list/) et contient le nom de domaine juste avant ce suffixe. Cela signifie que `lemonde.fr`, `sussex.ac.uk`, et `wikipedia.org` sont tous des domaines enregistrables.
+
+En prenant cette définition, `support.mozilla.org` et `developer.mozilla.org` font partie du même site, car `mozilla.org` est un domaine enregistrable.
+
+Dans certains contextes, le schéma rentre également en considération pour distinguer les sites (dans ce cas, on a alors `http://vpl.ca` et `https://vpl.ca` qui sont deux sites différents). Ajouter le schéma à la définition permet d'éviter qu'un site non-sécurisé (en HTTP) soit traité de la même façon qu'un site sécurisé (en HTTPS). Cette définition plus stricte est appliquée par les règles de gestion des cookies [`SameSite`](/fr/docs/Web/HTTP/Headers/Set-Cookie/SameSite) cookies.
 
 ## Exemples
 
-Pour les deux URL qui suivent, on a le même site car le domaine enregistrable est le même _mozilla.org_ (les noms d'hôte et chemins de fichier différents n'ont pas d'importance)&nbsp;:
+Pour les deux URL qui suivent, on a le même site, car le domaine enregistrable est le même _mozilla.org_ (les noms d'hôte et chemins de fichier différents n'ont pas d'importance)&nbsp;:
 
 - `https://developer.mozilla.org/fr/docs/`
 - `https://support.mozilla.org/fr/`
@@ -24,13 +26,18 @@ Là encore, ce sont les mêmes sites, car le schéma et le port ne sont pas pert
 - `http://example.com:8080`
 - `https://example.com`
 
-Ici, ce ne sont pas les mêmes sites car les domaines enregistrables des deux URL sont différents&nbsp;:
+Ici, ce ne sont pas les mêmes sites, car les domaines enregistrables des deux URL sont différents&nbsp;:
 
 - `https://developer.mozilla.org/fr/docs/`
 - `https://example.com`
 
-## Spécifications
+Si on ne prend pas le schéma en considération, ces deux URL porteront sur le même site&nbsp;:
 
-| Spécification                                        | Statut               | Commentaire         |
-| ---------------------------------------------------- | -------------------- | ------------------- |
-| {{SpecName('URL', '#host-same-site')}} | {{Spec2('URL')}} | Définition initiale |
+- `http://example.com`
+- `https://example.com`
+
+## Voir aussi
+
+- [Qu'est-ce qu'une URL&nbsp;?](/fr/docs/Learn/Common_questions/What_is_a_URL)
+- [L'entrée du glossaire pour le terme «&nbsp;origine&nbsp;»](/fr/docs/Glossary/Origin)
+- [La règle de même origine](/fr/docs/Web/Security/Same-origin_policy)


### PR DESCRIPTION
This is an "update" PR for Glossary pages which contained macros targeted by #5618 
