### PR TITLE
fix typo `ersquerdo` -> `esquerdo`

### DIFF
--- a/files/pt-br/learn/javascript/first_steps/math/index.html
+++ b/files/pt-br/learn/javascript/first_steps/math/index.html
@@ -220,7 +220,7 @@ num2;</pre>
 
 <h2 id="Operadores_de_atribuição">Operadores de atribuição</h2>
 
-<p>Operadores de atribuição são os que atribuem um valor à uma variável. Nós já usamos o básico, <code>=</code>, muitas vezes, simplesmente atribuindo à variável do lado ersquerdo o valor indicado do lado direito do operador:</p>
+<p>Operadores de atribuição são os que atribuem um valor à uma variável. Nós já usamos o básico, <code>=</code>, muitas vezes, simplesmente atribuindo à variável do lado esquerdo o valor indicado do lado direito do operador:</p>
 
 <pre class="brush: js notranslate">var x = 3; // x contém o valor 3
 var y = 4; // y contém o valor 4


### PR DESCRIPTION
Correcting error