### PR TITLE
ci: update git commiter email as `github-actions`

### DIFF
--- a/.github/workflows/sync-translated-content.yml
+++ b/.github/workflows/sync-translated-content.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           git remote add upstream "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git config --local user.email "actions@users.noreply.github.com"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "MDN"
           git commit -a -m "[CRON] sync translated content" && \
           git pull --rebase upstream main && \

--- a/.github/workflows/sync-translated-content.yml
+++ b/.github/workflows/sync-translated-content.yml
@@ -49,8 +49,8 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           git remote add upstream "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "MDN"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
           git commit -a -m "[CRON] sync translated content" && \
           git pull --rebase upstream main && \
           git push upstream main


### PR DESCRIPTION
Use the email of `github-actions[bot]` so we can list all the commit pushed by workflow (for the author of sync commit will be `github-actions[bot]` which is actually in GitHub).

The email of `github-acions[bot]` is veryfied [here](https://github.com/orgs/community/discussions/26560#discussioncomment-3252339).

[GitHub docs about noreply email](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address) shows that: the noreply email is in the form of `ID+username@users.noreply.github.com`, and the `ID` could be found here: <https://api.github.com/users/github-actions[bot]>

The commit fbbe7f30f0bb05b7a2794b8f3f8ebdd56d7935bb in [test branch](https://github.com/yin1999/translated-content/commits/test-branch) can confirm this.