### PR TITLE
remove duplicated frontmatter keys from conflicting (ja)

### DIFF
--- a/files/ja/conflicting/glossary/plugin/index.md
+++ b/files/ja/conflicting/glossary/plugin/index.md
@@ -1,7 +1,6 @@
 ---
 title: Firefox のプラグインロードマップ
 slug: conflicting/Glossary/Plugin
-translation_of: Plugins/Roadmap
 original_slug: Plugins/Roadmap
 ---
 プラグインは、Firefox ユーザーのセキュリティとパフォーマンスの問題があります。 NPAPI プラグインは時代遅れの技術であり、Mozilla はプラグインを必要としないウェブに移行しています。最後まで残った NPAPI プラグインである Adobe Flash は、サポート終了の計画を[発表](http://blogs.adobe.com/conversations/2017/07/adobe-flash-update.html)しました。 Flash からの移行をサポートするために、Firefox は他のブラウザーと連携して、Flash の利用を少なくするように徐々にかつ慎重に進めています。以下は、Firefox のプラグインに対する過去および将来のサポートのロードマップです。

--- a/files/ja/conflicting/learn/javascript/objects/classes_in_javascript/index.md
+++ b/files/ja/conflicting/learn/javascript/objects/classes_in_javascript/index.md
@@ -1,17 +1,6 @@
 ---
 title: 初心者のためのオブジェクト指向 JavaScript
 slug: conflicting/Learn/JavaScript/Objects/Classes_in_JavaScript
-tags:
-  - Beginner
-  - Create
-  - JavaScript
-  - OOJS
-  - OOP
-  - オブジェクト
-  - オブジェクト指向
-  - 学習
-  - 記事
-translation_of: Learn/JavaScript/Objects/Object-oriented_JS
 original_slug: Learn/JavaScript/Objects/Object-oriented_JS
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Objects/Basics", "Learn/JavaScript/Objects/Object_prototypes", "Learn/JavaScript/Objects")}}

--- a/files/ja/conflicting/mdn/community/contributing/getting_started/index.md
+++ b/files/ja/conflicting/mdn/community/contributing/getting_started/index.md
@@ -1,13 +1,6 @@
 ---
 title: 全くの初心者のための GitHub
 slug: conflicting/MDN/Community/Contributing/Getting_started
-tags:
-  - Best practices
-  - Community
-  - GitHub
-  - MDN
-  - Beginners
-translation_of: MDN/Contribute/GitHub_beginners
 original_slug: MDN/Contribute/GitHub_beginners
 ---
 {{MDNSidebar}}

--- a/files/ja/conflicting/mdn/community/issues/index.md
+++ b/files/ja/conflicting/mdn/community/issues/index.md
@@ -1,14 +1,6 @@
 ---
 title: GitHub 早見表
 slug: conflicting/MDN/Community/Issues
-tags:
-  - Best practices
-  - Community
-  - GitHub
-  - MDN
-  - Beginners
-  - Cheatsheet
-  - Commands
 original_slug: MDN/Contribute/GitHub_cheatsheet
 ---
 {{MDNSidebar}}

--- a/files/ja/conflicting/mdn/community/issues_508862bdb961f07f5a8b2e723cede961/index.md
+++ b/files/ja/conflicting/mdn/community/issues_508862bdb961f07f5a8b2e723cede961/index.md
@@ -1,11 +1,6 @@
 ---
 title: MDN の問題を報告する
 slug: conflicting/MDN/Community/Issues_508862bdb961f07f5a8b2e723cede961
-tags:
-  - ガイド
-  - Howto
-  - MDN Meta
-translation_of: MDN/Contribute/Howto/Report_a_problem
 original_slug: MDN/Contribute/Howto/Report_a_problem
 ---
 {{MDNSidebar}}

--- a/files/ja/conflicting/web/accessibility/aria/index.md
+++ b/files/ja/conflicting/web/accessibility/aria/index.md
@@ -1,12 +1,6 @@
 ---
 title: アラート
 slug: conflicting/Web/Accessibility/ARIA
-tags:
-  - ARIA
-  - アクセシビリティ
-  - フォーム
-  - ウェブ
-translation_of: Web/Accessibility/ARIA/forms/alerts
 original_slug: Web/Accessibility/ARIA/forms/alerts
 ---
 ## 問題点

--- a/files/ja/conflicting/web/accessibility/aria/roles/alert_role/index.md
+++ b/files/ja/conflicting/web/accessibility/aria/roles/alert_role/index.md
@@ -1,23 +1,6 @@
 ---
 title: alert ロールの使用
 slug: conflicting/Web/Accessibility/ARIA/Roles/alert_role
-tags:
-  - ARIA
-  - Accessibility
-  - Advanced
-  - CSS
-  - Example
-  - HTML
-  - NeedsContent
-  - alert
-  - alert role
-  - alertrole
-  - alerts
-  - assitive technology
-  - role configuration
-  - wcag1.2.1
-  - wcag3.3.1
-translation_of: Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role
 original_slug: Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role
 ---
 ### 説明

--- a/files/ja/conflicting/web/accessibility/aria_184f054b1090ff5cd518146ac4e09122/index.md
+++ b/files/ja/conflicting/web/accessibility/aria_184f054b1090ff5cd518146ac4e09122/index.md
@@ -1,11 +1,6 @@
 ---
 title: ウェブアプリケーションと ARIA の FAQ
 slug: conflicting/Web/Accessibility/ARIA_184f054b1090ff5cd518146ac4e09122
-tags:
-  - ARIA
-  - Accessibility
-  - Guide
-translation_of: Web/Accessibility/ARIA/Web_applications_and_ARIA_FAQ
 original_slug: Web/Accessibility/ARIA/Web_applications_and_ARIA_FAQ
 ---
 ## ARIA とは何か

--- a/files/ja/conflicting/web/accessibility/aria_229a3bbc8da83524de32990b14561155/index.md
+++ b/files/ja/conflicting/web/accessibility/aria_229a3bbc8da83524de32990b14561155/index.md
@@ -1,12 +1,6 @@
 ---
 title: ウィジェット
 slug: conflicting/Web/Accessibility/ARIA_229a3bbc8da83524de32990b14561155
-tags:
-  - Accessibility
-  - JavaScript
-  - Landing
-  - NeedsUpdate
-translation_of: Web/Accessibility/ARIA/widgets
 original_slug: Web/Accessibility/ARIA/widgets
 ---
 > **Warning:** 警告: 更新が必要

--- a/files/ja/conflicting/web/accessibility/aria_64707ba1917a56654679cbe273e2f4ea/index.md
+++ b/files/ja/conflicting/web/accessibility/aria_64707ba1917a56654679cbe273e2f4ea/index.md
@@ -1,11 +1,6 @@
 ---
 title: 基本的なフォームのヒント
 slug: conflicting/Web/Accessibility/ARIA_64707ba1917a56654679cbe273e2f4ea
-tags:
-  - ARIA
-  - アクセシビリティ
-  - Forms
-translation_of: Web/Accessibility/ARIA/forms/Basic_form_hints
 original_slug: Web/Accessibility/ARIA/forms/Basic_form_hints
 ---
 伝統的な HTML のフォーム関連要素を使用してフォームを実装する際は、コントロール向けのラベルを提供することと、ラベルとコントロールとを明示的に結びつけることが重要です。画面リーダーのユーザーがページを操作するとき、画面リーダーはフォームコントロールについて読み上げますが、コントロールトラベルとの間に直接的な結びつきがないと、どのラベルが適切かを画面リーダーが知る方法がなくなります。

--- a/files/ja/conflicting/web/accessibility/index.md
+++ b/files/ja/conflicting/web/accessibility/index.md
@@ -1,10 +1,6 @@
 ---
 title: アクセシビリティ関連ドキュメントの索引
 slug: conflicting/Web/Accessibility
-tags:
-  - Accessibility
-  - Index
-translation_of: Web/Accessibility/Index
 original_slug: Web/Accessibility/Index
 ---
 このドキュメントは、Mozilla Developer Network サイト上の、すべてのアクセシビリティの記事へのリンクの一覧を提供します。

--- a/files/ja/conflicting/web/api/audiotracklist/addtrack_event/index.md
+++ b/files/ja/conflicting/web/api/audiotracklist/addtrack_event/index.md
@@ -1,21 +1,6 @@
 ---
 title: AudioTrackList.onaddtrack
 slug: conflicting/Web/API/AudioTrackList/addtrack_event
-tags:
-  - API
-  - Adding Audio Tracks
-  - Adding Tracks
-  - Audio
-  - AudioTrackList
-  - Event Handler
-  - HTML DOM
-  - Media
-  - Property
-  - Reference
-  - addTrack
-  - onaddtrack
-  - track
-translation_of: Web/API/AudioTrackList/onaddtrack
 original_slug: Web/API/AudioTrackList/onaddtrack
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/conflicting/web/api/audiotracklist/change_event/index.md
+++ b/files/ja/conflicting/web/api/audiotracklist/change_event/index.md
@@ -1,21 +1,6 @@
 ---
 title: AudioTrackList.onchange
 slug: conflicting/Web/API/AudioTrackList/change_event
-tags:
-  - API
-  - Adding Audio Tracks
-  - Adding Tracks
-  - Audio
-  - AudioTrackList
-  - Event Handler
-  - HTML DOM
-  - Media
-  - Property
-  - Reference
-  - addTrack
-  - onchange
-  - track
-translation_of: Web/API/AudioTrackList/onchange
 original_slug: Web/API/AudioTrackList/onchange
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/conflicting/web/api/audiotracklist/removetrack_event/index.md
+++ b/files/ja/conflicting/web/api/audiotracklist/removetrack_event/index.md
@@ -1,22 +1,6 @@
 ---
 title: AudioTrackList.onremovetrack
 slug: conflicting/Web/API/AudioTrackList/removetrack_event
-tags:
-  - API
-  - Audio
-  - AudioTrackList
-  - Event Handler
-  - HTML DOM
-  - Media
-  - Property
-  - Reference
-  - Removing Audio Tracks
-  - Removing Tracks
-  - onremovetrack
-  - remove
-  - removeTrack
-  - track
-translation_of: Web/API/AudioTrackList/onremovetrack
 original_slug: Web/API/AudioTrackList/onremovetrack
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/conflicting/web/api/broadcastchannel/message_event/index.md
+++ b/files/ja/conflicting/web/api/broadcastchannel/message_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: BroadcastChannel.onmessage
 slug: conflicting/Web/API/BroadcastChannel/message_event
-tags:
-  - API
-  - Broadcast Channel API
-  - BroadcastChannel
-  - Event Handler
-  - Experimental
-  - HTML API
-  - Property
-  - Reference
-translation_of: Web/API/BroadcastChannel/onmessage
 original_slug: Web/API/BroadcastChannel/onmessage
 ---
 {{APIRef("BroadCastChannel API")}}

--- a/files/ja/conflicting/web/api/broadcastchannel/messageerror_event/index.md
+++ b/files/ja/conflicting/web/api/broadcastchannel/messageerror_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: BroadcastChannel.onmessageerror
 slug: conflicting/Web/API/BroadcastChannel/messageerror_event
-tags:
-  - API
-  - BroadcastChannel
-  - Event Handler
-  - Property
-  - Reference
-  - onmessageerror
-translation_of: Web/API/BroadcastChannel/onmessageerror
 original_slug: Web/API/BroadcastChannel/onmessageerror
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/conflicting/web/api/btoa/index.md
+++ b/files/ja/conflicting/web/api/btoa/index.md
@@ -1,14 +1,6 @@
 ---
 title: バイナリー文字列
 slug: conflicting/Web/API/btoa
-tags:
-  - DOM
-  - JavaScript
-  - JavaScript typed arrays
-  - JavaScript 型付き配列
-  - Reference
-  - String
-translation_of: Web/API/DOMString/Binary
 original_slug: Web/API/DOMString/Binary
 ---
 {{jsxref("String", "JavaScript の文字列")}} は、UTF-16 でエンコードされた文字列です。つまり、コードの最小単位はメモリー上に 2 バイトを必要とし、`65535` 通りのコードポイントを表現できます。この文字列のある部分集合として、ASCII 文字 (つまりコードポイントが `127` を超えない文字) だけを含む UTF-16 文字列というものが考えられます。例えば、文字列 `"Hello world!"` は、この ASCII 部分集合に含まれますが、文字列 `"ÀÈÌÒÙ"` はそうではありません。**バイナリー文字列**とは、この ASCII 部分集合と似た概念ですが、コードポイントを `127` までではなく、`255` まで許可するものです。しかし、その目的は文字列を表現することではなく、バイナリーデータを表現することです。この方法で表現されるデータの大きさは、バイナリーのままに比べて 2 倍になりますが、JavaScript の文字列の長さは 2 バイトを一つの単位として計算されるため、その大きさがユーザーの目に触れることはありません。

--- a/files/ja/conflicting/web/api/caches/index.md
+++ b/files/ja/conflicting/web/api/caches/index.md
@@ -1,14 +1,6 @@
 ---
 title: ServiceWorkerGlobalScope.caches
 slug: conflicting/Web/API/caches
-tags:
-  - API
-  - Property
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - ServiceWorkerGlobalScope
-translation_of: Web/API/ServiceWorkerGlobalScope/caches
 original_slug: Web/API/ServiceWorkerGlobalScope/caches
 ---
 {{APIRef("Service Workers API")}}

--- a/files/ja/conflicting/web/api/closeevent/index.md
+++ b/files/ja/conflicting/web/api/closeevent/index.md
@@ -1,16 +1,7 @@
 ---
 title: CloseEvent.initCloseEvent()
 slug: conflicting/Web/API/CloseEvent
-tags:
-  - API
-  - CloseEvent
-  - initCloseEvent
-  - メソッド
-  - リファレンス
-  - 非推奨
-translation_of: Web/API/CloseEvent/initCloseEvent
 original_slug: Web/API/CloseEvent/initCloseEvent
-browser-compat: api.CloseEvent.initCloseEvent
 ---
 {{APIRef("Websockets API")}}{{deprecated_header}}
 

--- a/files/ja/conflicting/web/api/credentialscontainer/create/index.md
+++ b/files/ja/conflicting/web/api/credentialscontainer/create/index.md
@@ -1,15 +1,6 @@
 ---
 title: PublicKeyCredentialCreationOptions.excludeCredentials
 slug: conflicting/Web/API/CredentialsContainer/create
-tags:
-  - API
-  - Property
-  - PublicKeyCredentialCreationOptions
-  - Reference
-  - Web Authentication API
-  - WebAuthn
-  - プロパティ
-translation_of: Web/API/PublicKeyCredentialCreationOptions/excludeCredentials
 original_slug: Web/API/PublicKeyCredentialCreationOptions/excludeCredentials
 ---
 {{APIRef("Web Authentication API")}}{{securecontext_header}}

--- a/files/ja/conflicting/web/api/credentialscontainer/create_18148a708412fc42b1affe2f08eab270/index.md
+++ b/files/ja/conflicting/web/api/credentialscontainer/create_18148a708412fc42b1affe2f08eab270/index.md
@@ -1,15 +1,6 @@
 ---
 title: PublicKeyCredentialCreationOptions
-slug: >-
-  conflicting/Web/API/CredentialsContainer/create_18148a708412fc42b1affe2f08eab270
-tags:
-  - API
-  - Dictionary
-  - PublicKeyCredentialCreationOptions
-  - Reference
-  - Web Authentication API
-  - WebAuthn
-translation_of: Web/API/PublicKeyCredentialCreationOptions
+slug: conflicting/Web/API/CredentialsContainer/create_18148a708412fc42b1affe2f08eab270
 original_slug: Web/API/PublicKeyCredentialCreationOptions
 ---
 {{APIRef("Web Authentication API")}}{{securecontext_header}}

--- a/files/ja/conflicting/web/api/document/fullscreenchange_event/index.md
+++ b/files/ja/conflicting/web/api/document/fullscreenchange_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: Document.onfullscreenchange
 slug: conflicting/Web/API/Document/fullscreenchange_event
-tags:
-  - API
-  - Document
-  - Event Handler
-  - Fullscreen API
-  - Property
-  - Reference
-  - イベントハンドラー
-  - プロパティ
-  - 全画面 API
-translation_of: Web/API/Document/onfullscreenchange
 original_slug: Web/API/Document/onfullscreenchange
 ---
 {{APIRef("Fullscreen API")}}

--- a/files/ja/conflicting/web/api/document/fullscreenerror_event/index.md
+++ b/files/ja/conflicting/web/api/document/fullscreenerror_event/index.md
@@ -1,18 +1,6 @@
 ---
 title: Document.onfullscreenerror
 slug: conflicting/Web/API/Document/fullscreenerror_event
-tags:
-  - API
-  - Document
-  - Event Handler
-  - Fullscreen API
-  - Property
-  - Reference
-  - イベントハンドラー
-  - エラー
-  - 全画面
-  - 全画面 API
-translation_of: Web/API/Document/onfullscreenerror
 original_slug: Web/API/Document/onfullscreenerror
 ---
 {{ApiRef("Fullscreen API")}}

--- a/files/ja/conflicting/web/api/eventtarget/addeventlistener/index.md
+++ b/files/ja/conflicting/web/api/eventtarget/addeventlistener/index.md
@@ -1,22 +1,7 @@
 ---
 title: EventListener.handleEvent()
 slug: conflicting/Web/API/EventTarget/addEventListener
-tags:
-  - API
-  - Callback
-  - DOM
-  - DOM Events
-  - Event Callback
-  - Event Handler
-  - Event Processing
-  - EventListener
-  - Handling Events
-  - Method
-  - Reference
-  - events
-  - handleEvent
 original_slug: Web/API/EventListener/handleEvent
-browser-compat: api.EventListener.handleEvent
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/conflicting/web/api/eventtarget/addeventlistener_380cb5f366307beb2c072f74e561ee98/index.md
+++ b/files/ja/conflicting/web/api/eventtarget/addeventlistener_380cb5f366307beb2c072f74e561ee98/index.md
@@ -1,13 +1,6 @@
 ---
 title: EventListener
-slug: >-
-  conflicting/Web/API/EventTarget/addEventListener_380cb5f366307beb2c072f74e561ee98
-tags:
-  - API
-  - DOM
-  - DOM Events
-  - NeedsContent
-translation_of: Web/API/EventListener
+slug: conflicting/Web/API/EventTarget/addEventListener_380cb5f366307beb2c072f74e561ee98
 original_slug: Web/API/EventListener
 ---
 {{APIRef("DOM Events")}}

--- a/files/ja/conflicting/web/api/file_and_directory_entries_api/index.md
+++ b/files/ja/conflicting/web/api/file_and_directory_entries_api/index.md
@@ -1,13 +1,6 @@
 ---
 title: FileHandle API
 slug: conflicting/Web/API/File_and_Directory_Entries_API
-tags:
-  - API
-  - Files
-  - Non Standard
-  - Reference
-  - WebAPI
-translation_of: Web/API/File_Handle_API
 original_slug: Web/API/File_Handle_API
 ---
 {{non-standard_header}}

--- a/files/ja/conflicting/web/api/file_and_directory_entries_api_14742f14781741be7bc237d4ec1399a0/index.md
+++ b/files/ja/conflicting/web/api/file_and_directory_entries_api_14742f14781741be7bc237d4ec1399a0/index.md
@@ -1,20 +1,6 @@
 ---
 title: FileSystemEntrySync
-slug: >-
-  conflicting/Web/API/File_and_Directory_Entries_API_14742f14781741be7bc237d4ec1399a0
-tags:
-  - API
-  - EntrySync
-  - File API
-  - File System API
-  - File and Directory Entries API
-  - FileSystemEntrySync
-  - インターフェイス
-  - オフライン
-  - ファイルシステム
-  - リファレンス
-  - 非標準
-translation_of: Web/API/FileSystemEntrySync
+slug: conflicting/Web/API/File_and_Directory_Entries_API_14742f14781741be7bc237d4ec1399a0
 original_slug: Web/API/FileSystemEntrySync
 ---
 {{APIRef("File System API")}}{{Non-standard_header()}}

--- a/files/ja/conflicting/web/api/file_and_directory_entries_api_330e25ac325178c58fd9fba0601787e1/index.md
+++ b/files/ja/conflicting/web/api/file_and_directory_entries_api_330e25ac325178c58fd9fba0601787e1/index.md
@@ -1,8 +1,6 @@
 ---
 title: LocalFileSystem
-slug: >-
-  conflicting/Web/API/File_and_Directory_Entries_API_330e25ac325178c58fd9fba0601787e1
-translation_of: Web/API/LocalFileSystem
+slug: conflicting/Web/API/File_and_Directory_Entries_API_330e25ac325178c58fd9fba0601787e1
 original_slug: Web/API/LocalFileSystem
 ---
 {{APIRef("File System API")}}{{non-standard_header()}}

--- a/files/ja/conflicting/web/api/file_and_directory_entries_api_b98af8eade9a709904ec6e38c4e7c98a/index.md
+++ b/files/ja/conflicting/web/api/file_and_directory_entries_api_b98af8eade9a709904ec6e38c4e7c98a/index.md
@@ -1,15 +1,6 @@
 ---
 title: LocalFileSystemSync
-slug: >-
-  conflicting/Web/API/File_and_Directory_Entries_API_b98af8eade9a709904ec6e38c4e7c98a
-tags:
-  - API
-  - File API
-  - File System API
-  - オフライン
-  - ファイルシステム
-  - リファレンス
-translation_of: Web/API/LocalFileSystemSync
+slug: conflicting/Web/API/File_and_Directory_Entries_API_b98af8eade9a709904ec6e38c4e7c98a
 original_slug: Web/API/LocalFileSystemSync
 ---
 {{APIRef("File System API")}}{{non-standard_header()}}

--- a/files/ja/conflicting/web/api/filereader/abort_event/index.md
+++ b/files/ja/conflicting/web/api/filereader/abort_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: FileReader.onabort
 slug: conflicting/Web/API/FileReader/abort_event
-tags:
-  - Event Handler
-  - File
-  - FileReader
-  - Property
-  - Reference
-translation_of: Web/API/FileReader/onabort
 original_slug: Web/API/FileReader/onabort
 ---
 **`FileReader.onabort`** プロパティには、[`abort`](/ja/docs/Web/Events/abort) イベントが発生したとき、つまりファイルの読み取り処理が中止されたときに実行されるイベント ハンドラが含まれています。

--- a/files/ja/conflicting/web/api/filereader/error_event/index.md
+++ b/files/ja/conflicting/web/api/filereader/error_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: onerror
 slug: conflicting/Web/API/FileReader/error_event
-translation_of: Web/API/FileReader/onerror
 original_slug: Web/API/FileReader/onerror
 ---
 [FileReader](/ja/docs/Web/API/FileReader) の onerror ハンドラは、Error オブジェクトではなく Event オブジェクトをパラメータとして受け取りますが、エラーは FileReader オブジェクトから [`instanceOfFileReader.error`](/ja/docs/Web/API/FileReader/error) のようにアクセスすることができます。

--- a/files/ja/conflicting/web/api/filereader/load_event/index.md
+++ b/files/ja/conflicting/web/api/filereader/load_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: FileReader.onload
 slug: conflicting/Web/API/FileReader/load_event
-tags:
-  - Event Handler
-  - File
-  - FileReader
-  - Property
-  - Reference
-translation_of: Web/API/FileReader/onload
 original_slug: Web/API/FileReader/onload
 ---
 {{APIRef}}

--- a/files/ja/conflicting/web/api/formdata/index.md
+++ b/files/ja/conflicting/web/api/formdata/index.md
@@ -1,9 +1,6 @@
 ---
 title: FormDataEntryValue
 slug: conflicting/Web/API/FormData
-tags:
-  - FormDataEntryValue
-translation_of: Web/API/FormDataEntryValue
 original_slug: Web/API/FormDataEntryValue
 ---
 {{APIRef("XMLHttpRequest")}}

--- a/files/ja/conflicting/web/api/geolocation/getcurrentposition/index.md
+++ b/files/ja/conflicting/web/api/geolocation/getcurrentposition/index.md
@@ -1,14 +1,6 @@
 ---
 title: PositionOptions
 slug: conflicting/Web/API/Geolocation/getCurrentPosition
-tags:
-  - API
-  - Geolocation API
-  - Interface
-  - PositionOptions
-  - Reference
-  - Secure context
-translation_of: Web/API/PositionOptions
 original_slug: Web/API/PositionOptions
 ---
 {{securecontext_header}}{{APIRef("Geolocation API")}}

--- a/files/ja/conflicting/web/api/htmlelement/change_event/index.md
+++ b/files/ja/conflicting/web/api/htmlelement/change_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: GlobalEventHandlers.onchange
 slug: conflicting/Web/API/HTMLElement/change_event
-tags:
-  - API
-  - Event Handler
-  - GlobalEventHandlers
-  - HTML DOM
-  - Property
-  - Reference
-translation_of: Web/API/GlobalEventHandlers/onchange
 original_slug: Web/API/GlobalEventHandlers/onchange
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/conflicting/web/api/htmlelement/drag_event/index.md
+++ b/files/ja/conflicting/web/api/htmlelement/drag_event/index.md
@@ -1,12 +1,6 @@
 ---
 title: GlobalEventHandlers.ondrag
 slug: conflicting/Web/API/HTMLElement/drag_event
-tags:
-  - API
-  - HTML DOM
-  - Reference
-  - drag and drop
-translation_of: Web/API/GlobalEventHandlers/ondrag
 original_slug: Web/API/GlobalEventHandlers/ondrag
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/conflicting/web/api/htmlelement/dragend_event/index.md
+++ b/files/ja/conflicting/web/api/htmlelement/dragend_event/index.md
@@ -1,12 +1,6 @@
 ---
 title: GlobalEventHandlers.ondragend
 slug: conflicting/Web/API/HTMLElement/dragend_event
-tags:
-  - API
-  - HTML DOM
-  - Reference
-  - drag and drop
-translation_of: Web/API/GlobalEventHandlers/ondragend
 original_slug: Web/API/GlobalEventHandlers/ondragend
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/conflicting/web/api/htmlelement/dragenter_event/index.md
+++ b/files/ja/conflicting/web/api/htmlelement/dragenter_event/index.md
@@ -1,12 +1,6 @@
 ---
 title: GlobalEventHandlers.ondragenter
 slug: conflicting/Web/API/HTMLElement/dragenter_event
-tags:
-  - API
-  - HTML DOM
-  - Reference
-  - drag and drop
-translation_of: Web/API/GlobalEventHandlers/ondragenter
 original_slug: Web/API/GlobalEventHandlers/ondragenter
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/conflicting/web/api/htmlelement/dragleave_event/index.md
+++ b/files/ja/conflicting/web/api/htmlelement/dragleave_event/index.md
@@ -1,12 +1,6 @@
 ---
 title: GlobalEventHandlers.ondragleave
 slug: conflicting/Web/API/HTMLElement/dragleave_event
-tags:
-  - API
-  - HTML DOM
-  - Reference
-  - drag and drop
-translation_of: Web/API/GlobalEventHandlers/ondragleave
 original_slug: Web/API/GlobalEventHandlers/ondragleave
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/conflicting/web/api/htmlelement/dragover_event/index.md
+++ b/files/ja/conflicting/web/api/htmlelement/dragover_event/index.md
@@ -1,12 +1,6 @@
 ---
 title: GlobalEventHandlers.ondragover
 slug: conflicting/Web/API/HTMLElement/dragover_event
-tags:
-  - API
-  - HTML DOM
-  - Reference
-  - drag and drop
-translation_of: Web/API/GlobalEventHandlers/ondragover
 original_slug: Web/API/GlobalEventHandlers/ondragover
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/conflicting/web/api/htmlelement/dragstart_event/index.md
+++ b/files/ja/conflicting/web/api/htmlelement/dragstart_event/index.md
@@ -1,12 +1,6 @@
 ---
 title: GlobalEventHandlers.ondragstart
 slug: conflicting/Web/API/HTMLElement/dragstart_event
-tags:
-  - API
-  - HTML DOM
-  - Reference
-  - drag and drop
-translation_of: Web/API/GlobalEventHandlers/ondragstart
 original_slug: Web/API/GlobalEventHandlers/ondragstart
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/conflicting/web/api/htmlelement/drop_event/index.md
+++ b/files/ja/conflicting/web/api/htmlelement/drop_event/index.md
@@ -1,12 +1,6 @@
 ---
 title: GlobalEventHandlers.ondrop
 slug: conflicting/Web/API/HTMLElement/drop_event
-tags:
-  - API
-  - HTML DOM
-  - Reference
-  - drag and drop
-translation_of: Web/API/GlobalEventHandlers/ondrop
 original_slug: Web/API/GlobalEventHandlers/ondrop
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/conflicting/web/api/htmlelement/input_event/index.md
+++ b/files/ja/conflicting/web/api/htmlelement/input_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: GlobalEventHandlers.oninput
 slug: conflicting/Web/API/HTMLElement/input_event
-tags:
-  - API
-  - Event Handler
-  - GlobalEventHandlers
-  - HTML DOM
-  - Property
-  - Reference
-translation_of: Web/API/GlobalEventHandlers/oninput
 original_slug: Web/API/GlobalEventHandlers/oninput
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/conflicting/web/api/htmlformelement/formdata_event/index.md
+++ b/files/ja/conflicting/web/api/htmlformelement/formdata_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: GlobalEventHandlers.onformdata
 slug: conflicting/Web/API/HTMLFormElement/formdata_event
-tags:
-  - API
-  - Event Handler
-  - Experimental
-  - GlobalEventHandlers
-  - HTML DOM
-  - Property
-  - Reference
-translation_of: Web/API/GlobalEventHandlers/onformdata
 original_slug: Web/API/GlobalEventHandlers/onformdata
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/conflicting/web/api/htmlformelement/reset_event/index.md
+++ b/files/ja/conflicting/web/api/htmlformelement/reset_event/index.md
@@ -1,12 +1,6 @@
 ---
 title: window.onreset
 slug: conflicting/Web/API/HTMLFormElement/reset_event
-tags:
-  - DOM
-  - Gecko
-  - Gecko DOM Reference
-  - Window
-translation_of: Web/API/GlobalEventHandlers/onreset
 original_slug: Web/API/GlobalEventHandlers/onreset
 ---
 {{ApiRef}}

--- a/files/ja/conflicting/web/api/htmlinputelement/index.md
+++ b/files/ja/conflicting/web/api/htmlinputelement/index.md
@@ -1,17 +1,7 @@
 ---
 title: HTMLInputElement.mozGetFileNameArray()
 slug: conflicting/Web/API/HTMLInputElement
-tags:
-  - API
-  - HTML DOM
-  - HTMLInputElement
-  - メソッド
-  - NeedsBrowserCompatibility
-  - 標準外
-  - リファレンス
-translation_of: Web/API/HTMLInputElement/mozGetFileNameArray
 original_slug: Web/API/HTMLInputElement/mozGetFileNameArray
-browser-compat: api.HTMLInputElement.mozGetFileNameArray
 ---
 {{ APIRef("HTML DOM") }}{{Non-standard_header}}
 

--- a/files/ja/conflicting/web/api/htmlinputelement/invalid_event/index.md
+++ b/files/ja/conflicting/web/api/htmlinputelement/invalid_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: GlobalEventHandlers.oninvalid
 slug: conflicting/Web/API/HTMLInputElement/invalid_event
-tags:
-  - API
-  - Event Handler
-  - GlobalEventHandlers
-  - Property
-  - Reference
-translation_of: Web/API/GlobalEventHandlers/oninvalid
 original_slug: Web/API/GlobalEventHandlers/oninvalid
 ---
 {{ ApiRef("HTML DOM") }}

--- a/files/ja/conflicting/web/api/htmlinputelement/select_event/index.md
+++ b/files/ja/conflicting/web/api/htmlinputelement/select_event/index.md
@@ -1,11 +1,6 @@
 ---
 title: window.onselect
 slug: conflicting/Web/API/HTMLInputElement/select_event
-tags:
-  - DOM
-  - Gecko
-  - Window
-translation_of: Web/API/GlobalEventHandlers/onselect
 original_slug: Web/API/GlobalEventHandlers/onselect
 ---
 {{ ApiRef("HTML DOM") }}

--- a/files/ja/conflicting/web/api/htmlinputelement/selectionchange_event/index.md
+++ b/files/ja/conflicting/web/api/htmlinputelement/selectionchange_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.onselectionchange
 slug: conflicting/Web/API/HTMLInputElement/selectionchange_event
-tags:
-  - API
-  - Document
-  - Experimental
-  - Reference
-  - イベントハンドラー
-  - プロパティ
-translation_of: Web/API/GlobalEventHandlers/onselectionchange
-translation_of_original: Web/API/Document/onselectionchange
 original_slug: Web/API/GlobalEventHandlers/onselectionchange
 ---
 {{ApiRef('DOM')}}{{SeeCompatTable}}

--- a/files/ja/conflicting/web/api/htmlmediaelement/canplay_event/index.md
+++ b/files/ja/conflicting/web/api/htmlmediaelement/canplay_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: GlobalEventHandlers.oncanplay
 slug: conflicting/Web/API/HTMLMediaElement/canplay_event
-tags:
-  - API
-  - Event Handler
-  - GlobalEventHandlers
-  - Property
-  - Reference
-translation_of: Web/API/GlobalEventHandlers/oncanplay
 original_slug: Web/API/GlobalEventHandlers/oncanplay
 ---
 {{ ApiRef("HTML DOM") }}

--- a/files/ja/conflicting/web/api/htmlmediaelement/canplaythrough_event/index.md
+++ b/files/ja/conflicting/web/api/htmlmediaelement/canplaythrough_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: GlobalEventHandlers.oncanplaythrough
 slug: conflicting/Web/API/HTMLMediaElement/canplaythrough_event
-tags:
-  - API
-  - Event Handler
-  - GlobalEventHandlers
-  - Property
-  - Reference
-translation_of: Web/API/GlobalEventHandlers/oncanplaythrough
 original_slug: Web/API/GlobalEventHandlers/oncanplaythrough
 ---
 {{ ApiRef("HTML DOM") }}

--- a/files/ja/conflicting/web/api/htmlmediaelement/playing_event/index.md
+++ b/files/ja/conflicting/web/api/htmlmediaelement/playing_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: GlobalEventHandlers.onplaying
 slug: conflicting/Web/API/HTMLMediaElement/playing_event
-tags:
-  - API
-  - Event Handler
-  - GlobalEventHandlers
-  - Property
-  - Reference
-  - イベントハンドラー
-  - プロパティ
-translation_of: Web/API/GlobalEventHandlers/onplaying
 original_slug: Web/API/GlobalEventHandlers/onplaying
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/conflicting/web/api/idbrequest/success_event/index.md
+++ b/files/ja/conflicting/web/api/idbrequest/success_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: IDBRequest.onsuccess
 slug: conflicting/Web/API/IDBRequest/success_event
-tags:
-  - API
-  - Database
-  - IDBRequest
-  - IndexedDB
-  - Property
-  - Reference
-  - Storage
-  - onsuccess
-translation_of: Web/API/IDBRequest/onsuccess
 original_slug: Web/API/IDBRequest/onsuccess
 ---
 {{ APIRef("IndexedDB") }}

--- a/files/ja/conflicting/web/api/mediadevices/getusermedia/index.md
+++ b/files/ja/conflicting/web/api/mediadevices/getusermedia/index.md
@@ -1,7 +1,6 @@
 ---
 title: MediaStreamConstraints
 slug: conflicting/Web/API/MediaDevices/getUserMedia
-translation_of: Web/API/MediaStreamConstraints
 original_slug: Web/API/MediaStreamConstraints
 ---
 {{APIRef("Media Capture and Streams")}}**`MediaStreamConstraints`**のオブジェクトは、{{domxref("MediaDevices.getUserMedia", "getUserMedia()")}}を呼び出した時に返される{{domxref("MediaStream")}}に含まれるトラックの種類が何であるかを知るため、また、これらのトラック設定の制約を確立するために使用されます。制約がどのようにして動作するのかについての詳細は、[Capabilities, constraints, and settings](/ja/docs/Web/API/Media_Streams_API/Constraints) (英語)をお読みください。

--- a/files/ja/conflicting/web/api/mediarecorder/error_event/index.md
+++ b/files/ja/conflicting/web/api/mediarecorder/error_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: MediaRecorder.onerror
 slug: conflicting/Web/API/MediaRecorder/error_event
-tags:
-  - API
-  - Audio
-  - Media Capture
-  - Media Recorder API
-  - MediaRecorder
-  - Property
-  - Reference
-  - Video
-  - onerror
-translation_of: Web/API/MediaRecorder/onerror
 original_slug: Web/API/MediaRecorder/onerror
 ---
 {{APIRef("MediaStream Recording")}}

--- a/files/ja/conflicting/web/api/mediastreamtrack/mute_event/index.md
+++ b/files/ja/conflicting/web/api/mediastreamtrack/mute_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: MediaStreamTrack.onmute
 slug: conflicting/Web/API/MediaStreamTrack/mute_event
-translation_of: Web/API/MediaStreamTrack/onmute
 original_slug: Web/API/MediaStreamTrack/onmute
 ---
 {{ APIRef("Media Capture and Streams") }}

--- a/files/ja/conflicting/web/api/mediastreamtrack/unmute_event/index.md
+++ b/files/ja/conflicting/web/api/mediastreamtrack/unmute_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: MediaStreamTrack.onunmute
 slug: conflicting/Web/API/MediaStreamTrack/unmute_event
-translation_of: Web/API/MediaStreamTrack/onunmute
 original_slug: Web/API/MediaStreamTrack/onunmute
 ---
 {{ APIRef("Media Capture and Streams") }}

--- a/files/ja/conflicting/web/api/mouseevent/index.md
+++ b/files/ja/conflicting/web/api/mouseevent/index.md
@@ -1,16 +1,7 @@
 ---
 title: MouseEvent.region
 slug: conflicting/Web/API/MouseEvent
-tags:
-  - API
-  - Canvas
-  - DOM イベント
-  - MouseEvent
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
 original_slug: Web/API/MouseEvent/region
-browser-compat: api.MouseEvent.region
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/conflicting/web/api/navigator/getbattery/index.md
+++ b/files/ja/conflicting/web/api/navigator/getbattery/index.md
@@ -1,21 +1,6 @@
 ---
 title: Navigator.battery
 slug: conflicting/Web/API/Navigator/getBattery
-tags:
-  - API
-  - Battery
-  - Battery API
-  - Device API
-  - Navigator
-  - Non-standard
-  - Obsolete
-  - Property
-  - Reference
-  - バッテリ
-  - プロパティ
-  - 廃止
-  - 標準外
-translation_of: Web/API/Navigator/battery
 original_slug: Web/API/Navigator/battery
 ---
 {{ApiRef("Battery API")}}

--- a/files/ja/conflicting/web/api/navigator/online/index.md
+++ b/files/ja/conflicting/web/api/navigator/online/index.md
@@ -1,15 +1,6 @@
 ---
 title: オンライン・オフラインイベント
 slug: conflicting/Web/API/Navigator/onLine
-tags:
-  - AJAX
-  - DOM
-  - HTML5
-  - Intermediate
-  - NeedsUpdate
-  - Offline web applications
-  - Web Development
-translation_of: Web/API/Navigator/Online_and_offline_events
 original_slug: Web/API/Navigator/Online_and_offline_events
 ---
 一部のブラウザーは、 [Online/Offline イベント](https://www.whatwg.org/specs/web-apps/current-work/#offline)を [WHATWG Web Applications 1.0 仕様書](https://www.whatwg.org/specs/web-apps/current-work/)に従って実装しています。

--- a/files/ja/conflicting/web/api/performance/resourcetimingbufferfull_event/index.md
+++ b/files/ja/conflicting/web/api/performance/resourcetimingbufferfull_event/index.md
@@ -1,14 +1,7 @@
 ---
 title: Performance.onresourcetimingbufferfull
 slug: conflicting/Web/API/Performance/resourcetimingbufferfull_event
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - ウェブパフォーマンス
-translation_of: Web/API/Performance/onresourcetimingbufferfull
 original_slug: Web/API/Performance/onresourcetimingbufferfull
-browser-compat: api.Performance.onresourcetimingbufferfull
 ---
 {{APIRef("Resource Timing API")}}
 

--- a/files/ja/conflicting/web/api/pointer_events/index.md
+++ b/files/ja/conflicting/web/api/pointer_events/index.md
@@ -1,11 +1,6 @@
 ---
 title: TouchEvent と MouseEvent の両方をサポートする
 slug: conflicting/Web/API/Pointer_events
-tags:
-  - Guide
-  - TouchEvent
-  - touch
-translation_of: Web/API/Touch_events/Supporting_both_TouchEvent_and_MouseEvent
 original_slug: Web/API/Touch_events/Supporting_both_TouchEvent_and_MouseEvent
 ---
 {{DefaultAPISidebar("Touch Events")}}

--- a/files/ja/conflicting/web/api/progressevent/index.md
+++ b/files/ja/conflicting/web/api/progressevent/index.md
@@ -1,15 +1,7 @@
 ---
 title: ProgressEvent.initProgressEvent()
 slug: conflicting/Web/API/ProgressEvent
-tags:
-  - API
-  - 非推奨
-  - メソッド
-  - 進捗イベント
-  - ProgressEvent
-translation_of: Web/API/ProgressEvent/initProgressEvent
 original_slug: Web/API/ProgressEvent/initProgressEvent
-browser-compat: api.ProgressEvent.initProgressEvent
 ---
 {{apiref("DOM Events")}} {{deprecated_header}}{{non-standard_header}}
 

--- a/files/ja/conflicting/web/api/serviceworkercontainer/message_event/index.md
+++ b/files/ja/conflicting/web/api/serviceworkercontainer/message_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: ServiceWorkerContainer.onmessage
 slug: conflicting/Web/API/ServiceWorkerContainer/message_event
-tags:
-  - API
-  - Property
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - ServiceWorkerContainer
-translation_of: Web/API/ServiceWorkerContainer/onmessage
 original_slug: Web/API/ServiceWorkerContainer/onmessage
 ---
 {{APIRef("Service Workers API")}}{{ SeeCompatTable() }}

--- a/files/ja/conflicting/web/api/serviceworkerglobalscope/message_event/index.md
+++ b/files/ja/conflicting/web/api/serviceworkerglobalscope/message_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: ServiceWorkerGlobalScope.onmessage
 slug: conflicting/Web/API/ServiceWorkerGlobalScope/message_event
-tags:
-  - API
-  - Property
-  - Reference
-  - Service
-  - ServiceWorker
-  - ServiceWorkerGlobalScope
-  - Worker
-  - onmessage
-translation_of: Web/API/ServiceWorkerGlobalScope/onmessage
 original_slug: Web/API/ServiceWorkerGlobalScope/onmessage
 ---
 {{APIRef("Service Workers API")}}

--- a/files/ja/conflicting/web/api/speechrecognition/audiostart_event/index.md
+++ b/files/ja/conflicting/web/api/speechrecognition/audiostart_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: SpeechRecognition.onaudiostart
 slug: conflicting/Web/API/SpeechRecognition/audiostart_event
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - SpeechRecognition
-  - Web Speech API
-  - onaudiostart
-  - recognition
-  - speech
-translation_of: Web/API/SpeechRecognition/onaudiostart
 original_slug: Web/API/SpeechRecognition/onaudiostart
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}

--- a/files/ja/conflicting/web/api/storagemanager/estimate/index.md
+++ b/files/ja/conflicting/web/api/storagemanager/estimate/index.md
@@ -1,18 +1,6 @@
 ---
 title: StorageEstimate
 slug: conflicting/Web/API/StorageManager/estimate
-tags:
-  - API
-  - Dictionary
-  - Interface
-  - Quotas
-  - Reference
-  - Secure context
-  - Storage
-  - Storage API
-  - StorageEstimate
-  - Usage
-translation_of: Web/API/StorageEstimate
 original_slug: Web/API/StorageEstimate
 ---
 {{securecontext_header}}{{APIRef("Storage")}}

--- a/files/ja/conflicting/web/api/syncevent/index.md
+++ b/files/ja/conflicting/web/api/syncevent/index.md
@@ -1,11 +1,6 @@
 ---
 title: registration
 slug: conflicting/Web/API/SyncEvent
-tags:
-  - DOM
-  - Junk
-  - Property
-translation_of: Web/API/SyncEvent/registration
 original_slug: Web/API/SyncEvent/registration
 ---
 {{Non-standard_header}}{{APIRef("Service Workers API")}}

--- a/files/ja/conflicting/web/api/text/index.md
+++ b/files/ja/conflicting/web/api/text/index.md
@@ -1,13 +1,7 @@
 ---
 title: Text.replaceWholeText()
 slug: conflicting/Web/API/Text
-tags:
-  - メソッド
-  - 非推奨
-  - リファレンス
-translation_of: Web/API/Text/replaceWholeText
 original_slug: Web/API/Text/replaceWholeText
-browser-compat: api.Text.replaceWholeText
 ---
 {{ApiRef("DOM")}}{{deprecated_header}}
 

--- a/files/ja/conflicting/web/api/videotracklist/addtrack_event/index.md
+++ b/files/ja/conflicting/web/api/videotracklist/addtrack_event/index.md
@@ -1,21 +1,6 @@
 ---
 title: VideoTrackList.onaddtrack
 slug: conflicting/Web/API/VideoTrackList/addtrack_event
-tags:
-  - API
-  - Adding Tracks
-  - Adding Video Tracks
-  - Event Handler
-  - HTML DOM
-  - Media
-  - Property
-  - Reference
-  - Video
-  - VideoTrackList
-  - addTrack
-  - onaddtrack
-  - track
-translation_of: Web/API/VideoTrackList/onaddtrack
 original_slug: Web/API/VideoTrackList/onaddtrack
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/conflicting/web/api/videotracklist/change_event/index.md
+++ b/files/ja/conflicting/web/api/videotracklist/change_event/index.md
@@ -1,21 +1,6 @@
 ---
 title: VideoTrackList.onchange
 slug: conflicting/Web/API/VideoTrackList/change_event
-tags:
-  - API
-  - Adding Tracks
-  - Adding Video Tracks
-  - Event Handler
-  - HTML DOM
-  - Media
-  - Property
-  - Reference
-  - Video
-  - VideoTrackList
-  - addTrack
-  - onchange
-  - track
-translation_of: Web/API/VideoTrackList/onchange
 original_slug: Web/API/VideoTrackList/onchange
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/conflicting/web/api/videotracklist/removetrack_event/index.md
+++ b/files/ja/conflicting/web/api/videotracklist/removetrack_event/index.md
@@ -1,22 +1,6 @@
 ---
 title: VideoTrackList.onremovetrack
 slug: conflicting/Web/API/VideoTrackList/removetrack_event
-tags:
-  - API
-  - Event Handler
-  - HTML DOM
-  - Media
-  - Property
-  - Reference
-  - Removing Tracks
-  - Removing Video Tracks
-  - Video
-  - VideoTrackList
-  - onremovetrack
-  - remove
-  - removeTrack
-  - track
-translation_of: Web/API/VideoTrackList/onremovetrack
 original_slug: Web/API/VideoTrackList/onremovetrack
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/conflicting/web/api/websocket/close_event/index.md
+++ b/files/ja/conflicting/web/api/websocket/close_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebSocket.onclose
 slug: conflicting/Web/API/WebSocket/close_event
-translation_of: Web/API/WebSocket/onclose
 original_slug: Web/API/WebSocket/onclose
 ---
 {{APIRef("Web Sockets API")}}

--- a/files/ja/conflicting/web/api/websocket/error_event/index.md
+++ b/files/ja/conflicting/web/api/websocket/error_event/index.md
@@ -1,19 +1,6 @@
 ---
 title: WebSocket.onerror
 slug: conflicting/Web/API/WebSocket/error_event
-tags:
-  - API
-  - Connection
-  - Error
-  - Error Handler
-  - Networking
-  - Property
-  - Reference
-  - Web API
-  - WebSocket
-  - onerror
-  - プロパティ
-translation_of: Web/API/WebSocket/onerror
 original_slug: Web/API/WebSocket/onerror
 ---
 {{APIRef("Web Sockets API")}}

--- a/files/ja/conflicting/web/api/websocket/message_event/index.md
+++ b/files/ja/conflicting/web/api/websocket/message_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: WebSocket.onmessage
 slug: conflicting/Web/API/WebSocket/message_event
-tags:
-  - API
-  - Property
-  - Reference
-  - Web API
-  - WebSocket
-  - プロパティ
-translation_of: Web/API/WebSocket/onmessage
 original_slug: Web/API/WebSocket/onmessage
 ---
 {{APIRef("Web Sockets API")}}

--- a/files/ja/conflicting/web/api/websocket/open_event/index.md
+++ b/files/ja/conflicting/web/api/websocket/open_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: WebSocket.onopen
 slug: conflicting/Web/API/WebSocket/open_event
-tags:
-  - API
-  - Property
-  - Reference
-  - Web API
-  - WebSocket
-  - プロパティ
-translation_of: Web/API/WebSocket/onopen
 original_slug: Web/API/WebSocket/onopen
 ---
 {{APIRef("Web Sockets API")}}

--- a/files/ja/conflicting/web/api/window/afterprint_event/index.md
+++ b/files/ja/conflicting/web/api/window/afterprint_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: WindowEventHandlers.onafterprint
 slug: conflicting/Web/API/Window/afterprint_event
-tags:
-  - API
-  - DOM
-  - Event Handler
-  - HTML DOM
-  - Property
-  - Reference
-  - WindowEventHandlers
-  - printing
-translation_of: Web/API/WindowEventHandlers/onafterprint
 original_slug: Web/API/WindowEventHandlers/onafterprint
 ---
 {{ApiRef}}

--- a/files/ja/conflicting/web/api/window/appinstalled_event/index.md
+++ b/files/ja/conflicting/web/api/window/appinstalled_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: Window.onappinstalled
 slug: conflicting/Web/API/Window/appinstalled_event
-tags:
-  - API
-  - Event Handler
-  - Property
-  - Reference
-  - Window
-  - web manifest
-translation_of: Web/API/Window/onappinstalled
 original_slug: Web/API/Window/onappinstalled
 ---
 {{APIRef}}

--- a/files/ja/conflicting/web/api/window/beforeprint_event/index.md
+++ b/files/ja/conflicting/web/api/window/beforeprint_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: WindowEventHandlers.onbeforeprint
 slug: conflicting/Web/API/Window/beforeprint_event
-tags:
-  - API
-  - DOM
-  - Event Handler
-  - HTML DOM
-  - Reference
-  - onbeforeprint
-  - プロパティ
-  - 印刷
-translation_of: Web/API/WindowEventHandlers/onbeforeprint
 original_slug: Web/API/WindowEventHandlers/onbeforeprint
 ---
 {{ApiRef}}

--- a/files/ja/conflicting/web/api/window/beforeunload_event/index.md
+++ b/files/ja/conflicting/web/api/window/beforeunload_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: WindowEventHandlers.onbeforeunload
 slug: conflicting/Web/API/Window/beforeunload_event
-tags:
-  - API
-  - DOM
-  - Event Handler
-  - Property
-  - Reference
-  - Window
-  - イベントハンドラー
-  - プロパティ
-translation_of: Web/API/WindowEventHandlers/onbeforeunload
 original_slug: Web/API/WindowEventHandlers/onbeforeunload
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/conflicting/web/api/window/devicemotion_event/index.md
+++ b/files/ja/conflicting/web/api/window/devicemotion_event/index.md
@@ -1,21 +1,6 @@
 ---
 title: Window.ondevicemotion
 slug: conflicting/Web/API/Window/devicemotion_event
-tags:
-  - API
-  - Device Orientation
-  - Event Handler
-  - Mobile
-  - Motion
-  - Orientation
-  - Property
-  - Reference
-  - イベントハンドラー
-  - プロパティ
-  - モバイル
-  - 向き
-  - 端末の向き
-translation_of: Web/API/Window/ondevicemotion
 original_slug: Web/API/Window/ondevicemotion
 ---
 {{APIRef("Device Orientation Events")}}

--- a/files/ja/conflicting/web/api/window/gamepadconnected_event/index.md
+++ b/files/ja/conflicting/web/api/window/gamepadconnected_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: Window.ongamepadconnected
 slug: conflicting/Web/API/Window/gamepadconnected_event
-tags:
-  - API
-  - Event Handler
-  - Experimental
-  - Gamepad API
-  - Property
-  - Reference
-  - Window
-  - ongamepadconnected
-translation_of: Web/API/Window/ongamepadconnected
 original_slug: Web/API/Window/ongamepadconnected
 ---
 {{DefaultAPISidebar("Gamepad API")}}{{SeeCompatTable}}{{domxref("Window")}} インターフェイスの **`ongamepadconnected`** プロパティは、ゲームパッドが接続されたとき ({{event('gamepadconnected')}}イベントが発生したとき) に実行されるイベントハンドラを表します。

--- a/files/ja/conflicting/web/api/window/gamepaddisconnected_event/index.md
+++ b/files/ja/conflicting/web/api/window/gamepaddisconnected_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: Window.ongamepaddisconnected
 slug: conflicting/Web/API/Window/gamepaddisconnected_event
-tags:
-  - API
-  - Event Handler
-  - Experimental
-  - Gamepad API
-  - Property
-  - Reference
-  - Window
-  - ongamepaddisconnected
-translation_of: Web/API/Window/ongamepaddisconnected
 original_slug: Web/API/Window/ongamepaddisconnected
 ---
 {{DefaultAPISidebar("Gamepad API")}}{{SeeCompatTable}}

--- a/files/ja/conflicting/web/api/window/hashchange_event/index.md
+++ b/files/ja/conflicting/web/api/window/hashchange_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: WindowEventHandlers.onhashchange
 slug: conflicting/Web/API/Window/hashchange_event
-tags:
-  - Event Handler
-  - HTML DOM
-  - Hash
-  - Property
-  - Reference
-  - URL & Hash
-  - WindowEventHandlers
-translation_of: Web/API/WindowEventHandlers/onhashchange
 original_slug: Web/API/WindowEventHandlers/onhashchange
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/conflicting/web/api/window/languagechange_event/index.md
+++ b/files/ja/conflicting/web/api/window/languagechange_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: WindowEventHandlers.onlanguagechange
 slug: conflicting/Web/API/Window/languagechange_event
-tags:
-  - API
-  - Event Handler
-  - Experimental
-  - HTML DOM
-  - Property
-  - Reference
-  - WindowEventHandlers
-translation_of: Web/API/WindowEventHandlers/onlanguagechange
 original_slug: Web/API/WindowEventHandlers/onlanguagechange
 ---
 {{APIRef("HTML DOM")}} {{SeeCompatTable}}

--- a/files/ja/conflicting/web/api/window/load_event/index.md
+++ b/files/ja/conflicting/web/api/window/load_event/index.md
@@ -1,17 +1,7 @@
 ---
 title: GlobalEventHandlers.onload
 slug: conflicting/Web/API/Window/load_event
-tags:
-  - API
-  - Event Handler
-  - GlobalEventHandlers
-  - HTML DOM
-  - Property
-  - Reference
-  - onload
-translation_of: Web/API/GlobalEventHandlers/onload
 original_slug: Web/API/GlobalEventHandlers/onload
-browser-compat: api.GlobalEventHandlers.onload
 ---
 {{ApiRef()}}
 

--- a/files/ja/conflicting/web/api/window/messageerror_event/index.md
+++ b/files/ja/conflicting/web/api/window/messageerror_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: WindowEventHandlers.onmessageerror
 slug: conflicting/Web/API/Window/messageerror_event
-tags:
-  - API
-  - Event Handler
-  - HTML DOM
-  - Property
-  - Reference
-  - Window
-  - WindowEventHandlers
-  - onmessageerror
-translation_of: Web/API/WindowEventHandlers/onmessageerror
 original_slug: Web/API/WindowEventHandlers/onmessageerror
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/conflicting/web/api/window/popstate_event/index.md
+++ b/files/ja/conflicting/web/api/window/popstate_event/index.md
@@ -1,18 +1,7 @@
 ---
 title: WindowEventHandlers.onpopstate
 slug: conflicting/Web/API/Window/popstate_event
-tags:
-  - API
-  - イベントハンドラー
-  - HTML DOM
-  - HTML5
-  - NeedsSpecTable
-  - プロパティ
-  - Window
-  - イベント
-translation_of: Web/API/WindowEventHandlers/onpopstate
 original_slug: Web/API/WindowEventHandlers/onpopstate
-browser-compat: api.WindowEventHandlers.onpopstate
 ---
 {{APIRef}}
 

--- a/files/ja/conflicting/web/api/window/rejectionhandled_event/index.md
+++ b/files/ja/conflicting/web/api/window/rejectionhandled_event/index.md
@@ -1,18 +1,6 @@
 ---
 title: WindowEventHandlers.onrejectionhandled
 slug: conflicting/Web/API/Window/rejectionhandled_event
-tags:
-  - API
-  - Event Handler
-  - HTML DOM
-  - JavaScript
-  - Promises
-  - Property
-  - Reference
-  - WindowEventHandlers
-  - events
-  - onrejectionhandled
-translation_of: Web/API/WindowEventHandlers/onrejectionhandled
 original_slug: Web/API/WindowEventHandlers/onrejectionhandled
 ---
 {{APIRef}}

--- a/files/ja/conflicting/web/api/window/resize_event/index.md
+++ b/files/ja/conflicting/web/api/window/resize_event/index.md
@@ -1,12 +1,6 @@
 ---
 title: window.onresize
 slug: conflicting/Web/API/Window/resize_event
-tags:
-  - DOM
-  - Gecko
-  - Property
-  - Window
-translation_of: Web/API/GlobalEventHandlers/onresize
 original_slug: Web/API/GlobalEventHandlers/onresize
 ---
 {{ ApiRef() }}

--- a/files/ja/conflicting/web/api/window/scroll/index.md
+++ b/files/ja/conflicting/web/api/window/scroll/index.md
@@ -1,14 +1,6 @@
 ---
 title: ScrollToOptions
 slug: conflicting/Web/API/Window/scroll
-tags:
-  - API
-  - CSSOM View
-  - Dictionary
-  - Reference
-  - ScrollToOptions
-  - 辞書
-translation_of: Web/API/ScrollToOptions
 original_slug: Web/API/ScrollToOptions
 ---
 {{APIRef("CSSOM")}}

--- a/files/ja/conflicting/web/api/window/storage_event/index.md
+++ b/files/ja/conflicting/web/api/window/storage_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: WindowEventHandlers.onstorage
 slug: conflicting/Web/API/Window/storage_event
-tags:
-  - API
-  - Event Handler
-  - Property
-  - Reference
-  - Web Storage
-  - WindowEventHandler
-translation_of: Web/API/WindowEventHandlers/onstorage
 original_slug: Web/API/WindowEventHandlers/onstorage
 ---
 <div class="syntaxbox">{{ ApiRef() }}</div>

--- a/files/ja/conflicting/web/api/window/unhandledrejection_event/index.md
+++ b/files/ja/conflicting/web/api/window/unhandledrejection_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: WindowEventHandlers.onunhandledrejection
 slug: conflicting/Web/API/Window/unhandledrejection_event
-tags:
-  - API
-  - Event Handler
-  - HTML DOM
-  - Promises
-  - Property
-  - Reference
-  - WindowEventHandlers
-  - events
-  - onunhandledrejection
-translation_of: Web/API/WindowEventHandlers/onunhandledrejection
 original_slug: Web/API/WindowEventHandlers/onunhandledrejection
 ---
 {{APIRef}}

--- a/files/ja/conflicting/web/api/window/unload_event/index.md
+++ b/files/ja/conflicting/web/api/window/unload_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: WindowEventHandlers.onunload
 slug: conflicting/Web/API/Window/unload_event
-tags:
-  - API
-  - Event Handler
-  - HTML DOM
-  - MakeBrowserAgnostic
-  - Property
-  - Reference
-  - WindowEventHandlers
-translation_of: Web/API/WindowEventHandlers/onunload
 original_slug: Web/API/WindowEventHandlers/onunload
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/conflicting/web/api/xmlhttprequest/loadend_event/index.md
+++ b/files/ja/conflicting/web/api/xmlhttprequest/loadend_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: GlobalEventHandlers.onloadend
 slug: conflicting/Web/API/XMLHttpRequest/loadend_event
-tags:
-  - API
-  - Event Handler
-  - GlobalEventHandlers
-  - HTML DOM
-  - Property
-  - Reference
-  - Web
-  - events
-  - onloadend
-translation_of: Web/API/GlobalEventHandlers/onloadend
 original_slug: Web/API/GlobalEventHandlers/onloadend
 ---
 {{ApiRef}}

--- a/files/ja/conflicting/web/api/xrinputsource/handedness/index.md
+++ b/files/ja/conflicting/web/api/xrinputsource/handedness/index.md
@@ -1,22 +1,6 @@
 ---
 title: XRHandedness
 slug: conflicting/Web/API/XRInputSource/handedness
-tags:
-  - API
-  - AR
-  - Enum
-  - Enumerated Type
-  - Handedness
-  - Reference
-  - Type
-  - VR
-  - WebXR
-  - WebXR Device API
-  - XRHandedness
-  - hand
-  - left
-  - right
-translation_of: Web/API/XRHandedness
 original_slug: Web/API/XRHandedness
 ---
 {{APIRef("WebXR")}}

--- a/files/ja/conflicting/web/api/xrinputsource/targetraymode/index.md
+++ b/files/ja/conflicting/web/api/xrinputsource/targetraymode/index.md
@@ -1,27 +1,6 @@
 ---
 title: XRTargetRayMode
 slug: conflicting/Web/API/XRInputSource/targetRayMode
-tags:
-  - 3D
-  - API
-  - AR
-  - Enum
-  - Enumerated Type
-  - Input
-  - Reality
-  - Reference
-  - Type
-  - VR
-  - Virtual
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-  - XRTargetRayMode
-  - augmented
-  - source
-  - target
-translation_of: Web/API/XRTargetRayMode
 original_slug: Web/API/XRTargetRayMode
 ---
 {{APIRef("WebXR")}}

--- a/files/ja/conflicting/web/css/css_scroll_snap/index.md
+++ b/files/ja/conflicting/web/css/css_scroll_snap/index.md
@@ -1,16 +1,6 @@
 ---
 title: ブラウザーの互換性とスクロールスナップ
 slug: conflicting/Web/CSS/CSS_Scroll_Snap
-tags:
-  - CSS
-  - CSS スクロールスナップ
-  - 互換性
-  - FAQ
-  - ガイド
-  - Usage
-  - browser compat
-  - compat
-translation_of: Web/CSS/CSS_Scroll_Snap/Browser_compat
 original_slug: Web/CSS/CSS_Scroll_Snap/Browser_compat
 ---
 {{CSSRef}}

--- a/files/ja/conflicting/web/css/cursor/index.md
+++ b/files/ja/conflicting/web/css/cursor/index.md
@@ -1,13 +1,6 @@
 ---
 title: cursor プロパティでの URL 値の使用
 slug: conflicting/Web/CSS/cursor
-tags:
-  - CSS
-  - Gecko
-  - ガイド
-  - NeedsUpdate
-  - Reference
-translation_of: Web/CSS/CSS_Basic_User_Interface/Using_URL_values_for_the_cursor_property
 original_slug: Web/CSS/CSS_Basic_User_Interface/Using_URL_values_for_the_cursor_property
 ---
 {{CSSRef}}

--- a/files/ja/conflicting/web/css/index.md
+++ b/files/ja/conflicting/web/css/index.md
@@ -1,12 +1,6 @@
 ---
 title: ツール
 slug: conflicting/Web/CSS
-tags:
-  - CSS
-  - Guide
-  - NeedsUpdate
-  - ガイド
-translation_of: Web/CSS/Tools
 original_slug: Web/CSS/Tools
 ---
 CSS は強力な機能を多数提供していますが、その中には使いこなすのが面倒だったり、引数が多かったりするので、作業をしながら視覚化できると便利です。このページでは、これらの機能を使ってコンテンツのスタイルを整えるための CSS を構築するのに役立つ便利なツールへのリンクをいくつか紹介しています。

--- a/files/ja/conflicting/web/css/print-color-adjust/index.md
+++ b/files/ja/conflicting/web/css/print-color-adjust/index.md
@@ -1,24 +1,7 @@
 ---
 title: color-adjust
 slug: conflicting/Web/CSS/print-color-adjust
-tags:
-  - Adjusting Colors
-  - CSS
-  - CSS 色
-  - CSS プロパティ
-  - HTML 色
-  - HTML スタイル
-  - レイアウト
-  - 標準外
-  - リファレンス
-  - Styling HTML
-  - Styling text
-  - ウェブ
-  - color-adjust
-  - recipe:css-property
-translation_of: Web/CSS/color-adjust
 original_slug: Web/CSS/color-adjust
-browser-compat: css.properties.color-adjust
 ---
 {{CSSRef}}
 

--- a/files/ja/conflicting/web/css/transform-function/skewx/index.md
+++ b/files/ja/conflicting/web/css/transform-function/skewx/index.md
@@ -1,15 +1,7 @@
 ---
 title: skewY()
 slug: conflicting/Web/CSS/transform-function/skewX
-tags:
-  - CSS
-  - CSS 関数
-  - CSS 座標変換
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/transform-function/skewY()
 original_slug: Web/CSS/transform-function/skewY()
-browser-compat: css.types.transform-function.skewY
 ---
 {{CSSRef}}
 

--- a/files/ja/conflicting/web/http/headers/feature-policy/xr-spatial-tracking/index.md
+++ b/files/ja/conflicting/web/http/headers/feature-policy/xr-spatial-tracking/index.md
@@ -1,7 +1,6 @@
 ---
 title: 'Feature-Policy: xr'
 slug: conflicting/Web/HTTP/Headers/Feature-Policy/xr-spatial-tracking
-translation_of: Web/HTTP/Headers/Feature-Policy/xr
 original_slug: Web/HTTP/Headers/Feature-Policy/xr
 ---
 {{HTTPSidebar}}

--- a/files/ja/conflicting/web/javascript/inheritance_and_the_prototype_chain/index.md
+++ b/files/ja/conflicting/web/javascript/inheritance_and_the_prototype_chain/index.md
@@ -1,13 +1,6 @@
 ---
 title: オブジェクトモデルの詳細
 slug: conflicting/Web/JavaScript/Inheritance_and_the_prototype_chain
-tags:
-  - ガイド
-  - 中級者
-  - JavaScript
-  - オブジェクト
-  - l10n:priority
-translation_of: Web/JavaScript/Guide/Details_of_the_Object_Model
 original_slug: Web/JavaScript/Guide/Details_of_the_Object_Model
 ---
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Working_with_Objects", "Web/JavaScript/Guide/Using_promises")}}

--- a/files/ja/conflicting/web/javascript/javascript_technologies_overview/index.md
+++ b/files/ja/conflicting/web/javascript/javascript_technologies_overview/index.md
@@ -1,12 +1,6 @@
 ---
 title: JavaScript 言語情報
 slug: conflicting/Web/JavaScript/JavaScript_technologies_overview
-tags:
-  - Advanced
-  - ECMA
-  - Guide
-  - JavaScript
-translation_of: Web/JavaScript/Language_Resources
 original_slug: Web/JavaScript/Language_Resources
 ---
 {{JsSidebar}}

--- a/files/ja/conflicting/web/javascript/reference/errors/unexpected_type/index.md
+++ b/files/ja/conflicting/web/javascript/reference/errors/unexpected_type/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'TypeError: can''t access property "x" of "y"'
 slug: conflicting/Web/JavaScript/Reference/Errors/Unexpected_type
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - TypeError
-translation_of: Web/JavaScript/Reference/Errors/Cant_access_property
 original_slug: Web/JavaScript/Reference/Errors/Cant_access_property
 ---
 {{jsSidebar("Errors")}}

--- a/files/ja/conflicting/web/javascript/reference/global_objects/object/setprototypeof/index.md
+++ b/files/ja/conflicting/web/javascript/reference/global_objects/object/setprototypeof/index.md
@@ -1,10 +1,6 @@
 ---
-title: '[[Prototype]] の変更の性能上の危険性'
+title: "[[Prototype]] の変更の性能上の危険性"
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf
-tags:
-  - Guide
-  - JavaScript
-  - Performance
 original_slug: Web/JavaScript/The_performance_hazards_of_prototype_mutation
 ---
 {{jsSidebar("Advanced")}}

--- a/files/ja/conflicting/web/manifest/index.md
+++ b/files/ja/conflicting/web/manifest/index.md
@@ -1,13 +1,7 @@
 ---
 title: dir
 slug: conflicting/Web/Manifest
-tags:
-  - マニフェスト
-  - ウェブ
-  - dir
-translation_of: Web/Manifest/dir
 original_slug: Web/Manifest/dir
-browser-compat: html.manifest.dir
 ---
 {{QuickLinksWithSubpages("/ja/docs/Web/Manifest")}}
 

--- a/files/ja/conflicting/web/manifest_7ec32c6987e59d5f1cb08f8c9d900a4c/index.md
+++ b/files/ja/conflicting/web/manifest_7ec32c6987e59d5f1cb08f8c9d900a4c/index.md
@@ -1,13 +1,7 @@
 ---
 title: lang
 slug: conflicting/Web/Manifest_7ec32c6987e59d5f1cb08f8c9d900a4c
-tags:
-  - マニフェスト
-  - ウェブ
-  - lang
-translation_of: Web/Manifest/lang
 original_slug: Web/Manifest/lang
-browser-compat: html.manifest.lang
 ---
 {{QuickLinksWithSubpages("/ja/docs/Web/Manifest")}}
 

--- a/files/ja/conflicting/web/manifest_e8c4835b067e177a000dc29c18483205/index.md
+++ b/files/ja/conflicting/web/manifest_e8c4835b067e177a000dc29c18483205/index.md
@@ -1,13 +1,7 @@
 ---
 title: iarc_rating_id
 slug: conflicting/Web/Manifest_e8c4835b067e177a000dc29c18483205
-tags:
-  - マニフェスト
-  - ウェブ
-  - iarc_rating_id
-translation_of: Web/Manifest/iarc_rating_id
 original_slug: Web/Manifest/iarc_rating_id
-browser-compat: html.manifest.iarc_rating_id
 ---
 {{QuickLinksWithSubpages("/ja/docs/Web/Manifest")}}
 

--- a/files/ja/conflicting/web/security/certificate_transparency/index.md
+++ b/files/ja/conflicting/web/security/certificate_transparency/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTTP Public Key Pinning (HPKP)
 slug: conflicting/Web/Security/Certificate_Transparency
-tags:
-  - Deprecated
-  - Guide
-  - HPKP
-  - HTTP
-  - Obsolete
-  - Security
-translation_of: Web/HTTP/Public_Key_Pinning
 original_slug: Web/HTTP/Public_Key_Pinning
 ---
 {{HTTPSidebar}}{{deprecated_header}}

--- a/files/ja/conflicting/web/svg/element/animate/index.md
+++ b/files/ja/conflicting/web/svg/element/animate/index.md
@@ -1,12 +1,6 @@
 ---
 title: animateColor
 slug: conflicting/Web/SVG/Element/animate
-tags:
-  - Deprecated
-  - Element
-  - SVG
-  - SVG Animation
-translation_of: Web/SVG/Element/animateColor
 original_slug: Web/SVG/Element/animateColor
 ---
 {{SVGRef}}{{deprecated_header}}

--- a/files/ja/conflicting/web/web_components/index.md
+++ b/files/ja/conflicting/web/web_components/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTML インポート
 slug: conflicting/Web/Web_Components
-translation_of: Web/Web_Components/HTML_Imports
 original_slug: Web/Web_Components/HTML_Imports
 ---
 {{DefaultAPISidebar("Web Components")}}

--- a/files/ja/conflicting/web/xslt/transforming_xml_with_xslt/index.md
+++ b/files/ja/conflicting/web/xslt/transforming_xml_with_xslt/index.md
@@ -1,14 +1,6 @@
 ---
 title: XSLT - リソース
 slug: conflicting/Web/XSLT/Transforming_XML_with_XSLT
-tags:
-  - Extensions
-  - NeedsContent
-  - NeedsExample
-  - NeedsLiveSample
-  - XML
-  - xsl
-translation_of: Web/XSLT/Transforming_XML_with_XSLT/Resources
 original_slug: Web/XSLT/Transforming_XML_with_XSLT/Resources
 ---
 - [XSL Results Firefox extension](https://addons.mozilla.org/ja/firefox/addon/xsl-results/) (現在レビュー待ち) - XML 文書 (現在ロードされている文書または手動で入力/貼り付けられた文書) に XSL スタイルシート (URL またはファイルシステムで手動で入力されたもの) を適用して、XSL を試すことができます。

--- a/files/ja/conflicting/webassembly/index.md
+++ b/files/ja/conflicting/webassembly/index.md
@@ -1,10 +1,6 @@
 ---
 title: Index
 slug: conflicting/WebAssembly
-tags:
-  - Index
-  - WebAssembly
-translation_of: WebAssembly/Index
 original_slug: WebAssembly/Index
 ---
 {{WebAssemblySidebar}}


### PR DESCRIPTION
Part of #7858

files/ja/conflicting から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "translation_of": 111,
  "tags": 106,
  "browser-compat": 14,
  "translation_of_original": 1
}
```

# 特記事項

* `translation_of_original` は `files/ja/conflicting/web/api/htmlmediaelement/canplaythrough_event/index.md` にありました。
* `/ja/docs/conflicting/Web/CSS/transform-function/skewX` など、 `slug` で指定された英語のドキュメントがないため、 `browser-compat` を消してしまったことで `Compat` マクロがエラーになるものがありました。
`conflicting` 配下なのでそのままにしていますが、もし必要であればメタを戻します。