### PR TITLE
remove duplicated frontmatter keys from games (ja)

### DIFF
--- a/files/ja/games/anatomy/index.md
+++ b/files/ja/games/anatomy/index.md
@@ -1,12 +1,6 @@
 ---
 title: ビデオゲームの解剖学
 slug: Games/Anatomy
-tags:
-  - Games
-  - JavaScript
-  - Main Loop
-  - requestAnimationFrame
-translation_of: Games/Anatomy
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/examples/index.md
+++ b/files/ja/games/examples/index.md
@@ -1,12 +1,6 @@
 ---
 title: 例
 slug: Games/Examples
-tags:
-  - Demos
-  - Example
-  - Games
-  - Web
-translation_of: Games/Examples
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/index.md
+++ b/files/ja/games/index.md
@@ -1,15 +1,6 @@
 ---
 title: ゲーム開発
 slug: Games
-tags:
-  - Apps
-  - Game Development
-  - Gamedev
-  - Games
-  - HTML Games
-  - JavaScript Games
-  - Web
-translation_of: Games
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/introduction/index.md
+++ b/files/ja/games/introduction/index.md
@@ -1,12 +1,6 @@
 ---
 title: ウェブ用のゲーム開発入門
 slug: Games/Introduction
-tags:
-  - Firefox OS
-  - Games
-  - Guide
-  - Mobile
-translation_of: Games/Introduction
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/introduction_to_html5_game_development/index.md
+++ b/files/ja/games/introduction_to_html5_game_development/index.md
@@ -1,12 +1,6 @@
 ---
 title: HTML5 ゲーム開発入門
 slug: Games/Introduction_to_HTML5_Game_Development
-tags:
-  - Firefox OS
-  - Games
-  - HTML5
-  - Mobile
-translation_of: Games/Introduction_to_HTML5_Game_Development
 original_slug: Games/Introduction_to_HTML5_Game_Gevelopment_(summary)
 ---
 {{GamesSidebar}}

--- a/files/ja/games/techniques/2d_collision_detection/index.md
+++ b/files/ja/games/techniques/2d_collision_detection/index.md
@@ -1,12 +1,6 @@
 ---
 title: 二次元の衝突検出
 slug: Games/Techniques/2D_collision_detection
-tags:
-  - 2D
-  - Games
-  - JavaScript
-  - collision detection
-translation_of: Games/Techniques/2D_collision_detection
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/techniques/3d_collision_detection/bounding_volume_collision_detection_with_three.js/index.md
+++ b/files/ja/games/techniques/3d_collision_detection/bounding_volume_collision_detection_with_three.js/index.md
@@ -1,17 +1,6 @@
 ---
 title: THREE.js によるバウンディングボリューム衝突検出
-slug: >-
-  Games/Techniques/3D_collision_detection/Bounding_volume_collision_detection_with_THREE.js
-tags:
-  - 3D
-  - Games
-  - JavaScript
-  - WebGL
-  - bounding boxes
-  - collision detection
-  - three.js
-translation_of: >-
-  Games/Techniques/3D_collision_detection/Bounding_volume_collision_detection_with_THREE.js
+slug: Games/Techniques/3D_collision_detection/Bounding_volume_collision_detection_with_THREE.js
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/techniques/3d_collision_detection/index.md
+++ b/files/ja/games/techniques/3d_collision_detection/index.md
@@ -1,13 +1,6 @@
 ---
 title: 三次元の衝突検出
 slug: Games/Techniques/3D_collision_detection
-tags:
-  - 3D
-  - Games
-  - JavaScript
-  - bounding boxes
-  - collision detection
-translation_of: Games/Techniques/3D_collision_detection
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/techniques/3d_on_the_web/basic_theory/index.md
+++ b/files/ja/games/techniques/3d_on_the_web/basic_theory/index.md
@@ -1,19 +1,6 @@
 ---
 title: 基本の 3D 理論の解説
 slug: Games/Techniques/3D_on_the_web/Basic_theory
-tags:
-  - 3D
-  - Coordinates
-  - Textures
-  - basics
-  - fragment
-  - lighting
-  - primitives
-  - rendering
-  - theory
-  - vertex
-  - vertices
-translation_of: Games/Techniques/3D_on_the_web/Basic_theory
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_a-frame/index.md
+++ b/files/ja/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_a-frame/index.md
@@ -1,14 +1,6 @@
 ---
 title: A-Frame を使った基本的なデモの作成
 slug: Games/Techniques/3D_on_the_web/Building_up_a_basic_demo_with_A-Frame
-tags:
-  - 3D
-  - A-Frame
-  - VR
-  - Virtual Reality
-  - Web
-  - WebGL
-translation_of: Games/Techniques/3D_on_the_web/Building_up_a_basic_demo_with_A-Frame
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_babylon.js/index.md
+++ b/files/ja/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_babylon.js/index.md
@@ -1,12 +1,6 @@
 ---
 title: Babylon.js を使った基本的なデモの作成
 slug: Games/Techniques/3D_on_the_web/Building_up_a_basic_demo_with_Babylon.js
-tags:
-  - 3D game engines
-  - Babylon.js
-  - Beginner
-  - WebGL
-translation_of: Games/Techniques/3D_on_the_web/Building_up_a_basic_demo_with_Babylon.js
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/index.md
+++ b/files/ja/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/index.md
@@ -1,19 +1,6 @@
 ---
 title: PlayCanvas を使った基本的なデモの作成
 slug: Games/Techniques/3D_on_the_web/Building_up_a_basic_demo_with_PlayCanvas
-tags:
-  - 3D
-  - Animation
-  - Beginner
-  - Canvas
-  - Games
-  - PlayCanvas
-  - Tutorial
-  - WebGL
-  - camera
-  - lighting
-  - rendering
-translation_of: Games/Techniques/3D_on_the_web/Building_up_a_basic_demo_with_PlayCanvas
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_three.js/index.md
+++ b/files/ja/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_three.js/index.md
@@ -1,19 +1,6 @@
 ---
 title: Three.js を使った基本的なデモの作成
 slug: Games/Techniques/3D_on_the_web/Building_up_a_basic_demo_with_Three.js
-tags:
-  - 3D
-  - Animation
-  - Beginner
-  - Canvas
-  - Games
-  - Tutorial
-  - WebGL
-  - camera
-  - lighting
-  - rendering
-  - three.js
-translation_of: Games/Techniques/3D_on_the_web/Building_up_a_basic_demo_with_Three.js
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/techniques/3d_on_the_web/glsl_shaders/index.md
+++ b/files/ja/games/techniques/3d_on_the_web/glsl_shaders/index.md
@@ -1,15 +1,6 @@
 ---
 title: GLSL シェーダー
 slug: Games/Techniques/3D_on_the_web/GLSL_Shaders
-tags:
-  - Beginner
-  - GLSL
-  - OpenGL
-  - Shader
-  - texture shader
-  - three.js
-  - vertex shader
-translation_of: Games/Techniques/3D_on_the_web/GLSL_Shaders
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/techniques/3d_on_the_web/index.md
+++ b/files/ja/games/techniques/3d_on_the_web/index.md
@@ -1,15 +1,6 @@
 ---
 title: ウェブ上の 3D ゲームの概要
 slug: Games/Techniques/3D_on_the_web
-tags:
-  - Games
-  - Graphics
-  - NeedsContent
-  - NeedsExample
-  - WebGL
-  - WebVR
-  - three.js
-translation_of: Games/Techniques/3D_on_the_web
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/techniques/3d_on_the_web/webvr/index.md
+++ b/files/ja/games/techniques/3d_on_the_web/webvr/index.md
@@ -1,12 +1,6 @@
 ---
 title: WebVR — ウェブによる仮想現実
 slug: Games/Techniques/3D_on_the_web/WebVR
-tags:
-  - 3D
-  - Games
-  - WebGL
-  - WebVR
-translation_of: Games/Techniques/3D_on_the_web/WebVR
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/techniques/async_scripts/index.md
+++ b/files/ja/games/techniques/async_scripts/index.md
@@ -1,12 +1,6 @@
 ---
 title: asm.js の非同期スクリプト
 slug: Games/Techniques/Async_scripts
-tags:
-  - Games
-  - JavaScript
-  - asm.js
-  - async
-translation_of: Games/Techniques/Async_scripts
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/techniques/audio_for_web_games/index.md
+++ b/files/ja/games/techniques/audio_for_web_games/index.md
@@ -1,14 +1,6 @@
 ---
 title: ウェブゲーム用の音声
 slug: Games/Techniques/Audio_for_Web_Games
-tags:
-  - Audio
-  - Games
-  - Web Audio API
-  - audio sprites
-  - spatialization
-  - syncing tracks
-translation_of: Games/Techniques/Audio_for_Web_Games
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/techniques/control_mechanisms/index.md
+++ b/files/ja/games/techniques/control_mechanisms/index.md
@@ -1,18 +1,6 @@
 ---
 title: ゲーム制御機構の搭載
 slug: Games/Techniques/Control_mechanisms
-tags:
-  - Controls
-  - Desktop
-  - Gamepad
-  - Games
-  - JavaScript
-  - Laptop
-  - Mobile
-  - keyboard
-  - mouse
-  - touch
-translation_of: Games/Techniques/Control_mechanisms
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/techniques/controls_gamepad_api/index.md
+++ b/files/ja/games/techniques/controls_gamepad_api/index.md
@@ -1,14 +1,6 @@
 ---
 title: ゲームパッド API を使用したコントロールの実装
 slug: Games/Techniques/Controls_Gamepad_API
-tags:
-  - Controls
-  - Gamepad API
-  - Gamepads
-  - Games
-  - JavaScript
-  - controllers
-translation_of: Games/Techniques/Controls_Gamepad_API
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/techniques/index.md
+++ b/files/ja/games/techniques/index.md
@@ -1,10 +1,6 @@
 ---
 title: ゲーム開発テクニック
 slug: Games/Techniques
-tags:
-  - Games
-  - Guide
-translation_of: Games/Techniques
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/techniques/webrtc_data_channels/index.md
+++ b/files/ja/games/techniques/webrtc_data_channels/index.md
@@ -1,15 +1,6 @@
 ---
 title: WebRTC データチャネル
 slug: Games/Techniques/WebRTC_data_channels
-tags:
-  - API
-  - Games
-  - NeedsContent
-  - Network
-  - P2P
-  - WebRTC
-  - data channels
-translation_of: Games/Techniques/WebRTC_data_channels
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/tools/asm.js/index.md
+++ b/files/ja/games/tools/asm.js/index.md
@@ -1,11 +1,6 @@
 ---
 title: asm.js
 slug: Games/Tools/asm.js
-tags:
-  - Deprecated
-  - JavaScript
-  - asm.js
-translation_of: Games/Tools/asm.js
 ---
 {{Deprecated_header}}{{GamesSidebar}}
 

--- a/files/ja/games/tools/index.md
+++ b/files/ja/games/tools/index.md
@@ -1,12 +1,6 @@
 ---
 title: ゲーム開発のためのツール
 slug: Games/Tools
-tags:
-  - Games
-  - Gecko
-  - Guide
-  - JavaScript
-translation_of: Games/Tools
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/tutorials/2d_breakout_game_phaser/index.md
+++ b/files/ja/games/tutorials/2d_breakout_game_phaser/index.md
@@ -1,14 +1,6 @@
 ---
 title: Phaser を使用した 2D ブロック崩しゲーム
 slug: Games/Tutorials/2D_breakout_game_Phaser
-tags:
-  - 2D
-  - Beginner
-  - Canvas
-  - Games
-  - JavaScript
-  - Phaser
-  - Tutorial
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/tutorials/2d_breakout_game_phaser/physics/index.md
+++ b/files/ja/games/tutorials/2d_breakout_game_phaser/physics/index.md
@@ -1,16 +1,6 @@
 ---
 title: 物理演算
 slug: Games/Tutorials/2D_breakout_game_Phaser/Physics
-tags:
-  - 2D
-  - Beginner
-  - Canvas
-  - Games
-  - JavaScript
-  - Phaser
-  - Tutorial
-  - physics
-translation_of: Games/Tutorials/2D_breakout_game_Phaser/Physics
 original_slug: Games/Workflows/2D_breakout_game_Phaser/Physics
 ---
 {{GamesSidebar}}

--- a/files/ja/games/tutorials/2d_breakout_game_pure_javascript/bounce_off_the_walls/index.md
+++ b/files/ja/games/tutorials/2d_breakout_game_pure_javascript/bounce_off_the_walls/index.md
@@ -1,17 +1,6 @@
 ---
 title: ボールを壁で跳ね返させる
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Bounce_off_the_walls
-tags:
-  - Animation
-  - Beginner
-  - Canvas
-  - Example
-  - Games
-  - Graphics
-  - Tutorial
-  - collision
-  - detection
-translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Bounce_off_the_walls
 original_slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Bounce_off_the_walls
 ---
 {{GamesSidebar}}

--- a/files/ja/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.md
+++ b/files/ja/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.md
@@ -1,14 +1,6 @@
 ---
 title: ブロックのかたまりを作る
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Build_the_brick_field
-tags:
-  - Beginner
-  - Canvas
-  - Games
-  - Graphics
-  - JavaScript
-  - Tutorial
-translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Build_the_brick_field
 original_slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Build_the_brick_field
 ---
 {{GamesSidebar}}

--- a/files/ja/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.md
+++ b/files/ja/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.md
@@ -1,15 +1,6 @@
 ---
 title: 衝突検出
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Collision_detection
-tags:
-  - Beginner
-  - Canvas
-  - Games
-  - JavaScript
-  - Tutorial
-  - collision
-  - detection
-translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Collision_detection
 original_slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Collision_detection
 ---
 {{GamesSidebar}}

--- a/files/ja/games/tutorials/2d_breakout_game_pure_javascript/create_the_canvas_and_draw_on_it/index.md
+++ b/files/ja/games/tutorials/2d_breakout_game_pure_javascript/create_the_canvas_and_draw_on_it/index.md
@@ -1,19 +1,7 @@
 ---
 title: キャンバスを作ってその上に描画する
-slug: >-
-  Games/Tutorials/2D_Breakout_game_pure_JavaScript/Create_the_Canvas_and_draw_on_it
-tags:
-  - 2D
-  - Beginner
-  - Canvas
-  - Games
-  - HTML
-  - JavaScript
-  - Tutorial
-translation_of: >-
-  Games/Tutorials/2D_Breakout_game_pure_JavaScript/Create_the_Canvas_and_draw_on_it
-original_slug: >-
-  Games/Tutorials/2D_Breakout_game_pure_JavaScript/Create_the_Canvas_and_draw_on_it
+slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Create_the_Canvas_and_draw_on_it
+original_slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Create_the_Canvas_and_draw_on_it
 ---
 {{GamesSidebar}}
 

--- a/files/ja/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.md
+++ b/files/ja/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.md
@@ -1,15 +1,6 @@
 ---
 title: 仕上げ
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Finishing_up
-tags:
-  - Beginner
-  - Canvas
-  - Games
-  - JavaScript
-  - Tutorial
-  - lives
-  - requestAnimationFrame
-translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Finishing_up
 original_slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Finishing_up
 ---
 {{GamesSidebar}}

--- a/files/ja/games/tutorials/2d_breakout_game_pure_javascript/game_over/index.md
+++ b/files/ja/games/tutorials/2d_breakout_game_pure_javascript/game_over/index.md
@@ -1,15 +1,6 @@
 ---
 title: ゲームオーバー
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Game_over
-tags:
-  - Beginner
-  - Canvas
-  - Games
-  - Graphics
-  - JavaScript
-  - Tutorial
-  - game over
-translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Game_over
 original_slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Game_over
 ---
 {{GamesSidebar}}

--- a/files/ja/games/tutorials/2d_breakout_game_pure_javascript/index.md
+++ b/files/ja/games/tutorials/2d_breakout_game_pure_javascript/index.md
@@ -1,14 +1,6 @@
 ---
 title: 純粋な JavaScript を使ったブロック崩しゲーム
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript
-tags:
-  - 2D
-  - Beginner
-  - Canvas
-  - Games
-  - JavaScript
-  - Tutorial
-translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript
 original_slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript
 ---
 {{GamesSidebar}}

--- a/files/ja/games/tutorials/2d_breakout_game_pure_javascript/mouse_controls/index.md
+++ b/files/ja/games/tutorials/2d_breakout_game_pure_javascript/mouse_controls/index.md
@@ -1,15 +1,6 @@
 ---
 title: マウス操作
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Mouse_controls
-tags:
-  - Beginner
-  - Canvas
-  - Controls
-  - Games
-  - JavaScript
-  - Tutorial
-  - mouse
-translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Mouse_controls
 original_slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Mouse_controls
 ---
 {{GamesSidebar}}

--- a/files/ja/games/tutorials/2d_breakout_game_pure_javascript/move_the_ball/index.md
+++ b/files/ja/games/tutorials/2d_breakout_game_pure_javascript/move_the_ball/index.md
@@ -1,16 +1,6 @@
 ---
 title: ボールを動かす
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Move_the_ball
-tags:
-  - 2D
-  - Beginner
-  - Canvas
-  - Games
-  - JavaScript
-  - Loop
-  - Tutorial
-  - movement
-translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Move_the_ball
 original_slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Move_the_ball
 ---
 {{GamesSidebar}}

--- a/files/ja/games/tutorials/2d_breakout_game_pure_javascript/paddle_and_keyboard_controls/index.md
+++ b/files/ja/games/tutorials/2d_breakout_game_pure_javascript/paddle_and_keyboard_controls/index.md
@@ -1,16 +1,6 @@
 ---
 title: パドルとキーボード操作
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Paddle_and_keyboard_controls
-tags:
-  - Beginner
-  - Canvas
-  - Controls
-  - Games
-  - Graphics
-  - JavaScript
-  - Tutorial
-  - keyboard
-translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Paddle_and_keyboard_controls
 original_slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Paddle_and_keyboard_controls
 ---
 {{GamesSidebar}}

--- a/files/ja/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.md
+++ b/files/ja/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.md
@@ -1,15 +1,6 @@
 ---
 title: スコアと勝ち負けを記録する
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Track_the_score_and_win
-tags:
-  - Beginner
-  - Canvas
-  - Games
-  - JavaScript
-  - Tutorial
-  - scoring
-  - winning
-translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Track_the_score_and_win
 original_slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Track_the_score_and_win
 ---
 {{GamesSidebar}}

--- a/files/ja/games/tutorials/index.md
+++ b/files/ja/games/tutorials/index.md
@@ -1,13 +1,6 @@
 ---
 title: チュートリアル
 slug: Games/Tutorials
-tags:
-  - Canvas
-  - Games
-  - JavaScript
-  - Web
-  - Workflows
-translation_of: Games/Tutorials
 original_slug: Games/Workflows
 l10n:
   sourceCommit: 86e302046641b6c4885d21bc0dc0ddd2f57db2e5


### PR DESCRIPTION
Part of #7858

`files/ja/games` から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "tags": 38,
  "translation_of": 37
}
```