### PR TITLE
remove duplicated frontmatter keys from learn (ja)

### DIFF
--- a/files/ja/learn/accessibility/accessibility_troubleshooting/index.md
+++ b/files/ja/learn/accessibility/accessibility_troubleshooting/index.md
@@ -1,17 +1,6 @@
 ---
 title: '評価: アクセシビリティのトラブルシューティング'
 slug: Learn/Accessibility/Accessibility_troubleshooting
-tags:
-  - Accessibility
-  - Assesment
-  - Beginner
-  - CSS
-  - CodingScripting
-  - HTML
-  - JavaScript
-  - Learn
-  - WAI-ARIA
-translation_of: Learn/Accessibility/Accessibility_troubleshooting
 ---
 {{LearnSidebar}}{{PreviousMenu("Learn/Accessibility/Mobile", "Learn/Accessibility")}}
 

--- a/files/ja/learn/accessibility/css_and_javascript/index.md
+++ b/files/ja/learn/accessibility/css_and_javascript/index.md
@@ -1,26 +1,6 @@
 ---
 title: CSS と JavaScript のアクセシビリティの ベスト・プラクティス
 slug: Learn/Accessibility/CSS_and_JavaScript
-tags:
-  - Accessibility
-  - Article
-  - CSS
-  - CodingScripting
-  - Guide
-  - JavaScript
-  - Learn
-  - color
-  - contrast
-  - hiding
-  - unobtrusive
-  - ひかえめ
-  - アクセシビリティ
-  - ガイド
-  - コントラスト
-  - 学習
-  - 色
-  - 隠す
-translation_of: Learn/Accessibility/CSS_and_JavaScript
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Accessibility/HTML","Learn/Accessibility/WAI-ARIA_basics", "Learn/Accessibility")}}
 

--- a/files/ja/learn/accessibility/html/index.md
+++ b/files/ja/learn/accessibility/html/index.md
@@ -1,33 +1,6 @@
 ---
 title: 'HTML: アクセシビリティの基礎'
 slug: Learn/Accessibility/HTML
-tags:
-  - AT
-  - Accessibility
-  - Article
-  - Beginner
-  - Buttons
-  - CodingScripting
-  - Forms
-  - HTML
-  - Learn
-  - Links
-  - a11y
-  - assistive technology
-  - keyboard
-  - screenreader
-  - semantics
-  - アクセシビリティ
-  - キーボード
-  - スクリーンリーダー
-  - セマンティクス
-  - フォーム
-  - ボタン
-  - リンク
-  - 初心者
-  - 学習
-  - 意味
-translation_of: Learn/Accessibility/HTML
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Accessibility/What_is_Accessibility","Learn/Accessibility/CSS_and_JavaScript", "Learn/Accessibility")}}
 

--- a/files/ja/learn/accessibility/index.md
+++ b/files/ja/learn/accessibility/index.md
@@ -1,22 +1,6 @@
 ---
 title: アクセシビリティ
 slug: Learn/Accessibility
-tags:
-  - ARIA
-  - Accessibility
-  - Articles
-  - Beginner
-  - CSS
-  - CodingScripting
-  - HTML
-  - JavaScript
-  - Landing
-  - Learn
-  - Module
-  - アクセシビリティ
-  - ランディング
-  - 初心者
-translation_of: Learn/Accessibility
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/accessibility/mobile/index.md
+++ b/files/ja/learn/accessibility/mobile/index.md
@@ -1,17 +1,6 @@
 ---
 title: モバイルのアクセシビリティ
 slug: Learn/Accessibility/Mobile
-tags:
-  - Accessibility
-  - コードスクリプト
-  - スクリーンリーダー
-  - タッチ
-  - モバイル
-  - レスポンシブ
-  - 初心者
-  - 学習
-  - 記事
-translation_of: Learn/Accessibility/Mobile
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Accessibility/Multimedia","Learn/Accessibility/Accessibility_troubleshooting", "Learn/Accessibility")}}
 

--- a/files/ja/learn/accessibility/multimedia/index.md
+++ b/files/ja/learn/accessibility/multimedia/index.md
@@ -1,22 +1,6 @@
 ---
 title: アクセシブルマルチメディア
 slug: Learn/Accessibility/Multimedia
-tags:
-  - Accessibility
-  - Article
-  - Audio
-  - Beginner
-  - CodingScripting
-  - HTML
-  - Images
-  - JavaScript
-  - Learn
-  - Multimedia
-  - Video
-  - captions
-  - subtitles
-  - text tracks
-translation_of: Learn/Accessibility/Multimedia
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Accessibility/WAI-ARIA_basics","Learn/Accessibility/Mobile", "Learn/Accessibility")}}
 

--- a/files/ja/learn/accessibility/wai-aria_basics/index.md
+++ b/files/ja/learn/accessibility/wai-aria_basics/index.md
@@ -1,23 +1,6 @@
 ---
 title: WAI-ARIAの基本
 slug: Learn/Accessibility/WAI-ARIA_basics
-tags:
-  - ARIA
-  - Accessibility
-  - Article
-  - Beginner
-  - CodingScripting
-  - Guide
-  - HTML
-  - JavaScript
-  - Learn
-  - WAI-ARIA
-  - semantics
-  - アクセシビリティ
-  - セマンティクス
-  - 初心者
-  - 学習
-translation_of: Learn/Accessibility/WAI-ARIA_basics
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Accessibility/CSS_and_JavaScript","Learn/Accessibility/Multimedia", "Learn/Accessibility")}}
 

--- a/files/ja/learn/accessibility/what_is_accessibility/index.md
+++ b/files/ja/learn/accessibility/what_is_accessibility/index.md
@@ -1,23 +1,6 @@
 ---
 title: アクセシビリティとは？
 slug: Learn/Accessibility/What_is_accessibility
-tags:
-  - AT
-  - Accessibility
-  - Article
-  - Beginner
-  - CSS
-  - CodingScripting
-  - HTML
-  - JavaScript
-  - Learn
-  - Tools
-  - Users
-  - assistive technology
-  - keyboard
-  - screan reader
-  - screenreader
-translation_of: Learn/Accessibility/What_is_accessibility
 ---
 {{LearnSidebar}}{{NextMenu("Learn/Accessibility/HTML", "Learn/Accessibility")}}
 

--- a/files/ja/learn/common_questions/available_text_editors/index.md
+++ b/files/ja/learn/common_questions/available_text_editors/index.md
@@ -1,13 +1,6 @@
 ---
 title: どんなテキストエディターが利用可能？
 slug: Learn/Common_questions/Available_text_editors
-tags:
-  - Beginner
-  - Composing
-  - Guide
-  - Tools
-  - text editor
-translation_of: Learn/Common_questions/Available_text_editors
 ---
 この記事ではウェブ開発向けのテキストエディターをインストールする際に考慮すべき点をいくつか取り上げます。
 

--- a/files/ja/learn/common_questions/checking_that_your_web_site_is_working_properly/index.md
+++ b/files/ja/learn/common_questions/checking_that_your_web_site_is_working_properly/index.md
@@ -1,16 +1,6 @@
 ---
 title: ウェブサイトが正しく動作することをどうやって確認する？
 slug: Learn/Common_questions/Checking_that_your_web_site_is_working_properly
-tags:
-  - Beginner
-  - Document
-  - Guide
-  - NeedsActiveLearning
-  - Web
-  - Web Development
-  - WebMechanics
-  - troubleshooting
-translation_of: Learn/Common_questions/Checking_that_your_web_site_is_working_properly
 ---
 この記事では、ウェブサイトのさまざまなトラブルシューティングの手順と、これらの問題を解決するための基本的な操作について説明します。
 

--- a/files/ja/learn/common_questions/common_web_layouts/index.md
+++ b/files/ja/learn/common_questions/common_web_layouts/index.md
@@ -1,13 +1,6 @@
 ---
 title: 一般的なウェブレイアウトには何が含まれているのか？
 slug: Learn/Common_questions/Common_web_layouts
-tags:
-  - Beginner
-  - CSS
-  - Design
-  - HTML
-  - NeedsActiveLearning
-translation_of: Learn/Common_questions/Common_web_layouts
 ---
 ウェブサイトのページをデザインする際、最も一般的なレイアウトを把握しておくとよいでしょう。
 

--- a/files/ja/learn/common_questions/design_for_all_types_of_users/index.md
+++ b/files/ja/learn/common_questions/design_for_all_types_of_users/index.md
@@ -1,15 +1,6 @@
 ---
 title: どうすればすべての種類のユーザーのためにデザインすることができるか？
 slug: Learn/Common_questions/Design_for_all_types_of_users
-tags:
-  - Accessibility
-  - Beginner
-  - Design
-  - Example
-  - Intro
-  - Mobile
-  - NeedsActiveLearning
-translation_of: Learn/Common_questions/Design_for_all_types_of_users
 ---
 この記事ではあらゆる種類のユーザーのためのウェブサイトを設計する基本的なヒントを紹介します。
 

--- a/files/ja/learn/common_questions/how_do_you_host_your_website_on_google_app_engine/index.md
+++ b/files/ja/learn/common_questions/how_do_you_host_your_website_on_google_app_engine/index.md
@@ -1,17 +1,6 @@
 ---
 title: Google App Engine を使ってウェブサイトを公開するには？
 slug: Learn/Common_questions/How_do_you_host_your_website_on_Google_App_Engine
-tags:
-  - Beginner
-  - Google App Engine
-  - Google Cloud Platform
-  - Guide
-  - Host
-  - Learn
-  - Web
-  - publish
-  - website
-translation_of: Learn/Common_questions/How_do_you_host_your_website_on_Google_App_Engine
 ---
 [Google App Engine](https://cloud.google.com/appengine/) は、Google のインフラストラクチャ上でアプリケーションを構築して実行できる強力なプラットフォームです。ゼロから多階層のウェブ アプリケーションを構築する場合でも、静的なウェブサイトをホストする場合でも、必要なアプリケーションを構築することができます。ここでは、 Google App Engine でウェブサイトをホスティングするためのステップバイステップガイドを紹介します。
 

--- a/files/ja/learn/common_questions/how_does_the_internet_work/index.md
+++ b/files/ja/learn/common_questions/how_does_the_internet_work/index.md
@@ -1,11 +1,6 @@
 ---
 title: インターネットはどのように動くのか？
 slug: Learn/Common_questions/How_does_the_Internet_work
-tags:
-  - Beginner
-  - Tutorial
-  - WebMechanics
-translation_of: Learn/Common_questions/How_does_the_Internet_work
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/common_questions/how_much_does_it_cost/index.md
+++ b/files/ja/learn/common_questions/how_much_does_it_cost/index.md
@@ -1,13 +1,6 @@
 ---
 title: ウェブ上で何かをするためにどれくらいコストがかかる？
 slug: Learn/Common_questions/How_much_does_it_cost
-tags:
-  - Beginner
-  - WebMechanics
-  - cost
-  - hosting
-  - web development tools
-translation_of: Learn/Common_questions/How_much_does_it_cost
 ---
 ウェブに関わることは、見た目ほど安いものではありません。この記事では、あなたがどれくらいの費用を負担しなければならないか、またその理由について説明します。
 

--- a/files/ja/learn/common_questions/html_features_for_accessibility/index.md
+++ b/files/ja/learn/common_questions/html_features_for_accessibility/index.md
@@ -1,13 +1,6 @@
 ---
 title: アクセシビリティを推進する HTML の機能とは？
 slug: Learn/Common_questions/HTML_features_for_accessibility
-tags:
-  - Accessibility
-  - Beginner
-  - HTML
-  - Learn
-  - NeedsContent
-translation_of: Learn/Common_questions/HTML_features_for_accessibility
 ---
 
 

--- a/files/ja/learn/common_questions/index.md
+++ b/files/ja/learn/common_questions/index.md
@@ -1,13 +1,6 @@
 ---
 title: よくある質問
 slug: Learn/Common_questions
-tags:
-  - CodingScripting
-  - Infrastructure
-  - Learn
-  - Web
-  - WebMechanics
-translation_of: Learn/Common_questions
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/common_questions/pages_sites_servers_and_search_engines/index.md
+++ b/files/ja/learn/common_questions/pages_sites_servers_and_search_engines/index.md
@@ -1,11 +1,6 @@
 ---
 title: ウェブページ、ウェブサイト、ウェブサーバー、検索エンジンの違いは？
 slug: Learn/Common_questions/Pages_sites_servers_and_search_engines
-tags:
-  - Beginner
-  - NeedsActiveLearning
-  - WebMechanics
-translation_of: Learn/Common_questions/Pages_sites_servers_and_search_engines
 ---
 この記事では、ウェブページ、ウェブサイト、ウェブサーバー、検索エンジンなどのウェブに関係する色々な概念に関して解説します。これらの用語はウェブの初心者を混乱させたり、間違って使われたりしています。それぞれの意味を学びましょう。
 

--- a/files/ja/learn/common_questions/set_up_a_local_testing_server/index.md
+++ b/files/ja/learn/common_questions/set_up_a_local_testing_server/index.md
@@ -1,19 +1,6 @@
 ---
 title: ローカルにテスト用サーバーを用意するには？
 slug: Learn/Common_questions/set_up_a_local_testing_server
-tags:
-  - Beginner
-  - Express
-  - Flask
-  - Learn
-  - Node
-  - PHP
-  - Python
-  - django
-  - lamp
-  - server-side
-  - servers
-translation_of: Learn/Common_questions/set_up_a_local_testing_server
 ---
 この記事では、マシン上に簡単なローカルテストサーバーを設定する方法と、その使い方の基本について説明します。
 

--- a/files/ja/learn/common_questions/thinking_before_coding/index.md
+++ b/files/ja/learn/common_questions/thinking_before_coding/index.md
@@ -1,12 +1,6 @@
 ---
 title: ウェブサイトのデザインは何から始めればよい？
 slug: Learn/Common_questions/Thinking_before_coding
-tags:
-  - Beginner
-  - Composing
-  - NeedsActiveLearning
-  - needsSchema
-translation_of: Learn/Common_questions/Thinking_before_coding
 ---
 この記事では、すべてのプロジェクトにおいて重要な最初のステップである、「そのプロジェクトで何を達成したいのか」を定義することについて述べます。
 

--- a/files/ja/learn/common_questions/upload_files_to_a_web_server/index.md
+++ b/files/ja/learn/common_questions/upload_files_to_a_web_server/index.md
@@ -1,16 +1,6 @@
 ---
 title: ウェブサーバーにファイルをアップロードするには？
 slug: Learn/Common_questions/Upload_files_to_a_web_server
-tags:
-  - Beginner
-  - FTP
-  - GitHub
-  - Uploading
-  - WebMechanics
-  - hosting
-  - rsync
-  - SFTP
-translation_of: Learn/Common_questions/Upload_files_to_a_web_server
 ---
 この記事では、ファイル転送ツールを使用してオンラインでサイトを公開する方法を説明します。
 

--- a/files/ja/learn/common_questions/using_github_pages/index.md
+++ b/files/ja/learn/common_questions/using_github_pages/index.md
@@ -1,15 +1,6 @@
 ---
 title: GitHub Pages を使うには？
 slug: Learn/Common_questions/Using_Github_pages
-tags:
-  - Beginner
-  - GitHub
-  - Guide
-  - Web
-  - gh-pages
-  - git
-  - publish
-translation_of: Learn/Common_questions/Using_Github_pages
 ---
 [GitHub](https://github.com/) は「ソーシャルコーディング」のサイトです。 [Git](https://git-scm.com/) **バージョン管理システム**のストレージに対して、ソースコードリポジトリーのアップロードを許可します。その後、コードプロジェクトで共同作業を行うことができます。また、システムはオープンソースに自動設定されています。つまり、世界中の誰もが GitHub コードを検索・使用また、そこから学習しコードを改善することができます。他の人のコードでもそれが可能です！この記事は GitHub の gh-pages 機能を使って、公開コンテンツに関する基本的なガイドを提供します。
 

--- a/files/ja/learn/common_questions/what_are_browser_developer_tools/index.md
+++ b/files/ja/learn/common_questions/what_are_browser_developer_tools/index.md
@@ -1,16 +1,6 @@
 ---
 title: ブラウザーの開発者ツールとは？
 slug: Learn/Common_questions/What_are_browser_developer_tools
-tags:
-  - Beginner
-  - Browser
-  - CSS
-  - CodingScripting
-  - Dev Tools
-  - HTML
-  - JavaScript
-  - Learn
-translation_of: Learn/Common_questions/What_are_browser_developer_tools
 ---
 近頃のブラウザーにはパワフルな開発者ツールが入っています。開発者ツールでは、現在の HTML や CSS、JavaScript の状態を検証したり、ページがどういった資産にアクセスし、どれだけ時間がかかったかといった多様なことができます。この記事ではブラウザーの開発者ツールの使い方について説明します。
 

--- a/files/ja/learn/common_questions/what_are_hyperlinks/index.md
+++ b/files/ja/learn/common_questions/what_are_hyperlinks/index.md
@@ -1,12 +1,6 @@
 ---
 title: ハイパーリンクとは？
 slug: Learn/Common_questions/What_are_hyperlinks
-tags:
-  - Beginner
-  - Infrastructure
-  - Navigation
-  - NeedsActiveLearning
-translation_of: Learn/Common_questions/What_are_hyperlinks
 ---
 この記事では、ハイパーリンクとは何か、なぜ重要なのかを詳しく説明します。
 

--- a/files/ja/learn/common_questions/what_is_a_domain_name/index.md
+++ b/files/ja/learn/common_questions/what_is_a_domain_name/index.md
@@ -1,14 +1,6 @@
 ---
 title: ドメイン名とは？
 slug: Learn/Common_questions/What_is_a_domain_name
-tags:
-  - Beginner
-  - Domain names
-  - Infrastructure
-  - Intro
-  - NeedsActiveLearning
-  - Web
-translation_of: Learn/Common_questions/What_is_a_domain_name
 ---
 <table>
   <tbody>

--- a/files/ja/learn/common_questions/what_is_a_url/index.md
+++ b/files/ja/learn/common_questions/what_is_a_url/index.md
@@ -1,13 +1,6 @@
 ---
 title: URL とは？
 slug: Learn/Common_questions/What_is_a_URL
-tags:
-  - Beginner
-  - Infrastructure
-  - URL
-  - resources
-  - urls
-translation_of: Learn/Common_questions/What_is_a_URL
 ---
 この記事では URL (Uniform Resource Locator) について説明し、その内容と構造を説明します。
 

--- a/files/ja/learn/common_questions/what_is_a_web_server/index.md
+++ b/files/ja/learn/common_questions/what_is_a_web_server/index.md
@@ -1,11 +1,6 @@
 ---
 title: ウェブサーバーとは？
 slug: Learn/Common_questions/What_is_a_web_server
-tags:
-  - Beginner
-  - Infrastructure
-  - needsSchema
-translation_of: Learn/Common_questions/What_is_a_web_server
 ---
 この記事では、ウェブサーバーとは何か、ウェブサーバーの仕組み、なぜウェブサーバーが重要なのかを説明します。
 

--- a/files/ja/learn/common_questions/what_is_accessibility/index.md
+++ b/files/ja/learn/common_questions/what_is_accessibility/index.md
@@ -1,13 +1,6 @@
 ---
 title: アクセシビリティとは？
 slug: Learn/Common_questions/What_is_accessibility
-tags:
-  - Accessibility
-  - Beginner
-  - Intro
-  - NeedsActiveLearning
-  - Web
-translation_of: Learn/Common_questions/What_is_accessibility
 ---
 この記事はウェブアクセシビリティの背景にある基本的な概念を紹介します。
 

--- a/files/ja/learn/common_questions/what_software_do_i_need/index.md
+++ b/files/ja/learn/common_questions/what_software_do_i_need/index.md
@@ -1,11 +1,6 @@
 ---
 title: ウェブサイトを作るのにどんなソフトウェアが必要？
 slug: Learn/Common_questions/What_software_do_I_need
-tags:
-  - Beginner
-  - NeedsActiveLearning
-  - WebMechanics
-translation_of: Learn/Common_questions/What_software_do_I_need
 ---
 <div class="summary">
 この記事では、ウェブサイトを編集、アップロード、または閲覧するときに必要なソフトウェアについて説明します。

--- a/files/ja/learn/css/building_blocks/a_cool_looking_box/index.md
+++ b/files/ja/learn/css/building_blocks/a_cool_looking_box/index.md
@@ -1,17 +1,6 @@
 ---
 title: かっこいいボックス
 slug: Learn/CSS/Building_blocks/A_cool_looking_box
-tags:
-  - Assessment
-  - Beginner
-  - CSS
-  - Learn
-  - backgrounds
-  - borders
-  - box
-  - box model
-  - effects
-translation_of: Learn/CSS/Building_blocks/A_cool_looking_box
 original_slug: Learn/CSS/Styling_boxes/A_cool_looking_box
 ---
 {{LearnSidebar}}{{PreviousMenu("Learn/CSS/Styling_boxes/Creating_fancy_letterheaded_paper", "Learn/CSS/Styling_boxes")}}

--- a/files/ja/learn/css/building_blocks/advanced_styling_effects/index.md
+++ b/files/ja/learn/css/building_blocks/advanced_styling_effects/index.md
@@ -1,18 +1,6 @@
 ---
 title: ボックスの高度なエフェクト
 slug: Learn/CSS/Building_blocks/Advanced_styling_effects
-tags:
-  - Article
-  - Beginner
-  - Blend modes
-  - Boxes
-  - CSS
-  - CodingScripting
-  - Filters
-  - Styling
-  - box shadows
-  - effects
-translation_of: Learn/CSS/Building_blocks/Advanced_styling_effects
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Styling_boxes/Styling tables", "Learn/CSS/Styling_boxes/Creating_fancy_letterheaded_paper", "Learn/CSS/Styling_boxes")}}
 

--- a/files/ja/learn/css/building_blocks/backgrounds_and_borders/index.md
+++ b/files/ja/learn/css/building_blocks/backgrounds_and_borders/index.md
@@ -1,16 +1,6 @@
 ---
 title: 背景と枠線
 slug: Learn/CSS/Building_blocks/Backgrounds_and_borders
-tags:
-  - Background
-  - Beginner
-  - CSS
-  - Image
-  - Learn
-  - Position
-  - borders
-  - color
-translation_of: Learn/CSS/Building_blocks/Backgrounds_and_borders
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/The_box_model", "Learn/CSS/Building_blocks/Handling_different_text_directions", "Learn/CSS/Building_blocks")}}
 

--- a/files/ja/learn/css/building_blocks/cascade_and_inheritance/index.md
+++ b/files/ja/learn/css/building_blocks/cascade_and_inheritance/index.md
@@ -1,16 +1,6 @@
 ---
 title: カスケードと継承
 slug: Learn/CSS/Building_blocks/Cascade_and_inheritance
-tags:
-  - Beginner
-  - CSS
-  - Cascade
-  - Inheritance
-  - Learn
-  - rules
-  - source order
-  - specificity
-translation_of: Learn/CSS/Building_blocks/Cascade_and_inheritance
 ---
 {{LearnSidebar}}{{NextMenu("Learn/CSS/Building_blocks/Selectors", "Learn/CSS/Building_blocks")}}
 

--- a/files/ja/learn/css/building_blocks/creating_fancy_letterheaded_paper/index.md
+++ b/files/ja/learn/css/building_blocks/creating_fancy_letterheaded_paper/index.md
@@ -1,20 +1,6 @@
 ---
 title: 装飾的なレターヘッド付きの便箋の作成
 slug: Learn/CSS/Building_blocks/Creating_fancy_letterheaded_paper
-tags:
-  - Assessment
-  - Background
-  - Beginner
-  - Boxes
-  - CSS
-  - CodingScripting
-  - border
-  - box
-  - letter
-  - letterhead
-  - letterheaded
-  - paper
-translation_of: Learn/CSS/Building_blocks/Creating_fancy_letterheaded_paper
 original_slug: Learn/CSS/Styling_boxes/Creating_fancy_letterheaded_paper
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Styling_boxes/Advanced_box_effects", "Learn/CSS/Styling_boxes/A_cool_looking_box", "Learn/CSS/Styling_boxes")}}

--- a/files/ja/learn/css/building_blocks/debugging_css/index.md
+++ b/files/ja/learn/css/building_blocks/debugging_css/index.md
@@ -1,15 +1,6 @@
 ---
 title: CSS のデバッグ
 slug: Learn/CSS/Building_blocks/Debugging_CSS
-tags:
-  - Beginner
-  - CSS
-  - DOM
-  - Debugging
-  - DevTools
-  - Learn
-  - source
-translation_of: Learn/CSS/Building_blocks/Debugging_CSS
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Styling_tables", "Learn/CSS/Building_blocks/Organizing", "Learn/CSS/Building_blocks")}}
 

--- a/files/ja/learn/css/building_blocks/fundamental_css_comprehension/index.md
+++ b/files/ja/learn/css/building_blocks/fundamental_css_comprehension/index.md
@@ -1,18 +1,6 @@
 ---
 title: 基本的な CSS の理解
 slug: Learn/CSS/Building_blocks/Fundamental_CSS_comprehension
-tags:
-  - Assessment
-  - Beginner
-  - CSS
-  - CodingScripting
-  - Syntax
-  - コメント
-  - スタイル
-  - セレクタ
-  - ボックスモデル
-  - ルール
-translation_of: Learn/CSS/Building_blocks/Fundamental_CSS_comprehension
 original_slug: Learn/CSS/Introduction_to_CSS/Fundamental_CSS_comprehension
 ---
 {{LearnSidebar}}{{PreviousMenu("Learn/CSS/Introduction_to_CSS/Debugging_CSS", "Learn/CSS/Introduction_to_CSS")}}

--- a/files/ja/learn/css/building_blocks/handling_different_text_directions/index.md
+++ b/files/ja/learn/css/building_blocks/handling_different_text_directions/index.md
@@ -1,13 +1,6 @@
 ---
 title: テキスト方向の操作
 slug: Learn/CSS/Building_blocks/Handling_different_text_directions
-tags:
-  - Beginner
-  - CSS
-  - Learn
-  - logical properties
-  - writing modes
-translation_of: Learn/CSS/Building_blocks/Handling_different_text_directions
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Backgrounds_and_borders", "Learn/CSS/Building_blocks/Overflowing_content", "Learn/CSS/Building_blocks")}}
 

--- a/files/ja/learn/css/building_blocks/images_media_form_elements/index.md
+++ b/files/ja/learn/css/building_blocks/images_media_form_elements/index.md
@@ -1,15 +1,6 @@
 ---
 title: 画像・メディア・フォーム要素
 slug: Learn/CSS/Building_blocks/Images_media_form_elements
-tags:
-  - Beginner
-  - CSS
-  - Forms
-  - Images
-  - Learn
-  - Media
-  - replaced content
-translation_of: Learn/CSS/Building_blocks/Images_media_form_elements
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Sizing_items_in_CSS", "Learn/CSS/Building_blocks/Styling_tables", "Learn/CSS/Building_blocks")}}
 

--- a/files/ja/learn/css/building_blocks/index.md
+++ b/files/ja/learn/css/building_blocks/index.md
@@ -1,12 +1,6 @@
 ---
 title: CSS の構成要素
 slug: Learn/CSS/Building_blocks
-tags:
-  - Beginner
-  - CSS
-  - Learn
-  - building blocks
-translation_of: Learn/CSS/Building_blocks
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/css/building_blocks/organizing/index.md
+++ b/files/ja/learn/css/building_blocks/organizing/index.md
@@ -1,19 +1,6 @@
 ---
 title: CSS の整理
 slug: Learn/CSS/Building_blocks/Organizing
-tags:
-  - Beginner
-  - CSS
-  - CodingScripting
-  - Learn
-  - comments
-  - formatting
-  - methodologies
-  - organizing
-  - post-processor
-  - pre-processor
-  - styleguide
-translation_of: Learn/CSS/Building_blocks/Organizing
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Debugging_CSS", "Learn/CSS/Building_blocks/Fundamental_CSS_comprehension", "Learn/CSS/Building_blocks")}}
 

--- a/files/ja/learn/css/building_blocks/overflowing_content/index.md
+++ b/files/ja/learn/css/building_blocks/overflowing_content/index.md
@@ -1,14 +1,6 @@
 ---
 title: 要素のはみ出し（オーバーフロー）
 slug: Learn/CSS/Building_blocks/Overflowing_content
-tags:
-  - Beginner
-  - Block Formatting Context
-  - CSS
-  - Data Loss
-  - Learn
-  - overflow
-translation_of: Learn/CSS/Building_blocks/Overflowing_content
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Handling_different_text_directions", "Learn/CSS/Building_blocks/Values_and_units", "Learn/CSS/Building_blocks")}}
 

--- a/files/ja/learn/css/building_blocks/selectors/attribute_selectors/index.md
+++ b/files/ja/learn/css/building_blocks/selectors/attribute_selectors/index.md
@@ -1,13 +1,6 @@
 ---
 title: 属性セレクター
 slug: Learn/CSS/Building_blocks/Selectors/Attribute_selectors
-tags:
-  - Attribute
-  - Beginner
-  - CSS
-  - Learn
-  - Selectors
-translation_of: Learn/CSS/Building_blocks/Selectors/Attribute_selectors
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Selectors/Type_Class_and_ID_Selectors", "Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements", "Learn/CSS/Building_blocks")}}
 

--- a/files/ja/learn/css/building_blocks/selectors/combinators/index.md
+++ b/files/ja/learn/css/building_blocks/selectors/combinators/index.md
@@ -1,13 +1,6 @@
 ---
 title: 結合子
 slug: Learn/CSS/Building_blocks/Selectors/Combinators
-tags:
-  - Beginner
-  - CSS
-  - Learn
-  - Selectors
-  - combinators
-translation_of: Learn/CSS/Building_blocks/Selectors/Combinators
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements", "Learn/CSS/Building_blocks/The_box_model", "Learn/CSS/Building_blocks")}}
 

--- a/files/ja/learn/css/building_blocks/selectors/index.md
+++ b/files/ja/learn/css/building_blocks/selectors/index.md
@@ -1,16 +1,6 @@
 ---
 title: CSS セレクター
 slug: Learn/CSS/Building_blocks/Selectors
-tags:
-  - Attribute
-  - Beginner
-  - CSS
-  - Class
-  - Learn
-  - Pseudo
-  - Selectors
-  - id
-translation_of: Learn/CSS/Building_blocks/Selectors
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Cascade_and_inheritance", "Learn/CSS/Building_blocks/Selectors/Type_Class_and_ID_Selectors", "Learn/CSS/Building_blocks")}}
 

--- a/files/ja/learn/css/building_blocks/selectors/pseudo-classes_and_pseudo-elements/index.md
+++ b/files/ja/learn/css/building_blocks/selectors/pseudo-classes_and_pseudo-elements/index.md
@@ -1,7 +1,6 @@
 ---
 title: 疑似クラスと疑似要素
 slug: Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements
-translation_of: Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Selectors/Attribute_selectors", "Learn/CSS/Building_blocks/Selectors/Combinators", "Learn/CSS/Building_blocks")}}
 

--- a/files/ja/learn/css/building_blocks/selectors/type_class_and_id_selectors/index.md
+++ b/files/ja/learn/css/building_blocks/selectors/type_class_and_id_selectors/index.md
@@ -1,16 +1,6 @@
 ---
 title: 要素・クラス・ID によるセレクター
 slug: Learn/CSS/Building_blocks/Selectors/Type_Class_and_ID_Selectors
-tags:
-  - Beginner
-  - CSS
-  - Class
-  - Learn
-  - Selectors
-  - Syntax
-  - id
-  - universal
-translation_of: Learn/CSS/Building_blocks/Selectors/Type_Class_and_ID_Selectors
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Selectors", "Learn/CSS/Building_blocks/Selectors/Attribute_selectors", "Learn/CSS/Building_blocks")}}
 

--- a/files/ja/learn/css/building_blocks/sizing_items_in_css/index.md
+++ b/files/ja/learn/css/building_blocks/sizing_items_in_css/index.md
@@ -1,17 +1,6 @@
 ---
 title: CSS によるサイズ設定
 slug: Learn/CSS/Building_blocks/Sizing_items_in_CSS
-tags:
-  - Beginner
-  - CSS
-  - Intrinsic size
-  - Learn
-  - max size
-  - min size
-  - percentage
-  - sizing
-  - viewport units
-translation_of: Learn/CSS/Building_blocks/Sizing_items_in_CSS
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Values_and_units", "Learn/CSS/Building_blocks/Images_media_form_elements", "Learn/CSS/Building_blocks")}}
 

--- a/files/ja/learn/css/building_blocks/styling_tables/index.md
+++ b/files/ja/learn/css/building_blocks/styling_tables/index.md
@@ -1,15 +1,6 @@
 ---
 title: 表のスタイリング
 slug: Learn/CSS/Building_blocks/Styling_tables
-tags:
-  - Article
-  - Beginner
-  - CSS
-  - CodingScripting
-  - Guide
-  - Styling
-  - Tables
-translation_of: Learn/CSS/Building_blocks/Styling_tables
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Images_media_form_elements", "Learn/CSS/Building_blocks/Debugging_CSS", "Learn/CSS/Building_blocks")}}
 

--- a/files/ja/learn/css/building_blocks/the_box_model/index.md
+++ b/files/ja/learn/css/building_blocks/the_box_model/index.md
@@ -1,16 +1,6 @@
 ---
 title: ボックスモデル
 slug: Learn/CSS/Building_blocks/The_box_model
-tags:
-  - Beginner
-  - CSS
-  - Learn
-  - border
-  - box model
-  - display
-  - margin
-  - padding
-translation_of: Learn/CSS/Building_blocks/The_box_model
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Selectors/Combinators", "Learn/CSS/Building_blocks/Backgrounds_and_borders", "Learn/CSS/Building_blocks")}}
 

--- a/files/ja/learn/css/building_blocks/values_and_units/index.md
+++ b/files/ja/learn/css/building_blocks/values_and_units/index.md
@@ -1,20 +1,6 @@
 ---
 title: CSS の値と単位
 slug: Learn/CSS/Building_blocks/Values_and_units
-tags:
-  - Beginner
-  - CSS
-  - Function
-  - Image
-  - Learn
-  - Number
-  - Position
-  - color
-  - length
-  - percentage
-  - units
-  - values
-translation_of: Learn/CSS/Building_blocks/Values_and_units
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Overflowing_content", "Learn/CSS/Building_blocks/Sizing_items_in_CSS", "Learn/CSS/Building_blocks")}}
 

--- a/files/ja/learn/css/css_layout/flexbox/index.md
+++ b/files/ja/learn/css/css_layout/flexbox/index.md
@@ -1,19 +1,6 @@
 ---
 title: フレックスボックス
 slug: Learn/CSS/CSS_layout/Flexbox
-tags:
-  - Article
-  - Beginner
-  - CSS
-  - CSS layouts
-  - CodingScripting
-  - Flexible Boxes
-  - Guide
-  - Layout
-  - Layouts
-  - Learn
-  - flexbox
-translation_of: Learn/CSS/CSS_layout/Flexbox
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/CSS_layout/Normal_Flow", "Learn/CSS/CSS_layout/Grids", "Learn/CSS/CSS_layout")}}
 

--- a/files/ja/learn/css/css_layout/floats/index.md
+++ b/files/ja/learn/css/css_layout/floats/index.md
@@ -1,18 +1,6 @@
 ---
 title: フロート
 slug: Learn/CSS/CSS_layout/Floats
-tags:
-  - Article
-  - Beginner
-  - CSS
-  - Clearing
-  - CodingScripting
-  - Floats
-  - Guide
-  - Layout
-  - columns
-  - multi-column
-translation_of: Learn/CSS/CSS_layout/Floats
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/CSS_layout/Grids", "Learn/CSS/CSS_layout/Positioning", "Learn/CSS/CSS_layout")}}
 

--- a/files/ja/learn/css/css_layout/fundamental_layout_comprehension/index.md
+++ b/files/ja/learn/css/css_layout/fundamental_layout_comprehension/index.md
@@ -1,13 +1,6 @@
 ---
 title: 基礎的なレイアウトの理解
 slug: Learn/CSS/CSS_layout/Fundamental_Layout_Comprehension
-tags:
-  - Assessment
-  - Beginner
-  - CSS
-  - Layout
-  - Learn
-translation_of: Learn/CSS/CSS_layout/Fundamental_Layout_Comprehension
 ---
 {{LearnSidebar}}{{PreviousMenu("Learn/CSS/CSS_layout/Supporting_Older_Browsers", "Learn/CSS/CSS_layout")}}
 

--- a/files/ja/learn/css/css_layout/grids/index.md
+++ b/files/ja/learn/css/css_layout/grids/index.md
@@ -1,21 +1,6 @@
 ---
 title: グリッド
 slug: Learn/CSS/CSS_layout/Grids
-tags:
-  - Article
-  - Beginner
-  - CSS
-  - CSS Grids
-  - CodingScripting
-  - Grids
-  - Guide
-  - Layout
-  - Learn
-  - Tutorial
-  - grid design
-  - grid framework
-  - grid system
-translation_of: Learn/CSS/CSS_layout/Grids
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/CSS_layout/Flexbox", "Learn/CSS/CSS_layout/Floats", "Learn/CSS/CSS_layout")}}
 

--- a/files/ja/learn/css/css_layout/index.md
+++ b/files/ja/learn/css/css_layout/index.md
@@ -1,23 +1,6 @@
 ---
 title: CSS レイアウト
 slug: Learn/CSS/CSS_layout
-tags:
-  - Beginner
-  - CSS
-  - Floating
-  - Grids
-  - Guide
-  - Landing
-  - Layout
-  - Learn
-  - Module
-  - Multiple column
-  - Positioning
-  - alignment
-  - flexbox
-  - float
-  - table
-translation_of: Learn/CSS/CSS_layout
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/css/css_layout/introduction/index.md
+++ b/files/ja/learn/css/css_layout/introduction/index.md
@@ -1,20 +1,6 @@
 ---
 title: CSS レイアウト入門
 slug: Learn/CSS/CSS_layout/Introduction
-tags:
-  - Article
-  - Beginner
-  - CSS
-  - Floats
-  - Grids
-  - Introduction
-  - Layout
-  - Learn
-  - Positioning
-  - Tables
-  - flexbox
-  - flow
-translation_of: Learn/CSS/CSS_layout/Introduction
 ---
 {{LearnSidebar}}{{NextMenu("Learn/CSS/CSS_layout/Normal_Flow", "Learn/CSS/CSS_layout")}}
 

--- a/files/ja/learn/css/css_layout/legacy_layout_methods/index.md
+++ b/files/ja/learn/css/css_layout/legacy_layout_methods/index.md
@@ -1,16 +1,6 @@
 ---
 title: 過去のレイアウト方法
 slug: Learn/CSS/CSS_layout/Legacy_Layout_Methods
-tags:
-  - Beginner
-  - CSS
-  - Floats
-  - Guide
-  - Layout
-  - Learn
-  - grid system
-  - legacy
-translation_of: Learn/CSS/CSS_layout/Legacy_Layout_Methods
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/css/css_layout/media_queries/index.md
+++ b/files/ja/learn/css/css_layout/media_queries/index.md
@@ -1,13 +1,6 @@
 ---
 title: メディアクエリーの初心者向けガイド
 slug: Learn/CSS/CSS_layout/Media_queries
-tags:
-  - Beginner
-  - CSS
-  - Layout
-  - Learn
-  - media query
-translation_of: Learn/CSS/CSS_layout/Media_queries
 ---
 {{learnsidebar}}{{PreviousMenuNext("Learn/CSS/CSS_layout/Responsive_Design", "Learn/CSS/CSS_layout/Legacy_Layout_Methods", "Learn/CSS/CSS_layout")}}
 

--- a/files/ja/learn/css/css_layout/multiple-column_layout/index.md
+++ b/files/ja/learn/css/css_layout/multiple-column_layout/index.md
@@ -1,16 +1,6 @@
 ---
 title: 段組みレイアウト
 slug: Learn/CSS/CSS_layout/Multiple-column_Layout
-tags:
-  - Beginner
-  - CSS
-  - Guide
-  - Layout
-  - Learn
-  - Learning
-  - Multi-col
-  - Multiple columns
-translation_of: Learn/CSS/CSS_layout/Multiple-column_Layout
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/CSS_layout/Positioning", "Learn/CSS/CSS_layout/Responsive_Design", "Learn/CSS/CSS_layout")}}
 

--- a/files/ja/learn/css/css_layout/normal_flow/index.md
+++ b/files/ja/learn/css/css_layout/normal_flow/index.md
@@ -1,15 +1,6 @@
 ---
 title: 通常フロー
 slug: Learn/CSS/CSS_layout/Normal_Flow
-tags:
-  - Beginner
-  - CSS
-  - Layout
-  - Learn
-  - float
-  - grid
-  - normal flow
-translation_of: Learn/CSS/CSS_layout/Normal_Flow
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/css/css_layout/positioning/index.md
+++ b/files/ja/learn/css/css_layout/positioning/index.md
@@ -1,18 +1,6 @@
 ---
 title: 位置指定
 slug: Learn/CSS/CSS_layout/Positioning
-tags:
-  - Article
-  - Beginner
-  - CSS
-  - CodingScripting
-  - Guide
-  - Layout
-  - Positioning
-  - absolute
-  - fixed
-  - relative
-translation_of: Learn/CSS/CSS_layout/Positioning
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/CSS_layout/Floats", "Learn/CSS/CSS_layout/Multiple-column_Layout", "Learn/CSS/CSS_layout")}}
 

--- a/files/ja/learn/css/css_layout/practical_positioning_examples/index.md
+++ b/files/ja/learn/css/css_layout/practical_positioning_examples/index.md
@@ -1,18 +1,6 @@
 ---
 title: 実用的な位置指定の例
 slug: Learn/CSS/CSS_layout/Practical_positioning_examples
-tags:
-  - Article
-  - Beginner
-  - CSS
-  - CodingScripting
-  - Guide
-  - Layout
-  - Learn
-  - absolute
-  - fixed
-  - relative
-translation_of: Learn/CSS/CSS_layout/Practical_positioning_examples
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/css/css_layout/responsive_design/index.md
+++ b/files/ja/learn/css/css_layout/responsive_design/index.md
@@ -1,17 +1,6 @@
 ---
 title: レスポンシブデザイン
 slug: Learn/CSS/CSS_layout/Responsive_Design
-tags:
-  - Images
-  - Media Queries
-  - RWD
-  - Responsive web design
-  - flexbox
-  - fluid grids
-  - grid
-  - multicol
-  - typography
-translation_of: Learn/CSS/CSS_layout/Responsive_Design
 ---
 {{learnsidebar}}{{PreviousMenuNext("Learn/CSS/CSS_layout/Multiple-column_Layout", "Learn/CSS/CSS_layout/Media_queries", "Learn/CSS/CSS_layout")}}
 

--- a/files/ja/learn/css/css_layout/supporting_older_browsers/index.md
+++ b/files/ja/learn/css/css_layout/supporting_older_browsers/index.md
@@ -1,18 +1,6 @@
 ---
 title: 古いブラウザーのサポート
 slug: Learn/CSS/CSS_layout/Supporting_Older_Browsers
-tags:
-  - Beginner
-  - CSS
-  - Guide
-  - Layout
-  - Learn
-  - feature queries
-  - flexbox
-  - float
-  - grid
-  - legacy
-translation_of: Learn/CSS/CSS_layout/Supporting_Older_Browsers
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/css/first_steps/getting_started/index.md
+++ b/files/ja/learn/css/first_steps/getting_started/index.md
@@ -1,16 +1,6 @@
 ---
 title: CSS 入門
 slug: Learn/CSS/First_steps/Getting_started
-tags:
-  - Beginner
-  - CSS
-  - Classes
-  - Elements
-  - Learn
-  - Selectors
-  - Syntax
-  - state
-translation_of: Learn/CSS/First_steps/Getting_started
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/First_steps/What_is_CSS", "Learn/CSS/First_steps/How_CSS_is_structured", "Learn/CSS/First_steps")}}
 

--- a/files/ja/learn/css/first_steps/how_css_is_structured/index.md
+++ b/files/ja/learn/css/first_steps/how_css_is_structured/index.md
@@ -1,19 +1,6 @@
 ---
 title: CSS の全体像
 slug: Learn/CSS/First_steps/How_CSS_is_structured
-tags:
-  - Beginner
-  - CSS
-  - HTML
-  - Learn
-  - Selectors
-  - Structure
-  - comments
-  - properties
-  - shorthand
-  - values
-  - whitespace
-translation_of: Learn/CSS/First_steps/How_CSS_is_structured
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/First_steps/Getting_started", "Learn/CSS/First_steps/How_CSS_works", "Learn/CSS/First_steps")}}
 

--- a/files/ja/learn/css/first_steps/how_css_works/index.md
+++ b/files/ja/learn/css/first_steps/how_css_works/index.md
@@ -1,12 +1,6 @@
 ---
 title: CSS はどう働くか？
 slug: Learn/CSS/First_steps/How_CSS_works
-tags:
-  - Beginner
-  - CSS
-  - DOM
-  - Learn
-translation_of: Learn/CSS/First_steps/How_CSS_works
 ---
 {{LearnSidebar}}
 {{PreviousMenuNext("Learn/CSS/First_steps/How_CSS_is_structured", "Learn/CSS/First_steps/Using_your_new_knowledge", "Learn/CSS/First_steps")}}

--- a/files/ja/learn/css/first_steps/index.md
+++ b/files/ja/learn/css/first_steps/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSS の第一歩
 slug: Learn/CSS/First_steps
-tags:
-  - Beginner
-  - CSS
-  - Landing
-  - Learn
-  - Module
-  - first steps
-translation_of: Learn/CSS/First_steps
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/css/first_steps/styling_a_biography_page/index.md
+++ b/files/ja/learn/css/first_steps/styling_a_biography_page/index.md
@@ -1,12 +1,6 @@
 ---
 title: 新しい知識を使う
 slug: Learn/CSS/First_steps/Styling_a_biography_page
-tags:
-  - Beginner
-  - CSS
-  - Learn
-  - Playground
-translation_of: Learn/CSS/First_steps/Using_your_new_knowledge
 original_slug: Learn/CSS/First_steps/Using_your_new_knowledge
 ---
 {{LearnSidebar}}{{PreviousMenu("Learn/CSS/First_steps/How_CSS_works", "Learn/CSS/First_steps")}}

--- a/files/ja/learn/css/first_steps/what_is_css/index.md
+++ b/files/ja/learn/css/first_steps/what_is_css/index.md
@@ -1,15 +1,6 @@
 ---
 title: CSSとは何か？
 slug: Learn/CSS/First_steps/What_is_CSS
-tags:
-  - Beginner
-  - CSS
-  - Introduction to CSS
-  - Learn
-  - Modules
-  - Specifications
-  - Syntax
-translation_of: Learn/CSS/First_steps/What_is_CSS
 ---
 {{LearnSidebar}}{{NextMenu("Learn/CSS/First_steps/Getting_started", "Learn/CSS/First_steps")}}
 

--- a/files/ja/learn/css/howto/create_fancy_boxes/index.md
+++ b/files/ja/learn/css/howto/create_fancy_boxes/index.md
@@ -1,12 +1,6 @@
 ---
 title: 装飾的なボックスの作成
 slug: Learn/CSS/Howto/create_fancy_boxes
-tags:
-  - Beginner
-  - CSS
-  - CodingScripting
-  - Learn
-translation_of: Learn/CSS/Howto/create_fancy_boxes
 ---
 CSS ボックスは、CSS で装飾されたウェブページの構成要素です。 見栄えを良くすることは、楽しさとやりがいの両方です。 デザインのアイデアを実用的なコードに変えることがすべてだからです。 面倒な制約と CSS の使用における狂気の自由のために、それは挑戦的です。 いくつかの装飾的なボックスをやりましょう。
 

--- a/files/ja/learn/css/howto/css_faq/index.md
+++ b/files/ja/learn/css/howto/css_faq/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSS の一般的な質問
 slug: Learn/CSS/Howto/CSS_FAQ
-tags:
-  - CSS
-  - FAQ
-  - Web
-  - questions
-  - ガイド
-  - 例
-translation_of: Learn/CSS/Howto/CSS_FAQ
 original_slug: Web/CSS/Common_CSS_Questions
 ---
 この記事には、 CSS に関するいくつかのよくある質問（FAQ）とその解答が見つかり、ウェブ開発者になるための道で役に立つでしょう。

--- a/files/ja/learn/css/howto/generated_content/index.md
+++ b/files/ja/learn/css/howto/generated_content/index.md
@@ -1,16 +1,6 @@
 ---
 title: CSS 生成コンテンツの使用
 slug: Learn/CSS/Howto/Generated_content
-tags:
-  - 基本
-  - 初心者
-  - CSS
-  - CSS:Getting_Started
-  - グラフィック
-  - ガイド
-  - NeedsUpdate
-  - ウェブ
-translation_of: Learn/CSS/Howto/Generated_content
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/css/howto/index.md
+++ b/files/ja/learn/css/howto/index.md
@@ -1,11 +1,6 @@
 ---
 title: CSS を使ってよくある問題を解決する
 slug: Learn/CSS/Howto
-tags:
-  - Beginner
-  - CSS
-  - Learn
-translation_of: Learn/CSS/Howto
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/css/index.md
+++ b/files/ja/learn/css/index.md
@@ -1,17 +1,6 @@
 ---
 title: CSS
 slug: Learn/CSS
-tags:
-  - Beginner
-  - CSS
-  - CodingScripting
-  - Debugging
-  - Landing
-  - NeedsContent
-  - Topic
-  - length
-  - specificity
-translation_of: Learn/CSS
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/css/styling_text/fundamentals/index.md
+++ b/files/ja/learn/css/styling_text/fundamentals/index.md
@@ -1,20 +1,6 @@
 ---
 title: 基本的なテキストとフォントの装飾
 slug: Learn/CSS/Styling_text/Fundamentals
-tags:
-  - Article
-  - Beginner
-  - CSS
-  - Guide
-  - Style
-  - Text
-  - alignment
-  - family
-  - font
-  - shorthand
-  - spacing
-  - weight
-translation_of: Learn/CSS/Styling_text/Fundamentals
 ---
 {{LearnSidebar}}{{NextMenu("Learn/CSS/Styling_text/Styling_lists", "Learn/CSS/Styling_text")}}
 

--- a/files/ja/learn/css/styling_text/index.md
+++ b/files/ja/learn/css/styling_text/index.md
@@ -1,22 +1,6 @@
 ---
 title: テキストの装飾
 slug: Learn/CSS/Styling_text
-tags:
-  - Beginner
-  - CSS
-  - CodingScripting
-  - Fonts
-  - Landing
-  - Links
-  - Module
-  - Text
-  - font
-  - letter
-  - line
-  - lists
-  - shadow
-  - web fonts
-translation_of: Learn/CSS/Styling_text
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/css/styling_text/styling_links/index.md
+++ b/files/ja/learn/css/styling_text/styling_links/index.md
@@ -1,20 +1,6 @@
 ---
 title: リンクの装飾
 slug: Learn/CSS/Styling_text/Styling_links
-tags:
-  - Article
-  - Beginner
-  - CSS
-  - Focus
-  - Guide
-  - Learn
-  - Links
-  - Pseudo-class
-  - hover
-  - hyperlinks
-  - menus
-  - tabs
-translation_of: Learn/CSS/Styling_text/Styling_links
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Styling_text/Styling_lists", "Learn/CSS/Styling_text/Web_fonts", "Learn/CSS/Styling_text")}}
 

--- a/files/ja/learn/css/styling_text/styling_lists/index.md
+++ b/files/ja/learn/css/styling_text/styling_lists/index.md
@@ -1,16 +1,6 @@
 ---
 title: リストの装飾
 slug: Learn/CSS/Styling_text/Styling_lists
-tags:
-  - Article
-  - Beginner
-  - CSS
-  - Guide
-  - Styling
-  - Text
-  - bullets
-  - lists
-translation_of: Learn/CSS/Styling_text/Styling_lists
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Styling_text/Fundamentals", "Learn/CSS/Styling_text/Styling_links", "Learn/CSS/Styling_text")}}
 

--- a/files/ja/learn/css/styling_text/typesetting_a_homepage/index.md
+++ b/files/ja/learn/css/styling_text/typesetting_a_homepage/index.md
@@ -1,17 +1,6 @@
 ---
 title: コミュニティスクールのホームページの組版
 slug: Learn/CSS/Styling_text/Typesetting_a_homepage
-tags:
-  - Assessment
-  - Beginner
-  - CSS
-  - CodingScripting
-  - Link
-  - Styling text
-  - font
-  - list
-  - web font
-translation_of: Learn/CSS/Styling_text/Typesetting_a_homepage
 ---
 {{LearnSidebar}}{{PreviousMenu("Learn/CSS/Styling_text/Web_fonts", "Learn/CSS/Styling_text")}}
 

--- a/files/ja/learn/css/styling_text/web_fonts/index.md
+++ b/files/ja/learn/css/styling_text/web_fonts/index.md
@@ -1,21 +1,6 @@
 ---
 title: ウェブフォント
 slug: Learn/CSS/Styling_text/Web_fonts
-tags:
-  - '@font-face'
-  - Article
-  - Beginner
-  - CSS
-  - CSS Fonts
-  - Fonts
-  - Guide
-  - Learn
-  - Web Development
-  - Web Fonts Article
-  - Web fonts documentation
-  - font-family
-  - web fonts
-translation_of: Learn/CSS/Styling_text/Web_fonts
 original_slug: Learn/CSS/Styling_text/ウェブフォント
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Styling_text/Styling_links", "Learn/CSS/Styling_text/Typesetting_a_homepage", "Learn/CSS/Styling_text")}}

--- a/files/ja/learn/forms/advanced_form_styling/index.md
+++ b/files/ja/learn/forms/advanced_form_styling/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTML フォームへの高度なスタイル設定
 slug: Learn/Forms/Advanced_form_styling
-tags:
-  - Advanced
-  - CSS
-  - Forms
-  - HTML
-  - Web
-  - ガイド
-  - 例
-translation_of: Learn/Forms/Advanced_form_styling
 original_slug: Learn/Forms/Advanced_styling_for_HTML_forms
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Forms/Styling_web_forms", "Learn/Forms/UI_pseudo-classes", "Learn/Forms")}}

--- a/files/ja/learn/forms/basic_native_form_controls/index.md
+++ b/files/ja/learn/forms/basic_native_form_controls/index.md
@@ -1,17 +1,6 @@
 ---
 title: 基本的なネイティブフォームコントロール
 slug: Learn/Forms/Basic_native_form_controls
-tags:
-  - Beginner
-  - Controls
-  - Example
-  - Forms
-  - Guide
-  - HTML
-  - Input
-  - Web
-  - Widgets
-translation_of: Learn/Forms/Basic_native_form_controls
 original_slug: Learn/Forms/The_native_form_widgets
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Forms/How_to_structure_a_web_form", "Learn/Forms/HTML5_input_types", "Learn/Forms")}}

--- a/files/ja/learn/forms/form_validation/index.md
+++ b/files/ja/learn/forms/form_validation/index.md
@@ -1,18 +1,6 @@
 ---
 title: クライアント側のフォームデータ検証
 slug: Learn/Forms/Form_validation
-tags:
-  - HTML
-  - Intermediate
-  - JavaScript
-  - Web
-  - ウェブ
-  - ガイド
-  - フォーム
-  - フォーム検証
-  - 中級者向け
-  - 例
-translation_of: Learn/Forms/Form_validation
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Forms/UI_pseudo-classes", "Learn/Forms/Sending_and_retrieving_form_data", "Learn/HTML/Forms")}}
 

--- a/files/ja/learn/forms/how_to_build_custom_form_controls/example_1/index.md
+++ b/files/ja/learn/forms/how_to_build_custom_form_controls/example_1/index.md
@@ -1,7 +1,6 @@
 ---
 title: 例 1
 slug: Learn/Forms/How_to_build_custom_form_controls/Example_1
-translation_of: Learn/Forms/How_to_build_custom_form_controls/Example_1
 original_slug: Learn/Forms/How_to_build_custom_form_widgets/Example_1
 ---
 これは、[カスタムフォームウィジェットの作成方法](/ja/docs/Learn/HTML/Forms/How_to_build_custom_form_widgets)を説明する最初のコード例です。

--- a/files/ja/learn/forms/how_to_build_custom_form_controls/example_2/index.md
+++ b/files/ja/learn/forms/how_to_build_custom_form_controls/example_2/index.md
@@ -1,10 +1,6 @@
 ---
 title: 例 2
 slug: Learn/Forms/How_to_build_custom_form_controls/Example_2
-tags:
-  - Forms
-  - HTML
-translation_of: Learn/Forms/How_to_build_custom_form_controls/Example_2
 original_slug: Learn/Forms/How_to_build_custom_form_widgets/Example_2
 ---
 これは、[カスタムフォームウィジェットの作成方法](/ja/docs/Learn/HTML/Forms/How_to_build_custom_form_widgets)を説明する 2 番目の例です。

--- a/files/ja/learn/forms/how_to_build_custom_form_controls/example_3/index.md
+++ b/files/ja/learn/forms/how_to_build_custom_form_controls/example_3/index.md
@@ -1,10 +1,6 @@
 ---
 title: 例 3
 slug: Learn/Forms/How_to_build_custom_form_controls/Example_3
-tags:
-  - Forms
-  - HTML
-translation_of: Learn/Forms/How_to_build_custom_form_controls/Example_3
 original_slug: Learn/Forms/How_to_build_custom_form_widgets/Example_3
 ---
 これは、[カスタムフォームウィジェットの作成方法](/ja/docs/Learn/HTML/Forms/How_to_build_custom_form_widgets)を説明する 3 番目の例です。

--- a/files/ja/learn/forms/how_to_build_custom_form_controls/example_4/index.md
+++ b/files/ja/learn/forms/how_to_build_custom_form_controls/example_4/index.md
@@ -1,14 +1,6 @@
 ---
 title: 例 4
 slug: Learn/Forms/How_to_build_custom_form_controls/Example_4
-tags:
-  - Advanced
-  - Example
-  - Forms
-  - Guide
-  - HTML
-  - Web
-translation_of: Learn/Forms/How_to_build_custom_form_controls/Example_4
 original_slug: Learn/Forms/How_to_build_custom_form_widgets/Example_4
 ---
 これは、[カスタムフォームウィジェットの作成方法](/ja/docs/Learn/HTML/Forms/How_to_build_custom_form_widgets)を説明する 4 番目の例です。

--- a/files/ja/learn/forms/how_to_build_custom_form_controls/example_5/index.md
+++ b/files/ja/learn/forms/how_to_build_custom_form_controls/example_5/index.md
@@ -1,10 +1,6 @@
 ---
 title: 例 5
 slug: Learn/Forms/How_to_build_custom_form_controls/Example_5
-tags:
-  - Forms
-  - HTML
-translation_of: Learn/Forms/How_to_build_custom_form_controls/Example_5
 original_slug: Learn/Forms/How_to_build_custom_form_widgets/Example_5
 ---
 これが、[カスタムフォームウィジェットの作成方法](/ja/docs/Learn/HTML/Forms/How_to_build_custom_form_widgets)を説明する最後の例です。

--- a/files/ja/learn/forms/how_to_build_custom_form_controls/index.md
+++ b/files/ja/learn/forms/how_to_build_custom_form_controls/index.md
@@ -1,14 +1,6 @@
 ---
 title: カスタムフォームコントロールの作成方法
 slug: Learn/Forms/How_to_build_custom_form_controls
-tags:
-  - Advanced
-  - Example
-  - Forms
-  - Guide
-  - HTML
-  - Web
-translation_of: Learn/Forms/How_to_build_custom_form_controls
 original_slug: Learn/Forms/How_to_build_custom_form_widgets
 ---
 {{LearnSidebar}}

--- a/files/ja/learn/forms/how_to_structure_a_web_form/example/index.md
+++ b/files/ja/learn/forms/how_to_structure_a_web_form/example/index.md
@@ -1,7 +1,6 @@
 ---
 title: '例: お支払いフォーム'
 slug: Learn/Forms/How_to_structure_a_web_form/Example
-translation_of: Learn/Forms/How_to_structure_a_web_form/Example
 original_slug: Learn/Forms/How_to_structure_an_HTML_form/Example
 ---
 これは記事 [HTML フォームの構築方法](/ja/docs/Learn/HTML/Forms/How_to_structure_an_HTML_form)の基本的なお支払いフォームの例です。

--- a/files/ja/learn/forms/how_to_structure_a_web_form/index.md
+++ b/files/ja/learn/forms/how_to_structure_a_web_form/index.md
@@ -1,17 +1,6 @@
 ---
 title: フォームの構築方法
 slug: Learn/Forms/How_to_structure_a_web_form
-tags:
-  - CodingScripting
-  - HTML
-  - Web
-  - ガイド
-  - フォーム
-  - 例
-  - 初心者
-  - 学習
-  - 構造
-translation_of: Learn/Forms/How_to_structure_a_web_form
 original_slug: Learn/Forms/How_to_structure_an_HTML_form
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Forms/Your_first_form", "Learn/Forms/Basic_native_form_controls", "Learn/Forms")}}

--- a/files/ja/learn/forms/html5_input_types/index.md
+++ b/files/ja/learn/forms/html5_input_types/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTML5 入力タイプ
 slug: Learn/Forms/HTML5_input_types
-tags:
-  - Beginner
-  - Controls
-  - Example
-  - Forms
-  - Guide
-  - HTML
-  - Web
-  - Widgets
-translation_of: Learn/Forms/HTML5_input_types
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Forms/Basic_native_form_controls", "Learn/Forms/Other_form_controls", "Learn/Forms")}}
 

--- a/files/ja/learn/forms/html_forms_in_legacy_browsers/index.md
+++ b/files/ja/learn/forms/html_forms_in_legacy_browsers/index.md
@@ -1,14 +1,6 @@
 ---
 title: 古いブラウザーでの HTML フォーム
 slug: Learn/Forms/HTML_forms_in_legacy_browsers
-tags:
-  - Example
-  - Forms
-  - Guide
-  - HTML
-  - Intermediate
-  - Web
-translation_of: Learn/Forms/HTML_forms_in_legacy_browsers
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/forms/index.md
+++ b/files/ja/learn/forms/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTML フォーム
 slug: Learn/Forms
-tags:
-  - Beginner
-  - Featured
-  - Forms
-  - Guide
-  - HTML
-  - Landing
-  - Learn
-  - Web
-translation_of: Learn/Forms
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/forms/other_form_controls/index.md
+++ b/files/ja/learn/forms/other_form_controls/index.md
@@ -1,16 +1,6 @@
 ---
 title: その他のフォームコントロール
 slug: Learn/Forms/Other_form_controls
-tags:
-  - Beginner
-  - Controls
-  - Example
-  - Forms
-  - Guide
-  - HTML
-  - Web
-  - Widgets
-translation_of: Learn/Forms/Other_form_controls
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Forms/HTML5_input_types","Learn/Forms/Styling_HTML_forms", "Learn/Forms")}}
 

--- a/files/ja/learn/forms/property_compatibility_table_for_form_controls/index.md
+++ b/files/ja/learn/forms/property_compatibility_table_for_form_controls/index.md
@@ -1,19 +1,6 @@
 ---
 title: フォームウィジェット向けプロパティ実装状況一覧
 slug: Learn/Forms/Property_compatibility_table_for_form_controls
-tags:
-  - Advanced
-  - CSS
-  - Forms
-  - Guide
-  - HTML
-  - NeedsUpdate
-  - Web
-  - ウェブ
-  - ガイド
-  - フォーム
-  - 高度
-translation_of: Learn/Forms/Property_compatibility_table_for_form_controls
 ---
 {{learnsidebar}}
 

--- a/files/ja/learn/forms/sending_and_retrieving_form_data/index.md
+++ b/files/ja/learn/forms/sending_and_retrieving_form_data/index.md
@@ -1,18 +1,6 @@
 ---
 title: フォームデータの送信
 slug: Learn/Forms/Sending_and_retrieving_form_data
-tags:
-  - 初心者
-  - CodingScripting
-  - ファイル
-  - フォーム
-  - ガイド
-  - HTML
-  - HTTP
-  - ヘッダー
-  - セキュリティ
-  - Web
-translation_of: Learn/Forms/Sending_and_retrieving_form_data
 ---
 {{LearnSidebar}}{{PreviousMenu("Learn/Forms/Form_validation", "Learn/Forms")}}
 

--- a/files/ja/learn/forms/sending_forms_through_javascript/index.md
+++ b/files/ja/learn/forms/sending_forms_through_javascript/index.md
@@ -1,20 +1,6 @@
 ---
 title: JavaScript によるフォームの送信
 slug: Learn/Forms/Sending_forms_through_JavaScript
-tags:
-  - Advanced
-  - Example
-  - Forms
-  - Forms Guide
-  - Guide
-  - HTML
-  - HTML forms
-  - JavaScript
-  - Learn
-  - Security
-  - Web
-  - Web Forms
-translation_of: Learn/Forms/Sending_forms_through_JavaScript
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/forms/styling_web_forms/index.md
+++ b/files/ja/learn/forms/styling_web_forms/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTML フォームへのスタイル設定
 slug: Learn/Forms/Styling_web_forms
-tags:
-  - CSS
-  - Example
-  - Forms
-  - Guide
-  - HTML
-  - Intermediate
-  - Web
-translation_of: Learn/Forms/Styling_web_forms
 original_slug: Learn/Forms/Styling_HTML_forms
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Forms/Other_form_controls","Learn/Forms/Advanced_form_styling","Learn/Forms")}}

--- a/files/ja/learn/forms/ui_pseudo-classes/index.md
+++ b/files/ja/learn/forms/ui_pseudo-classes/index.md
@@ -1,17 +1,6 @@
 ---
 title: UI 擬似クラス
 slug: Learn/Forms/UI_pseudo-classes
-tags:
-  - Beginner
-  - CSS
-  - Example
-  - Forms
-  - Guide
-  - HTML
-  - Pseudo-classes
-  - Styling
-  - Web
-translation_of: Learn/Forms/UI_pseudo-classes
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Forms/Advanced_form_styling", "Learn/Forms/Form_validation", "Learn/Forms")}}
 

--- a/files/ja/learn/forms/your_first_form/index.md
+++ b/files/ja/learn/forms/your_first_form/index.md
@@ -1,17 +1,6 @@
 ---
 title: 初めてのフォーム
 slug: Learn/Forms/Your_first_form
-tags:
-  - Beginner
-  - CSS
-  - CodingScripting
-  - Example
-  - Forms
-  - Guide
-  - HTML
-  - Learn
-  - Web
-translation_of: Learn/Forms/Your_first_form
 ---
 {{LearnSidebar}}{{NextMenu("Learn/Forms/How_to_structure_a_web_form", "Learn/Forms")}}
 

--- a/files/ja/learn/front-end_web_developer/index.md
+++ b/files/ja/learn/front-end_web_developer/index.md
@@ -1,7 +1,6 @@
 ---
 title: フロントエンドウェブ開発者
 slug: Learn/Front-end_web_developer
-translation_of: Learn/Front-end_web_developer
 ---
 {{learnsidebar}}
 

--- a/files/ja/learn/getting_started_with_the_web/css_basics/index.md
+++ b/files/ja/learn/getting_started_with_the_web/css_basics/index.md
@@ -1,17 +1,6 @@
 ---
 title: CSS の基本
 slug: Learn/Getting_started_with_the_web/CSS_basics
-tags:
-  - Beginner
-  - CSS
-  - CodingScripting
-  - Learn
-  - Styling
-  - Web
-  - l10n:priority
-  - 初心者
-  - 学習
-translation_of: Learn/Getting_started_with_the_web/CSS_basics
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Getting_started_with_the_web/HTML_basics", "Learn/Getting_started_with_the_web/JavaScript_basics", "Learn/Getting_started_with_the_web")}}
 

--- a/files/ja/learn/getting_started_with_the_web/dealing_with_files/index.md
+++ b/files/ja/learn/getting_started_with_the_web/dealing_with_files/index.md
@@ -1,16 +1,6 @@
 ---
 title: ファイルの扱い
 slug: Learn/Getting_started_with_the_web/Dealing_with_files
-tags:
-  - Beginner
-  - CodingScripting
-  - Files
-  - HTML
-  - l10n:priority
-  - theory
-  - website
-  - ガイド
-translation_of: Learn/Getting_started_with_the_web/Dealing_with_files
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Getting_started_with_the_web/What_will_your_website_look_like", "Learn/Getting_started_with_the_web/HTML_basics", "Learn/Getting_started_with_the_web")}}
 

--- a/files/ja/learn/getting_started_with_the_web/how_the_web_works/index.md
+++ b/files/ja/learn/getting_started_with_the_web/how_the_web_works/index.md
@@ -1,22 +1,6 @@
 ---
 title: ウェブのしくみ
 slug: Learn/Getting_started_with_the_web/How_the_Web_works
-tags:
-  - Beginner
-  - Client
-  - DNS
-  - HTTP
-  - IP
-  - Infrastructure
-  - Learn
-  - Server
-  - TCP
-  - l10n:priority
-  - クライアント
-  - サーバー
-  - 初心者
-  - 学習
-translation_of: Learn/Getting_started_with_the_web/How_the_Web_works
 ---
 {{LearnSidebar}}{{PreviousMenu("Learn/Getting_started_with_the_web/Publishing_your_website", "Learn/Getting_started_with_the_web")}}
 

--- a/files/ja/learn/getting_started_with_the_web/html_basics/index.md
+++ b/files/ja/learn/getting_started_with_the_web/html_basics/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTML の基本
 slug: Learn/Getting_started_with_the_web/HTML_basics
-tags:
-  - Beginner
-  - CodingScripting
-  - Doctype html
-  - HTML
-  - Learn
-  - Web
-  - l10n:priority
-translation_of: Learn/Getting_started_with_the_web/HTML_basics
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Getting_started_with_the_web/Dealing_with_files", "Learn/Getting_started_with_the_web/CSS_basics", "Learn/Getting_started_with_the_web")}}
 

--- a/files/ja/learn/getting_started_with_the_web/index.md
+++ b/files/ja/learn/getting_started_with_the_web/index.md
@@ -1,17 +1,6 @@
 ---
 title: ウェブ入門
 slug: Learn/Getting_started_with_the_web
-tags:
-  - Beginner
-  - CSS
-  - Design
-  - Guide
-  - HTML
-  - Index
-  - l10n:priority
-  - publishing
-  - theory
-translation_of: Learn/Getting_started_with_the_web
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/getting_started_with_the_web/installing_basic_software/index.md
+++ b/files/ja/learn/getting_started_with_the_web/installing_basic_software/index.md
@@ -1,16 +1,6 @@
 ---
 title: 基本的なソフトウェアのインストール
 slug: Learn/Getting_started_with_the_web/Installing_basic_software
-tags:
-  - WebMechanics
-  - l10n:priority
-  - セットアップ
-  - ツール
-  - テキストエディタ
-  - ブラウザー
-  - 初心者
-  - 学習
-translation_of: Learn/Getting_started_with_the_web/Installing_basic_software
 ---
 {{LearnSidebar}}{{NextMenu("Learn/Getting_started_with_the_web/What_will_your_website_look_like", "Learn/Getting_started_with_the_web")}}
 

--- a/files/ja/learn/getting_started_with_the_web/javascript_basics/index.md
+++ b/files/ja/learn/getting_started_with_the_web/javascript_basics/index.md
@@ -1,14 +1,6 @@
 ---
 title: JavaScript の基本
 slug: Learn/Getting_started_with_the_web/JavaScript_basics
-tags:
-  - Beginner
-  - CodingScripting
-  - JavaScript
-  - Learn
-  - Web
-  - l10n:priority
-translation_of: Learn/Getting_started_with_the_web/JavaScript_basics
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Getting_started_with_the_web/CSS_basics", "Learn/Getting_started_with_the_web/Publishing_your_website", "Learn/Getting_started_with_the_web")}}
 

--- a/files/ja/learn/getting_started_with_the_web/publishing_your_website/index.md
+++ b/files/ja/learn/getting_started_with_the_web/publishing_your_website/index.md
@@ -1,20 +1,6 @@
 ---
 title: ウェブサイトの公開
 slug: Learn/Getting_started_with_the_web/Publishing_your_website
-tags:
-  - Beginner
-  - CodingScripting
-  - FTP
-  - GitHub
-  - Google App Engine
-  - Learn
-  - Web
-  - l10n:priority
-  - publishing
-  - web server
-  - 初心者
-  - 学習
-translation_of: Learn/Getting_started_with_the_web/Publishing_your_website
 original_slug: Learn/Getting_started_with_the_web/ウェブサイトを公開する
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Getting_started_with_the_web/JavaScript_basics", "Learn/Getting_started_with_the_web/How_the_Web_works", "Learn/Getting_started_with_the_web")}}

--- a/files/ja/learn/getting_started_with_the_web/what_will_your_website_look_like/index.md
+++ b/files/ja/learn/getting_started_with_the_web/what_will_your_website_look_like/index.md
@@ -1,18 +1,6 @@
 ---
 title: Web サイトをどんな外見にするか
 slug: Learn/Getting_started_with_the_web/What_will_your_website_look_like
-tags:
-  - Assets
-  - Composing
-  - Deprecated
-  - Plan
-  - l10n:priority
-  - コンテンツ
-  - デザイン
-  - フォント
-  - 初心者
-  - 学習
-translation_of: Learn/Getting_started_with_the_web/What_will_your_website_look_like
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Getting_started_with_the_web/Installing_basic_software", "Learn/Getting_started_with_the_web/Dealing_with_files", "Learn/Getting_started_with_the_web")}}
 

--- a/files/ja/learn/html/howto/add_a_hit_map_on_top_of_an_image/index.md
+++ b/files/ja/learn/html/howto/add_a_hit_map_on_top_of_an_image/index.md
@@ -1,13 +1,6 @@
 ---
 title: 画像にヒットマップを追加する
 slug: Learn/HTML/Howto/Add_a_hit_map_on_top_of_an_image
-tags:
-  - Graphics
-  - Guide
-  - HTML
-  - Intermediate
-  - Navigation
-translation_of: Learn/HTML/Howto/Add_a_hit_map_on_top_of_an_image
 ---
 ここでは、イメージマップを設定する方法と、最初に検討すべきいくつかの欠点を説明します。
 

--- a/files/ja/learn/html/howto/author_fast-loading_html_pages/index.md
+++ b/files/ja/learn/html/howto/author_fast-loading_html_pages/index.md
@@ -1,15 +1,6 @@
 ---
 title: 読み込みが速い HTML ページを作成するための豆知識
 slug: Learn/HTML/Howto/Author_fast-loading_HTML_pages
-tags:
-  - Advanced
-  - Guide
-  - HTML
-  - NeedsUpdate
-  - Performance
-  - Web
-  - Web Performance
-translation_of: Learn/HTML/Howto/Author_fast-loading_HTML_pages
 original_slug: Web/Guide/HTML/Tips_for_authoring_fast-loading_HTML_pages
 ---
 これらの豆知識は、一般の知識や実験に基づくものです。

--- a/files/ja/learn/html/howto/define_terms_with_html/index.md
+++ b/files/ja/learn/html/howto/define_terms_with_html/index.md
@@ -1,12 +1,6 @@
 ---
 title: HTML で用語を定義する
 slug: Learn/HTML/Howto/Define_terms_with_HTML
-tags:
-  - Beginner
-  - Guide
-  - HTML
-  - Learn
-translation_of: Learn/HTML/Howto/Define_terms_with_HTML
 ---
 HTML は、インラインであろうと構造化された用語集であろうと、記述の意味を伝達するいくつかの方法を提供します。 この記事では、キーワードを定義する際に適切にマークアップする方法について説明します。
 

--- a/files/ja/learn/html/howto/index.md
+++ b/files/ja/learn/html/howto/index.md
@@ -1,10 +1,6 @@
 ---
 title: 一般的な問題解決に HTML を使う
 slug: Learn/HTML/Howto
-tags:
-  - CodingScripting
-  - HTML
-translation_of: Learn/HTML/Howto
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/html/howto/use_data_attributes/index.md
+++ b/files/ja/learn/html/howto/use_data_attributes/index.md
@@ -1,14 +1,6 @@
 ---
 title: データ属性の使用
 slug: Learn/HTML/Howto/Use_data_attributes
-tags:
-  - HTML
-  - HTML5
-  - ウェブ
-  - ガイド
-  - 例
-  - 独自データ属性
-translation_of: Learn/HTML/Howto/Use_data_attributes
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/html/howto/use_javascript_within_a_webpage/index.md
+++ b/files/ja/learn/html/howto/use_javascript_within_a_webpage/index.md
@@ -1,12 +1,6 @@
 ---
 title: ウェブページで JavaScript を使う方法
 slug: Learn/HTML/Howto/Use_JavaScript_within_a_webpage
-tags:
-  - Beginner
-  - HTML
-  - JavaScript
-  - OpenPractices
-translation_of: Learn/HTML/Howto/Use_JavaScript_within_a_webpage
 ---
 Take your webpages to the next level by harnessing JavaScript. Learn in this article how to trigger JavaScript right from your HTML documents.
 

--- a/files/ja/learn/html/index.md
+++ b/files/ja/learn/html/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'HTML の学習: ガイドとチュートリアル'
 slug: Learn/HTML
-tags:
-  - Beginner
-  - Guide
-  - HTML
-  - Intro
-  - Learn
-  - Topic
-  - ガイド
-  - トピック
-  - 初心者
-  - 学習
-  - 導入
-translation_of: Learn/HTML
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/html/introduction_to_html/advanced_text_formatting/index.md
+++ b/files/ja/learn/html/introduction_to_html/advanced_text_formatting/index.md
@@ -1,18 +1,6 @@
 ---
 title: 高度なテキスト処理
 slug: Learn/HTML/Introduction_to_HTML/Advanced_text_formatting
-tags:
-  - Beginner
-  - CodingScripting
-  - Guide
-  - HTML
-  - Learn
-  - Text
-  - abbreviation
-  - description list
-  - quote
-  - semantic
-translation_of: Learn/HTML/Introduction_to_HTML/Advanced_text_formatting
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/Creating_hyperlinks", "Learn/HTML/Introduction_to_HTML/Document_and_website_structure", "Learn/HTML/Introduction_to_HTML")}}
 

--- a/files/ja/learn/html/introduction_to_html/creating_hyperlinks/index.md
+++ b/files/ja/learn/html/introduction_to_html/creating_hyperlinks/index.md
@@ -1,19 +1,6 @@
 ---
 title: ハイパーリンクの作成
 slug: Learn/HTML/Introduction_to_HTML/Creating_hyperlinks
-tags:
-  - Beginner
-  - CodingScripting
-  - Guide
-  - HTML
-  - Learn
-  - Links
-  - Title
-  - absolute
-  - hyperlinks
-  - relative
-  - urls
-translation_of: Learn/HTML/Introduction_to_HTML/Creating_hyperlinks
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals", "Learn/HTML/Introduction_to_HTML/Advanced_text_formatting", "Learn/HTML/Introduction_to_HTML")}}
 

--- a/files/ja/learn/html/introduction_to_html/debugging_html/index.md
+++ b/files/ja/learn/html/introduction_to_html/debugging_html/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTML のデバッグ
 slug: Learn/HTML/Introduction_to_HTML/Debugging_HTML
-tags:
-  - CodingScripting
-  - HTML
-  - エラー
-  - ガイド
-  - デバッグ
-  - バリデーション
-  - バリデーター
-  - ビギナー
-translation_of: Learn/HTML/Introduction_to_HTML/Debugging_HTML
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/Document_and_website_structure", "Learn/HTML/Introduction_to_HTML/Marking_up_a_letter", "Learn/HTML/Introduction_to_HTML")}}
 

--- a/files/ja/learn/html/introduction_to_html/document_and_website_structure/index.md
+++ b/files/ja/learn/html/introduction_to_html/document_and_website_structure/index.md
@@ -1,17 +1,6 @@
 ---
 title: ドキュメントと Web サイトの構造
 slug: Learn/HTML/Introduction_to_HTML/Document_and_website_structure
-tags:
-  - Beginner
-  - CodingScripting
-  - Guide
-  - HTML
-  - Layout
-  - Page
-  - Site
-  - blocks
-  - semantics
-translation_of: Learn/HTML/Introduction_to_HTML/Document_and_website_structure
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/Advanced_text_formatting", "Learn/HTML/Introduction_to_HTML/Debugging_HTML", "Learn/HTML/Introduction_to_HTML")}}
 

--- a/files/ja/learn/html/introduction_to_html/getting_started/index.md
+++ b/files/ja/learn/html/introduction_to_html/getting_started/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTML を始めよう
 slug: Learn/HTML/Introduction_to_HTML/Getting_started
-tags:
-  - Attribute
-  - Beginner
-  - CodingScripting
-  - Comment
-  - Element
-  - Guide
-  - HTML
-  - entity reference
-  - whitespace
-translation_of: Learn/HTML/Introduction_to_HTML/Getting_started
 ---
 {{LearnSidebar}}{{NextMenu("Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML", "Learn/HTML/Introduction_to_HTML")}}
 

--- a/files/ja/learn/html/introduction_to_html/html_text_fundamentals/index.md
+++ b/files/ja/learn/html/introduction_to_html/html_text_fundamentals/index.md
@@ -1,18 +1,6 @@
 ---
 title: HTML テキストの基礎
 slug: Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals
-tags:
-  - Beginner
-  - CodingScripting
-  - Guide
-  - HTML
-  - Introduction to HTML
-  - Learn
-  - Text
-  - headings
-  - paragraphs
-  - semantics
-translation_of: Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML", "Learn/HTML/Introduction_to_HTML/Creating_hyperlinks", "Learn/HTML/Introduction_to_HTML")}}
 

--- a/files/ja/learn/html/introduction_to_html/index.md
+++ b/files/ja/learn/html/introduction_to_html/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTML 入門
 slug: Learn/HTML/Introduction_to_HTML
-tags:
-  - CodingScripting
-  - HTML
-  - Introduction to HTML
-  - Landing
-  - Links
-  - Structure
-  - Text
-  - head
-  - semantics
-translation_of: Learn/HTML/Introduction_to_HTML
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/html/introduction_to_html/marking_up_a_letter/index.md
+++ b/files/ja/learn/html/introduction_to_html/marking_up_a_letter/index.md
@@ -1,15 +1,6 @@
 ---
 title: 手紙をマークアップする
 slug: Learn/HTML/Introduction_to_HTML/Marking_up_a_letter
-tags:
-  - Beginner
-  - CodingScripting
-  - HTML
-  - head
-  - テキスト
-  - リンク
-  - 評価
-translation_of: Learn/HTML/Introduction_to_HTML/Marking_up_a_letter
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/Debugging_HTML", "Learn/HTML/Introduction_to_HTML/Structuring_a_page_of_content", "Learn/HTML/Introduction_to_HTML")}}私たちはみんな遅かれ早かれ手紙を書くことを学びます。
 

--- a/files/ja/learn/html/introduction_to_html/structuring_a_page_of_content/index.md
+++ b/files/ja/learn/html/introduction_to_html/structuring_a_page_of_content/index.md
@@ -1,17 +1,6 @@
 ---
 title: コンテンツページを構造化する
 slug: Learn/HTML/Introduction_to_HTML/Structuring_a_page_of_content
-tags:
-  - Beginner
-  - CodingScripting
-  - HTML
-  - セマンティクス
-  - デザイン
-  - レイアウト
-  - 学習
-  - 構造
-  - 評価
-translation_of: Learn/HTML/Introduction_to_HTML/Structuring_a_page_of_content
 ---
 {{LearnSidebar}}{{PreviousMenu("Learn/HTML/Introduction_to_HTML/Marking_up_a_letter", "Learn/HTML/Introduction_to_HTML")}}
 

--- a/files/ja/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/ja/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -1,17 +1,6 @@
 ---
 title: head には何が入る? HTML のメタデータ
 slug: Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML
-tags:
-  - Beginner
-  - CodingScripting
-  - Guide
-  - HTML
-  - Meta
-  - favicon
-  - head
-  - lang
-  - metadata
-translation_of: Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/Getting_started", "Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals", "Learn/HTML/Introduction_to_HTML")}}
 

--- a/files/ja/learn/html/multimedia_and_embedding/adding_vector_graphics_to_the_web/index.md
+++ b/files/ja/learn/html/multimedia_and_embedding/adding_vector_graphics_to_the_web/index.md
@@ -1,26 +1,6 @@
 ---
 title: ウェブにベクターグラフィックスを追加する
 slug: Learn/HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web
-tags:
-  - Beginner
-  - Graphics
-  - Guide
-  - HTML
-  - Images
-  - Learn
-  - Raster
-  - SVG
-  - Vector
-  - iframe
-  - img
-  - ガイド
-  - グラフィックス
-  - ベクター
-  - ラスター
-  - 初心者
-  - 学習
-  - 画像
-translation_of: Learn/HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies", "Learn/HTML/Multimedia_and_embedding/Responsive_images", "Learn/HTML/Multimedia_and_embedding")}}
 

--- a/files/ja/learn/html/multimedia_and_embedding/images_in_html/index.md
+++ b/files/ja/learn/html/multimedia_and_embedding/images_in_html/index.md
@@ -1,24 +1,6 @@
 ---
 title: HTML の画像
 slug: Learn/HTML/Multimedia_and_embedding/Images_in_HTML
-tags:
-  - Beginner
-  - Guide
-  - HTML
-  - Image
-  - alt text
-  - captions
-  - figcaption
-  - figure
-  - img
-  - ガイド
-  - キャプション
-  - 代替テキスト
-  - 初心者
-  - 図表
-  - 画像
-  - 記事
-translation_of: Learn/HTML/Multimedia_and_embedding/Images_in_HTML
 ---
 {{LearnSidebar}}{{NextMenu("Learn/HTML/Multimedia_and_embedding/Video_and_audio_content", "Learn/HTML/Multimedia_and_embedding")}}
 

--- a/files/ja/learn/html/multimedia_and_embedding/index.md
+++ b/files/ja/learn/html/multimedia_and_embedding/index.md
@@ -1,34 +1,6 @@
 ---
 title: マルチメディアとその埋め込み方
 slug: Learn/HTML/Multimedia_and_embedding
-tags:
-  - Assessment
-  - Audio
-  - Beginner
-  - CodingScripting
-  - Flash
-  - Guide
-  - HTML
-  - Images
-  - Landing
-  - Learn
-  - SVG
-  - Video
-  - iframes
-  - imagemaps
-  - responsive
-  - イメージマップ
-  - ガイド
-  - フラッシュ
-  - レスポンシブ
-  - 初心者
-  - 動画
-  - 学習
-  - 画像
-  - 着地ページ
-  - 評価試験
-  - 音声
-translation_of: Learn/HTML/Multimedia_and_embedding
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/html/multimedia_and_embedding/mozilla_splash_page/index.md
+++ b/files/ja/learn/html/multimedia_and_embedding/mozilla_splash_page/index.md
@@ -1,26 +1,6 @@
 ---
 title: Mozilla のスプラッシュページ
 slug: Learn/HTML/Multimedia_and_embedding/Mozilla_splash_page
-tags:
-  - Assessment
-  - Beginner
-  - CodingScripting
-  - Embedding
-  - HTML
-  - Multimedia
-  - Video
-  - iframe
-  - picture
-  - responsive
-  - sizes
-  - srcset
-  - マルチメディア
-  - レスポンシブ
-  - 初心者
-  - 動画
-  - 埋め込み
-  - 評価試験
-translation_of: Learn/HTML/Multimedia_and_embedding/Mozilla_splash_page
 ---
 {{LearnSidebar}}{{PreviousMenu("Learn/HTML/Multimedia_and_embedding/Responsive_images", "Learn/HTML/Multimedia_and_embedding")}}
 

--- a/files/ja/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
+++ b/files/ja/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
@@ -1,20 +1,6 @@
 ---
 title: object から iframe へ — その他の埋め込み技術
 slug: Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies
-tags:
-  - Article
-  - Beginner
-  - CodingScripting
-  - Embedding
-  - Flash
-  - Guide
-  - HTML
-  - Learn
-  - Multimedia and embedding
-  - Object
-  - embed
-  - iframe
-translation_of: Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Multimedia_and_embedding/Video_and_audio_content", "Learn/HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web", "Learn/HTML/Multimedia_and_embedding")}}
 

--- a/files/ja/learn/html/multimedia_and_embedding/responsive_images/index.md
+++ b/files/ja/learn/html/multimedia_and_embedding/responsive_images/index.md
@@ -1,28 +1,6 @@
 ---
 title: レスポンシブ画像
 slug: Learn/HTML/Multimedia_and_embedding/Responsive_images
-tags:
-  - Article
-  - Beginner
-  - CodingScripting
-  - Design
-  - Graphics
-  - Guide
-  - HTML
-  - Image
-  - Intermediate
-  - img
-  - picture
-  - sizes
-  - srcset
-  - ガイド
-  - グラフィックス
-  - デザイン
-  - 中級
-  - 初心者
-  - 画像
-  - 記事
-translation_of: Learn/HTML/Multimedia_and_embedding/Responsive_images
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web", "Learn/HTML/Multimedia_and_embedding/Mozilla_splash_page", "Learn/HTML/Multimedia_and_embedding")}}
 

--- a/files/ja/learn/html/multimedia_and_embedding/video_and_audio_content/index.md
+++ b/files/ja/learn/html/multimedia_and_embedding/video_and_audio_content/index.md
@@ -1,22 +1,6 @@
 ---
 title: 動画と音声のコンテンツ
 slug: Learn/HTML/Multimedia_and_embedding/Video_and_audio_content
-tags:
-  - Article
-  - Audio
-  - Beginner
-  - Guide
-  - HTML
-  - Video
-  - captions
-  - subtitles
-  - track
-  - ガイド
-  - 初心者
-  - 動画
-  - 記事
-  - 音声
-translation_of: Learn/HTML/Multimedia_and_embedding/Video_and_audio_content
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Multimedia_and_embedding/Images_in_HTML", "Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies", "Learn/HTML/Multimedia_and_embedding")}}
 

--- a/files/ja/learn/html/tables/advanced/index.md
+++ b/files/ja/learn/html/tables/advanced/index.md
@@ -1,23 +1,6 @@
 ---
 title: HTML 表の高度な機能とアクセシビリティ
 slug: Learn/HTML/Tables/Advanced
-tags:
-  - Accessibility
-  - Advanced
-  - Article
-  - Beginner
-  - CodingScripting
-  - HTML
-  - Headers
-  - Learn
-  - caption
-  - scope
-  - sumary
-  - table
-  - tbody
-  - tfoot
-  - thead
-translation_of: Learn/HTML/Tables/Advanced
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Tables/Basics", "Learn/HTML/Tables/Structuring_planet_data", "Learn/HTML/Tables")}}
 

--- a/files/ja/learn/html/tables/basics/index.md
+++ b/files/ja/learn/html/tables/basics/index.md
@@ -1,22 +1,6 @@
 ---
 title: HTML の表の基本
 slug: Learn/HTML/Tables/Basics
-tags:
-  - Beginner
-  - CodingScripting
-  - HTML
-  - Learn
-  - basics
-  - col
-  - colgroup
-  - colspan
-  - header
-  - row
-  - rowspan
-  - セル
-  - テーブル
-  - 記事
-translation_of: Learn/HTML/Tables/Basics
 ---
 {{LearnSidebar}}{{NextMenu("Learn/HTML/Tables/Advanced", "Learn/HTML/Tables")}}
 

--- a/files/ja/learn/html/tables/index.md
+++ b/files/ja/learn/html/tables/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTML テーブル
 slug: Learn/HTML/Tables
-tags:
-  - Article
-  - Beginner
-  - CodingScripting
-  - Guide
-  - HTML
-  - Landing
-  - Module
-  - Tables
-translation_of: Learn/HTML/Tables
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/html/tables/structuring_planet_data/index.md
+++ b/files/ja/learn/html/tables/structuring_planet_data/index.md
@@ -1,14 +1,6 @@
 ---
 title: '評価: 太陽系の惑星のデータを構造化する'
 slug: Learn/HTML/Tables/Structuring_planet_data
-tags:
-  - Assessment
-  - Beginner
-  - CodingScripting
-  - HTML
-  - Learn
-  - テーブル
-translation_of: Learn/HTML/Tables/Structuring_planet_data
 ---
 {{LearnSidebar}}{{PreviousMenu("Learn/HTML/Tables/Advanced", "Learn/HTML/Tables")}}
 

--- a/files/ja/learn/index.md
+++ b/files/ja/learn/index.md
@@ -1,16 +1,6 @@
 ---
 title: ウェブ開発を学ぶ
 slug: Learn
-tags:
-  - 初心者
-  - CSS
-  - HTML
-  - 索引
-  - Intro
-  - Landing
-  - 学習
-  - ウェブ
-translation_of: Learn
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/javascript/asynchronous/index.md
+++ b/files/ja/learn/javascript/asynchronous/index.md
@@ -1,20 +1,6 @@
 ---
 title: 非同期 JavaScript
 slug: Learn/JavaScript/Asynchronous
-tags:
-  - Beginner
-  - CodingScripting
-  - Guide
-  - JavaScript
-  - Landing
-  - Promises
-  - async
-  - asynchronous
-  - await
-  - callbacks
-  - requestAnimationFrame
-  - setInterval
-  - setTimeout
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/javascript/building_blocks/build_your_own_function/index.md
+++ b/files/ja/learn/javascript/building_blocks/build_your_own_function/index.md
@@ -1,20 +1,6 @@
 ---
 title: 独自の関数を作る
 slug: Learn/JavaScript/Building_blocks/Build_your_own_function
-tags:
-  - Article
-  - Beginner
-  - CodingScripting
-  - Functions
-  - Guide
-  - JavaScript
-  - Learn
-  - Tutorial
-  - build
-  - invoke
-  - l10n:priority
-  - parameters
-translation_of: Learn/JavaScript/Building_blocks/Build_your_own_function
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Building_blocks/Functions","Learn/JavaScript/Building_blocks/Return_values", "Learn/JavaScript/Building_blocks")}}
 

--- a/files/ja/learn/javascript/building_blocks/conditionals/index.md
+++ b/files/ja/learn/javascript/building_blocks/conditionals/index.md
@@ -1,20 +1,6 @@
 ---
 title: コードでの意思決定 — 条件文
 slug: Learn/JavaScript/Building_blocks/conditionals
-tags:
-  - Article
-  - Beginner
-  - CodingScripting
-  - Conditionals
-  - JavaScript
-  - Learn
-  - Switch
-  - conditions
-  - else
-  - if
-  - l10n:priority
-  - ternary
-translation_of: Learn/JavaScript/Building_blocks/conditionals
 ---
 {{LearnSidebar}}{{NextMenu("Learn/JavaScript/Building_blocks/Looping_code", "Learn/JavaScript/Building_blocks")}}
 

--- a/files/ja/learn/javascript/building_blocks/events/index.md
+++ b/files/ja/learn/javascript/building_blocks/events/index.md
@@ -1,16 +1,6 @@
 ---
 title: イベントへの入門
 slug: Learn/JavaScript/Building_blocks/Events
-tags:
-  - Beginner
-  - CodingScripting
-  - JavaScript
-  - イベント
-  - イベントハンドラー
-  - ガイド
-  - 学習
-  - 記事
-translation_of: Learn/JavaScript/Building_blocks/Events
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Building_blocks/Return_values","Learn/JavaScript/Building_blocks/Image_gallery", "Learn/JavaScript/Building_blocks")}}
 

--- a/files/ja/learn/javascript/building_blocks/functions/index.md
+++ b/files/ja/learn/javascript/building_blocks/functions/index.md
@@ -1,23 +1,6 @@
 ---
 title: 関数 — 再利用可能なコードブロック
 slug: Learn/JavaScript/Building_blocks/Functions
-tags:
-  - API
-  - Article
-  - Beginner
-  - Browser
-  - CodingScripting
-  - Custom
-  - Functions
-  - Guide
-  - JavaScript
-  - Learn
-  - Method
-  - anonymous
-  - invoke
-  - l10n:priority
-  - parameters
-translation_of: Learn/JavaScript/Building_blocks/Functions
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Building_blocks/Looping_code","Learn/JavaScript/Building_blocks/Build_your_own_function", "Learn/JavaScript/Building_blocks")}}
 

--- a/files/ja/learn/javascript/building_blocks/image_gallery/index.md
+++ b/files/ja/learn/javascript/building_blocks/image_gallery/index.md
@@ -1,17 +1,6 @@
 ---
 title: イメージギャラリー
 slug: Learn/JavaScript/Building_blocks/Image_gallery
-tags:
-  - Assessment
-  - Beginner
-  - CodingScripting
-  - Conditionals
-  - Event Handler
-  - JavaScript
-  - Learn
-  - Loops
-  - events
-translation_of: Learn/JavaScript/Building_blocks/Image_gallery
 ---
 {{LearnSidebar}}{{PreviousMenu("Learn/JavaScript/Building_blocks/Events", "Learn/JavaScript/Building_blocks")}}
 

--- a/files/ja/learn/javascript/building_blocks/index.md
+++ b/files/ja/learn/javascript/building_blocks/index.md
@@ -1,21 +1,6 @@
 ---
 title: JavaScript の構成要素
 slug: Learn/JavaScript/Building_blocks
-tags:
-  - Article
-  - Assesment
-  - Beginner
-  - CodingScripting
-  - Conditionals
-  - Functions
-  - Guide
-  - JavaScript
-  - Landing
-  - Loops
-  - Module
-  - events
-  - l10n:priority
-translation_of: Learn/JavaScript/Building_blocks
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/javascript/building_blocks/looping_code/index.md
+++ b/files/ja/learn/javascript/building_blocks/looping_code/index.md
@@ -1,21 +1,6 @@
 ---
 title: ループコード
 slug: Learn/JavaScript/Building_blocks/Looping_code
-tags:
-  - Article
-  - Beginner
-  - CodingScripting
-  - DO
-  - Guide
-  - JavaScript
-  - Learn
-  - Loop
-  - break
-  - continue
-  - for
-  - l10n:priority
-  - while
-translation_of: Learn/JavaScript/Building_blocks/Looping_code
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Building_blocks/conditionals","Learn/JavaScript/Building_blocks/Functions", "Learn/JavaScript/Building_blocks")}}
 

--- a/files/ja/learn/javascript/building_blocks/return_values/index.md
+++ b/files/ja/learn/javascript/building_blocks/return_values/index.md
@@ -1,14 +1,6 @@
 ---
 title: 関数の戻り値
 slug: Learn/JavaScript/Building_blocks/Return_values
-tags:
-  - リターン
-  - リターン値
-  - 戻り値
-  - 返り値
-  - 返却値
-  - 関数
-translation_of: Learn/JavaScript/Building_blocks/Return_values
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Building_blocks/Build_your_own_function","Learn/JavaScript/Building_blocks/Events", "Learn/JavaScript/Building_blocks")}}
 

--- a/files/ja/learn/javascript/client-side_web_apis/client-side_storage/index.md
+++ b/files/ja/learn/javascript/client-side_web_apis/client-side_storage/index.md
@@ -1,23 +1,6 @@
 ---
 title: クライアント側ストレージ
 slug: Learn/JavaScript/Client-side_web_APIs/Client-side_storage
-tags:
-  - API
-  - Article
-  - Beginner
-  - CodingScripting
-  - Guide
-  - IndexedDB
-  - JavaScript
-  - Learn
-  - Storage
-  - Web Storage
-  - ウェブストレージ
-  - ガイド
-  - 保存
-  - 初心者
-  - 学習
-translation_of: Learn/JavaScript/Client-side_web_APIs/Client-side_storage
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/javascript/client-side_web_apis/drawing_graphics/index.md
+++ b/files/ja/learn/javascript/client-side_web_apis/drawing_graphics/index.md
@@ -1,17 +1,6 @@
 ---
 title: グラフィックの描画
 slug: Learn/JavaScript/Client-side_web_APIs/Drawing_graphics
-tags:
-  - API
-  - Article
-  - Beginner
-  - Canvas
-  - CodingScripting
-  - Graphics
-  - JavaScript
-  - Learn
-  - WebGL
-translation_of: Learn/JavaScript/Client-side_web_APIs/Drawing_graphics
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Client-side_web_APIs/Third_party_APIs", "Learn/JavaScript/Client-side_web_APIs/Video_and_audio_APIs", "Learn/JavaScript/Client-side_web_APIs")}}
 

--- a/files/ja/learn/javascript/client-side_web_apis/fetching_data/index.md
+++ b/files/ja/learn/javascript/client-side_web_apis/fetching_data/index.md
@@ -1,23 +1,6 @@
 ---
 title: サーバからのデータ取得
 slug: Learn/JavaScript/Client-side_web_APIs/Fetching_data
-tags:
-  - API
-  - Article
-  - Beginner
-  - CodingScripting
-  - Fetch
-  - JSON
-  - JavaScript
-  - Learn
-  - Promises
-  - Server
-  - XHR
-  - XML
-  - XMLHttpRequest
-  - data
-  - request
-translation_of: Learn/JavaScript/Client-side_web_APIs/Fetching_data
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Client-side_web_APIs/Manipulating_documents", "Learn/JavaScript/Client-side_web_APIs/Third_party_APIs", "Learn/JavaScript/Client-side_web_APIs")}}
 

--- a/files/ja/learn/javascript/client-side_web_apis/index.md
+++ b/files/ja/learn/javascript/client-side_web_apis/index.md
@@ -1,21 +1,6 @@
 ---
 title: クライアントサイド Web API
 slug: Learn/JavaScript/Client-side_web_APIs
-tags:
-  - API
-  - CodingScripting
-  - DOM
-  - JavaScript
-  - Landing
-  - WebAPI
-  - グラフィック
-  - データ
-  - メディア
-  - モジュール
-  - 初心者向け
-  - 学習
-  - 記事
-translation_of: Learn/JavaScript/Client-side_web_APIs
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/javascript/client-side_web_apis/introduction/index.md
+++ b/files/ja/learn/javascript/client-side_web_apis/introduction/index.md
@@ -1,18 +1,6 @@
 ---
 title: Web API の紹介
 slug: Learn/JavaScript/Client-side_web_APIs/Introduction
-tags:
-  - 3rd party
-  - API
-  - Article
-  - Beginner
-  - Browser
-  - CodingScripting
-  - Learn
-  - Object
-  - WebAPI
-  - client-side
-translation_of: Learn/JavaScript/Client-side_web_APIs/Introduction
 ---
 {{LearnSidebar}}{{NextMenu("Learn/JavaScript/Client-side_web_APIs/Manipulating_documents", "Learn/JavaScript/Client-side_web_APIs")}}
 

--- a/files/ja/learn/javascript/client-side_web_apis/manipulating_documents/index.md
+++ b/files/ja/learn/javascript/client-side_web_apis/manipulating_documents/index.md
@@ -1,20 +1,6 @@
 ---
 title: ドキュメントの操作
 slug: Learn/JavaScript/Client-side_web_APIs/Manipulating_documents
-tags:
-  - API
-  - Article
-  - Beginner
-  - CodingScripting
-  - DOM
-  - Document
-  - Document Object Model
-  - JavaScript
-  - Learn
-  - Navigator
-  - WebAPI
-  - Window
-translation_of: Learn/JavaScript/Client-side_web_APIs/Manipulating_documents
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Client-side_web_APIs/Introduction", "Learn/JavaScript/Client-side_web_APIs/Fetching_data", "Learn/JavaScript/Client-side_web_APIs")}}
 

--- a/files/ja/learn/javascript/client-side_web_apis/third_party_apis/index.md
+++ b/files/ja/learn/javascript/client-side_web_apis/third_party_apis/index.md
@@ -1,17 +1,6 @@
 ---
 title: サードパーティ API
 slug: Learn/JavaScript/Client-side_web_APIs/Third_party_APIs
-tags:
-  - 3rd party
-  - API
-  - Beginner
-  - CodingScripting
-  - Google Maps
-  - Learn
-  - NYTimes
-  - Third party
-  - youtube
-translation_of: Learn/JavaScript/Client-side_web_APIs/Third_party_APIs
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Client-side_web_APIs/Fetching_data", "Learn/JavaScript/Client-side_web_APIs/Drawing_graphics", "Learn/JavaScript/Client-side_web_APIs")}}
 

--- a/files/ja/learn/javascript/client-side_web_apis/video_and_audio_apis/index.md
+++ b/files/ja/learn/javascript/client-side_web_apis/video_and_audio_apis/index.md
@@ -1,17 +1,6 @@
 ---
 title: 動画と音声の API
 slug: Learn/JavaScript/Client-side_web_APIs/Video_and_audio_APIs
-tags:
-  - API
-  - Audio
-  - Beginner
-  - CodingScripting
-  - Guide
-  - JavaScript
-  - Learn
-  - Video
-  - 記事
-translation_of: Learn/JavaScript/Client-side_web_APIs/Video_and_audio_APIs
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Client-side_web_APIs/Drawing_graphics", "Learn/JavaScript/Client-side_web_APIs/Client-side_storage", "Learn/JavaScript/Client-side_web_APIs")}}
 

--- a/files/ja/learn/javascript/first_steps/a_first_splash/index.md
+++ b/files/ja/learn/javascript/first_steps/a_first_splash/index.md
@@ -1,20 +1,6 @@
 ---
 title: JavaScriptへの最初のダイブ
 slug: Learn/JavaScript/First_steps/A_first_splash
-tags:
-  - CodingScripting
-  - Conditionals
-  - JavaScript
-  - Objects
-  - Operators
-  - events
-  - l10n:priority
-  - 初心者
-  - 変数
-  - 学習
-  - 記事
-  - 関数
-translation_of: Learn/JavaScript/First_steps/A_first_splash
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/First_steps/What_is_JavaScript", "Learn/JavaScript/First_steps/What_went_wrong", "Learn/JavaScript/First_steps")}}
 

--- a/files/ja/learn/javascript/first_steps/arrays/index.md
+++ b/files/ja/learn/javascript/first_steps/arrays/index.md
@@ -1,21 +1,6 @@
 ---
 title: 配列
 slug: Learn/JavaScript/First_steps/Arrays
-tags:
-  - CodingScripting
-  - JavaScript
-  - Join
-  - Pop
-  - Push
-  - l10n:priority
-  - shift
-  - split
-  - unshift
-  - 初心者
-  - 学習
-  - 記事
-  - 配列
-translation_of: Learn/JavaScript/First_steps/Arrays
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/First_steps/Useful_string_methods", "Learn/JavaScript/First_steps/Silly_story_generator", "Learn/JavaScript/First_steps")}}
 

--- a/files/ja/learn/javascript/first_steps/index.md
+++ b/files/ja/learn/javascript/first_steps/index.md
@@ -1,23 +1,6 @@
 ---
 title: JavaScript の第一歩
 slug: Learn/JavaScript/First_steps
-tags:
-  - Arrays
-  - Article
-  - Assessment
-  - Beginner
-  - CodingScripting
-  - Guide
-  - JavaScript
-  - Landing
-  - Module
-  - Numbers
-  - Operators
-  - Variables
-  - l10n:priority
-  - maths
-  - strings
-translation_of: Learn/JavaScript/First_steps
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/javascript/first_steps/math/index.md
+++ b/files/ja/learn/javascript/first_steps/math/index.md
@@ -1,21 +1,6 @@
 ---
 title: JavaScriptでの基本演算 — 数値と演算子
 slug: Learn/JavaScript/First_steps/Math
-tags:
-  - Article
-  - Beginner
-  - CodingScripting
-  - Guide
-  - JavaScript
-  - Learn
-  - Math
-  - Operators
-  - augmented
-  - increment
-  - l10n:priority
-  - maths
-  - modulo
-translation_of: Learn/JavaScript/First_steps/Math
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/First_steps/Variables", "Learn/JavaScript/First_steps/Strings", "Learn/JavaScript/First_steps")}}
 

--- a/files/ja/learn/javascript/first_steps/silly_story_generator/index.md
+++ b/files/ja/learn/javascript/first_steps/silly_story_generator/index.md
@@ -1,19 +1,6 @@
 ---
 title: バカ話ジェネレーター
 slug: Learn/JavaScript/First_steps/Silly_story_generator
-tags:
-  - Arrays
-  - Assessment
-  - CodingScripting
-  - JavaScript
-  - Numbers
-  - Operators
-  - Variables
-  - l10n:priority
-  - strings
-  - 初心者
-  - 学習
-translation_of: Learn/JavaScript/First_steps/Silly_story_generator
 ---
 {{LearnSidebar}}{{PreviousMenu("Learn/JavaScript/First_steps/Arrays", "Learn/JavaScript/First_steps")}}
 

--- a/files/ja/learn/javascript/first_steps/strings/index.md
+++ b/files/ja/learn/javascript/first_steps/strings/index.md
@@ -1,18 +1,6 @@
 ---
 title: テキストを扱う — JavaScript での文字列
 slug: Learn/JavaScript/First_steps/Strings
-tags:
-  - Article
-  - Beginner
-  - CodingScripting
-  - Guide
-  - JavaScript
-  - Join
-  - Quotes
-  - concatenation
-  - l10n:priority
-  - strings
-translation_of: Learn/JavaScript/First_steps/Strings
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/First_steps/Math", "Learn/JavaScript/First_steps/Useful_string_methods", "Learn/JavaScript/First_steps")}}
 

--- a/files/ja/learn/javascript/first_steps/test_your_skills_colon__arrays/index.md
+++ b/files/ja/learn/javascript/first_steps/test_your_skills_colon__arrays/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'あなたのスキルをテストしよう: 配列'
 slug: Learn/JavaScript/First_steps/Test_your_skills:_Arrays
-tags:
-  - Arrays
-  - Beginner
-  - JavaScript
-  - Learn
-  - test your skills
 ---
 {{learnsidebar}}
 

--- a/files/ja/learn/javascript/first_steps/test_your_skills_colon__math/index.md
+++ b/files/ja/learn/javascript/first_steps/test_your_skills_colon__math/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'あなたのスキルをテストしよう: 数学'
 slug: Learn/JavaScript/First_steps/Test_your_skills:_Math
-tags:
-  - Beginner
-  - JavaScript
-  - Learn
-  - Math
-  - test your skills
 ---
 {{learnsidebar}}
 

--- a/files/ja/learn/javascript/first_steps/useful_string_methods/index.md
+++ b/files/ja/learn/javascript/first_steps/useful_string_methods/index.md
@@ -1,21 +1,6 @@
 ---
 title: 便利な文字列メソッド
 slug: Learn/JavaScript/First_steps/Useful_string_methods
-tags:
-  - Article
-  - Beginner
-  - CodingScripting
-  - JavaScript
-  - Learn
-  - case
-  - indexof
-  - l10n:priority
-  - length
-  - lower
-  - replace
-  - split
-  - upper
-translation_of: Learn/JavaScript/First_steps/Useful_string_methods
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/First_steps/Strings", "Learn/JavaScript/First_steps/Arrays", "Learn/JavaScript/First_steps")}}
 

--- a/files/ja/learn/javascript/first_steps/variables/index.md
+++ b/files/ja/learn/javascript/first_steps/variables/index.md
@@ -1,20 +1,6 @@
 ---
 title: 必要な情報を保存する — 変数
 slug: Learn/JavaScript/First_steps/Variables
-tags:
-  - Arrays
-  - Booleans
-  - JavaScript
-  - Numbers
-  - Objects
-  - Updating
-  - Variables
-  - declaring
-  - initializing
-  - l10n:priority
-  - loose typing
-  - strings
-translation_of: Learn/JavaScript/First_steps/Variables
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/First_steps/What_went_wrong", "Learn/JavaScript/First_steps/Math", "Learn/JavaScript/First_steps")}}
 

--- a/files/ja/learn/javascript/first_steps/what_is_javascript/index.md
+++ b/files/ja/learn/javascript/first_steps/what_is_javascript/index.md
@@ -1,23 +1,6 @@
 ---
 title: JavaScript とは
 slug: Learn/JavaScript/First_steps/What_is_JavaScript
-tags:
-  - 3rd party
-  - API
-  - Article
-  - Beginner
-  - Browser
-  - CodingScripting
-  - Core
-  - JavaScript
-  - Learn
-  - Script
-  - comments
-  - external
-  - inline
-  - l10n:priority
-  - what
-translation_of: Learn/JavaScript/First_steps/What_is_JavaScript
 ---
 {{LearnSidebar}}{{NextMenu("Learn/JavaScript/First_steps/A_first_splash", "Learn/JavaScript/First_steps")}}
 

--- a/files/ja/learn/javascript/first_steps/what_went_wrong/index.md
+++ b/files/ja/learn/javascript/first_steps/what_went_wrong/index.md
@@ -1,19 +1,6 @@
 ---
 title: 何が間違っている? JavaScript のトラブルシューティング
 slug: Learn/JavaScript/First_steps/What_went_wrong
-tags:
-  - Article
-  - Beginner
-  - CodingScripting
-  - Debugging
-  - Developer Tools
-  - Error
-  - JavaScript
-  - Learn
-  - Tutorial
-  - console.log
-  - l10n:priority
-translation_of: Learn/JavaScript/First_steps/What_went_wrong
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/First_steps/A_first_splash", "Learn/JavaScript/First_steps/Variables", "Learn/JavaScript/First_steps")}}
 

--- a/files/ja/learn/javascript/howto/index.md
+++ b/files/ja/learn/javascript/howto/index.md
@@ -1,11 +1,6 @@
 ---
 title: JavaScriptのコードのよくある問題を解決する
 slug: Learn/JavaScript/Howto
-tags:
-  - Beginner
-  - JavaScript
-  - Learn
-translation_of: Learn/JavaScript/Howto
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/javascript/index.md
+++ b/files/ja/learn/javascript/index.md
@@ -1,16 +1,6 @@
 ---
 title: JavaScript
 slug: Learn/JavaScript
-tags:
-  - CodingScripting
-  - JavaScript
-  - JavaScripting beginner
-  - Landing
-  - Module
-  - Topic
-  - l10n:priority
-  - 初心者
-translation_of: Learn/JavaScript
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/javascript/objects/adding_bouncing_balls_features/index.md
+++ b/files/ja/learn/javascript/objects/adding_bouncing_balls_features/index.md
@@ -1,17 +1,6 @@
 ---
 title: バウンスボールのデモに機能を追加する
 slug: Learn/JavaScript/Objects/Adding_bouncing_balls_features
-tags:
-  - Assessment
-  - 初心者
-  - CodingScripting
-  - JavaScript
-  - 学習
-  - OOJS
-  - オブジェクト指向
-  - オブジェクト
-  - l10n:priority
-translation_of: Learn/JavaScript/Objects/Adding_bouncing_balls_features
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Objects/Object_building_practice", "", "Learn/JavaScript/Objects")}}
 

--- a/files/ja/learn/javascript/objects/basics/index.md
+++ b/files/ja/learn/javascript/objects/basics/index.md
@@ -1,22 +1,6 @@
 ---
 title: JavaScript オブジェクトの基本
 slug: Learn/JavaScript/Objects/Basics
-tags:
-  - API
-  - Article
-  - Beginner
-  - CodingScripting
-  - JavaScript
-  - Syntax
-  - bracket notation
-  - dot notation
-  - instance
-  - object literal
-  - this
-  - オブジェクト
-  - 学習
-  - 理論
-translation_of: Learn/JavaScript/Objects/Basics
 ---
 {{LearnSidebar}}{{NextMenu("Learn/JavaScript/Objects/Object_prototypes", "Learn/JavaScript/Objects")}}
 

--- a/files/ja/learn/javascript/objects/classes_in_javascript/index.md
+++ b/files/ja/learn/javascript/objects/classes_in_javascript/index.md
@@ -1,19 +1,6 @@
 ---
 title: JavaScript での継承
 slug: Learn/JavaScript/Objects/Classes_in_JavaScript
-tags:
-  - Article
-  - CodingScripting
-  - Inheritance
-  - JavaScript
-  - OOJS
-  - OOP
-  - Object
-  - Prototype
-  - l10n:priority
-  - 初心者
-  - 学習
-translation_of: Learn/JavaScript/Objects/Inheritance
 original_slug: Learn/JavaScript/Objects/Inheritance
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Objects/Object_prototypes", "Learn/JavaScript/Objects/JSON", "Learn/JavaScript/Objects")}}

--- a/files/ja/learn/javascript/objects/index.md
+++ b/files/ja/learn/javascript/objects/index.md
@@ -1,18 +1,6 @@
 ---
 title: JavaScript オブジェクト入門
 slug: Learn/JavaScript/Objects
-tags:
-  - Article
-  - Assesment
-  - Beginner
-  - CodingScripting
-  - Guide
-  - JavaScript
-  - Learn
-  - Objects
-  - Tutorial
-  - 学習
-translation_of: Learn/JavaScript/Objects
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/javascript/objects/json/index.md
+++ b/files/ja/learn/javascript/objects/json/index.md
@@ -1,22 +1,6 @@
 ---
 title: JSON の操作
 slug: Learn/JavaScript/Objects/JSON
-tags:
-  - 記事
-  - 初心者
-  - CodingScripting
-  - ガイド
-  - JSON
-  - JSON API
-  - JSON 配列
-  - JSON 解釈
-  - JSON 構造
-  - JavaScript
-  - 学習
-  - オブジェクト
-  - チュートリアル
-  - l10n:priority
-translation_of: Learn/JavaScript/Objects/JSON
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Objects/Inheritance", "Learn/JavaScript/Objects/Object_building_practice", "Learn/JavaScript/Objects")}}
 

--- a/files/ja/learn/javascript/objects/object_building_practice/index.md
+++ b/files/ja/learn/javascript/objects/object_building_practice/index.md
@@ -1,18 +1,6 @@
 ---
 title: オブジェクト構築の練習
 slug: Learn/JavaScript/Objects/Object_building_practice
-tags:
-  - Article
-  - Beginner
-  - Canvas
-  - CodingScripting
-  - Guide
-  - JavaScript
-  - Learn
-  - Objects
-  - Tutorial
-  - l10n:priority
-translation_of: Learn/JavaScript/Objects/Object_building_practice
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Objects/JSON", "Learn/JavaScript/Objects/Adding_bouncing_balls_features", "Learn/JavaScript/Objects")}}
 

--- a/files/ja/learn/javascript/objects/object_prototypes/index.md
+++ b/files/ja/learn/javascript/objects/object_prototypes/index.md
@@ -1,20 +1,6 @@
 ---
 title: Object のプロトタイプ
 slug: Learn/JavaScript/Objects/Object_prototypes
-tags:
-  - Beginner
-  - CodingScripting
-  - JavaScript
-  - Learn
-  - OOJS
-  - OOP
-  - Object
-  - Prototype
-  - create()
-  - l10n:priority
-  - コンストラクタ
-  - 記事
-translation_of: Learn/JavaScript/Objects/Object_prototypes
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Objects/Object-oriented_JS", "Learn/JavaScript/Objects/Inheritance", "Learn/JavaScript/Objects")}}
 

--- a/files/ja/learn/javascript/objects/test_your_skills_colon__object_basics/index.md
+++ b/files/ja/learn/javascript/objects/test_your_skills_colon__object_basics/index.md
@@ -1,7 +1,6 @@
 ---
 title: 'スキルテスト: オブジェクトの基本'
 slug: Learn/JavaScript/Objects/Test_your_skills:_Object_basics
-translation_of: Learn/JavaScript/Objects/Test_your_skills:_Object_basics
 ---
 {{learnsidebar}}
 

--- a/files/ja/learn/performance/business_case_for_performance/index.md
+++ b/files/ja/learn/performance/business_case_for_performance/index.md
@@ -1,10 +1,6 @@
 ---
 title: ウェブパフォーマンスのビジネスケース
 slug: Learn/Performance/business_case_for_performance
-tags:
-  - Web パフォーマンス
-  - Web 開発
-translation_of: Learn/Performance/business_case_for_performance
 ---
 {{LearnSidebar}}{{PreviousMenu("Learn/Performance/Mobile", "Learn/Performance")}}
 

--- a/files/ja/learn/performance/index.md
+++ b/files/ja/learn/performance/index.md
@@ -1,15 +1,6 @@
 ---
 title: ウェブパフォーマンス
 slug: Learn/Performance
-tags:
-  - CSS
-  - HTML
-  - HTTP
-  - JavaScript
-  - Learn
-  - Performance
-  - Web Performance
-translation_of: Learn/Performance
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/performance/measuring_performance/index.md
+++ b/files/ja/learn/performance/measuring_performance/index.md
@@ -1,13 +1,6 @@
 ---
 title: パフォーマンスの測定
 slug: Learn/Performance/Measuring_performance
-tags:
-  - API
-  - Beginner
-  - Guide
-  - Tools
-  - Web
-translation_of: Learn/Performance/Measuring_performance
 ---
 {{LearnSidebar}} {{PreviousMenuNext("Learn/Performance/Perceived_performance", "Learn/Performance/Multimedia", "Learn/Performance")}}パフォーマンスの測定は、あなたがあなたのアプリケーション、サイト、ウェブサービスを評価することを助ける重要な指標を提供します。たとえば、パフォーマンスの指標を使うことで、競合と比較してアプリケーションをどのように動作させるか決めたり、リリースごとのパフォーマンスを比較したりできます。測定対象として選択する指標はユーザー、サイト、そしてビジネスのゴールに関連するものであるべきです。それらは一貫した手法で収集、測定され、非技術系の関係者にも理解でき、利用可能なフォーマットで分析される必要があります。この記事ではサイトのパフォーマンス測定と最適化に利用できるウェブパフォーマンスの指標を紹介します。
 

--- a/files/ja/learn/performance/perceived_performance/index.md
+++ b/files/ja/learn/performance/perceived_performance/index.md
@@ -1,10 +1,6 @@
 ---
 title: 知覚されるパフォーマンス
 slug: Learn/Performance/perceived_performance
-tags:
-  - Perceived Performance
-  - Web Performance
-translation_of: Learn/Performance/perceived_performance
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Performance/what_is_web_performance", "Learn/Performance/Measuring_performance", "Learn/Performance")}}
 

--- a/files/ja/learn/performance/web_performance_basics/index.md
+++ b/files/ja/learn/performance/web_performance_basics/index.md
@@ -1,10 +1,6 @@
 ---
 title: ウェブパフォーマンスの基礎
 slug: Learn/Performance/Web_Performance_Basics
-tags:
-  - Best practices
-  - Website performance
-translation_of: Learn/Performance/Web_Performance_Basics
 ---
 あなたのウェブサイトが可能な限りのパフォーマンスを発揮すべき[理由](https://web.dev/why-speed-matters/)はたくさんあります。
 以下に、各トピックの詳細情報を提供するためのリンク付きのベストプラクティス、ツール、API の簡単なレビューを示します。

--- a/files/ja/learn/performance/what_is_web_performance/index.md
+++ b/files/ja/learn/performance/what_is_web_performance/index.md
@@ -1,16 +1,6 @@
 ---
 title: ウェブパフォーマンスとは
 slug: Learn/Performance/What_is_web_performance
-tags:
-  - Beginner
-  - Introduction
-  - Learn
-  - Performance
-  - Reference
-  - Tutorial
-  - Web Performance
-  - Web パフォーマンス
-translation_of: Learn/Performance/What_is_web_performance
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Performance/why_web_performance", "Learn/Performance/Perceived_performance", "Learn/Performance")}}
 

--- a/files/ja/learn/performance/why_web_performance/index.md
+++ b/files/ja/learn/performance/why_web_performance/index.md
@@ -1,16 +1,6 @@
 ---
 title: ウェブパフォーマンスの「なぜ」
 slug: Learn/Performance/why_web_performance
-tags:
-  - Beginner
-  - Introduction
-  - Learn
-  - Performance
-  - Reference
-  - Tutorial
-  - Web Performance
-  - Web パフォーマンス
-translation_of: Learn/Performance/why_web_performance
 ---
 {{LearnSidebar}}{{NextMenu("Learn/Performance/What_is_web_performance", "Learn/Performance")}}
 

--- a/files/ja/learn/server-side/django/development_environment/index.md
+++ b/files/ja/learn/server-side/django/development_environment/index.md
@@ -1,12 +1,6 @@
 ---
 title: Django 開発環境の設定
 slug: Learn/Server-side/Django/development_environment
-tags:
-  - Python
-  - Webフレームワーク
-  - django
-  - サーバーサイドプログラミング
-translation_of: Learn/Server-side/Django/development_environment
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Django/Introduction", "Learn/Server-side/Django/Tutorial_local_library_website", "Learn/Server-side/Django")}}
 

--- a/files/ja/learn/server-side/django/index.md
+++ b/files/ja/learn/server-side/django/index.md
@@ -1,16 +1,6 @@
 ---
 title: Djangoウェブフレームワーク (Python)
 slug: Learn/Server-side/Django
-tags:
-  - Python
-  - django
-  - ウェブアプリケーションフレームワーク
-  - サーバーサイドプログラミング
-  - プログラミング
-  - 初心者
-  - 学習
-  - 概要
-translation_of: Learn/Server-side/Django
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/server-side/django/introduction/index.md
+++ b/files/ja/learn/server-side/django/introduction/index.md
@@ -1,12 +1,6 @@
 ---
 title: Djangoの紹介
 slug: Learn/Server-side/Django/Introduction
-tags:
-  - Python
-  - Webフレームワーク
-  - django
-  - サーバーサイドプログラミング
-translation_of: Learn/Server-side/Django/Introduction
 ---
 {{LearnSidebar}}{{NextMenu("Learn/Server-side/Django/development_environment", "Learn/Server-side/Django")}}
 

--- a/files/ja/learn/server-side/django/models/index.md
+++ b/files/ja/learn/server-side/django/models/index.md
@@ -1,7 +1,6 @@
 ---
 title: 'Django チュートリアル Part 3: モデルの使用'
 slug: Learn/Server-side/Django/Models
-translation_of: Learn/Server-side/Django/Models
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Django/skeleton_website", "Learn/Server-side/Django/Admin_site", "Learn/Server-side/Django")}}
 

--- a/files/ja/learn/server-side/django/skeleton_website/index.md
+++ b/files/ja/learn/server-side/django/skeleton_website/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Django チュートリアル Part 2: スケルトンウェブサイトの作成'
 slug: Learn/Server-side/Django/skeleton_website
-tags:
-  - django
-  - イントロダクション
-  - ガイド
-  - チュートリアル
-  - 初心者
-  - 学習
-  - 記事
-translation_of: Learn/Server-side/Django/skeleton_website
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Django/Tutorial_local_library_website", "Learn/Server-side/Django/Models", "Learn/Server-side/Django")}}
 

--- a/files/ja/learn/server-side/django/tutorial_local_library_website/index.md
+++ b/files/ja/learn/server-side/django/tutorial_local_library_website/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'Django チュートリアル: 地域図書館ウェブサイト'
 slug: Learn/Server-side/Django/Tutorial_local_library_website
-tags:
-  - Python
-  - django
-  - チュートリアル
-  - 初心者
-translation_of: Learn/Server-side/Django/Tutorial_local_library_website
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Django/development_environment", "Learn/Server-side/Django/skeleton_website", "Learn/Server-side/Django")}}
 

--- a/files/ja/learn/server-side/django/web_application_security/index.md
+++ b/files/ja/learn/server-side/django/web_application_security/index.md
@@ -1,7 +1,6 @@
 ---
 title: Django Web アプリケーションのセキュリティ
 slug: Learn/Server-side/Django/web_application_security
-translation_of: Learn/Server-side/Django/web_application_security
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Django/Deployment", "Learn/Server-side/Django/django_assessment_blog", "Learn/Server-side/Django")}}ユーザーのデータを守ることは Web デザインにおいて重要です。 以前、より一般的なセキュリティの脅威の一部を [Web セキュリティ](/ja/docs/Web/Security) の記事で説明しました— 本記事では Django にビルトインされている保護機能がそのような脅威にどう対応しているか、より実践的な動きを見ながら説明していきます。
 

--- a/files/ja/learn/server-side/express_nodejs/deployment/index.md
+++ b/files/ja/learn/server-side/express_nodejs/deployment/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Express チュートリアル Part 7: プロダクションへのデプロイ'
 slug: Learn/Server-side/Express_Nodejs/deployment
-tags:
-  - CodingScripting
-  - Express
-  - Node
-  - heroku
-  - サーバサイド
-  - デプロイ
-  - 初心者
-  - 学習
-translation_of: Learn/Server-side/Express_Nodejs/deployment
 ---
 {{LearnSidebar}}{{PreviousMenu("Learn/Server-side/Express_Nodejs/forms", "Learn/Server-side/Express_Nodejs")}}
 

--- a/files/ja/learn/server-side/express_nodejs/development_environment/index.md
+++ b/files/ja/learn/server-side/express_nodejs/development_environment/index.md
@@ -1,21 +1,6 @@
 ---
 title: Node 開発環境の設定
 slug: Learn/Server-side/Express_Nodejs/development_environment
-tags:
-  - CodingScripting
-  - Express
-  - Intro
-  - Learn
-  - Node
-  - nodejs
-  - npm
-  - server-side
-  - イントロダクション
-  - サーバサイド
-  - 初心者
-  - 学習
-  - 開発環境
-translation_of: Learn/Server-side/Express_Nodejs/development_environment
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Express_Nodejs/Introduction", "Learn/Server-side/Express_Nodejs/Tutorial_local_library_website", "Learn/Server-side/Express_Nodejs")}}
 

--- a/files/ja/learn/server-side/express_nodejs/displaying_data/author_detail_page/index.md
+++ b/files/ja/learn/server-side/express_nodejs/displaying_data/author_detail_page/index.md
@@ -1,7 +1,6 @@
 ---
 title: 著者詳細ページ
 slug: Learn/Server-side/Express_Nodejs/Displaying_data/Author_detail_page
-translation_of: Learn/Server-side/Express_Nodejs/Displaying_data/Author_detail_page
 ---
 著者詳細ページには、指定された `Author` に関する情報を、その (自動的に生成された) `_id` フィールド値を使用して識別し、その `Author` に関連するすべての `Book` オブジェクトのリストを表示する必要があります。
 

--- a/files/ja/learn/server-side/express_nodejs/displaying_data/author_list_page/index.md
+++ b/files/ja/learn/server-side/express_nodejs/displaying_data/author_list_page/index.md
@@ -1,12 +1,6 @@
 ---
 title: 著者リストページとジャンルリストページのチャレンジ
 slug: Learn/Server-side/Express_Nodejs/Displaying_data/Author_list_page
-tags:
-  - Express
-  - Node
-  - displaying data
-  - server-side
-translation_of: Learn/Server-side/Express_Nodejs/Displaying_data/Author_list_page
 ---
 The author list page needs to display a list of all authors in the database, with each author name linked to its associated author detail page. The date of birth and date of death should be listed after the name on the same line.
 

--- a/files/ja/learn/server-side/express_nodejs/displaying_data/book_detail_page/index.md
+++ b/files/ja/learn/server-side/express_nodejs/displaying_data/book_detail_page/index.md
@@ -1,7 +1,6 @@
 ---
 title: 本の詳細ページ
 slug: Learn/Server-side/Express_Nodejs/Displaying_data/Book_detail_page
-translation_of: Learn/Server-side/Express_Nodejs/Displaying_data/Book_detail_page
 ---
 The _Book detail page_ needs to display the information for a specific `Book`, identified using its (automatically generated) `_id` field value, along with information about each associated copy in the libary (`BookInstance`). Wherever we display an author, genre, or book instance, these should be linked to the associated detail page for that item.
 

--- a/files/ja/learn/server-side/express_nodejs/displaying_data/book_list_page/index.md
+++ b/files/ja/learn/server-side/express_nodejs/displaying_data/book_list_page/index.md
@@ -1,7 +1,6 @@
 ---
 title: ブックリストページ
 slug: Learn/Server-side/Express_Nodejs/Displaying_data/Book_list_page
-translation_of: Learn/Server-side/Express_Nodejs/Displaying_data/Book_list_page
 ---
 Next we'll implement our book list page. This page needs to display a list of all books in the database along with their author, with each book title being a hyperlink to its associated book detail page.
 

--- a/files/ja/learn/server-side/express_nodejs/displaying_data/bookinstance_detail_page_and_challenge/index.md
+++ b/files/ja/learn/server-side/express_nodejs/displaying_data/bookinstance_detail_page_and_challenge/index.md
@@ -1,9 +1,6 @@
 ---
 title: ブックインスタンス詳細ページとチャレンジ
-slug: >-
-  Learn/Server-side/Express_Nodejs/Displaying_data/BookInstance_detail_page_and_challenge
-translation_of: >-
-  Learn/Server-side/Express_Nodejs/Displaying_data/BookInstance_detail_page_and_challenge
+slug: Learn/Server-side/Express_Nodejs/Displaying_data/BookInstance_detail_page_and_challenge
 ---
 ## BookInstance detail page
 

--- a/files/ja/learn/server-side/express_nodejs/displaying_data/bookinstance_list_page/index.md
+++ b/files/ja/learn/server-side/express_nodejs/displaying_data/bookinstance_list_page/index.md
@@ -1,7 +1,6 @@
 ---
 title: ブックインスタンスリストページ
 slug: Learn/Server-side/Express_Nodejs/Displaying_data/BookInstance_list_page
-translation_of: Learn/Server-side/Express_Nodejs/Displaying_data/BookInstance_list_page
 ---
 Next we'll implement our list of all book copies (`BookInstance`) in the library. This page needs to include the title of the `Book` associated with each `BookInstance` (linked to its detail page) along with other information in the `BookInstance` model, including the status, imprint, and unique id of each copy. The unique id text should be linked to the `BookInstance` detail page.
 

--- a/files/ja/learn/server-side/express_nodejs/displaying_data/date_formatting_using_moment/index.md
+++ b/files/ja/learn/server-side/express_nodejs/displaying_data/date_formatting_using_moment/index.md
@@ -1,7 +1,6 @@
 ---
 title: moment を使用した日付のフォーマット
 slug: Learn/Server-side/Express_Nodejs/Displaying_data/Date_formatting_using_moment
-translation_of: Learn/Server-side/Express_Nodejs/Displaying_data/Date_formatting_using_moment
 ---
 The default rendering of dates from our models is very ugly: _Tue Dec 06 2016 15:49:58 GMT+1100 (AUS Eastern Daylight Time)_. In this section we'll show how you can update the _BookInstance List_ page from the previous section to present the `due_date` field in a more friendly format: December 6th, 2016.
 

--- a/files/ja/learn/server-side/express_nodejs/displaying_data/flow_control_using_async/index.md
+++ b/files/ja/learn/server-side/express_nodejs/displaying_data/flow_control_using_async/index.md
@@ -1,12 +1,6 @@
 ---
 title: async を使用した非同期フロー制御
 slug: Learn/Server-side/Express_Nodejs/Displaying_data/flow_control_using_async
-tags:
-  - Express
-  - Node
-  - displaying data
-  - part 5
-  - server-side
 ---
 _LocalLibrary_ 中のいくつかのコントローラーのコードは、複数の非同期リクエストの結果に依存しています。そのため、操作を特定の順序もしくは並列して実行することが必要になる場合があります。フロー制御を管理して、必要となるすべての情報を取得した後でページをレンダリングするために、ここでは人気のある node [async](https://www.npmjs.com/package/async) を使うことにします。
 

--- a/files/ja/learn/server-side/express_nodejs/displaying_data/genre_detail_page/index.md
+++ b/files/ja/learn/server-side/express_nodejs/displaying_data/genre_detail_page/index.md
@@ -1,7 +1,6 @@
 ---
 title: ジャンル詳細ページ
 slug: Learn/Server-side/Express_Nodejs/Displaying_data/Genre_detail_page
-translation_of: Learn/Server-side/Express_Nodejs/Displaying_data/Genre_detail_page
 ---
 The genre _detail_ page needs to display the information for the particular genre instance using its automatically generated `_id` field value as the identifier. The page should display the genre name, and a list of all books in the genre with links to each book's details page.
 

--- a/files/ja/learn/server-side/express_nodejs/displaying_data/home_page/index.md
+++ b/files/ja/learn/server-side/express_nodejs/displaying_data/home_page/index.md
@@ -1,7 +1,6 @@
 ---
 title: ホームページ
 slug: Learn/Server-side/Express_Nodejs/Displaying_data/Home_page
-translation_of: Learn/Server-side/Express_Nodejs/Displaying_data/Home_page
 ---
 The first page we'll create will be the website home page, which is accessible from either the site (`'/'`) or catalog (`catalog/`) root. This will display some static text describing the site, along with dynamically calculated "counts" of different record types in the database.
 

--- a/files/ja/learn/server-side/express_nodejs/displaying_data/index.md
+++ b/files/ja/learn/server-side/express_nodejs/displaying_data/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Express チュートリアル Part 5: ライブラリデータの表示'
 slug: Learn/Server-side/Express_Nodejs/Displaying_data
-tags:
-  - Express
-  - nodejs
-  - pug
-  - コントローラ
-  - テンプレート
-  - ビュー
-  - 初心者
-  - 学習
-translation_of: Learn/Server-side/Express_Nodejs/Displaying_data
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Express_Nodejs/routes", "Learn/Server-side/Express_Nodejs/forms", "Learn/Server-side/Express_Nodejs")}}
 

--- a/files/ja/learn/server-side/express_nodejs/displaying_data/locallibrary_base_template/index.md
+++ b/files/ja/learn/server-side/express_nodejs/displaying_data/locallibrary_base_template/index.md
@@ -1,7 +1,6 @@
 ---
 title: LocalLibrary 基本テンプレート
 slug: Learn/Server-side/Express_Nodejs/Displaying_data/LocalLibrary_base_template
-translation_of: Learn/Server-side/Express_Nodejs/Displaying_data/LocalLibrary_base_template
 ---
 Now that we understand how to extend templates using Pug, let's start by creating a base template for the project. This will have a sidebar with links for the pages we hope to create across the tutorial articles (e.g. to display and create books, genres, authors, etc.) and a main content area that we'll override in each of our individual pages.
 

--- a/files/ja/learn/server-side/express_nodejs/displaying_data/template_primer/index.md
+++ b/files/ja/learn/server-side/express_nodejs/displaying_data/template_primer/index.md
@@ -1,7 +1,6 @@
 ---
 title: テンプレートプライマー
 slug: Learn/Server-side/Express_Nodejs/Displaying_data/Template_primer
-translation_of: Learn/Server-side/Express_Nodejs/Displaying_data/Template_primer
 ---
 A template is a text file defining the _structure_ or layout of an output file, with placeholders used to represent where data will be inserted when the template is rendered (in _Express_, templates are referred to as _views_).
 

--- a/files/ja/learn/server-side/express_nodejs/forms/index.md
+++ b/files/ja/learn/server-side/express_nodejs/forms/index.md
@@ -1,7 +1,6 @@
 ---
 title: 'Express チュートリアル Part 6: フォームの操作'
 slug: Learn/Server-side/Express_Nodejs/forms
-translation_of: Learn/Server-side/Express_Nodejs/forms
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Express_Nodejs/Displaying_data", "Learn/Server-side/Express_Nodejs/deployment", "Learn/Server-side/Express_Nodejs")}}
 

--- a/files/ja/learn/server-side/express_nodejs/index.md
+++ b/files/ja/learn/server-side/express_nodejs/index.md
@@ -1,22 +1,6 @@
 ---
 title: Express Web フレームワーク (Node.js/JavaScript)
 slug: Learn/Server-side/Express_Nodejs
-tags:
-  - Beginner
-  - CodingScripting
-  - Express
-  - Express.js
-  - Intro
-  - JavaScript
-  - Learn
-  - Node
-  - Server-side programming
-  - node.js
-  - イントロダクション
-  - サーバサイドプログラミング
-  - 初心者
-  - 学習
-translation_of: Learn/Server-side/Express_Nodejs
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/server-side/express_nodejs/introduction/index.md
+++ b/files/ja/learn/server-side/express_nodejs/introduction/index.md
@@ -1,17 +1,6 @@
 ---
 title: Express/Node のイントロダクション
 slug: Learn/Server-side/Express_Nodejs/Introduction
-tags:
-  - Beginner
-  - CodingScripting
-  - Express
-  - Learn
-  - Node
-  - nodejs
-  - server-side
-  - サーバーサイド
-  - 初心者
-translation_of: Learn/Server-side/Express_Nodejs/Introduction
 ---
 {{LearnSidebar}}{{NextMenu("Learn/Server-side/Express_Nodejs/development_environment", "Learn/Server-side/Express_Nodejs")}}
 

--- a/files/ja/learn/server-side/express_nodejs/mongoose/index.md
+++ b/files/ja/learn/server-side/express_nodejs/mongoose/index.md
@@ -1,7 +1,6 @@
 ---
 title: 'Express チュートリアル Part 3: データベースの使用 (Mongoose を使用)'
 slug: Learn/Server-side/Express_Nodejs/mongoose
-translation_of: Learn/Server-side/Express_Nodejs/mongoose
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Express_Nodejs/skeleton_website", "Learn/Server-side/Express_Nodejs/routes", "Learn/Server-side/Express_Nodejs")}}
 

--- a/files/ja/learn/server-side/express_nodejs/routes/index.md
+++ b/files/ja/learn/server-side/express_nodejs/routes/index.md
@@ -1,7 +1,6 @@
 ---
 title: 'Express チュートリアル Part 4: ルートとコントローラ'
 slug: Learn/Server-side/Express_Nodejs/routes
-translation_of: Learn/Server-side/Express_Nodejs/routes
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Express_Nodejs/mongoose", "Learn/Server-side/Express_Nodejs/Displaying_data", "Learn/Server-side/Express_Nodejs")}}
 

--- a/files/ja/learn/server-side/express_nodejs/skeleton_website/index.md
+++ b/files/ja/learn/server-side/express_nodejs/skeleton_website/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Express チュートリアル Part 2: スケルトン Web サイトの作成'
 slug: Learn/Server-side/Express_Nodejs/skeleton_website
-tags:
-  - CodingScripting
-  - Express
-  - Node
-  - イントロダクション
-  - サーバサイド
-  - 初心者
-  - 学習
-  - 開発環境
-translation_of: Learn/Server-side/Express_Nodejs/skeleton_website
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/server-side/express_nodejs/tutorial_local_library_website/index.md
+++ b/files/ja/learn/server-side/express_nodejs/tutorial_local_library_website/index.md
@@ -1,20 +1,6 @@
 ---
 title: 'Express チュートリアル: 地域図書館の Web サイト'
 slug: Learn/Server-side/Express_Nodejs/Tutorial_local_library_website
-tags:
-  - Beginner
-  - CodingScripting
-  - Express
-  - Intro
-  - Learn
-  - Node
-  - Tutorial
-  - nodejs
-  - イントロダクション
-  - サーバサイド
-  - 初心者
-  - 学習
-translation_of: Learn/Server-side/Express_Nodejs/Tutorial_local_library_website
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Express_Nodejs/development_environment", "Learn/Server-side/Express_Nodejs/skeleton_website", "Learn/Server-side/Express_Nodejs")}}
 

--- a/files/ja/learn/server-side/first_steps/client-server_overview/index.md
+++ b/files/ja/learn/server-side/first_steps/client-server_overview/index.md
@@ -1,15 +1,6 @@
 ---
 title: クライアント - サーバの概要
 slug: Learn/Server-side/First_steps/Client-Server_overview
-tags:
-  - Beginner
-  - CodingScripting
-  - イントロダクション
-  - ガイド
-  - サーバ
-  - サーバサイドプログラミング
-  - 学習
-translation_of: Learn/Server-side/First_steps/Client-Server_overview
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/First_steps/Introduction", "Learn/Server-side/First_steps/Web_frameworks", "Learn/Server-side/First_steps")}}
 

--- a/files/ja/learn/server-side/first_steps/index.md
+++ b/files/ja/learn/server-side/first_steps/index.md
@@ -1,15 +1,6 @@
 ---
 title: サーバサイドの Web サイトプログラミングの第一歩
 slug: Learn/Server-side/First_steps
-tags:
-  - CodingScripting
-  - Intro
-  - Landing
-  - ガイド
-  - サーバサイドプログラミング
-  - 初心者
-  - 学習
-translation_of: Learn/Server-side/First_steps
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/server-side/first_steps/introduction/index.md
+++ b/files/ja/learn/server-side/first_steps/introduction/index.md
@@ -1,7 +1,6 @@
 ---
 title: サーバサイドの概要
 slug: Learn/Server-side/First_steps/Introduction
-translation_of: Learn/Server-side/First_steps/Introduction
 ---
 {{LearnSidebar}}{{NextMenu("Learn/Server-side/First_steps/Client-Server_overview", "Learn/Server-side/First_steps")}}
 

--- a/files/ja/learn/server-side/first_steps/web_frameworks/index.md
+++ b/files/ja/learn/server-side/first_steps/web_frameworks/index.md
@@ -1,16 +1,6 @@
 ---
 title: サーバーサイドウェブフレームワーク
 slug: Learn/Server-side/First_steps/Web_frameworks
-tags:
-  - Beginner
-  - CodingScripting
-  - Guide
-  - Intro
-  - Learn
-  - Server
-  - Server-side programming
-  - Web frameworks
-translation_of: Learn/Server-side/First_steps/Web_frameworks
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/First_steps/Client-Server_overview", "Learn/Server-side/First_steps/Website_security", "Learn/Server-side/First_steps")}}
 

--- a/files/ja/learn/server-side/first_steps/website_security/index.md
+++ b/files/ja/learn/server-side/first_steps/website_security/index.md
@@ -1,17 +1,6 @@
 ---
 title: Web サイトのセキュリティ
 slug: Learn/Server-side/First_steps/Website_security
-tags:
-  - CodingScripting
-  - Web サイトセキュリティ
-  - Web セキュリティ
-  - イントロダクション
-  - ガイド
-  - サーバサイドプログラミング
-  - セキュリテイ
-  - 初心者
-  - 学習
-translation_of: Learn/Server-side/First_steps/Website_security
 ---
 {{LearnSidebar}}{{PreviousMenu("Learn/Server-side/First_steps/Web_frameworks", "Learn/Server-side/First_steps")}}
 

--- a/files/ja/learn/server-side/index.md
+++ b/files/ja/learn/server-side/index.md
@@ -1,18 +1,6 @@
 ---
 title: サーバサイド Web サイトプログラミング
 slug: Learn/Server-side
-tags:
-  - CodingScripting
-  - Landing
-  - NeedsTranslation
-  - Server
-  - Server-side programming
-  - Topic
-  - TopicStub
-  - 初学者
-  - 学習
-  - 導入部
-translation_of: Learn/Server-side
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/server-side/node_server_without_framework/index.md
+++ b/files/ja/learn/server-side/node_server_without_framework/index.md
@@ -1,13 +1,6 @@
 ---
 title: フレームワークなしの Node.js サーバ
 slug: Learn/Server-side/Node_server_without_framework
-tags:
-  - JavaScript
-  - NeedsContent
-  - Node
-  - サーバ
-  - フレームワークなし
-translation_of: Learn/Server-side/Node_server_without_framework
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/tools_and_testing/client-side_javascript_frameworks/angular_getting_started/index.md
+++ b/files/ja/learn/tools_and_testing/client-side_javascript_frameworks/angular_getting_started/index.md
@@ -1,15 +1,6 @@
 ---
 title: Angular をはじめる
-slug: >-
-  Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular_getting_started
-tags:
-  - Beginner
-  - Frameworks
-  - Installation
-  - JavaScript
-  - Learn
-  - client-side
-  - Angular
+slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular_getting_started
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_deployment_next","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular_todo_list_beginning", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}

--- a/files/ja/learn/tools_and_testing/client-side_javascript_frameworks/angular_item_component/index.md
+++ b/files/ja/learn/tools_and_testing/client-side_javascript_frameworks/angular_item_component/index.md
@@ -1,17 +1,6 @@
 ---
 title: item コンポーネントの作成
-slug: >-
-  Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular_item_component
-tags:
-  - Beginner
-  - Frameworks
-  - JavaScript
-  - Learn
-  - client-side
-  - Angular
-  - Components
-  - Events
-  - Data
+slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular_item_component
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular_styling","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular_filtering", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}

--- a/files/ja/learn/tools_and_testing/client-side_javascript_frameworks/angular_styling/index.md
+++ b/files/ja/learn/tools_and_testing/client-side_javascript_frameworks/angular_styling/index.md
@@ -1,14 +1,6 @@
 ---
 title: Angular アプリのスタイリング
 slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular_styling
-tags:
-  - Beginner
-  - Frameworks
-  - JavaScript
-  - Learn
-  - client-side
-  - Angular
-  - Styling
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular_todo_list_beginning","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular_item_component", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}

--- a/files/ja/learn/tools_and_testing/client-side_javascript_frameworks/angular_todo_list_beginning/index.md
+++ b/files/ja/learn/tools_and_testing/client-side_javascript_frameworks/angular_todo_list_beginning/index.md
@@ -1,16 +1,6 @@
 ---
 title: Angular todo リストアプリの事始め
-slug: >-
-  Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular_todo_list_beginning
-tags:
-  - Beginner
-  - Frameworks
-  - JavaScript
-  - Learn
-  - client-side
-  - Angular
-  - Components
-  - Structure
+slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular_todo_list_beginning
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular_getting_started","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular_styling", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}

--- a/files/ja/learn/tools_and_testing/client-side_javascript_frameworks/index.md
+++ b/files/ja/learn/tools_and_testing/client-side_javascript_frameworks/index.md
@@ -1,15 +1,6 @@
 ---
 title: クライアントサイドの JavaScript フレームワークを理解する
 slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks
-tags:
-  - Beginner
-  - Frameworks
-  - JavaScript
-  - Learn
-  - NeedsTranslation
-  - TopicStub
-  - client-side
-translation_of: Learn/Tools_and_testing/Client-side_JavaScript_frameworks
 ---
 
 {{LearnSidebar}}

--- a/files/ja/learn/tools_and_testing/client-side_javascript_frameworks/react_components/index.md
+++ b/files/ja/learn/tools_and_testing/client-side_javascript_frameworks/react_components/index.md
@@ -1,16 +1,6 @@
 ---
 title: React アプリのコンポーネント化
 slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_components
-tags:
-  - 初心者
-  - フレームワーク
-  - JavaScript
-  - 学習
-  - React
-  - クライアント側
-  - events
-  - interactivity
-  - state
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_todo_list_beginning","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_interactivity_events_state", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}

--- a/files/ja/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.md
+++ b/files/ja/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.md
@@ -1,16 +1,6 @@
 ---
 title: Reactをはじめる
-slug: >-
-  Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_getting_started
-tags:
-  - Beginner
-  - Frameworks
-  - JavaScript
-  - Learn
-  - React
-  - client-side
-translation_of: >-
-  Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_getting_started
+slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_getting_started
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Main_features","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_todo_list_beginning", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}
 

--- a/files/ja/learn/tools_and_testing/client-side_javascript_frameworks/react_resources/index.md
+++ b/files/ja/learn/tools_and_testing/client-side_javascript_frameworks/react_resources/index.md
@@ -1,14 +1,6 @@
 ---
 title: React のリソース
 slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_resources
-tags:
-  - Beginner
-  - JavaScript
-  - Learn
-  - React
-  - client-side
-  - framework
-  - resources
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_accessibility","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Ember_getting_started", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}

--- a/files/ja/learn/tools_and_testing/client-side_javascript_frameworks/react_todo_list_beginning/index.md
+++ b/files/ja/learn/tools_and_testing/client-side_javascript_frameworks/react_todo_list_beginning/index.md
@@ -1,9 +1,6 @@
 ---
 title: React ToDoリストをはじめる
-slug: >-
-  Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_todo_list_beginning
-translation_of: >-
-  Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_todo_list_beginning
+slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_todo_list_beginning
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/tools_and_testing/client-side_javascript_frameworks/vue_getting_started/index.md
+++ b/files/ja/learn/tools_and_testing/client-side_javascript_frameworks/vue_getting_started/index.md
@@ -1,15 +1,6 @@
 ---
 title: Getting started with Vue
 slug: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_getting_started
-tags:
-  - Beginner
-  - Frameworks
-  - Installation
-  - JavaScript
-  - Learn
-  - client-side
-  - vue
-translation_of: Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_getting_started
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Ember_resources","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_first_component", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}
 

--- a/files/ja/learn/tools_and_testing/cross_browser_testing/accessibility/index.md
+++ b/files/ja/learn/tools_and_testing/cross_browser_testing/accessibility/index.md
@@ -1,20 +1,6 @@
 ---
 title: よくあるアクセシビリティの問題を扱う
 slug: Learn/Tools_and_testing/Cross_browser_testing/Accessibility
-tags:
-  - Accessibility
-  - Article
-  - Beginner
-  - CSS
-  - CodingScripting
-  - HTML
-  - JavaScript
-  - Learn
-  - Testing
-  - Tools
-  - cross browser
-  - keyboard
-translation_of: Learn/Tools_and_testing/Cross_browser_testing/Accessibility
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Tools_and_testing/Cross_browser_testing/JavaScript","Learn/Tools_and_testing/Cross_browser_testing/Feature_detection", "Learn/Tools_and_testing/Cross_browser_testing")}}
 

--- a/files/ja/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
+++ b/files/ja/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
@@ -1,7 +1,6 @@
 ---
 title: 自動テストのイントロダクション
 slug: Learn/Tools_and_testing/Cross_browser_testing/Automated_testing
-translation_of: Learn/Tools_and_testing/Cross_browser_testing/Automated_testing
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Tools_and_testing/Cross_browser_testing/Feature_detection", "Learn/Tools_and_testing/Cross_browser_testing/Your_own_automation_environment", "Learn/Tools_and_testing/Cross_browser_testing")}}
 

--- a/files/ja/learn/tools_and_testing/cross_browser_testing/feature_detection/index.md
+++ b/files/ja/learn/tools_and_testing/cross_browser_testing/feature_detection/index.md
@@ -1,20 +1,6 @@
 ---
 title: 機能検出の実装
 slug: Learn/Tools_and_testing/Cross_browser_testing/Feature_detection
-tags:
-  - Article
-  - Beginner
-  - CSS
-  - CodingScripting
-  - JavaScript
-  - Learn
-  - Modernizr
-  - Testing
-  - Tools
-  - cross browser
-  - feature detection
-  - 機能検出
-translation_of: Learn/Tools_and_testing/Cross_browser_testing/Feature_detection
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Tools_and_testing/Cross_browser_testing/Accessibility","Learn/Tools_and_testing/Cross_browser_testing/Automated_testing", "Learn/Tools_and_testing/Cross_browser_testing")}}
 

--- a/files/ja/learn/tools_and_testing/cross_browser_testing/html_and_css/index.md
+++ b/files/ja/learn/tools_and_testing/cross_browser_testing/html_and_css/index.md
@@ -1,18 +1,6 @@
 ---
 title: 一般的な HTML と CSS の問題への対処
 slug: Learn/Tools_and_testing/Cross_browser_testing/HTML_and_CSS
-tags:
-  - Article
-  - Beginner
-  - CSS
-  - CodingScripting
-  - HTML
-  - Learn
-  - Selectors
-  - Testing
-  - cross browser
-  - linting
-translation_of: Learn/Tools_and_testing/Cross_browser_testing/HTML_and_CSS
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Tools_and_testing/Cross_browser_testing/Testing_strategies","Learn/Tools_and_testing/Cross_browser_testing/JavaScript", "Learn/Tools_and_testing/Cross_browser_testing")}}
 

--- a/files/ja/learn/tools_and_testing/cross_browser_testing/index.md
+++ b/files/ja/learn/tools_and_testing/cross_browser_testing/index.md
@@ -1,21 +1,6 @@
 ---
 title: クロスブラウザーテスト
 slug: Learn/Tools_and_testing/Cross_browser_testing
-tags:
-  - Accessibility
-  - Automation
-  - Beginner
-  - CSS
-  - CodingScripting
-  - HTML
-  - JavaScript
-  - Landing
-  - Learn
-  - Module
-  - Testing
-  - Tools
-  - cross browser
-translation_of: Learn/Tools_and_testing/Cross_browser_testing
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/tools_and_testing/cross_browser_testing/introduction/index.md
+++ b/files/ja/learn/tools_and_testing/cross_browser_testing/introduction/index.md
@@ -1,15 +1,6 @@
 ---
 title: はじめてのクロスブラウザーテスト
 slug: Learn/Tools_and_testing/Cross_browser_testing/Introduction
-tags:
-  - Article
-  - Beginner
-  - CodingScripting
-  - Learn
-  - Testing
-  - concepts
-  - cross browser
-translation_of: Learn/Tools_and_testing/Cross_browser_testing/Introduction
 ---
 {{LearnSidebar}}{{NextMenu("Learn/Tools_and_testing/Cross_browser_testing/Testing_strategies", "Learn/Tools_and_testing/Cross_browser_testing")}}
 

--- a/files/ja/learn/tools_and_testing/cross_browser_testing/javascript/index.md
+++ b/files/ja/learn/tools_and_testing/cross_browser_testing/javascript/index.md
@@ -1,19 +1,6 @@
 ---
 title: JavaScript のよくある問題を扱う
 slug: Learn/Tools_and_testing/Cross_browser_testing/JavaScript
-tags:
-  - Article
-  - Beginner
-  - CodingScripting
-  - JavaScript
-  - Learn
-  - Libraries
-  - Testing
-  - cross browser
-  - feature detection
-  - linting
-  - polyfills
-translation_of: Learn/Tools_and_testing/Cross_browser_testing/JavaScript
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Tools_and_testing/Cross_browser_testing/HTML_and_CSS","Learn/Tools_and_testing/Cross_browser_testing/Accessibility", "Learn/Tools_and_testing/Cross_browser_testing")}}
 

--- a/files/ja/learn/tools_and_testing/cross_browser_testing/testing_strategies/index.md
+++ b/files/ja/learn/tools_and_testing/cross_browser_testing/testing_strategies/index.md
@@ -1,19 +1,6 @@
 ---
 title: テスト実行のための戦略
 slug: Learn/Tools_and_testing/Cross_browser_testing/Testing_strategies
-tags:
-  - Article
-  - Automation
-  - Beginner
-  - CodingScripting
-  - Learn
-  - Testing
-  - concepts
-  - cross browser
-  - device lab
-  - user testing
-  - virtual machine
-translation_of: Learn/Tools_and_testing/Cross_browser_testing/Testing_strategies
 ---
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Tools_and_testing/Cross_browser_testing/Introduction","Learn/Tools_and_testing/Cross_browser_testing/HTML_and_CSS", "Learn/Tools_and_testing/Cross_browser_testing")}}
 

--- a/files/ja/learn/tools_and_testing/cross_browser_testing/your_own_automation_environment/index.md
+++ b/files/ja/learn/tools_and_testing/cross_browser_testing/your_own_automation_environment/index.md
@@ -1,18 +1,6 @@
 ---
 title: テスト自動化環境をセットアップする
 slug: Learn/Tools_and_testing/Cross_browser_testing/Your_own_automation_environment
-tags:
-  - Article
-  - Automation
-  - Beginner
-  - Browser
-  - CodingScripting
-  - Learn
-  - Testing
-  - Tools
-  - cross browser
-  - selenium
-translation_of: Learn/Tools_and_testing/Cross_browser_testing/Your_own_automation_environment
 ---
 {{LearnSidebar}}{{PreviousMenu("Learn/Tools_and_testing/Cross_browser_testing/Automated_testing", "Learn/Tools_and_testing/Cross_browser_testing")}}
 

--- a/files/ja/learn/tools_and_testing/github/index.md
+++ b/files/ja/learn/tools_and_testing/github/index.md
@@ -1,12 +1,6 @@
 ---
 title: Git と GitHub
 slug: Learn/Tools_and_testing/GitHub
-tags:
-  - Beginner
-  - GitHub
-  - Learn
-  - Web
-  - git
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/tools_and_testing/index.md
+++ b/files/ja/learn/tools_and_testing/index.md
@@ -1,30 +1,6 @@
 ---
 title: ツールとテスト
 slug: Learn/Tools_and_testing
-tags:
-  - Accessibility
-  - Automation
-  - Beginner
-  - CSS
-  - CodingScripting
-  - HTML
-  - JavaScript
-  - Landing
-  - Learn
-  - Testing
-  - Tools
-  - Topic
-  - cross browser
-  - user testing
-  - アクセシビリティ
-  - クロスブラウザー
-  - ツール
-  - テスト
-  - トピック
-  - 初心者
-  - 学習
-  - 自動化
-translation_of: Learn/Tools_and_testing
 ---
 {{LearnSidebar}}
 

--- a/files/ja/learn/tools_and_testing/understanding_client-side_tools/index.md
+++ b/files/ja/learn/tools_and_testing/understanding_client-side_tools/index.md
@@ -1,17 +1,6 @@
 ---
 title: クライアントサイドウェブ開発ツールの理解
 slug: Learn/Tools_and_testing/Understanding_client-side_tools
-tags:
-  - Beginner
-  - CSS
-  - Deployment
-  - HTML
-  - JavaScript
-  - Learn
-  - Tools
-  - Transformation
-  - client-side
-  - linting
 ---
 {{LearnSidebar}}
 


### PR DESCRIPTION
Part of #7858

`files\ja\learn` から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "tags": 222,
  "translation_of": 233
}
```
