### PR TITLE
remove duplicated frontmatter keys from mdn (ja)

### DIFF
--- a/files/ja/mdn/at_ten/history_of_mdn/index.md
+++ b/files/ja/mdn/at_ten/history_of_mdn/index.md
@@ -1,10 +1,6 @@
 ---
 title: MDN のあゆみ
 slug: MDN/At_ten/History_of_MDN
-tags:
-  - History
-  - MDN Meta
-translation_of: MDN_at_ten/History_of_MDN
 original_slug: MDN_at_ten/History_of_MDN
 i10n:
   sourceCommit: 356b0655db61fafedd864b54d39e04529b52fff4

--- a/files/ja/mdn/at_ten/index.md
+++ b/files/ja/mdn/at_ten/index.md
@@ -1,11 +1,6 @@
 ---
 title: MDN は 10 周年を迎えました
 slug: MDN/At_ten
-tags:
-  - History
-  - Landing
-  - MDN Meta
-translation_of: MDN_at_ten
 original_slug: MDN_at_ten
 i10n:
   sourceCommit: 0160aac0e623dacdce4019205f32f7b3d3e58019

--- a/files/ja/mdn/community/contributing/getting_started/index.md
+++ b/files/ja/mdn/community/contributing/getting_started/index.md
@@ -1,17 +1,6 @@
 ---
 title: MDN で始めよう
 slug: MDN/Community/Contributing/Getting_started
-tags:
-  - Documentation
-  - Getting Started
-  - Guide
-  - MDN
-  - MDN Project
-  - MDN プロジェクト
-  - New Contributors
-  - 初心者
-  - 新たな協力者
-translation_of: MDN/Contribute/Getting_started
 original_slug: MDN/Contribute/Getting_started
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/community/contributing/our_repositories/index.md
+++ b/files/ja/mdn/community/contributing/our_repositories/index.md
@@ -1,14 +1,6 @@
 ---
 title: MDN 上のものはどこにあるのか - リポジトリーのガイド
 slug: MDN/Community/Contributing/Our_repositories
-tags:
-  - Best practices
-  - Community
-  - GitHub
-  - MDN
-  - Beginners
-  - Repos
-translation_of: MDN/Contribute/Where_is_everything
 original_slug: MDN/Contribute/Where_is_everything
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/community/contributing/translated_content/index.md
+++ b/files/ja/mdn/community/contributing/translated_content/index.md
@@ -1,12 +1,6 @@
 ---
 title: MDN Web Docs のローカライズ
 slug: MDN/Community/Contributing/Translated_content
-page-type: mdn-community-guide
-tags:
-  - meta
-  - community-guidelines
-  - governance
-translation_of: MDN/Contribute/Localize
 original_slug: MDN/Contribute/Localize
 l10n:
   sourceCommit: 73dd350fd93be16bee3b9a6b860757265209b4b7

--- a/files/ja/mdn/community/index.md
+++ b/files/ja/mdn/community/index.md
@@ -1,12 +1,6 @@
 ---
 title: コミュニティガイドライン
 slug: MDN/Community
-page-type: mdn-community-guide
-tags:
-  - meta
-  - community-guidelines
-  - governance
-translation_of: MDN/Community
 i10n:
   sourceCommit: 8dbe0b2acd7fdbf533a9bd2f517999cc2035d952
 ---

--- a/files/ja/mdn/community/issues/content_suggestions_feature_proposals/index.md
+++ b/files/ja/mdn/community/issues/content_suggestions_feature_proposals/index.md
@@ -1,10 +1,6 @@
 ---
 title: 外部コンテンツを MDN Web Docs に移行するには
 slug: MDN/Community/Issues/Content_suggestions_feature_proposals
-tags:
-  - Content migration
-  - MDN Meta
-translation_of: MDN/Contribute/Howto/Migrate_external_content_to_MDN
 original_slug: MDN/Contribute/Howto/Migrate_external_content_to_MDN
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/community/issues/index.md
+++ b/files/ja/mdn/community/issues/index.md
@@ -1,11 +1,6 @@
 ---
 title: MDN のための GitHub のベストプラクティス
 slug: MDN/Community/Issues
-tags:
-  - Best practices
-  - Community
-  - GitHub
-  - MDN
 original_slug: MDN/Contribute/GitHub_best_practices
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/community/issues/issue_triage/index.md
+++ b/files/ja/mdn/community/issues/issue_triage/index.md
@@ -1,15 +1,6 @@
 ---
 title: MDN コンテンツのバグのトリアージ手順
 slug: MDN/Community/Issues/Issue_triage
-tags:
-  - MDN
-  - MDN Meta
-  - Meta
-  - Meta Docs
-  - Content bugs
-  - Process
-  - Triage
-translation_of: MDN/Contribute/Processes/Content_bug_triage
 original_slug: MDN/Contribute/Processes/Content_bug_triage
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/community/learn_forum/index.md
+++ b/files/ja/mdn/community/learn_forum/index.md
@@ -1,12 +1,6 @@
 ---
 title: 学習フォーラム
 slug: MDN/Community/Learn_forum
-page-type: mdn-community-guide
-tags:
-  - meta
-  - community-guidelines
-  - governance
-translation_of: MDN/Community/Learn_forum
 original_slug: MDN/Contribute/Help_beginners
 i10n:
   sourceCommit: 8dbe0b2acd7fdbf533a9bd2f517999cc2035d952

--- a/files/ja/mdn/community/mdn_content/index.md
+++ b/files/ja/mdn/community/mdn_content/index.md
@@ -1,10 +1,6 @@
 ---
 title: MDN コンテンツのバグ修正
 slug: MDN/Community/MDN_content
-tags:
-  - Bugs
-  - Contribute
-  - MDN
 original_slug: MDN/Contribute/Fixing_MDN_content_bugs
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/community/open_source_etiquette/index.md
+++ b/files/ja/mdn/community/open_source_etiquette/index.md
@@ -1,13 +1,6 @@
 ---
 title: オープンソースプロジェクトのための基本的なエチケット
 slug: MDN/Community/Open_source_etiquette
-tags:
-  - Best practices
-  - Community
-  - Open source
-  - MDN
-  - Beginners
-translation_of: MDN/Contribute/Open_source_etiquette
 original_slug: MDN/Contribute/Open_source_etiquette
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/contribute/changelog/index.md
+++ b/files/ja/mdn/contribute/changelog/index.md
@@ -1,10 +1,6 @@
 ---
 title: MDN への貢献の変更履歴
 slug: MDN/Contribute/Changelog
-tags:
-  - Changelog
-  - Contribute
-  - MDN
 ---
 {{MDNSidebar}}
 

--- a/files/ja/mdn/contribute/howto/index.md
+++ b/files/ja/mdn/contribute/howto/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'MDN web docs: How-to ガイド'
 slug: MDN/Contribute/Howto
-tags:
-  - Documentation
-  - ガイド
-  - Howto
-  - Landing
-  - MDN Meta
-translation_of: MDN/Contribute/Howto
 ---
 {{MDNSidebar}}
 

--- a/files/ja/mdn/contribute/howto/update_the_css_json_db/index.md
+++ b/files/ja/mdn/contribute/howto/update_the_css_json_db/index.md
@@ -1,11 +1,6 @@
 ---
 title: CSS JSON DB を更新するには
 slug: MDN/Contribute/Howto/Update_the_CSS_JSON_DB
-tags:
-  - Guide
-  - Howto
-  - MDN Meta
-translation_of: MDN/Contribute/Howto/Update_the_CSS_JSON_DB
 ---
 {{MDNSidebar}}
 

--- a/files/ja/mdn/contribute/index.md
+++ b/files/ja/mdn/contribute/index.md
@@ -1,11 +1,6 @@
 ---
 title: MDN への協力
 slug: MDN/Contribute
-tags:
-  - Guide
-  - Landing
-  - MDN Meta
-translation_of: MDN/Contribute
 l10n:
   sourceCommit: b5b22824e0c66855c55b9e4d275890aa3bec9483
 ---

--- a/files/ja/mdn/contribute/processes/index.md
+++ b/files/ja/mdn/contribute/processes/index.md
@@ -1,11 +1,6 @@
 ---
 title: 文書作成のプロセス
 slug: MDN/Contribute/Processes
-tags:
-  - Landing
-  - MDN Meta
-  - Processes
-translation_of: MDN/Contribute/Processes
 ---
 {{MDNSidebar}}
 

--- a/files/ja/mdn/contribute/processes/short_surveys/index.md
+++ b/files/ja/mdn/contribute/processes/short_surveys/index.md
@@ -1,14 +1,6 @@
 ---
 title: 短いアンケートの実施プロセス
 slug: MDN/Contribute/Processes/Short_surveys
-tags:
-  - MDN
-  - MDN Meta
-  - Meta
-  - Meta Docs
-  - Process
-  - Surveys
-  - Short surveys
 ---
 {{MDNSidebar}}
 

--- a/files/ja/mdn/index.md
+++ b/files/ja/mdn/index.md
@@ -1,10 +1,6 @@
 ---
 title: MDN Web Docs プロジェクト
 slug: MDN
-tags:
-  - Landing
-  - MDN Meta
-translation_of: MDN
 i10n:
   commitSource: 8dbe0b2acd7fdbf533a9bd2f517999cc2035d952
 ---

--- a/files/ja/mdn/mdn_product_advisory_board/index.md
+++ b/files/ja/mdn/mdn_product_advisory_board/index.md
@@ -1,11 +1,6 @@
 ---
 title: MDN 製品諮問委員会
 slug: MDN/MDN_Product_Advisory_Board
-tags:
-  - MDN
-  - PAB
-  - 製品諮問委員会
-translation_of: MDN/MDN_Product_Advisory_Board
 ---
 {{MDNSidebar}}
 

--- a/files/ja/mdn/mdn_product_advisory_board/members/index.md
+++ b/files/ja/mdn/mdn_product_advisory_board/members/index.md
@@ -1,12 +1,6 @@
 ---
 title: 製品諮問委員会
 slug: MDN/MDN_Product_Advisory_Board/Members
-tags:
-  - MDN
-  - メンバー
-  - PAB
-  - 製品諮問委員会
-translation_of: MDN/MDN_Product_Advisory_Board/Members
 ---
 {{MDNSidebar}}
 

--- a/files/ja/mdn/mdn_product_advisory_board/membership/index.md
+++ b/files/ja/mdn/mdn_product_advisory_board/membership/index.md
@@ -1,13 +1,6 @@
 ---
 title: 製品諮問委員会憲章および会員資格
 slug: MDN/MDN_Product_Advisory_Board/Membership
-tags:
-  - MDN
-  - Membership
-  - PAB
-  - Product advisory board
-  - Terms and conditions
-translation_of: MDN/MDN_Product_Advisory_Board/Membership
 ---
 {{MDNSidebar}}
 

--- a/files/ja/mdn/tools/index.md
+++ b/files/ja/mdn/tools/index.md
@@ -1,11 +1,6 @@
 ---
 title: MDN のツール
 slug: MDN/Tools
-tags:
-  - Landing
-  - MDN Meta
-  - Tools
-translation_of: MDN/Tools
 ---
 {{MDNSidebar}}
 

--- a/files/ja/mdn/tools/kumascript/index.md
+++ b/files/ja/mdn/tools/kumascript/index.md
@@ -1,14 +1,6 @@
 ---
 title: KumaScript
 slug: MDN/Tools/KumaScript
-tags:
-  - Guide
-  - Kuma
-  - KumaScript
-  - MDN Meta
-  - NeedsContent
-  - Site-wide
-translation_of: MDN/Tools/KumaScript
 ---
 {{MDNSidebar}}
 

--- a/files/ja/mdn/tools/kumascript/troubleshooting/index.md
+++ b/files/ja/mdn/tools/kumascript/troubleshooting/index.md
@@ -1,13 +1,6 @@
 ---
 title: KumaScript エラーのトラブルシューティング
 slug: MDN/Tools/KumaScript/Troubleshooting
-tags:
-  - Errors
-  - Guide
-  - KumaScript
-  - MDN Meta
-  - Tools
-translation_of: MDN/Tools/KumaScript/Troubleshooting
 ---
 {{MDNSidebar}}
 

--- a/files/ja/mdn/tools/sample_server/index.md
+++ b/files/ja/mdn/tools/sample_server/index.md
@@ -1,14 +1,6 @@
 ---
 title: MDN のサンプルサーバー
 slug: MDN/Tools/Sample_server
-tags:
-  - Advanced
-  - Draft
-  - Guide
-  - MDN Meta
-  - Site-wide
-  - Tools
-translation_of: MDN/Tools/Sample_server
 ---
 {{MDNSidebar}}
 

--- a/files/ja/mdn/tools/unsupported_get_api/index.md
+++ b/files/ja/mdn/tools/unsupported_get_api/index.md
@@ -1,17 +1,6 @@
 ---
 title: 非公式の GET API
 slug: MDN/Tools/Unsupported_GET_API
-tags:
-  - Advanced
-  - Automation
-  - Documentation
-  - Draft
-  - Guide
-  - MDN Meta
-  - PUT API
-  - Page-level
-  - Tools
-translation_of: MDN/Tools/Unsupported_GET_API
 ---
 {{MDNSidebar}}
 

--- a/files/ja/mdn/writing_guidelines/attrib_copyright_license/index.md
+++ b/files/ja/mdn/writing_guidelines/attrib_copyright_license/index.md
@@ -1,11 +1,6 @@
 ---
 title: 帰属表示と著作権使用許諾
 slug: MDN/Writing_guidelines/Attrib_copyright_license
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-translation_of: MDN/Writing_guidelines/Attrib_copyright_license
 ---
 {{MDNSidebar}}
 

--- a/files/ja/mdn/writing_guidelines/experimental_deprecated_obsolete/index.md
+++ b/files/ja/mdn/writing_guidelines/experimental_deprecated_obsolete/index.md
@@ -1,13 +1,6 @@
 ---
 title: MDN の慣習と定義
 slug: MDN/Writing_guidelines/Experimental_deprecated_obsolete
-tags:
-  - ドキュメント
-  - ガイド
-  - ガイドライン
-  - MDN
-  - MDN メタ
-translation_of: MDN/Guidelines/Conventions_definitions
 original_slug: MDN/Guidelines/Conventions_definitions
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
+++ b/files/ja/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
@@ -1,13 +1,6 @@
 ---
 title: ページを作成および編集する方法
 slug: MDN/Writing_guidelines/Howto/Creating_moving_deleting
-tags:
-  - 初心者
-  - ガイド
-  - Howto
-  - Intro
-  - MDN メタ
-translation_of: MDN/Contribute/Howto/Create_and_edit_pages
 original_slug: MDN/Contribute/Howto/Create_and_edit_pages
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/writing_guidelines/howto/document_a_css_property/index.md
+++ b/files/ja/mdn/writing_guidelines/howto/document_a_css_property/index.md
@@ -1,11 +1,6 @@
 ---
 title: CSS プロパティの記事を作成するには
 slug: MDN/Writing_guidelines/Howto/Document_a_CSS_property
-tags:
-  - CSS
-  - ガイド
-  - Howto
-  - MDN Meta
 original_slug: MDN/Contribute/Howto/Document_a_CSS_property
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/writing_guidelines/howto/document_an_http_header/index.md
+++ b/files/ja/mdn/writing_guidelines/howto/document_an_http_header/index.md
@@ -1,11 +1,6 @@
 ---
 title: HTTP ヘッダーの記事を作成するには
 slug: MDN/Writing_guidelines/Howto/Document_an_HTTP_header
-tags:
-  - Howto
-  - MDN
-  - Meta
-translation_of: MDN/Contribute/Howto/Document_an_HTTP_header
 original_slug: MDN/Contribute/Howto/Document_an_HTTP_header
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/writing_guidelines/howto/document_web_errors/index.md
+++ b/files/ja/mdn/writing_guidelines/howto/document_web_errors/index.md
@@ -1,11 +1,6 @@
 ---
 title: ウェブのエラーの記事を作成するには
 slug: MDN/Writing_guidelines/Howto/Document_web_errors
-tags:
-  - Howto
-  - MDN
-  - Meta
-translation_of: MDN/Contribute/Howto/Document_web_errors
 original_slug: MDN/Contribute/Howto/Document_web_errors
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/writing_guidelines/howto/images_media/index.md
+++ b/files/ja/mdn/writing_guidelines/howto/images_media/index.md
@@ -1,11 +1,6 @@
 ---
 title: MDN の動画コンテンツ
 slug: MDN/Writing_guidelines/Howto/Images_media
-tags:
-  - ガイドライン
-  - メタ
-  - 動画
-translation_of: MDN/Guidelines/Video
 original_slug: MDN/Guidelines/Video
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/ja/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -1,10 +1,6 @@
 ---
 title: Markdown で書くには
 slug: MDN/Writing_guidelines/Howto/Markdown_in_MDN
-tags:
-  - meta
-  - writing-guide
-translation_of: MDN/Writing_guidelines/Howto/Markdown_in_MDN
 original_slug: MDN/Contribute/Markdown_in_MDN
 l10n:
   sourceCommit: 9ce57d5046baf5d25c8eb066e60227f0fbd017cf

--- a/files/ja/mdn/writing_guidelines/howto/tag/index.md
+++ b/files/ja/mdn/writing_guidelines/howto/tag/index.md
@@ -1,16 +1,6 @@
 ---
 title: 適切にタグづけするには
 slug: MDN/Writing_guidelines/Howto/Tag
-tags:
-  - Beginner
-  - Contribute
-  - Glossary
-  - Guide
-  - Howto
-  - Intro
-  - MDN Meta
-  - Tutorial
-translation_of: MDN/Contribute/Howto/Tag
 original_slug: MDN/Contribute/Howto/Tag
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/writing_guidelines/howto/write_a_new_entry_in_the_glossary/index.md
+++ b/files/ja/mdn/writing_guidelines/howto/write_a_new_entry_in_the_glossary/index.md
@@ -1,18 +1,6 @@
 ---
 title: 用語集の項目を書いたり参照したりするには
 slug: MDN/Writing_guidelines/Howto/Write_a_new_entry_in_the_glossary
-tags:
-  - 協力
-  - 定義
-  - 項目
-  - Glossary
-  - ガイド
-  - Howto
-  - MDN メタ
-  - 用語
-  - Word
-  - define
-translation_of: MDN/Contribute/Howto/Write_a_new_entry_in_the_Glossary
 original_slug: MDN/Contribute/Howto/Write_a_new_entry_in_the_Glossary
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/writing_guidelines/howto/write_an_api_reference/index.md
+++ b/files/ja/mdn/writing_guidelines/howto/write_an_api_reference/index.md
@@ -1,12 +1,6 @@
 ---
 title: API リファレンスの書き方
 slug: MDN/Writing_guidelines/Howto/Write_an_API_reference
-tags:
-  - API
-  - Documentation
-  - Guide
-  - Howto
-  - MDN Meta
 original_slug: MDN/Writing_guidelines/Howto/Write_an_API_reference
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/writing_guidelines/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
+++ b/files/ja/mdn/writing_guidelines/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
@@ -1,16 +1,7 @@
 ---
 title: WebIDL ファイルに含まれる情報
-slug: >-
-  MDN/Writing_guidelines/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file
-tags:
-  - Howto
-  - MDN Meta
-  - Reference
-  - WebIDL
-translation_of: >-
-  MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file
-original_slug: >-
-  MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file
+slug: MDN/Writing_guidelines/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file
+original_slug: MDN/Contribute/Howto/Write_an_API_reference/Information_contained_in_a_WebIDL_file
 ---
 {{MDNSidebar}}
 

--- a/files/ja/mdn/writing_guidelines/howto/write_an_api_reference/sidebars/index.md
+++ b/files/ja/mdn/writing_guidelines/howto/write_an_api_reference/sidebars/index.md
@@ -1,18 +1,6 @@
 ---
 title: API リファレンスサイドバー
 slug: MDN/Writing_guidelines/Howto/Write_an_API_reference/Sidebars
-tags:
-  - API
-  - Documentation
-  - Guide
-  - MDN
-  - MDN Meta
-  - Reference
-  - groupdata
-  - metadata
-  - onboarding
-  - sidebars
-translation_of: MDN/Contribute/Howto/Write_an_API_reference/Sidebars
 original_slug: MDN/Contribute/Howto/Write_an_API_reference/Sidebars
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/writing_guidelines/index.md
+++ b/files/ja/mdn/writing_guidelines/index.md
@@ -1,11 +1,6 @@
 ---
 title: 執筆ガイドライン
 slug: MDN/Writing_guidelines
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-translation_of: MDN/Writing_guidelines
 original_slug: MDN/About
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/writing_guidelines/page_structures/banners_and_notices/index.md
+++ b/files/ja/mdn/writing_guidelines/page_structures/banners_and_notices/index.md
@@ -1,11 +1,6 @@
 ---
 title: バナーと注意
 slug: MDN/Writing_guidelines/Page_structures/Banners_and_notices
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-translation_of: MDN/Writing_guidelines/Page_structures/Banners_and_notices
 original_slug: MDN/Structures/Banners_and_notices
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/writing_guidelines/page_structures/code_examples/index.md
+++ b/files/ja/mdn/writing_guidelines/page_structures/code_examples/index.md
@@ -1,11 +1,6 @@
 ---
 title: コードサンプル
 slug: MDN/Writing_guidelines/Page_structures/Code_examples
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-translation_of: MDN/Writing_guidelines/Page_structures/Code_examples
 original_slug: MDN/Writing_guidelines/Page_structures/Code_examples
 ---
 

--- a/files/ja/mdn/writing_guidelines/page_structures/compatibility_tables/index.md
+++ b/files/ja/mdn/writing_guidelines/page_structures/compatibility_tables/index.md
@@ -1,13 +1,7 @@
 ---
 title: 互換性一覧表とブラウザー互換性データリポジトリー (BCD)
 slug: MDN/Writing_guidelines/Page_structures/Compatibility_tables
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-translation_of: MDN/Writing_guidelines/Page_structures/Compatibility_tables
 original_slug: MDN/Structures/Compatibility_tables
-browser-compat: api.AbortController
 l10n:
   sourceCommit: 1c5c86c721a5935e89065246d49506f1d4cf9567
 ---

--- a/files/ja/mdn/writing_guidelines/page_structures/index.md
+++ b/files/ja/mdn/writing_guidelines/page_structures/index.md
@@ -1,11 +1,6 @@
 ---
 title: 文書の構造
 slug: MDN/Writing_guidelines/Page_structures
-tags:
-  - Landing
-  - MDN Meta
-  - Structures
-translation_of: MDN/Writing_guidelines/Page_structures
 original_slug: MDN/Structures
 l10n:
   sourceCommit: 8dbe0b2acd7fdbf533a9bd2f517999cc2035d952

--- a/files/ja/mdn/writing_guidelines/page_structures/live_samples/index.md
+++ b/files/ja/mdn/writing_guidelines/page_structures/live_samples/index.md
@@ -1,11 +1,6 @@
 ---
 title: ライブサンプル
 slug: MDN/Writing_guidelines/Page_structures/Live_samples
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-translation_of: MDN/Writing_guidelines/Page_structures/Live_samples
 original_slug: MDN/Structures/Live_samples
 l10n:
   sourceCommit: 1c5c86c721a5935e89065246d49506f1d4cf9567

--- a/files/ja/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
+++ b/files/ja/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
@@ -1,11 +1,6 @@
 ---
 title: よく使われるマクロ
 slug: MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-translation_of: MDN/Writing_guidelines/Page_structures/Macros/Commonly-used_macros
 original_slug: MDN/Structures/Macros/Commonly-used_macros
 l10n:
   sourceCommit: 73dd350fd93be16bee3b9a6b860757265209b4b7

--- a/files/ja/mdn/writing_guidelines/page_structures/macros/index.md
+++ b/files/ja/mdn/writing_guidelines/page_structures/macros/index.md
@@ -1,11 +1,6 @@
 ---
 title: マクロの使用
 slug: MDN/Writing_guidelines/Page_structures/Macros
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-translation_of: MDN/Writing_guidelines/Page_structures/Macros
 original_slug: MDN/Structures/Macros
 l10n:
   sourceCommit: 73dd350fd93be16bee3b9a6b860757265209b4b7

--- a/files/ja/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
+++ b/files/ja/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
@@ -1,12 +1,6 @@
 ---
 title: API イベントサブページのテンプレート
 slug: MDN/Writing_guidelines/Page_structures/Page_types/API_event_subpage_template
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-browser-compat: path.to.feature.NameOfTheEvent_event
-translation_of: MDN/Writing_guidelines/Page_structures/Page_types/API_event_subpage_template
 original_slug: MDN/Structures/Page_types/API_event_subpage_template
 l10n:
   sourceCommit: 73dd350fd93be16bee3b9a6b860757265209b4b7

--- a/files/ja/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
+++ b/files/ja/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
@@ -1,12 +1,6 @@
 ---
 title: API メソッドサブページのテンプレート
 slug: MDN/Writing_guidelines/Page_structures/Page_types/API_method_subpage_template
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-browser-compat: path.to.feature.NameOfTheMethod
-translation_of: MDN/Writing_guidelines/Page_structures/Page_types/API_method_subpage_template
 original_slug: MDN/Structures/Page_types/API_method_subpage_template
 l10n:
   sourceCommit: 73dd350fd93be16bee3b9a6b860757265209b4b7

--- a/files/ja/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
+++ b/files/ja/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
@@ -1,12 +1,6 @@
 ---
 title: API プロパティサブページのテンプレート
 slug: MDN/Writing_guidelines/Page_structures/Page_types/API_property_subpage_template
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-browser-compat: path.to.feature.NameOfTheProperty
-translation_of: MDN/Writing_guidelines/Page_structures/Page_types/API_property_subpage_template
 original_slug: MDN/Structures/Page_types/API_property_subpage_template
 l10n:
   sourceCommit: 73dd350fd93be16bee3b9a6b860757265209b4b7

--- a/files/ja/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
+++ b/files/ja/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
@@ -1,12 +1,6 @@
 ---
 title: API リファレンスページのテンプレート
 slug: MDN/Writing_guidelines/Page_structures/Page_types/API_reference_page_template
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-browser-compat: path.to.feature.インターフェイス名
-translation_of: MDN/Writing_guidelines/Page_structures/Page_types/API_reference_page_template
 original_slug: MDN/Structures/Page_types/API_reference_page_template
 l10n:
   sourceCommit: 73dd350fd93be16bee3b9a6b860757265209b4b7

--- a/files/ja/mdn/writing_guidelines/page_structures/page_types/index.md
+++ b/files/ja/mdn/writing_guidelines/page_structures/page_types/index.md
@@ -1,11 +1,6 @@
 ---
 title: ページの種類
 slug: MDN/Writing_guidelines/Page_structures/Page_types
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-translation_of: MDN/Writing_guidelines/Page_structures/Page_types
 original_slug: MDN/Structures/Page_types
 l10n:
   sourceCommit: 73dd350fd93be16bee3b9a6b860757265209b4b7

--- a/files/ja/mdn/writing_guidelines/page_structures/quicklinks/index.md
+++ b/files/ja/mdn/writing_guidelines/page_structures/quicklinks/index.md
@@ -1,11 +1,6 @@
 ---
 title: クイックリンク
 slug: MDN/Writing_guidelines/Page_structures/Quicklinks
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-translation_of: MDN/Writing_guidelines/Page_structures/Quicklinks
 original_slug: MDN/Structures/Quicklinks
 l10n:
   sourceCommit: 1c5c86c721a5935e89065246d49506f1d4cf9567

--- a/files/ja/mdn/writing_guidelines/page_structures/specification_tables/index.md
+++ b/files/ja/mdn/writing_guidelines/page_structures/specification_tables/index.md
@@ -1,11 +1,6 @@
 ---
 title: 仕様書一覧表
 slug: MDN/Writing_guidelines/Page_structures/Specification_tables
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-translation_of: MDN/Writing_guidelines/Page_structures/Specification_tables
 original_slug: MDN/Structures/Specification_tables
 l10n:
   sourceCommit: 1c5c86c721a5935e89065246d49506f1d4cf9567

--- a/files/ja/mdn/writing_guidelines/page_structures/syntax_sections/index.md
+++ b/files/ja/mdn/writing_guidelines/page_structures/syntax_sections/index.md
@@ -1,11 +1,6 @@
 ---
 title: 構文の節
 slug: MDN/Writing_guidelines/Page_structures/Syntax_sections
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-translation_of: MDN/Writing_guidelines/Page_structures/Syntax_sections
 original_slug: MDN/Structures/Syntax_sections
 l10n:
   sourceCommit: 1c5c86c721a5935e89065246d49506f1d4cf9567

--- a/files/ja/mdn/writing_guidelines/what_we_write/criteria_for_inclusion/index.md
+++ b/files/ja/mdn/writing_guidelines/what_we_write/criteria_for_inclusion/index.md
@@ -1,11 +1,6 @@
 ---
 title: MDN Web Docs の掲載基準
 slug: MDN/Writing_guidelines/What_we_write/Criteria_for_inclusion
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-translation_of: MDN/Writing_guidelines/What_we_write/Criteria_for_inclusion
 ---
 
 {{MDNSidebar}}

--- a/files/ja/mdn/writing_guidelines/what_we_write/index.md
+++ b/files/ja/mdn/writing_guidelines/what_we_write/index.md
@@ -1,11 +1,6 @@
 ---
 title: 私たちが書くものは何か
 slug: MDN/Writing_guidelines/What_we_write
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-translation_of: MDN/Writing_guidelines/What_we_write
 ---
 {{MDNSidebar}}  
 

--- a/files/ja/mdn/writing_guidelines/writing_style_guide/code_style_guide/css/index.md
+++ b/files/ja/mdn/writing_guidelines/writing_style_guide/code_style_guide/css/index.md
@@ -1,11 +1,6 @@
 ---
 title: CSS のコード例を整形するためのガイドライン
 slug: MDN/Writing_guidelines/Writing_style_guide/Code_style_guide/CSS
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-translation_of: MDN/Writing_guidelines/Writing_style_guide/Code_style_guide/CSS
 original_slug: MDN/Guidelines/Code_guidelines/CSS
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
+++ b/files/ja/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
@@ -1,11 +1,6 @@
 ---
 title: HTML のコード例を整形するためのガイドライン
 slug: MDN/Writing_guidelines/Writing_style_guide/Code_style_guide/HTML
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-translation_of: MDN/Writing_guidelines/Writing_style_guide/Code_style_guide/HTML
 original_slug: MDN/Guidelines/Code_guidelines/HTML
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/writing_guidelines/writing_style_guide/code_style_guide/index.md
+++ b/files/ja/mdn/writing_guidelines/writing_style_guide/code_style_guide/index.md
@@ -1,11 +1,6 @@
 ---
 title: コード例のガイドライン
 slug: MDN/Writing_guidelines/Writing_style_guide/Code_style_guide
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-translation_of: MDN/Writing_guidelines/Writing_style_guide/Code_style_guide
 original_slug: MDN/Guidelines/Code_guidelines
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
+++ b/files/ja/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
@@ -1,11 +1,6 @@
 ---
 title: JavaScript のコード例を整形するためのガイドライン
 slug: MDN/Writing_guidelines/Writing_style_guide/Code_style_guide/JavaScript
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-translation_of: MDN/Writing_guidelines/Writing_style_guide/Code_style_guide/JavaScript
 original_slug: MDN/Guidelines/Code_guidelines/JavaScript
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/writing_guidelines/writing_style_guide/code_style_guide/shell/index.md
+++ b/files/ja/mdn/writing_guidelines/writing_style_guide/code_style_guide/shell/index.md
@@ -1,11 +1,6 @@
 ---
 title: シェルプロンプトのコード例を整形するためのガイドライン
 slug: MDN/Writing_guidelines/Writing_style_guide/Code_style_guide/Shell
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-translation_of: MDN/Writing_guidelines/Writing_style_guide/Code_style_guide/Shell
 original_slug: MDN/Guidelines/Code_guidelines/Shell
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/writing_guidelines/writing_style_guide/index.md
+++ b/files/ja/mdn/writing_guidelines/writing_style_guide/index.md
@@ -1,11 +1,6 @@
 ---
 title: 執筆スタイルガイド
 slug: MDN/Writing_guidelines/Writing_style_guide
-page-type: mdn-writing-guide
-tags:
-  - meta
-  - writing-guide
-translation_of: MDN/Writing_guidelines/Writing_style_guide
 original_slug: MDN/Guidelines/Writing_style_guide
 ---
 {{MDNSidebar}}

--- a/files/ja/mdn/yari/index.md
+++ b/files/ja/mdn/yari/index.md
@@ -1,11 +1,6 @@
 ---
 title: 'Yari: MDN のレンダリングプラットフォーム'
 slug: MDN/Yari
-tags:
-  - Yari
-  - Landing
-  - MDN Meta
-translation_of: MDN/Yari
 ---
 {{MDNSidebar}}
 

--- a/files/ja/orphaned/mdn/contribute/howto/add_or_update_browser_compatibility_data/index.md
+++ b/files/ja/orphaned/mdn/contribute/howto/add_or_update_browser_compatibility_data/index.md
@@ -1,11 +1,6 @@
 ---
 title: ブラウザーの互換性データを追加したり更新したりするには
 slug: orphaned/MDN/Contribute/Howto/Add_or_update_browser_compatibility_data
-tags:
-  - ガイド
-  - Howto
-  - MDN Meta
-translation_of: MDN/Contribute/Howto/Add_or_update_browser_compatibility_data
 original_slug: MDN/Contribute/Howto/Add_or_update_browser_compatibility_data
 ---
 {{MDNSidebar}}


### PR DESCRIPTION
Part of #7858

`files\ja\mdn` から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "tags": 66,
  "translation_of": 60,
  "page-type": 27,
  "browser-compat": 5
}
```