### PR TITLE
remove duplicated frontmatter keys from mozilla (ja)

### DIFF
--- a/files/ja/mozilla/add-ons/contact_us/index.md
+++ b/files/ja/mozilla/add-ons/contact_us/index.md
@@ -1,13 +1,6 @@
 ---
 title: 連絡先
 slug: Mozilla/Add-ons/Contact_us
-tags:
-  - Add-ons
-  - Extension
-  - Extensions
-  - Landing
-  - Mozilla
-translation_of: Mozilla/Add-ons/Contact_us
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/index.md
+++ b/files/ja/mozilla/add-ons/index.md
@@ -1,13 +1,6 @@
 ---
 title: アドオン
 slug: Mozilla/Add-ons
-tags:
-  - Add-ons
-  - Extension
-  - Extensions
-  - Landing
-  - Mozilla
-translation_of: Mozilla/Add-ons
 ---
 {{AddonSidebarMain}}
 

--- a/files/ja/mozilla/add-ons/webextensions/add_a_button_to_the_toolbar/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/add_a_button_to_the_toolbar/index.md
@@ -1,9 +1,6 @@
 ---
 title: ツールバーにボタンを追加する
 slug: Mozilla/Add-ons/WebExtensions/Add_a_button_to_the_toolbar
-tags:
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/Add_a_button_to_the_toolbar
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/anatomy_of_a_webextension/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/anatomy_of_a_webextension/index.md
@@ -1,9 +1,6 @@
 ---
 title: 拡張機能の中身
 slug: Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension
-tags:
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/alarms/alarm/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/alarms/alarm/index.md
@@ -1,17 +1,6 @@
 ---
 title: alarms.Alarm
 slug: Mozilla/Add-ons/WebExtensions/API/alarms/Alarm
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - alarm
-  - alarms
-translation_of: Mozilla/Add-ons/WebExtensions/API/alarms/Alarm
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/alarms/clear/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/alarms/clear/index.md
@@ -1,17 +1,6 @@
 ---
 title: alarms.clear()
 slug: Mozilla/Add-ons/WebExtensions/API/alarms/clear
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - alarms
-  - clear
-translation_of: Mozilla/Add-ons/WebExtensions/API/alarms/clear
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/alarms/clearall/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/alarms/clearall/index.md
@@ -1,17 +1,6 @@
 ---
 title: alarms.clearAll()
 slug: Mozilla/Add-ons/WebExtensions/API/alarms/clearAll
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - alarms
-  - clearAll
-translation_of: Mozilla/Add-ons/WebExtensions/API/alarms/clearAll
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/alarms/create/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/alarms/create/index.md
@@ -1,17 +1,6 @@
 ---
 title: alarms.create()
 slug: Mozilla/Add-ons/WebExtensions/API/alarms/create
-tags:
-  - API
-  - Add-ons
-  - Create
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - alarms
-translation_of: Mozilla/Add-ons/WebExtensions/API/alarms/create
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/alarms/get/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/alarms/get/index.md
@@ -1,17 +1,6 @@
 ---
 title: alarms.get()
 slug: Mozilla/Add-ons/WebExtensions/API/alarms/get
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - alarms
-  - get
-translation_of: Mozilla/Add-ons/WebExtensions/API/alarms/get
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/alarms/getall/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/alarms/getall/index.md
@@ -1,17 +1,6 @@
 ---
 title: alarms.getAll()
 slug: Mozilla/Add-ons/WebExtensions/API/alarms/getAll
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - alarms
-  - getAll
-translation_of: Mozilla/Add-ons/WebExtensions/API/alarms/getAll
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/alarms/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/alarms/index.md
@@ -1,7 +1,6 @@
 ---
 title: alarms
 slug: Mozilla/Add-ons/WebExtensions/API/alarms
-translation_of: Mozilla/Add-ons/WebExtensions/API/alarms
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/alarms/onalarm/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/alarms/onalarm/index.md
@@ -1,17 +1,6 @@
 ---
 title: alarms.onAlarm
 slug: Mozilla/Add-ons/WebExtensions/API/alarms/onAlarm
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - alarms
-  - onAlarm
-translation_of: Mozilla/Add-ons/WebExtensions/API/alarms/onAlarm
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
@@ -1,17 +1,6 @@
 ---
 title: bookmarks.BookmarkTreeNode
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNode
-tags:
-  - API
-  - Add-ons
-  - BookmarkTreeNode
-  - Bookmarks
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNode
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodetype/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodetype/index.md
@@ -1,16 +1,6 @@
 ---
 title: bookmarks.BookmarkTreeNodeType
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNodeType
-tags:
-  - API
-  - Add-ons
-  - BookmarkTreeNodeType
-  - Bookmarks
-  - Extensions
-  - Property
-  - Reference
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNodeType
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.md
@@ -1,17 +1,6 @@
 ---
 title: bookmarks.BookmarkTreeNodeUnmodifiable
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNodeUnmodifiable
-tags:
-  - API
-  - Add-ons
-  - BookmarkTreeNodeUnmodifiable
-  - Bookmarks
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNodeUnmodifiable
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/create/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/create/index.md
@@ -1,17 +1,6 @@
 ---
 title: bookmarks.create()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/create
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Create
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/create
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.md
@@ -1,17 +1,6 @@
 ---
 title: bookmarks.CreateDetails
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/CreateDetails
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - CreateDetails
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/CreateDetails
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/get/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/get/index.md
@@ -1,17 +1,6 @@
 ---
 title: bookmarks.get()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/get
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - get
-translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/get
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.md
@@ -1,17 +1,6 @@
 ---
 title: bookmarks.getChildren()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/getChildren
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getChildren
-translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/getChildren
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/getrecent/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/getrecent/index.md
@@ -1,17 +1,6 @@
 ---
 title: bookmarks.getRecent()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/getRecent
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getRecent
-translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/getRecent
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/getsubtree/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/getsubtree/index.md
@@ -1,17 +1,6 @@
 ---
 title: bookmarks.getSubTree()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/getSubTree
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getSubTree
-translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/getSubTree
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/gettree/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/gettree/index.md
@@ -1,17 +1,6 @@
 ---
 title: bookmarks.getTree()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/getTree
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getTree
-translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/getTree
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/index.md
@@ -1,16 +1,6 @@
 ---
 title: bookmarks
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/move/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/move/index.md
@@ -1,7 +1,6 @@
 ---
 title: bookmarks.move()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/move
-translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/move
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/onchanged/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/onchanged/index.md
@@ -1,17 +1,6 @@
 ---
 title: bookmarks.onChanged
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/onChanged
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onChanged
-translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/onChanged
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/onchildrenreordered/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/onchildrenreordered/index.md
@@ -1,17 +1,6 @@
 ---
 title: bookmarks.onChildrenReordered
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/onChildrenReordered
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onChildrenReordered
-translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/onChildrenReordered
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/oncreated/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/oncreated/index.md
@@ -1,17 +1,6 @@
 ---
 title: bookmarks.onCreated
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/onCreated
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onCreated
-translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/onCreated
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/onimportbegan/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/onimportbegan/index.md
@@ -1,17 +1,6 @@
 ---
 title: bookmarks.onImportBegan
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/onImportBegan
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onImportBegan
-translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/onImportBegan
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/onimportended/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/onimportended/index.md
@@ -1,17 +1,6 @@
 ---
 title: bookmarks.onImportEnded
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/onImportEnded
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onImportEnded
-translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/onImportEnded
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.md
@@ -1,17 +1,6 @@
 ---
 title: bookmarks.onMoved
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/onMoved
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onMoved
-translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/onMoved
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/onremoved/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/onremoved/index.md
@@ -1,17 +1,6 @@
 ---
 title: bookmarks.onRemoved
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/onRemoved
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onRemoved
-translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/onRemoved
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/remove/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/remove/index.md
@@ -1,17 +1,6 @@
 ---
 title: bookmarks.remove()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/remove
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - remove
-translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/remove
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.md
@@ -1,17 +1,6 @@
 ---
 title: bookmarks.removeTree()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/removeTree
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - removeTree
-translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/removeTree
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/search/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/search/index.md
@@ -1,17 +1,6 @@
 ---
 title: bookmarks.search()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/search
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - Search
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/search
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/bookmarks/update/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/bookmarks/update/index.md
@@ -1,17 +1,6 @@
 ---
 title: bookmarks.update()
 slug: Mozilla/Add-ons/WebExtensions/API/bookmarks/update
-tags:
-  - API
-  - Add-ons
-  - Bookmarks
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - Update
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API/bookmarks/update
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/browseraction/colorarray/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/browseraction/colorarray/index.md
@@ -1,7 +1,6 @@
 ---
 title: browserAction.ColorArray
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/ColorArray
-translation_of: Mozilla/Add-ons/WebExtensions/API/browserAction/ColorArray
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/browseraction/disable/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/browseraction/disable/index.md
@@ -1,7 +1,6 @@
 ---
 title: browserAction.disable()
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/disable
-translation_of: Mozilla/Add-ons/WebExtensions/API/browserAction/disable
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/browseraction/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/browseraction/index.md
@@ -1,16 +1,6 @@
 ---
 title: browserAction
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - browserAction
-translation_of: Mozilla/Add-ons/WebExtensions/API/browserAction
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.md
@@ -1,7 +1,6 @@
 ---
 title: browserAction.onClicked
 slug: Mozilla/Add-ons/WebExtensions/API/browserAction/onClicked
-translation_of: Mozilla/Add-ons/WebExtensions/API/browserAction/onClicked
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/browsersettings/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/browsersettings/index.md
@@ -1,15 +1,6 @@
 ---
 title: browserSettings
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - browserSettings
-translation_of: Mozilla/Add-ons/WebExtensions/API/browserSettings
 ---
 {{AddonSidebar}}拡張機能にグローバルなブラウザー設定の変更を可能にします。この API の各プロパティは {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} オブジェクトで、これはそれぞれの設定の変更能力を提供します。これはグローバルな設定のため、拡張機能で衝突が起きる可能性があります。衝突の処理方法の詳細は [`BrowserSetting.set()`](/ja/Add-ons/WebExtensions/API/types/BrowserSetting/set) の文書を見てください。
 

--- a/files/ja/mozilla/add-ons/webextensions/api/browsersettings/newtabpageoverride/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/browsersettings/newtabpageoverride/index.md
@@ -1,7 +1,6 @@
 ---
 title: browserSettings.newTabPageOverride
 slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/newTabPageOverride
-translation_of: Mozilla/Add-ons/WebExtensions/API/browserSettings/newTabPageOverride
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/browsingdata/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/browsingdata/index.md
@@ -1,15 +1,6 @@
 ---
 title: browsingData
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - browsingData
-translation_of: Mozilla/Add-ons/WebExtensions/API/browsingData
 ---
 {{AddonSidebar}}拡張機能がユーザーの閲覧中に蓄積したデータをクリアできるようにします。
 

--- a/files/ja/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.md
@@ -1,16 +1,6 @@
 ---
 title: browsingData.removeCache()
 slug: Mozilla/Add-ons/WebExtensions/API/browsingData/removeCache
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Reference
-  - WebExtensions
-  - browsingData
-  - removeCache
-translation_of: Mozilla/Add-ons/WebExtensions/API/browsingData/removeCache
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/clipboard/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/clipboard/index.md
@@ -1,14 +1,6 @@
 ---
 title: clipboard
 slug: Mozilla/Add-ons/WebExtensions/API/clipboard
-tags:
-  - API
-  - Add-ons
-  - Clipboard
-  - Extensions
-  - Reference
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API/clipboard
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.md
@@ -1,7 +1,6 @@
 ---
 title: clipboard.setImageData()
 slug: Mozilla/Add-ons/WebExtensions/API/clipboard/setImageData
-translation_of: Mozilla/Add-ons/WebExtensions/API/clipboard/setImageData
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/commands/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/commands/index.md
@@ -1,14 +1,6 @@
 ---
 title: commands
 slug: Mozilla/Add-ons/WebExtensions/API/commands
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - commands
-translation_of: Mozilla/Add-ons/WebExtensions/API/commands
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/contentscripts/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/contentscripts/index.md
@@ -1,16 +1,6 @@
 ---
 title: contentScripts
 slug: Mozilla/Add-ons/WebExtensions/API/contentScripts
-tags:
-  - API
-  - Extensions
-  - Interface
-  - WebExtensions
-  - contentScripts
-  - インタフェース
-  - コンテントスクリプト
-  - 拡張機能
-translation_of: Mozilla/Add-ons/WebExtensions/API/contentScripts
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
@@ -1,14 +1,6 @@
 ---
 title: contentScripts.register()
 slug: Mozilla/Add-ons/WebExtensions/API/contentScripts/register
-tags:
-  - API
-  - Extensions
-  - Method
-  - Reference
-  - contentScripts
-  - register
-translation_of: Mozilla/Add-ons/WebExtensions/API/contentScripts/register
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/contextualidentities/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/contextualidentities/index.md
@@ -1,9 +1,6 @@
 ---
 title: contextualIdentities
 slug: Mozilla/Add-ons/WebExtensions/API/contextualIdentities
-tags:
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API/contextualIdentities
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
@@ -1,17 +1,6 @@
 ---
 title: cookies.Cookie
 slug: Mozilla/Add-ons/WebExtensions/API/cookies/Cookie
-tags:
-  - API
-  - Add-ons
-  - Cookies
-  - Extensions
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - cookie
-translation_of: Mozilla/Add-ons/WebExtensions/API/cookies/Cookie
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/cookies/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/cookies/index.md
@@ -1,15 +1,6 @@
 ---
 title: cookies
 slug: Mozilla/Add-ons/WebExtensions/API/cookies
-tags:
-  - API
-  - Add-ons
-  - Cookies
-  - Extensions
-  - Interface
-  - Reference
-  - dard
-translation_of: Mozilla/Add-ons/WebExtensions/API/cookies
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.md
@@ -1,7 +1,6 @@
 ---
 title: devtools.inspectedWindow.eval()
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/inspectedWindow/eval
-translation_of: Mozilla/Add-ons/WebExtensions/API/devtools.inspectedWindow/eval
 original_slug: Mozilla/Add-ons/WebExtensions/API/devtools.inspectedWindow/eval
 ---
 {{AddonSidebar()}}

--- a/files/ja/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/index.md
@@ -1,14 +1,6 @@
 ---
 title: devtools.inspectedWindow
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/inspectedWindow
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - devtools.inspectedWindow
-translation_of: Mozilla/Add-ons/WebExtensions/API/devtools.inspectedWindow
 original_slug: Mozilla/Add-ons/WebExtensions/API/devtools.inspectedWindow
 ---
 {{AddonSidebar}}

--- a/files/ja/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.md
@@ -1,7 +1,6 @@
 ---
 title: devtools.inspectedWindow.tabId
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/inspectedWindow/tabId
-translation_of: Mozilla/Add-ons/WebExtensions/API/devtools.inspectedWindow/tabId
 original_slug: Mozilla/Add-ons/WebExtensions/API/devtools.inspectedWindow/tabId
 ---
 {{AddonSidebar()}}

--- a/files/ja/mozilla/add-ons/webextensions/api/devtools/network/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/devtools/network/index.md
@@ -1,14 +1,6 @@
 ---
 title: devtools.network
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/network
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - devtools.network
-translation_of: Mozilla/Add-ons/WebExtensions/API/devtools.network
 original_slug: Mozilla/Add-ons/WebExtensions/API/devtools.network
 ---
 {{AddonSidebar}}

--- a/files/ja/mozilla/add-ons/webextensions/api/devtools/panels/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/devtools/panels/index.md
@@ -1,14 +1,6 @@
 ---
 title: devtools.panels
 slug: Mozilla/Add-ons/WebExtensions/API/devtools/panels
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - devtools.panels
-translation_of: Mozilla/Add-ons/WebExtensions/API/devtools.panels
 original_slug: Mozilla/Add-ons/WebExtensions/API/devtools.panels
 ---
 {{AddonSidebar}}

--- a/files/ja/mozilla/add-ons/webextensions/api/downloads/download/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/downloads/download/index.md
@@ -1,7 +1,6 @@
 ---
 title: downloads.download()
 slug: Mozilla/Add-ons/WebExtensions/API/downloads/download
-translation_of: Mozilla/Add-ons/WebExtensions/API/downloads/download
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/downloads/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/downloads/index.md
@@ -1,16 +1,6 @@
 ---
 title: downloads
 slug: Mozilla/Add-ons/WebExtensions/API/downloads
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - downloads
-translation_of: Mozilla/Add-ons/WebExtensions/API/downloads
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/events/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/events/index.md
@@ -1,16 +1,6 @@
 ---
 title: events
 slug: Mozilla/Add-ons/WebExtensions/API/events
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - events
-translation_of: Mozilla/Add-ons/WebExtensions/API/events
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/extension/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/extension/index.md
@@ -1,16 +1,6 @@
 ---
 title: extension
 slug: Mozilla/Add-ons/WebExtensions/API/extension
-tags:
-  - API
-  - Add-ons
-  - Extension
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API/extension
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.md
@@ -1,17 +1,6 @@
 ---
 title: extensionTypes.ImageDetails
 slug: Mozilla/Add-ons/WebExtensions/API/extensionTypes/ImageDetails
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - ImageDetails
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - extensionTypes
-translation_of: Mozilla/Add-ons/WebExtensions/API/extensionTypes/ImageDetails
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/extensiontypes/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/extensiontypes/index.md
@@ -1,16 +1,6 @@
 ---
 title: extensionTypes
 slug: Mozilla/Add-ons/WebExtensions/API/extensionTypes
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - extensionTypes
-translation_of: Mozilla/Add-ons/WebExtensions/API/extensionTypes
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/extensiontypes/runat/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/extensiontypes/runat/index.md
@@ -1,17 +1,6 @@
 ---
 title: extensionTypes.RunAt
 slug: Mozilla/Add-ons/WebExtensions/API/extensionTypes/RunAt
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - RunAt
-  - Type
-  - WebExtensions
-  - extensionTypes
-translation_of: Mozilla/Add-ons/WebExtensions/API/extensionTypes/RunAt
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/find/find/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/find/find/index.md
@@ -1,7 +1,6 @@
 ---
 title: find.find()
 slug: Mozilla/Add-ons/WebExtensions/API/find/find
-translation_of: Mozilla/Add-ons/WebExtensions/API/find/find
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/find/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/find/index.md
@@ -1,14 +1,6 @@
 ---
 title: find
 slug: Mozilla/Add-ons/WebExtensions/API/find
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - find
-translation_of: Mozilla/Add-ons/WebExtensions/API/find
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/history/historyitem/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/history/historyitem/index.md
@@ -1,17 +1,6 @@
 ---
 title: history.HistoryItem
 slug: Mozilla/Add-ons/WebExtensions/API/history/HistoryItem
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - History
-  - HistoryItem
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API/history/HistoryItem
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/history/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/history/index.md
@@ -1,16 +1,6 @@
 ---
 title: history
 slug: Mozilla/Add-ons/WebExtensions/API/history
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - History
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API/history
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.md
@@ -1,17 +1,6 @@
 ---
 title: i18n.detectLanguage()
 slug: Mozilla/Add-ons/WebExtensions/API/i18n/detectLanguage
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - detectLanguage
-  - i18n
-translation_of: Mozilla/Add-ons/WebExtensions/API/i18n/detectLanguage
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.md
@@ -1,17 +1,6 @@
 ---
 title: i18n.getAcceptLanguages()
 slug: Mozilla/Add-ons/WebExtensions/API/i18n/getAcceptLanguages
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getAcceptLanguages
-  - i18n
-translation_of: Mozilla/Add-ons/WebExtensions/API/i18n/getAcceptLanguages
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/i18n/getmessage/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/i18n/getmessage/index.md
@@ -1,17 +1,6 @@
 ---
 title: i18n.getMessage()
 slug: Mozilla/Add-ons/WebExtensions/API/i18n/getMessage
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getMessage
-  - i18n
-translation_of: Mozilla/Add-ons/WebExtensions/API/i18n/getMessage
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.md
@@ -1,17 +1,6 @@
 ---
 title: i18n.getUILanguage()
 slug: Mozilla/Add-ons/WebExtensions/API/i18n/getUILanguage
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - getUILanguage
-  - i18n
-translation_of: Mozilla/Add-ons/WebExtensions/API/i18n/getUILanguage
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/i18n/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/i18n/index.md
@@ -1,16 +1,6 @@
 ---
 title: i18n
 slug: Mozilla/Add-ons/WebExtensions/API/i18n
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - i18n
-translation_of: Mozilla/Add-ons/WebExtensions/API/i18n
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/i18n/languagecode/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/i18n/languagecode/index.md
@@ -1,17 +1,6 @@
 ---
 title: i18n.LanguageCode
 slug: Mozilla/Add-ons/WebExtensions/API/i18n/LanguageCode
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - LanguageCode
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - i18n
-translation_of: Mozilla/Add-ons/WebExtensions/API/i18n/LanguageCode
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/i18n/locale-specific_message_reference/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/i18n/locale-specific_message_reference/index.md
@@ -1,17 +1,6 @@
 ---
 title: ロケール固有のメッセージ参照
 slug: Mozilla/Add-ons/WebExtensions/API/i18n/Locale-Specific_Message_reference
-tags:
-  - Internationalization
-  - Localization
-  - Reference
-  - String
-  - WebExtensions
-  - i18n
-  - message
-  - message.json
-  - placeholders
-translation_of: Mozilla/Add-ons/WebExtensions/API/i18n/Locale-Specific_Message_reference
 ---
 国際化対応 (i18n) した拡張機能は、ロケール固有のメッセージを提供する少なくとも 1 個の `messages.json` というファイルを持っています。このページでは、`messages.json` の書式を説明します。
 

--- a/files/ja/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.md
@@ -1,16 +1,6 @@
 ---
 title: identity.getRedirectURL()
 slug: Mozilla/Add-ons/WebExtensions/API/identity/getRedirectURL
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Identity
-  - Method
-  - Reference
-  - WebExtensions
-  - getRedirectURL
-translation_of: Mozilla/Add-ons/WebExtensions/API/identity/getRedirectURL
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/identity/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/identity/index.md
@@ -1,14 +1,6 @@
 ---
 title: identity
 slug: Mozilla/Add-ons/WebExtensions/API/identity
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Identity
-  - Reference
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API/identity
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/idle/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/idle/index.md
@@ -1,16 +1,6 @@
 ---
 title: idle
 slug: Mozilla/Add-ons/WebExtensions/API/idle
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Idle
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API/idle
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/index.md
@@ -1,9 +1,6 @@
 ---
 title: JavaScript API 群
 slug: Mozilla/Add-ons/WebExtensions/API
-tags:
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/management/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/management/index.md
@@ -1,14 +1,6 @@
 ---
 title: management
 slug: Mozilla/Add-ons/WebExtensions/API/management
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - management
-translation_of: Mozilla/Add-ons/WebExtensions/API/management
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/menus/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/menus/index.md
@@ -1,17 +1,6 @@
 ---
 title: menus
 slug: Mozilla/Add-ons/WebExtensions/API/menus
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - contextMenus
-  - menus
-translation_of: Mozilla/Add-ons/WebExtensions/API/menus
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/menus/onclicked/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/menus/onclicked/index.md
@@ -1,7 +1,6 @@
 ---
 title: menus.onClicked
 slug: Mozilla/Add-ons/WebExtensions/API/menus/onClicked
-translation_of: Mozilla/Add-ons/WebExtensions/API/menus/onClicked
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/notifications/create/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/notifications/create/index.md
@@ -1,7 +1,6 @@
 ---
 title: notifications.create()
 slug: Mozilla/Add-ons/WebExtensions/API/notifications/create
-translation_of: Mozilla/Add-ons/WebExtensions/API/notifications/create
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/notifications/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/notifications/index.md
@@ -1,13 +1,6 @@
 ---
 title: notifications
 slug: Mozilla/Add-ons/WebExtensions/API/notifications
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Notifications
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API/notifications
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/omnibox/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/omnibox/index.md
@@ -1,14 +1,6 @@
 ---
 title: omnibox
 slug: Mozilla/Add-ons/WebExtensions/API/omnibox
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - WebExtensions
-  - omnibox
-translation_of: Mozilla/Add-ons/WebExtensions/API/omnibox
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/pageaction/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/pageaction/index.md
@@ -1,16 +1,6 @@
 ---
 title: pageAction
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - pageAction
-translation_of: Mozilla/Add-ons/WebExtensions/API/pageAction
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.md
@@ -1,7 +1,6 @@
 ---
 title: pageAction.onClicked
 slug: Mozilla/Add-ons/WebExtensions/API/pageAction/onClicked
-translation_of: Mozilla/Add-ons/WebExtensions/API/pageAction/onClicked
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/permissions/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/permissions/index.md
@@ -1,14 +1,6 @@
 ---
 title: permissions
 slug: Mozilla/Add-ons/WebExtensions/API/permissions
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Permissions
-  - Reference
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API/permissions
 ---
 {{AddonSidebar}}拡張機能のインストール後、実行時に特別なパーミッションの要求を可能にする。
 

--- a/files/ja/mozilla/add-ons/webextensions/api/pkcs11/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/pkcs11/index.md
@@ -1,7 +1,6 @@
 ---
 title: pkcs11
 slug: Mozilla/Add-ons/WebExtensions/API/pkcs11
-translation_of: Mozilla/Add-ons/WebExtensions/API/pkcs11
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/privacy/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/privacy/index.md
@@ -1,14 +1,6 @@
 ---
 title: privacy
 slug: Mozilla/Add-ons/WebExtensions/API/privacy
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Privacy
-  - Reference
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API/privacy
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/proxy/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/proxy/index.md
@@ -1,12 +1,6 @@
 ---
 title: proxy
 slug: Mozilla/Add-ons/WebExtensions/API/proxy
-tags:
-  - API
-  - Add-ons
-  - Proxy
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API/proxy
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/runtime/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/runtime/index.md
@@ -1,16 +1,6 @@
 ---
 title: runtime
 slug: Mozilla/Add-ons/WebExtensions/API/runtime
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - runtime
-translation_of: Mozilla/Add-ons/WebExtensions/API/runtime
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/runtime/messagesender/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/runtime/messagesender/index.md
@@ -1,17 +1,6 @@
 ---
 title: runtime.MessageSender
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/MessageSender
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - MessageSender
-  - Non-standard
-  - Reference
-  - Type
-  - WebExtensions
-  - runtime
-translation_of: Mozilla/Add-ons/WebExtensions/API/runtime/MessageSender
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
@@ -1,17 +1,6 @@
 ---
 title: runtime.onMessage
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/onMessage
-tags:
-  - API
-  - Add-ons
-  - Event
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - onmessage
-  - runtime
-translation_of: Mozilla/Add-ons/WebExtensions/API/runtime/onMessage
 ---
 {{AddonSidebar()}}このイベントを使って、拡張機能の別の部品からのメッセージを受け取ることができます。例えば、次のような場面で使います。
 

--- a/files/ja/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.md
@@ -1,17 +1,6 @@
 ---
 title: runtime.openOptionsPage()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/openOptionsPage
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - openOptionsPage
-  - runtime
-translation_of: Mozilla/Add-ons/WebExtensions/API/runtime/openOptionsPage
 ---
 {{AddonSidebar()}}拡張機能に[オプションページ](/ja/docs/Mozilla/Add-ons/WebExtensions/user_interface/Options_pages)が定義されている場合、このメソッドはそれを開きます。
 

--- a/files/ja/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
@@ -1,17 +1,6 @@
 ---
 title: runtime.sendMessage()
 slug: Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - runtime
-  - sendMessage
-translation_of: Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/sessions/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/sessions/index.md
@@ -1,15 +1,6 @@
 ---
 title: sessions
 slug: Mozilla/Add-ons/WebExtensions/API/sessions
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - sessions
-translation_of: Mozilla/Add-ons/WebExtensions/API/sessions
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/sidebaraction/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/sidebaraction/index.md
@@ -1,15 +1,6 @@
 ---
 title: sidebarAction
 slug: Mozilla/Add-ons/WebExtensions/API/sidebarAction
-tags:
-  - API
-  - Extensions
-  - Non-standard
-  - Reference
-  - Sidebar
-  - WebExtensions
-  - sidebarAction
-translation_of: Mozilla/Add-ons/WebExtensions/API/sidebarAction
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/storage/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/storage/index.md
@@ -1,16 +1,6 @@
 ---
 title: storage
 slug: Mozilla/Add-ons/WebExtensions/API/storage
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - Storage
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API/storage
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/storage/local/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/storage/local/index.md
@@ -1,7 +1,6 @@
 ---
 title: storage.local
 slug: Mozilla/Add-ons/WebExtensions/API/storage/local
-translation_of: Mozilla/Add-ons/WebExtensions/API/storage/local
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/storage/storagearea/clear/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/storage/storagearea/clear/index.md
@@ -1,18 +1,6 @@
 ---
 title: StorageArea.clear()
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/clear
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - Storage
-  - StorageArea
-  - WebExtensions
-  - remove
-translation_of: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/clear
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
@@ -1,18 +1,6 @@
 ---
 title: StorageArea.get()
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/get
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - Storage
-  - StorageArea
-  - WebExtensions
-  - get
-translation_of: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/get
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.md
@@ -1,17 +1,6 @@
 ---
 title: StorageArea.getBytesInUse()
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/getBytesInUse
-tags:
-  - API
-  - Add-ons
-  - Method
-  - Non-standard
-  - Reference
-  - Storage
-  - StorageArea
-  - WebExtensions
-  - getBytesInUse
-translation_of: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/getBytesInUse
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/storage/storagearea/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/storage/storagearea/index.md
@@ -1,7 +1,6 @@
 ---
 title: storage.StorageArea
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea
-translation_of: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/storage/storagearea/remove/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/storage/storagearea/remove/index.md
@@ -1,18 +1,6 @@
 ---
 title: StorageArea.remove()
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/remove
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - Storage
-  - StorageArea
-  - WebExtensions
-  - remove
-translation_of: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/remove
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.md
@@ -1,18 +1,6 @@
 ---
 title: StorageArea.set()
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/set
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - Storage
-  - StorageArea
-  - WebExtensions
-  - set
-translation_of: Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/set
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/storage/storagechange/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/storage/storagechange/index.md
@@ -1,17 +1,6 @@
 ---
 title: storage.StorageChange
 slug: Mozilla/Add-ons/WebExtensions/API/storage/StorageChange
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Reference
-  - Storage
-  - StorageChange
-  - Type
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API/storage/StorageChange
 ---
 {{AddonSidebar()}}`StorageChange` はストレージ領域の変更を表すオブジェクトです。
 

--- a/files/ja/mozilla/add-ons/webextensions/api/storage/sync/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/storage/sync/index.md
@@ -1,17 +1,6 @@
 ---
 title: storage.sync
 slug: Mozilla/Add-ons/WebExtensions/API/storage/sync
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Non-standard
-  - Property
-  - Reference
-  - Storage
-  - Sync
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API/storage/sync
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.md
@@ -1,17 +1,6 @@
 ---
 title: tabs.captureVisibleTab()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/captureVisibleTab
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - captureVisibleTab
-  - tabs
-translation_of: Mozilla/Add-ons/WebExtensions/API/tabs/captureVisibleTab
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/tabs/create/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/tabs/create/index.md
@@ -1,7 +1,6 @@
 ---
 title: tabs.create()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/create
-translation_of: Mozilla/Add-ons/WebExtensions/API/tabs/create
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/tabs/duplicate/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/tabs/duplicate/index.md
@@ -1,7 +1,6 @@
 ---
 title: tabs.duplicate()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/duplicate
-translation_of: Mozilla/Add-ons/WebExtensions/API/tabs/duplicate
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/tabs/executescript/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/tabs/executescript/index.md
@@ -1,17 +1,6 @@
 ---
 title: tabs.executeScript()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/executeScript
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - executeScript
-  - tabs
-translation_of: Mozilla/Add-ons/WebExtensions/API/tabs/executeScript
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/tabs/get/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/tabs/get/index.md
@@ -1,7 +1,6 @@
 ---
 title: tabs.get()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/get
-translation_of: Mozilla/Add-ons/WebExtensions/API/tabs/get
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/tabs/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/tabs/index.md
@@ -1,17 +1,6 @@
 ---
 title: tabs
 slug: Mozilla/Add-ons/WebExtensions/API/tabs
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - tabs
-  - タブ
-translation_of: Mozilla/Add-ons/WebExtensions/API/tabs
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/tabs/mutedinfo/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/tabs/mutedinfo/index.md
@@ -1,7 +1,6 @@
 ---
 title: tabs.MutedInfo
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/MutedInfo
-translation_of: Mozilla/Add-ons/WebExtensions/API/tabs/MutedInfo
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/tabs/mutedinforeason/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/tabs/mutedinforeason/index.md
@@ -1,7 +1,6 @@
 ---
 title: tabs.MutedInfoReason
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/MutedInfoReason
-translation_of: Mozilla/Add-ons/WebExtensions/API/tabs/MutedInfoReason
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/tabs/oncreated/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/tabs/oncreated/index.md
@@ -1,7 +1,6 @@
 ---
 title: tabs.onCreated
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/onCreated
-translation_of: Mozilla/Add-ons/WebExtensions/API/tabs/onCreated
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/tabs/query/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/tabs/query/index.md
@@ -1,7 +1,6 @@
 ---
 title: tabs.query()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/query
-translation_of: Mozilla/Add-ons/WebExtensions/API/tabs/query
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/tabs/remove/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/tabs/remove/index.md
@@ -1,7 +1,6 @@
 ---
 title: tabs.remove()
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/remove
-translation_of: Mozilla/Add-ons/WebExtensions/API/tabs/remove
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/tabs/tab/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/tabs/tab/index.md
@@ -1,7 +1,6 @@
 ---
 title: tabs.Tab
 slug: Mozilla/Add-ons/WebExtensions/API/tabs/Tab
-translation_of: Mozilla/Add-ons/WebExtensions/API/tabs/Tab
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/theme/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/theme/index.md
@@ -1,12 +1,6 @@
 ---
 title: theme
 slug: Mozilla/Add-ons/WebExtensions/API/theme
-tags:
-  - Extensions
-  - Themes
-  - WebExtensions
-  - add-on
-translation_of: Mozilla/Add-ons/WebExtensions/API/theme
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/topsites/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/topsites/index.md
@@ -1,16 +1,6 @@
 ---
 title: topSites
 slug: Mozilla/Add-ons/WebExtensions/API/topSites
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - topSites
-translation_of: Mozilla/Add-ons/WebExtensions/API/topSites
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/types/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/types/index.md
@@ -1,14 +1,6 @@
 ---
 title: types
 slug: Mozilla/Add-ons/WebExtensions/API/types
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Reference
-  - Types
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/API/types
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/webnavigation/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/webnavigation/index.md
@@ -1,16 +1,6 @@
 ---
 title: webNavigation
 slug: Mozilla/Add-ons/WebExtensions/API/webNavigation
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - webNavigation
-translation_of: Mozilla/Add-ons/WebExtensions/API/webNavigation
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/webrequest/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/webrequest/index.md
@@ -1,16 +1,6 @@
 ---
 title: webRequest
 slug: Mozilla/Add-ons/WebExtensions/API/webRequest
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - webRequest
-translation_of: Mozilla/Add-ons/WebExtensions/API/webRequest
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/windows/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/windows/index.md
@@ -1,16 +1,6 @@
 ---
 title: windows
 slug: Mozilla/Add-ons/WebExtensions/API/windows
-tags:
-  - API
-  - Add-ons
-  - Extensions
-  - Interface
-  - Non-standard
-  - Reference
-  - WebExtensions
-  - Windows
-translation_of: Mozilla/Add-ons/WebExtensions/API/windows
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/windows/windowstate/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/windows/windowstate/index.md
@@ -1,7 +1,6 @@
 ---
 title: windows.WindowState
 slug: Mozilla/Add-ons/WebExtensions/API/windows/WindowState
-translation_of: Mozilla/Add-ons/WebExtensions/API/windows/WindowState
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/api/windows/windowtype/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/api/windows/windowtype/index.md
@@ -1,7 +1,6 @@
 ---
 title: windows.WindowType
 slug: Mozilla/Add-ons/WebExtensions/API/windows/WindowType
-translation_of: Mozilla/Add-ons/WebExtensions/API/windows/WindowType
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/browser_compatibility_for_manifest.json/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/browser_compatibility_for_manifest.json/index.md
@@ -1,11 +1,6 @@
 ---
 title: manifest.json のブラウザー互換性
 slug: Mozilla/Add-ons/WebExtensions/Browser_compatibility_for_manifest.json
-tags:
-  - Add-ons
-  - WebExtensions
-  - manifest.json
-translation_of: Mozilla/Add-ons/WebExtensions/Browser_compatibility_for_manifest.json
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/browser_support_for_javascript_apis/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/browser_support_for_javascript_apis/index.md
@@ -1,10 +1,6 @@
 ---
 title: JavaScript API 群のブラウザーの互換性
 slug: Mozilla/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs
-tags:
-  - Reference
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
@@ -1,10 +1,6 @@
 ---
 title: Chrome との非互換性
 slug: Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities
-tags:
-  - WebExtensions
-  - 初心者向け
-translation_of: Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/content_scripts/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/content_scripts/index.md
@@ -1,9 +1,6 @@
 ---
 title: コンテンツスクリプト
 slug: Mozilla/Add-ons/WebExtensions/Content_scripts
-tags:
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/Content_scripts
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/content_security_policy/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/content_security_policy/index.md
@@ -1,9 +1,6 @@
 ---
 title: Content Security Policy
 slug: Mozilla/Add-ons/WebExtensions/Content_Security_Policy
-tags:
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/Content_Security_Policy
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/developing_webextensions_for_thunderbird/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/developing_webextensions_for_thunderbird/index.md
@@ -1,7 +1,6 @@
 ---
 title: ThunderbirdにおけるWebExtensionsによるアドイン開発
 slug: Mozilla/Add-ons/WebExtensions/Developing_WebExtensions_for_Thunderbird
-translation_of: Mozilla/Add-ons/WebExtensions/Developing_WebExtensions_for_Thunderbird
 original_slug: Mozilla/Add-ons/WebExtensions/ThunderbirdにおけるWebExtensionsによるアドイン開発
 ---
 {{AddonSidebar}}

--- a/files/ja/mozilla/add-ons/webextensions/examples/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/examples/index.md
@@ -1,10 +1,6 @@
 ---
 title: 拡張機能の例
 slug: Mozilla/Add-ons/WebExtensions/Examples
-tags:
-  - Interface
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/Examples
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/extending_the_developer_tools/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/extending_the_developer_tools/index.md
@@ -1,14 +1,6 @@
 ---
 title: developer tools の拡張
 slug: Mozilla/Add-ons/WebExtensions/Extending_the_developer_tools
-tags:
-  - Add-ons
-  - DevTools
-  - Needs Privileges
-  - WebExtensions
-  - ガイド
-  - 拡張機能
-translation_of: Mozilla/Add-ons/WebExtensions/Extending_the_developer_tools
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/implement_a_settings_page/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/implement_a_settings_page/index.md
@@ -1,9 +1,6 @@
 ---
 title: 設定ページを実装する
 slug: Mozilla/Add-ons/WebExtensions/Implement_a_settings_page
-tags:
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/Implement_a_settings_page
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/index.md
@@ -1,12 +1,6 @@
 ---
 title: ブラウザー拡張機能
 slug: Mozilla/Add-ons/WebExtensions
-tags:
-  - Add-ons
-  - Extensions
-  - Landing
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.md
@@ -1,9 +1,6 @@
 ---
 title: クリップボードとのやりとり
 slug: Mozilla/Add-ons/WebExtensions/Interact_with_the_clipboard
-tags:
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/Interact_with_the_clipboard
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/intercept_http_requests/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/intercept_http_requests/index.md
@@ -1,12 +1,6 @@
 ---
 title: HTTP リクエストへの介入
 slug: Mozilla/Add-ons/WebExtensions/Intercept_HTTP_requests
-tags:
-  - Add-ons
-  - Extensions
-  - How-to
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/Intercept_HTTP_requests
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/internationalization/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/internationalization/index.md
@@ -1,17 +1,6 @@
 ---
 title: 国際化
 slug: Mozilla/Add-ons/WebExtensions/Internationalization
-tags:
-  - Article
-  - Guide
-  - Internationalization
-  - Localization
-  - WebExtensions
-  - i18n
-  - messages.json
-  - placeholders
-  - predefined messages
-translation_of: Mozilla/Add-ons/WebExtensions/Internationalization
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/author/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/author/index.md
@@ -1,11 +1,6 @@
 ---
 title: author
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/author
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/author
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/background/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/background/index.md
@@ -1,13 +1,6 @@
 ---
 title: background
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/background
-tags:
-  - Add-ons
-  - Extensions
-  - Manifest
-  - Reference
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/background
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/browser_action/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/browser_action/index.md
@@ -1,11 +1,6 @@
 ---
 title: browser_action
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/browser_action
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/browser_action
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.md
@@ -1,12 +1,6 @@
 ---
 title: browser_specific_settings
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-  - manifest.json
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/chrome_settings_overrides/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/chrome_settings_overrides/index.md
@@ -1,13 +1,6 @@
 ---
 title: chrome_settings_overrides
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-  - chrome_settings_overrides
-  - manifest.json
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/chrome_url_overrides/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/chrome_url_overrides/index.md
@@ -1,11 +1,6 @@
 ---
 title: chrome_url_overrides
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/chrome_url_overrides
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/chrome_url_overrides
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/commands/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/commands/index.md
@@ -1,11 +1,6 @@
 ---
 title: commands
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/commands
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/commands
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
@@ -1,11 +1,6 @@
 ---
 title: content_scripts
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.md
@@ -1,11 +1,6 @@
 ---
 title: content_security_policy
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/default_locale/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/default_locale/index.md
@@ -1,11 +1,6 @@
 ---
 title: default_locale
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/default_locale
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/default_locale
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/description/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/description/index.md
@@ -1,11 +1,6 @@
 ---
 title: description
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/description
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/description
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/developer/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/developer/index.md
@@ -1,11 +1,6 @@
 ---
 title: developer
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/developer
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/developer
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/devtools_page/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/devtools_page/index.md
@@ -1,7 +1,6 @@
 ---
 title: devtools_page
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/devtools_page
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/devtools_page
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/homepage_url/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/homepage_url/index.md
@@ -1,11 +1,6 @@
 ---
 title: homepage_url
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/homepage_url
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/homepage_url
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/icons/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/icons/index.md
@@ -1,11 +1,6 @@
 ---
 title: icons
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/icons
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/icons
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/incognito/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/incognito/index.md
@@ -1,12 +1,6 @@
 ---
 title: incognito
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/incognito
-tags:
-  - Add-ons
-  - WebExtensions
-  - incognito
-  - manifest.json
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/incognito
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/index.md
@@ -1,11 +1,6 @@
 ---
 title: manifest.json
 slug: Mozilla/Add-ons/WebExtensions/manifest.json
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/manifest_version/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/manifest_version/index.md
@@ -1,11 +1,6 @@
 ---
 title: manifest_version
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/manifest_version
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/manifest_version
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/name/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/name/index.md
@@ -1,11 +1,6 @@
 ---
 title: name
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/name
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/name
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/omnibox/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/omnibox/index.md
@@ -1,11 +1,6 @@
 ---
 title: omnibox
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/omnibox
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/omnibox
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.md
@@ -1,12 +1,6 @@
 ---
 title: optional_permissions
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions
-tags:
-  - Add-ons
-  - WebExtensions
-  - manifest.json
-  - optional_permissions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/options_ui/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/options_ui/index.md
@@ -1,11 +1,6 @@
 ---
 title: options_ui
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/options_ui
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/options_ui
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/page_action/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/page_action/index.md
@@ -1,11 +1,6 @@
 ---
 title: page_action
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/page_action
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/page_action
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/permissions/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/permissions/index.md
@@ -1,14 +1,6 @@
 ---
 title: permissions
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/permissions
-tags:
-  - Add-ons
-  - Extensions
-  - Permissions
-  - Reference
-  - WebExtensions
-  - manifest.json
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/permissions
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.md
@@ -1,12 +1,6 @@
 ---
 title: protocol_handlers
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/protocol_handlers
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-  - manifest.json
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/protocol_handlers
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/short_name/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/short_name/index.md
@@ -1,11 +1,6 @@
 ---
 title: short_name
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/short_name
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/short_name
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/sidebar_action/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/sidebar_action/index.md
@@ -1,9 +1,6 @@
 ---
 title: sidebar_action
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action
-tags:
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/theme/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/theme/index.md
@@ -1,10 +1,6 @@
 ---
 title: theme
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/theme
-tags:
-  - Add-ons
-  - Themes
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/theme
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/version/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/version/index.md
@@ -1,11 +1,6 @@
 ---
 title: version
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/version
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/version
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/version_name/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/version_name/index.md
@@ -1,11 +1,6 @@
 ---
 title: version_name
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/version_name
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/version_name
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
@@ -1,11 +1,6 @@
 ---
 title: web_accessible_resources
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources
-tags:
-  - Add-ons
-  - Extensions
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/match_patterns/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/match_patterns/index.md
@@ -1,9 +1,6 @@
 ---
 title: マッチパターン
 slug: Mozilla/Add-ons/WebExtensions/Match_patterns
-tags:
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/Match_patterns
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/modify_a_web_page/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/modify_a_web_page/index.md
@@ -1,9 +1,6 @@
 ---
 title: ウェブページを変更する
 slug: Mozilla/Add-ons/WebExtensions/Modify_a_web_page
-tags:
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/Modify_a_web_page
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/native_manifests/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/native_manifests/index.md
@@ -1,10 +1,6 @@
 ---
 title: ネイティブマニフェスト
 slug: Mozilla/Add-ons/WebExtensions/Native_manifests
-tags:
-  - Extensions
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/Native_manifests
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/native_messaging/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/native_messaging/index.md
@@ -1,9 +1,6 @@
 ---
 title: ネイティブメッセージング
 slug: Mozilla/Add-ons/WebExtensions/Native_messaging
-tags:
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/Native_messaging
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/prerequisites/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/prerequisites/index.md
@@ -1,7 +1,6 @@
 ---
 title: 前提条件
 slug: Mozilla/Add-ons/WebExtensions/Prerequisites
-translation_of: Mozilla/Add-ons/WebExtensions/Prerequisites
 original_slug: Mozilla/Add-ons/WebExtensions/前提条件
 ---
 WebExtension API を使って開発するには、いくつかの小さいセットアップが必要です。

--- a/files/ja/mozilla/add-ons/webextensions/tips/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/tips/index.md
@@ -1,7 +1,6 @@
 ---
 title: Tips and Tricks
 slug: Mozilla/Add-ons/WebExtensions/Tips
-translation_of: Mozilla/Add-ons/WebExtensions/Tips
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/user_interface/browser_action/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/user_interface/browser_action/index.md
@@ -1,9 +1,6 @@
 ---
 title: ツールバーボタン
 slug: Mozilla/Add-ons/WebExtensions/user_interface/Browser_action
-tags:
-  - WebExtension
-translation_of: Mozilla/Add-ons/WebExtensions/user_interface/Browser_action
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/user_interface/context_menu_items/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/user_interface/context_menu_items/index.md
@@ -1,9 +1,6 @@
 ---
 title: コンテキストメニュー項目
 slug: Mozilla/Add-ons/WebExtensions/user_interface/Context_menu_items
-tags:
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/user_interface/Context_menu_items
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/user_interface/devtools_panels/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/user_interface/devtools_panels/index.md
@@ -1,12 +1,6 @@
 ---
 title: 開発者ツールパネル
 slug: Mozilla/Add-ons/WebExtensions/user_interface/devtools_panels
-tags:
-  - 初心者
-  - ガイド
-  - ユーザーインターフェイス
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/user_interface/devtools_panels
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/user_interface/extension_pages/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/user_interface/extension_pages/index.md
@@ -1,11 +1,6 @@
 ---
 title: 拡張機能ページ
 slug: Mozilla/Add-ons/WebExtensions/user_interface/Extension_pages
-tags:
-  - 初心者
-  - ユーザーインターフェイス
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/user_interface/Extension_pages
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/user_interface/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/user_interface/index.md
@@ -1,11 +1,6 @@
 ---
 title: ユーザーインターフェイス
 slug: Mozilla/Add-ons/WebExtensions/user_interface
-tags:
-  - Landing
-  - ユーザーインターフェイス
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/user_interface
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/user_interface/notifications/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/user_interface/notifications/index.md
@@ -1,9 +1,6 @@
 ---
 title: 通知
 slug: Mozilla/Add-ons/WebExtensions/user_interface/Notifications
-tags:
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/user_interface/Notifications
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/user_interface/options_pages/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/user_interface/options_pages/index.md
@@ -1,9 +1,6 @@
 ---
 title: オプションページ
 slug: Mozilla/Add-ons/WebExtensions/user_interface/Options_pages
-tags:
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/user_interface/Options_pages
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/user_interface/page_actions/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/user_interface/page_actions/index.md
@@ -1,12 +1,6 @@
 ---
 title: アドレスバーボタン
 slug: Mozilla/Add-ons/WebExtensions/user_interface/Page_actions
-tags:
-  - AddressBarButton
-  - ページアクション
-  - ユーザーインターフェイス
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/user_interface/Page_actions
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/user_interface/popups/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/user_interface/popups/index.md
@@ -1,12 +1,6 @@
 ---
 title: ポップアップ
 slug: Mozilla/Add-ons/WebExtensions/user_interface/Popups
-tags:
-  - UI
-  - ユーザーインターフェイス
-  - WebExtensions
-  - ポップアップ
-translation_of: Mozilla/Add-ons/WebExtensions/user_interface/Popups
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/user_interface/sidebars/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/user_interface/sidebars/index.md
@@ -1,9 +1,6 @@
 ---
 title: サイドバー
 slug: Mozilla/Add-ons/WebExtensions/user_interface/Sidebars
-tags:
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/user_interface/Sidebars
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/what_are_webextensions/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/what_are_webextensions/index.md
@@ -1,10 +1,6 @@
 ---
 title: 拡張機能とは何か？
 slug: Mozilla/Add-ons/WebExtensions/What_are_WebExtensions
-tags:
-  - Extensions
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/What_are_WebExtensions
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/what_next_/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/what_next_/index.md
@@ -1,11 +1,6 @@
 ---
 title: 次にどうするのか？
 slug: Mozilla/Add-ons/WebExtensions/What_next_
-tags:
-  - Beginner
-  - Extensions
-  - WebExtension
-translation_of: Mozilla/Add-ons/WebExtensions/What_next_
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/work_with_the_bookmarks_api/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/work_with_the_bookmarks_api/index.md
@@ -1,14 +1,6 @@
 ---
 title: Bookmarks API を使う
 slug: Mozilla/Add-ons/WebExtensions/Work_with_the_Bookmarks_API
-tags:
-  - Add-ons
-  - Beginner
-  - Bookmarks
-  - Extensions
-  - How-to
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/Work_with_the_Bookmarks_API
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/working_with_files/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/working_with_files/index.md
@@ -1,10 +1,6 @@
 ---
 title: ファイルの操作
 slug: Mozilla/Add-ons/WebExtensions/Working_with_files
-tags:
-  - Guide
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/Working_with_files
 ---
 {{AddonSidebar()}}
 

--- a/files/ja/mozilla/add-ons/webextensions/working_with_the_tabs_api/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/working_with_the_tabs_api/index.md
@@ -1,14 +1,6 @@
 ---
 title: Tabs API を使う
 slug: Mozilla/Add-ons/WebExtensions/Working_with_the_Tabs_API
-tags:
-  - Add-ons
-  - Beginner
-  - Extensions
-  - How-to
-  - WebExtensions
-  - tabs
-translation_of: Mozilla/Add-ons/WebExtensions/Working_with_the_Tabs_API
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/your_first_webextension/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/your_first_webextension/index.md
@@ -1,10 +1,6 @@
 ---
 title: 初めての拡張機能
 slug: Mozilla/Add-ons/WebExtensions/Your_first_WebExtension
-tags:
-  - Guide
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/Your_first_WebExtension
 ---
 {{AddonSidebar}}
 

--- a/files/ja/mozilla/add-ons/webextensions/your_second_webextension/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/your_second_webextension/index.md
@@ -1,9 +1,6 @@
 ---
 title: 2 つめの拡張機能
 slug: Mozilla/Add-ons/WebExtensions/Your_second_WebExtension
-tags:
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/Your_second_WebExtension
 original_slug: Mozilla/Add-ons/WebExtensions/Walkthrough
 ---
 {{AddonSidebar}}

--- a/files/ja/mozilla/firefox/experimental_features/index.md
+++ b/files/ja/mozilla/firefox/experimental_features/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox における実験的機能
 slug: Mozilla/Firefox/Experimental_features
-tags:
-  - 実験的
-  - Firefox
-  - 設定
-  - 機能
-translation_of: Mozilla/Firefox/Experimental_features
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/index.md
+++ b/files/ja/mozilla/firefox/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox
 slug: Mozilla/Firefox
-tags:
-  - Firefox
-  - Landing
-  - Mozilla
-translation_of: Mozilla/Firefox
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/1.5/adapting_xul_applications_for_firefox_1.5/index.md
+++ b/files/ja/mozilla/firefox/releases/1.5/adapting_xul_applications_for_firefox_1.5/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 1.5 に XUL アプリケーションを対応させる
 slug: Mozilla/Firefox/Releases/1.5/Adapting_XUL_Applications_for_Firefox_1.5
-tags:
-  - Add-ons
-  - Extensions
-  - XUL
-translation_of: Mozilla/Firefox/Releases/1.5/Adapting_XUL_Applications_for_Firefox_1.5
 original_slug: Adapting_XUL_Applications_for_Firefox_1.5
 ---
 このページでは、[Firefox 1.5](/ja/Firefox_1.5) の変更点のうち、XUL アプリケーション開発者に影響するものについて、リストで示します。

--- a/files/ja/mozilla/firefox/releases/1.5/changing_the_priority_of_http_requests/index.md
+++ b/files/ja/mozilla/firefox/releases/1.5/changing_the_priority_of_http_requests/index.md
@@ -1,9 +1,6 @@
 ---
 title: HTTPリクエストの優先順位の変更
 slug: Mozilla/Firefox/Releases/1.5/Changing_the_priority_of_HTTP_requests
-tags:
-  - HTTP
-translation_of: Mozilla/Firefox/Releases/1.5/Changing_the_priority_of_HTTP_requests
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/1.5/index.md
+++ b/files/ja/mozilla/firefox/releases/1.5/index.md
@@ -1,22 +1,6 @@
 ---
 title: Firefox 1.5 for developers
 slug: Mozilla/Firefox/Releases/1.5
-tags:
-  - Add-ons
-  - CSS
-  - DOM
-  - Extensions
-  - HTML
-  - JavaScript
-  - RDF
-  - SVG
-  - Web Development
-  - Web Standards
-  - XML
-  - XML Web Services
-  - XSLT
-  - XUL
-translation_of: Mozilla/Firefox/Releases/1.5
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/1.5/using_firefox_1.5_caching/index.md
+++ b/files/ja/mozilla/firefox/releases/1.5/using_firefox_1.5_caching/index.md
@@ -1,14 +1,6 @@
 ---
 title: Using Firefox 1.5 caching
 slug: Mozilla/Firefox/Releases/1.5/Using_Firefox_1.5_caching
-tags:
-  - Add-ons
-  - DOM
-  - Extensions
-  - HTML
-  - JavaScript
-  - Web Development
-translation_of: Mozilla/Firefox/Releases/1.5/Using_Firefox_1.5_caching
 original_slug: Using_Firefox_1.5_caching
 ---
 {{FirefoxSidebar}}

--- a/files/ja/mozilla/firefox/releases/10/index.md
+++ b/files/ja/mozilla/firefox/releases/10/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 10 for developers
 slug: Mozilla/Firefox/Releases/10
-tags:
-  - Firefox
-  - Firefox 10
-  - Gecko 10
-translation_of: Mozilla/Firefox/Releases/10
 ---
 Gecko 10.0 を搭載した Firefox 10 は米国時間 2012 年 1 月 31 日にリリースされました。このページでは、開発者に影響する Firefox 10 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/100/index.md
+++ b/files/ja/mozilla/firefox/releases/100/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 100 for developers
 slug: Mozilla/Firefox/Releases/100
-tags:
-  - '100'
-  - Firefox
-  - Mozilla
-  - Release
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/101/index.md
+++ b/files/ja/mozilla/firefox/releases/101/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 101 for developers
 slug: Mozilla/Firefox/Releases/101
-tags:
-  - '101'
-  - Firefox
-  - Mozilla
-  - Release
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/102/index.md
+++ b/files/ja/mozilla/firefox/releases/102/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 102 for developers
 slug: Mozilla/Firefox/Releases/102
-tags:
-  - '102'
-  - Firefox
-  - Mozilla
-  - Release
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/103/index.md
+++ b/files/ja/mozilla/firefox/releases/103/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 103 for developers
 slug: Mozilla/Firefox/Releases/103
-tags:
-  - '103'
-  - Firefox
-  - Mozilla
-  - Release
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/11/index.md
+++ b/files/ja/mozilla/firefox/releases/11/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 11 for developers
 slug: Mozilla/Firefox/Releases/11
-tags:
-  - Firefox
-  - Firefox 11
-translation_of: Mozilla/Firefox/Releases/11
 ---
 Firefox 11 は米国時間 2012 年 3 月 13 日にリリースされました。この記事は Web 開発者とアドオン開発者向けに、今回のリリースにおける新機能と修正された重要なバグについての情報とより詳細なドキュメントへのリンクをまとめています。
 

--- a/files/ja/mozilla/firefox/releases/12/index.md
+++ b/files/ja/mozilla/firefox/releases/12/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 12 for developers
 slug: Mozilla/Firefox/Releases/12
-tags:
-  - Firefox
-  - Firefox 12
-  - Gecko 12
-  - Web Development
-translation_of: Mozilla/Firefox/Releases/12
 ---
 Firefox 12 は 米国時間 2012 年 4 月 24 日にリリースされました。この記事は開発者に影響がある Firefox 12 での変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/13/index.md
+++ b/files/ja/mozilla/firefox/releases/13/index.md
@@ -1,7 +1,6 @@
 ---
 title: Firefox 13 for developers
 slug: Mozilla/Firefox/Releases/13
-translation_of: Mozilla/Firefox/Releases/13
 ---
 Firefox 13 は 米国時間 2012 年 6 月 5 日にリリースされました。この記事は開発者に影響がある Firefox 13 での変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/14/index.md
+++ b/files/ja/mozilla/firefox/releases/14/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 14 for developers
 slug: Mozilla/Firefox/Releases/14
-tags:
-  - Firefox
-  - Firefox 14
-  - Gecko
-  - Gecko 14
-translation_of: Mozilla/Firefox/Releases/14
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/15/index.md
+++ b/files/ja/mozilla/firefox/releases/15/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 15 for developers
 slug: Mozilla/Firefox/Releases/15
-tags:
-  - Firefox
-  - Firefox 15
-  - Gecko 15
-translation_of: Mozilla/Firefox/Releases/15
 ---
 Firefox 15 は 2012 年 8 月 28 日にリリースされました。この記事では、ウェブ開発者に知らせるだけでなく、Firefox や Gecko 開発者、アドオン開発者にも役立つ主な変更点のリストを掲載しています。
 

--- a/files/ja/mozilla/firefox/releases/16/index.md
+++ b/files/ja/mozilla/firefox/releases/16/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 16 for developers
 slug: Mozilla/Firefox/Releases/16
-tags:
-  - '2009'
-  - Firefox
-translation_of: Mozilla/Firefox/Releases/16
 ---
 Firefox 16 は、2012 年 10 月 9 日にリリースされました。この記事では、ウェブ開発者に知らせるだけでなく、Firefox や Gecko 開発者、アドオン開発者にも役立つ主な変更点のリストを掲載しています。
 

--- a/files/ja/mozilla/firefox/releases/17/index.md
+++ b/files/ja/mozilla/firefox/releases/17/index.md
@@ -1,9 +1,6 @@
 ---
 title: Firefox 17 for developers
 slug: Mozilla/Firefox/Releases/17
-tags:
-  - Firefox
-translation_of: Mozilla/Firefox/Releases/17
 ---
 Gecko 17 を搭載した Firefox 17 は米国時間 2012 年 11 月 20 日にリリースされました。このページでは、開発者に影響する Firefox 17 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/18/index.md
+++ b/files/ja/mozilla/firefox/releases/18/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 18 for developers
 slug: Mozilla/Firefox/Releases/18
-tags:
-  - Firefox
-  - Firefox 18
-translation_of: Mozilla/Firefox/Releases/18
 ---
 Gecko 18 を搭載した Firefox 18 は米国時間 2013 年 1 月 8 日にリリースされました。このページでは、開発者に影響する Firefox 18 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/19/index.md
+++ b/files/ja/mozilla/firefox/releases/19/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 19 for developers
 slug: Mozilla/Firefox/Releases/19
-tags:
-  - Firefox
-  - Firefox 19
-  - NeedsContent
-translation_of: Mozilla/Firefox/Releases/19
 ---
 Gecko 19 を搭載した Firefox 19 は米国時間 2013 年 2 月 19 日にリリースされました。このページでは、開発者に影響する Firefox 19 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/2/adding_feed_readers_to_firefox/index.md
+++ b/files/ja/mozilla/firefox/releases/2/adding_feed_readers_to_firefox/index.md
@@ -1,9 +1,6 @@
 ---
 title: Firefox へのフィードリーダーの追加
 slug: Mozilla/Firefox/Releases/2/Adding_feed_readers_to_Firefox
-tags:
-  - Configuration management
-translation_of: Mozilla/Firefox/Releases/2/Adding_feed_readers_to_Firefox
 original_slug: Adding_feed_readers_to_Firefox
 ---
 Firefox 2 より、Firefox はフィードを読む際に使う RSS または Atom フィードリーダを選択できるようになっています。この記事ではデフォルトではサポートされていないリーダを追加サポートさせる方法について説明します。

--- a/files/ja/mozilla/firefox/releases/2/index.md
+++ b/files/ja/mozilla/firefox/releases/2/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 2 for developers
 slug: Mozilla/Firefox/Releases/2
-tags:
-  - Firefox
-  - Firefox 2
-translation_of: Mozilla/Firefox/Releases/2
 ---
 ## 開発者のための Firefox 2 の新機能
 

--- a/files/ja/mozilla/firefox/releases/2/security_changes/index.md
+++ b/files/ja/mozilla/firefox/releases/2/security_changes/index.md
@@ -1,7 +1,6 @@
 ---
 title: Firefox 2 のセキュリティ
 slug: Mozilla/Firefox/Releases/2/Security_changes
-translation_of: Mozilla/Firefox/Releases/2/Security_changes
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/2/updating_extensions/index.md
+++ b/files/ja/mozilla/firefox/releases/2/updating_extensions/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 2 のための拡張機能の更新
 slug: Mozilla/Firefox/Releases/2/Updating_extensions
-tags:
-  - Add-ons
-  - Extensions
-translation_of: Mozilla/Firefox/Releases/2/Updating_extensions
 original_slug: Updating_extensions_for_Firefox_2
 ---
 {{FirefoxSidebar}}

--- a/files/ja/mozilla/firefox/releases/20/index.md
+++ b/files/ja/mozilla/firefox/releases/20/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 20 for developers
 slug: Mozilla/Firefox/Releases/20
-tags:
-  - Firefox
-  - Firefox 20
-translation_of: Mozilla/Firefox/Releases/20
 ---
 Gecko 20 を搭載した Firefox 20 は米国時間 2013 年 4 月 2 日にリリースされました。このページでは、開発者に影響する Firefox 20 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/21/index.md
+++ b/files/ja/mozilla/firefox/releases/21/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 21 for developers
 slug: Mozilla/Firefox/Releases/21
-tags:
-  - Firefox
-  - Firefox 21
-translation_of: Mozilla/Firefox/Releases/21
 ---
 Gecko 21 を搭載した Firefox 21 は米国時間 2013 年 5 月 14 日にリリースされました。このページでは、開発者に影響する Firefox 20 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/22/index.md
+++ b/files/ja/mozilla/firefox/releases/22/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 22 for developers
 slug: Mozilla/Firefox/Releases/22
-tags:
-  - Firefox
-  - Firefox 22
-translation_of: Mozilla/Firefox/Releases/22
 ---
 Gecko 22 を搭載した Firefox 22 は米国時間 2013 年 6 月 25 日にリリースされました。このページでは、開発者に影響する Firefox 22 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/23/index.md
+++ b/files/ja/mozilla/firefox/releases/23/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 23 for developers
 slug: Mozilla/Firefox/Releases/23
-tags:
-  - Firefox
-  - Firefox 23
-translation_of: Mozilla/Firefox/Releases/23
 ---
 Gecko 23 を搭載した Firefox 23 は米国時間 2013 年 8 月 6 日にリリースされました。このページでは、開発者に影響する Firefox 23 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/24/index.md
+++ b/files/ja/mozilla/firefox/releases/24/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 24 for developers
 slug: Mozilla/Firefox/Releases/24
-tags:
-  - Firefox
-  - Firefox 24
-  - NeedsContent
-translation_of: Mozilla/Firefox/Releases/24
 ---
 Gecko 24 を搭載した Firefox 24 は米国時間 2013 年 9 月 17 日にリリースされました。このページでは、開発者に影響する Firefox 24 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/25/index.md
+++ b/files/ja/mozilla/firefox/releases/25/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 25 for developers
 slug: Mozilla/Firefox/Releases/25
-tags:
-  - Firefox
-  - Firefox 25
-translation_of: Mozilla/Firefox/Releases/25
 ---
 Gecko 25 を搭載した Firefox 25 は米国時間 2013 年 10 月 29 日にリリースされました。このページでは、開発者に影響する Firefox 25 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/26/index.md
+++ b/files/ja/mozilla/firefox/releases/26/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 26 for developers
 slug: Mozilla/Firefox/Releases/26
-tags:
-  - Firefox
-  - Firefox 26
-translation_of: Mozilla/Firefox/Releases/26
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/27/index.md
+++ b/files/ja/mozilla/firefox/releases/27/index.md
@@ -1,9 +1,6 @@
 ---
 title: Firefox 27 for developers
 slug: Mozilla/Firefox/Releases/27
-tags:
-  - Firefox
-translation_of: Mozilla/Firefox/Releases/27
 ---
 Gecko 27 を搭載した Firefox 27 は米国時間 2014 年 2 月 4 日にリリースされました。このページでは、開発者に影響する Firefox 27 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/28/index.md
+++ b/files/ja/mozilla/firefox/releases/28/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 28 for developers
 slug: Mozilla/Firefox/Releases/28
-tags:
-  - Compatibility
-  - Firefox
-  - Firefox 28
-  - Mozilla
-translation_of: Mozilla/Firefox/Releases/28
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/29/index.md
+++ b/files/ja/mozilla/firefox/releases/29/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 29 for developers
 slug: Mozilla/Firefox/Releases/29
-tags:
-  - Firefox
-  - firefox developers
-  - firefox29
-translation_of: Mozilla/Firefox/Releases/29
 ---
 Gecko 29 を搭載した Firefox 29 は、米国時間 2014 年 4 月 29 日にリリースされました。このページでは、開発者に影響する Firefox 29 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/3.5/icc_color_correction_in_firefox/index.md
+++ b/files/ja/mozilla/firefox/releases/3.5/icc_color_correction_in_firefox/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox の ICC カラーコレクション
 slug: Mozilla/Firefox/Releases/3.5/ICC_color_correction_in_Firefox
-tags:
-  - Firefox
-  - Firefox 3
-  - Firefox 3.5
-translation_of: Mozilla/Firefox/Releases/3.5/ICC_color_correction_in_Firefox
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/3.5/index.md
+++ b/files/ja/mozilla/firefox/releases/3.5/index.md
@@ -1,17 +1,6 @@
 ---
 title: Firefox 3.5 開発者向け情報
 slug: Mozilla/Firefox/Releases/3.5
-tags:
-  - CSS
-  - Firefox
-  - Firefox 3.5
-  - Gecko
-  - Gecko 1.9.1
-  - HTML
-  - JavaScript
-  - Storage
-  - XUL
-translation_of: Mozilla/Firefox/Releases/3.5
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/3.6/index.md
+++ b/files/ja/mozilla/firefox/releases/3.6/index.md
@@ -1,16 +1,6 @@
 ---
 title: Firefox 3.6 for developers
 slug: Mozilla/Firefox/Releases/3.6
-tags:
-  - CSS
-  - Firefox
-  - Firefox 3.6
-  - Gecko
-  - Gecko 1.9.2
-  - HTML
-  - JavaScript
-  - XUL
-translation_of: Mozilla/Firefox/Releases/3.6
 ---
 Firefox 3.6 では新規あるいは開発中のウェブ標準のサポート、性能の向上、ウェブユーザと開発者にとってより良い体験が提供されます。このページは Firefox 3.6 で新しく利用出来るようになった機能に関する記事のリンクを提供します。
 

--- a/files/ja/mozilla/firefox/releases/3/dom_improvements/index.md
+++ b/files/ja/mozilla/firefox/releases/3/dom_improvements/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 3 での DOM の改良
 slug: Mozilla/Firefox/Releases/3/DOM_improvements
-tags:
-  - DOM
-  - Firefox 3
-translation_of: Mozilla/Firefox/Releases/3/DOM_improvements
 original_slug: DOM_improvements_in_Firefox_3
 ---
 {{FirefoxSidebar}}

--- a/files/ja/mozilla/firefox/releases/3/full_page_zoom/index.md
+++ b/files/ja/mozilla/firefox/releases/3/full_page_zoom/index.md
@@ -1,11 +1,6 @@
 ---
 title: フルページズーム
 slug: Mozilla/Firefox/Releases/3/Full_page_zoom
-tags:
-  - Extensions
-  - Firefox 3
-  - XUL
-translation_of: Mozilla/Firefox/Releases/3/Full_page_zoom
 original_slug: Full_page_zoom
 ---
 {{FirefoxSidebar}}

--- a/files/ja/mozilla/firefox/releases/3/index.md
+++ b/files/ja/mozilla/firefox/releases/3/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 3 for developers
 slug: Mozilla/Firefox/Releases/3
-tags:
-  - Firefox
-  - Firefox 3
-translation_of: Mozilla/Firefox/Releases/3
 ---
 もしあなたが開発者で、Firefox 3 におけるすべての新機能について情報を得ようとしているなら、ここは理解を深めるのに最も適した場所です。この記事は、Firefox 3 に追加された機能をカバーする新しい記事の一覧を提供します。小さな変更が必ずしもすべてカバーされているわけではありませんが、主要な改善を学ぶ助けにはなるでしょう。
 

--- a/files/ja/mozilla/firefox/releases/3/notable_bugs_fixed/index.md
+++ b/files/ja/mozilla/firefox/releases/3/notable_bugs_fixed/index.md
@@ -1,9 +1,6 @@
 ---
 title: Firefox 3 で修正された重要なバグ
 slug: Mozilla/Firefox/Releases/3/Notable_bugs_fixed
-tags:
-  - Firefox 3
-translation_of: Mozilla/Firefox/Releases/3/Notable_bugs_fixed
 original_slug: Notable_bugs_fixed_in_Firefox_3
 ---
 {{FirefoxSidebar}}

--- a/files/ja/mozilla/firefox/releases/3/svg_improvements/index.md
+++ b/files/ja/mozilla/firefox/releases/3/svg_improvements/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 3 における SVG の改良
 slug: Mozilla/Firefox/Releases/3/SVG_improvements
-tags:
-  - Firefox 3
-  - SVG
-translation_of: Mozilla/Firefox/Releases/3/SVG_improvements
 original_slug: SVG_improvements_in_Firefox_3
 ---
 {{FirefoxSidebar}}

--- a/files/ja/mozilla/firefox/releases/3/updating_extensions/index.md
+++ b/files/ja/mozilla/firefox/releases/3/updating_extensions/index.md
@@ -1,9 +1,6 @@
 ---
 title: Updating extensions for Firefox 3
 slug: Mozilla/Firefox/Releases/3/Updating_extensions
-tags:
-  - Firefox 3
-translation_of: Mozilla/Firefox/Releases/3/Updating_extensions
 original_slug: Updating_extensions_for_Firefox_3
 ---
 このドキュメントは、拡張機能を更新して Firefox 3 に対応させたいと考える開発者のために役立つ情報を提供します。

--- a/files/ja/mozilla/firefox/releases/3/updating_web_applications/index.md
+++ b/files/ja/mozilla/firefox/releases/3/updating_web_applications/index.md
@@ -1,9 +1,6 @@
 ---
 title: Firefox 3 のためのウェブアプリケーションの更新
 slug: Mozilla/Firefox/Releases/3/Updating_web_applications
-tags:
-  - Firefox 3
-translation_of: Mozilla/Firefox/Releases/3/Updating_web_applications
 original_slug: Updating_web_applications_for_Firefox_3
 ---
 {{FirefoxSidebar}}

--- a/files/ja/mozilla/firefox/releases/30/index.md
+++ b/files/ja/mozilla/firefox/releases/30/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 30 for developers
 slug: Mozilla/Firefox/Releases/30
-tags:
-  - Firefox
-  - Firefox for Developers
-translation_of: Mozilla/Firefox/Releases/30
 ---
 Gecko 30 を搭載した Firefox 30 は、米国時間 2014 年 6 月 10 日にリリースされました。このページでは、開発者に影響する Firefox 30 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/31/index.md
+++ b/files/ja/mozilla/firefox/releases/31/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 31 for developers
 slug: Mozilla/Firefox/Releases/31
-tags:
-  - Firefox
-  - Firefox 31
-  - Firefox for Developers
-translation_of: Mozilla/Firefox/Releases/31
 ---
 Gecko 31 を搭載した Firefox 31 は、米国時間 2014 年 7 月 22 日にリリースされました。このページでは、開発者に影響する Firefox 31 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/32/index.md
+++ b/files/ja/mozilla/firefox/releases/32/index.md
@@ -1,9 +1,6 @@
 ---
 title: Firefox 32 for developers
 slug: Mozilla/Firefox/Releases/32
-tags:
-  - Firefox
-translation_of: Mozilla/Firefox/Releases/32
 ---
 Gecko 32 を搭載した Firefox 32 は、米国時間 2014 年 9 月 2 日にリリースされました。このページでは、開発者に影響する Firefox 32 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/33/index.md
+++ b/files/ja/mozilla/firefox/releases/33/index.md
@@ -1,9 +1,6 @@
 ---
 title: Firefox 33 for developers
 slug: Mozilla/Firefox/Releases/33
-tags:
-  - Firefox
-translation_of: Mozilla/Firefox/Releases/33
 ---
 Gecko 33 を搭載した Firefox 33 は、米国時間 2014 年 10 月 14 日にリリースされました。このページでは、開発者に影響する Firefox 33 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/34/index.md
+++ b/files/ja/mozilla/firefox/releases/34/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 34 for developers
 slug: Mozilla/Firefox/Releases/34
-tags:
-  - Firefox
-  - Releases
-translation_of: Mozilla/Firefox/Releases/34
 ---
 Gecko 34 を搭載した Firefox 34 は、米国時間 2014 年 12 月 1 日にリリースされました。このページでは、開発者に影響する Firefox 34 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/35/index.md
+++ b/files/ja/mozilla/firefox/releases/35/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 35 for developers
 slug: Mozilla/Firefox/Releases/35
-tags:
-  - Firefox
-  - Guide
-  - Mozilla
-translation_of: Mozilla/Firefox/Releases/35
 ---
 Gecko 35 を搭載した Firefox 35 は、米国時間 2015 年 1 月 13 日にリリースされました。このページでは、開発者に影響する Firefox 35 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/36/index.md
+++ b/files/ja/mozilla/firefox/releases/36/index.md
@@ -1,9 +1,6 @@
 ---
 title: Firefox 36 for developers
 slug: Mozilla/Firefox/Releases/36
-tags:
-  - Firefox
-translation_of: Mozilla/Firefox/Releases/36
 ---
 Firefox 36 は、米国時間 2015 年 2 月 24 日にリリースされました。このページでは、開発者に影響する Firefox 36 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/37/index.md
+++ b/files/ja/mozilla/firefox/releases/37/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 37 for developers
 slug: Mozilla/Firefox/Releases/37
-tags:
-  - Firefox
-  - Release Notes
-translation_of: Mozilla/Firefox/Releases/37
 ---
 Firefox 37 は、米国時間 2015 年 3 月 31 日にリリースされました。このページでは、開発者に影響する Firefox 37 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/38/index.md
+++ b/files/ja/mozilla/firefox/releases/38/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 38 for developers
 slug: Mozilla/Firefox/Releases/38
-tags:
-  - Firefox
-  - Release
-translation_of: Mozilla/Firefox/Releases/38
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/39/index.md
+++ b/files/ja/mozilla/firefox/releases/39/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 39 for developers
 slug: Mozilla/Firefox/Releases/39
-tags:
-  - Firefox
-  - Releases
-translation_of: Mozilla/Firefox/Releases/39
 ---
 Firefox 39 は、米国時間 2015 年 6 月 30 日にリリースされました。このページでは、開発者に影響する Firefox 39 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/4/index.md
+++ b/files/ja/mozilla/firefox/releases/4/index.md
@@ -1,18 +1,6 @@
 ---
 title: Firefox 4 for developers
 slug: Mozilla/Firefox/Releases/4
-tags:
-  - CSS
-  - Firefox
-  - Firefox 4
-  - Gecko
-  - Gecko 2.0
-  - HTML
-  - JavaScript
-  - XPCOM
-  - XUL
-  - 要更新
-translation_of: Mozilla/Firefox/Releases/4
 ---
 Firefox 4 （6 月後半にベータ版リリースが予定されています）では、パフォーマンスが向上し、 HTML 5 やその他の革新的な Web 技術のさらなるサポートが追加され、さらには、セキュリティも改善しています。 この記事では、この次期リリースについてのとっかかりの情報と、 Web 開発者、アドオン開発者、そして、Gecko プラットフォーム開発者向けに利用可能になる機能の一覧を提供します。
 

--- a/files/ja/mozilla/firefox/releases/4/the_add-on_bar/index.md
+++ b/files/ja/mozilla/firefox/releases/4/the_add-on_bar/index.md
@@ -1,13 +1,6 @@
 ---
 title: アドオンバー
 slug: Mozilla/Firefox/Releases/4/The_add-on_bar
-tags:
-  - Add-ons
-  - Extensions
-  - Firefox 4
-  - Toolbar
-  - 要更新
-translation_of: Mozilla/Firefox/Releases/4/The_add-on_bar
 original_slug: The_add-on_bar
 ---
 Firefox 4 よりウィンドウの下部に新しいツールバーを実装する為、ブラウザウィンドウの下部からステータスバーが削除されます。この新しいツールバーは ID "addon-bar" を持った、標準の XUL {{XULElem("toolbar")}} です。アドオンはこのバーにコンテンツを挿入することが可能であり、また、ユーザーはツールバーのカスタマイズ中にボタンをアドオンバーにドラッグすることができます。これがアドオンバーと旧ステータスバーの間の主な相違点です。標準のツールバーであるため、どの XUL 要素でもアドオンバーに配置することができます。

--- a/files/ja/mozilla/firefox/releases/40/index.md
+++ b/files/ja/mozilla/firefox/releases/40/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 40 for developers
 slug: Mozilla/Firefox/Releases/40
-tags:
-  - Firefox
-  - Releases
-translation_of: Mozilla/Firefox/Releases/40
 ---
 Firefox 40 は、米国時間 2015 年 8 月 11 日にリリースされました。このページでは、開発者に影響する Firefox 40 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/41/index.md
+++ b/files/ja/mozilla/firefox/releases/41/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 41 for developers
 slug: Mozilla/Firefox/Releases/41
-tags:
-  - Firefox
-  - Releases
-translation_of: Mozilla/Firefox/Releases/41
 ---
 Firefox 41 は、米国時間 2015 年 9 月 22 日にリリースされました。このページでは、開発者に影響する Firefox 41 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/42/index.md
+++ b/files/ja/mozilla/firefox/releases/42/index.md
@@ -1,13 +1,6 @@
 ---
 title: Firefox 42 for developers
 slug: Mozilla/Firefox/Releases/42
-tags:
-  - '42'
-  - Firefox
-  - Mozilla
-  - Release
-  - Release Notes
-translation_of: Mozilla/Firefox/Releases/42
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/43/index.md
+++ b/files/ja/mozilla/firefox/releases/43/index.md
@@ -1,9 +1,6 @@
 ---
 title: Firefox 43 for developers
 slug: Mozilla/Firefox/Releases/43
-tags:
-  - Firefox
-translation_of: Mozilla/Firefox/Releases/43
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/44/index.md
+++ b/files/ja/mozilla/firefox/releases/44/index.md
@@ -1,9 +1,6 @@
 ---
 title: Firefox 44 for developers
 slug: Mozilla/Firefox/Releases/44
-tags:
-  - Firefox
-translation_of: Mozilla/Firefox/Releases/44
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/45/index.md
+++ b/files/ja/mozilla/firefox/releases/45/index.md
@@ -1,9 +1,6 @@
 ---
 title: Firefox 45 for developers
 slug: Mozilla/Firefox/Releases/45
-tags:
-  - Firefox
-translation_of: Mozilla/Firefox/Releases/45
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/46/index.md
+++ b/files/ja/mozilla/firefox/releases/46/index.md
@@ -1,9 +1,6 @@
 ---
 title: Firefox 46 for developers
 slug: Mozilla/Firefox/Releases/46
-tags:
-  - Firefox
-translation_of: Mozilla/Firefox/Releases/46
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/47/index.md
+++ b/files/ja/mozilla/firefox/releases/47/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 47 for developers
 slug: Mozilla/Firefox/Releases/47
-tags:
-  - Firefox
-  - Release Notes
-translation_of: Mozilla/Firefox/Releases/47
 ---
 Firefox 47 は、米国時間 2016 年 6 月 7 日にリリースされました。このページでは、開発者に影響する Firefox 47 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/48/index.md
+++ b/files/ja/mozilla/firefox/releases/48/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 48 for developers
 slug: Mozilla/Firefox/Releases/48
-tags:
-  - Firefox
-  - Release Notes
-translation_of: Mozilla/Firefox/Releases/48
 ---
 Firefox 48 は、米国時間 2016 年 8 月 2 日にリリースされました。このページでは、開発者に影響する Firefox 48 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/49/index.md
+++ b/files/ja/mozilla/firefox/releases/49/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 49 for developers
 slug: Mozilla/Firefox/Releases/49
-tags:
-  - Firefox
-  - Release Notes
-translation_of: Mozilla/Firefox/Releases/49
 ---
 Firefox 49 は、米国時間 2016 年 9 月 20 日にリリースされました。このページでは、開発者に影響する Firefox 49 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/5/index.md
+++ b/files/ja/mozilla/firefox/releases/5/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 5 for developers
 slug: Mozilla/Firefox/Releases/5
-tags:
-  - Firefox
-  - Firefox 5
-  - Gecko 5.0
-translation_of: Mozilla/Firefox/Releases/5
 ---
 Firefox 5 は Gecko 5.0 ベースのブラウザで、2011 年 6 月 21 日にリリースされました。このページは Firefox 5 のリリースにあたり、開発者に影響する変更について情報をまとめたものです。
 

--- a/files/ja/mozilla/firefox/releases/50/index.md
+++ b/files/ja/mozilla/firefox/releases/50/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 50 for developers
 slug: Mozilla/Firefox/Releases/50
-tags:
-  - Firefox
-  - Release Notes
-translation_of: Mozilla/Firefox/Releases/50
 ---
 Firefox 50 は、米国時間 2016 年 11 月 15 日にリリースされました。このページでは、開発者に影響する Firefox 50 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/51/index.md
+++ b/files/ja/mozilla/firefox/releases/51/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 51 for developers
 slug: Mozilla/Firefox/Releases/51
-tags:
-  - Firefox
-  - Mozilla
-  - Release Notes
-translation_of: Mozilla/Firefox/Releases/51
 ---
 Firefox 51 は、米国時間 2017 年 1 月 24 日にリリースされました。このページでは、開発者に影響する Firefox 51 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/52/index.md
+++ b/files/ja/mozilla/firefox/releases/52/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 52 for developers
 slug: Mozilla/Firefox/Releases/52
-tags:
-  - Firefox
-  - Mozilla
-  - Release Notes
-translation_of: Mozilla/Firefox/Releases/52
 ---
 Firefox 52 は、米国時間 2017 年 3 月 7 日にリリースされました。このページでは、開発者に影響する Firefox 52 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/53/index.md
+++ b/files/ja/mozilla/firefox/releases/53/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 53 for developers
 slug: Mozilla/Firefox/Releases/53
-tags:
-  - Firefox
-  - Mozilla
-  - Release Notes
-translation_of: Mozilla/Firefox/Releases/53
 ---
 Firefox 53 は、米国時間 2017 年 4 月 19 日にリリースされました。このページでは、開発者に影響する Firefox 53 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/54/index.md
+++ b/files/ja/mozilla/firefox/releases/54/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 54 for developers
 slug: Mozilla/Firefox/Releases/54
-tags:
-  - Firefox
-  - Release Notes
-translation_of: Mozilla/Firefox/Releases/54
 ---
 Firefox 54 は、米国時間 2017 年 6 月 13 日にリリースされました。このページでは、開発者に影響する Firefox 54 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/55/index.md
+++ b/files/ja/mozilla/firefox/releases/55/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 55 for developers
 slug: Mozilla/Firefox/Releases/55
-tags:
-  - '55'
-  - Firefox
-  - Release Notes
-translation_of: Mozilla/Firefox/Releases/55
 ---
 Firefox 55 は、米国時間 2017 年 8 月 8 日にリリースされました。このページでは、開発者に影響する Firefox 55 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/56/index.md
+++ b/files/ja/mozilla/firefox/releases/56/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 56 for developers
 slug: Mozilla/Firefox/Releases/56
-tags:
-  - '56'
-  - Firefox
-  - Release Notes
-translation_of: Mozilla/Firefox/Releases/56
 ---
 Firefox 56 は、米国時間 2017 年 9 月 28 日にリリースされました。このページでは、開発者に影響する Firefox 56 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/57/index.md
+++ b/files/ja/mozilla/firefox/releases/57/index.md
@@ -1,13 +1,6 @@
 ---
 title: Firefox 57 (Quantum) for developers
 slug: Mozilla/Firefox/Releases/57
-tags:
-  - '57'
-  - Firefox
-  - Firefox Quantum
-  - Release Notes
-  - Stylo
-translation_of: Mozilla/Firefox/Releases/57
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/58/index.md
+++ b/files/ja/mozilla/firefox/releases/58/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 58 for developers
 slug: Mozilla/Firefox/Releases/58
-tags:
-  - '58'
-  - Firefox
-  - Release Notes
-translation_of: Mozilla/Firefox/Releases/58
 ---
 Firefox 58 は、米国時間 2018 年 1 月 23 日にリリースされました。このページでは、開発者に影響する Firefox 58 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/59/index.md
+++ b/files/ja/mozilla/firefox/releases/59/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 59 for developers
 slug: Mozilla/Firefox/Releases/59
-tags:
-  - '59'
-  - Firefox
-  - Release Notes
-translation_of: Mozilla/Firefox/Releases/59
 ---
 Firefox 59 は、米国時間 2018 年 3 月 13 日にリリースされました。このページでは、開発者に影響する Firefox 59 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/6/index.md
+++ b/files/ja/mozilla/firefox/releases/6/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 6 for developers
 slug: Mozilla/Firefox/Releases/6
-tags:
-  - Firefox
-  - Firefox 6
-  - Gecko 6.0
-translation_of: Mozilla/Firefox/Releases/6
 ---
 Firefox 6 は Gecko 6.0 ベースのブラウザで、2011 年 8 月 16 日にリリースされました。このページは Firefox 6 のリリースにあたり、開発者に関係する変更についてまとめたものです。
 

--- a/files/ja/mozilla/firefox/releases/60/index.md
+++ b/files/ja/mozilla/firefox/releases/60/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 60 for developers
 slug: Mozilla/Firefox/Releases/60
-tags:
-  - '60'
-  - Firefox
-  - Release Notes
-translation_of: Mozilla/Firefox/Releases/60
 ---
 Firefox 60 は、米国時間 2018 年 5 月 9 日にリリースされました。このページでは、開発者に影響する Firefox 60 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/61/index.md
+++ b/files/ja/mozilla/firefox/releases/61/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 61 for developers
 slug: Mozilla/Firefox/Releases/61
-tags:
-  - '61'
-  - Firefox
-  - Release
-translation_of: Mozilla/Firefox/Releases/61
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/62/index.md
+++ b/files/ja/mozilla/firefox/releases/62/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 62 for developers
 slug: Mozilla/Firefox/Releases/62
-tags:
-  - '62'
-  - Firefox
-  - Release
-translation_of: Mozilla/Firefox/Releases/62
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/63/index.md
+++ b/files/ja/mozilla/firefox/releases/63/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 63 for developers
 slug: Mozilla/Firefox/Releases/63
-tags:
-  - '63'
-  - Firefox
-  - Mozilla
-  - Release
-translation_of: Mozilla/Firefox/Releases/63
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/64/index.md
+++ b/files/ja/mozilla/firefox/releases/64/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 64 for developers
 slug: Mozilla/Firefox/Releases/64
-tags:
-  - '64'
-  - Firefox
-  - Mozilla
-  - Release
-translation_of: Mozilla/Firefox/Releases/64
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/65/index.md
+++ b/files/ja/mozilla/firefox/releases/65/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 65 for developers
 slug: Mozilla/Firefox/Releases/65
-tags:
-  - '65'
-  - Firefox
-  - Mozilla
-  - Release
-translation_of: Mozilla/Firefox/Releases/65
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/66/index.md
+++ b/files/ja/mozilla/firefox/releases/66/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 66 for developers
 slug: Mozilla/Firefox/Releases/66
-tags:
-  - '66'
-  - Firefox
-  - Mozilla
-  - Release
-translation_of: Mozilla/Firefox/Releases/66
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/67/index.md
+++ b/files/ja/mozilla/firefox/releases/67/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 67 for developers
 slug: Mozilla/Firefox/Releases/67
-tags:
-  - '67'
-  - Firefox
-  - Mozilla
-  - Release
-translation_of: Mozilla/Firefox/Releases/67
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/68/index.md
+++ b/files/ja/mozilla/firefox/releases/68/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 68 for developers
 slug: Mozilla/Firefox/Releases/68
-tags:
-  - '68'
-  - Firefox
-  - Mozilla
-  - Release
-translation_of: Mozilla/Firefox/Releases/68
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/69/index.md
+++ b/files/ja/mozilla/firefox/releases/69/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 69 for developers
 slug: Mozilla/Firefox/Releases/69
-tags:
-  - '69'
-  - Firefox
-  - Mozilla
-  - Release
-translation_of: Mozilla/Firefox/Releases/69
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/7/index.md
+++ b/files/ja/mozilla/firefox/releases/7/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 7 for developers
 slug: Mozilla/Firefox/Releases/7
-tags:
-  - Firefox
-  - Firefox 7
-  - Gecko 7
-translation_of: Mozilla/Firefox/Releases/7
 ---
 Firefox 7 は 2011 年 9 月 27 日にリリースされました。このページは Firefox 7 のリリースにあたり、開発者に関係する変更についてまとめたものです。
 

--- a/files/ja/mozilla/firefox/releases/70/index.md
+++ b/files/ja/mozilla/firefox/releases/70/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 70 for developers
 slug: Mozilla/Firefox/Releases/70
-tags:
-  - '70'
-  - Firefox
-  - Mozilla
-  - Release
-translation_of: Mozilla/Firefox/Releases/70
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/71/index.md
+++ b/files/ja/mozilla/firefox/releases/71/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 71 for Developers
 slug: Mozilla/Firefox/Releases/71
-tags:
-  - '71'
-  - Firefox
-  - Mozilla
-  - Release
-translation_of: Mozilla/Firefox/Releases/71
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/72/index.md
+++ b/files/ja/mozilla/firefox/releases/72/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 72 for Developers
 slug: Mozilla/Firefox/Releases/72
-tags:
-  - '72'
-  - Firefox
-  - Mozilla
-  - Release
-translation_of: Mozilla/Firefox/Releases/72
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/73/index.md
+++ b/files/ja/mozilla/firefox/releases/73/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 73 for developers
 slug: Mozilla/Firefox/Releases/73
-tags:
-  - '73'
-  - Firefox
-  - Mozilla
-  - Release
-translation_of: Mozilla/Firefox/Releases/73
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/74/index.md
+++ b/files/ja/mozilla/firefox/releases/74/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 74 for developers
 slug: Mozilla/Firefox/Releases/74
-tags:
-  - '74'
-  - Firefox
-  - Mozilla
-  - Release
-translation_of: Mozilla/Firefox/Releases/74
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/75/index.md
+++ b/files/ja/mozilla/firefox/releases/75/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 75 for developers
 slug: Mozilla/Firefox/Releases/75
-tags:
-  - '75'
-  - Firefox
-  - Mozilla
-  - Release
-translation_of: Mozilla/Firefox/Releases/75
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/76/index.md
+++ b/files/ja/mozilla/firefox/releases/76/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 76 for developers
 slug: Mozilla/Firefox/Releases/76
-tags:
-  - '76'
-  - Firefox
-  - Mozilla
-  - Release
-translation_of: Mozilla/Firefox/Releases/76
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/77/index.md
+++ b/files/ja/mozilla/firefox/releases/77/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 77 for developers
 slug: Mozilla/Firefox/Releases/77
-tags:
-  - '77'
-  - Firefox
-  - Mozilla
-  - Releases
-translation_of: Mozilla/Firefox/Releases/77
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/78/index.md
+++ b/files/ja/mozilla/firefox/releases/78/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 78 for developers
 slug: Mozilla/Firefox/Releases/78
-tags:
-  - '78'
-  - Firefox
-  - Mozilla
-  - Releases
-translation_of: Mozilla/Firefox/Releases/78
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/79/index.md
+++ b/files/ja/mozilla/firefox/releases/79/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 79 for developers
 slug: Mozilla/Firefox/Releases/79
-tags:
-  - '79'
-  - Firefox
-  - Mozilla
-  - Release
-translation_of: Mozilla/Firefox/Releases/79
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/8/index.md
+++ b/files/ja/mozilla/firefox/releases/8/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 8 for developers
 slug: Mozilla/Firefox/Releases/8
-tags:
-  - Firefox
-  - Firefox 8
-  - Gecko 8
-translation_of: Mozilla/Firefox/Releases/8
 ---
 Firefox 8 は 2011 年 11 月 8 日にリリースされました。このページでは、開発者に影響する Firefox 8 の変更点をまとめています。
 

--- a/files/ja/mozilla/firefox/releases/80/index.md
+++ b/files/ja/mozilla/firefox/releases/80/index.md
@@ -1,7 +1,6 @@
 ---
 title: Firefox 80 for developers
 slug: Mozilla/Firefox/Releases/80
-translation_of: Mozilla/Firefox/Releases/80
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/81/index.md
+++ b/files/ja/mozilla/firefox/releases/81/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 81 for developers
 slug: Mozilla/Firefox/Releases/81
-tags:
-  - '81'
-  - Firefox
-  - Mozilla
-  - Release
-translation_of: Mozilla/Firefox/Releases/81
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/82/index.md
+++ b/files/ja/mozilla/firefox/releases/82/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 82 for developers
 slug: Mozilla/Firefox/Releases/82
-tags:
-  - '82'
-  - Firefox
-  - Mozilla
-  - Release
-translation_of: Mozilla/Firefox/Releases/82
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/83/index.md
+++ b/files/ja/mozilla/firefox/releases/83/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 83 for developers
 slug: Mozilla/Firefox/Releases/83
-tags:
-  - '83'
-  - Firefox
-  - Mozilla
-  - Release
-translation_of: Mozilla/Firefox/Releases/83
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/84/index.md
+++ b/files/ja/mozilla/firefox/releases/84/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 84 for developers
 slug: Mozilla/Firefox/Releases/84
-tags:
-  - '84'
-  - Firefox
-  - Mozilla
-  - Release
-translation_of: Mozilla/Firefox/Releases/84
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/85/index.md
+++ b/files/ja/mozilla/firefox/releases/85/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 85 for developers
 slug: Mozilla/Firefox/Releases/85
-tags:
-  - '85'
-  - Firefox
-  - Mozilla
-  - Release
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/86/index.md
+++ b/files/ja/mozilla/firefox/releases/86/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 86 for developers
 slug: Mozilla/Firefox/Releases/86
-tags:
-  - '86'
-  - Firefox
-  - Mozilla
-  - Release
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/87/index.md
+++ b/files/ja/mozilla/firefox/releases/87/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 87 for developers
 slug: Mozilla/Firefox/Releases/87
-tags:
-  - '87'
-  - Firefox
-  - Mozilla
-  - Release
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/88/index.md
+++ b/files/ja/mozilla/firefox/releases/88/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 88 for developers
 slug: Mozilla/Firefox/Releases/88
-tags:
-  - '88'
-  - Firefox
-  - Mozilla
-  - Release
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/89/index.md
+++ b/files/ja/mozilla/firefox/releases/89/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 89 for developers
 slug: Mozilla/Firefox/Releases/89
-tags:
-  - '89'
-  - Firefox
-  - Mozilla
-  - Release
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/9/index.md
+++ b/files/ja/mozilla/firefox/releases/9/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 9 for developers
 slug: Mozilla/Firefox/Releases/9
-tags:
-  - Firefox
-  - Firefox 9
-  - Gecko 9
-translation_of: Mozilla/Firefox/Releases/9
 ---
 Firefox 9 は Windows 向けに 2011 年 12 月 20 日にリリースされました。その直後に見つかったクラッシュバグを修正した Mac 版および Linux 版のバージョン 9.0.1 は、2011 年 12 月 21 日にリリースされました。
 

--- a/files/ja/mozilla/firefox/releases/90/index.md
+++ b/files/ja/mozilla/firefox/releases/90/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 90 for developers
 slug: Mozilla/Firefox/Releases/90
-tags:
-  - '90'
-  - Firefox
-  - Mozilla
-  - Release
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/91/index.md
+++ b/files/ja/mozilla/firefox/releases/91/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 91 for developers
 slug: Mozilla/Firefox/Releases/91
-tags:
-  - '91'
-  - Firefox
-  - Mozilla
-  - Release
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/92/index.md
+++ b/files/ja/mozilla/firefox/releases/92/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 92 for developers
 slug: Mozilla/Firefox/Releases/92
-tags:
-  - '92'
-  - Firefox
-  - Mozilla
-  - Release
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/93/index.md
+++ b/files/ja/mozilla/firefox/releases/93/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 93 for developers
 slug: Mozilla/Firefox/Releases/93
-tags:
-  - '93'
-  - Firefox
-  - Mozilla
-  - Release
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/94/index.md
+++ b/files/ja/mozilla/firefox/releases/94/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 94 for developers
 slug: Mozilla/Firefox/Releases/94
-tags:
-  - '94'
-  - Firefox
-  - Mozilla
-  - Release
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/95/index.md
+++ b/files/ja/mozilla/firefox/releases/95/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 95 for developers
 slug: Mozilla/Firefox/Releases/95
-tags:
-  - '95'
-  - Firefox
-  - Mozilla
-  - Release
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/96/index.md
+++ b/files/ja/mozilla/firefox/releases/96/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 96 for developers
 slug: Mozilla/Firefox/Releases/96
-tags:
-  - '96'
-  - Firefox
-  - Mozilla
-  - Release
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/97/index.md
+++ b/files/ja/mozilla/firefox/releases/97/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 97 for developers
 slug: Mozilla/Firefox/Releases/97
-tags:
-  - '97'
-  - Firefox
-  - Mozilla
-  - Release
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/98/index.md
+++ b/files/ja/mozilla/firefox/releases/98/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 98 for developers
 slug: Mozilla/Firefox/Releases/98
-tags:
-  - '98'
-  - Firefox
-  - Mozilla
-  - Release
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/99/index.md
+++ b/files/ja/mozilla/firefox/releases/99/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox 99 for developers
 slug: Mozilla/Firefox/Releases/99
-tags:
-  - '99'
-  - Firefox
-  - Mozilla
-  - Release
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/firefox/releases/index.md
+++ b/files/ja/mozilla/firefox/releases/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 開発者向けリリースノート
 slug: Mozilla/Firefox/Releases
-tags:
-  - Firefox
-  - Landing
-  - Mozilla
-  - Release
-translation_of: Mozilla/Firefox/Releases
 ---
 {{FirefoxSidebar}}
 

--- a/files/ja/mozilla/index.md
+++ b/files/ja/mozilla/index.md
@@ -1,12 +1,6 @@
 ---
 title: Mozilla
 slug: Mozilla
-tags:
-  - Apps
-  - Landing
-  - Mozilla
-  - アドオン
-translation_of: Mozilla
 ---
 以下の記事は、Mozilla のコードをダウンロードしたりビルドしたりすることについてのコンテンツが含まれています。それに加え、コードがどのように動作するかや、Mozilla のアプリケーションやそれに類するアプリケーション向けのアドオンをビルドする方法について手助けとなる記事もあるでしょう。
 

--- a/files/ja/orphaned/mozilla/add-ons/webextensions/debugging_(before_firefox_50)/index.md
+++ b/files/ja/orphaned/mozilla/add-ons/webextensions/debugging_(before_firefox_50)/index.md
@@ -1,14 +1,6 @@
 ---
 title: デバッグ (Firefox 50 より前)
 slug: orphaned/Mozilla/Add-ons/WebExtensions/Debugging_(before_Firefox_50)
-tags:
-  - Debugging
-  - Firefox
-  - Guide
-  - Mozilla
-  - Deprecated
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/Debugging_(before_Firefox_50)
 original_slug: Mozilla/Add-ons/WebExtensions/Debugging_(before_Firefox_50)
 ---
 {{AddonSidebar}}


### PR DESCRIPTION
Part of #7858

`files\ja\mozilla` から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "tags": 283,
  "translation_of": 299
}
```
