### PR TITLE
remove duplicated frontmatter keys from orphaned (ja)

### DIFF
--- a/files/ja/orphaned/code_snippets/toolbar/index.md
+++ b/files/ja/orphaned/code_snippets/toolbar/index.md
@@ -1,9 +1,6 @@
 ---
 title: Toolbar
 slug: orphaned/Code_snippets/Toolbar
-tags:
-  - Add-ons
-  - Extensions
 original_slug: Code_snippets/Toolbar
 ---
 ### ツールバーボタンを追加する

--- a/files/ja/orphaned/creating_toolbar_buttons/index.md
+++ b/files/ja/orphaned/creating_toolbar_buttons/index.md
@@ -1,9 +1,6 @@
 ---
 title: Creating toolbar buttons
 slug: orphaned/Creating_toolbar_buttons
-tags:
-  - Add-ons
-  - Extensions
 original_slug: Creating_toolbar_buttons
 ---
 この記事ではツールキットアプリケーション（Firefox、Thunderbird、Nvu など）に [オーバレイ](ja/XUL_Overlays) を使用してツールバーボタンを追加する方法を説明します。[XUL](ja/XUL) と [CSS](ja/CSS) の基礎知識を備えた [拡張機能](ja/Extension) の開発者が対象です。

--- a/files/ja/orphaned/dynamically_modifying_xul-based_user_interface/index.md
+++ b/files/ja/orphaned/dynamically_modifying_xul-based_user_interface/index.md
@@ -1,11 +1,6 @@
 ---
 title: Dynamically modifying XUL-based user interface
 slug: orphaned/Dynamically_modifying_XUL-based_user_interface
-tags:
-  - Add-ons
-  - DOM
-  - Extensions
-  - XUL
 original_slug: Dynamically_modifying_XUL-based_user_interface
 ---
 この記事では、[DOM](ja/DOM) やその他の API を使って [XUL](ja/XUL) インターフェイスを操作する方法について検討します。まず DOM

--- a/files/ja/orphaned/feed_content_access_api/index.md
+++ b/files/ja/orphaned/feed_content_access_api/index.md
@@ -1,9 +1,6 @@
 ---
 title: Feed content access API
 slug: orphaned/Feed_content_access_API
-tags:
-  - Add-ons
-  - Extensions
 original_slug: Feed_content_access_API
 ---
 [Firefox 2](ja/Firefox_2) と Thunderbird 2 は拡張製作者に RSS と Atom フィードへのアクセスを簡単にする一連のインターフェースを導入します。

--- a/files/ja/orphaned/installing_extensions_and_themes_from_web_pages/index.md
+++ b/files/ja/orphaned/installing_extensions_and_themes_from_web_pages/index.md
@@ -1,10 +1,6 @@
 ---
 title: Web ページから拡張機能とテーマをインストールする
 slug: orphaned/Installing_Extensions_and_Themes_From_Web_Pages
-tags:
-  - Add-ons
-  - Extensions
-  - Themes
 original_slug: Installing_Extensions_and_Themes_From_Web_Pages
 ---
 [拡張機能](ja/Extension) と [テーマ](ja/Themes) を Web ページからインストールするには、XPI ファイルに直接リンクしたり、[InstallTrigger](ja/XPInstall_API_Reference/InstallTrigger_Object) オブジェクトを使用するなど様々な方法があります。

--- a/files/ja/orphaned/learn/server-side/express_nodejs/installing_on_pws_cloud_foundry/index.md
+++ b/files/ja/orphaned/learn/server-side/express_nodejs/installing_on_pws_cloud_foundry/index.md
@@ -1,7 +1,6 @@
 ---
 title: PWS/Cloud Foundry に LocalLibrary をインストールする
 slug: orphaned/Learn/Server-side/Express_Nodejs/Installing_on_PWS_Cloud_Foundry
-translation_of: Learn/Server-side/Express_Nodejs/Installing_on_PWS_Cloud_Foundry
 original_slug: Learn/Server-side/Express_Nodejs/Installing_on_PWS_Cloud_Foundry
 ---
 {{LearnSidebar}}

--- a/files/ja/orphaned/localizing_extension_descriptions/index.md
+++ b/files/ja/orphaned/localizing_extension_descriptions/index.md
@@ -1,11 +1,6 @@
 ---
 title: Localizing extension descriptions
 slug: orphaned/Localizing_extension_descriptions
-tags:
-  - Add-ons
-  - Extensions
-  - Internationalization
-  - Localization
 original_slug: Localizing_extension_descriptions
 ---
 ### Gecko 1.9 におけるローカライズ

--- a/files/ja/orphaned/mdn/about/linking_to_mdn/index.md
+++ b/files/ja/orphaned/mdn/about/linking_to_mdn/index.md
@@ -1,11 +1,6 @@
 ---
 title: MDN にリンクするには
 slug: orphaned/MDN/About/Linking_to_MDN
-tags:
-  - Documentation
-  - Guide
-  - MDN
-translation_of: MDN/About/Linking_to_MDN
 original_slug: MDN/About/Linking_to_MDN
 ---
 {{MDNSidebar}}

--- a/files/ja/orphaned/mdn/community/conversations/index.md
+++ b/files/ja/orphaned/mdn/community/conversations/index.md
@@ -1,11 +1,6 @@
 ---
 title: MDN コミュニティでの対話
 slug: orphaned/MDN/Community/Conversations
-tags:
-  - Community
-  - Guide
-  - MDN Meta
-translation_of: MDN/Community/Conversations
 original_slug: MDN/Community/Conversations
 ---
 {{MDNSidebar}}

--- a/files/ja/orphaned/mdn/community/doc_sprints/index.md
+++ b/files/ja/orphaned/mdn/community/doc_sprints/index.md
@@ -1,7 +1,6 @@
 ---
 title: Doc sprints
 slug: orphaned/MDN/Community/Doc_sprints
-translation_of: MDN/Community/Doc_sprints
 original_slug: MDN/Community/Doc_sprints
 ---
 {{MDNSidebar}}

--- a/files/ja/orphaned/mdn/community/whats_happening/index.md
+++ b/files/ja/orphaned/mdn/community/whats_happening/index.md
@@ -1,12 +1,6 @@
 ---
 title: 何が起きているかを追跡する
 slug: orphaned/MDN/Community/Whats_happening
-tags:
-  - Beginner
-  - Community
-  - Guide
-  - MDN Meta
-translation_of: MDN/Community/Whats_happening
 original_slug: MDN/Community/Whats_happening
 ---
 {{MDNSidebar}}

--- a/files/ja/orphaned/mdn/community/working_in_community/index.md
+++ b/files/ja/orphaned/mdn/community/working_in_community/index.md
@@ -1,11 +1,6 @@
 ---
 title: コミュニティでの作業
 slug: orphaned/MDN/Community/Working_in_community
-tags:
-  - Community
-  - Guide
-  - MDN Meta
-translation_of: MDN/Community/Working_in_community
 original_slug: MDN/Community/Working_in_community
 ---
 {{MDNSidebar}}

--- a/files/ja/orphaned/mdn/structures/api_references/what_does_an_api_reference_need/index.md
+++ b/files/ja/orphaned/mdn/structures/api_references/what_does_an_api_reference_need/index.md
@@ -1,11 +1,6 @@
 ---
 title: API リファレンスには何が必要ですか？
 slug: orphaned/MDN/Structures/API_references/What_does_an_API_reference_need
-tags:
-  - API
-  - ページ
-  - リファレンス
-translation_of: MDN/Structures/API_references/What_does_an_API_reference_need
 original_slug: MDN/Structures/API_references/What_does_an_API_reference_need
 ---
 {{MDNSidebar}}

--- a/files/ja/orphaned/mdn/structures/live_samples/simple_live_sample_demo/index.md
+++ b/files/ja/orphaned/mdn/structures/live_samples/simple_live_sample_demo/index.md
@@ -1,11 +1,6 @@
 ---
 title: ライブコードサンプルの簡単なデモ
 slug: orphaned/MDN/Structures/Live_samples/Simple_live_sample_demo
-tags:
-  - MDN Meta
-  - Structures
-  - 例
-translation_of: MDN/Structures/Live_samples/Simple_live_sample_demo
 original_slug: MDN/Structures/Live_samples/Simple_live_sample_demo
 ---
 {{MDNSidebar}}

--- a/files/ja/orphaned/microsummary_xml_grammar_reference/index.md
+++ b/files/ja/orphaned/microsummary_xml_grammar_reference/index.md
@@ -1,8 +1,6 @@
 ---
 title: Microsummary XML grammar reference
 slug: orphaned/Microsummary_XML_grammar_reference
-tags:
-  - Microsummaries
 original_slug: Microsummary_XML_grammar_reference
 ---
 ## はじめに

--- a/files/ja/orphaned/migrate_apps_from_internet_explorer_to_mozilla/index.md
+++ b/files/ja/orphaned/migrate_apps_from_internet_explorer_to_mozilla/index.md
@@ -1,8 +1,6 @@
 ---
 title: Migrate apps from Internet Explorer to Mozilla
 slug: orphaned/Migrate_apps_from_Internet_Explorer_to_Mozilla
-tags:
-  - 要更新
 original_slug: Migrate_apps_from_Internet_Explorer_to_Mozilla
 ---
 ### イントロダクション

--- a/files/ja/orphaned/new_in_javascript_1.8/index.md
+++ b/files/ja/orphaned/new_in_javascript_1.8/index.md
@@ -1,9 +1,6 @@
 ---
 title: New in JavaScript 1.8
 slug: orphaned/New_in_JavaScript_1.8
-tags:
-  - JavaScript
-  - JavaScript_version_overviews
 original_slug: New_in_JavaScript_1.8
 ---
 JavaScript 1.8 は（[Firefox 3](/ja/docs/Mozilla/Firefox/Releases/3 "Firefox_3_for_developers") に組み込まれている） Gecko 1.9 の一部分です。これは [JavaScript 1.7](/ja/docs/Web/JavaScript/New_in_JavaScript/1.7 "New_in_JavaScript_1.7") よりは大きな更新ではありませんが、ECMAScript 4/JavaScript 2 の進歩に追随するための更新がいくつか含まれています。このリリースは [JavaScript 1.6](/ja/docs/Web/JavaScript/New_in_JavaScript/1.6 "New_in_JavaScript_1.6") および [JavaScript 1.7](/ja/docs/Web/JavaScript/New_in_JavaScript/1.7 "New_in_JavaScript_1.7") で仕様化された新機能の全てを含んでいます。

--- a/files/ja/orphaned/reftest_opportunities_files/index.md
+++ b/files/ja/orphaned/reftest_opportunities_files/index.md
@@ -1,9 +1,6 @@
 ---
 title: reftest opportunities files
 slug: orphaned/reftest_opportunities_files
-tags:
-  - Automated testing
-  - Developing Mozilla
 original_slug: reftest_opportunities_files
 ---
 ### Introduction

--- a/files/ja/orphaned/setting_up_extension_development_environment/index.md
+++ b/files/ja/orphaned/setting_up_extension_development_environment/index.md
@@ -1,9 +1,6 @@
 ---
 title: Setting up extension development environment
 slug: orphaned/Setting_up_extension_development_environment
-tags:
-  - Add-ons
-  - Extensions
 original_slug: Setting_up_extension_development_environment
 ---
 この記事では、あなたの Mozilla アプリケーションにおいて拡張機能の開発を容易にするためのノウハウを提案します。

--- a/files/ja/orphaned/the_importance_of_correct_html_commenting/index.md
+++ b/files/ja/orphaned/the_importance_of_correct_html_commenting/index.md
@@ -1,8 +1,6 @@
 ---
 title: The Importance of Correct HTML Commenting
 slug: orphaned/The_Importance_of_Correct_HTML_Commenting
-tags:
-  - HTML
 original_slug: The_Importance_of_Correct_HTML_Commenting
 ---
 HTML を [標準モード](ja/Mozilla's_DOCTYPE_sniffing) で記述する場合、不正確に書かれたコメントによってページの表示が崩れ、コンテンツの一部または全体がコメントアウトされた状態になってしまいます。XHTML や XML を記述する場合、不正確なコメントが含まれると、ドキュメントそのものが表示できなくなります。

--- a/files/ja/orphaned/toolkit_api/official_references/index.md
+++ b/files/ja/orphaned/toolkit_api/official_references/index.md
@@ -1,8 +1,6 @@
 ---
 title: Official References
 slug: orphaned/Toolkit_API/Official_References
-tags:
-  - Toolkit API
 original_slug: Toolkit_API/Official_References
 ---
 Official References. Do not add to this list without contacting Benjamin Smedberg. Note that this page is included from the pages listed below. So: Don't Add Breadcrumbs!

--- a/files/ja/orphaned/web/api/document_object_model/events/index.md
+++ b/files/ja/orphaned/web/api/document_object_model/events/index.md
@@ -1,11 +1,6 @@
 ---
 title: イベントと DOM
 slug: orphaned/Web/API/Document_Object_Model/Events
-tags:
-  - DOM
-  - Guide
-  - ガイド
-translation_of: Web/API/Document_Object_Model/Events
 original_slug: Web/API/Document_Object_Model/Events
 ---
 {{DefaultAPISidebar("DOM")}}

--- a/files/ja/orphaned/web/api/navigatorstorage/index.md
+++ b/files/ja/orphaned/web/api/navigatorstorage/index.md
@@ -1,18 +1,6 @@
 ---
 title: NavigatorStorage
 slug: orphaned/Web/API/NavigatorStorage
-tags:
-  - API
-  - Interface
-  - Mixin
-  - Navigator
-  - NavigatorStorage
-  - Reference
-  - Secure context
-  - Storage
-  - Storage Standard
-  - WorkerNavigator
-translation_of: Web/API/NavigatorStorage
 original_slug: Web/API/NavigatorStorage
 ---
 {{securecontext_header}}{{APIRef("Storage")}}

--- a/files/ja/orphaned/web/api/navigatorstorage/storage/index.md
+++ b/files/ja/orphaned/web/api/navigatorstorage/storage/index.md
@@ -1,16 +1,6 @@
 ---
 title: NavigatorStorage.storage
 slug: orphaned/Web/API/NavigatorStorage/storage
-tags:
-  - API
-  - Navigator
-  - NavigatorStorage
-  - Property
-  - Reference
-  - Secure context
-  - Storage
-  - WorkerNavigator
-translation_of: Web/API/NavigatorStorage/storage
 original_slug: Web/API/NavigatorStorage/storage
 ---
 {{securecontext_header}}{{APIRef("Storage")}}

--- a/files/ja/orphaned/web/api/readablestreamdefaultcontroller/readablestreamdefaultcontroller/index.md
+++ b/files/ja/orphaned/web/api/readablestreamdefaultcontroller/readablestreamdefaultcontroller/index.md
@@ -1,14 +1,6 @@
 ---
 title: ReadableStreamDefaultController.ReadableStreamDefaultController()
-slug: >-
-  orphaned/Web/API/ReadableStreamDefaultController/ReadableStreamDefaultController
-tags:
-  - API
-  - Constructor
-  - ReadableStreamDefaultController
-  - Reference
-  - Streams
-translation_of: Web/API/ReadableStreamDefaultController/ReadableStreamDefaultController
+slug: orphaned/Web/API/ReadableStreamDefaultController/ReadableStreamDefaultController
 original_slug: Web/API/ReadableStreamDefaultController/ReadableStreamDefaultController
 ---
 {{APIRef("Streams")}}

--- a/files/ja/orphaned/web/api/rtcidentityerrorevent/index.md
+++ b/files/ja/orphaned/web/api/rtcidentityerrorevent/index.md
@@ -1,7 +1,6 @@
 ---
 title: RTCIdentityErrorEvent
 slug: orphaned/Web/API/RTCIdentityErrorEvent
-translation_of: Web/API/RTCIdentityErrorEvent
 original_slug: Web/API/RTCIdentityErrorEvent
 ---
 {{APIRef("WebRTC")}}{{SeeCompatTable}}

--- a/files/ja/orphaned/web/api/rtcidentityevent/index.md
+++ b/files/ja/orphaned/web/api/rtcidentityevent/index.md
@@ -1,7 +1,6 @@
 ---
 title: RTCIdentityEvent
 slug: orphaned/Web/API/RTCIdentityEvent
-translation_of: Web/API/RTCIdentityEvent
 original_slug: Web/API/RTCIdentityEvent
 ---
 {{APIRef("WebRTC")}}{{SeeCompatTable}}

--- a/files/ja/orphaned/web/api/rtcsessiondescriptioncallback/index.md
+++ b/files/ja/orphaned/web/api/rtcsessiondescriptioncallback/index.md
@@ -1,7 +1,6 @@
 ---
 title: RTCSessionDescriptionCallback
 slug: orphaned/Web/API/RTCSessionDescriptionCallback
-translation_of: Web/API/RTCSessionDescriptionCallback
 original_slug: Web/API/RTCSessionDescriptionCallback
 ---
 {{APIRef("WebRTC")}}{{SeeCompatTable}}RTCSessionDescriptionCallback はオファーまたはアンサーの作成が要求された時に [RTCPeerConnection](/ja/docs/) オブジェクトによって実行されます。

--- a/files/ja/orphaned/web/api/sourcebufferlist/sourcebuffer/index.md
+++ b/files/ja/orphaned/web/api/sourcebufferlist/sourcebuffer/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'SourceBufferList: indexed property getter'
 slug: orphaned/Web/API/SourceBufferList/SourceBuffer
-tags:
-  - API
-  - Audio
-  - Experimental
-  - Getter
-  - MSE
-  - Media Source Extensions
-  - Method
-  - Reference
-  - SourceBuffer
-  - SourceBufferList
-  - Video
-translation_of: Web/API/SourceBufferList/SourceBuffer
 original_slug: Web/API/SourceBufferList/SourceBuffer
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}

--- a/files/ja/orphaned/web/api/svgtransformable/index.md
+++ b/files/ja/orphaned/web/api/svgtransformable/index.md
@@ -1,14 +1,6 @@
 ---
 title: SVGTransformable
 slug: orphaned/Web/API/SVGTransformable
-tags:
-  - API
-  - NeedsExample
-  - Reference
-  - Référence(2)
-  - SVG
-  - SVG DOM
-translation_of: Web/API/SVGTransformable
 original_slug: Web/API/SVGTransformable
 ---
 {{APIRef("SVG")}}

--- a/files/ja/orphaned/web/api/window/getattention/index.md
+++ b/files/ja/orphaned/web/api/window/getattention/index.md
@@ -1,13 +1,6 @@
 ---
 title: window.getAttention
 slug: orphaned/Web/API/Window/getAttention
-tags:
-  - DOM
-  - DOM_0
-  - Gecko
-  - Gecko DOM Reference
-  - Window
-translation_of: Web/API/Window/getAttention
 original_slug: Web/API/Window/getAttention
 ---
 {{ApiRef}}

--- a/files/ja/orphaned/web/api/window/ondeviceproximity/index.md
+++ b/files/ja/orphaned/web/api/window/ondeviceproximity/index.md
@@ -1,15 +1,6 @@
 ---
 title: Window.ondeviceproximity
 slug: orphaned/Web/API/Window/ondeviceproximity
-tags:
-  - API
-  - Event Handler
-  - Experimental
-  - Property
-  - Proximitiy Event
-  - Reference
-  - Window
-translation_of: Web/API/Window/ondeviceproximity
 original_slug: Web/API/Window/ondeviceproximity
 ---
 {{ ApiRef() }}

--- a/files/ja/orphaned/web/api/xmlhttprequest/openrequest/index.md
+++ b/files/ja/orphaned/web/api/xmlhttprequest/openrequest/index.md
@@ -1,17 +1,6 @@
 ---
 title: XMLHttpRequest.openRequest()
 slug: orphaned/Web/API/XMLHttpRequest/openRequest
-tags:
-  - API
-  - DOM
-  - Firefox
-  - Gecko
-  - Method
-  - XHR
-  - XMLHttpRequest
-  - openRequest
-  - 非標準
-translation_of: Web/API/XMLHttpRequest/openRequest
 original_slug: Web/API/XMLHttpRequest/openRequest
 ---
 {{APIRef("XMLHttpRequest")}}{{non-standard_header}}

--- a/files/ja/orphaned/web/api/xrsessionmode/index.md
+++ b/files/ja/orphaned/web/api/xrsessionmode/index.md
@@ -1,22 +1,6 @@
 ---
 title: XRSessionMode
 slug: orphaned/Web/API/XRSessionMode
-tags:
-  - API
-  - AR
-  - Enum
-  - Graphics
-  - Reference
-  - Session
-  - Type
-  - VR
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-  - XRSession
-  - XRSessionMode
-translation_of: Web/API/XRSessionMode
 original_slug: Web/API/XRSessionMode
 ---
 {{APIRef("WebXR Device API")}}

--- a/files/ja/orphaned/web/compatibility_faq/broken_table_layout.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/broken_table_layout.html/index.md
@@ -1,9 +1,6 @@
 ---
 title: テーブルのレイアウトが崩れている
 slug: orphaned/Web/Compatibility_FAQ/Broken_Table_Layout.html
-tags:
-  - Compatibility
-  - Layout
 original_slug: Web/Compatibility_FAQ/Broken_Table_Layout.html
 ---
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/cut_off_text.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/cut_off_text.html/index.md
@@ -1,9 +1,6 @@
 ---
 title: 文字列の一部が表示されずに見切れる
 slug: orphaned/Web/Compatibility_FAQ/Cut_Off_Text.html
-tags:
-  - Compatibility
-  - Layout
 original_slug: Web/Compatibility_FAQ/Cut_Off_Text.html
 ---
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/empty_background_color.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/empty_background_color.html/index.md
@@ -1,9 +1,6 @@
 ---
 title: アイコン,バナーの色が抜けている
 slug: orphaned/Web/Compatibility_FAQ/Empty_Background_Color.html
-tags:
-  - Compatibility
-  - Decoration
 original_slug: Web/Compatibility_FAQ/Empty_Background_Color.html
 ---
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/index.md
@@ -1,8 +1,6 @@
 ---
 title: サイト表示互換性に関するノウハウ
 slug: orphaned/Web/Compatibility_FAQ
-tags:
-  - Compatibility
 original_slug: Web/Compatibility_FAQ
 ---
 ---

--- a/files/ja/orphaned/web/compatibility_faq/invalid_icon_size.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/invalid_icon_size.html/index.md
@@ -1,9 +1,6 @@
 ---
 title: アイコン、画像が期待と異なるサイズで表示される
 slug: orphaned/Web/Compatibility_FAQ/Invalid_Icon_Size.html
-tags:
-  - Compatibility
-  - Layout
 original_slug: Web/Compatibility_FAQ/Invalid_Icon_Size.html
 ---
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/misaligned_icon.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/misaligned_icon.html/index.md
@@ -1,9 +1,6 @@
 ---
 title: アイコン、画像の表示位置がずれる
 slug: orphaned/Web/Compatibility_FAQ/Misaligned_Icon.html
-tags:
-  - Compatibility
-  - Layout
 original_slug: Web/Compatibility_FAQ/Misaligned_Icon.html
 ---
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/misaligned_text.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/misaligned_text.html/index.md
@@ -1,9 +1,6 @@
 ---
 title: 文字列の表示位置がずれる
 slug: orphaned/Web/Compatibility_FAQ/Misaligned_Text.html
-tags:
-  - Compatibility
-  - Layout
 original_slug: Web/Compatibility_FAQ/Misaligned_Text.html
 ---
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/misaligned_text_inside_icon.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/misaligned_text_inside_icon.html/index.md
@@ -1,9 +1,6 @@
 ---
 title: アイコンの中身が外側にはみ出すなどして形が壊れている
 slug: orphaned/Web/Compatibility_FAQ/Misaligned_Text_Inside_Icon.html
-tags:
-  - Compatibility
-  - Layout
 original_slug: Web/Compatibility_FAQ/Misaligned_Text_Inside_Icon.html
 ---
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/no_background_shown.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/no_background_shown.html/index.md
@@ -1,9 +1,6 @@
 ---
 title: ページの背景色が抜けている
 slug: orphaned/Web/Compatibility_FAQ/No_Background_Shown.html
-tags:
-  - Compatibility
-  - Decoration
 original_slug: Web/Compatibility_FAQ/No_Background_Shown.html
 ---
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/no_border_line_shown.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/no_border_line_shown.html/index.md
@@ -1,9 +1,6 @@
 ---
 title: 罫線が表示されない
 slug: orphaned/Web/Compatibility_FAQ/No_Border_Line_Shown.html
-tags:
-  - Compatibility
-  - Invisible element
 original_slug: Web/Compatibility_FAQ/No_Border_Line_Shown.html
 ---
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/no_checkbox_check_shown.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/no_checkbox_check_shown.html/index.md
@@ -1,9 +1,6 @@
 ---
 title: チェックボックスのレ点が表示されない
 slug: orphaned/Web/Compatibility_FAQ/No_Checkbox_Check_Shown.html
-tags:
-  - Compatibility
-  - Invisible element
 original_slug: Web/Compatibility_FAQ/No_Checkbox_Check_Shown.html
 ---
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/no_decoreation_shown.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/no_decoreation_shown.html/index.md
@@ -1,9 +1,6 @@
 ---
 title: 枠のシャドウや角丸が抜けている
 slug: orphaned/Web/Compatibility_FAQ/No_Decoreation_Shown.html
-tags:
-  - Compatibility
-  - Decoration
 original_slug: Web/Compatibility_FAQ/No_Decoreation_Shown.html
 ---
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/no_icon_shown.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/no_icon_shown.html/index.md
@@ -1,9 +1,6 @@
 ---
 title: アイコンが表示されない
 slug: orphaned/Web/Compatibility_FAQ/No_Icon_Shown.html
-tags:
-  - Compatibility
-  - Invisible element
 original_slug: Web/Compatibility_FAQ/No_Icon_Shown.html
 ---
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/no_wrap.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/no_wrap.html/index.md
@@ -1,9 +1,6 @@
 ---
 title: 画面外に不要な空白が発生する
 slug: orphaned/Web/Compatibility_FAQ/No_Wrap.html
-tags:
-  - Compatibility
-  - Layout
 original_slug: Web/Compatibility_FAQ/No_Wrap.html
 ---
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/overwrapped_icon.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/overwrapped_icon.html/index.md
@@ -1,9 +1,6 @@
 ---
 title: アイコンが隣接する他のアイコンと重なってしまう
 slug: orphaned/Web/Compatibility_FAQ/Overwrapped_Icon.html
-tags:
-  - Compatibility
-  - Layout
 original_slug: Web/Compatibility_FAQ/Overwrapped_Icon.html
 ---
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/overwrapped_navigation.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/overwrapped_navigation.html/index.md
@@ -1,9 +1,6 @@
 ---
 title: ナビゲーションメニューが他のアイコンと重なって表示されたり、画面からはみ出たりしてしまう
 slug: orphaned/Web/Compatibility_FAQ/Overwrapped_Navigation.html
-tags:
-  - Compatibility
-  - Layout
 original_slug: Web/Compatibility_FAQ/Overwrapped_Navigation.html
 ---
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/tips_default_style_difference.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/tips_default_style_difference.html/index.md
@@ -1,9 +1,6 @@
 ---
 title: ブラウザごとの表示の違い(User-Agent-Stylesheetによる表示差異)
 slug: orphaned/Web/Compatibility_FAQ/Tips_Default_Style_Difference.html
-tags:
-  - Compatibility
-  - StyleSheet
 original_slug: Web/Compatibility_FAQ/Tips_Default_Style_Difference.html
 ---
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/tips_vendor_prefix.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/tips_vendor_prefix.html/index.md
@@ -1,9 +1,6 @@
 ---
 title: mobile版Firefox向けベンダープレフィックス対処方法まとめ
 slug: orphaned/Web/Compatibility_FAQ/Tips_Vendor_Prefix.html
-tags:
-  - Compatibility
-  - Vendor prefix
 original_slug: Web/Compatibility_FAQ/Tips_Vendor_Prefix.html
 ---
 ## 概要

--- a/files/ja/orphaned/web/compatibility_faq/underline_color_diffrence.html/index.md
+++ b/files/ja/orphaned/web/compatibility_faq/underline_color_diffrence.html/index.md
@@ -1,9 +1,6 @@
 ---
 title: 下線の色が相違している
 slug: orphaned/Web/Compatibility_FAQ/Underline_Color_Diffrence.html
-tags:
-  - Compatibility
-  - Decoration
 original_slug: Web/Compatibility_FAQ/Underline_Color_Diffrence.html
 ---
 ## 概要

--- a/files/ja/orphaned/web/css/@media/scan/index.md
+++ b/files/ja/orphaned/web/css/@media/scan/index.md
@@ -1,15 +1,6 @@
 ---
 title: scan
 slug: orphaned/Web/CSS/@media/scan
-tags:
-  - '@media'
-  - CSS
-  - Media Queries
-  - Reference
-  - media feature
-  - メディアクエリ
-  - メディア特性
-translation_of: Web/CSS/@media/scan
 original_slug: Web/CSS/@media/scan
 ---
 {{cssref}}

--- a/files/ja/orphaned/web/css/@page/bleed/index.md
+++ b/files/ja/orphaned/web/css/@page/bleed/index.md
@@ -1,16 +1,6 @@
 ---
 title: bleed
 slug: orphaned/Web/CSS/@page/bleed
-tags:
-  - '@page'
-  - CSS
-  - CSS ページ化メディア
-  - CSS 記述子
-  - Experimental
-  - Reference
-  - bleed
-  - ウェブ
-translation_of: Web/CSS/@page/bleed
 original_slug: Web/CSS/@page/bleed
 ---
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/ja/orphaned/web/css/@page/marks/index.md
+++ b/files/ja/orphaned/web/css/@page/marks/index.md
@@ -1,16 +1,6 @@
 ---
 title: marks
 slug: orphaned/Web/CSS/@page/marks
-tags:
-  - '@page'
-  - CSS
-  - CSS ページ化メディア
-  - CSS 記述子
-  - Experimental
-  - Reference
-  - ウェブ
-  - レイアウト
-translation_of: Web/CSS/@page/marks
 original_slug: Web/CSS/@page/marks
 ---
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/ja/orphaned/web/guide/ajax/other_resources/index.md
+++ b/files/ja/orphaned/web/guide/ajax/other_resources/index.md
@@ -1,9 +1,6 @@
 ---
 title: AJAX に関するその他の資料
 slug: orphaned/Web/Guide/AJAX/Other_Resources
-tags:
-  - AJAX
-translation_of: Web/Guide/AJAX/Other_Resources
 original_slug: Web/Guide/AJAX/Other_Resources
 ---
 - [AJAX Review](http://www.ajaxreview.com/)

--- a/files/ja/orphaned/web/guide/html/html5/index.md
+++ b/files/ja/orphaned/web/guide/html/html5/index.md
@@ -1,12 +1,6 @@
 ---
 title: HTML5
 slug: orphaned/Web/Guide/HTML/HTML5
-tags:
-  - HTML
-  - HTML5
-  - References
-  - Web Development
-translation_of: Web/Guide/HTML/HTML5
 original_slug: Web/Guide/HTML/HTML5
 ---
 HTML5 は [HTML](/ja/docs/HTML "HTML") で定義されている最新の標準仕様の名称です。この用語は、 2 つの異なる概念を表しています。これは HTML 言語の新しいバージョンであり、新しい要素、属性、動作、**および**より多彩でパワフルなウェブサイトやアプリケーションを構築することができるより大きな一連の技術でもあります。このセットは HTML5 & friends と呼ばれることがあり、よく HTML5 と短縮されます。

--- a/files/ja/orphaned/web/guide/html/using_html_sections_and_outlines/index.md
+++ b/files/ja/orphaned/web/guide/html/using_html_sections_and_outlines/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTML のセクションとアウトラインの使用
 slug: orphaned/Web/Guide/HTML/Using_HTML_sections_and_outlines
-tags:
-  - Advanced
-  - Example
-  - Guide
-  - HTML
-  - HTML5
-  - Outlines
-  - Overview
-  - Sections
-  - Web
-translation_of: Web/Guide/HTML/Using_HTML_sections_and_outlines
 original_slug: Web/Guide/HTML/Using_HTML_sections_and_outlines
 ---
 {{HTMLSidebar}}

--- a/files/ja/orphaned/web/guide/localizations_and_character_encodings/index.md
+++ b/files/ja/orphaned/web/guide/localizations_and_character_encodings/index.md
@@ -1,7 +1,6 @@
 ---
 title: ローカライゼーションと文字エンコーディング
 slug: orphaned/Web/Guide/Localizations_and_character_encodings
-translation_of: Web/Guide/Localizations_and_character_encodings
 original_slug: Web/Guide/Localizations_and_character_encodings
 ---
 ブラウザは内部的にテキストを Unicode として処理します。ただし、ネットワークを介してブラウザにテキストを転送するには、文字をバイトで表現する方法 (文字エンコーディング) が使用されます。[HTML 仕様](http://www.whatwg.org/specs/web-apps/current-work/multipage/semantics.html#charset)では、UTF-8 エンコーディング (これはすべての Unicode を表すことができます) の使用を推奨しています。使用されるエンコーディングにかかわらず、Web コンテンツがどのエンコーディングを使用するかを宣言する必要があります。

--- a/files/ja/orphaned/web/javascript/guide/predefined_functions/escape_and_unescape_functions/index.md
+++ b/files/ja/orphaned/web/javascript/guide/predefined_functions/escape_and_unescape_functions/index.md
@@ -1,7 +1,6 @@
 ---
 title: escape 関数と unescape 関数
-slug: >-
-  orphaned/Web/JavaScript/Guide/Predefined_Functions/escape_and_unescape_Functions
+slug: orphaned/Web/JavaScript/Guide/Predefined_Functions/escape_and_unescape_Functions
 original_slug: Web/JavaScript/Guide/Predefined_Functions/escape_and_unescape_Functions
 ---
 <div class="onlyinclude"><h3 id="escape_.E3.81.8A.E3.82.88.E3.81.B3_unescape_.E9.96.A2.E6.95.B0" name="escape_.E3.81.8A.E3.82.88.E3.81.B3_unescape_.E9.96.A2.E6.95.B0">escape および unescape 関数</h3><p><code>escape</code> および <code>unescape</code> 関数は文字列をエンコードしたりデコードしたりします。<code>escape</code> 関数は ISO Latin 文字セットで表された引数の 16 進エンコーディングを返します。<code>unescape</code> は指定した 16 進エンコーディングの値に対する ASCII 文字列を返します。</p><p>これらの関数の構文は以下のとおりです。</p><pre>escape(string)

--- a/files/ja/orphaned/web/javascript/guide/the_employee_example/object_properties/adding_properties/index.md
+++ b/files/ja/orphaned/web/javascript/guide/the_employee_example/object_properties/adding_properties/index.md
@@ -1,7 +1,6 @@
 ---
 title: Adding Properties
-slug: >-
-  orphaned/Web/JavaScript/Guide/The_Employee_Example/Object_Properties/Adding_Properties
+slug: orphaned/Web/JavaScript/Guide/The_Employee_Example/Object_Properties/Adding_Properties
 original_slug: Web/JavaScript/Guide/The_Employee_Example/Object_Properties/Adding_Properties
 ---
 ### プロパティの追加

--- a/files/ja/orphaned/web/javascript/guide/the_employee_example/object_properties/inheriting_properties/index.md
+++ b/files/ja/orphaned/web/javascript/guide/the_employee_example/object_properties/inheriting_properties/index.md
@@ -1,9 +1,7 @@
 ---
 title: Inheriting Properties
-slug: >-
-  orphaned/Web/JavaScript/Guide/The_Employee_Example/Object_Properties/Inheriting_Properties
-original_slug: >-
-  Web/JavaScript/Guide/The_Employee_Example/Object_Properties/Inheriting_Properties
+slug: orphaned/Web/JavaScript/Guide/The_Employee_Example/Object_Properties/Inheriting_Properties
+original_slug: Web/JavaScript/Guide/The_Employee_Example/Object_Properties/Inheriting_Properties
 ---
 ### プロパティの継承
 

--- a/files/ja/orphaned/web/javascript/reference/errors/typed_array_invalid_arguments/index.md
+++ b/files/ja/orphaned/web/javascript/reference/errors/typed_array_invalid_arguments/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'TypeError: invalid arguments'
 slug: orphaned/Web/JavaScript/Reference/Errors/Typed_array_invalid_arguments
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - TypeError
-translation_of: Web/JavaScript/Reference/Errors/Typed_array_invalid_arguments
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/orphaned/web/javascript/reference/global_objects/asyncfunction/prototype/index.md
+++ b/files/ja/orphaned/web/javascript/reference/global_objects/asyncfunction/prototype/index.md
@@ -1,13 +1,6 @@
 ---
 title: AsyncFunction.prototype
 slug: orphaned/Web/JavaScript/Reference/Global_Objects/AsyncFunction/prototype
-tags:
-  - Experimental
-  - JavaScript
-  - Property
-  - Prototype
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/AsyncFunction/prototype
 original_slug: Web/JavaScript/Reference/Global_Objects/AsyncFunction/prototype
 ---
 {{JSRef}}

--- a/files/ja/orphaned/web/security/information_security_basics/index.md
+++ b/files/ja/orphaned/web/security/information_security_basics/index.md
@@ -1,12 +1,6 @@
 ---
 title: 情報セキュリティの基本
 slug: orphaned/Web/Security/Information_Security_Basics
-tags:
-  - Beginner
-  - Landing
-  - Security
-  - セキュリティ
-translation_of: Web/Security/Information_Security_Basics
 original_slug: Web/Security/Information_Security_Basics
 ---
 情報セキュリティを基本的に理解しておくことは、ソフトウェアやサイトが危険で脆弱なままで、資産を奪ったりその他の悪意の理由のために弱点を悪用されるのを防ぐのに役立ちます。これらの記事は知るべきことを学ぶのに役立ちます。 この情報から、ウェブ開発を通じて、またそれ以外のコンテンツのデプロイにおいても、セキュリティの役割と重要性に気づくでしょう。

--- a/files/ja/orphaned/web/specification_list/index.md
+++ b/files/ja/orphaned/web/specification_list/index.md
@@ -1,7 +1,6 @@
 ---
 title: Specification List
 slug: orphaned/Web/Specification_list
-translation_of: Web/Specification_list
 original_slug: Web/Specification_list
 ---
 Open Web の基盤は幾つもの仕様書によって定義されています。このページではそれらの仕様書をリストしています。

--- a/files/ja/orphaned/web/web_components/status_in_firefox/index.md
+++ b/files/ja/orphaned/web/web_components/status_in_firefox/index.md
@@ -1,14 +1,6 @@
 ---
 title: Firefox での Web Components のサポート状況
 slug: orphaned/Web/Web_Components/Status_in_Firefox
-tags:
-  - API
-  - Experimental
-  - Firefox
-  - Guide
-  - Web Components
-  - status
-translation_of: Web/Web_Components/Status_in_Firefox
 original_slug: Web/Web_Components/Status_in_Firefox
 ---
 {{DefaultAPISidebar("Web Components")}}{{SeeCompatTable}}

--- a/files/ja/orphaned/working_with_windows_in_chrome_code/index.md
+++ b/files/ja/orphaned/working_with_windows_in_chrome_code/index.md
@@ -1,8 +1,6 @@
 ---
 title: window.arguments
 slug: orphaned/Working_with_windows_in_chrome_code
-translation_of: Working_with_windows_in_chrome_code#Passing_data_between_windows
-translation_of_original: Web/API/Window.arguments
 original_slug: Web/API/Window/arguments
 ---
 [『chrome コードでウィンドウを取り扱う』の頁の『ウィンドウ間でのデータのやり取り』の章](/ja/docs/Working_with_windows_in_chrome_code#Passing_data_between_windows)をご覧下さい。


### PR DESCRIPTION
Part of #7858

`files\ja\orphaned` から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "tags": 58,
  "translation_of": 34,
  "translation_of_original": 1
}
```

# 特記事項

* `translation_of_original` は `files/ja/orphaned/working_with_windows_in_chrome_code/index.md` にあります。こちらのメタについては、無関係な値が指定されているようです。今回は、単純に削除しました。