### PR TITLE
remove duplicated frontmatter keys from webassembly (ja)

### DIFF
--- a/files/ja/webassembly/c_to_wasm/index.md
+++ b/files/ja/webassembly/c_to_wasm/index.md
@@ -1,7 +1,6 @@
 ---
 title: C/C++からWebAssemblyにコンパイルする
 slug: WebAssembly/C_to_wasm
-translation_of: WebAssembly/C_to_wasm
 ---
 {{WebAssemblySidebar}}
 

--- a/files/ja/webassembly/caching_modules/index.md
+++ b/files/ja/webassembly/caching_modules/index.md
@@ -1,15 +1,6 @@
 ---
 title: コンパイルされた WebAssembly モジュールをキャッシュする
 slug: WebAssembly/Caching_modules
-tags:
-  - Caching
-  - IndexedDB
-  - JavaScript
-  - Module
-  - WebAssembly
-  - compile
-  - wasm
-translation_of: WebAssembly/Caching_modules
 ---
 {{WebAssemblySidebar}}
 

--- a/files/ja/webassembly/concepts/index.md
+++ b/files/ja/webassembly/concepts/index.md
@@ -1,15 +1,6 @@
 ---
 title: WebAssembly の概要
 slug: WebAssembly/Concepts
-tags:
-  - C
-  - C++
-  - Emscripten
-  - JavaScript
-  - Web プラットフォーム
-  - WebAssembly
-  - rust
-translation_of: WebAssembly/Concepts
 ---
 {{WebAssemblySidebar}}
 

--- a/files/ja/webassembly/existing_c_to_wasm/index.md
+++ b/files/ja/webassembly/existing_c_to_wasm/index.md
@@ -1,13 +1,6 @@
 ---
 title: Compiling an Existing C Module to WebAssembly
 slug: WebAssembly/existing_C_to_wasm
-tags:
-  - C++
-  - Emscripten
-  - WebAssembly
-  - wasm
-  - コンパイル
-translation_of: WebAssembly/existing_C_to_wasm
 ---
 {{WebAssemblySidebar}}
 

--- a/files/ja/webassembly/exported_functions/index.md
+++ b/files/ja/webassembly/exported_functions/index.md
@@ -1,15 +1,6 @@
 ---
 title: エクスポートされた WebAssembly 関数
 slug: WebAssembly/Exported_functions
-tags:
-  - Guide
-  - JavaScript
-  - WebAssembly
-  - export
-  - exported functions
-  - exported wasm functions
-  - wasm
-translation_of: WebAssembly/Exported_functions
 ---
 {{WebAssemblySidebar}}
 

--- a/files/ja/webassembly/index.md
+++ b/files/ja/webassembly/index.md
@@ -1,11 +1,6 @@
 ---
 title: WebAssembly
 slug: WebAssembly
-tags:
-  - Landing
-  - WebAssembly
-  - wasm
-translation_of: WebAssembly
 ---
 {{WebAssemblySidebar}}
 

--- a/files/ja/webassembly/loading_and_running/index.md
+++ b/files/ja/webassembly/loading_and_running/index.md
@@ -1,13 +1,6 @@
 ---
 title: WebAssemblyコードのロードと実行
 slug: WebAssembly/Loading_and_running
-tags:
-  - Fetch
-  - JavaScript
-  - WebAssembly
-  - XMLHttpRequest
-  - バイトコード
-translation_of: WebAssembly/Loading_and_running
 ---
 {{WebAssemblySidebar}}
 

--- a/files/ja/webassembly/rust_to_wasm/index.md
+++ b/files/ja/webassembly/rust_to_wasm/index.md
@@ -1,12 +1,6 @@
 ---
 title: Rust から WebAssembly にコンパイルする
 slug: WebAssembly/Rust_to_wasm
-tags:
-  - Compiling
-  - WebAssembly
-  - rust
-  - wasm
-translation_of: WebAssembly/Rust_to_wasm
 l10n:
   sourceCommit: 51f2cde58fff4a44242577b2540bdfdfc525dda4
 ---

--- a/files/ja/webassembly/text_format_to_wasm/index.md
+++ b/files/ja/webassembly/text_format_to_wasm/index.md
@@ -1,16 +1,6 @@
 ---
 title: WebAssembly テキストフォーマットから wasm に変換する
 slug: WebAssembly/Text_format_to_wasm
-tags:
-  - WebAssembly
-  - assembly
-  - conversion
-  - text format
-  - wabt
-  - wasm
-  - wast2wasm
-  - wat2wasm
-translation_of: WebAssembly/Text_format_to_wasm
 ---
 {{WebAssemblySidebar}}
 

--- a/files/ja/webassembly/understanding_the_text_format/index.md
+++ b/files/ja/webassembly/understanding_the_text_format/index.md
@@ -1,19 +1,6 @@
 ---
 title: WebAssembly テキスト形式の理解
 slug: WebAssembly/Understanding_the_text_format
-tags:
-  - 関数
-  - JavaScript
-  - S 式
-  - WebAssembly
-  - 呼び出し
-  - メモリー
-  - 共有アドレス
-  - テーブル
-  - テキスト形式
-  - was
-  - wasm
-translation_of: WebAssembly/Understanding_the_text_format
 ---
 {{WebAssemblySidebar}}
 

--- a/files/ja/webassembly/using_the_javascript_api/index.md
+++ b/files/ja/webassembly/using_the_javascript_api/index.md
@@ -1,16 +1,6 @@
 ---
 title: WebAssembly JavaScript API の使用
 slug: WebAssembly/Using_the_JavaScript_API
-tags:
-  - API
-  - 開発ツール
-  - JavaScript
-  - WebAssembly
-  - コンパイル
-  - インスタンス化
-  - メモリー
-  - テーブル
-translation_of: WebAssembly/Using_the_JavaScript_API
 ---
 {{WebAssemblySidebar}}
 


### PR DESCRIPTION
Part of #7858

`files\ja\webassembly` から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "translation_of": 11,
  "tags": 10
}
```
