### PR TITLE
remove duplicated frontmatter keys from web/api/{a-c} (ja)

### DIFF
--- a/files/ja/orphaned/web/api/canvas_api/tutorial/hit_regions_and_accessibility/index.md
+++ b/files/ja/orphaned/web/api/canvas_api/tutorial/hit_regions_and_accessibility/index.md
@@ -1,11 +1,6 @@
 ---
 title: ヒット領域とアクセシビリティ
 slug: orphaned/Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility
-tags:
-  - Canvas
-  - Graphics
-  - Tutorial
-translation_of: Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility
 original_slug: Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility
 ---
 <div>{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas", "Web/API/Canvas_API/Tutorial/Optimizing_canvas")}}</div>

--- a/files/ja/web/api/abortcontroller/index.md
+++ b/files/ja/web/api/abortcontroller/index.md
@@ -1,14 +1,6 @@
 ---
 title: AbortController
 slug: Web/API/AbortController
-tags:
-  - API
-  - AbortController
-  - 実験的
-  - インターフェース
-  - リファレンス
-translation_of: Web/API/AbortController
-browser-compat: api.AbortController
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/abortsignal/index.md
+++ b/files/ja/web/api/abortsignal/index.md
@@ -1,14 +1,6 @@
 ---
 title: AbortSignal
 slug: Web/API/AbortSignal
-tags:
-  - API
-  - AbortSignal
-  - DOM
-  - インターフェース
-  - リファレンス
-  - 実験的
-translation_of: Web/API/AbortSignal
 ---
 {{APIRef("DOM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/analysernode/index.md
+++ b/files/ja/web/api/analysernode/index.md
@@ -1,7 +1,6 @@
 ---
 title: AnalyserNode
 slug: Web/API/AnalyserNode
-translation_of: Web/API/AnalyserNode
 ---
 {{APIRef("Web Audio API")}}
 

--- a/files/ja/web/api/angle_instanced_arrays/index.md
+++ b/files/ja/web/api/angle_instanced_arrays/index.md
@@ -1,13 +1,6 @@
 ---
 title: ANGLE_instanced_arrays
 slug: Web/API/ANGLE_instanced_arrays
-tags:
-  - API
-  - リファレンス
-  - WebGL
-  - WebGL 拡張機能
-browser-compat: api.ANGLE_instanced_arrays
-translation_of: Web/API/ANGLE_instanced_arrays
 ---
 {{APIRef("WebGL")}}
 

--- a/files/ja/web/api/animation/animation/index.md
+++ b/files/ja/web/api/animation/animation/index.md
@@ -1,15 +1,6 @@
 ---
 title: Animation()
 slug: Web/API/Animation/Animation
-tags:
-  - API
-  - Animation
-  - アニメーション
-  - コンストラクター
-  - リファレンス
-  - ウェブアニメーション API
-browser-compat: api.Animation.Animation
-translation_of: Web/API/Animation/Animation
 ---
 {{ APIRef("Web Animations API") }}
 

--- a/files/ja/web/api/animation/cancel/index.md
+++ b/files/ja/web/api/animation/cancel/index.md
@@ -1,17 +1,6 @@
 ---
 title: Animation.cancel()
 slug: Web/API/Animation/cancel
-tags:
-  - API
-  - Animation
-  - メソッド
-  - リファレンス
-  - ウェブアニメーション
-  - cancel
-  - waapi
-  - ウェブアニメーション API
-browser-compat: api.Animation.cancel
-translation_of: Web/API/Animation/cancel
 ---
 {{ APIRef("Web Animations") }}
 

--- a/files/ja/web/api/animation/index.md
+++ b/files/ja/web/api/animation/index.md
@@ -1,16 +1,6 @@
 ---
 title: Animation
 slug: Web/API/Animation
-tags:
-  - API
-  - アニメーション
-  - インターフェイス
-  - リファレンス
-  - ウェブアニメーション
-  - waapi
-  - ウェブアニメーション API
-browser-compat: api.Animation
-translation_of: Web/API/Animation
 ---
 {{ APIRef("Web Animations") }}
 

--- a/files/ja/web/api/animationevent/elapsedtime/index.md
+++ b/files/ja/web/api/animationevent/elapsedtime/index.md
@@ -1,16 +1,6 @@
 ---
 title: AnimationEvent.elapsedTime
 slug: Web/API/AnimationEvent/elapsedTime
-tags:
-  - API
-  - AnimationEvent
-  - CSSOM
-  - Experimental
-  - Property
-  - Reference
-  - Web Animations
-  - プロパティ
-translation_of: Web/API/AnimationEvent/elapsedTime
 ---
 {{SeeCompatTable}}{{ apiref("Web Animations API") }}
 

--- a/files/ja/web/api/animationevent/index.md
+++ b/files/ja/web/api/animationevent/index.md
@@ -1,15 +1,6 @@
 ---
 title: AnimationEvent
 slug: Web/API/AnimationEvent
-tags:
-  - API
-  - CSS アニメーション
-  - Experimental
-  - Interface
-  - Reference
-  - Web Animations
-  - インターフェイス
-translation_of: Web/API/AnimationEvent
 ---
 {{SeeCompatTable}}{{APIRef("Web Animations API")}}
 

--- a/files/ja/web/api/atob/index.md
+++ b/files/ja/web/api/atob/index.md
@@ -1,14 +1,6 @@
 ---
 title: WindowOrWorkerGlobalScope.atob()
 slug: Web/API/atob
-tags:
-  - API
-  - HTML DOM
-  - Method
-  - Reference
-  - WindowOrWorkerGlobalScope
-  - atob
-translation_of: Web/API/WindowOrWorkerGlobalScope/atob
 original_slug: Web/API/WindowOrWorkerGlobalScope/atob
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/web/api/attr/index.md
+++ b/files/ja/web/api/attr/index.md
@@ -1,12 +1,6 @@
 ---
 title: Attr
 slug: Web/API/Attr
-page-type: web-api-interface
-tags:
-  - インターフェイス
-  - リファレンス
-browser-compat: api.Attr
-translation_of: Web/API/Attr
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/attr/localname/index.md
+++ b/files/ja/web/api/attr/localname/index.md
@@ -1,13 +1,6 @@
 ---
 title: Attr.localName
 slug: Web/API/Attr/localName
-page-type: web-api-instance-property
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.Attr.localName
-translation_of: Web/API/Attr/localName
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/attr/name/index.md
+++ b/files/ja/web/api/attr/name/index.md
@@ -1,13 +1,6 @@
 ---
 title: Attr.name
 slug: Web/API/Attr/name
-page-type: web-api-instance-property
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.Attr.name
-translation_of: Web/API/Attr/name
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/attr/namespaceuri/index.md
+++ b/files/ja/web/api/attr/namespaceuri/index.md
@@ -1,13 +1,6 @@
 ---
 title: Attr.namespaceURI
 slug: Web/API/Attr/namespaceURI
-page-type: web-api-instance-property
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.Attr.namespaceURI
-translation_of: Web/API/Attr/namespaceURI
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/attr/ownerelement/index.md
+++ b/files/ja/web/api/attr/ownerelement/index.md
@@ -1,13 +1,6 @@
 ---
 title: Attr.ownerElement
 slug: Web/API/Attr/ownerElement
-page-type: web-api-instance-property
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.Attr.ownerElement
-translation_of: Web/API/Attr/ownerElement
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/attr/prefix/index.md
+++ b/files/ja/web/api/attr/prefix/index.md
@@ -1,13 +1,6 @@
 ---
 title: Attr.prefix
 slug: Web/API/Attr/prefix
-page-type: web-api-instance-property
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.Attr.prefix
-translation_of: Web/API/Attr/prefix
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/attr/specified/index.md
+++ b/files/ja/web/api/attr/specified/index.md
@@ -1,14 +1,6 @@
 ---
 title: Attr.specified
 slug: Web/API/Attr/specified
-page-type: web-api-instance-property
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-  - 非推奨
-browser-compat: api.Attr.specified
-translation_of: Web/API/Attr/specified
 ---
 {{APIRef("DOM")}}{{Deprecated_header}}
 

--- a/files/ja/web/api/attr/value/index.md
+++ b/files/ja/web/api/attr/value/index.md
@@ -1,12 +1,6 @@
 ---
 title: Attr.value
 slug: Web/API/Attr/value
-page-type: web-api-instance-property
-tags:
-  - プロパティ
-  - リファレンス
-browser-compat: api.Attr.value
-translation_of: Web/API/Attr/value
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/audiobuffer/audiobuffer/index.md
+++ b/files/ja/web/api/audiobuffer/audiobuffer/index.md
@@ -1,19 +1,6 @@
 ---
 title: AudioBuffer()
 slug: Web/API/AudioBuffer/AudioBuffer
-tags:
-  - API
-  - 音声
-  - AudioBuffer
-  - バッファー
-  - コンストラクター
-  - メディア
-  - リファレンス
-  - ウェブ音声
-  - ウェブ音声 API
-  - sound
-browser-compat: api.AudioBuffer.AudioBuffer
-translation_of: Web/API/AudioBuffer/AudioBuffer
 ---
 {{APIRef("Web Audio API")}}
 

--- a/files/ja/web/api/audiobuffer/copyfromchannel/index.md
+++ b/files/ja/web/api/audiobuffer/copyfromchannel/index.md
@@ -1,22 +1,6 @@
 ---
 title: AudioBuffer.copyFromChannel()
 slug: Web/API/AudioBuffer/copyFromChannel
-tags:
-  - API
-  - 音声
-  - AudioBuffer
-  - コピー
-  - フレーム
-  - メソッド
-  - リファレンス
-  - Samples
-  - ウェブ音声
-  - ウェブ音声 API
-  - copy
-  - copyFromChannel
-  - 音
-browser-compat: api.AudioBuffer.copyFromChannel
-translation_of: Web/API/AudioBuffer/copyFromChannel
 ---
 {{APIRef("Web Audio API")}}
 

--- a/files/ja/web/api/audiobuffer/copytochannel/index.md
+++ b/files/ja/web/api/audiobuffer/copytochannel/index.md
@@ -1,16 +1,6 @@
 ---
 title: AudioBuffer.copyToChannel()
 slug: Web/API/AudioBuffer/copyToChannel
-tags:
-  - API
-  - 音声
-  - AudioBuffer
-  - メソッド
-  - リファレンス
-  - ウェブ音声 API
-  - copyToChannel
-browser-compat: api.AudioBuffer.copyToChannel
-translation_of: Web/API/AudioBuffer/copyToChannel
 ---
 {{ APIRef("Web Audio API") }}
 

--- a/files/ja/web/api/audiobuffer/duration/index.md
+++ b/files/ja/web/api/audiobuffer/duration/index.md
@@ -1,15 +1,6 @@
 ---
 title: AudioBuffer.duration
 slug: Web/API/AudioBuffer/duration
-tags:
-  - API
-  - AudioBuffer
-  - プロパティ
-  - リファレンス
-  - ウェブ音声 API
-  - duration
-browser-compat: api.AudioBuffer.duration
-translation_of: Web/API/AudioBuffer/duration
 ---
 {{ APIRef("Web Audio API") }}
 

--- a/files/ja/web/api/audiobuffer/getchanneldata/index.md
+++ b/files/ja/web/api/audiobuffer/getchanneldata/index.md
@@ -1,14 +1,6 @@
 ---
 title: AudioBuffer.getChannelData()
 slug: Web/API/AudioBuffer/getChannelData
-tags:
-  - API
-  - AudioBuffer
-  - メソッド
-  - リファレンス
-  - ウェブ音声 API
-browser-compat: api.AudioBuffer.getChannelData
-translation_of: Web/API/AudioBuffer/getChannelData
 ---
 {{ APIRef("Web Audio API") }}
 

--- a/files/ja/web/api/audiobuffer/index.md
+++ b/files/ja/web/api/audiobuffer/index.md
@@ -1,14 +1,6 @@
 ---
 title: AudioBuffer
 slug: Web/API/AudioBuffer
-tags:
-  - API
-  - AudioBuffer
-  - インターフェイス
-  - リファレンス
-  - ウェブ音声 API
-browser-compat: api.AudioBuffer
-translation_of: Web/API/AudioBuffer
 ---
 {{APIRef("Web Audio API")}}
 

--- a/files/ja/web/api/audiobuffer/length/index.md
+++ b/files/ja/web/api/audiobuffer/length/index.md
@@ -1,15 +1,6 @@
 ---
 title: AudioBuffer.length
 slug: Web/API/AudioBuffer/length
-tags:
-  - API
-  - AudioBuffer
-  - プロパティ
-  - リファレンス
-  - ウェブ音声 API
-  - length
-browser-compat: api.AudioBuffer.length
-translation_of: Web/API/AudioBuffer/length
 ---
 {{ APIRef("Web Audio API") }}
 

--- a/files/ja/web/api/audiobuffer/numberofchannels/index.md
+++ b/files/ja/web/api/audiobuffer/numberofchannels/index.md
@@ -1,15 +1,6 @@
 ---
 title: AudioBuffer.numberOfChannels
 slug: Web/API/AudioBuffer/numberOfChannels
-tags:
-  - API
-  - AudioBuffer
-  - プロパティ
-  - リファレンス
-  - ウェブ音声 API
-  - numberOfChannels
-browser-compat: api.AudioBuffer.numberOfChannels
-translation_of: Web/API/AudioBuffer/numberOfChannels
 ---
 {{ APIRef("Web Audio API") }}
 

--- a/files/ja/web/api/audiobuffer/samplerate/index.md
+++ b/files/ja/web/api/audiobuffer/samplerate/index.md
@@ -1,15 +1,6 @@
 ---
 title: AudioBuffer.sampleRate
 slug: Web/API/AudioBuffer/sampleRate
-tags:
-  - API
-  - AudioBuffer
-  - プロパティ
-  - リファレンス
-  - ウェブ音声 API
-  - sampleRate
-browser-compat: api.AudioBuffer.sampleRate
-translation_of: Web/API/AudioBuffer/sampleRate
 ---
 {{ APIRef("Web Audio API") }}
 

--- a/files/ja/web/api/audiobuffersourcenode/index.md
+++ b/files/ja/web/api/audiobuffersourcenode/index.md
@@ -1,7 +1,6 @@
 ---
 title: AudioBufferSourceNode
 slug: Web/API/AudioBufferSourceNode
-translation_of: Web/API/AudioBufferSourceNode
 ---
 {{APIRef("Web Audio API")}}
 

--- a/files/ja/web/api/audiobuffersourcenode/loop/index.md
+++ b/files/ja/web/api/audiobuffersourcenode/loop/index.md
@@ -1,21 +1,6 @@
 ---
 title: AudioBufferSourceNode.loop
 slug: Web/API/AudioBufferSourceNode/loop
-tags:
-  - API
-  - Audio
-  - AudioBufferSourceNode
-  - Loop
-  - Media
-  - Property
-  - Reference
-  - Web Audio API
-  - sound
-  - プロパティ
-  - メディア
-  - 繰り返し
-  - 音声
-translation_of: Web/API/AudioBufferSourceNode/loop
 ---
 {{ APIRef("Web Audio API") }}
 

--- a/files/ja/web/api/audiobuffersourcenode/start/index.md
+++ b/files/ja/web/api/audiobuffersourcenode/start/index.md
@@ -1,7 +1,6 @@
 ---
 title: AudioBufferSourceNode.start()
 slug: Web/API/AudioBufferSourceNode/start
-translation_of: Web/API/AudioBufferSourceNode/start
 ---
 {{ APIRef("Web Audio API") }}
 

--- a/files/ja/web/api/audiocontext/audiocontext/index.md
+++ b/files/ja/web/api/audiocontext/audiocontext/index.md
@@ -1,7 +1,6 @@
 ---
 title: AudioContext()
 slug: Web/API/AudioContext/AudioContext
-translation_of: Web/API/AudioContext/AudioContext
 ---
 {{APIRef("Web Audio API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/audiocontext/close/index.md
+++ b/files/ja/web/api/audiocontext/close/index.md
@@ -1,7 +1,6 @@
 ---
 title: AudioContext.close()
 slug: Web/API/AudioContext/close
-translation_of: Web/API/AudioContext/close
 ---
 {{ APIRef("Web Audio API") }}
 

--- a/files/ja/web/api/audiocontext/createmediaelementsource/index.md
+++ b/files/ja/web/api/audiocontext/createmediaelementsource/index.md
@@ -1,7 +1,6 @@
 ---
 title: AudioContext.createMediaElementSource()
 slug: Web/API/AudioContext/createMediaElementSource
-translation_of: Web/API/AudioContext/createMediaElementSource
 ---
 {{ APIRef("Web Audio API") }}
 

--- a/files/ja/web/api/audiocontext/createmediastreamdestination/index.md
+++ b/files/ja/web/api/audiocontext/createmediastreamdestination/index.md
@@ -1,15 +1,6 @@
 ---
 title: AudioContext.createMediaStreamDestination()
 slug: Web/API/AudioContext/createMediaStreamDestination
-tags:
-  - API
-  - AudioContext
-  - Method
-  - Reference
-  - Référence(2)
-  - Web Audio API
-  - createMediaStreamDestination
-translation_of: Web/API/AudioContext/createMediaStreamDestination
 ---
 {{ APIRef("Web Audio API") }}
 

--- a/files/ja/web/api/audiocontext/createmediastreamsource/index.md
+++ b/files/ja/web/api/audiocontext/createmediastreamsource/index.md
@@ -1,7 +1,6 @@
 ---
 title: AudioContext.createMediaStreamSource()
 slug: Web/API/AudioContext/createMediaStreamSource
-translation_of: Web/API/AudioContext/createMediaStreamSource
 ---
 {{ APIRef("Web Audio API") }}
 

--- a/files/ja/web/api/audiocontext/index.md
+++ b/files/ja/web/api/audiocontext/index.md
@@ -1,9 +1,6 @@
 ---
 title: AudioContext
 slug: Web/API/AudioContext
-tags:
-  - API
-translation_of: Web/API/AudioContext
 ---
 {{APIRef("Web Audio API")}}
 

--- a/files/ja/web/api/audiocontext/resume/index.md
+++ b/files/ja/web/api/audiocontext/resume/index.md
@@ -1,7 +1,6 @@
 ---
 title: AudioContext.resume()
 slug: Web/API/AudioContext/resume
-translation_of: Web/API/AudioContext/resume
 ---
 {{ APIRef("Web Audio API") }}
 

--- a/files/ja/web/api/audiocontext/suspend/index.md
+++ b/files/ja/web/api/audiocontext/suspend/index.md
@@ -1,7 +1,6 @@
 ---
 title: AudioContext.suspend()
 slug: Web/API/AudioContext/suspend
-translation_of: Web/API/AudioContext/suspend
 ---
 {{ APIRef("Web Audio API") }}
 

--- a/files/ja/web/api/audiodestinationnode/index.md
+++ b/files/ja/web/api/audiodestinationnode/index.md
@@ -1,7 +1,6 @@
 ---
 title: AudioDestinationNode
 slug: Web/API/AudioDestinationNode
-translation_of: Web/API/AudioDestinationNode
 ---
 {{APIRef("Web Audio API")}}
 

--- a/files/ja/web/api/audiodestinationnode/maxchannelcount/index.md
+++ b/files/ja/web/api/audiodestinationnode/maxchannelcount/index.md
@@ -1,7 +1,6 @@
 ---
 title: AudioDestinationNode.maxChannelCount
 slug: Web/API/AudioDestinationNode/maxChannelCount
-translation_of: Web/API/AudioDestinationNode/maxChannelCount
 ---
 {{ APIRef("Web Audio API") }}
 

--- a/files/ja/web/api/audiolistener/index.md
+++ b/files/ja/web/api/audiolistener/index.md
@@ -1,15 +1,6 @@
 ---
 title: AudioListener
 slug: Web/API/AudioListener
-page-type: web-api-interface
-tags:
-  - API
-  - AudioListener
-  - インターフェイス
-  - リファレンス
-  - ウェブ音声 API
-browser-compat: api.AudioListener
-translation_of: Web/API/AudioListener
 ---
 {{ APIRef("Web Audio API") }}
 

--- a/files/ja/web/api/audionode/index.md
+++ b/files/ja/web/api/audionode/index.md
@@ -1,7 +1,6 @@
 ---
 title: AudioNode
 slug: Web/API/AudioNode
-translation_of: Web/API/AudioNode
 ---
 {{APIRef()}}
 

--- a/files/ja/web/api/audioparam/index.md
+++ b/files/ja/web/api/audioparam/index.md
@@ -1,7 +1,6 @@
 ---
 title: AudioParam
 slug: Web/API/AudioParam
-translation_of: Web/API/AudioParam
 ---
 {{APIRef("Web Audio API")}}
 

--- a/files/ja/web/api/audioprocessingevent/index.md
+++ b/files/ja/web/api/audioprocessingevent/index.md
@@ -1,16 +1,6 @@
 ---
 title: AudioProcessingEvent
 slug: Web/API/AudioProcessingEvent
-page-type: web-api-interface
-tags:
-  - API
-  - Deprecated
-  - Interface
-  - Internationalization
-  - Reference
-  - Web Audio API
-browser-compat: api.AudioProcessingEvent
-translation_of: Web/API/AudioProcessingEvent
 ---
 {{APIRef("Web Audio API")}}
 

--- a/files/ja/web/api/audioscheduledsourcenode/ended_event/index.md
+++ b/files/ja/web/api/audioscheduledsourcenode/ended_event/index.md
@@ -1,8 +1,6 @@
 ---
 title: AudioBufferSourceNode.onended
 slug: Web/API/AudioScheduledSourceNode/ended_event
-translation_of: Web/API/AudioScheduledSourceNode/onended
-translation_of_original: Web/API/AudioBufferSourceNode/onended
 original_slug: Web/API/AudioScheduledSourceNode/onended
 ---
 {{ APIRef("AudioBufferSourceNode") }}

--- a/files/ja/web/api/audioscheduledsourcenode/index.md
+++ b/files/ja/web/api/audioscheduledsourcenode/index.md
@@ -1,17 +1,6 @@
 ---
 title: AudioScheduledSourceNode
 slug: Web/API/AudioScheduledSourceNode
-tags:
-  - API
-  - Audio
-  - AudioScheduledSourceNode
-  - Interface
-  - Media
-  - Reference
-  - Web Audio API
-  - sound
-  - インターフェイス
-translation_of: Web/API/AudioScheduledSourceNode
 ---
 {{APIRef("Web Audio API")}}AudioScheduledSourceNode インターフェース (Web Audio API の一部分) は、オーディオソースノード各種の親インターフェースであり、必要に応じ、指定された時間で開始や停止を行う機能を持ちます。具体的には、このインタフェースでは、{{domxref("AudioScheduledSourceNode.start", "start()")}} や、{{domxref("AudioScheduledSourceNode.stop", "stop()")}} メソッドの他、{{domxref("AudioScheduledSourceNode.onended", "onended")}} イベントハンドラーを定義しています。
 

--- a/files/ja/web/api/audioscheduledsourcenode/stop/index.md
+++ b/files/ja/web/api/audioscheduledsourcenode/stop/index.md
@@ -1,8 +1,6 @@
 ---
 title: AudioBufferSourceNode.stop()
 slug: Web/API/AudioScheduledSourceNode/stop
-translation_of: Web/API/AudioScheduledSourceNode/stop
-translation_of_original: Web/API/AudioBufferSourceNode/stop
 original_slug: Web/API/AudioBufferSourceNode/stop
 ---
 {{ APIRef("Web Audio API") }}

--- a/files/ja/web/api/audiotrack/enabled/index.md
+++ b/files/ja/web/api/audiotrack/enabled/index.md
@@ -1,22 +1,6 @@
 ---
 title: AudioTrack.enabled
 slug: Web/API/AudioTrack/enabled
-page-type: web-api-instance-property
-tags:
-  - Audio
-  - AudioTrack
-  - HTML DOM
-  - Media
-  - Media Controls
-  - Media Track
-  - Property
-  - Reference
-  - Video
-  - enabled
-  - mute
-  - track
-browser-compat: api.AudioTrack.enabled
-translation_of: Web/API/AudioTrack/enabled
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/audiotrack/id/index.md
+++ b/files/ja/web/api/audiotrack/id/index.md
@@ -1,22 +1,6 @@
 ---
 title: AudioTrack.id
 slug: Web/API/AudioTrack/id
-page-type: web-api-instance-property
-tags:
-  - API
-  - Audio
-  - Audio Track
-  - AudioTrack
-  - HTML DOM
-  - Interface
-  - Media
-  - Property
-  - Read-only
-  - Reference
-  - id
-  - track
-browser-compat: api.AudioTrack.id
-translation_of: Web/API/AudioTrack/id
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/audiotrack/index.md
+++ b/files/ja/web/api/audiotrack/index.md
@@ -1,18 +1,6 @@
 ---
 title: AudioTrack
 slug: Web/API/AudioTrack
-page-type: web-api-interface
-tags:
-  - Audio
-  - AudioTrack
-  - HTML
-  - HTML DOM
-  - Interface
-  - Media
-  - Reference
-  - track
-browser-compat: api.AudioTrack
-translation_of: Web/API/AudioTrack
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/audiotrack/kind/index.md
+++ b/files/ja/web/api/audiotrack/kind/index.md
@@ -1,21 +1,6 @@
 ---
 title: AudioTrack.kind
 slug: Web/API/AudioTrack/kind
-page-type: web-api-instance-property
-tags:
-  - API
-  - Audio
-  - Audio Track
-  - AudioTrack
-  - HTML DOM
-  - Media
-  - Property
-  - Read-only
-  - Reference
-  - id
-  - track
-browser-compat: api.AudioTrack.kind
-translation_of: Web/API/AudioTrack/kind
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/audiotrack/label/index.md
+++ b/files/ja/web/api/audiotrack/label/index.md
@@ -1,22 +1,6 @@
 ---
 title: AudioTrack.label
 slug: Web/API/AudioTrack/label
-page-type: web-api-instance-property
-tags:
-  - API
-  - Audio
-  - Audio Track
-  - AudioTrack
-  - HTML DOM
-  - Media
-  - Property
-  - Read-only
-  - Reference
-  - label
-  - metadata
-  - track
-browser-compat: api.AudioTrack.label
-translation_of: Web/API/AudioTrack/label
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/audiotrack/language/index.md
+++ b/files/ja/web/api/audiotrack/language/index.md
@@ -1,23 +1,6 @@
 ---
 title: AudioTrack.language
 slug: Web/API/AudioTrack/language
-page-type: web-api-instance-property
-tags:
-  - API
-  - Audio
-  - AudioTrack
-  - HTML DOM
-  - Language
-  - Localization
-  - Media
-  - Property
-  - Read-only
-  - Reference
-  - Translated
-  - Translation
-  - track
-browser-compat: api.AudioTrack.language
-translation_of: Web/API/AudioTrack/language
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/audiotrack/sourcebuffer/index.md
+++ b/files/ja/web/api/audiotrack/sourcebuffer/index.md
@@ -1,22 +1,6 @@
 ---
 title: AudioTrack.sourceBuffer
 slug: Web/API/AudioTrack/sourceBuffer
-page-type: web-api-instance-property
-tags:
-  - API
-  - Audio
-  - AudioTrack
-  - HTML DOM
-  - MSE
-  - Media
-  - Media Source Extensions
-  - Property
-  - Read-only
-  - Reference
-  - SourceBuffer
-  - track
-browser-compat: api.AudioTrack.sourceBuffer
-translation_of: Web/API/AudioTrack/sourceBuffer
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/audiotracklist/addtrack_event/index.md
+++ b/files/ja/web/api/audiotracklist/addtrack_event/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'AudioTrackList: addtrack イベント'
 slug: Web/API/AudioTrackList/addtrack_event
-tags:
-  - Audio​Track​List
-  - Event
-  - addTrack
-  - events
-translation_of: Web/API/AudioTrackList/addtrack_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/audiotracklist/change_event/index.md
+++ b/files/ja/web/api/audiotracklist/change_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'AudioTrackList: change イベント'
 slug: Web/API/AudioTrackList/change_event
-tags:
-  - API
-  - AudioTrackList
-  - Change
-  - Event
-  - HTML API
-translation_of: Web/API/AudioTrackList/change_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/audiotracklist/gettrackbyid/index.md
+++ b/files/ja/web/api/audiotracklist/gettrackbyid/index.md
@@ -1,21 +1,6 @@
 ---
 title: AudioTrackList.getTrackById()
 slug: Web/API/AudioTrackList/getTrackById
-tags:
-  - API
-  - Audio
-  - AudioTrackList
-  - HTML DOM
-  - Media
-  - Method
-  - Reference
-  - Track ID
-  - Track List
-  - Tracks
-  - getTrackById
-  - id
-  - track
-translation_of: Web/API/AudioTrackList/getTrackById
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/audiotracklist/index.md
+++ b/files/ja/web/api/audiotracklist/index.md
@@ -1,19 +1,6 @@
 ---
 title: AudioTrackList
 slug: Web/API/AudioTrackList
-tags:
-  - API
-  - Audio
-  - AudioTrackList
-  - HTML DOM
-  - Interface
-  - Media
-  - Reference
-  - Track List
-  - Tracks
-  - list
-  - インターフェイス
-translation_of: Web/API/AudioTrackList
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/audiotracklist/length/index.md
+++ b/files/ja/web/api/audiotracklist/length/index.md
@@ -1,19 +1,6 @@
 ---
 title: AudioTrackList.length
 slug: Web/API/AudioTrackList/length
-tags:
-  - API
-  - Audio
-  - AudioTrackList
-  - HTML DOM
-  - Media
-  - Property
-  - Read-only
-  - Reference
-  - length
-  - list
-  - track
-translation_of: Web/API/AudioTrackList/length
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/audiotracklist/removetrack_event/index.md
+++ b/files/ja/web/api/audiotracklist/removetrack_event/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'AudioTrackList: removetrack イベント'
 slug: Web/API/AudioTrackList/removetrack_event
-tags:
-  - AudioTrackList
-  - Event
-  - events
-  - removeTrack
-translation_of: Web/API/AudioTrackList/removetrack_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/authenticatorassertionresponse/index.md
+++ b/files/ja/web/api/authenticatorassertionresponse/index.md
@@ -1,16 +1,6 @@
 ---
 title: AuthenticatorAssertionResponse
 slug: Web/API/AuthenticatorAssertionResponse
-tags:
-  - API
-  - Authentication
-  - AuthenticatorAssertionResponse
-  - Interface
-  - Reference
-  - Web Authentication API
-  - WebAuthn
-  - インターフェイス
-translation_of: Web/API/AuthenticatorAssertionResponse
 ---
 {{APIRef("Web Authentication API")}}{{securecontext_header}}
 

--- a/files/ja/web/api/authenticatorattestationresponse/index.md
+++ b/files/ja/web/api/authenticatorattestationresponse/index.md
@@ -1,16 +1,6 @@
 ---
 title: AuthenticatorAttestationResponse
 slug: Web/API/AuthenticatorAttestationResponse
-tags:
-  - API
-  - Authentication
-  - AuthenticatorAttestationResponse
-  - Interface
-  - Reference
-  - Web Authentication API
-  - WebAuthn
-  - インターフェイス
-translation_of: Web/API/AuthenticatorAttestationResponse
 ---
 {{APIRef("Web Authentication API")}}{{securecontext_header}}
 

--- a/files/ja/web/api/authenticatorresponse/index.md
+++ b/files/ja/web/api/authenticatorresponse/index.md
@@ -1,16 +1,6 @@
 ---
 title: AuthenticatorResponse
 slug: Web/API/AuthenticatorResponse
-tags:
-  - API
-  - Authentication
-  - AuthenticatorResponse
-  - Interface
-  - Reference
-  - Web Authentication API
-  - WebAuthn
-  - インターフェイス
-translation_of: Web/API/AuthenticatorResponse
 ---
 {{APIRef("Web Authentication API")}}{{securecontext_header}}
 

--- a/files/ja/web/api/barcode_detection_api/index.md
+++ b/files/ja/web/api/barcode_detection_api/index.md
@@ -1,15 +1,6 @@
 ---
 title: バーコード検出 API
 slug: Web/API/Barcode_Detection_API
-tags:
-  - API
-  - ランディング
-  - 概要
-  - バーコード
-  - バーコード検出
-  - 形状認識
-  - 実験的
-translation_of: Web/API/Barcode_Detection_API
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Barcode Detection API")}} {{AvailableInWorkers}} {{SeeCompatTable}}
 

--- a/files/ja/web/api/barcodedetector/barcodedetector/index.md
+++ b/files/ja/web/api/barcodedetector/barcodedetector/index.md
@@ -1,16 +1,6 @@
 ---
 title: BarcodeDetector()
 slug: Web/API/BarcodeDetector/BarcodeDetector
-tags:
-  - バーコード検出 API
-  - BarcodeDetector
-  - コンストラクター
-  - barcode
-  - バーコード検出
-  - 形状認識
-  - 実験的
-browser-compat: api.BarcodeDetector.BarcodeDetector
-translation_of: Web/API/BarcodeDetector/BarcodeDetector
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Barcode Detector API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/barcodedetector/detect/index.md
+++ b/files/ja/web/api/barcodedetector/detect/index.md
@@ -1,15 +1,6 @@
 ---
 title: BarcodeDetector.detect()
 slug: Web/API/BarcodeDetector/detect
-tags:
-  - バーコード検出 API
-  - BarcodeDetector
-  - メソッド
-  - バーコード
-  - 形状認識
-  - 実験的
-browser-compat: api.BarcodeDetector.detect
-translation_of: Web/API/BarcodeDetector/detect
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Barcode Detector API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/barcodedetector/getsupportedformats/index.md
+++ b/files/ja/web/api/barcodedetector/getsupportedformats/index.md
@@ -1,15 +1,6 @@
 ---
 title: BarcodeDetector.getSupportedFormats()
 slug: Web/API/BarcodeDetector/getSupportedFormats
-tags:
-  - バーコード検出 API
-  - BarcodeDetector
-  - メソッド
-  - バーコード
-  - 形状認識
-  - 実験的
-browser-compat: api.BarcodeDetector.getSupportedFormats
-translation_of: Web/API/BarcodeDetector/getSupportedFormats
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Barcode Detector API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/barcodedetector/index.md
+++ b/files/ja/web/api/barcodedetector/index.md
@@ -1,15 +1,6 @@
 ---
 title: BarcodeDetector
 slug: Web/API/BarcodeDetector
-tags:
-  - バーコード検出 API
-  - BarcodeDetector
-  - インターフェイス
-  - バーコード
-  - バーコード検出器
-  - 実験的
-browser-compat: api.BarcodeDetector
-translation_of: Web/API/BarcodeDetector
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Barcode Detector API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/baseaudiocontext/audioworklet/index.md
+++ b/files/ja/web/api/baseaudiocontext/audioworklet/index.md
@@ -1,18 +1,6 @@
 ---
 title: BaseAudioContext.audioWorklet
 slug: Web/API/BaseAudioContext/audioWorklet
-tags:
-  - API
-  - 音声
-  - AudioContext
-  - AudioWorklet
-  - BaseAudioContext
-  - プロパティ
-  - リファレンス
-  - ウェブ音声 API
-  - Worklet
-browser-compat: api.BaseAudioContext.audioWorklet
-translation_of: Web/API/BaseAudioContext/audioWorklet
 ---
 {{ APIRef("Web Audio API") }}{{securecontext_header}}
 

--- a/files/ja/web/api/baseaudiocontext/createanalyser/index.md
+++ b/files/ja/web/api/baseaudiocontext/createanalyser/index.md
@@ -1,16 +1,6 @@
 ---
 title: BaseAudioContext.createAnalyser()
 slug: Web/API/BaseAudioContext/createAnalyser
-tags:
-  - API
-  - AudioContext
-  - BaseAudioContext
-  - メソッド
-  - リファレンス
-  - ウェブ音声 API
-  - createAnalyser
-browser-compat: api.BaseAudioContext.createAnalyser
-translation_of: Web/API/BaseAudioContext/createAnalyser
 original_slug: Web/API/AudioContext/createAnalyser
 ---
 {{APIRef("Web Audio API")}}

--- a/files/ja/web/api/baseaudiocontext/createbiquadfilter/index.md
+++ b/files/ja/web/api/baseaudiocontext/createbiquadfilter/index.md
@@ -1,16 +1,6 @@
 ---
 title: BaseAudioContext.createBiquadFilter()
 slug: Web/API/BaseAudioContext/createBiquadFilter
-tags:
-  - API
-  - AudioContext
-  - BaseAudioContext
-  - メソッド
-  - リファレンス
-  - ウェブ音声 API
-  - createBiquadFilter
-browser-compat: api.BaseAudioContext.createBiquadFilter
-translation_of: Web/API/BaseAudioContext/createBiquadFilter
 original_slug: Web/API/AudioContext/createBiquadFilter
 ---
 {{ APIRef("Web Audio API") }}

--- a/files/ja/web/api/baseaudiocontext/createbuffer/index.md
+++ b/files/ja/web/api/baseaudiocontext/createbuffer/index.md
@@ -1,20 +1,6 @@
 ---
 title: BaseAudioContext.createBuffer()
 slug: Web/API/BaseAudioContext/createBuffer
-tags:
-  - API
-  - Audio
-  - AudioContext
-  - BaseAudioContext
-  - バッファー
-  - メディア
-  - メソッド
-  - リファレンス
-  - ウェブ音声
-  - ウェブ音声 API
-  - createBuffer
-browser-compat: api.BaseAudioContext.createBuffer
-translation_of: Web/API/BaseAudioContext/createBuffer
 original_slug: Web/API/AudioContext/createBuffer
 ---
 {{ APIRef("Web Audio API") }}

--- a/files/ja/web/api/baseaudiocontext/createbuffersource/index.md
+++ b/files/ja/web/api/baseaudiocontext/createbuffersource/index.md
@@ -1,16 +1,6 @@
 ---
 title: BaseAudioContext.createBufferSource()
 slug: Web/API/BaseAudioContext/createBufferSource
-tags:
-  - API
-  - AudioContext
-  - BaseAudioContext
-  - メソッド
-  - リファレンス
-  - ウェブ音声 API
-  - createBufferSource
-browser-compat: api.BaseAudioContext.createBufferSource
-translation_of: Web/API/BaseAudioContext/createBufferSource
 original_slug: Web/API/AudioContext/createBufferSource
 ---
 {{ APIRef("Web Audio API") }}

--- a/files/ja/web/api/baseaudiocontext/createchannelmerger/index.md
+++ b/files/ja/web/api/baseaudiocontext/createchannelmerger/index.md
@@ -1,17 +1,6 @@
 ---
 title: BaseAudioContext.createChannelMerger()
 slug: Web/API/BaseAudioContext/createChannelMerger
-tags:
-  - API
-  - Audio
-  - AudioContext
-  - BaseAudioContext
-  - メソッド
-  - リファレンス
-  - ウェブ音声 API
-  - createChannelMerger
-browser-compat: api.BaseAudioContext.createChannelMerger
-translation_of: Web/API/BaseAudioContext/createChannelMerger
 original_slug: Web/API/AudioContext/createChannelMerger
 ---
 {{ APIRef("Web Audio API") }}

--- a/files/ja/web/api/baseaudiocontext/createchannelsplitter/index.md
+++ b/files/ja/web/api/baseaudiocontext/createchannelsplitter/index.md
@@ -1,16 +1,6 @@
 ---
 title: BaseAudioContext.createChannelSplitter()
 slug: Web/API/BaseAudioContext/createChannelSplitter
-tags:
-  - API
-  - AudioContext
-  - BaseAudioContext
-  - メソッド
-  - リファレンス
-  - ウェブ音声 API
-  - createChannelSplitter
-browser-compat: api.BaseAudioContext.createChannelSplitter
-translation_of: Web/API/BaseAudioContext/createChannelSplitter
 original_slug: Web/API/AudioContext/createChannelSplitter
 ---
 {{ APIRef("Web Audio API") }}

--- a/files/ja/web/api/baseaudiocontext/createconstantsource/index.md
+++ b/files/ja/web/api/baseaudiocontext/createconstantsource/index.md
@@ -1,17 +1,6 @@
 ---
 title: BaseAudioContext.createConstantSource()
 slug: Web/API/BaseAudioContext/createConstantSource
-tags:
-  - API
-  - 音声
-  - AudioContext
-  - BaseAudioContext
-  - ConstantSourceNode
-  - メディア
-  - メソッド
-  - createConstantSource
-browser-compat: api.BaseAudioContext.createConstantSource
-translation_of: Web/API/BaseAudioContext/createConstantSource
 ---
 {{APIRef("Web Audio API")}}
 

--- a/files/ja/web/api/baseaudiocontext/createconvolver/index.md
+++ b/files/ja/web/api/baseaudiocontext/createconvolver/index.md
@@ -1,16 +1,6 @@
 ---
 title: BaseAudioContext.createConvolver()
 slug: Web/API/BaseAudioContext/createConvolver
-tags:
-  - API
-  - AudioContext
-  - BaseAudioContext
-  - メソッド
-  - リファレンス
-  - ウェブ音声 API
-  - createConvolver
-browser-compat: api.BaseAudioContext.createConvolver
-translation_of: Web/API/BaseAudioContext/createConvolver
 original_slug: Web/API/AudioContext/createConvolver
 ---
 {{ APIRef("Web Audio API") }}

--- a/files/ja/web/api/baseaudiocontext/createdelay/index.md
+++ b/files/ja/web/api/baseaudiocontext/createdelay/index.md
@@ -1,16 +1,6 @@
 ---
 title: BaseAudioContext.createDelay()
 slug: Web/API/BaseAudioContext/createDelay
-tags:
-  - API
-  - AudioContext
-  - BaseAudioContext
-  - メソッド
-  - リファレンス
-  - ウェブ音声 API
-  - createDelay
-browser-compat: api.BaseAudioContext.createDelay
-translation_of: Web/API/BaseAudioContext/createDelay
 original_slug: Web/API/AudioContext/createDelay
 ---
 {{ APIRef("Web Audio API") }}

--- a/files/ja/web/api/baseaudiocontext/createdynamicscompressor/index.md
+++ b/files/ja/web/api/baseaudiocontext/createdynamicscompressor/index.md
@@ -1,16 +1,6 @@
 ---
 title: BaseAudioContext.createDynamicsCompressor()
 slug: Web/API/BaseAudioContext/createDynamicsCompressor
-tags:
-  - API
-  - AudioContext
-  - BaseAudioContext
-  - メソッド
-  - リファレンス
-  - ウェブ音声 API
-  - createDynamicsCompressor
-browser-compat: api.BaseAudioContext.createDynamicsCompressor
-translation_of: Web/API/BaseAudioContext/createDynamicsCompressor
 original_slug: Web/API/AudioContext/createDynamicsCompressor
 ---
 {{ APIRef("Web Audio API") }}

--- a/files/ja/web/api/baseaudiocontext/creategain/index.md
+++ b/files/ja/web/api/baseaudiocontext/creategain/index.md
@@ -1,19 +1,6 @@
 ---
 title: BaseAudioContext.createGain()
 slug: Web/API/BaseAudioContext/createGain
-tags:
-  - API
-  - Audio
-  - AudioContext
-  - BaseAudioContext
-  - メソッド
-  - リファレンス
-  - ボリューム制御
-  - ウェブ音声 API
-  - createGain
-  - sound
-browser-compat: api.BaseAudioContext.createGain
-translation_of: Web/API/BaseAudioContext/createGain
 original_slug: Web/API/AudioContext/createGain
 ---
 {{ APIRef("Web Audio API") }}

--- a/files/ja/web/api/baseaudiocontext/createiirfilter/index.md
+++ b/files/ja/web/api/baseaudiocontext/createiirfilter/index.md
@@ -1,17 +1,6 @@
 ---
 title: BaseAudioContext.createIIRFilter()
 slug: Web/API/BaseAudioContext/createIIRFilter
-tags:
-  - API
-  - 音声
-  - AudioContext
-  - BaseAudioContext
-  - CreateIIRFilter
-  - メソッド
-  - リファレンス
-  - ウェブ音声 API
-  - filter
-browser-compat: api.BaseAudioContext.createIIRFilter
 ---
 {{ APIRef("Web Audio API") }}
 

--- a/files/ja/web/api/baseaudiocontext/createoscillator/index.md
+++ b/files/ja/web/api/baseaudiocontext/createoscillator/index.md
@@ -1,16 +1,6 @@
 ---
 title: BaseAudioContext.createOscillator()
 slug: Web/API/BaseAudioContext/createOscillator
-tags:
-  - API
-  - AudioContext
-  - BaseAudioContext
-  - メソッド
-  - リファレンス
-  - ウェブ音声 API
-  - createOscillator
-browser-compat: api.BaseAudioContext.createOscillator
-translation_of: Web/API/BaseAudioContext/createOscillator
 original_slug: Web/API/AudioContext/createOscillator
 ---
 {{APIRef("Web Audio API")}}

--- a/files/ja/web/api/baseaudiocontext/createpanner/index.md
+++ b/files/ja/web/api/baseaudiocontext/createpanner/index.md
@@ -1,16 +1,6 @@
 ---
 title: BaseAudioContext.createPanner()
 slug: Web/API/BaseAudioContext/createPanner
-tags:
-  - API
-  - AudioContext
-  - BaseAudioContext
-  - メソッド
-  - リファレンス
-  - ウェブ音声 API
-  - createPanner
-browser-compat: api.BaseAudioContext.createPanner
-translation_of: Web/API/BaseAudioContext/createPanner
 original_slug: Web/API/AudioContext/createPanner
 ---
 {{ APIRef("Web Audio API") }}

--- a/files/ja/web/api/baseaudiocontext/createperiodicwave/index.md
+++ b/files/ja/web/api/baseaudiocontext/createperiodicwave/index.md
@@ -1,18 +1,6 @@
 ---
 title: BaseAudioContext.createPeriodicWave()
 slug: Web/API/BaseAudioContext/createPeriodicWave
-tags:
-  - API
-  - 音声
-  - AudioContext
-  - BaseAudioContext
-  - メディア
-  - メソッド
-  - リファレンス
-  - ウェブ音声 API
-  - createPeriodicWave
-browser-compat: api.BaseAudioContext.createPeriodicWave
-translation_of: Web/API/BaseAudioContext/createPeriodicWave
 original_slug: Web/API/AudioContext/createPeriodicWave
 ---
 {{ APIRef("Web Audio API") }}

--- a/files/ja/web/api/baseaudiocontext/createscriptprocessor/index.md
+++ b/files/ja/web/api/baseaudiocontext/createscriptprocessor/index.md
@@ -1,16 +1,6 @@
 ---
 title: BaseAudioContext.createScriptProcessor()
 slug: Web/API/BaseAudioContext/createScriptProcessor
-tags:
-  - API
-  - AudioContext
-  - BaseAudioContext
-  - メソッド
-  - リファレンス
-  - ウェブ音声 API
-  - createScriptProcessor
-browser-compat: api.BaseAudioContext.createScriptProcessor
-translation_of: Web/API/BaseAudioContext/createScriptProcessor
 original_slug: Web/API/AudioContext/createScriptProcessor
 ---
 {{APIRef("Web Audio API")}}{{deprecated_header}}

--- a/files/ja/web/api/baseaudiocontext/createstereopanner/index.md
+++ b/files/ja/web/api/baseaudiocontext/createstereopanner/index.md
@@ -1,17 +1,6 @@
 ---
 title: BaseAudioContext.createStereoPanner()
 slug: Web/API/BaseAudioContext/createStereoPanner
-tags:
-  - API
-  - AudioContext
-  - BaseAudioContext
-  - メディア
-  - メソッド
-  - リファレンス
-  - ウェブ音声 API
-  - createStereoPanner
-browser-compat: api.BaseAudioContext.createStereoPanner
-translation_of: Web/API/BaseAudioContext/createStereoPanner
 original_slug: Web/API/AudioContext/createStereoPanner
 ---
 {{ APIRef("Web Audio API") }}

--- a/files/ja/web/api/baseaudiocontext/createwaveshaper/index.md
+++ b/files/ja/web/api/baseaudiocontext/createwaveshaper/index.md
@@ -1,16 +1,6 @@
 ---
 title: BaseAudioContext.createWaveShaper()
 slug: Web/API/BaseAudioContext/createWaveShaper
-tags:
-  - API
-  - AudioContext
-  - BaseAudioContext
-  - メソッド
-  - リファレンス
-  - ウェブ音声 API
-  - createWaveShaper
-browser-compat: api.BaseAudioContext.createWaveShaper
-translation_of: Web/API/BaseAudioContext/createWaveShaper
 ---
 {{ APIRef("Web Audio API") }}
 

--- a/files/ja/web/api/baseaudiocontext/currenttime/index.md
+++ b/files/ja/web/api/baseaudiocontext/currenttime/index.md
@@ -1,16 +1,6 @@
 ---
 title: BaseAudioContext.currentTime
 slug: Web/API/BaseAudioContext/currentTime
-tags:
-  - API
-  - AudioContext
-  - BaseAudioContext
-  - プロパティ
-  - リファレンス
-  - ウェブ音声 API
-  - currentTime
-browser-compat: api.BaseAudioContext.currentTime
-translation_of: Web/API/BaseAudioContext/currentTime
 original_slug: Web/API/AudioContext/currentTime
 ---
 {{ APIRef("Web Audio API") }}

--- a/files/ja/web/api/baseaudiocontext/decodeaudiodata/index.md
+++ b/files/ja/web/api/baseaudiocontext/decodeaudiodata/index.md
@@ -1,16 +1,6 @@
 ---
 title: BaseAudioContext.decodeAudioData()
 slug: Web/API/BaseAudioContext/decodeAudioData
-tags:
-  - API
-  - 音声
-  - AudioContext
-  - BaseAudioContext
-  - メソッド
-  - リファレンス
-  - ウェブ音声 API
-  - decodeAudioData
-translation_of: Web/API/BaseAudioContext/decodeAudioData
 original_slug: Web/API/AudioContext/decodeAudioData
 ---
 {{ APIRef("Web Audio API") }}

--- a/files/ja/web/api/baseaudiocontext/destination/index.md
+++ b/files/ja/web/api/baseaudiocontext/destination/index.md
@@ -1,16 +1,6 @@
 ---
 title: BaseAudioContext.destination
 slug: Web/API/BaseAudioContext/destination
-tags:
-  - API
-  - AudioContext
-  - BaseAudioContext
-  - プロパティ
-  - リファレンス
-  - ウェブ音声 API
-  - destination
-browser-compat: api.BaseAudioContext.destination
-translation_of: Web/API/BaseAudioContext/destination
 original_slug: Web/API/AudioContext/destination
 ---
 {{ APIRef("Web Audio API") }}

--- a/files/ja/web/api/baseaudiocontext/index.md
+++ b/files/ja/web/api/baseaudiocontext/index.md
@@ -1,17 +1,6 @@
 ---
 title: BaseAudioContext
 slug: Web/API/BaseAudioContext
-tags:
-  - API
-  - 音声
-  - BaseAudioContext
-  - コンテキスト
-  - インターフェイス
-  - リファレンス
-  - ウェブ音声 API
-  - sound
-browser-compat: api.BaseAudioContext
-translation_of: Web/API/BaseAudioContext
 ---
 {{APIRef("Web Audio API")}}
 

--- a/files/ja/web/api/baseaudiocontext/listener/index.md
+++ b/files/ja/web/api/baseaudiocontext/listener/index.md
@@ -1,17 +1,6 @@
 ---
 title: BaseAudioContext.listener
 slug: Web/API/BaseAudioContext/listener
-tags:
-  - API
-  - AudioContext
-  - BaseAudioContext
-  - プロパティ
-  - リファレンス
-  - ウェブ音声 API
-  - listener
-  - spatialization
-browser-compat: api.BaseAudioContext.listener
-translation_of: Web/API/BaseAudioContext/listener
 original_slug: Web/API/AudioContext/listener
 ---
 {{ APIRef("Web Audio API") }}

--- a/files/ja/web/api/baseaudiocontext/samplerate/index.md
+++ b/files/ja/web/api/baseaudiocontext/samplerate/index.md
@@ -1,16 +1,6 @@
 ---
 title: BaseAudioContext.sampleRate
 slug: Web/API/BaseAudioContext/sampleRate
-tags:
-  - API
-  - AudioContext
-  - BaseAudioContext
-  - プロパティ
-  - リファレンス
-  - ウェブ音声 API
-  - sampleRate
-browser-compat: api.BaseAudioContext.sampleRate
-translation_of: Web/API/BaseAudioContext/sampleRate
 original_slug: Web/API/AudioContext/sampleRate
 ---
 {{ APIRef("Web Audio API") }}

--- a/files/ja/web/api/baseaudiocontext/state/index.md
+++ b/files/ja/web/api/baseaudiocontext/state/index.md
@@ -1,17 +1,6 @@
 ---
 title: BaseAudioContext.state
 slug: Web/API/BaseAudioContext/state
-tags:
-  - API
-  - Audio
-  - AudioContext
-  - BaseAudioContext
-  - プロパティ
-  - リファレンス
-  - ウェブ音声 API
-  - state
-browser-compat: api.BaseAudioContext.state
-translation_of: Web/API/BaseAudioContext/state
 original_slug: Web/API/AudioContext/state
 ---
 {{ APIRef("Web Audio API") }}

--- a/files/ja/web/api/baseaudiocontext/statechange_event/index.md
+++ b/files/ja/web/api/baseaudiocontext/statechange_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'BaseAudioContext: statechange イベント'
 slug: Web/API/BaseAudioContext/statechange_event
-tags:
-  - API
-  - Audio
-  - AudioContext
-  - BaseAudioContext
-  - イベントハンドラー
-  - リファレンス
-  - ウェブ音声 API
-  - statechange
-browser-compat: api.BaseAudioContext.statechange_event
-translation_of: Web/API/BaseAudioContext/onstatechange
 original_slug: Web/API/BaseAudioContext/onstatechange
 ---
 {{ APIRef("Web Audio API") }}

--- a/files/ja/web/api/battery_status_api/index.md
+++ b/files/ja/web/api/battery_status_api/index.md
@@ -1,15 +1,6 @@
 ---
 title: Battery Status API
 slug: Web/API/Battery_Status_API
-tags:
-  - API
-  - Apps
-  - Battery
-  - Firefox OS
-  - Guide
-  - Mobile
-  - ガイド
-translation_of: Web/API/Battery_Status_API
 ---
 {{DefaultAPISidebar("Battery API")}}{{deprecated_header}}
 

--- a/files/ja/web/api/blob/arraybuffer/index.md
+++ b/files/ja/web/api/blob/arraybuffer/index.md
@@ -1,16 +1,6 @@
 ---
 title: Blob.arrayBuffer()
 slug: Web/API/Blob/arrayBuffer
-tags:
-  - API
-  - ArrayBuffer
-  - Blob
-  - File API
-  - Method
-  - Reference
-  - binary
-  - read
-translation_of: Web/API/Blob/arrayBuffer
 ---
 {{APIRef("File API")}}
 

--- a/files/ja/web/api/blob/blob/index.md
+++ b/files/ja/web/api/blob/blob/index.md
@@ -1,15 +1,6 @@
 ---
 title: Blob()
 slug: Web/API/Blob/Blob
-tags:
-  - API
-  - Blob
-  - Constructor
-  - Experimental
-  - File API
-  - Reference
-  - コンストラクター
-translation_of: Web/API/Blob/Blob
 ---
 {{APIRef("File API")}}
 

--- a/files/ja/web/api/blob/index.md
+++ b/files/ja/web/api/blob/index.md
@@ -1,14 +1,6 @@
 ---
 title: Blob
 slug: Web/API/Blob
-tags:
-  - API
-  - Blob
-  - ファイル API
-  - インターフェイス
-  - リファレンス
-browser-compat: api.Blob
-translation_of: Web/API/Blob
 ---
 {{APIRef("File API")}}
 

--- a/files/ja/web/api/blob/size/index.md
+++ b/files/ja/web/api/blob/size/index.md
@@ -1,17 +1,6 @@
 ---
 title: Blob.size
 slug: Web/API/Blob/size
-tags:
-  - API
-  - Blob
-  - Bytes
-  - File API
-  - Files
-  - Property
-  - Reference
-  - length
-  - size
-translation_of: Web/API/Blob/size
 ---
 {{APIRef("File API")}}
 

--- a/files/ja/web/api/blob/slice/index.md
+++ b/files/ja/web/api/blob/slice/index.md
@@ -1,19 +1,6 @@
 ---
 title: Blob.slice()
 slug: Web/API/Blob/slice
-tags:
-  - API
-  - Blob
-  - File
-  - File API
-  - Method
-  - Reference
-  - Section
-  - Subset
-  - data
-  - slice
-  - split
-translation_of: Web/API/Blob/slice
 ---
 {{APIRef("File API")}}
 

--- a/files/ja/web/api/blob/stream/index.md
+++ b/files/ja/web/api/blob/stream/index.md
@@ -1,17 +1,6 @@
 ---
 title: Blob.stream()
 slug: Web/API/Blob/stream
-tags:
-  - API
-  - Blob
-  - Change
-  - Convert
-  - File API
-  - Method
-  - ReadableStream
-  - Reference
-  - stream
-translation_of: Web/API/Blob/stream
 ---
 {{APIRef("File API")}}
 

--- a/files/ja/web/api/blob/text/index.md
+++ b/files/ja/web/api/blob/text/index.md
@@ -1,18 +1,6 @@
 ---
 title: Blob.text()
 slug: Web/API/Blob/text
-tags:
-  - API
-  - Blob
-  - File API
-  - Method
-  - Reference
-  - String
-  - Text
-  - Utf-8
-  - get
-  - read
-translation_of: Web/API/Blob/text
 ---
 {{APIRef("File API")}}
 

--- a/files/ja/web/api/blob/type/index.md
+++ b/files/ja/web/api/blob/type/index.md
@@ -1,19 +1,6 @@
 ---
 title: Blob.type
 slug: Web/API/Blob/type
-tags:
-  - API
-  - Blob
-  - DOM
-  - File
-  - File API
-  - Format
-  - MIME
-  - MIME Type
-  - Property
-  - Reference
-  - Type
-translation_of: Web/API/Blob/type
 ---
 {{APIRef("File API")}}
 

--- a/files/ja/web/api/blobbuilder/index.md
+++ b/files/ja/web/api/blobbuilder/index.md
@@ -1,16 +1,6 @@
 ---
 title: BlobBuilder
 slug: Web/API/BlobBuilder
-page-type: web-api-interface
-tags:
-  - API
-  - DOM
-  - DOM リファレンス
-  - File API
-  - 非推奨
-  - リファレンス
-browser-compat: api.BlobBuilder
-translation_of: Web/API/BlobBuilder
 ---
 {{APIRef("File API")}}{{ deprecated_header}}
 

--- a/files/ja/web/api/blobevent/blobevent/index.md
+++ b/files/ja/web/api/blobevent/blobevent/index.md
@@ -1,16 +1,6 @@
 ---
 title: BlobEvent()
 slug: Web/API/BlobEvent/BlobEvent
-tags:
-  - API
-  - BlobEvent
-  - Constructor
-  - DOM
-  - DOM Reference
-  - Experimental
-  - Media Stream Encoding
-  - Reference
-translation_of: Web/API/BlobEvent/BlobEvent
 ---
 {{APIRef("Media Capture and Streams")}}{{seeCompatTable}}
 

--- a/files/ja/web/api/blobevent/data/index.md
+++ b/files/ja/web/api/blobevent/data/index.md
@@ -1,16 +1,6 @@
 ---
 title: BlobEvent.data
 slug: Web/API/BlobEvent/data
-tags:
-  - API
-  - BlobEvent
-  - DOM
-  - DOM Reference
-  - Experimental
-  - Media Stream Recording
-  - Property
-  - Reference
-translation_of: Web/API/BlobEvent/data
 ---
 {{ apiref("Media Capture and Streams") }}
 

--- a/files/ja/web/api/blobevent/index.md
+++ b/files/ja/web/api/blobevent/index.md
@@ -1,19 +1,6 @@
 ---
 title: BlobEvent
 slug: Web/API/BlobEvent
-tags:
-  - API
-  - Audio
-  - Blob
-  - Interface
-  - Media
-  - MediaStream Recording
-  - MediaStream Recording API
-  - Recording Media
-  - Reference
-  - Video
-  - events
-translation_of: Web/API/BlobEvent
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/blobevent/timecode/index.md
+++ b/files/ja/web/api/blobevent/timecode/index.md
@@ -1,14 +1,6 @@
 ---
 title: BlobEvent.timecode
 slug: Web/API/BlobEvent/timecode
-tags:
-  - API
-  - BlobEvent
-  - Media
-  - Media Stream Recording
-  - Property
-  - Reference
-translation_of: Web/API/BlobEvent/timecode
 ---
 {{SeeCompatTable}}{{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/bluetooth/index.md
+++ b/files/ja/web/api/bluetooth/index.md
@@ -1,14 +1,6 @@
 ---
 title: Bluetooth
 slug: Web/API/Bluetooth
-tags:
-  - API
-  - Buetooth
-  - Interface
-  - Non-standard
-  - Reference
-  - Web Buletooth API
-translation_of: Web/API/Bluetooth
 ---
 {{ apiref("W3C Bluetooth API") }} {{Non-standard_header()}}
 

--- a/files/ja/web/api/broadcast_channel_api/index.md
+++ b/files/ja/web/api/broadcast_channel_api/index.md
@@ -1,13 +1,6 @@
 ---
 title: Broadcast Channel API
 slug: Web/API/Broadcast_Channel_API
-tags:
-  - API
-  - Broadcast Channel API
-  - HTML API
-  - Overview
-  - Reference
-translation_of: Web/API/Broadcast_Channel_API
 ---
 {{DefaultAPISidebar("Broadcast Channel API")}}
 

--- a/files/ja/web/api/broadcastchannel/broadcastchannel/index.md
+++ b/files/ja/web/api/broadcastchannel/broadcastchannel/index.md
@@ -1,15 +1,6 @@
 ---
 title: BroadcastChannel()
 slug: Web/API/BroadcastChannel/BroadcastChannel
-tags:
-  - API
-  - Broadcast Channel API
-  - BroadcastChannel
-  - Constructor
-  - Experimental
-  - HTML API
-  - Reference
-translation_of: Web/API/BroadcastChannel/BroadcastChannel
 ---
 {{APIRef("BroadCastChannel API")}}
 

--- a/files/ja/web/api/broadcastchannel/close/index.md
+++ b/files/ja/web/api/broadcastchannel/close/index.md
@@ -1,15 +1,6 @@
 ---
 title: BroadcastChannel.close()
 slug: Web/API/BroadcastChannel/close
-tags:
-  - API
-  - Broadcast Channel API
-  - BroadcastChannel
-  - Experimental
-  - HTML API
-  - Method
-  - Reference
-translation_of: Web/API/BroadcastChannel/close
 ---
 {{APIRef("BroadCastChannel API")}}
 

--- a/files/ja/web/api/broadcastchannel/index.md
+++ b/files/ja/web/api/broadcastchannel/index.md
@@ -1,14 +1,6 @@
 ---
 title: BroadcastChannel
 slug: Web/API/BroadcastChannel
-tags:
-  - API
-  - Broadcast Channel API
-  - Experimental
-  - HTML API
-  - Interface
-  - Reference
-translation_of: Web/API/BroadcastChannel
 ---
 {{APIRef("Broadcast Channel API")}}
 

--- a/files/ja/web/api/broadcastchannel/message_event/index.md
+++ b/files/ja/web/api/broadcastchannel/message_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'BroadcastChannel: message イベント'
 slug: Web/API/BroadcastChannel/message_event
-tags:
-  - Communication
-  - Event
-  - EventSource
-  - Reference
-  - events
-  - message
-  - messaging
-translation_of: Web/API/BroadcastChannel/message_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/broadcastchannel/messageerror_event/index.md
+++ b/files/ja/web/api/broadcastchannel/messageerror_event/index.md
@@ -1,9 +1,6 @@
 ---
 title: 'BroadcastChannel: messageerror イベント'
 slug: Web/API/BroadcastChannel/messageerror_event
-tags:
-  - Event
-translation_of: Web/API/BroadcastChannel/messageerror_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/broadcastchannel/name/index.md
+++ b/files/ja/web/api/broadcastchannel/name/index.md
@@ -1,15 +1,6 @@
 ---
 title: BroadcastChannel.name
 slug: Web/API/BroadcastChannel/name
-tags:
-  - Broadcast Channel API
-  - BroadcastChannel
-  - Experimental
-  - HTML API
-  - Property
-  - Read-only
-  - Reference
-translation_of: Web/API/BroadcastChannel/name
 ---
 {{APIRef("BroadCastChannel API")}}
 

--- a/files/ja/web/api/broadcastchannel/postmessage/index.md
+++ b/files/ja/web/api/broadcastchannel/postmessage/index.md
@@ -1,15 +1,6 @@
 ---
 title: BroadcastChannel.postMessage()
 slug: Web/API/BroadcastChannel/postMessage
-tags:
-  - API
-  - Broadcast Channel API
-  - BroadcastChannel
-  - Experimental
-  - HTML API
-  - Method
-  - Reference
-translation_of: Web/API/BroadcastChannel/postMessage
 ---
 {{APIRef("BroadCastChannel API")}}
 

--- a/files/ja/web/api/btoa/index.md
+++ b/files/ja/web/api/btoa/index.md
@@ -1,17 +1,6 @@
 ---
 title: WindowOrWorkerGlobalScope.btoa()
 slug: Web/API/btoa
-tags:
-  - API
-  - HTML DOM
-  - Method
-  - Reference
-  - Web
-  - WindowOrWorkerGlobalScope
-  - btoa
-  - data
-  - strings
-translation_of: Web/API/WindowOrWorkerGlobalScope/btoa
 original_slug: Web/API/WindowOrWorkerGlobalScope/btoa
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.md
+++ b/files/ja/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.md
@@ -1,14 +1,6 @@
 ---
 title: ByteLengthQueuingStrategy.ByteLengthQueuingStrategy()
 slug: Web/API/ByteLengthQueuingStrategy/ByteLengthQueuingStrategy
-tags:
-  - API
-  - ByteLengthQueuingStrategy
-  - Constructor
-  - Experimental
-  - Reference
-  - Streams
-translation_of: Web/API/ByteLengthQueuingStrategy/ByteLengthQueuingStrategy
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/bytelengthqueuingstrategy/index.md
+++ b/files/ja/web/api/bytelengthqueuingstrategy/index.md
@@ -1,14 +1,6 @@
 ---
 title: ByteLengthQueuingStrategy
 slug: Web/API/ByteLengthQueuingStrategy
-tags:
-  - API
-  - ByteLengthQueuingStrategy
-  - Experimental
-  - Interface
-  - Reference
-  - Streams
-translation_of: Web/API/ByteLengthQueuingStrategy
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/bytelengthqueuingstrategy/size/index.md
+++ b/files/ja/web/api/bytelengthqueuingstrategy/size/index.md
@@ -1,15 +1,6 @@
 ---
 title: ByteLengthQueuingStrategy.size()
 slug: Web/API/ByteLengthQueuingStrategy/size
-tags:
-  - API
-  - ByteLengthQueuingStrategy
-  - Experimental
-  - Method
-  - Reference
-  - Streams
-  - size
-translation_of: Web/API/ByteLengthQueuingStrategy/size
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/cache/add/index.md
+++ b/files/ja/web/api/cache/add/index.md
@@ -1,15 +1,6 @@
 ---
 title: Cache.add()
 slug: Web/API/Cache/add
-tags:
-  - API
-  - Cache
-  - Experimental
-  - Method
-  - Reference
-  - Service Workers
-  - ServiceWorker
-translation_of: Web/API/Cache/add
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/cache/addall/index.md
+++ b/files/ja/web/api/cache/addall/index.md
@@ -1,13 +1,6 @@
 ---
 title: Cache.addAll()
 slug: Web/API/Cache/addAll
-tags:
-  - API
-  - Cache
-  - addAll
-  - サービスワーカー
-  - サービスワーカー API
-translation_of: Web/API/Cache/addAll
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/cache/delete/index.md
+++ b/files/ja/web/api/cache/delete/index.md
@@ -1,15 +1,6 @@
 ---
 title: Cache.delete()
 slug: Web/API/Cache/delete
-tags:
-  - API
-  - Cache
-  - Method
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - delete
-translation_of: Web/API/Cache/delete
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/cache/index.md
+++ b/files/ja/web/api/cache/index.md
@@ -1,21 +1,6 @@
 ---
 title: Cache
 slug: Web/API/Cache
-tags:
-  - API
-  - Cache
-  - Experimental
-  - Fraft
-  - Interface
-  - Offline
-  - Reference
-  - Service Worker
-  - ServiceWorker
-  - Storage
-  - インターフェイス
-  - オフライン
-  - サービスワーカー
-translation_of: Web/API/Cache
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/cache/keys/index.md
+++ b/files/ja/web/api/cache/keys/index.md
@@ -1,15 +1,6 @@
 ---
 title: Cache.keys()
 slug: Web/API/Cache/keys
-tags:
-  - API
-  - Cache
-  - Method
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - keys
-translation_of: Web/API/Cache/keys
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/cache/match/index.md
+++ b/files/ja/web/api/cache/match/index.md
@@ -1,16 +1,6 @@
 ---
 title: Cache.match()
 slug: Web/API/Cache/match
-tags:
-  - API
-  - Cache
-  - Method
-  - Reference
-  - Service Workers
-  - Service worker API
-  - ServiceWorker
-  - match
-translation_of: Web/API/Cache/match
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/cache/matchall/index.md
+++ b/files/ja/web/api/cache/matchall/index.md
@@ -1,15 +1,6 @@
 ---
 title: Cache.matchAll()
 slug: Web/API/Cache/matchAll
-tags:
-  - API
-  - Cache
-  - Method
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - matchAll
-translation_of: Web/API/Cache/matchAll
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/cache/put/index.md
+++ b/files/ja/web/api/cache/put/index.md
@@ -1,16 +1,6 @@
 ---
 title: Cache.put()
 slug: Web/API/Cache/put
-tags:
-  - API
-  - Cache
-  - Method
-  - Reference
-  - Service Workers
-  - Service worker API
-  - ServiceWorker
-  - put
-translation_of: Web/API/Cache/put
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/caches/index.md
+++ b/files/ja/web/api/caches/index.md
@@ -1,17 +1,6 @@
 ---
 title: WorkerGlobalScope.caches
 slug: Web/API/caches
-tags:
-  - API
-  - Experimental
-  - Property
-  - Read-only
-  - Reference
-  - Service Workers
-  - Web Workers
-  - Window
-  - WindowOrWorkerGlobalScope
-translation_of: Web/API/WindowOrWorkerGlobalScope/caches
 original_slug: Web/API/WindowOrWorkerGlobalScope/caches
 ---
 {{APIRef()}}{{SeeCompatTable}}

--- a/files/ja/web/api/cachestorage/delete/index.md
+++ b/files/ja/web/api/cachestorage/delete/index.md
@@ -1,16 +1,6 @@
 ---
 title: CacheStorage.delete()
 slug: Web/API/CacheStorage/delete
-tags:
-  - API
-  - CacheStorage
-  - Experimental
-  - Method
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - delete
-translation_of: Web/API/CacheStorage/delete
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/cachestorage/has/index.md
+++ b/files/ja/web/api/cachestorage/has/index.md
@@ -1,16 +1,6 @@
 ---
 title: CacheStorage.has()
 slug: Web/API/CacheStorage/has
-tags:
-  - API
-  - CacheStorage
-  - Experimental
-  - Method
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - has
-translation_of: Web/API/CacheStorage/has
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/cachestorage/index.md
+++ b/files/ja/web/api/cachestorage/index.md
@@ -1,15 +1,6 @@
 ---
 title: CacheStorage
 slug: Web/API/CacheStorage
-tags:
-  - API
-  - CacheStorage
-  - Experimental
-  - Interface
-  - Reference
-  - Service Workers
-  - ServiceWorker
-translation_of: Web/API/CacheStorage
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/cachestorage/keys/index.md
+++ b/files/ja/web/api/cachestorage/keys/index.md
@@ -1,16 +1,6 @@
 ---
 title: CacheStorage.keys()
 slug: Web/API/CacheStorage/keys
-tags:
-  - API
-  - CacheStorage
-  - Method
-  - Reference
-  - Service Workers
-  - Service worker API
-  - ServiceWorker
-  - keys
-translation_of: Web/API/CacheStorage/keys
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/cachestorage/match/index.md
+++ b/files/ja/web/api/cachestorage/match/index.md
@@ -1,16 +1,6 @@
 ---
 title: CacheStorage.match()
 slug: Web/API/CacheStorage/match
-tags:
-  - API
-  - CacheStorage
-  - Method
-  - Reference
-  - Service Workers
-  - Service worker API
-  - ServiceWorker
-  - match
-translation_of: Web/API/CacheStorage/match
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/cachestorage/open/index.md
+++ b/files/ja/web/api/cachestorage/open/index.md
@@ -1,16 +1,6 @@
 ---
 title: CacheStorage.open()
 slug: Web/API/CacheStorage/open
-tags:
-  - API
-  - CacheStorage
-  - Method
-  - Reference
-  - Service Workers
-  - Service worker API
-  - ServiceWorker
-  - open
-translation_of: Web/API/CacheStorage/open
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/canvas_api/index.md
+++ b/files/ja/web/api/canvas_api/index.md
@@ -1,14 +1,6 @@
 ---
 title: キャンバス API
 slug: Web/API/Canvas_API
-tags:
-  - API
-  - キャンバス
-  - グラフィック
-  - JavaScript
-  - 概要
-  - リファレンス
-translation_of: Web/API/Canvas_API
 ---
 {{CanvasSidebar}}
 

--- a/files/ja/web/api/canvas_api/tutorial/advanced_animations/index.md
+++ b/files/ja/web/api/canvas_api/tutorial/advanced_animations/index.md
@@ -1,11 +1,6 @@
 ---
 title: 高度なアニメーション
 slug: Web/API/Canvas_API/Tutorial/Advanced_animations
-tags:
-  - キャンバス
-  - グラフィック
-  - チュートリアル
-translation_of: Web/API/Canvas_API/Tutorial/Advanced_animations
 original_slug: Web/Guide/HTML/Canvas_tutorial/Advanced_animations
 ---
 {{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Basic_animations", "Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas")}}

--- a/files/ja/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
+++ b/files/ja/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
@@ -1,14 +1,6 @@
 ---
 title: スタイルと色の適用
 slug: Web/API/Canvas_API/Tutorial/Applying_styles_and_colors
-tags:
-  - キャンバス
-  - グラフィック
-  - HTML
-  - HTML5
-  - 中級者
-  - チュートリアル
-translation_of: Web/API/Canvas_API/Tutorial/Applying_styles_and_colors
 original_slug: Web/Guide/HTML/Canvas_tutorial/Applying_styles_and_colors
 ---
 {{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Drawing_shapes", "Web/API/Canvas_API/Tutorial/Drawing_text")}}

--- a/files/ja/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/ja/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -1,14 +1,6 @@
 ---
 title: 基本的なアニメーション
 slug: Web/API/Canvas_API/Tutorial/Basic_animations
-tags:
-  - キャンバス
-  - グラフィック
-  - HTML
-  - HTML5
-  - 中級者
-  - チュートリアル
-translation_of: Web/API/Canvas_API/Tutorial/Basic_animations
 original_slug: Web/Guide/HTML/Canvas_tutorial/Basic_animations
 ---
 {{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Compositing", "Web/API/Canvas_API/Tutorial/Advanced_animations")}}

--- a/files/ja/web/api/canvas_api/tutorial/basic_usage/index.md
+++ b/files/ja/web/api/canvas_api/tutorial/basic_usage/index.md
@@ -1,13 +1,6 @@
 ---
 title: キャンバスの基本的な使い方
 slug: Web/API/Canvas_API/Tutorial/Basic_usage
-tags:
-  - キャンバス
-  - グラフィック
-  - HTML
-  - 中級者
-  - チュートリアル
-translation_of: Web/API/Canvas_API/Tutorial/Basic_usage
 original_slug: Web/Guide/HTML/Canvas_tutorial/Basic_usage
 ---
 {{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial", "Web/API/Canvas_API/Tutorial/Drawing_shapes")}}

--- a/files/ja/web/api/canvas_api/tutorial/compositing/example/index.md
+++ b/files/ja/web/api/canvas_api/tutorial/compositing/example/index.md
@@ -1,14 +1,6 @@
 ---
 title: 合成の例
 slug: Web/API/Canvas_API/Tutorial/Compositing/Example
-tags:
-  - キャンバス
-  - 例
-  - グラフィック
-  - HTML
-  - HTML5
-  - チュートリアル
-translation_of: Web/API/Canvas_API/Tutorial/Compositing/Example
 ---
 {{CanvasSidebar}}
 

--- a/files/ja/web/api/canvas_api/tutorial/compositing/index.md
+++ b/files/ja/web/api/canvas_api/tutorial/compositing/index.md
@@ -1,14 +1,6 @@
 ---
 title: 合成とクリッピング
 slug: Web/API/Canvas_API/Tutorial/Compositing
-tags:
-  - キャンバス
-  - グラフィック
-  - HTML
-  - HTML5
-  - 中級者
-  - チュートリアル
-translation_of: Web/API/Canvas_API/Tutorial/Compositing
 ---
 {{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Transformations", "Web/API/Canvas_API/Tutorial/Basic_animations")}}
 

--- a/files/ja/web/api/canvas_api/tutorial/drawing_shapes/index.md
+++ b/files/ja/web/api/canvas_api/tutorial/drawing_shapes/index.md
@@ -1,15 +1,6 @@
 ---
 title: キャンバスでの図形の描画
 slug: Web/API/Canvas_API/Tutorial/Drawing_shapes
-tags:
-  - キャンバス
-  - グラフィック
-  - HTML
-  - HTML キャンバス
-  - HTML5
-  - 中級者
-  - チュートリアル
-translation_of: Web/API/Canvas_API/Tutorial/Drawing_shapes
 original_slug: Web/Guide/HTML/Canvas_tutorial/Drawing_shapes
 ---
 {{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Basic_usage", "Web/API/Canvas_API/Tutorial/Applying_styles_and_colors")}}

--- a/files/ja/web/api/canvas_api/tutorial/drawing_text/index.md
+++ b/files/ja/web/api/canvas_api/tutorial/drawing_text/index.md
@@ -1,12 +1,6 @@
 ---
 title: テキストの描画
 slug: Web/API/Canvas_API/Tutorial/Drawing_text
-tags:
-  - キャンバス
-  - グラフィック
-  - 中級者
-  - チュートリアル
-translation_of: Web/API/Canvas_API/Tutorial/Drawing_text
 original_slug: Drawing_text_using_a_canvas
 ---
 {{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Applying_styles_and_colors", "Web/API/Canvas_API/Tutorial/Using_images")}}

--- a/files/ja/web/api/canvas_api/tutorial/finale/index.md
+++ b/files/ja/web/api/canvas_api/tutorial/finale/index.md
@@ -1,11 +1,6 @@
 ---
 title: おわりに
 slug: Web/API/Canvas_API/Tutorial/Finale
-tags:
-  - キャンバス
-  - グラフィック
-  - チュートリアル
-translation_of: Web/API/Canvas_API/Tutorial/Finale
 original_slug: Web/Guide/HTML/Canvas_tutorial/Finale
 ---
 {{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Optimizing_canvas")}}

--- a/files/ja/web/api/canvas_api/tutorial/index.md
+++ b/files/ja/web/api/canvas_api/tutorial/index.md
@@ -1,15 +1,6 @@
 ---
 title: Canvas チュートリアル
 slug: Web/API/Canvas_API/Tutorial
-tags:
-  - キャンバス
-  - グラフィック
-  - ガイド
-  - HTML
-  - HTML5
-  - 中級者
-  - ウェブ
-translation_of: Web/API/Canvas_API/Tutorial
 ---
 {{CanvasSidebar}}
 

--- a/files/ja/web/api/canvas_api/tutorial/optimizing_canvas/index.md
+++ b/files/ja/web/api/canvas_api/tutorial/optimizing_canvas/index.md
@@ -1,14 +1,6 @@
 ---
 title: キャンバスの最適化
 slug: Web/API/Canvas_API/Tutorial/Optimizing_canvas
-tags:
-  - 上級者
-  - キャンバス
-  - グラフィック
-  - HTML
-  - HTML5
-  - チュートリアル
-translation_of: Web/API/Canvas_API/Tutorial/Optimizing_canvas
 original_slug: Web/Guide/HTML/Canvas_tutorial/Optimizing_canvas
 ---
 {{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas", "Web/API/Canvas_API/Tutorial/Finale")}}

--- a/files/ja/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
+++ b/files/ja/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
@@ -1,12 +1,6 @@
 ---
 title: キャンバスとピクセル操作
 slug: Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas
-tags:
-  - キャンバス
-  - グラフィック
-  - 中級者
-  - チュートリアル
-translation_of: Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas
 original_slug: Web/Guide/HTML/Canvas_tutorial/Pixel_manipulation_with_canvas
 ---
 {{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Advanced_animations", "Web/API/Canvas_API/Tutorial/Optimizing_canvas")}}

--- a/files/ja/web/api/canvas_api/tutorial/transformations/index.md
+++ b/files/ja/web/api/canvas_api/tutorial/transformations/index.md
@@ -1,15 +1,6 @@
 ---
 title: 座標変換
 slug: Web/API/Canvas_API/Tutorial/Transformations
-tags:
-  - キャンバス
-  - グラフィック
-  - ガイド
-  - HTML
-  - HTML5
-  - 中級者
-  - ウェブ
-translation_of: Web/API/Canvas_API/Tutorial/Transformations
 original_slug: Web/Guide/HTML/Canvas_tutorial/Transformations
 ---
 {{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Using_images", "Web/API/Canvas_API/Tutorial/Compositing")}}

--- a/files/ja/web/api/canvas_api/tutorial/using_images/index.md
+++ b/files/ja/web/api/canvas_api/tutorial/using_images/index.md
@@ -1,13 +1,6 @@
 ---
 title: 画像の使用
 slug: Web/API/Canvas_API/Tutorial/Using_images
-tags:
-  - 上級者
-  - キャンバス
-  - グラフィック
-  - HTML
-  - チュートリアル
-translation_of: Web/API/Canvas_API/Tutorial/Using_images
 original_slug: Web/Guide/HTML/Canvas_tutorial/Using_images
 ---
 {{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Drawing_text", "Web/API/Canvas_API/Tutorial/Transformations" )}}

--- a/files/ja/web/api/canvascapturemediastreamtrack/index.md
+++ b/files/ja/web/api/canvascapturemediastreamtrack/index.md
@@ -1,18 +1,6 @@
 ---
 title: CanvasCaptureMediaStreamTrack
 slug: Web/API/CanvasCaptureMediaStreamTrack
-tags:
-  - CanvasCaptureMediaStreamTrack
-  - Experimental
-  - Frame Capture
-  - Interface
-  - Media
-  - Media Capture
-  - NeedsTranslation
-  - Reference
-  - TopicStub
-  - Web
-translation_of: Web/API/CanvasCaptureMediaStreamTrack
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/canvascapturemediastreamtrack/requestframe/index.md
+++ b/files/ja/web/api/canvascapturemediastreamtrack/requestframe/index.md
@@ -1,17 +1,6 @@
 ---
 title: CanvasCaptureMediaStreamTrack.requestFrame()
 slug: Web/API/CanvasCaptureMediaStreamTrack/requestFrame
-tags:
-  - Canvas
-  - CanvasCaptureMediaStream
-  - DOM
-  - Experimental
-  - Frame Capture
-  - Media
-  - Method
-  - Reference
-  - requestFrame
-translation_of: Web/API/CanvasCaptureMediaStreamTrack/requestFrame
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/canvasgradient/index.md
+++ b/files/ja/web/api/canvasgradient/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasGradient
 slug: Web/API/CanvasGradient
-tags:
-  - API
-  - Canvas
-  - CanvasGradient
-  - Interface
-  - Reference
-  - グラデーション
-translation_of: Web/API/CanvasGradient
 ---
 **`CanvasGradient`** インターフェイスは、グラデーションを記述する[不透明オブジェクト](https://en.wikipedia.org/wiki/Opaque_data_type)を表します。 {{domxref("CanvasRenderingContext2D.createLinearGradient()")}} または {{domxref("CanvasRenderingContext2D.createRadialGradient()")}} メソッドから返されます。
 

--- a/files/ja/web/api/canvaspattern/index.md
+++ b/files/ja/web/api/canvaspattern/index.md
@@ -1,12 +1,6 @@
 ---
 title: CanvasPattern
 slug: Web/API/CanvasPattern
-tags:
-  - API
-  - Canvas
-  - Interface
-  - Reference
-translation_of: Web/API/CanvasPattern
 ---
 {{APIRef("Canvas API")}}
 

--- a/files/ja/web/api/canvaspattern/settransform/index.md
+++ b/files/ja/web/api/canvaspattern/settransform/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasPattern.setTransform()
 slug: Web/API/CanvasPattern/setTransform
-tags:
-  - API
-  - Canvas
-  - CanvasPattern
-  - Experimental
-  - Method
-  - Reference
-translation_of: Web/API/CanvasPattern/setTransform
 ---
 {{APIRef("Canvas API")}} {{SeeCompatTable}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/arc/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/arc/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.arc()
 slug: Web/API/CanvasRenderingContext2D/arc
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - メソッド
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.arc
-translation_of: Web/API/CanvasRenderingContext2D/arc
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/arcto/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/arcto/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.arcTo()
 slug: Web/API/CanvasRenderingContext2D/arcTo
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - メソッド
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.arcTo
-translation_of: Web/API/CanvasRenderingContext2D/arcTo
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/beginpath/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/beginpath/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.beginPath()
 slug: Web/API/CanvasRenderingContext2D/beginPath
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - メソッド
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.beginPath
-translation_of: Web/API/CanvasRenderingContext2D/beginPath
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/canvas/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/canvas/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.canvas
 slug: Web/API/CanvasRenderingContext2D/canvas
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - プロパティ
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.canvas
-translation_of: Web/API/CanvasRenderingContext2D/canvas
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/clearrect/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/clearrect/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.clearRect()
 slug: Web/API/CanvasRenderingContext2D/clearRect
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - メソッド
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.clearRect
-translation_of: Web/API/CanvasRenderingContext2D/clearRect
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/closepath/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/closepath/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.closePath()
 slug: Web/API/CanvasRenderingContext2D/closePath
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - メソッド
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.closePath
-translation_of: Web/API/CanvasRenderingContext2D/closePath
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/direction/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/direction/index.md
@@ -1,15 +1,6 @@
 ---
 title: CanvasRenderingContext2D.direction
 slug: Web/API/CanvasRenderingContext2D/direction
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - 実験的
-  - プロパティ
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.direction
-translation_of: Web/API/CanvasRenderingContext2D/direction
 ---
 {{APIRef}} {{SeeCompatTable}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/drawfocusifneeded/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/drawfocusifneeded/index.md
@@ -1,15 +1,6 @@
 ---
 title: CanvasRenderingContext2D.drawFocusIfNeeded()
 slug: Web/API/CanvasRenderingContext2D/drawFocusIfNeeded
-tags:
-  - API
-  - アクセシビリティ
-  - Canvas
-  - CanvasRenderingContext2D
-  - メソッド
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.drawFocusIfNeeded
-translation_of: Web/API/CanvasRenderingContext2D/drawFocusIfNeeded
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/ellipse/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/ellipse/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.ellipse()
 slug: Web/API/CanvasRenderingContext2D/ellipse
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - メソッド
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.ellipse
-translation_of: Web/API/CanvasRenderingContext2D/ellipse
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/fillrect/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/fillrect/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.fillRect()
 slug: Web/API/CanvasRenderingContext2D/fillRect
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - メソッド
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.fillRect
-translation_of: Web/API/CanvasRenderingContext2D/fillRect
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/fillstyle/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/fillstyle/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.fillStyle
 slug: Web/API/CanvasRenderingContext2D/fillStyle
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - プロパティ
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.fillStyle
-translation_of: Web/API/CanvasRenderingContext2D/fillStyle
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/filltext/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/filltext/index.md
@@ -1,22 +1,6 @@
 ---
 title: CanvasRenderingContext2D.fillText()
 slug: Web/API/CanvasRenderingContext2D/fillText
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - Draw String
-  - Draw Text
-  - 文字列の描画
-  - テキストの描画
-  - Fill Text
-  - Filling Text
-  - メソッド
-  - リファレンス
-  - テキスト
-  - fillText
-browser-compat: api.CanvasRenderingContext2D.fillText
-translation_of: Web/API/CanvasRenderingContext2D/fillText
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/font/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/font/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.font
 slug: Web/API/CanvasRenderingContext2D/font
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - プロパティ
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.font
-translation_of: Web/API/CanvasRenderingContext2D/font
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.md
@@ -1,16 +1,6 @@
 ---
 title: CanvasRenderingContext2D.globalCompositeOperation
 slug: Web/API/CanvasRenderingContext2D/globalCompositeOperation
-tags:
-  - API
-  - 混色
-  - Canvas
-  - CanvasRenderingContext2D
-  - Compositing
-  - プロパティ
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.globalCompositeOperation
-translation_of: Web/API/CanvasRenderingContext2D/globalCompositeOperation
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/imagesmoothingenabled/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/imagesmoothingenabled/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.imageSmoothingEnabled
 slug: Web/API/CanvasRenderingContext2D/imageSmoothingEnabled
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - プロパティ
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.imageSmoothingEnabled
-translation_of: Web/API/CanvasRenderingContext2D/imageSmoothingEnabled
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/index.md
@@ -1,16 +1,6 @@
 ---
 title: CanvasRenderingContext2D
 slug: Web/API/CanvasRenderingContext2D
-page-type: web-api-interface
-tags:
-  - API
-  - キャンバス
-  - CanvasRenderingContext2D
-  - ゲーム
-  - グラフィック
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D
-translation_of: Web/API/CanvasRenderingContext2D
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/linecap/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/linecap/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.lineCap
 slug: Web/API/CanvasRenderingContext2D/lineCap
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - プロパティ
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.lineCap
-translation_of: Web/API/CanvasRenderingContext2D/lineCap
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/lineto/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/lineto/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.lineTo()
 slug: Web/API/CanvasRenderingContext2D/lineTo
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - Method
-  - Reference
-browser-compat: api.CanvasRenderingContext2D.lineTo
-translation_of: Web/API/CanvasRenderingContext2D/lineTo
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/measuretext/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/measuretext/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.measureText()
 slug: Web/API/CanvasRenderingContext2D/measureText
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - メソッド
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.measureText
-translation_of: Web/API/CanvasRenderingContext2D/measureText
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/moveto/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/moveto/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.moveTo()
 slug: Web/API/CanvasRenderingContext2D/moveTo
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - メソッド
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.moveTo
-translation_of: Web/API/CanvasRenderingContext2D/moveTo
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/rect/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/rect/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.rect()
 slug: Web/API/CanvasRenderingContext2D/rect
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - メソッド
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.rect
-translation_of: Web/API/CanvasRenderingContext2D/rect
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/save/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/save/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.save()
 slug: Web/API/CanvasRenderingContext2D/save
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - メソッド
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.save
-translation_of: Web/API/CanvasRenderingContext2D/save
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/scale/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/scale/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.scale()
 slug: Web/API/CanvasRenderingContext2D/scale
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - メソッド
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.scale
-translation_of: Web/API/CanvasRenderingContext2D/scale
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/setlinedash/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/setlinedash/index.md
@@ -1,18 +1,6 @@
 ---
 title: CanvasRenderingContext2D.setLineDash()
 slug: Web/API/CanvasRenderingContext2D/setLineDash
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - 破線
-  - LInes
-  - メソッド
-  - リファレンス
-  - パターン
-  - setLineDash
-browser-compat: api.CanvasRenderingContext2D.setLineDash
-translation_of: Web/API/CanvasRenderingContext2D/setLineDash
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/stroke/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/stroke/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.stroke()
 slug: Web/API/CanvasRenderingContext2D/stroke
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - Method
-  - Reference
-browser-compat: api.CanvasRenderingContext2D.stroke
-translation_of: Web/API/CanvasRenderingContext2D/stroke
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/strokerect/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/strokerect/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.strokeRect()
 slug: Web/API/CanvasRenderingContext2D/strokeRect
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - メソッド
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.strokeRect
-translation_of: Web/API/CanvasRenderingContext2D/strokeRect
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/strokestyle/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/strokestyle/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.strokeStyle
 slug: Web/API/CanvasRenderingContext2D/strokeStyle
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - プロパティ
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.strokeStyle
-translation_of: Web/API/CanvasRenderingContext2D/strokeStyle
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/stroketext/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/stroketext/index.md
@@ -1,21 +1,6 @@
 ---
 title: CanvasRenderingContext2D.strokeText()
 slug: Web/API/CanvasRenderingContext2D/strokeText
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - Draw String
-  - Draw Text
-  - 文字列の描画
-  - テキストの描画
-  - メソッド
-  - リファレンス
-  - Stroke String
-  - テキストの輪郭
-  - strokeText
-browser-compat: api.CanvasRenderingContext2D.strokeText
-translation_of: Web/API/CanvasRenderingContext2D/strokeText
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/textalign/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/textalign/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.textAlign
 slug: Web/API/CanvasRenderingContext2D/textAlign
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - プロパティ
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.textAlign
-translation_of: Web/API/CanvasRenderingContext2D/textAlign
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/canvasrenderingcontext2d/textbaseline/index.md
+++ b/files/ja/web/api/canvasrenderingcontext2d/textbaseline/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.textBaseline
 slug: Web/API/CanvasRenderingContext2D/textBaseline
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - プロパティ
-  - リファレンス
-browser-compat: api.CanvasRenderingContext2D.textBaseline
-translation_of: Web/API/CanvasRenderingContext2D/textBaseline
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/caretposition/index.md
+++ b/files/ja/web/api/caretposition/index.md
@@ -1,13 +1,6 @@
 ---
 title: CaretPosition
 slug: Web/API/CaretPosition
-tags:
-  - API
-  - CSSOM View
-  - Experimental
-  - Interface
-  - Reference
-translation_of: Web/API/CaretPosition
 ---
 {{SeeCompatTable}} {{ APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cdatasection/index.md
+++ b/files/ja/web/api/cdatasection/index.md
@@ -1,11 +1,6 @@
 ---
 title: CDATASection
 slug: Web/API/CDATASection
-tags:
-  - API
-  - DOM
-  - Deprecated
-translation_of: Web/API/CDATASection
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/channel_messaging_api/index.md
+++ b/files/ja/web/api/channel_messaging_api/index.md
@@ -1,13 +1,6 @@
 ---
 title: チャンネルメッセージング API
 slug: Web/API/Channel_Messaging_API
-tags:
-  - API
-  - チャンネルメッセージング
-  - HTML API
-  - 概要
-  - リファレンス
-translation_of: Web/API/Channel_Messaging_API
 ---
 {{DefaultAPISidebar("Channel Messaging API")}}
 

--- a/files/ja/web/api/channel_messaging_api/using_channel_messaging/index.md
+++ b/files/ja/web/api/channel_messaging_api/using_channel_messaging/index.md
@@ -1,14 +1,6 @@
 ---
 title: チャンネルメッセージングの使用
 slug: Web/API/Channel_Messaging_API/Using_channel_messaging
-tags:
-  - API
-  - チャンネルメッセージング
-  - HTML5
-  - MessageChannel
-  - MessagePort
-  - チュートリアル
-translation_of: Web/API/Channel_Messaging_API/Using_channel_messaging
 ---
 {{DefaultAPISidebar("Channel Messaging API")}}
 

--- a/files/ja/web/api/channelmergernode/index.md
+++ b/files/ja/web/api/channelmergernode/index.md
@@ -1,15 +1,6 @@
 ---
 title: ChannelMergerNode
 slug: Web/API/ChannelMergerNode
-page-type: web-api-interface
-tags:
-  - API
-  - ChannelMergerNode
-  - Interface
-  - Reference
-  - Web Audio API
-browser-compat: api.ChannelMergerNode
-translation_of: Web/API/ChannelMergerNode
 ---
 
 {{APIRef("Web Audio API")}}

--- a/files/ja/web/api/characterdata/after/index.md
+++ b/files/ja/web/api/characterdata/after/index.md
@@ -1,11 +1,6 @@
 ---
 title: CharacterData.after()
 slug: Web/API/CharacterData/after
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.CharacterData.after
-translation_of: Web/API/CharacterData/after
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/characterdata/appenddata/index.md
+++ b/files/ja/web/api/characterdata/appenddata/index.md
@@ -1,11 +1,6 @@
 ---
 title: CharacterData.appendData()
 slug: Web/API/CharacterData/appendData
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.CharacterData.appendData
-translation_of: Web/API/CharacterData/appendData
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/characterdata/before/index.md
+++ b/files/ja/web/api/characterdata/before/index.md
@@ -1,11 +1,6 @@
 ---
 title: CharacterData.before()
 slug: Web/API/CharacterData/before
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.CharacterData.before
-translation_of: Web/API/CharacterData/before
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/characterdata/data/index.md
+++ b/files/ja/web/api/characterdata/data/index.md
@@ -1,11 +1,6 @@
 ---
 title: CharacterData.data
 slug: Web/API/CharacterData/data
-tags:
-  - プロパティ
-  - リファレンス
-browser-compat: api.CharacterData.data
-translation_of: Web/API/CharacterData/data
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/characterdata/deletedata/index.md
+++ b/files/ja/web/api/characterdata/deletedata/index.md
@@ -1,11 +1,6 @@
 ---
 title: CharacterData.deleteData()
 slug: Web/API/CharacterData/deleteData
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.CharacterData.deleteData
-translation_of: Web/API/CharacterData/deleteData
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/characterdata/index.md
+++ b/files/ja/web/api/characterdata/index.md
@@ -1,11 +1,6 @@
 ---
 title: CharacterData
 slug: Web/API/CharacterData
-tags:
-  - インターフェイス
-  - リファレンス
-browser-compat: api.CharacterData
-translation_of: Web/API/CharacterData
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/characterdata/insertdata/index.md
+++ b/files/ja/web/api/characterdata/insertdata/index.md
@@ -1,11 +1,6 @@
 ---
 title: CharacterData.insertData()
 slug: Web/API/CharacterData/insertData
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.CharacterData.insertData
-translation_of: Web/API/CharacterData/insertData
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/characterdata/length/index.md
+++ b/files/ja/web/api/characterdata/length/index.md
@@ -1,12 +1,6 @@
 ---
 title: CharacterData.length
 slug: Web/API/CharacterData/length
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.CharacterData.length
-translation_of: Web/API/CharacterData/length
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/characterdata/nextelementsibling/index.md
+++ b/files/ja/web/api/characterdata/nextelementsibling/index.md
@@ -1,12 +1,6 @@
 ---
 title: CharacterData.nextElementSibling
 slug: Web/API/CharacterData/nextElementSibling
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.CharacterData.nextElementSibling
-translation_of: Web/API/CharacterData/nextElementSibling
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/characterdata/previouselementsibling/index.md
+++ b/files/ja/web/api/characterdata/previouselementsibling/index.md
@@ -1,12 +1,6 @@
 ---
 title: CharacterData.previousElementSibling
 slug: Web/API/CharacterData/previousElementSibling
-tags:
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.Element.previousElementSibling
-translation_of: Web/API/CharacterData/previousElementSibling
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/characterdata/remove/index.md
+++ b/files/ja/web/api/characterdata/remove/index.md
@@ -1,11 +1,6 @@
 ---
 title: CharacterData.remove()
 slug: Web/API/CharacterData/remove
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.CharacterData.remove
-translation_of: Web/API/CharacterData/remove
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/characterdata/replacedata/index.md
+++ b/files/ja/web/api/characterdata/replacedata/index.md
@@ -1,11 +1,6 @@
 ---
 title: CharacterData.replaceData()
 slug: Web/API/CharacterData/replaceData
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.CharacterData.replaceData
-translation_of: Web/API/CharacterData/replaceData
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/characterdata/replacewith/index.md
+++ b/files/ja/web/api/characterdata/replacewith/index.md
@@ -1,14 +1,6 @@
 ---
 title: CharacterData.replaceWith()
 slug: Web/API/CharacterData/replaceWith
-tags:
-  - API
-  - DOM
-  - メソッド
-  - CharacterData
-  - リファレンス
-browser-compat: api.CharacterData.replaceWith
-translation_of: Web/API/CharacterData/replaceWith
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/characterdata/substringdata/index.md
+++ b/files/ja/web/api/characterdata/substringdata/index.md
@@ -1,11 +1,6 @@
 ---
 title: CharacterData.substringData()
 slug: Web/API/CharacterData/substringData
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.CharacterData.substringData
-translation_of: Web/API/CharacterData/substringData
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/clearinterval/index.md
+++ b/files/ja/web/api/clearinterval/index.md
@@ -1,15 +1,6 @@
 ---
 title: clearInterval()
 slug: Web/API/clearInterval
-tags:
-  - API
-  - HTML DOM
-  - JavaScript タイマー
-  - メソッド
-  - リファレンス
-  - clearInterval
-browser-compat: api.clearInterval
-translation_of: Web/API/WindowOrWorkerGlobalScope/clearInterval
 original_slug: Web/API/WindowOrWorkerGlobalScope/clearInterval
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/web/api/cleartimeout/index.md
+++ b/files/ja/web/api/cleartimeout/index.md
@@ -1,14 +1,6 @@
 ---
 title: clearTimeout()
 slug: Web/API/clearTimeout
-tags:
-  - API
-  - HTML DOM
-  - メソッド
-  - リファレンス
-  - clearTimeout
-browser-compat: api.clearTimeout
-translation_of: Web/API/clearTimeout
 original_slug: Web/API/WindowOrWorkerGlobalScope/clearTimeout
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/web/api/client/frametype/index.md
+++ b/files/ja/web/api/client/frametype/index.md
@@ -1,15 +1,6 @@
 ---
 title: Client.frameType
 slug: Web/API/Client/frameType
-tags:
-  - API
-  - Client
-  - Property
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - frameType
-translation_of: Web/API/Client/frameType
 ---
 {{SeeCompatTable}}{{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/client/id/index.md
+++ b/files/ja/web/api/client/id/index.md
@@ -1,15 +1,6 @@
 ---
 title: Client.id
 slug: Web/API/Client/id
-tags:
-  - API
-  - Client
-  - Property
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - id
-translation_of: Web/API/Client/id
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/client/index.md
+++ b/files/ja/web/api/client/index.md
@@ -1,16 +1,6 @@
 ---
 title: Client
 slug: Web/API/Client
-tags:
-  - API
-  - Client
-  - Interface
-  - Reference
-  - Service Workers
-  - Service worker API
-  - ServiceWorkerClient
-  - ServiceWorkers
-translation_of: Web/API/Client
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/client/postmessage/index.md
+++ b/files/ja/web/api/client/postmessage/index.md
@@ -1,16 +1,6 @@
 ---
 title: Client.postMessage()
 slug: Web/API/Client/postMessage
-tags:
-  - API
-  - Client
-  - Method
-  - Reference
-  - Service Workers
-  - Service worker API
-  - ServiceWorker
-  - postMessage
-translation_of: Web/API/Client/postMessage
 ---
 {{APIRef("Service Worker API")}}
 

--- a/files/ja/web/api/client/type/index.md
+++ b/files/ja/web/api/client/type/index.md
@@ -1,14 +1,6 @@
 ---
 title: Client.type
 slug: Web/API/Client/type
-tags:
-  - API
-  - Client
-  - Property
-  - Reference
-  - Service Workers
-  - Type
-translation_of: Web/API/Client/type
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/client/url/index.md
+++ b/files/ja/web/api/client/url/index.md
@@ -1,14 +1,6 @@
 ---
 title: Client.url
 slug: Web/API/Client/url
-tags:
-  - API
-  - Client
-  - Property
-  - Reference
-  - Service Workers
-  - URL
-translation_of: Web/API/Client/url
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/clients/claim/index.md
+++ b/files/ja/web/api/clients/claim/index.md
@@ -1,15 +1,6 @@
 ---
 title: Clients.claim()
 slug: Web/API/Clients/claim
-tags:
-  - API
-  - Clients
-  - Method
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - claim
-translation_of: Web/API/Clients/claim
 ---
 {{APIRef("Service Worker Clients")}}
 

--- a/files/ja/web/api/clients/get/index.md
+++ b/files/ja/web/api/clients/get/index.md
@@ -1,14 +1,6 @@
 ---
 title: Clients.get()
 slug: Web/API/Clients/get
-tags:
-  - API
-  - Clients
-  - Method
-  - Reference
-  - Service Workers
-  - get
-translation_of: Web/API/Clients/get
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/clients/index.md
+++ b/files/ja/web/api/clients/index.md
@@ -1,16 +1,6 @@
 ---
 title: Clients
 slug: Web/API/Clients
-tags:
-  - API
-  - Clients
-  - Interface
-  - Reference
-  - Service Workers
-  - Service worker API
-  - ServiceWorker
-  - Workers
-translation_of: Web/API/Clients
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/clients/matchall/index.md
+++ b/files/ja/web/api/clients/matchall/index.md
@@ -1,14 +1,6 @@
 ---
 title: Clients.matchAll()
 slug: Web/API/Clients/matchAll
-tags:
-  - API
-  - Clients
-  - Method
-  - Reference
-  - Service Workers
-  - ServiceWorker
-translation_of: Web/API/Clients/matchAll
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/clients/openwindow/index.md
+++ b/files/ja/web/api/clients/openwindow/index.md
@@ -1,15 +1,6 @@
 ---
 title: Clients.openWindow()
 slug: Web/API/Clients/openWindow
-tags:
-  - API
-  - Clients
-  - Method
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - openWindow
-translation_of: Web/API/Clients/openWindow
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/clipboard/index.md
+++ b/files/ja/web/api/clipboard/index.md
@@ -1,21 +1,6 @@
 ---
 title: Clipboard
 slug: Web/API/Clipboard
-page-type: web-api-interface
-tags:
-  - API
-  - Clip
-  - Clipboard
-  - Clipboard API
-  - Cut
-  - Editing
-  - Interface
-  - Pasteboard
-  - Reference
-  - copy
-  - paste
-browser-compat: api.Clipboard
-translation_of: Web/API/Clipboard
 ---
 {{APIRef("Clipboard API")}} {{SecureContext_Header}}
 

--- a/files/ja/web/api/clipboard/read/index.md
+++ b/files/ja/web/api/clipboard/read/index.md
@@ -1,23 +1,6 @@
 ---
 title: Clipboard.read()
 slug: Web/API/Clipboard/read
-page-type: web-api-instance-method
-tags:
-  - API
-  - Clip
-  - Clipboard
-  - Clipboard API
-  - Cut
-  - Editing
-  - Method
-  - Reference
-  - Scrap
-  - Text
-  - copy
-  - paste
-  - read
-browser-compat: api.Clipboard.read
-translation_of: Web/API/Clipboard/read
 ---
 {{APIRef("Clipboard API")}}
 

--- a/files/ja/web/api/clipboard/readtext/index.md
+++ b/files/ja/web/api/clipboard/readtext/index.md
@@ -1,24 +1,6 @@
 ---
 title: Clipboard.readText()
 slug: Web/API/Clipboard/readText
-page-type: web-api-instance-method
-tags:
-  - API
-  - Async Clipboard API
-  - Clip
-  - Clipboard
-  - Clipboard API
-  - Cut
-  - Editing
-  - Method
-  - Pasteboard
-  - Reference
-  - Text
-  - copy
-  - paste
-  - readText
-browser-compat: api.Clipboard.readText
-translation_of: Web/API/Clipboard/readText
 ---
 {{APIRef("Clipboard API")}}
 

--- a/files/ja/web/api/clipboard/write/index.md
+++ b/files/ja/web/api/clipboard/write/index.md
@@ -1,22 +1,6 @@
 ---
 title: Clipboard.write()
 slug: Web/API/Clipboard/write
-page-type: web-api-instance-method
-tags:
-  - API
-  - Clip
-  - Clipboard
-  - Clipboard API
-  - Cut
-  - Method
-  - Pasteboard
-  - Reference
-  - Scrap
-  - copy
-  - paste
-  - write
-translation_of: Web/API/Clipboard/write
-browser-compat: api.Clipboard.write
 ---
 {{APIRef("Clipboard API")}}
 

--- a/files/ja/web/api/clipboard/writetext/index.md
+++ b/files/ja/web/api/clipboard/writetext/index.md
@@ -1,22 +1,6 @@
 ---
 title: Clipboard.writeText()
 slug: Web/API/Clipboard/writeText
-page-type: web-api-instance-method
-tags:
-  - API
-  - Clip
-  - Clipboard
-  - Clipboard API
-  - Cut
-  - Method
-  - Pasteboard
-  - Reference
-  - Scrap
-  - copy
-  - paste
-  - writeText
-browser-compat: api.Clipboard.writeText
-translation_of: Web/API/Clipboard/writeText
 ---
 {{APIRef("Clipboard API")}}
 

--- a/files/ja/web/api/clipboard_api/index.md
+++ b/files/ja/web/api/clipboard_api/index.md
@@ -1,25 +1,6 @@
 ---
 title: クリップボード API
 slug: Web/API/Clipboard_API
-page-type: web-api-overview
-tags:
-  - API
-  - Async Clipboard API
-  - Clipboard
-  - Clipboard API
-  - Clipboard Event API
-  - ClipboardEvent
-  - ClipboardItem
-  - Cut
-  - Landing
-  - Reference
-  - copy
-  - paste
-browser-compat:
-  - api.Clipboard
-  - api.ClipboardEvent
-  - api.ClipboardItem
-translation_of: Web/API/Clipboard_API
 ---
 {{DefaultAPISidebar("Clipboard API")}}
 

--- a/files/ja/web/api/clipboardevent/clipboarddata/index.md
+++ b/files/ja/web/api/clipboardevent/clipboarddata/index.md
@@ -1,19 +1,6 @@
 ---
 title: ClipboardEvent.clipboardData
 slug: Web/API/ClipboardEvent/clipboardData
-page-type: web-api-instance-property
-tags:
-  - API
-  - Clipboard
-  - Clipboard API
-  - ClipboardEvent
-  - Cut
-  - Property
-  - Read-only
-  - copy
-  - paste
-browser-compat: api.ClipboardEvent.clipboardData
-translation_of: Web/API/ClipboardEvent/clipboardData
 ---
 {{APIRef("Clipboard API")}}
 

--- a/files/ja/web/api/clipboardevent/clipboardevent/index.md
+++ b/files/ja/web/api/clipboardevent/clipboardevent/index.md
@@ -1,19 +1,6 @@
 ---
 title: ClipboardEvent()
 slug: Web/API/ClipboardEvent/ClipboardEvent
-page-type: web-api-constructor
-tags:
-  - API
-  - Clipboard
-  - Clipboard API
-  - ClipboardEvent
-  - Constructor
-  - Cut
-  - Reference
-  - copy
-  - paste
-browser-compat: api.ClipboardEvent.ClipboardEvent
-translation_of: Web/API/ClipboardEvent/ClipboardEvent
 ---
 {{APIRef("Clipboard API")}}
 

--- a/files/ja/web/api/clipboardevent/index.md
+++ b/files/ja/web/api/clipboardevent/index.md
@@ -1,18 +1,6 @@
 ---
 title: ClipboardEvent
 slug: Web/API/ClipboardEvent
-page-type: web-api-interface
-tags:
-  - API
-  - Clipboard
-  - Clipboard API
-  - Cut
-  - Event
-  - Interface
-  - copy
-  - paste
-browser-compat: api.ClipboardEvent
-translation_of: Web/API/ClipboardEvent
 ---
 {{APIRef("Clipboard API")}}
 

--- a/files/ja/web/api/clipboarditem/clipboarditem/index.md
+++ b/files/ja/web/api/clipboarditem/clipboarditem/index.md
@@ -1,19 +1,6 @@
 ---
 title: ClipboardItem()
 slug: Web/API/ClipboardItem/ClipboardItem
-page-type: web-api-instance-property
-tags:
-  - API
-  - Clipboard
-  - Clipboard API
-  - ClipboardItem
-  - Constructor
-  - Cut
-  - Reference
-  - copy
-  - paste
-browser-compat: api.ClipboardItem.ClipboardItem
-translation_of: Web/API/ClipboardItem/ClipboardItem
 ---
 {{DefaultAPISidebar("Clipboard API")}}
 

--- a/files/ja/web/api/clipboarditem/gettype/index.md
+++ b/files/ja/web/api/clipboarditem/gettype/index.md
@@ -1,18 +1,6 @@
 ---
 title: ClipboardItem.getType()
 slug: Web/API/ClipboardItem/getType
-page-type: web-api-instance-method
-tags:
-  - Clipboard
-  - Clipboard API
-  - ClipboardItem
-  - Cut
-  - Method
-  - copy
-  - getTypes
-  - paste
-browser-compat: api.ClipboardItem.getType
-translation_of: Web/API/ClipboardItem/getType
 ---
 {{DefaultAPISidebar("Clipboard API")}}
 

--- a/files/ja/web/api/clipboarditem/index.md
+++ b/files/ja/web/api/clipboarditem/index.md
@@ -1,19 +1,6 @@
 ---
 title: ClipboardItem
 slug: Web/API/ClipboardItem
-page-type: web-api-interface
-tags:
-  - API
-  - Clipboard
-  - Clipboard API
-  - ClipboardItem
-  - Cut
-  - Interface
-  - Reference
-  - copy
-  - paste
-browser-compat: api.ClipboardItem
-translation_of: Web/API/ClipboardItem
 ---
 {{DefaultAPISidebar("Clipboard API")}}
 

--- a/files/ja/web/api/clipboarditem/presentationstyle/index.md
+++ b/files/ja/web/api/clipboarditem/presentationstyle/index.md
@@ -1,21 +1,6 @@
 ---
 title: ClipboardItem.presentationStyle
 slug: Web/API/ClipboardItem/presentationStyle
-page-type: web-api-instance-property
-tags:
-  - API
-  - Clipboard
-  - Clipboard API
-  - ClipboardItem
-  - Cut
-  - Property
-  - Read-only
-  - Reference
-  - presentationStyle
-  - copy
-  - paste
-browser-compat: api.ClipboardItem.presentationStyle
-translation_of: Web/API/ClipboardItem/presentationStyle
 ---
 {{DefaultAPISidebar("Clipboard API")}}
 

--- a/files/ja/web/api/clipboarditem/types/index.md
+++ b/files/ja/web/api/clipboarditem/types/index.md
@@ -1,21 +1,6 @@
 ---
 title: ClipboardItem.types
 slug: Web/API/ClipboardItem/types
-page-type: web-api-instance-property
-tags:
-  - API
-  - Clipboard
-  - Clipboard API
-  - ClipboardItem
-  - Cut
-  - Property
-  - Read-only
-  - Reference
-  - Types
-  - copy
-  - paste
-browser-compat: api.ClipboardItem.types
-translation_of: Web/API/ClipboardItem/types
 ---
 {{DefaultAPISidebar("Clipboard API")}}
 

--- a/files/ja/web/api/closeevent/closeevent/index.md
+++ b/files/ja/web/api/closeevent/closeevent/index.md
@@ -1,13 +1,6 @@
 ---
 title: CloseEvent()
 slug: Web/API/CloseEvent/CloseEvent
-tags:
-  - API
-  - CloseEvent
-  - コンストラクター
-  - リファレンス
-browser-compat: api.CloseEvent.CloseEvent
-translation_of: Web/API/CloseEvent/CloseEvent
 ---
 {{APIRef("Websockets API")}}
 

--- a/files/ja/web/api/closeevent/code/index.md
+++ b/files/ja/web/api/closeevent/code/index.md
@@ -1,13 +1,6 @@
 ---
 title: CloseEvent.code
 slug: Web/API/CloseEvent/code
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - closeEvent
-browser-compat: api.CloseEvent.code
-translation_of: Web/API/CloseEvent/code
 ---
 {{APIRef("Websockets API")}}
 

--- a/files/ja/web/api/closeevent/index.md
+++ b/files/ja/web/api/closeevent/index.md
@@ -1,15 +1,6 @@
 ---
 title: CloseEvent
 slug: Web/API/CloseEvent
-tags:
-  - API
-  - インターフェース
-  - リファレンス
-  - Web
-  - WebSocket
-  - WebSockets
-browser-compat: api.CloseEvent
-translation_of: Web/API/CloseEvent
 ---
 {{APIRef("Websockets API")}}
 

--- a/files/ja/web/api/closeevent/reason/index.md
+++ b/files/ja/web/api/closeevent/reason/index.md
@@ -1,13 +1,6 @@
 ---
 title: CloseEvent.reason
 slug: Web/API/CloseEvent/reason
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - closeEvent
-browser-compat: api.CloseEvent.reason
-translation_of: Web/API/CloseEvent/reason
 ---
 {{APIRef("Websockets API")}}
 

--- a/files/ja/web/api/closeevent/wasclean/index.md
+++ b/files/ja/web/api/closeevent/wasclean/index.md
@@ -1,13 +1,6 @@
 ---
 title: CloseEvent.wasClean
 slug: Web/API/CloseEvent/wasClean
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - closeEvent
-browser-compat: api.CloseEvent.wasClean
-translation_of: Web/API/CloseEvent/wasClean
 ---
 {{APIRef("Websockets API")}}
 

--- a/files/ja/web/api/comment/index.md
+++ b/files/ja/web/api/comment/index.md
@@ -1,10 +1,6 @@
 ---
 title: Comment
 slug: Web/API/Comment
-tags:
-  - API
-  - DOM
-translation_of: Web/API/Comment
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/compositionevent/compositionevent/index.md
+++ b/files/ja/web/api/compositionevent/compositionevent/index.md
@@ -1,12 +1,6 @@
 ---
 title: CompositionEvent.CompositionEvent()
 slug: Web/API/CompositionEvent/CompositionEvent
-tags:
-  - API
-  - CompositionEvent
-  - Constructor
-  - Reference
-translation_of: Web/API/CompositionEvent/CompositionEvent
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/compositionevent/index.md
+++ b/files/ja/web/api/compositionevent/index.md
@@ -1,13 +1,6 @@
 ---
 title: CompositionEvent
 slug: Web/API/CompositionEvent
-tags:
-  - API
-  - CompositionEvent
-  - DOM
-  - Event
-  - Reference
-translation_of: Web/API/CompositionEvent
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/compositionevent/initcompositionevent/index.md
+++ b/files/ja/web/api/compositionevent/initcompositionevent/index.md
@@ -1,14 +1,6 @@
 ---
 title: CompositionEvent.initCompositionEvent()
 slug: Web/API/CompositionEvent/initCompositionEvent
-tags:
-  - API
-  - CompositionEvent
-  - Deprecated
-  - Method
-  - Reference
-  - initCompositionEvent
-translation_of: Web/API/CompositionEvent/initCompositionEvent
 ---
 {{deprecated_header}}{{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/compositionevent/locale/index.md
+++ b/files/ja/web/api/compositionevent/locale/index.md
@@ -1,15 +1,6 @@
 ---
 title: CompositionEvent.locale
 slug: Web/API/CompositionEvent/locale
-tags:
-  - API
-  - CompositionEvent
-  - Deprecated
-  - Locale
-  - Property
-  - Reference
-  - プロパティ
-translation_of: Web/API/CompositionEvent/locale
 ---
 {{deprecated_header}}{{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/console_api/index.md
+++ b/files/ja/web/api/console_api/index.md
@@ -1,16 +1,6 @@
 ---
 title: Console API
 slug: Web/API/Console_API
-tags:
-  - API
-  - Debugging
-  - Overview
-  - console
-  - dump
-  - log
-  - output
-  - test
-translation_of: Web/API/Console_API
 ---
 {{DefaultAPISidebar("Console API")}}
 

--- a/files/ja/web/api/constraint_validation/index.md
+++ b/files/ja/web/api/constraint_validation/index.md
@@ -1,11 +1,6 @@
 ---
 title: 制約検証 API
 slug: Web/API/Constraint_validation
-tags:
-  - API
-  - Constraint validation
-  - Landing
-  - Reference
 ---
 {{apiref()}}
 

--- a/files/ja/web/api/convolvernode/index.md
+++ b/files/ja/web/api/convolvernode/index.md
@@ -1,15 +1,6 @@
 ---
 title: ConvolverNode
 slug: Web/API/ConvolverNode
-page-type: web-api-interface
-tags:
-  - API
-  - ConvolverNode
-  - Interface
-  - Reference
-  - Web Audio API
-browser-compat: api.ConvolverNode
-translation_of: Web/API/ConvolverNode
 ---
 {{APIRef("Web Audio API")}}
 

--- a/files/ja/web/api/cookiestore/change_event/index.md
+++ b/files/ja/web/api/cookiestore/change_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'CookieStore: change event'
 slug: Web/API/CookieStore/change_event
-tags:
-  - API
-  - Reference
-  - Event
-  - change
-  - onchange
-  - CookieStore
-browser-compat: api.CookieStore.change_event
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Cookie Store API")}}
 

--- a/files/ja/web/api/cookiestore/delete/index.md
+++ b/files/ja/web/api/cookiestore/delete/index.md
@@ -1,13 +1,6 @@
 ---
 title: CookieStore.delete()
 slug: Web/API/CookieStore/delete
-tags:
-  - API
-  - Method
-  - Reference
-  - delete()
-  - CookieStore
-browser-compat: api.CookieStore.delete
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Cookie Store API")}}
 

--- a/files/ja/web/api/cookiestore/get/index.md
+++ b/files/ja/web/api/cookiestore/get/index.md
@@ -1,13 +1,6 @@
 ---
 title: CookieStore.get()
 slug: Web/API/CookieStore/get
-tags:
-  - API
-  - Method
-  - Reference
-  - get()
-  - CookieStore
-browser-compat: api.CookieStore.get
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Cookie Store API")}}
 

--- a/files/ja/web/api/cookiestore/getall/index.md
+++ b/files/ja/web/api/cookiestore/getall/index.md
@@ -1,13 +1,6 @@
 ---
 title: CookieStore.getAll()
 slug: Web/API/CookieStore/getAll
-tags:
-  - API
-  - Method
-  - Reference
-  - getAll()
-  - CookieStore
-browser-compat: api.CookieStore.getAll
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Cookie Store API")}}
 

--- a/files/ja/web/api/cookiestore/index.md
+++ b/files/ja/web/api/cookiestore/index.md
@@ -1,12 +1,6 @@
 ---
 title: CookieStore
 slug: Web/API/CookieStore
-tags:
-  - API
-  - Interface
-  - Reference
-  - CookieStore
-browser-compat: api.CookieStore
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Cookie Store API")}}
 

--- a/files/ja/web/api/cookiestore/set/index.md
+++ b/files/ja/web/api/cookiestore/set/index.md
@@ -1,13 +1,6 @@
 ---
 title: CookieStore.set()
 slug: Web/API/CookieStore/set
-tags:
-  - API
-  - Method
-  - Reference
-  - set()
-  - CookieStore
-browser-compat: api.CookieStore.set
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Cookie Store API")}}
 

--- a/files/ja/web/api/countqueuingstrategy/countqueuingstrategy/index.md
+++ b/files/ja/web/api/countqueuingstrategy/countqueuingstrategy/index.md
@@ -1,14 +1,6 @@
 ---
 title: CountQueuingStrategy.CountQueuingStrategy()
 slug: Web/API/CountQueuingStrategy/CountQueuingStrategy
-tags:
-  - API
-  - Constructor
-  - CountQueuingStrategy
-  - Experimental
-  - Reference
-  - Streams
-translation_of: Web/API/CountQueuingStrategy/CountQueuingStrategy
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/countqueuingstrategy/index.md
+++ b/files/ja/web/api/countqueuingstrategy/index.md
@@ -1,14 +1,6 @@
 ---
 title: CountQueuingStrategy
 slug: Web/API/CountQueuingStrategy
-tags:
-  - API
-  - CountQueuingStrategy
-  - Experimental
-  - Interface
-  - Reference
-  - Streams
-translation_of: Web/API/CountQueuingStrategy
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/countqueuingstrategy/size/index.md
+++ b/files/ja/web/api/countqueuingstrategy/size/index.md
@@ -1,15 +1,6 @@
 ---
 title: CountQueuingStrategy.size()
 slug: Web/API/CountQueuingStrategy/size
-tags:
-  - API
-  - CountQueuingStrategy
-  - Experimental
-  - Method
-  - Reference
-  - Streams
-  - size
-translation_of: Web/API/CountQueuingStrategy/size
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/createimagebitmap/index.md
+++ b/files/ja/web/api/createimagebitmap/index.md
@@ -1,12 +1,6 @@
 ---
 title: self.createImageBitmap()
 slug: Web/API/createImageBitmap
-tags:
-  - API
-  - Canvas
-  - DOM
-  - createImageBitmap
-translation_of: Web/API/WindowOrWorkerGlobalScope/createImageBitmap
 original_slug: Web/API/WindowOrWorkerGlobalScope/createImageBitmap
 ---
 {{APIRef("Canvas API")}}

--- a/files/ja/web/api/credential/index.md
+++ b/files/ja/web/api/credential/index.md
@@ -1,16 +1,6 @@
 ---
 title: Credential
 slug: Web/API/Credential
-tags:
-  - API
-  - Credential Management API
-  - Experimental
-  - Interface
-  - NeedsExample
-  - Reference
-  - credential management
-  - インターフェイス
-translation_of: Web/API/Credential
 ---
 {{SeeCompatTable}}{{APIRef("Credential Management API")}}{{securecontext_header}}
 

--- a/files/ja/web/api/credential_management_api/index.md
+++ b/files/ja/web/api/credential_management_api/index.md
@@ -1,17 +1,6 @@
 ---
 title: 認証情報管理 API
 slug: Web/API/Credential_Management_API
-tags:
-  - API
-  - Credential Management API
-  - Landing
-  - NeedsContent
-  - Overview
-  - Reference
-  - credential management
-  - 認証情報
-  - 認証情報管理
-translation_of: Web/API/Credential_Management_API
 ---
 {{DefaultAPISidebar("Credential Management API")}}{{ SeeCompatTable() }}
 

--- a/files/ja/web/api/credentialscontainer/create/index.md
+++ b/files/ja/web/api/credentialscontainer/create/index.md
@@ -1,14 +1,6 @@
 ---
 title: PublicKeyCredentialCreationOptions.authenticatorSelection
 slug: Web/API/CredentialsContainer/create
-tags:
-  - API
-  - Property
-  - PublicKeyCredentialCreationOptions
-  - Reference
-  - Web Authentication API
-  - WebAuthn
-translation_of: Web/API/PublicKeyCredentialCreationOptions/authenticatorSelection
 original_slug: Web/API/PublicKeyCredentialCreationOptions/authenticatorSelection
 ---
 {{APIRef("Web Authentication API")}}{{securecontext_header}}

--- a/files/ja/web/api/crypto/getrandomvalues/index.md
+++ b/files/ja/web/api/crypto/getrandomvalues/index.md
@@ -1,22 +1,6 @@
 ---
 title: Crypto.getRandomValues()
 slug: Web/API/Crypto/getRandomValues
-tags:
-  - API
-  - Crypto
-  - Cryptography
-  - Encryption
-  - Integers
-  - メソッド
-  - Numbers
-  - Pseudorandom
-  - 擬似乱数
-  - 乱数
-  - リファレンス
-  - ウェブ暗号化 API
-  - getRandomValues
-browser-compat: api.Crypto.getRandomValues
-translation_of: Web/API/Crypto/getRandomValues
 ---
 {{APIRef("Web Crypto API")}}
 

--- a/files/ja/web/api/crypto/index.md
+++ b/files/ja/web/api/crypto/index.md
@@ -1,12 +1,6 @@
 ---
 title: Crypto
 slug: Web/API/Crypto
-tags:
-  - API
-  - Interface
-  - Reference
-  - Web Crypt API
-translation_of: Web/API/Crypto
 ---
 {{APIRef("Web Crypto API")}}
 

--- a/files/ja/web/api/crypto/subtle/index.md
+++ b/files/ja/web/api/crypto/subtle/index.md
@@ -1,14 +1,6 @@
 ---
 title: Crypto.subtle
 slug: Web/API/Crypto/subtle
-tags:
-  - API
-  - Cryptgraphy
-  - Property
-  - Read-only
-  - Reference
-  - Web Crypt API
-translation_of: Web/API/Crypto/subtle
 ---
 {{APIRef("Web Crypto API")}}
 

--- a/files/ja/web/api/crypto_property/index.md
+++ b/files/ja/web/api/crypto_property/index.md
@@ -1,19 +1,6 @@
 ---
 title: self.crypto
 slug: Web/API/crypto_property
-tags:
-  - API
-  - Crypto
-  - 暗号技術
-  - エンコーディング
-  - 暗号化
-  - HTML DOM
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - セキュリティ
-browser-compat: api.crypto
-translation_of: Web/API/Window/crypto
 original_slug: Web/API/Window/crypto
 ---
 {{APIRef}}

--- a/files/ja/web/api/cryptokey/index.md
+++ b/files/ja/web/api/cryptokey/index.md
@@ -1,12 +1,6 @@
 ---
 title: CryptoKey
 slug: Web/API/CryptoKey
-tags:
-  - API
-  - Interface
-  - Reference
-  - Web Crypto API
-translation_of: Web/API/CryptoKey
 ---
 {{APIRef("Web Crypto API")}}
 

--- a/files/ja/web/api/css/escape/index.md
+++ b/files/ja/web/api/css/escape/index.md
@@ -1,16 +1,6 @@
 ---
 title: CSS.escape()
 slug: Web/API/CSS/escape
-tags:
-  - API
-  - CSS
-  - CSSOM
-  - メソッド
-  - リファレンス
-  - Static
-  - escape()
-browser-compat: api.CSS.escape
-translation_of: Web/API/CSS/escape
 ---
 {{APIRef("CSSOM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/css/factory_functions/index.md
+++ b/files/ja/web/api/css/factory_functions/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSS 数値ファクトリー関数
 slug: Web/API/CSS/factory_functions
-tags:
-  - API
-  - CSS
-  - CSS API
-  - Houdini
-  - リファレンス
-  - ファクトリー関数
-translation_of: Web/API/CSS/factory_functions
 ---
 {{SeeCompatTable}}
 

--- a/files/ja/web/api/css/index.md
+++ b/files/ja/web/api/css/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS
 slug: Web/API/CSS
-tags:
-  - API
-  - CSSOM
-  - Interface
-  - Painting
-  - リファレンス
-translation_of: Web/API/CSS
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/css/paintworklet/index.md
+++ b/files/ja/web/api/css/paintworklet/index.md
@@ -1,19 +1,6 @@
 ---
 title: CSS.paintWorklet (静的プロパティ)
 slug: Web/API/CSS/paintWorklet
-tags:
-  - API
-  - CSS
-  - CSS 描画 API
-  - 実験的
-  - Houdini
-  - 描画
-  - プロパティ
-  - リファレンス
-  - ワークレット
-  - paintWorklet
-browser-compat: api.CSS.paintWorklet
-translation_of: Web/API/CSS/paintWorklet
 ---
 {{APIRef("CSSOM")}}{{SeeCompatTable}}{{SecureContext_Header}}
 

--- a/files/ja/web/api/css/registerproperty/index.md
+++ b/files/ja/web/api/css/registerproperty/index.md
@@ -1,12 +1,6 @@
 ---
 title: CSS.registerProperty()
 slug: Web/API/CSS/RegisterProperty
-tags:
-  - CSS
-  - Houdini
-  - リファレンス
-browser-compat: api.CSS.registerProperty
-translation_of: Web/API/CSS/RegisterProperty
 ---
 {{SeeCompatTable}}
 

--- a/files/ja/web/api/css/supports/index.md
+++ b/files/ja/web/api/css/supports/index.md
@@ -1,15 +1,6 @@
 ---
 title: CSS.supports()
 slug: Web/API/CSS/supports
-tags:
-  - API
-  - CSS
-  - CSSOM
-  - メソッド
-  - リファレンス
-  - supports
-browser-compat: api.CSS.supports
-translation_of: Web/API/CSS/supports
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/css_font_loading_api/index.md
+++ b/files/ja/web/api/css_font_loading_api/index.md
@@ -1,16 +1,6 @@
 ---
 title: CSS Font Loading API
 slug: Web/API/CSS_Font_Loading_API
-tags:
-  - API
-  - CSSFontLoading
-  - CSSOM
-  - Experimental
-  - Fonts
-  - NeedsContent
-  - Reference
-  - フォント
-translation_of: Web/API/CSS_Font_Loading_API
 ---
 {{DefaultAPISidebar("CSS Font Loading API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/css_object_model/determining_the_dimensions_of_elements/index.md
+++ b/files/ja/web/api/css_object_model/determining_the_dimensions_of_elements/index.md
@@ -1,17 +1,6 @@
 ---
 title: 要素の寸法の決定
 slug: Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements
-tags:
-  - API
-  - CSSOM View
-  - Client width
-  - Guide
-  - Intermediate
-  - client height
-  - offsetHeight
-  - offsetWidth
-  - size of displayed content
-translation_of: Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements
 ---
 {{DefaultAPISidebar("CSSOM View")}}
 

--- a/files/ja/web/api/css_object_model/index.md
+++ b/files/ja/web/api/css_object_model/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS オブジェクトモデル (CSSOM)
 slug: Web/API/CSS_Object_Model
-tags:
-  - API
-  - CSSOM
-  - Overview
-  - Reference
-  - 概要
-translation_of: Web/API/CSS_Object_Model
 ---
 {{DefaultAPISidebar("CSSOM")}}
 

--- a/files/ja/web/api/css_object_model/managing_screen_orientation/index.md
+++ b/files/ja/web/api/css_object_model/managing_screen_orientation/index.md
@@ -1,12 +1,6 @@
 ---
 title: 画面の向きを制御する
 slug: Web/API/CSS_Object_Model/Managing_screen_orientation
-tags:
-  - Advanced
-  - CSSOM View
-  - Guide
-  - Screen Orientation
-translation_of: Web/API/CSS_Object_Model/Managing_screen_orientation
 ---
 {{DefaultAPISidebar("Screen Orientation API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/css_object_model/using_dynamic_styling_information/index.md
+++ b/files/ja/web/api/css_object_model/using_dynamic_styling_information/index.md
@@ -1,10 +1,6 @@
 ---
 title: 動的なスタイル情報の利用
 slug: Web/API/CSS_Object_Model/Using_dynamic_styling_information
-tags:
-  - Beginner
-  - CSSOM
-translation_of: Web/API/CSS_Object_Model/Using_dynamic_styling_information
 ---
 {{DefaultAPISidebar("CSSOM")}}
 

--- a/files/ja/web/api/css_painting_api/guide/index.md
+++ b/files/ja/web/api/css_painting_api/guide/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS Painting APIを使用する
 slug: Web/API/CSS_Painting_API/Guide
-tags:
-  - CSS
-  - CSS Paint API
-  - Canvas
-  - Houdini
-  - Learn
-translation_of: Web/API/CSS_Painting_API/Guide
 original_slug: Web/API/CSS_Painting_API/ガイド
 ---
 CSS Paint API を用いると開発者がプログラムで画像を定義できます。CSS の [`background-image`](/ja/docs/Web/CSS/background-image), [`border-image`](/ja/docs/Web/CSS/border-image-source), [`mask-image`](/ja/docs/Web/CSS/mask-image) など CSS 画像を呼び出せる場所ならどこでも使用できるように設計されています。

--- a/files/ja/web/api/css_painting_api/index.md
+++ b/files/ja/web/api/css_painting_api/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSS Painting API
 slug: Web/API/CSS_Painting_API
-tags:
-  - API
-  - CSS
-  - CSS Paint API
-  - Houdini
-  - Painting
-  - Reference
-translation_of: Web/API/CSS_Painting_API
 ---
 {{DefaultAPISidebar("CSS Painting API")}}
 

--- a/files/ja/web/api/css_properties_and_values_api/guide/index.md
+++ b/files/ja/web/api/css_properties_and_values_api/guide/index.md
@@ -1,15 +1,6 @@
 ---
 title: CSS properties and values API の使用
 slug: Web/API/CSS_Properties_and_Values_API/guide
-tags:
-  - API
-  - CSS
-  - CSS Properties and Values
-  - Guide
-  - Houdini
-  - JavaScript
-  - Learn
-translation_of: Web/API/CSS_Properties_and_Values_API/guide
 ---
 {{SeeCompatTable}} **CSS Properties and Values API**（[CSS Houdini](/ja/docs/Web/Houdini) API の傘の一部）は、{{cssxref('--*', 'CSS カスタムプロパティ')}}の登録を可能にし、プロパティ型のチェック、デフォルト値、および値を継承するまたは継承しないプロパティを許可します。
 

--- a/files/ja/web/api/css_properties_and_values_api/index.md
+++ b/files/ja/web/api/css_properties_and_values_api/index.md
@@ -1,9 +1,6 @@
 ---
 title: CSS Properties and Values API
 slug: Web/API/CSS_Properties_and_Values_API
-tags:
-  - Houdini
-translation_of: Web/API/CSS_Properties_and_Values_API
 ---
 CSS Properties and Values API（[CSS Houdini](/ja/docs/Web/Houdini) API の傘の一部）を使用すると、開発者は {{cssxref('--*', 'CSS カスタムプロパティ')}}を明示的に定義して、プロパティ型のチェック、デフォルト値、および値を継承するまたは継承しないプロパティを許可できます。
 

--- a/files/ja/web/api/css_typed_om_api/guide/index.md
+++ b/files/ja/web/api/css_typed_om_api/guide/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS 型付きオブジェクトモデルの使用
 slug: Web/API/CSS_Typed_OM_API/Guide
-page-type: guide
-tags:
-  - CSS
-  - CSS Typed OM
-  - Houdini
-  - Learn
-translation_of: Web/API/CSS_Typed_OM_API/Guide
 ---
 {{DefaultAPISidebar("CSS Typed Object Model API")}}
 

--- a/files/ja/web/api/css_typed_om_api/index.md
+++ b/files/ja/web/api/css_typed_om_api/index.md
@@ -1,18 +1,6 @@
 ---
 title: CSS 型付きオブジェクトモデル API
 slug: Web/API/CSS_Typed_OM_API
-page-type: web-api-overview
-tags:
-  - CSS Typed OM
-  - CSS Typed Object Model API
-  - Houdini
-  - Reference
-browser-compat:
-  - api.CSSStyleValue
-  - api.StylePropertyMap
-  - api.CSSUnparsedValue
-  - api.CSSKeywordValue
-translation_of: Web/API/CSS_Typed_OM_API
 ---
 {{DefaultAPISidebar("CSS Typed Object Model API")}}
 

--- a/files/ja/web/api/cssconditionrule/conditiontext/index.md
+++ b/files/ja/web/api/cssconditionrule/conditiontext/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSSConditionRule.conditionText
 slug: Web/API/CSSConditionRule/conditionText
-tags:
-  - API
-  - CSSOM
-  - CSSConditionRule
-  - プロパティ
-  - リファレンス
-browser-compat: api.CSSConditionRule.conditionText
-translation_of: Web/API/CSSConditionRule/conditionText
 ---
 {{ APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssconditionrule/index.md
+++ b/files/ja/web/api/cssconditionrule/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSSConditionRule
 slug: Web/API/CSSConditionRule
-tags:
-  - API
-  - CSSOM
-  - インターフェイス
-  - リファレンス
-browser-compat: api.CSSConditionRule
-translation_of: Web/API/CSSConditionRule
 ---
 {{ APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssgroupingrule/cssrules/index.md
+++ b/files/ja/web/api/cssgroupingrule/cssrules/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSSGroupingRule.cssRules
 slug: Web/API/CSSGroupingRule/cssRules
-tags:
-  - API
-  - CSSOM
-  - CSSGroupingRule
-  - プロパティ
-  - リファレンス
-browser-compat: api.CSSGroupingRule.cssRules
-translation_of: Web/API/CSSGroupingRule/cssRules
 ---
 {{ APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssgroupingrule/deleterule/index.md
+++ b/files/ja/web/api/cssgroupingrule/deleterule/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSSGroupingRule.deleteRule()
 slug: Web/API/CSSGroupingRule/deleteRule
-tags:
-  - API
-  - CSSOM
-  - CSSGroupingRule
-  - メソッド
-  - リファレンス
-browser-compat: api.CSSGroupingRule.deleteRule
-translation_of: Web/API/CSSGroupingRule/deleteRule
 ---
 {{ APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssgroupingrule/index.md
+++ b/files/ja/web/api/cssgroupingrule/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSSGroupingRule
 slug: Web/API/CSSGroupingRule
-tags:
-  - API
-  - CSSOM
-  - インターフェイス
-  - リファレンス
-browser-compat: api.CSSGroupingRule
-translation_of: Web/API/CSSGroupingRule
 ---
 {{ APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssgroupingrule/insertrule/index.md
+++ b/files/ja/web/api/cssgroupingrule/insertrule/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSSGroupingRule.insertRule()
 slug: Web/API/CSSGroupingRule/insertRule
-tags:
-  - API
-  - CSSOM
-  - CSSGroupingRule
-  - メソッド
-  - リファレンス
-browser-compat: api.CSSGroupingRule.insertRule
-translation_of: Web/API/CSSGroupingRule/insertRule
 ---
 {{ APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssimagevalue/index.md
+++ b/files/ja/web/api/cssimagevalue/index.md
@@ -1,16 +1,6 @@
 ---
 title: CSSImageValue
 slug: Web/API/CSSImageValue
-tags:
-  - API
-  - CSS 型付きオブジェクトモデル API
-  - CSSImageValue
-  - 実験的
-  - Houdini
-  - インターフェイス
-  - リファレンス
-browser-compat: api.CSSImageValue
-translation_of: Web/API/CSSImageValue
 ---
 {{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}
 

--- a/files/ja/web/api/csskeyframerule/index.md
+++ b/files/ja/web/api/csskeyframerule/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSSKeyframeRule
 slug: Web/API/CSSKeyframeRule
-tags:
-  - API
-  - CSS Animations
-  - CSSOM
-  - Experimental
-  - Interface
-  - Reference
-translation_of: Web/API/CSSKeyframeRule
 ---
 {{APIRef("CSSOM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/csskeyframesrule/appendrule/index.md
+++ b/files/ja/web/api/csskeyframesrule/appendrule/index.md
@@ -1,15 +1,6 @@
 ---
 title: CSSKeyframesRule.appendRule()
 slug: Web/API/CSSKeyframesRule/appendRule
-tags:
-  - API
-  - CSSOM
-  - CSSKeyframesRule
-  - CSS アニメーション
-  - メソッド
-  - リファレンス
-browser-compat: api.CSSKeyframesRule.appendRule
-translation_of: Web/API/CSSKeyframesRule/appendRule
 ---
 {{APIRef("CSSOM") }}
 

--- a/files/ja/web/api/csskeyframesrule/cssrules/index.md
+++ b/files/ja/web/api/csskeyframesrule/cssrules/index.md
@@ -1,15 +1,6 @@
 ---
 title: CSSKeyframesRule.cssRules
 slug: Web/API/CSSKeyframesRule/cssRules
-tags:
-  - API
-  - CSSOM
-  - CSSKeyframesRule
-  - CSS アニメーション
-  - プロパティ
-  - リファレンス
-browser-compat: api.CSSKeyframesRule.cssRules
-translation_of: Web/API/CSSKeyframesRule/cssRules
 ---
 {{APIRef("CSSOM") }}
 

--- a/files/ja/web/api/csskeyframesrule/deleterule/index.md
+++ b/files/ja/web/api/csskeyframesrule/deleterule/index.md
@@ -1,15 +1,6 @@
 ---
 title: CSSKeyframesRule.deleteRule()
 slug: Web/API/CSSKeyframesRule/deleteRule
-tags:
-  - API
-  - CSSOM
-  - CSSKeyframesRule
-  - CSS アニメーション
-  - メソッド
-  - リファレンス
-browser-compat: api.CSSKeyframesRule.deleteRule
-translation_of: Web/API/CSSKeyframesRule/deleteRule
 ---
 {{APIRef("CSSOM") }}
 

--- a/files/ja/web/api/csskeyframesrule/findrule/index.md
+++ b/files/ja/web/api/csskeyframesrule/findrule/index.md
@@ -1,15 +1,6 @@
 ---
 title: CSSKeyframesRule.findRule()
 slug: Web/API/CSSKeyframesRule/findRule
-tags:
-  - API
-  - CSSOM
-  - CSSKeyframesRule
-  - CSS アニメーション
-  - メソッド
-  - リファレンス
-browser-compat: api.CSSKeyframesRule.findRule
-translation_of: Web/API/CSSKeyframesRule/findRule
 ---
 {{APIRef("CSSOM") }}
 

--- a/files/ja/web/api/csskeyframesrule/index.md
+++ b/files/ja/web/api/csskeyframesrule/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSSKeyframesRule
 slug: Web/API/CSSKeyframesRule
-tags:
-  - API
-  - CSS アニメーション
-  - CSSOM
-  - インターフェイス
-  - リファレンス
-browser-compat: api.CSSKeyframesRule
-translation_of: Web/API/CSSKeyframesRule
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/csskeyframesrule/name/index.md
+++ b/files/ja/web/api/csskeyframesrule/name/index.md
@@ -1,15 +1,6 @@
 ---
 title: CSSKeyframesRule.name
 slug: Web/API/CSSKeyframesRule/name
-tags:
-  - API
-  - CSSOM
-  - CSSKeyframesRule
-  - CSS アニメーション
-  - プロパティ
-  - リファレンス
-browser-compat: api.CSSKeyframesRule.name
-translation_of: Web/API/CSSKeyframesRule/name
 ---
 {{APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssmediarule/index.md
+++ b/files/ja/web/api/cssmediarule/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSSMediaRule
 slug: Web/API/CSSMediaRule
-tags:
-  - API
-  - CSSOM
-  - インターフェイス
-  - リファレンス
-browser-compat: api.CSSMediaRule
-translation_of: Web/API/CSSMediaRule
 ---
 {{ APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssmediarule/media/index.md
+++ b/files/ja/web/api/cssmediarule/media/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSSMediaRule.media
 slug: Web/API/CSSMediaRule/media
-tags:
-  - API
-  - CSSOM
-  - CSSMediaRule
-  - プロパティ
-  - リファレンス
-browser-compat: api.CSSMediaRule.media
-translation_of: Web/API/CSSMediaRule/media
 ---
 {{ APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssnumericvalue/add/index.md
+++ b/files/ja/web/api/cssnumericvalue/add/index.md
@@ -1,17 +1,6 @@
 ---
 title: CSSNumericValue.add()
 slug: Web/API/CSSNumericValue/add
-tags:
-  - API
-  - CSS 型付きオブジェクトモデル API
-  - CSSNumericValue
-  - 実験的
-  - Houdini
-  - メソッド
-  - リファレンス
-  - add()
-browser-compat: api.CSSNumericValue.add
-translation_of: Web/API/CSSNumericValue/add
 ---
 {{APIRef("CSS Typed OM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/cssnumericvalue/div/index.md
+++ b/files/ja/web/api/cssnumericvalue/div/index.md
@@ -1,17 +1,6 @@
 ---
 title: CSSNumericValue.div()
 slug: Web/API/CSSNumericValue/div
-tags:
-  - API
-  - CSS 型付きオブジェクトモデル API
-  - CSSNumericValue
-  - 実験的
-  - Houdini
-  - メソッド
-  - リファレンス
-  - div()
-browser-compat: api.CSSNumericValue.div
-translation_of: Web/API/CSSNumericValue/div
 ---
 {{APIRef("CSS Typed OM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/cssnumericvalue/equals/index.md
+++ b/files/ja/web/api/cssnumericvalue/equals/index.md
@@ -1,17 +1,6 @@
 ---
 title: CSSNumericValue.equals()
 slug: Web/API/CSSNumericValue/equals
-tags:
-  - API
-  - CSS 型付きオブジェクトモデル API
-  - CSSNumericValue
-  - 実験的
-  - Houdini
-  - メソッド
-  - リファレンス
-  - equals()
-browser-compat: api.CSSNumericValue.equals
-translation_of: Web/API/CSSNumericValue/equals
 ---
 {{APIRef("CSS Typed OM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/cssnumericvalue/index.md
+++ b/files/ja/web/api/cssnumericvalue/index.md
@@ -1,16 +1,6 @@
 ---
 title: CSSNumericValue
 slug: Web/API/CSSNumericValue
-tags:
-  - API
-  - CSS 型付きオブジェクトモデル API
-  - CSSNumericValue
-  - 実験的
-  - Houdini
-  - インターフェイス
-  - リファレンス
-browser-compat: api.CSSNumericValue
-translation_of: Web/API/CSSNumericValue
 ---
 {{APIRef("CSS Typed OM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/cssnumericvalue/max/index.md
+++ b/files/ja/web/api/cssnumericvalue/max/index.md
@@ -1,17 +1,6 @@
 ---
 title: CSSNumericValue.max()
 slug: Web/API/CSSNumericValue/max
-tags:
-  - API
-  - CSS 型付きオブジェクトモデル API
-  - CSSNumericValue
-  - 実験的
-  - Houdini
-  - メソッド
-  - リファレンス
-  - max()
-browser-compat: api.CSSNumericValue.max
-translation_of: Web/API/CSSNumericValue/max
 ---
 {{APIRef("CSS Typed OM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/cssnumericvalue/min/index.md
+++ b/files/ja/web/api/cssnumericvalue/min/index.md
@@ -1,16 +1,6 @@
 ---
 title: CSSNumericValue.min()
 slug: Web/API/CSSNumericValue/min
-tags:
-  - API
-  - CSS 型付きオブジェクトモデル API
-  - CSSNumericValue
-  - 実験的
-  - Houdini
-  - メソッド
-  - リファレンス
-  - min()
-browser-compat: api.CSSNumericValue.min
 ---
 {{APIRef("CSS Typed OM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/cssnumericvalue/mul/index.md
+++ b/files/ja/web/api/cssnumericvalue/mul/index.md
@@ -1,16 +1,6 @@
 ---
 title: CSSNumericValue.mul()
 slug: Web/API/CSSNumericValue/mul
-tags:
-  - API
-  - CSS 型付きオブジェクトモデル API
-  - CSSNumericValue
-  - 実験的
-  - Houdini
-  - メソッド
-  - リファレンス
-  - mul()
-browser-compat: api.CSSNumericValue.mul
 ---
 {{APIRef("CSS Typed OM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/cssnumericvalue/parse/index.md
+++ b/files/ja/web/api/cssnumericvalue/parse/index.md
@@ -1,17 +1,6 @@
 ---
 title: CSSNumericValue.parse()
 slug: Web/API/CSSNumericValue/parse
-tags:
-  - API
-  - CSS 型付きオブジェクトモデル API
-  - CSSNumericValue
-  - 実験的
-  - Houdini
-  - メソッド
-  - リファレンス
-  - parse()
-browser-compat: api.CSSNumericValue.parse
-translation_of: Web/API/CSSNumericValue/parse
 ---
 {{APIRef("CSS Typed OM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/cssnumericvalue/sub/index.md
+++ b/files/ja/web/api/cssnumericvalue/sub/index.md
@@ -1,17 +1,6 @@
 ---
 title: CSSNumericValue.sub()
 slug: Web/API/CSSNumericValue/sub
-tags:
-  - API
-  - CSS 型付きオブジェクトモデル API
-  - CSSNumericValue
-  - 実験的
-  - Houdini
-  - メソッド
-  - リファレンス
-  - sub()
-browser-compat: api.CSSNumericValue.sub
-translation_of: Web/API/CSSNumericValue/sub
 ---
 {{APIRef("CSS Typed OM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/cssnumericvalue/to/index.md
+++ b/files/ja/web/api/cssnumericvalue/to/index.md
@@ -1,17 +1,6 @@
 ---
 title: CSSNumericValue.to()
 slug: Web/API/CSSNumericValue/to
-tags:
-  - API
-  - CSS 型付きオブジェクトモデル API
-  - CSSNumericValue
-  - 実験的
-  - Houdini
-  - メソッド
-  - リファレンス
-  - to()
-browser-compat: api.CSSNumericValue.to
-translation_of: Web/API/CSSNumericValue/to
 ---
 {{APIRef("CSS Typed OM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/cssnumericvalue/tosum/index.md
+++ b/files/ja/web/api/cssnumericvalue/tosum/index.md
@@ -1,17 +1,6 @@
 ---
 title: CSSNumericValue.toSum()
 slug: Web/API/CSSNumericValue/toSum
-tags:
-  - API
-  - CSS 型付きオブジェクトモデル API
-  - CSSNumericValue
-  - 実験的
-  - Houdini
-  - メソッド
-  - リファレンス
-  - toSum()
-browser-compat: api.CSSNumericValue.toSum
-translation_of: Web/API/CSSNumericValue/toSum
 ---
 {{APIRef("CSS Typed OM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/cssnumericvalue/type/index.md
+++ b/files/ja/web/api/cssnumericvalue/type/index.md
@@ -1,17 +1,6 @@
 ---
 title: CSSNumericValue.type()
 slug: Web/API/CSSNumericValue/type
-tags:
-  - API
-  - CSS 型付きオブジェクトモデル API
-  - CSSNumericValue
-  - 実験的
-  - Houdini
-  - メソッド
-  - リファレンス
-  - Type
-browser-compat: api.CSSNumericValue.type
-translation_of: Web/API/CSSNumericValue/type
 ---
 {{APIRef("CSS Typed OM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/csspagerule/index.md
+++ b/files/ja/web/api/csspagerule/index.md
@@ -1,12 +1,6 @@
 ---
 title: CSSPageRule
 slug: Web/API/CSSPageRule
-tags:
-  - API
-  - CSSOM
-  - Interface
-  - Reference
-translation_of: Web/API/CSSPageRule
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/cssrule/csstext/index.md
+++ b/files/ja/web/api/cssrule/csstext/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSSRule.cssText
 slug: Web/API/CSSRule/cssText
-tags:
-  - API
-  - CSSOM
-  - プロパティ
-  - リファレンス
-browser-compat: api.CSSRule.cssText
-translation_of: Web/API/CSSRule/cssText
 ---
 {{APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssrule/index.md
+++ b/files/ja/web/api/cssrule/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSSRule
 slug: Web/API/CSSRule
-tags:
-  - API
-  - CSSOM
-  - インターフェイス
-  - リファレンス
-browser-compat: api.CSSRule
-translation_of: Web/API/CSSRule
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/cssrule/parentrule/index.md
+++ b/files/ja/web/api/cssrule/parentrule/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSSRule.parentRule
 slug: Web/API/CSSRule/parentRule
-tags:
-  - API
-  - CSSOM
-  - CSSRule
-  - プロパティ
-  - リファレンス
-browser-compat: api.CSSRule.parentRule
-translation_of: Web/API/CSSRule/parentRule
 ---
 {{ APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssrule/parentstylesheet/index.md
+++ b/files/ja/web/api/cssrule/parentstylesheet/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSSRule.parentStyleSheet
 slug: Web/API/CSSRule/parentStyleSheet
-tags:
-  - API
-  - CSSOM
-  - CSSRule
-  - プロパティ
-  - リファレンス
-browser-compat: api.CSSRule.parentStyleSheet
-translation_of: Web/API/CSSRule/parentStyleSheet
 ---
 {{ APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssrule/type/index.md
+++ b/files/ja/web/api/cssrule/type/index.md
@@ -1,15 +1,6 @@
 ---
 title: CSSRule.type
 slug: Web/API/CSSRule/type
-tags:
-  - API
-  - CSSOM
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-  - 非推奨
-browser-compat: api.CSSRule.type
-translation_of: Web/API/CSSRule/type
 ---
 {{APIRef("CSSOM")}}{{Deprecated_header}}
 

--- a/files/ja/web/api/cssrulelist/index.md
+++ b/files/ja/web/api/cssrulelist/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSSRuleList
 slug: Web/API/CSSRuleList
-tags:
-  - API
-  - CSSOM
-  - インターフェイス
-  - リファレンス
-browser-compat: api.CSSRuleList
-translation_of: Web/API/CSSRuleList
 ---
 {{ APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssrulelist/item/index.md
+++ b/files/ja/web/api/cssrulelist/item/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSSRuleList.item()
 slug: Web/API/CSSRuleList/item
-tags:
-  - API
-  - メソッド
-  - リファレンス
-  - item
-  - CSSRuleList
-browser-compat: api.CSSRuleList.item
 ---
 {{ APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssrulelist/length/index.md
+++ b/files/ja/web/api/cssrulelist/length/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSSRuleList.length
 slug: Web/API/CSSRuleList/length
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - length
-  - CSSRuleList
-browser-compat: api.CSSRuleList.length
-translation_of: Web/API/CSSRuleList/length
 ---
 {{ APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssstyledeclaration/cssfloat/index.md
+++ b/files/ja/web/api/cssstyledeclaration/cssfloat/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSSStyleDeclaration.cssFloat
 slug: Web/API/CSSStyleDeclaration/cssFloat
-tags:
-  - API
-  - CSSOM
-  - CSSStyleDeclaration
-  - Reference
-translation_of: Web/API/CSSStyleDeclaration/cssFloat
-browser-compat: api.CSSStyleDeclaration.cssFloat
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/cssstyledeclaration/csstext/index.md
+++ b/files/ja/web/api/cssstyledeclaration/csstext/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSSStyleDeclaration.cssText
 slug: Web/API/CSSStyleDeclaration/cssText
-tags:
-  - API
-  - CSSOM
-  - NeedsSpecTable
-  - Reference
-translation_of: Web/API/CSSStyleDeclaration/cssText
-browser-compat: api.CSSStyleDeclaration.cssText
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/cssstyledeclaration/getpropertycssvalue/index.md
+++ b/files/ja/web/api/cssstyledeclaration/getpropertycssvalue/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSSStyleDeclaration.getPropertyCSSValue()
 slug: Web/API/CSSStyleDeclaration/getPropertyCSSValue
-tags:
-  - API
-  - CSSOM
-  - Method
-  - Deprecated
-  - Reference
-translation_of: Web/API/CSSStyleDeclaration/getPropertyCSSValue
-browser-compat: api.CSSStyleDeclaration.getPropertyCSSValue
 ---
 {{ APIRef("CSSOM") }} {{deprecated_header}}
 

--- a/files/ja/web/api/cssstyledeclaration/getpropertypriority/index.md
+++ b/files/ja/web/api/cssstyledeclaration/getpropertypriority/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSSStyleDeclaration.getPropertyPriority()
 slug: Web/API/CSSStyleDeclaration/getPropertyPriority
-tags:
-  - API
-  - CSSOM
-  - Method
-  - Reference
-translation_of: Web/API/CSSStyleDeclaration/getPropertyPriority
-browser-compat: api.CSSStyleDeclaration.getPropertyPriority
 ---
 {{ APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssstyledeclaration/getpropertyvalue/index.md
+++ b/files/ja/web/api/cssstyledeclaration/getpropertyvalue/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSSStyleDeclaration.getPropertyValue()
 slug: Web/API/CSSStyleDeclaration/getPropertyValue
-tags:
-  - API
-  - CSSOM
-  - Method
-  - Reference
-translation_of: Web/API/CSSStyleDeclaration/getPropertyValue
-browser-compat: api.CSSStyleDeclaration.getPropertyValue
 ---
 {{ APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssstyledeclaration/index.md
+++ b/files/ja/web/api/cssstyledeclaration/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSSStyleDeclaration
 slug: Web/API/CSSStyleDeclaration
-tags:
-  - API
-  - CSSOM
-  - CSSRule
-  - Interface
-  - Reference
-translation_of: Web/API/CSSStyleDeclaration
-browser-compat: api.CSSStyleDeclaration
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/cssstyledeclaration/item/index.md
+++ b/files/ja/web/api/cssstyledeclaration/item/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSSStyleDeclaration.item()
 slug: Web/API/CSSStyleDeclaration/item
-tags:
-  - API
-  - CSSOM
-  - Method
-  - Reference
-translation_of: Web/API/CSSStyleDeclaration/item
-browser-compat: api.CSSStyleDeclaration.item
 ---
 {{ APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssstyledeclaration/length/index.md
+++ b/files/ja/web/api/cssstyledeclaration/length/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSSStyleDeclaration.length
 slug: Web/API/CSSStyleDeclaration/length
-tags:
-  - API
-  - CSSOM
-  - Property
-  - Reference
-translation_of: Web/API/CSSStyleDeclaration/length
-browser-compat: api.CSSStyleDeclaration.length
 ---
 {{ APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssstyledeclaration/parentrule/index.md
+++ b/files/ja/web/api/cssstyledeclaration/parentrule/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSSStyleDeclaration.parentRule
 slug: Web/API/CSSStyleDeclaration/parentRule
-tags:
-  - API
-  - CSSOM
-  - Property
-  - Reference
-translation_of: Web/API/CSSStyleDeclaration/parentRule
-browser-compat: api.CSSStyleDeclaration.parentRule
 ---
 {{ APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssstyledeclaration/removeproperty/index.md
+++ b/files/ja/web/api/cssstyledeclaration/removeproperty/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSSStyleDeclaration.removeProperty()
 slug: Web/API/CSSStyleDeclaration/removeProperty
-tags:
-  - API
-  - CSSOM
-  - Method
-  - Reference
-translation_of: Web/API/CSSStyleDeclaration/removeProperty
-browser-compat: api.CSSStyleDeclaration.removeProperty
 ---
 {{ APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssstyledeclaration/setproperty/index.md
+++ b/files/ja/web/api/cssstyledeclaration/setproperty/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSSStyleDeclaration.setProperty()
 slug: Web/API/CSSStyleDeclaration/setProperty
-tags:
-  - API
-  - CSSOM
-  - Method
-  - Reference
-translation_of: Web/API/CSSStyleDeclaration/setProperty
-browser-compat: api.CSSStyleDeclaration.setProperty
 ---
 {{ APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssstylerule/index.md
+++ b/files/ja/web/api/cssstylerule/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSSStyleRule
 slug: Web/API/CSSStyleRule
-tags:
-  - API
-  - CSSOM
-  - CSSStyleRule
-  - Interface
-  - Reference
-translation_of: Web/API/CSSStyleRule
 ---
 {{ APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssstylerule/selectortext/index.md
+++ b/files/ja/web/api/cssstylerule/selectortext/index.md
@@ -1,12 +1,6 @@
 ---
 title: CSSStyleRule.selectorText
 slug: Web/API/CSSStyleRule/selectorText
-tags:
-  - API
-  - CSSOM
-  - CSSStyleRule
-  - Reference
-translation_of: Web/API/CSSStyleRule/selectorText
 ---
 {{APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssstylerule/style/index.md
+++ b/files/ja/web/api/cssstylerule/style/index.md
@@ -1,12 +1,6 @@
 ---
 title: CSSStyleRule.style
 slug: Web/API/CSSStyleRule/style
-tags:
-  - API
-  - CSSOM
-  - Property
-  - Reference
-translation_of: Web/API/CSSStyleRule/style
 ---
 {{ APIRef("CSSOM") }}
 

--- a/files/ja/web/api/cssstylesheet/cssrules/index.md
+++ b/files/ja/web/api/cssstylesheet/cssrules/index.md
@@ -1,20 +1,6 @@
 ---
 title: CSSStyleSheet.cssRules
 slug: Web/API/CSSStyleSheet/cssRules
-tags:
-  - API
-  - CSS
-  - CSSOM
-  - CSSOM API
-  - CSSStyleSheet
-  - レイアウト
-  - オブジェクトモデル
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - スタイルシート
-browser-compat: api.CSSStyleSheet.cssRules
-translation_of: Web/API/CSSStyleSheet/cssRules
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/cssstylesheet/deleterule/index.md
+++ b/files/ja/web/api/cssstylesheet/deleterule/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSSStyleSheet.deleteRule()
 slug: Web/API/CSSStyleSheet/deleteRule
-tags:
-  - API
-  - CSSOM
-  - CSSStyleSheet
-  - Method
-  - Reference
-translation_of: Web/API/CSSStyleSheet/deleteRule
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/cssstylesheet/index.md
+++ b/files/ja/web/api/cssstylesheet/index.md
@@ -1,11 +1,6 @@
 ---
 title: CSSStyleSheet
 slug: Web/API/CSSStyleSheet
-tags:
-  - API
-  - CSSOM
-  - Reference
-translation_of: Web/API/CSSStyleSheet
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/cssstylesheet/insertrule/index.md
+++ b/files/ja/web/api/cssstylesheet/insertrule/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSSStyleSheet.insertRule()
 slug: Web/API/CSSStyleSheet/insertRule
-tags:
-  - API
-  - CSSOM
-  - CSSStyleSheet
-  - Method
-  - Reference
-translation_of: Web/API/CSSStyleSheet/insertRule
 ---
 **CSSStyleSheet.insertRule()** メソッドは、新しい [CSS 規則](/ja/docs/Web/API/CSSRule)を[現在のスタイルシート](/ja/docs/Web/API/CSSStyleSheet)に挿入しますが、いくつかの[制限](#Restrictions)があります。
 

--- a/files/ja/web/api/csssupportsrule/index.md
+++ b/files/ja/web/api/csssupportsrule/index.md
@@ -1,12 +1,6 @@
 ---
 title: CSSSupportsRule
 slug: Web/API/CSSSupportsRule
-tags:
-  - API
-  - CSSOM
-  - Interface
-  - Reference
-translation_of: Web/API/CSSSupportsRule
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/cssunparsedvalue/cssunparsedvalue/index.md
+++ b/files/ja/web/api/cssunparsedvalue/cssunparsedvalue/index.md
@@ -1,16 +1,6 @@
 ---
 title: CSSUnparsedValue.CSSUnparsedValue()
 slug: Web/API/CSSUnparsedValue/CSSUnparsedValue
-tags:
-  - API
-  - CSS Typed Object Model API
-  - CSSUnparsedValue
-  - Constructor
-  - Experimental
-  - Houdini
-  - NeedsExample
-  - Reference
-translation_of: Web/API/CSSUnparsedValue/CSSUnparsedValue
 ---
 {{APIRef("CSSOM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/cssunparsedvalue/entries/index.md
+++ b/files/ja/web/api/cssunparsedvalue/entries/index.md
@@ -1,18 +1,6 @@
 ---
 title: CSSUnparsedValue.entries()
 slug: Web/API/CSSUnparsedValue/entries
-tags:
-  - API
-  - CSS Typed Object Model API
-  - CSSUnparsedValue
-  - Constructor
-  - Entries
-  - Experimental
-  - Method
-  - NeedsExample
-  - Reference
-  - メソッド
-translation_of: Web/API/CSSUnparsedValue/entries
 ---
 {{APIRef("CSSOM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/cssunparsedvalue/foreach/index.md
+++ b/files/ja/web/api/cssunparsedvalue/foreach/index.md
@@ -1,18 +1,6 @@
 ---
 title: CSSUnparsedValue.forEach()
 slug: Web/API/CSSUnparsedValue/forEach
-tags:
-  - API
-  - CSS Typed Object Model API
-  - CSSUnparsedValue
-  - Constructor
-  - Experimental
-  - Method
-  - NeedsExample
-  - Reference
-  - forEach
-  - forEach()
-translation_of: Web/API/CSSUnparsedValue/forEach
 ---
 {{APIRef("CSSOM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/cssunparsedvalue/index.md
+++ b/files/ja/web/api/cssunparsedvalue/index.md
@@ -1,16 +1,6 @@
 ---
 title: CSSUnparsedValue
 slug: Web/API/CSSUnparsedValue
-tags:
-  - API
-  - CSS Typed Object Model API
-  - CSSUnparsedValue
-  - Experimental
-  - Houdini
-  - Interface
-  - NeedsExample
-  - Reference
-translation_of: Web/API/CSSUnparsedValue
 ---
 {{APIRef("CSSOM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/cssunparsedvalue/keys/index.md
+++ b/files/ja/web/api/cssunparsedvalue/keys/index.md
@@ -1,17 +1,6 @@
 ---
 title: CSSUnparsedValue.keys()
 slug: Web/API/CSSUnparsedValue/keys
-tags:
-  - API
-  - CSS Typed Object Model API
-  - CSSUnparsedValue
-  - Constructor
-  - Experimental
-  - Method
-  - NeedsExample
-  - Reference
-  - keys()
-translation_of: Web/API/CSSUnparsedValue/keys
 ---
 {{APIRef("CSSOM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/cssunparsedvalue/length/index.md
+++ b/files/ja/web/api/cssunparsedvalue/length/index.md
@@ -1,17 +1,6 @@
 ---
 title: CSSUnparsedValue.length
 slug: Web/API/CSSUnparsedValue/length
-tags:
-  - API
-  - CSS Typed Object Model API
-  - CSSUnparsedValue
-  - Constructor
-  - Experimental
-  - NeedsExample
-  - Property
-  - Reference
-  - length
-translation_of: Web/API/CSSUnparsedValue/length
 ---
 {{APIRef("CSSOM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/cssunparsedvalue/values/index.md
+++ b/files/ja/web/api/cssunparsedvalue/values/index.md
@@ -1,18 +1,6 @@
 ---
 title: CSSUnparsedValue.values()
 slug: Web/API/CSSUnparsedValue/values
-tags:
-  - API
-  - CSS Typed Object Model API
-  - CSSUnparsedValue
-  - Constructor
-  - Experimental
-  - Houdini
-  - Method
-  - NeedsExample
-  - Reference
-  - values()
-translation_of: Web/API/CSSUnparsedValue/values
 ---
 {{APIRef("CSSOM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/cssvalue/csstext/index.md
+++ b/files/ja/web/api/cssvalue/csstext/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSSValue.cssText
 slug: Web/API/CSSValue/cssText
-tags:
-  - API
-  - CSSValue
-  - Property
-  - Reference
-  - cssText
-translation_of: Web/API/CSSValue/cssText
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/cssvalue/cssvaluetype/index.md
+++ b/files/ja/web/api/cssvalue/cssvaluetype/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSSValue.cssValueType
 slug: Web/API/CSSValue/cssValueType
-tags:
-  - API
-  - CSSValue
-  - Property
-  - Read-only
-  - Reference
-  - cssValueType
-translation_of: Web/API/CSSValue/cssValueType
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/cssvalue/index.md
+++ b/files/ja/web/api/cssvalue/index.md
@@ -1,15 +1,6 @@
 ---
 title: CSSValue
 slug: Web/API/CSSValue
-tags:
-  - API
-  - CSSOM
-  - CSSValue
-  - Interface
-  - NeedsExample
-  - Obsolete
-  - Reference
-translation_of: Web/API/CSSValue
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/cssvariablereferencevalue/cssvariablereferencevalue/index.md
+++ b/files/ja/web/api/cssvariablereferencevalue/cssvariablereferencevalue/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSSVariableReferenceValue()
 slug: Web/API/CSSVariableReferenceValue/CSSVariableReferenceValue
-tags:
-  - API
-  - CSS Typed Object Model API
-  - CSSVariableReferenceValue
-  - Constructor
-  - Reference
-  - コンストラクター
-translation_of: Web/API/CSSVariableReferenceValue/CSSVariableReferenceValue
 ---
 {{APIRef("CSSOM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/cssvariablereferencevalue/fallback/index.md
+++ b/files/ja/web/api/cssvariablereferencevalue/fallback/index.md
@@ -1,17 +1,6 @@
 ---
 title: CSSVariableReferenceValue.fallback
 slug: Web/API/CSSVariableReferenceValue/fallback
-tags:
-  - API
-  - CSS Typed Object Model API
-  - CSSVariableReferenceValue
-  - Houdini
-  - NeedsExample
-  - Property
-  - Reference
-  - fallback
-  - プロパティ
-translation_of: Web/API/CSSVariableReferenceValue/fallback
 ---
 {{APIRef("CSSOM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/cssvariablereferencevalue/index.md
+++ b/files/ja/web/api/cssvariablereferencevalue/index.md
@@ -1,16 +1,6 @@
 ---
 title: CSSVariableReferenceValue
 slug: Web/API/CSSVariableReferenceValue
-tags:
-  - API
-  - CSS Typed Object Model API
-  - CSSVariableReferenceValue
-  - Experimental
-  - Interface
-  - NeedsTranslation
-  - Reference
-  - TopicStub
-translation_of: Web/API/CSSVariableReferenceValue
 ---
 {{APIRef("CSSOM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/cssvariablereferencevalue/variable/index.md
+++ b/files/ja/web/api/cssvariablereferencevalue/variable/index.md
@@ -1,17 +1,6 @@
 ---
 title: CSSVariableReferenceValue.variable
 slug: Web/API/CSSVariableReferenceValue/variable
-tags:
-  - API
-  - CSS Typed Object Model API
-  - CSSVariableReferenceValue
-  - Houdini
-  - NeedsExample
-  - Property
-  - Reference
-  - variable
-  - プロパティ
-translation_of: Web/API/CSSVariableReferenceValue/variable
 ---
 {{APIRef("CSSOM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/customelementregistry/define/index.md
+++ b/files/ja/web/api/customelementregistry/define/index.md
@@ -1,16 +1,6 @@
 ---
 title: CustomElementRegistry.define()
 slug: Web/API/CustomElementRegistry/define
-tags:
-  - API
-  - CustomElementRegistry
-  - メソッド
-  - リファレンス
-  - ウェブコンポーネント
-  - カスタム要素
-  - define
-browser-compat: api.CustomElementRegistry.define
-translation_of: Web/API/CustomElementRegistry/define
 ---
 {{APIRef("CustomElementRegistry")}}
 

--- a/files/ja/web/api/customelementregistry/get/index.md
+++ b/files/ja/web/api/customelementregistry/get/index.md
@@ -1,16 +1,6 @@
 ---
 title: CustomElementRegistry.get()
 slug: Web/API/CustomElementRegistry/get
-tags:
-  - API
-  - CustomElementRegistry
-  - 実験的
-  - メソッド
-  - リファレンス
-  - ウェブコンポーネント
-  - カスタム要素
-  - get
-browser-compat: api.CustomElementRegistry.get
 ---
 {{APIRef("CustomElementRegistry")}}
 

--- a/files/ja/web/api/customelementregistry/index.md
+++ b/files/ja/web/api/customelementregistry/index.md
@@ -1,16 +1,6 @@
 ---
 title: CustomElementRegistry
 slug: Web/API/CustomElementRegistry
-tags:
-  - API
-  - CustomElementRegistry
-  - 実験的
-  - インターフェイス
-  - リファレンス
-  - ウェブコンポーネント
-  - カスタム要素
-browser-compat: api.CustomElementRegistry
-translation_of: Web/API/CustomElementRegistry
 ---
 {{DefaultAPISidebar("Web Components")}}
 

--- a/files/ja/web/api/customelementregistry/upgrade/index.md
+++ b/files/ja/web/api/customelementregistry/upgrade/index.md
@@ -1,16 +1,6 @@
 ---
 title: CustomElementRegistry.upgrade()
 slug: Web/API/CustomElementRegistry/upgrade
-tags:
-  - API
-  - CustomElementRegistry
-  - メソッド
-  - リファレンス
-  - Upgrade
-  - ウェブコンポーネント
-  - カスタム要素
-browser-compat: api.CustomElementRegistry.upgrade
-translation_of: Web/API/CustomElementRegistry/upgrade
 ---
 {{APIRef("CustomElementRegistry")}}
 

--- a/files/ja/web/api/customelementregistry/whendefined/index.md
+++ b/files/ja/web/api/customelementregistry/whendefined/index.md
@@ -1,15 +1,6 @@
 ---
 title: CustomElementRegistry.whenDefined()
 slug: Web/API/CustomElementRegistry/whenDefined
-tags:
-  - API
-  - CustomElementRegistry
-  - メソッド
-  - リファレンス
-  - ウェブコンポーネント
-  - カスタム要素
-  - whenDefined
-translation_of: Web/API/CustomElementRegistry/whenDefined
 ---
 {{APIRef("CustomElementRegistry")}}
 

--- a/files/ja/web/api/customevent/customevent/index.md
+++ b/files/ja/web/api/customevent/customevent/index.md
@@ -1,12 +1,6 @@
 ---
 title: CustomEvent()
 slug: Web/API/CustomEvent/CustomEvent
-page-type: web-api-constructor
-tags:
-  - コンストラクター
-  - リファレンス
-browser-compat: api.CustomEvent.CustomEvent
-translation_of: Web/API/CustomEvent/CustomEvent
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/customevent/detail/index.md
+++ b/files/ja/web/api/customevent/detail/index.md
@@ -1,13 +1,6 @@
 ---
 title: CustomEvent.detail
 slug: Web/API/CustomEvent/detail
-page-type: web-api-instance-property
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.CustomEvent.detail
-translation_of: Web/API/CustomEvent/detail
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/customevent/index.md
+++ b/files/ja/web/api/customevent/index.md
@@ -1,12 +1,6 @@
 ---
 title: CustomEvent
 slug: Web/API/CustomEvent
-page-type: web-api-interface
-tags:
-  - インターフェイス
-  - リファレンス
-browser-compat: api.CustomEvent
-translation_of: Web/API/CustomEvent
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/customevent/initcustomevent/index.md
+++ b/files/ja/web/api/customevent/initcustomevent/index.md
@@ -1,13 +1,6 @@
 ---
 title: CustomEvent.initCustomEvent()
 slug: Web/API/CustomEvent/initCustomEvent
-page-type: web-api-instance-method
-tags:
-  - 非推奨
-  - メソッド
-  - リファレンス
-browser-compat: api.CustomEvent.initCustomEvent
-translation_of: Web/API/CustomEvent/initCustomEvent
 ---
 {{APIRef("DOM")}}{{Deprecated_header}}
 


### PR DESCRIPTION
Part of #7858

`files/ja/web/api/{a-c}` から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "tags": 368,
  "translation_of": 371,
  "browser-compat": 220,
  "page-type": 41,
  "translation_of_original": 2
}
```
