### PR TITLE
remove duplicated frontmatter keys from web/api/d* (ja)

### DIFF
--- a/files/ja/web/api/datatransfer/addelement/index.md
+++ b/files/ja/web/api/datatransfer/addelement/index.md
@@ -1,15 +1,6 @@
 ---
 title: DataTransfer.addElement()
 slug: Web/API/DataTransfer/addElement
-page-type: web-api-instance-method
-tags:
-  - API
-  - Method
-  - Non-standard
-  - Reference
-  - drag and drop
-browser-compat: api.DataTransfer.addElement
-translation_of: Web/API/DataTransfer/addElement
 ---
 {{APIRef("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/datatransfer/cleardata/index.md
+++ b/files/ja/web/api/datatransfer/cleardata/index.md
@@ -1,17 +1,6 @@
 ---
 title: DataTransfer.clearData()
 slug: Web/API/DataTransfer/clearData
-page-type: web-api-instance-method
-tags:
-  - API
-  - DataTransfer
-  - HTML DOM
-  - Method
-  - Reference
-  - clearData
-  - drag and drop
-browser-compat: api.DataTransfer.clearData
-translation_of: Web/API/DataTransfer/clearData
 ---
 {{APIRef("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/datatransfer/datatransfer/index.md
+++ b/files/ja/web/api/datatransfer/datatransfer/index.md
@@ -1,16 +1,6 @@
 ---
 title: DataTransfer()
 slug: Web/API/DataTransfer/DataTransfer
-page-type: web-api-constructor
-tags:
-  - API
-  - Constructor
-  - DataTransfer
-  - HTML Drag and Drop API
-  - Reference
-  - drag and drop
-browser-compat: api.DataTransfer.DataTransfer
-translation_of: Web/API/DataTransfer/DataTransfer
 ---
 {{APIRef("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/datatransfer/dropeffect/index.md
+++ b/files/ja/web/api/datatransfer/dropeffect/index.md
@@ -1,15 +1,6 @@
 ---
 title: DataTransfer.dropEffect
 slug: Web/API/DataTransfer/dropEffect
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - Property
-  - Reference
-  - drag and drop
-browser-compat: api.DataTransfer.dropEffect
-translation_of: Web/API/DataTransfer/dropEffect
 ---
 {{APIRef("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/datatransfer/effectallowed/index.md
+++ b/files/ja/web/api/datatransfer/effectallowed/index.md
@@ -1,15 +1,6 @@
 ---
 title: DataTransfer.effectAllowed
 slug: Web/API/DataTransfer/effectAllowed
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - Property
-  - Reference
-  - drag and drop
-browser-compat: api.DataTransfer.effectAllowed
-translation_of: Web/API/DataTransfer/effectAllowed
 ---
 {{APIRef("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/datatransfer/files/index.md
+++ b/files/ja/web/api/datatransfer/files/index.md
@@ -1,15 +1,6 @@
 ---
 title: DataTransfer.files
 slug: Web/API/DataTransfer/files
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - Property
-  - Reference
-  - drag and drop
-browser-compat: api.DataTransfer.files
-translation_of: Web/API/DataTransfer/files
 ---
 {{APIRef("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/datatransfer/getdata/index.md
+++ b/files/ja/web/api/datatransfer/getdata/index.md
@@ -1,15 +1,6 @@
 ---
 title: DataTransfer.getData()
 slug: Web/API/DataTransfer/getData
-page-type: web-api-instance-method
-tags:
-  - API
-  - HTML DOM
-  - Method
-  - Reference
-  - drag and drop
-browser-compat: api.DataTransfer.getData
-translation_of: Web/API/DataTransfer/getData
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/datatransfer/index.md
+++ b/files/ja/web/api/datatransfer/index.md
@@ -1,18 +1,6 @@
 ---
 title: DataTransfer
 slug: Web/API/DataTransfer
-page-type: web-api-interface
-tags:
-  - API
-  - DataTransfer
-  - HTML Drag and Drop API
-  - Interface
-  - NeedsMarkupWork
-  - Reference
-  - Web Development
-  - drag and drop
-browser-compat: api.DataTransfer
-translation_of: Web/API/DataTransfer
 ---
 {{APIRef("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/datatransfer/items/index.md
+++ b/files/ja/web/api/datatransfer/items/index.md
@@ -1,15 +1,6 @@
 ---
 title: DataTransfer.items
 slug: Web/API/DataTransfer/items
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - Property
-  - Reference
-  - drag and drop
-browser-compat: api.DataTransfer.items
-translation_of: Web/API/DataTransfer/items
 ---
 {{APIRef("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/datatransfer/mozcleardataat/index.md
+++ b/files/ja/web/api/datatransfer/mozcleardataat/index.md
@@ -1,15 +1,6 @@
 ---
 title: DataTransfer.mozClearDataAt()
 slug: Web/API/DataTransfer/mozClearDataAt
-page-type: web-api-instance-method
-tags:
-  - API
-  - Method
-  - Non-standard
-  - Reference
-  - drag and drop
-  - Deprecated
-browser-compat: api.DataTransfer.mozClearDataAt
 ---
 {{APIRef("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/datatransfer/mozcursor/index.md
+++ b/files/ja/web/api/datatransfer/mozcursor/index.md
@@ -1,14 +1,6 @@
 ---
 title: DataTransfer.mozCursor
 slug: Web/API/DataTransfer/mozCursor
-page-type: web-api-instance-property
-tags:
-  - API
-  - Non-standard
-  - Property
-  - Reference
-  - drag and drop
-browser-compat: api.DataTransfer.mozCursor
 ---
 {{APIRef("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/datatransfer/mozgetdataat/index.md
+++ b/files/ja/web/api/datatransfer/mozgetdataat/index.md
@@ -1,15 +1,6 @@
 ---
 title: DataTransfer.mozGetDataAt()
 slug: Web/API/DataTransfer/mozGetDataAt
-page-type: web-api-instance-method
-tags:
-  - API
-  - Method
-  - Non-standard
-  - Reference
-  - drag and drop
-  - Deprecated
-browser-compat: api.DataTransfer.mozGetDataAt
 ---
 {{APIRef("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/datatransfer/mozitemcount/index.md
+++ b/files/ja/web/api/datatransfer/mozitemcount/index.md
@@ -1,16 +1,6 @@
 ---
 title: DataTransfer.mozItemCount
 slug: Web/API/DataTransfer/mozItemCount
-page-type: web-api-instance-property
-tags:
-  - API
-  - Non-standard
-  - Property
-  - Reference
-  - drag and drop
-  - Deprecated
-browser-compat: api.DataTransfer.mozItemCount
-translation_of: Web/API/DataTransfer/mozItemCount
 ---
 {{APIRef("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/datatransfer/mozsetdataat/index.md
+++ b/files/ja/web/api/datatransfer/mozsetdataat/index.md
@@ -1,16 +1,6 @@
 ---
 title: DataTransfer.mozSetDataAt()
 slug: Web/API/DataTransfer/mozSetDataAt
-page-type: web-api-instance-method
-tags:
-  - API
-  - Method
-  - Non-standard
-  - Reference
-  - drag and drop
-  - Deprecated
-browser-compat: api.DataTransfer.mozSetDataAt
-translation_of: Web/API/DataTransfer/mozSetDataAt
 ---
 {{APIRef("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/datatransfer/mozsourcenode/index.md
+++ b/files/ja/web/api/datatransfer/mozsourcenode/index.md
@@ -1,15 +1,6 @@
 ---
 title: DataTransfer.mozSourceNode
 slug: Web/API/DataTransfer/mozSourceNode
-page-type: web-api-instance-property
-tags:
-  - API
-  - Non-standard
-  - Property
-  - Reference
-  - drag and drop
-browser-compat: api.DataTransfer.mozSourceNode
-translation_of: Web/API/DataTransfer/mozSourceNode
 ---
 {{APIRef("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/datatransfer/moztypesat/index.md
+++ b/files/ja/web/api/datatransfer/moztypesat/index.md
@@ -1,16 +1,6 @@
 ---
 title: DataTransfer.mozTypesAt()
 slug: Web/API/DataTransfer/mozTypesAt
-page-type: web-api-instance-method
-tags:
-  - API
-  - Method
-  - Non-standard
-  - Reference
-  - drag and drop
-  - Deprecated
-browser-compat: api.DataTransfer.mozTypesAt
-translation_of: Web/API/DataTransfer/mozTypesAt
 ---
 {{APIRef("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/datatransfer/mozusercancelled/index.md
+++ b/files/ja/web/api/datatransfer/mozusercancelled/index.md
@@ -1,15 +1,6 @@
 ---
 title: DataTransfer.mozUserCancelled
 slug: Web/API/DataTransfer/mozUserCancelled
-page-type: web-api-instance-property
-tags:
-  - API
-  - Non-standard
-  - Property
-  - Reference
-  - drag and drop
-browser-compat: api.DataTransfer.mozUserCancelled
-translation_of: Web/API/DataTransfer/mozUserCancelled
 ---
 {{APIRef("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/datatransfer/setdata/index.md
+++ b/files/ja/web/api/datatransfer/setdata/index.md
@@ -1,15 +1,6 @@
 ---
 title: DataTransfer.setData()
 slug: Web/API/DataTransfer/setData
-page-type: web-api-instance-method
-tags:
-  - API
-  - HTML DOM
-  - Method
-  - Reference
-  - drag and drop
-browser-compat: api.DataTransfer.setData
-translation_of: Web/API/DataTransfer/setData
 ---
 {{APIRef("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/datatransfer/setdragimage/index.md
+++ b/files/ja/web/api/datatransfer/setdragimage/index.md
@@ -1,16 +1,6 @@
 ---
 title: DataTransfer.setDragImage()
 slug: Web/API/DataTransfer/setDragImage
-page-type: web-api-instance-method
-tags:
-  - API
-  - H5 DnD
-  - HTML DOM
-  - Method
-  - Reference
-  - drag and drop
-browser-compat: api.DataTransfer.setDragImage
-translation_of: Web/API/DataTransfer/setDragImage
 ---
 {{APIRef("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/datatransfer/types/index.md
+++ b/files/ja/web/api/datatransfer/types/index.md
@@ -1,15 +1,6 @@
 ---
 title: DataTransfer.types
 slug: Web/API/DataTransfer/types
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - Property
-  - Reference
-  - drag and drop
-browser-compat: api.DataTransfer.types
-translation_of: Web/API/DataTransfer/types
 ---
 {{APIRef("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/datatransferitem/index.md
+++ b/files/ja/web/api/datatransferitem/index.md
@@ -1,15 +1,6 @@
 ---
 title: DataTransferItem
 slug: Web/API/DataTransferItem
-tags:
-  - API
-  - DataTransferItem
-  - HTML DOM
-  - HTML Drag and Drop API
-  - Interface
-  - Reference
-  - drag and drop
-translation_of: Web/API/DataTransferItem
 ---
 {{APIRef("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/datatransferitemlist/clear/index.md
+++ b/files/ja/web/api/datatransferitemlist/clear/index.md
@@ -1,16 +1,6 @@
 ---
 title: DataTransferItemList.clear()
 slug: Web/API/DataTransferItemList/clear
-tags:
-  - API
-  - DataTransferItemList
-  - HTML DOM
-  - HTML Drag and Drop API
-  - Method
-  - Reference
-  - clear
-  - ドラッグアンドドロップ
-translation_of: Web/API/DataTransferItemList/clear
 ---
 {{domxref("DataTransferItemList")}} の **`clear()`** メソッドは、ドラッグデータアイテムリストからすべての {{domxref("DataTransferItem")}} オブジェクトを削除し、リストを空にします。
 

--- a/files/ja/web/api/datatransferitemlist/index.md
+++ b/files/ja/web/api/datatransferitemlist/index.md
@@ -1,17 +1,6 @@
 ---
 title: DataTransferItemList
 slug: Web/API/DataTransferItemList
-tags:
-  - API
-  - DataTransferItemList
-  - HTML DOM
-  - HTML Drag and Drop API
-  - Interface
-  - NeedsTranslation
-  - Reference
-  - TopicStub
-  - drag and drop
-translation_of: Web/API/DataTransferItemList
 ---
 {{APIRef("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/datatransferitemlist/length/index.md
+++ b/files/ja/web/api/datatransferitemlist/length/index.md
@@ -1,16 +1,6 @@
 ---
 title: DataTransferItemList.length
 slug: Web/API/DataTransferItemList/length
-tags:
-  - API
-  - DataTransferItemList
-  - HTML DOM
-  - HTML Drag and Drop API
-  - Property
-  - Reference
-  - length
-  - ドラッグアンドドロップ
-translation_of: Web/API/DataTransferItemList/length
 ---
 {{domxref("DataTransferItemList")}} インターフェイスの **`length`** プロパティは読み取り専用で、ドラッグアイテムリストの中に現在入っているアイテムの数を返します。
 

--- a/files/ja/web/api/dedicatedworkerglobalscope/index.md
+++ b/files/ja/web/api/dedicatedworkerglobalscope/index.md
@@ -1,7 +1,6 @@
 ---
 title: DedicatedWorkerGlobalScope
 slug: Web/API/DedicatedWorkerGlobalScope
-translation_of: Web/API/DedicatedWorkerGlobalScope
 ---
 {{APIRef("Web Workers API")}}
 

--- a/files/ja/web/api/delaynode/delaytime/index.md
+++ b/files/ja/web/api/delaynode/delaytime/index.md
@@ -1,16 +1,6 @@
 ---
 title: DelayNode.delayTime
 slug: Web/API/DelayNode/delayTime
-page-type: web-api-instance-property
-tags:
-  - API
-  - DelayNode
-  - Property
-  - Reference
-  - Web Audio API
-  - delayTime
-browser-compat: api.DelayNode.delayTime
-translation_of: Web/API/DelayNode/delayTime
 ---
 {{ APIRef("Web Audio API") }}
 

--- a/files/ja/web/api/delaynode/index.md
+++ b/files/ja/web/api/delaynode/index.md
@@ -1,16 +1,6 @@
 ---
 title: DelayNode
 slug: Web/API/DelayNode
-page-type: web-api-interface
-tags:
-  - API
-  - Audio
-  - DelayNode
-  - Interface
-  - Reference
-  - Web Audio API
-browser-compat: api.DelayNode
-translation_of: Web/API/DelayNode
 ---
 {{APIRef("Web Audio API")}}
 

--- a/files/ja/web/api/device_memory_api/index.md
+++ b/files/ja/web/api/device_memory_api/index.md
@@ -1,9 +1,6 @@
 ---
 title: 端末メモリー API
 slug: Web/API/Device_Memory_API
-tags:
-  - 端末メモリー API
-translation_of: Web/API/Device_Memory_API
 ---
 {{DefaultAPISidebar("Device Memory API")}}{{securecontext_header}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/devicemotionevent/index.md
+++ b/files/ja/web/api/devicemotionevent/index.md
@@ -1,14 +1,6 @@
 ---
 title: DeviceMotionEvent
 slug: Web/API/DeviceMotionEvent
-tags:
-  - API
-  - Device Orientation
-  - Experimental
-  - Mobile
-  - Motion
-  - Orientation
-translation_of: Web/API/DeviceMotionEvent
 ---
 {{apiref("Device Orientation Events")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/devicemotioneventacceleration/index.md
+++ b/files/ja/web/api/devicemotioneventacceleration/index.md
@@ -1,16 +1,6 @@
 ---
 title: DeviceAcceleration
 slug: Web/API/DeviceMotionEventAcceleration
-tags:
-  - API
-  - Device
-  - Experimental
-  - Interface
-  - Orienttation
-  - Reference
-  - events
-translation_of: Web/API/DeviceMotionEventAcceleration
-translation_of_original: Web/API/DeviceAcceleration
 original_slug: Web/API/DeviceAcceleration
 ---
 {{ ApiRef("Device Orientation Events") }}{{SeeCompatTable}}

--- a/files/ja/web/api/deviceproximityevent/index.md
+++ b/files/ja/web/api/deviceproximityevent/index.md
@@ -1,12 +1,6 @@
 ---
 title: DeviceProximityEvent
 slug: Web/API/DeviceProximityEvent
-tags:
-  - API
-  - Interface
-  - Proximity Event
-  - Reference
-translation_of: Web/API/DeviceProximityEvent
 ---
 {{APIRef("Proximity Events")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/directoryentrysync/index.md
+++ b/files/ja/web/api/directoryentrysync/index.md
@@ -1,7 +1,6 @@
 ---
 title: DirectoryEntrySync
 slug: Web/API/DirectoryEntrySync
-translation_of: Web/API/DirectoryEntrySync
 ---
 {{APIRef("File System API")}}{{Non-standard_header}}
 

--- a/files/ja/web/api/document/activeelement/index.md
+++ b/files/ja/web/api/document/activeelement/index.md
@@ -1,16 +1,6 @@
 ---
 title: Document.activeElement
 slug: Web/API/Document/activeElement
-tags:
-  - API
-  - Document
-  - フォーカス
-  - プロパティ
-  - リファレンス
-  - ShadowRoot
-  - activeElement
-translation_of: Web/API/DocumentOrShadowRoot/activeElement
-translation_of_original: Web/API/Document/activeElement
 original_slug: Web/API/DocumentOrShadowRoot/activeElement
 ---
 {{APIRef("Shadow DOM")}}

--- a/files/ja/web/api/document/adoptnode/index.md
+++ b/files/ja/web/api/document/adoptnode/index.md
@@ -1,16 +1,6 @@
 ---
 title: Document.adoptNode()
 slug: Web/API/Document/adoptNode
-tags:
-  - API
-  - DOM
-  - DOM Reference
-  - Method
-  - NeedsExample
-  - NeedsSpecTable
-  - NeedsUpdate
-  - Reference
-translation_of: Web/API/Document/adoptNode
 ---
 {{ ApiRef("DOM") }}
 

--- a/files/ja/web/api/document/afterscriptexecute_event/index.md
+++ b/files/ja/web/api/document/afterscriptexecute_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.onafterscriptexecute
 slug: Web/API/Document/afterscriptexecute_event
-tags:
-  - API
-  - DOM
-  - Non-standard
-  - Reference
-  - プロパティ
-  - 標準外
-translation_of: Web/API/Document/onafterscriptexecute
 original_slug: Web/API/Document/onafterscriptexecute
 ---
 {{ApiRef("DOM")}}{{non-standard_header}}

--- a/files/ja/web/api/document/alinkcolor/index.md
+++ b/files/ja/web/api/document/alinkcolor/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.alinkColor
 slug: Web/API/Document/alinkColor
-tags:
-  - API
-  - DOM
-  - Deprecated
-  - Document
-  - Reference
-  - alinkColor
-  - プロパティ
-translation_of: Web/API/Document/alinkColor
 ---
 {{APIRef("DOM")}}{{Deprecated_header}}
 

--- a/files/ja/web/api/document/all/index.md
+++ b/files/ja/web/api/document/all/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.all
 slug: Web/API/Document/all
-tags:
-  - API
-  - DOM
-  - Document
-  - HTMLAllCollection
-  - Property
-  - Reference
-  - all
-translation_of: Web/API/Document/all
 ---
 {{APIRef("DOM")}}{{Deprecated_Header("HTML5")}}
 

--- a/files/ja/web/api/document/anchors/index.md
+++ b/files/ja/web/api/document/anchors/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.anchors
 slug: Web/API/Document/anchors
-tags:
-  - API
-  - Deprecated
-  - Document
-  - HTML DOM
-  - Property
-  - Reference
-translation_of: Web/API/Document/anchors
 ---
 {{APIRef("DOM")}} {{Deprecated_Header}}
 

--- a/files/ja/web/api/document/applets/index.md
+++ b/files/ja/web/api/document/applets/index.md
@@ -1,16 +1,6 @@
 ---
 title: Document.applets
 slug: Web/API/Document/applets
-tags:
-  - API
-  - Deprecated
-  - Document
-  - HTML DOM
-  - Property
-  - Reference
-  - applets
-  - プロパティ
-translation_of: Web/API/Document/applets
 ---
 {{APIRef("DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/document/beforescriptexecute_event/index.md
+++ b/files/ja/web/api/document/beforescriptexecute_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Document: beforescriptexecute イベント'
 slug: Web/API/Document/beforescriptexecute_event
-page-type: web-api-event
-tags:
- - Document
- - beforescriptexecute
- - API
- - Event
- - Reference
- - Non-standard
-translation_of: Web/API/Document/beforescriptexecute_event
 original_slug: Web/API/Document/onbeforescriptexecute
 ---
 {{APIRef}}{{non-standard_header}}

--- a/files/ja/web/api/document/bgcolor/index.md
+++ b/files/ja/web/api/document/bgcolor/index.md
@@ -1,16 +1,6 @@
 ---
 title: document.bgColor
 slug: Web/API/Document/bgColor
-tags:
-  - API
-  - DOM
-  - Deprecated
-  - Document
-  - Gecko
-  - HTML DOM
-  - Property
-  - Reference
-translation_of: Web/API/Document/bgColor
 ---
 {{APIRef("DOM")}} {{ Deprecated_header() }}
 

--- a/files/ja/web/api/document/body/index.md
+++ b/files/ja/web/api/document/body/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.body
 slug: Web/API/Document/body
-tags:
-  - API
-  - Document
-  - HTML DOM
-  - Property
-  - Reference
-  - プロパティ
-translation_of: Web/API/Document/body
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/caretpositionfrompoint/index.md
+++ b/files/ja/web/api/document/caretpositionfrompoint/index.md
@@ -1,15 +1,6 @@
 ---
 title: DocumentOrShadowRoot.caretPositionFromPoint()
 slug: Web/API/Document/caretPositionFromPoint
-tags:
-  - API
-  - Document
-  - DocumentOrShadowRoot
-  - Method
-  - Reference
-  - ShadowRoot
-  - caretPositionFromPoint()
-translation_of: Web/API/DocumentOrShadowRoot/caretPositionFromPoint
 original_slug: Web/API/DocumentOrShadowRoot/caretPositionFromPoint
 ---
 {{APIRef("CSSOM View")}}{{SeeCompatTable}}

--- a/files/ja/web/api/document/caretrangefrompoint/index.md
+++ b/files/ja/web/api/document/caretrangefrompoint/index.md
@@ -1,17 +1,6 @@
 ---
 title: Document.caretRangeFromPoint()
 slug: Web/API/Document/caretRangeFromPoint
-page-type: web-api-instance-method
-tags:
-  - API
-  - CSSOM View
-  - Document
-  - HTML DOM
-  - Method
-  - Non-standard
-  - Reference
-  - caretRangeFromPoint
-translation_of: Web/API/Document/caretRangeFromPoint
 ---
 {{APIRef("DOM")}}{{Non-standard_header}}
 

--- a/files/ja/web/api/document/characterset/index.md
+++ b/files/ja/web/api/document/characterset/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.characterSet
 slug: Web/API/Document/characterSet
-tags:
-  - API
-  - DOM
-  - Document
-  - Property
-  - Read-only
-  - Reference
-translation_of: Web/API/Document/characterSet
 ---
 {{ ApiRef("DOM") }}
 

--- a/files/ja/web/api/document/childelementcount/index.md
+++ b/files/ja/web/api/document/childelementcount/index.md
@@ -1,12 +1,6 @@
 ---
 title: Document.childElementCount
 slug: Web/API/Document/childElementCount
-tags:
-  - API
-  - DOM
-  - Property
-  - Reference
-translation_of: Web/API/Document/childElementCount
 ---
 {{ APIRef("DOM") }}
 

--- a/files/ja/web/api/document/clear/index.md
+++ b/files/ja/web/api/document/clear/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.clear()
 slug: Web/API/Document/clear
-tags:
-  - DOM
-  - DOM_0
-  - Document
-  - Gecko
-  - HTML5
-translation_of: Web/API/Document/clear
 ---
 {{APIRef("DOM")}}{{ Deprecated_header() }}
 

--- a/files/ja/web/api/document/close/index.md
+++ b/files/ja/web/api/document/close/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.close()
 slug: Web/API/Document/close
-tags:
-  - API
-  - Document
-  - HTML DOM
-  - Method
-  - Reference
-  - メソッド
-translation_of: Web/API/Document/close
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/compatmode/index.md
+++ b/files/ja/web/api/document/compatmode/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.compatMode
 slug: Web/API/Document/compatMode
-tags:
-  - API
-  - DOM
-  - Document
-  - Property
-  - Reference
-translation_of: Web/API/Document/compatMode
 ---
 {{ ApiRef("DOM") }}
 

--- a/files/ja/web/api/document/contenttype/index.md
+++ b/files/ja/web/api/document/contenttype/index.md
@@ -1,17 +1,6 @@
 ---
 title: Document.contentType
 slug: Web/API/Document/contentType
-tags:
-  - API
-  - DOM
-  - Document
-  - MIME
-  - Read-only
-  - Reference
-  - contentType
-  - プロパティ
-  - 読み取り専用
-translation_of: Web/API/Document/contentType
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/cookie/index.md
+++ b/files/ja/web/api/document/cookie/index.md
@@ -1,16 +1,6 @@
 ---
 title: Document.cookie
 slug: Web/API/Document/cookie
-tags:
-  - API
-  - Document
-  - HTML DOM
-  - JS
-  - Reference
-  - cookie
-  - クッキー
-  - ストレージ
-translation_of: Web/API/Document/cookie
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/copy_event/index.md
+++ b/files/ja/web/api/document/copy_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Document: copy イベント'
 slug: Web/API/Document/copy_event
-tags:
-  - API
-  - Clipboard API
-  - Document
-  - Event
-  - Reference
-  - Web
-  - copy
-translation_of: Web/API/Document/copy_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/createattribute/index.md
+++ b/files/ja/web/api/document/createattribute/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.createAttribute()
 slug: Web/API/Document/createAttribute
-page-type: web-api-instance-method
-tags:
-  - API
-  - DOM
-  - Method
-  - Reference
-browser-compat: api.Document.createAttribute
 ---
 {{ ApiRef("DOM") }}
 

--- a/files/ja/web/api/document/createcdatasection/index.md
+++ b/files/ja/web/api/document/createcdatasection/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.createCDATASection()
 slug: Web/API/Document/createCDATASection
-page-type: web-api-instance-method
-tags:
-  - API
-  - DOM
-  - Method
-  - Reference
-translation_of: Web/API/Document/createCDATASection
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/createcomment/index.md
+++ b/files/ja/web/api/document/createcomment/index.md
@@ -1,12 +1,6 @@
 ---
 title: Document.createComment()
 slug: Web/API/Document/createComment
-tags:
-  - API
-  - DOM
-  - Method
-  - Reference
-translation_of: Web/API/Document/createComment
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/createdocumentfragment/index.md
+++ b/files/ja/web/api/document/createdocumentfragment/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.createDocumentFragment()
 slug: Web/API/Document/createDocumentFragment
-tags:
-  - API
-  - DOM
-  - Document
-  - Method
-  - Reference
-  - createDocumentFragment
-translation_of: Web/API/Document/createDocumentFragment
 ---
 {{APIRef("DOM WHATWG")}}
 

--- a/files/ja/web/api/document/createelement/index.md
+++ b/files/ja/web/api/document/createelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.createElement()
 slug: Web/API/Document/createElement
-tags:
-  - API
-  - DOM
-  - Document
-  - メソッド
-  - リファレンス
-  - createElement
-translation_of: Web/API/Document/createElement
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/createelementns/index.md
+++ b/files/ja/web/api/document/createelementns/index.md
@@ -1,12 +1,6 @@
 ---
 title: Document.createElementNS()
 slug: Web/API/Document/createElementNS
-tags:
-  - API
-  - DOM
-  - Method
-  - Reference
-translation_of: Web/API/Document/createElementNS
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/createentityreference/index.md
+++ b/files/ja/web/api/document/createentityreference/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.createEntityReference()
 slug: Web/API/Document/createEntityReference
-page-type: web-api-instance-method
-tags:
-  - API
-  - DOM
-  - メソッド
-  - リファレンス
-  - 非推奨
-translation_of: Web/API/Document/createEntityReference
 ---
 {{ApiRef("DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/document/createevent/index.md
+++ b/files/ja/web/api/document/createevent/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.createEvent()
 slug: Web/API/Document/createEvent
-tags:
-  - API
-  - DOM
-  - Method
-  - Reference
-  - メソッド
-translation_of: Web/API/Document/createEvent
 ---
 > **Warning:** `createEvent` とともに使用される多くのメソッド (`initCustomEvent` など) は非推奨です。代わりに [イベントのコンストラクター](/ja/docs/Web/API/CustomEvent) を使用してください。
 

--- a/files/ja/web/api/document/createexpression/index.md
+++ b/files/ja/web/api/document/createexpression/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.createExpression()
 slug: Web/API/Document/createExpression
-tags:
-  - API
-  - DOM
-  - Document
-  - Reference
-  - XPath
-  - createExpression
-  - メソッド
-translation_of: Web/API/Document/createExpression
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/createnodeiterator/index.md
+++ b/files/ja/web/api/document/createnodeiterator/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.createNodeIterator()
 slug: Web/API/Document/createNodeIterator
-tags:
-  - API
-  - DOM
-  - Gecko
-  - MakeBrowserAgnostic
-  - Method
-  - メソッド
-translation_of: Web/API/Document/createNodeIterator
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/creatensresolver/index.md
+++ b/files/ja/web/api/document/creatensresolver/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.createNSResolver()
 slug: Web/API/Document/createNSResolver
-tags:
-  - API
-  - DOM
-  - DOM Reference
-  - Method
-  - Reference
-translation_of: Web/API/Document/createNSResolver
 ---
 {{ ApiRef("DOM") }}
 

--- a/files/ja/web/api/document/createprocessinginstruction/index.md
+++ b/files/ja/web/api/document/createprocessinginstruction/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.createProcessingInstruction()
 slug: Web/API/Document/createProcessingInstruction
-tags:
-  - API
-  - DOM
-  - Document
-  - Method
-  - Reference
-  - createProcessInstruction
-translation_of: Web/API/Document/createProcessingInstruction
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/createrange/index.md
+++ b/files/ja/web/api/document/createrange/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.createRange()
 slug: Web/API/Document/createRange
-tags:
-  - API
-  - DOM
-  - DOM Reference
-  - Document
-  - DocumentRange.createRange
-  - Method
-  - Range
-translation_of: Web/API/Document/createRange
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/createtextnode/index.md
+++ b/files/ja/web/api/document/createtextnode/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.createTextNode()
 slug: Web/API/Document/createTextNode
-tags:
-  - API
-  - DOM
-  - Document
-  - Reference
-  - createTextNode
-  - メソッド
-translation_of: Web/API/Document/createTextNode
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/createtouch/index.md
+++ b/files/ja/web/api/document/createtouch/index.md
@@ -1,16 +1,6 @@
 ---
 title: Document.createTouch()
 slug: Web/API/Document/createTouch
-tags:
-  - API
-  - Deprecated
-  - HTML DOM
-  - Method
-  - Mobile
-  - Reference
-  - createTouch
-  - touch
-translation_of: Web/API/Document/createTouch
 ---
 {{APIRef("DOM")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/document/createtouchlist/index.md
+++ b/files/ja/web/api/document/createtouchlist/index.md
@@ -1,18 +1,6 @@
 ---
 title: Document.createTouchList()
 slug: Web/API/Document/createTouchList
-tags:
-  - API
-  - DOM
-  - Deprecated
-  - Document
-  - Method
-  - Mobile
-  - createTouchList
-  - touch
-  - タッチパネル
-  - メソッド
-translation_of: Web/API/Document/createTouchList
 ---
 {{APIRef("DOM")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/document/currentscript/index.md
+++ b/files/ja/web/api/document/currentscript/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.currentScript
 slug: Web/API/Document/currentScript
-tags:
-  - API
-  - DOM
-  - Document
-  - Property
-  - Reference
-  - プロパティ
-translation_of: Web/API/Document/currentScript
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/cut_event/index.md
+++ b/files/ja/web/api/document/cut_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Document: cut イベント'
 slug: Web/API/Document/cut_event
-tags:
-  - API
-  - Clipboard API
-  - Cut
-  - Document
-  - Event
-  - Reference
-  - Web
-translation_of: Web/API/Document/cut_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/defaultview/index.md
+++ b/files/ja/web/api/document/defaultview/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.defaultView
 slug: Web/API/Document/defaultView
-tags:
-  - API
-  - Document
-  - HTML DOM
-  - Property
-  - Reference
-translation_of: Web/API/Document/defaultView
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/document/designmode/index.md
+++ b/files/ja/web/api/document/designmode/index.md
@@ -1,17 +1,6 @@
 ---
 title: Document.designMode
 slug: Web/API/Document/designMode
-tags:
-  - API
-  - DOM
-  - Document
-  - HTML DOM
-  - Property
-  - Reference
-  - designmode
-  - editor
-  - エディター
-translation_of: Web/API/Document/designMode
 ---
 {{ApiRef()}}
 

--- a/files/ja/web/api/document/dir/index.md
+++ b/files/ja/web/api/document/dir/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.dir
 slug: Web/API/Document/dir
-tags:
-  - API
-  - Document
-  - HTML DOM
-  - Reference
-  - プロパティ
-translation_of: Web/API/Document/dir
 ---
 {{ApiRef("HTML DOM")}}
 

--- a/files/ja/web/api/document/doctype/index.md
+++ b/files/ja/web/api/document/doctype/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.doctype
 slug: Web/API/Document/doctype
-tags:
-  - API
-  - DOCTYPE
-  - DOM
-  - Document
-  - Reference
-  - プロパティ
-translation_of: Web/API/Document/doctype
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/document/document/index.md
+++ b/files/ja/web/api/document/document/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document()
 slug: Web/API/Document/Document
-tags:
-  - API
-  - DOM
-  - Document
-  - Reference
-  - コンストラクター
-translation_of: Web/API/Document/Document
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/documentelement/index.md
+++ b/files/ja/web/api/document/documentelement/index.md
@@ -1,16 +1,6 @@
 ---
 title: Document.documentElement
 slug: Web/API/Document/documentElement
-tags:
-  - API
-  - DOM
-  - Document
-  - Node
-  - Reference
-  - documentElement
-  - root
-  - プロパティ
-translation_of: Web/API/Document/documentElement
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/document/documenturi/index.md
+++ b/files/ja/web/api/document/documenturi/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.documentURI
 slug: Web/API/Document/documentURI
-tags:
-  - API
-  - DOM
-  - Document
-  - Property
-  - Read-only
-  - Reference - Web - プロパティ
-translation_of: Web/API/Document/documentURI
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/document/documenturiobject/index.md
+++ b/files/ja/web/api/document/documenturiobject/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.documentURIObject
 slug: Web/API/Document/documentURIObject
-tags:
-  - API
-  - DOM
-  - Non-standard
-  - Reference
-  - プロパティ
-  - 標準外
-translation_of: Web/API/Document/documentURIObject
 ---
 {{ApiRef("DOM")}}{{Non-standard_header}}
 

--- a/files/ja/web/api/document/domain/index.md
+++ b/files/ja/web/api/document/domain/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.domain
 slug: Web/API/Document/domain
-tags:
-  - API
-  - Document
-  - HTML DOM
-  - Property
-  - Reference
-translation_of: Web/API/Document/domain
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/document/domcontentloaded_event/index.md
+++ b/files/ja/web/api/document/domcontentloaded_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'Document: DOMContentLoaded イベント'
 slug: Web/API/Document/DOMContentLoaded_event
-tags:
-  - API
-  - DOMContentLoaded
-  - Document
-  - Event
-  - Web
-translation_of: Web/API/Document/DOMContentLoaded_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/drag_event/index.md
+++ b/files/ja/web/api/document/drag_event/index.md
@@ -1,18 +1,6 @@
 ---
 title: 'Document: drag イベント'
 slug: Web/API/Document/drag_event
-page-type: web-api-event
-tags:
-  - API
-  - DOM
-  - Document
-  - Drag
-  - DragEvent
-  - Event
-  - Reference
-  - Web
-  - drag and drop
-translation_of: Web/API/Document/drag_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/dragend_event/index.md
+++ b/files/ja/web/api/document/dragend_event/index.md
@@ -1,18 +1,6 @@
 ---
 title: 'Document: dragend イベント'
 slug: Web/API/Document/dragend_event
-page-type: web-api-event
-tags:
-  - API
-  - DOM
-  - Document
-  - DragEvent
-  - Event
-  - Reference
-  - Web
-  - drag and drop
-  - dragend
-translation_of: Web/API/Document/dragend_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/dragenter_event/index.md
+++ b/files/ja/web/api/document/dragenter_event/index.md
@@ -1,18 +1,6 @@
 ---
 title: 'Document: dragenter イベント'
 slug: Web/API/Document/dragenter_event
-page-type: web-api-event
-tags:
-  - API
-  - DOM
-  - Document
-  - DragEvent
-  - Event
-  - Reference
-  - Web
-  - drag and drop
-  - dragenter
-translation_of: Web/API/Document/dragenter_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/dragleave_event/index.md
+++ b/files/ja/web/api/document/dragleave_event/index.md
@@ -1,18 +1,6 @@
 ---
 title: 'Document: dragleave イベント'
 slug: Web/API/Document/dragleave_event
-page-type: web-api-event
-tags:
-  - API
-  - DOM
-  - Document
-  - DragEvent
-  - Event
-  - Reference
-  - Web
-  - drag and drop
-  - dragleave
-translation_of: Web/API/Document/dragleave_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/dragover_event/index.md
+++ b/files/ja/web/api/document/dragover_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'Document: dragover イベント'
 slug: Web/API/Document/dragover_event
-page-type: web-api-event
-tags:
-  - API
-  - DOM
-  - Document
-  - DragEvent
-  - Event
-  - Reference
-  - Web
-  - drag and drop
-translation_of: Web/API/Document/dragover_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/dragstart_event/index.md
+++ b/files/ja/web/api/document/dragstart_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'Document: dragstart イベント'
 slug: Web/API/Document/dragstart_event
-page-type: web-api-event
-tags:
-  - DOM
-  - Event
-  - Reference
-  - drag and drop
-translation_of: Web/API/Document/dragstart_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/drop_event/index.md
+++ b/files/ja/web/api/document/drop_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Document: drop イベント'
 slug: Web/API/Document/drop_event
-page-type: web-api-event
-tags:
-  - DOM
-  - Drag Event
-  - Drop
-  - Event
-  - HTML 5
-  - Reference
-  - drag and drop
-translation_of: Web/API/Document/drop_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/elementfrompoint/index.md
+++ b/files/ja/web/api/document/elementfrompoint/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.elementFromPoint()
 slug: Web/API/Document/elementFromPoint
-tags:
-  - API
-  - 座標
-  - Document
-  - メソッド
-  - リファレンス
-translation_of: Web/API/DocumentOrShadowRoot/elementFromPoint
-translation_of_original: Web/API/Document/elementFromPoint
 original_slug: Web/API/DocumentOrShadowRoot/elementFromPoint
 ---
 {{APIRef("DOM")}}

--- a/files/ja/web/api/document/elementsfrompoint/index.md
+++ b/files/ja/web/api/document/elementsfrompoint/index.md
@@ -1,18 +1,6 @@
 ---
 title: DocumentOrShadowRoot.elementsFromPoint()
 slug: Web/API/Document/elementsFromPoint
-tags:
-  - API
-  - Document
-  - DocumentOrShadowRoot
-  - Method
-  - Reference
-  - ShadowRoot
-  - elementsFromPoint
-  - elementsFromPoint()
-  - shadow dom
-  - メソッド
-translation_of: Web/API/DocumentOrShadowRoot/elementsFromPoint
 original_slug: Web/API/DocumentOrShadowRoot/elementsFromPoint
 ---
 {{APIRef("DOM")}}{{SeeCompatTable}}

--- a/files/ja/web/api/document/embeds/index.md
+++ b/files/ja/web/api/document/embeds/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.embeds
 slug: Web/API/Document/embeds
-tags:
-  - API
-  - DOM
-  - Document
-  - HTML DOM
-  - Property
-  - embeds
-  - プロパティ
-translation_of: Web/API/Document/embeds
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/document/enablestylesheetsforset/index.md
+++ b/files/ja/web/api/document/enablestylesheetsforset/index.md
@@ -1,17 +1,6 @@
 ---
 title: Document.enableStyleSheetsForSet()
 slug: Web/API/Document/enableStyleSheetsForSet
-page-type: web-api-instance-method
-tags:
-  - API
-  - CSSOM
-  - DOM
-  - メソッド
-  - NeedsMarkupWork
-  - NeedsSpecTable
-  - リファレンス
-  - 非推奨
-translation_of: Web/API/Document/enableStyleSheetsForSet
 ---
 {{APIRef("DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/document/evaluate/index.md
+++ b/files/ja/web/api/document/evaluate/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.evaluate()
 slug: Web/API/Document/evaluate
-translation_of: Web/API/Document/evaluate
 ---
 {{ ApiRef("DOM") }}[XPath](/ja/docs/XPath "XPath") 式やその他与えられたパラメータに基づいて [`XPathResult`](/ja/docs/XPathResult "XPathResult") を返します。
 

--- a/files/ja/web/api/document/execcommand/index.md
+++ b/files/ja/web/api/document/execcommand/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.execCommand()
 slug: Web/API/Document/execCommand
-tags:
-  - API
-  - DOM
-  - メソッド
-  - NeedsExample
-  - リファレンス
-  - エディター
-  - 非推奨
-translation_of: Web/API/Document/execCommand
 ---
 {{ApiRef("DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/document/exitfullscreen/index.md
+++ b/files/ja/web/api/document/exitfullscreen/index.md
@@ -1,21 +1,6 @@
 ---
 title: Document.exitFullscreen()
 slug: Web/API/Document/exitFullscreen
-tags:
-  - API
-  - DOM
-  - Document
-  - Full
-  - Full-screen
-  - Fullscreen API
-  - Method
-  - Reference
-  - exitFullscreen
-  - fullscreen
-  - screen
-  - メソッド
-  - 全画面
-translation_of: Web/API/Document/exitFullscreen
 ---
 {{ApiRef("Fullscreen API")}}
 

--- a/files/ja/web/api/document/exitpointerlock/index.md
+++ b/files/ja/web/api/document/exitpointerlock/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.exitPointerLock()
 slug: Web/API/Document/exitPointerLock
-tags:
-  - API
-  - Experimental
-  - Method
-  - Reference
-  - mouse lock
-translation_of: Web/API/Document/exitPointerLock
 ---
 {{APIRef("DOM")}} {{seeCompatTable}}
 

--- a/files/ja/web/api/document/featurepolicy/index.md
+++ b/files/ja/web/api/document/featurepolicy/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.featurePolicy
 slug: Web/API/Document/featurePolicy
-tags:
-  - API
-  - Document
-  - Feature Policy
-  - Feature-Policy
-  - Reference
-  - 機能ポリシー
-translation_of: Web/API/Document/featurePolicy
 ---
 {{APIRef("Feature Policy")}}
 

--- a/files/ja/web/api/document/fgcolor/index.md
+++ b/files/ja/web/api/document/fgcolor/index.md
@@ -1,16 +1,6 @@
 ---
 title: Document.fgColor
 slug: Web/API/Document/fgColor
-tags:
-  - API
-  - DOM
-  - Deprecated
-  - Document
-  - HTML DOM
-  - Reference
-  - fgColor
-  - プロパティ
-translation_of: Web/API/Document/fgColor
 ---
 {{ApiRef}}{{Deprecated_header}}
 

--- a/files/ja/web/api/document/fonts/index.md
+++ b/files/ja/web/api/document/fonts/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.fonts
 slug: Web/API/Document/fonts
-tags:
-  - API
-  - DOM
-  - Font Loading API
-  - FontFace
-  - FontFaceSet
-  - Fonts
-  - フォント
-translation_of: Web/API/Document/fonts
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/forms/index.md
+++ b/files/ja/web/api/document/forms/index.md
@@ -1,16 +1,6 @@
 ---
 title: Document.forms
 slug: Web/API/Document/forms
-tags:
-  - API
-  - DOM
-  - Document
-  - HTML DOM
-  - HTML フォーム
-  - フォーム
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/Document/forms
 ---
 {{domxref("Document")}} インターフェイスの **`forms`** プロパティは読み取り専用で、文書内に含まれるすべての {{HTMLElement("form")}} を列挙した {{domxref("HTMLCollection")}} を返します。
 

--- a/files/ja/web/api/document/fullscreen/index.md
+++ b/files/ja/web/api/document/fullscreen/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.fullscreen
 slug: Web/API/Document/fullscreen
-tags:
-  - API
-  - Document
-  - Fullscreen API
-  - Read-only
-  - Reference
-  - プロパティ
-translation_of: Web/API/Document/fullscreen
 ---
 {{APIRef("Fullscreen API")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/document/fullscreenchange_event/index.md
+++ b/files/ja/web/api/document/fullscreenchange_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Document: fullscreenchange イベント'
 slug: Web/API/Document/fullscreenchange_event
-tags:
-  - API
-  - Fullscreen API
-  - Reference
-  - events
-  - fullscreen
-  - fullscreenchange
-  - イベント
-  - 全画面モード
-translation_of: Web/API/Document/fullscreenchange_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/fullscreenelement/index.md
+++ b/files/ja/web/api/document/fullscreenelement/index.md
@@ -1,23 +1,6 @@
 ---
 title: DocumentOrShadowRoot.fullscreenElement
 slug: Web/API/Document/fullscreenElement
-tags:
-  - API
-  - Document
-  - DocumentOrShadowRoot
-  - Full-screen
-  - Fullscreen API
-  - Graphics
-  - Property
-  - Read-only
-  - Reference
-  - ShadowRoot
-  - fullscreenElement
-  - screen
-  - グラフィック
-  - 全画面
-  - 読み取り専用
-translation_of: Web/API/DocumentOrShadowRoot/fullscreenElement
 original_slug: Web/API/DocumentOrShadowRoot/fullscreenElement
 ---
 {{ApiRef("Fullscreen API")}}

--- a/files/ja/web/api/document/fullscreenenabled/index.md
+++ b/files/ja/web/api/document/fullscreenenabled/index.md
@@ -1,18 +1,6 @@
 ---
 title: Document.fullscreenEnabled
 slug: Web/API/Document/fullscreenEnabled
-tags:
-  - API
-  - Document
-  - Fullscreen API
-  - Property
-  - Read-only
-  - Reference
-  - fullscreenEnabled
-  - プロパティ
-  - 全画面
-  - 画面
-translation_of: Web/API/Document/fullscreenEnabled
 ---
 {{APIRef("Fullscreen API")}}
 

--- a/files/ja/web/api/document/fullscreenerror_event/index.md
+++ b/files/ja/web/api/document/fullscreenerror_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Document: fullscreenerror イベント'
 slug: Web/API/Document/fullscreenerror_event
-tags:
-  - API
-  - Error
-  - Event
-  - Fullscreen API
-  - Reference
-  - fullscreen
-  - fullscreenerror
-translation_of: Web/API/Document/fullscreenerror_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/getanimations/index.md
+++ b/files/ja/web/api/document/getanimations/index.md
@@ -1,22 +1,6 @@
 ---
 title: Document.getAnimations()
 slug: Web/API/Document/getAnimations
-tags:
-  - API
-  - Animation
-  - CSS
-  - CSS Animations
-  - CSS Transitions
-  - Document
-  - Experimental
-  - Method
-  - Reference
-  - Transitions
-  - Web Animations
-  - getAnimations
-  - waapi
-  - web animations api
-translation_of: Web/API/DocumentOrShadowRoot/getAnimations
 original_slug: Web/API/DocumentOrShadowRoot/getAnimations
 ---
 {{ SeeCompatTable() }}{{APIRef("Web Animations")}}

--- a/files/ja/web/api/document/getelementbyid/index.md
+++ b/files/ja/web/api/document/getelementbyid/index.md
@@ -1,17 +1,6 @@
 ---
 title: Document.getElementById()
 slug: Web/API/Document/getElementById
-tags:
-  - API
-  - DOM
-  - Document
-  - Elements
-  - Method
-  - Reference
-  - Web
-  - getElementById
-  - id
-translation_of: Web/API/Document/getElementById
 ---
 {{ ApiRef("DOM") }}
 

--- a/files/ja/web/api/document/getelementsbyclassname/index.md
+++ b/files/ja/web/api/document/getelementsbyclassname/index.md
@@ -1,16 +1,6 @@
 ---
 title: Document.getElementsByClassName()
 slug: Web/API/Document/getElementsByClassName
-tags:
-  - API
-  - DOM
-  - DOM Element Methods
-  - Element
-  - HTML5
-  - Method
-  - Reference
-  - メソッド
-translation_of: Web/API/Document/getElementsByClassName
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/getelementsbyname/index.md
+++ b/files/ja/web/api/document/getelementsbyname/index.md
@@ -1,16 +1,6 @@
 ---
 title: Document.getElementsByName()
 slug: Web/API/Document/getElementsByName
-tags:
-  - API
-  - DOM
-  - Document
-  - HTML
-  - Method
-  - Reference
-  - getElementByName
-  - メソッド
-translation_of: Web/API/Document/getElementsByName
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/getelementsbytagname/index.md
+++ b/files/ja/web/api/document/getelementsbytagname/index.md
@@ -1,12 +1,6 @@
 ---
 title: Document.getElementsByTagName()
 slug: Web/API/Document/getElementsByTagName
-tags:
-  - API
-  - DOM
-  - Method
-  - Reference
-translation_of: Web/API/Document/getElementsByTagName
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/getelementsbytagnamens/index.md
+++ b/files/ja/web/api/document/getelementsbytagnamens/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.getElementsByTagNameNS()
 slug: Web/API/Document/getElementsByTagNameNS
-tags:
-  - API
-  - DOM
-  - Method
-  - NeedsMarkupWork
-  - NeedsSpecTable
-  - Reference
-  - getElementsByTagNameNS
-translation_of: Web/API/Document/getElementsByTagNameNS
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/getselection/index.md
+++ b/files/ja/web/api/document/getselection/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.getSelection()
 slug: Web/API/Document/getSelection
-tags:
-  - API
-  - Document
-  - Method
-  - Reference
-  - getSelection
-translation_of: Web/API/Document/getSelection
 original_slug: Web/API/DocumentOrShadowRoot/getSelection
 ---
 {{APIRef("DOM")}}

--- a/files/ja/web/api/document/hasfocus/index.md
+++ b/files/ja/web/api/document/hasfocus/index.md
@@ -1,15 +1,6 @@
 ---
 title: document.hasFocus()
 slug: Web/API/Document/hasFocus
-tags:
-  - API
-  - DOM
-  - Focus
-  - Method
-  - Reference
-  - フォーカス
-  - メソッド
-translation_of: Web/API/Document/hasFocus
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/hasstorageaccess/index.md
+++ b/files/ja/web/api/document/hasstorageaccess/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.hasStorageAccess()
 slug: Web/API/Document/hasStorageAccess
-tags:
-  - API
-  - DOM
-  - Document
-  - Reference
-  - Storage Access API
-  - hasStorageAccess
-  - メソッド
-translation_of: Web/API/Document/hasStorageAccess
 ---
 {{APIRef}}{{seecompattable}}
 

--- a/files/ja/web/api/document/head/index.md
+++ b/files/ja/web/api/document/head/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.head
 slug: Web/API/Document/head
-tags:
-  - API
-  - Document
-  - HTML DOM
-  - Reference
-  - head
-translation_of: Web/API/Document/head
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/height/index.md
+++ b/files/ja/web/api/document/height/index.md
@@ -1,17 +1,6 @@
 ---
 title: Document.height
 slug: Web/API/Document/height
-page-type: web-api-instance-property
-tags:
-  - API
-  - Document
-  - HTML DOM
-  - NeedsMarkupWork
-  - NeedsSpecTable
-  - プロパティ
-  - リファレンス
-  - 非推奨
-translation_of: Web/API/Document/height
 ---
 {{APIRef("DOM")}} {{deprecated_header}}
 

--- a/files/ja/web/api/document/hidden/index.md
+++ b/files/ja/web/api/document/hidden/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.hidden
 slug: Web/API/Document/hidden
-tags:
-  - DOM
-  - Document
-  - Page Visibility API
-  - Property
-  - Read-only
-  - Reference
-  - Web
-translation_of: Web/API/Document/hidden
 ---
 {{ ApiRef("DOM") }}
 

--- a/files/ja/web/api/document/images/index.md
+++ b/files/ja/web/api/document/images/index.md
@@ -1,12 +1,6 @@
 ---
 title: document.images
 slug: Web/API/Document/images
-tags:
-  - DOM
-  - Document
-  - Gecko
-  - Gecko DOM Reference
-translation_of: Web/API/Document/images
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/document/implementation/index.md
+++ b/files/ja/web/api/document/implementation/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.implementation
 slug: Web/API/Document/implementation
-tags:
-  - API
-  - DOM
-  - Document
-  - NeedsContent
-  - Property
-  - Reference
-translation_of: Web/API/Document/implementation
 ---
 {{ ApiRef("DOM") }}
 

--- a/files/ja/web/api/document/importnode/index.md
+++ b/files/ja/web/api/document/importnode/index.md
@@ -1,16 +1,6 @@
 ---
 title: Document.importNode()
 slug: Web/API/Document/importNode
-tags:
-  - API
-  - DOM
-  - Document
-  - メソッド
-  - ノード
-  - リファレンス
-  - コピー
-  - importNode
-translation_of: Web/API/Document/importNode
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/index.md
+++ b/files/ja/web/api/document/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document
 slug: Web/API/Document
-tags:
-  - API
-  - DOM
-  - Document
-  - インターフェイス
-  - リファレンス
-translation_of: Web/API/Document
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/lastmodified/index.md
+++ b/files/ja/web/api/document/lastmodified/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.lastModified
 slug: Web/API/Document/lastModified
-tags:
-  - API
-  - Document
-  - HTML DOM
-  - NeedsSpecTable
-  - Property
-  - Reference
-translation_of: Web/API/Document/lastModified
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/laststylesheetset/index.md
+++ b/files/ja/web/api/document/laststylesheetset/index.md
@@ -1,18 +1,6 @@
 ---
 title: Document.lastStyleSheetSet
 slug: Web/API/Document/lastStyleSheetSet
-page-type: web-api-instance-property
-tags:
-  - API
-  - CSSOM
-  - DOM
-  - Document
-  - プロパティ
-  - リファレンス
-  - スタイルシート
-  - lastStyleSheetSet
-  - 非推奨
-translation_of: Web/API/Document/lastStyleSheetSet
 ---
 {{APIRef("DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/document/linkcolor/index.md
+++ b/files/ja/web/api/document/linkcolor/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.linkColor
 slug: Web/API/Document/linkColor
-tags:
-  - API
-  - Deprecated
-  - Document
-  - HTML DOM
-  - Property
-  - Reference
-  - プロパティ
-translation_of: Web/API/Document/linkColor
 ---
 {{APIRef("DOM")}} {{Deprecated_header}}
 

--- a/files/ja/web/api/document/links/index.md
+++ b/files/ja/web/api/document/links/index.md
@@ -1,12 +1,6 @@
 ---
 title: document.links
 slug: Web/API/Document/links
-tags:
-  - DOM
-  - Document
-  - Gecko
-  - Gecko DOM Reference
-translation_of: Web/API/Document/links
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/document/location/index.md
+++ b/files/ja/web/api/document/location/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.location
 slug: Web/API/Document/location
-tags:
-  - API
-  - Document
-  - HTML DOM
-  - Property
-  - Read-only
-  - Reference
-  - プロパティ
-translation_of: Web/API/Document/location
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/lostpointercapture_event/index.md
+++ b/files/ja/web/api/document/lostpointercapture_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Document: lostpointercapture イベント'
 slug: Web/API/Document/lostpointercapture_event
-tags:
-  - API
-  - Document
-  - Event
-  - PointerEvent
-  - Reference
-  - lostpointercapture
-  - イベント
-translation_of: Web/API/Document/lostpointercapture_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/open/index.md
+++ b/files/ja/web/api/document/open/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.open()
 slug: Web/API/Document/open
-tags:
-  - API
-  - DOM
-  - Document
-  - Method
-  - Reference
-  - open
-  - メソッド
-translation_of: Web/API/Document/open
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/origin/index.md
+++ b/files/ja/web/api/document/origin/index.md
@@ -1,17 +1,6 @@
 ---
 title: Document.origin
 slug: Web/API/Document/origin
-page-type: web-api-instance-property
-tags:
-  - API
-  - DOM
-  - Document
-  - 実験的
-  - Interface
-  - プロパティ
-  - 読み取り専用
-  - 非推奨
-translation_of: Web/API/Document/origin
 ---
 {{APIRef("DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/document/paste_event/index.md
+++ b/files/ja/web/api/document/paste_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Document: paste イベント'
 slug: Web/API/Document/paste_event
-tags:
-  - API
-  - Document
-  - Event
-  - Reference
-  - Web
-  - paste
-  - イベント
-translation_of: Web/API/Document/paste_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/plugins/index.md
+++ b/files/ja/web/api/document/plugins/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.plugins
 slug: Web/API/Document/plugins
-tags:
-  - API
-  - Document
-  - Plugins
-  - Property
-  - Reference
-  - embed
-  - プロパティ
-translation_of: Web/API/Document/plugins
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/pointercancel_event/index.md
+++ b/files/ja/web/api/document/pointercancel_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Document: pointercancel イベント'
 slug: Web/API/Document/pointercancel_event
-tags:
-  - API
-  - Document
-  - Event
-  - PointerEvent
-  - onpointercancel
-  - pointercancel
-  - イベント
-translation_of: Web/API/Document/pointercancel_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/pointerdown_event/index.md
+++ b/files/ja/web/api/document/pointerdown_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Document: pointerdown イベント'
 slug: Web/API/Document/pointerdown_event
-tags:
-  - API
-  - Document
-  - Event
-  - PointerEvent
-  - Reference
-  - onpointerdown
-  - pointerdown
-  - イベント
-translation_of: Web/API/Document/pointerdown_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/pointerenter_event/index.md
+++ b/files/ja/web/api/document/pointerenter_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Document: pointerenter イベント'
 slug: Web/API/Document/pointerenter_event
-tags:
-  - API
-  - Document
-  - Event
-  - PointerEvent
-  - Reference
-  - onpointerenter
-  - pointerenter
-  - イベント
-translation_of: Web/API/Document/pointerenter_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/pointerleave_event/index.md
+++ b/files/ja/web/api/document/pointerleave_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Document: pointerleave イベント'
 slug: Web/API/Document/pointerleave_event
-tags:
-  - API
-  - Document
-  - Event
-  - PointerEvent
-  - Reference
-  - onpointerleave
-  - pointerleave
-  - イベント
-translation_of: Web/API/Document/pointerleave_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/pointerlockchange_event/index.md
+++ b/files/ja/web/api/document/pointerlockchange_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Document: pointerlockchange イベント'
 slug: Web/API/Document/pointerlockchange_event
-tags:
-  - Document
-  - Event
-  - Reference
-  - Web
-  - pointerlockchange
-  - イベント
-  - ウェブ
-translation_of: Web/API/Document/pointerlockchange_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/pointerlockelement/index.md
+++ b/files/ja/web/api/document/pointerlockelement/index.md
@@ -1,17 +1,6 @@
 ---
 title: DocumentOrShadowRoot.pointerLockElement
 slug: Web/API/Document/pointerLockElement
-tags:
-  - API
-  - DOM
-  - Document
-  - Property
-  - Reference
-  - ShadowRoot
-  - mouse lock
-  - プロパティ
-  - マウスロック
-translation_of: Web/API/DocumentOrShadowRoot/pointerLockElement
 original_slug: Web/API/DocumentOrShadowRoot/pointerLockElement
 ---
 {{APIRef("DOM")}}

--- a/files/ja/web/api/document/pointerlockerror_event/index.md
+++ b/files/ja/web/api/document/pointerlockerror_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Document: pointerlockerror イベント'
 slug: Web/API/Document/pointerlockerror_event
-tags:
-  - Document
-  - Event
-  - Reference
-  - Web
-  - pointerlockerror
-  - イベント
-  - ウェブ
-  - ポインター
-translation_of: Web/API/Document/pointerlockerror_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/pointermove_event/index.md
+++ b/files/ja/web/api/document/pointermove_event/index.md
@@ -1,18 +1,6 @@
 ---
 title: 'Document: pointermove イベント'
 slug: Web/API/Document/pointermove_event
-tags:
-  - Document
-  - Event
-  - PointerEvent
-  - Reference
-  - Web
-  - pointer
-  - pointermove
-  - イベント
-  - ウェブ
-  - ポインター
-translation_of: Web/API/Document/pointermove_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/pointerout_event/index.md
+++ b/files/ja/web/api/document/pointerout_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Document: pointerout イベント'
 slug: Web/API/Document/pointerout_event
-tags:
-  - Document
-  - Event
-  - PointerEvent
-  - Reference
-  - Web
-  - onpointerout
-  - pointerout
-  - イベント
-translation_of: Web/API/Document/pointerout_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/pointerover_event/index.md
+++ b/files/ja/web/api/document/pointerover_event/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'Document: pointerover イベント'
 slug: Web/API/Document/pointerover_event
-tags:
-  - API
-  - Document
-  - Event
-  - PointerEvent
-  - Reference
-  - Web
-  - onpointerover
-  - pointer
-  - pointerover
-  - イベント
-  - ポインター
-translation_of: Web/API/Document/pointerover_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/pointerup_event/index.md
+++ b/files/ja/web/api/document/pointerup_event/index.md
@@ -1,18 +1,6 @@
 ---
 title: 'Document: pointerup event'
 slug: Web/API/Document/pointerup_event
-tags:
-  - API
-  - Document
-  - Event
-  - PointerEvent
-  - Reference
-  - Web
-  - onpointerup
-  - pointerup
-  - イベント
-  - ポインター
-translation_of: Web/API/Document/pointerup_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/preferredstylesheetset/index.md
+++ b/files/ja/web/api/document/preferredstylesheetset/index.md
@@ -1,17 +1,6 @@
 ---
 title: Document.preferredStyleSheetSet
 slug: Web/API/Document/preferredStyleSheetSet
-page-type: web-api-instance-property
-tags:
-  - API
-  - CSSOM
-  - DOM
-  - Document
-  - プロパティ
-  - リファレンス
-  - Stylesheets
-  - 非推奨
-translation_of: Web/API/Document/preferredStyleSheetSet
 ---
 {{APIRef("DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/document/querycommandstate/index.md
+++ b/files/ja/web/api/document/querycommandstate/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.queryCommandState()
 slug: Web/API/Document/queryCommandState
-page-type: web-api-instance-method
-tags:
-  - API
-  - DOM
-  - リファレンス
-  - 非推奨
-translation_of: Web/API/Document/queryCommandState
 ---
 {{ApiRef("DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/document/querycommandsupported/index.md
+++ b/files/ja/web/api/document/querycommandsupported/index.md
@@ -1,16 +1,6 @@
 ---
 title: Document.queryCommandSupported()
 slug: Web/API/Document/queryCommandSupported
-page-type: web-api-instance-method
-tags:
-  - API
-  - DOM
-  - Document
-  - メソッド
-  - リファレンス
-  - エディター
-  - 非推奨
-translation_of: Web/API/Document/queryCommandSupported
 ---
 {{ApiRef("DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/document/queryselector/index.md
+++ b/files/ja/web/api/document/queryselector/index.md
@@ -1,18 +1,6 @@
 ---
 title: Document.querySelector()
 slug: Web/API/Document/querySelector
-tags:
-  - API
-  - CSS セレクター
-  - DOM
-  - DOM 要素
-  - Document
-  - メソッド
-  - リファレンス
-  - セレクター API
-  - セレクター
-  - querySelector
-translation_of: Web/API/Document/querySelector
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/document/queryselectorall/index.md
+++ b/files/ja/web/api/document/queryselectorall/index.md
@@ -1,20 +1,6 @@
 ---
 title: Document.querySelectorAll()
 slug: Web/API/Document/querySelectorAll
-tags:
-  - API
-  - CSS セレクター
-  - DOM
-  - Document
-  - Finding Elements
-  - Locating Elements
-  - メソッド
-  - リファレンス
-  - Searching Elements
-  - Selecting Elements
-  - セレクター
-  - querySelectorAll
-translation_of: Web/API/Document/querySelectorAll
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/readystate/index.md
+++ b/files/ja/web/api/document/readystate/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.readyState
 slug: Web/API/Document/readyState
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - Property
-  - Reference
-translation_of: Web/API/Document/readyState
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/readystatechange_event/index.md
+++ b/files/ja/web/api/document/readystatechange_event/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'Document: readystatechange イベント'
 slug: Web/API/Document/readystatechange_event
-tags:
-  - Event
-  - Reference
-  - XMLHttpRequest
-  - interactive
-translation_of: Web/API/Document/readystatechange_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/referrer/index.md
+++ b/files/ja/web/api/document/referrer/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.referrer
 slug: Web/API/Document/referrer
-tags:
-  - API
-  - Document
-  - HTML DOM
-  - Property
-  - Reference
-  - referrer
-  - プロパティ
-translation_of: Web/API/Document/referrer
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/releasecapture/index.md
+++ b/files/ja/web/api/document/releasecapture/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.releaseCapture()
 slug: Web/API/Document/releaseCapture
-page-type: web-api-instance-method
-tags:
-  - API
-  - DOM
-  - Method
-  - Reference
-translation_of: Web/API/Document/releaseCapture
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/document/requeststorageaccess/index.md
+++ b/files/ja/web/api/document/requeststorageaccess/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.requestStorageAccess()
 slug: Web/API/Document/requestStorageAccess
-tags:
-  - API
-  - DOM
-  - Document
-  - メソッド
-  - Reference
-  - Storage Access API
-  - requestStorageAccess
-translation_of: Web/API/Document/requestStorageAccess
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/rootelement/index.md
+++ b/files/ja/web/api/document/rootelement/index.md
@@ -1,16 +1,6 @@
 ---
 title: Document.rootElement
 slug: Web/API/Document/rootElement
-tags:
-  - API
-  - DOM
-  - Deprecated
-  - Document
-  - Property
-  - Reference
-  - SVG
-  - root
-translation_of: Web/API/Document/rootElement
 ---
 {{ApiRef("DOM")}}{{Deprecated_header}}
 

--- a/files/ja/web/api/document/scripts/index.md
+++ b/files/ja/web/api/document/scripts/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.scripts
 slug: Web/API/Document/scripts
-tags:
-  - API
-  - Document
-  - HTML DOM
-  - Property
-  - Reference
-  - Script
-  - プロパティ
-translation_of: Web/API/Document/scripts
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/scroll_event/index.md
+++ b/files/ja/web/api/document/scroll_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Document: scroll event'
 slug: Web/API/Document/scroll_event
-tags:
-  - API
-  - DOM
-  - Document
-  - Event
-  - Reference
-  - Scroll
-  - UIEvent
-translation_of: Web/API/Document/scroll_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/scrollingelement/index.md
+++ b/files/ja/web/api/document/scrollingelement/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.scrollingElement
 slug: Web/API/Document/scrollingElement
-tags:
-  - API
-  - Document
-  - Property
-  - Reference
-  - scrollingElement
-translation_of: Web/API/Document/scrollingElement
 ---
 {{APIRef("DOM")}}**`scrollingElement`** は、{{domxref("Document")}} インターフェースの読み込み専用プロパティです。スクロール可能な {{domxref("Element")}} の参照を返します。スタンダードモードでは、ドキュメントのルート要素である {{domxref("document.documentElement")}} になります。後方互換モードでは、`scrollingElement` は HTML の `body` 要素を返します。`body` 要素が存在しないか、それが [スクロール可能](https://drafts.csswg.org/cssom-view/#potentially-scrollable) な場合は null を返します。
 

--- a/files/ja/web/api/document/selectedstylesheetset/index.md
+++ b/files/ja/web/api/document/selectedstylesheetset/index.md
@@ -1,16 +1,6 @@
 ---
 title: Document.selectedStyleSheetSet
 slug: Web/API/Document/selectedStyleSheetSet
-page-type: web-api-instance-property
-tags:
-  - API
-  - CSSOM
-  - DOM
-  - プロパティ
-  - リファレンス
-  - スタイルシート
-  - 非推奨
-translation_of: Web/API/Document/selectedStyleSheetSet
 ---
 {{APIRef("DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/document/selectionchange_event/index.md
+++ b/files/ja/web/api/document/selectionchange_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'Document: selectionchange イベント'
 slug: Web/API/Document/selectionchange_event
-tags:
-  - Event
-  - Reference
-  - Selection
-  - Selection API
-  - selectionchange
-translation_of: Web/API/Document/selectionchange_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/selectstart_event/index.md
+++ b/files/ja/web/api/document/selectstart_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: 'Document: selectstart event'
 slug: Web/API/Document/selectstart_event
-translation_of: Web/API/Document/selectstart_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/stylesheets/index.md
+++ b/files/ja/web/api/document/stylesheets/index.md
@@ -1,16 +1,6 @@
 ---
 title: DocumentOrShadowRoot.styleSheets
 slug: Web/API/Document/styleSheets
-tags:
-  - API
-  - Document
-  - DocumentOrShadowRoot
-  - Property
-  - Reference
-  - ShadowRoot
-  - Stylesheets
-  - shadow dom
-translation_of: Web/API/DocumentOrShadowRoot/styleSheets
 original_slug: Web/API/DocumentOrShadowRoot/styleSheets
 ---
 {{SeeCompatTable}}{{APIRef("Shadow DOM")}}

--- a/files/ja/web/api/document/stylesheetsets/index.md
+++ b/files/ja/web/api/document/stylesheetsets/index.md
@@ -1,16 +1,6 @@
 ---
 title: Document.styleSheetSets
 slug: Web/API/Document/styleSheetSets
-page-type: web-api-instance-property
-tags:
-  - API
-  - CSSOM
-  - DOM
-  - プロパティ
-  - リファレンス
-  - スタイルシート
-  - 非推奨
-translation_of: Web/API/Document/styleSheetSets
 ---
 {{APIRef("DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/document/title/index.md
+++ b/files/ja/web/api/document/title/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.title
 slug: Web/API/Document/title
-tags:
-  - API
-  - Command API
-  - Document
-  - HTML DOM
-  - NeedsSpecTable
-  - Property
-  - Reference
-translation_of: Web/API/Document/title
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/tooltipnode/index.md
+++ b/files/ja/web/api/document/tooltipnode/index.md
@@ -1,17 +1,6 @@
 ---
 title: Document.tooltipNode
 slug: Web/API/Document/tooltipNode
-tags:
-  - API
-  - API:Mozilla Extensions
-  - DOM
-  - Draft
-  - Gecko
-  - Mozilla
-  - Non-standard
-  - Property
-  - Reference
-translation_of: Web/API/Document/tooltipNode
 ---
 {{APIRef("DOM")}}{{Non-standard_Header}}
 

--- a/files/ja/web/api/document/touchcancel_event/index.md
+++ b/files/ja/web/api/document/touchcancel_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'Document: touchcancel イベント'
 slug: Web/API/Document/touchcancel_event
-tags:
-  - Document
-  - Event
-  - Reference
-  - TouchEvent
-  - Web
-  - touchcancel
-translation_of: Web/API/Document/touchcancel_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/touchend_event/index.md
+++ b/files/ja/web/api/document/touchend_event/index.md
@@ -1,20 +1,6 @@
 ---
 title: Document:touchend イベント
 slug: Web/API/Document/touchend_event
-tags:
-  - API
-  - Event
-  - Reference
-  - Touch Events
-  - TouchEvent
-  - UI
-  - UI Events
-  - UX
-  - ontouchend
-  - touch
-  - touchend
-  - イベント
-translation_of: Web/API/Document/touchend_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/touchmove_event/index.md
+++ b/files/ja/web/api/document/touchmove_event/index.md
@@ -1,21 +1,6 @@
 ---
 title: 'Document: touchmove イベント'
 slug: Web/API/Document/touchmove_event
-tags:
-  - API
-  - DOM
-  - Document
-  - Event
-  - Reference
-  - Touch Events
-  - TouchEvent
-  - UI
-  - UI Events
-  - UX
-  - touch
-  - touchmove
-  - イベント
-translation_of: Web/API/Document/touchmove_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/touchstart_event/index.md
+++ b/files/ja/web/api/document/touchstart_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Document: touchstart event'
 slug: Web/API/Document/touchstart_event
-tags:
-  - Document
-  - Event
-  - Reference
-  - TouchEvent
-  - Web
-  - touchstart
-  - イベント
-  - ウェブ
-translation_of: Web/API/Document/touchstart_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/url/index.md
+++ b/files/ja/web/api/document/url/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.URL
 slug: Web/API/Document/URL
-tags:
-  - API
-  - DOM
-  - Document
-  - Property
-  - Reference
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/Document/URL
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/document/visibilitychange_event/index.md
+++ b/files/ja/web/api/document/visibilitychange_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Document: visibilitychange イベント'
 slug: Web/API/Document/visibilitychange_event
-tags:
-  - API
-  - Document
-  - Event
-  - Reference
-  - Visibility
-  - Web
-  - visibilitychange
-translation_of: Web/API/Document/visibilitychange_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/document/visibilitystate/index.md
+++ b/files/ja/web/api/document/visibilitystate/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.visibilityState
 slug: Web/API/Document/visibilityState
-tags:
-  - DOM
-  - Document
-  - Page Visibility API
-  - Property
-  - Read-only
-  - Reference
-  - Web
-translation_of: Web/API/Document/visibilityState
 ---
 {{ ApiRef("DOM") }}
 

--- a/files/ja/web/api/document/vlinkcolor/index.md
+++ b/files/ja/web/api/document/vlinkcolor/index.md
@@ -1,16 +1,6 @@
 ---
 title: Document.vlinkColor
 slug: Web/API/Document/vlinkColor
-tags:
-  - API
-  - Deprecated
-  - Document
-  - HTML DOM
-  - Property
-  - Reference
-  - プロパティ
-  - 非推奨
-translation_of: Web/API/Document/vlinkColor
 ---
 {{APIRef("DOM")}} {{ Deprecated_header() }}
 

--- a/files/ja/web/api/document/width/index.md
+++ b/files/ja/web/api/document/width/index.md
@@ -1,17 +1,6 @@
 ---
 title: Document.width
 slug: Web/API/Document/width
-page-type: web-api-instance-property
-tags:
-  - API
-  - Document
-  - HTML DOM
-  - NeedsBrowserAgnosticism
-  - NeedsSpecTable
-  - プロパティ
-  - リファレンス
-  - 非推奨
-translation_of: Web/API/Document/width
 ---
 {{APIRef("DOM")}} {{deprecated_header}}
 

--- a/files/ja/web/api/document/write/index.md
+++ b/files/ja/web/api/document/write/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.write()
 slug: Web/API/Document/write
-tags:
-  - API
-  - DOM
-  - Document
-  - Method
-  - Reference
-  - write
-translation_of: Web/API/Document/write
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/document/writeln/index.md
+++ b/files/ja/web/api/document/writeln/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.writeln()
 slug: Web/API/Document/writeln
-tags:
-  - API
-  - DOM
-  - Method
-  - Reference
-  - メソッド
-translation_of: Web/API/Document/writeln
 ---
 {{ ApiRef("DOM") }}
 

--- a/files/ja/web/api/document/xmlversion/index.md
+++ b/files/ja/web/api/document/xmlversion/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.xmlVersion
 slug: Web/API/Document/xmlVersion
-page-type: web-api-instance-property
-tags:
-  - API
-  - DOM
-  - DOM リファレンス
-  - プロパティ
-  - リファレンス
-  - 非推奨
-translation_of: Web/API/Document/xmlVersion
 ---
 {{APIRef("DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/document_object_model/examples/index.md
+++ b/files/ja/web/api/document_object_model/examples/index.md
@@ -1,10 +1,6 @@
 ---
 title: DOM を使用したウェブと XML の開発の例
 slug: Web/API/Document_Object_Model/Examples
-tags:
-  - DOM
-  - DOM リファレンス
-translation_of: Web/API/Document_Object_Model/Examples
 ---
 {{DefaultAPISidebar("DOM")}}
 

--- a/files/ja/web/api/document_object_model/how_to_create_a_dom_tree/index.md
+++ b/files/ja/web/api/document_object_model/how_to_create_a_dom_tree/index.md
@@ -1,15 +1,6 @@
 ---
 title: DOM ツリーの作成方法
 slug: Web/API/Document_object_model/How_to_create_a_DOM_tree
-tags:
-  - AJAX
-  - アドオン
-  - DOM
-  - 拡張機能
-  - JXON
-  - NeedsUpdate
-  - XML
-translation_of: Web/API/Document_object_model/How_to_create_a_DOM_tree
 ---
 {{DefaultAPISidebar("DOM")}}
 

--- a/files/ja/web/api/document_object_model/index.md
+++ b/files/ja/web/api/document_object_model/index.md
@@ -1,16 +1,6 @@
 ---
 title: ドキュメントオブジェクトモデル (DOM)
 slug: Web/API/Document_Object_Model
-tags:
-  - API
-  - DOM
-  - 文書
-  - ドキュメントオブジェクトモデル
-  - ガイド
-  - 概要
-  - リファレンス
-  - ウェブ
-translation_of: Web/API/Document_Object_Model
 ---
 {{DefaultAPISidebar("DOM")}}
 

--- a/files/ja/web/api/document_object_model/introduction/index.md
+++ b/files/ja/web/api/document_object_model/introduction/index.md
@@ -1,15 +1,6 @@
 ---
 title: DOM の紹介
 slug: Web/API/Document_Object_Model/Introduction
-tags:
-  - 初心者
-  - DOM
-  - 文書
-  - ガイド
-  - HTML DOM
-  - 導入
-  - チュートリアル
-translation_of: Web/API/Document_Object_Model/Introduction
 ---
 {{DefaultAPISidebar("DOM")}}
 

--- a/files/ja/web/api/document_object_model/locating_dom_elements_using_selectors/index.md
+++ b/files/ja/web/api/document_object_model/locating_dom_elements_using_selectors/index.md
@@ -1,11 +1,6 @@
 ---
 title: セレクターを使用した DOM 要素の特定
 slug: Web/API/Document_object_model/Locating_DOM_elements_using_selectors
-tags:
-  - 初心者向け
-  - DOM
-  - NeedsBeginnerUpdate
-translation_of: Web/API/Document_object_model/Locating_DOM_elements_using_selectors
 ---
 {{DefaultAPISidebar("DOM")}}
 

--- a/files/ja/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
+++ b/files/ja/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
@@ -1,15 +1,6 @@
 ---
 title: JavaScript と DOM インターフェイスによる HTML の表の操作
-slug: >-
-  Web/API/Document_Object_Model/Traversing_an_HTML_table_with_JavaScript_and_DOM_Interfaces
-tags:
-  - API
-  - DOM
-  - ガイド
-  - HTML
-  - JavaScript
-translation_of: >-
-  Web/API/Document_Object_Model/Traversing_an_HTML_table_with_JavaScript_and_DOM_Interfaces
+slug: Web/API/Document_Object_Model/Traversing_an_HTML_table_with_JavaScript_and_DOM_Interfaces
 ---
 {{DefaultAPISidebar("DOM")}}
 

--- a/files/ja/web/api/document_object_model/using_the_w3c_dom_level_1_core/index.md
+++ b/files/ja/web/api/document_object_model/using_the_w3c_dom_level_1_core/index.md
@@ -1,10 +1,6 @@
 ---
 title: W3C DOM Level 1 Core の使用
 slug: Web/API/Document_Object_Model/Using_the_W3C_DOM_Level_1_Core
-tags:
-  - DOM
-  - NeedsUpdate
-translation_of: Web/API/Document_object_model/Using_the_W3C_DOM_Level_1_Core
 ---
 {{DefaultAPISidebar("DOM")}}
 

--- a/files/ja/web/api/document_object_model/whitespace/index.md
+++ b/files/ja/web/api/document_object_model/whitespace/index.md
@@ -1,13 +1,6 @@
 ---
 title: ホワイトスペースは HTML、 CSS、そして DOM 内でどう扱われるか
 slug: Web/API/Document_Object_Model/Whitespace
-tags:
-  - CSS
-  - DOM
-  - HTML
-  - JavaScript
-  - ホワイトスペース
-translation_of: Web/API/Document_Object_Model/Whitespace
 ---
 {{DefaultAPISidebar("DOM")}}
 

--- a/files/ja/web/api/documentfragment/childelementcount/index.md
+++ b/files/ja/web/api/documentfragment/childelementcount/index.md
@@ -1,13 +1,6 @@
 ---
 title: DocumentFragment.childElementCount
 slug: Web/API/DocumentFragment/childElementCount
-tags:
-  - API
-  - DOM
-  - Property
-  - Reference
-translation_of: Web/API/DocumentFragment/childElementCount
-browser-compat: api.DocumentFragment.childElementCount
 ---
 {{ APIRef("DOM") }}
 

--- a/files/ja/web/api/documentfragment/index.md
+++ b/files/ja/web/api/documentfragment/index.md
@@ -1,15 +1,6 @@
 ---
 title: DocumentFragment
 slug: Web/API/DocumentFragment
-tags:
-  - API
-  - DOM
-  - DocumentFragment
-  - Reference
-  - インターフェイス
-  - ウェブコンポーネント
-  - 文書
-translation_of: Web/API/DocumentFragment
 ---
 {{ APIRef("DOM") }}
 

--- a/files/ja/web/api/documentfragment/queryselector/index.md
+++ b/files/ja/web/api/documentfragment/queryselector/index.md
@@ -1,13 +1,6 @@
 ---
 title: DocumentFragment.querySelector()
 slug: Web/API/DocumentFragment/querySelector
-tags:
-  - API
-  - DOM
-  - DocumentFragment
-  - メソッド
-browser-compat: api.DocumentFragment.querySelector
-translation_of: Web/API/DocumentFragment/querySelector
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/documentfragment/queryselectorall/index.md
+++ b/files/ja/web/api/documentfragment/queryselectorall/index.md
@@ -1,13 +1,6 @@
 ---
 title: DocumentFragment.querySelectorAll()
 slug: Web/API/DocumentFragment/querySelectorAll
-tags:
-  - API
-  - DOM
-  - DocumentFragment
-  - メソッド
-browser-compat: api.DocumentFragment.querySelectorAll
-translation_of: Web/API/DocumentFragment/querySelectorAll
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/documenttype/after/index.md
+++ b/files/ja/web/api/documenttype/after/index.md
@@ -1,15 +1,6 @@
 ---
 title: DocumentType.after()
 slug: Web/API/DocumentType/after
-page-type: web-api-instance-method
-tags:
-  - API
-  - DOM
-  - メソッド
-  - ノード
-  - リファレンス
-browser-compat: api.DocumentType.after
-translation_of: Web/API/DocumentType/after
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/documenttype/before/index.md
+++ b/files/ja/web/api/documenttype/before/index.md
@@ -1,14 +1,6 @@
 ---
 title: DocumentType.before()
 slug: Web/API/DocumentType/before
-page-type: web-api-instance-method
-tags:
-  - API
-  - DOM
-  - メソッド
-  - ノード
-  - リファレンス
-browser-compat: api.DocumentType.before
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/documenttype/index.md
+++ b/files/ja/web/api/documenttype/index.md
@@ -1,14 +1,6 @@
 ---
 title: DocumentType
 slug: Web/API/DocumentType
-page-type: web-api-interface
-tags:
-  - API
-  - DOM
-  - DocumentType
-  - インターフェイス
-browser-compat: api.DocumentType
-translation_of: Web/API/DocumentType
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/documenttype/remove/index.md
+++ b/files/ja/web/api/documenttype/remove/index.md
@@ -1,14 +1,6 @@
 ---
 title: DocumentType.remove()
 slug: Web/API/DocumentType/remove
-page-type: web-api-instance-method
-tags:
-  - API
-  - DocumentType
-  - DOM
-  - メソッド
-browser-compat: api.DocumentType.remove
-translation_of: Web/API/DocumentType/remove
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/documenttype/replacewith/index.md
+++ b/files/ja/web/api/documenttype/replacewith/index.md
@@ -1,15 +1,6 @@
 ---
 title: DocumentType.replaceWith()
 slug: Web/API/DocumentType/replaceWith
-page-type: web-api-instance-method
-tags:
-  - API
-  - DOM
-  - メソッド
-  - DocumentType
-  - リファレンス
-browser-compat: api.DocumentType.replaceWith
-translation_of: Web/API/DocumentType/replaceWith
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/domerror/index.md
+++ b/files/ja/web/api/domerror/index.md
@@ -1,14 +1,6 @@
 ---
 title: DOMError
 slug: Web/API/DOMError
-tags:
-  - API
-  - DOM
-  - DOMError
-  - Deprecated
-  - Interface
-  - Reference
-translation_of: Web/API/DOMError
 ---
 {{APIRef("DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/domexception/index.md
+++ b/files/ja/web/api/domexception/index.md
@@ -1,15 +1,6 @@
 ---
 title: DOMException
 slug: Web/API/DOMException
-tags:
-  - API
-  - DOM
-  - DOMException
-  - Error
-  - Error code
-  - Exception
-  - Reference
-translation_of: Web/API/DOMException
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/domexception/name/index.md
+++ b/files/ja/web/api/domexception/name/index.md
@@ -1,15 +1,6 @@
 ---
 title: DOMException.name
 slug: Web/API/DOMException/name
-tags:
-  - API
-  - DOM
-  - DOMException
-  - Property
-  - Reference
-  - name
-  - プロパティ
-translation_of: Web/API/DOMException/name
 ---
 {{ APIRef("DOM") }}
 

--- a/files/ja/web/api/domhighrestimestamp/index.md
+++ b/files/ja/web/api/domhighrestimestamp/index.md
@@ -1,14 +1,6 @@
 ---
 title: DOMHighResTimeStamp
 slug: Web/API/DOMHighResTimeStamp
-tags:
-  - API
-  - DOMHighResTimeStamp
-  - High Resolution Time
-  - Reference
-  - Time
-  - Type
-translation_of: Web/API/DOMHighResTimeStamp
 ---
 {{APIRef("High Resolution Time")}}
 

--- a/files/ja/web/api/domimplementation/index.md
+++ b/files/ja/web/api/domimplementation/index.md
@@ -1,12 +1,6 @@
 ---
 title: DOMImplementation
 slug: Web/API/DOMImplementation
-tags:
-  - API
-  - DOM
-  - Interface
-  - Reference
-translation_of: Web/API/DOMImplementation
 ---
 {{ ApiRef("DOM") }}
 

--- a/files/ja/web/api/dommatrix/index.md
+++ b/files/ja/web/api/dommatrix/index.md
@@ -1,12 +1,6 @@
 ---
 title: CSSMatrix
 slug: Web/API/DOMMatrix
-tags:
-  - API
-  - NeedsBrowserCompatibility
-  - Reference
-translation_of: Web/API/DOMMatrix
-translation_of_original: Web/API/CSSMatrix
 original_slug: Web/API/CSSMatrix
 ---
 {{APIRef("CSSOM")}}{{Non-standard_header}}

--- a/files/ja/web/api/domparser/index.md
+++ b/files/ja/web/api/domparser/index.md
@@ -1,21 +1,6 @@
 ---
 title: DOMParser
 slug: Web/API/DOMParser
-tags:
-  - API
-  - DOM
-  - DOM Parsing
-  - Document
-  - HTML
-  - HTMLDocument
-  - MakeBrowserAgnostic
-  - NeedsMarkupWork
-  - Parsing
-  - Reference
-  - SVG
-  - XML
-  - XMLDocument
-translation_of: Web/API/DOMParser
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/dompoint/dompoint/index.md
+++ b/files/ja/web/api/dompoint/dompoint/index.md
@@ -1,19 +1,6 @@
 ---
 title: DOMPoint()
 slug: Web/API/DOMPoint/DOMPoint
-page-type: web-api-constructor
-tags:
-  - API
-  - Constructor
-  - Coordinates
-  - DOM
-  - DOMPoint
-  - Geometry
-  - Geometry Interfaces
-  - Point
-  - Reference
-browser-compat: api.DOMPoint.DOMPoint
-translation_of: Web/API/DOMPoint/DOMPoint
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/dompoint/frompoint/index.md
+++ b/files/ja/web/api/dompoint/frompoint/index.md
@@ -1,22 +1,6 @@
 ---
 title: DOMPoint.fromPoint()
 slug: Web/API/DOMPoint/fromPoint
-page-type: web-api-static-method
-tags:
-  - API
-  - Coordinates
-  - DOM
-  - DOMPoint
-  - Geometry
-  - Geometry Interfaces
-  - Method
-  - Point
-  - Reference
-  - Static
-  - Static Method
-  - fromPoint
-browser-compat: api.DOMPoint.fromPoint
-translation_of: Web/API/DOMPoint/fromPoint
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/dompoint/index.md
+++ b/files/ja/web/api/dompoint/index.md
@@ -1,21 +1,6 @@
 ---
 title: DOMPoint
 slug: Web/API/DOMPoint
-page-type: web-api-interface
-tags:
-  - API
-  - Coordinate
-  - Coordinates
-  - DOM
-  - DOMPoint
-  - Geometry
-  - Geometry Interfaces
-  - Interface
-  - Point
-  - Reference
-  - VR
-browser-compat: api.DOMPoint
-translation_of: Web/API/DOMPoint
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/dompoint/w/index.md
+++ b/files/ja/web/api/dompoint/w/index.md
@@ -1,20 +1,6 @@
 ---
 title: DOMPoint.w
 slug: Web/API/DOMPoint/w
-page-type: web-api-instance-property
-tags:
-  - API
-  - DOM
-  - DOMPoint
-  - Geometry
-  - Geometry Interfaces
-  - Point
-  - Property
-  - Reference
-  - W
-  - perspective
-browser-compat: api.DOMPoint.w
-tranaslation_of: Web/API/DOMPoint/w
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/dompoint/x/index.md
+++ b/files/ja/web/api/dompoint/x/index.md
@@ -1,20 +1,6 @@
 ---
 title: DOMPoint.x
 slug: Web/API/DOMPoint/x
-page-type: web-api-instance-property
-tags:
-  - API
-  - Coordinates
-  - DOM
-  - DOMPoint
-  - Geometry
-  - Geometry Interfaces
-  - Point
-  - Property
-  - Reference
-  - x
-browser-compat: api.DOMPoint.x
-translation_of: Web/API/DOMPoint/x
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/dompoint/y/index.md
+++ b/files/ja/web/api/dompoint/y/index.md
@@ -1,20 +1,6 @@
 ---
 title: DOMPoint.y
 slug: Web/API/DOMPoint/y
-page-type: web-api-instance-property
-tags:
-  - API
-  - Coordinate
-  - DOM
-  - DOMPoint
-  - Geometry
-  - Geometry Interfaces
-  - Point
-  - Property
-  - Reference
-  - 'y'
-browser-compat: api.DOMPoint.y
-translation_of: Web/API/DOMPoint/y
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/dompoint/z/index.md
+++ b/files/ja/web/api/dompoint/z/index.md
@@ -1,22 +1,6 @@
 ---
 title: DOMPoint.z
 slug: Web/API/DOMPoint/z
-page-type: web-api-instance-property
-tags:
-  - API
-  - Coordinate
-  - DOM
-  - DOMPoint
-  - Depth
-  - Geometry
-  - Geometry Interfaces
-  - Point
-  - Position
-  - Property
-  - Reference
-  - z
-browser-compat: api.DOMPoint.z
-translation_of: Web/API/DOMPoint/z
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/dompointreadonly/dompointreadonly/index.md
+++ b/files/ja/web/api/dompointreadonly/dompointreadonly/index.md
@@ -1,19 +1,6 @@
 ---
 title: DOMPointReadOnly()
 slug: Web/API/DOMPointReadOnly/DOMPointReadOnly
-page-type: web-api-constructor
-tags:
-  - API
-  - Constructor
-  - Coordinates
-  - DOM
-  - DOMPointReadOnly
-  - Geometry
-  - Geometry Interfaces
-  - Point
-  - Position
-  - Reference
-browser-compat: api.DOMPointReadOnly.DOMPointReadOnly
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/dompointreadonly/frompoint/index.md
+++ b/files/ja/web/api/dompointreadonly/frompoint/index.md
@@ -1,20 +1,6 @@
 ---
 title: DOMPointReadOnly.fromPoint()
 slug: Web/API/DOMPointReadOnly/fromPoint
-page-type: web-api-static-method
-tags:
-  - API
-  - Coordinates
-  - DOM
-  - DOMPointReadOnly
-  - Geometry
-  - Geometry Interfaces
-  - Method
-  - Point
-  - Reference
-  - Static Method
-  - fromPoint
-browser-compat: api.DOMPointReadOnly.fromPoint
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/dompointreadonly/index.md
+++ b/files/ja/web/api/dompointreadonly/index.md
@@ -1,20 +1,6 @@
 ---
 title: DOMPointReadOnly
 slug: Web/API/DOMPointReadOnly
-page-type: web-api-interface
-tags:
-  - API
-  - Coordinate
-  - DOM
-  - DOM Reference
-  - DOMPointReadOnly
-  - Geometry
-  - Geometry Interfaces
-  - Interface
-  - Point
-  - Reference
-browser-compat: api.DOMPointReadOnly
-translation_of: Web/API/DOMPointReadOnly
 ---
 {{APIRef("Geometry Interfaces")}}
 

--- a/files/ja/web/api/dompointreadonly/tojson/index.md
+++ b/files/ja/web/api/dompointreadonly/tojson/index.md
@@ -1,21 +1,6 @@
 ---
 title: DOMPointReadOnly.toJSON()
 slug: Web/API/DOMPointReadOnly/toJSON
-page-type: web-api-instance-method
-tags:
-  - API
-  - Coordinates
-  - DOM
-  - DOMPointReadOnly
-  - Geometry
-  - Geometry Interfaces
-  - JSON
-  - Method
-  - Point
-  - Reference
-  - toJSON
-browser-compat: api.DOMPointReadOnly.toJSON
-translation_of: Web/API/DOMPointReadOnly/toJSON
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/dompointreadonly/w/index.md
+++ b/files/ja/web/api/dompointreadonly/w/index.md
@@ -1,23 +1,6 @@
 ---
 title: DOMPointReadOnly.w
 slug: Web/API/DOMPointReadOnly/w
-page-type: web-api-instance-property
-tags:
-  - API
-  - Coordinates
-  - DOM
-  - DOMPointReadOnly
-  - Geometry
-  - Geometry Interfaces
-  - Point
-  - Position
-  - Property
-  - Read-only
-  - Reference
-  - W
-  - perspective
-browser-compat: api.DOMPointReadOnly.w
-translation_of: Web/API/DOMPointReadOnly/w
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/dompointreadonly/x/index.md
+++ b/files/ja/web/api/dompointreadonly/x/index.md
@@ -1,21 +1,6 @@
 ---
 title: DOMPointReadOnly.x
 slug: Web/API/DOMPointReadOnly/x
-page-type: web-api-instance-property
-tags:
-  - API
-  - Coordinates
-  - DOM
-  - DOMPointReadOnly
-  - Geometry
-  - Geometry Interfaces
-  - Point
-  - Property
-  - Read-only
-  - Reference
-  - x
-browser-compat: api.DOMPointReadOnly.x
-translation_of: Web/API/DOMPointReadOnly/x
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/dompointreadonly/y/index.md
+++ b/files/ja/web/api/dompointreadonly/y/index.md
@@ -1,22 +1,6 @@
 ---
 title: DOMPointReadOnly.y
 slug: Web/API/DOMPointReadOnly/y
-page-type: web-api-instance-property
-tags:
-  - API
-  - Coordinates
-  - DOM
-  - DOMPointReadOnly
-  - Geometry
-  - Geometry Interfaces
-  - Point
-  - Property
-  - Read-only
-  - Reference
-  - Vertical
-  - 'y'
-browser-compat: api.DOMPointReadOnly.y
-translation_of: Web/API/DOMPointReadOnly/y
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/dompointreadonly/z/index.md
+++ b/files/ja/web/api/dompointreadonly/z/index.md
@@ -1,22 +1,6 @@
 ---
 title: DOMPointReadOnly.z
 slug: Web/API/DOMPointReadOnly/z
-page-type: web-api-instance-property
-tags:
-  - API
-  - Coordinates
-  - DOM
-  - DOMPointReadOnly
-  - Depth
-  - Geometry
-  - Geometry Interfaces
-  - Point
-  - Property
-  - Read-only
-  - Reference
-  - z
-browser-compat: api.DOMPointReadOnly.z
-translation_of: Web/API/DOMPointReadOnly/z
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/domrect/domrect/index.md
+++ b/files/ja/web/api/domrect/domrect/index.md
@@ -1,15 +1,6 @@
 ---
 title: DOMRect()
 slug: Web/API/DOMRect/DOMRect
-tags:
-  - API
-  - コンストラクター
-  - DOM リファレンス
-  - DOMRect
-  - 位置
-  - リファレンス
-browser-compat: api.DOMRect.DOMRect
-translation_of: Web/API/DOMRect/DOMRect
 ---
 {{APIRef("Geometry Interfaces")}}
 

--- a/files/ja/web/api/domrect/fromrect/index.md
+++ b/files/ja/web/api/domrect/fromrect/index.md
@@ -1,14 +1,6 @@
 ---
 title: DOMRect.fromRect()
 slug: Web/API/DOMRect/fromRect
-tags:
-  - API
-  - DOMRect
-  - 位置
-  - メソッド
-  - リファレンス
-browser-compat: api.DOMRect.fromRect
-translation_of: Web/API/DOMRect/fromRect
 ---
 {{APIRef("Geometry Interfaces")}}
 

--- a/files/ja/web/api/domrect/index.md
+++ b/files/ja/web/api/domrect/index.md
@@ -1,17 +1,6 @@
 ---
 title: DOMRect
 slug: Web/API/DOMRect
-tags:
-  - API
-  - DOM
-  - DOMRect
-  - 位置
-  - 位置インターフェイス
-  - インターフェイス
-  - 矩形
-  - リファレンス
-browser-compat: api.DOMRect
-translation_of: Web/API/DOMRect
 ---
 {{APIRef("Geometry Interfaces")}}
 

--- a/files/ja/web/api/domrectreadonly/bottom/index.md
+++ b/files/ja/web/api/domrectreadonly/bottom/index.md
@@ -1,16 +1,6 @@
 ---
 title: DOMRectReadOnly.bottom
 slug: Web/API/DOMRectReadOnly/bottom
-tags:
-  - API
-  - DOM
-  - DOMRectReadOnly
-  - 位置
-  - プロパティ
-  - リファレンス
-  - bottom
-browser-compat: api.DOMRectReadOnly.bottom
-translation_of: Web/API/DOMRectReadOnly/bottom
 ---
 {{APIRef("Geometry Interfaces")}}
 

--- a/files/ja/web/api/domrectreadonly/domrectreadonly/index.md
+++ b/files/ja/web/api/domrectreadonly/domrectreadonly/index.md
@@ -1,15 +1,6 @@
 ---
 title: DOMRectReadOnly()
 slug: Web/API/DOMRectReadOnly/DOMRectReadOnly
-tags:
-  - API
-  - コンストラクター
-  - DOM
-  - DOMRectReadOnly
-  - 位置
-  - リファレンス
-browser-compat: api.DOMRectReadOnly.DOMRectReadOnly
-translation_of: Web/API/DOMRectReadOnly/DOMRectReadOnly
 ---
 {{APIRef("Geometry Interfaces")}}
 

--- a/files/ja/web/api/domrectreadonly/fromrect/index.md
+++ b/files/ja/web/api/domrectreadonly/fromrect/index.md
@@ -1,14 +1,6 @@
 ---
 title: DOMRectReadOnly.fromRect()
 slug: Web/API/DOMRectReadOnly/fromRect
-tags:
-  - API
-  - DOMRectReadOnly
-  - 位置
-  - メソッド
-  - リファレンス
-browser-compat: api.DOMRectReadOnly.fromRect
-translation_of: Web/API/DOMRectReadOnly/fromRect
 ---
 {{APIRef("Geometry Interfaces")}}
 

--- a/files/ja/web/api/domrectreadonly/height/index.md
+++ b/files/ja/web/api/domrectreadonly/height/index.md
@@ -1,15 +1,6 @@
 ---
 title: DOMRectReadOnly.height
 slug: Web/API/DOMRectReadOnly/height
-tags:
-  - API
-  - DOM
-  - DOMRectReadOnly
-  - 位置
-  - プロパティ
-  - リファレンス
-browser-compat: api.DOMRectReadOnly.height
-translation_of: Web/API/DOMRectReadOnly/height
 ---
 {{APIRef("Geometry Interfaces")}}
 

--- a/files/ja/web/api/domrectreadonly/index.md
+++ b/files/ja/web/api/domrectreadonly/index.md
@@ -1,17 +1,6 @@
 ---
 title: DOMRectReadOnly
 slug: Web/API/DOMRectReadOnly
-tags:
-  - API
-  - DOMRectReadOnly
-  - 位置
-  - 位置インターフェイス
-  - インターフェイス
-  - 読み取り専用
-  - 矩形
-  - リファレンス
-browser-compat: api.DOMRectReadOnly
-translation_of: Web/API/DOMRectReadOnly
 ---
 {{APIRef("Geometry Interfaces")}}
 

--- a/files/ja/web/api/domrectreadonly/left/index.md
+++ b/files/ja/web/api/domrectreadonly/left/index.md
@@ -1,15 +1,6 @@
 ---
 title: DOMRectReadOnly.left
 slug: Web/API/DOMRectReadOnly/left
-tags:
-  - API
-  - DOM
-  - DOMRectReadOnly
-  - 位置
-  - プロパティ
-  - リファレンス
-browser-compat: api.DOMRectReadOnly.left
-translation_of: Web/API/DOMRectReadOnly/left
 ---
 {{APIRef("Geometry Interfaces")}}
 

--- a/files/ja/web/api/domrectreadonly/right/index.md
+++ b/files/ja/web/api/domrectreadonly/right/index.md
@@ -1,15 +1,6 @@
 ---
 title: DOMRectReadOnly.right
 slug: Web/API/DOMRectReadOnly/right
-tags:
-  - API
-  - DOM
-  - DOMRectReadOnly
-  - 位置
-  - プロパティ
-  - リファレンス
-browser-compat: api.DOMRectReadOnly.right
-translation_of: Web/API/DOMRectReadOnly/right
 ---
 {{APIRef("Geometry Interfaces")}}
 

--- a/files/ja/web/api/domrectreadonly/top/index.md
+++ b/files/ja/web/api/domrectreadonly/top/index.md
@@ -1,15 +1,6 @@
 ---
 title: DOMRectReadOnly.top
 slug: Web/API/DOMRectReadOnly/top
-tags:
-  - API
-  - DOM
-  - DOMRectReadOnly
-  - 位置
-  - プロパティ
-  - リファレンス
-browser-compat: api.DOMRectReadOnly.top
-translation_of: Web/API/DOMRectReadOnly/top
 ---
 {{APIRef("Geometry Interfaces")}}
 

--- a/files/ja/web/api/domrectreadonly/width/index.md
+++ b/files/ja/web/api/domrectreadonly/width/index.md
@@ -1,15 +1,6 @@
 ---
 title: DOMRectReadOnly.width
 slug: Web/API/DOMRectReadOnly/width
-tags:
-  - API
-  - DOM
-  - DOMRectReadOnly
-  - 位置
-  - プロパティ
-  - リファレンス
-browser-compat: api.DOMRectReadOnly.width
-translation_of: Web/API/DOMRectReadOnly/width
 ---
 {{APIRef("Geometry Interfaces")}}
 

--- a/files/ja/web/api/domrectreadonly/x/index.md
+++ b/files/ja/web/api/domrectreadonly/x/index.md
@@ -1,15 +1,6 @@
 ---
 title: DOMRectReadOnly.x
 slug: Web/API/DOMRectReadOnly/x
-tags:
-  - API
-  - DOM
-  - DOMRectReadOnly
-  - 位置
-  - プロパティ
-  - リファレンス
-browser-compat: api.DOMRectReadOnly.x
-translation_of: Web/API/DOMRectReadOnly/x
 ---
 {{APIRef("Geometry Interfaces")}}
 

--- a/files/ja/web/api/domrectreadonly/y/index.md
+++ b/files/ja/web/api/domrectreadonly/y/index.md
@@ -1,15 +1,6 @@
 ---
 title: DOMRectReadOnly.y
 slug: Web/API/DOMRectReadOnly/y
-tags:
-  - API
-  - DOM
-  - DOMRectReadOnly
-  - 位置
-  - プロパティ
-  - リファレンス
-browser-compat: api.DOMRectReadOnly.y
-translation_of: Web/API/DOMRectReadOnly/y
 ---
 {{APIRef("Geometry Interfaces")}}
 

--- a/files/ja/web/api/domstringlist/index.md
+++ b/files/ja/web/api/domstringlist/index.md
@@ -1,12 +1,6 @@
 ---
 title: DOMStringList
 slug: Web/API/DOMStringList
-tags:
-  - API
-  - DOM
-  - DOMStringList
-  - Reference
-translation_of: Web/API/DOMStringList
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/domstringmap/index.md
+++ b/files/ja/web/api/domstringmap/index.md
@@ -1,16 +1,6 @@
 ---
 title: DOMStringMap
 slug: Web/API/DOMStringMap
-tags:
-  - API
-  - HTML DOM
-  - Interface
-  - NeedsMarkupWork
-  - NeedsNewLayout
-  - NeedsUpdate
-  - Reference
-  - インターフェイス
-translation_of: Web/API/DOMStringMap
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/domtimestamp/index.md
+++ b/files/ja/web/api/domtimestamp/index.md
@@ -1,12 +1,6 @@
 ---
 title: DOMTimeStamp
 slug: Web/API/DOMTimeStamp
-tags:
-  - API
-  - DOM
-  - Interface
-  - Reference
-translation_of: Web/API/DOMTimeStamp
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/domtokenlist/add/index.md
+++ b/files/ja/web/api/domtokenlist/add/index.md
@@ -1,11 +1,6 @@
 ---
 title: DOMTokenList.add()
 slug: Web/API/DOMTokenList/add
-tags:
-- メソッド
-- リファレンス
-browser-compat: api.DOMTokenList.add
-translation_of: Web/API/DOMTokenList/add
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/domtokenlist/contains/index.md
+++ b/files/ja/web/api/domtokenlist/contains/index.md
@@ -1,11 +1,6 @@
 ---
 title: DOMTokenList.contains()
 slug: Web/API/DOMTokenList/contains
-tags:
-- メソッド
-- リファレンス
-browser-compat: api.DOMTokenList.contains
-translation_of: Web/API/DOMTokenList/contains
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/domtokenlist/entries/index.md
+++ b/files/ja/web/api/domtokenlist/entries/index.md
@@ -1,11 +1,6 @@
 ---
 title: DOMTokenList.entries()
 slug: Web/API/DOMTokenList/entries
-tags:
-- メソッド
-- リファレンス
-browser-compat: api.DOMTokenList.entries
-translation_of: Web/API/DOMTokenList/entries
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/domtokenlist/foreach/index.md
+++ b/files/ja/web/api/domtokenlist/foreach/index.md
@@ -1,11 +1,6 @@
 ---
 title: DOMTokenList.forEach()
 slug: Web/API/DOMTokenList/forEach
-tags:
-- メソッド
-- リファレンス
-browser-compat: api.DOMTokenList.forEach
-translation_of: Web/API/DOMTokenList/forEach
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/domtokenlist/index.md
+++ b/files/ja/web/api/domtokenlist/index.md
@@ -1,11 +1,6 @@
 ---
 title: DOMTokenList
 slug: Web/API/DOMTokenList
-tags:
-  - インターフェイス
-  - リファレンス
-browser-compat: api.DOMTokenList
-translation_of: Web/API/DOMTokenList
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/domtokenlist/item/index.md
+++ b/files/ja/web/api/domtokenlist/item/index.md
@@ -1,11 +1,6 @@
 ---
 title: DOMTokenList.item()
 slug: Web/API/DOMTokenList/item
-tags:
-- メソッド
-- リファレンス
-browser-compat: api.DOMTokenList.item
-translation_of: Web/API/DOMTokenList/item
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/domtokenlist/keys/index.md
+++ b/files/ja/web/api/domtokenlist/keys/index.md
@@ -1,11 +1,6 @@
 ---
 title: DOMTokenList.keys()
 slug: Web/API/DOMTokenList/keys
-tags:
-- メソッド
-- リファレンス
-browser-compat: api.DOMTokenList.keys
-translation_of: Web/API/DOMTokenList/keys
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/domtokenlist/length/index.md
+++ b/files/ja/web/api/domtokenlist/length/index.md
@@ -1,12 +1,6 @@
 ---
 title: DOMTokenList.length
 slug: Web/API/DOMTokenList/length
-tags:
-- プロパティ
-- リファレンス
-- 読み取り専用
-browser-compat: api.DOMTokenList.length
-translation_of: Web/API/DOMTokenList/length
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/domtokenlist/remove/index.md
+++ b/files/ja/web/api/domtokenlist/remove/index.md
@@ -1,15 +1,6 @@
 ---
 title: DOMTokenList.remove()
 slug: Web/API/DOMTokenList/remove
-tags:
-  - API
-  - DOM
-  - DOMTokenList
-  - メソッド
-  - リファレンス
-  - remove
-browser-compat: api.DOMTokenList.remove
-translation_of: Web/API/DOMTokenList/remove
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/domtokenlist/replace/index.md
+++ b/files/ja/web/api/domtokenlist/replace/index.md
@@ -1,14 +1,6 @@
 ---
 title: DOMTokenList.replace()
 slug: Web/API/DOMTokenList/replace
-tags:
-- API
-- DOM
-- Document
-- メソッド
-- リファレンス
-browser-compat: api.DOMTokenList.replace
-translation_of: Web/API/DOMTokenList/replace
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/domtokenlist/supports/index.md
+++ b/files/ja/web/api/domtokenlist/supports/index.md
@@ -1,11 +1,6 @@
 ---
 title: DOMTokenList.supports()
 slug: Web/API/DOMTokenList/supports
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.DOMTokenList.supports
-translation_of: Web/API/DOMTokenList/supports
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/domtokenlist/toggle/index.md
+++ b/files/ja/web/api/domtokenlist/toggle/index.md
@@ -1,11 +1,6 @@
 ---
 title: DOMTokenList.toggle()
 slug: Web/API/DOMTokenList/toggle
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.DOMTokenList.toggle
-translation_of: Web/API/DOMTokenList/toggle
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/domtokenlist/value/index.md
+++ b/files/ja/web/api/domtokenlist/value/index.md
@@ -1,11 +1,6 @@
 ---
 title: DOMTokenList.value
 slug: Web/API/DOMTokenList/value
-tags:
-- プロパティ
-- リファレンス
-browser-compat: api.DOMTokenList.value
-translation_of: Web/API/DOMTokenList/value
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/domtokenlist/values/index.md
+++ b/files/ja/web/api/domtokenlist/values/index.md
@@ -1,11 +1,6 @@
 ---
 title: DOMTokenList.values()
 slug: Web/API/DOMTokenList/values
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.DOMTokenList.values
-translation_of: Web/API/DOMTokenList/values
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/dragevent/datatransfer/index.md
+++ b/files/ja/web/api/dragevent/datatransfer/index.md
@@ -1,15 +1,6 @@
 ---
 title: DragEvent.dataTransfer
 slug: Web/API/DragEvent/dataTransfer
-page-type: web-api-instance-property
-tags:
-  - API
-  - DOM
-  - Property
-  - Reference
-  - drag and drop
-browser-compat: api.DragEvent.dataTransfer
-translation_of: Web/API/DragEvent/dataTransfer
 ---
 {{APIRef("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/dragevent/dragevent/index.md
+++ b/files/ja/web/api/dragevent/dragevent/index.md
@@ -1,15 +1,6 @@
 ---
 title: DragEvent()
 slug: Web/API/DragEvent/DragEvent
-page-type: web-api-constructor
-tags:
-  - API
-  - Constructor
-  - DOM
-  - Reference
-  - drag and drop
-browser-compat: api.DragEvent.DragEvent
-translation_of: Web/API/DragEvent/DragEvent
 ---
 {{APIRef("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/dragevent/index.md
+++ b/files/ja/web/api/dragevent/index.md
@@ -1,14 +1,6 @@
 ---
 title: DragEvent
 slug: Web/API/DragEvent
-page-type: web-api-interface
-tags:
-  - API
-  - DragEvent
-  - Reference
-  - drag and drop
-browser-compat: api.DragEvent
-translation_of: Web/API/DragEvent
 ---
 {{APIRef("HTML Drag and Drop API")}}
 


### PR DESCRIPTION
Part of #7858

`files/ja/web/api/d*` から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "page-type": 70,
  "tags": 243,
  "browser-compat": 77,
  "translation_of": 239,
  "translation_of_original": 4,
  "tranaslation_of": 1
}
```
