### PR TITLE
remove duplicated frontmatter keys from web/api/{e-g}* (ja)

### DIFF
--- a/files/ja/web/api/element/after/index.md
+++ b/files/ja/web/api/element/after/index.md
@@ -1,13 +1,6 @@
 ---
 title: Element.after()
 slug: Web/API/Element/after
-tags:
-  - API
-  - DOM
-  - メソッド
-  - Node
-  - リファレンス
-translation_of: Web/API/Element/after
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/animate/index.md
+++ b/files/ja/web/api/element/animate/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.animate()
 slug: Web/API/Element/animate
-tags:
-  - API
-  - アニメーション
-  - Element
-  - メソッド
-  - リファレンス
-  - ウェブアニメーション
-translation_of: Web/API/Element/animate
 ---
 {{APIRef('Web Animations')}}
 

--- a/files/ja/web/api/element/animationcancel_event/index.md
+++ b/files/ja/web/api/element/animationcancel_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'Document: animationcancel イベント'
 slug: Web/API/Element/animationcancel_event
-tags:
-  - CSS Animations
-  - CSS アニメーション
-  - Document
-  - Event
-  - Reference
-  - Web
-  - animationcancel
-  - イベント
-  - ウェブ
-translation_of: Web/API/Document/animationcancel_event
 original_slug: Web/API/Document/animationcancel_event
 ---
 {{APIRef}}{{SeeCompatTable}}

--- a/files/ja/web/api/element/animationend_event/index.md
+++ b/files/ja/web/api/element/animationend_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Document: animationend イベント'
 slug: Web/API/Element/animationend_event
-tags:
-  - CSS Animations
-  - CSS アニメーション
-  - Document
-  - Event
-  - Reference
-  - Web
-  - animationend
-  - イベント
-translation_of: Web/API/Document/animationend_event
 original_slug: Web/API/Document/animationend_event
 ---
 {{APIRef}}

--- a/files/ja/web/api/element/animationiteration_event/index.md
+++ b/files/ja/web/api/element/animationiteration_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Document: animationiteration イベント'
 slug: Web/API/Element/animationiteration_event
-tags:
-  - Animation
-  - AnimationEvent
-  - CSS Animations
-  - CSS アニメーション
-  - Event
-  - Reference
-  - animationiteration
-  - イベント
-translation_of: Web/API/Document/animationiteration_event
 original_slug: Web/API/Document/animationiteration_event
 ---
 {{APIRef}}

--- a/files/ja/web/api/element/animationstart_event/index.md
+++ b/files/ja/web/api/element/animationstart_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'Document: animationstart イベント'
 slug: Web/API/Element/animationstart_event
-tags:
-  - CSS Animations
-  - CSS アニメーション
-  - Document
-  - Event
-  - Reference
-  - Web
-  - animationstart
-  - イベント
-  - ウェブ
-translation_of: Web/API/Document/animationstart_event
 original_slug: Web/API/Document/animationstart_event
 ---
 {{APIRef}}

--- a/files/ja/web/api/element/append/index.md
+++ b/files/ja/web/api/element/append/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.append()
 slug: Web/API/Element/append
-tags:
-  - API
-  - DOM
-  - メソッド
-  - Node
-  - Element
-  - リファレンス
-translation_of: Web/API/Element/append
 original_slug: Web/API/ParentNode/append
 ---
 {{APIRef("DOM")}}

--- a/files/ja/web/api/element/assignedslot/index.md
+++ b/files/ja/web/api/element/assignedslot/index.md
@@ -1,15 +1,6 @@
 ---
 title: Element.assignedSlot
 slug: Web/API/Element/assignedSlot
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - Slottable
-  - ウェブコンポーネント
-  - assignedSlot
-  - シャドウ DOM
-translation_of: Web/API/Element/assignedSlot
 ---
 {{APIRef("Shadow DOM")}}
 

--- a/files/ja/web/api/element/attachshadow/index.md
+++ b/files/ja/web/api/element/attachshadow/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.attachShadow()
 slug: Web/API/Element/attachShadow
-tags:
-  - API
-  - Element
-  - メソッド
-  - リファレンス
-  - attachShadow
-  - シャドウ DOM
-translation_of: Web/API/Element/attachShadow
 ---
 {{APIRef('Shadow DOM')}}
 

--- a/files/ja/web/api/element/attributes/index.md
+++ b/files/ja/web/api/element/attributes/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.attributes
 slug: Web/API/Element/attributes
-tags:
-  - API
-  - Attributes
-  - DOM
-  - Element
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/Element/attributes
 ---
 {{ APIRef("DOM") }}
 

--- a/files/ja/web/api/element/auxclick_event/index.md
+++ b/files/ja/web/api/element/auxclick_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Element: auxclick イベント'
 slug: Web/API/Element/auxclick_event
-tags:
-  - Element
-  - イベント
-  - MouseEvent
-  - リファレンス
-  - UI
-  - auxclick
-  - マウス
-translation_of: Web/API/Element/auxclick_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/before/index.md
+++ b/files/ja/web/api/element/before/index.md
@@ -1,13 +1,6 @@
 ---
 title: Element.before()
 slug: Web/API/Element/before
-tags:
-  - API
-  - DOM
-  - メソッド
-  - Node
-  - リファレンス
-translation_of: Web/API/Element/before
 original_slug: Web/API/ChildNode/before
 ---
 {{APIRef("DOM")}}

--- a/files/ja/web/api/element/blur_event/index.md
+++ b/files/ja/web/api/element/blur_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Element: blur イベント'
 slug: Web/API/Element/blur_event
-tags:
-  - API
-  - DOM
-  - Element
-  - イベント
-  - FocusEvent
-  - リファレンス
-  - blur
-  - onblur
-translation_of: Web/API/Element/blur_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/childelementcount/index.md
+++ b/files/ja/web/api/element/childelementcount/index.md
@@ -1,12 +1,6 @@
 ---
 title: Element.childElementCount
 slug: Web/API/Element/childElementCount
-tags:
-  - API
-  - DOM
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/Element/childElementCount
 original_slug: Web/API/ParentNode/childElementCount
 ---
 {{ APIRef("DOM") }}

--- a/files/ja/web/api/element/children/index.md
+++ b/files/ja/web/api/element/children/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.children
 slug: Web/API/Element/children
-tags:
-  - API
-  - DOM
-  - Element
-  - HTMLCollection
-  - プロパティ
-  - children
-translation_of: Web/API/Element/children
 original_slug: Web/API/ParentNode/children
 ---
 {{ APIRef("DOM") }}

--- a/files/ja/web/api/element/classlist/index.md
+++ b/files/ja/web/api/element/classlist/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.classList
 slug: Web/API/Element/classList
-tags:
-  - API
-  - DOM
-  - Element
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-translation_of: Web/API/Element/classList
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/classname/index.md
+++ b/files/ja/web/api/element/classname/index.md
@@ -1,13 +1,6 @@
 ---
 title: Element.className
 slug: Web/API/Element/className
-tags:
-  - API
-  - DOM
-  - Gecko
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/Element/className
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/click_event/index.md
+++ b/files/ja/web/api/element/click_event/index.md
@@ -1,20 +1,6 @@
 ---
 title: 'Element: click イベント'
 slug: Web/API/Element/click_event
-tags:
-  - API
-  - DOM
-  - Element
-  - イベント
-  - インターフェイス
-  - MouseEvent
-  - NeedsBrowserCompatibility
-  - NeedsMobileBrowserCompatibility
-  - リファレンス
-  - UI
-  - click
-  - マウス
-translation_of: Web/API/Element/click_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/clientheight/index.md
+++ b/files/ja/web/api/element/clientheight/index.md
@@ -1,13 +1,6 @@
 ---
 title: Element.clientHeight
 slug: Web/API/Element/clientHeight
-tags:
-  - API
-  - CSSOM View
-  - NeedsMarkupWork
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/Element/clientHeight
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/clientleft/index.md
+++ b/files/ja/web/api/element/clientleft/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.clientLeft
 slug: Web/API/Element/clientLeft
-tags:
-  - API
-  - CSSOM View
-  - NeedsAgnostify
-  - NeedsMarkupWork
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/Element/clientLeft
 ---
 {{ APIRef("DOM") }}
 

--- a/files/ja/web/api/element/clienttop/index.md
+++ b/files/ja/web/api/element/clienttop/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.clientTop
 slug: Web/API/Element/clientTop
-tags:
-  - API
-  - CSSOM View
-  - NeedsAgnostify
-  - NeedsMarkupWork
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/Element/clientTop
 ---
 {{ APIRef("DOM") }}
 

--- a/files/ja/web/api/element/clientwidth/index.md
+++ b/files/ja/web/api/element/clientwidth/index.md
@@ -1,13 +1,6 @@
 ---
 title: Element.clientWidth
 slug: Web/API/Element/clientWidth
-tags:
-  - API
-  - CSSOM View
-  - NeedsMarkupWork
-  - リファレンス
-  - プロパティ
-translation_of: Web/API/Element/clientWidth
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/closest/index.md
+++ b/files/ja/web/api/element/closest/index.md
@@ -1,15 +1,6 @@
 ---
 title: Element.closest()
 slug: Web/API/Element/closest
-tags:
-  - API
-  - CSS セレクター
-  - DOM
-  - Element
-  - メソッド
-  - リファレンス
-  - セレクター
-translation_of: Web/API/Element/closest
 ---
 {{APIRef('DOM')}}
 

--- a/files/ja/web/api/element/compositionend_event/index.md
+++ b/files/ja/web/api/element/compositionend_event/index.md
@@ -1,10 +1,6 @@
 ---
 title: 'Element: compositionend イベント'
 slug: Web/API/Element/compositionend_event
-tags:
-  - Event
-  - Reference
-translation_of: Web/API/Element/compositionend_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/compositionstart_event/index.md
+++ b/files/ja/web/api/element/compositionstart_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Element: compositionstart イベント'
 slug: Web/API/Element/compositionstart_event
-tags:
-  - Element
-  - Event
-  - Input method
-  - Reference
-  - compositionstart
-  - イベント
-  - 入力メソッド
-translation_of: Web/API/Element/compositionstart_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/compositionupdate_event/index.md
+++ b/files/ja/web/api/element/compositionupdate_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'Element: compositionupdate イベント'
 slug: Web/API/Element/compositionupdate_event
-tags:
-  - Element
-  - Event
-  - Input method
-  - Reference
-  - compositionupdate
-translation_of: Web/API/Element/compositionupdate_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/computedstylemap/index.md
+++ b/files/ja/web/api/element/computedstylemap/index.md
@@ -1,17 +1,6 @@
 ---
 title: Element.computedStyleMap()
 slug: Web/API/Element/computedStyleMap
-tags:
-  - API
-  - CSS Typed Object Model API
-  - Element
-  - 実験的
-  - Houdini
-  - メソッド
-  - リファレンス
-  - StylePropertyMapReadOnly
-  - computedStyleMap()
-translation_of: Web/API/Element/computedStyleMap
 ---
 {{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/element/contextmenu_event/index.md
+++ b/files/ja/web/api/element/contextmenu_event/index.md
@@ -1,22 +1,6 @@
 ---
 title: 'Element: contextmenu イベント'
 slug: Web/API/Element/contextmenu_event
-tags:
-  - API
-  - コンテキスト
-  - DOM
-  - Element
-  - イベント
-  - インターフェイス
-  - MouseEvent
-  - リファレンス
-  - Right Click
-  - 右クリック
-  - ボタン
-  - contextmenu
-  - メニュー
-  - マウス
-translation_of: Web/API/Element/contextmenu_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/copy_event/index.md
+++ b/files/ja/web/api/element/copy_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'Element: copy イベント'
 slug: Web/API/Element/copy_event
-tags:
-  - API
-  - Clipboard API
-  - Element
-  - Event
-  - Reference
-  - Web
-translation_of: Web/API/Element/copy_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/createshadowroot/index.md
+++ b/files/ja/web/api/element/createshadowroot/index.md
@@ -1,15 +1,6 @@
 ---
 title: Element.createShadowRoot()
 slug: Web/API/Element/createShadowRoot
-tags:
-  - API
-  - Deprecated
-  - Element
-  - メソッド
-  - 標準外
-  - リファレンス
-  - シャドウ DOM
-translation_of: Web/API/Element/createShadowRoot
 ---
 {{APIRef('Shadow DOM')}}{{non-standard_header}}{{deprecated_header}}
 

--- a/files/ja/web/api/element/cut_event/index.md
+++ b/files/ja/web/api/element/cut_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Element: cut イベント'
 slug: Web/API/Element/cut_event
-page-type: web-api-event
-tags:
-  - API
-  - Clipboard API
-  - Cut
-  - Element
-  - Event
-  - Reference
-  - Web
-translation_of: Web/API/Element/cut_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/dblclick_event/index.md
+++ b/files/ja/web/api/element/dblclick_event/index.md
@@ -1,21 +1,6 @@
 ---
 title: 'Element: dblclick イベント'
 slug: Web/API/Element/dblclick_event
-tags:
-  - API
-  - DOM
-  - Double Click
-  - ダブルクリック
-  - Element
-  - イベント
-  - Input
-  - インターフェイス
-  - MouseEvent
-  - リファレンス
-  - ボタン
-  - dblclick
-  - mouse
-translation_of: Web/API/Element/dblclick_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/domactivate_event/index.md
+++ b/files/ja/web/api/element/domactivate_event/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'Element: DOMActivate イベント'
 slug: Web/API/Element/DOMActivate_event
-tags:
-  - API
-  - DOM
-  - Deprecated
-  - Element
-  - Event
-  - Input
-  - Mouse Events
-  - MouseEvent
-  - Reference
-  - activate event
-  - onactivate
-translation_of: Web/API/Element/DOMActivate_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/error_event/index.md
+++ b/files/ja/web/api/element/error_event/index.md
@@ -1,22 +1,6 @@
 ---
 title: 'Element: error イベント'
 slug: Web/API/Element/error_event
-tags:
-  - Audio
-  - DOM
-  - Error Handling
-  - Errors
-  - Event
-  - Media
-  - Reference
-  - UI
-  - UI Events
-  - UIEvent
-  - Video
-  - Web
-  - events
-  - イベント
-translation_of: Web/API/Element/error_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/firstelementchild/index.md
+++ b/files/ja/web/api/element/firstelementchild/index.md
@@ -1,12 +1,6 @@
 ---
 title: Element.firstElementChild
 slug: Web/API/Element/firstElementChild
-tags:
-  - API
-  - DOM
-  - Element
-  - プロパティ
-translation_of: Web/API/Element/firstElementChild
 ---
 {{ APIRef("DOM") }}
 

--- a/files/ja/web/api/element/focus_event/index.md
+++ b/files/ja/web/api/element/focus_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Element: focus イベント'
 slug: Web/API/Element/focus_event
-tags:
-  - API
-  - DOM
-  - Element
-  - イベント
-  - Focus
-  - FocusEvent
-  - リファレンス
-translation_of: Web/API/Element/focus_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/focusin_event/index.md
+++ b/files/ja/web/api/element/focusin_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Element: focusin イベント'
 slug: Web/API/Element/focusin_event
-tags:
-  - API
-  - DOM
-  - Element
-  - イベント
-  - FocusEvent
-  - リファレンス
-  - focusin
-translation_of: Web/API/Element/focusin_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/focusout_event/index.md
+++ b/files/ja/web/api/element/focusout_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Element: focusout イベント'
 slug: Web/API/Element/focusout_event
-tags:
-  - API
-  - DOM
-  - Element
-  - イベント
-  - FocusEvent
-  - リファレンス
-  - focusout
-  - onfocusout
-translation_of: Web/API/Element/focusout_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/fullscreenchange_event/index.md
+++ b/files/ja/web/api/element/fullscreenchange_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'Element: fullscreenchange イベント'
 slug: Web/API/Element/fullscreenchange_event
-tags:
-  - API
-  - Fullscreen API
-  - Fullscreen events
-  - events
-  - fullscreen
-  - fullscreenchange
-  - イベント
-  - 全画面 API
-  - 全画面イベント
-translation_of: Web/API/Element/fullscreenchange_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/fullscreenerror_event/index.md
+++ b/files/ja/web/api/element/fullscreenerror_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'Element: fullscreenerror イベント'
 slug: Web/API/Element/fullscreenerror_event
-tags:
-  - API
-  - Element
-  - Reference
-  - events
-  - fullscreenerror
-  - イベント
-translation_of: Web/API/Element/fullscreenerror_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/getanimations/index.md
+++ b/files/ja/web/api/element/getanimations/index.md
@@ -1,22 +1,6 @@
 ---
 title: Element.getAnimations()
 slug: Web/API/Element/getAnimations
-tags:
-  - API
-  - Animatable
-  - CSS
-  - CSS アニメーション
-  - CSS トランジション
-  - Element
-  - 実験的
-  - メソッド
-  - リファレンス
-  - トランジション
-  - ウェブアニメーション
-  - getAnimations
-  - waapi
-  - web animations api
-translation_of: Web/API/Element/getAnimations
 ---
 {{ SeeCompatTable() }}{{APIRef("Web Animations")}}
 

--- a/files/ja/web/api/element/getattribute/index.md
+++ b/files/ja/web/api/element/getattribute/index.md
@@ -1,13 +1,6 @@
 ---
 title: Element.getAttribute()
 slug: Web/API/Element/getAttribute
-tags:
-  - API
-  - DOM
-  - Element
-  - メソッド
-  - リファレンス
-translation_of: Web/API/Element/getAttribute
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/getattributenames/index.md
+++ b/files/ja/web/api/element/getattributenames/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.getAttributeNames()
 slug: Web/API/Element/getAttributeNames
-tags:
-  - API
-  - 属性
-  - DOM
-  - Element
-  - メソッド
-  - getAttributeNames
-translation_of: Web/API/Element/getAttributeNames
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/getattributenode/index.md
+++ b/files/ja/web/api/element/getattributenode/index.md
@@ -1,13 +1,6 @@
 ---
 title: Element.getAttributeNode()
 slug: Web/API/Element/getAttributeNode
-tags:
-  - API
-  - DOM
-  - Element
-  - メソッド
-  - リファレンス
-translation_of: Web/API/Element/getAttributeNode
 ---
 {{ APIRef("DOM") }}
 

--- a/files/ja/web/api/element/getattributenodens/index.md
+++ b/files/ja/web/api/element/getattributenodens/index.md
@@ -1,12 +1,6 @@
 ---
 title: Element.getAttributeNodeNS()
 slug: Web/API/Element/getAttributeNodeNS
-tags:
-  - API
-  - DOM
-  - メソッド
-  - リファレンス
-translation_of: Web/API/Element/getAttributeNodeNS
 ---
 {{ APIRef("DOM") }}
 

--- a/files/ja/web/api/element/getattributens/index.md
+++ b/files/ja/web/api/element/getattributens/index.md
@@ -1,13 +1,6 @@
 ---
 title: Element.getAttributeNS()
 slug: Web/API/Element/getAttributeNS
-tags:
-  - API
-  - DOM
-  - Element
-  - メソッド
-  - リファレンス
-translation_of: Web/API/Element/getAttributeNS
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/getboundingclientrect/index.md
+++ b/files/ja/web/api/element/getboundingclientrect/index.md
@@ -1,28 +1,6 @@
 ---
 title: Element.getBoundingClientRect()
 slug: Web/API/Element/getBoundingClientRect
-tags:
-  - API
-  - 境界
-  - Bounding
-  - Bounds
-  - CSSOM View
-  - Client
-  - Containing
-  - DOM
-  - Element
-  - Enclosing
-  - メソッド
-  - Minimum
-  - 長方形
-  - リファレンス
-  - Smallest
-  - clientHeight
-  - getBoundingClientRect
-  - getClientRects
-  - offsetHeight
-  - scrollHeight
-translation_of: Web/API/Element/getBoundingClientRect
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/getclientrects/index.md
+++ b/files/ja/web/api/element/getclientrects/index.md
@@ -1,18 +1,6 @@
 ---
 title: Element.getClientRects()
 slug: Web/API/Element/getClientRects
-tags:
-  - API
-  - CSSOM View
-  - Element
-  - メソッド
-  - リファレンス
-  - clientHeight
-  - getBoundingClientRect
-  - getClientRects
-  - offsetHeight
-  - scrollHeight
-translation_of: Web/API/Element/getClientRects
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/getelementsbyclassname/index.md
+++ b/files/ja/web/api/element/getelementsbyclassname/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.getElementsByClassName()
 slug: Web/API/Element/getElementsByClassName
-tags:
-  - API
-  - クラス
-  - Element
-  - メソッド
-  - リファレンス
-  - getElementsByClassName
-translation_of: Web/API/Element/getElementsByClassName
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/getelementsbytagname/index.md
+++ b/files/ja/web/api/element/getelementsbytagname/index.md
@@ -1,13 +1,6 @@
 ---
 title: Element.getElementsByTagName()
 slug: Web/API/Element/getElementsByTagName
-tags:
-  - API
-  - DOM
-  - Element
-  - メソッド
-  - リファレンス
-translation_of: Web/API/Element/getElementsByTagName
 ---
 {{ APIRef("DOM") }}
 

--- a/files/ja/web/api/element/getelementsbytagnamens/index.md
+++ b/files/ja/web/api/element/getelementsbytagnamens/index.md
@@ -1,13 +1,6 @@
 ---
 title: Element.getElementsByTagNameNS()
 slug: Web/API/Element/getElementsByTagNameNS
-tags:
-  - API
-  - DOM
-  - Element
-  - メソッド
-  - リファレンス
-translation_of: Web/API/Element/getElementsByTagNameNS
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/gotpointercapture_event/index.md
+++ b/files/ja/web/api/element/gotpointercapture_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Document: gotpointercapture イベント'
 slug: Web/API/Element/gotpointercapture_event
-tags:
-  - Document
-  - Event
-  - PointerEvent
-  - Reference
-  - Web
-  - gotpointercapture
-  - イベント
-  - ウェブ
-translation_of: Web/API/Document/gotpointercapture_event
 original_slug: Web/API/Document/gotpointercapture_event
 ---
 {{APIRef}}

--- a/files/ja/web/api/element/hasattribute/index.md
+++ b/files/ja/web/api/element/hasattribute/index.md
@@ -1,11 +1,6 @@
 ---
 title: element.hasAttribute
 slug: Web/API/Element/hasAttribute
-tags:
-  - DOM
-  - DOM Element Methods
-  - Gecko
-translation_of: Web/API/Element/hasAttribute
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/element/hasattributens/index.md
+++ b/files/ja/web/api/element/hasattributens/index.md
@@ -1,11 +1,6 @@
 ---
 title: element.hasAttributeNS
 slug: Web/API/Element/hasAttributeNS
-tags:
-  - DOM
-  - Gecko
-  - 翻訳中
-translation_of: Web/API/Element/hasAttributeNS
 ---
 {{ ApiRef() }}
 

--- a/files/ja/web/api/element/hasattributes/index.md
+++ b/files/ja/web/api/element/hasattributes/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.hasAttributes()
 slug: Web/API/Element/hasAttributes
-tags:
-  - API
-  - DOM
-  - Element
-  - Method
-  - Reference
-  - メソッド
-translation_of: Web/API/Element/hasAttributes
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/element/haspointercapture/index.md
+++ b/files/ja/web/api/element/haspointercapture/index.md
@@ -1,15 +1,6 @@
 ---
 title: Element.hasPointerCapture()
 slug: Web/API/Element/hasPointerCapture
-tags:
-  - API
-  - DOM
-  - Element
-  - Method
-  - PointerEvent
-  - Reference
-  - hasPointerCapture
-translation_of: Web/API/Element/hasPointerCapture
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/id/index.md
+++ b/files/ja/web/api/element/id/index.md
@@ -1,13 +1,6 @@
 ---
 title: Element.id
 slug: Web/API/Element/id
-tags:
-  - API
-  - DOM
-  - Element
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/Element/id
 ---
 {{ ApiRef("DOM") }}
 

--- a/files/ja/web/api/element/index.md
+++ b/files/ja/web/api/element/index.md
@@ -1,15 +1,6 @@
 ---
 title: Element
 slug: Web/API/Element
-tags:
-  - API
-  - DOM
-  - DOM リファレンス
-  - Element
-  - インターフェイス
-  - リファレンス
-  - Web API
-translation_of: Web/API/Element
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/innerhtml/index.md
+++ b/files/ja/web/api/element/innerhtml/index.md
@@ -1,17 +1,6 @@
 ---
 title: Element.innerHTML
 slug: Web/API/Element/innerHTML
-tags:
-  - API
-  - DOM
-  - DOM Parsing
-  - Element
-  - Parsing HTML
-  - プロパティ
-  - リファレンス
-  - innerHTML
-  - プロパティ
-translation_of: Web/API/Element/innerHTML
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/insertadjacentelement/index.md
+++ b/files/ja/web/api/element/insertadjacentelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.insertAdjacentElement()
 slug: Web/API/Element/insertAdjacentElement
-tags:
-  - API
-  - DOM
-  - Element
-  - Gecko
-  - メソッド
-  - リファレンス
-  - insertAdjacentElement
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/insertadjacenthtml/index.md
+++ b/files/ja/web/api/element/insertadjacenthtml/index.md
@@ -1,14 +1,6 @@
 ---
 title: element.insertAdjacentHTML
 slug: Web/API/Element/insertAdjacentHTML
-tags:
-  - API
-  - DOM
-  - DOM Element Methods
-  - Gecko
-  - Method
-  - Reference
-translation_of: Web/API/Element/insertAdjacentHTML
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/element/insertadjacenttext/index.md
+++ b/files/ja/web/api/element/insertadjacenttext/index.md
@@ -1,7 +1,6 @@
 ---
 title: Element.insertAdjacentText()
 slug: Web/API/Element/insertAdjacentText
-translation_of: Web/API/Element/insertAdjacentText
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/keydown_event/index.md
+++ b/files/ja/web/api/element/keydown_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'Element: keydown イベント'
 slug: Web/API/Element/keydown_event
-page-type: web-api-event
-tags:
-  - API
-  - DOM
-  - Element
-  - Event
-  - KeyboardEvent
-  - Reference
-  - keyboard
-  - keydown
-translation_of: Web/API/Element/keydown_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/keypress_event/index.md
+++ b/files/ja/web/api/element/keypress_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Element: keypress イベント'
 slug: Web/API/Element/keypress_event
-page-type: web-api-event
-tags:
-  - API
-  - Element
-  - Event
-  - Reference
-  - keypress
-  - Deprecated
-translation_of: Web/API/Element/keypress_event
 ---
 {{APIRef}} {{deprecated_header}}
 

--- a/files/ja/web/api/element/keyup_event/index.md
+++ b/files/ja/web/api/element/keyup_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'Element: keyup イベント'
 slug: Web/API/Element/keyup_event
-page-type: web-api-event
-tags:
-  - DOM
-  - Element
-  - Event
-  - Reference
-  - keyup
-translation_of: Web/API/Element/keyup_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/lastelementchild/index.md
+++ b/files/ja/web/api/element/lastelementchild/index.md
@@ -1,12 +1,6 @@
 ---
 title: Element.lastElementChild
 slug: Web/API/Element/lastElementChild
-tags:
-  - API
-  - DOM
-  - Element
-  - プロパティ
-translation_of: Web/API/Element/lastElementChild
 ---
 {{ APIRef("DOM") }}
 

--- a/files/ja/web/api/element/localname/index.md
+++ b/files/ja/web/api/element/localname/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.localName
 slug: Web/API/Element/localName
-tags:
-- API
-- DOM
-- NeedsBrowserCompatibility
-- NeedsMobileBrowserCompatibility
-- プロパティ
-- リファレンス
-translation_of: Web/API/Element/localName
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/lostpointercapture_event/index.md
+++ b/files/ja/web/api/element/lostpointercapture_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: GlobalEventHandlers.onlostpointercapture
 slug: Web/API/Element/lostpointercapture_event
-tags:
-  - API
-  - Event Handler
-  - GlobalEventHandlers
-  - HTML DOM
-  - Property
-  - Reference
-  - events
-  - onlostpointercapture
-translation_of: Web/API/GlobalEventHandlers/onlostpointercapture
 original_slug: Web/API/GlobalEventHandlers/onlostpointercapture
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/element/matches/index.md
+++ b/files/ja/web/api/element/matches/index.md
@@ -1,15 +1,6 @@
 ---
 title: Element.matches()
 slug: Web/API/Element/matches
-tags:
-  - API
-  - DOM
-  - Element
-  - Method
-  - Reference
-  - msMatchesSelector
-  - webkitMatchesSelector
-translation_of: Web/API/Element/matches
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/mousedown_event/index.md
+++ b/files/ja/web/api/element/mousedown_event/index.md
@@ -1,21 +1,6 @@
 ---
 title: 'Element: mousedown イベント'
 slug: Web/API/Element/mousedown_event
-tags:
-  - API
-  - DOM
-  - Down
-  - Element
-  - イベント
-  - インターフェイス
-  - MouseEvent
-  - Press
-  - リファレンス
-  - UI
-  - ボタン
-  - マウス
-  - mousedown
-translation_of: Web/API/Element/mousedown_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/mouseenter_event/index.md
+++ b/files/ja/web/api/element/mouseenter_event/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'Element: mouseenter イベント'
 slug: Web/API/Element/mouseenter_event
-tags:
-  - API
-  - Cursor
-  - DOM
-  - Element
-  - イベント
-  - インターフェイス
-  - MouseEvent
-  - リファレンス
-  - マウス
-  - mouseenter
-  - ポインター
-translation_of: Web/API/Element/mouseenter_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/mouseleave_event/index.md
+++ b/files/ja/web/api/element/mouseleave_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'Element: mouseleave イベント'
 slug: Web/API/Element/mouseleave_event
-tags:
-  - API
-  - DOM
-  - Element
-  - イベント
-  - MouseEvent
-  - リファレンス
-  - マウス
-  - mouseleave
-  - move
-translation_of: Web/API/Element/mouseleave_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/mousemove_event/index.md
+++ b/files/ja/web/api/element/mousemove_event/index.md
@@ -1,18 +1,6 @@
 ---
 title: 'Element: mousemove イベント'
 slug: Web/API/Element/mousemove_event
-tags:
-  - API
-  - DOM
-  - イベント
-  - インターフェイス
-  - MouseEvent
-  - リファレンス
-  - マウス
-  - mousemove
-  - move
-  - ポインター
-translation_of: Web/API/Element/mousemove_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/mouseout_event/index.md
+++ b/files/ja/web/api/element/mouseout_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'Element: mouseout イベント'
 slug: Web/API/Element/mouseout_event
-tags:
-  - API
-  - DOM
-  - イベント
-  - インターフェイス
-  - MouseEvent
-  - リファレンス
-  - マウス
-  - mouseout
-  - move
-translation_of: Web/API/Element/mouseout_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/mouseover_event/index.md
+++ b/files/ja/web/api/element/mouseover_event/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'Element: mouseover イベント'
 slug: Web/API/Element/mouseover_event
-tags:
-  - API
-  - Cursor
-  - DOM
-  - イベント
-  - インターフェイス
-  - MouseEvent
-  - リファレンス
-  - マウス
-  - mouseover
-  - move
-  - ポインター
-translation_of: Web/API/Element/mouseover_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/mouseup_event/index.md
+++ b/files/ja/web/api/element/mouseup_event/index.md
@@ -1,20 +1,6 @@
 ---
 title: 'Element: mouseup イベント'
 slug: Web/API/Element/mouseup_event
-tags:
-  - API
-  - DOM
-  - イベント
-  - インターフェイス
-  - MouseEvent
-  - リファレンス
-  - Release
-  - UI
-  - Up
-  - ボタン
-  - マウス
-  - mouseup
-translation_of: Web/API/Element/mouseup_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/namespaceuri/index.md
+++ b/files/ja/web/api/element/namespaceuri/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.namespaceURI
 slug: Web/API/Element/namespaceURI
-tags:
-  - API
-  - DOM
-  - NeedsBrowserCompatibility
-  - NeedsMobileBrowserCompatibility
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/Element/namespaceURI
 original_slug: Web/API/Node/namespaceURI
 ---
 {{APIRef("DOM")}}

--- a/files/ja/web/api/element/nextelementsibling/index.md
+++ b/files/ja/web/api/element/nextelementsibling/index.md
@@ -1,12 +1,6 @@
 ---
 title: Element.nextElementSibling
 slug: Web/API/Element/nextElementSibling
-tags:
-  - API
-  - DOM
-  - Element
-  - プロパティ
-translation_of: Web/API/Element/nextElementSibling
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/openorclosedshadowroot/index.md
+++ b/files/ja/web/api/element/openorclosedshadowroot/index.md
@@ -1,20 +1,6 @@
 ---
 title: Element.openOrClosedShadowRoot
 slug: Web/API/Element/openOrClosedShadowRoot
-tags:
-  - API
-  - Add-ons
-  - Element
-  - 拡張機能
-  - Mozilla
-  - 特権が必要
-  - 標準外
-  - プロパティ
-  - リファレンス
-  - WebExtensions
-  - openOrClosedShadowRoot
-  - シャドウ DOM
-translation_of: Web/API/Element/openOrClosedShadowRoot
 ---
 {{APIRef("Shadow DOM")}}{{non-standard_header}}
 

--- a/files/ja/web/api/element/outerhtml/index.md
+++ b/files/ja/web/api/element/outerhtml/index.md
@@ -1,19 +1,6 @@
 ---
 title: Element.outerHTML
 slug: Web/API/Element/outerHTML
-tags:
-  - API
-  - DOM
-  - DOM 解釈
-  - Element
-  - NeedsMobileBrowserCompatibility
-  - Parsing
-  - プロパティ
-  - リファレンス
-  - シリアライズ
-  - Serializing
-  - outerHTML
-translation_of: Web/API/Element/outerHTML
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/part/index.md
+++ b/files/ja/web/api/element/part/index.md
@@ -1,12 +1,6 @@
 ---
 title: Element.part
 slug: Web/API/Element/part
-tags:
-  - API
-  - Element
-  - プロパティ
-  - リファレンス
-  - part
 ---
 {{ ApiRef("DOM") }}
 

--- a/files/ja/web/api/element/paste_event/index.md
+++ b/files/ja/web/api/element/paste_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'Element: paste イベント'
 slug: Web/API/Element/paste_event
-page-type: web-api-event
-tags:
-  - Clipboard API
-  - Event
-  - NeedsUpdate
-  - Reference
-translation_of: Web/API/Element/paste_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/pointercancel_event/index.md
+++ b/files/ja/web/api/element/pointercancel_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: GlobalEventHandlers.onpointercancel
 slug: Web/API/Element/pointercancel_event
-tags:
-  - API
-  - Event Handler
-  - GlobalEventHandlers
-  - HTML DOM
-  - PointerEvent
-  - Property
-  - Reference
-translation_of: Web/API/GlobalEventHandlers/onpointercancel
 original_slug: Web/API/GlobalEventHandlers/onpointercancel
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/element/pointerdown_event/index.md
+++ b/files/ja/web/api/element/pointerdown_event/index.md
@@ -1,19 +1,6 @@
 ---
 title: GlobalEventHandlers.onpointerdown
 slug: Web/API/Element/pointerdown_event
-tags:
-  - API
-  - Document
-  - Element
-  - GlobalEventHandlers
-  - HTML DOM
-  - Pointer Events
-  - Pointer Events API
-  - PointerEvent
-  - Property
-  - Reference
-  - Window
-translation_of: Web/API/GlobalEventHandlers/onpointerdown
 original_slug: Web/API/GlobalEventHandlers/onpointerdown
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/web/api/element/pointerenter_event/index.md
+++ b/files/ja/web/api/element/pointerenter_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: GlobalEventHandlers.onpointerenter
 slug: Web/API/Element/pointerenter_event
-tags:
-  - API
-  - Event Handler
-  - GlobalEventHandlers
-  - HTML DOM
-  - PointerEvent
-  - Property
-  - Reference
-translation_of: Web/API/GlobalEventHandlers/onpointerenter
 original_slug: Web/API/GlobalEventHandlers/onpointerenter
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/element/pointerleave_event/index.md
+++ b/files/ja/web/api/element/pointerleave_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: GlobalEventHandlers.onpointerleave
 slug: Web/API/Element/pointerleave_event
-tags:
-  - API
-  - GlobalEventHandlers
-  - HTML DOM
-  - Pointer Events
-  - PointerEvent
-  - Property
-  - Reference
-  - onpointerleave
-translation_of: Web/API/GlobalEventHandlers/onpointerleave
 original_slug: Web/API/GlobalEventHandlers/onpointerleave
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/web/api/element/pointermove_event/index.md
+++ b/files/ja/web/api/element/pointermove_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: GlobalEventHandlers.onpointermove
 slug: Web/API/Element/pointermove_event
-tags:
-  - API
-  - Event Handler
-  - GlobalEventHandlers
-  - HTML DOM
-  - PointerEvent
-  - Property
-  - Reference
-translation_of: Web/API/GlobalEventHandlers/onpointermove
 original_slug: Web/API/GlobalEventHandlers/onpointermove
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/element/pointerout_event/index.md
+++ b/files/ja/web/api/element/pointerout_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: GlobalEventHandlers.onpointerout
 slug: Web/API/Element/pointerout_event
-tags:
-  - API
-  - Event Handler
-  - GlobalEventHandlers
-  - HTML DOM
-  - PointerEvent
-  - Property
-  - Reference
-translation_of: Web/API/GlobalEventHandlers/onpointerout
 original_slug: Web/API/GlobalEventHandlers/onpointerout
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/element/pointerover_event/index.md
+++ b/files/ja/web/api/element/pointerover_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: GlobalEventHandlers.onpointerover
 slug: Web/API/Element/pointerover_event
-tags:
-  - API
-  - Event Handler
-  - GlobalEventHandlers
-  - HTML DOM
-  - PointerEvent
-  - Property
-  - Reference
-translation_of: Web/API/GlobalEventHandlers/onpointerover
 original_slug: Web/API/GlobalEventHandlers/onpointerover
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/element/pointerup_event/index.md
+++ b/files/ja/web/api/element/pointerup_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: GlobalEventHandlers.onpointerup
 slug: Web/API/Element/pointerup_event
-tags:
-  - API
-  - Event Handler
-  - GlobalEventHandlers
-  - HTML DOM
-  - PointerEvent
-  - Property
-  - Reference
-translation_of: Web/API/GlobalEventHandlers/onpointerup
 original_slug: Web/API/GlobalEventHandlers/onpointerup
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/element/prefix/index.md
+++ b/files/ja/web/api/element/prefix/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.prefix
 slug: Web/API/Element/prefix
-tags:
-- API
-- DOM
-- NeedsBrowserCompatibility
-- NeedsMobileBrowserCompatibility
-- プロパティ
-- リファレンス
-translation_of: Web/API/Element/prefix
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/prepend/index.md
+++ b/files/ja/web/api/element/prepend/index.md
@@ -1,15 +1,6 @@
 ---
 title: Element.prepend()
 slug: Web/API/Element/prepend
-tags:
-  - API
-  - DOM
-  - Method
-  - Node
-  - Element
-  - Reference
-  - prepend
-translation_of: Web/API/Element/prepend
 original_slug: Web/API/ParentNode/prepend
 ---
 {{APIRef("DOM")}}

--- a/files/ja/web/api/element/previouselementsibling/index.md
+++ b/files/ja/web/api/element/previouselementsibling/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.previousElementSibling
 slug: Web/API/Element/previousElementSibling
-tags:
-  - API
-  - DOM
-  - Element
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-translation_of: Web/API/Element/nextElementSibling
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/queryselector/index.md
+++ b/files/ja/web/api/element/queryselector/index.md
@@ -1,22 +1,6 @@
 ---
 title: Element.querySelector()
 slug: Web/API/Element/querySelector
-tags:
-  - API
-  - CSS
-  - CSS セレクター
-  - DOM
-  - Element
-  - 要素
-  - Finding Elements
-  - Locating Elements
-  - メソッド
-  - リファレンス
-  - Searching Elements
-  - Selecting Elements
-  - セレクター
-  - querySelector
-translation_of: Web/API/Element/querySelector
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/queryselectorall/index.md
+++ b/files/ja/web/api/element/queryselectorall/index.md
@@ -1,19 +1,6 @@
 ---
 title: Element.querySelectorAll()
 slug: Web/API/Element/querySelectorAll
-tags:
-  - API
-  - CSS セレクター
-  - DOM
-  - Element
-  - Finding Elements
-  - メソッド
-  - リファレンス
-  - Searching Elements
-  - Selecting Elements
-  - セレクター
-  - querySelector
-translation_of: Web/API/Element/querySelectorAll
 original_slug: Web/API/ParentNode/querySelectorAll
 ---
 {{APIRef("DOM")}}

--- a/files/ja/web/api/element/releasepointercapture/index.md
+++ b/files/ja/web/api/element/releasepointercapture/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.releasePointerCapture()
 slug: Web/API/Element/releasePointerCapture
-tags:
-  - API
-  - DOM
-  - Element
-  - Method
-  - PointerEvent
-  - Reference
-translation_of: Web/API/Element/releasePointerCapture
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/remove/index.md
+++ b/files/ja/web/api/element/remove/index.md
@@ -1,12 +1,6 @@
 ---
 title: Element.remove()
 slug: Web/API/Element/remove
-tags:
-  - API
-  - Element
-  - DOM
-  - Method
-translation_of: Web/API/Element/remove
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/removeattribute/index.md
+++ b/files/ja/web/api/element/removeattribute/index.md
@@ -1,16 +1,6 @@
 ---
 title: Element.removeAttribute()
 slug: Web/API/Element/removeAttribute
-tags:
-  - API
-  - DOM
-  - Element
-  - Method
-  - Reference
-  - remove
-  - removeAttribute
-  - メソッド
-translation_of: Web/API/Element/removeAttribute
 ---
 {{ APIRef("DOM") }}
 

--- a/files/ja/web/api/element/removeattributenode/index.md
+++ b/files/ja/web/api/element/removeattributenode/index.md
@@ -1,11 +1,6 @@
 ---
 title: element.removeAttributeNode
 slug: Web/API/Element/removeAttributeNode
-tags:
-  - DOM
-  - Gecko
-  - 翻訳中
-translation_of: Web/API/Element/removeAttributeNode
 ---
 {{ ApiRef("DOM") }}
 

--- a/files/ja/web/api/element/removeattributens/index.md
+++ b/files/ja/web/api/element/removeattributens/index.md
@@ -1,15 +1,6 @@
 ---
 title: Element.removeAttributeNS()
 slug: Web/API/Element/removeAttributeNS
-page-type: web-api-instance-method
-tags:
-  - API
-  - DOM
-  - Element
-  - Method
-  - NeedsSpecTable
-  - Reference
-translation_of: Web/API/Element/removeAttributeNS
 l10n:
   sourceCommit: 196cc4ff3068a59b962a3fe1cbb960eb72ef542b
 ---

--- a/files/ja/web/api/element/replacechildren/index.md
+++ b/files/ja/web/api/element/replacechildren/index.md
@@ -1,15 +1,6 @@
 ---
 title: Element.replaceChildren()
 slug: Web/API/Element/replaceChildren
-tags:
-  - API
-  - DOM
-  - メソッド
-  - Node
-  - Element
-  - リファレンス
-  - replaceChildren
-translation_of: Web/API/Element/replaceChildren
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/replacewith/index.md
+++ b/files/ja/web/api/element/replacewith/index.md
@@ -1,13 +1,6 @@
 ---
 title: Element.replaceWith()
 slug: Web/API/Element/replaceWith
-tags:
-  - API
-  - DOM
-  - Method
-  - Element
-  - Reference
-translation_of: Web/API/Element/replaceWith
 original_slug: Web/API/ChildNode/replaceWith
 ---
 {{APIRef("DOM")}}

--- a/files/ja/web/api/element/requestfullscreen/index.md
+++ b/files/ja/web/api/element/requestfullscreen/index.md
@@ -1,16 +1,6 @@
 ---
 title: Element.requestFullscreen()
 slug: Web/API/Element/requestFullScreen
-tags:
-  - API
-  - DOM
-  - Element
-  - Fullscreen API
-  - requestFullscreen
-  - メソッド
-  - リファレンス
-  - 全画面 API
-translation_of: Web/API/Element/requestFullScreen
 ---
 {{APIRef("Fullscreen API")}}
 

--- a/files/ja/web/api/element/requestpointerlock/index.md
+++ b/files/ja/web/api/element/requestpointerlock/index.md
@@ -1,16 +1,6 @@
 ---
 title: Element.requestPointerLock()
 slug: Web/API/Element/requestPointerLock
-tags:
-  - API
-  - DOM
-  - 実験的
-  - メソッド
-  - NeedsExample
-  - PointerEvent
-  - リファレンス
-  - mouse lock
-translation_of: Web/API/Element/requestPointerLock
 ---
 {{ APIRef("DOM") }}{{ SeeCompatTable }}
 

--- a/files/ja/web/api/element/scroll/index.md
+++ b/files/ja/web/api/element/scroll/index.md
@@ -1,13 +1,6 @@
 ---
 title: Element.scroll()
 slug: Web/API/Element/scroll
-tags:
-  - API
-  - Element
-  - メソッド
-  - Reference
-  - Scroll
-translation_of: Web/API/Element/scroll
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/scroll_event/index.md
+++ b/files/ja/web/api/element/scroll_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'Element: scroll イベント'
 slug: Web/API/Element/scroll_event
-tags:
-  - API
-  - Element
-  - Event
-  - Reference
-  - Scroll
-translation_of: Web/API/Element/scroll_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/scrollby/index.md
+++ b/files/ja/web/api/element/scrollby/index.md
@@ -1,15 +1,6 @@
 ---
 title: Element.scrollBy()
 slug: Web/API/Element/scrollBy
-tags:
-  - API
-  - CSSOM View
-  - Element
-  - Method
-  - Reference
-  - scrollBy
-  - メソッド
-translation_of: Web/API/Element/scrollBy
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/scrollheight/index.md
+++ b/files/ja/web/api/element/scrollheight/index.md
@@ -1,13 +1,6 @@
 ---
 title: Element.scrollHeight
 slug: Web/API/Element/scrollHeight
-tags:
-  - API
-  - CSSOM View
-  - NeedsDHTMLRemovalInExample
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/Element/scrollHeight
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/scrollintoview/index.md
+++ b/files/ja/web/api/element/scrollintoview/index.md
@@ -1,19 +1,6 @@
 ---
 title: Element.scrollIntoView()
 slug: Web/API/Element/scrollIntoView
-tags:
-  - API
-  - CSSOM Views
-  - DOM
-  - Element
-  - Method
-  - Reference
-  - View
-  - scrollIntoView
-  - scrolling
-  - スクロール
-  - メソッド
-translation_of: Web/API/Element/scrollIntoView
 ---
 {{APIRef("DOM")}}{{domxref("Element")}} インターフェイスの **`scrollIntoView()`** メソッドは、 `scrollIntoView()` が呼び出された要素がユーザーに見えるところまで、要素の親コンテナーをスクロールします。
 

--- a/files/ja/web/api/element/scrollleft/index.md
+++ b/files/ja/web/api/element/scrollleft/index.md
@@ -1,12 +1,6 @@
 ---
 title: Element.scrollLeft
 slug: Web/API/Element/scrollLeft
-tags:
-  - API
-  - CSSOM View
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/Element/scrollLeft
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/scrollleftmax/index.md
+++ b/files/ja/web/api/element/scrollleftmax/index.md
@@ -1,15 +1,6 @@
 ---
 title: Element.scrollLeftMax
 slug: Web/API/Element/scrollLeftMax
-tags:
-  - API
-  - CSSOM View
-  - Element
-  - 標準外
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-translation_of: Web/API/Element/scrollLeftMax
 ---
 {{APIRef("DOM")}}{{Non-standard_header}}
 

--- a/files/ja/web/api/element/scrollto/index.md
+++ b/files/ja/web/api/element/scrollto/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.scrollTo()
 slug: Web/API/Element/scrollTo
-tags:
-  - API
-  - Element
-  - Method
-  - Reference
-  - scrollTo
-  - メソッド
-translation_of: Web/API/Element/scrollTo
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/scrolltop/index.md
+++ b/files/ja/web/api/element/scrolltop/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.scrollTop
 slug: Web/API/Element/scrollTop
-tags:
-  - API
-  - CSSOM View
-  - NeedsArtUpdate
-  - NeedsMarkupWork
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/Element/scrollTop
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/scrolltopmax/index.md
+++ b/files/ja/web/api/element/scrolltopmax/index.md
@@ -1,15 +1,6 @@
 ---
 title: Element.scrollTopMax
 slug: Web/API/Element/scrollTopMax
-tags:
-  - API
-  - CSSOM View
-  - Element
-  - 標準外
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-translation_of: Web/API/Element/scrollTopMax
 ---
 {{APIRef("DOM")}}{{Non-standard_header}}
 

--- a/files/ja/web/api/element/scrollwidth/index.md
+++ b/files/ja/web/api/element/scrollwidth/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.scrollWidth
 slug: Web/API/Element/scrollWidth
-tags:
-  - API
-  - CSSOM View
-  - NeedsMarkupWork
-  - NeedsSpecTable
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/Element/scrollWidth
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/setattribute/index.md
+++ b/files/ja/web/api/element/setattribute/index.md
@@ -1,12 +1,6 @@
 ---
 title: element.setAttribute
 slug: Web/API/Element/setAttribute
-tags:
-  - DOM
-  - DOM Element Methods
-  - Gecko
-  - Gecko DOM Reference
-translation_of: Web/API/Element/setAttribute
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/element/setattributenode/index.md
+++ b/files/ja/web/api/element/setattributenode/index.md
@@ -1,11 +1,6 @@
 ---
 title: element.setAttributeNode
 slug: Web/API/Element/setAttributeNode
-tags:
-  - DOM
-  - Gecko
-  - 翻訳中
-translation_of: Web/API/Element/setAttributeNode
 ---
 {{ ApiRef("DOM") }}
 

--- a/files/ja/web/api/element/setattributenodens/index.md
+++ b/files/ja/web/api/element/setattributenodens/index.md
@@ -1,11 +1,6 @@
 ---
 title: element.setAttributeNodeNS
 slug: Web/API/Element/setAttributeNodeNS
-tags:
-  - DOM
-  - Gecko
-  - 翻訳中
-translation_of: Web/API/Element/setAttributeNodeNS
 ---
 \<breadcrumbs>\</breadcrumbs>{{ ApiRef("DOM") }}== Summary ==
 

--- a/files/ja/web/api/element/setattributens/index.md
+++ b/files/ja/web/api/element/setattributens/index.md
@@ -1,11 +1,6 @@
 ---
 title: element.setAttributeNS
 slug: Web/API/Element/setAttributeNS
-tags:
-  - DOM
-  - Gecko
-  - 翻訳中
-translation_of: Web/API/Element/setAttributeNS
 ---
 {{ ApiRef() }}
 

--- a/files/ja/web/api/element/setcapture/index.md
+++ b/files/ja/web/api/element/setcapture/index.md
@@ -1,16 +1,6 @@
 ---
 title: Element.setCapture()
 slug: Web/API/Element/setCapture
-page-type: web-api-instance-method
-tags:
-  - API
-  - DOM
-  - Element
-  - Method
-  - Non-standard
-  - Reference
-  - Deprecated
-translation_of: Web/API/Element/setCapture
 ---
 {{Deprecated_Header}}{{non-standard_header}}{{ APIRef("DOM") }}
 

--- a/files/ja/web/api/element/sethtml/index.md
+++ b/files/ja/web/api/element/sethtml/index.md
@@ -1,13 +1,6 @@
 ---
 title: Element.setHTML()
 slug: Web/API/Element/setHTML
-tags:
-  - HTML 無害化 API
-  - メソッド
-  - Element.setHTML
-  - setHTML
-  - 実験的
-translation_of: Web/API/Element/setHTML
 ---
 {{SeeCompatTable}}{{DefaultAPISidebar("HTML Sanitizer API")}}
 

--- a/files/ja/web/api/element/setpointercapture/index.md
+++ b/files/ja/web/api/element/setpointercapture/index.md
@@ -1,15 +1,6 @@
 ---
 title: Element.setPointerCapture()
 slug: Web/API/Element/setPointerCapture
-tags:
-  - API
-  - DOM
-  - Element
-  - Method
-  - PointerEvent
-  - Reference
-  - 要素
-translation_of: Web/API/Element/setPointerCapture
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/shadowroot/index.md
+++ b/files/ja/web/api/element/shadowroot/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.shadowRoot
 slug: Web/API/Element/shadowRoot
-tags:
-  - API
-  - Element
-  - プロパティ
-  - リファレンス
-  - ShadowRoot
-  - シャドウ DOM
-translation_of: Web/API/Element/shadowRoot
 ---
 {{APIRef("Shadow DOM")}}
 

--- a/files/ja/web/api/element/show_event/index.md
+++ b/files/ja/web/api/element/show_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Element: show イベント'
 slug: Web/API/Element/show_event
-tags:
-  - API
-  - Deprecated
-  - Event
-  - Reference
-  - events
-  - show
-  - イベント
-translation_of: Web/API/Element/show_event
 ---
 {{APIRef}}{{deprecated_header}}
 

--- a/files/ja/web/api/element/slot/index.md
+++ b/files/ja/web/api/element/slot/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.slot
 slug: Web/API/Element/slot
-tags:
-  - API
-  - Element
-  - プロパティ
-  - リファレンス
-  - シャドウ DOM
-  - slot
-translation_of: Web/API/Element/slot
 ---
 {{APIRef("Shadow DOM")}}
 

--- a/files/ja/web/api/element/tagname/index.md
+++ b/files/ja/web/api/element/tagname/index.md
@@ -1,18 +1,6 @@
 ---
 title: Element.tagName
 slug: Web/API/Element/tagName
-tags:
-  - API
-  - DOM
-  - DOM リファレンス
-  - Element
-  - Gecko
-  - NeedsBrowserCompatibility
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - tagName
-translation_of: Web/API/Element/tagName
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/element/toggleattribute/index.md
+++ b/files/ja/web/api/element/toggleattribute/index.md
@@ -1,12 +1,6 @@
 ---
 title: Element.toggleAttribute()
 slug: Web/API/Element/toggleAttribute
-tags:
-  - API
-  - Element
-  - メソッド
-  - リファレンス
-translation_of: Web/API/Element/toggleAttribute
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/element/touchcancel_event/index.md
+++ b/files/ja/web/api/element/touchcancel_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Element: touchcancel event'
 slug: Web/API/Element/touchcancel_event
-tags:
-  - Event
-  - Touch Events
-  - TouchEvent
-  - UI
-  - UI Events
-  - UX
-  - touch
-translation_of: Web/API/Element/touchcancel_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/touchend_event/index.md
+++ b/files/ja/web/api/element/touchend_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'Element: touchend イベント'
 slug: Web/API/Element/touchend_event
-tags:
-  - Event
-  - Touch Events
-  - TouchEvent
-  - UI
-  - UI Events
-  - UX
-  - events
-  - touch
-  - touchstart
-translation_of: Web/API/Element/touchend_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/touchmove_event/index.md
+++ b/files/ja/web/api/element/touchmove_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Element: touchmove イベント'
 slug: Web/API/Element/touchmove_event
-tags:
-  - Event
-  - Touch Events
-  - TouchEvent
-  - UI
-  - UI Events
-  - UX
-  - touch
-  - touchmove
-translation_of: Web/API/Element/touchmove_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/touchstart_event/index.md
+++ b/files/ja/web/api/element/touchstart_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Element: touchstart イベント'
 slug: Web/API/Element/touchstart_event
-tags:
-  - Event
-  - Touch Event
-  - TouchEvent
-  - UI
-  - UI Events
-  - UX
-  - touch
-  - touchstart
-translation_of: Web/API/Element/touchstart_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/element/transitioncancel_event/index.md
+++ b/files/ja/web/api/element/transitioncancel_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'Document: transitioncancel イベント'
 slug: Web/API/Element/transitioncancel_event
-tags:
-  - Document
-  - Event
-  - Reference
-  - TransitionEvent
-  - Web
-  - transitioncancel
-  - イベント
-  - ウェブ
-  - トランジション
-translation_of: Web/API/Document/transitioncancel_event
 original_slug: Web/API/Document/transitioncancel_event
 ---
 {{APIRef}}{{SeeCompatTable}}

--- a/files/ja/web/api/element/transitionend_event/index.md
+++ b/files/ja/web/api/element/transitionend_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Document: transitionend イベント'
 slug: Web/API/Element/transitionend_event
-tags:
-  - CSS トランジション
-  - Document
-  - Event
-  - Reference
-  - Web
-  - transitionend
-  - イベント
-  - ウェブ
-translation_of: Web/API/Document/transitionend_event
 original_slug: Web/API/Document/transitionend_event
 ---
 {{APIRef}}

--- a/files/ja/web/api/element/transitionrun_event/index.md
+++ b/files/ja/web/api/element/transitionrun_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'Document: transitionrun イベント'
 slug: Web/API/Element/transitionrun_event
-tags:
-  - Document
-  - Event
-  - Reference
-  - TransitionEvent
-  - Web
-  - transitionrun
-  - イベント
-  - ウェブ
-  - トランジション
-translation_of: Web/API/Document/transitionrun_event
 original_slug: Web/API/Document/transitionrun_event
 ---
 {{APIRef}}{{SeeCompatTable}}

--- a/files/ja/web/api/element/transitionstart_event/index.md
+++ b/files/ja/web/api/element/transitionstart_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'Document: transitionstart イベント'
 slug: Web/API/Element/transitionstart_event
-tags:
-  - DOM
-  - Document
-  - Event
-  - Reference
-  - Web
-  - transitionstart
-  - イベント
-  - ウェブ
-  - トランジション
-translation_of: Web/API/Document/transitionstart_event
 original_slug: Web/API/Document/transitionstart_event
 ---
 {{APIRef}}{{SeeCompatTable}}

--- a/files/ja/web/api/element/wheel_event/index.md
+++ b/files/ja/web/api/element/wheel_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Element: wheel イベント'
 slug: Web/API/Element/wheel_event
-tags:
-  - API
-  - DOM
-  - Element
-  - Event
-  - Reference
-  - WheelEvent
-  - wheel
-translation_of: Web/API/Element/wheel_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/encoding_api/index.md
+++ b/files/ja/web/api/encoding_api/index.md
@@ -1,7 +1,6 @@
 ---
 title: Encoding API
 slug: Web/API/Encoding_API
-translation_of: Web/API/Encoding_API
 ---
 {{DefaultAPISidebar("Encoding API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/errorevent/index.md
+++ b/files/ja/web/api/errorevent/index.md
@@ -1,11 +1,6 @@
 ---
 title: ErrorEvent
 slug: Web/API/ErrorEvent
-tags:
-  - API
-  - Event
-  - Worker API
-translation_of: Web/API/ErrorEvent
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/event/bubbles/index.md
+++ b/files/ja/web/api/event/bubbles/index.md
@@ -1,13 +1,6 @@
 ---
 title: Event.bubbles
 slug: Web/API/Event/bubbles
-page-type: web-api-instance-property
-tags:
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.Event.bubbles
-translation_of: Web/API/Event/bubbles
 ---
 {{ ApiRef("DOM") }}
 

--- a/files/ja/web/api/event/cancelable/index.md
+++ b/files/ja/web/api/event/cancelable/index.md
@@ -1,13 +1,6 @@
 ---
 title: Event.cancelable
 slug: Web/API/Event/cancelable
-page-type: web-api-instance-property
-tags:
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.Event.cancelable
-translation_of: Web/API/Event/cancelable
 ---
 {{ ApiRef("DOM") }}
 

--- a/files/ja/web/api/event/cancelbubble/index.md
+++ b/files/ja/web/api/event/cancelbubble/index.md
@@ -1,13 +1,6 @@
 ---
 title: Event.cancelBubble
 slug: Web/API/Event/cancelBubble
-page-type: web-api-instance-property
-tags:
-  - プロパティ
-  - リファレンス
-  - 非推奨
-browser-compat: api.Event.cancelBubble
-translation_of: Web/API/Event/cancelBubble
 ---
 {{APIRef("DOM")}} {{Deprecated_Header}}
 

--- a/files/ja/web/api/event/comparison_of_event_targets/index.md
+++ b/files/ja/web/api/event/comparison_of_event_targets/index.md
@@ -1,11 +1,6 @@
 ---
 title: イベントターゲットの比較
 slug: Web/API/Event/Comparison_of_Event_Targets
-page-type: guide
-tags:
-  - DOM
-  - Gecko
-  - Guide
 ---
 {{ ApiRef() }}
 

--- a/files/ja/web/api/event/composed/index.md
+++ b/files/ja/web/api/event/composed/index.md
@@ -1,13 +1,6 @@
 ---
 title: Event.composed
 slug: Web/API/Event/composed
-page-type: web-api-instance-property
-tags:
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.Event.composed
-translation_of: Web/API/Event/composed
 ---
 {{APIRef("Shadow DOM")}}
 

--- a/files/ja/web/api/event/composedpath/index.md
+++ b/files/ja/web/api/event/composedpath/index.md
@@ -1,13 +1,6 @@
 ---
 title: Event.composedPath()
 slug: Web/API/Event/composedPath
-page-type: web-api-instance-method
-tags:
-  - メソッド
-  - リファレンス
-  - ウェブコンポーネント
-browser-compat: api.Event.composedPath
-translation_of: Web/API/Event/composedPath
 ---
 {{APIRef("Shadow DOM")}}
 

--- a/files/ja/web/api/event/currenttarget/index.md
+++ b/files/ja/web/api/event/currenttarget/index.md
@@ -1,13 +1,6 @@
 ---
 title: Event.currentTarget
 slug: Web/API/Event/currentTarget
-page-type: web-api-instance-property
-tags:
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.Event.currentTarget
-translation_of: Web/API/Event/currentTarget
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/event/defaultprevented/index.md
+++ b/files/ja/web/api/event/defaultprevented/index.md
@@ -1,12 +1,6 @@
 ---
 title: Event.defaultPrevented
 slug: Web/API/Event/defaultPrevented
-page-type: web-api-instance-property
-tags:
-  - プロパティ
-  - 読み取り専用
-browser-compat: api.Event.defaultPrevented
-translation_of: Web/API/Event/defaultPrevented
 ---
 {{ APIRef("DOM") }}
 

--- a/files/ja/web/api/event/event/index.md
+++ b/files/ja/web/api/event/event/index.md
@@ -1,12 +1,6 @@
 ---
 title: Event()
 slug: Web/API/Event/Event
-page-type: web-api-constructor
-tags:
-  - コンストラクター
-  - リファレンス
-browser-compat: api.Event.Event
-translation_of: Web/API/Event/Event
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/event/eventphase/index.md
+++ b/files/ja/web/api/event/eventphase/index.md
@@ -1,12 +1,6 @@
 ---
 title: Event.eventPhase
 slug: Web/API/Event/eventPhase
-page-type: web-api-instance-property
-tags:
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.Event.eventPhase
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/event/explicitoriginaltarget/index.md
+++ b/files/ja/web/api/event/explicitoriginaltarget/index.md
@@ -1,14 +1,6 @@
 ---
 title: Event.explicitOriginalTarget
 slug: Web/API/Event/explicitOriginalTarget
-page-type: web-api-instance-property
-tags:
-  - Non-standard
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.Event.explicitOriginalTarget
-translation_of: Web/API/Event/explicitOriginalTarget
 ---
 {{APIRef("DOM")}}{{Non-standard_Header}}
 

--- a/files/ja/web/api/event/index.md
+++ b/files/ja/web/api/event/index.md
@@ -1,12 +1,6 @@
 ---
 title: Event
 slug: Web/API/Event
-page-type: web-api-interface
-tags:
-  - インターフェイス
-  - リファレンス
-browser-compat: api.Event
-translation_of: Web/API/Event
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/event/initevent/index.md
+++ b/files/ja/web/api/event/initevent/index.md
@@ -1,13 +1,6 @@
 ---
 title: Event.initEvent()
 slug: Web/API/Event/initEvent
-page-type: web-api-instance-method
-tags:
-  - 非推奨
-  - メソッド
-  - リファレンス
-browser-compat: api.Event.initEvent
-translation_of: Web/API/Event/initEvent
 ---
 {{ ApiRef("DOM") }}{{deprecated_header}}
 

--- a/files/ja/web/api/event/istrusted/index.md
+++ b/files/ja/web/api/event/istrusted/index.md
@@ -1,13 +1,6 @@
 ---
 title: Event.isTrusted
 slug: Web/API/Event/isTrusted
-page-type: web-api-instance-property
-tags:
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.Event.isTrusted
-translation_of: Web/API/Event/isTrusted
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/event/originaltarget/index.md
+++ b/files/ja/web/api/event/originaltarget/index.md
@@ -1,14 +1,6 @@
 ---
 title: Event.originalTarget
 slug: Web/API/Event/originalTarget
-page-type: web-api-instance-property
-tags:
-  - Non-standard
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.Event.originalTarget
-translation_of: Web/API/Event/originalTarget
 ---
 {{ ApiRef("DOM") }} {{Non-standard_header}}
 

--- a/files/ja/web/api/event/preventdefault/index.md
+++ b/files/ja/web/api/event/preventdefault/index.md
@@ -1,12 +1,6 @@
 ---
 title: Event.preventDefault()
 slug: Web/API/Event/preventDefault
-page-type: web-api-instance-method
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.Event.preventDefault
-translation_of: Web/API/Event/preventDefault
 ---
 {{apiref("DOM")}}
 

--- a/files/ja/web/api/event/returnvalue/index.md
+++ b/files/ja/web/api/event/returnvalue/index.md
@@ -1,13 +1,6 @@
 ---
 title: Event.returnValue
 slug: Web/API/Event/returnValue
-page-type: web-api-instance-property
-tags:
-  - プロパティ
-  - リファレンス
-  - 非推奨
-browser-compat: api.Event.returnValue
-translation_of: Web/API/Event/returnValue
 ---
 {{APIRef("DOM")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/event/srcelement/index.md
+++ b/files/ja/web/api/event/srcelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: Event.srcElement
 slug: Web/API/Event/srcElement
-page-type: web-api-instance-property
-tags:
-  - 非推奨
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.Event.srcElement
-translation_of: Web/API/Event/srcElement
 ---
 {{ApiRef("DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/event/stopimmediatepropagation/index.md
+++ b/files/ja/web/api/event/stopimmediatepropagation/index.md
@@ -1,12 +1,6 @@
 ---
 title: Event.stopImmediatePropagation()
 slug: Web/API/Event/stopImmediatePropagation
-page-type: web-api-instance-method
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.Event.stopImmediatePropagation
-translation_of: Web/API/Event/stopImmediatePropagation
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/event/stoppropagation/index.md
+++ b/files/ja/web/api/event/stoppropagation/index.md
@@ -1,12 +1,6 @@
 ---
 title: Event.stopPropagation()
 slug: Web/API/Event/stopPropagation
-page-type: web-api-instance-method
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.Event.stopPropagation
-translation_of: Web/API/Event/stopPropagation
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/event/target/index.md
+++ b/files/ja/web/api/event/target/index.md
@@ -1,13 +1,6 @@
 ---
 title: Event.target
 slug: Web/API/Event/target
-page-type: web-api-instance-property
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.Event.target
-translation_of: Web/API/Event/target
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/event/timestamp/index.md
+++ b/files/ja/web/api/event/timestamp/index.md
@@ -1,13 +1,6 @@
 ---
 title: Event.timeStamp
 slug: Web/API/Event/timeStamp
-page-type: web-api-instance-property
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.Event.timeStamp
-translation_of: Web/API/Event/timeStamp
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/event/type/index.md
+++ b/files/ja/web/api/event/type/index.md
@@ -1,13 +1,6 @@
 ---
 title: Event.type
 slug: Web/API/Event/type
-page-type: web-api-instance-property
-tags:
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.Event.type
-translation_of: Web/API/Event/type
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/eventsource/eventsource/index.md
+++ b/files/ja/web/api/eventsource/eventsource/index.md
@@ -1,13 +1,6 @@
 ---
 title: EventSource()
 slug: Web/API/EventSource/EventSource
-tags:
-  - API
-  - EventSource
-  - Server-sent events
-  - コンストラクタ
-  - リファレンス
-translation_of: Web/API/EventSource/EventSource
 ---
 {{APIRef('WebSockets API')}}
 

--- a/files/ja/web/api/eventsource/index.md
+++ b/files/ja/web/api/eventsource/index.md
@@ -1,16 +1,6 @@
 ---
 title: EventSource
 slug: Web/API/EventSource
-tags:
-  - API
-  - Communications
-  - EventSource
-  - Interface
-  - Reference
-  - Server-sent event
-  - messaging
-  - インターフェイス
-translation_of: Web/API/EventSource
 ---
 {{APIRef("Server Sent Events")}}
 

--- a/files/ja/web/api/eventsource/message_event/index.md
+++ b/files/ja/web/api/eventsource/message_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: EventSource.onmessage
 slug: Web/API/EventSource/message_event
-tags:
-  - API
-  - EventSource
-  - Server-sent events
-  - onmessage
-  - イベントハンドラ
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/EventSource/onmessage
 original_slug: Web/API/EventSource/onmessage
 ---
 {{APIRef('WebSockets API')}}

--- a/files/ja/web/api/eventtarget/addeventlistener/index.md
+++ b/files/ja/web/api/eventtarget/addeventlistener/index.md
@@ -1,11 +1,6 @@
 ---
 title: EventTarget.addEventListener()
 slug: Web/API/EventTarget/addEventListener
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.EventTarget.addEventListener
-translation_of: Web/API/EventTarget/addEventListener
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/eventtarget/dispatchevent/index.md
+++ b/files/ja/web/api/eventtarget/dispatchevent/index.md
@@ -1,11 +1,6 @@
 ---
 title: EventTarget.dispatchEvent()
 slug: Web/API/EventTarget/dispatchEvent
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.EventTarget.dispatchEvent
-translation_of: Web/API/EventTarget/dispatchEvent
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/eventtarget/eventtarget/index.md
+++ b/files/ja/web/api/eventtarget/eventtarget/index.md
@@ -1,11 +1,6 @@
 ---
 title: EventTarget()
 slug: Web/API/EventTarget/EventTarget
-tags:
-  - コンストラクター
-  - リファレンス
-browser-compat: api.EventTarget.EventTarget
-translation_of: Web/API/EventTarget/EventTarget
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/eventtarget/index.md
+++ b/files/ja/web/api/eventtarget/index.md
@@ -1,11 +1,6 @@
 ---
 title: EventTarget
 slug: Web/API/EventTarget
-tags:
-  - インターフェイス
-  - リファレンス
-browser-compat: api.EventTarget
-translation_of: Web/API/EventTarget
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/eventtarget/removeeventlistener/index.md
+++ b/files/ja/web/api/eventtarget/removeeventlistener/index.md
@@ -1,11 +1,6 @@
 ---
 title: EventTarget.removeEventListener()
 slug: Web/API/EventTarget/removeEventListener
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.EventTarget.removeEventListener
-translation_of: Web/API/EventTarget/removeEventListener
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/extendableevent/extendableevent/index.md
+++ b/files/ja/web/api/extendableevent/extendableevent/index.md
@@ -1,14 +1,6 @@
 ---
 title: ExtendableEvent()
 slug: Web/API/ExtendableEvent/ExtendableEvent
-tags:
-  - API
-  - Constructor
-  - ExtendableEvent
-  - Reference
-  - Service Workers
-  - ServiceWorker
-translation_of: Web/API/ExtendableEvent/ExtendableEvent
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/extendableevent/index.md
+++ b/files/ja/web/api/extendableevent/index.md
@@ -1,16 +1,6 @@
 ---
 title: ExtendableEvent
 slug: Web/API/ExtendableEvent
-tags:
-  - API
-  - ExtendableEvent
-  - Interface
-  - Offline
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - Workers
-translation_of: Web/API/ExtendableEvent
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/extendableevent/waituntil/index.md
+++ b/files/ja/web/api/extendableevent/waituntil/index.md
@@ -1,13 +1,6 @@
 ---
 title: ExtendableEvent.waitUntil()
 slug: Web/API/ExtendableEvent/waitUntil
-tags:
-  - API
-  - ExtendableEvent
-  - Method
-  - Reference
-  - waitUntil
-translation_of: Web/API/ExtendableEvent/waitUntil
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/extendablemessageevent/data/index.md
+++ b/files/ja/web/api/extendablemessageevent/data/index.md
@@ -1,14 +1,6 @@
 ---
 title: ExtendableMessageEvent.data
 slug: Web/API/ExtendableMessageEvent/data
-tags:
-  - API
-  - ExtendableMessageEvent
-  - Property
-  - Reference
-  - Service Workers
-  - data
-translation_of: Web/API/ExtendableMessageEvent/data
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/extendablemessageevent/extendablemessageevent/index.md
+++ b/files/ja/web/api/extendablemessageevent/extendablemessageevent/index.md
@@ -1,13 +1,6 @@
 ---
 title: ExtendableMessageEvent()
 slug: Web/API/ExtendableMessageEvent/ExtendableMessageEvent
-tags:
-  - API
-  - Constructor
-  - ExtendableMessageEvent
-  - Reference
-  - Service Workers
-translation_of: Web/API/ExtendableMessageEvent/ExtendableMessageEvent
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/extendablemessageevent/index.md
+++ b/files/ja/web/api/extendablemessageevent/index.md
@@ -1,13 +1,6 @@
 ---
 title: ExtendableMessageEvent
 slug: Web/API/ExtendableMessageEvent
-tags:
-  - API
-  - ExtendableMessageEvent
-  - Interface
-  - Reference
-  - Service Workers
-translation_of: Web/API/ExtendableMessageEvent
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/extendablemessageevent/lasteventid/index.md
+++ b/files/ja/web/api/extendablemessageevent/lasteventid/index.md
@@ -1,7 +1,6 @@
 ---
 title: ExtendableMessageEvent.lastEventId
 slug: Web/API/ExtendableMessageEvent/lastEventId
-translation_of: Web/API/ExtendableMessageEvent/lastEventId
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/extendablemessageevent/origin/index.md
+++ b/files/ja/web/api/extendablemessageevent/origin/index.md
@@ -1,14 +1,6 @@
 ---
 title: ExtendableMessageEvent.origin
 slug: Web/API/ExtendableMessageEvent/origin
-tags:
-  - API
-  - ExtendableMessageEvent
-  - Property
-  - Reference
-  - Service Workers
-  - origin
-translation_of: Web/API/ExtendableMessageEvent/origin
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/extendablemessageevent/ports/index.md
+++ b/files/ja/web/api/extendablemessageevent/ports/index.md
@@ -1,14 +1,6 @@
 ---
 title: ExtendableMessageEvent.ports
 slug: Web/API/ExtendableMessageEvent/ports
-tags:
-  - API
-  - ExtendableMessageEvent
-  - Property
-  - Reference
-  - Service Workers
-  - ports
-translation_of: Web/API/ExtendableMessageEvent/ports
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/extendablemessageevent/source/index.md
+++ b/files/ja/web/api/extendablemessageevent/source/index.md
@@ -1,14 +1,6 @@
 ---
 title: ExtendableMessageEvent.source
 slug: Web/API/ExtendableMessageEvent/source
-tags:
-  - API
-  - ExtendableMessageEvent
-  - Property
-  - Reference
-  - Service Workers
-  - source
-translation_of: Web/API/ExtendableMessageEvent/source
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/federatedcredential/index.md
+++ b/files/ja/web/api/federatedcredential/index.md
@@ -1,15 +1,6 @@
 ---
 title: FederatedCredential
 slug: Web/API/FederatedCredential
-tags:
-  - API
-  - Credential Management API
-  - FederatedCredential
-  - Interface
-  - Reference
-  - credential management
-  - インターフェイス
-translation_of: Web/API/FederatedCredential
 ---
 {{SeeCompatTable}}{{APIRef("Credential Management API")}}
 

--- a/files/ja/web/api/federatedcredential/protocol/index.md
+++ b/files/ja/web/api/federatedcredential/protocol/index.md
@@ -1,17 +1,6 @@
 ---
 title: FederatedCredential.protocol
 slug: Web/API/FederatedCredential/protocol
-tags:
-  - API
-  - Credential Management API
-  - Experimental
-  - FederatedCredential
-  - NeedsExample
-  - Property
-  - Reference
-  - credential management
-  - プロパティ
-translation_of: Web/API/FederatedCredential/protocol
 ---
 {{SeeCompatTable}}{{APIRef("")}}{{securecontext_header}}
 

--- a/files/ja/web/api/fetch/index.md
+++ b/files/ja/web/api/fetch/index.md
@@ -1,18 +1,6 @@
 ---
 title: WindowOrWorkerGlobalScope.fetch()
 slug: Web/API/fetch
-tags:
-  - API
-  - Experimental
-  - Fetch
-  - Fetch API
-  - GlobalFetch
-  - Method
-  - Reference
-  - WindowOrWorkerGlobalScope
-  - request
-  - メソッド
-translation_of: Web/API/WindowOrWorkerGlobalScope/fetch
 original_slug: Web/API/WindowOrWorkerGlobalScope/fetch
 ---
 {{APIRef("Fetch API")}}

--- a/files/ja/web/api/fetch_api/basic_concepts/index.md
+++ b/files/ja/web/api/fetch_api/basic_concepts/index.md
@@ -1,15 +1,6 @@
 ---
 title: Fetch の基本概念
 slug: Web/API/Fetch_API/Basic_concepts
-tags:
-  - API
-  - Fetch
-  - Fetch API
-  - XMLHttpRequest
-  - 概念
-  - guard
-  - request
-translation_of: Web/API/Fetch_API/Basic_concepts
 ---
 {{DefaultAPISidebar("Fetch API")}}
 

--- a/files/ja/web/api/fetch_api/cross-global_fetch_usage/index.md
+++ b/files/ja/web/api/fetch_api/cross-global_fetch_usage/index.md
@@ -1,12 +1,6 @@
 ---
 title: グローバル間フェッチの使用
 slug: Web/API/Fetch_API/Cross-global_fetch_usage
-tags:
-  - Cross global
-  - Fetch
-  - edge case
-  - relative URL
-translation_of: Web/API/Fetch_API/Cross-global_fetch_usage
 ---
 {{DefaultAPISidebar("Fetch API")}}
 

--- a/files/ja/web/api/fetch_api/index.md
+++ b/files/ja/web/api/fetch_api/index.md
@@ -1,15 +1,6 @@
 ---
 title: Fetch API
 slug: Web/API/Fetch_API
-tags:
-  - API
-  - Fetch
-  - Landing
-  - Reference
-  - レスポンス
-  - XMLHttpRequest
-  - リクエスト
-translation_of: Web/API/Fetch_API
 ---
 <div>{{DefaultAPISidebar("Fetch API")}}</div>
 

--- a/files/ja/web/api/fetch_api/using_fetch/index.md
+++ b/files/ja/web/api/fetch_api/using_fetch/index.md
@@ -1,18 +1,6 @@
 ---
 title: Fetch の使用
 slug: Web/API/Fetch_API/Using_Fetch
-tags:
-  - API
-  - BODY
-  - 実験的
-  - Fetch
-  - ガイド
-  - HTTP
-  - Promise
-  - Response
-  - fetch POST & string body
-  - request
-translation_of: Web/API/Fetch_API/Using_Fetch
 ---
 {{DefaultAPISidebar("Fetch API")}}
 

--- a/files/ja/web/api/fetchevent/clientid/index.md
+++ b/files/ja/web/api/fetchevent/clientid/index.md
@@ -1,14 +1,6 @@
 ---
 title: FetchEvent.clientId
 slug: Web/API/FetchEvent/clientId
-tags:
-  - API
-  - FetchEvent
-  - Property
-  - Reference
-  - Service Workers
-  - clientId
-translation_of: Web/API/FetchEvent/clientId
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/fetchevent/index.md
+++ b/files/ja/web/api/fetchevent/index.md
@@ -1,15 +1,6 @@
 ---
 title: FetchEvent
 slug: Web/API/FetchEvent
-tags:
-  - API
-  - FetchEvent
-  - Interface
-  - Offline
-  - Reference
-  - Service Workers
-  - Workers
-translation_of: Web/API/FetchEvent
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/fetchevent/preloadresponse/index.md
+++ b/files/ja/web/api/fetchevent/preloadresponse/index.md
@@ -1,17 +1,6 @@
 ---
 title: FetchEvent.preloadResponse
 slug: Web/API/FetchEvent/PreloadResponse
-tags:
-  - API
-  - FetchEvent
-  - Offline
-  - Property
-  - Reference
-  - Service Workers
-  - Web Performance
-  - Workers
-  - request
-translation_of: Web/API/FetchEvent/PreloadResponse
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/fetchevent/replacesclientid/index.md
+++ b/files/ja/web/api/fetchevent/replacesclientid/index.md
@@ -1,16 +1,6 @@
 ---
 title: FetchEvent.replacesClientId
 slug: Web/API/FetchEvent/replacesClientId
-tags:
-  - API
-  - DOM
-  - FetchEvent
-  - Property
-  - Reference
-  - Service Workers
-  - Workers
-  - replacesClientId
-translation_of: Web/API/FetchEvent/replacesClientId
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/fetchevent/request/index.md
+++ b/files/ja/web/api/fetchevent/request/index.md
@@ -1,16 +1,6 @@
 ---
 title: FetchEvent.request
 slug: Web/API/FetchEvent/request
-tags:
-  - API
-  - FetchEvent
-  - Offline
-  - Property
-  - Reference
-  - Service Workers
-  - Workers
-  - request
-translation_of: Web/API/FetchEvent/request
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/fetchevent/respondwith/index.md
+++ b/files/ja/web/api/fetchevent/respondwith/index.md
@@ -1,17 +1,6 @@
 ---
 title: FetchEvent.respondWith()
 slug: Web/API/FetchEvent/respondWith
-tags:
-  - API
-  - Experimental
-  - FetchEvent
-  - Method
-  - Offline
-  - Reference
-  - Service Worker
-  - Worker
-  - respondWith
-translation_of: Web/API/FetchEvent/respondWith
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/fetchevent/resultingclientid/index.md
+++ b/files/ja/web/api/fetchevent/resultingclientid/index.md
@@ -1,16 +1,6 @@
 ---
 title: FetchEvent.resultingClientId
 slug: Web/API/FetchEvent/resultingClientId
-tags:
-  - API
-  - DOM
-  - FetchEvent
-  - Property
-  - Reference
-  - Service Workers
-  - Worker
-  - resultingClientId
-translation_of: Web/API/FetchEvent/resultingClientId
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/file/file/index.md
+++ b/files/ja/web/api/file/file/index.md
@@ -1,13 +1,6 @@
 ---
 title: File()
 slug: Web/API/File/File
-tags:
-  - API
-  - コンストラクター
-  - File API
-  - リファレンス
-browser-compat: api.File.File
-translation_of: Web/API/File/File
 ---
 {{APIRef("File")}}
 

--- a/files/ja/web/api/file/index.md
+++ b/files/ja/web/api/file/index.md
@@ -1,14 +1,6 @@
 ---
 title: File
 slug: Web/API/File
-tags:
-  - API
-  - File API
-  - インターフェイス
-  - リファレンス
-  - ウェブ
-browser-compat: api.File
-translation_of: Web/API/File
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/file/lastmodified/index.md
+++ b/files/ja/web/api/file/lastmodified/index.md
@@ -1,14 +1,6 @@
 ---
 title: File.lastModified
 slug: Web/API/File/lastModified
-tags:
-  - API
-  - File API
-  - ファイル
-  - プロパティ
-  - リファレンス
-browser-compat: api.File.lastModified
-translation_of: Web/API/File/lastModified
 ---
 {{APIRef("File")}}
 

--- a/files/ja/web/api/file/lastmodifieddate/index.md
+++ b/files/ja/web/api/file/lastmodifieddate/index.md
@@ -1,18 +1,6 @@
 ---
 title: File.lastModifiedDate
 slug: Web/API/File/lastModifiedDate
-tags:
-  - API
-  - 非推奨
-  - File
-  - File API
-  - ファイル
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - lastModifiedDate
-browser-compat: api.File.lastModifiedDate
-translation_of: Web/API/File/lastModifiedDate
 ---
 {{APIRef("File API") }} {{deprecated_header}}
 

--- a/files/ja/web/api/file/name/index.md
+++ b/files/ja/web/api/file/name/index.md
@@ -1,14 +1,6 @@
 ---
 title: File.name
 slug: Web/API/File/name
-tags:
-  - API
-  - File API
-  - ファイル
-  - プロパティ
-  - リファレンス
-browser-compat: api.File.name
-translation_of: Web/API/File/name
 ---
 {{APIRef("File API")}}
 

--- a/files/ja/web/api/file/type/index.md
+++ b/files/ja/web/api/file/type/index.md
@@ -1,15 +1,6 @@
 ---
 title: File.type
 slug: Web/API/File/type
-tags:
-  - API
-  - File API
-  - リファレンス
-  - ファイル
-  - ファイルタイプ
-  - プロパティ
-browser-compat: api.File.type
-translation_of: Web/API/File/type
 ---
 {{APIRef("File API")}}
 

--- a/files/ja/web/api/file/webkitrelativepath/index.md
+++ b/files/ja/web/api/file/webkitrelativepath/index.md
@@ -1,19 +1,6 @@
 ---
 title: File.webkitRelativePath
 slug: Web/API/File/webkitRelativePath
-tags:
-  - File
-  - File API
-  - File System API
-  - File and Directory Entries API
-  - 標準外
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - ウェブ
-  - webkitRelativePath
-browser-compat: api.File.webkitRelativePath
-translation_of: Web/API/File/webkitRelativePath
 ---
 {{APIRef("File API")}}{{non-standard_header}}
 

--- a/files/ja/web/api/file_and_directory_entries_api/index.md
+++ b/files/ja/web/api/file_and_directory_entries_api/index.md
@@ -1,15 +1,6 @@
 ---
 title: ファイルとディレクトリー項目 API
 slug: Web/API/File_and_Directory_Entries_API
-page-type: web-api-overview
-tags:
-  - API
-  - ファイルとディレクトリー項目 API
-  - ファイル
-  - 概要
-  - リファレンス
-browser-compat: api.FileSystem
-translation_of: Web/API/File_and_Directory_Entries_API
 ---
 {{DefaultAPISidebar("File and Directory Entries API")}}
 

--- a/files/ja/web/api/file_and_directory_entries_api/introduction/index.md
+++ b/files/ja/web/api/file_and_directory_entries_api/introduction/index.md
@@ -1,18 +1,6 @@
 ---
 title: ファイルとディレクトリエントリ API の紹介
 slug: Web/API/File_and_Directory_Entries_API/Introduction
-tags:
-  - API
-  - Beginner
-  - File
-  - File System API
-  - File and Directory Entries API
-  - Guide
-  - Introduction
-  - Non-standard
-  - ファイルとディレクトリエントリ API
-  - 標準外
-translation_of: Web/API/File_and_Directory_Entries_API/Introduction
 ---
 {{DefaultAPISidebar("File System API")}}{{Non-standard_header}}
 

--- a/files/ja/web/api/file_api/index.md
+++ b/files/ja/web/api/file_api/index.md
@@ -1,13 +1,6 @@
 ---
 title: ファイル API
 slug: Web/API/File_API
-page-type: web-api-overview
-tags:
-  - API
-  - Overview
-  - Reference
-spec-urls: https://w3c.github.io/FileAPI/
-translation_of: Web/API/File_API
 ---
 {{DefaultAPISidebar("File API")}}
 

--- a/files/ja/web/api/file_api/using_files_from_web_applications/index.md
+++ b/files/ja/web/api/file_api/using_files_from_web_applications/index.md
@@ -1,14 +1,6 @@
 ---
 title: ウェブアプリケーションからのファイルの使用
 slug: Web/API/File_API/Using_files_from_web_applications
-tags:
-  - ファイル
-  - HTML5
-  - 中級者
-  - 要更新
-  - ajax アップロード
-  - アップロード
-translation_of: Web/API/File/Using_files_from_web_applications
 original_slug: Web/API/File/Using_files_from_web_applications
 ---
 {{APIRef("File API")}}

--- a/files/ja/web/api/filelist/index.md
+++ b/files/ja/web/api/filelist/index.md
@@ -1,12 +1,6 @@
 ---
 title: FileList
 slug: Web/API/FileList
-tags:
-  - API
-  - File API
-  - ファイル
-browser-compat: api.FileList
-translation_of: Web/API/FileList
 ---
 {{APIRef("File API")}}
 

--- a/files/ja/web/api/filereader/abort/index.md
+++ b/files/ja/web/api/filereader/abort/index.md
@@ -1,16 +1,6 @@
 ---
 title: FileReader.abort()
 slug: Web/API/FileReader/abort
-tags:
-  - API
-  - File API
-  - FileReader
-  - Files
-  - Method
-  - Reference
-  - abort
-  - メソッド
-translation_of: Web/API/FileReader/abort
 ---
 {{APIRef("File API")}}
 

--- a/files/ja/web/api/filereader/abort_event/index.md
+++ b/files/ja/web/api/filereader/abort_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'FileReader: abort イベント'
 slug: Web/API/FileReader/abort_event
-tags:
-  - API
-  - Event
-  - FileReader
-  - ProgressEvent
-  - Reference
-  - Web
-  - abort
-  - イベント
-translation_of: Web/API/FileReader/abort_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/filereader/error/index.md
+++ b/files/ja/web/api/filereader/error/index.md
@@ -1,13 +1,6 @@
 ---
 title: FileReader.error
 slug: Web/API/FileReader/error
-tags:
-  - API
-  - File API
-  - Reference
-  - ファイル
-  - プロパティ
-translation_of: Web/API/FileReader/error
 ---
 {{APIRef("File API")}}
 

--- a/files/ja/web/api/filereader/error_event/index.md
+++ b/files/ja/web/api/filereader/error_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'FileReader: error イベント'
 slug: Web/API/FileReader/error_event
-tags:
-  - API
-  - Error
-  - Event
-  - FileReader
-  - ProgressEvent
-  - Reference
-  - Web
-  - onerror
-  - イベント
-translation_of: Web/API/FileReader/error_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/filereader/filereader/index.md
+++ b/files/ja/web/api/filereader/filereader/index.md
@@ -1,12 +1,6 @@
 ---
 title: FileReader()
 slug: Web/API/FileReader/FileReader
-tags:
-  - API
-  - Constructor
-  - FileReader
-  - Reference
-translation_of: Web/API/FileReader/FileReader
 ---
 **`FileReader()`** コンストラクタは、新しい FileReader を作成します。
 

--- a/files/ja/web/api/filereader/index.md
+++ b/files/ja/web/api/filereader/index.md
@@ -1,15 +1,6 @@
 ---
 title: FileReader
 slug: Web/API/FileReader
-page-type: web-api-interface
-tags:
-  - API
-  - File API
-  - Files
-  - Interface
-  - Reference
-browser-compat: api.FileReader
-translation_of: Web/API/FileReader
 ---
 {{APIRef("File API")}}
 

--- a/files/ja/web/api/filereader/load_event/index.md
+++ b/files/ja/web/api/filereader/load_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'FileReader: load イベント'
 slug: Web/API/FileReader/load_event
-tags:
-  - API
-  - Event
-  - FileReader
-  - Web
-  - load
-translation_of: Web/API/FileReader/load_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/filereader/loadend_event/index.md
+++ b/files/ja/web/api/filereader/loadend_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'FileReader: loadend イベント'
 slug: Web/API/FileReader/loadend_event
-tags:
-  - API
-  - Event
-  - FileReader
-  - ProgressiveEvent
-  - Web
-  - loadend
-  - イベント
-translation_of: Web/API/FileReader/loadend_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/filereader/loadstart_event/index.md
+++ b/files/ja/web/api/filereader/loadstart_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'FileReader: loadstart イベント'
 slug: Web/API/FileReader/loadstart_event
-tags:
-  - API
-  - Event
-  - FileReader
-  - ProgressEvent
-  - Web
-  - loadstart
-  - イベント
-translation_of: Web/API/FileReader/loadstart_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/filereader/progress_event/index.md
+++ b/files/ja/web/api/filereader/progress_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'FileReader: progress イベント'
 slug: Web/API/FileReader/progress_event
-tags:
-  - API
-  - Event
-  - FileReader
-  - ProgressEvent
-  - Reference
-  - Web
-  - progress
-  - イベント
-translation_of: Web/API/FileReader/progress_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/filereader/readasarraybuffer/index.md
+++ b/files/ja/web/api/filereader/readasarraybuffer/index.md
@@ -1,16 +1,6 @@
 ---
 title: FileReader.readAsArrayBuffer()
 slug: Web/API/FileReader/readAsArrayBuffer
-tags:
-  - API
-  - DOM
-  - File API
-  - FileReader
-  - Files
-  - Method
-  - Reference
-  - readAsArrayBuffer
-translation_of: Web/API/FileReader/readAsArrayBuffer
 ---
 {{APIRef("File API")}}
 

--- a/files/ja/web/api/filereader/readasbinarystring/index.md
+++ b/files/ja/web/api/filereader/readasbinarystring/index.md
@@ -1,13 +1,6 @@
 ---
 title: FileReader.readAsBinaryString()
 slug: Web/API/FileReader/readAsBinaryString
-tags:
-  - API
-  - File API
-  - Files
-  - Method
-  - Reference
-translation_of: Web/API/FileReader/readAsBinaryString
 ---
 {{APIRef("File API")}}
 

--- a/files/ja/web/api/filereader/readasdataurl/index.md
+++ b/files/ja/web/api/filereader/readasdataurl/index.md
@@ -1,16 +1,6 @@
 ---
 title: FileReader.readAsDataURL()
 slug: Web/API/FileReader/readAsDataURL
-tags:
-  - API
-  - Base 64
-  - File API
-  - FileReader
-  - Files
-  - Method
-  - Reference
-  - メソッド
-translation_of: Web/API/FileReader/readAsDataURL
 ---
 `readAsDataURL` メソッドは、指定された{{domxref("Blob")}} または {{domxref("File")}} の内容を読み込むために使用されます。読み込み操作が終了すると、{{domxref("FileReader.readyState", "readyState")}} が `DONE` となり、{{event("loadend")}} が発生します。このとき、{{domxref("FileReader.result", "result")}} 属性には、ファイルのデータを表す、base64 エンコーディングされた [data: URL](/ja/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) の文字列が格納されます。
 

--- a/files/ja/web/api/filereader/readastext/index.md
+++ b/files/ja/web/api/filereader/readastext/index.md
@@ -1,13 +1,6 @@
 ---
 title: FileReader.readAsText()
 slug: Web/API/FileReader/readAsText
-tags:
-  - API
-  - File API
-  - Reference
-  - ファイル
-  - メソッド
-translation_of: Web/API/FileReader/readAsText
 ---
 {{APIRef("File API")}}
 

--- a/files/ja/web/api/filereader/readystate/index.md
+++ b/files/ja/web/api/filereader/readystate/index.md
@@ -1,13 +1,6 @@
 ---
 title: FileReader.readyState
 slug: Web/API/FileReader/readyState
-tags:
-  - API
-  - File API
-  - Reference
-  - ファイル
-  - プロパティ
-translation_of: Web/API/FileReader/readyState
 ---
 {{APIRef("File API")}}
 

--- a/files/ja/web/api/filereader/result/index.md
+++ b/files/ja/web/api/filereader/result/index.md
@@ -1,15 +1,6 @@
 ---
 title: FileReader.result
 slug: Web/API/FileReader/result
-tags:
-  - API
-  - File API
-  - FileReader
-  - Reference
-  - result
-  - ファイル
-  - プロパティ
-translation_of: Web/API/FileReader/result
 ---
 {{APIRef("File API")}}
 

--- a/files/ja/web/api/filereadersync/index.md
+++ b/files/ja/web/api/filereadersync/index.md
@@ -1,12 +1,6 @@
 ---
 title: FileReaderSync
 slug: Web/API/FileReaderSync
-page-type: web-api-interface
-tags:
-  - API
-  - NeedsMarkupWork
-browser-compat: api.FileReaderSync
-translation_of: Web/API/FileReaderSync
 ---
 {{APIRef("File API")}}
 

--- a/files/ja/web/api/filereadersync/readasarraybuffer/index.md
+++ b/files/ja/web/api/filereadersync/readasarraybuffer/index.md
@@ -1,7 +1,6 @@
 ---
 title: FileReaderSync.readAsArrayBuffer()
 slug: Web/API/FileReaderSync/readAsArrayBuffer
-translation_of: Web/API/FileReaderSync/readAsArrayBuffer
 ---
 {{APIRef("File API")}}
 

--- a/files/ja/web/api/filereadersync/readasbinarystring/index.md
+++ b/files/ja/web/api/filereadersync/readasbinarystring/index.md
@@ -1,12 +1,6 @@
 ---
 title: FileReaderSync.readAsBinaryString()
 slug: Web/API/FileReaderSync/readAsBinaryString
-page-type: web-api-instance-method
-tags:
-  - Reference
-  - Deprecated
-browser-compat: api.FileReaderSync.readAsBinaryString
-translation_of: Web/API/FileReaderSync/readAsBinaryString
 ---
 {{APIRef("File API")}}{{deprecated_header}}
 

--- a/files/ja/web/api/filereadersync/readasdataurl/index.md
+++ b/files/ja/web/api/filereadersync/readasdataurl/index.md
@@ -1,9 +1,6 @@
 ---
 title: FileReaderSync.readAsDataURL()
 slug: Web/API/FileReaderSync/readAsDataURL
-page-type: web-api-instance-method
-browser-compat: api.FileReaderSync.readAsDataURL
-translation_of: Web/API/FileReaderSync/readAsDataURL
 ---
 {{APIRef("File API")}}
 

--- a/files/ja/web/api/filereadersync/readastext/index.md
+++ b/files/ja/web/api/filereadersync/readastext/index.md
@@ -1,9 +1,6 @@
 ---
 title: FileReaderSync.readAsText()
 slug: Web/API/FileReaderSync/readAsText
-page-type: web-api-instance-method
-browser-compat: api.FileReaderSync.readAsText
-translation_of: Web/API/FileReaderSync/readAsText
 ---
 {{APIRef("File API")}}
 

--- a/files/ja/web/api/filesystem/index.md
+++ b/files/ja/web/api/filesystem/index.md
@@ -1,16 +1,6 @@
 ---
 title: FileSystem
 slug: Web/API/FileSystem
-tags:
-  - API
-  - File API
-  - File System API
-  - File and Directory Entries API
-  - インターフェイス
-  - オフライン
-  - ファイルシステム
-  - 非標準
-translation_of: Web/API/FileSystem
 ---
 {{APIRef("File System API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/filesystemdirectoryentry/index.md
+++ b/files/ja/web/api/filesystemdirectoryentry/index.md
@@ -1,19 +1,6 @@
 ---
 title: FileSystemDirectoryEntry
 slug: Web/API/FileSystemDirectoryEntry
-tags:
-  - API
-  - File API
-  - File System API
-  - File and Directory Entries API
-  - FileSystemDirectoryEntry
-  - Files
-  - Interface
-  - NeedsMarkupWork
-  - Non-standard
-  - Offline
-  - Reference
-translation_of: Web/API/FileSystemDirectoryEntry
 ---
 {{APIRef("File System API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/filesystemfileentry/createwriter/index.md
+++ b/files/ja/web/api/filesystemfileentry/createwriter/index.md
@@ -1,19 +1,6 @@
 ---
 title: FileSystemFileEntry.createWriter()
 slug: Web/API/FileSystemFileEntry/createWriter
-page-type: web-api-instance-method
-tags:
-  - API
-  - ファイルとディレクトリー項目 API
-  - FileSystemFileEntry
-  - Files
-  - メソッド
-  - 標準外
-  - リファレンス
-  - createWriter
-  - 非推奨
-browser-compat: api.FileSystemFileEntry.createWriter
-translation_of: Web/API/FileSystemFileEntry/createWriter
 ---
 {{APIRef("File and Directories Entries API")}}{{deprecated_header}}{{Non-standard_header}}
 

--- a/files/ja/web/api/filesystemfileentry/file/index.md
+++ b/files/ja/web/api/filesystemfileentry/file/index.md
@@ -1,17 +1,6 @@
 ---
 title: FileSystemFileEntry.file()
 slug: Web/API/FileSystemFileEntry/file
-page-type: web-api-instance-method
-tags:
-  - API
-  - File
-  - ファイルとディレクトリー項目 API
-  - FileSystemFileEntry
-  - ファイル
-  - メソッド
-  - リファレンス
-browser-compat: api.FileSystemFileEntry.file
-translation_of: Web/API/FileSystemFileEntry/file
 ---
 {{APIRef("File and Directory Entries API")}}
 

--- a/files/ja/web/api/filesystemfileentry/index.md
+++ b/files/ja/web/api/filesystemfileentry/index.md
@@ -1,17 +1,6 @@
 ---
 title: FileSystemFileEntry
 slug: Web/API/FileSystemFileEntry
-page-type: web-api-interface
-tags:
-  - API
-  - ファイルとディレクトリー項目 API
-  - FileEntry
-  - ファイル
-  - インターフェイス
-  - オフライン
-  - リファレンス
-browser-compat: api.FileSystemFileEntry
-translation_of: Web/API/FileSystemFileEntry
 ---
 {{APIRef("File and Directory Entries API")}}
 

--- a/files/ja/web/api/filesystemsync/index.md
+++ b/files/ja/web/api/filesystemsync/index.md
@@ -1,14 +1,6 @@
 ---
 title: FileSystemSync
 slug: Web/API/FileSystemSync
-tags:
-  - API
-  - File API
-  - File System API
-  - オフライン
-  - ファイル
-  - ファイルシステム
-translation_of: Web/API/FileSystemSync
 ---
 {{APIRef("File System API")}} {{non-standard_header}}
 

--- a/files/ja/web/api/focusevent/focusevent/index.md
+++ b/files/ja/web/api/focusevent/focusevent/index.md
@@ -1,14 +1,6 @@
 ---
 title: FocusEvent()
 slug: Web/API/FocusEvent/FocusEvent
-tags:
-  - API
-  - コンストラクター
-  - イベント
-  - FocusEvent
-  - リファレンス
-browser-compat: api.FocusEvent.FocusEvent
-translation_of: Web/API/FocusEvent/FocusEvent
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/focusevent/index.md
+++ b/files/ja/web/api/focusevent/index.md
@@ -1,14 +1,6 @@
 ---
 title: FocusEvent
 slug: Web/API/FocusEvent
-tags:
-  - API
-  - DOM
-  - DOM イベント
-  - イベント
-  - リファレンス
-browser-compat: api.FocusEvent
-translation_of: Web/API/FocusEvent
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/focusevent/relatedtarget/index.md
+++ b/files/ja/web/api/focusevent/relatedtarget/index.md
@@ -1,15 +1,6 @@
 ---
 title: FocusEvent.relatedTarget
 slug: Web/API/FocusEvent/relatedTarget
-tags:
-  - API
-  - イベント
-  - 実験的
-  - FocusEvent
-  - プロパティ
-  - リファレンス
-browser-compat: api.FocusEvent.relatedTarget
-translation_of: Web/API/FocusEvent/relatedTarget
 ---
 {{ apiref("DOM Events") }}
 

--- a/files/ja/web/api/formdata/append/index.md
+++ b/files/ja/web/api/formdata/append/index.md
@@ -1,7 +1,6 @@
 ---
 title: FormData.append()
 slug: Web/API/FormData/append
-translation_of: Web/API/FormData/append
 ---
 {{APIRef("XMLHttpRequest")}}
 

--- a/files/ja/web/api/formdata/entries/index.md
+++ b/files/ja/web/api/formdata/entries/index.md
@@ -1,14 +1,6 @@
 ---
 title: FormData.entries()
 slug: Web/API/FormData/entries
-tags:
-  - API
-  - FormData
-  - Iterator
-  - Method
-  - Reference
-  - XMLHttpRequest API
-translation_of: Web/API/FormData/entries
 ---
 {{APIRef("XMLHttpRequest")}}
 

--- a/files/ja/web/api/formdata/formdata/index.md
+++ b/files/ja/web/api/formdata/formdata/index.md
@@ -1,14 +1,6 @@
 ---
 title: FormData()
 slug: Web/API/FormData/FormData
-tags:
-  - API
-  - Constructor
-  - FormData
-  - Reference
-  - XHR
-  - XMLHttpRequest
-translation_of: Web/API/FormData/FormData
 ---
 {{APIRef("XMLHttpRequest")}}
 

--- a/files/ja/web/api/formdata/index.md
+++ b/files/ja/web/api/formdata/index.md
@@ -1,13 +1,6 @@
 ---
 title: FormData
 slug: Web/API/FormData
-tags:
-  - API
-  - FormData
-  - Interface
-  - Reference
-  - XMLHttpRequest
-translation_of: Web/API/FormData
 ---
 {{APIRef("XMLHttpRequest")}}
 

--- a/files/ja/web/api/formdata/keys/index.md
+++ b/files/ja/web/api/formdata/keys/index.md
@@ -1,14 +1,6 @@
 ---
 title: FormData.keys()
 slug: Web/API/FormData/keys
-tags:
-  - API
-  - FormData
-  - Iterator
-  - Method
-  - Reference
-  - XMLHttpRequest API
-translation_of: Web/API/FormData/keys
 ---
 {{APIRef("XMLHttpRequest")}}
 

--- a/files/ja/web/api/formdata/using_formdata_objects/index.md
+++ b/files/ja/web/api/formdata/using_formdata_objects/index.md
@@ -1,15 +1,6 @@
 ---
 title: FormData オブジェクトの使用
 slug: Web/API/FormData/Using_FormData_Objects
-tags:
-  - AJAX
-  - Blob
-  - File
-  - FormData
-  - Forms
-  - XHR
-  - XMLHttpRequest
-translation_of: Web/API/FormData/Using_FormData_Objects
 ---
 {{APIRef("XMLHttpRequest")}}
 

--- a/files/ja/web/api/formdata/values/index.md
+++ b/files/ja/web/api/formdata/values/index.md
@@ -1,14 +1,6 @@
 ---
 title: FormData.values()
 slug: Web/API/FormData/values
-tags:
-  - API
-  - FormData
-  - Iterator
-  - Method
-  - Reference
-  - XMLHttpRequest API
-translation_of: Web/API/FormData/values
 ---
 {{APIRef("XMLHttpRequest")}}
 

--- a/files/ja/web/api/formdataevent/formdata/index.md
+++ b/files/ja/web/api/formdataevent/formdata/index.md
@@ -1,15 +1,6 @@
 ---
 title: FormDataEvent.formData
 slug: Web/API/FormDataEvent/formData
-tags:
-  - API
-  - Experimental
-  - FormDataEvent
-  - Forms
-  - Property
-  - Reference
-translation_of: Web/API/FormDataEvent/formData
-browser-compat: api.FormDataEvent.formData
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/formdataevent/formdataevent/index.md
+++ b/files/ja/web/api/formdataevent/formdataevent/index.md
@@ -1,15 +1,6 @@
 ---
 title: FormDataEvent()
 slug: Web/API/FormDataEvent/FormDataEvent
-tags:
-  - API
-  - Constructor
-  - Experimental
-  - FormDataEvent
-  - Forms
-  - Reference
-translation_of: Web/API/FormDataEvent/FormDataEvent
-browser-compat: api.FormDataEvent.FormDataEvent
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/formdataevent/index.md
+++ b/files/ja/web/api/formdataevent/index.md
@@ -1,15 +1,6 @@
 ---
 title: FormDataEvent
 slug: Web/API/FormDataEvent
-tags:
-  - API
-  - Experimental
-  - FormDataEvent
-  - Forms
-  - Landing
-  - Reference
-translation_of: Web/API/FormDataEvent
-browser-compat: api.FormDataEvent
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/frame_timing_api/index.md
+++ b/files/ja/web/api/frame_timing_api/index.md
@@ -1,13 +1,6 @@
 ---
 title: Frame Timing API
 slug: Web/API/Frame_Timing_API
-tags:
-  - Guide
-  - NeedsTranslation
-  - Overview
-  - TopicStub
-  - Web Performance
-translation_of: Web/API/Frame_Timing_API
 ---
 {{DefaultAPISidebar("Frame Timing API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/frame_timing_api/using_the_frame_timing_api/index.md
+++ b/files/ja/web/api/frame_timing_api/using_the_frame_timing_api/index.md
@@ -1,10 +1,6 @@
 ---
 title: フレームタイミング API の使用
 slug: Web/API/Frame_Timing_API/Using_the_Frame_Timing_API
-tags:
-  - Web パフォーマンス
-  - ガイド
-translation_of: Web/API/Frame_Timing_API/Using_the_Frame_Timing_API
 ---
 {{DefaultAPISidebar("Frame Timing API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/fullscreen_api/index.md
+++ b/files/ja/web/api/fullscreen_api/index.md
@@ -1,17 +1,6 @@
 ---
 title: Fullscreen API
 slug: Web/API/Fullscreen_API
-tags:
-  - API
-  - DOM
-  - Fullscreen API
-  - Intermediate
-  - Reference
-  - Tutorial
-  - 全画面
-  - 全画面モード
-  - 概要
-translation_of: Web/API/Fullscreen_API
 ---
 {{DefaultAPISidebar("Fullscreen API")}}
 

--- a/files/ja/web/api/gamepad/axes/index.md
+++ b/files/ja/web/api/gamepad/axes/index.md
@@ -1,16 +1,6 @@
 ---
 title: Gamepad.axes
 slug: Web/API/Gamepad/axes
-tags:
-  - API
-  - Gamepad API
-  - Games
-  - NeedsBetterSpecLink
-  - NeedsMarkupWork
-  - Property
-  - Reference
-  - Référence(2)
-translation_of: Web/API/Gamepad/axes
 ---
 {{APIRef("Gamepad API")}}
 

--- a/files/ja/web/api/gamepad/buttons/index.md
+++ b/files/ja/web/api/gamepad/buttons/index.md
@@ -1,16 +1,6 @@
 ---
 title: Gamepad.buttons
 slug: Web/API/Gamepad/buttons
-tags:
-  - API
-  - Gamepad API
-  - Games
-  - NeedsBetterSpecLink
-  - NeedsMarkupWork
-  - Property
-  - Reference
-  - Référence(2)
-translation_of: Web/API/Gamepad/buttons
 ---
 {{APIRef("Gamepad API")}}
 

--- a/files/ja/web/api/gamepad/connected/index.md
+++ b/files/ja/web/api/gamepad/connected/index.md
@@ -1,16 +1,6 @@
 ---
 title: Gamepad.connected
 slug: Web/API/Gamepad/connected
-tags:
-  - API
-  - Gamepad API
-  - Games
-  - NeedsBetterSpecLink
-  - NeedsMarkupWork
-  - Property
-  - Reference
-  - Référence(2)
-translation_of: Web/API/Gamepad/connected
 ---
 {{APIRef("Gamepad API")}}
 

--- a/files/ja/web/api/gamepad/displayid/index.md
+++ b/files/ja/web/api/gamepad/displayid/index.md
@@ -1,17 +1,6 @@
 ---
 title: Gamepad.displayId
 slug: Web/API/Gamepad/displayId
-tags:
-  - API
-  - Experimental
-  - Gamepad
-  - Property
-  - Reference
-  - VR
-  - Virtual Reality
-  - WebVR
-  - displayId
-translation_of: Web/API/Gamepad/displayId
 ---
 {{DefaultAPISidebar("WebVR API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/gamepad/hand/index.md
+++ b/files/ja/web/api/gamepad/hand/index.md
@@ -1,15 +1,6 @@
 ---
 title: Gamepad.hand
 slug: Web/API/Gamepad/hand
-tags:
-  - API
-  - Experimental
-  - Gamepad
-  - Gamepad API
-  - Property
-  - Reference
-  - hand
-translation_of: Web/API/Gamepad/hand
 ---
 {{APIRef("Gamepad")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/gamepad/hapticactuators/index.md
+++ b/files/ja/web/api/gamepad/hapticactuators/index.md
@@ -1,15 +1,6 @@
 ---
 title: Gamepad.hapticActuators
 slug: Web/API/Gamepad/hapticActuators
-tags:
-  - API
-  - Experimental
-  - Gamepad
-  - Gamepad API
-  - Property
-  - Reference
-  - hapticActuators
-translation_of: Web/API/Gamepad/hapticActuators
 ---
 {{APIRef("Gamepad")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/gamepad/id/index.md
+++ b/files/ja/web/api/gamepad/id/index.md
@@ -1,16 +1,6 @@
 ---
 title: Gamepad.id
 slug: Web/API/Gamepad/id
-tags:
-  - API
-  - Gamepad API
-  - Games
-  - NeedsBetterSpecLink
-  - NeedsMarkupWork
-  - Property
-  - Reference
-  - Référence(2)
-translation_of: Web/API/Gamepad/id
 ---
 {{APIRef("Gamepad API")}}
 

--- a/files/ja/web/api/gamepad/index.md
+++ b/files/ja/web/api/gamepad/index.md
@@ -1,13 +1,6 @@
 ---
 title: Gamepad
 slug: Web/API/Gamepad
-tags:
-  - API
-  - Gamepad API
-  - Games
-  - Interface
-  - Reference
-translation_of: Web/API/Gamepad
 ---
 {{APIRef("Gamepad API")}}
 

--- a/files/ja/web/api/gamepad/index/index.md
+++ b/files/ja/web/api/gamepad/index/index.md
@@ -1,15 +1,6 @@
 ---
 title: Gamepad.index
 slug: Web/API/Gamepad/index
-tags:
-  - API
-  - Gamepad
-  - Gamepad API
-  - Index
-  - ゲーム
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/Gamepad/index
 ---
 {{APIRef("Gamepad API")}}
 

--- a/files/ja/web/api/gamepad/mapping/index.md
+++ b/files/ja/web/api/gamepad/mapping/index.md
@@ -1,16 +1,6 @@
 ---
 title: Gamepad.mapping
 slug: Web/API/Gamepad/mapping
-tags:
-  - API
-  - Gamepad API
-  - Games
-  - NeedsBetterSpecLink
-  - NeedsMarkupWork
-  - Property
-  - Reference
-  - Référence(2)
-translation_of: Web/API/Gamepad/mapping
 ---
 {{APIRef("Gamepad API")}}
 

--- a/files/ja/web/api/gamepad/pose/index.md
+++ b/files/ja/web/api/gamepad/pose/index.md
@@ -1,15 +1,6 @@
 ---
 title: Gamepad.pose
 slug: Web/API/Gamepad/pose
-tags:
-  - API
-  - Experimental
-  - Gamepad
-  - Gamepad API
-  - Property
-  - Reference
-  - pose
-translation_of: Web/API/Gamepad/pose
 ---
 {{APIRef("Gamepad")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/gamepad/timestamp/index.md
+++ b/files/ja/web/api/gamepad/timestamp/index.md
@@ -1,16 +1,6 @@
 ---
 title: Gamepad.timestamp
 slug: Web/API/Gamepad/timestamp
-tags:
-  - API
-  - Gamepad API
-  - Games
-  - NeedsBetterSpecLink
-  - NeedsMarkupWork
-  - Property
-  - Reference
-  - Référence(2)
-translation_of: Web/API/Gamepad/timestamp
 ---
 {{APIRef("Gamepad API")}}
 

--- a/files/ja/web/api/gamepad_api/index.md
+++ b/files/ja/web/api/gamepad_api/index.md
@@ -1,13 +1,6 @@
 ---
 title: Gamepad API
 slug: Web/API/Gamepad_API
-tags:
-  - API
-  - Experimental
-  - Gamepad API
-  - Games
-  - Overview
-translation_of: Web/API/Gamepad_API
 ---
 {{DefaultAPISidebar("Gamepad API")}}
 

--- a/files/ja/web/api/gamepad_api/using_the_gamepad_api/index.md
+++ b/files/ja/web/api/gamepad_api/using_the_gamepad_api/index.md
@@ -1,13 +1,6 @@
 ---
 title: ゲームパッド API の使用
 slug: Web/API/Gamepad_API/Using_the_Gamepad_API
-tags:
-  - API
-  - Advanced
-  - Gamepad API
-  - Games
-  - Guide
-translation_of: Web/API/Gamepad_API/Using_the_Gamepad_API
 original_slug: Web/Guide/API/Gamepad
 ---
 {{DefaultAPISidebar("Gamepad API")}}

--- a/files/ja/web/api/gamepadbutton/index.md
+++ b/files/ja/web/api/gamepadbutton/index.md
@@ -1,14 +1,6 @@
 ---
 title: GamepadButton
 slug: Web/API/GamepadButton
-tags:
-  - API
-  - Gamepad API
-  - Games
-  - NeedsBufferSpecLink
-  - NeedsMarkupWork
-  - Référence(2)
-translation_of: Web/API/GamepadButton
 ---
 {{APIRef("Gamepad API")}}
 

--- a/files/ja/web/api/gamepadevent/gamepadevent/index.md
+++ b/files/ja/web/api/gamepadevent/gamepadevent/index.md
@@ -1,13 +1,6 @@
 ---
 title: GamepadEvent()
 slug: Web/API/GamepadEvent/GamepadEvent
-tags:
-  - API
-  - Constructor
-  - Gamepad API
-  - Games
-  - Referece
-translation_of: Web/API/GamepadEvent/GamepadEvent
 ---
 {{APIRef("Gamepad API")}}
 

--- a/files/ja/web/api/gamepadevent/index.md
+++ b/files/ja/web/api/gamepadevent/index.md
@@ -1,13 +1,6 @@
 ---
 title: GamepadEvent
 slug: Web/API/GamepadEvent
-tags:
-  - API
-  - Gamepad API
-  - Games
-  - Interface
-  - Reference
-translation_of: Web/API/GamepadEvent
 ---
 {{APIRef("Gamepad API")}}
 

--- a/files/ja/web/api/gamepadhapticactuator/index.md
+++ b/files/ja/web/api/gamepadhapticactuator/index.md
@@ -1,17 +1,6 @@
 ---
 title: GamepadHapticActuator
 slug: Web/API/GamepadHapticActuator
-tags:
-  - API
-  - Experimental
-  - Gamepad
-  - GamepadHapticActuator
-  - Interface
-  - Reference
-  - VR
-  - Virtual Reality
-  - WebVR
-translation_of: Web/API/GamepadHapticActuator
 ---
 {{APIRef("Gamepad API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/gamepadhapticactuator/pulse/index.md
+++ b/files/ja/web/api/gamepadhapticactuator/pulse/index.md
@@ -1,16 +1,6 @@
 ---
 title: GamepadHapticActuator.pulse()
 slug: Web/API/GamepadHapticActuator/pulse
-tags:
-  - API
-  - Experimental
-  - Gamepad
-  - Gamepad API
-  - GamepadHapticActuator
-  - Method
-  - Reference
-  - pulse
-translation_of: Web/API/GamepadHapticActuator/pulse
 ---
 {{APIRef("Gamepad")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/gamepadhapticactuator/type/index.md
+++ b/files/ja/web/api/gamepadhapticactuator/type/index.md
@@ -1,16 +1,6 @@
 ---
 title: GamepadHapticActuator.type
 slug: Web/API/GamepadHapticActuator/type
-tags:
-  - API
-  - Experimental
-  - Gamepad
-  - Gamepad API
-  - GamepadHapticActuator
-  - Property
-  - Reference
-  - Type
-translation_of: Web/API/GamepadHapticActuator/type
 ---
 {{APIRef("Gamepad")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/gamepadpose/hasorientation/index.md
+++ b/files/ja/web/api/gamepadpose/hasorientation/index.md
@@ -1,17 +1,6 @@
 ---
 title: GamepadPose.hasOrientation
 slug: Web/API/GamepadPose/hasOrientation
-tags:
-  - API
-  - Experimental
-  - Gamepad API
-  - GamepadPose
-  - Property
-  - Reference
-  - Virtual Reality
-  - WebVR
-  - hasOrientation
-translation_of: Web/API/GamepadPose/hasOrientation
 ---
 {{APIRef("WebVR API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/gamepadpose/index.md
+++ b/files/ja/web/api/gamepadpose/index.md
@@ -1,19 +1,6 @@
 ---
 title: GamepadPose
 slug: Web/API/GamepadPose
-tags:
-  - API
-  - Experimental
-  - Gamepad
-  - GamepadPose
-  - Interface
-  - NeedsTranslation
-  - Reference
-  - TopicStub
-  - VR
-  - Virtual Reality
-  - WebVR
-translation_of: Web/API/GamepadPose
 ---
 {{APIRef("Gamepad API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/geolocation/clearwatch/index.md
+++ b/files/ja/web/api/geolocation/clearwatch/index.md
@@ -1,17 +1,6 @@
 ---
 title: Geolocation.clearWatch()
 slug: Web/API/Geolocation/clearWatch
-tags:
-  - API
-  - Geolocation
-  - 位置情報 API
-  - メソッド
-  - NeedsExample
-  - リファレンス
-  - 安全なコンテキスト
-  - clearWatch
-browser-compat: api.Geolocation.clearWatch
-translation_of: Web/API/Geolocation/clearWatch
 ---
 {{securecontext_header}}{{ APIref("Geolocation API") }}
 

--- a/files/ja/web/api/geolocation/getcurrentposition/index.md
+++ b/files/ja/web/api/geolocation/getcurrentposition/index.md
@@ -1,16 +1,6 @@
 ---
 title: Geolocation.getCurrentPosition()
 slug: Web/API/Geolocation/getCurrentPosition
-tags:
-  - API
-  - Geolocation
-  - 位置情報 API
-  - メソッド
-  - リファレンス
-  - 安全なコンテキスト
-  - getCurrentPosition
-browser-compat: api.Geolocation.getCurrentPosition
-translation_of: Web/API/Geolocation/getCurrentPosition
 ---
 {{securecontext_header}}{{ APIRef("Geolocation API") }}
 

--- a/files/ja/web/api/geolocation/index.md
+++ b/files/ja/web/api/geolocation/index.md
@@ -1,15 +1,6 @@
 ---
 title: Geolocation
 slug: Web/API/Geolocation
-tags:
-  - API
-  - Advanced
-  - 位置情報 API
-  - インターフェイス
-  - リファレンス
-  - 安全なコンテキスト
-browser-compat: api.Geolocation
-translation_of: Web/API/Geolocation
 ---
 {{securecontext_header}}{{APIRef("Geolocation API")}}
 

--- a/files/ja/web/api/geolocation/watchposition/index.md
+++ b/files/ja/web/api/geolocation/watchposition/index.md
@@ -1,15 +1,6 @@
 ---
 title: Geolocation.watchPosition()
 slug: Web/API/Geolocation/watchPosition
-tags:
-  - API
-  - Geolocation
-  - 位置情報 API
-  - メソッド
-  - リファレンス
-  - 安全なコンテキスト
-browser-compat: api.Geolocation.watchPosition
-translation_of: Web/API/Geolocation/watchPosition
 ---
 {{securecontext_header}}{{ APIref("Geolocation API") }}
 

--- a/files/ja/web/api/geolocation_api/index.md
+++ b/files/ja/web/api/geolocation_api/index.md
@@ -1,12 +1,6 @@
 ---
 title: 位置情報 API
 slug: Web/API/Geolocation_API
-tags:
-  - 位置情報 API
-  - ガイド
-  - 中級者
-  - 概要
-translation_of: Web/API/Geolocation_API
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Geolocation API")}}
 

--- a/files/ja/web/api/geolocation_api/using_the_geolocation_api/index.md
+++ b/files/ja/web/api/geolocation_api/using_the_geolocation_api/index.md
@@ -1,11 +1,6 @@
 ---
 title: 位置情報 API の使用
 slug: Web/API/Geolocation_API/Using_the_Geolocation_API
-tags:
-  - 位置情報 API
-  - ガイド
-  - チュートリアル
-translation_of: Web/API/Geolocation_API/Using_the_Geolocation_API
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Geolocation API")}}
 

--- a/files/ja/web/api/geolocationcoordinates/accuracy/index.md
+++ b/files/ja/web/api/geolocationcoordinates/accuracy/index.md
@@ -1,15 +1,6 @@
 ---
 title: GeolocationCoordinates.accuracy
 slug: Web/API/GeolocationCoordinates/accuracy
-tags:
-  - API
-  - 位置情報 API
-  - GeolocationCoordinates
-  - プロパティ
-  - 安全なコンテキスト
-  - accuracy
-browser-compat: api.GeolocationCoordinates.accuracy
-translation_of: Web/API/GeolocationCoordinates/accuracy
 ---
 {{securecontext_header}}{{APIRef("Geolocation API")}}
 

--- a/files/ja/web/api/geolocationcoordinates/altitude/index.md
+++ b/files/ja/web/api/geolocationcoordinates/altitude/index.md
@@ -1,15 +1,6 @@
 ---
 title: GeolocationCoordinates.altitude
 slug: Web/API/GeolocationCoordinates/altitude
-tags:
-  - API
-  - 位置情報 API
-  - GeolocationCoordinates
-  - プロパティ
-  - 安全なコンテキスト
-  - altitude
-browser-compat: api.GeolocationCoordinates.altitude
-translation_of: Web/API/GeolocationCoordinates/altitude
 ---
 {{securecontext_header}}{{APIRef("Geolocation API")}}
 

--- a/files/ja/web/api/geolocationcoordinates/altitudeaccuracy/index.md
+++ b/files/ja/web/api/geolocationcoordinates/altitudeaccuracy/index.md
@@ -1,15 +1,6 @@
 ---
 title: GeolocationCoordinates.altitudeAccuracy
 slug: Web/API/GeolocationCoordinates/altitudeAccuracy
-tags:
-  - API
-  - 位置情報 API
-  - GeolocationCoordinates
-  - プロパティ
-  - 安全なコンテキスト
-  - altitudeAccuracy
-browser-compat: api.GeolocationCoordinates.altitudeAccuracy
-translation_of: Web/API/GeolocationCoordinates/altitudeAccuracy
 ---
 {{securecontext_header}}{{APIRef("Geolocation API")}}
 

--- a/files/ja/web/api/geolocationcoordinates/heading/index.md
+++ b/files/ja/web/api/geolocationcoordinates/heading/index.md
@@ -1,15 +1,6 @@
 ---
 title: GeolocationCoordinates.heading
 slug: Web/API/GeolocationCoordinates/heading
-tags:
-  - API
-  - 位置情報 API
-  - GeolocationCoordinates
-  - プロパティ
-  - 安全なコンテキスト
-  - heading
-browser-compat: api.GeolocationCoordinates.heading
-translation_of: Web/API/GeolocationCoordinates/heading
 ---
 {{securecontext_header}}{{APIRef("Geolocation API")}}
 

--- a/files/ja/web/api/geolocationcoordinates/index.md
+++ b/files/ja/web/api/geolocationcoordinates/index.md
@@ -1,13 +1,6 @@
 ---
 title: GeolocationCoordinates
 slug: Web/API/GeolocationCoordinates
-tags:
-  - API
-  - 位置情報 API
-  - GeolocationCoordinates
-  - Interface
-  - 安全なコンテキスト
-translation_of: Web/API/GeolocationCoordinates
 ---
 {{securecontext_header}}{{APIRef("Geolocation API")}}
 

--- a/files/ja/web/api/geolocationcoordinates/latitude/index.md
+++ b/files/ja/web/api/geolocationcoordinates/latitude/index.md
@@ -1,15 +1,6 @@
 ---
 title: GeolocationCoordinates.latitude
 slug: Web/API/GeolocationCoordinates/latitude
-tags:
-  - API
-  - 位置情報 API
-  - GeolocationCoordinates
-  - プロパティ
-  - 安全なコンテキスト
-  - latitude
-browser-compat: api.GeolocationCoordinates.latitude
-translation_of: Web/API/GeolocationCoordinates/latitude
 ---
 {{securecontext_header}}{{APIRef("Geolocation API")}}
 

--- a/files/ja/web/api/geolocationcoordinates/longitude/index.md
+++ b/files/ja/web/api/geolocationcoordinates/longitude/index.md
@@ -1,20 +1,6 @@
 ---
 title: GeolocationCoordinates.longitude
 slug: Web/API/GeolocationCoordinates/longitude
-tags:
-  - API
-  - GPS
-  - Geolocation
-  - 位置情報 API
-  - GeolocationCoordinates
-  - Global Positioning System
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - 安全なコンテキスト
-  - longitude
-browser-compat: api.GeolocationCoordinates.longitude
-translation_of: Web/API/GeolocationCoordinates/longitude
 ---
 {{securecontext_header}}{{APIRef("Geolocation API")}}
 

--- a/files/ja/web/api/geolocationcoordinates/speed/index.md
+++ b/files/ja/web/api/geolocationcoordinates/speed/index.md
@@ -1,15 +1,6 @@
 ---
 title: GeolocationCoordinates.speed
 slug: Web/API/GeolocationCoordinates/speed
-tags:
-  - API
-  - 位置情報 API
-  - GeolocationCoordinates
-  - プロパティ
-  - 安全なコンテキスト
-  - speed
-browser-compat: api.GeolocationCoordinates.speed
-translation_of: Web/API/GeolocationCoordinates/speed
 ---
 {{securecontext_header}}{{APIRef("Geolocation API")}}
 

--- a/files/ja/web/api/geolocationposition/coords/index.md
+++ b/files/ja/web/api/geolocationposition/coords/index.md
@@ -1,15 +1,6 @@
 ---
 title: GeolocationPosition.coords
 slug: Web/API/GeolocationPosition/coords
-tags:
-  - API
-  - 位置情報 API
-  - GeolocationPosition
-  - プロパティ
-  - 安全なコンテキスト
-  - coords
-browser-compat: api.GeolocationPosition.coords
-translation_of: Web/API/GeolocationPosition/coords
 ---
 {{securecontext_header}}{{APIRef("Geolocation API")}}
 

--- a/files/ja/web/api/geolocationposition/index.md
+++ b/files/ja/web/api/geolocationposition/index.md
@@ -1,14 +1,6 @@
 ---
 title: GeolocationPosition
 slug: Web/API/GeolocationPosition
-tags:
-  - API
-  - 位置情報 API
-  - GeolocationPosition
-  - インターフェイス
-  - 安全なコンテキスト
-browser-compat: api.GeolocationPosition
-translation_of: Web/API/GeolocationPosition
 ---
 {{securecontext_header}}{{APIRef("Geolocation API")}}
 

--- a/files/ja/web/api/geolocationposition/timestamp/index.md
+++ b/files/ja/web/api/geolocationposition/timestamp/index.md
@@ -1,15 +1,6 @@
 ---
 title: GeolocationPosition.timestamp
 slug: Web/API/GeolocationPosition/timestamp
-tags:
-  - API
-  - 位置情報 API
-  - GeolocationPosition
-  - プロパティ
-  - 安全なコンテキスト
-  - timeStamp
-browser-compat: api.GeolocationPosition.timestamp
-translation_of: Web/API/GeolocationPosition/timestamp
 ---
 {{securecontext_header}}{{APIRef("Geolocation API")}}
 

--- a/files/ja/web/api/geolocationpositionerror/code/index.md
+++ b/files/ja/web/api/geolocationpositionerror/code/index.md
@@ -1,15 +1,6 @@
 ---
 title: GeolocationPositionError.code
 slug: Web/API/GeolocationPositionError/code
-tags:
-  - API
-  - Code
-  - 位置情報 API
-  - GeolocationPositionError
-  - プロパティ
-  - 安全なコンテキスト
-browser-compat: api.GeolocationPositionError.code
-translation_of: Web/API/GeolocationPositionError/code
 ---
 {{securecontext_header}}{{APIRef("Geolocation API")}}
 

--- a/files/ja/web/api/geolocationpositionerror/index.md
+++ b/files/ja/web/api/geolocationpositionerror/index.md
@@ -1,14 +1,6 @@
 ---
 title: GeolocationPositionError
 slug: Web/API/GeolocationPositionError
-tags:
-  - API
-  - 位置情報 API
-  - GeolocationPositionError
-  - インターフェイス
-  - 安全なコンテキスト
-browser-compat: api.GeolocationPositionError
-translation_of: Web/API/GeolocationPositionError
 ---
 {{securecontext_header}}{{APIRef("Geolocation API")}}
 

--- a/files/ja/web/api/geolocationpositionerror/message/index.md
+++ b/files/ja/web/api/geolocationpositionerror/message/index.md
@@ -1,15 +1,6 @@
 ---
 title: GeolocationPositionError.message
 slug: Web/API/GeolocationPositionError/message
-tags:
-  - API
-  - 位置情報 API
-  - GeolocationPositionError
-  - プロパティ
-  - 安全なコンテキスト
-  - message
-browser-compat: api.GeolocationPositionError.message
-tranlation_of: Web/API/GeolocationPositionError/message
 ---
 {{securecontext_header}}{{APIRef("Geolocation API")}}
 


### PR DESCRIPTION
Part of #7858

`files/ja/web/api/{e-g}*` から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "tags": 283,
  "translation_of": 285,
  "page-type": 40,
  "browser-compat": 67,
  "spec-urls": 1,
  "tranlation_of": 1
}
```
