### PR TITLE
remove duplicated frontmatter keys from web/api/h* (ja)

### DIFF
--- a/files/ja/web/api/headers/append/index.md
+++ b/files/ja/web/api/headers/append/index.md
@@ -1,14 +1,6 @@
 ---
 title: Headers.append()
 slug: Web/API/Headers/append
-tags:
-  - API
-  - Append
-  - Experimental
-  - Fetch
-  - Method
-  - Reference
-translation_of: Web/API/Headers/append
 ---
 {{APIRef("Fetch")}}{{ SeeCompatTable() }}
 

--- a/files/ja/web/api/headers/delete/index.md
+++ b/files/ja/web/api/headers/delete/index.md
@@ -1,14 +1,6 @@
 ---
 title: Headers.delete()
 slug: Web/API/Headers/delete
-tags:
-  - API
-  - Experimental
-  - Fetch
-  - Method
-  - Reference
-  - delete
-translation_of: Web/API/Headers/delete
 ---
 {{APIRef("Fetch")}}
 

--- a/files/ja/web/api/headers/entries/index.md
+++ b/files/ja/web/api/headers/entries/index.md
@@ -1,7 +1,6 @@
 ---
 title: Headers.entries()
 slug: Web/API/Headers/entries
-translation_of: Web/API/Headers/entries
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/headers/get/index.md
+++ b/files/ja/web/api/headers/get/index.md
@@ -1,15 +1,6 @@
 ---
 title: Headers.get()
 slug: Web/API/Headers/get
-tags:
-  - API
-  - Experimental
-  - Fetch
-  - Headers
-  - Method
-  - Reference
-  - get
-translation_of: Web/API/Headers/get
 ---
 {{APIRef("Fetch")}}
 

--- a/files/ja/web/api/headers/headers/index.md
+++ b/files/ja/web/api/headers/headers/index.md
@@ -1,7 +1,6 @@
 ---
 title: Headers()
 slug: Web/API/Headers/Headers
-translation_of: Web/API/Headers/Headers
 ---
 {{APIRef("Fetch")}}
 

--- a/files/ja/web/api/headers/index.md
+++ b/files/ja/web/api/headers/index.md
@@ -1,15 +1,6 @@
 ---
 title: Headers
 slug: Web/API/Headers
-tags:
-  - API
-  - Experimental
-  - Fetch
-  - Fetch API
-  - Headers
-  - Interface
-  - Reference
-translation_of: Web/API/Headers
 ---
 {{ APIRef("Fetch") }}
 

--- a/files/ja/web/api/history/back/index.md
+++ b/files/ja/web/api/history/back/index.md
@@ -1,16 +1,6 @@
 ---
 title: History.back()
 slug: Web/API/History/back
-tags:
-  - API
-  - HTML DOM
-  - History
-  - 履歴 API
-  - メソッド
-  - リファレンス
-  - ウェブ
-browser-compat: api.History.back
-translation_of: Web/API/History/back
 ---
 {{APIRef("History API")}}
 

--- a/files/ja/web/api/history/forward/index.md
+++ b/files/ja/web/api/history/forward/index.md
@@ -1,15 +1,6 @@
 ---
 title: History.forward()
 slug: Web/API/History/forward
-tags:
-  - API
-  - HTML DOM
-  - History
-  - 履歴 API
-  - メソッド
-  - リファレンス
-browser-compat: api.History.forward
-translation_of: Web/API/History/forward
 ---
 {{APIRef("History API")}}
 

--- a/files/ja/web/api/history/go/index.md
+++ b/files/ja/web/api/history/go/index.md
@@ -1,15 +1,6 @@
 ---
 title: History.go()
 slug: Web/API/History/go
-tags:
-  - API
-  - HTML DOM
-  - History
-  - 履歴 API
-  - メソッド
-  - リファレンス
-browser-compat: api.History.go
-translation_of: Web/API/History/go
 ---
 {{APIRef("History API")}}
 

--- a/files/ja/web/api/history/index.md
+++ b/files/ja/web/api/history/index.md
@@ -1,14 +1,6 @@
 ---
 title: History
 slug: Web/API/History
-tags:
-  - API
-  - HTML DOM
-  - 履歴 API
-  - インターフェイス
-  - ウェブ
-browser-compat: api.History
-translation_of: Web/API/History
 ---
 {{ APIRef("History API") }}
 

--- a/files/ja/web/api/history/length/index.md
+++ b/files/ja/web/api/history/length/index.md
@@ -1,16 +1,6 @@
 ---
 title: History.length
 slug: Web/API/History/length
-tags:
-  - API
-  - HTML DOM
-  - History
-  - 履歴 API
-  - プロパティ
-  - Read-only
-  - リファレンス
-browser-compat: api.History.length
-translation_of: Web/API/History/length
 ---
 {{APIRef("History API")}}
 

--- a/files/ja/web/api/history/pushstate/index.md
+++ b/files/ja/web/api/history/pushstate/index.md
@@ -1,20 +1,6 @@
 ---
 title: History.pushState()
 slug: Web/API/History/pushState
-tags:
-  - API
-  - HTML DOM
-  - History
-  - 履歴 API
-  - Location
-  - メソッド
-  - リファレンス
-  - セッション
-  - URL
-  - ウェブ
-  - pushState
-browser-compat: api.History.pushState
-translation_of: Web/API/History/pushState
 ---
 {{APIRef("History API")}}
 

--- a/files/ja/web/api/history/replacestate/index.md
+++ b/files/ja/web/api/history/replacestate/index.md
@@ -1,15 +1,6 @@
 ---
 title: History.replaceState()
 slug: Web/API/History/replaceState
-tags:
-  - API
-  - HTML DOM
-  - History
-  - 履歴 API
-  - メソッド
-  - リファレンス
-browser-compat: api.History.replaceState
-translation_of: Web/API/History/replaceState
 ---
 {{APIRef("History API")}}
 

--- a/files/ja/web/api/history/scrollrestoration/index.md
+++ b/files/ja/web/api/history/scrollrestoration/index.md
@@ -1,15 +1,6 @@
 ---
 title: History.scrollRestoration
 slug: Web/API/History/scrollRestoration
-tags:
-  - API
-  - HTML DOM
-  - History
-  - 履歴 API
-  - プロパティ
-  - リファレンス
-browser-compat: api.History.scrollRestoration
-translation_of: Web/API/History/scrollRestoration
 ---
 {{APIRef("History API")}}
 

--- a/files/ja/web/api/history/state/index.md
+++ b/files/ja/web/api/history/state/index.md
@@ -1,15 +1,6 @@
 ---
 title: History.state
 slug: Web/API/History/state
-tags:
-  - API
-  - HTML DOM
-  - History
-  - 履歴 API
-  - プロパティ
-  - リファレンス
-browser-compat: api.History.state
-translation_of: Web/API/History/state
 ---
 {{APIRef("History API")}}
 

--- a/files/ja/web/api/history_api/example/index.md
+++ b/files/ja/web/api/history_api/example/index.md
@@ -1,7 +1,6 @@
 ---
 title: Ajax ナビゲーションの例
 slug: Web/API/History_API/Example
-translation_of: Web/API/History_API/Example
 ---
 これは 3 ページ (first_page.php、second_page.php、third_page.php) で構成された AJAX Web サイトの例です。どのように動作するかを確認するには、以下のファイル (または git clone [https://github.com/giabao/mdn-ajax-nav-example.git](https://github.com/giabao/mdn-ajax-nav-example "/en-US/docs/")) を作成してください：
 

--- a/files/ja/web/api/history_api/index.md
+++ b/files/ja/web/api/history_api/index.md
@@ -1,14 +1,6 @@
 ---
 title: History API
 slug: Web/API/History_API
-tags:
-  - API
-  - Advanced
-  - DOM
-  - HTML5
-  - History
-  - 履歴
-translation_of: Web/API/History_API
 ---
 {{DefaultAPISidebar("History API")}}
 

--- a/files/ja/web/api/history_api/working_with_the_history_api/index.md
+++ b/files/ja/web/api/history_api/working_with_the_history_api/index.md
@@ -1,13 +1,6 @@
 ---
 title: 履歴 API の操作
 slug: Web/API/History_API/Working_with_the_History_API
-page-type: guide
-tags:
-  - Advanced
-  - DOM
-  - History API
-  - History API Tutorial
-translation_of: Web/API/History_API/Working_with_the_History_API
 ---
 {{DefaultAPISidebar("History API")}}
 HTML5 では、履歴項目を追加および変更するための {{DOMxRef("History.pushState", "pushState()")}} および {{DOMxRef("History.replaceState", "replaceState()")}} メソッドをそれぞれ導入しています。これらのメソッドは {{domxref("Window/popstate_event", "popstate")}} イベントと一緒に動作します。

--- a/files/ja/web/api/html_dom_api/index.md
+++ b/files/ja/web/api/html_dom_api/index.md
@@ -1,20 +1,6 @@
 ---
 title: HTML DOM API
 slug: Web/API/HTML_DOM_API
-tags:
-  - API
-  - 初心者
-  - DOM
-  - 文書
-  - 要素
-  - HTML DOM
-  - HTML DOM API
-  - ノード
-  - 概要
-  - ウェブ
-  - ウィンドウ
-  - 階層
-translation_of: Web/API/HTML_DOM_API
 ---
 {{DefaultAPISidebar("HTML DOM")}}
 

--- a/files/ja/web/api/html_dom_api/microtask_guide/index.md
+++ b/files/ja/web/api/html_dom_api/microtask_guide/index.md
@@ -1,22 +1,6 @@
 ---
 title: JavaScript で queueMicrotask() によるマイクロタスクの使用
 slug: Web/API/HTML_DOM_API/Microtask_guide
-tags:
-  - API
-  - バッチ
-  - ガイド
-  - HTML DOM
-  - JavaScript
-  - マイクロタスク
-  - キュー
-  - リファレンス
-  - ServiceWorker
-  - SharedWorker
-  - Window
-  - ワーカー
-  - 非同期
-  - queueMicrotask
-translation_of: Web/API/HTML_DOM_API/Microtask_guide
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/html_drag_and_drop_api/drag_operations/index.md
+++ b/files/ja/web/api/html_drag_and_drop_api/drag_operations/index.md
@@ -1,14 +1,6 @@
 ---
 title: ドラッグ操作
 slug: Web/API/HTML_Drag_and_Drop_API/Drag_operations
-tags:
-  - Advanced
-  - Guide
-  - HTML
-  - HTML5
-  - drag and drop
-  - ドラッグ＆ドロップ
-translation_of: Web/API/HTML_Drag_and_Drop_API/Drag_operations
 original_slug: DragDrop/Drag_Operations
 ---
 {{DefaultAPISidebar("HTML Drag and Drop API")}}

--- a/files/ja/web/api/html_drag_and_drop_api/index.md
+++ b/files/ja/web/api/html_drag_and_drop_api/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTML ドラッグ＆ドロップ API
 slug: Web/API/HTML_Drag_and_Drop_API
-tags:
-  - Advanced
-  - Guide
-  - HTML5
-  - Overview
-  - XUL
-  - drag and drop
-  - events
-  - ドラッグ＆ドロップ
-translation_of: Web/API/HTML_Drag_and_Drop_API
 ---
 {{DefaultAPISidebar("HTML Drag and Drop API")}}
 

--- a/files/ja/web/api/html_drag_and_drop_api/multiple_items/index.md
+++ b/files/ja/web/api/html_drag_and_drop_api/multiple_items/index.md
@@ -1,12 +1,6 @@
 ---
 title: 複数のアイテムのドラッグ＆ドロップ
 slug: Web/API/HTML_Drag_and_Drop_API/Multiple_items
-tags:
-  - Gecko
-  - ガイド
-  - 標準外
-  - ドラッグ＆ドロップ
-translation_of: Web/API/HTML_Drag_and_Drop_API/Multiple_items
 original_slug: DragDrop/Dragging_and_Dropping_Multiple_Items
 ---
 {{DefaultAPISidebar("HTML Drag and Drop API")}}

--- a/files/ja/web/api/html_drag_and_drop_api/recommended_drag_types/index.md
+++ b/files/ja/web/api/html_drag_and_drop_api/recommended_drag_types/index.md
@@ -1,10 +1,6 @@
 ---
 title: 推奨されるドラッグのデータ型
 slug: Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types
-tags:
-  - Guide
-  - drag and drop
-translation_of: Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types
 original_slug: DragDrop/Recommended_Drag_Types
 ---
 {{DefaultAPISidebar("HTML Drag and Drop API")}}

--- a/files/ja/web/api/htmlanchorelement/download/index.md
+++ b/files/ja/web/api/htmlanchorelement/download/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLAnchorElement.download
 slug: Web/API/HTMLAnchorElement/download
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLAnchorElement
-  - プロパティ
-  - リファレンス
-  - download
-browser-compat: api.HTMLAnchorElement.download
-translation_of: Web/API/HTMLAnchorElement/download
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlanchorelement/hash/index.md
+++ b/files/ja/web/api/htmlanchorelement/hash/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLAnchorElement.hash
 slug: Web/API/HTMLAnchorElement/hash
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAnchorElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLAnchorElement.hash
-translation_of: Web/API/HTMLAnchorElement/hash
 original_slug: Web/API/HTMLHyperlinkElementUtils/hash
 ---
 {{ APIRef("HTML DOM") }}

--- a/files/ja/web/api/htmlanchorelement/host/index.md
+++ b/files/ja/web/api/htmlanchorelement/host/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLAnchorElement.host
 slug: Web/API/HTMLAnchorElement/host
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAnchorElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLAnchorElement.host
-translation_of: Web/API/HTMLAnchorElement/host
 original_slug: Web/API/HTMLHyperlinkElementUtils/host
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/htmlanchorelement/hostname/index.md
+++ b/files/ja/web/api/htmlanchorelement/hostname/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLAnchorElement.hostname
 slug: Web/API/HTMLAnchorElement/hostname
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAnchorElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLAnchorElement.hostname
-translation_of: Web/API/HTMLAnchorElement/hostname
 original_slug: Web/API/HTMLHyperlinkElementUtils/hostname
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/htmlanchorelement/href/index.md
+++ b/files/ja/web/api/htmlanchorelement/href/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLAnchorElement.href
 slug: Web/API/HTMLAnchorElement/href
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAnchorElement
-  - Location
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLAnchorElement.href
-translation_of: Web/API/HTMLAnchorElement/href
 original_slug: Web/API/HTMLHyperlinkElementUtils/href
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/htmlanchorelement/index.md
+++ b/files/ja/web/api/htmlanchorelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLAnchorElement
 slug: Web/API/HTMLAnchorElement
-page-type: web-api-interface
-tags:
-  - API
-  - HTML DOM
-  - インターフェイス
-  - リファレンス
-browser-compat: api.HTMLAnchorElement
-translation_of: Web/API/HTMLAnchorElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlanchorelement/origin/index.md
+++ b/files/ja/web/api/htmlanchorelement/origin/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLAnchorElement.origin
 slug: Web/API/HTMLAnchorElement/origin
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAnchorElement
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.HTMLAnchorElement.origin
-translation_of: Web/API/HTMLAnchorElement/origin
 original_slug: Web/API/HTMLHyperlinkElementUtils/origin
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/web/api/htmlanchorelement/password/index.md
+++ b/files/ja/web/api/htmlanchorelement/password/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLAnchorElement.password
 slug: Web/API/HTMLAnchorElement/password
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAnchorElement
-  - プロパティ
-browser-compat: api.HTMLAnchorElement.password
-translation_of: Web/API/HTMLAnchorElement/password
 original_slug: Web/API/HTMLHyperlinkElementUtils/password
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/htmlanchorelement/pathname/index.md
+++ b/files/ja/web/api/htmlanchorelement/pathname/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLAnchorElement.pathname
 slug: Web/API/HTMLAnchorElement/pathname
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAnchorElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLAnchorElement.pathname
-translation_of: Web/API/HTMLAnchorElement/pathname
 original_slug: Web/API/HTMLHyperlinkElementUtils/pathname
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/htmlanchorelement/port/index.md
+++ b/files/ja/web/api/htmlanchorelement/port/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLAnchorElement.port
 slug: Web/API/HTMLAnchorElement/port
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAnchorElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLAnchorElement.port
-translation_of: Web/API/HTMLAnchorElement/port
 original_slug: Web/API/HTMLHyperlinkElementUtils/port
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/htmlanchorelement/protocol/index.md
+++ b/files/ja/web/api/htmlanchorelement/protocol/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLAnchorElement.protocol
 slug: Web/API/HTMLAnchorElement/protocol
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAnchorElement
-  - プロパティ
-browser-compat: api.HTMLAnchorElement.protocol
-translation_of: Web/API/HTMLAnchorElement/protocol
 original_slug: Web/API/HTMLHyperlinkElementUtils/protocol
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/htmlanchorelement/referrerpolicy/index.md
+++ b/files/ja/web/api/htmlanchorelement/referrerpolicy/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLAnchorElement.referrerPolicy
 slug: Web/API/HTMLAnchorElement/referrerPolicy
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAnchorElement
-  - プロパティ
-  - リファレンス
-  - Referrer Policy
-browser-compat: api.HTMLAnchorElement.referrerPolicy
-translation_of: Web/API/HTMLAnchorElement/referrerPolicy
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmlanchorelement/rel/index.md
+++ b/files/ja/web/api/htmlanchorelement/rel/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLAnchorElement.rel
 slug: Web/API/HTMLAnchorElement/rel
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLAnchorElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLAnchorElement.rel
-translation_of: Web/API/HTMLAnchorElement/rel
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlanchorelement/rellist/index.md
+++ b/files/ja/web/api/htmlanchorelement/rellist/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLAnchorElement.relList
 slug: Web/API/HTMLAnchorElement/relList
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLAnchorElement
-  - プロパティ
-  - リファレンス
-  - relList
-browser-compat: api.HTMLAnchorElement.relList
-translation_of: Web/API/HTMLAnchorElement/relList
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlanchorelement/search/index.md
+++ b/files/ja/web/api/htmlanchorelement/search/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLAnchorElement.search
 slug: Web/API/HTMLAnchorElement/search
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAnchorElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLAnchorElement.search
-translation_of: Web/API/HTMLAnchorElement/search
 original_slug: Web/API/HTMLHyperlinkElementUtils/search
 ---
 {{ApiRef("URL API")}}

--- a/files/ja/web/api/htmlanchorelement/tostring/index.md
+++ b/files/ja/web/api/htmlanchorelement/tostring/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLAnchorElement.toString()
 slug: Web/API/HTMLAnchorElement/toString
-page-type: web-api-instance-method
-tags:
-  - API
-  - HTMLAnchorElement
-  - Method
-  - Stringifier
-browser-compat: api.HTMLAnchorElement.toString
-translation_of: Web/API/HTMLAnchorElement/toString
 original_slug: Web/API/HTMLHyperlinkElementUtils/toString
 ---
 {{ApiRef("URL API")}}

--- a/files/ja/web/api/htmlanchorelement/username/index.md
+++ b/files/ja/web/api/htmlanchorelement/username/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLAnchorElement.username
 slug: Web/API/HTMLAnchorElement/username
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAnchorElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLAnchorElement.username
-translation_of: Web/API/HTMLAnchorElement/username
 original_slug: Web/API/HTMLHyperlinkElementUtils/username
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/htmlareaelement/hash/index.md
+++ b/files/ja/web/api/htmlareaelement/hash/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLAreaElement.hash
 slug: Web/API/HTMLAreaElement/hash
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAreaElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLAreaElement.hash
-translation_of: Web/API/HTMLAnchorElement/hash
 original_slug: Web/API/HTMLHyperlinkElementUtils/hash
 ---
 {{ APIRef("HTML DOM") }}

--- a/files/ja/web/api/htmlareaelement/host/index.md
+++ b/files/ja/web/api/htmlareaelement/host/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLAreaElement.host
 slug: Web/API/HTMLAreaElement/host
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAreaElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLAreaElement.host
-translation_of: Web/API/api.HTMLAreaElement.host/host
 original_slug: Web/API/HTMLHyperlinkElementUtils/host
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/htmlareaelement/hostname/index.md
+++ b/files/ja/web/api/htmlareaelement/hostname/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLAreaElement.hostname
 slug: Web/API/HTMLAreaElement/hostname
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAreaElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLAreaElement.hostname
-translation_of: Web/API/HTMLAreaElement/hostname
 original_slug: Web/API/HTMLHyperlinkElementUtils/hostname
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/htmlareaelement/href/index.md
+++ b/files/ja/web/api/htmlareaelement/href/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLAreaElement.href
 slug: Web/API/HTMLAreaElement/href
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAreaElement
-  - Location
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLAreaElement.href
-translation_of: Web/API/HTMLAreaElement/href
 original_slug: Web/API/HTMLHyperlinkElementUtils/href
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/htmlareaelement/index.md
+++ b/files/ja/web/api/htmlareaelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLAreaElement
 slug: Web/API/HTMLAreaElement
-page-type: web-api-interface
-tags:
-  - API
-  - HTML DOM
-  - インターフェイス
-  - リファレンス
-browser-compat: api.HTMLAreaElement
-translation_of: Web/API/HTMLAreaElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlareaelement/origin/index.md
+++ b/files/ja/web/api/htmlareaelement/origin/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLAreaElement.origin
 slug: Web/API/HTMLAreaElement/origin
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAreaElement
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.HTMLAreaElement.origin
-translation_of: Web/API/HTMLAreaElement/origin
 original_slug: Web/API/HTMLHyperlinkElementUtils/origin
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/web/api/htmlareaelement/password/index.md
+++ b/files/ja/web/api/htmlareaelement/password/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLAreaElement.password
 slug: Web/API/HTMLAreaElement/password
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAreaElement
-  - プロパティ
-browser-compat: api.HTMLAreaElement.password
-translation_of: Web/API/HTMLAreaElement/password
 original_slug: Web/API/HTMLHyperlinkElementUtils/password
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/htmlareaelement/pathname/index.md
+++ b/files/ja/web/api/htmlareaelement/pathname/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLAreaElement.pathname
 slug: Web/API/HTMLAreaElement/pathname
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAreaElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLAreaElement.pathname
-translation_of: Web/API/HTMLAreaElement/pathname
 original_slug: Web/API/HTMLHyperlinkElementUtils/pathname
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/htmlareaelement/port/index.md
+++ b/files/ja/web/api/htmlareaelement/port/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLAreaElement.port
 slug: Web/API/HTMLAreaElement/port
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAreaElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLAreaElement.port
-translation_of: Web/API/HTMLAreaElement/port
 original_slug: Web/API/HTMLHyperlinkElementUtils/port
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/htmlareaelement/protocol/index.md
+++ b/files/ja/web/api/htmlareaelement/protocol/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLAreaElement.protocol
 slug: Web/API/HTMLAreaElement/protocol
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAreaElement
-  - プロパティ
-browser-compat: api.HTMLAreaElement.protocol
-translation_of: Web/API/HTMLAreaElement/protocol
 original_slug: Web/API/HTMLHyperlinkElementUtils/protocol
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/htmlareaelement/referrerpolicy/index.md
+++ b/files/ja/web/api/htmlareaelement/referrerpolicy/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLAreaElement.referrerPolicy
 slug: Web/API/HTMLAreaElement/referrerPolicy
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAreaElement
-  - プロパティ
-  - リファレンス
-  - Referrer Policy
-browser-compat: api.HTMLAreaElement.referrerPolicy
-translation_of: Web/API/HTMLAreaElement/referrerPolicy
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmlareaelement/rel/index.md
+++ b/files/ja/web/api/htmlareaelement/rel/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLAreaElement.rel
 slug: Web/API/HTMLAreaElement/rel
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLAreaElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLAreaElement.rel
-translation_of: Web/API/HTMLAreaElement/rel
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlareaelement/rellist/index.md
+++ b/files/ja/web/api/htmlareaelement/rellist/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLAreaElement.relList
 slug: Web/API/HTMLAreaElement/relList
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLAreaElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLAreaElement.relList
-translation_of: Web/API/HTMLAreaElement/relList
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlareaelement/search/index.md
+++ b/files/ja/web/api/htmlareaelement/search/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLAreaElement.search
 slug: Web/API/HTMLAreaElement/search
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAreaElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLAreaElement.search
-translation_of: Web/API/HTMLAreaElement/search
 original_slug: Web/API/HTMLHyperlinkElementUtils/search
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/htmlareaelement/tostring/index.md
+++ b/files/ja/web/api/htmlareaelement/tostring/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLAreaElement.toString()
 slug: Web/API/HTMLAreaElement/toString
-page-type: web-api-instance-method
-tags:
-  - API
-  - HTMLAreaElement
-  - メソッド
-  - Stringifier
-browser-compat: api.HTMLAreaElement.toString
-translation_of: Web/API/HTMLAreaElement/toString
 original_slug: Web/API/HTMLHyperlinkElementUtils/toString
 ---
 {{ApiRef("URL API")}}

--- a/files/ja/web/api/htmlareaelement/username/index.md
+++ b/files/ja/web/api/htmlareaelement/username/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLAreaElement.username
 slug: Web/API/HTMLAreaElement/username
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLAreaElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLAreaElement.username
-translation_of: Web/API/HTMLAreaElement/username
 original_slug: Web/API/HTMLHyperlinkElementUtils/username
 ---
 {{ApiRef("HTML DOM")}}

--- a/files/ja/web/api/htmlaudioelement/index.md
+++ b/files/ja/web/api/htmlaudioelement/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLAudioElement
 slug: Web/API/HTMLAudioElement
-tags:
-  - API
-  - HTML DOM
-  - HTMLAudioElement
-  - Interface
-  - Reference
-translation_of: Web/API/HTMLAudioElement
 ---
 **`HTMLAudioElement`** インターフェイスは {{HTMLElement("audio")}} 要素のプロパティと、操作するメソッドを提供します。 {{domxref("HTMLMediaElement")}} インターフェイスから派生しています。
 

--- a/files/ja/web/api/htmlbaseelement/index.md
+++ b/files/ja/web/api/htmlbaseelement/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLBaseElement
 slug: Web/API/HTMLBaseElement
-tags:
-  - API
-  - HTML DOM
-  - インターフェイス
-  - リファレンス
-browser-compat: api.HTMLBaseElement
-translation_of: Web/API/HTMLBaseElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlbodyelement/index.md
+++ b/files/ja/web/api/htmlbodyelement/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLBodyElement
 slug: Web/API/HTMLBodyElement
-page-type: web-api-interface
-tags:
-  - API
-  - HTML DOM
-  - インターフェイス
-  - NeedsNewLayout
-  - リファレンス
-browser-compat: api.HTMLBodyElement
-translation_of: Web/API/HTMLBodyElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlbrelement/index.md
+++ b/files/ja/web/api/htmlbrelement/index.md
@@ -1,12 +1,6 @@
 ---
 title: HTMLBRElement
 slug: Web/API/HTMLBRElement
-tags:
-  - DOM
-  - DOM Reference
-  - Interface
-  - Reference
-translation_of: Web/API/HTMLBRElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlbuttonelement/disabled/index.md
+++ b/files/ja/web/api/htmlbuttonelement/disabled/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLButtonElement.disabled
 slug: Web/API/HTMLButtonElement/disabled
-tags:
-  - API
-  - HTML DOM
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLButtonElement.disabled
-translation_of: Web/API/HTMLButtonElement/disabled
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/htmlbuttonelement/index.md
+++ b/files/ja/web/api/htmlbuttonelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLButtonElement
 slug: Web/API/HTMLButtonElement
-tags:
-  - API
-  - HTML DOM
-  - HTMLButtonElement
-  - インターフェイス
-  - リファレンス
-browser-compat: api.HTMLButtonElement
-translation_of: Web/API/HTMLButtonElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlbuttonelement/labels/index.md
+++ b/files/ja/web/api/htmlbuttonelement/labels/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLButtonElement.labels
 slug: Web/API/HTMLButtonElement/labels
-tags:
-  - API
-  - HTML DOM
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLButtonElement.labels
-translation_of: Web/API/HTMLButtonElement/labels
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/htmlcanvaselement/capturestream/index.md
+++ b/files/ja/web/api/htmlcanvaselement/capturestream/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLCanvasElement.captureStream()
 slug: Web/API/HTMLCanvasElement/captureStream
-tags:
-  - Canvas
-  - Experimental
-  - HTMLCanvasElement
-  - Interface
-  - Media
-  - Media Capture DOM Elements
-  - Method
-  - Reference
-  - Web
-translation_of: Web/API/HTMLCanvasElement/captureStream
 ---
 {{APIRef("Media Capture and Streams")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/htmlcanvaselement/index.md
+++ b/files/ja/web/api/htmlcanvaselement/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLCanvasElement
 slug: Web/API/HTMLCanvasElement
-tags:
-  - API
-  - Canvas
-  - HTML DOM
-  - Interface
-  - NeedsTranslation
-  - Reference
-  - TopicStub
-translation_of: Web/API/HTMLCanvasElement
 ---
 {{APIRef("Canvas API")}}
 

--- a/files/ja/web/api/htmlcanvaselement/toblob/index.md
+++ b/files/ja/web/api/htmlcanvaselement/toblob/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLCanvasElement.toBlob()
 slug: Web/API/HTMLCanvasElement/toBlob
-tags:
-  - API
-  - Canvas
-  - HTMLCanvasElement
-  - Method
-  - Reference
-translation_of: Web/API/HTMLCanvasElement/toBlob
 ---
 {{APIRef("Canvas API")}}
 

--- a/files/ja/web/api/htmlcanvaselement/todataurl/index.md
+++ b/files/ja/web/api/htmlcanvaselement/todataurl/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLCanvasElement.toDataURL()
 slug: Web/API/HTMLCanvasElement/toDataURL
-translation_of: Web/API/HTMLCanvasElement/toDataURL
 ---
 {{APIRef("Canvas API")}}
 

--- a/files/ja/web/api/htmlcollection/index.md
+++ b/files/ja/web/api/htmlcollection/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLCollection
 slug: Web/API/HTMLCollection
-tags:
-  - API
-  - DOM
-  - Element Lists
-  - HTMLCollection
-  - Interface
-  - Reference
-translation_of: Web/API/HTMLCollection
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/htmlcontentelement/index.md
+++ b/files/ja/web/api/htmlcontentelement/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLContentElement
 slug: Web/API/HTMLContentElement
-tags:
-  - API
-  - Deprecated
-  - HTML DOM
-  - インターフェース
-  - リファレンス
-translation_of: Web/API/HTMLContentElement
 ---
 {{ APIRef("Web Components") }}
 

--- a/files/ja/web/api/htmldataelement/index.md
+++ b/files/ja/web/api/htmldataelement/index.md
@@ -1,11 +1,6 @@
 ---
 title: HTMLDataElement
 slug: Web/API/HTMLDataElement
-tags:
-  - API
-  - Interface
-  - Reference
-translation_of: Web/API/HTMLDataElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmldatalistelement/index.md
+++ b/files/ja/web/api/htmldatalistelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLDataListElement
 slug: Web/API/HTMLDataListElement
-page-type: web-api-interface
-tags:
-  - API
-  - HTML DOM
-  - Interface
-  - Reference
-browser-compat: api.HTMLDataListElement
-translation_of: Web/API/HTMLDataListElement
 l10n:
   sourceCommit: d766739f2a7c02812a0a15a0383588c2ada4e6bd
 ---

--- a/files/ja/web/api/htmldetailselement/index.md
+++ b/files/ja/web/api/htmldetailselement/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLDetailsElement
 slug: Web/API/HTMLDetailsElement
-translation_of: Web/API/HTMLDetailsElement
 ---
 > **Note:** translation in progress
 

--- a/files/ja/web/api/htmldetailselement/toggle_event/index.md
+++ b/files/ja/web/api/htmldetailselement/toggle_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'HTMLDetailsElement: toggle イベント'
 slug: Web/API/HTMLDetailsElement/toggle_event
-tags:
-  - Event
-  - HTMLDetailsElement
-  - Reference
-  - details
-  - events
-  - toggle
-  - イベント
-translation_of: Web/API/HTMLDetailsElement/toggle_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmldialogelement/cancel_event/index.md
+++ b/files/ja/web/api/htmldialogelement/cancel_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'HTMLDialogElement: cancel イベント'
 slug: Web/API/HTMLDialogElement/cancel_event
-tags:
-  - API
-  - Event
-  - HTML DOM
-  - HTMLDialogElement
-  - NeedsExample
-  - cancel
-  - events
-  - イベント
-translation_of: Web/API/HTMLDialogElement/cancel_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmldialogelement/close_event/index.md
+++ b/files/ja/web/api/htmldialogelement/close_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: window.onclose
 slug: Web/API/HTMLDialogElement/close_event
-tags:
-  - API
-  - Dialog
-  - Event Handler
-  - Experimental
-  - GlobalEventHandlers
-  - HTML DOM
-  - NeedsExample
-  - Property
-  - Reference
-translation_of: Web/API/GlobalEventHandlers/onclose
 original_slug: Web/API/GlobalEventHandlers/onclose
 ---
 {{ApiRef("HTML DOM")}} {{SeeCompatTable}}

--- a/files/ja/web/api/htmldialogelement/index.md
+++ b/files/ja/web/api/htmldialogelement/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLDialogElement
 slug: Web/API/HTMLDialogElement
-tags:
-  - API
-  - Experimental
-  - HTML DOM
-  - HTMLDialogElement
-  - Interface
-  - Reference
-  - インターフェイス
-translation_of: Web/API/HTMLDialogElement
 ---
 {{APIRef("HTML DOM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/htmldivelement/index.md
+++ b/files/ja/web/api/htmldivelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLDivElement
 slug: Web/API/HTMLDivElement
-tags:
-  - API
-  - HTML DOM
-  - インターフェイス
-  - NeedsNewLayout
-  - リファレンス
-browser-compat: api.HTMLDivElement
-translation_of: Web/API/HTMLDivElement
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmldlistelement/index.md
+++ b/files/ja/web/api/htmldlistelement/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLDListElement
 slug: Web/API/HTMLDListElement
-page-type: web-api-interface
-tags:
-  - API
-  - HTML DOM
-  - インターフェイス
-  - NeedsNewLayout
-  - リファレンス
-browser-compat: api.HTMLDListElement
-translation_of: Web/API/HTMLDListElement
 ---
 {{ApiRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmldocument/index.md
+++ b/files/ja/web/api/htmldocument/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLDocument
 slug: Web/API/HTMLDocument
-tags:
-  - API
-  - DOM
-  - Deprecated
-  - Document
-  - HTML
-  - HTML DOM
-  - HTMLDocument
-  - Interface
-  - Reference
-translation_of: Web/API/HTMLDocument
 ---
 {{APIRef("HTML DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/htmlelement/accesskey/index.md
+++ b/files/ja/web/api/htmlelement/accesskey/index.md
@@ -1,9 +1,6 @@
 ---
 title: HTMLElement.accessKey
 slug: Web/API/HTMLElement/accessKey
-browser-compat: api.HTMLElement.accessKey
-translation_of: Web/API/HTMLElement/accessKey
-translation_of_original: Web/API/Element/accessKey
 original_slug: Web/API/Element/accessKey
 ---
 {{APIRef("DOM")}}

--- a/files/ja/web/api/htmlelement/accesskeylabel/index.md
+++ b/files/ja/web/api/htmlelement/accesskeylabel/index.md
@@ -1,8 +1,6 @@
 ---
 title: HTMLElement.accessKeyLabel
 slug: Web/API/HTMLElement/accessKeyLabel
-browser-compat: api.HTMLElement.accessKeyLabel
-translation_of: Web/API/HTMLElement/accessKeyLabel
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlelement/attachinternals/index.md
+++ b/files/ja/web/api/htmlelement/attachinternals/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLElement.attachInternals()
 slug: Web/API/HTMLElement/attachInternals
-tags:
-  - API
-  - 要素
-  - メソッド
-  - リファレンス
-  - attachInternals
-browser-compat: api.HTMLElement.attachInternals
-translation_of: Web/API/HTMLElement/attachInternals
 ---
 {{APIRef('DOM')}}
 

--- a/files/ja/web/api/htmlelement/beforeinput_event/index.md
+++ b/files/ja/web/api/htmlelement/beforeinput_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'HTMLElement: beforeinput イベント'
 slug: Web/API/HTMLElement/beforeinput_event
-tags:
-  - API
-  - イベント
-  - HTML DOM
-  - HTMLElement
-  - InputEvent
-  - リファレンス
-  - beforeinput
-translation_of: Web/API/HTMLElement/beforeinput_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmlelement/blur/index.md
+++ b/files/ja/web/api/htmlelement/blur/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLElement.blur()
 slug: Web/API/HTMLElement/blur
-tags:
-  - API
-  - HTML DOM
-  - HTMLElement
-  - メソッド
-  - リファレンス
-browser-compat: api.HTMLElement.blur
-translation_of: Web/API/HTMLElement/blur
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlelement/change_event/index.md
+++ b/files/ja/web/api/htmlelement/change_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'HTMLElement: change イベント'
 slug: Web/API/HTMLElement/change_event
-tags:
-  - Change
-  - イベント
-  - HTML
-  - HTML DOM
-  - HTMLElement
-  - リファレンス
-  - Web
-translation_of: Web/API/HTMLElement/change_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmlelement/click/index.md
+++ b/files/ja/web/api/htmlelement/click/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLElement.click()
 slug: Web/API/HTMLElement/click
-tags:
-  - API
-  - HTML DOM
-  - HTMLElement
-  - メソッド
-  - リファレンス
-browser-compat: api.HTMLElement.click
-translation_of: Web/API/HTMLElement/click
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlelement/contenteditable/index.md
+++ b/files/ja/web/api/htmlelement/contenteditable/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLElement.contentEditable
 slug: Web/API/HTMLElement/contentEditable
-tags:
-  - API
-  - HTML DOM
-  - HTMLElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLElement.contentEditable
-translation_of: Web/API/HTMLElement/contentEditable
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlelement/contextmenu/index.md
+++ b/files/ja/web/api/htmlelement/contextmenu/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLElement.contextMenu
 slug: Web/API/HTMLElement/contextMenu
-tags:
-  - API
-  - 非推奨
-  - Element
-  - HTML
-  - HTML DOM
-  - プロパティ
-  - リファレンス
-  - UX
-browser-compat: api.HTMLElement.contextMenu
-translation_of: Web/API/HTMLElement/contextMenu
 ---
 {{APIRef("HTML DOM")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/htmlelement/copy_event/index.md
+++ b/files/ja/web/api/htmlelement/copy_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'HTMLElement: copy イベント'
 slug: Web/API/HTMLElement/copy_event
-tags:
-  - API
-  - クリップボード API
-  - HTMLElement
-  - イベント
-  - リファレンス
-  - ウェブ
-  - copy
-browser-compat: api.HTMLElement.copy_event
-translation_of: Web/API/HTMLElement/oncopy
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlelement/cut_event/index.md
+++ b/files/ja/web/api/htmlelement/cut_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'HTMLElement: cut イベント'
 slug: Web/API/HTMLElement/cut_event
-tags:
-  - API
-  - クリップボード API
-  - HTMLElement
-  - イベント
-  - リファレンス
-  - ウェブ
-  - cut
-browser-compat: api.HTMLElement.cut_event
-translation_of: Web/API/HTMLElement/cut_event
 original_slug: Web/API/HTMLElement/oncut
 ---
 {{ APIRef("HTML DOM") }}

--- a/files/ja/web/api/htmlelement/dataset/index.md
+++ b/files/ja/web/api/htmlelement/dataset/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLElement.dataset
 slug: Web/API/HTMLElement/dataset
-tags:
-  - API
-  - HTML DOM
-  - HTMLElement
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - dataset
-browser-compat: api.HTMLElement.dataset
-translation_of: Web/API/HTMLElement/dataset
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlelement/dir/index.md
+++ b/files/ja/web/api/htmlelement/dir/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLElement.dir
 slug: Web/API/HTMLElement/dir
-tags:
-  - API
-  - HTML DOM
-  - HTMLElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLElement.dir
-translation_of: Web/API/HTMLElement/dir
 ---
 {{ApiRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlelement/drag_event/index.md
+++ b/files/ja/web/api/htmlelement/drag_event/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'HTMLElement: drag イベント'
 slug: Web/API/HTMLElement/drag_event
-page-type: web-api-event
-tags:
-  - API
-  - DOM
-  - Element
-  - Drag
-  - DragEvent
-  - Event
-  - Reference
-  - Web
-  - drag and drop
-browser-compat: api.HTMLElement.drag_event
-translation_of: Web/API/Document/drag_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmlelement/dragend_event/index.md
+++ b/files/ja/web/api/htmlelement/dragend_event/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'HTMLElement: dragend イベント'
 slug: Web/API/HTMLElement/dragend_event
-page-type: web-api-event
-tags:
-  - API
-  - DOM
-  - HTMLElement
-  - DragEvent
-  - Event
-  - Reference
-  - Web
-  - drag and drop
-  - dragend
-browser-compat: api.HTMLElement.dragend_event
-translation_of: Web/API/HTMLElement/dragend_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmlelement/dragenter_event/index.md
+++ b/files/ja/web/api/htmlelement/dragenter_event/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'HTMLElement: dragenter イベント'
 slug: Web/API/HTMLElement/dragenter_event
-page-type: web-api-event
-tags:
-  - API
-  - DOM
-  - HTMLElement
-  - DragEvent
-  - Event
-  - Reference
-  - Web
-  - drag and drop
-  - dragenter
-browser-compat: api.HTMLElement.dragenter_event
-translation_of: Web/API/Document/dragenter_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmlelement/dragleave_event/index.md
+++ b/files/ja/web/api/htmlelement/dragleave_event/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'HTMLElement: dragleave イベント'
 slug: Web/API/HTMLElement/dragleave_event
-page-type: web-api-event
-tags:
-  - API
-  - DOM
-  - HTMLElement
-  - DragEvent
-  - Event
-  - Reference
-  - Web
-  - drag and drop
-  - dragleave
-browser-compat: api.HTMLElement.dragleave_event
-translation_of: Web/API/HTMLElement/dragleave_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmlelement/dragover_event/index.md
+++ b/files/ja/web/api/htmlelement/dragover_event/index.md
@@ -1,18 +1,6 @@
 ---
 title: 'HTMLElement: dragover イベント'
 slug: Web/API/HTMLElement/dragover_event
-page-type: web-api-event
-tags:
-  - API
-  - DOM
-  - HTMLElement
-  - DragEvent
-  - Event
-  - Reference
-  - Web
-  - drag and drop
-browser-compat: api.HTMLElement.dragover_event
-translation_of: Web/API/HTMLElement/dragover_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmlelement/dragstart_event/index.md
+++ b/files/ja/web/api/htmlelement/dragstart_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'HTMLElement: dragstart イベント'
 slug: Web/API/HTMLElement/dragstart_event
-page-type: web-api-event
-tags:
-  - DOM
-  - Event
-  - Reference
-  - drag and drop
-browser-compat: api.HTMLElement.dragstart_event
-translation_of: Web/API/HTMLElement/dragstart_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmlelement/drop_event/index.md
+++ b/files/ja/web/api/htmlelement/drop_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'HTMLElement: drop イベント'
 slug: Web/API/HTMLElement/drop_event
-page-type: web-api-event
-tags:
-  - DOM
-  - Drag Event
-  - Drop
-  - Event
-  - HTML 5
-  - Reference
-  - drag and drop
-browser-compat: api.HTMLElement.drop_event
-translation_of: Web/API/HTMLElement/drop_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmlelement/enterkeyhint/index.md
+++ b/files/ja/web/api/htmlelement/enterkeyhint/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLElement.enterKeyHint
 slug: Web/API/HTMLElement/enterKeyHint
-tags:
-  - API
-  - HTML DOM
-  - HTMLElement
-  - プロパティ
-  - リファレンス
-  - キーボード
-browser-compat: api.HTMLElement.enterKeyHint
-translation_of: Web/API/HTMLElement/enterKeyHint
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlelement/focus/index.md
+++ b/files/ja/web/api/htmlelement/focus/index.md
@@ -1,18 +1,6 @@
 ---
 title: HTMLElement.focus()
 slug: Web/API/HTMLElement/focus
-tags:
-  - API
-  - Focus
-  - HTML DOM
-  - HTMLElement
-  - メソッド
-  - リファレンス
-  - スクロール
-  - ビュー
-  - activate
-browser-compat: api.HTMLElement.focus
-translation_of: Web/API/HTMLElement/focus
 original_slug: Web/API/HTMLElement/focus
 ---
 {{ APIRef("HTML DOM") }}

--- a/files/ja/web/api/htmlelement/hidden/index.md
+++ b/files/ja/web/api/htmlelement/hidden/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLElement.hidden
 slug: Web/API/HTMLElement/hidden
-tags:
-  - API
-  - 属性
-  - 要素
-  - HTML
-  - HTML 要素
-  - プロパティ
-  - リファレンス
-  - hidden
-browser-compat: api.HTMLElement.hidden
-translation_of: Web/API/HTMLElement/hidden
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlelement/index.md
+++ b/files/ja/web/api/htmlelement/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLElement
 slug: Web/API/HTMLElement
-tags:
-  - API
-  - HTML DOM
-  - HTMLElement
-  - インターフェイス
-  - NeedsNewLayout
-  - リファレンス
-browser-compat: api.HTMLElement
-translation_of: Web/API/HTMLElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlelement/inert/index.md
+++ b/files/ja/web/api/htmlelement/inert/index.md
@@ -1,8 +1,6 @@
 ---
 title: HTMLElement.inert
 slug: Web/API/HTMLElement/inert
-browser-compat: api.HTMLElement.inert
-translation_of: Web/API/HTMLElement/inert
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlelement/innertext/index.md
+++ b/files/ja/web/api/htmlelement/innertext/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLElement.innerText
 slug: Web/API/HTMLElement/innerText
-tags:
-  - API
-  - HTML DOM
-  - HTMLElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLElement.innerText
-translation_of: Web/API/HTMLElement/innerText
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlelement/input_event/index.md
+++ b/files/ja/web/api/htmlelement/input_event/index.md
@@ -1,21 +1,6 @@
 ---
 title: 'HTMLElement: input イベント'
 slug: Web/API/HTMLElement/input_event
-tags:
-  - コンテンツ
-  - 編集
-  - Event
-  - フォーム
-  - HTML DOM
-  - HTMLElement
-  - Input
-  - InputEvent
-  - NeedsMobileBrowserCompatibility
-  - リファレンス
-  - データ
-  - 値
-browser-compat: api.HTMLElement.input_event
-translation_of: Web/API/HTMLElement/input_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmlelement/iscontenteditable/index.md
+++ b/files/ja/web/api/htmlelement/iscontenteditable/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLElement.isContentEditable
 slug: Web/API/HTMLElement/isContentEditable
-tags:
-  - API
-  - 編集
-  - HTML DOM
-  - HTMLElement
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.HTMLElement.isContentEditable
-translation_of: Web/API/HTMLElement/isContentEditable
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlelement/lang/index.md
+++ b/files/ja/web/api/htmlelement/lang/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLElement.lang
 slug: Web/API/HTMLElement/lang
-tags:
-  - API
-  - HTML DOM
-  - HTMLElement
-  - NeedsUpdate
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLElement.lang
-translation_of: Web/API/HTMLElement/lang
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlelement/nonce/index.md
+++ b/files/ja/web/api/htmlelement/nonce/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLElement.nonce
 slug: Web/API/HTMLElement/nonce
-tags:
-  - API
-  - Content Security Policy
-  - Experimental
-  - HTML DOM
-  - HTMLElement
-  - プロパティ
-  - リファレンス
-  - nonce
-browser-compat: api.HTMLElement.nonce
-translation_of: Web/API/HTMLElement/nonce
 original_slug: Web/API/HTMLElement/nonce
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/web/api/htmlelement/offsetheight/index.md
+++ b/files/ja/web/api/htmlelement/offsetheight/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLElement.offsetHeight
 slug: Web/API/HTMLElement/offsetHeight
-tags:
-  - API
-  - CSSOM View
-  - NeedsMarkupWork
-  - NeedsNonDHMLImage
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLElement.offsetHeight
-translation_of: Web/API/HTMLElement/offsetHeight
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlelement/offsetleft/index.md
+++ b/files/ja/web/api/htmlelement/offsetleft/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLElement.offsetLeft
 slug: Web/API/HTMLElement/offsetLeft
-tags:
-  - API
-  - CSSOM View
-  - NeedsMarkupWork
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.HTMLElement.offsetLeft
-translation_of: Web/API/HTMLElement/offsetLeft
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlelement/offsetparent/index.md
+++ b/files/ja/web/api/htmlelement/offsetparent/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLElement.offsetParent
 slug: Web/API/HTMLElement/offsetParent
-tags:
-  - API
-  - CSSOM View
-  - NeedsMarkupWork
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLElement.offsetParent
-translation_of: Web/API/HTMLElement/offsetParent
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlelement/offsettop/index.md
+++ b/files/ja/web/api/htmlelement/offsettop/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLElement.offsetTop
 slug: Web/API/HTMLElement/offsetTop
-tags:
-  - API
-  - CSSOM View
-  - NeedsMarkupWork
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.HTMLElement.offsetTop
-translation_of: Web/API/HTMLElement/offsetTop
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlelement/offsetwidth/index.md
+++ b/files/ja/web/api/htmlelement/offsetwidth/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLElement.offsetWidth
 slug: Web/API/HTMLElement/offsetWidth
-tags:
-  - API
-  - CSSOM View
-  - NeedsMarkupWork
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.HTMLElement.offsetWidth
-translation_of: Web/API/HTMLElement/offsetWidth
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlelement/outertext/index.md
+++ b/files/ja/web/api/htmlelement/outertext/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLElement.outerText
 slug: Web/API/HTMLElement/outerText
-tags:
-  - API
-  - HTML DOM
-  - HTMLElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLElement.outerText
-translation_of: Web/API/HTMLElement/outerText
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/htmlelement/paste_event/index.md
+++ b/files/ja/web/api/htmlelement/paste_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'HTMLElement: paste イベント'
 slug: Web/API/HTMLElement/paste_event
-tags:
-  - API
-  - クリップボード API
-  - HTMLElement
-  - Event
-  - リファレンス
-  - ウェブ
-  - paste
-browser-compat: api.HTMLElement.paste_event
-translation_of: Web/API/HTMLElement/paste_event
 original_slug: Web/API/HTMLElement/onpaste
 ---
 {{ APIRef("HTML DOM") }}

--- a/files/ja/web/api/htmlelement/style/index.md
+++ b/files/ja/web/api/htmlelement/style/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLElement.style
 slug: Web/API/HTMLElement/style
-tags:
-  - API
-  - CSSOM
-  - HTMLElement
-  - プロパティ
-  - リファレンス
-  - Style
-browser-compat: api.HTMLElement.style
-translation_of: Web/API/HTMLElement/style
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/htmlelement/tabindex/index.md
+++ b/files/ja/web/api/htmlelement/tabindex/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLElement.tabIndex
 slug: Web/API/HTMLElement/tabIndex
-tags:
-  - API
-  - HTML DOM
-  - HTMLElement
-  - プロパティ
-  - リファレンス
-  - tabIndex
-browser-compat: api.HTMLElement.tabIndex
-translation_of: Web/API/HTMLElement/tabIndex
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlelement/title/index.md
+++ b/files/ja/web/api/htmlelement/title/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLElement.title
 slug: Web/API/HTMLElement/title
-tags:
-  - API
-  - HTML DOM
-  - HTMLElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLElement.title
-translation_of: Web/API/HTMLElement/title
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlembedelement/index.md
+++ b/files/ja/web/api/htmlembedelement/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLEmbedElement
 slug: Web/API/HTMLEmbedElement
-page-type: web-api-interface
-tags:
-  - API
-  - HTML DOM
-  - インターフェイス
-  - NeedsNewLayout
-  - リファレンス
-browser-compat: api.HTMLEmbedElement
-translation_of: Web/API/HTMLEmbedElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlfieldsetelement/index.md
+++ b/files/ja/web/api/htmlfieldsetelement/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLFieldSetElement
 slug: Web/API/HTMLFieldSetElement
-tags:
-  - API
-  - HTML DOM
-  - Interface
-  - Reference
-  - インターフェイス
-translation_of: Web/API/HTMLFieldSetElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlformcontrolscollection/index.md
+++ b/files/ja/web/api/htmlformcontrolscollection/index.md
@@ -1,10 +1,6 @@
 ---
 title: HTMLFormControlsCollection
 slug: Web/API/HTMLFormControlsCollection
-tags:
-  - DOM
-  - DOM Reference
-translation_of: Web/API/HTMLFormControlsCollection
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/htmlformelement/acceptcharset/index.md
+++ b/files/ja/web/api/htmlformelement/acceptcharset/index.md
@@ -1,11 +1,6 @@
 ---
 title: HTMLFormElement.acceptCharset
 slug: Web/API/HTMLFormElement/acceptCharset
-tags:
-  - DOM
-  - Gecko
-  - Gecko DOM Reference
-translation_of: Web/API/HTMLFormElement/acceptCharset
 ---
 {{APIRef}}概要
 

--- a/files/ja/web/api/htmlformelement/action/index.md
+++ b/files/ja/web/api/htmlformelement/action/index.md
@@ -1,11 +1,6 @@
 ---
 title: HTMLFormElement.action
 slug: Web/API/HTMLFormElement/action
-tags:
-  - DOM
-  - Forms
-  - Reference
-translation_of: Web/API/HTMLFormElement/action
 ---
 ## 概要
 

--- a/files/ja/web/api/htmlformelement/elements/index.md
+++ b/files/ja/web/api/htmlformelement/elements/index.md
@@ -1,11 +1,6 @@
 ---
 title: HTMLFormElement.elements
 slug: Web/API/HTMLFormElement/elements
-tags:
-  - DOM
-  - Gecko
-  - Gecko DOM Reference
-translation_of: Web/API/HTMLFormElement/elements
 ---
 {{ApiRef()}}
 

--- a/files/ja/web/api/htmlformelement/encoding/index.md
+++ b/files/ja/web/api/htmlformelement/encoding/index.md
@@ -1,11 +1,6 @@
 ---
 title: HTMLFormElement.encoding
 slug: Web/API/HTMLFormElement/encoding
-tags:
-  - DOM
-  - Gecko
-  - Gecko DOM Reference
-translation_of: Web/API/HTMLFormElement/encoding
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/htmlformelement/enctype/index.md
+++ b/files/ja/web/api/htmlformelement/enctype/index.md
@@ -1,10 +1,6 @@
 ---
 title: HTMLFormElement.enctype
 slug: Web/API/HTMLFormElement/enctype
-tags:
-  - Reference
-  - form
-translation_of: Web/API/HTMLFormElement/enctype
 ---
 ## 概要
 

--- a/files/ja/web/api/htmlformelement/formdata_event/index.md
+++ b/files/ja/web/api/htmlformelement/formdata_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'HTMLFormElement: formdata イベント'
 slug: Web/API/HTMLFormElement/formdata_event
-tags:
-  - Event
-  - Forms
-  - Reference
-  - formevent
-translation_of: Web/API/HTMLFormElement/formdata_event
-browser-compat: api.HTMLFormElement.formdata_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmlformelement/index.md
+++ b/files/ja/web/api/htmlformelement/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLFormElement
 slug: Web/API/HTMLFormElement
-tags:
-  - API
-  - Form Element
-  - Forms
-  - HTML DOM
-  - HTML forms
-  - HTMLFormElement
-  - Interface
-  - Reference
-translation_of: Web/API/HTMLFormElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlformelement/length/index.md
+++ b/files/ja/web/api/htmlformelement/length/index.md
@@ -1,11 +1,6 @@
 ---
 title: HTMLFormElement.length
 slug: Web/API/HTMLFormElement/length
-tags:
-  - DOM
-  - Gecko
-  - Gecko DOM Reference
-translation_of: Web/API/HTMLFormElement/length
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/htmlformelement/method/index.md
+++ b/files/ja/web/api/htmlformelement/method/index.md
@@ -1,11 +1,6 @@
 ---
 title: HTMLFormElement.method
 slug: Web/API/HTMLFormElement/method
-tags:
-  - DOM
-  - Gecko
-  - Gecko DOM Reference
-translation_of: Web/API/HTMLFormElement/method
 ---
 {{APIRef}}概要
 

--- a/files/ja/web/api/htmlformelement/name/index.md
+++ b/files/ja/web/api/htmlformelement/name/index.md
@@ -1,11 +1,6 @@
 ---
 title: HTMLFormElement.name
 slug: Web/API/HTMLFormElement/name
-tags:
-  - DOM
-  - Gecko
-  - Gecko DOM Reference
-translation_of: Web/API/HTMLFormElement/name
 ---
 ## 概要
 

--- a/files/ja/web/api/htmlformelement/reportvalidity/index.md
+++ b/files/ja/web/api/htmlformelement/reportvalidity/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLFormElement.reportValidity()
 slug: Web/API/HTMLFormElement/reportValidity
-tags:
-  - HTML
-  - HTMLFormElement
-  - Method
-  - Reference
-translation_of: Web/API/HTMLFormElement/reportValidity
-browser-compat: api.HTMLFormElement.reportValidity
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlformelement/reset/index.md
+++ b/files/ja/web/api/htmlformelement/reset/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLFormElement.reset
 slug: Web/API/HTMLFormElement/reset
-tags:
-  - DOM
-  - Gecko
-  - Gecko DOM Reference
-  - form
-  - form Methods
-translation_of: Web/API/HTMLFormElement/reset
 ---
 ## 概要
 

--- a/files/ja/web/api/htmlformelement/reset_event/index.md
+++ b/files/ja/web/api/htmlformelement/reset_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'HTMLFormElement: reset イベント'
 slug: Web/API/HTMLFormElement/reset_event
-tags:
-  - API
-  - Event
-  - Forms
-  - HTML DOM
-  - HTMLFormElement
-  - Reference
-translation_of: Web/API/HTMLFormElement/reset_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmlformelement/submit/index.md
+++ b/files/ja/web/api/htmlformelement/submit/index.md
@@ -1,11 +1,6 @@
 ---
 title: HTMLFormElement.submit
 slug: Web/API/HTMLFormElement/submit
-tags:
-  - DOM
-  - Gecko
-  - Gecko DOM Reference
-translation_of: Web/API/HTMLFormElement/submit
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/htmlformelement/submit_event/index.md
+++ b/files/ja/web/api/htmlformelement/submit_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'HTMLFormElement: submit イベント'
 slug: Web/API/HTMLFormElement/submit_event
-tags:
-  - Event
-  - Forms
-  - HTML DOM
-  - HTMLFormElement
-  - Reference
-  - events
-  - submit
-  - イベント
-  - フォーム
-translation_of: Web/API/HTMLFormElement/submit_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmlformelement/target/index.md
+++ b/files/ja/web/api/htmlformelement/target/index.md
@@ -1,10 +1,6 @@
 ---
 title: HTMLFormElement.target
 slug: Web/API/HTMLFormElement/target
-tags:
-  - Reference
-  - form
-translation_of: Web/API/HTMLFormElement/target
 ---
 ## 概要
 

--- a/files/ja/web/api/htmlheadelement/index.md
+++ b/files/ja/web/api/htmlheadelement/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLHeadElement
 slug: Web/API/HTMLHeadElement
-tags:
-  - API
-  - HTML DOM
-  - インターフェイス
-  - リファレンス
-browser-compat: api.HTMLHeadElement
-translation_of: Web/API/HTMLHeadElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlheadingelement/index.md
+++ b/files/ja/web/api/htmlheadingelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLHeadingElement
 slug: Web/API/HTMLHeadingElement
-tags:
-  - API
-  - HTML DOM
-  - インターフェイス
-  - NeedsNewLayout
-  - リファレンス
-browser-compat: api.HTMLHeadingElement
-translation_of: Web/API/HTMLHeadingElement
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlhrelement/index.md
+++ b/files/ja/web/api/htmlhrelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLHRElement
 slug: Web/API/HTMLHRElement
-tags:
-  - API
-  - HTML DOM
-  - インターフェイス
-  - NeedsNewLayout
-  - リファレンス
-browser-compat: api.HTMLHRElement
-translation_of: Web/API/HTMLHRElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlhtmlelement/index.md
+++ b/files/ja/web/api/htmlhtmlelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLHtmlElement
 slug: Web/API/HTMLHtmlElement
-tags:
-  - API
-  - HTML DOM
-  - インターフェイス
-  - NeedsNewLayout
-  - リファレンス
-browser-compat: api.HTMLHtmlElement
-translation_of: Web/API/HTMLHtmlElement
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlhtmlelement/version/index.md
+++ b/files/ja/web/api/htmlhtmlelement/version/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLHtmlElement.version
 slug: Web/API/HTMLHtmlElement/version
-tags:
-  - API
-  - 非推奨
-  - HTML DOM
-  - NeedsContent
-  - NeedsLayout
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLHtmlElement.version
-translation_of: Web/API/HTMLHtmlElement/version
 ---
 {{ APIRef("HTML DOM") }} {{deprecated_header}}
 

--- a/files/ja/web/api/htmliframeelement/contentwindow/index.md
+++ b/files/ja/web/api/htmliframeelement/contentwindow/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLIFrameElement.contentWindow
 slug: Web/API/HTMLIFrameElement/contentWindow
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLIFrameElement
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - ウェブ
-browser-compat: api.HTMLIFrameElement.contentWindow
-translation_of: Web/API/HTMLIFrameElement/contentWindow
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmliframeelement/index.md
+++ b/files/ja/web/api/htmliframeelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLIFrameElement
 slug: Web/API/HTMLIFrameElement
-page-type: web-api-interface
-tags:
-  - API
-  - HTML DOM
-  - インターフェイス
-  - リファレンス
-browser-compat: api.HTMLIFrameElement
-translation_of: Web/API/HTMLIFrameElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmliframeelement/referrerpolicy/index.md
+++ b/files/ja/web/api/htmliframeelement/referrerpolicy/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLIFrameElement.referrerPolicy
 slug: Web/API/HTMLIFrameElement/referrerPolicy
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLIFrameElement
-  - プロパティ
-  - リファレンス
-  - リファラーポリシー
-browser-compat: api.HTMLIFrameElement.referrerPolicy
-translation_of: Web/API/HTMLIFrameElement/referrerPolicy
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmliframeelement/srcdoc/index.md
+++ b/files/ja/web/api/htmliframeelement/srcdoc/index.md
@@ -1,9 +1,6 @@
 ---
 title: HTMLIFrameElement.srcdoc
 slug: Web/API/HTMLIFrameElement/srcdoc
-page-type: web-api-instance-property
-browser-compat: api.HTMLIFrameElement.srcdoc
-translation_of: Web/API/HTMLIFrameElement/srcdoc
 ---
 {{APIRef('HTMLIFrameElement')}}
 

--- a/files/ja/web/api/htmlimageelement/align/index.md
+++ b/files/ja/web/api/htmlimageelement/align/index.md
@@ -1,21 +1,6 @@
 ---
 title: HTMLImageElement.align
 slug: Web/API/HTMLImageElement/align
-page-type: web-api-instance-property
-tags:
-  - API
-  - Align
-  - HTML
-  - HTML DOM
-  - HTMLImageElement
-  - 画像
-  - プロパティ
-  - リファレンス
-  - alignment
-  - float
-  - img
-  - 非推奨
-browser-compat: api.HTMLImageElement.align
 ---
 {{APIRef("HTML DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/htmlimageelement/alt/index.md
+++ b/files/ja/web/api/htmlimageelement/alt/index.md
@@ -1,21 +1,6 @@
 ---
 title: HTMLImageElement.alt
 slug: Web/API/HTMLImageElement/alt
-page-type: web-api-instance-property
-tags:
-  - API
-  - 要素
-  - HTML
-  - HTML DOM
-  - HTMLImageElement
-  - 画像
-  - プロパティ
-  - リファレンス
-  - Text
-  - alt
-  - alternate
-  - fallback
-browser-compat: api.HTMLImageElement.alt
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlimageelement/border/index.md
+++ b/files/ja/web/api/htmlimageelement/border/index.md
@@ -1,20 +1,6 @@
 ---
 title: HTMLImageElement.border
 slug: Web/API/HTMLImageElement/border
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML
-  - HTML DOM
-  - HTMLImageElement
-  - 画像
-  - プロパティ
-  - リファレンス
-  - border
-  - img
-  - 非推奨
-browser-compat: api.HTMLImageElement.border
-translation_of: Web/API/HTMLImageElement/border
 ---
 {{APIRef("HTML DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/htmlimageelement/complete/index.md
+++ b/files/ja/web/api/htmlimageelement/complete/index.md
@@ -1,18 +1,6 @@
 ---
 title: HTMLImageElement.complete
 slug: Web/API/HTMLImageElement/complete
-page-type: web-api-instance-property
-tags:
-  - API
-  - Fetching
-  - HTML
-  - HTML DOM
-  - HTMLImageElement
-  - Loading
-  - プロパティ
-  - リファレンス
-  - complete
-browser-compat: api.HTMLImageElement.complete
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlimageelement/crossorigin/index.md
+++ b/files/ja/web/api/htmlimageelement/crossorigin/index.md
@@ -1,21 +1,6 @@
 ---
 title: HTMLImageElement.crossOrigin
 slug: Web/API/HTMLImageElement/crossOrigin
-page-type: web-api-instance-property
-tags:
-  - API
-  - CORS
-  - Cross-Origin
-  - Crossorigin
-  - HTML DOM
-  - HTMLImageElement
-  - 画像
-  - プロパティ
-  - リファレンス
-  - Security
-  - origin
-browser-compat: api.HTMLImageElement.crossOrigin
-translation_of: Web/API/HTMLImageElement/crossOrigin
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlimageelement/currentsrc/index.md
+++ b/files/ja/web/api/htmlimageelement/currentsrc/index.md
@@ -1,18 +1,6 @@
 ---
 title: HTMLImageElement.currentSrc
 slug: Web/API/HTMLImageElement/currentSrc
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLImageElement
-  - 画像
-  - プロパティ
-  - リファレンス
-  - URL
-  - currentSrc
-  - source
-browser-compat: api.HTMLImageElement.currentSrc
-translation_of: Web/API/HTMLImageElement/currentSrc
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlimageelement/decode/index.md
+++ b/files/ja/web/api/htmlimageelement/decode/index.md
@@ -1,23 +1,6 @@
 ---
 title: HTMLImageElement.decode()
 slug: Web/API/HTMLImageElement/decode
-page-type: web-api-instance-method
-tags:
-  - API
-  - Decode
-  - グラフィック
-  - HTML DOM
-  - HTMLImageElement
-  - 画像
-  - Loading
-  - Method
-  - Performance
-  - リファレンス
-  - async
-  - asynchronous
-  - decoding
-browser-compat: api.HTMLImageElement.decode
-translation_of: Web/API/HTMLImageElement/decode
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlimageelement/decoding/index.md
+++ b/files/ja/web/api/htmlimageelement/decoding/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLImageElement.decoding
 slug: Web/API/HTMLImageElement/decoding
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLImageElement
-  - プロパティ
-  - リファレンス
-  - decoding
-browser-compat: api.HTMLImageElement.decoding
-translation_of: Web/API/HTMLImageElement/decoding
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmlimageelement/fetchpriority/index.md
+++ b/files/ja/web/api/htmlimageelement/fetchpriority/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLImageElement.fetchPriority
 slug: Web/API/HTMLImageElement/fetchPriority
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLImageElement
-  - プロパティ
-  - リファレンス
-  - fetchPriority
-browser-compat: api.HTMLImageElement.fetchPriority
-translation_of: Web/API/HTMLImageElement/fetchPriority
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmlimageelement/height/index.md
+++ b/files/ja/web/api/htmlimageelement/height/index.md
@@ -1,20 +1,6 @@
 ---
 title: HTMLImageElement.height
 slug: Web/API/HTMLImageElement/height
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML
-  - HTML DOM
-  - HTMLImageElement
-  - 画像
-  - プロパティ
-  - リファレンス
-  - dimensions
-  - height
-  - size
-browser-compat: api.HTMLImageElement.height
-translation_of: Web/API/HTMLImageElement/height
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlimageelement/hspace/index.md
+++ b/files/ja/web/api/htmlimageelement/hspace/index.md
@@ -1,26 +1,6 @@
 ---
 title: HTMLImageElement.hspace
 slug: Web/API/HTMLImageElement/hspace
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML
-  - HTML DOM
-  - HTMLImageElement
-  - Horizontal
-  - 画像
-  - Layout
-  - プロパティ
-  - リファレンス
-  - hspace
-  - img
-  - left
-  - margin
-  - right
-  - spacing
-  - 非推奨
-browser-compat: api.HTMLImageElement.hspace
-translation_of: Web/API/HTMLImageElement/hspace
 ---
 {{APIRef("HTML DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/htmlimageelement/image/index.md
+++ b/files/ja/web/api/htmlimageelement/image/index.md
@@ -1,19 +1,6 @@
 ---
 title: Image()
 slug: Web/API/HTMLImageElement/Image
-page-type: web-api-constructor
-tags:
-  - API
-  - コンストラクター
-  - DOM
-  - HTML
-  - HTML DOM
-  - HTMLImageElement
-  - 画像()
-  - リファレンス
-  - img
-browser-compat: api.HTMLImageElement.Image
-translation_of: Web/API/HTMLImageElement/Image
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlimageelement/index.md
+++ b/files/ja/web/api/htmlimageelement/index.md
@@ -1,20 +1,6 @@
 ---
 title: HTMLImageElement
 slug: Web/API/HTMLImageElement
-page-type: web-api-interface
-tags:
-  - API
-  - 要素
-  - グラフィック
-  - HTML DOM
-  - HTMLImageElement
-  - 画像
-  - インターフェイス
-  - リファレンス
-  - img
-  - picture
-browser-compat: api.HTMLImageElement
-translation_of: Web/API/HTMLImageElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlimageelement/ismap/index.md
+++ b/files/ja/web/api/htmlimageelement/ismap/index.md
@@ -1,20 +1,6 @@
 ---
 title: HTMLImageElement.isMap
 slug: Web/API/HTMLImageElement/isMap
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML
-  - HTML DOM
-  - HTMLImageElement
-  - 画像 Map
-  - Link
-  - リファレンス
-  - isMap
-  - server-side
-  - プロパティ
-browser-compat: api.HTMLImageElement.isMap
-translation_of: Web/API/HTMLImageElement/isMap
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlimageelement/loading/index.md
+++ b/files/ja/web/api/htmlimageelement/loading/index.md
@@ -1,27 +1,6 @@
 ---
 title: HTMLImageElement.loading
 slug: Web/API/HTMLImageElement/loading
-page-type: web-api-instance-property
-tags:
-  - API
-  - Content
-  - Eager
-  - グラフィック
-  - HTML DOM
-  - HTMLImageElement
-  - 画像
-  - Layout
-  - Lazy
-  - Lazy-loading
-  - Loading
-  - Performance
-  - Pictures
-  - プロパティ
-  - リファレンス
-  - load
-  - rendering
-browser-compat: api.HTMLImageElement.loading
-translation_of: Web/API/HTMLImageElement/loading
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlimageelement/longdesc/index.md
+++ b/files/ja/web/api/htmlimageelement/longdesc/index.md
@@ -1,21 +1,6 @@
 ---
 title: HTMLImageElement.longDesc
 slug: Web/API/HTMLImageElement/longDesc
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML
-  - HTML DOM
-  - HTMLImageElement
-  - Long description
-  - プロパティ
-  - リファレンス
-  - description
-  - img
-  - longDesc
-  - 非推奨
-browser-compat: api.HTMLImageElement.longDesc
-translation_of: Web/API/HTMLImageElement/longDesc
 ---
 {{APIRef("HTML DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/htmlimageelement/name/index.md
+++ b/files/ja/web/api/htmlimageelement/name/index.md
@@ -1,20 +1,6 @@
 ---
 title: HTMLImageElement.name
 slug: Web/API/HTMLImageElement/name
-page-type: web-api-instance-property
-tags:
-  - API
-  - 非推奨
-  - HTML
-  - HTML DOM
-  - HTMLImageElement
-  - 画像
-  - プロパティ
-  - リファレンス
-  - img
-  - name
-browser-compat: api.HTMLImageElement.name
-translation_of: Web/API/HTMLImageElement/name
 ---
 {{APIRef("HTML DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/htmlimageelement/naturalheight/index.md
+++ b/files/ja/web/api/htmlimageelement/naturalheight/index.md
@@ -1,18 +1,6 @@
 ---
 title: HTMLImageElement.naturalHeight
 slug: Web/API/HTMLImageElement/naturalHeight
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTMLImageElement
-  - Intrinsic Height
-  - リファレンス
-  - プロパティ
-  - Vertical
-  - naturalHeight
-  - size
-browser-compat: api.HTMLImageElement.naturalHeight
-translation_of: Web/API/HTMLImageElement/naturalHeight
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlimageelement/naturalwidth/index.md
+++ b/files/ja/web/api/htmlimageelement/naturalwidth/index.md
@@ -1,20 +1,6 @@
 ---
 title: HTMLImageElement.naturalWidth
 slug: Web/API/HTMLImageElement/naturalWidth
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML
-  - HTML DOM
-  - HTMLImageElement
-  - Intrinsic Width
-  - Intrinsic size
-  - プロパティ
-  - リファレンス
-  - naturalWidth
-  - size
-  - width
-browser-compat: api.HTMLImageElement.naturalWidth
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlimageelement/referrerpolicy/index.md
+++ b/files/ja/web/api/htmlimageelement/referrerpolicy/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLImageElement.referrerPolicy
 slug: Web/API/HTMLImageElement/referrerPolicy
-page-type: web-api-instance-property
-tags:
-  - API
-  - Experimental
-  - HTMLImageElement
-  - プロパティ
-  - Referrer Policy
-browser-compat: api.HTMLImageElement.referrerPolicy
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlimageelement/sizes/index.md
+++ b/files/ja/web/api/htmlimageelement/sizes/index.md
@@ -1,21 +1,6 @@
 ---
 title: HTMLImageElement.sizes
 slug: Web/API/HTMLImageElement/sizes
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML
-  - HTML DOM
-  - HTMLImageElement
-  - プロパティ
-  - リファレンス
-  - Responsive Design
-  - Responsive Images
-  - size
-  - sizes
-  - width
-browser-compat: api.HTMLImageElement.sizes
-translation_of: Web/API/HTMLImageElement/sizes
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlimageelement/src/index.md
+++ b/files/ja/web/api/htmlimageelement/src/index.md
@@ -1,21 +1,6 @@
 ---
 title: HTMLImageElement.src
 slug: Web/API/HTMLImageElement/src
-page-type: web-api-instance-property
-tags:
-  - 1x
-  - API
-  - HTML
-  - HTML DOM
-  - HTMLImageElement
-  - 画像
-  - リファレンス
-  - URL
-  - fallback
-  - source
-  - src
-  - プロパティ
-browser-compat: api.HTMLImageElement.src
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlimageelement/srcset/index.md
+++ b/files/ja/web/api/htmlimageelement/srcset/index.md
@@ -1,21 +1,6 @@
 ---
 title: HTMLImageElement.srcset
 slug: Web/API/HTMLImageElement/srcset
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML
-  - HTML DOM
-  - HTMLImageElement
-  - 画像
-  - 画像 Candidates
-  - プロパティ
-  - リファレンス
-  - Responsive Design
-  - list
-  - source
-  - srcset
-browser-compat: api.HTMLImageElement.srcset
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlimageelement/usemap/index.md
+++ b/files/ja/web/api/htmlimageelement/usemap/index.md
@@ -1,22 +1,6 @@
 ---
 title: HTMLImageElement.useMap
 slug: Web/API/HTMLImageElement/useMap
-page-type: web-api-instance-property
-tags:
-  - API
-  - DOM
-  - HTML
-  - HTML DOM
-  - HTML WHATWG
-  - HTMLImageElement
-  - 画像 maps
-  - Links
-  - プロパティ
-  - リファレンス
-  - interactive
-  - useMap
-browser-compat: api.HTMLImageElement.useMap
-translation_of: Web/API/HTMLImageElement/useMap
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlimageelement/vspace/index.md
+++ b/files/ja/web/api/htmlimageelement/vspace/index.md
@@ -1,26 +1,6 @@
 ---
 title: HTMLImageElement.vspace
 slug: Web/API/HTMLImageElement/vspace
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML
-  - HTML DOM
-  - HTMLImageElement
-  - 画像
-  - プロパティ
-  - リファレンス
-  - Vertical
-  - bottom
-  - img
-  - margin
-  - space
-  - spacing
-  - top
-  - vspace
-  - 非推奨
-browser-compat: api.HTMLImageElement.vspace
-translation_of: Web/API/HTMLImageElement/vspace
 ---
 {{APIRef("HTML DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/htmlimageelement/width/index.md
+++ b/files/ja/web/api/htmlimageelement/width/index.md
@@ -1,19 +1,6 @@
 ---
 title: HTMLImageElement.width
 slug: Web/API/HTMLImageElement/width
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML
-  - HTML DOM
-  - HTMLImageElement
-  - 画像
-  - プロパティ
-  - リファレンス
-  - size
-  - width
-browser-compat: api.HTMLImageElement.width
-translation_of: Web/API/HTMLImageElement/width
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlimageelement/x/index.md
+++ b/files/ja/web/api/htmlimageelement/x/index.md
@@ -1,24 +1,6 @@
 ---
 title: HTMLImageElement.x
 slug: Web/API/HTMLImageElement/x
-page-type: web-api-instance-property
-tags:
-  - API
-  - CSSOM
-  - CSSOM View
-  - Coordinate
-  - Edge
-  - HTML
-  - HTML DOM
-  - HTMLImageElement
-  - Position
-  - リファレンス
-  - border
-  - left
-  - x
-  - プロパティ
-browser-compat: api.HTMLImageElement.x
-translation_of: Web/API/HTMLImageElement/x
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlimageelement/y/index.md
+++ b/files/ja/web/api/htmlimageelement/y/index.md
@@ -1,11 +1,6 @@
 ---
 title: HTMLImageElement.y
 slug: Web/API/HTMLImageElement/y
-page-type: web-api-instance-property
-tags:
-- プロパティ
-browser-compat: api.HTMLImageElement.y
-translation_of: Web/API/HTMLImageElement/y
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlinputelement/checkvalidity/index.md
+++ b/files/ja/web/api/htmlinputelement/checkvalidity/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLInputElement.checkValidity()
 slug: Web/API/HTMLInputElement/checkValidity
-tags:
-  - API
-  - HTML DOM
-  - HTMLInputElement
-  - Method
-  - NeedsExample
-  - リファレンス
-  - checkValidity
-  - checkValidity()
-browser-compat: api.HTMLObjectElement.checkValidity
-translation_of: Web/API/HTMLInputElement/checkValidity
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlinputelement/index.md
+++ b/files/ja/web/api/htmlinputelement/index.md
@@ -1,18 +1,6 @@
 ---
 title: HTMLInputElement
 slug: Web/API/HTMLInputElement
-tags:
-  - API
-  - DOM
-  - HTML DOM
-  - HTMLInputElement
-  - Input
-  - インターフェイス
-  - NeedsContent
-  - NeedsMarkupWork
-  - リファレンス
-browser-compat: api.HTMLInputElement
-translation_of: Web/API/HTMLInputElement
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlinputelement/invalid_event/index.md
+++ b/files/ja/web/api/htmlinputelement/invalid_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'HTMLInputElement: invalid イベント'
 slug: Web/API/HTMLInputElement/invalid_event
-tags:
-  - API
-  - 制約検証 API
-  - 制約検証
-  - イベント
-  - フォーム
-  - リファレンス
-  - invalid
-browser-compat: api.HTMLInputElement.invalid_event
-translation_of: Web/API/HTMLInputElement/invalid_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmlinputelement/labels/index.md
+++ b/files/ja/web/api/htmlinputelement/labels/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLInputElement.labels
 slug: Web/API/HTMLInputElement/labels
-tags:
-  - API
-  - HTML DOM
-  - HTMLInputElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLInputElement.labels
-translation_of: Web/API/HTMLInputElement/labels
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/htmlinputelement/multiple/index.md
+++ b/files/ja/web/api/htmlinputelement/multiple/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLInputElement.multiple
 slug: Web/API/HTMLInputElement/multiple
-tags:
-  - API
-  - HTML DOM
-  - HTMLInputElement
-  - NeedsMarkupWork
-  - NeedsSpecTable
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLInputElement.multiple
-translation_of: Web/API/HTMLInputElement/multiple
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlinputelement/reportvalidity/index.md
+++ b/files/ja/web/api/htmlinputelement/reportvalidity/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLInputElement.reportValidity()
 slug: Web/API/HTMLInputElement/reportValidity
-tags:
-  - API
-  - HTML DOM
-  - HTMLInputElement
-  - メソッド
-  - NeedsExample
-  - リファレンス
-  - reportValidity
-  - reportValidity()
-browser-compat: api.HTMLInputElement.reportValidity
-translation_of: Web/API/HTMLInputElement/reportValidity
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlinputelement/search_event/index.md
+++ b/files/ja/web/api/htmlinputelement/search_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'HTMLInputElement: search イベント'
 slug: Web/API/HTMLInputElement/search_event
-tags:
-  - API
-  - Event
-  - HTMLInputElement
-  - 標準外
-  - リファレンス
-  - Search
-  - ウェブ
-browser-compat: api.HTMLInputElement.search_event
-translation_of: Web/API/HTMLInputElement/search_event
 ---
 {{APIRef}}{{non-standard_header}}
 

--- a/files/ja/web/api/htmlinputelement/select/index.md
+++ b/files/ja/web/api/htmlinputelement/select/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLInputElement.select()
 slug: Web/API/HTMLInputElement/select
-tags:
-  - API
-  - HTML DOM
-  - HTMLInputElement
-  - メソッド
-  - NeedsCompatTable
-  - リファレンス
-browser-compat: api.HTMLInputElement.select
-translation_of: Web/API/HTMLInputElement/select
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlinputelement/select_event/index.md
+++ b/files/ja/web/api/htmlinputelement/select_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Element: select イベント'
 slug: Web/API/HTMLInputElement/select_event
-tags:
-  - Element
-  - Event
-  - Event Handler
-  - NeedsCompatTable
-  - Reference
-  - UIEvent
-  - イベント
-translation_of: Web/API/Element/select_event
 original_slug: Web/API/Element/select_event
 ---
 {{APIRef}}

--- a/files/ja/web/api/htmlinputelement/selectionchange_event/index.md
+++ b/files/ja/web/api/htmlinputelement/selectionchange_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'HTMLInputElement: selectionchange イベント'
 slug: Web/API/HTMLInputElement/selectionchange_event
-tags:
-  - API
-  - Event
-  - リファレンス
-  - Selection
-  - 選択 API
-  - selectionchange
-  - 実験的
-browser-compat: api.HTMLInputElement.selectionchange_event
-translation_of: Web/API/HTMLInputElement/selectionchange_event
 ---
 {{APIRef}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/htmlinputelement/setcustomvalidity/index.md
+++ b/files/ja/web/api/htmlinputelement/setcustomvalidity/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLInputElement.setCustomValidity()
 slug: Web/API/HTMLInputElement/setCustomValidity
-tags:
-  - API
-  - HTML DOM
-  - HTMLInputElement
-  - メソッド
-  - NeedsExample
-  - リファレンス
-  - setCustomValidity
-  - setCustomValidity()
-browser-compat: api.HTMLObjectElement.setCustomValidity
-translation_of: Web/API/HTMLInputElement/setCustomValidity
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlinputelement/setrangetext/index.md
+++ b/files/ja/web/api/htmlinputelement/setrangetext/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLInputElement.setRangeText()
 slug: Web/API/HTMLInputElement/setRangeText
-tags:
-  - API
-  - HTML DOM
-  - HTMLInputElement
-  - メソッド
-  - NeedsCompatTable
-  - リファレンス
-  - テキスト欄選択 API
-browser-compat: api.HTMLInputElement.setRangeText
-translation_of: Web/API/HTMLInputElement/setRangeText
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlinputelement/setselectionrange/index.md
+++ b/files/ja/web/api/htmlinputelement/setselectionrange/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLInputElement.setSelectionRange()
 slug: Web/API/HTMLInputElement/setSelectionRange
-tags:
-  - API
-  - HTML DOM
-  - HTMLInputElement
-  - メソッド
-  - リファレンス
-  - テキスト欄選択 API
-browser-compat: api.HTMLInputElement.setSelectionRange
-translation_of: Web/API/HTMLInputElement/setSelectionRange
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlinputelement/showpicker/index.md
+++ b/files/ja/web/api/htmlinputelement/showpicker/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLInputElement.showPicker()
 slug: Web/API/HTMLInputElement/showPicker
-tags:
-  - API
-  - HTML DOM
-  - HTMLInputElement
-  - メソッド
-  - NeedsCompatTable
-  - リファレンス
-browser-compat: api.HTMLInputElement.showPicker
-translation_of: Web/API/HTMLInputElement/showPicker
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlinputelement/stepdown/index.md
+++ b/files/ja/web/api/htmlinputelement/stepdown/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLInputElement.stepDown()
 slug: Web/API/HTMLInputElement/stepDown
-tags:
-  - API
-  - HTML DOM
-  - HTMLInputElement
-  - メソッド
-  - リファレンス
-  - テキスト欄選択 API
-browser-compat: api.HTMLInputElement.stepDown
-translation_of: Web/API/HTMLInputElement/stepDown
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlinputelement/stepup/index.md
+++ b/files/ja/web/api/htmlinputelement/stepup/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLInputElement.stepUp()
 slug: Web/API/HTMLInputElement/stepUp
-tags:
-  - API
-  - HTML DOM
-  - HTMLInputElement
-  - メソッド
-  - リファレンス
-  - テキスト欄選択 API
-browser-compat: api.HTMLInputElement.stepUp
-translation_of: Web/API/HTMLInputElement/stepUp
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlinputelement/webkitdirectory/index.md
+++ b/files/ja/web/api/htmlinputelement/webkitdirectory/index.md
@@ -1,20 +1,6 @@
 ---
 title: HTMLInputElement.webkitdirectory
 slug: Web/API/HTMLInputElement/webkitdirectory
-tags:
-  - API
-  - ファイルシステム API
-  - ファイルとディレクトリー項目 API
-  - ファイル
-  - HTML DOM
-  - HTMLInputElement
-  - 標準外
-  - プロパティ
-  - リファレンス
-  - Web
-  - webkitdirectory
-  - プロパティ
-translation_of: Web/API/HTMLInputElement/webkitdirectory
 ---
 {{APIRef("HTML DOM")}}{{non-standard_header}}
 

--- a/files/ja/web/api/htmlinputelement/webkitentries/index.md
+++ b/files/ja/web/api/htmlinputelement/webkitentries/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLInputElement.webkitEntries
 slug: Web/API/HTMLInputElement/webkitEntries
-tags:
-  - API
-  - ファイルシステム API
-  - ファイルとディレクトリー項目 API
-  - Files
-  - HTML DOM
-  - HTMLInputElement
-  - 標準外
-  - プロパティ
-  - webkitEntries
-browser-compat: api.HTMLInputElement.webkitEntries
 ---
 {{APIRef("File System API")}}{{SeeCompatTable}}{{Non-standard_header}}
 

--- a/files/ja/web/api/htmlkeygenelement/index.md
+++ b/files/ja/web/api/htmlkeygenelement/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLKeygenElement
 slug: Web/API/HTMLKeygenElement
-tags:
-  - API
-  - HTML DOM
-  - Interface
-  - NeedsBrowserAgnosticism
-  - NeedsCompatTable
-  - NeedsNewLayout
-  - Reference
-translation_of: Web/API/HTMLKeygenElement
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmllabelelement/control/index.md
+++ b/files/ja/web/api/htmllabelelement/control/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLLabelElement.control
 slug: Web/API/HTMLLabelElement/control
-tags:
-  - フォーム
-  - HTML DOM
-  - HTMLLabelElement
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - コントロール
-browser-compat: api.HTMLLabelElement.control
-translation_of: Web/API/HTMLLabelElement/control
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmllabelelement/form/index.md
+++ b/files/ja/web/api/htmllabelelement/form/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLLabelElement.form
 slug: Web/API/HTMLLabelElement/form
-tags:
-  - フォーム
-  - HTML DOM
-  - HTMLLabelElement
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - form
-browser-compat: api.HTMLLabelElement.form
-translation_of: Web/API/HTMLLabelElement/form
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmllabelelement/htmlfor/index.md
+++ b/files/ja/web/api/htmllabelelement/htmlfor/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLLabelElement.htmlFor
 slug: Web/API/HTMLLabelElement/htmlFor
-tags:
-  - フォーム
-  - HTML DOM
-  - HTMLLabelElement
-  - リファレンス
-  - htmlFor
-browser-compat: api.HTMLLabelElement.htmlFor
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmllabelelement/index.md
+++ b/files/ja/web/api/htmllabelelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLLabelElement
 slug: Web/API/HTMLLabelElement
-tags:
-  - API
-  - HTML DOM
-  - HTMLLabelElement
-  - インターフェイス
-  - リファレンス
-browser-compat: api.HTMLLabelElement
-translation_of: Web/API/HTMLLabelElement
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmllegendelement/index.md
+++ b/files/ja/web/api/htmllegendelement/index.md
@@ -1,12 +1,6 @@
 ---
 title: HTMLLegendElement
 slug: Web/API/HTMLLegendElement
-tags:
-  - API
-  - HTML DOM
-  - Interface
-  - Reference
-translation_of: Web/API/HTMLLegendElement
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmllielement/index.md
+++ b/files/ja/web/api/htmllielement/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLLIElement
 slug: Web/API/HTMLLIElement
-page-type: web-api-interface
-tags:
-  - API
-  - HTML DOM
-  - HTML DOM インターフェイス
-  - NeedsNewLayout
-  - リファレンス
-browser-compat: api.HTMLLIElement
-translation_of: Web/API/HTMLLIElement
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmllinkelement/as/index.md
+++ b/files/ja/web/api/htmllinkelement/as/index.md
@@ -1,18 +1,6 @@
 ---
 title: HTMLLinkElement.as
 slug: Web/API/HTMLLinkElement/as
-page-type: web-api-instance-property
-tags:
-  - API
-  - Element
-  - HTMLLinkElement
-  - Link
-  - Preload API
-  - プロパティ
-  - リファレンス
-  - as
-browser-compat: api.HTMLLinkElement.as
-translation_of: Web/API/HTMLLinkElement/as
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmllinkelement/fetchpriority/index.md
+++ b/files/ja/web/api/htmllinkelement/fetchpriority/index.md
@@ -1,18 +1,6 @@
 ---
 title: HTMLLinkElement.fetchPriority
 slug: Web/API/HTMLLinkElement/fetchPriority
-page-type: web-api-instance-property
-tags:
-  - API
-  - Element
-  - HTMLLinkElement
-  - リンク
-  - 先読み API
-  - プロパティ
-  - リファレンス
-  - fetchPriority
-browser-compat: api.HTMLLinkElement.fetchPriority
-translation_of: Web/API/HTMLLinkElement/fetchPriority
 ---
 {{SeeCompatTable}}{{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmllinkelement/index.md
+++ b/files/ja/web/api/htmllinkelement/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLLinkElement
 slug: Web/API/HTMLLinkElement
-page-type: web-api-interface
-tags:
-  - API
-  - HTML DOM
-  - HTMLLinkElement
-  - インターフェイス
-  - リファレンス
-browser-compat: api.HTMLLinkElement
-translation_of: Web/API/HTMLLinkElement
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmllinkelement/referrerpolicy/index.md
+++ b/files/ja/web/api/htmllinkelement/referrerpolicy/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLLinkElement.referrerPolicy
 slug: Web/API/HTMLLinkElement/referrerPolicy
-page-type: web-api-instance-property
-tags:
-  - API
-  - Experimental
-  - HTMLLinkElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLLinkElement.referrerPolicy
-translation_of: Web/API/HTMLLinkElement/referrerPolicy
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmllinkelement/rel/index.md
+++ b/files/ja/web/api/htmllinkelement/rel/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLLinkElement.rel
 slug: Web/API/HTMLLinkElement/rel
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLLinkElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLLinkElement.rel
-translation_of: Web/API/HTMLLinkElement/rel
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmllinkelement/rellist/index.md
+++ b/files/ja/web/api/htmllinkelement/rellist/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLLinkElement.relList
 slug: Web/API/HTMLLinkElement/relList
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLLinkElement
-  - プロパティ
-  - Read-only
-  - リファレンス
-browser-compat: api.HTMLLinkElement.relList
-translation_of: Web/API/HTMLLinkElement/relList
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlmapelement/index.md
+++ b/files/ja/web/api/htmlmapelement/index.md
@@ -1,12 +1,6 @@
 ---
 title: HTMLMapElement
 slug: Web/API/HTMLMapElement
-tags:
-  - API
-  - HTML DOM
-  - インターフェイス
-  - リファレンス
-translation_of: Web/API/HTMLMapElement
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlmediaelement/abort_event/index.md
+++ b/files/ja/web/api/htmlmediaelement/abort_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: GlobalEventHandlers.onabort
 slug: Web/API/HTMLMediaElement/abort_event
-page-type: web-api-event
-tags:
-  - API
-  - Event
-  - HTMLMediaElement
-  - Reference
-  - Web
-  - abort
-browser-compat: api.HTMLMediaElement.abort_event
-translation_of: Web/API/HTMLMediaElement/abort_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmlmediaelement/audiotracks/index.md
+++ b/files/ja/web/api/htmlmediaelement/audiotracks/index.md
@@ -1,21 +1,6 @@
 ---
 title: HTMLMediaElement.audioTracks
 slug: Web/API/HTMLMediaElement/audioTracks
-page-type: web-api-instance-property
-tags:
-  - API
-  - Audio
-  - Audio Tracks
-  - HTML DOM
-  - HTMLMediaElement
-  - Media
-  - Property
-  - Reference
-  - Tracks
-  - Web
-  - audiotracks
-browser-compat: api.HTMLMediaElement.audioTracks
-translation_of: Web/API/HTMLMediaElement/audioTracks
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/autoplay/index.md
+++ b/files/ja/web/api/htmlmediaelement/autoplay/index.md
@@ -1,20 +1,6 @@
 ---
 title: HTMLMediaElement.autoplay
 slug: Web/API/HTMLMediaElement/autoplay
-page-type: web-api-instance-property
-tags:
-  - API
-  - Audio
-  - HTML DOM
-  - HTMLMediaElement
-  - Media
-  - NeedsExample
-  - Property
-  - Video
-  - Web
-  - autoplay
-browser-compat: api.HTMLMediaElement.autoplay
-translation_of: Web/API/HTMLMediaElement/autoplay
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/buffered/index.md
+++ b/files/ja/web/api/htmlmediaelement/buffered/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLMediaElement.buffered
 slug: Web/API/HTMLMediaElement/buffered
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLMediaElement
-  - Property
-  - Read-only
-  - Web
-browser-compat: api.HTMLMediaElement.buffered
-translation_of: Web/API/HTMLMediaElement/buffered
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/canplay_event/index.md
+++ b/files/ja/web/api/htmlmediaelement/canplay_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'HTMLMediaElement: canplay イベント'
 slug: Web/API/HTMLMediaElement/canplay_event
-page-type: web-api-event
-tags:
-  - Audio
-  - Event
-  - HTMLMediaElement
-  - Reference
-  - Video
-browser-compat: api.HTMLMediaElement.canplay_event
-translation_of: Web/API/HTMLMediaElement/canplay_event
 ---
 {{APIRef("HTMLMediaElement")}}
 

--- a/files/ja/web/api/htmlmediaelement/canplaythrough_event/index.md
+++ b/files/ja/web/api/htmlmediaelement/canplaythrough_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'HTMLMedia​Element: canplaythrough イベント'
 slug: Web/API/HTMLMediaElement/canplaythrough_event
-page-type: web-api-event
-tags:
-  - Audio
-  - Event
-  - HTMLMediaElement
-  - Reference
-  - Video
-browser-compat: api.HTMLMediaElement.canplaythrough_event
-translation_of: Web/API/HTMLMediaElement/canplaythrough_event
 ---
 {{APIRef("HTMLMediaElement")}}
 

--- a/files/ja/web/api/htmlmediaelement/canplaytype/index.md
+++ b/files/ja/web/api/htmlmediaelement/canplaytype/index.md
@@ -1,27 +1,6 @@
 ---
 title: HTMLMediaElement.canPlayType()
 slug: Web/API/HTMLMediaElement/canPlayType
-page-type: web-api-instance-method
-tags:
-  - API
-  - Audio
-  - Capability
-  - Compatibility
-  - Format
-  - HTML DOM
-  - HTMLMediaElement
-  - MIME Types
-  - Media
-  - Media Types
-  - Method
-  - Reference
-  - Type
-  - Video
-  - Web
-  - canPlayType
-  - support
-browser-compat: api.HTMLMediaElement.canPlayType
-translation_of: Web/API/HTMLMediaElement/canPlayType
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/capturestream/index.md
+++ b/files/ja/web/api/htmlmediaelement/capturestream/index.md
@@ -1,20 +1,6 @@
 ---
 title: HTMLMediaElement.captureStream()
 slug: Web/API/HTMLMediaElement/captureStream
-page-type: web-api-instance-method
-tags:
-  - API
-  - Audio
-  - HTML DOM
-  - HTMLMediaElement
-  - Media
-  - Media Capture DOM Elements
-  - Method
-  - Reference
-  - Video
-  - captureStream
-browser-compat: api.HTMLMediaElement.captureStream
-translation_of: Web/API/HTMLMediaElement/captureStream
 ---
 {{APIRef("HTML Media Capture")}}
 

--- a/files/ja/web/api/htmlmediaelement/controller/index.md
+++ b/files/ja/web/api/htmlmediaelement/controller/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLMediaElement.controller
 slug: Web/API/HTMLMediaElement/controller
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLMediaElement
-  - Property
-  - Web
-  - Deprecated
-browser-compat: api.HTMLMediaElement.controller
-translation_of: Web/API/HTMLMediaElement/controller
 ---
 {{APIRef("HTML DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/htmlmediaelement/controls/index.md
+++ b/files/ja/web/api/htmlmediaelement/controls/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLMediaElement.controls
 slug: Web/API/HTMLMediaElement/controls
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLMediaElement
-  - Property
-  - Web
-browser-compat: api.HTMLMediaElement.controls
-translation_of: Web/API/HTMLMediaElement/controls
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/crossorigin/index.md
+++ b/files/ja/web/api/htmlmediaelement/crossorigin/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLMediaElement.crossOrigin
 slug: Web/API/HTMLMediaElement/crossOrigin
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLMediaElement
-  - Property
-  - Web
-browser-compat: api.HTMLMediaElement.crossOrigin
-translation_of: Web/API/HTMLMediaElement/crossOrigin
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/currentsrc/index.md
+++ b/files/ja/web/api/htmlmediaelement/currentsrc/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLMediaElement.currentSrc
 slug: Web/API/HTMLMediaElement/currentSrc
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLMediaElement
-  - Property
-  - Read-only
-  - Web
-browser-compat: api.HTMLMediaElement.currentSrc
-translation_of: Web/API/HTMLMediaElement/currentSrc
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/currenttime/index.md
+++ b/files/ja/web/api/htmlmediaelement/currenttime/index.md
@@ -1,23 +1,6 @@
 ---
 title: HTMLMediaElement.currentTime
 slug: Web/API/HTMLMediaElement/currentTime
-page-type: web-api-instance-property
-tags:
-  - API
-  - Audio
-  - HTML DOM
-  - HTMLMediaElement
-  - Media
-  - Property
-  - Time
-  - Video
-  - Web
-  - currentTime
-  - offset
-  - seconds
-  - seek
-browser-compat: api.HTMLMediaElement.currentTime
-translation_of: Web/API/HTMLMediaElement/currentTime
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/defaultmuted/index.md
+++ b/files/ja/web/api/htmlmediaelement/defaultmuted/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLMediaElement.defaultMuted
 slug: Web/API/HTMLMediaElement/defaultMuted
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLMediaElement
-  - Property
-  - Web
-browser-compat: api.HTMLMediaElement.defaultMuted
-translation_of: Web/API/HTMLMediaElement/defaultMuted
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/defaultplaybackrate/index.md
+++ b/files/ja/web/api/htmlmediaelement/defaultplaybackrate/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLMediaElement.defaultPlaybackRate
 slug: Web/API/HTMLMediaElement/defaultPlaybackRate
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLMediaElement
-  - Property
-  - Web
-browser-compat: api.HTMLMediaElement.defaultPlaybackRate
-translation_of: Web/API/HTMLMediaElement/defaultPlaybackRate
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/disableremoteplayback/index.md
+++ b/files/ja/web/api/htmlmediaelement/disableremoteplayback/index.md
@@ -1,11 +1,6 @@
 ---
 title: HTMLMediaElement.disableRemotePlayback
 slug: Web/API/HTMLMediaElement/disableRemotePlayback
-page-type: web-api-instance-property
-tags:
-- Property
-browser-compat: api.HTMLMediaElement.disableRemotePlayback
-translation_of: Web/API/HTMLMediaElement/disableRemotePlayback
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/duration/index.md
+++ b/files/ja/web/api/htmlmediaelement/duration/index.md
@@ -1,19 +1,6 @@
 ---
 title: HTMLMediaElement.duration
 slug: Web/API/HTMLMediaElement/duration
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLMediaElement
-  - Property
-  - Read-only
-  - Time
-  - Web
-  - duration
-  - seconds
-browser-compat: api.HTMLMediaElement.duration
-translation_of: Web/API/HTMLMediaElement/duration
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/durationchange_event/index.md
+++ b/files/ja/web/api/htmlmediaelement/durationchange_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'HTMLMediaElement: durationchange イベント'
 slug: Web/API/HTMLMediaElement/durationchange_event
-page-type: web-api-event
-tags:
-  - Audio
-  - Event
-  - HTMLMediaElement
-  - Reference
-  - Video
-browser-compat: api.HTMLMediaElement.durationchange_event
-translation_of: Web/API/HTMLMediaElement/durationchange_event
 ---
 {{APIRef("HTMLMediaElement")}}
 

--- a/files/ja/web/api/htmlmediaelement/emptied_event/index.md
+++ b/files/ja/web/api/htmlmediaelement/emptied_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'HTMLMediaElement: emptied イベント'
 slug: Web/API/HTMLMediaElement/emptied_event
-page-type: web-api-event
-tags:
-  - Audio
-  - Event
-  - HTMLMediaElement
-  - Reference
-  - Video
-browser-compat: api.HTMLMediaElement.emptied_event
-translation_of: Web/API/HTMLMediaElement/emptied_event
 ---
 {{APIRef("HTMLMediaElement")}}
 

--- a/files/ja/web/api/htmlmediaelement/ended/index.md
+++ b/files/ja/web/api/htmlmediaelement/ended/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLMediaElement.ended
 slug: Web/API/HTMLMediaElement/ended
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLMediaElement
-  - Property
-  - Read-only
-  - Web
-  - ended
-browser-compat: api.HTMLMediaElement.ended
-translation_of: Web/API/HTMLMediaElement/ended
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/ended_event/index.md
+++ b/files/ja/web/api/htmlmediaelement/ended_event/index.md
@@ -1,20 +1,6 @@
 ---
 title: 'HTMLMediaElement: ended イベント'
 slug: Web/API/HTMLMediaElement/ended_event
-page-type: web-api-event
-tags:
-  - Audio
-  - Event
-  - HTML DOM
-  - HTMLMediaElement
-  - Media
-  - Media Streams API
-  - Reference
-  - Video
-  - ウェブ音声 API
-  - ended
-browser-compat: api.HTMLMediaElement.ended_event
-translation_of: Web/API/HTMLMediaElement/ended_event
 ---
 {{APIRef("HTMLMediaElement")}}
 

--- a/files/ja/web/api/htmlmediaelement/error/index.md
+++ b/files/ja/web/api/htmlmediaelement/error/index.md
@@ -1,20 +1,6 @@
 ---
 title: HTMLMediaElement.error
 slug: Web/API/HTMLMediaElement/error
-page-type: web-api-instance-property
-tags:
-  - API
-  - Audio
-  - HTML DOM
-  - HTMLMediaElement
-  - Media
-  - Property
-  - Read-only
-  - Reference
-  - Video
-  - Web
-browser-compat: api.HTMLMediaElement.error
-translation_of: Web/API/HTMLMediaElement/error
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/error_event/index.md
+++ b/files/ja/web/api/htmlmediaelement/error_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'HTMLMediaElement: error イベント'
 slug: Web/API/HTMLMediaElement/error_event
-page-type: web-api-event
-tags:
-  - API
-  - Error
-  - Event
-  - HTMLMediaElement
-  - Reference
-  - Web
-browser-compat: api.HTMLMediaElement.error_event
-translation_of: Web/API/HTMLMediaElement/error_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmlmediaelement/fastseek/index.md
+++ b/files/ja/web/api/htmlmediaelement/fastseek/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLMediaElement.fastSeek()
 slug: Web/API/HTMLMediaElement/fastSeek
-page-type: web-api-instance-method
-tags:
-  - API
-  - Audio
-  - HTMLMediaElement
-  - Media
-  - Method
-  - Reference
-  - fastSeek
-browser-compat: api.HTMLMediaElement.fastSeek
-translation_of: Web/API/HTMLMediaElement/fastSeek
 ---
 {{APIRef("HTML DOM")}} {{SeeCompatTable}}
 

--- a/files/ja/web/api/htmlmediaelement/index.md
+++ b/files/ja/web/api/htmlmediaelement/index.md
@@ -1,19 +1,6 @@
 ---
 title: HTMLMediaElement
 slug: Web/API/HTMLMediaElement
-page-type: web-api-interface
-tags:
-  - API
-  - Audio
-  - HTML
-  - HTML DOM
-  - HTMLMediaElement
-  - Interface
-  - Media
-  - Reference
-  - Video
-browser-compat: api.HTMLMediaElement
-translation_of: Web/API/HTMLMediaElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/load/index.md
+++ b/files/ja/web/api/htmlmediaelement/load/index.md
@@ -1,21 +1,6 @@
 ---
 title: HTMLMediaElement.load()
 slug: Web/API/HTMLMediaElement/load
-page-type: web-api-instance-method
-tags:
-  - API
-  - Audio
-  - Element
-  - HTML DOM
-  - HTMLMediaElement
-  - Media
-  - Method
-  - Reference
-  - Video
-  - load
-  - reset
-browser-compat: api.HTMLMediaElement.load
-translation_of: Web/API/HTMLMediaElement/load
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/loadeddata_event/index.md
+++ b/files/ja/web/api/htmlmediaelement/loadeddata_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'HTMLMediaElement: loadeddata イベント'
 slug: Web/API/HTMLMediaElement/loadeddata_event
-page-type: web-api-event
-tags:
-  - Audio
-  - Event
-  - HTMLMediaElement
-  - Reference
-  - Video
-browser-compat: api.HTMLMediaElement.loadeddata_event
-translation_of: Web/API/HTMLMediaElement/loadeddata_event
 ---
 {{APIRef("HTMLMediaElement")}}
 

--- a/files/ja/web/api/htmlmediaelement/loadedmetadata_event/index.md
+++ b/files/ja/web/api/htmlmediaelement/loadedmetadata_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'HTMLMediaElement: loadedmetadata イベント'
 slug: Web/API/HTMLMediaElement/loadedmetadata_event
-page-type: web-api-event
-tags:
-  - Audio
-  - Event
-  - HTMLMediaElement
-  - Reference
-  - Video
-browser-compat: api.HTMLMediaElement.loadedmetadata_event
-translation_of: Web/API/HTMLMediaElement/loadedmetadata_event
 ---
 {{APIRef("HTMLMediaElement")}}
 

--- a/files/ja/web/api/htmlmediaelement/loadstart_event/index.md
+++ b/files/ja/web/api/htmlmediaelement/loadstart_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'HTMLMediaElement: loadstart イベント'
 slug: Web/API/HTMLMediaElement/loadstart_event
-page-type: web-api-event
-tags:
-  - API
-  - Event
-  - HTMLMediaElement
-  - Reference
-  - Web
-  - loadstart
-browser-compat: api.HTMLMediaElement.loadstart_event
-translation_of: Web/API/HTMLMediaElement/loadstart_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmlmediaelement/loop/index.md
+++ b/files/ja/web/api/htmlmediaelement/loop/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLMediaElement.loop
 slug: Web/API/HTMLMediaElement/loop
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLMediaElement
-  - Property
-  - Web
-browser-compat: api.HTMLMediaElement.loop
-translation_of: Web/API/HTMLMediaElement/loop
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/mediagroup/index.md
+++ b/files/ja/web/api/htmlmediaelement/mediagroup/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLMediaElement.mediaGroup
 slug: Web/API/HTMLMediaElement/mediaGroup
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLMediaElement
-  - Property
-  - Web
-  - Deprecated
-browser-compat: api.HTMLMediaElement.mediaGroup
-translation_of: Web/API/HTMLMediaElement/mediaGroup
 ---
 {{APIRef("HTML DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/htmlmediaelement/muted/index.md
+++ b/files/ja/web/api/htmlmediaelement/muted/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLMediaElement.muted
 slug: Web/API/HTMLMediaElement/muted
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLMediaElement
-  - Property
-  - Web
-browser-compat: api.HTMLMediaElement.muted
-translation_of: Web/API/HTMLMediaElement/muted
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/networkstate/index.md
+++ b/files/ja/web/api/htmlmediaelement/networkstate/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLMediaElement.networkState
 slug: Web/API/HTMLMediaElement/networkState
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - Property
-  - Read-only
-  - Web
-browser-compat: api.HTMLMediaElement.networkState
-translation_of: Web/API/HTMLMediaElement/networkState
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/onerror/index.md
+++ b/files/ja/web/api/htmlmediaelement/onerror/index.md
@@ -1,21 +1,6 @@
 ---
 title: HTMLMediaElement.onerror
 slug: Web/API/HTMLMediaElement/onerror
-page-type: web-api-instance-property
-tags:
-  - API
-  - Audio
-  - Errors
-  - Event Handler
-  - HTML DOM
-  - HTMLMediaElement
-  - Media
-  - Property
-  - Reference
-  - Video
-  - onerror
-browser-compat: api.HTMLMediaElement.onerror
-translation_of: Web/API/HTMLMediaElement/onerror
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/pause/index.md
+++ b/files/ja/web/api/htmlmediaelement/pause/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLMediaElement.pause()
 slug: Web/API/HTMLMediaElement/pause
-page-type: web-api-instance-method
-tags:
-  - API
-  - Audio
-  - HTMLMediaElement
-  - Method
-  - Reference
-  - Video
-browser-compat: api.HTMLMediaElement.pause
-translation_of: Web/API/HTMLMediaElement/pause
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/pause_event/index.md
+++ b/files/ja/web/api/htmlmediaelement/pause_event/index.md
@@ -1,25 +1,6 @@
 ---
 title: 'HTMLMediaElement: pause イベント'
 slug: Web/API/HTMLMediaElement/pause_event
-page-type: web-api-event
-tags:
-  - Audio
-  - Event
-  - HTML
-  - HTMLMediaElement
-  - Media
-  - Media Events
-  - Pausing
-  - Pausing Media
-  - Pausing Speech
-  - Speech Events
-  - Video
-  - Web Speech API
-  - Web Speech Events
-  - pause
-  - speech
-browser-compat: api.HTMLMediaElement.pause_event
-translation_of: Web/API/HTMLMediaElement/pause_event
 ---
 {{APIRef("HTMLMediaElement")}}
 

--- a/files/ja/web/api/htmlmediaelement/paused/index.md
+++ b/files/ja/web/api/htmlmediaelement/paused/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLMediaElement.paused
 slug: Web/API/HTMLMediaElement/paused
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLMediaElement
-  - Property
-  - Read-only
-browser-compat: api.HTMLMediaElement.paused
-translation_of: Web/API/HTMLMediaElement/paused
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/play/index.md
+++ b/files/ja/web/api/htmlmediaelement/play/index.md
@@ -1,19 +1,6 @@
 ---
 title: HTMLMediaElement.play()
 slug: Web/API/HTMLMediaElement/play
-page-type: web-api-instance-method
-tags:
-  - API
-  - Audio
-  - HTMLMediaElement
-  - Interface
-  - Media
-  - Method
-  - Reference
-  - Video
-  - play
-browser-compat: api.HTMLMediaElement.play
-translation_of: Web/API/HTMLMediaElement/play
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/play_event/index.md
+++ b/files/ja/web/api/htmlmediaelement/play_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'HTMLMedia​Element: play イベント'
 slug: Web/API/HTMLMediaElement/play_event
-page-type: web-api-event
-tags:
-  - Audio
-  - Event
-  - HTMLMediaElement
-  - Reference
-  - Video
-browser-compat: api.HTMLMediaElement.play_event
-translation_of: Web/API/HTMLMediaElement/play_event
 ---
 {{APIRef("HTMLMediaElement")}}
 

--- a/files/ja/web/api/htmlmediaelement/playbackrate/index.md
+++ b/files/ja/web/api/htmlmediaelement/playbackrate/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLMediaElement.playbackRate
 slug: Web/API/HTMLMediaElement/playbackRate
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLMediaElement
-  - Property
-browser-compat: api.HTMLMediaElement.playbackRate
-translation_of: Web/API/HTMLMediaElement/playbackRate
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/playing_event/index.md
+++ b/files/ja/web/api/htmlmediaelement/playing_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'HTMLMediaElement: playing イベント'
 slug: Web/API/HTMLMediaElement/playing_event
-page-type: web-api-event
-tags:
-  - API
-  - HTMLMediaElement
-  - Reference
-  - playing
-  - Event
-browser-compat: api.HTMLMediaElement.playing_event
-translation_of: Web/API/HTMLMediaElement/playing_event
 ---
 {{APIRef("HTMLMediaElement")}}
 

--- a/files/ja/web/api/htmlmediaelement/progress_event/index.md
+++ b/files/ja/web/api/htmlmediaelement/progress_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'HTMLMediaElement: progress イベント'
 slug: Web/API/HTMLMediaElement/progress_event
-page-type: web-api-event
-tags:
-  - API
-  - Event
-  - HTMLMediaElement
-  - Reference
-  - Web
-  - progress
-browser-compat: api.HTMLMediaElement.progress_event
-translation_of: Web/API/HTMLMediaElement/progress_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmlmediaelement/ratechange_event/index.md
+++ b/files/ja/web/api/htmlmediaelement/ratechange_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'HTMLMediaElement: ratechange イベント'
 slug: Web/API/HTMLMediaElement/ratechange_event
-page-type: web-api-event
-tags:
-  - API
-  - Audio
-  - Event
-  - HTMLMediaElement
-  - Reference
-  - Video
-browser-compat: api.HTMLMediaElement.ratechange_event
-translation_of: Web/API/HTMLMediaElement/ratechange_event
 ---
 {{APIRef("HTMLMediaElement")}}
 

--- a/files/ja/web/api/htmlmediaelement/readystate/index.md
+++ b/files/ja/web/api/htmlmediaelement/readystate/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLMediaElement.readyState
 slug: Web/API/HTMLMediaElement/readyState
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLMediaElement
-  - Property
-  - Read-only
-  - Web
-browser-compat: api.HTMLMediaElement.readyState
-translation_of: Web/API/HTMLMediaElement/readyState
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/seekable/index.md
+++ b/files/ja/web/api/htmlmediaelement/seekable/index.md
@@ -1,21 +1,6 @@
 ---
 title: HTMLMediaElement.seekable
 slug: Web/API/HTMLMediaElement/seekable
-page-type: web-api-instance-property
-tags:
-  - API
-  - Audio
-  - Extensions
-  - HTMLMediaElement
-  - MSE
-  - Media
-  - Property
-  - Reference
-  - Video
-  - seekable
-  - source
-browser-compat: api.HTMLMediaElement.seekable
-translation_of: Web/API/HTMLMediaElement/seekable
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/seeked_event/index.md
+++ b/files/ja/web/api/htmlmediaelement/seeked_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'HTMLMediaElement: seeked イベント'
 slug: Web/API/HTMLMediaElement/seeked_event
-page-type: web-api-event
-tags:
-  - API
-  - Audio
-  - Event
-  - HTMLMediaElement
-  - Reference
-  - Video
-browser-compat: api.HTMLMediaElement.seeked_event
-translation_of: Web/API/HTMLMediaElement/seeked_event
 ---
 {{APIRef("HTMLMediaElement")}}
 

--- a/files/ja/web/api/htmlmediaelement/seeking_event/index.md
+++ b/files/ja/web/api/htmlmediaelement/seeking_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'HTMLMediaElement: seeking イベント'
 slug: Web/API/HTMLMediaElement/seeking_event
-page-type: web-api-event
-tags:
-  - API
-  - Audio
-  - Event
-  - HTMLMediaElement
-  - Reference
-  - Video
-browser-compat: api.HTMLMediaElement.seeking_event
-translation_of: Web/API/HTMLMediaElement/seeking_event
 ---
 {{APIRef("HTMLMediaElement")}}
 

--- a/files/ja/web/api/htmlmediaelement/src/index.md
+++ b/files/ja/web/api/htmlmediaelement/src/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLMediaElement.src
 slug: Web/API/HTMLMediaElement/src
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLMediaElement
-  - Property
-  - Reference
-  - src
-browser-compat: api.HTMLMediaElement.src
-translation_of: Web/API/HTMLMediaElement/src
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/srcobject/index.md
+++ b/files/ja/web/api/htmlmediaelement/srcobject/index.md
@@ -1,18 +1,6 @@
 ---
 title: HTMLMediaElement.srcObject
 slug: Web/API/HTMLMediaElement/srcObject
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML
-  - HTML DOM
-  - HTMLMediaElement
-  - Media
-  - Property
-  - Reference
-  - srcObject
-browser-compat: api.HTMLMediaElement.srcObject
-translation_of: Web/API/HTMLMediaElement/srcObject
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/stalled_event/index.md
+++ b/files/ja/web/api/htmlmediaelement/stalled_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'HTMLMediaElement: stalled イベント'
 slug: Web/API/HTMLMediaElement/stalled_event
-page-type: web-api-event
-tags:
-  - API
-  - Audio
-  - Event
-  - HTMLMediaElement
-  - Reference
-  - Video
-browser-compat: api.HTMLMediaElement.stalled_event
-translation_of: Web/API/HTMLMediaElement/stalled_event
 ---
 {{APIRef("HTMLMediaElement")}}
 

--- a/files/ja/web/api/htmlmediaelement/suspend_event/index.md
+++ b/files/ja/web/api/htmlmediaelement/suspend_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'HTMLMediaElement: suspend イベント'
 slug: Web/API/HTMLMediaElement/suspend_event
-page-type: web-api-event
-tags:
-  - API
-  - Audio
-  - Event
-  - HTMLMediaElement
-  - Reference
-  - Video
-browser-compat: api.HTMLMediaElement.suspend_event
-translation_of: Web/API/HTMLMediaElement/suspend_event
 ---
 {{APIRef("HTMLMediaElement")}}
 

--- a/files/ja/web/api/htmlmediaelement/timeupdate_event/index.md
+++ b/files/ja/web/api/htmlmediaelement/timeupdate_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'HTMLMediaElement: timeupdate イベント'
 slug: Web/API/HTMLMediaElement/timeupdate_event
-page-type: web-api-event
-tags:
-  - Audio
-  - Event
-  - HTMLMediaElement
-  - Reference
-  - Video
-browser-compat: api.HTMLMediaElement.timeupdate_event
-translation_of: Web/API/HTMLMediaElement/timeupdate_event
 ---
 {{APIRef("HTMLMediaElement")}}
 

--- a/files/ja/web/api/htmlmediaelement/videotracks/index.md
+++ b/files/ja/web/api/htmlmediaelement/videotracks/index.md
@@ -1,21 +1,6 @@
 ---
 title: HTMLMediaElement.videoTracks
 slug: Web/API/HTMLMediaElement/videoTracks
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLMediaElement
-  - Media
-  - Property
-  - Reference
-  - Tracks
-  - Video
-  - Video Tracks
-  - Web
-  - videoTracks
-browser-compat: api.HTMLMediaElement.videoTracks
-translation_of: Web/API/HTMLMediaElement/videoTracks
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/volume/index.md
+++ b/files/ja/web/api/htmlmediaelement/volume/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLMediaElement.volume
 slug: Web/API/HTMLMediaElement/volume
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLMediaElement
-  - Property
-  - Reference
-  - Volume
-browser-compat: api.HTMLMediaElement.volume
-translation_of: Web/API/HTMLMediaElement/volume
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlmediaelement/volumechange_event/index.md
+++ b/files/ja/web/api/htmlmediaelement/volumechange_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'HTMLMediaElement: volumechange イベント'
 slug: Web/API/HTMLMediaElement/volumechange_event
-page-type: web-api-event
-tags:
-  - API
-  - Audio
-  - Event
-  - HTMLMediaElement
-  - Reference
-  - Video
-  - Web
-browser-compat: api.HTMLMediaElement.volumechange_event
-translation_of: Web/API/HTMLMediaElement/volumechange_event
 ---
 {{APIRef("HTMLMediaElement")}}
 

--- a/files/ja/web/api/htmlmediaelement/waiting_event/index.md
+++ b/files/ja/web/api/htmlmediaelement/waiting_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'HTMLMediaElement: waiting イベント'
 slug: Web/API/HTMLMediaElement/waiting_event
-page-type: web-api-event
-tags:
-  - Audio
-  - Event
-  - HTMLMediaElement
-  - Reference
-  - Video
-  - Web
-browser-compat: api.HTMLMediaElement.waiting_event
-translation_of: Web/API/HTMLMediaElement/waiting_event
 ---
 {{APIRef("HTMLMediaElement")}}
 

--- a/files/ja/web/api/htmlmetaelement/index.md
+++ b/files/ja/web/api/htmlmetaelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLMetaElement
 slug: Web/API/HTMLMetaElement
-page-type: web-api-interface
-tags:
-  - API
-  - HTML DOM
-  - インターフェイス
-  - リファレンス
-browser-compat: api.HTMLMetaElement
-translation_of: Web/API/HTMLMetaElement
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlmodelement/index.md
+++ b/files/ja/web/api/htmlmodelement/index.md
@@ -1,12 +1,6 @@
 ---
 title: HTMLModElement
 slug: Web/API/HTMLModElement
-tags:
-  - API
-  - HTML DOM
-  - Interface
-  - Reference
-translation_of: Web/API/HTMLModElement
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlobjectelement/checkvalidity/index.md
+++ b/files/ja/web/api/htmlobjectelement/checkvalidity/index.md
@@ -1,18 +1,6 @@
 ---
 title: HTMLObjectElement.checkValidity()
 slug: Web/API/HTMLObjectElement/checkValidity
-page-type: web-api-instance-method
-tags:
-  - API
-  - HTML DOM
-  - HTMLObjectElement
-  - Method
-  - NeedsExample
-  - Reference
-  - checkValidity
-  - checkValidity()
-browser-compat: api.HTMLObjectElement.checkValidity
-translation_of: Web/API/HTMLObjectElement/checkValidity
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlobjectelement/contentdocument/index.md
+++ b/files/ja/web/api/htmlobjectelement/contentdocument/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLObjectElement.contentDocument
 slug: Web/API/HTMLObjectElement/contentDocument
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLObjectElement
-  - NeedsExample
-  - Property
-  - Reference
-  - contentDocument
-browser-compat: api.HTMLObjectElement.contentDocument
-translation_of: Web/API/HTMLObjectElement/contentDocument
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlobjectelement/contentwindow/index.md
+++ b/files/ja/web/api/htmlobjectelement/contentwindow/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLObjectElement.contentWindow
 slug: Web/API/HTMLObjectElement/contentWindow
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLObjectElement
-  - NeedsExample
-  - Property
-  - Reference
-  - contentWindow
-browser-compat: api.HTMLObjectElement.contentWindow
-translation_of: Web/API/HTMLObjectElement/contentWindow
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlobjectelement/data/index.md
+++ b/files/ja/web/api/htmlobjectelement/data/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLObjectElement.data
 slug: Web/API/HTMLObjectElement/data
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLObjectElement
-  - NeedsExample
-  - Property
-  - Reference
-  - data
-browser-compat: api.HTMLObjectElement.data
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlobjectelement/form/index.md
+++ b/files/ja/web/api/htmlobjectelement/form/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLObjectElement.form
 slug: Web/API/HTMLObjectElement/form
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLObjectElement
-  - NeedsExample
-  - Property
-  - Reference
-  - form
-browser-compat: api.HTMLObjectElement.form
-translation_of: Web/API/HTMLObjectElement/form
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlobjectelement/height/index.md
+++ b/files/ja/web/api/htmlobjectelement/height/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLObjectElement.height
 slug: Web/API/HTMLObjectElement/height
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLObjectElement
-  - NeedsExample
-  - Property
-  - Reference
-  - height
-browser-compat: api.HTMLObjectElement.height
-translation_of: Web/API/HTMLObjectElement/height
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlobjectelement/index.md
+++ b/files/ja/web/api/htmlobjectelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLObjectElement
 slug: Web/API/HTMLObjectElement
-page-type: web-api-interface
-tags:
-  - API
-  - HTML DOM
-  - Interface
-  - Reference
-browser-compat: api.HTMLObjectElement
-translation_of: Web/API/HTMLObjectElement
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlobjectelement/name/index.md
+++ b/files/ja/web/api/htmlobjectelement/name/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLObjectElement.name
 slug: Web/API/HTMLObjectElement/name
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLObjectElement
-  - NeedsExample
-  - Property
-  - Reference
-  - name
-browser-compat: api.HTMLObjectElement.name
-translation_of: Web/API/HTMLObjectElement/name
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlobjectelement/setcustomvalidity/index.md
+++ b/files/ja/web/api/htmlobjectelement/setcustomvalidity/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLObjectElement.setCustomValidity()
 slug: Web/API/HTMLObjectElement/setCustomValidity
-page-type: web-api-instance-method
-tags:
-  - API
-  - HTML DOM
-  - HTMLObjectElement
-  - Method
-  - NeedsExample
-  - Reference
-  - setCustomValidity()
-browser-compat: api.HTMLObjectElement.setCustomValidity
-translation_of: Web/API/HTMLObjectElement/setCustomValidity
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlobjectelement/type/index.md
+++ b/files/ja/web/api/htmlobjectelement/type/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLObjectElement.type
 slug: Web/API/HTMLObjectElement/type
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLObjectElement
-  - NeedsExample
-  - Property
-  - Reference
-  - Type
-browser-compat: api.HTMLObjectElement.type
-translation_of: Web/API/HTMLObjectElement/type
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlobjectelement/usemap/index.md
+++ b/files/ja/web/api/htmlobjectelement/usemap/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLObjectElement.useMap
 slug: Web/API/HTMLObjectElement/useMap
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLObjectElement
-  - NeedsExample
-  - Property
-  - Reference
-  - useMap
-browser-compat: api.HTMLObjectElement.useMap
-translation_of: Web/API/HTMLObjectElement/useMap
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlobjectelement/validationmessage/index.md
+++ b/files/ja/web/api/htmlobjectelement/validationmessage/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLObjectElement.validationMessage
 slug: Web/API/HTMLObjectElement/validationMessage
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLObjectElement
-  - NeedsExample
-  - Property
-  - Reference
-  - validationMessage
-browser-compat: api.HTMLObjectElement.validationMessage
-translation_of: Web/API/HTMLObjectElement/validationMessage
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlobjectelement/validity/index.md
+++ b/files/ja/web/api/htmlobjectelement/validity/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLObjectElement.validity
 slug: Web/API/HTMLObjectElement/validity
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLObjectElement
-  - NeedsExample
-  - Property
-  - Reference
-  - validity
-browser-compat: api.HTMLObjectElement.validity
-translation_of: Web/API/HTMLObjectElement/validity
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlobjectelement/width/index.md
+++ b/files/ja/web/api/htmlobjectelement/width/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLObjectElement.width
 slug: Web/API/HTMLObjectElement/width
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLObjectElement
-  - NeedsExample
-  - Property
-  - Reference
-  - width
-browser-compat: api.HTMLObjectElement.width
-translation_of: Web/API/HTMLObjectElement/width
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlobjectelement/willvalidate/index.md
+++ b/files/ja/web/api/htmlobjectelement/willvalidate/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLObjectElement.willValidate
 slug: Web/API/HTMLObjectElement/willValidate
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - HTMLObjectElement
-  - NeedsExample
-  - Property
-  - Reference
-  - willValidate
-browser-compat: api.HTMLObjectElement.willValidate
-translation_of: Web/API/HTMLObjectElement/willValidate
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlolistelement/index.md
+++ b/files/ja/web/api/htmlolistelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLOListElement
 slug: Web/API/HTMLOListElement
-page-type: web-api-interface
-tags:
-  - API
-  - HTML DOM
-  - インターフェイス
-  - リファレンス
-browser-compat: api.HTMLOListElement
-translation_of: Web/API/HTMLOListElement
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmloptionelement/index.md
+++ b/files/ja/web/api/htmloptionelement/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLOptionElement
 slug: Web/API/HTMLOptionElement
-tags:
-  - API
-  - HTML DOM
-  - Interface
-  - NeedsNewLayout
-  - Reference
-translation_of: Web/API/HTMLOptionElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmloptionelement/option/index.md
+++ b/files/ja/web/api/htmloptionelement/option/index.md
@@ -1,16 +1,6 @@
 ---
 title: Option()
 slug: Web/API/HTMLOptionElement/Option
-tags:
-  - API
-  - Constructor
-  - HTML DOM
-  - HTMLOptionElement
-  - NeedsBrowserCompatibility
-  - NeedsContent
-  - NeedsExample
-  - NeedsSpecTable
-translation_of: Web/API/HTMLOptionElement/Option
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmloutputelement/index.md
+++ b/files/ja/web/api/htmloutputelement/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLOutputElement
 slug: Web/API/HTMLOutputElement
-tags:
-  - API
-  - HTML DOM
-  - Interface
-  - Reference
-  - インターフェイス
-translation_of: Web/API/HTMLOutputElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlparagraphelement/index.md
+++ b/files/ja/web/api/htmlparagraphelement/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLParagraphElement
 slug: Web/API/HTMLParagraphElement
-tags:
-  - API
-  - HTML DOM
-  - インターフェイス
-  - リファレンス
-browser-compat: api.HTMLParagraphElement
-translation_of: Web/API/HTMLParagraphElement
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlparamelement/index.md
+++ b/files/ja/web/api/htmlparamelement/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLParamElement
 slug: Web/API/HTMLParamElement
-page-type: web-api-interface
-tags:
-  - API
-  - HTML DOM
-  - インターフェイス
-  - リファレンス
-  - 非推奨
-browser-compat: api.HTMLParamElement
-translation_of: Web/API/HTMLParamElement
 ---
 {{ APIRef("HTML DOM") }}{{Deprecated_Header}}
 

--- a/files/ja/web/api/htmlpictureelement/index.md
+++ b/files/ja/web/api/htmlpictureelement/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLPictureElement
 slug: Web/API/HTMLPictureElement
-tags:
-  - API
-  - Experimental
-  - HTML DOM
-  - Interface
-  - Reference
-translation_of: Web/API/HTMLPictureElement
 ---
 {{APIRef("HTML DOM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/htmlquoteelement/index.md
+++ b/files/ja/web/api/htmlquoteelement/index.md
@@ -1,12 +1,6 @@
 ---
 title: HTMLQuoteElement
 slug: Web/API/HTMLQuoteElement
-tags:
-  - API
-  - HTML DOM
-  - Interface
-  - Reference
-translation_of: Web/API/HTMLQuoteElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlscriptelement/index.md
+++ b/files/ja/web/api/htmlscriptelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLScriptElement
 slug: Web/API/HTMLScriptElement
-tags:
-  - API
-  - HTML DOM
-  - インターフェイス
-  - NeedsNewLayout
-  - リファレンス
-browser-compat: api.HTMLScriptElement
-translation_of: Web/API/HTMLScriptElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlselectelement/add/index.md
+++ b/files/ja/web/api/htmlselectelement/add/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLSelectElement.add()
 slug: Web/API/HTMLSelectElement/add
-tags:
-  - API
-  - HTML DOM
-  - HTMLSelectElement
-  - メソッド
-  - リファレンス
-browser-compat: api.HTMLSelectElement.add
-translation_of: Web/API/HTMLSelectElement/add
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlselectelement/autofocus/index.md
+++ b/files/ja/web/api/htmlselectelement/autofocus/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLSelectElement.autofocus
 slug: Web/API/HTMLSelectElement/autofocus
-tags:
-  - API
-  - HTML フォーム
-  - HTMLSelectElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLSelectElement.autofocus
-translation_of: Web/API/HTMLSelectElement/autofocus
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlselectelement/checkvalidity/index.md
+++ b/files/ja/web/api/htmlselectelement/checkvalidity/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLSelectElement.checkValidity()
 slug: Web/API/HTMLSelectElement/checkValidity
-tags:
-  - API
-  - Constraint Validation API
-  - HTML DOM
-  - HTMLSelectElement
-  - メソッド
-  - リファレンス
-browser-compat: api.HTMLSelectElement.checkValidity
-translation_of: Web/API/HTMLSelectElement/checkValidity
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlselectelement/disabled/index.md
+++ b/files/ja/web/api/htmlselectelement/disabled/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLSelectElement.disabled
 slug: Web/API/HTMLSelectElement/disabled
-tags:
-  - API
-  - HTML DOM
-  - HTMLSelectElement
-  - プロパティ
-browser-compat: api.HTMLSelectElement.disabled
-translation_of: Web/API/HTMLSelectElement/disabled
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlselectelement/form/index.md
+++ b/files/ja/web/api/htmlselectelement/form/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLSelectElement.form
 slug: Web/API/HTMLSelectElement/form
-tags:
-  - API
-  - HTMLSelectElement
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.HTMLSelectElement.form
-translation_of: Web/API/HTMLSelectElement/form
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlselectelement/index.md
+++ b/files/ja/web/api/htmlselectelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLSelectElement
 slug: Web/API/HTMLSelectElement
-tags:
-  - API
-  - HTML DOM
-  - HTMLSelectElement
-  - インターフェイス
-  - リファレンス
-browser-compat: api.HTMLSelectElement
-translation_of: Web/API/HTMLSelectElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlselectelement/item/index.md
+++ b/files/ja/web/api/htmlselectelement/item/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLSelectElement.item()
 slug: Web/API/HTMLSelectElement/item
-tags:
-  - API
-  - HTML DOM
-  - HTMLSelectElement
-  - メソッド
-  - リファレンス
-browser-compat: api.HTMLSelectElement.item
-translation_of: Web/API/HTMLSelectElement/item
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlselectelement/labels/index.md
+++ b/files/ja/web/api/htmlselectelement/labels/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLSelectElement.labels
 slug: Web/API/HTMLSelectElement/labels
-tags:
-  - API
-  - HTML DOM
-  - HTMLSelectElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLSelectElement.labels
-translation_of: Web/API/HTMLSelectElement/labels
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/htmlselectelement/nameditem/index.md
+++ b/files/ja/web/api/htmlselectelement/nameditem/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLSelectElement.namedItem()
 slug: Web/API/HTMLSelectElement/namedItem
-tags:
-  - API
-  - HTML DOM
-  - HTMLSelectElement
-  - メソッド
-  - リファレンス
-browser-compat: api.HTMLSelectElement.namedItem
-translation_of: Web/API/HTMLSelectElement/namedItem
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlselectelement/options/index.md
+++ b/files/ja/web/api/htmlselectelement/options/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLSelectElement.options
 slug: Web/API/HTMLSelectElement/options
-tags:
-  - API
-  - HTMLSelectElement
-  - Options
-  - プロパティ
-  - 読み取り専用
-  - ウェブ
-browser-compat: api.HTMLSelectElement.options
-translation_of: Web/API/HTMLSelectElement/options
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/htmlselectelement/remove/index.md
+++ b/files/ja/web/api/htmlselectelement/remove/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLSelectElement.remove()
 slug: Web/API/HTMLSelectElement/remove
-tags:
-  - API
-  - HTML DOM
-  - HTMLSelectElement
-  - メソッド
-  - リファレンス
-browser-compat: api.HTMLSelectElement.remove
-translation_of: Web/API/HTMLSelectElement/remove
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlselectelement/selectedindex/index.md
+++ b/files/ja/web/api/htmlselectelement/selectedindex/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLSelectElement.selectedIndex
 slug: Web/API/HTMLSelectElement/selectedIndex
-tags:
-  - API
-  - HTML DOM
-  - HTML フォーム
-  - HTMLSelectElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLSelectElement.selectedIndex
-translation_of: Web/API/HTMLSelectElement/selectedIndex
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlselectelement/selectedoptions/index.md
+++ b/files/ja/web/api/htmlselectelement/selectedoptions/index.md
@@ -1,18 +1,6 @@
 ---
 title: HTMLSelectElement.selectedOptions
 slug: Web/API/HTMLSelectElement/selectedOptions
-tags:
-  - API
-  - HTML DOM
-  - HTMLSelectElement
-  - Options
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - Select
-  - ウェブ
-  - selectedOptions
-browser-compat: api.HTMLSelectElement.selectedOptions
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlselectelement/setcustomvalidity/index.md
+++ b/files/ja/web/api/htmlselectelement/setcustomvalidity/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLSelectElement.setCustomValidity()
 slug: Web/API/HTMLSelectElement/setCustomValidity
-tags:
-  - API
-  - Constrain Validation API
-  - HTML DOM
-  - HTMLSelectElement
-  - メソッド
-  - リファレンス
-browser-compat: api.HTMLSelectElement.setCustomValidity
-translation_of: Web/API/HTMLSelectElement/setCustomValidity
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlselectelement/type/index.md
+++ b/files/ja/web/api/htmlselectelement/type/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLSelectElement.type
 slug: Web/API/HTMLSelectElement/type
-tags:
-  - API
-  - HTML DOM
-  - HTMLSelectElement
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.HTMLSelectElement.type
-translation_of: Web/API/HTMLSelectElement/type
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlshadowelement/getdistributednodes/index.md
+++ b/files/ja/web/api/htmlshadowelement/getdistributednodes/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLShadowElement.getDistributedNodes()
 slug: Web/API/HTMLShadowElement/getDistributedNodes
-tags:
-  - API
-  - HTML DOM
-  - Property
-  - Reference
-  - Web Components
-translation_of: Web/API/HTMLShadowElement/getDistributedNodes
 ---
 {{APIRef("Web Components")}}
 

--- a/files/ja/web/api/htmlshadowelement/index.md
+++ b/files/ja/web/api/htmlshadowelement/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLShadowElement
 slug: Web/API/HTMLShadowElement
-tags:
-  - API
-  - HTML DOM
-  - Interface
-  - Reference
-  - Web Components
-translation_of: Web/API/HTMLShadowElement
 ---
 {{ APIRef("Web Components") }}
 

--- a/files/ja/web/api/htmlslotelement/assign/index.md
+++ b/files/ja/web/api/htmlslotelement/assign/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLSlotElement.assign()
 slug: Web/API/HTMLSlotElement/assign
-tags:
-  - API
-  - HTMLSlotElement
-  - メソッド
-  - リファレンス
-  - ウェブコンポーネント
-  - assign
-  - シャドウ DOM
-browser-compat: api.HTMLSlotElement.assign
-translation_of: Web/API/HTMLSlotElement/assign
 ---
 {{APIRef("Shadow DOM API")}}
 

--- a/files/ja/web/api/htmlslotelement/assignedelements/index.md
+++ b/files/ja/web/api/htmlslotelement/assignedelements/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLSlotElement.assignedElements()
 slug: Web/API/HTMLSlotElement/assignedElements
-tags:
-  - API
-  - HTMLSlotElement
-  - メソッド
-  - リファレンス
-  - ウェブコンポーネント
-  - assignedElements
-  - シャドウ DOM
-browser-compat: api.HTMLSlotElement.assignedElements
-translation_of: Web/API/HTMLSlotElement/assignedElements
 ---
 {{APIRef("Shadow DOM API")}}
 

--- a/files/ja/web/api/htmlslotelement/assignednodes/index.md
+++ b/files/ja/web/api/htmlslotelement/assignednodes/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLSlotElement.assignedNodes()
 slug: Web/API/HTMLSlotElement/assignedNodes
-tags:
-  - API
-  - HTMLSlotElement
-  - メソッド
-  - リファレンス
-  - assignedNodes
-  - シャドウ DOM
-browser-compat: api.HTMLSlotElement.assignedNodes
-translation_of: Web/API/HTMLSlotElement/assignedNodes
 ---
 {{APIRef("Shadow DOM API")}}
 

--- a/files/ja/web/api/htmlslotelement/index.md
+++ b/files/ja/web/api/htmlslotelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLSlotElement
 slug: Web/API/HTMLSlotElement
-tags:
-  - API
-  - HTMLSlotElement
-  - インターフェイス
-  - リファレンス
-  - シャドウ DOM
-browser-compat: api.HTMLSlotElement
-translation_of: Web/API/HTMLSlotElement
 ---
 {{APIRef('Web Components')}}
 

--- a/files/ja/web/api/htmlslotelement/name/index.md
+++ b/files/ja/web/api/htmlslotelement/name/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLSlotElement.name
 slug: Web/API/HTMLSlotElement/name
-tags:
-  - API
-  - HTMLSlotElement
-  - プロパティ
-  - リファレンス
-  - name
-  - シャドウ DOM
-browser-compat: api.HTMLSlotElement.name
-translation_of: Web/API/HTMLSlotElement/name
 ---
 {{APIRef("Shadow DOM API")}}
 

--- a/files/ja/web/api/htmlslotelement/slotchange_event/index.md
+++ b/files/ja/web/api/htmlslotelement/slotchange_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'HTMLSlotElement: slotchange イベント'
 slug: Web/API/HTMLSlotElement/slotchange_event
-tags:
-  - Event
-  - リファレンス
-  - ウェブコンポーネント
-  - イベント
-  - シャドウ DOM
-  - slotchange
-browser-compat: api.HTMLSlotElement.slotchange_event
-translation_of: Web/API/HTMLSlotElement/slotchange_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/htmlsourceelement/index.md
+++ b/files/ja/web/api/htmlsourceelement/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLSourceElement
 slug: Web/API/HTMLSourceElement
-tags:
-  - API
-  - HTML DOM
-  - HTMLSourceElement
-  - Interface
-  - Reference
-translation_of: Web/API/HTMLSourceElement
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/htmlspanelement/index.md
+++ b/files/ja/web/api/htmlspanelement/index.md
@@ -1,10 +1,6 @@
 ---
 title: HTMLSpanElement
 slug: Web/API/HTMLSpanElement
-tags:
-  - DOM
-  - DOM Reference
-translation_of: Web/API/HTMLSpanElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlstyleelement/index.md
+++ b/files/ja/web/api/htmlstyleelement/index.md
@@ -1,11 +1,6 @@
 ---
 title: HTMLStyleElement
 slug: Web/API/HTMLStyleElement
-tags:
-  - DOM
-  - DOM Reference
-  - 要更新
-translation_of: Web/API/HTMLStyleElement
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/htmlstyleelement/media/index.md
+++ b/files/ja/web/api/htmlstyleelement/media/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLStyleElement.media
 slug: Web/API/HTMLStyleElement/media
-tags:
-  - API
-  - HTML DOM
-  - HTMLStyleElement
-  - Media
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/HTMLStyleElement/media
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmltablecaptionelement/index.md
+++ b/files/ja/web/api/htmltablecaptionelement/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLTableCaptionElement
 slug: Web/API/HTMLTableCaptionElement
-tags:
-  - API
-  - HTML DOM
-  - インターフェイス
-  - リファレンス
-browser-compat: api.HTMLTableCaptionElement
-translation_of: Web/API/HTMLTableCaptionElement
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmltablecellelement/index.md
+++ b/files/ja/web/api/htmltablecellelement/index.md
@@ -1,18 +1,6 @@
 ---
 title: HTMLTableCellElement
 slug: Web/API/HTMLTableCellElement
-page-type: web-api-interface
-tags:
-  - API
-  - セル
-  - HTML DOM
-  - HTMLTableCellElement
-  - インターフェイス
-  - リファレンス
-  - 表のセル
-  - 表
-browser-compat: api.HTMLTableCellElement
-translation_of: Web/API/HTMLTableCellElement
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmltablecolelement/index.md
+++ b/files/ja/web/api/htmltablecolelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLTableColElement
 slug: Web/API/HTMLTableColElement
-tags:
-  - API
-  - HTML DOM
-  - インターフェイス
-  - NeedsNewLayout
-  - リファレンス
-browser-compat: api.HTMLTableColElement
-translation_of: Web/API/HTMLTableColElement
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmltableelement/align/index.md
+++ b/files/ja/web/api/htmltableelement/align/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLTableElement.align
 slug: Web/API/HTMLTableElement/align
-tags:
-  - API
-  - 非推奨
-  - HTML DOM
-  - HTMLTableElement
-  - NeedsMarkupWork
-  - NeedsSpecTable
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLTableElement.align
-translation_of: Web/API/HTMLTableElement/align
 ---
 {{APIRef("HTML DOM")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/htmltableelement/bgcolor/index.md
+++ b/files/ja/web/api/htmltableelement/bgcolor/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLTableElement.bgColor
 slug: Web/API/HTMLTableElement/bgColor
-tags:
-  - API
-  - 非推奨
-  - HTML DOM
-  - NeedsBrowserCompatibility
-  - NeedsMarkupWork
-  - NeedsSpecTable
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLTableElement.bgColor
-translation_of: Web/API/HTMLTableElement/bgColor
 ---
 {{APIRef("HTML DOM")}} {{Deprecated_Header}}
 

--- a/files/ja/web/api/htmltableelement/border/index.md
+++ b/files/ja/web/api/htmltableelement/border/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLTableElement.border
 slug: Web/API/HTMLTableElement/border
-tags:
-  - API
-  - Deprecated
-  - HTML DOM
-  - NeedsSpecTable
-  - Property
-  - Reference
-browser-compat: api.HTMLTableElement.border
-translation_of: Web/API/HTMLTableElement/border
 ---
 {{APIRef("HTML DOM")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/htmltableelement/caption/index.md
+++ b/files/ja/web/api/htmltableelement/caption/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLTableElement.caption
 slug: Web/API/HTMLTableElement/caption
-tags:
-  - API
-  - HTML DOM
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLTableElement.caption
-translation_of: Web/API/HTMLTableElement/caption
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmltableelement/cellpadding/index.md
+++ b/files/ja/web/api/htmltableelement/cellpadding/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLTableElement.cellPadding
 slug: Web/API/HTMLTableElement/cellPadding
-tags:
-  - API
-  - HTML DOM
-  - NeedsSpecTable
-  - プロパティ
-  - リファレンス
-  - 非推奨
-browser-compat: api.HTMLTableElement.cellPadding
-translation_of: Web/API/HTMLTableElement/cellPadding
 ---
 {{APIRef("HTML DOM")}} {{Deprecated_Header}}
 

--- a/files/ja/web/api/htmltableelement/cellspacing/index.md
+++ b/files/ja/web/api/htmltableelement/cellspacing/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLTableElement.cellSpacing
 slug: Web/API/HTMLTableElement/cellSpacing
-tags:
-  - API
-  - HTML DOM
-  - HTMLTableElement
-  - NeedsSpecTable
-  - プロパティ
-  - リファレンス
-  - cellSpacing
-  - 非推奨
-browser-compat: api.HTMLTableElement.cellSpacing
-translation_of: Web/API/HTMLTableElement/cellSpacing
 ---
 {{APIRef("HTML DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/htmltableelement/createcaption/index.md
+++ b/files/ja/web/api/htmltableelement/createcaption/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLTableElement.createCaption()
 slug: Web/API/HTMLTableElement/createCaption
-tags:
-  - API
-  - HTML DOM
-  - HTMLTableElement
-  - メソッド
-  - NeedsSpecTable
-  - リファレンス
-browser-compat: api.HTMLTableElement.createCaption
-translation_of: Web/API/HTMLTableElement/createCaption
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmltableelement/createtbody/index.md
+++ b/files/ja/web/api/htmltableelement/createtbody/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLTableElement.createTBody()
 slug: Web/API/HTMLTableElement/createTBody
-tags:
-  - API
-  - HTML DOM
-  - HTMLTableElement
-  - メソッド
-  - NeedsSpecTable
-  - リファレンス
-browser-compat: api.HTMLTableElement.createTBody
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmltableelement/createtfoot/index.md
+++ b/files/ja/web/api/htmltableelement/createtfoot/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLTableElement.createTFoot()
 slug: Web/API/HTMLTableElement/createTFoot
-tags:
-  - API
-  - HTML DOM
-  - HTMLTableElement
-  - メソッド
-  - NeedsSpecTable
-  - リファレンス
-browser-compat: api.HTMLTableElement.createTFoot
-translation_of: Web/API/HTMLTableElement/createTFoot
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmltableelement/createthead/index.md
+++ b/files/ja/web/api/htmltableelement/createthead/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLTableElement.createTHead()
 slug: Web/API/HTMLTableElement/createTHead
-tags:
-  - API
-  - HTML DOM
-  - HTMLTableElement
-  - メソッド
-  - NeedsSpecTable
-  - リファレンス
-browser-compat: api.HTMLTableElement.createTHead
-translation_of: Web/API/HTMLTableElement/createTHead
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmltableelement/deletecaption/index.md
+++ b/files/ja/web/api/htmltableelement/deletecaption/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLTableElement.deleteCaption()
 slug: Web/API/HTMLTableElement/deleteCaption
-tags:
-  - API
-  - HTML DOM
-  - HTMLTableElement
-  - メソッド
-  - NeedsSpecTable
-  - リファレンス
-browser-compat: api.HTMLTableElement.deleteCaption
-translation_of: Web/API/HTMLTableElement/deleteCaption
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmltableelement/deleterow/index.md
+++ b/files/ja/web/api/htmltableelement/deleterow/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLTableElement.deleteRow()
 slug: Web/API/HTMLTableElement/deleteRow
-tags:
-  - API
-  - HTML DOM
-  - HTMLTableElement
-  - メソッド
-  - NeedsSpecTable
-  - リファレンス
-browser-compat: api.HTMLTableElement.deleteRow
-translation_of: Web/API/HTMLTableElement/deleteRow
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmltableelement/deletetfoot/index.md
+++ b/files/ja/web/api/htmltableelement/deletetfoot/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLTableElement.deleteTFoot()
 slug: Web/API/HTMLTableElement/deleteTFoot
-tags:
-  - API
-  - HTML DOM
-  - HTMLTableElement
-  - メソッド
-  - NeedsSpecTable
-  - リファレンス
-browser-compat: api.HTMLTableElement.deleteTFoot
-translation_of: Web/API/HTMLTableElement/deleteTFoot
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmltableelement/deletethead/index.md
+++ b/files/ja/web/api/htmltableelement/deletethead/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLTableElement.deleteTHead()
 slug: Web/API/HTMLTableElement/deleteTHead
-tags:
-  - API
-  - HTML DOM
-  - HTMLTableElement
-  - メソッド
-  - NeedsSpecTable
-  - リファレンス
-browser-compat: api.HTMLTableElement.deleteTHead
-translation_of: Web/API/HTMLTableElement/deleteTHead
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmltableelement/frame/index.md
+++ b/files/ja/web/api/htmltableelement/frame/index.md
@@ -1,18 +1,6 @@
 ---
 title: HTMLTableElement.frame
 slug: Web/API/HTMLTableElement/frame
-tags:
-  - API
-  - HTML DOM
-  - HTMLTableElement
-  - NeedsBrowserCompatibility
-  - NeedsSpecTable
-  - プロパティ
-  - リファレンス
-  - 表
-  - 非推奨
-browser-compat: api.HTMLTableElement.frame
-translation_of: Web/API/HTMLTableElement/frame
 ---
 {{APIRef("HTML DOM")}} {{Deprecated_Header}}
 

--- a/files/ja/web/api/htmltableelement/index.md
+++ b/files/ja/web/api/htmltableelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLTableElement
 slug: Web/API/HTMLTableElement
-page-type: web-api-interface
-tags:
-  - API
-  - HTML DOM
-  - インターフェイス
-  - リファレンス
-browser-compat: api.HTMLTableElement
-translation_of: Web/API/HTMLTableElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmltableelement/insertrow/index.md
+++ b/files/ja/web/api/htmltableelement/insertrow/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLTableElement.insertRow()
 slug: Web/API/HTMLTableElement/insertRow
-tags:
-  - API
-  - HTML DOM
-  - HTMLTableElement
-  - メソッド
-  - NeedsMobileBrowserCompatibility
-  - リファレンス
-browser-compat: api.HTMLTableElement.insertRow
-translation_of: Web/API/HTMLTableElement/insertRow
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmltableelement/rows/index.md
+++ b/files/ja/web/api/htmltableelement/rows/index.md
@@ -1,19 +1,6 @@
 ---
 title: HTMLTableElement.rows
 slug: Web/API/HTMLTableElement/rows
-tags:
-  - API
-  - HTML DOM
-  - HTMLTableElement
-  - NeedsBrowserCompatibility
-  - NeedsSpecTable
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - 表の行
-  - rows
-browser-compat: api.HTMLTableElement.rows
-translation_of: Web/API/HTMLTableElement/rows
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmltableelement/rules/index.md
+++ b/files/ja/web/api/htmltableelement/rules/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLTableElement.rules
 slug: Web/API/HTMLTableElement/rules
-tags:
-  - API
-  - HTML DOM
-  - HTMLTableElement
-  - NeedsBrowserCompatibility
-  - NeedsSpecTable
-  - プロパティ
-  - リファレンス
-  - 非推奨
-browser-compat: api.HTMLTableElement.rules
-translation_of: Web/API/HTMLTableElement/rules
 ---
 {{APIRef("HTML DOM")}} {{Deprecated_Header}}
 

--- a/files/ja/web/api/htmltableelement/summary/index.md
+++ b/files/ja/web/api/htmltableelement/summary/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLTableElement.summary
 slug: Web/API/HTMLTableElement/summary
-tags:
-  - API
-  - HTML DOM
-  - HTMLTableElement
-  - NeedsBrowserCompatibility
-  - NeedsSpecTable
-  - プロパティ
-  - リファレンス
-  - 非推奨
-browser-compat: api.HTMLTableElement.summary
-translation_of: Web/API/HTMLTableElement/summary
 ---
 {{APIRef("HTML DOM")}} {{Deprecated_Header}}
 

--- a/files/ja/web/api/htmltableelement/tbodies/index.md
+++ b/files/ja/web/api/htmltableelement/tbodies/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLTableElement.tBodies
 slug: Web/API/HTMLTableElement/tBodies
-tags:
-  - API
-  - HTML DOM
-  - HTMLTableElement
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.HTMLTableElement.tBodies
-translation_of: Web/API/HTMLTableElement/tBodies
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmltableelement/tfoot/index.md
+++ b/files/ja/web/api/htmltableelement/tfoot/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLTableElement.tFoot
 slug: Web/API/HTMLTableElement/tFoot
-tags:
-  - API
-  - HTML DOM
-  - HTMLTableElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLTableElement.tFoot
-translation_of: Web/API/HTMLTableElement/tFoot
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmltableelement/thead/index.md
+++ b/files/ja/web/api/htmltableelement/thead/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLTableElement.tHead
 slug: Web/API/HTMLTableElement/tHead
-tags:
-  - API
-  - HTML DOM
-  - HTMLTableElement
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLTableElement.tHead
-translation_of: Web/API/HTMLTableElement/tHead
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmltableelement/width/index.md
+++ b/files/ja/web/api/htmltableelement/width/index.md
@@ -1,17 +1,6 @@
 ---
 title: HTMLTableElement.width
 slug: Web/API/HTMLTableElement/width
-tags:
-  - API
-  - HTML DOM
-  - HTMLTableElement
-  - NeedsBrowserCompatibility
-  - NeedsSpecTable
-  - プロパティ
-  - リファレンス
-  - 非推奨
-browser-compat: api.HTMLTableElement.width
-translation_of: Web/API/HTMLTableElement/width
 ---
 {{APIRef("HTML DOM")}} {{Deprecated_Header}}
 

--- a/files/ja/web/api/htmltablerowelement/index.md
+++ b/files/ja/web/api/htmltablerowelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLTableRowElement
 slug: Web/API/HTMLTableRowElement
-page-type: web-api-interface
-tags:
-  - API
-  - HTML DOM
-  - インターフェイス
-  - リファレンス
-browser-compat: api.HTMLTableRowElement
-translation_of: Web/API/HTMLTableRowElement
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmltablerowelement/insertcell/index.md
+++ b/files/ja/web/api/htmltablerowelement/insertcell/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLTableRowElement.insertCell()
 slug: Web/API/HTMLTableRowElement/insertCell
-tags:
-  - API
-  - HTML DOM
-  - HTMLTableRowElement
-  - メソッド
-  - リファレンス
-browser-compat: api.HTMLTableRowElement.insertCell
-translation_of: Web/API/HTMLTableRowElement/insertCell
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmltablerowelement/rowindex/index.md
+++ b/files/ja/web/api/htmltablerowelement/rowindex/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLTableRowElement.rowIndex
 slug: Web/API/HTMLTableRowElement/rowIndex
-tags:
-  - API
-  - HTML DOM
-  - NeedsSpecTable
-  - プロパティ
-  - リファレンス
-browser-compat: api.HTMLTableRowElement.rowIndex
-translation_of: Web/API/HTMLTableRowElement/rowIndex
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmltablesectionelement/index.md
+++ b/files/ja/web/api/htmltablesectionelement/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLTableSectionElement
 slug: Web/API/HTMLTableSectionElement
-tags:
-  - API
-  - HTML DOM
-  - Interface
-  - Reference
-browser-compat: api.HTMLTableSectionElement
-translation_of: Web/API/HTMLTableSectionElement
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmltemplateelement/content/index.md
+++ b/files/ja/web/api/htmltemplateelement/content/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLTemplateElement.content
 slug: Web/API/HTMLTemplateElement/content
-tags:
-  - API
-  - HTML DOM
-  - HTMLTemplateElement
-  - プロパティ
-  - リファレンス
-  - ウェブコンポーネント
-browser-compat: api.HTMLTemplateElement.content
-translation_of: Web/API/HTMLTemplateElement/content
 ---
 {{APIRef("Web Components")}}
 

--- a/files/ja/web/api/htmltemplateelement/index.md
+++ b/files/ja/web/api/htmltemplateelement/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLTemplateElement
 slug: Web/API/HTMLTemplateElement
-tags:
-  - API
-  - HTML DOM
-  - HTMLTemplateElement
-  - インターフェイス
-  - リファレンス
-  - ウェブコンポーネント
-browser-compat: api.HTMLTemplateElement
-translation_of: Web/API/HTMLTemplateElement
 ---
 {{APIRef("Web Components")}}
 

--- a/files/ja/web/api/htmltextareaelement/index.md
+++ b/files/ja/web/api/htmltextareaelement/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLTextAreaElement
 slug: Web/API/HTMLTextAreaElement
-page-type: web-api-interface
-tags:
-  - API
-  - HTML DOM
-  - HTMLTextAreaElement
-  - Interface
-  - Reference
-browser-compat: api.HTMLTextAreaElement
-translation_of: Web/API/HTMLTextAreaElement
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmltimeelement/index.md
+++ b/files/ja/web/api/htmltimeelement/index.md
@@ -1,12 +1,6 @@
 ---
 title: HTMLTimeElement
 slug: Web/API/HTMLTimeElement
-tags:
-  - API
-  - HTML DOM
-  - Interface
-  - Reference
-translation_of: Web/API/HTMLTimeElement
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmltitleelement/index.md
+++ b/files/ja/web/api/htmltitleelement/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLTitleElement
 slug: Web/API/HTMLTitleElement
-translation_of: Web/API/HTMLTitleElement
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/htmltrackelement/cuechange_event/index.md
+++ b/files/ja/web/api/htmltrackelement/cuechange_event/index.md
@@ -1,29 +1,6 @@
 ---
 title: 'HTMLTrackElement: cuechange event'
 slug: Web/API/HTMLTrackElement/cuechange_event
-page-type: web-api-event
-tags:
-  - API
-  - Accessibility
-  - Audio
-  - Chapters
-  - Descriptions
-  - HTMLTextTrack
-  - Media
-  - Reference
-  - Text
-  - TextTrack
-  - Video
-  - WebVTT
-  - a11y
-  - captions
-  - cuechange
-  - events
-  - oncuechange
-  - track
-  - vtt
-browser-compat: api.HTMLTrackElement.cuechange_event
-translation_of: Web/API/HTMLTrackElement/cuechange_event
 ---
 {{APIRef("WebVTT")}}
 

--- a/files/ja/web/api/htmltrackelement/index.md
+++ b/files/ja/web/api/htmltrackelement/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLTrackElement
 slug: Web/API/HTMLTrackElement
-page-type: web-api-interface
-tags:
-  - API
-  - HTML DOM
-  - HTMLTrackElement
-  - Interface
-  - NeedsNewLayout
-  - Reference
-browser-compat: api.HTMLTrackElement
-translation_of: Web/API/HTMLTrackElement
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmltrackelement/src/index.md
+++ b/files/ja/web/api/htmltrackelement/src/index.md
@@ -1,18 +1,6 @@
 ---
 title: HTMLTrackElement.src
 slug: Web/API/HTMLTrackElement/src
-page-type: web-api-instance-property
-tags:
-  - HTML
-  - HTML DOM
-  - HTMLTrackElement
-  - Property
-  - Reference
-  - Web
-  - WebVTT
-  - src
-browser-compat: api.HTMLTrackElement.src
-translation_of: Web/API/HTMLTrackElement/src
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/htmlunknownelement/index.md
+++ b/files/ja/web/api/htmlunknownelement/index.md
@@ -1,12 +1,6 @@
 ---
 title: HTMLUnknownElement
 slug: Web/API/HTMLUnknownElement
-tags:
-  - API
-  - HTML DOM
-  - Interface
-  - Reference
-translation_of: Web/API/HTMLUnknownElement
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/htmlvideoelement/index.md
+++ b/files/ja/web/api/htmlvideoelement/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLVideoElement
 slug: Web/API/HTMLVideoElement
-tags:
-  - API
-  - HTML DOM
-  - HTMLVideoElement
-  - インターフェイス
-  - リファレンス
-  - Video
-browser-compat: api.HTMLVideoElement
-translation_of: Web/API/HTMLVideoElement
 ---
 {{APIRef("HTML DOM")}}
 


### PR DESCRIPTION
Part of #7858

`files/ja/web/api/h*` から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "tags": 348,
  "translation_of": 346,
  "browser-compat": 290,
  "page-type": 165,
  "translation_of_original": 1
}
```
