### PR TITLE
remove duplicated frontmatter keys from web/api/{i-m}* (ja)

### DIFF
--- a/files/ja/web/api/idbcursor/advance/index.md
+++ b/files/ja/web/api/idbcursor/advance/index.md
@@ -1,16 +1,6 @@
 ---
 title: IDBCursor.advance()
 slug: Web/API/IDBCursor/advance
-tags:
-  - API
-  - Database
-  - IDBCursor
-  - IndexedDB
-  - Method
-  - Reference
-  - Storage
-  - advance
-translation_of: Web/API/IDBCursor/advance
 ---
 {{APIRef("IndexedDB")}}
 

--- a/files/ja/web/api/idbcursor/continue/index.md
+++ b/files/ja/web/api/idbcursor/continue/index.md
@@ -1,16 +1,6 @@
 ---
 title: IDBCursor.continue()
 slug: Web/API/IDBCursor/continue
-tags:
-  - API
-  - Database
-  - IDBCursor
-  - IndexedDB
-  - Reference
-  - continue
-  - ストレージ
-  - メソッド
-translation_of: Web/API/IDBCursor/continue
 ---
 {{APIRef("IndexedDB")}}
 

--- a/files/ja/web/api/idbcursor/index.md
+++ b/files/ja/web/api/idbcursor/index.md
@@ -1,17 +1,6 @@
 ---
 title: IDBCursor
 slug: Web/API/IDBCursor
-tags:
-  - API
-  - Database
-  - IDBCursor
-  - IndexedDB
-  - Interface
-  - NeedsTranslation
-  - Reference
-  - Storage
-  - TopicStub
-translation_of: Web/API/IDBCursor
 ---
 {{APIRef("IndexedDB")}}
 

--- a/files/ja/web/api/idbdatabase/close/index.md
+++ b/files/ja/web/api/idbdatabase/close/index.md
@@ -1,15 +1,6 @@
 ---
 title: IDBDatabase.close
 slug: Web/API/IDBDatabase/close
-tags:
-  - API
-  - Database
-  - IDBDatabase
-  - IndexedDB
-  - Method
-  - Storage
-  - close
-translation_of: Web/API/IDBDatabase/close
 ---
 {{ APIRef("IDBDatabase") }}
 

--- a/files/ja/web/api/idbdatabase/createobjectstore/index.md
+++ b/files/ja/web/api/idbdatabase/createobjectstore/index.md
@@ -1,14 +1,6 @@
 ---
 title: IDBDatabase.createObjectStore
 slug: Web/API/IDBDatabase/createObjectStore
-tags:
-  - API
-  - Database
-  - IDBDatabase
-  - IndexedDB
-  - Storage
-  - createObjectStore
-translation_of: Web/API/IDBDatabase/createObjectStore
 ---
 {{ APIRef("IDBDatabase") }}
 

--- a/files/ja/web/api/idbdatabase/index.md
+++ b/files/ja/web/api/idbdatabase/index.md
@@ -1,14 +1,6 @@
 ---
 title: IDBDatabase
 slug: Web/API/IDBDatabase
-tags:
-  - API
-  - Database
-  - IDBDatabase
-  - IndexedDB
-  - Storage
-  - transactions
-translation_of: Web/API/IDBDatabase
 ---
 {{APIRef()}}
 

--- a/files/ja/web/api/idbdatabase/name/index.md
+++ b/files/ja/web/api/idbdatabase/name/index.md
@@ -1,14 +1,6 @@
 ---
 title: IDBDatabase.name
 slug: Web/API/IDBDatabase/name
-tags:
-  - Database
-  - IDBDatabase
-  - IndexedDB
-  - Property
-  - Storage
-  - name
-translation_of: Web/API/IDBDatabase/name
 ---
 {{ APIRef("IDBDatabase") }}
 

--- a/files/ja/web/api/idbdatabase/objectstorenames/index.md
+++ b/files/ja/web/api/idbdatabase/objectstorenames/index.md
@@ -1,14 +1,6 @@
 ---
 title: IDBDatabase.objectStoreNames
 slug: Web/API/IDBDatabase/objectStoreNames
-tags:
-  - Database
-  - IDBDatabase
-  - IndexedDB
-  - Property
-  - Storage
-  - objectStoreNames
-translation_of: Web/API/IDBDatabase/objectStoreNames
 ---
 {{ APIRef("IDBDatabase") }}
 

--- a/files/ja/web/api/idbdatabase/version/index.md
+++ b/files/ja/web/api/idbdatabase/version/index.md
@@ -1,14 +1,6 @@
 ---
 title: IDBDatabase.version
 slug: Web/API/IDBDatabase/version
-tags:
-  - Database
-  - IDBDatabase
-  - IndexedDB
-  - Property
-  - Storage
-  - version
-translation_of: Web/API/IDBDatabase/version
 ---
 {{ APIRef("IDBDatabase") }}
 

--- a/files/ja/web/api/idbfactory/cmp/index.md
+++ b/files/ja/web/api/idbfactory/cmp/index.md
@@ -1,14 +1,6 @@
 ---
 title: IDBFactory.cmp
 slug: Web/API/IDBFactory/cmp
-tags:
-  - API
-  - Database
-  - IDBFactory
-  - IndexedDB
-  - Storage
-  - cmp
-translation_of: Web/API/IDBFactory/cmp
 ---
 {{ APIRef("IDBFactory") }}
 

--- a/files/ja/web/api/idbfactory/deletedatabase/index.md
+++ b/files/ja/web/api/idbfactory/deletedatabase/index.md
@@ -1,13 +1,6 @@
 ---
 title: IDBFactory.deleteDatabase
 slug: Web/API/IDBFactory/deleteDatabase
-tags:
-  - API
-  - IDBFactory
-  - IndexedDB
-  - Storage
-  - deleteDatabase
-translation_of: Web/API/IDBFactory/deleteDatabase
 ---
 {{ APIRef("IDBFactory") }}
 

--- a/files/ja/web/api/idbfactory/index.md
+++ b/files/ja/web/api/idbfactory/index.md
@@ -1,15 +1,6 @@
 ---
 title: IDBFactory
 slug: Web/API/IDBFactory
-tags:
-  - API
-  - HTTP
-  - IndexedDB
-  - Interface
-  - Offline
-  - Reference
-  - Storage
-translation_of: Web/API/IDBFactory
 ---
 {{APIRef("IndexedDB")}}
 

--- a/files/ja/web/api/idbfactory/open/index.md
+++ b/files/ja/web/api/idbfactory/open/index.md
@@ -1,12 +1,6 @@
 ---
 title: IDBFactory.open
 slug: Web/API/IDBFactory/open
-tags:
-  - Database
-  - IDBFactory
-  - Storage
-  - open
-translation_of: Web/API/IDBFactory/open
 ---
 {{APIRef("IDBFactory")}}
 

--- a/files/ja/web/api/idbrequest/index.md
+++ b/files/ja/web/api/idbrequest/index.md
@@ -1,17 +1,6 @@
 ---
 title: IDBRequest
 slug: Web/API/IDBRequest
-tags:
-  - API
-  - Database
-  - IDBRequest
-  - IndexedDB
-  - Interface
-  - NeedsTranslation
-  - Reference
-  - Storage
-  - TopicStub
-translation_of: Web/API/IDBRequest
 ---
 {{APIRef("IndexedDB")}}
 

--- a/files/ja/web/api/idbrequest/success_event/index.md
+++ b/files/ja/web/api/idbrequest/success_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: 'IDBRequest: success event'
 slug: Web/API/IDBRequest/success_event
-translation_of: Web/API/IDBRequest/success_event
 ---
 {{ APIRef("IndexedDB") }}
 

--- a/files/ja/web/api/idbtransaction/complete_event/index.md
+++ b/files/ja/web/api/idbtransaction/complete_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: complete
 slug: Web/API/IDBTransaction/complete_event
-tags:
-  - Event
-  - IDBTransaction
-  - Reference
-  - complete
-  - イベント
-translation_of: Web/API/IDBTransaction/complete_event
 ---
 {{APIRef("IndexedDB")}}
 

--- a/files/ja/web/api/idbtransaction/index.md
+++ b/files/ja/web/api/idbtransaction/index.md
@@ -1,15 +1,6 @@
 ---
 title: IDBTransaction
 slug: Web/API/IDBTransaction
-tags:
-  - API
-  - Database
-  - IDBTransaction
-  - IndexedDB
-  - Interface
-  - Reference
-  - Storage
-translation_of: Web/API/IDBTransaction
 ---
 {{APIRef("IndexedDB")}}
 

--- a/files/ja/web/api/imagedata/index.md
+++ b/files/ja/web/api/imagedata/index.md
@@ -1,12 +1,6 @@
 ---
 title: ImageData
 slug: Web/API/ImageData
-tags:
-  - API
-  - Canvas
-  - ImageData
-  - Images
-translation_of: Web/API/ImageData
 ---
 {{APIRef("Canvas API")}}
 

--- a/files/ja/web/api/indexeddb/index.md
+++ b/files/ja/web/api/indexeddb/index.md
@@ -1,14 +1,6 @@
 ---
 title: WindowOrWorkerGlobalScope.indexedDB
 slug: Web/API/indexedDB
-tags:
-  - API
-  - Database
-  - IndexedDB
-  - Property
-  - Reference
-  - Storage
-translation_of: Web/API/WindowOrWorkerGlobalScope/indexedDB
 original_slug: Web/API/WindowOrWorkerGlobalScope/indexedDB
 ---
 {{ APIRef() }}

--- a/files/ja/web/api/indexeddb_api/basic_terminology/index.md
+++ b/files/ja/web/api/indexeddb_api/basic_terminology/index.md
@@ -1,11 +1,6 @@
 ---
 title: IndexedDB の主な特徴と基本用語
 slug: Web/API/IndexedDB_API/Basic_Terminology
-tags:
-  - Advanced
-  - IndexedDB
-  - terminology
-translation_of: Web/API/IndexedDB_API/Basic_Terminology
 ---
 {{DefaultAPISidebar("IndexedDB")}}
 

--- a/files/ja/web/api/indexeddb_api/browser_storage_limits_and_eviction_criteria/index.md
+++ b/files/ja/web/api/indexeddb_api/browser_storage_limits_and_eviction_criteria/index.md
@@ -1,15 +1,6 @@
 ---
 title: ブラウザーのストレージ制限と削除基準
 slug: Web/API/IndexedDB_API/Browser_storage_limits_and_eviction_criteria
-tags:
-  - Database
-  - IndexedDB
-  - LRU
-  - Storage
-  - client-side
-  - eviction
-  - limit
-translation_of: Web/API/IndexedDB_API/Browser_storage_limits_and_eviction_criteria
 ---
 {{DefaultAPISidebar("IndexedDB")}}
 

--- a/files/ja/web/api/indexeddb_api/checking_when_a_deadline_is_due/index.md
+++ b/files/ja/web/api/indexeddb_api/checking_when_a_deadline_is_due/index.md
@@ -1,14 +1,6 @@
 ---
 title: 期限の確認
 slug: Web/API/IndexedDB_API/Checking_when_a_deadline_is_due
-tags:
-  - Apps
-  - Date
-  - Example
-  - Guide
-  - IndexedDB
-  - deadline
-translation_of: Web/API/IndexedDB_API/Checking_when_a_deadline_is_due
 ---
 {{DefaultAPISidebar("IndexedDB")}}
 

--- a/files/ja/web/api/indexeddb_api/index.md
+++ b/files/ja/web/api/indexeddb_api/index.md
@@ -1,15 +1,6 @@
 ---
 title: IndexedDB API
 slug: Web/API/IndexedDB_API
-tags:
-  - API
-  - Advanced
-  - Database
-  - IndexedDB
-  - Landing
-  - Reference
-  - Storage
-translation_of: Web/API/IndexedDB_API
 ---
 {{DefaultAPISidebar("IndexedDB")}}
 

--- a/files/ja/web/api/indexeddb_api/using_indexeddb/index.md
+++ b/files/ja/web/api/indexeddb_api/using_indexeddb/index.md
@@ -1,16 +1,6 @@
 ---
 title: IndexedDB の使用
 slug: Web/API/IndexedDB_API/Using_IndexedDB
-tags:
-  - API
-  - Advanced
-  - Database
-  - Guide
-  - IndexedDB
-  - Storage
-  - Tutorial
-  - jsstore
-translation_of: Web/API/IndexedDB_API/Using_IndexedDB
 ---
 {{DefaultAPISidebar("IndexedDB")}}
 

--- a/files/ja/web/api/inputevent/index.md
+++ b/files/ja/web/api/inputevent/index.md
@@ -1,11 +1,6 @@
 ---
 title: InputEvent
 slug: Web/API/InputEvent
-tags:
-  - API
-  - DOM
-  - Interface
-translation_of: Web/API/InputEvent
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/inputevent/inputtype/index.md
+++ b/files/ja/web/api/inputevent/inputtype/index.md
@@ -1,18 +1,6 @@
 ---
 title: InputEvent.inputType
 slug: Web/API/InputEvent/inputType
-tags:
-  - API
-  - DOM
-  - DOM Events
-  - Input
-  - InputEvent
-  - Property
-  - Reference
-  - events
-  - inputType
-  - プロパティ
-translation_of: Web/API/InputEvent/inputType
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/intersection_observer_api/index.md
+++ b/files/ja/web/api/intersection_observer_api/index.md
@@ -1,17 +1,6 @@
 ---
 title: 交差オブザーバー API
 slug: Web/API/Intersection_Observer_API
-tags:
-  - API
-  - Clipping
-  - 交差
-  - 交差オブザーバー API
-  - IntersectionObserver
-  - 概要
-  - パフォーマンス
-  - リファレンス
-  - ウェブ
-translation_of: Web/API/Intersection_Observer_API
 ---
 {{DefaultAPISidebar("Intersection Observer API")}}
 

--- a/files/ja/web/api/intersection_observer_api/timing_element_visibility/index.md
+++ b/files/ja/web/api/intersection_observer_api/timing_element_visibility/index.md
@@ -1,14 +1,6 @@
 ---
 title: Intersection Observer API を使用したタイミング要素の可視性
 slug: Web/API/Intersection_Observer_API/Timing_element_visibility
-tags:
-  - API
-  - Intersection Observer
-  - Intersection Observer API
-  - チュートリアル
-  - 中級
-  - 例
-translation_of: Web/API/Intersection_Observer_API/Timing_element_visibility
 ---
 {{DefaultAPISidebar("Intersection Observer API")}}
 

--- a/files/ja/web/api/intersectionobserver/disconnect/index.md
+++ b/files/ja/web/api/intersectionobserver/disconnect/index.md
@@ -1,16 +1,6 @@
 ---
 title: IntersectionObserver.disconnect()
 slug: Web/API/IntersectionObserver/disconnect
-tags:
-  - API
-  - Disconnect
-  - Intersection Observer
-  - Intersection Observer API
-  - IntersectionObserver
-  - Method
-  - Reference
-  - メソッド
-translation_of: Web/API/IntersectionObserver/disconnect
 ---
 {{APIRef("Intersection Observer API")}}
 

--- a/files/ja/web/api/intersectionobserver/index.md
+++ b/files/ja/web/api/intersectionobserver/index.md
@@ -1,16 +1,6 @@
 ---
 title: IntersectionObserver
 slug: Web/API/IntersectionObserver
-tags:
-  - API
-  - Experimental
-  - Intersection Observer API
-  - IntersectionObserver
-  - Reference
-  - インターフェイス
-  - リファレンス
-  - 実験的
-translation_of: Web/API/IntersectionObserver
 ---
 {{APIRef("Intersection Observer API")}}
 

--- a/files/ja/web/api/intersectionobserver/intersectionobserver/index.md
+++ b/files/ja/web/api/intersectionobserver/intersectionobserver/index.md
@@ -1,15 +1,6 @@
 ---
 title: IntersectionObserver.IntersectionObserver()
 slug: Web/API/IntersectionObserver/IntersectionObserver
-tags:
-  - API
-  - Constructor
-  - Intersection Observer API
-  - IntersectionObserver
-  - Reference
-  - Visibility
-  - Visible
-translation_of: Web/API/IntersectionObserver/IntersectionObserver
 ---
 {{APIRef("Intersection Observer API")}}
 

--- a/files/ja/web/api/intersectionobserver/observe/index.md
+++ b/files/ja/web/api/intersectionobserver/observe/index.md
@@ -1,15 +1,6 @@
 ---
 title: IntersectionObserver.observe()
 slug: Web/API/IntersectionObserver/observe
-tags:
-  - API
-  - Intersection Observer
-  - Intersection Observer API
-  - IntersectionObserver
-  - Method
-  - Reference
-  - observe
-translation_of: Web/API/IntersectionObserver/observe
 ---
 {{APIRef("Intersection Observer API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/intersectionobserver/takerecords/index.md
+++ b/files/ja/web/api/intersectionobserver/takerecords/index.md
@@ -1,17 +1,6 @@
 ---
 title: IntersectionObserver.takeRecords()
 slug: Web/API/IntersectionObserver/takeRecords
-tags:
-  - API
-  - Intersection Observer
-  - Intersection Observer API
-  - IntersectionObserver
-  - Method
-  - NeedsExample
-  - Reference
-  - takeRecords
-  - メソッド
-translation_of: Web/API/IntersectionObserver/takeRecords
 ---
 {{APIRef("Intersection Observer API")}}
 

--- a/files/ja/web/api/intersectionobserverentry/index.md
+++ b/files/ja/web/api/intersectionobserverentry/index.md
@@ -1,7 +1,6 @@
 ---
 title: IntersectionObserverEntry
 slug: Web/API/IntersectionObserverEntry
-translation_of: Web/API/IntersectionObserverEntry
 ---
 {{SeeCompatTable}}{{APIRef("Intersection Observer API")}}
 

--- a/files/ja/web/api/issecurecontext/index.md
+++ b/files/ja/web/api/issecurecontext/index.md
@@ -1,17 +1,6 @@
 ---
 title: WindowOrWorkerGlobalScope.isSecureContext
 slug: Web/API/isSecureContext
-tags:
-  - API
-  - DOM
-  - Window
-  - WindowOrWorkerGlobalContext
-  - Workers
-  - isSecureContext
-  - ウェブ
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/WindowOrWorkerGlobalScope/isSecureContext
 original_slug: Web/API/WindowOrWorkerGlobalScope/isSecureContext
 ---
 {{APIRef()}}{{SeeCompatTable}}

--- a/files/ja/web/api/keyboardevent/altkey/index.md
+++ b/files/ja/web/api/keyboardevent/altkey/index.md
@@ -1,16 +1,6 @@
 ---
 title: KeyboardEvent.altKey
 slug: Web/API/KeyboardEvent/altKey
-page-type: web-api-instance-property
-tags:
-  - API
-  - DOM
-  - KeyboardEvent
-  - Property
-  - Read-only
-  - Reference
-browser-compat: api.KeyboardEvent.altKey
-translation_of: Web/API/KeyboardEvent/altKey
 ---
 {{APIRef("UI Events")}}
 

--- a/files/ja/web/api/keyboardevent/charcode/index.md
+++ b/files/ja/web/api/keyboardevent/charcode/index.md
@@ -1,16 +1,6 @@
 ---
 title: KeyboardEvent.charCode
 slug: Web/API/KeyboardEvent/charCode
-page-type: web-api-instance-property
-tags:
-  - API
-  - DOM
-  - Deprecated
-  - KeyboardEvent
-  - Property
-  - Reference
-browser-compat: api.KeyboardEvent.charCode
-translation_of: Web/API/KeyboardEvent/charCode
 ---
 {{APIRef("UI Events")}} {{non-standard_header}} {{deprecated_header}}
 

--- a/files/ja/web/api/keyboardevent/code/index.md
+++ b/files/ja/web/api/keyboardevent/code/index.md
@@ -1,19 +1,6 @@
 ---
 title: KeyboardEvent.code
 slug: Web/API/KeyboardEvent/code
-page-type: web-api-instance-property
-tags:
-  - API
-  - Code
-  - DOM
-  - DOM Events
-  - KeyboardEvent
-  - Property
-  - Read-only
-  - Reference
-  - UI Events
-browser-compat: api.KeyboardEvent.code
-translation_of: Web/API/KeyboardEvent/code
 ---
 {{APIRef("UI Events")}}
 

--- a/files/ja/web/api/keyboardevent/ctrlkey/index.md
+++ b/files/ja/web/api/keyboardevent/ctrlkey/index.md
@@ -1,16 +1,6 @@
 ---
 title: KeyboardEvent.ctrlKey
 slug: Web/API/KeyboardEvent/ctrlKey
-page-type: web-api-instance-property
-tags:
-  - API
-  - DOM
-  - KeyboardEvent
-  - Property
-  - Read-only
-  - Reference
-browser-compat: api.KeyboardEvent.ctrlKey
-translation_of: Web/API/KeyboardEvent/ctrlKey
 ---
 {{APIRef("UI Events")}}
 

--- a/files/ja/web/api/keyboardevent/getmodifierstate/index.md
+++ b/files/ja/web/api/keyboardevent/getmodifierstate/index.md
@@ -1,16 +1,6 @@
 ---
 title: KeyboardEvent.getModifierState()
 slug: Web/API/KeyboardEvent/getModifierState
-page-type: web-api-instance-method
-tags:
-  - API
-  - DOM
-  - KeyboardEvent
-  - Method
-  - Reference
-  - getModifierState
-browser-compat: api.KeyboardEvent.getModifierState
-translation_of: Web/API/KeyboardEvent/getModifierState
 ---
 {{APIRef("UI Events")}}
 

--- a/files/ja/web/api/keyboardevent/index.md
+++ b/files/ja/web/api/keyboardevent/index.md
@@ -1,23 +1,6 @@
 ---
 title: KeyboardEvent
 slug: Web/API/KeyboardEvent
-page-type: web-api-interface
-tags:
-  - API
-  - DOM
-  - Event
-  - Input
-  - Interface
-  - Key Events
-  - Keyboard Events
-  - KeyboardEvent
-  - MakeBrowserAgnostic
-  - Reference
-  - UI Events
-  - keyboard
-  - user input
-browser-compat: api.KeyboardEvent
-translation_of: Web/API/KeyboardEvent
 ---
 {{APIRef("UI Events")}}
 

--- a/files/ja/web/api/keyboardevent/initkeyboardevent/index.md
+++ b/files/ja/web/api/keyboardevent/initkeyboardevent/index.md
@@ -1,15 +1,6 @@
 ---
 title: KeyboardEvent.initKeyboardEvent()
 slug: Web/API/KeyboardEvent/initKeyboardEvent
-page-type: web-api-instance-method
-tags:
-  - API
-  - Deprecated
-  - KeyboardEvent
-  - Method
-  - Reference
-browser-compat: api.KeyboardEvent.initKeyboardEvent
-translation_of: Web/API/KeyboardEvent/initKeyboardEvent
 ---
 {{APIRef("UI Events")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/keyboardevent/initkeyevent/index.md
+++ b/files/ja/web/api/keyboardevent/initkeyevent/index.md
@@ -1,16 +1,6 @@
 ---
 title: KeyboardEvent.initKeyEvent()
 slug: Web/API/KeyboardEvent/initKeyEvent
-page-type: web-api-instance-method
-tags:
-  - API
-  - DOM
-  - Deprecated
-  - KeyboardEvent
-  - Method
-  - Reference
-  - Non Standard
-translation_of: Web/API/KeyboardEvent/initKeyEvent
 ---
 {{APIRef("UI Events")}}
 

--- a/files/ja/web/api/keyboardevent/iscomposing/index.md
+++ b/files/ja/web/api/keyboardevent/iscomposing/index.md
@@ -1,16 +1,6 @@
 ---
 title: KeyboardEvent.isComposing
 slug: Web/API/KeyboardEvent/isComposing
-page-type: web-api-instance-property
-tags:
-  - API
-  - DOM
-  - KeyboardEvent
-  - Property
-  - Read-only
-  - Reference
-browser-compat: api.KeyboardEvent.isComposing
-translation_of: Web/API/KeyboardEvent/isComposing
 ---
 {{APIRef("UI Events")}}
 

--- a/files/ja/web/api/keyboardevent/key/index.md
+++ b/files/ja/web/api/keyboardevent/key/index.md
@@ -1,17 +1,6 @@
 ---
 title: KeyboardEvent.key
 slug: Web/API/KeyboardEvent/key
-page-type: web-api-instance-property
-tags:
-  - API
-  - DOM
-  - KeyboardEvent
-  - Property
-  - Read-only
-  - Reference
-  - UI Events
-browser-compat: api.KeyboardEvent.key
-translation_of: Web/API/KeyboardEvent/key
 ---
 {{APIRef("UI Events")}}
 

--- a/files/ja/web/api/keyboardevent/keyboardevent/index.md
+++ b/files/ja/web/api/keyboardevent/keyboardevent/index.md
@@ -1,15 +1,6 @@
 ---
 title: KeyboardEvent()
 slug: Web/API/KeyboardEvent/KeyboardEvent
-page-type: web-api-constructor
-tags:
-  - API
-  - Constructor
-  - DOM
-  - KeyboardEvent
-  - Reference
-browser-compat: api.KeyboardEvent.KeyboardEvent
-translation_of: Web/API/KeyboardEvent/KeyboardEvent
 ---
 {{APIRef("UI Events")}}
 

--- a/files/ja/web/api/keyboardevent/keycode/index.md
+++ b/files/ja/web/api/keyboardevent/keycode/index.md
@@ -1,19 +1,6 @@
 ---
 title: KeyboardEvent.keyCode
 slug: Web/API/KeyboardEvent/keyCode
-page-type: web-api-instance-property
-tags:
-  - API
-  - DOM
-  - DOM Events
-  - Deprecated
-  - KeyboardEvent
-  - Property
-  - Read-only
-  - Reference
-  - keyCode
-browser-compat: api.KeyboardEvent.keyCode
-translation_of: Web/API/KeyboardEvent/keyCode
 ---
 {{APIRef("UI Events")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/keyboardevent/keyidentifier/index.md
+++ b/files/ja/web/api/keyboardevent/keyidentifier/index.md
@@ -1,17 +1,6 @@
 ---
 title: KeyboardEvent.keyIdentifier
 slug: Web/API/KeyboardEvent/keyIdentifier
-page-type: web-api-instance-property
-tags:
-  - API
-  - DOM
-  - Deprecated
-  - Non-standard
-  - Property
-  - Reference
-  - events
-browser-compat: api.KeyboardEvent.keyIdentifier
-translation_of: Web/API/KeyboardEvent/keyIdentifier
 ---
 {{APIRef("UI Events")}}{{non-standard_header}}{{deprecated_header}}
 

--- a/files/ja/web/api/keyboardevent/location/index.md
+++ b/files/ja/web/api/keyboardevent/location/index.md
@@ -1,16 +1,6 @@
 ---
 title: KeyboardEvent.location
 slug: Web/API/KeyboardEvent/location
-page-type: web-api-instance-property
-tags:
-  - API
-  - DOM
-  - KeyboardEvent
-  - Property
-  - Read-only
-  - Reference
-browser-compat: api.KeyboardEvent.location
-translation_of: Web/API/KeyboardEvent/location
 ---
 {{APIRef("UI Events")}}
 

--- a/files/ja/web/api/keyboardevent/metakey/index.md
+++ b/files/ja/web/api/keyboardevent/metakey/index.md
@@ -1,16 +1,6 @@
 ---
 title: KeyboardEvent.metaKey
 slug: Web/API/KeyboardEvent/metaKey
-page-type: web-api-instance-property
-tags:
-  - API
-  - DOM
-  - MouseEvent
-  - Property
-  - Read-only
-  - Reference
-browser-compat: api.KeyboardEvent.metaKey
-translation_of: Web/API/KeyboardEvent/metaKey
 ---
 {{APIRef("UI Events")}}
 

--- a/files/ja/web/api/keyboardevent/repeat/index.md
+++ b/files/ja/web/api/keyboardevent/repeat/index.md
@@ -1,16 +1,6 @@
 ---
 title: KeyboardEvent.repeat
 slug: Web/API/KeyboardEvent/repeat
-page-type: web-api-instance-property
-tags:
-  - API
-  - DOM
-  - KeyboardEvent
-  - Property
-  - Read-only
-  - Reference
-browser-compat: api.KeyboardEvent.repeat
-translation_of: Web/API/KeyboardEvent/repeat
 ---
 {{APIRef("UI Events")}}
 

--- a/files/ja/web/api/keyboardevent/shiftkey/index.md
+++ b/files/ja/web/api/keyboardevent/shiftkey/index.md
@@ -1,16 +1,6 @@
 ---
 title: KeyboardEvent.shiftKey
 slug: Web/API/KeyboardEvent/shiftKey
-page-type: web-api-instance-property
-tags:
-  - API
-  - DOM
-  - KeyboardEvent
-  - Property
-  - Read-only
-  - Reference
-browser-compat: api.KeyboardEvent.shiftKey
-translation_of: Web/API/KeyboardEvent/shiftKey
 ---
 {{APIRef("UI Events")}}
 

--- a/files/ja/web/api/keyframeeffect/keyframeeffect/index.md
+++ b/files/ja/web/api/keyframeeffect/keyframeeffect/index.md
@@ -1,7 +1,6 @@
 ---
 title: EffectTiming
 slug: Web/API/KeyframeEffect/KeyframeEffect
-translation_of: Web/API/EffectTiming
 original_slug: Web/API/EffectTiming
 ---
 {{ SeeCompatTable() }}{{ APIRef("Web Animations") }}

--- a/files/ja/web/api/location/ancestororigins/index.md
+++ b/files/ja/web/api/location/ancestororigins/index.md
@@ -1,13 +1,6 @@
 ---
 title: location.ancestorOrigins
 slug: Web/API/Location/ancestorOrigins
-tags:
-  - API
-  - Location
-  - プロパティ
-  - リファレンス
-browser-compat: api.Location.ancestorOrigins
-translation_of: Web/API/Location/ancestorOrigins
 ---
 {{APIRef("Location")}}
 

--- a/files/ja/web/api/location/assign/index.md
+++ b/files/ja/web/api/location/assign/index.md
@@ -1,14 +1,6 @@
 ---
 title: location.assign()
 slug: Web/API/Location/assign
-tags:
-  - API
-  - HTML DOM
-  - Location
-  - メソッド
-  - リファレンス
-browser-compat: api.Location.assign
-translation_of: Web/API/Location/assign
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/location/hash/index.md
+++ b/files/ja/web/api/location/hash/index.md
@@ -1,13 +1,6 @@
 ---
 title: location.hash
 slug: Web/API/Location/hash
-tags:
-  - API
-  - Location
-  - プロパティ
-  - リファレンス
-browser-compat: api.Location.hash
-translation_of: Web/API/Location/hash
 ---
 {{ APIRef("Location") }}
 

--- a/files/ja/web/api/location/host/index.md
+++ b/files/ja/web/api/location/host/index.md
@@ -1,13 +1,6 @@
 ---
 title: location.host
 slug: Web/API/Location/host
-tags:
-  - API
-  - Location
-  - プロパティ
-  - リファレンス
-browser-compat: api.Location.host
-translation_of: Web/API/Location/host
 ---
 {{ApiRef("Location")}}
 

--- a/files/ja/web/api/location/hostname/index.md
+++ b/files/ja/web/api/location/hostname/index.md
@@ -1,13 +1,6 @@
 ---
 title: location.hostname
 slug: Web/API/Location/hostname
-tags:
-  - API
-  - Location
-  - プロパティ
-  - リファレンス
-browser-compat: api.Location.hostname
-translation_of: Web/API/Location/hostname
 ---
 {{ApiRef("URL API")}}
 

--- a/files/ja/web/api/location/href/index.md
+++ b/files/ja/web/api/location/href/index.md
@@ -1,13 +1,6 @@
 ---
 title: location.href
 slug: Web/API/Location/href
-tags:
-  - API
-  - Location
-  - プロパティ
-  - リファレンス
-browser-compat: api.Location.href
-translation_of: Web/API/Location/href
 ---
 {{ApiRef("Location")}}
 

--- a/files/ja/web/api/location/index.md
+++ b/files/ja/web/api/location/index.md
@@ -1,14 +1,6 @@
 ---
 title: Location
 slug: Web/API/Location
-tags:
-  - API
-  - HTML DOM
-  - インターフェイス
-  - Location
-  - リファレンス
-browser-compat: api.Location
-translation_of: Web/API/Location
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/location/origin/index.md
+++ b/files/ja/web/api/location/origin/index.md
@@ -1,13 +1,6 @@
 ---
 title: location.origin
 slug: Web/API/Location/origin
-tags:
-  - API
-  - Location
-  - プロパティ
-  - リファレンス
-browser-compat: api.Location.origin
-translation_of: Web/API/Location/origin
 ---
 {{APIRef("Location")}}
 

--- a/files/ja/web/api/location/password/index.md
+++ b/files/ja/web/api/location/password/index.md
@@ -1,13 +1,6 @@
 ---
 title: location.password
 slug: Web/API/Location/password
-tags:
-  - API
-  - Location
-  - プロパティ
-  - リファレンス
-browser-compat: api.Location.password
-translation_of: Web/API/Location/password
 ---
 {{deprecated_header}}
 

--- a/files/ja/web/api/location/pathname/index.md
+++ b/files/ja/web/api/location/pathname/index.md
@@ -1,13 +1,6 @@
 ---
 title: location.pathname
 slug: Web/API/Location/pathname
-tags:
-  - API
-  - Location
-  - プロパティ
-  - リファレンス
-browser-compat: api.Location.pathname
-translation_of: Web/API/Location/pathname
 ---
 {{ApiRef("Location")}}
 

--- a/files/ja/web/api/location/port/index.md
+++ b/files/ja/web/api/location/port/index.md
@@ -1,13 +1,6 @@
 ---
 title: location.port
 slug: Web/API/Location/port
-tags:
-  - API
-  - Location
-  - プロパティ
-  - リファレンス
-browser-compat: api.Location.port
-translation_of: Web/API/Location/port
 ---
 {{ApiRef("Location")}}
 

--- a/files/ja/web/api/location/protocol/index.md
+++ b/files/ja/web/api/location/protocol/index.md
@@ -1,13 +1,6 @@
 ---
 title: location.protocol
 slug: Web/API/Location/protocol
-tags:
-  - API
-  - Location
-  - プロパティ
-  - リファレンス
-browser-compat: api.Location.protocol
-tranalation_of: Web/API/Location/protocol
 ---
 {{ApiRef("Location")}}
 

--- a/files/ja/web/api/location/reload/index.md
+++ b/files/ja/web/api/location/reload/index.md
@@ -1,14 +1,6 @@
 ---
 title: location.reload()
 slug: Web/API/Location/reload
-tags:
-  - API
-  - HTML DOM
-  - Location
-  - メソッド
-  - リファレンス
-browser-compat: api.Location.reload
-translation_of: Web/API/Location/reload
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/location/replace/index.md
+++ b/files/ja/web/api/location/replace/index.md
@@ -1,14 +1,6 @@
 ---
 title: location.replace()
 slug: Web/API/Location/replace
-tags:
-  - API
-  - HTML DOM
-  - Location
-  - メソッド
-  - リファレンス
-browser-compat: api.Location.replace
-translation_of: Web/API/Location/replace
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/location/search/index.md
+++ b/files/ja/web/api/location/search/index.md
@@ -1,12 +1,6 @@
 ---
 title: location.search
 slug: Web/API/Location/search
-tags:
-  - API
-  - Location
-  - プロパティ
-browser-compat: api.Location.search
-translation_of: Web/API/Location/search
 ---
 {{ApiRef("Location")}}
 

--- a/files/ja/web/api/location/tostring/index.md
+++ b/files/ja/web/api/location/tostring/index.md
@@ -1,14 +1,6 @@
 ---
 title: location.toString()
 slug: Web/API/Location/toString
-tags:
-  - API
-  - Location
-  - メソッド
-  - リファレンス
-  - Stringifier
-browser-compat: api.Location.toString
-translation_of: Web/API/Location/toString
 ---
 {{ApiRef("Location")}}
 

--- a/files/ja/web/api/location/username/index.md
+++ b/files/ja/web/api/location/username/index.md
@@ -1,13 +1,6 @@
 ---
 title: location.username
 slug: Web/API/Location/username
-tags:
-  - API
-  - Location
-  - プロパティ
-  - リファレンス
-browser-compat: api.Location.username
-translation_of: Web/API/Location/username
 ---
 {{deprecated_header}}
 

--- a/files/ja/web/api/long_tasks_api/index.md
+++ b/files/ja/web/api/long_tasks_api/index.md
@@ -1,18 +1,6 @@
 ---
 title: Long Tasks API
 slug: Web/API/Long_Tasks_API
-tags:
-  - API
-  - Experimental
-  - Landing
-  - Long Tasks API
-  - Overview
-  - Performance
-  - PerformanceLongTaskTiming
-  - Reference
-  - TaskAttributionTiming
-  - Web Performance
-translation_of: Web/API/Long_Tasks_API
 ---
 {{DefaultAPISidebar("Long Tasks")}}
 

--- a/files/ja/web/api/media_capture_and_streams_api/constraints/index.md
+++ b/files/ja/web/api/media_capture_and_streams_api/constraints/index.md
@@ -1,20 +1,6 @@
 ---
 title: 能力、制約、そして設定
 slug: Web/API/Media_Capture_and_Streams_API/Constraints
-tags:
-  - Advanced
-  - Audio
-  - Constraints
-  - Example
-  - Guide
-  - Media
-  - Media Capture and Streams API
-  - Media Streams API
-  - Settings
-  - Video
-  - WebRTC
-  - capabilities
-translation_of: Web/API/Media_Streams_API/Constraints
 original_slug: Web/API/Media_Streams_API/Constraints
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}

--- a/files/ja/web/api/media_capture_and_streams_api/index.md
+++ b/files/ja/web/api/media_capture_and_streams_api/index.md
@@ -1,18 +1,6 @@
 ---
 title: Media Capture and Streams API (Media Streams)
 slug: Web/API/Media_Capture_and_Streams_API
-tags:
-  - API
-  - Advanced
-  - Audio
-  - Guide
-  - Introduction
-  - Media
-  - Media Capture and Streams API
-  - Media Streams API
-  - NeedsContent
-  - Video
-translation_of: Web/API/Media_Streams_API
 original_slug: Web/API/Media_Streams_API
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}

--- a/files/ja/web/api/media_source_extensions_api/index.md
+++ b/files/ja/web/api/media_source_extensions_api/index.md
@@ -1,17 +1,6 @@
 ---
 title: Media Source Extensions API
 slug: Web/API/Media_Source_Extensions_API
-tags:
-  - API
-  - Audio
-  - Experimental
-  - Landing
-  - MSE
-  - Media Source Extensions
-  - Reference
-  - Video
-  - streaming
-translation_of: Web/API/Media_Source_Extensions_API
 ---
 {{DefaultAPISidebar("Media Source Extensions")}}
 

--- a/files/ja/web/api/media_source_extensions_api/transcoding_assets_for_mse/index.md
+++ b/files/ja/web/api/media_source_extensions_api/transcoding_assets_for_mse/index.md
@@ -1,14 +1,6 @@
 ---
 title: Media Source Extensions のためのアセットのトランスコード
 slug: Web/API/Media_Source_Extensions_API/Transcoding_assets_for_MSE
-tags:
-  - DASH
-  - Dynamic Adaptive Streaming over HTTP
-  - Encoding
-  - MSE
-  - Media Source Extensions
-  - adaptive
-translation_of: Web/API/Media_Source_Extensions_API/Transcoding_assets_for_MSE
 ---
 Media Source Extensions を使用する場合、アセットをストリーミングする前に調整する必要がある可能性があります。 この記事では、要件を説明し、アセットを適切にエンコードするために使用できるツールチェーンを示します。
 

--- a/files/ja/web/api/mediacapabilities/encodinginfo/index.md
+++ b/files/ja/web/api/mediacapabilities/encodinginfo/index.md
@@ -1,16 +1,6 @@
 ---
 title: MediaCapabilitiesInfo
 slug: Web/API/MediaCapabilities/encodingInfo
-tags:
-  - API
-  - Audio
-  - Experimental
-  - Interface
-  - Media Capabilities API
-  - MediaCapabilitiesInfo
-  - Reference
-  - Video
-translation_of: Web/API/MediaCapabilitiesInfo
 original_slug: Web/API/MediaCapabilitiesInfo
 ---
 {{APIRef("Media Capabilities API")}}

--- a/files/ja/web/api/mediadeviceinfo/index.md
+++ b/files/ja/web/api/mediadeviceinfo/index.md
@@ -1,10 +1,6 @@
 ---
 title: MediaDeviceInfo
 slug: Web/API/MediaDeviceInfo
-tags:
-  - API
-  - WebRTC
-translation_of: Web/API/MediaDeviceInfo
 ---
 {{APIRef("WebRTC")}}
 

--- a/files/ja/web/api/mediadevices/devicechange_event/index.md
+++ b/files/ja/web/api/mediadevices/devicechange_event/index.md
@@ -1,18 +1,6 @@
 ---
 title: 'MediaDevices: devicechange イベント'
 slug: Web/API/MediaDevices/devicechange_event
-tags:
-  - API
-  - Audio
-  - Media
-  - Media Capture and Streams API
-  - Media Streams API
-  - MediaDevices
-  - Reference
-  - Video
-  - Event
-browser-compat: api.MediaDevices.devicechange_event
-translation_of: Web/API/MediaDevices/devicechange_event
 original_slug: Web/API/MediaDevices/ondevicechange
 ---
 {{APIRef}}

--- a/files/ja/web/api/mediadevices/enumeratedevices/index.md
+++ b/files/ja/web/api/mediadevices/enumeratedevices/index.md
@@ -1,14 +1,6 @@
 ---
 title: MediaDevices.enumerateDevices()
 slug: Web/API/MediaDevices/enumerateDevices
-tags:
-  - API
-  - MediaDevices
-  - メソッド
-  - リファレンス
-  - WebRTC
-browser-compat: api.MediaDevices.enumerateDevices
-translation_of: Web/API/MediaDevices/enumerateDevices
 ---
 {{APIRef("WebRTC")}}
 

--- a/files/ja/web/api/mediadevices/getdisplaymedia/index.md
+++ b/files/ja/web/api/mediadevices/getdisplaymedia/index.md
@@ -1,23 +1,6 @@
 ---
 title: MediaDevices.getDisplayMedia()
 slug: Web/API/MediaDevices/getDisplayMedia
-tags:
-  - API
-  - キャプチャ
-  - 会議
-  - メディア
-  - MediaDevices
-  - メソッド
-  - リファレンス
-  - 画面キャプチャ
-  - 画面キャプチャ API
-  - Sharing
-  - Video
-  - display
-  - getDisplayMedia
-  - screen
-browser-compat: api.MediaDevices.getDisplayMedia
-translationof: Web/API/MediaDevices/getDisplayMedia
 ---
 {{DefaultAPISidebar("Screen Capture API")}}
 

--- a/files/ja/web/api/mediadevices/getsupportedconstraints/index.md
+++ b/files/ja/web/api/mediadevices/getsupportedconstraints/index.md
@@ -1,18 +1,6 @@
 ---
 title: MediaDevices.getSupportedConstraints()
 slug: Web/API/MediaDevices/getSupportedConstraints
-tags:
-  - API
-  - メディア
-  - メディアキャプチャとストリーム API
-  - メディアストリーム API
-  - MediaDevices
-  - メソッド
-  - リファレンス
-  - WebRTC
-  - getSupportedConstraints
-browser-compat: api.MediaDevices.getSupportedConstraints
-translation_of: Web/API/MediaDevices/getSupportedConstraints
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediadevices/getusermedia/index.md
+++ b/files/ja/web/api/mediadevices/getusermedia/index.md
@@ -1,22 +1,6 @@
 ---
 title: MediaDevices.getUserMedia()
 slug: Web/API/MediaDevices/getUserMedia
-tags:
-  - API
-  - Audio
-  - キャプチャ
-  - メディア
-  - メディアキャプチャとストリーム API
-  - メディアストリーム API
-  - MediaDevices
-  - メソッド
-  - 写真
-  - リファレンス
-  - 動画
-  - WebRTC
-  - getusermedia
-browser-compat: api.MediaDevices.getUserMedia
-translation_of: Web/API/MediaDevices/getUserMedia
 ---
 {{securecontext_header}}{{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediadevices/index.md
+++ b/files/ja/web/api/mediadevices/index.md
@@ -1,24 +1,6 @@
 ---
 title: MediaDevices
 slug: Web/API/MediaDevices
-tags:
-  - API
-  - Audio
-  - Conference
-  - Devices
-  - インターフェイス
-  - メディア
-  - メディアキャプチャとストリーム API
-  - メディアストリーム API
-  - MediaDevices
-  - リファレンス
-  - 画面キャプチャ
-  - 画面キャプチャ API
-  - Sharing
-  - Video
-  - WebRTC
-browser-compat: api.MediaDevices
-translation_of: Web/API/MediaDevices
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediadevices/selectaudiooutput/index.md
+++ b/files/ja/web/api/mediadevices/selectaudiooutput/index.md
@@ -1,16 +1,6 @@
 ---
 title: MediaDevices.selectAudioOutput()
 slug: Web/API/MediaDevices/selectAudioOutput
-tags:
-  - API
-  - MediaDevices
-  - メソッド
-  - リファレンス
-  - WebRTC
-  - selectAudioOutput
-  - 実験的
-browser-compat: api.MediaDevices.selectAudioOutput
-translation_of: Web/API/MediaDevices/selectAudioOutput
 ---
 {{APIRef("WebRTC")}} {{SeeCompatTable}}
 

--- a/files/ja/web/api/medialist/index.md
+++ b/files/ja/web/api/medialist/index.md
@@ -1,14 +1,6 @@
 ---
 title: MediaList
 slug: Web/API/MediaList
-tags:
-  - API
-  - CSSOM
-  - インターフェイス
-  - MediaList
-  - リファレンス
-browser-compat: api.MediaList
-translation_of: Web/API/MediaList
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/medialist/mediatext/index.md
+++ b/files/ja/web/api/medialist/mediatext/index.md
@@ -1,15 +1,6 @@
 ---
 title: MediaList.mediaText
 slug: Web/API/MediaList/mediaText
-tags:
-  - API
-  - CSSOM
-  - MediaList
-  - プロパティ
-  - リファレンス
-  - mediaText
-browser-compat: api.MediaList.mediaText
-translation_of: Web/API/MediaList/mediaText
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/mediaquerylist/change_event/index.md
+++ b/files/ja/web/api/mediaquerylist/change_event/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'MediaQueryList: change イベント'
 slug: Web/API/MediaQueryList/change_event
-tags:
-  - API
-  - CSSOM View
-  - Event Handler
-  - MediaQueryList
-  - Property
-  - Reference
-  - onchange
-  - イベントハンドラー
-  - プロパティ
-  - メディアクエリー
-browser-compat: api.MediaQueryList.change_event
-translation_of: Web/API/MediaQueryList/change_event
 original_slug: Web/API/MediaQueryList/change_event
 ---
 {{APIRef("CSSOM")}}

--- a/files/ja/web/api/mediaquerylist/index.md
+++ b/files/ja/web/api/mediaquerylist/index.md
@@ -1,20 +1,6 @@
 ---
 title: MediaQueryList
 slug: Web/API/MediaQueryList
-tags:
-  - API
-  - Adaptive Design
-  - CSSOM View
-  - DOM
-  - Interface
-  - Media Queries
-  - MediaQueryList
-  - Reference
-  - query
-  - アダプティブデザイン
-  - インターフェイス
-  - メディアクエリー
-translation_of: Web/API/MediaQueryList
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/mediaquerylist/matches/index.md
+++ b/files/ja/web/api/mediaquerylist/matches/index.md
@@ -1,21 +1,6 @@
 ---
 title: MediaQueryList.matches
 slug: Web/API/MediaQueryList/matches
-tags:
-  - API
-  - Adaptive Design
-  - CSSOM
-  - CSSOM View
-  - DOM
-  - Media Queries
-  - MediaQueryList
-  - Property
-  - Reference
-  - matches
-  - アダプティブデザイン
-  - プロパティ
-  - メディアクエリー
-translation_of: Web/API/MediaQueryList/matches
 ---
 
 {{APIRef("CSSOM")}}

--- a/files/ja/web/api/mediaquerylist/media/index.md
+++ b/files/ja/web/api/mediaquerylist/media/index.md
@@ -1,18 +1,6 @@
 ---
 title: MediaQueryList.media
 slug: Web/API/MediaQueryList/media
-tags:
-  - API
-  - CSSOM View
-  - Media
-  - Media Queries
-  - MediaQueryList
-  - Property
-  - Reference
-  - プロパティ
-  - メディア
-  - メディアクエリー
-translation_of: Web/API/MediaQueryList/media
 ---
 
 {{APIRef("CSSOM")}}

--- a/files/ja/web/api/mediarecorder/dataavailable_event/index.md
+++ b/files/ja/web/api/mediarecorder/dataavailable_event/index.md
@@ -1,18 +1,6 @@
 ---
 title: MediaRecorder.ondataavailable
 slug: Web/API/MediaRecorder/dataavailable_event
-tags:
-  - API
-  - Audio
-  - Media Capture
-  - Media Recorder API
-  - MediaRecorder
-  - MediaStream Recording API
-  - Property
-  - Reference
-  - Video
-  - ondataavailable
-translation_of: Web/API/MediaRecorder/ondataavailable
 original_slug: Web/API/MediaRecorder/ondataavailable
 ---
 {{APIRef("MediaStream Recording")}}

--- a/files/ja/web/api/mediarecorder/error_event/index.md
+++ b/files/ja/web/api/mediarecorder/error_event/index.md
@@ -1,9 +1,6 @@
 ---
 title: 'MediaRecorder: error イベント'
 slug: Web/API/MediaRecorder/error_event
-tags:
-  - Event
-translation_of: Web/API/MediaRecorder/error_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/mediarecorder/index.md
+++ b/files/ja/web/api/mediarecorder/index.md
@@ -1,18 +1,6 @@
 ---
 title: MediaRecorder
 slug: Web/API/MediaRecorder
-tags:
-  - API
-  - Audio
-  - Interface
-  - Media
-  - Media Capture
-  - Media Capture and Streams
-  - Media Recorder API
-  - MediaRecorder
-  - Reference
-  - Video
-translation_of: Web/API/MediaRecorder
 ---
 {{APIRef("Media Recorder API")}}
 

--- a/files/ja/web/api/mediarecorder/istypesupported/index.md
+++ b/files/ja/web/api/mediarecorder/istypesupported/index.md
@@ -1,18 +1,6 @@
 ---
 title: MediaRecorder.isTypeSupported
 slug: Web/API/MediaRecorder/isTypeSupported
-tags:
-  - API
-  - Audio
-  - Media
-  - Media Capture
-  - Media Recorder API
-  - MediaRecorder
-  - Method
-  - Reference
-  - Video
-  - canRecordMimeType
-translation_of: Web/API/MediaRecorder/isTypeSupported
 ---
 {{APIRef("MediaStream Recording")}}
 

--- a/files/ja/web/api/mediarecorder/mediarecorder/index.md
+++ b/files/ja/web/api/mediarecorder/mediarecorder/index.md
@@ -1,17 +1,6 @@
 ---
 title: MediaRecorder()
 slug: Web/API/MediaRecorder/MediaRecorder
-tags:
-  - API
-  - Audio
-  - Constructor
-  - Media
-  - Media Capture
-  - Media Recorder API
-  - MediaRecorder
-  - Reference
-  - Video
-translation_of: Web/API/MediaRecorder/MediaRecorder
 ---
 {{APIRef("MediaStream Recording")}}
 

--- a/files/ja/web/api/mediarecorder/mimetype/index.md
+++ b/files/ja/web/api/mediarecorder/mimetype/index.md
@@ -1,18 +1,6 @@
 ---
 title: MediaRecorder.mimeType
 slug: Web/API/MediaRecorder/mimeType
-tags:
-  - API
-  - Audio
-  - Media
-  - MediaRecorder
-  - MediaRecorder API
-  - MediaStream Recording
-  - Property
-  - Reference
-  - Video
-  - mimeType
-translation_of: Web/API/MediaRecorder/mimeType
 ---
 {{APIRef("MediaStream Recording")}}
 

--- a/files/ja/web/api/mediarecorder/pause/index.md
+++ b/files/ja/web/api/mediarecorder/pause/index.md
@@ -1,15 +1,6 @@
 ---
 title: MediaRecorder.pause()
 slug: Web/API/MediaRecorder/pause
-tags:
-  - API
-  - Media Capture
-  - Media Recorder API
-  - MediaRecorder
-  - Method
-  - Reference
-  - pause
-translation_of: Web/API/MediaRecorder/pause
 ---
 {{APIRef("MediaStream Recording")}}
 

--- a/files/ja/web/api/mediarecorder/pause_event/index.md
+++ b/files/ja/web/api/mediarecorder/pause_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: MediaRecorder.onpause
 slug: Web/API/MediaRecorder/pause_event
-tags:
-  - API
-  - Audio
-  - Media Capture
-  - Media Recorder API
-  - MediaRecorder
-  - Property
-  - Reference
-  - Video
-  - onpause
-translation_of: Web/API/MediaRecorder/onpause
 original_slug: Web/API/MediaRecorder/onpause
 ---
 {{APIRef("Media Recorder API")}}

--- a/files/ja/web/api/mediarecorder/requestdata/index.md
+++ b/files/ja/web/api/mediarecorder/requestdata/index.md
@@ -1,19 +1,6 @@
 ---
 title: MediaRecorder.requestData()
 slug: Web/API/MediaRecorder/requestData
-tags:
-  - API
-  - Audio
-  - Media
-  - Media Capture
-  - Media Recorder API
-  - MediaRecorder
-  - MediaStream Recording
-  - Method
-  - Reference
-  - Video
-  - requestData
-translation_of: Web/API/MediaRecorder/requestData
 ---
 {{APIRef("MediaStream Recording")}}
 

--- a/files/ja/web/api/mediarecorder/resume/index.md
+++ b/files/ja/web/api/mediarecorder/resume/index.md
@@ -1,15 +1,6 @@
 ---
 title: MediaRecorder.resume()
 slug: Web/API/MediaRecorder/resume
-tags:
-  - API
-  - Media Capture
-  - Media Recorder API
-  - MediaRecorder
-  - Method
-  - Reference
-  - resume
-translation_of: Web/API/MediaRecorder/resume
 ---
 {{APIRef("MediaStream Recording")}}
 

--- a/files/ja/web/api/mediarecorder/resume_event/index.md
+++ b/files/ja/web/api/mediarecorder/resume_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: MediaRecorder.onresume
 slug: Web/API/MediaRecorder/resume_event
-tags:
-  - API
-  - Audio
-  - Media Capture
-  - Media Recorder API
-  - MediaRecorder
-  - Property
-  - Reference
-  - Video
-  - onresume
-translation_of: Web/API/MediaRecorder/onresume
 original_slug: Web/API/MediaRecorder/onresume
 ---
 {{APIRef("Media Recorder API")}}

--- a/files/ja/web/api/mediarecorder/start/index.md
+++ b/files/ja/web/api/mediarecorder/start/index.md
@@ -1,20 +1,6 @@
 ---
 title: MediaRecorder.start()
 slug: Web/API/MediaRecorder/start
-tags:
-  - API
-  - Audio
-  - Media
-  - Media Capture
-  - MediaRecorder
-  - MediaStream Recording
-  - MediaStream Recording API
-  - Method
-  - Recording Media
-  - Reference
-  - Video
-  - start
-translation_of: Web/API/MediaRecorder/start
 ---
 {{APIRef("MediaStream Recording")}}
 

--- a/files/ja/web/api/mediarecorder/start_event/index.md
+++ b/files/ja/web/api/mediarecorder/start_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: MediaRecorder.onstart
 slug: Web/API/MediaRecorder/start_event
-tags:
-  - API
-  - Audio
-  - Media Capture
-  - Media Recorder API
-  - MediaRecorder
-  - Property
-  - Reference
-  - Video
-  - onstart
-translation_of: Web/API/MediaRecorder/onstart
 original_slug: Web/API/MediaRecorder/onstart
 ---
 {{APIRef("Media Recorder API")}}

--- a/files/ja/web/api/mediarecorder/state/index.md
+++ b/files/ja/web/api/mediarecorder/state/index.md
@@ -1,14 +1,6 @@
 ---
 title: MediaRecorder.state
 slug: Web/API/MediaRecorder/state
-tags:
-  - API
-  - Media Recorder API
-  - MediaRecording
-  - Property
-  - Reference
-  - state
-translation_of: Web/API/MediaRecorder/state
 ---
 {{APIRef("MediaStream Recording")}}
 

--- a/files/ja/web/api/mediarecorder/stop/index.md
+++ b/files/ja/web/api/mediarecorder/stop/index.md
@@ -1,15 +1,6 @@
 ---
 title: MediaRecorder.stop()
 slug: Web/API/MediaRecorder/stop
-tags:
-  - API
-  - Media Capture
-  - Media Recorder API
-  - MediaRecorder
-  - Method
-  - Reference
-  - stop
-translation_of: Web/API/MediaRecorder/stop
 ---
 {{APIRef("MediaStream Recording")}}
 

--- a/files/ja/web/api/mediarecorder/stop_event/index.md
+++ b/files/ja/web/api/mediarecorder/stop_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: MediaRecorder.onstop
 slug: Web/API/MediaRecorder/stop_event
-tags:
-  - API
-  - Audio
-  - Media Capture
-  - Media Recorder API
-  - MediaRecorder
-  - Property
-  - Reference
-  - Video
-  - onstop
-translation_of: Web/API/MediaRecorder/onstop
 original_slug: Web/API/MediaRecorder/onstop
 ---
 {{APIRef("Media Recorder API")}}

--- a/files/ja/web/api/mediarecorder/stream/index.md
+++ b/files/ja/web/api/mediarecorder/stream/index.md
@@ -1,14 +1,6 @@
 ---
 title: MediaRecorder.stream
 slug: Web/API/MediaRecorder/stream
-tags:
-  - API
-  - Media Recorder API
-  - MediaRecorder
-  - Property
-  - Reference
-  - stream
-translation_of: Web/API/MediaRecorder/stream
 ---
 {{APIRef("MediaStream Recording")}}
 

--- a/files/ja/web/api/mediarecordererrorevent/error/index.md
+++ b/files/ja/web/api/mediarecordererrorevent/error/index.md
@@ -1,16 +1,6 @@
 ---
 title: MediaRecorderErrorEvent.error
 slug: Web/API/MediaRecorderErrorEvent/error
-tags:
-  - API
-  - Error
-  - Error Handling
-  - MediaRecordingErrorEvent
-  - MediaStream Recording
-  - MediaStream Recording API
-  - Property
-  - Reference
-translation_of: Web/API/MediaRecorderErrorEvent/error
 ---
 {{APIRef("MediaStream Recording")}}
 

--- a/files/ja/web/api/mediarecordererrorevent/index.md
+++ b/files/ja/web/api/mediarecordererrorevent/index.md
@@ -1,23 +1,6 @@
 ---
 title: MediaRecorderErrorEvent
 slug: Web/API/MediaRecorderErrorEvent
-tags:
-  - AV
-  - Audio
-  - Error
-  - Event
-  - Interface
-  - Media
-  - MediaRecorderErrorEvent
-  - MediaStream
-  - MediaStream Recording
-  - MediaStream Recording API
-  - Recording Audio
-  - Recording Media
-  - Recording Video
-  - Video
-  - WebRTC
-translation_of: Web/API/MediaRecorderErrorEvent
 ---
 {{APIRef("MediaStream Recording")}}
 

--- a/files/ja/web/api/mediarecordererrorevent/mediarecordererrorevent/index.md
+++ b/files/ja/web/api/mediarecordererrorevent/mediarecordererrorevent/index.md
@@ -1,19 +1,6 @@
 ---
 title: MediaRecorderErrorEvent()
 slug: Web/API/MediaRecorderErrorEvent/MediaRecorderErrorEvent
-tags:
-  - API
-  - Audio
-  - Constructor
-  - Media
-  - Media Capture
-  - Media Capture and Streams
-  - MediaRecordingErrorEvent
-  - MediaStream Recording
-  - MediaStream Recording API
-  - Recording
-  - Video
-translation_of: Web/API/MediaRecorderErrorEvent/MediaRecorderErrorEvent
 ---
 {{APIRef("MediaStream Recording")}}
 

--- a/files/ja/web/api/mediasession/index.md
+++ b/files/ja/web/api/mediasession/index.md
@@ -1,15 +1,6 @@
 ---
 title: MediaSession
 slug: Web/API/MediaSession
-tags:
-  - Media Session API
-  - MediaSession
-  - Reference
-  - インターフェイス
-  - オーディオ
-  - ビデオ
-  - メディア
-translation_of: Web/API/MediaSession
 ---
 {{SeeCompatTable}}{{APIRef("Media Session API")}}
 

--- a/files/ja/web/api/mediasource/activesourcebuffers/index.md
+++ b/files/ja/web/api/mediasource/activesourcebuffers/index.md
@@ -1,18 +1,6 @@
 ---
 title: MediaSource.activeSourceBuffers
 slug: Web/API/MediaSource/activeSourceBuffers
-tags:
-  - API
-  - Audio
-  - Experimental
-  - MSE
-  - Media Source Extensions
-  - MediaSource
-  - Property
-  - Reference
-  - Video
-  - activeSourceBuffers
-translation_of: Web/API/MediaSource/activeSourceBuffers
 ---
 {{APIRef("Media Source Extensions")}}
 

--- a/files/ja/web/api/mediasource/addsourcebuffer/index.md
+++ b/files/ja/web/api/mediasource/addsourcebuffer/index.md
@@ -1,18 +1,6 @@
 ---
 title: MediaSource.addSourceBuffer()
 slug: Web/API/MediaSource/addSourceBuffer
-tags:
-  - API
-  - Audio
-  - MSE
-  - Media
-  - Media Source Extensions
-  - MediaSource
-  - Method
-  - Reference
-  - Video
-  - addSourceBuffer
-translation_of: Web/API/MediaSource/addSourceBuffer
 ---
 {{APIRef("Media Source Extensions")}}
 

--- a/files/ja/web/api/mediasource/clearliveseekablerange/index.md
+++ b/files/ja/web/api/mediasource/clearliveseekablerange/index.md
@@ -1,18 +1,6 @@
 ---
 title: MediaSource.clearLiveSeekableRange()
 slug: Web/API/MediaSource/clearLiveSeekableRange
-tags:
-  - API
-  - Audio
-  - Extensions
-  - Media
-  - Media Source Extensions
-  - MediaSource
-  - Method
-  - Reference
-  - Video
-  - clearLiveSeekableRange()
-translation_of: Web/API/MediaSource/clearLiveSeekableRange
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/mediasource/duration/index.md
+++ b/files/ja/web/api/mediasource/duration/index.md
@@ -1,18 +1,6 @@
 ---
 title: MediaSource.duration
 slug: Web/API/MediaSource/duration
-tags:
-  - API
-  - Audio
-  - Experimental
-  - MSE
-  - Media Source Extensions
-  - MediaSource
-  - Property
-  - Reference
-  - Video
-  - duration
-translation_of: Web/API/MediaSource/duration
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/mediasource/endofstream/index.md
+++ b/files/ja/web/api/mediasource/endofstream/index.md
@@ -1,18 +1,6 @@
 ---
 title: MediaSource.endOfStream()
 slug: Web/API/MediaSource/endOfStream
-tags:
-  - API
-  - Audio
-  - Experimental
-  - MSE
-  - Media Source Extensions
-  - MediaSource
-  - Method
-  - Reference
-  - Video
-  - endOfStream
-translation_of: Web/API/MediaSource/endOfStream
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/mediasource/index.md
+++ b/files/ja/web/api/mediasource/index.md
@@ -1,7 +1,6 @@
 ---
 title: MediaSource
 slug: Web/API/MediaSource
-translation_of: Web/API/MediaSource
 ---
 {{SeeCompatTable}}
 

--- a/files/ja/web/api/mediasource/istypesupported/index.md
+++ b/files/ja/web/api/mediasource/istypesupported/index.md
@@ -1,20 +1,6 @@
 ---
 title: MediaSource.isTypeSupported()
 slug: Web/API/MediaSource/isTypeSupported
-tags:
-  - API
-  - Audio
-  - Experimental
-  - MSE
-  - Media Source Extensions
-  - MediaSource
-  - Method
-  - Reference
-  - Static
-  - Static Method
-  - Video
-  - isTypeSupported
-translation_of: Web/API/MediaSource/isTypeSupported
 ---
 {{APIRef("Media Source Extensions")}}
 

--- a/files/ja/web/api/mediasource/mediasource/index.md
+++ b/files/ja/web/api/mediasource/mediasource/index.md
@@ -1,17 +1,6 @@
 ---
 title: MediaSource.MediaSource()
 slug: Web/API/MediaSource/MediaSource
-tags:
-  - API
-  - Audio
-  - Constructor
-  - Experimental
-  - MSE
-  - Media Source Extensions
-  - MediaSource
-  - Reference
-  - Video
-translation_of: Web/API/MediaSource/MediaSource
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/mediasource/readystate/index.md
+++ b/files/ja/web/api/mediasource/readystate/index.md
@@ -1,18 +1,6 @@
 ---
 title: MediaSource.readyState
 slug: Web/API/MediaSource/readyState
-tags:
-  - API
-  - Audio
-  - Experimental
-  - MSE
-  - Media Source Extensions
-  - MediaSource
-  - Property
-  - Reference
-  - Video
-  - readyState
-translation_of: Web/API/MediaSource/readyState
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/mediasource/removesourcebuffer/index.md
+++ b/files/ja/web/api/mediasource/removesourcebuffer/index.md
@@ -1,18 +1,6 @@
 ---
 title: MediaSource.removeSourceBuffer()
 slug: Web/API/MediaSource/removeSourceBuffer
-tags:
-  - API
-  - Audio
-  - Experimental
-  - MSE
-  - Media Source Extensions
-  - MediaSource
-  - Method
-  - Reference
-  - Video
-  - removeSourceBuffer
-translation_of: Web/API/MediaSource/removeSourceBuffer
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/mediasource/setliveseekablerange/index.md
+++ b/files/ja/web/api/mediasource/setliveseekablerange/index.md
@@ -1,18 +1,6 @@
 ---
 title: MediaSource.setLiveSeekableRange()
 slug: Web/API/MediaSource/setLiveSeekableRange
-tags:
-  - API
-  - Audio
-  - Extensions
-  - Media
-  - Media Source Extensions
-  - MediaSource
-  - Method
-  - Reference
-  - Video
-  - setLiveSeekableRange()
-translation_of: Web/API/MediaSource/setLiveSeekableRange
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/mediasource/sourcebuffers/index.md
+++ b/files/ja/web/api/mediasource/sourcebuffers/index.md
@@ -1,18 +1,6 @@
 ---
 title: MediaSource.sourceBuffers
 slug: Web/API/MediaSource/sourceBuffers
-tags:
-  - API
-  - Audio
-  - Experimental
-  - MSE
-  - Media Source Extensions
-  - MediaSource
-  - Property
-  - Reference
-  - Video
-  - sourceBuffers
-translation_of: Web/API/MediaSource/sourceBuffers
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/mediastream/active/index.md
+++ b/files/ja/web/api/mediastream/active/index.md
@@ -1,16 +1,6 @@
 ---
 title: MediaStream.active
 slug: Web/API/MediaStream/active
-tags:
-  - API
-  - メディアキャプチャとストリーム
-  - メディアストリーム API
-  - MediaStream
-  - プロパティ
-  - リファレンス
-  - active
-browser-compat: api.MediaStream.active
-translation_of: Web/API/MediaStream/active
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediastream/addtrack/index.md
+++ b/files/ja/web/api/mediastream/addtrack/index.md
@@ -1,15 +1,6 @@
 ---
 title: MediaStream.addTrack()
 slug: Web/API/MediaStream/addTrack
-tags:
-  - API
-  - メディアストリーム API
-  - メソッド
-  - NeedsExample
-  - リファレンス
-  - addTrack
-browser-compat: api.MediaStream.addTrack
-translation_of: Web/API/MediaStream/addTrack
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediastream/addtrack_event/index.md
+++ b/files/ja/web/api/mediastream/addtrack_event/index.md
@@ -1,10 +1,6 @@
 ---
 title: 'MediaStream: addtrack イベント'
 slug: Web/API/MediaStream/addtrack_event
-tags:
-  - イベント
-browser-compat: api.MediaStream.addtrack_event
-translation_of: Web/API/MediaStream/addtrack_event
 original_slug: Web/API/MediaStream/onaddtrack
 ---
 {{APIRef("Media Capture and Streams")}}

--- a/files/ja/web/api/mediastream/clone/index.md
+++ b/files/ja/web/api/mediastream/clone/index.md
@@ -1,16 +1,6 @@
 ---
 title: MediaStream.clone()
 slug: Web/API/MediaStream/clone
-tags:
-  - API
-  - メディアキャプチャとストリーム API
-  - メディアストリーム API
-  - MediaStream
-  - メソッド
-  - リファレンス
-  - clone
-browser-compat: api.MediaStream.clone
-translation_of: Web/API/MediaStream/clone
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediastream/getaudiotracks/index.md
+++ b/files/ja/web/api/mediastream/getaudiotracks/index.md
@@ -1,21 +1,6 @@
 ---
 title: MediaStream.getAudioTracks()
 slug: Web/API/MediaStream/getAudioTracks
-tags:
-  - API
-  - Audio
-  - 実験的
-  - Media
-  - メディアキャプチャとストリーム API
-  - メディアストリーム API
-  - MediaStream
-  - MediaStreamTrack
-  - メソッド
-  - リファレンス
-  - getAudioTracks
-  - トラック
-browser-compat: api.MediaStream.getAudioTracks
-translation_of: Web/API/MediaStream/getAudioTracks
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediastream/gettrackbyid/index.md
+++ b/files/ja/web/api/mediastream/gettrackbyid/index.md
@@ -1,16 +1,6 @@
 ---
 title: MediaStream.getTrackById()
 slug: Web/API/MediaStream/getTrackById
-tags:
-  - Media
-  - MediaStream
-  - メディアストリーム API
-  - メソッド
-  - リファレンス
-  - WebRTC
-  - getTrackById
-browser-compat: api.MediaStream.getTrackById
-translation_of: Web/API/MediaStream/getTrackById
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediastream/gettracks/index.md
+++ b/files/ja/web/api/mediastream/gettracks/index.md
@@ -1,16 +1,6 @@
 ---
 title: MediaStream.getTracks()
 slug: Web/API/MediaStream/getTracks
-tags:
-  - API
-  - Experimental
-  - Media Streams API
-  - MediaStream
-  - MediaStreamTrack
-  - Method
-  - リファレンス
-  - getTracks
-browser-compat: api.MediaStream.getTracks
 ---
 {{APIRef("Media Capture and Streams")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/mediastream/getvideotracks/index.md
+++ b/files/ja/web/api/mediastream/getvideotracks/index.md
@@ -1,20 +1,6 @@
 ---
 title: MediaStream.getVideoTracks()
 slug: Web/API/MediaStream/getVideoTracks
-tags:
-  - API
-  - Media
-  - メディアキャプチャとストリーム API
-  - メディアストリーム API
-  - MediaStream
-  - メソッド
-  - リファレンス
-  - 動画
-  - getVideoTracks
-  - ストリーム
-  - トラック
-browser-compat: api.MediaStream.getVideoTracks
-translation_of: Web/API/MediaStream/getVideoTracks
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediastream/id/index.md
+++ b/files/ja/web/api/mediastream/id/index.md
@@ -1,14 +1,6 @@
 ---
 title: MediaStream.id
 slug: Web/API/MediaStream/id
-tags:
-  - MediaStream
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - ウェブ
-browser-compat: api.MediaStream.id
-translation_of: Web/API/MediaStream/id
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediastream/index.md
+++ b/files/ja/web/api/mediastream/index.md
@@ -1,15 +1,6 @@
 ---
 title: MediaStream
 slug: Web/API/MediaStream
-tags:
-  - API
-  - インターフェイス
-  - メディアストリーム API
-  - MediaStream
-  - リファレンス
-  - WebRTC
-browser-compat: api.MediaStream
-translation_of: Web/API/MediaStream
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediastream/mediastream/index.md
+++ b/files/ja/web/api/mediastream/mediastream/index.md
@@ -1,22 +1,6 @@
 ---
 title: MediaStream()
 slug: Web/API/MediaStream/MediaStream
-tags:
-  - API
-  - Audio
-  - コンストラクター
-  - Media
-  - メディアキャプチャとストリーム
-  - メディアキャプチャとストリーム API
-  - MediaStream
-  - リファレンス
-  - ストリーム
-  - トラック
-  - Video
-  - WebRTC
-  - ストリーミング
-browser-compat: api.MediaStream.MediaStream
-translation_of: Web/API/MediaStream/MediaStream
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediastream/removetrack_event/index.md
+++ b/files/ja/web/api/mediastream/removetrack_event/index.md
@@ -1,10 +1,6 @@
 ---
 title: 'MediaStream: removetrack イベント'
 slug: Web/API/MediaStream/removetrack_event
-tags:
-  - イベント
-browser-compat: api.MediaStream.removetrack_event
-translation_of: Web/API/MediaStream/removetrack_event
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediastream_image_capture_api/index.md
+++ b/files/ja/web/api/mediastream_image_capture_api/index.md
@@ -1,7 +1,6 @@
 ---
 title: MediaStream Image Capture API
 slug: Web/API/MediaStream_Image_Capture_API
-translation_of: Web/API/MediaStream_Image_Capture_API
 ---
 {{DefaultAPISidebar("Image Capture API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/mediastream_recording_api/index.md
+++ b/files/ja/web/api/mediastream_recording_api/index.md
@@ -1,17 +1,6 @@
 ---
 title: MediaStream Recording API
 slug: Web/API/MediaStream_Recording_API
-tags:
-  - API
-  - Audio
-  - Media
-  - Media Capture and Streams
-  - MediaStream Recording
-  - MediaStream Recording API
-  - Overview
-  - Reference
-  - Video
-translation_of: Web/API/MediaStream_Recording_API
 ---
 {{DefaultAPISidebar("MediaStream Recording")}}
 

--- a/files/ja/web/api/mediastream_recording_api/recording_a_media_element/index.md
+++ b/files/ja/web/api/mediastream_recording_api/recording_a_media_element/index.md
@@ -1,17 +1,6 @@
 ---
 title: メディア要素の記録
 slug: Web/API/MediaStream_Recording_API/Recording_a_media_element
-tags:
-  - API
-  - Audio
-  - Example
-  - Guide
-  - Media
-  - Media Recording
-  - MediaStream Recording
-  - Tutorial
-  - Video
-translation_of: Web/API/MediaStream_Recording_API/Recording_a_media_element
 ---
 {{DefaultAPISidebar("MediaStream Recording")}}
 

--- a/files/ja/web/api/mediastream_recording_api/using_the_mediastream_recording_api/index.md
+++ b/files/ja/web/api/mediastream_recording_api/using_the_mediastream_recording_api/index.md
@@ -1,14 +1,6 @@
 ---
 title: Media​Stream Recording API の使用
 slug: Web/API/MediaStream_Recording_API/Using_the_MediaStream_Recording_API
-tags:
-  - API
-  - Example
-  - Guide
-  - MediaRecorder
-  - MediaStream Recording API
-  - Tutorial
-translation_of: Web/API/MediaStream_Recording_API/Using_the_MediaStream_Recording_API
 ---
 {{DefaultAPISidebar("MediaStream Recording")}}
 

--- a/files/ja/web/api/mediastreamtrack/enabled/index.md
+++ b/files/ja/web/api/mediastreamtrack/enabled/index.md
@@ -1,19 +1,6 @@
 ---
 title: MediaStreamTrack.enabled
 slug: Web/API/MediaStreamTrack/enabled
-page-type: web-api-instance-property
-tags:
-  - Media
-  - Media Capture and Streams
-  - MediaStreamTrack
-  - Muting a Media Track
-  - Muting a Track
-  - Property
-  - Reference
-  - WebRTC
-  - enabled
-browser-compat: api.MediaStreamTrack.enabled
-translation_of: Web/API/MediaStreamTrack/enabled
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediastreamtrack/ended_event/index.md
+++ b/files/ja/web/api/mediastreamtrack/ended_event/index.md
@@ -1,20 +1,6 @@
 ---
 title: 'MediaStreamTrack: ended イベント'
 slug: Web/API/MediaStreamTrack/ended_event
-page-type: web-api-event
-tags:
-  - Audio
-  - Event
-  - HTML DOM
-  - HTMLMediaElement
-  - Media
-  - Media Streams API
-  - Reference
-  - Video
-  - Web Audio API
-  - ended
-browser-compat: api.MediaStreamTrack.ended_event
-translation_of: Web/API/MediaStreamTrack/ended_event
 original_slug: Web/API/MediaStreamTrack/onended
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}

--- a/files/ja/web/api/mediastreamtrack/id/index.md
+++ b/files/ja/web/api/mediastreamtrack/id/index.md
@@ -1,16 +1,6 @@
 ---
 title: MediaStreamTrack.id
 slug: Web/API/MediaStreamTrack/id
-page-type: web-api-instance-property
-tags:
-  - Media Capture and Streams
-  - MediaStreamTrack
-  - Property
-  - Read-only
-  - Reference
-  - WebRTC
-browser-compat: api.MediaStreamTrack.id
-translation_of: Web/API/MediaStreamTrack/id
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediastreamtrack/index.md
+++ b/files/ja/web/api/mediastreamtrack/index.md
@@ -1,20 +1,6 @@
 ---
 title: MediaStreamTrack
 slug: Web/API/MediaStreamTrack
-page-type: web-api-interface
-tags:
-  - API
-  - Audio
-  - Interface
-  - Media
-  - Media Capture and Streams API
-  - Media Streams API
-  - MediaStreamTrack
-  - Reference
-  - Video
-  - WebRTC
-browser-compat: api.MediaStreamTrack
-translation_of: Web/API/MediaStreamTrack
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediastreamtrack/kind/index.md
+++ b/files/ja/web/api/mediastreamtrack/kind/index.md
@@ -1,17 +1,6 @@
 ---
 title: MediaStreamTrack.kind
 slug: Web/API/MediaStreamTrack/kind
-page-type: web-api-instance-property
-tags:
-  - Media Capture and Streams
-  - MediaStreamTrack
-  - NeedsExample
-  - Property
-  - Read-only
-  - Reference
-  - WebRTC
-browser-compat: api.MediaStreamTrack.kind
-translation_of: Web/API/MediaStreamTrack/kind
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediastreamtrack/label/index.md
+++ b/files/ja/web/api/mediastreamtrack/label/index.md
@@ -1,17 +1,6 @@
 ---
 title: MediaStreamTrack.label
 slug: Web/API/MediaStreamTrack/label
-page-type: web-api-instance-property
-tags:
-  - Media Capture and Streams
-  - MediaStreamTrack
-  - NeedsExample
-  - Property
-  - Read-only
-  - Reference
-  - WebRTC
-browser-compat: api.MediaStreamTrack.label
-translation_of: Web/API/MediaStreamTrack/label
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediastreamtrack/mute_event/index.md
+++ b/files/ja/web/api/mediastreamtrack/mute_event/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'MediaStreamTrack: mute イベント'
 slug: Web/API/MediaStreamTrack/mute_event
-page-type: web-api-event
-tags:
-  - API
-  - Audio
-  - Event
-  - Media
-  - Media Capture and Streams
-  - MediaStreamTrack
-  - Reference
-  - Video
-  - mute
-browser-compat: api.MediaStreamTrack.mute_event
-translation_of: Web/API/MediaStreamTrack/mute_event
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediastreamtrack/muted/index.md
+++ b/files/ja/web/api/mediastreamtrack/muted/index.md
@@ -1,17 +1,6 @@
 ---
 title: MediaStreamTrack.muted
 slug: Web/API/MediaStreamTrack/muted
-page-type: web-api-instance-property
-tags:
-  - API
-  - Media Capture and Streams
-  - MediaStreamTrack
-  - Property
-  - Read-only
-  - Reference
-  - muted
-browser-compat: api.MediaStreamTrack.muted
-translation_of: Web/API/MediaStreamTrack/muted
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediastreamtrack/overconstrained_event/index.md
+++ b/files/ja/web/api/mediastreamtrack/overconstrained_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'MediaStreamTrack: overconstrained イベント'
 slug: Web/API/MediaStreamTrack/overconstrained_event
-page-type: web-api-event
-tags:
-  - API
-  - Deprecated
-  - Event Handler
-  - Event
-  - Reference
-  - WebRTC
-browser-compat: api.MediaStreamTrack.overconstrained_event
-translation_of: Web/API/MediaStreamTrack/overconstrained_event
 original_slug: Web/API/MediaStreamTrack/onoverconstrained
 ---
 {{ APIRef("Media Capture and Streams") }}{{deprecated_header}}

--- a/files/ja/web/api/mediastreamtrack/readystate/index.md
+++ b/files/ja/web/api/mediastreamtrack/readystate/index.md
@@ -1,17 +1,6 @@
 ---
 title: MediaStreamTrack.readyState
 slug: Web/API/MediaStreamTrack/readyState
-page-type: web-api-instance-property
-tags:
-  - API
-  - Media Capture and Streams
-  - MediaStreamTrack
-  - NeedsExample
-  - Property
-  - Read-only
-  - Reference
-browser-compat: api.MediaStreamTrack.readyState
-translation_of: Web/API/MediaStreamTrack/readyState
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediastreamtrack/remote/index.md
+++ b/files/ja/web/api/mediastreamtrack/remote/index.md
@@ -1,16 +1,6 @@
 ---
 title: MediaStreamTrack.remote
 slug: Web/API/MediaStreamTrack/remote
-page-type: web-api-instance-property
-tags:
-  - Deprecated
-  - MediaStreamTrack
-  - Property
-  - Read-only
-  - Reference
-  - WebRTC
-browser-compat: api.MediaStreamTrack.remote
-translation_of: Web/API/MediaStreamTrack/remote
 ---
 {{APIRef("Media Capture and Streams")}}{{deprecated_header}}
 

--- a/files/ja/web/api/mediastreamtrack/stop/index.md
+++ b/files/ja/web/api/mediastreamtrack/stop/index.md
@@ -1,20 +1,6 @@
 ---
 title: MediaStreamTrack.stop()
 slug: Web/API/MediaStreamTrack/stop
-page-type: web-api-instance-method
-tags:
-  - API
-  - Media
-  - Media Capture and Streams API
-  - Media Streams API
-  - MediaStreamTrack
-  - Method
-  - Reference
-  - Streams
-  - WebRTC
-  - stop
-browser-compat: api.MediaStreamTrack.stop
-translation_of: Web/API/MediaStreamTrack/stop
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediastreamtrack/unmute_event/index.md
+++ b/files/ja/web/api/mediastreamtrack/unmute_event/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'MediaStreamTrack: unmute イベント'
 slug: Web/API/MediaStreamTrack/unmute_event
-page-type: web-api-event
-tags:
-  - Audio
-  - Event
-  - Media
-  - Media Capture and Streams
-  - Media Streams
-  - MediaStreamTrack
-  - Reference
-  - Video
-  - unmute
-browser-compat: api.MediaStreamTrack.unmute_event
-translation_of: Web/API/MediaStreamTrack/unmute_event
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediatracksupportedconstraints/aspectratio/index.md
+++ b/files/ja/web/api/mediatracksupportedconstraints/aspectratio/index.md
@@ -1,21 +1,6 @@
 ---
 title: MediaTrackSupportedConstraints.aspectRatio
 slug: Web/API/MediaTrackSupportedConstraints/aspectRatio
-page-type: web-api-instance-property
-tags:
-  - API
-  - Constraints
-  - Media
-  - Media Capture and Streams API
-  - Media Streams API
-  - MediaTrackSupportedConstraints
-  - Property
-  - Reference
-  - Web
-  - WebRTC
-  - aspectRatio
-browser-compat: api.MediaTrackSupportedConstraints.aspectRatio
-translation_of: Web/API/MediaTrackSupportedConstraints/aspectRatio
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediatracksupportedconstraints/autogaincontrol/index.md
+++ b/files/ja/web/api/mediatracksupportedconstraints/autogaincontrol/index.md
@@ -1,23 +1,6 @@
 ---
 title: MediaTrackSupportedConstraints.autoGainControl
 slug: Web/API/MediaTrackSupportedConstraints/autoGainControl
-page-type: web-api-instance-property
-tags:
-  - API
-  - Audio
-  - Constraints
-  - Media
-  - Media Capture and Streams
-  - Media Capture and Streams API
-  - Media Constraints
-  - Media Streams
-  - MediaTrackSupportedConstraints
-  - Property
-  - Volume
-  - Web
-  - autoGainControl
-browser-compat: api.MediaTrackSupportedConstraints.autoGainControl
-translation_of: Web/API/MediaTrackSupportedConstraints/autoGainControl
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediatracksupportedconstraints/channelcount/index.md
+++ b/files/ja/web/api/mediatracksupportedconstraints/channelcount/index.md
@@ -1,21 +1,6 @@
 ---
 title: MediaTrackSupportedConstraints.channelCount
 slug: Web/API/MediaTrackSupportedConstraints/channelCount
-page-type: web-api-instance-property
-tags:
-  - API
-  - Constraints
-  - Media
-  - Media Capture and Streams API
-  - Media Streams API
-  - MediaTrackSupportedConstraints
-  - Property
-  - Reference
-  - Web
-  - WebRTC
-  - channelCount
-browser-compat: api.MediaTrackSupportedConstraints.channelCount
-translation_of: Web/API/MediaTrackSupportedConstraints/channelCount
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediatracksupportedconstraints/deviceid/index.md
+++ b/files/ja/web/api/mediatracksupportedconstraints/deviceid/index.md
@@ -1,21 +1,6 @@
 ---
 title: MediaTrackSupportedConstraints.deviceId
 slug: Web/API/MediaTrackSupportedConstraints/deviceId
-page-type: web-api-instance-property
-tags:
-  - API
-  - Constraints
-  - Media
-  - Media Capture and Streams API
-  - Media Stream API
-  - MediaTrackSupportedConstraints
-  - Property
-  - Reference
-  - Web
-  - WebRTC
-  - deviceId
-browser-compat: api.MediaTrackSupportedConstraints.deviceId
-translation_of: Web/API/MediaTrackSupportedConstraints/deviceId
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediatracksupportedconstraints/echocancellation/index.md
+++ b/files/ja/web/api/mediatracksupportedconstraints/echocancellation/index.md
@@ -1,20 +1,6 @@
 ---
 title: MediaTrackSupportedConstraints.echoCancellation
 slug: Web/API/MediaTrackSupportedConstraints/echoCancellation
-page-type: web-api-instance-property
-tags:
-  - API
-  - Media
-  - Media Capture and Streams API
-  - Media Streams API
-  - MediaTrackSupportedConstraints
-  - Property
-  - Reference
-  - Web
-  - WebRTC
-  - echoCancellation
-browser-compat: api.MediaTrackSupportedConstraints.echoCancellation
-translation_of: Web/API/MediaTrackSupportedConstraints/echoCancellation
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediatracksupportedconstraints/facingmode/index.md
+++ b/files/ja/web/api/mediatracksupportedconstraints/facingmode/index.md
@@ -1,19 +1,6 @@
 ---
 title: MediaTrackSupportedConstraints.facingMode
 slug: Web/API/MediaTrackSupportedConstraints/facingMode
-page-type: web-api-instance-property
-tags:
-  - API
-  - Constraints
-  - Media
-  - Media Capture and Streams API
-  - Media Streams API
-  - MediaTrackSupportedConstraints
-  - Property
-  - Web
-  - WebRTC
-  - facingMode
-translation_of: Web/API/MediaTrackSupportedConstraints/facingMode
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediatracksupportedconstraints/framerate/index.md
+++ b/files/ja/web/api/mediatracksupportedconstraints/framerate/index.md
@@ -1,21 +1,6 @@
 ---
 title: MediaTrackSupportedConstraints.frameRate
 slug: Web/API/MediaTrackSupportedConstraints/frameRate
-page-type: web-api-instance-property
-tags:
-  - API
-  - Constraints
-  - Media
-  - Media Capture and Streams API
-  - Media Streams API
-  - MediaTrackSupportedConstraints
-  - Property
-  - Reference
-  - Web
-  - WebRTC
-  - frameRate
-browser-compat: api.MediaTrackSupportedConstraints.frameRate
-translation_of: Web/API/MediaTrackSupportedConstraints/frameRate
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediatracksupportedconstraints/groupid/index.md
+++ b/files/ja/web/api/mediatracksupportedconstraints/groupid/index.md
@@ -1,20 +1,6 @@
 ---
 title: MediaTrackSupportedConstraints.groupId
 slug: Web/API/MediaTrackSupportedConstraints/groupId
-page-type: web-api-instance-property
-tags:
-  - API
-  - Media
-  - Media Capture and Streams API
-  - Media Streams API
-  - MediaTrackSupportedConstraints
-  - Property
-  - Reference
-  - Web
-  - WebRTC
-  - groupId
-browser-compat: api.MediaTrackSupportedConstraints.groupId
-translation_of: Web/API/MediaTrackSupportedConstraints/groupId
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediatracksupportedconstraints/height/index.md
+++ b/files/ja/web/api/mediatracksupportedconstraints/height/index.md
@@ -1,20 +1,6 @@
 ---
 title: MediaTrackSupportedConstraints.height
 slug: Web/API/MediaTrackSupportedConstraints/height
-page-type: web-api-instance-property
-tags:
-  - API
-  - Media
-  - Media Capture and Streams API
-  - Media Streams API
-  - MediaTrackSupportedConstraints
-  - Property
-  - Reference
-  - Web
-  - WebRTC
-  - height
-browser-compat: api.MediaTrackSupportedConstraints.height
-translation_of: Web/API/MediaTrackSupportedConstraints/height
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediatracksupportedconstraints/index.md
+++ b/files/ja/web/api/mediatracksupportedconstraints/index.md
@@ -1,22 +1,6 @@
 ---
 title: MediaTrackSupportedConstraints
 slug: Web/API/MediaTrackSupportedConstraints
-page-type: web-api-interface
-tags:
-  - API
-  - Capture
-  - Constraints
-  - Dictionary
-  - Interface
-  - Media Capture and Streams API
-  - Media Streams API
-  - MediaTrackSupportedConstraints
-  - Reference
-  - Screen Capture
-  - Screen Capture API
-  - screen
-browser-compat: api.MediaTrackSupportedConstraints
-translation_of: Web/API/MediaTrackSupportedConstraints
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediatracksupportedconstraints/latency/index.md
+++ b/files/ja/web/api/mediatracksupportedconstraints/latency/index.md
@@ -1,21 +1,6 @@
 ---
 title: MediaTrackSupportedConstraints.latency
 slug: Web/API/MediaTrackSupportedConstraints/latency
-page-type: web-api-instance-property
-tags:
-  - API
-  - Constraints
-  - Media
-  - Media Capture and Streams API
-  - Media Streams API
-  - MediaTrackSupportedConstraints
-  - Property
-  - Reference
-  - Web
-  - WebRTC
-  - latency
-browser-compat: api.MediaTrackSupportedConstraints.latency
-translation_of: Web/API/MediaTrackSupportedConstraints/latency
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediatracksupportedconstraints/noisesuppression/index.md
+++ b/files/ja/web/api/mediatracksupportedconstraints/noisesuppression/index.md
@@ -1,20 +1,6 @@
 ---
 title: MediaTrackSupportedConstraints.noiseSuppression
 slug: Web/API/MediaTrackSupportedConstraints/noiseSuppression
-page-type: web-api-instance-property
-tags:
-  - API
-  - Audio
-  - Constraints
-  - Media
-  - Media Capture and Streams API
-  - Media Constraints
-  - Media Streams API
-  - MediaStreamTrackSupportedConstraints
-  - Property
-  - noiseSuppression
-browser-compat: api.MediaTrackSupportedConstraints.noiseSuppression
-translation_of: Web/API/MediaTrackSupportedConstraints/noiseSuppression
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediatracksupportedconstraints/samplerate/index.md
+++ b/files/ja/web/api/mediatracksupportedconstraints/samplerate/index.md
@@ -1,19 +1,6 @@
 ---
 title: MediaTrackSupportedConstraints.sampleRate
 slug: Web/API/MediaTrackSupportedConstraints/sampleRate
-page-type: web-api-instance-property
-tags:
-  - API
-  - Constraints
-  - Media
-  - Media Capture and Streams API
-  - Media Streams API
-  - MediaTrackSupportedConstraints
-  - Property
-  - Reference
-  - Web
-  - sampleRate
-translation_of: Web/API/MediaTrackSupportedConstraints/sampleRate
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediatracksupportedconstraints/samplesize/index.md
+++ b/files/ja/web/api/mediatracksupportedconstraints/samplesize/index.md
@@ -1,19 +1,6 @@
 ---
 title: MediaTrackSupportedConstraints.sampleSize
 slug: Web/API/MediaTrackSupportedConstraints/sampleSize
-page-type: web-api-instance-property
-tags:
-  - API
-  - Constraints
-  - Media
-  - Media Capture and Streams API
-  - Media Streams API
-  - MediaTrackSupportedConstraints
-  - Property
-  - Reference
-  - WebRTC
-  - sampleSize
-translation_of: Web/API/MediaTrackSupportedConstraints/sampleSize
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}
 

--- a/files/ja/web/api/mediatracksupportedconstraints/volume/index.md
+++ b/files/ja/web/api/mediatracksupportedconstraints/volume/index.md
@@ -1,19 +1,6 @@
 ---
 title: MediaTrackSupportedConstraints.volume
 slug: Web/API/MediaTrackSupportedConstraints/volume
-page-type: web-api-instance-property
-tags:
-  - API
-  - Constraints
-  - Media
-  - Media Capture and Streams API
-  - Media Streams API
-  - MediaTrackSupportedConstraints
-  - Property
-  - Reference
-  - Volume
-  - WebRTC
-translation_of: Web/API/MediaTrackSupportedConstraints/volume
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}{{deprecated_header}}
 

--- a/files/ja/web/api/mediatracksupportedconstraints/width/index.md
+++ b/files/ja/web/api/mediatracksupportedconstraints/width/index.md
@@ -1,8 +1,6 @@
 ---
 title: MediaTrackSupportedConstraints.width
 slug: Web/API/MediaTrackSupportedConstraints/width
-page-type: web-api-instance-property
-browser-compat: api.MediaTrackSupportedConstraints.width
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}
 

--- a/files/ja/web/api/messagechannel/index.md
+++ b/files/ja/web/api/messagechannel/index.md
@@ -1,14 +1,6 @@
 ---
 title: MessageChannel
 slug: Web/API/MessageChannel
-tags:
-  - API
-  - Channel Messaging API
-  - Interface
-  - MessageChannel
-  - Reference
-  - web messaging
-translation_of: Web/API/MessageChannel
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/messagechannel/messagechannel/index.md
+++ b/files/ja/web/api/messagechannel/messagechannel/index.md
@@ -1,13 +1,6 @@
 ---
 title: MessageChannel()
 slug: Web/API/MessageChannel/MessageChannel
-tags:
-  - API
-  - Channel messaging
-  - Constructor
-  - MessageChannel
-  - Reference
-translation_of: Web/API/MessageChannel/MessageChannel
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/messagechannel/port1/index.md
+++ b/files/ja/web/api/messagechannel/port1/index.md
@@ -1,15 +1,6 @@
 ---
 title: MessageChannel.port1
 slug: Web/API/MessageChannel/port1
-tags:
-  - API
-  - Channel messaging
-  - HTML5
-  - Message Channel API
-  - MessageChannel
-  - Property
-  - Reference
-translation_of: Web/API/MessageChannel/port1
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/messagechannel/port2/index.md
+++ b/files/ja/web/api/messagechannel/port2/index.md
@@ -1,14 +1,6 @@
 ---
 title: MessageChannel.port2
 slug: Web/API/MessageChannel/port2
-tags:
-  - API
-  - Channel messaging
-  - HTML5
-  - MessageChannel
-  - Property
-  - Reference
-translation_of: Web/API/MessageChannel/port2
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/messageevent/data/index.md
+++ b/files/ja/web/api/messageevent/data/index.md
@@ -1,16 +1,6 @@
 ---
 title: MessageEvent.data
 slug: Web/API/MessageEvent/data
-tags:
-  - API
-  - DOM
-  - MessageEvent
-  - プロパティ
-  - リファレンス
-  - data
-  - messaging
-browser-compat: api.MessageEvent.data
-translation_of: Web/API/MessageEvent/data
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/messageevent/index.md
+++ b/files/ja/web/api/messageevent/index.md
@@ -1,17 +1,6 @@
 ---
 title: MessageEvent
 slug: Web/API/MessageEvent
-tags:
-  - API
-  - チャンネル
-  - インターフェイス
-  - リファレンス
-  - WebSockets
-  - ウィンドウ
-  - ワーカー
-  - messaging
-browser-compat: api.MessageEvent
-translation_of: Web/API/MessageEvent
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/messageevent/lasteventid/index.md
+++ b/files/ja/web/api/messageevent/lasteventid/index.md
@@ -1,16 +1,6 @@
 ---
 title: MessageEvent.lastEventId
 slug: Web/API/MessageEvent/lastEventId
-tags:
-  - API
-  - DOM
-  - MessageEvent
-  - プロパティ
-  - リファレンス
-  - lastEventID
-  - messaging
-browser-compat: api.MessageEvent.lastEventId
-translation_of: Web/API/MessageEvent/lastEventId
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/messageevent/messageevent/index.md
+++ b/files/ja/web/api/messageevent/messageevent/index.md
@@ -1,15 +1,6 @@
 ---
 title: MessageEvent()
 slug: Web/API/MessageEvent/MessageEvent
-tags:
-  - API
-  - コンストラクター
-  - DOM
-  - MessageEvent
-  - リファレンス
-  - messaging
-browser-compat: api.MessageEvent.MessageEvent
-translation_of: Web/API/MessageEvent/MessageEvent
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/messageevent/origin/index.md
+++ b/files/ja/web/api/messageevent/origin/index.md
@@ -1,16 +1,6 @@
 ---
 title: MessageEvent.origin
 slug: Web/API/MessageEvent/origin
-tags:
-  - API
-  - DOM
-  - MessageEvent
-  - プロパティ
-  - リファレンス
-  - messaging
-  - origin
-browser-compat: api.MessageEvent.origin
-translation_of: Web/API/MessageEvent/origin
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/messageevent/ports/index.md
+++ b/files/ja/web/api/messageevent/ports/index.md
@@ -1,16 +1,6 @@
 ---
 title: MessageEvent.ports
 slug: Web/API/MessageEvent/ports
-tags:
-  - API
-  - DOM
-  - MessagingEvent
-  - プロパティ
-  - リファレンス
-  - messaging
-  - ports
-browser-compat: api.MessageEvent.ports
-translation_of: Web/API/MessageEvent/ports
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/messageevent/source/index.md
+++ b/files/ja/web/api/messageevent/source/index.md
@@ -1,16 +1,6 @@
 ---
 title: MessageEvent.source
 slug: Web/API/MessageEvent/source
-tags:
-  - API
-  - DOM
-  - MessageEvent
-  - プロパティ
-  - リファレンス
-  - messaging
-  - source
-browser-compat: api.MessageEvent.source
-translation_of: Web/API/MessageEvent/source
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/messageport/close/index.md
+++ b/files/ja/web/api/messageport/close/index.md
@@ -1,13 +1,6 @@
 ---
 title: MessagePort.close()
 slug: Web/API/MessagePort/close
-tags:
-  - API
-  - Channel messaging
-  - MessagePort
-  - Method
-  - Reference
-translation_of: Web/API/MessagePort/close
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/messageport/index.md
+++ b/files/ja/web/api/messageport/index.md
@@ -1,14 +1,6 @@
 ---
 title: MessagePort
 slug: Web/API/MessagePort
-tags:
-  - API
-  - Channel messaging
-  - HTML5
-  - Interface
-  - MessagePort
-  - Reference
-translation_of: Web/API/MessagePort
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/messageport/message_event/index.md
+++ b/files/ja/web/api/messageport/message_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: MessagePort.onmessage
 slug: Web/API/MessagePort/message_event
-tags:
-  - API
-  - Channel messaging
-  - MessagePort
-  - Property
-  - Reference
-translation_of: Web/API/MessagePort/onmessage
 original_slug: Web/API/MessagePort/onmessage
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/web/api/messageport/messageerror_event/index.md
+++ b/files/ja/web/api/messageport/messageerror_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: MessagePort.onmessageerror
 slug: Web/API/MessagePort/messageerror_event
-tags:
-  - API
-  - Channel messaging
-  - MessagePort
-  - Property
-  - Reference
-  - events
-  - onmessageerror
-translation_of: Web/API/MessagePort/onmessageerror
 original_slug: Web/API/MessagePort/onmessageerror
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/web/api/messageport/postmessage/index.md
+++ b/files/ja/web/api/messageport/postmessage/index.md
@@ -1,13 +1,6 @@
 ---
 title: MessagePort.postMessage()
 slug: Web/API/MessagePort/postMessage
-tags:
-  - API
-  - Channel messagging
-  - MessagePort
-  - Reference
-  - postMessage
-translation_of: Web/API/MessagePort/postMessage
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/messageport/start/index.md
+++ b/files/ja/web/api/messageport/start/index.md
@@ -1,13 +1,6 @@
 ---
 title: MessagePort.start()
 slug: Web/API/MessagePort/start
-tags:
-  - API
-  - Channel messaging
-  - MessagePort
-  - Method
-  - Reference
-translation_of: Web/API/MessagePort/start
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/microsoft_extensions/index.md
+++ b/files/ja/web/api/microsoft_extensions/index.md
@@ -1,13 +1,6 @@
 ---
 title: Microsoft API extensions
 slug: Web/API/Microsoft_Extensions
-tags:
-  - API
-  - API:Microsoft Extensions
-  - Non-standard
-  - Overview
-  - Reference
-translation_of: Web/API/Microsoft_Extensions
 ---
 {{DefaultAPISidebar("Microsoft Extensions")}}
 

--- a/files/ja/web/api/mouseevent/altkey/index.md
+++ b/files/ja/web/api/mouseevent/altkey/index.md
@@ -1,17 +1,6 @@
 ---
 title: MouseEvent.altKey
 slug: Web/API/MouseEvent/altKey
-tags:
-  - API
-  - DOM
-  - DOM イベント
-  - MouseEvent
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.MouseEvent.altKey
-translation_of: Web/API/MouseEvent/altKey
-translation_of_original: Web/API/event.altKey
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/mouseevent/button/index.md
+++ b/files/ja/web/api/mouseevent/button/index.md
@@ -1,16 +1,6 @@
 ---
 title: MouseEvent.button
 slug: Web/API/MouseEvent/button
-tags:
-  - API
-  - DOM
-  - DOM イベント
-  - MouseEvent
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.MouseEvent.button
-translation_of: Web/API/MouseEvent/button
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/mouseevent/buttons/index.md
+++ b/files/ja/web/api/mouseevent/buttons/index.md
@@ -1,16 +1,6 @@
 ---
 title: MouseEvent.buttons
 slug: Web/API/MouseEvent/buttons
-tags:
-  - API
-  - DOM
-  - DOM イベント
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - UIEvent
-browser-compat: api.MouseEvent.buttons
-translation_of: Web/API/MouseEvent/buttons
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/mouseevent/clientx/index.md
+++ b/files/ja/web/api/mouseevent/clientx/index.md
@@ -1,17 +1,6 @@
 ---
 title: MouseEvent.clientX
 slug: Web/API/MouseEvent/clientX
-tags:
-  - API
-  - CSSOM View
-  - DOM
-  - DOM イベント
-  - MouseEvent
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.MouseEvent.clientX
-translation_of: Web/API/MouseEvent/clientX
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/mouseevent/clienty/index.md
+++ b/files/ja/web/api/mouseevent/clienty/index.md
@@ -1,15 +1,6 @@
 ---
 title: MouseEvent.clientY
 slug: Web/API/MouseEvent/clientY
-tags:
-  - API
-  - CSSOM View
-  - DOM イベント
-  - MouseEvent
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.MouseEvent.clientY
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/mouseevent/ctrlkey/index.md
+++ b/files/ja/web/api/mouseevent/ctrlkey/index.md
@@ -1,16 +1,6 @@
 ---
 title: MouseEvent.ctrlKey
 slug: Web/API/MouseEvent/ctrlKey
-tags:
-  - API
-  - DOM
-  - DOM イベント
-  - MouseEvent
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.MouseEvent.ctrlKey
-translation_of: Web/API/MouseEvent/ctrlKey
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/mouseevent/getmodifierstate/index.md
+++ b/files/ja/web/api/mouseevent/getmodifierstate/index.md
@@ -1,15 +1,6 @@
 ---
 title: MouseEvent.getModifierState()
 slug: Web/API/MouseEvent/getModifierState
-tags:
-  - API
-  - DOM
-  - DOM イベント
-  - メソッド
-  - MouseEvent
-  - リファレンス
-  - getModifierState
-browser-compat: api.MouseEvent.getModifierState
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/mouseevent/index.md
+++ b/files/ja/web/api/mouseevent/index.md
@@ -1,17 +1,6 @@
 ---
 title: MouseEvent
 slug: Web/API/MouseEvent
-tags:
-  - API
-  - DOM
-  - DOM イベント
-  - インターフェイス
-  - MouseEvent
-  - リファレンス
-  - イベント
-  - マウス
-browser-compat: api.MouseEvent
-translation_of: Web/API/MouseEvent
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/mouseevent/initmouseevent/index.md
+++ b/files/ja/web/api/mouseevent/initmouseevent/index.md
@@ -1,16 +1,6 @@
 ---
 title: MouseEvent.initMouseEvent()
 slug: Web/API/MouseEvent/initMouseEvent
-tags:
-  - API
-  - DOM
-  - DOM イベント
-  - 非推奨
-  - メソッド
-  - MouseEvent
-  - リファレンス
-browser-compat: api.MouseEvent.initMouseEvent
-translation_of: Web/API/MouseEvent/initMouseEvent
 ---
 {{APIRef("DOM Events")}}{{deprecated_header}}
 

--- a/files/ja/web/api/mouseevent/layerx/index.md
+++ b/files/ja/web/api/mouseevent/layerx/index.md
@@ -1,16 +1,7 @@
 ---
 title: UIEvent.layerX
 slug: Web/API/MouseEvent/layerX
-tags:
-  - API
-  - DOM
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - UIEvent
-translation_of: Web/API/UIEvent/layerX
 original_slug: Web/API/UIEvent/layerX
-browser-compat: api.UIEvent.layerX
 ---
 {{APIRef("DOM Events")}} {{Non-standard_header}}
 

--- a/files/ja/web/api/mouseevent/layery/index.md
+++ b/files/ja/web/api/mouseevent/layery/index.md
@@ -1,16 +1,7 @@
 ---
 title: UIEvent.layerY
 slug: Web/API/MouseEvent/layerY
-tags:
-  - API
-  - DOM
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - UIEvent
-translation_of: Web/API/UIEvent/layerY
 original_slug: Web/API/UIEvent/layerY
-browser-compat: api.UIEvent.layerY
 ---
 {{APIRef("DOM Events")}}{{Non-standard_header}}
 

--- a/files/ja/web/api/mouseevent/metakey/index.md
+++ b/files/ja/web/api/mouseevent/metakey/index.md
@@ -1,16 +1,6 @@
 ---
 title: MouseEvent.metaKey
 slug: Web/API/MouseEvent/metaKey
-tags:
-  - API
-  - DOM
-  - DOM イベント
-  - MouseEvent
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.MouseEvent.metaKey
-translation_of: Web/API/MouseEvent/metaKey
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/mouseevent/mouseevent/index.md
+++ b/files/ja/web/api/mouseevent/mouseevent/index.md
@@ -1,15 +1,6 @@
 ---
 title: MouseEvent()
 slug: Web/API/MouseEvent/MouseEvent
-tags:
-  - API
-  - コンストラクター
-  - DOM
-  - MouseEvent
-  - リファレンス
-  - イベント
-browser-compat: api.MouseEvent.MouseEvent
-translation_of: Web/API/MouseEvent/MouseEvent
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/mouseevent/movementx/index.md
+++ b/files/ja/web/api/mouseevent/movementx/index.md
@@ -1,19 +1,6 @@
 ---
 title: MouseEvent.movementX
 slug: Web/API/MouseEvent/movementX
-tags:
-  - API
-  - DOM
-  - DOM イベント
-  - MouseEvent
-  - MovementX
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - mouse lock
-  - pointer lock
-translation_of: Web/API/MouseEvent/movementX
-browser-compat: api.MouseEvent.movementX
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/mouseevent/movementy/index.md
+++ b/files/ja/web/api/mouseevent/movementy/index.md
@@ -1,18 +1,6 @@
 ---
 title: MouseEvent.movementY
 slug: Web/API/MouseEvent/movementY
-tags:
-  - API
-  - DOM
-  - DOM イベント
-  - MouseEvent
-  - MovementY
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - mouse lock
-  - pointer lock
-browser-compat: api.MouseEvent.movementY
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/mouseevent/offsetx/index.md
+++ b/files/ja/web/api/mouseevent/offsetx/index.md
@@ -1,14 +1,6 @@
 ---
 title: MouseEvent.offsetX
 slug: Web/API/MouseEvent/offsetX
-tags:
-  - API
-  - MouseEvent
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.MouseEvent.offsetX
-translation_of: Web/API/MouseEvent/offsetX
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/mouseevent/offsety/index.md
+++ b/files/ja/web/api/mouseevent/offsety/index.md
@@ -1,14 +1,6 @@
 ---
 title: MouseEvent.offsetY
 slug: Web/API/MouseEvent/offsetY
-tags:
-  - API
-  - MouseEvent
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.MouseEvent.offsetY
-translation_of: Web/API/MouseEvent/offsetY
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/mouseevent/pagex/index.md
+++ b/files/ja/web/api/mouseevent/pagex/index.md
@@ -1,20 +1,6 @@
 ---
 title: MouseEvent.pageX
 slug: Web/API/MouseEvent/pageX
-tags:
-  - API
-  - CSSOM View
-  - DOM
-  - マウスイベント
-  - MouseEvent
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - UI イベント
-  - イベント
-  - pageX
-translation_of: Web/API/MouseEvent/pageX
-browser-compat: api.MouseEvent.pageX
 ---
 {{APIRef("CSSOM View")}}
 

--- a/files/ja/web/api/mouseevent/pagey/index.md
+++ b/files/ja/web/api/mouseevent/pagey/index.md
@@ -1,14 +1,6 @@
 ---
 title: MouseEvent.pageY
 slug: Web/API/MouseEvent/pageY
-tags:
-  - API
-  - DOM
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.MouseEvent.pageY
-translation_of: Web/API/MouseEvent/pageY
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/mouseevent/relatedtarget/index.md
+++ b/files/ja/web/api/mouseevent/relatedtarget/index.md
@@ -1,16 +1,6 @@
 ---
 title: MouseEvent.relatedTarget
 slug: Web/API/MouseEvent/relatedTarget
-tags:
-  - API
-  - DOM
-  - DOM イベント
-  - MouseEvent
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.MouseEvent.relatedTarget
-translation_of: Web/API/MouseEvent/relatedTarget
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/mouseevent/screenx/index.md
+++ b/files/ja/web/api/mouseevent/screenx/index.md
@@ -1,16 +1,6 @@
 ---
 title: MouseEvent.screenX
 slug: Web/API/MouseEvent/screenX
-tags:
-  - API
-  - CSSOM View
-  - DOM イベント
-  - MouseEvent
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.MouseEvent.screenX
-translation_of: Web/API/MouseEvent/screenX
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/mouseevent/screeny/index.md
+++ b/files/ja/web/api/mouseevent/screeny/index.md
@@ -1,15 +1,6 @@
 ---
 title: MouseEvent.screenY
 slug: Web/API/MouseEvent/screenY
-tags:
-  - API
-  - DOM イベント
-  - MouseEvent
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.MouseEvent.screenY
-translation_of: Web/API/MouseEvent/screenY
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/mouseevent/shiftkey/index.md
+++ b/files/ja/web/api/mouseevent/shiftkey/index.md
@@ -1,16 +1,6 @@
 ---
 title: MouseEvent.shiftKey
 slug: Web/API/MouseEvent/shiftKey
-tags:
-  - API
-  - DOM
-  - DOM イベント
-  - MouseEvent
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.MouseEvent.shiftKey
-translation_of: Web/API/MouseEvent/shiftKey
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/mouseevent/webkit_force_at_force_mouse_down/index.md
+++ b/files/ja/web/api/mouseevent/webkit_force_at_force_mouse_down/index.md
@@ -1,21 +1,6 @@
 ---
 title: MouseEvent.WEBKIT_FORCE_AT_FORCE_MOUSE_DOWN
 slug: Web/API/MouseEvent/WEBKIT_FORCE_AT_FORCE_MOUSE_DOWN
-tags:
-  - API
-  - DOM
-  - DOM イベント
-  - JavaScript
-  - MouseEvent
-  - NeedsBrowserCompatibility
-  - NeedsCompatTable
-  - NeedsExample
-  - NeedsMobileBrowserCompatibility
-  - 標準外
-  - プロパティ
-  - リファレンス
-  - WEBKIT_FORCE_AT_FORCE_MOUSE_DOWN
-translation_of: Web/API/MouseEvent/WEBKIT_FORCE_AT_FORCE_MOUSE_DOWN
 ---
 {{Non-standard_header()}}
 

--- a/files/ja/web/api/mouseevent/webkit_force_at_mouse_down/index.md
+++ b/files/ja/web/api/mouseevent/webkit_force_at_mouse_down/index.md
@@ -1,21 +1,6 @@
 ---
 title: MouseEvent.WEBKIT_FORCE_AT_MOUSE_DOWN
 slug: Web/API/MouseEvent/WEBKIT_FORCE_AT_MOUSE_DOWN
-tags:
-  - API
-  - DOM
-  - DOM イベント
-  - JavaScript
-  - MouseEvent
-  - NeedsBrowserCompatibility
-  - NeedsCompatTable
-  - NeedsExample
-  - NeedsMobileBrowserCompatibility
-  - 標準外
-  - プロパティ
-  - リファレンス
-  - WEBKIT_FORCE_AT_MOUSE_DOWN
-translation_of: Web/API/MouseEvent/WEBKIT_FORCE_AT_MOUSE_DOWN
 ---
 {{Non-standard_header()}}
 

--- a/files/ja/web/api/mouseevent/webkitforce/index.md
+++ b/files/ja/web/api/mouseevent/webkitforce/index.md
@@ -1,13 +1,6 @@
 ---
 title: MouseEvent.webkitForce
 slug: Web/API/MouseEvent/webkitForce
-tags:
-  - API
-  - DOM
-  - DOM イベント
-  - MouseEvent
-  - プロパティ
-  - リファレンス
 ---
 {{Non-standard_header()}}
 

--- a/files/ja/web/api/mouseevent/x/index.md
+++ b/files/ja/web/api/mouseevent/x/index.md
@@ -1,13 +1,6 @@
 ---
 title: MouseEvent.x
 slug: Web/API/MouseEvent/x
-tags:
-  - API
-  - DOM
-  - プロパティ
-  - リファレンス
-browser-compat: api.MouseEvent.x
-translation_of: Web/API/MouseEvent/x
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/mouseevent/y/index.md
+++ b/files/ja/web/api/mouseevent/y/index.md
@@ -1,13 +1,6 @@
 ---
 title: MouseEvent.y
 slug: Web/API/MouseEvent/y
-tags:
-  - API
-  - DOM
-  - プロパティ
-  - リファレンス
-browser-compat: api.MouseEvent.y
-translation_of: Web/API/MouseEvent/y
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/mutationobserver/disconnect/index.md
+++ b/files/ja/web/api/mutationobserver/disconnect/index.md
@@ -1,7 +1,6 @@
 ---
 title: MutationObserver.disconnect()
 slug: Web/API/MutationObserver/disconnect
-translation_of: Web/API/MutationObserver/disconnect
 ---
 {{APIRef("DOM WHATWG")}}
 

--- a/files/ja/web/api/mutationobserver/index.md
+++ b/files/ja/web/api/mutationobserver/index.md
@@ -1,19 +1,6 @@
 ---
 title: MutationObserver
 slug: Web/API/MutationObserver
-tags:
-  - API
-  - DOM
-  - DOM Reference
-  - Interface
-  - MutationObserver
-  - NeedsContent
-  - NeedsUpdate
-  - Reference
-  - mutation
-  - observers
-  - resize
-translation_of: Web/API/MutationObserver
 ---
 {{APIRef("DOM WHATWG")}}
 

--- a/files/ja/web/api/mutationobserver/mutationobserver/index.md
+++ b/files/ja/web/api/mutationobserver/mutationobserver/index.md
@@ -1,12 +1,6 @@
 ---
 title: MutationObserver.MutationObserver()
 slug: Web/API/MutationObserver/MutationObserver
-tags:
-  - API
-  - DOM
-  - Mutation Observer API
-  - MutationObserver
-translation_of: Web/API/MutationObserver/MutationObserver
 ---
 {{APIRef("DOM WHATWG")}}
 

--- a/files/ja/web/api/mutationobserver/observe/index.md
+++ b/files/ja/web/api/mutationobserver/observe/index.md
@@ -1,7 +1,6 @@
 ---
 title: MutationObserver.observe()
 slug: Web/API/MutationObserver/observe
-translation_of: Web/API/MutationObserver/observe
 ---
 {{APIRef("DOM WHATWG")}}
 

--- a/files/ja/web/api/mutationobserver/takerecords/index.md
+++ b/files/ja/web/api/mutationobserver/takerecords/index.md
@@ -1,7 +1,6 @@
 ---
 title: MutationObserver.takeRecords()
 slug: Web/API/MutationObserver/takeRecords
-translation_of: Web/API/MutationObserver/takeRecords
 ---
 {{APIRef("DOM WHATWG")}}
 

--- a/files/ja/web/api/mutationrecord/index.md
+++ b/files/ja/web/api/mutationrecord/index.md
@@ -1,14 +1,6 @@
 ---
 title: MutationRecord
 slug: Web/API/MutationRecord
-tags:
-  - API
-  - Advanced
-  - DOM
-  - DOM Reference
-  - NeedsContent
-  - Reference
-translation_of: Web/API/MutationRecord
 ---
 {{APIRef("DOM")}}
 


### PR DESCRIPTION
Part of #7858

`files/ja/web/api/{i-m}*` から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "tags": 211,
  "translation_of": 212,
  "page-type": 46,
  "browser-compat": 112,
  "tranalation_of": 1,
  "translationof": 1,
  "translation_of_original": 1
}
```
