### PR TITLE
remove duplicated frontmatter keys from web/api/{n-q}* (ja)

### DIFF
--- a/files/ja/web/api/namednodemap/getnameditem/index.md
+++ b/files/ja/web/api/namednodemap/getnameditem/index.md
@@ -1,12 +1,6 @@
 ---
 title: NamedNodeMap.getNamedItem()
 slug: Web/API/NamedNodeMap/getNamedItem
-page-type: web-api-instance-method
-tags:
-  - Method
-  - Reference
-browser-compat: api.NamedNodeMap.getNamedItem
-translation_of: Web/API/NamedNodeMap/getNamedItem
 l10n:
   sourceCommit: 6f983d8b9fa0081ba57ccab31a345a41ffccbbb1
 ---

--- a/files/ja/web/api/namednodemap/getnameditemns/index.md
+++ b/files/ja/web/api/namednodemap/getnameditemns/index.md
@@ -1,12 +1,6 @@
 ---
 title: NamedNodeMap.getNamedItemNS()
 slug: Web/API/NamedNodeMap/getNamedItemNS
-page-type: web-api-instance-method
-tags:
-  - Method
-  - Reference
-browser-compat: api.NamedNodeMap.getNamedItemNS
-translation_of: Web/API/NamedNodeMap/getNamedItemNS
 l10n:
   sourceCommit: 9ce57d5046baf5d25c8eb066e60227f0fbd017cf
 ---

--- a/files/ja/web/api/namednodemap/index.md
+++ b/files/ja/web/api/namednodemap/index.md
@@ -1,12 +1,6 @@
 ---
 title: NamedNodeMap
 slug: Web/API/NamedNodeMap
-page-type: web-api-interface
-tags:
-  - Interface
-  - Reference
-browser-compat: api.NamedNodeMap
-translation_of: Web/API/NamedNodeMap
 l10n:
   sourceCommit: a33268ca8d264ca3d504f65fdf11ce38a7bcb9bd
 ---

--- a/files/ja/web/api/namednodemap/item/index.md
+++ b/files/ja/web/api/namednodemap/item/index.md
@@ -1,12 +1,6 @@
 ---
 title: NamedNodeMap.item()
 slug: Web/API/NamedNodeMap/item
-page-type: web-api-instance-method
-tags:
-  - Method
-  - Reference
-browser-compat: api.NamedNodeMap.item
-translation_of: Web/API/NamedNodeMap/item
 l10n:
   sourceCommit: 7a45a40ff9c0a0de348c497b325e103aa6d875f8
 ---

--- a/files/ja/web/api/namednodemap/length/index.md
+++ b/files/ja/web/api/namednodemap/length/index.md
@@ -1,13 +1,6 @@
 ---
 title: NamedNodeMap.length
 slug: Web/API/NamedNodeMap/length
-page-type: web-api-instance-property
-tags:
-  - Property
-  - Reference
-  - Read-only
-browser-compat: api.NamedNodeMap.length
-translation_of: Web/API/NamedNodeMap/length
 l10n:
   sourceCommit: 6f983d8b9fa0081ba57ccab31a345a41ffccbbb1
 ---

--- a/files/ja/web/api/namednodemap/removenameditem/index.md
+++ b/files/ja/web/api/namednodemap/removenameditem/index.md
@@ -1,12 +1,6 @@
 ---
 title: NamedNodeMap.removeNamedItem()
 slug: Web/API/NamedNodeMap/removeNamedItem
-page-type: web-api-instance-method
-tags:
-  - Method
-  - Reference
-browser-compat: api.NamedNodeMap.removeNamedItem
-translation_of: Web/API/NamedNodeMap/removeNamedItem
 l10n:
   sourceCommit: 6f983d8b9fa0081ba57ccab31a345a41ffccbbb1
 ---

--- a/files/ja/web/api/namednodemap/removenameditemns/index.md
+++ b/files/ja/web/api/namednodemap/removenameditemns/index.md
@@ -1,12 +1,6 @@
 ---
 title: NamedNodeMap.removeNamedItemNS()
 slug: Web/API/NamedNodeMap/removeNamedItemNS
-page-type: web-api-instance-method
-tags:
-  - Method
-  - Reference
-browser-compat: api.NamedNodeMap.removeNamedItemNS
-translation_of: Web/API/NamedNodeMap/removeNamedItem
 l10n:
   sourceCommit: 6f983d8b9fa0081ba57ccab31a345a41ffccbbb1
 ---

--- a/files/ja/web/api/namednodemap/setnameditem/index.md
+++ b/files/ja/web/api/namednodemap/setnameditem/index.md
@@ -1,12 +1,6 @@
 ---
 title: NamedNodeMap.setNamedItem()
 slug: Web/API/NamedNodeMap/setNamedItem
-page-type: web-api-instance-method
-tags:
-  - Method
-  - Reference
-browser-compat: api.NamedNodeMap.setNamedItem
-translation_of: Web/API/NamedNodeMap/setNamedItem
 l10n:
   sourceCommit: 6f983d8b9fa0081ba57ccab31a345a41ffccbbb1
 ---

--- a/files/ja/web/api/namednodemap/setnameditemns/index.md
+++ b/files/ja/web/api/namednodemap/setnameditemns/index.md
@@ -1,12 +1,6 @@
 ---
 title: NamedNodeMap.setNamedItemNS()
 slug: Web/API/NamedNodeMap/setNamedItemNS
-page-type: web-api-instance-method
-tags:
-  - Method
-  - Reference
-browser-compat: api.NamedNodeMap.setNamedItemNS
-translation_of: Web/API/NamedNodeMap/setNamedItemNS
 l10n:
   sourceCommit: 8c93f95b9e71b6d43f56e94c49d1b12e81f6ec73
 ---

--- a/files/ja/web/api/navigation_timing_api/index.md
+++ b/files/ja/web/api/navigation_timing_api/index.md
@@ -1,11 +1,6 @@
 ---
 title: Navigation Timing API
 slug: Web/API/Navigation_timing_API
-tags:
-  - API
-  - Performance
-  - Web
-translation_of: Web/API/Navigation_timing_API
 ---
 {{DefaultAPISidebar("Navigation Timing")}}
 

--- a/files/ja/web/api/navigationpreloadmanager/index.md
+++ b/files/ja/web/api/navigationpreloadmanager/index.md
@@ -1,15 +1,6 @@
 ---
 title: NavigationPreloadManager
 slug: Web/API/NavigationPreloadManager
-tags:
-  - API
-  - Interface
-  - Navigation
-  - NavigationPreloadManager
-  - Offline
-  - Reference
-  - Service Workers
-translation_of: Web/API/NavigationPreloadManager
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/navigator/activevrdisplays/index.md
+++ b/files/ja/web/api/navigator/activevrdisplays/index.md
@@ -1,20 +1,6 @@
 ---
 title: Navigator.activeVRDisplays
 slug: Web/API/Navigator/activeVRDisplays
-page-type: web-api-instance-property
-tags:
-  - API
-  - Deprecated
-  - HTML DOM
-  - Navigator
-  - Property
-  - Reference
-  - VR
-  - Virtual Reality
-  - WebVR
-  - activeVRDisplays
-browser-compat: api.Navigator.activeVRDisplays
-translation_of: Web/API/Navigator/activeVRDisplays
 ---
 {{securecontext_header}}{{DefaultAPISidebar("WebVR API")}}{{deprecated_header}}
 

--- a/files/ja/web/api/navigator/appcodename/index.md
+++ b/files/ja/web/api/navigator/appcodename/index.md
@@ -1,16 +1,7 @@
 ---
 title: Navigator.appCodeName
 slug: Web/API/Navigator/appCodeName
-tags:
-  - API
-  - Deprecated
-  - HTML DOM
-  - Navigator
-  - Property
-  - Reference
-translation_of: Web/API/NavigatorID/appCodeName
 original_slug: Web/API/NavigatorID/appCodeName
-browser-compat: api.Navigator.appCodeName
 ---
 {{APIRef("HTML DOM")}} {{Deprecated_Header}}
 

--- a/files/ja/web/api/navigator/appname/index.md
+++ b/files/ja/web/api/navigator/appname/index.md
@@ -1,16 +1,7 @@
 ---
 title: Navigator.appName
 slug: Web/API/Navigator/appName
-tags:
-  - API
-  - Deprecated
-  - HTML DOM
-  - Navigator
-  - Property
-  - Reference
-translation_of: Web/API/NavigatorID/appName
 original_slug: Web/API/NavigatorID/appName
-browser-compat: api.Navigator.appName
 ---
 {{APIRef("HTML DOM")}} {{Deprecated_Header}}
 

--- a/files/ja/web/api/navigator/appversion/index.md
+++ b/files/ja/web/api/navigator/appversion/index.md
@@ -1,16 +1,7 @@
 ---
 title: Navigator.appVersion
 slug: Web/API/Navigator/appVersion
-tags:
-  - API
-  - Deprecated
-  - Navigator
-  - Property
-  - Reference
-  - appVersion
-translation_of: Web/API/NavigatorID/appVersion
 original_slug: Web/API/NavigatorID/appVersion
-browser-compat: api.Navigator.appVersion
 ---
 {{APIRef("HTML DOM")}} {{Deprecated_Header}}
 

--- a/files/ja/web/api/navigator/buildid/index.md
+++ b/files/ja/web/api/navigator/buildid/index.md
@@ -1,14 +1,6 @@
 ---
 title: Navigator.buildID
 slug: Web/API/Navigator/buildID
-tags:
-  - API
-  - DOM
-  - Gecko
-  - Navigator
-  - Property
-  - buildID
-translation_of: Web/API/Navigator/buildID
 ---
 {{ ApiRef("HTML DOM") }}
 

--- a/files/ja/web/api/navigator/clipboard/index.md
+++ b/files/ja/web/api/navigator/clipboard/index.md
@@ -1,21 +1,6 @@
 ---
 title: Navigator.clipboard
 slug: Web/API/Navigator/clipboard
-page-type: web-api-instance-property
-tags:
-  - API
-  - Clip
-  - Clipboard
-  - Cut
-  - Navigator
-  - Pasteboard
-  - Property
-  - Read-only
-  - Reference
-  - copy
-  - paste
-browser-compat: api.Navigator.clipboard
-translation_of: Web/API/Navigator/clipboard
 ---
 [クリップボード API](/ja/docs/Web/API/Clipboard_API) は **{{domxref("Navigator")}}** インターフェイスに読み取り専用の **`clipboard`** プロパティを追加し、これはクリップボードの内容を読み書きするために使用する {{domxref("Clipboard")}} オブジェクトを返します。
 

--- a/files/ja/web/api/navigator/connection/index.md
+++ b/files/ja/web/api/navigator/connection/index.md
@@ -1,14 +1,6 @@
 ---
 title: Navigator.connection
 slug: Web/API/Navigator/connection
-tags:
-  - API
-  - Experimental
-  - Navigator
-  - Network Information API
-  - Property
-  - Reference
-translation_of: Web/API/Navigator/connection
 ---
 {{APIRef("Network Information API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/navigator/cookieenabled/index.md
+++ b/files/ja/web/api/navigator/cookieenabled/index.md
@@ -1,13 +1,6 @@
 ---
 title: Navigator.cookieEnabled
 slug: Web/API/Navigator/cookieEnabled
-tags:
-  - API
-  - HTML DOM
-  - Navigator
-  - Property
-  - プロパティ
-translation_of: Web/API/Navigator/cookieEnabled
 ---
 {{ApiRef("HTML DOM")}}
 

--- a/files/ja/web/api/navigator/credentials/index.md
+++ b/files/ja/web/api/navigator/credentials/index.md
@@ -1,15 +1,6 @@
 ---
 title: Navigator.credentials
 slug: Web/API/Navigator/credentials
-tags:
-  - API
-  - CredentialsContainer
-  - Property
-  - Reference
-  - credentials
-  - プロパティ
-  - 資格情報
-translation_of: Web/API/Navigator/credentials
 ---
 {{securecontext_header}}{{APIRef("")}}
 

--- a/files/ja/web/api/navigator/devicememory/index.md
+++ b/files/ja/web/api/navigator/devicememory/index.md
@@ -1,15 +1,6 @@
 ---
 title: Navigator.deviceMemory
 slug: Web/API/Navigator/deviceMemory
-tags:
-  - API
-  - 端末メモリー API
-  - Navigator
-  - プロパティ
-  - リファレンス
-  - deviceMemory
-  - メモリー
-translation_of: Web/API/Navigator/deviceMemory
 ---
 {{APIRef("Device Memory")}}{{securecontext_header}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/navigator/donottrack/index.md
+++ b/files/ja/web/api/navigator/donottrack/index.md
@@ -1,14 +1,6 @@
 ---
 title: Navigator.doNotTrack
 slug: Web/API/Navigator/doNotTrack
-tags:
-  - API
-  - Experimental
-  - HTML DOM
-  - Navigator
-  - Property
-  - Reference
-translation_of: Web/API/Navigator/doNotTrack
 ---
 {{ApiRef("HTML DOM")}}
 

--- a/files/ja/web/api/navigator/geolocation/index.md
+++ b/files/ja/web/api/navigator/geolocation/index.md
@@ -1,14 +1,6 @@
 ---
 title: Navigator.geolocation
 slug: Web/API/Navigator/geolocation
-tags:
-  - API
-  - Geolocation API
-  - Navigator
-  - Property
-  - Reference
-  - Secure context
-translation_of: Web/API/Navigator/geolocation
 ---
 <div>{{securecontext_header}}{{APIRef("Geolocation API")}}</div>
 

--- a/files/ja/web/api/navigator/getbattery/index.md
+++ b/files/ja/web/api/navigator/getbattery/index.md
@@ -1,16 +1,6 @@
 ---
 title: Navigator.getBattery()
 slug: Web/API/Navigator/getBattery
-tags:
-  - API
-  - Battery API
-  - Device API
-  - Method
-  - Navigator
-  - Reference
-  - getBattery
-  - メッセージ
-translation_of: Web/API/Navigator/getBattery
 ---
 {{ ApiRef("Battery API") }}{{deprecated_header}}
 

--- a/files/ja/web/api/navigator/getgamepads/index.md
+++ b/files/ja/web/api/navigator/getgamepads/index.md
@@ -1,15 +1,6 @@
 ---
 title: Navigator.getGamepads()
 slug: Web/API/Navigator/getGamepads
-tags:
-  - API
-  - Experimental
-  - Gamepad API
-  - Games
-  - Method
-  - Navigator
-  - Reference
-translation_of: Web/API/Navigator/getGamepads
 ---
 {{APIRef("Gamepad API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/navigator/getusermedia/index.md
+++ b/files/ja/web/api/navigator/getusermedia/index.md
@@ -1,20 +1,6 @@
 ---
 title: Navigator.getUserMedia()
 slug: Web/API/Navigator/getUserMedia
-page-type: web-api-instance-method
-tags:
-  - API
-  - Deprecated
-  - Media
-  - Media Capture and Streams API
-  - Media Streams API
-  - Method
-  - Navigator
-  - Reference
-  - WebRTC
-  - getusermedia
-browser-compat: api.Navigator.getUserMedia
-translation_of: Web/API/Navigator/getUserMedia
 ---
 {{APIRef("Media Capture and Streams")}}{{deprecated_header}}
 

--- a/files/ja/web/api/navigator/getvrdisplays/index.md
+++ b/files/ja/web/api/navigator/getvrdisplays/index.md
@@ -1,21 +1,6 @@
 ---
 title: Navigator.getVRDisplays()
 slug: Web/API/Navigator/getVRDisplays
-page-type: web-api-instance-method
-tags:
-  - API
-  - Deprecated
-  - HTML DOM
-  - Media
-  - Method
-  - Navigator
-  - Reference
-  - VR
-  - Virtual Reality
-  - WebVR
-  - getVRDisplays()
-browser-compat: api.Navigator.getVRDisplays
-translation_of: Web/API/Navigator/getVRDisplays
 ---
 {{DefaultAPISidebar("WebVR API")}}{{deprecated_header}}
 

--- a/files/ja/web/api/navigator/hardwareconcurrency/index.md
+++ b/files/ja/web/api/navigator/hardwareconcurrency/index.md
@@ -1,15 +1,7 @@
 ---
 title: Navigator.hardwareConcurrency
 slug: Web/API/Navigator/hardwareConcurrency
-tags:
-  - API
-  - HTML DOM
-  - Navigator
-  - Property
-  - hardwareConcurrency
-translation_of: Web/API/Navigator/hardwareConcurrency
 original_slug: Web/API/NavigatorConcurrentHardware/hardwareConcurrency
-browser-compat: api.Navigator.hardwareConcurrency
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/navigator/index.md
+++ b/files/ja/web/api/navigator/index.md
@@ -1,16 +1,6 @@
 ---
 title: Navigator
 slug: Web/API/Navigator
-tags:
-  - API
-  - DOM
-  - Interface
-  - Navigator
-  - Reference
-  - Web
-  - Web Performance
-translation_of: Web/API/Navigator
-browser-compat: api.Navigator
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/navigator/keyboard/index.md
+++ b/files/ja/web/api/navigator/keyboard/index.md
@@ -1,17 +1,6 @@
 ---
 title: Navigator.keyboard
 slug: Web/API/Navigator/keyboard
-tags:
-  - API
-  - Experimental
-  - Keyboard API
-  - Keyboard Map
-  - Navigator
-  - Property
-  - Reference
-  - keyboard
-  - プロパティ
-translation_of: Web/API/Navigator/keyboard
 ---
 {{SeeCompatTable}}{{APIRef("Keyboard API")}}
 

--- a/files/ja/web/api/navigator/language/index.md
+++ b/files/ja/web/api/navigator/language/index.md
@@ -1,16 +1,7 @@
 ---
 title: Navigator.language
 slug: Web/API/Navigator/language
-tags:
-  - API
-  - Language
-  - Navigator
-  - Property
-  - Read-only
-  - Reference
-translation_of: Web/API/Navigator/language
 original_slug: Web/API/NavigatorLanguage/language
-browser-compat: api.Navigator.language
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/navigator/languages/index.md
+++ b/files/ja/web/api/navigator/languages/index.md
@@ -1,17 +1,7 @@
 ---
 title: Navigator.languages
 slug: Web/API/Navigator/languages
-tags:
-  - API
-  - Experimental
-  - Navigator
-  - Property
-  - Read-only
-  - Reference
-  - languages
-translation_of: Web/API/Navigator/languages
 original_slug: Web/API/NavigatorLanguage/languages
-browser-compat: api.Navigator.languages
 ---
 {{APIRef("HTML DOM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/navigator/locks/index.md
+++ b/files/ja/web/api/navigator/locks/index.md
@@ -1,15 +1,6 @@
 ---
 title: Navigator.locks
 slug: Web/API/Navigator/locks
-tags:
-  - API
-  - Experimental
-  - LockManager
-  - Property
-  - Reference
-  - Web Locks API
-  - locks
-translation_of: Web/API/Navigator/locks
 ---
 {{SeeCompatTable}}{{APIRef("Web Locks")}}
 

--- a/files/ja/web/api/navigator/maxtouchpoints/index.md
+++ b/files/ja/web/api/navigator/maxtouchpoints/index.md
@@ -1,15 +1,6 @@
 ---
 title: Navigator.maxTouchPoints
 slug: Web/API/Navigator/maxTouchPoints
-tags:
-  - API
-  - DOM
-  - Navigator
-  - Property
-  - Reference
-  - maxTouchPoints
-  - ポインターイベント
-translation_of: Web/API/Navigator/maxTouchPoints
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/navigator/mediacapabilities/index.md
+++ b/files/ja/web/api/navigator/mediacapabilities/index.md
@@ -1,14 +1,6 @@
 ---
 title: Navigator.mediaCapabilities
 slug: Web/API/Navigator/mediaCapabilities
-tags:
-  - API
-  - Experimental
-  - MediaCapabilities
-  - Navigator
-  - メディア
-  - メディア能力 API
-translation_of: Web/API/Navigator/mediaCapabilities
 ---
 {{SeeCompatTable}}
 

--- a/files/ja/web/api/navigator/mediadevices/index.md
+++ b/files/ja/web/api/navigator/mediadevices/index.md
@@ -1,17 +1,6 @@
 ---
 title: Navigator.mediaDevices
 slug: Web/API/Navigator/mediaDevices
-tags:
-  - Media
-  - Media Capture and Streams API
-  - Media Streams API
-  - MediaDevices
-  - Navigator
-  - Property
-  - Read-only
-  - Reference
-  - Web
-translation_of: Web/API/Navigator/mediaDevices
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/navigator/mozislocallyavailable/index.md
+++ b/files/ja/web/api/navigator/mozislocallyavailable/index.md
@@ -1,14 +1,6 @@
 ---
 title: Navigator.mozIsLocallyAvailable()
 slug: Web/API/Navigator/mozIsLocallyAvailable
-tags:
-  - API
-  - メソッド
-  - Navigator
-  - Non-standard
-  - 非推奨
-browser-compat: api.Navigator.mozIsLocallyAvailable
-translation_of: Web/API/Navigator/mozIsLocallyAvailable
 ---
 {{APIRef("HTML DOM")}} {{non-standard_header}}{{deprecated_header}}
 

--- a/files/ja/web/api/navigator/online/index.md
+++ b/files/ja/web/api/navigator/online/index.md
@@ -1,16 +1,7 @@
 ---
 title: Navigator.onLine
 slug: Web/API/Navigator/onLine
-tags:
-  - API
-  - DOM Reference
-  - Navigator
-  - Online
-  - Property
-  - Reference
-translation_of: Web/API/Navigator/onLine
 original_slug: Web/API/NavigatorOnLine/onLine
-browser-compat: api.Navigator.onLine
 ---
 {{ApiRef("HTML DOM")}}
 

--- a/files/ja/web/api/navigator/oscpu/index.md
+++ b/files/ja/web/api/navigator/oscpu/index.md
@@ -1,17 +1,6 @@
 ---
 title: Navigator.oscpu
 slug: Web/API/Navigator/oscpu
-tags:
-  - API
-  - CPU
-  - HTML DOM
-  - Navigator
-  - NavigatorID
-  - Property
-  - Reference
-  - oscpu
-  - processor
-translation_of: Web/API/Navigator/oscpu
 ---
 {{ ApiRef("HTML DOM") }}
 

--- a/files/ja/web/api/navigator/permissions/index.md
+++ b/files/ja/web/api/navigator/permissions/index.md
@@ -1,14 +1,6 @@
 ---
 title: Navigator.permissions
 slug: Web/API/Navigator/permissions
-tags:
-  - API
-  - Experimental
-  - Navigator
-  - Permissions
-  - Property
-  - Reference
-translation_of: Web/API/Navigator/permissions
 ---
 {{APIRef("HTML DOM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/navigator/platform/index.md
+++ b/files/ja/web/api/navigator/platform/index.md
@@ -1,17 +1,7 @@
 ---
 title: Navigator.platform
 slug: Web/API/Navigator/platform
-tags:
-  - API
-  - Deprecated
-  - HTML DOM
-  - Navigator
-  - Property
-  - Reference
-  - platform
-translation_of: Web/API/NavigatorID/platform
 original_slug: Web/API/NavigatorID/platform
-browser-compat: api.Navigator.platform
 ---
 {{ APIRef("HTML DOM") }} {{Deprecated_Header}}
 

--- a/files/ja/web/api/navigator/presentation/index.md
+++ b/files/ja/web/api/navigator/presentation/index.md
@@ -1,7 +1,6 @@
 ---
 title: Navigator.presentation
 slug: Web/API/Navigator/presentation
-translation_of: Web/API/Navigator/presentation
 ---
 {{SeeCompatTable}}{{securecontext_header}}{{APIRef("Presentation API")}}
 

--- a/files/ja/web/api/navigator/product/index.md
+++ b/files/ja/web/api/navigator/product/index.md
@@ -1,15 +1,7 @@
 ---
 title: Navigator.product
 slug: Web/API/Navigator/product
-tags:
-  - API
-  - Deprecated
-  - Navigator
-  - Property
-  - Reference
-translation_of: Web/API/NavigatorID/product
 original_slug: Web/API/NavigatorID/product
-browser-compat: api.Navigator.product
 ---
 {{APIRef("HTML DOM")}} {{Deprecated_Header}}
 

--- a/files/ja/web/api/navigator/productsub/index.md
+++ b/files/ja/web/api/navigator/productsub/index.md
@@ -1,13 +1,6 @@
 ---
 title: Navigator.productSub
 slug: Web/API/Navigator/productSub
-tags:
-  - API
-  - DOM
-  - Navigator
-  - Property
-  - Read-only
-translation_of: Web/API/Navigator/productSub
 ---
 {{ ApiRef("HTML DOM") }}
 

--- a/files/ja/web/api/navigator/registerprotocolhandler/index.md
+++ b/files/ja/web/api/navigator/registerprotocolhandler/index.md
@@ -1,17 +1,6 @@
 ---
 title: Navigator.registerProtocolHandler()
 slug: Web/API/Navigator/registerProtocolHandler
-page-type: web-api-instance-method
-tags:
-  - API
-  - HTML DOM
-  - メソッド
-  - Navigator
-  - リファレンス
-  - ウェブベースプロトコルハンドラー
-  - registerProtocolHandler
-browser-compat: api.Navigator.registerProtocolHandler
-translation_of: Web/API/Navigator/registerProtocolHandler
 ---
 {{APIRef("HTML DOM")}}{{securecontext_header}}
 

--- a/files/ja/web/api/navigator/registerprotocolhandler/web-based_protocol_handlers/index.md
+++ b/files/ja/web/api/navigator/registerprotocolhandler/web-based_protocol_handlers/index.md
@@ -1,12 +1,6 @@
 ---
 title: ウェブベースのプロトコルハンドラー
 slug: Web/API/Navigator/registerProtocolHandler/Web-based_protocol_handlers
-page-type: guide
-tags:
-  - 上級者
-  - HTML5
-  - ウェブベースのプロトコルハンドラー
-translation_of: Web/API/Navigator/registerProtocolHandler/Web-based_protocol_handlers
 ---
 ## 背景
 

--- a/files/ja/web/api/navigator/sendbeacon/index.md
+++ b/files/ja/web/api/navigator/sendbeacon/index.md
@@ -1,19 +1,6 @@
 ---
 title: Navigator.sendBeacon()
 slug: Web/API/Navigator/sendBeacon
-tags:
-  - API
-  - Beacon
-  - Method
-  - Navigator
-  - Networking
-  - Reference
-  - Web Performance
-  - sendBeacon
-  - ネットワーク
-  - ビーコン
-  - メソッド
-translation_of: Web/API/Navigator/sendBeacon
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/navigator/serviceworker/index.md
+++ b/files/ja/web/api/navigator/serviceworker/index.md
@@ -1,15 +1,6 @@
 ---
 title: Navigator.serviceWorker
 slug: Web/API/Navigator/serviceWorker
-tags:
-  - API
-  - Navigator
-  - Property
-  - Reference
-  - Service Workers
-  - Service worker API
-  - ServiceWorker
-translation_of: Web/API/Navigator/serviceWorker
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/navigator/share/index.md
+++ b/files/ja/web/api/navigator/share/index.md
@@ -1,14 +1,6 @@
 ---
 title: Navigator.share()
 slug: Web/API/Navigator/share
-tags:
-  - Method
-  - Navigator
-  - Reference
-  - Share
-  - Web
-  - メソッド
-translation_of: Web/API/Navigator/share
 ---
 {{APIRef("HTML DOM")}}{{securecontext_header}}
 

--- a/files/ja/web/api/navigator/useragent/index.md
+++ b/files/ja/web/api/navigator/useragent/index.md
@@ -1,15 +1,7 @@
 ---
 title: Navigator.userAgent
 slug: Web/API/Navigator/userAgent
-tags:
-  - API
-  - Navigator
-  - Property
-  - Read-only
-  - Reference
-translation_of: Web/API/NavigatorID/userAgent
 original_slug: Web/API/NavigatorID/userAgent
-browser-compat: api.Navigator.userAgent
 ---
 {{ApiRef("HTML DOM")}}
 

--- a/files/ja/web/api/navigator/vendor/index.md
+++ b/files/ja/web/api/navigator/vendor/index.md
@@ -1,13 +1,6 @@
 ---
 title: Navigator.vendor
 slug: Web/API/Navigator/vendor
-tags:
-  - API
-  - HTML DOM
-  - Navigator
-  - Read-only
-  - プロパティ
-translation_of: Web/API/Navigator/vendor
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/ja/web/api/navigator/vendorsub/index.md
+++ b/files/ja/web/api/navigator/vendorsub/index.md
@@ -1,13 +1,6 @@
 ---
 title: Navigator.vendorSub
 slug: Web/API/Navigator/vendorSub
-tags:
-  - API
-  - HTML DOM
-  - Navigator
-  - Property
-  - Read-only
-translation_of: Web/API/Navigator/vendorSub
 ---
 {{ApiRef}}{{deprecated_header}}
 

--- a/files/ja/web/api/navigator/vibrate/index.md
+++ b/files/ja/web/api/navigator/vibrate/index.md
@@ -1,13 +1,6 @@
 ---
 title: Navigator.vibrate()
 slug: Web/API/Navigator/vibrate
-tags:
-  - API
-  - Method
-  - Navigator
-  - Reference
-  - Vibration API
-translation_of: Web/API/Navigator/vibrate
 ---
 {{APIRef("Vibration API")}}
 

--- a/files/ja/web/api/navigator/wakelock/index.md
+++ b/files/ja/web/api/navigator/wakelock/index.md
@@ -1,12 +1,6 @@
 ---
 title: Navigator.wakeLock
 slug: Web/API/Navigator/wakeLock
-tags:
-  - API
-  - リファレンス
-  - 画面起動ロック API
-browser-compat: api.Navigator.wakeLock
-translation_of: Web/API/Navigator/wakeLock
 ---
 {{ApiRef("Screen Wake Lock API")}}{{SeeCompatTable}}{{securecontext_header}}
 

--- a/files/ja/web/api/navigator/webdriver/index.md
+++ b/files/ja/web/api/navigator/webdriver/index.md
@@ -1,15 +1,6 @@
 ---
 title: Navigator.webdriver
 slug: Web/API/Navigator/webdriver
-tags:
-  - API
-  - Navigator
-  - Property
-  - Reference
-  - WebDriver
-  - weblock
-  - プロパティ
-translation_of: Web/API/Navigator/webdriver
 ---
 {{SeeCompatTable}}{{APIRef("WebDriver")}}
 

--- a/files/ja/web/api/navigator/xr/index.md
+++ b/files/ja/web/api/navigator/xr/index.md
@@ -1,20 +1,6 @@
 ---
 title: Navigator.xr
 slug: Web/API/Navigator/xr
-tags:
-  - API
-  - AR
-  - Augmented Reality
-  - Getter
-  - Graphics
-  - Navigator
-  - Property
-  - Reference
-  - VR
-  - Virtual Reality
-  - WebXR
-  - XR
-translation_of: Web/API/Navigator/xr
 ---
 {{APIRef("WebXR Device API")}}
 

--- a/files/ja/web/api/ndefmessage/index.md
+++ b/files/ja/web/api/ndefmessage/index.md
@@ -1,12 +1,6 @@
 ---
 title: NDEFMessage
 slug: Web/API/NDEFMessage
-tags:
-  - NDEF
-  - リファレンス
-  - ウェブ NFC
-browser-compat: api.NDEFMessage
-translation_of: Web/API/NDEFMessage
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
 

--- a/files/ja/web/api/ndefmessage/ndefmessage/index.md
+++ b/files/ja/web/api/ndefmessage/ndefmessage/index.md
@@ -1,13 +1,6 @@
 ---
 title: NDEFMessage.NDEFMessage()
 slug: Web/API/NDEFMessage/NDEFMessage
-tags:
-  - API
-  - コンストラクター
-  - リファレンス
-  - NDEFMessage
-browser-compat: api.NDEFMessage.NDEFMessage
-translation_of: Web/API/NDEFMessage/NDEFMessage
 ---
 {{securecontext_header}}{{APIRef()}}
 

--- a/files/ja/web/api/ndefmessage/records/index.md
+++ b/files/ja/web/api/ndefmessage/records/index.md
@@ -1,13 +1,6 @@
 ---
 title: NDEFMessage.records
 slug: Web/API/NDEFMessage/records
-tags:
-  - NDEF
-  - リファレンス
-  - ウェブ NFC
-  - プロパティ
-browser-compat: api.NDEFMessage.records
-translation_of: Web/API/NDEFMessage/records
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
 

--- a/files/ja/web/api/ndefreader/index.md
+++ b/files/ja/web/api/ndefreader/index.md
@@ -1,12 +1,6 @@
 ---
 title: NDEFReader
 slug: Web/API/NDEFReader
-tags:
-  - NDEF
-  - リファレンス
-  - ウェブ NFC
-browser-compat: api.NDEFReader
-translation_of: Web/API/NDEFReader
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
 

--- a/files/ja/web/api/ndefreader/ndefreader/index.md
+++ b/files/ja/web/api/ndefreader/ndefreader/index.md
@@ -1,13 +1,6 @@
 ---
 title: NDEFReader()
 slug: Web/API/NDEFReader/NDEFReader
-tags:
-  - NDEF
-  - リファレンス
-  - ウェブ NFC
-  - コンストラクター
-browser-compat: api.NDEFReader.NDEFReader
-translation_of: Web/API/NDEFReader/NDEFReader
 ---
 {{securecontext_header}}{{APIRef()}}
 

--- a/files/ja/web/api/ndefreader/reading_event/index.md
+++ b/files/ja/web/api/ndefreader/reading_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'NDEFReader: reading イベント'
 slug: Web/API/NDEFReader/reading_event
-tags:
-  - NDEF
-  - リファレンス
-  - ウェブ NFC
-  - Event
-browser-compat: api.NDEFReader.reading_event
-translation_of: Web/API/NDEFReader/reading_event
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
 

--- a/files/ja/web/api/ndefreader/readingerror_event/index.md
+++ b/files/ja/web/api/ndefreader/readingerror_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'NDEFReader: readingerror イベント'
 slug: Web/API/NDEFReader/readingerror_event
-tags:
-  - Event
-  - NDEF
-  - リファレンス
-  - ウェブ NFC
-  - プロパティ
-browser-compat: api.NDEFReader.readingerror_event
-translation_of: Web/API/NDEFReader/readingerror_event
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
 

--- a/files/ja/web/api/ndefreader/scan/index.md
+++ b/files/ja/web/api/ndefreader/scan/index.md
@@ -1,12 +1,6 @@
 ---
 title: NDEFReader.scan()
 slug: Web/API/NDEFReader/scan
-tags:
-  - NDEF
-  - リファレンス
-  - ウェブ NFC
-  - メソッド
-browser-compat: api.NDEFReader.scan
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
 

--- a/files/ja/web/api/ndefreader/write/index.md
+++ b/files/ja/web/api/ndefreader/write/index.md
@@ -1,13 +1,6 @@
 ---
 title: NDEFReader.write()
 slug: Web/API/NDEFReader/write
-tags:
-  - NDEF
-  - リファレンス
-  - ウェブ NFC
-  - メソッド
-browser-compat: api.NDEFReader.write
-translation_of: Web/API/NDEFReader/write
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
 

--- a/files/ja/web/api/ndefreadingevent/index.md
+++ b/files/ja/web/api/ndefreadingevent/index.md
@@ -1,12 +1,6 @@
 ---
 title: NDEFReadingEvent
 slug: Web/API/NDEFReadingEvent
-tags:
-  - NDEF
-  - リファレンス
-  - Web NFC
-browser-compat: api.NDEFReadingEvent
-translation_of: Web/API/NDEFReadingEvent
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
 

--- a/files/ja/web/api/ndefreadingevent/message/index.md
+++ b/files/ja/web/api/ndefreadingevent/message/index.md
@@ -1,13 +1,6 @@
 ---
 title: NDEFReadingEvent.message
 slug: Web/API/NDEFReadingEvent/message
-tags:
-  - API
-  - Property
-  - リファレンス
-  - message
-  - NDEFReadingEvent
-browser-compat: api.NDEFReadingEvent.message
 ---
 {{securecontext_header}}{{APIRef()}}
 

--- a/files/ja/web/api/ndefreadingevent/ndefreadingevent/index.md
+++ b/files/ja/web/api/ndefreadingevent/ndefreadingevent/index.md
@@ -1,13 +1,6 @@
 ---
 title: NDEFReadingEvent.NDEFReadingEvent()
 slug: Web/API/NDEFReadingEvent/NDEFReadingEvent
-tags:
-  - API
-  - コンストラクター
-  - リファレンス
-  - NDEFReadingEvent
-browser-compat: api.NDEFReadingEvent.NDEFReadingEvent
-translation_of: Web/API/NDEFReadingEvent/NDEFReadingEvent
 ---
 {{securecontext_header}}{{APIRef()}}
 

--- a/files/ja/web/api/ndefreadingevent/serialnumber/index.md
+++ b/files/ja/web/api/ndefreadingevent/serialnumber/index.md
@@ -1,14 +1,6 @@
 ---
 title: NDEFReadingEvent.serialNumber
 slug: Web/API/NDEFReadingEvent/serialNumber
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - serialNumber
-  - NDEFReadingEvent
-browser-compat: api.NDEFReadingEvent.serialNumber
-tranlation_of: Web/API/NDEFReadingEvent/serialNumber
 ---
 {{securecontext_header}}{{APIRef()}}
 

--- a/files/ja/web/api/ndefrecord/data/index.md
+++ b/files/ja/web/api/ndefrecord/data/index.md
@@ -1,12 +1,6 @@
 ---
 title: NDEFRecord.data
 slug: Web/API/NDEFRecord/data
-tags:
-  - NDEF
-  - リファレンス
-  - ウェブ NFC
-browser-compat: api.NDEFRecord.data
-translation_of: Web/API/NDEFRecord/data
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
 

--- a/files/ja/web/api/ndefrecord/encoding/index.md
+++ b/files/ja/web/api/ndefrecord/encoding/index.md
@@ -1,13 +1,6 @@
 ---
 title: NDEFRecord.encoding
 slug: Web/API/NDEFRecord/encoding
-tags:
-  - Encoding
-  - NDEF
-  - リファレンス
-  - ウェブ NFC
-browser-compat: api.NDEFRecord.encoding
-translation_of: Web/API/NDEFRecord/encoding
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
 

--- a/files/ja/web/api/ndefrecord/id/index.md
+++ b/files/ja/web/api/ndefrecord/id/index.md
@@ -1,13 +1,6 @@
 ---
 title: NDEFRecord.id
 slug: Web/API/NDEFRecord/id
-tags:
-  - NDEF
-  - NDEFRecord
-  - リファレンス
-  - ウェブ NFC
-browser-compat: api.NDEFRecord.id
-translation_of: Web/API/NDEFRecord/id
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
 

--- a/files/ja/web/api/ndefrecord/index.md
+++ b/files/ja/web/api/ndefrecord/index.md
@@ -1,12 +1,6 @@
 ---
 title: NDEFRecord
 slug: Web/API/NDEFRecord
-tags:
-  - NDEF
-  - リファレンス
-  - ウェブ NFC
-browser-compat: api.NDEFRecord
-translation_of: Web/API/NDEFRecord
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
 

--- a/files/ja/web/api/ndefrecord/lang/index.md
+++ b/files/ja/web/api/ndefrecord/lang/index.md
@@ -1,12 +1,6 @@
 ---
 title: NDEFRecord.lang
 slug: Web/API/NDEFRecord/lang
-tags:
-  - NDEF
-  - リファレンス
-  - ウェブ NFC
-browser-compat: api.NDEFRecord.lang
-translation_of: Web/API/NDEFRecord/lang
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
 

--- a/files/ja/web/api/ndefrecord/mediatype/index.md
+++ b/files/ja/web/api/ndefrecord/mediatype/index.md
@@ -1,12 +1,6 @@
 ---
 title: NDEFRecord.mediaType
 slug: Web/API/NDEFRecord/mediaType
-tags:
-  - NDEF
-  - リファレンス
-  - ウェブ NFC
-browser-compat: api.NDEFRecord.mediaType
-translation_of: Web/API/NDEFRecord/mediaType
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
 

--- a/files/ja/web/api/ndefrecord/ndefrecord/index.md
+++ b/files/ja/web/api/ndefrecord/ndefrecord/index.md
@@ -1,12 +1,6 @@
 ---
 title: NDEFRecord()
 slug: Web/API/NDEFRecord/NDEFRecord
-tags:
-  - NDEF
-  - リファレンス
-  - ウェブ NFC
-browser-compat: api.NDEFRecord.NDEFRecord
-translation_of: Web/API/NDEFRecord/NDEFRecord
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
 

--- a/files/ja/web/api/ndefrecord/recordtype/index.md
+++ b/files/ja/web/api/ndefrecord/recordtype/index.md
@@ -1,12 +1,6 @@
 ---
 title: NDEFRecord.recordType
 slug: Web/API/NDEFRecord/recordType
-tags:
-  - NDEF
-  - リファレンス
-  - ウェブ NFC
-browser-compat: api.NDEFRecord.recordType
-translation_of: Web/API/NDEFRecord/recordType
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
 

--- a/files/ja/web/api/ndefrecord/torecords/index.md
+++ b/files/ja/web/api/ndefrecord/torecords/index.md
@@ -1,12 +1,6 @@
 ---
 title: NDEFRecord.toRecords()
 slug: Web/API/NDEFRecord/toRecords
-tags:
-  - NDEF
-  - リファレンス
-  - ウェブ NFC
-browser-compat: api.NDEFRecord.toRecords
-translation_of: Web/API/NDEFRecord/toRecords
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
 

--- a/files/ja/web/api/network_information_api/index.md
+++ b/files/ja/web/api/network_information_api/index.md
@@ -1,13 +1,6 @@
 ---
 title: Network Information API
 slug: Web/API/Network_Information_API
-tags:
-  - API
-  - Experimental
-  - Network Information API
-  - Reference
-  - WebAPI
-translation_of: Web/API/Network_Information_API
 ---
 {{DefaultAPISidebar("Network Information API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/networkinformation/change_event/index.md
+++ b/files/ja/web/api/networkinformation/change_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: NetworkInformation.onchange
 slug: Web/API/NetworkInformation/change_event
-tags:
-  - API
-  - Event Handler
-  - Experimental
-  - Network Information API
-  - NetworkInformation
-  - Property
-  - Reference
-translation_of: Web/API/NetworkInformation/onchange
 original_slug: Web/API/NetworkInformation/onchange
 ---
 {{apiref("Network Information API")}}{{SeeCompatTable}}

--- a/files/ja/web/api/networkinformation/downlinkmax/index.md
+++ b/files/ja/web/api/networkinformation/downlinkmax/index.md
@@ -1,15 +1,6 @@
 ---
 title: NetworkInformation.downlinkMax
 slug: Web/API/NetworkInformation/downlinkMax
-tags:
-  - API
-  - Experimental
-  - Network Information API
-  - NetworkInformation
-  - Property
-  - Read-only
-  - Reference
-translation_of: Web/API/NetworkInformation/downlinkMax
 ---
 {{APIRef("Network Information API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/networkinformation/index.md
+++ b/files/ja/web/api/networkinformation/index.md
@@ -1,13 +1,6 @@
 ---
 title: NetworkInformation
 slug: Web/API/NetworkInformation
-tags:
-  - API
-  - Experimental
-  - Interface
-  - Network Information API
-  - Reference
-translation_of: Web/API/NetworkInformation
 ---
 {{APIRef("Network Information API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/networkinformation/type/index.md
+++ b/files/ja/web/api/networkinformation/type/index.md
@@ -1,15 +1,6 @@
 ---
 title: NetworkInformation.type
 slug: Web/API/NetworkInformation/type
-tags:
-  - API
-  - Experimental
-  - Network Information API
-  - NetworkInformation
-  - Property
-  - Read-only
-  - Reference
-translation_of: Web/API/NetworkInformation/type
 ---
 {{apiref("Network Information API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/node/appendchild/index.md
+++ b/files/ja/web/api/node/appendchild/index.md
@@ -1,11 +1,6 @@
 ---
 title: Node.appendChild()
 slug: Web/API/Node/appendChild
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.Node.appendChild
-translation_of: Web/API/Node/appendChild
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/baseuri/index.md
+++ b/files/ja/web/api/node/baseuri/index.md
@@ -1,12 +1,6 @@
 ---
 title: Node.baseURI
 slug: Web/API/Node/baseURI
-tags:
-  - Node
-  - プロパティ
-  - 読み取り専用
-browser-compat: api.Node.baseURI
-translation_of: Web/API/Node/baseURI
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/childnodes/index.md
+++ b/files/ja/web/api/node/childnodes/index.md
@@ -1,12 +1,6 @@
 ---
 title: Node.childNodes
 slug: Web/API/Node/childNodes
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.Node.childNodes
-translation_of: Web/API/Node/childNodes
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/clonenode/index.md
+++ b/files/ja/web/api/node/clonenode/index.md
@@ -1,11 +1,6 @@
 ---
 title: Node.cloneNode()
 slug: Web/API/Node/cloneNode
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.Node.cloneNode
-translation_of: Web/API/Node/cloneNode
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/comparedocumentposition/index.md
+++ b/files/ja/web/api/node/comparedocumentposition/index.md
@@ -1,11 +1,6 @@
 ---
 title: Node.compareDocumentPosition()
 slug: Web/API/Node/compareDocumentPosition
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.Node.compareDocumentPosition
-translation_of: Web/API/Node/compareDocumentPosition
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/contains/index.md
+++ b/files/ja/web/api/node/contains/index.md
@@ -1,11 +1,6 @@
 ---
 title: Node.contains()
 slug: Web/API/Node/contains
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.Node.contains
-translation_of: Web/API/Node/contains
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/firstchild/index.md
+++ b/files/ja/web/api/node/firstchild/index.md
@@ -1,11 +1,6 @@
 ---
 title: Node.firstChild
 slug: Web/API/Node/firstChild
-tags:
-  - プロパティ
-  - リファレンス
-browser-compat: api.Node.firstChild
-translation_of: Web/API/Node/firstChild
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/getrootnode/index.md
+++ b/files/ja/web/api/node/getrootnode/index.md
@@ -1,11 +1,6 @@
 ---
 title: Node.getRootNode()
 slug: Web/API/Node/getRootNode
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.Node.getRootNode
-translation_of: Web/API/Node/getRootNode
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/haschildnodes/index.md
+++ b/files/ja/web/api/node/haschildnodes/index.md
@@ -1,12 +1,6 @@
 ---
 title: Node.hasChildNodes()
 slug: Web/API/Node/hasChildNodes
-tags:
-  - メソッド
-
-  - リファレンス
-browser-compat: api.Node.hasChildNodes
-translation_of: Web/API/Node/hasChildNodes
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/index.md
+++ b/files/ja/web/api/node/index.md
@@ -1,11 +1,6 @@
 ---
 title: Node
 slug: Web/API/Node
-tags:
-  - インターフェイス
-  - リファレンス
-browser-compat: api.Node
-translation_of: Web/API/Node
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/insertbefore/index.md
+++ b/files/ja/web/api/node/insertbefore/index.md
@@ -1,11 +1,6 @@
 ---
 title: Node.insertBefore()
 slug: Web/API/Node/insertBefore
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.Node.insertBefore
-translation_of: Web/API/Node/insertBefore
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/isconnected/index.md
+++ b/files/ja/web/api/node/isconnected/index.md
@@ -1,12 +1,6 @@
 ---
 title: Node.isConnected
 slug: Web/API/Node/isConnected
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.Node.isConnected
-translation_of: Web/API/Node/isConnected
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/isdefaultnamespace/index.md
+++ b/files/ja/web/api/node/isdefaultnamespace/index.md
@@ -1,11 +1,6 @@
 ---
 title: Node.isDefaultNamespace()
 slug: Web/API/Node/isDefaultNamespace
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.Node.isDefaultNamespace
-translation_of: Web/API/Node/isDefaultNamespace
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/isequalnode/index.md
+++ b/files/ja/web/api/node/isequalnode/index.md
@@ -1,11 +1,6 @@
 ---
 title: Node.isEqualNode()
 slug: Web/API/Node/isEqualNode
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.Node.isEqualNode
-translation_of: Web/API/Node/isEqualNode
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/issamenode/index.md
+++ b/files/ja/web/api/node/issamenode/index.md
@@ -1,11 +1,6 @@
 ---
 title: Node.isSameNode()
 slug: Web/API/Node/isSameNode
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.Node.isSameNode
-translation_of: Web/API/Node/isSameNode
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/issupported/index.md
+++ b/files/ja/web/api/node/issupported/index.md
@@ -1,12 +1,6 @@
 ---
 title: Node.isSupported()
 slug: Web/API/Node/isSupported
-tags:
-  - メソッド
-  - 非推奨
-  - リファレンス
-browser-compat: api.Node.isSupported
-translation_of: Web/API/Node/isSupported
 ---
 {{APIRef("DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/node/lastchild/index.md
+++ b/files/ja/web/api/node/lastchild/index.md
@@ -1,12 +1,6 @@
 ---
 title: Node.lastChild
 slug: Web/API/Node/lastChild
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.Node.lastChild
-translation_of: Web/API/Node/lastChild
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/lookupnamespaceuri/index.md
+++ b/files/ja/web/api/node/lookupnamespaceuri/index.md
@@ -1,10 +1,6 @@
 ---
 title: Node.lookupNamespaceURI()
 slug: Web/API/Node/lookupNamespaceURI
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.Node.lookupNamespaceURI
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/lookupprefix/index.md
+++ b/files/ja/web/api/node/lookupprefix/index.md
@@ -1,11 +1,6 @@
 ---
 title: Node.lookupPrefix()
 slug: Web/API/Node/lookupPrefix
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.Node.lookupPrefix
-translation_of: Web/API/Node/lookupPrefix
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/nextsibling/index.md
+++ b/files/ja/web/api/node/nextsibling/index.md
@@ -1,12 +1,6 @@
 ---
 title: Node.nextSibling
 slug: Web/API/Node/nextSibling
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.Node.nextSibling
-translation_of: Web/API/Node/nextSibling
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/nodename/index.md
+++ b/files/ja/web/api/node/nodename/index.md
@@ -1,12 +1,6 @@
 ---
 title: Node.nodeName
 slug: Web/API/Node/nodeName
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.Node.nodeName
-translation_of: Web/API/Node/nodeName
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/nodetype/index.md
+++ b/files/ja/web/api/node/nodetype/index.md
@@ -1,12 +1,6 @@
 ---
 title: Node.nodeType
 slug: Web/API/Node/nodeType
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.Node.nodeType
-translation_of: Web/API/Node/nodeType
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/nodevalue/index.md
+++ b/files/ja/web/api/node/nodevalue/index.md
@@ -1,11 +1,6 @@
 ---
 title: Node.nodeValue
 slug: Web/API/Node/nodeValue
-tags:
-  - プロパティ
-  - リファレンス
-browser-compat: api.Node.nodeValue
-translation_of: Web/API/Node/nodeValue
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/normalize/index.md
+++ b/files/ja/web/api/node/normalize/index.md
@@ -1,11 +1,6 @@
 ---
 title: Node.normalize()
 slug: Web/API/Node/normalize
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.Node.normalize
-translation_of: Web/API/Node/normalize
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/ownerdocument/index.md
+++ b/files/ja/web/api/node/ownerdocument/index.md
@@ -1,12 +1,6 @@
 ---
 title: Node.ownerDocument
 slug: Web/API/Node/ownerDocument
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.Node.ownerDocument
-translation_of: Web/API/Node/ownerDocument
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/parentelement/index.md
+++ b/files/ja/web/api/node/parentelement/index.md
@@ -1,12 +1,6 @@
 ---
 title: Node.parentElement
 slug: Web/API/Node/parentElement
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.Node.parentElement
-translation_of: Web/API/Node/parentElement
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/parentnode/index.md
+++ b/files/ja/web/api/node/parentnode/index.md
@@ -1,12 +1,6 @@
 ---
 title: Node.parentNode
 slug: Web/API/Node/parentNode
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.Node.parentNode
-translation_of: Web/API/Node/parentNode
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/previoussibling/index.md
+++ b/files/ja/web/api/node/previoussibling/index.md
@@ -1,12 +1,6 @@
 ---
 title: Node.previousSibling
 slug: Web/API/Node/previousSibling
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.Node.previousSibling
-translation_of: Web/API/Node/previousSibling
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/removechild/index.md
+++ b/files/ja/web/api/node/removechild/index.md
@@ -1,11 +1,6 @@
 ---
 title: Node.removeChild()
 slug: Web/API/Node/removeChild
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.Node.removeChild
-translation_of: Web/API/Node/removeChild
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/replacechild/index.md
+++ b/files/ja/web/api/node/replacechild/index.md
@@ -1,11 +1,6 @@
 ---
 title: Node.replaceChild
 slug: Web/API/Node/replaceChild
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.Node.replaceChild
-translation_of: Web/API/Node/replaceChild
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/node/textcontent/index.md
+++ b/files/ja/web/api/node/textcontent/index.md
@@ -1,11 +1,6 @@
 ---
 title: Node.textContent
 slug: Web/API/Node/textContent
-tags:
-  - プロパティ
-  - リファレンス
-browser-compat: api.Node.textContent
-translation_of: Web/API/Node/textContent
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/nodeiterator/index.md
+++ b/files/ja/web/api/nodeiterator/index.md
@@ -1,12 +1,6 @@
 ---
 title: NodeIterator
 slug: Web/API/NodeIterator
-page-type: web-api-interface
-tags:
-  - API
-  - DOM
-browser-compat: api.NodeIterator
-translation_of: Web/API/NodeIterator
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/nodelist/foreach/index.md
+++ b/files/ja/web/api/nodelist/foreach/index.md
@@ -1,14 +1,6 @@
 ---
 title: NodeList.prototype.forEach()
 slug: Web/API/NodeList/forEach
-tags:
-  - DOM
-  - Iterable
-  - Method
-  - NodeList
-  - Reference
-  - Web
-translation_of: Web/API/NodeList/forEach
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/nodelist/index.md
+++ b/files/ja/web/api/nodelist/index.md
@@ -1,13 +1,6 @@
 ---
 title: NodeList
 slug: Web/API/NodeList
-tags:
-  - API
-  - DOM
-  - Interface
-  - NodeList
-  - インターフェイス
-translation_of: Web/API/NodeList
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/nodelist/item/index.md
+++ b/files/ja/web/api/nodelist/item/index.md
@@ -1,12 +1,6 @@
 ---
 title: NodeList.item
 slug: Web/API/NodeList/item
-tags:
-  - DOM
-  - Gecko
-  - Gecko DOM Reference
-  - NodeList
-translation_of: Web/API/NodeList/item
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/nodelist/length/index.md
+++ b/files/ja/web/api/nodelist/length/index.md
@@ -1,13 +1,6 @@
 ---
 title: NodeList.length
 slug: Web/API/NodeList/length
-tags:
-  - API
-  - DOM
-  - Gecko
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/NodeList/length
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/notification/actions/index.md
+++ b/files/ja/web/api/notification/actions/index.md
@@ -1,17 +1,6 @@
 ---
 title: Notification.actions
 slug: Web/API/Notification/actions
-page-type: web-api-instance-property
-tags:
-  - API
-  - Notification
-  - Notifications
-  - Notifications API
-  - Property
-  - Reference
-  - actions
-browser-compat: api.Notification.actions
-translation_of: Web/API/Notification/actions
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 

--- a/files/ja/web/api/notification/badge/index.md
+++ b/files/ja/web/api/notification/badge/index.md
@@ -1,17 +1,6 @@
 ---
 title: Notification.badge
 slug: Web/API/Notification/badge
-page-type: web-api-instance-property
-tags:
-  - API
-  - Notification
-  - Notifications
-  - Notifications API
-  - Property
-  - Reference
-  - badge
-browser-compat: api.Notification.badge
-translation_of: Web/API/Notification/badge
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 

--- a/files/ja/web/api/notification/body/index.md
+++ b/files/ja/web/api/notification/body/index.md
@@ -1,17 +1,6 @@
 ---
 title: Notification.body
 slug: Web/API/Notification/body
-page-type: web-api-instance-property
-tags:
-  - API
-  - BODY
-  - Notification
-  - Notifications
-  - Notifications API
-  - Property
-  - Reference
-browser-compat: api.Notification.body
-translation_of: Web/API/Notification/body
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 

--- a/files/ja/web/api/notification/click_event/index.md
+++ b/files/ja/web/api/notification/click_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'Notification: click イベント'
 slug: Web/API/Notification/click_event
-page-type: web-api-event
-tags:
-  - API
-  - Notification
-  - Notifications
-  - Notifications API
-  - Event
-  - Reference
-  - click
-browser-compat: api.Notification.click_event
-translation_of: Web/API/Notification/click_event
 original_slug: Web/API/Notification/onclick
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}

--- a/files/ja/web/api/notification/close/index.md
+++ b/files/ja/web/api/notification/close/index.md
@@ -1,17 +1,6 @@
 ---
 title: Notification.close()
 slug: Web/API/Notification/close
-page-type: web-api-instance-method
-tags:
-  - API
-  - Method
-  - Notification
-  - Notifications
-  - Notifications API
-  - Reference
-  - close
-browser-compat: api.Notification.close
-translation_of: Web/API/Notification/close
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 

--- a/files/ja/web/api/notification/close_event/index.md
+++ b/files/ja/web/api/notification/close_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'Notification: close イベント'
 slug: Web/API/Notification/close_event
-page-type: web-api-event
-tags:
-  - API
-  - Notification
-  - Notifications
-  - Notifications API
-  - Event
-  - Reference
-  - close
-browser-compat: api.Notification.close_event
-translation_of: Web/API/Notification/close_event
 original_slug: Web/API/Notification/onclose
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}

--- a/files/ja/web/api/notification/data/index.md
+++ b/files/ja/web/api/notification/data/index.md
@@ -1,17 +1,6 @@
 ---
 title: Notification.data
 slug: Web/API/Notification/data
-page-type: web-api-instance-property
-tags:
-  - API
-  - Notification
-  - Notifications
-  - Notifications API
-  - Property
-  - Reference
-  - data
-browser-compat: api.Notification.data
-translation_of: Web/API/Notification/data
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 

--- a/files/ja/web/api/notification/dir/index.md
+++ b/files/ja/web/api/notification/dir/index.md
@@ -1,17 +1,6 @@
 ---
 title: Notification.dir
 slug: Web/API/Notification/dir
-page-type: web-api-instance-property
-tags:
-  - API
-  - Notification
-  - Notifications
-  - Notifications API
-  - Property
-  - Reference
-  - dir
-browser-compat: api.Notification.dir
-translation_of: Web/API/Notification/dir
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 

--- a/files/ja/web/api/notification/error_event/index.md
+++ b/files/ja/web/api/notification/error_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'Notification: error イベント'
 slug: Web/API/Notification/error_event
-page-type: web-api-event
-tags:
-  - API
-  - Notification
-  - Notifications
-  - Notifications API
-  - Event
-  - Reference
-  - error
-browser-compat: api.Notification.error_event
-translation_of: Web/API/Notification/error_event
 original_slug: Web/API/Notification/onerror
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}

--- a/files/ja/web/api/notification/icon/index.md
+++ b/files/ja/web/api/notification/icon/index.md
@@ -1,17 +1,6 @@
 ---
 title: Notification.icon
 slug: Web/API/Notification/icon
-page-type: web-api-instance-property
-tags:
-  - API
-  - Notification
-  - Notifications
-  - Notifications API
-  - Property
-  - Reference
-  - icon
-browser-compat: api.Notification.icon
-translation_of: Web/API/Notification/icon
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 

--- a/files/ja/web/api/notification/image/index.md
+++ b/files/ja/web/api/notification/image/index.md
@@ -1,17 +1,6 @@
 ---
 title: Notification.image
 slug: Web/API/Notification/image
-page-type: web-api-instance-property
-tags:
-  - API
-  - Image
-  - Notification
-  - Notifications
-  - Notifications API
-  - Property
-  - Reference
-browser-compat: api.Notification.image
-translation_of: Web/API/Notification/image
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 

--- a/files/ja/web/api/notification/index.md
+++ b/files/ja/web/api/notification/index.md
@@ -1,15 +1,6 @@
 ---
 title: Notification
 slug: Web/API/Notification
-page-type: web-api-interface
-tags:
-  - API
-  - Interface
-  - Notifications
-  - Notifications API
-  - Reference
-browser-compat: api.Notification
-translation_of: Web/API/Notification
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 

--- a/files/ja/web/api/notification/lang/index.md
+++ b/files/ja/web/api/notification/lang/index.md
@@ -1,16 +1,6 @@
 ---
 title: Notification.lang
 slug: Web/API/Notification/lang
-page-type: web-api-instance-property
-tags:
-  - API
-  - Notification
-  - Notifications
-  - Notifications API
-  - Property
-  - Reference
-browser-compat: api.Notification.lang
-translation_of: Web/API/Notification/lang
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 

--- a/files/ja/web/api/notification/maxactions/index.md
+++ b/files/ja/web/api/notification/maxactions/index.md
@@ -1,17 +1,6 @@
 ---
 title: Notification.maxActions
 slug: Web/API/Notification/maxActions
-page-type: web-api-static-property
-tags:
-  - API
-  - Notification
-  - Notifications
-  - Notifications API
-  - Property
-  - Reference
-  - actions
-browser-compat: api.Notification.maxActions
-translation_of: Web/API/Notification/maxActions
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 

--- a/files/ja/web/api/notification/notification/index.md
+++ b/files/ja/web/api/notification/notification/index.md
@@ -1,16 +1,6 @@
 ---
 title: Notification()
 slug: Web/API/Notification/Notification
-page-type: web-api-constructor
-tags:
-  - API
-  - Constructor
-  - Notification
-  - Notifications
-  - Notifications API
-  - Reference
-browser-compat: api.Notification.Notification
-translation_of: Web/API/Notification/Notification
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 

--- a/files/ja/web/api/notification/permission/index.md
+++ b/files/ja/web/api/notification/permission/index.md
@@ -1,16 +1,6 @@
 ---
 title: Notification.permission
 slug: Web/API/Notification/permission
-page-type: web-api-static-property
-tags:
-  - API
-  - Notification
-  - Notifications
-  - Notifications API
-  - Property
-  - Reference
-browser-compat: api.Notification.permission
-translation_of: Web/API/Notification/permission
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 

--- a/files/ja/web/api/notification/renotify/index.md
+++ b/files/ja/web/api/notification/renotify/index.md
@@ -1,16 +1,6 @@
 ---
 title: Notification.renotify
 slug: Web/API/Notification/renotify
-page-type: web-api-instance-property
-tags:
-  - API
-  - Experimental
-  - Notifications
-  - Property
-  - Reference
-  - renotify
-browser-compat: api.Notification.renotify
-translation_of: Web/API/Notification/renotify
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 

--- a/files/ja/web/api/notification/requestpermission/index.md
+++ b/files/ja/web/api/notification/requestpermission/index.md
@@ -1,16 +1,6 @@
 ---
 title: Notification.requestPermission()
 slug: Web/API/Notification/requestPermission
-page-type: web-api-static-method
-tags:
-  - API
-  - Method
-  - Notification
-  - Notifications
-  - Notifications API
-  - Reference
-browser-compat: api.Notification.requestPermission
-translation_of: Web/API/Notification/requestPermission
 ---
 {{APIRef("Web Notifications")}}{{securecontext_header}}
 

--- a/files/ja/web/api/notification/requireinteraction/index.md
+++ b/files/ja/web/api/notification/requireinteraction/index.md
@@ -1,18 +1,6 @@
 ---
 title: Notification.requireInteraction
 slug: Web/API/Notification/requireInteraction
-page-type: web-api-instance-property
-tags:
-  - API
-  - Notification
-  - Notifications
-  - Notifications API
-  - Property
-  - Reference
-  - Web
-  - requireInteraction
-browser-compat: api.Notification.requireInteraction
-translation_of: Web/API/Notification/requireInteraction
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 

--- a/files/ja/web/api/notification/show_event/index.md
+++ b/files/ja/web/api/notification/show_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'Notification: show イベント'
 slug: Web/API/Notification/show_event
-page-type: web-api-event
-tags:
-  - API
-  - Notification
-  - Notifications
-  - Notifications API
-  - Event
-  - Reference
-  - show
-browser-compat: api.Notification.show_event
-translation_of: Web/API/Notification/show_event
 original_slug: Web/API/Notification/onshow
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}

--- a/files/ja/web/api/notification/silent/index.md
+++ b/files/ja/web/api/notification/silent/index.md
@@ -1,17 +1,6 @@
 ---
 title: Notification.silent
 slug: Web/API/Notification/silent
-page-type: web-api-instance-property
-tags:
-  - API
-  - Notification
-  - Notifications
-  - Notifications API
-  - Property
-  - Reference
-  - silent
-browser-compat: api.Notification.silent
-translation_of: Web/API/Notification/silent
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 

--- a/files/ja/web/api/notification/tag/index.md
+++ b/files/ja/web/api/notification/tag/index.md
@@ -1,17 +1,6 @@
 ---
 title: Notification.tag
 slug: Web/API/Notification/tag
-page-type: web-api-instance-property
-tags:
-  - API
-  - Notification
-  - Notifications
-  - Notifications API
-  - Property
-  - Reference
-  - tag
-browser-compat: api.Notification.tag
-translation_of: Web/API/Notification/tag
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 

--- a/files/ja/web/api/notification/timestamp/index.md
+++ b/files/ja/web/api/notification/timestamp/index.md
@@ -1,17 +1,6 @@
 ---
 title: Notification.timestamp
 slug: Web/API/Notification/timestamp
-page-type: web-api-instance-property
-tags:
-  - API
-  - Notification
-  - Notifications
-  - Notifications API
-  - Property
-  - Reference
-  - timeStamp
-browser-compat: api.Notification.timestamp
-translation_of: Web/API/Notification/timestamp
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 

--- a/files/ja/web/api/notification/title/index.md
+++ b/files/ja/web/api/notification/title/index.md
@@ -1,17 +1,6 @@
 ---
 title: Notification.title
 slug: Web/API/Notification/title
-page-type: web-api-instance-property
-tags:
-  - API
-  - Notification
-  - Notifications
-  - Notifications API
-  - Property
-  - Reference
-  - Title
-browser-compat: api.Notification.title
-translation_of: Web/API/Notification/title
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 

--- a/files/ja/web/api/notification/vibrate/index.md
+++ b/files/ja/web/api/notification/vibrate/index.md
@@ -1,18 +1,6 @@
 ---
 title: Notification.vibrate
 slug: Web/API/Notification/vibrate
-page-type: web-api-instance-property
-tags:
-  - API
-  - Device
-  - Notification
-  - Notifications
-  - Notifications API
-  - Property
-  - Reference
-  - vibrate
-browser-compat: api.Notification.vibrate
-translation_of: Web/API/Notification/vibrate
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 

--- a/files/ja/web/api/notificationevent/action/index.md
+++ b/files/ja/web/api/notificationevent/action/index.md
@@ -1,19 +1,6 @@
 ---
 title: NotificationEvent.action
 slug: Web/API/NotificationEvent/action
-tags:
-  - API
-  - Experimental
-  - NotificationEvent
-  - Notifications
-  - Property
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - action
-  - プロパティ
-  - 通知
-translation_of: Web/API/NotificationEvent/action
 ---
 {{APIRef("Web Notifications")}}
 

--- a/files/ja/web/api/notificationevent/index.md
+++ b/files/ja/web/api/notificationevent/index.md
@@ -1,14 +1,6 @@
 ---
 title: NotificationEvent
 slug: Web/API/NotificationEvent
-tags:
-  - API
-  - Interface
-  - NotificationEvent
-  - Reference
-  - Service Workers
-  - ServiceWorker
-translation_of: Web/API/NotificationEvent
 ---
 {{APIRef("Web Notifications")}}
 

--- a/files/ja/web/api/notificationevent/notification/index.md
+++ b/files/ja/web/api/notificationevent/notification/index.md
@@ -1,18 +1,6 @@
 ---
 title: NotificationEvent.notification
 slug: Web/API/NotificationEvent/notification
-tags:
-  - API
-  - Experimental
-  - NotificationEvent
-  - Notifications
-  - Property
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - プロパティ
-  - 通知
-translation_of: Web/API/NotificationEvent/notification
 ---
 {{APIRef("Web Notifications")}}
 

--- a/files/ja/web/api/notificationevent/notificationevent/index.md
+++ b/files/ja/web/api/notificationevent/notificationevent/index.md
@@ -1,18 +1,6 @@
 ---
 title: NotificationEvent.NotificationEvent()
 slug: Web/API/NotificationEvent/NotificationEvent
-tags:
-  - API
-  - Constructor
-  - Experimental
-  - NotificationEvent
-  - Notifications
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - コンストラクター
-  - 通知
-translation_of: Web/API/NotificationEvent/NotificationEvent
 ---
 {{APIRef("Web Notifications")}}
 

--- a/files/ja/web/api/notifications_api/index.md
+++ b/files/ja/web/api/notifications_api/index.md
@@ -1,15 +1,6 @@
 ---
 title: 通知 API
 slug: Web/API/Notifications_API
-page-type: web-api-overview
-tags:
-  - Landing
-  - Notifications
-  - Notifications API
-  - permission
-  - system
-browser-compat: api.Notification
-translation_of: Web/API/Notifications_API
 ---
 {{DefaultAPISidebar("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 

--- a/files/ja/web/api/notifications_api/using_the_notifications_api/index.md
+++ b/files/ja/web/api/notifications_api/using_the_notifications_api/index.md
@@ -1,17 +1,6 @@
 ---
 title: 通知 API の使用
 slug: Web/API/Notifications_API/Using_the_Notifications_API
-page-type: guide
-tags:
-  - API
-  - Advanced
-  - Guide
-  - Notifications
-  - Notifications API
-  - Push
-  - Tutorial
-browser-compat: api.Notification
-translation_of: Web/API/Notifications_API/Using_the_Notifications_API
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 

--- a/files/ja/web/api/offlineaudiocontext/index.md
+++ b/files/ja/web/api/offlineaudiocontext/index.md
@@ -1,7 +1,6 @@
 ---
 title: OfflineAudioContext
 slug: Web/API/OfflineAudioContext
-translation_of: Web/API/OfflineAudioContext
 ---
 {{APIRef("Web Audio API")}}`OfflineAudioContext` インターフェイスは {{domxref("AudioContext")}} インターフェイスの一種で、{{domxref("AudioNode")}} をつなげて造られる音声処理グラフを表しています。通常の {{domxref("AudioContext")}} と異なり、`OfflineAudioContext` で処理された音声はハードウェアから再生されることはありません。処理された結果は {{domxref("AudioBuffer")}} に出力されます。
 

--- a/files/ja/web/api/offscreencanvas/getcontext/index.md
+++ b/files/ja/web/api/offscreencanvas/getcontext/index.md
@@ -1,7 +1,6 @@
 ---
 title: OffscreenCanvas.getContext()
 slug: Web/API/OffscreenCanvas/getContext
-translation_of: Web/API/OffscreenCanvas/getContext
 ---
 {{APIRef("Canvas API")}} {{SeeCompatTable}}
 

--- a/files/ja/web/api/offscreencanvas/index.md
+++ b/files/ja/web/api/offscreencanvas/index.md
@@ -1,16 +1,6 @@
 ---
 title: OffscreenCanvas
 slug: Web/API/OffscreenCanvas
-tags:
-  - API
-  - Canvas
-  - Experimental
-  - Interface
-  - NeedsTranslation
-  - Reference
-  - TopicStub
-translation_of: Web/API/OffscreenCanvas
-browser-compat: api.OffscreenCanvas
 ---
 {{APIRef("Canvas API")}} {{SeeCompatTable}}
 

--- a/files/ja/web/api/origin/index.md
+++ b/files/ja/web/api/origin/index.md
@@ -1,15 +1,6 @@
 ---
 title: WindowOrWorkerGlobalScope.origin
 slug: Web/API/origin
-tags:
-  - API
-  - DOM
-  - Window
-  - WindowOrWorkerGlobalScope
-  - Worker
-  - ウェブ
-  - プロパティ
-translation_of: Web/API/WindowOrWorkerGlobalScope/origin
 original_slug: Web/API/WindowOrWorkerGlobalScope/origin
 ---
 {{APIRef()}}{{SeeCompatTable}}

--- a/files/ja/web/api/oscillatornode/index.md
+++ b/files/ja/web/api/oscillatornode/index.md
@@ -1,7 +1,6 @@
 ---
 title: OscillatorNode
 slug: Web/API/OscillatorNode
-translation_of: Web/API/OscillatorNode
 ---
 {{APIRef("Web Audio API")}}
 

--- a/files/ja/web/api/page_visibility_api/index.md
+++ b/files/ja/web/api/page_visibility_api/index.md
@@ -1,11 +1,6 @@
 ---
 title: Page Visibility API
 slug: Web/API/Page_Visibility_API
-tags:
-  - DOM
-  - Intermediate
-  - Tutorials
-translation_of: Web/API/Page_Visibility_API
 original_slug: Web/Guide/User_experience/Using_the_Page_Visibility_API
 ---
 {{DefaultAPISidebar("Page Visibility API")}}

--- a/files/ja/web/api/pagetransitionevent/index.md
+++ b/files/ja/web/api/pagetransitionevent/index.md
@@ -1,7 +1,6 @@
 ---
 title: PageTransitionEvent
 slug: Web/API/PageTransitionEvent
-translation_of: Web/API/PageTransitionEvent
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/pannernode/coneinnerangle/index.md
+++ b/files/ja/web/api/pannernode/coneinnerangle/index.md
@@ -1,16 +1,6 @@
 ---
 title: PannerNode.coneInnerAngle
 slug: Web/API/PannerNode/coneInnerAngle
-page-type: web-api-instance-property
-tags:
-  - API
-  - PannerNode
-  - Property
-  - Reference
-  - Web Audio API
-  - coneInnerAngle
-browser-compat: api.PannerNode.coneInnerAngle
-translation_of: Web/API/PannerNode/coneInnerAngle
 ---
 {{ APIRef("Web Audio API") }}
 

--- a/files/ja/web/api/pannernode/coneouterangle/index.md
+++ b/files/ja/web/api/pannernode/coneouterangle/index.md
@@ -1,16 +1,6 @@
 ---
 title: PannerNode.coneOuterAngle
 slug: Web/API/PannerNode/coneOuterAngle
-page-type: web-api-instance-property
-tags:
-  - API
-  - PannerNode
-  - Property
-  - Reference
-  - Web Audio API
-  - coneOuterAngle
-browser-compat: api.PannerNode.coneOuterAngle
-translation_of: Web/API/PannerNode/coneOuterAngle
 ---
 {{ APIRef("Web Audio API") }}
 

--- a/files/ja/web/api/pannernode/index.md
+++ b/files/ja/web/api/pannernode/index.md
@@ -1,15 +1,6 @@
 ---
 title: PannerNode
 slug: Web/API/PannerNode
-page-type: web-api-interface
-tags:
-  - API
-  - Interface
-  - PannerNode
-  - Reference
-  - Web Audio API
-browser-compat: api.PannerNode
-translation_of: Web/API/PannerNode
 ---
 {{ APIRef("Web Audio API") }}
 

--- a/files/ja/web/api/pannernode/orientationx/index.md
+++ b/files/ja/web/api/pannernode/orientationx/index.md
@@ -1,15 +1,6 @@
 ---
 title: PannerNode.orientationX
 slug: Web/API/PannerNode/orientationX
-page-type: web-api-instance-property
-tags:
-  - PannerNode
-  - Property
-  - Reference
-  - Web Audio API
-  - orientationX
-browser-compat: api.PannerNode.orientationX
-translation_of: Web/API/PannerNode/orientationX
 ---
 {{ APIRef("Web Audio API") }}
 

--- a/files/ja/web/api/path2d/addpath/index.md
+++ b/files/ja/web/api/path2d/addpath/index.md
@@ -1,7 +1,6 @@
 ---
 title: Path2D.addPath()
 slug: Web/API/Path2D/addPath
-translation_of: Web/API/Path2D/addPath
 ---
 {{APIRef("Canvas API")}}
 

--- a/files/ja/web/api/path2d/index.md
+++ b/files/ja/web/api/path2d/index.md
@@ -1,15 +1,6 @@
 ---
 title: Path2D
 slug: Web/API/Path2D
-tags:
-  - API
-  - Canvas
-  - Interface
-  - NeedsTranslation
-  - Path2D
-  - Reference
-  - TopicStub
-translation_of: Web/API/Path2D
 ---
 {{APIRef("Canvas API")}} {{SeeCompatTable}}
 

--- a/files/ja/web/api/path2d/path2d/index.md
+++ b/files/ja/web/api/path2d/path2d/index.md
@@ -1,16 +1,6 @@
 ---
 title: Path2D()
 slug: Web/API/Path2D/Path2D
-tags:
-  - API
-  - Canvas
-  - Constructor
-  - Drawing
-  - Graphics
-  - Path2D
-  - Paths
-  - Reference
-translation_of: Web/API/Path2D/Path2D
 ---
 {{APIRef("Canvas API")}}{{seeCompatTable}}
 

--- a/files/ja/web/api/payment_request_api/index.md
+++ b/files/ja/web/api/payment_request_api/index.md
@@ -1,21 +1,6 @@
 ---
 title: 支払いリクエスト API
 slug: Web/API/Payment_Request_API
-page-type: web-api-overview
-tags:
-  - API
-  - Commerce
-  - Credit Card
-  - Intermediate
-  - Landing
-  - NeedsContent
-  - Overview
-  - Payment Request
-  - Payment Request API
-  - Reference
-  - Secure context
-  - payment
-browser-compat: api.PaymentRequest
 l10n:
   sourceCommit: 2d55f134b973850ecaa4ad01fe55c63bd3982576
 ---

--- a/files/ja/web/api/paymentaddress/index.md
+++ b/files/ja/web/api/paymentaddress/index.md
@@ -1,16 +1,6 @@
 ---
 title: PaymentAddress
 slug: Web/API/PaymentAddress
-page-type: web-api-interface
-tags:
-  - API
-  - Interface
-  - Payment Request
-  - Payment Request API
-  - PaymentRequest
-  - Reference
-  - paymentAddress
-browser-compat: api.PaymentAddress
 l10n:
   sourceCommit: da3e8fe86e7ae4bb7342c6ccb56188b25f9be55c
 ---

--- a/files/ja/web/api/paymentmethodchangeevent/index.md
+++ b/files/ja/web/api/paymentmethodchangeevent/index.md
@@ -1,18 +1,6 @@
 ---
 title: PaymentMethodChangeEvent
 slug: Web/API/PaymentMethodChangeEvent
-tags:
-  - API
-  - Interface
-  - Payment Handler
-  - Payment Request
-  - Payment Request API
-  - PaymentRequestUpdateEvent
-  - Reference
-  - Secure context
-  - payment
-  - インターフェイス
-translation_of: Web/API/PaymentMethodChangeEvent
 ---
 {{securecontext_header}}{{APIRef("Payment Request API")}}
 

--- a/files/ja/web/api/performance/clearmarks/index.md
+++ b/files/ja/web/api/performance/clearmarks/index.md
@@ -1,13 +1,6 @@
 ---
 title: performance.clearMarks()
 slug: Web/API/Performance/clearMarks
-tags:
-  - API
-  - メソッド
-  - リファレンス
-  - ウェブパフォーマンス
-browser-compat: api.Performance.clearMarks
-translation_of: Web/API/Performance/clearMarks
 ---
 {{APIRef("User Timing API")}}
 

--- a/files/ja/web/api/performance/clearmeasures/index.md
+++ b/files/ja/web/api/performance/clearmeasures/index.md
@@ -1,13 +1,6 @@
 ---
 title: performance.clearMeasures()
 slug: Web/API/Performance/clearMeasures
-tags:
-  - API
-  - メソッド
-  - リファレンス
-  - ウェブパフォーマンス
-browser-compat: api.Performance.clearMeasures
-translation_of: Web/API/Performance/clearMeasures
 ---
 {{APIRef("User Timing API")}}
 

--- a/files/ja/web/api/performance/clearresourcetimings/index.md
+++ b/files/ja/web/api/performance/clearresourcetimings/index.md
@@ -1,13 +1,6 @@
 ---
 title: performance.clearResourceTimings()
 slug: Web/API/Performance/clearResourceTimings
-tags:
-  - API
-  - メソッド
-  - リファレンス
-  - ウェブパフォーマンス
-browser-compat: api.Performance.clearResourceTimings
-translation_of: Web/API/Performance/clearResourceTimings
 ---
 {{APIRef("Resource Timing API")}}
 

--- a/files/ja/web/api/performance/getentries/index.md
+++ b/files/ja/web/api/performance/getentries/index.md
@@ -1,13 +1,6 @@
 ---
 title: performance.getEntries()
 slug: Web/API/Performance/getEntries
-tags:
-  - API
-  - メソッド
-  - リファレンス
-  - ウェブパフォーマンス
-browser-compat: api.Performance.getEntries
-translation_of: Web/API/Performance/getEntries
 ---
 {{APIRef("Performance Timeline API")}}
 

--- a/files/ja/web/api/performance/getentriesbyname/index.md
+++ b/files/ja/web/api/performance/getentriesbyname/index.md
@@ -1,13 +1,6 @@
 ---
 title: performance.getEntriesByName()
 slug: Web/API/Performance/getEntriesByName
-tags:
-  - API
-  - メソッド
-  - リファレンス
-  - ウェブパフォーマンス
-browser-compat: api.Performance.getEntriesByName
-translation_of: Web/API/Performance/getEntriesByName
 ---
 {{APIRef("Performance Timeline API")}}
 

--- a/files/ja/web/api/performance/getentriesbytype/index.md
+++ b/files/ja/web/api/performance/getentriesbytype/index.md
@@ -1,13 +1,6 @@
 ---
 title: performance.getEntriesByType()
 slug: Web/API/Performance/getEntriesByType
-tags:
-  - API
-  - メソッド
-  - リファレンス
-  - ウェブパフォーマンス
-browser-compat: api.Performance.getEntriesByType
-translation_of: Web/API/Performance/getEntriesByType
 ---
 {{APIRef("Performance Timeline API")}}
 

--- a/files/ja/web/api/performance/index.md
+++ b/files/ja/web/api/performance/index.md
@@ -1,14 +1,6 @@
 ---
 title: Performance
 slug: Web/API/Performance
-tags:
-  - API
-  - Web パフォーマンス
-  - インターフェイス
-  - ナビゲーションタイミング
-  - パフォーマンス
-  - リファレンス
-translation_of: Web/API/Performance
 ---
 {{APIRef("High Resolution Time")}}
 

--- a/files/ja/web/api/performance/mark/index.md
+++ b/files/ja/web/api/performance/mark/index.md
@@ -1,13 +1,6 @@
 ---
 title: performance.mark()
 slug: Web/API/Performance/mark
-tags:
-  - API
-  - メソッド
-  - リファレンス
-  - ウェブパフォーマンス
-browser-compat: api.Performance.mark
-translation_of: Web/API/Performance/mark
 ---
 {{APIRef("User Timing API")}}
 

--- a/files/ja/web/api/performance/measure/index.md
+++ b/files/ja/web/api/performance/measure/index.md
@@ -1,14 +1,6 @@
 ---
 title: performance.measure()
 slug: Web/API/Performance/measure
-tags:
-  - API
-  - メソッド
-  - リファレンス
-  - ウェブパフォーマンス
-  - ウェブワーカー
-browser-compat: api.Performance.measure
-translation_of: Web/API/Performance/measure
 ---
 {{APIRef("User Timing API")}}
 

--- a/files/ja/web/api/performance/navigation/index.md
+++ b/files/ja/web/api/performance/navigation/index.md
@@ -1,18 +1,6 @@
 ---
 title: Performance.navigation
 slug: Web/API/Performance/navigation
-tags:
-  - API
-  - 後方互換性
-  - 非推奨
-  - HTTP
-  - ナビゲーションタイミング
-  - パフォーマンス
-  - プロパティ
-  - 読み取り専用
-  - legacy
-browser-compat: api.Performance.navigation
-translation_of: Web/API/Performance/navigation
 ---
 {{APIRef("Navigation Timing")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/performance/now/index.md
+++ b/files/ja/web/api/performance/now/index.md
@@ -1,14 +1,6 @@
 ---
 title: performance.now()
 slug: Web/API/Performance/now
-tags:
-  - API
-  - メソッド
-  - パフォーマンス
-  - リファレンス
-  - ウェブパフォーマンス API
-browser-compat: api.Performance.now
-translation_of: Web/API/Performance/now
 ---
 {{APIRef("High Resolution Timing")}}
 

--- a/files/ja/web/api/performance/resourcetimingbufferfull_event/index.md
+++ b/files/ja/web/api/performance/resourcetimingbufferfull_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Performance: resourcetimingbufferfull イベント'
 slug: Web/API/Performance/resourcetimingbufferfull_event
-tags:
-  - API
-  - DOM
-  - イベント
-  - パフォーマンス
-  - リファレンス
-  - ウェブパフォーマンス
-  - onresourcetimingbufferfull
-browser-compat: api.Performance.resourcetimingbufferfull_event
-translation_of: Web/API/Performance/resourcetimingbufferfull_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/performance/setresourcetimingbuffersize/index.md
+++ b/files/ja/web/api/performance/setresourcetimingbuffersize/index.md
@@ -1,13 +1,6 @@
 ---
 title: performance.setResourceTimingBufferSize()
 slug: Web/API/Performance/setResourceTimingBufferSize
-tags:
-  - API
-  - メソッド
-  - リファレンス
-  - ウェブパフォーマンス
-browser-compat: api.Performance.setResourceTimingBufferSize
-translation_of: Web/API/Performance/setResourceTimingBufferSize
 ---
 {{APIRef("Resource Timing API")}}
 

--- a/files/ja/web/api/performance/timeorigin/index.md
+++ b/files/ja/web/api/performance/timeorigin/index.md
@@ -1,15 +1,6 @@
 ---
 title: Performance.timeOrigin
 slug: Web/API/Performance/timeOrigin
-tags:
-  - API
-  - 実験的
-  - 高解像度時間 API
-  - パフォーマンス
-  - プロパティ
-  - リファレンス
-  - timeOrigin
-translation_of: Web/API/Performance/timeOrigin
 ---
 {{SeeCompatTable}}{{APIRef("High Resolution Time")}}
 

--- a/files/ja/web/api/performance/timing/index.md
+++ b/files/ja/web/api/performance/timing/index.md
@@ -1,17 +1,6 @@
 ---
 title: Performance.timing
 slug: Web/API/Performance/timing
-tags:
-  - API
-  - 後方互換性
-  - 非推奨
-  - ナビゲーションタイミング
-  - パフォーマンス
-  - プロパティ
-  - 読み取り専用
-  - legacy
-browser-compat: api.Performance.timing
-translation_of: Web/API/Performance/timing
 ---
 {{APIRef("Navigation Timing")}}{{deprecated_header}}
 

--- a/files/ja/web/api/performance/tojson/index.md
+++ b/files/ja/web/api/performance/tojson/index.md
@@ -1,13 +1,6 @@
 ---
 title: performance.toJSON()
 slug: Web/API/Performance/toJSON
-tags:
-  - API
-  - メソッド
-  - パフォーマンス
-  - リファレンス
-browser-compat: api.Performance.toJSON
-translation_of: Web/API/Performance/toJSON
 ---
 {{APIRef("High Resolution Timing")}}
 

--- a/files/ja/web/api/performance_api/index.md
+++ b/files/ja/web/api/performance_api/index.md
@@ -1,13 +1,6 @@
 ---
 title: Performance API
 slug: Web/API/Performance_API
-tags:
-  - NeedsContent
-  - Web パフォーマンス
-  - ガイド
-  - パフォーマンス
-  - 概要
-translation_of: Web/API/Performance_API
 ---
 {{DefaultAPISidebar("High Resolution Time")}}
 

--- a/files/ja/web/api/performance_property/index.md
+++ b/files/ja/web/api/performance_property/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.performance
 slug: Web/API/performance_property
-translation_of: Web/API/Window/performance
 original_slug: Web/API/Window/performance
 ---
 {{APIRef("High Resolution Time")}}

--- a/files/ja/web/api/performance_timeline/index.md
+++ b/files/ja/web/api/performance_timeline/index.md
@@ -1,11 +1,6 @@
 ---
 title: パフォーマンスタイムライン
 slug: Web/API/Performance_Timeline
-tags:
-  - Web パフォーマンス
-  - ガイド
-  - 概要
-translation_of: Web/API/Performance_Timeline
 ---
 {{DefaultAPISidebar("Performance Timeline API")}}
 

--- a/files/ja/web/api/performance_timeline/using_performance_timeline/index.md
+++ b/files/ja/web/api/performance_timeline/using_performance_timeline/index.md
@@ -1,10 +1,6 @@
 ---
 title: パフォーマンスタイムラインの使用
 slug: Web/API/Performance_Timeline/Using_Performance_Timeline
-tags:
-  - Web パフォーマンス
-  - ガイド
-translation_of: Web/API/Performance_Timeline/Using_Performance_Timeline
 ---
 {{DefaultAPISidebar("Performance Timeline API")}}
 

--- a/files/ja/web/api/performanceentry/duration/index.md
+++ b/files/ja/web/api/performanceentry/duration/index.md
@@ -1,12 +1,6 @@
 ---
 title: PerformanceEntry.duration
 slug: Web/API/PerformanceEntry/duration
-tags:
-  - API
-  - Web パフォーマンス
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/PerformanceEntry/duration
 ---
 {{APIRef("Performance Timeline API")}}
 

--- a/files/ja/web/api/performanceentry/entrytype/index.md
+++ b/files/ja/web/api/performanceentry/entrytype/index.md
@@ -1,14 +1,6 @@
 ---
 title: PerformanceEntry.entryType
 slug: Web/API/PerformanceEntry/entryType
-tags:
-  - API
-  - PerformanceEntry
-  - Web パフォーマンス
-  - パフォーマンスタイムライン API
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/PerformanceEntry/entryType
 ---
 {{APIRef("Performance Timeline API")}}
 

--- a/files/ja/web/api/performanceentry/index.md
+++ b/files/ja/web/api/performanceentry/index.md
@@ -1,14 +1,6 @@
 ---
 title: PerformanceEntry
 slug: Web/API/PerformanceEntry
-tags:
-  - API
-  - PerformanceEntry
-  - Web パフォーマンス
-  - インターフェイス
-  - パフォーマンスタイムライン API
-  - リファレンス
-translation_of: Web/API/PerformanceEntry
 ---
 {{APIRef("Performance Timeline API")}}
 

--- a/files/ja/web/api/performanceentry/name/index.md
+++ b/files/ja/web/api/performanceentry/name/index.md
@@ -1,12 +1,6 @@
 ---
 title: PerformanceEntry.name
 slug: Web/API/PerformanceEntry/name
-tags:
-  - API
-  - Web パフォーマンス
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/PerformanceEntry/name
 ---
 {{APIRef("Performance Timeline API")}}
 

--- a/files/ja/web/api/performanceentry/starttime/index.md
+++ b/files/ja/web/api/performanceentry/starttime/index.md
@@ -1,12 +1,6 @@
 ---
 title: PerformanceEntry.startTime
 slug: Web/API/PerformanceEntry/startTime
-tags:
-  - API
-  - Web パフォーマンス
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/PerformanceEntry/startTime
 ---
 {{APIRef("Performance Timeline API")}}
 

--- a/files/ja/web/api/performanceentry/tojson/index.md
+++ b/files/ja/web/api/performanceentry/tojson/index.md
@@ -1,12 +1,6 @@
 ---
 title: PerformanceEntry.toJSON()
 slug: Web/API/PerformanceEntry/toJSON
-tags:
-  - API
-  - Web パフォーマンス
-  - メソッド
-  - リファレンス
-translation_of: Web/API/PerformanceEntry/toJSON
 ---
 {{APIRef("Performance Timeline API")}}
 

--- a/files/ja/web/api/performanceframetiming/index.md
+++ b/files/ja/web/api/performanceframetiming/index.md
@@ -1,15 +1,6 @@
 ---
 title: PerformanceFrameTiming
 slug: Web/API/PerformanceFrameTiming
-tags:
-  - API
-  - PerformanceFrameTiming
-  - Web パフォーマンス
-  - インターフェイス
-  - パフォーマンスタイムライン API
-  - フレームタイミング API
-  - リファレンス
-translation_of: Web/API/PerformanceFrameTiming
 ---
 {{APIRef("Frame Timing API")}}{{SeeCompatTable}}**`PerformanceFrameTiming`** は、ブラウザーのイベントループに関するフレームタイミングデータを提供する抽象インターフェイスです。 フレームは、DOM イベントの処理、サイズ変更、スクロール、レンダリング、CSS アニメーションなど、[1 つのイベントループ](https://html.spec.whatwg.org/multipage/webappapis.html#processing-model-8)でブラウザーが実行する作業量を表します。60 Hz のリフレッシュレートに対して 60 fps (フレーム/秒) のフレームレートは、応答性の良いユーザーエクスペリエンスの目標です。これはブラウザーが約 16.7 ms でフレームを処理するはずであることを意味します。
 

--- a/files/ja/web/api/performancelongtasktiming/attribution/index.md
+++ b/files/ja/web/api/performancelongtasktiming/attribution/index.md
@@ -1,7 +1,6 @@
 ---
 title: PerformanceLongTaskTiming.attribution
 slug: Web/API/PerformanceLongTaskTiming/attribution
-translation_of: Web/API/PerformanceLongTaskTiming/attribution
 ---
 {{SeeCompatTable}}{{APIRef("Long Tasks")}}
 

--- a/files/ja/web/api/performancelongtasktiming/index.md
+++ b/files/ja/web/api/performancelongtasktiming/index.md
@@ -1,13 +1,6 @@
 ---
 title: PerformanceLongTaskTiming
 slug: Web/API/PerformanceLongTaskTiming
-tags:
-  - API
-  - Interface
-  - Long Tasks API
-  - PerformanceLongTaskTiming
-  - Reference
-translation_of: Web/API/PerformanceLongTaskTiming
 ---
 {{SeeCompatTable}}{{APIRef("Long Tasks")}}
 

--- a/files/ja/web/api/performancemark/index.md
+++ b/files/ja/web/api/performancemark/index.md
@@ -1,13 +1,6 @@
 ---
 title: PerformanceMark
 slug: Web/API/PerformanceMark
-tags:
-  - API
-  - Web パフォーマンス
-  - インターフェイス
-  - パフォーマンスタイミング API
-  - リファレンス
-translation_of: Web/API/PerformanceMark
 ---
 {{APIRef("User Timing API")}}
 

--- a/files/ja/web/api/performancemeasure/index.md
+++ b/files/ja/web/api/performancemeasure/index.md
@@ -1,13 +1,6 @@
 ---
 title: PerformanceMeasure
 slug: Web/API/PerformanceMeasure
-tags:
-  - API
-  - Web パフォーマンス
-  - インターフェイス
-  - パフォーマンスタイムライン API
-  - リファレンス
-translation_of: Web/API/PerformanceMeasure
 ---
 {{APIRef("User Timing API")}}
 

--- a/files/ja/web/api/performancenavigation/index.md
+++ b/files/ja/web/api/performancenavigation/index.md
@@ -1,19 +1,6 @@
 ---
 title: PerformanceNavigation
 slug: Web/API/PerformanceNavigation
-tags:
-  - API
-  - PerformanceNavigation
-  - legacy
-  - インターフェイス
-  - タイミング
-  - ナビゲーションタイミング
-  - ナビゲーションタイミング API
-  - パフォーマンス
-  - リファレンス
-  - 後方互換性
-  - 非推奨
-translation_of: Web/API/PerformanceNavigation
 ---
 {{APIRef("Navigation Timing")}}
 

--- a/files/ja/web/api/performancenavigation/redirectcount/index.md
+++ b/files/ja/web/api/performancenavigation/redirectcount/index.md
@@ -1,17 +1,6 @@
 ---
 title: PerformanceNavigation.redirectCount
 slug: Web/API/PerformanceNavigation/redirectCount
-tags:
-  - API
-  - HTML
-  - PerformanceNavigation
-  - legacy
-  - ナビゲーションタイミング
-  - プロパティ
-  - 後方互換性
-  - 読み取り専用
-  - 非推奨
-translation_of: Web/API/PerformanceNavigation/redirectCount
 ---
 {{APIRef("Navigation Timing")}}
 

--- a/files/ja/web/api/performancenavigation/type/index.md
+++ b/files/ja/web/api/performancenavigation/type/index.md
@@ -1,16 +1,6 @@
 ---
 title: PerformanceNavigation.type
 slug: Web/API/PerformanceNavigation/type
-tags:
-  - API
-  - PerformanceNavigation
-  - legacy
-  - ナビゲーションタイミング
-  - プロパティ
-  - 後方互換性
-  - 読み取り専用
-  - 非推奨
-translation_of: Web/API/PerformanceNavigation/type
 ---
 {{APIRef("Navigation Timing")}}
 

--- a/files/ja/web/api/performancenavigationtiming/index.md
+++ b/files/ja/web/api/performancenavigationtiming/index.md
@@ -1,14 +1,6 @@
 ---
 title: PerformanceNavigationTiming
 slug: Web/API/PerformanceNavigationTiming
-tags:
-  - API
-  - Interface
-  - Navigation Timing API
-  - Performance Timeline API
-  - Reference
-  - Web Performance
-translation_of: Web/API/PerformanceNavigationTiming
 ---
 {{APIRef("Navigation Timing")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/performancenavigationtiming/loadeventend/index.md
+++ b/files/ja/web/api/performancenavigationtiming/loadeventend/index.md
@@ -1,12 +1,6 @@
 ---
 title: PerformanceNavigationTiming.loadEventEnd
 slug: Web/API/PerformanceNavigationTiming/loadEventEnd
-tags:
-  - API
-  - Web パフォーマンス
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/PerformanceNavigationTiming/loadEventEnd
 ---
 {{APIRef("Navigation Timing")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/performanceobserver/disconnect/index.md
+++ b/files/ja/web/api/performanceobserver/disconnect/index.md
@@ -1,16 +1,6 @@
 ---
 title: PeformanceObserver.disconnect()
 slug: Web/API/PerformanceObserver/disconnect
-tags:
-  - API
-  - PerformanceObserver
-  - Web パフォーマンス
-  - disconnect()
-  - オブザーバー
-  - パフォーマンスオブザーバー API
-  - メソッド
-  - リファレンス
-translation_of: Web/API/PerformanceObserver/disconnect
 ---
 {{APIRef("Performance Timeline API")}}
 

--- a/files/ja/web/api/performanceobserver/index.md
+++ b/files/ja/web/api/performanceobserver/index.md
@@ -1,15 +1,6 @@
 ---
 title: PerformanceObserver
 slug: Web/API/PerformanceObserver
-tags:
-  - API
-  - PerformanceObserver
-  - Web パフォーマンス
-  - observers
-  - インターフェイス
-  - パフォーマンスオブザーバー API
-  - リファレンス
-translation_of: Web/API/PerformanceObserver
 ---
 {{APIRef("Performance Timeline API")}}
 

--- a/files/ja/web/api/performanceobserver/observe/index.md
+++ b/files/ja/web/api/performanceobserver/observe/index.md
@@ -1,14 +1,6 @@
 ---
 title: PerformanceObserver.observe()
 slug: Web/API/PerformanceObserver/observe
-tags:
-  - API
-  - PerformanceObserver
-  - Web パフォーマンス
-  - パフォーマンス
-  - メソッド
-  - リファレンス
-translation_of: Web/API/PerformanceObserver/observe
 ---
 {{APIRef("Performance Timeline API")}}
 

--- a/files/ja/web/api/performanceobserver/performanceobserver/index.md
+++ b/files/ja/web/api/performanceobserver/performanceobserver/index.md
@@ -1,13 +1,6 @@
 ---
 title: PerformanceObserver()
 slug: Web/API/PerformanceObserver/PerformanceObserver
-tags:
-  - API
-  - PerformanceObserver
-  - Web パフォーマンス
-  - コンストラクタ
-  - リファレンス
-translation_of: Web/API/PerformanceObserver/PerformanceObserver
 ---
 {{APIRef("Performance Timeline API")}}
 

--- a/files/ja/web/api/performanceobserver/takerecords/index.md
+++ b/files/ja/web/api/performanceobserver/takerecords/index.md
@@ -1,15 +1,6 @@
 ---
 title: PerformanceObserver.takeRecords()
 slug: Web/API/PerformanceObserver/takeRecords
-tags:
-  - API
-  - PerformanceObserver
-  - takeRecords()
-  - オブザーバー
-  - パフォーマンスオブザーバー API
-  - メソッド
-  - リファレンス
-translation_of: Web/API/PerformanceObserver/takeRecords
 ---
 {{APIRef("Performance Timeline API")}}
 

--- a/files/ja/web/api/performanceobserverentrylist/index.md
+++ b/files/ja/web/api/performanceobserverentrylist/index.md
@@ -1,12 +1,6 @@
 ---
 title: PerformanceObserverEntryList
 slug: Web/API/PerformanceObserverEntryList
-tags:
-  - API
-  - Web パフォーマンス
-  - インターフェイス
-  - リファレンス
-translation_of: Web/API/PerformanceObserverEntryList
 ---
 {{APIRef("Performance Timeline API")}}
 

--- a/files/ja/web/api/performancepainttiming/index.md
+++ b/files/ja/web/api/performancepainttiming/index.md
@@ -1,15 +1,6 @@
 ---
 title: PerformancePaintTiming
 slug: Web/API/PerformancePaintTiming
-tags:
-  - API
-  - PerformancePaintTiming
-  - Web パフォーマンス
-  - インターフェイス
-  - パフォーマンスタイムライン API
-  - ペイントタイミング
-  - リファレンス
-translation_of: Web/API/PerformancePaintTiming
 ---
 {{SeeCompatTable}}{{APIRef("Performance Timeline API")}}
 

--- a/files/ja/web/api/performanceresourcetiming/connectend/index.md
+++ b/files/ja/web/api/performanceresourcetiming/connectend/index.md
@@ -1,12 +1,6 @@
 ---
 title: PerformanceResourceTiming.connectEnd
 slug: Web/API/PerformanceResourceTiming/connectEnd
-tags:
-  - API
-  - Web パフォーマンス
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/PerformanceResourceTiming/connectEnd
 ---
 {{APIRef("Resource Timing API")}}
 

--- a/files/ja/web/api/performanceresourcetiming/connectstart/index.md
+++ b/files/ja/web/api/performanceresourcetiming/connectstart/index.md
@@ -1,12 +1,6 @@
 ---
 title: PerformanceResourceTiming.connectStart
 slug: Web/API/PerformanceResourceTiming/connectStart
-tags:
-  - API
-  - Web パフォーマンス
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/PerformanceResourceTiming/connectStart
 ---
 {{APIRef("Resource Timing API")}}
 

--- a/files/ja/web/api/performanceresourcetiming/decodedbodysize/index.md
+++ b/files/ja/web/api/performanceresourcetiming/decodedbodysize/index.md
@@ -1,12 +1,6 @@
 ---
 title: PerformanceResourceTiming.decodedBodySize
 slug: Web/API/PerformanceResourceTiming/decodedBodySize
-tags:
-  - API
-  - Web パフォーマンス
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/PerformanceResourceTiming/decodedBodySize
 ---
 {{APIRef("Resource Timing API")}}
 

--- a/files/ja/web/api/performanceresourcetiming/domainlookupend/index.md
+++ b/files/ja/web/api/performanceresourcetiming/domainlookupend/index.md
@@ -1,12 +1,6 @@
 ---
 title: PerformanceResourceTiming.domainLookupEnd
 slug: Web/API/PerformanceResourceTiming/domainLookupEnd
-tags:
-  - API
-  - Web パフォーマンス
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/PerformanceResourceTiming/domainLookupEnd
 ---
 {{APIRef("Resource Timing API")}}
 

--- a/files/ja/web/api/performanceresourcetiming/domainlookupstart/index.md
+++ b/files/ja/web/api/performanceresourcetiming/domainlookupstart/index.md
@@ -1,12 +1,6 @@
 ---
 title: PerformanceResourceTiming.domainLookupStart
 slug: Web/API/PerformanceResourceTiming/domainLookupStart
-tags:
-  - API
-  - Web パフォーマンス
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/PerformanceResourceTiming/domainLookupStart
 ---
 {{APIRef("Resource Timing API")}}
 

--- a/files/ja/web/api/performanceresourcetiming/encodedbodysize/index.md
+++ b/files/ja/web/api/performanceresourcetiming/encodedbodysize/index.md
@@ -1,12 +1,6 @@
 ---
 title: PerformanceResourceTiming.encodedBodySize
 slug: Web/API/PerformanceResourceTiming/encodedBodySize
-tags:
-  - API
-  - Web パフォーマンス
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/PerformanceResourceTiming/encodedBodySize
 ---
 {{APIRef("Resource Timing API")}}
 

--- a/files/ja/web/api/performanceresourcetiming/fetchstart/index.md
+++ b/files/ja/web/api/performanceresourcetiming/fetchstart/index.md
@@ -1,12 +1,6 @@
 ---
 title: PerformanceResourceTiming.fetchStart
 slug: Web/API/PerformanceResourceTiming/fetchStart
-tags:
-  - API
-  - Web パフォーマンス
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/PerformanceResourceTiming/fetchStart
 ---
 {{APIRef("Resource Timing API")}}
 

--- a/files/ja/web/api/performanceresourcetiming/index.md
+++ b/files/ja/web/api/performanceresourcetiming/index.md
@@ -1,12 +1,6 @@
 ---
 title: PerformanceResourceTiming
 slug: Web/API/PerformanceResourceTiming
-tags:
-  - DOM
-  - Web パフォーマンス
-  - インターフェイス
-  - リファレンス
-translation_of: Web/API/PerformanceResourceTiming
 ---
 {{APIRef("Resource Timing API")}}
 

--- a/files/ja/web/api/performanceresourcetiming/initiatortype/index.md
+++ b/files/ja/web/api/performanceresourcetiming/initiatortype/index.md
@@ -1,12 +1,6 @@
 ---
 title: PerformanceResourceTiming.initiatorType
 slug: Web/API/PerformanceResourceTiming/initiatorType
-tags:
-  - API
-  - Web パフォーマンス
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/PerformanceResourceTiming/initiatorType
 ---
 {{APIRef("Resource Timing API")}}
 

--- a/files/ja/web/api/performanceresourcetiming/nexthopprotocol/index.md
+++ b/files/ja/web/api/performanceresourcetiming/nexthopprotocol/index.md
@@ -1,13 +1,6 @@
 ---
 title: PerformanceResourceTiming.nextHopProtocol
 slug: Web/API/PerformanceResourceTiming/nextHopProtocol
-tags:
-  - API
-  - Web パフォーマンス
-  - プロパティ
-  - リソースタイミング API
-  - リファレンス
-translation_of: Web/API/PerformanceResourceTiming/nextHopProtocol
 ---
 {{APIRef("Resource Timing API")}}
 

--- a/files/ja/web/api/performanceresourcetiming/redirectend/index.md
+++ b/files/ja/web/api/performanceresourcetiming/redirectend/index.md
@@ -1,12 +1,6 @@
 ---
 title: PerformanceResourceTiming.redirectEnd
 slug: Web/API/PerformanceResourceTiming/redirectEnd
-tags:
-  - API
-  - Web パフォーマンス
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/PerformanceResourceTiming/redirectEnd
 ---
 {{APIRef("Resource Timing API")}}
 

--- a/files/ja/web/api/performanceresourcetiming/redirectstart/index.md
+++ b/files/ja/web/api/performanceresourcetiming/redirectstart/index.md
@@ -1,12 +1,6 @@
 ---
 title: PerformanceResourceTiming.redirectStart
 slug: Web/API/PerformanceResourceTiming/redirectStart
-tags:
-  - API
-  - Web パフォーマンス
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/PerformanceResourceTiming/redirectStart
 ---
 {{APIRef("Resource Timing API")}}
 

--- a/files/ja/web/api/performanceresourcetiming/requeststart/index.md
+++ b/files/ja/web/api/performanceresourcetiming/requeststart/index.md
@@ -1,12 +1,6 @@
 ---
 title: PerformanceResourceTiming.requestStart
 slug: Web/API/PerformanceResourceTiming/requestStart
-tags:
-  - API
-  - Web パフォーマンス
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/PerformanceResourceTiming/requestStart
 ---
 {{APIRef("Resource Timing API")}}
 

--- a/files/ja/web/api/performanceresourcetiming/responseend/index.md
+++ b/files/ja/web/api/performanceresourcetiming/responseend/index.md
@@ -1,12 +1,6 @@
 ---
 title: PerformanceResourceTiming.responseEnd
 slug: Web/API/PerformanceResourceTiming/responseEnd
-tags:
-  - API
-  - Web パフォーマンス
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/PerformanceResourceTiming/responseEnd
 ---
 {{APIRef("Resource Timing API")}}
 

--- a/files/ja/web/api/performanceresourcetiming/responsestart/index.md
+++ b/files/ja/web/api/performanceresourcetiming/responsestart/index.md
@@ -1,12 +1,6 @@
 ---
 title: PerformanceResourceTiming.responseStart
 slug: Web/API/PerformanceResourceTiming/responseStart
-tags:
-  - API
-  - Web パフォーマンス
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/PerformanceResourceTiming/responseStart
 ---
 {{APIRef("Resource Timing API")}}
 

--- a/files/ja/web/api/performanceresourcetiming/secureconnectionstart/index.md
+++ b/files/ja/web/api/performanceresourcetiming/secureconnectionstart/index.md
@@ -1,12 +1,6 @@
 ---
 title: PerformanceResourceTiming.secureConnectionStart
 slug: Web/API/PerformanceResourceTiming/secureConnectionStart
-tags:
-  - API
-  - Web パフォーマンス
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/PerformanceResourceTiming/secureConnectionStart
 ---
 {{APIRef("Resource Timing API")}}
 

--- a/files/ja/web/api/performanceresourcetiming/servertiming/index.md
+++ b/files/ja/web/api/performanceresourcetiming/servertiming/index.md
@@ -1,14 +1,6 @@
 ---
 title: PerformanceResourceTiming.serverTiming
 slug: Web/API/PerformanceResourceTiming/serverTiming
-tags:
-  - API
-  - PerformanceResourceTiming
-  - SecureContextOnly
-  - ServerTiming
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/PerformanceResourceTiming/serverTiming
 ---
 {{APIRef("Resource Timing API")}} {{securecontext_header}}
 

--- a/files/ja/web/api/performanceresourcetiming/tojson/index.md
+++ b/files/ja/web/api/performanceresourcetiming/tojson/index.md
@@ -1,12 +1,6 @@
 ---
 title: PerformanceResourceTiming.toJSON()
 slug: Web/API/PerformanceResourceTiming/toJSON
-tags:
-  - API
-  - Web パフォーマンス
-  - メソッド
-  - リファレンス
-translation_of: Web/API/PerformanceResourceTiming/toJSON
 ---
 {{APIRef("Resource Timing API")}}
 

--- a/files/ja/web/api/performanceresourcetiming/transfersize/index.md
+++ b/files/ja/web/api/performanceresourcetiming/transfersize/index.md
@@ -1,12 +1,6 @@
 ---
 title: PerformanceResourceTiming.transferSize
 slug: Web/API/PerformanceResourceTiming/transferSize
-tags:
-  - API
-  - Web パフォーマンス
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/PerformanceResourceTiming/transferSize
 ---
 {{APIRef("Resource Timing API")}}
 

--- a/files/ja/web/api/performanceresourcetiming/workerstart/index.md
+++ b/files/ja/web/api/performanceresourcetiming/workerstart/index.md
@@ -1,14 +1,6 @@
 ---
 title: PerformanceResourceTiming.workerStart
 slug: Web/API/PerformanceResourceTiming/workerStart
-tags:
-  - API
-  - PerformanceResourceTiming
-  - Web パフォーマンス
-  - workerStart
-  - プロパティ
-  - リファレンス
-translation_of: Web/API/PerformanceResourceTiming/workerStart
 ---
 {{APIRef("Resource Timing API")}}
 

--- a/files/ja/web/api/performancetiming/index.md
+++ b/files/ja/web/api/performancetiming/index.md
@@ -1,20 +1,6 @@
 ---
 title: PerformanceTiming
 slug: Web/API/PerformanceTiming
-tags:
-  - API
-  - 後方互換性
-  - 非推奨
-  - インターフェイス
-  - Navigation Timing
-  - Navigation Timing API
-  - Optimization
-  - Performance
-  - Reference
-  - Timing
-  - legacy
-browser-compat: api.PerformanceTiming
-translation_of: Web/API/PerformanceTiming
 ---
 {{APIRef("Navigation Timing")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/permissions/index.md
+++ b/files/ja/web/api/permissions/index.md
@@ -1,14 +1,6 @@
 ---
 title: Permissions
 slug: Web/API/Permissions
-tags:
-  - API
-  - Experimental
-  - Interface
-  - Permissions
-  - Permissions API
-  - Reference
-translation_of: Web/API/Permissions
 ---
 {{APIRef("Permissions API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/permissions/query/index.md
+++ b/files/ja/web/api/permissions/query/index.md
@@ -1,13 +1,6 @@
 ---
 title: Permissions.query()
 slug: Web/API/Permissions/query
-tags:
-  - API
-  - Experimental
-  - Method
-  - Permissions
-  - Reference
-translation_of: Web/API/Permissions/query
 ---
 {{APIRef("Permissions API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/permissions/revoke/index.md
+++ b/files/ja/web/api/permissions/revoke/index.md
@@ -1,15 +1,6 @@
 ---
 title: Permissions.revoke()
 slug: Web/API/Permissions/revoke
-tags:
-  - API
-  - Experimental
-  - Method
-  - Permissions
-  - Permissions API
-  - Reference
-  - revoke
-translation_of: Web/API/Permissions/revoke
 ---
 {{APIRef("Permissions API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/permissions_api/index.md
+++ b/files/ja/web/api/permissions_api/index.md
@@ -1,12 +1,6 @@
 ---
 title: Permissions API
 slug: Web/API/Permissions_API
-tags:
-  - API
-  - Overview
-  - Permissions
-  - Reference
-translation_of: Web/API/Permissions_API
 ---
 {{DefaultAPISidebar("Permissions API")}}
 

--- a/files/ja/web/api/permissions_api/using_the_permissions_api/index.md
+++ b/files/ja/web/api/permissions_api/using_the_permissions_api/index.md
@@ -1,13 +1,6 @@
 ---
 title: Permissions API の使用
 slug: Web/API/Permissions_API/Using_the_Permissions_API
-tags:
-  - API
-  - Experimental
-  - Geolocation
-  - Guide
-  - Permissions
-translation_of: Web/API/Permissions_API/Using_the_Permissions_API
 ---
 {{DefaultAPISidebar("Permissions API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/permissionstatus/change_event/index.md
+++ b/files/ja/web/api/permissionstatus/change_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: PermissionStatus.onchange
 slug: Web/API/PermissionStatus/change_event
-tags:
-  - API
-  - Event Handler
-  - Experimental
-  - PermissionStatus
-  - Permissions
-  - Property
-  - Reference
-  - onchange
-translation_of: Web/API/PermissionStatus/onchange
 original_slug: Web/API/PermissionStatus/onchange
 ---
 {{APIRef("Permissions API")}}{{SeeCompatTable}}

--- a/files/ja/web/api/permissionstatus/index.md
+++ b/files/ja/web/api/permissionstatus/index.md
@@ -1,15 +1,6 @@
 ---
 title: PermissionStatus
 slug: Web/API/PermissionStatus
-tags:
-  - API
-  - Experimental
-  - Interface
-  - PermissionStatus
-  - Permissions
-  - Permissions API
-  - Reference
-translation_of: Web/API/PermissionStatus
 ---
 {{APIRef("Permissions API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/permissionstatus/state/index.md
+++ b/files/ja/web/api/permissionstatus/state/index.md
@@ -1,18 +1,6 @@
 ---
 title: PermissionStatus.state
 slug: Web/API/PermissionStatus/state
-tags:
-  - API
-  - Event Handler
-  - Experimental
-  - PermissionStatus
-  - Permissions
-  - Permissions API
-  - Property
-  - Reference
-  - state
-  - status
-translation_of: Web/API/PermissionStatus/state
 ---
 {{APIRef("Permissions API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/plugin/index.md
+++ b/files/ja/web/api/plugin/index.md
@@ -1,16 +1,6 @@
 ---
 title: Plugin
 slug: Web/API/Plugin
-page-type: web-api-interface
-tags:
-  - API
-  - Add-ons
-  - DOM
-  - NeedsContent
-  - Plug-in
-  - Plugins
-browser-compat: api.Plugin
-translation_of: Web/API/Plugin
 ---
 {{ApiRef("HTML DOM")}}{{deprecated_header}}
 

--- a/files/ja/web/api/pluginarray/index.md
+++ b/files/ja/web/api/pluginarray/index.md
@@ -1,12 +1,6 @@
 ---
 title: PluginArray
 slug: Web/API/PluginArray
-tags:
-  - Add-ons
-  - DOM
-  - Gecko DOM Reference
-  - Plugins
-translation_of: Web/API/PluginArray
 ---
 {{ApiRef}} {{non-standard_header}}
 

--- a/files/ja/web/api/pointer_events/index.md
+++ b/files/ja/web/api/pointer_events/index.md
@@ -1,15 +1,6 @@
 ---
 title: ポインターイベント
 slug: Web/API/Pointer_events
-tags:
-  - API
-  - インターフェイス
-  - Landing
-  - 概要
-  - ポインターイベント
-  - ウェブ
-  - イベント
-translation_of: Web/API/Pointer_events
 ---
 {{DefaultAPISidebar("Pointer Events")}}
 

--- a/files/ja/web/api/pointer_events/multi-touch_interaction/index.md
+++ b/files/ja/web/api/pointer_events/multi-touch_interaction/index.md
@@ -1,11 +1,6 @@
 ---
 title: マルチタッチ操作
 slug: Web/API/Pointer_events/Multi-touch_interaction
-tags:
-  - ガイド
-  - ポインターイベント
-  - touch
-translation_of: Web/API/Pointer_events/Multi-touch_interaction
 ---
 {{DefaultAPISidebar("Pointer Events")}}
 

--- a/files/ja/web/api/pointer_events/pinch_zoom_gestures/index.md
+++ b/files/ja/web/api/pointer_events/pinch_zoom_gestures/index.md
@@ -1,11 +1,6 @@
 ---
 title: ピンチズームのジェスチャー
 slug: Web/API/Pointer_events/Pinch_zoom_gestures
-tags:
-  - ガイド
-  - PointerEvent
-  - タッチ
-translation_of: Web/API/Pointer_events/Pinch_zoom_gestures
 ---
 {{DefaultAPISidebar("Pointer Events")}}
 

--- a/files/ja/web/api/pointer_events/using_pointer_events/index.md
+++ b/files/ja/web/api/pointer_events/using_pointer_events/index.md
@@ -1,14 +1,6 @@
 ---
 title: ポインターイベントの使用
 slug: Web/API/Pointer_events/Using_Pointer_Events
-tags:
-  - ガイド
-  - Input
-  - ポインターイベント
-  - PointerEvent
-  - イベント
-  - タッチ
-translation_of: Web/API/Pointer_events/Using_Pointer_Events
 ---
 {{DefaultAPISidebar("Pointer Events")}}
 

--- a/files/ja/web/api/pointer_lock_api/index.md
+++ b/files/ja/web/api/pointer_lock_api/index.md
@@ -1,14 +1,6 @@
 ---
 title: Pointer Lock API
 slug: Web/API/Pointer_Lock_API
-tags:
-  - API
-  - Advanced
-  - Games
-  - Reference
-  - mouse lock
-  - pointer lock
-translation_of: Web/API/Pointer_Lock_API
 ---
 {{DefaultAPISidebar("Pointer Lock API")}}
 

--- a/files/ja/web/api/pointerevent/getcoalescedevents/index.md
+++ b/files/ja/web/api/pointerevent/getcoalescedevents/index.md
@@ -1,15 +1,6 @@
 ---
 title: PointerEvent.getCoalescedEvents()
 slug: Web/API/PointerEvent/getCoalescedEvents
-tags:
-  - API
-  - DOM
-  - Deprecated
-  - Method
-  - Pointer Events
-  - PointerEvent
-  - Reference
-translation_of: Web/API/PointerEvent/getCoalescedEvents
 ---
 {{APIRef("Pointer Events")}}{{seecompattable}}
 

--- a/files/ja/web/api/pointerevent/height/index.md
+++ b/files/ja/web/api/pointerevent/height/index.md
@@ -1,14 +1,6 @@
 ---
 title: PointerEvent.height
 slug: Web/API/PointerEvent/height
-tags:
-  - API
-  - DOM
-  - Interface
-  - PointerEvent
-  - Property
-  - Reference
-translation_of: Web/API/PointerEvent/height
 ---
 {{ APIRef("Pointer Events") }}
 

--- a/files/ja/web/api/pointerevent/index.md
+++ b/files/ja/web/api/pointerevent/index.md
@@ -1,14 +1,6 @@
 ---
 title: PointerEvent
 slug: Web/API/PointerEvent
-tags:
-  - API
-  - DOM
-  - Interface
-  - Pointer Events
-  - PointerEvent
-  - Reference
-translation_of: Web/API/PointerEvent
 ---
 {{ APIRef("Pointer Events") }}
 

--- a/files/ja/web/api/pointerevent/isprimary/index.md
+++ b/files/ja/web/api/pointerevent/isprimary/index.md
@@ -1,14 +1,6 @@
 ---
 title: PointerEvent.isPrimary
 slug: Web/API/PointerEvent/isPrimary
-tags:
-  - API
-  - DOM
-  - Interface
-  - PointerEvent
-  - Property
-  - Reference
-translation_of: Web/API/PointerEvent/isPrimary
 ---
 {{ APIRef("Pointer Events") }}
 

--- a/files/ja/web/api/pointerevent/pointerevent/index.md
+++ b/files/ja/web/api/pointerevent/pointerevent/index.md
@@ -1,12 +1,6 @@
 ---
 title: PointerEvent.PointerEvent()
 slug: Web/API/PointerEvent/PointerEvent
-tags:
-  - API
-  - Constructor
-  - PointerEvent
-  - Reference
-translation_of: Web/API/PointerEvent/PointerEvent
 ---
 {{APIRef("Pointer Events")}}
 

--- a/files/ja/web/api/pointerevent/pointerid/index.md
+++ b/files/ja/web/api/pointerevent/pointerid/index.md
@@ -1,14 +1,6 @@
 ---
 title: PointerEvent.pointerId
 slug: Web/API/PointerEvent/pointerId
-tags:
-  - API
-  - DOM
-  - Interface
-  - PointerEvent
-  - Property
-  - Reference
-translation_of: Web/API/PointerEvent/pointerId
 ---
 {{ APIRef("Pointer Events") }}
 

--- a/files/ja/web/api/pointerevent/pointertype/index.md
+++ b/files/ja/web/api/pointerevent/pointertype/index.md
@@ -1,14 +1,6 @@
 ---
 title: PointerEvent.pointerType
 slug: Web/API/PointerEvent/pointerType
-tags:
-  - API
-  - DOM
-  - Interface
-  - PointerEvent
-  - Property
-  - Reference
-translation_of: Web/API/PointerEvent/pointerType
 ---
 {{ APIRef("Pointer Events") }}
 

--- a/files/ja/web/api/pointerevent/pressure/index.md
+++ b/files/ja/web/api/pointerevent/pressure/index.md
@@ -1,14 +1,6 @@
 ---
 title: PointerEvent.pressure
 slug: Web/API/PointerEvent/pressure
-tags:
-  - API
-  - DOM
-  - Interface
-  - PointerEvent
-  - Property
-  - Reference
-translation_of: Web/API/PointerEvent/pressure
 ---
 {{ APIRef("Pointer Events") }}
 

--- a/files/ja/web/api/pointerevent/tangentialpressure/index.md
+++ b/files/ja/web/api/pointerevent/tangentialpressure/index.md
@@ -1,15 +1,6 @@
 ---
 title: PointerEvent.tangentialPressure
 slug: Web/API/PointerEvent/tangentialPressure
-tags:
-  - API
-  - DOM
-  - Pointer Events
-  - PointerEvent
-  - Property
-  - Reference
-  - tangentialPressure
-translation_of: Web/API/PointerEvent/tangentialPressure
 ---
 {{ APIRef("Pointer Events") }}
 

--- a/files/ja/web/api/pointerevent/tiltx/index.md
+++ b/files/ja/web/api/pointerevent/tiltx/index.md
@@ -1,14 +1,6 @@
 ---
 title: PointerEvent.tiltX
 slug: Web/API/PointerEvent/tiltX
-tags:
-  - API
-  - DOM
-  - Interface
-  - PointerEvent
-  - Property
-  - Reference
-translation_of: Web/API/PointerEvent/tiltX
 ---
 {{ APIRef("Pointer Events") }}
 

--- a/files/ja/web/api/pointerevent/tilty/index.md
+++ b/files/ja/web/api/pointerevent/tilty/index.md
@@ -1,14 +1,6 @@
 ---
 title: PointerEvent.tiltY
 slug: Web/API/PointerEvent/tiltY
-tags:
-  - API
-  - DOM
-  - Interface
-  - PointerEvent
-  - Property
-  - Reference
-translation_of: Web/API/PointerEvent/tiltY
 ---
 {{ APIRef("Pointer Events") }}
 

--- a/files/ja/web/api/pointerevent/twist/index.md
+++ b/files/ja/web/api/pointerevent/twist/index.md
@@ -1,15 +1,6 @@
 ---
 title: PointerEvent.twist
 slug: Web/API/PointerEvent/twist
-tags:
-  - API
-  - DOM
-  - Pointer Events
-  - PointerEvent
-  - Property
-  - Reference
-  - twist
-translation_of: Web/API/PointerEvent/twist
 ---
 {{ APIRef("Pointer Events") }}
 

--- a/files/ja/web/api/pointerevent/width/index.md
+++ b/files/ja/web/api/pointerevent/width/index.md
@@ -1,14 +1,6 @@
 ---
 title: PointerEvent.width
 slug: Web/API/PointerEvent/width
-tags:
-  - API
-  - DOM
-  - Interface
-  - PointerEvent
-  - Property
-  - Reference
-translation_of: Web/API/PointerEvent/width
 ---
 {{ APIRef("Pointer Events") }}
 

--- a/files/ja/web/api/processinginstruction/index.md
+++ b/files/ja/web/api/processinginstruction/index.md
@@ -1,11 +1,6 @@
 ---
 title: ProcessingInstruction
 slug: Web/API/ProcessingInstruction
-tags:
-  - インターフェイス
-  - リファレンス
-browser-compat: api.ProcessingInstruction
-translation_of: Web/API/ProcessingInstruction
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/processinginstruction/sheet/index.md
+++ b/files/ja/web/api/processinginstruction/sheet/index.md
@@ -1,12 +1,6 @@
 ---
 title: ProcessingInstruction.sheet
 slug: Web/API/ProcessingInstruction/sheet
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.ProcessingInstruction.sheet
-translation_of: Web/API/ProcessingInstruction/sheet
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/processinginstruction/target/index.md
+++ b/files/ja/web/api/processinginstruction/target/index.md
@@ -1,12 +1,6 @@
 ---
 title: ProcessingInstruction.target
 slug: Web/API/ProcessingInstruction/target
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.ProcessingInstruction.target
-translation_of: Web/API/ProcessingInstruction/target
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/progressevent/index.md
+++ b/files/ja/web/api/progressevent/index.md
@@ -1,14 +1,6 @@
 ---
 title: ProgressEvent
 slug: Web/API/ProgressEvent
-tags:
-  - API
-  - Interface
-  - 進捗イベント
-  - ProgressEvent
-  - Reference
-browser-compat: api.ProgressEvent
-translation_of: Web/API/ProgressEvent
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/progressevent/lengthcomputable/index.md
+++ b/files/ja/web/api/progressevent/lengthcomputable/index.md
@@ -1,13 +1,6 @@
 ---
 title: ProgressEvent.lengthComputable
 slug: Web/API/ProgressEvent/lengthComputable
-tags:
-  - API
-  - 進捗イベント
-  - ProgressEvent
-  - プロパティ
-browser-compat: api.ProgressEvent.lengthComputable
-translation_of: Web/API/ProgressEvent/lengthComputable
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/progressevent/loaded/index.md
+++ b/files/ja/web/api/progressevent/loaded/index.md
@@ -1,12 +1,6 @@
 ---
 title: ProgressEvent.loaded
 slug: Web/API/ProgressEvent/loaded
-tags:
-  - API
-  - 進捗イベント
-  - ProgressEvent
-  - プロパティ
-browser-compat: api.ProgressEvent.loaded
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/progressevent/progressevent/index.md
+++ b/files/ja/web/api/progressevent/progressevent/index.md
@@ -1,13 +1,6 @@
 ---
 title: ProgressEvent()
 slug: Web/API/ProgressEvent/ProgressEvent
-tags:
-  - API
-  - コンストラクター
-  - DOM イベント
-  - ProgressEvent
-browser-compat: api.ProgressEvent.ProgressEvent
-translation_of: Web/API/ProgressEvent/ProgressEvent
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/progressevent/total/index.md
+++ b/files/ja/web/api/progressevent/total/index.md
@@ -1,14 +1,6 @@
 ---
 title: ProgressEvent.total
 slug: Web/API/ProgressEvent/total
-tags:
-  - API
-  - 進捗イベント
-  - ProgressEvent
-  - プロパティ
-  - Reference
-browser-compat: api.ProgressEvent.total
-translation_of: Web/API/ProgressEvent/total
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/promiserejectionevent/index.md
+++ b/files/ja/web/api/promiserejectionevent/index.md
@@ -1,17 +1,6 @@
 ---
 title: PromiseRejectionEvent
 slug: Web/API/PromiseRejectionEvent
-tags:
-  - API
-  - HTML DOM
-  - Interface
-  - JavaScript
-  - PromiseRejectionEvent
-  - Promises
-  - Reference
-  - events
-  - イベント
-translation_of: Web/API/PromiseRejectionEvent
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/promiserejectionevent/promise/index.md
+++ b/files/ja/web/api/promiserejectionevent/promise/index.md
@@ -1,17 +1,6 @@
 ---
 title: PromiseRejectionEvent.promise
 slug: Web/API/PromiseRejectionEvent/promise
-tags:
-  - API
-  - HTML DOM
-  - JavaScript
-  - Promise
-  - PromiseRejection
-  - Promises
-  - Property
-  - Reference
-  - events
-translation_of: Web/API/PromiseRejectionEvent/promise
 ---
 {{APIRef("HTML DOM") }}{{domxref("PromiseRejectionEvent")}}インターフェイスの読み取り専用プロパティである **`promise`** は、拒否された JavaScript の {{jsxref("Promise")}} を表します。promise が拒否された理由は、イベントの {{domxref("PromiseRejectionEvent.reason")}} プロパティを検査することでわかります。
 

--- a/files/ja/web/api/promiserejectionevent/promiserejectionevent/index.md
+++ b/files/ja/web/api/promiserejectionevent/promiserejectionevent/index.md
@@ -1,16 +1,6 @@
 ---
 title: PromiseRejectionEvent()
 slug: Web/API/PromiseRejectionEvent/PromiseRejectionEvent
-tags:
-  - API
-  - Constructor
-  - HTML DOM
-  - JavaScript
-  - PromiseRejectionEvent
-  - Promises
-  - Reference
-  - events
-translation_of: Web/API/PromiseRejectionEvent/PromiseRejectionEvent
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/promiserejectionevent/reason/index.md
+++ b/files/ja/web/api/promiserejectionevent/reason/index.md
@@ -1,17 +1,6 @@
 ---
 title: PromiseRejectionEvent.reason
 slug: Web/API/PromiseRejectionEvent/reason
-tags:
-  - API
-  - HTML DOM
-  - JavaScript
-  - PromiseRejectionEvent
-  - Promises
-  - Property
-  - Reference
-  - events
-  - reason
-translation_of: Web/API/PromiseRejectionEvent/reason
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/proximity_events/index.md
+++ b/files/ja/web/api/proximity_events/index.md
@@ -1,12 +1,6 @@
 ---
 title: Proximity Events
 slug: Web/API/Proximity_Events
-tags:
-  - API
-  - Experimental
-  - Proximity Events
-  - Reference
-translation_of: Web/API/Proximity_Events
 original_slug: WebAPI/Proximity
 ---
 {{DefaultAPISidebar("Proximity Events")}}{{ SeeCompatTable }}

--- a/files/ja/web/api/publickeycredential/getclientextensionresults/index.md
+++ b/files/ja/web/api/publickeycredential/getclientextensionresults/index.md
@@ -1,14 +1,6 @@
 ---
 title: PublicKeyCredential.getClientExtensionResults()
 slug: Web/API/PublicKeyCredential/getClientExtensionResults
-tags:
-  - API
-  - Method
-  - PublicKeyCredential
-  - Reference
-  - Web Authentication API
-  - WebAuthn
-translation_of: Web/API/PublicKeyCredential/getClientExtensionResults
 ---
 {{APIRef("Web Authentication API")}}{{securecontext_header}}
 

--- a/files/ja/web/api/publickeycredential/index.md
+++ b/files/ja/web/api/publickeycredential/index.md
@@ -1,16 +1,6 @@
 ---
 title: PublicKeyCredential
 slug: Web/API/PublicKeyCredential
-tags:
-  - API
-  - Authentication
-  - Interface
-  - PublicKeyCredential
-  - Reference
-  - Web Authentication API
-  - WebAuthn
-  - インターフェイス
-translation_of: Web/API/PublicKeyCredential
 ---
 {{APIRef("Web Authentication API")}}{{securecontext_header}}
 

--- a/files/ja/web/api/publickeycredential/rawid/index.md
+++ b/files/ja/web/api/publickeycredential/rawid/index.md
@@ -1,15 +1,6 @@
 ---
 title: PublicKeyCredential.rawId
 slug: Web/API/PublicKeyCredential/rawId
-tags:
-  - API
-  - Property
-  - PublicKeyCredential
-  - Reference
-  - Web Authentication API
-  - WebAuthn
-  - プロパティ
-translation_of: Web/API/PublicKeyCredential/rawId
 ---
 {{APIRef("Web Authentication API")}}{{securecontext_header}}
 

--- a/files/ja/web/api/publickeycredentialrequestoptions/index.md
+++ b/files/ja/web/api/publickeycredentialrequestoptions/index.md
@@ -1,15 +1,6 @@
 ---
 title: PublicKeyCredentialRequestOptions
 slug: Web/API/PublicKeyCredentialRequestOptions
-tags:
-  - API
-  - Dictionary
-  - PublicKeyCredentialRequestOptions
-  - Reference
-  - Web Authentication API
-  - WebAuthn
-  - 辞書
-translation_of: Web/API/PublicKeyCredentialRequestOptions
 ---
 {{APIRef("Web Authentication API")}}{{securecontext_header}}
 

--- a/files/ja/web/api/push_api/index.md
+++ b/files/ja/web/api/push_api/index.md
@@ -1,16 +1,6 @@
 ---
 title: Push API
 slug: Web/API/Push_API
-tags:
-  - API
-  - Experimental
-  - Landing
-  - Notifications
-  - Push
-  - Reference
-  - サービスワーカー
-  - プッシュ通知
-translation_of: Web/API/Push_API
 ---
 {{ApiRef("Push API")}}
 

--- a/files/ja/web/api/pushevent/data/index.md
+++ b/files/ja/web/api/pushevent/data/index.md
@@ -1,15 +1,6 @@
 ---
 title: PushEvent.data
 slug: Web/API/PushEvent/data
-tags:
-  - API
-  - Experimental
-  - Property
-  - Push
-  - PushEvent
-  - Reference
-  - data
-translation_of: Web/API/PushEvent/data
 ---
 {{APIRef("Push API")}}{{SeeCompatTable()}}
 

--- a/files/ja/web/api/pushevent/index.md
+++ b/files/ja/web/api/pushevent/index.md
@@ -1,17 +1,6 @@
 ---
 title: PushEvent
 slug: Web/API/PushEvent
-tags:
-  - API
-  - ExtendableEvent
-  - Interface
-  - Offline
-  - Push
-  - Push API
-  - Reference
-  - Service Workers
-  - Workers
-translation_of: Web/API/PushEvent
 ---
 {{APIRef("Push API")}}{{SeeCompatTable()}}
 

--- a/files/ja/web/api/pushevent/pushevent/index.md
+++ b/files/ja/web/api/pushevent/pushevent/index.md
@@ -1,16 +1,6 @@
 ---
 title: PushEvent.PushEvent()
 slug: Web/API/PushEvent/PushEvent
-tags:
-  - API
-  - Constructor
-  - Experimental
-  - Push
-  - Push API
-  - PushEvent
-  - Reference
-  - Service Workers
-translation_of: Web/API/PushEvent/PushEvent
 ---
 {{APIRef("Push API")}}{{SeeCompatTable()}}
 

--- a/files/ja/web/api/pushmanager/getsubscription/index.md
+++ b/files/ja/web/api/pushmanager/getsubscription/index.md
@@ -1,14 +1,6 @@
 ---
 title: PushManager.getSubscription()
 slug: Web/API/PushManager/getSubscription
-tags:
-  - API
-  - Experimental
-  - Method
-  - PushManager
-  - Reference
-  - Service Workers
-translation_of: Web/API/PushManager/getSubscription
 ---
 {{SeeCompatTable}}{{ApiRef("Push API")}}
 

--- a/files/ja/web/api/pushmanager/index.md
+++ b/files/ja/web/api/pushmanager/index.md
@@ -1,15 +1,6 @@
 ---
 title: PushManager
 slug: Web/API/PushManager
-tags:
-  - API
-  - Experimental
-  - Interface
-  - Push
-  - Push API
-  - Reference
-  - Service Workers
-translation_of: Web/API/PushManager
 ---
 {{SeeCompatTable}}{{ApiRef("Push API")}}
 

--- a/files/ja/web/api/pushmanager/permissionstate/index.md
+++ b/files/ja/web/api/pushmanager/permissionstate/index.md
@@ -1,15 +1,6 @@
 ---
 title: PushManager.permissionState()
 slug: Web/API/PushManager/permissionState
-tags:
-  - API
-  - Experimental
-  - Method
-  - PushManager
-  - Reference
-  - Service Workers
-  - permissionState
-translation_of: Web/API/PushManager/permissionState
 ---
 {{SeeCompatTable}}{{ApiRef("Push API")}}
 

--- a/files/ja/web/api/pushmanager/register/index.md
+++ b/files/ja/web/api/pushmanager/register/index.md
@@ -1,14 +1,6 @@
 ---
 title: PushManager.register()
 slug: Web/API/PushManager/register
-tags:
-  - API
-  - Deprecated
-  - Method
-  - Reference
-  - Simple Push API
-  - メソッド
-translation_of: Web/API/PushManager/register
 ---
 {{deprecated_header}}{{ ApiRef("Push API")}}
 

--- a/files/ja/web/api/pushmanager/registrations/index.md
+++ b/files/ja/web/api/pushmanager/registrations/index.md
@@ -1,14 +1,6 @@
 ---
 title: PushManager.registrations()
 slug: Web/API/PushManager/registrations
-tags:
-  - API
-  - Deprecated
-  - Method
-  - Reference
-  - Simple Push API
-  - メソッド
-translation_of: Web/API/PushManager/registrations
 ---
 {{deprecated_header}}{{ApiRef("Push API")}}
 

--- a/files/ja/web/api/pushmanager/subscribe/index.md
+++ b/files/ja/web/api/pushmanager/subscribe/index.md
@@ -1,15 +1,6 @@
 ---
 title: PushManager.subscribe()
 slug: Web/API/PushManager/subscribe
-tags:
-  - API
-  - Experimental
-  - Method
-  - PushManager
-  - Reference
-  - Web API
-  - subscribe
-translation_of: Web/API/PushManager/subscribe
 ---
 {{SeeCompatTable}}{{ApiRef("Push API")}}
 

--- a/files/ja/web/api/pushmanager/unregister/index.md
+++ b/files/ja/web/api/pushmanager/unregister/index.md
@@ -1,14 +1,6 @@
 ---
 title: PushManager.unregister()
 slug: Web/API/PushManager/unregister
-tags:
-  - API
-  - Deprecated
-  - Method
-  - Reference
-  - Simple Push API
-  - メソッド
-translation_of: Web/API/PushManager/unregister
 ---
 {{deprecated_header}}{{ ApiRef("Push API")}}
 

--- a/files/ja/web/api/pushmessagedata/arraybuffer/index.md
+++ b/files/ja/web/api/pushmessagedata/arraybuffer/index.md
@@ -1,16 +1,6 @@
 ---
 title: PushMessageData.arrayBuffer()
 slug: Web/API/PushMessageData/arrayBuffer
-tags:
-  - API
-  - ArrayBuffer
-  - Experimental
-  - Method
-  - Push
-  - PushMessageData
-  - Reference
-  - ServiceWorkers
-translation_of: Web/API/PushMessageData/arrayBuffer
 ---
 {{APIRef("Push API")}}{{SeeCompatTable()}}
 

--- a/files/ja/web/api/pushmessagedata/blob/index.md
+++ b/files/ja/web/api/pushmessagedata/blob/index.md
@@ -1,16 +1,6 @@
 ---
 title: PushMessageData.blob()
 slug: Web/API/PushMessageData/blob
-tags:
-  - API
-  - Blob
-  - Experimental
-  - Method
-  - Push
-  - PushMessageData
-  - Reference
-  - Service Workers
-translation_of: Web/API/PushMessageData/blob
 ---
 {{APIRef("Push API")}}{{SeeCompatTable()}}
 

--- a/files/ja/web/api/pushmessagedata/index.md
+++ b/files/ja/web/api/pushmessagedata/index.md
@@ -1,16 +1,6 @@
 ---
 title: PushMessageData
 slug: Web/API/PushMessageData
-tags:
-  - API
-  - Experimental
-  - Interface
-  - Push
-  - Push API
-  - PushMessageData
-  - Reference
-  - Service Workers
-translation_of: Web/API/PushMessageData
 ---
 {{APIRef("Push API")}}{{SeeCompatTable()}}
 

--- a/files/ja/web/api/pushmessagedata/json/index.md
+++ b/files/ja/web/api/pushmessagedata/json/index.md
@@ -1,16 +1,6 @@
 ---
 title: PushMessageData.json()
 slug: Web/API/PushMessageData/json
-tags:
-  - API
-  - Experimental
-  - JSON
-  - Method
-  - Push
-  - PushMessageData
-  - Reference
-  - Service Workers
-translation_of: Web/API/PushMessageData/json
 ---
 {{APIRef("Push API")}}{{SeeCompatTable()}}
 

--- a/files/ja/web/api/pushmessagedata/text/index.md
+++ b/files/ja/web/api/pushmessagedata/text/index.md
@@ -1,17 +1,6 @@
 ---
 title: PushMessageData.text()
 slug: Web/API/PushMessageData/text
-tags:
-  - API
-  - Experimental
-  - Method
-  - Plain text
-  - Push
-  - PushuMessageData
-  - Reference
-  - Service Workers
-  - Text
-translation_of: Web/API/PushMessageData/text
 ---
 {{APIRef("Push API")}}{{SeeCompatTable()}}
 

--- a/files/ja/web/api/pushsubscription/endpoint/index.md
+++ b/files/ja/web/api/pushsubscription/endpoint/index.md
@@ -1,17 +1,6 @@
 ---
 title: PushSubscription.endpoint
 slug: Web/API/PushSubscription/endpoint
-tags:
-  - API
-  - Experimental
-  - Property
-  - Push
-  - Push API
-  - PushSubscription
-  - Reference
-  - Service Workers
-  - endPoint
-translation_of: Web/API/PushSubscription/endpoint
 ---
 {{SeeCompatTable}}{{APIRef("Push API")}}
 

--- a/files/ja/web/api/pushsubscription/getkey/index.md
+++ b/files/ja/web/api/pushsubscription/getkey/index.md
@@ -1,18 +1,6 @@
 ---
 title: PushSubscription.getKey()
 slug: Web/API/PushSubscription/getKey
-tags:
-  - API
-  - Experimental
-  - Method
-  - Non-standard
-  - Push
-  - Push API
-  - PushSubscription
-  - Reference
-  - Service Workers
-  - getKey
-translation_of: Web/API/PushSubscription/getKey
 ---
 {{SeeCompatTable}}{{APIRef("Push API")}}
 

--- a/files/ja/web/api/pushsubscription/index.md
+++ b/files/ja/web/api/pushsubscription/index.md
@@ -1,16 +1,6 @@
 ---
 title: PushSubscription
 slug: Web/API/PushSubscription
-tags:
-  - API
-  - Experimental
-  - Interface
-  - Push
-  - Push API
-  - PushSubscription
-  - Reference
-  - Service Workers
-translation_of: Web/API/PushSubscription
 ---
 {{SeeCompatTable}}{{ApiRef("Push API")}}
 

--- a/files/ja/web/api/pushsubscription/tojson/index.md
+++ b/files/ja/web/api/pushsubscription/tojson/index.md
@@ -1,17 +1,6 @@
 ---
 title: PushSubscription.toJSON()
 slug: Web/API/PushSubscription/toJSON
-tags:
-  - API
-  - Experimental
-  - Method
-  - Push
-  - Push API
-  - PushSubscription
-  - Reference
-  - Service Workers
-  - toJSON
-translation_of: Web/API/PushSubscription/toJSON
 ---
 {{SeeCompatTable}}{{APIRef("Push API")}}
 

--- a/files/ja/web/api/pushsubscription/unsubscribe/index.md
+++ b/files/ja/web/api/pushsubscription/unsubscribe/index.md
@@ -1,17 +1,6 @@
 ---
 title: PushSubscription.unsubscribe()
 slug: Web/API/PushSubscription/unsubscribe
-tags:
-  - API
-  - Experimental
-  - Method
-  - Push
-  - Push API
-  - PushSubscription
-  - Reference
-  - Service Workers
-  - unsubscribe
-translation_of: Web/API/PushSubscription/unsubscribe
 ---
 {{SeeCompatTable}}{{APIRef("Push API")}}
 

--- a/files/ja/web/api/queuemicrotask/index.md
+++ b/files/ja/web/api/queuemicrotask/index.md
@@ -1,27 +1,6 @@
 ---
 title: queueMicrotask()
 slug: Web/API/queueMicrotask
-tags:
-  - API
-  - HTML DOM
-  - Intervals
-  - JavaScript
-  - Method
-  - Microtask
-  - Performance
-  - Reference
-  - Scheduling
-  - ServiceWorker
-  - SharedWorker
-  - Tasks
-  - Timers
-  - Window
-  - Worker
-  - asynchronous
-  - queueMicrotask
-  - setTimeout
-  - Polyfill
-browser-compat: api.queueMicrotask
 ---
 {{APIRef("HTML DOM")}}
 


### PR DESCRIPTION
Part of #7858

`files/ja/web/api/{n-q}*` から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "page-type": 50,
  "tags": 290,
  "browser-compat": 140,
  "translation_of": 290,
  "tranlation_of": 1
}
```
