### PR TITLE
remove duplicated frontmatter keys from web/api/{r-s}* (ja)

### DIFF
--- a/files/ja/web/api/range/clonecontents/index.md
+++ b/files/ja/web/api/range/clonecontents/index.md
@@ -1,14 +1,6 @@
 ---
 title: Range.cloneContents()
 slug: Web/API/Range/cloneContents
-page-type: web-api-instance-method
-tags:
-  - API
-  - DOM
-  - Method
-  - Range
-browser-compat: api.Range.cloneContents
-translation_of: Web/API/Range/cloneContents
 ---
 {{ APIRef("DOM") }}
 

--- a/files/ja/web/api/range/collapsed/index.md
+++ b/files/ja/web/api/range/collapsed/index.md
@@ -1,16 +1,6 @@
 ---
 title: Range.collapsed
 slug: Web/API/Range/collapsed
-page-type: web-api-instance-property
-tags:
-  - API
-  - DOM
-  - DOM Reference
-  - Property
-  - Range
-  - Reference
-browser-compat: api.Range.collapsed
-translation_of: Web/API/Range/collapsed
 ---
 {{ APIRef("DOM") }}
 

--- a/files/ja/web/api/range/commonancestorcontainer/index.md
+++ b/files/ja/web/api/range/commonancestorcontainer/index.md
@@ -1,14 +1,6 @@
 ---
 title: Range.commonAncestorContainer
 slug: Web/API/Range/commonAncestorContainer
-page-type: web-api-instance-property
-tags:
-  - API
-  - DOM
-  - Property
-  - Range
-browser-compat: api.Range.commonAncestorContainer
-translation_of: Web/API/Range/commonAncestorContainer
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/range/endcontainer/index.md
+++ b/files/ja/web/api/range/endcontainer/index.md
@@ -1,14 +1,6 @@
 ---
 title: Range.endContainer
 slug: Web/API/Range/endContainer
-page-type: web-api-instance-property
-tags:
-  - API
-  - DOM
-  - Property
-  - Range
-browser-compat: api.Range.endContainer
-translation_of: Web/API/Range/endContainer
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/range/endoffset/index.md
+++ b/files/ja/web/api/range/endoffset/index.md
@@ -1,14 +1,6 @@
 ---
 title: Range.endOffset
 slug: Web/API/Range/endOffset
-page-type: web-api-instance-property
-tags:
-  - API
-  - DOM
-  - Property
-  - Range
-browser-compat: api.Range.endOffset
-translation_of: Web/API/Range/endOffset
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/range/index.md
+++ b/files/ja/web/api/range/index.md
@@ -1,12 +1,6 @@
 ---
 title: Range
 slug: Web/API/Range
-page-type: web-api-interface
-tags:
-  - API
-  - DOM
-browser-compat: api.Range
-translation_of: Web/API/Range
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/range/intersectsnode/index.md
+++ b/files/ja/web/api/range/intersectsnode/index.md
@@ -1,16 +1,6 @@
 ---
 title: Range.intersectsNode()
 slug: Web/API/Range/intersectsNode
-page-type: web-api-instance-method
-tags:
-  - API
-  - DOM
-  - Experimental
-  - Method
-  - Range
-  - Reference
-browser-compat: api.Range.intersectsNode
-translation_of: Web/API/Range/intersectsNode
 ---
 {{ApiRef("DOM")}} {{SeeCompatTable}}
 

--- a/files/ja/web/api/range/setstart/index.md
+++ b/files/ja/web/api/range/setstart/index.md
@@ -1,14 +1,6 @@
 ---
 title: Range.setStart()
 slug: Web/API/Range/setStart
-page-type: web-api-instance-method
-tags:
-  - API
-  - DOM
-  - Method
-  - Range
-browser-compat: api.Range.setStart
-translation_of: Web/API/Range/setStart
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/range/startcontainer/index.md
+++ b/files/ja/web/api/range/startcontainer/index.md
@@ -1,14 +1,6 @@
 ---
 title: Range.startContainer
 slug: Web/API/Range/startContainer
-page-type: web-api-instance-property
-tags:
-  - API
-  - DOM
-  - Property
-  - Range
-browser-compat: api.Range.startContainer
-translation_of: Web/API/Range/startContainer
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/range/startoffset/index.md
+++ b/files/ja/web/api/range/startoffset/index.md
@@ -1,14 +1,6 @@
 ---
 title: Range.startOffset
 slug: Web/API/Range/startOffset
-page-type: web-api-instance-property
-tags:
-  - API
-  - DOM
-  - Property
-  - Range
-browser-compat: api.Range.startOffset
-translation_of: Web/API/Range/startOffset
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/readablebytestreamcontroller/byobrequest/index.md
+++ b/files/ja/web/api/readablebytestreamcontroller/byobrequest/index.md
@@ -1,15 +1,6 @@
 ---
 title: ReadableByteStreamController.byobRequest
 slug: Web/API/ReadableByteStreamController/byobRequest
-tags:
-  - API
-  - Experimental
-  - Property
-  - ReadableByteStreamController
-  - Reference
-  - Streams
-  - byobRequest
-translation_of: Web/API/ReadableByteStreamController/byobRequest
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablebytestreamcontroller/close/index.md
+++ b/files/ja/web/api/readablebytestreamcontroller/close/index.md
@@ -1,15 +1,6 @@
 ---
 title: ReadableByteStreamController.close()
 slug: Web/API/ReadableByteStreamController/close
-tags:
-  - API
-  - Experimental
-  - Method
-  - ReadableByteStreamController
-  - Reference
-  - Streams
-  - close
-translation_of: Web/API/ReadableByteStreamController/close
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablebytestreamcontroller/desiredsize/index.md
+++ b/files/ja/web/api/readablebytestreamcontroller/desiredsize/index.md
@@ -1,15 +1,6 @@
 ---
 title: ReadableByteStreamController.desiredSize
 slug: Web/API/ReadableByteStreamController/desiredSize
-tags:
-  - API
-  - Experimental
-  - Property
-  - ReadableByteStreamController
-  - Reference
-  - Streams
-  - desiredSize
-translation_of: Web/API/ReadableByteStreamController/desiredSize
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablebytestreamcontroller/enqueue/index.md
+++ b/files/ja/web/api/readablebytestreamcontroller/enqueue/index.md
@@ -1,15 +1,6 @@
 ---
 title: ReadableByteStreamController.enqueue()
 slug: Web/API/ReadableByteStreamController/enqueue
-tags:
-  - API
-  - Experimental
-  - Method
-  - ReadableByteStreamController
-  - Reference
-  - Streams
-  - enqueue
-translation_of: Web/API/ReadableByteStreamController/enqueue
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablebytestreamcontroller/error/index.md
+++ b/files/ja/web/api/readablebytestreamcontroller/error/index.md
@@ -1,15 +1,6 @@
 ---
 title: ReadableByteStreamController.error()
 slug: Web/API/ReadableByteStreamController/error
-tags:
-  - API
-  - Error
-  - Experimental
-  - Method
-  - ReadableByteStreamController
-  - Reference
-  - Streams
-translation_of: Web/API/ReadableByteStreamController/error
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablebytestreamcontroller/index.md
+++ b/files/ja/web/api/readablebytestreamcontroller/index.md
@@ -1,15 +1,6 @@
 ---
 title: ReadableByteStreamController
 slug: Web/API/ReadableByteStreamController
-tags:
-  - API
-  - Experimental
-  - Fetch
-  - Interface
-  - ReadableByteStreamController
-  - Reference
-  - Streams
-translation_of: Web/API/ReadableByteStreamController
 ---
 {{APIRef("Streams")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/readablestream/cancel/index.md
+++ b/files/ja/web/api/readablestream/cancel/index.md
@@ -1,14 +1,6 @@
 ---
 title: ReadableStream.cancel()
 slug: Web/API/ReadableStream/cancel
-tags:
-  - API
-  - Method
-  - ReadableStream
-  - Reference
-  - Streams
-  - cancel
-translation_of: Web/API/ReadableStream/cancel
 ---
 {{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablestream/getreader/index.md
+++ b/files/ja/web/api/readablestream/getreader/index.md
@@ -1,14 +1,6 @@
 ---
 title: ReadableStream.getReader()
 slug: Web/API/ReadableStream/getReader
-tags:
-  - API
-  - Method
-  - ReadableStream
-  - Reference
-  - Streams
-  - getReader
-translation_of: Web/API/ReadableStream/getReader
 ---
 {{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablestream/index.md
+++ b/files/ja/web/api/readablestream/index.md
@@ -1,19 +1,6 @@
 ---
 title: ReadableStream
 slug: Web/API/ReadableStream
-tags:
-  - API
-  - Fetch
-  - Fetch API
-  - Files
-  - HTTP
-  - Interface
-  - Networking
-  - ReadableStream
-  - Reference
-  - Streams
-  - data
-translation_of: Web/API/ReadableStream
 ---
 {{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablestream/locked/index.md
+++ b/files/ja/web/api/readablestream/locked/index.md
@@ -1,14 +1,6 @@
 ---
 title: ReadableStream.locked
 slug: Web/API/ReadableStream/locked
-tags:
-  - API
-  - Property
-  - ReadableStream
-  - Reference
-  - Streams
-  - locked
-translation_of: Web/API/ReadableStream/locked
 ---
 {{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablestream/pipethrough/index.md
+++ b/files/ja/web/api/readablestream/pipethrough/index.md
@@ -1,15 +1,6 @@
 ---
 title: ReadableStream.pipeThrough()
 slug: Web/API/ReadableStream/pipeThrough
-tags:
-  - API
-  - Experimental
-  - Method
-  - ReadableStream
-  - Reference
-  - Streams
-  - pipeThrough
-translation_of: Web/API/ReadableStream/pipeThrough
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablestream/pipeto/index.md
+++ b/files/ja/web/api/readablestream/pipeto/index.md
@@ -1,15 +1,6 @@
 ---
 title: ReadableStream.pipeTo()
 slug: Web/API/ReadableStream/pipeTo
-tags:
-  - API
-  - Experimental
-  - Method
-  - ReadableStream
-  - Reference
-  - Streams
-  - pipeTo
-translation_of: Web/API/ReadableStream/pipeTo
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablestream/readablestream/index.md
+++ b/files/ja/web/api/readablestream/readablestream/index.md
@@ -1,12 +1,6 @@
 ---
 title: ReadableStream.ReadableStream()
 slug: Web/API/ReadableStream/ReadableStream
-tags:
-  - API
-  - Constructor
-  - ReadableStream
-  - Reference
-translation_of: Web/API/ReadableStream/ReadableStream
 ---
 {{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablestream/tee/index.md
+++ b/files/ja/web/api/readablestream/tee/index.md
@@ -1,14 +1,6 @@
 ---
 title: ReadableStream.tee()
 slug: Web/API/ReadableStream/tee
-tags:
-  - API
-  - Method
-  - ReadableStream
-  - Reference
-  - Streams
-  - tee
-translation_of: Web/API/ReadableStream/tee
 ---
 {{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablestreambyobreader/cancel/index.md
+++ b/files/ja/web/api/readablestreambyobreader/cancel/index.md
@@ -1,15 +1,6 @@
 ---
 title: ReadableStreamBYOBReader.cancel()
 slug: Web/API/ReadableStreamBYOBReader/cancel
-tags:
-  - API
-  - Experimental
-  - Method
-  - ReadableStreamBYOBReader
-  - Reference
-  - Streams
-  - cancel
-translation_of: Web/API/ReadableStreamBYOBReader/cancel
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablestreambyobreader/closed/index.md
+++ b/files/ja/web/api/readablestreambyobreader/closed/index.md
@@ -1,15 +1,6 @@
 ---
 title: ReadableStreamBYOBReader.closed
 slug: Web/API/ReadableStreamBYOBReader/closed
-tags:
-  - API
-  - Experimental
-  - Property
-  - ReadableStreamBYOBReader
-  - Reference
-  - Streams
-  - closed
-translation_of: Web/API/ReadableStreamBYOBReader/closed
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablestreambyobreader/index.md
+++ b/files/ja/web/api/readablestreambyobreader/index.md
@@ -1,15 +1,6 @@
 ---
 title: ReadableStreamBYOBReader
 slug: Web/API/ReadableStreamBYOBReader
-tags:
-  - API
-  - Experimental
-  - Fetch
-  - Interface
-  - ReadableStreamBYOBReader
-  - Reference
-  - Streams
-translation_of: Web/API/ReadableStreamBYOBReader
 ---
 {{APIRef("Streams")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/readablestreambyobreader/read/index.md
+++ b/files/ja/web/api/readablestreambyobreader/read/index.md
@@ -1,15 +1,6 @@
 ---
 title: ReadableStreamBYOBReader.read()
 slug: Web/API/ReadableStreamBYOBReader/read
-tags:
-  - API
-  - Experimental
-  - Method
-  - ReadableStreamBYOBReader
-  - Reference
-  - Streams
-  - read
-translation_of: Web/API/ReadableStreamBYOBReader/read
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablestreambyobreader/readablestreambyobreader/index.md
+++ b/files/ja/web/api/readablestreambyobreader/readablestreambyobreader/index.md
@@ -1,14 +1,6 @@
 ---
 title: ReadableStreamBYOBReader.ReadableStreamBYOBReader()
 slug: Web/API/ReadableStreamBYOBReader/ReadableStreamBYOBReader
-tags:
-  - API
-  - Constructor
-  - Experimental
-  - ReadableStreamBYOBReader
-  - Reference
-  - Streams
-translation_of: Web/API/ReadableStreamBYOBReader/ReadableStreamBYOBReader
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablestreambyobreader/releaselock/index.md
+++ b/files/ja/web/api/readablestreambyobreader/releaselock/index.md
@@ -1,15 +1,6 @@
 ---
 title: ReadableStreamBYOBReader.releaseLock()
 slug: Web/API/ReadableStreamBYOBReader/releaseLock
-tags:
-  - API
-  - Experimental
-  - Method
-  - ReadableStreamBYOBReader
-  - Reference
-  - Streams
-  - releaseLock
-translation_of: Web/API/ReadableStreamBYOBReader/releaseLock
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablestreamdefaultcontroller/close/index.md
+++ b/files/ja/web/api/readablestreamdefaultcontroller/close/index.md
@@ -1,14 +1,6 @@
 ---
 title: ReadableStreamDefaultController.close()
 slug: Web/API/ReadableStreamDefaultController/close
-tags:
-  - API
-  - Method
-  - ReadableStreamDefaultController
-  - Reference
-  - Streams
-  - close
-translation_of: Web/API/ReadableStreamDefaultController/close
 ---
 {{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablestreamdefaultcontroller/desiredsize/index.md
+++ b/files/ja/web/api/readablestreamdefaultcontroller/desiredsize/index.md
@@ -1,14 +1,6 @@
 ---
 title: ReadableStreamDefaultController.desiredSize
 slug: Web/API/ReadableStreamDefaultController/desiredSize
-tags:
-  - API
-  - Property
-  - ReadableStreamDefaultController
-  - Reference
-  - Streams
-  - desiredSize
-translation_of: Web/API/ReadableStreamDefaultController/desiredSize
 ---
 {{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablestreamdefaultcontroller/enqueue/index.md
+++ b/files/ja/web/api/readablestreamdefaultcontroller/enqueue/index.md
@@ -1,14 +1,6 @@
 ---
 title: ReadableStreamDefaultController.enqueue()
 slug: Web/API/ReadableStreamDefaultController/enqueue
-tags:
-  - API
-  - Method
-  - ReadableStreamDefaultController
-  - Reference
-  - Streams
-  - enqueue
-translation_of: Web/API/ReadableStreamDefaultController/enqueue
 ---
 {{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablestreamdefaultcontroller/error/index.md
+++ b/files/ja/web/api/readablestreamdefaultcontroller/error/index.md
@@ -1,14 +1,6 @@
 ---
 title: ReadableStreamDefaultController.error()
 slug: Web/API/ReadableStreamDefaultController/error
-tags:
-  - API
-  - Error
-  - Method
-  - ReadableStreamDefaultController
-  - Reference
-  - Streams
-translation_of: Web/API/ReadableStreamDefaultController/error
 ---
 {{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablestreamdefaultcontroller/index.md
+++ b/files/ja/web/api/readablestreamdefaultcontroller/index.md
@@ -1,14 +1,6 @@
 ---
 title: ReadableStreamDefaultController
 slug: Web/API/ReadableStreamDefaultController
-tags:
-  - API
-  - Fetch
-  - Interface
-  - ReadableStreamDefaultController
-  - Reference
-  - Streams
-translation_of: Web/API/ReadableStreamDefaultController
 ---
 {{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablestreamdefaultreader/cancel/index.md
+++ b/files/ja/web/api/readablestreamdefaultreader/cancel/index.md
@@ -1,14 +1,6 @@
 ---
 title: ReadableStreamDefaultReader.cancel()
 slug: Web/API/ReadableStreamDefaultReader/cancel
-tags:
-  - API
-  - Method
-  - ReadableStreamDefaultReader
-  - Reference
-  - Streams
-  - cancel
-translation_of: Web/API/ReadableStreamDefaultReader/cancel
 ---
 {{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablestreamdefaultreader/closed/index.md
+++ b/files/ja/web/api/readablestreamdefaultreader/closed/index.md
@@ -1,14 +1,6 @@
 ---
 title: ReadableStreamDefaultReader.closed
 slug: Web/API/ReadableStreamDefaultReader/closed
-tags:
-  - API
-  - Property
-  - ReadableStreamDefaultReader
-  - Reference
-  - Streams
-  - closed
-translation_of: Web/API/ReadableStreamDefaultReader/closed
 ---
 {{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablestreamdefaultreader/index.md
+++ b/files/ja/web/api/readablestreamdefaultreader/index.md
@@ -1,14 +1,6 @@
 ---
 title: ReadableStreamDefaultReader
 slug: Web/API/ReadableStreamDefaultReader
-tags:
-  - API
-  - Fetch
-  - Interface
-  - ReadableStreamDefaultReader
-  - Reference
-  - Streams
-translation_of: Web/API/ReadableStreamDefaultReader
 ---
 {{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablestreamdefaultreader/read/index.md
+++ b/files/ja/web/api/readablestreamdefaultreader/read/index.md
@@ -1,14 +1,6 @@
 ---
 title: ReadableStreamDefaultReader.read()
 slug: Web/API/ReadableStreamDefaultReader/read
-tags:
-  - API
-  - Method
-  - ReadableStreamDefaultReader
-  - Reference
-  - Streams
-  - read
-translation_of: Web/API/ReadableStreamDefaultReader/read
 ---
 {{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablestreamdefaultreader/readablestreamdefaultreader/index.md
+++ b/files/ja/web/api/readablestreamdefaultreader/readablestreamdefaultreader/index.md
@@ -1,13 +1,6 @@
 ---
 title: ReadableStreamDefaultReader.ReadableStreamDefaultReader()
 slug: Web/API/ReadableStreamDefaultReader/ReadableStreamDefaultReader
-tags:
-  - API
-  - Constructor
-  - ReadableStreamDefaultReader
-  - Reference
-  - Streams
-translation_of: Web/API/ReadableStreamDefaultReader/ReadableStreamDefaultReader
 ---
 {{APIRef("Streams")}}
 

--- a/files/ja/web/api/readablestreamdefaultreader/releaselock/index.md
+++ b/files/ja/web/api/readablestreamdefaultreader/releaselock/index.md
@@ -1,14 +1,6 @@
 ---
 title: ReadableStreamDefaultReader.releaseLock()
 slug: Web/API/ReadableStreamDefaultReader/releaseLock
-tags:
-  - API
-  - Method
-  - ReadableStreamDefaultReader
-  - Reference
-  - Streams
-  - releaseLock
-translation_of: Web/API/ReadableStreamDefaultReader/releaseLock
 ---
 {{APIRef("Streams")}}
 

--- a/files/ja/web/api/request/cache/index.md
+++ b/files/ja/web/api/request/cache/index.md
@@ -1,15 +1,6 @@
 ---
 title: Request.cache
 slug: Web/API/Request/cache
-tags:
-  - API
-  - Cache
-  - Experimental
-  - Fetch
-  - Property
-  - Reference
-  - requesut
-translation_of: Web/API/Request/cache
 ---
 {{APIRef("Fetch")}}
 

--- a/files/ja/web/api/request/clone/index.md
+++ b/files/ja/web/api/request/clone/index.md
@@ -1,15 +1,6 @@
 ---
 title: Request.clone()
 slug: Web/API/Request/clone
-tags:
-  - API
-  - Experimenal
-  - Fetch
-  - Method
-  - Reference
-  - clone
-  - request
-translation_of: Web/API/Request/clone
 ---
 {{APIRef("Fetch")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/request/credentials/index.md
+++ b/files/ja/web/api/request/credentials/index.md
@@ -1,17 +1,6 @@
 ---
 title: Request.credentials
 slug: Web/API/Request/credentials
-tags:
-  - API
-  - Cookies
-  - Fetch
-  - Networking
-  - Property
-  - Reference
-  - Security
-  - credentials
-  - request
-translation_of: Web/API/Request/credentials
 ---
 {{APIRef("Fetch")}}
 

--- a/files/ja/web/api/request/headers/index.md
+++ b/files/ja/web/api/request/headers/index.md
@@ -1,15 +1,6 @@
 ---
 title: Request.headers
 slug: Web/API/Request/headers
-tags:
-  - API
-  - Experimental
-  - Fetch
-  - Headers
-  - Property
-  - Reference
-  - request
-translation_of: Web/API/Request/headers
 ---
 {{APIRef("Fetch")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/request/index.md
+++ b/files/ja/web/api/request/index.md
@@ -1,16 +1,6 @@
 ---
 title: Request
 slug: Web/API/Request
-tags:
-  - API
-  - Fetch
-  - Fetch API
-  - Interface
-  - Networking
-  - Reference
-  - request
-translation_of: Web/API/Request
-browser-compat: api.Request
 ---
 {{APIRef("Fetch API")}}
 

--- a/files/ja/web/api/request/integrity/index.md
+++ b/files/ja/web/api/request/integrity/index.md
@@ -1,15 +1,6 @@
 ---
 title: Request.integrity
 slug: Web/API/Request/integrity
-tags:
-  - API
-  - Experimental
-  - Fetch
-  - Property
-  - Reference
-  - integrity
-  - request
-translation_of: Web/API/Request/integrity
 ---
 {{APIRef("Fetch")}}
 

--- a/files/ja/web/api/request/method/index.md
+++ b/files/ja/web/api/request/method/index.md
@@ -1,14 +1,6 @@
 ---
 title: Request.method
 slug: Web/API/Request/method
-tags:
-  - API
-  - Experimental
-  - Fetch
-  - Property
-  - Reference
-  - request
-translation_of: Web/API/Request/method
 ---
 {{APIRef("Fetch")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/request/mode/index.md
+++ b/files/ja/web/api/request/mode/index.md
@@ -1,15 +1,6 @@
 ---
 title: Request.mode
 slug: Web/API/Request/mode
-tags:
-  - API
-  - Experimental
-  - Fetch
-  - Property
-  - Reference
-  - mode
-  - request
-translation_of: Web/API/Request/mode
 ---
 {{APIRef("Fetch")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/request/redirect/index.md
+++ b/files/ja/web/api/request/redirect/index.md
@@ -1,15 +1,6 @@
 ---
 title: Request.redirect
 slug: Web/API/Request/redirect
-tags:
-  - API
-  - Experimental
-  - Fetch
-  - Property
-  - Redirect
-  - Reference
-  - request
-translation_of: Web/API/Request/redirect
 ---
 {{APIRef("Fetch")}}
 

--- a/files/ja/web/api/request/referrer/index.md
+++ b/files/ja/web/api/request/referrer/index.md
@@ -1,15 +1,6 @@
 ---
 title: Request.referrer
 slug: Web/API/Request/referrer
-tags:
-  - API
-  - Experimental
-  - Fetch
-  - Property
-  - Reference
-  - referrer
-  - request
-translation_of: Web/API/Request/referrer
 ---
 {{APIRef("Fetch")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/request/request/index.md
+++ b/files/ja/web/api/request/request/index.md
@@ -1,14 +1,6 @@
 ---
 title: Request()
 slug: Web/API/Request/Request
-tags:
-  - API
-  - Experimental
-  - Fetch
-  - request
-  - コンストラクター
-  - リファレンス
-translation_of: Web/API/Request/Request
 ---
 {{APIRef("Fetch")}}
 

--- a/files/ja/web/api/request/url/index.md
+++ b/files/ja/web/api/request/url/index.md
@@ -1,15 +1,6 @@
 ---
 title: Request.url
 slug: Web/API/Request/url
-tags:
-  - API
-  - Experimental
-  - Fetch
-  - Property
-  - Reference
-  - URL
-  - request
-translation_of: Web/API/Request/url
 ---
 {{APIRef("Fetch")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/resizeobserver/disconnect/index.md
+++ b/files/ja/web/api/resizeobserver/disconnect/index.md
@@ -1,17 +1,6 @@
 ---
 title: ResizeObserver.disconnect()
 slug: Web/API/ResizeObserver/disconnect
-page-type: web-api-instance-method
-tags:
-  - API
-  - メソッド
-  - リファレンス
-  - リサイズオブザーバー API
-  - ResizeObserver
-  - disconnect()
-  - observers
-browser-compat: api.ResizeObserver.disconnect
-translation_of: Web/API/ResizeObserver/disconnect
 ---
 {{APIRef("Resize Observer API")}}
 

--- a/files/ja/web/api/resizeobserver/index.md
+++ b/files/ja/web/api/resizeobserver/index.md
@@ -1,19 +1,6 @@
 ---
 title: ResizeObserver
 slug: Web/API/ResizeObserver
-page-type: web-api-interface
-tags:
-  - API
-  - バウンディングボックス
-  - Experimental
-  - インターフェイス
-  - リファレンス
-  - リサイズオブザーバー API
-  - ResizeObserver
-  - コンテンツボックス
-  - observers
-browser-compat: api.ResizeObserver
-translation_of: Web/API/ResizeObserver
 ---
 {{APIRef("Resize Observer API")}}
 

--- a/files/ja/web/api/resizeobserver/observe/index.md
+++ b/files/ja/web/api/resizeobserver/observe/index.md
@@ -1,17 +1,6 @@
 ---
 title: ResizeObserver.observe()
 slug: Web/API/ResizeObserver/observe
-page-type: web-api-instance-method
-tags:
-  - API
-  - メソッド
-  - リファレンス
-  - リサイズオブザーバー API
-  - ResizeObserver
-  - observe()
-  - observers
-browser-compat: api.ResizeObserver.observe
-translation_of: Web/API/ResizeObserver/observe
 ---
 {{APIRef("Resize Observer API")}}
 

--- a/files/ja/web/api/resizeobserver/resizeobserver/index.md
+++ b/files/ja/web/api/resizeobserver/resizeobserver/index.md
@@ -1,16 +1,6 @@
 ---
 title: ResizeObserver()
 slug: Web/API/ResizeObserver/ResizeObserver
-page-type: web-api-constructor
-tags:
-  - API
-  - コンストラクター
-  - リファレンス
-  - リサイズオブザーバー API
-  - ResizeObserver
-  - オブザーバー
-browser-compat: api.ResizeObserver.ResizeObserver
-translation_of: Web/API/ResizeObserver/ResizeObserver
 ---
 {{APIRef("Resize Observer API")}}
 

--- a/files/ja/web/api/resizeobserver/unobserve/index.md
+++ b/files/ja/web/api/resizeobserver/unobserve/index.md
@@ -1,17 +1,6 @@
 ---
 title: ResizeObserver.unobserve()
 slug: Web/API/ResizeObserver/unobserve
-page-type: web-api-instance-method
-tags:
-  - API
-  - メソッド
-  - リファレンス
-  - リサイズオブザーバー API
-  - ResizeObserver
-  - observers
-  - unobserve()
-browser-compat: api.ResizeObserver.unobserve
-translation_of: Web/API/ResizeObserver/unobserve
 ---
 {{APIRef("Resize Observer API")}}
 

--- a/files/ja/web/api/resizeobserverentry/borderboxsize/index.md
+++ b/files/ja/web/api/resizeobserverentry/borderboxsize/index.md
@@ -1,16 +1,6 @@
 ---
 title: ResizeObserverEntry.borderBoxSize
 slug: Web/API/ResizeObserverEntry/borderBoxSize
-page-type: web-api-instance-property
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - リサイズオブザーバー API
-  - ResizeObserverEntry
-  - borderBoxSize
-browser-compat: api.ResizeObserverEntry.borderBoxSize
-translation_of: Web/API/ResizeObserverEntry/borderBoxSize
 ---
 {{APIRef("Resize Observer API")}}
 

--- a/files/ja/web/api/resizeobserverentry/contentboxsize/index.md
+++ b/files/ja/web/api/resizeobserverentry/contentboxsize/index.md
@@ -1,16 +1,6 @@
 ---
 title: ResizeObserverEntry.contentBoxSize
 slug: Web/API/ResizeObserverEntry/contentBoxSize
-page-type: web-api-instance-property
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - リサイズオブザーバー API
-  - ResizeObserverEntry
-  - contentBoxSize
-browser-compat: api.ResizeObserverEntry.contentBoxSize
-translation_of: Web/API/ResizeObserverEntry/contentBoxSize
 ---
 {{APIRef("Resize Observer API")}}
 

--- a/files/ja/web/api/resizeobserverentry/contentrect/index.md
+++ b/files/ja/web/api/resizeobserverentry/contentrect/index.md
@@ -1,19 +1,6 @@
 ---
 title: ResizeObserverEntry.contentRect
 slug: Web/API/ResizeObserverEntry/contentRect
-page-type: web-api-instance-property
-tags:
-  - API
-  - バウンディングボックス
-  - プロパティ
-  - リファレンス
-  - リサイズオブザーバー API
-  - ResizeObserver
-  - ResizeObserverEntry
-  - コンテンツボックス
-  - observers
-browser-compat: api.ResizeObserverEntry.contentRect
-translation_of: Web/API/ResizeObserverEntry/contentRect
 ---
 {{APIRef("Resize Observer API")}}
 

--- a/files/ja/web/api/resizeobserverentry/devicepixelcontentboxsize/index.md
+++ b/files/ja/web/api/resizeobserverentry/devicepixelcontentboxsize/index.md
@@ -1,16 +1,6 @@
 ---
 title: ResizeObserverEntry.devicePixelContentBoxSize
 slug: Web/API/ResizeObserverEntry/devicePixelContentBoxSize
-page-type: web-api-instance-property
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - リサイズオブザーバー API
-  - ResizeObserverEntry
-  - devicePixelContentBoxSize
-browser-compat: api.ResizeObserverEntry.devicePixelContentBoxSize
-translation_of: Web/API/ResizeObserverEntry/devicePixelContentBoxSize
 ---
 {{APIRef("Resize Observer API")}}
 

--- a/files/ja/web/api/resizeobserverentry/index.md
+++ b/files/ja/web/api/resizeobserverentry/index.md
@@ -1,19 +1,6 @@
 ---
 title: ResizeObserverEntry
 slug: Web/API/ResizeObserverEntry
-page-type: web-api-interface
-tags:
-  - API
-  - バウンディングボックス
-  - インターフェイス
-  - リファレンス
-  - リサイズオブザーバー API
-  - ResizeObserver
-  - ResizeObserverEntry
-  - コンテンツボックス
-  - オブザーバー
-browser-compat: api.ResizeObserverEntry
-translation_of: Web/API/ResizeObserverEntry
 ---
 {{APIRef("Resize Observer API")}}
 

--- a/files/ja/web/api/resizeobserverentry/target/index.md
+++ b/files/ja/web/api/resizeobserverentry/target/index.md
@@ -1,20 +1,6 @@
 ---
 title: ResizeObserverEntry.target
 slug: Web/API/ResizeObserverEntry/target
-page-type: web-api-instance-property
-tags:
-  - API
-  - バウンディングボックス
-  - プロパティ
-  - リファレンス
-  - リサイズオブザーバー API
-  - ResizeObserver
-  - ResizeObserverEntry
-  - コンテンツボックス
-  - observers
-  - target
-browser-compat: api.ResizeObserverEntry.target
-translation_of: Web/API/ResizeObserverEntry/target
 ---
 {{APIRef("Resize Observer API")}}
 

--- a/files/ja/web/api/resource_timing_api/index.md
+++ b/files/ja/web/api/resource_timing_api/index.md
@@ -1,7 +1,6 @@
 ---
 title: Resource Timing API
 slug: Web/API/Resource_Timing_API
-translation_of: Web/API/Resource_Timing_API
 ---
 {{DefaultAPISidebar("Resource Timing API")}}
 

--- a/files/ja/web/api/resource_timing_api/using_the_resource_timing_api/index.md
+++ b/files/ja/web/api/resource_timing_api/using_the_resource_timing_api/index.md
@@ -1,16 +1,6 @@
 ---
 title: Using the Resource Timing API
 slug: Web/API/Resource_Timing_API/Using_the_Resource_Timing_API
-tags:
-  - API
-  - Web
-  - Web パフォーマンス
-  - Web 開発
-  - タイミング
-  - パフォーマンス
-  - リソースタイミング
-  - リソースタイミング API
-translation_of: Web/API/Resource_Timing_API/Using_the_Resource_Timing_API
 ---
 {{DefaultAPISidebar("Resource Timing API")}}
 

--- a/files/ja/web/api/response/arraybuffer/index.md
+++ b/files/ja/web/api/response/arraybuffer/index.md
@@ -1,16 +1,7 @@
 ---
 title: Response.arrayBuffer()
 slug: Web/API/Response/arrayBuffer
-tags:
-  - API
-  - ArrayBuffer
-  - Fetch
-  - Method
-  - Reference
-  - Response
-translation_of: Web/API/Response/arrayBuffer
 original_slug: Web/API/Body/arrayBuffer
-browser-compat: api.Response.arrayBuffer
 ---
 {{APIRef("Fetch")}}
 

--- a/files/ja/web/api/response/blob/index.md
+++ b/files/ja/web/api/response/blob/index.md
@@ -1,16 +1,7 @@
 ---
 title: Response.blob()
 slug: Web/API/Response/blob
-tags:
-  - API
-  - Blob
-  - Fetch
-  - Method
-  - Reference
-  - Response
-translation_of: Web/API/Response/blob
 original_slug: Web/API/Body/blob
-browser-compat: api.Response.blob
 ---
 {{APIRef("Fetch")}}
 

--- a/files/ja/web/api/response/body/index.md
+++ b/files/ja/web/api/response/body/index.md
@@ -1,16 +1,7 @@
 ---
 title: Response.body
 slug: Web/API/Response/body
-tags:
-  - API
-  - Fetch
-  - Property
-  - Reference
-  - Streams
-  - Response
-translation_of: Web/API/Response/body
 original_slug: Web/API/Body/body
-browser-compat: api.Response.body
 ---
 {{APIRef("Fetch")}}
 

--- a/files/ja/web/api/response/bodyused/index.md
+++ b/files/ja/web/api/response/bodyused/index.md
@@ -1,16 +1,7 @@
 ---
 title: Response.bodyUsed
 slug: Web/API/Response/bodyUsed
-tags:
-  - API
-  - Fetch
-  - Property
-  - Reference
-  - bodyUsed
-  - Response
-translation_of: Web/API/Response/bodyUsed
 original_slug: Web/API/Body/bodyUsed
-browser-compat: api.Response.bodyUsed
 ---
 {{APIRef("Fetch")}}
 

--- a/files/ja/web/api/response/error/index.md
+++ b/files/ja/web/api/response/error/index.md
@@ -1,7 +1,6 @@
 ---
 title: Response.error()
 slug: Web/API/Response/error
-translation_of: Web/API/Response/error
 ---
 {{APIRef("Fetch")}}
 

--- a/files/ja/web/api/response/formdata/index.md
+++ b/files/ja/web/api/response/formdata/index.md
@@ -1,18 +1,7 @@
 ---
 title: Response.formData()
 slug: Web/API/Response/formData
-tags:
-  - API
-  - Fetch
-  - Fetch API
-  - FormData
-  - Method
-  - NeedsExample
-  - Reference
-  - Response
-translation_of: Web/API/Response/formData
 original_slug: Web/API/Body/formData
-browser-compat: api.Response.formData
 ---
 {{APIRef("Fetch")}}
 

--- a/files/ja/web/api/response/headers/index.md
+++ b/files/ja/web/api/response/headers/index.md
@@ -1,15 +1,6 @@
 ---
 title: Response.headers
 slug: Web/API/Response/headers
-tags:
-  - API
-  - Experimental
-  - Fetch
-  - Headers
-  - Property
-  - Reference
-  - Response
-translation_of: Web/API/Response/headers
 ---
 {{APIRef("Fetch")}}
 

--- a/files/ja/web/api/response/index.md
+++ b/files/ja/web/api/response/index.md
@@ -1,16 +1,6 @@
 ---
 title: Response
 slug: Web/API/Response
-tags:
-  - API
-  - Experimental
-  - Fetch
-  - Fetch API
-  - Interface
-  - Reference
-  - Response
-translation_of: Web/API/Response
-browser-compat: api.Response
 ---
 {{APIRef("Fetch API")}}
 

--- a/files/ja/web/api/response/json/index.md
+++ b/files/ja/web/api/response/json/index.md
@@ -1,17 +1,7 @@
 ---
 title: Response.json()
 slug: Web/API/Response/json
-tags:
-  - API
-  - Fetch
-  - JSON
-  - Method
-  - Reference
-  - メソッド
-  - Response
-translation_of: Web/API/Response/json
 original_slug: Web/API/Body/json
-browser-compat: api.Response.json
 ---
 {{APIRef("Fetch API")}}
 

--- a/files/ja/web/api/response/redirect/index.md
+++ b/files/ja/web/api/response/redirect/index.md
@@ -1,7 +1,6 @@
 ---
 title: Response.redirect()
 slug: Web/API/Response/redirect
-translation_of: Web/API/Response/redirect
 ---
 {{APIRef("Fetch")}}
 

--- a/files/ja/web/api/response/response/index.md
+++ b/files/ja/web/api/response/response/index.md
@@ -1,7 +1,6 @@
 ---
 title: Response()
 slug: Web/API/Response/Response
-translation_of: Web/API/Response/Response
 ---
 {{APIRef("Fetch")}}
 

--- a/files/ja/web/api/response/text/index.md
+++ b/files/ja/web/api/response/text/index.md
@@ -1,16 +1,7 @@
 ---
 title: Response.text()
 slug: Web/API/Response/text
-tags:
-  - API
-  - Fetch
-  - Method
-  - Reference
-  - Text
-  - Response
-translation_of: Web/API/Response/text
 original_slug: Web/API/Body/text
-browser-compat: api.Response.text
 ---
 {{APIRef("Fetch")}}
 

--- a/files/ja/web/api/rtcdatachannel/index.md
+++ b/files/ja/web/api/rtcdatachannel/index.md
@@ -1,18 +1,6 @@
 ---
 title: RTCDataChannel
 slug: Web/API/RTCDataChannel
-tags:
-  - API
-  - Communication
-  - Data Transfer
-  - Interface
-  - Media
-  - Networking
-  - RTCDataChannel
-  - Reference
-  - WebRTC
-  - WebRTC API
-translation_of: Web/API/RTCDataChannel
 ---
 {{APIRef("WebRTC")}}
 

--- a/files/ja/web/api/rtcdatachannelevent/index.md
+++ b/files/ja/web/api/rtcdatachannelevent/index.md
@@ -1,7 +1,6 @@
 ---
 title: RTCDataChannelEvent
 slug: Web/API/RTCDataChannelEvent
-translation_of: Web/API/RTCDataChannelEvent
 ---
 {{APIRef("WebRTC")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/rtcpeerconnection/cantrickleicecandidates/index.md
+++ b/files/ja/web/api/rtcpeerconnection/cantrickleicecandidates/index.md
@@ -1,21 +1,6 @@
 ---
 title: RTCPeerConnection.canTrickleIceCandidates
 slug: Web/API/RTCPeerConnection/canTrickleIceCandidates
-page-type: web-api-instance-property
-tags:
-  - API
-  - ICE
-  - Media
-  - Property
-  - RTCPeerConnection
-  - Reference
-  - Trickle
-  - Trickling
-  - WebRTC
-  - WebRTC API
-  - canTrickleIceCandidates
-browser-compat: api.RTCPeerConnection.canTrickleIceCandidates
-translation_of: Web/API/RTCPeerConnection/canTrickleIceCandidates
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/ja/web/api/rtcpeerconnection/index.md
+++ b/files/ja/web/api/rtcpeerconnection/index.md
@@ -1,23 +1,6 @@
 ---
 title: RTCPeerConnection
 slug: Web/API/RTCPeerConnection
-page-type: web-api-interface
-tags:
-  - API
-  - Audio
-  - Communication
-  - Interface
-  - Media
-  - NeedsUpdate
-  - Networking
-  - RTCPeerConnection
-  - Reference
-  - Telecom
-  - Video
-  - WebRTC
-  - WebRTC API
-browser-compat: api.RTCPeerConnection
-translation_of: Web/API/RTCPeerConnection
 ---
 {{APIRef('WebRTC')}}
 

--- a/files/ja/web/api/rtcpeerconnection/rtcpeerconnection/index.md
+++ b/files/ja/web/api/rtcpeerconnection/rtcpeerconnection/index.md
@@ -1,15 +1,6 @@
 ---
 title: RTCPeerConnection()
 slug: Web/API/RTCPeerConnection/RTCPeerConnection
-page-type: web-api-constructor
-tags:
-  - API
-  - Constructor
-  - RTCPeerConnection
-  - Reference
-  - WebRTC
-browser-compat: api.RTCPeerConnection.RTCPeerConnection
-translation_of: Web/API/RTCPeerConnection/RTCPeerConnection
 original_slug: Web/API/RTCConfiguration
 ---
 {{APIRef("WebRTC")}}

--- a/files/ja/web/api/rtcpeerconnectioniceevent/index.md
+++ b/files/ja/web/api/rtcpeerconnectioniceevent/index.md
@@ -1,7 +1,6 @@
 ---
 title: RTCPeerConnectionIceEvent
 slug: Web/API/RTCPeerConnectionIceEvent
-translation_of: Web/API/RTCPeerConnectionIceEvent
 ---
 {{APIRef("WebRTC")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/rtcsessiondescription/index.md
+++ b/files/ja/web/api/rtcsessiondescription/index.md
@@ -1,18 +1,6 @@
 ---
 title: RTCSessionDescription
 slug: Web/API/RTCSessionDescription
-tags:
-  - API
-  - Audio
-  - Experimental
-  - Interface
-  - Media
-  - RTCSessionDescription
-  - Reference
-  - Video
-  - Web
-  - WebRTC
-translation_of: Web/API/RTCSessionDescription
 ---
 {{APIRef("WebRTC")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/screen/availheight/index.md
+++ b/files/ja/web/api/screen/availheight/index.md
@@ -1,16 +1,6 @@
 ---
 title: Screen.availHeight
 slug: Web/API/Screen/availHeight
-page-type: web-api-instance-property
-tags:
-  - API
-  - CSSOM View
-  - Property
-  - Reference
-  - Screen size
-  - availHeight
-browser-compat: api.Screen.availHeight
-translation_of: Web/API/Screen/availHeight
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/screen/availleft/index.md
+++ b/files/ja/web/api/screen/availleft/index.md
@@ -1,16 +1,6 @@
 ---
 title: Screen.availLeft
 slug: Web/API/Screen/availLeft
-page-type: web-api-instance-property
-tags:
-  - API
-  - API:Mozilla Extensions
-  - API:WebKit Extensions
-  - DOM
-  - Non-standard
-  - Property
-browser-compat: api.Screen.availLeft
-translation_of: Web/API/Screen/availLeft
 ---
 {{APIRef("CSSOM")}}{{Non-standard_Header}}
 

--- a/files/ja/web/api/screen/availtop/index.md
+++ b/files/ja/web/api/screen/availtop/index.md
@@ -1,16 +1,6 @@
 ---
 title: Screen.availTop
 slug: Web/API/Screen/availTop
-page-type: web-api-instance-property
-tags:
-  - API
-  - API:Mozilla Extensions
-  - API:WebKit Extensions
-  - DOM
-  - Non-standard
-  - Property
-browser-compat: api.Screen.availTop
-translation_of: Web/API/Screen/availTop
 ---
 {{APIRef("CSSOM")}}{{Non-standard_Header}}
 

--- a/files/ja/web/api/screen/availwidth/index.md
+++ b/files/ja/web/api/screen/availwidth/index.md
@@ -1,14 +1,6 @@
 ---
 title: Screen.availWidth
 slug: Web/API/Screen/availWidth
-page-type: web-api-instance-property
-tags:
-  - API
-  - CSSOM View
-  - Property
-  - Reference
-browser-compat: api.Screen.availWidth
-translation_of: Web/API/Screen/availWidth
 ---
 {{APIRef("CSSOM View")}}
 

--- a/files/ja/web/api/screen/colordepth/index.md
+++ b/files/ja/web/api/screen/colordepth/index.md
@@ -1,14 +1,6 @@
 ---
 title: Screen.colorDepth
 slug: Web/API/Screen/colorDepth
-page-type: web-api-instance-property
-tags:
-  - API
-  - CSSOM View
-  - Property
-  - Reference
-browser-compat: api.Screen.colorDepth
-translation_of: Web/API/Screen/colorDepth
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/screen/height/index.md
+++ b/files/ja/web/api/screen/height/index.md
@@ -1,16 +1,6 @@
 ---
 title: Screen.height
 slug: Web/API/Screen/height
-page-type: web-api-instance-property
-tags:
-  - API
-  - CSSOM View
-  - NeedsMarkupWork
-  - NeedsMobileBrowserCompatibility
-  - Property
-  - Reference
-browser-compat: api.Screen.height
-translation_of: Web/API/Screen/height
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/screen/index.md
+++ b/files/ja/web/api/screen/index.md
@@ -1,14 +1,6 @@
 ---
 title: Screen
 slug: Web/API/Screen
-page-type: web-api-interface
-tags:
-  - API
-  - CSSOM View
-  - Interface
-  - Reference
-browser-compat: api.Screen
-translation_of: Web/API/Screen
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/screen/left/index.md
+++ b/files/ja/web/api/screen/left/index.md
@@ -1,17 +1,6 @@
 ---
 title: Screen.left
 slug: Web/API/Screen/left
-page-type: web-api-instance-property
-tags:
-  - API
-  - API:Microsoft Extensions
-  - API:Mozilla Extensions
-  - API:WebKit Extensions
-  - DOM
-  - Non-standard
-  - Property
-browser-compat: api.Screen.left
-translation_of: Web/API/Screen/left
 ---
 {{APIRef("CSSOM")}}{{Non-standard_Header}}
 

--- a/files/ja/web/api/screen/lockorientation/index.md
+++ b/files/ja/web/api/screen/lockorientation/index.md
@@ -1,17 +1,6 @@
 ---
 title: Screen.lockOrientation()
 slug: Web/API/Screen/lockOrientation
-page-type: web-api-instance-method
-tags:
-  - API
-  - CSSOM View
-  - Deprecated
-  - Method
-  - NeedsUpdate
-  - Screen Orientation
-  - screen
-browser-compat: api.Screen.lockOrientation
-translation_of: Web/API/Screen/lockOrientation
 ---
 {{APIRef("Screen Orientation API")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/screen/mozbrightness/index.md
+++ b/files/ja/web/api/screen/mozbrightness/index.md
@@ -1,15 +1,6 @@
 ---
 title: Screen.mozBrightness
 slug: Web/API/Screen/mozBrightness
-page-type: web-api-instance-property
-tags:
-  - API
-  - API:Mozilla Extensions
-  - Deprecated
-  - Non-standard
-  - Property
-browser-compat: api.Screen.mozBrightness
-translation_of: Web/API/Screen/mozBrightness
 ---
 {{APIRef("CSSOM")}}{{Deprecated_Header}}{{Non-standard_Header}}
 

--- a/files/ja/web/api/screen/mozenabled/index.md
+++ b/files/ja/web/api/screen/mozenabled/index.md
@@ -1,17 +1,6 @@
 ---
 title: Screen.mozEnabled
 slug: Web/API/Screen/mozEnabled
-page-type: web-api-instance-property
-tags:
-  - API
-  - API:Mozilla Extensions
-  - DOM
-  - Deprecated
-  - Non-standard
-  - Property
-  - Reference
-browser-compat: api.Screen.mozEnabled
-translation_of: Web/API/Screen/mozEnabled
 ---
 {{APIRef("CSSOM")}}{{Deprecated_Header}}{{Non-standard_Header}}
 

--- a/files/ja/web/api/screen/orientation/index.md
+++ b/files/ja/web/api/screen/orientation/index.md
@@ -1,17 +1,6 @@
 ---
 title: Screen.orientation
 slug: Web/API/Screen/orientation
-page-type: web-api-instance-property
-tags:
-  - API
-  - CSSOM View
-  - Experimental
-  - Property
-  - Read-only
-  - Screen Orientation
-  - screen
-browser-compat: api.Screen.orientation
-translation_of: Web/API/Screen/orientation
 ---
 {{APIRef("Screen Orientation API")}}
 

--- a/files/ja/web/api/screen/orientationchange_event/index.md
+++ b/files/ja/web/api/screen/orientationchange_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Screen: orientationchange イベント'
 slug: Web/API/Screen/orientationchange_event
-page-type: web-api-event
-tags:
-  - API
-  - CSSOM View
-  - Deprecated
-  - Event Handler
-  - Property
-  - Screen Orientation
-browser-compat: api.Screen.orientationchange_event
-translation_of: Web/API/Screen/orientationchange_event
 original_slug: Web/API/Screen/onorientationchange
 ---
 {{APIRef("Screen Orientation API")}}{{Deprecated_Header}}

--- a/files/ja/web/api/screen/pixeldepth/index.md
+++ b/files/ja/web/api/screen/pixeldepth/index.md
@@ -1,15 +1,6 @@
 ---
 title: Screen.pixelDepth
 slug: Web/API/Screen/pixelDepth
-page-type: web-api-instance-property
-tags:
-  - API
-  - CSSOM View
-  - NeedsMarkupWork
-  - Property
-  - Reference
-browser-compat: api.Screen.pixelDepth
-translation_of: Web/API/Screen/pixelDepth
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/screen/top/index.md
+++ b/files/ja/web/api/screen/top/index.md
@@ -1,18 +1,6 @@
 ---
 title: Screen.top
 slug: Web/API/Screen/top
-page-type: web-api-instance-property
-tags:
-  - API
-  - API:Microsoft Extensions
-  - API:Mozilla Extensions
-  - API:WebKit Extensions
-  - DOM
-  - Non-standard
-  - Property
-  - Window
-browser-compat: api.Screen.top
-translation_of: Web/API/Screen/top
 ---
 {{APIRef("CSSOM")}}{{deprecated_header}}{{Non-standard_Header}}
 

--- a/files/ja/web/api/screen/unlockorientation/index.md
+++ b/files/ja/web/api/screen/unlockorientation/index.md
@@ -1,16 +1,6 @@
 ---
 title: Screen.unlockOrientation()
 slug: Web/API/Screen/unlockOrientation
-page-type: web-api-instance-method
-tags:
-  - API
-  - CSSOM View
-  - Deprecated
-  - Method
-  - NeedsMarkupWork
-  - Screen Orientation
-browser-compat: api.Screen.unlockOrientation
-translation_of: Web/API/Screen/unlockOrientation
 ---
 {{APIRef("Screen Orientation API")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/screen/width/index.md
+++ b/files/ja/web/api/screen/width/index.md
@@ -1,14 +1,6 @@
 ---
 title: Screen.width
 slug: Web/API/Screen/width
-page-type: web-api-instance-property
-tags:
-  - API
-  - CSSOM View
-  - Property
-  - Reference
-browser-compat: api.Screen.width
-translation_of: Web/API/Screen/width
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/screen_capture_api/index.md
+++ b/files/ja/web/api/screen_capture_api/index.md
@@ -1,17 +1,6 @@
 ---
 title: 画面キャプチャ API
 slug: Web/API/Screen_Capture_API
-tags:
-  - API
-  - MediaDevices
-  - MediaStream
-  - 概要
-  - リファレンス
-  - 画面キャプチャ
-  - 画面キャプチャ API
-  - 画面共有
-  - getDisplayMedia
-translation_of: Web/API/Screen_Capture_API
 ---
 {{DefaultAPISidebar("Screen Capture API")}}
 

--- a/files/ja/web/api/screen_capture_api/using_screen_capture/index.md
+++ b/files/ja/web/api/screen_capture_api/using_screen_capture/index.md
@@ -1,20 +1,6 @@
 ---
 title: 画面キャプチャ API の使用
 slug: Web/API/Screen_Capture_API/Using_Screen_Capture
-tags:
-  - API
-  - キャプチャ
-  - 会議
-  - ガイド
-  - メディア
-  - 画面キャプチャ
-  - 画面キャプチャ API
-  - 共有
-  - 動画
-  - WebRTC
-  - display
-  - getDisplayMedia
-  - screen
 ---
 {{DefaultAPISidebar("Screen Capture API")}}
 

--- a/files/ja/web/api/screen_wake_lock_api/index.md
+++ b/files/ja/web/api/screen_wake_lock_api/index.md
@@ -1,14 +1,6 @@
 ---
 title: 画面起動ロック API
 slug: Web/API/Screen_Wake_Lock_API
-tags:
-  - API
-  - 概要
-  - リファレンス
-  - 画面起動ロック API
-  - Wake Lock
-  - WakeLock
-  - screen
 ---
 {{DefaultAPISidebar("Screen Wake Lock API")}}
 

--- a/files/ja/web/api/scriptprocessornode/index.md
+++ b/files/ja/web/api/scriptprocessornode/index.md
@@ -1,16 +1,6 @@
 ---
 title: ScriptProcessorNode
 slug: Web/API/ScriptProcessorNode
-page-type: web-api-interface
-tags:
-  - API
-  - Deprecated
-  - Interface
-  - Reference
-  - ScriptProcessorNode
-  - Web Audio API
-browser-compat: api.ScriptProcessorNode
-translation_of: Web/API/ScriptProcessorNode
 ---
 {{APIRef("Web Audio API")}}{{deprecated_header}}
 

--- a/files/ja/web/api/selection/collapsetostart/index.md
+++ b/files/ja/web/api/selection/collapsetostart/index.md
@@ -1,11 +1,6 @@
 ---
 title: collapseToStart
 slug: Web/API/Selection/collapseToStart
-tags:
-  - DOM
-  - Gecko DOM Reference
-  - Selection
-translation_of: Web/API/Selection/collapseToStart
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/selection/index.md
+++ b/files/ja/web/api/selection/index.md
@@ -1,14 +1,6 @@
 ---
 title: Selection
 slug: Web/API/Selection
-page-type: web-api-interface
-tags:
-  - API
-  - Interface
-  - Reference
-  - Selection
-browser-compat: api.Selection
-translation_of: Web/API/Selection
 ---
 {{ ApiRef("Selection API") }}
 

--- a/files/ja/web/api/server-sent_events/index.md
+++ b/files/ja/web/api/server-sent_events/index.md
@@ -1,14 +1,6 @@
 ---
 title: サーバー送信イベント
 slug: Web/API/Server-sent_events
-page-type: web-api-overview
-tags:
-  - API
-  - Overview
-  - SSE
-  - Server-sent events
-spec-urls: https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events
-translation_of: Web/API/Server-sent_events
 ---
 {{DefaultAPISidebar("Server Sent Events")}}
 

--- a/files/ja/web/api/server-sent_events/using_server-sent_events/index.md
+++ b/files/ja/web/api/server-sent_events/using_server-sent_events/index.md
@@ -1,18 +1,6 @@
 ---
 title: サーバー送信イベントの使用
 slug: Web/API/Server-sent_events/Using_server-sent_events
-page-type: guide
-tags:
-  - Advanced
-  - Communication
-  - DOM
-  - Guide
-  - SSE
-  - Server Sent Events
-  - Server-sent events
-  - messaging
-browser-compat: api.EventSource
-translation_of: Web/API/Server-sent_events/Using_server-sent_events
 ---
 {{DefaultAPISidebar("Server Sent Events")}}
 

--- a/files/ja/web/api/service_worker_api/index.md
+++ b/files/ja/web/api/service_worker_api/index.md
@@ -1,15 +1,6 @@
 ---
 title: サービスワーカー API
 slug: Web/API/Service_Worker_API
-tags:
-  - API
-  - ランディング
-  - オフライン
-  - 概要
-  - リファレンス
-  - サービスワーカー
-  - ワーカー
-translation_of: Web/API/Service_Worker_API
 ---
 {{ServiceWorkerSidebar}}
 

--- a/files/ja/web/api/service_worker_api/using_service_workers/index.md
+++ b/files/ja/web/api/service_worker_api/using_service_workers/index.md
@@ -1,13 +1,6 @@
 ---
 title: サービスワーカーの使用
 slug: Web/API/Service_Worker_API/Using_Service_Workers
-tags:
-  - ガイド
-  - サービス
-  - ServiceWorker
-  - ワーカー
-  - basics
-translation_of: Web/API/Service_Worker_API/Using_Service_Workers
 ---
 {{ServiceWorkerSidebar}}
 

--- a/files/ja/web/api/serviceworker/index.md
+++ b/files/ja/web/api/serviceworker/index.md
@@ -1,15 +1,6 @@
 ---
 title: ServiceWorker
 slug: Web/API/ServiceWorker
-tags:
-  - API
-  - Draft
-  - Interface
-  - Offline
-  - Service Workers
-  - ServiceWorker
-  - Workers
-translation_of: Web/API/ServiceWorker
 ---
 {{SeeCompatTable}}{{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworker/state/index.md
+++ b/files/ja/web/api/serviceworker/state/index.md
@@ -1,15 +1,6 @@
 ---
 title: ServiceWorker.state
 slug: Web/API/ServiceWorker/state
-tags:
-  - API
-  - Property
-  - Reference
-  - Référence(2)
-  - Service Workers
-  - ServiceWorker
-  - state
-translation_of: Web/API/ServiceWorker/state
 ---
 {{SeeCompatTable}}{{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkercontainer/controller/index.md
+++ b/files/ja/web/api/serviceworkercontainer/controller/index.md
@@ -1,16 +1,6 @@
 ---
 title: ServiceWorkerContainer.controller
 slug: Web/API/ServiceWorkerContainer/controller
-tags:
-  - API
-  - Controller
-  - Property
-  - Reference
-  - Service Workers
-  - Service worker API
-  - ServiceWorker
-  - ServiceWorkerController
-translation_of: Web/API/ServiceWorkerContainer/controller
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkercontainer/controllerchange_event/index.md
+++ b/files/ja/web/api/serviceworkercontainer/controllerchange_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: ServiceWorkerContainer.oncontrollerchange
 slug: Web/API/ServiceWorkerContainer/controllerchange_event
-tags:
-  - API
-  - Interface
-  - Property
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - ServiceWorkerContainer
-  - onchange
-  - oncontrollerchange
-translation_of: Web/API/ServiceWorkerContainer/oncontrollerchange
 original_slug: Web/API/ServiceWorkerContainer/oncontrollerchange
 ---
 {{APIRef("Service Workers API")}}{{ SeeCompatTable() }}

--- a/files/ja/web/api/serviceworkercontainer/error_event/index.md
+++ b/files/ja/web/api/serviceworkercontainer/error_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: ServiceWorkerContainer.onerror
 slug: Web/API/ServiceWorkerContainer/error_event
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - ServiceWorkerContainer
-  - onerror
-translation_of: Web/API/ServiceWorkerContainer/onerror
 original_slug: Web/API/ServiceWorkerContainer/onerror
 ---
 {{APIRef("Service Workers API")}}{{ SeeCompatTable() }}

--- a/files/ja/web/api/serviceworkercontainer/getregistration/index.md
+++ b/files/ja/web/api/serviceworkercontainer/getregistration/index.md
@@ -1,14 +1,6 @@
 ---
 title: ServiceWorkerContainer.getRegistration()
 slug: Web/API/ServiceWorkerContainer/getRegistration
-tags:
-  - API
-  - Method
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - ServiceWorkerContainer
-translation_of: Web/API/ServiceWorkerContainer/getRegistration
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkercontainer/getregistrations/index.md
+++ b/files/ja/web/api/serviceworkercontainer/getregistrations/index.md
@@ -1,15 +1,6 @@
 ---
 title: ServiceWorkerContainer.getRegistrations()
 slug: Web/API/ServiceWorkerContainer/getRegistrations
-tags:
-  - API
-  - Method
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - ServiceWorkerContainer
-  - getRegistrations
-translation_of: Web/API/ServiceWorkerContainer/getRegistrations
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkercontainer/index.md
+++ b/files/ja/web/api/serviceworkercontainer/index.md
@@ -1,16 +1,6 @@
 ---
 title: ServiceWorkerContainer
 slug: Web/API/ServiceWorkerContainer
-tags:
-  - API
-  - Interface
-  - Offline
-  - Reference
-  - Service Workers
-  - Service worker API
-  - ServiceWorkerContainer
-  - Workers
-translation_of: Web/API/ServiceWorkerContainer
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkercontainer/message_event/index.md
+++ b/files/ja/web/api/serviceworkercontainer/message_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'ServiceWorkerContainer: message イベント'
 slug: Web/API/ServiceWorkerContainer/message_event
-tags:
-  - API
-  - Event
-  - Reference
-  - Service Workers
-  - ServiceWorkerContainer
-translation_of: Web/API/ServiceWorkerContainer/message_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/serviceworkercontainer/ready/index.md
+++ b/files/ja/web/api/serviceworkercontainer/ready/index.md
@@ -1,15 +1,6 @@
 ---
 title: ServiceWorkerContainer.ready
 slug: Web/API/ServiceWorkerContainer/ready
-tags:
-  - API
-  - Property
-  - Ready
-  - Reference
-  - Service worker API
-  - ServiceWorker
-  - ServiceWorkerContainer
-translation_of: Web/API/ServiceWorkerContainer/ready
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkercontainer/register/index.md
+++ b/files/ja/web/api/serviceworkercontainer/register/index.md
@@ -1,16 +1,6 @@
 ---
 title: ServiceWorkerContainer.register()
 slug: Web/API/ServiceWorkerContainer/register
-tags:
-  - API
-  - Method
-  - Reference
-  - Service Workers
-  - Service worker API
-  - ServiceWorker
-  - ServiceWorkerContainer
-  - register
-translation_of: Web/API/ServiceWorkerContainer/register
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkercontainer/startmessages/index.md
+++ b/files/ja/web/api/serviceworkercontainer/startmessages/index.md
@@ -1,13 +1,6 @@
 ---
 title: ServiceWorkerContainer.startMessages()
 slug: Web/API/ServiceWorkerContainer/startMessages
-tags:
-  - API
-  - Reference
-  - Service Workers
-  - ServiceWorkerContainer
-  - startMessages
-translation_of: Web/API/ServiceWorkerContainer/startMessages
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerglobalscope/activate_event/index.md
+++ b/files/ja/web/api/serviceworkerglobalscope/activate_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'ServiceWorkerGlobalScope: activate イベント'
 slug: Web/API/ServiceWorkerGlobalScope/activate_event
-tags:
-  - API
-  - Reference
-  - Service Workers
-  - ServiceWorkerGlobalScope
-  - activate
-  - events
-translation_of: Web/API/ServiceWorkerGlobalScope/activate_event
 ---
 {{DefaultAPISidebar("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerglobalscope/clients/index.md
+++ b/files/ja/web/api/serviceworkerglobalscope/clients/index.md
@@ -1,15 +1,6 @@
 ---
 title: ServiceWorkerGlobalScope.clients
 slug: Web/API/ServiceWorkerGlobalScope/clients
-tags:
-  - API
-  - Clients
-  - Property
-  - Reference
-  - Service Worker
-  - ServiceWorker
-  - ServiceWorkerGlobalScope
-translation_of: Web/API/ServiceWorkerGlobalScope/clients
 ---
 {{SeeCompatTable}}{{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerglobalscope/index.md
+++ b/files/ja/web/api/serviceworkerglobalscope/index.md
@@ -1,19 +1,6 @@
 ---
 title: ServiceWorkerGlobalScope
 slug: Web/API/ServiceWorkerGlobalScope
-tags:
-  - API
-  - Draft
-  - Interface
-  - NeedsTranslation
-  - Offline
-  - Reference
-  - Service Workers
-  - ServiceWorkerGlobalScope
-  - TopicStub
-  - Workers
-  - インターフェイス
-translation_of: Web/API/ServiceWorkerGlobalScope
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerglobalscope/install_event/index.md
+++ b/files/ja/web/api/serviceworkerglobalscope/install_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'ServiceWorkerGlobalScope: install event'
 slug: Web/API/ServiceWorkerGlobalScope/install_event
-tags:
-  - API
-  - Reference
-  - Service Worker
-  - ServiceWorkerGlobalScope
-  - events
-  - install
-translation_of: Web/API/ServiceWorkerGlobalScope/install_event
 ---
 {{DefaultAPISidebar("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerglobalscope/message_event/index.md
+++ b/files/ja/web/api/serviceworkerglobalscope/message_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'ServiceWorkerGlobalScope: message event'
 slug: Web/API/ServiceWorkerGlobalScope/message_event
-tags:
-  - Event
-  - Reference
-  - Service worker API
-  - ServiceWorkerGlobalScope
-  - message
-translation_of: Web/API/ServiceWorkerGlobalScope/message_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/serviceworkerglobalscope/notificationclick_event/index.md
+++ b/files/ja/web/api/serviceworkerglobalscope/notificationclick_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'ServiceWorkerGlobalScope: notificationclick イベント'
 slug: Web/API/ServiceWorkerGlobalScope/notificationclick_event
-tags:
-  - Event
-  - Notifications
-  - Service Worker
-  - ServiceWorkerGloablScope
-  - events
-  - notificationclick
-  - イベント
-translation_of: Web/API/ServiceWorkerGlobalScope/notificationclick_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/serviceworkerglobalscope/onactivate/index.md
+++ b/files/ja/web/api/serviceworkerglobalscope/onactivate/index.md
@@ -1,16 +1,6 @@
 ---
 title: ServiceWorkerGlobalScope.onactivate
 slug: Web/API/ServiceWorkerGlobalScope/onactivate
-tags:
-  - API
-  - Property
-  - Reference
-  - Service
-  - ServiceWorker
-  - ServiceWorkerGlovalScope
-  - Worker
-  - onactivate
-translation_of: Web/API/ServiceWorkerGlobalScope/onactivate
 ---
 {{SeeCompatTable}}{{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerglobalscope/onfetch/index.md
+++ b/files/ja/web/api/serviceworkerglobalscope/onfetch/index.md
@@ -1,15 +1,6 @@
 ---
 title: ServiceWorkerGlobalScope.onfetch
 slug: Web/API/ServiceWorkerGlobalScope/onfetch
-tags:
-  - API
-  - Property
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - ServiceWorkerGlobalScope
-  - onfetch
-translation_of: Web/API/ServiceWorkerGlobalScope/onfetch
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerglobalscope/oninstall/index.md
+++ b/files/ja/web/api/serviceworkerglobalscope/oninstall/index.md
@@ -1,15 +1,6 @@
 ---
 title: ServiceWorkerGlobalScope.oninstall
 slug: Web/API/ServiceWorkerGlobalScope/oninstall
-tags:
-  - API
-  - Property
-  - Reference
-  - Service Worker
-  - ServiceWorker
-  - ServiceWorkerGlobalScope
-  - oninstall
-translation_of: Web/API/ServiceWorkerGlobalScope/oninstall
 ---
 {{SeeCompatTable}}{{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerglobalscope/onnotificationclick/index.md
+++ b/files/ja/web/api/serviceworkerglobalscope/onnotificationclick/index.md
@@ -1,15 +1,6 @@
 ---
 title: ServiceWorkerGlobalScope.onnotificationclick
 slug: Web/API/ServiceWorkerGlobalScope/onnotificationclick
-tags:
-  - API
-  - Experimental
-  - Interface
-  - Property
-  - Reference
-  - ServiceWorkerGlobalScope
-  - onnotificationclick
-translation_of: Web/API/ServiceWorkerGlobalScope/onnotificationclick
 ---
 {{SeeCompatTable}}{{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerglobalscope/onnotificationclose/index.md
+++ b/files/ja/web/api/serviceworkerglobalscope/onnotificationclose/index.md
@@ -1,15 +1,6 @@
 ---
 title: onnotificationclose
 slug: Web/API/ServiceWorkerGlobalScope/onnotificationclose
-tags:
-  - API
-  - Experimental
-  - Interface
-  - Property
-  - Reference
-  - ServiceWorkerGlobalScope
-  - onnotificationclose
-translation_of: Web/API/ServiceWorkerGlobalScope/onnotificationclose
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerglobalscope/onpush/index.md
+++ b/files/ja/web/api/serviceworkerglobalscope/onpush/index.md
@@ -1,16 +1,6 @@
 ---
 title: ServiceWorkerGlobalScope.onpush
 slug: Web/API/ServiceWorkerGlobalScope/onpush
-tags:
-  - API
-  - Property
-  - Push
-  - Reference
-  - Service Worker
-  - ServiceWorker
-  - ServiceWorkerGlobalScope
-  - onpush
-translation_of: Web/API/ServiceWorkerGlobalScope/onpush
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerglobalscope/onpushsubscriptionchange/index.md
+++ b/files/ja/web/api/serviceworkerglobalscope/onpushsubscriptionchange/index.md
@@ -1,16 +1,6 @@
 ---
 title: ServiceWorkerGlobalScope.onpushsubscriptionchange
 slug: Web/API/ServiceWorkerGlobalScope/onpushsubscriptionchange
-tags:
-  - API
-  - NeedsExample
-  - Property
-  - Push
-  - Reference
-  - Service Worker
-  - ServiceWorkerGlobalScope
-  - onpushsubscriptionchange
-translation_of: Web/API/ServiceWorkerGlobalScope/onpushsubscriptionchange
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerglobalscope/push_event/index.md
+++ b/files/ja/web/api/serviceworkerglobalscope/push_event/index.md
@@ -1,21 +1,6 @@
 ---
 title: 'ServiceWorkerGlobalScope: push イベント'
 slug: Web/API/ServiceWorkerGlobalScope/push_event
-tags:
-  - API
-  - Event
-  - Notifications
-  - Push
-  - Push API
-  - PushEvent
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - ServiceWorkerGlobalScope
-  - events
-  - messaging
-  - イベント
-translation_of: Web/API/ServiceWorkerGlobalScope/push_event
 ---
 {{APIRef("Push API")}}
 

--- a/files/ja/web/api/serviceworkerglobalscope/pushsubscriptionchange_event/index.md
+++ b/files/ja/web/api/serviceworkerglobalscope/pushsubscriptionchange_event/index.md
@@ -1,21 +1,6 @@
 ---
 title: 'ServiceWorkerGlobalScope: pushsubscriptionchange イベント'
 slug: Web/API/ServiceWorkerGlobalScope/pushsubscriptionchange_event
-tags:
-  - API
-  - Event
-  - Push
-  - Push API
-  - PushSubscriptionChangeEvent
-  - Reference
-  - Service Workers
-  - Service Workers API
-  - ServiceWorker
-  - ServiceWorkerGlobalScope
-  - Subscription
-  - events
-  - プッシュ通知
-translation_of: Web/API/ServiceWorkerGlobalScope/pushsubscriptionchange_event
 ---
 {{APIRef("Push API")}}
 

--- a/files/ja/web/api/serviceworkerglobalscope/registration/index.md
+++ b/files/ja/web/api/serviceworkerglobalscope/registration/index.md
@@ -1,15 +1,6 @@
 ---
 title: ServiceWorkerGlobalScope.registration
 slug: Web/API/ServiceWorkerGlobalScope/registration
-tags:
-  - API
-  - Property
-  - Reference
-  - Service Worker
-  - ServiceWorker
-  - ServiceWorkerGlobalScope
-  - registration
-translation_of: Web/API/ServiceWorkerGlobalScope/registration
 ---
 {{SeeCompatTable}}{{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerglobalscope/skipwaiting/index.md
+++ b/files/ja/web/api/serviceworkerglobalscope/skipwaiting/index.md
@@ -1,13 +1,6 @@
 ---
 title: ServiceWorkerGlobalScope.skipWaiting()
 slug: Web/API/ServiceWorkerGlobalScope/skipWaiting
-tags:
-  - API
-  - Method
-  - Reference
-  - ServiceWorker
-  - skipWaiting
-translation_of: Web/API/ServiceWorkerGlobalScope/skipWaiting
 ---
 {{SeeCompatTable}}{{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerregistration/active/index.md
+++ b/files/ja/web/api/serviceworkerregistration/active/index.md
@@ -1,15 +1,6 @@
 ---
 title: ServiceWorkerRegistration.active
 slug: Web/API/ServiceWorkerRegistration/active
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - サービスワーカー
-  - ServiceWorkerRegistration
-  - active
-browser-compat: api.ServiceWorkerRegistration.active
-translation_of: Web/API/ServiceWorkerRegistration/active
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerregistration/getnotifications/index.md
+++ b/files/ja/web/api/serviceworkerregistration/getnotifications/index.md
@@ -1,18 +1,6 @@
 ---
 title: ServiceWorkerRegistration.getNotifications()
 slug: Web/API/ServiceWorkerRegistration/getNotifications
-tags:
-  - API
-  - 実験的
-  - メソッド
-  - 通知
-  - リファレンス
-  - サービスワーカー
-  - サービスワーカー API
-  - ServiceWorker
-  - ServiceWorkerRegistration
-  - getNotifications
-translation_of: Web/API/ServiceWorkerRegistration/getNotifications
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerregistration/index.md
+++ b/files/ja/web/api/serviceworkerregistration/index.md
@@ -1,16 +1,6 @@
 ---
 title: ServiceWorkerRegistration
 slug: Web/API/ServiceWorkerRegistration
-tags:
-  - API
-  - Interface
-  - Offline
-  - リファレンス
-  - サービスワーカー
-  - サービスワーカー API
-  - ServiceWorkerRegistration
-  - ワーカー
-translation_of: Web/API/ServiceWorkerRegistration
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerregistration/index/index.md
+++ b/files/ja/web/api/serviceworkerregistration/index/index.md
@@ -1,17 +1,6 @@
 ---
 title: ServiceWorkerRegistration.index
 slug: Web/API/ServiceWorkerRegistration/index
-tags:
-  - Content
-  - Content Index API
-  - Index
-  - PWA
-  - プロパティ
-  - ServiceWorker
-  - ServiceWorkerRegistration
-  - content index
-  - content indexing
-browser-compat: api.ServiceWorkerRegistration.index
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerregistration/installing/index.md
+++ b/files/ja/web/api/serviceworkerregistration/installing/index.md
@@ -1,15 +1,6 @@
 ---
 title: ServiceWorkerRegistration.installing
 slug: Web/API/ServiceWorkerRegistration/installing
-tags:
-  - API
-  - Installing
-  - プロパティ
-  - リファレンス
-  - サービスワーカー
-  - ServiceWorkerRegistration
-browser-compat: api.ServiceWorkerRegistration.installing
-translation_of: Web/API/ServiceWorkerRegistration/installing
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerregistration/navigationpreload/index.md
+++ b/files/ja/web/api/serviceworkerregistration/navigationpreload/index.md
@@ -1,14 +1,6 @@
 ---
 title: ServiceWorkerRegistration.navigationPreload
 slug: Web/API/ServiceWorkerRegistration/navigationPreload
-tags:
-  - API
-  - NavigationPreloadManager
-  - プロパティ
-  - サービスワーカー
-  - ワーカー
-browser-compat: api.ServiceWorkerRegistration.navigationPreload
-translation_of: Web/API/ServiceWorkerRegistration/navigationPreload
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerregistration/periodicsync/index.md
+++ b/files/ja/web/api/serviceworkerregistration/periodicsync/index.md
@@ -1,17 +1,6 @@
 ---
 title: ServiceWorkerRegistration.periodicSync
 slug: Web/API/ServiceWorkerRegistration/periodicSync
-tags:
-  - API
-  - 実験的
-  - PeriodicSyncManager
-  - プロパティ
-  - リファレンス
-  - サービスワーカー
-  - ServiceWorkerRegistration
-  - periodicSync
-browser-compat: api.ServiceWorkerRegistration.periodicSync
-translation_of: Web/API/ServiceWorkerRegistration/periodicSync
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerregistration/pushmanager/index.md
+++ b/files/ja/web/api/serviceworkerregistration/pushmanager/index.md
@@ -1,15 +1,6 @@
 ---
 title: ServiceWorkerRegistration.pushManager
 slug: Web/API/ServiceWorkerRegistration/pushManager
-tags:
-  - API
-  - プロパティ
-  - プッシュ
-  - PushManager
-  - リファレンス
-  - サービスワーカー
-  - ServiceWorkerRegistration
-translation_of: Web/API/ServiceWorkerRegistration/pushManager
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerregistration/scope/index.md
+++ b/files/ja/web/api/serviceworkerregistration/scope/index.md
@@ -1,15 +1,6 @@
 ---
 title: ServiceWorkerRegistration.scope
 slug: Web/API/ServiceWorkerRegistration/scope
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - サービスワーカー
-  - ServiceWorkerRegistration
-  - scope
-browser-compat: api.ServiceWorkerRegistration.scope
-translation_of: Web/API/ServiceWorkerRegistration/scope
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerregistration/shownotification/index.md
+++ b/files/ja/web/api/serviceworkerregistration/shownotification/index.md
@@ -1,18 +1,6 @@
 ---
 title: ServiceWorkerRegistration.showNotification()
 slug: Web/API/ServiceWorkerRegistration/showNotification
-tags:
-  - API
-  - 実験的
-  - メソッド
-  - NeedsExample
-  - リファレンス
-  - サービスワーカー
-  - ServiceWorker
-  - ServiceWorkerRegistration
-  - showNotification
-browser-compat: api.ServiceWorkerRegistration.showNotification
-translation_of: Web/API/ServiceWorkerRegistration/showNotification
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerregistration/sync/index.md
+++ b/files/ja/web/api/serviceworkerregistration/sync/index.md
@@ -1,16 +1,6 @@
 ---
 title: ServiceWorkerRegistration.sync
 slug: Web/API/ServiceWorkerRegistration/sync
-tags:
-  - API
-  - 実験的
-  - プロパティ
-  - リファレンス
-  - サービスワーカー
-  - ServiceWorkerRegistration
-  - Sync
-browser-compat: api.ServiceWorkerRegistration.sync
-translation_of: Web/API/ServiceWorkerRegistration/sync
 ---
 {{Non-standard_header}}{{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerregistration/unregister/index.md
+++ b/files/ja/web/api/serviceworkerregistration/unregister/index.md
@@ -1,15 +1,6 @@
 ---
 title: ServiceWorkerRegistration.unregister()
 slug: Web/API/ServiceWorkerRegistration/unregister
-tags:
-  - API
-  - メソッド
-  - リファレンス
-  - サービスワーカー
-  - ServiceWorkerRegistration
-  - unregister
-browser-compat: api.ServiceWorkerRegistration.unregister
-translation_of: Web/API/ServiceWorkerRegistration/unregister
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerregistration/update/index.md
+++ b/files/ja/web/api/serviceworkerregistration/update/index.md
@@ -1,15 +1,6 @@
 ---
 title: ServiceWorkerRegistration.update()
 slug: Web/API/ServiceWorkerRegistration/update
-tags:
-  - API
-  - メソッド
-  - リファレンス
-  - サービスワーカー
-  - ServiceWorkerRegistration
-  - Update
-browser-compat: api.ServiceWorkerRegistration.update
-translation_of: Web/API/ServiceWorkerRegistration/update
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerregistration/updatefound_event/index.md
+++ b/files/ja/web/api/serviceworkerregistration/updatefound_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'ServiceWorkerRegistration: updatefound イベント'
 slug: Web/API/ServiceWorkerRegistration/updatefound_event
-tags:
-  - API
-  - イベント
-  - リファレンス
-  - サービスワーカー
-  - ServiceWorkerRegistration
-browser-compat: api.ServiceWorkerRegistration.updatefound_event
-translation_of: Web/API/ServiceWorkerRegistration/updatefound_event
 original_slug: Web/API/ServiceWorkerRegistration/onupdatefound
 ---
 {{APIRef("Service Workers API")}}

--- a/files/ja/web/api/serviceworkerregistration/updateviacache/index.md
+++ b/files/ja/web/api/serviceworkerregistration/updateviacache/index.md
@@ -1,15 +1,6 @@
 ---
 title: ServiceWorkerRegistration.updateViaCache
 slug: Web/API/ServiceWorkerRegistration/updateViaCache
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - サービスワーカー
-  - ServiceWorkerRegistration
-  - updateViaCache
-browser-compat: api.ServiceWorkerRegistration.updateViaCache
-translation_of: Web/API/ServiceWorkerRegistration/updateViaCache
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/serviceworkerregistration/waiting/index.md
+++ b/files/ja/web/api/serviceworkerregistration/waiting/index.md
@@ -1,15 +1,6 @@
 ---
 title: ServiceWorkerRegistration.waiting
 slug: Web/API/ServiceWorkerRegistration/waiting
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - サービスワーカー
-  - ServiceWorkerRegistration
-  - waiting
-browser-compat: api.ServiceWorkerRegistration.waiting
-translation_of: Web/API/ServiceWorkerRegistration/waiting
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/setinterval/index.md
+++ b/files/ja/web/api/setinterval/index.md
@@ -1,20 +1,6 @@
 ---
 title: setInterval()
 slug: Web/API/setInterval
-tags:
-  - API
-  - Gecko
-  - HTML DOM
-  - Intervals
-  - JavaScript タイマー
-  - MakeBrowserAgnostic
-  - メソッド
-  - NeedsMarkupWork
-  - タイマー
-  - setInterval
-  - Polyfill
-browser-compat: api.setInterval
-translation_of: Web/API/setInterval
 original_slug: Web/API/WindowOrWorkerGlobalScope/setInterval
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/web/api/settimeout/index.md
+++ b/files/ja/web/api/settimeout/index.md
@@ -1,20 +1,6 @@
 ---
 title: setTimeout()
 slug: Web/API/setTimeout
-tags:
-  - API
-  - HTML DOM
-  - Intervals
-  - JavaScript タイマー
-  - MakeBrowserAgnostic
-  - メソッド
-  - NeedsMarkupWork
-  - リファレンス
-  - Timers
-  - setTimeout
-  - ポリフィル
-browser-compat: api.setTimeout
-translation_of: Web/API/WindowOrWorkerGlobalScope/setTimeout
 original_slug: Web/API/WindowOrWorkerGlobalScope/setTimeout
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/web/api/shadowroot/activeelement/index.md
+++ b/files/ja/web/api/shadowroot/activeelement/index.md
@@ -1,15 +1,6 @@
 ---
 title: ShadowRoot.activeElement
 slug: Web/API/ShadowRoot/activeElement
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - ShadowRoot
-  - ウェブコンポーネント
-  - シャドウ DOM
-browser-compat: api.ShadowRoot.activeElement
-translation_of: Web/API/ShadowRoot/activeElement
 ---
 {{APIRef("Shadow DOM")}}
 

--- a/files/ja/web/api/shadowroot/delegatesfocus/index.md
+++ b/files/ja/web/api/shadowroot/delegatesfocus/index.md
@@ -1,16 +1,6 @@
 ---
 title: ShadowRoot.delegatesFocus
 slug: Web/API/ShadowRoot/delegatesFocus
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - ShadowRoot
-  - ウェブコンポーネント
-  - delegatesFocus
-  - シャドウ DOM
-browser-compat: api.ShadowRoot.delegatesFocus
-translation_of: Web/API/ShadowRoot/delegatesFocus
 ---
 {{APIRef("Shadow DOM")}}
 

--- a/files/ja/web/api/shadowroot/fullscreenelement/index.md
+++ b/files/ja/web/api/shadowroot/fullscreenelement/index.md
@@ -1,15 +1,6 @@
 ---
 title: ShadowRoot.fullscreenElement
 slug: Web/API/ShadowRoot/fullscreenElement
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - ShadowRoot
-  - ウェブコンポーネント
-  - シャドウ DOM
-browser-compat: api.ShadowRoot.fullscreenElement
-translation_of: Web/API/ShadowRoot/fullscreenElement
 ---
 {{APIRef("Shadow DOM")}}
 

--- a/files/ja/web/api/shadowroot/getanimations/index.md
+++ b/files/ja/web/api/shadowroot/getanimations/index.md
@@ -1,22 +1,6 @@
 ---
 title: ShadowRoot.getAnimations()
 slug: Web/API/ShadowRoot/getAnimations
-tags:
-  - API
-  - Animation
-  - CSS
-  - CSS アニメーション
-  - CSS トランジション
-  - ShadowRoot
-  - メソッド
-  - リファレンス
-  - トランジション
-  - ウェブアニメーション
-  - getAnimations
-  - waapi
-  - ウェブアニメーション API
-browser-compat: api.ShadowRoot.getAnimations
-translation_of: Web/API/ShadowRoot/getAnimations
 ---
 {{APIRef("Web Animations")}}
 

--- a/files/ja/web/api/shadowroot/host/index.md
+++ b/files/ja/web/api/shadowroot/host/index.md
@@ -1,14 +1,6 @@
 ---
 title: ShadowRoot.host
 slug: Web/API/ShadowRoot/host
-tags:
-  - API
-  - Host
-  - プロパティ
-  - リファレンス
-  - ShadowRoot
-  - シャドウ DOM
-browser-compat: api.ShadowRoot.host
 ---
 {{APIRef("Shadow DOM")}}
 

--- a/files/ja/web/api/shadowroot/index.md
+++ b/files/ja/web/api/shadowroot/index.md
@@ -1,15 +1,6 @@
 ---
 title: ShadowRoot
 slug: Web/API/ShadowRoot
-tags:
-  - API
-  - Interface
-  - リファレンス
-  - ShadowRoot
-  - ウェブコンポーネント
-  - シャドウ DOM
-browser-compat: api.ShadowRoot
-translation_of: Web/API/ShadowRoot
 ---
 {{APIRef('Shadow DOM')}}
 

--- a/files/ja/web/api/shadowroot/innerhtml/index.md
+++ b/files/ja/web/api/shadowroot/innerhtml/index.md
@@ -1,15 +1,6 @@
 ---
 title: ShadowRoot.innerHTML
 slug: Web/API/ShadowRoot/innerHTML
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - ShadowRoot
-  - innerHTML
-  - シャドウ DOM
-browser-compat: api.ShadowRoot.innerHTML
-translation_of: Web/API/ShadowRoot/innerHTML
 ---
 {{APIRef("Shadow DOM")}}
 

--- a/files/ja/web/api/shadowroot/mode/index.md
+++ b/files/ja/web/api/shadowroot/mode/index.md
@@ -1,15 +1,6 @@
 ---
 title: ShadowRoot.mode
 slug: Web/API/ShadowRoot/mode
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - ShadowRoot
-  - mode
-  - シャドウ DOM
-browser-compat: api.ShadowRoot.mode
-translation_of: Web/API/ShadowRoot/mode
 ---
 {{APIRef("Shadow DOM")}}
 

--- a/files/ja/web/api/shadowroot/onslotchange/index.md
+++ b/files/ja/web/api/shadowroot/onslotchange/index.md
@@ -1,18 +1,6 @@
 ---
 title: ShadowRoot.onslotchange
 slug: Web/API/ShadowRoot/onslotchange
-tags:
-  - API
-  - イベントハンドラー
-  - 実験的
-  - ShadowRoot
-  - プロパティ
-  - リファレンス
-  - シャドウ DOM API
-  - slot
-  - slotchange
-  - onslotchange
-browser-compat: api.ShadowRoot.onslotchange
 ---
 {{ApiRef('DOM')}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/shadowroot/pictureinpictureelement/index.md
+++ b/files/ja/web/api/shadowroot/pictureinpictureelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: ShadowRoot.pictureInPictureElement
 slug: Web/API/ShadowRoot/pictureInPictureElement
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - ShadowRoot
-  - ウェブコンポーネント
-  - シャドウ DOM
-browser-compat: api.ShadowRoot.pictureInPictureElement
 ---
 {{APIRef("Shadow DOM")}}
 

--- a/files/ja/web/api/shadowroot/pointerlockelement/index.md
+++ b/files/ja/web/api/shadowroot/pointerlockelement/index.md
@@ -1,15 +1,6 @@
 ---
 title: ShadowRoot.pointerLockElement
 slug: Web/API/ShadowRoot/pointerLockElement
-tags:
-  - API
-  - DOM
-  - ShadowRoot
-  - プロパティ
-  - リファレンス
-  - マウスロック
-browser-compat: api.ShadowRoot.pointerLockElement
-translation_of: Web/API/ShadowRoot/pointerLockElement
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/shadowroot/stylesheets/index.md
+++ b/files/ja/web/api/shadowroot/stylesheets/index.md
@@ -1,13 +1,6 @@
 ---
 title: ShadowRoot.styleSheets
 slug: Web/API/ShadowRoot/styleSheets
-tags:
-  - API
-  - ShadowRoot
-  - プロパティ
-  - リファレンス
-  - スタイルシート
-browser-compat: api.ShadowRoot.styleSheets
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/sharedworker/index.md
+++ b/files/ja/web/api/sharedworker/index.md
@@ -1,7 +1,6 @@
 ---
 title: SharedWorker
 slug: Web/API/SharedWorker
-translation_of: Web/API/SharedWorker
 ---
 {{APIRef("Web Workers API")}}
 

--- a/files/ja/web/api/sharedworker/port/index.md
+++ b/files/ja/web/api/sharedworker/port/index.md
@@ -1,14 +1,6 @@
 ---
 title: SharedWorker.port
 slug: Web/API/SharedWorker/port
-tags:
-  - API
-  - Property
-  - Reference
-  - SharedWorker
-  - Web Workers
-  - port
-translation_of: Web/API/SharedWorker/port
 ---
 {{APIRef("Web Workers API")}}
 

--- a/files/ja/web/api/sharedworkerglobalscope/connect_event/index.md
+++ b/files/ja/web/api/sharedworkerglobalscope/connect_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'SharedWorkerGlobalScope: connect イベント'
 slug: Web/API/SharedWorkerGlobalScope/connect_event
-tags:
-  - API
-  - Event
-  - Reference
-  - SharedWorkerGlobalScope
-  - connect
-  - events
-  - イベント
-translation_of: Web/API/SharedWorkerGlobalScope/connect_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/sharedworkerglobalscope/index.md
+++ b/files/ja/web/api/sharedworkerglobalscope/index.md
@@ -1,15 +1,6 @@
 ---
 title: SharedWorkerGlobalScope
 slug: Web/API/SharedWorkerGlobalScope
-tags:
-  - API
-  - Interface
-  - Reference
-  - SharedWorkerGlobalScope
-  - Web Workers
-  - インターフェイス
-  - ウェブワーカー
-translation_of: Web/API/SharedWorkerGlobalScope
 ---
 {{APIRef("Web Workers API")}}
 

--- a/files/ja/web/api/sourcebuffer/abort/index.md
+++ b/files/ja/web/api/sourcebuffer/abort/index.md
@@ -1,18 +1,6 @@
 ---
 title: SourceBuffer.abort()
 slug: Web/API/SourceBuffer/abort
-tags:
-  - API
-  - Audio
-  - Experimental
-  - MSE
-  - Media Source Extensions
-  - Method
-  - Reference
-  - SourceBuffer
-  - Video
-  - abort
-translation_of: Web/API/SourceBuffer/abort
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/sourcebuffer/appendbuffer/index.md
+++ b/files/ja/web/api/sourcebuffer/appendbuffer/index.md
@@ -1,19 +1,6 @@
 ---
 title: SourceBuffer.appendBuffer()
 slug: Web/API/SourceBuffer/appendBuffer
-tags:
-  - API
-  - Audio
-  - Experimental
-  - MSE
-  - Media
-  - Media Source Extensions
-  - Method
-  - Reference
-  - SourceBuffer
-  - Video
-  - appendBuffer
-translation_of: Web/API/SourceBuffer/appendBuffer
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/sourcebuffer/appendbufferasync/index.md
+++ b/files/ja/web/api/sourcebuffer/appendbufferasync/index.md
@@ -1,20 +1,6 @@
 ---
 title: SourceBuffer.appendBufferAsync()
 slug: Web/API/SourceBuffer/appendBufferAsync
-tags:
-  - API
-  - Audio
-  - Experimental
-  - MSE
-  - Media
-  - Media Source Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - SourceBuffer
-  - Video
-  - appendBufferAsync
-translation_of: Web/API/SourceBuffer/appendBufferAsync
 ---
 {{APIRef("Media Source Extensions")}}{{non-standard_header}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/sourcebuffer/appendstream/index.md
+++ b/files/ja/web/api/sourcebuffer/appendstream/index.md
@@ -1,18 +1,6 @@
 ---
 title: SourceBuffer.appendStream()
 slug: Web/API/SourceBuffer/appendStream
-tags:
-  - API
-  - Audio
-  - Experimental
-  - MSE
-  - Media Source Extensions
-  - Method
-  - Reference
-  - SourceBuffer
-  - Video
-  - appendstream
-translation_of: Web/API/SourceBuffer/appendStream
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/sourcebuffer/appendwindowend/index.md
+++ b/files/ja/web/api/sourcebuffer/appendwindowend/index.md
@@ -1,18 +1,6 @@
 ---
 title: SourceBuffer.appendWindowEnd
 slug: Web/API/SourceBuffer/appendWindowEnd
-tags:
-  - API
-  - Audio
-  - Experimental
-  - MSE
-  - Media Source Extensions
-  - Property
-  - Reference
-  - SourceBuffer
-  - Video
-  - appendWindowEnd
-translation_of: Web/API/SourceBuffer/appendWindowEnd
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/sourcebuffer/appendwindowstart/index.md
+++ b/files/ja/web/api/sourcebuffer/appendwindowstart/index.md
@@ -1,18 +1,6 @@
 ---
 title: SourceBuffer.appendWindowStart
 slug: Web/API/SourceBuffer/appendWindowStart
-tags:
-  - API
-  - Audio
-  - Experimental
-  - MSE
-  - Media Source Extensions
-  - Property
-  - Reference
-  - SourceBuffer
-  - Video
-  - appendWindowStart
-translation_of: Web/API/SourceBuffer/appendWindowStart
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/sourcebuffer/audiotracks/index.md
+++ b/files/ja/web/api/sourcebuffer/audiotracks/index.md
@@ -1,17 +1,6 @@
 ---
 title: SourceBuffer.audioTracks
 slug: Web/API/SourceBuffer/audioTracks
-tags:
-  - API
-  - Audio
-  - Experimental
-  - MSE
-  - Media Source Extensions
-  - Property
-  - Reference
-  - SourceBuffer
-  - audiotracks
-translation_of: Web/API/SourceBuffer/audioTracks
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/sourcebuffer/buffered/index.md
+++ b/files/ja/web/api/sourcebuffer/buffered/index.md
@@ -1,18 +1,6 @@
 ---
 title: SourceBuffer.buffered
 slug: Web/API/SourceBuffer/buffered
-tags:
-  - API
-  - Audio
-  - Experimental
-  - MSE
-  - Media Source Extensions
-  - Property
-  - Reference
-  - SourceBuffer
-  - Video
-  - buffered
-translation_of: Web/API/SourceBuffer/buffered
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/sourcebuffer/changetype/index.md
+++ b/files/ja/web/api/sourcebuffer/changetype/index.md
@@ -1,18 +1,6 @@
 ---
 title: SourceBuffer.changeType()
 slug: Web/API/SourceBuffer/changeType
-tags:
-  - API
-  - Audio
-  - MSE
-  - Media
-  - Media Source
-  - Media Source Extensions
-  - Method
-  - SourceBuffer
-  - Video
-  - changeType
-translation_of: Web/API/SourceBuffer/changeType
 ---
 {{APIRef("Media Source Extensions")}}
 

--- a/files/ja/web/api/sourcebuffer/index.md
+++ b/files/ja/web/api/sourcebuffer/index.md
@@ -1,17 +1,6 @@
 ---
 title: SourceBuffer
 slug: Web/API/SourceBuffer
-tags:
-  - API
-  - Audio
-  - Experimental
-  - Interface
-  - MSE
-  - Media Source Extensions
-  - Reference
-  - SourceBuffer
-  - Video
-translation_of: Web/API/SourceBuffer
 ---
 {{APIRef("Media Source Extensions")}}
 

--- a/files/ja/web/api/sourcebuffer/mode/index.md
+++ b/files/ja/web/api/sourcebuffer/mode/index.md
@@ -1,18 +1,6 @@
 ---
 title: SourceBuffer.mode
 slug: Web/API/SourceBuffer/mode
-tags:
-  - API
-  - Audio
-  - Experimental
-  - MSE
-  - Media Source Extensions
-  - Property
-  - Reference
-  - SourceBuffer
-  - Video
-  - mode
-translation_of: Web/API/SourceBuffer/mode
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/sourcebuffer/remove/index.md
+++ b/files/ja/web/api/sourcebuffer/remove/index.md
@@ -1,18 +1,6 @@
 ---
 title: SourceBuffer.remove()
 slug: Web/API/SourceBuffer/remove
-tags:
-  - API
-  - Audio
-  - Experimental
-  - MSE
-  - Media Source Extensions
-  - Method
-  - Reference
-  - SourceBuffer
-  - Video
-  - remove
-translation_of: Web/API/SourceBuffer/remove
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/sourcebuffer/removeasync/index.md
+++ b/files/ja/web/api/sourcebuffer/removeasync/index.md
@@ -1,19 +1,6 @@
 ---
 title: SourceBuffer.removeAsync()
 slug: Web/API/SourceBuffer/removeAsync
-tags:
-  - API
-  - Audio
-  - MSE
-  - Media
-  - Media Source Extensions
-  - Method
-  - Non-standard
-  - Reference
-  - SourceBuffer
-  - Video
-  - removeAsync
-translation_of: Web/API/SourceBuffer/removeAsync
 ---
 {{APIRef("Media Source Extensions")}}{{non-standard_header}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/sourcebuffer/texttracks/index.md
+++ b/files/ja/web/api/sourcebuffer/texttracks/index.md
@@ -1,17 +1,6 @@
 ---
 title: SourceBuffer.textTracks
 slug: Web/API/SourceBuffer/textTracks
-tags:
-  - API
-  - Experimental
-  - MSE
-  - Media Source Extensions
-  - Property
-  - Reference
-  - SourceBuffer
-  - Video
-  - textTracks
-translation_of: Web/API/SourceBuffer/textTracks
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/sourcebuffer/timestampoffset/index.md
+++ b/files/ja/web/api/sourcebuffer/timestampoffset/index.md
@@ -1,18 +1,6 @@
 ---
 title: SourceBuffer.timestampOffset
 slug: Web/API/SourceBuffer/timestampOffset
-tags:
-  - API
-  - Audio
-  - Experimental
-  - MSE
-  - Media Source Extensions
-  - Property
-  - Reference
-  - SourceBuffer
-  - Video
-  - timestampOffset
-translation_of: Web/API/SourceBuffer/timestampOffset
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/sourcebuffer/trackdefaults/index.md
+++ b/files/ja/web/api/sourcebuffer/trackdefaults/index.md
@@ -1,18 +1,6 @@
 ---
 title: SourceBuffer.trackDefaults
 slug: Web/API/SourceBuffer/trackDefaults
-tags:
-  - API
-  - Audio
-  - Experimental
-  - MSE
-  - Media Source Extensions
-  - Property
-  - Reference
-  - SourceBuffer
-  - Video
-  - trackDefaults
-translation_of: Web/API/SourceBuffer/trackDefaults
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/sourcebuffer/updating/index.md
+++ b/files/ja/web/api/sourcebuffer/updating/index.md
@@ -1,18 +1,6 @@
 ---
 title: SourceBuffer.updating
 slug: Web/API/SourceBuffer/updating
-tags:
-  - API
-  - Audio
-  - Experimental
-  - MSE
-  - Media Source Extensions
-  - Property
-  - Reference
-  - SourceBuffer
-  - Updating
-  - Video
-translation_of: Web/API/SourceBuffer/updating
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/sourcebuffer/videotracks/index.md
+++ b/files/ja/web/api/sourcebuffer/videotracks/index.md
@@ -1,17 +1,6 @@
 ---
 title: SourceBuffer.videoTracks
 slug: Web/API/SourceBuffer/videoTracks
-tags:
-  - API
-  - Experimental
-  - MSE
-  - Media Source Extensions
-  - Property
-  - Reference
-  - SourceBuffer
-  - Video
-  - videoTracks
-translation_of: Web/API/SourceBuffer/videoTracks
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/sourcebufferlist/index.md
+++ b/files/ja/web/api/sourcebufferlist/index.md
@@ -1,17 +1,6 @@
 ---
 title: SourceBufferList
 slug: Web/API/SourceBufferList
-tags:
-  - API
-  - Audio
-  - Experimental
-  - Interface
-  - MSE
-  - Media Source Extensions
-  - Reference
-  - SourceBufferList
-  - Video
-translation_of: Web/API/SourceBufferList
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/sourcebufferlist/length/index.md
+++ b/files/ja/web/api/sourcebufferlist/length/index.md
@@ -1,17 +1,6 @@
 ---
 title: SourceBufferList.length
 slug: Web/API/SourceBufferList/length
-tags:
-  - API
-  - Audio
-  - MSE
-  - Media Source Extensions
-  - Property
-  - Reference
-  - SourceBufferList
-  - Video
-  - length
-translation_of: Web/API/SourceBufferList/length
 ---
 {{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/speechgrammar/index.md
+++ b/files/ja/web/api/speechgrammar/index.md
@@ -1,16 +1,6 @@
 ---
 title: SpeechGrammar
 slug: Web/API/SpeechGrammar
-tags:
-  - API
-  - Experimental
-  - Interface
-  - Reference
-  - SpeechGrammar
-  - Web Speech API
-  - recognition
-  - speech
-translation_of: Web/API/SpeechGrammar
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/speechrecognition/abort/index.md
+++ b/files/ja/web/api/speechrecognition/abort/index.md
@@ -1,17 +1,6 @@
 ---
 title: SpeechRecognition.abort()
 slug: Web/API/SpeechRecognition/abort
-tags:
-  - API
-  - Experimental
-  - Method
-  - Reference
-  - SpeechRecognition
-  - Web Speech API
-  - abort
-  - recognition
-  - speech
-translation_of: Web/API/SpeechRecognition/abort
 ---
 {{APIRef("Web Speech API")}}{{ SeeCompatTable() }}
 

--- a/files/ja/web/api/speechrecognition/audioend_event/index.md
+++ b/files/ja/web/api/speechrecognition/audioend_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: SpeechRecognition.onaudioend
 slug: Web/API/SpeechRecognition/audioend_event
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - SpeechRecognition
-  - Web Speech API
-  - onaudioend
-  - recognition
-  - speech
-translation_of: Web/API/SpeechRecognition/onaudioend
 original_slug: Web/API/SpeechRecognition/onaudioend
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}

--- a/files/ja/web/api/speechrecognition/audiostart_event/index.md
+++ b/files/ja/web/api/speechrecognition/audiostart_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'SpeechRecognition: audiostart イベント'
 slug: Web/API/SpeechRecognition/audiostart_event
-tags:
-  - Event
-  - Reference
-  - SpeechRecognition
-  - Web Speech API
-  - audiostart
-  - onaudiostart
-  - イベント
-translation_of: Web/API/SpeechRecognition/audiostart_event
 ---
 {{APIRef("Web Speech API")}} {{SeeCompatTable}}
 

--- a/files/ja/web/api/speechrecognition/continuous/index.md
+++ b/files/ja/web/api/speechrecognition/continuous/index.md
@@ -1,17 +1,6 @@
 ---
 title: SpeechRecognition.continuous
 slug: Web/API/SpeechRecognition/continuous
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - SpeechRecognition
-  - Web Speech API
-  - continuous
-  - recognition
-  - speech
-translation_of: Web/API/SpeechRecognition/continuous
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/speechrecognition/end_event/index.md
+++ b/files/ja/web/api/speechrecognition/end_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: SpeechRecognition.onend
 slug: Web/API/SpeechRecognition/end_event
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - SpeechRecognition
-  - Web Speech API
-  - onend
-  - recognition
-  - speech
-translation_of: Web/API/SpeechRecognition/onend
 original_slug: Web/API/SpeechRecognition/onend
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}

--- a/files/ja/web/api/speechrecognition/error_event/index.md
+++ b/files/ja/web/api/speechrecognition/error_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: SpeechRecognition.onerror
 slug: Web/API/SpeechRecognition/error_event
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - SpeechRecognition
-  - Web Speech API
-  - onerror
-  - recognition
-  - speech
-translation_of: Web/API/SpeechRecognition/onerror
 original_slug: Web/API/SpeechRecognition/onerror
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}

--- a/files/ja/web/api/speechrecognition/grammars/index.md
+++ b/files/ja/web/api/speechrecognition/grammars/index.md
@@ -1,17 +1,6 @@
 ---
 title: SpeechRecognition.grammars
 slug: Web/API/SpeechRecognition/grammars
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - SpeechRecognition
-  - Web Speech API
-  - grammars
-  - recognition
-  - speech
-translation_of: Web/API/SpeechRecognition/grammars
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/speechrecognition/index.md
+++ b/files/ja/web/api/speechrecognition/index.md
@@ -1,16 +1,6 @@
 ---
 title: SpeechRecognition
 slug: Web/API/SpeechRecognition
-tags:
-  - API
-  - Experimental
-  - Interface
-  - Reference
-  - SpeechRecognition
-  - Web Speech API
-  - recognition
-  - speech
-translation_of: Web/API/SpeechRecognition
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/speechrecognition/interimresults/index.md
+++ b/files/ja/web/api/speechrecognition/interimresults/index.md
@@ -1,16 +1,6 @@
 ---
 title: SpeechRecognition.interimResults
 slug: Web/API/SpeechRecognition/interimResults
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - SpeechRecognition
-  - Web Speech API
-  - recognition
-  - speech
-translation_of: Web/API/SpeechRecognition/interimResults
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/speechrecognition/lang/index.md
+++ b/files/ja/web/api/speechrecognition/lang/index.md
@@ -1,17 +1,6 @@
 ---
 title: SpeechRecognition.lang
 slug: Web/API/SpeechRecognition/lang
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - SpeechRecognition
-  - Web Speech API
-  - lang
-  - recognition
-  - speech
-translation_of: Web/API/SpeechRecognition/lang
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/speechrecognition/maxalternatives/index.md
+++ b/files/ja/web/api/speechrecognition/maxalternatives/index.md
@@ -1,17 +1,6 @@
 ---
 title: SpeechRecognition.maxAlternatives
 slug: Web/API/SpeechRecognition/maxAlternatives
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - SpeechRecognition
-  - Web Speech API
-  - maxAlternatives
-  - recognition
-  - speech
-translation_of: Web/API/SpeechRecognition/maxAlternatives
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/speechrecognition/nomatch_event/index.md
+++ b/files/ja/web/api/speechrecognition/nomatch_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: SpeechRecognition.onnomatch
 slug: Web/API/SpeechRecognition/nomatch_event
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - SpeechRecognition
-  - Web Speech API
-  - onnomatch
-  - recognition
-  - speech
-translation_of: Web/API/SpeechRecognition/onnomatch
 original_slug: Web/API/SpeechRecognition/onnomatch
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}

--- a/files/ja/web/api/speechrecognition/result_event/index.md
+++ b/files/ja/web/api/speechrecognition/result_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: SpeechRecognition.onresult
 slug: Web/API/SpeechRecognition/result_event
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - SpeechRecognition
-  - Web Speech API
-  - onresult
-  - recognition
-  - speech
-translation_of: Web/API/SpeechRecognition/onresult
 original_slug: Web/API/SpeechRecognition/onresult
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}

--- a/files/ja/web/api/speechrecognition/serviceuri/index.md
+++ b/files/ja/web/api/speechrecognition/serviceuri/index.md
@@ -1,17 +1,6 @@
 ---
 title: SpeechRecognition.serviceURI
 slug: Web/API/SpeechRecognition/serviceURI
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - SpeechRecognition
-  - Web Speech API
-  - recognition
-  - serviceURI
-  - speech
-translation_of: Web/API/SpeechRecognition/serviceURI
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/speechrecognition/soundend_event/index.md
+++ b/files/ja/web/api/speechrecognition/soundend_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: SpeechRecognition.onsoundend
 slug: Web/API/SpeechRecognition/soundend_event
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - SpeechRecognition
-  - Web Speech API
-  - onsoundend
-  - recognition
-  - speech
-translation_of: Web/API/SpeechRecognition/onsoundend
 original_slug: Web/API/SpeechRecognition/onsoundend
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}

--- a/files/ja/web/api/speechrecognition/soundstart_event/index.md
+++ b/files/ja/web/api/speechrecognition/soundstart_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: SpeechRecognition.onsoundstart
 slug: Web/API/SpeechRecognition/soundstart_event
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - SpeechRecognition
-  - Web Speech API
-  - onsoundstart
-  - recognition
-  - speech
-translation_of: Web/API/SpeechRecognition/onsoundstart
 original_slug: Web/API/SpeechRecognition/onsoundstart
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}

--- a/files/ja/web/api/speechrecognition/speechend_event/index.md
+++ b/files/ja/web/api/speechrecognition/speechend_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: SpeechRecognition.onspeechend
 slug: Web/API/SpeechRecognition/speechend_event
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - SpeechRecognition
-  - Web Speech API
-  - onspeechend
-  - recognition
-  - speech
-translation_of: Web/API/SpeechRecognition/onspeechend
 original_slug: Web/API/SpeechRecognition/onspeechend
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}

--- a/files/ja/web/api/speechrecognition/speechrecognition/index.md
+++ b/files/ja/web/api/speechrecognition/speechrecognition/index.md
@@ -1,16 +1,6 @@
 ---
 title: SpeechRecognition()
 slug: Web/API/SpeechRecognition/SpeechRecognition
-tags:
-  - API
-  - Constructor
-  - Experimental
-  - Reference
-  - SpeechRecognition
-  - Web Speech API
-  - recognition
-  - speech
-translation_of: Web/API/SpeechRecognition/SpeechRecognition
 ---
 {{APIRef("Web Speech API")}}{{ SeeCompatTable() }}
 

--- a/files/ja/web/api/speechrecognition/speechstart_event/index.md
+++ b/files/ja/web/api/speechrecognition/speechstart_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: SpeechRecognition.onspeechstart
 slug: Web/API/SpeechRecognition/speechstart_event
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - SpeechRecognition
-  - Web Speech API
-  - onspeechstart
-  - recognition
-  - speech
-translation_of: Web/API/SpeechRecognition/onspeechstart
 original_slug: Web/API/SpeechRecognition/onspeechstart
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}

--- a/files/ja/web/api/speechrecognition/start/index.md
+++ b/files/ja/web/api/speechrecognition/start/index.md
@@ -1,17 +1,6 @@
 ---
 title: SpeechRecognition.start()
 slug: Web/API/SpeechRecognition/start
-tags:
-  - API
-  - Experimental
-  - Method
-  - Reference
-  - SpeechRecognition
-  - Web Speech API
-  - recognition
-  - speech
-  - start
-translation_of: Web/API/SpeechRecognition/start
 ---
 {{APIRef("Web Speech API")}}{{ SeeCompatTable() }}
 

--- a/files/ja/web/api/speechrecognition/start_event/index.md
+++ b/files/ja/web/api/speechrecognition/start_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: SpeechRecognition.onstart
 slug: Web/API/SpeechRecognition/start_event
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - SpeechRecognition
-  - Web Speech API
-  - onstart
-  - recognition
-  - speech
-translation_of: Web/API/SpeechRecognition/onstart
 original_slug: Web/API/SpeechRecognition/onstart
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}

--- a/files/ja/web/api/speechrecognition/stop/index.md
+++ b/files/ja/web/api/speechrecognition/stop/index.md
@@ -1,17 +1,6 @@
 ---
 title: SpeechRecognition.stop()
 slug: Web/API/SpeechRecognition/stop
-tags:
-  - API
-  - Experimental
-  - Method
-  - Reference
-  - SpeechRecognition
-  - Web Speech API
-  - recognition
-  - speech
-  - stop
-translation_of: Web/API/SpeechRecognition/stop
 ---
 {{APIRef("Web Speech API")}}{{ SeeCompatTable() }}
 

--- a/files/ja/web/api/speechrecognitionalternative/index.md
+++ b/files/ja/web/api/speechrecognitionalternative/index.md
@@ -1,16 +1,6 @@
 ---
 title: SpeechRecognitionAlternative
 slug: Web/API/SpeechRecognitionAlternative
-tags:
-  - API
-  - Experimental
-  - Interface
-  - Reference
-  - SpeechRecognitionAlternative
-  - Web Speech API
-  - recognition
-  - speech
-translation_of: Web/API/SpeechRecognitionAlternative
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/speechrecognitionalternative/transcript/index.md
+++ b/files/ja/web/api/speechrecognitionalternative/transcript/index.md
@@ -1,17 +1,6 @@
 ---
 title: SpeechRecognitionAlternative.transcript
 slug: Web/API/SpeechRecognitionAlternative/transcript
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - SpeechRecognitionAlternative
-  - Web Speech API
-  - recognition
-  - speech
-  - transcript
-translation_of: Web/API/SpeechRecognitionAlternative/transcript
 ---
 {{APIRef("Web Speech API")}}{{ SeeCompatTable() }}
 

--- a/files/ja/web/api/speechrecognitionerrorevent/index.md
+++ b/files/ja/web/api/speechrecognitionerrorevent/index.md
@@ -1,16 +1,6 @@
 ---
 title: SpeechRecognitionError
 slug: Web/API/SpeechRecognitionErrorEvent
-tags:
-  - API
-  - Experimental
-  - Interface
-  - Reference
-  - SpeechRecognitionError
-  - Web Speech API
-  - recognition
-  - speech
-translation_of: Web/API/SpeechRecognitionError
 original_slug: Web/API/SpeechRecognitionError
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}

--- a/files/ja/web/api/speechrecognitionresult/index.md
+++ b/files/ja/web/api/speechrecognitionresult/index.md
@@ -1,18 +1,6 @@
 ---
 title: SpeechRecognitionResult
 slug: Web/API/SpeechRecognitionResult
-tags:
-  - API
-  - Experimental
-  - Interface
-  - NeedsTranslation
-  - Reference
-  - SpeechRecognitionResult
-  - TopicStub
-  - Web Speech API
-  - recognition
-  - speech
-translation_of: Web/API/SpeechRecognitionResult
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/speechrecognitionresult/isfinal/index.md
+++ b/files/ja/web/api/speechrecognitionresult/isfinal/index.md
@@ -1,17 +1,6 @@
 ---
 title: SpeechRecognitionResult.isFinal
 slug: Web/API/SpeechRecognitionResult/isFinal
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - SpeechRecognitionResult
-  - Web Speech API
-  - isFinal
-  - recognition
-  - speech
-translation_of: Web/API/SpeechRecognitionResult/isFinal
 ---
 {{APIRef("Web Speech API")}}{{ SeeCompatTable() }}
 

--- a/files/ja/web/api/speechsynthesis/index.md
+++ b/files/ja/web/api/speechsynthesis/index.md
@@ -1,16 +1,6 @@
 ---
 title: SpeechSynthesis
 slug: Web/API/SpeechSynthesis
-tags:
-  - API
-  - Experimental
-  - Interface
-  - Reference
-  - SpeechSynthesis
-  - Web Speech API
-  - speech
-  - synthesis
-translation_of: Web/API/SpeechSynthesis
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/speechsynthesisutterance/index.md
+++ b/files/ja/web/api/speechsynthesisutterance/index.md
@@ -1,16 +1,6 @@
 ---
 title: SpeechSynthesisUtterance
 slug: Web/API/SpeechSynthesisUtterance
-tags:
-  - API
-  - Experimental
-  - Interface
-  - Reference
-  - SpeechSynthesisUtterance
-  - Web Speech API
-  - speech
-  - synthesis
-translation_of: Web/API/SpeechSynthesisUtterance
 ---
 {{APIRef("Web Speech API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/speechsynthesisutterance/lang/index.md
+++ b/files/ja/web/api/speechsynthesisutterance/lang/index.md
@@ -1,7 +1,6 @@
 ---
 title: SpeechSynthesisUtterance.lang
 slug: Web/API/SpeechSynthesisUtterance/lang
-translation_of: Web/API/SpeechSynthesisUtterance/lang
 ---
 {{APIRef("Web Speech API")}} {{SeeCompatTable}}
 {{domxref("SpeechSynthesisUtterance")}}インターフェースの**lang**プロパティは、発話の言語を取得、設定します。

--- a/files/ja/web/api/stereopannernode/index.md
+++ b/files/ja/web/api/stereopannernode/index.md
@@ -1,16 +1,6 @@
 ---
 title: StereoPannerNode
 slug: Web/API/StereoPannerNode
-page-type: web-api-interface
-tags:
-  - API
-  - Audio
-  - Interface
-  - Reference
-  - StereoPannerNode
-  - Web Audio API
-browser-compat: api.StereoPannerNode
-translation_of: Web/API/StereoPannerNode
 ---
 {{APIRef("Web Audio API")}}
 

--- a/files/ja/web/api/storage/clear/index.md
+++ b/files/ja/web/api/storage/clear/index.md
@@ -1,13 +1,6 @@
 ---
 title: Storage.clear()
 slug: Web/API/Storage/clear
-tags:
-  - API
-  - Method
-  - Reference
-  - Storage
-  - Web Storage
-translation_of: Web/API/Storage/clear
 ---
 {{APIRef("Web Storage API")}}
 

--- a/files/ja/web/api/storage/getitem/index.md
+++ b/files/ja/web/api/storage/getitem/index.md
@@ -1,13 +1,6 @@
 ---
 title: Storage.getItem()
 slug: Web/API/Storage/getItem
-tags:
-  - API
-  - Method
-  - Reference
-  - Storage
-  - Web Storage
-translation_of: Web/API/Storage/getItem
 ---
 {{APIRef("Web Storage API")}}
 

--- a/files/ja/web/api/storage/index.md
+++ b/files/ja/web/api/storage/index.md
@@ -1,14 +1,6 @@
 ---
 title: Storage
 slug: Web/API/Storage
-tags:
-  - API
-  - Interface
-  - Reference
-  - Storage
-  - Web Storage
-  - data
-translation_of: Web/API/Storage
 ---
 {{APIRef("Web Storage API")}}
 

--- a/files/ja/web/api/storage/key/index.md
+++ b/files/ja/web/api/storage/key/index.md
@@ -1,13 +1,6 @@
 ---
 title: Storage.key()
 slug: Web/API/Storage/key
-tags:
-  - API
-  - Method
-  - Reference
-  - Storage
-  - Web Storage
-translation_of: Web/API/Storage/key
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/storage/length/index.md
+++ b/files/ja/web/api/storage/length/index.md
@@ -1,14 +1,6 @@
 ---
 title: Storage.length
 slug: Web/API/Storage/length
-tags:
-  - API
-  - Property
-  - Read-only
-  - Reference
-  - Storage
-  - Web Storage
-translation_of: Web/API/Storage/length
 ---
 {{APIRef("Web Storage API")}}
 

--- a/files/ja/web/api/storage/removeitem/index.md
+++ b/files/ja/web/api/storage/removeitem/index.md
@@ -1,14 +1,6 @@
 ---
 title: Storage.removeItem()
 slug: Web/API/Storage/removeItem
-tags:
-  - API
-  - Method
-  - Reference
-  - Référence(2)
-  - Storage
-  - Web Storage
-translation_of: Web/API/Storage/removeItem
 ---
 {{APIRef("Web Storage API")}}
 

--- a/files/ja/web/api/storage/setitem/index.md
+++ b/files/ja/web/api/storage/setitem/index.md
@@ -1,13 +1,6 @@
 ---
 title: Storage.setItem()
 slug: Web/API/Storage/setItem
-tags:
-  - API
-  - Method
-  - Reference
-  - Storage
-  - Web Storage
-translation_of: Web/API/Storage/setItem
 ---
 {{APIRef("Web Storage API")}}
 

--- a/files/ja/web/api/storage_access_api/index.md
+++ b/files/ja/web/api/storage_access_api/index.md
@@ -1,12 +1,6 @@
 ---
 title: Storage Access API
 slug: Web/API/Storage_Access_API
-tags:
-  - API
-  - Reference
-  - Storage
-  - Storage Access API
-translation_of: Web/API/Storage_Access_API
 ---
 {{DefaultAPISidebar("Storage Access API")}}{{seecompattable}}
 

--- a/files/ja/web/api/storage_access_api/using/index.md
+++ b/files/ja/web/api/storage_access_api/using/index.md
@@ -1,14 +1,6 @@
 ---
 title: Storage Access API の使用
 slug: Web/API/Storage_Access_API/Using
-tags:
-  - API
-  - DOM
-  - Guide
-  - Reference
-  - Storage
-  - Storage Access API
-translation_of: Web/API/Storage_Access_API/Using
 ---
 {{seecompattable}}{{DefaultAPISidebar("Storage Access API")}}
 

--- a/files/ja/web/api/storage_api/index.md
+++ b/files/ja/web/api/storage_api/index.md
@@ -1,16 +1,6 @@
 ---
 title: Storage API
 slug: Web/API/Storage_API
-tags:
-  - API
-  - Overview
-  - Quotas
-  - Reference
-  - Secure context
-  - Storage
-  - Storage API
-  - Usage
-translation_of: Web/API/Storage_API
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Storage")}}
 

--- a/files/ja/web/api/storageevent/index.md
+++ b/files/ja/web/api/storageevent/index.md
@@ -1,11 +1,6 @@
 ---
 title: StorageEvent
 slug: Web/API/StorageEvent
-tags:
-  - API
-  - Reference
-  - Web Storage API
-translation_of: Web/API/StorageEvent
 ---
 {{APIRef("Web Storage API")}}
 

--- a/files/ja/web/api/storagemanager/estimate/index.md
+++ b/files/ja/web/api/storagemanager/estimate/index.md
@@ -1,19 +1,6 @@
 ---
 title: StorageManager.estimate()
 slug: Web/API/StorageManager/estimate
-tags:
-  - API
-  - Method
-  - Quota
-  - Reference
-  - Secure context
-  - Storage
-  - Storage API
-  - StorageManager
-  - Usage
-  - estimate
-  - メソッド
-translation_of: Web/API/StorageManager/estimate
 ---
 {{securecontext_header}}{{APIRef("Storage")}}
 

--- a/files/ja/web/api/storagemanager/index.md
+++ b/files/ja/web/api/storagemanager/index.md
@@ -1,18 +1,6 @@
 ---
 title: StorageManager
 slug: Web/API/StorageManager
-tags:
-  - API
-  - Interface
-  - Persistence
-  - Quotas
-  - Reference
-  - Secure context
-  - Storage
-  - Storage API
-  - StorageManager
-  - Usage
-translation_of: Web/API/StorageManager
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef("Storage")}}
 

--- a/files/ja/web/api/storagemanager/persist/index.md
+++ b/files/ja/web/api/storagemanager/persist/index.md
@@ -1,13 +1,6 @@
 ---
 title: StorageManager.persist()
 slug: Web/API/StorageManager/persist
-tags:
-  - Method
-  - Reference
-  - Secure context
-  - Storage API
-  - persist()
-translation_of: Web/API/StorageManager/persist
 ---
 {{securecontext_header}}{{APIRef("Storage")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/storagemanager/persisted/index.md
+++ b/files/ja/web/api/storagemanager/persisted/index.md
@@ -1,13 +1,6 @@
 ---
 title: StorageManager.persisted()
 slug: Web/API/StorageManager/persisted
-tags:
-  - Method
-  - Reference
-  - Secure context
-  - Storage API
-  - persisted()
-translation_of: Web/API/StorageManager/persisted
 ---
 {{securecontext_header}}{{APIRef("Storage")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/streams_api/concepts/index.md
+++ b/files/ja/web/api/streams_api/concepts/index.md
@@ -1,11 +1,6 @@
 ---
 title: Streams API の概念
 slug: Web/API/Streams_API/Concepts
-tags:
-  - API
-  - Streams
-  - concepts
-translation_of: Web/API/Streams_API/Concepts
 ---
 {{apiref("Streams")}}
 

--- a/files/ja/web/api/streams_api/index.md
+++ b/files/ja/web/api/streams_api/index.md
@@ -1,14 +1,6 @@
 ---
 title: Streams API
 slug: Web/API/Streams_API
-tags:
-  - API
-  - Experimental
-  - JavaScript
-  - Landing
-  - Reference
-  - Streams
-translation_of: Web/API/Streams_API
 ---
 {{SeeCompatTable}}{{DefaultAPISidebar("Streams")}}
 

--- a/files/ja/web/api/streams_api/using_readable_streams/index.md
+++ b/files/ja/web/api/streams_api/using_readable_streams/index.md
@@ -1,18 +1,6 @@
 ---
 title: 読み取り可能なストリームの使用
 slug: Web/API/Streams_API/Using_readable_streams
-tags:
-  - API
-  - Controller
-  - Fetch
-  - Guide
-  - ReadableStreams
-  - Streams
-  - pipe chains
-  - readable streams
-  - reader
-  - tee
-translation_of: Web/API/Streams_API/Using_readable_streams
 ---
 {{apiref("Streams")}}
 

--- a/files/ja/web/api/streams_api/using_writable_streams/index.md
+++ b/files/ja/web/api/streams_api/using_writable_streams/index.md
@@ -1,15 +1,6 @@
 ---
 title: 書き込み可能なストリームの使用
 slug: Web/API/Streams_API/Using_writable_streams
-tags:
-  - API
-  - Controller
-  - Guide
-  - Streams
-  - WritableStream
-  - writable streams
-  - writer
-translation_of: Web/API/Streams_API/Using_writable_streams
 ---
 {{apiref("Streams")}}
 

--- a/files/ja/web/api/stylepropertymapreadonly/entries/index.md
+++ b/files/ja/web/api/stylepropertymapreadonly/entries/index.md
@@ -1,17 +1,6 @@
 ---
 title: StylePropertyMapReadOnly.entries()
 slug: Web/API/StylePropertyMapReadOnly/entries
-tags:
-  - API
-  - CSS 型付きオブジェクトモデル API
-  - 実験的
-  - Houdini
-  - メソッド
-  - リファレンス
-  - StylePropertyMapReadOnly
-  - entries()
-browser-compat: api.StylePropertyMapReadOnly.entries
-translation_of: Web/API/StylePropertyMapReadOnly/entries
 ---
 {{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/stylepropertymapreadonly/foreach/index.md
+++ b/files/ja/web/api/stylepropertymapreadonly/foreach/index.md
@@ -1,17 +1,6 @@
 ---
 title: StylePropertyMapReadOnly.forEach()
 slug: Web/API/StylePropertyMapReadOnly/forEach
-tags:
-  - API
-  - CSS Typed Object Model API
-  - 実験的
-  - Houdini
-  - メソッド
-  - リファレンス
-  - StylePropertyMapReadOnly
-  - forEach()
-browser-compat: api.StylePropertyMapReadOnly.forEach
-translation_of: Web/API/StylePropertyMapReadOnly/forEach
 ---
 {{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/stylepropertymapreadonly/get/index.md
+++ b/files/ja/web/api/stylepropertymapreadonly/get/index.md
@@ -1,16 +1,6 @@
 ---
 title: StylePropertyMapReadOnly.get()
 slug: Web/API/StylePropertyMapReadOnly/get
-tags:
-  - API
-  - CSS Typed Object Model API
-  - 実験的
-  - Houdini
-  - メソッド
-  - リファレンス
-  - get()
-browser-compat: api.StylePropertyMapReadOnly.get
-translation_of: Web/API/StylePropertyMapReadOnly/get
 ---
 {{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/stylepropertymapreadonly/getall/index.md
+++ b/files/ja/web/api/stylepropertymapreadonly/getall/index.md
@@ -1,17 +1,6 @@
 ---
 title: StylePropertyMapReadOnly.getAll()
 slug: Web/API/StylePropertyMapReadOnly/getAll
-tags:
-  - API
-  - CSS Typed Object Model API
-  - 実験的
-  - Houdini
-  - メソッド
-  - リファレンス
-  - StylePropertyMapReadOnly
-  - getAll()
-browser-compat: api.StylePropertyMapReadOnly.getAll
-translation_of: Web/API/StylePropertyMapReadOnly/getAll
 ---
 {{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/stylepropertymapreadonly/has/index.md
+++ b/files/ja/web/api/stylepropertymapreadonly/has/index.md
@@ -1,17 +1,6 @@
 ---
 title: StylePropertyMapReadOnly.has()
 slug: Web/API/StylePropertyMapReadOnly/has
-tags:
-  - API
-  - CSS Typed Object Model API
-  - 実験的
-  - Houdini
-  - メソッド
-  - リファレンス
-  - StylePropertyMapReadOnly
-  - has()
-browser-compat: api.StylePropertyMapReadOnly.has
-translation_of: Web/API/StylePropertyMapReadOnly/has
 ---
 {{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/stylepropertymapreadonly/index.md
+++ b/files/ja/web/api/stylepropertymapreadonly/index.md
@@ -1,16 +1,6 @@
 ---
 title: StylePropertyMapReadOnly
 slug: Web/API/StylePropertyMapReadOnly
-tags:
-  - API
-  - CSS 型付きオブジェクトモデル API
-  - 実験的
-  - Houdini
-  - インターフェイス
-  - リファレンス
-  - StylePropertyMapReadOnly
-browser-compat: api.StylePropertyMapReadOnly
-translation_of: Web/API/StylePropertyMapReadOnly
 ---
 {{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}
 

--- a/files/ja/web/api/stylepropertymapreadonly/keys/index.md
+++ b/files/ja/web/api/stylepropertymapreadonly/keys/index.md
@@ -1,17 +1,6 @@
 ---
 title: StylePropertyMapReadOnly.keys()
 slug: Web/API/StylePropertyMapReadOnly/keys
-tags:
-  - API
-  - CSS Typed Object Model API
-  - 実験的
-  - Houdini
-  - メソッド
-  - リファレンス
-  - StylePropertyMapReadOnly
-  - keys()
-browser-compat: api.StylePropertyMapReadOnly.keys
-translation_of: Web/API/StylePropertyMapReadOnly/keys
 ---
 {{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/stylepropertymapreadonly/size/index.md
+++ b/files/ja/web/api/stylepropertymapreadonly/size/index.md
@@ -1,17 +1,6 @@
 ---
 title: StylePropertyMapReadOnly.size
 slug: Web/API/StylePropertyMapReadOnly/size
-tags:
-  - API
-  - CSS 型付きオブジェクトモデル API
-  - 実験的
-  - Houdini
-  - Property
-  - リファレンス
-  - StylePropertyMapReadOnly
-  - size
-browser-compat: api.StylePropertyMapReadOnly.size
-translation_of: Web/API/StylePropertyMapReadOnly/size
 ---
 {{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}
 

--- a/files/ja/web/api/stylepropertymapreadonly/values/index.md
+++ b/files/ja/web/api/stylepropertymapreadonly/values/index.md
@@ -1,17 +1,6 @@
 ---
 title: StylePropertyMapReadOnly.values()
 slug: Web/API/StylePropertyMapReadOnly/values
-tags:
-  - API
-  - CSS Typed Object Model API
-  - 実験的
-  - Houdini
-  - メソッド
-  - リファレンス
-  - StylePropertyMapReadOnly
-  - values()
-browser-compat: api.StylePropertyMapReadOnly.values
-translation_of: Web/API/StylePropertyMapReadOnly/values
 ---
 {{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/stylesheet/disabled/index.md
+++ b/files/ja/web/api/stylesheet/disabled/index.md
@@ -1,12 +1,6 @@
 ---
 title: StyleSheet.disabled
 slug: Web/API/StyleSheet/disabled
-tags:
-  - DOM
-  - Gecko
-  - Gecko DOM Reference
-  - StyleSheet
-translation_of: Web/API/StyleSheet/disabled
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/stylesheet/href/index.md
+++ b/files/ja/web/api/stylesheet/href/index.md
@@ -1,12 +1,6 @@
 ---
 title: StyleSheet.href
 slug: Web/API/StyleSheet/href
-tags:
-  - DOM
-  - Gecko
-  - Gecko DOM Reference
-  - StyleSheet
-translation_of: Web/API/StyleSheet/href
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/stylesheet/index.md
+++ b/files/ja/web/api/stylesheet/index.md
@@ -1,13 +1,6 @@
 ---
 title: StyleSheet
 slug: Web/API/StyleSheet
-tags:
-  - CSSOM
-  - DOM
-  - NeedsTranslation
-  - TopicStub
-  - 要更新
-translation_of: Web/API/StyleSheet
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/stylesheet/media/index.md
+++ b/files/ja/web/api/stylesheet/media/index.md
@@ -1,13 +1,6 @@
 ---
 title: StyleSheet.media
 slug: Web/API/StyleSheet/media
-tags:
-  - API
-  - CSSOM
-  - Media
-  - StyleSheet
-  - プロパティ
-translation_of: Web/API/StyleSheet/media
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/stylesheet/ownernode/index.md
+++ b/files/ja/web/api/stylesheet/ownernode/index.md
@@ -1,12 +1,6 @@
 ---
 title: StyleSheet.ownerNode
 slug: Web/API/StyleSheet/ownerNode
-tags:
-  - API
-  - CSSOM
-  - Property
-  - Reference
-translation_of: Web/API/StyleSheet/ownerNode
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/stylesheet/parentstylesheet/index.md
+++ b/files/ja/web/api/stylesheet/parentstylesheet/index.md
@@ -1,11 +1,6 @@
 ---
 title: StyleSheet.parentStyleSheet
 slug: Web/API/StyleSheet/parentStyleSheet
-tags:
-  - DOM
-  - Gecko
-  - Gecko DOM Reference
-translation_of: Web/API/StyleSheet/parentStyleSheet
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/stylesheet/title/index.md
+++ b/files/ja/web/api/stylesheet/title/index.md
@@ -1,11 +1,6 @@
 ---
 title: StyleSheet.title
 slug: Web/API/StyleSheet/title
-tags:
-  - DOM
-  - Gecko
-  - Gecko DOM Reference
-translation_of: Web/API/StyleSheet/title
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/stylesheet/type/index.md
+++ b/files/ja/web/api/stylesheet/type/index.md
@@ -1,11 +1,6 @@
 ---
 title: StyleSheet.type
 slug: Web/API/StyleSheet/type
-tags:
-  - DOM
-  - Gecko
-  - Gecko DOM Reference
-translation_of: Web/API/StyleSheet/type
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/stylesheetlist/index.md
+++ b/files/ja/web/api/stylesheetlist/index.md
@@ -1,12 +1,6 @@
 ---
 title: StyleSheetList
 slug: Web/API/StyleSheetList
-tags:
-  - API
-  - CSSOM
-  - NeedsContent
-  - NeedsUpdate
-translation_of: Web/API/StyleSheetList
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/subtlecrypto/digest/index.md
+++ b/files/ja/web/api/subtlecrypto/digest/index.md
@@ -1,15 +1,6 @@
 ---
 title: SubtleCrypto.digest()
 slug: Web/API/SubtleCrypto/digest
-tags:
-  - API
-  - Method
-  - Reference
-  - SubtleCrypto
-  - WebCrypto API
-  - digest
-  - メソッド
-translation_of: Web/API/SubtleCrypto/digest
 ---
 {{APIRef("Web Crypto API")}}{{SecureContext_header}}
 

--- a/files/ja/web/api/subtlecrypto/index.md
+++ b/files/ja/web/api/subtlecrypto/index.md
@@ -1,12 +1,6 @@
 ---
 title: SubtleCrypto
 slug: Web/API/SubtleCrypto
-tags:
-  - API
-  - Interface
-  - Reference
-  - Web Crypto API
-translation_of: Web/API/SubtleCrypto
 ---
 {{APIRef("Web Crypto API")}}
 

--- a/files/ja/web/api/svgelement/index.md
+++ b/files/ja/web/api/svgelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: SVGElement
 slug: Web/API/SVGElement
-tags:
-  - API
-  - Interface
-  - Reference
-  - SVG
-  - SVG DOM
-  - SVGElement
-translation_of: Web/API/SVGElement
 ---
 {{APIRef("SVG")}}
 

--- a/files/ja/web/api/svgevent/index.md
+++ b/files/ja/web/api/svgevent/index.md
@@ -1,11 +1,6 @@
 ---
 title: SVGEvent
 slug: Web/API/SVGEvent
-tags:
-  - API
-  - Reference
-  - SVG
-translation_of: Web/API/SVGEvent
 ---
 {{APIRef("SVG")}}
 

--- a/files/ja/web/api/svgfontelement/index.md
+++ b/files/ja/web/api/svgfontelement/index.md
@@ -1,10 +1,6 @@
 ---
 title: SVGFontElement
 slug: Web/API/SVGFontElement
-tags:
-  - SVG
-  - SVG DOM
-translation_of: Web/API/SVGFontElement
 ---
 {{APIRef("SVG")}}{{deprecated_header}}
 

--- a/files/ja/web/api/svggraphicselement/getbbox/index.md
+++ b/files/ja/web/api/svggraphicselement/getbbox/index.md
@@ -1,15 +1,6 @@
 ---
 title: getBBox()
 slug: Web/API/SVGGraphicsElement/getBBox
-tags:
-  - API
-  - Method
-  - Reference
-  - SVG
-  - SVG DOM
-  - SVGGraphicsElement
-  - メソッド
-translation_of: Web/API/SVGGraphicsElement/getBBox
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/svggraphicselement/index.md
+++ b/files/ja/web/api/svggraphicselement/index.md
@@ -1,13 +1,6 @@
 ---
 title: SVGGraphicsElement
 slug: Web/API/SVGGraphicsElement
-tags:
-  - API
-  - NeedsExample
-  - Reference
-  - SVG
-  - SVG OM
-translation_of: Web/API/SVGGraphicsElement
 ---
 {{APIRef("SVG")}}
 

--- a/files/ja/web/api/svgrect/index.md
+++ b/files/ja/web/api/svgrect/index.md
@@ -1,12 +1,6 @@
 ---
 title: SVGRect
 slug: Web/API/SVGRect
-tags:
-  - API
-  - Reference
-  - SVG
-  - SVG DOM
-translation_of: Web/API/SVGRect
 ---
 {{APIRef("SVG")}}
 

--- a/files/ja/web/api/svgstringlist/index.md
+++ b/files/ja/web/api/svgstringlist/index.md
@@ -1,13 +1,6 @@
 ---
 title: SVGStringList
 slug: Web/API/SVGStringList
-page-type: web-api-interface
-tags:
-  - API
-  - Reference
-  - SVG
-  - SVG DOM
-translation_of: Web/API/SVGStringList
 ---
 {{APIRef("SVG")}}
 

--- a/files/ja/web/api/svgtextelement/index.md
+++ b/files/ja/web/api/svgtextelement/index.md
@@ -1,7 +1,6 @@
 ---
 title: SVGTextElement
 slug: Web/API/SVGTextElement
-translation_of: Web/API/SVGTextElement
 ---
 ## SVGTextElement インタフェース
 

--- a/files/ja/web/api/syncevent/index.md
+++ b/files/ja/web/api/syncevent/index.md
@@ -1,17 +1,6 @@
 ---
 title: SyncEvent
 slug: Web/API/SyncEvent
-tags:
-  - API
-  - Background Sync
-  - Interface
-  - Non-standard
-  - Offline
-  - Reference
-  - ServiceWorker
-  - SyncEvent
-  - Workers
-translation_of: Web/API/SyncEvent
 ---
 {{APIRef("Service Workers API")}} {{Non-standard_header}}
 

--- a/files/ja/web/api/syncevent/lastchance/index.md
+++ b/files/ja/web/api/syncevent/lastchance/index.md
@@ -1,16 +1,6 @@
 ---
 title: SyncEvent.lastChance
 slug: Web/API/SyncEvent/lastChance
-tags:
-  - API
-  - Background Sync
-  - Experimental
-  - Property
-  - Reference
-  - ServiceWorker
-  - SyncEvent
-  - lastChance
-translation_of: Web/API/SyncEvent/lastChance
 ---
 {{SeeCompatTable}}{{APIRef("")}}
 

--- a/files/ja/web/api/syncevent/syncevent/index.md
+++ b/files/ja/web/api/syncevent/syncevent/index.md
@@ -1,15 +1,6 @@
 ---
 title: SyncEvent.SyncEvent()
 slug: Web/API/SyncEvent/SyncEvent
-tags:
-  - API
-  - Background Sync
-  - Constructor
-  - Experimental
-  - Reference
-  - ServiceWorker
-  - SyncEvent
-translation_of: Web/API/SyncEvent/SyncEvent
 ---
 {{APIRef("Service Workers API")}}{{Non-standard_header}}
 

--- a/files/ja/web/api/syncevent/tag/index.md
+++ b/files/ja/web/api/syncevent/tag/index.md
@@ -1,16 +1,6 @@
 ---
 title: SyncEvent.tag
 slug: Web/API/SyncEvent/tag
-tags:
-  - API
-  - Background Sync
-  - Experimental
-  - Property
-  - Reference
-  - ServiceWorker
-  - SyncEvent
-  - tag
-translation_of: Web/API/SyncEvent/tag
 ---
 {{SeeCompatTable}}{{APIRef("")}}
 

--- a/files/ja/web/api/syncmanager/index.md
+++ b/files/ja/web/api/syncmanager/index.md
@@ -1,7 +1,6 @@
 ---
 title: SyncManager
 slug: Web/API/SyncManager
-translation_of: Web/API/SyncManager
 ---
 {{APIRef("Service Workers API")}}{{Non-standard_header}}
 


### PR DESCRIPTION
Part of #7858

`files/ja/web/api/{r-s}*` から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "page-type": 47,
  "tags": 269,
  "browser-compat": 90,
  "translation_of": 272,
  "spec-urls": 1
}
```
