### PR TITLE
remove duplicated frontmatter keys from web/api/{t-v}* (ja)

### DIFF
--- a/files/ja/web/api/taskattributiontiming/containerid/index.md
+++ b/files/ja/web/api/taskattributiontiming/containerid/index.md
@@ -1,14 +1,6 @@
 ---
 title: TaskAttributionTiming.containerId
 slug: Web/API/TaskAttributionTiming/containerId
-tags:
-  - API
-  - Long Tasks API
-  - Performance
-  - Property
-  - Reference
-  - TaskAttributionTiming
-translation_of: Web/API/TaskAttributionTiming/containerId
 ---
 {{SeeCompatTable}}{{APIRef("Long Tasks")}}
 

--- a/files/ja/web/api/taskattributiontiming/containername/index.md
+++ b/files/ja/web/api/taskattributiontiming/containername/index.md
@@ -1,14 +1,6 @@
 ---
 title: TaskAttributionTiming.containerName
 slug: Web/API/TaskAttributionTiming/containerName
-tags:
-  - API
-  - Long Tasks API
-  - Performance
-  - Property
-  - Reference
-  - TaskAttributionTiming
-translation_of: Web/API/TaskAttributionTiming/containerName
 ---
 {{SeeCompatTable}}{{APIRef("Long Tasks")}}
 

--- a/files/ja/web/api/taskattributiontiming/containersrc/index.md
+++ b/files/ja/web/api/taskattributiontiming/containersrc/index.md
@@ -1,14 +1,6 @@
 ---
 title: TaskAttributionTiming.containerSrc
 slug: Web/API/TaskAttributionTiming/containerSrc
-tags:
-  - API
-  - Long Tasks API
-  - Performance
-  - Property
-  - Reference
-  - TaskAttributionTiming
-translation_of: Web/API/TaskAttributionTiming/containerSrc
 ---
 {{SeeCompatTable}}{{APIRef("Long Tasks")}}
 

--- a/files/ja/web/api/taskattributiontiming/containertype/index.md
+++ b/files/ja/web/api/taskattributiontiming/containertype/index.md
@@ -1,14 +1,6 @@
 ---
 title: TaskAttributionTiming.containerType
 slug: Web/API/TaskAttributionTiming/containerType
-tags:
-  - API
-  - Long Tasks API
-  - Performance
-  - Property
-  - Reference
-  - TaskAttributionTiming
-translation_of: Web/API/TaskAttributionTiming/containerType
 ---
 {{SeeCompatTable}}{{APIRef("Long Tasks")}}
 

--- a/files/ja/web/api/taskattributiontiming/index.md
+++ b/files/ja/web/api/taskattributiontiming/index.md
@@ -1,14 +1,6 @@
 ---
 title: TaskAttributionTiming
 slug: Web/API/TaskAttributionTiming
-tags:
-  - API
-  - Experimental
-  - Interface
-  - Long Tasks API
-  - Performance
-  - TaskAttributionTiming
-translation_of: Web/API/TaskAttributionTiming
 ---
 {{SeeCompatTable}}{{APIRef("Long Tasks")}}
 

--- a/files/ja/web/api/text/assignedslot/index.md
+++ b/files/ja/web/api/text/assignedslot/index.md
@@ -1,11 +1,6 @@
 ---
 title: Text.assignedSlot
 slug: Web/API/Text/assignedSlot
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.Text.assignedSlot
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/text/index.md
+++ b/files/ja/web/api/text/index.md
@@ -1,11 +1,6 @@
 ---
 title: Text
 slug: Web/API/Text
-tags:
-  - インターフェイス
-  - リファレンス
-browser-compat: api.Text
-translation_of: Web/API/Text
 ---
 {{ApiRef("DOM")}}
 

--- a/files/ja/web/api/text/splittext/index.md
+++ b/files/ja/web/api/text/splittext/index.md
@@ -1,11 +1,6 @@
 ---
 title: Text.splitText()
 slug: Web/API/Text/splitText
-tags:
-  - メソッド
-  - リファレンス
-browser-compat: api.Text.splitText
-translation_of: Web/API/Text/splitText
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/text/text/index.md
+++ b/files/ja/web/api/text/text/index.md
@@ -1,11 +1,6 @@
 ---
 title: Text()
 slug: Web/API/Text/Text
-tags:
-  - コンストラクター
-  - リファレンス
-browser-compat: api.Text.Text
-translation_of: Web/API/Text/Text
 ---
 {{ APIRef("DOM")}}
 

--- a/files/ja/web/api/text/wholetext/index.md
+++ b/files/ja/web/api/text/wholetext/index.md
@@ -1,12 +1,6 @@
 ---
 title: Text.wholeText
 slug: Web/API/Text/wholeText
-tags:
-  - プロパティ
-  - リファレンス
-  - 読み取り専用
-browser-compat: api.Text.wholeText
-translation_of: Web/API/Text/wholeText
 ---
 {{ apiref("DOM") }}
 

--- a/files/ja/web/api/textdecoder/index.md
+++ b/files/ja/web/api/textdecoder/index.md
@@ -1,15 +1,6 @@
 ---
 title: TextDecoder
 slug: Web/API/TextDecoder
-tags:
-  - API
-  - DOM
-  - Encoding
-  - Experimental
-  - Interface
-  - Reference
-  - TextDecoder
-translation_of: Web/API/TextDecoder
 ---
 {{APIRef("Encoding API")}}
 

--- a/files/ja/web/api/textencoder/encode/index.md
+++ b/files/ja/web/api/textencoder/encode/index.md
@@ -1,15 +1,6 @@
 ---
 title: TextEncode.encode()
 slug: Web/API/TextEncoder/encode
-tags:
-  - API
-  - エンコーディング
-  - メソッド
-  - リファレンス
-  - TextEncoder
-  - encode
-browser-compat: api.TextEncoder.encode
-translation_of: Web/API/TextEncoder/encode
 ---
 {{APIRef("Encoding API")}}
 

--- a/files/ja/web/api/textencoder/encodeinto/index.md
+++ b/files/ja/web/api/textencoder/encodeinto/index.md
@@ -1,15 +1,6 @@
 ---
 title: TextEncoder.encodeInto()
 slug: Web/API/TextEncoder/encodeInto
-tags:
-  - API
-  - 実験的
-  - メソッド
-  - リファレンス
-  - TextEncoder
-  - encodeInto
-browser-compat: api.TextEncoder.encodeInto
-translation_of: Web/API/TextEncoder/encodeInto
 ---
 {{APIRef("Encoding API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/textencoder/encoding/index.md
+++ b/files/ja/web/api/textencoder/encoding/index.md
@@ -1,15 +1,6 @@
 ---
 title: TextEncoder.encoding
 slug: Web/API/TextEncoder/encoding
-tags:
-  - API
-  - エンコーディング
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - TextEncoder
-browser-compat: api.TextEncoder.encoding
-translation_of: Web/API/TextEncoder/encoding
 ---
 {{APIRef("Encoding API")}}
 

--- a/files/ja/web/api/textencoder/index.md
+++ b/files/ja/web/api/textencoder/index.md
@@ -1,15 +1,6 @@
 ---
 title: TextEncoder
 slug: Web/API/TextEncoder
-tags:
-  - API
-  - エンコーディング
-  - 実験的
-  - インターフェイス
-  - リファレンス
-  - TextEncoder
-browser-compat: api.TextEncoder
-translation_of: Web/API/TextEncoder
 ---
 {{APIRef("Encoding API")}}
 

--- a/files/ja/web/api/textencoder/textencoder/index.md
+++ b/files/ja/web/api/textencoder/textencoder/index.md
@@ -1,14 +1,6 @@
 ---
 title: TextEncoder()
 slug: Web/API/TextEncoder/TextEncoder
-tags:
-  - API
-  - コンストラクター
-  - エンコーディング
-  - リファレンス
-  - TextEncoder
-browser-compat: api.TextEncoder.TextEncoder
-translation_of: Web/API/TextEncoder/TextEncoder
 ---
 {{APIRef("Encoding API")}}
 

--- a/files/ja/web/api/texttrack/cuechange_event/index.md
+++ b/files/ja/web/api/texttrack/cuechange_event/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'TextTrack: cuechange イベント'
 slug: Web/API/TextTrack/cuechange_event
-tags:
-  - API
-  - Event
-  - Reference
-  - TextTrack
-  - WebVTT
-  - cuechange
-  - oncuechange
-  - track
-  - イベント
-  - テキストトラック
-  - トラック
-translation_of: Web/API/TextTrack/cuechange_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/texttrack/index.md
+++ b/files/ja/web/api/texttrack/index.md
@@ -1,17 +1,6 @@
 ---
 title: TextTrack
 slug: Web/API/TextTrack
-tags:
-  - API
-  - Interface
-  - Media
-  - Reference
-  - TextTrack
-  - TopicStub
-  - Web
-  - WebVTT
-  - インターフェイス
-translation_of: Web/API/TextTrack
 ---
 {{APIRef("WebVTT")}}
 

--- a/files/ja/web/api/texttrack/mode/index.md
+++ b/files/ja/web/api/texttrack/mode/index.md
@@ -1,15 +1,6 @@
 ---
 title: TextTrack.mode
 slug: Web/API/TextTrack/mode
-tags:
-  - Accessibility
-  - NeedsExample
-  - Property
-  - TextTrack
-  - Web
-  - WebVTT
-  - mode
-translation_of: Web/API/TextTrack/mode
 ---
 {{APIRef("WebVTT")}}
 

--- a/files/ja/web/api/texttrackcue/index.md
+++ b/files/ja/web/api/texttrackcue/index.md
@@ -1,11 +1,6 @@
 ---
 title: TextTrackCue
 slug: Web/API/TextTrackCue
-tags:
-  - API
-  - HTML5
-  - WebVTT
-translation_of: Web/API/TextTrackCue
 ---
 {{APIRef("WebVTT")}}
 

--- a/files/ja/web/api/timeranges/end/index.md
+++ b/files/ja/web/api/timeranges/end/index.md
@@ -1,14 +1,6 @@
 ---
 title: TimeRanges.end()
 slug: Web/API/TimeRanges/end
-tags:
-  - API
-  - HTML DOM
-  - Media
-  - Method
-  - Reference
-  - TimeRanges
-translation_of: Web/API/TimeRanges/end
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/timeranges/index.md
+++ b/files/ja/web/api/timeranges/index.md
@@ -1,15 +1,6 @@
 ---
 title: TimeRanges
 slug: Web/API/TimeRanges
-tags:
-  - API
-  - HTML DOM
-  - Interface
-  - Media
-  - NeedsExample
-  - Reference
-  - TopicStub
-translation_of: Web/API/TimeRanges
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/timeranges/length/index.md
+++ b/files/ja/web/api/timeranges/length/index.md
@@ -1,15 +1,6 @@
 ---
 title: TimeRanges.length
 slug: Web/API/TimeRanges/length
-tags:
-  - API
-  - HTML DOM
-  - Media
-  - Property
-  - Read-only
-  - Reference
-  - TimeRanges
-translation_of: Web/API/TimeRanges/length
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/timeranges/start/index.md
+++ b/files/ja/web/api/timeranges/start/index.md
@@ -1,16 +1,6 @@
 ---
 title: TimeRanges.start()
 slug: Web/API/TimeRanges/start
-page-type: web-api-instance-method
-tags:
-  - API
-  - HTML DOM
-  - Media
-  - Method
-  - Reference
-  - TimeRanges
-browser-compat: api.TimeRanges.start
-translation_of: Web/API/TimeRanges/start
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/touch/clientx/index.md
+++ b/files/ja/web/api/touch/clientx/index.md
@@ -1,14 +1,6 @@
 ---
 title: Touch.clientX
 slug: Web/API/Touch/clientX
-tags:
-  - API
-  - DOM
-  - Property
-  - Read-only
-  - Reference
-  - touch
-translation_of: Web/API/Touch/clientX
 ---
 {{ APIRef("Touch Events") }}
 

--- a/files/ja/web/api/touch/clienty/index.md
+++ b/files/ja/web/api/touch/clienty/index.md
@@ -1,14 +1,6 @@
 ---
 title: Touch.clientY
 slug: Web/API/Touch/clientY
-tags:
-  - API
-  - DOM
-  - Property
-  - Read-only
-  - Reference
-  - touch
-translation_of: Web/API/Touch/clientY
 ---
 {{ APIRef("Touch Events") }}
 

--- a/files/ja/web/api/touch/identifier/index.md
+++ b/files/ja/web/api/touch/identifier/index.md
@@ -1,15 +1,6 @@
 ---
 title: Touch.identifier
 slug: Web/API/Touch/identifier
-tags:
-  - API
-  - DOM
-  - Identifier
-  - Property
-  - Read-only
-  - Reference
-  - touch
-translation_of: Web/API/Touch/identifier
 ---
 {{ APIRef("Touch Events") }}{{SeeCompatTable}}
 

--- a/files/ja/web/api/touch/index.md
+++ b/files/ja/web/api/touch/index.md
@@ -1,14 +1,6 @@
 ---
 title: Touch
 slug: Web/API/Touch
-tags:
-  - API
-  - DOM
-  - Interface
-  - Reference
-  - TouchEvent
-  - touch
-translation_of: Web/API/Touch
 ---
 {{APIRef("Touch Events")}}
 

--- a/files/ja/web/api/touch/screeny/index.md
+++ b/files/ja/web/api/touch/screeny/index.md
@@ -1,13 +1,6 @@
 ---
 title: Touch.screenY
 slug: Web/API/Touch/screenY
-tags:
-  - API
-  - DOM
-  - Mobile
-  - Property
-  - touch
-translation_of: Web/API/Touch/screenY
 ---
 {{ APIRef("Touch Events") }}
 

--- a/files/ja/web/api/touch_events/index.md
+++ b/files/ja/web/api/touch_events/index.md
@@ -1,18 +1,6 @@
 ---
 title: タッチイベント
 slug: Web/API/Touch_events
-tags:
-  - Advanced
-  - DOM
-  - Event
-  - Guide
-  - Mobile
-  - Overview
-  - touch
-  - イベント
-  - タッチ
-  - 概要
-translation_of: Web/API/Touch_events
 ---
 {{DefaultAPISidebar("Touch Events")}}
 

--- a/files/ja/web/api/touchevent/index.md
+++ b/files/ja/web/api/touchevent/index.md
@@ -1,15 +1,6 @@
 ---
 title: TouchEvent
 slug: Web/API/TouchEvent
-tags:
-  - API
-  - DOM
-  - Interface
-  - Reference
-  - TouchEvent
-  - touch
-  - インターフェイス
-translation_of: Web/API/TouchEvent
 ---
 {{APIRef("Touch Events")}}
 

--- a/files/ja/web/api/touchlist/index.md
+++ b/files/ja/web/api/touchlist/index.md
@@ -1,16 +1,6 @@
 ---
 title: TouchList
 slug: Web/API/TouchList
-tags:
-  - API
-  - DOM
-  - DOM Reference
-  - Mobile
-  - Reference
-  - Touch Event
-  - TouchList
-  - touch
-translation_of: Web/API/TouchList
 ---
 {{APIRef("Touch Events")}}
 

--- a/files/ja/web/api/touchlist/length/index.md
+++ b/files/ja/web/api/touchlist/length/index.md
@@ -1,12 +1,6 @@
 ---
 title: TouchList.length
 slug: Web/API/TouchList/length
-tags:
-  - DOM
-  - Gecko DOM Reference
-  - Mobile
-  - touch
-translation_of: Web/API/TouchList/length
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/trackevent/index.md
+++ b/files/ja/web/api/trackevent/index.md
@@ -1,16 +1,6 @@
 ---
 title: TrackEvent
 slug: Web/API/TrackEvent
-tags:
-  - API
-  - Audio
-  - HTML DOM
-  - Interface
-  - Media
-  - Reference
-  - TrackEvent
-  - Video
-translation_of: Web/API/TrackEvent
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/trackevent/track/index.md
+++ b/files/ja/web/api/trackevent/track/index.md
@@ -1,19 +1,6 @@
 ---
 title: TrackEvent.track
 slug: Web/API/TrackEvent/track
-tags:
-  - API
-  - Audio
-  - Event
-  - HTML DOM
-  - Media
-  - Property
-  - Read-only
-  - Reference
-  - TrackEvent
-  - Video
-  - track
-translation_of: Web/API/TrackEvent/track
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/trackevent/trackevent/index.md
+++ b/files/ja/web/api/trackevent/trackevent/index.md
@@ -1,17 +1,6 @@
 ---
 title: TrackEvent()
 slug: Web/API/TrackEvent/TrackEvent
-tags:
-  - API
-  - Audio
-  - Constructor
-  - HTML DOM
-  - Media
-  - Reference
-  - TrackEvent
-  - Tracks
-  - Video
-translation_of: Web/API/TrackEvent/TrackEvent
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/transformstream/index.md
+++ b/files/ja/web/api/transformstream/index.md
@@ -1,14 +1,6 @@
 ---
 title: TransformStream
 slug: Web/API/TransformStream
-tags:
-  - API
-  - Interface
-  - Streams API
-  - TransformStream
-  - Web
-  - インターフェイス
-translation_of: Web/API/TransformStream
 ---
 {{APIRef("Media Capture and Streams")}}
 

--- a/files/ja/web/api/transitionevent/index.md
+++ b/files/ja/web/api/transitionevent/index.md
@@ -1,14 +1,6 @@
 ---
 title: TransitionEvent
 slug: Web/API/TransitionEvent
-tags:
-  - API
-  - CSS
-  - CSS3 Transitions
-  - CSSOM
-  - Experimental
-  - Reference
-translation_of: Web/API/TransitionEvent
 ---
 {{APIRef("CSSOM")}} {{SeeCompatTable}}
 

--- a/files/ja/web/api/transitionevent/pseudoelement/index.md
+++ b/files/ja/web/api/transitionevent/pseudoelement/index.md
@@ -1,16 +1,6 @@
 ---
 title: TransitionEvent.pseudoElement
 slug: Web/API/TransitionEvent/pseudoElement
-tags:
-  - API
-  - CSS
-  - CSS3 Transitions
-  - CSSOM
-  - Experimental
-  - Property
-  - Reference
-  - TransitionEvent
-translation_of: Web/API/TransitionEvent/pseudoElement
 ---
 {{ apiref("CSSOM") }} {{SeeCompatTable}}
 

--- a/files/ja/web/api/treewalker/index.md
+++ b/files/ja/web/api/treewalker/index.md
@@ -1,12 +1,6 @@
 ---
 title: TreeWalker
 slug: Web/API/TreeWalker
-page-type: web-api-interface
-tags:
-  - API
-  - DOM
-browser-compat: api.TreeWalker
-translation_of: Web/API/TreeWalker
 ---
 {{ APIRef("DOM") }}
 

--- a/files/ja/web/api/treewalker/root/index.md
+++ b/files/ja/web/api/treewalker/root/index.md
@@ -1,14 +1,6 @@
 ---
 title: TreeWalker.root
 slug: Web/API/TreeWalker/root
-page-type: web-api-instance-property
-tags:
-  - API
-  - DOM
-  - Property
-  - TreeWalker
-browser-compat: api.TreeWalker.root
-translation_of: Web/API/TreeWalker/root
 ---
 {{ APIRef("DOM") }}
 

--- a/files/ja/web/api/uievent/detail/index.md
+++ b/files/ja/web/api/uievent/detail/index.md
@@ -1,13 +1,6 @@
 ---
 title: UIEvent.detail
 slug: Web/API/UIEvent/detail
-tags:
-  - API
-  - DOM
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.UIEvent.detail
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/uievent/index.md
+++ b/files/ja/web/api/uievent/index.md
@@ -1,16 +1,6 @@
 ---
 title: UIEvent
 slug: Web/API/UIEvent
-tags:
-  - API
-  - DOM
-  - Event
-  - インターフェイス
-  - リファレンス
-  - UIEvent
-  - イベント
-browser-compat: api.UIEvent
-translation_of: Web/API/UIEvent
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/uievent/inituievent/index.md
+++ b/files/ja/web/api/uievent/inituievent/index.md
@@ -1,14 +1,6 @@
 ---
 title: UIEvent.initUIEvent()
 slug: Web/API/UIEvent/initUIEvent
-tags:
-  - API
-  - DOM
-  - Deprecated
-  - Event
-  - Method
-  - UIEvent
-browser-compat: api.UIEvent.initUIEvent
 ---
 {{APIRef("DOM Events")}} {{deprecated_header}}
 

--- a/files/ja/web/api/uievent/sourcecapabilities/index.md
+++ b/files/ja/web/api/uievent/sourcecapabilities/index.md
@@ -1,13 +1,6 @@
 ---
 title: UIEvent.sourceCapabilities
 slug: Web/API/UIEvent/sourceCapabilities
-tags:
-  - API
-  - DOM
-  - プロパティ
-  - リファレンス
-  - UIEvent
-browser-compat: api.UIEvent.sourceCapabilities
 ---
 {{SeeCompatTable}}{{APIRef()}}
 

--- a/files/ja/web/api/uievent/uievent/index.md
+++ b/files/ja/web/api/uievent/uievent/index.md
@@ -1,13 +1,6 @@
 ---
 title: UIEvent()
 slug: Web/API/UIEvent/UIEvent
-tags:
-  - API
-  - コンストラクター
-  - リファレンス
-  - UIEvent
-browser-compat: api.UIEvent.UIEvent
-translation_of: Web/API/UIEvent/UIEvent
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/uievent/view/index.md
+++ b/files/ja/web/api/uievent/view/index.md
@@ -1,16 +1,6 @@
 ---
 title: UIEvent.view
 slug: Web/API/UIEvent/view
-tags:
-  - API
-  - DOM
-  - NeedsLiveExample
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - UIEvent
-browser-compat: api.UIEvent.view
-translation_of: Web/API/UIEvent/view
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/uievent/which/index.md
+++ b/files/ja/web/api/uievent/which/index.md
@@ -1,15 +1,6 @@
 ---
 title: UIEvent.which
 slug: Web/API/UIEvent/which
-tags:
-  - API
-  - DOM
-  - UIEvent
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-browser-compat: api.UIEvent.which
-translation_of: Web/API/UIEvent/which
 original_slug: Web/API/MouseEvent/which
 ---
 {{ APIRef("DOM Events") }} {{Non-standard_header}}

--- a/files/ja/web/api/url/createobjecturl/index.md
+++ b/files/ja/web/api/url/createobjecturl/index.md
@@ -1,15 +1,6 @@
 ---
 title: URL.createObjectURL()
 slug: Web/API/URL/createObjectURL
-tags:
-  - API
-  - Blob
-  - DOM
-  - Reference
-  - URL
-  - URL API
-  - createObjectURL
-translation_of: Web/API/URL/createObjectURL
 ---
 **`URL.createObjectURL()`** 静的メソッドは、引数で指定されたオブジェクトを表す URL を含む {{domxref("DOMString")}} を生成します。 URL の寿命は、それを作成したウィンドウ内の {{domxref("document")}} と結び付けられています。 新しいオブジェクト URL は、指定された {{domxref("File")}} オブジェクトか {{domxref("Blob")}} オブジェクトを表します。
 

--- a/files/ja/web/api/url/hash/index.md
+++ b/files/ja/web/api/url/hash/index.md
@@ -1,13 +1,6 @@
 ---
 title: URL.hash
 slug: Web/API/URL/hash
-tags:
-  - API
-  - Hash
-  - Property
-  - Reference
-  - URL
-translation_of: Web/API/URL/hash
 ---
 {{ APIRef("URL API") }}
 

--- a/files/ja/web/api/url/host/index.md
+++ b/files/ja/web/api/url/host/index.md
@@ -1,13 +1,6 @@
 ---
 title: URL.host
 slug: Web/API/URL/host
-tags:
-  - API
-  - Host
-  - Property
-  - Reference
-  - URL
-translation_of: Web/API/URL/host
 ---
 {{ApiRef("URL API")}}
 

--- a/files/ja/web/api/url/hostname/index.md
+++ b/files/ja/web/api/url/hostname/index.md
@@ -1,13 +1,6 @@
 ---
 title: URL.hostname
 slug: Web/API/URL/hostname
-tags:
-  - API
-  - Property
-  - Reference
-  - URL
-  - hostname
-translation_of: Web/API/URL/hostname
 ---
 {{ApiRef("URL API")}}
 

--- a/files/ja/web/api/url/href/index.md
+++ b/files/ja/web/api/url/href/index.md
@@ -1,13 +1,6 @@
 ---
 title: URL.href
 slug: Web/API/URL/href
-tags:
-  - API
-  - Property
-  - Reference
-  - URL
-  - href
-translation_of: Web/API/URL/href
 ---
 {{ApiRef("URL API")}}
 

--- a/files/ja/web/api/url/index.md
+++ b/files/ja/web/api/url/index.md
@@ -1,21 +1,6 @@
 ---
 title: URL
 slug: Web/API/URL
-tags:
-  - API
-  - Address
-  - Domain
-  - Interface
-  - Location
-  - Networking
-  - Reference
-  - URI
-  - URL API
-  - Web
-  - hostname
-  - href
-  - origin
-translation_of: Web/API/URL
 ---
 {{APIRef("URL API")}}
 

--- a/files/ja/web/api/url/origin/index.md
+++ b/files/ja/web/api/url/origin/index.md
@@ -1,15 +1,6 @@
 ---
 title: URL.origin
 slug: Web/API/URL/origin
-tags:
-  - API
-  - Property
-  - Read-only
-  - Reference
-  - URL
-  - URL API
-  - origin
-translation_of: Web/API/URL/origin
 ---
 {{APIRef("URL API")}}
 

--- a/files/ja/web/api/url/password/index.md
+++ b/files/ja/web/api/url/password/index.md
@@ -1,13 +1,6 @@
 ---
 title: URL.password
 slug: Web/API/URL/password
-tags:
-  - API
-  - Property
-  - Reference
-  - URL
-  - password
-translation_of: Web/API/URL/password
 ---
 {{ApiRef("URL API")}}
 

--- a/files/ja/web/api/url/pathname/index.md
+++ b/files/ja/web/api/url/pathname/index.md
@@ -1,13 +1,6 @@
 ---
 title: URL.pathname
 slug: Web/API/URL/pathname
-tags:
-  - API
-  - Property
-  - Reference
-  - URL
-  - pathname
-translation_of: Web/API/URL/pathname
 ---
 {{ApiRef("URL API")}}
 

--- a/files/ja/web/api/url/port/index.md
+++ b/files/ja/web/api/url/port/index.md
@@ -1,13 +1,6 @@
 ---
 title: URL.port
 slug: Web/API/URL/port
-tags:
-  - API
-  - Property
-  - Reference
-  - URL
-  - port
-translation_of: Web/API/URL/port
 ---
 {{ApiRef("URL API")}}
 

--- a/files/ja/web/api/url/protocol/index.md
+++ b/files/ja/web/api/url/protocol/index.md
@@ -1,13 +1,6 @@
 ---
 title: URL.protocol
 slug: Web/API/URL/protocol
-tags:
-  - API
-  - Property
-  - Protocol
-  - Reference
-  - URL
-translation_of: Web/API/URL/protocol
 ---
 {{ApiRef("URL API")}}
 

--- a/files/ja/web/api/url/revokeobjecturl/index.md
+++ b/files/ja/web/api/url/revokeobjecturl/index.md
@@ -1,14 +1,6 @@
 ---
 title: URL.revokeObjectURL()
 slug: Web/API/URL/revokeObjectURL
-tags:
-  - API
-  - DOM
-  - Method
-  - URL
-  - URL API
-  - revokeObjectURL
-translation_of: Web/API/URL/revokeObjectURL
 ---
 {{ApiRef("URL")}}
 

--- a/files/ja/web/api/url/search/index.md
+++ b/files/ja/web/api/url/search/index.md
@@ -1,13 +1,6 @@
 ---
 title: URL.search
 slug: Web/API/URL/search
-tags:
-  - API
-  - Property
-  - Reference
-  - Search
-  - URL
-translation_of: Web/API/URL/search
 ---
 {{ApiRef("URL API")}}
 

--- a/files/ja/web/api/url/searchparams/index.md
+++ b/files/ja/web/api/url/searchparams/index.md
@@ -1,16 +1,6 @@
 ---
 title: URL.searchParams
 slug: Web/API/URL/searchParams
-tags:
-  - API
-  - Property
-  - Read-only
-  - Reference
-  - URL
-  - URLSearchParameter
-  - URLSearchParams
-  - searchParams
-translation_of: Web/API/URL/searchParams
 ---
 {{APIRef("URL API")}}
 

--- a/files/ja/web/api/url/tojson/index.md
+++ b/files/ja/web/api/url/tojson/index.md
@@ -1,14 +1,6 @@
 ---
 title: URL.toJSON()
 slug: Web/API/URL/toJSON
-tags:
-  - API
-  - Method
-  - Reference
-  - URL
-  - toJSON
-  - toJSON()
-translation_of: Web/API/URL/toJSON
 ---
 {{APIRef("URL API")}}
 

--- a/files/ja/web/api/url/tostring/index.md
+++ b/files/ja/web/api/url/tostring/index.md
@@ -1,14 +1,6 @@
 ---
 title: URL.toString()
 slug: Web/API/URL/toString
-tags:
-  - API
-  - Method
-  - Reference
-  - Stringifier
-  - URL
-  - toString()
-translation_of: Web/API/URL/toString
 ---
 {{ApiRef("URL API")}}
 

--- a/files/ja/web/api/url/url/index.md
+++ b/files/ja/web/api/url/url/index.md
@@ -1,13 +1,6 @@
 ---
 title: URL()
 slug: Web/API/URL/URL
-tags:
-  - API
-  - Constructor
-  - Reference
-  - URL
-  - URL API
-translation_of: Web/API/URL/URL
 ---
 {{APIRef("URL API")}}
 

--- a/files/ja/web/api/url/username/index.md
+++ b/files/ja/web/api/url/username/index.md
@@ -1,13 +1,6 @@
 ---
 title: URL.username
 slug: Web/API/URL/username
-tags:
-  - API
-  - Property
-  - Reference
-  - URL
-  - username
-translation_of: Web/API/URL/username
 ---
 {{ApiRef("URL API")}}
 

--- a/files/ja/web/api/url_api/index.md
+++ b/files/ja/web/api/url_api/index.md
@@ -1,19 +1,6 @@
 ---
 title: URL API
 slug: Web/API/URL_API
-tags:
-  - API
-  - Address
-  - Domain
-  - Forms
-  - Host
-  - IP
-  - Overview
-  - URL
-  - URL API
-  - Web
-  - hostname
-translation_of: Web/API/URL_API
 ---
 {{DefaultAPISidebar("URL API")}}
 

--- a/files/ja/web/api/urlsearchparams/append/index.md
+++ b/files/ja/web/api/urlsearchparams/append/index.md
@@ -1,13 +1,6 @@
 ---
 title: URLSearchParams.append()
 slug: Web/API/URLSearchParams/append
-tags:
-  - API
-  - Append
-  - Method
-  - URL API
-  - URLSearchParams
-translation_of: Web/API/URLSearchParams/append
 ---
 {{ApiRef("URL API")}}
 

--- a/files/ja/web/api/urlsearchparams/delete/index.md
+++ b/files/ja/web/api/urlsearchparams/delete/index.md
@@ -1,13 +1,6 @@
 ---
 title: URLSearchParams.delete()
 slug: Web/API/URLSearchParams/delete
-tags:
-  - API
-  - Method
-  - URL API
-  - URLSearchParams
-  - delete
-translation_of: Web/API/URLSearchParams/delete
 ---
 {{ApiRef("URL API")}}
 

--- a/files/ja/web/api/urlsearchparams/entries/index.md
+++ b/files/ja/web/api/urlsearchparams/entries/index.md
@@ -1,14 +1,6 @@
 ---
 title: URLSearchParams.entries()
 slug: Web/API/URLSearchParams/entries
-tags:
-  - API
-  - Entries
-  - Method
-  - Reference
-  - URL API
-  - URLSearchParams
-translation_of: Web/API/URLSearchParams/entries
 ---
 {{APIRef("URL API")}}
 

--- a/files/ja/web/api/urlsearchparams/foreach/index.md
+++ b/files/ja/web/api/urlsearchparams/foreach/index.md
@@ -1,14 +1,6 @@
 ---
 title: URLSearchParams.forEach()
 slug: Web/API/URLSearchParams/forEach
-tags:
-  - API
-  - Method
-  - Reference
-  - URL API
-  - URLSearchParams
-  - forEach
-translation_of: Web/API/URLSearchParams/forEach
 ---
 {{APIRef("URL API")}}
 

--- a/files/ja/web/api/urlsearchparams/get/index.md
+++ b/files/ja/web/api/urlsearchparams/get/index.md
@@ -1,13 +1,6 @@
 ---
 title: URLSearchParams.get()
 slug: Web/API/URLSearchParams/get
-tags:
-  - API
-  - Method
-  - URL API
-  - URLSearchParams
-  - get
-translation_of: Web/API/URLSearchParams/get
 ---
 {{ApiRef("URL API")}}
 

--- a/files/ja/web/api/urlsearchparams/getall/index.md
+++ b/files/ja/web/api/urlsearchparams/getall/index.md
@@ -1,13 +1,6 @@
 ---
 title: URLSearchParams.getAll()
 slug: Web/API/URLSearchParams/getAll
-tags:
-  - API
-  - Method
-  - URL API
-  - URLSearchParams
-  - getAll
-translation_of: Web/API/URLSearchParams/getAll
 ---
 {{ApiRef("URL API")}}
 

--- a/files/ja/web/api/urlsearchparams/has/index.md
+++ b/files/ja/web/api/urlsearchparams/has/index.md
@@ -1,13 +1,6 @@
 ---
 title: URLSearchParams.has()
 slug: Web/API/URLSearchParams/has
-tags:
-  - API
-  - Method
-  - URL API
-  - URLSearchParams
-  - has
-translation_of: Web/API/URLSearchParams/has
 ---
 {{ApiRef("URL API")}}
 

--- a/files/ja/web/api/urlsearchparams/index.md
+++ b/files/ja/web/api/urlsearchparams/index.md
@@ -1,14 +1,6 @@
 ---
 title: URLSearchParams
 slug: Web/API/URLSearchParams
-tags:
-  - API
-  - Interface
-  - Landing
-  - Reference
-  - URL API
-  - URLSearchParams
-translation_of: Web/API/URLSearchParams
 ---
 {{ApiRef("URL API")}}
 

--- a/files/ja/web/api/urlsearchparams/keys/index.md
+++ b/files/ja/web/api/urlsearchparams/keys/index.md
@@ -1,13 +1,6 @@
 ---
 title: URLSearchParams.keys()
 slug: Web/API/URLSearchParams/keys
-tags:
-  - API
-  - Method
-  - Reference
-  - URL API
-  - URLSearchParams
-translation_of: Web/API/URLSearchParams/keys
 ---
 {{APIRef("URL API")}}
 

--- a/files/ja/web/api/urlsearchparams/set/index.md
+++ b/files/ja/web/api/urlsearchparams/set/index.md
@@ -1,13 +1,6 @@
 ---
 title: URLSearchParams.set()
 slug: Web/API/URLSearchParams/set
-tags:
-  - API
-  - Method
-  - URL API
-  - URLSearchParams
-  - set
-translation_of: Web/API/URLSearchParams/set
 ---
 {{ApiRef("URL API")}}
 

--- a/files/ja/web/api/urlsearchparams/sort/index.md
+++ b/files/ja/web/api/urlsearchparams/sort/index.md
@@ -1,14 +1,6 @@
 ---
 title: URLSearchParams.sort()
 slug: Web/API/URLSearchParams/sort
-tags:
-  - API
-  - Method
-  - Reference
-  - URL API
-  - URLSearchParams
-  - sort
-translation_of: Web/API/URLSearchParams/sort
 ---
 {{APIRef("URL API")}}
 

--- a/files/ja/web/api/urlsearchparams/tostring/index.md
+++ b/files/ja/web/api/urlsearchparams/tostring/index.md
@@ -1,13 +1,6 @@
 ---
 title: URLSearchParams.toString()
 slug: Web/API/URLSearchParams/toString
-tags:
-  - API
-  - Method
-  - URL API
-  - URLSearchParams
-  - toString
-translation_of: Web/API/URLSearchParams/toString
 ---
 {{ApiRef("URL API")}}
 

--- a/files/ja/web/api/urlsearchparams/urlsearchparams/index.md
+++ b/files/ja/web/api/urlsearchparams/urlsearchparams/index.md
@@ -1,13 +1,6 @@
 ---
 title: URLSearchParams()
 slug: Web/API/URLSearchParams/URLSearchParams
-tags:
-  - API
-  - Constructor
-  - Reference
-  - URL API
-  - URLSearchParams
-translation_of: Web/API/URLSearchParams/URLSearchParams
 ---
 {{ApiRef("URL API")}}
 

--- a/files/ja/web/api/urlsearchparams/values/index.md
+++ b/files/ja/web/api/urlsearchparams/values/index.md
@@ -1,14 +1,6 @@
 ---
 title: URLSearchParams.values()
 slug: Web/API/URLSearchParams/values
-tags:
-  - API
-  - Iterator
-  - Method
-  - Reference
-  - URL API
-  - URLSearchParams
-translation_of: Web/API/URLSearchParams/values
 ---
 {{APIRef("URL API")}}
 

--- a/files/ja/web/api/user_timing_api/index.md
+++ b/files/ja/web/api/user_timing_api/index.md
@@ -1,7 +1,6 @@
 ---
 title: User Timing API
 slug: Web/API/User_Timing_API
-translation_of: Web/API/User_Timing_API
 ---
 {{DefaultAPISidebar("User Timing API")}}
 

--- a/files/ja/web/api/userproximityevent/index.md
+++ b/files/ja/web/api/userproximityevent/index.md
@@ -1,12 +1,6 @@
 ---
 title: UserProximityEvent
 slug: Web/API/UserProximityEvent
-tags:
-  - API
-  - Experimental
-  - Interface
-  - Proximity Events
-translation_of: Web/API/UserProximityEvent
 ---
 {{APIRef("Proximity Events")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/validitystate/badinput/index.md
+++ b/files/ja/web/api/validitystate/badinput/index.md
@@ -1,14 +1,6 @@
 ---
 title: ValidityState.badInput
 slug: Web/API/ValidityState/badInput
-tags:
-  - API
-  - 制約検証 API
-  - HTML DOM
-  - プロパティ
-  - 読み取り専用
-  - ValidityState
-translation_of: Web/API/ValidityState/badInput
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/validitystate/index.md
+++ b/files/ja/web/api/validitystate/index.md
@@ -1,14 +1,6 @@
 ---
 title: ValidityState
 slug: Web/API/ValidityState
-tags:
-  - API
-  - 制約検証 API
-  - フォーム
-  - HTML DOM
-  - インターフェイス
-browser-compat: api.ValidityState
-translation_of: Web/API/ValidityState
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/validitystate/patternmismatch/index.md
+++ b/files/ja/web/api/validitystate/patternmismatch/index.md
@@ -1,14 +1,6 @@
 ---
 title: ValidityState.patternMismatch
 slug: Web/API/ValidityState/patternMismatch
-tags:
-  - API
-  - 制約検証 API
-  - DOM
-  - プロパティ
-  - リファレンス
-browser-compat: api.ValidityState.patternMismatch
-translation_of: Web/API/ValidityState
 ---
 **`patternMismatch`** は **[`ValidityState`](/ja/docs/Web/API/ValidityState)** オブジェクトの読み取り専用プロパティで、 {{HTMLElement("input")}} 要素の値がユーザーによって編集された後で、その要素の [`pattern`](/ja/docs/Web/HTML/Attributes/pattern) 属性で設定された制約に適合するかどうかを示します。
 

--- a/files/ja/web/api/validitystate/rangeoverflow/index.md
+++ b/files/ja/web/api/validitystate/rangeoverflow/index.md
@@ -1,14 +1,6 @@
 ---
 title: ValidityState.rangeOverflow
 slug: Web/API/ValidityState/rangeOverflow
-tags:
-  - API
-  - 制約検証 API
-  - DOM
-  - プロパティ
-  - リファレンス
-browser-compat: api.ValidityState.rangeOverflow
-translation_of: Web/API/ValidityState/rangeOverflow
 ---
 **`rangeOverflow`** は **[`ValidityState`](/ja/docs/Web/API/ValidityState)** オブジェクトの読み取り専用プロパティで、 {{HTMLElement("input")}} の値がユーザーに変更された後、その要素の [`max`](/ja/docs/Web/HTML/Attributes/max) 属性に設定された制約に適合しないことを示します。
 

--- a/files/ja/web/api/validitystate/rangeunderflow/index.md
+++ b/files/ja/web/api/validitystate/rangeunderflow/index.md
@@ -1,14 +1,6 @@
 ---
 title: ValidityState.rangeUnderflow
 slug: Web/API/ValidityState/rangeUnderflow
-tags:
-  - API
-  - 制約検証 API
-  - DOM
-  - プロパティ
-  - リファレンス
-browser-compat: api.ValidityState.rangeUnderflow
-translation_of: Web/API/ValidityState/rangeUnderflow
 ---
 **`rangeUnderflow`** は **[`ValidityState`](/ja/docs/Web/API/ValidityState)** オブジェクトの読み取り専用プロパティで、 {{HTMLElement("input")}} の値がユーザーに変更された後、その要素の [`min`](/ja/docs/Web/HTML/Attributes/min) 属性に設定された制約に適合しないことを示します。
 

--- a/files/ja/web/api/validitystate/stepmismatch/index.md
+++ b/files/ja/web/api/validitystate/stepmismatch/index.md
@@ -1,14 +1,6 @@
 ---
 title: ValidityState.stepMismatch
 slug: Web/API/ValidityState/stepMismatch
-tags:
-  - API
-  - 制約検証 API
-  - DOM
-  - プロパティ
-  - リファレンス
-browser-compat: api.ValidityState.stepMismatch
-translation_of: Web/API/ValidityState/stepMismatch
 ---
 **`stepMismatch`** は **[`ValidityState`](/ja/docs/Web/API/ValidityState)** オブジェクトの読み取り専用プロパティで、 {{HTMLElement("input")}} の値がユーザーに変更された後、その要素の `step` 属性に設定された制約に適合しないことを示します。
 

--- a/files/ja/web/api/validitystate/toolong/index.md
+++ b/files/ja/web/api/validitystate/toolong/index.md
@@ -1,15 +1,6 @@
 ---
 title: ValidityState.tooLong
 slug: Web/API/ValidityState/tooLong
-tags:
-  - API
-  - 制約検証 API
-  - DOM
-  - NeedsExample
-  - プロパティ
-  - リファレンス
-browser-compat: api.ValidityState.tooLong
-translation_of: Web/API/ValidityState/tooLong
 ---
 
 **`tooLong`** は **[`ValidityState`](/ja/docs/Web/API/ValidityState)** オブジェクトの読み取り専用のプロパティで、 {{HTMLElement("input")}} や {{HTMLElement("textarea")}} の値がユーザーに変更された後、その要素の [`maxlength`](/ja/docs/Web/HTML/Attributes/maxlength) 属性で設定された最大コード単位長を超えているかどうかを示します。

--- a/files/ja/web/api/validitystate/tooshort/index.md
+++ b/files/ja/web/api/validitystate/tooshort/index.md
@@ -1,7 +1,6 @@
 ---
 title: ValidityState.tooShort
 slug: Web/API/ValidityState/tooShort
-browser-compat: api.ValidityState.tooShort
 ---
 **`tooShort`** は **[`ValidityState`](/ja/docs/Web/API/ValidityState)** オブジェクトの読み取り専用プロパティで、 {{HTMLElement("input")}}, {{HTMLElement("button")}}, {{HTMLElement("select")}}, {{HTMLElement("output")}}, {{HTMLElement("fieldset")}}, {{HTMLElement("textarea")}} の何れかの値がユーザーによって変更された後、要素の `minlength` 属性で指定されたコード単位長よりも短くなったことを示します。
 

--- a/files/ja/web/api/validitystate/typemismatch/index.md
+++ b/files/ja/web/api/validitystate/typemismatch/index.md
@@ -1,13 +1,6 @@
 ---
 title: ValidityState.typeMismatch
 slug: Web/API/ValidityState/typeMismatch
-tags:
-  - API
-  - 制約検証 API
-  - DOM
-  - プロパティ
-  - リファレンス
-browser-compat: api.ValidityState.typeMismatch
 ---
 **`typeMismatch`** は **[`ValidityState`](/ja/docs/Web/API/ValidityState)** オブジェクトの読み取り専用プロパティで、 {{HTMLElement("input")}} の値がユーザーによって変更された後、その要素の [`type`](/ja/docs/Web/HTML/Element/input#input_types) 属性で設定された制約に適合していないことを示します。
 

--- a/files/ja/web/api/vibration_api/index.md
+++ b/files/ja/web/api/vibration_api/index.md
@@ -1,12 +1,6 @@
 ---
 title: Vibration API
 slug: Web/API/Vibration_API
-tags:
-  - API
-  - Beginner
-  - Mobile
-  - Vibration
-translation_of: Web/API/Vibration_API
 original_slug: Web/Guide/API/Vibration
 ---
 {{DefaultAPISidebar("Vibration API")}}

--- a/files/ja/web/api/videotrack/id/index.md
+++ b/files/ja/web/api/videotrack/id/index.md
@@ -1,20 +1,6 @@
 ---
 title: VideoTrack.id
 slug: Web/API/VideoTrack/id
-tags:
-  - API
-  - HTML DOM
-  - Interface
-  - Media
-  - Property
-  - Read-only
-  - Reference
-  - Video
-  - Video Track
-  - VideoTrack
-  - id
-  - track
-translation_of: Web/API/VideoTrack/id
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/videotrack/index.md
+++ b/files/ja/web/api/videotrack/index.md
@@ -1,16 +1,6 @@
 ---
 title: VideoTrack
 slug: Web/API/VideoTrack
-tags:
-  - HTML
-  - HTML DOM
-  - Interface
-  - Media
-  - Reference
-  - Video
-  - VideoTrack
-  - track
-translation_of: Web/API/VideoTrack
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/videotrack/kind/index.md
+++ b/files/ja/web/api/videotrack/kind/index.md
@@ -1,19 +1,6 @@
 ---
 title: VideoTrack.kind
 slug: Web/API/VideoTrack/kind
-tags:
-  - API
-  - HTML DOM
-  - Media
-  - Property
-  - Read-only
-  - Reference
-  - Video
-  - Video Track
-  - VideoTrack
-  - id
-  - track
-translation_of: Web/API/VideoTrack/kind
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/videotrack/label/index.md
+++ b/files/ja/web/api/videotrack/label/index.md
@@ -1,20 +1,6 @@
 ---
 title: VideoTrack.label
 slug: Web/API/VideoTrack/label
-tags:
-  - API
-  - HTML DOM
-  - Media
-  - Property
-  - Read-only
-  - Reference
-  - Video
-  - Video Track
-  - VideoTrack
-  - label
-  - metadata
-  - track
-translation_of: Web/API/VideoTrack/label
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/videotrack/language/index.md
+++ b/files/ja/web/api/videotrack/language/index.md
@@ -1,19 +1,6 @@
 ---
 title: Videotrack.language
 slug: Web/API/VideoTrack/language
-tags:
-  - API
-  - HTML DOM
-  - Language
-  - Localization
-  - Media
-  - Property
-  - Read-only
-  - Reference
-  - Video
-  - VideoTrack
-  - track
-translation_of: Web/API/VideoTrack/language
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/videotrack/selected/index.md
+++ b/files/ja/web/api/videotrack/selected/index.md
@@ -1,18 +1,6 @@
 ---
 title: VideoTrack.selected
 slug: Web/API/VideoTrack/selected
-tags:
-  - HTML DOM
-  - Media
-  - Media Controls
-  - Media Track
-  - Property
-  - Reference
-  - Video
-  - VideoTrack
-  - selected
-  - track
-translation_of: Web/API/VideoTrack/selected
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/videotrack/sourcebuffer/index.md
+++ b/files/ja/web/api/videotrack/sourcebuffer/index.md
@@ -1,20 +1,6 @@
 ---
 title: VideoTrack.sourceBuffer
 slug: Web/API/VideoTrack/sourceBuffer
-tags:
-  - API
-  - HTML DOM
-  - MSE
-  - Media
-  - Media Source Extensions
-  - Property
-  - Read-only
-  - Reference
-  - SourceBuffer
-  - Video
-  - VideoTrack
-  - track
-translation_of: Web/API/VideoTrack/sourceBuffer
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/videotracklist/addtrack_event/index.md
+++ b/files/ja/web/api/videotracklist/addtrack_event/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'VideoTrackList: addtrack イベント'
 slug: Web/API/VideoTrackList/addtrack_event
-tags:
-  - API
-  - Reference
-  - addTrack
-  - events
-translation_of: Web/API/VideoTrackList/addtrack_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/videotracklist/change_event/index.md
+++ b/files/ja/web/api/videotracklist/change_event/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'VideoTrackList: change イベント'
 slug: Web/API/VideoTrackList/change_event
-tags:
-  - API
-  - Change
-  - Reference
-  - events
-translation_of: Web/API/VideoTrackList/change_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/videotracklist/gettrackbyid/index.md
+++ b/files/ja/web/api/videotracklist/gettrackbyid/index.md
@@ -1,21 +1,6 @@
 ---
 title: Video​Track​List​.get​Track​ById
 slug: Web/API/VideoTrackList/getTrackById
-tags:
-  - API
-  - HTML DOM
-  - Media
-  - Method
-  - Reference
-  - Track ID
-  - Track List
-  - Tracks
-  - Video
-  - VideoTrackList
-  - getTrackById
-  - id
-  - track
-translation_of: Web/API/VideoTrackList/getTrackById
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/videotracklist/index.md
+++ b/files/ja/web/api/videotracklist/index.md
@@ -1,18 +1,6 @@
 ---
 title: VideoTrackList
 slug: Web/API/VideoTrackList
-tags:
-  - API
-  - HTML DOM
-  - Interface
-  - Media
-  - Reference
-  - Track List
-  - Tracks
-  - Video
-  - VideoTrackList
-  - list
-translation_of: Web/API/VideoTrackList
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/videotracklist/length/index.md
+++ b/files/ja/web/api/videotracklist/length/index.md
@@ -1,19 +1,6 @@
 ---
 title: VideoTrackList.length
 slug: Web/API/VideoTrackList/length
-tags:
-  - API
-  - HTML DOM
-  - Media
-  - Property
-  - Read-only
-  - Reference
-  - Video
-  - VideoTrackList
-  - length
-  - list
-  - track
-translation_of: Web/API/VideoTrackList/length
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/videotracklist/removetrack_event/index.md
+++ b/files/ja/web/api/videotracklist/removetrack_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'VideoTrackList: removetrack イベント'
 slug: Web/API/VideoTrackList/removetrack_event
-tags:
-  - API
-  - Media Streams API
-  - MediaStreamTrackEvent
-  - Reference
-  - Removing Tracks
-  - events
-  - removeTrack
-translation_of: Web/API/VideoTrackList/removetrack_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/videotracklist/selectedindex/index.md
+++ b/files/ja/web/api/videotracklist/selectedindex/index.md
@@ -1,17 +1,6 @@
 ---
 title: VideoTrackList.selectedIndex
 slug: Web/API/VideoTrackList/selectedIndex
-tags:
-  - API
-  - HTML DOM
-  - Media
-  - Property
-  - Read-only
-  - Reference
-  - Video
-  - VideoTrackList
-  - track
-translation_of: Web/API/VideoTrackList/selectedIndex
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/vrdisplay/cancelanimationframe/index.md
+++ b/files/ja/web/api/vrdisplay/cancelanimationframe/index.md
@@ -1,19 +1,6 @@
 ---
 title: VRDisplay.cancelAnimationFrame()
 slug: Web/API/VRDisplay/cancelAnimationFrame
-page-type: web-api-instance-method
-tags:
-  - API
-  - Deprecated
-  - Method
-  - Reference
-  - VR
-  - VRDisplay
-  - Virtual Reality
-  - WebVR
-  - cancelAnimationFrame()
-browser-compat: api.VRDisplay.cancelAnimationFrame
-translation_of: Web/API/VRDisplay/cancelAnimationFrame
 original_slug: Web/API/VRDevice/cancelAnimationFrame
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}

--- a/files/ja/web/api/vrdisplay/capabilities/index.md
+++ b/files/ja/web/api/vrdisplay/capabilities/index.md
@@ -1,19 +1,6 @@
 ---
 title: VRDisplay.capabilities
 slug: Web/API/VRDisplay/capabilities
-page-type: web-api-instance-property
-tags:
-  - API
-  - Deprecated
-  - Property
-  - Reference
-  - VR
-  - VRDisplay
-  - Virtual Reality
-  - WebVR
-  - capabilities
-browser-compat: api.VRDisplay.capabilities
-translation_of: Web/API/VRDisplay/capabilities
 original_slug: Web/API/VRDevice/capabilities
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}

--- a/files/ja/web/api/vrdisplay/depthfar/index.md
+++ b/files/ja/web/api/vrdisplay/depthfar/index.md
@@ -1,19 +1,6 @@
 ---
 title: VRDisplay.depthFar
 slug: Web/API/VRDisplay/depthFar
-page-type: web-api-instance-property
-tags:
-  - API
-  - Deprecated
-  - Property
-  - Reference
-  - VR
-  - VRDisplay
-  - Virtual Reality
-  - WebVR
-  - depthFar
-browser-compat: api.VRDisplay.depthFar
-translation_of: Web/API/VRDisplay/depthFar
 original_slug: Web/API/VRDevice/depthFar
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}

--- a/files/ja/web/api/vrdisplay/depthnear/index.md
+++ b/files/ja/web/api/vrdisplay/depthnear/index.md
@@ -1,19 +1,6 @@
 ---
 title: VRDisplay.depthNear
 slug: Web/API/VRDisplay/depthNear
-page-type: web-api-instance-property
-tags:
-  - API
-  - Deprecated
-  - Property
-  - Reference
-  - VR
-  - VRDisplay
-  - Virtual Reality
-  - WebVR
-  - depthNear
-browser-compat: api.VRDisplay.depthNear
-translation_of: Web/API/VRDisplay/depthNear
 original_slug: Web/API/VRDevice/depthNear
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}

--- a/files/ja/web/api/vrdisplay/displayid/index.md
+++ b/files/ja/web/api/vrdisplay/displayid/index.md
@@ -1,19 +1,6 @@
 ---
 title: VRDisplay.displayId
 slug: Web/API/VRDisplay/displayId
-page-type: web-api-instance-property
-tags:
-  - API
-  - Deprecated
-  - Property
-  - Reference
-  - VR
-  - VRDisplay
-  - Virtual Reality
-  - WebVR
-  - displayId
-browser-compat: api.VRDisplay.displayId
-translation_of: Web/API/VRDisplay/displayId
 original_slug: Web/API/VRDevice/displayId
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}

--- a/files/ja/web/api/vrdisplay/displayname/index.md
+++ b/files/ja/web/api/vrdisplay/displayname/index.md
@@ -1,19 +1,6 @@
 ---
 title: VRDisplay.displayName
 slug: Web/API/VRDisplay/displayName
-page-type: web-api-instance-property
-tags:
-  - API
-  - Deprecated
-  - Property
-  - Reference
-  - VR
-  - VRDisplay
-  - Virtual Reality
-  - WebVR
-  - displayName
-browser-compat: api.VRDisplay.displayName
-translation_of: Web/API/VRDisplay/displayName
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/vrdisplay/exitpresent/index.md
+++ b/files/ja/web/api/vrdisplay/exitpresent/index.md
@@ -1,19 +1,6 @@
 ---
 title: VRDisplay.exitPresent()
 slug: Web/API/VRDisplay/exitPresent
-page-type: web-api-instance-method
-tags:
-  - API
-  - Deprecated
-  - Method
-  - Reference
-  - VR
-  - VRDisplay
-  - Virtual Reality
-  - WebVR
-  - exitPresent()
-browser-compat: api.VRDisplay.exitPresent
-translation_of: Web/API/VRDisplay/exitPresent
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/vrdisplay/geteyeparameters/index.md
+++ b/files/ja/web/api/vrdisplay/geteyeparameters/index.md
@@ -1,20 +1,6 @@
 ---
 title: VRDisplay.getEyeParameters()
 slug: Web/API/VRDisplay/getEyeParameters
-page-type: web-api-instance-method
-tags:
-  - API
-  - Deprecated
-  - Deprecated
-  - Method
-  - Reference
-  - VR
-  - VRDisplay
-  - Virtual Reality
-  - WebVR
-  - getEyeParameters()
-browser-compat: api.VRDisplay.getEyeParameters
-translation_of: Web/API/VRDisplay/getEyeParameters
 original_slug: Web/API/VRDevice/getEyeParameters
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}

--- a/files/ja/web/api/vrdisplay/getframedata/index.md
+++ b/files/ja/web/api/vrdisplay/getframedata/index.md
@@ -1,19 +1,6 @@
 ---
 title: VRDisplay.getFrameData()
 slug: Web/API/VRDisplay/getFrameData
-page-type: web-api-instance-method
-tags:
-  - API
-  - Deprecated
-  - Method
-  - Reference
-  - VR
-  - VRDisplay
-  - Virtual Reality
-  - WebVR
-  - getFrameData
-browser-compat: api.VRDisplay.getFrameData
-translation_of: Web/API/VRDisplay/getFrameData
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/vrdisplay/getimmediatepose/index.md
+++ b/files/ja/web/api/vrdisplay/getimmediatepose/index.md
@@ -1,20 +1,6 @@
 ---
 title: VRDisplay.getImmediatePose()
 slug: Web/API/VRDisplay/getImmediatePose
-page-type: web-api-instance-method
-tags:
-  - API
-  - Deprecated
-  - Method
-  - Deprecated
-  - Reference
-  - VR
-  - VRDisplay
-  - Virtual Reality
-  - WebVR
-  - getImmediatePose()
-browser-compat: api.VRDisplay.getImmediatePose
-translation_of: Web/API/VRDisplay/getImmediatePose
 original_slug: Web/API/VRDevice/getImmediatePose
 ---
 {{deprecated_header}}{{APIRef("WebVR API")}}

--- a/files/ja/web/api/vrdisplay/getlayers/index.md
+++ b/files/ja/web/api/vrdisplay/getlayers/index.md
@@ -1,20 +1,6 @@
 ---
 title: VRDisplay.getLayers()
 slug: Web/API/VRDisplay/getLayers
-page-type: web-api-instance-method
-tags:
-  - API
-  - Deprecated
-  - Deprecated
-  - Method
-  - Reference
-  - VR
-  - VRDisplay
-  - Virtual Reality
-  - WebVR
-  - getLayers()
-browser-compat: api.VRDisplay.getLayers
-translation_of: Web/API/VRDisplay/getLayers
 original_slug: Web/API/VRDevice/getLayers
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}

--- a/files/ja/web/api/vrdisplay/getpose/index.md
+++ b/files/ja/web/api/vrdisplay/getpose/index.md
@@ -1,19 +1,6 @@
 ---
 title: VRDisplay.getPose()
 slug: Web/API/VRDisplay/getPose
-page-type: web-api-instance-method
-tags:
-  - API
-  - Deprecated
-  - Method
-  - Reference
-  - VR
-  - VRDisplay
-  - Virtual Reality
-  - WebVR
-  - getPose()
-browser-compat: api.VRDisplay.getPose
-translation_of: Web/API/VRDisplay/getPose
 original_slug: Web/API/VRDevice/getPose
 ---
 {{APIRef("WebVR API")}}{{deprecated_header}}

--- a/files/ja/web/api/vrdisplay/index.md
+++ b/files/ja/web/api/vrdisplay/index.md
@@ -1,20 +1,6 @@
 ---
 title: VRDisplay
 slug: Web/API/VRDisplay
-page-type: web-api-interface
-tags:
-  - API
-  - DOM
-  - Experimental
-  - Interface
-  - Media
-  - Reference
-  - VR
-  - VRDisplay
-  - Virtual Reality
-  - WebVR
-browser-compat: api.VRDisplay
-translation_of: Web/API/VRDisplay
 original_slug: Web/API/VRDevice
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}

--- a/files/ja/web/api/vrdisplay/isconnected/index.md
+++ b/files/ja/web/api/vrdisplay/isconnected/index.md
@@ -1,19 +1,6 @@
 ---
 title: VRDisplay.isConnected
 slug: Web/API/VRDisplay/isConnected
-page-type: web-api-instance-property
-tags:
-  - API
-  - Deprecated
-  - Property
-  - Reference
-  - VR
-  - VRDisplay
-  - Virtual Reality
-  - WebVR
-  - isConnected
-browser-compat: api.VRDisplay.isConnected
-translation_of: Web/API/VRDisplay/isConnected
 original_slug: Web/API/VRDevice/isConnected
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}

--- a/files/ja/web/api/vrdisplay/ispresenting/index.md
+++ b/files/ja/web/api/vrdisplay/ispresenting/index.md
@@ -1,19 +1,6 @@
 ---
 title: VRDisplay.isPresenting
 slug: Web/API/VRDisplay/isPresenting
-page-type: web-api-instance-property
-tags:
-  - API
-  - Deprecated
-  - Property
-  - Reference
-  - VR
-  - VRDisplay
-  - Virtual Reality
-  - WebVR
-  - isPresenting
-browser-compat: api.VRDisplay.isPresenting
-translation_of: Web/API/VRDisplay/isPresenting
 original_slug: Web/API/VRDevice/isPresenting
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}

--- a/files/ja/web/api/vrdisplay/requestanimationframe/index.md
+++ b/files/ja/web/api/vrdisplay/requestanimationframe/index.md
@@ -1,19 +1,6 @@
 ---
 title: VRDisplay.requestAnimationFrame()
 slug: Web/API/VRDisplay/requestAnimationFrame
-page-type: web-api-instance-method
-tags:
-  - API
-  - Deprecated
-  - Method
-  - Reference
-  - VR
-  - VRDisplay
-  - Virtual Reality
-  - WebVR
-  - requestAnimationFrame()
-browser-compat: api.VRDisplay.requestAnimationFrame
-translation_of: Web/API/VRDisplay/requestAnimationFrame
 original_slug: Web/API/VRDevice/requestAnimationFrame
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}

--- a/files/ja/web/api/vrdisplay/requestpresent/index.md
+++ b/files/ja/web/api/vrdisplay/requestpresent/index.md
@@ -1,19 +1,6 @@
 ---
 title: VRDisplay.requestPresent()
 slug: Web/API/VRDisplay/requestPresent
-page-type: web-api-instance-method
-tags:
-  - API
-  - Deprecated
-  - Method
-  - Reference
-  - VR
-  - VRDisplay
-  - Virtual Display
-  - WebVR
-  - requestPresent()
-browser-compat: api.VRDisplay.requestPresent
-translation_of: Web/API/VRDisplay/requestPresent
 original_slug: Web/API/VRDevice/requestPresent
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}

--- a/files/ja/web/api/vrdisplay/resetpose/index.md
+++ b/files/ja/web/api/vrdisplay/resetpose/index.md
@@ -1,19 +1,6 @@
 ---
 title: VRDisplay.resetPose()
 slug: Web/API/VRDisplay/resetPose
-page-type: web-api-instance-method
-tags:
-  - API
-  - Deprecated
-  - Method
-  - Reference
-  - VR
-  - VRDevice
-  - Virtual Reality
-  - WebVR
-  - resetPose()
-browser-compat: api.VRDisplay.resetPose
-translation_of: Web/API/VRDisplay/resetPose
 original_slug: Web/API/VRDevice/resetPose
 ---
 {{APIRef("WebVR API")}}{{deprecated_header}}

--- a/files/ja/web/api/vrdisplay/stageparameters/index.md
+++ b/files/ja/web/api/vrdisplay/stageparameters/index.md
@@ -1,19 +1,6 @@
 ---
 title: VRDisplay.stageParameters
 slug: Web/API/VRDisplay/stageParameters
-page-type: web-api-instance-property
-tags:
-  - API
-  - Deprecated
-  - Property
-  - Reference
-  - VR
-  - VRDisplay
-  - Virtual Reality
-  - WebVR
-  - stageParameters
-browser-compat: api.VRDisplay.stageParameters
-translation_of: Web/API/VRDisplay/stageParameters
 original_slug: Web/API/VRDevice/stageParameters
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}

--- a/files/ja/web/api/vrdisplay/submitframe/index.md
+++ b/files/ja/web/api/vrdisplay/submitframe/index.md
@@ -1,19 +1,6 @@
 ---
 title: VRDisplay.submitFrame()
 slug: Web/API/VRDisplay/submitFrame
-page-type: web-api-instance-method
-tags:
-  - API
-  - Deprecated
-  - Method
-  - Reference
-  - VR
-  - VRDisplay
-  - Virtual Reality
-  - WebVR
-  - submitFrame()
-browser-compat: api.VRDisplay.submitFrame
-translation_of: Web/API/VRDisplay/submitFrame
 original_slug: Web/API/VRDevice/submitFrame
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}

--- a/files/ja/web/api/vrdisplaycapabilities/canpresent/index.md
+++ b/files/ja/web/api/vrdisplaycapabilities/canpresent/index.md
@@ -1,7 +1,6 @@
 ---
 title: VRDisplayCapabilities.canPresent
 slug: Web/API/VRDisplayCapabilities/canPresent
-translation_of: Web/API/VRDisplayCapabilities/canPresent
 ---
 {{APIRef("WebVR API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/vrdisplaycapabilities/hasexternaldisplay/index.md
+++ b/files/ja/web/api/vrdisplaycapabilities/hasexternaldisplay/index.md
@@ -1,7 +1,6 @@
 ---
 title: VRDisplayCapabilities.hasExternalDisplay
 slug: Web/API/VRDisplayCapabilities/hasExternalDisplay
-translation_of: Web/API/VRDisplayCapabilities/hasExternalDisplay
 ---
 {{APIRef("WebVR API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/vrdisplaycapabilities/hasorientation/index.md
+++ b/files/ja/web/api/vrdisplaycapabilities/hasorientation/index.md
@@ -1,7 +1,6 @@
 ---
 title: VRDisplayCapabilities.hasOrientation
 slug: Web/API/VRDisplayCapabilities/hasOrientation
-translation_of: Web/API/VRDisplayCapabilities/hasOrientation
 ---
 {{APIRef("WebVR API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/vrdisplaycapabilities/hasposition/index.md
+++ b/files/ja/web/api/vrdisplaycapabilities/hasposition/index.md
@@ -1,7 +1,6 @@
 ---
 title: VRDisplayCapabilities.hasPosition
 slug: Web/API/VRDisplayCapabilities/hasPosition
-translation_of: Web/API/VRDisplayCapabilities/hasPosition
 ---
 {{APIRef("WebVR API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/vrdisplaycapabilities/index.md
+++ b/files/ja/web/api/vrdisplaycapabilities/index.md
@@ -1,7 +1,6 @@
 ---
 title: VRDisplayCapabilities
 slug: Web/API/VRDisplayCapabilities
-translation_of: Web/API/VRDisplayCapabilities
 ---
 {{APIRef("WebVR API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/vrdisplaycapabilities/maxlayers/index.md
+++ b/files/ja/web/api/vrdisplaycapabilities/maxlayers/index.md
@@ -1,7 +1,6 @@
 ---
 title: VRDisplayCapabilities.maxLayers
 slug: Web/API/VRDisplayCapabilities/maxLayers
-translation_of: Web/API/VRDisplayCapabilities/maxLayers
 ---
 {{APIRef("WebVR API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/vrdisplayevent/index.md
+++ b/files/ja/web/api/vrdisplayevent/index.md
@@ -1,16 +1,6 @@
 ---
 title: VRDisplayEvent
 slug: Web/API/VRDisplayEvent
-tags:
-  - API
-  - Experimental
-  - Interface
-  - Reference
-  - VR
-  - VRDisplayEvent
-  - Virtual Reality
-  - WebVR
-translation_of: Web/API/VRDisplayEvent
 ---
 {{APIRef("WebVR API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/vreyeparameters/fieldofview/index.md
+++ b/files/ja/web/api/vreyeparameters/fieldofview/index.md
@@ -1,7 +1,6 @@
 ---
 title: VREyeParameters.fieldOfView
 slug: Web/API/VREyeParameters/fieldOfView
-translation_of: Web/API/VREyeParameters/fieldOfView
 ---
 {{APIRef("WebVR API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/vreyeparameters/index.md
+++ b/files/ja/web/api/vreyeparameters/index.md
@@ -1,7 +1,6 @@
 ---
 title: VREyeParameters
 slug: Web/API/VREyeParameters
-translation_of: Web/API/VREyeParameters
 ---
 {{APIRef("WebVR API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/vreyeparameters/offset/index.md
+++ b/files/ja/web/api/vreyeparameters/offset/index.md
@@ -1,7 +1,6 @@
 ---
 title: VREyeParameters.offset
 slug: Web/API/VREyeParameters/offset
-translation_of: Web/API/VREyeParameters/offset
 ---
 {{APIRef("WebVR API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/vreyeparameters/renderheight/index.md
+++ b/files/ja/web/api/vreyeparameters/renderheight/index.md
@@ -1,7 +1,6 @@
 ---
 title: VREyeParameters.renderHeight
 slug: Web/API/VREyeParameters/renderHeight
-translation_of: Web/API/VREyeParameters/renderHeight
 ---
 {{APIRef("WebVR API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/vreyeparameters/renderwidth/index.md
+++ b/files/ja/web/api/vreyeparameters/renderwidth/index.md
@@ -1,7 +1,6 @@
 ---
 title: VREyeParameters.renderWidth
 slug: Web/API/VREyeParameters/renderWidth
-translation_of: Web/API/VREyeParameters/renderWidth
 ---
 {{APIRef("WebVR API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/vrfieldofview/index.md
+++ b/files/ja/web/api/vrfieldofview/index.md
@@ -1,7 +1,6 @@
 ---
 title: VRFieldOfView
 slug: Web/API/VRFieldOfView
-translation_of: Web/API/VRFieldOfView
 ---
 {{APIRef("WebVR API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/vrframedata/index.md
+++ b/files/ja/web/api/vrframedata/index.md
@@ -1,18 +1,6 @@
 ---
 title: VRFrameData
 slug: Web/API/VRFrameData
-page-type: web-api-interface
-tags:
-  - API
-  - Deprecated
-  - Interface
-  - Reference
-  - VR
-  - VRFrameData
-  - Virtual Reality
-  - WebVR
-browser-compat: api.VRFrameData
-translation_of: Web/API/VRFrameData
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/vrframedata/leftprojectionmatrix/index.md
+++ b/files/ja/web/api/vrframedata/leftprojectionmatrix/index.md
@@ -1,19 +1,6 @@
 ---
 title: VRFrameData.leftProjectionMatrix
 slug: Web/API/VRFrameData/leftProjectionMatrix
-page-type: web-api-instance-property
-tags:
-  - API
-  - Deprecated
-  - Property
-  - Reference
-  - VR
-  - VRFrameData
-  - Virtual Reality
-  - WebVR
-  - leftProjectionMatrix
-browser-compat: api.VRFrameData.leftProjectionMatrix
-translation_of: Web/API/VRFrameData/leftProjectionMatrix
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/vrframedata/leftviewmatrix/index.md
+++ b/files/ja/web/api/vrframedata/leftviewmatrix/index.md
@@ -1,19 +1,6 @@
 ---
 title: VRFrameData.leftViewMatrix
 slug: Web/API/VRFrameData/leftViewMatrix
-page-type: web-api-instance-property
-tags:
-  - API
-  - Deprecated
-  - Property
-  - Reference
-  - VR
-  - VRFrameData
-  - Virtual Reality
-  - WebVR
-  - leftViewMatrix
-browser-compat: api.VRFrameData.leftViewMatrix
-translation_of: Web/API/VRFrameData/leftViewMatrix
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/vrframedata/pose/index.md
+++ b/files/ja/web/api/vrframedata/pose/index.md
@@ -1,19 +1,6 @@
 ---
 title: VRFrameData.pose
 slug: Web/API/VRFrameData/pose
-page-type: web-api-instance-property
-tags:
-  - API
-  - Deprecated
-  - Property
-  - Reference
-  - VR
-  - VRFrameData
-  - Virtual Reality
-  - WebVR
-  - pose
-browser-compat: api.VRFrameData.pose
-translation_of: Web/API/VRFrameData/pose
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/vrframedata/rightprojectionmatrix/index.md
+++ b/files/ja/web/api/vrframedata/rightprojectionmatrix/index.md
@@ -1,19 +1,6 @@
 ---
 title: VRFrameData.rightProjectionMatrix
 slug: Web/API/VRFrameData/rightProjectionMatrix
-page-type: web-api-instance-property
-tags:
-  - API
-  - Deprecated
-  - Property
-  - Reference
-  - VR
-  - VRFrameData
-  - Virtual Reality
-  - WebVR
-  - rightProjectionMatrix
-browser-compat: api.VRFrameData.rightProjectionMatrix
-translation_of: Web/API/VRFrameData/rightProjectionMatrix
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/vrframedata/rightviewmatrix/index.md
+++ b/files/ja/web/api/vrframedata/rightviewmatrix/index.md
@@ -1,19 +1,6 @@
 ---
 title: VRFrameData.rightViewMatrix
 slug: Web/API/VRFrameData/rightViewMatrix
-page-type: web-api-instance-property
-tags:
-  - API
-  - Deprecated
-  - Property
-  - Reference
-  - VR
-  - VRFrameData
-  - Virtual Reality
-  - WebVR
-  - rightViewMatrix
-browser-compat: api.VRFrameData.rightViewMatrix
-translation_of: Web/API/VRFrameData/rightViewMatrix
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/vrframedata/timestamp/index.md
+++ b/files/ja/web/api/vrframedata/timestamp/index.md
@@ -1,19 +1,6 @@
 ---
 title: VRFrameData.timestamp
 slug: Web/API/VRFrameData/timestamp
-page-type: web-api-instance-property
-tags:
-  - API
-  - Deprecated
-  - Property
-  - Reference
-  - VR
-  - VRFrameData
-  - Virtual Reality
-  - WebVR
-  - timeStamp
-browser-compat: api.VRFrameData.timestamp
-translation_of: Web/API/VRFrameData/timestamp
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/vrframedata/vrframedata/index.md
+++ b/files/ja/web/api/vrframedata/vrframedata/index.md
@@ -1,18 +1,6 @@
 ---
 title: VRFrameData()
 slug: Web/API/VRFrameData/VRFrameData
-page-type: web-api-constructor
-tags:
-  - API
-  - Constructor
-  - Deprecated
-  - Reference
-  - VR
-  - VRFrameData
-  - Virtual Reality
-  - WebVR
-browser-compat: api.VRFrameData.VRFrameData
-translation_of: Web/API/VRFrameData/VRFrameData
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/vrlayerinit/index.md
+++ b/files/ja/web/api/vrlayerinit/index.md
@@ -1,18 +1,6 @@
 ---
 title: VRLayerInit
 slug: Web/API/VRLayerInit
-page-type: web-api-interface
-tags:
-  - API
-  - Dictionary
-  - Deprecated
-  - Interface
-  - Reference
-  - VR
-  - VRLayerInit
-  - Virtual Reality
-  - WebVR
-translation_of: Web/API/VRLayerInit
 original_slug: Web/API/VRLayer
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}

--- a/files/ja/web/api/vrlayerinit/leftbounds/index.md
+++ b/files/ja/web/api/vrlayerinit/leftbounds/index.md
@@ -1,18 +1,6 @@
 ---
 title: VRLayerInit.leftBounds
 slug: Web/API/VRLayerInit/leftBounds
-page-type: web-api-instance-property
-tags:
-  - API
-  - Deprecated
-  - Property
-  - Reference
-  - VR
-  - VRLayerInit
-  - Virtual Reality
-  - WebVR
-  - leftBounds
-translation_of: Web/API/VRLayerInit/leftBounds
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/vrlayerinit/rightbounds/index.md
+++ b/files/ja/web/api/vrlayerinit/rightbounds/index.md
@@ -1,18 +1,6 @@
 ---
 title: VRLayerInit.rightBounds
 slug: Web/API/VRLayerInit/rightBounds
-page-type: web-api-instance-property
-tags:
-  - API
-  - Deprecated
-  - Property
-  - Reference
-  - VR
-  - VRLayerInit
-  - Virtual Reality
-  - WebVR
-  - rightBounds
-translation_of: Web/API/VRLayerInit/rightBounds
 original_slug: Web/API/VRLayer/rightBounds
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}

--- a/files/ja/web/api/vrlayerinit/source/index.md
+++ b/files/ja/web/api/vrlayerinit/source/index.md
@@ -1,18 +1,6 @@
 ---
 title: VRLayerInit.source
 slug: Web/API/VRLayerInit/source
-page-type: web-api-instance-property
-tags:
-  - API
-  - Deprecated
-  - Property
-  - Reference
-  - VR
-  - VRLayerInit
-  - Virtual Reality
-  - WebVR
-  - source
-translation_of: Web/API/VRLayerInit/source
 original_slug: Web/API/VRLayer/source
 ---
 {{APIRef("WebVR API")}}{{Deprecated_Header}}

--- a/files/ja/web/api/vrpose/index.md
+++ b/files/ja/web/api/vrpose/index.md
@@ -1,7 +1,6 @@
 ---
 title: VRPose
 slug: Web/API/VRPose
-translation_of: Web/API/VRPose
 ---
 {{APIRef("WebVR API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/vrstageparameters/index.md
+++ b/files/ja/web/api/vrstageparameters/index.md
@@ -1,7 +1,6 @@
 ---
 title: VRStageParameters
 slug: Web/API/VRStageParameters
-translation_of: Web/API/VRStageParameters
 ---
 {{APIRef("WebVR API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/vrstageparameters/sittingtostandingtransform/index.md
+++ b/files/ja/web/api/vrstageparameters/sittingtostandingtransform/index.md
@@ -1,7 +1,6 @@
 ---
 title: VRStageParameters.sittingToStandingTransform
 slug: Web/API/VRStageParameters/sittingToStandingTransform
-translation_of: Web/API/VRStageParameters/sittingToStandingTransform
 ---
 {{APIRef("WebVR API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/vrstageparameters/sizex/index.md
+++ b/files/ja/web/api/vrstageparameters/sizex/index.md
@@ -1,7 +1,6 @@
 ---
 title: VRStageParameters.sizeX
 slug: Web/API/VRStageParameters/sizeX
-translation_of: Web/API/VRStageParameters/sizeX
 ---
 {{APIRef("WebVR API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/vrstageparameters/sizey/index.md
+++ b/files/ja/web/api/vrstageparameters/sizey/index.md
@@ -1,7 +1,6 @@
 ---
 title: VRStageParameters.sizeY
 slug: Web/API/VRStageParameters/sizeY
-translation_of: Web/API/VRStageParameters/sizeY
 ---
 {{APIRef("WebVR API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/vttcue/index.md
+++ b/files/ja/web/api/vttcue/index.md
@@ -1,12 +1,6 @@
 ---
 title: VTTCue
 slug: Web/API/VTTCue
-tags:
-  - VTTCue
-  - WebVTT
-  - text track
-  - vtt
-translation_of: Web/API/VTTCue
 ---
 {{APIRef("WebVTT")}}
 WebVTT（メディアプレゼンテーションに関するテキストトラック）を処理するための API の一部である `VTTCue` インターフェイスは、特定の {{HTMLElement("track")}} 要素に関連付けられたテキストトラックを記述および制御します。

--- a/files/ja/web/api/vttcue/vttcue/index.md
+++ b/files/ja/web/api/vttcue/vttcue/index.md
@@ -1,12 +1,6 @@
 ---
 title: VTTCue()
 slug: Web/API/VTTCue/VTTCue
-tags:
-  - API
-  - Constructor
-  - VTTCue
-  - WebVTT
-translation_of: Web/API/VTTCue/VTTCue
 ---
 {{APIRef("WebVTT")}}
 

--- a/files/ja/web/api/vttregion/index.md
+++ b/files/ja/web/api/vttregion/index.md
@@ -1,11 +1,6 @@
 ---
 title: VTTRegion
 slug: Web/API/VTTRegion
-tags:
-  - API
-  - VTTRegion
-  - WebVTT
-translation_of: Web/API/VTTRegion
 ---
 {{APIRef("WebVTT")}}
 


### PR DESCRIPTION
Part of #7858

`files/ja/web/api/{t-v}*` から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "tags": 141,
  "translation_of": 154,
  "browser-compat": 56,
  "page-type": 35
}
```
