### PR TITLE
remove duplicated frontmatter keys from web/api/w* (ja)

### DIFF
--- a/files/ja/orphaned/web/api/window/dialogarguments/index.md
+++ b/files/ja/orphaned/web/api/window/dialogarguments/index.md
@@ -1,12 +1,6 @@
 ---
 title: window.dialogArguments
 slug: orphaned/Web/API/Window/dialogArguments
-tags:
-  - DOM
-  - Dialogs
-  - Reference
-  - Window
-translation_of: Web/API/Window/dialogArguments
 original_slug: Web/API/Window/dialogArguments
 ---
 {{APIRef}}

--- a/files/ja/orphaned/web/api/window/issecurecontext/index.md
+++ b/files/ja/orphaned/web/api/window/issecurecontext/index.md
@@ -1,13 +1,6 @@
 ---
 title: Window.isSecureContext
 slug: orphaned/Web/API/Window/isSecureContext
-tags:
-  - API
-  - Property
-  - Reference
-  - Security
-  - Window
-translation_of: Web/API/Window/isSecureContext
 original_slug: Web/API/Window/isSecureContext
 ---
 {{APIRef}}{{SeeCompatTable}}

--- a/files/ja/orphaned/web/api/window/pkcs11/index.md
+++ b/files/ja/orphaned/web/api/window/pkcs11/index.md
@@ -1,17 +1,6 @@
 ---
 title: Window.pkcs11
 slug: orphaned/Web/API/Window/pkcs11
-tags:
-  - API
-  - HTML DOM
-  - NeedsExample
-  - NeedsMarkupWork
-  - NeedsSpecTable
-  - Deprecated
-  - Property
-  - Reference
-  - Window
-translation_of: Web/API/Window/pkcs11
 original_slug: Web/API/Window/pkcs11
 ---
 {{APIRef()}}{{deprecated_header}}

--- a/files/ja/web/api/wakelock/index.md
+++ b/files/ja/web/api/wakelock/index.md
@@ -1,14 +1,6 @@
 ---
 title: WakeLock
 slug: Web/API/WakeLock
-tags:
-  - インターフェイス
-  - リファレンス
-  - 画面起動ロック API
-  - 起動ロック
-  - 画面
-browser-compat: api.WakeLock
-translation_of: Web/API/WakeLock
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Screen Wake Lock API")}}
 

--- a/files/ja/web/api/wakelock/request/index.md
+++ b/files/ja/web/api/wakelock/request/index.md
@@ -1,14 +1,6 @@
 ---
 title: WakeLock.request()
 slug: Web/API/WakeLock/request
-tags:
-  - API
-  - Method
-  - リファレンス
-  - 画面起動ロック API
-  - WakeLock
-browser-compat: api.WakeLock.request
-translation_of: Web/API/WakeLock/request
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Screen Wake Lock API")}}
 

--- a/files/ja/web/api/wakelocksentinel/index.md
+++ b/files/ja/web/api/wakelocksentinel/index.md
@@ -1,15 +1,6 @@
 ---
 title: WakeLockSentinel
 slug: Web/API/WakeLockSentinel
-tags:
-  - API
-  - インターフェイス
-  - リファレンス
-  - 画面起動ロック API
-  - 起動ロック
-  - 画面
-browser-compat: api.WakeLockSentinel
-translation_of: Web/API/WakeLockSentinel
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Screen Wake Lock API")}}
 

--- a/files/ja/web/api/wakelocksentinel/release/index.md
+++ b/files/ja/web/api/wakelocksentinel/release/index.md
@@ -1,16 +1,6 @@
 ---
 title: WakeLockSentinel.release()
 slug: Web/API/WakeLockSentinel/release
-tags:
-  - API
-  - Method
-  - リファレンス
-  - 画面起動ロック API
-  - 起動ロック
-  - WakeLockSentinel
-  - 画面
-browser-compat: api.WakeLockSentinel.release
-translation_of: Web/API/WakeLockSentinel/release
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Screen Wake Lock API")}}
 

--- a/files/ja/web/api/wakelocksentinel/release_event/index.md
+++ b/files/ja/web/api/wakelocksentinel/release_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'WakeLockSentinel: release イベント'
 slug: Web/API/WakeLockSentinel/release_event
-tags:
-  - Event Handler
-  - プロパティ
-  - 画面 Wake Lock API
-  - 起動ロック
-  - WakeLockSentinel
-  - 画面
-  - 画面 wake lock
-browser-compat: api.WakeLockSentinel.release_event
-translation_of: Web/API/WakeLockSentinel/release_event
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Screen Wake Lock API")}}
 

--- a/files/ja/web/api/wakelocksentinel/released/index.md
+++ b/files/ja/web/api/wakelocksentinel/released/index.md
@@ -1,13 +1,6 @@
 ---
 title: WakeLockSentinel.released
 slug: Web/API/WakeLockSentinel/released
-tags:
-  - プロパティ
-  - 読み取り専用
-  - 画面起動ロック API
-  - WakeLockSentinel
-browser-compat: api.WakeLockSentinel.released
-translation_of: Web/API/WakeLockSentinel/released
 ---
 {{DefaultAPISidebar("Screen Wake Lock API")}}
 

--- a/files/ja/web/api/wakelocksentinel/type/index.md
+++ b/files/ja/web/api/wakelocksentinel/type/index.md
@@ -1,15 +1,6 @@
 ---
 title: WakeLockSentinel.type
 slug: Web/API/WakeLockSentinel/type
-tags:
-  - プロパティ
-  - 読み取り専用
-  - 画面起動ロック API
-  - 起動ロック
-  - WakeLockSentinel
-  - 画面
-browser-compat: api.WakeLockSentinel.type
-translation_of: Web/API/WakeLockSentinel/type
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Screen Wake Lock API")}}
 

--- a/files/ja/web/api/web_animations_api/index.md
+++ b/files/ja/web/api/web_animations_api/index.md
@@ -1,15 +1,6 @@
 ---
 title: ウェブアニメーション API
 slug: Web/API/Web_Animations_API
-tags:
-  - API
-  - Animation
-  - Landing
-  - Reference
-  - Web Animations
-  - アニメーション
-  - ウェブアニメーション
-translation_of: Web/API/Web_Animations_API
 ---
 {{DefaultAPISidebar("Web Animations")}}
 

--- a/files/ja/web/api/web_animations_api/using_the_web_animations_api/index.md
+++ b/files/ja/web/api/web_animations_api/using_the_web_animations_api/index.md
@@ -1,15 +1,6 @@
 ---
 title: Web Animations API を利用する
 slug: Web/API/Web_Animations_API/Using_the_Web_Animations_API
-tags:
-  - CSS
-  - JavaScript
-  - web animations api
-  - アニメーション
-  - キーフレーム
-  - 不思議の国のアリス
-  - 初心者
-translation_of: Web/API/Web_Animations_API/Using_the_Web_Animations_API
 ---
 {{DefaultAPISidebar("Web Animations")}}
 

--- a/files/ja/web/api/web_audio_api/basic_concepts_behind_web_audio_api/index.md
+++ b/files/ja/web/api/web_audio_api/basic_concepts_behind_web_audio_api/index.md
@@ -1,18 +1,6 @@
 ---
 title: Basic concepts behind Web Audio API
 slug: Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API
-tags:
-  - Audio
-  - Beginner
-  - Guide
-  - Introduction
-  - Media
-  - Web Audio
-  - Web Audio API
-  - concepts
-  - sound
-  - 初心者
-translation_of: Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API
 ---
 この記事では、アプリを経由した音声伝達方法の設計をする際に、十分な情報に基づいた決断をする助けとなるよう、 Web Audio API の特徴がいかに働いているか、その背後にある音声理論について説明します。この記事はあなたを熟練のサウンドエンジニアにさせることはできないものの、Web Audio API が動く理由を理解するための十分な背景を提供します。
 

--- a/files/ja/web/api/web_audio_api/index.md
+++ b/files/ja/web/api/web_audio_api/index.md
@@ -1,15 +1,6 @@
 ---
 title: Web Audio API
 slug: Web/API/Web_Audio_API
-tags:
-  - API
-  - Audio
-  - Example
-  - Landing
-  - Overview
-  - Web Audio API
-  - sound
-translation_of: Web/API/Web_Audio_API
 ---
 {{DefaultAPISidebar("Web Audio API")}}
 

--- a/files/ja/web/api/web_audio_api/using_web_audio_api/index.md
+++ b/files/ja/web/api/web_audio_api/using_web_audio_api/index.md
@@ -1,21 +1,6 @@
 ---
 title: Web Audio API の使用
 slug: Web/API/Web_Audio_API/Using_Web_Audio_API
-tags:
-  - API
-  - Audio
-  - Guide
-  - Playback
-  - Using
-  - Web
-  - Web Audio
-  - Web Audio API
-  - basics
-  - sound
-  - ガイド
-  - 再生
-  - 音声
-translation_of: Web/API/Web_Audio_API/Using_Web_Audio_API
 ---
 {{DefaultAPISidebar("Web Audio API")}}
 

--- a/files/ja/web/api/web_audio_api/visualizations_with_web_audio_api/index.md
+++ b/files/ja/web/api/web_audio_api/visualizations_with_web_audio_api/index.md
@@ -1,14 +1,6 @@
 ---
 title: Visualizations with Web Audio API
 slug: Web/API/Web_Audio_API/Visualizations_with_Web_Audio_API
-tags:
-  - API
-  - Web Audio API
-  - analyser
-  - fft
-  - visualization
-  - waveform
-translation_of: Web/API/Web_Audio_API/Visualizations_with_Web_Audio_API
 ---
 Web Audio API の最も興味深い機能の 1 つは、オーディオソースから周波数、波形、その他のデータを抽出し、それを使用してビジュアライゼーションを作成する機能です。この記事では、方法について説明し、いくつかの基本的な使用例を示します。
 

--- a/files/ja/web/api/web_authentication_api/index.md
+++ b/files/ja/web/api/web_authentication_api/index.md
@@ -1,15 +1,6 @@
 ---
 title: ウェブ認証 API
 slug: Web/API/Web_Authentication_API
-tags:
-  - 2FA
-  - API
-  - 認証
-  - Landing
-  - Reference
-  - ウェブ認証 API
-  - WebAuthn
-translation_of: Web/API/Web_Authentication_API
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Web Authentication API")}}
 

--- a/files/ja/web/api/web_crypto_api/index.md
+++ b/files/ja/web/api/web_crypto_api/index.md
@@ -1,7 +1,6 @@
 ---
 title: Web Crypto API
 slug: Web/API/Web_Crypto_API
-translation_of: Web/API/Web_Crypto_API
 ---
 {{DefaultAPISidebar("Web Crypto API")}}
 

--- a/files/ja/web/api/web_nfc_api/index.md
+++ b/files/ja/web/api/web_nfc_api/index.md
@@ -1,10 +1,6 @@
 ---
 title: ウェブ NFC API
 slug: Web/API/Web_NFC_API
-tags:
-  - NDEF
-  - リファレンス
-  - ウェブ NFC
 ---
 {{DefaultAPISidebar("Web NFC API")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/web_periodic_background_synchronization_api/index.md
+++ b/files/ja/web/api/web_periodic_background_synchronization_api/index.md
@@ -1,7 +1,6 @@
 ---
 title: Web Periodic Background Synchronization API
 slug: Web/API/Web_Periodic_Background_Synchronization_API
-translation_of: Web/API/Web_Periodic_Background_Synchronization_API
 ---
 {{securecontext_header}}
 

--- a/files/ja/web/api/web_speech_api/index.md
+++ b/files/ja/web/api/web_speech_api/index.md
@@ -1,16 +1,6 @@
 ---
 title: Web Speech API
 slug: Web/API/Web_Speech_API
-tags:
-  - API
-  - Experimental
-  - Landing
-  - Reference
-  - Web Speech API
-  - recognition
-  - speech
-  - synthesis
-translation_of: Web/API/Web_Speech_API
 ---
 {{DefaultAPISidebar("Web Speech API")}}{{seecompattable}}
 

--- a/files/ja/web/api/web_speech_api/using_the_web_speech_api/index.md
+++ b/files/ja/web/api/web_speech_api/using_the_web_speech_api/index.md
@@ -1,7 +1,6 @@
 ---
 title: Web Speech APIを使う
 slug: Web/API/Web_Speech_API/Using_the_Web_Speech_API
-translation_of: Web/API/Web_Speech_API/Using_the_Web_Speech_API
 ---
 Web Speech API は、音声認識と音声合成（text to speech または tts としても知られています）という 2 つの異なる分野の機能を提供しており、アクセシビリティと制御メカニズムに興味深い新しい可能性をもたらします。この記事では、両方の分野の簡単な紹介とデモを提供します。
 

--- a/files/ja/web/api/web_storage_api/index.md
+++ b/files/ja/web/api/web_storage_api/index.md
@@ -1,14 +1,6 @@
 ---
 title: Web Storage API
 slug: Web/API/Web_Storage_API
-tags:
-  - API
-  - Reference
-  - Storage
-  - Web Storage
-  - localStorage
-  - sessionStorage
-translation_of: Web/API/Web_Storage_API
 ---
 {{DefaultAPISidebar("Web Storage API")}}
 

--- a/files/ja/web/api/web_storage_api/using_the_web_storage_api/index.md
+++ b/files/ja/web/api/web_storage_api/using_the_web_storage_api/index.md
@@ -1,14 +1,6 @@
 ---
 title: Web Storage API の使用
 slug: Web/API/Web_Storage_API/Using_the_Web_Storage_API
-tags:
-  - API
-  - Guide
-  - Storage
-  - Web Storage API
-  - localStorage
-  - sessionStorage
-translation_of: Web/API/Web_Storage_API/Using_the_Web_Storage_API
 ---
 {{DefaultAPISidebar("Web Storage API")}}
 

--- a/files/ja/web/api/web_workers_api/functions_and_classes_available_to_workers/index.md
+++ b/files/ja/web/api/web_workers_api/functions_and_classes_available_to_workers/index.md
@@ -1,12 +1,6 @@
 ---
 title: Web Workers が使用できる関数とクラス
 slug: Web/API/Web_Workers_API/Functions_and_classes_available_to_workers
-tags:
-  - Reference
-  - Web
-  - Web Worker
-  - Worker
-translation_of: Web/API/Web_Workers_API/Functions_and_classes_available_to_workers
 ---
 標準的な [JavaScript](/ja/docs/Web/JavaScript) の関数（{{jsxref("String")}} や {{jsxref("Array")}}、{{jsxref("Object")}}、 {{jsxref("JSON")}} など）に加えて、DOM から worker に利用できる様々な関数があります。この記事ではそれらの機能のリストを提供します。
 

--- a/files/ja/web/api/web_workers_api/index.md
+++ b/files/ja/web/api/web_workers_api/index.md
@@ -1,12 +1,6 @@
 ---
 title: Web Workers API
 slug: Web/API/Web_Workers_API
-tags:
-  - API
-  - DOM
-  - Web Workers
-  - Workers
-translation_of: Web/API/Web_Workers_API
 ---
 {{DefaultAPISidebar("Web Workers API")}}
 

--- a/files/ja/web/api/web_workers_api/structured_clone_algorithm/index.md
+++ b/files/ja/web/api/web_workers_api/structured_clone_algorithm/index.md
@@ -1,7 +1,6 @@
 ---
 title: 構造化複製アルゴリズム
 slug: Web/API/Web_Workers_API/Structured_clone_algorithm
-translation_of: Web/API/Web_Workers_API/Structured_clone_algorithm
 ---
 **構造化複製アルゴリズム** は複雑な JavaScript オブジェクトをコピーするためのアルゴリズムです。これは {{domxref("Worker.postMessage()", "postMessage()")}} を介して [Worker](/ja/docs/Web/API/Worker) と送受信するとき、[IndexedDB](/ja/docs/Glossary/IndexedDB) にオブジェクトを格納するとき、[他の API](/ja/docs/Web/API/Web_Workers_API/Structured_clone_algorithm$edit#See_Also) のためにオブジェクトをコピーするときなど、データ転送時に内部で用いられています。無限ループを避けるため、以前にアクセスした参照のマップを保持しながら、入力オブジェクトを再帰処理することで複製していきます。
 

--- a/files/ja/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/ja/web/api/web_workers_api/using_web_workers/index.md
@@ -1,15 +1,6 @@
 ---
 title: Web Worker の使用
 slug: Web/API/Web_Workers_API/Using_web_workers
-tags:
-  - Advanced
-  - Firefox
-  - Guide
-  - HTML5
-  - JavaScript
-  - WebWorkers
-  - Workers
-translation_of: Web/API/Web_Workers_API/Using_web_workers
 ---
 {{DefaultAPISidebar("Web Workers API")}}
 

--- a/files/ja/web/api/webgl_api/basic_2d_animation_example/index.md
+++ b/files/ja/web/api/webgl_api/basic_2d_animation_example/index.md
@@ -1,15 +1,6 @@
 ---
 title: 基本的な 2D WebGL アニメーションの例
 slug: Web/API/WebGL_API/Basic_2D_animation_example
-tags:
-  - 2D Animation
-  - 2D Graphics
-  - Animation
-  - Drawing
-  - Example
-  - WebGL
-  - WebGL API
-translation_of: Web/API/WebGL_API/Basic_2D_animation_example
 ---
 {{WebGLSidebar}}
 

--- a/files/ja/web/api/webgl_api/by_example/index.md
+++ b/files/ja/web/api/webgl_api/by_example/index.md
@@ -1,13 +1,6 @@
 ---
 title: 実例による WebGL
 slug: Web/API/WebGL_API/By_example
-tags:
-  - Beginner
-  - Example
-  - Graphics
-  - Learn
-  - WebGL
-translation_of: Web/API/WebGL_API/By_example
 ---
 {{learnsidebar}}
 

--- a/files/ja/web/api/webgl_api/constants/index.md
+++ b/files/ja/web/api/webgl_api/constants/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebGL の定数
 slug: Web/API/WebGL_API/Constants
-translation_of: Web/API/WebGL_API/Constants
 ---
 {{WebGLSidebar}}
 

--- a/files/ja/web/api/webgl_api/data/index.md
+++ b/files/ja/web/api/webgl_api/data/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebGL でのデータ
 slug: Web/API/WebGL_API/Data
-translation_of: Web/API/WebGL_API/Data
 ---
 {{WebGLSidebar}}
 

--- a/files/ja/web/api/webgl_api/index.md
+++ b/files/ja/web/api/webgl_api/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'WebGL: ウェブの 2D および 3D グラフィック'
 slug: Web/API/WebGL_API
-tags:
-  - 3D
-  - 3D Graphics
-  - Advanced
-  - Graphics
-  - Media
-  - Overview
-  - WebGL
-  - WebGL API
-translation_of: Web/API/WebGL_API
 ---
 {{WebGLSidebar}}
 

--- a/files/ja/web/api/webgl_api/matrix_math_for_the_web/index.md
+++ b/files/ja/web/api/webgl_api/matrix_math_for_the_web/index.md
@@ -1,21 +1,6 @@
 ---
 title: ウェブの行列計算
 slug: Web/API/WebGL_API/Matrix_math_for_the_web
-tags:
-  - 3D
-  - 3D2D
-  - Animation
-  - CSS
-  - GLSL
-  - Graphics
-  - Guide
-  - WebGL
-  - WebXR
-  - matrices
-  - matrix
-  - rendering
-  - transform3d
-translation_of: Web/API/WebGL_API/Matrix_math_for_the_web
 ---
 {{WebGLSidebar}}
 

--- a/files/ja/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
@@ -1,10 +1,6 @@
 ---
 title: WebGL コンテキストへの平面コンテンツの追加
 slug: Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context
-tags:
-  - Tutorial
-  - WebGL
-translation_of: Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context
 ---
 {{WebGLSidebar("Tutorial")}} {{PreviousNext("Web/API/WebGL_API/Tutorial/Getting_started_with_WebGL", "Web/API/WebGL_API/Tutorial/Using_shaders_to_apply_color_in_WebGL")}}
 

--- a/files/ja/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
@@ -1,10 +1,6 @@
 ---
 title: WebGL でのオブジェクトのアニメーティング
 slug: Web/API/WebGL_API/Tutorial/Animating_objects_with_WebGL
-tags:
-  - Tutorial
-  - WebGL
-translation_of: Web/API/WebGL_API/Tutorial/Animating_objects_with_WebGL
 ---
 {{WebGLSidebar("Tutorial")}} {{PreviousNext("Web/API/WebGL_API/Tutorial/Using_shaders_to_apply_color_in_WebGL", "Web/API/WebGL_API/Tutorial/Creating_3D_objects_using_WebGL") }}
 

--- a/files/ja/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
@@ -1,12 +1,6 @@
 ---
 title: WebGL でのテクスチャのアニメーティング
 slug: Web/API/WebGL_API/Tutorial/Animating_textures_in_WebGL
-tags:
-  - Media
-  - Tutorial
-  - Video
-  - WebGL
-translation_of: Web/API/WebGL_API/Tutorial/Animating_textures_in_WebGL
 ---
 {{WebGLSidebar("Tutorial") }} {{Previous("Web/API/WebGL_API/Tutorial/Lighting_in_WebGL")}}
 

--- a/files/ja/web/api/webgl_api/tutorial/creating_3d_objects_using_webgl/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/creating_3d_objects_using_webgl/index.md
@@ -1,10 +1,6 @@
 ---
 title: WebGL を用いた 3D オブジェクトの作成
 slug: Web/API/WebGL_API/Tutorial/Creating_3D_objects_using_WebGL
-tags:
-  - Tutorial
-  - WebGL
-translation_of: Web/API/WebGL_API/Tutorial/Creating_3D_objects_using_WebGL
 ---
 {{WebGLSidebar("Tutorial")}} {{PreviousNext("Web/API/WebGL_API/Tutorial/Animating_objects_with_WebGL", "Web/API/WebGL_API/Tutorial/Using_textures_in_WebGL")}}
 

--- a/files/ja/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
@@ -1,10 +1,6 @@
 ---
 title: WebGL 入門
 slug: Web/API/WebGL_API/Tutorial/Getting_started_with_WebGL
-tags:
-  - Tutorial
-  - WebGL
-translation_of: Web/API/WebGL_API/Tutorial/Getting_started_with_WebGL
 ---
 {{WebGLSidebar("Tutorial")}} {{Next("Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context")}}
 

--- a/files/ja/web/api/webgl_api/tutorial/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/index.md
@@ -1,12 +1,6 @@
 ---
 title: WebGL チュートリアル
 slug: Web/API/WebGL_API/Tutorial
-tags:
-  - Overview
-  - Tutorial
-  - WebGL
-  - WebGL API
-translation_of: Web/API/WebGL_API/Tutorial
 ---
 {{WebGLSidebar}}
 

--- a/files/ja/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
@@ -1,10 +1,6 @@
 ---
 title: WebGL でのライティング
 slug: Web/API/WebGL_API/Tutorial/Lighting_in_WebGL
-tags:
-  - Tutorial
-  - WebGL
-translation_of: Web/API/WebGL_API/Tutorial/Lighting_in_WebGL
 ---
 {{WebGLSidebar("Tutorial")}} {{PreviousNext("Web/API/WebGL_API/Tutorial/Using_textures_in_WebGL", "Web/API/WebGL_API/Tutorial/Animating_textures_in_WebGL")}}
 

--- a/files/ja/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
@@ -1,10 +1,6 @@
 ---
 title: シェーダーを用いた WebGL での色の指定
 slug: Web/API/WebGL_API/Tutorial/Using_shaders_to_apply_color_in_WebGL
-tags:
-  - Tutorial
-  - WebGL
-translation_of: Web/API/WebGL_API/Tutorial/Using_shaders_to_apply_color_in_WebGL
 ---
 {{WebGLSidebar("Tutorial")}} {{PreviousNext("Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context", "Web/API/WebGL_API/Tutorial/Animating_objects_with_WebGL")}}
 

--- a/files/ja/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -1,10 +1,6 @@
 ---
 title: WebGL でのテクスチャの使用
 slug: Web/API/WebGL_API/Tutorial/Using_textures_in_WebGL
-tags:
-  - Tutorial
-  - WebGL
-translation_of: Web/API/WebGL_API/Tutorial/Using_textures_in_WebGL
 ---
 {{WebGLSidebar("Tutorial")}} {{PreviousNext("Web/API/WebGL_API/Tutorial/Creating_3D_objects_using_WebGL", "Web/API/WebGL_API/Tutorial/Lighting_in_WebGL")}}
 

--- a/files/ja/web/api/webgl_api/types/index.md
+++ b/files/ja/web/api/webgl_api/types/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebGL の型
 slug: Web/API/WebGL_API/Types
-translation_of: Web/API/WebGL_API/Types
 ---
 {{WebGLSidebar}}
 

--- a/files/ja/web/api/webgl_api/using_extensions/index.md
+++ b/files/ja/web/api/webgl_api/using_extensions/index.md
@@ -1,11 +1,6 @@
 ---
 title: WebGL 拡張機能の使用
 slug: Web/API/WebGL_API/Using_Extensions
-page-type: guide
-tags:
-  - Advanced
-  - WebGL
-translation_of: Web/API/WebGL_API/Using_Extensions
 ---
 {{WebGLSidebar}}
 

--- a/files/ja/web/api/webgl_api/webgl_best_practices/index.md
+++ b/files/ja/web/api/webgl_api/webgl_best_practices/index.md
@@ -1,9 +1,6 @@
 ---
 title: WebGL best practices
 slug: Web/API/WebGL_API/WebGL_best_practices
-tags:
-  - WebGL
-translation_of: Web/API/WebGL_API/WebGL_best_practices
 ---
 {{WebGLSidebar}}
 

--- a/files/ja/web/api/webgl_api/webgl_model_view_projection/index.md
+++ b/files/ja/web/api/webgl_api/webgl_model_view_projection/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebGL モデル ビュー 射影
 slug: Web/API/WebGL_API/WebGL_model_view_projection
-translation_of: Web/API/WebGL_API/WebGL_model_view_projection
 ---
 {{WebGLSidebar}}
 

--- a/files/ja/web/api/webglrenderingcontext/attachshader/index.md
+++ b/files/ja/web/api/webglrenderingcontext/attachshader/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebGLRenderingContext.attachShader()
 slug: Web/API/WebGLRenderingContext/attachShader
-translation_of: Web/API/WebGLRenderingContext/attachShader
 ---
 {{APIRef("WebGL")}}
 

--- a/files/ja/web/api/webglrenderingcontext/bindbuffer/index.md
+++ b/files/ja/web/api/webglrenderingcontext/bindbuffer/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebGLRenderingContext.bindBuffer()
 slug: Web/API/WebGLRenderingContext/bindBuffer
-translation_of: Web/API/WebGLRenderingContext/bindBuffer
 ---
 {{APIRef("WebGL")}}
 

--- a/files/ja/web/api/webglrenderingcontext/bufferdata/index.md
+++ b/files/ja/web/api/webglrenderingcontext/bufferdata/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebGLRenderingContext.bufferData()
 slug: Web/API/WebGLRenderingContext/bufferData
-translation_of: Web/API/WebGLRenderingContext/bufferData
 ---
 {{APIRef("WebGL")}}
 

--- a/files/ja/web/api/webglrenderingcontext/clear/index.md
+++ b/files/ja/web/api/webglrenderingcontext/clear/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebGLRenderingContext.clear()
 slug: Web/API/WebGLRenderingContext/clear
-translation_of: Web/API/WebGLRenderingContext/clear
 ---
 {{APIRef("WebGL")}}
 

--- a/files/ja/web/api/webglrenderingcontext/clearcolor/index.md
+++ b/files/ja/web/api/webglrenderingcontext/clearcolor/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebGLRenderingContext.clearColor()
 slug: Web/API/WebGLRenderingContext/clearColor
-translation_of: Web/API/WebGLRenderingContext/clearColor
 ---
 {{APIRef("WebGL")}}
 

--- a/files/ja/web/api/webglrenderingcontext/cleardepth/index.md
+++ b/files/ja/web/api/webglrenderingcontext/cleardepth/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebGLRenderingContext.clearDepth()
 slug: Web/API/WebGLRenderingContext/clearDepth
-translation_of: Web/API/WebGLRenderingContext/clearDepth
 ---
 {{APIRef("WebGL")}}
 

--- a/files/ja/web/api/webglrenderingcontext/clearstencil/index.md
+++ b/files/ja/web/api/webglrenderingcontext/clearstencil/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebGLRenderingContext.clearStencil()
 slug: Web/API/WebGLRenderingContext/clearStencil
-translation_of: Web/API/WebGLRenderingContext/clearStencil
 ---
 {{APIRef("WebGL")}}
 

--- a/files/ja/web/api/webglrenderingcontext/compileshader/index.md
+++ b/files/ja/web/api/webglrenderingcontext/compileshader/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebGLRenderingContext.compileShader()
 slug: Web/API/WebGLRenderingContext/compileShader
-translation_of: Web/API/WebGLRenderingContext/compileShader
 ---
 {{APIRef("WebGL")}}
 

--- a/files/ja/web/api/webglrenderingcontext/createbuffer/index.md
+++ b/files/ja/web/api/webglrenderingcontext/createbuffer/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebGLRenderingContext.createBuffer()
 slug: Web/API/WebGLRenderingContext/createBuffer
-translation_of: Web/API/WebGLRenderingContext/createBuffer
 ---
 {{APIRef("WebGL")}}
 

--- a/files/ja/web/api/webglrenderingcontext/createprogram/index.md
+++ b/files/ja/web/api/webglrenderingcontext/createprogram/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebGLRenderingContext.createProgram()
 slug: Web/API/WebGLRenderingContext/createProgram
-translation_of: Web/API/WebGLRenderingContext/createProgram
 ---
 {{APIRef("WebGL")}}
 

--- a/files/ja/web/api/webglrenderingcontext/createshader/index.md
+++ b/files/ja/web/api/webglrenderingcontext/createshader/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebGLRenderingContext.createShader()
 slug: Web/API/WebGLRenderingContext/createShader
-translation_of: Web/API/WebGLRenderingContext/createShader
 ---
 {{APIRef("WebGL")}}
 

--- a/files/ja/web/api/webglrenderingcontext/drawarrays/index.md
+++ b/files/ja/web/api/webglrenderingcontext/drawarrays/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebGLRenderingContext.drawArrays()
 slug: Web/API/WebGLRenderingContext/drawArrays
-translation_of: Web/API/WebGLRenderingContext/drawArrays
 ---
 {{APIRef("WebGL")}}
 

--- a/files/ja/web/api/webglrenderingcontext/drawelements/index.md
+++ b/files/ja/web/api/webglrenderingcontext/drawelements/index.md
@@ -1,14 +1,6 @@
 ---
 title: WebGLRenderingContext.drawElements()
 slug: Web/API/WebGLRenderingContext/drawElements
-tags:
-  - API
-  - メソッド
-  - リファレンス
-  - WebGL
-  - WebGLRenderingContext
-browser-compat: api.WebGLRenderingContext.drawElements
-translation_of: Web/API/WebGLRenderingContext/drawElements
 ---
 {{APIRef("WebGL")}}
 

--- a/files/ja/web/api/webglrenderingcontext/getattriblocation/index.md
+++ b/files/ja/web/api/webglrenderingcontext/getattriblocation/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebGLRenderingContext.getAttribLocation()
 slug: Web/API/WebGLRenderingContext/getAttribLocation
-translation_of: Web/API/WebGLRenderingContext/getAttribLocation
 ---
 {{APIRef("WebGL")}}
 

--- a/files/ja/web/api/webglrenderingcontext/index.md
+++ b/files/ja/web/api/webglrenderingcontext/index.md
@@ -1,23 +1,6 @@
 ---
 title: WebGLRenderingContext
 slug: Web/API/WebGLRenderingContext
-page-type: web-api-interface
-tags:
-  - 2D
-  - 3D
-  - API
-  - Canvas
-  - Context
-  - Drawing
-  - GL
-  - Graphics
-  - Interface
-  - Reference
-  - WebGL
-  - WebGLRenderingContext
-  - rendering
-browser-compat: api.WebGLRenderingContext
-translation_of: Web/API/WebGLRenderingContext
 ---
 {{APIRef("WebGL")}}
 

--- a/files/ja/web/api/webglrenderingcontext/linkprogram/index.md
+++ b/files/ja/web/api/webglrenderingcontext/linkprogram/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebGLRenderingContext.linkProgram()
 slug: Web/API/WebGLRenderingContext/linkProgram
-translation_of: Web/API/WebGLRenderingContext/linkProgram
 ---
 {{APIRef("WebGL")}}
 

--- a/files/ja/web/api/webglrenderingcontext/shadersource/index.md
+++ b/files/ja/web/api/webglrenderingcontext/shadersource/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebGLRenderingContext.shaderSource()
 slug: Web/API/WebGLRenderingContext/shaderSource
-translation_of: Web/API/WebGLRenderingContext/shaderSource
 ---
 {{APIRef("WebGL")}}
 

--- a/files/ja/web/api/webglrenderingcontext/uniform/index.md
+++ b/files/ja/web/api/webglrenderingcontext/uniform/index.md
@@ -1,14 +1,6 @@
 ---
 title: WebGLRenderingContext.uniform[1234][fi][v]()
 slug: Web/API/WebGLRenderingContext/uniform
-tags:
-  - API
-  - メソッド
-  - リファレンス
-  - WebGL
-  - WebGLRenderingContext
-browser-compat: api.WebGLRenderingContext.uniform1f
-translation_of: Web/API/WebGLRenderingContext/uniform
 ---
 {{APIRef("WebGL")}}
 

--- a/files/ja/web/api/webglrenderingcontext/uniformmatrix/index.md
+++ b/files/ja/web/api/webglrenderingcontext/uniformmatrix/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebGLRenderingContext.uniformMatrix[234]fv()
 slug: Web/API/WebGLRenderingContext/uniformMatrix
-translation_of: Web/API/WebGLRenderingContext/uniformMatrix
 ---
 {{APIRef("WebGL")}}
 

--- a/files/ja/web/api/webglrenderingcontext/useprogram/index.md
+++ b/files/ja/web/api/webglrenderingcontext/useprogram/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebGLRenderingContext.useProgram()
 slug: Web/API/WebGLRenderingContext/useProgram
-translation_of: Web/API/WebGLRenderingContext/useProgram
 ---
 {{APIRef("WebGL")}}
 

--- a/files/ja/web/api/webglrenderingcontext/vertexattribpointer/index.md
+++ b/files/ja/web/api/webglrenderingcontext/vertexattribpointer/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebGLRenderingContext.vertexAttribPointer()
 slug: Web/API/WebGLRenderingContext/vertexAttribPointer
-translation_of: Web/API/WebGLRenderingContext/vertexAttribPointer
 ---
 {{APIRef("WebGL")}}
 

--- a/files/ja/web/api/webrtc_api/connectivity/index.md
+++ b/files/ja/web/api/webrtc_api/connectivity/index.md
@@ -1,17 +1,6 @@
 ---
 title: WebRTC 接続
 slug: Web/API/WebRTC_API/Connectivity
-page-type: guide
-tags:
-  - API
-  - Advanced
-  - Audio
-  - Draft
-  - Guide
-  - Media
-  - Video
-  - WebRTC
-translation_of: Web/API/WebRTC_API/Connectivity
 ---
 {{WebRTCSidebar}}
 

--- a/files/ja/web/api/webrtc_api/index.md
+++ b/files/ja/web/api/webrtc_api/index.md
@@ -1,23 +1,6 @@
 ---
 title: WebRTC API
 slug: Web/API/WebRTC_API
-page-type: web-api-overview
-tags:
-  - API
-  - Audio
-  - Conferencing
-  - Landing
-  - Media
-  - Networking
-  - Video
-  - WebRTC
-  - WebRTC API
-  - streaming
-spec-urls:
-  - https://w3c.github.io/webrtc-pc/
-  - https://w3c.github.io/mediacapture-main/
-  - https://w3c.github.io/mediacapture-fromelement/
-translation_of: Web/API/WebRTC_API
 ---
 {{DefaultAPISidebar("WebRTC")}}
 

--- a/files/ja/web/api/webrtc_api/protocols/index.md
+++ b/files/ja/web/api/webrtc_api/protocols/index.md
@@ -1,23 +1,6 @@
 ---
 title: WebRTC プロトコル入門
 slug: Web/API/WebRTC_API/Protocols
-page-type: guide
-tags:
-  - API
-  - Audio
-  - Beginner
-  - Draft
-  - Guide
-  - ICE
-  - Media
-  - NAT
-  - SDP
-  - STUN
-  - TURN
-  - Video
-  - WebRTC
-  - WebRTC API
-translation_of: Web/API/WebRTC_API/Protocols
 ---
 {{WebRTCSidebar}}
 

--- a/files/ja/web/api/websocket/binarytype/index.md
+++ b/files/ja/web/api/websocket/binarytype/index.md
@@ -1,14 +1,6 @@
 ---
 title: WebSocket.binaryType
 slug: Web/API/WebSocket/binaryType
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - Web API
-  - WebSocket
-browser-compat: api.WebSocket.binaryType
-translation_of: Web/API/WebSocket/binaryType
 ---
 {{APIRef("Web Sockets API")}}
 

--- a/files/ja/web/api/websocket/bufferedamount/index.md
+++ b/files/ja/web/api/websocket/bufferedamount/index.md
@@ -1,14 +1,6 @@
 ---
 title: WebSocket.bufferedAmount
 slug: Web/API/WebSocket/bufferedAmount
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - Web API
-  - WebSocket
-browser-compat: api.WebSocket.bufferedAmount
-translation_of: Web/API/WebSocket/bufferedAmount
 ---
 {{APIRef("Web Sockets API")}}
 

--- a/files/ja/web/api/websocket/close/index.md
+++ b/files/ja/web/api/websocket/close/index.md
@@ -1,14 +1,6 @@
 ---
 title: WebSocket.close()
 slug: Web/API/WebSocket/close
-tags:
-  - API
-  - メソッド
-  - リファレンス
-  - Web API
-  - WebSocket
-browser-compat: api.WebSocket.close
-translation_of: Web/API/WebSocket/close
 ---
 {{APIRef("Web Sockets API")}}
 

--- a/files/ja/web/api/websocket/close_event/index.md
+++ b/files/ja/web/api/websocket/close_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'WebSocket: close イベント'
 slug: Web/API/WebSocket/close_event
-tags:
-  - API
-  - Event
-  - リファレンス
-  - ウェブ
-  - WebSocket
-  - close
-  - イベント
-browser-compat: api.WebSocket.close_event
-translation_of: Web/API/WebSocket/close_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/websocket/error_event/index.md
+++ b/files/ja/web/api/websocket/error_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'WebSocket: error イベント'
 slug: Web/API/WebSocket/error_event
-tags:
-  - API
-  - Error
-  - イベント
-  - リファレンス
-  - ウェブ
-  - WebSocket
-browser-compat: api.WebSocket.error_event
-translation_of: Web/API/WebSocket/error_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/websocket/extensions/index.md
+++ b/files/ja/web/api/websocket/extensions/index.md
@@ -1,14 +1,6 @@
 ---
 title: WebSocket.extensions
 slug: Web/API/WebSocket/extensions
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - Web API
-  - WebSocket
-browser-compat: api.WebSocket.extensions
-translation_of: Web/API/WebSocket/extensions
 ---
 {{APIRef("Web Sockets API")}}
 

--- a/files/ja/web/api/websocket/index.md
+++ b/files/ja/web/api/websocket/index.md
@@ -1,14 +1,6 @@
 ---
 title: WebSocket
 slug: Web/API/WebSocket
-tags:
-  - API
-  - インターフェイス
-  - NeedsContent
-  - WebSocket
-  - WebSockets
-browser-compat: api.WebSocket
-translation_of: Web/API/WebSocket
 ---
 {{APIRef("Web Sockets API")}}
 

--- a/files/ja/web/api/websocket/message_event/index.md
+++ b/files/ja/web/api/websocket/message_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'WebSocket: message イベント'
 slug: Web/API/WebSocket/message_event
-tags:
-  - Event
-  - リファレンス
-  - WebSocket
-  - message
-browser-compat: api.WebSocket.message_event
-translation_of: Web/API/WebSocket/message_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/websocket/open_event/index.md
+++ b/files/ja/web/api/websocket/open_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'WebSocket: open イベント'
 slug: Web/API/WebSocket/open_event
-tags:
-  - API
-  - Event
-  - WebSocket
-  - イベント
-  - open
-browser-compat: api.WebSocket.open_event
-translation_of: Web/API/WebSocket/open_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/websocket/protocol/index.md
+++ b/files/ja/web/api/websocket/protocol/index.md
@@ -1,14 +1,6 @@
 ---
 title: WebSocket.protocol
 slug: Web/API/WebSocket/protocol
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - Web API
-  - WebSocket
-browser-compat: api.WebSocket.protocol
-translation_of: Web/API/WebSocket/protocol
 ---
 {{APIRef("Web Sockets API")}}
 

--- a/files/ja/web/api/websocket/readystate/index.md
+++ b/files/ja/web/api/websocket/readystate/index.md
@@ -1,14 +1,6 @@
 ---
 title: WebSocket.readyState
 slug: Web/API/WebSocket/readyState
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - Web API
-  - WebSocket
-browser-compat: api.WebSocket.readyState
-translation_of: Web/API/WebSocket/readyState
 ---
 {{APIRef("Web Sockets API")}}
 

--- a/files/ja/web/api/websocket/send/index.md
+++ b/files/ja/web/api/websocket/send/index.md
@@ -1,14 +1,6 @@
 ---
 title: WebSocket.send()
 slug: Web/API/WebSocket/send
-tags:
-  - API
-  - メソッド
-  - リファレンス
-  - Web API
-  - WebSocket
-browser-compat: api.WebSocket.send
-translation_of: Web/API/WebSocket/send
 ---
 {{APIRef("Web Sockets API")}}
 

--- a/files/ja/web/api/websocket/url/index.md
+++ b/files/ja/web/api/websocket/url/index.md
@@ -1,14 +1,6 @@
 ---
 title: WebSocket.url
 slug: Web/API/WebSocket/url
-tags:
-  - API
-  - プロパティ
-  - リファレンス
-  - Web API
-  - WebSocket
-browser-compat: api.WebSocket.url
-translation_of: Web/API/WebSocket/url
 ---
 {{APIRef("Web Sockets API")}}
 

--- a/files/ja/web/api/websocket/websocket/index.md
+++ b/files/ja/web/api/websocket/websocket/index.md
@@ -1,14 +1,6 @@
 ---
 title: WebSocket()
 slug: Web/API/WebSocket/WebSocket
-tags:
-  - API
-  - コンストラクター
-  - リファレンス
-  - Web API
-  - WebSocket
-browser-compat: api.WebSocket.WebSocket
-translation_of: Web/API/WebSocket/WebSocket
 ---
 {{APIRef("Web Sockets API")}}
 

--- a/files/ja/web/api/websockets_api/index.md
+++ b/files/ja/web/api/websockets_api/index.md
@@ -1,19 +1,6 @@
 ---
 title: WebSocket API (WebSockets)
 slug: Web/API/WebSockets_API
-tags:
-  - API
-  - クライアント
-  - 通信
-  - 概要
-  - サーバー
-  - 双方向
-  - WebSocket
-  - WebSocket API
-  - ウェブソケット
-  - データ
-  - 対話
-translation_of: Web/API/WebSockets_API
 ---
 {{DefaultAPISidebar("Websockets API")}}
 

--- a/files/ja/web/api/websockets_api/writing_a_websocket_server_in_java/index.md
+++ b/files/ja/web/api/websockets_api/writing_a_websocket_server_in_java/index.md
@@ -1,13 +1,6 @@
 ---
 title: Java で WebSocket サーバーを記述する
 slug: Web/API/WebSockets_API/Writing_a_WebSocket_server_in_Java
-tags:
-  - HTML5
-  - ハンドシェイク
-  - NeedsMarkupWork
-  - チュートリアル
-  - WebSocket
-translation_of: Web/API/WebSockets_API/Writing_a_WebSocket_server_in_Java
 ---
 ## はじめに
 

--- a/files/ja/web/api/websockets_api/writing_websocket_client_applications/index.md
+++ b/files/ja/web/api/websockets_api/writing_websocket_client_applications/index.md
@@ -1,16 +1,6 @@
 ---
 title: WebSocket クライアントアプリケーションの記述
 slug: Web/API/WebSockets_API/Writing_WebSocket_client_applications
-tags:
-  - Client
-  - Example
-  - ガイド
-  - ネットワーク
-  - ウェブソケット API
-  - WebSocket
-  - WebSocket API
-  - WebSockets
-translation_of: Web/API/WebSockets_API/Writing_WebSocket_client_applications
 ---
 {{APIRef("Websockets API")}}
 

--- a/files/ja/web/api/websockets_api/writing_websocket_server/index.md
+++ b/files/ja/web/api/websockets_api/writing_websocket_server/index.md
@@ -1,12 +1,6 @@
 ---
 title: C# で WebSocket サーバーを記述する
 slug: Web/API/WebSockets_API/Writing_WebSocket_server
-tags:
-  - HTML5
-  - NeedsMarkupWork
-  - チュートリアル
-  - WebSockets
-translation_of: Web/API/WebSockets_API/Writing_WebSocket_server
 ---
 ## はじめに
 

--- a/files/ja/web/api/websockets_api/writing_websocket_servers/index.md
+++ b/files/ja/web/api/websockets_api/writing_websocket_servers/index.md
@@ -1,17 +1,6 @@
 ---
 title: WebSocket サーバーの記述
 slug: Web/API/WebSockets_API/Writing_WebSocket_servers
-tags:
-  - ガイド
-  - HTML5
-  - NeedsContent
-  - NeedsExample
-  - NeedsMarkupWork
-  - チュートリアル
-  - WebSocket
-  - WebSocket API
-  - WebSockets
-translation_of: Web/API/WebSockets_API/Writing_WebSocket_servers
 ---
 {{APIRef("Websockets API")}}
 

--- a/files/ja/web/api/webvr_api/concepts/index.md
+++ b/files/ja/web/api/webvr_api/concepts/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebVR concepts
 slug: Web/API/WebVR_API/Concepts
-translation_of: Web/API/WebVR_API/Concepts
 ---
 {{APIRef("WebVR API")}}
 

--- a/files/ja/web/api/webvr_api/index.md
+++ b/files/ja/web/api/webvr_api/index.md
@@ -1,17 +1,6 @@
 ---
 title: WebVR API
 slug: Web/API/WebVR_API
-tags:
-  - API
-  - Deprecated
-  - Experimental
-  - Landing
-  - Obsolete
-  - Reference
-  - VR
-  - Virtual Reality
-  - WebVR
-translation_of: Web/API/WebVR_API
 ---
 {{DefaultAPISidebar("WebVR API")}}{{Deprecated_Header}}
 

--- a/files/ja/web/api/webvr_api/using_the_webvr_api/index.md
+++ b/files/ja/web/api/webvr_api/using_the_webvr_api/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebVR APIの使い方
 slug: Web/API/WebVR_API/Using_the_WebVR_API
-translation_of: Web/API/WebVR_API/Using_the_WebVR_API
 ---
 [WebVR API](/ja/docs/Web/API/WebVR_API) はウェブ開発者のツールキットへのすばらしい追加機能で、[Oculus Rift](https://developer.oculus.com/) のようなバーチャルリアリティハードウェアへのアクセスが可能となります。そして出力された動きや向きはウェブアプリの描画更新に変換されます。しかし VR アプリを開発はどのようにやればいいのでしょうか？ この記事では、それに関する基礎的な解説を行います。
 

--- a/files/ja/web/api/webvr_api/using_vr_controllers_with_webvr/index.md
+++ b/files/ja/web/api/webvr_api/using_vr_controllers_with_webvr/index.md
@@ -1,16 +1,6 @@
 ---
 title: WebVRでの VRコントローラーの使用
 slug: Web/API/WebVR_API/Using_VR_controllers_with_WebVR
-tags:
-  - Experimental
-  - Gamepad API
-  - Guide
-  - VR
-  - Virtual Reality
-  - WebGL
-  - WebVR
-  - controllers
-translation_of: Web/API/WebVR_API/Using_VR_controllers_with_WebVR
 ---
 {{APIRef("WebVR API")}}
 

--- a/files/ja/web/api/webvtt_api/index.md
+++ b/files/ja/web/api/webvtt_api/index.md
@@ -1,18 +1,6 @@
 ---
 title: Web ビデオテキストトラックフォーマット (WebVTT)
 slug: Web/API/WebVTT_API
-tags:
-  - API
-  - Intermediate
-  - Media
-  - Reference
-  - Video
-  - Web Video Text Tracks
-  - WebVTT
-  - captions
-  - subtitles
-  - text tracks
-translation_of: Web/API/WebVTT_API
 ---
 {{DefaultAPISidebar("WebVTT")}}
 

--- a/files/ja/web/api/webxr_device_api/cameras/index.md
+++ b/files/ja/web/api/webxr_device_api/cameras/index.md
@@ -1,31 +1,6 @@
 ---
 title: '視点とビューアー: WebXR でのカメラのシミュレーション'
 slug: Web/API/WebXR_Device_API/Cameras
-tags:
-  - 3D
-  - API
-  - AR
-  - Advanced
-  - Cameras
-  - Coordinates
-  - Guide
-  - Location
-  - Motion
-  - Position
-  - VR
-  - Viewers
-  - Viewpoints
-  - WebGL
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-  - XRPose
-  - XRView
-  - XRViewerPose
-  - rotation
-  - transform
-translation_of: Web/API/WebXR_Device_API/Cameras
 ---
 {{DefaultAPISidebar("WebXR Device API")}}
 

--- a/files/ja/web/api/webxr_device_api/fundamentals/index.md
+++ b/files/ja/web/api/webxr_device_api/fundamentals/index.md
@@ -1,22 +1,6 @@
 ---
 title: WebXR の基礎
 slug: Web/API/WebXR_Device_API/Fundamentals
-page-type: guide
-tags:
-  - API
-  - AR
-  - Getting Started
-  - Guide
-  - Reality
-  - VR
-  - Virtual
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-  - augmented
-  - basics
-  - memory
 ---
 {{DefaultAPISidebar("WebXR Device API")}}
 

--- a/files/ja/web/api/webxr_device_api/geometry/index.md
+++ b/files/ja/web/api/webxr_device_api/geometry/index.md
@@ -1,21 +1,6 @@
 ---
 title: WebXR の形状と参照空間
 slug: Web/API/WebXR_Device_API/Geometry
-page-type: guide
-tags:
-  - API
-  - Geometry
-  - Guide
-  - Math
-  - Orientation
-  - Placement
-  - Position
-  - Reference Spaces
-  - Spaces
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-translation_of: Web/API/WebXR_Device_API/Geometry
 ---
 {{DefaultAPISidebar("WebXR Device API")}}
 

--- a/files/ja/web/api/webxr_device_api/index.md
+++ b/files/ja/web/api/webxr_device_api/index.md
@@ -1,19 +1,6 @@
 ---
 title: WebXR Device API
 slug: Web/API/WebXR_Device_API
-tags:
-  - API
-  - AR
-  - Augmented Reality
-  - Graphics
-  - Overview
-  - VR
-  - Virtual Reality
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-translation_of: Web/API/WebXR_Device_API
 ---
 {{DefaultAPISidebar("WebXR Device API")}}
 

--- a/files/ja/web/api/webxr_device_api/lighting/index.md
+++ b/files/ja/web/api/webxr_device_api/lighting/index.md
@@ -1,19 +1,6 @@
 ---
 title: WebXR 設定の照明
 slug: Web/API/WebXR_Device_API/Lighting
-tags:
-  - 3D
-  - API
-  - Graphics
-  - Light
-  - Shading
-  - Shadows
-  - WebGL
-  - WebXR
-  - WebXR Device API
-  - lighting
-  - rendering
-translation_of: Web/API/WebXR_Device_API/Lighting
 ---
 {{DefaultAPISidebar("WebXR Device API")}}
 

--- a/files/ja/web/api/webxr_device_api/movement_and_motion/index.md
+++ b/files/ja/web/api/webxr_device_api/movement_and_motion/index.md
@@ -1,23 +1,6 @@
 ---
 title: '移動、向き、モーション: WebXR の例'
 slug: Web/API/WebXR_Device_API/Movement_and_motion
-tags:
-  - 3D
-  - API
-  - AR
-  - Example
-  - Guide
-  - Reality
-  - Tutorial
-  - VR
-  - Virtual
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-  - augmented
-  - rendering
-translation_of: Web/API/WebXR_Device_API/Movement_and_motion
 ---
 {{DefaultAPISidebar("WebXR Device API")}}
 

--- a/files/ja/web/api/webxr_device_api/rendering/index.md
+++ b/files/ja/web/api/webxr_device_api/rendering/index.md
@@ -1,28 +1,6 @@
 ---
 title: レンダリングと WebXR フレームアニメーションコールバック
 slug: Web/API/WebXR_Device_API/Rendering
-tags:
-  - API
-  - AR
-  - Animation
-  - Drawing
-  - Frames
-  - Games
-  - Guide
-  - Intermediate
-  - Reality
-  - Scene
-  - VR
-  - Virtual
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-  - augmented
-  - display
-  - rendering
-  - requestAnimationFrame
-translation_of: Web/API/WebXR_Device_API/Rendering
 ---
 {{DefaultAPISidebar("WebXR Device API")}}
 

--- a/files/ja/web/api/webxr_device_api/startup_and_shutdown/index.md
+++ b/files/ja/web/api/webxr_device_api/startup_and_shutdown/index.md
@@ -1,27 +1,6 @@
 ---
 title: WebXR セッションの起動と停止
 slug: Web/API/WebXR_Device_API/Startup_and_shutdown
-tags:
-  - 3D
-  - API
-  - AR
-  - Beginner
-  - Guide
-  - Initialization
-  - Mixed
-  - Preparation
-  - Reality
-  - Setup
-  - Shutdown
-  - Startup
-  - VR
-  - Virtual
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-  - augmented
-translation_of: Web/API/WebXR_Device_API/Startup_and_shutdown
 ---
 {{DefaultAPISidebar("WebXR Device API")}}{{SecureContext_header}}
 

--- a/files/ja/web/api/wheelevent/index.md
+++ b/files/ja/web/api/wheelevent/index.md
@@ -1,13 +1,6 @@
 ---
 title: WheelEvent
 slug: Web/API/WheelEvent
-tags:
-  - API
-  - DOM
-  - Interface
-  - Reference
-  - WheelEvent
-translation_of: Web/API/WheelEvent
 ---
 {{APIRef("DOM Events")}}
 

--- a/files/ja/web/api/window/afterprint_event/index.md
+++ b/files/ja/web/api/window/afterprint_event/index.md
@@ -1,11 +1,6 @@
 ---
 title: 'Window: afterprint イベント'
 slug: Web/API/Window/afterprint_event
-tags:
-  - Event
-  - Reference
-  - イベント
-translation_of: Web/API/Window/afterprint_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/alert/index.md
+++ b/files/ja/web/api/window/alert/index.md
@@ -1,15 +1,6 @@
 ---
 title: window.alert
 slug: Web/API/Window/alert
-tags:
-  - API
-  - DOM
-  - Gecko
-  - Method
-  - Reference
-  - Window
-  - alert
-translation_of: Web/API/Window/alert
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/window/appinstalled_event/index.md
+++ b/files/ja/web/api/window/appinstalled_event/index.md
@@ -1,18 +1,6 @@
 ---
 title: 'Window: appinstalled イベント'
 slug: Web/API/Window/appinstalled_event
-tags:
-  - API
-  - Event
-  - Manifest
-  - Reference
-  - Web
-  - appinstalled
-  - events
-  - web manifest
-  - ウェブマニフェスト
-  - マニフェスト
-translation_of: Web/API/Window/appinstalled_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/applicationcache/index.md
+++ b/files/ja/web/api/window/applicationcache/index.md
@@ -1,14 +1,6 @@
 ---
 title: window.applicationCache
 slug: Web/API/Window/applicationCache
-tags:
-  - API
-  - Deprecated
-  - HTML DOM
-  - Property
-  - Reference
-  - Window
-translation_of: Web/API/Window/applicationCache
 ---
 > **Warning:** **重要**: アプリケーションキャッシュは Firefox 44 で非推奨となり、 Firefox 60 以降では安全ではないコンテキストでは利用できなくなりました ({{bug(1354175)}}、現在は Nightly/Beta のみ)。ウェブサイトをオフラインで利用するために使用しないでください。 — 代わりに[サービスワーカー](/ja/docs/Web/API/Service_Worker_API)の利用を検討してください。
 

--- a/files/ja/web/api/window/back/index.md
+++ b/files/ja/web/api/window/back/index.md
@@ -1,18 +1,6 @@
 ---
 title: Window.back()
 slug: Web/API/Window/back
-page-type: web-api-instance-method
-tags:
-  - API
-  - Firefox
-  - Gecko
-  - HTML DOM
-  - Method
-  - Non-standard
-  - Deprecated
-  - Window
-  - back
-translation_of: Web/API/Window/back
 ---
 {{APIRef}}{{ Non-standard_header() }}{{deprecated_header}}
 

--- a/files/ja/web/api/window/beforeprint_event/index.md
+++ b/files/ja/web/api/window/beforeprint_event/index.md
@@ -1,10 +1,6 @@
 ---
 title: 'Window: beforeprint イベント'
 slug: Web/API/Window/beforeprint_event
-tags:
-  - Event
-  - Reference
-translation_of: Web/API/Window/beforeprint_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/beforeunload_event/index.md
+++ b/files/ja/web/api/window/beforeunload_event/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'Window: beforeunload イベント'
 slug: Web/API/Window/beforeunload_event
-tags:
-  - Event
-  - Reference
-  - Window
-  - イベント
-translation_of: Web/API/Window/beforeunload_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/blur/index.md
+++ b/files/ja/web/api/window/blur/index.md
@@ -1,13 +1,6 @@
 ---
 title: Window.blur()
 slug: Web/API/Window/blur
-tags:
-  - API
-  - DOM
-  - Gecko
-  - メソッド
-browser-compat: api.Window.blur
-translation_of: Web/API/Window/blur
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/blur_event/index.md
+++ b/files/ja/web/api/window/blur_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'Window: blur イベント'
 slug: Web/API/Window/blur_event
-tags:
-  - API
-  - イベント
-  - FocusEvent
-  - リファレンス
-  - ウェブ
-  - Window
-  - blur
-  - onblur
-browser-compat: api.Window.blur_event
-translation_of: Web/API/Window/blur_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/cancelanimationframe/index.md
+++ b/files/ja/web/api/window/cancelanimationframe/index.md
@@ -1,11 +1,6 @@
 ---
 title: window.cancelAnimationFrame
 slug: Web/API/Window/cancelAnimationFrame
-tags:
-  - API
-  - DOM
-  - Method
-translation_of: Web/API/Window/cancelAnimationFrame
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/captureevents/index.md
+++ b/files/ja/web/api/window/captureevents/index.md
@@ -1,13 +1,6 @@
 ---
 title: Window.captureEvents()
 slug: Web/API/Window/captureEvents
-tags:
-  - API
-  - Gecko
-  - HTML DOM
-  - Method
-  - Non-standard
-translation_of: Web/API/Window/captureEvents
 ---
 {{ ApiRef() }} {{Deprecated_Header}} {{Non-standard_header}}
 

--- a/files/ja/web/api/window/close/index.md
+++ b/files/ja/web/api/window/close/index.md
@@ -1,14 +1,6 @@
 ---
 title: window.close
 slug: Web/API/Window/close
-tags:
-  - API
-  - DOM
-  - Gecko
-  - Method
-  - Reference
-  - Window
-translation_of: Web/API/Window/close
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/closed/index.md
+++ b/files/ja/web/api/window/closed/index.md
@@ -1,13 +1,6 @@
 ---
 title: window.closed
 slug: Web/API/Window/closed
-tags:
-  - DOM
-  - DOM_0
-  - Gecko
-  - Gecko DOM Reference
-  - Window
-translation_of: Web/API/Window/closed
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/window/confirm/index.md
+++ b/files/ja/web/api/window/confirm/index.md
@@ -1,12 +1,6 @@
 ---
 title: window.confirm
 slug: Web/API/Window/confirm
-tags:
-  - DOM
-  - DOM_0
-  - Gecko
-  - Gecko DOM Reference
-translation_of: Web/API/Window/confirm
 ---
 {{ApiRef("Window")}}
 

--- a/files/ja/web/api/window/console/index.md
+++ b/files/ja/web/api/window/console/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.console
 slug: Web/API/Window/console
-translation_of: Web/API/Window/console
 ---
 {{ APIRef }}
 

--- a/files/ja/web/api/window/content/index.md
+++ b/files/ja/web/api/window/content/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.content
 slug: Web/API/Window/content
-translation_of: Web/API/Window/content
 ---
 {{APIRef}}{{non-standard_header}}
 

--- a/files/ja/web/api/window/copy_event/index.md
+++ b/files/ja/web/api/window/copy_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Window: copy イベント'
 slug: Web/API/Window/copy_event
-tags:
-  - API
-  - Clippboard API
-  - Event
-  - Reference
-  - Web
-  - Window
-  - copy
-  - イベント
-translation_of: Web/API/Window/copy_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/customelements/index.md
+++ b/files/ja/web/api/window/customelements/index.md
@@ -1,17 +1,6 @@
 ---
 title: Window.customElements
 slug: Web/API/Window/customElements
-tags:
-  - API
-  - CustomElementRegistry
-  - プロパティ
-  - リファレンス
-  - ウェブコンポーネント
-  - Window
-  - カスタム要素
-  - customElements
-browser-compat: api.Window.customElements
-translation_of: Web/API/Window/customElements
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/cut_event/index.md
+++ b/files/ja/web/api/window/cut_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Window: cut イベント'
 slug: Web/API/Window/cut_event
-tags:
-  - API
-  - Clippboard API
-  - Cut
-  - Event
-  - Reference
-  - Web
-  - Window
-  - イベント
-translation_of: Web/API/Window/cut_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/defaultstatus/index.md
+++ b/files/ja/web/api/window/defaultstatus/index.md
@@ -1,18 +1,6 @@
 ---
 title: Window.defaultStatus
 slug: Web/API/Window/defaultStatus
-tags:
-  - API
-  - HTML DOM
-  - NeedsCompatTable
-  - NeedsExample
-  - NeedsMarkupWork
-  - NeedsSpecTable
-  - Deprecated
-  - Property
-  - Reference
-  - Window
-translation_of: Web/API/Window/defaultStatus
 ---
 {{APIRef()}}{{deprecated_header}}
 

--- a/files/ja/web/api/window/devicemotion_event/index.md
+++ b/files/ja/web/api/window/devicemotion_event/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'Window: devicemotion イベント'
 slug: Web/API/Window/devicemotion_event
-tags:
-  - API
-  - Device Orientation API
-  - Sensors
-  - events
-translation_of: Web/API/Window/devicemotion_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/deviceorientation_event/index.md
+++ b/files/ja/web/api/window/deviceorientation_event/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'Window: deviceorientation イベント'
 slug: Web/API/Window/deviceorientation_event
-tags:
-  - Device Orientation API
-  - Sensors
-  - Window Event
-  - events
-translation_of: Web/API/Window/deviceorientation_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/devicepixelratio/index.md
+++ b/files/ja/web/api/window/devicepixelratio/index.md
@@ -1,19 +1,6 @@
 ---
 title: Window.devicePixelRatio
 slug: Web/API/Window/devicePixelRatio
-page-type: web-api-instance-property
-tags:
-  - API
-  - Adaptive Design
-  - Property
-  - Read-only
-  - Reference
-  - Window
-  - devicePixelRatio
-  - ratio
-  - resolution
-browser-compat: api.Window.devicePixelRatio
-translation_of: Web/API/Window/devicePixelRatio
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/document/index.md
+++ b/files/ja/web/api/window/document/index.md
@@ -1,13 +1,6 @@
 ---
 title: Window.document
 slug: Web/API/Window/document
-tags:
-  - API
-  - HTML DOM
-  - Property
-  - Reference
-  - Window
-translation_of: Web/API/Window/document
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/domcontentloaded_event/index.md
+++ b/files/ja/web/api/window/domcontentloaded_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'Window: DOMContentLoaded イベント'
 slug: Web/API/Window/DOMContentLoaded_event
-tags:
-  - Event
-  - Reference
-  - Web
-  - Window
-  - events
-translation_of: Web/API/Window/DOMContentLoaded_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/dump/index.md
+++ b/files/ja/web/api/window/dump/index.md
@@ -1,13 +1,6 @@
 ---
 title: window.dump()
 slug: Web/API/Window/dump
-tags:
-  - API
-  - DOM
-  - DOM_0
-  - Method
-  - Non-standard
-translation_of: Web/API/Window/dump
 ---
 {{ ApiRef() }}
 

--- a/files/ja/web/api/window/error_event/index.md
+++ b/files/ja/web/api/window/error_event/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'Window: error イベント'
 slug: Web/API/Window/error_event
-tags:
-  - API
-  - Event
-  - UI Events
-  - Window
-translation_of: Web/API/Window/error_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/event/index.md
+++ b/files/ja/web/api/window/event/index.md
@@ -1,14 +1,6 @@
 ---
 title: Window.event
 slug: Web/API/Window/event
-tags:
-  - API
-  - DOM
-  - Event
-  - Event Handler
-  - Read-only
-  - Window
-translation_of: Web/API/Window/event
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/window/find/index.md
+++ b/files/ja/web/api/window/find/index.md
@@ -1,18 +1,6 @@
 ---
 title: Window.find()
 slug: Web/API/Window/find
-tags:
-  - API
-  - HTML DOM
-  - メソッド
-  - NeedsCompatTable
-  - NeedsContent
-  - 標準外
-  - リファレンス
-  - Window
-  - find
-browser-compat: api.Window.find
-translation_of: Web/API/Window/find
 ---
 {{ApiRef}}{{Non-standard_Header}}
 

--- a/files/ja/web/api/window/focus/index.md
+++ b/files/ja/web/api/window/focus/index.md
@@ -1,14 +1,6 @@
 ---
 title: Window.focus()
 slug: Web/API/Window/focus
-tags:
-  - API
-  - Gecko
-  - HTML DOM
-  - メソッド
-  - Window
-browser-compat: api.Window.focus
-translation_of: Web/API/Window/focus
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/focus_event/index.md
+++ b/files/ja/web/api/window/focus_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'Window: focus イベント'
 slug: Web/API/Window/focus_event
-tags:
-  - API
-  - イベント
-  - Focus
-  - FocusEvent
-  - リファレンス
-  - ウェブ
-  - Window
-  - onfocus
-browser-compat: api.Window.focus_event
-translation_of: Web/API/Window/focus_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/forward/index.md
+++ b/files/ja/web/api/window/forward/index.md
@@ -1,17 +1,6 @@
 ---
 title: window.forward
 slug: Web/API/Window/forward
-tags:
-  - API
-  - DOM
-  - Firefox
-  - Gecko
-  - Method
-  - Non-standard
-  - Obsolete
-  - Window
-  - forward
-translation_of: Web/API/Window/forward
 ---
 {{ApiRef}}{{Non-standard_header}} {{deprecated_header}}
 

--- a/files/ja/web/api/window/frameelement/index.md
+++ b/files/ja/web/api/window/frameelement/index.md
@@ -1,13 +1,6 @@
 ---
 title: window.frameElement
 slug: Web/API/Window/frameElement
-tags:
-  - API
-  - DOM
-  - Gecko
-  - HTML DOM
-  - Window
-translation_of: Web/API/Window/frameElement
 ---
 {{ ApiRef }}
 

--- a/files/ja/web/api/window/frames/index.md
+++ b/files/ja/web/api/window/frames/index.md
@@ -1,17 +1,6 @@
 ---
 title: Window.frames
 slug: Web/API/Window/frames
-tags:
-  - API
-  - Gecko
-  - HTML DOM
-  - NeedsContent
-  - NeedsUpdate
-  - Property
-  - Reference
-  - Window
-  - プロパティ
-translation_of: Web/API/Window/frames
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/window/fullscreen/index.md
+++ b/files/ja/web/api/window/fullscreen/index.md
@@ -1,17 +1,6 @@
 ---
 title: Window.fullScreen
 slug: Web/API/Window/fullScreen
-tags:
-  - API
-  - HTML DOM
-  - NeedsMarkupWork
-  - Non-standard
-  - Property
-  - Reference
-  - Window
-  - プロパティ
-  - 標準外
-translation_of: Web/API/Window/fullScreen
 ---
 {{APIRef}}{{Non-standard_Header}}
 

--- a/files/ja/web/api/window/gamepadconnected_event/index.md
+++ b/files/ja/web/api/window/gamepadconnected_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: gamepadconnected
 slug: Web/API/Window/gamepadconnected_event
-translation_of: Web/API/Window/gamepadconnected_event
 ---
 `gamepadconnected` イベントは、ゲームパッドが接続されたことをブラウザが検出したとき、またはゲームパッドのボタン/軸が初めて使用されたときに発生します。
 

--- a/files/ja/web/api/window/gamepaddisconnected_event/index.md
+++ b/files/ja/web/api/window/gamepaddisconnected_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: gamepaddisconnected
 slug: Web/API/Window/gamepaddisconnected_event
-translation_of: Web/API/Window/gamepaddisconnected_event
 ---
 ゲームパッドが切断されたことをブラウザが検出すると、`gampaddisconnected` イベントが発生します。
 

--- a/files/ja/web/api/window/getcomputedstyle/index.md
+++ b/files/ja/web/api/window/getcomputedstyle/index.md
@@ -1,16 +1,6 @@
 ---
 title: Window.getComputedStyle()
 slug: Web/API/Window/getComputedStyle
-page-type: web-api-instance-method
-tags:
-  - API
-  - CSSOM View
-  - Method
-  - Reference
-  - Window
-  - getComputedStyle
-browser-compat: api.Window.getComputedStyle
-translation_of: Web/API/Window/getComputedStyle
 l10n:
   sourceCommit: 27e11bf5ee2425dc6b939d0d1825ac741414a688
 ---

--- a/files/ja/web/api/window/getselection/index.md
+++ b/files/ja/web/api/window/getselection/index.md
@@ -1,17 +1,6 @@
 ---
 title: Window.getSelection()
 slug: Web/API/Window/getSelection
-page-type: web-api-instance-method
-tags:
-  - API
-  - HTML DOM
-  - Method
-  - Reference
-  - Selection
-  - Selection API
-  - Window
-browser-compat: api.Window.getSelection
-translation_of: Web/API/Window/getSelection
 l10n:
   sourceCommit: 964126ef650d6d6c11287db3f0e5c747bc5e36ac
 ---

--- a/files/ja/web/api/window/hashchange_event/index.md
+++ b/files/ja/web/api/window/hashchange_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'Window: hashchange イベント'
 slug: Web/API/Window/hashchange_event
-tags:
-  - API
-  - Event
-  - HTML DOM
-  - Reference
-  - Window
-  - イベント
-translation_of: Web/API/Window/hashchange_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/history/index.md
+++ b/files/ja/web/api/window/history/index.md
@@ -1,14 +1,6 @@
 ---
 title: Window.history
 slug: Web/API/Window/history
-tags:
-  - API
-  - HTML DOM
-  - History API
-  - Property
-  - Reference
-  - Window
-translation_of: Web/API/Window/history
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/index.md
+++ b/files/ja/web/api/window/index.md
@@ -1,20 +1,6 @@
 ---
 title: Window
 slug: Web/API/Window
-page-type: web-api-interface
-tags:
-  - API
-  - Browser
-  - HTML DOM
-  - Interface
-  - Reference
-  - Tab
-  - Window
-  - global
-  - global scope
-  - scope
-browser-compat: api.Window
-translation_of: Web/API/Window
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/window/innerheight/index.md
+++ b/files/ja/web/api/window/innerheight/index.md
@@ -1,19 +1,6 @@
 ---
 title: Window.innerHeight
 slug: Web/API/Window/innerHeight
-tags:
-  - API
-  - CSSOM
-  - CSSOM View
-  - HTML DOM
-  - NeedsInteractiveExample
-  - Property
-  - Reference
-  - View
-  - Window
-  - height
-  - innerHeight
-translation_of: Web/API/Window/innerHeight
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/innerwidth/index.md
+++ b/files/ja/web/api/window/innerwidth/index.md
@@ -1,17 +1,6 @@
 ---
 title: Window.innerWidth
 slug: Web/API/Window/innerWidth
-tags:
-  - API
-  - CSSOM View
-  - HTML DOM
-  - Layout
-  - Property
-  - Reference
-  - Window
-  - innerWidth
-  - width
-translation_of: Web/API/Window/innerWidth
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/languagechange_event/index.md
+++ b/files/ja/web/api/window/languagechange_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'Window: languagechange イベント'
 slug: Web/API/Window/languagechange_event
-tags:
-  - Event
-  - Experimental
-  - HTML DOM
-  - Reference
-  - Window
-  - イベント
-translation_of: Web/API/Window/languagechange_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/length/index.md
+++ b/files/ja/web/api/window/length/index.md
@@ -1,14 +1,6 @@
 ---
 title: window.length
 slug: Web/API/Window/length
-tags:
-  - API
-  - Gecko
-  - HTML DOM
-  - Property
-  - Reference
-  - Window
-translation_of: Web/API/Window/length
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/window/load_event/index.md
+++ b/files/ja/web/api/window/load_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'Window: load イベント'
 slug: Web/API/Window/load_event
-tags:
-  - DOM
-  - Event
-  - Reference
-  - Window
-  - load
-translation_of: Web/API/Window/load_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/localstorage/index.md
+++ b/files/ja/web/api/window/localstorage/index.md
@@ -1,17 +1,6 @@
 ---
 title: Window.localStorage
 slug: Web/API/Window/localStorage
-tags:
-  - API
-  - Property
-  - Read-only
-  - Reference
-  - Storage
-  - Web Storage
-  - Window
-  - WindowLocalStorage
-  - localStorage
-translation_of: Web/API/Window/localStorage
 ---
 {{APIRef()}}
 

--- a/files/ja/web/api/window/location/index.md
+++ b/files/ja/web/api/window/location/index.md
@@ -1,13 +1,6 @@
 ---
 title: Window.location
 slug: Web/API/Window/location
-tags:
-  - API
-  - HTML
-  - Reference
-  - Window
-  - プロパティ
-translation_of: Web/API/Window/location
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/locationbar/index.md
+++ b/files/ja/web/api/window/locationbar/index.md
@@ -1,15 +1,6 @@
 ---
 title: Window.locationbar
 slug: Web/API/Window/locationbar
-tags:
-  - API
-  - HTML DOM
-  - NeedsExample
-  - NeedsMarkupWork
-  - Property
-  - Reference
-  - Window
-translation_of: Web/API/Window/locationbar
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/matchmedia/index.md
+++ b/files/ja/web/api/window/matchmedia/index.md
@@ -1,14 +1,6 @@
 ---
 title: window.matchMedia
 slug: Web/API/Window/matchMedia
-tags:
-  - API
-  - CSSOM View
-  - Method
-  - NeedsMarkupWork
-  - NeedsSpecTable
-  - Reference
-translation_of: Web/API/Window/matchMedia
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/window/menubar/index.md
+++ b/files/ja/web/api/window/menubar/index.md
@@ -1,13 +1,6 @@
 ---
 title: Window.menubar
 slug: Web/API/Window/menubar
-tags:
-  - API
-  - HTML DOM
-  - Property
-  - Reference
-  - Window
-translation_of: Web/API/Window/menubar
 ---
 {{ APIRef() }}
 

--- a/files/ja/web/api/window/message_event/index.md
+++ b/files/ja/web/api/window/message_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: WindowEventHandlers.onmessage
 slug: Web/API/Window/message_event
-tags:
-  - API
-  - Event Handler
-  - HTML DOM
-  - Property
-  - Reference
-  - Window
-  - WindowEventHandlers
-  - events
-  - onmessage
-translation_of: Web/API/WindowEventHandlers/onmessage
 original_slug: Web/API/WindowEventHandlers/onmessage
 ---
 {{APIRef("HTML DOM")}}{{ SeeCompatTable() }}

--- a/files/ja/web/api/window/messageerror_event/index.md
+++ b/files/ja/web/api/window/messageerror_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'Window: messageerror イベント'
 slug: Web/API/Window/messageerror_event
-tags:
-  - API
-  - Event
-  - MessageEvent
-  - Reference
-  - Window
-  - イベント
-translation_of: Web/API/Window/messageerror_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/moveby/index.md
+++ b/files/ja/web/api/window/moveby/index.md
@@ -1,14 +1,6 @@
 ---
 title: Window.moveBy()
 slug: Web/API/Window/moveBy
-tags:
-  - API
-  - CSSOM View
-  - メソッド
-  - リファレンス
-  - Window
-browser-compat: api.Window.moveBy
-translation_of: Web/API/Window/moveBy
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/moveto/index.md
+++ b/files/ja/web/api/window/moveto/index.md
@@ -1,14 +1,6 @@
 ---
 title: Window.moveTo()
 slug: Web/API/Window/moveTo
-tags:
-  - API
-  - CSSOM View
-  - Method
-  - Reference
-  - Window
-browser-compat: api.Window.moveTo
-translation_of: Web/API/Window/moveTo
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/mozinnerscreenx/index.md
+++ b/files/ja/web/api/window/mozinnerscreenx/index.md
@@ -1,18 +1,6 @@
 ---
 title: Window.mozInnerScreenX
 slug: Web/API/Window/mozInnerScreenX
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - NeedsExample
-  - NeedsMarkupWork
-  - NeedsSpecTable
-  - Property
-  - Reference
-  - Window
-browser-compat: api.Window.mozInnerScreenX
-translation_of: Web/API/Window/mozInnerScreenX
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/mozinnerscreeny/index.md
+++ b/files/ja/web/api/window/mozinnerscreeny/index.md
@@ -1,18 +1,6 @@
 ---
 title: Window.mozInnerScreenY
 slug: Web/API/Window/mozInnerScreenY
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - NeedsExample
-  - NeedsMarkupWork
-  - NeedsSpecTable
-  - Property
-  - Reference
-  - Window
-browser-compat: api.Window.mozInnerScreenY
-translation_of: Web/API/Window/mozInnerScreenY
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/name/index.md
+++ b/files/ja/web/api/window/name/index.md
@@ -1,13 +1,6 @@
 ---
 title: window.name
 slug: Web/API/Window/name
-tags:
-  - API
-  - HTML DOM
-  - Property
-  - Reference
-  - Window
-translation_of: Web/API/Window/name
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/window/navigator/index.md
+++ b/files/ja/web/api/window/navigator/index.md
@@ -1,16 +1,6 @@
 ---
 title: Window.navigator
 slug: Web/API/Window/navigator
-page-type: web-api-instance-property
-tags:
-  - API
-  - HTML DOM
-  - Property
-  - Read-only
-  - Reference
-  - Window
-browser-compat: api.Window.navigator
-translation_of: Web/API/Window/navigator
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/offline_event/index.md
+++ b/files/ja/web/api/window/offline_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.onoffline
 slug: Web/API/Window/offline_event
-tags:
-  - API
-  - DOM
-  - NeedsContent
-  - Property
-  - Reference
-translation_of: Web/API/Document/onoffline
 original_slug: Web/API/Document/onoffline
 ---
 {{APIRef("DOM")}}

--- a/files/ja/web/api/window/online_event/index.md
+++ b/files/ja/web/api/window/online_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.ononline
 slug: Web/API/Window/online_event
-tags:
-  - API
-  - DOM
-  - Document
-  - Property
-  - Reference
-translation_of: Web/API/Document/ononline
 original_slug: Web/API/Document/ononline
 ---
 {{APIRef("DOM")}}

--- a/files/ja/web/api/window/open/index.md
+++ b/files/ja/web/api/window/open/index.md
@@ -1,16 +1,6 @@
 ---
 title: Window.open()
 slug: Web/API/Window/open
-page-type: web-api-instance-method
-tags:
-  - API
-  - DOM
-  - Method
-  - Reference
-  - Window
-  - open
-browser-compat: api.Window.open
-translation_of: Web/API/Window/open
 l10n:
   sourceCommit: 27e11bf5ee2425dc6b939d0d1825ac741414a688
 ---

--- a/files/ja/web/api/window/opener/index.md
+++ b/files/ja/web/api/window/opener/index.md
@@ -1,12 +1,6 @@
 ---
 title: window.opener
 slug: Web/API/Window/opener
-tags:
-  - DOM
-  - DOM_0
-  - Gecko
-  - Window
-translation_of: Web/API/Window/opener
 original_slug: Web/API/window.opener
 ---
 {{ApiRef}}

--- a/files/ja/web/api/window/orientationchange_event/index.md
+++ b/files/ja/web/api/window/orientationchange_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Window: orientationchange イベント'
 slug: Web/API/Window/orientationchange_event
-tags:
-  - API
-  - Event
-  - Reference
-  - Sensors
-  - Window
-  - onorientationchange
-  - イベント
-translation_of: Web/API/Window/orientationchange_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/outerheight/index.md
+++ b/files/ja/web/api/window/outerheight/index.md
@@ -1,14 +1,6 @@
 ---
 title: Window.outerHeight
 slug: Web/API/Window/outerHeight
-tags:
-  - API
-  - CSSOM View
-  - NeedsContent
-  - Property
-  - Reference
-  - outerHeight
-translation_of: Web/API/Window/outerHeight
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/outerwidth/index.md
+++ b/files/ja/web/api/window/outerwidth/index.md
@@ -1,14 +1,6 @@
 ---
 title: Window.outerWidth
 slug: Web/API/Window/outerWidth
-tags:
-  - API
-  - CSSOM View
-  - NeedsContent
-  - Property
-  - Reference
-  - outerWidth
-translation_of: Web/API/Window/outerWidth
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/pagehide_event/index.md
+++ b/files/ja/web/api/window/pagehide_event/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'Window: pagehide イベント'
 slug: Web/API/Window/pagehide_event
-tags:
-  - API
-  - Event
-  - History
-  - Navigation
-  - Reference
-  - Window
-  - pagehide
-  - イベント
-  - 履歴
-translation_of: Web/API/Window/pagehide_event
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/window/pageshow_event/index.md
+++ b/files/ja/web/api/window/pageshow_event/index.md
@@ -1,23 +1,6 @@
 ---
 title: 'Window: pageshow イベント'
 slug: Web/API/Window/pageshow_event
-tags:
-  - API
-  - Document
-  - Event
-  - History
-  - Navigation
-  - Page
-  - PageTransitionEvent
-  - Reference
-  - Window
-  - pageshow
-  - show
-  - イベント
-  - ナビゲーション
-  - ページ
-  - 履歴
-translation_of: Web/API/Window/pageshow_event
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/window/parent/index.md
+++ b/files/ja/web/api/window/parent/index.md
@@ -1,12 +1,6 @@
 ---
 title: window.parent
 slug: Web/API/Window/parent
-tags:
-  - API
-  - Gecko
-  - HTML DOM
-  - Window
-translation_of: Web/API/Window/parent
 ---
 {{ APIRef() }}
 

--- a/files/ja/web/api/window/paste_event/index.md
+++ b/files/ja/web/api/window/paste_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Window: paste イベント'
 slug: Web/API/Window/paste_event
-tags:
-  - API
-  - Event
-  - Reference
-  - Web
-  - Window
-  - paste
-  - イベント
-translation_of: Web/API/Window/paste_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/personalbar/index.md
+++ b/files/ja/web/api/window/personalbar/index.md
@@ -1,11 +1,6 @@
 ---
 title: window.personalbar
 slug: Web/API/Window/personalbar
-tags:
-  - Gecko
-  - HTML DOM
-  - Window
-translation_of: Web/API/Window/personalbar
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/window/popstate_event/index.md
+++ b/files/ja/web/api/window/popstate_event/index.md
@@ -1,20 +1,6 @@
 ---
 title: 'Window: popstate イベント'
 slug: Web/API/Window/popstate_event
-tags:
-  - API
-  - Event
-  - HTML DOM
-  - History
-  - 履歴 API
-  - Location
-  - Navigation
-  - リファレンス
-  - URL
-  - Window
-  - popstate
-browser-compat: api.Window.popstate_event
-translation_of: Web/API/Window/popstate_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/postmessage/index.md
+++ b/files/ja/web/api/window/postmessage/index.md
@@ -1,16 +1,6 @@
 ---
 title: Window.postMessage()
 slug: Web/API/Window/postMessage
-tags:
-  - API
-  - オリジン間通信
-  - HTML DOM
-  - メソッド
-  - メソッド
-  - Window
-  - postMessage
-browser-compat: api.Window.postMessage
-translation_of: Web/API/Window/postMessage
 ---
 {{ApiRef("HTML DOM")}}
 

--- a/files/ja/web/api/window/print/index.md
+++ b/files/ja/web/api/window/print/index.md
@@ -1,14 +1,6 @@
 ---
 title: Window.print()
 slug: Web/API/Window/print
-tags:
-  - API
-  - HTML DOM
-  - メソッド
-  - リファレンス
-  - Window
-browser-compat: api.Window.print
-translation_of: Web/API/Window/print
 ---
 {{ ApiRef() }}
 

--- a/files/ja/web/api/window/prompt/index.md
+++ b/files/ja/web/api/window/prompt/index.md
@@ -1,16 +1,6 @@
 ---
 title: Window.prompt()
 slug: Web/API/Window/prompt
-tags:
-  - API
-  - HTML DOM
-  - MakeBrowserAgnostic
-  - メソッド
-  - リファレンス
-  - Window
-  - prompt
-browser-compat: api.Window.prompt
-translation_of: Web/API/Window/prompt
 ---
 {{ApiRef("Window")}}
 

--- a/files/ja/web/api/window/rejectionhandled_event/index.md
+++ b/files/ja/web/api/window/rejectionhandled_event/index.md
@@ -1,21 +1,6 @@
 ---
 title: 'Window: rejectionhandled イベント'
 slug: Web/API/Window/rejectionhandled_event
-tags:
-  - API
-  - Event
-  - HTML DOM
-  - JavaScript
-  - Promise
-  - Promises
-  - Reference
-  - Window
-  - Worker
-  - global
-  - onrejectionhandled
-  - rejectionhandled
-  - イベント
-translation_of: Web/API/Window/rejectionhandled_event
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/window/releaseevents/index.md
+++ b/files/ja/web/api/window/releaseevents/index.md
@@ -1,16 +1,6 @@
 ---
 title: Window.releaseEvents()
 slug: Web/API/Window/releaseEvents
-tags:
-  - API
-  - DOM
-  - DOM_0
-  - Method
-  - Non-standard
-  - Reference
-  - Window
-  - releaseEvents
-translation_of: Web/API/Window/releaseEvents
 ---
 {{ ApiRef() }} {{Deprecated_Header}} {{Non-standard_header}}
 

--- a/files/ja/web/api/window/requestanimationframe/index.md
+++ b/files/ja/web/api/window/requestanimationframe/index.md
@@ -1,24 +1,6 @@
 ---
 title: Window.requestAnimationFrame()
 slug: Web/API/Window/requestAnimationFrame
-tags:
-  - API
-  - アニメーション
-  - Drawing
-  - Games
-  - Graphics
-  - HTML DOM
-  - 中級者
-  - JavaScript タイマー
-  - メソッド
-  - Performance
-  - リファレンス
-  - スケジュール
-  - Window
-  - requestAnimationFrame
-  - Polyfill
-browser-compat: api.Window.requestAnimationFrame
-translation_of: Web/API/window/requestAnimationFrame
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/requestidlecallback/index.md
+++ b/files/ja/web/api/window/requestidlecallback/index.md
@@ -1,13 +1,6 @@
 ---
 title: requestIdleCallback
 slug: Web/API/Window/requestIdleCallback
-tags:
-  - API
-  - HTML DOM
-  - JavaScript timer
-  - Reference
-  - Window
-translation_of: Web/API/Window/requestIdleCallback
 ---
 {{APIRef("HTML DOM")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/window/resize_event/index.md
+++ b/files/ja/web/api/window/resize_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'Window: resize イベント'
 slug: Web/API/Window/resize_event
-tags:
-  - API
-  - Reference
-  - Web
-  - Window
-  - events
-  - resize
-browser-compat: api.Window.resize_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/resizeby/index.md
+++ b/files/ja/web/api/window/resizeby/index.md
@@ -1,15 +1,6 @@
 ---
 title: Window.resizeBy()
 slug: Web/API/Window/resizeBy
-tags:
-  - API
-  - CSSOM View
-  - メソッド
-  - NeedsMarkupWork
-  - リファレンス
-  - Window
-browser-compat: api.Window.resizeBy
-translation_of: Web/API/Window/resizeBy
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/resizeto/index.md
+++ b/files/ja/web/api/window/resizeto/index.md
@@ -1,14 +1,6 @@
 ---
 title: Window.resizeTo()
 slug: Web/API/Window/resizeTo
-tags:
-  - API
-  - CSSOM View
-  - メソッド
-  - リファレンス
-  - Window
-browser-compat: api.Window.resizeTo
-translation_of: Web/API/Window/resizeTo
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/screen/index.md
+++ b/files/ja/web/api/window/screen/index.md
@@ -1,13 +1,6 @@
 ---
 title: Window.screen
 slug: Web/API/Window/screen
-tags:
-  - API
-  - CSSOM View
-  - HTML DOM
-  - Property
-  - Window
-translation_of: Web/API/Window/screen
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/ja/web/api/window/screenx/index.md
+++ b/files/ja/web/api/window/screenx/index.md
@@ -1,15 +1,6 @@
 ---
 title: Window.screenX
 slug: Web/API/Window/screenX
-tags:
-  - API
-  - CSSOM View
-  - Property
-  - Read-only
-  - Reference
-  - Window
-  - screenX
-translation_of: Web/API/Window/screenX
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/screeny/index.md
+++ b/files/ja/web/api/window/screeny/index.md
@@ -1,14 +1,6 @@
 ---
 title: Window.screenY
 slug: Web/API/Window/screenY
-tags:
-  - API
-  - CSSOM View
-  - Property
-  - Read-only
-  - Reference
-  - Window
-translation_of: Web/API/Window/screenY
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/scroll/index.md
+++ b/files/ja/web/api/window/scroll/index.md
@@ -1,10 +1,6 @@
 ---
 title: window.scroll
 slug: Web/API/Window/scroll
-tags:
-  - CSSOM View
-  - DOM
-translation_of: Web/API/Window/scroll
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/window/scrollbars/index.md
+++ b/files/ja/web/api/window/scrollbars/index.md
@@ -1,11 +1,6 @@
 ---
 title: window.scrollbars
 slug: Web/API/Window/scrollbars
-tags:
-  - Gecko
-  - HTML DOM
-  - Window
-translation_of: Web/API/Window/scrollbars
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/window/scrollby/index.md
+++ b/files/ja/web/api/window/scrollby/index.md
@@ -1,13 +1,6 @@
 ---
 title: Window.scrollBy()
 slug: Web/API/Window/scrollBy
-tags:
-  - API
-  - CSSOM View
-  - メソッド
-  - リファレンス
-browser-compat: api.Window.scrollBy
-translation_of: Web/API/Window/scrollBy
 ---
 {{ APIRef() }}
 

--- a/files/ja/web/api/window/scrollbylines/index.md
+++ b/files/ja/web/api/window/scrollbylines/index.md
@@ -1,14 +1,6 @@
 ---
 title: Window.scrollByLines()
 slug: Web/API/Window/scrollByLines
-tags:
-  - API
-  - HTML DOM
-  - Method
-  - Non-standard
-  - Reference
-  - Window
-translation_of: Web/API/Window/scrollByLines
 ---
 {{ ApiRef() }} {{Non-standard_header}}
 

--- a/files/ja/web/api/window/scrollbypages/index.md
+++ b/files/ja/web/api/window/scrollbypages/index.md
@@ -1,16 +1,6 @@
 ---
 title: Window.scrollByPages()
 slug: Web/API/Window/scrollByPages
-tags:
-  - API
-  - HTML DOM
-  - Method
-  - Non-standard
-  - Reference
-  - Window
-  - scrollByPages
-  - scrolling
-translation_of: Web/API/Window/scrollByPages
 ---
 {{ ApiRef() }} {{Non-standard_header}}
 

--- a/files/ja/web/api/window/scrollmaxx/index.md
+++ b/files/ja/web/api/window/scrollmaxx/index.md
@@ -1,14 +1,6 @@
 ---
 title: Window.scrollMaxX
 slug: Web/API/Window/scrollMaxX
-tags:
-  - API
-  - Gecko
-  - HTML DOM
-  - Non-standard
-  - Property
-  - Window
-translation_of: Web/API/Window/scrollMaxX
 ---
 {{APIRef}} {{Non-standard_header}}
 

--- a/files/ja/web/api/window/scrollmaxy/index.md
+++ b/files/ja/web/api/window/scrollmaxy/index.md
@@ -1,18 +1,6 @@
 ---
 title: Window.scrollMaxY
 slug: Web/API/Window/scrollMaxY
-tags:
-  - API
-  - DOM_0
-  - HTML DOM
-  - NeedsExample
-  - NeedsMarkupWork
-  - NeedsSpecTable
-  - Non-standard
-  - Property
-  - Reference
-  - Window
-translation_of: Web/API/Window/scrollMaxY
 ---
 {{APIRef}} {{Non-standard_header}}
 

--- a/files/ja/web/api/window/scrollto/index.md
+++ b/files/ja/web/api/window/scrollto/index.md
@@ -1,13 +1,6 @@
 ---
 title: window.scrollTo
 slug: Web/API/Window/scrollTo
-tags:
-  - API
-  - CSSOM View
-  - Method
-  - NeedsMarkupWork
-  - Reference
-translation_of: Web/API/Window/scrollTo
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/scrollx/index.md
+++ b/files/ja/web/api/window/scrollx/index.md
@@ -1,12 +1,6 @@
 ---
 title: window.scrollX
 slug: Web/API/Window/scrollX
-tags:
-  - API
-  - CSSOM View
-  - Property
-  - Reference
-translation_of: Web/API/Window/scrollX
 ---
 {{APIRef("CSSOM View")}}
 

--- a/files/ja/web/api/window/scrolly/index.md
+++ b/files/ja/web/api/window/scrolly/index.md
@@ -1,15 +1,6 @@
 ---
 title: window.scrollY
 slug: Web/API/Window/scrollY
-tags:
-  - API
-  - CSSOM View
-  - Property
-  - Reference
-  - Window
-  - scrollY
-  - プロパティ
-translation_of: Web/API/Window/scrollY
 ---
 {{APIRef("CSSOM View")}}
 

--- a/files/ja/web/api/window/self/index.md
+++ b/files/ja/web/api/window/self/index.md
@@ -1,15 +1,6 @@
 ---
 title: window.self
 slug: Web/API/Window/self
-tags:
-  - API
-  - Gecko
-  - HTML DOM
-  - Property
-  - Read-only
-  - Reference
-  - Window
-translation_of: Web/API/Window/self
 ---
 {{ APIRef() }}
 

--- a/files/ja/web/api/window/sessionstorage/index.md
+++ b/files/ja/web/api/window/sessionstorage/index.md
@@ -1,14 +1,6 @@
 ---
 title: Window.sessionStorage
 slug: Web/API/Window/sessionStorage
-tags:
-  - API
-  - Property
-  - Reference
-  - Storage
-  - WindowSessionStorage
-  - sessionStorage
-translation_of: Web/API/Window/sessionStorage
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/showmodaldialog/index.md
+++ b/files/ja/web/api/window/showmodaldialog/index.md
@@ -1,14 +1,6 @@
 ---
 title: Window.showModalDialog()
 slug: Web/API/Window/showModalDialog
-tags:
-  - API
-  - 非推奨
-  - HTML DOM
-  - メソッド
-  - Window
-browser-compat: api.Window.showModalDialog
-translation_of: Web/API/Window/showModalDialog
 ---
 {{deprecated_header}}{{APIRef}}
 

--- a/files/ja/web/api/window/sidebar/index.md
+++ b/files/ja/web/api/window/sidebar/index.md
@@ -1,15 +1,6 @@
 ---
 title: Window.sidebar
 slug: Web/API/Window/sidebar
-page-type: web-api-instance-property
-tags:
-  - HTML DOM
-  - Property
-  - Reference
-  - Window
-  - Non-standard
-  - Deprecated
-translation_of: Web/API/Window/sidebar
 ---
 {{APIRef}} {{Deprecated_Header}}
 

--- a/files/ja/web/api/window/sizetocontent/index.md
+++ b/files/ja/web/api/window/sizetocontent/index.md
@@ -1,14 +1,6 @@
 ---
 title: Window.sizeToContent()
 slug: Web/API/Window/sizeToContent
-tags:
-  - API
-  - HTML DOM
-  - メソッド
-  - リファレンス
-  - Window
-browser-compat: api.Window.sizeToContent
-translation_of: Web/API/Window/sizeToContent
 ---
 {{APIRef}}{{Non-standard_header}}
 

--- a/files/ja/web/api/window/speechsynthesis/index.md
+++ b/files/ja/web/api/window/speechsynthesis/index.md
@@ -1,14 +1,6 @@
 ---
 title: Window.speechSynthesis
 slug: Web/API/Window/speechSynthesis
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - SpeechSynthesis
-  - Window
-translation_of: Web/API/Window/speechSynthesis
 ---
 {{APIRef()}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/window/status/index.md
+++ b/files/ja/web/api/window/status/index.md
@@ -1,16 +1,6 @@
 ---
 title: Window.status
 slug: Web/API/Window/status
-tags:
-  - API
-  - HTML DOM
-  - NeedsExample
-  - NeedsSpecTable
-  - Property
-  - Reference
-  - Window
-translation_of: Web/API/Window/status
-browser-compat: api.Window.status
 ---
 {{APIRef}} {{Deprecated_Header}}
 

--- a/files/ja/web/api/window/statusbar/index.md
+++ b/files/ja/web/api/window/statusbar/index.md
@@ -1,15 +1,6 @@
 ---
 title: Window.statusbar
 slug: Web/API/Window/statusbar
-tags:
-  - API
-  - HTML DOM
-  - NeedsExample
-  - NeedsMarkupWork
-  - Property
-  - Reference
-  - Window
-translation_of: Web/API/Window/statusbar
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/stop/index.md
+++ b/files/ja/web/api/window/stop/index.md
@@ -1,12 +1,6 @@
 ---
 title: window.stop
 slug: Web/API/Window/stop
-tags:
-  - API
-  - DOM
-  - Gecko
-  - HTML DOM
-translation_of: Web/API/Window/stop
 original_slug: Web/API/window.stop
 ---
 {{ApiRef}}

--- a/files/ja/web/api/window/storage_event/index.md
+++ b/files/ja/web/api/window/storage_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: storage
 slug: Web/API/Window/storage_event
-translation_of: Web/API/Window/storage_event
 ---
 `storage` イベントは、ストレージエリア (`localStorage` または `sessionStorage`) が変更されたときに発生します。詳しくは [Web Storage API](/ja/docs/Web/API/Web_Storage_API) をご覧ください。
 

--- a/files/ja/web/api/window/toolbar/index.md
+++ b/files/ja/web/api/window/toolbar/index.md
@@ -1,16 +1,6 @@
 ---
 title: Window.toolbar
 slug: Web/API/Window/toolbar
-tags:
-  - API
-  - HTML DOM
-  - NeedsExample
-  - NeedsMarkupWork
-  - プロパティ
-  - リファレンス
-  - Window
-browser-compat: api.Window.toolbar
-translation_of: Web/API/Window/toolbar
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/top/index.md
+++ b/files/ja/web/api/window/top/index.md
@@ -1,12 +1,6 @@
 ---
 title: window.top
 slug: Web/API/Window/top
-tags:
-  - API
-  - DOM
-  - HTML
-  - Window
-translation_of: Web/API/Window/top
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/unhandledrejection_event/index.md
+++ b/files/ja/web/api/window/unhandledrejection_event/index.md
@@ -1,22 +1,6 @@
 ---
 title: 'Window: unhandledrejection イベント'
 slug: Web/API/Window/unhandledrejection_event
-tags:
-  - API
-  - Event
-  - HTML DOM
-  - JavaScript
-  - Promise
-  - Promises
-  - Reference
-  - Rejection
-  - Window
-  - Worker
-  - events
-  - global scope
-  - unhandledrejection
-  - イベント
-translation_of: Web/API/Window/unhandledrejection_event
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/ja/web/api/window/unload_event/index.md
+++ b/files/ja/web/api/window/unload_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: unload
 slug: Web/API/Window/unload_event
-translation_of: Web/API/Window/unload_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/window/updatecommands/index.md
+++ b/files/ja/web/api/window/updatecommands/index.md
@@ -1,17 +1,6 @@
 ---
 title: Window.updateCommands()
 slug: Web/API/Window/updateCommands
-tags:
-  - API
-  - HTML DOM
-  - メソッド
-  - リファレンス
-  - Window
-  - XUL コマンドノード
-  - sCommandName
-  - updateCommands
-browser-compat: api.Window.updateCommands
-translation_of: Web/API/Window/updateCommands
 ---
 {{ ApiRef() }}{{Non-standard_header}}
 

--- a/files/ja/web/api/window/visualviewport/index.md
+++ b/files/ja/web/api/window/visualviewport/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.visualViewport
 slug: Web/API/Window/visualViewport
-translation_of: Web/API/Window/visualViewport
 ---
 {{SeeCompatTable}}{{APIRef("Visual Viewport")}}
 

--- a/files/ja/web/api/window/vrdisplayconnect_event/index.md
+++ b/files/ja/web/api/window/vrdisplayconnect_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: vrdisplayconnected
 slug: Web/API/Window/vrdisplayconnect_event
-translation_of: Web/API/Window/vrdisplayconnect_event
 ---
 {{APIRef}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/window/vrdisplaydisconnect_event/index.md
+++ b/files/ja/web/api/window/vrdisplaydisconnect_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: vrdisplaydisconnected
 slug: Web/API/Window/vrdisplaydisconnect_event
-translation_of: Web/API/Window/vrdisplaydisconnect_event
 ---
 {{APIRef}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/window/vrdisplayfocus_event/index.md
+++ b/files/ja/web/api/window/vrdisplayfocus_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'Window: vrdisplayfocus event'
 slug: Web/API/Window/vrdisplayfocus_event
-tags:
-  - Reference
-  - WebVR
-  - events
-  - onvrdisplayfocus
-  - vrdisplayfocus
-translation_of: Web/API/Window/vrdisplayfocus_event
 ---
 {{APIRef("Window")}}
 

--- a/files/ja/web/api/window/vrdisplaypresentchange_event/index.md
+++ b/files/ja/web/api/window/vrdisplaypresentchange_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: vrdisplaypresentchange
 slug: Web/API/Window/vrdisplaypresentchange_event
-translation_of: Web/API/Window/vrdisplaypresentchange_event
 ---
 {{APIRef}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/window/window/index.md
+++ b/files/ja/web/api/window/window/index.md
@@ -1,15 +1,6 @@
 ---
 title: window.window
 slug: Web/API/Window/window
-tags:
-  - API
-  - Gecko
-  - HTML DOM
-  - Property
-  - Reference
-  - Window
-  - 要更新
-translation_of: Web/API/Window/window
 ---
 {{ApiRef}}
 

--- a/files/ja/web/api/windowclient/focus/index.md
+++ b/files/ja/web/api/windowclient/focus/index.md
@@ -1,14 +1,6 @@
 ---
 title: WindowClient.focus()
 slug: Web/API/WindowClient/focus
-tags:
-  - API
-  - Focus
-  - Method
-  - Reference
-  - Service Workers
-  - WindowClient
-translation_of: Web/API/WindowClient/focus
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/windowclient/focused/index.md
+++ b/files/ja/web/api/windowclient/focused/index.md
@@ -1,15 +1,6 @@
 ---
 title: WindowClient.focused
 slug: Web/API/WindowClient/focused
-tags:
-  - API
-  - Property
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - WindowClient
-  - focused
-translation_of: Web/API/WindowClient/focused
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/windowclient/index.md
+++ b/files/ja/web/api/windowclient/index.md
@@ -1,15 +1,6 @@
 ---
 title: WindowClient
 slug: Web/API/WindowClient
-tags:
-  - API
-  - Client
-  - Interface
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - WindowClient
-translation_of: Web/API/WindowClient
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/windowclient/navigate/index.md
+++ b/files/ja/web/api/windowclient/navigate/index.md
@@ -1,14 +1,6 @@
 ---
 title: WindowClient.navigate()
 slug: Web/API/WindowClient/navigate
-tags:
-  - API
-  - Method
-  - Navigate
-  - Reference
-  - Service Workers
-  - WindowClient
-translation_of: Web/API/WindowClient/navigate
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/windowclient/visibilitystate/index.md
+++ b/files/ja/web/api/windowclient/visibilitystate/index.md
@@ -1,15 +1,6 @@
 ---
 title: WindowClient.visibilityState
 slug: Web/API/WindowClient/visibilityState
-tags:
-  - API
-  - Property
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - WindowClient
-  - visibilityState
-translation_of: Web/API/WindowClient/visibilityState
 ---
 {{APIRef("Service Workers API")}}
 

--- a/files/ja/web/api/worker/error_event/index.md
+++ b/files/ja/web/api/worker/error_event/index.md
@@ -1,18 +1,7 @@
 ---
 title: Worker.onerror
 slug: Web/API/Worker/error_event
-tags:
-  - API
-  - Worker
-  - EventHandler
-  - Property
-  - Reference
-  - Web Workers
-  - Workers
-  - onerror
-translation_of: Web/API/Worker/onerror
 original_slug: Web/API/Worker/onerror
-browser-compat: api.Worker.onerror
 ---
 {{APIRef("Web Workers API")}}
 

--- a/files/ja/web/api/worker/index.md
+++ b/files/ja/web/api/worker/index.md
@@ -1,17 +1,6 @@
 ---
 title: Worker
 slug: Web/API/Worker
-tags:
-  - API
-  - DOM
-  - Interface
-  - JavaScript
-  - Reference
-  - Web Workers
-  - Worker
-  - Workers
-translation_of: Web/API/Worker
-browser-compat: api.Worker
 ---
 {{APIRef("Web Workers API")}}
 

--- a/files/ja/web/api/worker/messageerror_event/index.md
+++ b/files/ja/web/api/worker/messageerror_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: Worker.onmessageerror
 slug: Web/API/Worker/messageerror_event
-tags:
-  - API
-  - Property
-  - Reference
-  - Worker
-  - onmessageerror
-  - イベントハンドラ
-translation_of: Web/API/Worker/onmessageerror
 original_slug: Web/API/Worker/onmessageerror
 ---
 {{APIRef("HTML DOM")}}

--- a/files/ja/web/api/worker/postmessage/index.md
+++ b/files/ja/web/api/worker/postmessage/index.md
@@ -1,16 +1,6 @@
 ---
 title: Worker.prototype.postMessage()
 slug: Web/API/Worker/postMessage
-tags:
-  - API
-  - JavaScript
-  - Method
-  - Reference
-  - Web Workers
-  - Worker
-  - postMessage
-translation_of: Web/API/Worker/postMessage
-browser-compat: api.Worker.postMessage
 ---
 {{APIRef("Web Workers API")}}
 

--- a/files/ja/web/api/worker/terminate/index.md
+++ b/files/ja/web/api/worker/terminate/index.md
@@ -1,7 +1,6 @@
 ---
 title: Worker.terminate()
 slug: Web/API/Worker/terminate
-translation_of: Web/API/Worker/terminate
 ---
 {{APIRef("Web Workers API")}}
 

--- a/files/ja/web/api/worker/worker/index.md
+++ b/files/ja/web/api/worker/worker/index.md
@@ -1,13 +1,6 @@
 ---
 title: Worker()
 slug: Web/API/Worker/Worker
-tags:
-  - API
-  - Constructor
-  - Reference
-  - Web Workers
-  - Worker
-translation_of: Web/API/Worker/Worker
 ---
 {{APIRef("Web Workers API")}}
 

--- a/files/ja/web/api/workerglobalscope/console/index.md
+++ b/files/ja/web/api/workerglobalscope/console/index.md
@@ -1,14 +1,6 @@
 ---
 title: WorkerGlobalScope.console
 slug: Web/API/WorkerGlobalScope/console
-tags:
-  - API
-  - ウェブワーカー
-  - リファレンス
-  - リファレンス(2)
-  - ワーカーグローバルスコープ
-  - 読み込み専用
-translation_of: Web/API/WorkerGlobalScope/console
 ---
 {{APIRef("Web Workers API")}}{{Non-standard_header}}
 

--- a/files/ja/web/api/workerglobalscope/importscripts/index.md
+++ b/files/ja/web/api/workerglobalscope/importscripts/index.md
@@ -1,17 +1,6 @@
 ---
 title: WorkerGlobalScope.importScripts()
 slug: Web/API/WorkerGlobalScope/importScripts
-tags:
-  - API
-  - Method
-  - Reference
-  - Web Workers
-  - WorkderGlobalScope
-  - importScripts
-  - ウェブワーカー
-  - メソッド
-  - ワーカーグローバルスコープ
-translation_of: Web/API/WorkerGlobalScope/importScripts
 ---
 {{APIRef("Web Workers API")}}
 

--- a/files/ja/web/api/workerglobalscope/index.md
+++ b/files/ja/web/api/workerglobalscope/index.md
@@ -1,14 +1,6 @@
 ---
 title: WorkerGlobalScope
 slug: Web/API/WorkerGlobalScope
-tags:
-  - API
-  - Interface
-  - NeedsBrowserCompatibility
-  - Reference
-  - WorkerGlobalScope
-  - Workers
-translation_of: Web/API/WorkerGlobalScope
 ---
 {{APIRef("Web Workers API")}}
 

--- a/files/ja/web/api/workerglobalscope/languagechange_event/index.md
+++ b/files/ja/web/api/workerglobalscope/languagechange_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'WorkerGlobalScope: languagechange イベント'
 slug: Web/API/WorkerGlobalScope/languagechange_event
-tags:
-  - API
-  - Event
-  - Reference
-  - WorkerGlobalScope
-  - イベント
-translation_of: Web/API/WorkerGlobalScope/languagechange_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/workerglobalscope/self/index.md
+++ b/files/ja/web/api/workerglobalscope/self/index.md
@@ -1,14 +1,6 @@
 ---
 title: WorkerGlobalScope.self
 slug: Web/API/WorkerGlobalScope/self
-tags:
-  - API
-  - Property
-  - Reference
-  - Web Worker
-  - WorkerGlobalScope
-  - self
-translation_of: Web/API/WorkerGlobalScope/self
 ---
 {{APIRef("Web Workers API")}}
 

--- a/files/ja/web/api/workerlocation/index.md
+++ b/files/ja/web/api/workerlocation/index.md
@@ -1,7 +1,6 @@
 ---
 title: WorkerLocation
 slug: Web/API/WorkerLocation
-translation_of: Web/API/WorkerLocation
 ---
 {{APIRef("Web Workers API")}}
 

--- a/files/ja/web/api/worklet/addmodule/index.md
+++ b/files/ja/web/api/worklet/addmodule/index.md
@@ -1,21 +1,6 @@
 ---
 title: Worklet.addModule()
 slug: Web/API/Worklet/addModule
-page-type: web-api-instance-method
-tags:
-  - API
-  - Background
-  - Experimental
-  - Houdini
-  - Method
-  - Multiprocessor
-  - Processes
-  - Reference
-  - Tasks
-  - Worklets
-  - addModule
-browser-compat: api.Worklet.addModule
-translation_of: Web/API/Worklet/addModule
 ---
 {{APIRef("Worklets")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/worklet/index.md
+++ b/files/ja/web/api/worklet/index.md
@@ -1,15 +1,6 @@
 ---
 title: Worklet
 slug: Web/API/Worklet
-page-type: web-api-interface
-tags:
-  - API
-  - Interface
-  - Reference
-  - Worklet
-  - Worklets
-browser-compat: api.Worklet
-translation_of: Web/API/Worklet
 ---
 {{APIRef("Worklets")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/writablestream/abort/index.md
+++ b/files/ja/web/api/writablestream/abort/index.md
@@ -1,15 +1,6 @@
 ---
 title: WritableStream.abort()
 slug: Web/API/WritableStream/abort
-tags:
-  - API
-  - Experimental
-  - Method
-  - Reference
-  - Streams
-  - WritableStream
-  - abort
-translation_of: Web/API/WritableStream/abort
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/writablestream/getwriter/index.md
+++ b/files/ja/web/api/writablestream/getwriter/index.md
@@ -1,15 +1,6 @@
 ---
 title: WritableStream.getWriter()
 slug: Web/API/WritableStream/getWriter
-tags:
-  - API
-  - Experimental
-  - Method
-  - Reference
-  - Streams
-  - WritableStream
-  - getWriter
-translation_of: Web/API/WritableStream/getWriter
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/writablestream/index.md
+++ b/files/ja/web/api/writablestream/index.md
@@ -1,14 +1,6 @@
 ---
 title: WritableStream
 slug: Web/API/WritableStream
-tags:
-  - API
-  - Experimental
-  - Interface
-  - Reference
-  - Streams
-  - WritableStream
-translation_of: Web/API/WritableStream
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/writablestream/locked/index.md
+++ b/files/ja/web/api/writablestream/locked/index.md
@@ -1,15 +1,6 @@
 ---
 title: WritableStream.locked
 slug: Web/API/WritableStream/locked
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - Streams
-  - WritableStream
-  - locked
-translation_of: Web/API/WritableStream/locked
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/writablestream/writablestream/index.md
+++ b/files/ja/web/api/writablestream/writablestream/index.md
@@ -1,14 +1,6 @@
 ---
 title: WritableStream.WritableStream()
 slug: Web/API/WritableStream/WritableStream
-tags:
-  - API
-  - Constructor
-  - Experimental
-  - Reference
-  - Streams
-  - WritableStream
-translation_of: Web/API/WritableStream/WritableStream
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/writablestreamdefaultcontroller/error/index.md
+++ b/files/ja/web/api/writablestreamdefaultcontroller/error/index.md
@@ -1,15 +1,6 @@
 ---
 title: WritableStreamDefaultController.error()
 slug: Web/API/WritableStreamDefaultController/error
-tags:
-  - API
-  - Error
-  - Experimental
-  - Method
-  - Reference
-  - Streams
-  - WritableStreamDefaultController
-translation_of: Web/API/WritableStreamDefaultController/error
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/writablestreamdefaultcontroller/index.md
+++ b/files/ja/web/api/writablestreamdefaultcontroller/index.md
@@ -1,15 +1,6 @@
 ---
 title: WritableStreamDefaultController
 slug: Web/API/WritableStreamDefaultController
-tags:
-  - API
-  - Experimental
-  - Fetch
-  - Interface
-  - Reference
-  - Streams
-  - WritableStreamDefaultController
-translation_of: Web/API/WritableStreamDefaultController
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/writablestreamdefaultwriter/abort/index.md
+++ b/files/ja/web/api/writablestreamdefaultwriter/abort/index.md
@@ -1,15 +1,6 @@
 ---
 title: WritableStreamDefaultWriter.abort()
 slug: Web/API/WritableStreamDefaultWriter/abort
-tags:
-  - API
-  - Experimental
-  - Method
-  - Reference
-  - Streams
-  - WritableStreamDefaultWriter
-  - abort
-translation_of: Web/API/WritableStreamDefaultWriter/abort
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/writablestreamdefaultwriter/close/index.md
+++ b/files/ja/web/api/writablestreamdefaultwriter/close/index.md
@@ -1,15 +1,6 @@
 ---
 title: WritableStreamDefaultWriter.close()
 slug: Web/API/WritableStreamDefaultWriter/close
-tags:
-  - API
-  - Experimental
-  - Method
-  - Reference
-  - Streams
-  - WritableStreamDefaultWriter
-  - close
-translation_of: Web/API/WritableStreamDefaultWriter/close
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/writablestreamdefaultwriter/closed/index.md
+++ b/files/ja/web/api/writablestreamdefaultwriter/closed/index.md
@@ -1,15 +1,6 @@
 ---
 title: WritableStreamDefaultWriter.closed
 slug: Web/API/WritableStreamDefaultWriter/closed
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - Streams
-  - WritableStreamDefaultWriter
-  - closed
-translation_of: Web/API/WritableStreamDefaultWriter/closed
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/writablestreamdefaultwriter/desiredsize/index.md
+++ b/files/ja/web/api/writablestreamdefaultwriter/desiredsize/index.md
@@ -1,15 +1,6 @@
 ---
 title: WritableStreamDefaultWriter.desiredSize
 slug: Web/API/WritableStreamDefaultWriter/desiredSize
-tags:
-  - API
-  - Experimental
-  - Property
-  - Reference
-  - Streams
-  - WritableStreamDefaultWriter
-  - desiredSize
-translation_of: Web/API/WritableStreamDefaultWriter/desiredSize
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/writablestreamdefaultwriter/index.md
+++ b/files/ja/web/api/writablestreamdefaultwriter/index.md
@@ -1,15 +1,6 @@
 ---
 title: WritableStreamDefaultWriter
 slug: Web/API/WritableStreamDefaultWriter
-tags:
-  - API
-  - Experimental
-  - Interface
-  - Reference
-  - Streams
-  - Streams API
-  - WritableStream
-translation_of: Web/API/WritableStreamDefaultWriter
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/writablestreamdefaultwriter/ready/index.md
+++ b/files/ja/web/api/writablestreamdefaultwriter/ready/index.md
@@ -1,16 +1,6 @@
 ---
 title: WritableStreamDefaultWriter.ready
 slug: Web/API/WritableStreamDefaultWriter/ready
-tags:
-  - API
-  - Property
-  - Ready
-  - Reference
-  - Streams
-  - Streams API
-  - WritableStream
-  - WritableStreamDefaultWriter
-translation_of: Web/API/WritableStreamDefaultWriter/ready
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/writablestreamdefaultwriter/releaselock/index.md
+++ b/files/ja/web/api/writablestreamdefaultwriter/releaselock/index.md
@@ -1,15 +1,6 @@
 ---
 title: WritableStreamDefaultWriter.releaseLock()
 slug: Web/API/WritableStreamDefaultWriter/releaseLock
-tags:
-  - API
-  - Experimental
-  - Method
-  - Reference
-  - Streams
-  - WritiableStream
-  - releaseLock
-translation_of: Web/API/WritableStreamDefaultWriter/releaseLock
 ---
 {{APIRef("Streams")}}{{SeeCompatTable}}
 

--- a/files/ja/web/api/writablestreamdefaultwriter/writablestreamdefaultwriter/index.md
+++ b/files/ja/web/api/writablestreamdefaultwriter/writablestreamdefaultwriter/index.md
@@ -1,14 +1,6 @@
 ---
 title: WritableStreamDefaultWriter.WritableStreamDefaultWriter()
 slug: Web/API/WritableStreamDefaultWriter/WritableStreamDefaultWriter
-tags:
-  - API
-  - Constructor
-  - Experimental
-  - Reference
-  - Streams
-  - WritableStreamDefaultWriter
-translation_of: Web/API/WritableStreamDefaultWriter/WritableStreamDefaultWriter
 ---
 {{SeeCompatTable}}{{APIRef("Streams")}}
 

--- a/files/ja/web/api/writablestreamdefaultwriter/write/index.md
+++ b/files/ja/web/api/writablestreamdefaultwriter/write/index.md
@@ -1,15 +1,6 @@
 ---
 title: WritableStreamDefaultWriter.write()
 slug: Web/API/WritableStreamDefaultWriter/write
-tags:
-  - API
-  - Experimental
-  - Method
-  - Reference
-  - Streams
-  - WritableStreamDefaultWriter
-  - write
-translation_of: Web/API/WritableStreamDefaultWriter/write
 ---
 {{APIRef("Streams")}}{{SeeCompatTable}}
 


### PR DESCRIPTION
Part of #7858

`files/ja/web/api/w*` から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "tags": 216,
  "browser-compat": 59,
  "translation_of": 253,
  "page-type": 19,
  "spec-urls": 1
}
```
