### PR TITLE
remove duplicated frontmatter keys from web/api/{x-z}* (ja)

### DIFF
--- a/files/ja/web/api/xmldocument/async/index.md
+++ b/files/ja/web/api/xmldocument/async/index.md
@@ -1,17 +1,6 @@
 ---
 title: XMLDocument.async
 slug: Web/API/XMLDocument/async
-tags:
-  - API
-  - DOM
-  - DOM Reference
-  - Deprecated
-  - Document
-  - Non-standard
-  - Property
-  - Reference
-  - async
-translation_of: Web/API/XMLDocument/async
 original_slug: Web/API/Document/async
 ---
 {{APIRef("DOM")}}{{Non-standard_header}}{{Deprecated_header}}

--- a/files/ja/web/api/xmldocument/index.md
+++ b/files/ja/web/api/xmldocument/index.md
@@ -1,13 +1,6 @@
 ---
 title: XMLDocument
 slug: Web/API/XMLDocument
-tags:
-  - API
-  - DOM
-  - Interface
-  - Reference
-  - XMLDocument
-translation_of: Web/API/XMLDocument
 ---
 {{APIRef("DOM")}}
 

--- a/files/ja/web/api/xmlhttprequest/abort/index.md
+++ b/files/ja/web/api/xmlhttprequest/abort/index.md
@@ -1,23 +1,6 @@
 ---
 title: XMLHttpRequest.abort()
 slug: Web/API/XMLHttpRequest/abort
-tags:
-  - AJAX
-  - API
-  - XHR の中止
-  - XHR のキャンセル
-  - HTTP
-  - HttpRequest
-  - メソッド
-  - リファレンス
-  - XHR の停止
-  - XHR
-  - XMLHttpRequest
-  - abort
-  - キャンセル
-  - 停止
-browser-compat: api.XMLHttpRequest.abort
-translation_of: Web/API/XMLHttpRequest/abort
 ---
 {{APIRef('XMLHttpRequest')}}
 

--- a/files/ja/web/api/xmlhttprequest/abort_event/index.md
+++ b/files/ja/web/api/xmlhttprequest/abort_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'XMLHttpRequest: abort イベント'
 slug: Web/API/XMLHttpRequest/abort_event
-tags:
-  - API
-  - イベント
-  - ProgressEvent
-  - ウェブ
-  - XMLHttpRequest
-  - abort
-browser-compat: api.XMLHttpRequest.abort_event
-translation_of: Web/API/XMLHttpRequest/abort_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/xmlhttprequest/channel/index.md
+++ b/files/ja/web/api/xmlhttprequest/channel/index.md
@@ -1,16 +1,6 @@
 ---
 title: XMLHttpRequest.channel
 slug: Web/API/XMLHttpRequest/channel
-tags:
-  - API
-  - 標準外
-  - プロパティ
-  - リファレンス
-  - XHR
-  - XMLHttpRequest
-  - channel
-  - nsIChannel
-translation_of: Web/API/XMLHttpRequest/channel
 ---
 {{APIRef('XMLHttpRequest')}}
 

--- a/files/ja/web/api/xmlhttprequest/error_event/index.md
+++ b/files/ja/web/api/xmlhttprequest/error_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'XMLHttpRequest: error イベント'
 slug: Web/API/XMLHttpRequest/error_event
-tags:
-  - API
-  - Error
-  - イベント
-  - ProgressEvent
-  - ウェブ
-  - XMLHttpRequest
-browser-compat: api.XMLHttpRequest.error_event
-translation_of: Web/API/XMLHttpRequest/error_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/xmlhttprequest/getallresponseheaders/index.md
+++ b/files/ja/web/api/xmlhttprequest/getallresponseheaders/index.md
@@ -1,20 +1,6 @@
 ---
 title: XMLHttpRequest.getAllResponseHeaders()
 slug: Web/API/XMLHttpRequest/getAllResponseHeaders
-tags:
-  - API
-  - ヘッダーの読み取り
-  - ヘッダーの取得
-  - HTTP
-  - HTTP ヘッダー
-  - メソッド
-  - リファレンス
-  - レスポンスヘッダー
-  - XHR
-  - XMLHttpRequest
-  - getAllResponseHeaders
-browser-compat: api.XMLHttpRequest.getAllResponseHeaders
-translation_of: Web/API/XMLHttpRequest/getAllResponseHeaders
 ---
 {{APIRef('XMLHttpRequest')}}
 

--- a/files/ja/web/api/xmlhttprequest/getresponseheader/index.md
+++ b/files/ja/web/api/xmlhttprequest/getresponseheader/index.md
@@ -1,20 +1,6 @@
 ---
 title: XMLHttpRequest.getResponseHeader()
 slug: Web/API/XMLHttpRequest/getResponseHeader
-tags:
-  - API
-  - ヘッダーの取得
-  - HTTP
-  - HTTP ヘッダー
-  - ヘッダー
-  - メソッド
-  - リファレンス
-  - XHR
-  - XHR ヘッダー
-  - XMLHttpRequest
-  - getResponseHeader
-browser-compat: api.XMLHttpRequest.getResponseHeader
-translation_of: Web/API/XMLHttpRequest/getResponseHeader
 ---
 {{APIRef('XMLHttpRequest')}}
 

--- a/files/ja/web/api/xmlhttprequest/html_in_xmlhttprequest/index.md
+++ b/files/ja/web/api/xmlhttprequest/html_in_xmlhttprequest/index.md
@@ -1,15 +1,6 @@
 ---
 title: XMLHttpRequest における HTML の扱い
 slug: Web/API/XMLHttpRequest/HTML_in_XMLHttpRequest
-tags:
-  - API
-  - HTML
-  - HTML の解析
-  - HTML の読み込み
-  - XMLHttpRequest
-  - ウェブ
-  - ガイド
-translation_of: Web/API/XMLHttpRequest/HTML_in_XMLHttpRequest
 ---
 {{APIRef("XMLHttpRequest")}}
 

--- a/files/ja/web/api/xmlhttprequest/index.md
+++ b/files/ja/web/api/xmlhttprequest/index.md
@@ -1,18 +1,6 @@
 ---
 title: XMLHttpRequest
 slug: Web/API/XMLHttpRequest
-tags:
-  - AJAX
-  - API
-  - 通信
-  - HTTP
-  - インターフェイス
-  - リファレンス
-  - ウェブ
-  - XHR
-  - XMLHttpRequest
-browser-compat: api.XMLHttpRequest
-translation_of: Web/API/XMLHttpRequest
 ---
 {{DefaultAPISidebar("XMLHttpRequest")}}
 

--- a/files/ja/web/api/xmlhttprequest/load_event/index.md
+++ b/files/ja/web/api/xmlhttprequest/load_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'XMLHttpRequest: load イベント'
 slug: Web/API/XMLHttpRequest/load_event
-tags:
-  - API
-  - イベント
-  - ProgressEvent
-  - ウェブ
-  - XMLHttpRequest
-  - load
-browser-compat: api.XMLHttpRequest.load_event
-translation_of: Web/API/XMLHttpRequest/load_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/xmlhttprequest/loadend_event/index.md
+++ b/files/ja/web/api/xmlhttprequest/loadend_event/index.md
@@ -1,18 +1,6 @@
 ---
 title: 'XMLHttpRequest: loadend イベント'
 slug: Web/API/XMLHttpRequest/loadend_event
-tags:
-  - API
-  - イベント
-  - NeedsCompatTable
-  - NeedsSpecTable
-  - ProgressEvent
-  - リファレンス
-  - ウェブ
-  - イベント
-  - loadend
-browser-compat: api.XMLHttpRequest.loadend_event
-translation_of: Web/API/XMLHttpRequest/loadend_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/xmlhttprequest/loadstart_event/index.md
+++ b/files/ja/web/api/xmlhttprequest/loadstart_event/index.md
@@ -1,18 +1,6 @@
 ---
 title: 'XMLHttpRequest: loadstart イベント'
 slug: Web/API/XMLHttpRequest/loadstart_event
-tags:
-  - API
-  - イベント
-  - NeedsCompatTable
-  - NeedsSpecTable
-  - ProgressEvent
-  - ウェブ
-  - XMLHttpRequest
-  - イベント
-  - loadstart
-browser-compat: api.XMLHttpRequest.loadstart_event
-translation_of: Web/API/XMLHttpRequest/loadstart_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/xmlhttprequest/mozanon/index.md
+++ b/files/ja/web/api/xmlhttprequest/mozanon/index.md
@@ -1,17 +1,6 @@
 ---
 title: XMLHttpRequest.mozAnon
 slug: Web/API/XMLHttpRequest/mozAnon
-tags:
-  - API
-  - 認証
-  - Cookies
-  - 標準外
-  - プロパティ
-  - リファレンス
-  - XHR
-  - XMLHttpRequest
-  - mozAnon
-translation_of: Web/API/XMLHttpRequest/mozAnon
 ---
 {{APIRef('XMLHttpRequest')}}
 

--- a/files/ja/web/api/xmlhttprequest/mozbackgroundrequest/index.md
+++ b/files/ja/web/api/xmlhttprequest/mozbackgroundrequest/index.md
@@ -1,17 +1,6 @@
 ---
 title: XMLHttpRequest.mozBackgroundRequest
 slug: Web/API/XMLHttpRequest/mozBackgroundRequest
-tags:
-  - API
-  - バックグラウンドサービス
-  - Mozilla
-  - 標準外
-  - プロパティ
-  - リファレンス
-  - XHR
-  - XMLHttpRequest
-  - mozBackgroundRequest
-translation_of: Web/API/XMLHttpRequest/mozBackgroundRequest
 ---
 {{APIRef('XMLHttpRequest')}}
 

--- a/files/ja/web/api/xmlhttprequest/mozsystem/index.md
+++ b/files/ja/web/api/xmlhttprequest/mozsystem/index.md
@@ -1,17 +1,6 @@
 ---
 title: XMLHttpRequest.mozSystem
 slug: Web/API/XMLHttpRequest/mozSystem
-tags:
-  - AP
-  - 標準外
-  - プロパティ
-  - リファレンス
-  - 同一オリジンポリシー
-  - XHR
-  - XMLHttpRequest
-  - mozSystem
-  - オリジン
-translation_of: Web/API/XMLHttpRequest/mozSystem
 ---
 {{APIRef('XMLHttpRequest')}}
 

--- a/files/ja/web/api/xmlhttprequest/open/index.md
+++ b/files/ja/web/api/xmlhttprequest/open/index.md
@@ -1,17 +1,6 @@
 ---
 title: XMLHttpRequest.open()
 slug: Web/API/XMLHttpRequest/open
-tags:
-  - API
-  - HTTP
-  - メソッド
-  - NeedsExample
-  - リファレンス
-  - XHR
-  - XMLHttpRequest
-  - open
-browser-compat: api.XMLHttpRequest.open
-translation_of: Web/API/XMLHttpRequest/open
 ---
 {{APIRef('XMLHttpRequest')}}
 

--- a/files/ja/web/api/xmlhttprequest/overridemimetype/index.md
+++ b/files/ja/web/api/xmlhttprequest/overridemimetype/index.md
@@ -1,17 +1,6 @@
 ---
 title: XMLHttpRequest.overrideMimeType()
 slug: Web/API/XMLHttpRequest/overrideMimeType
-tags:
-  - API
-  - ファイル形式
-  - MIME タイプ
-  - メソッド
-  - リファレンス
-  - XHR
-  - XHR MIME タイプ
-  - XMLHttpRequest
-  - overrideMimeType
-browser-compat: api.XMLHttpRequest.overrideMimeType
 ---
 {{APIRef('XMLHttpRequest')}}
 

--- a/files/ja/web/api/xmlhttprequest/progress_event/index.md
+++ b/files/ja/web/api/xmlhttprequest/progress_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'XMLHttpRequest: progress イベント'
 slug: Web/API/XMLHttpRequest/progress_event
-tags:
-  - API
-  - イベント
-  - ProgressEvent
-  - リファレンス
-  - ウェブ
-  - XMLHttpRequest
-  - progress
-browser-compat: api.XMLHttpRequest.progress_event
-translation_of: Web/API/XMLHttpRequest/progress_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/xmlhttprequest/readystate/index.md
+++ b/files/ja/web/api/xmlhttprequest/readystate/index.md
@@ -1,13 +1,6 @@
 ---
 title: XMLHttpRequest.readyState
 slug: Web/API/XMLHttpRequest/readyState
-tags:
-  - AJAX
-  - プロパティ
-  - リファレンス
-  - XMLHttpRequest
-browser-compat: api.XMLHttpRequest.readyState
-translation_of: Web/API/XMLHttpRequest/readyState
 ---
 {{APIRef('XMLHttpRequest')}}
 

--- a/files/ja/web/api/xmlhttprequest/readystatechange_event/index.md
+++ b/files/ja/web/api/xmlhttprequest/readystatechange_event/index.md
@@ -1,17 +1,7 @@
 ---
 title: XMLHttpRequest.onreadystatechange
 slug: Web/API/XMLHttpRequest/readystatechange_event
-tags:
-  - API
-  - Event
-  - ハンドラー
-  - プロパティ
-  - リファレンス
-  - XHR
-  - XMLHttpRequest
-translation_of: Web/API/XMLHttpRequest/onreadystatechange
 original_slug: Web/API/XMLHttpRequest/onreadystatechange
-browser-compat: api.XMLHttpRequest.onreadystatechange
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/xmlhttprequest/response/index.md
+++ b/files/ja/web/api/xmlhttprequest/response/index.md
@@ -1,20 +1,6 @@
 ---
 title: XMLHttpRequest.response
 slug: Web/API/XMLHttpRequest/response
-tags:
-  - AJAX
-  - API
-  - コンテンツの読み取り
-  - データの読み取り
-  - データの読み込み
-  - プロパティ
-  - 読み取り専用
-  - Reading Data
-  - リファレンス
-  - Response
-  - サーバー
-  - XMLHttpRequest
-translation_of: Web/API/XMLHttpRequest/response
 ---
 {{APIRef('XMLHttpRequest')}}
 

--- a/files/ja/web/api/xmlhttprequest/responsetext/index.md
+++ b/files/ja/web/api/xmlhttprequest/responsetext/index.md
@@ -1,17 +1,6 @@
 ---
 title: XMLHttpRequest.responseText
 slug: Web/API/XMLHttpRequest/responseText
-tags:
-  - API
-  - テキストの読み取り
-  - テキストのロード
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - XMLHttpRequest
-  - responseText
-browser-compat: api.XMLHttpRequest.responseText
-translation_of: Web/API/XMLHttpRequest/responseText
 ---
 {{APIRef('XMLHttpRequest')}}
 

--- a/files/ja/web/api/xmlhttprequest/responsetype/index.md
+++ b/files/ja/web/api/xmlhttprequest/responsetype/index.md
@@ -1,20 +1,6 @@
 ---
 title: XMLHttpRequest.responseType
 slug: Web/API/XMLHttpRequest/responseType
-tags:
-  - AJAX
-  - API
-  - HTTP
-  - HTTP レスポンス
-  - HTTP レスポンス型
-  - プロパティ
-  - リファレンス
-  - レスポンス
-  - XHR
-  - XMLHttpRequest
-  - responseType
-browser-compat: api.XMLHttpRequest.responseType
-translation_of: Web/API/XMLHttpRequest/responseType
 ---
 {{APIRef('XMLHttpRequest')}}
 

--- a/files/ja/web/api/xmlhttprequest/responseurl/index.md
+++ b/files/ja/web/api/xmlhttprequest/responseurl/index.md
@@ -1,16 +1,6 @@
 ---
 title: XMLHttpRequest.responseURL
 slug: Web/API/XMLHttpRequest/responseURL
-tags:
-  - AJAX
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - URL
-  - XMLHttpRequest
-  - responseURL
-browser-compat: api.XMLHttpRequest.responseURL
-translation_of: Web/API/XMLHttpRequest/responseURL
 ---
 {{APIRef('XMLHttpRequest')}}
 

--- a/files/ja/web/api/xmlhttprequest/responsexml/index.md
+++ b/files/ja/web/api/xmlhttprequest/responsexml/index.md
@@ -1,23 +1,6 @@
 ---
 title: XMLHttpRequest.responseXML
 slug: Web/API/XMLHttpRequest/responseXML
-tags:
-  - AJAX
-  - API
-  - Fetching XML
-  - Loading XML
-  - プロパティ
-  - 読み取り専用
-  - Reading XML
-  - リファレンス
-  - 変換
-  - XML
-  - XMLHttpRequest
-  - ダウンロード
-  - responseXML
-  - アップロード
-browser-compat: api.XMLHttpRequest.responseXML
-translation_of: Web/API/XMLHttpRequest/responseXML
 ---
 {{APIRef('XMLHttpRequest')}}
 

--- a/files/ja/web/api/xmlhttprequest/send/index.md
+++ b/files/ja/web/api/xmlhttprequest/send/index.md
@@ -1,20 +1,6 @@
 ---
 title: XMLHttpRequest.send()
 slug: Web/API/XMLHttpRequest/send
-tags:
-  - AJAX
-  - API
-  - HTTP リクエスト
-  - メソッド
-  - NeedsContent
-  - NeedsExample
-  - リファレンス
-  - XHR
-  - XHR リクエスト
-  - XMLHttpRequest
-  - send
-browser-compat: api.XMLHttpRequest.send
-translation_of: Web/API/XMLHttpRequest/send
 ---
 {{APIRef('XMLHttpRequest')}}
 

--- a/files/ja/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
+++ b/files/ja/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
@@ -1,12 +1,6 @@
 ---
 title: バイナリデータの送信と受信
 slug: Web/API/XMLHttpRequest/Sending_and_Receiving_Binary_Data
-tags:
-  - AJAX
-  - FileReader
-  - MIME
-  - XMLHttpRequest
-translation_of: Web/API/XMLHttpRequest/Sending_and_Receiving_Binary_Data
 ---
 ## JavaScript 型付き配列を使ったバイナリデータの受信
 

--- a/files/ja/web/api/xmlhttprequest/setrequestheader/index.md
+++ b/files/ja/web/api/xmlhttprequest/setrequestheader/index.md
@@ -1,22 +1,6 @@
 ---
 title: XMLHttpRequest.setRequestHeader()
 slug: Web/API/XMLHttpRequest/setRequestHeader
-tags:
-  - API
-  - HTTP
-  - HTTP ヘッダー
-  - メソッド
-  - NeedsExample
-  - リファレンス
-  - リクエストヘッダー
-  - XHR
-  - XHR リクエスト
-  - XMLHttpRequest
-  - ヘッダー
-  - request
-  - setRequestHeader
-browser-compat: api.XMLHttpRequest.setRequestHeader
-translation_of: Web/API/XMLHttpRequest/setRequestHeader
 ---
 {{APIRef('XMLHttpRequest')}}
 

--- a/files/ja/web/api/xmlhttprequest/status/index.md
+++ b/files/ja/web/api/xmlhttprequest/status/index.md
@@ -1,17 +1,6 @@
 ---
 title: XMLHttpRequest.status
 slug: Web/API/XMLHttpRequest/status
-tags:
-  - API
-  - エラー
-  - プロパティ
-  - リファレンス
-  - XMLHttpRequest
-  - XMLHttpRequest ステータス
-  - 結果
-  - status
-browser-compat: api.XMLHttpRequest.status
-translation_of: Web/API/XMLHttpRequest/status
 ---
 {{APIRef('XMLHttpRequest')}}
 

--- a/files/ja/web/api/xmlhttprequest/statustext/index.md
+++ b/files/ja/web/api/xmlhttprequest/statustext/index.md
@@ -1,16 +1,6 @@
 ---
 title: XMLHttpRequest.statusText
 slug: Web/API/XMLHttpRequest/statusText
-tags:
-  - AJAX
-  - API
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - XMLHttpRequest
-  - XMLHttpRequest Status
-browser-compat: api.XMLHttpRequest.statusText
-translation_of: Web/API/XMLHttpRequest/statusText
 ---
 {{APIRef('XMLHttpRequest')}}
 

--- a/files/ja/web/api/xmlhttprequest/synchronous_and_asynchronous_requests/index.md
+++ b/files/ja/web/api/xmlhttprequest/synchronous_and_asynchronous_requests/index.md
@@ -1,9 +1,6 @@
 ---
 title: 同期と非同期のリクエスト
 slug: Web/API/XMLHttpRequest/Synchronous_and_Asynchronous_Requests
-tags:
-  - XMLHttpRequest
-translation_of: Web/API/XMLHttpRequest/Synchronous_and_Asynchronous_Requests
 ---
 {{domxref('XMLHttpRequest')}} は同期及び非同期通信の両方に対応しています。しかし、一般的には性能上の理由により、同期リクエストより非同期リクエストを推奨するべきです。
 

--- a/files/ja/web/api/xmlhttprequest/timeout/index.md
+++ b/files/ja/web/api/xmlhttprequest/timeout/index.md
@@ -1,17 +1,6 @@
 ---
 title: XMLHttpRequest.timeout
 slug: Web/API/XMLHttpRequest/timeout
-tags:
-  - AJAX
-  - 非同期 XHR
-  - 非同期 XMLHttpRequest
-  - プロパティ
-  - リファレンス
-  - XHR
-  - XMLHttpRequest
-  - timeout
-browser-compat: api.XMLHttpRequest.timeout
-translation_of: Web/API/XMLHttpRequest/timeout
 ---
 {{APIRef('XMLHttpRequest')}}
 

--- a/files/ja/web/api/xmlhttprequest/timeout_event/index.md
+++ b/files/ja/web/api/xmlhttprequest/timeout_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'XMLHttp​Request: timeout イベント'
 slug: Web/API/XMLHttpRequest/timeout_event
-tags:
-  - API
-  - Event
-  - リファレンス
-  - XHR
-  - XMLHttpRequest
-  - イベント
-  - timeout
-browser-compat: api.XMLHttpRequest.timeout_event
-translation_of: Web/API/XMLHttpRequest/timeout_event
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/xmlhttprequest/upload/index.md
+++ b/files/ja/web/api/xmlhttprequest/upload/index.md
@@ -1,23 +1,6 @@
 ---
 title: XMLHttpRequest.upload
 slug: Web/API/XMLHttpRequest/upload
-tags:
-  - AJAX
-  - API
-  - Monitoring XMLHttpRequest
-  - プロパティ
-  - 読み取り専用
-  - リファレンス
-  - ファイル送信
-  - アップロード
-  - XHR
-  - XHR アップロード
-  - XMLHttpRequest
-  - XMLHttpRequest アップロード
-  - XMLHttpRequestUpload
-  - アップロード
-browser-compat: api.XMLHttpRequest.upload
-translation_of: Web/API/XMLHttpRequest/upload
 ---
 {{APIRef('XMLHttpRequest')}}
 

--- a/files/ja/web/api/xmlhttprequest/using_xmlhttprequest/index.md
+++ b/files/ja/web/api/xmlhttprequest/using_xmlhttprequest/index.md
@@ -1,20 +1,6 @@
 ---
 title: XMLHttpRequest の使用
 slug: Web/API/XMLHttpRequest/Using_XMLHttpRequest
-tags:
-  - AJAX
-  - AJAXfile
-  - DOM
-  - HTTP
-  - JXON
-  - MakeBrowserAgnostic
-  - XHR
-  - XML
-  - XMLHttpRequest
-  - ガイド
-  - チュートリアル
-  - 高度
-translation_of: Web/API/XMLHttpRequest/Using_XMLHttpRequest
 ---
 {{APIRef("XMLHttpRequest")}}
 

--- a/files/ja/web/api/xmlhttprequest/using_xmlhttprequest_in_ie6/index.md
+++ b/files/ja/web/api/xmlhttprequest/using_xmlhttprequest_in_ie6/index.md
@@ -1,10 +1,6 @@
 ---
 title: Using XMLHttpRequest in IE6
 slug: Web/API/XMLHttpRequest/Using_XMLHttpRequest_in_IE6
-tags:
-  - Web Development
-  - Web Standards
-translation_of: Web/API/XMLHttpRequest/Using_XMLHttpRequest_in_IE6
 ---
 [XMLHttpRequest](/ja/DOM/XMLHttpRequest "en/DOM/XMLHttpRequest") は、 Microsoft によって Internet Explorer 5.0 で ActiveX control として最初に導入されました。ただし、 IE7 およびその他のブラウザーでは XMLHttpRequest はネイティブ JavaScript オブジェクトです。
 

--- a/files/ja/web/api/xmlhttprequest/withcredentials/index.md
+++ b/files/ja/web/api/xmlhttprequest/withcredentials/index.md
@@ -1,18 +1,6 @@
 ---
 title: XMLHttpRequest.withCredentials
 slug: Web/API/XMLHttpRequest/withCredentials
-tags:
-  - AJAX
-  - API
-  - プロパティ
-  - リファレンス
-  - セキュリティ
-  - XHR
-  - XMLHttpRequest
-  - 資格情報
-  - 資格情報付き
-browser-compat: api.XMLHttpRequest.withCredentials
-translation_of: Web/API/XMLHttpRequest/withCredentials
 ---
 {{APIRef('XMLHttpRequest')}}
 

--- a/files/ja/web/api/xmlhttprequest/xmlhttprequest/index.md
+++ b/files/ja/web/api/xmlhttprequest/xmlhttprequest/index.md
@@ -1,19 +1,6 @@
 ---
 title: XMLHttpRequest()
 slug: Web/API/XMLHttpRequest/XMLHttpRequest
-tags:
-  - API
-  - コンストラクター
-  - XMLHttpRequest の作成
-  - データの読み取り
-  - Loading Data
-  - Reading Data
-  - リファレンス
-  - サーバーアクセス
-  - XHR
-  - XMLHttpRequest
-browser-compat: api.XMLHttpRequest.XMLHttpRequest
-translation_of: Web/API/XMLHttpRequest/XMLHttpRequest
 ---
 {{APIRef('XMLHttpRequest')}}
 

--- a/files/ja/web/api/xmlhttprequesteventtarget/index.md
+++ b/files/ja/web/api/xmlhttprequesteventtarget/index.md
@@ -1,14 +1,6 @@
 ---
 title: XMLHttpRequestEventTarget
 slug: Web/API/XMLHttpRequestEventTarget
-tags:
-  - AJAX
-  - API
-  - NeedsBrowserCompatibility
-  - NeedsContent
-  - Reference
-  - XMLHttpRequest
-translation_of: Web/API/XMLHttpRequestEventTarget
 ---
 {{APIRef("XMLHttpRequest")}}
 

--- a/files/ja/web/api/xmlserializer/index.md
+++ b/files/ja/web/api/xmlserializer/index.md
@@ -1,18 +1,6 @@
 ---
 title: XMLSerializer
 slug: Web/API/XMLSerializer
-tags:
-  - Converting
-  - DOM Parsing
-  - Interface
-  - Parsing
-  - Reference
-  - Serialization
-  - Serializing
-  - XML
-  - XML Serializer
-  - conversion
-translation_of: Web/API/XMLSerializer
 original_slug: XMLSerializer
 ---
 {{APIRef("XMLSerializer")}}

--- a/files/ja/web/api/xpathresult/index.md
+++ b/files/ja/web/api/xpathresult/index.md
@@ -1,7 +1,6 @@
 ---
 title: XPathResult
 slug: Web/API/XPathResult
-translation_of: Web/API/XPathResult
 ---
 {{APIRef}}
 

--- a/files/ja/web/api/xpathresult/snapshotitem/index.md
+++ b/files/ja/web/api/xpathresult/snapshotitem/index.md
@@ -1,15 +1,6 @@
 ---
 title: XPathResult.snapshotItem()
 slug: Web/API/XPathResult/snapshotItem
-tags:
-  - API
-  - DOM XPath API
-  - Method
-  - Reference
-  - XPath
-  - XPathResult
-  - メソッド
-translation_of: Web/API/XPathResult/snapshotItem
 ---
 {{APIRef("DOM XPath")}}
 

--- a/files/ja/web/api/xrboundedreferencespace/boundsgeometry/index.md
+++ b/files/ja/web/api/xrboundedreferencespace/boundsgeometry/index.md
@@ -1,27 +1,6 @@
 ---
 title: XRBoundedReferenceSpace.boundsGeometry
 slug: Web/API/XRBoundedReferenceSpace/boundsGeometry
-tags:
-  - API
-  - AR
-  - Boundary
-  - Edges
-  - Geometry
-  - Property
-  - Read-only
-  - Reality
-  - Reference
-  - VR
-  - Virtual
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-  - XRBoundedReferenceSpace
-  - augmented
-  - boundsGeometry
-  - space
-translation_of: Web/API/XRBoundedReferenceSpace/boundsGeometry
 ---
 {{APIRef("WebXR Device API")}}{{secureContext_header}}
 

--- a/files/ja/web/api/xrboundedreferencespace/index.md
+++ b/files/ja/web/api/xrboundedreferencespace/index.md
@@ -1,21 +1,6 @@
 ---
 title: XRBoundedReferenceSpace
 slug: Web/API/XRBoundedReferenceSpace
-tags:
-  - API
-  - AR
-  - Boundary
-  - Interface
-  - Reference
-  - VR
-  - Virtual
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-  - XRBoundedReferenceSpace
-  - augmented
-translation_of: Web/API/XRBoundedReferenceSpace
 ---
 {{APIRef("WebXR Device API")}}{{secureContext_header}}
 

--- a/files/ja/web/api/xrinputsource/gripspace/index.md
+++ b/files/ja/web/api/xrinputsource/gripspace/index.md
@@ -1,20 +1,6 @@
 ---
 title: XRInputSource.gripSpace
 slug: Web/API/XRInputSource/gripSpace
-tags:
-  - API
-  - AR
-  - Augmented Reality
-  - Experimental
-  - Property
-  - Reference
-  - VR
-  - Virtual Reality
-  - WebXR
-  - WebXR Device API
-  - XRInputSession
-  - gripSpace
-translation_of: Web/API/XRInputSource/gripSpace
 ---
 {{securecontext_header}}{{APIRef("WebXR")}}
 

--- a/files/ja/web/api/xrinputsource/handedness/index.md
+++ b/files/ja/web/api/xrinputsource/handedness/index.md
@@ -1,26 +1,6 @@
 ---
 title: XRInputSource.handedness
 slug: Web/API/XRInputSource/handedness
-tags:
-  - API
-  - AR
-  - Controller
-  - Handedness
-  - Input
-  - Property
-  - Read-only
-  - Reference
-  - VR
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-  - XRInputSource
-  - hand
-  - left
-  - right
-browser-compat: api.XRInputSource.handedness
-translation_of: Web/API/XRInputSource/handedness
 ---
 {{APIRef("WebXR Device API")}}
 

--- a/files/ja/web/api/xrinputsource/index.md
+++ b/files/ja/web/api/xrinputsource/index.md
@@ -1,21 +1,6 @@
 ---
 title: XRInputSource
 slug: Web/API/XRInputSource
-tags:
-  - API
-  - AR
-  - Augmented Reality
-  - Experimental
-  - Input
-  - Interface
-  - Reference
-  - VR
-  - Virtual Reality
-  - WebXR
-  - WebXR Device API
-  - XRInputSource
-  - control
-translation_of: Web/API/XRInputSource
 ---
 {{securecontext_header}}{{APIRef("WebXR Device API")}}
 

--- a/files/ja/web/api/xrinputsource/profiles/index.md
+++ b/files/ja/web/api/xrinputsource/profiles/index.md
@@ -1,24 +1,6 @@
 ---
 title: XRInputSource.profiles
 slug: Web/API/XRInputSource/profiles
-tags:
-  - API
-  - AR
-  - Configuration
-  - Input
-  - Property
-  - Read-only
-  - Reference
-  - VR
-  - Virtual
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-  - XRInputSource
-  - augmented
-  - profile
-translation_of: Web/API/XRInputSource/profiles
 ---
 {{APIRef("WebXR")}}{{securecontext_header}}
 

--- a/files/ja/web/api/xrinputsource/targetraymode/index.md
+++ b/files/ja/web/api/xrinputsource/targetraymode/index.md
@@ -1,25 +1,6 @@
 ---
 title: XRInputSource.targetRayMode
 slug: Web/API/XRInputSource/targetRayMode
-tags:
-  - API
-  - AR
-  - Pointing
-  - Property
-  - Ray
-  - Read-only
-  - Reference
-  - VR
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-  - XRInputSource
-  - direction
-  - pointer
-  - target
-  - targetRayMode
-translation_of: Web/API/XRInputSource/targetRayMode
 ---
 {{APIRef("WebXR Device API")}}
 

--- a/files/ja/web/api/xrreferencespace/getoffsetreferencespace/index.md
+++ b/files/ja/web/api/xrreferencespace/getoffsetreferencespace/index.md
@@ -1,27 +1,6 @@
 ---
 title: XRReferenceSpace.getOffsetReferenceSpace()
 slug: Web/API/XRReferenceSpace/getOffsetReferenceSpace
-tags:
-  - API
-  - AR
-  - Mixed
-  - Orientation
-  - Position
-  - Reality
-  - Reference
-  - Rotate
-  - VR
-  - Virtual
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-  - XRReferenceSpace
-  - augmented
-  - getOffsetReferenceSpace
-  - move
-  - movement
-translation_of: Web/API/XRReferenceSpace/getOffsetReferenceSpace
 ---
 {{APIRef("WebXR Device API")}}{{secureContext_header}}
 

--- a/files/ja/web/api/xrreferencespace/index.md
+++ b/files/ja/web/api/xrreferencespace/index.md
@@ -1,27 +1,6 @@
 ---
 title: XRReferenceSpace
 slug: Web/API/XRReferenceSpace
-page-type: web-api-interface
-tags:
-  - API
-  - AR
-  - Augmented Reality
-  - Distances
-  - Interface
-  - Mixed Reality
-  - Offsets
-  - Reference
-  - Spaces
-  - VR
-  - Virtual Reality
-  - WebXR API
-  - WebXR Device API
-  - WebXR\
-  - XR
-  - XRReferenceSpace
-  - matrix
-  - transform
-translation_of: Web/API/XRReferenceSpace
 ---
 {{APIRef("WebXR Device API")}}{{secureContext_header}}
 

--- a/files/ja/web/api/xrreferencespace/reset_event/index.md
+++ b/files/ja/web/api/xrreferencespace/reset_event/index.md
@@ -1,23 +1,6 @@
 ---
 title: 'XRReferenceSpace: reset イベント'
 slug: Web/API/XRReferenceSpace/reset_event
-tags:
-  - API
-  - AR
-  - Event
-  - Graphics
-  - Reality
-  - Reference
-  - VR
-  - Virtual
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-  - XRReferenceSpace
-  - augmented
-  - reset
-translation_of: Web/API/XRReferenceSpace/reset_event
 ---
 {{APIRef("WebXR Device API")}}{{secureContext_header}}
 

--- a/files/ja/web/api/xrreferencespaceevent/index.md
+++ b/files/ja/web/api/xrreferencespaceevent/index.md
@@ -1,24 +1,6 @@
 ---
 title: XRReferenceSpaceEvent
 slug: Web/API/XRReferenceSpaceEvent
-tags:
-  - API
-  - AR
-  - Event
-  - Interface
-  - Mixed
-  - Reality
-  - Reference
-  - Reference Space
-  - VR
-  - Virtual
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-  - XRReferenceSpaceEvent
-  - augmented
-translation_of: Web/API/XRReferenceSpaceEvent
 ---
 {{APIRef("WebXR Device API")}}{{SecureContext_header}}
 

--- a/files/ja/web/api/xrreferencespaceevent/referencespace/index.md
+++ b/files/ja/web/api/xrreferencespaceevent/referencespace/index.md
@@ -1,25 +1,6 @@
 ---
 title: XRReferenceSpaceEvent.referenceSpace
 slug: Web/API/XRReferenceSpaceEvent/referenceSpace
-tags:
-  - API
-  - AR
-  - Mixed
-  - Reality
-  - Reference
-  - Reference Space
-  - VR
-  - Virtual
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-  - XRReferenceSpaceEvent
-  - augmented
-  - events
-  - referenceSpace
-  - source
-translation_of: Web/API/XRReferenceSpaceEvent/referenceSpace
 ---
 {{APIRef("WebXR Device API")}}{{SecureContext_header}}
 

--- a/files/ja/web/api/xrreferencespaceevent/transform/index.md
+++ b/files/ja/web/api/xrreferencespaceevent/transform/index.md
@@ -1,30 +1,6 @@
 ---
 title: XRReferenceSpaceEvent.transform
 slug: Web/API/XRReferenceSpaceEvent/transform
-tags:
-  - API
-  - AR
-  - Coordinate System
-  - Coordinates
-  - Event
-  - Mixed
-  - Orientation
-  - Position
-  - Property
-  - Read-only
-  - Reality
-  - Reference
-  - VR
-  - Virtual
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-  - XRReferenceSpace
-  - augmented
-  - reset
-  - transform
-translation_of: Web/API/XRReferenceSpaceEvent/transform
 ---
 {{APIRef("WebXR Device API")}}{{SecureContext_header}}
 

--- a/files/ja/web/api/xrreferencespaceevent/xrreferencespaceevent/index.md
+++ b/files/ja/web/api/xrreferencespaceevent/xrreferencespaceevent/index.md
@@ -1,26 +1,6 @@
 ---
 title: XRReferenceSpaceEvent()
 slug: Web/API/XRReferenceSpaceEvent/XRReferenceSpaceEvent
-tags:
-  - API
-  - AR
-  - Constructor
-  - Events
-  - Mixed
-  - Reality
-  - Reference
-  - Reference Space
-  - VR
-  - Virtual
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-  - XRReferenceSpaceEvent
-  - augmented
-  - events
-browser-compat: api.XRReferenceSpaceEvent.XRReferenceSpaceEvent
-translation_of: Web/API/XRReferenceSpaceEvent/XRReferenceSpaceEvent
 ---
 {{APIRef("WebXR Device API")}}
 

--- a/files/ja/web/api/xrrigidtransform/index.md
+++ b/files/ja/web/api/xrrigidtransform/index.md
@@ -1,25 +1,6 @@
 ---
 title: XRRigidTransform
 slug: Web/API/XRRigidTransform
-tags:
-  - API
-  - AR
-  - Interface
-  - Reality
-  - Reference
-  - Reference Space
-  - VR
-  - Virtual
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-  - XRReferenceSpace
-  - XRRigidTransform
-  - augmented
-  - space
-  - transform
-translation_of: Web/API/XRRigidTransform
 ---
 {{APIRef("WebXR Device API")}}
 

--- a/files/ja/web/api/xrrigidtransform/inverse/index.md
+++ b/files/ja/web/api/xrrigidtransform/inverse/index.md
@@ -1,24 +1,6 @@
 ---
 title: XRRigidTransform.inverse
 slug: Web/API/XRRigidTransform/inverse
-tags:
-  - API
-  - AR
-  - Property
-  - Read-only
-  - Reality
-  - Reference
-  - VR
-  - Virtual
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-  - XRRigidTransform
-  - augmented
-  - inverse
-  - transform
-translation_of: Web/API/XRRigidTransform/inverse
 ---
 {{APIRef("WebXR Device API")}}
 

--- a/files/ja/web/api/xrrigidtransform/matrix/index.md
+++ b/files/ja/web/api/xrrigidtransform/matrix/index.md
@@ -1,24 +1,6 @@
 ---
 title: XRRigidTransform.matrix
 slug: Web/API/XRRigidTransform/matrix
-tags:
-  - API
-  - AR
-  - Property
-  - Read-only
-  - Reality
-  - Reference
-  - VR
-  - Virtual
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-  - XRRigidTransform
-  - augmented
-  - matrix
-  - transform
-translation_of: Web/API/XRRigidTransform/matrix
 ---
 {{APIRef("WebXR Device API")}}
 

--- a/files/ja/web/api/xrrigidtransform/orientation/index.md
+++ b/files/ja/web/api/xrrigidtransform/orientation/index.md
@@ -1,24 +1,6 @@
 ---
 title: XRRigidTransform.orientation
 slug: Web/API/XRRigidTransform/orientation
-tags:
-  - API
-  - AR
-  - Orientation
-  - Property
-  - Read-only
-  - Reality
-  - Reference
-  - VR
-  - Virtual
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-  - XRRigidTransform
-  - augmented
-  - rotation
-translation_of: Web/API/XRRigidTransform/orientation
 ---
 {{APIRef("WebXR Device API")}}
 

--- a/files/ja/web/api/xrrigidtransform/position/index.md
+++ b/files/ja/web/api/xrrigidtransform/position/index.md
@@ -1,23 +1,6 @@
 ---
 title: XRRigidTransform.position
 slug: Web/API/XRRigidTransform/position
-tags:
-  - 3D
-  - API
-  - AR
-  - Coordinates
-  - Location
-  - Point
-  - Position
-  - Property
-  - Reference
-  - VR
-  - WebXR
-  - WebXR API
-  - XR
-  - XRRigidTransform
-  - transform
-translation_of: Web/API/XRRigidTransform/position
 ---
 {{APIRef("WebXR Device API")}}
 

--- a/files/ja/web/api/xrrigidtransform/xrrigidtransform/index.md
+++ b/files/ja/web/api/xrrigidtransform/xrrigidtransform/index.md
@@ -1,23 +1,6 @@
 ---
 title: XRRigidTransform()
 slug: Web/API/XRRigidTransform/XRRigidTransform
-tags:
-  - API
-  - AR
-  - Constructor
-  - Mixed Reality
-  - Orientation
-  - Position
-  - Reality
-  - Reference
-  - VR
-  - Virtual
-  - WebXR
-  - XR
-  - XRRigidTransform
-  - augmented
-  - transform
-translation_of: Web/API/XRRigidTransform/XRRigidTransform
 ---
 {{APIRef("WebXR Device API")}}
 

--- a/files/ja/web/api/xrsession/requestreferencespace/index.md
+++ b/files/ja/web/api/xrsession/requestreferencespace/index.md
@@ -1,26 +1,6 @@
 ---
 title: XRReferenceSpaceType
 slug: Web/API/XRSession/requestReferenceSpace
-tags:
-  - API
-  - AR
-  - Enumerated
-  - Enumerated Type
-  - Reality
-  - Reference
-  - Type
-  - VR
-  - Virtual
-  - WebXR
-  - WebXR API
-  - WebXR Device API
-  - XR
-  - XRReferenceSpace
-  - XRReferenceSpaceType
-  - augmented
-  - space
-  - tracking
-translation_of: Web/API/XRReferenceSpaceType
 original_slug: Web/API/XRReferenceSpaceType
 ---
 {{APIRef("WebXR Device API")}}

--- a/files/ja/web/api/xrsystem/index.md
+++ b/files/ja/web/api/xrsystem/index.md
@@ -1,20 +1,6 @@
 ---
 title: XRSystem
 slug: Web/API/XRSystem
-tags:
-  - API
-  - AR
-  - Augmented Reality
-  - Experimental
-  - Interface
-  - Reference
-  - VR
-  - Virtual Reality
-  - WebXR
-  - WebXR Device API
-  - XR
-  - XRSystem
-translation_of: Web/API/XRSystem
 ---
 {{APIRef("WebXR Device API")}}{{SecureContext_Header}}
 

--- a/files/ja/web/api/xsltprocessor/basic_example/index.md
+++ b/files/ja/web/api/xsltprocessor/basic_example/index.md
@@ -1,9 +1,6 @@
 ---
 title: XSLT の基本的な例
 slug: Web/API/XSLTProcessor/Basic_Example
-tags:
-  - XSLT
-translation_of: Web/API/XSLTProcessor/Basic_Example
 ---
 ## 基本的な例
 

--- a/files/ja/web/api/xsltprocessor/browser_differences/index.md
+++ b/files/ja/web/api/xsltprocessor/browser_differences/index.md
@@ -1,7 +1,6 @@
 ---
 title: ブラウザー間の違い
 slug: Web/API/XSLTProcessor/Browser_Differences
-translation_of: Web/API/XSLTProcessor/Browser_Differences
 ---
 ## ブラウザー間の違い
 

--- a/files/ja/web/api/xsltprocessor/generating_html/index.md
+++ b/files/ja/web/api/xsltprocessor/generating_html/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTML の生成
 slug: Web/API/XSLTProcessor/Generating_HTML
-translation_of: Web/API/XSLTProcessor/Generating_HTML
 ---
 ## HTML の生成
 

--- a/files/ja/web/api/xsltprocessor/index.md
+++ b/files/ja/web/api/xsltprocessor/index.md
@@ -1,14 +1,6 @@
 ---
 title: XSLTProcessor
 slug: Web/API/XSLTProcessor
-tags:
-  - API
-  - DOM
-  - DOM Reference
-  - Reference
-  - XSLT
-translation_of: Web/API/XSLTProcessor
-browser-compat: api.XSLTProcessor
 ---
 {{Non-standard_header}}{{SeeCompatTable}}{{APIRef("XSLT")}}
 

--- a/files/ja/web/api/xsltprocessor/introduction/index.md
+++ b/files/ja/web/api/xsltprocessor/introduction/index.md
@@ -1,7 +1,6 @@
 ---
 title: 序文
 slug: Web/API/XSLTProcessor/Introduction
-translation_of: Web/API/XSLTProcessor/Introduction
 ---
 ## 序文
 

--- a/files/ja/web/api/xsltprocessor/resources/index.md
+++ b/files/ja/web/api/xsltprocessor/resources/index.md
@@ -1,7 +1,6 @@
 ---
 title: Resources
 slug: Web/API/XSLTProcessor/Resources
-translation_of: Web/API/XSLTProcessor/Resources
 ---
 ## 参考
 


### PR DESCRIPTION
Part of #7858

`files/ja/web/api/{x-z}*` から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "tags": 66,
  "translation_of": 70,
  "browser-compat": 30,
  "page-type": 1
}
```
