### PR TITLE
Change the HTMLRefTable of Contenu Embarqué

### DIFF
--- a/files/fr/web/html/element/index.md
+++ b/files/fr/web/html/element/index.md
@@ -58,7 +58,7 @@ HTML prend en charge différents fichiers multimédias pour les images, les fich
 
 En plus du contenu multimédia, un document HTML peut embarquer d'autres contenus (bien que les interactions soient plutôt limitées).
 
-{{HTMLRefTable("multimedia")}}
+{{HTMLRefTable({"include":["HTML embedded content"], "exclude":["multimedia"]})}}
 
 ## SVG et MathML
 


### PR DESCRIPTION
This element  was a copy of Images et Médias and I have used the same link than in the EN version which is : {{HTMLRefTable({"include":["HTML embedded content"], "exclude":["multimedia"]})}}