### PR TITLE
chore: Optimize some Flaws in HTTP for ZH-CN and ZH-TW

### DIFF
--- a/files/zh-cn/web/http/index.md
+++ b/files/zh-cn/web/http/index.md
@@ -2,6 +2,7 @@
 title: HTTP
 slug: Web/HTTP
 ---
+
 {{HTTPSidebar}}
 
 **_超文本传输协议_**（HTTP）是一个用于传输超媒体文档（例如 HTML）的[应用层](https://en.wikipedia.org/wiki/Application_Layer)协议。它是为 Web 浏览器与 Web 服务器之间的通信而设计的，但也可以用于其他目的。HTTP 遵循经典的[客户端 - 服务端模型](https://en.wikipedia.org/wiki/Client%E2%80%93server_model)，客户端打开一个连接以发出请求，然后等待直到收到服务器端响应。HTTP 是[无状态协议](http://en.wikipedia.org/wiki/Stateless_protocol)，这意味着服务器不会在两个请求之间保留任何数据（状态）。尽管通常基于 TCP/IP 层，但它可以在任何可靠的[传输层](https://zh.wikipedia.org/wiki/%E4%BC%A0%E8%BE%93%E5%B1%82)上使用，也就是说，该协议不会像 UDP 那样静默的丢失消息。[RUDP](https://en.wikipedia.org/wiki/Reliable_User_Datagram_Protocol)——作为 UDP 的可靠化升级版本——是一种合适的替代选择。
@@ -12,11 +13,11 @@ slug: Web/HTTP
 
 - [HTTP 概述](/zh-CN/docs/Web/HTTP/Overview)
   - : 介绍了客户端 - 服务器端协议的基本特征：它能够做什么以及它的设计意图。
-- [HTTP 缓存](/zh-CN/docs/Web/HTTP/Caching_FAQ)
+- [HTTP 缓存](/zh-CN/docs/Web/HTTP/Caching)
   - : 缓存对高速 Web 站点来说是非常之重要的。这篇文章阐述了不同种类的缓存以及如何配置 HTTP Headers 来控制它们。
 - [HTTP Cookie](/zh-CN/docs/Web/HTTP/Cookies)
-  - : [RFC 6265](http://tools.ietf.org/html/rfc6265) 定义了 cookie 的工作方式。在处理 HTTP 请求时，服务器可以在 HTTP 响应头中通过 HTTP Headers `Set-Cookie` 为客户端设置 cookie。然后，对于同一服务器发起的每一个请求，客户端都会在 HTTP 请求头中以字段 `Cookie` 的形式将 cookie 的值发送过去。也可以将 cookie 设置为在特定日期过期，或限制为特定的域和路径。
-- [跨域资源共享（CORS）](/zh-CN/docs/Web/HTTP/Access_control_CORS)
+  - : [RFC 6265](https://tools.ietf.org/html/rfc6265) 定义了 cookie 的工作方式。在处理 HTTP 请求时，服务器可以在 HTTP 响应头中通过 HTTP Headers `Set-Cookie` 为客户端设置 cookie。然后，对于同一服务器发起的每一个请求，客户端都会在 HTTP 请求头中以字段 `Cookie` 的形式将 cookie 的值发送过去。也可以将 cookie 设置为在特定日期过期，或限制为特定的域和路径。
+- [跨域资源共享（CORS）](/zh-CN/docs/Web/HTTP/CORS)
   - : **跨站点 HTTP 请求**就是从**另一个域名**，而不是资源所在的域名发起的 HTTP 请求。举例来说，在域名 A (`http://domaina.example/`) 的 HTML 页面上使用 `img` 元素 (`<img src="http://domainb.foo/image.jpg">`) 来请求域名 B (http\://domainb.foo/) 上的图片资源。这在当今的 Web 页面上是很常见的 —— 加载跨站点资源，包括 CSS 样式表，图片，脚本和其他资源。CORS 允许 Web 开发人员控制其站点对跨站点请求的反应。
 - [HTTP 的演变](/zh-CN/docs/Web/HTTP/Basics_of_HTTP/Evolution_of_HTTP)
   - : 简单描述了从早期版本的 HTTP 到现代 HTTP/2，新兴的 HTTP/3 以及未来版本的 HTTP 这个过程中发生的变更。
@@ -37,7 +38,7 @@ slug: Web/HTTP
   - : HTTP 消息头用于描述资源或服务器或客户端的行为。可以使用 `X-` 前缀添加自定义专有头。其他的可以在 [IANA registry](https://www.iana.org/assignments/message-headers/message-headers.xhtml#perm-headers) 中找到，其原始定义在 [RFC 4229](https://tools.ietf.org/html/rfc4229)。IANA 同时也维护着一份 [registry of proposed new HTTP message headers](https://www.iana.org/assignments/message-headers/message-headers.xhtml#prov-headers)。
 - [HTTP 请求方式](/zh-CN/docs/Web/HTTP/Methods)
   - : 可以使用 HTTP: {{HTTPMethod("GET")}}，{{HTTPMethod("POST")}} 方式来完成不同操作，或是一些不太常见的请求方式，像是： {{HTTPMethod("OPTIONS")}}，{{HTTPMethod("DELETE")}} 和 {{HTTPMethod("TRACE")}}。
-- [HTTP 状态码](/zh-CN/docs/Web/HTTP/Response_codes)
+- [HTTP 状态码](/zh-CN/docs/Web/HTTP/Status)
   - : HTTP 状态码用来表示特定的 HTTP 请求是否已成功完成。响应分为五类：消息响应，成功响应，重定向，客户端错误和服务器错误。
 - [CSP 指令](/zh-CN/docs/Web/HTTP/Headers/Content-Security-Policy)
   - : {{HTTPHeader("Content-Security-Policy")}} 响应报头字段允许网站管理员控制页面上哪些资源能够被用户代理程序加载。除了少数例外，此策略主要涉及指定服务器来源和脚本终端。
@@ -46,11 +47,11 @@ slug: Web/HTTP
 
 有助于了解和调试 HTTP 的工具和资源。
 
-- [Firefox 开发者工具](/zh-CN/docs/Tools)
-  - : [网络监视器](/zh-CN/docs/Tools/Network_Monitor)
+- [Firefox 开发者工具](https://firefox-source-docs.mozilla.org/devtools-user/index.html)
+  - : [网络监视器](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/index.html)
 - [Mozilla Observatory](https://observatory.mozilla.org/)
   - : 一个旨在帮助开发人员，系统管理员和安全专业人员安全地配置其站点的项目。
 - [RedBot](https://redbot.org/)
   - : 用于检查与缓存相关的 HTTP 头的工具。
-- [浏览器的工作原理](https://www.html5rocks.com/en/tutorials/internals/howbrowserswork/)
+- [浏览器的工作原理](https://web.dev/howbrowserswork/)
   - : 一篇非常全面的关于浏览器内部实现与通过 HTTP 协议的请求流的文章。可以说是所有 Web 开发者的**必读内容**。

--- a/files/zh-tw/web/http/index.md
+++ b/files/zh-tw/web/http/index.md
@@ -35,7 +35,7 @@ slug: Web/HTTP
 詳細的 HTTP 參考文件。
 
 - [HTTP Headers](/zh-TW/docs/Web/HTTP/Headers)
-  - : HTTP 消息頭用於描述資源或服務器或客戶端的行為。可以使用 `X-` 前綴添加自定義專有頭。其他的可以在 [IANA registry](https://www.iana.org/assignments/message-headers/message-headers.xhtml#perm-headers) 中找到，其原始定義在 [RFC 4229](https://tools.ietf.org/html/rfc4229)。 IANA 同時也維護著一份 [registry of proposed new HTTP message headers](https://www.iana.org/assignments/message-headers/message-headers.xhtml#prov-headers)。
+  - : HTTP 訊息檔頭（header）用於描述資源、伺服器或用戶端的行為。可以透過 `X-` 前綴以增加自定義的專有項目。其他的項目可以在 [IANA registry](https://www.iana.org/assignments/message-headers/message-headers.xhtml#perm-headers) 中找到，其原始定義在 [RFC 4229](https://tools.ietf.org/html/rfc4229)。IANA 同時也維護 [新 HTTP 訊息檔頭的提案登記（registry of proposed new HTTP message headers）](https://www.iana.org/assignments/message-headers/message-headers.xhtml#prov-headers)。
 - [HTTP 請求方法](/zh-TW/docs/Web/HTTP/Methods)
   - : 透過 HTTP 有幾種不同操作方法：{{HTTPMethod("GET")}}、{{HTTPMethod("POST")}}，或是較少見的請求方法，如 {{HTTPMethod("OPTIONS")}}、{{HTTPMethod("DELETE")}}、或 {{HTTPMethod("TRACE")}}。
 - [HTTP 狀態回應碼](/zh-TW/docs/Web/HTTP/Status)

--- a/files/zh-tw/web/http/index.md
+++ b/files/zh-tw/web/http/index.md
@@ -2,6 +2,7 @@
 title: HTTP
 slug: Web/HTTP
 ---
+
 {{HTTPSidebar}}
 
 **_超文本傳輸協定 (HTTP)_** 是一種用來傳輸超媒體文件 (像是 HTML 文件) 的[應用層](http://en.wikipedia.org/wiki/Application_Layer)協定，被設計來讓瀏覽器和伺服器進行溝通，但也可做其他用途。HTTP 遵循標準[客戶端—伺服器](https://en.wikipedia.org/wiki/Client%E2%80%93server_model)模式，由客戶端連線以發送請求，然後等待接收回應。HTTP 是一種[無狀態協定](https://en.wikipedia.org/wiki/Stateless_protocol)，意思是伺服器不會保存任兩個請求間的任何資料 (狀態)。儘管作為 TCP/IP 的應用層，HTTP 亦可應用於其他可靠的[傳輸層](http://en.wikipedia.org/wiki/Transport_Layer) (例如 [UDP](https://en.wikipedia.org/wiki/User_Datagram_Protocol))，只要不會無聲無息地遺失訊息即可。
@@ -15,8 +16,8 @@ slug: Web/HTTP
 - [HTTP Cache](/zh-TW/docs/Web/HTTP/Caching)
   - : Cache 對網站速度很重要。 此文章描敘不同的方法使用 HTTP Header 控制它。
 - [HTTP Cookies](/zh-TW/docs/Web/HTTP/Cookies)
-  - : [RFC 6265](http://tools.ietf.org/html/rfc6265) 定義了 cookies 的工作方式，當 HTTP 請求一個服務時，一個伺服器可以發送一個`Set-Cookie`的 HTTP header 回應。客戶端將以 header 的方式回傳 cookie 值給每個請求的同 一個伺服器，Cookie 也會在某些時間進行更新，或是限制一個實體網域或路徑。
-- [HTTP Access Control (CORS)](/zh-TW/docs/Web/HTTP/Access_control_CORS)
+  - : [RFC 6265](https://tools.ietf.org/html/rfc6265) 定義了 cookies 的工作方式，當 HTTP 請求一個服務時，一個伺服器可以發送一個`Set-Cookie`的 HTTP header 回應。客戶端將以 header 的方式回傳 cookie 值給每個請求的同 一個伺服器，Cookie 也會在某些時間進行更新，或是限制一個實體網域或路徑。
+- [HTTP Access Control (CORS)](/zh-TW/docs/Web/HTTP/CORS)
   - : **Cross-site HTTP requests** 是來自不同網域的資源請求。舉個例子，一個 HTML 網頁從網域 A (`http://domaina.example/`) 從網域 B(`http://domainb.foo/image.jpg`)請求一個圖片，經由`img`元件。現今的網頁通常會讀取跨站資源，包括 CSS 樣式表、圖片、腳本與其他資源。CORS 允許網頁開發人員的網站響應跨站讀取。
 - [HTTP 的演化](/zh-TW/docs/Web/HTTP/Basics_of_HTTP/Evolution_of_HTTP)
   - : HTTP 早期版本變化的簡要說明，到現在的 HTTP/2 與其他版本。
@@ -33,24 +34,24 @@ slug: Web/HTTP
 
 詳細的 HTTP 參考文件。
 
-- [HTTP Headers](/zh-TW/docs/Web/HTTP/Headers)
-  - : HTTP message headers are used to describe a resource, or the behavior of the server or the client. Custom proprietary headers can be added using the `X-` prefix; others in an [IANA registry](http://www.iana.org/assignments/message-headers/perm-headers.html), whose original content was defined in [RFC 4229](http://tools.ietf.org/html/rfc4229). IANA also maintains a [registry of proposed new HTTP message headers](http://www.iana.org/assignments/message-headers/prov-headers.html).
+- [HTTP 頭](/zh-TW/docs/Web/HTTP/Headers)
+  - : HTTP 消息頭用於描述資源或服務器或客戶端的行為。可以使用 `X-` 前綴添加自定義專有頭。其他的可以在 [IANA registry](https://www.iana.org/assignments/message-headers/message-headers.xhtml#perm-headers) 中找到，其原始定義在 [RFC 4229](https://tools.ietf.org/html/rfc4229)。 IANA 同時也維護著一份 [registry of proposed new HTTP message headers](https://www.iana.org/assignments/message-headers/message-headers.xhtml#prov-headers)。
 - [HTTP 請求方法](/zh-TW/docs/Web/HTTP/Methods)
-  - : 透過 HTTP 有幾種不同操作方法：{{HTTPMethod("GET")}}, {{HTTPMethod("POST")}}, and also less common requests like {{HTTPMethod("OPTIONS")}}, {{HTTPMethod("DELETE")}}, or {{HTTPMethod("TRACE")}}.
-- [HTTP 狀態回應碼](/zh-TW/docs/Web/HTTP/Response_codes)
-  - : HTTP response codes indicate whether a specific HTTP request has been successfully completed. Responses are grouped in five classes: informational responses, successful responses, redirections, client errors, and servers errors.
-- [CSP directives](/zh-TW/docs/Web/HTTP/Headers/Content-Security-Policy)
-  - : The {{HTTPHeader("Content-Security-Policy")}} response header fields allows web site administrators to control resources the user agent is allowed to load for a given page. With a few exceptions, policies mostly involve specifying server origins and script endpoints.
+  - : 透過 HTTP 有幾種不同操作方法：{{HTTPMethod("GET")}}, {{HTTPMethod("POST")}}，或是一些不太常見的請求方式，像是：{{HTTPMethod("OPTIONS")}}, {{HTTPMethod("DELETE")}}, or {{HTTPMethod("TRACE")}}.
+- [HTTP 狀態回應碼](/zh-TW/docs/Web/HTTP/Status)
+  - : HTTP 狀態碼用來表示特定的 HTTP 請求是否已成功完成。響應分為五類：消息響應，成功響應，重定向，客戶端錯誤和服務器錯誤。
+- [CSP 指令](/zh-TW/docs/Web/HTTP/Headers/Content-Security-Policy)
+  - : {{HTTPHeader("Content-Security-Policy")}} 響應報頭字段允許網站管理員控制頁面上哪些資源能夠被用戶代理程序加載。除了少數例外，此策略主要涉及指定服務器來源和腳本終端。
 
 ## 工具與資源
 
-Helpful tools and resources for understanding and debugging HTTP.
+有助於了解和調試 HTTP 的工具和資源。
 
-- [Firefox Developer Tools](/zh-TW/docs/Tools)
-  - : [Network monitor](/zh-TW/docs/Tools/Network_Monitor)
+- [Firefox 開發者工具](https://firefox-source-docs.mozilla.org/devtools-user/index.html)
+  - : [網絡監視器](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/index.html)
 - [Mozilla Observatory](https://observatory.mozilla.org/)
-  - : A project designed to help developers, system administrators, and security professionals configure their sites safely and securely.
+  - : 一個旨在幫助開發人員，系統管理員和安全專業人員安全地配置其站點的項目。
 - [RedBot](https://redbot.org/)
-  - : Tools to check your cache-related headers
-- [How Browsers Work](http://www.html5rocks.com/en/tutorials/internals/howbrowserswork/)
-  - : A very comprehensive article on browser internals and request flow through HTTP protocol. A MUST-READ for any web developer.
+  - : 用於檢查與緩存相關的 HTTP 頭的工具。
+- [瀏覽器的工作原理](https://web.dev/howbrowserswork/)
+  - : 一篇非常全面的關於瀏覽器內部實現與通過 HTTP 協議的請求流的文章。可以說是所有 Web 開發者的**必讀內容**。

--- a/files/zh-tw/web/http/index.md
+++ b/files/zh-tw/web/http/index.md
@@ -52,6 +52,6 @@ slug: Web/HTTP
 - [Mozilla Observatory](https://observatory.mozilla.org/)
   - : 一個旨在幫助開發人員，系統管理員和安全專業人員安全地配置其站點的項目。
 - [RedBot](https://redbot.org/)
-  - : 用於檢查與緩存相關的 HTTP 頭的工具。
+  - : 用於檢查與暫存相關的 HTTP 檔頭的工具。
 - [瀏覽器的工作原理](https://web.dev/howbrowserswork/)
   - : 關於瀏覽器內部實作及 HTTP 通訊協定請求流程的一篇非常詳盡的文章。可以說是所有 Web 開發者都**必讀**的內容。

--- a/files/zh-tw/web/http/index.md
+++ b/files/zh-tw/web/http/index.md
@@ -45,7 +45,7 @@ slug: Web/HTTP
 
 ## 工具與資源
 
-有助於了解和調試 HTTP 的工具和資源。
+有助了解與測試 HTTP 的工具和資源。
 
 - [Firefox 開發者工具](https://firefox-source-docs.mozilla.org/devtools-user/index.html)
   - : [網絡監視器](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/index.html)

--- a/files/zh-tw/web/http/index.md
+++ b/files/zh-tw/web/http/index.md
@@ -39,7 +39,7 @@ slug: Web/HTTP
 - [HTTP 請求方法](/zh-TW/docs/Web/HTTP/Methods)
   - : 透過 HTTP 有幾種不同操作方法：{{HTTPMethod("GET")}}, {{HTTPMethod("POST")}}，或是一些不太常見的請求方式，像是：{{HTTPMethod("OPTIONS")}}, {{HTTPMethod("DELETE")}}, or {{HTTPMethod("TRACE")}}.
 - [HTTP 狀態回應碼](/zh-TW/docs/Web/HTTP/Status)
-  - : HTTP 狀態碼用來表示特定的 HTTP 請求是否已成功完成。響應分為五類：消息響應，成功響應，重定向，客戶端錯誤和服務器錯誤。
+  - : HTTP 狀態碼用來表示特定的 HTTP 請求是否已成功完成。回應分為五類：資訊回應、成功回應、重定向、用戶端錯誤、以及伺服器錯誤。
 - [CSP 指令](/zh-TW/docs/Web/HTTP/Headers/Content-Security-Policy)
   - : {{HTTPHeader("Content-Security-Policy")}} 響應報頭字段允許網站管理員控制頁面上哪些資源能夠被用戶代理程序加載。除了少數例外，此策略主要涉及指定服務器來源和腳本終端。
 

--- a/files/zh-tw/web/http/index.md
+++ b/files/zh-tw/web/http/index.md
@@ -54,4 +54,4 @@ slug: Web/HTTP
 - [RedBot](https://redbot.org/)
   - : 用於檢查與緩存相關的 HTTP 頭的工具。
 - [瀏覽器的工作原理](https://web.dev/howbrowserswork/)
-  - : 一篇非常全面的關於瀏覽器內部實現與通過 HTTP 協議的請求流的文章。可以說是所有 Web 開發者的**必讀內容**。
+  - : 關於瀏覽器內部實作及 HTTP 通訊協定請求流程的一篇非常詳盡的文章。可以說是所有 Web 開發者都**必讀**的內容。

--- a/files/zh-tw/web/http/index.md
+++ b/files/zh-tw/web/http/index.md
@@ -41,7 +41,7 @@ slug: Web/HTTP
 - [HTTP 狀態回應碼](/zh-TW/docs/Web/HTTP/Status)
   - : HTTP 狀態碼用來表示特定的 HTTP 請求是否已成功完成。回應分為五類：資訊回應、成功回應、重定向、用戶端錯誤、以及伺服器錯誤。
 - [CSP 指令](/zh-TW/docs/Web/HTTP/Headers/Content-Security-Policy)
-  - : {{HTTPHeader("Content-Security-Policy")}} 響應報頭字段允許網站管理員控制頁面上哪些資源能夠被用戶代理程序加載。除了少數例外，此策略主要涉及指定服務器來源和腳本終端。
+  - : {{HTTPHeader("Content-Security-Policy")}} 回應檔頭讓網站管理員控制哪些頁面上的資源能被用戶端程式（user agent）載入。除了少數特例外，此政策主要關於指定來源伺服器和腳本程式的端點（endpoints）。
 
 ## 工具與資源
 

--- a/files/zh-tw/web/http/index.md
+++ b/files/zh-tw/web/http/index.md
@@ -37,7 +37,7 @@ slug: Web/HTTP
 - [HTTP Headers](/zh-TW/docs/Web/HTTP/Headers)
   - : HTTP 消息頭用於描述資源或服務器或客戶端的行為。可以使用 `X-` 前綴添加自定義專有頭。其他的可以在 [IANA registry](https://www.iana.org/assignments/message-headers/message-headers.xhtml#perm-headers) 中找到，其原始定義在 [RFC 4229](https://tools.ietf.org/html/rfc4229)。 IANA 同時也維護著一份 [registry of proposed new HTTP message headers](https://www.iana.org/assignments/message-headers/message-headers.xhtml#prov-headers)。
 - [HTTP 請求方法](/zh-TW/docs/Web/HTTP/Methods)
-  - : 透過 HTTP 有幾種不同操作方法：{{HTTPMethod("GET")}}, {{HTTPMethod("POST")}}，或是一些不太常見的請求方式，像是：{{HTTPMethod("OPTIONS")}}, {{HTTPMethod("DELETE")}}, or {{HTTPMethod("TRACE")}}.
+  - : 透過 HTTP 有幾種不同操作方法：{{HTTPMethod("GET")}}、{{HTTPMethod("POST")}}，或是較少見的請求方法，如 {{HTTPMethod("OPTIONS")}}、{{HTTPMethod("DELETE")}}、或 {{HTTPMethod("TRACE")}}。
 - [HTTP 狀態回應碼](/zh-TW/docs/Web/HTTP/Status)
   - : HTTP 狀態碼用來表示特定的 HTTP 請求是否已成功完成。回應分為五類：資訊回應、成功回應、重定向、用戶端錯誤、以及伺服器錯誤。
 - [CSP 指令](/zh-TW/docs/Web/HTTP/Headers/Content-Security-Policy)

--- a/files/zh-tw/web/http/index.md
+++ b/files/zh-tw/web/http/index.md
@@ -34,7 +34,7 @@ slug: Web/HTTP
 
 詳細的 HTTP 參考文件。
 
-- [HTTP 頭](/zh-TW/docs/Web/HTTP/Headers)
+- [HTTP Headers](/zh-TW/docs/Web/HTTP/Headers)
   - : HTTP 消息頭用於描述資源或服務器或客戶端的行為。可以使用 `X-` 前綴添加自定義專有頭。其他的可以在 [IANA registry](https://www.iana.org/assignments/message-headers/message-headers.xhtml#perm-headers) 中找到，其原始定義在 [RFC 4229](https://tools.ietf.org/html/rfc4229)。 IANA 同時也維護著一份 [registry of proposed new HTTP message headers](https://www.iana.org/assignments/message-headers/message-headers.xhtml#prov-headers)。
 - [HTTP 請求方法](/zh-TW/docs/Web/HTTP/Methods)
   - : 透過 HTTP 有幾種不同操作方法：{{HTTPMethod("GET")}}, {{HTTPMethod("POST")}}，或是一些不太常見的請求方式，像是：{{HTTPMethod("OPTIONS")}}, {{HTTPMethod("DELETE")}}, or {{HTTPMethod("TRACE")}}.

--- a/files/zh-tw/web/http/index.md
+++ b/files/zh-tw/web/http/index.md
@@ -53,5 +53,5 @@ slug: Web/HTTP
   - : 旨在幫助開發者、系統管理員和安全專業人員安全地配置網站的專案。
 - [RedBot](https://redbot.org/)
   - : 用於檢查與暫存相關的 HTTP 檔頭的工具。
-- [瀏覽器的工作原理](https://web.dev/howbrowserswork/)
+- [How Browsers Work](https://web.dev/howbrowserswork/)
   - : 關於瀏覽器內部實作及 HTTP 通訊協定請求流程的一篇非常詳盡的文章。可以說是所有 Web 開發者都**必讀**的內容。

--- a/files/zh-tw/web/http/index.md
+++ b/files/zh-tw/web/http/index.md
@@ -48,7 +48,7 @@ slug: Web/HTTP
 有助了解與測試 HTTP 的工具和資源。
 
 - [Firefox 開發者工具](https://firefox-source-docs.mozilla.org/devtools-user/index.html)
-  - : [網絡監視器](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/index.html)
+  - : [網路監視器（Network Monitor）](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/index.html)
 - [Mozilla Observatory](https://observatory.mozilla.org/)
   - : 一個旨在幫助開發人員，系統管理員和安全專業人員安全地配置其站點的項目。
 - [RedBot](https://redbot.org/)

--- a/files/zh-tw/web/http/index.md
+++ b/files/zh-tw/web/http/index.md
@@ -50,7 +50,7 @@ slug: Web/HTTP
 - [Firefox 開發者工具](https://firefox-source-docs.mozilla.org/devtools-user/index.html)
   - : [網路監視器（Network Monitor）](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/index.html)
 - [Mozilla Observatory](https://observatory.mozilla.org/)
-  - : 一個旨在幫助開發人員，系統管理員和安全專業人員安全地配置其站點的項目。
+  - : 旨在幫助開發者、系統管理員和安全專業人員安全地配置網站的專案。
 - [RedBot](https://redbot.org/)
   - : 用於檢查與暫存相關的 HTTP 檔頭的工具。
 - [瀏覽器的工作原理](https://web.dev/howbrowserswork/)


### PR DESCRIPTION
Fixed some Flaws I just saw in the GitHub bot prompt

Include some updated URLs, some links not using https, and a redirect link (https://www.html5rocks.com/en/tutorials/internals/howbrowserswork/ will automatically redirect to https://web.dev/howbrowserswork/)

And I tried to translate other parts of ZH-TW of this page

As for other Flaws that exist in ZH-TW because other parts of the site are not fully translated, I ignore them