### PR TITLE
[pt-br] Fixing the small typo 'trabahando'

### DIFF
--- a/files/pt-br/learn/javascript/first_steps/math/index.html
+++ b/files/pt-br/learn/javascript/first_steps/math/index.html
@@ -57,7 +57,7 @@ original_slug: Learn/JavaScript/First_steps/Matematica
 <ul>
  <li><strong>Binário</strong> — A linguagem de menor level dos computadores; 0s e 1s.</li>
  <li><strong>Octal</strong> — Base 8, usa um caractere entre 0–7 em cada coluna.</li>
- <li><strong>Hexadecimal</strong> — Base 16, usa um caractere entre 0–9 e depois um entre a–f em cada coluna. Você pode já ter encontrado esses números anteriormente, trabahando com <a href="/pt-BR/docs/Aprender/CSS/Introduction_to_CSS/Valores_e_unidades#Valores_hexadecimais">cores no CSS</a>.</li>
+ <li><strong>Hexadecimal</strong> — Base 16, usa um caractere entre 0–9 e depois um entre a–f em cada coluna. Você pode já ter encontrado esses números anteriormente, trabalhando com <a href="/pt-BR/docs/Aprender/CSS/Introduction_to_CSS/Valores_e_unidades#Valores_hexadecimais">cores no CSS</a>.</li>
 </ul>
 
 <p><strong>Antes de se preocupar com seu cérebro estar derretendo, pare agora mesmo!</strong> Para um começo, vamos nos ater aos números decimais no decorrer desse curso; você raramente irá se deparar com a necessidade de começar a pensar sobre os outros tipos, se é que vai precisar algum dia.</p>


### PR DESCRIPTION
Fixing small typo present in ```files/pt-br/learn/javascript/first_steps/math```. 

Error mentioned in issue #8005