### PR TITLE
Remove `{{warning}}` for fr

### DIFF
--- a/files/fr/web/api/performance/navigation/index.md
+++ b/files/fr/web/api/performance/navigation/index.md
@@ -1,6 +1,8 @@
 ---
 title: Performance.navigation
 slug: Web/API/Performance/navigation
+l10n:
+  sourceCommit: cadd198e75b25e939938c414e46e95aa7f14318b
 ---
 {{APIRef("Navigation Timing")}}{{Deprecated_Header}}
 

--- a/files/fr/web/api/performance/navigation/index.md
+++ b/files/fr/web/api/performance/navigation/index.md
@@ -1,37 +1,22 @@
 ---
-title: performance.navigation
+title: Performance.navigation
 slug: Web/API/Performance/navigation
-tags:
-  - API
-  - Rétrocompatibilité
-  - Déprécié
-  - HTTP
-  - Performance
-  - Propriété
-  - Property
-  - Lecture seule
-  - Read-only
-  - Reference
-  - legacy
-translation_of: Web/API/Performance/navigation
 ---
-{{Deprecated_Header}}{{APIRef("Navigation Timing")}}
+{{APIRef("Navigation Timing")}}{{Deprecated_Header}}
 
-> **Attention :** Cette propriété est dépréciée dans la spécification [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete).
+L'ancienne propriété **`Performance.navigation`** en lecture seule renvoie un objet [`PerformanceNavigation`](/fr/docs/Web/API/PerformanceNavigation) représentant le type de navigation qui se produit dans le contexte de navigation donné, comme le nombre de redirections nécessaires pour aller chercher la ressource.
 
-L'ancienne propriété en lecture seule **`Performance.navigation`** renvoie un objet {{domxref("PerformanceNavigation")}} représentant le type de navigation qui se produit dans le contexte de navigation donné, comme le nombre de redirections nécessaires pour aller chercher la ressource.
+Cette propriété n'est pas disponible pour les <i lang="en">workers</i>.
 
-{{warning("Cette propriété n'est pas disponible dans les Web Workers.")}}
+> **Attention :** Cette propriété est dépréciée dans la [spécification de mesure des durées de navigation (<i lang="en">Navigation Timing</i>)](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
-## Syntaxe
+## Valeur
 
-```js
-  navObject = performance.navigation;
-```
+Un objet [`PerformanceNavigation`](/fr/docs/Web/API/PerformanceNavigation).
 
 ## Spécifications
 
-{{Specifications}}
+Cette fonctionnalité n'est plus en voie de standardisation, car elle est indiquée comme dépréciée dans la [spécification de mesure des durées de navigation (<i lang="en">Navigation Timing</i>)](https://w3c.github.io/navigation-timing/#obsolete). Utilisez à la place l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming).
 
 ## Compatibilité des navigateurs
 
@@ -39,4 +24,4 @@ L'ancienne propriété en lecture seule **`Performance.navigation`** renvoie un 
 
 ## Voir aussi
 
-- L'interface {{domxref("Performance")}} à laquelle il appartient.
+- L'interface qui porte cette propriété, [`Performance`](/fr/docs/Web/API/Performance).

--- a/files/fr/web/api/performance/timing/index.md
+++ b/files/fr/web/api/performance/timing/index.md
@@ -1,6 +1,8 @@
 ---
 title: Performance.timing
 slug: Web/API/Performance/timing
+l10n:
+  sourceCommit: cadd198e75b25e939938c414e46e95aa7f14318b
 ---
 {{APIRef("Navigation Timing")}}{{deprecated_header}}
 

--- a/files/fr/web/api/performance/timing/index.md
+++ b/files/fr/web/api/performance/timing/index.md
@@ -1,36 +1,22 @@
 ---
-title: performance.timing
+title: Performance.timing
 slug: Web/API/Performance/timing
-tags:
-  - API
-  - Rétrocompatibilité
-  - Déprécié
-  - Navigation Timing
-  - Performance
-  - Property
-  - Propriété
-  - Read-only
-  - Lecture seule
-  - Reference
-translation_of: Web/API/Performance/timing
 ---
-{{deprecated_header}}{{APIRef("Navigation Timing")}}
+{{APIRef("Navigation Timing")}}{{deprecated_header}}
 
-> **Attention :** Cette propriété est dépréciée dans la spécification [Navigation Timing Level 2](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface {{domxref("PerformanceNavigationTiming")}} à la place.
+L'ancienne propriété **`Performance.timing`** en lecture seule renvoie un objet [`PerformanceTiming`](/fr/docs/Web/API/PerformanceTiming) contenant des informations de performance liées à la latence.
 
-L'ancienne propriété **`Performance.timing`** renvoie un objet {{domxref("PerformanceTiming")}} en lecture seule contenant des informations de performance liées à la latence.
+Cette propriété n'est pas disponible pour les <i lang="en">workers</i>.
 
-{{warning("Cette propriété n'est pas disponible dans les Web Workers.")}}
+> **Attention :** Cette propriété est dépréciée dans la [spécification de mesure des durées de navigation (<i lang="en">Navigation Timing</i>)](https://w3c.github.io/navigation-timing/#obsolete). Veuillez utiliser l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming) à la place.
 
-## Syntaxe
+## Valeur
 
-```js
-  timingInfo = performance.timing;
-```
+Un objet [`PerformanceTiming`](/fr/docs/Web/API/PerformanceTiming).
 
 ## Spécifications
 
-{{Specifications}}
+Cette fonctionnalité n'est plus en voie de standardisation, car elle est indiquée comme dépréciée dans la [spécification de mesure des durées de navigation (<i lang="en">Navigation Timing</i>)](https://w3c.github.io/navigation-timing/#obsolete). Utilisez à la place l'interface [`PerformanceNavigationTiming`](/fr/docs/Web/API/PerformanceNavigationTiming).
 
 ## Compatibilité des navigateurs
 
@@ -38,4 +24,4 @@ L'ancienne propriété **`Performance.timing`** renvoie un objet {{domxref("Perf
 
 ## Voir aussi
 
-- L'interface {{domxref("Performance")}} à laquelle il appartient.
+- L'interface qui porte cette propriété, [`Performance`](/fr/docs/Web/API/Performance).


### PR DESCRIPTION
An update for two pages to remove `{{warning}}` (#8108 for fr)