### PR TITLE
fix: typo on zh-cn page

### DIFF
--- a/files/zh-cn/web/html/element/input/tel/index.md
+++ b/files/zh-cn/web/html/element/input/tel/index.md
@@ -4,7 +4,7 @@ slug: Web/HTML/Element/Input/tel
 ---
 {{HTMLRef}}
 
-{{HTMLElement("input")}} **`"tel"`** 类型的元素用于让用户输入和编辑电话号码。 Unli 不同于[`<input type="email">`](/en-US/docs/Web/HTML/Element/input/email) 和 [`<input type="url">`](/en-US/docs/Web/HTML/Element/input/url) , 在提交表格之前，输入值不会被自动验证为特定格式，因为世界各地的电话号码格式差别很大。
+{{HTMLElement("input")}} **`"tel"`** 类型的元素用于让用户输入和编辑电话号码。不同于[`<input type="email">`](/en-US/docs/Web/HTML/Element/input/email) 和 [`<input type="url">`](/en-US/docs/Web/HTML/Element/input/url) , 在提交表格之前，输入值不会被自动验证为特定格式，因为世界各地的电话号码格式差别很大。
 
 尽管 `tel` 类型的输入在功能上和 `text` 输入一致，但它们确实有用; 其中最明显的就是移动浏览器— 特别是在手机上 — 可能会选择提供为输入电话号码而优化的自定义键盘。使用电话号码的特定输入类型也使添加自定义验证和处理电话号码更方便。
 

--- a/files/zh-cn/web/html/element/input/tel/index.md
+++ b/files/zh-cn/web/html/element/input/tel/index.md
@@ -4,7 +4,7 @@ slug: Web/HTML/Element/Input/tel
 ---
 {{HTMLRef}}
 
-{{HTMLElement("input")}} **`"tel"`** 类型的元素用于让用户输入和编辑电话号码。不同于[`<input type="email">`](/en-US/docs/Web/HTML/Element/input/email) 和 [`<input type="url">`](/en-US/docs/Web/HTML/Element/input/url) , 在提交表格之前，输入值不会被自动验证为特定格式，因为世界各地的电话号码格式差别很大。
+{{HTMLElement("input")}} **`"tel"`** 类型的元素用于让用户输入和编辑电话号码。不同于[`<input type="email">`](/zh-CN/docs/Web/HTML/Element/input/email) 和 [`<input type="url">`](/zh-CN/docs/Web/HTML/Element/input/url) , 在提交表格之前，输入值不会被自动验证为特定格式，因为世界各地的电话号码格式差别很大。
 
 尽管 `tel` 类型的输入在功能上和 `text` 输入一致，但它们确实有用; 其中最明显的就是移动浏览器— 特别是在手机上 — 可能会选择提供为输入电话号码而优化的自定义键盘。使用电话号码的特定输入类型也使添加自定义验证和处理电话号码更方便。
 


### PR DESCRIPTION
remove [unnecessary English word](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Element/Input/tel#:~:text=%E7%BC%96%E8%BE%91%E7%94%B5%E8%AF%9D%E5%8F%B7%E7%A0%81%E3%80%82-,Unli,-%E4%B8%8D%E5%90%8C%E4%BA%8E%3Cinput)

![image](https://user-images.githubusercontent.com/35162802/187844536-ef582112-4c35-4aac-b73d-d9411110973e.png)

It is the word `unlike` on [English page](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/tel), and had translated into `不同于`

![image](https://user-images.githubusercontent.com/35162802/187844660-ff57a08c-3093-43a8-8e54-35fabc441a31.png)
