### PR TITLE
Intl.Segments 関連の翻訳

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/intl/segments/@@iterator/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/segments/@@iterator/index.md
@@ -1,0 +1,71 @@
+---
+title: Intl.Segments.prototype[@@iterator]()
+slug: Web/JavaScript/Reference/Global_Objects/Intl/Segments/@@iterator
+tags:
+  - Internationalization
+  - Intl
+  - JavaScript
+  - Localization
+  - Reference
+browser-compat: javascript.builtins.Intl.Segments.@@iterator
+---
+{{JSRef}}
+
+The **`[@@iterator]()`** method is part of [the iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol), which returns a new iterator object that can iterate over the entries in an `Intl.Segmenter` object.  Each entry is returned as an object.
+
+{{EmbedInteractiveExample("pages/js/intl-segments-prototype-@@iterator.html")}}
+
+## Syntax
+
+```js
+segments[Symbol.iterator]
+```
+
+The one iterator function available is `.next()`, as described in the [iterator protocol page](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterator_protocol).
+
+### Return value
+
+A new Iterator object.
+
+## Examples
+
+```js
+const segmenter = new Intl.Segmenter("fr", {granularity: "word"});
+const input = "Moi ? N'est-ce pas ?";
+const segments = segmenter.segment(input);
+const iterator = segments[Symbol.iterator]();
+
+let result = iterator.next();
+
+while (!result.done) {
+  console.log(result.value);
+  result = iterator.next();
+}
+
+/* Logs
+{segment: 'Moi', index: 0, input: "Moi ? N'est-ce pas ?", isWordLike: true}
+{segment: ' ', index: 3, input: "Moi ? N'est-ce pas ?", isWordLike: false}
+{segment: '?', index: 4, input: "Moi ? N'est-ce pas ?", isWordLike: false}
+{segment: ' ', index: 5, input: "Moi ? N'est-ce pas ?", isWordLike: false}
+{segment: "N'est", index: 6, input: "Moi ? N'est-ce pas ?", isWordLike: true}
+{segment: '-', index: 11, input: "Moi ? N'est-ce pas ?", isWordLike: false}
+{segment: 'ce', index: 12, input: "Moi ? N'est-ce pas ?", isWordLike: true}
+{segment: ' ', index: 14, input: "Moi ? N'est-ce pas ?", isWordLike: false}
+{segment: 'pas', index: 15, input: "Moi ? N'est-ce pas ?", isWordLike: true}
+{segment: ' ', index: 18, input: "Moi ? N'est-ce pas ?", isWordLike: false}
+{segment: '?', index: 19, input: "Moi ? N'est-ce pas ?", isWordLike: false}
+*/
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Iteration protocols](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)
+- [`Array.prototype[@@iterator]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator)

--- a/files/ja/web/javascript/reference/global_objects/intl/segments/@@iterator/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/segments/@@iterator/index.md
@@ -1,33 +1,28 @@
 ---
 title: Intl.Segments.prototype[@@iterator]()
 slug: Web/JavaScript/Reference/Global_Objects/Intl/Segments/@@iterator
-tags:
-  - Internationalization
-  - Intl
-  - JavaScript
-  - Localization
-  - Reference
-browser-compat: javascript.builtins.Intl.Segments.@@iterator
+l10n:
+  sourceCommit: 6dfc15fbe7a8679ec06140d7cdb37d6908512426
 ---
 {{JSRef}}
 
-The **`[@@iterator]()`** method is part of [the iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol), which returns a new iterator object that can iterate over the entries in an `Intl.Segmenter` object.  Each entry is returned as an object.
+**`[@@iterator]()`** メソッドは、[iterable プロトコル](/ja/docs/Web/JavaScript/Reference/Iteration_protocols#反復可能_iterable_プロトコル)の一部で、`Intl.Segmenter` オブジェクトのエントリーを反復処理できる新しいイテレーターオブジェクトを返します。各エントリーは、オブジェクトとして返されます。
 
 {{EmbedInteractiveExample("pages/js/intl-segments-prototype-@@iterator.html")}}
 
-## Syntax
+## 構文
 
 ```js
 segments[Symbol.iterator]
 ```
 
-The one iterator function available is `.next()`, as described in the [iterator protocol page](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterator_protocol).
+利用できるイテレーター関数は、[iterable プロトコル](/ja/docs/Web/JavaScript/Reference/Iteration_protocols#反復子_iterator_プロトコル)のページで説明したように、`.next()` の 1 つです。
 
-### Return value
+### 返値
 
-A new Iterator object.
+新しいイテレーターオブジェクト。
 
-## Examples
+## 例
 
 ```js
 const segmenter = new Intl.Segmenter("fr", {granularity: "word"});
@@ -57,15 +52,15 @@ while (!result.done) {
 */
 ```
 
-## Specifications
+## 仕様書
 
 {{Specifications}}
 
-## Browser compatibility
+## ブラウザーの互換性
 
 {{Compat}}
 
-## See also
+## 関連情報
 
-- [Iteration protocols](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)
-- [`Array.prototype[@@iterator]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator)
+- [Iteration protocols](/ja/docs/Web/JavaScript/Reference/Iteration_protocols)
+- [`Array.prototype[@@iterator]()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator)

--- a/files/ja/web/javascript/reference/global_objects/intl/segments/containing/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/segments/containing/index.md
@@ -1,0 +1,78 @@
+---
+title: Intl.Segments.prototype.containing()
+slug: Web/JavaScript/Reference/Global_Objects/Intl/Segments/containing
+tags:
+  - Internationalization
+  - Intl
+  - JavaScript
+  - Localization
+  - Reference
+browser-compat: javascript.builtins.Intl.Segments.containing
+---
+{{JSRef}}
+
+The **`Intl.Segments.containing()`** method returns an object describing the segment in the string that includes the code unit at the specified index.
+
+{{EmbedInteractiveExample("pages/js/intl-segments-prototype-containing.html")}}
+
+## Syntax
+
+```js
+containing(codeUnitIndex)
+```
+
+### Parameters
+
+- `codeUnitIndex` {{ optional_inline }}
+  - : A number specifying the index of the code unit in the original input string. If the value is omitted, it defaults to `0`.
+
+### Return Value
+
+An object describing the segment of the original string with the following properties, or `undefined` if the supplied index value is out of bounds.
+
+- `segment`
+  - : A string containing the segment extracted from the original input string.
+- `index`
+  - : The code unit index in the original input string at which the segment begins.
+- `input`
+  - : The complete input string that was segmented.
+- `isWordLike`
+  - : A boolean value only if `granularity` is `"word"`; otherwise, `undefined`.  If `granularity` is `"word"`, then `isWordLike` is `true` when the segment is word-like (i.e., consists of letters/numbers/ideographs/etc.); otherwise, `false`.
+
+## Examples
+
+```js
+// ┃0 1 2 3 4 5┃6┃7┃8┃9  ← code unit index
+// ┃A l l o n s┃-┃y┃!┃   ← code unit
+const input = "Allons-y!";
+
+const segmenter = new Intl.Segmenter("fr", {granularity: "word"});
+const segments = segmenter.segment(input);
+let current = undefined;
+
+current = segments.containing();
+// → { index: 0, segment: "Allons", isWordLike: true }
+
+current = segments.containing(4);
+// → { index: 0, segment: "Allons", isWordLike: true }
+
+current = segments.containing(6);
+// → { index: 6, segment: "-", isWordLike: false }
+
+current = segments.containing(current.index + current.segment.length);
+// → { index: 7, segment: "y", isWordLike: true }
+
+current = segments.containing(current.index + current.segment.length);
+// → { index: 8, segment: "!", isWordLike: false }
+
+current = segments.containing(current.index + current.segment.length);
+// → undefined
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/ja/web/javascript/reference/global_objects/intl/segments/containing/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/segments/containing/index.md
@@ -1,45 +1,40 @@
 ---
 title: Intl.Segments.prototype.containing()
 slug: Web/JavaScript/Reference/Global_Objects/Intl/Segments/containing
-tags:
-  - Internationalization
-  - Intl
-  - JavaScript
-  - Localization
-  - Reference
-browser-compat: javascript.builtins.Intl.Segments.containing
+l10n:
+  sourceCommit: 46c0f5269f597ad055d0b6322f736f5c70996c4c
 ---
 {{JSRef}}
 
-The **`Intl.Segments.containing()`** method returns an object describing the segment in the string that includes the code unit at the specified index.
+**`Intl.Segments.containing()`** メソッドは、指定されたインデックスのコードユニットを含む文字列中のセグメントを記述したオブジェクトを返します。
 
 {{EmbedInteractiveExample("pages/js/intl-segments-prototype-containing.html")}}
 
-## Syntax
+## 構文
 
 ```js
 containing(codeUnitIndex)
 ```
 
-### Parameters
+### 引数
 
 - `codeUnitIndex` {{ optional_inline }}
-  - : A number specifying the index of the code unit in the original input string. If the value is omitted, it defaults to `0`.
+  - : 元の入力文字列におけるコードユニットのインデックスを指定する数値。省略した場合のデフォルトは `0` となります。
 
-### Return Value
+### 返値
 
-An object describing the segment of the original string with the following properties, or `undefined` if the supplied index value is out of bounds.
+元の文字列のセグメントを記述するオブジェクトで以下のプロパティを持ちます。与えられたインデックス値が範囲外の場合は `undefined` となります。
 
 - `segment`
-  - : A string containing the segment extracted from the original input string.
+  - : 元の入力文字列から抽出されたセグメントを含む文字列。
 - `index`
-  - : The code unit index in the original input string at which the segment begins.
+  - : セグメントを開始する元の入力文字列のコードユニットのインデックス。
 - `input`
-  - : The complete input string that was segmented.
+  - : セグメント化された完全な入力文字列。
 - `isWordLike`
-  - : A boolean value only if `granularity` is `"word"`; otherwise, `undefined`.  If `granularity` is `"word"`, then `isWordLike` is `true` when the segment is word-like (i.e., consists of letters/numbers/ideographs/etc.); otherwise, `false`.
+  - : `granularity` が `"word"` の場合のみブール値となり、それ以外は `undefined` です。`granularity` が `"word"` の場合、`isWordLike` は、セグメントが単語のようなもの（すなわち、文字／数字／英字／その他）である場合に `true`、それ以外の場合に `false` となります。
 
-## Examples
+## 例
 
 ```js
 // ┃0 1 2 3 4 5┃6┃7┃8┃9  ← code unit index
@@ -69,10 +64,10 @@ current = segments.containing(current.index + current.segment.length);
 // → undefined
 ```
 
-## Specifications
+## 仕様書
 
 {{Specifications}}
 
-## Browser compatibility
+## ブラウザーの互換性
 
 {{Compat}}

--- a/files/ja/web/javascript/reference/global_objects/intl/segments/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/segments/index.md
@@ -1,0 +1,31 @@
+---
+title: Intl.Segments
+slug: Web/JavaScript/Reference/Global_Objects/Intl/Segments
+tags:
+  - Internationalization
+  - Intl
+  - JavaScript
+  - Localization
+  - Reference
+browser-compat: javascript.builtins.Intl.Segments
+---
+{{JSRef}}
+
+An **`Intl.Segments`** instance is an iterable collection of the segments of a text string. It is returned by a call to the [`segment()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment) method of an [`Intl.Segmenter`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter) object.
+
+{{EmbedInteractiveExample("pages/js/intl-segments-prototype-containing.html")}}
+
+## Instance methods
+
+- [`Segments.prototype.containing()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segments/containing)
+  - : Returns an object describing the segment in the original string that includes the code unit at a specified index.
+- [`Segments.prototype[@@iterator]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segments/@@iterator)
+  - : Returns an iterator to iterate over the segments.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/ja/web/javascript/reference/global_objects/intl/segments/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/segments/index.md
@@ -1,31 +1,26 @@
 ---
 title: Intl.Segments
 slug: Web/JavaScript/Reference/Global_Objects/Intl/Segments
-tags:
-  - Internationalization
-  - Intl
-  - JavaScript
-  - Localization
-  - Reference
-browser-compat: javascript.builtins.Intl.Segments
+l10n:
+  sourceCommit: 46c0f5269f597ad055d0b6322f736f5c70996c4c
 ---
 {{JSRef}}
 
-An **`Intl.Segments`** instance is an iterable collection of the segments of a text string. It is returned by a call to the [`segment()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment) method of an [`Intl.Segmenter`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter) object.
+**`Intl.Segments`** のインスタンスは、テキスト文字列のセグメントを反復可能なコレクションとして保持します。[`Intl.Segmenter`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter) オブジェクトの [`segment()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment) メソッドをコールすると、このインスタンスが返されます。
 
 {{EmbedInteractiveExample("pages/js/intl-segments-prototype-containing.html")}}
 
-## Instance methods
+## インスタンスメソッド
 
-- [`Segments.prototype.containing()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segments/containing)
-  - : Returns an object describing the segment in the original string that includes the code unit at a specified index.
-- [`Segments.prototype[@@iterator]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segments/@@iterator)
-  - : Returns an iterator to iterate over the segments.
+- [`Segments.prototype.containing()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segments/containing)
+  - : 指定されたインデックスのコードユニットを含む元の文字列のセグメントを記述したオブジェクトを返します。
+- [`Segments.prototype[@@iterator]()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segments/@@iterator)
+  - : セグメントを反復処理するためのイテレータを返します。
 
-## Specifications
+## 仕様書
 
 {{Specifications}}
 
-## Browser compatibility
+## ブラウザーの互換性
 
 {{Compat}}

--- a/files/ja/web/javascript/reference/global_objects/intl/segments/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/segments/index.md
@@ -15,7 +15,7 @@ l10n:
 - [`Segments.prototype.containing()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segments/containing)
   - : 指定されたインデックスのコードユニットを含む元の文字列のセグメントを記述したオブジェクトを返します。
 - [`Segments.prototype[@@iterator]()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segments/@@iterator)
-  - : セグメントを反復処理するためのイテレータを返します。
+  - : セグメントを反復処理するためのイテレーターを返します。
 
 ## 仕様書
 


### PR DESCRIPTION
### 概要

以下のページの新規翻訳

- https://developer.mozilla.org/en-US/docs/web/javascript/reference/global_objects/intl/segments
- https://developer.mozilla.org/en-US/docs/web/javascript/reference/global_objects/intl/segments/@@iterator
- https://developer.mozilla.org/en-US/docs/web/javascript/reference/global_objects/intl/segments/containing

### 備考

メタデータ項目を最新の形（不要なものを削除する）にしてみました。

### 関連

close mozilla-japan/translation#634