### PR TITLE
for...of文の構文の修正 Fix syntax of for...of statement

### DIFF
--- a/files/ja/web/javascript/reference/statements/for...of/index.md
+++ b/files/ja/web/javascript/reference/statements/for...of/index.md
@@ -19,9 +19,8 @@ translation_of: Web/JavaScript/Reference/Statements/for...of
 ## 構文
 
 ```
-for (variable of iterable) {
+for (variable of iterable)
   statement
-}
 ```
 
 - `variable`


### PR DESCRIPTION
[仕様](https://tc39.es/ecma262/#sec-for-in-and-for-of-statements)を参考に2つの中括弧を削除しました。

Two braces have been removed in reference to [specification](https://tc39.es/ecma262/#sec-for-in-and-for-of-statements).