### PR TITLE
Remove `{{index}}` macro from translated-content

### DIFF
--- a/files/es/_redirects.txt
+++ b/files/es/_redirects.txt
@@ -2667,7 +2667,7 @@
 /es/docs/Web/Reference/Events/transitionend	/es/docs/Web/API/Element/transitionend_event
 /es/docs/Web/Reference/Events/wheel	/es/docs/Web/API/Element/wheel_event
 /es/docs/Web/SVG/Element/glifo	/es/docs/Web/SVG/Element/glyph
-/es/docs/Web/SVG/Index	/es/docs/conflicting/Web/SVG
+/es/docs/Web/SVG/Index	/es/docs/Web/SVG
 /es/docs/Web/SVG/SVG_1.1_Support_in_Firefox	/es/docs/orphaned/Web/SVG/SVG_1.1_Support_in_Firefox
 /es/docs/Web/SVG/Tutorial/Introducción	/es/docs/Web/SVG/Tutorial/Introduction
 /es/docs/Web/Security/Same-origin_politica	/es/docs/Web/Security/Same-origin_policy

--- a/files/es/_redirects.txt
+++ b/files/es/_redirects.txt
@@ -2072,7 +2072,7 @@
 /es/docs/Web/HTML/Elementos_en_línea	/es/docs/Web/HTML/Inline_elements
 /es/docs/Web/HTML/Gestión_del_foco_en_HTML	/es/docs/Web/API/Document/hasFocus
 /es/docs/Web/HTML/Imagen_con_CORS_habilitado	/es/docs/Web/HTML/CORS_enabled_image
-/es/docs/Web/HTML/Index	/es/docs/conflicting/Web/HTML
+/es/docs/Web/HTML/Index	/es/docs/Web/HTML
 /es/docs/Web/HTML/Microdatos	/es/docs/Web/HTML/Microdata
 /es/docs/Web/HTML/Optimizing_your_pages_for_speculative_parsing	/es/docs/Glossary/speculative_parsing
 /es/docs/Web/HTML/Referencia	/es/docs/Web/HTML/Reference
@@ -2080,7 +2080,7 @@
 /es/docs/Web/HTML/Transision_adaptativa_DASH	/es/docs/Web/Media/DASH_Adaptive_Streaming_for_HTML_5_Video
 /es/docs/Web/HTML/anipular_video_por_medio_de_canvas	/es/docs/Web/API/Canvas_API/Manipulating_video_using_canvas
 /es/docs/Web/HTML/microformatos	/es/docs/Web/HTML/microformats
-/es/docs/Web/HTML/Índice	/es/docs/conflicting/Web/HTML
+/es/docs/Web/HTML/Índice	/es/docs/Web/HTML
 /es/docs/Web/HTTP/Access_control_CORS	/es/docs/Web/HTTP/CORS
 /es/docs/Web/HTTP/Basics_of_HTTP/Data_URIs	/es/docs/Web/HTTP/Basics_of_HTTP/Data_URLs
 /es/docs/Web/HTTP/Basics_of_HTTP/Datos_URIs	/es/docs/Web/HTTP/Basics_of_HTTP/Data_URLs

--- a/files/es/_wikihistory.json
+++ b/files/es/_wikihistory.json
@@ -14864,10 +14864,6 @@
     "modified": "2019-03-23T23:32:51.331Z",
     "contributors": ["wbamberg"]
   },
-  "conflicting/Web/HTML": {
-    "modified": "2019-01-16T22:12:02.767Z",
-    "contributors": ["raecillacastellana", "pekechis"]
-  },
   "conflicting/Web/HTML/Element": {
     "modified": "2020-01-21T22:36:54.135Z",
     "contributors": [

--- a/files/es/_wikihistory.json
+++ b/files/es/_wikihistory.json
@@ -15121,10 +15121,6 @@
     "modified": "2019-11-03T14:52:14.998Z",
     "contributors": ["totopizzahn"]
   },
-  "conflicting/Web/SVG": {
-    "modified": "2019-01-16T22:36:49.773Z",
-    "contributors": ["jwhitlock", "ComplementosMozilla"]
-  },
   "conflicting/Web/Web_Components/Using_custom_elements": {
     "modified": "2019-03-23T22:21:51.809Z",
     "contributors": ["cawilff", "AlePerez92", "fipadron", "V.Morantes"]

--- a/files/es/conflicting/web/html/index.md
+++ b/files/es/conflicting/web/html/index.md
@@ -1,9 +1,0 @@
----
-title: Índice de la documentación HTML
-slug: conflicting/Web/HTML
-tags:
-  - HTML
-translation_of: Web/HTML/Index
-original_slug: Web/HTML/Index
----
-{{Index("/es/docs/Web/HTML")}}

--- a/files/es/conflicting/web/svg/index.md
+++ b/files/es/conflicting/web/svg/index.md
@@ -1,7 +1,0 @@
----
-title: SVG documentation index
-slug: conflicting/Web/SVG
-translation_of: Web/SVG/Index
-original_slug: Web/SVG/Index
----
-{{Index("/en-US/docs/Web/SVG")}}

--- a/files/ja/_redirects.txt
+++ b/files/ja/_redirects.txt
@@ -3962,7 +3962,7 @@
 /ja/docs/Web/Accessibility/ARIA/widgets	/ja/docs/conflicting/Web/Accessibility/ARIA_229a3bbc8da83524de32990b14561155
 /ja/docs/Web/Accessibility/ARIA/widgets/overview	/ja/docs/conflicting/Web/Accessibility/ARIA_229a3bbc8da83524de32990b14561155
 /ja/docs/Web/Accessibility/Accessibility_FAQ	/ja/docs/Web/Accessibility/FAQ
-/ja/docs/Web/Accessibility/Index	/ja/docs/conflicting/Web/Accessibility
+/ja/docs/Web/Accessibility/Index	/ja/docs/Web/Accessibility
 /ja/docs/Web/Apps/Build/Manipulating_media	/ja/docs/Web/Guide/Audio_and_video_delivery
 /ja/docs/Web/Apps/Build/Manipulating_media/Adding_captions_and_subtitles_to_HTML5_video	/ja/docs/Web/Guide/Audio_and_video_delivery/Adding_captions_and_subtitles_to_HTML5_video
 /ja/docs/Web/Apps/Build/Manipulating_media/Live_streaming_web_audio_and_video	/ja/docs/Web/Guide/Audio_and_video_delivery/Live_streaming_web_audio_and_video

--- a/files/ja/_wikihistory.json
+++ b/files/ja/_wikihistory.json
@@ -31589,10 +31589,6 @@
     "modified": "2020-10-15T22:29:46.631Z",
     "contributors": ["Wind1808"]
   },
-  "conflicting/Web/Accessibility": {
-    "modified": "2019-03-23T22:41:12.085Z",
-    "contributors": ["Marsf"]
-  },
   "conflicting/Web/Accessibility/ARIA": {
     "modified": "2019-03-23T23:28:42.286Z",
     "contributors": ["yyss", "teoli"]

--- a/files/ja/conflicting/web/accessibility/index.md
+++ b/files/ja/conflicting/web/accessibility/index.md
@@ -1,8 +1,0 @@
----
-title: アクセシビリティ関連ドキュメントの索引
-slug: conflicting/Web/Accessibility
-original_slug: Web/Accessibility/Index
----
-このドキュメントは、Mozilla Developer Network サイト上の、すべてのアクセシビリティの記事へのリンクの一覧を提供します。
-
-{{Index("/ja/docs/Web/Accessibility")}}

--- a/files/ja/conflicting/webassembly/index.md
+++ b/files/ja/conflicting/webassembly/index.md
@@ -1,8 +1,0 @@
----
-title: Index
-slug: conflicting/WebAssembly
-original_slug: WebAssembly/Index
----
-{{WebAssemblySidebar}}
-
-{{Index("/ja/docs/WebAssembly")}}


### PR DESCRIPTION
Removed all those simple conflicting documents for [the macro has been deprecated](https://github.com/mdn/yari/blob/1850cecade16ebb1105ef31075d8867eac1ac031/kumascript/macros/Index.ejs#L8).