### PR TITLE
Run `sync-translated-content` on `mdn/translated-content` only

### DIFF
--- a/.github/workflows/sync-translated-content.yml
+++ b/.github/workflows/sync-translated-content.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'mdn/translated-content'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This workflow should only run on `mdn/translated-content`, not on forks.