### PR TITLE
remove duplicated frontmatter keys from web/http (ja)

### DIFF
--- a/files/ja/web/http/authentication/index.md
+++ b/files/ja/web/http/authentication/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTTP 認証
 slug: Web/HTTP/Authentication
-tags:
-  - アクセス制御
-  - 認証
-  - ガイド
-  - HTTP
-  - セキュリティ
-translation_of: Web/HTTP/Authentication
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/basics_of_http/choosing_between_www_and_non-www_urls/index.md
+++ b/files/ja/web/http/basics_of_http/choosing_between_www_and_non-www_urls/index.md
@@ -1,11 +1,6 @@
 ---
 title: www 付きと www なしの URL の選択
 slug: Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs
-tags:
-  - Guide
-  - HTTP
-  - URL
-translation_of: Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/basics_of_http/data_urls/index.md
+++ b/files/ja/web/http/basics_of_http/data_urls/index.md
@@ -1,13 +1,6 @@
 ---
 title: データ URL
 slug: Web/HTTP/Basics_of_HTTP/Data_URLs
-tags:
-  - Base64
-  - Guide
-  - HTTP
-  - Intermediate
-  - URL
-translation_of: Web/HTTP/Basics_of_HTTP/Data_URIs
 original_slug: Web/HTTP/Basics_of_HTTP/Data_URIs
 ---
 {{HTTPSidebar}}

--- a/files/ja/web/http/basics_of_http/evolution_of_http/index.md
+++ b/files/ja/web/http/basics_of_http/evolution_of_http/index.md
@@ -1,12 +1,6 @@
 ---
 title: HTTP の進化
 slug: Web/HTTP/Basics_of_HTTP/Evolution_of_HTTP
-tags:
-  - Guide
-  - HTTP
-  - NeedsUpdate
-  - NeedsUpdate(HTTP/3)
-translation_of: Web/HTTP/Basics_of_HTTP/Evolution_of_HTTP
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/basics_of_http/identifying_resources_on_the_web/index.md
+++ b/files/ja/web/http/basics_of_http/identifying_resources_on_the_web/index.md
@@ -1,21 +1,6 @@
 ---
 title: ウェブ上のリソースの識別
 slug: Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web
-tags:
-  - Domain
-  - HTTP
-  - Path
-  - Scheme
-  - Syntax
-  - URI
-  - URL
-  - URL Syntax
-  - Web
-  - fragment
-  - port
-  - query
-  - resources
-translation_of: Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/basics_of_http/index.md
+++ b/files/ja/web/http/basics_of_http/index.md
@@ -1,12 +1,6 @@
 ---
 title: HTTP の基本
 slug: Web/HTTP/Basics_of_HTTP
-tags:
-  - Guide
-  - HTTP
-  - ガイド
-  - 概要
-translation_of: Web/HTTP/Basics_of_HTTP
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/basics_of_http/mime_types/common_types/index.md
+++ b/files/ja/web/http/basics_of_http/mime_types/common_types/index.md
@@ -1,18 +1,6 @@
 ---
 title: よくある MIME タイプ
 slug: Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
-tags:
-  - HTTP
-  - MIME
-  - MIME タイプ
-  - Reference
-  - タイプ
-  - テキスト
-  - ファイル
-  - ファイルタイプ
-  - 動画
-  - 音声
-translation_of: Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/basics_of_http/mime_types/index.md
+++ b/files/ja/web/http/basics_of_http/mime_types/index.md
@@ -1,18 +1,6 @@
 ---
 title: MIME タイプ (IANA メディアタイプ)
 slug: Web/HTTP/Basics_of_HTTP/MIME_types
-tags:
-  - Content-Type
-  - Guide
-  - HTTP
-  - MIME Types
-  - Meta
-  - Request header
-  - Response Header
-  - application/javascript
-  - application/json
-  - application/xml
-translation_of: Web/HTTP/Basics_of_HTTP/MIME_types
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/basics_of_http/resource_urls/index.md
+++ b/files/ja/web/http/basics_of_http/resource_urls/index.md
@@ -1,12 +1,6 @@
 ---
 title: リソース URL
 slug: Web/HTTP/Basics_of_HTTP/Resource_URLs
-tags:
-  - Guide
-  - HTTP
-  - Intermediate
-  - Resource
-translation_of: Web/HTTP/Basics_of_HTTP/Resource_URLs
 ---
 {{HTTPSidebar}}{{non-standard_header}}
 

--- a/files/ja/web/http/browser_detection_using_the_user_agent/index.md
+++ b/files/ja/web/http/browser_detection_using_the_user_agent/index.md
@@ -1,11 +1,6 @@
 ---
 title: ユーザーエージェント文字列を用いたブラウザーの判定
 slug: Web/HTTP/Browser_detection_using_the_user_agent
-tags:
-  - Compatibility
-  - HTTP
-  - Web Development
-translation_of: Web/HTTP/Browser_detection_using_the_user_agent
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/caching/index.md
+++ b/files/ja/web/http/caching/index.md
@@ -1,11 +1,6 @@
 ---
 title: HTTP キャッシュ
 slug: Web/HTTP/Caching
-tags:
-  - Caching
-  - Guide
-  - HTTP
-translation_of: Web/HTTP/Caching
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/client_hints/index.md
+++ b/files/ja/web/http/client_hints/index.md
@@ -1,13 +1,6 @@
 ---
 title: Client Hints (クライアントヒント)
 slug: Web/HTTP/Client_hints
-tags:
-  - Client hints
-  - Glossary
-  - Performance
-  - Reference
-  - Web Performance
-translation_of: Glossary/Client_hints
 original_slug: Glossary/Client_hints
 ---
 **クライアントヒント** (Client Hints) は、プロアクティブコンテンツネゴシエーション用の [HTTP リクエストヘッダー](/ja/docs/Web/HTTP/Headers)フィールドのセットで、クライアントがデバイスとエージェントに固有の設定のリストを示すことができます。 [クライアントヒント](/ja/docs/Web/HTTP/Headers#Client_hints)により、画像の DPR 解像度の自動ネゴシエーションなどの最適化されたアセットの自動配信が可能になります。

--- a/files/ja/web/http/compression/index.md
+++ b/files/ja/web/http/compression/index.md
@@ -1,12 +1,6 @@
 ---
 title: HTTP の圧縮
 slug: Web/HTTP/Compression
-tags:
-  - Guide
-  - HTTP
-  - ガイド
-  - 圧縮
-translation_of: Web/HTTP/Compression
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/conditional_requests/index.md
+++ b/files/ja/web/http/conditional_requests/index.md
@@ -1,11 +1,6 @@
 ---
 title: HTTP 条件付きリクエスト
 slug: Web/HTTP/Conditional_requests
-tags:
-  - Conditional Requests
-  - Guide
-  - HTTP
-translation_of: Web/HTTP/Conditional_requests
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/configuring_servers_for_ogg_media/index.md
+++ b/files/ja/web/http/configuring_servers_for_ogg_media/index.md
@@ -1,12 +1,6 @@
 ---
 title: Ogg メディア用のサーバーの設定
 slug: Web/HTTP/Configuring_servers_for_Ogg_media
-tags:
-  - Audio
-  - Media
-  - Ogg
-  - Video
-translation_of: Web/HTTP/Configuring_servers_for_Ogg_media
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/connection_management_in_http_1.x/index.md
+++ b/files/ja/web/http/connection_management_in_http_1.x/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTTP/1.x のコネクション管理
 slug: Web/HTTP/Connection_management_in_HTTP_1.x
-tags:
-  - Connection Management
-  - Guide
-  - HTTP
-  - Networking
-  - Performance
-  - WebMechanics
-translation_of: Web/HTTP/Connection_management_in_HTTP_1.x
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/content_negotiation/index.md
+++ b/files/ja/web/http/content_negotiation/index.md
@@ -1,13 +1,6 @@
 ---
 title: コンテンツ交渉
 slug: Web/HTTP/Content_negotiation
-tags:
-  - コンテンツ交渉
-  - コンテンツ交渉リファレンス
-  - HTTP
-  - リファレンス
-  - コンテンツ交渉
-translation_of: Web/HTTP/Content_negotiation
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/content_negotiation/list_of_default_accept_values/index.md
+++ b/files/ja/web/http/content_negotiation/list_of_default_accept_values/index.md
@@ -1,12 +1,6 @@
 ---
 title: 既定の Accept 値の一覧
 slug: Web/HTTP/Content_negotiation/List_of_default_Accept_values
-tags:
-  - Accept
-  - コンテンツネゴシエーション
-  - HTTP
-  - リファレンス
-translation_of: Web/HTTP/Content_negotiation/List_of_default_Accept_values
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/cookies/index.md
+++ b/files/ja/web/http/cookies/index.md
@@ -1,24 +1,6 @@
 ---
 title: HTTP Cookie の使用
 slug: Web/HTTP/Cookies
-tags:
-  - 広告
-  - ブラウザー
-  - Cookie
-  - Cookies Article
-  - ガイド
-  - HTTP
-  - 履歴
-  - JavaScript
-  - プライバシー
-  - プロトコル
-  - サーバー
-  - ストレージ
-  - ウェブ開発
-  - データ
-  - リクエスト
-  - 追跡
-translation_of: Web/HTTP/Cookies
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/cors/errors/corsalloworiginnotmatchingorigin/index.md
+++ b/files/ja/web/http/cors/errors/corsalloworiginnotmatchingorigin/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'Reason: CORS header ''Access-Control-Allow-Origin'' does not match ''xyz'''
 slug: Web/HTTP/CORS/Errors/CORSAllowOriginNotMatchingOrigin
-tags:
-  - CORS
-  - CORSAllowOriginNotMatchingOrigin
-  - HTTP
-  - HTTPS
-  - エラー
-  - オリジン間
-  - コンソール
-  - セキュリティ
-  - トラブルシューティング
-  - メッセージ
-  - 理由
-translation_of: Web/HTTP/CORS/Errors/CORSAllowOriginNotMatchingOrigin
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/cors/errors/corsdidnotsucceed/index.md
+++ b/files/ja/web/http/cors/errors/corsdidnotsucceed/index.md
@@ -1,20 +1,6 @@
 ---
 title: 'Reason: CORS request did not succeed'
 slug: Web/HTTP/CORS/Errors/CORSDidNotSucceed
-tags:
-  - CORS
-  - CORSDidNotSccceed
-  - HTTP
-  - HTTPS
-  - エラー
-  - オリジン間
-  - クロスオリジン
-  - コンソール
-  - セキュリティ
-  - トラブルシューティング
-  - メッセージ
-  - 理由
-translation_of: Web/HTTP/CORS/Errors/CORSDidNotSucceed
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/cors/errors/corsdisabled/index.md
+++ b/files/ja/web/http/cors/errors/corsdisabled/index.md
@@ -1,20 +1,6 @@
 ---
 title: 'Reason: CORS disabled'
 slug: Web/HTTP/CORS/Errors/CORSDisabled
-tags:
-  - CORS
-  - HTTP
-  - HTTPS
-  - エラー
-  - オリジン間
-  - セキュリティ
-  - トラブルシューティング
-  - メッセージ
-  - リソース
-  - 共有
-  - 同一オリジン
-  - 無効
-translation_of: Web/HTTP/CORS/Errors/CORSDisabled
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/cors/errors/corsexternalredirectnotallowed/index.md
+++ b/files/ja/web/http/cors/errors/corsexternalredirectnotallowed/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'Reason: CORS request external redirect not allowed'
 slug: Web/HTTP/CORS/Errors/CORSExternalRedirectNotAllowed
-tags:
-  - CORS
-  - CORSExternalRedirectNotAllowed
-  - HTTP
-  - HTTPS
-  - エラー
-  - オリジン間
-  - コンソール
-  - セキュリティ
-  - トラブルシューティング
-  - メッセージ
-  - 理由
-translation_of: Web/HTTP/CORS/Errors/CORSExternalRedirectNotAllowed
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/cors/errors/corsinvalidallowheader/index.md
+++ b/files/ja/web/http/cors/errors/corsinvalidallowheader/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'Reason: invalid token ‘xyz’ in CORS header ‘Access-Control-Allow-Headers’'
 slug: Web/HTTP/CORS/Errors/CORSInvalidAllowHeader
-tags:
-  - CORS
-  - CORSInvalidAllowHeader
-  - HTTP
-  - HTTPS
-  - エラー
-  - オリジン間
-  - コンソール
-  - セキュリティ
-  - トラブルシューティング
-  - メッセージ
-  - 理由
-translation_of: Web/HTTP/CORS/Errors/CORSInvalidAllowHeader
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/cors/errors/corsinvalidallowmethod/index.md
+++ b/files/ja/web/http/cors/errors/corsinvalidallowmethod/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Reason: invalid token ‘xyz’ in CORS header ‘Access-Control-Allow-Methods’'
 slug: Web/HTTP/CORS/Errors/CORSInvalidAllowMethod
-tags:
-  - CORS
-  - CORSInvalidAllowMethod
-  - HTTP
-  - HTTPS
-  - console
-  - エラー
-  - オリジン間
-  - メッセージ
-translation_of: Web/HTTP/CORS/Errors/CORSInvalidAllowMethod
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/cors/errors/corsmethodnotfound/index.md
+++ b/files/ja/web/http/cors/errors/corsmethodnotfound/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'Reason: Did not find method in CORS header ‘Access-Control-Allow-Methods’'
 slug: Web/HTTP/CORS/Errors/CORSMethodNotFound
-tags:
-  - CORS
-  - CORSMethodNotFound
-  - HTTP
-  - HTTPS
-  - エラー
-  - オリジン間
-  - コンソール
-  - セキュリティ
-  - トラブルシューティング
-  - メッセージ
-  - 理由
-translation_of: Web/HTTP/CORS/Errors/CORSMethodNotFound
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/cors/errors/corsmissingallowcredentials/index.md
+++ b/files/ja/web/http/cors/errors/corsmissingallowcredentials/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'Reason: expected ‘true’ in CORS header ‘Access-Control-Allow-Credentials’'
 slug: Web/HTTP/CORS/Errors/CORSMIssingAllowCredentials
-tags:
-  - CORS
-  - CORSMissingAllowCredentials
-  - HTTP
-  - HTTPS
-  - エラー
-  - オリジン間
-  - コンソール
-  - セキュリティ
-  - トラブルシューティング
-  - メッセージ
-  - 理由
-translation_of: Web/HTTP/CORS/Errors/CORSMIssingAllowCredentials
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/cors/errors/corsmissingallowheaderfrompreflight/index.md
+++ b/files/ja/web/http/cors/errors/corsmissingallowheaderfrompreflight/index.md
@@ -1,21 +1,7 @@
 ---
-title: >-
-  Reason: missing token ‘xyz’ in CORS header ‘Access-Control-Allow-Headers’ from
-  CORS preflight channel
+title: 'Reason: missing token ‘xyz’ in CORS header ‘Access-Control-Allow-Headers’
+  from CORS preflight channel'
 slug: Web/HTTP/CORS/Errors/CORSMissingAllowHeaderFromPreflight
-tags:
-  - CORS
-  - CORSMissingAllowHeaderFromPreflight
-  - HTTP
-  - HTTPS
-  - エラー
-  - オリジン間
-  - コンソール
-  - セキュリティ
-  - トラブルシューティング
-  - メッセージ
-  - 理由
-translation_of: Web/HTTP/CORS/Errors/CORSMissingAllowHeaderFromPreflight
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/cors/errors/corsmissingalloworigin/index.md
+++ b/files/ja/web/http/cors/errors/corsmissingalloworigin/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'Reason: CORS header ''Access-Control-Allow-Origin'' missing'
 slug: Web/HTTP/CORS/Errors/CORSMissingAllowOrigin
-tags:
-  - CORS
-  - CORSMissingAllowOrigin
-  - Cross-Origin
-  - Error
-  - HTTP
-  - HTTPS
-  - Messages
-  - Reasons
-  - Security
-  - console
-  - troubleshooting
-translation_of: Web/HTTP/CORS/Errors/CORSMissingAllowOrigin
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/cors/errors/corsmultiplealloworiginnotallowed/index.md
+++ b/files/ja/web/http/cors/errors/corsmultiplealloworiginnotallowed/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'Reason: Multiple CORS header ''Access-Control-Allow-Origin'' not allowed'
 slug: Web/HTTP/CORS/Errors/CORSMultipleAllowOriginNotAllowed
-tags:
-  - CORS
-  - CORSMultipleAllowOriginNotAllowed
-  - HTTP
-  - HTTPS
-  - エラー
-  - オリジン間
-  - コンソール
-  - セキュリティ
-  - トラブルシューティング
-  - メッセージ
-  - 理由
-translation_of: Web/HTTP/CORS/Errors/CORSMultipleAllowOriginNotAllowed
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/cors/errors/corsnotsupportingcredentials/index.md
+++ b/files/ja/web/http/cors/errors/corsnotsupportingcredentials/index.md
@@ -1,21 +1,7 @@
 ---
-title: >-
-  Reason: Credential is not supported if the CORS header
-  ‘Access-Control-Allow-Origin’ is ‘*’
+title: 'Reason: Credential is not supported if the CORS header ‘Access-Control-Allow-Origin’
+  is ‘*’'
 slug: Web/HTTP/CORS/Errors/CORSNotSupportingCredentials
-tags:
-  - CORS
-  - CORSNotSupportingCredentials
-  - HTTP
-  - HTTPS
-  - エラー
-  - オリジン間
-  - コンソール
-  - セキュリティ
-  - トラブルシューティング
-  - メッセージ
-  - 理由
-translation_of: Web/HTTP/CORS/Errors/CORSNotSupportingCredentials
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/cors/errors/corsoriginheadernotadded/index.md
+++ b/files/ja/web/http/cors/errors/corsoriginheadernotadded/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'Reason: CORS header ‘Origin’ cannot be added'
 slug: Web/HTTP/CORS/Errors/CORSOriginHeaderNotAdded
-tags:
-  - CORS
-  - CORSOriginHeaderNotAdded
-  - HTTP
-  - HTTPS
-  - エラー
-  - オリジン間
-  - コンソール
-  - セキュリティ
-  - トラブルシューティング
-  - メッセージ
-  - 理由
-translation_of: Web/HTTP/CORS/Errors/CORSOriginHeaderNotAdded
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/cors/errors/corspreflightdidnotsucceed/index.md
+++ b/files/ja/web/http/cors/errors/corspreflightdidnotsucceed/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'Reason: CORS preflight channel did not succeed'
 slug: Web/HTTP/CORS/Errors/CORSPreflightDidNotSucceed
-tags:
-  - CORS
-  - CORSPreflightDidNotSucceed
-  - HTTP
-  - HTTPS
-  - エラー
-  - オリジン間
-  - コンソール
-  - セキュリティ
-  - トラブルシューティング
-  - メッセージ
-  - 理由
-translation_of: Web/HTTP/CORS/Errors/CORSPreflightDidNotSucceed
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/cors/errors/corsrequestnothttp/index.md
+++ b/files/ja/web/http/cors/errors/corsrequestnothttp/index.md
@@ -1,18 +1,6 @@
 ---
 title: 'Reason: CORS request not HTTP'
 slug: Web/HTTP/CORS/Errors/CORSRequestNotHttp
-tags:
-  - CORS
-  - CORSRequestNotHttp
-  - HTTP
-  - HTTPS
-  - エラー
-  - オリジン間
-  - コンソール
-  - セキュリティ
-  - メッセージ
-  - 理由
-translation_of: Web/HTTP/CORS/Errors/CORSRequestNotHttp
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/cors/errors/index.md
+++ b/files/ja/web/http/cors/errors/index.md
@@ -1,17 +1,6 @@
 ---
 title: CORS のエラー
 slug: Web/HTTP/CORS/Errors
-tags:
-  - CORS
-  - HTTP
-  - HTTPS
-  - エラー
-  - コンソール
-  - セキュリティ
-  - トラブル解決
-  - メッセージ
-  - 同一オリジン
-translation_of: Web/HTTP/CORS/Errors
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/cors/index.md
+++ b/files/ja/web/http/cors/index.md
@@ -1,19 +1,6 @@
 ---
 title: オリジン間リソース共有 (CORS)
 slug: Web/HTTP/CORS
-tags:
-  - AJAX
-  - CORS
-  - オリジン間リソース共有
-  - Fetch
-  - Fetch API
-  - HTTP
-  - HTTP アクセス制御
-  - 同一オリジンポリシー
-  - セキュリティ
-  - XMLHttpRequest
-  - l10n:priority
-translation_of: Web/HTTP/CORS
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/cross-origin_resource_policy_(corp)/index.md
+++ b/files/ja/web/http/cross-origin_resource_policy_(corp)/index.md
@@ -1,11 +1,6 @@
 ---
 title: Cross-Origin Resource Policy (CORP)
 slug: Web/HTTP/Cross-Origin_Resource_Policy_(CORP)
-tags:
-  - HTTP
-  - Reference
-  - Security
-translation_of: Web/HTTP/Cross-Origin_Resource_Policy_(CORP)
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/csp/errors/cspviolation/index.md
+++ b/files/ja/web/http/csp/errors/cspviolation/index.md
@@ -1,21 +1,7 @@
 ---
-title: >-
-  Content Security Policy: The page’s settings blocked the loading of a
-  resource: xyz
+title: 'Content Security Policy: The page’s settings blocked the loading of a resource:
+  xyz'
 slug: Web/HTTP/CSP/Errors/CSPViolation
-tags:
-  - CSP
-  - CSPViolation
-  - Content Security Policy
-  - HTTP
-  - HTTPS
-  - NeedsContent
-  - Reference
-  - Security
-  - Warning
-  - Web security
-  - message
-translation_of: Web/HTTP/CSP/Errors/CSPViolation
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/csp/errors/index.md
+++ b/files/ja/web/http/csp/errors/index.md
@@ -1,15 +1,6 @@
 ---
 title: CSP のエラーと警告 (Content Security Policy)
 slug: Web/HTTP/CSP/Errors
-tags:
-  - CSP
-  - Errors
-  - HTTP
-  - Landing
-  - Messages
-  - Warnings
-  - console
-  - log
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/csp/index.md
+++ b/files/ja/web/http/csp/index.md
@@ -1,16 +1,6 @@
 ---
 title: コンテンツセキュリティポリシー (CSP)
 slug: Web/HTTP/CSP
-tags:
-  - CSP
-  - Content Security Policy
-  - Example
-  - Guide
-  - access
-  - コンテンツセキュリティポリシー
-  - セキュリティ
-translation_of: Web/HTTP/CSP
-browser-compat: http.headers.csp
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/feature_policy/index.md
+++ b/files/ja/web/http/feature_policy/index.md
@@ -1,14 +1,6 @@
 ---
 title: Feature Policy
 slug: Web/HTTP/Feature_Policy
-tags:
-  - Feature-Policy
-  - HTTP
-  - Reference
-  - セキュリティ
-  - ヘッダー
-  - 機能ポリシー
-translation_of: Web/HTTP/Feature_Policy
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/feature_policy/using_feature_policy/index.md
+++ b/files/ja/web/http/feature_policy/using_feature_policy/index.md
@@ -1,20 +1,6 @@
 ---
 title: 機能ポリシーの使用
 slug: Web/HTTP/Feature_Policy/Using_Feature_Policy
-tags:
-  - Feature Policy
-  - Feature-Policy
-  - HTTP
-  - Permissions
-  - Privileges
-  - Reference
-  - Security
-  - access
-  - delegation
-  - header
-  - セキュリティ
-  - 機能ポリシー
-translation_of: Web/HTTP/Feature_Policy/Using_Feature_Policy
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/accept-ch-lifetime/index.md
+++ b/files/ja/web/http/headers/accept-ch-lifetime/index.md
@@ -1,11 +1,6 @@
 ---
 title: Accept-CH-Lifetime
 slug: Web/HTTP/Headers/Accept-CH-Lifetime
-tags:
-  - Client hints
-  - HTTP
-  - header
-translation_of: Web/HTTP/Headers/Accept-CH-Lifetime
 ---
 {{HTTPSidebar}}{{securecontext_header}}{{SeeCompatTable}}
 

--- a/files/ja/web/http/headers/accept-ch/index.md
+++ b/files/ja/web/http/headers/accept-ch/index.md
@@ -1,11 +1,6 @@
 ---
 title: Accept-CH
 slug: Web/HTTP/Headers/Accept-CH
-tags:
-  - Client hints
-  - HTTP
-  - HTTP Header
-translation_of: Web/HTTP/Headers/Accept-CH
 ---
 {{HTTPSidebar}}{{securecontext_header}}{{SeeCompatTable}}
 

--- a/files/ja/web/http/headers/accept-charset/index.md
+++ b/files/ja/web/http/headers/accept-charset/index.md
@@ -1,13 +1,6 @@
 ---
 title: Accept-Charset
 slug: Web/HTTP/Headers/Accept-Charset
-tags:
-  - Content Negotiation
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
-translation_of: Web/HTTP/Headers/Accept-Charset
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/accept-encoding/index.md
+++ b/files/ja/web/http/headers/accept-encoding/index.md
@@ -1,13 +1,6 @@
 ---
 title: Accept-Encoding
 slug: Web/HTTP/Headers/Accept-Encoding
-tags:
-  - Content Negotiation
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
-translation_of: Web/HTTP/Headers/Accept-Encoding
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/accept-language/index.md
+++ b/files/ja/web/http/headers/accept-language/index.md
@@ -1,14 +1,6 @@
 ---
 title: Accept-Language
 slug: Web/HTTP/Headers/Accept-Language
-tags:
-  - Accept-Language
-  - HTTP
-  - HTTP ヘッダー
-  - Reference
-  - コンテンツネゴシエーション
-  - リファレンス
-translation_of: Web/HTTP/Headers/Accept-Language
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/accept-patch/index.md
+++ b/files/ja/web/http/headers/accept-patch/index.md
@@ -1,10 +1,6 @@
 ---
 title: Accept-Patch
 slug: Web/HTTP/Headers/Accept-Patch
-tags:
-  - HTTP
-  - Reference
-translation_of: Web/HTTP/Headers/Accept-Patch
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/accept-ranges/index.md
+++ b/files/ja/web/http/headers/accept-ranges/index.md
@@ -1,13 +1,6 @@
 ---
 title: Accept-Ranges
 slug: Web/HTTP/Headers/Accept-Ranges
-tags:
-  - HTTP
-  - HTTP ヘッダー
-  - Reference
-  - レスポンスヘッダー
-  - 範囲リクエスト
-translation_of: Web/HTTP/Headers/Accept-Ranges
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/accept/index.md
+++ b/files/ja/web/http/headers/accept/index.md
@@ -1,12 +1,6 @@
 ---
 title: Accept
 slug: Web/HTTP/Headers/Accept
-tags:
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
-translation_of: Web/HTTP/Headers/Accept
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/access-control-allow-credentials/index.md
+++ b/files/ja/web/http/headers/access-control-allow-credentials/index.md
@@ -1,16 +1,6 @@
 ---
 title: Access-Control-Allow-Credentials
 slug: Web/HTTP/Headers/Access-Control-Allow-Credentials
-tags:
-  - Access-Control-Allow-Credentials
-  - CORS
-  - HTTP
-  - Reference
-  - credentials
-  - header
-  - レスポンスヘッダー
-  - 資格情報
-translation_of: Web/HTTP/Headers/Access-Control-Allow-Credentials
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/access-control-allow-headers/index.md
+++ b/files/ja/web/http/headers/access-control-allow-headers/index.md
@@ -1,14 +1,6 @@
 ---
 title: Access-Control-Allow-Headers
 slug: Web/HTTP/Headers/Access-Control-Allow-Headers
-tags:
-  - CORS
-  - HTTP
-  - Reference
-  - ヘッダー
-  - リファレンス
-  - レスポンスヘッダー
-translation_of: Web/HTTP/Headers/Access-Control-Allow-Headers
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/access-control-allow-methods/index.md
+++ b/files/ja/web/http/headers/access-control-allow-methods/index.md
@@ -1,13 +1,6 @@
 ---
 title: Access-Control-Allow-Methods
 slug: Web/HTTP/Headers/Access-Control-Allow-Methods
-tags:
-  - CORS
-  - HTTP
-  - header
-  - ヘッダー
-  - リファレンス
-translation_of: Web/HTTP/Headers/Access-Control-Allow-Methods
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/access-control-allow-origin/index.md
+++ b/files/ja/web/http/headers/access-control-allow-origin/index.md
@@ -1,20 +1,6 @@
 ---
 title: Access-Control-Allow-Origin
 slug: Web/HTTP/Headers/Access-Control-Allow-Origin
-tags:
-  - Access Control
-  - Access-Control-Allow-Origin
-  - CORS
-  - Dealing with CORS
-  - HTTP
-  - HTTP Header
-  - How to Fix CORS
-  - Reference
-  - Security
-  - cross-origin issue
-  - header
-  - origin
-translation_of: Web/HTTP/Headers/Access-Control-Allow-Origin
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/access-control-expose-headers/index.md
+++ b/files/ja/web/http/headers/access-control-expose-headers/index.md
@@ -1,13 +1,6 @@
 ---
 title: Access-Control-Expose-Headers
 slug: Web/HTTP/Headers/Access-Control-Expose-Headers
-tags:
-  - CORS
-  - HTTP
-  - Reference
-  - ヘッダー
-  - リファレンス
-translation_of: Web/HTTP/Headers/Access-Control-Expose-Headers
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/access-control-max-age/index.md
+++ b/files/ja/web/http/headers/access-control-max-age/index.md
@@ -1,12 +1,6 @@
 ---
 title: Access-Control-Max-Age
 slug: Web/HTTP/Headers/Access-Control-Max-Age
-tags:
-  - CORS
-  - HTTP
-  - Reference
-  - header
-translation_of: Web/HTTP/Headers/Access-Control-Max-Age
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/access-control-request-headers/index.md
+++ b/files/ja/web/http/headers/access-control-request-headers/index.md
@@ -1,12 +1,6 @@
 ---
 title: Access-Control-Request-Headers
 slug: Web/HTTP/Headers/Access-Control-Request-Headers
-tags:
-  - CORS
-  - HTTP
-  - Reference
-  - header
-translation_of: Web/HTTP/Headers/Access-Control-Request-Headers
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/access-control-request-method/index.md
+++ b/files/ja/web/http/headers/access-control-request-method/index.md
@@ -1,12 +1,6 @@
 ---
 title: Access-Control-Request-Method
 slug: Web/HTTP/Headers/Access-Control-Request-Method
-tags:
-  - CORS
-  - HTTP
-  - Reference
-  - header
-translation_of: Web/HTTP/Headers/Access-Control-Request-Method
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/age/index.md
+++ b/files/ja/web/http/headers/age/index.md
@@ -1,12 +1,6 @@
 ---
 title: Age
 slug: Web/HTTP/Headers/Age
-tags:
-  - Caching
-  - HTTP
-  - ヘッダー
-  - レスポンス
-translation_of: Web/HTTP/Headers/Age
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/allow/index.md
+++ b/files/ja/web/http/headers/allow/index.md
@@ -1,13 +1,6 @@
 ---
 title: Allow
 slug: Web/HTTP/Headers/Allow
-tags:
-  - Entity header
-  - HTTP
-  - HTTP Header
-  - Reference
-  - header
-translation_of: Web/HTTP/Headers/Allow
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/alt-svc/index.md
+++ b/files/ja/web/http/headers/alt-svc/index.md
@@ -1,12 +1,6 @@
 ---
 title: Alt-Svc
 slug: Web/HTTP/Headers/Alt-Svc
-tags:
-  - HTTP
-  - HTTP Header
-  - NeedsCompatTable
-  - Reference
-translation_of: Web/HTTP/Headers/Alt-Svc
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/authorization/index.md
+++ b/files/ja/web/http/headers/authorization/index.md
@@ -1,13 +1,6 @@
 ---
 title: Authorization
 slug: Web/HTTP/Headers/Authorization
-tags:
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
-  - header
-translation_of: Web/HTTP/Headers/Authorization
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/cache-control/index.md
+++ b/files/ja/web/http/headers/cache-control/index.md
@@ -1,15 +1,6 @@
 ---
 title: Cache-Control
 slug: Web/HTTP/Headers/Cache-Control
-tags:
-  - Cache-Control
-  - HTTP
-  - HTTP ヘッダー
-  - リクエストヘッダー
-  - レスポンスヘッダー
-  - リファレンス
-browser-compat: http.headers.Cache-Control
-translation_of: Web/HTTP/Headers/Cache-Control
 ---
 
 {{HTTPSidebar}}

--- a/files/ja/web/http/headers/clear-site-data/index.md
+++ b/files/ja/web/http/headers/clear-site-data/index.md
@@ -1,16 +1,6 @@
 ---
 title: Clear-Site-Data
 slug: Web/HTTP/Headers/Clear-Site-Data
-tags:
-  - HTTP
-  - HTTP Header
-  - HTTP ヘッダー
-  - Reference
-  - Response Header
-  - ヘッダー
-  - リファレンス
-  - レスポンスヘッダー
-translation_of: Web/HTTP/Headers/Clear-Site-Data
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/connection/index.md
+++ b/files/ja/web/http/headers/connection/index.md
@@ -1,15 +1,6 @@
 ---
 title: Connection
 slug: Web/HTTP/Headers/Connection
-tags:
-  - HTTP
-  - HTTP ヘッダー
-  - リクエストヘッダー
-  - レスポンスヘッダー
-  - リファレンス
-  - ウェブ
-browser-compat: http.headers.Connection
-translation_of: Web/HTTP/Headers/Connection
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-disposition/index.md
+++ b/files/ja/web/http/headers/content-disposition/index.md
@@ -1,11 +1,6 @@
 ---
 title: Content-Disposition
 slug: Web/HTTP/Headers/Content-Disposition
-tags:
-  - HTTP
-  - Reference
-  - header
-translation_of: Web/HTTP/Headers/Content-Disposition
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-encoding/index.md
+++ b/files/ja/web/http/headers/content-encoding/index.md
@@ -1,14 +1,6 @@
 ---
 title: Content-Encoding
 slug: Web/HTTP/Headers/Content-Encoding
-tags:
-  - HTTP
-  - HTTP ヘッダー
-  - Reference
-  - エンティティヘッダー
-  - ヘッダー
-  - リファレンス
-translation_of: Web/HTTP/Headers/Content-Encoding
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-language/index.md
+++ b/files/ja/web/http/headers/content-language/index.md
@@ -1,11 +1,6 @@
 ---
 title: Content-Language
 slug: Web/HTTP/Headers/Content-Language
-tags:
-  - HTTP
-  - Headers
-  - Reference
-translation_of: Web/HTTP/Headers/Content-Language
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-length/index.md
+++ b/files/ja/web/http/headers/content-length/index.md
@@ -1,13 +1,6 @@
 ---
 title: Content-Length
 slug: Web/HTTP/Headers/Content-Length
-tags:
-  - HTTP
-  - Reference
-  - エンティティヘッダー
-  - ヘッダー
-  - リファレンス
-translation_of: Web/HTTP/Headers/Content-Length
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-location/index.md
+++ b/files/ja/web/http/headers/content-location/index.md
@@ -1,13 +1,6 @@
 ---
 title: Content-Location
 slug: Web/HTTP/Headers/Content-Location
-tags:
-  - HTTP
-  - Reference
-  - エンティティヘッダー
-  - ヘッダー
-  - リファレンス
-translation_of: Web/HTTP/Headers/Content-Location
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-range/index.md
+++ b/files/ja/web/http/headers/content-range/index.md
@@ -1,13 +1,6 @@
 ---
 title: Content-Range
 slug: Web/HTTP/Headers/Content-Range
-tags:
-  - HTTP
-  - HTTPヘッダー
-  - ヘッダー
-  - リファレンス
-  - レスポンスヘッダー
-translation_of: Web/HTTP/Headers/Content-Range
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-security-policy-report-only/index.md
+++ b/files/ja/web/http/headers/content-security-policy-report-only/index.md
@@ -1,14 +1,6 @@
 ---
 title: Content-Security-Policy-Report-Only
 slug: Web/HTTP/Headers/Content-Security-Policy-Report-Only
-tags:
-  - CSP
-  - HTTP
-  - HTTPS
-  - Reference
-  - Security
-  - header
-translation_of: Web/HTTP/Headers/Content-Security-Policy-Report-Only
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-security-policy/base-uri/index.md
+++ b/files/ja/web/http/headers/content-security-policy/base-uri/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'CSP: base-uri'
 slug: Web/HTTP/Headers/Content-Security-Policy/base-uri
-tags:
-  - CSP
-  - Directive
-  - Document directive
-  - HTTP
-  - Security
-browser-compat: http.headers.Content-Security-Policy.base-uri
-translation_of: Web/HTTP/Headers/Content-Security-Policy/base-uri
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-security-policy/block-all-mixed-content/index.md
+++ b/files/ja/web/http/headers/content-security-policy/block-all-mixed-content/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'CSP: block-all-mixed-content'
 slug: Web/HTTP/Headers/Content-Security-Policy/block-all-mixed-content
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Mixed Content
-  - Reference
-  - Security
-  - block-all-mixed-content
-browser-compat: http.headers.Content-Security-Policy.block-all-mixed-content
-translation_of: Web/HTTP/Headers/Content-Security-Policy/block-all-mixed-content
 ---
 {{HTTPSidebar}}{{deprecated_header}}
 

--- a/files/ja/web/http/headers/content-security-policy/connect-src/index.md
+++ b/files/ja/web/http/headers/content-security-policy/connect-src/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'CSP: connect-src'
 slug: Web/HTTP/Headers/Content-Security-Policy/connect-src
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Reference
-  - Security
-  - connect-src
-  - source
-browser-compat: http.headers.Content-Security-Policy.connect-src
-translation_of: Web/HTTP/Headers/Content-Security-Policy/connect-src
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-security-policy/default-src/index.md
+++ b/files/ja/web/http/headers/content-security-policy/default-src/index.md
@@ -1,18 +1,6 @@
 ---
 title: 'CSP: default-src'
 slug: Web/HTTP/Headers/Content-Security-Policy/default-src
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Reference
-  - Security
-  - default
-  - default-src
-  - source
-browser-compat: http.headers.Content-Security-Policy.default-src
-translation_of: Web/HTTP/Headers/Content-Security-Policy/default-src
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-security-policy/frame-ancestors/index.md
+++ b/files/ja/web/http/headers/content-security-policy/frame-ancestors/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'CSP: frame-ancestors'
 slug: Web/HTTP/Headers/Content-Security-Policy/frame-ancestors
-tags:
-  - Ancestors
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - Frame
-  - HTTP
-  - Security
-  - frame-ancestors
-browser-compat: http.headers.Content-Security-Policy.frame-ancestors
-translation_of: Web/HTTP/Headers/Content-Security-Policy/frame-ancestors
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-security-policy/frame-src/index.md
+++ b/files/ja/web/http/headers/content-security-policy/frame-src/index.md
@@ -1,18 +1,6 @@
 ---
 title: 'CSP: frame-src'
 slug: Web/HTTP/Headers/Content-Security-Policy/frame-src
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - Frame
-  - HTTP
-  - Reference
-  - Security
-  - frame-src
-  - source
-browser-compat: http.headers.Content-Security-Policy.frame-src
-translation_of: Web/HTTP/Headers/Content-Security-Policy/frame-src
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-security-policy/img-src/index.md
+++ b/files/ja/web/http/headers/content-security-policy/img-src/index.md
@@ -1,18 +1,6 @@
 ---
 title: 'CSP: img-src'
 slug: Web/HTTP/Headers/Content-Security-Policy/img-src
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Image
-  - Reference
-  - Security
-  - img-src
-  - source
-browser-compat: http.headers.Content-Security-Policy.img-src
-translation_of: Web/HTTP/Headers/Content-Security-Policy/img-src
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-security-policy/index.md
+++ b/files/ja/web/http/headers/content-security-policy/index.md
@@ -1,15 +1,6 @@
 ---
 title: Content-Security-Policy
 slug: Web/HTTP/Headers/Content-Security-Policy
-tags:
-  - CSP
-  - Content Security Policy
-  - HTTP
-  - Reference
-  - セキュリティ
-  - header
-browser-compat: http.headers.csp.Content-Security-Policy
-translation_of: Web/HTTP/Headers/Content-Security-Policy
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-security-policy/manifest-src/index.md
+++ b/files/ja/web/http/headers/content-security-policy/manifest-src/index.md
@@ -1,18 +1,6 @@
 ---
 title: 'CSP: manifest-src'
 slug: Web/HTTP/Headers/Content-Security-Policy/manifest-src
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Manifest
-  - Reference
-  - Security
-  - manifest-src
-  - source
-browser-compat: http.headers.Content-Security-Policy.manifest-src
-translation_of: Web/HTTP/Headers/Content-Security-Policy/manifest-src
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-security-policy/media-src/index.md
+++ b/files/ja/web/http/headers/content-security-policy/media-src/index.md
@@ -1,18 +1,6 @@
 ---
 title: 'CSP: media-src'
 slug: Web/HTTP/Headers/Content-Security-Policy/media-src
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Media
-  - Reference
-  - Security
-  - media-src
-  - source
-browser-compat: http.headers.Content-Security-Policy.media-src
-translation_of: Web/HTTP/Headers/Content-Security-Policy/media-src
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-security-policy/object-src/index.md
+++ b/files/ja/web/http/headers/content-security-policy/object-src/index.md
@@ -1,18 +1,6 @@
 ---
 title: 'CSP: object-src'
 slug: Web/HTTP/Headers/Content-Security-Policy/object-src
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Object
-  - Reference
-  - Security
-  - object-src
-  - source
-browser-compat: http.headers.Content-Security-Policy.object-src
-translation_of: Web/HTTP/Headers/Content-Security-Policy/object-src
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-security-policy/plugin-types/index.md
+++ b/files/ja/web/http/headers/content-security-policy/plugin-types/index.md
@@ -1,18 +1,6 @@
 ---
 title: 'CSP: plugin-types'
 slug: Web/HTTP/Headers/Content-Security-Policy/plugin-types
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - Flash
-  - HTTP
-  - Java
-  - Plugin
-  - Plugins
-  - Security
-browser-compat: http.headers.Content-Security-Policy.plugin-types
-translation_of: Web/HTTP/Headers/Content-Security-Policy/plugin-types
 ---
 {{HTTPSidebar}}{{deprecated_header}}
 

--- a/files/ja/web/http/headers/content-security-policy/prefetch-src/index.md
+++ b/files/ja/web/http/headers/content-security-policy/prefetch-src/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'CSP: prefetch-src'
 slug: Web/HTTP/Headers/Content-Security-Policy/prefetch-src
-tags:
-  - CSP
-  - Content Security Policy
-  - Directive
-  - HTTP
-  - Reference
-  - prefetch-src
-browser-compat: http.headers.Content-Security-Policy.prefetch-src
-translation_of: Web/HTTP/Headers/Content-Security-Policy/prefetch-src
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-security-policy/referrer/index.md
+++ b/files/ja/web/http/headers/content-security-policy/referrer/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'CSP: referrer'
 slug: Web/HTTP/Headers/Content-Security-Policy/referrer
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Deprecated
-  - Reference
-  - Security
-  - referrer
-browser-compat: http.headers.Content-Security-Policy.referrer
-translation_of: Web/HTTP/Headers/Content-Security-Policy/referrer
 ---
 {{HTTPSidebar}} {{deprecated_header}}
 

--- a/files/ja/web/http/headers/content-security-policy/report-to/index.md
+++ b/files/ja/web/http/headers/content-security-policy/report-to/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'CSP: report-to'
 slug: Web/HTTP/Headers/Content-Security-Policy/report-to
-tags:
-  - CSP
-  - Content Security Policy
-  - Content-Security-Policy
-  - HTTP
-  - Reporting
-  - Security
-  - report-to
-browser-compat: http.headers.Content-Security-Policy.report-to
-translation_of: Web/HTTP/Headers/Content-Security-Policy/report-to
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-security-policy/require-sri-for/index.md
+++ b/files/ja/web/http/headers/content-security-policy/require-sri-for/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'CSP: require-sri-for'
 slug: Web/HTTP/Headers/Content-Security-Policy/require-sri-for
-tags:
-  - CSP
-  - Directive
-  - HTTP
-  - Reference
-  - Security
-  - Subresource Integrity
-  - require-sri-for
-browser-compat: http.headers.Content-Security-Policy.require-sri-for
-translation_of: Web/HTTP/Headers/Content-Security-Policy/require-sri-for
 ---
 {{deprecated_header}}
 

--- a/files/ja/web/http/headers/content-security-policy/sandbox/index.md
+++ b/files/ja/web/http/headers/content-security-policy/sandbox/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'CSP: sandbox'
 slug: Web/HTTP/Headers/Content-Security-Policy/sandbox
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Sandbox
-  - Security
-browser-compat: http.headers.Content-Security-Policy.sandbox
-translation_of: Web/HTTP/Headers/Content-Security-Policy/sandbox
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-security-policy/script-src-elem/index.md
+++ b/files/ja/web/http/headers/content-security-policy/script-src-elem/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'CSP: script-src-elem'
 slug: Web/HTTP/Headers/Content-Security-Policy/script-src-elem
-tags:
-  - CSP
-  - Content
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Reference
-  - Script
-  - Security
-  - script-src
-  - source
-browser-compat: http.headers.Content-Security-Policy.script-src-elem
-translation_of: Web/HTTP/Headers/Content-Security-Policy/script-src-elem
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-security-policy/script-src/index.md
+++ b/files/ja/web/http/headers/content-security-policy/script-src/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'CSP: script-src'
 slug: Web/HTTP/Headers/Content-Security-Policy/script-src
-tags:
-  - CSP
-  - Content
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Reference
-  - Script
-  - Security
-  - script-src
-  - source
-browser-compat: http.headers.Content-Security-Policy.script-src
-translation_of: Web/HTTP/Headers/Content-Security-Policy/script-src
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-security-policy/sources/index.md
+++ b/files/ja/web/http/headers/content-security-policy/sources/index.md
@@ -1,15 +1,6 @@
 ---
-title: 'CSP ソース値'
+title: CSP ソース値
 slug: Web/HTTP/Headers/Content-Security-Policy/Sources
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Reference
-  - Security
-  - source
-translation_of: Web/HTTP/Headers/Content-Security-Policy/Sources
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-security-policy/style-src/index.md
+++ b/files/ja/web/http/headers/content-security-policy/style-src/index.md
@@ -1,19 +1,6 @@
 ---
 title: 'CSP: style-src'
 slug: Web/HTTP/Headers/Content-Security-Policy/style-src
-tags:
-  - CSP
-  - Content
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Reference
-  - Security
-  - Style
-  - source
-  - style-src
-browser-compat: http.headers.Content-Security-Policy.style-src
-translation_of: Web/HTTP/Headers/Content-Security-Policy/style-src
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-security-policy/trusted-types/index.md
+++ b/files/ja/web/http/headers/content-security-policy/trusted-types/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'CSP: trusted-types'
 slug: Web/HTTP/Headers/Content-Security-Policy/trusted-types
-tags:
-  - CSP
-  - Directive
-  - HTTP
-  - Security
-browser-compat: http.headers.Content-Security-Policy.trusted-types
-translation_of: Web/HTTP/Headers/Content-Security-Policy/trusted-types
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-security-policy/upgrade-insecure-requests/index.md
+++ b/files/ja/web/http/headers/content-security-policy/upgrade-insecure-requests/index.md
@@ -1,18 +1,6 @@
 ---
 title: 'CSP: upgrade-insecure-requests'
 slug: Web/HTTP/Headers/Content-Security-Policy/upgrade-insecure-requests
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Reference
-  - Requests
-  - Security
-  - Upgrade
-  - upgrade-insecure-requests
-browser-compat: http.headers.Content-Security-Policy.upgrade-insecure-requests
-translation_of: Web/HTTP/Headers/Content-Security-Policy/upgrade-insecure-requests
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-security-policy/worker-src/index.md
+++ b/files/ja/web/http/headers/content-security-policy/worker-src/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'CSP: worker-src'
 slug: Web/HTTP/Headers/Content-Security-Policy/worker-src
-tags:
-  - CSP
-  - Content-Security-Policy
-  - Directive
-  - HTTP
-  - Reference
-  - Security
-browser-compat: http.headers.Content-Security-Policy.worker-src
-translation_of: Web/HTTP/Headers/Content-Security-Policy/worker-src
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/content-type/index.md
+++ b/files/ja/web/http/headers/content-type/index.md
@@ -1,16 +1,6 @@
 ---
 title: Content-Type
 slug: Web/HTTP/Headers/Content-Type
-tags:
-  - Content-Type
-  - HTTP
-  - HTTP header
-  - Representation header
-  - Reference
-  - 表現ヘッダー
-  - ヘッダー
-browser-compat: http.headers.Content-Type
-translation_of: Web/HTTP/Headers/Content-Type
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/cookie/index.md
+++ b/files/ja/web/http/headers/cookie/index.md
@@ -1,15 +1,6 @@
 ---
 title: Cookie
 slug: Web/HTTP/Headers/Cookie
-tags:
-  - HTTP
-  - cookie
-  - クッキー
-  - ヘッダー
-  - リクエストヘッダー
-  - リファレンス
-  - 禁止ヘッダー名
-translation_of: Web/HTTP/Headers/Cookie
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/cross-origin-embedder-policy/index.md
+++ b/files/ja/web/http/headers/cross-origin-embedder-policy/index.md
@@ -1,14 +1,6 @@
 ---
 title: Cross-Origin-Embedder-Policy
 slug: Web/HTTP/Headers/Cross-Origin-Embedder-Policy
-tags:
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Response Header
-  - header
-browser-compat: http.headers.Cross-Origin-Embedder-Policy
-translation_of: Web/HTTP/Headers/Cross-Origin-Embedder-Policy
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/cross-origin-opener-policy/index.md
+++ b/files/ja/web/http/headers/cross-origin-opener-policy/index.md
@@ -1,14 +1,6 @@
 ---
 title: Cross-Origin-Opener-Policy
 slug: Web/HTTP/Headers/Cross-Origin-Opener-Policy
-tags:
-  - HTTP
-  - HTTP ヘッダー
-  - リファレンス
-  - レスポンスヘッダー
-  - ヘッダー
-browser-compat: http.headers.Cross-Origin-Opener-Policy
-translation_of: Web/HTTP/Headers/Cross-Origin-Opener-Policy
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/cross-origin-resource-policy/index.md
+++ b/files/ja/web/http/headers/cross-origin-resource-policy/index.md
@@ -1,15 +1,6 @@
 ---
 title: Cross-Origin-Resource-Policy
 slug: Web/HTTP/Headers/Cross-Origin-Resource-Policy
-tags:
-  - HTTP
-  - HTTP Header
-  - HTTP ヘッダー
-  - Reference
-  - Response Header
-  - header
-  - レスポンスヘッダー
-translation_of: Web/HTTP/Headers/Cross-Origin-Resource-Policy
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/date/index.md
+++ b/files/ja/web/http/headers/date/index.md
@@ -1,15 +1,6 @@
 ---
 title: Date
 slug: Web/HTTP/Headers/Date
-tags:
-  - General Header
-  - HTTP
-  - Reference
-  - header
-  - リファレンス
-  - 一般ヘッダー
-  - 汎用ヘッダー
-translation_of: Web/HTTP/Headers/Date
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/device-memory/index.md
+++ b/files/ja/web/http/headers/device-memory/index.md
@@ -1,12 +1,6 @@
 ---
 title: Device-Memory
 slug: Web/HTTP/Headers/Device-Memory
-tags:
-  - Client hints
-  - Device Memory API
-  - HTTP
-  - HTTP Header
-translation_of: Web/HTTP/Headers/Device-Memory
 ---
 {{HTTPSidebar}}{{securecontext_header}}{{SeeCompatTable}}
 

--- a/files/ja/web/http/headers/dnt/index.md
+++ b/files/ja/web/http/headers/dnt/index.md
@@ -1,13 +1,6 @@
 ---
 title: DNT
 slug: Web/HTTP/Headers/DNT
-tags:
-  - DNT
-  - HTTP
-  - ヘッダー
-  - リファレンス
-browser-compat: http.headers.DNT
-translation_of: Web/HTTP/Headers/DNT
 ---
 {{HTTPSidebar}}{{Deprecated_header}}
 

--- a/files/ja/web/http/headers/dpr/index.md
+++ b/files/ja/web/http/headers/dpr/index.md
@@ -1,11 +1,6 @@
 ---
 title: DPR
 slug: Web/HTTP/Headers/DPR
-tags:
-  - Client hints
-  - HTTP
-  - HTTP Header
-translation_of: Web/HTTP/Headers/DPR
 ---
 {{HTTPSidebar}}{{securecontext_header}}{{SeeCompatTable}}
 

--- a/files/ja/web/http/headers/early-data/index.md
+++ b/files/ja/web/http/headers/early-data/index.md
@@ -1,12 +1,6 @@
 ---
 title: Early-Data
 slug: Web/HTTP/Headers/Early-Data
-tags:
-  - HTTP
-  - クライアントヒント
-  - ヘッダー
-  - リクエスト
-translation_of: Web/HTTP/Headers/Early-Data
 ---
 {{SeeCompatTable}}{{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/etag/index.md
+++ b/files/ja/web/http/headers/etag/index.md
@@ -1,14 +1,6 @@
 ---
 title: ETag
 slug: Web/HTTP/Headers/ETag
-tags:
-  - HTTP
-  - Reference
-  - ヘッダー
-  - リファレンス
-  - レスポンス
-  - レスポンスヘッダー
-translation_of: Web/HTTP/Headers/ETag
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/expect-ct/index.md
+++ b/files/ja/web/http/headers/expect-ct/index.md
@@ -1,13 +1,6 @@
 ---
 title: Expect-CT
 slug: Web/HTTP/Headers/Expect-CT
-tags:
-  - HTTP
-  - Reference
-  - ヘッダー
-  - レスポンスヘッダー
-translation_of: Web/HTTP/Headers/Expect-CT
-browser-compat: http.headers.Expect-CT
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/expect/index.md
+++ b/files/ja/web/http/headers/expect/index.md
@@ -1,12 +1,6 @@
 ---
 title: Expect
 slug: Web/HTTP/Headers/Expect
-tags:
-  - HTTP
-  - HTTP ヘッダー
-  - Reference
-  - リクエストヘッダー
-translation_of: Web/HTTP/Headers/Expect
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/expires/index.md
+++ b/files/ja/web/http/headers/expires/index.md
@@ -1,15 +1,6 @@
 ---
 title: Expires
 slug: Web/HTTP/Headers/Expires
-tags:
-  - Caching
-  - HTTP
-  - HTTPResponse
-  - header
-  - キャッシング
-  - ヘッダー
-  - レスポンス
-translation_of: Web/HTTP/Headers/Expires
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/feature-policy/accelerometer/index.md
+++ b/files/ja/web/http/headers/feature-policy/accelerometer/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Feature-Policy: accelerometer'
 slug: Web/HTTP/Headers/Feature-Policy/accelerometer
-tags:
-  - Accelerometer
-  - ディレクティブ
-  - 機能ポリシー
-  - HTTP
-  - リファレンス
-  - 実験的
-browser-compat: http.headers.Feature-Policy.accelerometer
-translation_of: Web/HTTP/Headers/Feature-Policy/accelerometer
 ---
 {{HTTPSidebar}} {{SeeCompatTable}}
 

--- a/files/ja/web/http/headers/feature-policy/ambient-light-sensor/index.md
+++ b/files/ja/web/http/headers/feature-policy/ambient-light-sensor/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'Feature-Policy: ambient-light-sensor'
 slug: Web/HTTP/Headers/Feature-Policy/ambient-light-sensor
-tags:
-  - Ambient Light Sensor
-  - 機能ポリシー
-  - HTTP
-  - 実験的
-browser-compat: http.headers.Feature-Policy.ambient-light-sensor
-translation_of: Web/HTTP/Headers/Feature-Policy/ambient-light-sensor
 ---
 {{HTTPSidebar}} {{SeeCompatTable}}
 

--- a/files/ja/web/http/headers/feature-policy/autoplay/index.md
+++ b/files/ja/web/http/headers/feature-policy/autoplay/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Feature-Policy: autoplay'
 slug: Web/HTTP/Headers/Feature-Policy/autoplay
-tags:
-  - ディレクティブ
-  - 機能ポリシー
-  - Feature-Policy
-  - HTTP
-  - リファレンス
-  - autoplay
-  - 実験的
-browser-compat: http.headers.Feature-Policy.autoplay
-translation_of: Web/HTTP/Headers/Feature-Policy/autoplay
 ---
 {{HTTPSidebar}} {{SeeCompatTable}}
 

--- a/files/ja/web/http/headers/feature-policy/battery/index.md
+++ b/files/ja/web/http/headers/feature-policy/battery/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'Feature-Policy: battery'
 slug: Web/HTTP/Headers/Feature-Policy/battery
-tags:
-  - Battery
-  - Feature Policy
-  - HTTP
-  - Experimental
-browser-compat: http.headers.Feature-Policy.battery
-translation_of: Web/HTTP/Headers/Feature-Policy/battery
 ---
 {{HTTPSidebar}}{{SeeCompatTable}}
 

--- a/files/ja/web/http/headers/feature-policy/camera/index.md
+++ b/files/ja/web/http/headers/feature-policy/camera/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Feature-Policy: camera'
 slug: Web/HTTP/Headers/Feature-Policy/camera
-tags:
-  - ディレクティブ
-  - 機能ポリシー
-  - Feature-Policy
-  - HTTP
-  - リファレンス
-  - camera
-  - 実験的
-browser-compat: http.headers.Feature-Policy.camera
-translation_of: Web/HTTP/Headers/Feature-Policy/camera
 ---
 {{HTTPSidebar}} {{SeeCompatTable}}
 

--- a/files/ja/web/http/headers/feature-policy/display-capture/index.md
+++ b/files/ja/web/http/headers/feature-policy/display-capture/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Feature-Policy: display-capture'
 slug: Web/HTTP/Headers/Feature-Policy/display-capture
-tags:
-  - ディレクティブ
-  - 機能ポリシー
-  - HTTP
-  - リファレンス
-  - display-capture
-  - 実験的
-browser-compat: http.headers.Feature-Policy.display-capture
-translation_of: Web/HTTP/Headers/Feature-Policy/display-capture
 ---
 {{HTTPSidebar}} {{SeeCompatTable}}
 

--- a/files/ja/web/http/headers/feature-policy/document-domain/index.md
+++ b/files/ja/web/http/headers/feature-policy/document-domain/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'Feature-Policy: document-domain'
 slug: Web/HTTP/Headers/Feature-Policy/document-domain
-tags:
-  - ディレクティブ
-  - 実験的
-  - 機能ポリシー
-  - Feature-Policy
-  - HTTP
-  - リファレンス
-  - document-domain
-  - ヘッダー
-browser-compat: http.headers.Feature-Policy.document-domain
-translation_of: Web/HTTP/Headers/Feature-Policy/document-domain
 ---
 {{HTTPSidebar}} {{SeeCompatTable}}
 

--- a/files/ja/web/http/headers/feature-policy/encrypted-media/index.md
+++ b/files/ja/web/http/headers/feature-policy/encrypted-media/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Feature-Policy: encrypted-media'
 slug: Web/HTTP/Headers/Feature-Policy/encrypted-media
-tags:
-  - ディレクティブ
-  - EME
-  - 機能ポリシー
-  - Feature-Policy
-  - HTTP
-  - リファレンス
-  - Experimental
-browser-compat: http.headers.Feature-Policy.encrypted-media
-translation_of: Web/HTTP/Headers/Feature-Policy/encrypted-media
 ---
 {{HTTPSidebar}}{{SeeCompatTable}}
 

--- a/files/ja/web/http/headers/feature-policy/fullscreen/index.md
+++ b/files/ja/web/http/headers/feature-policy/fullscreen/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Feature-Policy: fullscreen'
 slug: Web/HTTP/Headers/Feature-Policy/fullscreen
-tags:
-  - 機能ポリシー
-  - Feature-Policy
-  - HTTP
-  - fullscreen
-  - ヘッダー
-  - 実験的
-browser-compat: http.headers.Feature-Policy.fullscreen
-translation_of: Web/HTTP/Headers/Feature-Policy/fullscreen
 ---
 {{HTTPSidebar}} {{SeeCompatTable}}
 

--- a/files/ja/web/http/headers/feature-policy/geolocation/index.md
+++ b/files/ja/web/http/headers/feature-policy/geolocation/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'Feature-Policy: geolocation'
 slug: Web/HTTP/Headers/Feature-Policy/geolocation
-tags:
-  - 機能ポリシー
-  - Geolocation
-  - HTTP
-  - ヘッダー
-  - 実験的
-browser-compat: http.headers.Feature-Policy.geolocation
-translation_of: Web/HTTP/Headers/Feature-Policy/geolocation
 ---
 {{HTTPSidebar}} {{SeeCompatTable}}
 

--- a/files/ja/web/http/headers/feature-policy/index.md
+++ b/files/ja/web/http/headers/feature-policy/index.md
@@ -1,18 +1,6 @@
 ---
 title: Feature-Policy
 slug: Web/HTTP/Headers/Feature-Policy
-tags:
-  - 認証
-  - 実験的
-  - Feature-Policy
-  - HTTP
-  - 権限
-  - リファレンス
-  - セキュリティ
-  - ウェブ
-  - ヘッダー
-browser-compat: http.headers.Feature-Policy
-translation_of: Web/HTTP/Headers/Feature-Policy
 ---
 {{HTTPSidebar}} {{SeeCompatTable}}
 

--- a/files/ja/web/http/headers/feature-policy/microphone/index.md
+++ b/files/ja/web/http/headers/feature-policy/microphone/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Feature-Policy: microphone'
 slug: Web/HTTP/Headers/Feature-Policy/microphone
-tags:
-  - 機能ポリシー
-  - Feature-Policy
-  - HTTP
-  - ヘッダー
-  - microphone
-  - 実験的
-browser-compat: http.headers.Feature-Policy.microphone
-translation_of: Web/HTTP/Headers/Feature-Policy/microphone
 ---
 {{HTTPSidebar}} {{SeeCompatTable}}
 

--- a/files/ja/web/http/headers/feature-policy/midi/index.md
+++ b/files/ja/web/http/headers/feature-policy/midi/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Feature-Policy: midi'
 slug: Web/HTTP/Headers/Feature-Policy/midi
-tags:
-  - ディレクティブ
-  - 機能ポリシー
-  - Feature-Policy
-  - HTTP
-  - MIDI
-  - リファレンス
-  - 実験的
-browser-compat: http.headers.Feature-Policy.midi
-translation_of: Web/HTTP/Headers/Feature-Policy/midi
 ---
 {{HTTPSidebar}}{{SeeCompatTable}}
 

--- a/files/ja/web/http/headers/feature-policy/payment/index.md
+++ b/files/ja/web/http/headers/feature-policy/payment/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'Feature-Policy: payment'
 slug: Web/HTTP/Headers/Feature-Policy/payment
-tags:
-  - ディレクティブ
-  - 機能ポリシー
-  - Feature-Policy
-  - HTTP
-  - Payment Request API
-  - Payments API
-  - リファレンス
-  - 実験的
-browser-compat: http.headers.Feature-Policy.payment
-translation_of: Web/HTTP/Headers/Feature-Policy/payment
 ---
 {{HTTPSidebar}} {{SeeCompatTable}}
 

--- a/files/ja/web/http/headers/feature-policy/screen-wake-lock/index.md
+++ b/files/ja/web/http/headers/feature-policy/screen-wake-lock/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Feature-Policy: screen-wake-lock'
 slug: Web/HTTP/Headers/Feature-Policy/screen-wake-lock
-tags:
-  - ディレクティブ
-  - 機能ポリシー
-  - Feature-Policy
-  - HTTP
-  - リファレンス
-  - screen-wake-lock
-  - 実験的
-browser-compat: http.headers.Feature-Policy.screen-wake-lock
-translation_of: Web/HTTP/Headers/Feature-Policy/screen-wake-lock
 ---
 {{HTTPSidebar}} {{SeeCompatTable}}
 

--- a/files/ja/web/http/headers/feature-policy/web-share/index.md
+++ b/files/ja/web/http/headers/feature-policy/web-share/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'Feature-Policy: web-share'
 slug: Web/HTTP/Headers/Feature-Policy/web-share
-tags:
-  - Feature-Policy
-  - HTTP
-  - Web Share
-  - 実験的
-browser-compat: http.headers.Feature-Policy.web-share
-translation_of: Web/HTTP/Headers/Feature-Policy/web-share
 ---
 {{HTTPSidebar}} {{SeeCompatTable}}
 

--- a/files/ja/web/http/headers/feature-policy/xr-spatial-tracking/index.md
+++ b/files/ja/web/http/headers/feature-policy/xr-spatial-tracking/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'Feature-Policy: xr-spatial-tracking'
 slug: Web/HTTP/Headers/Feature-Policy/xr-spatial-tracking
-tags:
-  - ディレクティブ
-  - 機能ポリシー
-  - Feature-Policy
-  - HTTP
-  - リファレンス
-  - xr-spatial-tracking
-  - 実験的
-browser-compat: http.headers.Feature-Policy.xr-spatial-tracking
-translation_of: Web/HTTP/Headers/Feature-Policy/xr-spatial-tracking
 original_slug: Web/HTTP/Headers/Feature-Policy/vr
 ---
 {{HTTPSidebar}}{{SeeCompatTable}}

--- a/files/ja/web/http/headers/forwarded/index.md
+++ b/files/ja/web/http/headers/forwarded/index.md
@@ -1,14 +1,6 @@
 ---
 title: Forwarded
 slug: Web/HTTP/Headers/Forwarded
-tags:
-  - HTTP
-  - HTTP ヘッダー
-  - Reference
-  - リクエストヘッダー
-  - ヘッダー
-browser-compat: http.headers.Forwarded
-translation_of: Web/HTTP/Headers/Forwarded
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/from/index.md
+++ b/files/ja/web/http/headers/from/index.md
@@ -1,11 +1,6 @@
 ---
 title: From
 slug: Web/HTTP/Headers/From
-tags:
-  - HTTP
-  - Reference
-  - ヘッダー
-translation_of: Web/HTTP/Headers/From
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/host/index.md
+++ b/files/ja/web/http/headers/host/index.md
@@ -1,12 +1,6 @@
 ---
 title: Host
 slug: Web/HTTP/Headers/Host
-tags:
-  - HTTP
-  - Reference
-  - ヘッダー
-  - リクエストヘッダー
-translation_of: Web/HTTP/Headers/Host
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/if-match/index.md
+++ b/files/ja/web/http/headers/if-match/index.md
@@ -1,13 +1,6 @@
 ---
 title: If-Match
 slug: Web/HTTP/Headers/If-Match
-tags:
-  - HTTP
-  - HTTP ヘッダー
-  - Reference
-  - リクエストヘッダー
-  - 条件付きリクエスト
-translation_of: Web/HTTP/Headers/If-Match
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/if-modified-since/index.md
+++ b/files/ja/web/http/headers/if-modified-since/index.md
@@ -1,13 +1,6 @@
 ---
 title: If-Modified-Since
 slug: Web/HTTP/Headers/If-Modified-Since
-tags:
-  - HTTP
-  - HTTP ヘッダー
-  - Reference
-  - リクエストヘッダー
-  - 条件付きリクエスト
-translation_of: Web/HTTP/Headers/If-Modified-Since
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/if-none-match/index.md
+++ b/files/ja/web/http/headers/if-none-match/index.md
@@ -1,13 +1,6 @@
 ---
 title: If-None-Match
 slug: Web/HTTP/Headers/If-None-Match
-tags:
-  - Conditional Requests
-  - HTTP
-  - HTTP Header
-  - Reference
-  - Request header
-translation_of: Web/HTTP/Headers/If-None-Match
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/if-range/index.md
+++ b/files/ja/web/http/headers/if-range/index.md
@@ -1,14 +1,6 @@
 ---
 title: If-Range
 slug: Web/HTTP/Headers/If-Range
-tags:
-  - HTTP
-  - HTTP ヘッダー
-  - リクエストヘッダー
-  - リファレンス
-  - レンジリクエスト
-  - 条件リクエスト
-translation_of: Web/HTTP/Headers/If-Range
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/if-unmodified-since/index.md
+++ b/files/ja/web/http/headers/if-unmodified-since/index.md
@@ -1,13 +1,6 @@
 ---
 title: If-Unmodified-Since
 slug: Web/HTTP/Headers/If-Unmodified-Since
-tags:
-  - HTTP
-  - HTTP ヘッダー
-  - Reference
-  - リクエストヘッダー
-  - リファレンス
-translation_of: Web/HTTP/Headers/If-Unmodified-Since
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/index.md
+++ b/files/ja/web/http/headers/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTTP ヘッダー
 slug: Web/HTTP/Headers
-tags:
-  - HTTP
-  - HTTP ヘッダー
-  - Networking
-  - Reference
-  - header
-  - ネットワーク
-  - ヘッダー
-  - リファレンス
-translation_of: Web/HTTP/Headers
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/keep-alive/index.md
+++ b/files/ja/web/http/headers/keep-alive/index.md
@@ -1,12 +1,6 @@
 ---
 title: Keep-Alive
 slug: Web/HTTP/Headers/Keep-Alive
-tags:
-  - General Header
-  - HTTP
-  - HTTP Header
-  - Reference
-translation_of: Web/HTTP/Headers/Keep-Alive
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/last-modified/index.md
+++ b/files/ja/web/http/headers/last-modified/index.md
@@ -1,12 +1,6 @@
 ---
 title: Last-Modified
 slug: Web/HTTP/Headers/Last-Modified
-tags:
-  - HTTP
-  - HTTP ヘッダー
-  - Reference
-  - レスポンスヘッダー
-translation_of: Web/HTTP/Headers/Last-Modified
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/link/index.md
+++ b/files/ja/web/http/headers/link/index.md
@@ -1,17 +1,6 @@
 ---
 title: Link
 slug: Web/HTTP/Headers/Link
-tags:
-  - Draft
-  - HTTP
-  - HTTP ヘッダー
-  - Link
-  - NeedsCompatTable
-  - NeedsContent
-  - NeedsSyntax
-  - リファレンス
-browser-compat: http.headers.Link
-translation_of: Web/HTTP/Headers/Link
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/location/index.md
+++ b/files/ja/web/http/headers/location/index.md
@@ -1,12 +1,6 @@
 ---
 title: Location
 slug: Web/HTTP/Headers/Location
-tags:
-  - HTTP
-  - HTTP レスポンスヘッダー
-  - リファレンス
-  - レスポンスヘッダー
-translation_of: Web/HTTP/Headers/Location
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/nel/index.md
+++ b/files/ja/web/http/headers/nel/index.md
@@ -1,18 +1,6 @@
 ---
 title: NEL
 slug: Web/HTTP/Headers/NEL
-tags:
-  - HTTP
-  - HTTP Header
-  - HTTP ヘッダー
-  - Network Error Logging
-  - Reference
-  - Response Header
-  - header
-  - ネットワークエラーログ記録
-  - ヘッダー
-  - レスポンスヘッダー
-translation_of: Web/HTTP/Headers/NEL
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/origin/index.md
+++ b/files/ja/web/http/headers/origin/index.md
@@ -1,13 +1,6 @@
 ---
 title: Origin
 slug: Web/HTTP/Headers/Origin
-tags:
-  - HTTP
-  - Reference
-  - header
-  - origin
-  - リクエストヘッダー
-translation_of: Web/HTTP/Headers/Origin
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/pragma/index.md
+++ b/files/ja/web/http/headers/pragma/index.md
@@ -1,13 +1,6 @@
 ---
 title: Pragma
 slug: Web/HTTP/Headers/Pragma
-tags:
-  - Caching
-  - Deprecated
-  - HTTP
-  - ヘッダー
-  - リクエスト
-translation_of: Web/HTTP/Headers/Pragma
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/proxy-authenticate/index.md
+++ b/files/ja/web/http/headers/proxy-authenticate/index.md
@@ -1,13 +1,6 @@
 ---
 title: Proxy-Authenticate
 slug: Web/HTTP/Headers/Proxy-Authenticate
-tags:
-  - HTTP
-  - HTTP ヘッダー
-  - Reference
-  - プロキシ
-  - レスポンスヘッダー
-translation_of: Web/HTTP/Headers/Proxy-Authenticate
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/proxy-authorization/index.md
+++ b/files/ja/web/http/headers/proxy-authorization/index.md
@@ -1,7 +1,6 @@
 ---
 title: Proxy-Authorization
 slug: Web/HTTP/Headers/Proxy-Authorization
-translation_of: Web/HTTP/Headers/Proxy-Authorization
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/range/index.md
+++ b/files/ja/web/http/headers/range/index.md
@@ -1,14 +1,6 @@
 ---
 title: Range
 slug: Web/HTTP/Headers/Range
-tags:
-  - HTTP
-  - HTTP Header
-  - Range Requests
-  - Reference
-  - Request header
-  - リクエストヘッダー
-translation_of: Web/HTTP/Headers/Range
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/referer/index.md
+++ b/files/ja/web/http/headers/referer/index.md
@@ -1,15 +1,6 @@
 ---
 title: Referer
 slug: Web/HTTP/Headers/Referer
-tags:
-  - HTTP
-  - HTTP リクエストヘッダー
-  - Reference
-  - referer
-  - ヘッダー
-  - リクエストヘッダー
-  - リファラー
-translation_of: Web/HTTP/Headers/Referer
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/referrer-policy/index.md
+++ b/files/ja/web/http/headers/referrer-policy/index.md
@@ -1,17 +1,6 @@
 ---
 title: Referrer-Policy
 slug: Web/HTTP/Headers/Referrer-Policy
-tags:
-  - HTTP
-  - HTTP Header
-  - Privacy
-  - Reference
-  - Referrer-Policy
-  - Response
-  - Response Header
-  - referrer
-browser-compat: http.headers.Referrer-Policy
-translation_of: Web/HTTP/Headers/Referrer-Policy
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/retry-after/index.md
+++ b/files/ja/web/http/headers/retry-after/index.md
@@ -1,13 +1,6 @@
 ---
 title: Retry-After
 slug: Web/HTTP/Headers/Retry-After
-tags:
-  - HTTP
-  - ヘッダー
-  - リファレンス
-  - レスポンス
-  - レスポンスヘッダー
-translation_of: Web/HTTP/Headers/Retry-After
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/server-timing/index.md
+++ b/files/ja/web/http/headers/server-timing/index.md
@@ -1,12 +1,6 @@
 ---
 title: Server-Timing
 slug: Web/HTTP/Headers/Server-Timing
-tags:
-  - HTTP
-  - Reference
-  - パフォーマンス
-  - ヘッダー
-translation_of: Web/HTTP/Headers/Server-Timing
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/server/index.md
+++ b/files/ja/web/http/headers/server/index.md
@@ -1,11 +1,6 @@
 ---
 title: Server
 slug: Web/HTTP/Headers/Server
-tags:
-  - HTTP
-  - Reference
-  - header
-translation_of: Web/HTTP/Headers/Server
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/set-cookie/index.md
+++ b/files/ja/web/http/headers/set-cookie/index.md
@@ -1,15 +1,6 @@
 ---
 title: Set-Cookie
 slug: Web/HTTP/Headers/Set-Cookie
-tags:
-  - Cookies
-  - HTTP
-  - リファレンス
-  - レスポンス
-  - ヘッダー
-  - samesite
-browser-compat: http.headers.Set-Cookie
-translation_of: Web/HTTP/Headers/Set-Cookie
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/set-cookie/samesite/index.md
+++ b/files/ja/web/http/headers/set-cookie/samesite/index.md
@@ -1,12 +1,6 @@
 ---
 title: SameSite cookies
 slug: Web/HTTP/Headers/Set-Cookie/SameSite
-tags:
-  - Cookies
-  - HTTP
-  - Reference
-  - samesite
-translation_of: Web/HTTP/Headers/Set-Cookie/SameSite
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/sourcemap/index.md
+++ b/files/ja/web/http/headers/sourcemap/index.md
@@ -1,13 +1,6 @@
 ---
 title: SourceMap
 slug: Web/HTTP/Headers/SourceMap
-tags:
-  - HTTP
-  - HTTP ヘッダー
-  - ヘッダー
-  - リファレンス
-  - レスポンスヘッダー
-translation_of: Web/HTTP/Headers/SourceMap
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/strict-transport-security/index.md
+++ b/files/ja/web/http/headers/strict-transport-security/index.md
@@ -1,14 +1,6 @@
 ---
 title: Strict-Transport-Security
 slug: Web/HTTP/Headers/Strict-Transport-Security
-tags:
-  - HSTS
-  - HTTP
-  - HTTPS
-  - セキュリティ
-  - ヘッダー
-  - レスポンスヘッダー
-translation_of: Web/HTTP/Headers/Strict-Transport-Security
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/timing-allow-origin/index.md
+++ b/files/ja/web/http/headers/timing-allow-origin/index.md
@@ -1,13 +1,6 @@
 ---
 title: Timing-Allow-Origin
 slug: Web/HTTP/Headers/Timing-Allow-Origin
-tags:
-  - CORS
-  - HTTP
-  - Reference
-  - Timing-Allow-Origin
-  - header
-translation_of: Web/HTTP/Headers/Timing-Allow-Origin
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/tk/index.md
+++ b/files/ja/web/http/headers/tk/index.md
@@ -1,15 +1,6 @@
 ---
 title: Tk
 slug: Web/HTTP/Headers/Tk
-tags:
-  - DNT
-  - HTTP
-  - ヘッダー
-  - リファレンス
-  - レスポンス
-  - レスポンスヘッダー
-  - 追跡
-translation_of: Web/HTTP/Headers/Tk
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/transfer-encoding/index.md
+++ b/files/ja/web/http/headers/transfer-encoding/index.md
@@ -1,12 +1,6 @@
 ---
 title: Transfer-Encoding
 slug: Web/HTTP/Headers/Transfer-Encoding
-tags:
-  - HTTP
-  - Reference
-  - ヘッダー
-  - レスポンスヘッダー
-translation_of: Web/HTTP/Headers/Transfer-Encoding
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/upgrade-insecure-requests/index.md
+++ b/files/ja/web/http/headers/upgrade-insecure-requests/index.md
@@ -1,13 +1,6 @@
 ---
 title: Upgrade-Insecure-Requests
 slug: Web/HTTP/Headers/Upgrade-Insecure-Requests
-tags:
-  - HTTP
-  - HTTPS
-  - Security
-  - header
-browser-compat: http.headers.Upgrade-Insecure-Requests
-translation_of: Web/HTTP/Headers/Upgrade-Insecure-Requests
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/upgrade/index.md
+++ b/files/ja/web/http/headers/upgrade/index.md
@@ -1,14 +1,6 @@
 ---
 title: Upgrade
 slug: Web/HTTP/Headers/Upgrade
-tags:
-  - HTTP
-  - HTTP ヘッダー
-  - リクエストヘッダー
-  - レスポンスヘッダー
-  - Upgrade
-browser-compat: http.headers.Upgrade
-translation_of: Web/HTTP/Headers/Upgrade
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/user-agent/firefox/index.md
+++ b/files/ja/web/http/headers/user-agent/firefox/index.md
@@ -1,14 +1,6 @@
 ---
 title: Firefox ユーザーエージェント文字列リファレンス
 slug: Web/HTTP/Headers/User-Agent/Firefox
-tags:
-  - Compatibility
-  - Firefox
-  - Firefox 4
-  - Gecko
-  - Gecko 2.0
-  - Guide
-translation_of: Web/HTTP/Headers/User-Agent/Firefox
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/user-agent/index.md
+++ b/files/ja/web/http/headers/user-agent/index.md
@@ -1,13 +1,6 @@
 ---
 title: User-Agent
 slug: Web/HTTP/Headers/User-Agent
-tags:
-  - HTTP
-  - HTTP Header
-  - HTTP ヘッダー
-  - Reference
-  - User-agent
-translation_of: Web/HTTP/Headers/User-Agent
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/vary/index.md
+++ b/files/ja/web/http/headers/vary/index.md
@@ -1,14 +1,6 @@
 ---
 title: Vary
 slug: Web/HTTP/Headers/Vary
-tags:
-  - HTTP
-  - Reference
-  - ヘッダー
-  - リファレンス
-  - レスポンス
-  - レスポンスヘッダー
-translation_of: Web/HTTP/Headers/Vary
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/via/index.md
+++ b/files/ja/web/http/headers/via/index.md
@@ -1,7 +1,6 @@
 ---
 title: Via
 slug: Web/HTTP/Headers/Via
-translation_of: Web/HTTP/Headers/Via
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/warning/index.md
+++ b/files/ja/web/http/headers/warning/index.md
@@ -1,12 +1,6 @@
 ---
 title: Warning
 slug: Web/HTTP/Headers/Warning
-tags:
-  - General Header
-  - HTTP
-  - Reference
-  - header
-translation_of: Web/HTTP/Headers/Warning
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/www-authenticate/index.md
+++ b/files/ja/web/http/headers/www-authenticate/index.md
@@ -1,16 +1,6 @@
 ---
 title: WWW-Authenticate
 slug: Web/HTTP/Headers/WWW-Authenticate
-tags:
-  - HTTP
-  - HTTP ヘッダー
-  - Reference
-  - レスポンスヘッダー
-  - ヘッダー
-  - WWW-Authenticate
-  - 認証
-browser-compat: http.headers.WWW-Authenticate
-translation_of: Web/HTTP/Headers/WWW-Authenticate
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/x-content-type-options/index.md
+++ b/files/ja/web/http/headers/x-content-type-options/index.md
@@ -1,13 +1,6 @@
 ---
 title: X-Content-Type-Options
 slug: Web/HTTP/Headers/X-Content-Type-Options
-tags:
-  - HTTP
-  - HTTP ヘッダー
-  - Reference
-  - レスポンスヘッダー
-browser-compat: http.headers.X-Content-Type-Options
-translation_of: Web/HTTP/Headers/X-Content-Type-Options
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/x-dns-prefetch-control/index.md
+++ b/files/ja/web/http/headers/x-dns-prefetch-control/index.md
@@ -1,13 +1,6 @@
 ---
 title: X-DNS-Prefetch-Control
 slug: Web/HTTP/Headers/X-DNS-Prefetch-Control
-tags:
-  - DNS
-  - HTTP
-  - X-DNS-Prefetch-Control
-  - header
-translation_of: Web/HTTP/Headers/X-DNS-Prefetch-Control
-browser-compat: http.headers.X-DNS-Prefetch-Control
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/x-forwarded-for/index.md
+++ b/files/ja/web/http/headers/x-forwarded-for/index.md
@@ -1,14 +1,6 @@
 ---
 title: X-Forwarded-For
 slug: Web/HTTP/Headers/X-Forwarded-For
-tags:
-  - HTTP
-  - HTTP ヘッダー
-  - ヘッダー
-  - リクエストヘッダー
-  - リファレンス
-  - 標準外
-translation_of: Web/HTTP/Headers/X-Forwarded-For
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/x-forwarded-host/index.md
+++ b/files/ja/web/http/headers/x-forwarded-host/index.md
@@ -1,14 +1,6 @@
 ---
 title: X-Forwarded-Host
 slug: Web/HTTP/Headers/X-Forwarded-Host
-tags:
-  - HTTP
-  - HTTPヘッダー
-  - Reference
-  - ヘッダー
-  - リクエストヘッダー
-  - 標準外
-translation_of: Web/HTTP/Headers/X-Forwarded-Host
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/x-forwarded-proto/index.md
+++ b/files/ja/web/http/headers/x-forwarded-proto/index.md
@@ -1,14 +1,6 @@
 ---
 title: X-Forwarded-Proto
 slug: Web/HTTP/Headers/X-Forwarded-Proto
-tags:
-  - HTTP
-  - HTTPヘッダー
-  - Reference
-  - ヘッダー
-  - リクエストヘッダー
-  - 標準外
-translation_of: Web/HTTP/Headers/X-Forwarded-Proto
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/x-frame-options/index.md
+++ b/files/ja/web/http/headers/x-frame-options/index.md
@@ -1,15 +1,6 @@
 ---
 title: X-Frame-Options
 slug: Web/HTTP/Headers/X-Frame-Options
-tags:
-  - Gecko
-  - HAProxy
-  - HTTP
-  - レスポンスヘッダー
-  - セキュリティ
-  - nginx
-browser-compat: http.headers.X-Frame-Options
-translation_of: Web/HTTP/Headers/X-Frame-Options
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/headers/x-xss-protection/index.md
+++ b/files/ja/web/http/headers/x-xss-protection/index.md
@@ -1,13 +1,6 @@
 ---
 title: X-XSS-Protection
 slug: Web/HTTP/Headers/X-XSS-Protection
-tags:
-  - HTTP
-  - Reference
-  - XSS
-  - セキュリティ
-  - ヘッダー
-translation_of: Web/HTTP/Headers/X-XSS-Protection
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/index.md
+++ b/files/ja/web/http/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTTP
 slug: Web/HTTP
-tags:
-  - HTTP
-  - Hypertext
-  - Reference
-  - TCP/IP
-  - Web
-  - Web Development
-  - l10n:priority
-translation_of: Web/HTTP
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/link_prefetching_faq/index.md
+++ b/files/ja/web/http/link_prefetching_faq/index.md
@@ -1,17 +1,6 @@
 ---
 title: リンク先読みの FAQ
 slug: Web/HTTP/Link_prefetching_FAQ
-tags:
-  - Gecko
-  - HTML
-  - HTTP
-  - Link
-  - Necko
-  - Performance
-  - Web Development
-  - 先読み
-  - 移行
-translation_of: Web/HTTP/Link_prefetching_FAQ
 ---
 ### リンクの先読みとは?
 

--- a/files/ja/web/http/messages/index.md
+++ b/files/ja/web/http/messages/index.md
@@ -1,12 +1,6 @@
 ---
 title: HTTP メッセージ
 slug: Web/HTTP/Messages
-tags:
-  - Guide
-  - HTTP
-  - WebMechanics
-  - ガイド
-translation_of: Web/HTTP/Messages
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/methods/connect/index.md
+++ b/files/ja/web/http/methods/connect/index.md
@@ -1,12 +1,6 @@
 ---
 title: CONNECT
 slug: Web/HTTP/Methods/CONNECT
-tags:
-  - HTTP
-  - リファレンス
-  - リクエストメソッド
-browser-compat: http.methods.CONNECT
-translation_of: Web/HTTP/Methods/CONNECT
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/methods/delete/index.md
+++ b/files/ja/web/http/methods/delete/index.md
@@ -1,12 +1,6 @@
 ---
 title: DELETE
 slug: Web/HTTP/Methods/DELETE
-tags:
-  - HTTP
-  - リファレンス
-  - リクエストメソッド
-browser-compat: http.methods.DELETE
-translation_of: Web/HTTP/Methods/DELETE
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/methods/get/index.md
+++ b/files/ja/web/http/methods/get/index.md
@@ -1,12 +1,6 @@
 ---
 title: GET
 slug: Web/HTTP/Methods/GET
-tags:
-  - HTTP
-  - リファレンス
-  - リクエストメソッド
-browser-compat: http.methods.GET
-translation_of: Web/HTTP/Methods/GET
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/methods/head/index.md
+++ b/files/ja/web/http/methods/head/index.md
@@ -1,12 +1,6 @@
 ---
 title: HEAD
 slug: Web/HTTP/Methods/HEAD
-tags:
-  - HTTP
-  - リファレンス
-  - リクエストメソッド
-browser-compat: http.methods.HEAD
-translation_of: Web/HTTP/Methods/HEAD
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/methods/index.md
+++ b/files/ja/web/http/methods/index.md
@@ -1,12 +1,6 @@
 ---
 title: HTTP リクエストメソッド
 slug: Web/HTTP/Methods
-tags:
-  - HTTP
-  - メソッド
-  - リファレンス
-browser-compat: http.methods
-translation_of: Web/HTTP/Methods
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/methods/options/index.md
+++ b/files/ja/web/http/methods/options/index.md
@@ -1,12 +1,6 @@
 ---
 title: OPTIONS
 slug: Web/HTTP/Methods/OPTIONS
-tags:
-  - HTTP
-  - リファレンス
-  - リクエストメソッド
-browser-compat: http.methods.OPTIONS
-translation_of: Web/HTTP/Methods/OPTIONS
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/methods/patch/index.md
+++ b/files/ja/web/http/methods/patch/index.md
@@ -1,11 +1,6 @@
 ---
 title: PATCH
 slug: Web/HTTP/Methods/PATCH
-tags:
-  - HTTP
-  - リファレンス
-  - リクエストメソッド
-translation_of: Web/HTTP/Methods/PATCH
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/methods/post/index.md
+++ b/files/ja/web/http/methods/post/index.md
@@ -1,12 +1,6 @@
 ---
 title: POST
 slug: Web/HTTP/Methods/POST
-tags:
-  - HTTP
-  - リファレンス
-  - リクエストメソッド
-browser-compat: http.methods.POST
-translation_of: Web/HTTP/Methods/POST
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/methods/put/index.md
+++ b/files/ja/web/http/methods/put/index.md
@@ -1,12 +1,6 @@
 ---
 title: PUT
 slug: Web/HTTP/Methods/PUT
-tags:
-  - HTTP
-  - リファレンス
-  - リクエストメソッド
-browser-compat: http.methods.PUT
-translation_of: Web/HTTP/Methods/PUT
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/methods/trace/index.md
+++ b/files/ja/web/http/methods/trace/index.md
@@ -1,12 +1,6 @@
 ---
 title: TRACE
 slug: Web/HTTP/Methods/TRACE
-tags:
-  - HTTP
-  - リファレンス
-  - リクエストメソッド
-browser-compat: http.methods.TRACE
-translation_of: Web/HTTP/Methods/TRACE
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/network_error_logging/index.md
+++ b/files/ja/web/http/network_error_logging/index.md
@@ -1,12 +1,6 @@
 ---
 title: Network Error Logging
 slug: Web/HTTP/Network_Error_Logging
-tags:
-  - Guide
-  - HTTP
-  - Network Error Logging
-  - Reference
-translation_of: Web/HTTP/Network_Error_Logging
 ---
 {{HTTPSidebar}}{{SeeCompatTable}}
 

--- a/files/ja/web/http/overview/index.md
+++ b/files/ja/web/http/overview/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTTP の概要
 slug: Web/HTTP/Overview
-tags:
-  - HTML
-  - HTTP
-  - Overview
-  - WebMechanics
-  - 概要
-translation_of: Web/HTTP/Overview
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/protocol_upgrade_mechanism/index.md
+++ b/files/ja/web/http/protocol_upgrade_mechanism/index.md
@@ -1,17 +1,6 @@
 ---
 title: プロトコルのアップグレードメカニズム
 slug: Web/HTTP/Protocol_upgrade_mechanism
-tags:
-  - HTTP
-  - HTTP/2
-  - TLS
-  - WebSocket
-  - WebSockets
-  - アップグレード
-  - ガイド
-  - ネットワーキング
-  - プロトコル
-translation_of: Web/HTTP/Protocol_upgrade_mechanism
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/proxy_servers_and_tunneling/index.md
+++ b/files/ja/web/http/proxy_servers_and_tunneling/index.md
@@ -1,12 +1,6 @@
 ---
 title: プロキシサーバーとトンネリング
 slug: Web/HTTP/Proxy_servers_and_tunneling
-tags:
-  - HTTP
-  - HTTP Tunneling
-  - Proxies
-  - Proxy
-translation_of: Web/HTTP/Proxy_servers_and_tunneling
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
+++ b/files/ja/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
@@ -1,12 +1,6 @@
 ---
 title: プロキシー自動設定ファイル
 slug: Web/HTTP/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_PAC_file
-tags:
-  - Necko
-  - Networking
-  - PAC
-  - Proxy
-translation_of: Web/HTTP/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_(PAC)_file
 original_slug: Web/HTTP/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_(PAC)_file
 ---
 {{HTTPSidebar}}

--- a/files/ja/web/http/range_requests/index.md
+++ b/files/ja/web/http/range_requests/index.md
@@ -1,11 +1,6 @@
 ---
 title: HTTP 範囲リクエスト
 slug: Web/HTTP/Range_requests
-tags:
-  - HTTP
-  - HTTP 範囲リクエスト
-  - ガイド
-translation_of: Web/HTTP/Range_requests
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/redirections/index.md
+++ b/files/ja/web/http/redirections/index.md
@@ -1,11 +1,6 @@
 ---
 title: HTTP のリダイレクト
 slug: Web/HTTP/Redirections
-tags:
-  - Guide
-  - HTTP
-  - redirects
-translation_of: Web/HTTP/Redirections
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/resources_and_specifications/index.md
+++ b/files/ja/web/http/resources_and_specifications/index.md
@@ -1,10 +1,6 @@
 ---
 title: HTTP のリソースと仕様書
 slug: Web/HTTP/Resources_and_specifications
-tags:
-  - Guide
-  - HTTP
-translation_of: Web/HTTP/Resources_and_specifications
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/resources_and_uris/index.md
+++ b/files/ja/web/http/resources_and_uris/index.md
@@ -1,15 +1,6 @@
 ---
 title: リソースと URI
 slug: Web/HTTP/Resources_and_URIs
-tags:
-  - HTTP
-  - MIME
-  - MIME タイプ
-  - URI
-  - URL
-  - リソース
-  - 概要
-translation_of: Web/HTTP/Resources_and_URIs
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/session/index.md
+++ b/files/ja/web/http/session/index.md
@@ -1,9 +1,6 @@
 ---
 title: 典型的な HTTP セッション
 slug: Web/HTTP/Session
-tags:
-  - HTTP
-translation_of: Web/HTTP/Session
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/100/index.md
+++ b/files/ja/web/http/status/100/index.md
@@ -1,11 +1,6 @@
 ---
 title: 100 Continue
 slug: Web/HTTP/Status/100
-tags:
-  - HTTP
-  - Informational
-  - ステータスコード
-translation_of: Web/HTTP/Status/100
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/101/index.md
+++ b/files/ja/web/http/status/101/index.md
@@ -1,13 +1,6 @@
 ---
 title: 101 Switching Protocols
 slug: Web/HTTP/Status/101
-tags:
-  - HTTP
-  - HTTP ステータスコード
-  - WebSocket
-  - リファレンス
-  - 情報
-translation_of: Web/HTTP/Status/101
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/103/index.md
+++ b/files/ja/web/http/status/103/index.md
@@ -1,14 +1,6 @@
 ---
 title: 103 Early Hints
 slug: Web/HTTP/Status/103
-tags:
-  - Draft
-  - HTTP
-  - Informational
-  - NeedsCompatTable
-  - NeedsContent
-  - Status code
-translation_of: Web/HTTP/Status/103
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/200/index.md
+++ b/files/ja/web/http/status/200/index.md
@@ -1,11 +1,6 @@
 ---
 title: 200 OK
 slug: Web/HTTP/Status/200
-tags:
-  - HTTP
-  - HTTP ステータスコード
-  - 成功
-translation_of: Web/HTTP/Status/200
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/201/index.md
+++ b/files/ja/web/http/status/201/index.md
@@ -1,12 +1,6 @@
 ---
 title: 201 Created
 slug: Web/HTTP/Status/201
-tags:
-  - HTTP
-  - Reference
-  - ステータスコード
-  - 成功
-translation_of: Web/HTTP/Status/201
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/202/index.md
+++ b/files/ja/web/http/status/202/index.md
@@ -1,12 +1,6 @@
 ---
 title: 202 Accepted
 slug: Web/HTTP/Status/202
-tags:
-  - HTTP
-  - リファレンス
-  - ステータスコード
-  - 成功レスポンス
-translation_of: Web/HTTP/Status/202
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/203/index.md
+++ b/files/ja/web/http/status/203/index.md
@@ -1,14 +1,6 @@
 ---
 title: 203 Non-Authoritative Information
 slug: Web/HTTP/Status/203
-tags:
-  - HTTP
-  - HTTP ステータスコード
-  - Reference
-  - Status code
-  - ステータスコード
-  - 成功レスポンス
-translation_of: Web/HTTP/Status/203
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/204/index.md
+++ b/files/ja/web/http/status/204/index.md
@@ -1,12 +1,6 @@
 ---
 title: 204 No Content
 slug: Web/HTTP/Status/204
-tags:
-  - HTTP
-  - Success
-  - ステータスコード
-  - リファレンス
-translation_of: Web/HTTP/Status/204
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/205/index.md
+++ b/files/ja/web/http/status/205/index.md
@@ -1,12 +1,6 @@
 ---
 title: 205 Reset Content
 slug: Web/HTTP/Status/205
-tags:
-  - HTTP
-  - HTTP ステータスコード
-  - ステータスコード
-  - リファレンス
-translation_of: Web/HTTP/Status/205
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/206/index.md
+++ b/files/ja/web/http/status/206/index.md
@@ -1,12 +1,6 @@
 ---
 title: 206 Partial Content
 slug: Web/HTTP/Status/206
-tags:
-  - HTTP
-  - HTTP ステータスコード
-  - Range Requests
-  - Success
-translation_of: Web/HTTP/Status/206
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/300/index.md
+++ b/files/ja/web/http/status/300/index.md
@@ -1,11 +1,6 @@
 ---
 title: 300 Multiple Choices
 slug: Web/HTTP/Status/300
-tags:
-  - HTTP
-  - HTTP ステータスコード
-  - リファレンス
-translation_of: Web/HTTP/Status/300
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/301/index.md
+++ b/files/ja/web/http/status/301/index.md
@@ -1,14 +1,6 @@
 ---
 title: 301 Moved Permanently
 slug: Web/HTTP/Status/301
-tags:
-  - HTTP
-  - Redirect
-  - Reference
-  - Status code
-  - ステータスコード
-  - リダイレクト
-translation_of: Web/HTTP/Status/301
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/302/index.md
+++ b/files/ja/web/http/status/302/index.md
@@ -1,12 +1,6 @@
 ---
 title: 302 Found
 slug: Web/HTTP/Status/302
-tags:
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - redirects
-translation_of: Web/HTTP/Status/302
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/303/index.md
+++ b/files/ja/web/http/status/303/index.md
@@ -1,12 +1,6 @@
 ---
 title: 303 See Other
 slug: Web/HTTP/Status/303
-tags:
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - redirects
-translation_of: Web/HTTP/Status/303
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/304/index.md
+++ b/files/ja/web/http/status/304/index.md
@@ -1,12 +1,6 @@
 ---
 title: 304 Not Modified
 slug: Web/HTTP/Status/304
-tags:
-  - HTTP
-  - ステータスコード
-  - リダイレクト
-  - リファレンス
-translation_of: Web/HTTP/Status/304
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/307/index.md
+++ b/files/ja/web/http/status/307/index.md
@@ -1,12 +1,6 @@
 ---
 title: 307 Temporary Redirect
 slug: Web/HTTP/Status/307
-tags:
-  - HTTP
-  - HTTP ステータスコード
-  - Reference
-  - リダイレクト
-translation_of: Web/HTTP/Status/307
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/308/index.md
+++ b/files/ja/web/http/status/308/index.md
@@ -1,12 +1,6 @@
 ---
 title: 308 Permanent Redirect
 slug: Web/HTTP/Status/308
-tags:
-  - HTTP
-  - HTTP ステータスコード
-  - Reference
-  - リダイレクト
-translation_of: Web/HTTP/Status/308
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/400/index.md
+++ b/files/ja/web/http/status/400/index.md
@@ -1,13 +1,6 @@
 ---
 title: 400 Bad Request
 slug: Web/HTTP/Status/400
-tags:
-  - HTTP
-  - HTTP ステータスコード
-  - Reference
-  - クライアントエラー
-  - ステータスコード
-translation_of: Web/HTTP/Status/400
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/401/index.md
+++ b/files/ja/web/http/status/401/index.md
@@ -1,11 +1,6 @@
 ---
 title: 401 Unauthorized
 slug: Web/HTTP/Status/401
-tags:
-  - HTTP
-  - HTTP ステータスコード
-  - Reference
-translation_of: Web/HTTP/Status/401
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/402/index.md
+++ b/files/ja/web/http/status/402/index.md
@@ -1,14 +1,6 @@
 ---
 title: 402 Payment Required
 slug: Web/HTTP/Status/402
-tags:
-  - Browser
-  - Client error
-  - HTTP
-  - Status code
-  - クライアントエラー
-  - ステータスコード
-translation_of: Web/HTTP/Status/402
 ---
 {{HTTPSidebar}}{{SeeCompatTable}}
 

--- a/files/ja/web/http/status/403/index.md
+++ b/files/ja/web/http/status/403/index.md
@@ -1,13 +1,6 @@
 ---
 title: 403 Forbidden
 slug: Web/HTTP/Status/403
-tags:
-  - HTTP
-  - HTTP ステータスコード
-  - Reference
-  - クライアントエラー
-  - ステータスコード
-translation_of: Web/HTTP/Status/403
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/404/index.md
+++ b/files/ja/web/http/status/404/index.md
@@ -1,14 +1,6 @@
 ---
 title: 404 Not Found
 slug: Web/HTTP/Status/404
-tags:
-  - Browser
-  - HTTP
-  - Reference
-  - Status code
-  - クライアントエラー
-  - ステータスコード
-translation_of: Web/HTTP/Status/404
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/405/index.md
+++ b/files/ja/web/http/status/405/index.md
@@ -1,13 +1,6 @@
 ---
 title: 405 Method Not Allowed
 slug: Web/HTTP/Status/405
-tags:
-  - HTTP
-  - HTTP ステータスコード
-  - Reference
-  - クライアントエラー
-  - リファレンス
-translation_of: Web/HTTP/Status/405
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/406/index.md
+++ b/files/ja/web/http/status/406/index.md
@@ -1,11 +1,6 @@
 ---
 title: 406 Not Acceptable
 slug: Web/HTTP/Status/406
-tags:
-  - HTTP
-  - HTTP ステータスコード
-  - Reference
-translation_of: Web/HTTP/Status/406
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/407/index.md
+++ b/files/ja/web/http/status/407/index.md
@@ -1,12 +1,6 @@
 ---
 title: 407 Proxy Authentication Required
 slug: Web/HTTP/Status/407
-tags:
-  - HTTP
-  - クライアントエラー
-  - ステータスコード
-  - リファレンス
-translation_of: Web/HTTP/Status/407
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/408/index.md
+++ b/files/ja/web/http/status/408/index.md
@@ -1,13 +1,6 @@
 ---
 title: 408 Request Timeout
 slug: Web/HTTP/Status/408
-tags:
-  - HTTP
-  - HTTPステータスコード
-  - クライアントエラー
-  - ステータスコード
-  - リファレンス
-translation_of: Web/HTTP/Status/408
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/409/index.md
+++ b/files/ja/web/http/status/409/index.md
@@ -1,12 +1,6 @@
 ---
 title: 409 Conflict
 slug: Web/HTTP/Status/409
-tags:
-  - HTTP
-  - HTTPステータスコード
-  - Reference
-  - クライアントエラー
-translation_of: Web/HTTP/Status/409
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/410/index.md
+++ b/files/ja/web/http/status/410/index.md
@@ -1,13 +1,6 @@
 ---
 title: 410 Gone
 slug: Web/HTTP/Status/410
-tags:
-  - Client error
-  - HTTP
-  - Reference
-  - クライアントエラー
-  - ステータスコード
-translation_of: Web/HTTP/Status/410
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/411/index.md
+++ b/files/ja/web/http/status/411/index.md
@@ -1,13 +1,6 @@
 ---
 title: 411 Length Required
 slug: Web/HTTP/Status/411
-tags:
-  - HTTP
-  - HTTPステータスコード
-  - クライアントエラー
-  - ステータスコード
-  - リファレンス
-translation_of: Web/HTTP/Status/411
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/412/index.md
+++ b/files/ja/web/http/status/412/index.md
@@ -1,13 +1,6 @@
 ---
 title: 412 Precondition Failed
 slug: Web/HTTP/Status/412
-tags:
-  - HTTP
-  - Reference
-  - エラー
-  - ステータスコード
-  - リファレンス
-translation_of: Web/HTTP/Status/412
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/413/index.md
+++ b/files/ja/web/http/status/413/index.md
@@ -1,13 +1,6 @@
 ---
 title: 413 Payload Too Large
 slug: Web/HTTP/Status/413
-tags:
-  - Client error
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - Status code
-translation_of: Web/HTTP/Status/413
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/414/index.md
+++ b/files/ja/web/http/status/414/index.md
@@ -1,12 +1,6 @@
 ---
 title: 414 URI Too Long
 slug: Web/HTTP/Status/414
-tags:
-  - HTTP
-  - Reference
-  - クライアントエラー
-  - ステータスコード
-translation_of: Web/HTTP/Status/414
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/415/index.md
+++ b/files/ja/web/http/status/415/index.md
@@ -1,13 +1,6 @@
 ---
 title: 415 Unsupported Media Type
 slug: Web/HTTP/Status/415
-tags:
-  - HTTP
-  - HTTPステータスコード
-  - クライアントエラー
-  - ステータスコード
-  - リファレンス
-translation_of: Web/HTTP/Status/415
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/416/index.md
+++ b/files/ja/web/http/status/416/index.md
@@ -1,11 +1,6 @@
 ---
 title: 416 Range Not Satisfiable
 slug: Web/HTTP/Status/416
-tags:
-  - Client error
-  - HTTP
-  - Status code
-translation_of: Web/HTTP/Status/416
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/417/index.md
+++ b/files/ja/web/http/status/417/index.md
@@ -1,13 +1,6 @@
 ---
 title: 417 Expectation Failed
 slug: Web/HTTP/Status/417
-tags:
-  - HTTP
-  - HTTP ステータスコード
-  - クライアントエラー
-  - ステータスコード
-  - リファレンス
-translation_of: Web/HTTP/Status/417
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/418/index.md
+++ b/files/ja/web/http/status/418/index.md
@@ -1,11 +1,6 @@
 ---
 title: 418 I'm a teapot
 slug: Web/HTTP/Status/418
-tags:
-  - HTTP
-  - HTTP Status Code
-  - Reference
-translation_of: Web/HTTP/Status/418
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/422/index.md
+++ b/files/ja/web/http/status/422/index.md
@@ -1,13 +1,6 @@
 ---
 title: 422 Unprocessable Entity
 slug: Web/HTTP/Status/422
-tags:
-  - HTTP
-  - HTTP ステータスコード
-  - WebDAV
-  - クライアントエラー
-  - リファレンス
-translation_of: Web/HTTP/Status/422
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/425/index.md
+++ b/files/ja/web/http/status/425/index.md
@@ -1,13 +1,6 @@
 ---
 title: 425 Too Early
 slug: Web/HTTP/Status/425
-tags:
-  - HTTP
-  - HTTP ステータスコード
-  - クライアントエラー
-  - ステータスコード
-  - ブラウザー
-translation_of: Web/HTTP/Status/425
 ---
 {{SeeCompatTable}}{{HTTPSidebar}}
 

--- a/files/ja/web/http/status/426/index.md
+++ b/files/ja/web/http/status/426/index.md
@@ -1,13 +1,6 @@
 ---
 title: 426 Upgrade Required
 slug: Web/HTTP/Status/426
-tags:
-  - HTTP
-  - HTTP ステータスコード
-  - クライアントエラー
-  - ステータスコード
-  - リファレンス
-translation_of: Web/HTTP/Status/426
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/428/index.md
+++ b/files/ja/web/http/status/428/index.md
@@ -1,13 +1,6 @@
 ---
 title: 428 Precondition Required
 slug: Web/HTTP/Status/428
-tags:
-  - HTTP
-  - HTTP ステータスコード
-  - クライアントエラー
-  - ステータスコード
-  - リファレンス
-translation_of: Web/HTTP/Status/428
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/429/index.md
+++ b/files/ja/web/http/status/429/index.md
@@ -1,13 +1,6 @@
 ---
 title: 429 Too Many Requests
 slug: Web/HTTP/Status/429
-tags:
-  - Client error
-  - HTTP
-  - HTTP Status Code
-  - Reference
-  - Status code
-translation_of: Web/HTTP/Status/429
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/431/index.md
+++ b/files/ja/web/http/status/431/index.md
@@ -1,13 +1,6 @@
 ---
 title: 431 Request Header Fields Too Large
 slug: Web/HTTP/Status/431
-tags:
-  - HTTP
-  - HTTP ステータスコード
-  - Reference
-  - クライアントエラー
-  - ステータスコード
-translation_of: Web/HTTP/Status/431
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/451/index.md
+++ b/files/ja/web/http/status/451/index.md
@@ -1,12 +1,6 @@
 ---
 title: 451 Unavailable For Legal Reasons
 slug: Web/HTTP/Status/451
-tags:
-  - Client error
-  - HTTP
-  - Reference
-  - Status code
-translation_of: Web/HTTP/Status/451
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/500/index.md
+++ b/files/ja/web/http/status/500/index.md
@@ -1,13 +1,6 @@
 ---
 title: 500 Internal Server Error
 slug: Web/HTTP/Status/500
-tags:
-  - HTTP
-  - Server error
-  - Status code
-  - サーバーエラー
-  - ステータスコード
-translation_of: Web/HTTP/Status/500
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/501/index.md
+++ b/files/ja/web/http/status/501/index.md
@@ -1,11 +1,6 @@
 ---
 title: 501 Not Implemented
 slug: Web/HTTP/Status/501
-tags:
-  - HTTP
-  - Server error
-  - Status code
-translation_of: Web/HTTP/Status/501
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/502/index.md
+++ b/files/ja/web/http/status/502/index.md
@@ -1,13 +1,6 @@
 ---
 title: 502 Bad Gateway
 slug: Web/HTTP/Status/502
-tags:
-  - HTTP
-  - Server error
-  - Status code
-  - サーバーエラー
-  - ステータスコード
-translation_of: Web/HTTP/Status/502
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/503/index.md
+++ b/files/ja/web/http/status/503/index.md
@@ -1,14 +1,6 @@
 ---
 title: 503 Service Unavailable
 slug: Web/HTTP/Status/503
-tags:
-  - HTTP
-  - Reference
-  - Server error
-  - Status code
-  - サーバーエラー
-  - ステータスコード
-translation_of: Web/HTTP/Status/503
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/504/index.md
+++ b/files/ja/web/http/status/504/index.md
@@ -1,13 +1,6 @@
 ---
 title: 504 Gateway Timeout
 slug: Web/HTTP/Status/504
-tags:
-  - HTTP
-  - Server error
-  - Status code
-  - サーバーエラー
-  - ステータスコード
-translation_of: Web/HTTP/Status/504
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/505/index.md
+++ b/files/ja/web/http/status/505/index.md
@@ -1,12 +1,6 @@
 ---
 title: 505 HTTP Version Not Supported
 slug: Web/HTTP/Status/505
-tags:
-  - HTTP
-  - サーバーエラー
-  - ステータスコード
-  - リファレンス
-translation_of: Web/HTTP/Status/505
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/506/index.md
+++ b/files/ja/web/http/status/506/index.md
@@ -1,11 +1,6 @@
 ---
 title: 506 Variant Also Negotiates
 slug: Web/HTTP/Status/506
-tags:
-  - HTTP
-  - Server error
-  - Status code
-translation_of: Web/HTTP/Status/506
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/507/index.md
+++ b/files/ja/web/http/status/507/index.md
@@ -1,11 +1,6 @@
 ---
 title: 507 Insufficient Storage
 slug: Web/HTTP/Status/507
-tags:
-  - HTTP
-  - Server error
-  - Status code
-translation_of: Web/HTTP/Status/507
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/508/index.md
+++ b/files/ja/web/http/status/508/index.md
@@ -1,14 +1,6 @@
 ---
 title: 508 Loop Detected
 slug: Web/HTTP/Status/508
-tags:
-  - '508'
-  - HTTP
-  - Server error
-  - Status code
-  - サーバーエラー
-  - ステータスコード
-translation_of: Web/HTTP/Status/508
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/510/index.md
+++ b/files/ja/web/http/status/510/index.md
@@ -1,11 +1,6 @@
 ---
 title: 510 Not Extended
 slug: Web/HTTP/Status/510
-tags:
-  - HTTP
-  - Server error
-  - Status code
-translation_of: Web/HTTP/Status/510
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/511/index.md
+++ b/files/ja/web/http/status/511/index.md
@@ -1,13 +1,6 @@
 ---
 title: 511 Network Authentication Required
 slug: Web/HTTP/Status/511
-tags:
-  - HTTP
-  - HTTPステータスコード
-  - サーバーエラー
-  - ステータスコード
-  - リファレンス
-translation_of: Web/HTTP/Status/511
 ---
 {{HTTPSidebar}}
 

--- a/files/ja/web/http/status/index.md
+++ b/files/ja/web/http/status/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTTP レスポンスステータスコード
 slug: Web/HTTP/Status
-tags:
-  - HTTP
-  - ランディング
-  - 概要
-  - リファレンス
-  - ステータスコード
-  - ウェブ
-translation_of: Web/HTTP/Status
 ---
 {{HTTPSidebar}}
 


### PR DESCRIPTION
Part of #7858

`files/ja/web/http/*` から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "tags": 249,
  "translation_of": 250,
  "browser-compat": 67
}
```
