### PR TITLE
remove duplicated frontmatter keys from web/css/{-,_,a,b,c,d} (ja)

### DIFF
--- a/files/ja/web/css/--_star_/index.md
+++ b/files/ja/web/css/--_star_/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'カスタムプロパティ (--*): CSS 変数'
 slug: Web/CSS/--*
-tags:
-  - CSS
-  - CSS カスタムプロパティ
-  - ガイド
-  - リファレンス
-browser-compat: css.properties.custom-property
-translation_of: Web/CSS/--*
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/-moz-float-edge/index.md
+++ b/files/ja/web/css/-moz-float-edge/index.md
@@ -1,16 +1,6 @@
 ---
 title: '-moz-float-edge'
 slug: Web/CSS/-moz-float-edge
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS:Mozilla 拡張
-  - Layout
-  - NeedsCompatTable
-  - 標準外
-  - recipe:css-property
-browser-compat: css.properties.-moz-float-edge
-translation_of: Web/CSS/-moz-float-edge
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/-moz-force-broken-image-icon/index.md
+++ b/files/ja/web/css/-moz-force-broken-image-icon/index.md
@@ -1,14 +1,6 @@
 ---
 title: '-moz-force-broken-image-icon'
 slug: Web/CSS/-moz-force-broken-image-icon
-tags:
-  - CSS
-  - NeedsCompatTable
-  - 標準外
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.-moz-force-broken-image-icon
-translation_of: Web/CSS/-moz-force-broken-image-icon
 ---
 {{Non-standard_header}}{{CSSRef}}
 

--- a/files/ja/web/css/-moz-image-rect/index.md
+++ b/files/ja/web/css/-moz-image-rect/index.md
@@ -1,15 +1,6 @@
 ---
 title: '-moz-image-rect'
 slug: Web/CSS/-moz-image-rect
-tags:
-  - CSS
-  - CSS 関数
-  - CSS 画像
-  - CSS:Mozilla 拡張
-  - 関数
-  - 標準外
-  - リファレンス
-browser-compat: css.types.-moz-image-rect
 ---
 {{CSSRef}}{{Non-standard_Header}}
 

--- a/files/ja/web/css/-moz-image-region/index.md
+++ b/files/ja/web/css/-moz-image-region/index.md
@@ -1,14 +1,6 @@
 ---
 title: '-moz-image-region'
 slug: Web/CSS/-moz-image-region
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS:Mozilla 拡張
-  - 標準外
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.-moz-image-region
 ---
 {{CSSRef}}{{Non-standard_Header}}
 

--- a/files/ja/web/css/-moz-orient/index.md
+++ b/files/ja/web/css/-moz-orient/index.md
@@ -1,15 +1,6 @@
 ---
 title: '-moz-orient'
 slug: Web/CSS/-moz-orient
-tags:
-  - CSS
-  - CSS プロパティ
-  - Mozilla 拡張
-  - 標準外
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.-moz-orient
-translation_of: Web/CSS/-moz-orient
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/-moz-outline-radius-bottomleft/index.md
+++ b/files/ja/web/css/-moz-outline-radius-bottomleft/index.md
@@ -1,16 +1,6 @@
 ---
 title: '-moz-outline-radius-bottomleft'
 slug: Web/CSS/-moz-outline-radius-bottomleft
-tags:
-  - CSS
-  - CSS プロパティ
-  - NeedsCompatTable
-  - NeedsContent
-  - 標準外
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.-moz-outline-radius-bottomleft
-translation_of: Web/CSS/-moz-outline-radius-bottomleft
 ---
 {{CSSRef}}{{deprecated_header}}
 

--- a/files/ja/web/css/-moz-outline-radius-bottomright/index.md
+++ b/files/ja/web/css/-moz-outline-radius-bottomright/index.md
@@ -1,16 +1,6 @@
 ---
 title: '-moz-outline-radius-bottomright'
 slug: Web/CSS/-moz-outline-radius-bottomright
-tags:
-  - CSS
-  - CSS プロパティ
-  - NeedsCompatTable
-  - NeedsContent
-  - 標準外
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.-moz-outline-radius-bottomright
-translation_of: Web/CSS/-moz-outline-radius-bottomright
 ---
 {{CSSRef}}{{deprecated_header}}
 

--- a/files/ja/web/css/-moz-outline-radius-topleft/index.md
+++ b/files/ja/web/css/-moz-outline-radius-topleft/index.md
@@ -1,16 +1,6 @@
 ---
 title: '-moz-outline-radius-topleft'
 slug: Web/CSS/-moz-outline-radius-topleft
-tags:
-  - CSS
-  - CSS プロパティ
-  - NeedsCompatTable
-  - NeedsContent
-  - 標準外
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.-moz-outline-radius-topleft
-translation_of: Web/CSS/-moz-outline-radius-topleft
 ---
 {{CSSRef}}{{deprecated_header}}
 

--- a/files/ja/web/css/-moz-outline-radius-topright/index.md
+++ b/files/ja/web/css/-moz-outline-radius-topright/index.md
@@ -1,16 +1,6 @@
 ---
 title: '-moz-outline-radius-topright'
 slug: Web/CSS/-moz-outline-radius-topright
-tags:
-  - CSS
-  - CSS プロパティ
-  - NeedsCompatTable
-  - NeedsContent
-  - 標準外
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.-moz-outline-radius-topright
-translation_of: Web/CSS/-moz-outline-radius-topright
 ---
 {{CSSRef}}{{deprecated_header}}
 

--- a/files/ja/web/css/-moz-outline-radius/index.md
+++ b/files/ja/web/css/-moz-outline-radius/index.md
@@ -1,15 +1,6 @@
 ---
 title: '-moz-outline-radius'
 slug: Web/CSS/-moz-outline-radius
-tags:
-  - CSS
-  - CSS プロパティ
-  - Mozilla 拡張
-  - 標準外
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.-moz-outline-radius
-translation_of: Web/CSS/-moz-outline-radius
 ---
 {{CSSRef}}{{deprecated_header}}
 

--- a/files/ja/web/css/-moz-user-focus/index.md
+++ b/files/ja/web/css/-moz-user-focus/index.md
@@ -1,16 +1,6 @@
 ---
 title: '-moz-user-focus'
 slug: Web/CSS/-moz-user-focus
-tags:
-  - '-moz-user-focus'
-  - CSS
-  - CSS:Mozilla 拡張
-  - NeedsContent
-  - 標準外
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.-moz-user-focus
-translation_of: Web/CSS/-moz-user-focus
 ---
 {{CSSRef}} {{Non-standard_header}}
 

--- a/files/ja/web/css/-moz-user-input/index.md
+++ b/files/ja/web/css/-moz-user-input/index.md
@@ -1,14 +1,6 @@
 ---
 title: '-moz-user-input'
 slug: Web/CSS/-moz-user-input
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS:Mozilla 拡張
-  - 非推奨
-  - 標準外
-  - リファレンス
-translation_of: Web/CSS/-moz-user-input
 ---
 {{CSSRef}}{{Non-standard_Header}}{{Deprecated_Header}}
 

--- a/files/ja/web/css/-webkit-border-before/index.md
+++ b/files/ja/web/css/-webkit-border-before/index.md
@@ -1,16 +1,6 @@
 ---
 title: '-webkit-border-before'
 slug: Web/CSS/-webkit-border-before
-tags:
-  - '-webkit-border-before'
-  - CSS
-  - CSS プロパティ
-  - CSS:WebKit 拡張
-  - 標準外
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.-webkit-border-before
-translation_of: Web/CSS/-webkit-border-before
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/-webkit-box-reflect/index.md
+++ b/files/ja/web/css/-webkit-box-reflect/index.md
@@ -1,16 +1,6 @@
 ---
 title: '-webkit-box-reflect'
 slug: Web/CSS/-webkit-box-reflect
-tags:
-  - '-webkit-box-reflect'
-  - CSS
-  - CSS プロパティ
-  - CSS:WebKit 拡張
-  - 標準外
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.-webkit-box-reflect
-translation_of: Web/CSS/-webkit-box-reflect
 ---
 {{CSSRef}}{{Non-standard_Header}}
 

--- a/files/ja/web/css/-webkit-line-clamp/index.md
+++ b/files/ja/web/css/-webkit-line-clamp/index.md
@@ -1,14 +1,6 @@
 ---
 title: '-webkit-line-clamp'
 slug: Web/CSS/-webkit-line-clamp
-tags:
-  - '-webkit-line-clamp'
-  - CSS
-  - CSS プロパティ
-  - 標準外
-  - recipe:css-property
-browser-compat: css.properties.-webkit-line-clamp
-translation_of: Web/CSS/-webkit-line-clamp
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/-webkit-mask-attachment/index.md
+++ b/files/ja/web/css/-webkit-mask-attachment/index.md
@@ -1,16 +1,6 @@
 ---
 title: '-webkit-mask-attachment'
 slug: Web/CSS/-webkit-mask-attachment
-tags:
-  - CSS
-  - CSS プロパティ
-  - レイアウト
-  - 標準外
-  - リファレンス
-  - ウェブ
-  - recipe:css-property
-browser-compat: css.properties.-webkit-mask-attachment
-translation_of: Web/CSS/-webkit-mask-attachment
 ---
 {{CSSRef}}{{Non-standard_Header}}
 

--- a/files/ja/web/css/-webkit-mask-box-image/index.md
+++ b/files/ja/web/css/-webkit-mask-box-image/index.md
@@ -1,15 +1,6 @@
 ---
 title: '-webkit-mask-box-image'
 slug: Web/CSS/-webkit-mask-box-image
-tags:
-  - CSS
-  - レイアウト
-  - 標準外
-  - リファレンス
-  - ウェブ
-  - recipe:css-property
-browser-compat: css.properties.-webkit-mask-box-image
-translation_of: Web/CSS/-webkit-mask-box-image
 ---
 {{ CSSRef() }} {{ Non-standard_header() }}
 

--- a/files/ja/web/css/-webkit-mask-composite/index.md
+++ b/files/ja/web/css/-webkit-mask-composite/index.md
@@ -1,18 +1,6 @@
 ---
 title: '-webkit-mask-composite'
 slug: Web/CSS/-webkit-mask-composite
-tags:
-  - '-webkit-mask-composite'
-  - CSS
-  - CSS マスク
-  - CSS プロパティ
-  - CSS:WebKit 拡張
-  - 標準外
-  - リファレンス
-  - mask-composite
-  - recipe:css-property
-browser-compat: css.properties.-webkit-mask-composite
-translation_of: Web/CSS/-webkit-mask-composite
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/-webkit-mask-position-x/index.md
+++ b/files/ja/web/css/-webkit-mask-position-x/index.md
@@ -1,15 +1,6 @@
 ---
 title: '-webkit-mask-position-x'
 slug: Web/CSS/-webkit-mask-position-x
-tags:
-  - CSS
-  - CSS マスク
-  - CSS プロパティ
-  - 標準外
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.-webkit-mask-position-x
-translation_of: Web/CSS/-webkit-mask-position-x
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/-webkit-mask-position-y/index.md
+++ b/files/ja/web/css/-webkit-mask-position-y/index.md
@@ -1,15 +1,6 @@
 ---
 title: '-webkit-mask-position-y'
 slug: Web/CSS/-webkit-mask-position-y
-tags:
-  - CSS
-  - CSS マスク
-  - CSS プロパティ
-  - 標準外
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.-webkit-mask-position-y
-translation_of: Web/CSS/-webkit-mask-position-y
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/-webkit-mask-repeat-x/index.md
+++ b/files/ja/web/css/-webkit-mask-repeat-x/index.md
@@ -1,15 +1,6 @@
 ---
 title: '-webkit-mask-repeat-x'
 slug: Web/CSS/-webkit-mask-repeat-x
-tags:
-  - CSS
-  - CSS マスク
-  - CSS プロパティ
-  - 標準外
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.-webkit-mask-repeat-x
-translation_of: Web/CSS/-webkit-mask-repeat-x
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/-webkit-mask-repeat-y/index.md
+++ b/files/ja/web/css/-webkit-mask-repeat-y/index.md
@@ -1,15 +1,6 @@
 ---
 title: '-webkit-mask-repeat-y'
 slug: Web/CSS/-webkit-mask-repeat-y
-tags:
-  - CSS
-  - CSS マスク
-  - CSS プロパティ
-  - 標準外
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.-webkit-mask-repeat-y
-translation_of: Web/CSS/-webkit-mask-repeat-y
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/-webkit-overflow-scrolling/index.md
+++ b/files/ja/web/css/-webkit-overflow-scrolling/index.md
@@ -1,14 +1,6 @@
 ---
 title: '-webkit-overflow-scrolling'
 slug: Web/CSS/-webkit-overflow-scrolling
-tags:
-  - CSS
-  - CSS プロパティ
-  - 標準外
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.-webkit-overflow-scrolling
-translation_of: Web/CSS/-webkit-overflow-scrolling
 ---
 {{CSSRef}} {{Non-standard_header}}
 

--- a/files/ja/web/css/-webkit-tap-highlight-color/index.md
+++ b/files/ja/web/css/-webkit-tap-highlight-color/index.md
@@ -1,15 +1,6 @@
 ---
 title: '-webkit-tap-highlight-color'
 slug: Web/CSS/-webkit-tap-highlight-color
-tags:
-  - CSS
-  - CSS プロパティ
-  - リファレンス
-  - 標準外
-  - WebKit
-  - recipe:css-property
-browser-compat: css.properties.-webkit-tap-highlight-color
-translation_of: Web/CSS/-webkit-tap-highlight-color
 ---
 {{ CSSRef() }}
 

--- a/files/ja/web/css/-webkit-text-fill-color/index.md
+++ b/files/ja/web/css/-webkit-text-fill-color/index.md
@@ -1,14 +1,6 @@
 ---
 title: '-webkit-text-fill-color'
 slug: Web/CSS/-webkit-text-fill-color
-tags:
-  - CSS
-  - CSS プロパティ
-  - 標準外
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.-webkit-text-fill-color
-translation_of: Web/CSS/-webkit-text-fill-color
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/-webkit-text-stroke-color/index.md
+++ b/files/ja/web/css/-webkit-text-stroke-color/index.md
@@ -1,15 +1,6 @@
 ---
 title: '-webkit-text-stroke-color'
 slug: Web/CSS/-webkit-text-stroke-color
-tags:
-  - CSS
-  - CSS プロパティ
-  - 標準外
-  - リファレンス
-  - WebKit
-  - recipe:css-property
-browser-compat: css.properties.-webkit-text-stroke-color
-translation_of: Web/CSS/-webkit-text-stroke-color
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/-webkit-text-stroke-width/index.md
+++ b/files/ja/web/css/-webkit-text-stroke-width/index.md
@@ -1,15 +1,6 @@
 ---
 title: '-webkit-text-stroke-width'
 slug: Web/CSS/-webkit-text-stroke-width
-tags:
-  - CSS
-  - CSS プロパティ
-  - 標準外
-  - リファレンス
-  - WebKit
-  - recipe:css-property
-browser-compat: css.properties.-webkit-text-stroke-width
-translation_of: Web/CSS/-webkit-text-stroke-width
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/-webkit-text-stroke/index.md
+++ b/files/ja/web/css/-webkit-text-stroke/index.md
@@ -1,15 +1,6 @@
 ---
 title: '-webkit-text-stroke'
 slug: Web/CSS/-webkit-text-stroke
-tags:
-  - CSS
-  - CSS プロパティ
-  - 標準外
-  - リファレンス
-  - WebKit
-  - recipe:css-shorthand-property
-browser-compat: css.properties.-webkit-text-stroke
-translation_of: Web/CSS/-webkit-text-stroke
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/-webkit-touch-callout/index.md
+++ b/files/ja/web/css/-webkit-touch-callout/index.md
@@ -1,17 +1,6 @@
 ---
 title: '-webkit-touch-callout'
 slug: Web/CSS/-webkit-touch-callout
-tags:
-  - CSS
-  - CSS プロパティ
-  - レイアウト
-  - NeedsLiveSample
-  - 標準外
-  - リファレンス
-  - WebKit
-  - recipe:css-property
-browser-compat: css.properties.-webkit-touch-callout
-translation_of: Web/CSS/-webkit-touch-callout
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/_colon_-moz-broken/index.md
+++ b/files/ja/web/css/_colon_-moz-broken/index.md
@@ -1,16 +1,6 @@
 ---
 title: ':-moz-broken'
 slug: Web/CSS/:-moz-broken
-tags:
-  - CSS
-  - CSS:Mozilla 拡張
-  - NeedsCompatTable
-  - 標準外
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.-moz-broken
-translation_of: 'Web/CSS/:-moz-broken'
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/_colon_-moz-drag-over/index.md
+++ b/files/ja/web/css/_colon_-moz-drag-over/index.md
@@ -1,18 +1,6 @@
 ---
 title: ':-moz-drag-over'
 slug: Web/CSS/:-moz-drag-over
-tags:
-  - CSS
-  - CSS:Mozilla 拡張
-  - Firefox
-  - Mozilla
-  - NeedsCompatTable
-  - 標準外
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors:-moz-drag-over
-translation_of: Web/CSS/:-moz-drag-over
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/_colon_-moz-first-node/index.md
+++ b/files/ja/web/css/_colon_-moz-first-node/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':-moz-first-node'
 slug: Web/CSS/:-moz-first-node
-tags:
-  - CSS
-  - CSS:Mozilla 拡張
-  - NeedsCompatTable
-  - 標準外
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-translation_of: Web/CSS/:-moz-first-node
 ---
 {{Non-standard_header}}{{CSSRef}}
 

--- a/files/ja/web/css/_colon_-moz-focusring/index.md
+++ b/files/ja/web/css/_colon_-moz-focusring/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':-moz-focusring'
 slug: Web/CSS/:-moz-focusring
-tags:
-  - CSS
-  - CSS:Mozilla 拡張
-  - 標準外
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.-moz-focusring
-translation_of: Web/CSS/:-moz-focusring
 ---
 {{Non-standard_header}}{{CSSRef}}
 

--- a/files/ja/web/css/_colon_-moz-last-node/index.md
+++ b/files/ja/web/css/_colon_-moz-last-node/index.md
@@ -1,14 +1,6 @@
 ---
 title: ':-moz-last-node'
 slug: Web/CSS/:-moz-last-node
-tags:
-  - CSS
-  - CSS:Mozilla 拡張
-  - NeedsCompatTable
-  - 標準外
-  - 擬似クラス
-  - セレクター
-translation_of: Web/CSS/:-moz-last-node
 ---
 {{Non-standard_header}}{{CSSRef}}
 

--- a/files/ja/web/css/_colon_-moz-list-bullet/index.md
+++ b/files/ja/web/css/_colon_-moz-list-bullet/index.md
@@ -1,15 +1,6 @@
 ---
 title: '::-moz-list-bullet'
 slug: Web/CSS/:-moz-list-bullet
-tags:
-  - CSS
-  - CSS:Mozilla Extensions
-  - NeedsCompatTable
-  - Non-standard
-  - Pseudo-element
-  - Reference
-  - Selector
-translation_of: Web/CSS/:-moz-list-bullet
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/_colon_-moz-loading/index.md
+++ b/files/ja/web/css/_colon_-moz-loading/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':-moz-loading'
 slug: Web/CSS/:-moz-loading
-tags:
-  - CSS
-  - CSS:Mozilla 拡張
-  - NeedsCompatTable
-  - 標準外
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-translation_of: Web/CSS/:-moz-loading
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/_colon_-moz-locale-dir(ltr)/index.md
+++ b/files/ja/web/css/_colon_-moz-locale-dir(ltr)/index.md
@@ -1,16 +1,6 @@
 ---
 title: ':-moz-locale-dir(ltr)'
-slug: 'Web/CSS/:-moz-locale-dir(ltr)'
-tags:
-  - CSS
-  - CSS:Mozilla 拡張
-  - ローカライズ
-  - NeedsCompatTable
-  - 標準外
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-translation_of: Web/CSS/:-moz-locale-dir(ltr)
+slug: Web/CSS/:-moz-locale-dir(ltr)
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/_colon_-moz-locale-dir(rtl)/index.md
+++ b/files/ja/web/css/_colon_-moz-locale-dir(rtl)/index.md
@@ -1,19 +1,6 @@
 ---
 title: ':-moz-locale-dir(rtl)'
 slug: Web/CSS/:-moz-locale-dir(rtl)
-tags:
-  - ':-moz-locale-dir'
-  - CSS
-  - CSS:Mozilla 拡張
-  - ローカライズ
-  - NeedsCompatTable
-  - NeedsExample
-  - 標準外
-  - 擬似クラス
-  - リファレンス
-  - 右書き
-  - セレクター
-translation_of: Web/CSS/:-moz-locale-dir(rtl)
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/_colon_-moz-only-whitespace/index.md
+++ b/files/ja/web/css/_colon_-moz-only-whitespace/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':-moz-only-whitespace'
 slug: Web/CSS/:-moz-only-whitespace
-tags:
-  - ':-moz-only-whitespace'
-  - CSS
-  - 標準外
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.-moz-only-whitespace
-translation_of: Web/CSS/:-moz-only-whitespace
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_-moz-submit-invalid/index.md
+++ b/files/ja/web/css/_colon_-moz-submit-invalid/index.md
@@ -1,16 +1,6 @@
 ---
 title: ':-moz-submit-invalid'
 slug: Web/CSS/:-moz-submit-invalid
-tags:
-  - ':-moz-submit-invalid'
-  - CSS
-  - CSS:Mozilla 拡張
-  - 標準外
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.-moz-submit-invalid
-translation_of: Web/CSS/:-moz-submit-invalid
 ---
 {{CSSRef}}{{Non-standard_Header}}
 

--- a/files/ja/web/css/_colon_active/index.md
+++ b/files/ja/web/css/_colon_active/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':active'
 slug: Web/CSS/:active
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.active
-translation_of: Web/CSS/:active
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_any-link/index.md
+++ b/files/ja/web/css/_colon_any-link/index.md
@@ -1,19 +1,6 @@
 ---
 title: ':any-link'
 slug: Web/CSS/:any-link
-tags:
-  - ':any-link'
-  - CSS
-  - 実験的
-  - レイアウト
-  - リンク
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-  - ハイパーリンク
-browser-compat: css.selectors.any-link
-translation_of: Web/CSS/:any-link
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_autofill/index.md
+++ b/files/ja/web/css/_colon_autofill/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':autofill'
 slug: Web/CSS/:autofill
-tags:
-  - CSS
-  - 標準外
-  - リファレンス
-  - 擬似クラス
-browser-compat: css.selectors.autofill
-translation_of: Web/CSS/:autofill
 original_slug: Web/CSS/:-webkit-autofill
 ---
 {{CSSRef}}

--- a/files/ja/web/css/_colon_blank/index.md
+++ b/files/ja/web/css/_colon_blank/index.md
@@ -1,18 +1,6 @@
 ---
 title: ':blank'
 slug: Web/CSS/:blank
-tags:
-  - ':blank'
-  - CSS
-  - CSS セレクター
-  - Draft
-  - Experimental
-  - NeedsContent
-  - NeedsExample
-  - 擬似クラス
-  - セレクター
-browser-compat: css.selectors.blank
-translation_of: Web/CSS/:blank
 ---
 {{CSSRef}}{{SeeCompatTable}}
 

--- a/files/ja/web/css/_colon_checked/index.md
+++ b/files/ja/web/css/_colon_checked/index.md
@@ -1,20 +1,6 @@
 ---
 title: ':checked'
 slug: Web/CSS/:checked
-tags:
-  - ':checked'
-  - CSS
-  - Checked
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - Toggled
-  - ウェブ
-  - button
-  - checkbox
-  - radio
-translation_of: Web/CSS/:checked
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_default/index.md
+++ b/files/ja/web/css/_colon_default/index.md
@@ -1,18 +1,6 @@
 ---
 title: ':default'
 slug: Web/CSS/:default
-tags:
-  - ':default'
-  - CSS
-  - フォーム
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-  - default
-browser-compat: css.selectors.default
-translation_of: Web/CSS/:default
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_defined/index.md
+++ b/files/ja/web/css/_colon_defined/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':defined'
 slug: Web/CSS/:defined
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.defined
-translation_of: Web/CSS/:defined
 ---
 {{ CSSRef }}
 

--- a/files/ja/web/css/_colon_dir/index.md
+++ b/files/ja/web/css/_colon_dir/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':dir()'
-slug: 'Web/CSS/:dir'
-tags:
-  - BiDi
-  - CSS
-  - 実験的
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.dir
-translation_of: 'Web/CSS/:dir'
+slug: Web/CSS/:dir
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_disabled/index.md
+++ b/files/ja/web/css/_colon_disabled/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':disabled'
 slug: Web/CSS/:disabled
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.disabled
-translation_of: Web/CSS/:disabled
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_empty/index.md
+++ b/files/ja/web/css/_colon_empty/index.md
@@ -1,16 +1,6 @@
 ---
 title: ':empty'
 slug: Web/CSS/:empty
-tags:
-  - CSS
-  - レイアウト
-  - NeedsUpdate
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.empty
-translation_of: Web/CSS/:empty
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_enabled/index.md
+++ b/files/ja/web/css/_colon_enabled/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':enabled'
 slug: Web/CSS/:enabled
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.enabled
-translation_of: Web/CSS/:enabled
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_first-child/index.md
+++ b/files/ja/web/css/_colon_first-child/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':first-child'
 slug: Web/CSS/:first-child
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.first-child
-translation_of: Web/CSS/:first-child
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_first-of-type/index.md
+++ b/files/ja/web/css/_colon_first-of-type/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':first-of-type'
 slug: Web/CSS/:first-of-type
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.first-of-type
-translation_of: Web/CSS/:first-of-type
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_first/index.md
+++ b/files/ja/web/css/_colon_first/index.md
@@ -1,16 +1,6 @@
 ---
 title: ':first'
 slug: Web/CSS/:first
-tags:
-  - '@page'
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - Reference
-  - セレクター
-  - Web
-browser-compat: css.selectors.first
-translation_of: Web/CSS/:first
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_focus-visible/index.md
+++ b/files/ja/web/css/_colon_focus-visible/index.md
@@ -1,16 +1,6 @@
 ---
 title: ':focus-visible'
-slug: 'Web/CSS/:focus-visible'
-tags:
-  - ':focus'
-  - ':focus-visible'
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-translation_of: 'Web/CSS/:focus-visible'
+slug: Web/CSS/:focus-visible
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_focus-within/index.md
+++ b/files/ja/web/css/_colon_focus-within/index.md
@@ -1,17 +1,6 @@
 ---
 title: ':focus-within'
-slug: 'Web/CSS/:focus-within'
-tags:
-  - ':focus'
-  - ':focus-within'
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.focus-within
-translation_of: 'Web/CSS/:focus-within'
+slug: Web/CSS/:focus-within
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_focus/index.md
+++ b/files/ja/web/css/_colon_focus/index.md
@@ -1,16 +1,6 @@
 ---
 title: ':focus'
-slug: 'Web/CSS/:focus'
-tags:
-  - ':focus'
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.focus
-translation_of: 'Web/CSS/:focus'
+slug: Web/CSS/:focus
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_fullscreen/index.md
+++ b/files/ja/web/css/_colon_fullscreen/index.md
@@ -1,18 +1,6 @@
 ---
 title: ':fullscreen'
 slug: Web/CSS/:fullscreen
-tags:
-  - CSS
-  - 全画面
-  - 全画面 API
-  - フルスクリーン API
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - fullscreen
-  - 画面
-browser-compat: css.selectors.fullscreen
-translation_of: Web/CSS/:fullscreen
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_has/index.md
+++ b/files/ja/web/css/_colon_has/index.md
@@ -1,16 +1,6 @@
 ---
 title: ':has()'
 slug: Web/CSS/:has
-tags:
-  - ':has'
-  - CSS
-  - 実験的
-  - リファレンス
-  - セレクター
-  - リファレンス
-  - 擬似クラス
-browser-compat: css.selectors.has
-translation_of: Web/CSS/:has
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_host/index.md
+++ b/files/ja/web/css/_colon_host/index.md
@@ -1,20 +1,6 @@
 ---
 title: ':host'
 slug: Web/CSS/:host
-tags:
-  - ':host'
-  - CSS
-  - DOM
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-  - ウェブコンポーネント
-  - shadow
-  - シャドウ DOM
-browser-compat: css.selectors.host
-translation_of: Web/CSS/:host
 ---
 {{ CSSRef }}
 

--- a/files/ja/web/css/_colon_host_function/index.md
+++ b/files/ja/web/css/_colon_host_function/index.md
@@ -1,17 +1,7 @@
 ---
 title: ':host()'
 slug: Web/CSS/:host_function
-tags:
-  - ':host()'
-  - CSS
-  - Layout
-  - Pseudo-class
-  - Reference
-  - Selector
-  - Web
-translation_of: Web/CSS/:host()
 original_slug: Web/CSS/:host()
-browser-compat: css.selectors.hostfunction
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_hover/index.md
+++ b/files/ja/web/css/_colon_hover/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':hover'
 slug: Web/CSS/:hover
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.hover
-translation_of: Web/CSS/:hover
 ---
 {{ CSSRef }}
 

--- a/files/ja/web/css/_colon_in-range/index.md
+++ b/files/ja/web/css/_colon_in-range/index.md
@@ -1,14 +1,6 @@
 ---
 title: ':in-range'
 slug: Web/CSS/:in-range
-tags:
-  - CSS
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.in-range
-translation_of: 'Web/CSS/:in-range'
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_indeterminate/index.md
+++ b/files/ja/web/css/_colon_indeterminate/index.md
@@ -1,19 +1,6 @@
 ---
 title: ':indeterminate'
 slug: Web/CSS/:indeterminate
-tags:
-  - ':indeterminate'
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-  - checkbox
-  - progress
-  - ラジオボタン
-browser-compat: css.selectors.indeterminate
-translation_of: Web/CSS/:indeterminate
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_invalid/index.md
+++ b/files/ja/web/css/_colon_invalid/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':invalid'
 slug: Web/CSS/:invalid
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.invalid
-translation_of: Web/CSS/:invalid
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_is/index.md
+++ b/files/ja/web/css/_colon_is/index.md
@@ -1,16 +1,6 @@
 ---
 title: ':is() (:matches(), :any())'
 slug: Web/CSS/:is
-tags:
-  - ':is'
-  - CSS
-  - 実験的
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.is
-translation_of: Web/CSS/:is
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_lang/index.md
+++ b/files/ja/web/css/_colon_lang/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':lang()'
 slug: Web/CSS/:lang
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.lang
-translation_of: Web/CSS/:lang
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_last-child/index.md
+++ b/files/ja/web/css/_colon_last-child/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':last-child'
 slug: Web/CSS/:last-child
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.last-child
-translation_of: Web/CSS/:last-child
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_last-of-type/index.md
+++ b/files/ja/web/css/_colon_last-of-type/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':last-of-type'
 slug: Web/CSS/:last-of-type
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.last-of-type
-translation_of: Web/CSS/:last-of-type
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_left/index.md
+++ b/files/ja/web/css/_colon_left/index.md
@@ -1,16 +1,6 @@
 ---
 title: ':left'
 slug: Web/CSS/:left
-tags:
-  - '@page'
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - Reference
-  - セレクター
-  - Web
-browser-compat: css.selectors.left
-translation_of: Web/CSS/:left
 ---
 {{ CSSRef() }}
 

--- a/files/ja/web/css/_colon_link/index.md
+++ b/files/ja/web/css/_colon_link/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':link'
 slug: Web/CSS/:link
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.link
-translation_of: Web/CSS/:link
 ---
 {{ CSSRef }}
 

--- a/files/ja/web/css/_colon_not/index.md
+++ b/files/ja/web/css/_colon_not/index.md
@@ -1,17 +1,6 @@
 ---
 title: ':not()'
 slug: Web/CSS/:not
-tags:
-  - ':not()'
-  - CSS
-  - レイアウト
-  - 否定
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.not
-translation_of: Web/CSS/:not
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_nth-child/index.md
+++ b/files/ja/web/css/_colon_nth-child/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':nth-child()'
 slug: Web/CSS/:nth-child
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.nth-child
-translation_of: Web/CSS/:nth-child
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_nth-last-child/index.md
+++ b/files/ja/web/css/_colon_nth-last-child/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':nth-last-child()'
 slug: Web/CSS/:nth-last-child
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.nth-last-child
-translation_of: Web/CSS/:nth-last-child
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_nth-last-of-type/index.md
+++ b/files/ja/web/css/_colon_nth-last-of-type/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':nth-last-of-type()'
 slug: Web/CSS/:nth-last-of-type
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.nth-last-of-type
-translation_of: Web/CSS/:nth-last-of-type
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_nth-of-type/index.md
+++ b/files/ja/web/css/_colon_nth-of-type/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':nth-of-type()'
 slug: Web/CSS/:nth-of-type
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.nth-of-type
-translation_of: Web/CSS/:nth-of-type
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_only-child/index.md
+++ b/files/ja/web/css/_colon_only-child/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':only-child'
 slug: Web/CSS/:only-child
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.only-child
-translation_of: Web/CSS/:only-child
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_only-of-type/index.md
+++ b/files/ja/web/css/_colon_only-of-type/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':only-of-type'
 slug: Web/CSS/:only-of-type
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.only-of-type
-translation_of: Web/CSS/:only-of-type
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_optional/index.md
+++ b/files/ja/web/css/_colon_optional/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':optional'
 slug: Web/CSS/:optional
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.optional
-translation_of: Web/CSS/:optional
 ---
 {{ CSSRef }}
 

--- a/files/ja/web/css/_colon_out-of-range/index.md
+++ b/files/ja/web/css/_colon_out-of-range/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':out-of-range'
 slug: Web/CSS/:out-of-range
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - UI セレクター
-browser-compat: css.selectors.out-of-range
-translation_of: Web/CSS/:out-of-range
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_paused/index.md
+++ b/files/ja/web/css/_colon_paused/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':paused'
 slug: Web/CSS/:paused
-tags:
-  - CSS
-  - 擬似クラス
-  - リファレンス
-  - paused
-browser-compat: css.selectors.paused
-translation_of: Web/CSS/:paused
 ---
 {{CSSRef}}{{SeeCompatTable}}
 

--- a/files/ja/web/css/_colon_picture-in-picture/index.md
+++ b/files/ja/web/css/_colon_picture-in-picture/index.md
@@ -1,17 +1,6 @@
 ---
 title: ':picture-in-picture'
 slug: Web/CSS/:picture-in-picture
-tags:
-  - CSS
-  - Picture-in-Picture
-  - Picture-in-Picture API
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - 動画
-  - pip
-browser-compat: css.selectors.picture-in-picture
-translation_of: Web/CSS/:picture-in-picture
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_placeholder-shown/index.md
+++ b/files/ja/web/css/_colon_placeholder-shown/index.md
@@ -1,14 +1,6 @@
 ---
 title: ':placeholder-shown'
 slug: Web/CSS/:placeholder-shown
-tags:
-  - ':placeholder-shown'
-  - CSS
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.placeholder-shown
-translation_of: Web/CSS/:placeholder-shown
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_playing/index.md
+++ b/files/ja/web/css/_colon_playing/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':playing'
 slug: Web/CSS/:playing
-tags:
-  - CSS
-  - 擬似クラス
-  - リファレンス
-  - playing
-browser-compat: css.selectors.playing
-translation_of: Web/CSS/:playing
 ---
 {{CSSRef}}{{SeeCompatTable}}
 

--- a/files/ja/web/css/_colon_read-only/index.md
+++ b/files/ja/web/css/_colon_read-only/index.md
@@ -1,16 +1,6 @@
 ---
 title: ':read-only'
 slug: Web/CSS/:read-only
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - 読み取り専用
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.read-only
-translation_of: Web/CSS/:read-only
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_read-write/index.md
+++ b/files/ja/web/css/_colon_read-write/index.md
@@ -1,16 +1,6 @@
 ---
 title: ':read-write'
 slug: Web/CSS/:read-write
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-  - read-write
-browser-compat: css.selectors.read-write
-translation_of: Web/CSS/:read-write
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_required/index.md
+++ b/files/ja/web/css/_colon_required/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':required'
 slug: Web/CSS/:required
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.required
-translation_of: Web/CSS/:required
 ---
 {{ CSSRef }}
 

--- a/files/ja/web/css/_colon_right/index.md
+++ b/files/ja/web/css/_colon_right/index.md
@@ -1,16 +1,6 @@
 ---
 title: ':right'
 slug: Web/CSS/:right
-tags:
-  - '@page'
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - Reference
-  - セレクター
-  - Web
-browser-compat: css.selectors.right
-translation_of: Web/CSS/:right
 ---
 {{ CSSRef() }}
 

--- a/files/ja/web/css/_colon_root/index.md
+++ b/files/ja/web/css/_colon_root/index.md
@@ -1,18 +1,6 @@
 ---
 title: ':root'
 slug: Web/CSS/:root
-tags:
-  - CSS
-  - 要素
-  - レイアウト
-  - ノード
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-  - root
-browser-compat: css.selectors.root
-translation_of: Web/CSS/:root
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_scope/index.md
+++ b/files/ja/web/css/_colon_scope/index.md
@@ -1,17 +1,6 @@
 ---
 title: ':scope'
 slug: Web/CSS/:scope
-tags:
-  - ':scope'
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - スコープ付き要素
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.scope
-translation_of: Web/CSS/:scope
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_target/index.md
+++ b/files/ja/web/css/_colon_target/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':target'
 slug: Web/CSS/:target
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.target
-translation_of: Web/CSS/:target
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_user-invalid/index.md
+++ b/files/ja/web/css/_colon_user-invalid/index.md
@@ -1,14 +1,6 @@
 ---
 title: ':user-invalid (:-moz-ui-invalid)'
 slug: Web/CSS/:user-invalid
-tags:
-  - CSS
-  - CSS Selectors
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.user-invalid
-translation_of: Web/CSS/:user-invalid
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_user-valid/index.md
+++ b/files/ja/web/css/_colon_user-valid/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':user-valid (:-moz-ui-valid)'
 slug: web/css/:user-valid
-tags:
-  - CSS
-  - CSS Selectors
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.user-valid
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_valid/index.md
+++ b/files/ja/web/css/_colon_valid/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':valid'
 slug: Web/CSS/:valid
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.valid
-translation_of: Web/CSS/:valid
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_visited/index.md
+++ b/files/ja/web/css/_colon_visited/index.md
@@ -1,14 +1,6 @@
 ---
 title: ':visited'
 slug: Web/CSS/:visited
-tags:
-  - CSS
-  - レイアウト
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-translation_of: Web/CSS/:visited
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_colon_where/index.md
+++ b/files/ja/web/css/_colon_where/index.md
@@ -1,19 +1,6 @@
 ---
 title: ':where()'
 slug: Web/CSS/:where
-tags:
-  - ':where'
-  - CSS
-  - 実験的
-  - NeedsBrowserCompatibility
-  - NeedsContent
-  - NeedsExample
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.where
-translation_of: Web/CSS/:where
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_doublecolon_-moz-color-swatch/index.md
+++ b/files/ja/web/css/_doublecolon_-moz-color-swatch/index.md
@@ -1,15 +1,6 @@
 ---
 title: '::-moz-color-swatch'
 slug: Web/CSS/::-moz-color-swatch
-tags:
-  - CSS
-  - CSS:Mozilla 拡張
-  - 標準外
-  - 擬似要素
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.-moz-color-swatch
-translation_of: Web/CSS/::-moz-color-swatch
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/_doublecolon_-moz-progress-bar/index.md
+++ b/files/ja/web/css/_doublecolon_-moz-progress-bar/index.md
@@ -1,15 +1,6 @@
 ---
 title: '::-moz-progress-bar'
 slug: Web/CSS/::-moz-progress-bar
-tags:
-  - CSS
-  - CSS:Mozilla 拡張
-  - NeedsCompatTable
-  - 標準外
-  - 擬似要素
-  - リファレンス
-  - セレクター
-translation_of: Web/CSS/::-moz-progress-bar
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/_doublecolon_-moz-range-track/index.md
+++ b/files/ja/web/css/_doublecolon_-moz-range-track/index.md
@@ -1,14 +1,6 @@
 ---
 title: '::-moz-range-track'
 slug: Web/CSS/::-moz-range-track
-tags:
-  - CSS
-  - CSS:Mozilla 拡張
-  - 標準外
-  - 擬似要素
-  - リファレンス
-  - セレクター
-translation_of: Web/CSS/::-moz-range-track
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/_doublecolon_-webkit-progress-value/index.md
+++ b/files/ja/web/css/_doublecolon_-webkit-progress-value/index.md
@@ -1,14 +1,6 @@
 ---
 title: '::-webkit-progress-value'
 slug: Web/CSS/::-webkit-progress-value
-tags:
-  - CSS
-  - 標準外
-  - 擬似要素
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.-webkit-progress-value
-translation_of: Web/CSS/::-webkit-progress-value
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/_doublecolon_-webkit-slider-runnable-track/index.md
+++ b/files/ja/web/css/_doublecolon_-webkit-slider-runnable-track/index.md
@@ -1,19 +1,6 @@
 ---
 title: '::-webkit-slider-runnable-track'
 slug: Web/CSS/::-webkit-slider-runnable-track
-tags:
-  - CSS
-  - CSS:WebKit 拡張
-  - NeedsBrowserCompatibility
-  - NeedsCompatTable
-  - NeedsExample
-  - NeedsMobileBrowserCompatibility
-  - 標準外
-  - 擬似要素
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.-webkit-slider-runnable-track
-translation_of: Web/CSS/::-webkit-slider-runnable-track
 ---
 {{CSSRef}}{{Non-standard_Header}}
 

--- a/files/ja/web/css/_doublecolon_-webkit-slider-thumb/index.md
+++ b/files/ja/web/css/_doublecolon_-webkit-slider-thumb/index.md
@@ -1,18 +1,6 @@
 ---
 title: '::-webkit-slider-thumb'
 slug: Web/CSS/::-webkit-slider-thumb
-tags:
-  - CSS
-  - NeedsBrowserCompatibility
-  - NeedsCompatTable
-  - NeedsExample
-  - NeedsMobileBrowserCompatibility
-  - 標準外
-  - 擬似要素
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.-webkit-slider-thumb
-translation_of: 'Web/CSS/::-webkit-slider-thumb'
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/_doublecolon_after/index.md
+++ b/files/ja/web/css/_doublecolon_after/index.md
@@ -1,15 +1,6 @@
 ---
 title: '::after (:after)'
 slug: Web/CSS/::after
-tags:
-  - CSS
-  - レイアウト
-  - 擬似要素
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.after
-translation_of: Web/CSS/::after
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_doublecolon_backdrop/index.md
+++ b/files/ja/web/css/_doublecolon_backdrop/index.md
@@ -1,20 +1,6 @@
 ---
 title: '::backdrop'
 slug: Web/CSS/::backdrop
-tags:
-  - API
-  - CSS
-  - ダイアログ
-  - 全画面
-  - Fullscreen API
-  - HTML DOM
-  - レイアウト
-  - 擬似要素
-  - リファレンス
-  - セレクター
-  - フルスクリーン
-browser-compat: css.selectors.backdrop
-translation_of: Web/CSS/::backdrop
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_doublecolon_before/index.md
+++ b/files/ja/web/css/_doublecolon_before/index.md
@@ -1,15 +1,6 @@
 ---
 title: '::before (:before)'
 slug: Web/CSS/::before
-tags:
-  - CSS
-  - レイアウト
-  - 擬似要素
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.before
-translation_of: 'Web/CSS/::before'
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_doublecolon_cue-region/index.md
+++ b/files/ja/web/css/_doublecolon_cue-region/index.md
@@ -1,16 +1,6 @@
 ---
 title: '::cue-region'
 slug: Web/CSS/::cue-region
-tags:
-  - '::cue-region'
-  - CSS
-  - メディア
-  - 擬似要素
-  - リファレンス
-  - セレクター
-  - Web Video Text Tracks
-  - WebVTT
-browser-compat: css.selectors.cue-region
 ---
 {{CSSRef}}{{SeeCompatTable}}
 

--- a/files/ja/web/css/_doublecolon_cue/index.md
+++ b/files/ja/web/css/_doublecolon_cue/index.md
@@ -1,18 +1,6 @@
 ---
 title: '::cue'
 slug: Web/CSS/::cue
-tags:
-  - '::cue'
-  - CSS
-  - メディア
-  - 擬似要素
-  - リファレンス
-  - セレクター
-  - ウェブ動画テキストトラック
-  - WebVTT
-  - cue
-browser-compat: css.selectors.cue
-translation_of: Web/CSS/::cue
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_doublecolon_first-letter/index.md
+++ b/files/ja/web/css/_doublecolon_first-letter/index.md
@@ -1,14 +1,6 @@
 ---
 title: '::first-letter (:first-letter)'
 slug: Web/CSS/::first-letter
-tags:
-  - CSS
-  - レイアウト
-  - 擬似要素
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.first-letter
-translation_of: Web/CSS/::first-letter
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_doublecolon_first-line/index.md
+++ b/files/ja/web/css/_doublecolon_first-line/index.md
@@ -1,14 +1,6 @@
 ---
 title: '::first-line (:first-line)'
 slug: Web/CSS/::first-line
-tags:
-  - CSS
-  - レイアウト
-  - 擬似要素
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.first-line
-translation_of: Web/CSS/::first-line
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_doublecolon_grammar-error/index.md
+++ b/files/ja/web/css/_doublecolon_grammar-error/index.md
@@ -1,14 +1,6 @@
 ---
 title: '::grammar-error'
 slug: Web/CSS/::grammar-error
-tags:
-  - CSS
-  - 実験的
-  - 擬似要素
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.grammar-error
-translation_of: Web/CSS/::grammar-error
 ---
 {{CSSRef}}{{SeeCompatTable}}
 

--- a/files/ja/web/css/_doublecolon_marker/index.md
+++ b/files/ja/web/css/_doublecolon_marker/index.md
@@ -1,16 +1,6 @@
 ---
 title: '::marker'
 slug: Web/CSS/::marker
-tags:
-  - CSS
-  - CSS リスト
-  - 実験的
-  - レイアウト
-  - 擬似要素
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.marker
-translation_of: Web/CSS/::marker
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_doublecolon_part/index.md
+++ b/files/ja/web/css/_doublecolon_part/index.md
@@ -1,18 +1,6 @@
 ---
 title: '::part()'
 slug: Web/CSS/::part
-tags:
-  - '::part'
-  - CSS
-  - Draft
-  - 実験的
-  - NeedsBrowserCompatibility
-  - NeedsExample
-  - 擬似要素
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.part
-translation_of: Web/CSS/::part
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_doublecolon_placeholder/index.md
+++ b/files/ja/web/css/_doublecolon_placeholder/index.md
@@ -1,14 +1,6 @@
 ---
 title: '::placeholder'
 slug: Web/CSS/::placeholder
-tags:
-  - '::placeholder'
-  - CSS
-  - 擬似要素
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.placeholder
-translation_of: Web/CSS/::placeholder
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_doublecolon_selection/index.md
+++ b/files/ja/web/css/_doublecolon_selection/index.md
@@ -1,14 +1,6 @@
 ---
 title: '::selection'
 slug: Web/CSS/::selection
-tags:
-  - CSS
-  - レイアウト
-  - 擬似要素
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.selection
-translation_of: Web/CSS/::selection
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/_doublecolon_slotted/index.md
+++ b/files/ja/web/css/_doublecolon_slotted/index.md
@@ -1,16 +1,6 @@
 ---
 title: '::slotted()'
 slug: Web/CSS/::slotted
-tags:
-  - '::slotted'
-  - CSS
-  - レイアウト
-  - 擬似要素
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.slotted
-translation_of: Web/CSS/::slotted
 ---
 {{ CSSRef }}
 

--- a/files/ja/web/css/_doublecolon_spelling-error/index.md
+++ b/files/ja/web/css/_doublecolon_spelling-error/index.md
@@ -1,15 +1,6 @@
 ---
 title: '::spelling-error'
 slug: Web/CSS/::spelling-error
-tags:
-  - CSS
-  - 実験的
-  - 擬似要素
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.spelling-error
-translation_of: Web/CSS/::spelling-error
 ---
 {{CSSRef}}{{SeeCompatTable}}
 

--- a/files/ja/web/css/_doublecolon_target-text/index.md
+++ b/files/ja/web/css/_doublecolon_target-text/index.md
@@ -1,15 +1,6 @@
 ---
 title: '::target-text'
 slug: Web/CSS/::target-text
-tags:
-  - '::target-text'
-  - CSS
-  - 擬似要素
-  - リファレンス
-  - セレクター
-  - ウェブ
-browser-compat: css.selectors.target-text
-translation_of: Web/CSS/::target-text
 ---
 {{CSSRef}}{{SeeCompatTable}}
 

--- a/files/ja/web/css/accent-color/index.md
+++ b/files/ja/web/css/accent-color/index.md
@@ -1,18 +1,6 @@
 ---
 title: accent-color
 slug: Web/CSS/accent-color
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS ユーザーインターフェイス
-  - HTML 色
-  - Input
-  - リファレンス
-  - HTML 整形
-  - accent-color
-  - recipe:css-property
-browser-compat: css.properties.accent-color
-translation_of: Web/CSS/accent-color
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/actual_value/index.md
+++ b/files/ja/web/css/actual_value/index.md
@@ -1,12 +1,6 @@
 ---
 title: 実効値
 slug: Web/CSS/actual_value
-tags:
-  - CSS
-  - Guide
-  - Reference
-spec-urls: https://www.w3.org/TR/CSS22/cascade.html#actual-value
-translation_of: Web/CSS/actual_value
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/adjacent_sibling_combinator/index.md
+++ b/files/ja/web/css/adjacent_sibling_combinator/index.md
@@ -1,13 +1,6 @@
 ---
 title: 隣接兄弟結合子
 slug: Web/CSS/Adjacent_sibling_combinator
-tags:
-  - CSS
-  - NeedsMobileBrowserCompatibility
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.adjacent_sibling
-translation_of: Web/CSS/Adjacent_sibling_combinator
 ---
 {{CSSRef("Selectors")}}
 

--- a/files/ja/web/css/align-content/index.md
+++ b/files/ja/web/css/align-content/index.md
@@ -1,14 +1,6 @@
 ---
 title: align-content
 slug: Web/CSS/align-content
-tags:
-  - CSS
-  - CSS ボックス配置
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.align-content
-translation_of: Web/CSS/align-content
 ---
 [CSS](/ja/docs/Web/CSS) の **`align-content`** プロパティは、[フレックスボックス](/ja/docs/Web/CSS/CSS_Flexible_Box_Layout)の交差軸または[グリッド](/ja/docs/Web/CSS/CSS_Grid_Layout)のブロック軸方向の内部のアイテムの間または周囲の空間の配分方法を設定します。
 

--- a/files/ja/web/css/align-items/index.md
+++ b/files/ja/web/css/align-items/index.md
@@ -1,14 +1,6 @@
 ---
 title: align-items
 slug: Web/CSS/align-items
-tags:
-  - CSS
-  - CSS フレックスボックス
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.align-items
-translation_of: Web/CSS/align-items
 ---
 [CSS](/ja/docs/Web/CSS) の **`align-items`** プロパティは、すべての直接の子要素に集合として {{cssxref("align-self")}} の値を設定します。フレックスボックスでは{{glossary("Cross Axis", "交差軸")}}方向のアイテムの配置を制御します。グリッドレイアウトでは、{{glossary("Grid Areas", "グリッド領域")}}におけるアイテムのブロック軸方向の配置を制御します。
 

--- a/files/ja/web/css/align-self/index.md
+++ b/files/ja/web/css/align-self/index.md
@@ -1,15 +1,6 @@
 ---
 title: align-self
 slug: Web/CSS/align-self
-tags:
-  - CSS
-  - CSS ボックス配置
-  - CSS フレックスボックス
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.align-self
-translation_of: Web/CSS/align-self
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/align-tracks/index.md
+++ b/files/ja/web/css/align-tracks/index.md
@@ -1,16 +1,6 @@
 ---
 title: align-tracks
 slug: Web/CSS/align-tracks
-tags:
-  - CSS
-  - 実験的
-  - プロパティ
-  - リファレンス
-  - align-tracks
-  - grid
-  - masonry
-browser-compat: css.properties.align-tracks
-translation_of: Web/CSS/align-tracks
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/all/index.md
+++ b/files/ja/web/css/all/index.md
@@ -1,14 +1,6 @@
 ---
 title: all
 slug: Web/CSS/all
-tags:
-  - CSS
-  - CSS カスケードと継承
-  - CSS プロパティ
-  - リファレンス
-  - all
-browser-compat: css.properties.all
-translation_of: Web/CSS/all
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/alpha-value/index.md
+++ b/files/ja/web/css/alpha-value/index.md
@@ -1,18 +1,6 @@
 ---
 title: <alpha-value>
 slug: Web/CSS/alpha-value
-tags:
-  - Alpha
-  - Alpha-value
-  - CSS
-  - CSS データ型
-  - CSS リファレンス
-  - データ型
-  - Example
-  - リファレンス
-  - 色
-spec-urls: https://drafts.csswg.org/css-color/#type-def-alpha-value
-translation_of: Web/CSS/alpha-value
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/alternative_style_sheets/index.md
+++ b/files/ja/web/css/alternative_style_sheets/index.md
@@ -1,15 +1,6 @@
 ---
 title: 代替スタイルシート
 slug: Web/CSS/Alternative_style_sheets
-tags:
-  - CSS
-  - Guide
-  - HTML
-  - NeedsCompatTable
-  - NeedsUpdate
-  - Reference
-  - ガイド
-translation_of: Web/CSS/Alternative_style_sheets
 ---
 {{cssref}}
 

--- a/files/ja/web/css/angle-percentage/index.md
+++ b/files/ja/web/css/angle-percentage/index.md
@@ -1,15 +1,6 @@
 ---
 title: <angle-percentage>
 slug: Web/CSS/angle-percentage
-tags:
-  - CSS
-  - CSS データ型
-  - データ型
-  - リファレンス
-  - angle-percentage
-  - 単位
-  - 値
-translation_of: Web/CSS/angle-percentage
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/angle/index.md
+++ b/files/ja/web/css/angle/index.md
@@ -1,16 +1,6 @@
 ---
 title: <angle>
 slug: Web/CSS/angle
-tags:
-  - CSS
-  - CSS データ型
-  - データ型
-  - レイアウト
-  - リファレンス
-  - ウェブ
-  - angle
-browser-compat: css.types.angle
-translation_of: Web/CSS/angle
 ---
 {{ CSSRef() }}
 

--- a/files/ja/web/css/animation-delay/index.md
+++ b/files/ja/web/css/animation-delay/index.md
@@ -1,14 +1,6 @@
 ---
 title: animation-delay
 slug: Web/CSS/animation-delay
-tags:
-  - CSS
-  - CSS アニメーション
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.animation-delay
-translation_of: Web/CSS/animation-delay
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/animation-direction/index.md
+++ b/files/ja/web/css/animation-direction/index.md
@@ -1,14 +1,6 @@
 ---
 title: animation-direction
 slug: Web/CSS/animation-direction
-tags:
-  - CSS
-  - CSS アニメーション
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.animation-direction
-translation_of: Web/CSS/animation-direction
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/animation-duration/index.md
+++ b/files/ja/web/css/animation-duration/index.md
@@ -1,15 +1,6 @@
 ---
 title: animation-duration
 slug: Web/CSS/animation-duration
-tags:
-  - アニメーション
-  - CSS
-  - CSS アニメーション
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.animation-duration
-translation_of: Web/CSS/animation-duration
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/animation-fill-mode/index.md
+++ b/files/ja/web/css/animation-fill-mode/index.md
@@ -1,14 +1,6 @@
 ---
 title: animation-fill-mode
 slug: Web/CSS/animation-fill-mode
-tags:
-  - CSS
-  - CSS アニメーション
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.animation-fill-mode
-translation_of: Web/CSS/animation-fill-mode
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/animation-iteration-count/index.md
+++ b/files/ja/web/css/animation-iteration-count/index.md
@@ -1,14 +1,6 @@
 ---
 title: animation-iteration-count
 slug: Web/CSS/animation-iteration-count
-tags:
-  - CSS
-  - CSS アニメーション
-  - CSS プロパティ
-  - CSS プロパティアニメーション
-  - recipe:css-property
-browser-compat: css.properties.animation-iteration-count
-translation_of: Web/CSS/animation-iteration-count
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/animation-name/index.md
+++ b/files/ja/web/css/animation-name/index.md
@@ -1,14 +1,6 @@
 ---
 title: animation-name
 slug: Web/CSS/animation-name
-tags:
-  - CSS
-  - CSS アニメーション
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.animation-name
-translation_of: Web/CSS/animation-name
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/animation-play-state/index.md
+++ b/files/ja/web/css/animation-play-state/index.md
@@ -1,12 +1,6 @@
 ---
 title: animation-play-state
 slug: Web/CSS/animation-play-state
-tags:
-  - CSS
-  - CSS アニメーション
-  - CSS プロパティ
-  - リファレンス
-translation_of: Web/CSS/animation-play-state
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/animation-timeline/index.md
+++ b/files/ja/web/css/animation-timeline/index.md
@@ -1,14 +1,6 @@
 ---
 title: animation-timeline
 slug: Web/CSS/animation-timeline
-tags:
-  - CSS
-  - CSS アニメーション
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.animation-timeline
-translation_of: Web/CSS/animation-timeline
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/animation-timing-function/index.md
+++ b/files/ja/web/css/animation-timing-function/index.md
@@ -1,14 +1,6 @@
 ---
 title: animation-timing-function
 slug: Web/CSS/animation-timing-function
-tags:
-  - CSS
-  - CSS アニメーション
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.animation-timing-function
-translation_of: Web/CSS/animation-timing-function
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/animation/index.md
+++ b/files/ja/web/css/animation/index.md
@@ -1,14 +1,6 @@
 ---
 title: animation
 slug: Web/CSS/animation
-tags:
-  - CSS
-  - CSS アニメーション
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.animation
-translation_of: Web/CSS/animation
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/appearance/index.md
+++ b/files/ja/web/css/appearance/index.md
@@ -1,17 +1,6 @@
 ---
 title: appearance (-moz-appearance, -webkit-appearance)
 slug: Web/CSS/appearance
-tags:
-  - '-moz-appearance'
-  - '-webkit-appearance'
-  - CSS
-  - CSS プロパティ
-  - CSS 基本ユーザーインターフェイス
-  - Reference
-  - appearance
-  - recipe:css-property
-browser-compat: css.properties.appearance
-translation_of: Web/CSS/appearance
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/aspect-ratio/index.md
+++ b/files/ja/web/css/aspect-ratio/index.md
@@ -1,15 +1,6 @@
 ---
 title: aspect-ratio
 slug: Web/CSS/aspect-ratio
-tags:
-  - CSS
-  - CSS プロパティ
-  - 画像
-  - リファレンス
-  - aspect-ratio
-  - recipe:css-property
-browser-compat: css.properties.aspect-ratio
-translation_of: Web/CSS/aspect-ratio
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/at-rule/index.md
+++ b/files/ja/web/css/at-rule/index.md
@@ -1,14 +1,6 @@
 ---
 title: アットルール
 slug: Web/CSS/At-rule
-tags:
-  - CSS
-  - Guide
-  - Reference
-spec-urls:
-  - https://drafts.csswg.org/css-conditional-3/
-  - https://compat.spec.whatwg.org/#css-at-rules
-translation_of: Web/CSS/At-rule
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/attr/index.md
+++ b/files/ja/web/css/attr/index.md
@@ -1,17 +1,7 @@
 ---
 title: attr()
 slug: Web/CSS/attr
-tags:
-  - CSS
-  - CSS 関数
-  - 関数
-  - レイアウト
-  - リファレンス
-  - ウェブ
-  - attr
-translation_of: Web/CSS/attr()
 original_slug: Web/CSS/attr()
-browser-compat: css.types.attr
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/attribute_selectors/index.md
+++ b/files/ja/web/css/attribute_selectors/index.md
@@ -1,13 +1,6 @@
 ---
 title: 属性セレクター
 slug: Web/CSS/Attribute_selectors
-tags:
-  - 属性セレクター
-  - CSS
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.attribute
-translation_of: Web/CSS/Attribute_selectors
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/backdrop-filter/index.md
+++ b/files/ja/web/css/backdrop-filter/index.md
@@ -1,19 +1,6 @@
 ---
 title: backdrop-filter
 slug: Web/CSS/backdrop-filter
-tags:
-  - CSS
-  - CSS プロパティ
-  - グラフィック
-  - レイアウト
-  - NeedsContent
-  - リファレンス
-  - SVG
-  - SVG フィルター
-  - ウェブ
-  - recipe:css-property
-browser-compat: css.properties.backdrop-filter
-translation_of: Web/CSS/backdrop-filter
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/backface-visibility/index.md
+++ b/files/ja/web/css/backface-visibility/index.md
@@ -1,14 +1,6 @@
 ---
 title: backface-visibility
 slug: Web/CSS/backface-visibility
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS 座標変換
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.backface-visibility
-translation_of: Web/CSS/backface-visibility
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/background-attachment/index.md
+++ b/files/ja/web/css/background-attachment/index.md
@@ -1,14 +1,6 @@
 ---
 title: background-attachment
 slug: Web/CSS/background-attachment
-tags:
-  - CSS
-  - CSS 背景
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.background-attachment
-translation_of: Web/CSS/background-attachment
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/background-blend-mode/index.md
+++ b/files/ja/web/css/background-blend-mode/index.md
@@ -1,13 +1,6 @@
 ---
 title: background-blend-mode
 slug: Web/CSS/background-blend-mode
-tags:
-  - CSS
-  - CSS プロパティ
-  - 合成と混合
-  - recipe:css-property
-browser-compat: css.properties.background-blend-mode
-translation_of: Web/CSS/background-blend-mode
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/background-clip/index.md
+++ b/files/ja/web/css/background-clip/index.md
@@ -1,14 +1,6 @@
 ---
 title: background-clip
 slug: Web/CSS/background-clip
-tags:
-  - CSS
-  - CSS 背景
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.background-clip
-translation_of: Web/CSS/background-clip
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/background-color/index.md
+++ b/files/ja/web/css/background-color/index.md
@@ -1,21 +1,6 @@
 ---
 title: background-color
 slug: Web/CSS/background-color
-tags:
-  - CSS
-  - CSS 背景
-  - CSS プロパティ
-  - グラフィック
-  - HTML 色
-  - HTML スタイル
-  - レイアウト
-  - リファレンス
-  - スタイル
-  - Styling HTML
-  - background-color
-  - recipe:css-property
-browser-compat: css.properties.background-color
-translation_of: Web/CSS/background-color
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/background-image/index.md
+++ b/files/ja/web/css/background-image/index.md
@@ -1,14 +1,6 @@
 ---
 title: background-image
 slug: Web/CSS/background-image
-tags:
-  - CSS
-  - CSS 背景
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.background-image
-translation_of: Web/CSS/background-image
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/background-origin/index.md
+++ b/files/ja/web/css/background-origin/index.md
@@ -1,14 +1,6 @@
 ---
 title: background-origin
 slug: Web/CSS/background-origin
-tags:
-  - CSS
-  - CSS 背景
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.background-origin
-translation_of: Web/CSS/background-origin
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/background-position-x/index.md
+++ b/files/ja/web/css/background-position-x/index.md
@@ -1,15 +1,6 @@
 ---
 title: background-position-x
 slug: Web/CSS/background-position-x
-tags:
-  - CSS
-  - CSS 背景
-  - CSS プロパティ
-  - Experimental
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.background-position-x
-translation_of: Web/CSS/background-position-x
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/background-position-y/index.md
+++ b/files/ja/web/css/background-position-y/index.md
@@ -1,15 +1,6 @@
 ---
 title: background-position-y
 slug: Web/CSS/background-position-y
-tags:
-  - CSS
-  - CSS 背景
-  - CSS プロパティ
-  - Experimental
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.background-position-y
-translation_of: Web/CSS/background-position-y
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/background-position/index.md
+++ b/files/ja/web/css/background-position/index.md
@@ -1,14 +1,6 @@
 ---
 title: background-position
 slug: Web/CSS/background-position
-tags:
-  - CSS
-  - CSS 背景
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.background-position
-translation_of: Web/CSS/background-position
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/background-repeat/index.md
+++ b/files/ja/web/css/background-repeat/index.md
@@ -1,14 +1,6 @@
 ---
 title: background-repeat
 slug: Web/CSS/background-repeat
-tags:
-  - CSS
-  - CSS 背景
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.background-repeat
-translation_of: Web/CSS/background-repeat
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/background-size/index.md
+++ b/files/ja/web/css/background-size/index.md
@@ -1,14 +1,6 @@
 ---
 title: background-size
 slug: Web/CSS/background-size
-tags:
-  - CSS
-  - CSS 背景
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.background-size
-translation_of: Web/CSS/background-size
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/background/index.md
+++ b/files/ja/web/css/background/index.md
@@ -1,14 +1,6 @@
 ---
 title: background
 slug: Web/CSS/background
-tags:
-  - CSS
-  - CSS 背景
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.background
-translation_of: Web/CSS/background
 ---
 {{CSSRef("CSS Background")}}
 

--- a/files/ja/web/css/basic-shape/circle/index.md
+++ b/files/ja/web/css/basic-shape/circle/index.md
@@ -1,17 +1,7 @@
 ---
 title: circle()
 slug: Web/CSS/basic-shape/circle
-tags:
-  - CSS
-  - CSS データ型
-  - CSS シェイプ
-  - circle
-  - CSS 関数
-  - データ型
-  - Reference
-translation_of: Web/CSS/basic-shape/circle()
 original_slug: Web/CSS/basic-shape/circle()
-browser-compat: css.types.basic-shape.circle
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/basic-shape/ellipse/index.md
+++ b/files/ja/web/css/basic-shape/ellipse/index.md
@@ -1,17 +1,7 @@
 ---
 title: ellipse()
 slug: Web/CSS/basic-shape/ellipse
-tags:
-  - CSS
-  - CSS データ型
-  - CSS シェイプ
-  - ellipse
-  - CSS 関数
-  - データ型
-  - Reference
-translation_of: Web/CSS/basic-shape/ellipse()
 original_slug: Web/CSS/basic-shape/ellipse()
-browser-compat: css.types.basic-shape.ellipse
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/basic-shape/index.md
+++ b/files/ja/web/css/basic-shape/index.md
@@ -1,12 +1,6 @@
 ---
 title: <basic-shape>
 slug: Web/CSS/basic-shape
-tags:
-  - CSS
-  - CSS シェイプ
-  - CSS データ型
-  - リファレンス
-translation_of: Web/CSS/basic-shape
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/basic-shape/inset/index.md
+++ b/files/ja/web/css/basic-shape/inset/index.md
@@ -1,17 +1,7 @@
 ---
 title: inset()
 slug: Web/CSS/basic-shape/inset
-tags:
-  - CSS
-  - CSS データ型
-  - CSS シェイプ
-  - inset
-  - CSS 関数
-  - データ型
-  - Reference
-translation_of: Web/CSS/basic-shape/inset()
 original_slug: Web/CSS/basic-shape/inset()
-browser-compat: css.types.basic-shape.inset
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/basic-shape/polygon/index.md
+++ b/files/ja/web/css/basic-shape/polygon/index.md
@@ -1,17 +1,7 @@
 ---
 title: polygon()
 slug: Web/CSS/basic-shape/polygon
-tags:
-  - CSS
-  - CSS データ型
-  - CSS シェイプ
-  - polygon
-  - CSS 関数
-  - データ型
-  - Reference
-translation_of: Web/CSS/basic-shape/polygon()
 original_slug: Web/CSS/basic-shape/polygon()
-browser-compat: css.types.basic-shape.polygon
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/blend-mode/index.md
+++ b/files/ja/web/css/blend-mode/index.md
@@ -1,17 +1,6 @@
 ---
 title: <blend-mode>
 slug: Web/CSS/blend-mode
-tags:
-  - 混合モード
-  - CSS
-  - CSS Data Type
-  - 合成
-  - Compositing and Blending
-  - Data Type
-  - Reference
-  - color
-browser-compat: css.types.blend-mode
-translation_of: Web/CSS/blend-mode
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/block-size/index.md
+++ b/files/ja/web/css/block-size/index.md
@@ -1,15 +1,6 @@
 ---
 title: block-size
 slug: Web/CSS/block-size
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - Experimental
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.block-size
-translation_of: Web/CSS/block-size
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-block-color/index.md
+++ b/files/ja/web/css/border-block-color/index.md
@@ -1,15 +1,6 @@
 ---
 title: border-block-color
 slug: Web/CSS/border-block-color
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-block-color
-translation_of: Web/CSS/border-block-color
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-block-end-color/index.md
+++ b/files/ja/web/css/border-block-end-color/index.md
@@ -1,19 +1,6 @@
 ---
 title: border-block-end-color
 slug: Web/CSS/border-block-end-color
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - border-block
-  - border-block-color
-  - border-block-end
-  - border-block-end-color
-  - recipe:css-property
-browser-compat: css.properties.border-block-end-color
-translation_of: Web/CSS/border-block-end-color
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-block-end-style/index.md
+++ b/files/ja/web/css/border-block-end-style/index.md
@@ -1,19 +1,6 @@
 ---
 title: border-block-end-style
 slug: Web/CSS/border-block-end-style
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - border-block
-  - border-block-end
-  - border-block-end-style
-  - border-block-style
-  - recipe:css-property
-browser-compat: css.properties.border-block-end-style
-translation_of: Web/CSS/border-block-end-style
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-block-end-width/index.md
+++ b/files/ja/web/css/border-block-end-width/index.md
@@ -1,19 +1,6 @@
 ---
 title: border-block-end-width
 slug: Web/CSS/border-block-end-width
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - border-block
-  - border-block-end
-  - border-block-end-width
-  - border-block-width
-  - recipe:css-property
-browser-compat: css.properties.border-block-end-width
-translation_of: Web/CSS/border-block-end-width
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-block-end/index.md
+++ b/files/ja/web/css/border-block-end/index.md
@@ -1,19 +1,6 @@
 ---
 title: border-block-end
 slug: Web/CSS/border-block-end
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - border-block
-  - border-block-end-color
-  - border-block-end-style
-  - border-block-end-width
-  - recipe:css-shorthand-property
-browser-compat: css.properties.border-block-end
-translation_of: Web/CSS/border-block-end
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-block-start-color/index.md
+++ b/files/ja/web/css/border-block-start-color/index.md
@@ -1,19 +1,6 @@
 ---
 title: border-block-start-color
 slug: Web/CSS/border-block-start-color
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - border-block
-  - border-block-color
-  - border-block-start
-  - border-block-start-color
-  - recipe:css-property
-browser-compat: css.properties.border-block-start-color
-translation_of: Web/CSS/border-block-start-color
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-block-start-style/index.md
+++ b/files/ja/web/css/border-block-start-style/index.md
@@ -1,19 +1,6 @@
 ---
 title: border-block-start-style
 slug: Web/CSS/border-block-start-style
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - border-block
-  - border-block-start
-  - border-block-start-style
-  - border-block-style
-  - recipe:css-property
-browser-compat: css.properties.border-block-start-style
-translation_of: Web/CSS/border-block-start-style
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-block-start-width/index.md
+++ b/files/ja/web/css/border-block-start-width/index.md
@@ -1,19 +1,6 @@
 ---
 title: border-block-start-width
 slug: Web/CSS/border-block-start-width
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - border-block
-  - border-block-start
-  - border-block-start-width
-  - border-block-width
-  - recipe:css-property
-browser-compat: css.properties.border-block-start-width
-translation_of: Web/CSS/border-block-start-width
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-block-start/index.md
+++ b/files/ja/web/css/border-block-start/index.md
@@ -1,20 +1,6 @@
 ---
 title: border-block-start
 slug: Web/CSS/border-block-start
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - border-block
-  - border-block-start
-  - border-block-start-color
-  - border-block-start-style
-  - border-block-start-width
-  - recipe:css-shorthand-property
-browser-compat: css.properties.border-block-start
-translation_of: Web/CSS/border-block-start
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-block-style/index.md
+++ b/files/ja/web/css/border-block-style/index.md
@@ -1,16 +1,6 @@
 ---
 title: border-block-style
 slug: Web/CSS/border-block-style
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - Non-standard
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-block-style
-translation_of: Web/CSS/border-block-style
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-block-width/index.md
+++ b/files/ja/web/css/border-block-width/index.md
@@ -1,15 +1,6 @@
 ---
 title: border-block-width
 slug: Web/CSS/border-block-width
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-block-width
-translation_of: Web/CSS/border-block-width
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-block/index.md
+++ b/files/ja/web/css/border-block/index.md
@@ -1,16 +1,6 @@
 ---
 title: border-block
 slug: Web/CSS/border-block
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - Non-standard
-  - リファレンス
-  - 'recipe:css-shorthand-property'
-browser-compat: css.properties.border-block
-translation_of: Web/CSS/border-block
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-bottom-color/index.md
+++ b/files/ja/web/css/border-bottom-color/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-bottom-color
 slug: Web/CSS/border-bottom-color
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-bottom-color
-translation_of: Web/CSS/border-bottom-color
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-bottom-left-radius/index.md
+++ b/files/ja/web/css/border-bottom-left-radius/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-bottom-left-radius
 slug: Web/CSS/border-bottom-left-radius
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-bottom-left-radius
-translation_of: Web/CSS/border-bottom-left-radius
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-bottom-right-radius/index.md
+++ b/files/ja/web/css/border-bottom-right-radius/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-bottom-right-radius
 slug: Web/CSS/border-bottom-right-radius
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-bottom-right-radius
-translation_of: Web/CSS/border-bottom-right-radius
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-bottom-style/index.md
+++ b/files/ja/web/css/border-bottom-style/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-bottom-style
 slug: Web/CSS/border-bottom-style
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-bottom-style
-translation_of: Web/CSS/border-bottom-style
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-bottom-width/index.md
+++ b/files/ja/web/css/border-bottom-width/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-bottom-width
 slug: Web/CSS/border-bottom-width
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-bottom-width
-translation_of: Web/CSS/border-bottom-width
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-bottom/index.md
+++ b/files/ja/web/css/border-bottom/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-bottom
 slug: Web/CSS/border-bottom
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.border-bottom
-translation_of: Web/CSS/border-bottom
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-collapse/index.md
+++ b/files/ja/web/css/border-collapse/index.md
@@ -1,15 +1,6 @@
 ---
 title: border-collapse
 slug: Web/CSS/border-collapse
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - CSS 表
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-collapse
-translation_of: Web/CSS/border-collapse
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-color/index.md
+++ b/files/ja/web/css/border-color/index.md
@@ -1,20 +1,6 @@
 ---
 title: border-color
 slug: Web/CSS/border-color
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - CSS スタイル
-  - HTML 色
-  - リファレンス
-  - Styling HTML
-  - border-color
-  - 境界
-  - 色
-  - recipe:css-shorthand-property
-browser-compat: css.properties.border-color
-translation_of: Web/CSS/border-color
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-end-end-radius/index.md
+++ b/files/ja/web/css/border-end-end-radius/index.md
@@ -1,17 +1,6 @@
 ---
 title: border-end-end-radius
 slug: Web/CSS/border-end-end-radius
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - border-end-end-radius
-  - recipe:css-property
-  - 書字方向
-browser-compat: css.properties.border-end-end-radius
-translation_of: Web/CSS/border-end-end-radius
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-end-start-radius/index.md
+++ b/files/ja/web/css/border-end-start-radius/index.md
@@ -1,17 +1,6 @@
 ---
 title: border-end-start-radius
 slug: Web/CSS/border-end-start-radius
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - border-end-start-radius
-  - recipe:css-property
-  - 書字方向
-browser-compat: css.properties.border-end-start-radius
-translation_of: Web/CSS/border-end-start-radius
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-image-outset/index.md
+++ b/files/ja/web/css/border-image-outset/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-image-outset
 slug: Web/CSS/border-image-outset
-tags:
-  - CSS
-  - CSS 背景と境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-image-outset
-translation_of: Web/CSS/border-image-outset
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-image-repeat/index.md
+++ b/files/ja/web/css/border-image-repeat/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-image-repeat
 slug: Web/CSS/border-image-repeat
-tags:
-  - CSS
-  - CSS 背景と境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-image-repeat
-translation_of: Web/CSS/border-image-repeat
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-image-slice/index.md
+++ b/files/ja/web/css/border-image-slice/index.md
@@ -1,15 +1,6 @@
 ---
 title: border-image-slice
 slug: Web/CSS/border-image-slice
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS 背景と境界
-  - NeedsExample
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-image-slice
-translation_of: Web/CSS/border-image-slice
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-image-source/index.md
+++ b/files/ja/web/css/border-image-source/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-image-source
 slug: Web/CSS/border-image-source
-tags:
-  - CSS
-  - CSS 背景と境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-image-source
-translation_of: Web/CSS/border-image-source
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-image-width/index.md
+++ b/files/ja/web/css/border-image-width/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-image-width
 slug: Web/CSS/border-image-width
-tags:
-  - CSS
-  - CSS 背景と境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-image-width
-translation_of: Web/CSS/border-image-width
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-image/index.md
+++ b/files/ja/web/css/border-image/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-image
 slug: Web/CSS/border-image
-tags:
-  - CSS
-  - CSS 背景と境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.border-image
-translation_of: Web/CSS/border-image
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-inline-color/index.md
+++ b/files/ja/web/css/border-inline-color/index.md
@@ -1,15 +1,6 @@
 ---
 title: border-inline-color
 slug: Web/CSS/border-inline-color
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-inline-color
-translation_of: Web/CSS/border-inline-color
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-inline-end-color/index.md
+++ b/files/ja/web/css/border-inline-end-color/index.md
@@ -1,19 +1,6 @@
 ---
 title: border-inline-end-color
 slug: Web/CSS/border-inline-end-color
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - border-inline
-  - border-inline-color
-  - border-inline-end
-  - border-inline-end-color
-  - recipe:css-property
-browser-compat: css.properties.border-inline-end-color
-translation_of: Web/CSS/border-inline-end-color
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-inline-end-style/index.md
+++ b/files/ja/web/css/border-inline-end-style/index.md
@@ -1,19 +1,6 @@
 ---
 title: border-inline-end-style
 slug: Web/CSS/border-inline-end-style
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - border-inline
-  - border-inline-end
-  - border-inline-end-style
-  - border-inline-style
-  - recipe:css-property
-browser-compat: css.properties.border-inline-end-style
-translation_of: Web/CSS/border-inline-end-style
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-inline-end-width/index.md
+++ b/files/ja/web/css/border-inline-end-width/index.md
@@ -1,19 +1,6 @@
 ---
 title: border-inline-end-width
 slug: Web/CSS/border-inline-end-width
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - border-inline
-  - border-inline-end
-  - border-inline-end-width
-  - border-inline-width
-  - recipe:css-property
-browser-compat: css.properties.border-inline-end-width
-translation_of: Web/CSS/border-inline-end-width
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-inline-end/index.md
+++ b/files/ja/web/css/border-inline-end/index.md
@@ -1,20 +1,6 @@
 ---
 title: border-inline-end
 slug: Web/CSS/border-inline-end
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - border-inline
-  - border-inline-end
-  - border-inline-end-color
-  - border-inline-end-style
-  - border-inline-end-width
-  - recipe:css-shorthand-property
-browser-compat: css.properties.border-inline-end
-translation_of: Web/CSS/border-inline-end
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-inline-start-color/index.md
+++ b/files/ja/web/css/border-inline-start-color/index.md
@@ -1,19 +1,6 @@
 ---
 title: border-inline-start-color
 slug: Web/CSS/border-inline-start-color
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - border-inline
-  - border-inline-color
-  - border-inline-start
-  - border-inline-start-color
-  - recipe:css-property
-browser-compat: css.properties.border-inline-start-color
-translation_of: Web/CSS/border-inline-start-color
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-inline-start-style/index.md
+++ b/files/ja/web/css/border-inline-start-style/index.md
@@ -1,19 +1,6 @@
 ---
 title: border-inline-start-style
 slug: Web/CSS/border-inline-start-style
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - border-inline
-  - border-inline-start
-  - border-inline-start-style
-  - border-inline-style
-  - recipe:css-property
-browser-compat: css.properties.border-inline-start-style
-translation_of: Web/CSS/border-inline-start-style
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-inline-start-width/index.md
+++ b/files/ja/web/css/border-inline-start-width/index.md
@@ -1,19 +1,6 @@
 ---
 title: border-inline-start-width
 slug: Web/CSS/border-inline-start-width
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - border-inline
-  - border-inline-start
-  - border-inline-start-width
-  - border-inline-width
-  - recipe:css-property
-browser-compat: css.properties.border-inline-start-width
-translation_of: Web/CSS/border-inline-start-width
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-inline-start/index.md
+++ b/files/ja/web/css/border-inline-start/index.md
@@ -1,20 +1,6 @@
 ---
 title: border-inline-start
 slug: Web/CSS/border-inline-start
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - border-inline
-  - border-inline-start
-  - border-inline-start-color
-  - border-inline-start-style
-  - border-inline-start-width
-  - recipe:css-shorthand-property
-browser-compat: css.properties.border-inline-start
-translation_of: Web/CSS/border-inline-start
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-inline-style/index.md
+++ b/files/ja/web/css/border-inline-style/index.md
@@ -1,15 +1,6 @@
 ---
 title: border-inline-style
 slug: Web/CSS/border-inline-style
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-inline-style
-translation_of: Web/CSS/border-inline-style
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-inline-width/index.md
+++ b/files/ja/web/css/border-inline-width/index.md
@@ -1,15 +1,6 @@
 ---
 title: border-inline-width
 slug: Web/CSS/border-inline-width
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-inline-width
-translation_of: Web/CSS/border-inline-width
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-inline/index.md
+++ b/files/ja/web/css/border-inline/index.md
@@ -1,15 +1,6 @@
 ---
 title: border-inline
 slug: Web/CSS/border-inline
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.border-inline
-translation_of: Web/CSS/border-inline
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-left-color/index.md
+++ b/files/ja/web/css/border-left-color/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-left-color
 slug: Web/CSS/border-left-color
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-left-color
-translation_of: Web/CSS/border-left-color
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-left-style/index.md
+++ b/files/ja/web/css/border-left-style/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-left-style
 slug: Web/CSS/border-left-style
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-left-style
-translation_of: Web/CSS/border-left-style
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-left-width/index.md
+++ b/files/ja/web/css/border-left-width/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-left-width
 slug: Web/CSS/border-left-width
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-left-width
-translation_of: Web/CSS/border-left-width
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-left/index.md
+++ b/files/ja/web/css/border-left/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-left
 slug: Web/CSS/border-left
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.border-left
-translation_of: Web/CSS/border-left
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-radius/index.md
+++ b/files/ja/web/css/border-radius/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-radius
 slug: Web/CSS/border-radius
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.border-radius
-translation_of: Web/CSS/border-radius
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-right-color/index.md
+++ b/files/ja/web/css/border-right-color/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-right-color
 slug: Web/CSS/border-right-color
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-right-color
-translation_of: Web/CSS/border-right-color
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-right-style/index.md
+++ b/files/ja/web/css/border-right-style/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-right-style
 slug: Web/CSS/border-right-style
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-right-style
-translation_of: Web/CSS/border-right-style
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-right-width/index.md
+++ b/files/ja/web/css/border-right-width/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-right-width
 slug: Web/CSS/border-right-width
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS 境界
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-right-width
-translation_of: Web/CSS/border-right-width
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-right/index.md
+++ b/files/ja/web/css/border-right/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-right
 slug: Web/CSS/border-right
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.border-right
-translation_of: Web/CSS/border-right
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-spacing/index.md
+++ b/files/ja/web/css/border-spacing/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-spacing
 slug: Web/CSS/border-spacing
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS 表
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-spacing
-translation_of: Web/CSS/border-spacing
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-start-end-radius/index.md
+++ b/files/ja/web/css/border-start-end-radius/index.md
@@ -1,17 +1,6 @@
 ---
 title: border-start-end-radius
 slug: Web/CSS/border-start-end-radius
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - border-start-end-radius
-  - recipe:css-property
-  - 書字方向
-browser-compat: css.properties.border-start-end-radius
-translation_of: Web/CSS/border-start-end-radius
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-start-start-radius/index.md
+++ b/files/ja/web/css/border-start-start-radius/index.md
@@ -1,17 +1,6 @@
 ---
 title: border-start-start-radius
 slug: Web/CSS/border-start-start-radius
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - border-start-start-radius
-  - recipe:css-property
-  - 書字方向
-browser-compat: css.properties.border-start-start-radius
-translation_of: Web/CSS/border-start-start-radius
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-style/index.md
+++ b/files/ja/web/css/border-style/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-style
 slug: Web/CSS/border-style
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.border-style
-translation_of: Web/CSS/border-style
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-top-color/index.md
+++ b/files/ja/web/css/border-top-color/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-top-color
 slug: Web/CSS/border-top-color
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-top-color
-translation_of: Web/CSS/border-top-color
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-top-left-radius/index.md
+++ b/files/ja/web/css/border-top-left-radius/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-top-left-radius
 slug: Web/CSS/border-top-left-radius
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-top-left-radius
-translation_of: Web/CSS/border-top-left-radius
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-top-right-radius/index.md
+++ b/files/ja/web/css/border-top-right-radius/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-top-right-radius
 slug: Web/CSS/border-top-right-radius
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-top-right-radius
-translation_of: Web/CSS/border-top-right-radius
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-top-style/index.md
+++ b/files/ja/web/css/border-top-style/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-top-style
 slug: Web/CSS/border-top-style
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-top-style
-translation_of: Web/CSS/border-top-style
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-top-width/index.md
+++ b/files/ja/web/css/border-top-width/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-top-width
 slug: Web/CSS/border-top-width
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.border-top-width
-translation_of: Web/CSS/border-top-width
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-top/index.md
+++ b/files/ja/web/css/border-top/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-top
 slug: Web/CSS/border-top
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.border-top
-translation_of: Web/CSS/border-top
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border-width/index.md
+++ b/files/ja/web/css/border-width/index.md
@@ -1,14 +1,6 @@
 ---
 title: border-width
 slug: Web/CSS/border-width
-tags:
-  - CSS
-  - CSS 境界
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.border-width
-translation_of: Web/CSS/border-width
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/border/index.md
+++ b/files/ja/web/css/border/index.md
@@ -1,15 +1,6 @@
 ---
 title: border
 slug: Web/CSS/border
-tags:
-  - CSS
-  - CSS 境界
-  - CSS 一括指定プロパティ
-  - レイアウト
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.border
-translation_of: Web/CSS/border
 ---
 {{CSSRef("CSS Borders")}}
 

--- a/files/ja/web/css/bottom/index.md
+++ b/files/ja/web/css/bottom/index.md
@@ -1,14 +1,6 @@
 ---
 title: bottom
 slug: Web/CSS/bottom
-tags:
-  - CSS
-  - CSS 位置指定レイアウト
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.bottom
-translation_of: Web/CSS/bottom
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/box-align/index.md
+++ b/files/ja/web/css/box-align/index.md
@@ -1,15 +1,6 @@
 ---
 title: box-align
 slug: Web/CSS/box-align
-tags:
-  - CSS
-  - CSS プロパティ
-  - NeedsUpdate
-  - 標準外
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.box-align
-translation_of: Web/CSS/box-align
 ---
 {{CSSRef}}{{Non-standard_header}}{{warning("このプロパティは、当初の CSS Flexible Box Layout Module の草案段階のものでしたが、より新しい標準で置き換えられました。")}}
 

--- a/files/ja/web/css/box-decoration-break/index.md
+++ b/files/ja/web/css/box-decoration-break/index.md
@@ -1,15 +1,6 @@
 ---
 title: box-decoration-break
 slug: Web/CSS/box-decoration-break
-tags:
-  - CSS
-  - CSS 断片化
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.box-decoration-break
-translation_of: Web/CSS/box-decoration-break
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/box-direction/index.md
+++ b/files/ja/web/css/box-direction/index.md
@@ -1,13 +1,6 @@
 ---
 title: box-direction
 slug: Web/CSS/box-direction
-tags:
-  - CSS
-  - 標準外
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.box-direction
-translation_of: Web/CSS/box-direction
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/box-flex-group/index.md
+++ b/files/ja/web/css/box-flex-group/index.md
@@ -1,13 +1,6 @@
 ---
 title: box-flex-group
 slug: Web/CSS/box-flex-group
-tags:
-  - CSS
-  - CSS Property
-  - Non-standard
-  - Reference
-  - recipe:css-property
-translation_of: Web/CSS/box-flex-group
 ---
 {{CSSRef}}{{Non-standard_Header}}
 

--- a/files/ja/web/css/box-flex/index.md
+++ b/files/ja/web/css/box-flex/index.md
@@ -1,15 +1,6 @@
 ---
 title: box-flex
 slug: Web/CSS/box-flex
-tags:
-  - CSS
-  - CSS プロパティ
-  - 標準外
-  - リファレンス
-  - box-flex
-  - recipe:css-property
-browser-compat: css.properties.box-flex
-translation_of: Web/CSS/box-flex
 ---
 {{CSSRef}}{{Non-standard_Header}}
 

--- a/files/ja/web/css/box-lines/index.md
+++ b/files/ja/web/css/box-lines/index.md
@@ -1,14 +1,6 @@
 ---
 title: box-lines
 slug: Web/CSS/box-lines
-tags:
-  - CSS
-  - CSS プロパティ
-  - 標準外
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.box-lines
-translation_of: Web/CSS/box-lines
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/box-ordinal-group/index.md
+++ b/files/ja/web/css/box-ordinal-group/index.md
@@ -1,13 +1,6 @@
 ---
 title: box-ordinal-group
 slug: Web/CSS/box-ordinal-group
-tags:
-  - CSS
-  - CSS Property
-  - Non-standard
-  - Reference
-  - recipe:css-property
-translation_of: Web/CSS/box-ordinal-group
 ---
 {{CSSRef}}{{Non-standard_Header}}
 

--- a/files/ja/web/css/box-orient/index.md
+++ b/files/ja/web/css/box-orient/index.md
@@ -1,13 +1,6 @@
 ---
 title: box-orient
 slug: Web/CSS/box-orient
-tags:
-  - CSS
-  - Non-standard
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.box-orient
-translation_of: Web/CSS/box-orient
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/box-pack/index.md
+++ b/files/ja/web/css/box-pack/index.md
@@ -1,15 +1,6 @@
 ---
 title: box-pack
 slug: Web/CSS/box-pack
-tags:
-  - CSS
-  - CSS プロパティ
-  - 標準外
-  - リファレンス
-  - box-pack
-  - recipe:css-property
-browser-compat: css.properties.box-pack
-translation_of: Web/CSS/box-pack
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/box-shadow/index.md
+++ b/files/ja/web/css/box-shadow/index.md
@@ -1,20 +1,6 @@
 ---
 title: box-shadow
 slug: Web/CSS/box-shadow
-tags:
-  - CSS
-  - CSS 背景と境界
-  - CSS プロパティ
-  - CSS スタイル
-  - HTML Colors
-  - リファレンス
-  - 影
-  - Styles
-  - Styling HTML
-  - box-shadow
-  - recipe:css-property
-browser-compat: css.properties.box-shadow
-translation_of: Web/CSS/box-shadow
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/box-sizing/index.md
+++ b/files/ja/web/css/box-sizing/index.md
@@ -1,22 +1,6 @@
 ---
 title: box-sizing
 slug: Web/CSS/box-sizing
-tags:
-  - Boxes
-  - CSS
-  - CSS ボックスモデル
-  - CSS プロパティ
-  - リファレンス
-  - border-box
-  - box model
-  - box-sizing
-  - content-box
-  - height
-  - recipe:css-property
-  - size
-  - width
-browser-compat: css.properties.box-sizing
-translation_of: Web/CSS/box-sizing
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/break-after/index.md
+++ b/files/ja/web/css/break-after/index.md
@@ -1,15 +1,6 @@
 ---
 title: break-after
 slug: Web/CSS/break-after
-tags:
-  - CSS
-  - CSS 断片化
-  - CSS 段組みレイアウト
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.break-after
-translation_of: Web/CSS/break-after
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/break-before/index.md
+++ b/files/ja/web/css/break-before/index.md
@@ -1,15 +1,6 @@
 ---
 title: break-before
 slug: Web/CSS/break-before
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS 断片化
-  - CSS 段組みレイアウト
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.break-before
-translation_of: Web/CSS/break-before
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/break-inside/index.md
+++ b/files/ja/web/css/break-inside/index.md
@@ -1,16 +1,6 @@
 ---
 title: break-inside
 slug: Web/CSS/break-inside
-tags:
-  - CSS
-  - CSS 断片化
-  - CSS 段組みレイアウト
-  - CSS プロパティ
-  - NeedsExample
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.break-inside
-translation_of: Web/CSS/break-inside
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/calc/index.md
+++ b/files/ja/web/css/calc/index.md
@@ -1,19 +1,7 @@
 ---
 title: calc()
 slug: Web/CSS/calc
-tags:
-  - CSS
-  - CSS 関数
-  - 計算
-  - 演算
-  - 関数
-  - レイアウト
-  - リファレンス
-  - ウェブ
-  - calc
-translation_of: Web/CSS/calc()
 original_slug: Web/CSS/calc()
-browser-compat: css.types.calc
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/caption-side/index.md
+++ b/files/ja/web/css/caption-side/index.md
@@ -1,14 +1,6 @@
 ---
 title: caption-side
 slug: Web/CSS/caption-side
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS 表
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.caption-side
-translation_of: Web/CSS/caption-side
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/caret-color/index.md
+++ b/files/ja/web/css/caret-color/index.md
@@ -1,22 +1,6 @@
 ---
 title: caret-color
 slug: Web/CSS/caret-color
-tags:
-  - CSS
-  - CSS Property
-  - CSS User Interface
-  - Editing
-  - HTML Colors
-  - Input
-  - Reference
-  - Styling HTML
-  - Text Editing
-  - caret
-  - caret-color
-  - contenteditable
-  - recipe:css-property
-translation_of: Web/CSS/caret-color
-browser-compat: css.properties.caret-color
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/cascade/index.md
+++ b/files/ja/web/css/cascade/index.md
@@ -1,21 +1,6 @@
 ---
 title: CSS カスケード入門
 slug: Web/CSS/Cascade
-tags:
-  - CSS
-  - Cascade
-  - Guide
-  - Introduction
-  - Layout
-  - Cascade layers
-  - specificity
-  - \@layers
-  - Reference
-  - Style
-  - Style sheet
-  - Stylesheets
-spec-urls: https://drafts.csswg.org/css-cascade/
-translation_of: Web/CSS/Cascade
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/child_combinator/index.md
+++ b/files/ja/web/css/child_combinator/index.md
@@ -1,12 +1,6 @@
 ---
 title: 子結合子
 slug: Web/CSS/Child_combinator
-tags:
-  - CSS
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.child
-translation_of: Web/CSS/Child_combinator
 ---
 {{CSSRef("Selectors")}}
 

--- a/files/ja/web/css/clamp/index.md
+++ b/files/ja/web/css/clamp/index.md
@@ -1,19 +1,7 @@
 ---
 title: clamp()
 slug: Web/CSS/clamp
-tags:
-  - CSS
-  - CSS 関数
-  - 計算
-  - 演算
-  - 関数
-  - レイアウト
-  - リファレンス
-  - ウェブ
-  - clamp
-translation_of: Web/CSS/clamp()
 original_slug: Web/CSS/clamp()
-browser-compat: css.types.clamp
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/class_selectors/index.md
+++ b/files/ja/web/css/class_selectors/index.md
@@ -1,12 +1,6 @@
 ---
 title: クラスセレクター
 slug: Web/CSS/Class_selectors
-tags:
-  - CSS
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.class
-translation_of: Web/CSS/Class_selectors
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/clear/index.md
+++ b/files/ja/web/css/clear/index.md
@@ -1,14 +1,6 @@
 ---
 title: clear
 slug: Web/CSS/clear
-tags:
-  - CSS
-  - CSS 位置指定レイアウト
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.clear
-translation_of: Web/CSS/clear
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/clip-path/index.md
+++ b/files/ja/web/css/clip-path/index.md
@@ -1,16 +1,6 @@
 ---
 title: clip-path
 slug: Web/CSS/clip-path
-tags:
-  - CSS
-  - CSS マスク
-  - CSS プロパティ
-  - Experimental
-  - リファレンス
-  - ウェブ
-  - recipe:css-property
-browser-compat: css.properties.clip-path
-translation_of: Web/CSS/clip-path
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/clip/index.md
+++ b/files/ja/web/css/clip/index.md
@@ -1,15 +1,6 @@
 ---
 title: clip
 slug: Web/CSS/clip
-tags:
-  - CSS
-  - CSS マスク
-  - CSS プロパティ
-  - 非推奨
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.clip
-translation_of: Web/CSS/clip
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/color-scheme/index.md
+++ b/files/ja/web/css/color-scheme/index.md
@@ -1,21 +1,6 @@
 ---
 title: color-scheme
 slug: Web/CSS/color-scheme
-tags:
-  - CSS
-  - CSS Colors
-  - CSS Property
-  - HTML Colors
-  - HTML Styles
-  - Layout
-  - Reference
-  - Styling HTML
-  - Styling text
-  - Web
-  - color-adjust
-  - recipe:css-property
-browser-compat: css.properties.color-scheme
-translation_of: Web/CSS/color-scheme
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/color/index.md
+++ b/files/ja/web/css/color/index.md
@@ -1,22 +1,6 @@
 ---
 title: color
 slug: Web/CSS/color
-tags:
-  - CSS
-  - CSS 色
-  - CSS プロパティ
-  - CSS テキスト
-  - HTML 色
-  - HTML 
-  - レイアウト
-  - リファレンス
-  - Styling HTML
-  - Styling text
-  - ウェブ
-  - color
-  - recipe:css-property
-browser-compat: css.properties.color
-translation_of: Web/CSS/color
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/color_value/index.md
+++ b/files/ja/web/css/color_value/index.md
@@ -1,23 +1,6 @@
 ---
 title: <color>
 slug: Web/CSS/color_value
-tags:
-  - CSS
-  - CSS データ型
-  - データ型
-  - レイアウト
-  - リファレンス
-  - ウェブ
-  - 色
-  - hsl
-  - hsla
-  - rgb
-  - rgba
-  - 単位
-  - lch
-  - lab
-browser-compat: css.types.color
-translation_of: Web/CSS/color_value
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/column-count/index.md
+++ b/files/ja/web/css/column-count/index.md
@@ -1,17 +1,6 @@
 ---
 title: column-count
 slug: Web/CSS/column-count
-tags:
-  - CSS
-  - CSS 段組みレイアウト
-  - CSS プロパティ
-  - レイアウト
-  - リファレンス
-  - column-count
-  - columns
-  - recipe:css-property
-browser-compat: css.properties.column-count
-translation_of: Web/CSS/column-count
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/column-fill/index.md
+++ b/files/ja/web/css/column-fill/index.md
@@ -1,14 +1,6 @@
 ---
 title: column-fill
 slug: Web/CSS/column-fill
-tags:
-  - CSS
-  - CSS 段組みレイアウト
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.column-fill
-translation_of: Web/CSS/column-fill
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/column-gap/index.md
+++ b/files/ja/web/css/column-gap/index.md
@@ -1,17 +1,6 @@
 ---
 title: column-gap (grid-column-gap)
 slug: Web/CSS/column-gap
-tags:
-  - CSS
-  - CSS フレックスボックス
-  - CSS グリッドレイアウト
-  - CSS 段組みレイアウト
-  - CSS プロパティ
-  - リファレンス
-  - column-gap
-  - recipe:css-property
-browser-compat: css.properties.column-gap
-translation_of: Web/CSS/column-gap
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/column-rule-color/index.md
+++ b/files/ja/web/css/column-rule-color/index.md
@@ -1,19 +1,6 @@
 ---
 title: column-rule-color
 slug: Web/CSS/column-rule-color
-tags:
-  - CSS
-  - CSS 段組みレイアウト
-  - CSS プロパティ
-  - HTML 色
-  - リファレンス
-  - スタイル
-  - HTML のスタイル付け
-  - column-rule-color
-  - columns
-  - recipe:css-property
-browser-compat: css.properties.column-rule-color
-translation_of: Web/CSS/column-rule-color
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/column-rule-style/index.md
+++ b/files/ja/web/css/column-rule-style/index.md
@@ -1,14 +1,6 @@
 ---
 title: column-rule-style
 slug: Web/CSS/column-rule-style
-tags:
-  - CSS
-  - CSS 段組みレイアウト
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.column-rule-style
-translation_of: Web/CSS/column-rule-style
 ---
 {{ CSSRef}}
 

--- a/files/ja/web/css/column-rule-width/index.md
+++ b/files/ja/web/css/column-rule-width/index.md
@@ -1,14 +1,6 @@
 ---
 title: column-rule-width
 slug: Web/CSS/column-rule-width
-tags:
-  - CSS
-  - CSS 段組みレイアウト
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.column-rule-width
-translation_of: Web/CSS/column-rule-width
 ---
 {{ CSSRef}}
 

--- a/files/ja/web/css/column-rule/index.md
+++ b/files/ja/web/css/column-rule/index.md
@@ -1,14 +1,6 @@
 ---
 title: column-rule
 slug: Web/CSS/column-rule
-tags:
-  - CSS
-  - CSS 段組みレイアウト
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.column-rule
-translation_of: Web/CSS/column-rule
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/column-span/index.md
+++ b/files/ja/web/css/column-span/index.md
@@ -1,14 +1,6 @@
 ---
 title: column-span
 slug: Web/CSS/column-span
-tags:
-  - CSS
-  - CSS 段組みレイアウト
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.column-span
-translation_of: Web/CSS/column-span
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/column-width/index.md
+++ b/files/ja/web/css/column-width/index.md
@@ -1,14 +1,6 @@
 ---
 title: column-width
 slug: Web/CSS/column-width
-tags:
-  - CSS
-  - CSS 段組みレイアウト
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.column-width
-translation_of: Web/CSS/column-width
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/column_combinator/index.md
+++ b/files/ja/web/css/column_combinator/index.md
@@ -1,14 +1,6 @@
 ---
 title: 列結合子
 slug: Web/CSS/Column_combinator
-tags:
-  - CSS
-  - 実験的
-  - リファレンス
-  - セレクター
-  - 表
-browser-compat: css.selectors.column
-translation_of: Web/CSS/Column_combinator
 ---
 {{CSSRef("Selectors")}}{{SeeCompatTable}}
 

--- a/files/ja/web/css/columns/index.md
+++ b/files/ja/web/css/columns/index.md
@@ -1,14 +1,6 @@
 ---
 title: columns
 slug: Web/CSS/columns
-tags:
-  - CSS
-  - CSS 段組みレイアウト
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.columns
-translation_of: Web/CSS/columns
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/comments/index.md
+++ b/files/ja/web/css/comments/index.md
@@ -1,11 +1,6 @@
 ---
 title: コメント
 slug: Web/CSS/Comments
-tags:
-  - CSS
-  - Guide
-  - Reference
-translation_of: Web/CSS/Comments
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/compositing_and_blending/index.md
+++ b/files/ja/web/css/compositing_and_blending/index.md
@@ -1,13 +1,6 @@
 ---
 title: 合成と混合
 slug: Web/CSS/Compositing_and_Blending
-tags:
-  - CSS
-  - 合成と混合
-  - ガイド
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/Compositing_and_Blending
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/computed_value/index.md
+++ b/files/ja/web/css/computed_value/index.md
@@ -1,12 +1,6 @@
 ---
 title: 計算値
 slug: Web/CSS/computed_value
-tags:
-  - CSS
-  - Guide
-  - Reference
-spec-urls: https://www.w3.org/TR/CSS22/cascade.html#computed-value
-translation_of: Web/CSS/computed_value
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/contain-intrinsic-size/index.md
+++ b/files/ja/web/css/contain-intrinsic-size/index.md
@@ -1,7 +1,6 @@
 ---
 title: contain-intrinsic-size
 slug: Web/CSS/contain-intrinsic-size
-translation_of: Web/CSS/contain-intrinsic-size
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/contain/index.md
+++ b/files/ja/web/css/contain/index.md
@@ -1,19 +1,6 @@
 ---
 title: contain
 slug: Web/CSS/contain
-tags:
-  - CSS
-  - CSS 封じ込め
-  - CSS プロパティ
-  - レイアウト
-  - NeedsExample
-  - Paint
-  - リファレンス
-  - Style
-  - ウェブ
-  - recipe:css-property
-browser-compat: css.properties.contain
-translation_of: Web/CSS/contain
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/containing_block/index.md
+++ b/files/ja/web/css/containing_block/index.md
@@ -1,18 +1,6 @@
 ---
 title: レイアウトと包含ブロック
 slug: Web/CSS/Containing_block
-tags:
-  - CSS
-  - CSS Position
-  - Containers
-  - Guide
-  - Layout
-  - Position
-  - Style
-  - blocks
-  - containing block
-  - size
-translation_of: Web/CSS/Containing_block
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/content-visibility/index.md
+++ b/files/ja/web/css/content-visibility/index.md
@@ -1,18 +1,6 @@
 ---
 title: content-visibility
 slug: Web/CSS/content-visibility
-tags:
-  - CSS
-  - CSS 封じ込め
-  - CSS プロパティ
-  - レイアウト
-  - Paint
-  - リファレンス
-  - Style
-  - Visibility
-  - ウェブ
-browser-compat: css.properties.content-visibility
-translation_of: Web/CSS/content-visibility
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/content/index.md
+++ b/files/ja/web/css/content/index.md
@@ -1,15 +1,6 @@
 ---
 title: content
 slug: Web/CSS/content
-tags:
-  - CSS
-  - CSS カウンター
-  - CSS プロパティ
-  - 生成コンテンツ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.content
-translation_of: Web/CSS/content
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/counter-increment/index.md
+++ b/files/ja/web/css/counter-increment/index.md
@@ -1,15 +1,6 @@
 ---
 title: counter-increment
 slug: Web/CSS/counter-increment
-tags:
-  - CSS
-  - CSS カウンター
-  - CSS リスト
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.counter-increment
-translation_of: Web/CSS/counter-increment
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/counter-reset/index.md
+++ b/files/ja/web/css/counter-reset/index.md
@@ -1,14 +1,6 @@
 ---
 title: counter-reset
 slug: Web/CSS/counter-reset
-tags:
-  - CSS
-  - CSS カウンター
-  - CSS リスト
-  - CSS プロパティ
-  - recipe:css-property
-browser-compat: css.properties.counter-reset
-translation_of: Web/CSS/counter-reset
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/counter-set/index.md
+++ b/files/ja/web/css/counter-set/index.md
@@ -1,14 +1,6 @@
 ---
 title: counter-set
 slug: Web/CSS/counter-set
-tags:
-  - CSS
-  - CSS カウンター
-  - CSS リスト
-  - CSS プロパティ
-  - recipe:css-property
-browser-compat: css.properties.counter-set
-translation_of: Web/CSS/counter-set
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/counter/index.md
+++ b/files/ja/web/css/counter/index.md
@@ -1,15 +1,7 @@
 ---
 title: counter()
 slug: Web/CSS/counter
-tags:
-  - CSS
-  - CSS カウンター
-  - CSS 関数
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/counter()
 original_slug: Web/CSS/counter()
-browser-compat: css.types.counter
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/counters/index.md
+++ b/files/ja/web/css/counters/index.md
@@ -1,15 +1,7 @@
 ---
 title: counters()
 slug: Web/CSS/counters
-tags:
-  - CSS
-  - CSS カウンター
-  - CSS 関数
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/counters()
 original_slug: Web/CSS/counters()
-browser-compat: css.types.counters
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/cross-fade/index.md
+++ b/files/ja/web/css/cross-fade/index.md
@@ -1,17 +1,7 @@
 ---
 title: cross-fade()
 slug: Web/CSS/cross-fade
-tags:
-  - CSS
-  - CSS 関数
-  - CSS-4 画像
-  - 実験的
-  - 関数
-  - Reference
-  - ウェブ
-translation_of: Web/CSS/cross-fade()
 original_slug: Web/CSS/cross-fade()
-browser-compat: css.types.image.cross-fade
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_animated_properties/index.md
+++ b/files/ja/web/css/css_animated_properties/index.md
@@ -1,16 +1,6 @@
 ---
 title: アニメーション可能な CSS プロパティ
 slug: Web/CSS/CSS_animated_properties
-tags:
-  - CSS
-  - CSS Animations
-  - CSS Transitions
-  - CSS アニメーション
-  - CSS トランジション
-  - Guide
-  - Reference
-  - ガイド
-translation_of: Web/CSS/CSS_animated_properties
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_animations/index.md
+++ b/files/ja/web/css/css_animations/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS アニメーション
 slug: Web/CSS/CSS_Animations
-tags:
-  - CSS
-  - CSS アニメーション
-  - ガイド
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/CSS_Animations
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_animations/tips/index.md
+++ b/files/ja/web/css/css_animations/tips/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS アニメーションのヒントとコツ
 slug: Web/CSS/CSS_Animations/Tips
-tags:
-  - CSS
-  - CSS アニメーション
-  - 例
-  - ガイド
-  - リファレンス
-translation_of: Web/CSS/CSS_Animations/Tips
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_animations/using_css_animations/index.md
+++ b/files/ja/web/css/css_animations/using_css_animations/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS アニメーションの使用
 slug: Web/CSS/CSS_Animations/Using_CSS_animations
-tags:
-  - 上級者
-  - CSS
-  - CSS アニメーション
-  - 例
-  - ガイド
-translation_of: Web/CSS/CSS_Animations/Using_CSS_animations
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_backgrounds_and_borders/border-image_generator/index.md
+++ b/files/ja/web/css/css_backgrounds_and_borders/border-image_generator/index.md
@@ -1,10 +1,6 @@
 ---
 title: 境界画像作成ツール
 slug: Web/CSS/CSS_Backgrounds_and_Borders/Border-image_generator
-tags:
-  - CSS
-  - ツール
-translation_of: Web/CSS/CSS_Backgrounds_and_Borders/Border-image_generator
 ---
 このツールを使用して、 CSS3 の {{cssxref("border-image")}} の値を作成できます。
 

--- a/files/ja/web/css/css_backgrounds_and_borders/border-radius_generator/index.md
+++ b/files/ja/web/css/css_backgrounds_and_borders/border-radius_generator/index.md
@@ -1,11 +1,6 @@
 ---
 title: 境界角丸作成ツール
 slug: Web/CSS/CSS_Backgrounds_and_Borders/Border-radius_generator
-tags:
-  - CSS
-  - CSS Borders
-  - Tools
-translation_of: Web/CSS/CSS_Backgrounds_and_Borders/Border-radius_generator
 ---
 このツールを使用して、 CSS3 の {{cssxref("border-radius")}} の効果を生成することができます。
 

--- a/files/ja/web/css/css_backgrounds_and_borders/box-shadow_generator/index.md
+++ b/files/ja/web/css/css_backgrounds_and_borders/box-shadow_generator/index.md
@@ -1,11 +1,6 @@
 ---
 title: ボックスの影作成ツール
 slug: Web/CSS/CSS_Backgrounds_and_Borders/Box-shadow_generator
-tags:
-  - CSS
-  - Tools
-  - box-shadow
-translation_of: Web/CSS/CSS_Backgrounds_and_Borders/Box-shadow_generator
 ---
 このツールで CSS の {{cssxref("box-shadow")}} 効果を組み立てて、 CSS オブジェクトにボックスの影の効果を追加することができます。
 

--- a/files/ja/web/css/css_backgrounds_and_borders/index.md
+++ b/files/ja/web/css/css_backgrounds_and_borders/index.md
@@ -1,12 +1,6 @@
 ---
 title: CSS 背景と境界
 slug: Web/CSS/CSS_Backgrounds_and_Borders
-tags:
-  - CSS
-  - CSS 背景と境界
-  - Reference
-  - 概要
-translation_of: Web/CSS/CSS_Backgrounds_and_Borders
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_backgrounds_and_borders/resizing_background_images/index.md
+++ b/files/ja/web/css/css_backgrounds_and_borders/resizing_background_images/index.md
@@ -1,21 +1,6 @@
 ---
 title: 背景画像の拡大縮小
 slug: Web/CSS/CSS_Backgrounds_and_Borders/Resizing_background_images
-tags:
-  - CSS
-  - CSS 背景
-  - 例
-  - ガイド
-  - 中級者
-  - リファレンス
-  - Scale
-  - Scaling
-  - ウェブ
-  - dimensions
-  - height
-  - resize
-  - width
-translation_of: Web/CSS/CSS_Backgrounds_and_Borders/Resizing_background_images
 original_slug: Web/CSS/CSS_Backgrounds_and_Borders/Scaling_background_images
 ---
 {{CSSRef}}

--- a/files/ja/web/css/css_backgrounds_and_borders/using_multiple_backgrounds/index.md
+++ b/files/ja/web/css/css_backgrounds_and_borders/using_multiple_backgrounds/index.md
@@ -1,13 +1,6 @@
 ---
 title: 複数の背景画像の利用
 slug: Web/CSS/CSS_Backgrounds_and_Borders/Using_multiple_backgrounds
-tags:
-  - CSS
-  - CSS 背景
-  - 例
-  - ガイド
-  - リファレンス
-translation_of: Web/CSS/CSS_Backgrounds_and_Borders/Using_multiple_backgrounds
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_basic_user_interface/index.md
+++ b/files/ja/web/css/css_basic_user_interface/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS 基本ユーザーインターフェイス
 slug: Web/CSS/CSS_Basic_User_Interface
-tags:
-  - CSS
-  - CSS 基本ユーザーインターフェイス
-  - ガイド
-  - 概要
-  - Reference
-translation_of: Web/CSS/CSS_Basic_User_Interface
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_box_alignment/box_alignment_in_block_abspos_tables/index.md
+++ b/files/ja/web/css/css_box_alignment/box_alignment_in_block_abspos_tables/index.md
@@ -1,14 +1,6 @@
 ---
 title: ブロック、絶対配置、表レイアウトのブロック配置
 slug: Web/CSS/CSS_Box_Alignment/Box_Alignment_In_Block_Abspos_Tables
-tags:
-  - ブロック
-  - CSS
-  - ガイド
-  - 絶対配置
-  - ボックス配置
-  - 表
-translation_of: Web/CSS/CSS_Box_Alignment/Box_Alignment_In_Block_Abspos_Tables
 ---
 [ボックス配置仕様書](/ja/docs/Web/CSS/CSS_Box_Alignment)は、様々なレイアウト方式でどのように配置が動作するかを詳説しています。このページでは、ボックス配置は浮動、位置指定、表要素を含むボックスレイアウトのレイアウトでどのように動作するかを明らかにします。このページはブロックレイアウトとボックス配置に固有のことを詳説するため、様々なレイアウト方式に共通のボックス配置の共通機能について説明している、中心となる[ボックス配置](/ja/docs/Web/CSS/CSS_Box_Alignment)ページを併せて読んでください。
 

--- a/files/ja/web/css/css_box_alignment/box_alignment_in_flexbox/index.md
+++ b/files/ja/web/css/css_box_alignment/box_alignment_in_flexbox/index.md
@@ -1,12 +1,6 @@
 ---
 title: フレックスボックスでのボックス配置
 slug: Web/CSS/CSS_Box_Alignment/Box_Alignment_in_Flexbox
-tags:
-  - CSS
-  - ガイド
-  - ボックス配置
-  - フレックスボックス
-translation_of: Web/CSS/CSS_Box_Alignment/Box_Alignment_in_Flexbox
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_box_alignment/box_alignment_in_grid_layout/index.md
+++ b/files/ja/web/css/css_box_alignment/box_alignment_in_grid_layout/index.md
@@ -1,12 +1,6 @@
 ---
 title: グリッドレイアウトでのボックス配置
 slug: Web/CSS/CSS_Box_Alignment/Box_Alignment_In_Grid_Layout
-tags:
-  - CSS
-  - ガイド
-  - ボックス配置
-  - グリッド
-translation_of: Web/CSS/CSS_Box_Alignment/Box_Alignment_In_Grid_Layout
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_box_alignment/box_alignment_in_multi-column_layout/index.md
+++ b/files/ja/web/css/css_box_alignment/box_alignment_in_multi-column_layout/index.md
@@ -1,12 +1,6 @@
 ---
 title: 段組みレイアウトでのボックス配置
 slug: Web/CSS/CSS_Box_Alignment/Box_Alignment_in_Multi-column_Layout
-tags:
-  - CSS
-  - ガイド
-  - ボックス配置
-  - 段組み
-translation_of: Web/CSS/CSS_Box_Alignment/Box_Alignment_in_Multi-column_Layout
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_box_alignment/index.md
+++ b/files/ja/web/css/css_box_alignment/index.md
@@ -1,16 +1,6 @@
 ---
 title: CSS ボックス配置
 slug: Web/CSS/CSS_Box_Alignment
-tags:
-  - CSS
-  - CSS ボックス配置
-  - グリッドレイアウト
-  - ガイド
-  - 配置
-  - ボックス配置
-  - フレックスボックス
-  - 段組み
-translation_of: Web/CSS/CSS_Box_Alignment
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_box_model/index.md
+++ b/files/ja/web/css/css_box_model/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS ボックスモデル
 slug: Web/CSS/CSS_Box_Model
-tags:
-  - CSS
-  - CSS ボックスモデル
-  - ガイド
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/CSS_Box_Model
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_box_model/introduction_to_the_css_box_model/index.md
+++ b/files/ja/web/css/css_box_model/introduction_to_the_css_box_model/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS 基本ボックスモデル入門
 slug: Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model
-tags:
-  - CSS
-  - CSS Box Model
-  - Guide
-  - Layout
-spec-urls: https://drafts.csswg.org/css-box/#intro
-translation_of: Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_box_model/mastering_margin_collapsing/index.md
+++ b/files/ja/web/css/css_box_model/mastering_margin_collapsing/index.md
@@ -1,13 +1,6 @@
 ---
 title: マージンの相殺の習得
 slug: Web/CSS/CSS_Box_Model/Mastering_margin_collapsing
-tags:
-  - CSS
-  - CSS Box Model
-  - Guide
-  - Reference
-spec-urls: https://www.w3.org/TR/CSS22/box.html#collapsing-margins
-translation_of: Web/CSS/CSS_Box_Model/Mastering_margin_collapsing
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_charsets/index.md
+++ b/files/ja/web/css/css_charsets/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS 文字セット
 slug: Web/CSS/CSS_Charsets
-tags:
-  - CSS
-  - CSS 文字セット
-  - ガイド
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/CSS_Charsets
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_colors/applying_color/index.md
+++ b/files/ja/web/css/css_colors/applying_color/index.md
@@ -1,17 +1,6 @@
 ---
 title: CSS を使った HTML の要素への色の適用
 slug: Web/CSS/CSS_Colors/Applying_color
-tags:
-  - Beginner
-  - CSS
-  - CSS 色
-  - Guide
-  - HTML
-  - HTML 色
-  - HTML スタイル
-  - Styling HTML
-  - color
-translation_of: Web/HTML/Applying_color
 original_slug: Web/HTML/Applying_color
 ---
 {{HTMLRef}}

--- a/files/ja/web/css/css_colors/color_picker_tool/index.md
+++ b/files/ja/web/css/css_colors/color_picker_tool/index.md
@@ -1,19 +1,6 @@
 ---
 title: 色選択ツール
 slug: Web/CSS/CSS_Colors/Color_picker_tool
-tags:
-  - CSS
-  - CSS 色選択
-  - CSS 色選択ツール
-  - CSS 色
-  - 色選択
-  - HTML 色選択
-  - HTML 色選択ツール
-  - HTML 色
-  - ツール
-  - color
-  - colors
-translation_of: Web/CSS/CSS_Colors/Color_picker_tool
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_colors/index.md
+++ b/files/ja/web/css/css_colors/index.md
@@ -1,17 +1,6 @@
 ---
 title: CSS 色
 slug: Web/CSS/CSS_Colors
-tags:
-  - CSS
-  - CSS 色
-  - ガイド
-  - HTML 色
-  - 概要
-  - リファレンス
-  - スタイル
-  - Styling HTML
-  - 色
-translation_of: Web/CSS/CSS_Color
 original_slug: Web/CSS/CSS_Color
 ---
 {{CSSRef}}

--- a/files/ja/web/css/css_columns/basic_concepts_of_multicol/index.md
+++ b/files/ja/web/css/css_columns/basic_concepts_of_multicol/index.md
@@ -1,12 +1,6 @@
 ---
 title: 段組みの基本概念
 slug: Web/CSS/CSS_Columns/Basic_Concepts_of_Multicol
-tags:
-  - CSS
-  - CSS 段組みレイアウト
-  - ガイド
-  - レイアウト
-translation_of: Web/CSS/CSS_Columns/Basic_Concepts_of_Multicol
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_columns/handling_content_breaks_in_multicol/index.md
+++ b/files/ja/web/css/css_columns/handling_content_breaks_in_multicol/index.md
@@ -1,12 +1,6 @@
 ---
 title: 段組みにおける内容物の分割の扱い
 slug: Web/CSS/CSS_Columns/Handling_content_breaks_in_multicol
-tags:
-  - CSS
-  - CSS 段組みレイアウト
-  - Guide
-  - レイアウト
-translation_of: Web/CSS/CSS_Columns/Handling_content_breaks_in_multicol
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_columns/handling_overflow_in_multicol/index.md
+++ b/files/ja/web/css/css_columns/handling_overflow_in_multicol/index.md
@@ -1,12 +1,6 @@
 ---
 title: 段組みでのはみ出しの扱い
 slug: Web/CSS/CSS_Columns/Handling_Overflow_in_Multicol
-tags:
-  - CSS
-  - CSS 段組みレイアウト
-  - ガイド
-  - レイアウト
-translation_of: Web/CSS/CSS_Columns/Handling_Overflow_in_Multicol
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_columns/index.md
+++ b/files/ja/web/css/css_columns/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSS 段組みレイアウト
 slug: Web/CSS/CSS_Columns
-tags:
-  - CSS
-  - CSS 段組みレイアウト
-  - ガイド
-  - レイアウト
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/CSS_Columns
 ---
 {{CSSRef("CSS3 Multicol")}}
 

--- a/files/ja/web/css/css_columns/spanning_columns/index.md
+++ b/files/ja/web/css/css_columns/spanning_columns/index.md
@@ -1,12 +1,6 @@
 ---
 title: 段抜きと段の均衡
 slug: Web/CSS/CSS_Columns/Spanning_Columns
-tags:
-  - CSS
-  - CSS 段組みレイアウト
-  - ガイド
-  - レイアウト
-translation_of: Web/CSS/CSS_Columns/Spanning_Columns
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_columns/styling_columns/index.md
+++ b/files/ja/web/css/css_columns/styling_columns/index.md
@@ -1,13 +1,6 @@
 ---
 title: 段のスタイル付け
 slug: Web/CSS/CSS_Columns/Styling_Columns
-tags:
-  - CSS
-  - CSS 段組みレイアウト
-  - ガイド
-  - レイアウト
-  - 日本語処理
-translation_of: Web/CSS/CSS_Columns/Styling_Columns
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_columns/using_multi-column_layouts/index.md
+++ b/files/ja/web/css/css_columns/using_multi-column_layouts/index.md
@@ -1,14 +1,6 @@
 ---
 title: 段組みレイアウトの使用
 slug: Web/CSS/CSS_Columns/Using_multi-column_layouts
-tags:
-  - Advanced
-  - CSS
-  - CSS Multi-column Layout
-  - Guide
-  - Layout
-  - Web
-translation_of: Web/CSS/CSS_Columns/Using_multi-column_layouts
 l10n:
   sourceCommit: 77abaefce3b90a6439c5bd4a162956e7d0cf8fda
 ---

--- a/files/ja/web/css/css_conditional_rules/index.md
+++ b/files/ja/web/css/css_conditional_rules/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS 条件付き規則
 slug: Web/CSS/CSS_Conditional_Rules
-tags:
-  - CSS
-  - CSS 条件付き規則
-  - ガイド
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/CSS_Conditional_Rules
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_conditional_rules/using_feature_queries/index.md
+++ b/files/ja/web/css/css_conditional_rules/using_feature_queries/index.md
@@ -1,12 +1,6 @@
 ---
 title: 機能クエリーの使用
 slug: Web/CSS/CSS_Conditional_Rules/Using_Feature_Queries
-tags:
-  - CSS
-  - 条件付き CSS
-  - ガイド
-  - 機能クエリー
-  - プログレッシブエンハンスメント
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_containment/index.md
+++ b/files/ja/web/css/css_containment/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS 封じ込め
 slug: Web/CSS/CSS_Containment
-tags:
-  - CSS
-  - CSS 封じ込め
-  - Guide
-  - Paint
-  - Performance
-translation_of: Web/CSS/CSS_Containment
 ---
 {{CSSRef}}
 CSS 封じ込め (CSS Containment) 仕様の目的は、ウェブページの表示性能を向上させるために、開発者がページの任意のサブツリーをページのそれ以外の部分から独立させることができるようにすることです。もしページの一部が独立していることをブラウザーが知っていれば、レンダリングを最適化し、表示性能を向上させることができます。この仕様では、単一の CSS プロパティ {{cssxref("contain")}} を定義しています。この文書では、その仕様の基本的な目的を説明しています。

--- a/files/ja/web/css/css_counter_styles/index.md
+++ b/files/ja/web/css/css_counter_styles/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSS カウンタースタイル
 slug: Web/CSS/CSS_Counter_Styles
-tags:
-  - CSS
-  - CSS カウンタースタイル
-  - ガイド
-  - NeedsContent
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/CSS_Counter_Styles
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_counter_styles/using_css_counters/index.md
+++ b/files/ja/web/css/css_counter_styles/using_css_counters/index.md
@@ -1,15 +1,6 @@
 ---
 title: CSS カウンターの使用
 slug: Web/CSS/CSS_Counter_Styles/Using_CSS_counters
-tags:
-  - 上級者
-  - CSS
-  - CSS カウンタースタイル
-  - ガイド
-  - レイアウト
-  - リファレンス
-  - ウェブ
-translation_of: Web/CSS/CSS_Counter_Styles/Using_CSS_counters
 original_slug: Web/CSS/CSS_Lists_and_Counters/Using_CSS_counters
 ---
 {{CSSRef}}

--- a/files/ja/web/css/css_device_adaptation/index.md
+++ b/files/ja/web/css/css_device_adaptation/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS 端末適合
 slug: Web/CSS/CSS_Device_Adaptation
-tags:
-  - CSS
-  - CSS 端末適合
-  - ガイド
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/CSS_Device_Adaptation
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_display/index.md
+++ b/files/ja/web/css/css_display/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS 表示方法
 slug: Web/CSS/CSS_Display
-tags:
-  - CSS
-  - CSS 表示方法
-  - ガイド
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/CSS_Display
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.md
+++ b/files/ja/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.md
@@ -1,19 +1,6 @@
 ---
 title: フレックスコンテナー内のアイテムの配置
 slug: Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container
-tags:
-  - 配置
-  - CSS
-  - Flex
-  - ガイド
-  - align-content
-  - align-items
-  - align-self
-  - alignment
-  - フレックスボックス
-  - justify
-  - justify-content
-translation_of: Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_flexible_box_layout/backwards_compatibility_of_flexbox/index.md
+++ b/files/ja/web/css/css_flexible_box_layout/backwards_compatibility_of_flexbox/index.md
@@ -1,18 +1,6 @@
 ---
 title: フレックスボックスの後方互換性
 slug: Web/CSS/CSS_Flexible_Box_Layout/Backwards_Compatibility_of_Flexbox
-tags:
-  - '@supports'
-  - CSS
-  - CSS 表
-  - フレックスボックス
-  - 浮動
-  - ガイド
-  - 代替
-  - 機能クエリー
-  - フレックスボックス
-  - inline-block
-translation_of: Web/CSS/CSS_Flexible_Box_Layout/Backwards_Compatibility_of_Flexbox
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
+++ b/files/ja/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
@@ -1,15 +1,6 @@
 ---
 title: フレックスボックスの基本概念
 slug: Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox
-tags:
-  - CSS
-  - Flex
-  - ガイド
-  - axes
-  - 概念
-  - コンテナー
-  - フレックスボックス
-translation_of: Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_flexible_box_layout/controlling_ratios_of_flex_items_along_the_main_ax/index.md
+++ b/files/ja/web/css/css_flexible_box_layout/controlling_ratios_of_flex_items_along_the_main_ax/index.md
@@ -1,21 +1,6 @@
 ---
 title: 主軸に沿ったフレックスアイテムの比率の制御
-slug: >-
-  Web/CSS/CSS_Flexible_Box_Layout/Controlling_Ratios_of_Flex_Items_Along_the_Main_Ax
-tags:
-  - Basis
-  - CSS
-  - Flex
-  - ガイド
-  - フレックスボックス
-  - free space
-  - grow
-  - max-content
-  - min-content
-  - shrink
-  - space
-translation_of: >-
-  Web/CSS/CSS_Flexible_Box_Layout/Controlling_Ratios_of_Flex_Items_Along_the_Main_Ax
+slug: Web/CSS/CSS_Flexible_Box_Layout/Controlling_Ratios_of_Flex_Items_Along_the_Main_Ax
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_flexible_box_layout/index.md
+++ b/files/ja/web/css/css_flexible_box_layout/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSS フレックスボックスレイアウト
 slug: Web/CSS/CSS_Flexible_Box_Layout
-tags:
-  - CSS
-  - CSS フレックスボックス
-  - ガイド
-  - 概要
-  - リファレンス
-  - フレックスボックス
-translation_of: Web/CSS/CSS_Flexible_Box_Layout
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_flexible_box_layout/mastering_wrapping_of_flex_items/index.md
+++ b/files/ja/web/css/css_flexible_box_layout/mastering_wrapping_of_flex_items/index.md
@@ -1,15 +1,6 @@
 ---
 title: フレックスアイテムの折り返しのマスター
 slug: Web/CSS/CSS_Flexible_Box_Layout/Mastering_Wrapping_of_Flex_Items
-tags:
-  - CSS
-  - Flex
-  - ガイド
-  - collapsed items
-  - フレックスボックス
-  - grid
-  - 折り返し
-translation_of: Web/CSS/CSS_Flexible_Box_Layout/Mastering_Wrapping_of_Flex_Items
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_flexible_box_layout/ordering_flex_items/index.md
+++ b/files/ja/web/css/css_flexible_box_layout/ordering_flex_items/index.md
@@ -1,16 +1,6 @@
 ---
 title: フレックスアイテムの並べ替え
 slug: Web/CSS/CSS_Flexible_Box_Layout/Ordering_Flex_Items
-tags:
-  - アクセシビリティ
-  - CSS
-  - Flex
-  - ガイド
-  - 方向
-  - フレックスボックス
-  - order
-  - reverse
-translation_of: Web/CSS/CSS_Flexible_Box_Layout/Ordering_Flex_Items
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_flexible_box_layout/relationship_of_flexbox_to_other_layout_methods/index.md
+++ b/files/ja/web/css/css_flexible_box_layout/relationship_of_flexbox_to_other_layout_methods/index.md
@@ -1,18 +1,6 @@
 ---
 title: フレックスボックスと他のレイアウト方法の関係
-slug: >-
-  Web/CSS/CSS_Flexible_Box_Layout/Relationship_of_Flexbox_to_Other_Layout_Methods
-tags:
-  - CSS
-  - ガイド
-  - 書字方向
-  - ボックス配置
-  - contents
-  - display
-  - フレックスボックス
-  - grid
-translation_of: >-
-  Web/CSS/CSS_Flexible_Box_Layout/Relationship_of_Flexbox_to_Other_Layout_Methods
+slug: Web/CSS/CSS_Flexible_Box_Layout/Relationship_of_Flexbox_to_Other_Layout_Methods
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_flexible_box_layout/typical_use_cases_of_flexbox/index.md
+++ b/files/ja/web/css/css_flexible_box_layout/typical_use_cases_of_flexbox/index.md
@@ -1,14 +1,6 @@
 ---
 title: フレックスボックスの典型的な用途
 slug: Web/CSS/CSS_Flexible_Box_Layout/Typical_Use_Cases_of_Flexbox
-tags:
-  - CSS
-  - フレックスボックス
-  - ガイド
-  - 用途
-  - フレックスボックス
-  - patterns
-translation_of: Web/CSS/CSS_Flexible_Box_Layout/Typical_Use_Cases_of_Flexbox
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_flow_layout/block_and_inline_layout_in_normal_flow/index.md
+++ b/files/ja/web/css/css_flow_layout/block_and_inline_layout_in_normal_flow/index.md
@@ -1,20 +1,6 @@
 ---
 title: 通常フローでのブロック及びインラインレイアウト
 slug: Web/CSS/CSS_Flow_Layout/Block_and_Inline_Layout_in_Normal_Flow
-tags:
-  - CSS
-  - CSS Flow Layout
-  - CSS フローレイアウト
-  - Guide
-  - Intermediate
-  - Layout
-  - Margins
-  - flow
-  - ガイド
-  - マージン
-  - レイアウト
-  - 中級者
-translation_of: Web/CSS/CSS_Flow_Layout/Block_and_Inline_Layout_in_Normal_Flow
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_flow_layout/flow_layout_and_overflow/index.md
+++ b/files/ja/web/css/css_flow_layout/flow_layout_and_overflow/index.md
@@ -1,16 +1,6 @@
 ---
 title: フローレイアウトとオーバーフロー
 slug: Web/CSS/CSS_Flow_Layout/Flow_Layout_and_Overflow
-tags:
-  - CSS
-  - overflow
-  - text-overflow
-  - ガイド
-  - フローレイアウト
-  - レイアウト
-  - 中級者
-  - 可視性
-translation_of: Web/CSS/CSS_Flow_Layout/Flow_Layout_and_Overflow
 ---
 コンテナーに収まらない量のコンテンツがある場合、オーバーフローが発生します。どのようにオーバーフローが動作するかを理解することは、 CSS で制約された寸法で要素を扱うのに重要です。このガイドでは、通常フローで作業中にオーバーフローがどのように起こるかを説明します。
 

--- a/files/ja/web/css/css_flow_layout/flow_layout_and_writing_modes/index.md
+++ b/files/ja/web/css/css_flow_layout/flow_layout_and_writing_modes/index.md
@@ -1,14 +1,6 @@
 ---
 title: フローレイアウトと書字方向
 slug: Web/CSS/CSS_Flow_Layout/Flow_Layout_and_Writing_Modes
-tags:
-  - CSS 書字方向
-  - ガイド
-  - フローレイアウト
-  - 方向
-  - 日本語処理
-  - 書字方向
-translation_of: Web/CSS/CSS_Flow_Layout/Flow_Layout_and_Writing_Modes
 ---
 通常フローの動きについて詳細を説明している CSS 2.1 仕様書は、横書きを想定しています。[レイアウト](/ja/docs/Web/CSS/CSS_Flow_Layout/Block_and_Inline_Layout_in_Normal_Flow)プロパティは縦書きモードでも同様に動作するべきです。このガイドでは、異なる文書の書字方向が使われた場合のフローレイアウトの動作を見てみましょう。
 

--- a/files/ja/web/css/css_flow_layout/in_flow_and_out_of_flow/index.md
+++ b/files/ja/web/css/css_flow_layout/in_flow_and_out_of_flow/index.md
@@ -1,7 +1,6 @@
 ---
 title: フロー内とフローの外
 slug: Web/CSS/CSS_Flow_Layout/In_Flow_and_Out_of_Flow
-translation_of: Web/CSS/CSS_Flow_Layout/In_Flow_and_Out_of_Flow
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_flow_layout/index.md
+++ b/files/ja/web/css/css_flow_layout/index.md
@@ -1,15 +1,6 @@
 ---
 title: CSS フローレイアウト
 slug: Web/CSS/CSS_Flow_Layout
-tags:
-  - CSS
-  - Reference
-  - ガイド
-  - フロー
-  - フローレイアウト
-  - レイアウト
-  - 中級者
-translation_of: Web/CSS/CSS_Flow_Layout
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_flow_layout/intro_to_formatting_contexts/index.md
+++ b/files/ja/web/css/css_flow_layout/intro_to_formatting_contexts/index.md
@@ -1,20 +1,6 @@
 ---
 title: 整形コンテキストの紹介
 slug: Web/CSS/CSS_Flow_Layout/Intro_to_formatting_contexts
-tags:
-  - BFC
-  - Block Formatting Context
-  - CSS
-  - Formatting contexts
-  - Guide
-  - Intermediate
-  - Layout
-  - flow
-  - ガイド
-  - ブロック整形コンテキスト
-  - 中級者
-  - 整形コンテキスト
-translation_of: Web/CSS/CSS_Flow_Layout/Intro_to_formatting_contexts
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_fonts/index.md
+++ b/files/ja/web/css/css_fonts/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS フォント
 slug: Web/CSS/CSS_Fonts
-tags:
-  - CSS
-  - CSS フォント
-  - ガイド
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/CSS_Fonts
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_fonts/opentype_fonts_guide/index.md
+++ b/files/ja/web/css/css_fonts/opentype_fonts_guide/index.md
@@ -1,11 +1,6 @@
 ---
 title: OpenType フォント特性の手引き
 slug: Web/CSS/CSS_Fonts/OpenType_fonts_guide
-tags:
-  - CSS
-  - Fonts
-  - Text
-translation_of: Web/CSS/CSS_Fonts/OpenType_fonts_guide
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_fonts/variable_fonts_guide/index.md
+++ b/files/ja/web/css/css_fonts/variable_fonts_guide/index.md
@@ -1,14 +1,6 @@
 ---
 title: 可変フォントガイド
 slug: Web/CSS/CSS_Fonts/Variable_Fonts_Guide
-tags:
-  - CSS
-  - Fonts
-  - Guide
-  - Text
-  - variable fonts
-  - web fonts
-translation_of: Web/CSS/CSS_Fonts/Variable_Fonts_Guide
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_fragmentation/index.md
+++ b/files/ja/web/css/css_fragmentation/index.md
@@ -1,15 +1,6 @@
 ---
 title: CSS 断片化
 slug: Web/CSS/CSS_Fragmentation
-tags:
-  - CSS
-  - CSS 断片化
-  - ガイド
-  - NeedsCompatTable
-  - NeedsContent
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/CSS_Fragmentation
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_functions/index.md
+++ b/files/ja/web/css/css_functions/index.md
@@ -1,16 +1,6 @@
 ---
 title: CSS 関数記法
 slug: Web/CSS/CSS_Functions
-tags:
-  - CSS
-  - CSS データ型
-  - CSS 関数
-  - 関数記法
-  - 関数
-  - リファレンス
-  - 型
-  - データ型
-translation_of: Web/CSS/CSS_Functions
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_generated_content/index.md
+++ b/files/ja/web/css/css_generated_content/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS 生成コンテンツ
 slug: Web/CSS/CSS_Generated_Content
-tags:
-  - CSS
-  - CSS 生成コンテンツ
-  - ガイド
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/CSS_Generated_Content
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_grid_layout/auto-placement_in_css_grid_layout/index.md
+++ b/files/ja/web/css/css_grid_layout/auto-placement_in_css_grid_layout/index.md
@@ -1,11 +1,6 @@
 ---
 title: CSS グリッドレイアウトでの自動配置
 slug: Web/CSS/CSS_Grid_Layout/Auto-placement_in_CSS_Grid_Layout
-tags:
-  - CSS
-  - CSS グリッド
-  - ガイド
-translation_of: Web/CSS/CSS_Grid_Layout/Auto-placement_in_CSS_Grid_Layout
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
+++ b/files/ja/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
@@ -1,12 +1,6 @@
 ---
 title: グリッドレイアウトの基本概念
 slug: Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout
-tags:
-  - CSS
-  - CSS グリッド
-  - ガイド
-  - レイアウト
-translation_of: Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_grid_layout/box_alignment_in_css_grid_layout/index.md
+++ b/files/ja/web/css/css_grid_layout/box_alignment_in_css_grid_layout/index.md
@@ -1,16 +1,6 @@
 ---
 title: CSS グリッドレイアウトのボックス配置
 slug: Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout
-tags:
-  - グリッドでの配置
-  - ボックス
-  - CSS
-  - CSS グリッド
-  - グリッド配置
-  - ガイド
-  - alignment
-  - ボックス配置
-translation_of: Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_grid_layout/css_grid_and_progressive_enhancement/index.md
+++ b/files/ja/web/css/css_grid_layout/css_grid_and_progressive_enhancement/index.md
@@ -1,12 +1,6 @@
 ---
 title: CSS グリッドレイアウトとプログレッシブエンハンスメント
 slug: Web/CSS/CSS_Grid_Layout/CSS_Grid_and_Progressive_Enhancement
-tags:
-  - CSS
-  - CSS グリッド
-  - デザイン
-  - ガイド
-translation_of: Web/CSS/CSS_Grid_Layout/CSS_Grid_and_Progressive_Enhancement
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_grid_layout/css_grid_layout_and_accessibility/index.md
+++ b/files/ja/web/css/css_grid_layout/css_grid_layout_and_accessibility/index.md
@@ -1,11 +1,6 @@
 ---
 title: CSS グリッドレイアウトとアクセシビリティ
 slug: Web/CSS/CSS_Grid_Layout/CSS_Grid_Layout_and_Accessibility
-tags:
-  - Accessibility
-  - CSS
-  - CSS グリッド
-  - ガイド
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_grid_layout/css_grid_logical_values_and_writing_modes/index.md
+++ b/files/ja/web/css/css_grid_layout/css_grid_logical_values_and_writing_modes/index.md
@@ -1,11 +1,6 @@
 ---
 title: CSS グリッドと論理的な値と書字方向
 slug: Web/CSS/CSS_Grid_Layout/CSS_Grid_Logical_Values_and_Writing_Modes
-tags:
-  - CSS
-  - CSS グリッド
-  - ガイド
-translation_of: Web/CSS/CSS_Grid_Layout/CSS_Grid_Logical_Values_and_Writing_Modes
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_grid_layout/grid_template_areas/index.md
+++ b/files/ja/web/css/css_grid_layout/grid_template_areas/index.md
@@ -1,11 +1,6 @@
 ---
 title: グリッドテンプレート領域
 slug: Web/CSS/CSS_Grid_Layout/Grid_Template_Areas
-tags:
-  - CSS
-  - CSS グリッド
-  - ガイド
-translation_of: Web/CSS/CSS_Grid_Layout/Grid_Template_Areas
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_grid_layout/index.md
+++ b/files/ja/web/css/css_grid_layout/index.md
@@ -1,15 +1,6 @@
 ---
 title: CSS グリッドレイアウト
 slug: Web/CSS/CSS_Grid_Layout
-tags:
-  - CSS
-  - グリッドレイアウト
-  - グリッド
-  - ガイド
-  - レイアウト
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/CSS_Grid_Layout
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_grid_layout/layout_using_named_grid_lines/index.md
+++ b/files/ja/web/css/css_grid_layout/layout_using_named_grid_lines/index.md
@@ -1,11 +1,6 @@
 ---
 title: 名前付きグリッド線を使用したレイアウト
 slug: Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines
-tags:
-  - CSS
-  - CSS グリッド
-  - ガイド
-translation_of: Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_grid_layout/line-based_placement_with_css_grid/index.md
+++ b/files/ja/web/css/css_grid_layout/line-based_placement_with_css_grid/index.md
@@ -1,11 +1,6 @@
 ---
 title: CSS グリッドにおける線に基づく配置
 slug: Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid
-tags:
-  - CSS
-  - CSS グリッド
-  - ガイド
-translation_of: Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_grid_layout/masonry_layout/index.md
+++ b/files/ja/web/css/css_grid_layout/masonry_layout/index.md
@@ -1,12 +1,6 @@
 ---
 title: 組積レイアウト
 slug: Web/CSS/CSS_Grid_Layout/Masonry_Layout
-tags:
-  - CSS
-  - CSS グリッド
-  - 実験的
-  - 組積
-translation_of: Web/CSS/CSS_Grid_Layout/Masonry_Layout
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_grid_layout/realizing_common_layouts_using_css_grid_layout/index.md
+++ b/files/ja/web/css/css_grid_layout/realizing_common_layouts_using_css_grid_layout/index.md
@@ -1,11 +1,6 @@
 ---
 title: CSS Grid Layout によるよくあるレイアウトの実現
 slug: Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout
-tags:
-  - CSS
-  - CSS Grids
-  - Guide
-translation_of: Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_grid_layout/relationship_of_grid_layout/index.md
+++ b/files/ja/web/css/css_grid_layout/relationship_of_grid_layout/index.md
@@ -1,11 +1,6 @@
 ---
 title: グリッドレイアウトと他のレイアウト方法との関係
 slug: Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout
-tags:
-  - CSS
-  - CSS Grids
-  - Guide
-translation_of: Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_grid_layout/subgrid/index.md
+++ b/files/ja/web/css/css_grid_layout/subgrid/index.md
@@ -1,13 +1,6 @@
 ---
 title: サブグリッド
 slug: Web/CSS/CSS_Grid_Layout/Subgrid
-tags:
-  - CSS
-  - CSS 表示
-  - CSS グリッド
-  - ガイド
-  - サブグリッド
-translation_of: Web/CSS/CSS_Grid_Layout/Subgrid
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_houdini/index.md
+++ b/files/ja/web/css/css_houdini/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSS Houdini
 slug: Web/CSS/CSS_Houdini
-tags:
-  - CSS
-  - Houdini
-  - Experimental
-  - Guide
-  - Overview
-  - Reference
-translation_of: Web/CSS/CSS_Houdini
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_images/implementing_image_sprites_in_css/index.md
+++ b/files/ja/web/css/css_images/implementing_image_sprites_in_css/index.md
@@ -1,16 +1,6 @@
 ---
 title: CSS での画像スプライトの実装
 slug: Web/CSS/CSS_Images/Implementing_image_sprites_in_CSS
-tags:
-  - 上級者
-  - CSS
-  - CSS 画像
-  - グラフィック
-  - ガイド
-  - NeedsContent
-  - スプライト
-  - ウェブ
-translation_of: Web/CSS/CSS_Images/Implementing_image_sprites_in_CSS
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_images/index.md
+++ b/files/ja/web/css/css_images/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS 画像
 slug: Web/CSS/CSS_Images
-tags:
-  - CSS
-  - CSS 画像
-  - ガイド
-  - 概要
-  - Reference
-translation_of: Web/CSS/CSS_Images
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_images/using_css_gradients/index.md
+++ b/files/ja/web/css/css_images/using_css_gradients/index.md
@@ -1,15 +1,6 @@
 ---
 title: CSS グラデーションの使用
 slug: Web/CSS/CSS_Images/Using_CSS_gradients
-tags:
-  - 上級者
-  - CSS
-  - CSS 画像
-  - 例
-  - グラデーション
-  - ガイド
-  - ウェブ
-translation_of: Web/CSS/CSS_Images/Using_CSS_gradients
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_lists_and_counters/consistent_list_indentation/index.md
+++ b/files/ja/web/css/css_lists_and_counters/consistent_list_indentation/index.md
@@ -1,11 +1,6 @@
 ---
 title: 一貫性のあるリストのインデント
 slug: Web/CSS/CSS_Lists_and_Counters/Consistent_list_indentation
-tags:
-  - CSS
-  - ガイド
-  - NeedsUpdate
-translation_of: Web/CSS/CSS_Lists_and_Counters/Consistent_list_indentation
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_lists_and_counters/index.md
+++ b/files/ja/web/css/css_lists_and_counters/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS リスト
 slug: Web/CSS/CSS_Lists_and_Counters
-tags:
-  - CSS
-  - CSS リスト
-  - ガイド
-  - 概要
-  - Reference
-translation_of: Web/CSS/CSS_Lists_and_Counters
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_logical_properties/basic_concepts/index.md
+++ b/files/ja/web/css/css_logical_properties/basic_concepts/index.md
@@ -1,13 +1,6 @@
 ---
 title: 論理的プロパティと値の基本概念
 slug: Web/CSS/CSS_Logical_Properties/Basic_concepts
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - ガイド
-  - 概念
-  - 書字方向
-translation_of: Web/CSS/CSS_Logical_Properties/Basic_concepts
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_logical_properties/floating_and_positioning/index.md
+++ b/files/ja/web/css/css_logical_properties/floating_and_positioning/index.md
@@ -1,13 +1,6 @@
 ---
 title: 浮動と位置指定の論理的プロパティ
 slug: Web/CSS/CSS_Logical_Properties/Floating_and_positioning
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - 浮動
-  - ガイド
-  - 位置指定
-translation_of: Web/CSS/CSS_Logical_Properties/Floating_and_positioning
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_logical_properties/index.md
+++ b/files/ja/web/css/css_logical_properties/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSS 論理的プロパティと値
 slug: Web/CSS/CSS_Logical_Properties
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - ガイド
-  - Landing
-  - 概要
-  - Reference
-translation_of: Web/CSS/CSS_Logical_Properties
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_logical_properties/margins_borders_padding/index.md
+++ b/files/ja/web/css/css_logical_properties/margins_borders_padding/index.md
@@ -1,13 +1,6 @@
 ---
 title: マージン、境界、パディングの論理的プロパティ
 slug: Web/CSS/CSS_Logical_Properties/Margins_borders_padding
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - ガイド
-  - 概念
-  - 書字方向
-translation_of: Web/CSS/CSS_Logical_Properties/Margins_borders_padding
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_logical_properties/sizing/index.md
+++ b/files/ja/web/css/css_logical_properties/sizing/index.md
@@ -1,13 +1,6 @@
 ---
 title: 寸法の論理的プロパティ
 slug: Web/CSS/CSS_Logical_Properties/Sizing
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - ガイド
-  - 寸法
-  - 書字方向
-translation_of: Web/CSS/CSS_Logical_Properties/Sizing
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_masking/index.md
+++ b/files/ja/web/css/css_masking/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS マスク
 slug: Web/CSS/CSS_Masking
-tags:
-  - CSS
-  - CSS マスク
-  - ガイド
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/CSS_Masking
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_miscellaneous/index.md
+++ b/files/ja/web/css/css_miscellaneous/index.md
@@ -1,12 +1,6 @@
 ---
 title: CSS 雑題
 slug: Web/CSS/CSS_Miscellaneous
-tags:
-  - CSS
-  - ガイド
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/CSS_Miscellaneous
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_motion_path/index.md
+++ b/files/ja/web/css/css_motion_path/index.md
@@ -1,15 +1,6 @@
 ---
 title: CSS モーションパス
 slug: Web/CSS/CSS_Motion_Path
-tags:
-  - CSS
-  - CSS モーションパス
-  - 実験的
-  - ガイド
-  - モーションパス
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/CSS_Motion_Path
 ---
 {{CSSRef}}{{SeeCompatTable}}
 

--- a/files/ja/web/css/css_namespaces/index.md
+++ b/files/ja/web/css/css_namespaces/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSS 名前空間
 slug: Web/CSS/CSS_Namespaces
-tags:
-  - CSS
-  - CSS 名前空間
-  - ガイド
-  - 概要
-  - リファレンス
-  - ウェブ
-translation_of: Web/CSS/CSS_Namespaces
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_overflow/index.md
+++ b/files/ja/web/css/css_overflow/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS オーバーフロー
 slug: Web/CSS/CSS_Overflow
-tags:
-  - CSS
-  - ガイド
-  - overflow
-  - スクロールバー
-  - スクロール
-translation_of: Web/CSS/CSS_Overflow
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_pages/index.md
+++ b/files/ja/web/css/css_pages/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS ページメディア
 slug: Web/CSS/CSS_Pages
-tags:
-  - CSS
-  - CSS ページメディア
-  - ガイド
-  - 概要
-  - Reference
-translation_of: Web/CSS/CSS_Pages
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_positioning/index.md
+++ b/files/ja/web/css/css_positioning/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS 位置指定レイアウト
 slug: Web/CSS/CSS_Positioning
-tags:
-  - CSS
-  - CSS 位置指定レイアウト
-  - ガイド
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/CSS_Positioning
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_positioning/understanding_z_index/adding_z-index/index.md
+++ b/files/ja/web/css/css_positioning/understanding_z_index/adding_z-index/index.md
@@ -1,14 +1,6 @@
 ---
 title: z-index の使用
 slug: Web/CSS/CSS_Positioning/Understanding_z_index/Adding_z-index
-tags:
-  - 上級者
-  - CSS
-  - ガイド
-  - リファレンス
-  - Understanding_CSS_z-index
-  - z-index
-translation_of: Web/CSS/CSS_Positioning/Understanding_z_index/Adding_z-index
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_positioning/understanding_z_index/index.md
+++ b/files/ja/web/css/css_positioning/understanding_z_index/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSS の z-index を理解する
 slug: Web/CSS/CSS_Positioning/Understanding_z_index
-tags:
-  - 上級者
-  - CSS
-  - ガイド
-  - リファレンス
-  - Understanding_CSS_z-index
-  - z-index
-translation_of: Web/CSS/CSS_Positioning/Understanding_z_index
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_positioning/understanding_z_index/stacking_and_float/index.md
+++ b/files/ja/web/css/css_positioning/understanding_z_index/stacking_and_float/index.md
@@ -1,14 +1,6 @@
 ---
 title: 浮動ブロックの重ね合わせ
 slug: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_and_float
-tags:
-  - 上級者
-  - CSS
-  - ガイド
-  - リファレンス
-  - Understanding_CSS_z-index
-  - z-index
-translation_of: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_and_float
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_positioning/understanding_z_index/stacking_context_example_1/index.md
+++ b/files/ja/web/css/css_positioning/understanding_z_index/stacking_context_example_1/index.md
@@ -1,12 +1,6 @@
 ---
 title: 重ね合わせコンテキストの例 1
 slug: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_1
-tags:
-  - Advanced
-  - CSS
-  - Guide
-  - Understanding_CSS_z-index
-translation_of: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_1
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_positioning/understanding_z_index/stacking_context_example_2/index.md
+++ b/files/ja/web/css/css_positioning/understanding_z_index/stacking_context_example_2/index.md
@@ -1,12 +1,6 @@
 ---
 title: 重ね合わせコンテキストの例 2
 slug: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_2
-tags:
-  - 上級者
-  - CSS
-  - ガイド
-  - Understanding_CSS_z-index
-translation_of: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_2
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_positioning/understanding_z_index/stacking_context_example_3/index.md
+++ b/files/ja/web/css/css_positioning/understanding_z_index/stacking_context_example_3/index.md
@@ -1,12 +1,6 @@
 ---
 title: 重ね合わせコンテキストの例 3
 slug: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_3
-tags:
-  - 上級者
-  - CSS
-  - ガイド
-  - Understanding_CSS_z-index
-translation_of: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_3
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_positioning/understanding_z_index/stacking_without_z-index/index.md
+++ b/files/ja/web/css/css_positioning/understanding_z_index/stacking_without_z-index/index.md
@@ -1,14 +1,6 @@
 ---
 title: z-index なしの重ね合わせ
 slug: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_without_z-index
-tags:
-  - 上級者
-  - CSS
-  - ガイド
-  - リファレンス
-  - Understanding_CSS_z-index
-  - z-index
-translation_of: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_without_z-index
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_positioning/understanding_z_index/the_stacking_context/index.md
+++ b/files/ja/web/css/css_positioning/understanding_z_index/the_stacking_context/index.md
@@ -1,13 +1,6 @@
 ---
 title: 重ね合わせコンテキスト
 slug: Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
-tags:
-  - 上級者
-  - CSS
-  - ガイド
-  - リファレンス
-  - z-index
-translation_of: Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_ruby/index.md
+++ b/files/ja/web/css/css_ruby/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS ルビレイアウト
 slug: Web/CSS/CSS_Ruby
-tags:
-  - CSS
-  - CSS ルビ
-  - ガイド
-  - 概要
-  - Reference
-translation_of: Web/CSS/CSS_Ruby
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_scroll_snap/basic_concepts/index.md
+++ b/files/ja/web/css/css_scroll_snap/basic_concepts/index.md
@@ -1,11 +1,6 @@
 ---
 title: CSS スクロールスナップの基本概念
 slug: Web/CSS/CSS_Scroll_Snap/Basic_concepts
-tags:
-  - CSS
-  - CSS スクロールスナップ
-  - Guide
-  - concepts
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_scroll_snap/index.md
+++ b/files/ja/web/css/css_scroll_snap/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS スクロールスナップ
 slug: Web/CSS/CSS_Scroll_Snap
-tags:
-  - CSS
-  - CSS スクロールスナップ
-  - Guide
-  - 概要
-  - Reference
-translation_of: Web/CSS/CSS_Scroll_Snap
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_scroll_snap_points/index.md
+++ b/files/ja/web/css/css_scroll_snap_points/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS スクロールスナップ点
 slug: Web/CSS/CSS_Scroll_Snap_Points
-tags:
-  - CSS
-  - CSS スクロールスナップ
-  - ガイド
-  - 概要
-  - Reference
-translation_of: Web/CSS/CSS_Scroll_Snap_Points
 ---
 {{CSSRef}} {{deprecated_header}}
 

--- a/files/ja/web/css/css_scrollbars/index.md
+++ b/files/ja/web/css/css_scrollbars/index.md
@@ -1,12 +1,6 @@
 ---
 title: CSS スクロールバー
 slug: Web/CSS/CSS_Scrollbars
-tags:
-  - CSS
-  - ガイド
-  - 概要
-  - CSS スクロールバー
-translation_of: Web/CSS/CSS_Scrollbars
 ---
 {{CSSRef}}{{SeeCompatTable}}
 

--- a/files/ja/web/css/css_selectors/index.md
+++ b/files/ja/web/css/css_selectors/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS セレクター
 slug: Web/CSS/CSS_Selectors
-tags:
-  - CSS
-  - ガイド
-  - 概要
-  - リファレンス
-  - セレクター
-translation_of: Web/CSS/CSS_Selectors
 ---
 {{CSSRef("Selectors")}}
 

--- a/files/ja/web/css/css_selectors/using_the__colon_target_pseudo-class_in_selectors/index.md
+++ b/files/ja/web/css/css_selectors/using_the__colon_target_pseudo-class_in_selectors/index.md
@@ -1,13 +1,6 @@
 ---
-title: 'セレクターでの :target 擬似クラスの利用'
+title: セレクターでの :target 擬似クラスの利用
 slug: Web/CSS/CSS_Selectors/Using_the_:target_pseudo-class_in_selectors
-tags:
-  - ':target'
-  - CSS
-  - ガイド
-  - リファレンス
-  - セレクター
-translation_of: Web/CSS/CSS_Selectors/Using_the_:target_pseudo-class_in_selectors
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_shapes/basic_shapes/index.md
+++ b/files/ja/web/css/css_shapes/basic_shapes/index.md
@@ -1,12 +1,6 @@
 ---
 title: 基本シェイプ
 slug: Web/CSS/CSS_Shapes/Basic_Shapes
-tags:
-  - CSS
-  - CSS シェイプ
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/CSS_Shapes/Basic_Shapes
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_shapes/from_box_values/index.md
+++ b/files/ja/web/css/css_shapes/from_box_values/index.md
@@ -1,22 +1,6 @@
 ---
 title: ボックス値からのシェイプ
 slug: Web/CSS/CSS_Shapes/From_box_values
-tags:
-  - 境界
-  - ボックス
-  - CSS
-  - CSS シェイプ
-  - 概要
-  - マージン
-  - border-box
-  - border-radius
-  - ボックス値
-  - content-box
-  - float
-  - margin-box
-  - padding-box
-  - シェイプ
-translation_of: Web/CSS/CSS_Shapes/From_box_values
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_shapes/index.md
+++ b/files/ja/web/css/css_shapes/index.md
@@ -1,16 +1,6 @@
 ---
 title: CSS シェイプ
 slug: Web/CSS/CSS_Shapes
-tags:
-  - 境界
-  - CSS
-  - CSS シェイプ
-  - ガイド
-  - 概要
-  - Reference
-  - シェイプ
-  - wrapping
-translation_of: Web/CSS/CSS_Shapes
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_shapes/overview_of_css_shapes/index.md
+++ b/files/ja/web/css/css_shapes/overview_of_css_shapes/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS シェイプの概要
 slug: Web/CSS/CSS_Shapes/Overview_of_CSS_Shapes
-tags:
-  - CSS
-  - CSS シェイプ
-  - ガイド
-  - 概要
-  - シェイプ
-translation_of: Web/CSS/CSS_Shapes/Overview_of_CSS_Shapes
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_shapes/shapes_from_images/index.md
+++ b/files/ja/web/css/css_shapes/shapes_from_images/index.md
@@ -1,11 +1,6 @@
 ---
 title: 画像からのシェイプの作成
 slug: Web/CSS/CSS_Shapes/Shapes_From_Images
-tags:
-  - CSS
-  - CSS シェイプ
-  - ガイド
-translation_of: Web/CSS/CSS_Shapes/Shapes_From_Images
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_table/index.md
+++ b/files/ja/web/css/css_table/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS 表
 slug: Web/CSS/CSS_Table
-tags:
-  - CSS
-  - CSS 表
-  - ガイド
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/CSS_Table
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_text/index.md
+++ b/files/ja/web/css/css_text/index.md
@@ -1,11 +1,6 @@
 ---
 title: CSS テキスト
 slug: Web/CSS/CSS_Text
-tags:
-  - CSS
-  - CSS テキスト
-  - ガイド
-translation_of: Web/CSS/CSS_Text
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_text/wrapping_text/index.md
+++ b/files/ja/web/css/css_text/wrapping_text/index.md
@@ -1,14 +1,6 @@
 ---
 title: テキストの分割と折り返し
 slug: Web/CSS/CSS_Text/Wrapping_Text
-tags:
-  - CSS
-  - CSS テキスト
-  - Guide
-  - overflow
-  - overflow-wrap
-  - word-break
-translation_of: Web/CSS/CSS_Text/Wrapping_Text
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_text_decoration/index.md
+++ b/files/ja/web/css/css_text_decoration/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS テキスト装飾
 slug: Web/CSS/CSS_Text_Decoration
-tags:
-  - CSS
-  - CSS Text Decoration
-  - Guide
-  - Overview
-  - Reference
-translation_of: Web/CSS/CSS_Text_Decoration
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_transforms/index.md
+++ b/files/ja/web/css/css_transforms/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS 座標変換
 slug: Web/CSS/CSS_Transforms
-tags:
-  - CSS
-  - CSS 座標変換
-  - ガイド
-  - 概要
-  - Reference
-translation_of: Web/CSS/CSS_Transforms
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_transforms/using_css_transforms/index.md
+++ b/files/ja/web/css/css_transforms/using_css_transforms/index.md
@@ -1,19 +1,6 @@
 ---
 title: CSS 座標変換の使用
 slug: Web/CSS/CSS_Transforms/Using_CSS_transforms
-tags:
-  - 3D
-  - Advanced
-  - CSS
-  - CSS 座標変換
-  - グラフィック
-  - ガイド
-  - 回転
-  - 拡大縮小
-  - Scaling
-  - perspective
-  - rotation
-translation_of: Web/CSS/CSS_Transforms/Using_CSS_transforms
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_transitions/index.md
+++ b/files/ja/web/css/css_transitions/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS トランジション
 slug: Web/CSS/CSS_Transitions
-tags:
-  - CSS
-  - CSS トランジション
-  - ガイド
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/CSS_Transitions
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_transitions/using_css_transitions/index.md
+++ b/files/ja/web/css/css_transitions/using_css_transitions/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS トランジションの使用
 slug: Web/CSS/CSS_Transitions/Using_CSS_transitions
-tags:
-  - 上級者
-  - CSS
-  - CSS トランジション
-  - CSS3 トランジション
-  - Guide
-translation_of: Web/CSS/CSS_Transitions/Using_CSS_transitions
 ---
 {{CSSref}}
 

--- a/files/ja/web/css/css_types/index.md
+++ b/files/ja/web/css/css_types/index.md
@@ -1,18 +1,6 @@
 ---
 title: CSS データ型
 slug: Web/CSS/CSS_Types
-tags:
-  - CSS
-  - CSS データ型
-  - ガイド
-  - Index
-  - 概要
-  - リファレンス
-  - 構文
-  - 型
-  - データ型
-  - list
-translation_of: Web/CSS/CSS_Types
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_values_and_units/index.md
+++ b/files/ja/web/css/css_values_and_units/index.md
@@ -1,12 +1,6 @@
 ---
 title: CSS 値と単位
 slug: Web/CSS/CSS_Values_and_Units
-tags:
-  - CSS
-  - ガイド
-  - リファレンス
-  - 値と単位
-translation_of: Web/CSS/CSS_Values_and_Units
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/css_variables/index.md
+++ b/files/ja/web/css/css_variables/index.md
@@ -1,12 +1,6 @@
 ---
 title: 段階変数用のCSSカスタムプロパティ
 slug: Web/CSS/CSS_Variables
-tags:
-  - CSS
-  - CSS Variables
-  - Overview
-  - Reference
-translation_of: Web/CSS/CSS_Variables
 ---
 {{cssref}}
 

--- a/files/ja/web/css/css_writing_modes/index.md
+++ b/files/ja/web/css/css_writing_modes/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS 書字方向
 slug: Web/CSS/CSS_Writing_Modes
-tags:
-  - CSS
-  - CSS 書字方向
-  - リファレンス
-  - 日本語処理
-  - 概要
-translation_of: Web/CSS/CSS_Writing_Modes
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/cssom_view/coordinate_systems/index.md
+++ b/files/ja/web/css/cssom_view/coordinate_systems/index.md
@@ -1,15 +1,6 @@
 ---
 title: 座標系
 slug: Web/CSS/CSSOM_View/Coordinate_systems
-tags:
-  - CSS
-  - CSSOM
-  - CSSOM View
-  - 座標系
-  - 座標
-  - ガイド
-  - レイアウト
-  - NeedsContent
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/cssom_view/index.md
+++ b/files/ja/web/css/cssom_view/index.md
@@ -1,15 +1,6 @@
 ---
 title: CSSOM View
 slug: Web/CSS/CSSOM_View
-tags:
-  - CSS
-  - CSSOM
-  - CSSOM View
-  - ガイド
-  - レイアウト
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/CSSOM_View
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/cursor/index.md
+++ b/files/ja/web/css/cursor/index.md
@@ -1,19 +1,6 @@
 ---
 title: cursor
 slug: Web/CSS/cursor
-tags:
-  - Arrow
-  - CSS
-  - CSS プロパティ
-  - カーソル
-  - カスタムカーソル
-  - Reference
-  - UI
-  - マウス
-  - ポインター
-  - recipe:css-property
-browser-compat: css.properties.cursor
-translation_of: Web/CSS/cursor
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/custom-ident/index.md
+++ b/files/ja/web/css/custom-ident/index.md
@@ -1,14 +1,6 @@
 ---
 title: <custom-ident>
 slug: Web/CSS/custom-ident
-tags:
-  - CSS
-  - CSS データ型
-  - データ型
-  - レイアウト
-  - リファレンス
-  - ウェブ
-translation_of: Web/CSS/custom-ident
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/descendant_combinator/index.md
+++ b/files/ja/web/css/descendant_combinator/index.md
@@ -1,12 +1,6 @@
 ---
 title: 子孫結合子
 slug: Web/CSS/Descendant_combinator
-tags:
-  - CSS
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.descendant
-translation_of: Web/CSS/Descendant_combinator
 ---
 {{CSSRef("Selectors")}}
 

--- a/files/ja/web/css/dimension/index.md
+++ b/files/ja/web/css/dimension/index.md
@@ -1,16 +1,6 @@
 ---
 title: <dimension>
 slug: Web/CSS/dimension
-tags:
-  - CSS
-  - CSS データ型
-  - データ型
-  - リファレンス
-  - dimension
-  - 単位
-  - 値
-browser-compat: css.types.dimension
-translation_of: Web/CSS/dimension
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/direction/index.md
+++ b/files/ja/web/css/direction/index.md
@@ -1,14 +1,6 @@
 ---
 title: direction
 slug: Web/CSS/direction
-tags:
-  - BiDi
-  - CSS
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.direction
-translation_of: Web/CSS/direction
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/display-box/index.md
+++ b/files/ja/web/css/display-box/index.md
@@ -1,14 +1,6 @@
 ---
 title: <display-box>
 slug: Web/CSS/display-box
-tags:
-  - CSS
-  - CSS データ型
-  - CSS 表示
-  - データ型
-  - リファレンス
-  - display-box
-translation_of: Web/CSS/display-box
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/display-inside/index.md
+++ b/files/ja/web/css/display-inside/index.md
@@ -1,14 +1,6 @@
 ---
 title: <display-inside>
 slug: Web/CSS/display-inside
-tags:
-  - CSS
-  - CSS データ型
-  - CSS 表示
-  - データ型
-  - リファレンス
-  - display-inside
-translation_of: Web/CSS/display-inside
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/display-internal/index.md
+++ b/files/ja/web/css/display-internal/index.md
@@ -1,14 +1,6 @@
 ---
 title: <display-internal>
 slug: Web/CSS/display-internal
-tags:
-  - CSS
-  - CSS データ型
-  - CSS Display
-  - データ型
-  - リファレンス
-  - display-internal
-translation_of: Web/CSS/display-internal
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/display-legacy/index.md
+++ b/files/ja/web/css/display-legacy/index.md
@@ -1,14 +1,6 @@
 ---
 title: <display-legacy>
 slug: Web/CSS/display-legacy
-tags:
-  - CSS
-  - CSS データ型
-  - CSS 表示
-  - データ型
-  - リファレンス
-  - display-legacy
-translation_of: Web/CSS/display-legacy
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/display-listitem/index.md
+++ b/files/ja/web/css/display-listitem/index.md
@@ -1,13 +1,6 @@
 ---
 title: <display-listitem>
 slug: Web/CSS/display-listitem
-tags:
-  - CSS
-  - CSS データ型
-  - CSS 表示
-  - リファレンス
-  - list-item
-translation_of: Web/CSS/display-listitem
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/display-outside/index.md
+++ b/files/ja/web/css/display-outside/index.md
@@ -1,14 +1,6 @@
 ---
 title: <display-outside>
 slug: Web/CSS/display-outside
-tags:
-  - CSS
-  - CSS データ型
-  - CSS 表示
-  - データ型
-  - リファレンス
-  - display-outside
-translation_of: Web/CSS/display-outside
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/display/index.md
+++ b/files/ja/web/css/display/index.md
@@ -1,15 +1,6 @@
 ---
 title: display
 slug: Web/CSS/display
-tags:
-  - CSS
-  - CSS 表示方法
-  - CSS プロパティ
-  - リファレンス
-  - display
-  - recipe:css-property
-browser-compat: css.properties.display
-translation_of: Web/CSS/display
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/display/two-value_syntax_of_display/index.md
+++ b/files/ja/web/css/display/two-value_syntax_of_display/index.md
@@ -1,12 +1,6 @@
 ---
 title: display の新しい 2 値構文への対応
 slug: Web/CSS/display/two-value_syntax_of_display
-tags:
-  - CSS
-  - 例
-  - 実験的
-  - ガイド
-  - 中級者
 ---
 {{CSSRef}}
 


### PR DESCRIPTION
Part of #7858

`files/ja/web/css/{-,_,a,b,c,d}*` から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "tags": 415,
  "browser-compat": 258,
  "translation_of": 408,
  "spec-urls": 7
}
```
