### PR TITLE
remove duplicated frontmatter keys from web/css/{e..z} (ja)

### DIFF
--- a/files/ja/web/css/easing-function/index.md
+++ b/files/ja/web/css/easing-function/index.md
@@ -1,17 +1,6 @@
 ---
 title: <easing-function>
 slug: Web/CSS/easing-function
-tags:
-  - API
-  - CSS
-  - CSS Animations
-  - CSS Data Type
-  - CSS Transitions
-  - Data Type
-  - Layout
-  - Reference
-  - easing-function
-translation_of: Web/CSS/easing-function
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/element/index.md
+++ b/files/ja/web/css/element/index.md
@@ -1,17 +1,7 @@
 ---
 title: element()
 slug: Web/CSS/element
-tags:
-  - CSS
-  - CSS 関数
-  - CSS4-images
-  - 関数
-  - レイアウト
-  - Reference
-  - ウェブ
-translation_of: Web/CSS/element()
 original_slug: Web/CSS/element()
-browser-compat: css.types.image.element
 ---
 {{CSSRef}}{{SeeCompatTable}}
 

--- a/files/ja/web/css/empty-cells/index.md
+++ b/files/ja/web/css/empty-cells/index.md
@@ -1,14 +1,6 @@
 ---
 title: empty-cells
 slug: Web/CSS/empty-cells
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS 表
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.empty-cells
-translation_of: Web/CSS/empty-cells
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/env/index.md
+++ b/files/ja/web/css/env/index.md
@@ -1,19 +1,7 @@
 ---
 title: env()
 slug: Web/CSS/env
-tags:
-  - CSS
-  - CSS 変数
-  - CSS 関数
-  - Draft
-  - 関数
-  - リファレンス
-  - 変数
-  - env
-  - env()
-translation_of: Web/CSS/env()
 original_slug: Web/CSS/env()
-browser-compat: css.properties.custom-property.env
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/filter-function/blur/index.md
+++ b/files/ja/web/css/filter-function/blur/index.md
@@ -1,15 +1,7 @@
 ---
 title: blur()
 slug: Web/CSS/filter-function/blur
-tags:
-  - CSS
-  - CSS 関数
-  - フィルター効果
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/filter-function/blur()
 original_slug: Web/CSS/filter-function/blur()
-browser-compat: css.types.filter-function.blur
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/filter-function/brightness/index.md
+++ b/files/ja/web/css/filter-function/brightness/index.md
@@ -1,15 +1,7 @@
 ---
 title: brightness()
 slug: Web/CSS/filter-function/brightness
-tags:
-  - CSS
-  - CSS 関数
-  - フィルター効果
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/filter-function/brightness()
 original_slug: Web/CSS/filter-function/brightness()
-browser-compat: css.types.filter-function.brightness
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/filter-function/contrast/index.md
+++ b/files/ja/web/css/filter-function/contrast/index.md
@@ -1,15 +1,7 @@
 ---
 title: contrast()
 slug: Web/CSS/filter-function/contrast
-tags:
-  - CSS
-  - CSS 関数
-  - フィルター効果
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/filter-function/contrast()
 original_slug: Web/CSS/filter-function/contrast()
-browser-compat: css.types.filter-function.contrast
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/filter-function/drop-shadow/index.md
+++ b/files/ja/web/css/filter-function/drop-shadow/index.md
@@ -1,15 +1,7 @@
 ---
 title: drop-shadow()
 slug: Web/CSS/filter-function/drop-shadow
-tags:
-  - CSS
-  - CSS 関数
-  - フィルター効果
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/filter-function/drop-shadow()
 original_slug: Web/CSS/filter-function/drop-shadow()
-browser-compat: css.types.filter-function.drop-shadow
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/filter-function/grayscale/index.md
+++ b/files/ja/web/css/filter-function/grayscale/index.md
@@ -1,15 +1,7 @@
 ---
 title: grayscale()
 slug: Web/CSS/filter-function/grayscale
-tags:
-  - CSS
-  - CSS 関数
-  - フィルター効果
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/filter-function/grayscale()
 original_slug: Web/CSS/filter-function/grayscale()
-browser-compat: css.types.filter-function.grayscale
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/filter-function/hue-rotate/index.md
+++ b/files/ja/web/css/filter-function/hue-rotate/index.md
@@ -1,15 +1,7 @@
 ---
 title: hue-rotate()
 slug: Web/CSS/filter-function/hue-rotate
-tags:
-  - CSS
-  - CSS 関数
-  - フィルター効果
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/filter-function/hue-rotate()
 original_slug: Web/CSS/filter-function/hue-rotate()
-browser-compat: css.types.filter-function.hue-rotate
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/filter-function/index.md
+++ b/files/ja/web/css/filter-function/index.md
@@ -1,15 +1,6 @@
 ---
 title: <filter-function>
 slug: Web/CSS/filter-function
-tags:
-  - CSS
-  - CSS データ型
-  - データ型
-  - フィルター効果
-  - NeedsCompatTable
-  - リファレンス
-browser-compat: css.types.filter-function
-translation_of: Web/CSS/filter-function
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/filter-function/invert/index.md
+++ b/files/ja/web/css/filter-function/invert/index.md
@@ -1,15 +1,7 @@
 ---
 title: invert()
 slug: Web/CSS/filter-function/invert
-tags:
-  - CSS
-  - CSS 関数
-  - フィルター効果
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/filter-function/invert()
 original_slug: Web/CSS/filter-function/invert()
-browser-compat: css.types.filter-function.invert
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/filter-function/opacity/index.md
+++ b/files/ja/web/css/filter-function/opacity/index.md
@@ -1,15 +1,7 @@
 ---
 title: opacity()
 slug: Web/CSS/filter-function/opacity
-tags:
-  - CSS
-  - CSS 関数
-  - フィルター効果
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/filter-function/opacity()
 original_slug: Web/CSS/filter-function/opacity()
-browser-compat: css.types.filter-function.opacity
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/filter-function/saturate/index.md
+++ b/files/ja/web/css/filter-function/saturate/index.md
@@ -1,15 +1,7 @@
 ---
 title: saturate()
 slug: Web/CSS/filter-function/saturate
-tags:
-  - CSS
-  - CSS 関数
-  - フィルター効果
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/filter-function/saturate()
 original_slug: Web/CSS/filter-function/saturate()
-browser-compat: css.types.filter-function.saturate
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/filter-function/sepia/index.md
+++ b/files/ja/web/css/filter-function/sepia/index.md
@@ -1,15 +1,7 @@
 ---
 title: sepia()
 slug: Web/CSS/filter-function/sepia
-tags:
-  - CSS
-  - CSS 関数
-  - フィルター効果
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/filter-function/sepia()
 original_slug: Web/CSS/filter-function/sepia()
-browser-compat: css.types.filter-function.sepia
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/filter/index.md
+++ b/files/ja/web/css/filter/index.md
@@ -1,15 +1,6 @@
 ---
 title: filter
 slug: Web/CSS/filter
-tags:
-  - CSS
-  - CSS プロパティ
-  - Reference
-  - SVG
-  - SVG フィルター
-  - recipe:css-property
-browser-compat: css.properties.filter
-translation_of: Web/CSS/filter
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/filter_effects/index.md
+++ b/files/ja/web/css/filter_effects/index.md
@@ -1,13 +1,6 @@
 ---
 title: フィルター効果
 slug: Web/CSS/Filter_Effects
-tags:
-  - CSS
-  - フィルター効果
-  - ガイド
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/Filter_Effects
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/fit-content/index.md
+++ b/files/ja/web/css/fit-content/index.md
@@ -1,14 +1,6 @@
 ---
 title: fit-content
 slug: Web/CSS/fit-content
-tags:
-  - CSS
-  - キーワード
-  - リファレンス
-  - ウェブ
-  - fit-content
-browser-compat: css.properties.width.fit-content
-translation_of: Web/CSS/fit-content
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/fit-content_function/index.md
+++ b/files/ja/web/css/fit-content_function/index.md
@@ -1,15 +1,6 @@
 ---
 title: fit-content()
 slug: Web/CSS/fit-content_function
-tags:
-  - CSS
-  - CSS 関数
-  - CSS グリッド
-  - 関数
-  - レイアウト
-  - リファレンス
-  - ウェブ
-translation_of: Web/CSS/fit-content()
 original_slug: Web/CSS/fit-content()
 ---
 {{CSSRef}}

--- a/files/ja/web/css/flex-basis/index.md
+++ b/files/ja/web/css/flex-basis/index.md
@@ -1,14 +1,6 @@
 ---
 title: flex-basis
 slug: Web/CSS/flex-basis
-tags:
-  - CSS
-  - CSS フレックスボックス
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.flex-basis
-translation_of: Web/CSS/flex-basis
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/flex-direction/index.md
+++ b/files/ja/web/css/flex-direction/index.md
@@ -1,14 +1,6 @@
 ---
 title: flex-direction
 slug: Web/CSS/flex-direction
-tags:
-  - CSS
-  - CSS フレックスボックス
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.flex-direction
-translation_of: Web/CSS/flex-direction
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/flex-flow/index.md
+++ b/files/ja/web/css/flex-flow/index.md
@@ -1,14 +1,6 @@
 ---
 title: flex-flow
 slug: Web/CSS/flex-flow
-tags:
-  - CSS
-  - CSS フレックスボックス
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.flex-flow
-translation_of: Web/CSS/flex-flow
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/flex-grow/index.md
+++ b/files/ja/web/css/flex-grow/index.md
@@ -1,15 +1,6 @@
 ---
 title: flex-grow
 slug: Web/CSS/flex-grow
-tags:
-  - CSS
-  - CSS Flexible Boxes
-  - CSS Property
-  - NeedsContent
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.flex-grow
-translation_of: Web/CSS/flex-grow
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/flex-shrink/index.md
+++ b/files/ja/web/css/flex-shrink/index.md
@@ -1,15 +1,6 @@
 ---
 title: flex-shrink
 slug: Web/CSS/flex-shrink
-tags:
-  - CSS
-  - CSS フレックスボックス
-  - CSS プロパティ
-  - NeedsContent
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.flex-shrink
-translation_of: Web/CSS/flex-shrink
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/flex-wrap/index.md
+++ b/files/ja/web/css/flex-wrap/index.md
@@ -1,14 +1,6 @@
 ---
 title: flex-wrap
 slug: Web/CSS/flex-wrap
-tags:
-  - CSS
-  - CSS Flexible Boxes
-  - CSS Property
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.flex-wrap
-translation_of: Web/CSS/flex-wrap
 ---
 {{ CSSRef}}
 

--- a/files/ja/web/css/flex/index.md
+++ b/files/ja/web/css/flex/index.md
@@ -1,14 +1,6 @@
 ---
 title: flex
 slug: Web/CSS/flex
-tags:
-  - CSS
-  - CSS フレックスボックス
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.flex
-translation_of: Web/CSS/flex
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/flex_value/index.md
+++ b/files/ja/web/css/flex_value/index.md
@@ -1,14 +1,6 @@
 ---
 title: <flex>
 slug: Web/CSS/flex_value
-tags:
-  - CSS
-  - CSS データ型
-  - データ型
-  - レイアウト
-  - リファレンス
-  - ウェブ
-translation_of: Web/CSS/flex_value
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/float/index.md
+++ b/files/ja/web/css/float/index.md
@@ -1,14 +1,6 @@
 ---
 title: float
 slug: Web/CSS/float
-tags:
-  - CSS
-  - CSS 位置指定レイアウト
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.float
-translation_of: Web/CSS/float
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/font-family/index.md
+++ b/files/ja/web/css/font-family/index.md
@@ -1,14 +1,6 @@
 ---
 title: font-family
 slug: Web/CSS/font-family
-tags:
-  - CSS
-  - CSS フォント
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.font-family
-translation_of: Web/CSS/font-family
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/font-feature-settings/index.md
+++ b/files/ja/web/css/font-feature-settings/index.md
@@ -1,14 +1,6 @@
 ---
 title: font-feature-settings
 slug: Web/CSS/font-feature-settings
-tags:
-  - CSS
-  - CSS フォント
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.font-feature-settings
-translation_of: Web/CSS/font-feature-settings
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/font-kerning/index.md
+++ b/files/ja/web/css/font-kerning/index.md
@@ -1,14 +1,6 @@
 ---
 title: font-kerning
 slug: Web/CSS/font-kerning
-tags:
-  - CSS
-  - CSS フォント
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.font-kerning
-translation_of: Web/CSS/font-kerning
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/font-language-override/index.md
+++ b/files/ja/web/css/font-language-override/index.md
@@ -1,16 +1,6 @@
 ---
 title: font-language-override
 slug: Web/CSS/font-language-override
-tags:
-  - CSS
-  - CSS Fonts
-  - CSS Property
-  - Reference
-  - font-language-override
-  - l10n
-  - recipe:css-property
-browser-compat: css.properties.font-language-override
-translation_of: Web/CSS/font-language-override
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/font-optical-sizing/index.md
+++ b/files/ja/web/css/font-optical-sizing/index.md
@@ -1,15 +1,6 @@
 ---
 title: font-optical-sizing
 slug: Web/CSS/font-optical-sizing
-tags:
-  - CSS
-  - CSS フォント
-  - CSS プロパティ
-  - NeedsExample
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.font-optical-sizing
-translation_of: Web/CSS/font-optical-sizing
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/font-size-adjust/index.md
+++ b/files/ja/web/css/font-size-adjust/index.md
@@ -1,14 +1,6 @@
 ---
 title: font-size-adjust
 slug: Web/CSS/font-size-adjust
-tags:
-  - CSS
-  - CSS フォント
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.font-size-adjust
-translation_of: Web/CSS/font-size-adjust
 ---
 **`font-size-adjust`** は [CSS](/ja/docs/Web/CSS) のプロパティで、 (大文字の大きさを定義する) 現在のフォントサイズに相対的な小文字の大きさを設定します。
 

--- a/files/ja/web/css/font-size/index.md
+++ b/files/ja/web/css/font-size/index.md
@@ -1,13 +1,6 @@
 ---
 title: font-size
 slug: Web/CSS/font-size
-tags:
-  - CSS
-  - CSS フォント
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-translation_of: Web/CSS/font-size
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/font-smooth/index.md
+++ b/files/ja/web/css/font-smooth/index.md
@@ -1,14 +1,6 @@
 ---
 title: font-smooth
 slug: Web/CSS/font-smooth
-tags:
-  - CSS
-  - CSS プロパティ
-  - 標準外
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.font-smooth
-translation_of: Web/CSS/font-smooth
 ---
 {{ CSSRef }} {{ Non-standard_header }}
 

--- a/files/ja/web/css/font-stretch/index.md
+++ b/files/ja/web/css/font-stretch/index.md
@@ -1,14 +1,6 @@
 ---
 title: font-stretch
 slug: Web/CSS/font-stretch
-tags:
-  - CSS
-  - CSS フォント
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.font-stretch
-translation_of: Web/CSS/font-stretch
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/font-style/index.md
+++ b/files/ja/web/css/font-style/index.md
@@ -1,16 +1,6 @@
 ---
 title: font-style
 slug: Web/CSS/font-style
-tags:
-  - CSS
-  - CSS フォント
-  - CSS プロパティ
-  - リファレンス
-  - ウェブ
-  - font
-  - recipe:css-property
-browser-compat: css.properties.font-style
-translation_of: Web/CSS/font-style
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/font-synthesis/index.md
+++ b/files/ja/web/css/font-synthesis/index.md
@@ -1,14 +1,6 @@
 ---
 title: font-synthesis
 slug: Web/CSS/font-synthesis
-tags:
-  - CSS
-  - CSS フォント
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.font-synthesis
-translation_of: Web/CSS/font-synthesis
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/font-variant-alternates/index.md
+++ b/files/ja/web/css/font-variant-alternates/index.md
@@ -1,14 +1,6 @@
 ---
 title: font-variant-alternates
 slug: Web/CSS/font-variant-alternates
-tags:
-  - CSS
-  - CSS Fonts
-  - CSS Property
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.font-variant-alternates
-translation_of: Web/CSS/font-variant-alternates
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/font-variant-caps/index.md
+++ b/files/ja/web/css/font-variant-caps/index.md
@@ -1,14 +1,6 @@
 ---
 title: font-variant-caps
 slug: Web/CSS/font-variant-caps
-tags:
-  - CSS
-  - CSS フォント
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.font-variant-caps
-translation_of: Web/CSS/font-variant-caps
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/font-variant-east-asian/index.md
+++ b/files/ja/web/css/font-variant-east-asian/index.md
@@ -1,16 +1,6 @@
 ---
 title: font-variant-east-asian
 slug: Web/CSS/font-variant-east-asian
-tags:
-  - CSS
-  - CSS フォント
-  - CSS プロパティ
-  - NeedsLiveSample
-  - リファレンス
-  - recipe:css-property
-  - 日本語処理
-browser-compat: css.properties.font-variant-east-asian
-translation_of: Web/CSS/font-variant-east-asian
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/font-variant-ligatures/index.md
+++ b/files/ja/web/css/font-variant-ligatures/index.md
@@ -1,14 +1,6 @@
 ---
 title: font-variant-ligatures
 slug: Web/CSS/font-variant-ligatures
-tags:
-  - CSS
-  - CSS Fonts
-  - CSS Property
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.font-variant-ligatures
-translation_of: Web/CSS/font-variant-ligatures
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/font-variant-numeric/index.md
+++ b/files/ja/web/css/font-variant-numeric/index.md
@@ -1,14 +1,6 @@
 ---
 title: font-variant-numeric
 slug: Web/CSS/font-variant-numeric
-tags:
-  - CSS
-  - CSS フォント
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.font-variant-numeric
-translation_of: Web/CSS/font-variant-numeric
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/font-variant-position/index.md
+++ b/files/ja/web/css/font-variant-position/index.md
@@ -1,14 +1,6 @@
 ---
 title: font-variant-position
 slug: Web/CSS/font-variant-position
-tags:
-  - CSS
-  - CSS フォント
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.font-variant-position
-translation_of: Web/CSS/font-variant-position
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/font-variant/index.md
+++ b/files/ja/web/css/font-variant/index.md
@@ -1,14 +1,6 @@
 ---
 title: font-variant
 slug: Web/CSS/font-variant
-tags:
-  - CSS
-  - CSS Fonts
-  - CSS Property
-  - Reference
-  - recipe:css-shorthand-property
-browser-compat: css.properties.font-variant
-translation_of: Web/CSS/font-variant
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/font-variation-settings/index.md
+++ b/files/ja/web/css/font-variation-settings/index.md
@@ -1,14 +1,6 @@
 ---
 title: font-variation-settings
 slug: Web/CSS/font-variation-settings
-tags:
-  - CSS
-  - CSS フォント
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.font-variation-settings
-translation_of: Web/CSS/font-variation-settings
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/font-weight/index.md
+++ b/files/ja/web/css/font-weight/index.md
@@ -1,14 +1,6 @@
 ---
 title: font-weight
 slug: Web/CSS/font-weight
-tags:
-  - CSS
-  - CSS フォント
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.font-weight
-translation_of: Web/CSS/font-weight
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/font/index.md
+++ b/files/ja/web/css/font/index.md
@@ -1,14 +1,6 @@
 ---
 title: font
 slug: Web/CSS/font
-tags:
-  - CSS
-  - CSS フォント
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.font
-translation_of: Web/CSS/font
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/forced-color-adjust/index.md
+++ b/files/ja/web/css/forced-color-adjust/index.md
@@ -1,22 +1,6 @@
 ---
 title: forced-color-adjust
 slug: Web/CSS/forced-color-adjust
-tags:
-  - 色の調整
-  - CSS
-  - CSS 色
-  - CSS プロパティ
-  - HTML 色
-  - HTML スタイル
-  - レイアウト
-  - リファレンス
-  - HTML 整形
-  - テキスト整形
-  - ウェブ
-  - forced-color-adjust
-  - recipe:css-property
-browser-compat: css.properties.forced-color-adjust
-translation_of: Web/CSS/forced-color-adjust
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/frequency-percentage/index.md
+++ b/files/ja/web/css/frequency-percentage/index.md
@@ -1,16 +1,6 @@
 ---
 title: <frequency-percentage>
 slug: Web/CSS/frequency-percentage
-tags:
-  - CSS
-  - CSS データ型
-  - データ型
-  - リファレンス
-  - frequency-percentage
-  - 単位
-  - 値
-browser-compat: css.types.frequency-percentage
-translation_of: Web/CSS/frequency-percentage
 ---
 {{CSSRef}}{{SeeCompatTable}}
 

--- a/files/ja/web/css/frequency/index.md
+++ b/files/ja/web/css/frequency/index.md
@@ -1,14 +1,6 @@
 ---
 title: <frequency>
 slug: Web/CSS/frequency
-tags:
-  - CSS
-  - CSS データ型
-  - データ型
-  - リファレンス
-  - ウェブ
-browser-compat: css.types.frequency
-translation_of: Web/CSS/frequency
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/gap/index.md
+++ b/files/ja/web/css/gap/index.md
@@ -1,17 +1,6 @@
 ---
 title: gap (grid-gap)
 slug: Web/CSS/gap
-tags:
-  - CSS
-  - CSS フレックスボックス
-  - CSS グリッド
-  - CSS 段組みレイアウト
-  - CSS プロパティ
-  - リファレンス
-  - gap
-  - recipe:css-property
-browser-compat: css.properties.gap
-translation_of: Web/CSS/gap
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/general_sibling_combinator/index.md
+++ b/files/ja/web/css/general_sibling_combinator/index.md
@@ -1,12 +1,6 @@
 ---
 title: 一般兄弟結合子
 slug: Web/CSS/General_sibling_combinator
-tags:
-  - CSS
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.general_sibling
-translation_of: Web/CSS/General_sibling_combinator
 ---
 {{CSSRef("Selectors")}}
 

--- a/files/ja/web/css/gradient/conic-gradient/index.md
+++ b/files/ja/web/css/gradient/conic-gradient/index.md
@@ -1,19 +1,7 @@
 ---
 title: conic-gradient()
 slug: Web/CSS/gradient/conic-gradient
-tags:
-  - CSS
-  - CSS Function
-  - CSS Images
-  - Function
-  - Graphics
-  - Layout
-  - Reference
-  - Web
-  - gradient
-translation_of: Web/CSS/gradient/conic-gradient()
 original_slug: Web/CSS/gradient/conic-gradient()
-browser-compat: css.types.image.gradient.conic-gradient
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/gradient/index.md
+++ b/files/ja/web/css/gradient/index.md
@@ -1,16 +1,6 @@
 ---
 title: <gradient>
 slug: Web/CSS/gradient
-tags:
-  - CSS
-  - CSS Data Type
-  - CSS Images
-  - Data Type
-  - グラフィック
-  - Layout
-  - Reference
-browser-compat: css.types.image.gradient
-translation_of: Web/CSS/gradient
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/gradient/linear-gradient/index.md
+++ b/files/ja/web/css/gradient/linear-gradient/index.md
@@ -1,19 +1,7 @@
 ---
 title: linear-gradient()
 slug: Web/CSS/gradient/linear-gradient
-tags:
-  - CSS
-  - CSS 画像
-  - CSS 関数
-  - Function
-  - Graphics
-  - Layout
-  - Reference
-  - Web
-  - gradient
-translation_of: Web/CSS/gradient/linear-gradient()
 original_slug: Web/CSS/gradient/linear-gradient()
-browser-compat: css.types.image.gradient.linear-gradient
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/gradient/radial-gradient/index.md
+++ b/files/ja/web/css/gradient/radial-gradient/index.md
@@ -1,19 +1,7 @@
 ---
 title: radial-gradient()
 slug: Web/CSS/gradient/radial-gradient
-tags:
-  - CSS
-  - CSS Function
-  - CSS Images
-  - Function
-  - Graphics
-  - Layout
-  - Reference
-  - Web
-  - gradient
-translation_of: Web/CSS/gradient/radial-gradient()
 original_slug: Web/CSS/gradient/radial-gradient()
-browser-compat: css.types.image.gradient.radial-gradient
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/gradient/repeating-conic-gradient/index.md
+++ b/files/ja/web/css/gradient/repeating-conic-gradient/index.md
@@ -1,19 +1,7 @@
 ---
 title: repeating-conic-gradient()
 slug: Web/CSS/gradient/repeating-conic-gradient
-tags:
-  - CSS
-  - CSS Function
-  - CSS Images
-  - Function
-  - Graphics
-  - Layout
-  - Reference
-  - Web
-  - gradient
-translation_of: Web/CSS/gradient/repeating-conic-gradient()
 original_slug: Web/CSS/gradient/repeating-conic-gradient()
-browser-compat: css.types.image.gradient.repeating-conic-gradient
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/gradient/repeating-linear-gradient/index.md
+++ b/files/ja/web/css/gradient/repeating-linear-gradient/index.md
@@ -1,19 +1,7 @@
 ---
 title: repeating-linear-gradient()
 slug: Web/CSS/gradient/repeating-linear-gradient
-tags:
-  - CSS
-  - CSS Function
-  - CSS Images
-  - Function
-  - Gradients
-  - Graphics
-  - Layout
-  - Reference
-  - Web
-translation_of: Web/CSS/gradient/repeating-linear-gradient()
 original_slug: Web/CSS/gradient/repeating-linear-gradient()
-browser-compat: css.types.image.gradient.repeating-linear-gradient
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/gradient/repeating-radial-gradient/index.md
+++ b/files/ja/web/css/gradient/repeating-radial-gradient/index.md
@@ -1,19 +1,7 @@
 ---
 title: repeating-radial-gradient()
 slug: Web/CSS/gradient/repeating-radial-gradient
-tags:
-  - CSS
-  - CSS Function
-  - CSS Images
-  - Function
-  - Gradients
-  - Graphics
-  - Layout
-  - Reference
-  - Web
-translation_of: Web/CSS/gradient/repeating-radial-gradient()
 original_slug: Web/CSS/gradient/repeating-radial-gradient()
-browser-compat: css.types.image.gradient.repeating-radial-gradient
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/grid-area/index.md
+++ b/files/ja/web/css/grid-area/index.md
@@ -1,13 +1,6 @@
 ---
 title: grid-area
 slug: Web/CSS/grid-area
-tags:
-  - CSS
-  - CSS グリッド
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.grid-area
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/grid-auto-columns/index.md
+++ b/files/ja/web/css/grid-auto-columns/index.md
@@ -1,13 +1,6 @@
 ---
 title: grid-auto-columns
 slug: Web/CSS/grid-auto-columns
-tags:
-  - CSS
-  - CSS グリッド
-  - CSS プロパティ
-  - リファレンス
-browser-compat: css.properties.grid-auto-columns
-translation_of: Web/CSS/grid-auto-columns
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/grid-auto-flow/index.md
+++ b/files/ja/web/css/grid-auto-flow/index.md
@@ -1,13 +1,6 @@
 ---
 title: grid-auto-flow
 slug: Web/CSS/grid-auto-flow
-tags:
-  - CSS
-  - CSS グリッド
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.grid-auto-flow
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/grid-auto-rows/index.md
+++ b/files/ja/web/css/grid-auto-rows/index.md
@@ -1,13 +1,6 @@
 ---
 title: grid-auto-rows
 slug: Web/CSS/grid-auto-rows
-tags:
-  - CSS
-  - CSS グリッド
-  - CSS プロパティ
-  - リファレンス
-browser-compat: css.properties.grid-auto-rows
-translation_of: Web/CSS/grid-auto-rows
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/grid-column-end/index.md
+++ b/files/ja/web/css/grid-column-end/index.md
@@ -1,14 +1,6 @@
 ---
 title: grid-column-end
 slug: Web/CSS/grid-column-end
-tags:
-  - CSS
-  - CSS グリッド
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.grid-column-end
-translation_of: Web/CSS/grid-column-end
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/grid-column-start/index.md
+++ b/files/ja/web/css/grid-column-start/index.md
@@ -1,14 +1,6 @@
 ---
 title: grid-column-start
 slug: Web/CSS/grid-column-start
-tags:
-  - CSS
-  - CSS グリッド
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.grid-column-start
-translation_of: Web/CSS/grid-column-start
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/grid-column/index.md
+++ b/files/ja/web/css/grid-column/index.md
@@ -1,14 +1,6 @@
 ---
 title: grid-column
 slug: Web/CSS/grid-column
-tags:
-  - CSS
-  - CSS グリッド
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.grid-column
-translation_of: Web/CSS/grid-column
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/grid-row-end/index.md
+++ b/files/ja/web/css/grid-row-end/index.md
@@ -1,13 +1,6 @@
 ---
 title: grid-row-end
 slug: Web/CSS/grid-row-end
-tags:
-  - CSS
-  - CSS グリッド
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.grid-row-end
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/grid-row-start/index.md
+++ b/files/ja/web/css/grid-row-start/index.md
@@ -1,14 +1,6 @@
 ---
 title: grid-row-start
 slug: Web/CSS/grid-row-start
-tags:
-  - CSS
-  - CSS グリッド
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.grid-row-start
-tra: Web/CSS/grid-row-start
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/grid-row/index.md
+++ b/files/ja/web/css/grid-row/index.md
@@ -1,14 +1,6 @@
 ---
 title: grid-row
 slug: Web/CSS/grid-row
-tags:
-  - CSS
-  - CSS グリッド
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.grid-row
-translation_of: Web/CSS/grid-row
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/grid-template-areas/index.md
+++ b/files/ja/web/css/grid-template-areas/index.md
@@ -1,14 +1,6 @@
 ---
 title: grid-template-areas
 slug: Web/CSS/grid-template-areas
-tags:
-  - CSS
-  - CSS グリッド
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.grid-template-areas
-translation_of: Web/CSS/grid-template-areas
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/grid-template-columns/index.md
+++ b/files/ja/web/css/grid-template-columns/index.md
@@ -1,14 +1,6 @@
 ---
 title: grid-template-columns
 slug: Web/CSS/grid-template-columns
-tags:
-  - CSS
-  - CSS グリッド
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.grid-template-columns
-translation_of: Web/CSS/grid-template-columns
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/grid-template-rows/index.md
+++ b/files/ja/web/css/grid-template-rows/index.md
@@ -1,14 +1,6 @@
 ---
 title: grid-template-rows
 slug: Web/CSS/grid-template-rows
-tags:
-  - CSS
-  - CSS グリッド
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.grid-template-rows
-translation_of: Web/CSS/grid-template-rows
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/grid-template/index.md
+++ b/files/ja/web/css/grid-template/index.md
@@ -1,14 +1,6 @@
 ---
 title: grid-template
 slug: Web/CSS/grid-template
-tags:
-  - CSS
-  - CSS グリッド
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.grid-template
-translation_of: Web/CSS/grid-template
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/grid/index.md
+++ b/files/ja/web/css/grid/index.md
@@ -1,14 +1,6 @@
 ---
 title: grid
 slug: Web/CSS/grid
-tags:
-  - CSS
-  - CSS グリッド
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.grid
-translation_of: Web/CSS/grid
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/hanging-punctuation/index.md
+++ b/files/ja/web/css/hanging-punctuation/index.md
@@ -1,16 +1,6 @@
 ---
 title: hanging-punctuation
 slug: Web/CSS/hanging-punctuation
-tags:
-  - CSS
-  - CSS Property
-  - CSS テキスト
-  - CSS テキスト
-  - CSS プロパティ
-  - Experimental
-  - Reference
-  - リファレンス
-translation_of: Web/CSS/hanging-punctuation
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/height/index.md
+++ b/files/ja/web/css/height/index.md
@@ -1,18 +1,6 @@
 ---
 title: height
 slug: Web/CSS/height
-tags:
-  - CSS
-  - CSS プロパティ
-  - レイアウト
-  - リファレンス
-  - 垂直
-  - 寸法
-  - height
-  - recipe:css-property
-  - size
-browser-compat: css.properties.height
-translation_of: Web/CSS/height
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/hyphenate-character/index.md
+++ b/files/ja/web/css/hyphenate-character/index.md
@@ -1,12 +1,6 @@
 ---
 title: hyphenate-character
 slug: Web/CSS/hyphenate-character
-tags:
-  - CSS
-  - CSS プロパティ
-  - リファレンス
-browser-compat: css.properties.hyphenate-character
-translation_of: Web/CSS/hyphenate-character
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/hyphens/index.md
+++ b/files/ja/web/css/hyphens/index.md
@@ -1,14 +1,6 @@
 ---
 title: hyphens
 slug: Web/CSS/hyphens
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS テキスト
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.hyphens
-translation_of: Web/CSS/hyphens
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/id_selectors/index.md
+++ b/files/ja/web/css/id_selectors/index.md
@@ -1,12 +1,6 @@
 ---
 title: ID セレクター
 slug: Web/CSS/ID_selectors
-tags:
-  - CSS
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.id
-translation_of: Web/CSS/ID_selectors
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/ident/index.md
+++ b/files/ja/web/css/ident/index.md
@@ -1,7 +1,6 @@
 ---
 title: ident
 slug: Web/CSS/ident
-translation_of: Web/CSS/ident
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/image-orientation/index.md
+++ b/files/ja/web/css/image-orientation/index.md
@@ -1,13 +1,6 @@
 ---
 title: image-orientation
 slug: Web/CSS/image-orientation
-tags:
-  - CSS
-  - リファレンス
-  - image-orientation
-  - recipe:css-property
-browser-compat: css.properties.image-orientation
-translation_of: Web/CSS/image-orientation
 ---
 **`image-orientation`** は [CSS](/ja/docs/Web/CSS) のプロパティで、画像の向きのレイアウトに依存しない修正を指定します。
 

--- a/files/ja/web/css/image-rendering/index.md
+++ b/files/ja/web/css/image-rendering/index.md
@@ -1,15 +1,6 @@
 ---
 title: image-rendering
 slug: Web/CSS/image-rendering
-tags:
-  - CSS
-  - CSS 画像
-  - CSS プロパティ
-  - Reference
-  - image-rendering
-  - recipe:css-property
-browser-compat: css.properties.image-rendering
-translation_of: Web/CSS/image-rendering
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/image-resolution/index.md
+++ b/files/ja/web/css/image-resolution/index.md
@@ -1,15 +1,6 @@
 ---
 title: image-resolution
 slug: Web/CSS/image-resolution
-tags:
-  - CSS
-  - CSS 画像
-  - CSS プロパティ
-  - 実験的
-  - Reference
-  - image-resolution
-browser-compat: css.properties.image-resolution
-translation_of: Web/CSS/image-resolution
 ---
 {{CSSRef}}{{SeeCompatTable}}
 

--- a/files/ja/web/css/image/image-set/index.md
+++ b/files/ja/web/css/image/image-set/index.md
@@ -1,16 +1,7 @@
 ---
 title: image-set()
 slug: Web/CSS/image/image-set
-tags:
-  - CSS
-  - CSS Function
-  - CSS-4 Images
-  - Function
-  - Reference
-  - Web
-translation_of: Web/CSS/image/image-set()
 original_slug: Web/CSS/image/image-set()
-browser-compat: css.types.image.image-set
 ---
 {{cssref}}
 

--- a/files/ja/web/css/image/image/index.md
+++ b/files/ja/web/css/image/image/index.md
@@ -1,16 +1,7 @@
 ---
 title: image()
 slug: Web/CSS/image/image
-tags:
-  - CSS
-  - CSS 関数
-  - CSS 画像
-  - 関数
-  - Reference
-  - ウェブ
-translation_of: Web/CSS/image/image()
 original_slug: Web/CSS/image/image()
-browser-compat: css.types.image.image
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/image/index.md
+++ b/files/ja/web/css/image/index.md
@@ -1,17 +1,6 @@
 ---
 title: <image>
 slug: Web/CSS/image
-tags:
-  - CSS
-  - CSS データ型
-  - CSS 画像
-  - データ型
-  - グラフィック
-  - レイアウト
-  - リファレンス
-  - ウェブ
-browser-compat: css.types.image
-translation_of: Web/CSS/image
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/image/paint/index.md
+++ b/files/ja/web/css/image/paint/index.md
@@ -1,17 +1,7 @@
 ---
 title: paint()
 slug: Web/CSS/image/paint
-tags:
-  - CSS
-  - CSS 関数
-  - CSS4-images
-  - 関数
-  - Houdini
-  - リファレンス
-  - ウェブ
-translation_of: Web/CSS/image/paint()
 original_slug: Web/CSS/image/paint()
-browser-compat: css.types.image.paint
 ---
 {{CSSRef}}{{SeeCompatTable}}
 

--- a/files/ja/web/css/ime-mode/index.md
+++ b/files/ja/web/css/ime-mode/index.md
@@ -1,13 +1,6 @@
 ---
 title: ime-mode
 slug: Web/CSS/ime-mode
-tags:
-  - CSS
-  - CSS プロパティ
-  - Deprecated
-  - recipe:css-property
-browser-compat: css.properties.ime-mode
-translation_of: Web/CSS/ime-mode
 ---
 {{CSSRef}} {{deprecated_header}}
 

--- a/files/ja/web/css/inherit/index.md
+++ b/files/ja/web/css/inherit/index.md
@@ -1,19 +1,6 @@
 ---
 title: inherit
 slug: Web/CSS/inherit
-tags:
-  - CSS
-  - CSS カスケード
-  - CSS 値
-  - カスケード
-  - 継承
-  - キーワード
-  - レイアウト
-  - リファレンス
-  - スタイル
-  - inherit
-browser-compat: css.types.global_keywords.inherit
-translation_of: Web/CSS/inherit
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/inheritance/index.md
+++ b/files/ja/web/css/inheritance/index.md
@@ -1,13 +1,6 @@
 ---
 title: 継承
 slug: Web/CSS/inheritance
-tags:
-  - CSS
-  - Guide
-  - Inheritance
-  - Layout
-  - Web
-translation_of: Web/CSS/inheritance
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/initial-letter-align/index.md
+++ b/files/ja/web/css/initial-letter-align/index.md
@@ -1,20 +1,6 @@
 ---
 title: initial-letter-align
 slug: Web/CSS/initial-letter-align
-tags:
-  - Align
-  - CSS
-  - CSS Inline
-  - CSS Property
-  - CSS プロパティ
-  - Experimental
-  - Graphics
-  - Layout
-  - NeedsL
-  - Reference
-  - Web
-  - recipe:css-property
-translation_of: Web/CSS/initial-letter-align
 ---
 {{CSSRef}}{{SeeCompatTable}}
 

--- a/files/ja/web/css/initial-letter/index.md
+++ b/files/ja/web/css/initial-letter/index.md
@@ -1,17 +1,6 @@
 ---
 title: initial-letter
 slug: Web/CSS/initial-letter
-tags:
-  - CSS
-  - CSS Inline
-  - CSS Property
-  - Experimental
-  - Graphics
-  - Layout
-  - Reference
-  - Web
-  - recipe:css-property
-translation_of: Web/CSS/initial-letter
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/initial/index.md
+++ b/files/ja/web/css/initial/index.md
@@ -1,18 +1,6 @@
 ---
 title: initial
 slug: Web/CSS/initial
-tags:
-  - CSS
-  - CSS カスケード
-  - CSS 値
-  - 既定の状態
-  - 初期状態
-  - キーワード
-  - レイアウト
-  - リファレンス
-  - initial
-browser-compat: css.types.global_keywords.initial
-translation_of: Web/CSS/initial
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/initial_value/index.md
+++ b/files/ja/web/css/initial_value/index.md
@@ -1,12 +1,6 @@
 ---
 title: 初期値
 slug: Web/CSS/initial_value
-tags:
-  - CSS
-  - Guide
-  - Reference
-spec-urls: https://www.w3.org/TR/CSS22/cascade.html#specified-value
-translation_of: Web/CSS/initial_value
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/inline-size/index.md
+++ b/files/ja/web/css/inline-size/index.md
@@ -1,14 +1,6 @@
 ---
 title: inline-size
 slug: Web/CSS/inline-size
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.inline-size
-translation_of: Web/CSS/inline-size
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/inset-block-end/index.md
+++ b/files/ja/web/css/inset-block-end/index.md
@@ -1,15 +1,6 @@
 ---
 title: inset-block-end
 slug: Web/CSS/inset-block-end
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.inset-block-end
-translation_of: Web/CSS/inset-block-end
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/inset-block-start/index.md
+++ b/files/ja/web/css/inset-block-start/index.md
@@ -1,15 +1,6 @@
 ---
 title: inset-block-start
 slug: Web/CSS/inset-block-start
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.inset-block-start
-translation_of: Web/CSS/inset-block-start
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/inset-block/index.md
+++ b/files/ja/web/css/inset-block/index.md
@@ -1,15 +1,6 @@
 ---
 title: inset-block
 slug: Web/CSS/inset-block
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.inset-block
-translation_of: Web/CSS/inset-block
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/inset-inline-end/index.md
+++ b/files/ja/web/css/inset-inline-end/index.md
@@ -1,15 +1,6 @@
 ---
 title: inset-inline-end
 slug: Web/CSS/inset-inline-end
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - NeedsContent
-  - リファレンス
-  - 'recipe:css-property'
-translation_of: Web/CSS/inset-inline-end
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/inset-inline-start/index.md
+++ b/files/ja/web/css/inset-inline-start/index.md
@@ -1,15 +1,6 @@
 ---
 title: inset-inline-start
 slug: Web/CSS/inset-inline-start
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.inset-inline-start
-translation_of: Web/CSS/inset-inline-start
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/inset-inline/index.md
+++ b/files/ja/web/css/inset-inline/index.md
@@ -1,15 +1,6 @@
 ---
 title: inset-inline
 slug: Web/CSS/inset-inline
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.inset-inline
-translation_of: Web/CSS/inset-inline
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/inset/index.md
+++ b/files/ja/web/css/inset/index.md
@@ -1,16 +1,6 @@
 ---
 title: inset
 slug: Web/CSS/inset
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - Property
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.inset
-translation_of: Web/CSS/inset
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/integer/index.md
+++ b/files/ja/web/css/integer/index.md
@@ -1,12 +1,6 @@
 ---
 title: <integer>
 slug: Web/CSS/integer
-tags:
-  - CSS
-  - CSS データ型
-  - リファレンス
-  - ウェブ
-translation_of: Web/CSS/integer
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/isolation/index.md
+++ b/files/ja/web/css/isolation/index.md
@@ -1,15 +1,6 @@
 ---
 title: isolation
 slug: Web/CSS/isolation
-tags:
-  - CSS
-  - CSS プロパティ
-  - 合成と混合
-  - NeedsContent
-  - isolation
-  - recipe:css-property
-browser-compat: css.properties.isolation
-translation_of: Web/CSS/isolation
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/justify-content/index.md
+++ b/files/ja/web/css/justify-content/index.md
@@ -1,14 +1,6 @@
 ---
 title: justify-content
 slug: Web/CSS/justify-content
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS ボックス配置
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.justify-content
-translation_of: Web/CSS/justify-content
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/justify-items/index.md
+++ b/files/ja/web/css/justify-items/index.md
@@ -1,14 +1,6 @@
 ---
 title: justify-items
 slug: Web/CSS/justify-items
-tags:
-  - CSS
-  - CSS ボックス配置
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.justify-items
-translation_of: Web/CSS/justify-items
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/justify-self/index.md
+++ b/files/ja/web/css/justify-self/index.md
@@ -1,14 +1,6 @@
 ---
 title: justify-self
 slug: Web/CSS/justify-self
-tags:
-  - CSS
-  - CSS ボックス配置
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.justify-self
-translation_of: Web/CSS/justify-self
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/justify-tracks/index.md
+++ b/files/ja/web/css/justify-tracks/index.md
@@ -1,16 +1,6 @@
 ---
 title: justify-tracks
 slug: Web/CSS/justify-tracks
-tags:
-  - CSS
-  - 実験的
-  - プロパティ
-  - リファレンス
-  - grid
-  - justify-tracks
-  - masonry
-browser-compat: css.properties.justify-tracks
-translation_of: Web/CSS/justify-tracks
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/layout_cookbook/breadcrumb_navigation/index.md
+++ b/files/ja/web/css/layout_cookbook/breadcrumb_navigation/index.md
@@ -1,14 +1,6 @@
 ---
 title: パンくずナビゲーション
 slug: Web/CSS/Layout_cookbook/Breadcrumb_Navigation
-tags:
-  - CSS
-  - ガイド
-  - レイアウト
-  - ナビゲーション
-  - 料理帳
-  - フレックスボックス
-translation_of: Web/CSS/Layout_cookbook/Breadcrumb_Navigation
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/layout_cookbook/card/index.md
+++ b/files/ja/web/css/layout_cookbook/card/index.md
@@ -1,14 +1,6 @@
 ---
 title: カード
 slug: Web/CSS/Layout_cookbook/Card
-tags:
-  - CSS
-  - CSS 料理帳
-  - CSS グリッド
-  - ガイド
-  - カード
-  - css レイアウト
-translation_of: Web/CSS/Layout_cookbook/Card
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/layout_cookbook/center_an_element/index.md
+++ b/files/ja/web/css/layout_cookbook/center_an_element/index.md
@@ -1,16 +1,6 @@
 ---
 title: 要素を中央に配置
 slug: Web/CSS/Layout_cookbook/Center_an_element
-tags:
-  - CSS
-  - ガイド
-  - レイアウト
-  - レシピ
-  - ボックス配置
-  - センタリング
-  - 料理帳
-  - フレックスボックス
-translation_of: Web/CSS/Layout_cookbook/Center_an_element
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/layout_cookbook/column_layouts/index.md
+++ b/files/ja/web/css/layout_cookbook/column_layouts/index.md
@@ -1,16 +1,6 @@
 ---
 title: 欄レイアウト
 slug: Web/CSS/Layout_cookbook/Column_layouts
-tags:
-  - CSS
-  - ガイド
-  - レイアウト
-  - 段組み
-  - columns
-  - 料理帳
-  - フレックスボックス
-  - グリッド
-translation_of: Web/CSS/Layout_cookbook/Column_layouts
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/layout_cookbook/contribute_a_recipe/cookbook_template/index.md
+++ b/files/ja/web/css/layout_cookbook/contribute_a_recipe/cookbook_template/index.md
@@ -1,15 +1,6 @@
 ---
 title: 料理帳テンプレート
 slug: Web/CSS/Layout_cookbook/Contribute_a_recipe/Cookbook_template
-tags:
-  - CSS
-  - 協力
-  - ガイド
-  - レイアウト
-  - テンプレート
-  - 料理帳
-  - レシピ
-translation_of: Web/CSS/Layout_cookbook/Contribute_a_recipe/Cookbook_template
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/layout_cookbook/contribute_a_recipe/index.md
+++ b/files/ja/web/css/layout_cookbook/contribute_a_recipe/index.md
@@ -1,15 +1,6 @@
 ---
 title: レシピを投稿する
 slug: Web/CSS/Layout_cookbook/Contribute_a_recipe
-tags:
-  - CSS
-  - 協力
-  - ガイド
-  - レイアウト
-  - テンプレート
-  - 料理帳
-  - レシピ
-translation_of: Web/CSS/Layout_cookbook/Contribute_a_recipe
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/layout_cookbook/grid_wrapper/index.md
+++ b/files/ja/web/css/layout_cookbook/grid_wrapper/index.md
@@ -1,13 +1,6 @@
 ---
 title: グリッドラッパー
 slug: Web/CSS/Layout_cookbook/Grid_wrapper
-tags:
-  - CSS
-  - ガイド
-  - レイアウト
-  - 料理帳
-  - レシピ
-translation_of: Web/CSS/Layout_cookbook/Grid_wrapper
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/layout_cookbook/index.md
+++ b/files/ja/web/css/layout_cookbook/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS レイアウト料理帳
 slug: Web/CSS/Layout_cookbook
-tags:
-  - CSS
-  - ガイド
-  - レイアウト
-  - 料理帳
-  - レシピ
-translation_of: Web/CSS/Layout_cookbook
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/layout_cookbook/list_group_with_badges/index.md
+++ b/files/ja/web/css/layout_cookbook/list_group_with_badges/index.md
@@ -1,15 +1,6 @@
 ---
 title: バッジ付きリストグループ
 slug: Web/CSS/Layout_cookbook/List_group_with_badges
-tags:
-  - CSS
-  - ガイド
-  - レイアウト
-  - ボックス配置
-  - 料理帳
-  - フレックスボックス
-  - リスト
-translation_of: Web/CSS/Layout_cookbook/List_group_with_badges
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/layout_cookbook/media_objects/index.md
+++ b/files/ja/web/css/layout_cookbook/media_objects/index.md
@@ -1,16 +1,6 @@
 ---
 title: 'レシピ: メディアオブジェクト'
 slug: Web/CSS/Layout_cookbook/Media_objects
-tags:
-  - CSS
-  - ガイド
-  - レイアウト
-  - メディアオブジェクト
-  - 料理帳
-  - fit-content
-  - float
-  - グリッド
-translation_of: Web/CSS/Layout_cookbook/Media_objects
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/layout_cookbook/pagination/index.md
+++ b/files/ja/web/css/layout_cookbook/pagination/index.md
@@ -1,14 +1,6 @@
 ---
 title: ページ付け
 slug: Web/CSS/Layout_cookbook/Pagination
-tags:
-  - CSS
-  - CSS 料理帳
-  - ガイド
-  - CSS レイアウト
-  - フレックスボックス
-  - pagination
-translation_of: Web/CSS/Layout_cookbook/Pagination
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/layout_cookbook/split_navigation/index.md
+++ b/files/ja/web/css/layout_cookbook/split_navigation/index.md
@@ -1,14 +1,6 @@
 ---
 title: ナビゲーションの分割
 slug: Web/CSS/Layout_cookbook/Split_Navigation
-tags:
-  - CSS
-  - ガイド
-  - レイアウト
-  - ナビゲーション
-  - 料理帳
-  - フレックスボックス
-translation_of: Web/CSS/Layout_cookbook/Split_Navigation
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/layout_cookbook/sticky_footers/index.md
+++ b/files/ja/web/css/layout_cookbook/sticky_footers/index.md
@@ -1,15 +1,6 @@
 ---
 title: 張りつくフッター
 slug: Web/CSS/Layout_cookbook/Sticky_footers
-tags:
-  - CSS
-  - ガイド
-  - レイアウト
-  - 料理帳
-  - フレックスボックス
-  - グリッド
-  - 張りつくフッター
-translation_of: Web/CSS/Layout_cookbook/Sticky_footers
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/layout_mode/index.md
+++ b/files/ja/web/css/layout_mode/index.md
@@ -1,12 +1,6 @@
 ---
 title: レイアウトモード
 slug: Web/CSS/Layout_mode
-tags:
-  - CSS
-  - ガイド
-  - レイアウト
-  - リファレンス
-translation_of: Web/CSS/Layout_mode
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/left/index.md
+++ b/files/ja/web/css/left/index.md
@@ -1,14 +1,6 @@
 ---
 title: left
 slug: Web/CSS/left
-tags:
-  - CSS
-  - CSS 位置指定レイアウト
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.left
-translation_of: Web/CSS/left
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/length-percentage/index.md
+++ b/files/ja/web/css/length-percentage/index.md
@@ -1,16 +1,6 @@
 ---
 title: <length-percentage>
 slug: Web/CSS/length-percentage
-tags:
-  - CSS
-  - CSS データ型
-  - データ型
-  - リファレンス
-  - length-percentage
-  - 単位
-  - 値
-browser-compat: css.types.length-percentage
-translation_of: Web/CSS/length-percentage
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/length/index.md
+++ b/files/ja/web/css/length/index.md
@@ -1,16 +1,6 @@
 ---
 title: <length>
 slug: Web/CSS/length
-tags:
-  - CSS
-  - CSS データ型
-  - データ型
-  - レイアウト
-  - リファレンス
-  - ウェブ
-  - length
-browser-compat: css.types.length
-translation_of: Web/CSS/length
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/letter-spacing/index.md
+++ b/files/ja/web/css/letter-spacing/index.md
@@ -1,14 +1,6 @@
 ---
 title: letter-spacing
 slug: Web/CSS/letter-spacing
-tags:
-  - CSS
-  - CSS Property
-  - CSS テキスト
-  - Reference
-  - SVG
-  - recipe:css-property
-browser-compat: css.properties.letter-spacing
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/line-break/index.md
+++ b/files/ja/web/css/line-break/index.md
@@ -1,20 +1,6 @@
 ---
 title: line-break
 slug: Web/CSS/line-break
-tags:
-  - Asian
-  - CSS
-  - CSS Property
-  - CSS テキスト
-  - NeedsExample
-  - Reference
-  - i18n
-  - l10n
-  - recipe:css-property
-  - 日本語処理
-  - 禁則処理
-browser-compat: css.properties.line-break
-translation_of: Web/CSS/line-break
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/line-height-step/index.md
+++ b/files/ja/web/css/line-height-step/index.md
@@ -1,14 +1,6 @@
 ---
 title: line-height-step
 slug: Web/CSS/line-height-step
-tags:
-  - CSS
-  - CSS Fonts
-  - CSS Property
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.line-height-step
-translation_of: Web/CSS/line-height-step
 l10n:
   sourceCommit: 293c903f50ef81458e5e1df61887abaf8b4d7bb9
 ---

--- a/files/ja/web/css/line-height/index.md
+++ b/files/ja/web/css/line-height/index.md
@@ -1,19 +1,6 @@
 ---
 title: line-height
 slug: Web/CSS/line-height
-tags:
-  - CSS
-  - CSS フォント
-  - CSS プロパティ
-  - レイアウト
-  - リファレンス
-  - テキスト
-  - Vertical
-  - height
-  - recipe:css-property
-  - size
-browser-compat: css.properties.line-height
-translation_of: Web/CSS/line-height
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/list-style-image/index.md
+++ b/files/ja/web/css/list-style-image/index.md
@@ -1,14 +1,6 @@
 ---
 title: list-style-image
 slug: Web/CSS/list-style-image
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS リスト
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.list-style-image
-translation_of: Web/CSS/list-style-image
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/list-style-position/index.md
+++ b/files/ja/web/css/list-style-position/index.md
@@ -1,14 +1,6 @@
 ---
 title: list-style-position
 slug: Web/CSS/list-style-position
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS リスト
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.list-style-position
-translation_of: Web/CSS/list-style-position
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/list-style-type/index.md
+++ b/files/ja/web/css/list-style-type/index.md
@@ -1,14 +1,6 @@
 ---
 title: list-style-type
 slug: Web/CSS/list-style-type
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS リスト
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.list-style-type
-translation_of: Web/CSS/list-style-type
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/list-style/index.md
+++ b/files/ja/web/css/list-style/index.md
@@ -1,14 +1,6 @@
 ---
 title: list-style
 slug: Web/CSS/list-style
-tags:
-  - CSS
-  - CSS Lists
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.list-style
-translation_of: Web/CSS/list-style
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/margin-block-end/index.md
+++ b/files/ja/web/css/margin-block-end/index.md
@@ -1,18 +1,6 @@
 ---
 title: margin-block-end
 slug: Web/CSS/margin-block-end
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - NeedsContent
-  - リファレンス
-  - margin-block
-  - margin-block-end
-  - recipe:css-property
-browser-compat: css.properties.margin-block-end
-translation_of: Web/CSS/margin-block-end
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/margin-block-start/index.md
+++ b/files/ja/web/css/margin-block-start/index.md
@@ -1,18 +1,6 @@
 ---
 title: margin-block-start
 slug: Web/CSS/margin-block-start
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - NeedsContent
-  - リファレンス
-  - margin-block
-  - margin-block-start
-  - recipe:css-property
-browser-compat: css.properties.margin-block-start
-translation_of: Web/CSS/margin-block-start
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/margin-block/index.md
+++ b/files/ja/web/css/margin-block/index.md
@@ -1,16 +1,6 @@
 ---
 title: margin-block
 slug: Web/CSS/margin-block
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - margin-block
-  - recipe:css-shorthand-property
-browser-compat: css.properties.margin-block
-translation_of: Web/CSS/margin-block
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/margin-bottom/index.md
+++ b/files/ja/web/css/margin-bottom/index.md
@@ -1,13 +1,6 @@
 ---
 title: margin-bottom
 slug: Web/CSS/margin-bottom
-tags:
-  - CSS
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.margin-bottom
-translation_of: Web/CSS/margin-bottom
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/margin-inline-end/index.md
+++ b/files/ja/web/css/margin-inline-end/index.md
@@ -1,18 +1,6 @@
 ---
 title: margin-inline-end
 slug: Web/CSS/margin-inline-end
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - NeedsContent
-  - リファレンス
-  - margin-inline
-  - margin-inline-end
-  - recipe:css-property
-browser-compat: css.properties.margin-inline-end
-translation_of: Web/CSS/margin-inline-end
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/margin-inline-start/index.md
+++ b/files/ja/web/css/margin-inline-start/index.md
@@ -1,17 +1,6 @@
 ---
 title: margin-inline-start
 slug: Web/CSS/margin-inline-start
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - margin-inline
-  - margin-inline-start
-  - recipe:css-property
-browser-compat: css.properties.margin-inline-start
-translation_of: Web/CSS/margin-inline-start
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/margin-inline/index.md
+++ b/files/ja/web/css/margin-inline/index.md
@@ -1,16 +1,6 @@
 ---
 title: margin-inline
 slug: Web/CSS/margin-inline
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - margin-inline
-  - recipe:css-shorthand-property
-browser-compat: css.properties.margin-inline
-translation_of: Web/CSS/margin-inline
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/margin-left/index.md
+++ b/files/ja/web/css/margin-left/index.md
@@ -1,14 +1,6 @@
 ---
 title: margin-left
 slug: Web/CSS/margin-left
-tags:
-  - CSS
-  - CSS プロパティ
-  - Layout
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.margin-left
-translation_of: Web/CSS/margin-left
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/margin-right/index.md
+++ b/files/ja/web/css/margin-right/index.md
@@ -1,13 +1,6 @@
 ---
 title: margin-right
 slug: Web/CSS/margin-right
-tags:
-  - CSS
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.margin-right
-translation_of: Web/CSS/margin-right
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/margin-top/index.md
+++ b/files/ja/web/css/margin-top/index.md
@@ -1,13 +1,6 @@
 ---
 title: margin-top
 slug: Web/CSS/margin-top
-tags:
-  - CSS
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.margin-top
-translation_of: Web/CSS/margin-top
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/margin-trim/index.md
+++ b/files/ja/web/css/margin-trim/index.md
@@ -1,18 +1,6 @@
 ---
 title: margin-trim
 slug: Web/CSS/margin-trim
-tags:
-  - CSS
-  - CSS プロパティ
-  - Draft
-  - Experimental
-  - NeedsContent
-  - NeedsExample
-  - NeedsLiveSample
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.margin-trim
-translation_of: Web/CSS/margin-trim
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/margin/index.md
+++ b/files/ja/web/css/margin/index.md
@@ -1,13 +1,6 @@
 ---
 title: margin
 slug: Web/CSS/margin
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS 基本ボックスモデル
-  - recipe:css-shorthand-property
-browser-compat: css.properties.margin
-translation_of: Web/CSS/margin
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/mask-border-mode/index.md
+++ b/files/ja/web/css/mask-border-mode/index.md
@@ -1,17 +1,6 @@
 ---
 title: mask-border-mode
 slug: Web/CSS/mask-border-mode
-tags:
-  - CSS
-  - CSS マスク
-  - CSS プロパティ
-  - 実験的
-  - NeedsContent
-  - NeedsExample
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.mask-border-mode
-translation_of: Web/CSS/mask-border-mode
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/mask-border-outset/index.md
+++ b/files/ja/web/css/mask-border-outset/index.md
@@ -1,17 +1,6 @@
 ---
 title: mask-border-outset
 slug: Web/CSS/mask-border-outset
-tags:
-  - CSS
-  - CSS マスク
-  - CSS プロパティ
-  - 実験的
-  - NeedsCompatTable
-  - NeedsExample
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.mask-border-outset
-translation_of: Web/CSS/mask-border-outset
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/mask-border-repeat/index.md
+++ b/files/ja/web/css/mask-border-repeat/index.md
@@ -1,17 +1,6 @@
 ---
 title: mask-border-repeat
 slug: Web/CSS/mask-border-repeat
-tags:
-  - CSS
-  - CSS マスク
-  - CSS プロパティ
-  - 実験的
-  - NeedsCompatTable
-  - NeedsExample
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.mask-border-repeat
-translation_of: Web/CSS/mask-border-repeat
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/mask-border-slice/index.md
+++ b/files/ja/web/css/mask-border-slice/index.md
@@ -1,17 +1,6 @@
 ---
 title: mask-border-slice
 slug: Web/CSS/mask-border-slice
-tags:
-  - CSS
-  - CSS マスク
-  - CSS プロパティ
-  - 実験的
-  - NeedsCompatTable
-  - NeedsExample
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.mask-border-slice
-translation_of: Web/CSS/mask-border-slice
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/mask-border-source/index.md
+++ b/files/ja/web/css/mask-border-source/index.md
@@ -1,17 +1,6 @@
 ---
 title: mask-border-source
 slug: Web/CSS/mask-border-source
-tags:
-  - CSS
-  - CSS マスク
-  - CSS プロパティ
-  - 実験的
-  - NeedsCompatTable
-  - NeedsExample
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.mask-border-source
-translation_of: Web/CSS/mask-border-source
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/mask-border-width/index.md
+++ b/files/ja/web/css/mask-border-width/index.md
@@ -1,17 +1,6 @@
 ---
 title: mask-border-width
 slug: Web/CSS/mask-border-width
-tags:
-  - CSS
-  - CSS マスク
-  - CSS プロパティ
-  - 実験的
-  - NeedsCompatTable
-  - NeedsExample
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.mask-border-width
-translation_of: Web/CSS/mask-border-width
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/mask-border/index.md
+++ b/files/ja/web/css/mask-border/index.md
@@ -1,14 +1,6 @@
 ---
 title: mask-border
 slug: Web/CSS/mask-border
-tags:
-  - CSS
-  - CSS マスク
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.mask-border
-translation_of: Web/CSS/mask-border
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/mask-clip/index.md
+++ b/files/ja/web/css/mask-clip/index.md
@@ -1,15 +1,6 @@
 ---
 title: mask-clip
 slug: Web/CSS/mask-clip
-tags:
-  - CSS
-  - CSS マスク
-  - CSS プロパティ
-  - Experimental
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.mask-clip
-translation_of: Web/CSS/mask-clip
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/mask-composite/index.md
+++ b/files/ja/web/css/mask-composite/index.md
@@ -1,15 +1,6 @@
 ---
 title: mask-composite
 slug: Web/CSS/mask-composite
-tags:
-  - CSS
-  - CSS マスク
-  - CSS プロパティ
-  - Experimental
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.mask-composite
-translation_of: Web/CSS/mask-composite
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/mask-image/index.md
+++ b/files/ja/web/css/mask-image/index.md
@@ -1,15 +1,6 @@
 ---
 title: mask-image
 slug: Web/CSS/mask-image
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS マスク
-  - Experimental
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.mask-image
-translation_of: Web/CSS/mask-image
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/mask-mode/index.md
+++ b/files/ja/web/css/mask-mode/index.md
@@ -1,15 +1,6 @@
 ---
 title: mask-mode
 slug: Web/CSS/mask-mode
-tags:
-  - CSS
-  - CSS マスク
-  - CSS プロパティ
-  - Experimental
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.mask-mode
-translation_of: Web/CSS/mask-mode
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/mask-origin/index.md
+++ b/files/ja/web/css/mask-origin/index.md
@@ -1,15 +1,6 @@
 ---
 title: mask-origin
 slug: Web/CSS/mask-origin
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS マスク
-  - Experimental
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.mask-origin
-translation_of: Web/CSS/mask-origin
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/mask-position/index.md
+++ b/files/ja/web/css/mask-position/index.md
@@ -1,15 +1,6 @@
 ---
 title: mask-position
 slug: Web/CSS/mask-position
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS マスク
-  - Experimental
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.mask-position
-translation_of: Web/CSS/mask-position
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/mask-repeat/index.md
+++ b/files/ja/web/css/mask-repeat/index.md
@@ -1,15 +1,6 @@
 ---
 title: mask-repeat
 slug: Web/CSS/mask-repeat
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS マスク
-  - Experimental
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.mask-repeat
-translation_of: Web/CSS/mask-repeat
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/mask-size/index.md
+++ b/files/ja/web/css/mask-size/index.md
@@ -1,15 +1,6 @@
 ---
 title: mask-size
 slug: Web/CSS/mask-size
-tags:
-  - CSS
-  - CSS マスク
-  - CSS プロパティ
-  - Experimental
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.mask-size
-translation_of: Web/CSS/mask-size
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/mask-type/index.md
+++ b/files/ja/web/css/mask-type/index.md
@@ -1,15 +1,6 @@
 ---
 title: mask-type
 slug: Web/CSS/mask-type
-tags:
-  - CSS
-  - CSS マスク
-  - CSS プロパティ
-  - リファレンス
-  - SVG
-  - recipe:css-property
-browser-compat: css.properties.mask-type
-translation_of: Web/CSS/mask-type
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/mask/index.md
+++ b/files/ja/web/css/mask/index.md
@@ -1,17 +1,6 @@
 ---
 title: mask
 slug: Web/CSS/mask
-tags:
-  - CSS
-  - CSS マスク
-  - CSS プロパティ
-  - Layout
-  - リファレンス
-  - SVG
-  - Web
-  - recipe:css-shorthand-property
-browser-compat: css.properties.mask
-translation_of: Web/CSS/mask
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/masonry-auto-flow/index.md
+++ b/files/ja/web/css/masonry-auto-flow/index.md
@@ -1,16 +1,6 @@
 ---
 title: masonry-auto-flow
 slug: Web/CSS/masonry-auto-flow
-tags:
-  - CSS
-  - 実験的
-  - プロパティ
-  - リファレンス
-  - grid
-  - masonry
-  - masonry-auto-flow
-browser-compat: css.properties.masonry-auto-flow
-translation_of: Web/CSS/masonry-auto-flow
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/max-block-size/index.md
+++ b/files/ja/web/css/max-block-size/index.md
@@ -1,21 +1,6 @@
 ---
 title: max-block-size
 slug: Web/CSS/max-block-size
-tags:
-  - CSS
-  - CSS Logical Property
-  - CSS Property
-  - Layout
-  - Maximum Height
-  - Maximum Width
-  - Reference
-  - height
-  - max-block-size
-  - recipe:css-property
-  - size
-  - width
-browser-compat: css.properties.max-block-size
-translation_of: Web/CSS/max-block-size
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/max-content/index.md
+++ b/files/ja/web/css/max-content/index.md
@@ -1,14 +1,6 @@
 ---
 title: max-content
 slug: Web/CSS/max-content
-tags:
-  - CSS
-  - CSS グリッド
-  - リファレンス
-  - max-content
-  - 大きさ
-browser-compat: css.properties.width.max-content
-translation_of: Web/CSS/max-content
 ---
 `max-content` は大きさのキーワードで、コンテンツの内在的な最大幅や高さを表しています。テキストコンテンツの場合は、オーバーフローが発生しても、コンテンツはまったく折り返されないことを意味します。
 

--- a/files/ja/web/css/max-height/index.md
+++ b/files/ja/web/css/max-height/index.md
@@ -1,20 +1,6 @@
 ---
 title: max-height
 slug: Web/CSS/max-height
-tags:
-  - CSS
-  - CSS プロパティ
-  - レイアウト
-  - 最大
-  - リファレンス
-  - 寸法
-  - height
-  - limit
-  - max-height
-  - recipe:css-property
-  - size
-browser-compat: css.properties.max-height
-translation_of: Web/CSS/max-height
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/max-inline-size/index.md
+++ b/files/ja/web/css/max-inline-size/index.md
@@ -1,20 +1,6 @@
 ---
 title: max-inline-size
 slug: Web/CSS/max-inline-size
-tags:
-  - CSS
-  - CSS Logical Properties
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - Element size
-  - Experimental
-  - リファレンス
-  - Text Direction
-  - Writing Mode
-  - max-inline-size
-  - recipe:css-property
-browser-compat: css.properties.max-inline-size
-translation_of: Web/CSS/max-inline-size
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/max-width/index.md
+++ b/files/ja/web/css/max-width/index.md
@@ -1,20 +1,6 @@
 ---
 title: max-width
 slug: Web/CSS/max-width
-tags:
-  - CSS
-  - CSS プロパティ
-  - レイアウト
-  - Limits
-  - 最大
-  - リファレンス
-  - 寸法
-  - max-width
-  - recipe:css-property
-  - size
-  - width
-browser-compat: css.properties.max-width
-translation_of: Web/CSS/max-width
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/max/index.md
+++ b/files/ja/web/css/max/index.md
@@ -1,19 +1,7 @@
 ---
 title: max()
 slug: Web/CSS/max
-tags:
-  - CSS
-  - CSS 関数
-  - Calculate
-  - Compute
-  - 関数
-  - レイアウト
-  - リファレンス
-  - ウェブ
-  - max
-translation_of: Web/CSS/max()
 original_slug: Web/CSS/max()
-browser-compat: css.types.max
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/media_queries/index.md
+++ b/files/ja/web/css/media_queries/index.md
@@ -1,14 +1,6 @@
 ---
 title: メディアクエリー
 slug: Web/CSS/Media_Queries
-tags:
-  - CSS
-  - ガイド
-  - メディアクエリー
-  - 概要
-  - リファレンス
-  - レスポンシブデザイン
-translation_of: Web/CSS/Media_Queries
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/media_queries/testing_media_queries/index.md
+++ b/files/ja/web/css/media_queries/testing_media_queries/index.md
@@ -1,18 +1,6 @@
 ---
 title: プログラムによるメディアクエリーの評価
 slug: Web/CSS/Media_Queries/Testing_media_queries
-tags:
-  - 上級者
-  - CSS
-  - DOM
-  - ガイド
-  - JavaScript
-  - メディアクエリー
-  - MediaQueryList
-  - レスポンシブデザイン
-  - ウェブ
-  - matchMedia
-translation_of: Web/CSS/Media_Queries/Testing_media_queries
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/media_queries/using_media_queries/index.md
+++ b/files/ja/web/css/media_queries/using_media_queries/index.md
@@ -1,15 +1,6 @@
 ---
 title: メディアクエリーの使用
 slug: Web/CSS/Media_Queries/Using_media_queries
-tags:
-  - 上級者
-  - CSS
-  - ガイド
-  - ウェブ
-  - メディア
-  - メディアクエリー
-  - レスポンシブデザイン
-translation_of: Web/CSS/Media_Queries/Using_media_queries
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/media_queries/using_media_queries_for_accessibility/index.md
+++ b/files/ja/web/css/media_queries/using_media_queries_for_accessibility/index.md
@@ -1,13 +1,6 @@
 ---
 title: アクセシビリティのためのメディアクエリーの使用
 slug: Web/CSS/Media_Queries/Using_Media_Queries_for_Accessibility
-tags:
-  - '@media'
-  - アクセシビリティ
-  - アニメーション
-  - CSS
-  - ガイド
-translation_of: Web/CSS/Media_Queries/Using_Media_Queries_for_Accessibility
 ---
 **メディアクエリー**は、障碍を持ったユーザーがウェブサイトをより理解することを支援するためにも利用することができます。
 

--- a/files/ja/web/css/microsoft_extensions/index.md
+++ b/files/ja/web/css/microsoft_extensions/index.md
@@ -1,14 +1,6 @@
 ---
 title: Microsoft CSS 拡張
 slug: Web/CSS/Microsoft_Extensions
-tags:
-  - CSS
-  - CSS:Microsoft 拡張
-  - ガイド
-  - 標準外
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/Microsoft_Extensions
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/min-block-size/index.md
+++ b/files/ja/web/css/min-block-size/index.md
@@ -1,16 +1,6 @@
 ---
 title: min-block-size
 slug: Web/CSS/min-block-size
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - Experimental
-  - リファレンス
-  - min-block-size
-  - recipe:css-property
-browser-compat: css.properties.min-block-size
-translation_of: Web/CSS/min-block-size
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/min-content/index.md
+++ b/files/ja/web/css/min-content/index.md
@@ -1,14 +1,6 @@
 ---
 title: min-content
 slug: Web/CSS/min-content
-tags:
-  - CSS
-  - キーワード
-  - リファレンス
-  - min-content
-  - 大きさ
-browser-compat: css.properties.width.min-content
-translation_of: min-content
 ---
 `min-content` は大きさのキーワードで、コンテンツの内在的な最小幅を表しています。テキストコンテンツの場合は、コンテンツがすべてのソフトラッピングの機会を使用した場合に、最も長い単語と同じくらい小さくなることを意味します。
 

--- a/files/ja/web/css/min-height/index.md
+++ b/files/ja/web/css/min-height/index.md
@@ -1,19 +1,6 @@
 ---
 title: min-height
 slug: Web/CSS/min-height
-tags:
-  - CSS
-  - CSS プロパティ
-  - レイアウト
-  - 最小
-  - リファレンス
-  - 寸法
-  - height
-  - min-height
-  - recipe:css-property
-  - size
-browser-compat: css.properties.min-height
-translation_of: Web/CSS/min-height
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/min-inline-size/index.md
+++ b/files/ja/web/css/min-inline-size/index.md
@@ -1,16 +1,6 @@
 ---
 title: min-inline-size
 slug: Web/CSS/min-inline-size
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - Experimental
-  - リファレンス
-  - min-inline-size
-  - recipe:css-property
-browser-compat: css.properties.min-inline-size
-translation_of: Web/CSS/min-inline-size
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/min-width/index.md
+++ b/files/ja/web/css/min-width/index.md
@@ -1,20 +1,6 @@
 ---
 title: min-width
 slug: Web/CSS/min-width
-tags:
-  - CSS
-  - CSS プロパティ
-  - 水平
-  - レイアウト
-  - 最小
-  - リファレンス
-  - 寸法
-  - min-width
-  - recipe:css-property
-  - size
-  - width
-browser-compat: css.properties.min-width
-translation_of: Web/CSS/min-width
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/min/index.md
+++ b/files/ja/web/css/min/index.md
@@ -1,18 +1,7 @@
 ---
 title: min()
 slug: Web/CSS/min
-tags:
-  - CSS
-  - CSS 関数
-  - Calculate
-  - Compute
-  - 関数
-  - レイアウト
-  - リファレンス
-  - min
-translation_of: Web/CSS/min()
 original_slug: Web/CSS/min()
-browser-compat: css.types.min
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/minmax/index.md
+++ b/files/ja/web/css/minmax/index.md
@@ -1,18 +1,7 @@
 ---
 title: minmax()
 slug: Web/CSS/minmax
-tags:
-  - CSS
-  - CSS 関数
-  - CSS グリッド
-  - Experimental
-  - 関数
-  - リファレンス
-  - ウェブ
-  - レイアウト
-translation_of: Web/CSS/minmax()
 original_slug: Web/CSS/minmax()
-browser-compat: css.properties.grid-template-columns.minmax
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/mix-blend-mode/index.md
+++ b/files/ja/web/css/mix-blend-mode/index.md
@@ -1,15 +1,6 @@
 ---
 title: mix-blend-mode
 slug: Web/CSS/mix-blend-mode
-tags:
-  - 混合
-  - CSS
-  - CSS プロパティ
-  - 合成
-  - 合成と混合
-  - recipe:css-property
-browser-compat: css.properties.mix-blend-mode
-translation_of: Web/CSS/mix-blend-mode
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/mozilla_extensions/index.md
+++ b/files/ja/web/css/mozilla_extensions/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSS の Mozilla 拡張
 slug: Web/CSS/Mozilla_Extensions
-tags:
-  - CSS
-  - CSS:Mozilla 拡張
-  - ガイド
-  - 標準外
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/Mozilla_Extensions
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/number/index.md
+++ b/files/ja/web/css/number/index.md
@@ -1,15 +1,6 @@
 ---
 title: <number>
 slug: Web/CSS/number
-tags:
-  - CSS
-  - CSS データ型
-  - データ型
-  - レイアウト
-  - リファレンス
-  - ウェブ
-browser-compat: css.types.number
-translation_of: Web/CSS/number
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/object-fit/index.md
+++ b/files/ja/web/css/object-fit/index.md
@@ -1,18 +1,6 @@
 ---
 title: object-fit
 slug: Web/CSS/object-fit
-tags:
-  - CSS
-  - CSS 画像
-  - CSS プロパティ
-  - レイアウト
-  - Reference
-  - css レイアウト
-  - object-fit
-  - recipe:css-property
-  - 寸法
-browser-compat: css.properties.object-fit
-translation_of: Web/CSS/object-fit
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/object-position/index.md
+++ b/files/ja/web/css/object-position/index.md
@@ -1,19 +1,6 @@
 ---
 title: object-position
 slug: Web/CSS/object-position
-tags:
-  - CSS
-  - CSS 画像
-  - CSS プロパティ
-  - レイアウト
-  - 位置
-  - Reference
-  - 置換要素
-  - css レイアウト
-  - object-position
-  - recipe:css-property
-browser-compat: css.properties.object-position
-translation_of: Web/CSS/object-position
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/offset-anchor/index.md
+++ b/files/ja/web/css/offset-anchor/index.md
@@ -1,16 +1,6 @@
 ---
 title: offset-anchor
 slug: Web/CSS/offset-anchor
-tags:
-  - CSS
-  - CSS モーションパス
-  - 実験的
-  - モーションパス
-  - リファレンス
-  - offset-anchor
-  - recipe:css-property
-browser-compat: css.properties.offset-anchor
-translation_of: Web/CSS/offset-anchor
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/offset-distance/index.md
+++ b/files/ja/web/css/offset-distance/index.md
@@ -1,18 +1,6 @@
 ---
 title: offset-distance
 slug: Web/CSS/offset-distance
-tags:
-  - CSS
-  - CSS モーションパス
-  - CSS プロパティ
-  - 実験的
-  - モーションパス
-  - リファレンス
-  - motion-offset
-  - offset-distance
-  - recipe:css-property
-browser-compat: css.properties.offset-distance
-translation_of: Web/CSS/offset-distance
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/offset-path/index.md
+++ b/files/ja/web/css/offset-path/index.md
@@ -1,17 +1,6 @@
 ---
 title: offset-path
 slug: Web/CSS/offset-path
-tags:
-  - CSS
-  - CSS モーションパス
-  - 実験的
-  - モーションパス
-  - リファレンス
-  - motion-path
-  - offset-path
-  - recipe:css-property
-browser-compat: css.properties.offset-path
-translation_of: Web/CSS/offset-path
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/offset-position/index.md
+++ b/files/ja/web/css/offset-position/index.md
@@ -1,16 +1,6 @@
 ---
 title: offset-position
 slug: Web/CSS/offset-position
-tags:
-  - CSS
-  - CSS モーションパス
-  - CSS プロパティ
-  - 実験的
-  - プロパティ
-  - offset-position
-  - recipe:css-property
-browser-compat: css.properties.offset-position
-translation_of: Web/CSS/offset-position
 ---
 {{CSSRef}}{{SeeCompatTable}}
 

--- a/files/ja/web/css/offset-rotate/index.md
+++ b/files/ja/web/css/offset-rotate/index.md
@@ -1,16 +1,6 @@
 ---
 title: offset-rotate
 slug: Web/CSS/offset-rotate
-tags:
-  - CSS
-  - CSS モーションパス
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - offset-rotate
-  - recipe:css-property
-browser-compat: css.properties.offset-rotate
-translation_of: Web/CSS/offset-rotate
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/offset/index.md
+++ b/files/ja/web/css/offset/index.md
@@ -1,15 +1,6 @@
 ---
 title: offset
 slug: Web/CSS/offset
-tags:
-  - CSS
-  - CSS モーションパス
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.offset
-translation_of: Web/CSS/offset
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/opacity/index.md
+++ b/files/ja/web/css/opacity/index.md
@@ -1,14 +1,6 @@
 ---
 title: opacity
 slug: Web/CSS/opacity
-tags:
-  - CSS
-  - CSS プロパティ
-  - 不透明度
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.opacity
-translation_of: Web/CSS/opacity
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/order/index.md
+++ b/files/ja/web/css/order/index.md
@@ -1,14 +1,6 @@
 ---
 title: order
 slug: Web/CSS/order
-tags:
-  - CSS
-  - CSS フレックスボックス
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.order
-translation_of: Web/CSS/order
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/orphans/index.md
+++ b/files/ja/web/css/orphans/index.md
@@ -1,13 +1,6 @@
 ---
 title: orphans
 slug: Web/CSS/orphans
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS 断片化
-  - リファレンス
-  - Web
-translation_of: Web/CSS/orphans
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/outline-color/index.md
+++ b/files/ja/web/css/outline-color/index.md
@@ -1,20 +1,6 @@
 ---
 title: outline-color
 slug: Web/CSS/outline-color
-tags:
-  - CSS
-  - CSS 輪郭線
-  - CSS プロパティ
-  - CSS ユーザーインターフェイス
-  - HTML 色
-  - HTML スタイル
-  - アウトライン
-  - Reference
-  - スタイル
-  - Styling HTML
-  - outline-color
-  - 'recipe:css-property'
-translation_of: Web/CSS/outline-color
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/outline-offset/index.md
+++ b/files/ja/web/css/outline-offset/index.md
@@ -1,14 +1,6 @@
 ---
 title: outline-offset
 slug: Web/CSS/outline-offset
-tags:
-  - CSS
-  - CSS 輪郭線
-  - CSS プロパティ
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.outline-offset
-translation_of: Web/CSS/outline-offset
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/outline-style/index.md
+++ b/files/ja/web/css/outline-style/index.md
@@ -1,14 +1,6 @@
 ---
 title: outline-style
 slug: Web/CSS/outline-style
-tags:
-  - CSS
-  - CSS 輪郭線
-  - CSS プロパティ
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.outline-style
-translation_of: Web/CSS/outline-style
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/outline-width/index.md
+++ b/files/ja/web/css/outline-width/index.md
@@ -1,15 +1,6 @@
 ---
 title: outline-width
 slug: Web/CSS/outline-width
-tags:
-  - CSS
-  - CSS 輪郭線
-  - CSS プロパティ
-  - Layout
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.outline-width
-translation_of: Web/CSS/outline-width
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/outline/index.md
+++ b/files/ja/web/css/outline/index.md
@@ -1,15 +1,6 @@
 ---
 title: outline
 slug: Web/CSS/outline
-tags:
-  - CSS
-  - CSS 輪郭線
-  - CSS プロパティ
-  - レイアウト
-  - Reference
-  - recipe:css-shorthand-property
-browser-compat: css.properties.outline
-translation_of: Web/CSS/outline
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/overflow-anchor/guide_to_scroll_anchoring/index.md
+++ b/files/ja/web/css/overflow-anchor/guide_to_scroll_anchoring/index.md
@@ -1,12 +1,6 @@
 ---
 title: スクロールアンカリングの紹介
 slug: Web/CSS/overflow-anchor/Guide_to_scroll_anchoring
-tags:
-  - CSS
-  - ガイド
-  - overflow-anchor
-  - スクロールアンカリング
-translation_of: Web/CSS/overflow-anchor/Guide_to_scroll_anchoring
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/overflow-anchor/index.md
+++ b/files/ja/web/css/overflow-anchor/index.md
@@ -1,14 +1,6 @@
 ---
 title: overflow-anchor
 slug: Web/CSS/overflow-anchor
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS スクロールアンカリング
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.overflow-anchor
-translation_of: Web/CSS/overflow-anchor
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/overflow-block/index.md
+++ b/files/ja/web/css/overflow-block/index.md
@@ -1,14 +1,6 @@
 ---
 title: overflow-block
 slug: Web/CSS/overflow-block
-tags:
-  - CSS
-  - CSS ボックスモデル
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.overflow-block
-translation_of: Web/CSS/overflow-block
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/overflow-clip-margin/index.md
+++ b/files/ja/web/css/overflow-clip-margin/index.md
@@ -1,14 +1,6 @@
 ---
 title: overflow-clip-margin
 slug: Web/CSS/overflow-clip-margin
-tags:
-  - CSS
-  - CSS Overflow
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.overflow-clip-margin
-translation_of: Web/CSS/overflow-clip-margin
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/overflow-inline/index.md
+++ b/files/ja/web/css/overflow-inline/index.md
@@ -1,14 +1,6 @@
 ---
 title: overflow-inline
 slug: Web/CSS/overflow-inline
-tags:
-  - CSS
-  - CSS ボックスモデル
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.overflow-inline
-translation_of: Web/CSS/overflow-inline
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/overflow-wrap/index.md
+++ b/files/ja/web/css/overflow-wrap/index.md
@@ -1,14 +1,6 @@
 ---
 title: overflow-wrap
 slug: Web/CSS/overflow-wrap
-tags:
-  - CSS
-  - CSS テキスト
-  - CSS プロパティ
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.overflow-wrap
-translation_of: Web/CSS/overflow-wrap
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/overflow-x/index.md
+++ b/files/ja/web/css/overflow-x/index.md
@@ -1,14 +1,6 @@
 ---
 title: overflow-x
 slug: Web/CSS/overflow-x
-tags:
-  - CSS
-  - CSS ボックスモデル
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.overflow-x
-translation_of: Web/CSS/overflow-x
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/overflow-y/index.md
+++ b/files/ja/web/css/overflow-y/index.md
@@ -1,14 +1,6 @@
 ---
 title: overflow-y
 slug: Web/CSS/overflow-y
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS ボックスモデル
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.overflow-y
-translation_of: Web/CSS/overflow-y
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/overflow/index.md
+++ b/files/ja/web/css/overflow/index.md
@@ -1,18 +1,6 @@
 ---
 title: overflow
 slug: Web/CSS/overflow
-tags:
-  - CSS
-  - CSS ボックスモデル
-  - CSS プロパティ
-  - クリッピング
-  - レイアウト
-  - リファレンス
-  - overflow
-  - recipe:css-shorthand-property
-  - スクロール
-browser-compat: css.properties.overflow
-translation_of: Web/CSS/overflow
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/overscroll-behavior-block/index.md
+++ b/files/ja/web/css/overscroll-behavior-block/index.md
@@ -1,16 +1,6 @@
 ---
 title: overscroll-behavior-block
 slug: Web/CSS/overscroll-behavior-block
-tags:
-  - CSS
-  - CSS ボックスモデル
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - リファレンス
-  - overscroll-behavior-block
-  - recipe:css-property
-browser-compat: css.properties.overscroll-behavior-block
-translation_of: Web/CSS/overscroll-behavior-block
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/overscroll-behavior-inline/index.md
+++ b/files/ja/web/css/overscroll-behavior-inline/index.md
@@ -1,17 +1,6 @@
 ---
 title: overscroll-behavior-inline
 slug: Web/CSS/overscroll-behavior-inline
-tags:
-  - CSS
-  - CSS ボックスモデル
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - NeedsExample
-  - リファレンス
-  - overscroll-behavior-inline
-  - recipe:css-property
-browser-compat: css.properties.overscroll-behavior-inline
-translation_of: Web/CSS/overscroll-behavior-inline
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/overscroll-behavior-x/index.md
+++ b/files/ja/web/css/overscroll-behavior-x/index.md
@@ -1,14 +1,6 @@
 ---
 title: overscroll-behavior-x
 slug: Web/CSS/overscroll-behavior-x
-tags:
-  - CSS
-  - CSS Box Model
-  - CSS Property
-  - Reference
-  - overscroll-behavior-x
-  - recipe:css-property
-translation_of: Web/CSS/overscroll-behavior-x
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/overscroll-behavior-y/index.md
+++ b/files/ja/web/css/overscroll-behavior-y/index.md
@@ -1,14 +1,6 @@
 ---
 title: overscroll-behavior-y
 slug: Web/CSS/overscroll-behavior-y
-tags:
-  - CSS
-  - CSS Box Model
-  - CSS Property
-  - Reference
-  - overscroll-behavior-y
-  - recipe:css-property
-translation_of: Web/CSS/overscroll-behavior-y
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/overscroll-behavior/index.md
+++ b/files/ja/web/css/overscroll-behavior/index.md
@@ -1,14 +1,6 @@
 ---
 title: overscroll-behavior
 slug: Web/CSS/overscroll-behavior
-tags:
-  - CSS
-  - CSS Box Model
-  - CSS Property
-  - Reference
-  - overscroll-behavior
-  - recipe:css-property
-translation_of: Web/CSS/overscroll-behavior
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/padding-block-end/index.md
+++ b/files/ja/web/css/padding-block-end/index.md
@@ -1,17 +1,6 @@
 ---
 title: padding-block-end
 slug: Web/CSS/padding-block-end
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - padding-block
-  - padding-block-end
-  - recipe:css-property
-browser-compat: css.properties.padding-block-end
-translation_of: Web/CSS/padding-block-end
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/padding-block-start/index.md
+++ b/files/ja/web/css/padding-block-start/index.md
@@ -1,17 +1,6 @@
 ---
 title: padding-block-start
 slug: Web/CSS/padding-block-start
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - padding-block
-  - padding-block-start
-  - recipe:css-property
-browser-compat: css.properties.padding-block-start
-translation_of: Web/CSS/padding-block-start
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/padding-block/index.md
+++ b/files/ja/web/css/padding-block/index.md
@@ -1,12 +1,6 @@
 ---
 title: padding-block
 slug: Web/CSS/padding-block
-tags:
-  - CSS
-  - padding-block
-  - recipe:css-shorthand-property
-browser-compat: css.properties.padding-block
-translation_of: Web/CSS/padding-block
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/padding-bottom/index.md
+++ b/files/ja/web/css/padding-bottom/index.md
@@ -1,14 +1,6 @@
 ---
 title: padding-bottom
 slug: Web/CSS/padding-bottom
-tags:
-  - CSS
-  - CSS パディング
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.padding-bottom
-translation_of: Web/CSS/padding-bottom
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/padding-inline-end/index.md
+++ b/files/ja/web/css/padding-inline-end/index.md
@@ -1,17 +1,6 @@
 ---
 title: padding-inline-end
 slug: Web/CSS/padding-inline-end
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - padding-inline
-  - padding-inline-end
-  - recipe:css-property
-browser-compat: css.properties.padding-inline-end
-translation_of: Web/CSS/padding-inline-end
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/padding-inline-start/index.md
+++ b/files/ja/web/css/padding-inline-start/index.md
@@ -1,17 +1,6 @@
 ---
 title: padding-inline-start
 slug: Web/CSS/padding-inline-start
-tags:
-  - CSS
-  - CSS 論理的プロパティ
-  - CSS プロパティ
-  - 実験的
-  - リファレンス
-  - padding-inline
-  - padding-inline-start
-  - recipe:css-property
-browser-compat: css.properties.padding-inline-start
-translation_of: Web/CSS/padding-inline-start
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/padding-inline/index.md
+++ b/files/ja/web/css/padding-inline/index.md
@@ -1,11 +1,6 @@
 ---
 title: padding-inline
 slug: Web/CSS/padding-inline
-tags:
-  - CSS
-  - recipe:css-shorthand-property
-browser-compat: css.properties.padding-inline
-translation_of: Web/CSS/padding-inline
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/padding-left/index.md
+++ b/files/ja/web/css/padding-left/index.md
@@ -1,14 +1,6 @@
 ---
 title: padding-left
 slug: Web/CSS/padding-left
-tags:
-  - CSS
-  - CSS パディング
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.padding-left
-translation_of: Web/CSS/padding-left
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/padding-right/index.md
+++ b/files/ja/web/css/padding-right/index.md
@@ -1,14 +1,6 @@
 ---
 title: padding-right
 slug: Web/CSS/padding-right
-tags:
-  - CSS
-  - CSS パディング
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.padding-right
-translation_of: Web/CSS/padding-right
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/padding-top/index.md
+++ b/files/ja/web/css/padding-top/index.md
@@ -1,14 +1,6 @@
 ---
 title: padding-top
 slug: Web/CSS/padding-top
-tags:
-  - CSS
-  - CSS パディング
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.padding-top
-translation_of: Web/CSS/padding-top
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/padding/index.md
+++ b/files/ja/web/css/padding/index.md
@@ -1,14 +1,6 @@
 ---
 title: padding
 slug: Web/CSS/padding
-tags:
-  - CSS
-  - CSS パディング
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.padding
-translation_of: Web/CSS/padding
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/page-break-after/index.md
+++ b/files/ja/web/css/page-break-after/index.md
@@ -1,14 +1,6 @@
 ---
 title: page-break-after
 slug: Web/CSS/page-break-after
-tags:
-  - CSS
-  - CSS プロパティ
-  - ページ区切り
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.page-break-after
-translation_of: Web/CSS/page-break-after
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/page-break-before/index.md
+++ b/files/ja/web/css/page-break-before/index.md
@@ -1,14 +1,6 @@
 ---
 title: page-break-before
 slug: Web/CSS/page-break-before
-tags:
-  - CSS
-  - CSS プロパティ
-  - 改ページ
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.page-break-before
-translation_of: Web/CSS/page-break-before
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/page-break-inside/index.md
+++ b/files/ja/web/css/page-break-inside/index.md
@@ -1,14 +1,6 @@
 ---
 title: page-break-inside
 slug: Web/CSS/page-break-inside
-tags:
-  - CSS
-  - CSS プロパティ
-  - 改ページ
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.page-break-inside
-translation_of: Web/CSS/page-break-inside
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/paged_media/index.md
+++ b/files/ja/web/css/paged_media/index.md
@@ -1,12 +1,6 @@
 ---
 title: ページ化メディア
 slug: Web/CSS/Paged_Media
-tags:
-  - CSS
-  - CSS ページ化メディア
-  - ページ区切り
-  - リファレンス
-translation_of: Web/CSS/Paged_Media
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/paint-order/index.md
+++ b/files/ja/web/css/paint-order/index.md
@@ -1,14 +1,6 @@
 ---
 title: paint-order
 slug: Web/CSS/paint-order
-tags:
-  - CSS
-  - Experimental
-  - Reference
-  - SVG
-  - ウェブ
-  - 描画順序
-translation_of: Web/CSS/paint-order
 ---
 {{CSSRef}}{{SeeCompatTable}}
 

--- a/files/ja/web/css/path/index.md
+++ b/files/ja/web/css/path/index.md
@@ -1,13 +1,6 @@
 ---
 title: path()
 slug: Web/CSS/path
-tags:
-  - CSS
-  - CSS Function
-  - Function
-  - Reference
-browser-compat: css.types.basic-shape.path
-translation_of: Web/CSS/path
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/percentage/index.md
+++ b/files/ja/web/css/percentage/index.md
@@ -1,15 +1,6 @@
 ---
 title: <percentage>
 slug: Web/CSS/percentage
-tags:
-  - CSS
-  - CSS データ型
-  - データ型
-  - レイアウト
-  - リファレンス
-  - ウェブ
-browser-compat: css.types.percentage
-translation_of: Web/CSS/percentage
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/perspective-origin/index.md
+++ b/files/ja/web/css/perspective-origin/index.md
@@ -1,20 +1,6 @@
 ---
 title: perspective-origin
 slug: Web/CSS/perspective-origin
-tags:
-  - 3D
-  - CSS
-  - CSS プロパティ
-  - CSS 座標変換
-  - グラフィック
-  - プロパティ
-  - Reference
-  - 座標変換
-  - perspective
-  - perspective-origin
-  - recipe:css-property
-browser-compat: css.properties.perspective-origin
-translation_of: Web/CSS/perspective-origin
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/perspective/index.md
+++ b/files/ja/web/css/perspective/index.md
@@ -1,19 +1,6 @@
 ---
 title: perspective
 slug: Web/CSS/perspective
-tags:
-  - 3D
-  - CSS
-  - CSS プロパティ
-  - CSS 座標変換
-  - 距離
-  - グラフィック
-  - プロパティ
-  - Reference
-  - perspective
-  - recipe:css-property
-browser-compat: css.properties.perspective
-translation_of: Web/CSS/perspective
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/place-content/index.md
+++ b/files/ja/web/css/place-content/index.md
@@ -1,15 +1,6 @@
 ---
 title: place-content
 slug: Web/CSS/place-content
-tags:
-  - CSS
-  - CSS ボックス配置
-  - CSS プロパティ
-  - リファレンス
-  - place-content
-  - recipe:css-shorthand-property
-browser-compat: css.properties.place-content
-translation_of: Web/CSS/place-content
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/place-items/index.md
+++ b/files/ja/web/css/place-items/index.md
@@ -1,15 +1,6 @@
 ---
 title: place-items
 slug: Web/CSS/place-items
-tags:
-  - CSS
-  - CSS フレックスボックス
-  - CSS グリッドレイアウト
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.place-items
-translation_of: Web/CSS/place-items
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/place-self/index.md
+++ b/files/ja/web/css/place-self/index.md
@@ -1,14 +1,6 @@
 ---
 title: place-self
 slug: Web/CSS/place-self
-tags:
-  - CSS
-  - CSS ボックス配置
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.place-self
-translation_of: Web/CSS/place-self
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/pointer-events/index.md
+++ b/files/ja/web/css/pointer-events/index.md
@@ -1,15 +1,6 @@
 ---
 title: pointer-events
 slug: Web/CSS/pointer-events
-tags:
-  - CSS
-  - CSS Property
-  - CSS プロパティ
-  - Reference
-  - SVG
-  - pointer-events
-  - recipe:css-property
-translation_of: Web/CSS/pointer-events
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/position/index.md
+++ b/files/ja/web/css/position/index.md
@@ -1,14 +1,6 @@
 ---
 title: position
 slug: Web/CSS/position
-tags:
-  - CSS
-  - CSS 位置指定レイアウト
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.position
-translation_of: Web/CSS/position
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/position_value/index.md
+++ b/files/ja/web/css/position_value/index.md
@@ -1,15 +1,6 @@
 ---
 title: <position>
 slug: Web/CSS/position_value
-tags:
-  - CSS
-  - CSS データ型
-  - データ型
-  - レイアウト
-  - リファレンス
-  - ウェブ
-browser-compat: css.types.position
-translation_of: Web/CSS/position_value
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/print-color-adjust/index.md
+++ b/files/ja/web/css/print-color-adjust/index.md
@@ -1,16 +1,7 @@
 ---
 title: '-webkit-print-color-adjust'
 slug: Web/CSS/print-color-adjust
-tags:
-  - CSS
-  - CSS プロパティ
-  - レイアウト
-  - 標準外
-  - ウェブ
-  - recipe:css-property
-translation_of: Web/CSS/-webkit-print-color-adjust
 original_slug: Web/CSS/-webkit-print-color-adjust
-browser-compat: css.properties.-webkit-print-color-adjust
 ---
 {{CSSRef}}{{Non-standard_header}}
 

--- a/files/ja/web/css/privacy_and_the__colon_visited_selector/index.md
+++ b/files/ja/web/css/privacy_and_the__colon_visited_selector/index.md
@@ -1,14 +1,6 @@
 ---
 title: プライバシーと :visited セレクター
 slug: Web/CSS/Privacy_and_the_:visited_selector
-tags:
-  - CSS
-  - Guide
-  - Pseudo-class
-  - Reference
-  - Security
-  - Selectors
-translation_of: Web/CSS/Privacy_and_the_:visited_selector
 ---
 {{cssref}}
 

--- a/files/ja/web/css/pseudo-classes/index.md
+++ b/files/ja/web/css/pseudo-classes/index.md
@@ -1,14 +1,6 @@
 ---
 title: 擬似クラス
 slug: Web/CSS/Pseudo-classes
-tags:
-  - CSS
-  - ガイド
-  - 概要
-  - 擬似クラス
-  - リファレンス
-  - セレクター
-translation_of: Web/CSS/Pseudo-classes
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/pseudo-elements/index.md
+++ b/files/ja/web/css/pseudo-elements/index.md
@@ -1,14 +1,6 @@
 ---
 title: 擬似要素
 slug: Web/CSS/Pseudo-elements
-tags:
-  - CSS
-  - ガイド
-  - 概要
-  - 擬似要素
-  - リファレンス
-  - セレクター
-translation_of: Web/CSS/Pseudo-elements
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/quotes/index.md
+++ b/files/ja/web/css/quotes/index.md
@@ -1,15 +1,6 @@
 ---
 title: quotes
 slug: Web/CSS/quotes
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS 生成コンテンツ
-  - リファレンス
-  - ウェブ
-  - レイアウト
-  - 生成コンテンツ
-translation_of: Web/CSS/quotes
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/ratio/index.md
+++ b/files/ja/web/css/ratio/index.md
@@ -1,14 +1,6 @@
 ---
 title: <ratio>
 slug: Web/CSS/ratio
-tags:
-  - CSS
-  - CSS Data Type
-  - Data Type
-  - Layout
-  - Reference
-  - Web
-translation_of: Web/CSS/ratio
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/reference/index.md
+++ b/files/ja/web/css/reference/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS リファレンス
 slug: Web/CSS/Reference
-tags:
-  - CSS
-  - Guide
-  - Overview
-  - Reference
-  - l10n:priority
-translation_of: Web/CSS/Reference
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/repeat/index.md
+++ b/files/ja/web/css/repeat/index.md
@@ -1,17 +1,7 @@
 ---
 title: repeat()
 slug: Web/CSS/repeat
-tags:
-  - CSS
-  - CSS 関数
-  - CSS グリッド
-  - 関数
-  - レイアウト
-  - リファレンス
-  - ウェブ
-translation_of: Web/CSS/repeat()
 original_slug: Web/CSS/repeat()
-browser-compat: css.properties.grid-template-columns.repeat
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/replaced_element/index.md
+++ b/files/ja/web/css/replaced_element/index.md
@@ -1,15 +1,6 @@
 ---
 title: 置換要素
 slug: Web/CSS/Replaced_element
-tags:
-  - CSS
-  - Guide
-  - Layout
-  - Reference
-  - css layout
-  - rendering
-  - replaced element
-translation_of: Web/CSS/Replaced_element
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/resize/index.md
+++ b/files/ja/web/css/resize/index.md
@@ -1,14 +1,6 @@
 ---
 title: resize
 slug: Web/CSS/resize
-tags:
-  - CSS 基本ユーザーインターフェイス
-  - CSS
-  - CSS プロパティ
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.resize
-translation_of: Web/CSS/resize
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/resolution/index.md
+++ b/files/ja/web/css/resolution/index.md
@@ -1,15 +1,6 @@
 ---
 title: <resolution>
 slug: Web/CSS/resolution
-tags:
-  - CSS
-  - CSS データ型
-  - データ型
-  - リファレンス
-  - ウェブ
-  - レイアウト
-browser-compat: css.types.resolution
-translation_of: Web/CSS/resolution
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/resolved_value/index.md
+++ b/files/ja/web/css/resolved_value/index.md
@@ -1,12 +1,6 @@
 ---
 title: 解決値
 slug: Web/CSS/resolved_value
-tags:
-  - CSS
-  - Guide
-  - Reference
-spec-urls: https://drafts.csswg.org/cssom/#resolved-values
-translation_of: Web/CSS/resolved_value
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/revert/index.md
+++ b/files/ja/web/css/revert/index.md
@@ -1,18 +1,6 @@
 ---
 title: revert
 slug: Web/CSS/revert
-tags:
-  - CSS
-  - CSS カスケード
-  - CSS 値
-  - カスケード
-  - キーワード
-  - レイアウト
-  - リファレンス
-  - スタイル
-  - revert
-browser-compat: css.types.global_keywords.revert
-translation_of: Web/CSS/revert
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/right/index.md
+++ b/files/ja/web/css/right/index.md
@@ -1,16 +1,6 @@
 ---
 title: right
 slug: Web/CSS/right
-tags:
-  - CSS
-  - CSS 位置指定レイアウト
-  - CSS プロパティ
-  - レイアウト
-  - リファレンス
-  - ウェブ
-  - recipe:css-property
-browser-compat: css.properties.right
-translation_of: Web/CSS/right
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/rotate/index.md
+++ b/files/ja/web/css/rotate/index.md
@@ -1,17 +1,6 @@
 ---
 title: rotate
 slug: Web/CSS/rotate
-tags:
-  - CSS
-  - CSS プロパティ
-  - Reference
-  - 回転
-  - 座標変換
-  - angle
-  - recipe:css-property
-  - rotation
-browser-compat: css.properties.rotate
-translation_of: Web/CSS/rotate
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/row-gap/index.md
+++ b/files/ja/web/css/row-gap/index.md
@@ -1,16 +1,6 @@
 ---
 title: row-gap (grid-row-gap)
 slug: Web/CSS/row-gap
-tags:
-  - CSS
-  - CSS フレックスボックス
-  - CSS グリッド
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-  - row-gap
-browser-compat: css.properties.row-gap
-translation_of: Web/CSS/row-gap
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/ruby-align/index.md
+++ b/files/ja/web/css/ruby-align/index.md
@@ -1,14 +1,6 @@
 ---
 title: ruby-align
 slug: Web/CSS/ruby-align
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS ルビ
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.ruby-align
-translation_of: Web/CSS/ruby-align
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/ruby-position/index.md
+++ b/files/ja/web/css/ruby-position/index.md
@@ -1,14 +1,6 @@
 ---
 title: ruby-position
 slug: Web/CSS/ruby-position
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS ルビ
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.ruby-position
-translation_of: Web/CSS/ruby-position
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scale/index.md
+++ b/files/ja/web/css/scale/index.md
@@ -1,14 +1,6 @@
 ---
 title: scale
 slug: Web/CSS/scale
-tags:
-  - CSS
-  - CSS プロパティ
-  - Reference
-  - 座標変換
-  - recipe:css-property
-browser-compat: css.properties.scale
-translation_of: Web/CSS/scale
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-behavior/index.md
+++ b/files/ja/web/css/scroll-behavior/index.md
@@ -1,14 +1,6 @@
 ---
 title: scroll-behavior
 slug: Web/CSS/scroll-behavior
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSSOM View
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.scroll-behavior
-translation_of: Web/CSS/scroll-behavior
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-margin-block-end/index.md
+++ b/files/ja/web/css/scroll-margin-block-end/index.md
@@ -1,12 +1,6 @@
 ---
 title: scroll-margin-block-end
 slug: Web/CSS/scroll-margin-block-end
-tags:
-  - CSS
-  - recipe:css-property
-  - scroll-margin-block-end
-browser-compat: css.properties.scroll-margin-block-end
-translation_of: Web/CSS/scroll-margin-block-end
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-margin-block-start/index.md
+++ b/files/ja/web/css/scroll-margin-block-start/index.md
@@ -1,14 +1,6 @@
 ---
 title: scroll-margin-block-start
 slug: Web/CSS/scroll-margin-block-start
-tags:
-  - 初心者
-  - CSS
-  - Example
-  - recipe:css-property
-  - scroll-margin-block-start
-browser-compat: css.properties.scroll-margin-block-start
-translation_of: Web/CSS/scroll-margin-block-start
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-margin-block/index.md
+++ b/files/ja/web/css/scroll-margin-block/index.md
@@ -1,11 +1,6 @@
 ---
 title: scroll-margin-block
 slug: Web/CSS/scroll-margin-block
-tags:
-  - CSS
-  - recipe:css-shorthand-property
-  - scroll-margin-block
-browser-compat: css.properties.scroll-margin-block
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-margin-bottom/index.md
+++ b/files/ja/web/css/scroll-margin-bottom/index.md
@@ -1,17 +1,6 @@
 ---
 title: scroll-margin-bottom
 slug: Web/CSS/scroll-margin-bottom
-tags:
-  - CSS
-  - CSS プロパティ
-  - Reference
-  - Scroll margin bottom
-  - Web
-  - recipe:css-property
-  - scroll-margin
-  - scroll-margin-bottom
-browser-compat: css.properties.scroll-margin-bottom
-translation_of: Web/CSS/scroll-margin-bottom
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-margin-inline-end/index.md
+++ b/files/ja/web/css/scroll-margin-inline-end/index.md
@@ -1,14 +1,6 @@
 ---
 title: scroll-margin-inline-end
 slug: Web/CSS/scroll-margin-inline-end
-tags:
-  - 上級者
-  - CSS
-  - NeedsExample
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.scroll-margin-inline-end
-translation_of: Web/CSS/scroll-margin-inline-end
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-margin-inline-start/index.md
+++ b/files/ja/web/css/scroll-margin-inline-start/index.md
@@ -1,16 +1,6 @@
 ---
 title: scroll-margin-inline-start
 slug: Web/CSS/scroll-margin-inline-start
-tags:
-  - CSS
-  - CSS プロパティ
-  - Reference
-  - Web
-  - recipe:css-property
-  - scroll-margin-inline
-  - scroll-margin-inline-start
-browser-compat: css.properties.scroll-margin-inline-start
-translation_of: Web/CSS/scroll-margin-inline-start
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-margin-inline/index.md
+++ b/files/ja/web/css/scroll-margin-inline/index.md
@@ -1,16 +1,6 @@
 ---
 title: scroll-margin-inline
 slug: Web/CSS/scroll-margin-inline
-tags:
-  - CSS
-  - CSS プロパティ
-  - Reference
-  - Web
-  - recipe:css-shorthand-property
-  - scroll-margin
-  - scroll-margin-inline
-browser-compat: css.properties.scroll-margin-inline
-translation_of: Web/CSS/scroll-margin-inline
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-margin-left/index.md
+++ b/files/ja/web/css/scroll-margin-left/index.md
@@ -1,17 +1,6 @@
 ---
 title: scroll-margin-left
 slug: Web/CSS/scroll-margin-left
-tags:
-  - CSS
-  - CSS プロパティ
-  - Reference
-  - Scroll margin left
-  - Web
-  - recipe:css-property
-  - scroll-margin
-  - scroll-margin-left
-browser-compat: css.properties.scroll-margin-left
-translation_of: Web/CSS/scroll-margin-left
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-margin-right/index.md
+++ b/files/ja/web/css/scroll-margin-right/index.md
@@ -1,16 +1,6 @@
 ---
 title: scroll-margin-right
 slug: Web/CSS/scroll-margin-right
-tags:
-  - CSS
-  - CSS プロパティ
-  - Reference
-  - Web
-  - recipe:css-property
-  - scroll-margin
-  - scroll-margin-right
-browser-compat: css.properties.scroll-margin-right
-translation_of: Web/CSS/scroll-margin-right
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-margin-top/index.md
+++ b/files/ja/web/css/scroll-margin-top/index.md
@@ -1,16 +1,6 @@
 ---
 title: scroll-margin-top
 slug: Web/CSS/scroll-margin-top
-tags:
-  - CSS
-  - CSS プロパティ
-  - Reference
-  - Web
-  - recipe:css-property
-  - scroll-margin
-  - scroll-margin-top
-browser-compat: css.properties.scroll-margin-top
-translation_of: Web/CSS/scroll-margin-top
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-margin/index.md
+++ b/files/ja/web/css/scroll-margin/index.md
@@ -1,17 +1,6 @@
 ---
 title: scroll-margin
 slug: Web/CSS/scroll-margin
-tags:
-  - CSS
-  - プロパティ
-  - Reference
-  - margin
-  - recipe:css-shorthand-property
-  - scroll-margin
-  - scrollbar
-  - scrolling
-browser-compat: css.properties.scroll-margin
-translation_of: Web/CSS/scroll-margin
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-padding-block-end/index.md
+++ b/files/ja/web/css/scroll-padding-block-end/index.md
@@ -1,16 +1,6 @@
 ---
 title: scroll-padding-block-end
 slug: Web/CSS/scroll-padding-block-end
-tags:
-  - CSS
-  - CSS プロパティ
-  - Reference
-  - Web
-  - recipe:css-property
-  - scroll-padding-block
-  - scroll-padding-block-end
-browser-compat: css.properties.scroll-padding-block-end
-translation_of: Web/CSS/scroll-padding-block-end
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-padding-block-start/index.md
+++ b/files/ja/web/css/scroll-padding-block-start/index.md
@@ -1,16 +1,6 @@
 ---
 title: scroll-padding-block-start
 slug: Web/CSS/scroll-padding-block-start
-tags:
-  - CSS
-  - CSS プロパティ
-  - Reference
-  - Web
-  - recipe:css-property
-  - scroll-padding-block
-  - scroll-padding-block-start
-browser-compat: css.properties.scroll-padding-block-start
-translation_of: Web/CSS/scroll-padding-block-start
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-padding-block/index.md
+++ b/files/ja/web/css/scroll-padding-block/index.md
@@ -1,16 +1,6 @@
 ---
 title: scroll-padding-block
 slug: Web/CSS/scroll-padding-block
-tags:
-  - CSS
-  - CSS スクロールスナップ
-  - Reference
-  - Web
-  - recipe:css-shorthand-property
-  - scroll-padding
-  - scroll-padding-block
-browser-compat: css.properties.scroll-padding-block
-translation_of: Web/CSS/scroll-padding-block
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-padding-bottom/index.md
+++ b/files/ja/web/css/scroll-padding-bottom/index.md
@@ -1,16 +1,6 @@
 ---
 title: scroll-padding-bottom
 slug: Web/CSS/scroll-padding-bottom
-tags:
-  - CSS
-  - CSS プロパティ
-  - Reference
-  - Web
-  - recipe:css-property
-  - scroll-padding
-  - scroll-padding-bottom
-browser-compat: css.properties.scroll-padding-bottom
-translation_of: Web/CSS/scroll-padding-bottom
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-padding-inline-end/index.md
+++ b/files/ja/web/css/scroll-padding-inline-end/index.md
@@ -1,15 +1,6 @@
 ---
 title: scroll-padding-inline-end
 slug: Web/CSS/scroll-padding-inline-end
-tags:
-  - CSS
-  - CSS プロパティ
-  - Web
-  - recipe:css-property
-  - scroll-padding-inline
-  - scroll-padding-inline-end
-browser-compat: css.properties.scroll-padding-inline-end
-translation_of: Web/CSS/scroll-padding-inline-end
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-padding-inline-start/index.md
+++ b/files/ja/web/css/scroll-padding-inline-start/index.md
@@ -1,15 +1,6 @@
 ---
 title: scroll-padding-inline-start
 slug: Web/CSS/scroll-padding-inline-start
-tags:
-  - CSS
-  - CSS プロパティ
-  - Web
-  - recipe:css-property
-  - scroll-padding-inline
-  - scroll-padding-inline-start
-browser-compat: css.properties.scroll-padding-inline-start
-translation_of: Web/CSS/scroll-padding-inline-start
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-padding-inline/index.md
+++ b/files/ja/web/css/scroll-padding-inline/index.md
@@ -1,17 +1,6 @@
 ---
 title: scroll-padding-inline
 slug: Web/CSS/scroll-padding-inline
-tags:
-  - CSS
-  - CSS プロパティ
-  - Reference
-  - Web
-  - recipe:css-shorthand-property
-  - scroll-padding-inline
-  - scroll-padding-inline-end
-  - scroll-padding-inline-start
-browser-compat: css.properties.scroll-padding-inline
-translation_of: Web/CSS/scroll-padding-inline
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-padding-left/index.md
+++ b/files/ja/web/css/scroll-padding-left/index.md
@@ -1,15 +1,6 @@
 ---
 title: scroll-padding-left
 slug: Web/CSS/scroll-padding-left
-tags:
-  - CSS
-  - CSS プロパティ
-  - Reference
-  - recipe:css-property
-  - scroll-padding
-  - scroll-padding-left
-browser-compat: css.properties.scroll-padding-left
-translation_of: Web/CSS/scroll-padding-left
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-padding-right/index.md
+++ b/files/ja/web/css/scroll-padding-right/index.md
@@ -1,15 +1,6 @@
 ---
 title: scroll-padding-right
 slug: Web/CSS/scroll-padding-right
-tags:
-  - CSS
-  - Reference
-  - Web
-  - recipe:css-property
-  - scroll-padding
-  - scroll-padding-right
-browser-compat: css.properties.scroll-padding-right
-translation_of: Web/CSS/scroll-padding-right
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-padding-top/index.md
+++ b/files/ja/web/css/scroll-padding-top/index.md
@@ -1,15 +1,6 @@
 ---
 title: scroll-padding-top
 slug: Web/CSS/scroll-padding-top
-tags:
-  - CSS
-  - Reference
-  - Web
-  - recipe:css-property
-  - scroll-padding
-  - scroll-padding-top
-browser-compat: css.properties.scroll-padding-top
-translation_of: Web/CSS/scroll-padding-top
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-padding/index.md
+++ b/files/ja/web/css/scroll-padding/index.md
@@ -1,13 +1,6 @@
 ---
 title: scroll-padding
 slug: Web/CSS/scroll-padding
-tags:
-  - CSS
-  - CSS プロパティ
-  - recipe:css-shorthand-property
-  - scroll-snap
-browser-compat: css.properties.scroll-padding
-translation_of: Web/CSS/scroll-padding
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-snap-align/index.md
+++ b/files/ja/web/css/scroll-snap-align/index.md
@@ -1,15 +1,6 @@
 ---
 title: scroll-snap-align
 slug: Web/CSS/scroll-snap-align
-tags:
-  - 上級者
-  - CSS
-  - Example
-  - NeedsLiveSample
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.scroll-snap-align
-translation_of: Web/CSS/scroll-snap-align
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-snap-coordinate/index.md
+++ b/files/ja/web/css/scroll-snap-coordinate/index.md
@@ -1,15 +1,6 @@
 ---
 title: scroll-snap-coordinate
 slug: Web/CSS/scroll-snap-coordinate
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS スクロールスナップ
-  - 非推奨
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.scroll-snap-coordinate
-translation_of: Web/CSS/scroll-snap-coordinate
 ---
 {{CSSRef}}{{deprecated_header}}
 

--- a/files/ja/web/css/scroll-snap-destination/index.md
+++ b/files/ja/web/css/scroll-snap-destination/index.md
@@ -1,15 +1,6 @@
 ---
 title: scroll-snap-destination
 slug: Web/CSS/scroll-snap-destination
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS スクロールスナップ
-  - 非推奨
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.scroll-snap-destination
-translation_of: Web/CSS/scroll-snap-destination
 ---
 {{CSSRef}}{{deprecated_header}}
 

--- a/files/ja/web/css/scroll-snap-points-x/index.md
+++ b/files/ja/web/css/scroll-snap-points-x/index.md
@@ -1,15 +1,6 @@
 ---
 title: scroll-snap-points-x
 slug: Web/CSS/scroll-snap-points-x
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS スクロールスナップ
-  - 非推奨
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.scroll-snap-points-x
-translation_of: Web/CSS/scroll-snap-points-x
 ---
 {{CSSRef}}{{deprecated_header}}
 

--- a/files/ja/web/css/scroll-snap-points-y/index.md
+++ b/files/ja/web/css/scroll-snap-points-y/index.md
@@ -1,15 +1,6 @@
 ---
 title: scroll-snap-points-y
 slug: Web/CSS/scroll-snap-points-y
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS スクロールスナップ
-  - 非推奨
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.scroll-snap-points-y
-translation_of: Web/CSS/scroll-snap-points-y
 ---
 {{CSSRef}}{{deprecated_header}}
 

--- a/files/ja/web/css/scroll-snap-stop/index.md
+++ b/files/ja/web/css/scroll-snap-stop/index.md
@@ -1,15 +1,6 @@
 ---
 title: scroll-snap-stop
 slug: Web/CSS/scroll-snap-stop
-tags:
-  - CSS
-  - CSS スクロールスナップ
-  - Reference
-  - Web
-  - recipe:css-property
-  - scroll-snap-stop
-browser-compat: css.properties.scroll-snap-stop
-translation_of: Web/CSS/scroll-snap-stop
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scroll-snap-type-x/index.md
+++ b/files/ja/web/css/scroll-snap-type-x/index.md
@@ -1,16 +1,6 @@
 ---
 title: scroll-snap-type-x
 slug: Web/CSS/scroll-snap-type-x
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS スクロールスナップ
-  - NeedsExample
-  - Non-standard
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.scroll-snap-type-x
-translation_of: Web/CSS/scroll-snap-type-x
 ---
 {{CSSRef}}{{deprecated_header}}
 

--- a/files/ja/web/css/scroll-snap-type-y/index.md
+++ b/files/ja/web/css/scroll-snap-type-y/index.md
@@ -1,16 +1,6 @@
 ---
 title: scroll-snap-type-y
 slug: Web/CSS/scroll-snap-type-y
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS スクロールスナップ
-  - NeedsExample
-  - Non-standard
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.scroll-snap-type-y
-translation_of: Web/CSS/scroll-snap-type-y
 ---
 {{CSSRef}}{{deprecated_header}}
 

--- a/files/ja/web/css/scroll-snap-type/index.md
+++ b/files/ja/web/css/scroll-snap-type/index.md
@@ -1,14 +1,6 @@
 ---
 title: scroll-snap-type
 slug: Web/CSS/scroll-snap-type
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS スクロールスナップ
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.scroll-snap-type
-translation_of: Web/CSS/scroll-snap-type
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scrollbar-color/index.md
+++ b/files/ja/web/css/scrollbar-color/index.md
@@ -1,15 +1,6 @@
 ---
 title: scrollbar-color
 slug: Web/CSS/scrollbar-color
-tags:
-  - CSS
-  - CSS プロパティ
-  - リファレンス
-  - CSS スクロールバー
-  - recipe:css-property
-  - scrollbar-color
-browser-compat: css.properties.scrollbar-color
-translation_of: Web/CSS/scrollbar-color
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/scrollbar-width/index.md
+++ b/files/ja/web/css/scrollbar-width/index.md
@@ -1,15 +1,6 @@
 ---
 title: scrollbar-width
 slug: Web/CSS/scrollbar-width
-tags:
-  - CSS
-  - CSS プロパティ
-  - リファレンス
-  - CSS スクロールバー
-  - recipe:css-property
-  - scrollbar-width
-browser-compat: css.properties.scrollbar-width
-translation_of: Web/CSS/scrollbar-width
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/selector_list/index.md
+++ b/files/ja/web/css/selector_list/index.md
@@ -1,12 +1,6 @@
 ---
 title: セレクターリスト
 slug: Web/CSS/Selector_list
-tags:
-  - CSS
-  - セレクター
-  - セレクターリスト
-browser-compat: css.selectors.list
-translation_of: Web/CSS/Selector_list
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/shape-image-threshold/index.md
+++ b/files/ja/web/css/shape-image-threshold/index.md
@@ -1,20 +1,6 @@
 ---
 title: shape-image-threshold
 slug: Web/CSS/shape-image-threshold
-tags:
-  - 境界
-  - CSS
-  - CSS プロパティ
-  - CSS シェイプ
-  - 浮動領域
-  - Opacity
-  - プロパティ
-  - Reference
-  - シェイプ
-  - recipe:css-property
-  - shape-image-threshold
-browser-compat: css.properties.shape-image-threshold
-translation_of: Web/CSS/shape-image-threshold
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/shape-margin/index.md
+++ b/files/ja/web/css/shape-margin/index.md
@@ -1,21 +1,6 @@
 ---
 title: shape-margin
 slug: Web/CSS/shape-margin
-tags:
-  - 境界
-  - CSS
-  - CSS プロパティ
-  - CSS シェイプ
-  - 浮動領域
-  - プロパティ
-  - Reference
-  - シェイプ
-  - float
-  - マージン
-  - recipe:css-property
-  - shape-margin
-browser-compat: css.properties.shape-margin
-translation_of: Web/CSS/shape-margin
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/shape-outside/index.md
+++ b/files/ja/web/css/shape-outside/index.md
@@ -1,21 +1,6 @@
 ---
 title: shape-outside
 slug: Web/CSS/shape-outside
-tags:
-  - 境界
-  - CSS
-  - CSS プロパティ
-  - CSS シェイプ
-  - 浮動領域
-  - プロパティ
-  - Reference
-  - シェイプ
-  - マージン
-  - recipe:css-property
-  - shape-outside
-  - wrapping
-browser-compat: css.properties.shape-outside
-translation_of: Web/CSS/shape-outside
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/shape/index.md
+++ b/files/ja/web/css/shape/index.md
@@ -1,17 +1,6 @@
 ---
 title: <shape>
 slug: Web/CSS/shape
-tags:
-  - CSS
-  - CSS データ型
-  - CSS 関数
-  - データ型
-  - 非推奨
-  - レイアウト
-  - リファレンス
-  - ウェブ
-browser-compat: css.types.shape
-translation_of: Web/CSS/shape
 ---
 {{CSSRef}}{{deprecated_header}}
 

--- a/files/ja/web/css/shorthand_properties/index.md
+++ b/files/ja/web/css/shorthand_properties/index.md
@@ -1,15 +1,6 @@
 ---
 title: 一括指定プロパティ
 slug: Web/CSS/Shorthand_properties
-tags:
-  - CSS
-  - Guide
-  - Layout
-  - Reference
-  - Shorthand Properties
-  - properties
-  - shorthand
-translation_of: Web/CSS/Shorthand_properties
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/specificity/index.md
+++ b/files/ja/web/css/specificity/index.md
@@ -1,14 +1,6 @@
 ---
 title: 詳細度
 slug: Web/CSS/Specificity
-tags:
-  - CSS
-  - Example
-  - Guide
-  - Reference
-  - Web
-spec-urls: https://drafts.csswg.org/selectors/#specificity-rules
-translation_of: Web/CSS/Specificity
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/specified_value/index.md
+++ b/files/ja/web/css/specified_value/index.md
@@ -1,12 +1,6 @@
 ---
 title: 指定値
 slug: Web/CSS/specified_value
-tags:
-  - CSS
-  - Guide
-  - Reference
-spec-urls: https://www.w3.org/TR/CSS22/cascade.html#specified-value
-translation_of: Web/CSS/specified_value
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/string/index.md
+++ b/files/ja/web/css/string/index.md
@@ -1,14 +1,6 @@
 ---
 title: <string>
 slug: Web/CSS/string
-tags:
-  - CSS
-  - CSS データ型
-  - データ型
-  - レイアウト
-  - リファレンス
-  - ウェブ
-translation_of: Web/CSS/string
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/symbols/index.md
+++ b/files/ja/web/css/symbols/index.md
@@ -1,14 +1,7 @@
 ---
 title: symbols()
 slug: Web/CSS/symbols
-tags:
-  - CSS
-  - CSS カウンタースタイル
-  - Function
-  - リファレンス
-translation_of: Web/CSS/symbols()
 original_slug: Web/CSS/symbols()
-browser-compat: css.properties.list-style-type.symbols
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/syntax/index.md
+++ b/files/ja/web/css/syntax/index.md
@@ -1,12 +1,6 @@
 ---
 title: 構文
 slug: Web/CSS/Syntax
-tags:
-  - CSS
-  - Guide
-  - Reference
-  - Web
-translation_of: Web/CSS/Syntax
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/tab-size/index.md
+++ b/files/ja/web/css/tab-size/index.md
@@ -1,14 +1,6 @@
 ---
 title: tab-size
 slug: Web/CSS/tab-size
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS テキスト
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.tab-size
-translation_of: Web/CSS/tab-size
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/table-layout/index.md
+++ b/files/ja/web/css/table-layout/index.md
@@ -1,14 +1,6 @@
 ---
 title: table-layout
 slug: Web/CSS/table-layout
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS 表
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.table-layout
-translation_of: Web/CSS/table-layout
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/text-align-last/index.md
+++ b/files/ja/web/css/text-align-last/index.md
@@ -1,15 +1,6 @@
 ---
 title: text-align-last
 slug: Web/CSS/text-align-last
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS テキスト
-  - Experimental
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.text-align-last
-translation_of: Web/CSS/text-align-last
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/text-align/index.md
+++ b/files/ja/web/css/text-align/index.md
@@ -1,14 +1,6 @@
 ---
 title: text-align
 slug: Web/CSS/text-align
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS テキスト
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.text-align
-translation_of: Web/CSS/text-align
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/text-combine-upright/index.md
+++ b/files/ja/web/css/text-combine-upright/index.md
@@ -1,15 +1,6 @@
 ---
 title: text-combine-upright
 slug: Web/CSS/text-combine-upright
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS 書字方向
-  - 実験的
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.text-combine-upright
-translation_of: Web/CSS/text-combine-upright
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/text-decoration-color/index.md
+++ b/files/ja/web/css/text-decoration-color/index.md
@@ -1,21 +1,6 @@
 ---
 title: text-decoration-color
 slug: Web/CSS/text-decoration-color
-tags:
-  - CSS
-  - CSS Property
-  - CSS Text
-  - CSS Text Decoration
-  - HTML Colors
-  - HTML Styles
-  - Reference
-  - Styling HTML
-  - Styling text
-  - color
-  - colors
-  - recipe:css-property
-browser-compat: css.properties.text-decoration-color
-translation_of: Web/CSS/text-decoration-color
 ---
 {{ CSSRef }}
 

--- a/files/ja/web/css/text-decoration-line/index.md
+++ b/files/ja/web/css/text-decoration-line/index.md
@@ -1,14 +1,6 @@
 ---
 title: text-decoration-line
 slug: Web/CSS/text-decoration-line
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS テキスト装飾
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.text-decoration-line
-translation_of: Web/CSS/text-decoration-line
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/text-decoration-skip-ink/index.md
+++ b/files/ja/web/css/text-decoration-skip-ink/index.md
@@ -1,18 +1,6 @@
 ---
 title: text-decoration-skip-ink
 slug: Web/CSS/text-decoration-skip-ink
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS テキスト装飾
-  - Experimental
-  - レイアウト
-  - Reference
-  - Web
-  - recipe:css-property
-  - text-decoration-skip-ink
-browser-compat: css.properties.text-decoration-skip-ink
-translation_of: Web/CSS/text-decoration-skip-ink
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/text-decoration-skip/index.md
+++ b/files/ja/web/css/text-decoration-skip/index.md
@@ -1,17 +1,6 @@
 ---
 title: text-decoration-skip
 slug: Web/CSS/text-decoration-skip
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS テキスト装飾
-  - Experimental
-  - レイアウト
-  - Reference
-  - Web
-  - recipe:css-property
-browser-compat: css.properties.text-decoration-skip
-translation_of: Web/CSS/text-decoration-skip
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/text-decoration-style/index.md
+++ b/files/ja/web/css/text-decoration-style/index.md
@@ -1,15 +1,6 @@
 ---
 title: text-decoration-style
 slug: Web/CSS/text-decoration-style
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS テキスト装飾
-  - レイアウト
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.text-decoration-style
-translation_of: Web/CSS/text-decoration-style
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/text-decoration-thickness/index.md
+++ b/files/ja/web/css/text-decoration-thickness/index.md
@@ -1,16 +1,6 @@
 ---
 title: text-decoration-thickness
 slug: Web/CSS/text-decoration-thickness
-tags:
-  - CSS
-  - CSS テキスト装飾
-  - プロパティ
-  - Reference
-  - recipe:css-property
-  - text-decoration
-  - text-decoration-thickness
-browser-compat: css.properties.text-decoration-thickness
-translation_of: Web/CSS/text-decoration-thickness
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/text-decoration/index.md
+++ b/files/ja/web/css/text-decoration/index.md
@@ -1,14 +1,6 @@
 ---
 title: text-decoration
 slug: Web/CSS/text-decoration
-tags:
-  - CSS
-  - CSS Property
-  - CSS Text Decoration
-  - Reference
-  - recipe:css-shorthand-property
-browser-compat: css.properties.text-decoration
-translation_of: Web/CSS/text-decoration
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/text-emphasis-color/index.md
+++ b/files/ja/web/css/text-emphasis-color/index.md
@@ -1,19 +1,6 @@
 ---
 title: text-emphasis-color
 slug: Web/CSS/text-emphasis-color
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS スタイル
-  - CSS テキスト装飾
-  - HTML 色
-  - Reference
-  - HTML のスタイル付け
-  - テキストの強調
-  - recipe:css-property
-  - text-decoration-color
-browser-compat: css.properties.text-emphasis-color
-translation_of: Web/CSS/text-emphasis-color
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/text-emphasis-position/index.md
+++ b/files/ja/web/css/text-emphasis-position/index.md
@@ -1,14 +1,6 @@
 ---
 title: text-emphasis-position
 slug: Web/CSS/text-emphasis-position
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS テキスト装飾
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.text-emphasis-position
-translation_of: Web/CSS/text-emphasis-position
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/text-emphasis-style/index.md
+++ b/files/ja/web/css/text-emphasis-style/index.md
@@ -1,14 +1,6 @@
 ---
 title: text-emphasis-style
 slug: Web/CSS/text-emphasis-style
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS テキスト装飾
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.text-emphasis-style
-translation_of: Web/CSS/text-emphasis-style
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/text-emphasis/index.md
+++ b/files/ja/web/css/text-emphasis/index.md
@@ -1,14 +1,6 @@
 ---
 title: text-emphasis
 slug: Web/CSS/text-emphasis
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS テキスト装飾
-  - Reference
-  - recipe:css-shorthand-property
-browser-compat: css.properties.text-emphasis
-translation_of: Web/CSS/text-emphasis
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/text-indent/index.md
+++ b/files/ja/web/css/text-indent/index.md
@@ -1,17 +1,6 @@
 ---
 title: text-indent
 slug: Web/CSS/text-indent
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS テキスト
-  - 字下げ
-  - レイアウト
-  - Reference
-  - recipe:css-property
-  - text-indent
-browser-compat: css.properties.text-indent
-translation_of: Web/CSS/text-indent
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/text-justify/index.md
+++ b/files/ja/web/css/text-justify/index.md
@@ -1,15 +1,6 @@
 ---
 title: text-justify
 slug: Web/CSS/text-justify
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS テキスト
-  - Reference
-  - recipe:css-property
-  - text-justify
-browser-compat: css.properties.text-justify
-translation_of: Web/CSS/text-justify
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/text-orientation/index.md
+++ b/files/ja/web/css/text-orientation/index.md
@@ -1,15 +1,6 @@
 ---
 title: text-orientation
 slug: Web/CSS/text-orientation
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS Writing Modes
-  - Reference
-  - recipe:css-property
-  - 日本語処理
-browser-compat: css.properties.text-orientation
-translation_of: Web/CSS/text-orientation
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/text-overflow/index.md
+++ b/files/ja/web/css/text-overflow/index.md
@@ -1,13 +1,6 @@
 ---
 title: text-overflow
 slug: Web/CSS/text-overflow
-tags:
-  - CSS
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.text-overflow
-translation_of: Web/CSS/text-overflow
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/text-rendering/index.md
+++ b/files/ja/web/css/text-rendering/index.md
@@ -1,20 +1,6 @@
 ---
 title: text-rendering
 slug: Web/CSS/text-rendering
-tags:
-  - CSS
-  - CSS プロパティ
-  - Legibility
-  - Ligatures
-  - Precision
-  - リファレンス
-  - SVG
-  - テキスト
-  - テキスト特性
-  - テキスト描画
-  - recipe:css-property
-browser-compat: css.properties.text-rendering
-translation_of: Web/CSS/text-rendering
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/text-shadow/index.md
+++ b/files/ja/web/css/text-shadow/index.md
@@ -1,20 +1,6 @@
 ---
 title: text-shadow
 slug: Web/CSS/text-shadow
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS スタイル
-  - CSS テキスト装飾
-  - HTML 色
-  - HTML スタイル
-  - Reference
-  - スタイル
-  - HTML のスタイル付け
-  - color
-  - recipe:css-property
-browser-compat: css.properties.text-shadow
-translation_of: Web/CSS/text-shadow
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/text-size-adjust/index.md
+++ b/files/ja/web/css/text-size-adjust/index.md
@@ -1,16 +1,6 @@
 ---
 title: text-size-adjust
 slug: Web/CSS/text-size-adjust
-tags:
-  - CSS
-  - CSS Mobile Text Size Adjustment
-  - CSS プロパティ
-  - Experimental
-  - NeedsExample
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.text-size-adjust
-translation_of: Web/CSS/text-size-adjust
 ---
 {{CSSRef}}{{SeeCompatTable}}
 

--- a/files/ja/web/css/text-transform/index.md
+++ b/files/ja/web/css/text-transform/index.md
@@ -1,16 +1,6 @@
 ---
 title: text-transform
 slug: Web/CSS/text-transform
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS テキスト
-  - レイアウト
-  - Reference
-  - recipe:css-property
-  - 日本語処理
-browser-compat: css.properties.text-transform
-translation_of: Web/CSS/text-transform
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/text-underline-offset/index.md
+++ b/files/ja/web/css/text-underline-offset/index.md
@@ -1,16 +1,6 @@
 ---
 title: text-underline-offset
 slug: Web/CSS/text-underline-offset
-tags:
-  - CSS
-  - CSS Text Decoration
-  - プロパティ
-  - Reference
-  - recipe:css-property
-  - text-decoration
-  - text-underline-offset
-browser-compat: css.properties.text-underline-offset
-translation_of: Web/CSS/text-underline-offset
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/text-underline-position/index.md
+++ b/files/ja/web/css/text-underline-position/index.md
@@ -1,14 +1,6 @@
 ---
 title: text-underline-position
 slug: Web/CSS/text-underline-position
-tags:
-  - CSS
-  - CSS Property
-  - CSS Text Decoration
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.text-underline-position
-translation_of: Web/CSS/text-underline-position
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/time-percentage/index.md
+++ b/files/ja/web/css/time-percentage/index.md
@@ -1,15 +1,6 @@
 ---
 title: <time-percentage>
 slug: Web/CSS/time-percentage
-tags:
-  - CSS
-  - CSS データ型
-  - データ型
-  - リファレンス
-  - time-percentage
-  - 単位
-  - 値
-translation_of: Web/CSS/time-percentage
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/time/index.md
+++ b/files/ja/web/css/time/index.md
@@ -1,15 +1,6 @@
 ---
 title: <time>
 slug: Web/CSS/time
-tags:
-  - CSS
-  - CSS データ型
-  - データ型
-  - レイアウト
-  - リファレンス
-  - ウェブ
-browser-compat: css.types.time
-translation_of: Web/CSS/time
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/top/index.md
+++ b/files/ja/web/css/top/index.md
@@ -1,14 +1,6 @@
 ---
 title: top
 slug: Web/CSS/top
-tags:
-  - CSS
-  - CSS 位置指定レイアウト
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.top
-translation_of: Web/CSS/top
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/touch-action/index.md
+++ b/files/ja/web/css/touch-action/index.md
@@ -1,14 +1,6 @@
 ---
 title: touch-action
 slug: Web/CSS/touch-action
-tags:
-  - CSS
-  - CSS プロパティ
-  - ポインターイベント
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.touch-action
-translation_of: Web/CSS/touch-action
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform-box/index.md
+++ b/files/ja/web/css/transform-box/index.md
@@ -1,16 +1,6 @@
 ---
 title: transform-box
 slug: Web/CSS/transform-box
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS Transforms
-  - Experimental
-  - NeedsExample
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.transform-box
-translation_of: Web/CSS/transform-box
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform-function/index.md
+++ b/files/ja/web/css/transform-function/index.md
@@ -1,15 +1,6 @@
 ---
 title: <transform-function>
 slug: Web/CSS/transform-function
-tags:
-  - CSS
-  - CSS データ型
-  - CSS 座標変換
-  - データ型
-  - レイアウト
-  - リファレンス
-browser-compat: css.types.transform-function
-translation_of: Web/CSS/transform-function
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform-function/matrix/index.md
+++ b/files/ja/web/css/transform-function/matrix/index.md
@@ -1,15 +1,7 @@
 ---
 title: matrix()
 slug: Web/CSS/transform-function/matrix
-tags:
-  - CSS
-  - CSS 関数
-  - CSS 座標変換
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/transform-function/matrix()
 original_slug: Web/CSS/transform-function/matrix()
-browser-compat: css.types.transform-function.matrix
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform-function/matrix3d/index.md
+++ b/files/ja/web/css/transform-function/matrix3d/index.md
@@ -1,15 +1,7 @@
 ---
 title: matrix3d()
 slug: Web/CSS/transform-function/matrix3d
-tags:
-  - CSS
-  - CSS 関数
-  - CSS 座標変換
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/transform-function/matrix3d()
 original_slug: Web/CSS/transform-function/matrix3d()
-browser-compat: css.types.transform-function.matrix3d
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform-function/perspective/index.md
+++ b/files/ja/web/css/transform-function/perspective/index.md
@@ -1,15 +1,7 @@
 ---
 title: perspective()
 slug: Web/CSS/transform-function/perspective
-tags:
-  - CSS
-  - CSS 関数
-  - CSS 座標変換
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/transform-function/perspective()
 original_slug: Web/CSS/transform-function/perspective()
-browser-compat: css.types.transform-function.perspective
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform-function/rotate/index.md
+++ b/files/ja/web/css/transform-function/rotate/index.md
@@ -1,15 +1,7 @@
 ---
 title: rotate()
 slug: Web/CSS/transform-function/rotate
-tags:
-  - CSS
-  - CSS 関数
-  - CSS 座標変換
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/transform-function/rotate()
 original_slug: Web/CSS/transform-function/rotate()
-browser-compat: css.types.transform-function.rotate
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform-function/rotate3d/index.md
+++ b/files/ja/web/css/transform-function/rotate3d/index.md
@@ -1,15 +1,7 @@
 ---
 title: rotate3d()
 slug: Web/CSS/transform-function/rotate3d
-tags:
-  - CSS
-  - CSS 関数
-  - CSS 座標変換
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/transform-function/rotate3d()
 original_slug: Web/CSS/transform-function/rotate3d()
-browser-compat: css.types.transform-function.rotate3d
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform-function/rotatex/index.md
+++ b/files/ja/web/css/transform-function/rotatex/index.md
@@ -1,15 +1,7 @@
 ---
 title: rotateX()
 slug: Web/CSS/transform-function/rotateX
-tags:
-  - CSS
-  - CSS 関数
-  - CSS 座標変換
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/transform-function/rotateX()
 original_slug: Web/CSS/transform-function/rotateX()
-browser-compat: css.types.transform-function.rotateX
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform-function/rotatey/index.md
+++ b/files/ja/web/css/transform-function/rotatey/index.md
@@ -1,15 +1,7 @@
 ---
 title: rotateY()
 slug: Web/CSS/transform-function/rotateY
-tags:
-  - CSS
-  - CSS 関数
-  - CSS 座標変換
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/transform-function/rotateY()
 original_slug: Web/CSS/transform-function/rotateY()
-browser-compat: css.types.transform-function.rotateY
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform-function/rotatez/index.md
+++ b/files/ja/web/css/transform-function/rotatez/index.md
@@ -1,15 +1,7 @@
 ---
 title: rotateZ()
 slug: Web/CSS/transform-function/rotateZ
-tags:
-  - CSS
-  - CSS 関数
-  - CSS 座標変換
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/transform-function/rotateZ()
 original_slug: Web/CSS/transform-function/rotateZ()
-browser-compat: css.types.transform-function.rotateZ
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform-function/scale/index.md
+++ b/files/ja/web/css/transform-function/scale/index.md
@@ -1,15 +1,7 @@
 ---
 title: scale()
 slug: Web/CSS/transform-function/scale
-tags:
-  - CSS
-  - CSS 関数
-  - CSS 座標変換
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/transform-function/scale()
 original_slug: Web/CSS/transform-function/scale()
-browser-compat: css.types.transform-function.scale
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform-function/scale3d/index.md
+++ b/files/ja/web/css/transform-function/scale3d/index.md
@@ -1,15 +1,7 @@
 ---
 title: scale3d()
 slug: Web/CSS/transform-function/scale3d
-tags:
-  - CSS
-  - CSS 関数
-  - CSS 座標変換
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/transform-function/scale3d()
 original_slug: Web/CSS/transform-function/scale3d()
-browser-compat: css.types.transform-function.scale3d
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform-function/scalex/index.md
+++ b/files/ja/web/css/transform-function/scalex/index.md
@@ -1,15 +1,7 @@
 ---
 title: scaleX()
 slug: Web/CSS/transform-function/scaleX
-tags:
-  - CSS
-  - CSS 関数
-  - CSS 座標変換
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/transform-function/scaleX()
 original_slug: Web/CSS/transform-function/scaleX()
-browser-compat: css.types.transform-function.scaleX
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform-function/scaley/index.md
+++ b/files/ja/web/css/transform-function/scaley/index.md
@@ -1,15 +1,7 @@
 ---
 title: scaleY()
 slug: Web/CSS/transform-function/scaleY
-tags:
-  - CSS
-  - CSS 関数
-  - CSS 座標変換
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/transform-function/scaleY()
 original_slug: Web/CSS/transform-function/scaleY()
-browser-compat: css.types.transform-function.scaleY
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform-function/scalez/index.md
+++ b/files/ja/web/css/transform-function/scalez/index.md
@@ -1,14 +1,7 @@
 ---
 title: scaleZ()
 slug: Web/CSS/transform-function/scaleZ
-tags:
-  - CSS
-  - CSS 関数
-  - CSS 座標変換
-  - 関数
-  - リファレンス
 original_slug: Web/CSS/transform-function/scaleZ()
-browser-compat: css.types.transform-function.scaleZ
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform-function/skew/index.md
+++ b/files/ja/web/css/transform-function/skew/index.md
@@ -1,15 +1,7 @@
 ---
 title: skew()
 slug: Web/CSS/transform-function/skew
-tags:
-  - CSS
-  - CSS 関数
-  - CSS 座標変換
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/transform-function/skew()
 original_slug: Web/CSS/transform-function/skew()
-browser-compat: css.types.transform-function.skew
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform-function/skewx/index.md
+++ b/files/ja/web/css/transform-function/skewx/index.md
@@ -1,15 +1,7 @@
 ---
 title: skewX()
 slug: Web/CSS/transform-function/skewX
-tags:
-  - CSS
-  - CSS 関数
-  - CSS 座標変換
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/transform-function/skewX()
 original_slug: Web/CSS/transform-function/skewX()
-browser-compat: css.types.transform-function.skewX
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform-function/translate/index.md
+++ b/files/ja/web/css/transform-function/translate/index.md
@@ -1,15 +1,7 @@
 ---
 title: translate()
 slug: Web/CSS/transform-function/translate
-tags:
-  - CSS
-  - CSS 関数
-  - CSS 座標変換
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/transform-function/translate()
 original_slug: Web/CSS/transform-function/translate()
-browser-compat: css.types.transform-function.translate
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform-function/translate3d/index.md
+++ b/files/ja/web/css/transform-function/translate3d/index.md
@@ -1,15 +1,7 @@
 ---
 title: translate3d()
 slug: Web/CSS/transform-function/translate3d
-tags:
-  - CSS
-  - CSS 関数
-  - CSS 座標変換
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/transform-function/translate3d()
 original_slug: Web/CSS/transform-function/translate3d()
-browser-compat: css.types.transform-function.translate3d
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform-function/translatex/index.md
+++ b/files/ja/web/css/transform-function/translatex/index.md
@@ -1,15 +1,7 @@
 ---
 title: translateX()
 slug: Web/CSS/transform-function/translateX
-tags:
-  - CSS
-  - CSS 関数
-  - CSS 座標変換
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/transform-function/translateX()
 original_slug: Web/CSS/transform-function/translateX()
-browser-compat: css.types.transform-function.translateX
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform-function/translatey/index.md
+++ b/files/ja/web/css/transform-function/translatey/index.md
@@ -1,15 +1,7 @@
 ---
 title: translateY()
 slug: Web/CSS/transform-function/translateY
-tags:
-  - CSS
-  - CSS 関数
-  - CSS 座標変換
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/transform-function/translateY()
 original_slug: Web/CSS/transform-function/translateY()
-browser-compat: css.types.transform-function.translateY
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform-function/translatez/index.md
+++ b/files/ja/web/css/transform-function/translatez/index.md
@@ -1,16 +1,7 @@
 ---
 title: translateZ()
 slug: Web/CSS/transform-function/translateZ
-tags:
-  - 3D
-  - CSS
-  - CSS 関数
-  - CSS 座標変換
-  - 関数
-  - リファレンス
-translation_of: Web/CSS/transform-function/translateZ()
 original_slug: Web/CSS/transform-function/translateZ()
-browser-compat: css.types.transform-function.translateZ
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform-origin/index.md
+++ b/files/ja/web/css/transform-origin/index.md
@@ -1,16 +1,6 @@
 ---
 title: transform-origin
 slug: Web/CSS/transform-origin
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS 座標変換
-  - Reference
-  - 'default value: center'
-  - recipe:css-property
-  - transform-origin
-browser-compat: css.properties.transform-origin
-translation_of: Web/CSS/transform-origin
 ---
 {{ CSSRef }}
 

--- a/files/ja/web/css/transform-style/index.md
+++ b/files/ja/web/css/transform-style/index.md
@@ -1,15 +1,6 @@
 ---
 title: transform-style
 slug: Web/CSS/transform-style
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS 座標変換
-  - 実験的
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.transform-style
-translation_of: Web/CSS/transform-style
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transform/index.md
+++ b/files/ja/web/css/transform/index.md
@@ -1,14 +1,6 @@
 ---
 title: transform
 slug: Web/CSS/transform
-tags:
-  - CSS
-  - CSS プロパティ
-  - Reference
-  - 座標変換
-  - recipe:css-property
-browser-compat: css.properties.transform
-translation_of: Web/CSS/transform
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transition-delay/index.md
+++ b/files/ja/web/css/transition-delay/index.md
@@ -1,14 +1,6 @@
 ---
 title: transition-delay
 slug: Web/CSS/transition-delay
-tags:
-  - CSS
-  - CSS トランジション
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.transition-delay
-translation_of: Web/CSS/transition-delay
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transition-duration/index.md
+++ b/files/ja/web/css/transition-duration/index.md
@@ -1,14 +1,6 @@
 ---
 title: transition-duration
 slug: Web/CSS/transition-duration
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS トランジション
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.transition-duration
-translation_of: Web/CSS/transition-duration
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transition-property/index.md
+++ b/files/ja/web/css/transition-property/index.md
@@ -1,14 +1,6 @@
 ---
 title: transition-property
 slug: Web/CSS/transition-property
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS トランジション
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.transition-property
-translation_of: Web/CSS/transition-property
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transition-timing-function/index.md
+++ b/files/ja/web/css/transition-timing-function/index.md
@@ -1,14 +1,6 @@
 ---
 title: transition-timing-function
 slug: Web/CSS/transition-timing-function
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS Transitions
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.transition-timing-function
-translation_of: Web/CSS/transition-timing-function
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/transition/index.md
+++ b/files/ja/web/css/transition/index.md
@@ -1,14 +1,6 @@
 ---
 title: transition
 slug: Web/CSS/transition
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS トランジション
-  - リファレンス
-  - recipe:css-shorthand-property
-browser-compat: css.properties.transition
-translation_of: Web/CSS/transition
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/translate/index.md
+++ b/files/ja/web/css/translate/index.md
@@ -1,14 +1,6 @@
 ---
 title: translate
 slug: Web/CSS/translate
-tags:
-  - CSS
-  - CSS プロパティ
-  - Reference
-  - 座標変換
-  - recipe:css-property
-browser-compat: css.properties.translate
-translation_of: Web/CSS/translate
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/translation-value/index.md
+++ b/files/ja/web/css/translation-value/index.md
@@ -1,14 +1,6 @@
 ---
 title: <translation-value>
 slug: Web/CSS/translation-value
-tags:
-  - CSS
-  - CSS Data Type
-  - CSS Transforms
-  - Data Type
-  - Reference
-browser-compat: css.types.transform-function
-translation_of: Web/CSS/translation-value
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/type_selectors/index.md
+++ b/files/ja/web/css/type_selectors/index.md
@@ -1,14 +1,6 @@
 ---
 title: 要素型セレクター
 slug: Web/CSS/Type_selectors
-tags:
-  - CSS
-  - HTML
-  - Node
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.type
-translation_of: Web/CSS/Type_selectors
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/unicode-bidi/index.md
+++ b/files/ja/web/css/unicode-bidi/index.md
@@ -1,14 +1,6 @@
 ---
 title: unicode-bidi
 slug: Web/CSS/unicode-bidi
-tags:
-  - BiDi
-  - CSS
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.unicode-bidi
-translation_of: Web/CSS/unicode-bidi
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/universal_selectors/index.md
+++ b/files/ja/web/css/universal_selectors/index.md
@@ -1,12 +1,6 @@
 ---
 title: 全称セレクター
 slug: Web/CSS/Universal_selectors
-tags:
-  - CSS
-  - リファレンス
-  - セレクター
-browser-compat: css.selectors.universal
-translation_of: Web/CSS/Universal_selectors
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/unset/index.md
+++ b/files/ja/web/css/unset/index.md
@@ -1,17 +1,6 @@
 ---
 title: unset
 slug: Web/CSS/unset
-tags:
-  - CSS
-  - CSS カスケード
-  - CSS 値
-  - キーワード
-  - レイアウト
-  - リファレンス
-  - スタイル
-  - unset
-browser-compat: css.types.global_keywords.unset
-translation_of: Web/CSS/unset
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/url/index.md
+++ b/files/ja/web/css/url/index.md
@@ -1,17 +1,7 @@
 ---
 title: url()
 slug: Web/CSS/url
-tags:
-  - CSS
-  - CSS 関数
-  - 関数
-  - レイアウト
-  - リファレンス
-  - ウェブ
-  - url()
-translation_of: Web/CSS/url()
 original_slug: Web/CSS/url()
-browser-compat: css.types.url
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/used_value/index.md
+++ b/files/ja/web/css/used_value/index.md
@@ -1,12 +1,6 @@
 ---
 title: 使用値
 slug: Web/CSS/used_value
-tags:
-  - CSS
-  - Guide
-  - Reference
-spec-urls: https://www.w3.org/TR/CSS22/cascade.html#used-value
-translation_of: Web/CSS/used_value
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/user-modify/index.md
+++ b/files/ja/web/css/user-modify/index.md
@@ -1,17 +1,6 @@
 ---
 title: user-modify
 slug: Web/CSS/user-modify
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS:Mozilla 拡張
-  - CSS:WebKit 拡張
-  - 非推奨
-  - 標準外
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.user-modify
-translation_of: Web/CSS/user-modify
 ---
 {{CSSRef}}{{Non-standard_Header}}{{Deprecated_Header}}
 

--- a/files/ja/web/css/user-select/index.md
+++ b/files/ja/web/css/user-select/index.md
@@ -1,16 +1,6 @@
 ---
 title: user-select
 slug: Web/CSS/user-select
-tags:
-  - CSS
-  - CSS プロパティ
-  - プロパティ
-  - Reference
-  - Selection
-  - recipe:css-property
-  - user-select
-browser-compat: css.properties.user-select
-translation_of: Web/CSS/user-select
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/using_css_custom_properties/index.md
+++ b/files/ja/web/css/using_css_custom_properties/index.md
@@ -1,16 +1,6 @@
 ---
 title: CSS カスタムプロパティ (変数) の使用
 slug: Web/CSS/Using_CSS_custom_properties
-tags:
-  - CSS
-  - CSS Variables
-  - CSS 変数
-  - Guide
-  - Web
-  - ウェブ
-  - カスケード変数
-  - カスタムプロパティ
-translation_of: Web/CSS/Using_CSS_custom_properties
 ---
 {{cssref}}
 

--- a/files/ja/web/css/value_definition_syntax/index.md
+++ b/files/ja/web/css/value_definition_syntax/index.md
@@ -1,13 +1,6 @@
 ---
 title: 値の定義構文
 slug: Web/CSS/Value_definition_syntax
-tags:
-  - CSS
-  - Guide
-  - Reference
-  - Syntax
-spec-urls: https://drafts.csswg.org/css-values/#value-defs
-translation_of: Web/CSS/Value_definition_syntax
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/var/index.md
+++ b/files/ja/web/css/var/index.md
@@ -1,20 +1,7 @@
 ---
 title: var()
 slug: Web/CSS/var
-tags:
-  - CSS
-  - CSS カスタムプロパティ
-  - CSS 変数
-  - CSS 関数
-  - 実験的
-  - 関数
-  - リファレンス
-  - 変数
-  - var
-  - var()
-translation_of: Web/CSS/var()
 original_slug: Web/CSS/var()
-browser-compat: css.properties.custom-property.var
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/vertical-align/index.md
+++ b/files/ja/web/css/vertical-align/index.md
@@ -1,11 +1,6 @@
 ---
 title: vertical-align
 slug: Web/CSS/vertical-align
-tags:
-  - CSS
-  - CSS プロパティ
-  - リファレンス
-translation_of: Web/CSS/vertical-align
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/viewport_concepts/index.md
+++ b/files/ja/web/css/viewport_concepts/index.md
@@ -1,16 +1,6 @@
 ---
 title: ビューポートの概念
 slug: Web/CSS/Viewport_concepts
-tags:
-  - Best practices
-  - CSS
-  - Guide
-  - Mobile
-  - Resource
-  - layout viewport
-  - viewport
-  - virtual viewport
-translation_of: Web/CSS/Viewport_concepts
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/visibility/index.md
+++ b/files/ja/web/css/visibility/index.md
@@ -1,15 +1,6 @@
 ---
 title: visibility
 slug: Web/CSS/visibility
-tags:
-  - CSS
-  - CSS Box Model
-  - CSS Property
-  - Layout
-  - Reference
-  - Web
-  - recipe:css-property
-translation_of: Web/CSS/visibility
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/visual_formatting_model/index.md
+++ b/files/ja/web/css/visual_formatting_model/index.md
@@ -1,13 +1,6 @@
 ---
 title: 視覚整形モデル
 slug: Web/CSS/Visual_formatting_model
-tags:
-  - CSS
-  - CSS Box Model
-  - Guide
-  - Reference
-  - visual formatting model
-translation_of: Web/CSS/Visual_formatting_model
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/webkit_extensions/index.md
+++ b/files/ja/web/css/webkit_extensions/index.md
@@ -1,14 +1,6 @@
 ---
 title: WebKit の CSS 拡張
 slug: Web/CSS/WebKit_Extensions
-tags:
-  - CSS
-  - CSS:WebKit 拡張
-  - ガイド
-  - 標準外
-  - 概要
-  - リファレンス
-translation_of: Web/CSS/WebKit_Extensions
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/white-space/index.md
+++ b/files/ja/web/css/white-space/index.md
@@ -1,15 +1,6 @@
 ---
 title: white-space
 slug: Web/CSS/white-space
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS テキスト
-  - Reference
-  - recipe:css-property
-  - white-space
-browser-compat: css.properties.white-space
-translation_of: Web/CSS/white-space
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/widows/index.md
+++ b/files/ja/web/css/widows/index.md
@@ -1,15 +1,6 @@
 ---
 title: widows
 slug: Web/CSS/widows
-tags:
-  - CSS
-  - CSS 断片化
-  - CSS 段組みレイアウト
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.widows
-translation_of: Web/CSS/widows
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/width/index.md
+++ b/files/ja/web/css/width/index.md
@@ -1,17 +1,6 @@
 ---
 title: width
 slug: Web/CSS/width
-tags:
-  - CSS
-  - CSS プロパティ
-  - レイアウト
-  - リファレンス
-  - 寸法
-  - recipe:css-property
-  - size
-  - width
-browser-compat: css.properties.width
-translation_of: Web/CSS/width
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/will-change/index.md
+++ b/files/ja/web/css/will-change/index.md
@@ -1,15 +1,6 @@
 ---
 title: will-change
 slug: Web/CSS/will-change
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS 変更予定
-  - Reference
-  - recipe:css-property
-  - transition
-  - トランジション
-translation_of: Web/CSS/will-change
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/word-break/index.md
+++ b/files/ja/web/css/word-break/index.md
@@ -1,16 +1,6 @@
 ---
 title: word-break
 slug: Web/CSS/word-break
-tags:
-  - CSS
-  - CSS プロパティ
-  - Reference
-  - break-word
-  - recipe:css-property
-  - word-break
-  - 日本語処理
-browser-compat: css.properties.word-break
-translation_of: Web/CSS/word-break
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/word-spacing/index.md
+++ b/files/ja/web/css/word-spacing/index.md
@@ -1,14 +1,6 @@
 ---
 title: word-spacing
 slug: Web/CSS/word-spacing
-tags:
-  - CSS
-  - CSS プロパティ
-  - CSS テキスト
-  - Reference
-  - recipe:css-property
-browser-compat: css.properties.word-spacing
-translation_of: Web/CSS/word-spacing
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/writing-mode/index.md
+++ b/files/ja/web/css/writing-mode/index.md
@@ -1,15 +1,6 @@
 ---
 title: writing-mode
 slug: Web/CSS/writing-mode
-tags:
-  - CSS
-  - CSS プロパティ
-  - レイアウト
-  - リファレンス
-  - recipe:css-property
-  - 日本語処理
-browser-compat: css.properties.writing-mode
-translation_of: Web/CSS/writing-mode
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/z-index/index.md
+++ b/files/ja/web/css/z-index/index.md
@@ -1,14 +1,6 @@
 ---
 title: z-index
 slug: Web/CSS/z-index
-tags:
-  - CSS
-  - CSS 位置指定レイアウト
-  - CSS プロパティ
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.z-index
-translation_of: Web/CSS/z-index
 ---
 {{CSSRef}}
 

--- a/files/ja/web/css/zoom/index.md
+++ b/files/ja/web/css/zoom/index.md
@@ -1,14 +1,6 @@
 ---
 title: zoom
 slug: Web/CSS/zoom
-tags:
-  - CSS
-  - CSS プロパティ
-  - 標準外
-  - リファレンス
-  - recipe:css-property
-browser-compat: css.properties.zoom
-translation_of: Web/CSS/zoom
 ---
 {{CSSRef}}{{Non-standard_header}}
 


### PR DESCRIPTION
Part of #7858

`files/ja/web/css/{e..z}*` から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "tags": 392,
  "translation_of": 386,
  "browser-compat": 328,
  "tra": 1,
  "spec-urls": 6
}
```