### PR TITLE
remove duplicated frontmatter keys from web/javascript/global_objects/{k..z}* (ja)

### DIFF
--- a/files/ja/web/javascript/reference/global_objects/map/@@iterator/index.md
+++ b/files/ja/web/javascript/reference/global_objects/map/@@iterator/index.md
@@ -1,15 +1,6 @@
 ---
 title: Map.prototype[@@iterator]()
 slug: Web/JavaScript/Reference/Global_Objects/Map/@@iterator
-tags:
-  - ECMAScript 2015
-  - Iterator
-  - JavaScript
-  - Map
-  - Method
-  - Prototype
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Map/@@iterator
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/map/@@species/index.md
+++ b/files/ja/web/javascript/reference/global_objects/map/@@species/index.md
@@ -1,12 +1,6 @@
 ---
 title: get Map[@@species]
 slug: Web/JavaScript/Reference/Global_Objects/Map/@@species
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Map
-  - Property
-translation_of: Web/JavaScript/Reference/Global_Objects/Map/@@species
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/map/@@tostringtag/index.md
+++ b/files/ja/web/javascript/reference/global_objects/map/@@tostringtag/index.md
@@ -1,15 +1,6 @@
 ---
 title: Map.prototype[@@toStringTag]
 slug: Web/JavaScript/Reference/Global_Objects/Map/@@toStringTag
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Map
-  - Property
-  - Prototype
-  - Reference
-  - プロパティ
-translation_of: Web/JavaScript/Reference/Global_Objects/Map/@@toStringTag
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/map/clear/index.md
+++ b/files/ja/web/javascript/reference/global_objects/map/clear/index.md
@@ -1,14 +1,6 @@
 ---
 title: Map.prototype.clear()
 slug: Web/JavaScript/Reference/Global_Objects/Map/clear
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Map
-  - Method
-  - Prototype
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Map/clear
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/map/delete/index.md
+++ b/files/ja/web/javascript/reference/global_objects/map/delete/index.md
@@ -1,14 +1,6 @@
 ---
 title: Map.prototype.delete()
 slug: Web/JavaScript/Reference/Global_Objects/Map/delete
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Map
-  - Method
-  - Prototype
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Map/delete
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/map/entries/index.md
+++ b/files/ja/web/javascript/reference/global_objects/map/entries/index.md
@@ -1,14 +1,6 @@
 ---
 title: Map.prototype.entries()
 slug: Web/JavaScript/Reference/Global_Objects/Map/entries
-tags:
-  - ECMAScript 2015
-  - Iterator
-  - JavaScript
-  - Map
-  - Method
-  - Prototype
-translation_of: Web/JavaScript/Reference/Global_Objects/Map/entries
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/map/foreach/index.md
+++ b/files/ja/web/javascript/reference/global_objects/map/foreach/index.md
@@ -1,14 +1,6 @@
 ---
 title: Map.prototype.forEach()
 slug: Web/JavaScript/Reference/Global_Objects/Map/forEach
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Map
-  - Method
-  - Prototype
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Map/forEach
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/map/get/index.md
+++ b/files/ja/web/javascript/reference/global_objects/map/get/index.md
@@ -1,14 +1,6 @@
 ---
 title: Map.prototype.get()
 slug: Web/JavaScript/Reference/Global_Objects/Map/get
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Map
-  - Method
-  - Prototype
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Map/get
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/map/has/index.md
+++ b/files/ja/web/javascript/reference/global_objects/map/has/index.md
@@ -1,14 +1,6 @@
 ---
 title: Map.prototype.has()
 slug: Web/JavaScript/Reference/Global_Objects/Map/has
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Map
-  - Method
-  - Prototype
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Map/has
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/map/index.md
+++ b/files/ja/web/javascript/reference/global_objects/map/index.md
@@ -1,13 +1,6 @@
 ---
 title: Map
 slug: Web/JavaScript/Reference/Global_Objects/Map
-tags:
-  - Class
-  - ECMAScript 2015
-  - JavaScript
-  - Map
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Map
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/map/keys/index.md
+++ b/files/ja/web/javascript/reference/global_objects/map/keys/index.md
@@ -1,14 +1,6 @@
 ---
 title: Map.prototype.keys()
 slug: Web/JavaScript/Reference/Global_Objects/Map/keys
-tags:
-  - ECMAScript 2015
-  - Iterator
-  - JavaScript
-  - Map
-  - Method
-  - Prototype
-translation_of: Web/JavaScript/Reference/Global_Objects/Map/keys
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/map/map/index.md
+++ b/files/ja/web/javascript/reference/global_objects/map/map/index.md
@@ -1,12 +1,6 @@
 ---
 title: Map() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/Map/Map
-tags:
-  - Constructor
-  - JavaScript
-  - Map
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Map/Map
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/map/set/index.md
+++ b/files/ja/web/javascript/reference/global_objects/map/set/index.md
@@ -1,14 +1,6 @@
 ---
 title: Map.prototype.set()
 slug: Web/JavaScript/Reference/Global_Objects/Map/set
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Map
-  - Method
-  - Prototype
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Map/set
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/map/size/index.md
+++ b/files/ja/web/javascript/reference/global_objects/map/size/index.md
@@ -1,12 +1,6 @@
 ---
 title: Map.prototype.size
 slug: Web/JavaScript/Reference/Global_Objects/Map/size
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Map
-  - Property
-translation_of: Web/JavaScript/Reference/Global_Objects/Map/size
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/map/values/index.md
+++ b/files/ja/web/javascript/reference/global_objects/map/values/index.md
@@ -1,14 +1,6 @@
 ---
 title: Map.prototype.values()
 slug: Web/JavaScript/Reference/Global_Objects/Map/values
-tags:
-  - ECMAScript 2015
-  - Iterator
-  - JavaScript
-  - Map
-  - Method
-  - Prototype
-translation_of: Web/JavaScript/Reference/Global_Objects/Map/values
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/abs/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/abs/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.abs()
 slug: Web/JavaScript/Reference/Global_Objects/Math/abs
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/abs
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/acos/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/acos/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.acos()
 slug: Web/JavaScript/Reference/Global_Objects/Math/acos
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/acos
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/acosh/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/acosh/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.acosh()
 slug: Web/JavaScript/Reference/Global_Objects/Math/acosh
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/acosh
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/asin/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/asin/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.asin()
 slug: Web/JavaScript/Reference/Global_Objects/Math/asin
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/asin
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/asinh/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/asinh/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.asinh()
 slug: Web/JavaScript/Reference/Global_Objects/Math/asinh
-tags:
-  - JavaScript
-  - Math
-  - Mathod
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/asinh
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/atan/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/atan/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.atan()
 slug: Web/JavaScript/Reference/Global_Objects/Math/atan
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/atan
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/atan2/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/atan2/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.atan2()
 slug: Web/JavaScript/Reference/Global_Objects/Math/atan2
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/atan2
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/atanh/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/atanh/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.atanh()
 slug: Web/JavaScript/Reference/Global_Objects/Math/atanh
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/atanh
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/cbrt/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/cbrt/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.cbrt()
 slug: Web/JavaScript/Reference/Global_Objects/Math/cbrt
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/cbrt
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/ceil/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/ceil/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.ceil()
 slug: Web/JavaScript/Reference/Global_Objects/Math/ceil
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/ceil
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/clz32/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/clz32/index.md
@@ -1,13 +1,6 @@
 ---
 title: Math.clz32()
 slug: Web/JavaScript/Reference/Global_Objects/Math/clz32
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/clz32
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/cos/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/cos/index.md
@@ -1,16 +1,6 @@
 ---
 title: Math.cos()
 slug: Web/JavaScript/Reference/Global_Objects/Math/cos
-tags:
-  - Geometry
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-  - Trigonometry
-  - cos
-  - cosine
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/cos
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/cosh/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/cosh/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.cosh()
 slug: Web/JavaScript/Reference/Global_Objects/Math/cosh
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/cosh
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/e/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/e/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.E
 slug: Web/JavaScript/Reference/Global_Objects/Math/E
-tags:
-  - JavaScript
-  - Math
-  - Property
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/E
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/exp/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/exp/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.exp()
 slug: Web/JavaScript/Reference/Global_Objects/Math/exp
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/exp
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/expm1/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/expm1/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.expm1()
 slug: Web/JavaScript/Reference/Global_Objects/Math/expm1
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/expm1
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/floor/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/floor/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.floor()
 slug: Web/JavaScript/Reference/Global_Objects/Math/floor
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/floor
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/fround/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/fround/index.md
@@ -1,14 +1,6 @@
 ---
 title: Math.fround()
 slug: Web/JavaScript/Reference/Global_Objects/Math/fround
-tags:
-  - ES6
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-  - fround
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/fround
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/hypot/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/hypot/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.hypot()
 slug: Web/JavaScript/Reference/Global_Objects/Math/hypot
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/hypot
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/imul/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/imul/index.md
@@ -1,13 +1,6 @@
 ---
 title: Math.imul()
 slug: Web/JavaScript/Reference/Global_Objects/Math/imul
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-  - imul
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/imul
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/index.md
@@ -1,13 +1,6 @@
 ---
 title: Math
 slug: Web/JavaScript/Reference/Global_Objects/Math
-tags:
-  - JavaScript
-  - Math
-  - Namespace
-  - Reference
-  - 名前空間
-translation_of: Web/JavaScript/Reference/Global_Objects/Math
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/ln10/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/ln10/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.LN10
 slug: Web/JavaScript/Reference/Global_Objects/Math/LN10
-tags:
-  - JavaScript
-  - Math
-  - Property
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/LN10
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/ln2/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/ln2/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.LN2
 slug: Web/JavaScript/Reference/Global_Objects/Math/LN2
-tags:
-  - JavaScript
-  - Math
-  - Property
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/LN2
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/log/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/log/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.log()
 slug: Web/JavaScript/Reference/Global_Objects/Math/log
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/log
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/log10/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/log10/index.md
@@ -1,13 +1,6 @@
 ---
 title: Math.log10()
 slug: Web/JavaScript/Reference/Global_Objects/Math/log10
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/log10
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/log10e/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/log10e/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.LOG10E
 slug: Web/JavaScript/Reference/Global_Objects/Math/LOG10E
-tags:
-  - JavaScript
-  - Math
-  - Property
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/LOG10E
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/log1p/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/log1p/index.md
@@ -1,13 +1,6 @@
 ---
 title: Math.log1p()
 slug: Web/JavaScript/Reference/Global_Objects/Math/log1p
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/log1p
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/log2/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/log2/index.md
@@ -1,13 +1,6 @@
 ---
 title: Math.log2()
 slug: Web/JavaScript/Reference/Global_Objects/Math/log2
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/log2
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/log2e/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/log2e/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.LOG2E
 slug: Web/JavaScript/Reference/Global_Objects/Math/LOG2E
-tags:
-  - JavaScript
-  - Math
-  - Property
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/LOG2E
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/max/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/max/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.max()
 slug: Web/JavaScript/Reference/Global_Objects/Math/max
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/max
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/min/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/min/index.md
@@ -1,19 +1,6 @@
 ---
 title: Math.min()
 slug: Web/JavaScript/Reference/Global_Objects/Math/min
-tags:
-  - JavaScript
-  - Lowest Number
-  - Lowest Value
-  - Math
-  - Method
-  - Minimum
-  - Reference
-  - Smallest
-  - Smallest Number
-  - Smallest Value
-  - min
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/min
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/pi/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/pi/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.PI
 slug: Web/JavaScript/Reference/Global_Objects/Math/PI
-tags:
-  - JavaScript
-  - Math
-  - Property
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/PI
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/pow/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/pow/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.pow()
 slug: Web/JavaScript/Reference/Global_Objects/Math/pow
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/pow
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/random/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/random/index.md
@@ -1,14 +1,6 @@
 ---
 title: Math.random()
 slug: Web/JavaScript/Reference/Global_Objects/Math/random
-tags:
-  - JavaScript
-  - Math
-  - Math.random()
-  - Method
-  - Random
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/random
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/round/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/round/index.md
@@ -1,13 +1,6 @@
 ---
 title: Math.round()
 slug: Web/JavaScript/Reference/Global_Objects/Math/round
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Number
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/round
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/sign/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/sign/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.sign()
 slug: Web/JavaScript/Reference/Global_Objects/Math/sign
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/sign
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/sin/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/sin/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.sin()
 slug: Web/JavaScript/Reference/Global_Objects/Math/sin
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/sin
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/sinh/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/sinh/index.md
@@ -1,13 +1,6 @@
 ---
 title: Math.sinh()
 slug: Web/JavaScript/Reference/Global_Objects/Math/sinh
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/sinh
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/sqrt/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/sqrt/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.sqrt()
 slug: Web/JavaScript/Reference/Global_Objects/Math/sqrt
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/sqrt
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/sqrt1_2/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/sqrt1_2/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.SQRT1_2
 slug: Web/JavaScript/Reference/Global_Objects/Math/SQRT1_2
-tags:
-  - JavaScript
-  - Math
-  - Property
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/SQRT1_2
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/sqrt2/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/sqrt2/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.SQRT2
 slug: Web/JavaScript/Reference/Global_Objects/Math/SQRT2
-tags:
-  - JavaScript
-  - Math
-  - Property
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/SQRT2
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/tan/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/tan/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.tan()
 slug: Web/JavaScript/Reference/Global_Objects/Math/tan
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/tan
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/tanh/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/tanh/index.md
@@ -1,13 +1,6 @@
 ---
 title: Math.tanh()
 slug: Web/JavaScript/Reference/Global_Objects/Math/tanh
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/tanh
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/math/trunc/index.md
+++ b/files/ja/web/javascript/reference/global_objects/math/trunc/index.md
@@ -1,13 +1,6 @@
 ---
 title: Math.trunc()
 slug: Web/JavaScript/Reference/Global_Objects/Math/trunc
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/trunc
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/nan/index.md
+++ b/files/ja/web/javascript/reference/global_objects/nan/index.md
@@ -1,12 +1,6 @@
 ---
 title: NaN
 slug: Web/JavaScript/Reference/Global_Objects/NaN
-tags:
-  - JavaScript
-  - プロパティ
-  - リファレンス
-browser-compat: javascript.builtins.NaN
-translation_of: Web/JavaScript/Reference/Global_Objects/NaN
 ---
 {{jsSidebar("Objects")}}
 

--- a/files/ja/web/javascript/reference/global_objects/number/epsilon/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/epsilon/index.md
@@ -1,14 +1,6 @@
 ---
 title: Number.EPSILON
 slug: Web/JavaScript/Reference/Global_Objects/Number/EPSILON
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Number
-  - プロパティ
-  - ポリフィル
-browser-compat: javascript.builtins.Number.EPSILON
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/EPSILON
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/number/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/index.md
@@ -1,14 +1,6 @@
 ---
 title: Number
 slug: Web/JavaScript/Reference/Global_Objects/Number
-tags:
-  - クラス
-  - JavaScript
-  - Number
-  - リファレンス
-  - ポリフィル
-browser-compat: javascript.builtins.Number
-translation_of: Web/JavaScript/Reference/Global_Objects/Number
 ---
 {{JSRef}}**`Number`** は[プリミティブラッパーオブジェクト](/ja/docs/Glossary/Primitive#primitive_wrapper_objects_in_javascript)で、 `37` や `-9.25` のような数値を表現したり操作したりするために使用されます。
 

--- a/files/ja/web/javascript/reference/global_objects/number/isfinite/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/isfinite/index.md
@@ -1,14 +1,6 @@
 ---
 title: Number.isFinite()
 slug: Web/JavaScript/Reference/Global_Objects/Number/isFinite
-tags:
-  - JavaScript
-  - メソッド
-  - Number
-  - リファレンス
-  - ポリフィル
-browser-compat: javascript.builtins.Number.isFinite
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/isFinite
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/number/isinteger/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/isinteger/index.md
@@ -1,14 +1,6 @@
 ---
 title: Number.isInteger()
 slug: Web/JavaScript/Reference/Global_Objects/Number/isInteger
-tags:
-  - JavaScript
-  - メソッド
-  - Number
-  - リファレンス
-  - ポリフィル
-browser-compat: javascript.builtins.Number.isInteger
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/isInteger
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/number/isnan/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/isnan/index.md
@@ -1,15 +1,6 @@
 ---
 title: Number.isNaN()
 slug: Web/JavaScript/Reference/Global_Objects/Number/isNaN
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - メソッド
-  - Number
-  - isNaN
-  - ポリフィル
-browser-compat: javascript.builtins.Number.isNaN
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/isNaN
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/number/issafeinteger/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/issafeinteger/index.md
@@ -1,14 +1,6 @@
 ---
 title: Number.isSafeInteger()
 slug: Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - メソッド
-  - Number
-  - ポリフィル
-browser-compat: javascript.builtins.Number.isSafeInteger
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/number/max_safe_integer/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/max_safe_integer/index.md
@@ -1,14 +1,6 @@
 ---
 title: Number.MAX_SAFE_INTEGER
 slug: Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Number
-  - プロパティ
-  - ポリフィル
-browser-compat: javascript.builtins.Number.MAX_SAFE_INTEGER
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/number/max_value/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/max_value/index.md
@@ -1,13 +1,6 @@
 ---
 title: Number.MAX_VALUE
 slug: Web/JavaScript/Reference/Global_Objects/Number/MAX_VALUE
-tags:
-  - JavaScript
-  - Number
-  - プロパティ
-  - リファレンス
-browser-compat: javascript.builtins.Number.MAX_VALUE
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/MAX_VALUE
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/number/min_safe_integer/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/min_safe_integer/index.md
@@ -1,14 +1,6 @@
 ---
 title: Number.MIN_SAFE_INTEGER
 slug: Web/JavaScript/Reference/Global_Objects/Number/MIN_SAFE_INTEGER
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Number
-  - プロパティ
-  - ポリフィル
-browser-compat: javascript.builtins.Number.MIN_SAFE_INTEGER
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/MIN_SAFE_INTEGER
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/number/min_value/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/min_value/index.md
@@ -1,12 +1,6 @@
 ---
 title: Number.MIN_VALUE
 slug: Web/JavaScript/Reference/Global_Objects/Number/MIN_VALUE
-tags:
-  - JavaScript
-  - Number
-  - プロパティ
-browser-compat: javascript.builtins.Number.MIN_VALUE
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/MIN_VALUE
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/number/nan/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/nan/index.md
@@ -1,12 +1,6 @@
 ---
 title: Number.NaN
 slug: Web/JavaScript/Reference/Global_Objects/Number/NaN
-tags:
-  - JavaScript
-  - Number
-  - プロパティ
-browser-compat: javascript.builtins.Number.NaN
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/NaN
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/number/negative_infinity/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/negative_infinity/index.md
@@ -1,13 +1,6 @@
 ---
 title: Number.NEGATIVE_INFINITY
 slug: Web/JavaScript/Reference/Global_Objects/Number/NEGATIVE_INFINITY
-tags:
-  - JavaScript
-  - Number
-  - プロパティ
-  - リファレンス
-browser-compat: javascript.builtins.Number.NEGATIVE_INFINITY
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/NEGATIVE_INFINITY
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/number/number/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/number/index.md
@@ -1,14 +1,6 @@
 ---
 title: Number() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/Number/Number
-tags:
-  - コンストラクター
-  - JavaScript
-  - Number
-  - リファレンス
-  - ポリフィル
-browser-compat: javascript.builtins.Number.Number
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/Number
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/number/parsefloat/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/parsefloat/index.md
@@ -1,14 +1,6 @@
 ---
 title: Number.parseFloat()
 slug: Web/JavaScript/Reference/Global_Objects/Number/parseFloat
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - メソッド
-  - Number
-  - ポリフィル
-browser-compat: javascript.builtins.Number.parseFloat
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/parseFloat
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/number/parseint/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/parseint/index.md
@@ -1,14 +1,6 @@
 ---
 title: Number.parseInt()
 slug: Web/JavaScript/Reference/Global_Objects/Number/parseInt
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - メソッド
-  - Number
-  - ポリフィル
-browser-compat: javascript.builtins.Number.parseInt
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/parseInt
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/number/positive_infinity/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/positive_infinity/index.md
@@ -1,13 +1,6 @@
 ---
 title: Number.POSITIVE_INFINITY
 slug: Web/JavaScript/Reference/Global_Objects/Number/POSITIVE_INFINITY
-tags:
-  - JavaScript
-  - Number
-  - プロパティ
-  - リファレンス
-browser-compat: javascript.builtins.Number.POSITIVE_INFINITY
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/POSITIVE_INFINITY
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/number/toexponential/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/toexponential/index.md
@@ -1,14 +1,6 @@
 ---
 title: Number.prototype.toExponential()
 slug: Web/JavaScript/Reference/Global_Objects/Number/toExponential
-tags:
-  - JavaScript
-  - メソッド
-  - Number
-  - Prototype
-  - ポリフィル
-browser-compat: javascript.builtins.Number.toExponential
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/toExponential
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/number/tofixed/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/tofixed/index.md
@@ -1,14 +1,6 @@
 ---
 title: Number.prototype.toFixed()
 slug: Web/JavaScript/Reference/Global_Objects/Number/toFixed
-tags:
-  - JavaScript
-  - メソッド
-  - Number
-  - Prototype
-  - リファレンス
-browser-compat: javascript.builtins.Number.toFixed
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/toFixed
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/number/tolocalestring/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/tolocalestring/index.md
@@ -1,14 +1,6 @@
 ---
 title: Number.prototype.toLocaleString()
 slug: Web/JavaScript/Reference/Global_Objects/Number/toLocaleString
-tags:
-  - 国際化
-  - JavaScript
-  - メソッド
-  - Number
-  - プロトタイプ
-browser-compat: javascript.builtins.Number.toLocaleString
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/toLocaleString
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/number/toprecision/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/toprecision/index.md
@@ -1,13 +1,6 @@
 ---
 title: Number.prototype.toPrecision()
 slug: Web/JavaScript/Reference/Global_Objects/Number/toPrecision
-tags:
-  - JavaScript
-  - メソッド
-  - Number
-  - Prototype
-browser-compat: javascript.builtins.Number.toPrecision
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/toPrecision
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/number/tostring/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/tostring/index.md
@@ -1,12 +1,6 @@
 ---
 title: Number.prototype.toString()
 slug: Web/JavaScript/Reference/Global_Objects/Number/toString
-tags:
-  - JavaScript
-  - メソッド
-  - Number
-  - Prototype
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/toString
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/number/valueof/index.md
+++ b/files/ja/web/javascript/reference/global_objects/number/valueof/index.md
@@ -1,14 +1,6 @@
 ---
 title: Number.prototype.valueOf()
 slug: Web/JavaScript/Reference/Global_Objects/Number/valueOf
-tags:
-  - JavaScript
-  - メソッド
-  - Number
-  - Prototype
-  - リファレンス
-browser-compat: javascript.builtins.Number.valueOf
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/valueOf
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/__definegetter__/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/__definegetter__/index.md
@@ -1,15 +1,6 @@
 ---
 title: Object.prototype.__defineGetter__()
 slug: Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__
-tags:
-  - Deprecated
-  - JavaScript
-  - Method
-  - Object
-  - Prototype
-  - Polyfill
-browser-compat: javascript.builtins.Object.defineGetter
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/__definesetter__/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/__definesetter__/index.md
@@ -1,15 +1,6 @@
 ---
 title: Object.prototype.__defineSetter__()
 slug: Web/JavaScript/Reference/Global_Objects/Object/__defineSetter__
-tags:
-  - Deprecated
-  - JavaScript
-  - Method
-  - Object
-  - Prototype
-  - Polyfill
-browser-compat: javascript.builtins.Object.defineSetter
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/__defineSetter__
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/__lookupgetter__/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/__lookupgetter__/index.md
@@ -1,15 +1,6 @@
 ---
 title: Object.prototype.__lookupGetter__()
 slug: Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__
-tags:
-  - Deprecated
-  - JavaScript
-  - Method
-  - Object
-  - Prototype
-  - Polyfill
-browser-compat: javascript.builtins.Object.lookupGetter
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__
 ---
 {{JSRef}} {{deprecated_header}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/__lookupsetter__/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/__lookupsetter__/index.md
@@ -1,15 +1,6 @@
 ---
 title: Object.prototype.__lookupSetter__()
 slug: Web/JavaScript/Reference/Global_Objects/Object/__lookupSetter__
-tags:
-  - Deprecated
-  - JavaScript
-  - Method
-  - Object
-  - Prototype
-  - Polyfill
-browser-compat: javascript.builtins.Object.lookupSetter
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/__lookupSetter__
 ---
 {{JSRef}} {{deprecated_header}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/assign/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/assign/index.md
@@ -1,15 +1,6 @@
 ---
 title: Object.assign()
 slug: Web/JavaScript/Reference/Global_Objects/Object/assign
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Object
-  - Reference
-  - Polyfill
-browser-compat: javascript.builtins.Object.assign
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/assign
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/constructor/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/constructor/index.md
@@ -1,13 +1,6 @@
 ---
 title: Object.prototype.constructor
 slug: Web/JavaScript/Reference/Global_Objects/Object/constructor
-tags:
-  - JavaScript
-  - Object
-  - プロパティ
-  - Prototype
-browser-compat: javascript.builtins.Object.constructor
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/constructor
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/create/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/create/index.md
@@ -1,16 +1,6 @@
 ---
 title: Object.create()
 slug: Web/JavaScript/Reference/Global_Objects/Object/create
-tags:
-  - ECMAScript 5
-  - JavaScript
-  - メソッド
-  - 'Null'
-  - Object
-  - リファレンス
-  - ポリフィル
-browser-compat: javascript.builtins.Object.create
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/create
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/defineproperties/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/defineproperties/index.md
@@ -1,12 +1,6 @@
 ---
 title: Object.defineProperties()
 slug: Web/JavaScript/Reference/Global_Objects/Object/defineProperties
-tags:
-  - ECMAScript 5
-  - JavaScript
-  - Method
-  - Object
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/defineProperties
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/defineproperty/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/defineproperty/index.md
@@ -1,14 +1,6 @@
 ---
 title: Object.defineProperty()
 slug: Web/JavaScript/Reference/Global_Objects/Object/defineProperty
-tags:
-  - ECMAScript 5
-  - JavaScript
-  - JavaScript 1.8.5
-  - メソッド
-  - Object
-browser-compat: javascript.builtins.Object.defineProperty
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/defineProperty
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/entries/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/entries/index.md
@@ -1,14 +1,6 @@
 ---
 title: Object.entries()
 slug: Web/JavaScript/Reference/Global_Objects/Object/entries
-tags:
-  - JavaScript
-  - メソッド
-  - Object
-  - リファレンス
-  - ポリフィル
-browser-compat: javascript.builtins.Object.entries
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/entries
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/freeze/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/freeze/index.md
@@ -1,19 +1,6 @@
 ---
 title: Object.freeze()
 slug: Web/JavaScript/Reference/Global_Objects/Object/freeze
-tags:
-  - ECMAScript5
-  - JavaScript
-  - Object
-  - Reference
-  - freeze
-  - メソッド
-  - ロック
-  - 不変性
-  - 凍結
-  - 変更
-  - 変更可能性
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/freeze
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/fromentries/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/fromentries/index.md
@@ -1,12 +1,6 @@
 ---
 title: Object.fromEntries()
 slug: Web/JavaScript/Reference/Global_Objects/Object/fromEntries
-tags:
-  - JavaScript
-  - Method
-  - Object
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/fromEntries
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/getownpropertydescriptor/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/getownpropertydescriptor/index.md
@@ -1,13 +1,6 @@
 ---
 title: Object.getOwnPropertyDescriptor()
 slug: Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor
-tags:
-  - ECMAScript 5
-  - JavaScript
-  - Method
-  - Object
-browser-compat: javascript.builtins.Object.getOwnPropertyDescriptor
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/getownpropertydescriptors/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/getownpropertydescriptors/index.md
@@ -1,11 +1,6 @@
 ---
 title: Object.getOwnPropertyDescriptors()
 slug: Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptors
-tags:
-  - JavaScript
-  - Method
-  - Object
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptors
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/getownpropertynames/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/getownpropertynames/index.md
@@ -1,14 +1,6 @@
 ---
 title: Object.getOwnPropertyNames()
 slug: Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames
-tags:
-  - ECMAScript 5
-  - JavaScript
-  - JavaScript 1.8.5
-  - Method
-  - Object
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/getownpropertysymbols/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/getownpropertysymbols/index.md
@@ -1,12 +1,6 @@
 ---
 title: Object.getOwnPropertySymbols()
 slug: Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Object
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/getprototypeof/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/getprototypeof/index.md
@@ -1,12 +1,6 @@
 ---
 title: Object.getPrototypeOf()
 slug: Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf
-tags:
-  - ECMAScript 5
-  - JavaScript
-  - Method
-  - Object
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/hasownproperty/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/hasownproperty/index.md
@@ -1,14 +1,6 @@
 ---
 title: Object.prototype.hasOwnProperty()
 slug: Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty
-tags:
-  - JavaScript
-  - Method
-  - Object
-  - Prototype
-  - hasOwnProperty
-  - メソッド
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/index.md
@@ -1,12 +1,6 @@
 ---
 title: Object
 slug: Web/JavaScript/Reference/Global_Objects/Object
-tags:
-  - Class
-  - JavaScript
-  - Object
-browser-compat: javascript.builtins.Object
-translation_of: Web/JavaScript/Reference/Global_Objects/Object
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/is/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/is/index.md
@@ -1,16 +1,6 @@
 ---
 title: Object.is()
 slug: Web/JavaScript/Reference/Global_Objects/Object/is
-tags:
-  - Comparison
-  - Condition
-  - Conditional
-  - ECMAScript 2015
-  - Equality
-  - JavaScript
-  - Method
-  - Object
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/is
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/isextensible/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/isextensible/index.md
@@ -1,13 +1,6 @@
 ---
 title: Object.isExtensible()
 slug: Web/JavaScript/Reference/Global_Objects/Object/isExtensible
-tags:
-  - ECMAScript 5
-  - JavaScript
-  - JavaScript 1.8.5
-  - Method
-  - Object
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/isExtensible
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/isfrozen/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/isfrozen/index.md
@@ -1,12 +1,6 @@
 ---
 title: Object.isFrozen()
 slug: Web/JavaScript/Reference/Global_Objects/Object/isFrozen
-tags:
-  - ECMAScript 5
-  - JavaScript
-  - Method
-  - Object
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/isFrozen
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/isprototypeof/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/isprototypeof/index.md
@@ -1,14 +1,6 @@
 ---
 title: Object.prototype.isPrototypeOf()
 slug: Web/JavaScript/Reference/Global_Objects/Object/isPrototypeOf
-tags:
-  - JavaScript
-  - Mehtod
-  - Object
-  - Prototype
-  - Reference
-  - isPrototype
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/isPrototypeOf
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/issealed/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/issealed/index.md
@@ -1,13 +1,6 @@
 ---
 title: Object.isSealed()
 slug: Web/JavaScript/Reference/Global_Objects/Object/isSealed
-tags:
-  - ECMAScript 5
-  - JavaScript
-  - JavaScript 1.8.5
-  - Method
-  - Object
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/isSealed
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/keys/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/keys/index.md
@@ -1,13 +1,6 @@
 ---
 title: Object.keys()
 slug: Web/JavaScript/Reference/Global_Objects/Object/keys
-tags:
-  - ECMAScript 5
-  - JavaScript
-  - JavaScript 1.8.5
-  - Method
-  - Object
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/keys
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/object/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/object/index.md
@@ -1,13 +1,6 @@
 ---
 title: Object() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/Object/Object
-tags:
-  - Constructor
-  - JavaScript
-  - Object
-  - Reference
-browser-compat: javascript.builtins.Object.Object
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/Object
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/preventextensions/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/preventextensions/index.md
@@ -1,13 +1,6 @@
 ---
 title: Object.preventExtensions()
 slug: Web/JavaScript/Reference/Global_Objects/Object/preventExtensions
-tags:
-  - ECMAScript 5
-  - JavaScript
-  - JavaScript 1.8.5
-  - Method
-  - Object
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/preventExtensions
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/propertyisenumerable/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/propertyisenumerable/index.md
@@ -1,13 +1,6 @@
 ---
 title: Object.prototype.propertyIsEnumerable()
 slug: Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable
-tags:
-  - JavaScript
-  - メソッド
-  - Object
-  - プロトタイプ
-browser-compat: javascript.builtins.Object.propertyIsEnumerable
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/proto/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/proto/index.md
@@ -1,16 +1,6 @@
 ---
 title: Object.prototype.__proto__
 slug: Web/JavaScript/Reference/Global_Objects/Object/proto
-tags:
-  - Deprecated
-  - ECMAScript 2015
-  - JavaScript
-  - Object
-  - Property
-  - Prototype
-  - Reference
-browser-compat: javascript.builtins.Object.proto
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/proto
 ---
 {{JSRef}}{{Deprecated_header}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/seal/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/seal/index.md
@@ -1,14 +1,6 @@
 ---
 title: Object.seal()
 slug: Web/JavaScript/Reference/Global_Objects/Object/seal
-tags:
-  - ECMAScript 5
-  - JavaScript
-  - JavaScript 1.8.5
-  - Method
-  - Object
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/seal
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/setprototypeof/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/setprototypeof/index.md
@@ -1,13 +1,6 @@
 ---
 title: Object.setPrototypeOf()
 slug: Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Object
-  - Prototype
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/tolocalestring/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/tolocalestring/index.md
@@ -1,13 +1,6 @@
 ---
 title: Object.prototype.toLocaleString()
 slug: Web/JavaScript/Reference/Global_Objects/Object/toLocaleString
-tags:
-  - JavaScript
-  - Method
-  - Object
-  - Prototype
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/toLocaleString
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/tostring/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/tostring/index.md
@@ -1,12 +1,6 @@
 ---
 title: Object.prototype.toString()
 slug: Web/JavaScript/Reference/Global_Objects/Object/toString
-tags:
-  - JavaScript
-  - Method
-  - Object
-  - Prototype
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/toString
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/valueof/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/valueof/index.md
@@ -1,13 +1,6 @@
 ---
 title: Object.prototype.valueOf()
 slug: Web/JavaScript/Reference/Global_Objects/Object/valueOf
-tags:
-  - JavaScript
-  - Method
-  - Object
-  - Prototype
-  - indexof
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/valueOf
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/object/values/index.md
+++ b/files/ja/web/javascript/reference/global_objects/object/values/index.md
@@ -1,14 +1,6 @@
 ---
 title: Object.values()
 slug: Web/JavaScript/Reference/Global_Objects/Object/values
-tags:
-  - JavaScript
-  - メソッド
-  - Object
-  - リファレンス
-  - Polyfill
-browser-compat: javascript.builtins.Object.values
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/values
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/parsefloat/index.md
+++ b/files/ja/web/javascript/reference/global_objects/parsefloat/index.md
@@ -1,12 +1,6 @@
 ---
 title: parseFloat()
 slug: Web/JavaScript/Reference/Global_Objects/parseFloat
-tags:
-  - JavaScript
-  - Method
-  - Reference
-  - メソッド
-translation_of: Web/JavaScript/Reference/Global_Objects/parseFloat
 ---
 {{jsSidebar("Objects")}}
 

--- a/files/ja/web/javascript/reference/global_objects/parseint/index.md
+++ b/files/ja/web/javascript/reference/global_objects/parseint/index.md
@@ -1,13 +1,6 @@
 ---
 title: parseInt()
 slug: Web/JavaScript/Reference/Global_Objects/parseInt
-tags:
-  - JavaScript
-  - メソッド
-  - リファレンス
-  - parseInt
-browser-compat: javascript.builtins.parseInt
-translation_of: Web/JavaScript/Reference/Global_Objects/parseInt
 ---
 {{jsSidebar("Objects")}}
 

--- a/files/ja/web/javascript/reference/global_objects/promise/all/index.md
+++ b/files/ja/web/javascript/reference/global_objects/promise/all/index.md
@@ -1,13 +1,6 @@
 ---
 title: Promise.all()
 slug: Web/JavaScript/Reference/Global_Objects/Promise/all
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - メソッド
-  - Promise
-browser-compat: javascript.builtins.Promise.all
-translation_of: Web/JavaScript/Reference/Global_Objects/Promise/all
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/promise/allsettled/index.md
+++ b/files/ja/web/javascript/reference/global_objects/promise/allsettled/index.md
@@ -1,16 +1,6 @@
 ---
 title: Promise.allSettled()
 slug: Web/JavaScript/Reference/Global_Objects/Promise/allSettled
-tags:
-  - JavaScript
-  - メソッド
-  - プロミス
-  - リファレンス
-  - allSettled
-  - 非同期
-  - ポリフィル
-browser-compat: javascript.builtins.Promise.allSettled
-translation_of: Web/JavaScript/Reference/Global_Objects/Promise/allSettled
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/promise/any/index.md
+++ b/files/ja/web/javascript/reference/global_objects/promise/any/index.md
@@ -1,14 +1,6 @@
 ---
 title: Promise.any()
 slug: Web/JavaScript/Reference/Global_Objects/Promise/any
-tags:
-  - JavaScript
-  - メソッド
-  - プロミス
-  - リファレンス
-  - ポリフィル
-browser-compat: javascript.builtins.Promise.any
-translation_of: Web/JavaScript/Reference/Global_Objects/Promise/any
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/promise/catch/index.md
+++ b/files/ja/web/javascript/reference/global_objects/promise/catch/index.md
@@ -1,14 +1,6 @@
 ---
 title: Promise.prototype.catch()
 slug: Web/JavaScript/Reference/Global_Objects/Promise/catch
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - メソッド
-  - Promise
-  - プロトタイプ
-browser-compat: javascript.builtins.Promise.catch
-translation_of: Web/JavaScript/Reference/Global_Objects/Promise/catch
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/promise/finally/index.md
+++ b/files/ja/web/javascript/reference/global_objects/promise/finally/index.md
@@ -1,16 +1,6 @@
 ---
 title: Promise.prototype.finally()
 slug: Web/JavaScript/Reference/Global_Objects/Promise/finally
-tags:
-  - JavaScript
-  - メソッド
-  - Promise
-  - プロトタイプ
-  - リファレンス
-  - finally
-  - ポリフィル
-browser-compat: javascript.builtins.Promise.finally
-translation_of: Web/JavaScript/Reference/Global_Objects/Promise/finally
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/promise/index.md
+++ b/files/ja/web/javascript/reference/global_objects/promise/index.md
@@ -1,16 +1,6 @@
 ---
 title: Promise
 slug: Web/JavaScript/Reference/Global_Objects/Promise
-tags:
-  - クラス
-  - ECMAScript 2015
-  - JavaScript
-  - Promise
-  - リファレンス
-  - promise.all
-  - ポリフィル
-browser-compat: javascript.builtins.Promise
-translation_of: Web/JavaScript/Reference/Global_Objects/Promise
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/promise/promise/index.md
+++ b/files/ja/web/javascript/reference/global_objects/promise/promise/index.md
@@ -1,14 +1,6 @@
 ---
 title: Promise() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/Promise/Promise
-tags:
-  - コンストラクター
-  - JavaScript
-  - Promise
-  - リファレンス
-  - ポリフィル
-browser-compat: javascript.builtins.Promise.Promise
-translation_of: Web/JavaScript/Reference/Global_Objects/Promise/Promise
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/promise/race/index.md
+++ b/files/ja/web/javascript/reference/global_objects/promise/race/index.md
@@ -1,14 +1,6 @@
 ---
 title: Promise.race()
 slug: Web/JavaScript/Reference/Global_Objects/Promise/race
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - メソッド
-  - Promise
-  - リファレンス
-browser-compat: javascript.builtins.Promise.race
-translation_of: Web/JavaScript/Reference/Global_Objects/Promise/race
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/promise/reject/index.md
+++ b/files/ja/web/javascript/reference/global_objects/promise/reject/index.md
@@ -1,14 +1,6 @@
 ---
 title: Promise.reject()
 slug: Web/JavaScript/Reference/Global_Objects/Promise/reject
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - メソッド
-  - Promise
-  - リファレンス
-browser-compat: javascript.builtins.Promise.reject
-translation_of: Web/JavaScript/Reference/Global_Objects/Promise/reject
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/promise/resolve/index.md
+++ b/files/ja/web/javascript/reference/global_objects/promise/resolve/index.md
@@ -1,14 +1,6 @@
 ---
 title: Promise.resolve()
 slug: Web/JavaScript/Reference/Global_Objects/Promise/resolve
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - メソッド
-  - Promise
-  - リファレンス
-browser-compat: javascript.builtins.Promise.resolve
-translation_of: Web/JavaScript/Reference/Global_Objects/Promise/resolve
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/promise/then/index.md
+++ b/files/ja/web/javascript/reference/global_objects/promise/then/index.md
@@ -1,14 +1,6 @@
 ---
 title: Promise.prototype.then()
 slug: Web/JavaScript/Reference/Global_Objects/Promise/then
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - メソッド
-  - Promise
-  - プロトタイプ
-browser-compat: javascript.builtins.Promise.then
-translation_of: Web/JavaScript/Reference/Global_Objects/Promise/then
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/proxy/index.md
+++ b/files/ja/web/javascript/reference/global_objects/proxy/index.md
@@ -1,12 +1,6 @@
 ---
 title: Proxy
 slug: Web/JavaScript/Reference/Global_Objects/Proxy
-tags:
-  - Class
-  - ECMAScript 2015
-  - JavaScript
-  - Proxy
-translation_of: Web/JavaScript/Reference/Global_Objects/Proxy
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/proxy/proxy/apply/index.md
+++ b/files/ja/web/javascript/reference/global_objects/proxy/proxy/apply/index.md
@@ -1,12 +1,6 @@
 ---
 title: handler.apply()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/apply
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Proxy
-translation_of: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/apply
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/proxy/proxy/construct/index.md
+++ b/files/ja/web/javascript/reference/global_objects/proxy/proxy/construct/index.md
@@ -1,12 +1,6 @@
 ---
 title: handler.construct()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/construct
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Proxy
-translation_of: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/construct
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/proxy/proxy/defineproperty/index.md
+++ b/files/ja/web/javascript/reference/global_objects/proxy/proxy/defineproperty/index.md
@@ -1,12 +1,6 @@
 ---
 title: handler.defineProperty()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/defineProperty
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Proxy
-translation_of: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/defineProperty
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/proxy/proxy/deleteproperty/index.md
+++ b/files/ja/web/javascript/reference/global_objects/proxy/proxy/deleteproperty/index.md
@@ -1,12 +1,6 @@
 ---
 title: handler.deleteProperty()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/deleteProperty
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Proxy
-translation_of: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/deleteProperty
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/proxy/proxy/get/index.md
+++ b/files/ja/web/javascript/reference/global_objects/proxy/proxy/get/index.md
@@ -1,12 +1,6 @@
 ---
 title: handler.get()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/get
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Proxy
-translation_of: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/get
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/proxy/proxy/getownpropertydescriptor/index.md
+++ b/files/ja/web/javascript/reference/global_objects/proxy/proxy/getownpropertydescriptor/index.md
@@ -1,12 +1,6 @@
 ---
 title: handler.getOwnPropertyDescriptor()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/getOwnPropertyDescriptor
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Proxy
-translation_of: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/getOwnPropertyDescriptor
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/proxy/proxy/getprototypeof/index.md
+++ b/files/ja/web/javascript/reference/global_objects/proxy/proxy/getprototypeof/index.md
@@ -1,12 +1,6 @@
 ---
 title: handler.getPrototypeOf()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/getPrototypeOf
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Proxy
-translation_of: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/getPrototypeOf
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/proxy/proxy/has/index.md
+++ b/files/ja/web/javascript/reference/global_objects/proxy/proxy/has/index.md
@@ -1,12 +1,6 @@
 ---
 title: handler.has()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/has
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Proxy
-translation_of: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/has
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/proxy/proxy/index.md
+++ b/files/ja/web/javascript/reference/global_objects/proxy/proxy/index.md
@@ -1,13 +1,6 @@
 ---
 title: Proxy() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy
-tags:
-  - Constructor
-  - JavaScript
-  - Proxy
-  - Reference
-  - コンストラクター
-translation_of: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/proxy/proxy/isextensible/index.md
+++ b/files/ja/web/javascript/reference/global_objects/proxy/proxy/isextensible/index.md
@@ -1,12 +1,6 @@
 ---
 title: handler.isExtensible()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/isExtensible
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Proxy
-translation_of: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/isExtensible
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/proxy/proxy/ownkeys/index.md
+++ b/files/ja/web/javascript/reference/global_objects/proxy/proxy/ownkeys/index.md
@@ -1,12 +1,6 @@
 ---
 title: handler.ownKeys()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/ownKeys
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Proxy
-translation_of: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/ownKeys
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/proxy/proxy/preventextensions/index.md
+++ b/files/ja/web/javascript/reference/global_objects/proxy/proxy/preventextensions/index.md
@@ -1,13 +1,6 @@
 ---
 title: handler.preventExtensions()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/preventExtensions
-tags:
-  - ECMAScript 2015
-  - ECMAScript6
-  - JavaScript
-  - Method
-  - Proxy
-translation_of: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/preventExtensions
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/proxy/proxy/set/index.md
+++ b/files/ja/web/javascript/reference/global_objects/proxy/proxy/set/index.md
@@ -1,12 +1,6 @@
 ---
 title: handler.set()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/set
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Proxy
-translation_of: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/set
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/proxy/proxy/setprototypeof/index.md
+++ b/files/ja/web/javascript/reference/global_objects/proxy/proxy/setprototypeof/index.md
@@ -1,13 +1,6 @@
 ---
 title: handler.setPrototypeOf()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/setPrototypeOf
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - Proxy
-translation_of: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/setPrototypeOf
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/proxy/revocable/index.md
+++ b/files/ja/web/javascript/reference/global_objects/proxy/revocable/index.md
@@ -1,13 +1,6 @@
 ---
 title: Proxy.revocable()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/revocable
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Proxy
-browser-compat: javascript.builtins.Proxy.revocable
-translation_of: Web/JavaScript/Reference/Global_Objects/Proxy/revocable
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/rangeerror/index.md
+++ b/files/ja/web/javascript/reference/global_objects/rangeerror/index.md
@@ -1,12 +1,6 @@
 ---
 title: RangeError
 slug: Web/JavaScript/Reference/Global_Objects/RangeError
-tags:
-  - Class
-  - JavaScript
-  - Object
-  - RangeError
-translation_of: Web/JavaScript/Reference/Global_Objects/RangeError
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/rangeerror/rangeerror/index.md
+++ b/files/ja/web/javascript/reference/global_objects/rangeerror/rangeerror/index.md
@@ -1,11 +1,6 @@
 ---
 title: RangeError() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/RangeError/RangeError
-tags:
-  - Constructor
-  - JavaScript
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/RangeError/RangeError
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/referenceerror/index.md
+++ b/files/ja/web/javascript/reference/global_objects/referenceerror/index.md
@@ -1,13 +1,6 @@
 ---
 title: ReferenceError
 slug: Web/JavaScript/Reference/Global_Objects/ReferenceError
-tags:
-  - Class
-  - JavaScript
-  - Object
-  - Reference
-  - ReferenceError
-translation_of: Web/JavaScript/Reference/Global_Objects/ReferenceError
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/referenceerror/referenceerror/index.md
+++ b/files/ja/web/javascript/reference/global_objects/referenceerror/referenceerror/index.md
@@ -1,12 +1,6 @@
 ---
 title: ReferenceError() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/ReferenceError/ReferenceError
-tags:
-  - Constructor
-  - JavaScript
-  - Reference
-  - ReferenceError
-translation_of: Web/JavaScript/Reference/Global_Objects/ReferenceError/ReferenceError
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/reflect/apply/index.md
+++ b/files/ja/web/javascript/reference/global_objects/reflect/apply/index.md
@@ -1,13 +1,6 @@
 ---
 title: Reflect.apply()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/apply
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Reference
-  - Reflect
-translation_of: Web/JavaScript/Reference/Global_Objects/Reflect/apply
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/reflect/comparing_reflect_and_object_methods/index.md
+++ b/files/ja/web/javascript/reference/global_objects/reflect/comparing_reflect_and_object_methods/index.md
@@ -1,16 +1,6 @@
 ---
 title: Reflect と Object のメソッドの比較
-slug: >-
-  Web/JavaScript/Reference/Global_Objects/Reflect/Comparing_Reflect_and_Object_methods
-tags:
-  - Guide
-  - JavaScript
-  - JavaScript Object Model
-  - Object
-  - Overview
-  - Reflect
-translation_of: >-
-  Web/JavaScript/Reference/Global_Objects/Reflect/Comparing_Reflect_and_Object_methods
+slug: Web/JavaScript/Reference/Global_Objects/Reflect/Comparing_Reflect_and_Object_methods
 ---
 {{jssidebar}}
 

--- a/files/ja/web/javascript/reference/global_objects/reflect/construct/index.md
+++ b/files/ja/web/javascript/reference/global_objects/reflect/construct/index.md
@@ -1,15 +1,6 @@
 ---
 title: Reflect.construct()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/construct
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Reference
-  - Reflect
-  - Polyfill
-browser-compat: javascript.builtins.Reflect.construct
-translation_of: Web/JavaScript/Reference/Global_Objects/Reflect/construct
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/reflect/defineproperty/index.md
+++ b/files/ja/web/javascript/reference/global_objects/reflect/defineproperty/index.md
@@ -1,13 +1,6 @@
 ---
 title: Reflect.defineProperty()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/defineProperty
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Reference
-  - Reflect
-translation_of: Web/JavaScript/Reference/Global_Objects/Reflect/defineProperty
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/reflect/deleteproperty/index.md
+++ b/files/ja/web/javascript/reference/global_objects/reflect/deleteproperty/index.md
@@ -1,13 +1,6 @@
 ---
 title: Reflect.deleteProperty()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/deleteProperty
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Reference
-  - Reflect
-translation_of: Web/JavaScript/Reference/Global_Objects/Reflect/deleteProperty
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/reflect/get/index.md
+++ b/files/ja/web/javascript/reference/global_objects/reflect/get/index.md
@@ -1,14 +1,6 @@
 ---
 title: Reflect.get()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/get
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Reference
-  - Reflect
-  - メソッド
-translation_of: Web/JavaScript/Reference/Global_Objects/Reflect/get
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/reflect/getownpropertydescriptor/index.md
+++ b/files/ja/web/javascript/reference/global_objects/reflect/getownpropertydescriptor/index.md
@@ -1,13 +1,6 @@
 ---
 title: Reflect.getOwnPropertyDescriptor()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/getOwnPropertyDescriptor
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Reference
-  - Reflect
-translation_of: Web/JavaScript/Reference/Global_Objects/Reflect/getOwnPropertyDescriptor
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/reflect/getprototypeof/index.md
+++ b/files/ja/web/javascript/reference/global_objects/reflect/getprototypeof/index.md
@@ -1,13 +1,6 @@
 ---
 title: Reflect.getPrototypeOf()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/getPrototypeOf
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Reference
-  - Reflect
-translation_of: Web/JavaScript/Reference/Global_Objects/Reflect/getPrototypeOf
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/reflect/has/index.md
+++ b/files/ja/web/javascript/reference/global_objects/reflect/has/index.md
@@ -1,13 +1,6 @@
 ---
 title: Reflect.has()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/has
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Reference
-  - Reflect
-translation_of: Web/JavaScript/Reference/Global_Objects/Reflect/has
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/reflect/index.md
+++ b/files/ja/web/javascript/reference/global_objects/reflect/index.md
@@ -1,14 +1,6 @@
 ---
 title: Reflect
 slug: Web/JavaScript/Reference/Global_Objects/Reflect
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - 名前空間
-  - 概要
-  - Reflect
-browser-compat: javascript.builtins.Reflect
-translation_of: Web/JavaScript/Reference/Global_Objects/Reflect
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/reflect/isextensible/index.md
+++ b/files/ja/web/javascript/reference/global_objects/reflect/isextensible/index.md
@@ -1,13 +1,6 @@
 ---
 title: Reflect.isExtensible()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/isExtensible
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Reference
-  - Reflect
-translation_of: Web/JavaScript/Reference/Global_Objects/Reflect/isExtensible
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/reflect/ownkeys/index.md
+++ b/files/ja/web/javascript/reference/global_objects/reflect/ownkeys/index.md
@@ -1,13 +1,6 @@
 ---
 title: Reflect.ownKeys()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/ownKeys
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Reference
-  - Reflect
-translation_of: Web/JavaScript/Reference/Global_Objects/Reflect/ownKeys
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/reflect/preventextensions/index.md
+++ b/files/ja/web/javascript/reference/global_objects/reflect/preventextensions/index.md
@@ -1,13 +1,6 @@
 ---
 title: Reflect.preventExtensions()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/preventExtensions
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Reference
-  - Reflect
-translation_of: Web/JavaScript/Reference/Global_Objects/Reflect/preventExtensions
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/reflect/set/index.md
+++ b/files/ja/web/javascript/reference/global_objects/reflect/set/index.md
@@ -1,13 +1,6 @@
 ---
 title: Reflect.set()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/set
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Reference
-  - Reflect
-translation_of: Web/JavaScript/Reference/Global_Objects/Reflect/set
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/reflect/setprototypeof/index.md
+++ b/files/ja/web/javascript/reference/global_objects/reflect/setprototypeof/index.md
@@ -1,13 +1,6 @@
 ---
 title: Reflect.setPrototypeOf()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/setPrototypeOf
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Reference
-  - Reflect
-translation_of: Web/JavaScript/Reference/Global_Objects/Reflect/setPrototypeOf
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/@@match/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/@@match/index.md
@@ -1,14 +1,6 @@
 ---
 title: RegExp.prototype[@@match]()
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/@@match
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - RegExp
-  - Regular Expression
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/@@match
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/@@matchall/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/@@matchall/index.md
@@ -1,16 +1,6 @@
 ---
 title: RegExp.prototype[@@matchAll]()
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/@@matchAll
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - RegExp
-  - Regular Expressions
-  - メソッド
-  - 正規表現
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/@@matchAll
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/@@replace/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/@@replace/index.md
@@ -1,14 +1,6 @@
 ---
 title: RegExp.prototype[@@replace]()
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/@@replace
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - RegExp
-  - Regular Expression
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/@@replace
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/@@search/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/@@search/index.md
@@ -1,14 +1,6 @@
 ---
 title: RegExp.prototype[@@search]()
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/@@search
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - RegExp
-  - Regular Expression
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/@@search
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/@@species/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/@@species/index.md
@@ -1,14 +1,6 @@
 ---
 title: get RegExp[@@species]
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/@@species
-tags:
-  - JavaScript
-  - Property
-  - Prototype
-  - Reference
-  - RegExp
-  - Regular Expressions
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/@@species
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/@@split/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/@@split/index.md
@@ -1,14 +1,6 @@
 ---
 title: RegExp.prototype[@@split]()
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/@@split
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - RegExp
-  - Regular Expressions
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/@@split
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/compile/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/compile/index.md
@@ -1,15 +1,6 @@
 ---
 title: RegExp.prototype.compile()
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/compile
-tags:
-  - Deprecated
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - RegExp
-  - Regular Expressions
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/compile
 ---
 {{JSRef}} {{deprecated_header}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/dotall/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/dotall/index.md
@@ -1,15 +1,6 @@
 ---
 title: RegExp.prototype.dotAll
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/dotAll
-tags:
-  - Draft
-  - JavaScript
-  - Property
-  - Prototype
-  - Reference
-  - RegExp
-  - Regular Expressions
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/dotAll
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/exec/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/exec/index.md
@@ -1,15 +1,6 @@
 ---
 title: RegExp.prototype.exec()
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/exec
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - RegExp
-  - Regular Expressions
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/exec
-browser-compat: javascript.builtins.RegExp.exec
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/flags/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/flags/index.md
@@ -1,15 +1,6 @@
 ---
 title: RegExp.prototype.flags
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/flags
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Property
-  - Prototype
-  - Reference
-  - RegExp
-  - Regular Expressions
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/flags
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/global/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/global/index.md
@@ -1,14 +1,6 @@
 ---
 title: RegExp.prototype.global
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/global
-tags:
-  - JavaScript
-  - Property
-  - Prototype
-  - Reference
-  - RegExp
-  - Regular Expressions
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/global
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/hasindices/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/hasindices/index.md
@@ -1,16 +1,6 @@
 ---
 title: RegExp.prototype.hasIndices
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/hasIndices
-tags:
-  - Draft
-  - JavaScript
-  - Property
-  - Prototype
-  - Reference
-  - RegExp
-  - Regular Expressions
-browser-compat: javascript.builtins.RegExp.hasIndices
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/hasIndices
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/ignorecase/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/ignorecase/index.md
@@ -1,14 +1,6 @@
 ---
 title: RegExp.prototype.ignoreCase
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/ignoreCase
-tags:
-  - JavaScript
-  - Property
-  - Prototype
-  - Reference
-  - RegExp
-  - Regular Expressions
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/ignoreCase
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/index.md
@@ -1,15 +1,6 @@
 ---
 title: RegExp
 slug: Web/JavaScript/Reference/Global_Objects/RegExp
-tags:
-  - クラス
-  - JavaScript
-  - リファレンス
-  - RegExp
-  - 正規表現
-  - ポリフィル
-browser-compat: javascript.builtins.RegExp
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/input/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/input/index.md
@@ -1,14 +1,6 @@
 ---
 title: RegExp.input ($_)
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/input
-tags:
-  - JavaScript
-  - Non-standard
-  - Property
-  - Reference
-  - RegExp
-  - Regular Expressions
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/input
 ---
 {{JSRef}} {{non-standard_header}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/lastindex/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/lastindex/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'RegExp: lastIndex'
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex
-tags:
-  - JavaScript
-  - Property
-  - Reference
-  - RegExp
-  - 正規表現
-browser-compat: javascript.builtins.RegExp.lastIndex
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/lastmatch/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/lastmatch/index.md
@@ -1,15 +1,6 @@
 ---
 title: RegExp.lastMatch ($&)
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/lastMatch
-tags:
-  - JavaScript
-  - Non-standard
-  - Property
-  - Read-only
-  - Reference
-  - RegExp
-  - Regular Expressions
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/lastMatch
 ---
 {{JSRef}} {{non-standard_header}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/lastparen/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/lastparen/index.md
@@ -1,15 +1,6 @@
 ---
 title: RegExp.lastParen ($+)
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/lastParen
-tags:
-  - JavaScript
-  - Non-standard
-  - Property
-  - Read-only
-  - Reference
-  - RegExp
-  - Regular Expressions
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/lastParen
 ---
 {{JSRef}} {{non-standard_header}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/leftcontext/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/leftcontext/index.md
@@ -1,15 +1,6 @@
 ---
 title: RegExp.leftContext ($`)
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/leftContext
-tags:
-  - JavaScript
-  - Non-standard
-  - Property
-  - Read-only
-  - Reference
-  - RegExp
-  - Regular Expressions
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/leftContext
 ---
 {{JSRef}} {{non-standard_header}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/multiline/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/multiline/index.md
@@ -1,14 +1,6 @@
 ---
 title: RegExp.prototype.multiline
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/multiline
-tags:
-  - JavaScript
-  - Property
-  - Prototype
-  - Reference
-  - RegExp
-  - Regular Expressions
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/multiline
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/n/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/n/index.md
@@ -1,15 +1,6 @@
 ---
 title: RegExp.$1-$9
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/n
-tags:
-  - JavaScript
-  - Non-standard
-  - Property
-  - Read-only
-  - Reference
-  - RegExp
-  - Regular Expressions
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/n
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/regexp/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/regexp/index.md
@@ -1,12 +1,6 @@
 ---
 title: RegExp() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/RegExp
-tags:
-  - Constructor
-  - JavaScript
-  - Reference
-  - RegExp
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/RegExp
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/rightcontext/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/rightcontext/index.md
@@ -1,15 +1,6 @@
 ---
 title: RegExp.rightContext ($')
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/rightContext
-tags:
-  - JavaScript
-  - Non-standard
-  - Property
-  - Read-only
-  - Reference
-  - RegExp
-  - Regular Expressions
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/rightContext
 ---
 {{JSRef}} {{non-standard_header}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/source/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/source/index.md
@@ -1,14 +1,6 @@
 ---
 title: RegExp.prototype.source
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/source
-tags:
-  - JavaScript
-  - Property
-  - Prototype
-  - Reference
-  - RegExp
-  - Regular Expressions
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/source
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/sticky/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/sticky/index.md
@@ -1,17 +1,6 @@
 ---
 title: RegExp.prototype.sticky
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/sticky
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Property
-  - Prototype
-  - Reference
-  - RegExp
-  - Regular Expressions
-  - プロパティ
-  - 正規表現
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/sticky
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/test/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/test/index.md
@@ -1,14 +1,6 @@
 ---
 title: RegExp.prototype.test()
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/test
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - RegExp
-  - Regular Expressions
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/test
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/tostring/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/tostring/index.md
@@ -1,14 +1,6 @@
 ---
 title: RegExp.prototype.toString()
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/toString
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - RegExp
-  - Regular Expressions
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/toString
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/regexp/unicode/index.md
+++ b/files/ja/web/javascript/reference/global_objects/regexp/unicode/index.md
@@ -1,15 +1,6 @@
 ---
 title: RegExp.prototype.unicode
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/unicode
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Property
-  - Prototype
-  - Reference
-  - RegExp
-  - Regular Expressions
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/unicode
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/set/@@iterator/index.md
+++ b/files/ja/web/javascript/reference/global_objects/set/@@iterator/index.md
@@ -1,16 +1,6 @@
 ---
 title: Set.prototype[@@iterator]()
 slug: Web/JavaScript/Reference/Global_Objects/Set/@@iterator
-tags:
-  - ECMAScript 2015
-  - 反復子
-  - JavaScript
-  - メソッド
-  - プロトタイプ
-  - リファレンス
-  - set
-browser-compat: javascript.builtins.Set.@@iterator
-translation_of: Web/JavaScript/Reference/Global_Objects/Set/@@iterator
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/set/@@species/index.md
+++ b/files/ja/web/javascript/reference/global_objects/set/@@species/index.md
@@ -1,13 +1,6 @@
 ---
 title: get Set[@@species]
 slug: Web/JavaScript/Reference/Global_Objects/Set/@@species
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - プロパティ
-  - set
-browser-compat: javascript.builtins.Set.@@species
-translation_of: Web/JavaScript/Reference/Global_Objects/Set/@@species
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/set/add/index.md
+++ b/files/ja/web/javascript/reference/global_objects/set/add/index.md
@@ -1,15 +1,6 @@
 ---
 title: Set.prototype.add()
 slug: Web/JavaScript/Reference/Global_Objects/Set/add
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - メソッド
-  - プロトタイプ
-  - リファレンス
-  - set
-browser-compat: javascript.builtins.Set.add
-translation_of: Web/JavaScript/Reference/Global_Objects/Set/add
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/set/clear/index.md
+++ b/files/ja/web/javascript/reference/global_objects/set/clear/index.md
@@ -1,15 +1,6 @@
 ---
 title: Set.prototype.clear()
 slug: Web/JavaScript/Reference/Global_Objects/Set/clear
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - メソッド
-  - プロトタイプ
-  - リファレンス
-  - set
-browser-compat: javascript.builtins.Set.clear
-translation_of: Web/JavaScript/Reference/Global_Objects/Set/clear
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/set/delete/index.md
+++ b/files/ja/web/javascript/reference/global_objects/set/delete/index.md
@@ -1,15 +1,6 @@
 ---
 title: Set.prototype.delete()
 slug: Web/JavaScript/Reference/Global_Objects/Set/delete
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - メソッド
-  - プロトタイプ
-  - リファレンス
-  - set
-browser-compat: javascript.builtins.Set.delete
-translation_of: Web/JavaScript/Reference/Global_Objects/Set/delete
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/set/entries/index.md
+++ b/files/ja/web/javascript/reference/global_objects/set/entries/index.md
@@ -1,15 +1,6 @@
 ---
 title: Set.prototype.entries()
 slug: Web/JavaScript/Reference/Global_Objects/Set/entries
-tags:
-  - ECMAScript 2015
-  - 反復子
-  - JavaScript
-  - メソッド
-  - プロトタイプ
-  - set
-browser-compat: javascript.builtins.Set.entries
-translation_of: Web/JavaScript/Reference/Global_Objects/Set/entries
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/set/foreach/index.md
+++ b/files/ja/web/javascript/reference/global_objects/set/foreach/index.md
@@ -1,15 +1,6 @@
 ---
 title: Set.prototype.forEach()
 slug: Web/JavaScript/Reference/Global_Objects/Set/forEach
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - メソッド
-  - プロトタイプ
-  - リファレンス
-  - set
-browser-compat: javascript.builtins.Set.forEach
-translation_of: Web/JavaScript/Reference/Global_Objects/Set/forEach
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/set/has/index.md
+++ b/files/ja/web/javascript/reference/global_objects/set/has/index.md
@@ -1,14 +1,6 @@
 ---
 title: Set.prototype.has()
 slug: Web/JavaScript/Reference/Global_Objects/Set/has
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - メソッド
-  - プロトタイプ
-  - set
-browser-compat: javascript.builtins.Set.has
-translation_of: Web/JavaScript/Reference/Global_Objects/Set/has
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/set/index.md
+++ b/files/ja/web/javascript/reference/global_objects/set/index.md
@@ -1,17 +1,6 @@
 ---
 title: Set
 slug: Web/JavaScript/Reference/Global_Objects/Set
-tags:
-  - クラス
-  - ECMAScript 2015
-  - グローバルオブジェクト
-  - JavaScript
-  - オブジェクト
-  - リファレンス
-  - set
-  - Polyfill
-browser-compat: javascript.builtins.Set
-translation_of: Web/JavaScript/Reference/Global_Objects/Set
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/set/set/index.md
+++ b/files/ja/web/javascript/reference/global_objects/set/set/index.md
@@ -1,14 +1,6 @@
 ---
 title: Set() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/Set/Set
-tags:
-  - コンストラクター
-  - JavaScript
-  - リファレンス
-  - set
-  - ポリフィル
-browser-compat: javascript.builtins.Set.Set
-translation_of: Web/JavaScript/Reference/Global_Objects/Set/Set
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/set/size/index.md
+++ b/files/ja/web/javascript/reference/global_objects/set/size/index.md
@@ -1,14 +1,6 @@
 ---
 title: Set.prototype.size
 slug: Web/JavaScript/Reference/Global_Objects/Set/size
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - プロパティ
-  - プロトタイプ
-  - set
-browser-compat: javascript.builtins.Set.size
-translation_of: Web/JavaScript/Reference/Global_Objects/Set/size
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/set/values/index.md
+++ b/files/ja/web/javascript/reference/global_objects/set/values/index.md
@@ -1,15 +1,6 @@
 ---
 title: Set.prototype.values()
 slug: Web/JavaScript/Reference/Global_Objects/Set/values
-tags:
-  - ECMAScript 2015
-  - 反復子
-  - JavaScript
-  - メソッド
-  - プロトタイプ
-  - set
-browser-compat: javascript.builtins.Set.values
-translation_of: Web/JavaScript/Reference/Global_Objects/Set/values
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/sharedarraybuffer/bytelength/index.md
+++ b/files/ja/web/javascript/reference/global_objects/sharedarraybuffer/bytelength/index.md
@@ -1,14 +1,6 @@
 ---
 title: SharedArrayBuffer.prototype.byteLength
 slug: Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/byteLength
-tags:
-  - JavaScript
-  - プロパティ
-  - 共有メモリー
-  - SharedArrayBuffer
-  - 型付き配列
-browser-compat: javascript.builtins.SharedArrayBuffer.byteLength
-translation_of: Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/byteLength
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/sharedarraybuffer/index.md
+++ b/files/ja/web/javascript/reference/global_objects/sharedarraybuffer/index.md
@@ -1,14 +1,6 @@
 ---
 title: SharedArrayBuffer
 slug: Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer
-tags:
-  - クラス
-  - JavaScript
-  - 共有メモリー
-  - SharedArrayBuffer
-  - 型付き配列
-browser-compat: javascript.builtins.SharedArrayBuffer
-translation_of: Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/sharedarraybuffer/planned_changes/index.md
+++ b/files/ja/web/javascript/reference/global_objects/sharedarraybuffer/planned_changes/index.md
@@ -1,15 +1,6 @@
 ---
 title: 共有メモリーに関する変更予定
 slug: Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/Planned_changes
-tags:
-  - Fetch
-  - ガイド
-  - HTML
-  - JavaScript
-  - セキュリティ
-  - SharedArrayBuffer
-  - Spectre
-  - postMessage
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/sharedarraybuffer/sharedarraybuffer/index.md
+++ b/files/ja/web/javascript/reference/global_objects/sharedarraybuffer/sharedarraybuffer/index.md
@@ -1,13 +1,6 @@
 ---
 title: SharedArrayBuffer() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/SharedArrayBuffer
-tags:
-  - コストラクター
-  - JavaScript
-  - リファレンス
-  - SharedArrayBuffer
-browser-compat: javascript.builtins.SharedArrayBuffer.SharedArrayBuffer
-translation_of: Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/SharedArrayBuffer
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/sharedarraybuffer/slice/index.md
+++ b/files/ja/web/javascript/reference/global_objects/sharedarraybuffer/slice/index.md
@@ -1,15 +1,6 @@
 ---
 title: SharedArrayBuffer.prototype.slice()
 slug: Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/slice
-tags:
-  - JavaScript
-  - メソッド
-  - Prototype
-  - 共有メモリー
-  - SharedArrayBuffer
-  - 型付き配列
-browser-compat: javascript.builtins.SharedArrayBuffer.slice
-translation_of: Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/slice
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/@@iterator/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/@@iterator/index.md
@@ -1,15 +1,6 @@
 ---
 title: String.prototype[@@iterator]()
 slug: Web/JavaScript/Reference/Global_Objects/String/@@iterator
-tags:
-  - ECMAScript 2015
-  - Iterator
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/@@iterator
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/anchor/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/anchor/index.md
@@ -1,15 +1,6 @@
 ---
 title: String.prototype.anchor()
 slug: Web/JavaScript/Reference/Global_Objects/String/anchor
-tags:
-  - Deprecated
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/anchor
 ---
 {{JSRef}} {{deprecated_header}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/big/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/big/index.md
@@ -1,17 +1,6 @@
 ---
 title: String.prototype.big()
 slug: Web/JavaScript/Reference/Global_Objects/String/big
-tags:
-  - Deprecated
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-  - Polyfill
-translation_of: Web/JavaScript/Reference/Global_Objects/String/big
-browser-compat: javascript.builtins.String.big
 ---
 {{JSRef}} {{deprecated_header}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/blink/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/blink/index.md
@@ -1,15 +1,6 @@
 ---
 title: String.prototype.blink()
 slug: Web/JavaScript/Reference/Global_Objects/String/blink
-tags:
-  - Deprecated
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/blink
 ---
 {{JSRef}} {{deprecated_header}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/bold/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/bold/index.md
@@ -1,15 +1,6 @@
 ---
 title: String.prototype.bold()
 slug: Web/JavaScript/Reference/Global_Objects/String/bold
-tags:
-  - Deprecated
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/bold
 ---
 {{JSRef}} {{deprecated_header}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/charat/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/charat/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.charAt()
 slug: Web/JavaScript/Reference/Global_Objects/String/charAt
-tags:
-  - JavaScript
-  - メソッド
-  - プロトタイプ
-  - リファレンス
-  - String
-browser-compat: javascript.builtins.String.charAt
-translation_of: Web/JavaScript/Reference/Global_Objects/String/charAt
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/charcodeat/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/charcodeat/index.md
@@ -1,13 +1,6 @@
 ---
 title: String.prototype.charCodeAt()
 slug: Web/JavaScript/Reference/Global_Objects/String/charCodeAt
-tags:
-  - JavaScript
-  - Method
-  - Reference
-  - String
-  - Unicode
-translation_of: Web/JavaScript/Reference/Global_Objects/String/charCodeAt
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/codepointat/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/codepointat/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.codePointAt()
 slug: Web/JavaScript/Reference/Global_Objects/String/codePointAt
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/codePointAt
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/concat/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/concat/index.md
@@ -1,13 +1,6 @@
 ---
 title: String.prototype.concat()
 slug: Web/JavaScript/Reference/Global_Objects/String/concat
-tags:
-  - JavaScript
-  - Prototype
-  - Reference
-  - String
-  - メソッド
-translation_of: Web/JavaScript/Reference/Global_Objects/String/concat
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/endswith/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/endswith/index.md
@@ -1,13 +1,6 @@
 ---
 title: String.prototype.endsWith()
 slug: Web/JavaScript/Reference/Global_Objects/String/endsWith
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/endsWith
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/fixed/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/fixed/index.md
@@ -1,15 +1,6 @@
 ---
 title: String.prototype.fixed()
 slug: Web/JavaScript/Reference/Global_Objects/String/fixed
-tags:
-  - Deprecated
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/fixed
 ---
 {{JSRef}} {{deprecated_header}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/fontcolor/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/fontcolor/index.md
@@ -1,17 +1,6 @@
 ---
 title: String.prototype.fontcolor()
 slug: Web/JavaScript/Reference/Global_Objects/String/fontcolor
-tags:
-  - Deprecated
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-  - Polyfill
-translation_of: Web/JavaScript/Reference/Global_Objects/String/fontcolor
-browser-compat: javascript.builtins.String.fontcolor
 ---
 {{JSRef}} {{deprecated_header}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/fontsize/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/fontsize/index.md
@@ -1,17 +1,6 @@
 ---
 title: String.prototype.fontsize()
 slug: Web/JavaScript/Reference/Global_Objects/String/fontsize
-tags:
-  - Deprecated
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-  - Polyfill
-translation_of: Web/JavaScript/Reference/Global_Objects/String/fontsize
-browser-compat: javascript.builtins.String.fontsize
 ---
 {{JSRef}} {{deprecated_header}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/fromcharcode/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/fromcharcode/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.fromCharCode()
 slug: Web/JavaScript/Reference/Global_Objects/String/fromCharCode
-tags:
-  - JavaScript
-  - Method
-  - Reference
-  - String
-  - UTF-16
-  - Unicode
-translation_of: Web/JavaScript/Reference/Global_Objects/String/fromCharCode
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/fromcodepoint/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/fromcodepoint/index.md
@@ -1,17 +1,6 @@
 ---
 title: String.fromCodePoint()
 slug: Web/JavaScript/Reference/Global_Objects/String/fromCodePoint
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - メソッド
-  - リファレンス
-  - String
-  - UTF-32
-  - Unicode
-  - ポリフィル
-browser-compat: javascript.builtins.String.fromCodePoint
-translation_of: Web/JavaScript/Reference/Global_Objects/String/fromCodePoint
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/includes/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/includes/index.md
@@ -1,15 +1,6 @@
 ---
 title: String.prototype.includes()
 slug: Web/JavaScript/Reference/Global_Objects/String/includes
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-  - Polyfill
-browser-compat: javascript.builtins.String.includes
-translation_of: Web/JavaScript/Reference/Global_Objects/String/includes
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/index.md
@@ -1,13 +1,6 @@
 ---
 title: String
 slug: Web/JavaScript/Reference/Global_Objects/String
-tags:
-  - Class
-  - ECMAScript 2015
-  - JavaScript
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/indexof/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/indexof/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.indexOf()
 slug: Web/JavaScript/Reference/Global_Objects/String/indexOf
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-  - メソッド
-translation_of: Web/JavaScript/Reference/Global_Objects/String/indexOf
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/italics/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/italics/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.italics()
 slug: Web/JavaScript/Reference/Global_Objects/String/italics
-tags:
-  - Deprecated
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/italics
 ---
 {{JSRef}} {{deprecated_header}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/lastindexof/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/lastindexof/index.md
@@ -1,15 +1,6 @@
 ---
 title: String.prototype.lastIndexOf()
 slug: Web/JavaScript/Reference/Global_Objects/String/lastIndexOf
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-  - lastIndexOf
-translation_of: Web/JavaScript/Reference/Global_Objects/String/lastIndexOf
-browser-compat: javascript.builtins.String.lastIndexOf
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/length/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/length/index.md
@@ -1,15 +1,6 @@
 ---
 title: String length
 slug: Web/JavaScript/Reference/Global_Objects/String/length
-tags:
-  - JavaScript
-  - Property
-  - Prototype
-  - Reference
-  - String
-  - String Length
-  - length
-translation_of: Web/JavaScript/Reference/Global_Objects/String/length
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/link/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/link/index.md
@@ -1,15 +1,6 @@
 ---
 title: String.prototype.link()
 slug: Web/JavaScript/Reference/Global_Objects/String/link
-tags:
-  - Deprecated
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/link
 ---
 {{JSRef}} {{deprecated_header}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/localecompare/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/localecompare/index.md
@@ -1,15 +1,6 @@
 ---
 title: String.prototype.localeCompare()
 slug: Web/JavaScript/Reference/Global_Objects/String/localeCompare
-tags:
-  - Internationalization
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-browser-compat: javascript.builtins.String.localeCompare
-translation_of: Web/JavaScript/Reference/Global_Objects/String/localeCompare
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/match/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/match/index.md
@@ -1,15 +1,6 @@
 ---
 title: String.prototype.match()
 slug: Web/JavaScript/Reference/Global_Objects/String/match
-tags:
-  - JavaScript
-  - メソッド
-  - プロトタイプ
-  - リファレンス
-  - 正規表現
-  - String
-browser-compat: javascript.builtins.String.match
-translation_of: Web/JavaScript/Reference/Global_Objects/String/match
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/matchall/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/matchall/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.matchAll()
 slug: Web/JavaScript/Reference/Global_Objects/String/matchAll
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - Regular Expressions
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/matchAll
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/normalize/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/normalize/index.md
@@ -1,16 +1,6 @@
 ---
 title: String.prototype.normalize()
 slug: Web/JavaScript/Reference/Global_Objects/String/normalize
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-  - Unicode
-  - メソッド
-translation_of: Web/JavaScript/Reference/Global_Objects/String/normalize
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/padend/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/padend/index.md
@@ -1,13 +1,6 @@
 ---
 title: String.prototype.padEnd()
 slug: Web/JavaScript/Reference/Global_Objects/String/padEnd
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/padEnd
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/padstart/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/padstart/index.md
@@ -1,15 +1,6 @@
 ---
 title: String.prototype.padStart()
 slug: Web/JavaScript/Reference/Global_Objects/String/padStart
-tags:
-  - Advanced
-  - Intermediate
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/padStart
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/raw/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/raw/index.md
@@ -1,13 +1,6 @@
 ---
 title: String.raw()
 slug: Web/JavaScript/Reference/Global_Objects/String/raw
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/raw
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/repeat/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/repeat/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.repeat()
 slug: Web/JavaScript/Reference/Global_Objects/String/repeat
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/repeat
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/replace/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/replace/index.md
@@ -1,16 +1,6 @@
 ---
 title: String.prototype.replace()
 slug: Web/JavaScript/Reference/Global_Objects/String/replace
-tags:
-  - Expressions
-  - JavaScript
-  - メソッド
-  - プロトタイプ
-  - リファレンス
-  - Regular
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/replace
-browser-compat: javascript.builtins.String.replace
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/replaceall/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/replaceall/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.replaceAll()
 slug: Web/JavaScript/Reference/Global_Objects/String/replaceAll
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-  - regex
-translation_of: Web/JavaScript/Reference/Global_Objects/String/replaceAll
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/search/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/search/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.search()
 slug: Web/JavaScript/Reference/Global_Objects/String/search
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - Regular Expressions
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/search
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/slice/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/slice/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.slice()
 slug: Web/JavaScript/Reference/Global_Objects/String/slice
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-browser-compat: javascript.builtins.String.slice
-translation_of: Web/JavaScript/Reference/Global_Objects/String/slice
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/small/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/small/index.md
@@ -1,17 +1,6 @@
 ---
 title: String.prototype.small()
 slug: Web/JavaScript/Reference/Global_Objects/String/small
-tags:
-  - Deprecated
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-  - Polyfill
-translation_of: Web/JavaScript/Reference/Global_Objects/String/small
-browser-compat: javascript.builtins.String.small
 ---
 {{JSRef}} {{deprecated_header}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/split/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/split/index.md
@@ -1,17 +1,6 @@
 ---
 title: String.prototype.split()
 slug: Web/JavaScript/Reference/Global_Objects/String/split
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - Regular Expressions
-  - String
-  - プロトタイプ
-  - メソッド
-  - 正規表現
-translation_of: Web/JavaScript/Reference/Global_Objects/String/split
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/startswith/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/startswith/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.startsWith()
 slug: Web/JavaScript/Reference/Global_Objects/String/startsWith
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/startsWith
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/strike/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/strike/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.strike()
 slug: Web/JavaScript/Reference/Global_Objects/String/strike
-tags:
-  - Deprecated
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/strike
 ---
 {{JSRef}} {{deprecated_header}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/string/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/string/index.md
@@ -1,12 +1,6 @@
 ---
 title: String() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/String/String
-tags:
-  - Constructor
-  - JavaScript
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/String
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/sub/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/sub/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.sub()
 slug: Web/JavaScript/Reference/Global_Objects/String/sub
-tags:
-  - Deprecated
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/sub
 ---
 {{JSRef}} {{deprecated_header}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/substr/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/substr/index.md
@@ -1,16 +1,6 @@
 ---
 title: String.prototype.substr()
 slug: Web/JavaScript/Reference/Global_Objects/String/substr
-tags:
-  - Deprecated
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-  - Polyfill
-browser-compat: javascript.builtins.String.substr
-translation_of: Web/JavaScript/Reference/Global_Objects/String/substr
 ---
 {{JSRef}} {{deprecated_header}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/substring/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/substring/index.md
@@ -1,13 +1,6 @@
 ---
 title: String.prototype.substring()
 slug: Web/JavaScript/Reference/Global_Objects/String/substring
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/substring
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/sup/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/sup/index.md
@@ -1,15 +1,6 @@
 ---
 title: String.prototype.sup()
 slug: Web/JavaScript/Reference/Global_Objects/String/sup
-tags:
-  - Deprecated
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/sup
 ---
 {{JSRef}} {{deprecated_header}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/tolocalelowercase/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/tolocalelowercase/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.toLocaleLowerCase()
 slug: Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase
-tags:
-  - Internationalization
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/tolocaleuppercase/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/tolocaleuppercase/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.toLocaleUpperCase()
 slug: Web/JavaScript/Reference/Global_Objects/String/toLocaleUpperCase
-tags:
-  - Internationalization
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/toLocaleUpperCase
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/tolowercase/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/tolowercase/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.toLowerCase()
 slug: Web/JavaScript/Reference/Global_Objects/String/toLowerCase
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-  - メソッド
-translation_of: Web/JavaScript/Reference/Global_Objects/String/toLowerCase
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/tostring/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/tostring/index.md
@@ -1,13 +1,6 @@
 ---
 title: String.prototype.toString()
 slug: Web/JavaScript/Reference/Global_Objects/String/toString
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/toString
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/touppercase/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/touppercase/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.toUpperCase()
 slug: Web/JavaScript/Reference/Global_Objects/String/toUpperCase
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-  - メソッド
-translation_of: Web/JavaScript/Reference/Global_Objects/String/toUpperCase
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/trim/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/trim/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.trim()
 slug: Web/JavaScript/Reference/Global_Objects/String/trim
-tags:
-  - ECMAScript 5
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/Trim
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/trimend/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/trimend/index.md
@@ -1,13 +1,6 @@
 ---
 title: String.prototype.trimEnd()
 slug: Web/JavaScript/Reference/Global_Objects/String/trimEnd
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/trimEnd
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/trimstart/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/trimstart/index.md
@@ -1,13 +1,6 @@
 ---
 title: String.prototype.trimStart()
 slug: Web/JavaScript/Reference/Global_Objects/String/trimStart
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/trimStart
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/string/valueof/index.md
+++ b/files/ja/web/javascript/reference/global_objects/string/valueof/index.md
@@ -1,13 +1,6 @@
 ---
 title: String.prototype.valueOf()
 slug: Web/JavaScript/Reference/Global_Objects/String/valueOf
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/valueOf
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/symbol/@@toprimitive/index.md
+++ b/files/ja/web/javascript/reference/global_objects/symbol/@@toprimitive/index.md
@@ -1,13 +1,6 @@
 ---
 title: Symbol.prototype[@@toPrimitive]
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/@@toPrimitive
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - Symbol
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/@@toPrimitive
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/symbol/asynciterator/index.md
+++ b/files/ja/web/javascript/reference/global_objects/symbol/asynciterator/index.md
@@ -1,14 +1,6 @@
 ---
 title: Symbol.asyncIterator
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator
-tags:
-  - ECMAScript 2018
-  - JavaScript
-  - Property
-  - Reference
-  - Symbol
-  - asynchronous
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/symbol/description/index.md
+++ b/files/ja/web/javascript/reference/global_objects/symbol/description/index.md
@@ -1,12 +1,6 @@
 ---
 title: Symbol.prototype.description
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/description
-tags:
-  - JavaScript
-  - Property
-  - Prototype
-  - Symbol
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/description
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/symbol/for/index.md
+++ b/files/ja/web/javascript/reference/global_objects/symbol/for/index.md
@@ -1,12 +1,6 @@
 ---
 title: Symbol.for()
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/for
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Symbol
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/for
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/symbol/hasinstance/index.md
+++ b/files/ja/web/javascript/reference/global_objects/symbol/hasinstance/index.md
@@ -1,13 +1,6 @@
 ---
 title: Symbol.hasInstance
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Property
-  - Reference
-  - Symbol
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/symbol/index.md
+++ b/files/ja/web/javascript/reference/global_objects/symbol/index.md
@@ -1,14 +1,6 @@
 ---
 title: Symbol (シンボル)
 slug: Web/JavaScript/Reference/Global_Objects/Symbol
-tags:
-  - データ型
-  - ECMAScript 2015
-  - 用語集
-  - JavaScript
-  - Sharing
-  - Symbol
-translation_of: Glossary/Symbol
 original_slug: Glossary/Symbol
 ---
 {{Glossary("JavaScript")}} では、シンボルは{{Glossary("Primitive", "プリミティブ値")}}です。

--- a/files/ja/web/javascript/reference/global_objects/symbol/isconcatspreadable/index.md
+++ b/files/ja/web/javascript/reference/global_objects/symbol/isconcatspreadable/index.md
@@ -1,12 +1,6 @@
 ---
 title: Symbol.isConcatSpreadable
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/isConcatSpreadable
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Property
-  - Symbol
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/isConcatSpreadable
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/symbol/iterator/index.md
+++ b/files/ja/web/javascript/reference/global_objects/symbol/iterator/index.md
@@ -1,14 +1,6 @@
 ---
 title: Symbol.iterator
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/iterator
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Property
-  - Symbol
-  - Polyfill
-browser-compat: javascript.builtins.Symbol.iterator
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/iterator
 ---
 <div>{{JSRef}}</div>
 

--- a/files/ja/web/javascript/reference/global_objects/symbol/keyfor/index.md
+++ b/files/ja/web/javascript/reference/global_objects/symbol/keyfor/index.md
@@ -1,12 +1,6 @@
 ---
 title: Symbol.keyFor()
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/keyFor
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Symbol
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/keyFor
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/symbol/match/index.md
+++ b/files/ja/web/javascript/reference/global_objects/symbol/match/index.md
@@ -1,12 +1,6 @@
 ---
 title: Symbol.match
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/match
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Property
-  - Symbol
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/match
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/symbol/matchall/index.md
+++ b/files/ja/web/javascript/reference/global_objects/symbol/matchall/index.md
@@ -1,12 +1,6 @@
 ---
 title: Symbol.matchAll
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/matchAll
-tags:
-  - JavaScript
-  - Property
-  - Reference
-  - Symbol
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/matchAll
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/symbol/replace/index.md
+++ b/files/ja/web/javascript/reference/global_objects/symbol/replace/index.md
@@ -1,12 +1,6 @@
 ---
 title: Symbol.replace
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/replace
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Property
-  - Symbol
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/replace
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/symbol/search/index.md
+++ b/files/ja/web/javascript/reference/global_objects/symbol/search/index.md
@@ -1,12 +1,6 @@
 ---
 title: Symbol.search
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/search
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Property
-  - Symbol
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/search
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/symbol/species/index.md
+++ b/files/ja/web/javascript/reference/global_objects/symbol/species/index.md
@@ -1,12 +1,6 @@
 ---
 title: Symbol.species
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/species
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Property
-  - Symbol
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/species
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/symbol/split/index.md
+++ b/files/ja/web/javascript/reference/global_objects/symbol/split/index.md
@@ -1,12 +1,6 @@
 ---
 title: Symbol.split
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/split
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Property
-  - Symbol
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/split
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/symbol/symbol/index.md
+++ b/files/ja/web/javascript/reference/global_objects/symbol/symbol/index.md
@@ -1,12 +1,6 @@
 ---
 title: Symbol() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/Symbol
-tags:
-  - Constructor
-  - JavaScript
-  - Reference
-  - Symbol
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/Symbol
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/symbol/toprimitive/index.md
+++ b/files/ja/web/javascript/reference/global_objects/symbol/toprimitive/index.md
@@ -1,12 +1,6 @@
 ---
 title: Symbol.toPrimitive
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Property
-  - Symbol
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/symbol/tostring/index.md
+++ b/files/ja/web/javascript/reference/global_objects/symbol/tostring/index.md
@@ -1,13 +1,6 @@
 ---
 title: Symbol.prototype.toString()
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/toString
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - Symbol
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/toString
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/symbol/tostringtag/index.md
+++ b/files/ja/web/javascript/reference/global_objects/symbol/tostringtag/index.md
@@ -1,15 +1,6 @@
 ---
 title: Symbol.toStringTag
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Property
-  - Reference
-  - Symbol
-  - シンボル
-  - プロパティ
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/symbol/unscopables/index.md
+++ b/files/ja/web/javascript/reference/global_objects/symbol/unscopables/index.md
@@ -1,12 +1,6 @@
 ---
 title: Symbol.unscopables
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/unscopables
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Property
-  - Symbol
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/unscopables
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/symbol/valueof/index.md
+++ b/files/ja/web/javascript/reference/global_objects/symbol/valueof/index.md
@@ -1,13 +1,6 @@
 ---
 title: Symbol.prototype.valueOf()
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/valueOf
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - Symbol
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/valueOf
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/syntaxerror/index.md
+++ b/files/ja/web/javascript/reference/global_objects/syntaxerror/index.md
@@ -1,13 +1,6 @@
 ---
 title: SyntaxError
 slug: Web/JavaScript/Reference/Global_Objects/SyntaxError
-tags:
-  - Error
-  - JavaScript
-  - Object
-  - Reference
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Global_Objects/SyntaxError
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/syntaxerror/syntaxerror/index.md
+++ b/files/ja/web/javascript/reference/global_objects/syntaxerror/syntaxerror/index.md
@@ -1,12 +1,6 @@
 ---
 title: SyntaxError() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/SyntaxError/SyntaxError
-tags:
-  - Constructor
-  - JavaScript
-  - Reference
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Global_Objects/SyntaxError/SyntaxError
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/@@iterator/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/@@iterator/index.md
@@ -1,15 +1,6 @@
 ---
 title: TypedArray.prototype[@@iterator]()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/@@iterator
-tags:
-  - Iterator
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/@@iterator
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/@@species/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/@@species/index.md
@@ -1,13 +1,6 @@
 ---
 title: get TypedArray[@@species]
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/@@species
-tags:
-  - JavaScript
-  - Property
-  - Prototype
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/@@species
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/buffer/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/buffer/index.md
@@ -1,13 +1,6 @@
 ---
 title: TypedArray.prototype.buffer
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/buffer
-tags:
-  - JavaScript
-  - Property
-  - Prototype
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/buffer
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/bytelength/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/bytelength/index.md
@@ -1,13 +1,6 @@
 ---
 title: TypedArray.prototype.byteLength
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/byteLength
-tags:
-  - JavaScript
-  - Property
-  - Prototype
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/byteLength
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/byteoffset/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/byteoffset/index.md
@@ -1,13 +1,6 @@
 ---
 title: TypedArray.prototype.byteOffset
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/byteOffset
-tags:
-  - JavaScript
-  - Property
-  - Prototype
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/byteOffset
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/bytes_per_element/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/bytes_per_element/index.md
@@ -1,12 +1,6 @@
 ---
 title: TypedArray.BYTES_PER_ELEMENT
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/BYTES_PER_ELEMENT
-tags:
-  - JavaScript
-  - Property
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/BYTES_PER_ELEMENT
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/copywithin/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/copywithin/index.md
@@ -1,14 +1,6 @@
 ---
 title: TypedArray.prototype.copyWithin()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - TypedArray
-  - メソッド
-  - 型付き配列
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/entries/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/entries/index.md
@@ -1,16 +1,6 @@
 ---
 title: TypedArray.prototype.entries()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/entries
-tags:
-  - ECMAScript 2015
-  - Iterator
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/entries
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/every/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/every/index.md
@@ -1,14 +1,6 @@
 ---
 title: TypedArray.prototype.every()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/every
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/every
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/fill/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/fill/index.md
@@ -1,14 +1,6 @@
 ---
 title: TypedArray.prototype.fill()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/fill
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/fill
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/filter/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/filter/index.md
@@ -1,14 +1,6 @@
 ---
 title: TypedArray.prototype.filter()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/filter
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/filter
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/find/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/find/index.md
@@ -1,15 +1,6 @@
 ---
 title: TypedArray.prototype.find()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/find
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/find
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/findindex/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/findindex/index.md
@@ -1,15 +1,6 @@
 ---
 title: TypedArray.prototype.findIndex()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/findIndex
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/findIndex
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/foreach/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/foreach/index.md
@@ -1,15 +1,6 @@
 ---
 title: TypedArray.prototype.forEach()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/forEach
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/forEach
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/from/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/from/index.md
@@ -1,14 +1,6 @@
 ---
 title: TypedArray.from()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/from
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - TypedArray
-  - TypedArrays
-  - from
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/from
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/includes/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/includes/index.md
@@ -1,15 +1,6 @@
 ---
 title: TypedArray.prototype.includes()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/includes
-tags:
-  - ECMAScript 2016
-  - JavaScript
-  - Method
-  - Prototype
-  - TypedArray
-  - メソッド
-  - 型付き配列
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/includes
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/index.md
@@ -1,12 +1,6 @@
 ---
 title: TypedArray
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray
-tags:
-  - Class
-  - JavaScript
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/indexof/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/indexof/index.md
@@ -1,15 +1,6 @@
 ---
 title: TypedArray.prototype.indexOf()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/indexOf
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - TypedArray
-  - メソッド
-  - 型付き配列
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/indexOf
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/join/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/join/index.md
@@ -1,14 +1,6 @@
 ---
 title: TypedArray.prototype.join()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/join
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/join
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/keys/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/keys/index.md
@@ -1,16 +1,6 @@
 ---
 title: TypedArray.prototype.keys()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/keys
-tags:
-  - ECMAScript 2015
-  - Iterator
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/keys
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/lastindexof/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/lastindexof/index.md
@@ -1,15 +1,6 @@
 ---
 title: TypedArray.prototype.lastIndexOf()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/lastIndexOf
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - TypedArray
-  - メソッド
-  - 型付き配列
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/lastIndexOf
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/length/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/length/index.md
@@ -1,13 +1,6 @@
 ---
 title: TypedArray.prototype.length
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/length
-tags:
-  - JavaScript
-  - Property
-  - Prototype
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/length
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/map/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/map/index.md
@@ -1,14 +1,6 @@
 ---
 title: TypedArray.prototype.map()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/map
-tags:
-  - ECMAScript6
-  - JavaScript
-  - Method
-  - Prototype
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/map
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/name/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/name/index.md
@@ -1,12 +1,6 @@
 ---
 title: TypedArray.name
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/name
-tags:
-  - JavaScript
-  - Property
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/name
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/of/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/of/index.md
@@ -1,13 +1,6 @@
 ---
 title: TypedArray.of()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/of
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/of
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/reduce/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/reduce/index.md
@@ -1,14 +1,6 @@
 ---
 title: TypedArray.prototype.reduce()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/reduce
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/reduce
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/reduceright/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/reduceright/index.md
@@ -1,14 +1,6 @@
 ---
 title: TypedArray.prototype.reduceRight()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/reduceRight
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/reduceRight
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/reverse/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/reverse/index.md
@@ -1,15 +1,6 @@
 ---
 title: TypedArray.prototype.reverse()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/reverse
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - TypedArray
-  - メソッド
-  - 型付き配列
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/reverse
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/set/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/set/index.md
@@ -1,14 +1,6 @@
 ---
 title: TypedArray.prototype.set()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/set
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - TypedArray
-  - メソッド
-  - 型付き配列
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/set
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/slice/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/slice/index.md
@@ -1,14 +1,6 @@
 ---
 title: TypedArray.prototype.slice()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/slice
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/slice
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/some/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/some/index.md
@@ -1,14 +1,6 @@
 ---
 title: TypedArray.prototype.some()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/some
-tags:
-  - ECMAScript6
-  - JavaScript
-  - Method
-  - Prototype
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/some
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/sort/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/sort/index.md
@@ -1,15 +1,6 @@
 ---
 title: TypedArray.prototype.sort()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/sort
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - TypedArray
-  - メソッド
-  - 型付き配列
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/sort
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/subarray/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/subarray/index.md
@@ -1,13 +1,6 @@
 ---
 title: TypedArray.prototype.subarray()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/subarray
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/subarray
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/tolocalestring/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/tolocalestring/index.md
@@ -1,14 +1,6 @@
 ---
 title: TypedArray.prototype.toLocaleString()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/toLocaleString
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/toLocaleString
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/tostring/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/tostring/index.md
@@ -1,13 +1,6 @@
 ---
 title: TypedArray.prototype.toString()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/toString
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - TypedArray
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/toString
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typedarray/values/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typedarray/values/index.md
@@ -1,15 +1,6 @@
 ---
 title: TypedArray.prototype.values()
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/values
-tags:
-  - ECMAScript6
-  - Iterator
-  - JavaScript
-  - Method
-  - Prototype
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/values
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typeerror/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typeerror/index.md
@@ -1,13 +1,6 @@
 ---
 title: TypeError
 slug: Web/JavaScript/Reference/Global_Objects/TypeError
-tags:
-  - Error
-  - JavaScript
-  - Object
-  - Reference
-  - TypeError
-translation_of: Web/JavaScript/Reference/Global_Objects/TypeError
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/typeerror/typeerror/index.md
+++ b/files/ja/web/javascript/reference/global_objects/typeerror/typeerror/index.md
@@ -1,12 +1,6 @@
 ---
 title: TypeError() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/TypeError/TypeError
-tags:
-  - Constructor
-  - JavaScript
-  - Reference
-  - TypeError
-translation_of: Web/JavaScript/Reference/Global_Objects/TypeError/TypeError
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/uint16array/index.md
+++ b/files/ja/web/javascript/reference/global_objects/uint16array/index.md
@@ -1,15 +1,6 @@
 ---
 title: Uint16Array
 slug: Web/JavaScript/Reference/Global_Objects/Uint16Array
-tags:
-  - クラス
-  - JavaScript
-  - TypedArray
-  - 型付き配列
-  - Uint16Array
-  - ポリフィル
-browser-compat: javascript.builtins.Uint16Array
-translation_of: Web/JavaScript/Reference/Global_Objects/Uint16Array
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/uint16array/uint16array/index.md
+++ b/files/ja/web/javascript/reference/global_objects/uint16array/uint16array/index.md
@@ -1,12 +1,6 @@
 ---
 title: Uint16Array() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/Uint16Array/Uint16Array
-tags:
-  - Constructor
-  - JavaScript
-  - Reference
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/Uint16Array/Uint16Array
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/uint32array/index.md
+++ b/files/ja/web/javascript/reference/global_objects/uint32array/index.md
@@ -1,15 +1,6 @@
 ---
 title: Uint32Array
 slug: Web/JavaScript/Reference/Global_Objects/Uint32Array
-tags:
-  - クラス
-  - JavaScript
-  - TypedArray
-  - 型付き配列
-  - Uint32Array
-  - ポリフィル
-browser-compat: javascript.builtins.Uint32Array
-translation_of: Web/JavaScript/Reference/Global_Objects/Uint32Array
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/uint32array/uint32array/index.md
+++ b/files/ja/web/javascript/reference/global_objects/uint32array/uint32array/index.md
@@ -1,12 +1,6 @@
 ---
 title: Uint32Array() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/Uint32Array/Uint32Array
-tags:
-  - Constructor
-  - JavaScript
-  - Reference
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/Uint32Array/Uint32Array
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/uint8array/index.md
+++ b/files/ja/web/javascript/reference/global_objects/uint8array/index.md
@@ -1,14 +1,6 @@
 ---
 title: Uint8Array
 slug: Web/JavaScript/Reference/Global_Objects/Uint8Array
-tags:
-  - クラス
-  - JavaScript
-  - TypedArray
-  - 型付き配列
-  - ポリフィル
-browser-compat: javascript.builtins.Uint8Array
-translation_of: Web/JavaScript/Reference/Global_Objects/Uint8Array
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/uint8array/uint8array/index.md
+++ b/files/ja/web/javascript/reference/global_objects/uint8array/uint8array/index.md
@@ -1,12 +1,6 @@
 ---
 title: Uint8Array() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/Uint8Array/Uint8Array
-tags:
-  - Constructor
-  - JavaScript
-  - Reference
-  - TypedArray
-translation_of: Web/JavaScript/Reference/Global_Objects/Uint8Array/Uint8Array
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/uint8clampedarray/index.md
+++ b/files/ja/web/javascript/reference/global_objects/uint8clampedarray/index.md
@@ -1,14 +1,6 @@
 ---
 title: Uint8ClampedArray
 slug: Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray
-tags:
-  - クラス
-  - JavaScript
-  - TypedArray
-  - 型付き配列
-  - ポリフィル
-browser-compat: javascript.builtins.Uint8ClampedArray
-translation_of: Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/uint8clampedarray/uint8clampedarray/index.md
+++ b/files/ja/web/javascript/reference/global_objects/uint8clampedarray/uint8clampedarray/index.md
@@ -1,12 +1,6 @@
 ---
 title: Uint8ClampedArray() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray/Uint8ClampedArray
-tags:
-  - Constructor
-  - JavaScript
-  - Reference
-  - TypedArray
-translation_of: Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray/Uint8ClampedArray
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/undefined/index.md
+++ b/files/ja/web/javascript/reference/global_objects/undefined/index.md
@@ -1,12 +1,6 @@
 ---
 title: undefined
 slug: Web/JavaScript/Reference/Global_Objects/undefined
-tags:
-  - JavaScript
-  - 言語機能
-  - リファレンス
-browser-compat: javascript.builtins.undefined
-translation_of: Web/JavaScript/Reference/Global_Objects/undefined
 ---
 {{jsSidebar("Objects")}}
 

--- a/files/ja/web/javascript/reference/global_objects/unescape/index.md
+++ b/files/ja/web/javascript/reference/global_objects/unescape/index.md
@@ -1,13 +1,6 @@
 ---
 title: unescape()
 slug: Web/JavaScript/Reference/Global_Objects/unescape
-tags:
-  - Deprecated
-  - JavaScript
-  - Method
-  - Polyfill
-browser-compat: javascript.builtins.unescape
-translation_of: Web/JavaScript/Reference/Global_Objects/unescape
 l10n:
   sourceCommit: 1931ea17c117b5eafa315c638e70429e500bdca9
 ---

--- a/files/ja/web/javascript/reference/global_objects/urierror/index.md
+++ b/files/ja/web/javascript/reference/global_objects/urierror/index.md
@@ -1,13 +1,6 @@
 ---
 title: URIError
 slug: Web/JavaScript/Reference/Global_Objects/URIError
-tags:
-  - Error
-  - JavaScript
-  - Object
-  - Reference
-  - URIError
-translation_of: Web/JavaScript/Reference/Global_Objects/URIError
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/urierror/urierror/index.md
+++ b/files/ja/web/javascript/reference/global_objects/urierror/urierror/index.md
@@ -1,12 +1,6 @@
 ---
 title: URIError() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/URIError/URIError
-tags:
-  - Constructor
-  - JavaScript
-  - Reference
-  - URIError
-translation_of: Web/JavaScript/Reference/Global_Objects/URIError/URIError
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/weakmap/delete/index.md
+++ b/files/ja/web/javascript/reference/global_objects/weakmap/delete/index.md
@@ -1,13 +1,6 @@
 ---
 title: WeakMap.prototype.delete()
 slug: Web/JavaScript/Reference/Global_Objects/WeakMap/delete
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - WeakMap
-translation_of: Web/JavaScript/Reference/Global_Objects/WeakMap/delete
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/weakmap/get/index.md
+++ b/files/ja/web/javascript/reference/global_objects/weakmap/get/index.md
@@ -1,13 +1,6 @@
 ---
 title: WeakMap.prototype.get()
 slug: Web/JavaScript/Reference/Global_Objects/WeakMap/get
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - WeakMap
-translation_of: Web/JavaScript/Reference/Global_Objects/WeakMap/get
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/weakmap/has/index.md
+++ b/files/ja/web/javascript/reference/global_objects/weakmap/has/index.md
@@ -1,13 +1,6 @@
 ---
 title: WeakMap.prototype.has()
 slug: Web/JavaScript/Reference/Global_Objects/WeakMap/has
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - WeakMap
-translation_of: Web/JavaScript/Reference/Global_Objects/WeakMap/has
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/weakmap/index.md
+++ b/files/ja/web/javascript/reference/global_objects/weakmap/index.md
@@ -1,13 +1,6 @@
 ---
 title: WeakMap
 slug: Web/JavaScript/Reference/Global_Objects/WeakMap
-tags:
-  - Class
-  - ECMAScript 2015
-  - JavaScript
-  - Reference
-  - WeakMap
-translation_of: Web/JavaScript/Reference/Global_Objects/WeakMap
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/weakmap/set/index.md
+++ b/files/ja/web/javascript/reference/global_objects/weakmap/set/index.md
@@ -1,13 +1,6 @@
 ---
 title: WeakMap.prototype.set()
 slug: Web/JavaScript/Reference/Global_Objects/WeakMap/set
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - WeakMap
-translation_of: Web/JavaScript/Reference/Global_Objects/WeakMap/set
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/weakmap/weakmap/index.md
+++ b/files/ja/web/javascript/reference/global_objects/weakmap/weakmap/index.md
@@ -1,12 +1,6 @@
 ---
 title: WeakMap() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/WeakMap/WeakMap
-tags:
-  - Constructor
-  - JavaScript
-  - Reference
-  - WeakMap
-translation_of: Web/JavaScript/Reference/Global_Objects/WeakMap/WeakMap
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/weakref/deref/index.md
+++ b/files/ja/web/javascript/reference/global_objects/weakref/deref/index.md
@@ -1,14 +1,6 @@
 ---
 title: WeakRef.prototype.deref()
 slug: Web/JavaScript/Reference/Global_Objects/WeakRef/deref
-tags:
-  - JavaScript
-  - メソッド
-  - プロトタイプ
-  - Reference
-  - WeakRef
-browser-compat: javascript.builtins.WeakRef.deref
-translation_of: Web/JavaScript/Reference/Global_Objects/WeakRef/deref
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/weakref/index.md
+++ b/files/ja/web/javascript/reference/global_objects/weakref/index.md
@@ -1,14 +1,6 @@
 ---
 title: WeakRef
 slug: Web/JavaScript/Reference/Global_Objects/WeakRef
-tags:
-  - Class
-  - JavaScript
-  - NeedsTranslation
-  - Reference
-  - TopicStub
-  - WeakRef
-translation_of: Web/JavaScript/Reference/Global_Objects/WeakRef
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/weakref/weakref/index.md
+++ b/files/ja/web/javascript/reference/global_objects/weakref/weakref/index.md
@@ -1,13 +1,6 @@
 ---
 title: WeakRef() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/WeakRef/WeakRef
-tags:
-  - Constructor
-  - JavaScript
-  - Reference
-  - WeakRef
-  - コンストラクター
-translation_of: Web/JavaScript/Reference/Global_Objects/WeakRef/WeakRef
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/weakset/add/index.md
+++ b/files/ja/web/javascript/reference/global_objects/weakset/add/index.md
@@ -1,13 +1,6 @@
 ---
 title: WeakSet.prototype.add()
 slug: Web/JavaScript/Reference/Global_Objects/WeakSet/add
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - WeakSet
-translation_of: Web/JavaScript/Reference/Global_Objects/WeakSet/add
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/weakset/delete/index.md
+++ b/files/ja/web/javascript/reference/global_objects/weakset/delete/index.md
@@ -1,13 +1,6 @@
 ---
 title: WeakSet.prototype.delete()
 slug: Web/JavaScript/Reference/Global_Objects/WeakSet/delete
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - WeakSet
-translation_of: Web/JavaScript/Reference/Global_Objects/WeakSet/delete
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/weakset/has/index.md
+++ b/files/ja/web/javascript/reference/global_objects/weakset/has/index.md
@@ -1,13 +1,6 @@
 ---
 title: WeakSet.prototype.has()
 slug: Web/JavaScript/Reference/Global_Objects/WeakSet/has
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototype
-  - WeakSet
-translation_of: Web/JavaScript/Reference/Global_Objects/WeakSet/has
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/weakset/index.md
+++ b/files/ja/web/javascript/reference/global_objects/weakset/index.md
@@ -1,12 +1,6 @@
 ---
 title: WeakSet
 slug: Web/JavaScript/Reference/Global_Objects/WeakSet
-tags:
-  - Class
-  - ECMAScript 2015
-  - JavaScript
-  - WeakSet
-translation_of: Web/JavaScript/Reference/Global_Objects/WeakSet
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/weakset/weakset/index.md
+++ b/files/ja/web/javascript/reference/global_objects/weakset/weakset/index.md
@@ -1,12 +1,6 @@
 ---
 title: WeakSet() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/WeakSet/WeakSet
-tags:
-  - Constructor
-  - JavaScript
-  - Reference
-  - WeakSet
-translation_of: Web/JavaScript/Reference/Global_Objects/WeakSet/WeakSet
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/compile/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/compile/index.md
@@ -1,16 +1,6 @@
 ---
 title: WebAssembly.compile()
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/compile
-tags:
-  - API
-  - JavaScript
-  - Method
-  - Object
-  - Reference
-  - WebAssembly
-  - compile
-browser-compat: javascript.builtins.WebAssembly.compile
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/compile
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/compileerror/compileerror/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/compileerror/compileerror/index.md
@@ -1,13 +1,6 @@
 ---
 title: WebAssembly.CompileError() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError/CompileError
-tags:
-  - Constructor
-  - JavaScript
-  - Reference
-  - WebAssembly
-browser-compat: javascript.builtins.WebAssembly.CompileError.CompileError
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError/CompileError
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/compileerror/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/compileerror/index.md
@@ -1,16 +1,6 @@
 ---
 title: WebAssembly.CompileError
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError
-tags:
-  - API
-  - Class
-  - CompileError
-  - JavaScript
-  - NativeError
-  - Reference
-  - WebAssembly
-browser-compat: javascript.builtins.WebAssembly.CompileError
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/compilestreaming/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/compilestreaming/index.md
@@ -1,18 +1,6 @@
 ---
 title: WebAssembly.compileStreaming()
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/compileStreaming
-tags:
-  - API
-  - JavaScript
-  - Method
-  - Object
-  - Reference
-  - WebAssembly
-  - compile
-  - compileStreaming
-  - streaming
-browser-compat: javascript.builtins.WebAssembly.compileStreaming
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/compileStreaming
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/global/global/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/global/global/index.md
@@ -1,13 +1,6 @@
 ---
 title: WebAssembly.Global() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Global/Global
-tags:
-  - Constructor
-  - JavaScript
-  - Reference
-  - WebAssembly
-browser-compat: javascript.builtins.WebAssembly.Global.Global
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Global/Global
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/global/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/global/index.md
@@ -1,13 +1,6 @@
 ---
 title: WebAssembly.Global
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Global
-tags:
-  - Class
-  - JavaScript
-  - Reference
-  - WebAssembly
-browser-compat: javascript.builtins.WebAssembly.Global
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Global
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/index.md
@@ -1,15 +1,6 @@
 ---
 title: WebAssembly
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly
-tags:
-  - API
-  - JavaScript
-  - Namespace
-  - Object
-  - Reference
-  - WebAssembly
-browser-compat: javascript.builtins.WebAssembly
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/instance/exports/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/instance/exports/index.md
@@ -1,15 +1,6 @@
 ---
 title: WebAssembly.Instance.prototype.exports
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/exports
-tags:
-  - API
-  - JavaScript
-  - プロパティ
-  - リファレンス
-  - WebAssembly
-  - exports
-  - instance
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/exports
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/instance/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/instance/index.md
@@ -1,13 +1,6 @@
 ---
 title: WebAssembly.Instance
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance
-tags:
-  - クラス
-  - JavaScript
-  - リファレンス
-  - WebAssembly
-browser-compat: javascript.builtins.WebAssembly.Instance
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/instance/instance/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/instance/instance/index.md
@@ -1,13 +1,6 @@
 ---
 title: WebAssembly.Instance() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/Instance
-tags:
-  - コンストラクター
-  - JavaScript
-  - Reference
-  - WebAssembly
-browser-compat: javascript.builtins.WebAssembly.Instance.Instance
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/Instance
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/instantiate/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/instantiate/index.md
@@ -1,17 +1,6 @@
 ---
 title: WebAssembly.instantiate()
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiate
-tags:
-  - API
-  - JavaScript
-  - Method
-  - Object
-  - Reference
-  - WebAssembly
-  - instantiate
-  - オブジェクト
-  - メソッド
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiate
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/instantiatestreaming/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/instantiatestreaming/index.md
@@ -1,18 +1,6 @@
 ---
 title: WebAssembly.instantiateStreaming()
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming
-tags:
-  - API
-  - JavaScript
-  - Method
-  - Object
-  - Reference
-  - WebAssembly
-  - instantiate
-  - instantiateStreaming
-  - streaming
-browser-compat: javascript.builtins.WebAssembly.instantiateStreaming
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/linkerror/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/linkerror/index.md
@@ -1,15 +1,6 @@
 ---
 title: WebAssembly.LinkError
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/LinkError
-tags:
-  - API
-  - Class
-  - JavaScript
-  - LinkError
-  - Reference
-  - WebAssembly
-browser-compat: javascript.builtins.WebAssembly.LinkError
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/LinkError
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/linkerror/linkerror/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/linkerror/linkerror/index.md
@@ -1,13 +1,6 @@
 ---
 title: WebAssembly.LinkError() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/LinkError/LinkError
-tags:
-  - Constructor
-  - JavaScript
-  - Reference
-  - WebAssembly
-browser-compat: javascript.builtins.WebAssembly.LinkError.LinkError
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/LinkError/LinkError
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/memory/buffer/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/memory/buffer/index.md
@@ -1,16 +1,6 @@
 ---
 title: WebAssembly.Memory.prototype.buffer
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/buffer
-tags:
-  - API
-  - Buffer
-  - JavaScript
-  - プロパティ
-  - Reference
-  - WebAssembly
-  - memory
-browser-compat: javascript.builtins.WebAssembly.Memory.buffer
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/buffer
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/memory/grow/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/memory/grow/index.md
@@ -1,16 +1,6 @@
 ---
 title: WebAssembly.Memory.prototype.grow()
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/grow
-tags:
-  - API
-  - JavaScript
-  - メソッド
-  - Reference
-  - WebAssembly
-  - grow
-  - memory
-browser-compat: javascript.builtins.WebAssembly.Memory.grow
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/grow
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/memory/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/memory/index.md
@@ -1,13 +1,6 @@
 ---
 title: WebAssembly.Memory()
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory
-tags:
-  - クラス
-  - JavaScript
-  - Reference
-  - WebAssembly
-browser-compat: javascript.builtins.WebAssembly.Memory
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/memory/memory/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/memory/memory/index.md
@@ -1,13 +1,6 @@
 ---
 title: WebAssembly.Memory() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/Memory
-tags:
-  - コンストラクター
-  - JavaScript
-  - Reference
-  - WebAssembly
-browser-compat: javascript.builtins.WebAssembly.Memory.Memory
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/Memory
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/module/customsections/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/module/customsections/index.md
@@ -1,17 +1,6 @@
 ---
 title: WebAssembly.Module.customSections()
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/customSections
-tags:
-  - API
-  - JavaScript
-  - Method
-  - Module
-  - Object
-  - Reference
-  - WebAssembly
-  - customSections
-browser-compat: javascript.builtins.WebAssembly.Module.customSections
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/customSections
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/module/exports/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/module/exports/index.md
@@ -1,17 +1,6 @@
 ---
 title: WebAssembly.Module.exports()
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/exports
-tags:
-  - API
-  - JavaScript
-  - Method
-  - Module
-  - Object
-  - Reference
-  - WebAssembly
-  - exports
-browser-compat: javascript.builtins.WebAssembly.Module.exports
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/exports
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/module/imports/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/module/imports/index.md
@@ -1,17 +1,6 @@
 ---
 title: WebAssembly.Module.imports()
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/imports
-tags:
-  - API
-  - JavaScript
-  - メソッド
-  - Module
-  - Object
-  - Reference
-  - WebAssembly
-  - imports
-browser-compat: javascript.builtins.WebAssembly.Module.imports
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/imports
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/module/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/module/index.md
@@ -1,14 +1,6 @@
 ---
 title: WebAssembly.Module
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module
-tags:
-  - Class
-  - JavaScript
-  - Module
-  - Reference
-  - WebAssembly
-browser-compat: javascript.builtins.WebAssembly.Module
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/module/module/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/module/module/index.md
@@ -1,14 +1,6 @@
 ---
 title: WebAssembly.Module() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/Module
-tags:
-  - Constructor
-  - JavaScript
-  - Module
-  - Reference
-  - WebAssembly
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/Module
-browser-compat: javascript.builtins.WebAssembly.Module.Module
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/runtimeerror/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/runtimeerror/index.md
@@ -1,15 +1,6 @@
 ---
 title: WebAssembly.RuntimeError
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError
-tags:
-  - API
-  - Class
-  - JavaScript
-  - Reference
-  - RuntimeError
-  - WebAssembly
-browser-compat: javascript.builtins.WebAssembly.RuntimeError
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/runtimeerror/runtimeerror/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/runtimeerror/runtimeerror/index.md
@@ -1,13 +1,6 @@
 ---
 title: WebAssembly.RuntimeError() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError/RuntimeError
-tags:
-  - Constructor
-  - JavaScript
-  - Reference
-  - WebAssembly
-browser-compat: javascript.builtins.WebAssembly.RuntimeError.RuntimeError
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError/RuntimeError
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/table/get/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/table/get/index.md
@@ -1,16 +1,6 @@
 ---
 title: WebAssembly.Table.prototype.get()
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/get
-tags:
-  - API
-  - JavaScript
-  - メソッド
-  - Reference
-  - WebAssembly
-  - get
-  - table
-browser-compat: javascript.builtins.WebAssembly.Table.get
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/get
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/table/grow/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/table/grow/index.md
@@ -1,16 +1,6 @@
 ---
 title: WebAssembly.Table.prototype.grow()
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/grow
-tags:
-  - API
-  - JavaScript
-  - メソッド
-  - Reference
-  - WebAssembly
-  - grow
-  - table
-browser-compat: javascript.builtins.WebAssembly.Table.grow
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/grow
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/table/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/table/index.md
@@ -1,14 +1,6 @@
 ---
 title: WebAssembly.Table
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table
-tags:
-  - Class
-  - JavaScript
-  - Reference
-  - WebAssembly
-  - table
-browser-compat: javascript.builtins.WebAssembly.Table
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/table/length/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/table/length/index.md
@@ -1,16 +1,6 @@
 ---
 title: WebAssembly.Table.prototype.length
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/length
-tags:
-  - API
-  - JavaScript
-  - プロパティ
-  - Reference
-  - WebAssembly
-  - length
-  - table
-browser-compat: javascript.builtins.WebAssembly.Table.length
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/length
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/table/set/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/table/set/index.md
@@ -1,16 +1,6 @@
 ---
 title: WebAssembly.Table.prototype.set()
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/set
-tags:
-  - API
-  - JavaScript
-  - メソッド
-  - Reference
-  - WebAssembly
-  - set
-  - table
-browser-compat: javascript.builtins.WebAssembly.Table.set
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/set
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/table/table/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/table/table/index.md
@@ -1,13 +1,6 @@
 ---
 title: WebAssembly.Table() コンストラクター
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/Table
-tags:
-  - コンストラクター
-  - JavaScript
-  - Reference
-  - WebAssembly
-browser-compat: javascript.builtins.WebAssembly.Table.Table
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/Table
 ---
 {{JSRef}}
 

--- a/files/ja/web/javascript/reference/global_objects/webassembly/validate/index.md
+++ b/files/ja/web/javascript/reference/global_objects/webassembly/validate/index.md
@@ -1,16 +1,6 @@
 ---
 title: WebAssembly.validate()
 slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/validate
-tags:
-  - API
-  - JavaScript
-  - Method
-  - Object
-  - Reference
-  - WebAssembly
-  - validate
-browser-compat: javascript.builtins.WebAssembly.validate
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/validate
 ---
 {{JSRef}}
 


### PR DESCRIPTION
Part of #7858

`web/javascript/global_objects/{k..z}*` から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "tags": 381,
  "translation_of": 380,
  "browser-compat": 123
}
```
