### PR TITLE
remove duplicated frontmatter keys from web/javascript/reference/* (ja)

### DIFF
--- a/files/ja/web/javascript/reference/about/index.md
+++ b/files/ja/web/javascript/reference/about/index.md
@@ -1,10 +1,6 @@
 ---
 title: JavaScript リファレンスについて
 slug: Web/JavaScript/Reference/About
-tags:
-  - ガイド
-  - JavaScript
-translation_of: Web/JavaScript/Reference/About
 ---
 {{JsSidebar}}
 

--- a/files/ja/web/javascript/reference/classes/constructor/index.md
+++ b/files/ja/web/javascript/reference/classes/constructor/index.md
@@ -1,12 +1,6 @@
 ---
 title: コンストラクター
 slug: Web/JavaScript/Reference/Classes/constructor
-tags:
-  - Classes
-  - ECMAScript 2015
-  - JavaScript
-  - Language feature
-translation_of: Web/JavaScript/Reference/Classes/constructor
 ---
 {{jsSidebar("Classes")}}
 

--- a/files/ja/web/javascript/reference/classes/extends/index.md
+++ b/files/ja/web/javascript/reference/classes/extends/index.md
@@ -1,12 +1,6 @@
 ---
 title: extends
 slug: Web/JavaScript/Reference/Classes/extends
-tags:
-  - Classes
-  - ECMAScript 2015
-  - JavaScript
-  - Language feature
-translation_of: Web/JavaScript/Reference/Classes/extends
 ---
 {{jsSidebar("Classes")}}
 

--- a/files/ja/web/javascript/reference/classes/index.md
+++ b/files/ja/web/javascript/reference/classes/index.md
@@ -1,16 +1,6 @@
 ---
 title: クラス
 slug: Web/JavaScript/Reference/Classes
-tags:
-  - クラス
-  - コンストラクター
-  - ECMAScript 2015
-  - ガイド
-  - 継承
-  - 中級者
-  - JavaScript
-browser-compat: javascript.classes
-translation_of: Web/JavaScript/Reference/Classes
 ---
 {{JsSidebar("Classes")}}
 

--- a/files/ja/web/javascript/reference/classes/private_class_fields/index.md
+++ b/files/ja/web/javascript/reference/classes/private_class_fields/index.md
@@ -1,12 +1,6 @@
 ---
 title: プライベートクラス機能
 slug: Web/JavaScript/Reference/Classes/Private_class_fields
-tags:
-  - Classes
-  - Private
-  - JavaScript
-  - Language feature
-translation_of: Web/JavaScript/Reference/Classes/Private_class_fields
 ---
 {{JsSidebar("Classes")}}
 

--- a/files/ja/web/javascript/reference/classes/public_class_fields/index.md
+++ b/files/ja/web/javascript/reference/classes/public_class_fields/index.md
@@ -1,11 +1,6 @@
 ---
 title: パブリッククラスフィールド
 slug: Web/JavaScript/Reference/Classes/Public_class_fields
-tags:
-  - Classes
-  - JavaScript
-  - Language feature
-translation_of: Web/JavaScript/Reference/Classes/Public_class_fields
 ---
 {{JsSidebar("Classes")}}
 

--- a/files/ja/web/javascript/reference/classes/static/index.md
+++ b/files/ja/web/javascript/reference/classes/static/index.md
@@ -1,13 +1,6 @@
 ---
 title: static
 slug: Web/JavaScript/Reference/Classes/static
-tags:
-  - Classes
-  - ECMAScript 2015
-  - JavaScript
-  - Language feature
-  - Static
-translation_of: Web/JavaScript/Reference/Classes/static
 ---
 {{jsSidebar("Classes")}}
 

--- a/files/ja/web/javascript/reference/deprecated_and_obsolete_features/index.md
+++ b/files/ja/web/javascript/reference/deprecated_and_obsolete_features/index.md
@@ -1,12 +1,6 @@
 ---
 title: 非推奨の機能、廃止された機能
 slug: Web/JavaScript/Reference/Deprecated_and_obsolete_features
-tags:
-  - 非推奨
-  - ガイド
-  - JavaScript
-  - 廃止
-translation_of: Web/JavaScript/Reference/Deprecated_and_obsolete_features
 ---
 {{JsSidebar("More")}}
 

--- a/files/ja/web/javascript/reference/deprecated_and_obsolete_features/the_legacy_iterator_protocol/index.md
+++ b/files/ja/web/javascript/reference/deprecated_and_obsolete_features/the_legacy_iterator_protocol/index.md
@@ -1,14 +1,6 @@
 ---
 title: 古い反復子プロトコル
-slug: >-
-  Web/JavaScript/Reference/Deprecated_and_obsolete_features/The_legacy_Iterator_protocol
-tags:
-  - ES2015
-  - ガイド
-  - JavaScript
-  - 古い反復子
-translation_of: >-
-  Web/JavaScript/Reference/Deprecated_and_obsolete_features/The_legacy_Iterator_protocol
+slug: Web/JavaScript/Reference/Deprecated_and_obsolete_features/The_legacy_Iterator_protocol
 ---
 {{jsSidebar("More")}}
 

--- a/files/ja/web/javascript/reference/errors/already_has_pragma/index.md
+++ b/files/ja/web/javascript/reference/errors/already_has_pragma/index.md
@@ -1,13 +1,7 @@
 ---
-title: 'Warning: -file- is being assigned a //# sourceMappingURL, but already has one'
+title: 'Warning: -file- is being assigned a //# sourceMappingURL, but already has
+  one'
 slug: Web/JavaScript/Reference/Errors/Already_has_pragma
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - Source maps
-  - Warning
-translation_of: Web/JavaScript/Reference/Errors/Already_has_pragma
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/array_sort_argument/index.md
+++ b/files/ja/web/javascript/reference/errors/array_sort_argument/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'TypeError: invalid Array.prototype.sort argument'
 slug: Web/JavaScript/Reference/Errors/Array_sort_argument
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - TypeError
-translation_of: Web/JavaScript/Reference/Errors/Array_sort_argument
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/bad_octal/index.md
+++ b/files/ja/web/javascript/reference/errors/bad_octal/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'Warning: 08/09 is not a legal ECMA-262 octal constant'
 slug: Web/JavaScript/Reference/Errors/Bad_octal
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - SyntaxError
-  - Warning
-translation_of: Web/JavaScript/Reference/Errors/Bad_octal
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/bad_radix/index.md
+++ b/files/ja/web/javascript/reference/errors/bad_radix/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'RangeError: radix must be an integer'
 slug: Web/JavaScript/Reference/Errors/Bad_radix
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - RangeError
-translation_of: Web/JavaScript/Reference/Errors/Bad_radix
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/bad_regexp_flag/index.md
+++ b/files/ja/web/javascript/reference/errors/bad_regexp_flag/index.md
@@ -1,11 +1,6 @@
 ---
 title: 'SyntaxError: invalid regular expression flag "x"'
 slug: Web/JavaScript/Reference/Errors/Bad_regexp_flag
-tags:
-  - Error
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Bad_regexp_flag
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/bad_return_or_yield/index.md
+++ b/files/ja/web/javascript/reference/errors/bad_return_or_yield/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'SyntaxError: return not in function'
 slug: Web/JavaScript/Reference/Errors/Bad_return_or_yield
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Bad_return_or_yield
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/called_on_incompatible_type/index.md
+++ b/files/ja/web/javascript/reference/errors/called_on_incompatible_type/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'TypeError: X.prototype.y called on incompatible type'
 slug: Web/JavaScript/Reference/Errors/Called_on_incompatible_type
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - TypeError
-translation_of: Web/JavaScript/Reference/Errors/Called_on_incompatible_type
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/cant_access_lexical_declaration_before_init/index.md
+++ b/files/ja/web/javascript/reference/errors/cant_access_lexical_declaration_before_init/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'ReferenceError: can''t access lexical declaration`X'' before initialization'
 slug: Web/JavaScript/Reference/Errors/Cant_access_lexical_declaration_before_init
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - ReferenceError
-translation_of: Web/JavaScript/Reference/Errors/Cant_access_lexical_declaration_before_init
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/cant_assign_to_property/index.md
+++ b/files/ja/web/javascript/reference/errors/cant_assign_to_property/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'TypeError: can''t assign to property "x" on "y": not an object'
 slug: Web/JavaScript/Reference/Errors/Cant_assign_to_property
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - TypeError
-translation_of: Web/JavaScript/Reference/Errors/Cant_assign_to_property
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/cant_define_property_object_not_extensible/index.md
+++ b/files/ja/web/javascript/reference/errors/cant_define_property_object_not_extensible/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'TypeError: can''t define property "x": "obj" is not extensible'
 slug: Web/JavaScript/Reference/Errors/Cant_define_property_object_not_extensible
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - TypeError
-translation_of: Web/JavaScript/Reference/Errors/Cant_define_property_object_not_extensible
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/cant_delete/index.md
+++ b/files/ja/web/javascript/reference/errors/cant_delete/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'TypeError: property "x" is non-configurable and can''t be deleted'
 slug: Web/JavaScript/Reference/Errors/Cant_delete
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - Strict Mode
-  - TypeError
-translation_of: Web/JavaScript/Reference/Errors/Cant_delete
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/cant_redefine_property/index.md
+++ b/files/ja/web/javascript/reference/errors/cant_redefine_property/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'TypeError: can''t redefine non-configurable property "x"'
 slug: Web/JavaScript/Reference/Errors/Cant_redefine_property
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - TypeError
-translation_of: Web/JavaScript/Reference/Errors/Cant_redefine_property
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/cyclic_object_value/index.md
+++ b/files/ja/web/javascript/reference/errors/cyclic_object_value/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'TypeError: cyclic object value'
 slug: Web/JavaScript/Reference/Errors/Cyclic_object_value
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - TypeError
-translation_of: Web/JavaScript/Reference/Errors/Cyclic_object_value
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/dead_object/index.md
+++ b/files/ja/web/javascript/reference/errors/dead_object/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'TypeError: can''t access dead object'
 slug: Web/JavaScript/Reference/Errors/Dead_object
-tags:
-  - Addons
-  - Error
-  - Errors
-  - JavaScript
-translation_of: Web/JavaScript/Reference/Errors/Dead_object
 ---
 {{JSSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/delete_in_strict_mode/index.md
+++ b/files/ja/web/javascript/reference/errors/delete_in_strict_mode/index.md
@@ -1,14 +1,6 @@
 ---
-title: >-
-  SyntaxError: applying the 'delete' operator to an unqualified name is
-  deprecated
+title: 'SyntaxError: applying the ''delete'' operator to an unqualified name is deprecated'
 slug: Web/JavaScript/Reference/Errors/Delete_in_strict_mode
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Delete_in_strict_mode
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/deprecated_caller_or_arguments_usage/index.md
+++ b/files/ja/web/javascript/reference/errors/deprecated_caller_or_arguments_usage/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'ReferenceError: deprecated caller or arguments usage'
 slug: Web/JavaScript/Reference/Errors/Deprecated_caller_or_arguments_usage
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - Strict Mode
-  - Warning
-translation_of: Web/JavaScript/Reference/Errors/Deprecated_caller_or_arguments_usage
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/deprecated_expression_closures/index.md
+++ b/files/ja/web/javascript/reference/errors/deprecated_expression_closures/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'Warning: expression closures are deprecated'
 slug: Web/JavaScript/Reference/Errors/Deprecated_expression_closures
-tags:
-  - JavaScript
-  - Warning
-  - エラー
-  - 警告
-translation_of: Web/JavaScript/Reference/Errors/Deprecated_expression_closures
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/deprecated_octal/index.md
+++ b/files/ja/web/javascript/reference/errors/deprecated_octal/index.md
@@ -1,11 +1,6 @@
 ---
 title: 'SyntaxError: "0"-prefixed octal literals and octal escape seq. are deprecated'
 slug: Web/JavaScript/Reference/Errors/Deprecated_octal
-tags:
-  - Error
-  - Errors
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Deprecated_octal
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/deprecated_source_map_pragma/index.md
+++ b/files/ja/web/javascript/reference/errors/deprecated_source_map_pragma/index.md
@@ -1,14 +1,7 @@
 ---
-title: >-
-  SyntaxError: Using //@ to indicate sourceURL pragmas is deprecated. Use //#
-  instead
+title: 'SyntaxError: Using //@ to indicate sourceURL pragmas is deprecated. Use //#
+  instead'
 slug: Web/JavaScript/Reference/Errors/Deprecated_source_map_pragma
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - Source maps
-translation_of: Web/JavaScript/Reference/Errors/Deprecated_source_map_pragma
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/deprecated_string_generics/index.md
+++ b/files/ja/web/javascript/reference/errors/deprecated_string_generics/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'Warning: String.x is deprecated; use String.prototype.x instead'
 slug: Web/JavaScript/Reference/Errors/Deprecated_String_generics
-tags:
-  - JavaScript
-  - Warning
-  - エラー
-  - 警告
-translation_of: Web/JavaScript/Reference/Errors/Deprecated_String_generics
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/deprecated_tolocaleformat/index.md
+++ b/files/ja/web/javascript/reference/errors/deprecated_tolocaleformat/index.md
@@ -1,11 +1,6 @@
 ---
 title: 'Warning: Date.prototype.toLocaleFormat is deprecated'
 slug: Web/JavaScript/Reference/Errors/Deprecated_toLocaleFormat
-tags:
-  - Error
-  - JavaScript
-  - Warning
-translation_of: Web/JavaScript/Reference/Errors/Deprecated_toLocaleFormat
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/equal_as_assign/index.md
+++ b/files/ja/web/javascript/reference/errors/equal_as_assign/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'SyntaxError: test for equality (==) mistyped as assignment (=)?'
 slug: Web/JavaScript/Reference/Errors/Equal_as_assign
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Equal_as_assign
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/getter_only/index.md
+++ b/files/ja/web/javascript/reference/errors/getter_only/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'TypeError: setting getter-only property "x"'
 slug: Web/JavaScript/Reference/Errors/Getter_only
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - Strict Mode
-  - TypeError
-translation_of: Web/JavaScript/Reference/Errors/Getter_only
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/identifier_after_number/index.md
+++ b/files/ja/web/javascript/reference/errors/identifier_after_number/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'SyntaxError: identifier starts immediately after numeric literal'
 slug: Web/JavaScript/Reference/Errors/Identifier_after_number
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Identifier_after_number
 ---
 {{JSSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/illegal_character/index.md
+++ b/files/ja/web/javascript/reference/errors/illegal_character/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'SyntaxError: illegal character'
 slug: Web/JavaScript/Reference/Errors/Illegal_character
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Illegal_character
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/in_operator_no_object/index.md
+++ b/files/ja/web/javascript/reference/errors/in_operator_no_object/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'TypeError: cannot use ''in'' operator to search for ''x'' in ''y'''
 slug: Web/JavaScript/Reference/Errors/in_operator_no_object
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - TypeError
-translation_of: Web/JavaScript/Reference/Errors/in_operator_no_object
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/index.md
+++ b/files/ja/web/javascript/reference/errors/index.md
@@ -1,14 +1,6 @@
 ---
 title: JavaScript エラーリファレンス
 slug: Web/JavaScript/Reference/Errors
-tags:
-  - Debugging
-  - Error
-  - Errors
-  - Exception
-  - JavaScript
-  - exceptions
-translation_of: Web/JavaScript/Reference/Errors
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/invalid_array_length/index.md
+++ b/files/ja/web/javascript/reference/errors/invalid_array_length/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'RangeError: invalid array length'
 slug: Web/JavaScript/Reference/Errors/Invalid_array_length
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - RangeError
-translation_of: Web/JavaScript/Reference/Errors/Invalid_array_length
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.md
+++ b/files/ja/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'ReferenceError: invalid assignment left-hand side'
 slug: Web/JavaScript/Reference/Errors/Invalid_assignment_left-hand_side
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - ReferenceError
-translation_of: Web/JavaScript/Reference/Errors/Invalid_assignment_left-hand_side
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/invalid_const_assignment/index.md
+++ b/files/ja/web/javascript/reference/errors/invalid_const_assignment/index.md
@@ -1,11 +1,6 @@
 ---
 title: 'TypeError: invalid assignment to const "x"'
 slug: Web/JavaScript/Reference/Errors/Invalid_const_assignment
-tags:
-  - Error
-  - JavaScript
-  - TypeError
-translation_of: Web/JavaScript/Reference/Errors/Invalid_const_assignment
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/invalid_date/index.md
+++ b/files/ja/web/javascript/reference/errors/invalid_date/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'RangeError: invalid date'
 slug: Web/JavaScript/Reference/Errors/Invalid_date
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - RangeError
-translation_of: Web/JavaScript/Reference/Errors/Invalid_date
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/invalid_for-in_initializer/index.md
+++ b/files/ja/web/javascript/reference/errors/invalid_for-in_initializer/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'SyntaxError: for-in loop head declarations may not have initializers'
 slug: Web/JavaScript/Reference/Errors/Invalid_for-in_initializer
-tags:
-  - Error
-  - JavaScript
-  - Strict Mode
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Invalid_for-in_initializer
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/invalid_for-of_initializer/index.md
+++ b/files/ja/web/javascript/reference/errors/invalid_for-of_initializer/index.md
@@ -1,13 +1,6 @@
 ---
-title: >-
-  SyntaxError: a declaration in the head of a for-of loop can't have an
-  initializer
+title: 'SyntaxError: a declaration in the head of a for-of loop can''t have an initializer'
 slug: Web/JavaScript/Reference/Errors/Invalid_for-of_initializer
-tags:
-  - Error
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Invalid_for-of_initializer
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/invalid_right_hand_side_instanceof_operand/index.md
+++ b/files/ja/web/javascript/reference/errors/invalid_right_hand_side_instanceof_operand/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'TypeError: invalid ''instanceof'' operand ''x'''
 slug: Web/JavaScript/Reference/Errors/invalid_right_hand_side_instanceof_operand
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - Reference
-  - TypeError
-translation_of: Web/JavaScript/Reference/Errors/invalid_right_hand_side_instanceof_operand
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/is_not_iterable/index.md
+++ b/files/ja/web/javascript/reference/errors/is_not_iterable/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'TypeError: ''x'' is not iterable'
 slug: Web/JavaScript/Reference/Errors/is_not_iterable
-tags:
-  - Error
-  - JavaScript
-  - Reference
-  - TypeError
-translation_of: Web/JavaScript/Reference/Errors/is_not_iterable
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/json_bad_parse/index.md
+++ b/files/ja/web/javascript/reference/errors/json_bad_parse/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'SyntaxError: JSON.parse: bad parsing'
 slug: Web/JavaScript/Reference/Errors/JSON_bad_parse
-tags:
-  - Error
-  - Errors
-  - JSON
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/JSON_bad_parse
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/malformed_formal_parameter/index.md
+++ b/files/ja/web/javascript/reference/errors/malformed_formal_parameter/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'SyntaxError: Malformed formal parameter'
 slug: Web/JavaScript/Reference/Errors/Malformed_formal_parameter
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Malformed_formal_parameter
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/malformed_uri/index.md
+++ b/files/ja/web/javascript/reference/errors/malformed_uri/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'URIError: malformed URI sequence'
 slug: Web/JavaScript/Reference/Errors/Malformed_URI
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - URIError
-translation_of: Web/JavaScript/Reference/Errors/Malformed_URI
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/missing_bracket_after_list/index.md
+++ b/files/ja/web/javascript/reference/errors/missing_bracket_after_list/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'SyntaxError: missing ] after element list'
 slug: Web/JavaScript/Reference/Errors/Missing_bracket_after_list
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Missing_bracket_after_list
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/missing_colon_after_property_id/index.md
+++ b/files/ja/web/javascript/reference/errors/missing_colon_after_property_id/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'SyntaxError: missing : after property id'
 slug: Web/JavaScript/Reference/Errors/Missing_colon_after_property_id
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Missing_colon_after_property_id
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/missing_curly_after_function_body/index.md
+++ b/files/ja/web/javascript/reference/errors/missing_curly_after_function_body/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'SyntaxError: missing } after function body'
 slug: Web/JavaScript/Reference/Errors/Missing_curly_after_function_body
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Missing_curly_after_function_body
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/missing_curly_after_property_list/index.md
+++ b/files/ja/web/javascript/reference/errors/missing_curly_after_property_list/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'SyntaxError: missing } after property list'
 slug: Web/JavaScript/Reference/Errors/Missing_curly_after_property_list
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Missing_curly_after_property_list
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/missing_formal_parameter/index.md
+++ b/files/ja/web/javascript/reference/errors/missing_formal_parameter/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'SyntaxError: missing formal parameter'
 slug: Web/JavaScript/Reference/Errors/Missing_formal_parameter
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Missing_formal_parameter
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/missing_initializer_in_const/index.md
+++ b/files/ja/web/javascript/reference/errors/missing_initializer_in_const/index.md
@@ -1,11 +1,6 @@
 ---
 title: 'SyntaxError: missing = in const declaration'
 slug: Web/JavaScript/Reference/Errors/Missing_initializer_in_const
-tags:
-  - Error
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Missing_initializer_in_const
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/missing_name_after_dot_operator/index.md
+++ b/files/ja/web/javascript/reference/errors/missing_name_after_dot_operator/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'SyntaxError: missing name after . operator'
 slug: Web/JavaScript/Reference/Errors/Missing_name_after_dot_operator
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Missing_name_after_dot_operator
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/missing_parenthesis_after_argument_list/index.md
+++ b/files/ja/web/javascript/reference/errors/missing_parenthesis_after_argument_list/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'SyntaxError: missing ) after argument list'
 slug: Web/JavaScript/Reference/Errors/Missing_parenthesis_after_argument_list
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Missing_parenthesis_after_argument_list
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/missing_parenthesis_after_condition/index.md
+++ b/files/ja/web/javascript/reference/errors/missing_parenthesis_after_condition/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'SyntaxError: missing ) after condition'
 slug: Web/JavaScript/Reference/Errors/Missing_parenthesis_after_condition
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Missing_parenthesis_after_condition
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/missing_semicolon_before_statement/index.md
+++ b/files/ja/web/javascript/reference/errors/missing_semicolon_before_statement/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'SyntaxError: missing ; before statement'
 slug: Web/JavaScript/Reference/Errors/Missing_semicolon_before_statement
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Missing_semicolon_before_statement
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/more_arguments_needed/index.md
+++ b/files/ja/web/javascript/reference/errors/more_arguments_needed/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'TypeError: More arguments needed'
 slug: Web/JavaScript/Reference/Errors/More_arguments_needed
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - TypeError
-translation_of: Web/JavaScript/Reference/Errors/More_arguments_needed
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/negative_repetition_count/index.md
+++ b/files/ja/web/javascript/reference/errors/negative_repetition_count/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'RangeError: repeat count must be non-negative'
 slug: Web/JavaScript/Reference/Errors/Negative_repetition_count
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - RangeError
-translation_of: Web/JavaScript/Reference/Errors/Negative_repetition_count
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/no_non-null_object/index.md
+++ b/files/ja/web/javascript/reference/errors/no_non-null_object/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'TypeError: "x" is not a non-null object'
 slug: Web/JavaScript/Reference/Errors/No_non-null_object
-tags:
-- Error
-- Errors
-- JavaScript
-- TypeError
-translation_of: Web/JavaScript/Reference/Errors/No_non-null_object
 ---
 {{JSSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/no_properties/index.md
+++ b/files/ja/web/javascript/reference/errors/no_properties/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'TypeError: "x" has no properties'
 slug: Web/JavaScript/Reference/Errors/No_properties
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - TypeError
-translation_of: Web/JavaScript/Reference/Errors/No_properties
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/no_variable_name/index.md
+++ b/files/ja/web/javascript/reference/errors/no_variable_name/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'SyntaxError: missing variable name'
 slug: Web/JavaScript/Reference/Errors/No_variable_name
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/No_variable_name
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/non_configurable_array_element/index.md
+++ b/files/ja/web/javascript/reference/errors/non_configurable_array_element/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'TypeError: can''t delete non-configurable array element'
 slug: Web/JavaScript/Reference/Errors/Non_configurable_array_element
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - TypeError
-translation_of: Web/JavaScript/Reference/Errors/Non_configurable_array_element
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/not_a_codepoint/index.md
+++ b/files/ja/web/javascript/reference/errors/not_a_codepoint/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'RangeError: argument is not a valid code point'
 slug: Web/JavaScript/Reference/Errors/Not_a_codepoint
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - RangeError
-translation_of: Web/JavaScript/Reference/Errors/Not_a_codepoint
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/not_a_constructor/index.md
+++ b/files/ja/web/javascript/reference/errors/not_a_constructor/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'TypeError: "x" is not a constructor'
 slug: Web/JavaScript/Reference/Errors/Not_a_constructor
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - TypeError
-translation_of: Web/JavaScript/Reference/Errors/Not_a_constructor
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/not_a_function/index.md
+++ b/files/ja/web/javascript/reference/errors/not_a_function/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'TypeError: "x" is not a function'
 slug: Web/JavaScript/Reference/Errors/Not_a_function
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - TypeError
-translation_of: Web/JavaScript/Reference/Errors/Not_a_function
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/not_defined/index.md
+++ b/files/ja/web/javascript/reference/errors/not_defined/index.md
@@ -1,11 +1,6 @@
 ---
 title: 'ReferenceError: "x" is not defined'
 slug: Web/JavaScript/Reference/Errors/Not_defined
-tags:
-  - Error
-  - JavaScript
-  - ReferenceError
-translation_of: Web/JavaScript/Reference/Errors/Not_defined
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/precision_range/index.md
+++ b/files/ja/web/javascript/reference/errors/precision_range/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'RangeError: precision is out of range'
 slug: Web/JavaScript/Reference/Errors/Precision_range
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - RangeError
-translation_of: Web/JavaScript/Reference/Errors/Precision_range
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/property_access_denied/index.md
+++ b/files/ja/web/javascript/reference/errors/property_access_denied/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'Error: Permission denied to access property "x"'
 slug: Web/JavaScript/Reference/Errors/Property_access_denied
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - Security
-translation_of: Web/JavaScript/Reference/Errors/Property_access_denied
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/read-only/index.md
+++ b/files/ja/web/javascript/reference/errors/read-only/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'TypeError: "x" is read-only'
 slug: Web/JavaScript/Reference/Errors/Read-only
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - TypeError
-translation_of: Web/JavaScript/Reference/Errors/Read-only
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/redeclared_parameter/index.md
+++ b/files/ja/web/javascript/reference/errors/redeclared_parameter/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'SyntaxError: redeclaration of formal parameter "x"'
 slug: Web/JavaScript/Reference/Errors/Redeclared_parameter
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Redeclared_parameter
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/reduce_of_empty_array_with_no_initial_value/index.md
+++ b/files/ja/web/javascript/reference/errors/reduce_of_empty_array_with_no_initial_value/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'TypeError: Reduce of empty array with no initial value'
 slug: Web/JavaScript/Reference/Errors/Reduce_of_empty_array_with_no_initial_value
-tags:
-  - Error
-  - JavaScript
-  - Reference
-  - TypeError
-translation_of: Web/JavaScript/Reference/Errors/Reduce_of_empty_array_with_no_initial_value
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/reserved_identifier/index.md
+++ b/files/ja/web/javascript/reference/errors/reserved_identifier/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'SyntaxError: "x" is a reserved identifier'
 slug: Web/JavaScript/Reference/Errors/Reserved_identifier
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Reserved_identifier
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/resulting_string_too_large/index.md
+++ b/files/ja/web/javascript/reference/errors/resulting_string_too_large/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'RangeError: repeat count must be less than infinity'
 slug: Web/JavaScript/Reference/Errors/Resulting_string_too_large
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - RangeError
-translation_of: Web/JavaScript/Reference/Errors/Resulting_string_too_large
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/stmt_after_return/index.md
+++ b/files/ja/web/javascript/reference/errors/stmt_after_return/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'Warning: unreachable code after return statement'
 slug: Web/JavaScript/Reference/Errors/Stmt_after_return
-tags:
-  - JavaScript
-  - Warning
-  - エラー
-  - 警告
-translation_of: Web/JavaScript/Reference/Errors/Stmt_after_return
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/strict_non_simple_params/index.md
+++ b/files/ja/web/javascript/reference/errors/strict_non_simple_params/index.md
@@ -1,11 +1,6 @@
 ---
 title: 'SyntaxError: "use strict" not allowed in function with non-simple parameters'
 slug: Web/JavaScript/Reference/Errors/Strict_Non_Simple_Params
-tags:
-  - Errors
-  - JavaScript
-  - TypeError
-translation_of: Web/JavaScript/Reference/Errors/Strict_Non_Simple_Params
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/too_much_recursion/index.md
+++ b/files/ja/web/javascript/reference/errors/too_much_recursion/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'InternalError: too much recursion'
 slug: Web/JavaScript/Reference/Errors/Too_much_recursion
-tags:
-  - Error
-  - Errors
-  - InternalError
-  - JavaScript
-translation_of: Web/JavaScript/Reference/Errors/Too_much_recursion
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/undeclared_var/index.md
+++ b/files/ja/web/javascript/reference/errors/undeclared_var/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'ReferenceError: assignment to undeclared variable "x"'
 slug: Web/JavaScript/Reference/Errors/Undeclared_var
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - ReferenceError
-  - Strict Mode
-translation_of: Web/JavaScript/Reference/Errors/Undeclared_var
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/undefined_prop/index.md
+++ b/files/ja/web/javascript/reference/errors/undefined_prop/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'ReferenceError: reference to undefined property "x"'
 slug: Web/JavaScript/Reference/Errors/Undefined_prop
-tags:
-  - Errors
-  - JavaScript
-  - ReferenceError
-  - Strict Mode
-translation_of: Web/JavaScript/Reference/Errors/Undefined_prop
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/unexpected_token/index.md
+++ b/files/ja/web/javascript/reference/errors/unexpected_token/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'SyntaxError: Unexpected token'
 slug: Web/JavaScript/Reference/Errors/Unexpected_token
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Unexpected_token
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/unexpected_type/index.md
+++ b/files/ja/web/javascript/reference/errors/unexpected_type/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'TypeError: "x" is (not) "y"'
 slug: Web/JavaScript/Reference/Errors/Unexpected_type
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - TypeError
-translation_of: Web/JavaScript/Reference/Errors/Unexpected_type
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/unnamed_function_statement/index.md
+++ b/files/ja/web/javascript/reference/errors/unnamed_function_statement/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'SyntaxError: function statement requires a name'
 slug: Web/JavaScript/Reference/Errors/Unnamed_function_statement
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Unnamed_function_statement
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/errors/unterminated_string_literal/index.md
+++ b/files/ja/web/javascript/reference/errors/unterminated_string_literal/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'SyntaxError: unterminated string literal'
 slug: Web/JavaScript/Reference/Errors/Unterminated_string_literal
-tags:
-  - Error
-  - Errors
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Unterminated_string_literal
 ---
 {{jsSidebar("Errors")}}
 

--- a/files/ja/web/javascript/reference/functions/arguments/@@iterator/index.md
+++ b/files/ja/web/javascript/reference/functions/arguments/@@iterator/index.md
@@ -1,13 +1,6 @@
 ---
 title: arguments[@@iterator]()
 slug: Web/JavaScript/Reference/Functions/arguments/@@iterator
-tags:
-  - 関数
-  - JavaScript
-  - プロパティ
-  - arguments
-browser-compat: javascript.functions.arguments.@@iterator
-translation_of: Web/JavaScript/Reference/Functions/arguments/@@iterator
 ---
 {{jsSidebar("Functions")}}
 

--- a/files/ja/web/javascript/reference/functions/arguments/callee/index.md
+++ b/files/ja/web/javascript/reference/functions/arguments/callee/index.md
@@ -1,14 +1,6 @@
 ---
 title: arguments.callee
 slug: Web/JavaScript/Reference/Functions/arguments/callee
-tags:
-  - Deprecated
-  - 関数
-  - JavaScript
-  - プロパティ
-  - arguments
-browser-compat: javascript.functions.arguments.callee
-translation_of: Web/JavaScript/Reference/Functions/arguments/callee
 ---
 {{jsSidebar("Functions")}}
 

--- a/files/ja/web/javascript/reference/functions/arguments/index.md
+++ b/files/ja/web/javascript/reference/functions/arguments/index.md
@@ -1,14 +1,6 @@
 ---
 title: arguments オブジェクト
 slug: Web/JavaScript/Reference/Functions/arguments
-tags:
-  - 関数
-  - JavaScript
-  - 名前空間
-  - リファレンス
-  - arguments
-browser-compat: javascript.functions.arguments
-translation_of: Web/JavaScript/Reference/Functions/arguments
 ---
 {{JSSidebar("Functions")}}
 

--- a/files/ja/web/javascript/reference/functions/arguments/length/index.md
+++ b/files/ja/web/javascript/reference/functions/arguments/length/index.md
@@ -1,13 +1,6 @@
 ---
 title: arguments.length
 slug: Web/JavaScript/Reference/Functions/arguments/length
-tags:
-  - 関数
-  - JavaScript
-  - プロパティ
-  - arguments
-browser-compat: javascript.functions.arguments.length
-translation_of: Web/JavaScript/Reference/Functions/arguments/length
 ---
 {{jsSidebar("Functions")}}
 

--- a/files/ja/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/ja/web/javascript/reference/functions/arrow_functions/index.md
@@ -1,15 +1,6 @@
 ---
 title: アロー関数式
 slug: Web/JavaScript/Reference/Functions/Arrow_functions
-tags:
-  - ECMAScript 2015
-  - 関数
-  - 中級者
-  - JavaScript
-  - 言語機能
-  - リファレンス
-browser-compat: javascript.functions.arrow_functions
-translation_of: Web/JavaScript/Reference/Functions/Arrow_functions
 ---
 {{jsSidebar("Functions")}}
 

--- a/files/ja/web/javascript/reference/functions/default_parameters/index.md
+++ b/files/ja/web/javascript/reference/functions/default_parameters/index.md
@@ -1,14 +1,6 @@
 ---
 title: デフォルト引数
 slug: Web/JavaScript/Reference/Functions/Default_parameters
-tags:
-  - ECMAScript 2015
-  - 関数
-  - JavaScript
-  - 言語機能
-  - 関数
-browser-compat: javascript.functions.default_parameters
-translation_of: Web/JavaScript/Reference/Functions/Default_parameters
 ---
 {{jsSidebar("Functions")}}
 

--- a/files/ja/web/javascript/reference/functions/get/index.md
+++ b/files/ja/web/javascript/reference/functions/get/index.md
@@ -1,15 +1,6 @@
 ---
 title: ゲッター
 slug: Web/JavaScript/Reference/Functions/get
-tags:
-  - ECMAScript 2015
-  - ECMAScript 5
-  - 関数
-  - JavaScript
-  - 言語機能
-  - リファレンス
-browser-compat: javascript.functions.get
-translation_of: Web/JavaScript/Reference/Functions/get
 ---
 {{jsSidebar("Functions")}}
 

--- a/files/ja/web/javascript/reference/functions/index.md
+++ b/files/ja/web/javascript/reference/functions/index.md
@@ -1,15 +1,6 @@
 ---
 title: 関数
 slug: Web/JavaScript/Reference/Functions
-tags:
-  - Function
-  - 関数
-  - ガイド
-  - JavaScript
-  - Parameter
-  - 引数
-browser-compat: javascript.functions
-translation_of: Web/JavaScript/Reference/Functions
 ---
 {{jsSidebar("Functions")}}
 

--- a/files/ja/web/javascript/reference/functions/method_definitions/index.md
+++ b/files/ja/web/javascript/reference/functions/method_definitions/index.md
@@ -1,15 +1,6 @@
 ---
 title: メソッド定義
 slug: Web/JavaScript/Reference/Functions/Method_definitions
-tags:
-  - ECMAScript 2015
-  - 関数
-  - JavaScript
-  - 言語機能
-  - オブジェクト
-  - 構文
-browser-compat: javascript.functions.method_definitions
-translation_of: Web/JavaScript/Reference/Functions/Method_definitions
 ---
 {{JsSidebar("Functions")}}
 

--- a/files/ja/web/javascript/reference/functions/rest_parameters/index.md
+++ b/files/ja/web/javascript/reference/functions/rest_parameters/index.md
@@ -1,13 +1,6 @@
 ---
 title: 残余引数
 slug: Web/JavaScript/Reference/Functions/rest_parameters
-tags:
-  - 関数
-  - JavaScript
-  - 言語機能
-  - リファレンス
-browser-compat: javascript.functions.rest_parameters
-translation_of: Web/JavaScript/Reference/Functions/rest_parameters
 ---
 {{jsSidebar("Functions")}}
 

--- a/files/ja/web/javascript/reference/functions/set/index.md
+++ b/files/ja/web/javascript/reference/functions/set/index.md
@@ -1,14 +1,6 @@
 ---
 title: セッター
 slug: Web/JavaScript/Reference/Functions/set
-tags:
-  - ECMAScript 5
-  - 関数
-  - JavaScript
-  - 言語機能
-  - リファレンス
-browser-compat: javascript.functions.set
-translation_of: Web/JavaScript/Reference/Functions/set
 ---
 {{jsSidebar("Functions")}}
 

--- a/files/ja/web/javascript/reference/index.md
+++ b/files/ja/web/javascript/reference/index.md
@@ -1,19 +1,6 @@
 ---
 title: JavaScript リファレンス
 slug: Web/JavaScript/Reference
-tags:
-  - Code
-  - ECMAScript
-  - ECMAScript6
-  - ES6
-  - JS
-  - JavaScript
-  - Landing page
-  - Reference
-  - es
-  - l10n:priority
-  - programming
-translation_of: Web/JavaScript/Reference
 ---
 {{JsSidebar}}
 

--- a/files/ja/web/javascript/reference/iteration_protocols/index.md
+++ b/files/ja/web/javascript/reference/iteration_protocols/index.md
@@ -1,15 +1,6 @@
 ---
 title: 反復処理プロトコル
 slug: Web/JavaScript/Reference/Iteration_protocols
-tags:
-  - ECMAScript 2015
-  - ガイド
-  - 中級者
-  - 反復可能
-  - 反復子
-  - JavaScript
-  - プロトコル
-translation_of: Web/JavaScript/Reference/Iteration_protocols
 ---
 {{jsSidebar("More")}}
 

--- a/files/ja/web/javascript/reference/lexical_grammar/index.md
+++ b/files/ja/web/javascript/reference/lexical_grammar/index.md
@@ -1,14 +1,6 @@
 ---
 title: 字句文法
 slug: Web/JavaScript/Reference/Lexical_grammar
-tags:
-  - ガイド
-  - JavaScript
-  - キーワード
-  - 字句文法
-  - リテラル
-browser-compat: javascript.grammar
-translation_of: Web/JavaScript/Reference/Lexical_grammar
 ---
 {{JsSidebar("More")}}
 

--- a/files/ja/web/javascript/reference/operators/addition/index.md
+++ b/files/ja/web/javascript/reference/operators/addition/index.md
@@ -1,13 +1,6 @@
 ---
 title: 加算 (+)
 slug: Web/JavaScript/Reference/Operators/Addition
-tags:
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.addition
-translation_of: Web/JavaScript/Reference/Operators/Addition
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/addition_assignment/index.md
+++ b/files/ja/web/javascript/reference/operators/addition_assignment/index.md
@@ -1,14 +1,6 @@
 ---
 title: 加算代入 (+=)
 slug: Web/JavaScript/Reference/Operators/Addition_assignment
-tags:
-  - 代入演算子
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.addition_assignment
-translation_of: Web/JavaScript/Reference/Operators/Addition_assignment
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/assignment/index.md
+++ b/files/ja/web/javascript/reference/operators/assignment/index.md
@@ -1,14 +1,6 @@
 ---
 title: 代入 (=)
 slug: Web/JavaScript/Reference/Operators/Assignment
-tags:
-  - 代入演算子
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.assignment
-translation_of: Web/JavaScript/Reference/Operators/Assignment
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/async_function/index.md
+++ b/files/ja/web/javascript/reference/operators/async_function/index.md
@@ -1,14 +1,6 @@
 ---
 title: 非同期関数式
 slug: Web/JavaScript/Reference/Operators/async_function
-tags:
-  - 関数
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Primary Expression
-browser-compat: javascript.operators.async_function
-translation_of: Web/JavaScript/Reference/Operators/async_function
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/await/index.md
+++ b/files/ja/web/javascript/reference/operators/await/index.md
@@ -1,14 +1,6 @@
 ---
 title: await
 slug: Web/JavaScript/Reference/Operators/await
-tags:
-  - 関数
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Primary Expression
-browser-compat: javascript.operators.await
-translation_of: Web/JavaScript/Reference/Operators/await
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/bitwise_and/index.md
+++ b/files/ja/web/javascript/reference/operators/bitwise_and/index.md
@@ -1,14 +1,6 @@
 ---
 title: ビット論理積 (&)
 slug: Web/JavaScript/Reference/Operators/Bitwise_AND
-tags:
-  - ビット演算子
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.bitwise_and
-translation_of: Web/JavaScript/Reference/Operators/Bitwise_AND
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/bitwise_and_assignment/index.md
+++ b/files/ja/web/javascript/reference/operators/bitwise_and_assignment/index.md
@@ -1,14 +1,6 @@
 ---
 title: ビット論理積代入 (&=)
 slug: Web/JavaScript/Reference/Operators/Bitwise_AND_assignment
-tags:
-  - 代入演算子
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.bitwise_and_assignment
-translation_of: Web/JavaScript/Reference/Operators/Bitwise_AND_assignment
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/bitwise_not/index.md
+++ b/files/ja/web/javascript/reference/operators/bitwise_not/index.md
@@ -1,14 +1,6 @@
 ---
 title: ビット否定 (~)
 slug: Web/JavaScript/Reference/Operators/Bitwise_NOT
-tags:
-  - ビット演算子
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.bitwise_not
-translation_of: Web/JavaScript/Reference/Operators/Bitwise_NOT
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/bitwise_or/index.md
+++ b/files/ja/web/javascript/reference/operators/bitwise_or/index.md
@@ -1,14 +1,6 @@
 ---
 title: ビット論理和 (|)
 slug: Web/JavaScript/Reference/Operators/Bitwise_OR
-tags:
-  - ビット演算子
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.bitwise_or
-translation_of: Web/JavaScript/Reference/Operators/Bitwise_OR
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/bitwise_or_assignment/index.md
+++ b/files/ja/web/javascript/reference/operators/bitwise_or_assignment/index.md
@@ -1,14 +1,6 @@
 ---
 title: ビット論理和代入 (|=)
 slug: Web/JavaScript/Reference/Operators/Bitwise_OR_assignment
-tags:
-  - 代入演算子
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.bitwise_or_assignment
-translation_of: Web/JavaScript/Reference/Operators/Bitwise_OR_assignment
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/bitwise_xor/index.md
+++ b/files/ja/web/javascript/reference/operators/bitwise_xor/index.md
@@ -1,14 +1,6 @@
 ---
 title: ビット排他的論理和 (^)
 slug: Web/JavaScript/Reference/Operators/Bitwise_XOR
-tags:
-  - ビット演算子
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.bitwise_xor
-translation_of: Web/JavaScript/Reference/Operators/Bitwise_XOR
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/bitwise_xor_assignment/index.md
+++ b/files/ja/web/javascript/reference/operators/bitwise_xor_assignment/index.md
@@ -1,13 +1,6 @@
 ---
 title: ビット排他的論理和代入 (^=)
 slug: Web/JavaScript/Reference/Operators/Bitwise_XOR_assignment
-tags:
-  - 代入演算子
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-translation_of: Web/JavaScript/Reference/Operators/Bitwise_XOR_assignment
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/class/index.md
+++ b/files/ja/web/javascript/reference/operators/class/index.md
@@ -1,16 +1,6 @@
 ---
 title: クラス式
 slug: Web/JavaScript/Reference/Operators/class
-tags:
-  - クラス
-  - ECMAScript 2015
-  - 式
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - リファレンス
-browser-compat: javascript.operators.class
-translation_of: Web/JavaScript/Reference/Operators/class
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/comma_operator/index.md
+++ b/files/ja/web/javascript/reference/operators/comma_operator/index.md
@@ -1,16 +1,6 @@
 ---
 title: カンマ演算子 (,)
 slug: Web/JavaScript/Reference/Operators/Comma_Operator
-tags:
-- カンマ
-- 合成
-- 式
-- JavaScript
-- 言語機能
-- 演算子
-- リファレンス
-browser-compat: javascript.operators.comma
-translation_of: Web/JavaScript/Reference/Operators/Comma_Operator
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/conditional_operator/index.md
+++ b/files/ja/web/javascript/reference/operators/conditional_operator/index.md
@@ -1,19 +1,6 @@
 ---
 title: 条件 (三項) 演算子
 slug: Web/JavaScript/Reference/Operators/Conditional_Operator
-tags:
-  - 条件
-  - Decision
-  - JS
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - リファレンス
-  - else
-  - if
-  - 三項
-browser-compat: javascript.operators.conditional
-translation_of: Web/JavaScript/Reference/Operators/Conditional_Operator
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/decrement/index.md
+++ b/files/ja/web/javascript/reference/operators/decrement/index.md
@@ -1,13 +1,6 @@
 ---
 title: デクリメント (--)
 slug: Web/JavaScript/Reference/Operators/Decrement
-tags:
-  - デクリメント
-  - JavaScript
-  - 言語機能
-  - 演算子
-browser-compat: javascript.operators.decrement
-translation_of: Web/JavaScript/Reference/Operators/Decrement
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/delete/index.md
+++ b/files/ja/web/javascript/reference/operators/delete/index.md
@@ -1,18 +1,6 @@
 ---
 title: delete 演算子
 slug: Web/JavaScript/Reference/Operators/delete
-tags:
-  - JavaScript
-  - 言語機能
-  - メモリーー管理
-  - Object
-  - Operator
-  - リファレンス
-  - 解放
-  - Unary
-  - delete
-browser-compat: javascript.operators.delete
-translation_of: Web/JavaScript/Reference/Operators/delete
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/destructuring_assignment/index.md
+++ b/files/ja/web/javascript/reference/operators/destructuring_assignment/index.md
@@ -1,17 +1,6 @@
 ---
 title: 分割代入
 slug: Web/JavaScript/Reference/Operators/Destructuring_assignment
-tags:
-  - Destructuring
-  - 分割代入
-  - ECMAScript 2015
-  - ES6
-  - JavaScript
-  - 言語機能
-  - 階層オブジェクトと配列の分割代入
-  - 演算子
-browser-compat: javascript.operators.destructuring
-translation_of: Web/JavaScript/Reference/Operators/Destructuring_assignment
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/division/index.md
+++ b/files/ja/web/javascript/reference/operators/division/index.md
@@ -1,13 +1,6 @@
 ---
 title: 除算 (/)
 slug: Web/JavaScript/Reference/Operators/Division
-tags:
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.division
-translation_of: Web/JavaScript/Reference/Operators/Division
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/division_assignment/index.md
+++ b/files/ja/web/javascript/reference/operators/division_assignment/index.md
@@ -1,14 +1,6 @@
 ---
 title: 除算代入 (/=)
 slug: Web/JavaScript/Reference/Operators/Division_assignment
-tags:
-  - 代入演算子
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.division_assignment
-translation_of: Web/JavaScript/Reference/Operators/Division_assignment
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/equality/index.md
+++ b/files/ja/web/javascript/reference/operators/equality/index.md
@@ -1,13 +1,6 @@
 ---
 title: 等価 (==)
 slug: Web/JavaScript/Reference/Operators/Equality
-tags:
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.equality
-translation_of: Web/JavaScript/Reference/Operators/Equality
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/exponentiation/index.md
+++ b/files/ja/web/javascript/reference/operators/exponentiation/index.md
@@ -1,13 +1,6 @@
 ---
 title: べき乗 (**)
 slug: Web/JavaScript/Reference/Operators/Exponentiation
-tags:
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.exponentiation
-translation_of: Web/JavaScript/Reference/Operators/Exponentiation
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/exponentiation_assignment/index.md
+++ b/files/ja/web/javascript/reference/operators/exponentiation_assignment/index.md
@@ -1,14 +1,6 @@
 ---
 title: べき乗代入 (**=)
 slug: Web/JavaScript/Reference/Operators/Exponentiation_assignment
-tags:
-  - 代入演算子
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.exponentiation_assignment
-translation_of: Web/JavaScript/Reference/Operators/Exponentiation_assignment
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/function/index.md
+++ b/files/ja/web/javascript/reference/operators/function/index.md
@@ -1,14 +1,6 @@
 ---
 title: 関数式
 slug: Web/JavaScript/Reference/Operators/function
-tags:
-  - Function
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Primary Expressions
-browser-compat: javascript.operators.function
-translation_of: Web/JavaScript/Reference/Operators/function
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/function_star_/index.md
+++ b/files/ja/web/javascript/reference/operators/function_star_/index.md
@@ -1,16 +1,6 @@
 ---
 title: function* 式
 slug: Web/JavaScript/Reference/Operators/function*
-tags:
-  - ECMAScript 2015
-  - Function
-  - Iterator
-  - JavaScript
-  - Language feature
-  - Operator
-  - Primary Expression
-browser-compat: javascript.operators.generator_function
-translation_of: Web/JavaScript/Reference/Operators/function*
 ---
 {{jsSidebar("Operators")}}</div>
 

--- a/files/ja/web/javascript/reference/operators/greater_than/index.md
+++ b/files/ja/web/javascript/reference/operators/greater_than/index.md
@@ -1,13 +1,6 @@
 ---
 title: 大なり (>)
 slug: Web/JavaScript/Reference/Operators/Greater_than
-tags:
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.greater_than
-translation_of: Web/JavaScript/Reference/Operators/Greater_than
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/greater_than_or_equal/index.md
+++ b/files/ja/web/javascript/reference/operators/greater_than_or_equal/index.md
@@ -1,13 +1,6 @@
 ---
 title: 大なりイコール (>=)
 slug: Web/JavaScript/Reference/Operators/Greater_than_or_equal
-tags:
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.greater_than_or_equal
-translation_of: Web/JavaScript/Reference/Operators/Greater_than_or_equal
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/grouping/index.md
+++ b/files/ja/web/javascript/reference/operators/grouping/index.md
@@ -1,13 +1,6 @@
 ---
 title: グループ化演算子 ( )
 slug: Web/JavaScript/Reference/Operators/Grouping
-tags:
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Primary Expressions
-browser-compat: javascript.operators.grouping
-translation_of: Web/JavaScript/Reference/Operators/Grouping
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/import.meta/index.md
+++ b/files/ja/web/javascript/reference/operators/import.meta/index.md
@@ -1,15 +1,6 @@
 ---
 title: import.meta
 slug: Web/JavaScript/Reference/Operators/import.meta
-tags:
-  - JavaScript
-  - Language feature
-  - Modules
-  - Reference
-  - Statement
-  - import
-  - import.meta
-translation_of: Web/JavaScript/Reference/Statements/import.meta
 original_slug: Web/JavaScript/Reference/Statements/import.meta
 ---
 {{JSSidebar("Statements")}}

--- a/files/ja/web/javascript/reference/operators/in/index.md
+++ b/files/ja/web/javascript/reference/operators/in/index.md
@@ -1,13 +1,6 @@
 ---
 title: in 演算子
 slug: Web/JavaScript/Reference/Operators/in
-tags:
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - 関係演算子
-browser-compat: javascript.operators.in
-translation_of: Web/JavaScript/Reference/Operators/in
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/increment/index.md
+++ b/files/ja/web/javascript/reference/operators/increment/index.md
@@ -1,13 +1,6 @@
 ---
 title: インクリメント (++)
 slug: Web/JavaScript/Reference/Operators/Increment
-tags:
-  - JavaScript
-  - Language feature
-  - Operator
-  - Reference
-browser-compat: javascript.operators.increment
-translation_of: Web/JavaScript/Reference/Operators/Increment
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/index.md
+++ b/files/ja/web/javascript/reference/operators/index.md
@@ -1,14 +1,6 @@
 ---
 title: 式と演算子
 slug: Web/JavaScript/Reference/Operators
-tags:
-  - JavaScript
-  - Landing page
-  - 演算子
-  - 概要
-  - Reference
-browser-compat: javascript.operators
-translation_of: Web/JavaScript/Reference/Operators
 ---
 {{JSSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/inequality/index.md
+++ b/files/ja/web/javascript/reference/operators/inequality/index.md
@@ -1,13 +1,6 @@
 ---
 title: 不等価 (!=)
 slug: Web/JavaScript/Reference/Operators/Inequality
-tags:
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.inequality
-translation_of: Web/JavaScript/Reference/Operators/Inequality
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/instanceof/index.md
+++ b/files/ja/web/javascript/reference/operators/instanceof/index.md
@@ -1,16 +1,6 @@
 ---
 title: instanceof
 slug: Web/JavaScript/Reference/Operators/instanceof
-tags:
-  - JavaScript
-  - 言語機能
-  - オブジェクト
-  - 演算子
-  - プロトタイプ
-  - 関連演算子
-  - instanceof
-browser-compat: javascript.operators.instanceof
-translation_of: Web/JavaScript/Reference/Operators/instanceof
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/left_shift/index.md
+++ b/files/ja/web/javascript/reference/operators/left_shift/index.md
@@ -1,14 +1,6 @@
 ---
 title: 左シフト (<<)
 slug: Web/JavaScript/Reference/Operators/Left_shift
-tags:
-  - ビット演算子
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.left_shift
-translation_of: Web/JavaScript/Reference/Operators/Left_shift
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/left_shift_assignment/index.md
+++ b/files/ja/web/javascript/reference/operators/left_shift_assignment/index.md
@@ -1,14 +1,6 @@
 ---
 title: 左シフト代入 (<<=)
 slug: Web/JavaScript/Reference/Operators/Left_shift_assignment
-tags:
-  - 代入演算子
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.left_shift_assignment
-translation_of: Web/JavaScript/Reference/Operators/Left_shift_assignment
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/less_than/index.md
+++ b/files/ja/web/javascript/reference/operators/less_than/index.md
@@ -1,13 +1,6 @@
 ---
 title: 小なり (<)
 slug: Web/JavaScript/Reference/Operators/Less_than
-tags:
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.less_than
-translation_of: Web/JavaScript/Reference/Operators/Less_than
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/less_than_or_equal/index.md
+++ b/files/ja/web/javascript/reference/operators/less_than_or_equal/index.md
@@ -1,13 +1,6 @@
 ---
 title: 小なりイコール (<=)
 slug: Web/JavaScript/Reference/Operators/Less_than_or_equal
-tags:
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.less_than_or_equal
-translation_of: Web/JavaScript/Reference/Operators/Less_than_or_equal
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/logical_and/index.md
+++ b/files/ja/web/javascript/reference/operators/logical_and/index.md
@@ -1,14 +1,6 @@
 ---
 title: 論理積 (&&)
 slug: Web/JavaScript/Reference/Operators/Logical_AND
-tags:
-  - JavaScript
-  - 言語機能
-  - 論理演算子
-  - 演算子
-  - リファレンス
-browser-compat: javascript.operators.logical_and
-translation_of: Web/JavaScript/Reference/Operators/Logical_AND
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/logical_and_assignment/index.md
+++ b/files/ja/web/javascript/reference/operators/logical_and_assignment/index.md
@@ -1,14 +1,6 @@
 ---
 title: 論理積代入 (&&=)
 slug: Web/JavaScript/Reference/Operators/Logical_AND_assignment
-tags:
-  - JavaScript
-  - 言語機能
-  - 論理代入
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.logical_and_assignment
-translation_of: Web/JavaScript/Reference/Operators/Logical_AND_assignment
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/logical_not/index.md
+++ b/files/ja/web/javascript/reference/operators/logical_not/index.md
@@ -1,14 +1,6 @@
 ---
 title: 論理否定 (!)
 slug: Web/JavaScript/Reference/Operators/Logical_NOT
-tags:
-  - JavaScript
-  - 言語機能
-  - 論理演算子
-  - 演算子
-  - リファレンス
-browser-compat: javascript.operators.logical_not
-translation_of: Web/JavaScript/Reference/Operators/Logical_NOT
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/logical_nullish_assignment/index.md
+++ b/files/ja/web/javascript/reference/operators/logical_nullish_assignment/index.md
@@ -1,15 +1,6 @@
 ---
 title: Null 合体代入 (??=)
 slug: Web/JavaScript/Reference/Operators/Logical_nullish_assignment
-tags:
-  - 代入演算子
-  - JavaScript
-  - 言語機能
-  - 論理演算子
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.logical_nullish_assignment
-translation_of: Web/JavaScript/Reference/Operators/Logical_nullish_assignment
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/logical_or/index.md
+++ b/files/ja/web/javascript/reference/operators/logical_or/index.md
@@ -1,14 +1,6 @@
 ---
 title: 論理和 (||)
 slug: Web/JavaScript/Reference/Operators/Logical_OR
-tags:
-  - JavaScript
-  - 言語機能
-  - 論理演算子
-  - 演算子
-  - リファレンス
-browser-compat: javascript.operators.logical_or
-translation_of: Web/JavaScript/Reference/Operators/Logical_OR
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/logical_or_assignment/index.md
+++ b/files/ja/web/javascript/reference/operators/logical_or_assignment/index.md
@@ -1,14 +1,6 @@
 ---
 title: 論理和代入 (||=)
 slug: Web/JavaScript/Reference/Operators/Logical_OR_assignment
-tags:
-  - JavaScript
-  - 言語機能
-  - 論理代入
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.logical_or_assignment
-translation_of: Web/JavaScript/Reference/Operators/Logical_OR_assignment
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/multiplication/index.md
+++ b/files/ja/web/javascript/reference/operators/multiplication/index.md
@@ -1,13 +1,6 @@
 ---
 title: 乗算 (*)
 slug: Web/JavaScript/Reference/Operators/Multiplication
-tags:
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.multiplication
-translation_of: Web/JavaScript/Reference/Operators/Multiplication
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/multiplication_assignment/index.md
+++ b/files/ja/web/javascript/reference/operators/multiplication_assignment/index.md
@@ -1,14 +1,6 @@
 ---
 title: 乗算代入 (*=)
 slug: Web/JavaScript/Reference/Operators/Multiplication_assignment
-tags:
-  - 代入演算子
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.multiplication_assignment
-translation_of: Web/JavaScript/Reference/Operators/Multiplication_assignment
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/new.target/index.md
+++ b/files/ja/web/javascript/reference/operators/new.target/index.md
@@ -1,14 +1,6 @@
 ---
 title: new.target
 slug: Web/JavaScript/Reference/Operators/new.target
-tags:
-  - クラス
-  - ECMAScript 2015
-  - JavaScript
-  - 言語機能
-  - リファレンス
-browser-compat: javascript.operators.new_target
-translation_of: Web/JavaScript/Reference/Operators/new.target
 ---
 {{JSSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/new/index.md
+++ b/files/ja/web/javascript/reference/operators/new/index.md
@@ -1,14 +1,6 @@
 ---
 title: new 演算子
 slug: Web/JavaScript/Reference/Operators/new
-tags:
-  - JavaScript
-  - 言語機能
-  - 左辺値式
-  - 演算子
-  - リファレンス
-browser-compat: javascript.operators.new
-translation_of: Web/JavaScript/Reference/Operators/new
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/null/index.md
+++ b/files/ja/web/javascript/reference/operators/null/index.md
@@ -1,14 +1,7 @@
 ---
 title: 'null'
 slug: Web/JavaScript/Reference/Operators/null
-tags:
-  - JavaScript
-  - 言語機能
-  - リテラル
-  - プリミティブ
-translation_of: Web/JavaScript/Reference/Global_Objects/null
 original_slug: Web/JavaScript/Reference/Global_Objects/null
-browser-compat: javascript.builtins.null
 ---
 {{jsSidebar("Objects")}}
 

--- a/files/ja/web/javascript/reference/operators/nullish_coalescing_operator/index.md
+++ b/files/ja/web/javascript/reference/operators/nullish_coalescing_operator/index.md
@@ -1,14 +1,6 @@
 ---
 title: Null 合体演算子 (??)
 slug: Web/JavaScript/Reference/Operators/Nullish_coalescing_operator
-tags:
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - リファレンス
-  - nullish coalescing
-browser-compat: javascript.operators.nullish_coalescing
-translation_of: Web/JavaScript/Reference/Operators/Nullish_coalescing_operator
 ---
 {{JSSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/object_initializer/index.md
+++ b/files/ja/web/javascript/reference/operators/object_initializer/index.md
@@ -1,20 +1,6 @@
 ---
 title: オブジェクト初期化子
 slug: Web/JavaScript/Reference/Operators/Object_initializer
-tags:
-  - ECMAScript 2015
-  - JSON
-  - JavaScript
-  - 言語機能
-  - リテラル
-  - メソッド
-  - オブジェクト
-  - Primary Expression
-  - computed
-  - mutation
-  - プロパティ
-browser-compat: javascript.operators.object_initializer
-translation_of: Web/JavaScript/Reference/Operators/Object_initializer
 ---
 {{JsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/operator_precedence/index.md
+++ b/files/ja/web/javascript/reference/operators/operator_precedence/index.md
@@ -1,11 +1,6 @@
 ---
 title: 演算子の優先順位
 slug: Web/JavaScript/Reference/Operators/Operator_Precedence
-tags:
-  - ガイド
-  - JavaScript
-  - 優先順位
-translation_of: Web/JavaScript/Reference/Operators/Operator_Precedence
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/optional_chaining/index.md
+++ b/files/ja/web/javascript/reference/operators/optional_chaining/index.md
@@ -1,15 +1,6 @@
 ---
 title: オプショナルチェーン (?.)
 slug: Web/JavaScript/Reference/Operators/Optional_chaining
-tags:
-  - Chaining
-  - JavaScript
-  - Language feature
-  - Operator
-  - Optional chaining
-  - Reference
-browser-compat: javascript.operators.optional_chaining
-translation_of: Web/JavaScript/Reference/Operators/Optional_chaining
 ---
 {{JSSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/property_accessors/index.md
+++ b/files/ja/web/javascript/reference/operators/property_accessors/index.md
@@ -1,12 +1,6 @@
 ---
 title: プロパティアクセサー
 slug: Web/JavaScript/Reference/Operators/Property_Accessors
-tags:
-  - JavaScript
-  - Language feature
-  - Operator
-  - Reference
-translation_of: Web/JavaScript/Reference/Operators/Property_Accessors
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/remainder/index.md
+++ b/files/ja/web/javascript/reference/operators/remainder/index.md
@@ -1,13 +1,6 @@
 ---
 title: 剰余 (%)
 slug: Web/JavaScript/Reference/Operators/Remainder
-tags:
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.remainder
-translation_of: Web/JavaScript/Reference/Operators/Remainder
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/remainder_assignment/index.md
+++ b/files/ja/web/javascript/reference/operators/remainder_assignment/index.md
@@ -1,14 +1,6 @@
 ---
 title: 剰余代入 (%=)
 slug: Web/JavaScript/Reference/Operators/Remainder_assignment
-tags:
-  - 代入演算子
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.remainder_assignment
-translation_of: Web/JavaScript/Reference/Operators/Remainder_assignment
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/right_shift/index.md
+++ b/files/ja/web/javascript/reference/operators/right_shift/index.md
@@ -1,14 +1,6 @@
 ---
 title: 右シフト (>>)
 slug: Web/JavaScript/Reference/Operators/Right_shift
-tags:
-  - ビット演算子
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.right_shift
-translation_of: Web/JavaScript/Reference/Operators/Right_shift
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/right_shift_assignment/index.md
+++ b/files/ja/web/javascript/reference/operators/right_shift_assignment/index.md
@@ -1,14 +1,6 @@
 ---
 title: 右シフト代入 (>>=)
 slug: Web/JavaScript/Reference/Operators/Right_shift_assignment
-tags:
-  - 代入演算子
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.right_shift_assignment
-translation_of: Web/JavaScript/Reference/Operators/Right_shift_assignment
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/spread_syntax/index.md
+++ b/files/ja/web/javascript/reference/operators/spread_syntax/index.md
@@ -1,14 +1,6 @@
 ---
 title: スプレッド構文
 slug: Web/JavaScript/Reference/Operators/Spread_syntax
-tags:
-  - ECMAScript 2015
-  - イテレーター
-  - JavaScript
-  - 言語機能
-  - Reference
-browser-compat: javascript.operators.spread
-translation_of: Web/JavaScript/Reference/Operators/Spread_syntax
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/strict_equality/index.md
+++ b/files/ja/web/javascript/reference/operators/strict_equality/index.md
@@ -1,13 +1,6 @@
 ---
 title: 厳密等価 (===)
 slug: Web/JavaScript/Reference/Operators/Strict_equality
-tags:
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.strict_equality
-translation_of: Web/JavaScript/Reference/Operators/Strict_equality
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/strict_inequality/index.md
+++ b/files/ja/web/javascript/reference/operators/strict_inequality/index.md
@@ -1,13 +1,6 @@
 ---
 title: 厳密不等価 (!==)
 slug: Web/JavaScript/Reference/Operators/Strict_inequality
-tags:
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.strict_inequality
-translation_of: Web/JavaScript/Reference/Operators/Strict_inequality
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/subtraction/index.md
+++ b/files/ja/web/javascript/reference/operators/subtraction/index.md
@@ -1,13 +1,6 @@
 ---
 title: 減算 (-)
 slug: Web/JavaScript/Reference/Operators/Subtraction
-tags:
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.subtraction
-translation_of: Web/JavaScript/Reference/Operators/Subtraction
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/subtraction_assignment/index.md
+++ b/files/ja/web/javascript/reference/operators/subtraction_assignment/index.md
@@ -1,14 +1,6 @@
 ---
 title: 減算代入 (-=)
 slug: Web/JavaScript/Reference/Operators/Subtraction_assignment
-tags:
-  - 代入演算子
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.subtraction_assignment
-translation_of: Web/JavaScript/Reference/Operators/Subtraction_assignment
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/super/index.md
+++ b/files/ja/web/javascript/reference/operators/super/index.md
@@ -1,15 +1,6 @@
 ---
 title: super
 slug: Web/JavaScript/Reference/Operators/super
-tags:
-  - クラス
-  - ECMAScript 2015
-  - JavaScript
-  - 言語機能
-  - 左辺式
-  - 演算子
-browser-compat: javascript.operators.super
-translation_of: Web/JavaScript/Reference/Operators/super
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/this/index.md
+++ b/files/ja/web/javascript/reference/operators/this/index.md
@@ -1,15 +1,6 @@
 ---
 title: this
 slug: Web/JavaScript/Reference/Operators/this
-tags:
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Primary Expressions
-  - リファレンス
-  - this
-browser-compat: javascript.operators.this
-translation_of: Web/JavaScript/Reference/Operators/this
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/typeof/index.md
+++ b/files/ja/web/javascript/reference/operators/typeof/index.md
@@ -1,14 +1,6 @@
 ---
 title: typeof
 slug: Web/JavaScript/Reference/Operators/typeof
-tags:
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - リファレンス
-  - 単項
-browser-compat: javascript.operators.typeof
-translation_of: Web/JavaScript/Reference/Operators/typeof
 ---
 {{JSSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/unary_negation/index.md
+++ b/files/ja/web/javascript/reference/operators/unary_negation/index.md
@@ -1,13 +1,6 @@
 ---
 title: 単項マイナス (-)
 slug: Web/JavaScript/Reference/Operators/Unary_negation
-tags:
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.unary_negation
-translation_of: Web/JavaScript/Reference/Operators/Unary_negation
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/unary_plus/index.md
+++ b/files/ja/web/javascript/reference/operators/unary_plus/index.md
@@ -1,13 +1,6 @@
 ---
 title: 単項プラス (+)
 slug: Web/JavaScript/Reference/Operators/Unary_plus
-tags:
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.unary_plus
-translation_of: Web/JavaScript/Reference/Operators/Unary_plus
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/unsigned_right_shift/index.md
+++ b/files/ja/web/javascript/reference/operators/unsigned_right_shift/index.md
@@ -1,14 +1,6 @@
 ---
 title: 符号なし右シフト (>>>)
 slug: Web/JavaScript/Reference/Operators/Unsigned_right_shift
-tags:
-  - ビット演算子
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.unsigned_right_shift
-translation_of: Web/JavaScript/Reference/Operators/Unsigned_right_shift
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/unsigned_right_shift_assignment/index.md
+++ b/files/ja/web/javascript/reference/operators/unsigned_right_shift_assignment/index.md
@@ -1,14 +1,6 @@
 ---
 title: 符号なし右シフト代入 (>>>=)
 slug: Web/JavaScript/Reference/Operators/Unsigned_right_shift_assignment
-tags:
-  - 代入演算子
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - Reference
-browser-compat: javascript.operators.unsigned_right_shift_assignment
-translation_of: Web/JavaScript/Reference/Operators/Unsigned_right_shift_assignment
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/void/index.md
+++ b/files/ja/web/javascript/reference/operators/void/index.md
@@ -1,14 +1,6 @@
 ---
 title: void 演算子
 slug: Web/JavaScript/Reference/Operators/void
-tags:
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - リファレンス
-  - 単項
-browser-compat: javascript.operators.void
-translation_of: Web/JavaScript/Reference/Operators/void
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/yield/index.md
+++ b/files/ja/web/javascript/reference/operators/yield/index.md
@@ -1,15 +1,6 @@
 ---
 title: yield
 slug: Web/JavaScript/Reference/Operators/yield
-tags:
-  - ECMAScript 2015
-  - ジェネレーター
-  - 反復子
-  - JavaScript
-  - 言語機能
-  - 演算子
-browser-compat: javascript.operators.yield
-translation_of: Web/JavaScript/Reference/Operators/yield
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/operators/yield_star_/index.md
+++ b/files/ja/web/javascript/reference/operators/yield_star_/index.md
@@ -1,17 +1,6 @@
 ---
 title: yield*
 slug: Web/JavaScript/Reference/Operators/yield*
-tags:
-  - ECMAScript 2015
-  - ジェネレーター
-  - 反復可能
-  - 反復子
-  - JavaScript
-  - 言語機能
-  - 演算子
-  - リファレンス
-browser-compat: javascript.operators.yield_star
-translation_of: Web/JavaScript/Reference/Operators/yield*
 ---
 {{jsSidebar("Operators")}}
 

--- a/files/ja/web/javascript/reference/statements/async_function/index.md
+++ b/files/ja/web/javascript/reference/statements/async_function/index.md
@@ -1,14 +1,6 @@
 ---
 title: 非同期関数
 slug: Web/JavaScript/Reference/Statements/async_function
-tags:
-  - Example
-  - 関数
-  - JavaScript
-  - 言語機能
-  - 文
-browser-compat: javascript.statements.async_function
-translation_of: Web/JavaScript/Reference/Statements/async_function
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/block/index.md
+++ b/files/ja/web/javascript/reference/statements/block/index.md
@@ -1,14 +1,6 @@
 ---
 title: ブロック
 slug: Web/JavaScript/Reference/Statements/block
-tags:
-  - JavaScript
-  - Language feature
-  - Reference
-  - Statement
-  - 文
-  - 言語機能
-translation_of: Web/JavaScript/Reference/Statements/block
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/break/index.md
+++ b/files/ja/web/javascript/reference/statements/break/index.md
@@ -1,12 +1,6 @@
 ---
 title: break
 slug: Web/JavaScript/Reference/Statements/break
-tags:
-  - JavaScript
-  - Language feature
-  - Reference
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/break
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/class/index.md
+++ b/files/ja/web/javascript/reference/statements/class/index.md
@@ -1,15 +1,6 @@
 ---
 title: class
 slug: Web/JavaScript/Reference/Statements/class
-tags:
-  - Classes
-  - Declaration
-  - ECMAScript6
-  - JavaScript
-  - Reference
-  - クラス
-  - 宣言
-translation_of: Web/JavaScript/Reference/Statements/class
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/const/index.md
+++ b/files/ja/web/javascript/reference/statements/const/index.md
@@ -1,15 +1,6 @@
 ---
 title: const
 slug: Web/JavaScript/Reference/Statements/const
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Language feature
-  - Reference
-  - Statement
-  - constants
-browser-compat: javascript.statements.const
-translation_of: Web/JavaScript/Reference/Statements/const
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/continue/index.md
+++ b/files/ja/web/javascript/reference/statements/continue/index.md
@@ -1,11 +1,6 @@
 ---
 title: continue
 slug: Web/JavaScript/Reference/Statements/continue
-tags:
-  - JavaScript
-  - Language feature
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/continue
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/debugger/index.md
+++ b/files/ja/web/javascript/reference/statements/debugger/index.md
@@ -1,11 +1,6 @@
 ---
 title: debugger
 slug: Web/JavaScript/Reference/Statements/debugger
-tags:
-  - JavaScript
-  - Language feature
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/debugger
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/do...while/index.md
+++ b/files/ja/web/javascript/reference/statements/do...while/index.md
@@ -1,12 +1,6 @@
 ---
 title: do...while
 slug: Web/JavaScript/Reference/Statements/do...while
-tags:
-  - JavaScript
-  - Statement
-  - 文
-  - 言語機能
-translation_of: Web/JavaScript/Reference/Statements/do...while
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/empty/index.md
+++ b/files/ja/web/javascript/reference/statements/empty/index.md
@@ -1,11 +1,6 @@
 ---
 title: 空文
 slug: Web/JavaScript/Reference/Statements/Empty
-tags:
-  - JavaScript
-  - Language feature
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/Empty
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/export/index.md
+++ b/files/ja/web/javascript/reference/statements/export/index.md
@@ -1,15 +1,6 @@
 ---
 title: export
 slug: Web/JavaScript/Reference/Statements/export
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Language feature
-  - Modules
-  - Reference
-  - Statement
-  - export
-translation_of: Web/JavaScript/Reference/Statements/export
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/for-await...of/index.md
+++ b/files/ja/web/javascript/reference/statements/for-await...of/index.md
@@ -1,18 +1,6 @@
 ---
 title: for await...of
 slug: Web/JavaScript/Reference/Statements/for-await...of
-tags:
-  - Iterate
-  - Iteration
-  - JavaScript
-  - Reference
-  - Statement
-  - asynchronous
-  - await
-  - 文
-  - 繰り返し
-  - 非同期
-translation_of: Web/JavaScript/Reference/Statements/for-await...of
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/for...in/index.md
+++ b/files/ja/web/javascript/reference/statements/for...in/index.md
@@ -1,11 +1,6 @@
 ---
 title: for...in
 slug: Web/JavaScript/Reference/Statements/for...in
-tags:
-  - JavaScript
-  - Language feature
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/for...in
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/for...of/index.md
+++ b/files/ja/web/javascript/reference/statements/for...of/index.md
@@ -1,14 +1,6 @@
 ---
 title: for...of
 slug: Web/JavaScript/Reference/Statements/for...of
-tags:
-  - ECMAScript 2015
-  - ES6
-  - JavaScript
-  - Language feature
-  - Reference
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/for...of
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/for/index.md
+++ b/files/ja/web/javascript/reference/statements/for/index.md
@@ -1,14 +1,6 @@
 ---
 title: for
 slug: Web/JavaScript/Reference/Statements/for
-tags:
-  - JavaScript
-  - Language feature
-  - Loop
-  - Reference
-  - Statement
-  - for
-translation_of: Web/JavaScript/Reference/Statements/for
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/function/index.md
+++ b/files/ja/web/javascript/reference/statements/function/index.md
@@ -1,12 +1,6 @@
 ---
 title: 関数宣言
 slug: Web/JavaScript/Reference/Statements/function
-tags:
-  - Function
-  - JavaScript
-  - Language feature
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/function
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/function_star_/index.md
+++ b/files/ja/web/javascript/reference/statements/function_star_/index.md
@@ -1,14 +1,6 @@
 ---
 title: function* 宣言
 slug: Web/JavaScript/Reference/Statements/function*
-tags:
-  - ECMAScript 2015
-  - Function
-  - Iterator
-  - JavaScript
-  - Language feature
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/function*
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/if...else/index.md
+++ b/files/ja/web/javascript/reference/statements/if...else/index.md
@@ -1,16 +1,6 @@
 ---
 title: if...else
 slug: Web/JavaScript/Reference/Statements/if...else
-tags:
-  - JavaScript
-  - Language feature
-  - Reference
-  - Statement
-  - else
-  - if
-  - 文
-  - 言語機能
-translation_of: Web/JavaScript/Reference/Statements/if...else
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/import/index.md
+++ b/files/ja/web/javascript/reference/statements/import/index.md
@@ -1,16 +1,6 @@
 ---
 title: import
 slug: Web/JavaScript/Reference/Statements/import
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Language feature
-  - Modules
-  - Reference
-  - Statement
-  - dynamic import
-  - import
-translation_of: Web/JavaScript/Reference/Statements/import
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/index.md
+++ b/files/ja/web/javascript/reference/statements/index.md
@@ -1,12 +1,6 @@
 ---
 title: 文と宣言
 slug: Web/JavaScript/Reference/Statements
-tags:
-  - JavaScript
-  - Landing page
-  - Reference
-  - statements
-translation_of: Web/JavaScript/Reference/Statements
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/label/index.md
+++ b/files/ja/web/javascript/reference/statements/label/index.md
@@ -1,11 +1,6 @@
 ---
 title: label
 slug: Web/JavaScript/Reference/Statements/label
-tags:
-  - JavaScript
-  - Language feature
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/label
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/let/index.md
+++ b/files/ja/web/javascript/reference/statements/let/index.md
@@ -1,19 +1,6 @@
 ---
 title: let
 slug: Web/JavaScript/Reference/Statements/let
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Language feature
-  - Statement
-  - Variable declaration
-  - Variables
-  - let
-  - 変数
-  - 変数宣言
-  - 文
-  - 言語機能
-translation_of: Web/JavaScript/Reference/Statements/let
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/return/index.md
+++ b/files/ja/web/javascript/reference/statements/return/index.md
@@ -1,11 +1,6 @@
 ---
 title: return
 slug: Web/JavaScript/Reference/Statements/return
-tags:
-  - JavaScript
-  - Language feature
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/return
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/switch/index.md
+++ b/files/ja/web/javascript/reference/statements/switch/index.md
@@ -1,15 +1,6 @@
 ---
 title: switch
 slug: Web/JavaScript/Reference/Statements/switch
-tags:
-  - JavaScript
-  - Language feature
-  - Reference
-  - Statement
-  - Web
-  - 文
-  - 言語機能
-translation_of: Web/JavaScript/Reference/Statements/switch
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/throw/index.md
+++ b/files/ja/web/javascript/reference/statements/throw/index.md
@@ -1,14 +1,6 @@
 ---
 title: throw
 slug: Web/JavaScript/Reference/Statements/throw
-tags:
-  - JavaScript
-  - Language feature
-  - Reference
-  - Statement
-  - 文
-  - 言語機能
-translation_of: Web/JavaScript/Reference/Statements/throw
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/try...catch/index.md
+++ b/files/ja/web/javascript/reference/statements/try...catch/index.md
@@ -1,13 +1,6 @@
 ---
 title: try...catch
 slug: Web/JavaScript/Reference/Statements/try...catch
-tags:
-  - 例外
-  - JavaScript
-  - 言語機能
-  - 文
-browser-compat: javascript.statements.try_catch
-translation_of: Web/JavaScript/Reference/Statements/try...catch
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/var/index.md
+++ b/files/ja/web/javascript/reference/statements/var/index.md
@@ -1,13 +1,6 @@
 ---
 title: var
 slug: Web/JavaScript/Reference/Statements/var
-tags:
-  - JavaScript
-  - 言語機能
-  - リファレンス
-  - 文
-browser-compat: javascript.statements.var
-translation_of: Web/JavaScript/Reference/Statements/var
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/while/index.md
+++ b/files/ja/web/javascript/reference/statements/while/index.md
@@ -1,12 +1,6 @@
 ---
 title: while
 slug: Web/JavaScript/Reference/Statements/while
-tags:
-  - JavaScript
-  - Language feature
-  - Statement
-  - while
-translation_of: Web/JavaScript/Reference/Statements/while
 ---
 {{jsSidebar("Statements")}}
 

--- a/files/ja/web/javascript/reference/statements/with/index.md
+++ b/files/ja/web/javascript/reference/statements/with/index.md
@@ -1,12 +1,6 @@
 ---
 title: with
 slug: Web/JavaScript/Reference/Statements/with
-tags:
-  - Deprecated
-  - JavaScript
-  - Language feature
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/with
 ---
 > **Warning:** 混乱させるバグや互換性問題の原因になり得るため、`with` 文の使用は推奨されません。詳しくは "説明" の章の "あいまい性の欠点" をご覧ください。
 

--- a/files/ja/web/javascript/reference/strict_mode/index.md
+++ b/files/ja/web/javascript/reference/strict_mode/index.md
@@ -1,12 +1,6 @@
 ---
 title: 厳格モード
 slug: Web/JavaScript/Reference/Strict_mode
-tags:
-  - ECMAScript 5
-  - ガイド
-  - JavaScript
-  - 厳格モード
-translation_of: Web/JavaScript/Reference/Strict_mode
 ---
 {{JsSidebar("More")}}
 

--- a/files/ja/web/javascript/reference/strict_mode/transitioning_to_strict_mode/index.md
+++ b/files/ja/web/javascript/reference/strict_mode/transitioning_to_strict_mode/index.md
@@ -1,11 +1,6 @@
 ---
 title: 厳格モードへの移行
 slug: Web/JavaScript/Reference/Strict_mode/Transitioning_to_strict_mode
-tags:
-  - 上級者
-  - ガイド
-  - JavaScript
-translation_of: Web/JavaScript/Reference/Strict_mode/Transitioning_to_strict_mode
 ---
 {{jsSidebar("More")}}
 

--- a/files/ja/web/javascript/reference/template_literals/index.md
+++ b/files/ja/web/javascript/reference/template_literals/index.md
@@ -1,18 +1,6 @@
 ---
 title: テンプレートリテラル (テンプレート文字列)
 slug: Web/JavaScript/Reference/Template_literals
-tags:
-  - ECMAScript 2015
-  - ガイド
-  - JavaScript
-  - React
-  - String
-  - テンプレート文字列
-  - テンプレートリテラル
-  - Template string
-  - 文字列
-browser-compat: javascript.grammar.template_literals
-translation_of: Web/JavaScript/Reference/Template_literals
 ---
 {{JsSidebar("More")}}
 

--- a/files/ja/web/javascript/reference/trailing_commas/index.md
+++ b/files/ja/web/javascript/reference/trailing_commas/index.md
@@ -1,16 +1,6 @@
 ---
 title: 末尾のカンマ
 slug: Web/JavaScript/Reference/Trailing_commas
-tags:
-  - Comma
-  - ECMAScript2017
-  - ECMAScript5
-  - JavaScript
-  - Language feature
-  - Syntax
-  - Trailing comma
-browser-compat: javascript.grammar.trailing_commas
-translation_of: Web/JavaScript/Reference/Trailing_commas
 ---
 {{JsSidebar("More")}}
 


### PR DESCRIPTION
Part of #7858

`web/javascript/reference/*` ( `global_objects` 以外) から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "tags": 202,
  "translation_of": 202,
  "browser-compat": 88
}
```
