### PR TITLE
remove duplicated frontmatter keys from web/javascript/* (ja)

### DIFF
--- a/files/ja/web/javascript/about_javascript/index.md
+++ b/files/ja/web/javascript/about_javascript/index.md
@@ -1,11 +1,6 @@
 ---
 title: JavaScript について
 slug: Web/JavaScript/About_JavaScript
-tags:
-  - Beginner
-  - Introduction
-  - JavaScript
-translation_of: Web/JavaScript/About_JavaScript
 ---
 {{JsSidebar}}
 

--- a/files/ja/web/javascript/closures/index.md
+++ b/files/ja/web/javascript/closures/index.md
@@ -1,14 +1,6 @@
 ---
 title: クロージャ
 slug: Web/JavaScript/Closures
-tags:
-  - Closure
-  - ES5
-  - Guide
-  - Intermediate
-  - JavaScript
-  - Reference
-translation_of: Web/JavaScript/Closures
 ---
 {{jsSidebar("Intermediate")}}
 

--- a/files/ja/web/javascript/data_structures/index.md
+++ b/files/ja/web/javascript/data_structures/index.md
@@ -1,12 +1,6 @@
 ---
 title: JavaScript のデータ型とデータ構造
 slug: Web/JavaScript/Data_structures
-tags:
-  - Beginner
-  - Guide
-  - JavaScript
-  - Types
-translation_of: Web/JavaScript/Data_structures
 ---
 {{jsSidebar("More")}}
 

--- a/files/ja/web/javascript/enumerability_and_ownership_of_properties/index.md
+++ b/files/ja/web/javascript/enumerability_and_ownership_of_properties/index.md
@@ -1,10 +1,6 @@
 ---
 title: プロパティの列挙可能性と所有権
 slug: Web/JavaScript/Enumerability_and_ownership_of_properties
-tags:
-  - Guide
-  - JavaScript
-translation_of: Web/JavaScript/Enumerability_and_ownership_of_properties
 ---
 {{JsSidebar("More")}}
 

--- a/files/ja/web/javascript/equality_comparisons_and_sameness/index.md
+++ b/files/ja/web/javascript/equality_comparisons_and_sameness/index.md
@@ -1,21 +1,6 @@
 ---
 title: 等価性の比較と同一性
 slug: Web/JavaScript/Equality_comparisons_and_sameness
-tags:
-  - Comparison
-  - Equality
-  - Intermediate
-  - JS
-  - JavaScript
-  - NaN
-  - SameValue
-  - SameValueZero
-  - Sameness
-  - 中級者
-  - 同値
-  - 比較
-  - 等価性
-translation_of: Web/JavaScript/Equality_comparisons_and_sameness
 ---
 {{jsSidebar("Intermediate")}}
 

--- a/files/ja/web/javascript/eventloop/index.md
+++ b/files/ja/web/javascript/eventloop/index.md
@@ -1,10 +1,6 @@
 ---
 title: 並行モデルとイベントループ
 slug: Web/JavaScript/EventLoop
-tags:
-  - Advanced
-  - JavaScript
-translation_of: Web/JavaScript/EventLoop
 ---
 {{JsSidebar("Advanced")}}
 

--- a/files/ja/web/javascript/guide/control_flow_and_error_handling/index.md
+++ b/files/ja/web/javascript/guide/control_flow_and_error_handling/index.md
@@ -1,18 +1,6 @@
 ---
 title: 制御フローとエラー処理
 slug: Web/JavaScript/Guide/Control_flow_and_error_handling
-tags:
-  - Beginner
-  - Decision making
-  - Error Handling
-  - Flow control
-  - Guide
-  - JavaScript
-  - Logic
-  - control
-  - l10n:priority
-  - statements
-translation_of: Web/JavaScript/Guide/Control_flow_and_error_handling
 ---
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Grammar_and_types", "Web/JavaScript/Guide/Loops_and_iteration")}}
 

--- a/files/ja/web/javascript/guide/expressions_and_operators/index.md
+++ b/files/ja/web/javascript/guide/expressions_and_operators/index.md
@@ -1,14 +1,6 @@
 ---
 title: 式と演算子
 slug: Web/JavaScript/Guide/Expressions_and_Operators
-tags:
-  - 初心者
-  - 式
-  - ガイド
-  - JavaScript
-  - 演算子
-  - l10n:priority
-translation_of: Web/JavaScript/Guide/Expressions_and_Operators
 ---
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Functions", "Web/JavaScript/Guide/Numbers_and_dates")}}
 

--- a/files/ja/web/javascript/guide/functions/index.md
+++ b/files/ja/web/javascript/guide/functions/index.md
@@ -1,13 +1,6 @@
 ---
 title: 関数
 slug: Web/JavaScript/Guide/Functions
-tags:
-  - Beginner
-  - Functions
-  - Guide
-  - JavaScript
-  - l10n:priority
-translation_of: Web/JavaScript/Guide/Functions
 ---
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Loops_and_iteration", "Web/JavaScript/Guide/Expressions_and_Operators")}}
 

--- a/files/ja/web/javascript/guide/grammar_and_types/index.md
+++ b/files/ja/web/javascript/guide/grammar_and_types/index.md
@@ -1,11 +1,6 @@
 ---
 title: 文法とデータ型
 slug: Web/JavaScript/Guide/Grammar_and_types
-tags:
-  - Guide
-  - JavaScript
-  - l10n:priority
-translation_of: Web/JavaScript/Guide/Grammar_and_types
 ---
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Introduction", "Web/JavaScript/Guide/Control_flow_and_error_handling")}}
 

--- a/files/ja/web/javascript/guide/index.md
+++ b/files/ja/web/javascript/guide/index.md
@@ -1,12 +1,6 @@
 ---
 title: JavaScript ガイド
 slug: Web/JavaScript/Guide
-tags:
-  - Guide
-  - JavaScript
-  - l10n:priority
-  - ガイド
-translation_of: Web/JavaScript/Guide
 ---
 {{jsSidebar("JavaScript Guide")}}
 

--- a/files/ja/web/javascript/guide/indexed_collections/index.md
+++ b/files/ja/web/javascript/guide/indexed_collections/index.md
@@ -1,11 +1,6 @@
 ---
 title: インデックス付きコレクション
 slug: Web/JavaScript/Guide/Indexed_collections
-tags:
-  - Guide
-  - JavaScript
-  - l10n:priority
-translation_of: Web/JavaScript/Guide/Indexed_collections
 ---
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Regular_Expressions", "Web/JavaScript/Guide/Keyed_Collections")}}
 

--- a/files/ja/web/javascript/guide/introduction/index.md
+++ b/files/ja/web/javascript/guide/introduction/index.md
@@ -1,13 +1,6 @@
 ---
 title: 入門編
 slug: Web/JavaScript/Guide/Introduction
-tags:
-  - Beginner
-  - Guide
-  - Introduction
-  - JavaScript
-  - l10n:priority
-translation_of: Web/JavaScript/Guide/Introduction
 ---
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide", "Web/JavaScript/Guide/Grammar_and_types")}}
 

--- a/files/ja/web/javascript/guide/iterators_and_generators/index.md
+++ b/files/ja/web/javascript/guide/iterators_and_generators/index.md
@@ -1,12 +1,6 @@
 ---
 title: イテレーターとジェネレーター
 slug: Web/JavaScript/Guide/Iterators_and_Generators
-tags:
-  - Guide
-  - Intermediate
-  - JavaScript
-  - l10n:priority
-translation_of: Web/JavaScript/Guide/Iterators_and_Generators
 ---
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Using_promises", "Web/JavaScript/Guide/Meta_programming")}}
 

--- a/files/ja/web/javascript/guide/keyed_collections/index.md
+++ b/files/ja/web/javascript/guide/keyed_collections/index.md
@@ -1,14 +1,6 @@
 ---
 title: キー付きコレクション
 slug: Web/JavaScript/Guide/Keyed_collections
-tags:
-  - Collections
-  - Guide
-  - JavaScript
-  - Map
-  - l10n:priority
-  - set
-translation_of: Web/JavaScript/Guide/Keyed_collections
 ---
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Indexed_Collections", "Web/JavaScript/Guide/Working_with_Objects")}}
 

--- a/files/ja/web/javascript/guide/loops_and_iteration/index.md
+++ b/files/ja/web/javascript/guide/loops_and_iteration/index.md
@@ -1,13 +1,6 @@
 ---
 title: ループと反復処理
 slug: Web/JavaScript/Guide/Loops_and_iteration
-tags:
-  - Guide
-  - JavaScript
-  - Loop
-  - Syntax
-  - l10n:priority
-translation_of: Web/JavaScript/Guide/Loops_and_iteration
 ---
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Control_flow_and_error_handling", "Web/JavaScript/Guide/Functions")}}
 

--- a/files/ja/web/javascript/guide/meta_programming/index.md
+++ b/files/ja/web/javascript/guide/meta_programming/index.md
@@ -1,14 +1,6 @@
 ---
 title: メタプログラミング
 slug: Web/JavaScript/Guide/Meta_programming
-tags:
-  - ECMAScript 2015
-  - Guide
-  - JavaScript
-  - Proxy
-  - Reflect
-  - l10n:priority
-translation_of: Web/JavaScript/Guide/Meta_programming
 ---
 {{jsSidebar("JavaScript Guide")}}{{PreviousNext("Web/JavaScript/Guide/Iterators_and_Generators", "Web/JavaScript/Guide/Modules")}}
 

--- a/files/ja/web/javascript/guide/modules/index.md
+++ b/files/ja/web/javascript/guide/modules/index.md
@@ -1,13 +1,6 @@
 ---
 title: JavaScript モジュール
 slug: Web/JavaScript/Guide/Modules
-tags:
-  - Guide
-  - JavaScript
-  - Modules
-  - export
-  - impot
-translation_of: Web/JavaScript/Guide/Modules
 ---
 {{jsSidebar("JavaScript Guide")}}{{Previous("Web/JavaScript/Guide/Meta_programming")}}
 

--- a/files/ja/web/javascript/guide/numbers_and_dates/index.md
+++ b/files/ja/web/javascript/guide/numbers_and_dates/index.md
@@ -1,20 +1,6 @@
 ---
 title: 数値と日付
 slug: Web/JavaScript/Guide/Numbers_and_dates
-tags:
-  - Calculation
-  - Dates
-  - FP
-  - Floating Point
-  - Floating-Point
-  - Guide
-  - Integer
-  - JavaScript
-  - Math
-  - Numbers
-  - Numeric
-  - l10n:priority
-translation_of: Web/JavaScript/Guide/Numbers_and_dates
 ---
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Expressions_and_Operators", "Web/JavaScript/Guide/Text_formatting")}}
 

--- a/files/ja/web/javascript/guide/regular_expressions/assertions/index.md
+++ b/files/ja/web/javascript/guide/regular_expressions/assertions/index.md
@@ -1,13 +1,6 @@
 ---
 title: 言明
 slug: Web/JavaScript/Guide/Regular_Expressions/Assertions
-tags:
-  - Assertions
-  - JavaScript
-  - Reference
-  - Regular Expressions
-  - regex
-translation_of: Web/JavaScript/Guide/Regular_Expressions/Assertions
 ---
 {{jsSidebar("JavaScript Guide")}}
 

--- a/files/ja/web/javascript/guide/regular_expressions/character_classes/index.md
+++ b/files/ja/web/javascript/guide/regular_expressions/character_classes/index.md
@@ -1,12 +1,6 @@
 ---
 title: 文字クラス
 slug: Web/JavaScript/Guide/Regular_Expressions/Character_Classes
-tags:
-  - JavaScript
-  - Reference
-  - RegExp
-  - Regular Expressions
-translation_of: Web/JavaScript/Guide/Regular_Expressions/Character_Classes
 ---
 {{JSSidebar("JavaScript Guide")}}
 

--- a/files/ja/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
+++ b/files/ja/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
@@ -1,13 +1,6 @@
 ---
 title: グループと範囲
 slug: Web/JavaScript/Guide/Regular_Expressions/Groups_and_Backreferences
-tags:
-  - Guide
-  - JavaScript
-  - Reference
-  - Regular Expressions
-  - regex
-translation_of: Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges
 original_slug: Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges
 ---
 {{jsSidebar("JavaScript Guide")}}

--- a/files/ja/web/javascript/guide/regular_expressions/index.md
+++ b/files/ja/web/javascript/guide/regular_expressions/index.md
@@ -1,15 +1,6 @@
 ---
 title: 正規表現
 slug: Web/JavaScript/Guide/Regular_Expressions
-tags:
-  - Guide
-  - Intermediate
-  - JavaScript
-  - Reference
-  - RegExp
-  - Regular Expressions
-  - regex
-translation_of: Web/JavaScript/Guide/Regular_Expressions
 ---
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Text_formatting", "Web/JavaScript/Guide/Indexed_collections")}}
 

--- a/files/ja/web/javascript/guide/regular_expressions/quantifiers/index.md
+++ b/files/ja/web/javascript/guide/regular_expressions/quantifiers/index.md
@@ -1,14 +1,6 @@
 ---
 title: 数量詞
 slug: Web/JavaScript/Guide/Regular_Expressions/Quantifiers
-tags:
-  - Guide
-  - JavaScript
-  - Reference
-  - Regular Expressions
-  - quantifiers
-  - regex
-translation_of: Web/JavaScript/Guide/Regular_Expressions/Quantifiers
 ---
 {{jsSidebar("JavaScript Guide")}}
 

--- a/files/ja/web/javascript/guide/text_formatting/index.md
+++ b/files/ja/web/javascript/guide/text_formatting/index.md
@@ -1,11 +1,6 @@
 ---
 title: テキスト処理
 slug: Web/JavaScript/Guide/Text_formatting
-tags:
-  - Guide
-  - JavaScript
-  - l10n:priority
-translation_of: Web/JavaScript/Guide/Text_formatting
 ---
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Numbers_and_dates", "Web/JavaScript/Guide/Regular_Expressions")}}
 

--- a/files/ja/web/javascript/guide/using_promises/index.md
+++ b/files/ja/web/javascript/guide/using_promises/index.md
@@ -1,15 +1,6 @@
 ---
 title: プロミスの使用
 slug: Web/JavaScript/Guide/Using_promises
-tags:
-  - Guide
-  - Intermediate
-  - JavaScript
-  - Promise
-  - Promises
-  - asynchronous
-  - l10n:priority
-translation_of: Web/JavaScript/Guide/Using_promises
 ---
 {{jsSidebar("JavaScript Guide")}}{{PreviousNext("Web/JavaScript/Guide/Details_of_the_Object_Model", "Web/JavaScript/Guide/Iterators_and_Generators")}}
 

--- a/files/ja/web/javascript/guide/working_with_objects/index.md
+++ b/files/ja/web/javascript/guide/working_with_objects/index.md
@@ -1,16 +1,6 @@
 ---
 title: オブジェクトでの作業
 slug: Web/JavaScript/Guide/Working_with_Objects
-tags:
-  - Beginner
-  - Document
-  - Guide
-  - JavaScript
-  - Object
-  - l10n:priority
-  - オブジェクトの比較
-  - コンストラクター
-translation_of: Web/JavaScript/Guide/Working_with_Objects
 ---
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Keyed_collections", "Web/JavaScript/Guide/Details_of_the_Object_Model")}}
 

--- a/files/ja/web/javascript/index.md
+++ b/files/ja/web/javascript/index.md
@@ -1,13 +1,6 @@
 ---
 title: JavaScript
 slug: Web/JavaScript
-tags:
-  - JavaScript
-  - Landing
-  - Landing page
-  - Learn
-  - l10n:priority
-translation_of: Web/JavaScript
 ---
 {{JsSidebar}}
 

--- a/files/ja/web/javascript/inheritance_and_the_prototype_chain/index.md
+++ b/files/ja/web/javascript/inheritance_and_the_prototype_chain/index.md
@@ -1,11 +1,6 @@
 ---
 title: 継承とプロトタイプチェーン
 slug: Web/JavaScript/Inheritance_and_the_prototype_chain
-tags:
-  - Inheritance
-  - JavaScript
-  - OOP
-translation_of: Web/JavaScript/Inheritance_and_the_prototype_chain
 ---
 {{jsSidebar("Advanced")}}
 

--- a/files/ja/web/javascript/javascript_technologies_overview/index.md
+++ b/files/ja/web/javascript/javascript_technologies_overview/index.md
@@ -1,11 +1,6 @@
 ---
 title: JavaScript 技術概説
 slug: Web/JavaScript/JavaScript_technologies_overview
-tags:
-  - Beginner
-  - DOM
-  - JavaScript
-translation_of: Web/JavaScript/JavaScript_technologies_overview
 ---
 {{JsSidebar("Introductory")}}
 

--- a/files/ja/web/javascript/language_overview/index.md
+++ b/files/ja/web/javascript/language_overview/index.md
@@ -1,15 +1,6 @@
 ---
 title: JavaScript 「再」入門
 slug: Web/JavaScript/Language_Overview
-tags:
-  - CodingScripting
-  - Guide
-  - Intermediate
-  - Intro
-  - JavaScript
-  - Learn
-  - Tutorial
-translation_of: Web/JavaScript/A_re-introduction_to_JavaScript
 original_slug: Web/JavaScript/A_re-introduction_to_JavaScript
 ---
 {{jsSidebar}}

--- a/files/ja/web/javascript/memory_management/index.md
+++ b/files/ja/web/javascript/memory_management/index.md
@@ -1,10 +1,6 @@
 ---
 title: メモリ管理
 slug: Web/JavaScript/Memory_Management
-tags:
-  - JavaScript
-  - memory
-translation_of: Web/JavaScript/Memory_Management
 ---
 {{JsSidebar("Advanced")}}
 

--- a/files/ja/web/javascript/shells/index.md
+++ b/files/ja/web/javascript/shells/index.md
@@ -1,12 +1,6 @@
 ---
 title: JavaScript シェル
 slug: Web/JavaScript/Shells
-tags:
-  - Extensions
-  - Guide
-  - JavaScript
-  - Tools
-translation_of: Web/JavaScript/Shells
 ---
 {{JsSidebar}}
 

--- a/files/ja/web/javascript/typed_arrays/index.md
+++ b/files/ja/web/javascript/typed_arrays/index.md
@@ -1,10 +1,6 @@
 ---
 title: JavaScript の型付き配列
 slug: Web/JavaScript/Typed_arrays
-tags:
-  - Guide
-  - JavaScript
-translation_of: Web/JavaScript/Typed_arrays
 ---
 {{JsSidebar("Advanced")}}
 


### PR DESCRIPTION
Part of #7858

`web/javascript/*` ( `reference` 以外) から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "tags": 34,
  "translation_of": 34
}
```
