### PR TITLE
remove duplicated frontmatter keys from web/xpath/* (ja)

### DIFF
--- a/files/ja/web/xpath/axes/ancestor-or-self/index.md
+++ b/files/ja/web/xpath/axes/ancestor-or-self/index.md
@@ -1,9 +1,5 @@
 ---
 title: ancestor-or-self
 slug: Web/XPath/Axes/ancestor-or-self
-tags:
-  - Axe
-  - XPath
-translation_of: Web/XPath/Axes/ancestor-or-self
 ---
 `ancestor-or-self`の軸は、コンテキストノードおよびルートノードを含むそのすべての祖先を示します。

--- a/files/ja/web/xpath/axes/ancestor/index.md
+++ b/files/ja/web/xpath/axes/ancestor/index.md
@@ -1,9 +1,5 @@
 ---
 title: ancestor
 slug: Web/XPath/Axes/ancestor
-tags:
-  - Axe
-  - XPath
-translation_of: Web/XPath/Axes/ancestor
 ---
 `ancestor`の軸は、親ノードで始まりルートノードに移動するコンテキストノードのすべての祖先を示します。

--- a/files/ja/web/xpath/axes/attribute/index.md
+++ b/files/ja/web/xpath/axes/attribute/index.md
@@ -1,9 +1,5 @@
 ---
 title: attribute
 slug: Web/XPath/Axes/attribute
-tags:
-  - Axe
-  - XPath
-translation_of: Web/XPath/Axes/attribute
 ---
 `attribute`の軸は、コンテキストノードの属性を示します。要素だけが属性を持ちます。この軸は、アットマーク (`@`) で省略することができます。

--- a/files/ja/web/xpath/axes/child/index.md
+++ b/files/ja/web/xpath/axes/child/index.md
@@ -1,10 +1,6 @@
 ---
 title: child
 slug: Web/XPath/Axes/child
-tags:
-  - Axe
-  - XPath
-translation_of: Web/XPath/Axes/child
 ---
 `child` 軸はコンテキストノードの子を示します。XPath 式が軸を指定していない場合、`child` 軸はデフォルトで認識されます。ルートノードまたは要素ノードだけが子を持つため、他の用途では何も選択されません。
 

--- a/files/ja/web/xpath/axes/descendant-or-self/index.md
+++ b/files/ja/web/xpath/axes/descendant-or-self/index.md
@@ -1,9 +1,5 @@
 ---
 title: descendant-or-self
 slug: Web/XPath/Axes/descendant-or-self
-tags:
-  - Axe
-  - XPath
-translation_of: Web/XPath/Axes/descendant-or-self
 ---
 `descendant-or-self`軸は、コンテキストノードとその子孫のすべてを示します。 属性ノードと名前空間ノードは含まれません。属性ノードの`parent`は`attribute`ノードですが、`attribute`ノードは親の子ノードではありません。

--- a/files/ja/web/xpath/axes/descendant/index.md
+++ b/files/ja/web/xpath/axes/descendant/index.md
@@ -1,9 +1,5 @@
 ---
 title: descendant
 slug: Web/XPath/Axes/descendant
-tags:
-  - Axe
-  - XPath
-translation_of: Web/XPath/Axes/descendant
 ---
 `descendant`軸は、コンテキストノードのすべての子孫、およびすべての子孫などを示します。 属性ノードと名前空間ノードは含まれ**ません**。属性ノードの`parent`は`attribute`ノードですが、`attribute`ノードは親の子ノードではありません。

--- a/files/ja/web/xpath/axes/following-sibling/index.md
+++ b/files/ja/web/xpath/axes/following-sibling/index.md
@@ -1,9 +1,5 @@
 ---
 title: following-sibling
 slug: Web/XPath/Axes/following-sibling
-tags:
-  - Axe
-  - XPath
-translation_of: Web/XPath/Axes/following-sibling
 ---
 `following-sibling`軸は、コンテキストノードと同じ親を持ち、ソースドキュメント内のコンテキストノードの後に現れるすべてのノードを示します。

--- a/files/ja/web/xpath/axes/following/index.md
+++ b/files/ja/web/xpath/axes/following/index.md
@@ -1,9 +1,5 @@
 ---
 title: following
 slug: Web/XPath/Axes/following
-tags:
-  - Axe
-  - XPath
-translation_of: Web/XPath/Axes/following
 ---
 `following`軸は、`descendant`ノード、`attribute`ノード、および`namespace`ノードを除き、コンテキストノードの後に表示されるすべてのノードを示します。

--- a/files/ja/web/xpath/axes/index.md
+++ b/files/ja/web/xpath/axes/index.md
@@ -1,13 +1,6 @@
 ---
 title: 軸
 slug: Web/XPath/Axes
-tags:
-  - Transforming_XML_with_XSLT
-  - XPath
-  - XPath_Reference
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Axes
 ---
 {{ XsltRef() }} [XPath](/ja/docs/Web/XPath) 仕様では 13 種類の軸 (Axis) が定められています。軸はコンテキストノードとの関連性を表し、ツリー上でのノードのコンテキストノードからの相対的な位置を示すのに用いられます。
 

--- a/files/ja/web/xpath/axes/namespace/index.md
+++ b/files/ja/web/xpath/axes/namespace/index.md
@@ -1,10 +1,6 @@
 ---
 title: namespace
 slug: Web/XPath/Axes/namespace
-tags:
-  - Axe
-  - XPath
-translation_of: Web/XPath/Axes/namespace
 ---
 _(サポート対象外)_
 `namespace`軸は、コンテキストノードのスコープ内にあるすべてのノードを示します。この場合、コンテキストノードは要素ノードでなければなりません。

--- a/files/ja/web/xpath/axes/parent/index.md
+++ b/files/ja/web/xpath/axes/parent/index.md
@@ -1,9 +1,5 @@
 ---
 title: parent
 slug: Web/XPath/Axes/parent
-tags:
-  - Axe
-  - XPath
-translation_of: Web/XPath/Axes/parent
 ---
 `parent`軸は、コンテキストノードの親である単一のノードを示します。それは 2 つのピリオド（..）に省略することができます。

--- a/files/ja/web/xpath/axes/preceding-sibling/index.md
+++ b/files/ja/web/xpath/axes/preceding-sibling/index.md
@@ -1,9 +1,5 @@
 ---
 title: preceding-sibling
 slug: Web/XPath/Axes/preceding-sibling
-tags:
-  - Axe
-  - XPath
-translation_of: Web/XPath/Axes/preceding-sibling
 ---
 `preceding-sibling`軸は、コンテキストノードと同じ親を持ち、ソースドキュメントのコンテキストノードの前に現れるすべてのノードを示します。

--- a/files/ja/web/xpath/axes/preceding/index.md
+++ b/files/ja/web/xpath/axes/preceding/index.md
@@ -1,9 +1,5 @@
 ---
 title: preceding
 slug: Web/XPath/Axes/preceding
-tags:
-  - Axe
-  - XPath
-translation_of: Web/XPath/Axes/preceding
 ---
 `preceding`軸は、`ancestor`ノード、`attribute`ノード、および`namespace`ノードを除いて、ドキュメント内のコンテキストノードに先行するすべてのノードを示します。

--- a/files/ja/web/xpath/axes/self/index.md
+++ b/files/ja/web/xpath/axes/self/index.md
@@ -1,10 +1,6 @@
 ---
 title: self
 slug: Web/XPath/Axes/self
-tags:
-  - Axe
-  - XPath
-translation_of: Web/XPath/Axes/self
 ---
 `self` 軸はコンテキストノード自体を表します。単一のピリオド (`.`) に省略することができます。
 

--- a/files/ja/web/xpath/comparison_with_css_selectors/index.md
+++ b/files/ja/web/xpath/comparison_with_css_selectors/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSS セレクターと XPath の比較
 slug: Web/XPath/Comparison_with_CSS_selectors
-tags:
-  - CSS
-  - Draft
-  - NeedsContent
-  - Reference
-  - Selectors
-  - XPath
-translation_of: Web/XPath/Comparison_with_CSS_selectors
 ---
 {{XSLTRef}}
 

--- a/files/ja/web/xpath/functions/boolean/index.md
+++ b/files/ja/web/xpath/functions/boolean/index.md
@@ -1,10 +1,6 @@
 ---
 title: boolean
 slug: Web/XPath/Functions/boolean
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/boolean
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/ceiling/index.md
+++ b/files/ja/web/xpath/functions/ceiling/index.md
@@ -1,10 +1,6 @@
 ---
 title: ceiling
 slug: Web/XPath/Functions/ceiling
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/ceiling
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/choose/index.md
+++ b/files/ja/web/xpath/functions/choose/index.md
@@ -1,11 +1,6 @@
 ---
 title: choose
 slug: Web/XPath/Functions/choose
-tags:
-  - Function
-  - XPath
-  - XSLT
-translation_of: Web/XPath/Functions/choose
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/concat/index.md
+++ b/files/ja/web/xpath/functions/concat/index.md
@@ -1,10 +1,6 @@
 ---
 title: concat
 slug: Web/XPath/Functions/concat
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/concat
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/contains/index.md
+++ b/files/ja/web/xpath/functions/contains/index.md
@@ -1,10 +1,6 @@
 ---
 title: contains
 slug: Web/XPath/Functions/contains
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/contains
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/count/index.md
+++ b/files/ja/web/xpath/functions/count/index.md
@@ -1,10 +1,6 @@
 ---
 title: count
 slug: Web/XPath/Functions/count
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/count
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/current/index.md
+++ b/files/ja/web/xpath/functions/current/index.md
@@ -1,10 +1,6 @@
 ---
 title: current
 slug: Web/XPath/Functions/current
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/current
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/document/index.md
+++ b/files/ja/web/xpath/functions/document/index.md
@@ -1,10 +1,6 @@
 ---
 title: document
 slug: Web/XPath/Functions/document
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/document
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/element-available/index.md
+++ b/files/ja/web/xpath/functions/element-available/index.md
@@ -1,10 +1,6 @@
 ---
 title: element-available
 slug: Web/XPath/Functions/element-available
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/element-available
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/false/index.md
+++ b/files/ja/web/xpath/functions/false/index.md
@@ -1,10 +1,6 @@
 ---
 title: 'false'
 slug: Web/XPath/Functions/false
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/false
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/floor/index.md
+++ b/files/ja/web/xpath/functions/floor/index.md
@@ -1,10 +1,6 @@
 ---
 title: floor
 slug: Web/XPath/Functions/floor
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/floor
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/format-number/index.md
+++ b/files/ja/web/xpath/functions/format-number/index.md
@@ -1,10 +1,6 @@
 ---
 title: format-number
 slug: Web/XPath/Functions/format-number
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/format-number
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/function-available/index.md
+++ b/files/ja/web/xpath/functions/function-available/index.md
@@ -1,10 +1,6 @@
 ---
 title: function-available
 slug: Web/XPath/Functions/function-available
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/function-available
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/generate-id/index.md
+++ b/files/ja/web/xpath/functions/generate-id/index.md
@@ -1,10 +1,6 @@
 ---
 title: generate-id
 slug: Web/XPath/Functions/generate-id
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/generate-id
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/id/index.md
+++ b/files/ja/web/xpath/functions/id/index.md
@@ -1,10 +1,6 @@
 ---
 title: id
 slug: Web/XPath/Functions/id
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/id
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/index.md
+++ b/files/ja/web/xpath/functions/index.md
@@ -1,13 +1,6 @@
 ---
 title: Functions
 slug: Web/XPath/Functions
-tags:
-  - Transforming_XML_with_XSLT
-  - XPath
-  - XPath_Reference
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/key/index.md
+++ b/files/ja/web/xpath/functions/key/index.md
@@ -1,10 +1,6 @@
 ---
 title: key
 slug: Web/XPath/Functions/key
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/key
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/lang/index.md
+++ b/files/ja/web/xpath/functions/lang/index.md
@@ -1,10 +1,6 @@
 ---
 title: lang
 slug: Web/XPath/Functions/lang
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/lang
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/last/index.md
+++ b/files/ja/web/xpath/functions/last/index.md
@@ -1,10 +1,6 @@
 ---
 title: last
 slug: Web/XPath/Functions/last
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/last
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/local-name/index.md
+++ b/files/ja/web/xpath/functions/local-name/index.md
@@ -1,10 +1,6 @@
 ---
 title: local-name
 slug: Web/XPath/Functions/local-name
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/local-name
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/name/index.md
+++ b/files/ja/web/xpath/functions/name/index.md
@@ -1,10 +1,6 @@
 ---
 title: name
 slug: Web/XPath/Functions/name
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/name
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/namespace-uri/index.md
+++ b/files/ja/web/xpath/functions/namespace-uri/index.md
@@ -1,10 +1,6 @@
 ---
 title: namespace-uri
 slug: Web/XPath/Functions/namespace-uri
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/namespace-uri
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/normalize-space/index.md
+++ b/files/ja/web/xpath/functions/normalize-space/index.md
@@ -1,10 +1,6 @@
 ---
 title: normalize-space
 slug: Web/XPath/Functions/normalize-space
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/normalize-space
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/not/index.md
+++ b/files/ja/web/xpath/functions/not/index.md
@@ -1,10 +1,6 @@
 ---
 title: not
 slug: Web/XPath/Functions/not
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/not
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/number/index.md
+++ b/files/ja/web/xpath/functions/number/index.md
@@ -1,10 +1,6 @@
 ---
 title: number
 slug: Web/XPath/Functions/number
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/number
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/position/index.md
+++ b/files/ja/web/xpath/functions/position/index.md
@@ -1,10 +1,6 @@
 ---
 title: position
 slug: Web/XPath/Functions/position
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/position
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/round/index.md
+++ b/files/ja/web/xpath/functions/round/index.md
@@ -1,10 +1,6 @@
 ---
 title: round
 slug: Web/XPath/Functions/round
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/round
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/starts-with/index.md
+++ b/files/ja/web/xpath/functions/starts-with/index.md
@@ -1,10 +1,6 @@
 ---
 title: starts-with
 slug: Web/XPath/Functions/starts-with
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/starts-with
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/string-length/index.md
+++ b/files/ja/web/xpath/functions/string-length/index.md
@@ -1,10 +1,6 @@
 ---
 title: string-length
 slug: Web/XPath/Functions/string-length
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/string-length
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/string/index.md
+++ b/files/ja/web/xpath/functions/string/index.md
@@ -1,10 +1,6 @@
 ---
 title: string
 slug: Web/XPath/Functions/string
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/string
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/substring-after/index.md
+++ b/files/ja/web/xpath/functions/substring-after/index.md
@@ -1,12 +1,6 @@
 ---
 title: substring-after
 slug: Web/XPath/Functions/substring-after
-tags:
-  - XPath 関数
-  - XSLT
-  - XSLT_Reference
-  - substring-after
-translation_of: Web/XPath/Functions/substring-after
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/substring-before/index.md
+++ b/files/ja/web/xpath/functions/substring-before/index.md
@@ -1,12 +1,6 @@
 ---
 title: substring-before
 slug: Web/XPath/Functions/substring-before
-tags:
-  - Function
-  - XSLT
-  - XSLT_Reference
-  - substring-before
-translation_of: Web/XPath/Functions/substring-before
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/substring/index.md
+++ b/files/ja/web/xpath/functions/substring/index.md
@@ -1,10 +1,6 @@
 ---
 title: substring
 slug: Web/XPath/Functions/substring
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/substring
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/sum/index.md
+++ b/files/ja/web/xpath/functions/sum/index.md
@@ -1,10 +1,6 @@
 ---
 title: sum
 slug: Web/XPath/Functions/sum
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/sum
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/system-property/index.md
+++ b/files/ja/web/xpath/functions/system-property/index.md
@@ -1,10 +1,6 @@
 ---
 title: system-property
 slug: Web/XPath/Functions/system-property
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/system-property
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/translate/index.md
+++ b/files/ja/web/xpath/functions/translate/index.md
@@ -1,10 +1,6 @@
 ---
 title: translate
 slug: Web/XPath/Functions/translate
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/translate
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/true/index.md
+++ b/files/ja/web/xpath/functions/true/index.md
@@ -1,10 +1,6 @@
 ---
 title: 'true'
 slug: Web/XPath/Functions/true
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/true
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/functions/unparsed-entity-url/index.md
+++ b/files/ja/web/xpath/functions/unparsed-entity-url/index.md
@@ -1,10 +1,6 @@
 ---
 title: unparsed-entity-url
 slug: Web/XPath/Functions/unparsed-entity-url
-tags:
-  - XSLT
-  - XSLT_Reference
-translation_of: Web/XPath/Functions/unparsed-entity-url
 ---
 {{ XsltRef() }}
 

--- a/files/ja/web/xpath/index.md
+++ b/files/ja/web/xpath/index.md
@@ -1,16 +1,6 @@
 ---
 title: XPath
 slug: Web/XPath
-tags:
-  - CSS セレクター
-  - DOM
-  - JXON
-  - Landing
-  - Path
-  - XML
-  - XPath
-  - XSLT
-translation_of: Web/XPath
 ---
 {{XSLTRef}}
 

--- a/files/ja/web/xpath/introduction_to_using_xpath_in_javascript/index.md
+++ b/files/ja/web/xpath/introduction_to_using_xpath_in_javascript/index.md
@@ -1,16 +1,6 @@
 ---
 title: JavaScript での XPath の利用の手引き
 slug: Web/XPath/Introduction_to_using_XPath_in_JavaScript
-tags:
-  - Add-ons
-  - DOM
-  - Extensions
-  - JavaScript
-  - Transforming_XML_with_XSLT
-  - Web Development
-  - XML
-  - XPath
-  - XSLT
 original_slug: Introduction_to_using_XPath_in_JavaScript
 ---
 この文書では、拡張機能やウェブサイトから JavaScript 内で [XPath](/ja/docs/Web/XPath) を使うためのインターフェイスについて解説します。 Mozilla は [DOM 3 XPath](https://www.w3.org/TR/DOM-Level-3-XPath/xpath.html) のかなりの部分を実装しており、 HTML 文書と XML 文書のどちらに対しても XPath 式を実行することができます。

--- a/files/ja/web/xpath/snippets/index.md
+++ b/files/ja/web/xpath/snippets/index.md
@@ -1,13 +1,6 @@
 ---
 title: XPath スニペット
 slug: Web/XPath/Snippets
-tags:
-  - XML
-  - XPath
-  - XSLT
-  - スニペット
-  - 例
-translation_of: Web/XPath/Snippets
 ---
 この記事ではいくつか XPath コードスニペットを提供します。それは XPath 機能を JavaScript コードに公開する[DOM Level 3 XPath 仕様](http://www.w3.org/TR/DOM-Level-3-XPath/)の標準インタフェースに基づく簡単なユーティリティ関数の簡単な例です。スニペットは実際にあなた自身のコードの中で使用できる関数です。
 


### PR DESCRIPTION
Part of #7858

`web/xpath/*` から、不要なメタを一括削除しました。

削除したメタの件数は以下の通りです。
```json
{
  "tags": 56,
  "translation_of": 55
}
```
