### PR TITLE
remove `{{Link}}` macro from ja locale

### DIFF
--- a/files/ja/glossary/javascript/index.md
+++ b/files/ja/glossary/javascript/index.md
@@ -26,7 +26,7 @@ JavaScript は主にブラウザーで使用され、これにより {{Glossary(
 
 ### JavaScript の学習
 
-- MDN 上の記事「{{Link("/ja/docs/Web/JavaScript/Guide")}}」
+- MDN 上の記事「[JavaScript ガイド](/ja/docs/Web/JavaScript/Guide)」
 - [NodeSchool による JavaScript ワークショップ](http://nodeschool.io/#workshoppers)
 - [codecademy.com による JavaScript 演習コース](https://www.codecademy.com/tracks/javascript)
 - [John Resig によるチュートリアル _「Learning Advanced JavaScript」_](http://ejohn.org/apps/learn/)
@@ -34,5 +34,5 @@ JavaScript は主にブラウザーで使用され、これにより {{Glossary(
 ### 技術リファレンス
 
 - [最新の ECMAScript 仕様書](http://www.ecma-international.org/publications/standards/Ecma-262.htm)
-- MDN 上の記事「{{Link("/ja/docs/Web/JavaScript/reference")}}」
+- MDN 上の記事「[JavaScript リファレンス](/ja/docs/Web/JavaScript/Reference)」
 - [JavaScript テキスト「Eloquent JavaScript」](http://eloquentjavascript.net/)

--- a/files/ja/glossary/json/index.md
+++ b/files/ja/glossary/json/index.md
@@ -16,4 +16,4 @@ JSON は伝統的な CSV 形式とは異なり、XML のような階層データ
 
 ### 技術リファレンス
 
-- MDN の {{Link("/ja/docs/Web/JavaScript/Reference/Global_Objects/JSON")}}
+- MDN の [JSON](/ja/docs/Web/JavaScript/Reference/Global_Objects/JSON)

--- a/files/ja/glossary/localization/index.md
+++ b/files/ja/glossary/localization/index.md
@@ -27,6 +27,5 @@ original_slug: Localization
 
 ### 一般知識
 
-- MDN の{{Link("/ja/docs/Mozilla/Localization")}}
 - ウィキペディアの{{interwiki("wikipedia", "ローカライゼーション")}}
 - ウィキペディアの{{interwiki("wikipedia", "国際化と地域化")}}


### PR DESCRIPTION
Part of #7566

# Note

`files/ja/glossary/localization/index.md` は、英語版から該当の記載がなくなっていたので削除