### PR TITLE
Remove most of the {{link}} macros from Spanish

### DIFF
--- a/files/es/glossary/javascript/index.md
+++ b/files/es/glossary/javascript/index.md
@@ -34,7 +34,7 @@ Recientemente, la popularidad de JavaScript se ha expandido aún más gracias a 
 
 ### Aprende JavaScript
 
-- {{Link("/es/docs/Web/JavaScript/Guide")}} en MDN
+- [Guía de JavaScript](/es/docs/Web/JavaScript/Guide) en MDN
 - [El taller de "javascripting" en NodeSchool](http://nodeschool.io/#workshoppers)
 - [El curso de JavaScript en codecademy.com](https://www.codecademy.com/tracks/javascript)
 - [_Aprendizaje avanzado de JavaScript_](http://ejohn.org/apps/learn/) de John Resig
@@ -42,5 +42,5 @@ Recientemente, la popularidad de JavaScript se ha expandido aún más gracias a 
 ### Referencia técnica
 
 - [El último estándar ECMAScript](http://www.ecma-international.org/publications/standards/Ecma-262.htm)
-- {{Link("/es/docs/Web/JavaScript/referencia")}} en MDN
+- [Referencia de JavaScript](/es/docs/Web/JavaScript/referencia) en MDN
 - [El libro _JavaScript elocuente_](http://eloquentjavascript.net/)

--- a/files/es/glossary/primitive/index.md
+++ b/files/es/glossary/primitive/index.md
@@ -103,7 +103,7 @@ El método {{JSxRef("Objetos_globales/Object/valueOf"," valueOf()")}} del conten
 
 <section id="Quick_links">
  <ol>
-  <li>{{Link("/es/docs/Glossary")}}
+  <li><a href="/es/docs/Glossary">Glosario</a>
    <ol>
     <li>{{Glossary("JavaScript")}}</li>
     <li>{{Glossary("string")}}</li>


### PR DESCRIPTION
The ones I didn’t remove had other attributes that I didn’t know what to do with.