### PR TITLE
Adding a space to successfully apply a syntax

### DIFF
--- a/files/zh-cn/web/javascript/reference/functions/get/index.md
+++ b/files/zh-cn/web/javascript/reference/functions/get/index.md
@@ -4,7 +4,7 @@ slug: Web/JavaScript/Reference/Functions/get
 ---
 {{jsSidebar("Functions")}}
 
-**`get`**语法将对象属性绑定到查询该属性时将被调用的函数。
+**`get`** 语法将对象属性绑定到查询该属性时将被调用的函数。
 
 {{EmbedInteractiveExample("pages/js/functions-getter.html")}}
 


### PR DESCRIPTION
The first line should be added a space to successfully apply the "bold text" syntax.