### PR TITLE
Correct the errors of translation expression about zh-CN

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/object/assign/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/object/assign/index.md
@@ -4,7 +4,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Object/assign
 ---
 {{JSRef}}
 
-**`Object.assign()`** 方法将所有{{jsxref("Object/propertyIsEnumerable", "可枚举", "", 1)}}（`Object.propertyIsEnumerable()` 返回 true）和{{jsxref("Object/hasOwnProperty", "自有", "", 1)}}（`Object.hasOwnProperty()` 返回 true）属性从一个或多个源对象复制到目标对象，返回修改后的对象。
+**`Object.assign()`** 方法将所有{{jsxref("Object/propertyIsEnumerable", "可枚举", "", 1)}}（`Object.propertyIsEnumerable()` 返回 true）的{{jsxref("Object/hasOwnProperty", "自有", "", 1)}}（`Object.hasOwnProperty()` 返回 true）属性从一个或多个源对象复制到目标对象，返回修改后的对象。
 
 {{EmbedInteractiveExample("pages/js/object-assign.html")}}
 


### PR DESCRIPTION
原文的意思是`可枚举且自有`，这里翻译成`可枚举的自有属性`较为合适，`可枚举和自有`在中文语境里具有歧义。
The original meaning is 'enumerable and own', this has translated into 'enumerable own properties' is more appropriate, 'enumerable, own' have the ambiguity in the Chinese.