### PR TITLE
add missing pt-br content about closures

### DIFF
--- a/files/pt-br/web/javascript/closures/index.html
+++ b/files/pt-br/web/javascript/closures/index.html
@@ -12,7 +12,7 @@ original_slug: Web/JavaScript/Guide/Closures
 ---
 <div>{{jsSidebar("Intermediate")}}</div>
 
-<p class="summary">Um <em>closure </em>(fechamento) é uma função que se "lembra" do ambiente — ou escopo léxico — em que ela foi criada.</p>
+<p class="summary">Uma <b>closure</b> é a combinação de uma função com as referências ao estado que a circunda (o <b>ambiente léxico</b>). Em outras palavras, uma closure lhe dá acesso ao escopo de uma função externa a partir de uma função interna. Em JavaScript, as closures são criadas toda vez que uma função é criada, no momento da criação da função.</p>
 
 <h2 id="Escopo_léxico">Escopo léxico</h2>
 
@@ -20,9 +20,10 @@ original_slug: Web/JavaScript/Guide/Closures
 
 <div style="width: auto; overflow: hidden;">
 <pre class="brush: js">function init() {
-  var name = "Mozilla";
+  var name = "Mozilla"; // name é uma variável local criada pelo init
   function displayName() {
-    alert(name);
+    // displayName() é a função interna, uma closure
+    console.log(name); // usa a variável declarada na função pai
   }
   displayName();
 }
@@ -30,7 +31,7 @@ init();
 </pre>
 </div>
 
-<p>A função <code>init()</code> cria uma variável local chamada <code>name</code>, e depois define uma função chamada <code>displayName()</code>. <code>displayName()</code> é uma função aninhada (um <em>closure</em>) — ela é definida dentro da função <code>init()</code>, e está disponivel apenas dentro do corpo daquela função. Diferente de <span style="font-family: courier new,andale mono,monospace; line-height: 1.5;">init()</span><span style="line-height: 1.5;">,</span><span style="line-height: 1.5;"> </span><code style="font-style: normal; line-height: 1.5;">displayName()</code><span style="line-height: 1.5;"> não tem variáveis locais próprias, e ao invés disso reusa a variável </span><code style="font-style: normal; line-height: 1.5;">name</code><span style="line-height: 1.5;"> declarada na função pai.</span></p>
+<p>A função <code>init()</code> cria uma variável local chamada <code>name</code>, e depois define uma função chamada <code>displayName()</code>. <code>displayName()</code> é uma função aninhada (uma <em>closure</em>) — ela é definida dentro da função <code>init()</code>, e está disponivel apenas dentro do corpo daquela função. Diferente de <span style="font-family: courier new,andale mono,monospace; line-height: 1.5;">init()</span><span style="line-height: 1.5;">,</span><span style="line-height: 1.5;"> </span><code style="font-style: normal; line-height: 1.5;">displayName()</code><span style="line-height: 1.5;"> não tem variáveis locais próprias, e ao invés disso reusa a variável </span><code style="font-style: normal; line-height: 1.5;">name</code><span style="line-height: 1.5;"> declarada na função pai.</span></p>
 
 <p><a href="http://jsfiddle.net/xAFs9/3/">Rode</a> o código e veja que isso funciona. Este é um exemplo de <em>escopo léxico:</em> em JavaScript, o escopo de uma variável é definido por sua localização dentro do código fonte (isto é aparentemente <em>léxico</em>) e funções aninhadas têm acesso às variáveis declaradas em seu escopo externo.</p>
 
@@ -54,7 +55,7 @@ myFunc();
 
 <p>Pode parecer não muito intuitivo de que o código de fato funciona. Normalmente variáveis locais de uma função, apenas existem pela duração de sua execução. Uma vez que <code>makeFunc()</code> terminou de executar, é razoável esperar que a variável <code>name</code> não será mais necessária. Dado que o código ainda funciona como o esperado, este não é o caso.</p>
 
-<p>A solução para tal problema é que a função <code>myFunc</code> tornou-se uma <code>closure</code>. Uma closure (fechamento) trata-se de um tipo especial de objeto que combina duas coisas: a função e o ambiente onde a função foi criada. Este ambiente consiste de quaisquer variáveis que estavam no escopo naquele momento em que a função foi criada. Neste caso, <code>myFunc</code> é a closure que incorpora tanto a função <code>displayName</code> quanto a palavra <em>Mozilla</em> que existia quando a closure foi criada.</p>
+<p>A solução para tal problema é que a função <code>myFunc</code> tornou-se uma <code>closure</code>. Uma closure trata-se de um tipo especial de objeto que combina duas coisas: a função e o ambiente onde a função foi criada. Este ambiente consiste de quaisquer variáveis que estavam no escopo naquele momento em que a função foi criada. Neste caso, <code>myFunc</code> é a closure que incorpora tanto a função <code>displayName</code> quanto a palavra <em>Mozilla</em> que existia quando a closure foi criada.</p>
 
 <p>Aqui temos um exemplo um pouco mais interessante, a função <code>makeAdder</code>:</p>
 
@@ -213,12 +214,12 @@ alert(Counter2.value()); /* Alerts 0 */
 
 <h2 id="Criando_closures_dentro_de_loops_Um_erro_comum">Criando closures dentro de loops: Um erro comum</h2>
 
-<p>Antes da introdução da palavra chave <a href="/en-US/docs/JavaScript/Reference/Statements/let" title="let"><code>let</code></a> no JavaScript 1.7, um problema comum ocorria com closures quando eram criadas dentro de um loop. Considere o exemplo:</p>
+<p>Antes da introdução da palavra chave <a href="/pt-BR/docs/JavaScript/Reference/Statements/let" title="let"><code>let</code></a> no JavaScript 1.7, um problema comum ocorria com closures quando eram criadas dentro de um loop. Considere o exemplo:</p>
 
-<pre class="brush: html">&lt;p id="help"&gt;Helpful notes will appear here&lt;/p&gt;
+<pre class="brush: html">&lt;p id="help"&gt;Notas úteis aparecerão aqui&lt;/p&gt;
 &lt;p&gt;E-mail: &lt;input type="text" id="email" name="email"&gt;&lt;/p&gt;
-&lt;p&gt;Name: &lt;input type="text" id="name" name="name"&gt;&lt;/p&gt;
-&lt;p&gt;Age: &lt;input type="text" id="age" name="age"&gt;&lt;/p&gt;
+&lt;p&gt;Nome: &lt;input type="text" id="name" name="name"&gt;&lt;/p&gt;
+&lt;p&gt;Idade: &lt;input type="text" id="age" name="age"&gt;&lt;/p&gt;
 </pre>
 
 <pre class="brush: js">function showHelp(help) {
@@ -227,12 +228,13 @@ alert(Counter2.value()); /* Alerts 0 */
 
 function setupHelp() {
   var helpText = [
-      {'id': 'email', 'help': 'Your e-mail address'},
-      {'id': 'name', 'help': 'Your full name'},
-      {'id': 'age', 'help': 'Your age (you must be over 16)'}
-    ];
+    {'id': 'email', 'help': 'Seu e-mail'},
+    {'id': 'name', 'help': 'Seu nome completo'},
+    {'id': 'age', 'help': 'Sua idade (você deve ter mais de 16 anos)'}
+  ];
 
   for (var i = 0; i &lt; helpText.length; i++) {
+    // O culpado é o uso do `var` nesta linha
     var item = helpText[i];
     document.getElementById(item.id).onfocus = function() {
       showHelp(item.help);
@@ -245,16 +247,16 @@ setupHelp();
 
 <p><a href="https://jsfiddle.net/v7gjv">View on JSFiddle</a></p>
 
-<p>O array <code>helpText</code> define três dicas úteis, cada uma associada ao ID de um input no documento. O loop percorre essas definições, atrelando um evento onfocus para cada um que mostra o método de ajuda associado.</p>
+<p>O array <code>helpText</code> define três dicas úteis, cada uma associada ao ID de um input no documento. O loop percorre essas definições, atrelando um evento <code>onfocus</code> para cada um que mostra o método de ajuda associado.</p>
 
 <p>Se você tentar executar esse código, Você verá que não vai funcionar como esperado. Não importa em qual campo ocorre o focus, a mensagem sobre a sua idade será mostrada.</p>
 
-<p>O motivo disto é que as funções atreladas ao onfocus são closures; elas consistem na definição da função e do ambiente capturado do escopo da função <code>setupHelp</code>. Três closures foram criados, mas todos eles compartilham o mesmo ambiente. No momento em que os callbacks do onfocus são executados, o loop segue seu curso e então a variável item (compartilhada por todos os três closures) fica apontando para a última entrada na lista <code>helpText</code>.</p>
+<p>O motivo disto é que as funções atreladas ao <code>onfocus</code> são closures; elas consistem na definição da função e do ambiente capturado do escopo da função <code>setupHelp</code>. Três closures foram criados, mas todos eles compartilham o mesmo ambiente. No momento em que os callbacks do <code>onfocus</code> são executados, o loop segue seu curso e então a variável <code>item</code> (compartilhada por todos os três closures) fica apontando para a última entrada na lista <code>helpText</code>.</p>
 
 <p>Uma solução seria neste caso usar mais closures: em particular, usar uma fábrica de funções como descrito anteriormente:</p>
 
 <pre class="brush: js">function showHelp(help) {
-  document.getElementById('help').innerHTML = help;
+  document.getElementById('help').textContent = help;
 }
 
 function makeHelpCallback(help) {
@@ -265,10 +267,10 @@ function makeHelpCallback(help) {
 
 function setupHelp() {
   var helpText = [
-      {'id': 'email', 'help': 'Your e-mail address'},
-      {'id': 'name', 'help': 'Your full name'},
-      {'id': 'age', 'help': 'Your age (you must be over 16)'}
-    ];
+    {'id': 'email', 'help': 'Seu e-mail'},
+    {'id': 'name', 'help': 'Seu nome completo'},
+    {'id': 'age', 'help': 'Sua idade (você deve ter mais de 16 anos)'}
+  ];
 
   for (var i = 0; i &lt; helpText.length; i++) {
     var item = helpText[i];
@@ -283,9 +285,84 @@ setupHelp();
 
 <p>Isto funciona conforme o esperado. Ao invés dos callbacks compartilharem o mesmo ambiente, a função <code>makeHelpCallback</code> cria um novo ambiente para cada um no qual <code>help</code> se refere à string correspondente do array <code>helpText</code>.</p>
 
+<p>Uma outra maneira de escrever o mesmo usando closures anônimas é:</p>
+
+<pre class="brush: js">function showHelp(help) {
+  document.getElementById('help').textContent = help;
+}
+
+function setupHelp() {
+  var helpText = [
+    {'id': 'email', 'help': 'Seu e-mail'},
+    {'id': 'name', 'help': 'Seu nome completo'},
+    {'id': 'age', 'help': 'Sua idade (você deve ter mais de 16 anos)'}
+  ];
+
+  for (var i = 0; i < helpText.length; i++) {
+    (function () {
+      var item = helpText[i];
+      document.getElementById(item.id).onfocus = function () {
+        showHelp(item.help);
+      };
+    })(); // Expressão de função invocada imediatamente com o valor atual do item (preservado até a iteração).
+  }
+}
+
+setupHelp();
+</pre>
+
+<p>Se você não quiser usar mais closures, você pode usar a palavra-chave <a href="/pt-BR/docs/JavaScript/Reference/Statements/let"><code>let</code></a> ou <a href="/pt-BR/docs/Web/JavaScript/Reference/Statements/const"><code>const</code></a>:</p>
+
+<pre class="brush: js">function showHelp(help) {
+  document.getElementById('help').textContent = help;
+}
+
+function setupHelp() {
+  var helpText = [
+    {'id': 'email', 'help': 'Seu e-mail'},
+    {'id': 'name', 'help': 'Seu nome completo'},
+    {'id': 'age', 'help': 'Sua idade (você deve ter mais de 16 anos)'}
+  ];
+
+  for (let i = 0; i < helpText.length; i++) {
+    const item = helpText[i];
+    document.getElementById(item.id).onfocus = () => {
+      showHelp(item.help);
+    };
+  }
+}
+
+setupHelp();
+</pre>
+
+<p>Este exemplo usa <code>const</code> em vez de <code>var</code>, portanto cada closure vincula a variável com escopo de bloco, o que significa que nenhuma closure adicional é necessária.</p>
+
+<p>Outra alternativa poderia ser usar <code>forEach()</code> para iterar sobre o array <code>helpText</code> e anexar um ouvinte a cada <a href="/pt-BR/docs/Web/HTML/Element/input"><code>&lt;input&gt;</code></a>, conforme mostrado:</p>
+
+<pre class="brush: js">function showHelp(help) {
+  document.getElementById('help').textContent = help;
+}
+
+function setupHelp() {
+  var helpText = [
+    {'id': 'email', 'help': 'Seu e-mail'},
+    {'id': 'name', 'help': 'Seu nome completo'},
+    {'id': 'age', 'help': 'Sua idade (você deve ter mais de 16 anos)'}
+  ];
+
+  helpText.forEach(function (text) {
+    document.getElementById(text.id).onfocus = function () {
+      showHelp(text.help);
+    };
+  });
+}
+
+setupHelp();
+</pre>
+
 <h2 id="Considerações_de_performance">Considerações de performance</h2>
 
-<p>Não é sábio criar funções dentro de outras funções se o closure não for necessário para uma tarefa em particular, pois ele afetará a performance do script de forma bem negativa tanto em velocidade de processamento quanto em consumo de memória.</p>
+<p>Não é sábio criar funções dentro de outras funções se a closure não for necessário para uma tarefa em particular, pois ele afetará a performance do script de forma bem negativa tanto em velocidade de processamento quanto em consumo de memória.</p>
 
 <p>Por exemplo, ao criar uma nova classe/objeto, os métodos devem normalmente estar associados ao protótipo do objeto do que definido no construtor. O motivo disso é que sempre que o construtor for chamado os métodos serão reatribuídos (isto é, para cada criação de objeto).</p>
 


### PR DESCRIPTION
I noticed missing content on the pt-BR version of Closures page (https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Closures).

I added some of the missing content based on the English version and took the opportunity to improve some Portuguese translations on the page.

(Didn't find any open issues related)