### PR TITLE
change korean interpretation of 'examples'

### DIFF
--- a/docs/ko/translation-guide.md
+++ b/docs/ko/translation-guide.md
@@ -234,7 +234,7 @@ A value of 0.01 was used for the value to ramp down to in the last function rath
 | Demo | 데모 | [링크](https://developer.mozilla.org/en-US/docs/Games/Techniques/3D_on_the_web/GLSL_Shaders#demo)
 | Description | 설명 | [링크](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#description)  
 | Example | 예제 | [링크](https://developer.mozilla.org/en-US/docs/Web/API/Event/target) |
-| Examples | 예제들 | [링크](https://developer.mozilla.org/en-US/docs/Glossary/loop#examples) |
+| Examples | 예제 | [링크](https://github.com/mdn/translated-content/blob/main/files/ko/web/javascript/reference/global_objects/proxy/proxy/apply/index.md) |
 | Guides | 가이드 | |
 | In this module | | [링크](https://developer.mozilla.org/ko/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_getting_started#in_this_module) |
 | Learn More | 더 알아보기 | [링크](https://developer.mozilla.org/en-US/docs/Glossary/Mutable) |


### PR DESCRIPTION
메인테이너들의 방에서 논의한 것과 같이 examples의 번역어를 '예제'로 제안합니다.
'예제들' 표현이 우리말에서 복수형을 자주 사용하지 않아 번역투로 느껴지는 까닭입니다. 