### PR TITLE
-webkit-text-fill-color の更新

### DIFF
--- a/files/ja/web/css/-webkit-text-fill-color/index.md
+++ b/files/ja/web/css/-webkit-text-fill-color/index.md
@@ -2,9 +2,9 @@
 title: '-webkit-text-fill-color'
 slug: Web/CSS/-webkit-text-fill-color
 ---
-{{CSSRef}}{{Non-standard_header}}
+{{CSSRef}}
 
-`**-webkit-text-fill-color**` は CSS のプロパティで、テキストの文字の塗りつぶしの[色](/ja/docs/Web/CSS/color_value)を指定します。このプロパティが設定されていない場合、 {{cssxref("color")}} プロパティの値が使用されます。
+**`-webkit-text-fill-color`** は CSS のプロパティで、テキストの文字の塗りつぶしの[色](/ja/docs/Web/CSS/color_value)を指定します。このプロパティが設定されていない場合、 {{cssxref("color")}} プロパティの値が使用されます。
 
 ```css
 /* <color> 値 */


### PR DESCRIPTION
https://developer.mozilla.org/ja/docs/Web/CSS/-webkit-text-fill-color
https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-text-fill-color

* 内容の更新（2022/09/07 時点の英語版に同期）