### PR TITLE
ci: Sync mdn-content through PRs

### DIFF
--- a/.github/workflows/sync-translated-content.yml
+++ b/.github/workflows/sync-translated-content.yml
@@ -60,7 +60,7 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           commit-message: "${{ matrix.lang }}: sync translated content"
-          branch: ${{ matrix.lang }}-content-sync
-          title: "${{ matrix.lang }}: sync translated content"
+          branch: content-sync-${{ matrix.lang }}
+          title: "[${{ matrix.lang }}] sync translated content"
           author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
           body: Yari generated sync

--- a/.github/workflows/sync-translated-content.yml
+++ b/.github/workflows/sync-translated-content.yml
@@ -62,5 +62,5 @@ jobs:
           commit-message: "${{ matrix.lang }}: sync translated content"
           branch: content-sync-${{ matrix.lang }}
           title: "[${{ matrix.lang }}] sync translated content"
-          author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           body: Yari generated sync

--- a/.github/workflows/sync-translated-content.yml
+++ b/.github/workflows/sync-translated-content.yml
@@ -16,6 +16,20 @@ jobs:
     if: github.repository == 'mdn/translated-content'
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+
+      matrix:
+        lang:
+          - es
+          - fr
+          - ja
+          - ko
+          - pt-br
+          - ru
+          - zh-cn
+          - zh-tw
+
     steps:
       - uses: actions/checkout@v3
 
@@ -33,25 +47,20 @@ jobs:
 
       - name: Install all yarn packages
         working-directory: ${{ github.workspace }}/mdn/content
-        run: |
-          yarn --frozen-lockfile
+        run: yarn --frozen-lockfile
 
       - name: Sync translated content
         env:
           CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
           CONTENT_TRANSLATED_ROOT: ${{ github.workspace }}/files
         working-directory: ${{ github.workspace }}/mdn/content
-        run: |
-          yarn content sync-translated-content
+        run: yarn content sync-translated-content ${{ matrix.lang }}
 
-      - name: Commit changes
-        # git commit will fail if there are no changes but that's okay!
-        continue-on-error: true
-        run: |
-          cd $GITHUB_WORKSPACE
-          git remote add upstream "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git commit -a -m "[CRON] sync translated content" && \
-          git pull --rebase upstream main && \
-          git push upstream main
+      - name: Create PR with sync for ${{ matrix.lang }}
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: "${{ matrix.lang }}: sync translated content"
+          branch: ${{ matrix.lang }}-content-sync
+          title: "${{ matrix.lang }}: sync translated content"
+          author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
+          body: Yari generated sync

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _githistory.json
 .DS_Store
+mdn/content


### PR DESCRIPTION
Creates a PR per language instead of pushing a larger sync commit to main.
Pretty sure the current approach is intended, so feel free to close.
This would also allow marking `main` as protected against non-PR pushes