### PR TITLE
Remove unnecessary ariaref

### DIFF
--- a/files/ja/web/accessibility/aria/roles/textbox_role/index.md
+++ b/files/ja/web/accessibility/aria/roles/textbox_role/index.md
@@ -2,7 +2,7 @@
 title: 'ARIA: textbox ロール'
 slug: Web/Accessibility/ARIA/Roles/textbox_role
 ---
-\\{{ariaref}}`textbox` ロールは、自由形式テキストの入力を可能にする要素を識別するために使用されます。 可能であれば、このロールを使用するのではなく、単一行入力の場合は [`type="text"`](/ja/docs/Web/HTML/Element/input/text) の {{HTMLElement("input")}} 要素を使用し、複数行入力の場合は {{HTMLElement("textarea")}} 要素を使用してください。
+`textbox` ロールは、自由形式テキストの入力を可能にする要素を識別するために使用されます。 可能であれば、このロールを使用するのではなく、単一行入力の場合は [`type="text"`](/ja/docs/Web/HTML/Element/input/text) の {{HTMLElement("input")}} 要素を使用し、複数行入力の場合は {{HTMLElement("textarea")}} 要素を使用してください。
 
 ## 説明
 


### PR DESCRIPTION
Remove unnecessary ariaref from "ARIA: textbox ロール" page. 

- https://developer.mozilla.org/ja/docs/Web/Accessibility/ARIA/Roles/textbox_role

<img width="426" alt="スクリーンショット 2022-09-10 11 23 37" src="https://user-images.githubusercontent.com/1457682/189465273-c3f397bc-e416-40ac-a954-eeb24bce3e52.png">

- original sentence: https://github.com/mdn/content/blob/main/files/en-us/web/accessibility/aria/roles/textbox_role/index.md?plain=1#L13