### PR TITLE
zh-CN: update AbortController example code

### DIFF
--- a/files/zh-cn/web/api/abortcontroller/index.md
+++ b/files/zh-cn/web/api/abortcontroller/index.md
@@ -34,27 +34,33 @@ slug: Web/API/AbortController
 当一个 [fetch request](/zh-CN/docs/Web/API/fetch) 初始化，我们把 `AbortSignal` 作为一个选项传递到到请求对象（如下 `{ signal }`）。这将 `signal` 和 `controller` 与这个 `fetch request` 相关联，然后允许我们通过调用 {{domxref("AbortController.abort()")}} 中止请求，如下第二个事件监听函数。
 
 ```js
-const controller = new AbortController();
-let signal = controller.signal;
+let controller;
+const url = 'video.mp4';
 
 const downloadBtn = document.querySelector('.download');
 const abortBtn = document.querySelector('.abort');
 
 downloadBtn.addEventListener('click', fetchVideo);
 
-abortBtn.addEventListener('click', function() {
-  controller.abort();
-  console.log('Download aborted');
+abortBtn.addEventListener('click', () => {
+  if (controller) {
+    controller.abort();
+    console.log('中止下载');
+  }
 });
 
 function fetchVideo() {
-  //...
-  fetch(url, {signal}).then(function(response) {
-    //...
-  }).catch(function(e) {
-    reports.textContent = 'Download error: ' + e.message;
-  })
+  controller = new AbortController();
+  const signal = controller.signal;
+  fetch(url, { signal })
+    .then((response) => {
+      console.log('下载完成', response);
+    })
+    .catch((err) => {
+      console.error(`下载错误: ${err.message}`);
+    });
 }
+
 ```
 
 > **备注：** 当 `abort()` 被调用时，这个 `fetch()` promise 将 `reject` 一个名为 `AbortError` 的 `DOMException`。

--- a/files/zh-cn/web/api/abortcontroller/index.md
+++ b/files/zh-cn/web/api/abortcontroller/index.md
@@ -57,10 +57,9 @@ function fetchVideo() {
       console.log('下载完成', response);
     })
     .catch((err) => {
-      console.error(`下载错误: ${err.message}`);
+      console.error(`下载错误：${err.message}`);
     });
 }
-
 ```
 
 > **备注：** 当 `abort()` 被调用时，这个 `fetch()` promise 将 `reject` 一个名为 `AbortError` 的 `DOMException`。
@@ -71,11 +70,11 @@ function fetchVideo() {
 
 {{Specifications}}
 
-## 浏览器兼容
+## 浏览器兼容性
 
 {{Compat}}
 
 ## 参见
 
 - [Fetch API](/zh-CN/docs/Web/API/Fetch_API)
-- [Abortable Fetch](https://developers.google.com/web/updates/2017/09/abortable-fetch) by Jake Archibald
+- [Abortable Fetch](https://developer.chrome.com/blog/abortable-fetch/) by Jake Archibald


### PR DESCRIPTION
The `zh-CN` version is not align with English version, and there is a Reference Error in `reports.textContent = 'Download error: ' + e.message;`. `reports` is not defined.

I think it should align with English version.