### PR TITLE
[Fixes #8464] Issue with "Héritage et chaîne de prototype": small typo

### DIFF
--- a/files/fr/web/javascript/inheritance_and_the_prototype_chain/index.md
+++ b/files/fr/web/javascript/inheritance_and_the_prototype_chain/index.md
@@ -12,7 +12,7 @@ original_slug: Web/JavaScript/Héritage_et_chaîne_de_prototypes
 ---
 {{jsSidebar("Advanced")}}
 
-JavaScript peut prêter à confusion losqu'on est habitué à manipuler des langages de programmation manipulant les classes (tels que Java ou C++). En effet, JavaScript est un langage dynamique et ne possède pas de concept de classe à part entière (le mot-clé `class` a certes été ajouté avec ES2015 mais il s'agit uniquement de sucre syntaxique, JavaScript continue de reposer sur l'héritage prototypique).
+JavaScript peut prêter à confusion lorsqu'on est habitué à manipuler des langages de programmation manipulant les classes (tels que Java ou C++). En effet, JavaScript est un langage dynamique et ne possède pas de concept de classe à part entière (le mot-clé `class` a certes été ajouté avec ES2015 mais il s'agit uniquement de sucre syntaxique, JavaScript continue de reposer sur l'héritage prototypique).
 
 En ce qui concerne l'héritage, JavaScript n'utilise qu'une seule structure : les objets. Chaque objet possède une propriété privée qui contient un lien vers un autre objet appelé le **prototype**. Ce prototype possède également son prototype et ainsi de suite, jusqu'à ce qu'un objet ait {{jsxref("null")}} comme prototype. Par définition, `null` ne possède pas de prototype et est ainsi le dernier maillon de la **chaîne de prototype**.
 


### PR DESCRIPTION
Description: Fixed typo in french in `fr/docs/Web/JavaScript/Inheritance_and_the_prototype_chain`

Issues: fixes #8464 which was added to `To-Do - Issues` by @cw118 