### PR TITLE
fix code example

### DIFF
--- a/files/zh-cn/web/javascript/reference/operators/super/index.md
+++ b/files/zh-cn/web/javascript/reference/operators/super/index.md
@@ -4,9 +4,9 @@ slug: Web/JavaScript/Reference/Operators/super
 ---
 {{jsSidebar("Operators")}}
 
-**super**关键字用于访问和调用一个对象的父对象上的函数。
+**super** 关键字用于访问和调用一个对象的父对象上的函数。
 
-`super.prop`和`super[expr]`表达式在[类](/zh-CN/docs/Web/JavaScript/Reference/Classes)和[对象字面量](/zh-CN/docs/Web/JavaScript/Reference/Operators/Object_initializer)任何[方法定义](/zh-CN/docs/Web/JavaScript/Reference/Functions/Method_definitions)中都是有效的。
+`super.prop` 和 `super[expr]` 表达式在[类](/zh-CN/docs/Web/JavaScript/Reference/Classes)和[对象字面量](/zh-CN/docs/Web/JavaScript/Reference/Operators/Object_initializer)任何[方法定义](/zh-CN/docs/Web/JavaScript/Reference/Functions/Method_definitions)中都是有效的。
 
 ## 语法
 
@@ -20,7 +20,7 @@ super.functionOnParent([arguments]);
 
 ## 描述
 
-在构造函数中使用时，`super`关键字将单独出现，并且必须在使用`this`关键字之前使用。`super`关键字也可以用来调用父对象上的函数。
+在构造函数中使用时，`super` 关键字将单独出现，并且必须在使用 `this` 关键字之前使用。`super` 关键字也可以用来调用父对象上的函数。
 
 ## 示例
 
@@ -67,18 +67,14 @@ class Square extends Polygon {
 
 ```js
 class Rectangle {
-  constructor() {}
   static logNbSides() {
     return 'I have 4 sides';
   }
 }
 
 class Square extends Rectangle {
-  constructor() {
-    super()
-  }
   static logDescription() {
-    return super.logNbSides() + ' which are all equal';
+    return `${super.logNbSides()} which are all equal`;
   }
 }
 Square.logDescription(); // 'I have 4 sides which are all equal'
@@ -86,17 +82,13 @@ Square.logDescription(); // 'I have 4 sides which are all equal'
 
 ### 删除 super 上的属性将抛出异常
 
-你不能使用 [delete 操作符](/zh-CN/docs/Web/JavaScript/Reference/Operators/delete) 加 `super.prop` 或者 `super[expr]` 去删除父类的属性，这样做会抛出 {{jsxref("ReferenceError")}}。
+你不能使用 [delete 操作符](/zh-CN/docs/Web/JavaScript/Reference/Operators/delete)加 `super.prop` 或者 `super[expr]` 去删除父类的属性，这样做会抛出 {{jsxref("ReferenceError")}}。
 
 ```js
 class Base {
-  constructor() {}
   foo() {}
 }
 class Derived extends Base {
-  constructor() {
-    super()
-  }
   delete() {
     delete super.foo; // this is bad
   }
@@ -107,7 +99,7 @@ new Derived().delete(); // ReferenceError: invalid delete involving 'super'.
 
 ### `super.prop` 不能覆写不可写属性
 
-当使用 {{jsxref("Object.defineProperty")}} 定义一个属性为不可写时，`super`将不能重写这个属性的值。
+当使用 {{jsxref("Object.defineProperty")}} 定义一个属性为不可写时，`super` 将不能重写这个属性的值。
 
 ```js
 class X {
@@ -134,9 +126,9 @@ y.foo(); // TypeError: "prop" is read-only
 console.log(y.prop); // 1
 ```
 
-### 在对象字面量中使用`super.prop`
+### 在对象字面量中使用 `super.prop`
 
-`Super`也可以在[object initializer / literal](/zh-CN/docs/Web/JavaScript/Reference/Operators/Object_initializer) 符号中使用。在下面的例子中，两个对象各定义了一个方法。在第二个对象中，我们使用`super`调用了第一个对象中的方法。 当然，这需要我们先利用 {{jsxref("Object.setPrototypeOf()")}} 设置`obj2`的原型为`obj1`，然后才能够使用`super`调用 `obj1`上的`method1`。
+`Super` 也可以在 [object initializer / literal](/zh-CN/docs/Web/JavaScript/Reference/Operators/Object_initializer) 符号中使用。在下面的例子中，两个对象各定义了一个方法。在第二个对象中，我们使用 `super` 调用了第一个对象中的方法。 当然，这需要我们先利用 {{jsxref("Object.setPrototypeOf()")}} 设置 `obj2` 的原型为 `obj1`，然后才能够使用 `super` 调用 `obj1` 上的 `method1`。
 
 ```js
 var obj1 = {
@@ -163,7 +155,6 @@ obj2.method2(); // logs "method 1"
 
 {{Compat}}
 
-## 相关链接
+## 参见
 
-- [Classes](/zh-CN/docs/Web/JavaScript/Reference/Classes)
-- [Anurag Majumdar - Super & Extends in JavaScript](https://medium.com/beginners-guide-to-mobile-web-development/super-and-extends-in-javascript-es6-understanding-the-tough-parts-6120372d3420)
+- [类](/zh-CN/docs/Web/JavaScript/Reference/Classes)

--- a/files/zh-cn/web/javascript/reference/operators/super/index.md
+++ b/files/zh-cn/web/javascript/reference/operators/super/index.md
@@ -74,7 +74,9 @@ class Rectangle {
 }
 
 class Square extends Rectangle {
-  constructor() {}
+  constructor() {
+    super()
+  }
   static logDescription() {
     return super.logNbSides() + ' which are all equal';
   }
@@ -92,7 +94,9 @@ class Base {
   foo() {}
 }
 class Derived extends Base {
-  constructor() {}
+  constructor() {
+    super()
+  }
   delete() {
     delete super.foo; // this is bad
   }


### PR DESCRIPTION
A subclass must call super when its constructor is declared. Sometimes, an empty constructor for the subclass are misleading