### PR TITLE
用語集 Server Timing の翻訳

### DIFF
--- a/files/ja/glossary/server_timing/index.md
+++ b/files/ja/glossary/server_timing/index.md
@@ -1,0 +1,13 @@
+---
+title: Server Timing
+slug: Glossary/Server_Timing
+l10n: 
+  sourceCommit: f4f8e2f18ccf19a0bee59e1fe78753e276b98232
+---
+
+[Server Timing specification](https://www.w3.org/TR/server-timing/) は、サーバーがリクエストとレスポンスのサイクルからユーザーエージェントにパフォーマンス指標を伝達することを可能にします。また、アプリケーションの配信を最適化するために、JavaScript のインターフェイスを利用して、アプリケーションがこれらの指標を収集・処理・動作することを可能にします。
+
+## 関連情報
+
+- <https://www.w3.org/TR/server-timing/>
+- [Resource Timing](https://www.w3.org/TR/resource-timing/)


### PR DESCRIPTION
ページ（用語集）：
https://developer.mozilla.org/en-US/docs/glossary/server_timing

日本語ページを新規追加（.md）して翻訳しました。

close https://github.com/mozilla-japan/translation/issues/640