### PR TITLE
chore: update links to pt-br learning area to learning-area

### DIFF
--- a/files/pt-br/learn/javascript/first_steps/a_first_splash/index.html
+++ b/files/pt-br/learn/javascript/first_steps/a_first_splash/index.html
@@ -201,7 +201,7 @@ translation_of: Learn/JavaScript/First_steps/A_first_splash
 
 <h3 id="Configuração_Inicial">Configuração Inicial</h3>
 
-<p>Para iniciar este tutorial, gostaríamos que você fizesse uma cópia do arquivo <a href="https://github.com/mdn/learning-area-pt-br/blob/master/javascript/introduction-to-js-1/first-splash/jogo-advinhe-o-numero-inicio.html">jogo-adivinhe-o-numero-inicio.html</a> (<a href="https://mdn.github.io/learning-area-pt-br/javascript/introduction-to-js-1/first-splash/jogo-advinhe-o-numero-inicio.html">ver demonstração</a>). Abra-o em um editor de texto e também no seu browser. No momento você vai apenas ver um simples cabeçalho, parágrafo de instruções e um formulário para entrada de informações, mas o formulário não fará nada por enquanto.</p>
+<p>Para iniciar este tutorial, gostaríamos que você fizesse uma cópia do arquivo <a href="https://github.com/mdn/learning-area/blob/main/javascript/introduction-to-js-1/first-splash/number-guessing-game-start.html">jogo-adivinhe-o-numero-inicio.html</a> (<a href="https://mdn.github.io/learning-area/javascript/introduction-to-js-1/first-splash/number-guessing-game-start.html">ver demonstração</a>). Abra-o em um editor de texto e também no seu browser. No momento você vai apenas ver um simples cabeçalho, parágrafo de instruções e um formulário para entrada de informações, mas o formulário não fará nada por enquanto.</p>
 
 <p>O lugar em que começaremos a escrever nosso código será dentro da tag {{htmlelement("script")}} na parte inferior do HTML:</p>
 
@@ -674,6 +674,6 @@ palpites.style.boxShadow = '3px 3px 6px black';</pre>
 
 <h2 id="Finalizado_por_enquanto...">Finalizado por enquanto...</h2>
 
-<p>Então é isso, para construir o exemplo — você chegou ao final, muito bem! Teste o resultado do seu código, ou <a href="https://mdn.github.io/learning-area-pt-br/javascript/introduction-to-js-1/first-splash/jogo-advinhe-o-numero.html">jogue com nossa versão finalizada aqui</a>. Se você não conseguir fazer o exemplo funcionar, compare com o <a href="https://github.com/mdn/learning-area-pt-br/blob/master/javascript/introduction-to-js-1/first-splash/jogo-advinhe-o-numero.html">código fonte</a>.</p>
+<p>Então é isso, para construir o exemplo — você chegou ao final, muito bem! Teste o resultado do seu código, ou <a href="https://mdn.github.io/learning-area/javascript/introduction-to-js-1/first-splash/number-guessing-game.html">jogue com nossa versão finalizada aqui</a>. Se você não conseguir fazer o exemplo funcionar, compare com o <a href="https://github.com/mdn/learning-area/blob/main/javascript/introduction-to-js-1/first-splash/number-guessing-game.html">código fonte</a>.</p>
 
 <p>{{PreviousMenuNext("Learn/JavaScript/First_steps/What_is_JavaScript", "Learn/JavaScript/First_steps/What_went_wrong", "Learn/JavaScript/First_steps")}}</p>

--- a/files/pt-br/learn/javascript/first_steps/math/index.html
+++ b/files/pt-br/learn/javascript/first_steps/math/index.html
@@ -68,9 +68,9 @@ original_slug: Learn/JavaScript/First_steps/Matematica
 
 <p>Vamos brincar rapidamente com alguns números para nos familiarizarmos com a sintaxe básica que precisamos. Insira os comandos listados abaixo em seu <a href="/pt-BR/docs/Learn/Common_questions/ferramentas_de_desenvolvimento_do_navegador">console JavaScript</a>, ou use o console simples incorporado abaixo, se preferir.</p>
 
-<p>{{EmbedGHLiveSample("learning-area-pt-br/javascript/introduction-to-js-1/variables/index.html", '100%', 300)}}</p>
+<p>{{EmbedGHLiveSample("learning-area/javascript/introduction-to-js-1/variables/index.html", '100%', 300)}}</p>
 
-<p><strong><a href="https://mdn.github.io/learning-area-pt-br/javascript/introduction-to-js-1/variables/">Abra em uma nova janela</a></strong></p>
+<p><strong><a href="https://mdn.github.io/learning-area/javascript/introduction-to-js-1/variables/">Abra em uma nova janela</a></strong></p>
 
 <ol>
  <li>Primeiramente, vamos declarar duas variáveis e as inicializar com um <em>integer</em> e um <em>float</em>, respectivamente, então digitaremos os nomes das variáveis para verificar se está tudo em ordem:

--- a/files/pt-br/learn/javascript/first_steps/what_is_javascript/index.html
+++ b/files/pt-br/learn/javascript/first_steps/what_is_javascript/index.html
@@ -90,7 +90,7 @@ function atualizarNome() {
 
 <p>{{ EmbedLiveSample('A_high-level_definition', '100%', 80, "", "", "hide-codepen-jsfiddle") }}</p>
 
-<p>Experimente clicar no botão acima para ver o que acontece (note também que você pode encontrar essa demonstração no GitHub — veja o <a href="https://github.com/mdn/learning-area-pt-br/blob/master/javascript/introduction-to-js-1/what-is-js/javascript-rotulo.html">código fonte</a> ou <a href="https://mdn.github.io/learning-area-pt-br/javascript/introduction-to-js-1/what-is-js/javascript-rotulo.html">veja funcionar</a>)!</p>
+<p>Experimente clicar no botão acima para ver o que acontece (note também que você pode encontrar essa demonstração no GitHub — veja o <a href="https://github.com/mdn/learning-area/blob/main/javascript/introduction-to-js-1/what-is-js/javascript-label.html">código fonte</a> ou <a href="https://mdn.github.io/learning-area/javascript/introduction-to-js-1/what-is-js/javascript-label.html">veja funcionar</a>)!</p>
 
 <p>JavaScript pode fazer muito mais do que isso — vamos explorar com mais detalhes.</p>
 
@@ -207,7 +207,7 @@ function atualizarNome() {
 <h3 id="JavaScript_interno">JavaScript interno</h3>
 
 <ol>
- <li>Antes de tudo, faça uma cópia local do nosso arquivo de exemplo <a href="https://github.com/mdn/learning-area-pt-br/blob/master/javascript/introduction-to-js-1/what-is-js/aplicando-javascript.html">aplicando-javascript.html</a>. Salve-o em alguma pasta, de uma forma sensata.</li>
+ <li>Antes de tudo, faça uma cópia local do nosso arquivo de exemplo <a href="https://github.com/mdn/learning-area/blob/main/javascript/introduction-to-js-1/what-is-js/apply-javascript.html">aplicando-javascript.html</a>. Salve-o em alguma pasta, de uma forma sensata.</li>
  <li>Abra o arquivo no seu navegador web e no seu editor de texto. Você verá que o HTML cria uma simples página web contendo um botão clicável.</li>
  <li>Agora, vá até o seu editor de texto e adicione o código a seguir antes da tag de fechamento <code>&lt;/body&gt;</code>:
   <pre class="brush: html notranslate">&lt;script&gt;
@@ -237,7 +237,7 @@ for(var i = 0; i &lt; botoes.length ; i++) {
 </div>
 
 <div class="note">
-<p><strong>Nota</strong>: Você pode ver essa versão no GitHub como <a href="https://github.com/mdn/learning-area-pt-br/blob/master/javascript/introduction-to-js-1/what-is-js/aplicando-javascript-interno.html">apicando-javascript-interno.html</a> (<a href="https://mdn.github.io/learning-area-pt-br/javascript/introduction-to-js-1/what-is-js/aplicando-javascript-interno.html">veja funcionar também</a>).</p>
+<p><strong>Nota</strong>: Você pode ver essa versão no GitHub como <a href="https://github.com/mdn/learning-area/blob/main/javascript/introduction-to-js-1/what-is-js/apply-javascript-internal.html">apicando-javascript-interno.html</a> (<a href="https://mdn.github.io/learning-area/javascript/introduction-to-js-1/what-is-js/apply-javascript-internal.html">veja funcionar também</a>).</p>
 </div>
 
 <h3 id="JavaScript_externo">JavaScript externo</h3>
@@ -266,7 +266,7 @@ for(let i = 0; i &lt; buttons.length ; i++) {
 </ol>
 
 <div class="note">
-<p><strong>Nota</strong>: Você pode ver essa versão no GitHub como <a href="https://github.com/mdn/learning-area-pt-br/blob/master/javascript/introduction-to-js-1/what-is-js/aplicando-javascript-externo.html">aplicando-javascript-externo.html</a> e <a href="https://github.com/mdn/learning-area-pt-br/blob/master/javascript/introduction-to-js-1/what-is-js/script.js">script.js</a> (<a href="https://mdn.github.io/learning-area-pt-br/javascript/introduction-to-js-1/what-is-js/aplicando-javascript-externo.html">veja funcionar também</a>).</p>
+<p><strong>Nota</strong>: Você pode ver essa versão no GitHub como <a href="https://github.com/mdn/learning-area/blob/main/javascript/introduction-to-js-1/what-is-js/apply-javascript-external.html">aplicando-javascript-externo.html</a> e <a href="https://github.com/mdn/learning-area/blob/main/javascript/introduction-to-js-1/what-is-js/script.js">script.js</a> (<a href="https://mdn.github.io/learning-area/javascript/introduction-to-js-1/what-is-js/apply-javascript-external.html">veja funcionar também</a>).</p>
 </div>
 
 <h3 id="Manipuladores_de_JavaScript_inline">Manipuladores de JavaScript inline</h3>

--- a/files/pt-br/learn/javascript/first_steps/what_went_wrong/index.html
+++ b/files/pt-br/learn/javascript/first_steps/what_went_wrong/index.html
@@ -37,7 +37,7 @@ translation_of: Learn/JavaScript/First_steps/What_went_wrong
 
 <h2 id="Um_exemplo_errôneo">Um exemplo errôneo</h2>
 
-<p>Para começar, voltemos ao nosso jogo de adivinhação - porém desta vez estaremos explorando uma versão que tem alguns erros inseridos propositalmente. Vá até o Github e faça uma cópia local de <a href="https://github.com/mdn/learning-area-pt-br/blob/master/javascript/introduction-to-js-1/troubleshooting/jogo-numero-erros.html">jogo-numero-erros.html</a> (<a href="https://mdn.github.io/learning-area-pt-br/javascript/introduction-to-js-1/troubleshooting/jogo-numero-erros.html">veja-o em execução aqui</a>).</p>
+<p>Para começar, voltemos ao nosso jogo de adivinhação - porém desta vez estaremos explorando uma versão que tem alguns erros inseridos propositalmente. Vá até o Github e faça uma cópia local de <a href="https://github.com/mdn/learning-area/blob/main/javascript/introduction-to-js-1/troubleshooting/number-game-errors.html">jogo-numero-erros.html</a> (<a href="https://mdn.github.io/learning-area/javascript/introduction-to-js-1/troubleshooting/number-game-errors.html">veja-o em execução aqui</a>).</p>
 
 <ol>
  <li>Para começar, abra a cópia local dentro do seu editor de texto favorito, e em seu navegador.</li>


### PR DESCRIPTION
The pt-br version of the learning area repository has been archived.
https://github.com/orgs/mdn/teams/yari-content-pt-br/discussions/2

This updates links to point to the same pages on mdn/learning-area
