### PR TITLE
ci: use automerge token for sync PRs

### DIFF
--- a/.github/workflows/sync-translated-content.yml
+++ b/.github/workflows/sync-translated-content.yml
@@ -64,3 +64,4 @@ jobs:
           title: "[${{ matrix.lang }}] sync translated content"
           author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           body: Yari generated sync
+          token: ${{ secrets.AUTOMERGE_TOKEN }}

--- a/.github/workflows/sync-translated-content.yml
+++ b/.github/workflows/sync-translated-content.yml
@@ -62,6 +62,6 @@ jobs:
           commit-message: "${{ matrix.lang }}: sync translated content"
           branch: content-sync-${{ matrix.lang }}
           title: "[${{ matrix.lang }}] sync translated content"
-          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
           body: Yari generated sync
           token: ${{ secrets.AUTOMERGE_TOKEN }}


### PR DESCRIPTION
Fixes #8647

This should allow the CI jobs and labeling to work on these PRs https://github.com/peter-evans/create-pull-request#action-inputs