### PR TITLE
Update index.md

### DIFF
--- a/files/pt-br/web/javascript/reference/global_objects/array/slice/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/array/slice/index.md
@@ -11,7 +11,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/Array/slice
 ---
 {{JSRef}}
 
-O método **`slice()`** retorna uma cópia de parte de um array a partir de um subarray criado entre as posições `início` e `fim` (fim não é necessário) de um array original. O Array original não é modificado.
+O método **`slice()`** retorna uma cópia de parte de um array a partir de um subarray criado entre as posições `início` e `fim` (fim não é incluído) de um array original. O Array original não é modificado.
 
 ## Syntaxe
 


### PR DESCRIPTION
Considerando o texto em inglês: ... into a new array object selected from start to end (end not included) ...., acredito que para o melhor entendimento do funcionamento do método slice(), seria colocar no texto entre parênteses (fim não é incluído) que acredito que foi a intenção do texto em inglês e que seria a informação mais importante para estar no parágrafo introdutório desse método.

Acredito que a informação (fim não é necessário) também é correta, pois é possível utilizar o slice() apenas com o valor inicial, mas pelo motivo apresentado anteriormente, acredito que (fim não é incluído) facilitaria o entendimento do método logo no início do conteúdo.