### PR TITLE
「MDN Web Docs のローカライズ」の微修正

### DIFF
--- a/files/ja/mdn/community/contributing/translated_content/index.md
+++ b/files/ja/mdn/community/contributing/translated_content/index.md
@@ -27,7 +27,7 @@ l10n:
 
 ### フランス語 (fr)
 
-- Discussions : [Matrix (#l10n-fr channel)](https://chat.mozilla.org/#/room/#l10n-fr:mozilla.org)
+- ディスカッション: [Matrix (#l10n-fr channel)](https://chat.mozilla.org/#/room/#l10n-fr:mozilla.org)
 - 現在の貢献者: [cw118](https://github.com/cw118), [SphinxKnight](https://github.com/SphinxKnight), [tristantheb](https://github.com/tristantheb)
 
 ### 日本語 (ja)


### PR DESCRIPTION
ディスカッションに表記ゆれがありましたので修正しました