### PR TITLE
Use double quotes to remain consistent with other content

### DIFF
--- a/files/fr/web/css/_doublecolon_before/index.md
+++ b/files/fr/web/css/_doublecolon_before/index.md
@@ -47,7 +47,7 @@ q::before {
   color: blue;
 }
 q::after {
-  content: '»';
+  content: "»";
   color: red;
 }
 ```


### PR DESCRIPTION
Use double quotes for `::after` pseudo-element to remain consistent with other content like for `::before`