### PR TITLE
リンクから $edit を除去

### DIFF
--- a/files/ja/mozilla/add-ons/webextensions/match_patterns/index.md
+++ b/files/ja/mozilla/add-ons/webextensions/match_patterns/index.md
@@ -12,7 +12,7 @@ slug: Mozilla/Add-ons/WebExtensions/Match_patterns
 ## マッチパターンの構造
 
 > **Note:** **記:** ブラウザーによってはサポートしていないスキームがあります。
-> 詳しくは[ブラウザー互換性テーブル](/ja/docs/Mozilla/Add-ons/WebExtensions/Match_patterns$edit#Browser_compatibility)を見てください。
+> 詳しくは[ブラウザー互換性テーブル](/ja/docs/Mozilla/Add-ons/WebExtensions/Match_patterns#Browser_compatibility)を見てください。
 
 すべてのマッチパターンは文字列で指定します。特別な値 [`<all_urls>`](/ja/Add-ons/WebExtensions/Match_patterns#%3Call_urls%3E) を除き、マッチパターンは３つの部分から成り立っています。 _scheme_, _host_, _path_ です。 scheme と host の間は `://` で句切られます。
 

--- a/files/ja/web/api/idbcursor/index.md
+++ b/files/ja/web/api/idbcursor/index.md
@@ -17,7 +17,7 @@ slug: Web/API/IDBCursor
 - {{domxref("IDBCursor.source")}} {{readonlyInline}}
   - : カーソルが繰り返している{{domxref("IDBObjectStore")}} か {{domxref("IDBIndex")}} を返します。この関数は、カーソルが現在繰り返されていたり、繰り返しが終わりを過ぎたり、トランザクションがアクティブでなくても、null や例外を返しません。
 - {{domxref("IDBCursor.direction")}} {{readonlyInline}}
-  - : カーソルの横断の向きを返します。取りうる値については [Constants](/ja/docs/Web/API/IDBCursor$edit#const_next) を見てください。
+  - : カーソルの横断の向きを返します。取りうる値については [Constants](/ja/docs/Web/API/IDBCursor#const_next) を見てください。
 - {{domxref("IDBCursor.key")}} {{readonlyInline}}
   - : カーソル位置のレコードのキーを返します。カーソルが範囲外の場合、`undefined` にセットされます。カーソルキーはあらゆるデータ型となりえます。
 - {{domxref("IDBCursor.value")}} {{readonlyInline}}

--- a/files/ja/web/http/feature_policy/using_feature_policy/index.md
+++ b/files/ja/web/http/feature_policy/using_feature_policy/index.md
@@ -77,7 +77,7 @@ Feature Policy を使用する 2 つ目の方法は、iframe 内のコンテン�
 <iframe src="https://example.com..." allow="fullscreen"></iframe>
 ```
 
-`<iframe>` がデフォルトで許可している [allowlist](/ja/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy$edit#allowlist) の値は `'src'` です。したがって、以下のようにも書いても同じとなります。
+`<iframe>` がデフォルトで許可している [allowlist](/ja/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy#allowlist) の値は `'src'` です。したがって、以下のようにも書いても同じとなります。
 
 ```html
 <iframe src="https://example.com..." allow="fullscreen 'src'"></iframe>


### PR DESCRIPTION
$edit は旧プラットフォームの名残であり、現在のプラットフォームでは誤動作を引き起こしかねないため