### PR TITLE
Issue #8532 - Fix incorrect wikipedia REST link

### DIFF
--- a/files/es/glossary/rest/index.md
+++ b/files/es/glossary/rest/index.md
@@ -22,5 +22,5 @@ Como {{Glossary("HTTP")}}, el protocolo estandar de la {{glossary("World Wide We
 
 ### Conocimientos generales
 
-- [REST](https://es.wikipedia.org/wiki/Transferencia_de_Estado_Representacional) on Wikipedia
+- [REST](https://es.wikipedia.org/wiki/Transferencia_de_Estado_Representacional) en Wikipedia
 - [REST Architecture](https://www.service-architecture.com/articles/web-services/representational_state_transfer_rest.html)

--- a/files/es/glossary/rest/index.md
+++ b/files/es/glossary/rest/index.md
@@ -22,5 +22,5 @@ Como {{Glossary("HTTP")}}, el protocolo estandar de la {{glossary("World Wide We
 
 ### Conocimientos generales
 
-- {{Interwiki("wikipedia", "Representational_state_transfer", "REST")}} on Wikipedia
+- [REST](https://es.wikipedia.org/wiki/Transferencia_de_Estado_Representacional) on Wikipedia
 - [REST Architecture](https://www.service-architecture.com/articles/web-services/representational_state_transfer_rest.html)


### PR DESCRIPTION
Changed the wrong link to the correct one and fixed the structure of the content to be the same as the rest of the page

fix #8532