### PR TITLE
用語集 XIncludeを日本語に翻訳。

### DIFF
--- a/files/ja/glossary/xinclude/index.md
+++ b/files/ja/glossary/xinclude/index.md
@@ -1,14 +1,13 @@
 ---
 title: XInclude
 slug: Glossary/XInclude
-tags:
-  - CodingScripting
-  - Glossary
+l10n: 
+  sourceCommit: f4f8e2f18ccf19a0bee59e1fe78753e276b98232
 ---
 
 XInclude は、文書に他の文書または他の文書の一部を含められるようにする、包含タグを定めた W3C 勧告です。他の XML ファイルやテキストファイルからコンテンツを取り込むことができます。
 
-主要なブラウザは、XInclude の仕組みを標準ではサポートしていません。
+主要なブラウザーは、XInclude の仕組みを標準ではサポートしていません。
 
 ## 関連情報
 

--- a/files/ja/glossary/xinclude/index.md
+++ b/files/ja/glossary/xinclude/index.md
@@ -1,0 +1,16 @@
+---
+title: XInclude
+slug: Glossary/XInclude
+tags:
+  - CodingScripting
+  - Glossary
+---
+
+XInclude は、文書に他の文書または他の文書の一部を含められるようにする、包含タグを定めた W3C 勧告です。他の XML ファイルやテキストファイルからコンテンツを取り込むことができます。
+
+主要なブラウザは、XInclude の仕組みを標準ではサポートしていません。
+
+## 関連情報
+
+- [XInclude standard](https://www.w3.org/TR/xinclude-11/)
+- [`XPath`](/en-US/docs/Web/XPath)

--- a/files/ja/glossary/xinclude/index.md
+++ b/files/ja/glossary/xinclude/index.md
@@ -13,4 +13,4 @@ XInclude は、文書に他の文書または他の文書の一部を含めら�
 ## 関連情報
 
 - [XInclude standard](https://www.w3.org/TR/xinclude-11/)
-- [`XPath`](/en-US/docs/Web/XPath)
+- [`XPath`](/ja/docs/Web/XPath)


### PR DESCRIPTION
用語集 XInclude を日本語に翻訳しました。確認をお願いします。