### PR TITLE
fix: typo on Set documentation

### DIFF
--- a/files/fr/web/javascript/reference/global_objects/set/index.md
+++ b/files/fr/web/javascript/reference/global_objects/set/index.md
@@ -253,7 +253,7 @@ new Set('Firefox');
 // Set(7) { "F", "i", "r", "e", "f", "o", "x" }
 
 new Set('firefox');
-// Set(6) { "f", "i", "r", "e", "o", "x" }
+// Set(7) { "f", "i", "r", "e", "f", "o", "x" }
 ```
 
 ### Utilisation de `Set` pour vérifier l'unicité des valeurs d'une liste


### PR DESCRIPTION
### Description

Fix a small typo in the french documentation page of `Set`

### Motivation

Just stumbled on it while reading the page
