### PR TITLE
fix view (after rendering) for 'Web/CSS/Adjacent_sibling_combinator' "result" part

### DIFF
--- a/files/zh-cn/web/css/adjacent_sibling_combinator/index.md
+++ b/files/zh-cn/web/css/adjacent_sibling_combinator/index.md
@@ -42,9 +42,7 @@ li:first-of-type + li {
 
 ### 结果
 
-- One
-- Two!
-- Three
+{{EmbedLiveSample("Examples", "100%", 100)}}
 
 ## 规范
 

--- a/files/zh-cn/web/css/adjacent_sibling_combinator/index.md
+++ b/files/zh-cn/web/css/adjacent_sibling_combinator/index.md
@@ -42,7 +42,7 @@ li:first-of-type + li {
 
 ### 结果
 
-{{EmbedLiveSample("Examples", "100%", 100)}}
+{{EmbedLiveSample("示例", "100%", 100)}}
 
 ## 规范
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Updated the "after HTML rendering" show at doc: https://developer.mozilla.org/zh-CN/docs/Web/CSS/Adjacent_sibling_combinator#%E7%BB%93%E6%9E%9C    

since the original "result" code was incorrectly expressed in CSS,  
I updated the code in the "zh-CN version" document by referring to the same location in the "en-US version" document.


<!-- ✍️ Summarize your changes in one or two sentences -->

### ~~Motivation~~

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

THE PROBLEMS happend at the doc: https://developer.mozilla.org/zh-CN/docs/Web/CSS/Adjacent_sibling_combinator#%E7%BB%93%E6%9E%9C    
  
![CleanShot 2022-10-01 at 23 33 01@2x](https://user-images.githubusercontent.com/11187239/193416880-dc314d70-e26b-420e-a27e-80bb3d079055.png)

THE CORRECT reference at the doc: https://developer.mozilla.org/en-US/docs/Web/CSS/Adjacent_sibling_combinator#result
  
![CleanShot 2022-10-01 at 23 38 38@2x](https://user-images.githubusercontent.com/11187239/193417052-0955e4cf-c0a9-4b9c-9944-77dc8ac68ed7.png)

---
Due to CSP limitations, during local development I used the plugin: "Disable Content-Security-Policy" in the browser: https://chrome.google.com/webstore/detail/disable-content-security/ieelmcmcagommplceebfedjlakkhpden


<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### ~~Related issues and pull requests~~

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
