### PR TITLE
fix: fix typo in web audio docs

### DIFF
--- a/files/es/web/api/web_audio_api/index.html
+++ b/files/es/web/api/web_audio_api/index.html
@@ -22,7 +22,7 @@ original_slug: Web_Audio_API
  <li>Crear contexto de audio</li>
  <li>Dentro del contexto, crear fuentes — como <code>&lt;audio&gt;</code>, oscillator, stream</li>
  <li>Crear nodos de efectos, <span class="short_text" id="result_box" lang="es"><span>tales como reverberación, filtro biquad, panner, compresor</span></span></li>
- <li>Ecoge el destino final del audio, por ejemplo tu sistema de altavoces</li>
+ <li>Escoge el destino final del audio, por ejemplo tu sistema de altavoces</li>
  <li>Conecta las fuentes a los efectos, y los efectos al destino.</li>
 </ol>
 


### PR DESCRIPTION
### Description

Fixes a simple typo, `Ecoge` 👉  `Escoge`
