### PR TITLE
Markdown rendering fails to bold code

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/object/values/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/object/values/index.md
@@ -5,7 +5,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Object/values
 
 {{JSRef}}
 
-**`Object.values()`**方法返回一个给定对象自身的所有可枚举属性值的数组，值的顺序与使用{{jsxref("Statements/for...in", "for...in")}}循环的顺序相同 ( 区别在于 for-in 循环枚举原型链中的属性 )。
+**`Object.values()`** 方法返回一个给定对象自身的所有可枚举属性值的数组，值的顺序与使用{{jsxref("Statements/for...in", "for...in")}}循环的顺序相同 ( 区别在于 for-in 循环枚举原型链中的属性 )。
 
 ## 语法
 

--- a/files/zh-cn/web/javascript/reference/global_objects/object/values/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/object/values/index.md
@@ -5,7 +5,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Object/values
 
 {{JSRef}}
 
-**`Object.values()`** 方法返回一个给定对象自身的所有可枚举属性值的数组，值的顺序与使用{{jsxref("Statements/for...in", "for...in")}}循环的顺序相同 ( 区别在于 for-in 循环枚举原型链中的属性 )。
+**`Object.values()`** 方法返回一个给定对象自身的所有可枚举属性值的数组，值的顺序与使用 {{jsxref("Statements/for...in", "for...in")}} 循环的顺序相同（区别在于 for-in 循环枚举原型链中的属性）。
 
 ## 语法
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Object.values () bold rendering did not succeed, compared with the English document seems to have some problems, in ** end with a space to render success

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I hope to make the MDN Chinese document look more beautiful, not to have the Markdown rendering failure, and improve everyone's reading experience

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
THE PROBLEMS happend at the doc: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/values
![image.png](https://s2.loli.net/2022/10/02/74oqv9rjiaWYz8g.png)
THE CORRECT reference at the doc:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values
![image.png](https://s2.loli.net/2022/10/02/Fqcr1LpOGMJQ4dh.png)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
