### PR TITLE
chore: add `es` as codeowner of `/docs/es/`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,6 +56,7 @@
 # TRANSLATION GUIDE OWNER(S)
 # ----------------------------------------------------------------------------
 /docs/        @mdn/core-yari-content
+/docs/es/     @mdn/yari-content-es
 /docs/ko/     @mdn/yari-content-ko
 /docs/ru/     @mdn/yari-content-ru
 /docs/zh-cn/  @mdn/yari-content-zh

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,6 +8,7 @@ l10n-de:
 
 l10n-es:
   - files/es/**/*
+  - docs/es/**/*
 
 l10n-fr:
   - files/fr/**/*


### PR DESCRIPTION
### Description

chore: add `es` as codeowner of `/docs/es/`
