### PR TITLE
Fix non-coinciding tag <code>

### DIFF
--- a/files/ru/web/api/window/frameelement/index.html
+++ b/files/ru/web/api/window/frameelement/index.html
@@ -9,7 +9,7 @@ translation_of: Web/API/Window/frameElement
 
 <h2 id="Summary">Сводка</h2>
 
-<p>Возвращает элемент (например <code>&lt;iframe&gt;</code> или <code>&lt;object&gt;), в который встроено окно, или </code> <code>null, если это окно верхнего уровня.</code></p>
+<p>Возвращает элемент (например <code>&lt;iframe&gt;</code> или <code>&lt;object&gt;</code>), в который встроено окно, или <code>null</code>, если это окно верхнего уровня.</p>
 
 <h2 id="Syntax">Синтаксис</h2>
 
@@ -17,7 +17,7 @@ translation_of: Web/API/Window/frameElement
 </pre>
 
 <ul>
- <li><code>frameEl</code> это элемент, в который встроено окно, или  <code>null, если это окно верхнего уровня</code></li>
+ <li><code>frameEl</code> это элемент, в который встроено окно, или <code>null</code>, если это окно верхнего уровня</li>
 </ul>
 
 <h2 id="Example">Пример</h2>


### PR DESCRIPTION
I went to http://developer.mozilla.org/en/docs/Web/API/Window/frameElement and saw strange behavior in some paragraphs. 
**Not the code** ended up in the &lt;code&gt; tag!