### PR TITLE
fix: adds ^ as <sup> alternative

### DIFF
--- a/files/es/web/javascript/reference/global_objects/math/expm1/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/expm1/index.md
@@ -13,7 +13,7 @@ original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/expm1
 ---
 {{JSRef}}
 
-La función **`Math.expm1()`** regresa `ex - 1`, donde `x` es el argumento, y {{jsxref("Math.E", "e", "", 1)}} la base del logaritmo natural.
+La función **`Math.expm1()`** regresa `e^x - 1`, donde `x` es el argumento, y {{jsxref("Math.E", "e", "", 1)}} la base del logaritmo natural.
 
 {{EmbedInteractiveExample("pages/js/math-expm1.html")}}El código para este ejemplo interactivo está almacenado en un repositorio de GitHub. Sí te gustaría contribuir al proyecto de ejemplos interactivos If you'd like to contribute, por favor clona <https://github.com/mdn/interactive-examples> y envíanos un pull request.
 
@@ -30,7 +30,7 @@ Math.expm1(x)
 
 ### Valor de retorno
 
-Un número representando `ex - 1`, donde `e` es {{jsxref("Math.E", "Número de Euler", "", 1)}} y `x` es el argumento.
+Un número representando `e^x - 1`, donde `e` es {{jsxref("Math.E", "Número de Euler", "", 1)}} y `x` es el argumento.
 
 ## Descripción
 

--- a/files/es/web/javascript/reference/global_objects/number/max_safe_integer/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/max_safe_integer/index.md
@@ -11,7 +11,7 @@ original_slug: Web/JavaScript/Referencia/Objetos_globales/Number/MAX_SAFE_INTEGE
 ---
 {{JSRef}}
 
-La constante **`Number.MAX_SAFE_INTEGER`** es el número mas grande 'seguro' en JavaScript (`253 - 1`).
+La constante **`Number.MAX_SAFE_INTEGER`** es el número mas grande 'seguro' en JavaScript (`2^53 - 1`).
 
 {{EmbedInteractiveExample("pages/js/number-maxsafeinteger.html")}}
 
@@ -21,7 +21,7 @@ La fuente de este ejemplo interactivo está almacenada en GitHub. Si quieres con
 
 ## Descripción
 
-La constante `MAX_SAFE_INTEGER` tiene un valor de `9007199254740991` (9,007,199,254,740,991 o \~9 mil billones). El razonamiento detrás de ese número es que JavaScript usa [números flotantes de doble precisión](http://en.wikipedia.org/wiki/Double_precision_floating-point_format) tal como está especfificado en [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point) por lo que puedes representar números de forma segura entre `-(253 - 1)` y `253 - 1`.
+La constante `MAX_SAFE_INTEGER` tiene un valor de `9007199254740991` (9,007,199,254,740,991 o \~9 mil billones). El razonamiento detrás de ese número es que JavaScript usa [números flotantes de doble precisión](http://en.wikipedia.org/wiki/Double_precision_floating-point_format) tal como está especfificado en [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point) por lo que puedes representar números de forma segura entre `-(2^53 - 1)` y `2^53 - 1`.
 
 Seguro, en este contexto, se refiere a la habilidad de representar enteros de forma exacta y compararlos de forma correcta. Por ejemplo, `Number.MAX_SAFE_INTEGER + 1 === Number.MAX_SAFE_INTEGER + 2` evaluará como 'verdadero', lo cual es matemáticamente incorrecto. Ver {{jsxref("Number.isSafeInteger()")}} para más información.
 

--- a/files/es/web/javascript/reference/global_objects/typedarray/index.md
+++ b/files/es/web/javascript/reference/global_objects/typedarray/index.md
@@ -37,10 +37,10 @@ Al crear una instancia de `TypedArray` (p. ej., `Int8Array`), se crea un arreglo
 | {{jsxref("Uint16Array")}}         | `0` a `65535`                  | 2               | Entero de 16 bits sin signo                                                               | `Short sin signo`         | `uint16_t`                       |
 | {{jsxref("Int32Array")}}         | `-2147483648` a `2147483647`   | 4               | dos enteros complementarios de 32 bits con signo                                          | `long`                    | `int32_t`                        |
 | {{jsxref("Uint32Array")}}         | `0` a `4294967295`             | 4               | Enteros de 32 bits sin signo                                                              | `long sin signo`          | `uint32_t`                       |
-| {{jsxref("Float32Array")}}     | `1.2`×`10-38` a `3.4`×`1038`   | 4               | Número de coma flotante IEEE de 32 bits (7 dígitos significativos, p. ej., `1.1234567`)   | `float sin restricciones` | `float`                          |
-| {{jsxref("Float64Array")}}     | `5.0`×`10-324` a `1.8`×`10308` | 8               | Número de coma flotante IEEE de 64 bits (16 dígitos significativos, p. Ej., `1.123...15`) | `doble sin restricciones` | `double`                         |
-| {{jsxref("BigInt64Array")}}     | `-263` a `263-1`               | 8               | Dos enteros complementarios de 64 bits con signo                                          | `bigint`                  | `int64_t (long long con signo)`  |
-| {{jsxref("BigUint64Array")}}     | `0` a `264-1`                  | 8               | Entero de 64 bits sin signo                                                               | `bigint`                  | `uint64_t (long long sin signo)` |
+| {{jsxref("Float32Array")}}     | `1.2`×`10^-38` a `3.4`×`10^38`   | 4               | Número de coma flotante IEEE de 32 bits (7 dígitos significativos, p. ej., `1.1234567`)   | `float sin restricciones` | `float`                          |
+| {{jsxref("Float64Array")}}     | `5.0`×`10^-324` a `1.8`×`10^308` | 8               | Número de coma flotante IEEE de 64 bits (16 dígitos significativos, p. Ej., `1.123...15`) | `doble sin restricciones` | `double`                         |
+| {{jsxref("BigInt64Array")}}     | `-2^63` a `2^63-1`               | 8               | Dos enteros complementarios de 64 bits con signo                                          | `bigint`                  | `int64_t (long long con signo)`  |
+| {{jsxref("BigUint64Array")}}     | `0` a `2^64-1`                  | 8               | Entero de 64 bits sin signo                                                               | `bigint`                  | `uint64_t (long long sin signo)` |
 
 ## Constructor
 


### PR DESCRIPTION
### Description

Adds `^` as an alternative for the now missing `<sup>` elements
