### PR TITLE
Create separate `page-report` for locales

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,7 +57,10 @@
 # ----------------------------------------------------------------------------
 /docs/        @mdn/core-yari-content
 /docs/es/     @mdn/yari-content-es
+/docs/fr/     @mdn/yari-content-fr
+/docs/ja/     @mdn/yari-content-ja
 /docs/ko/     @mdn/yari-content-ko
+/docs/pt-br/  @mdn/yari-content-pt-br
 /docs/ru/     @mdn/yari-content-ru
 /docs/zh-cn/  @mdn/yari-content-zh
 /docs/zh-tw/  @mdn/yari-content-zh

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,10 +56,23 @@
 # TRANSLATION GUIDE OWNER(S)
 # ----------------------------------------------------------------------------
 /docs/        @mdn/core-yari-content
+/docs/es/     @mdn/yari-content-es
 /docs/ko/     @mdn/yari-content-ko
 /docs/ru/     @mdn/yari-content-ru
 /docs/zh-cn/  @mdn/yari-content-zh
 /docs/zh-tw/  @mdn/yari-content-zh
+
+# ----------------------------------------------------------------------------
+# ISSUE TEMPLATE OWNER(S)
+# ----------------------------------------------------------------------------
+.github/ISSUE_TEMPLATE/page-report-es.yml     @mdn/yari-content-es
+.github/ISSUE_TEMPLATE/page-report-fr.yml     @mdn/yari-content-fr
+.github/ISSUE_TEMPLATE/page-report-ja.yml     @mdn/yari-content-ja
+.github/ISSUE_TEMPLATE/page-report-ko.yml     @mdn/yari-content-ko
+.github/ISSUE_TEMPLATE/page-report-pt-br.yml  @mdn/yari-content-pt-br
+.github/ISSUE_TEMPLATE/page-report-ru.yml     @mdn/yari-content-ru
+.github/ISSUE_TEMPLATE/page-report-zh-cn.yml  @mdn/yari-content-zh
+.github/ISSUE_TEMPLATE/page-report-zh-tw.yml  @mdn/yari-content-zh
 
 # ----------------------------------------------------------------------------
 # CONTROL FILES OWNER(S)

--- a/.github/ISSUE_TEMPLATE/page-report-es.yml
+++ b/.github/ISSUE_TEMPLATE/page-report-es.yml
@@ -1,0 +1,62 @@
+name: "[via MDN pages only]"
+description: Issue filed via "Report a problem with this content on GitHub" link on MDN pages.
+labels: ["l10n-es", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Before you start
+
+        **Want to change this page yourself?** This content is open source!
+        ↩ Go back and use the _Edit on GitHub_ link on the page.
+
+        **Is your issue about the browser compatibility table?**
+        ↩ Go back and use the _Report problems with this compatibility data on GitHub_ link on the page.
+
+        **Need help with a browser?**
+        🙋 To get help with [Firefox](https://support.mozilla.org/en-US/kb/file-bug-report-or-feature-request-mozilla), [Chrome](https://support.google.com/chrome/answer/95315?hl=en-GB&ref_topic=7439544), [Safari](https://www.apple.com/feedback/safari.html), or another browser, check the browser's support site.
+
+        ---
+  - type: input
+    id: mdn-url
+    attributes:
+      label: MDN URL
+      description: Set automatically. Do not modify.
+    validations:
+      required: true
+  - type: input
+    id: section
+    attributes:
+      label: What specific section or headline is this issue about?
+  - type: textarea
+    id: problem
+    attributes:
+      label: What information was incorrect, unhelpful, or incomplete?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to see?
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: Do you have any supporting links, references, or citations?
+      description: Link to information that helps us confirm your issue.
+  - type: textarea
+    id: more-info
+    attributes:
+      label: Do you have anything more you want to share?
+      description: For example, steps to reproduce a bug, screenshots, screen recordings, or sample code
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        You're finished! The following fields are prefilled. Please click **Submit new issue**.
+  - type: textarea
+    id: metadata
+    attributes:
+      label: MDN metadata
+      description: Set automatically. Do not modify.

--- a/.github/ISSUE_TEMPLATE/page-report-fr.yml
+++ b/.github/ISSUE_TEMPLATE/page-report-fr.yml
@@ -1,0 +1,63 @@
+name: "[via des pages MDN uniquement]"
+description: Issue filed via le lien "Report a problem with this content on GitHub" sur des pages MDN.
+labels: ["l10n-fr", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Before you start
+
+        **Want to change this page yourself?** This content is open source!
+        ↩ Go back and use the _Edit on GitHub_ link on the page.
+
+        **Is your issue about the browser compatibility table?**
+        ↩ Go back and use the _Report problems with this compatibility data on GitHub_ link on the page.
+
+        **Need help with a browser?**
+        🙋 To get help with [Firefox](https://support.mozilla.org/en-US/kb/file-bug-report-or-feature-request-mozilla), [Chrome](https://support.google.com/chrome/answer/95315?hl=en-GB&ref_topic=7439544), [Safari](https://www.apple.com/feedback/safari.html), or another browser, check the browser's support site.
+
+        ---
+  - type: input
+    id: mdn-url
+    attributes:
+      label: MDN URL
+      description: Set automatically. Do not modify.
+    validations:
+      required: true
+  - type: input
+    id: section
+    attributes:
+      label: What specific section or headline is this issue about?
+  - type: textarea
+    id: problem
+    attributes:
+      label: What information was incorrect, unhelpful, or incomplete?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to see?
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: Do you have any supporting links, references, or citations?
+      description: Link to information that helps us confirm your issue.
+  - type: textarea
+    id: more-info
+    attributes:
+      label: Do you have anything more you want to share?
+      description: For example, steps to reproduce a bug, screenshots, screen recordings, or sample code
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        You're finished! The following fields are prefilled. Please click **Submit new issue**.
+  - type: textarea
+    id: metadata
+    attributes:
+      label: MDN metadata
+      description: Set automatically. Do not modify.
+

--- a/.github/ISSUE_TEMPLATE/page-report-ja.yml
+++ b/.github/ISSUE_TEMPLATE/page-report-ja.yml
@@ -1,0 +1,62 @@
+name: "[via MDN pages only]"
+description: Issue filed via "Report a problem with this content on GitHub" link on MDN pages.
+labels: ["l10n-ja", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Before you start
+
+        **Want to change this page yourself?** This content is open source!
+        ↩ Go back and use the _Edit on GitHub_ link on the page.
+
+        **Is your issue about the browser compatibility table?**
+        ↩ Go back and use the _Report problems with this compatibility data on GitHub_ link on the page.
+
+        **Need help with a browser?**
+        🙋 To get help with [Firefox](https://support.mozilla.org/en-US/kb/file-bug-report-or-feature-request-mozilla), [Chrome](https://support.google.com/chrome/answer/95315?hl=en-GB&ref_topic=7439544), [Safari](https://www.apple.com/feedback/safari.html), or another browser, check the browser's support site.
+
+        ---
+  - type: input
+    id: mdn-url
+    attributes:
+      label: MDN URL
+      description: Set automatically. Do not modify.
+    validations:
+      required: true
+  - type: input
+    id: section
+    attributes:
+      label: What specific section or headline is this issue about?
+  - type: textarea
+    id: problem
+    attributes:
+      label: What information was incorrect, unhelpful, or incomplete?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to see?
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: Do you have any supporting links, references, or citations?
+      description: Link to information that helps us confirm your issue.
+  - type: textarea
+    id: more-info
+    attributes:
+      label: Do you have anything more you want to share?
+      description: For example, steps to reproduce a bug, screenshots, screen recordings, or sample code
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        You're finished! The following fields are prefilled. Please click **Submit new issue**.
+  - type: textarea
+    id: metadata
+    attributes:
+      label: MDN metadata
+      description: Set automatically. Do not modify.

--- a/.github/ISSUE_TEMPLATE/page-report-ko.yml
+++ b/.github/ISSUE_TEMPLATE/page-report-ko.yml
@@ -1,0 +1,62 @@
+name: "[via MDN pages only]"
+description: Issue filed via "Report a problem with this content on GitHub" link on MDN pages.
+labels: ["l10n-ko", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Before you start
+
+        **Want to change this page yourself?** This content is open source!
+        ↩ Go back and use the _Edit on GitHub_ link on the page.
+
+        **Is your issue about the browser compatibility table?**
+        ↩ Go back and use the _Report problems with this compatibility data on GitHub_ link on the page.
+
+        **Need help with a browser?**
+        🙋 To get help with [Firefox](https://support.mozilla.org/en-US/kb/file-bug-report-or-feature-request-mozilla), [Chrome](https://support.google.com/chrome/answer/95315?hl=en-GB&ref_topic=7439544), [Safari](https://www.apple.com/feedback/safari.html), or another browser, check the browser's support site.
+
+        ---
+  - type: input
+    id: mdn-url
+    attributes:
+      label: MDN URL
+      description: Set automatically. Do not modify.
+    validations:
+      required: true
+  - type: input
+    id: section
+    attributes:
+      label: What specific section or headline is this issue about?
+  - type: textarea
+    id: problem
+    attributes:
+      label: What information was incorrect, unhelpful, or incomplete?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to see?
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: Do you have any supporting links, references, or citations?
+      description: Link to information that helps us confirm your issue.
+  - type: textarea
+    id: more-info
+    attributes:
+      label: Do you have anything more you want to share?
+      description: For example, steps to reproduce a bug, screenshots, screen recordings, or sample code
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        You're finished! The following fields are prefilled. Please click **Submit new issue**.
+  - type: textarea
+    id: metadata
+    attributes:
+      label: MDN metadata
+      description: Set automatically. Do not modify.

--- a/.github/ISSUE_TEMPLATE/page-report-pt-br.yml
+++ b/.github/ISSUE_TEMPLATE/page-report-pt-br.yml
@@ -1,0 +1,62 @@
+name: "[via MDN pages only]"
+description: Issue filed via "Report a problem with this content on GitHub" link on MDN pages.
+labels: ["l10n-pt-br", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Before you start
+
+        **Want to change this page yourself?** This content is open source!
+        ↩ Go back and use the _Edit on GitHub_ link on the page.
+
+        **Is your issue about the browser compatibility table?**
+        ↩ Go back and use the _Report problems with this compatibility data on GitHub_ link on the page.
+
+        **Need help with a browser?**
+        🙋 To get help with [Firefox](https://support.mozilla.org/en-US/kb/file-bug-report-or-feature-request-mozilla), [Chrome](https://support.google.com/chrome/answer/95315?hl=en-GB&ref_topic=7439544), [Safari](https://www.apple.com/feedback/safari.html), or another browser, check the browser's support site.
+
+        ---
+  - type: input
+    id: mdn-url
+    attributes:
+      label: MDN URL
+      description: Set automatically. Do not modify.
+    validations:
+      required: true
+  - type: input
+    id: section
+    attributes:
+      label: What specific section or headline is this issue about?
+  - type: textarea
+    id: problem
+    attributes:
+      label: What information was incorrect, unhelpful, or incomplete?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to see?
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: Do you have any supporting links, references, or citations?
+      description: Link to information that helps us confirm your issue.
+  - type: textarea
+    id: more-info
+    attributes:
+      label: Do you have anything more you want to share?
+      description: For example, steps to reproduce a bug, screenshots, screen recordings, or sample code
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        You're finished! The following fields are prefilled. Please click **Submit new issue**.
+  - type: textarea
+    id: metadata
+    attributes:
+      label: MDN metadata
+      description: Set automatically. Do not modify.

--- a/.github/ISSUE_TEMPLATE/page-report-ru.yml
+++ b/.github/ISSUE_TEMPLATE/page-report-ru.yml
@@ -1,0 +1,62 @@
+name: "[via MDN pages only]"
+description: Issue filed via "Report a problem with this content on GitHub" link on MDN pages.
+labels: ["l10n-ru", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Before you start
+
+        **Want to change this page yourself?** This content is open source!
+        ↩ Go back and use the _Edit on GitHub_ link on the page.
+
+        **Is your issue about the browser compatibility table?**
+        ↩ Go back and use the _Report problems with this compatibility data on GitHub_ link on the page.
+
+        **Need help with a browser?**
+        🙋 To get help with [Firefox](https://support.mozilla.org/en-US/kb/file-bug-report-or-feature-request-mozilla), [Chrome](https://support.google.com/chrome/answer/95315?hl=en-GB&ref_topic=7439544), [Safari](https://www.apple.com/feedback/safari.html), or another browser, check the browser's support site.
+
+        ---
+  - type: input
+    id: mdn-url
+    attributes:
+      label: MDN URL
+      description: Set automatically. Do not modify.
+    validations:
+      required: true
+  - type: input
+    id: section
+    attributes:
+      label: What specific section or headline is this issue about?
+  - type: textarea
+    id: problem
+    attributes:
+      label: What information was incorrect, unhelpful, or incomplete?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to see?
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: Do you have any supporting links, references, or citations?
+      description: Link to information that helps us confirm your issue.
+  - type: textarea
+    id: more-info
+    attributes:
+      label: Do you have anything more you want to share?
+      description: For example, steps to reproduce a bug, screenshots, screen recordings, or sample code
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        You're finished! The following fields are prefilled. Please click **Submit new issue**.
+  - type: textarea
+    id: metadata
+    attributes:
+      label: MDN metadata
+      description: Set automatically. Do not modify.

--- a/.github/ISSUE_TEMPLATE/page-report-zh-cn.yml
+++ b/.github/ISSUE_TEMPLATE/page-report-zh-cn.yml
@@ -1,0 +1,62 @@
+name: "[via MDN pages only]"
+description: Issue filed via "Report a problem with this content on GitHub" link on MDN pages.
+labels: ["l10n-zh", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Before you start
+
+        **Want to change this page yourself?** This content is open source!
+        ↩ Go back and use the _Edit on GitHub_ link on the page.
+
+        **Is your issue about the browser compatibility table?**
+        ↩ Go back and use the _Report problems with this compatibility data on GitHub_ link on the page.
+
+        **Need help with a browser?**
+        🙋 To get help with [Firefox](https://support.mozilla.org/en-US/kb/file-bug-report-or-feature-request-mozilla), [Chrome](https://support.google.com/chrome/answer/95315?hl=en-GB&ref_topic=7439544), [Safari](https://www.apple.com/feedback/safari.html), or another browser, check the browser's support site.
+
+        ---
+  - type: input
+    id: mdn-url
+    attributes:
+      label: MDN URL
+      description: Set automatically. Do not modify.
+    validations:
+      required: true
+  - type: input
+    id: section
+    attributes:
+      label: What specific section or headline is this issue about?
+  - type: textarea
+    id: problem
+    attributes:
+      label: What information was incorrect, unhelpful, or incomplete?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to see?
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: Do you have any supporting links, references, or citations?
+      description: Link to information that helps us confirm your issue.
+  - type: textarea
+    id: more-info
+    attributes:
+      label: Do you have anything more you want to share?
+      description: For example, steps to reproduce a bug, screenshots, screen recordings, or sample code
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        You're finished! The following fields are prefilled. Please click **Submit new issue**.
+  - type: textarea
+    id: metadata
+    attributes:
+      label: MDN metadata
+      description: Set automatically. Do not modify.

--- a/.github/ISSUE_TEMPLATE/page-report-zh-tw.yml
+++ b/.github/ISSUE_TEMPLATE/page-report-zh-tw.yml
@@ -1,0 +1,62 @@
+name: "[via MDN pages only]"
+description: Issue filed via "Report a problem with this content on GitHub" link on MDN pages.
+labels: ["l10n-zh", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Before you start
+
+        **Want to change this page yourself?** This content is open source!
+        ↩ Go back and use the _Edit on GitHub_ link on the page.
+
+        **Is your issue about the browser compatibility table?**
+        ↩ Go back and use the _Report problems with this compatibility data on GitHub_ link on the page.
+
+        **Need help with a browser?**
+        🙋 To get help with [Firefox](https://support.mozilla.org/en-US/kb/file-bug-report-or-feature-request-mozilla), [Chrome](https://support.google.com/chrome/answer/95315?hl=en-GB&ref_topic=7439544), [Safari](https://www.apple.com/feedback/safari.html), or another browser, check the browser's support site.
+
+        ---
+  - type: input
+    id: mdn-url
+    attributes:
+      label: MDN URL
+      description: Set automatically. Do not modify.
+    validations:
+      required: true
+  - type: input
+    id: section
+    attributes:
+      label: What specific section or headline is this issue about?
+  - type: textarea
+    id: problem
+    attributes:
+      label: What information was incorrect, unhelpful, or incomplete?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to see?
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: Do you have any supporting links, references, or citations?
+      description: Link to information that helps us confirm your issue.
+  - type: textarea
+    id: more-info
+    attributes:
+      label: Do you have anything more you want to share?
+      description: For example, steps to reproduce a bug, screenshots, screen recordings, or sample code
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        You're finished! The following fields are prefilled. Please click **Submit new issue**.
+  - type: textarea
+    id: metadata
+    attributes:
+      label: MDN metadata
+      description: Set automatically. Do not modify.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,29 +8,38 @@ l10n-de:
 
 l10n-es:
   - files/es/**/*
+  - docs/es/**/*
+  - /.github/ISSUE_TEMPLATE/page-report-es.yml
 
 l10n-fr:
   - files/fr/**/*
+  - /.github/ISSUE_TEMPLATE/page-report-fr.yml
 
 l10n-ja:
   - files/ja/**/*
+  - /.github/ISSUE_TEMPLATE/page-report-ja.yml
 
 l10n-ko:
   - files/ko/**/*
   - docs/ko/**/*
+  - /.github/ISSUE_TEMPLATE/page-report-ko.yml
 
 l10n-pl:
   - files/pl/**/*
 
 l10n-pt-br:
   - files/pt-br/**/*
+  - /.github/ISSUE_TEMPLATE/page-report-pt-br.yml
 
 l10n-ru:
   - files/ru/**/*
   - docs/ru/**/*
+  - /.github/ISSUE_TEMPLATE/page-report-ru.yml
 
 l10n-zh:
   - files/zh-cn/**/*
   - files/zh-tw/**/*
   - docs/zh-cn/**/*
   - docs/zh-tw/**/*
+  - /.github/ISSUE_TEMPLATE/page-report-zh-cn.yml
+  - /.github/ISSUE_TEMPLATE/page-report-zh-tw.yml


### PR DESCRIPTION
Create a `page-report` file for each locale, all in English first (w/ updates to CODEOWNERS) so that the yari PR can be merged sooner. See #8918 and mdn/yari#7277. The idea is that locale teams can translate templates after this and the yari update are merged.

Politely poking @mdn/mdn-community-engagement for a review :)