### PR TITLE
typo: prórpio -> próprio

### DIFF
--- a/files/pt-br/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.md
+++ b/files/pt-br/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.md
@@ -58,7 +58,7 @@ Enquanto React pode ser utilizado por [pequenos pedaços de interface](https://r
 
 Além disso, muitos dos beneficios da experiencias de desenvolvimento de uma aplicação React, tais como escrever interfaces com JSX, requerem um processo de compilação. Adicionar um compilador como o Babel em um website faz o código funcionar lentamente, então os desenvolvedores geralmente configuram algumas ferramentas para fazer compilações em etapas. React, sem duvídas, tem um grande ecossistema de ferramentas, mas isso pode ser aprendido.
 
-Este artigo será focado no caso de uso do React para renderizar toda a interface do usuario de um aplicativo, usando ferramentas fornecidas pelo prórpio [create-react-app](https://create-react-app.dev/) do Facebook.
+Este artigo será focado no caso de uso do React para renderizar toda a interface do usuario de um aplicativo, usando ferramentas fornecidas pelo próprio [create-react-app](https://create-react-app.dev/) do Facebook.
 
 ## Como React usa JavaScript?
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
fixes a typo (`prórprio` -> `próprio`)

### Related issues and pull requests
Same as https://github.com/mdn/translated-content/pull/4768, but after markdown conversion