### PR TITLE
chore: translate links /en-US/ -> /pt-BR/ (web/html)

### DIFF
--- a/files/pt-br/web/html/element/a/index.md
+++ b/files/pt-br/web/html/element/a/index.md
@@ -46,7 +46,7 @@ Os atributos do elemento incluem os [atributos globais](/pt-BR/docs/Web/HTML/Glo
     - Pieces of media files with media fragments (Pedaços de arquivos de mídia com fragmentos da própria mídia)
     - Números de telefone com `tel:` URLs
     - Email addresses with(Endereço de email com) `mailto:` URLs
-    - Alguns navegadores talvez não aguentem certos arranjos em URL, para isso os websites fazem uso do [`registerProtocolHandler()`](/en-US/docs/Web/API/Navigator/registerProtocolHandler)
+    - Alguns navegadores talvez não aguentem certos arranjos em URL, para isso os websites fazem uso do [`registerProtocolHandler()`](/pt-BR/docs/Web/API/Navigator/registerProtocolHandler)
 
 - {{HTMLAttrDef("hreflang")}}
   - : Hints at the human language of the linked URL. No built-in functionality. Allowed values are the same as [the global `lang` attribute](/pt-BR/docs/Web/HTML/Global_attributes/lang).
@@ -102,16 +102,16 @@ Os atributos do elemento incluem os [atributos globais](/pt-BR/docs/Web/HTML/Glo
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/Web/HTML/Content_categories">Content categories</a>
+        <a href="/pt-BR/docs/Web/HTML/Content_categories">Content categories</a>
       </th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Flow_content"
           >Flow content</a
         >,
-        <a href="/en-US/docs/Web/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Phrasing_content"
           >phrasing content</a
         >,
-        <a href="/en-US/docs/Web/HTML/Content_categories#Interactive_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Interactive_content"
           >interactive content</a
         >, palpable content.
       </td>
@@ -120,17 +120,17 @@ Os atributos do elemento incluem os [atributos globais](/pt-BR/docs/Web/HTML/Glo
       <th scope="row">Permitted content</th>
       <td>
         <a
-          href="/en-US/docs/Web/HTML/Content_categories#Transparent_content_model"
+          href="/pt-BR/docs/Web/HTML/Content_categories#Transparent_content_model"
           >Transparent</a
         >, containing either
-        <a href="/en-US/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Flow_content"
           >flow content</a
         >
         (excluding
-        <a href="/en-US/docs/Web/HTML/Content_categories#Interactive_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Interactive_content"
           >interactive content</a
         >) or
-        <a href="/en-US/docs/Web/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Phrasing_content"
           >phrasing content</a
         >.
       </td>
@@ -143,10 +143,10 @@ Os atributos do elemento incluem os [atributos globais](/pt-BR/docs/Web/HTML/Glo
       <th scope="row">Permitted parents</th>
       <td>
         Any element that accepts
-        <a href="/en-US/docs/Web/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Phrasing_content"
           >phrasing content</a
         >, or any element that accepts
-        <a href="/en-US/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Flow_content"
           >flow content</a
         >, but not other <code>&#x3C;a></code> elements.
       </td>
@@ -212,7 +212,7 @@ Os atributos do elemento incluem os [atributos globais](/pt-BR/docs/Web/HTML/Glo
 
 ```html
 <a href="//example.com">Scheme-relative URL</a>
-<a href="/en-US/docs/Web/HTML">Origin-relative URL</a>
+<a href="/pt-BR/docs/Web/HTML">Origin-relative URL</a>
 <a href="./p">Directory-relative URL</a>
 ```
 

--- a/files/pt-br/web/html/element/audio/index.md
+++ b/files/pt-br/web/html/element/audio/index.md
@@ -53,7 +53,7 @@ Como todos os elementos HTML, este elemento suporta os [global attributes](/pt-B
     > - O navegador não é forçado pela especifição a seguir o valor desse atributo; é apenas uma sugestão.
 
 - {{ htmlattrdef("src") }}
-  - : A URL do áudio a ser incorporado. Isso é sujeito a [HTTP access controls](/pt-BR/docs/HTTP_access_control). Isto é opcional; ao invés disso você pode usar o elemento [`<source>`](http://developer.mozilla.org/en-US/docs/pt-BR/HTML/Element/source) dentro do bloco do áudio para especificar o vídeo a ser incorporado .
+  - : A URL do áudio a ser incorporado. Isso é sujeito a [HTTP access controls](/pt-BR/docs/HTTP_access_control). Isto é opcional; ao invés disso você pode usar o elemento [`<source>`](http://developer.mozilla.org/pt-BR/docs/pt-BR/HTML/Element/source) dentro do bloco do áudio para especificar o vídeo a ser incorporado .
 
 O tempo de compensação (time offset) entre o áudio e o vídeo está especificado como um valor de ponto flutuante (float) representando o número de segundos da compensação.
 

--- a/files/pt-br/web/html/element/bdo/index.md
+++ b/files/pt-br/web/html/element/bdo/index.md
@@ -16,13 +16,13 @@ O **_elemento_ HTML `<bdo>` **(_bidirectional override_) é usado para substitui
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/HTML/Content_categories">Content categories</a>
+        <a href="/pt-BR/docs/HTML/Content_categories">Content categories</a>
       </th>
       <td>
-        <a href="/en-US/docs/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/HTML/Content_categories#Flow_content"
           >Flow content</a
         >,
-        <a href="/en-US/docs/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/HTML/Content_categories#Phrasing_content"
           >phrasing content</a
         >, palpable content.
       </td>
@@ -30,7 +30,7 @@ O **_elemento_ HTML `<bdo>` **(_bidirectional override_) é usado para substitui
     <tr>
       <th scope="row">Permitted content</th>
       <td>
-        <a href="/en-US/docs/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/HTML/Content_categories#Phrasing_content"
           >Phrasing content</a
         >.
       </td>
@@ -43,7 +43,7 @@ O **_elemento_ HTML `<bdo>` **(_bidirectional override_) é usado para substitui
       <th scope="row">Permitted parents</th>
       <td>
         Any element that accepts
-        <a href="/en-US/docs/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/HTML/Content_categories#Phrasing_content"
           >phrasing content</a
         >.
       </td>
@@ -58,7 +58,7 @@ O **_elemento_ HTML `<bdo>` **(_bidirectional override_) é usado para substitui
         {{domxref("HTMLElement")}} Up to Gecko 1.9.2 (Firefox 4)
         inclusive, Firefox implements the
         <code
-          ><a href="/en-US/docs/Web/API/HTMLSpanElement"
+          ><a href="/pt-BR/docs/Web/API/HTMLSpanElement"
             >HTMLSpanElement</a
           ></code
         >

--- a/files/pt-br/web/html/element/body/index.md
+++ b/files/pt-br/web/html/element/body/index.md
@@ -25,7 +25,7 @@ O **elemento** `<body>` do **HTML** representa o conteúdo de um documento HTML.
       </th>
       <td>
         <a
-          href="https://developer.mozilla.org/en-US/docs/Web/HTML/Sections_and_Outlines_of_an_HTML5_document#Sectioning_roots"
+          href="https://developer.mozilla.org/pt-BR/docs/Web/HTML/Sections_and_Outlines_of_an_HTML5_document#Sectioning_roots"
           >Seção raiz</a
         >.
       </td>

--- a/files/pt-br/web/html/element/br/index.md
+++ b/files/pt-br/web/html/element/br/index.md
@@ -14,17 +14,17 @@ Não use \<br> para aumentar o espaço entre as linhas de texto; para isso use a
     <tr>
       <th scope="row">
         <a
-          href="/en-US/docs/HTML/Content_categories"
+          href="/pt-BR/docs/HTML/Content_categories"
           >Categorias de Conteúdo</a
         >
       </th>
       <td>
         <a
-          href="/en-US/docs/HTML/Content_categories#Flow_content"
+          href="/pt-BR/docs/HTML/Content_categories#Flow_content"
           >Conteúdo de Fluxo</a
         >,
         <a
-          href="/en-US/docs/HTML/Content_categories#Phrasing_content"
+          href="/pt-BR/docs/HTML/Content_categories#Phrasing_content"
           >conteúdo fraseado</a
         >.
       </td>
@@ -45,7 +45,7 @@ Não use \<br> para aumentar o espaço entre as linhas de texto; para isso use a
       <td>
         Qualquer elemento que aceita
         <a
-          href="/en-US/docs/HTML/Content_categories#Phrasing_content"
+          href="/pt-BR/docs/HTML/Content_categories#Phrasing_content"
           >conteúdo fraseado</a
         >.
       </td>

--- a/files/pt-br/web/html/element/canvas/index.md
+++ b/files/pt-br/web/html/element/canvas/index.md
@@ -49,4 +49,4 @@ Como qualquer outro elemento HTML, este também tem [global attributes](/en/HTML
 - [MDN canvas portal](/en/HTML/Canvas)
 - Um [canvas tutorial](/en/Canvas_tutorial)
 - [Canvas cheat sheet](http://blog.nihilogic.dk/2009/02/html5-canvas-cheat-sheet.html)
-- [Canvas-related demos](/en-US/demos/tag/tech:canvas)
+- [Canvas-related demos](/pt-BR/demos/tag/tech:canvas)

--- a/files/pt-br/web/html/element/caption/index.md
+++ b/files/pt-br/web/html/element/caption/index.md
@@ -19,7 +19,7 @@ O **Elemento** **HTML `<caption>` (**ou _Elemento HTML Subtitulo de Tabela_) rep
     <tr>
       <th scope="row">
         <a
-          href="/en-US/docs/HTML/Content_categories"
+          href="/pt-BR/docs/HTML/Content_categories"
           >Categoria de conteúdo</a
         >
       </th>
@@ -29,7 +29,7 @@ O **Elemento** **HTML `<caption>` (**ou _Elemento HTML Subtitulo de Tabela_) rep
       <th scope="row">Conteúdo permitido</th>
       <td>
         <a
-          href="/en-US/docs/HTML/Content_categories#Flow_content"
+          href="/pt-BR/docs/HTML/Content_categories#Flow_content"
           >Flow content</a
         >.
       </td>

--- a/files/pt-br/web/html/element/cite/index.md
+++ b/files/pt-br/web/html/element/cite/index.md
@@ -9,13 +9,13 @@ O **elemento** **HTML \<cite>** representa uma referência a um trabalho artíst
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/HTML/Content_categories">Content categories</a>
+        <a href="/pt-BR/docs/HTML/Content_categories">Content categories</a>
       </th>
       <td>
-        <a href="/en-US/docs/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/HTML/Content_categories#Flow_content"
           >Flow content</a
         >,
-        <a href="/en-US/docs/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/HTML/Content_categories#Phrasing_content"
           >phrasing content</a
         >, palpable content.
       </td>
@@ -23,7 +23,7 @@ O **elemento** **HTML \<cite>** representa uma referência a um trabalho artíst
     <tr>
       <th scope="row">Permitted content</th>
       <td>
-        <a href="/en-US/docs/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/HTML/Content_categories#Phrasing_content"
           >Phrasing content</a
         >.
       </td>
@@ -36,7 +36,7 @@ O **elemento** **HTML \<cite>** representa uma referência a um trabalho artíst
       <th scope="row">Permitted parents</th>
       <td>
         Any element that accepts
-        <a href="/en-US/docs/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/HTML/Content_categories#Phrasing_content"
           >phrasing content</a
         >.
       </td>

--- a/files/pt-br/web/html/element/code/index.md
+++ b/files/pt-br/web/html/element/code/index.md
@@ -13,13 +13,13 @@ O **elemento** **HTML `<code>` **apresenta seu conteúdo estilizado de maneira a
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/Web/HTML/Content_categories">Content categories</a>
+        <a href="/pt-BR/docs/Web/HTML/Content_categories">Content categories</a>
       </th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Flow_content"
           >Flow content</a
         >,
-        <a href="/en-US/docs/Web/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Phrasing_content"
           >phrasing content</a
         >, palpable content.
       </td>
@@ -27,7 +27,7 @@ O **elemento** **HTML `<code>` **apresenta seu conteúdo estilizado de maneira a
     <tr>
       <th scope="row">Permitted content</th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Phrasing_content"
           >Phrasing content</a
         >.
       </td>
@@ -40,7 +40,7 @@ O **elemento** **HTML `<code>` **apresenta seu conteúdo estilizado de maneira a
       <th scope="row">Permitted parents</th>
       <td>
         Any element that accepts
-        <a href="/en-US/docs/Web/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Phrasing_content"
           >phrasing content</a
         >.
       </td>

--- a/files/pt-br/web/html/element/col/index.md
+++ b/files/pt-br/web/html/element/col/index.md
@@ -9,7 +9,7 @@ translation_of: Web/HTML/Element/col
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/HTML/Content_categories">Content categories</a>
+        <a href="/pt-BR/docs/HTML/Content_categories">Content categories</a>
       </th>
       <td>None.</td>
     </tr>

--- a/files/pt-br/web/html/element/content/index.md
+++ b/files/pt-br/web/html/element/content/index.md
@@ -15,13 +15,13 @@ The **HTML `<content>` element**—an obsolete part of the [Web Components](/pt-
     <tr>
       <th scope="row">
         <a
-          href="/en-US/docs/Web/HTML/Content_categories"
+          href="/pt-BR/docs/Web/HTML/Content_categories"
           >Content categories</a
         >
       </th>
       <td>
         <a
-          href="/en-US/docs/Web/HTML/Content_categories#Transparent_content_model"
+          href="/pt-BR/docs/Web/HTML/Content_categories#Transparent_content_model"
           >Transparent content</a
         >.
       </td>
@@ -29,7 +29,7 @@ The **HTML `<content>` element**—an obsolete part of the [Web Components](/pt-
     <tr>
       <th scope="row">Permitted content</th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Flow_content"
           >Flow content</a
         >.
       </td>

--- a/files/pt-br/web/html/element/dd/index.md
+++ b/files/pt-br/web/html/element/dd/index.md
@@ -52,7 +52,7 @@ O **elemento HTML \<dd>** fornece detalhes ou uma definição mais completa do t
       <th scope="row">Ancestrais permitidos</th>
       <td>
         {{HTMLElement("dl")}} ou (em
-        <a href="/en-US/docs/Glossary/WHATWG">WHATWG</a> HTML) uma
+        <a href="/pt-BR/docs/Glossary/WHATWG">WHATWG</a> HTML) uma
         {{HTMLElement("div")}} que está dentro de uma
         {{HTMLElement("dl")}}.
       </td>

--- a/files/pt-br/web/html/element/dialog/index.md
+++ b/files/pt-br/web/html/element/dialog/index.md
@@ -18,11 +18,11 @@ O **elemento HTML `<dialog>`** representa uma caixa de diálogo ou outro compone
     <tr>
       <th scope="row">Categorias de conteúdo</th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Flow_content"
           >Flow content</a
         >,
         <a
-          href="/en-US/docs/Web/HTML/Sections_and_Outlines_of_an_HTML5_document#Sectioning_roots"
+          href="/pt-BR/docs/Web/HTML/Sections_and_Outlines_of_an_HTML5_document#Sectioning_roots"
           >sectioning root</a
         >
       </td>
@@ -30,7 +30,7 @@ O **elemento HTML `<dialog>`** representa uma caixa de diálogo ou outro compone
     <tr>
       <th scope="row">Permitted content</th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Flow_content"
           >Flow content</a
         >
       </td>
@@ -43,7 +43,7 @@ O **elemento HTML `<dialog>`** representa uma caixa de diálogo ou outro compone
       <th scope="row">Permitted parents</th>
       <td>
         Qualquer elemento que aceite
-        <a href="/en-US/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Flow_content"
           >flow content</a
         >
       </td>

--- a/files/pt-br/web/html/element/em/index.md
+++ b/files/pt-br/web/html/element/em/index.md
@@ -16,16 +16,16 @@ O **elemento** **HTML** **`<em>`** marca o texto que tem ênfase. O elemento \<e
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/Web/HTML/Content_categories"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories"
           >Categorias de conteúdo</a
         >
       </th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Flow_content"
           >Conteúdo fluído</a
         >,
         <a
-          href="https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#Phrasing_content"
+          href="https://developer.mozilla.org/pt-BR/docs/Web/HTML/Content_categories#Phrasing_content"
           >conteúdo de frase</a
         >, conteúdo palpável
       </td>
@@ -34,7 +34,7 @@ O **elemento** **HTML** **`<em>`** marca o texto que tem ênfase. O elemento \<e
       <th scope="row">Conteúdo permitido</th>
       <td>
         <a
-          href="https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#Phrasing_content"
+          href="https://developer.mozilla.org/pt-BR/docs/Web/HTML/Content_categories#Phrasing_content"
           >Conteúdo de frase</a
         >.
       </td>
@@ -48,7 +48,7 @@ O **elemento** **HTML** **`<em>`** marca o texto que tem ênfase. O elemento \<e
       <td>
         Qualquer elemento que aceita
         <a
-          href="https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#Phrasing_content"
+          href="https://developer.mozilla.org/pt-BR/docs/Web/HTML/Content_categories#Phrasing_content"
           >conteúdo de frase</a
         >.
       </td>

--- a/files/pt-br/web/html/element/fieldset/index.md
+++ b/files/pt-br/web/html/element/fieldset/index.md
@@ -11,17 +11,17 @@ O **elemento** **HTML `<fieldset>`** é usado para agrupar elementos, assim como
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/HTML/Content_categories">Categorias de Conteúdo</a>
+        <a href="/pt-BR/docs/HTML/Content_categories">Categorias de Conteúdo</a>
       </th>
       <td>
-        <a href="/en-US/docs/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/HTML/Content_categories#Flow_content"
           >Conteúdo de fluxo</a
         >,
         <a
-          href="/en-US/docs/Sections_and_Outlines_of_an_HTML5_document#sectioning_root"
+          href="/pt-BR/docs/Sections_and_Outlines_of_an_HTML5_document#sectioning_root"
           >sectioning root</a
-        >, <a href="/en-US/docs/HTML/Content_categories#form_listed">listed</a>,
-        <a href="/en-US/docs/HTML/Content_categories#form-associated_content"
+        >, <a href="/pt-BR/docs/HTML/Content_categories#form_listed">listed</a>,
+        <a href="/pt-BR/docs/HTML/Content_categories#form-associated_content"
           >form-associated</a
         >
         element, palpable content.
@@ -42,7 +42,7 @@ O **elemento** **HTML `<fieldset>`** é usado para agrupar elementos, assim como
       <th scope="row">Elementos pai permitidos</th>
       <td>
         Qualquer elemento que aceita
-        <a href="/en-US/docs/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/HTML/Content_categories#Flow_content"
           >conteúdo de fluxo</a
         >.
       </td>

--- a/files/pt-br/web/html/element/figcaption/index.md
+++ b/files/pt-br/web/html/element/figcaption/index.md
@@ -12,14 +12,14 @@ translation_of: Web/HTML/Element/figcaption
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/HTML/Content_categories">Categorias de conteúdo</a>
+        <a href="/pt-BR/docs/HTML/Content_categories">Categorias de conteúdo</a>
       </th>
       <td>Nenhuma.</td>
     </tr>
     <tr>
       <th scope="row">Conteúdo permitido</th>
       <td>
-        <a href="/en-US/docs/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/HTML/Content_categories#Flow_content"
           >Flow content</a
         >.
       </td>

--- a/files/pt-br/web/html/element/footer/index.md
+++ b/files/pt-br/web/html/element/footer/index.md
@@ -26,7 +26,7 @@ Este elemento não tem outros atributos que os [global attributes](/pt-BR/docs/H
 
 ## DOM Interface
 
-Este elemento implementa a interface [`HTMLElement`](/en-US/docs/DOM/element).
+Este elemento implementa a interface [`HTMLElement`](/pt-BR/docs/DOM/element).
 
 ## Exemplos
 

--- a/files/pt-br/web/html/element/head/index.md
+++ b/files/pt-br/web/html/element/head/index.md
@@ -14,7 +14,7 @@ O elemento **HTML `<head>` providencia informações gerais** (metadados) sobre 
   <tbody>
     <tr>
       <th>
-        <a href="/en-US/docs/Web/HTML/Content_categories"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories"
           >Categoria de conteúdo</a
         >
       </th>

--- a/files/pt-br/web/html/element/hgroup/index.md
+++ b/files/pt-br/web/html/element/hgroup/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/hgroup
 ---
 {{HTMLRef}}{{seeCompatTable}}
 
-O **elemento HTML `<hgroup>` **destina-se a agrupar cabeçalhos de diferentes níveis para uma seção do documento. Ele agrupa (é um container para) um conjunto de elementos [`<h1>–<h6>`](/en-US/docs/Web/HTML/Element/Heading_Elements).
+O **elemento HTML `<hgroup>` **destina-se a agrupar cabeçalhos de diferentes níveis para uma seção do documento. Ele agrupa (é um container para) um conjunto de elementos [`<h1>–<h6>`](/pt-BR/docs/Web/HTML/Element/Heading_Elements).
 
 <table class="properties">
   <tbody>
@@ -13,7 +13,7 @@ O **elemento HTML `<hgroup>` **destina-se a agrupar cabeçalhos de diferentes n�
       <th scope="row">Categorias de conteudo</th>
       <td>
         <a
-          href="/en-US/docs/HTML/Content_categories#Flow_content"
+          href="/pt-BR/docs/HTML/Content_categories#Flow_content"
           >Flow content</a
         >, heading content, palpable content.
       </td>
@@ -35,7 +35,7 @@ O **elemento HTML `<hgroup>` **destina-se a agrupar cabeçalhos de diferentes n�
       <td>
         Any element that accepts
         <a
-          href="/en-US/docs/HTML/Content_categories#Flow_content"
+          href="/pt-BR/docs/HTML/Content_categories#Flow_content"
           >flow content</a
         >.
       </td>

--- a/files/pt-br/web/html/element/i/index.md
+++ b/files/pt-br/web/html/element/i/index.md
@@ -11,15 +11,15 @@ O **elemento HTML `<i>` **representa uma parte do texto que é destacada do rest
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/Web/HTML/Content_categories"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories"
           >Categorias de conteúdo</a
         >
       </th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Flow_content"
           >Conteúdo de fluxo (flow content)</a
         >,
-        <a href="/en-US/docs/Web/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Phrasing_content"
           >conteúdo com texto (phrasing content)</a
         >, conteúdo palpável (palpable content).
       </td>
@@ -27,7 +27,7 @@ O **elemento HTML `<i>` **representa uma parte do texto que é destacada do rest
     <tr>
       <th scope="row">Conteúdo permitido</th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Phrasing_content"
           >Conteúdo com texto (phrasing content)</a
         >.
       </td>
@@ -40,7 +40,7 @@ O **elemento HTML `<i>` **representa uma parte do texto que é destacada do rest
       <th scope="row">Pais permitidos</th>
       <td>
         Qualquer elemento que aceite
-        <a href="/en-US/docs/Web/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Phrasing_content"
           >conteúdo com texto (phrasing content)</a
         >.
       </td>

--- a/files/pt-br/web/html/element/img/index.md
+++ b/files/pt-br/web/html/element/img/index.md
@@ -185,7 +185,7 @@ Quando o atributo `alt` não estiver presente em uma imagem, alguns programas le
 
 O atributo {{htmlattrxref("title")}} não é um substituto aceitável para o atributo `alt`. Além disso, evite duplicar o valor do atributo `alt` no atributo `title` para uma mesma imagem. Isso pode fazer com que alguns programas leitores de tela narrem duas vezes a descrição, o que pode criar uma experiência confusa para usuários.
 
-Evite usar o atributo `title` como uma forma suplementar de legenda para a descrição do `alt`. Caso a imagem precise de uma legenda, prefisa os elementos [`figure`](/en-US/docs/Web/HTML/Element/figure) e [`figcaption`](/en-US/docs/Web/HTML/Element/figcaption).
+Evite usar o atributo `title` como uma forma suplementar de legenda para a descrição do `alt`. Caso a imagem precise de uma legenda, prefisa os elementos [`figure`](/pt-BR/docs/Web/HTML/Element/figure) e [`figcaption`](/pt-BR/docs/Web/HTML/Element/figcaption).
 
 O valor do atributo `title` é geralmente mostrado ao usuário como uma dica, que aparece após o usuário parar o cursor sobre a imagem. Apesar de _poder_ _prover_ informações adicionais ao usuário, não se deve assumir todos os usuários vão vê-lo, pois o mesmo pode possuir apenas um teclado ou uma tela de toque (touchscreen). Se você considera a informação particularmente importante para o usuário, prefira o uso de elementos inline.
 

--- a/files/pt-br/web/html/element/input/button/index.md
+++ b/files/pt-br/web/html/element/input/button/index.md
@@ -75,7 +75,7 @@ Se você não especificar um `value`, você obtém um botão vazio:
 
 ## Usando buttons
 
-Elementos `<input type="button">` não possuem comportamento padrão (seu primos, `<input type="submit">` e [`<input type="reset">`](/en-US/docs/Web/HTML/Element/input/reset) são usados para submeter e resetar formulários). Para que botões possam fazer algo, você tem de escrever um código em JavaScript para fazê-lo trabalhar.
+Elementos `<input type="button">` não possuem comportamento padrão (seu primos, `<input type="submit">` e [`<input type="reset">`](/pt-BR/docs/Web/HTML/Element/input/reset) são usados para submeter e resetar formulários). Para que botões possam fazer algo, você tem de escrever um código em JavaScript para fazê-lo trabalhar.
 
 ### Um simples botão
 

--- a/files/pt-br/web/html/element/input/checkbox/index.md
+++ b/files/pt-br/web/html/element/input/checkbox/index.md
@@ -180,7 +180,7 @@ Portanto, neste caso, o `indeterminate`estado é usado para afirmar que a coleta
 
 ## Validação
 
-As caixas de seleção suportam [validação](/pt-BR/docs/Web/Guide/HTML/HTML5/Constraint_validation) (oferecidas para todos os [`<input>`](/pt-BR/docs/Web/HTML/Element/input)s). No entanto, a maioria dos {{domxref ("ValidityState")}} s sempre será `false`. Se a caixa de seleção tiver o [`required`](/en-US/docs/Web/HTML/Element/input#attr-required) atributo, mas não estiver marcada, ela [`ValidityState.valueMissing`](/en-US/docs/Web/API/ValidityState/valueMissing) será `true`.
+As caixas de seleção suportam [validação](/pt-BR/docs/Web/Guide/HTML/HTML5/Constraint_validation) (oferecidas para todos os [`<input>`](/pt-BR/docs/Web/HTML/Element/input)s). No entanto, a maioria dos {{domxref ("ValidityState")}} s sempre será `false`. Se a caixa de seleção tiver o [`required`](/pt-BR/docs/Web/HTML/Element/input#attr-required) atributo, mas não estiver marcada, ela [`ValidityState.valueMissing`](/pt-BR/docs/Web/API/ValidityState/valueMissing) será `true`.
 
 ## Exemplos
 

--- a/files/pt-br/web/html/element/input/date/index.md
+++ b/files/pt-br/web/html/element/input/date/index.md
@@ -15,9 +15,9 @@ tags:
 translation_of: Web/HTML/Element/input/date
 original_slug: Web/HTML/Element/Input/data
 ---
-Os elementos {{htmlelement("input")}} do tipo **`date`** cria campos de entrada que permite o usuário informar uma data, como também usar uma caixa de texto que valida automaticamente o conteúdo, ou usando uma interface de seleção de data especial. O valor resultante inclui ano, mês e dia, mas não o `horário`. Os tipos de entrada [time](/pt-BR/docs/Web/HTML/Element/input/time) e [`datetime-local`](/en-US/docs/Web/HTML/Element/input/datetime-local) permitem informar horário e data/hora.
+Os elementos {{htmlelement("input")}} do tipo **`date`** cria campos de entrada que permite o usuário informar uma data, como também usar uma caixa de texto que valida automaticamente o conteúdo, ou usando uma interface de seleção de data especial. O valor resultante inclui ano, mês e dia, mas não o `horário`. Os tipos de entrada [time](/pt-BR/docs/Web/HTML/Element/input/time) e [`datetime-local`](/pt-BR/docs/Web/HTML/Element/input/datetime-local) permitem informar horário e data/hora.
 
-A interface do usuário do controle varia geralmente de navegador para navegador; neste momento o suporte é irregular, veja [Browser compatibility](#browser_compatibility) para maiores detalhes. Nos navegadores sem suporte, o controle é rebaixado graciosamente para um [`<input type="text">`](/en-US/docs/Web/HTML/Element/input/text) simples.
+A interface do usuário do controle varia geralmente de navegador para navegador; neste momento o suporte é irregular, veja [Browser compatibility](#browser_compatibility) para maiores detalhes. Nos navegadores sem suporte, o controle é rebaixado graciosamente para um [`<input type="text">`](/pt-BR/docs/Web/HTML/Element/input/text) simples.
 
 ```html
 <input id="date" type="date">

--- a/files/pt-br/web/html/element/input/range/index.md
+++ b/files/pt-br/web/html/element/input/range/index.md
@@ -13,7 +13,7 @@ translation_of: Web/HTML/Element/input/range
 
 {{EmbedLiveSample("summary_sample1", 600, 40)}}
 
-Se o navegador do usuário não suportar o tipo `"range"`, este será tratado como um input do tipo [`"text"`](/en-US/docs/Web/HTML/Element/input/text).
+Se o navegador do usuário não suportar o tipo `"range"`, este será tratado como um input do tipo [`"text"`](/pt-BR/docs/Web/HTML/Element/input/text).
 
 <table class="properties">
   <tbody>
@@ -339,4 +339,4 @@ Além dos exemplos variados acima, você encontrará as entradas de alcance demo
 
 - [HTML Forms](/pt-BR/docs/Learn/HTML/Forms)
 - {{HTMLElement("input")}} and the {{domxref("HTMLInputElement")}} interface it's based upon
-- [`<input type="number">`](/en-US/docs/Web/HTML/Element/input/number)
+- [`<input type="number">`](/pt-BR/docs/Web/HTML/Element/input/number)

--- a/files/pt-br/web/html/element/input/time/index.md
+++ b/files/pt-br/web/html/element/input/time/index.md
@@ -11,7 +11,7 @@ translation_of: Web/HTML/Element/input/time
 
 Elementos `<input>` do tipo **`time`** (hora) criam campos de inserção que permitem que o usuário digite horários facilmente (horas e minutos e, opcionalmente, segundos).
 
-A interface de usuário deste tipo de campo varia de navegador para navegador. A maioria dos navegadores modernos é compatível com ele exceto pelo Safari, o único grande navegador que ainda não o implementou; no Safari (e em qualquer outro navegador que ainda não suporte `<time>`), ele regride para [`<input type="text">`](/en-US/docs/Web/HTML/Element/input/text).
+A interface de usuário deste tipo de campo varia de navegador para navegador. A maioria dos navegadores modernos é compatível com ele exceto pelo Safari, o único grande navegador que ainda não o implementou; no Safari (e em qualquer outro navegador que ainda não suporte `<time>`), ele regride para [`<input type="text">`](/pt-BR/docs/Web/HTML/Element/input/text).
 
 {{EmbedInteractiveExample("pages/tabbed/input-time.html", "tabbed-standard")}}
 
@@ -464,4 +464,4 @@ function populateMinutes() {
 
 - The generic {{HTMLElement("input")}} element and the interface used to manipulate it, {{domxref("HTMLInputElement")}}
 - [Date and Time picker tutorial](/pt-BR/docs/Web/Guide/HTML/Forms/The_native_form_widgets#Date_and_time_picker)
-- [`<input type="datetime-local">`](/en-US/docs/Web/HTML/Element/input/datetime-local), [`<input type="date">`](/en-US/docs/Web/HTML/Element/input/date), [`<input type="week">`](/en-US/docs/Web/HTML/Element/input/week), and [`<input type="month">`](/en-US/docs/Web/HTML/Element/input/month)
+- [`<input type="datetime-local">`](/pt-BR/docs/Web/HTML/Element/input/datetime-local), [`<input type="date">`](/pt-BR/docs/Web/HTML/Element/input/date), [`<input type="week">`](/pt-BR/docs/Web/HTML/Element/input/week), and [`<input type="month">`](/pt-BR/docs/Web/HTML/Element/input/month)

--- a/files/pt-br/web/html/element/meta/index.md
+++ b/files/pt-br/web/html/element/meta/index.md
@@ -11,17 +11,17 @@ O elemento **HTML `<meta>` **define qualquer informação de metadados que não 
   <tbody>
     <tr>
       <th>
-        <a href="/en-US/docs/Web/HTML/Content_categories">Categoria</a> de
+        <a href="/pt-BR/docs/Web/HTML/Content_categories">Categoria</a> de
         conteúdo
       </th>
       <td>
         Conteúdo de metadado. Se o
         {{htmlattrxref("itemprop", "meta")}} atributo estiver
         presente:
-        <a href="/en-US/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Flow_content"
           >flow content</a
         >,
-        <a href="/en-US/docs/Web/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Phrasing_content"
           >phrasing content</a
         >.
       </td>

--- a/files/pt-br/web/html/element/q/index.md
+++ b/files/pt-br/web/html/element/q/index.md
@@ -15,13 +15,13 @@ translation_of: Web/HTML/Element/q
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/HTML/Content_categories">Categorias de conteúdo</a>
+        <a href="/pt-BR/docs/HTML/Content_categories">Categorias de conteúdo</a>
       </th>
       <td>
-        <a href="/en-US/docs/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/HTML/Content_categories#Flow_content"
           >Fluxo de conteúdo</a
         >,
-        <a href="/en-US/docs/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/HTML/Content_categories#Phrasing_content"
           >conteúdo textual</a
         >, conteúdo palpável.
       </td>
@@ -29,7 +29,7 @@ translation_of: Web/HTML/Element/q
     <tr>
       <th scope="row">Conteúdo permitido</th>
       <td>
-        <a href="/en-US/docs/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/HTML/Content_categories#Phrasing_content"
           >Conteúdo textual</a
         >.
       </td>
@@ -42,7 +42,7 @@ translation_of: Web/HTML/Element/q
       <th scope="row">Parents permitidos</th>
       <td>
         Qualquer elemento que aceite
-        <a href="/en-US/docs/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/HTML/Content_categories#Phrasing_content"
           >conteúdo textual</a
         >.
       </td>
@@ -74,7 +74,7 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/HTML/Global_attributes).
 ```html
 <p>According to Mozilla's website,
   <q
-  cite="https://www.mozilla.org/en-US/about/history/details/">Firefox 1.0
+  cite="https://www.mozilla.org/pt-BR/about/history/details/">Firefox 1.0
   was released in 2004 and became a big success.</q></p>
 ```
 

--- a/files/pt-br/web/html/element/s/index.md
+++ b/files/pt-br/web/html/element/s/index.md
@@ -13,16 +13,16 @@ O **elemento HTML `<s>`** renderiza um texto tachado ou uma linha cortando o tex
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/Web/HTML/Content_categories"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories"
           >Categorias de conteúdo</a
         >
       </th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Phrasing_content"
           >Conteúdo fraseado</a
         >
         ou
-        <a href="/en-US/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Flow_content"
           >conteúdo de fluxo</a
         >.
       </td>
@@ -30,7 +30,7 @@ O **elemento HTML `<s>`** renderiza um texto tachado ou uma linha cortando o tex
     <tr>
       <th scope="row">Conteúdo permitido</th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Phrasing_content"
           >Conteúdo freaseado</a
         >.
       </td>
@@ -43,7 +43,7 @@ O **elemento HTML `<s>`** renderiza um texto tachado ou uma linha cortando o tex
       <th scope="row">Pais permitidos</th>
       <td>
         Qualquer elemento que aceite
-        <a href="/en-US/docs/Web/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Phrasing_content"
           >conteúdo fraseado</a
         >.
       </td>

--- a/files/pt-br/web/html/element/script/index.md
+++ b/files/pt-br/web/html/element/script/index.md
@@ -9,18 +9,18 @@ O **elemento HTML `<script>`** é usado para incluir ou referenciar um script ex
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/Web/HTML/Content_categories"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories"
           >Categorias de conteúdo</a
         >
       </th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#Metadata_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Metadata_content"
           >Conteúdo de metadados</a
         >,
-        <a href="/en-US/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Flow_content"
           >Fluxo de conteúdo</a
         >,
-        <a href="/en-US/docs/Web/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Phrasing_content"
           >Conteúdo fraseado</a
         >.
       </td>
@@ -37,10 +37,10 @@ O **elemento HTML `<script>`** é usado para incluir ou referenciar um script ex
       <th scope="row">Pais permitidos</th>
       <td>
         Qualquer elemento que aceite
-        <a href="/en-US/docs/Web/HTML/Content_categories#Metadata_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Metadata_content"
           >conteúdo de metadados</a
         >, ou qualquer elemento que aceite
-        <a href="/en-US/docs/Web/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Phrasing_content"
           >conteúdo fraseado</a
         >.
       </td>
@@ -100,7 +100,7 @@ Esse elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
 
     Note that in Firefox you can use advanced features such as let statements and other features in later JS versions, by using `type=application/javascript;version=1.8` {{Non-standard_inline}}. Beware, however, that as this is a non-standard feature, this will most likely break support for other browsers, in particular Chromium-based browsers.
 
-    For how to include _exotic programming languages_, read about [Rosetta](/en-US/Add-ons/Code_snippets/Rosetta).
+    For how to include _exotic programming languages_, read about [Rosetta](/pt-BR/Add-ons/Code_snippets/Rosetta).
 
 ### Atributos obsoletos
 

--- a/files/pt-br/web/html/element/section/index.md
+++ b/files/pt-br/web/html/element/section/index.md
@@ -11,16 +11,16 @@ Por exemplo, um menu de navegação deve estar dentro um elemento {{htmlelement 
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/Web/HTML/Content_categories"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories"
           >Categorias de conteúdo</a
         >
       </th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Flow_content"
           >Conteúdo de fluxo</a
         >
         ,
-        <a href="/en-US/docs/Web/HTML/Content_categories#Sectioning_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Sectioning_content"
           >conteúdo de seção</a
         >, conteúdo palpável.
       </td>
@@ -28,7 +28,7 @@ Por exemplo, um menu de navegação deve estar dentro um elemento {{htmlelement 
     <tr>
       <th scope="row">Conteúdo permitido</th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Flow_content"
           >Conteúdo de fluxo</a
         >.
       </td>
@@ -41,7 +41,7 @@ Por exemplo, um menu de navegação deve estar dentro um elemento {{htmlelement 
       <th scope="row">Tags-pai permitidas</th>
       <td>
         Qualquer elemento que aceite
-        <a href="/en-US/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Flow_content"
           >conteúdo de fluxo</a
         >. Note que um elemento {{HTMLElement("section")}} não deve
         ser um descendente de um elemento {{HTMLElement("address")}}.

--- a/files/pt-br/web/html/element/span/index.md
+++ b/files/pt-br/web/html/element/span/index.md
@@ -29,7 +29,7 @@ Esse elemento inclui apenas os [a](/pt-BR/docs/HTML/Global_attributes)[tributos 
 
 ## DOM interface
 
-Este elemento implementa a interface [`HTMLSpanElement`](/en-US/docs/HTMLSpanElement).
+Este elemento implementa a interface [`HTMLSpanElement`](/pt-BR/docs/HTMLSpanElement).
 
 ## Exemplos
 

--- a/files/pt-br/web/html/element/strong/index.md
+++ b/files/pt-br/web/html/element/strong/index.md
@@ -17,14 +17,14 @@ O elemento HTML <strong> dá ao texto uma forte importância, e é tipicamente m
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/Web/HTML/Content_categories"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories"
           >Categorias do conteúdo</a
         >
       </th>
       <td>
-        <a href="/en-US/docs/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/HTML/Content_categories#Flow_content"
           >Flux content</a
-        >,<a href="/en-US/docs/HTML/Content_categories#Phrasing_content">
+        >,<a href="/pt-BR/docs/HTML/Content_categories#Phrasing_content">
           Phrasing content</a
         >, conteúdo palpável.
       </td>
@@ -32,7 +32,7 @@ O elemento HTML <strong> dá ao texto uma forte importância, e é tipicamente m
     <tr>
       <th scope="row">Conteúdo permitido</th>
       <td>
-        <a href="/en-US/docs/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/HTML/Content_categories#Phrasing_content"
           >Phrasing content</a
         >.
       </td>
@@ -45,10 +45,10 @@ O elemento HTML <strong> dá ao texto uma forte importância, e é tipicamente m
       <th scope="row">Permitted parents</th>
       <td>
         Qualquer elemento que aceite
-        <a href="/en-US/docs/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/HTML/Content_categories#Phrasing_content"
           >phrasing content</a
         >, ou qualquer elemento que aceite
-        <a href="/en-US/docs/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/HTML/Content_categories#Flow_content"
           >flow content</a
         >.
       </td>
@@ -62,7 +62,7 @@ O elemento HTML <strong> dá ao texto uma forte importância, e é tipicamente m
       <td>
         {{domxref("HTMLElement")}} Até Gecko 1.9.2 (Firefox 4)
         inclusive, Firefox implementa a interface
-        <a href="/en-US/docs/DOM/span"><code>HTMLSpanElement</code></a> para
+        <a href="/pt-BR/docs/DOM/span"><code>HTMLSpanElement</code></a> para
         este elemento.
       </td>
     </tr>

--- a/files/pt-br/web/html/element/table/index.md
+++ b/files/pt-br/web/html/element/table/index.md
@@ -20,13 +20,13 @@ O elemento HTML _Table_ (`<table>`) representa dados em duas dimensões ou mais.
     <tr>
       <td>
         <a
-          href="/en-US/docs/HTML/Content_categories"
+          href="/pt-BR/docs/HTML/Content_categories"
           >Categoria de conteúdo</a
         >
       </td>
       <td>
         <a
-          href="/en-US/docs/HTML/Content_categories#Flow_content"
+          href="/pt-BR/docs/HTML/Content_categories#Flow_content"
           >Fluxo de conteúdo</a
         >
       </td>
@@ -190,7 +190,7 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/HTML/Global_attributes).
 
 ## DOM interface
 
-This element implements the [`HTMLTableElement`](/en-US/docs/DOM/HTMLTableElement) interface.
+This element implements the [`HTMLTableElement`](/pt-BR/docs/DOM/HTMLTableElement) interface.
 
 ## Examples
 

--- a/files/pt-br/web/html/element/template/index.md
+++ b/files/pt-br/web/html/element/template/index.md
@@ -21,18 +21,18 @@ Pense no template como um fragmento de conteúdo, que é armazenado para um poss
     <tr>
       <th scope="row">
         <a
-          href="/en-US/docs/Web/HTML/Content_categories"
+          href="/pt-BR/docs/Web/HTML/Content_categories"
           >Conteúdo de categorias</a
         >
       </th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#Metadata_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Metadata_content"
           >Metadata content</a
         >,
-        <a href="/en-US/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Flow_content"
           >flow content</a
         >,
-        <a href="/en-US/docs/Web/Guide/HTML/Content_categories#Phrasing_content"
+        <a href="/pt-BR/docs/Web/Guide/HTML/Content_categories#Phrasing_content"
           >phrasing content</a
         >, script-supporting element
       </td>
@@ -40,10 +40,10 @@ Pense no template como um fragmento de conteúdo, que é armazenado para um poss
     <tr>
       <th scope="row">Conteúdo Permitido</th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#Metadata_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Metadata_content"
           >Metadata content</a
         >,
-        <a href="/en-US/docs/Web/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/Web/HTML/Content_categories#Flow_content"
           >flow content, </a
         >qualquer conteúdo HTML válido que é permitido para ocorrer dentro do
         {{HTMLElement("ol")}}, {{HTMLElement("dl")}},

--- a/files/pt-br/web/html/element/textarea/index.md
+++ b/files/pt-br/web/html/element/textarea/index.md
@@ -62,7 +62,7 @@ Este elemento inclui os atributos globais.
 
   - : Uma dica para o usuário sobre o que pode ser inserido no controle. Retornos de carro ou feeds de linha no texto do espaço reservado devem ser tratados como quebras de linha ao renderizar a dica.
 
-    > **Note:** **Nota: Os espaços reservados devem ser usados apenas para mostrar um exemplo do tipo de dados que deve ser inserido em um formulário; eles não substituem uma adequada** {{HTMLElement("label")}} elemento vinculado à entrada. Veja {{SectionOnPage("/en-US/docs/Web/HTML/Element/input", "Labels and placeholders")}} para uma explicação completa.
+    > **Note:** **Nota: Os espaços reservados devem ser usados apenas para mostrar um exemplo do tipo de dados que deve ser inserido em um formulário; eles não substituem uma adequada** {{HTMLElement("label")}} elemento vinculado à entrada. Veja {{SectionOnPage("/pt-BR/docs/Web/HTML/Element/input", "Labels and placeholders")}} para uma explicação completa.
 
 - {{ htmlattrdef("readonly") }}
   - : Esse atributo booleano indica que o usuário não pode modificar o valor do controle. Ao contrário do `disabled` atributo, o`readonly` O atributo não impede o usuário de clicar ou selecionar no controle. O valor de um controle somente leitura ainda é enviado com o formulário.
@@ -161,7 +161,7 @@ Este exemplo tem um espaço reservado definido. Observe como ele desaparece quan
 
 {{ EmbedLiveSample('Placeholder','600','80') }}
 
-> **Note:** **Nota: Os espaços reservados devem ser usados apenas para mostrar um exemplo do tipo de dados que deve ser inserido em um formulário; eles não substituem uma adequada**{{HTMLElement("label")}} elemento vinculado à entrada. Veja {{SectionOnPage("/en-US/docs/Web/HTML/Element/input", "Labels and placeholders")}} para uma explicação completa.
+> **Note:** **Nota: Os espaços reservados devem ser usados apenas para mostrar um exemplo do tipo de dados que deve ser inserido em um formulário; eles não substituem uma adequada**{{HTMLElement("label")}} elemento vinculado à entrada. Veja {{SectionOnPage("/pt-BR/docs/Web/HTML/Element/input", "Labels and placeholders")}} para uma explicação completa.
 
 ### Desativado e somente leitura
 
@@ -184,10 +184,10 @@ Este exemplo mostra dois `<textarea>`s — um dos quais é `disabled`, e o outro
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/HTML/Content_categories">Categorias de conteúdo</a>
+        <a href="/pt-BR/docs/HTML/Content_categories">Categorias de conteúdo</a>
       </th>
       <td>
-        <a href="/en-US/docs/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/HTML/Content_categories#Flow_content"
           >Elemento associado ao formulário de conteúdo de fluxo, conteúdo de
           frases, conteúdo interativo, listado, rotulável, redefinível e
           submetível a envio.</a

--- a/files/pt-br/web/html/element/tfoot/index.md
+++ b/files/pt-br/web/html/element/tfoot/index.md
@@ -13,7 +13,7 @@ O **`<tfoot>` **é um **elemento HTML** que define um conjunto de linhas as quai
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/Web/Guide/HTML/Content_categories"
+        <a href="/pt-BR/docs/Web/Guide/HTML/Content_categories"
           >Categorias de conteúdo</a
         >
       </th>

--- a/files/pt-br/web/html/element/th/index.md
+++ b/files/pt-br/web/html/element/th/index.md
@@ -13,7 +13,7 @@ O **elemento** **HTML `<th>` **define uma célula cabeçalho do grupo de célula
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/Web/Guide/HTML/Content_categories"
+        <a href="/pt-BR/docs/Web/Guide/HTML/Content_categories"
           >Categorias do conteúdo</a
         >
       </th>
@@ -22,7 +22,7 @@ O **elemento** **HTML `<th>` **define uma célula cabeçalho do grupo de célula
     <tr>
       <th scope="row">Conteúdo permitido</th>
       <td>
-        <a href="/en-US/docs/Web/Guide/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/Web/Guide/HTML/Content_categories#Flow_content"
           >Conteúdo de fluxo</a
         >, mas sem descendentes de cabeçalho, rodapé, conteúdo de seção ou
         conteúdo de cabeçalho.
@@ -71,7 +71,7 @@ Esse elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
 
     - `row`: O cabeçalho se relaciona com todas as células da linha a que pertence.
     - `col`: O cabeçalho se relaciona com todas as células da coluna a que pertence.
-    - `rowgroup`: O cabeçalho pertence a um grupo de linhas e se relaciona com todas as suas células. Essas células podem ser colocadas à direita ou à esquerda do cabeçalho, dependendo do valor do atributo [`dir`](/en-US/docs/Web/HTML/Global_attributes/dir) no elemento {{HTMLElement("table")}}.
+    - `rowgroup`: O cabeçalho pertence a um grupo de linhas e se relaciona com todas as suas células. Essas células podem ser colocadas à direita ou à esquerda do cabeçalho, dependendo do valor do atributo [`dir`](/pt-BR/docs/Web/HTML/Global_attributes/dir) no elemento {{HTMLElement("table")}}.
     - `colgroup`: O cabeçalho pertence a um grupo de colgroup e se relaciona com todas as suas células.
     - `auto`
 

--- a/files/pt-br/web/html/element/time/index.md
+++ b/files/pt-br/web/html/element/time/index.md
@@ -33,7 +33,7 @@ Como todo outro elemento HTML, este elemento suporta os [atributos globais](/pt-
 
 ## DOM interface
 
-This element implements the [`HTMLTimeElement`](/en-US/docs/DOM/HTMLTimeElement) interface.
+This element implements the [`HTMLTimeElement`](/pt-BR/docs/DOM/HTMLTimeElement) interface.
 
 ## Exemplos
 

--- a/files/pt-br/web/html/element/track/index.md
+++ b/files/pt-br/web/html/element/track/index.md
@@ -36,7 +36,7 @@ O **elemento HTML `<track>` **é usado como filho dos elementos de mídia{{HTMLE
       <th scope="row">Permite Parentes</th>
       <td>
         Um elemento de mídia, antes de qualquer
-        <a href="/en-US/docs/HTML/Content_categories#Flow_content"
+        <a href="/pt-BR/docs/HTML/Content_categories#Flow_content"
           >conteúdo de fluxo</a
         >.
       </td>
@@ -89,7 +89,7 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/HTML/Global_attributes).
 - {{htmlattrdef("label")}}
   - : A user-readable title of the text track which is used by the browser when listing available text tracks.
 - {{htmlattrdef("src")}}
-  - : Address of the track (`.vtt` file). Must be a valid URL. This attribute must be specified and its URL value must have the same origin as the document — unless the {{HTMLElement("audio")}} or {{HTMLElement("video")}} parent element of the `track` element has a [`crossorigin`](/en-US/docs/Web/HTML/CORS_settings_attributes) attribute.
+  - : Address of the track (`.vtt` file). Must be a valid URL. This attribute must be specified and its URL value must have the same origin as the document — unless the {{HTMLElement("audio")}} or {{HTMLElement("video")}} parent element of the `track` element has a [`crossorigin`](/pt-BR/docs/Web/HTML/CORS_settings_attributes) attribute.
 - {{htmlattrdef("srclang")}}
   - : Language of the track text data. It must be a valid [BCP 47](https://r12a.github.io/app-subtags/) language tag. If the `kind` attribute is set to `subtitles`, then `srclang` must be defined.
 

--- a/files/pt-br/web/html/element/var/index.md
+++ b/files/pt-br/web/html/element/var/index.md
@@ -21,7 +21,7 @@ Este elemento somente inclui os [global attributes](/pt-BR/docs/HTML/Global_attr
 
 ## Interface DOM
 
-Este elemento implementa a interface [`HTMLElement`](/en-US/docs/DOM/element).
+Este elemento implementa a interface [`HTMLElement`](/pt-BR/docs/DOM/element).
 
 > **Note:** **Implementation note:** up to Gecko 1.9.2 inclusive, Firefox implements the [HTMLSpanElement](/pt-BR/docs/DOM/span) interface for this element.
 

--- a/files/pt-br/web/html/global_attributes/index.md
+++ b/files/pt-br/web/html/global_attributes/index.md
@@ -41,11 +41,11 @@ Além dos atributos globais HTML básicos, os seguintes atributos globais també
     - `true` ou uma string vazia, indica que o elemento deve ser editável;
     - `false`, indica que o elemento não deve ser editável.
 
-- [`contextmenu`](/en-US/docs/Web/HTML/Global_attributes/contextmenu)
+- [`contextmenu`](/pt-BR/docs/Web/HTML/Global_attributes/contextmenu)
   - : É o **[`id`](#attr-id)** de um {{HTMLElement("menu")}} para usar como o menu contextual para este elemento.
 - [`data-*`](/pt-BR/docs/Web/HTML/Global_attributes/data-*)
   - : Forma uma classe de atributos, denominado de dados personalizados, que permite troca de informações proprietárias entre o [HTML](/pt-BR/docs/Web/HTML) e a sua representação no [DOM](/pt-BR/docs/Glossary/DOM) pode ser usada por scripts. Todos esses dados personalizados estão disponíveis através da interface do elemento {{domxref("HTMLElement")}} em que o atributo está definido. A propriedade {{domxref("HTMLElement.dataset")}} dá acesso a eles.
-- [`dir`](/en-US/docs/Web/HTML/Global_attributes/dir)
+- [`dir`](/pt-BR/docs/Web/HTML/Global_attributes/dir)
 
   - : É um atributo enumerado que indica a direcionalidade do texto do elemento. Pode ter os seguintes valores:
 
@@ -53,14 +53,14 @@ Além dos atributos globais HTML básicos, os seguintes atributos globais també
     - `rtl`, significa da direita para a esquerda e deve ser usado para idiomas que são escritos da direita para a esquerda (como o árabe);
     - `auto`, que permite que o agente do usuário decida. Ele usa um algoritmo básico, pois analisa os caracteres dentro do elemento até encontrar um caractere com uma direcionalidade forte e, em seguida, aplica essa direcionalidade para todo o elemento.
 
-- [`draggable`](/en-US/docs/Web/HTML/Global_attributes/draggable) {{experimental_inline}}
+- [`draggable`](/pt-BR/docs/Web/HTML/Global_attributes/draggable) {{experimental_inline}}
 
   - : É um atributo enumerado que indica se o elemento pode ser arrastado, usando a [API Drag and Drop](/pt-BR/docs/DragDrop/Drag_and_Drop). Pode ter os seguintes valores:
 
     - `true`, que indica que o elemento pode ser arrastado
     - `false`, que indica que o elemento não pode ser arrastado.
 
-- [`dropzone`](/en-US/docs/Web/HTML/Global_attributes/dropzone) {{experimental_inline}}
+- [`dropzone`](/pt-BR/docs/Web/HTML/Global_attributes/dropzone) {{experimental_inline}}
 
   - : É um atributo enumerado que indica quais tipos de conteúdo podem ser descartados em um elemento, usando a [API Drag and Drop](/pt-BR/docs/DragDrop/Drag_and_Drop). Pode ter os seguintes valores:
 
@@ -75,16 +75,16 @@ Além dos atributos globais HTML básicos, os seguintes atributos globais també
 
 > **Note:** **Nota:** Os 5 atributos seguintes são partes do [Recursos de Microdados WHATWG HTML](http://www.whatwg.org/specs/web-apps/current-work/multipage/links.html#microdata).
 
-- [`itemid`](/en-US/docs/Web/HTML/Global_attributes/itemid) {{experimental_inline}}
+- [`itemid`](/pt-BR/docs/Web/HTML/Global_attributes/itemid) {{experimental_inline}}
   - : O identificador único e global de um item.
 - [`itemprop`](/pt-BR/docs/Web/HTML/Global_attributes/itemprop) {{experimental_inline}}
   - : Usado para adicionar propriedades a um item. Cada elemento HTML pode ter um atributo itemprop especificado, onde um itemprop consiste em um par de nomes e valores.
-- [`itemref`](/en-US/docs/Web/HTML/Global_attributes/itemref) {{experimental_inline}}
+- [`itemref`](/pt-BR/docs/Web/HTML/Global_attributes/itemref) {{experimental_inline}}
   - : As propriedades que não são descendentes de um elemento com o atributo `itemscope` podem ser associadas ao item usando um **itemref**. Itemref fornece uma lista de ids de elementos (não `itemid`) com propriedades adicionais em outro lugar do documento.
 - `itemscope` {{experimental_inline}}
-  - : Este atributo funciona, em geral, com o atributo [`itemtype`](/en-US/docs/Web/HTML/Global_attributes/itemtype) para especificar o HTML dentro de um bloco é sobre um item particular. [`itemscope`](/en-US/docs/Web/HTML/Global_attributes/itemscope) cria o item e define o escopo do [`itemtype`](/en-US/docs/Web/HTML/Global_attributes/itemtype) associado a ele. [`itemtype`](/en-US/docs/Web/HTML/Global_attributes/itemtype) é uma URL válida de um vocabulário (como o [schema.org](http://schema.org/)) que descreve o item e o context de seus atributos.
-- [`itemtype`](/en-US/docs/Web/HTML/Global_attributes/itemtype) {{experimental_inline}}
-  - : Especifica a URL do vocabulário que será usado para definir as propriedades do item na estrutura de dados. [`itemscope`](/en-US/docs/Web/HTML/Global_attributes/itemscope) é usado para alterar o escopo na estrutura de dados onde o vocabulário definido por [`itemtype`](/en-US/docs/Web/HTML/Global_attributes/itemtype) estará ativo.
+  - : Este atributo funciona, em geral, com o atributo [`itemtype`](/pt-BR/docs/Web/HTML/Global_attributes/itemtype) para especificar o HTML dentro de um bloco é sobre um item particular. [`itemscope`](/pt-BR/docs/Web/HTML/Global_attributes/itemscope) cria o item e define o escopo do [`itemtype`](/pt-BR/docs/Web/HTML/Global_attributes/itemtype) associado a ele. [`itemtype`](/pt-BR/docs/Web/HTML/Global_attributes/itemtype) é uma URL válida de um vocabulário (como o [schema.org](http://schema.org/)) que descreve o item e o context de seus atributos.
+- [`itemtype`](/pt-BR/docs/Web/HTML/Global_attributes/itemtype) {{experimental_inline}}
+  - : Especifica a URL do vocabulário que será usado para definir as propriedades do item na estrutura de dados. [`itemscope`](/pt-BR/docs/Web/HTML/Global_attributes/itemscope) é usado para alterar o escopo na estrutura de dados onde o vocabulário definido por [`itemtype`](/pt-BR/docs/Web/HTML/Global_attributes/itemtype) estará ativo.
 - [`lang`](/pt-BR/docs/Web/HTML/Global_attributes/lang)
   - : Participa da definição do idioma do elemento, o idioma no qual os elementos não-editáveis estão escritos, ou o idioma no qual elementos editáveis devem ser escritos. A Tag contém um único valor no formato definido no documento da IEFT [Tags para Identificação de Idiomas (BCP47)](http://www.ietf.org/rfc/bcp/bcp47.txt). [**xml:lang**](#attr-xml:lang) tem prioridade mais alta que [`lang`](/pt-BR/docs/Web/HTML/Global_attributes/lang).
 - [`spellcheck`](/pt-BR/docs/Web/HTML/Global_attributes/spellcheck) {{experimental_inline}}
@@ -94,7 +94,7 @@ Além dos atributos globais HTML básicos, os seguintes atributos globais també
     - `true`, indica que o elemento deve ser, se possível, verificado por errors ortográficos;
     - `false`, indica que o elemento não deve ser verificado quanto à ortogratia do texto.
 
-- [`style`](/en-US/docs/Web/HTML/Global_attributes/style)
+- [`style`](/pt-BR/docs/Web/HTML/Global_attributes/style)
   - : Contém regras de declarações [CSS](/pt-BR/docs/) para aplicar no elemento. Note que é recomendado que as regras CSS fiquem num arquivo, ou vários arquivos, separado do HTML. Este atributo e o elemento {{HTMLElement("style")}} tem principalmente o propósito para rápida estilização do elemento, como por exemplo para testes.
 - [`tabindex`](/pt-BR/docs/Web/HTML/Global_attributes/tabindex)
 
@@ -106,7 +106,7 @@ Além dos atributos globais HTML básicos, os seguintes atributos globais també
 
 - [`title`](/pt-BR/docs/Web/HTML/Global_attributes/title)
   - : Contém um texto representativo sobre a informação relacionada ao elemento ao qual este atributo pertence. Tal informação pode, mas não necessariamente, ser apresentada através de um _tooltip_.
-- [`translate`](/en-US/docs/Web/HTML/Global_attributes/translate)
+- [`translate`](/pt-BR/docs/Web/HTML/Global_attributes/translate)
 
   - : É um atributo enumerado, usado para especificar se um atributo de um elemento e os valores dos seus nós descendentes (filhos) {{domxref("Text")}} serão traduzidos quando a página for localizada, ou se não serão alterados. Pode ter os seguintes valores:
 

--- a/files/pt-br/web/html/index.md
+++ b/files/pt-br/web/html/index.md
@@ -51,11 +51,11 @@ Nossa [Área de Aprendizado de HTML](/pt-BR/docs/Aprender/HTML) apresenta vário
 ## Tópicos avançados
 
 - [Habilitando Imagem CORS](/pt-BR/docs/Web/HTML/CORS_enabled_image)
-  - : O atributo [`crossorigin`](/en-US/docs/Web/HTML/Element/img#attr-crossorigin), em combinação com um cabeçalho [CORS](/pt-BR/docs/Glossary/CORS) adequado, permite definir imagens pelo elemento {{HTMLElement("img")}} para ser carregado de outras fontes em um elemento {{HTMLElement("canvas")}} como se estivessem sendo carregados da fonte atual.
+  - : O atributo [`crossorigin`](/pt-BR/docs/Web/HTML/Element/img#attr-crossorigin), em combinação com um cabeçalho [CORS](/pt-BR/docs/Glossary/CORS) adequado, permite definir imagens pelo elemento {{HTMLElement("img")}} para ser carregado de outras fontes em um elemento {{HTMLElement("canvas")}} como se estivessem sendo carregados da fonte atual.
 - [Configuração de atributos CORS](/pt-BR/docs/Web/HTML/CORS_settings_attributes)
   - : Alguns elementos em HTML que suportam [CORS](/pt-BR/docs/HTTP/Access_control_CORS), como por exemplo o {{HTMLElement("img")}} ou {{HTMLElement("video")}}, têm o atributo `crossorigin` (a propriedade `crossOrigin`), que permite configurar as requisições CORS para os dados recebidos pelo elemento.
 - [Gerenciamento de foco em HTML](/pt-BR/docs/Web/HTML/Focus_management_in_HTML)
-  - : O atributo DOM [`activeElement`](/en-US/docs/Web/API/Document/activeElement) e o método DOM [`hasFocus()`](/en-US/docs/Web/API/Document/hasFocus) lhe ajudam a melhorar a interação entre o usuário e os elementos da página.
+  - : O atributo DOM [`activeElement`](/pt-BR/docs/Web/API/Document/activeElement) e o método DOM [`hasFocus()`](/pt-BR/docs/Web/API/Document/hasFocus) lhe ajudam a melhorar a interação entre o usuário e os elementos da página.
 - [Tipos de conexões](/pt-BR/docs/Web/HTML/Link_types)
   - : Em HTML, vários tipos de links podem ser utilizados para realizar conexões entre documentos, como por exemplo [`<a>`](/pt-BR/docs/Web/HTML/Element/a), [`<area>`](/pt-BR/docs/Web/HTML/Element/area) e [`<link>`](/pt-BR/docs/Web/HTML/Element/link).
 - [Formatos de arquivos suportados pelos elementos de áudio e vídeo em HTML](/pt-BR/docs/Web/HTML/Supported_media_formats)
@@ -78,7 +78,7 @@ Nossa [Área de Aprendizado de HTML](/pt-BR/docs/Aprender/HTML) apresenta vário
 - [Elementos em linha](/pt-BR/docs/Web/HTML/Inline_elements) e [Elementos em nível de bloco](/pt-BR/docs/Web/HTML/Block-level_elements)
   - : Elementos HTML são normalmente elementos _inline_ (em linha) ou _block-level_ (em nível de bloco). Um elemento em linha ocupa somente o espaço limitado pelas tags que o definem. Um elemento em nível de bloco ocupa o espaço inteiro do elemento pai (container), portanto criando um bloco.
 - [Tipos de Links](/pt-BR/docs/Web/HTML/Link_types)
-  - : No HTML, vários tipos de links podem ser utilizados para estabelecer e definir o relacionamento entre dois documentos. Os tipos de elementos de link que podem ser incluídos são [`<a>`](/pt-BR/docs/Web/HTML/Element/a), [`<area>`](/pt-BR/docs/Web/HTML/Element/area) e [`<link>`](/en-US/docs/Web/HTML/Element/link).
+  - : No HTML, vários tipos de links podem ser utilizados para estabelecer e definir o relacionamento entre dois documentos. Os tipos de elementos de link que podem ser incluídos são [`<a>`](/pt-BR/docs/Web/HTML/Element/a), [`<area>`](/pt-BR/docs/Web/HTML/Element/area) e [`<link>`](/pt-BR/docs/Web/HTML/Element/link).
 - [Formatos de mídia suportados pelos elementos vídeo e áudio do HTML](/pt-BR/docs/Web/HTML/Supported_media_formats)
   - : Os elementos [`<audio>`](/pt-BR/docs/Web/HTML/Element/audio) e [`<video>`](/pt-BR/docs/Web/HTML/Element/video) permitem que você reproduza mídias de áudio e vídeo. Estes elementos fornecem uma alternativa nativa para o navegador reproduzir recursos similares aos encontrados no Adobe Flash e outros plug-ins.
 - [Tipos de conteúdo HTML](/pt-BR/docs/Web/HTML/Kinds_of_HTML_content)

--- a/files/pt-br/web/html/microformats/index.md
+++ b/files/pt-br/web/html/microformats/index.md
@@ -157,7 +157,7 @@ Exemplo de h-entry como uma postagem em blog:
   <p><span class="p-author h-card">
     <a href="https://quickthoughts.jgregorymcverry.com/profile/jgmac1106" ><img class="u-photo" src="https://quickthoughts.jgregorymcverry.com/file/2d6c9cfed7ac8e849f492b5bc7e6a630/thumb.jpg"/></a>
     <a class="p-name u-url" href="https://quickthoughts.jgregorymcverry.com/profile/jgmac1106">Greg McVerry</a></span>
-     Replied to <a class="u-in-reply-to" href="https://developer.mozilla.org/en-US/docs/Web/HTML/microformats">a post on
+     Replied to <a class="u-in-reply-to" href="https://developer.mozilla.org/pt-BR/docs/Web/HTML/microformats">a post on
    <strong>developer.mozilla.org</strong> </a>:
   </p>
    <p class="p-name e-content">Hey thanks for making this microformats resource</p>
@@ -173,7 +173,7 @@ Exemplo de h-entry como uma postagem em blog:
     {
       "type": [ "h-entry" ],
       "properties": {
-        "in-reply-to": [ "https://developer.mozilla.org/en-US/docs/Web/HTML/microformats" ],
+        "in-reply-to": [ "https://developer.mozilla.org/pt-BR/docs/Web/HTML/microformats" ],
         "name": [ "Hey thanks for making this microformats resource" ],
         "url": [ "https://quickthoughts.jgregorymcverry.com/2019/05/31/hey-thanks-for-making-this-microformats-resource" ],
         "published": [ "2019-05-31T14:19:09+0000" ],


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

There are a lot of links pointing to english version of the content

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
It is expected the user navigates to destinations following the same language
