### PR TITLE
remove the last `{{source}}` macro from pt-br

### DIFF
--- a/files/pt-br/web/api/event/comparison_of_event_targets/index.md
+++ b/files/pt-br/web/api/event/comparison_of_event_targets/index.md
@@ -99,7 +99,7 @@ Há 5 tipos de _targets_ a se considerar:
         >
       </td>
       <td>
-        {{ Source("/dom/public/idl/events/nsIDOMNSEvent.idl", "nsIDOMNSEvent.idl") }}
+        <a href="https://dxr.mozilla.org/mozilla-central/source/dom/webidl/Event.webidl">Event.webidl</a>
       </td>
       <td>
         {{ Non-standard_inline() }} Se o evento foi redirecionado por
@@ -122,7 +122,7 @@ Há 5 tipos de _targets_ a se considerar:
         >
       </td>
       <td>
-        {{ Source("/dom/public/idl/events/nsIDOMNSEvent.idl", "nsIDOMNSEvent.idl") }}
+        <a href="https://dxr.mozilla.org/mozilla-central/source/dom/webidl/Event.webidl">Event.webidl</a>
       </td>
       <td>
         {{ Non-standard_inline() }} O alvo original do evento, antes de

--- a/files/pt-br/web/api/selection/index.md
+++ b/files/pt-br/web/api/selection/index.md
@@ -166,7 +166,5 @@ Outras palavras chaves usadas nesta seção.
 ## Notas da Gecko
 
 - Gecko/Firefox provide additional features, available to chrome (internal and add-on) code only. These are defined in `nsISelectionPrivate`.
-- Mozilla source code: {{Source("dom/webidl/Selection.webidl")}}
+- Mozilla source code: [`Selection.webidl`](https://searchfox.org/mozilla-central/source/dom/webidl/Selection.webidl)
 - {{DOMxRef("Selection.selectionLanguageChange()")}}{{Obsolete_Inline("gecko29")}} used to be exposed to the web content until Firefox 29
-
-<!---->


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

remove the last `{{source}}` macro from pt-br

### Related issues and pull requests

Part of #7178
