### PR TITLE
chore: remove all Note* macros from es

### DIFF
--- a/files/es/orphaned/web/api/fileerror/index.html
+++ b/files/es/orphaned/web/api/fileerror/index.html
@@ -54,7 +54,7 @@ browser-compat: api.FileError
 
 <h2 id="Error_codes">Error codes</h2>
 
-<p>{{ Note("Do not rely on the numeric values of the constants, which might change as the specifications continue to change. Use the constant names instead.") }}</p>
+<div class="note"><p><strong>Nota:</strong> Do not rely on the numeric values of the constants, which might change as the specifications continue to change. Use the constant names instead.</p></div>
 
 <table class="standard-table">
  <thead>

--- a/files/es/web/api/console/warn/index.html
+++ b/files/es/web/api/console/warn/index.html
@@ -11,7 +11,7 @@ translation_of: Web/API/Console/warn
 
 <p>{{AvailableInWorkers}}</p>
 
-<p>{{Note("En Firefox, las advertencias tienen un pequeño icono de signo de exclamación junto a estas en el registro de la Consola Web.")}}</p>
+<div class="note"><p><strong>Nota:</strong> En Firefox, las advertencias tienen un pequeño icono de signo de exclamación junto a estas en el registro de la Consola Web.</p></div>
 
 <h2 id="Sintaxis">Sintaxis</h2>
 

--- a/files/es/web/api/element/blur_event/index.html
+++ b/files/es/web/api/element/blur_event/index.html
@@ -25,7 +25,7 @@ original_slug: Web/Events/blur
  <dd style="margin: 0 0 0 120px;">Ninguna.</dd>
 </dl>
 
-<p>{{NoteStart}}El valor de  {{domxref("Document.activeElement")}} varía a traves de navegadores mientras este evento está siendo manejado ({{bug(452307)}}): IE10 lo agrega al elemento al cual el foco se movera, mientras Firefox y Chrome muy seguido lo agregan al cuerpo del documento.{{NoteEnd}}</p>
+<div class="note"><p><strong>Nota:</strong> El valor de  {{domxref("Document.activeElement")}} varía a traves de navegadores mientras este evento está siendo manejado ({{bug(452307)}}): IE10 lo agrega al elemento al cual el foco se movera, mientras Firefox y Chrome muy seguido lo agregan al cuerpo del documento.</p></div>
 
 <h2 id="Propiedades">Propiedades</h2>
 

--- a/files/es/web/api/indexeddb_api/using_indexeddb/index.html
+++ b/files/es/web/api/indexeddb_api/using_indexeddb/index.html
@@ -1292,7 +1292,9 @@ input {
 <p>Tutorials</p>
 
 <ul>
- <li><a class="external" href="http://www.html5rocks.com/tutorials/indexeddb/todo/">A simple TODO list using HTML5 IndexedDB</a><span class="external">. {{Note("This tutorial is based on an old version of the specification and does not work on up-to-date browsers - it still uses the removed <code>setVersion()</code> method.") }}</span></li>
+ <li><a class="external" href="http://www.html5rocks.com/tutorials/indexeddb/todo/">A simple TODO list using HTML5 IndexedDB</a>.
+  <div class="note"><p><strong>Nota:</strong> This tutorial is based on an old version of the specification and does not work on up-to-date browsers - it still uses the removed <code>setVersion()</code> method.</p></div>
+ </li>
  <li><a href="http://www.html5rocks.com/en/tutorials/indexeddb/uidatabinding/">Databinding UI Elements with IndexedDB</a></li>
 </ul>
 

--- a/files/es/web/api/window/showmodaldialog/index.md
+++ b/files/es/web/api/window/showmodaldialog/index.md
@@ -36,7 +36,7 @@ donde
 | `resizable: {on \| off \| yes \| no \| 1 \| 0 }` | Si el valor de este argumentoes `on`, `yes`, ó 1, la ventana de diálogo podrá ser redimensionada por el usuario; en caso controario su tamaño será fijo. El valor por defecto es `no`. |
 | `scroll: {on \| off \| yes \| no \| 1 \| 0 }`    | Si el valor de este argumento es `on`, `yes`, ó 1, la ventana de diálogo tendrá barras de desplazamiento; en caso contrario su tamaño será fijo. El valor por defecto es `no`.         |
 
-{{Note("Firefox no implementa los argumentos <code>dialogHide</code>, <code>edge</code>, <code>status</code>, ó <code>unadorned</code>.")}}
+> **Nota:** Firefox no implementa los argumentos `dialogHide`, `edge`, `status`, ó `unadorned`.
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/text-shadow/index.html
+++ b/files/es/web/css/text-shadow/index.html
@@ -48,7 +48,9 @@ text-shadow: unset;
 
 <dl>
  <dt>&lt;color&gt;</dt>
- <dd>Opcional. Puede ser especificado antes o después de los valores de offset. Si el color no es especificado, se usa el predeterminado del agente usuario. {{note("Para asegurar consistencia entre navegadores, se recomienda especificar un color explícito.")}}</dd>
+ <dd>Opcional. Puede ser especificado antes o después de los valores de offset. Si el color no es especificado, se usa el predeterminado del agente usuario.
+  <div class="note"><p><strong>Nota:</strong> Para asegurar consistencia entre navegadores, se recomienda especificar un color explícito.</p></div>
+ </dd>
  <dt>&lt;offset-x&gt; &lt;offset-y&gt;</dt>
  <dd>Requeridos. Estos valores <code>length</code> especifican el ófset de la sombra del texto. <code>&lt;offset-x&gt;</code> especifica la distancia horizontal; un valor negativo pone la sombra a la izquierda del texto. <code>&lt;offset-y&gt;</code> especifica la distancia vertical; un valor negativo pone la sombra encima del texto. Si ambos valores son <code>0</code>, la sombra es colocada detrás del texto (y puede generar un efecto de difuminado cuando se define el valor <code>&lt;blur-radius&gt;</code>).<br>
  Para más detalles de las unidades que se pueden usar, véase {{cssxref("length")}}.</dd>

--- a/files/es/web/javascript/reference/global_objects/function/apply/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/apply/index.md
@@ -45,7 +45,7 @@ Puede también utilizarse {{jsxref("Functions/arguments", "arguments")}} como pa
 
 Desde la 5ta edición de ECMAScript se puede utilizar también cualquier tipo de objeto similar a un arreglo, que en términos prácticos significa que tendrá una propiedad `length` y propiedades integer en el rango (`0...length)`. Por ejemplo, ahora puede utilizarse un {{domxref("NodeList")}} o un objeto personalizado como: `{'length': 2, '0': 'eat', '1': 'bananas'}`.
 
-{{ note("La mayoría de los navegadores, incluidos Chrome 14 e Internet Explorer 9, aún no soportan el uso de objetos similares a un array y arrojarán una excepción.") }}
+> **Nota:** La mayoría de los navegadores, incluidos Chrome 14 e Internet Explorer 9, aún no soportan el uso de objetos similares a un array y arrojarán una excepción.
 
 ## Ejemplos
 

--- a/files/es/web/javascript/reference/global_objects/string/split/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/split/index.md
@@ -38,7 +38,7 @@ Cuando se encuentra, el `separador` es eliminado de la cadena y las subcadenas o
 
 Si el `separador` es una expresión regular que contiene paréntesis de captura, entonces cada vez que el `separador` concuerda, los resultados (incluído cualquier resultado indefinido) de los paréntesis de captura son divididos en el array resultante. Sin embargo no todos los navegadores soportan esta característica.
 
-{{Note("Cuando la cadena está vacía, <code>split()</code> devuelve un array que contiene una cadena vacía, en lugar de un array vacío.")}}
+> **Nota:** Cuando la cadena está vacía, `split()` devuelve un array que contiene una cadena vacía, en lugar de un array vacío.
 
 ## Ejemplos
 


### PR DESCRIPTION
### Description

chore: remove all Note* macros from es

### Related issues and pull requests

Part of #5603.
