### PR TITLE
chore: remove unreferenced wiki history for l10n-zh

### DIFF
--- a/files/zh-cn/_wikihistory.json
+++ b/files/zh-cn/_wikihistory.json
@@ -1599,10 +1599,6 @@
     "modified": "2020-11-06T23:30:24.170Z",
     "contributors": ["liguorain"]
   },
-  "HTML_in_XMLHttpRequest": {
-    "modified": "2019-03-24T00:17:24.579Z",
-    "contributors": ["OoOoOoOo", "ziyunfei"]
-  },
   "Learn": {
     "modified": "2020-07-16T22:43:49.854Z",
     "contributors": [
@@ -23332,22 +23328,6 @@
   "Web/HTML/Reference": {
     "modified": "2019-09-09T07:23:44.694Z",
     "contributors": ["SphinxKnight", "wbamberg", "FredWe", "Breezewish"]
-  },
-  "Web/HTML/Using_the_application_cache": {
-    "modified": "2019-10-29T05:43:20.065Z",
-    "contributors": [
-      "7NZ",
-      "xgqfrms-GitHub",
-      "eforegist",
-      "liuzeyafzy",
-      "nianiaJR",
-      "shajiquan",
-      "hdwills",
-      "teoli",
-      "fsy0718",
-      "sunnylost",
-      "karsa.si"
-    ]
   },
   "Web/HTTP": {
     "modified": "2020-08-27T09:08:49.830Z",

--- a/files/zh-tw/_wikihistory.json
+++ b/files/zh-tw/_wikihistory.json
@@ -3587,18 +3587,6 @@
       "stingyong"
     ]
   },
-  "Web/HTML/Using_the_application_cache": {
-    "modified": "2019-03-24T00:10:44.785Z",
-    "contributors": [
-      "SphinxKnight",
-      "jackblackevo",
-      "teoli",
-      "Kennyluck",
-      "Mgjbot",
-      "Cooldll694",
-      "BobChao"
-    ]
-  },
   "Web/HTTP": {
     "modified": "2020-05-09T15:09:07.858Z",
     "contributors": [


### PR DESCRIPTION
### Description

chore: remove unreferenced wiki history for l10n-zh. Those wiki are not used.
