### PR TITLE
Fix a broken macro

### DIFF
--- a/files/ja/web/api/console_api/index.md
+++ b/files/ja/web/api/console_api/index.md
@@ -42,7 +42,7 @@ console.log(myString)
 
 ## ブラウザーの互換性
 
-{{Compat("api.Console")}}
+{{Compat}}
 
 ## 関連情報
 


### PR DESCRIPTION
### Description
[Console APIのブラウザの互換性の部分](https://developer.mozilla.org/ja/docs/Web/API/Console_API#%E3%83%96%E3%83%A9%E3%82%A6%E3%82%B6%E3%83%BC%E3%81%AE%E4%BA%92%E6%8F%9B%E6%80%A7)のマクロが壊れていたので、[英語版](https://developer.mozilla.org/en-US/docs/Web/API/Console_API#browser_compatibility)に合わせました。
### Motivation
### Additional details
### Related issues and pull requests