### PR TITLE
Corrected a word in PT-BR

### DIFF
--- a/files/pt-br/web/css/index.md
+++ b/files/pt-br/web/css/index.md
@@ -14,7 +14,7 @@ translation_of: Web/CSS
 
 **CSS** (**_Cascading Style Sheets_ ou Folhas de Estilo em Cascata)** é uma linguagem de [estilo](/pt-BR/docs/Web/API/StyleSheet) usada para descrever a apresentação de um documento escrito em [HTML](/pt-BR/HTML) ou em [XML](/pt-BR/docs/Glossary/XML) (incluindo várias linguagens em XML como [SVG](/pt-BR/SVG), [MathML](/pt-BR/docs/Web/MathML) ou [XHTML](/pt-BR/XHTML)). O CSS descreve como elementos são mostrados na tela, no papel, na fala ou em outras mídias.
 
-CSS é uma das principais linguagens da **open web** e é padronizada em navagadores web de acordo com as [especificação da W3C](http://w3.org/Style/CSS/#specs). Desenvolvido em níveis, o CSS1 está atualmente obsoleto, o CSS2.1 é uma recomendação e o [CSS3](/pt-BR/docs/Web/CSS/CSS3), agora dividido em pequenos módulos, está progredindo para a sua padronização.
+CSS é uma das principais linguagens da **open web** e é padronizada em navegadores web de acordo com as [especificação da W3C](http://w3.org/Style/CSS/#specs). Desenvolvido em níveis, o CSS1 está atualmente obsoleto, o CSS2.1 é uma recomendação e o [CSS3](/pt-BR/docs/Web/CSS/CSS3), agora dividido em pequenos módulos, está progredindo para a sua padronização.
 
 - Introdução CSS
 


### PR DESCRIPTION
### Description
A simple fix in the word "navagadores" to the correct form: "navegadores" in Brazilian Portuguese

### Motivation
Maintain linguistic compliance