### PR TITLE
chore: remove {{IncludeSubnav}} macro from pt-br

### DIFF
--- a/files/pt-br/conflicting/mdn/writing_guidelines/index.html
+++ b/files/pt-br/conflicting/mdn/writing_guidelines/index.html
@@ -10,8 +10,6 @@ original_slug: MDN/Guidelines
 ---
 <div>{{MDNSidebar}}</div>
 
-<div>{{IncludeSubnav("/pt-BR/docs/MDN")}}</div>
-
 <p><span class="seoSummary">Estes guias fornecem detalhes sobre como a documentação do MDN deve ser escrita e formatada, bem como a forma como nossas amostras de código e outros conteúdos devem ser apresentados. </span>Seguindo esses guias, você pode garantir que o material produzido seja limpo e fácil de usar.</p>
 
 <p>{{LandingPageListSubpages}}</p>

--- a/files/pt-br/conflicting/mdn/writing_guidelines/page_structures/index.html
+++ b/files/pt-br/conflicting/mdn/writing_guidelines/page_structures/index.html
@@ -4,7 +4,7 @@ slug: conflicting/MDN/Writing_guidelines/Page_structures
 translation_of: MDN/Structures
 original_slug: MDN/Structures
 ---
-<div>{{MDNSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/MDN")}}</div>
+<div>{{MDNSidebar}}</div>
 
 <p>Em todo MDN, há várias estruturas de documentos que são usadas repetidamente, providenciando uma consistência na apresentação das informações dos artigos do MDN. Aqui estão artigos descrevendo estas estruturas, de modo, como um autor do MDN, você pode reconhecer, aplicar, e modificar eles como apropriado para documentos você escreve, edita, ou traduz.</p>
 

--- a/files/pt-br/games/anatomy/index.md
+++ b/files/pt-br/games/anatomy/index.md
@@ -5,8 +5,6 @@ translation_of: Games/Anatomy
 ---
 {{GamesSidebar}}
 
-{{IncludeSubnav("/pt-BR/docs/Games")}}
-
 Este artigo analisa a anatomia e o fluxo de trabalho do vídeo game médio de um ponto de vista técnico, em termos de como o loop principal deve ser executado. Isso ajuda os iniciantes da arena do desenvolvimento de jogos modernos a entender o que é necessário ao construir um jogo e como os padrões da web como o JavaScript se prestam como ferramentas. Os programadores de jogos experientes que são novos no desenvolvimento da web também podem se beneficiar.
 
 ## Apresentar, aceitar, interpretar, calcular, repetir

--- a/files/pt-br/games/introduction/index.md
+++ b/files/pt-br/games/introduction/index.md
@@ -3,7 +3,7 @@ title: Introdução ao desenvolvimento de jogos para a Web
 slug: Games/Introduction
 translation_of: Games/Introduction
 ---
-{{GamesSidebar}}{{IncludeSubnav("/pt-BR/docs/Games")}}
+{{GamesSidebar}}
 
 A web moderna rapidamente tem se tornado uma plataforma não só para criar jogos esplêndidos de alta qualidade, mas também para a distribuição desses mesmos jogos.
 

--- a/files/pt-br/games/introduction_to_html5_game_development/index.md
+++ b/files/pt-br/games/introduction_to_html5_game_development/index.md
@@ -12,7 +12,7 @@ tags:
 translation_of: Games/Introduction_to_HTML5_Game_Development_(summary)
 original_slug: Games/Introduction_to_HTML5_Game_Gevelopment_(summary)
 ---
-{{GamesSidebar}}{{IncludeSubnav("/en-US/docs/Games")}}
+{{GamesSidebar}}
 
 ## Vantagens
 

--- a/files/pt-br/games/techniques/2d_collision_detection/index.md
+++ b/files/pt-br/games/techniques/2d_collision_detection/index.md
@@ -5,8 +5,6 @@ translation_of: Games/Techniques/2D_collision_detection
 ---
 {{GamesSidebar}}
 
-{{IncludeSubnav("/en-US/docs/Games")}}
-
 Algoritmos para detectar colisões em jogos 2D dependem do tipo de formas que podem colidir (por exemplo, retângulo para retângulo, retângulo para círculo, círculo para círculo). Geralmente, você terá uma forma genérica simples que abrange a entidade conhecida como "hitbox", portanto, mesmo que a colisão não seja perfeita, ela terá boa aparência e terá bom desempenho em várias entidades. Este artigo fornece uma revisão das técnicas mais comuns usadas para fornecer detecção de colisão em jogos 2D.
 
 ## Caixa delimitadora alinhada por eixo

--- a/files/pt-br/games/techniques/index.md
+++ b/files/pt-br/games/techniques/index.md
@@ -6,7 +6,7 @@ tags:
   - TopicStub
 translation_of: Games/Techniques
 ---
-{{GamesSidebar}}{{IncludeSubnav("/en-US/docs/Games")}}
+{{GamesSidebar}}
 
 This page lists essential core techniques for anyone wanting to develop games using open web technologies.
 

--- a/files/pt-br/games/tools/asm.js/index.md
+++ b/files/pt-br/games/tools/asm.js/index.md
@@ -3,7 +3,7 @@ title: asm.js
 slug: Games/Tools/asm.js
 translation_of: Games/Tools/asm.js
 ---
-{{GamesSidebar}}{{IncludeSubnav("/en-US/docs/Games")}}
+{{GamesSidebar}}
 
 [Asm.js](http://asmjs.org/) é uma especificação que define um subconjunto de JavaScript que é altamente otimizável. Esta seção examina exatamente o que é permitido no subconjunto asm.js, que melhorias confere, Onde e como você pode fazer uso dele, e mais Principais recursos e exemplos.
 

--- a/files/pt-br/games/tools/index.md
+++ b/files/pt-br/games/tools/index.md
@@ -8,7 +8,7 @@ tags:
   - Jogos
 translation_of: Games/Tools
 ---
-{{GamesSidebar}}{{IncludeSubnav("/en-US/docs/Games")}}
+{{GamesSidebar}}
 
 Nesta página você pode encontrar links para a nossa ferramenta de desenvolvimento de jogos, artigos, os quais eventualmente abrangem frameworks, compiladores, e ferramentas de debug.
 

--- a/files/pt-br/games/tutorials/2d_breakout_game_pure_javascript/index.md
+++ b/files/pt-br/games/tutorials/2d_breakout_game_pure_javascript/index.md
@@ -12,7 +12,7 @@ tags:
   - Tutorial
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript
 ---
-{{GamesSidebar}}{{IncludeSubnav("/en-US/docs/Games")}}
+{{GamesSidebar}}
 
 {{Next("Games/Workflows/2D_Breakout_game_pure_JavaScript/Create_the_Canvas_and_draw_on_it")}}
 

--- a/files/pt-br/games/tutorials/2d_breakout_game_pure_javascript/move_the_ball/index.md
+++ b/files/pt-br/games/tutorials/2d_breakout_game_pure_javascript/move_the_ball/index.md
@@ -3,7 +3,7 @@ title: Move the ball
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Move_the_ball
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Move_the_ball
 ---
-{{GamesSidebar}}{{IncludeSubnav("/en-US/docs/Games")}}
+{{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/2D_Breakout_game_pure_JavaScript/Create_the_Canvas_and_draw_on_it", "Games/Workflows/2D_Breakout_game_pure_JavaScript/Bounce_off_the_walls")}}
 

--- a/files/pt-br/games/tutorials/index.md
+++ b/files/pt-br/games/tutorials/index.md
@@ -11,7 +11,7 @@ tags:
   - Workflows
 translation_of: Games/Tutorials
 ---
-{{GamesSidebar}}{{IncludeSubnav("/en-US/docs/Games")}}
+{{GamesSidebar}}
 
 This page contains multiple tutorial series that highlight different workflows for effectively creating different types of web games.
 

--- a/files/pt-br/learn/common_questions/what_are_browser_developer_tools/index.md
+++ b/files/pt-br/learn/common_questions/what_are_browser_developer_tools/index.md
@@ -4,7 +4,6 @@ slug: Learn/Common_questions/What_are_browser_developer_tools
 translation_of: Learn/Common_questions/What_are_browser_developer_tools
 original_slug: Learn/Common_questions/ferramentas_de_desenvolvimento_do_navegador
 ---
-{{IncludeSubnav("/en-US/Learn")}}
 
 Todo navegador web moderno inclui um poderoso conjunto de ferramentas para desenvolvedores. Essas ferramentas fazem muitas coisas, desde inspecionar o HTML, CSS e JavaScript recém carregado e quais recursos foram requeridos até mostrar quanto tempo a página precisou para carregar. Este artigo explica como usar as funções básicas das ferramentas para desenvolvedores do seu navegador.
 

--- a/files/pt-br/mdn/community/index.md
+++ b/files/pt-br/mdn/community/index.md
@@ -8,7 +8,7 @@ tags:
 translation_of: MDN/Contribute/Feedback
 original_slug: MDN/Contribute/Feedback
 ---
-{{MDNSidebar}}{{IncludeSubnav("/pt-BR/docs/MDN")}}
+{{MDNSidebar}}
 
 Bem-vindo ao Mozilla Developer Network! Se você tem sugestões, ou está tendo problemas usando MDN, este é o lugar certo para estar. O fato de que você está interessado em oferecer um feedback, faz de você mais uma parte da comunidade Mozilla e agradecemos antecipadamente por seu interesse.
 

--- a/files/pt-br/mdn/contribute/index.md
+++ b/files/pt-br/mdn/contribute/index.md
@@ -7,7 +7,7 @@ tags:
   - Página de destino
 translation_of: MDN/Contribute
 ---
-{{MDNSidebar}}{{IncludeSubnav("/pt-BR/docs/MDN")}}
+{{MDNSidebar}}
 
 Bem-vindo! Ao visitar esta página, você deu o primeiro passo para se tornar um colaborador da MDN.
 

--- a/files/pt-br/mdn/tools/index.md
+++ b/files/pt-br/mdn/tools/index.md
@@ -6,7 +6,7 @@ tags:
   - MDN Meta
 translation_of: MDN/Tools
 ---
-{{MDNSidebar}}{{IncludeSubnav("/pt-BR/docs/MDN")}}
+{{MDNSidebar}}
 
 MDN oferece ferramentas tornando fácil o acompanhamento do progresso, gerenciamento de conteúdo e manter o site com as últimas atualizações.
 

--- a/files/pt-br/mdn/writing_guidelines/howto/tag/index.md
+++ b/files/pt-br/mdn/writing_guidelines/howto/tag/index.md
@@ -16,7 +16,7 @@ tags:
 translation_of: MDN/Contribute/Howto/Tag
 original_slug: MDN/Contribute/Howto/Tag
 ---
-{{MDNSidebar}}{{IncludeSubnav("/pt-BR/docs/MDN")}}
+{{MDNSidebar}}
 
 As etiquetas dos artigos são uma forma importante de ajudar visitantes a encontrar o conteúdo procurado. Há muitas etiquetas usadas para ajudar a organizar as informações na MDN. Esta página vai lhe ensinar a melhor maneira de rotular as páginas, a fim de fazer com que as informações sejam organizadas, classificadas e localizadas mais facilmente. Cada página pode ser marcada por etiquetas que ajudam a classificar seu conteúdo.
 

--- a/files/pt-br/mdn/writing_guidelines/index.md
+++ b/files/pt-br/mdn/writing_guidelines/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: MDN/About
 original_slug: MDN/About
 ---
-{{MDNSidebar}}{{IncludeSubNav("/pt-BR/docs/MDN")}}
+{{MDNSidebar}}
 
 A Rede de Desenvolvedores da Mozilla (MDN) é uma plataforma de aprendizagem em evolução para tecnologias da Web e o software que alimenta a Web, incluindo:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

chore: remove {{IncludeSubnav}} macro from pt-br

### Motivation

The macro has been deprecated and it's a [no-op macro](https://github.com/mdn/yari/blob/main/kumascript/macros/IncludeSubnav.ejs) now. We can just remove this.

### Related issues and pull requests

Part of #5170.
