### PR TITLE
chore: remove {{IncludeSubnav}} macro from es

### DIFF
--- a/files/es/conflicting/mdn/writing_guidelines/page_structures/index.md
+++ b/files/es/conflicting/mdn/writing_guidelines/page_structures/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: MDN/Structures
 original_slug: MDN/Structures
 ---
-{{MDNSidebar}}{{IncludeSubnav("/en-US/docs/MDN")}}
+{{MDNSidebar}}
 
 Throughout MDN, there are various document structures that are used repeatedly, to provide consistent presentation of information in MDN articles. Here are articles describing these structures, so that, as an MDN author, you can recognize, apply, and modify them as appropriate for documents you write, edit, or translate.
 

--- a/files/es/games/introduction/index.md
+++ b/files/es/games/introduction/index.md
@@ -9,7 +9,6 @@ translation_of: Games/Introduction
 original_slug: Games/Introduccion
 ---
 {{GamesSidebar}}
-{{IncludeSubnav("/en-US/docs/Games")}}
 
 La Web rapidamente se ha convertido en una plataforma viable no solo para crear impresionantes juegos de alta calidad, sino también para distruibuirlos.El rango de juegos que pueden ser creados está a la par tanto de los juegos de escritorio como de SO nativos (Android, iOS). Con tecnologias Web modernas y un navegador reciente es totalmente posible hacer juegos de primera categoria para la Web. Y no estamos hablando sobre simples juegos de cartas o juegos sociales multijugadores que en tiempos anteriores se podian hacer con Flash®. Estamos hablando sobre juegos 3D _shooters_ de accion, RPGs, y más. Gracias a las masivas mejoras de rendimiento en [JavaScript](/en-US/docs/JavaScript) con tecnologia de compilación _just-in-time_ y nuevas APIs, se pueden construir juegos que pueden correr en el navegador (o en dispositivos [HTML5](/en-US/docs/HTML/HTML5) como [Firefox OS](/en-US/docs/Mozilla/Firefox_OS)) sin problemas.
 

--- a/files/es/games/introduction_to_html5_game_development/index.md
+++ b/files/es/games/introduction_to_html5_game_development/index.md
@@ -10,7 +10,6 @@ translation_of: Games/Introduction_to_HTML5_Game_Development_(summary)
 original_slug: Games/Introducción_al_desarrollo_de_juegos_HTML5_(resumen)
 ---
 {{GamesSidebar}}
-{{IncludeSubnav("/es/docs/Games")}}
 
 ## Ventajas
 

--- a/files/es/games/techniques/webrtc_data_channels/index.md
+++ b/files/es/games/techniques/webrtc_data_channels/index.md
@@ -4,7 +4,6 @@ slug: Games/Techniques/WebRTC_data_channels
 translation_of: Games/Techniques/WebRTC_data_channels
 ---
 {{GamesSidebar}}
-{{IncludeSubnav("/en-US/docs/Games")}}
 
 {{SeeCompatTable}}
 

--- a/files/es/games/tools/asm.js/index.md
+++ b/files/es/games/tools/asm.js/index.md
@@ -8,7 +8,6 @@ translation_of: Games/Tools/asm.js
 original_slug: Games/Herramients/asm.js
 ---
 {{GamesSidebar}}
-{{IncludeSubnav("/en-US/docs/Games")}}
 
 [Asm.js](http://asmjs.org/) es un subconjunto de JavaScript que es altamente optimizable. Este artículo analiza exactamente lo que está permitido en el subconjunto asm.js, las mejoras que confiere, donde y cómo puedo utilizarlo, y otros recursos y ejemplos.
 

--- a/files/es/games/tutorials/2d_breakout_game_phaser/animations_and_tweens/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/animations_and_tweens/index.md
@@ -14,7 +14,6 @@ tags:
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Animations_and_tweens
 ---
 {{GamesSidebar}}
-{{IncludeSubnav("/en-US/docs/Games")}}
 
 {{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Extra_lives", "Games/Workflows/2D_Breakout_game_Phaser/Buttons")}}
 

--- a/files/es/games/tutorials/2d_breakout_game_phaser/bounce_off_the_walls/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/bounce_off_the_walls/index.md
@@ -14,7 +14,6 @@ translation_of: Games/Tutorials/2D_breakout_game_Phaser/Bounce_off_the_walls
 original_slug: Games/Tutorials/2D_breakout_game_Phaser/Rebotar_en_las_paredes
 ---
 {{GamesSidebar}}
-{{IncludeSubnav("/en-US/docs/Games")}}
 
 {{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Physics", "Games/Workflows/2D_Breakout_game_Phaser/Player_paddle_and_controls")}}
 

--- a/files/es/games/tutorials/2d_breakout_game_phaser/buttons/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/buttons/index.md
@@ -14,7 +14,6 @@ translation_of: Games/Tutorials/2D_breakout_game_Phaser/Buttons
 original_slug: Games/Tutorials/2D_breakout_game_Phaser/Botones
 ---
 {{GamesSidebar}}
-{{IncludeSubnav("/en-US/docs/Games")}}
 
 {{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Animations_and_tweens", "Games/Workflows/2D_Breakout_game_Phaser/Randomizing_gameplay")}}
 

--- a/files/es/games/tutorials/2d_breakout_game_phaser/collision_detection/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/collision_detection/index.md
@@ -13,7 +13,6 @@ tags:
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Collision_detection
 ---
 {{GamesSidebar}}
-{{IncludeSubnav("/en-US/docs/Games")}}
 
 {{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Build_the_brick_field", "Games/Workflows/2D_Breakout_game_Phaser/The_score")}}
 

--- a/files/es/games/tutorials/2d_breakout_game_phaser/extra_lives/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/extra_lives/index.md
@@ -13,7 +13,7 @@ tags:
   - juegos
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Extra_lives
 ---
-{{GamesSidebar}}{{IncludeSubnav("/en-US/docs/Games")}}
+{{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Win_the_game", "Games/Workflows/2D_Breakout_game_Phaser/Animations_and_tweens")}}
 

--- a/files/es/games/tutorials/2d_breakout_game_phaser/game_over/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/game_over/index.md
@@ -12,7 +12,7 @@ tags:
   - juego terminado
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Game_over
 ---
-{{GamesSidebar}}{{IncludeSubnav("/en-US/docs/Games")}}
+{{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Player_paddle_and_controls", "Games/Workflows/2D_Breakout_game_Phaser/Build_the_brick_field")}}
 

--- a/files/es/games/tutorials/2d_breakout_game_phaser/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/index.md
@@ -13,8 +13,6 @@ tags:
   - Tutorial
 translation_of: Games/Tutorials/2D_breakout_game_Phaser
 ---
-<div>{{GamesSidebar}}</div><div>{{IncludeSubnav("/en-US/docs/Games")}}</div>
-
 {{GamesSidebar}}
 
 {{Next("Games/Workflows/2D_Breakout_game_Phaser/Initialize_the_framework")}}

--- a/files/es/games/tutorials/2d_breakout_game_phaser/initialize_the_framework/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/initialize_the_framework/index.md
@@ -3,7 +3,7 @@ title: Inicializar el framework
 slug: Games/Tutorials/2D_breakout_game_Phaser/Initialize_the_framework
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Initialize_the_framework
 ---
-{{GamesSidebar}}{{IncludeSubnav("/en-US/docs/Games")}}
+{{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser", "Games/Workflows/2D_Breakout_game_Phaser/Scaling")}}
 

--- a/files/es/games/tutorials/2d_breakout_game_phaser/move_the_ball/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/move_the_ball/index.md
@@ -12,7 +12,7 @@ tags:
   - juegos
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Move_the_ball
 ---
-{{GamesSidebar}}{{IncludeSubnav("/en-US/docs/Games")}}
+{{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Load_the_assets_and_print_them_on_screen", "Games/Workflows/2D_Breakout_game_Phaser/Physics")}}
 

--- a/files/es/games/tutorials/2d_breakout_game_phaser/scaling/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/scaling/index.md
@@ -3,7 +3,7 @@ title: Scaling
 slug: Games/Tutorials/2D_breakout_game_Phaser/Scaling
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Scaling
 ---
-{{GamesSidebar}}{{IncludeSubnav("/en-US/docs/Games")}}
+{{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Initialize_the_framework", "Games/Workflows/2D_Breakout_game_Phaser/Load_the_assets_and_print_them_on_screen")}}
 

--- a/files/es/games/tutorials/2d_breakout_game_phaser/the_score/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/the_score/index.md
@@ -12,7 +12,7 @@ tags:
   - juegos
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/The_score
 ---
-{{GamesSidebar}}{{IncludeSubnav("/en-US/docs/Games")}}
+{{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Collision_detection", "Games/Workflows/2D_Breakout_game_Phaser/Win_the_game")}}
 

--- a/files/es/games/tutorials/2d_breakout_game_phaser/win_the_game/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/win_the_game/index.md
@@ -11,7 +11,7 @@ tags:
   - ganando
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Win_the_game
 ---
-{{GamesSidebar}}{{IncludeSubnav("/en-US/docs/Games")}}
+{{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/The_score", "Games/Workflows/2D_Breakout_game_Phaser/Extra_lives")}}
 

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/bounce_off_the_walls/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/bounce_off_the_walls/index.md
@@ -6,8 +6,6 @@ original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Bounce_off
 ---
 {{GamesSidebar}}
 
-{{IncludeSubnav("/es/docs/Games")}}
-
 {{PreviousNext("Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Mueve_la_bola", "Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Control_pala_y_teclado")}}
 
 Este es el **tercer** paso de 10 del [tutorial Canvas para el desarrollo de juegos](/es/docs/Games/Workflows/Breakout_game_from_scratch). Puedes encontrar el código fuente y pegarle un vistazo después de completar esta lección [Gamedev-Canvas-workshop/lesson3.html](https://github.com/end3r/Gamedev-Canvas-workshop/blob/gh-pages/lesson03.html).

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.md
@@ -4,7 +4,7 @@ slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Build_the_brick_field
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Build_the_brick_field
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Construye_grupo_bloques
 ---
-{{GamesSidebar}}{{IncludeSubnav("/es/docs/Games")}}
+{{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Fin_del_juego", "Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Deteccion_colisiones")}}
 

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.md
@@ -4,7 +4,7 @@ slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Collision_detection
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Collision_detection
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Deteccion_colisiones
 ---
-{{GamesSidebar}}{{IncludeSubnav("/en-US/docs/Games")}}
+{{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Construye_grupo_bloques", "Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Track_the_score_and_win")}}
 

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/create_the_canvas_and_draw_on_it/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/create_the_canvas_and_draw_on_it/index.md
@@ -7,7 +7,7 @@ translation_of: >-
 original_slug: >-
   Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Create_the_Canvas_and_draw_on_it
 ---
-{{GamesSidebar}}{{IncludeSubnav("/en-US/docs/Games")}}
+{{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro", "Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Mueve_la_bola")}}
 

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.md
@@ -4,7 +4,7 @@ slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Finishing_up
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Finishing_up
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Terminando
 ---
-{{GamesSidebar}}{{IncludeSubnav("/en-US/docs/Games")}}
+{{GamesSidebar}}
 
 {{Previous("Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Controles_raton")}}
 

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/game_over/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/game_over/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Game_over
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Fin_del_juego
 ---
-{{GamesSidebar}}{{IncludeSubnav("/es-ES/docs/Games")}}
+{{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Control_pala_y_teclado", "Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Construye_grupo_bloques")}}
 

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/index.md
@@ -7,7 +7,7 @@ tags:
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro
 ---
-{{GamesSidebar}}{{IncludeSubnav("/es-ES/docs/Games")}}
+{{GamesSidebar}}
 
 {{Next("Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Create_the_Canvas_and_draw_on_it")}}
 

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/mouse_controls/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/mouse_controls/index.md
@@ -4,7 +4,7 @@ slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Mouse_controls
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Mouse_controls
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Controles_raton
 ---
-{{GamesSidebar}}{{IncludeSubnav("/en-US/docs/Games")}}
+{{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Track_the_score_and_win", "Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Terminando")}}
 

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/move_the_ball/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/move_the_ball/index.md
@@ -4,7 +4,7 @@ slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Move_the_ball
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Move_the_ball
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Mueve_la_bola
 ---
-{{GamesSidebar}}{{IncludeSubnav("/es-ES/docs/Games")}}
+{{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Create_the_Canvas_and_draw_on_it", "Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Bounce_off_the_walls")}}
 

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/paddle_and_keyboard_controls/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/paddle_and_keyboard_controls/index.md
@@ -4,7 +4,7 @@ slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Paddle_and_keyboard_contr
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Paddle_and_keyboard_controls
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Control_pala_y_teclado
 ---
-{{GamesSidebar}}{{IncludeSubnav("/es/docs/Games")}}
+{{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Bounce_off_the_walls", "Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Fin_del_juego")}}
 

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.md
@@ -4,7 +4,7 @@ slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Track_the_score_and_win
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Track_the_score_and_win
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Track_the_score_and_win
 ---
-{{GamesSidebar}}{{IncludeSubnav("/en-US/docs/Games")}}
+{{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Deteccion_colisiones", "Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Controles_raton")}}
 

--- a/files/es/learn/common_questions/common_web_layouts/index.md
+++ b/files/es/learn/common_questions/common_web_layouts/index.md
@@ -11,7 +11,6 @@ tags:
 translation_of: Learn/Common_questions/Common_web_layouts
 original_slug: Learn/Common_questions/diseños_web_comunes
 ---
-{{IncludeSubnav("/en-US/Learn")}}
 
 Cuando diseña páginas para su sitio web es bueno tener una idea de los diseños más comunes.
 

--- a/files/es/learn/common_questions/what_are_browser_developer_tools/index.md
+++ b/files/es/learn/common_questions/what_are_browser_developer_tools/index.md
@@ -13,7 +13,6 @@ tags:
   - aprende
 translation_of: Learn/Common_questions/What_are_browser_developer_tools
 ---
-{{IncludeSubnav("/es/Learn")}}
 
 Todos los navegadores web modernos incluyen un potente conjunto de herramientas para desarrolladores. Estas herramientas hacen una variedad de cosas, desde inspeccionar HTML, CSS y JavaScript actualmente cargados, hasta mostrar qué activos ha solicitado la página y cuánto tiempo tardaron en cargarse. Este artículo explica cómo utilizar las funciones básicas de las herramientas de desarrollo de tu navegador.
 

--- a/files/es/mdn/community/index.md
+++ b/files/es/mdn/community/index.md
@@ -6,8 +6,6 @@ original_slug: MDN/Contribute/Feedback
 ---
 {{MDNSidebar}}
 
-{{IncludeSubnav("/es/docs/MDN")}}
-
 ¡Bienvenido a la Red de Desarrolladores de Mozilla! si tienes algunas sugerencias, o estás teniendo problemas usando MDN, estás en el lugar correcto. El mismo hecho de que muestres interés en ofrecer feedback, te hace más parte de la comunidad de Mozilla, y te agradecemos de antemano tu interés.
 
 Tienes varias opciones parar ofrecer tu punto de vista, este artículo te ayudará.

--- a/files/es/mdn/contribute/howto/index.md
+++ b/files/es/mdn/contribute/howto/index.md
@@ -8,7 +8,7 @@ tags:
   - TopicStub
 translation_of: MDN/Contribute/Howto
 ---
-{{MDNSidebar}}{{IncludeSubnav("/es/docs/MDN")}}
+{{MDNSidebar}}
 
 Estos artículos proveen guías paso a paso para lograr metas específicas cuando se contribuye a MDN.
 

--- a/files/es/mdn/contribute/processes/index.md
+++ b/files/es/mdn/contribute/processes/index.md
@@ -8,7 +8,7 @@ tags:
 translation_of: MDN/Contribute/Processes
 original_slug: MDN/Contribute/Procesos
 ---
-{{MDNSidebar}}{{IncludeSubnav("/es/docs/MDN")}}
+{{MDNSidebar}}
 
 El proyecto de Documentación MDN es enorme; hay un sinfín de teconologías que cubrimos a través de la asistencia de cientos de colaboradores de todo el mundo. Para ayudarnos a llevar orden al caos, tenemos procesos estandarizados para seguir cuando se trabaja en tareas específicas relacionadas con la documentación. Aquí encontrarás guías para estos procesos.
 

--- a/files/es/mdn/writing_guidelines/experimental_deprecated_obsolete/index.md
+++ b/files/es/mdn/writing_guidelines/experimental_deprecated_obsolete/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: MDN/Guidelines/Conventions_definitions
 original_slug: MDN/Guidelines/Conventions_definitions
 ---
-{{MDNSidebar}}{{IncludeSubnav("/es/docs/MDN")}}
+{{MDNSidebar}}
 
 Este artículo define algunas convenciones y definiciones que se usan comúnmente en MDN, que pueden no ser obvias para algunas personas cuando las encuentran en la documentación.
 

--- a/files/es/mdn/writing_guidelines/index.md
+++ b/files/es/mdn/writing_guidelines/index.md
@@ -12,7 +12,7 @@ tags:
 translation_of: MDN/About
 original_slug: MDN/About
 ---
-{{MDNSidebar}}{{IncludeSubNav("/es/docs/MDN")}}
+{{MDNSidebar}}
 
 MDN Web Docs es una plataforma de aprendizaje para las tecnologías Web y el software con el que funciona la Web, incluyendo:
 


### PR DESCRIPTION
### Description

chore: remove {{IncludeSubnav}} macro from es

### Motivation

The macro has been deprecated and it's a [no-op macro](https://github.com/mdn/yari/blob/main/kumascript/macros/IncludeSubnav.ejs) now. We can just remove this.

### Related issues and pull requests

Part of #5170.

Fix #6756
- Fix #6757
