### PR TITLE
Inserção do exemplo e correção no destaque

### DIFF
--- a/files/pt-br/web/javascript/reference/global_objects/array/includes/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/array/includes/index.md
@@ -14,7 +14,9 @@ original_slug: Web/JavaScript/Reference/Global_Objects/Array/contains
 
 ## Sumário
 
-O método includes`()` determina se um array contém um determinado elemento, retornando `true` ou `false` apropriadamente.
+O método `includes()` determina se um array contém um determinado elemento, retornando `true` ou `false` apropriadamente.
+
+{{EmbedInteractiveExample("pages/js/array-includes.html")}}
 
 **Sintaxe**
 


### PR DESCRIPTION
Inserção do exemplo interativo e correção do destaque do termo de includes() do primeiro parágrafo, passando de includes`()` para `includes()`.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
