### PR TITLE
The results of Universal selectors are not displayed properly

### DIFF
--- a/files/zh-cn/web/css/universal_selectors/index.md
+++ b/files/zh-cn/web/css/universal_selectors/index.md
@@ -36,7 +36,7 @@ slug: Web/CSS/Universal_selectors
 
 则会产生这样的效果：
 
-{{EmbedLiveSample('Examples')}}
+{{EmbedLiveSample('示例')}}
 
 > **备注：** 笔者不推荐使用通配选择器，因为它是[性能最低的一个 CSS 选择器](http://www.stevesouders.com/blog/2009/06/18/simplifying-css-selectors/).
 

--- a/files/zh-cn/web/css/universal_selectors/index.md
+++ b/files/zh-cn/web/css/universal_selectors/index.md
@@ -36,9 +36,7 @@ slug: Web/CSS/Universal_selectors
 
 则会产生这样的效果：
 
-A green span in a red paragraph.
-
-A red span in a green paragraph (with a border.)
+{{EmbedLiveSample('Examples')}}
 
 > **备注：** 笔者不推荐使用通配选择器，因为它是[性能最低的一个 CSS 选择器](http://www.stevesouders.com/blog/2009/06/18/simplifying-css-selectors/).
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The results of Universal selectors cannot be displayed properly, and comparing with the English document, I found that the Chinese document seems to be translated directly from the original text and written directly,I have modified it according to the English document

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
I hope the MDN Chinese documentation can demonstrate the effect of Universal selectors properly
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
THE PROBLEMS happend at the doc:https://developer.mozilla.org/zh-CN/docs/Web/CSS/Universal_selectors
![image.png](https://dd-static.jd.com/ddimg/jfs/t1/42706/25/19313/33638/6348cfc3Ea182cb08/2dd7c111d955985f.png)
THE CORRECT reference at the doc:https://developer.mozilla.org/en-US/docs/Web/CSS/Universal_selectors
![image.png](https://dd-static.jd.com/ddimg/jfs/t1/102178/16/33881/14681/6348d02eE08b657a6/a80bafca42f707a7.png)
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->


<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
