### PR TITLE
Update index.md

### DIFF
--- a/files/zh-cn/web/guide/css/block_formatting_context/index.md
+++ b/files/zh-cn/web/guide/css/block_formatting_context/index.md
@@ -157,7 +157,7 @@ section {
 
 ### 外边距重叠
 
-创建新的 BFC 避免两个相邻的 div 之间 [外边距重叠](/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing) 。
+创建新的 BFC 避免父元素与直接子元素之间的 [外边距重叠](/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing) 。
 
 #### HTML
 

--- a/files/zh-cn/web/guide/css/block_formatting_context/index.md
+++ b/files/zh-cn/web/guide/css/block_formatting_context/index.md
@@ -157,7 +157,7 @@ section {
 
 ### 外边距重叠
 
-创建新的 BFC 避免父元素与直接子元素之间的 [外边距重叠](/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing) 。
+创建新的 BFC 避免两个相邻元素之间的[外边距重叠](/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing) 。
 
 #### HTML
 


### PR DESCRIPTION
Margin overlap between container and immediate child elements is prevented, and margins between two child elements in the same format context still overlap, which is internal to the block format context