### PR TITLE
chore: update css/reference to remove `page` macro

### DIFF
--- a/files/zh-cn/web/css/reference/index.md
+++ b/files/zh-cn/web/css/reference/index.md
@@ -5,7 +5,7 @@ slug: Web/CSS/Reference
 
 {{CSSRef}}
 
-使用此**CSS 参考**页面以浏览按[字母索引](#索引)的所有标准 [CSS](/zh-CN/docs/Web/CSS) 属性、[伪类](/zh-CN/docs/Web/CSS/Pseudo-classes)、[伪元素](/zh-CN/docs/Web/CSS/Pseudo-elements)、[数据类型](/zh-CN/docs/Web/CSS/CSS_Types)、[功能表记](/zh-CN/docs/Web/CSS/CSS_Functions)以及[@ 规则](/zh-CN/docs/Web/CSS/At-rule)。你也可以浏览[CSS 关键概念](#概念)和[按类型排列的 CSS 选择器](#选择器)列表。还有一份简短的 [DOM-CSS / CSSOM 参考](#dom-css_cssom)。
+使用此 **CSS 参考**页面以浏览按[字母索引](#索引)的所有标准 [CSS](/zh-CN/docs/Web/CSS) 属性、[伪类](/zh-CN/docs/Web/CSS/Pseudo-classes)、[伪元素](/zh-CN/docs/Web/CSS/Pseudo-elements)、[数据类型](/zh-CN/docs/Web/CSS/CSS_Types)、[功能表记](/zh-CN/docs/Web/CSS/CSS_Functions)以及[@ 规则](/zh-CN/docs/Web/CSS/At-rule)。你也可以浏览[CSS 关键概念](#概念)和[按类型排列的 CSS 选择器](#选择器)列表。还有一份简短的 [DOM-CSS / CSSOM 参考](#dom-css_cssom)。
 
 ## 基本规则语法
 
@@ -29,7 +29,7 @@ properties-list ::=
     [property : value] [; properties-list]
 ```
 
-参阅后面的 [_selector_](#选择器)、[_pseudo-element_](#伪类)、[_pseudo-class_](#伪元素) 列表。每个指定*值*的语法取决于为每个指定*属性*定义的数据类型。
+参阅后面的 [_选择器_](#选择器)、[_伪元素_](#伪元素)、[_伪类_](#伪类) 列表。每个指定*值*的语法取决于为每个指定*属性*定义的数据类型。
 
 #### 样式规则示例
 

--- a/files/zh-cn/web/css/reference/index.md
+++ b/files/zh-cn/web/css/reference/index.md
@@ -5,24 +5,22 @@ slug: Web/CSS/Reference
 
 {{CSSRef}}
 
-使用此**CSS 参考**页面以浏览按[字母索引](#索引)的所有标准 [CSS](/zh-CN/docs/CSS) 属性、[伪类](/zh-CN/docs/CSS/Pseudo-classes)、[伪元素](/zh-CN/docs/CSS/Pseudo-elements)、[数据类型](/zh-CN/docs/Web/CSS/CSS_Types)、以及[@ 规则](/zh-CN/docs/CSS/At-rule)。你也可以浏览 [按类型排列的 CSS 选择器](#选择器) 列表和 [CSS 关键概念](#概念) 列表。还有一份简短的 [DOM-CSS / CSSOM 参考](#DOM-CSS_CSSOM)。
+使用此**CSS 参考**页面以浏览按[字母索引](#索引)的所有标准 [CSS](/zh-CN/docs/Web/CSS) 属性、[伪类](/zh-CN/docs/Web/CSS/Pseudo-classes)、[伪元素](/zh-CN/docs/Web/CSS/Pseudo-elements)、[数据类型](/zh-CN/docs/Web/CSS/CSS_Types)、[功能表记](/zh-CN/docs/Web/CSS/CSS_Functions)以及[@ 规则](/zh-CN/docs/Web/CSS/At-rule)。你也可以浏览[CSS 关键概念](#概念)和[按类型排列的 CSS 选择器](#选择器)列表。还有一份简短的 [DOM-CSS / CSSOM 参考](#dom-css_cssom)。
 
 ## 基本规则语法
 
 ### 样式规则语法
 
-```
+```css
 style-rule ::=
     selectors-list {
       properties-list
     }
 ```
 
-```
-... 其中
-```
+其中：
 
-```
+```css
 selectors-list ::=
     selector[:pseudo-class] [::pseudo-element]
     [, selectors-list]
@@ -31,7 +29,7 @@ properties-list ::=
     [property : value] [; properties-list]
 ```
 
-参阅后面的 [_selector_](#选择器)、[_pseudo-element_](#pelm)、[_pseudo-class_](#pcls) 列表。每个指定值的语法取决于为每个指定属性定义的数据类型。
+参阅后面的 [_selector_](#选择器)、[_pseudo-element_](#伪类)、[_pseudo-class_](#伪元素) 列表。每个指定*值*的语法取决于为每个指定*属性*定义的数据类型。
 
 #### 样式规则示例
 
@@ -45,62 +43,62 @@ div.menu-bar li:hover > ul {
 }
 ```
 
-有关 CSS 选择器语法的初学者介绍，请参阅[此教程](/zh-CN/docs/Learn/CSS/Introduction_to_CSS/Selectors)。注意，规则定义中的任何 [CSS 语法](/zh-CN/docs/Web/CSS/syntax)错误都将使整个规则无效。无效的规则将被浏览器忽略。注意 CSS 定义完全是[基于文本](https://www.w3.org/TR/css-syntax-3/#intro)(ASCII) 的 , 而 DOM-CSS / CSSOM (规则管理系统) 是[基于对象](https://www.w3.org/TR/cssom/#introduction)的。
+有关 CSS 选择器语法的初学者介绍，请参阅 [CSS 选择器教程](/zh-CN/docs/Learn/CSS/Building_blocks/Selectors)。注意，规则定义中的任何 [CSS 语法](/zh-CN/docs/Web/CSS/syntax)错误都将使整个规则无效，无效的规则将被浏览器忽略。注意 CSS 定义完全是[基于（ASCII）文本](https://www.w3.org/TR/css-syntax-3/#intro)的，而 DOM-CSS / CSSOM（规则管理系统） 是[基于对象](https://www.w3.org/TR/cssom/#introduction)的。
 
 ### @规则语法
 
-由于 @规则间的结构变化很大，请参阅[@规则](/zh-CN/docs/Web/CSS/At-rule)以找到你所想要的特定规则语法。
+由于 @规则间的结构变化很大，请参阅 [@规则](/zh-CN/docs/Web/CSS/At-rule)以找到你所想要的特定规则语法。
 
 ## 索引
 
-> **备注：** 此索引中的属性名称不包括与 CSS 标准名称不同的 JavaScript 名称。
+> **备注：** 此索引中的属性名称**不包括**与 CSS 标准名称不同的 [JavaScript 名称](/zh-CN/docs/Web/CSS/CSS_Properties_Reference)。
 
 {{CSS_Ref}}
 
-## [选择器](/zh-CN/docs/Web/CSS/CSS_Selectors)
+## 选择器
 
-### [基本选择器](/zh-CN/docs/Web/CSS/CSS_Selectors#Simple_selectors)
+以下是一些[选择器](/zh-CN/docs/Web/CSS/CSS_Selectors)的列表，它们允许根据 DOM 内元素的各种特征对样式进行条件限制。
 
-- [通配选择器](/zh-CN/docs/CSS/Universal_selectors) `*`, `ns|*`, `*|*`, `|*`
-- [元素选择器](/zh-CN/docs/CSS/Type_selectors) `elementname(元素名称)`
-- [类选择器](/zh-CN/docs/CSS/Class_selectors) `.classname(类名)`
-- [ID 选择器](/zh-CN/docs/CSS/ID_selectors) `#idname(ID 名)`
-- [属性选择器](/zh-CN/docs/CSS/Attribute_selectors) `[属性=值]`
+### 基本选择器
+
+[基本选择器](/zh-CN/docs/Web/CSS/CSS_Selectors#Simple_selectors)是选择器中最初级的，通常由它们的组合构成其他更复杂的选择器。
+
+- [通配选择器](/zh-CN/docs/Web/CSS/Universal_selectors) `*`
+- [元素选择器](/zh-CN/docs/Web/CSS/Type_selectors) `elementname`（元素名称）
+- [类选择器](/zh-CN/docs/Web/CSS/Class_selectors) `.classname`（类名）
+- [ID 选择器](/zh-CN/docs/Web/CSS/ID_selectors) `#idname`（ID 名）
+- [属性选择器](/zh-CN/docs/Web/CSS/Attribute_selectors) `[attr=value]`（属性=值）
 
 ### 分组选择器
 
 - [选择器列表](/zh-CN/docs/Web/CSS/Selector_list) `A, B`
-  - : 指定同时选择`A` 和 `B`元素。这是一种选择多个匹配元素的分组方法。
+  - : 指定同时选择 `A` 和 `B` 元素。这是一种选择多个匹配元素的分组方法。
 
-### [组合选择器](/zh-CN/docs/Web/CSS/CSS_Selectors#Combinators)
+### 组合选择器
 
-组合选择器是在两个或多个简单选择器之间建立关系的选择器，例如“A 是 B 的子代”或“A 与 B 相邻”。
+组合选择器是在两个或多个简单选择器之间建立关系的选择器，例如“`A` 是 `B` 的子代”或“`A` 与 `B` 相邻”，它们构成了比较复杂的选择器。
 
-- [相邻兄弟选择器](/zh-CN/docs/CSS/Adjacent_sibling_selectors) `A + B`
+- [相邻兄弟选择器](/zh-CN/docs/Web/CSS/Adjacent_sibling_selectors) `A + B`
+  - : 指定 `A` 和 `B` 选择的元素具有相同的父元素，并且 `B` 选择的元素在水平方向上紧随 `A` 选择的元素。
+- [普通兄弟选择器](/zh-CN/docs/Web/CSS/General_sibling_selectors) `A ~ B`
+  - : 指定由 `A` 和 `B` 选择的元素共享相同的父元素，并指定 `A` 选择的元素在 `B` 选择的元素之前（但不一定紧接在 `B` 之前）。
+- [子选择器](/zh-CN/docs/Web/CSS/Child_selectors) `A > B`
+  - : 指定 `B` 选择的元素是 `A` 选择的元素的直接子元素。
+- [后代选择器](/zh-CN/docs/Web/CSS/Descendant_selectors) `A B`
+  - : 指定 `B` 选择的元素是 `A` 选择的元素的后代，但不一定是直接子代。
+- [列选择器](/zh-CN/docs/Web/CSS/Column_combinator) `A || B` {{Experimental_Inline}}
+  - : 指定 `B` 选择的元素在 `A` 指定的表格列中，跨越多列的元素被认为是所有这些列的成员。
 
-指定`A`和`B`选择的元素具有相同的父元素，并且`B`选择的元素在水平方向上紧随`A`选择的元素。
+### 伪类
 
-- [普通兄弟选择器](/zh-CN/docs/CSS/General_sibling_selectors) `A ~ B`
+- [伪类](/zh-CN/docs/Web/CSS/Pseudo-classes) `:`
+  - : 指定了所选择元素特定的状态。
+- [伪元素](/zh-CN/docs/Web/CSS/Pseudo-elements) `::`
+  - : 代表不包含在 HTML 中的实体。
 
-指定由`A`和`B`选择的元素共享相同的父元素，并指定`A`选择的元素在`B`选择的元素之前（但不一定紧接在`B`之前）。
-
-- [子选择器](/zh-CN/docs/CSS/Child_selectors) `A > B`
-
-指定`B`选择的元素是`A`选择的元素的直接子元素。
-
-- [后代选择器](/zh-CN/docs/CSS/Descendant_selectors) `A B`
-
-指定`B`选择的元素是`A`选择的元素的后代，但不一定是直接子代。
-
-### [伪类](/zh-CN/docs/Web/CSS/Pseudo-classes)
-
-{{Page("/zh-CN/docs/Web/CSS/Pseudo-classes", "index")}}
-
-### [伪元素](/zh-CN/docs/Web/CSS/Pseudo-elements)
-
-- {{Page("/zh-CN/docs/Web/CSS/Pseudo-elements", "index")}}
-
-> **备注：** 另见：一份完整的选择器标准 3 [选择器列表](https://www.w3.org/TR/selectors/#selectors)。
+> **标注：** 
+> 
+> 参见[标准 4 定义的选择器列表](https://www.w3.org/TR/selectors/#overview)。
 
 ## 概念
 
@@ -110,12 +108,13 @@ div.menu-bar li:hover > ul {
 - [@ 规则](/zh-CN/docs/Web/CSS/At-rule)
 - [层叠](/zh-CN/docs/Web/CSS/Cascade)
 - [注释](/zh-CN/docs/Web/CSS/Comments)
-- [解释器](</zh-CN/docs/Glossary/Descriptor_(CSS)>)
+- [解释器](/zh-CN/docs/Glossary/Descriptor_(CSS))
 - [继承](/zh-CN/docs/Web/CSS/inheritance)
 - [简写属性](/zh-CN/docs/Web/CSS/Shorthand_properties)
 - [优先级](/zh-CN/docs/Web/CSS/Specificity)
 - [值定义语法](/zh-CN/docs/Web/CSS/Value_definition_syntax)
 - [CSS 单位与取值类型](/zh-CN/docs/Web/CSS/CSS_Values_and_Units)
+- [CSS 函数表记](/zh-CN/docs/Web/CSS/CSS_Functions)
 
 ### 值
 
@@ -129,7 +128,7 @@ div.menu-bar li:hover > ul {
 ### 布局
 
 - [块级格式化上下文](/zh-CN/docs/Web/Guide/CSS/Block_formatting_context)
-- [盒式模型](/zh-CN/docs/Web/CSS/box_model)
+- [盒模型](/zh-CN/docs/Web/CSS/box_model)
 - [包含块](/zh-CN/docs/Web/CSS/All_About_The_Containing_Block)
 - [布局模式](/zh-CN/docs/Web/CSS/Layout_mode)
 - [外边距合并](/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing)
@@ -152,11 +151,15 @@ div.menu-bar li:hover > ul {
 
 ### 重要方法
 
-- {{domxref("CSSStyleSheet.insertRule()")}}
-- {{domxref("CSSStyleSheet.deleteRule()")}}
+- {{DOMxRef("CSSStyleSheet.insertRule()")}}
+- {{DOMxRef("CSSStyleSheet.deleteRule()")}}
 
-## 相关链接
+## 参见
 
-- [Mozilla CSS extensions](/zh-CN/docs/Web/CSS/Mozilla_Extensions) (prefixed with `-moz`)
-- [WebKit CSS extensions](/zh-CN/docs/Web/CSS/Webkit_Extensions) (mostly prefixed with `-webkit`)
-- [Microsoft CSS extensions](/zh-CN/docs/Web/CSS/Microsoft_CSS_extensions) (prefixed with `-ms`)
+- [Mozilla CSS 扩展](/zh-CN/docs/Web/CSS/Mozilla_Extensions)（以 `-moz` 前缀）
+- [WebKit CSS 扩展](/zh-CN/docs/Web/CSS/Webkit_Extensions)（大多数时候以 `-webkit` 前缀）
+- [Microsoft CSS 扩展](/zh-CN/docs/Web/CSS/Microsoft_CSS_extensions)（以 `-ms` 前缀）
+
+## 外部链接
+
+- [CSS 索引（w3.org）](https://www.w3.org/TR/CSS/#indices)

--- a/files/zh-cn/web/css/reference/index.md
+++ b/files/zh-cn/web/css/reference/index.md
@@ -29,7 +29,7 @@ properties-list ::=
     [property : value] [; properties-list]
 ```
 
-参阅后面的 [_选择器_](#选择器)、[_伪元素_](#伪元素)、[_伪类_](#伪类) 列表。每个指定*值*的语法取决于为每个指定*属性*定义的数据类型。
+参阅后面的[_选择器_](#选择器)、[_伪元素_](#伪元素)、[_伪类_](#伪类)列表。每个指定*值*的语法取决于为每个指定*属性*定义的数据类型。
 
 #### 样式规则示例
 
@@ -51,7 +51,7 @@ div.menu-bar li:hover > ul {
 
 ## 索引
 
-> **备注：** 此索引中的属性名称**不包括**与 CSS 标准名称不同的 [JavaScript 名称](/zh-CN/docs/Web/CSS/Reference#索引)。
+> **备注：** 此索引中的属性名称**不包括**与 CSS 标准名称不同的 [JavaScript 名称](#索引)。
 
 {{CSS_Ref}}
 
@@ -61,7 +61,7 @@ div.menu-bar li:hover > ul {
 
 ### 基本选择器
 
-[基本选择器](/zh-CN/docs/Web/CSS/CSS_Selectors#Simple_selectors)是选择器中最初级的，通常由它们的组合构成其他更复杂的选择器。
+[基本选择器](/zh-CN/docs/Web/CSS/CSS_Selectors#基本选择器)是选择器中最初级的，通常由它们的组合构成其他更复杂的选择器。
 
 - [通配选择器](/zh-CN/docs/Web/CSS/Universal_selectors) `*`
 - [元素选择器](/zh-CN/docs/Web/CSS/Type_selectors) `elementname`（元素名称）
@@ -108,7 +108,7 @@ div.menu-bar li:hover > ul {
 - [@ 规则](/zh-CN/docs/Web/CSS/At-rule)
 - [层叠](/zh-CN/docs/Web/CSS/Cascade)
 - [注释](/zh-CN/docs/Web/CSS/Comments)
-- [解释器](/zh-CN/docs/Glossary/Descriptor_(CSS))
+- [解释器](</zh-CN/docs/Glossary/Descriptor_(CSS)>)
 - [继承](/zh-CN/docs/Web/CSS/inheritance)
 - [简写属性](/zh-CN/docs/Web/CSS/Shorthand_properties)
 - [优先级](/zh-CN/docs/Web/CSS/Specificity)

--- a/files/zh-cn/web/css/reference/index.md
+++ b/files/zh-cn/web/css/reference/index.md
@@ -43,7 +43,7 @@ div.menu-bar li:hover > ul {
 }
 ```
 
-有关 CSS 选择器语法的初学者介绍，请参阅 [CSS 选择器教程](/zh-CN/docs/Learn/CSS/Building_blocks/Selectors)。注意，规则定义中的任何 [CSS 语法](/zh-CN/docs/Web/CSS/syntax)错误都将使整个规则无效，无效的规则将被浏览器忽略。注意 CSS 定义完全是[基于（ASCII）文本](https://www.w3.org/TR/css-syntax-3/#intro)的，而 DOM-CSS / CSSOM（规则管理系统） 是[基于对象](https://www.w3.org/TR/cssom/#introduction)的。
+有关 CSS 选择器语法的初学者介绍，请参阅 [CSS 选择器教程](/zh-CN/docs/Learn/CSS/Building_blocks/Selectors)。注意，规则定义中的任何 [CSS 语法](/zh-CN/docs/Web/CSS/Syntax)错误都将使整个规则无效，无效的规则将被浏览器忽略。注意 CSS 定义完全是[基于（ASCII）文本](https://www.w3.org/TR/css-syntax-3/#intro)的，而 DOM-CSS / CSSOM（规则管理系统） 是[基于对象](https://www.w3.org/TR/cssom/#introduction)的。
 
 ### @规则语法
 
@@ -51,7 +51,7 @@ div.menu-bar li:hover > ul {
 
 ## 索引
 
-> **备注：** 此索引中的属性名称**不包括**与 CSS 标准名称不同的 [JavaScript 名称](/zh-CN/docs/Web/CSS/CSS_Properties_Reference)。
+> **备注：** 此索引中的属性名称**不包括**与 CSS 标准名称不同的 [JavaScript 名称](/zh-CN/docs/Web/CSS/Reference#索引)。
 
 {{CSS_Ref}}
 
@@ -78,13 +78,13 @@ div.menu-bar li:hover > ul {
 
 组合选择器是在两个或多个简单选择器之间建立关系的选择器，例如“`A` 是 `B` 的子代”或“`A` 与 `B` 相邻”，它们构成了比较复杂的选择器。
 
-- [相邻兄弟选择器](/zh-CN/docs/Web/CSS/Adjacent_sibling_selectors) `A + B`
+- [相邻兄弟选择器](/zh-CN/docs/Web/CSS/Adjacent_sibling_combinator) `A + B`
   - : 指定 `A` 和 `B` 选择的元素具有相同的父元素，并且 `B` 选择的元素在水平方向上紧随 `A` 选择的元素。
-- [普通兄弟选择器](/zh-CN/docs/Web/CSS/General_sibling_selectors) `A ~ B`
+- [普通兄弟选择器](/zh-CN/docs/Web/CSS/General_sibling_combinator) `A ~ B`
   - : 指定由 `A` 和 `B` 选择的元素共享相同的父元素，并指定 `A` 选择的元素在 `B` 选择的元素之前（但不一定紧接在 `B` 之前）。
-- [子选择器](/zh-CN/docs/Web/CSS/Child_selectors) `A > B`
+- [子选择器](/zh-CN/docs/Web/CSS/Child_combinator) `A > B`
   - : 指定 `B` 选择的元素是 `A` 选择的元素的直接子元素。
-- [后代选择器](/zh-CN/docs/Web/CSS/Descendant_selectors) `A B`
+- [后代选择器](/zh-CN/docs/Web/CSS/Descendant_combinator) `A B`
   - : 指定 `B` 选择的元素是 `A` 选择的元素的后代，但不一定是直接子代。
 - [列选择器](/zh-CN/docs/Web/CSS/Column_combinator) `A || B` {{Experimental_Inline}}
   - : 指定 `B` 选择的元素在 `A` 指定的表格列中，跨越多列的元素被认为是所有这些列的成员。
@@ -128,8 +128,8 @@ div.menu-bar li:hover > ul {
 ### 布局
 
 - [块级格式化上下文](/zh-CN/docs/Web/Guide/CSS/Block_formatting_context)
-- [盒模型](/zh-CN/docs/Web/CSS/box_model)
-- [包含块](/zh-CN/docs/Web/CSS/All_About_The_Containing_Block)
+- [盒模型](/zh-CN/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
+- [包含块](/zh-CN/docs/Web/CSS/Containing_block)
 - [布局模式](/zh-CN/docs/Web/CSS/Layout_mode)
 - [外边距合并](/zh-CN/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing)
 - [替换元素](/zh-CN/docs/Web/CSS/Replaced_element)
@@ -157,7 +157,7 @@ div.menu-bar li:hover > ul {
 ## 参见
 
 - [Mozilla CSS 扩展](/zh-CN/docs/Web/CSS/Mozilla_Extensions)（以 `-moz` 前缀）
-- [WebKit CSS 扩展](/zh-CN/docs/Web/CSS/Webkit_Extensions)（大多数时候以 `-webkit` 前缀）
+- [WebKit CSS 扩展](/zh-CN/docs/Web/CSS/WebKit_Extensions)（大多数时候以 `-webkit` 前缀）
 - [Microsoft CSS 扩展](/zh-CN/docs/Web/CSS/Microsoft_CSS_extensions)（以 `-ms` 前缀）
 
 ## 外部链接


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

sync css/reference/index with newest EN document

### Motivation

continue removing `{{page}}` macro calls

### Related issues and pull requests

#3893 
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
