### PR TITLE
Manually editing redirects to remove link with macros

### DIFF
--- a/files/fr/_redirects.txt
+++ b/files/fr/_redirects.txt
@@ -1844,7 +1844,6 @@
 /fr/docs/HTML/Element/Optgroup	/fr/docs/Web/HTML/Element/Optgroup
 /fr/docs/HTML/Element/Option	/fr/docs/Web/HTML/Element/Option
 /fr/docs/HTML/Element/Output	/fr/docs/Web/HTML/Element/Output
-/fr/docs/HTML/Element/Output_{{HTMLVersionInline(5)}}_{{fx_minversion_inline(4)}}	/fr/docs/Web/HTML/Element/Output
 /fr/docs/HTML/Element/Progress	/fr/docs/Web/HTML/Element/Progress
 /fr/docs/HTML/Element/Select	/fr/docs/Web/HTML/Element/Select
 /fr/docs/HTML/Element/Source	/fr/docs/Web/HTML/Element/Source
@@ -4699,7 +4698,6 @@
 /fr/docs/Web/HTML/DASH_Adaptive_Streaming_for_HTML_5_Video	/fr/docs/Web/Media/DASH_Adaptive_Streaming_for_HTML_5_Video
 /fr/docs/Web/HTML/Element/Input/datetime	/fr/docs/Web/HTML/Element/input/datetime-local
 /fr/docs/Web/HTML/Element/Input/mois	/fr/docs/Web/HTML/Element/Input/month
-/fr/docs/Web/HTML/Element/Output_{{HTMLVersionInline(5)}}_{{fx_minversion_inline(4)}}	/fr/docs/Web/HTML/Element/Output
 /fr/docs/Web/HTML/Element/Video/canplay_event	/fr/docs/Web/API/HTMLMediaElement/canplay_event
 /fr/docs/Web/HTML/Element/Video/emptied_event	/fr/docs/Web/API/HTMLMediaElement/emptied_event
 /fr/docs/Web/HTML/Element/Video/ended_event	/fr/docs/Web/API/HTMLMediaElement/ended_event


### PR DESCRIPTION
This removes two redirects which included a macro name.
I assume any consequences for those redirects being lost (even though cool URLs shouldn't change, I'm not sur those one were cool to begin with)