### PR TITLE
Make issue template names unique

### DIFF
--- a/.github/ISSUE_TEMPLATE/page-report-es.yml
+++ b/.github/ISSUE_TEMPLATE/page-report-es.yml
@@ -1,4 +1,4 @@
-name: "[via MDN pages only]"
+name: "[via MDN pages only // es]"
 description: Issue filed via "Report a problem with this content on GitHub" link on MDN pages.
 labels: ["l10n-es", "needs triage"]
 body:

--- a/.github/ISSUE_TEMPLATE/page-report-fr.yml
+++ b/.github/ISSUE_TEMPLATE/page-report-fr.yml
@@ -1,4 +1,4 @@
-name: "[via des pages MDN uniquement]"
+name: "[via des pages MDN uniquement // fr]"
 description: Issue filed via le lien "Report a problem with this content on GitHub" sur des pages MDN.
 labels: ["l10n-fr", "needs triage"]
 body:

--- a/.github/ISSUE_TEMPLATE/page-report-ja.yml
+++ b/.github/ISSUE_TEMPLATE/page-report-ja.yml
@@ -1,4 +1,4 @@
-name: "[via MDN pages only]"
+name: "[via MDN pages only // ja]"
 description: Issue filed via "Report a problem with this content on GitHub" link on MDN pages.
 labels: ["l10n-ja", "needs triage"]
 body:

--- a/.github/ISSUE_TEMPLATE/page-report-ko.yml
+++ b/.github/ISSUE_TEMPLATE/page-report-ko.yml
@@ -1,4 +1,4 @@
-name: "[via MDN pages only]"
+name: "[via MDN pages only // ko]"
 description: Issue filed via "Report a problem with this content on GitHub" link on MDN pages.
 labels: ["l10n-ko", "needs triage"]
 body:

--- a/.github/ISSUE_TEMPLATE/page-report-pt-br.yml
+++ b/.github/ISSUE_TEMPLATE/page-report-pt-br.yml
@@ -1,4 +1,4 @@
-name: "[via MDN pages only]"
+name: "[via MDN pages only // pt-br]"
 description: Issue filed via "Report a problem with this content on GitHub" link on MDN pages.
 labels: ["l10n-pt-br", "needs triage"]
 body:

--- a/.github/ISSUE_TEMPLATE/page-report-ru.yml
+++ b/.github/ISSUE_TEMPLATE/page-report-ru.yml
@@ -1,4 +1,4 @@
-name: "[via MDN pages only]"
+name: "[via MDN pages only // ru]"
 description: Issue filed via "Report a problem with this content on GitHub" link on MDN pages.
 labels: ["l10n-ru", "needs triage"]
 body:

--- a/.github/ISSUE_TEMPLATE/page-report-zh-cn.yml
+++ b/.github/ISSUE_TEMPLATE/page-report-zh-cn.yml
@@ -1,4 +1,4 @@
-name: "[via MDN pages only]"
+name: "[via MDN pages only // zh-cn]"
 description: Issue filed via "Report a problem with this content on GitHub" link on MDN pages.
 labels: ["l10n-zh", "needs triage"]
 body:

--- a/.github/ISSUE_TEMPLATE/page-report-zh-tw.yml
+++ b/.github/ISSUE_TEMPLATE/page-report-zh-tw.yml
@@ -1,4 +1,4 @@
-name: "[via MDN pages only]"
+name: "[via MDN pages only // zh-tw]"
 description: Issue filed via "Report a problem with this content on GitHub" link on MDN pages.
 labels: ["l10n-zh", "needs triage"]
 body:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixes a regression introduced by https://github.com/mdn/translated-content/pull/9073.

### Motivation

The "Report a problem" links are currently broken, as multiple issue templates with the same name exist.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

See: https://github.com/mdn/translated-content/pull/9073#issuecomment-1284364700
