### PR TITLE
HTTP 206 - fix Content-Range hyperlinks texts

### DIFF
--- a/files/fr/web/http/status/206/index.md
+++ b/files/fr/web/http/status/206/index.md
@@ -9,9 +9,9 @@ browser-compat: http.status.206
 
 Le code de statut de réponse succès HTTP **`206 Partial Content`** indique que la requête a bien abouti et que le corps de la réponse contient les plages de données demandées, tel que décrit dans l'en-tête [`Range`](/fr/docs/Web/HTTP/Headers/Range) de la requête.
 
-S'il n'y a qu'une seule plage, l'entête [`Content-Type`](/fr/docs/Web/HTTP/Headers/Content-Type) de la réponse correspondra au type du document et l'en-tête [`Content-Type`](/fr/docs/Web/HTTP/Headers/Content-Range) sera fourni.
+S'il n'y a qu'une seule plage, l'entête [`Content-Type`](/fr/docs/Web/HTTP/Headers/Content-Type) de la réponse correspondra au type du document et l'en-tête [`Content-Range`](/fr/docs/Web/HTTP/Headers/Content-Range) sera fourni.
 
-Si plusieurs plages sont renvoyées, l'en-tête [`Content-Type`](/fr/docs/Web/HTTP/Headers/Content-Type) vaudra `multipart/byteranges` et chaque fragment couvrira une plage, décrite par les en-têtes [`Content-Type`](/fr/docs/Web/HTTP/Headers/Content-Range) et [`Content-Type`](/fr/docs/Web/HTTP/Headers/Content-Type).
+Si plusieurs plages sont renvoyées, l'en-tête [`Content-Type`](/fr/docs/Web/HTTP/Headers/Content-Type) vaudra `multipart/byteranges` et chaque fragment couvrira une plage, décrite par les en-têtes [`Content-Range`](/fr/docs/Web/HTTP/Headers/Content-Range) et [`Content-Type`](/fr/docs/Web/HTTP/Headers/Content-Type).
 
 ## Statut
 


### PR DESCRIPTION
### Description

Set the right labels on "Content-Range" hyperlinks.

### Motivation

The previous labels made the whole explanation wrong.

### Additional details

-
### Related issues and pull requests

-
