### PR TITLE
Markdown bolded rendering fails

### DIFF
--- a/files/zh-cn/web/css/transition/index.md
+++ b/files/zh-cn/web/css/transition/index.md
@@ -5,7 +5,7 @@ slug: Web/CSS/transition
 
 {{CSSRef}}
 
-**`transition`** [CSS](/zh-CN/CSS) 属性是 {{ cssxref("transition-property") }}、{{ cssxref("transition-duration") }}、{{ cssxref("transition-timing-function") }} 和 {{ cssxref("transition-delay") }} 的一个[简写属性](/zh-CN/docs/CSS/Shorthand_properties)。
+**`transition`** [CSS](/zh-CN/docs/Web/CSS) 属性是 {{ cssxref("transition-property") }}、{{ cssxref("transition-duration") }}、{{ cssxref("transition-timing-function") }} 和 {{ cssxref("transition-delay") }} 的一个[简写属性](/zh-CN/docs/CSS/Shorthand_properties)。
 
 {{EmbedInteractiveExample("pages/css/transition.html")}}
 

--- a/files/zh-cn/web/css/transition/index.md
+++ b/files/zh-cn/web/css/transition/index.md
@@ -5,7 +5,7 @@ slug: Web/CSS/transition
 
 {{CSSRef}}
 
-**`transition`**[CSS](/zh-CN/CSS) 属性是 {{ cssxref("transition-property") }}，{{ cssxref("transition-duration") }}，{{ cssxref("transition-timing-function") }} 和 {{ cssxref("transition-delay") }} 的一个[简写属性](/zh-CN/docs/CSS/Shorthand_properties)。
+**`transition`** [CSS](/zh-CN/CSS) 属性是 {{ cssxref("transition-property") }}、{{ cssxref("transition-duration") }}、{{ cssxref("transition-timing-function") }} 和 {{ cssxref("transition-delay") }} 的一个[简写属性](/zh-CN/docs/CSS/Shorthand_properties)。
 
 {{EmbedInteractiveExample("pages/css/transition.html")}}
 

--- a/files/zh-cn/web/css/transition/index.md
+++ b/files/zh-cn/web/css/transition/index.md
@@ -5,7 +5,7 @@ slug: Web/CSS/transition
 
 {{CSSRef}}
 
-**`transition` **[CSS](/zh-CN/CSS) 属性是 {{ cssxref("transition-property") }}，{{ cssxref("transition-duration") }}，{{ cssxref("transition-timing-function") }} 和 {{ cssxref("transition-delay") }} 的一个[简写属性](/zh-CN/docs/CSS/Shorthand_properties)。
+**`transition`**[CSS](/zh-CN/CSS) 属性是 {{ cssxref("transition-property") }}，{{ cssxref("transition-duration") }}，{{ cssxref("transition-timing-function") }} 和 {{ cssxref("transition-delay") }} 的一个[简写属性](/zh-CN/docs/CSS/Shorthand_properties)。
 
 {{EmbedInteractiveExample("pages/css/transition.html")}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Markdown bold rendering failure, Chinese documents and English documents compared to see that the process of writing more than one space added
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Fix Chinese documentation
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
THE PROBLEMS happend at the doc:https://developer.mozilla.org/zh-CN/docs/Web/CSS/transition
![image.png](https://pic1.58cdn.com.cn/nowater/webim/big/n_v26ce5c40da87d4b5b9bfa12155ed94fbf.png)
THE CORRECT reference at the doc:https://developer.mozilla.org/en-US/docs/Web/CSS/transition
![image.png](https://pic5.58cdn.com.cn/nowater/webim/big/n_v296079c5657a849f2b3b61ce145742113.png)
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

