### PR TITLE
PointerEvent.height の更新

### DIFF
--- a/files/ja/web/api/pointerevent/height/index.md
+++ b/files/ja/web/api/pointerevent/height/index.md
@@ -1,15 +1,13 @@
 ---
 title: PointerEvent.height
 slug: Web/API/PointerEvent/height
-page-type: web-api-instance-property
-browser-compat: api.PointerEvent.height
 l10n:
   sourceCommit: 4b4638246aad5d39b9a2e5c572b179b4c39c0a84
 ---
 
 {{ APIRef("Pointer Events") }}
 
-{{domxref("PointerEvent")}} インターフェイスの読み取り専用プロパティである **`height`** は、ポインタの接触ジオメトリーの高さを y 軸に従って表します (CSS ピクセル単位)。またポインタデバイスのソース (指など) によっては、与えられたポインタに対して、各イベントが異なる値を生成することがあります。
+{{domxref("PointerEvent")}} インターフェイスの読み取り専用プロパティである **`height`** は、ポインターの接触ジオメトリーの高さを y 軸に従って表します (CSS ピクセル単位)。またポインターデバイスのソース (指など) によっては、与えられたポインターに対して、各イベントが異なる値を生成することがあります。
 
 入力ハードウェアが接触ジオメトリーをブラウザーに報告できない場合、高さはデフォルトで `1` になります。
 
@@ -19,7 +17,7 @@ l10n:
 
 ## 例
 
-このプロパティの例は [PointerEvent.width の例](/ja/docs/Web/API/PointerEvent/width#example)に含まれています。
+このプロパティの例は [PointerEvent.width の例](/ja/docs/Web/API/PointerEvent/width#例)に含まれています。
 
 ## 仕様
 

--- a/files/ja/web/api/pointerevent/height/index.md
+++ b/files/ja/web/api/pointerevent/height/index.md
@@ -1,36 +1,30 @@
 ---
 title: PointerEvent.height
 slug: Web/API/PointerEvent/height
+page-type: web-api-instance-property
+browser-compat: api.PointerEvent.height
+l10n:
+  sourceCommit: 4b4638246aad5d39b9a2e5c572b179b4c39c0a84
 ---
 
 {{ APIRef("Pointer Events") }}
 
-{{domxref("PointerEvent")}} インターフェイスの **`height`** 読み取り専用プロパティは、y 軸に沿ったポインタの接触ジオメトリの高さを表します（CSS ピクセル単位）。 ポインタデバイスのソース（指など）によっては、特定のポインタに対して、各イベントが異なる値を生成することがあります。
+{{domxref("PointerEvent")}} インターフェイスの読み取り専用プロパティである **`height`** は、ポインタの接触ジオメトリーの高さを y 軸に従って表します (CSS ピクセル単位)。またポインタデバイスのソース (指など) によっては、与えられたポインタに対して、各イベントが異なる値を生成することがあります。
 
-入力ハードウェアが接触ジオメトリをブラウザーに報告できない場合、高さのデフォルトは `1` です。
+入力ハードウェアが接触ジオメトリーをブラウザーに報告できない場合、高さはデフォルトで `1` になります。
 
-## 構文
+## 値
 
-```
-var contactHeight = pointerEvent.height;
-```
-
-### 戻り値
-
-- `contactHeight`
-  - : イベントの接触面積の高さ（CSS ピクセル単位）。
+イベントの接触ジオメトリーの高さ (CSS ピクセル単位)。
 
 ## 例
 
-このプロパティの例は、[PointerEvent.width の例](/ja/docs/Web/API/PointerEvent/width#Example)に含まれています。
+このプロパティの例は [PointerEvent.width の例](/ja/docs/Web/API/PointerEvent/width#example)に含まれています。
 
 ## 仕様
 
-| 仕様                                                                                         | 状態                                     | コメント |
-| -------------------------------------------------------------------------------------------- | ---------------------------------------- | -------- |
-| {{SpecName('Pointer Events 2','#widl-PointerEvent-height', 'height')}} | {{Spec2('Pointer Events 2')}} | 不安定版 |
-| {{SpecName('Pointer Events', '#widl-PointerEvent-height', 'height')}} | {{Spec2('Pointer Events')}}     | 初期定義 |
+{{Specifications}}
 
 ## ブラウザーの互換性
 
-{{Compat("api.PointerEvent.height")}}
+{{Compat}}


### PR DESCRIPTION
### Description

[PointerEvent.height](https://developer.mozilla.org/ja/docs/Web/API/PointerEvent/height) の翻訳を更新しました。

* 原文リンク：https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/height

### Related issues and pull requests

resolve: mozilla-japan/translation#655
