### PR TITLE
zh-CN: glossary/speculative_parsing: fix inline-code format

### DIFF
--- a/files/zh-cn/glossary/speculative_parsing/index.md
+++ b/files/zh-cn/glossary/speculative_parsing/index.md
@@ -4,7 +4,7 @@ slug: Glossary/speculative_parsing
 original_slug: Web/HTML/Optimizing_your_pages_for_speculative_parsing
 ---
 
-在传统的浏览器中，HTML 解析器运行于主线程之中，并且在遇到 \</script> 标签后会被阻塞，直到脚本从网络中被获取和执行。Firefox 4 和后续的版本支持从主线程中分离的预解析技术。当脚本在获取和执行的过程中，预解析技术能提前解析 HTML 文档。在 Firefox 3.5 和 3.6 中，HTML 解析器能够在文档流中预先加载脚本、层叠样式表和图片。然而，在 Firefox 4 和后续的版本中 HTML 解析器也预先运行 HTML 树构建算法。这一举措的优点是当预解析成功后，就没有必要再重新解析已经扫描过并且成功下载的脚本，层叠样式表和图片；缺点就是当预解析失败之后，有很多工作需要去做。
+在传统的浏览器中，HTML 解析器运行于主线程之中，并且在遇到 `</script>` 标签后会被阻塞，直到脚本从网络中被获取和执行。Firefox 4 和后续的版本支持从主线程中分离的预解析技术。当脚本在获取和执行的过程中，预解析技术能提前解析 HTML 文档。在 Firefox 3.5 和 3.6 中，HTML 解析器能够在文档流中预先加载脚本、层叠样式表和图片。然而，在 Firefox 4 和后续的版本中 HTML 解析器也预先运行 HTML 树构建算法。这一举措的优点是当预解析成功后，就没有必要再重新解析已经扫描过并且成功下载的脚本，层叠样式表和图片；缺点就是当预解析失败之后，有很多工作需要去做。
 
 这篇文档旨在帮助你避免预解析失败和页面加载变慢。
 
@@ -12,11 +12,11 @@ original_slug: Web/HTML/Optimizing_your_pages_for_speculative_parsing
 
 让脚本、层叠样式表和图片预加载成功的规则只有一条：
 
-- 如果你使用 `<base>` 元素重载页面的基 URI，将这个元素放置到文档的非脚本部分。不要通过 `document.write()` 或者 `document.createElement() 添加`.
+- 如果你使用 `<base>` 元素重载页面的基 URI，将这个元素放置到文档的非脚本部分。不要通过 `document.write()` 或者 `document.createElement()` 添加。
 
 ## 避免树构建器的输出丢失
 
-当 document.write() 改变了文档树的状态时，树构建器的预构建过程会失败。例如，当所有被`document.write() 插入的内容被解析之后</script>` 标签后的预处理状态不再持有。然而，只有不寻常地使用 `document.write()` 才会产生问题。这些事情需要避免：
+当 `document.write()` 改变了文档树的状态时，树构建器的预构建过程会失败。例如，当所有被 `document.write()` 插入的内容被解析之后 `</script>` 标签后的预处理状态不再持有。然而，只有不寻常地使用 `document.write()` 才会产生问题。这些事情需要避免：
 
 - 不要写不对称的文档树。`<script>document.write("<div>");</script>` 很糟糕。`<script>document.write("<div></div>");</script>` 则是可行的。
 - 不要写未完成的标识。 `<script>document.write("<div></div");</script>` 很糟糕。


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

#### 1

Before:

<p>在传统的浏览器中，HTML 解析器运行于主线程之中，并且在遇到 &lt;/script&gt; 标签后会被阻塞，直到脚本从网络中被获取和执行。...</p>

After:

<p>在传统的浏览器中，HTML 解析器运行于主线程之中，并且在遇到 <code>&lt;/script&gt;</code> 标签后会被阻塞，直到脚本从网络中被获取和执行。...</p>

#### 2

Before:

<li>如果你使用 <code>&lt;base&gt;</code> 元素重载页面的基 URI，将这个元素放置到文档的非脚本部分。不要通过 <code>document.write()</code> 或者 <code>document.createElement() 添加</code>.</li>

After:

<li>如果你使用 <code>&lt;base&gt;</code> 元素重载页面的基 URI，将这个元素放置到文档的非脚本部分。不要通过 <code>document.write()</code> 或者 <code>document.createElement()</code> 添加。</li>

#### 3

Before:

<p>当 document.write() 改变了文档树的状态时，树构建器的预构建过程会失败。例如，当所有被<code>document.write() 插入的内容被解析之后&lt;/script&gt;</code> 标签后的预处理状态不再持有。然而，只有不寻常地使用 <code>document.write()</code> 才会产生问题。这些事情需要避免：</p>

After:

<p>当 <code>document.write()</code> 改变了文档树的状态时，树构建器的预构建过程会失败。例如，当所有被 <code>document.write()</code> 插入的内容被解析之后 <code>&lt;/script&gt;</code> 标签后的预处理状态不再持有。然而，只有不寻常地使用 <code>document.write()</code> 才会产生问题。这些事情需要避免：</p>

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
