### PR TITLE
zh: mozilla: fix inline-code format, typo, links and wrong translation

### DIFF
--- a/files/zh-cn/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
@@ -45,7 +45,7 @@ var sending = browser.runtime.sendMessage(
     2. null
     3. undefined
 
-  - 否则，将会被当做 `(extensionId, message)。`消息将会给发送给 `extensionId` 指定 ID 的扩展
+  - 否则，将会被当做 `(extensionId, message)`。消息将会给发送给 `extensionId` 指定 ID 的扩展
 
 - **有 3 个参数**：将会被当做 `(extensionId, message, options)`. 消息将会给发送给 `extensionId` 指定 ID 的扩展
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/api/sessions/session/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/api/sessions/session/index.md
@@ -25,7 +25,7 @@ slug: Mozilla/Add-ons/WebExtensions/API/sessions/Session
 - `lastModified`
   - : `number`。选项卡或窗口关闭的时间，[自 epoch 以来的毫秒数](https://en.wikipedia.org/wiki/Unix_time)。
 - `tab`{{optional_inline}}
-  - : `object`。如果对象表示关闭的选项卡，则此属性存在，并且将是{{WebExtAPIRef("tabs.Tab")}}对象。仅当扩展名具有“tabs” [许可](/zh-CN/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions)权时`url`，它才会包含`title`和。`favIconUrl`
+  - : `object`。如果对象表示已关闭的选项卡，则此属性存在，并且将是 {{WebExtAPIRef("tabs.Tab")}} 对象。仅当扩展具有“tabs” [权限](/zh-CN/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions)时，它才会包含 `url`，`title` 和 `favIconUrl`。
 - `window`{{optional_inline}}
   - : `object`。如果对象表示一个关闭的窗口，则此属性存在并且将是{{WebExtAPIRef("windows.Window")}}对象。
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
@@ -95,7 +95,7 @@ setCookie.then(logCookie, logError);
 
 #### [webRequest](/zh-CN/Add-ons/WebExtensions/API/webRequest)
 
-- 在 Firefx 中，只有原网址使用 `http:` `或 https:` 协议时所请求的重定向才有效。
+- 在 Firefox 中，只有原网址使用 `http:` 或 `https:` 协议时所请求的重定向才有效。
 - In Firefox, events are not fired for system requests (for example, extension upgrades or searchbar suggestions). From Firefox 57 onwards, Firefox makes an exception for extensions that need to intercept {{WebExtAPIRef("webRequest.onAuthRequired")}} for proxy authorization. See the documentation for {{WebExtAPIRef("webRequest.onAuthRequired")}}.
 - In Firefox, if an extension wants to redirect a public (e.g. HTTPS) URL to an [extension page](/zh-CN/docs/Mozilla/Add-ons/WebExtensions/user_interface/Extension_pages), the extension's manifest.json file must contain a [web_accessible_resources](/zh-CN/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources) key that lists the URL for the extension page. Note that any website may then link or redirect to that url, and extensions should treat any input (POST data, for examples) as if it came from an untrusted source, just as a normal web page should.
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/internationalization/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/internationalization/index.md
@@ -172,13 +172,13 @@ var content = browser.i18n.getMessage("notificationContent", message.url);
 
 `"placeholders"` 这个成员定义了所有的占位符，以及它们所检索的来源。`"url"` 这个占位符指定了其内容取自 $1，它就是 `getMessage()` 第二个参数里的第一个值。由于占位符就叫做 `"url"`，我们就在实际的消息字符串中用 `$URL$` 调用它（`"name"` 用 `$NAME$` 调用也是一样的，以此类推）。对于多个占位符，你可以将其置于数组内，并作为第二个参数传递到 {{WebExtAPIRef("i18n.getMessage()")}} —`[a, b, c]`可替换为`$1`, `$2`, and `$3，以此类推，并置于` `messages.json` 内。
 
-接下来我们看一个例子：在 `en/messages.json 文件中`原始的 `notificationContent` 消息字符串如下：in the `en/messages.json` file is
+接下来我们看一个例子：在 `en/messages.json` 文件中原始的 `notificationContent` 消息字符串如下：in the `en/messages.json` file is
 
 ```
 您点击了 $URL$。
 ```
 
-我们可以看到链接点击后会打开 `https://developer.mozilla.org。`在 {{WebExtAPIRef("i18n.getMessage()")}} 调用后，第二个参数的内容就变成了 messages.json 里的 `$1`，并替换定义在 `"url" 占位符里的` `$URL$` 这个占位符。所以最后的消息字符串就变成了：
+我们可以看到链接点击后会打开 `https://developer.mozilla.org`。在 {{WebExtAPIRef("i18n.getMessage()")}} 调用后，第二个参数的内容就变成了 messages.json 里的 `$1`，并替换定义在 `"url"` 占位符里的 `$URL$` 这个占位符。所以最后的消息字符串就变成了：
 
 ```
 您点击了 https://developer.mozilla.org。
@@ -213,7 +213,7 @@ var content = browser.i18n.getMessage("notificationContent", message.url);
 }
 ```
 
-在本例中我们只是硬编码了占位符的内容，而不是从 `$1 这样的变量值中获取它。有时候你会遇到消息文件非常复杂，或者如果你想将文件里的不同值分离开来以便字符串可读性更好，`这种情况下它会很有用，这些值可通过编程来访问。
+在本例中我们只是硬编码了占位符的内容，而不是从 `$1` 这样的变量值中获取它。有时候你会遇到消息文件非常复杂，或者如果你想将文件里的不同值分离开来以便字符串可读性更好，这种情况下它会很有用，这些值可通过编程来访问。
 
 此外，你可使用这样的替代方式指定不想被翻译的一部分字符串，例如人名或公司名。
 
@@ -223,7 +223,7 @@ var content = browser.i18n.getMessage("notificationContent", message.url);
 
 1. 如果有精确匹配当前语言区域的 `messages.json` 文件，并且它包含该字符串，则返回它。
 2. 否则，如果当前语言区域有合格区域（例如 `en_US`）并且有一个无区域限定的 `messages.json` 文件（例如 `en`）且包含该字符串，则返回它。
-3. 否则，如果 `manifest.json 里包含` `default_locale` 所对应的 `messages.json` 文件且包含该字符串，则返回它。
+3. 否则，如果 `manifest.json` 里包含 `default_locale` 所对应的 `messages.json` 文件且包含该字符串，则返回它。
 4. 否则，返回一个空字符串。
 
 参见下列示例：

--- a/files/zh-cn/mozilla/firefox/releases/14/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/14/index.md
@@ -46,7 +46,7 @@ _No change._
 
 ### HTTP
 
-- Gecko 开始支持新的[HTTP](/zh-CN/HTTP) [`308`永久重定向](/zh-CN/HTTP/HTTP_response_codes#308) 状态码。由于 Gecko 并不区分永久重定向和零食重定向，所以该状态码的表现行为和[`307 临时重定向`](/zh-CN/HTTP/HTTP_response_codes#307)状态码是一样的，和 302 以及 301 状态码的区别是，它们禁止用户代理改变重定之后的 HTTP 方法 (`POST` 还是 `POST`, `GET` 还是 `GET`).
+- Gecko 开始支持新的[HTTP](/zh-CN/HTTP) [`308 永久重定向`](/zh-CN/HTTP/HTTP_response_codes#308) 状态码。由于 Gecko 并不区分永久重定向和临时重定向，所以该状态码的表现行为和[`307 临时重定向`](/zh-CN/HTTP/HTTP_response_codes#307)状态码是一样的，和 302 以及 301 状态码的区别是，它们禁止用户代理改变重定之后的 HTTP 方法 (`POST` 还是 `POST`, `GET` 还是 `GET`).
 
 ## Changes for Mozilla and add-on developers
 

--- a/files/zh-cn/mozilla/firefox/releases/19/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/19/index.md
@@ -27,7 +27,7 @@ Firefox 19 已于 2013 年 2 月 19 日正式发布。
 
 ### DOM
 
-- {{domxref("element.getElementsByTagName")}} 方法开始返回 `HTMLCollection` 对象，而不是以前的 `NodeList 对象`. ({{bug("799464")}}).
+- {{domxref("element.getElementsByTagName")}} 方法开始返回 `HTMLCollection` 对象，而不是以前的 `NodeList` 对象. ({{bug("799464")}}).
 - 实现了 {{domxref("File")}} 对象的 `mozLastModifiedDate` 属性。({{bug("793955")}})
 - 当 {{domxref("File")}} 对象的最后修改时间无法获取到时，它的 lastModifiedDate 属性会返回当前日期。({{bug("793459")}}
 - 实现了 {{domxref("CanvasRenderingContext2D")}}对象的 `isPointInStroke` 方法。({{bug("803124")}}).

--- a/files/zh-cn/mozilla/firefox/releases/27/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/27/index.md
@@ -45,7 +45,7 @@ _No change._
 
 ## 附加组件和 Mozilla 开发者需要注意的变化
 
-- `移除了 downloads-indicator`, 你应该使用 `downloads-button` 元素来代替。
+- 移除了 `downloads-indicator`, 你应该使用 `downloads-button` 元素来代替。
 - Firefox 不再使用 `chrome://browser/skin/downloads/indicator.css` 样式。
 
 ## 相关链接

--- a/files/zh-cn/mozilla/firefox/releases/41/index.md
+++ b/files/zh-cn/mozilla/firefox/releases/41/index.md
@@ -63,7 +63,7 @@ Highlights:
 
   - 使用 `'paste'`名利作为参数，{{domxref("Document.queryCommandSupported()")}}现在会返回 false 如果不充分的权限被执行 ({{bug(1161721)}}).
   - 使用`'cut'` 或 `'copy'` 命令作为参数，{{domxref("Document.queryCommandSupported()")}} 现在返回`true` 如果调用的上下文中包括用户发起的或特权代码 ({{bug(1162952)}}).
-  - 使用 `'cut'` 或`'copy' 命令作为参数`, {{domxref("Document.execCommand()")}} 将会执行，但是仅仅在用户发起的或特权代码的上下文下 ({{bug(1012662)}}).
+  - 使用 `'cut'` 或`'copy'` 命令作为参数, {{domxref("Document.execCommand()")}} 将会执行，但是仅仅在用户发起的或特权代码的上下文下 ({{bug(1012662)}}).
 
 #### Events
 

--- a/files/zh-tw/mozilla/add-ons/webextensions/content_scripts/index.md
+++ b/files/zh-tw/mozilla/add-ons/webextensions/content_scripts/index.md
@@ -276,7 +276,7 @@ document.body.addEventListener("click", function() {
 - 監聽來自內容腳本的連線請求
 - 當它收到連線請求：
 
-  - 將端口儲存在 `portFromCS 這個變數`
+  - 將端口儲存在 `portFromCS` 這個變數
   - 透過端口傳送訊息給內容腳本
   - 開始監聽並記錄端口上的訊息
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Partial.

#### files/zh-cn/mozilla/add-ons/webextensions/api/sessions/session/index.md

Before:

<p><code>object</code>。如果对象表示关闭的选项卡，则此属性存在，并且将是<a href="/zh-CN/docs/Mozilla/Add-ons/WebExtensions/API/tabs/Tab"><code>tabs.Tab</code></a>对象。仅当扩展名具有“tabs” <a href="/zh-CN/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions">许可</a>权时<code>url</code>，它才会包含<code>title</code>和。<code>favIconUrl</code></p>

After:

<p><code>object</code>。如果对象表示已关闭的选项卡，则此属性存在，并且将是 <a href="/zh-CN/docs/Mozilla/Add-ons/WebExtensions/API/tabs/Tab"><code>tabs.Tab</code></a> 对象。仅当扩展具有“tabs” <a href="/zh-CN/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions">权限</a>时，它才会包含 <code>url</code>，<code>title</code> 和 <code>favIconUrl</code>。</p>

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
