### PR TITLE
zh-cn: web/accessibility: fix inline-code format

### DIFF
--- a/files/zh-cn/web/accessibility/aria/attributes/aria-labelledby/index.md
+++ b/files/zh-cn/web/accessibility/aria/attributes/aria-labelledby/index.md
@@ -7,7 +7,7 @@ slug: Web/Accessibility/ARIA/Attributes/aria-labelledby
 
 [`aria-labelledby`](http://www.w3.org/TR/wai-aria/states_and_properties#aria-labelledby)属性用来表明某些元素的 id 是某一对象的标签。它被用来确定控件或控件组与它们标签之间的联系。使用诸如屏幕阅读器等辅助技术的用户通常使用 tabbing 在页面的不同区域间进行导航。如果一个输入元素、控件或控件组没有被分配一个 label 标签，那么屏幕阅读器就无法对其进行阅读。
 
-`aria-labelledby 属性与`[aria-describedby](/zh-CN/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute)属性非常相似：用一个标签描述某一对象的本质，可能会提供一些用户需要了解的额外信息。
+`aria-labelledby` 属性与[aria-describedby](/zh-CN/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute)属性非常相似：用一个标签描述某一对象的本质，可能会提供一些用户需要了解的额外信息。
 
 `aria-labelledby` 属性并不仅仅用于表单元素，也可以用来分配静态文本给控件、元素组、面板组以及包含标题和定义等内容的区域等。下方的示例将会展示如何针对这些情况运用这一属性的更多信息。
 

--- a/files/zh-cn/web/accessibility/keyboard-navigable_javascript_widgets/index.md
+++ b/files/zh-cn/web/accessibility/keyboard-navigable_javascript_widgets/index.md
@@ -137,7 +137,7 @@ _范例 2: 一个使用 tabindex 控制键盘 access 的菜单控件_
 
 当用户从一个组件 tab 离开之后 focus 回来，焦点应该回到离开之时正被 focus 中的元素上，比如某个树节点或者网格单元。有两种办法完成这一点：
 
-1. `流动 tabindex`: 通过编程移动 focus
+1. 流动 `tabindex`: 通过编程移动 focus
 2. `aria-activedescendent`: 管理一个“虚拟”focus
 
 #### 方法 1: 流动 tabindex
@@ -166,7 +166,7 @@ _范例 2: 一个使用 tabindex 控制键盘 access 的菜单控件_
 
 #### 方法 2: aria-activedescendant
 
-这个办法包含绑定一个单独的事件句柄到容器窗口组件上，运用 `aria-activedescendent 属性`来追踪一个 "虚拟" 焦点。（关于 ARIA 更多的信息，查看 [overview of accessible web applications and widgets](../../../../An_Overview_of_Accessible_Web_Applications_and_Widgets).）
+这个办法包含绑定一个单独的事件句柄到容器窗口组件上，运用 `aria-activedescendent` 属性来追踪一个 "虚拟" 焦点。（关于 ARIA 更多的信息，查看 [overview of accessible web applications and widgets](../../../../An_Overview_of_Accessible_Web_Applications_and_Widgets).）
 
 `aria-activedescendant` 属性用来标识拥有虚拟焦点的后代元素的 ID。在窗口容器的事件句柄里面在键盘和鼠标事件响应更新 aria-activedescendant 值并且确保当前 The event handler on the container must respond to key and mouse events by updating the value of `aria-activedescendant` and ensuring that the current item is styled appropriately (for example, with a border or background color).
 
@@ -217,4 +217,4 @@ IE 不会自动为` tabindex="-1" `的元素绘制聚焦框。可以选择一种
 
 #### 不要认为按键连发（repeat）有一致性
 
-非常不幸，`onkeydown 连发或不连发`取决于代码执行的浏览器和操作系统。
+非常不幸，`onkeydown` 连发或不连发取决于代码执行的浏览器和操作系统。

--- a/files/zh-cn/web/accessibility/keyboard-navigable_javascript_widgets/index.md
+++ b/files/zh-cn/web/accessibility/keyboard-navigable_javascript_widgets/index.md
@@ -166,7 +166,7 @@ _范例 2: 一个使用 tabindex 控制键盘 access 的菜单控件_
 
 #### 方法 2: aria-activedescendant
 
-这个办法包含绑定一个单独的事件句柄到容器窗口组件上，运用 `aria-activedescendent` 属性来追踪一个 "虚拟" 焦点。（关于 ARIA 更多的信息，查看 [overview of accessible web applications and widgets](../../../../An_Overview_of_Accessible_Web_Applications_and_Widgets).）
+这个办法包含绑定一个单独的事件句柄到容器窗口组件上，运用 `aria-activedescendent` 属性来追踪一个 "虚拟" 焦点。（关于 ARIA 更多的信息，查看[可访问的 Web 应用程序和组件概述](/zh-CN/docs/Web/Accessibility/An_overview_of_accessible_web_applications_and_widgets)。）
 
 `aria-activedescendant` 属性用来标识拥有虚拟焦点的后代元素的 ID。在窗口容器的事件句柄里面在键盘和鼠标事件响应更新 aria-activedescendant 值并且确保当前 The event handler on the container must respond to key and mouse events by updating the value of `aria-activedescendant` and ensuring that the current item is styled appropriately (for example, with a border or background color).
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

In `files/zh-cn/web/accessibility/aria/attributes/aria-labelledby/index.md` , both [`/zh-CN/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute`](https://developer.mozilla.org/zh-CN/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute) and [`/zh-CN/docs/Web/Accessibility/ARIA/Attributes/aria-describedby`](https://developer.mozilla.org/zh-CN/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) are not existing documents, so I leave the red link it there.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
