### PR TITLE
用語集 Secure Context を翻訳

### DIFF
--- a/files/ja/glossary/secure_context/index.md
+++ b/files/ja/glossary/secure_context/index.md
@@ -1,0 +1,10 @@
+---
+title: Secure Context (安全なコンテキスト)
+slug: Glossary/Secure_Context
+l10n: 
+  sourceCommit: ed947b2c608428b62a60f07d09dc543f732dc09b
+---
+
+**安全なコンテキスト**とは、認証と機密性の一定の最低基準を満たした `Window` や `Worker` のことです。多くの Web API や機能は、安全なコンテキストでのみアクセス可能です。これにより、悪意のあるコードによって悪用される可能性を減らすことができます。
+
+詳細については、[開発者向けのウェブ技術 > ウェブセキュリティ> 安全なコンテキスト](/ja/docs/Web/Security/Secure_Contexts)を参照してください。


### PR DESCRIPTION
### Description

用語集 Secure Context を翻訳しました。
確認してください。

### Motivation

### Additional details

なお、この用語集からリンクされているページでは「安全なコンテキスト」という訳と「セキュアコンテキスト」という訳が使われています。どちらかに統一した方がいいと思いますが、もしも統一してもよいなら、わたしのほうで別issueをたてて作業を行おうかと思っています。

### Related issues and pull requests

https://github.com/mozilla-japan/translation/issues/657
