### PR TITLE
fix: stuck DD characters

### DIFF
--- a/files/ko/web/html/attributes/autocomplete/index.md
+++ b/files/ko/web/html/attributes/autocomplete/index.md
@@ -175,7 +175,7 @@ translation_of: Web/HTML/Attributes/autocomplete
 - 충청남도 홍성군 홍북읍 충남대로 21
 - `address-level1`
 
-  - :&#x20;
+  - : &#x20;
 
     시/도: "서울특별시", "경기도", "충청남도"
 

--- a/files/ko/web/html/element/frame/index.md
+++ b/files/ko/web/html/element/frame/index.md
@@ -25,7 +25,7 @@ translation_of: Web/HTML/Element/frame
   - : 이 속성은 사용자가 프레임크기를 조정할수 없게합니다.
 
 - {{htmlattrdef("scrolling")}}
-  - :&#x20;
+  - : &#x20;
     이 속성은 스크롤바의 유무를 결정합니다. 이 속성을 사용하지않으면 특정상황에서 자동으로 브라우져에 스크롤바가 생깁니다.
     두가지를 선택할 수 있습니다. "yes"면 항상 스크롤바를 보여주고 "no"면 항상 스크롤바를 보여주지 않습니다.
 - {{htmlattrdef("marginheight")}}

--- a/files/ko/web/http/headers/index.md
+++ b/files/ko/web/http/headers/index.md
@@ -73,7 +73,7 @@ HTTP 클라이언트 힌트는 작업중에 있습니다. 실제 문서는 [HTTP
   - : `DPR` 요청 헤더 필드는 레이아웃 뷰포트(Section 9.1.1 of [\[CSS2\]](https://httpwg.org/http-extensions/client-hints.html#CSS2))의 CSS px(Section 5.2 of [\[CSSVAL\]](https://httpwg.org/http-extensions/client-hints.html#CSSVAL))를 통한 물리적 픽셀 비율인 클라이언트의 현재 기기 픽셀 비율(DPR)을 나타내는 숫자입니다.
 - {{HTTPHeader("Save-Data")}} {{experimental_inline}}
 
-  - :&#x20;
+  - : &#x20;
 
     <a class="internalDFN" href="https://wicg.github.io/netinfo/#dom-networkinformation-savedata"><code>SaveData</code></a>
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

These DDs with a non-breaking space don't actually exist upstream, but added the extra space for consistency, since characters stuck to the colon in DDs usually break the rendering

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
