### PR TITLE
Fix a bug in Chinese documentation about <strong> pages

### DIFF
--- a/files/zh-cn/web/html/element/strong/index.md
+++ b/files/zh-cn/web/html/element/strong/index.md
@@ -42,7 +42,7 @@ Strong 元素 (`<strong>`) 表示文本十分重要，一般用粗体显示。
 
 实现了 `HTMLElement` 接口。
 
-> **备注：** 实现注意事项**:** 一直到 Gecko 1.9.2 (含), Firefox 对这个元素实现了 [`HTMLSpanElement`](/zh-CN/docs/DOM/span) 接口
+> **备注:** 实现注意事项: 一直到 Gecko 1.9.2 (含), Firefox 对这个元素实现了 [`HTMLSpanElement`](/zh-CN/docs/Web/API/HTMLSpanElement) 接口
 
 ## 举例
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The document seems to have a slight error in the Markdown manipulation and the link does not point to the `HTMLSpanElement` correctly.

<!-- ✍️ Summarize your changes in one or two sentences -->



### Additional details
This is the address of the wrong document link：https://developer.mozilla.org/zh-CN/docs/Web/HTML/Element/strong
![image.png](https://pic1.58cdn.com.cn/nowater/webim/big/n_v26fe3abbeea55440aa9ee62c6583c05b3.png)
It's worth mentioning that your subsequent demo also has an error, but I'm not sure how this needs to be changed, maybe there is a special pointing example like you taught me when I mentioned pr before
![image.png](https://pic1.58cdn.com.cn/nowater/webim/big/n_v2ff55fb742e724825ab2614b68a2897f1.png)

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
