### PR TITLE
Remove deprecated CompatChrome macro from es

### DIFF
--- a/files/es/web/api/window/confirm/index.md
+++ b/files/es/web/api/window/confirm/index.md
@@ -34,7 +34,7 @@ The following text is shared between this article, DOM:window\.prompt and DOM:wi
 
 Los usuarios de [Mozilla Chrome](/en-US/Chrome) users (e.g. Firefox extensions) deberían usar métodos de `nsIPromptService` en vez de cajas de diálogo.
 
-A partir de la versión {{CompatChrome(46.0)}} de Chrome este método es bloqueado dentro de un {{htmlelement("iframe")}} a no ser que el atributo sandbox tenga el valor `allow-modal`.
+A partir de la versión 46.0 de Chrome este método es bloqueado dentro de un {{htmlelement("iframe")}} a no ser que el atributo sandbox tenga el valor `allow-modal`.
 
 {{gecko_minversion_inline("23.0")}} El argumento es opcional y no requerido por la especificación.
 

--- a/files/es/web/api/window/print/index.md
+++ b/files/es/web/api/window/print/index.md
@@ -29,7 +29,7 @@ window.print()
 
 ## Notas
 
-Empezando con Chrome {{CompatChrome(46.0)}} este método esta bloqueado dentro de un {{htmlelement("iframe")}} a menos que el atributo del contenedor tenga el valor `allow-modal`.
+Empezando con Chrome 46.0 este método esta bloqueado dentro de un {{htmlelement("iframe")}} a menos que el atributo del contenedor tenga el valor `allow-modal`.
 
 ## Especificación
 

--- a/files/es/web/api/window/prompt/index.md
+++ b/files/es/web/api/window/prompt/index.md
@@ -52,7 +52,7 @@ Nótese que el resultado es una cadena de texto. Esto significa que a veces se d
 
 Usuarios de [Mozilla Chrome](/en-US/Chrome) (p.ej. extensiones de Firefox) deben usar preferentemente métodos de `nsIPromptService`.
 
-A partir de Chrome {{CompatChrome(46.0)}} este método está bloqueado para los elementos {{htmlelement("iframe")}}, , a menos que su atributo [sandbox](/es/docs/Web/HTML/Elemento/iframe#attr-sandbox) tenga el valor `allow-modal`.
+A partir de Chrome 46.0 este método está bloqueado para los elementos {{htmlelement("iframe")}}, , a menos que su atributo [sandbox](/es/docs/Web/HTML/Elemento/iframe#attr-sandbox) tenga el valor `allow-modal`.
 
 En Safari, si el usuario presiona el botón Cancel, la función devuelve una cadena vacía. Por lo tanto, no se puede diferenciar si canceló o si mandó una cadena de texto vacía como valor del cuadro de texto.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove deprecated CompatChrome macro from es

Process: remove the macro and keep the inner text due to this already doesn't do anything to it

### Motivation

The chore of deprecated macros removal

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Relates to https://github.com/orgs/mdn/discussions/263
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
