### PR TITLE
docs: update korean translation of String.prototype.localeCompare

### DIFF
--- a/files/ko/web/javascript/reference/global_objects/string/localecompare/index.md
+++ b/files/ko/web/javascript/reference/global_objects/string/localecompare/index.md
@@ -13,19 +13,14 @@ translation_of: Web/JavaScript/Reference/Global_Objects/String/localeCompare
 ---
 {{JSRef}}
 
-The **`localeCompare()`** method returns a number indicating
-whether a reference string comes before, or after, or is the same as the given string in
-sort order.
+**`localeCompare()`** 메서드는 참조 문자열이 정렬 순으로 지정된 문자열 앞 혹은 뒤에 오는지 또는 동일한 문자열인지 나타내는 수치를 반환합니다.
 
 {{EmbedInteractiveExample("pages/js/string-localecompare.html")}}
 
-The new `locales` and `options` arguments
-let applications specify the language whose sort order should be used and customize the
-behavior of the function. In older implementations, which ignore the
-`locales` and `options` arguments, the
-locale and sort order used are entirely implementation-dependent.
+새로운 `locales` 인수와 `options` 인수를 사용하면 정렬에 사용될 언어를 지정하고 함수의 동작을 사용자 정의할 수 있습니다. 
+`locales`와 `options`의 인수를 무시하는 오래된 구현에서는 사용되는 locale과 정렬 순서는 완전히 구현에 의존합니다.
 
-## Syntax
+## 구문
 
 ```js
 localeCompare(compareString)
@@ -33,70 +28,58 @@ localeCompare(compareString, locales)
 localeCompare(compareString, locales, options)
 ```
 
-### Parameters
+### 매개변수
 
 - `compareString`
-  - : The string against which the `referenceStr` is compared.
-- `locales` and `options`
+  - `referenceStr`가 비교되는 문자열.
+- `locales`와 `options`
 
-  - : These arguments customize the behavior of the function and let applications specify
-    the language whose formatting conventions should be used. In implementations which
-    ignore the `locales` and
-    `options` arguments, the locale used and the form of the
-    string returned are entirely implementation-dependent.
+  - 이러한 인수는 함수의 동작을 사용자 정의하여 응용 프로그램에서 포맷 규칙을 사용할 언어를 지정합니다. 
+    `"locales"`와 `"options"`의 인자를 무시하는 구현에서는 사용되는 로케일과 반환되는 문자열의 형식은 
+    완전히 구현에 의존합니다.
+    
+    매개변수의 상세 및 사용 방법은 [`Intl.Collator()`
+    constructor](/ko/docs/Web/JavaScript/Reference/Global_Objects/Collator/Collator)를 참조하세요.
 
-    See the [`Intl.Collator()`
-    constructor](/ko/docs/Web/JavaScript/Reference/Global_Objects/Collator/Collator) for details on these parameters and how to use them.
+### 반환 값
 
-### Return value
+`compareString` 전에 `referenceStr`가 위치하는 경우 **음수**, `compareString` 후에 `referenceStr`가 위치하는 경우 **양수**, 동등할 경우 `0`이 됩니다.
+## 설명
 
-A **negative** number if `referenceStr` occurs
-before `compareString`; **positive** if the
-`referenceStr` occurs after `compareString`;
-`0` if they are equivalent.
+`referenceStr`가 `compareString` 전 혹은 뒤에 오는지 또는 동등한지를 나타내는 정수를 반환합니다.
 
-## Description
+- `compareString` 전에 `referenceStr`이 오면 음수
+- `compareString` 뒤에 `referenceStr`이 오면 양수
+- 동등한 경우 `0` 을 반환합니다.
 
-Returns an integer indicating whether the `referenceStr` comes
-before, after or is equivalent to the `compareString`.
-
-- Negative when the `referenceStr` occurs before
-  `compareString`
-- Positive when the `referenceStr` occurs after
-  `compareString`
-- Returns `0` if they are equivalent
-
-> **Warning:** Do not rely on exact return values of `-1` or `1`!
+> **주의:** `-1` 또는 `1`의 정확한 반환 값에 의존하지 마세요.
 >
-> Negative and positive integer results vary between browsers (as well as between
-> browser versions) because the W3C specification only mandates negative and positive
-> values. Some browsers may return `-2` or `2`, or even some other
-> negative or positive value.
+> 음의 정수와 양의 정수의 결과는 브라우저마다(브라우저 버전에 따라서도) 다릅니다.이는 W3C 사양에서는 음의 값과 양의 값만 필요하기 때문입니다. 
+> 브라우저에 따라서는, `-2`나 `2`를 반환하거나, 그 외의 음의 값이나 양의 값을 반환할 수도 있습니다.
 
-## Performance
+## 성능
 
-When comparing large numbers of strings, such as in sorting large arrays, it is better
-to create an {{jsxref("Global_Objects/Collator", "Intl.Collator")}} object and use the
-function provided by its {{jsxref("Collator.prototype.compare", "compare")}} property.
+큰 배열의 정렬과 같이 대량의 문자열을 비교하는 경우, {{jsxref("Global_Objects/Collator", "Intl.Collator")}} 객체를 작성하고 
+해당 {{jsxref("Collator.prototype.compare", "compare")}} 프로퍼티가 제공하는 함수를 사용하는 것이 좋습니다.
 
-## Examples
+## 예시
 
-### Using `localeCompare()`
+### `localeCompare()` 사용
 
 ```js
-// The letter "a" is before "c" yielding a negative value
-'a'.localeCompare('c'); // -2 or -1 (or some other negative value)
+// "a"는 "c" 전에 위치하므로 음수 값을 반환
+'a'.localeCompare('c'); // -2 혹은 -1 (또는 다른 음수 값)
 
-// Alphabetically the word "check" comes after "against" yielding a positive value
-'check'.localeCompare('against'); // 2 or 1 (or some other positive value)
+// 알파벳 순으로 단어 "check"는 "against"보다 뒤에 위치하므로 양수 값을 반환
+'check'.localeCompare('against'); // 2 혹은 1 (또는 다른 양수 값)
 
-// "a" and "a" are equivalent yielding a neutral value of zero
+// "a"와 "a"는 서로 동등하므로 중립 값 0을 반환
 'a'.localeCompare('a'); // 0
 ```
 
-### Sort an array
+### 배열 정렬
 
-`localeCompare()` enables case-insensitive sorting for an array.
+`localeCompare()`을 사용해 대소문자를 구분하지 않는 배열 정렬을 할 수 있습니다.
 
 ```js
 let items = ['réservé', 'Premier', 'Cliché', 'communiqué', 'café', 'Adieu'];
@@ -104,14 +87,11 @@ items.sort( (a, b) => a.localeCompare(b, 'fr', {ignorePunctuation: true}));
 // ['Adieu', 'café', 'Cliché', 'communiqué', 'Premier', 'réservé']
 ```
 
-### Check browser support for extended arguments
+### 확장인수 브라우저 지원 확인
 
-The `locales` and `options` arguments are
-not supported in all browsers yet.
+`locales`와 `options` 인자는 일부 브라우저에서 아직 지원되지 않습니다.
 
-To check whether an implementation supports them, use the `"i"` argument (a
-requirement that illegal language tags are rejected) and look for a
-{{jsxref("RangeError")}} exception:
+구현이 지원되는지 확인하려면 `"i"` 인수(잘못된 언어(illegal language) 태그가 제외되는 요건)을 사용해 {{jsxref("RangeError")}} 예외를 찾습니다.
 
 ```js
 function localeCompareSupportsLocales() {
@@ -124,52 +104,49 @@ function localeCompareSupportsLocales() {
 }
 ```
 
-### Using `locales`
+### `locales` 사용
 
-The results provided by `localeCompare()` vary between languages. In order
-to get the sort order of the language used in the user interface of your application,
-make sure to specify that language (and possibly some fallback languages) using the
-`locales` argument:
+`localeCompare()` 결과는 언어에 따라 달라집니다. 
+응용 프로그램의 사용자 인터페이스에서 사용되는 언어의 정렬 순서를 얻으려면 반드시 `locales` 인자를 사용하여 해당 언어(및 폴백 언어의 일부)를 지정하세요.
 
 ```js
-console.log('ä'.localeCompare('z', 'de')); // a negative value: in German, ä sorts before z
-console.log('ä'.localeCompare('z', 'sv')); // a positive value: in Swedish, ä sorts after z
+console.log('ä'.localeCompare('z', 'de')); // 음수: 독일어는 ä가 z 전에 위치
+console.log('ä'.localeCompare('z', 'sv')); // 양수: 스웨덴어는 ä가 z 뒤에 위치
 ```
 
-### Using `options`
+### `options` 사용
 
-The results provided by `localeCompare()` can be customized using the
-`options` argument:
+`localeCompare()`이 제공하는 결과는 `options` 인자를 사용해 사용자 정의할 수 있습니다.
 
 ```js
-// in German, ä has a as the base letter
+// 독일어에선 ä는 a를 기본 문자(base letter)로 가집니다.
 console.log('ä'.localeCompare('a', 'de', { sensitivity: 'base' })); // 0
 
-// in Swedish, ä and a are separate base letters
-console.log('ä'.localeCompare('a', 'sv', { sensitivity: 'base' })); // a positive value
+// 스웨덴어에선 ä와 a는 별도의 기본 문자입니다.
+console.log('ä'.localeCompare('a', 'sv', { sensitivity: 'base' })); // 양수
 ```
 
-### Numeric sorting
+### 숫자 정렬
 
 ```js
-// by default, "2" > "10"
+// 기본적으로 "2" > "10"
 console.log("2".localeCompare("10")); // 1
 
-// numeric using options:
+// numeric 옵션 사용
 console.log("2".localeCompare("10", undefined, {numeric: true})); // -1
 
-// numeric using locales tag:
+// locales tag 사용
 console.log("2".localeCompare("10", "en-u-kn-true")); // -1
 ```
 
-## Specifications
+## 명세
 
 {{Specifications}}
 
-## Browser compatibility
+## 브라우저 호환성
 
 {{Compat}}
 
-## See also
+## 같이 보기
 
 - {{jsxref("Global_Objects/Collator", "Intl.Collator")}}


### PR DESCRIPTION
https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare

I translated the docs of localeCompare into Korean.  😉
해당 페이지의 한국어 문서가 아직 번역되지 않아 번역하였습니다. 😊

확인 부탁드립니다!
