### PR TITLE
Korean Translation: web/css/display

### DIFF
--- a/files/ko/web/css/display/index.md
+++ b/files/ko/web/css/display/index.md
@@ -147,10 +147,7 @@ with {{CSSxRef("list-style-type")}} and {{CSSxRef("list-style-position")}}.
         readers will not look at what's inside. See the
         [Accessibility concerns](#accessibility_concerns) section below for more details._
     - `none`
-      - : Turns off the display of an element so that it has no effect on layout (the document is rendered as though the
-        element did not exist). All descendant elements also have their display turned off. To have an element take up
-        the space that it would normally take, but without actually rendering anything, use the
-        {{CSSxRef("visibility")}} property instead.
+      - : 레이아웃에 영향을 주지 않도록 요소의 display를 끄게 합니다(웹문서는 마치 해당 요소가 존재하지 않는 것처럼 렌더링되어집니다). 모든 하위 요소들 또한 display를 끄게 합니다. 요소가 정상적으로 본연의 공간을 가지고 있게 하면서 해당 공간에 아무것도 렌더링되지 않게 하려면, {{CSSxRef("visibility")}} 속성으로 대체하여 사용하시기 바랍니다.
 
 ### 레거시
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The "none" part of the "box" keyword of the CSS display property has been translated into Korean.
(https://developer.mozilla.org/en-US/docs/Web/CSS/display#box)

- Before translation (en-US version)

>Turns off the display of an element so that it has no effect on layout (the document is rendered as though the element did not exist). All descendant elements also have their display turned off. To have an element take up the space that it would normally take, but without actually rendering anything, use the [visibility](https://developer.mozilla.org/en-US/docs/Web/CSS/visibility) property instead.

- After translation (ko-KR version)

>레이아웃에 영향을 주지 않도록 요소의 display를 끄게 합니다(웹문서는 마치 해당 요소가 존재하지 않는 것처럼 렌더링되어집니다). 모든 하위 요소들 또한 display를 끄게 합니다. 요소가 정상적으로 본연의 공간을 가지고 있게 하면서 해당 공간에 아무것도 렌더링되지 않게 하려면, [visibility](http://localhost:5042/ko/docs/Web/CSS/visibility) 속성으로 대체하여 사용하시기 바랍니다.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

This translation was made to ensure that native Korean developers (or learners) who have difficulty reading English will not have linguistic difficulties in using and understanding CSS properties.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details



<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
