### PR TITLE
chore: remove {{warning}} macro from l10n-es

### DIFF
--- a/files/es/web/css/box-flex/index.md
+++ b/files/es/web/css/box-flex/index.md
@@ -8,7 +8,9 @@ tags:
 translation_of: Web/CSS/box-flex
 original_slug: Web/CSS/-moz-box-flex
 ---
-{{CSSRef}}{{warning("Esta propiedad es para controlar parte del modelo de caja XUL. No coincide ni con el antiguo borrador del módulo CSS para el diseño de caja flexibles  '<code>box-flex</code>' (que se basa en esta propiedad) ni con el comportamiento de '<code>-webkit-box-flex</code>' (que se basa en esos borradores).")}}
+{{CSSRef}}
+
+> **Advertencia:** Esta propiedad es para controlar parte del modelo de caja XUL. No coincide ni con el antiguo borrador del módulo CSS para el diseño de caja flexibles  '`box-flex`' (que se basa en esta propiedad) ni con el comportamiento de '`-webkit-box-flex`' (que se basa en esos borradores).
 
 Ver [Flexbox](/es/docs/Web/CSS/CSS_Flexible_Box_Layout/Using_CSS_flexible_boxes) para más información acerca de qué usar en vez de esta propiedad.
 

--- a/files/es/web/css/box-ordinal-group/index.md
+++ b/files/es/web/css/box-ordinal-group/index.md
@@ -12,7 +12,8 @@ translation_of_original: Web/CSS/-moz-box-ordinal-group
 original_slug: Web/CSS/-moz-box-ordinal-group
 ---
 {{CSSRef}}
-{{warning("Esta propiedad pertenece al borrador original del diseño o esquema de la caja CSS flexible, y ha sido reemplazada en borradores posteriores.")}}
+
+> **Advertencia:** Esta propiedad pertenece al borrador original del diseño o esquema de la caja CSS flexible, y ha sido reemplazada en borradores posteriores.
 
 Ver [Flexbox](/es/docs/Web/CSS/CSS_Flexible_Box_Layout/Using_CSS_flexible_boxes) para más información sobre qué usar en sustitución de esta propiedad.
 

--- a/files/es/web/css/box-pack/index.md
+++ b/files/es/web/css/box-pack/index.md
@@ -10,7 +10,9 @@ tags:
 translation_of: Web/CSS/box-pack
 original_slug: Web/CSS/-moz-box-pack
 ---
-{{CSSRef}}{{warning("Esta propiedad es parte del módulo estándar original para el diseño de las cajas CSS Flexible que fue sustituida por un nuevo estándar.")}}
+{{CSSRef}}
+
+> **Advertencia:** Esta propiedad es parte del módulo estándar original para el diseño de las cajas CSS Flexible que fue sustituida por un nuevo estándar.
 
 Ver [Flexbox](/es/docs/Web/CSS/CSS_Flexible_Box_Layout/Using_CSS_flexible_boxes) para más información.
 


### PR DESCRIPTION
### Description

chore: remove {{warning}} macro from l10n-es

### Related issues and pull requests

Part of #8108.
