### PR TITLE
Elimina Obsolete_Header macro [es]

### DIFF
--- a/files/es/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
@@ -164,8 +164,6 @@ Estas plantillas tienen la misma semántica que sus contrapartes en línea descr
 - {{TemplateLink("SeeCompatTable")}} se debe usar en páginas que documentan [características experimentales](/es/docs/MDN/Contribute/Guidelines/Conventions_definitions#Experimental). Ejemplo: `\{{SeeCompatTable}}` {{SeeCompatTable}}
 - {{TemplateLink("Deprecated_Header")}}: `\{{Deprecated_Header}}` {{Deprecated_Header}}
 - {{TemplateLink("Deprecated_Header")}} con parámetro: `\{{Deprecated_Header("gecko5")}}` {{Deprecated_Header("gecko5")}} No utilices el parámetro en ninguna área de diagnóstico del navegador (HTML, APIs, JS, CSS, …).
-- {{TemplateLink("Obsolete_Header")}}: `\{{Obsolete_Header}}` {{Obsolete_Header}}
-- {{TemplateLink("Obsolete_Header")}} con parámetro: `\{{Obsolete_Header("gecko30")}}` {{Obsolete_Header("gecko30")}} No utilice el parámetro en ninguna área de diagnóstico del navegador (HTML, APIs, JS, CSS, …).
 - {{TemplateLink("secureContext_header")}}: `\{{SecureContext_Header}}` {{SecureContext_Header}}
 
 ### Indica que una función está disponible en `workers` web


### PR DESCRIPTION
### Description
Elimina la macro `Obsolete_Header`

Obsolete_Header esta reportado en 11 archivos pero solo encontre 6 coincidencias en 1 archivo.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Fix https://github.com/mdn/translated-content/issues/9596

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Fixes #9596
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
