### PR TITLE
chore: remove {{event}} macro from zh-CN (Part 2)

### DIFF
--- a/files/zh-cn/web/api/event/preventdefault/index.md
+++ b/files/zh-cn/web/api/event/preventdefault/index.md
@@ -90,7 +90,7 @@ document.querySelector("#id-checkbox").addEventListener("click", function(event)
 
 #### JavaScript
 
-这里是相关的 JavaScript 代码。首先，监听{{event("keypress")}}事件：
+这里是相关的 JavaScript 代码。首先，监听[`keypress`](/zh-CN/docs/Web/API/Element/keypress_event)事件：
 
 ```js
 var myTextbox = document.getElementById('my-textbox');

--- a/files/zh-cn/web/api/eventsource/error_event/index.md
+++ b/files/zh-cn/web/api/eventsource/error_event/index.md
@@ -5,7 +5,7 @@ slug: Web/API/EventSource/error_event
 
 {{APIRef('WebSockets API')}}
 
-{{domxref("EventSource")}} 的属性 **`onerror`** 是当发生错误且这个错误事件（{{event("error")}} ）被 EventSource 触发时调用的一个事件处理函数（{{event("Event_handlers", "event handler")}}）
+{{domxref("EventSource")}} 的属性 **`onerror`** 是当发生错误且这个错误事件（[`error`](/zh-CN/docs/Web/API/Element/error_event) ）被 EventSource 触发时调用的一个事件处理函数（{{event("Event_handlers", "event handler")}}）
 
 ## 语法
 

--- a/files/zh-cn/web/api/eventsource/index.md
+++ b/files/zh-cn/web/api/eventsource/index.md
@@ -21,7 +21,7 @@ slug: Web/API/EventSource
 _此接口从其父接口 {{domxref("EventTarget")}} 继承属性。_
 
 - {{domxref("EventSource.onerror")}}
-  - : 是一个 {{event("Event_handlers", "event handler")}}，当发生错误时被调用，并且在此对象上派发 {{event("error")}} 事件。
+  - : 是一个 {{event("Event_handlers", "event handler")}}，当发生错误时被调用，并且在此对象上派发 [`error`](/zh-CN/docs/Web/API/Element/error_event) 事件。
 - {{domxref("EventSource.onmessage")}}
   - : 是一个 {{event("Event_handlers", "event handler")}}，当收到一个 {{event("message")}} 事件，即消息来自源头时被调用。
 - {{domxref("EventSource.onopen")}}

--- a/files/zh-cn/web/api/file/webkitrelativepath/index.md
+++ b/files/zh-cn/web/api/file/webkitrelativepath/index.md
@@ -19,7 +19,7 @@ slug: Web/API/File/webkitRelativePath
 
 ## 示例
 
-这个示例展示了目录选择器，它让用户选择一个或多个目录。{{event("change")}} 事件触发时，所选目录包含的所有文件的列表，会生成并展示，带有所选目录的层次结构。
+这个示例展示了目录选择器，它让用户选择一个或多个目录。[`change`](/zh-CN/docs/Web/API/HTMLElement/change_event) 事件触发时，所选目录包含的所有文件的列表，会生成并展示，带有所选目录的层次结构。
 
 ### HTML 内容
 

--- a/files/zh-cn/web/api/file_and_directory_entries_api/index.md
+++ b/files/zh-cn/web/api/file_and_directory_entries_api/index.md
@@ -11,7 +11,7 @@ slug: Web/API/File_and_Directory_Entries_API
 
 有两种方法可以访问当前规范草案中定义的文件系统：
 
-- 当处理用于拖放的 {{event("drop")}} 事件时，你可以调用 {{domxref("DataTransferItem.webkitGetAsEntry()")}} 来为被放置（dropped）的项获取 {{domxref("FileSystemEntry")}}。如果结果不是 `null`，那么它就是一个被放置的文件或目录，你可以使用文件系统调用来处理它。
+- 当处理用于拖放的 [`drop`](/zh-CN/docs/Web/API/HTMLElement/drop_event) 事件时，你可以调用 {{domxref("DataTransferItem.webkitGetAsEntry()")}} 来为被放置（dropped）的项获取 {{domxref("FileSystemEntry")}}。如果结果不是 `null`，那么它就是一个被放置的文件或目录，你可以使用文件系统调用来处理它。
 - {{domxref("HTMLInputElement.webkitEntries")}} 属性允许你访问当前选定文件的 {{domxref("FileSystemFileEntry")}} 对象，但前提是将它们拖放到文件选择器（{{bug(1326031)}}）。如果 {{domxref("HTMLInputElement.webkitdirectory")}} 为真，则 {{HTMLElement("input")}} 元素是一个目录选择器，你将得到表示每个选择的目录的 {{domxref("FileSystemDirectoryEntry")}} 对象。
 
 ## 接口

--- a/files/zh-cn/web/api/file_api/using_files_from_web_applications/index.md
+++ b/files/zh-cn/web/api/file_api/using_files_from_web_applications/index.md
@@ -205,7 +205,7 @@ dropbox.addEventListener("dragover", dragover, false);
 dropbox.addEventListener("drop", drop, false);
 ```
 
-在这个例子中，我们将 ID 为`dropbox`的元素变为了我们的 drop 区域。这是通过给元素添加{{event('dragenter')}}, {{event('dragover')}}, 和{{event('drop')}} 事件监听器实现的。
+在这个例子中，我们将 ID 为`dropbox`的元素变为了我们的 drop 区域。这是通过给元素添加[`dragenter`](/zh-CN/docs/Web/API/HTMLElement/dragenter_event), [`dragover`](/zh-CN/docs/Web/API/HTMLElement/dragover_event), 和[`drop`](/zh-CN/docs/Web/API/HTMLElement/drop_event) 事件监听器实现的。
 
 我们其实并不需要对`dragenter` and `dragover` 事件进行处理，所以这些函数都很简单。他们只需要包括禁止事件传播和阻止默认事件：
 

--- a/files/zh-cn/web/api/filereader/index.md
+++ b/files/zh-cn/web/api/filereader/index.md
@@ -40,17 +40,17 @@ slug: Web/API/FileReader
 ### 事件处理
 
 - {{domxref("FileReader.onabort")}}
-  - : 处理{{event("abort")}}事件。该事件在读取操作被中断时触发。
+  - : 处理[`abort`](/zh-CN/docs/Web/API/HTMLMediaElement/abort_event)事件。该事件在读取操作被中断时触发。
 - {{domxref("FileReader.onerror")}}
-  - : 处理{{event("error")}}事件。该事件在读取操作发生错误时触发。
+  - : 处理[`error`](/zh-CN/docs/Web/API/Element/error_event)事件。该事件在读取操作发生错误时触发。
 - {{domxref("FileReader.onload")}}
-  - : 处理{{event("load")}}事件。该事件在读取操作完成时触发。
+  - : 处理[`load`](/zh-CN/docs/Web/API/Window/load_event)事件。该事件在读取操作完成时触发。
 - {{domxref("FileReader.onloadstart")}}
-  - : 处理{{event("loadstart")}}事件。该事件在读取操作开始时触发。
+  - : 处理[`loadstart`](/zh-CN/docs/Web/API/XMLHttpRequest/loadstart_event)事件。该事件在读取操作开始时触发。
 - {{domxref("FileReader.onloadend")}}
-  - : 处理{{event("loadend")}}事件。该事件在读取操作结束时（要么成功，要么失败）触发。
+  - : 处理[`loadend`](/zh-CN/docs/Web/API/XMLHttpRequest/loadend_event)事件。该事件在读取操作结束时（要么成功，要么失败）触发。
 - {{domxref("FileReader.onprogress")}}
-  - : 处理{{event("progress")}}事件。该事件在读取{{domxref("Blob")}}时触发。
+  - : 处理[`progress`](/zh-CN/docs/Web/API/XMLHttpRequest/progress_event)事件。该事件在读取{{domxref("Blob")}}时触发。
 
 > **备注：** 因为 `FileReader` 继承自{{domxref("EventTarget")}}，所以所有这些事件也可以通过{{domxref("EventTarget.addEventListener()","addEventListener")}}方法使用。
 

--- a/files/zh-cn/web/api/filereader/readasarraybuffer/index.md
+++ b/files/zh-cn/web/api/filereader/readasarraybuffer/index.md
@@ -5,7 +5,7 @@ slug: Web/API/FileReader/readAsArrayBuffer
 
 {{APIRef("File API")}}
 
-{{domxref("FileReader")}} 接口提供的 **`readAsArrayBuffer()`** 方法用于启动读取指定的 {{domxref("Blob")}} 或 {{domxref("File")}} 内容。当读取操作完成时，{{domxref("FileReader.readyState","readyState")}} 变成 `DONE`（已完成），并触发 {{event("loadend")}} 事件，同时 {{domxref("FileReader.result","result")}} 属性中将包含一个 {{domxref("ArrayBuffer")}} 对象以表示所读取文件的数据。
+{{domxref("FileReader")}} 接口提供的 **`readAsArrayBuffer()`** 方法用于启动读取指定的 {{domxref("Blob")}} 或 {{domxref("File")}} 内容。当读取操作完成时，{{domxref("FileReader.readyState","readyState")}} 变成 `DONE`（已完成），并触发 [`loadend`](/zh-CN/docs/Web/API/XMLHttpRequest/loadend_event) 事件，同时 {{domxref("FileReader.result","result")}} 属性中将包含一个 {{domxref("ArrayBuffer")}} 对象以表示所读取文件的数据。
 
 ## 语法
 

--- a/files/zh-cn/web/api/filereader/readasbinarystring/index.md
+++ b/files/zh-cn/web/api/filereader/readasbinarystring/index.md
@@ -5,7 +5,7 @@ slug: Web/API/FileReader/readAsBinaryString
 
 {{APIRef("File API")}} {{non-standard_header}}
 
-`readAsBinaryString` 方法会读取指定的 {{domxref("Blob")}} 或 {{domxref("File")}} 对象，当读取完成的时候，{{domxref("FileReader.readyState","readyState")}} 会变成`DONE`（已完成），并触发 {{event("loadend")}} 事件，同时 {{domxref("FileReader.result","result")}} 属性将包含所读取文件原始二进制格式。
+`readAsBinaryString` 方法会读取指定的 {{domxref("Blob")}} 或 {{domxref("File")}} 对象，当读取完成的时候，{{domxref("FileReader.readyState","readyState")}} 会变成`DONE`（已完成），并触发 [`loadend`](/zh-CN/docs/Web/API/XMLHttpRequest/loadend_event) 事件，同时 {{domxref("FileReader.result","result")}} 属性将包含所读取文件原始二进制格式。
 
 注意：从 2012 年 7 月 12 日起，该方法已从 W3C 工作草案废除。
 

--- a/files/zh-cn/web/api/filereader/readasdataurl/index.md
+++ b/files/zh-cn/web/api/filereader/readasdataurl/index.md
@@ -5,7 +5,7 @@ slug: Web/API/FileReader/readAsDataURL
 
 {{APIRef("File API")}}
 
-`readAsDataURL` 方法会读取指定的 {{domxref("Blob")}} 或 {{domxref("File")}} 对象。读取操作完成的时候，{{domxref("FileReader.readyState","readyState")}} 会变成已完成`DONE`，并触发 {{event("loadend")}} 事件，同时 {{domxref("FileReader.result","result")}} 属性将包含一个`data:`URL 格式的字符串（base64 编码）以表示所读取文件的内容。
+`readAsDataURL` 方法会读取指定的 {{domxref("Blob")}} 或 {{domxref("File")}} 对象。读取操作完成的时候，{{domxref("FileReader.readyState","readyState")}} 会变成已完成`DONE`，并触发 [`loadend`](/zh-CN/docs/Web/API/XMLHttpRequest/loadend_event) 事件，同时 {{domxref("FileReader.result","result")}} 属性将包含一个`data:`URL 格式的字符串（base64 编码）以表示所读取文件的内容。
 
 ## 语法
 

--- a/files/zh-cn/web/api/filesystemfileentry/index.md
+++ b/files/zh-cn/web/api/filesystemfileentry/index.md
@@ -29,7 +29,7 @@ slug: Web/API/FileSystemFileEntry
 
 ### 示例
 
-下面的代码创建了一个空文件，叫做 "`log.txt"` （如果不存在的话），并使用文本 "Meow" 来填充。在成功的回调中，设置了事件处理器，来处理 {{event("error")}} `error` 和 {{event("writeend")}} 事件。通过创建 blob，向其追加文本，以及将 blob 传递给 {{domxref("FileWriter.write()")}}，文本数据写入了文件。
+下面的代码创建了一个空文件，叫做 "`log.txt"` （如果不存在的话），并使用文本 "Meow" 来填充。在成功的回调中，设置了事件处理器，来处理 [`error`](/zh-CN/docs/Web/API/Element/error_event) `error` 和 {{event("writeend")}} 事件。通过创建 blob，向其追加文本，以及将 blob 传递给 {{domxref("FileWriter.write()")}}，文本数据写入了文件。
 
 ```js
 function onInitFs(fs) {

--- a/files/zh-cn/web/api/focusevent/index.md
+++ b/files/zh-cn/web/api/focusevent/index.md
@@ -5,7 +5,7 @@ slug: Web/API/FocusEvent
 
 {{APIRef("DOM Events")}}
 
-**`FocusEvent`** 接口表示和焦点相关的事件比如 {{event("focus")}}, {{event("blur")}}, {{event("focusin")}}, 和 {{event("focusout")}}。
+**`FocusEvent`** 接口表示和焦点相关的事件比如 [`focus`](/zh-CN/docs/Web/API/Element/focus_event), [`blur`](/zh-CN/docs/Web/API/Element/blur_event), [`focusin`](/zh-CN/docs/Web/API/Element/focusin_event), 和 [`focusout`](/zh-CN/docs/Web/API/Element/focusout_event)。
 
 {{InheritanceDiagram}}
 

--- a/files/zh-cn/web/api/force_touch_events/index.md
+++ b/files/zh-cn/web/api/force_touch_events/index.md
@@ -12,17 +12,17 @@ slug: Web/API/Force_Touch_events
 ## Events
 
 - {{event("webkitmouseforcewillbegin")}} {{non-standard_inline}}
-  - : This event is fired before the {{event("mousedown")}} event. Its main use is that it can be {{domxref("Event.preventDefault()")}}ed.
+  - : This event is fired before the [`mousedown`](/zh-CN/docs/Web/API/Element/mousedown_event) event. Its main use is that it can be {{domxref("Event.preventDefault()")}}ed.
 - {{event("webkitmouseforcedown")}} {{non-standard_inline}}
-  - : This event is fired after the {{event("mousedown")}} event as soon as sufficient pressure has been applied for it to qualify as a "force click".
+  - : This event is fired after the [`mousedown`](/zh-CN/docs/Web/API/Element/mousedown_event) event as soon as sufficient pressure has been applied for it to qualify as a "force click".
 - {{event("webkitmouseforceup")}} {{non-standard_inline}}
   - : This event is fired after the {{event("webkitmouseforcedown")}} event as soon as the pressure has been reduced sufficiently to end the "force click".
 - {{event("webkitmouseforcechanged")}} {{non-standard_inline}}
-  - : This event is fired each time the amount of pressure changes. This event first fires after the {{event("mousedown")}} event and stops firing before the {{event("mouseup")}} event.
+  - : This event is fired each time the amount of pressure changes. This event first fires after the [`mousedown`](/zh-CN/docs/Web/API/Element/mousedown_event) event and stops firing before the [`mouseup`](/zh-CN/docs/Web/API/Element/mouseup_event) event.
 
 ## Event properties
 
-The following property is known to be available on the {{event("webkitmouseforcewillbegin")}}, {{event("mousedown")}}, {{event("webkitmouseforcechanged")}}, {{event("webkitmouseforcedown")}}, {{event("webkitmouseforceup")}}, {{event("mousemove")}}, and {{event("mouseup")}} event objects:
+The following property is known to be available on the {{event("webkitmouseforcewillbegin")}}, [`mousedown`](/zh-CN/docs/Web/API/Element/mousedown_event), {{event("webkitmouseforcechanged")}}, {{event("webkitmouseforcedown")}}, {{event("webkitmouseforceup")}}, [`mousemove`](/zh-CN/docs/Web/API/Element/mousemove_event), and [`mouseup`](/zh-CN/docs/Web/API/Element/mouseup_event) event objects:
 
 - {{domxref("MouseEvent.webkitForce")}} {{non-standard_inline()}} {{readonlyinline}}
   - : 当前施加于触控板/触摸屏的压力量

--- a/files/zh-cn/web/api/fullscreen_api/guide/index.md
+++ b/files/zh-cn/web/api/fullscreen_api/guide/index.md
@@ -46,7 +46,7 @@ if (elem.requestFullscreen) {
 
 ### 通知
 
-当成功进入全屏模式时，包含该元素的文档会收到一个 {{Event("fullscreenchange")}} 事件。当退出全屏模式时，文档会再一次收到 {{Event("fullscreenchange")}} 事件。注意此 {{Event("fullscreenchange")}} 事件，不管在文档进入和退出全屏模式时，都不会提供任何信息，但如果文档的 {{DOMxRef("document.fullscreenElement", "fullscreenElement")}} 为非空（`null`），即处于全屏模式中。
+当成功进入全屏模式时，包含该元素的文档会收到一个 [`fullscreenchange`](/zh-CN/docs/Web/API/Document/fullscreenchange_event) 事件。当退出全屏模式时，文档会再一次收到 [`fullscreenchange`](/zh-CN/docs/Web/API/Document/fullscreenchange_event) 事件。注意此 [`fullscreenchange`](/zh-CN/docs/Web/API/Document/fullscreenchange_event) 事件，不管在文档进入和退出全屏模式时，都不会提供任何信息，但如果文档的 {{DOMxRef("document.fullscreenElement", "fullscreenElement")}} 为非空（`null`），即处于全屏模式中。
 
 ### 当全屏请求失败时
 

--- a/files/zh-cn/web/api/fullscreen_api/index.md
+++ b/files/zh-cn/web/api/fullscreen_api/index.md
@@ -43,21 +43,21 @@ _{{DOMxRef("Document")}} 提供了可以用于判断是否支持和启用全屏�
 
 Fullscreen API 定义了两个事件，可用于检测全屏模式的打开和关闭，以及在全屏和窗口模式之间切换过程中发生的错误。_{{DOMxRef("Document")}}_ 和 _{{DOMxRef("Element")}}_ 接口提供了这些事件的事件处理函数。
 
-> **备注：** 这些事件处理函数特性不可以当成 HTML 内容属性来使用。换句话说，你无法在 HTML 内容中为 {{Event("fullscreenchange")}} 和 {{Event("fullscreenerror")}} 指定事件处理程序，你必须通过 JavaScript 代码添加它们。
+> **备注：** 这些事件处理函数特性不可以当成 HTML 内容属性来使用。换句话说，你无法在 HTML 内容中为 [`fullscreenchange`](/zh-CN/docs/Web/API/Document/fullscreenchange_event) 和 [`fullscreenerror`](/zh-CN/docs/Web/API/Document/fullscreenerror_event) 指定事件处理程序，你必须通过 JavaScript 代码添加它们。
 
 #### Document 上的事件处理程序
 
 - {{DOMxRef("Document.onfullscreenchange")}}
-  - : {{Event("fullscreenchange")}} 事件的处理程序，当进入全屏或退出全屏时，事件将被发送到{{DOMxRef("Document")}}上。此处理程序仅在整个文档全屏模式更改时有效。
+  - : [`fullscreenchange`](/zh-CN/docs/Web/API/Document/fullscreenchange_event) 事件的处理程序，当进入全屏或退出全屏时，事件将被发送到{{DOMxRef("Document")}}上。此处理程序仅在整个文档全屏模式更改时有效。
 - {{DOMxRef("Document.onfullscreenerror")}}
-  - : {{Event("fullscreenerror")}} 事件的处理程序，当进入全屏或退出全屏出错时，事件将被发送到 {{DOMxRef("Document")}} 上，仅对整个文档的全屏模式更改出错时候有效。
+  - : [`fullscreenerror`](/zh-CN/docs/Web/API/Document/fullscreenerror_event) 事件的处理程序，当进入全屏或退出全屏出错时，事件将被发送到 {{DOMxRef("Document")}} 上，仅对整个文档的全屏模式更改出错时候有效。
 
 #### Element 上的事件处理程序
 
 - {{DOMxRef("Element.onfullscreenchange")}}
   - : 当全屏事件发生时，该事件会被发送到该元素，表明该元素进入或退出全屏模式
 - {{DOMxRef("Element.onfullscreenerror")}}
-  - : {{Event("fullscreenerror")}} 事件的处理程序，当指定的 {{DOMxRef("Element")}} 改变全屏模式时候出现错误，该事件将被发送到指定的 {{DOMxRef("Element")}} 上。
+  - : [`fullscreenerror`](/zh-CN/docs/Web/API/Document/fullscreenerror_event) 事件的处理程序，当指定的 {{DOMxRef("Element")}} 改变全屏模式时候出现错误，该事件将被发送到指定的 {{DOMxRef("Element")}} 上。
 
 ### 废弃属性
 
@@ -71,9 +71,9 @@ Fullscreen API 定义了两个事件，可用于检测全屏模式的打开和�
 
 全屏 API 定义了两个事件：1.可用来检测全屏模式何时打开和关闭。2.在全屏模式和窗口模式之间切换过程中何时发生错误。
 
-- {{Event("fullscreenchange")}}
+- [`fullscreenchange`](/zh-CN/docs/Web/API/Document/fullscreenchange_event)
   - : 当全屏或退出全屏时发送消息给（监听的）的 {{DOMxRef("Document")}} 或 {{DOMxRef("Element")}} 。
-- {{Event("fullscreenerror")}}
+- [`fullscreenerror`](/zh-CN/docs/Web/API/Document/fullscreenerror_event)
   - : 当全屏或退出全屏是发生了错误时，将错误消息发送给（监听的）的 {{DOMxRef("Document")}} 或 {{DOMxRef("Element")}} 。
 
 ## Dictionaries

--- a/files/zh-cn/web/api/gamepad/index.md
+++ b/files/zh-cn/web/api/gamepad/index.md
@@ -7,7 +7,7 @@ slug: Web/API/Gamepad
 
 [Gamepad API](/zh-CN/docs/Web/API/Gamepad_API) 的 `Gamepad` 接口，定义了一个独立的游戏手柄或其他控制器，允许访问控制器的信息，譬如按钮按下的状态、坐标输入的位置。游戏手柄或其他控制器，允许访问如按钮按下，和 ID 等信息。
 
-Gamepad 对象有两种方式返回值：通过 {{event("gamepadconnected")}} 和 {{event("gamepaddisconnected")}} 事件的 `gamepad` 属性，或者在任意位置抓取 {{domxref("Navigator.getGamepads()")}} 方法返回的数组。
+Gamepad 对象有两种方式返回值：通过 [`gamepadconnected`](/zh-CN/docs/Web/API/Window/gamepadconnected_event) 和 [`gamepaddisconnected`](/zh-CN/docs/Web/API/Window/gamepaddisconnected_event) 事件的 `gamepad` 属性，或者在任意位置抓取 {{domxref("Navigator.getGamepads()")}} 方法返回的数组。
 
 ## 属性
 

--- a/files/zh-cn/web/api/gamepad_api/index.md
+++ b/files/zh-cn/web/api/gamepad_api/index.md
@@ -35,9 +35,9 @@ slug: Web/API/Gamepad_API
 #### Window 事件
 
 - {{domxref("Window.ongamepadconnected")}}
-  - : 表示当控制器连接时（当{{event('gamepadconnected')}} 事件触发时）运行的处理程序。
+  - : 表示当控制器连接时（当[`gamepadconnected`](/zh-CN/docs/Web/API/Window/gamepadconnected_event) 事件触发时）运行的处理程序。
 - {{domxref("Window.ongamepaddisconnected")}}
-  - : 表示当控制器断开连接时（当{{event('gamepaddisconnected')}} 事件触发时）运行的处理程序。
+  - : 表示当控制器断开连接时（当[`gamepaddisconnected`](/zh-CN/docs/Web/API/Window/gamepaddisconnected_event) 事件触发时）运行的处理程序。
 
 ## 教程与指南
 

--- a/files/zh-cn/web/api/gamepad_api/using_the_gamepad_api/index.md
+++ b/files/zh-cn/web/api/gamepad_api/using_the_gamepad_api/index.md
@@ -11,11 +11,11 @@ HTML5 为丰富的交互式游戏开发引入了许多必要的组件。像 `<ca
 
 ## 连接控制器
 
-当一个新的手柄连接到计算机时，焦点页面 (当前页面) 首先接收一个 {{ event("gamepadconnected") }} 事件。如果在加载页面时已经连接了手柄，则会在用户按下某个按钮或移动坐标方向 (axes) 时触发焦点页面的 {{ event("gamepadconnected") }} 事件。
+当一个新的手柄连接到计算机时，焦点页面 (当前页面) 首先接收一个 [`gamepadconnected`](/zh-CN/docs/Web/API/Window/gamepadconnected_event) 事件。如果在加载页面时已经连接了手柄，则会在用户按下某个按钮或移动坐标方向 (axes) 时触发焦点页面的 [`gamepadconnected`](/zh-CN/docs/Web/API/Window/gamepadconnected_event) 事件。
 
 > **备注：** 在 Firefox 中，控制器只会暴露给与用户产生交互的可见页面。这有助于防止控制器被用于获取用户的指纹。一旦有一个手柄与页面产生交互，那么其他连接的控制器将自动对页面可见。
 
-你可以这样使用 {{ event("gamepadconnected") }} ：
+你可以这样使用 [`gamepadconnected`](/zh-CN/docs/Web/API/Window/gamepadconnected_event) ：
 
 ```js
 window.addEventListener("gamepadconnected", function(e) {
@@ -29,7 +29,7 @@ window.addEventListener("gamepadconnected", function(e) {
 
 ## 断开控制器连接
 
-当控制器断开连接时，如果页面以前接收过该手柄的数据 (例如 {{ event("gamepadconnected") }})，那么第二个事件 {{ event("gamepaddisconnected") }} 将会分配至焦点页面：
+当控制器断开连接时，如果页面以前接收过该手柄的数据 (例如 [`gamepadconnected`](/zh-CN/docs/Web/API/Window/gamepadconnected_event))，那么第二个事件 [`gamepaddisconnected`](/zh-CN/docs/Web/API/Window/gamepaddisconnected_event) 将会分配至焦点页面：
 
 ```js
 window.addEventListener("gamepaddisconnected", function(e) {
@@ -92,7 +92,7 @@ window.addEventListener("gamepadconnected", function(e) {
 - `axes`: 一个表示设备上坐标输入控件 (例如控制器摇杆) 的数组对象。数组中的每个值都是介于 -1.0 到 1.0 的浮点值，来表示坐标方向的最低 (-1.0) 和最大 (1.0) 值。
 - `timestamp`: 它将返回一个 {{ domxref("DOMHighResTimeStamp") }} ，该值表示上次更新此控制器数据的时间，以便开发者确定 `axes` 和 `button` 数据是否已从硬件更新。该值必须相对于 {{ domxref("PerformanceTiming") }} 接口的 `navigationStart` 对象。值是单调递增的，这意味着可以通过对比大小来确定数据更新的先后顺序，因为新的值始终比旧的值大。请注意 Firefox 当前不支持该属性。
 
-> **备注：** 出于安全原因，Gamepad 对象在 {{ event("gamepadconnected") }} 事件上可用而在 {{ domxref("Window") }} 对象上不可用。一旦我们得到了对它的引用，我们就可以获取其属性以了解有关控制器当前状态的信息。在后台，此对象将会在控制器状态更改时更新。
+> **备注：** 出于安全原因，Gamepad 对象在 [`gamepadconnected`](/zh-CN/docs/Web/API/Window/gamepadconnected_event) 事件上可用而在 {{ domxref("Window") }} 对象上不可用。一旦我们得到了对它的引用，我们就可以获取其属性以了解有关控制器当前状态的信息。在后台，此对象将会在控制器状态更改时更新。
 
 ### 使用按键信息
 
@@ -108,7 +108,7 @@ var a = 0;
 var b = 0;
 ```
 
-接下来我们使用 {{ event("gamepadconnected") }} 事件来检查控制器是否连接。当有一个控制连接时，我们就使用 {{ domxref("Navigator.getGamepads()") }}`[0]` 来抓取，输出控制器信息到我们“控制器信息”的 `div` 里，并开始 `gameLoop()` 函数来启动球的运动进程。
+接下来我们使用 [`gamepadconnected`](/zh-CN/docs/Web/API/Window/gamepadconnected_event) 事件来检查控制器是否连接。当有一个控制连接时，我们就使用 {{ domxref("Navigator.getGamepads()") }}`[0]` 来抓取，输出控制器信息到我们“控制器信息”的 `div` 里，并开始 `gameLoop()` 函数来启动球的运动进程。
 
 ```js
 window.addEventListener("gamepadconnected", function(e) {
@@ -119,7 +119,7 @@ window.addEventListener("gamepadconnected", function(e) {
 });
 ```
 
-现在我们再使用 {{ event("gamepaddisconnected") }} 事件来检查如果控制器断开的情况。如果断开了，我们会停止 {{ domxref("Window.requestAnimationFrame", "requestAnimationFrame()") }} 循环 (见下方) 并重置控制器信息到原来的样子。
+现在我们再使用 [`gamepaddisconnected`](/zh-CN/docs/Web/API/Window/gamepaddisconnected_event) 事件来检查如果控制器断开的情况。如果断开了，我们会停止 {{ domxref("Window.requestAnimationFrame", "requestAnimationFrame()") }} 循环 (见下方) 并重置控制器信息到原来的样子。
 
 ```js
 window.addEventListener("gamepaddisconnected", function(e) {
@@ -196,7 +196,7 @@ function gameLoop() {
 
 ## 完整的例子：显示控制器状态
 
-这个例子展示了怎样使用 {{ domxref("Gamepad") }} 对象，还有 {{ event("gamepadconnected") }} 和 {{ event("gamepaddisconnected") }} 事件显示所有已连接到系统的控制器的状态。你可以查看[在线演示](http://luser.github.io/gamepadtest/)并且可在 Github 上看到[完整的源代码](https://github.com/luser/gamepadtest)。
+这个例子展示了怎样使用 {{ domxref("Gamepad") }} 对象，还有 [`gamepadconnected`](/zh-CN/docs/Web/API/Window/gamepadconnected_event) 和 [`gamepaddisconnected`](/zh-CN/docs/Web/API/Window/gamepaddisconnected_event) 事件显示所有已连接到系统的控制器的状态。你可以查看[在线演示](http://luser.github.io/gamepadtest/)并且可在 Github 上看到[完整的源代码](https://github.com/luser/gamepadtest)。
 
 ```js
 var haveEvents = 'ongamepadconnected' in window;

--- a/files/zh-cn/web/api/gamepadevent/gamepad/index.md
+++ b/files/zh-cn/web/api/gamepadevent/gamepad/index.md
@@ -5,7 +5,7 @@ slug: Web/API/GamepadEvent/gamepad
 
 {{APIRef("Gamepad API")}}
 
-**{{domxref("GamepadEvent")}} interface** 的 **`GamepadEvent.gamepad`** 属性返回一个 {{domxref("Gamepad")}} 对象，为触发 {{event("gamepadconnected")}} 和{{event("gamepaddisconnected")}} 事件提供相关联控制器数据的访问。
+**{{domxref("GamepadEvent")}} interface** 的 **`GamepadEvent.gamepad`** 属性返回一个 {{domxref("Gamepad")}} 对象，为触发 [`gamepadconnected`](/zh-CN/docs/Web/API/Window/gamepadconnected_event) 和[`gamepaddisconnected`](/zh-CN/docs/Web/API/Window/gamepaddisconnected_event) 事件提供相关联控制器数据的访问。
 
 ## 语法
 

--- a/files/zh-cn/web/api/hashchangeevent/index.md
+++ b/files/zh-cn/web/api/hashchangeevent/index.md
@@ -28,7 +28,7 @@ _这个接口没有自己的方法，但从 {{domxref("Event")}} 中继承方法
 
 ### 井号内容变化的语法选择
 
-你可以选择使用下述的任一方法监听 {{event("hashchange")}} 事件。
+你可以选择使用下述的任一方法监听 [`hashchange`](/zh-CN/docs/Web/API/Window/hashchange_event) 事件。
 
 ```js
 window.onhashchange = funcRef;
@@ -104,5 +104,5 @@ window.addEventListener('hashchange', locationHashChanged);
 
 ## 相关事件
 
-- {{event("hashchange")}}
-- {{event("popstate")}}
+- [`hashchange`](/zh-CN/docs/Web/API/Window/hashchange_event)
+- [`popstate`](/zh-CN/docs/Web/API/Window/popstate_event)

--- a/files/zh-cn/web/api/history/pushstate/index.md
+++ b/files/zh-cn/web/api/history/pushstate/index.md
@@ -16,7 +16,7 @@ history.pushState(state, title[, url])
 ### 参数
 
 - `state`
-  - : 状态对象是一个 JavaScript 对象，它与`pushState()`创建的新历史记录条目相关联。每当用户导航到新状态时，都会触发{{event("popstate")}}事件，并且该事件的状态属性包含历史记录条目的状态对象的副本。
+  - : 状态对象是一个 JavaScript 对象，它与`pushState()`创建的新历史记录条目相关联。每当用户导航到新状态时，都会触发[`popstate`](/zh-CN/docs/Web/API/Window/popstate_event)事件，并且该事件的状态属性包含历史记录条目的状态对象的副本。
     状态对象可以是任何可以序列化的对象。因为 Firefox 将状态对象保存到用户的磁盘上，以便用户重新启动浏览器后可以将其还原，所以我们对状态对象的序列化表示施加了 2MiB 的大小限制。如果将序列化表示形式大于此状态的状态对象传递给`pushState()`，则该方法将引发异常。如果您需要更多空间，建议您使用 {{domxref("Window.sessionStorage", "sessionStorage")}}或者{{domxref("Window.localStorage", "localStorage")}}。
 - `title`
   - : [当前大多数浏览器都忽略此参数](https://github.com/whatwg/html/issues/2174)，尽管将来可能会使用它。在此处传递空字符串应该可以防止将来对方法的更改。或者，您可以为要移动的状态传递简短的标题。
@@ -31,7 +31,7 @@ history.pushState(state, title[, url])
 - 非强制修改 URL。相反，设置 `window.location = "#foo";` 仅仅会在锚的值不是 #foo 情况下创建一条新的历史记录。
 - 可以在新的历史记录中关联任何数据。`window.location = "#foo"`形式的操作，你只可以将所需数据写入锚的字符串中。
 
-注意： `pushState()` 不会造成 {{event("hashchange")}} 事件调用，即使新的 URL 和之前的 URL 只是锚的数据不同。
+注意： `pushState()` 不会造成 [`hashchange`](/zh-CN/docs/Web/API/Window/hashchange_event) 事件调用，即使新的 URL 和之前的 URL 只是锚的数据不同。
 
 ## 示例
 

--- a/files/zh-cn/web/api/html_drag_and_drop_api/drag_operations/index.md
+++ b/files/zh-cn/web/api/html_drag_and_drop_api/drag_operations/index.md
@@ -18,7 +18,7 @@ slug: Web/API/HTML_Drag_and_Drop_API/Drag_operations
 要使其他的 HTML 元素可拖拽，必须做三件事：
 
 - 将想要拖拽的元素的 `{{htmlattrxref("draggable")}}` 属性设置成 `{{htmlattrxref("draggable")}}="true"`。
-- 为 `{{event("dragstart")}}` 事件添加一个监听程序。
+- 为 `[`dragstart`](/zh-CN/docs/Web/API/HTMLElement/dragstart_event)` 事件添加一个监听程序。
 - 在上一步定义的监听程序中 {{domxref("DataTransfer.setData","设置拖拽数据")}}。
 
 下面的例子允许拖拽一个段落的内容：
@@ -37,7 +37,7 @@ slug: Web/API/HTML_Drag_and_Drop_API/Drag_operations
 
 ## 开始拖拽操作
 
-这个例子使用 `{{domxref("GlobalEventHandlers.ondragstart","ondragstart")}}` 属性为 {{event("dragstart")}} 事件添加监听程序。
+这个例子使用 `{{domxref("GlobalEventHandlers.ondragstart","ondragstart")}}` 属性为 [`dragstart`](/zh-CN/docs/Web/API/HTMLElement/dragstart_event) 事件添加监听程序。
 
 ```
 <p draggable="true" ondragstart="event.dataTransfer.setData('text/plain', 'This text may be dragged')">
@@ -45,11 +45,11 @@ slug: Web/API/HTML_Drag_and_Drop_API/Drag_operations
 </p>
 ```
 
-当用户开始拖拽时，会触发 {{event("dragstart")}} 事件。
+当用户开始拖拽时，会触发 [`dragstart`](/zh-CN/docs/Web/API/HTMLElement/dragstart_event) 事件。
 
-在这个例子中，{{event("dragstart")}} 事件监听程序被添加到可拖拽元素本身；然而，你可以监听一个祖先元素，因为就像大多数其他事件一样，拖拽事件会冒泡。
+在这个例子中，[`dragstart`](/zh-CN/docs/Web/API/HTMLElement/dragstart_event) 事件监听程序被添加到可拖拽元素本身；然而，你可以监听一个祖先元素，因为就像大多数其他事件一样，拖拽事件会冒泡。
 
-在 {{event("dragstart")}} 事件中，你可以指定拖拽数据、反馈图像和拖拽效果，所有这些都将在下面描述。不过，我们只需要设置拖拽数据，因为在大多数情况下默认的图像和拖拽效果都是适用的。
+在 [`dragstart`](/zh-CN/docs/Web/API/HTMLElement/dragstart_event) 事件中，你可以指定拖拽数据、反馈图像和拖拽效果，所有这些都将在下面描述。不过，我们只需要设置拖拽数据，因为在大多数情况下默认的图像和拖拽效果都是适用的。
 
 ## 拖拽数据
 
@@ -57,7 +57,7 @@ slug: Web/API/HTML_Drag_and_Drop_API/Drag_operations
 
 当拖拽发生时，数据必须与被拖拽的项目相关联。例如，当在文本框中拖拽选定的文本时，与拖拽数据项相关联的数据就是文本本身。类似地，当在 Web 页面上拖拽链接时，拖拽数据项就是链接的 URL。
 
-{{domxref("DataTransfer","拖拽数据")}} 包含两个信息，数据的类型（或格式）和数据值。格式是一个类型字符串（例如文本数据的格式是 [`text/plain`](/zh-CN/docs/DragDrop/Recommended_Drag_Types#text)），值是一个文本字符串。拖拽开始时，你提供数据类型和数据值。在拖拽过程中，在 `{{event("dragenter")}}` 和 `{{event("dragover")}}` 事件监听程序中，你使用拖拽数据的类型来检查是否允许放置（drop）。例如，接受链接的放置目标将检查链接类型 [`text/uri-list`](/zh-CN/docs/DragDrop/Recommended_Drag_Types#link)。在放置事件中，监听程序将取回拖拽数据，并将其插入到放置位置。
+{{domxref("DataTransfer","拖拽数据")}} 包含两个信息，数据的类型（或格式）和数据值。格式是一个类型字符串（例如文本数据的格式是 [`text/plain`](/zh-CN/docs/DragDrop/Recommended_Drag_Types#text)），值是一个文本字符串。拖拽开始时，你提供数据类型和数据值。在拖拽过程中，在 `[`dragenter`](/zh-CN/docs/Web/API/HTMLElement/dragenter_event)` 和 `[`dragover`](/zh-CN/docs/Web/API/HTMLElement/dragover_event)` 事件监听程序中，你使用拖拽数据的类型来检查是否允许放置（drop）。例如，接受链接的放置目标将检查链接类型 [`text/uri-list`](/zh-CN/docs/DragDrop/Recommended_Drag_Types#link)。在放置事件中，监听程序将取回拖拽数据，并将其插入到放置位置。
 
 {{domxref("DataTransfer","拖拽数据")}} 的 {{domxref("DataTransfer.types","类型")}} 属性返回一个类似 {{domxref("DOMString")}} 的 MIME-type 的列表，如 [`text/plain`](/zh-CN/docs/DragDrop/Recommended_Drag_Types#text) 或 [`image/jpeg`](/zh-CN/docs/DragDrop/Recommended_Drag_Types#image)。你还可以创建自己的类型。最常用的类型列在文章 [推荐拖拽类型](/zh-CN/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types) 中。
 
@@ -96,7 +96,7 @@ event.dataTransfer.clearData("text/uri-list");
 
 ## 设置拖拽反馈图像
 
-当拖拽发生时，会生成拖拽目标的一个半透明图像（触发"{{event("dragstart")}}" 事件的元素），并在拖拽过程中跟踪鼠标指针。这个图像是自动创建的，所以你不需要自己创建它。但是，你可以使用 {{domxref("DataTransfer.setDragImage","setDragImage()")}} 方法来自定义拖拽反馈图像。
+当拖拽发生时，会生成拖拽目标的一个半透明图像（触发"[`dragstart`](/zh-CN/docs/Web/API/HTMLElement/dragstart_event)" 事件的元素），并在拖拽过程中跟踪鼠标指针。这个图像是自动创建的，所以你不需要自己创建它。但是，你可以使用 {{domxref("DataTransfer.setDragImage","setDragImage()")}} 方法来自定义拖拽反馈图像。
 
 ```js
 event.dataTransfer.setDragImage(image, xOffset, yOffset);
@@ -131,7 +131,7 @@ function dragWithCustomImage(event) {
 
 拖拽过程中可能会执行一些操作。 `copy` 操作用来指示被拖拽的数据将从当前位置复制到放置位置。 `move` 操作指示被拖拽的数据会被移动，`link` 操作表示在源和放置位置之间将会创建某种形式的关系或连接。
 
-你可以在 `{{event("dragstart")}}` 事件监听程序中设置 {{domxref("DataTransfer.effectAllowed","effectAllowed")}} 属性以指定允许拖拽源头执行三种操作中的哪几种。
+你可以在 `[`dragstart`](/zh-CN/docs/Web/API/HTMLElement/dragstart_event)` 事件监听程序中设置 {{domxref("DataTransfer.effectAllowed","effectAllowed")}} 属性以指定允许拖拽源头执行三种操作中的哪几种。
 
 ```js
 event.dataTransfer.effectAllowed = "copy";
@@ -160,11 +160,11 @@ event.dataTransfer.effectAllowed = "copy";
 
 注意，这些值必须像上面列出的那样使用。例如，将 {{domxref("DataTransfer.effectAllowed","effectAllowed")}} 属性设置为`copyMove` 允许复制或移动操作，但阻止用户执行链接操作。属性默认允许以上所有的操作（all），所以你不需要调整这个属性，除非你想要排除某个特定操作。
 
-在拖拽操作期间，`{{event("dragenter")}}` 或 `{{event("dragover")}}` 事件的监听程序可以检查 {{domxref("DataTransfer.effectAllowed","effectAllowed")}} 属性，以查看哪些操作是允许的。相关的 {{domxref("DataTransfer.dropEffect","dropEffect")}} 属性应该在其中的一个事件中设置，来指定应该执行哪一个单项操作。{{domxref("DataTransfer.dropEffect","dropEffect")}} 是 `none`, `copy`, `move`, 或 `link`。这个属性不使用上述的组合值。
+在拖拽操作期间，`[`dragenter`](/zh-CN/docs/Web/API/HTMLElement/dragenter_event)` 或 `[`dragover`](/zh-CN/docs/Web/API/HTMLElement/dragover_event)` 事件的监听程序可以检查 {{domxref("DataTransfer.effectAllowed","effectAllowed")}} 属性，以查看哪些操作是允许的。相关的 {{domxref("DataTransfer.dropEffect","dropEffect")}} 属性应该在其中的一个事件中设置，来指定应该执行哪一个单项操作。{{domxref("DataTransfer.dropEffect","dropEffect")}} 是 `none`, `copy`, `move`, 或 `link`。这个属性不使用上述的组合值。
 
-在 `{{event("dragenter")}}` 和 `{{event("dragover")}}` 事件中，{{domxref("DataTransfer.dropEffect","dropEffect")}} 属性被初始化为用户请求的效果。用户可以通过按下修饰键来修改为所需的效果。尽管使用什么修饰键取决于不同的平台，但典型情况下，<kbd>Shift</kbd> 和 <kbd>Ctrl</kbd> 键用于在复制、移动和链接之间切换。鼠标指针会改变样式以指示需要的操作；例如，对于"复制"操作，光标可能会在旁边出现加号。
+在 `[`dragenter`](/zh-CN/docs/Web/API/HTMLElement/dragenter_event)` 和 `[`dragover`](/zh-CN/docs/Web/API/HTMLElement/dragover_event)` 事件中，{{domxref("DataTransfer.dropEffect","dropEffect")}} 属性被初始化为用户请求的效果。用户可以通过按下修饰键来修改为所需的效果。尽管使用什么修饰键取决于不同的平台，但典型情况下，<kbd>Shift</kbd> 和 <kbd>Ctrl</kbd> 键用于在复制、移动和链接之间切换。鼠标指针会改变样式以指示需要的操作；例如，对于"复制"操作，光标可能会在旁边出现加号。
 
-你可以在 `{{event("dragenter")}}` 或 `{{event("dragover")}}` 事件期间修改 {{domxref("DataTransfer.dropEffect","dropEffect")}} 属性，例如将某个放置目标设置为只支持某些操作。你可以修改 {{domxref("DataTransfer.dropEffect","dropEffect")}} 属性来覆盖用户指定的效果，并强制修改为一个特定的放置操作。注意，这个效果必须是 {{domxref("DataTransfer.effectAllowed","effectAllowed")}} 属性中的一个。否则，它将被设置为允许的替代值。
+你可以在 `[`dragenter`](/zh-CN/docs/Web/API/HTMLElement/dragenter_event)` 或 `[`dragover`](/zh-CN/docs/Web/API/HTMLElement/dragover_event)` 事件期间修改 {{domxref("DataTransfer.dropEffect","dropEffect")}} 属性，例如将某个放置目标设置为只支持某些操作。你可以修改 {{domxref("DataTransfer.dropEffect","dropEffect")}} 属性来覆盖用户指定的效果，并强制修改为一个特定的放置操作。注意，这个效果必须是 {{domxref("DataTransfer.effectAllowed","effectAllowed")}} 属性中的一个。否则，它将被设置为允许的替代值。
 
 ```js
 event.dataTransfer.dropEffect = "copy";
@@ -174,11 +174,11 @@ event.dataTransfer.dropEffect = "copy";
 
 你可以使用 `none` 表示在这个位置不允许任何放置，尽管在这种情况下，最好不要取消事件。
 
-在 `{{event("drop")}}` 和 `{{event("dragend")}}` 事件中，你可以检查 {{domxref("DataTransfer.dropEffect","dropEffect")}} 属性，以确定最终选择了哪种效果。如果所选的效果是 "move"，那么应该在 `{{event("dragend")}}` 事件中从拖拽源头删除拖拽数据。
+在 `[`drop`](/zh-CN/docs/Web/API/HTMLElement/drop_event)` 和 `[`dragend`](/zh-CN/docs/Web/API/HTMLElement/dragend_event)` 事件中，你可以检查 {{domxref("DataTransfer.dropEffect","dropEffect")}} 属性，以确定最终选择了哪种效果。如果所选的效果是 "move"，那么应该在 `[`dragend`](/zh-CN/docs/Web/API/HTMLElement/dragend_event)` 事件中从拖拽源头删除拖拽数据。
 
 ## 指定放置目标
 
-`{{event("dragenter")}}` 或 `{{event("dragover")}}` 事件的监听程序用于表示有效的放置目标，也就是被拖拽项目可能放置的地方。网页或应用程序的大多数区域都不是放置数据的有效位置。因此，这些事件的默认处理是不允许放置。
+`[`dragenter`](/zh-CN/docs/Web/API/HTMLElement/dragenter_event)` 或 `[`dragover`](/zh-CN/docs/Web/API/HTMLElement/dragover_event)` 事件的监听程序用于表示有效的放置目标，也就是被拖拽项目可能放置的地方。网页或应用程序的大多数区域都不是放置数据的有效位置。因此，这些事件的默认处理是不允许放置。
 
 如果你想要允许放置，你必须取消 `dragenter` 和 `dragover` 事件来阻止默认的处理。你可以在属性定义的事件监听程序返回 `false`，或者调用事件的 {{domxref("Event.preventDefault","preventDefault()")}} 方法来实现这一点。在一个独立脚本中的定义的函数里，可能后者更可行。
 
@@ -187,7 +187,7 @@ event.dataTransfer.dropEffect = "copy";
 <div ondragover="event.preventDefault()">
 ```
 
-在 `{{event("dragenter")}}` 和 `{{event("dragover")}}` 事件中调用 {{domxref("Event.preventDefault","preventDefault()")}} 方法将表明在该位置允许放置。但是，你通常希望只在某些情况下调用 {{domxref("Event.preventDefault","preventDefault()")}} 方法（如只当拖拽的是链接时）。
+在 `[`dragenter`](/zh-CN/docs/Web/API/HTMLElement/dragenter_event)` 和 `[`dragover`](/zh-CN/docs/Web/API/HTMLElement/dragover_event)` 事件中调用 {{domxref("Event.preventDefault","preventDefault()")}} 方法将表明在该位置允许放置。但是，你通常希望只在某些情况下调用 {{domxref("Event.preventDefault","preventDefault()")}} 方法（如只当拖拽的是链接时）。
 
 要做到这一点，调用一个函数以检查条件，并且只在满足条件时取消事件。如果条件未满足，则不取消事件，此时用户释放鼠标按钮不会执行放置。
 
@@ -225,23 +225,23 @@ function doDragOver(event) {
 }
 ```
 
-在这个例子中，当带有 `droparea` 类的元素是一个有效的放置目标时，即在该元素的 `{{event("dragenter")}}` 事件中调用 {{domxref("Event.preventDefault","preventDefault()")}} 方法时，元素会出现一个 1 像素的黑色轮廓。
+在这个例子中，当带有 `droparea` 类的元素是一个有效的放置目标时，即在该元素的 `[`dragenter`](/zh-CN/docs/Web/API/HTMLElement/dragenter_event)` 事件中调用 {{domxref("Event.preventDefault","preventDefault()")}} 方法时，元素会出现一个 1 像素的黑色轮廓。
 
-> **备注：** 要使这个伪类生效，你必须在 `{{event("dragenter")}}` 事件中调用 {{domxref("Event.preventDefault","preventDefault()")}} 方法，因为这个伪类状态不会检查 `{{event("dragover")}}` 事件（译者注：即在 `{{event("dragover")}}` 事件中调用 {{domxref("Event.preventDefault","preventDefault()")}} 方法也不会使伪类生效，尽管这个伪类叫做“-moz-drag-over”）。
+> **备注：** 要使这个伪类生效，你必须在 `[`dragenter`](/zh-CN/docs/Web/API/HTMLElement/dragenter_event)` 事件中调用 {{domxref("Event.preventDefault","preventDefault()")}} 方法，因为这个伪类状态不会检查 `[`dragover`](/zh-CN/docs/Web/API/HTMLElement/dragover_event)` 事件（译者注：即在 `[`dragover`](/zh-CN/docs/Web/API/HTMLElement/dragover_event)` 事件中调用 {{domxref("Event.preventDefault","preventDefault()")}} 方法也不会使伪类生效，尽管这个伪类叫做“-moz-drag-over”）。
 
-对于更复杂的视觉效果，你可以在 `{{event("dragenter")}}` 事件中执行其他操作。例如在放置位置插入一个元素，这样的元素可以表示一个插入标记，或表示被拖拽的元素移动到了新位置。为此你可以在 `{{event("dragenter")}}` 事件中创建一个新元素，然后将其插入到文档中。
+对于更复杂的视觉效果，你可以在 `[`dragenter`](/zh-CN/docs/Web/API/HTMLElement/dragenter_event)` 事件中执行其他操作。例如在放置位置插入一个元素，这样的元素可以表示一个插入标记，或表示被拖拽的元素移动到了新位置。为此你可以在 `[`dragenter`](/zh-CN/docs/Web/API/HTMLElement/dragenter_event)` 事件中创建一个新元素，然后将其插入到文档中。
 
-`{{event("dragover")}}` 事件在鼠标指向的元素上触发。自然，你可能需要将插入标记移动到事件发生的位置附近。你可以使用事件的 {{domxref("MouseEvent.clientX","clientX")}} 和 {{domxref("MouseEvent.clientY","clientY")}} 属性，还有其他鼠标事件的属性来确定鼠标的位置。
+`[`dragover`](/zh-CN/docs/Web/API/HTMLElement/dragover_event)` 事件在鼠标指向的元素上触发。自然，你可能需要将插入标记移动到事件发生的位置附近。你可以使用事件的 {{domxref("MouseEvent.clientX","clientX")}} 和 {{domxref("MouseEvent.clientY","clientY")}} 属性，还有其他鼠标事件的属性来确定鼠标的位置。
 
-最后，`{{event("dragleave")}}` 事件会在拖拽离开元素时在该元素上触发。这是移除插入标记或高亮的好时机。你不需要取消这个事件（译者注：即不需要使用 {{domxref("Event.preventDefault","preventDefault()")}} ）。使用 `-moz-drag-over` 伪类设置的高亮或其他视觉效果会被自动移除。即使拖拽被取消了，`{{event("dragleave")}}` 事件也会照常触发，所以你可以确保在这个事件中对任何插入标记的清除操作都一定可以完成。
+最后，`[`dragleave`](/zh-CN/docs/Web/API/HTMLElement/dragleave_event)` 事件会在拖拽离开元素时在该元素上触发。这是移除插入标记或高亮的好时机。你不需要取消这个事件（译者注：即不需要使用 {{domxref("Event.preventDefault","preventDefault()")}} ）。使用 `-moz-drag-over` 伪类设置的高亮或其他视觉效果会被自动移除。即使拖拽被取消了，`[`dragleave`](/zh-CN/docs/Web/API/HTMLElement/dragleave_event)` 事件也会照常触发，所以你可以确保在这个事件中对任何插入标记的清除操作都一定可以完成。
 
 ## 执行放置
 
 当用户放开鼠标，拖放操作就会结束。
 
-如果在有效的放置目标元素（即取消了 `{{event("dragenter")}}` 或 `{{event("dragover")}}` 的元素）上放开鼠标，放置会成功实现，`{{event("drop")}}` 事件在目标元素上被触发。否则，拖拽会被取消，不会触发 `{{event("drop")}}` 事件。
+如果在有效的放置目标元素（即取消了 `[`dragenter`](/zh-CN/docs/Web/API/HTMLElement/dragenter_event)` 或 `[`dragover`](/zh-CN/docs/Web/API/HTMLElement/dragover_event)` 的元素）上放开鼠标，放置会成功实现，`[`drop`](/zh-CN/docs/Web/API/HTMLElement/drop_event)` 事件在目标元素上被触发。否则，拖拽会被取消，不会触发 `[`drop`](/zh-CN/docs/Web/API/HTMLElement/drop_event)` 事件。
 
-在 `{{event("drop")}}` 事件中，你应该取回放置的数据并将其插入到放置的位置。你可以使用 {{domxref("DataTransfer.dropEffect","dropEffect")}} 属性来确定需要哪种拖拽操作。
+在 `[`drop`](/zh-CN/docs/Web/API/HTMLElement/drop_event)` 事件中，你应该取回放置的数据并将其插入到放置的位置。你可以使用 {{domxref("DataTransfer.dropEffect","dropEffect")}} 属性来确定需要哪种拖拽操作。
 
 在所有拖拽操作相关的事件中，事件的 `{{domxref("DragEvent.dataTransfer","dataTransfer")}}` 属性会一直保存着拖拽数据。可使用 {{domxref("DataTransfer.getData","getData()")}} 方法来取回数据。
 
@@ -253,7 +253,7 @@ function onDrop(event) {
 }
 ```
 
-{{domxref("DataTransfer.getData","getData()")}} 方法接收一个参数，取回数据的类型。这个方法会返回拖拽操作开始时调用 {{domxref("DataTransfer.setData","setData()")}} 方法设置的字符串值。如果不存在传入类型的数据，则会返回空字符串。自然，你应该知道哪种类型的数据可用，因为之前你应该已经在 `{{event("dragover")}}` 事件中检查过数据类型了。
+{{domxref("DataTransfer.getData","getData()")}} 方法接收一个参数，取回数据的类型。这个方法会返回拖拽操作开始时调用 {{domxref("DataTransfer.setData","setData()")}} 方法设置的字符串值。如果不存在传入类型的数据，则会返回空字符串。自然，你应该知道哪种类型的数据可用，因为之前你应该已经在 `[`dragover`](/zh-CN/docs/Web/API/HTMLElement/dragover_event)` 事件中检查过数据类型了。
 
 在上面的例子中，我们一取回数据就把它作为文本内容插入到目标中。实际效果就是拖拽文本被插入到放置位置，假设放置目标是文本区域，例如 `p` 或 `div` 元素。
 
@@ -304,15 +304,15 @@ function doDrop(event) {
 
 ## 完成拖拽
 
-一旦拖拽完成，`{{event("dragend")}}` 事件会在拖拽源头（即触发 `{{event("dragstart")}}` 的元素）上发生。无论拖拽是成功还是被取消，这个事件都会被触发。然而，你可以使用 {{domxref("DataTransfer.dropEffect","dropEffect")}} 属性来决定执行什么放置操作。
+一旦拖拽完成，`[`dragend`](/zh-CN/docs/Web/API/HTMLElement/dragend_event)` 事件会在拖拽源头（即触发 `[`dragstart`](/zh-CN/docs/Web/API/HTMLElement/dragstart_event)` 的元素）上发生。无论拖拽是成功还是被取消，这个事件都会被触发。然而，你可以使用 {{domxref("DataTransfer.dropEffect","dropEffect")}} 属性来决定执行什么放置操作。
 
-如果在`{{event("dragend")}}` 事件中，{{domxref("DataTransfer.dropEffect","dropEffect")}} 属性值为 `none`，则拖拽会被取消。否则，这个属性会规定需要执行什么操作。源头元素可使用这个信息以在拖拽操作完成后从原来的位置移除被拖拽的项目。{{domxref("DataTransfer.mozUserCancelled","mozUserCancelled")}} 属性会在用户取消拖拽（按下 Esc 键）时设置为 true，在拖拽因为其他原因如无效放置目标等被取消时，或拖拽成功时，则设置为 false。
+如果在`[`dragend`](/zh-CN/docs/Web/API/HTMLElement/dragend_event)` 事件中，{{domxref("DataTransfer.dropEffect","dropEffect")}} 属性值为 `none`，则拖拽会被取消。否则，这个属性会规定需要执行什么操作。源头元素可使用这个信息以在拖拽操作完成后从原来的位置移除被拖拽的项目。{{domxref("DataTransfer.mozUserCancelled","mozUserCancelled")}} 属性会在用户取消拖拽（按下 Esc 键）时设置为 true，在拖拽因为其他原因如无效放置目标等被取消时，或拖拽成功时，则设置为 false。
 
-放置可发生在同一窗口或另一个应用程序中。两种情况都会触发 `{{event("dragend")}}` 事件。事件的 {{domxref("MouseEvent.screenX","screenX")}} 和 {{domxref("MouseEvent.screenY","screenY")}} 属性会被设置为放置发生时鼠标在屏幕上的坐标。
+放置可发生在同一窗口或另一个应用程序中。两种情况都会触发 `[`dragend`](/zh-CN/docs/Web/API/HTMLElement/dragend_event)` 事件。事件的 {{domxref("MouseEvent.screenX","screenX")}} 和 {{domxref("MouseEvent.screenY","screenY")}} 属性会被设置为放置发生时鼠标在屏幕上的坐标。
 
-`{{event("dragend")}}` 事件结束后，整个拖放操作就完成了。
+`[`dragend`](/zh-CN/docs/Web/API/HTMLElement/dragend_event)` 事件结束后，整个拖放操作就完成了。
 
-\[1] 在 Gecko 内核中，如果源头节点在拖拽过程中（如放置或 {{event("dragover")}} 中）被移动或移除了，则不会触发 {{event("dragend")}} 事件。参见 [bug 460801](https://bugzilla.mozilla.org/show_bug.cgi?id=460801)。
+\[1] 在 Gecko 内核中，如果源头节点在拖拽过程中（如放置或 [`dragover`](/zh-CN/docs/Web/API/HTMLElement/dragover_event) 中）被移动或移除了，则不会触发 [`dragend`](/zh-CN/docs/Web/API/HTMLElement/dragend_event) 事件。参见 [bug 460801](https://bugzilla.mozilla.org/show_bug.cgi?id=460801)。
 
 ## 参见
 

--- a/files/zh-cn/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
+++ b/files/zh-cn/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
@@ -7,13 +7,13 @@ slug: Web/API/HTML_Drag_and_Drop_API/File_drag_and_drop
 
 HTML 拖放接口使得 web 应用能够在网页中拖放文件。这篇文档介绍了 web 应用如何接受从底层平台的文件管理器拖动一个或多个文件到网页的操作。
 
-拖放的主要步骤是为 {{event("drop")}} 事件定义一个*释放区*(释放文件的目标元素) 和为{{event("dragover")}}事件定义一个事件处理程序。下面描述了这些步骤，包括示例程序片段。完整的源码在[MDN's drag-and-drop repository](https://github.com/mdn/dom-examples/tree/master/drag-and-drop) (欢迎提交 pull requests 和/或 issues).
+拖放的主要步骤是为 [`drop`](/zh-CN/docs/Web/API/HTMLElement/drop_event) 事件定义一个*释放区*(释放文件的目标元素) 和为[`dragover`](/zh-CN/docs/Web/API/HTMLElement/dragover_event)事件定义一个事件处理程序。下面描述了这些步骤，包括示例程序片段。完整的源码在[MDN's drag-and-drop repository](https://github.com/mdn/dom-examples/tree/master/drag-and-drop) (欢迎提交 pull requests 和/或 issues).
 
 注意：{{domxref("HTML_Drag_and_Drop_API","HTML drag and drop")}}定义了两套不同的 API 来支持拖放文件。一个{{domxref("DataTransfer")}}接口和另一个{{domxref("DataTransferItem")}}与{{domxref("DataTransferItemList")}}接口。这个示例介绍了这两种 API 的用法 (没有使用任何 Gecko 专用的接口)。
 
 ## 定义拖放区域
 
-触发 {{event("drop")}} 事件的目标元素需要一个{{domxref("GlobalEventHandlers.ondrop","ondrop")}} 事件处理函数。下面这一段代码以一个 {{HTMLelement("div")}} 元素为例展示了这些工作是如何完成的：
+触发 [`drop`](/zh-CN/docs/Web/API/HTMLElement/drop_event) 事件的目标元素需要一个{{domxref("GlobalEventHandlers.ondrop","ondrop")}} 事件处理函数。下面这一段代码以一个 {{HTMLelement("div")}} 元素为例展示了这些工作是如何完成的：
 
 ```html
 <div id="drop_zone" ondrop="dropHandler(event);">
@@ -21,7 +21,7 @@ HTML 拖放接口使得 web 应用能够在网页中拖放文件。这篇文档�
 </div>
 ```
 
-一般来说，在实际应用中需要定义一个 {{event("dragover")}} 事件的处理函数并在其中加入关闭浏览器默认拖放行为的代码。你需要定义一个 {{domxref("GlobalEventHandlers.ondragover","ondragover")}} 事件处理函数：
+一般来说，在实际应用中需要定义一个 [`dragover`](/zh-CN/docs/Web/API/HTMLElement/dragover_event) 事件的处理函数并在其中加入关闭浏览器默认拖放行为的代码。你需要定义一个 {{domxref("GlobalEventHandlers.ondragover","ondragover")}} 事件处理函数：
 
 ```html
 <div id="drop_zone" ondrop="dropHandler(event);" ondragover="dragOverHandler(event);">
@@ -43,7 +43,7 @@ HTML 拖放接口使得 web 应用能够在网页中拖放文件。这篇文档�
 
 ## 执行释放事件
 
-当用户释放文件时 {{event("drop")}} 事件将会被触发。在下面的 drop 处理函数中，如果浏览器支持 {{domxref("DataTransferItemList")}} 接口，则可以使用 {{domxref("DataTransferItem.getAsFile","getAsFile()")}} 来获取每个文件；否则使用 {{domxref("DataTransfer")}} 接口的 {{domxref("DataTransfer.files","files")}} 属性来获取每个文件。
+当用户释放文件时 [`drop`](/zh-CN/docs/Web/API/HTMLElement/drop_event) 事件将会被触发。在下面的 drop 处理函数中，如果浏览器支持 {{domxref("DataTransferItemList")}} 接口，则可以使用 {{domxref("DataTransferItem.getAsFile","getAsFile()")}} 来获取每个文件；否则使用 {{domxref("DataTransfer")}} 接口的 {{domxref("DataTransfer.files","files")}} 属性来获取每个文件。
 
 这个示例展示了如何讲每个被拖动的文件的名字输出到控制台。在实际应用中可能会用到 {{domxref("File","File API")}} 来处理一个文件。
 
@@ -76,7 +76,7 @@ function dropHandler(ev) {
 
 ## 阻止浏览器的默认释放行为
 
-下面的 {{event("dragover")}} 事件处理函数调用 {{domxref("Event.preventDefault","preventDefault()")}} 来关闭浏览器的默认拖动和释放行为。
+下面的 [`dragover`](/zh-CN/docs/Web/API/HTMLElement/dragover_event) 事件处理函数调用 {{domxref("Event.preventDefault","preventDefault()")}} 来关闭浏览器的默认拖动和释放行为。
 
 ```js
 function dragOverHandler(ev) {

--- a/files/zh-cn/web/api/html_drag_and_drop_api/index.md
+++ b/files/zh-cn/web/api/html_drag_and_drop_api/index.md
@@ -15,20 +15,20 @@ slug: Web/API/HTML_Drag_and_Drop_API
 
 HTML 的 drag & drop 使用了 {{domxref("Event","DOM event model")}} 以及从 {{domxref("MouseEvent","mouse events")}} 继承而来的 _{{domxref("DragEvent","drag events")}}_。一个典型的拖拽操作是这样的：用户选中一个*可拖拽的（draggable）*元素，并将其拖拽（鼠标不放开）到一个*可放置的（droppable）*元素，然后释放鼠标。
 
-在操作期间，会触发一些事件类型，有一些事件类型可能会被多次触发（比如{{event("drag")}} 和 {{event("dragover")}} 事件类型）。
+在操作期间，会触发一些事件类型，有一些事件类型可能会被多次触发（比如[`drag`](/zh-CN/docs/Web/API/HTMLElement/drag_event) 和 [`dragover`](/zh-CN/docs/Web/API/HTMLElement/dragover_event) 事件类型）。
 
 所有的 [拖拽事件类型](/zh-CN/docs/Web/API/DragEvent#Event_types) 有一个对应的 [拖拽全局属性](/zh-CN/docs/Web/API/DragEvent#GlobalEventHandlers)。每个拖拽事件类型和拖拽全局属性都有对应的描述文档。下面的表格提供了一个简短的事件类型描述，以及一个相关文档的链接。
 
 | 事件                         | On 型事件处理程序                                                                | 触发时刻                                                                                                              |
 | ---------------------------- | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| {{event('drag')}}     | {{domxref('GlobalEventHandlers.ondrag','ondrag')}}             | 当拖拽元素或选中的文本时触发。                                                                                        |
-| {{event('dragend')}} | {{domxref('GlobalEventHandlers.ondragend','ondragend')}}     | 当拖拽操作结束时触发 (比如松开鼠标按键或敲“Esc”键). (见[结束拖拽](/zh-CN/docs/DragDrop/Drag_Operations#dragend))      |
-| {{event('dragenter')}} | {{domxref('GlobalEventHandlers.ondragenter','ondragenter')}} | 当拖拽元素或选中的文本到一个可释放目标时触发（见 [指定释放目标](/zh-CN/docs/DragDrop/Drag_Operations#droptargets)）。 |
+| [`drag`](/zh-CN/docs/Web/API/HTMLElement/drag_event)     | {{domxref('GlobalEventHandlers.ondrag','ondrag')}}             | 当拖拽元素或选中的文本时触发。                                                                                        |
+| [`dragend`](/zh-CN/docs/Web/API/HTMLElement/dragend_event) | {{domxref('GlobalEventHandlers.ondragend','ondragend')}}     | 当拖拽操作结束时触发 (比如松开鼠标按键或敲“Esc”键). (见[结束拖拽](/zh-CN/docs/DragDrop/Drag_Operations#dragend))      |
+| [`dragenter`](/zh-CN/docs/Web/API/HTMLElement/dragenter_event) | {{domxref('GlobalEventHandlers.ondragenter','ondragenter')}} | 当拖拽元素或选中的文本到一个可释放目标时触发（见 [指定释放目标](/zh-CN/docs/DragDrop/Drag_Operations#droptargets)）。 |
 | {{event('dragexit')}} | {{domxref('GlobalEventHandlers.ondragexit','ondragexit')}}     | 当元素变得不再是拖拽操作的选中目标时触发。                                                                            |
-| {{event('dragleave')}} | {{domxref('GlobalEventHandlers.ondragleave','ondragleave')}} | 当拖拽元素或选中的文本离开一个可释放目标时触发。                                                                      |
-| {{event('dragover')}} | {{domxref('GlobalEventHandlers.ondragover','ondragover')}}     | 当元素或选中的文本被拖到一个可释放目标上时触发（每 100 毫秒触发一次）。                                               |
-| {{event('dragstart')}} | {{domxref('GlobalEventHandlers.ondragstart','ondragstart')}} | 当用户开始拖拽一个元素或选中的文本时触发（见[开始拖拽操作](/zh-CN/docs/DragDrop/Drag_Operations#dragstart)）。        |
-| {{event('drop')}}     | {{domxref('GlobalEventHandlers.ondrop','ondrop')}}             | 当元素或选中的文本在可释放目标上被释放时触发（见[执行释放](/zh-CN/docs/DragDrop/Drag_Operations#drop)）。             |
+| [`dragleave`](/zh-CN/docs/Web/API/HTMLElement/dragleave_event) | {{domxref('GlobalEventHandlers.ondragleave','ondragleave')}} | 当拖拽元素或选中的文本离开一个可释放目标时触发。                                                                      |
+| [`dragover`](/zh-CN/docs/Web/API/HTMLElement/dragover_event) | {{domxref('GlobalEventHandlers.ondragover','ondragover')}}     | 当元素或选中的文本被拖到一个可释放目标上时触发（每 100 毫秒触发一次）。                                               |
+| [`dragstart`](/zh-CN/docs/Web/API/HTMLElement/dragstart_event) | {{domxref('GlobalEventHandlers.ondragstart','ondragstart')}} | 当用户开始拖拽一个元素或选中的文本时触发（见[开始拖拽操作](/zh-CN/docs/DragDrop/Drag_Operations#dragstart)）。        |
+| [`drop`](/zh-CN/docs/Web/API/HTMLElement/drop_event)     | {{domxref('GlobalEventHandlers.ondrop','ondrop')}}             | 当元素或选中的文本在可释放目标上被释放时触发（见[执行释放](/zh-CN/docs/DragDrop/Drag_Operations#drop)）。             |
 
 **注意：**当从操作系统向浏览器中拖拽文件时，不会触发 `dragstart` 和`dragend` 事件。
 
@@ -165,7 +165,7 @@ function drop_handler(ev) {
 
 ### 处理放置效果
 
-{{event("drop")}} 事件的处理程序是以程序指定的方法处理拖拽数据。一般，程序调用 {{domxref("DataTransfer.getData","getData()")}} 方法取出拖拽项目并按一定方式处理。程序意义根据 {{domxref("DataTransfer.dropEffect","dropEffect")}} 的值与/或可变更关键字的状态而不同
+[`drop`](/zh-CN/docs/Web/API/HTMLElement/drop_event) 事件的处理程序是以程序指定的方法处理拖拽数据。一般，程序调用 {{domxref("DataTransfer.getData","getData()")}} 方法取出拖拽项目并按一定方式处理。程序意义根据 {{domxref("DataTransfer.dropEffect","dropEffect")}} 的值与/或可变更关键字的状态而不同
 
 下面的例子展示了一个处理程序，从拖拽数据中获取事件源元素的 `id` 然后根据 `id` 移动源元素到目标元素：
 
@@ -196,7 +196,7 @@ function drop_handler(ev) {
 
 ### 拖拽结束
 
-拖拽操作结束时，在源元素（开始拖拽时的目标元素）上触发 {{event("dragend")}} 事件。不管拖拽是完成还是被取消这个事件都会被触发。{{event("dragend")}} 事件处理程序可以检查{{domxref("DataTransfer.dropEffect","dropEffect")}} 属性的值来确认拖拽成功与否。
+拖拽操作结束时，在源元素（开始拖拽时的目标元素）上触发 [`dragend`](/zh-CN/docs/Web/API/HTMLElement/dragend_event) 事件。不管拖拽是完成还是被取消这个事件都会被触发。[`dragend`](/zh-CN/docs/Web/API/HTMLElement/dragend_event) 事件处理程序可以检查{{domxref("DataTransfer.dropEffect","dropEffect")}} 属性的值来确认拖拽成功与否。
 
 更多关于处理拖拽结束的信息请参见 [结束拖拽](/zh-CN/docs/DragDrop/Drag_Operations#dragend)。
 

--- a/files/zh-cn/web/api/html_drag_and_drop_api/multiple_items/index.md
+++ b/files/zh-cn/web/api/html_drag_and_drop_api/multiple_items/index.md
@@ -13,7 +13,7 @@ Mozilla 提供了一些额外的非标准方法来支持多个元素的拖拽。
 
 ## 基于索引的添加和获取
 
-{{domxref("DataTransfer.mozSetDataAt","mozSetDataAt()")}} 方法可以让你在 {{event("dragstart")}} 事件里添加多个元素。该函数功能类似于 {{domxref("DataTransfer.setData","setData()")}}。
+{{domxref("DataTransfer.mozSetDataAt","mozSetDataAt()")}} 方法可以让你在 [`dragstart`](/zh-CN/docs/Web/API/HTMLElement/dragstart_event) 事件里添加多个元素。该函数功能类似于 {{domxref("DataTransfer.setData","setData()")}}。
 
 ```
 var dt = event.dataTransfer;
@@ -62,7 +62,7 @@ dt.mozClearDataAt("text/plain", 1);
 
 比较常见的使用多元素拖拽的场景，例如多个文件或者多个书签的拖拽中，记得给每个元素设置合适的数据项类型。尽管不是必须的，但你应该为所有元素设置一致的数据项类型，这可以确保目标元素接收到和预期一致的数据。
 
-你可以通过检查 {{domxref("DataTransfer.mozItemCount","mozItemCount")}} 属性来判断是否有多个元素被拖拽。该属性的值等于当前被拖拽的元素的个数。如果某个拖拽的目标元素只接受单个拖拽元素，它可以直接拒绝这次拖拽操作或者只接受其中的第一个元素。若需要拒绝这些元素，你可以不阻止 {{event("dragover")}} 事件，或者设置 {{domxref("DataTransfer.effectAllowed","effectAllowed")}} 属性为 `none`。最好将两者结合使用，因为有可能另一个监听函数已经阻止了事件。
+你可以通过检查 {{domxref("DataTransfer.mozItemCount","mozItemCount")}} 属性来判断是否有多个元素被拖拽。该属性的值等于当前被拖拽的元素的个数。如果某个拖拽的目标元素只接受单个拖拽元素，它可以直接拒绝这次拖拽操作或者只接受其中的第一个元素。若需要拒绝这些元素，你可以不阻止 [`dragover`](/zh-CN/docs/Web/API/HTMLElement/dragover_event) 事件，或者设置 {{domxref("DataTransfer.effectAllowed","effectAllowed")}} 属性为 `none`。最好将两者结合使用，因为有可能另一个监听函数已经阻止了事件。
 
 若只接受拖拽的第一个元素，可以使用 {{domxref("DataTransfer.getData","getData()")}} 方法，就和处理单个元素一样。拖拽的目标只需支持单个元素的拖拽而无需任何额外的操作就可以适用于这个场景。
 
@@ -151,7 +151,7 @@ function output(text)
 </html>
 ```
 
-这个例子中通过调用 {{domxref("Event.preventDefault","preventDefault()")}} 方法，阻止了 `{{event("dragenter")}}` 和 `{{event("dragover")}}` 事件。这使放置事件可以在该的元素上被触发。
+这个例子中通过调用 {{domxref("Event.preventDefault","preventDefault()")}} 方法，阻止了 `[`dragenter`](/zh-CN/docs/Web/API/HTMLElement/dragenter_event)` 和 `[`dragover`](/zh-CN/docs/Web/API/HTMLElement/dragover_event)` 事件。这使放置事件可以在该的元素上被触发。
 
 当放下一个元素时， `dodrop` 事件处理函数将会被调用。它会检查 {{domxref("DataTransfer.mozItemCount","mozItemCount")}} 属性来获取有多少元素被放下并且遍历他们。对于每个元素，都会通过调用 {{domxref("DataTransfer.mozTypesAt","mozTypesAt()")}} 方法来获得类型列表。数据类型列表也将被遍历以获取到所有和被拖拽元素相关的信息。
 

--- a/files/zh-cn/web/api/htmlbodyelement/index.md
+++ b/files/zh-cn/web/api/htmlbodyelement/index.md
@@ -34,37 +34,37 @@ _No specific methods; inherits methods from its parent, {{domxref("HTMLElement")
 No specific event handlers; inherits event handlers from its parent, {{domxref("HTMLElement")}}.
 
 - {{domxref("window.afterprint_event", "HTMLBodyElement.onafterprint")}}
-  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("afterprint")}} event is raised.
+  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the [`afterprint`](/zh-CN/docs/Web/API/Window/afterprint_event) event is raised.
 - {{domxref("window.beforeprint_event", "HTMLBodyElement.onbeforeprint")}}
-  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("beforeprint")}} event is raised.
+  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the [`beforeprint`](/zh-CN/docs/Web/API/Window/beforeprint_event) event is raised.
 - {{domxref("window.beforeunload_event", "HTMLBodyElement.onbeforeunload")}}
-  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("beforeunload")}} event is raised.
+  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the [`beforeunload`](/zh-CN/docs/Web/API/Window/beforeunload_event) event is raised.
 - {{domxref("window.hashchange_event", "HTMLBodyElement.onhashchange")}}
-  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("hashchange")}} event is raised.
+  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the [`hashchange`](/zh-CN/docs/Web/API/Window/hashchange_event) event is raised.
 - {{domxref("window.languagechange_event", "HTMLBodyElement.onlanguagechange")}} {{experimental_inline}}
-  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("languagechange")}} event is raised.
+  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the [`languagechange`](/zh-CN/docs/Web/API/Window/languagechange_event) event is raised.
 - {{domxref("window.message_event", "HTMLBodyElement.onmessage")}}
   - : Is an {{event("Event_handlers", "event handler")}} called whenever an object receives a {{event("message")}} event.
 - {{domxref("window.messageerror_event", "HTMLBodyElement.onmessageerror")}}
   - : Is an {{event("Event_handlers", "event handler")}} called whenever an object receives a {{event("messageerror")}} event.
 - {{domxref("window.offline_event", "HTMLBodyElement.onoffline")}}
-  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("offline")}} event is raised.
+  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the [`offline`](/zh-CN/docs/Web/API/Window/offline_event) event is raised.
 - {{domxref("window.online_event", "HTMLBodyElement.ononline")}}
-  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("online")}} event is raised.
+  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the [`online`](/zh-CN/docs/Web/API/Window/online_event) event is raised.
 - {{domxref("window.pagehide_event", "HTMLBodyElement.onpagehide")}}
-  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("pagehide")}} event is raised.
+  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the [`pagehide`](/zh-CN/docs/Web/API/Window/pagehide_event) event is raised.
 - {{domxref("window.pageshow_event", "HTMLBodyElement.onpageshow")}}
-  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("pageshow")}} event is raised.
+  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the [`pageshow`](/zh-CN/docs/Web/API/Window/pageshow_event) event is raised.
 - {{domxref("window.popstate_event", "HTMLBodyElement.onpopstate")}}
-  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("popstate")}} event is raised.
+  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the [`popstate`](/zh-CN/docs/Web/API/Window/popstate_event) event is raised.
 - {{domxref("window.rejectionhandled_event", "HTMLBodyElement.onrejectionhandled")}}
   - : An {{event("Event_handlers", "event handler")}} representing the code executed when the {{event("rejectionhandled")}} event is raised, indicating that a {{jsxref("Promise")}} was rejected and the rejection has been handled.
 - {{domxref("window.storage_event", "HTMLBodyElement.onstorage")}}
-  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("storage")}} event is raised.
+  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the [`storage`](/zh-CN/docs/Web/API/Window/storage_event) event is raised.
 - {{domxref("window.unhandledrejection_event", "HTMLBodyElement.onunhandledrejection")}}
   - : An {{event("Event_handlers", "event handler")}} representing the code executed when the {{event("unhandledrejection")}} event is raised, indicating that a {{jsxref("Promise")}} was rejected but the rejection was not handled.
 - {{domxref("window.unload_event", "HTMLBodyElement.onunload")}}
-  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("unload")}} event is raised.
+  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the [`unload`](/zh-CN/docs/Web/API/Window/unload_event) event is raised.
 
 ## 规范
 

--- a/files/zh-cn/web/api/htmlelement/dragenter_event/index.md
+++ b/files/zh-cn/web/api/htmlelement/dragenter_event/index.md
@@ -72,11 +72,11 @@ original_slug: Web/API/Document/dragenter_event
 
 ## 相关
 
-- {{event("drag")}}
-- {{event("dragstart")}}
-- {{event("dragend")}}
-- {{event("dragover")}}
-- {{event("dragenter")}}
-- {{event("dragleave")}}
+- [`drag`](/zh-CN/docs/Web/API/HTMLElement/drag_event)
+- [`dragstart`](/zh-CN/docs/Web/API/HTMLElement/dragstart_event)
+- [`dragend`](/zh-CN/docs/Web/API/HTMLElement/dragend_event)
+- [`dragover`](/zh-CN/docs/Web/API/HTMLElement/dragover_event)
+- [`dragenter`](/zh-CN/docs/Web/API/HTMLElement/dragenter_event)
+- [`dragleave`](/zh-CN/docs/Web/API/HTMLElement/dragleave_event)
 - {{event("dragexit")}}
-- {{event("drop")}}
+- [`drop`](/zh-CN/docs/Web/API/HTMLElement/drop_event)

--- a/files/zh-cn/web/api/htmlelement/dragover_event/index.md
+++ b/files/zh-cn/web/api/htmlelement/dragover_event/index.md
@@ -76,11 +76,11 @@ original_slug: Web/API/Document/dragover_event
 
 ## 相关
 
-- {{event("drag")}}
-- {{event("dragstart")}}
-- {{event("dragend")}}
-- {{event("dragover")}}
-- {{event("dragenter")}}
-- {{event("dragleave")}}
+- [`drag`](/zh-CN/docs/Web/API/HTMLElement/drag_event)
+- [`dragstart`](/zh-CN/docs/Web/API/HTMLElement/dragstart_event)
+- [`dragend`](/zh-CN/docs/Web/API/HTMLElement/dragend_event)
+- [`dragover`](/zh-CN/docs/Web/API/HTMLElement/dragover_event)
+- [`dragenter`](/zh-CN/docs/Web/API/HTMLElement/dragenter_event)
+- [`dragleave`](/zh-CN/docs/Web/API/HTMLElement/dragleave_event)
 - {{event("dragexit")}}
-- {{event("drop")}}
+- [`drop`](/zh-CN/docs/Web/API/HTMLElement/drop_event)

--- a/files/zh-cn/web/api/htmlelement/dragstart_event/index.md
+++ b/files/zh-cn/web/api/htmlelement/dragstart_event/index.md
@@ -161,11 +161,11 @@ original_slug: Web/API/Document/dragstart_event
 
 ## 相关事件
 
-- {{event("drag")}}
-- {{event("dragstart")}}
-- {{event("dragend")}}
-- {{event("dragover")}}
-- {{event("dragenter")}}
-- {{event("dragleave")}}
+- [`drag`](/zh-CN/docs/Web/API/HTMLElement/drag_event)
+- [`dragstart`](/zh-CN/docs/Web/API/HTMLElement/dragstart_event)
+- [`dragend`](/zh-CN/docs/Web/API/HTMLElement/dragend_event)
+- [`dragover`](/zh-CN/docs/Web/API/HTMLElement/dragover_event)
+- [`dragenter`](/zh-CN/docs/Web/API/HTMLElement/dragenter_event)
+- [`dragleave`](/zh-CN/docs/Web/API/HTMLElement/dragleave_event)
 - {{event("dragexit")}}
-- {{event("drop")}}
+- [`drop`](/zh-CN/docs/Web/API/HTMLElement/drop_event)

--- a/files/zh-cn/web/api/htmlelement/index.md
+++ b/files/zh-cn/web/api/htmlelement/index.md
@@ -47,17 +47,17 @@ _继承自父接口 {{domxref("Element")}} 和 {{domxref("GlobalEventHandlers")}
 The events properties, of the form `onXYZ`, are defined on the {{domxref("GlobalEventHandlers")}}, implemented by `HTMLElement`. A few more are specific to `HTMLElement`.
 
 - {{domxref("HTMLElement.onTouchStart")}} {{non-standard_inline}}
-  - : Returns the event handling code for the {{event("touchstart")}} event.
+  - : Returns the event handling code for the [`touchstart`](/zh-CN/docs/Web/API/Element/touchstart_event) event.
 - {{domxref("HTMLElement.onTouchEnd")}} {{non-standard_inline}}
-  - : Returns the event handling code for the {{event("touchend")}} event.
+  - : Returns the event handling code for the [`touchend`](/zh-CN/docs/Web/API/Element/touchend_event) event.
 - {{domxref("HTMLElement.onTouchMove")}} {{non-standard_inline}}
-  - : Returns the event handling code for the {{event("touchmove")}} event.
+  - : Returns the event handling code for the [`touchmove`](/zh-CN/docs/Web/API/Element/touchmove_event) event.
 - {{domxref("HTMLElement.onTouchEnter")}} {{non-standard_inline}}
   - : Returns the event handling code for the {{event("touchenter")}} event.
 - {{domxref("HTMLElement.onTouchLeave")}} {{non-standard_inline}}
   - : Returns the event handling code for the {{event("touchleave")}} event.
 - {{domxref("HTMLElement.onTouchCancel")}} {{non-standard_inline}}
-  - : Returns the event handling code for the {{event("touchcancel")}} event.
+  - : Returns the event handling code for the [`touchcancel`](/zh-CN/docs/Web/API/Element/touchcancel_event) event.
 
 ## 方法
 

--- a/files/zh-cn/web/api/htmlelement/input_event/index.md
+++ b/files/zh-cn/web/api/htmlelement/input_event/index.md
@@ -30,7 +30,7 @@ slug: Web/API/HTMLElement/input_event
 
 **`input`** 事件也适用于启用了 {{domxref("HTMLElement.contentEditable", "contenteditable")}} 的元素，以及开启了 {{domxref("Document.designMode", "designMode")}} 的任意元素。在`contenteditable` 和 `designMode` 的情况下，事件的 target 为当前正在编辑的宿主。如果这些属性应用于多个元素上，当前正在编辑的宿主为最近的父节点不可编辑的祖先元素。
 
-对于 `type=checkbox` 或 `type=radio` 的 `input` 元素，每当用户切换控件（通过触摸、鼠标或键盘）时（[HTML5 规范](https://html.spec.whatwg.org/multipage/input.html#the-input-element:event-input-2)），`input` 事件都应该触发。然而，历史事实并非如此。请检查兼容性，或使用 {{event("change")}} 事件代替这些类型的元素。
+对于 `type=checkbox` 或 `type=radio` 的 `input` 元素，每当用户切换控件（通过触摸、鼠标或键盘）时（[HTML5 规范](https://html.spec.whatwg.org/multipage/input.html#the-input-element:event-input-2)），`input` 事件都应该触发。然而，历史事实并非如此。请检查兼容性，或使用 [`change`](/zh-CN/docs/Web/API/HTMLElement/change_event) 事件代替这些类型的元素。
 
 > **备注：** 每当元素的 `value` 改变，`input` 事件都会被触发。这与 {{domxref("HTMLInputElement.change_event", "change")}} 事件不同。change 事件仅当 value 被提交时触发，如按回车键，从一个 options 列表中选择一个值等。
 
@@ -89,10 +89,10 @@ function updateValue(e) {
 
 ## 参见
 
-- {{event("keydown")}}
-- {{event("keyup")}}
-- {{event("keypress")}}
-- {{event("input")}}
+- [`keydown`](/zh-CN/docs/Web/API/Element/keydown_event)
+- [`keyup`](/zh-CN/docs/Web/API/Element/keyup_event)
+- [`keypress`](/zh-CN/docs/Web/API/Element/keypress_event)
+- [`input`](/zh-CN/docs/Web/API/HTMLElement/input_event)
 - {{domxref("HTMLElement/beforeinput_event", "beforeinput")}}
 - {{domxref("HTMLElement/change_event", "change")}}
 - {{domxref("HTMLInputElement/invalid_event", "invalid")}}

--- a/files/zh-cn/web/api/htmlformelement/index.md
+++ b/files/zh-cn/web/api/htmlformelement/index.md
@@ -39,7 +39,7 @@ _继承自父类的属性，{{domxref("HTMLElement")}}._
 _这个元素继承了 {{domxref("HTMLElement")}} 的属性。_
 
 - {{domxref("HTMLFormElement.checkValidity()")}}
-  - : Returns a {{jsxref("Boolean")}} that is `true` if the element's child controls are subject to constraint validation and satify those contraints, or `false` if some controls do not satisfy their constraints. Fires an event named {{event("invalid")}} at any control that does not satisfy its constraints; such controls are considered invalid if the event is not canceled. It is up to the programmer to decide how to respond to `false`.
+  - : Returns a {{jsxref("Boolean")}} that is `true` if the element's child controls are subject to constraint validation and satify those contraints, or `false` if some controls do not satisfy their constraints. Fires an event named [`invalid`](/zh-CN/docs/Web/API/HTMLInputElement/invalid_event) at any control that does not satisfy its constraints; such controls are considered invalid if the event is not canceled. It is up to the programmer to decide how to respond to `false`.
 - {{domxref("HTMLFormElement.item()")}}
   - : Gets the item in the `elements` collection at the specified index, or null if there is no item at that index. You can also specify the index in array-style brackets or parentheses after the form object name, without calling this method explicitly.
 - {{domxref("HTMLFormElement.namedItem()")}}

--- a/files/zh-cn/web/api/htmlformelement/submit/index.md
+++ b/files/zh-cn/web/api/htmlformelement/submit/index.md
@@ -9,7 +9,7 @@ slug: Web/API/HTMLFormElement/submit
 
 这个方法和触发提交表单按钮很类似，但有所不同：
 
-- 没有引发 {{event("submit")}} 事件。即，表单的 {{domxref("GlobalEventHandlers.onsubmit", "onsubmit")}} 事件处理程序不会运行。
+- 没有引发 [`submit`](/zh-CN/docs/Web/API/HTMLFormElement/submit_event) 事件。即，表单的 {{domxref("GlobalEventHandlers.onsubmit", "onsubmit")}} 事件处理程序不会运行。
 - 不会触发[约束验证](/zh-CN/docs/Web/Guide/HTML/Constraint_validation) 。
 
 {{domxref("HTMLFormElement.requestSubmit()")}} 方法与触发表单提交的 {{HtmlElement("button")}} 的效果是相同的。

--- a/files/zh-cn/web/api/htmlimageelement/decode/index.md
+++ b/files/zh-cn/web/api/htmlimageelement/decode/index.md
@@ -31,7 +31,7 @@ var promise = HTMLImageElement.decode();
 
 ## 例子
 
-以下例子展示了如何使用 `decode()` 方法来控制一个图像插入 DOM 的时机。若不使用 {{domxref('Promise')}} 返回方法，你将在图像的 {{event("load")}} 事件处理函数中将图像加入 DOM 中，通过 {{event("error")}} 事件处理函数处理错误。
+以下例子展示了如何使用 `decode()` 方法来控制一个图像插入 DOM 的时机。若不使用 {{domxref('Promise')}} 返回方法，你将在图像的 [`load`](/zh-CN/docs/Web/API/Window/load_event) 事件处理函数中将图像加入 DOM 中，通过 [`error`](/zh-CN/docs/Web/API/Element/error_event) 事件处理函数处理错误。
 
 ```js
 const img = new Image();

--- a/files/zh-cn/web/api/htmlimageelement/index.md
+++ b/files/zh-cn/web/api/htmlimageelement/index.md
@@ -86,7 +86,7 @@ _从它的父元素 {{domxref("HTMLElement")}} 继承的方法。_
 - The specified image's metadata is corrupted in such a way that it's impossible to retrieve its dimensions, and no dimensions were specified in the `<img>` element's attributes.
 - The specified image is in a format not supported by the {{Glossary("user agent")}}.
 
-If an error occurs while trying to load or render the image, and an {{htmlattrxref("onerror")}} event handler has been configured to handle the {{event("error")}} event, that event handler will get called. This can happen in a number of situations, including:
+If an error occurs while trying to load or render the image, and an {{htmlattrxref("onerror")}} event handler has been configured to handle the [`error`](/zh-CN/docs/Web/API/Element/error_event) event, that event handler will get called. This can happen in a number of situations, including:
 
 ## 例子
 

--- a/files/zh-cn/web/api/htmlinputelement/index.md
+++ b/files/zh-cn/web/api/htmlinputelement/index.md
@@ -267,7 +267,7 @@ slug: Web/API/HTMLInputElement
         Returns a {{jsxref("Boolean")}} that is <code>false</code> if the
         element is a candidate for constraint validation, and it does not
         satisfy its constraints. In this case, it also fires an
-        {{event("invalid")}} event at the element. It returns
+        [`invalid`](/zh-CN/docs/Web/API/HTMLInputElement/invalid_event) event at the element. It returns
         <code>true</code> if the element is not a candidate for constraint
         validation, or if it satisfies its constraints.
       </td>

--- a/files/zh-cn/web/api/htmlinputelement/invalid_event/index.md
+++ b/files/zh-cn/web/api/htmlinputelement/invalid_event/index.md
@@ -30,7 +30,7 @@ slug: Web/API/HTMLInputElement/invalid_event
 
 这个事件可用于展示提交表单时所出现的问题的概览。当表单提交时，若任一表单控件无效，则会触发 `invalid` 事件。对可提交元素有效性的检查是在提交父元素 {{HtmlElement("form")}} 之前或调用父元素 `<form>` 或元素自己的 [`checkValidity()`](/zh-CN/docs/Learn/Forms#constraint_validation_api) 方法之后。
 
-这个事件不会在 {{Event("blur")}} 事件中触发。
+这个事件不会在 [`blur`](/zh-CN/docs/Web/API/Element/blur_event) 事件中触发。
 
 ## 示例
 
@@ -75,5 +75,5 @@ function logValue(e) {
 ## 参见
 
 - HTML {{HtmlElement("form")}} 元素
-- 相关事件：{{Event("submit")}}
+- 相关事件：[`submit`](/zh-CN/docs/Web/API/HTMLFormElement/submit_event)
 - [CSS `:invalid` 伪类](/zh-CN/docs/Web/CSS/:invalid)

--- a/files/zh-cn/web/api/htmlinputelement/webkitdirectory/index.md
+++ b/files/zh-cn/web/api/htmlinputelement/webkitdirectory/index.md
@@ -55,7 +55,7 @@ slug: Web/API/HTMLInputElement/webkitdirectory
 
 ## 示例
 
-在这个例子中，提供了一个目录选择器，它使用户可以选择一个或多个目录。当{{event("change")}}事件被触发的时候，将生成并显示所选目录层次结构中包含的所有文件的列表。
+在这个例子中，提供了一个目录选择器，它使用户可以选择一个或多个目录。当[`change`](/zh-CN/docs/Web/API/HTMLElement/change_event)事件被触发的时候，将生成并显示所选目录层次结构中包含的所有文件的列表。
 
 ### HTML 内容
 

--- a/files/zh-cn/web/api/htmlmediaelement/load/index.md
+++ b/files/zh-cn/web/api/htmlmediaelement/load/index.md
@@ -32,7 +32,7 @@ The process of aborting any ongoing activities will cause any outstanding {{jsxr
 在 load 过程中 合适的事件会发生并通知给媒体本身，包括：
 
 - 如果已经是 `load` 过了，则 `abort` 事件发送给媒体。
-- If the element has already been initialized with media, the **{{event("emptied")}}** event is sent.
+- If the element has already been initialized with media, the **[`emptied`](/zh-CN/docs/Web/API/HTMLMediaElement/emptied_event)** event is sent.
 - 如果重置播放位置到开始，通常指修改播放位置，**timeupdate** 事件触发。
 - 当已经选择了源并且已经准备加载内容了，**loadstart** 事件触发。
 - 之前的几点，媒体加载并且事件已经送达

--- a/files/zh-cn/web/api/htmlmediaelement/loadedmetadata_event/index.md
+++ b/files/zh-cn/web/api/htmlmediaelement/loadedmetadata_event/index.md
@@ -5,7 +5,7 @@ slug: Web/API/HTMLMediaElement/loadedmetadata_event
 
 {{ ApiRef("HTML DOM") }}
 
-{{domxref("GlobalEventHandlers")}} mixin 的 **`onloadedmetadata`** 属性是处理{{event("loadedmetadata")}}事件的{{event("Event_handlers", "event handler")}}。
+{{domxref("GlobalEventHandlers")}} mixin 的 **`onloadedmetadata`** 属性是处理[`loadedmetadata`](/zh-CN/docs/Web/API/HTMLMediaElement/loadedmetadata_event)事件的{{event("Event_handlers", "event handler")}}。
 
 `loadedmetadata`事件在元数据（metadata）被加载完成后触发。
 
@@ -28,5 +28,5 @@ var handlerFunction = element.onloadedmetadata;
 
 ## 参考
 
-- {{event("loadedmetadata")}}
+- [`loadedmetadata`](/zh-CN/docs/Web/API/HTMLMediaElement/loadedmetadata_event)
 - [DOM 事件句柄](/zh-CN/docs/Web/Guide/Events/Event_handlers)

--- a/files/zh-cn/web/api/htmlmediaelement/play/index.md
+++ b/files/zh-cn/web/api/htmlmediaelement/play/index.md
@@ -76,7 +76,7 @@ function handlePlayButton() {
 
 在这个例子中，视频的播放由 [`async`](/zh-CN/docs/Web/JavaScript/Reference/Statements/async_function) `playVideo()` 函数控制。函数尝试播放视频，如果播放成功，将 `playButton` 元素的类名称设为 `"playing"`。如果播放失败，去除 `playButton` 元素的类名称，恢复其原来的样式。通过监视 `play()` 返回的 {{jsxref("Promise")}} 是被解决还是被拒绝以保证播放按钮的外观与实际的播放状态相匹配。
 
-上述代码开始执行时，先获取 {{HTMLElement("video")}} 元素和用于切换播放、暂停的 {{HTMLElement("button")}} 元素的引用。在切换按钮上添加 {{event("click")}} 事件的处理程序。最后调用 `playVideo()` 尝试自动开始播放。
+上述代码开始执行时，先获取 {{HTMLElement("video")}} 元素和用于切换播放、暂停的 {{HTMLElement("button")}} 元素的引用。在切换按钮上添加 [`click`](/zh-CN/docs/Web/API/Element/click_event) 事件的处理程序。最后调用 `playVideo()` 尝试自动开始播放。
 
 你可以在 [这里](https://media-play-promise.glitch.me/) 查看或修改这个例子。
 

--- a/files/zh-cn/web/api/htmlselectelement/checkvalidity/index.md
+++ b/files/zh-cn/web/api/htmlselectelement/checkvalidity/index.md
@@ -5,7 +5,7 @@ slug: Web/API/HTMLSelectElement/checkValidity
 
 {{ APIRef("HTML DOM") }}
 
-**`HTMLSelectElement.checkValidity()`** 会检查元素是否有任何输入约束条件，并且检查值是否符合约束条件。如果值是不符合约束条件的，浏览器就会在该元素上触发一个可以撤销的 {{event("invalid")}} 事件，然后返回 `false`.
+**`HTMLSelectElement.checkValidity()`** 会检查元素是否有任何输入约束条件，并且检查值是否符合约束条件。如果值是不符合约束条件的，浏览器就会在该元素上触发一个可以撤销的 [`invalid`](/zh-CN/docs/Web/API/HTMLInputElement/invalid_event) 事件，然后返回 `false`.
 
 ## Syntax
 

--- a/files/zh-cn/web/api/idbfilehandle/index.md
+++ b/files/zh-cn/web/api/idbfilehandle/index.md
@@ -23,11 +23,11 @@ slug: Web/API/IDBFileHandle
 ### 事件处理
 
 - {{domxref("LockedFile.oncomplete")}}
-  - : 每次读取或写入操作成功时触发 {{event("complete")}} 事件。
+  - : 每次读取或写入操作成功时触发 [`complete`](/zh-CN/docs/Web/API/OfflineAudioContext/complete_event) 事件。
 - {{domxref("LockedFile.onabort")}}
-  - : 每次调用{{domxref("LockedFile.abort()","abort()")}} 方法时会触发{{event("abort")}}事件。
+  - : 每次调用{{domxref("LockedFile.abort()","abort()")}} 方法时会触发[`abort`](/zh-CN/docs/Web/API/HTMLMediaElement/abort_event)事件。
 - {{domxref("LockedFile.onerror")}}
-  - : 在每次出现问题时触发{{event("error")}}事件。
+  - : 在每次出现问题时触发[`error`](/zh-CN/docs/Web/API/Element/error_event)事件。
 
 ## 方法
 

--- a/files/zh-cn/web/api/inputevent/index.md
+++ b/files/zh-cn/web/api/inputevent/index.md
@@ -21,7 +21,7 @@ slug: Web/API/InputEvent
 - {{domxref("InputEvent.data")}} {{readOnlyInline}}
   - : 返回当前输入的字符串，如果是删除操作，则该值为空字符串。
 - {{domxref("InputEvent.isComposing")}}{{readOnlyInline}}
-  - : 返回一个布尔值，表明该事件是在触发 {{event("compositionstart")}} 事件之后且触发 {{event("compositionend")}} 事件之前触发的，也就是表明当前输入的字符是输入法的中途输入。
+  - : 返回一个布尔值，表明该事件是在触发 [`compositionstart`](/zh-CN/docs/Web/API/Element/compositionstart_event) 事件之后且触发 [`compositionend`](/zh-CN/docs/Web/API/Element/compositionend_event) 事件之前触发的，也就是表明当前输入的字符是输入法的中途输入。
 
 ## 方法
 
@@ -38,4 +38,4 @@ slug: Web/API/InputEvent
 ## 相关链接
 
 - {{ event("beforeinput") }}
-- {{ event("input") }}
+- [`input`](/zh-CN/docs/Web/API/HTMLElement/input_event)

--- a/files/zh-cn/web/api/inputevent/inputevent/index.md
+++ b/files/zh-cn/web/api/inputevent/inputevent/index.md
@@ -24,7 +24,7 @@ slug: Web/API/InputEvent/InputEvent
     - `inputType`（可选），指定可编辑内容更改类型的字符串，例如插入、删除或格式化文本。
     - `data`（可选），包含要插入的字符的字符串。如果更改未插入文本（例如删除字符时），则其可能为空字符串。
     - `dataTransfer`（可选），一个 {{domxref("DataTransfer")}} 对象，其中包含有关添加到可编辑内容，或从可编辑内容中删除的富文本或纯文本数据的信息。
-    - `isComposing`（可选），一个布尔值，指示事件是组合会话的一部分，这意味着它在 {{event("compositionstart")}} 事件之后，但在 {{event("compositionend")}} 事件之前。默认值为 `false`。
+    - `isComposing`（可选），一个布尔值，指示事件是组合会话的一部分，这意味着它在 [`compositionstart`](/zh-CN/docs/Web/API/Element/compositionstart_event) 事件之后，但在 [`compositionend`](/zh-CN/docs/Web/API/Element/compositionend_event) 事件之前。默认值为 `false`。
     - `ranges`（可选），一个静态 {{domxref("Range")}} 数组，如果输入事件没有被取消，它将受到对 DOM 的更改的影响。
 
 `InputEventInit` 字典也接受来自 {{domxref("UIEvent.UIEvent", "UIEventInit")}} 以及 {{domxref("Event.Event", "EventInit")}} 字典的值。

--- a/files/zh-cn/web/api/inputevent/iscomposing/index.md
+++ b/files/zh-cn/web/api/inputevent/iscomposing/index.md
@@ -5,7 +5,7 @@ slug: Web/API/InputEvent/isComposing
 
 {{APIRef("DOM Events")}}
 
-The **`InputEvent.isComposing`** read-only property returns a {{jsxref("Boolean")}} value indicating if the event is fired after {{event("compositionstart")}} and before {{event("compositionend")}}.
+The **`InputEvent.isComposing`** read-only property returns a {{jsxref("Boolean")}} value indicating if the event is fired after [`compositionstart`](/zh-CN/docs/Web/API/Element/compositionstart_event) and before [`compositionend`](/zh-CN/docs/Web/API/Element/compositionend_event).
 
 ## 这是一个只读属性，返回 boolean 类型。表示正处于输入事件的开始与结束之间，表示正在输入状态。
 
@@ -32,5 +32,5 @@ console.log(inputEvent.isComposing); // return false
 
 ## See also
 
-- {{ event("compositionstart") }} and {{ event("compositionend")}}
+- [`compositionstart`](/zh-CN/docs/Web/API/Element/compositionstart_event) and [`compositionend`](/zh-CN/docs/Web/API/Element/compositionend_event)
 - {{domxref("InputEvent")}}

--- a/files/zh-cn/web/api/intersection_observer_api/index.md
+++ b/files/zh-cn/web/api/intersection_observer_api/index.md
@@ -405,7 +405,7 @@ The constants and variables we set up here are:
 - `decreasingColor`
   - : Similarly, this is a string defining a color we'll apply when the visibility ratio is decreasing.
 
-We call {{domxref("EventTarget.addEventListener", "Window.addEventListener()")}} to start listening for the {{event("load")}} event; once the page has finished loading, we get a reference to the element with the ID `"box"` using {{domxref("Document.querySelector", "querySelector()")}}, then call the `createObserver()` method we'll create in a moment to handle building and installing the intersection observer.
+We call {{domxref("EventTarget.addEventListener", "Window.addEventListener()")}} to start listening for the [`load`](/zh-CN/docs/Web/API/Window/load_event) event; once the page has finished loading, we get a reference to the element with the ID `"box"` using {{domxref("Document.querySelector", "querySelector()")}}, then call the `createObserver()` method we'll create in a moment to handle building and installing the intersection observer.
 
 #### Creating the intersection observer
 

--- a/files/zh-cn/web/api/intersection_observer_api/timing_element_visibility/index.md
+++ b/files/zh-cn/web/api/intersection_observer_api/timing_element_visibility/index.md
@@ -245,7 +245,7 @@ function startup() {
 }
 ```
 
-First, a reference to the content wrapping {{HTMLElement("main")}} element is obtained, so we can insert our content into it. Then we set up an event listener for the {{event("visibilitychange")}} event. This event is sent when the document becomes hidden or visible, such as when the user switches tabs in their browser. The Intersection Observer API doesn't take this into account when detecting intersection, since intersection isn't affected by page visibility. Therefore, we need to pause our timers while the page is tabbed out; hence this event listener.
+First, a reference to the content wrapping {{HTMLElement("main")}} element is obtained, so we can insert our content into it. Then we set up an event listener for the [`visibilitychange`](/zh-CN/docs/Web/API/Document/visibilitychange_event) event. This event is sent when the document becomes hidden or visible, such as when the user switches tabs in their browser. The Intersection Observer API doesn't take this into account when detecting intersection, since intersection isn't affected by page visibility. Therefore, we need to pause our timers while the page is tabbed out; hence this event listener.
 
 Next we set up the options for the {{domxref("IntersectionObserver")}} which will monitor target elements (ads, in our case) for intersection changes relative to the document. The options are configured to watch for intersections with the document's viewport (by setting `root` to `null`). We have no margins to extend or contract the intersection root's rectangle; we want to match the boundaries of the document's viewport exactly for intersection purposes. And the `threshold` is set to an array containing the values 0.0 and 0.75; this will cause our callback to execute whenever a targeted element becomes completely obscured or first starts to become unobscured (intersection ratio 0.0) or passes through 75% visible in either direction (intersection ratio 0.75).
 
@@ -257,7 +257,7 @@ Finally, we set up an interval which triggers once a second to handle any necess
 
 ### Handling document visibility changes
 
-Let's take a look at the handler for the {{event("visibilitychange")}} event. Our script receives this event when the document itself becomes visible or invisible. The most important scenario here is when the user switches tabs. Since Intersection Observer only cares about the intersection between the targeted elements and the intersection root, and not the tab's visibility (which is a different issue entirely), we need to use the [Page Visibility API](/zh-CN/docs/Web/API/Page_Visibility_API) to detect these tab switches and disable our timers for the duration.
+Let's take a look at the handler for the [`visibilitychange`](/zh-CN/docs/Web/API/Document/visibilitychange_event) event. Our script receives this event when the document itself becomes visible or invisible. The most important scenario here is when the user switches tabs. Since Intersection Observer only cares about the intersection between the targeted elements and the intersection root, and not the tab's visibility (which is a different issue entirely), we need to use the [Page Visibility API](/zh-CN/docs/Web/API/Page_Visibility_API) to detect these tab switches and disable our timers for the duration.
 
 ```js
 function handleVisibilityChange() {

--- a/files/zh-cn/web/api/keyboardevent/code/index.md
+++ b/files/zh-cn/web/api/keyboardevent/code/index.md
@@ -58,7 +58,7 @@ To ensure that keystrokes go to the sample, click in the output box below before
 
 ### Handle keyboard events in a game
 
-This example establishes an event listener for {{event("keydown")}} events which handles keyboard input for a game which uses the typical "WASD" keyboard layout for steering forward, left, backward, and right. This will use the same four keys physically regardless of what the actual corresponding characters are, such as if the user is using an AZERTY keyboard.
+This example establishes an event listener for [`keydown`](/zh-CN/docs/Web/API/Element/keydown_event) events which handles keyboard input for a game which uses the typical "WASD" keyboard layout for steering forward, left, backward, and right. This will use the same four keys physically regardless of what the actual corresponding characters are, such as if the user is using an AZERTY keyboard.
 
 #### HTML
 
@@ -145,7 +145,7 @@ function refresh() {
 }
 ```
 
-Finally, the `addEventListener()` method is used to start listening for {{event("keydown")}} events, acting on each key by updating the ship position and rotation angle, then calling `refresh()` to draw the ship at its new position and angle.
+Finally, the `addEventListener()` method is used to start listening for [`keydown`](/zh-CN/docs/Web/API/Element/keydown_event) events, acting on each key by updating the ship position and rotation angle, then calling `refresh()` to draw the ship at its new position and angle.
 
 ```js
 window.addEventListener("keydown", function(event) {
@@ -189,7 +189,7 @@ To ensure that keystrokes go to the sample code, click inside the black game pla
 
 {{EmbedLiveSample("Handle_keyboard_events_in_a_game", 420, 460)}}
 
-There are several ways this code can be made better. Most real games would watch for {{event("keydown")}} events, start motion when that happens, and stop the motion when the corresponding {{event("keyup")}} occurs, instead of relying on key repeats. That would allow both smoother and faster movement, but would also allow the player to be moving and steering at the same time. Transitions or animations could be used to make the ship's movement smoother, too.
+There are several ways this code can be made better. Most real games would watch for [`keydown`](/zh-CN/docs/Web/API/Element/keydown_event) events, start motion when that happens, and stop the motion when the corresponding [`keyup`](/zh-CN/docs/Web/API/Element/keyup_event) occurs, instead of relying on key repeats. That would allow both smoother and faster movement, but would also allow the player to be moving and steering at the same time. Transitions or animations could be used to make the ship's movement smoother, too.
 
 ## Specification
 

--- a/files/zh-cn/web/api/keyboardevent/index.md
+++ b/files/zh-cn/web/api/keyboardevent/index.md
@@ -7,7 +7,7 @@ slug: Web/API/KeyboardEvent
 
 **`KeyboardEvent`** 对象描述了用户与键盘的交互。每个事件都描述了用户与一个按键（或一个按键和修饰键的组合）的单个交互；事件类型`keydown`， `keypress` 与 `keyup` 用于识别不同的键盘活动类型。
 
-> **备注：** `KeyboardEvent` 只在低级别提示用户与一个键盘按键的交互是什么，不涉及这个交互的上下文含义。当你需要处理文本输入的时候，使用 {{event("input")}} 事件代替。用户使用其他方式输入文本时，如使用平板电脑的手写系统或绘图板，键盘事件可能不会触发。
+> **备注：** `KeyboardEvent` 只在低级别提示用户与一个键盘按键的交互是什么，不涉及这个交互的上下文含义。当你需要处理文本输入的时候，使用 [`input`](/zh-CN/docs/Web/API/HTMLElement/input_event) 事件代替。用户使用其他方式输入文本时，如使用平板电脑的手写系统或绘图板，键盘事件可能不会触发。
 
 ## 构造函数
 
@@ -159,7 +159,7 @@ The following events are based on the `KeyboardEvent` type. They can be delivere
 
 ## 用法说明
 
-There are three types of keyboard events: {{event("keydown")}}, {{event("keypress")}}, and {{event("keyup")}}. For most keys, Gecko dispatches a sequence of key events like this:
+There are three types of keyboard events: [`keydown`](/zh-CN/docs/Web/API/Element/keydown_event), [`keypress`](/zh-CN/docs/Web/API/Element/keypress_event), and [`keyup`](/zh-CN/docs/Web/API/Element/keyup_event). For most keys, Gecko dispatches a sequence of key events like this:
 
 1. When the key is first pressed, the `keydown` event is sent.
 2. If the key is not a modifier key, the `keypress` event is sent.

--- a/files/zh-cn/web/api/keyboardevent/iscomposing/index.md
+++ b/files/zh-cn/web/api/keyboardevent/iscomposing/index.md
@@ -5,7 +5,7 @@ slug: Web/API/KeyboardEvent/isComposing
 
 {{APIRef("DOM Events")}}
 
-**`KeyboardEvent.isComposing`** 只读属性，返回一个 {{jsxref("Boolean")}} 值，表示该事件是否在 {{event("compositionstart")}} 之后和 {{event("compositionend")}} 之前被触发。
+**`KeyboardEvent.isComposing`** 只读属性，返回一个 {{jsxref("Boolean")}} 值，表示该事件是否在 [`compositionstart`](/zh-CN/docs/Web/API/Element/compositionstart_event) 之后和 [`compositionend`](/zh-CN/docs/Web/API/Element/compositionend_event) 之前被触发。
 
 ## 语法
 
@@ -30,5 +30,5 @@ console.log(kbdEvent.isComposing); // return false
 
 ## 参考
 
-- {{ event("compositionstart") }} 与 {{ event("compositionend")}}
+- [`compositionstart`](/zh-CN/docs/Web/API/Element/compositionstart_event) 与 [`compositionend`](/zh-CN/docs/Web/API/Element/compositionend_event)
 - {{domxref("KeyboardEvent")}}

--- a/files/zh-cn/web/api/keyboardevent/key/index.md
+++ b/files/zh-cn/web/api/keyboardevent/key/index.md
@@ -19,9 +19,9 @@ slug: Web/API/KeyboardEvent/key
 
 `KeyboardEvent` 事件以一个预设的次序触发，理解这一点对于理解特定 `KeyboardEvent` 的 `key` 属性值大有帮助。对于一个给定的按键操作，`KeyboardEvent` 将假定 {{domxref("Event.preventDefault")}} 未调用并按下面次序触发：
 
-1. 首先触发 {{event("keydown")}} 事件。如果按键长按且生成一个字符，则事件将以一个与平台实现方式相关的时间间隔持续发出，同时将只读属性 {{domxref("KeyboardEvent.repeat")}} 设定为 `true`。
-2. 如果按键生成的字符即将插入某个 {{HTMLElement("input")}}、{{HTMLElement("textarea")}} 或其它某个 {{domxref("HTMLElement.contentEditable")}} 设为 true 的元素，则依次触发 {{event("beforeinput")}}、{{event("input")}}事件。注意某些实现中若支持 {{event("keypress")}} 事件则可能将其触发。当按键长按时重复触发。
-3. 当按键松开时触发 {{event("keyup")}} 事件。操作结束。
+1. 首先触发 [`keydown`](/zh-CN/docs/Web/API/Element/keydown_event) 事件。如果按键长按且生成一个字符，则事件将以一个与平台实现方式相关的时间间隔持续发出，同时将只读属性 {{domxref("KeyboardEvent.repeat")}} 设定为 `true`。
+2. 如果按键生成的字符即将插入某个 {{HTMLElement("input")}}、{{HTMLElement("textarea")}} 或其它某个 {{domxref("HTMLElement.contentEditable")}} 设为 true 的元素，则依次触发 {{event("beforeinput")}}、[`input`](/zh-CN/docs/Web/API/HTMLElement/input_event)事件。注意某些实现中若支持 [`keypress`](/zh-CN/docs/Web/API/Element/keypress_event) 事件则可能将其触发。当按键长按时重复触发。
+3. 当按键松开时触发 [`keyup`](/zh-CN/docs/Web/API/Element/keyup_event) 事件。操作结束。
 
 在次序 1、3 中，`KeyboardEvent.key` 属性按照事先定义的规则设定为恰当的值。
 
@@ -200,27 +200,27 @@ btnClearConsole.addEventListener('click', (e) => {
 
 ### 用例 1
 
-当按下 shift 键时，首先触发 {{event("keydown")}} 事件，然后将 `key` 属性的值设为 `"Shift"` 字符串。如果继续长按 shift 键，由于不会生成字符按键值，{{event("keydown")}} 事件不会继续重复触发。
+当按下 shift 键时，首先触发 [`keydown`](/zh-CN/docs/Web/API/Element/keydown_event) 事件，然后将 `key` 属性的值设为 `"Shift"` 字符串。如果继续长按 shift 键，由于不会生成字符按键值，[`keydown`](/zh-CN/docs/Web/API/Element/keydown_event) 事件不会继续重复触发。
 
-当按下 `key 2` 时，另一个 {{event("keydown")}} 事件将会为这个新的按键动作触发，若使用的是美式键盘，它的 `key` 属性将被设为 `"@"` 字符，若为英式键盘，则会设为 `"""` 字符。这是因为 `key` 属性 `"shift"` 处于激活状态。由于生成了一个字符的按键值，{{event("beforeinput")}} 和 {{event("input")}} 事件随后触发。
+当按下 `key 2` 时，另一个 [`keydown`](/zh-CN/docs/Web/API/Element/keydown_event) 事件将会为这个新的按键动作触发，若使用的是美式键盘，它的 `key` 属性将被设为 `"@"` 字符，若为英式键盘，则会设为 `"""` 字符。这是因为 `key` 属性 `"shift"` 处于激活状态。由于生成了一个字符的按键值，{{event("beforeinput")}} 和 [`input`](/zh-CN/docs/Web/API/HTMLElement/input_event) 事件随后触发。
 
-松开 `key 2` 时，{{event("keyup")}} 事件将触发，`key` 属性将会为不同键盘布局设定合适的字符值，比如 `"@"`、`"""`。
+松开 `key 2` 时，[`keyup`](/zh-CN/docs/Web/API/Element/keyup_event) 事件将触发，`key` 属性将会为不同键盘布局设定合适的字符值，比如 `"@"`、`"""`。
 
-最后在松开 shift 键时，另一个 {{event("keyup")}} 事件触发，`key` 值将保持 `"Shift"` 不变。
+最后在松开 shift 键时，另一个 [`keyup`](/zh-CN/docs/Web/API/Element/keyup_event) 事件触发，`key` 值将保持 `"Shift"` 不变。
 
 ### 用例 2
 
-当按下 shift 键时，首先触发 {{event("keydown")}} 事件，然后将 `key` 属性的值设为 `"Shift"` 字符串。如果继续长按 shift 键，由于不会生成字符按键值，{{event("keydown")}} 事件不会继续重复触发。
+当按下 shift 键时，首先触发 [`keydown`](/zh-CN/docs/Web/API/Element/keydown_event) 事件，然后将 `key` 属性的值设为 `"Shift"` 字符串。如果继续长按 shift 键，由于不会生成字符按键值，[`keydown`](/zh-CN/docs/Web/API/Element/keydown_event) 事件不会继续重复触发。
 
-当按下 `key 2` 时，另一个 {{event("keydown")}} 事件将会为这个新的按键动作触发，若使用的是美式键盘，它的 `key` 属性将被设为 `"@"` 字符，若为英式键盘，则会设为 `"""` 字符。这是因上档键处于激活状态。由于生成了一个字符的按键值，{{event("beforeinput")}} 和 {{event("input")}} 事件随后触发。如果继续长按 `2` 键，则 {{event("keydown")}} 事件将持续重复触发，同时将 {{domxref("KeyboardEvent.repeat")}} 属性设置为 `true`。{{event("beforeinput")}} 和 {{event("input")}} 事件也将持续重复触发。
+当按下 `key 2` 时，另一个 [`keydown`](/zh-CN/docs/Web/API/Element/keydown_event) 事件将会为这个新的按键动作触发，若使用的是美式键盘，它的 `key` 属性将被设为 `"@"` 字符，若为英式键盘，则会设为 `"""` 字符。这是因上档键处于激活状态。由于生成了一个字符的按键值，{{event("beforeinput")}} 和 [`input`](/zh-CN/docs/Web/API/HTMLElement/input_event) 事件随后触发。如果继续长按 `2` 键，则 [`keydown`](/zh-CN/docs/Web/API/Element/keydown_event) 事件将持续重复触发，同时将 {{domxref("KeyboardEvent.repeat")}} 属性设置为 `true`。{{event("beforeinput")}} 和 [`input`](/zh-CN/docs/Web/API/HTMLElement/input_event) 事件也将持续重复触发。
 
-当松开 shift 键时，{{event("keyup")}} 事件随之触发，且 `key` 属性保留为 `"Shift"`。此时请注意为 `key 2` 长按触发的重复 `keydown` 事件的 `key` 值会变成 `"2"`，因为上档键不再处于激活状态。{{event("beforeinput")}} 与 {{event("input")}} 事件的 {{domxref("InputEvent.data")}} 属性同理。
+当松开 shift 键时，[`keyup`](/zh-CN/docs/Web/API/Element/keyup_event) 事件随之触发，且 `key` 属性保留为 `"Shift"`。此时请注意为 `key 2` 长按触发的重复 `keydown` 事件的 `key` 值会变成 `"2"`，因为上档键不再处于激活状态。{{event("beforeinput")}} 与 [`input`](/zh-CN/docs/Web/API/HTMLElement/input_event) 事件的 {{domxref("InputEvent.data")}} 属性同理。
 
-最终 `key 2` 松开，{{event("keyup")}} 事件触发，但两种键盘布局的 `key` 属性均为 `"2"`。就是因为没有激活上档键。
+最终 `key 2` 松开，[`keyup`](/zh-CN/docs/Web/API/Element/keyup_event) 事件触发，但两种键盘布局的 `key` 属性均为 `"2"`。就是因为没有激活上档键。
 
 ## 示例
 
-这个示例使用 {{domxref("EventTarget.addEventListener()")}} 监听 {{event("keydown")}} 事件。当我们事件触发时，将检测按键的值是否为代码所关注，如果是，就进行某项操作。（可能是给飞船转向，或者是调整电子表格中选中单元格的位置。）
+这个示例使用 {{domxref("EventTarget.addEventListener()")}} 监听 [`keydown`](/zh-CN/docs/Web/API/Element/keydown_event) 事件。当我们事件触发时，将检测按键的值是否为代码所关注，如果是，就进行某项操作。（可能是给飞船转向，或者是调整电子表格中选中单元格的位置。）
 
 ```js
 window.addEventListener("keydown", function (event) {

--- a/files/zh-cn/web/api/mediarecorder/index.md
+++ b/files/zh-cn/web/api/mediarecorder/index.md
@@ -54,7 +54,7 @@ slug: Web/API/MediaRecorder
 - {{domxref("MediaRecorder.onerror")}}
   - : An {{event("Event_handlers", "event handler")}} called to handle the {{event("recordingerror")}} event, including reporting errors that arise with media recording. These are fatal errors that stop recording.
 - {{domxref("MediaRecorder.onpause")}}
-  - : 用来处理 {{event("pause")}} 事件，该事件在媒体暂停录制时触发（{{domxref("MediaRecorder.pause()")}}）.
+  - : 用来处理 [`pause`](/zh-CN/docs/Web/API/HTMLMediaElement/pause_event) 事件，该事件在媒体暂停录制时触发（{{domxref("MediaRecorder.pause()")}}）.
 - {{domxref("MediaRecorder.onresume")}}
   - : 用来处理 {{event("resume")}} 事件，该事件在暂停后回复录制视频时触发（{{domxref("MediaRecorder.resume()")}}）.
 - {{domxref("MediaRecorder.onstart")}}

--- a/files/zh-cn/web/api/mediarecorder/pause/index.md
+++ b/files/zh-cn/web/api/mediarecorder/pause/index.md
@@ -12,7 +12,7 @@ When a `MediaRecorder` object’s `pause()`method is called, the browser queues 
 1. If {{domxref("MediaRecorder.state")}} is "inactive", raise a DOM `InvalidState` error and terminate these steps. If not, continue to the next step.
 2. Set {{domxref("MediaRecorder.state")}} to "paused".
 3. Stop gathering data into the current {{domxref("Blob")}}, but keep it available so that recording can be resumed later on.
-4. Raise a {{event("pause")}} event.
+4. Raise a [`pause`](/zh-CN/docs/Web/API/HTMLMediaElement/pause_event) event.
 
 ## Syntax
 

--- a/files/zh-cn/web/api/mediastream_recording_api/index.md
+++ b/files/zh-cn/web/api/mediastream_recording_api/index.md
@@ -23,7 +23,7 @@ MediaStream Recording API 由一个主接口{{domxref("MediaRecorder")}}组成�
 
 > **备注：** 单单使用包含已经录制好媒体切片的{{domxref("Blob")}}s 将大可不能单独播放。媒体在重放之前需要重新组装。
 
-如果在录制过程中出错，{{event("error")}} 事件将会传给`MediaRecorder`. 你可以设置{{domxref("MediaRecorder.onerror", "onerror")}}去监听 `error` 事件。
+如果在录制过程中出错，[`error`](/zh-CN/docs/Web/API/Element/error_event) 事件将会传给`MediaRecorder`. 你可以设置{{domxref("MediaRecorder.onerror", "onerror")}}去监听 `error` 事件。
 
 例子中，我们使用 Canvas 作为{{domxref("MediaStream")}}的源，在 9 秒后停止录音。
 

--- a/files/zh-cn/web/api/mediastreamtrack/stop/index.md
+++ b/files/zh-cn/web/api/mediastreamtrack/stop/index.md
@@ -56,4 +56,4 @@ Finally, `srcObject` is set to `null` to sever the link to the {{domxref("MediaS
 
 - {{domxref("MediaStreamTrack")}}，它所属的接口。
 - {{domxref("MediaStreamTrack.readyState")}}
-- {{event("ended")}}
+- [`ended`](/zh-CN/docs/Web/API/HTMLMediaElement/ended_event)

--- a/files/zh-cn/web/api/mouseevent/button/index.md
+++ b/files/zh-cn/web/api/mouseevent/button/index.md
@@ -7,7 +7,7 @@ slug: Web/API/MouseEvent/button
 
 **`MouseEvent.button`**是只读属性，它返回一个值，代表用户按下并触发了事件的鼠标按键。
 
-这个属性只能够表明在触发事件的单个或多个按键按下或释放过程中哪些按键被按下了。因此，它对判断{{event("mouseenter")}}, {{event("mouseleave")}}, {{event("mouseover")}}, {{event("mouseout")}} {{event("mousemove")}}这些事件并不可靠。
+这个属性只能够表明在触发事件的单个或多个按键按下或释放过程中哪些按键被按下了。因此，它对判断[`mouseenter`](/zh-CN/docs/Web/API/Element/mouseenter_event), [`mouseleave`](/zh-CN/docs/Web/API/Element/mouseleave_event), [`mouseover`](/zh-CN/docs/Web/API/Element/mouseover_event), [`mouseout`](/zh-CN/docs/Web/API/Element/mouseout_event) [`mousemove`](/zh-CN/docs/Web/API/Element/mousemove_event)这些事件并不可靠。
 
 用户可能会改变鼠标按键的配置，因此当一个事件的 **`MouseEvent.button`** 值为 0 时，它可能不是由物理上设备最左边的按键触发的。但是对于一个标准按键布局的鼠标来说就会是左键。
 

--- a/files/zh-cn/web/api/mouseevent/index.md
+++ b/files/zh-cn/web/api/mouseevent/index.md
@@ -5,7 +5,7 @@ slug: Web/API/MouseEvent
 
 {{APIRef("DOM Events")}}
 
-**`MouseEvent`** 接口指用户与指针设备（如鼠标）交互时发生的事件。使用此接口的常见事件包括：{{event("click")}}、{{event("dblclick")}}、{{event("mouseup")}}、{{event("mousedown")}}。
+**`MouseEvent`** 接口指用户与指针设备（如鼠标）交互时发生的事件。使用此接口的常见事件包括：[`click`](/zh-CN/docs/Web/API/Element/click_event)、[`dblclick`](/zh-CN/docs/Web/API/Element/dblclick_event)、[`mouseup`](/zh-CN/docs/Web/API/Element/mouseup_event)、[`mousedown`](/zh-CN/docs/Web/API/Element/mousedown_event)。
 
 `MouseEvent` 派生自 {{domxref("UIEvent")}}，{{domxref("UIEvent")}} 派生自 {{domxref("Event")}}。虽然 `MouseEvent.initMouseEvent()` 方法保持向后兼容性，但是应该使用 `MouseEvent()` 构造函数创建一个 `MouseEvent` 对象。
 
@@ -39,9 +39,9 @@ _这个接口也继承了{{domxref("UIEvent")}} 和 {{domxref("Event")}}原型�
 - {{domxref("MouseEvent.metaKey")}} {{readonlyinline}}
   - : 当鼠标事件触发时，如果 <kbd>meta</kbd> 键被按下，则返回 true；
 - {{domxref("MouseEvent.movementX")}} {{readonlyinline}}
-  - : 鼠标指针相对于最后{{event("mousemove")}}事件位置的 X 坐标。
+  - : 鼠标指针相对于最后[`mousemove`](/zh-CN/docs/Web/API/Element/mousemove_event)事件位置的 X 坐标。
 - {{domxref("MouseEvent.movementY")}} {{readonlyinline}}
-  - : 鼠标指针相对于最后{{event("mousemove")}}事件位置的 Y 坐标。
+  - : 鼠标指针相对于最后[`mousemove`](/zh-CN/docs/Web/API/Element/mousemove_event)事件位置的 Y 坐标。
 - {{domxref("MouseEvent.offsetX")}} {{readonlyinline}}{{experimental_inline}}
   - : 鼠标指针相对于目标节点内边位置的 X 坐标
 - {{domxref("MouseEvent.offsetY")}} {{readonlyinline}}{{experimental_inline}}

--- a/files/zh-cn/web/api/mouseevent/mouseevent/index.md
+++ b/files/zh-cn/web/api/mouseevent/mouseevent/index.md
@@ -66,7 +66,7 @@ slug: Web/API/MouseEvent/MouseEvent
       | `2`                        | 次按键被按下 (通常为右键)   |
       | `4`                        | 辅助按键被按下 (通常为中键) |
 
-    - `"relatedTarget"`，{{domxref("EventTarget")}} 型可选，默认为 `null`，若事件为 {{event("mouseenter")}} 或 {{event("mouseover")}}，则表示刚离开的元素；若事件为 {{event("mouseout")}} 或 {{event("mouseleave")}}，则表示刚进入的元素。
+    - `"relatedTarget"`，{{domxref("EventTarget")}} 型可选，默认为 `null`，若事件为 [`mouseenter`](/zh-CN/docs/Web/API/Element/mouseenter_event) 或 [`mouseover`](/zh-CN/docs/Web/API/Element/mouseover_event)，则表示刚离开的元素；若事件为 [`mouseout`](/zh-CN/docs/Web/API/Element/mouseout_event) 或 [`mouseleave`](/zh-CN/docs/Web/API/Element/mouseleave_event)，则表示刚进入的元素。
     - `"region"`，{{domxref("DOMString")}} 型可选，默认为`null`，标明点击事件影响的区域 DOM 的 id。不影响任何区域的话，请传`null`值。
 
     在一些实现中，passing anything other than a number for the screen and client fields will throw a `TypeError`.

--- a/files/zh-cn/web/api/mouseevent/movementx/index.md
+++ b/files/zh-cn/web/api/mouseevent/movementx/index.md
@@ -5,7 +5,7 @@ slug: Web/API/MouseEvent/movementX
 
 {{APIRef("DOM Events")}}
 
-**`MouseEvent.movementX`** 是只读属性，它提供了当前事件和上一个{{event("mousemove")}}事件之间鼠标在水平方向上的移动值。换句话说，这个值是这样计算的 : `currentEvent.movementX = currentEvent.screenX - previousEvent.screenX`.
+**`MouseEvent.movementX`** 是只读属性，它提供了当前事件和上一个[`mousemove`](/zh-CN/docs/Web/API/Element/mousemove_event)事件之间鼠标在水平方向上的移动值。换句话说，这个值是这样计算的 : `currentEvent.movementX = currentEvent.screenX - previousEvent.screenX`.
 
 ## 语法
 

--- a/files/zh-cn/web/api/mouseevent/movementy/index.md
+++ b/files/zh-cn/web/api/mouseevent/movementy/index.md
@@ -5,7 +5,7 @@ slug: Web/API/MouseEvent/movementY
 
 {{APIRef("DOM Events")}}
 
-**`MouseEvent.movementY`** 是只读属性，它提供了当前事件和上一个 {{event("mousemove")}} 事件之间鼠标在水平方向上的移动值。换句话说，这个值是这样计算的 : `currentEvent.movementY = currentEvent.screenY - previousEvent.screenY`.
+**`MouseEvent.movementY`** 是只读属性，它提供了当前事件和上一个 [`mousemove`](/zh-CN/docs/Web/API/Element/mousemove_event) 事件之间鼠标在水平方向上的移动值。换句话说，这个值是这样计算的 : `currentEvent.movementY = currentEvent.screenY - previousEvent.screenY`.
 
 ## 语法
 

--- a/files/zh-cn/web/api/mouseevent/relatedtarget/index.md
+++ b/files/zh-cn/web/api/mouseevent/relatedtarget/index.md
@@ -9,13 +9,13 @@ slug: Web/API/MouseEvent/relatedTarget
 
 | 事件名称                         | `target`                                          | `relatedTarget`                                   |
 | -------------------------------- | ------------------------------------------------- | ------------------------------------------------- |
-| {{Event("focusin")}}     | {{domxref("EventTarget")}} 获取焦点     | {{domxref("EventTarget")}} 失去焦点     |
-| {{Event("focusout")}}     | {{domxref("EventTarget")}} 失去焦点     | The {{domxref("EventTarget")}} 获取焦点 |
-| {{Event("mouseenter")}} | 指针设备进入{{domxref("EventTarget")}}  | 指针设备离开{{domxref("EventTarget")}}  |
-| {{Event("mouseleave")}} | 指针设备离开 {{domxref("EventTarget")}} | 指针设备进入 {{domxref("EventTarget")}} |
-| {{Event("mouseout")}}     | 指针设备离开 {{domxref("EventTarget")}} | The {{domxref("EventTarget")}}          |
-| {{Event("mouseover")}}     | 指针设备进入 {{domxref("EventTarget")}} | 指针设备离开 {{domxref("EventTarget")}} |
-| {{Event("dragenter")}}     | 指针设备进入 {{domxref("EventTarget")}} | 指针设备离开 {{domxref("EventTarget")}} |
+| [`focusin`](/zh-CN/docs/Web/API/Element/focusin_event)     | {{domxref("EventTarget")}} 获取焦点     | {{domxref("EventTarget")}} 失去焦点     |
+| [`focusout`](/zh-CN/docs/Web/API/Element/focusout_event)     | {{domxref("EventTarget")}} 失去焦点     | The {{domxref("EventTarget")}} 获取焦点 |
+| [`mouseenter`](/zh-CN/docs/Web/API/Element/mouseenter_event) | 指针设备进入{{domxref("EventTarget")}}  | 指针设备离开{{domxref("EventTarget")}}  |
+| [`mouseleave`](/zh-CN/docs/Web/API/Element/mouseleave_event) | 指针设备离开 {{domxref("EventTarget")}} | 指针设备进入 {{domxref("EventTarget")}} |
+| [`mouseout`](/zh-CN/docs/Web/API/Element/mouseout_event)     | 指针设备离开 {{domxref("EventTarget")}} | The {{domxref("EventTarget")}}          |
+| [`mouseover`](/zh-CN/docs/Web/API/Element/mouseover_event)     | 指针设备进入 {{domxref("EventTarget")}} | 指针设备离开 {{domxref("EventTarget")}} |
+| [`dragenter`](/zh-CN/docs/Web/API/HTMLElement/dragenter_event)     | 指针设备进入 {{domxref("EventTarget")}} | 指针设备离开 {{domxref("EventTarget")}} |
 | {{Event("dragexit")}}     | 指针设备离开 {{domxref("EventTarget")}} | 指针设备进入 {{domxref("EventTarget")}} |
 
 如果事件没有次要目标，`relatedTarget` 将返回 `null`.

--- a/files/zh-cn/web/api/mouseevent/screenx/index.md
+++ b/files/zh-cn/web/api/mouseevent/screenx/index.md
@@ -21,7 +21,7 @@ var x = instanceOfMouseEvent.screenX
 
 ## 示例
 
-这个例子展示了当触发 {{Event("mousemove")}} 事件时鼠标的坐标。
+这个例子展示了当触发 [`mousemove`](/zh-CN/docs/Web/API/Element/mousemove_event) 事件时鼠标的坐标。
 
 #### HTML
 

--- a/files/zh-cn/web/api/mouseevent/screeny/index.md
+++ b/files/zh-cn/web/api/mouseevent/screeny/index.md
@@ -13,7 +13,7 @@ slug: Web/API/MouseEvent/screenY
 
 ## 示例
 
-这个例子展示了当触发 {{Event("mousemove")}} 事件时鼠标的坐标。
+这个例子展示了当触发 [`mousemove`](/zh-CN/docs/Web/API/Element/mousemove_event) 事件时鼠标的坐标。
 
 ### HTML
 

--- a/files/zh-cn/web/api/navigation_timing_api/index.md
+++ b/files/zh-cn/web/api/navigation_timing_api/index.md
@@ -9,7 +9,7 @@ slug: Web/API/Navigation_timing_API
 
 ## Concepts and usage
 
-你可以使用 Navigation Timing API 在客户端收集性能数据，并用 {{domxref("XMLHttpRequest")}} 或其它技术传送到服务端。同时，该 API 使你可以衡量之前难以获取的数据，如卸载前一个页面的时间，在域名解析上的时间，在执行 {{event("load")}} 事件处理器上花费的总时间等。
+你可以使用 Navigation Timing API 在客户端收集性能数据，并用 {{domxref("XMLHttpRequest")}} 或其它技术传送到服务端。同时，该 API 使你可以衡量之前难以获取的数据，如卸载前一个页面的时间，在域名解析上的时间，在执行 [`load`](/zh-CN/docs/Web/API/Window/load_event) 事件处理器上花费的总时间等。
 
 ## Interfaces
 

--- a/files/zh-cn/web/api/navigation_timing_api/using_navigation_timing/index.md
+++ b/files/zh-cn/web/api/navigation_timing_api/using_navigation_timing/index.md
@@ -21,7 +21,7 @@ window.addEventListener("load", function() {
 }, false);
 ```
 
-在发生 {{event("load")}} 事件时执行的该代码从当前时间中减去浏览器导航开始时记录的时间 ({{domxref("PerformanceTiming.navigationStart", "performance.timing.navigationStart")}})，并通过将该信息插入到元素中，输出到屏幕。
+在发生 [`load`](/zh-CN/docs/Web/API/Window/load_event) 事件时执行的该代码从当前时间中减去浏览器导航开始时记录的时间 ({{domxref("PerformanceTiming.navigationStart", "performance.timing.navigationStart")}})，并通过将该信息插入到元素中，输出到屏幕。
 
 ```html hidden
 <div class="output">

--- a/files/zh-cn/web/api/navigator/sendbeacon/index.md
+++ b/files/zh-cn/web/api/navigator/sendbeacon/index.md
@@ -29,7 +29,7 @@ navigator.sendBeacon(url, data);
 
 ## 描述
 
-这个方法主要用于满足统计和诊断代码的需要，这些代码通常尝试在卸载（unload）文档之前向 Web 服务器发送数据。过早的发送数据可能导致错过收集数据的机会。然而，对于开发者来说保证在文档卸载期间发送数据一直是一个困难。因为用户代理通常会忽略在 {{event("unload")}} 事件处理器中产生的异步 {{domxref("XMLHttpRequest")}}。
+这个方法主要用于满足统计和诊断代码的需要，这些代码通常尝试在卸载（unload）文档之前向 Web 服务器发送数据。过早的发送数据可能导致错过收集数据的机会。然而，对于开发者来说保证在文档卸载期间发送数据一直是一个困难。因为用户代理通常会忽略在 [`unload`](/zh-CN/docs/Web/API/Window/unload_event) 事件处理器中产生的异步 {{domxref("XMLHttpRequest")}}。
 
 过去，为了解决这个问题，统计和诊断代码通常要在
 
@@ -49,7 +49,7 @@ navigator.sendBeacon(url, data);
 
 ### 在会话结束时发送统计数据
 
-网站通常希望在用户完成页面浏览后向服务器发送分析或诊断数据，最可靠的方法是在 {{event("visibilitychange")}} 事件发生时发送数据：
+网站通常希望在用户完成页面浏览后向服务器发送分析或诊断数据，最可靠的方法是在 [`visibilitychange`](/zh-CN/docs/Web/API/Document/visibilitychange_event) 事件发生时发送数据：
 
 ```js
 document.addEventListener('visibilitychange', function logData() {
@@ -61,7 +61,7 @@ document.addEventListener('visibilitychange', function logData() {
 
 ### 避免使用 unload 和 beforeunload
 
-过去，许多网站使用 {{event("unload")}} 或 {{event("beforeunload")}} 事件以在会话结束时发送统计数据。然而这是不可靠的，在许多情况下（尤其是移动设备）浏览器不会产生 `unload`、`beforeunload` 或 `pagehide` 事件。下面列出了一种不触发上述事件的情况：
+过去，许多网站使用 [`unload`](/zh-CN/docs/Web/API/Window/unload_event) 或 [`beforeunload`](/zh-CN/docs/Web/API/Window/beforeunload_event) 事件以在会话结束时发送统计数据。然而这是不可靠的，在许多情况下（尤其是移动设备）浏览器不会产生 `unload`、`beforeunload` 或 `pagehide` 事件。下面列出了一种不触发上述事件的情况：
 
 1. 用户加载了网页并与其交互。
 2. 完成浏览后，用户切换到了其它应用程序，而不是关闭选项卡。
@@ -73,11 +73,11 @@ Firefox 也会在 bfcache 中排除包含 `beforeunload` 事件处理器的页�
 
 #### 使用 pagehide 作为回退
 
-可使用 {{event("pagehide")}} 事件来代替部分浏览器未实现的 `visibilitychange` 事件。和 `beforeunload` 与 `unload` 事件类似，这一事件不会被可靠地触发（特别是在移动设备上），但它与 bfcache 兼容。
+可使用 [`pagehide`](/zh-CN/docs/Web/API/Window/pagehide_event) 事件来代替部分浏览器未实现的 `visibilitychange` 事件。和 `beforeunload` 与 `unload` 事件类似，这一事件不会被可靠地触发（特别是在移动设备上），但它与 bfcache 兼容。
 
 ## 示例
 
-示例代码使用 {{event("visibilitychange")}} 事件来调用 `sendBeacon()` 以发送统计数据。
+示例代码使用 [`visibilitychange`](/zh-CN/docs/Web/API/Document/visibilitychange_event) 事件来调用 `sendBeacon()` 以发送统计数据。
 
 ```js
 document.addEventListener('visibilitychange', function logData() {
@@ -97,7 +97,7 @@ document.addEventListener('visibilitychange', function logData() {
 
 ## 参见
 
-- {{event("visibilitychange")}} 事件。
+- [`visibilitychange`](/zh-CN/docs/Web/API/Document/visibilitychange_event) 事件。
 - {{domxref("Beacon_API","Beacon API", "" , "true")}} 概述。
 - [Don't
   lose user and app state, use Page Visibility](https://www.igvita.com/2015/11/20/dont-lose-user-and-app-state-use-page-visibility/) 解释了为什么你应该使用 `visibilitychange` 而不是 `beforeunload`/`unload`。

--- a/files/zh-cn/web/api/networkinformation/index.md
+++ b/files/zh-cn/web/api/networkinformation/index.md
@@ -32,7 +32,7 @@ _这些属性接口继承自 {{domxref("EventTarget")}}._
 ### Event handlers
 
 - {{domxref("NetworkInformation.onchange")}}
-  - : 当连接信息更改并在此对象上触发更改时触发的 {{event("change")}} 。
+  - : 当连接信息更改并在此对象上触发更改时触发的 [`change`](/zh-CN/docs/Web/API/HTMLElement/change_event) 。
 
 ## Methods
 

--- a/files/zh-cn/web/api/notification/click_event/index.md
+++ b/files/zh-cn/web/api/notification/click_event/index.md
@@ -5,7 +5,7 @@ slug: Web/API/Notification/click_event
 
 {{APIRef("Web Notifications")}}
 
-{{domxref("Notification")}} 接口的 onclick 属性指定一个事件侦听器来接收 {{event("click")}} 事件。
+{{domxref("Notification")}} 接口的 onclick 属性指定一个事件侦听器来接收 [`click`](/zh-CN/docs/Web/API/Element/click_event) 事件。
 
 当用户点击一个显示的{{domxref("Notification")}}时，会发生这些事件。
 

--- a/files/zh-cn/web/api/notification/error_event/index.md
+++ b/files/zh-cn/web/api/notification/error_event/index.md
@@ -7,7 +7,7 @@ slug: Web/API/Notification/error_event
 
 ## Summary
 
-{{domxref("Notification")}} 接口的 onerror 属性指定一个事件侦听器来接收 {{event("error")}} 事件。
+{{domxref("Notification")}} 接口的 onerror 属性指定一个事件侦听器来接收 [`error`](/zh-CN/docs/Web/API/Element/error_event) 事件。
 
 当一个 {{domxref("Notification")}} 发生错误时，会发生这些事件（在许多情况下，一个错误阻止显示通知）。
 
@@ -19,7 +19,7 @@ Notification.onerror = EventListener;
 
 ### Value
 
-A {{jsxref("function")}} which serves as the event handler for the {{event("error")}} event. When an error occurs, the specified function will be called. If `null`, no error handler is in effect.
+A {{jsxref("function")}} which serves as the event handler for the [`error`](/zh-CN/docs/Web/API/Element/error_event) event. When an error occurs, the specified function will be called. If `null`, no error handler is in effect.
 
 ## 规范
 


### PR DESCRIPTION
### Description

chore: remove {{event}} macro from zh-CN (Part 2)

### Related issues and pull requests

continue #9585.
