### PR TITLE
Remove deprecated DiscussionList macro from es

### DIFF
--- a/files/es/web/accessibility/community/index.md
+++ b/files/es/web/accessibility/community/index.md
@@ -1,42 +1,27 @@
 ---
 title: Comunidad
 slug: Web/Accessibility/Community
-tags:
-  - Accesibilidad
-  - Todas_las_Categorías
 translation_of: Web/Accessibility/Community
 original_slug: Web/Accesibilidad/Comunidad
 ---
-Si conoces alguna lista de correo, grupo de noticias, foro, o comunidad relacionada con la
-_accesibilidad_
-que pueda ser de interés. Por favor, pon aquí un enlace.
+
+Si conoces alguna lista de correo, grupo de noticias, foro, o comunidad relacionada con la _accesibilidad_ que pueda ser de interés. Por favor, pon aquí un enlace.
 
 ### Mozilla
 
-- La
-  _Accesibilidad_
-  en la comunidad Mozilla... en inglés
-
-{{ DiscussionList("support-accessibility", "mozilla.support.accessibility") }}
+- La _Accesibilidad_ en la comunidad Mozilla... en inglés
+- [como lista de correo](https://lists.mozilla.org/listinfo/support-accessibility)
+- [como grupo de noticias](https://groups.google.com/group/mozilla.support.accessibility)
+- [como RSS](https://groups.google.com/group/mozilla.support.accessibility/feeds)
 
 ### Listas de correo
 
 - [Accesoweb](http://es.groups.yahoo.com/group/accesoweb) Lista en castellano sobre problemas y soluciones de diseño accesible para la Red de la **Fundación Sidar**.
 
-### Foros
-
--
-
 ### Bitácoras
 
 - [Accesibilidad, Usabilidad y Estándares Web](http://accesibilidadweb.blogspot.com/) Este es un blog dedicado a todos los temas relacionados con la accesibilidad web, usabilidad y estándares web.
 
-### Wikis
-
--
-
 ### Otros Sitios
 
 - [El sitio del WAI (en)](http://www.w3.org/WAI/)
-
-categorías

--- a/files/es/web/guide/ajax/community/index.md
+++ b/files/es/web/guide/ajax/community/index.md
@@ -1,39 +1,19 @@
 ---
 title: Comunidad
 slug: Web/Guide/AJAX/Community
-tags:
-  - AJAX
-  - Todas_las_Categorías
 translation_of: Web/Guide/AJAX/Community
 original_slug: Web/Guide/AJAX/Comunidad
 ---
+
 Si conoces alguna lista de correo, grupo de noticias, foro, o comunidad relacionada con AJAX que pueda ser de interés. Por favor, pon aquí un enlace.
 
 ### Mozilla
 
 - La comunidad Mozilla... en inglés
-
-{{ DiscussionList("dev-ajax", "mozilla.dev.ajax") }}
-
-### Listas de correo
-
--
+- [como lista de correo](https://lists.mozilla.org/listinfo/dev-ajax)
+- [como grupo de noticias](https://groups.google.com/group/mozilla.dev.ajax)
+- [como RSS](https://groups.google.com/group/mozilla.dev.ajax/feeds)
 
 ### Foros
 
-- [AJAX](http://www.forosdelweb.com/forumdisplay.php?f=77) en
-  _Foros del Web_
-
-### Bitácoras
-
--
-
-### Wikis
-
--
-
-### Otros Sitios
-
--
-
-categorías
+- [AJAX](http://www.forosdelweb.com/forumdisplay.php?f=77) en _Foros del Web_

--- a/files/es/web/guide/ajax/index.md
+++ b/files/es/web/guide/ajax/index.md
@@ -3,6 +3,7 @@ title: AJAX
 slug: Web/Guide/AJAX
 translation_of: Web/Guide/AJAX
 ---
+
 **[Primeros Pasos](/es/docs/Web/Guide/AJAX/Getting_Started)**
 Una introducción a AJAX.
 
@@ -13,27 +14,17 @@ Una introducción a AJAX.
 - [Primeros pasos con AJAX](/es/docs/Web/Guide/AJAX/Getting_Started)
   - : Este artículo te guiará por los conceptos básicos de AJAX y te proporcionará dos ejemplos prácticos para que empieces.
 
-<!---->
-
 - [Técnicas Ajax Alternativas](http://www.webreference.com/programming/ajax_tech/)
   - : La mayoría de los artículos sobre Ajax se enfocaron en utilizar XMLHttp como el medio para llevar a cabo dicha comunicación, pero las técnicas Ajax no están limitadas solo a XMLHttp. Existen otros métodos más.
-
-<!---->
 
 - [Ajax con PHP, JSON y CSS](http://thinkcoderepeat.blogspot.com/2006/02/tutorial-de-ajax-con-php-y-json.html)
   - : Con este tutorial puedes programar con AJAX utilizando PHP y JSON, un nuevo estándar más simple que XML. Programarás en AJAX, PHP y CSS de forma simple y natural.
 
-<!---->
-
 - [Ajax Upload File](http://webdev20.blogspot.com/2006/02/ajax-upload-file.html)
   - : Artículo en el que se explica la carga de archivos de un formulario usando AJAX y PHP, además de otros ejemplos en los que se puede visualizar la barra de progreso de la carga.
 
-<!---->
-
 - [Creando formulario editables in situ](http://www.baluart.net/articulo/346/edicion-in-situ-con-ajax.php)
   - : Breve tutorial que nos muestra como crear nuestros formularios editables in situ con AJAX, PHP y MySQL, al estilo Flickr.
-
-<!---->
 
 - [Arquitectura Cliente Servidor con AJAX](http://thinkcoderepeat.blogspot.com/2006/08/arquitectura-cliente-servidor-con-ajax.html)
   - : Artículo avanzado que muestra un patrón de diseño para desarrollar con AJAX, haciendo el modelo de la aplicación como web-services, la interface (view) con HTML y el controlador (controller) en Javascript, para crear aplicaciones siguiendo el paradigma MVC. Herramientas: Prototype, JSON y CSS.
@@ -41,12 +32,10 @@ Una introducción a AJAX.
 #### Comunidad
 
 - [Ajax-es](http://groups.google.es/group/Ajax-es?lnk=sg&hl=es). Foro sobre AJAX.
-
-<!---->
-
 - Foros sobre AJAX en la comunidad Mozilla en inglés:
-
-{{ DiscussionList("dev-ajax", "mozilla.dev.ajax") }}
+- [como lista de correo](https://lists.mozilla.org/listinfo/dev-ajax)
+- [como grupo de noticias](https://groups.google.com/group/mozilla.dev.ajax)
+- [como RSS](https://groups.google.com/group/mozilla.dev.ajax/feeds)
 
 #### Herramientas
 

--- a/files/es/web/mathml/index.md
+++ b/files/es/web/mathml/index.md
@@ -1,15 +1,9 @@
 ---
 title: MathML
 slug: Web/MathML
-tags:
-  - Landing
-  - MathML
-  - NeedsTranslation
-  - Reference
-  - Référence(2)
-  - TopicStub
 translation_of: Web/MathML
 ---
+
 **Lenguaje de Marcado Matemático (MathML)** es un lenguaje de marcado [XML](/es/docs/Introducción_a_XML) para describir expresiones matemáticas capturando tanto su contenido como su estructura.
 
 Aquí encontrarás enlaces a documentación, ejemplos y herramientas que te ayudarán a trabajar con esta tecnología poderosa. Para un resumen, vea la [presentación](https://fred-wang.github.io/MozSummitMathML/index.html) que se preparó para Mozilla Summit 2013.
@@ -30,7 +24,9 @@ Aquí encontrarás enlaces a documentación, ejemplos y herramientas que te ayud
 ## Obteniendo ayuda de la comunidad
 
 - Ver los foros de Mozilla...
-  {{ DiscussionList("dev-tech-mathml", "mozilla.dev.tech.mathml") }}
+  - [como lista de correo](https://lists.mozilla.org/listinfo/dev-tech-mathml)
+  - [como grupo de noticias](https://groups.google.com/group/mozilla.dev.tech.mathml)
+  - [como RSS](https://groups.google.com/group/mozilla.dev.tech.mathml/feeds)
 - [Canal IRC](irc://irc.mozilla.org/%23mathml)
 - [Wiki usada por contribuyentes de Mozilla](https://wiki.mozilla.org/MathML:Home_Page)
 - [W3C Math Home](https://www.w3.org/Math/)

--- a/files/es/web/svg/index.md
+++ b/files/es/web/svg/index.md
@@ -1,14 +1,9 @@
 ---
 title: SVG
 slug: Web/SVG
-tags:
-  - Gráficos 2D
-  - Gráficos(2)
-  - SVG
-  - Todas_las_Categorías
-  - Web
 translation_of: Web/SVG
 ---
+
 **[Comenzando con SVG](/es/docs/SVG/Tutorial)**
 Este tutorial te ayudará a comenzar a usar SVG.
 
@@ -29,7 +24,10 @@ SVG es un estándar Web abierto basado en texto. Está expresamente diseñado pa
 
 ## Comunidad
 
-- Ver foros de Mozilla... {{DiscussionList("dev-tech-svg", "mozilla.dev.tech.svg")}}
+- Ver foros de Mozilla...
+  - [como lista de correo](https://lists.mozilla.org/listinfo/dev-tech-svg)
+  - [como grupo de noticias](https://groups.google.com/group/mozilla.dev.tech.svg)
+  - [como RSS](https://groups.google.com/group/mozilla.dev.tech.svg/feeds)
 
 ## Herramientas
 
@@ -70,7 +68,3 @@ Aunque un poco de SVG puede dar mucho recorrido a la hora de mejorar contenidos 
 - [Caja 3D box](http://www.treebuilder.de/default.asp?file=441875.xml) y [Cajas 3D](http://www.treebuilder.de/default.asp?file=206524.xml)
 - [jVectorMap](http://jvectormap.com/) (mapas interactivos para visualización de datos)
 - [JointJS](http://jointjs.com) (JavaScript libreria de creación de diagramas con JavaScript)
-
-Categorías
-
-Interwiki Language Links

--- a/files/es/web/svg/index.md
+++ b/files/es/web/svg/index.md
@@ -67,4 +67,4 @@ Aunque un poco de SVG puede dar mucho recorrido a la hora de mejorar contenidos 
 - [Mapa de población de los Estados Unidos de América](http://www.carto.net/papers/svg/us_population/index.html)
 - [Caja 3D box](http://www.treebuilder.de/default.asp?file=441875.xml) y [Cajas 3D](http://www.treebuilder.de/default.asp?file=206524.xml)
 - [jVectorMap](http://jvectormap.com/) (mapas interactivos para visualización de datos)
-- [JointJS](http://jointjs.com) (JavaScript libreria de creación de diagramas con JavaScript)
+- [JointJS](https://jointjs.com) (Librería JavaScript para la creación de diagramas)

--- a/files/es/web/xslt/index.md
+++ b/files/es/web/xslt/index.md
@@ -1,11 +1,9 @@
 ---
 title: XSLT
 slug: Web/XSLT
-tags:
-  - Todas_las_Categorías
-  - XSLT
 translation_of: Web/XSLT
 ---
+
 **[Tutorial XSLT (en)](http://www.w3schools.com/xsl/)**
 Este tutorial enseña como usar XSLT para transformar documentos XML en otros formatos.
 
@@ -36,8 +34,9 @@ Actualmente, XSLT es muy usado en la edición web, generando páginas HTML o XHT
 #### Comunidad
 
 - Los foros de Mozilla en inglés:
-
-{{ DiscussionList("dev-tech-xslt", "mozilla.dev.tech.xslt") }}
+- [como lista de correo](https://lists.mozilla.org/listinfo/dev-tech-xslt)
+- [como grupo de noticias](https://groups.google.com/group/mozilla.dev.tech.xslt)
+- [como RSS](https://groups.google.com/group/mozilla.dev.tech.xslt/feeds)
 
 #### Herramientas
 
@@ -45,7 +44,3 @@ Actualmente, XSLT es muy usado en la edición web, generando páginas HTML o XHT
   - : [XML](/es/XML), [XPath](/es/XPath), [XSL](/es/XSL).
 
 > **Nota:** Esta descripción de XSLT ha sido obtenida del [Artículo sobre XSLT en la Wikipedia (es)](http://es.wikipedia.org/wiki/XSLT).
-
-Categorías
-
-Interwiki Language Links


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove deprecated DiscussionList macro from es

Process: remove the macro and replace with the rendered content

### Motivation

The chore of deprecated macros removal

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Relates to https://github.com/orgs/mdn/discussions/263
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
