### PR TITLE
Remove deprecated gecko_minversion_header macro from es

### DIFF
--- a/files/es/web/api/document/readystate/index.md
+++ b/files/es/web/api/document/readystate/index.md
@@ -3,7 +3,7 @@ title: Document.readyState
 slug: Web/API/Document/readyState
 translation_of: Web/API/Document/readyState
 ---
-{{APIRef("DOM")}} {{ gecko_minversion_header("1.9.2") }}
+{{APIRef("DOM")}}
 
 ## Resumen
 

--- a/files/es/web/api/file_api/using_files_from_web_applications/index.md
+++ b/files/es/web/api/file_api/using_files_from_web_applications/index.md
@@ -13,7 +13,6 @@ tags:
 translation_of: Web/API/File/Using_files_from_web_applications
 original_slug: Web/API/File/Using_files_from_web_applications
 ---
-{{ gecko_minversion_header("1.9.2") }}
 
 El uso de la API File añadida al DOM en HTML5, ahora hace posible que la página web solicite al usuario que seleccione archivos locales y, a continuación, leer el contenido de esos archivos. Esta selección se puede hacer, ya sea usando un elemento {{HTMLElement ( "input")}} de HTML o mediante arrastrar y soltar.
 

--- a/files/es/web/api/history_api/index.md
+++ b/files/es/web/api/history_api/index.md
@@ -67,8 +67,6 @@ var numeroDeEntradas = window.history.length;
 
 ## Añadiendo y modificando entradas del historial
 
-{{ gecko_minversion_header("2") }}
-
 HTML5 introduce los métodos `history.pushState()` y `history.replaceState()`, los cuales te permiten añadir y modificar entradas del historial, respectivamente. Estos métodos trabajan en conjunto con el evento {{ domxref("window.onpopstate") }}.
 
 Hacer uso de `history.pushState()` cambia el referer que es utilizado en la cabecera HTTP por los objetos [XMLHttpRequest](/es/docs/XMLHttpRequest) que hayan sido creados luego de cambiar el estado. El referer utilizará la URL del documento cuyo objeto window sea `this` al momento de la creación del objeto [XMLHttpRequest](/es/docs/XMLHttpRequest).

--- a/files/es/web/api/websockets_api/writing_websocket_servers/index.md
+++ b/files/es/web/api/websockets_api/writing_websocket_servers/index.md
@@ -4,7 +4,6 @@ slug: Web/API/WebSockets_API/Writing_WebSocket_servers
 translation_of: Web/API/WebSockets_API/Writing_WebSocket_servers
 original_slug: Web/API/WebSockets_API/Escribiendo_servidores_con_WebSocket
 ---
-{{gecko_minversion_header("2")}}
 
 ## Introducción
 

--- a/files/es/web/css/-moz-image-rect/index.md
+++ b/files/es/web/css/-moz-image-rect/index.md
@@ -8,7 +8,8 @@ tags:
   - Referencia CSS
 translation_of: Web/CSS/-moz-image-rect
 ---
-{{Non-standard_header}}{{CSSRef}}{{gecko_minversion_header("2.0")}}
+
+{{Non-standard_header}}{{CSSRef}}
 
 ## Resumen
 

--- a/files/es/web/css/_colon_-moz-broken/index.md
+++ b/files/es/web/css/_colon_-moz-broken/index.md
@@ -9,7 +9,8 @@ tags:
   - Referencia CSS
 translation_of: Web/CSS/:-moz-broken
 ---
-{{Non-standard_header}}{{CSSRef}}{{gecko_minversion_header("1.9")}}
+
+{{Non-standard_header}}{{CSSRef}}
 
 ## Resumen
 

--- a/files/es/web/css/_colon_-moz-handler-blocked/index.md
+++ b/files/es/web/css/_colon_-moz-handler-blocked/index.md
@@ -7,7 +7,8 @@ tags:
   - Referencia CSS
 translation_of: Web/CSS/:-moz-handler-blocked
 ---
-{{Non-standard_header}}{{ CSSRef() }}{{ gecko_minversion_header("1.9.1") }}
+
+{{Non-standard_header}}{{ CSSRef() }}
 
 ## Resumen
 

--- a/files/es/web/css/_colon_-moz-handler-crashed/index.md
+++ b/files/es/web/css/_colon_-moz-handler-crashed/index.md
@@ -7,7 +7,8 @@ tags:
   - Referencia CSS
 translation_of: Web/CSS/:-moz-handler-crashed
 ---
-{{Non-standard_header}}{{ CSSRef() }}{{ gecko_minversion_header("2.0") }}
+
+{{Non-standard_header}}{{ CSSRef() }}
 
 ## Resumen
 

--- a/files/es/web/css/_colon_-moz-handler-disabled/index.md
+++ b/files/es/web/css/_colon_-moz-handler-disabled/index.md
@@ -7,7 +7,8 @@ tags:
   - Referencia CSS
 translation_of: Web/CSS/:-moz-handler-disabled
 ---
-{{Non-standard_header}}{{ CSSRef() }}{{ gecko_minversion_header("1.9.1") }}
+
+{{Non-standard_header}}{{ CSSRef() }}
 
 ## Resumen
 

--- a/files/es/web/css/_colon_-moz-loading/index.md
+++ b/files/es/web/css/_colon_-moz-loading/index.md
@@ -10,7 +10,8 @@ tags:
   - Referencia CSS
 translation_of: Web/CSS/:-moz-loading
 ---
-{{CSSRef}}{{Non-standard_header}}{{gecko_minversion_header("1.9")}}
+
+{{CSSRef}}{{Non-standard_header}}
 
 ## Resumen
 

--- a/files/es/web/css/_colon_-moz-locale-dir(ltr)/index.md
+++ b/files/es/web/css/_colon_-moz-locale-dir(ltr)/index.md
@@ -11,7 +11,8 @@ tags:
   - Referencia CSS
 translation_of: Web/CSS/:-moz-locale-dir(ltr)
 ---
-{{Non-standard_header}}{{CSSRef}} {{gecko_minversion_header("1.9.2")}}
+
+{{Non-standard_header}}{{CSSRef}}
 
 ## Resumen
 

--- a/files/es/web/css/_colon_-moz-locale-dir(rtl)/index.md
+++ b/files/es/web/css/_colon_-moz-locale-dir(rtl)/index.md
@@ -11,7 +11,8 @@ tags:
   - Referencia CSS
 translation_of: Web/CSS/:-moz-locale-dir(rtl)
 ---
-{{Non-standard_header}}{{CSSRef}}{{gecko_minversion_header("1.9.2")}}
+
+{{Non-standard_header}}{{CSSRef}}
 
 ## Resumen
 

--- a/files/es/web/css/_colon_-moz-suppressed/index.md
+++ b/files/es/web/css/_colon_-moz-suppressed/index.md
@@ -10,7 +10,8 @@ tags:
   - Referencia CSS
 translation_of: Web/CSS/:-moz-suppressed
 ---
-{{Non-standard_header}}{{CSSRef}}{{gecko_minversion_header("1.9")}}
+
+{{Non-standard_header}}{{CSSRef}}
 
 ## Resumen
 

--- a/files/es/web/css/_colon_-moz-user-disabled/index.md
+++ b/files/es/web/css/_colon_-moz-user-disabled/index.md
@@ -9,7 +9,8 @@ tags:
   - Referencia CSS
 translation_of: Web/CSS/:-moz-user-disabled
 ---
-{{Non-standard_header}}{{CSSRef}}{{gecko_minversion_header("1.9")}}
+
+{{Non-standard_header}}{{CSSRef}}
 
 ## Resumen
 

--- a/files/es/web/svg/applying_svg_effects_to_html_content/index.md
+++ b/files/es/web/svg/applying_svg_effects_to_html_content/index.md
@@ -13,8 +13,6 @@ original_slug: Applying_SVG_effects_to_HTML_content
 ---
 Aplicación de efectos de SVG para el contenido HTML.
 
-{{ gecko_minversion_header("1.9.1") }}
-
 Firefox 3.5 introduce soporte para usar SVG como un componente de estilos CSS para aplicar efectos de SVG para el contenido HTML.
 
 Puede especificar SVG en los estilos, ya sea dentro del mismo documento, o dentro de una hoja de estilos externa.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove deprecated gecko_minversion_header macro from es

Process: just remove the macro due to doesn't render anything

### Motivation

The chore of deprecated macros removal

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Relates to https://github.com/orgs/mdn/discussions/263
Fix #6752
- Fix #6753
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
