### PR TITLE
Remove deprecated TemplateLink macro from es

### DIFF
--- a/files/es/mdn/writing_guidelines/experimental_deprecated_obsolete/index.md
+++ b/files/es/mdn/writing_guidelines/experimental_deprecated_obsolete/index.md
@@ -111,8 +111,8 @@ A veces, durante el desarrollo de una nueva especificación, o en el transcurso 
 
 - Si el elemento se implementó en cualquier versión de lanzamiento de uno o más navegadores, pero _solo_ detrás de una preferencia o marca, no elimines el elemento de la documentación inmediatamente. En su lugar, marca el artículo como obsoleto de la siguiente manera:
 
-  - Si el elemento tiene páginas de documentación que describen solo ese elemento (como {{domxref("RTCPeerConnection.close()")}}), agrega la macro {{TemplateLink("deprecated_header")}} en la parte superior de la página y agrega la etiqueta `Deprecated` a la lista de etiquetas de la página.
-  - En la página de descripción general del elemento, la interfaz o la API, busca la lista de elementos que incluyan el elemento que se ha eliminado de la especificación y agrega la macro {{TemplateLink("deprecated_inline")}} después del nombre del elemento en esa lista.
+  - Si el elemento tiene páginas de documentación que describen solo ese elemento (como {{domxref("RTCPeerConnection.close()")}}), agrega la macro [`deprecated_header`](https://github.com/mdn/yari/tree/main/kumascript/macros/deprecated_header.ejs) en la parte superior de la página y agrega la etiqueta `Deprecated` a la lista de etiquetas de la página.
+  - En la página de descripción general del elemento, la interfaz o la API, busca la lista de elementos que incluyan el elemento que se ha eliminado de la especificación y agrega la macro [`deprecated_inline`](https://github.com/mdn/yari/tree/main/kumascript/macros/deprecated_inline.ejs) después del nombre del elemento en esa lista.
   - Busca en el texto informativo de la página de descripción general de esa interfaz, elemento, etc., cualquier referencia al elemento eliminado. Agrega cuadros de advertencia en los lugares apropiados con texto del tipo "\[lo que sea] se ha eliminado de la especificación y pronto se eliminará de los navegadores. Consulta \[enlace a la página] para conocer una nueva forma de hacer esto."
   - Del mismo modo, busca cualquier discusión sobre el tema en las guías y tutoriales sobre la API o tecnología relevante. Agrega advertencias similares.
   - Busca en MDN referencias al elemento eliminado, en caso de que haya discusiones en otro lugar. Agrega también cuadros de advertencia similares allí.
@@ -121,8 +121,8 @@ A veces, durante el desarrollo de una nueva especificación, o en el transcurso 
 
 - Si el elemento se implementó en una o más versiones de publicaciones de navegadores, sin que sea necesario cambiar una preferencia o una marca, marca el elemento como obsoleto, de la siguiente manera:
 
-  - Si el elemento tiene páginas de documentación que describen solo ese elemento (como {{domxref("RTCPeerConnection.close()")}}), agrega la macro {{TemplateLink("deprecated_header")}} en la parte superior de la página y agrega la etiqueta `Deprecated` a la lista de etiquetas de la página.
-  - En la página de descripción general del elemento, la interfaz o la API, busca la lista de elementos que incluyan el elemento que se ha eliminado de la especificación y agrega la macro {{TemplateLink("deprecated_inline")}} después del nombre del elemento en esa lista.
+  - Si el elemento tiene páginas de documentación que describen solo ese elemento (como {{domxref("RTCPeerConnection.close()")}}), agrega la macro [`deprecated_header`](https://github.com/mdn/yari/tree/main/kumascript/macros/deprecated_header.ejs) en la parte superior de la página y agrega la etiqueta `Deprecated` a la lista de etiquetas de la página.
+  - En la página de descripción general del elemento, la interfaz o la API, busca la lista de elementos que incluyan el elemento que se ha eliminado de la especificación y agrega la macro [`deprecated_inline`](https://github.com/mdn/yari/tree/main/kumascript/macros/deprecated_inline.ejs) después del nombre del elemento en esa lista.
   - Busca en el texto informativo de la página de descripción general de esa interfaz, elemento, etc., cualquier referencia al elemento eliminado. Agrega recuadros de advertencia en los lugares apropiados con texto del tipo "\[lo que sea] se ha eliminado de la especificación y está obsoleto. Es posible que se elimine de los navegadores en el futuro, por lo que no debes usarlo. Consulta \[enlace a la página] para conocer una nueva forma de hacer esto."
   - Del mismo modo, busca cualquier discusión sobre el tema en las guías y tutoriales sobre la API o tecnología relevante. Agrega advertencias similares.
   - Busca en MDN referencias al elemento eliminado, en caso de que haya discusiones en otro lugar. Agrega también cuadros de advertencia similares allí.
@@ -151,7 +151,7 @@ A veces, necesitas reutilizar el mismo texto en varias páginas (o deseas usar e
 
   > **Nota:** **Usuarios de Chrome:** Chrome generalmente no incluye las clases aplicadas al contenido al copiar y pegar documentos en nuestro editor. Debes revisar el contenido después de hacer esto y volver a aplicar los estilos perdidos. Checa las tablas, cuadros de sintaxis, resaltado de sintaxis y secciones ocultas de contenido en particular.
 
-- A veces, literalmente, deseas utilizar el mismo contenido en muchas páginas. En este caso, es mejor que coloques el contenido en una página y luego uses la macro {{TemplateLink("Page")}} para trasladar el material de una página a otra. De esta forma, siempre que se actualice el texto de la página fuente, la página de destino también se actualizará (es decir, esto sucederá en una actualización forzada o cuando la página destino pase por una reconstrucción programada).
+- A veces, literalmente, deseas utilizar el mismo contenido en muchas páginas. En este caso, es mejor que coloques el contenido en una página y luego uses la macro [`Page`](https://github.com/mdn/yari/tree/main/kumascript/macros/Page.ejs) para trasladar el material de una página a otra. De esta forma, siempre que se actualice el texto de la página fuente, la página de destino también se actualizará (es decir, esto sucederá en una actualización forzada o cuando la página destino pase por una reconstrucción programada).
 
 #### Copiar contenido de otro lugar
 

--- a/files/es/mdn/writing_guidelines/page_structures/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/index.md
@@ -463,7 +463,7 @@ En este punto, solo tienes que esperar. Un revisor examinará tu solicitud de ex
 
 ## Insertar los datos en páginas MDN
 
-Una vez que tus nuevos datos se hayan incluido en el repositorio principal, puedes comenzar a generar dinámicamente tablas de compatibilidad del navegador basadas en esos datos en las páginas MDN usando la macro {{TemplateLink("Compat")}}. Esta toma un solo parámetro, la notación de puntos requerida para recorrer los datos JSON y encontrar el objeto que representa la característica para la que deseas generar la tabla de compatibilidad.
+Una vez que tus nuevos datos se hayan incluido en el repositorio principal, puedes comenzar a generar dinámicamente tablas de compatibilidad del navegador basadas en esos datos en las páginas MDN usando la macro [`Compat`](https://github.com/mdn/yari/tree/main/kumascript/macros/Compat.ejs). Esta toma un solo parámetro, la notación de puntos requerida para recorrer los datos JSON y encontrar el objeto que representa la característica para la que deseas generar la tabla de compatibilidad.
 
 Por encima de la llamada a la macro, para ayudar a otros colaboradores a encontrar su camino, debes agregar un texto oculto que solo sea visible a los colaboradores de MDN en el modo de edición:
 

--- a/files/es/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
@@ -22,7 +22,7 @@ Consulta también la [guía de estilo CSS](/es/docs/MDN/Contribute/Guidelines/CS
 
 En general, no es necesario utilizar macros para crear enlaces arbitrarios. Utiliza el botón **Enlace** en la interfaz del editor para crear enlaces.
 
-- La macro {{TemplateLink("Glossary")}} crea un vínculo a la entrada de un término específico en el [glosario](/es/docs/Glossary) de MDN. Esta macro acepta un parámetro obligatorio y dos opcionales:
+- La macro [`Glossary`](https://github.com/mdn/yari/tree/main/kumascript/macros/Glossary.ejs) crea un vínculo a la entrada de un término específico en el [glosario](/es/docs/Glossary) de MDN. Esta macro acepta un parámetro obligatorio y dos opcionales:
 
   Ejemplos:
 
@@ -38,50 +38,50 @@ En general, no es necesario utilizar macros para crear enlaces arbitrarios. Util
 
 Hay varias macros para vincular páginas en áreas de referencia específicas de MDN.
 
-- {{TemplateLink("cssxref")}} links to a page in the [CSS Reference](/es/docs/Web/CSS/Reference).
+- [`cssxref`](https://github.com/mdn/yari/tree/main/kumascript/macros/cssxref.ejs) links to a page in the [CSS Reference](/es/docs/Web/CSS/Reference).
   Ejemplo: `\{{CSSxRef("cursor")}}`, da como resultado: {{CSSxRef("cursor")}}.
-- {{TemplateLink("DOMxRef")}} enlaces a páginas en la referencia DOM; si incluyes paréntesis al final, la plantilla sabe que debe mostrar el enlace para que aparezca el nombre de una función. Por ejemplo, `\{{DOMxRef("document.getElementsByName()")}}` da como resultado: {{DOMxRef("document.getElementsByName()")}} mientras que `\{{DOMxRef("Node")}}` da como resultado: {{DOMxRef("Node")}}.
-- {{TemplateLink("event")}} enlaces a páginas en la referencia de Evento del DOM, por ejemplo: `\{{Event("change")}}` da como resultado {{Event("change")}}.
-- {{TemplateLink("HTMLElement")}} enlaza a un elemento HTML en la Referencia HTML.
-- {{TemplateLink("htmlattrxref")}} enlaza a un atributo HTML, ya sea una descripción de atributo global si solo especificas el nombre del atributo o un atributo asociado con un elemento específico si especificas un nombre de atributo y un nombre de elemento. Por ejemplo, `\{{HTMLAttrxRef("lang")}}` creará este enlace: {{HTMLAttrxRef("lang")}}. `\{{HTMLAttrxRef("type", "input")}}` creará este enlace: {{HTMLAttrxRef("type", "input")}}.
-- {{TemplateLink("jsxref")}} enlaza a una página en la {{JSxRef("Referencia", "Referencia de JavaScript")}}.
-- {{TemplateLink("SVGAttr")}} enlaza a un atributo SVG específico. Por ejemplo, `\{{SVGAttr("d")}}` crea este enlace: {{SVGAttr("d")}}.
-- {{TemplateLink("SVGElement")}} enlaza a un elemento SVG en la Referencia SVG.
-- {{TemplateLink("httpheader")}} enlaza a un [header de HTTP](/es/docs/Web/HTTP/Headers).
-- {{TemplateLink("HTTPMethod")}} enlaza a un [método de solicitud HTTP](/es/docs/Web/HTTP/Methods).
-- {{TemplateLink("HTTPStatus")}} enlaces a un [código de estado de respuesta HTTP](/es/docs/Web/HTTP/Status).
+- [`DOMxRef`](https://github.com/mdn/yari/tree/main/kumascript/macros/DOMxRef.ejs) enlaces a páginas en la referencia DOM; si incluyes paréntesis al final, la plantilla sabe que debe mostrar el enlace para que aparezca el nombre de una función. Por ejemplo, `\{{DOMxRef("document.getElementsByName()")}}` da como resultado: {{DOMxRef("document.getElementsByName()")}} mientras que `\{{DOMxRef("Node")}}` da como resultado: {{DOMxRef("Node")}}.
+- [`event`](https://github.com/mdn/yari/tree/main/kumascript/macros/event.ejs) enlaces a páginas en la referencia de Evento del DOM, por ejemplo: `\{{Event("change")}}` da como resultado {{Event("change")}}.
+- [`HTMLElement`](https://github.com/mdn/yari/tree/main/kumascript/macros/HTMLElement.ejs) enlaza a un elemento HTML en la Referencia HTML.
+- [`htmlattrxref`](https://github.com/mdn/yari/tree/main/kumascript/macros/htmlattrxref.ejs) enlaza a un atributo HTML, ya sea una descripción de atributo global si solo especificas el nombre del atributo o un atributo asociado con un elemento específico si especificas un nombre de atributo y un nombre de elemento. Por ejemplo, `\{{HTMLAttrxRef("lang")}}` creará este enlace: {{HTMLAttrxRef("lang")}}. `\{{HTMLAttrxRef("type", "input")}}` creará este enlace: {{HTMLAttrxRef("type", "input")}}.
+- [`jsxref`](https://github.com/mdn/yari/tree/main/kumascript/macros/jsxref.ejs) enlaza a una página en la {{JSxRef("Referencia", "Referencia de JavaScript")}}.
+- [`SVGAttr`](https://github.com/mdn/yari/tree/main/kumascript/macros/SVGAttr.ejs) enlaza a un atributo SVG específico. Por ejemplo, `\{{SVGAttr("d")}}` crea este enlace: {{SVGAttr("d")}}.
+- [`SVGElement`](https://github.com/mdn/yari/tree/main/kumascript/macros/SVGElement.ejs) enlaza a un elemento SVG en la Referencia SVG.
+- [`httpheader`](https://github.com/mdn/yari/tree/main/kumascript/macros/httpheader.ejs) enlaza a un [header de HTTP](/es/docs/Web/HTTP/Headers).
+- [`HTTPMethod`](https://github.com/mdn/yari/tree/main/kumascript/macros/HTTPMethod.ejs) enlaza a un [método de solicitud HTTP](/es/docs/Web/HTTP/Methods).
+- [`HTTPStatus`](https://github.com/mdn/yari/tree/main/kumascript/macros/HTTPStatus.ejs) enlaces a un [código de estado de respuesta HTTP](/es/docs/Web/HTTP/Status).
 
 ### Enlazar a errores
 
 - `Bugs`
 
-  - {{TemplateLink("bug")}} te permite enlazar a un error en bugzilla.mozilla.org fácilmente usando esta sintaxis: `\{{Bug(123456)}}`. Esto te da: {{Bug(123456)}}.
-  - {{TemplateLink("WebkitBug")}} inserta un enlace a un error en la base de datos de errores de `WebKit`. For example, `\{{WebkitBug(31277)}}` inserta {{WebkitBug(31277)}}.
+  - [`bug`](https://github.com/mdn/yari/tree/main/kumascript/macros/bug.ejs) te permite enlazar a un error en bugzilla.mozilla.org fácilmente usando esta sintaxis: `\{{Bug(123456)}}`. Esto te da: {{Bug(123456)}}.
+  - [`WebkitBug`](https://github.com/mdn/yari/tree/main/kumascript/macros/WebkitBug.ejs) inserta un enlace a un error en la base de datos de errores de `WebKit`. For example, `\{{WebkitBug(31277)}}` inserta {{WebkitBug(31277)}}.
 
 ### Ayuda a la navegación para guías multipágina
 
-{{TemplateLink("Previous")}}, {{TemplateLink("Next")}} y {{TemplateLink("PreviousNext")}} proporcionan controles de navegación para artículos que forman parte de secuencias. Para las plantillas unidireccionales, el único parámetro necesario es la ubicación wiki del artículo anterior o siguiente de la secuencia. Para {{TemplateLink("PreviousNext")}}, los dos parámetros necesarios son las ubicaciones wiki de los artículos correspondientes. El primer parámetro es para el artículo anterior y el segundo es para el artículo siguiente.
+[`Previous`](https://github.com/mdn/yari/tree/main/kumascript/macros/Previous.ejs), [`Next`](https://github.com/mdn/yari/tree/main/kumascript/macros/Next.ejs) y [`PreviousNext`](https://github.com/mdn/yari/tree/main/kumascript/macros/PreviousNext.ejs) proporcionan controles de navegación para artículos que forman parte de secuencias. Para las plantillas unidireccionales, el único parámetro necesario es la ubicación wiki del artículo anterior o siguiente de la secuencia. Para [`PreviousNext`](https://github.com/mdn/yari/tree/main/kumascript/macros/PreviousNext.ejs), los dos parámetros necesarios son las ubicaciones wiki de los artículos correspondientes. El primer parámetro es para el artículo anterior y el segundo es para el artículo siguiente.
 
 ## Ejemplos de código
 
 ### Ejemplos en vivo
 
-- {{TemplateLink("EmbedLiveSample")}} te permite insertar la salida de un ejemplo de código en una página, como se describe en [Ejemplos en vivo](/es/docs/MDN/Contribute/Structures/Live_samples).
-- {{TemplateLink("LiveSampleLink")}} crea un vínculo a una página que contiene el resultado de un ejemplo de código en una página, como se describe en [Ejemplos en vivo](/es/docs/MDN/Contribute/Structures/Live_samples).
+- [`EmbedLiveSample`](https://github.com/mdn/yari/tree/main/kumascript/macros/EmbedLiveSample.ejs) te permite insertar la salida de un ejemplo de código en una página, como se describe en [Ejemplos en vivo](/es/docs/MDN/Contribute/Structures/Live_samples).
+- [`LiveSampleLink`](https://github.com/mdn/yari/tree/main/kumascript/macros/LiveSampleLink.ejs) crea un vínculo a una página que contiene el resultado de un ejemplo de código en una página, como se describe en [Ejemplos en vivo](/es/docs/MDN/Contribute/Structures/Live_samples).
 
 ## Generar la barra lateral
 
 Hay plantillas para casi todas las grandes colecciones de páginas. Por lo general, enlazan a la página principal de `reference/guide/tutorial` (esto, a menudo es necesario porque nuestras rutas de navegación a veces no lo pueden hacer) y colocan el artículo en la categoría apropiada.
 
-- {{TemplateLink("CSSRef")}} genera la barra lateral para las páginas de referencia CSS.
-- {{TemplateLink("HTMLRef")}} genera la barra lateral para las páginas de referencia HTML.
-- {{TemplateLink("APIRef")}} genera la barra lateral para las páginas de referencia de la API web.
+- [`CSSRef`](https://github.com/mdn/yari/tree/main/kumascript/macros/CSSRef.ejs) genera la barra lateral para las páginas de referencia CSS.
+- [`HTMLRef`](https://github.com/mdn/yari/tree/main/kumascript/macros/HTMLRef.ejs) genera la barra lateral para las páginas de referencia HTML.
+- [`APIRef`](https://github.com/mdn/yari/tree/main/kumascript/macros/APIRef.ejs) genera la barra lateral para las páginas de referencia de la API web.
 
 ## Formato de propósito general
 
 ### Indicadores en línea para documentación de APIs
 
-{{TemplateLink("optional_inline")}} y {{TemplateLink("ReadOnlyInline")}} se utilizan en la documentación de la API, normalmente cuando se describe la lista de propiedades de un objeto o parámetros de una función.
+[`optional_inline`](https://github.com/mdn/yari/tree/main/kumascript/macros/optional_inline.ejs) y [`ReadOnlyInline`](https://github.com/mdn/yari/tree/main/kumascript/macros/ReadOnlyInline.ejs) se utilizan en la documentación de la API, normalmente cuando se describe la lista de propiedades de un objeto o parámetros de una función.
 
 Uso: `\{{Optional_Inline}}` o `\{{ReadOnlyInline}}`. Ejemplo:
 
@@ -96,7 +96,7 @@ Uso: `\{{Optional_Inline}}` o `\{{ReadOnlyInline}}`. Ejemplo:
 
 #### `Non-standard`
 
-{{TemplateLink("Non-standard_Inline")}} inserta una marca en línea que indica que la API no se ha estandarizado y no está en un seguimiento de estándares.
+[`Non-standard_Inline`](https://github.com/mdn/yari/tree/main/kumascript/macros/Non-standard_Inline.ejs) inserta una marca en línea que indica que la API no se ha estandarizado y no está en un seguimiento de estándares.
 
 ##### Sintaxis
 
@@ -108,7 +108,7 @@ Uso: `\{{Optional_Inline}}` o `\{{ReadOnlyInline}}`. Ejemplo:
 
 #### Experimental
 
-{{TemplateLink("experimental_inline")}} inserta una marca en línea que indica que la API no está ampliamente implementada y puede cambiar en el futuro.
+[`experimental_inline`](https://github.com/mdn/yari/tree/main/kumascript/macros/experimental_inline.ejs) inserta una marca en línea que indica que la API no está ampliamente implementada y puede cambiar en el futuro.
 
 ##### Sintaxis
 
@@ -124,7 +124,7 @@ En estas macros, el parámetro (cuando se especifica) debe ser una de las cadena
 
 #### Desaprobado
 
-{{TemplateLink("Deprecated_Inline")}} inserta una marca desaprobado en línea (`Deprecated_Inline`) para desalentar el uso de una API que oficialmente está en desuso. **Nota**: "Desaprobado" significa que el elemento ya no se debe utilizar, pero sigue funcionando. Si quieres decir que ya no funciona, utiliza el término "obsoleto".
+[`Deprecated_Inline`](https://github.com/mdn/yari/tree/main/kumascript/macros/Deprecated_Inline.ejs) inserta una marca desaprobado en línea (`Deprecated_Inline`) para desalentar el uso de una API que oficialmente está en desuso. **Nota**: "Desaprobado" significa que el elemento ya no se debe utilizar, pero sigue funcionando. Si quieres decir que ya no funciona, utiliza el término "obsoleto".
 
 No utilices el parámetro en ningún área independiente del navegador (HTML, API, JS, CSS, …).
 
@@ -139,7 +139,7 @@ No utilices el parámetro en ningún área independiente del navegador (HTML, AP
 
 #### Obsoleto
 
-{{TemplateLink("Obsolete_Inline")}} inserta una marca de obsoleto en línea (`Deprecated_Inline`) para evitar el uso de, por ejemplo, una función, método o propiedad que oficialmente es obsoleto.
+[`Obsolete_Inline`](https://github.com/mdn/yari/tree/main/kumascript/macros/Obsolete_Inline.ejs) inserta una marca de obsoleto en línea (`Deprecated_Inline`) para evitar el uso de, por ejemplo, una función, método o propiedad que oficialmente es obsoleto.
 
 No utilices el parámetro en ningún área independiente del navegador (HTML, API, JS, CSS, …).
 
@@ -160,14 +160,14 @@ Estas macros se utilizan principalmente en la página [WebAPI](/es/docs/Web/API)
 
 Estas plantillas tienen la misma semántica que sus contrapartes en línea descritas anteriormente. Las plantillas se deben colocar directamente debajo del título de la página principal (o la ruta de navegación si está disponible) en la página de referencia. También se pueden utilizar para marcar una sección en una página.
 
-- {{TemplateLink("Non-standard_Header")}}: `\{{Non-standard_Header}}` {{Non-standard_Header}}
-- {{TemplateLink("SeeCompatTable")}} se debe usar en páginas que documentan [características experimentales](/es/docs/MDN/Contribute/Guidelines/Conventions_definitions#Experimental). Ejemplo: `\{{SeeCompatTable}}` {{SeeCompatTable}}
-- {{TemplateLink("Deprecated_Header")}}: `\{{Deprecated_Header}}` {{Deprecated_Header}}
-- {{TemplateLink("Deprecated_Header")}} con parámetro: `\{{Deprecated_Header("gecko5")}}` {{Deprecated_Header("gecko5")}} No utilices el parámetro en ninguna área de diagnóstico del navegador (HTML, APIs, JS, CSS, …).
-- {{TemplateLink("secureContext_header")}}: `\{{SecureContext_Header}}` {{SecureContext_Header}}
+- [`Non-standard_Header`](https://github.com/mdn/yari/tree/main/kumascript/macros/Non-standard_Header.ejs): `\{{Non-standard_Header}}` {{Non-standard_Header}}
+- [`SeeCompatTable`](https://github.com/mdn/yari/tree/main/kumascript/macros/SeeCompatTable.ejs) se debe usar en páginas que documentan [características experimentales](/es/docs/MDN/Contribute/Guidelines/Conventions_definitions#Experimental). Ejemplo: `\{{SeeCompatTable}}` {{SeeCompatTable}}
+- [`Deprecated_Header`](https://github.com/mdn/yari/tree/main/kumascript/macros/Deprecated_Header.ejs): `\{{Deprecated_Header}}` {{Deprecated_Header}}
+- [`Deprecated_Header`](https://github.com/mdn/yari/tree/main/kumascript/macros/Deprecated_Header.ejs) con parámetro: `\{{Deprecated_Header("gecko5")}}` {{Deprecated_Header("gecko5")}} No utilices el parámetro en ninguna área de diagnóstico del navegador (HTML, APIs, JS, CSS, …).
+- [`secureContext_header`](https://github.com/mdn/yari/tree/main/kumascript/macros/secureContext_header.ejs): `\{{SecureContext_Header}}` {{SecureContext_Header}}
 
 ### Indica que una función está disponible en `workers` web
 
-La macro {{TemplateLink("AvailableInWorkers")}} inserta un cuadro de nota localizado que indica que una función está disponible en el contexto de [workers web](/es/docs/Web/API/Web_Workers_API).
+La macro [`AvailableInWorkers`](https://github.com/mdn/yari/tree/main/kumascript/macros/AvailableInWorkers.ejs) inserta un cuadro de nota localizado que indica que una función está disponible en el contexto de [workers web](/es/docs/Web/API/Web_Workers_API).
 
 {{AvailableInWorkers}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove deprecated TemplateLink macro from es

Process: remove the macro and replace with the rendered content

### Motivation

The chore of deprecated macros removal

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Relates to https://github.com/orgs/mdn/discussions/263
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
