### PR TITLE
Remove deprecated spec macro from es

### DIFF
--- a/files/es/conflicting/web/api/blob/index.md
+++ b/files/es/conflicting/web/api/blob/index.md
@@ -103,6 +103,6 @@ Un Objeto {{domxref("File")}}.
 
 ## Vea también
 
-- {{spec("http://dev.w3.org/2009/dap/file-system/file-writer.html#idl-def-BlobBuilder", "File API Specification: BlobBuilder", "ED")}}
+- [File API Specification: BlobBuilder](https://dev.w3.org/2009/dap/file-system/file-writer.html#idl-def-BlobBuilder)
 - {{domxref("Blob")}}
 - {{domxref("File")}}

--- a/files/es/conflicting/web/api/eventtarget/addeventlistener/index.md
+++ b/files/es/conflicting/web/api/eventtarget/addeventlistener/index.md
@@ -34,4 +34,4 @@ Como la interfaz es marcada con la bandera [function], todas los objetos [Functi
 
 ## Mira también
 
-- {{ spec("http://www.w3.org/TR/DOM-Level-2-Events/events.html#Events-EventListener","Document Object Model Events: EventListener","REC") }}
+- [Document Object Model Events: EventListener](https://www.w3.org/TR/DOM-Level-2-Events/events.html#Events-EventListener)

--- a/files/es/conflicting/web/api/window/beforeunload_event/index.md
+++ b/files/es/conflicting/web/api/window/beforeunload_event/index.md
@@ -3,6 +3,7 @@ title: Window.onbeforeunload
 slug: conflicting/Web/API/Window/beforeunload_event
 translation_of: Web/API/WindowEventHandlers/onbeforeunload
 original_slug: Web/API/WindowEventHandlers/onbeforeunload
+browser-compat: api.Window.beforeunload_event
 ---
 {{ApiRef}}
 
@@ -40,11 +41,9 @@ Se _puede_ y se _debería_ controlar este evento con {{domxref("EventTarget.addE
 
 {{Compat("api.WindowEventHandlers.onbeforeunload")}}
 
-## Especificación
+## Especificaciones
 
-Este evento fue introducido originalmente por Microsoft en Internet Explorer 4 y estandarizado en la especificación HTML5.
-
-- {{spec("http://dev.w3.org/html5/spec-LC/history.html#unloading-documents", "Especificación HTML5: <em>Browsing the Web, Unloading documents</em>", "LC")}} (en inglés)
+{{Specifications}}
 
 ## Ver también
 

--- a/files/es/orphaned/web/api/fileerror/index.md
+++ b/files/es/orphaned/web/api/fileerror/index.md
@@ -82,4 +82,4 @@ Hasta el momento se ha traducido hasta este punto, las tablas que verás a conti
 - {{ domxref("FileReader") }}
 - {{ domxref("File") }}
 - {{ domxref("Blob") }}
-- {{ spec("http://www.w3.org/TR/file-system-api/#errors-and-exceptions", "Specification: FileAPI Errors and exceptions", "WD") }}
+- [Specification: FileAPI Errors and exceptions](https://www.w3.org/TR/file-system-api/#errors-and-exceptions)

--- a/files/es/web/api/domerror/index.md
+++ b/files/es/web/api/domerror/index.md
@@ -44,7 +44,7 @@ La interfaz **`DOMError`** describe un objeto de error que contiene un nombre de
 
 ## Especificaciones
 
-- {{ spec("http://www.w3.org/TR/dom/#interface-domerror", "DOM 4 DOMError specification", "WD") }}
+- [DOM 4 DOMError specification](https://www.w3.org/TR/dom/#interface-domerror)
 
 ## Véase también
 

--- a/files/es/web/api/navigator/vibrate/index.md
+++ b/files/es/web/api/navigator/vibrate/index.md
@@ -32,9 +32,9 @@ Podrá producirse una excepción si el patrón de vibración especificado es dem
 
 {{Compat("api.Navigator.vibrate")}}
 
-## Especificación
+## Especificaciones
 
-- {{spec("http://www.w3.org/TR/vibration/", "Vibration API Specification", "WD")}}
+{{Specifications}}
 
 ## Véase también
 

--- a/files/es/web/api/network_information_api/index.md
+++ b/files/es/web/api/network_information_api/index.md
@@ -70,6 +70,6 @@ if (connection) {
 
 ## Véase también
 
-- {{spec("http://w3c.github.io/netinfo/", "Network Information API Specification", "ED")}}
+- [Network Information API Specification](http://w3c.github.io/netinfo/)
 - [Online and offline events](/es/docs/Online_and_offline_events)
 - {{domxref("Navigator.connection", "window.navigator.connection")}}

--- a/files/es/web/api/node/parentelement/index.md
+++ b/files/es/web/api/node/parentelement/index.md
@@ -36,9 +36,9 @@ En algunos navegadores, la propiedad `elementoPadre` es solo definida en nodos q
 
 {{Compat("api.Node.parentElement")}}
 
-## Especificación
+## Especificaciones
 
-- {{spec("http://dvcs.w3.org/hg/domcore/raw-file/tip/Overview.html#parent-element", "DOM Level 4: Node.parentElement", "WD")}}
+{{Specifications}}
 
 ## Ver también
 

--- a/files/es/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/es/web/api/web_workers_api/using_web_workers/index.md
@@ -532,7 +532,7 @@ The Fibonacci example shown previously demonstrates that workers can in fact [sp
 
 ## See also
 
-- {{ spec("http://dev.w3.org/html5/workers/", "File API Specification: Web Workers", "ED") }}
+- [File API Specification: Web Workers](https://dev.w3.org/html5/workers/)
 - [`Worker`](/en/DOM/Worker) interface
 - [`SharedWorker`](/en/DOM/SharedWorker) interface
 - [Functions available to workers](/en/DOM/Worker/Functions_available_to_workers)

--- a/files/es/web/api/window/cancelanimationframe/index.md
+++ b/files/es/web/api/window/cancelanimationframe/index.md
@@ -49,9 +49,9 @@ window.cancelAnimationFrame(myReq);
 
 {{Compat("api.Window.cancelAnimationFrame")}}
 
-## Especificación
+## Especificaciones
 
-- {{spec("http://www.w3.org/TR/animation-timing/#cancelAnimationFrame", "Timing control for script-based animations: cancelAnimationFrame", "WD")}}
+{{Specifications}}
 
 ## Ver también
 

--- a/files/es/web/api/window/requestanimationframe/index.md
+++ b/files/es/web/api/window/requestanimationframe/index.md
@@ -57,7 +57,7 @@ window.requestAnimationFrame(step);
 
 ## Especificaciones
 
-{{ spec("http://www.w3.org/TR/animation-timing/#requestAnimationFrame", "Timing control for script-based animations: requestAnimationFrame", "WD") }}
+{{Specifications}}
 
 ## Véase también
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove deprecated spec macro from es

Process: 
- remove the macro and replace with `{{Specifications}}` macro when apply
- remove the macro and replace with the rendered content

### Motivation

The chore of deprecated macros removal

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Relates to https://github.com/orgs/mdn/discussions/263
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
