### PR TITLE
Markdown bolded rendering fails 

### DIFF
--- a/files/zh-cn/web/javascript/reference/statements/try...catch/index.md
+++ b/files/zh-cn/web/javascript/reference/statements/try...catch/index.md
@@ -5,7 +5,7 @@ slug: Web/JavaScript/Reference/Statements/try...catch
 
 {{jsSidebar("Statements")}}
 
-**`try...catch`**语句标记要尝试的语句块，并指定一个出现异常时抛出的响应。
+**`try...catch`** 语句标记要尝试的语句块，并指定一个出现异常时抛出的响应。
 
 {{EmbedInteractiveExample("pages/js/statement-trycatch.html")}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This time the problem and the previous markdown syntax error is the same problem, you just need to add a space after it, this is my previous pr, basically the same: https://github.com/mdn/translated-content/pull/9417

<!-- ✍️ Summarize your changes in one or two sentences -->