### PR TITLE
CSS/flex: fixes “toggle” translation

### DIFF
--- a/files/fr/web/css/flex/index.md
+++ b/files/fr/web/css/flex/index.md
@@ -217,7 +217,7 @@ La propriété `flex` peut être définie avec une, deux ou trois valeurs.
 
 ```html
 <div id="flex-container">
-    <div class="flex-item" id="flex">Boîte flexible (cliquer pour passer à la boîte « normale »)</div>
+    <div class="flex-item" id="flex">Boîte flexible (cliquez pour basculer l’affichage de la boîte « normale »)</div>
     <div class="raw-item" id="raw">Boîte « normale » </div>
 </div>
 ```


### PR DESCRIPTION
### Description

In HTML code sample, I turned “cliquez pour passer à la boite normale” into “cliquer pour basculer l’affichage de la boite normale”.

### Motivation

“Toggle” (English source term) means “(dés)activer”. Clicking does not allow to switch to raw box (« passer à la boite normale »), but displays or hides it (depending on it is already displayed). [OQLF recommends](https://vitrinelinguistique.oqlf.gouv.qc.ca/fiche-gdt/fiche/26558667/basculer) “basculer” as a translation. Since “basculer la boite” looks strange, I propose “basculer l’affichage de la boite”).

By the way, I use imperative form (« cliquez ») instead of infinitive one (« cliquer »), since it is not really an action button label, but more an explanatory instruction.