### PR TITLE
Remove deprecated mediawiki.external macro from es

### DIFF
--- a/files/es/web/api/document/stylesheets/index.md
+++ b/files/es/web/api/document/stylesheets/index.md
@@ -23,10 +23,7 @@ styleSheetList = document.styleSheets
 
 El objeto devuelto es del tipo [StyleSheetList](https://www.w3.org/TR/DOM-Level-2-Style/stylesheets.html#StyleSheets-DocumentStyle-styleSheets).
 
-Es una colección ordenada de objetos de tipo [stylesheet](/es/DOM/stylesheet). `styleSheetList.item(index)` o simplemente `styleSheetList{{ mediawiki.external('
- <i>
-  index</i>
- ') }}` devuelve un único objeto de tipo stylesheet con el índice especificado (el índice es de origen 0).
+Es una colección ordenada de objetos de tipo [stylesheet](/es/DOM/stylesheet). `styleSheetList.item(index)` o simplemente `styleSheetList[ index ]` devuelve un único objeto de tipo stylesheet con el índice especificado (el índice es de origen 0).
 
 ## Especificaciones
 

--- a/files/es/web/api/document_object_model/introduction/index.md
+++ b/files/es/web/api/document_object_model/introduction/index.md
@@ -101,7 +101,7 @@ La siguiente tabla describe brevemente estos tipos de datos.
     <td>Una "<code>nodeList</code>" es una serie de elementos, parecido a lo que devuelve el método <code>document.getElementsByTagName()</code>. Se accede a los items de la <code>nodeList</code> de cualquiera de las siguientes dos formas:
       <ul>
       <li>list.item (1)</li>
-      <li>lista {{mediawiki.external (1)}}</li>
+      <li>lista [1]</li>
       </ul>
       <p>Ambas maneras son equivalentes. En la primera, <strong>item()</strong> es el método del objeto <code>nodeList</code>. En la última se utiliza la típica sintaxis de acceso a listas para llegar al segundo ítem de la lista.</p>
     </td>

--- a/files/es/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
+++ b/files/es/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
@@ -165,7 +165,7 @@ En este ejemplo, establecemos la variable `myP` en el objeto DOM para el segundo
     myBody = document.getElementsByTagName("body")[0]
     ```
 
-    Como en cualquier documento HTML sólo hay un elemento body válido, esta lista tendrá sólo un elemento, que recuperamos seleccionando el primer elemento de esa lista usando `{{mediawiki.external(0)}}`.
+    Como en cualquier documento HTML sólo hay un elemento body válido, esta lista tendrá sólo un elemento, que recuperamos seleccionando el primer elemento de esa lista usando `[0]`.
 
 2. Luego, obtenemos todos los elementos p que son descendientes del body mediante
 
@@ -200,7 +200,7 @@ This means that you have created a node of the type TEXT_NODE (a piece of text) 
 
 ### Inserting Elements with appendChild(..)
 
-So, by calling myP.appendChild({{mediawiki.external('node_element')}}), you are making the element a new child of the second \<p> element.
+So, by calling myP.appendChild([node_element]), you are making the element a new child of the second \<p> element.
 
 ```
 myP.appendChild(myTextNode);
@@ -308,7 +308,7 @@ The basic steps to create the table in sample1.html are:
 
 ### Getting a text node from the table
 
-This example introduces two new DOM attributes. First it uses the `childNodes` attribute to get the list of child nodes of mycel. The `childNodes` list includes all child nodes, regardless of what their name or type is. Like getElementsByTagName(), it returns a list of nodes. The differences are that (a) getElementsByTagName() only returns elements of the specified tag name; and (b) getElementsByTagName() returns descendants at any level, not just immediate children. Once you have the returned list, use `{{mediawiki.external('x')}}` method to retrieve the desired child item. This example stores in myceltext the text node of the second cell in the second row of the table. Then, to display the results in this example, it creates a new text node whose content is the data of myceltext and appends it as a child of the \<body> element.
+This example introduces two new DOM attributes. First it uses the `childNodes` attribute to get the list of child nodes of mycel. The `childNodes` list includes all child nodes, regardless of what their name or type is. Like getElementsByTagName(), it returns a list of nodes. The differences are that (a) getElementsByTagName() only returns elements of the specified tag name; and (b) getElementsByTagName() returns descendants at any level, not just immediate children. Once you have the returned list, use `[x]` method to retrieve the desired child item. This example stores in myceltext the text node of the second cell in the second row of the table. Then, to display the results in this example, it creates a new text node whose content is the data of myceltext and appends it as a child of the \<body> element.
 
 > **Nota:** If your object is a text node, you can use the data attribute and retrieve the text content of the node.
 

--- a/files/es/web/api/htmlstyleelement/index.md
+++ b/files/es/web/api/htmlstyleelement/index.md
@@ -23,7 +23,7 @@ Vea las siguientes páginas para información sobre alguno de los objetos utiliz
 
 El objeto básico `style`, presenta los estilos definidos para el DOM en su especificación de nivel 2. Los estilos se definen mediante `las interfaces StyleSheet` y `CSSStyleSheet`. Estas interfaces contienen miembros tales como `insertRule`, `selectorText`, y `parentStyleSheet` que permiten acceder y manipular las reglas de estilo individuales de que se compone una hoja de estilos CSS.
 
-Para obtener los objetos `style` de un `document`, podemos usar la propiedad `document.styleSheets` y llegar a los distintos objetos por su índice (por ejemplo: `document.styleSheets{{ mediawiki.external(0) }}` es la primer stylesheet definida en el documento, etc.). Aunque hay varias formas y sintaxis para expresar una stylsheet para un documento, Netscape implementa exclusivamente, CSS, de manera que el objeto `style` obtenido por este método, es a la vez StyleSheet y CSSStyleSheet.
+Para obtener los objetos `style` de un `document`, podemos usar la propiedad `document.styleSheets` y llegar a los distintos objetos por su índice (por ejemplo: `document.styleSheets[0]` es la primer stylesheet definida en el documento, etc.). Aunque hay varias formas y sintaxis para expresar una stylsheet para un documento, Netscape implementa exclusivamente, CSS, de manera que el objeto `style` obtenido por este método, es a la vez StyleSheet y CSSStyleSheet.
 
 ```
 var ss = document.styleSheets[1];

--- a/files/es/web/api/window/error_event/index.md
+++ b/files/es/web/api/window/error_event/index.md
@@ -54,7 +54,7 @@ window.onerror = function myErrorHandler(errorMsg, url, lineNumber) {
 
 El evento de error es lanzado cuando ocurre un error en el script.
 
-Cuando se use el marcado html en línea (\<body onerror="alert('an error occurred')>...), los argumentos son anónimos. Pueden ser referenciados usando desde `arguments{{ mediawiki.external(0) }}` hasta `arguments{{ mediawiki.external(2) }}`.
+Cuando se use el marcado html en línea (\<body onerror="alert('an error occurred')>...), los argumentos son anónimos. Pueden ser referenciados usando desde `arguments[0]` hasta `arguments[2]`.
 
 No hay llamante `Components.stack.caller` que recuperar. (Vea [**bug 355430**](https://bugzilla.mozilla.org/show_bug.cgi?id=355430).)
 

--- a/files/es/web/css/content/index.md
+++ b/files/es/web/css/content/index.md
@@ -17,7 +17,7 @@ La propiedad `content` se usa junto con los pseudo-elementos `:before` y `:after
 
 En **CSS3**
 
-- Value: {{ mediawiki.external(' &lt;uri&gt; \',\' ') }}\</uri>\* {{ mediawiki.external(' normal | none | inhibit | &lt;content-list&gt; ') }}\</content-list>
+- Value: [ &lt;uri&gt; \',\' ]\</uri>\* [ normal | none | inhibit | &lt;content-list&gt; ]\</content-list>
 - Valor inicial: normal
 - Se aplica a: todos los elementos y a `::before, ::after, ::alternate, ::marker, ::line-marker, áreas de margin y @footnote`.
 - {{ Cssxref("inheritance", "Valor heredado") }}: no

--- a/files/es/web/css/cursor/index.md
+++ b/files/es/web/css/cursor/index.md
@@ -30,7 +30,7 @@ cursor: [<url> [<x> <y>]?,]*  <std-cursor-name> ;
 
 ### Values
 
-- \<url> {{ mediawiki.external(' ') }}?
+- \<url> [ ]?
   - : URL del cursor seleccionado mas posición opcional. Mas de un URL puede provocar problemas, in caso de que algunos tipode de imágenes de cursor no puedan ser usados.vea [Uso_de_URL_como_valor_de_la_propiedad_cursor](es/Uso_de_URL_como_valor_de_la_propiedad_cursor) para mas detalles.
 - \<std-cursor-name>
   - : Algunos nombres de cursores se encuentra en la siguiente tabla.

--- a/files/es/web/css/font-variant/index.md
+++ b/files/es/web/css/font-variant/index.md
@@ -17,7 +17,9 @@ La propiedad `font-variant` selecciona entre los aspectos `normal` y `small-caps
 
 ## Sintaxis
 
-`font-variant:` {{ mediawiki.external('<code>normal</code> | <code>small-caps</code>') }} ;
+```
+font-variant: [normal | small-caps] ;
+```
 
 ### Valores
 

--- a/files/es/web/css/list-style/index.md
+++ b/files/es/web/css/list-style/index.md
@@ -23,7 +23,7 @@ La propiedad de estilo de lista (`list-style`) permite definir de golpe todos lo
 
 ## Sintaxis
 
-list-style: {{ mediawiki.external(' list-style-type || list-style-position || list-style-image ') }} | inherit
+list-style: [ list-style-type || list-style-position || list-style-image ] | inherit
 
 ### Valores
 

--- a/files/es/web/html/element/col/index.md
+++ b/files/es/web/html/element/col/index.md
@@ -237,7 +237,7 @@ original_slug: Web/HTML/Elemento/col
       <td>Carácter que se usará como punto de alineación.</td>
       <td>
         Un carácter, Uno de estos:
-        {{ mediawiki.external('ISO10646') }}.
+        [ISO10646].
       </td>
       <td>Lo fija el navegador.</td>
     </tr>

--- a/files/es/web/html/element/meta/index.md
+++ b/files/es/web/html/element/meta/index.md
@@ -25,7 +25,7 @@ original_slug: Web/HTML/Elemento/meta
 
 ~~Por defecto~~: Debe indicarlo el autor.
 
-name = name {{ mediawiki.external('CS') }} Este atributo identifica un nombre de propiedad. Esta especificación no enumera los valores legales para este atributo. content = cdata {{ mediawiki.external('CS') }} Este atributo especifica el valor de una propiedad. Esta especificación no enumera los valores legales para este atributo. scheme = cdata {{ mediawiki.external('CS') }} Este atributo especifica un esquema que se usará para interpretar el valor de la propiedad (véase la sección sobre perfiles para más detalles). http-equiv = name {{ mediawiki.external('CI') }} Este atributo puede utilizarse en lugar del atributo name. Los servidores HTTP utilizan este atributo para obtener información sobre los encabezados del mensaje de respuesta HTTP.
+name = name [CS] Este atributo identifica un nombre de propiedad. Esta especificación no enumera los valores legales para este atributo. content = cdata [CS] Este atributo especifica el valor de una propiedad. Esta especificación no enumera los valores legales para este atributo. scheme = cdata [CS] Este atributo especifica un esquema que se usará para interpretar el valor de la propiedad (véase la sección sobre perfiles para más detalles). http-equiv = name [CI] Este atributo puede utilizarse en lugar del atributo name. Los servidores HTTP utilizan este atributo para obtener información sobre los encabezados del mensaje de respuesta HTTP.
 
 <table class="fullwidth-table standard-table">
   <tbody>

--- a/files/es/web/javascript/reference/about/index.md
+++ b/files/es/web/javascript/reference/about/index.md
@@ -25,8 +25,8 @@ El formato de números ha sido extendido para incluir los métodos `Number.proto
 Las siguientes extensiones para expresiones regulares han sido añadidas:
 
 - Cuantificadores avaros: `— +, *, ? y {}`:ahora pueden seguirse por un `?` para forzarlos ha no ser avaros. Para la entrada **?** Véase la página [Escribir un patrón de expresiones regulares](/es/Guía_JavaScript_1.5/Escribir_un_patrón_de_expresión_regular#Uso_de_caracteres_especiales).
-- Paréntesis sin captura: `(?:x)`:pueden ser usados en vez de paréntesis con captura `(x)`. Cuando son utilizados, las sub expresiones de compatibilidad {{ mediawiki.external('match') }} no están disponibles como referencias de respaldo {{ mediawiki.external('back-references') }}. Para la entrada **(?:x)** Véase la página: [Escribir un patrón de expresiones regulares](/es/Guía_JavaScript_1.5/Escribir_un_patrón_de_expresión_regular#Uso_de_caracteres_especiales).
-- Aserciones predictivas {{ mediawiki.external('lookahead assertions') }} positivas y negativas son soportadas. Las dos aserguran una comparación dependiente de lo que sigue en la cadena de texto que está siendo cotejada. Ver las entradas para `x(?=y) y x(?!y)` en la página: [Escribir un patrón de expresiónes regulares](/es/Guía_JavaScript_1.5/Escribir_un_patrón_de_expresión_regular#Uso_de_caracteres_especiales).
+- Paréntesis sin captura: `(?:x)`:pueden ser usados en vez de paréntesis con captura `(x)`. Cuando son utilizados, las sub expresiones de compatibilidad `[match]` no están disponibles como referencias de respaldo `[back-references]`. Para la entrada **(?:x)** Véase la página: [Escribir un patrón de expresiones regulares](/es/Guía_JavaScript_1.5/Escribir_un_patrón_de_expresión_regular#Uso_de_caracteres_especiales).
+- Aserciones predictivas `[lookahead assertions]` positivas y negativas son soportadas. Las dos aserguran una comparación dependiente de lo que sigue en la cadena de texto que está siendo cotejada. Ver las entradas para `x(?=y) y x(?!y)` en la página: [Escribir un patrón de expresiónes regulares](/es/Guía_JavaScript_1.5/Escribir_un_patrón_de_expresión_regular#Uso_de_caracteres_especiales).
 - La bandera m ha sido añadida para especificar que la expresión regular deberá cotejarse sobre múltiples líneas.
 
 **Declaraciones condicionales de funciones**
@@ -47,14 +47,14 @@ Constantes nominadas como sólo de lectura son soportadas. Esta característica 
 
 **Obtenedores y Modificadores (Getters and Setters)**
 
-Los editores de JavaScript ahora pueden añadir obtenedores {{ mediawiki.external('getters') }} y modificadores {{ mediawiki.external('setters') }} a sus objetos. Esta característica está disponible únicamente en la implementación C de JavaScript.
+Los editores de JavaScript ahora pueden añadir obtenedores `[getters]` y modificadores `[setters]` a sus objetos. Esta característica está disponible únicamente en la implementación C de JavaScript.
 
 ### Qué debería saberse ya
 
 Esta referencia asume que usted tiene a su respaldo el siguiente conocimiento básico:
 
 - Un entendimiento general de la Internet y de la World Wide Web (WWW).
-- Un conocimiento práctico del lenguaje de marcas para Hipertexto {{ mediawiki.external('HyperText Markup Language') }} ([HTML](/es/HTML)).
+- Un conocimiento práctico del lenguaje de marcas para Hipertexto `[HyperText Markup Language]` ([HTML](/es/HTML)).
 
 Es beneficioso alguna experiencia en programación en lenguajes como C o Visual Basic, pero no es requerido.
 
@@ -97,13 +97,13 @@ Si usted es principiante con JavaScript, comience por la [Guía de JavaScript](/
 
 ### Convenciones en el documento
 
-Las aplicaciones JavaScript se ejecutan en muchos sistemas operativos; la información en este libro se aplica a todas las versiones. Las rutas {{ mediawiki.external('paths') }} para archivos y directorios están dadas en un formato Windows (con backslashes separando los nombres de directorios). Para las versiones Unix, la ruta de los directorios son las mismas, excepto que deben usarse slashes en vez de backslashes para separar los directorios.
+Las aplicaciones JavaScript se ejecutan en muchos sistemas operativos; la información en este libro se aplica a todas las versiones. Las rutas `[paths]` para archivos y directorios están dadas en un formato Windows (con backslashes separando los nombres de directorios). Para las versiones Unix, la ruta de los directorios son las mismas, excepto que deben usarse slashes en vez de backslashes para separar los directorios.
 
-Esta guía utiliza los localizadores uniformes de recursos {{ mediawiki.external('uniform resource locators') }} (URLs) de la siguiente forma:
+Esta guía utiliza los localizadores uniformes de recursos `[uniform resource locators]` (URLs) de la siguiente forma:
 
 `http://servidor.dominio/path/file.html`
 
-En estos URLs, "servidor" representa el nombre del servidor en el cual puede ejecutar su aplicación (p.e., busqueda1, www), "dominio" representa un nombre de dominio de Internet (p.e., netscape.com, uiuc.edu), "path" representa la estructura de directorios en el servidor y "file.html" representa un nombre individual de archivo. En general, los items en italica en un URLs se mantienen en su lugar y los items en un tipo normal de fuente monospace son literales. Si su servidor tiene habilitada la capa de sockets seguros {{ mediawiki.external('Secure Sockets Layer') }} (SSL), deberá usar https en lugar de http en el URL.
+En estos URLs, "servidor" representa el nombre del servidor en el cual puede ejecutar su aplicación (p.e., busqueda1, www), "dominio" representa un nombre de dominio de Internet (p.e., netscape.com, uiuc.edu), "path" representa la estructura de directorios en el servidor y "file.html" representa un nombre individual de archivo. En general, los items en italica en un URLs se mantienen en su lugar y los items en un tipo normal de fuente monospace son literales. Si su servidor tiene habilitada la capa de sockets seguros `[Secure Sockets Layer]` (SSL), deberá usar https en lugar de http en el URL.
 
 Esta guía utiliza las siguientes convenciones de tipo de fuente:
 

--- a/files/es/web/javascript/reference/global_objects/number/tostring/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/tostring/index.md
@@ -18,7 +18,7 @@ Devuelve una cadena que representa al objeto _Number_ especificado
 
 ## Sintaxis
 
-`number .toString( {{ mediawiki.external('<em>base</em> ') }} )`
+`number .toString( [base ] )`
 
 ### Parámetro
 

--- a/files/es/web/javascript/reference/global_objects/object/tostring/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/tostring/index.md
@@ -21,7 +21,7 @@ Devuelve una cadena que representa al objeto.
 
 ## Descripción
 
-Todos los objetos tienen un método `toString` que se llama automáticamente cuando el objeto se representa como un valor de texto o cuando un objeto se referencia de tal manera que se espera una cadena. Por defecto, el método `toString` es heredado por todos los objetos que descienden de `Object`. Si este método no se sobreescribe en el objeto personalizado, `toString` devuelve `objecttype`, donde `type` es el tipo de objeto. El siguiente código ilustra esto:
+Todos los objetos tienen un método `toString` que se llama automáticamente cuando el objeto se representa como un valor de texto o cuando un objeto se referencia de tal manera que se espera una cadena. Por defecto, el método `toString` es heredado por todos los objetos que descienden de `Object`. Si este método no se sobreescribe en el objeto personalizado, `toString` devuelve `[objecttype]`, donde `type` es el tipo de objeto. El siguiente código ilustra esto:
 
 ```js
 var objeto = new Object();

--- a/files/es/web/javascript/reference/global_objects/object/tostring/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/tostring/index.md
@@ -21,7 +21,7 @@ Devuelve una cadena que representa al objeto.
 
 ## Descripción
 
-Todos los objetos tienen un método `toString` que se llama automáticamente cuando el objeto se representa como un valor de texto o cuando un objeto se referencia de tal manera que se espera una cadena. Por defecto, el método `toString` es heredado por todos los objetos que descienden de `Object`. Si este método no se sobreescribe en el objeto personalizado, `toString` devuelve `{{ mediawiki.external('object<em>type</em> ') }}`, donde `type` es el tipo de objeto. El siguiente código ilustra esto:
+Todos los objetos tienen un método `toString` que se llama automáticamente cuando el objeto se representa como un valor de texto o cuando un objeto se referencia de tal manera que se espera una cadena. Por defecto, el método `toString` es heredado por todos los objetos que descienden de `Object`. Si este método no se sobreescribe en el objeto personalizado, `toString` devuelve `objecttype`, donde `type` es el tipo de objeto. El siguiente código ilustra esto:
 
 ```js
 var objeto = new Object();

--- a/files/es/web/javascript/reference/global_objects/string/match/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/match/index.md
@@ -69,7 +69,7 @@ var array_emparejamientos = cadena.match(expresion);
 console.log(array_emparejamientos);
 ```
 
-`array_emparejamientos` será `{{ mediawiki.external('\'A\', \'B\', \'C\', \'D\', \'E\', \'a\', \'b\', \'c\', \'d\', \'e\'') }}`
+`array_emparejamientos` será `['A', 'B', 'C', 'D', 'E', 'a', 'b', 'c', 'd', 'e']`
 
 ## Vea También
 

--- a/files/es/web/javascript/reference/operators/property_accessors/index.md
+++ b/files/es/web/javascript/reference/operators/property_accessors/index.md
@@ -71,7 +71,7 @@ objeto[foo] = 'valor';
 alert(objeto[bar]);
 ```
 
-Ésto también tiene como resultado "valor", ya que tanto foo como bar se convierten a la misma cadena. En el motor de JavaScript [SpiderMonkey](/es/docs/Mozilla/SpiderMonkey), esta cadena sería "{{ mediawiki.external('objeto Object') }}".
+Ésto también tiene como resultado "valor", ya que tanto foo como bar se convierten a la misma cadena. En el motor de JavaScript [SpiderMonkey](/es/docs/Mozilla/SpiderMonkey), esta cadena sería `[objeto Object]`.
 
 ### Enlace a métodos
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove deprecated spec macro from es

Process: remove the macro and replace with the rendered content

### Motivation

The chore of deprecated macros removal

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Relates to https://github.com/orgs/mdn/discussions/263
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
