### PR TITLE
Remove deprecated HTMLVersionInline macro from es

### DIFF
--- a/files/es/orphaned/web/accessibility/aria/aria_techniques/using_the_aria-required_attribute/index.md
+++ b/files/es/orphaned/web/accessibility/aria/aria_techniques/using_the_aria-required_attribute/index.md
@@ -11,7 +11,7 @@ original_slug: Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_at
 
 El atributo [`aria-required`](http://www.w3.org/TR/wai-aria/states_and_properties#aria-required) es usado para indicar al usuario que un input es requerido en un elemento antes de que un form pueda ser enviado. Este atributo puede ser usado en un form con cualquier elemento HTML típico; no se limita a elementosque tengan un `role` ARIA asignado.
 
-{{ HTMLVersionInline("5") }} ahora tiene el atributo `required`, pero aria-required todavía es útil para un agente de usuario que no soporta HTML5.
+HTML5 ahora tiene el atributo `required`, pero aria-required todavía es útil para un agente de usuario que no soporta HTML5.
 
 ### Value
 
@@ -66,4 +66,4 @@ Por determinar: Agregar información de soporte para combinaciones comunes de pr
 
 - [Especificación WAI-ARIA para `aria-required`](http://www.w3.org/TR/wai-aria/states_and_properties#aria-required)
 - [WAI-ARIA Authoring Practices for forms](http://www.w3.org/TR/wai-aria-practices/#ariaform)
-- [Constraint validation](/en/HTML/HTML5/Constraint_validation) in {{ HTMLVersionInline("5") }}
+- [Constraint validation](/en/HTML/HTML5/Constraint_validation) in HTML5

--- a/files/es/web/api/htmlinputelement/index.md
+++ b/files/es/web/api/htmlinputelement/index.md
@@ -115,9 +115,7 @@ Properties that apply only to text/number-containing or elements
   - : _`string`:_ **Returns / Sets** the element's {{ htmlattrxref("placeholder", "input") }} attribute, containing a hint to the user of what can be entered in the control. The placeholder text must not contain carriage returns or line-feeds. This attribute applies when the value of the {{htmlattrxref("type","input")}} attribute is `text`, `search`, `tel`, `url` or `email`; otherwise it is ignored.
 - `readOnly`
 
-  - : _`boolean`:_ **Returns / Sets** the element's {{ htmlattrxref("readonly", "input") }} attribute, indicating that the user cannot modify the value of the control.
-
-    {{HTMLVersionInline(5)}} This is ignored if the value of the {{htmlattrxref("type","input")}} attribute is `hidden`, `range`, `color`, `checkbox`, `radio`, `file`, or a button type.
+  - : _`boolean`:_ **Returns / Sets** the element's {{ htmlattrxref("readonly", "input") }} attribute, indicating that the user cannot modify the value of the control. This is ignored if the value of the {{htmlattrxref("type","input")}} attribute is `hidden`, `range`, `color`, `checkbox`, `radio`, `file`, or a button type.
 
 - `min`
   - : _`string`:_ **Returns / Sets** the element's {{ htmlattrxref("min", "input") }} attribute, containing the minimum (numeric or date-time) value for this item, which must not be greater than its maximum ({{htmlattrxref("max","input")}} attribute) value.

--- a/files/es/web/html/block-level_elements/index.md
+++ b/files/es/web/html/block-level_elements/index.md
@@ -51,15 +51,15 @@ La siguiente es una lista completa de todos los elementos en bloque de HTML (aun
 
 - {{ HTMLElement("address") }}
   - : Información de contacto.
-- {{ HTMLElement("article") }} {{ HTMLVersionInline(5) }}
+- {{ HTMLElement("article") }} 
   - : Contenido de Articulo.
-- {{ HTMLElement("aside") }} {{ HTMLVersionInline(5) }}
+- {{ HTMLElement("aside") }} 
   - : Contenido adicional.
-- {{ HTMLElement("audio") }} {{ HTMLVersionInline(5) }}
+- {{ HTMLElement("audio") }} 
   - : Reproductor de audio
 - {{ HTMLElement("blockquote") }}
   - : Bloque de "cita".
-- {{ HTMLElement("canvas") }} {{ HTMLVersionInline(5) }}
+- {{ HTMLElement("canvas") }} 
   - : Dibujo canvas.
 - {{ HTMLElement("dd") }}
   - : Descripción de definición.
@@ -70,19 +70,19 @@ La siguiente es una lista completa de todos los elementos en bloque de HTML (aun
 - {{ HTMLElement("fieldset") }}
   - : Etiqueta de conjunto de campos.
 
-- {{ HTMLElement("figcaption") }} {{ HTMLVersionInline(5) }}
+- {{ HTMLElement("figcaption") }} 
   - : Leyenda de figura.
-- {{ HTMLElement("figure") }} {{ HTMLVersionInline(5) }}
+- {{ HTMLElement("figure") }} 
   - : Grupos contenido multimedia con una leyenda (ver {{ HTMLElement("figcaption") }}).
-- {{ HTMLElement("footer") }} {{ HTMLVersionInline(5) }}
+- {{ HTMLElement("footer") }} 
   - : Sección o pie de página.
 - {{ HTMLElement("form") }}
   - : Formulario de entrada.
 - {{ HTMLElement("h1") }}, {{ HTMLElement("h2") }}, {{ HTMLElement("h3") }}, {{ HTMLElement("h4") }}, {{ HTMLElement("h5") }}, {{ HTMLElement("h6") }}
   - : Niveles de cabecera 1-6.
-- {{ HTMLElement("header") }} {{ HTMLVersionInline(5) }}
+- {{ HTMLElement("header") }} 
   - : Sección o cabecera de página.
-- {{ HTMLElement("hgroup") }} {{ HTMLVersionInline(5) }}
+- {{ HTMLElement("hgroup") }} 
   - : Grupos información de encabezado.
 - {{ HTMLElement("hr") }}
   - : Regla Horizontal (línea divisoria).
@@ -97,13 +97,13 @@ La siguiente es una lista completa de todos los elementos en bloque de HTML (aun
   - : Contenido para ser usado si los scripts no son soportados o permitidos.
 - {{ HTMLElement("ol") }}
   - : Lista ordenada.
-- {{ HTMLElement("output") }} {{ HTMLVersionInline(5) }}
+- {{ HTMLElement("output") }} 
   - : Formulario de salida.
 - {{ HTMLElement("p") }}
   - : Párrafo.
 - {{ HTMLElement("pre") }}
   - : Texto preformateado.
-- {{ HTMLElement("section") }} {{ HTMLVersionInline(5) }}
+- {{ HTMLElement("section") }} 
   - : Sección de una página web.
 - {{ HTMLElement("table") }}
   - : Tabla.
@@ -111,7 +111,7 @@ La siguiente es una lista completa de todos los elementos en bloque de HTML (aun
   - : Pie de tabla.
 - {{ HTMLElement("ul") }}
   - : Lista no ordenada.
-- {{ HTMLElement("video") }} {{ HTMLVersionInline(5) }}
+- {{ HTMLElement("video") }} 
   - : Reproductor de vídeo.
 
 ### Ver también

--- a/files/es/web/html/element/a/index.md
+++ b/files/es/web/html/element/a/index.md
@@ -68,7 +68,7 @@ El _Elemento HTML `Anchor`_ **`<a>`** crea un enlace a otras páginas de interne
 
 Este elemento incluye los [atributos globales](/es/docs/HTML/Global_attributes).
 
-- {{htmlattrdef("download")}} {{HTMLVersionInline(5)}}
+- {{htmlattrdef("download")}} 
 
   - : Este atributo, indica descargar a los navegadores una URL en lugar de navegar hacia ella, por lo que el usuario será dirigido para salvarla como un archivo local. Si el atributo tiene un valor, éste se utilizará como nombre de archivo por defecto en el mensaje Guardar que se abre cuando el usuario hace clic en el enlace (sin embargo, el usuario puede cambiar el nombre antes de guardar el archivo). No hay restricciones sobre los valores permitidos, aunque: / y: \ se convertirán en guiones bajos (_underscores_), lo que evitará sugerencias de ruta específicas. Se debe tener en cuenta que la mayoría de los sistemas de archivos tienen limitaciones con respecto a los símbolos de puntuación admitidos en los nombres de archivo, por lo que los navegadores ajustarán los nombres de los archivos en consecuencia.
 

--- a/files/es/web/html/element/br/index.md
+++ b/files/es/web/html/element/br/index.md
@@ -25,7 +25,7 @@ Este elemento incluye los [atributos globales](/es/docs/HTML/Global_attributes).
 - {{htmlattrdef("clear")}} {{Deprecated_Inline}}
   - : Indica donde empieza la siguiente línea después del salto.
 
-> **Nota:** **Nota de uso:** Este atributo está obsoleot en {{HTMLVersionInline(5)}} y **no debe utilizarse por los autores**. En su lugar utiliza la propiedad {{CSSxref('clear')}} de CSS.
+> **Nota:** **Nota de uso:** Este atributo está obsoleot en HTML5 y **no debe utilizarse por los autores**. En su lugar utiliza la propiedad {{CSSxref('clear')}} de CSS.
 
 ## Ejemplo
 

--- a/files/es/web/html/element/form/index.md
+++ b/files/es/web/html/element/form/index.md
@@ -22,7 +22,7 @@ Es posible usar las pseudo-clasess de CSS [`:valid`](/es/CSS/%3Avalid) e [`:inva
 
 Como cualquier otro elemento HTML, este elemento soporta [atributos globales](/en/HTML/Global_attributes)
 
-- {{ htmlattrdef("accept") }} {{ HTMLVersionInline(4) }} {{ obsolete_inline() }}
+- {{ htmlattrdef("accept") }}  {{ obsolete_inline() }}
 
   - : Una lista separada por comas de los tipos de contenido que el servidor acepta.
 
@@ -36,7 +36,7 @@ Como cualquier otro elemento HTML, este elemento soporta [atributos globales](/e
 
 - {{ htmlattrdef("action") }}
   - : La URI de un programa que procesa la información enviada por medio del formulario. Este valor puede ser sobreescrito por un atributo {{ htmlattrxref("formaction", "button") }} en un {{ HTMLElement("button") }} o en el elemento{{ HTMLElement("input") }}.
-- {{ htmlattrdef("autocomplete") }} {{ HTMLVersionInline(5) }}
+- {{ htmlattrdef("autocomplete") }} 
 
   - : Indica cuales de los controles en este formulario puede tener sus valores automáticamente completados por el navegador. Esta configuración puede ser sobreescrita por un atributo `autocomplete` en un elemento que pertenezca al formulario:
 
@@ -67,7 +67,7 @@ Como cualquier otro elemento HTML, este elemento soporta [atributos globales](/e
 
 - {{ htmlattrdef("name") }}
   - : El nombre del formulario. En HTML4 ha quedado en desuso (debe usarse un id en su lugar). Debe ser único entre los formularios en un documento y no una cadena vacia en HTML5.
-- {{ htmlattrdef("novalidate") }} {{ HTMLVersionInline(5) }}
+- {{ htmlattrdef("novalidate") }} 
   - : Este atributo booleano indica que el formulario no es validado cuando es enviado. Si el atributo no existe {{ htmlattrxref("formnovalidate", "button") }} en un {{ HTMLElement("button") }} o en un elemento {{ HTMLElement("input") }} que pertenece al formulario.
 - {{ htmlattrdef("target") }}
 

--- a/files/es/web/html/element/iframe/index.md
+++ b/files/es/web/html/element/iframe/index.md
@@ -104,7 +104,7 @@ Este elemento admite [atributos globales](/es/docs/Web/HTML/Atributos_Globales).
 - {{htmlattrdef("csp")}} {{experimental_inline}}
   - : Una [Politica de Seguridad del Contenido](/es/docs/Web/HTTP/CSP) aplicada para el recurso incrustado. Vea {{domxref("HTMLIFrameElement.csp")}} para detalles.
 - {{ htmlattrdef("height") }}
-  - : Indica la altura del frame {{ HTMLVersionInline(5) }}en píxeles CSS, o {{ HTMLVersionInline(4.01) }} en píxeles o como un porcentaje.
+  - : Indica la altura del frame en HTML5 en píxeles CSS, o en HTML4.01 en píxeles o como un porcentaje.
 - {{htmlattrdef("importance")}} {{experimental_inline}}
 
   - : La prioridad de descarga en el recurso para el atributo `src` del `<iframe>`. Valores permitidos:
@@ -164,7 +164,7 @@ Este elemento admite [atributos globales](/es/docs/Web/HTML/Atributos_Globales).
 - {{ htmlattrdef("srcdoc") }}
   - : The content of the page that the embedded context is to contain.
 - {{ htmlattrdef("width") }}
-  - : Indicates the width of the frame {{ HTMLVersionInline(5) }} in CSS pixels, or {{ HTMLVersionInline(4.01) }} in pixels or as a percentage.
+  - : Indicates the width of the frame in HTML5 in CSS pixels, or in HTML4.01 in pixels or as a percentage.
 
 ### Atributos obsoletos
 

--- a/files/es/web/html/element/img/index.md
+++ b/files/es/web/html/element/img/index.md
@@ -72,7 +72,7 @@ Este elemento incluye atributos globales.
 
   - : Anchura del borde alrededor de la imagen.
 
-- {{htmlattrdef("crossorigin")}} {{HTMLVersionInline(5)}}
+- {{htmlattrdef("crossorigin")}} 
 
   - : Este atributo enumerado indica si la búsqueda de la imagen debe ser por CORS o no. [Imagen hablidata CORS](/es/docs/Web/HTML/Imagen_con_CORS_habilitado) puede ser usada en el elemento {{HTMLElement("canvas")}} sin ser pintada. Los valores permitidos son:
 
@@ -83,7 +83,7 @@ Este elemento incluye atributos globales.
 
     Cuando no existe, el recurso es buscado sin petición CORS (i.e., `sin enviar el Origen:` HTTP header) , previniendo el uso no pintado del elemento {{HTMLElement('canvas')}}. Si es inválido, se maneja como si se hubiese usado **anonymous**. Ver [atributos de configuración CORS](/es/docs/HTML/CORS_settings_attributes) para más información.
 - {{htmlattrdef("height")}}
-  - : La altura de la imagen en píxeles CSS {{HTMLVersionInline(5)}} o píxeles o como porcentaje en {{HTMLVersionInline(4)}}.
+  - : La altura de la imagen en píxeles CSS en HTML5 o píxeles o como porcentaje en HTML4.
 - {{htmlattrdef("hspace")}} {{deprecated_inline}}
   - : El número de píxeles de espaciado a la izquierda y la derecha de la imagen.
 - {{htmlattrdef("ismap")}}
@@ -95,7 +95,7 @@ Este elemento incluye atributos globales.
 - {{htmlattrdef("longdesc")}}
   - : La URL como descripción de una imagen mostrada, complementa al texto de {{htmlattrdef("alt", "img")}}.
 - {{htmlattrdef("name")}} {{deprecated_inline}}
-  - : El nombre para el elemento. Soportado en {{HTMLVersionInline(4)}} solo para compatibilidad con versiones anteriores. En su lugar, usa el atributo **`id`**.
+  - : El nombre para el elemento. Soportado en HTML4 solo para compatibilidad con versiones anteriores. En su lugar, usa el atributo **`id`**.
 - {{htmlattrdef("referrerpolicy")}} {{experimental_inline}}
 
   - : Una cadena indicando que referencia usar cuando buscas un recurso:
@@ -106,7 +106,7 @@ Este elemento incluye atributos globales.
     - "origin-when-cross-origin": navega hacia otro origen limitado por el esquema, el anfitrión y el puerto, mientras navegas en el mismo origen incluirá el camino del referente.
     - `"unsafe-url"`: el referente incluirá el origen y el camino (pero no el fragment, contraseña, o nombre de usuario). Este caso es arriegasdo porque puede haber una fuga del origen o el camino desde los recursos protegidos por TLS desde orígenes inseguros.
 
-- {{htmlattrdef("sizes")}}{{HTMLVersionInline(5)}}
+- {{htmlattrdef("sizes")}}
 
   - : Una lista de una o más cadenas separadas por comas indicando el tamaño de la fuente. Cada tamaño de la fuente consiste en:
 
@@ -117,7 +117,7 @@ Este elemento incluye atributos globales.
 
 - {{htmlattrdef("src")}}
   - : La URL de la imagen. Este atributo es obligatorio para el elemento \<img>. En navegadores que soportan `srcset`, `src` es tratado como imagen candidata con una densidad del píxel `1x` sino una imagen estará definida en `srcset` o `srcset` contiene ancho.
-- {{htmlattrdef("srcset")}}{{HTMLVersionInline(5)}}
+- {{htmlattrdef("srcset")}}
 
   - : Una lista de una o más cadenas separadas por comas indicando las posibles fuentes para usar. Cada cadena está compuesta por:
 
@@ -134,7 +134,7 @@ Este elemento incluye atributos globales.
     Los agentes de usuario son discretos al elegir cualquiera de las fuentes disponibles. Esto les proporciona un margen significativo para adaptar su selección basada en cosas como las preferencias del usuario o las condiciones de ancho de banda.
 
 - {{htmlattrdef("width")}}
-  - : El ancho de la imagen en píxeles CSS {{HTMLVersionInline(5)}}, o píxeles o porcentaje en {{HTMLVersionInline(4)}}.
+  - : El ancho de la imagen en píxeles CSS en HTML5, o píxeles o porcentaje en HTML4.
 - {{htmlattrdef("usemap")}}
 
   - : La URL parcial (empezando con '#') de un [mapa de imagea](/es/docs/HTML/Element/map) asociado a un elemento.

--- a/files/es/web/html/element/input/button/index.md
+++ b/files/es/web/html/element/input/button/index.md
@@ -116,11 +116,11 @@ Este elemento puede tener cualquiera de los [atributos globales](/es/docs/HTML/G
 
     Firefox, al contrario que otros navegadores, [mantiene por defecto el estado de desactivación dinámico](http://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing) de un {{HTMLElement("button")}} a lo largo de las cargas de la página. Use el atributo {{htmlattrxref("autocomplete","button")}} para controlar esta característica.
 
-- {{htmlattrdef("autofocus")}} {{HTMLVersionInline(5)}}
+- {{htmlattrdef("autofocus")}} 
   - : Este atributo booleano le permite especificar que el botón deba tener el foco cuando la página se cargue, a no ser que el usuario lo anule, por ejemplo, escribiendo en otro cuadro de texto. Únicamente un elemento asociado con los formularios en un documento puede tener este atributo especificado.
 - {{htmlattrdef("autocomplete")}} {{non-standard_inline}}
   - : El uso de este atributo en un {{HTMLElement("button")}} es algo fuera de lo común, y específico de Firefox. Firefox, por defecto y al contrario de otros navegadores, [mantiene por defecto el estado de desactivación dinámico](http://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing) de un {{HTMLElement("button")}} a lo largo de las cargas de la página. Establecer el valor de este atributo a `off` (`autocomplete="off"`) desactiva esta característica.
-- {{htmlattrdef("form")}} {{HTMLVersionInline(5)}}
+- {{htmlattrdef("form")}} 
   - : El elemento del formulario con el que el botón está asociado (es _dueño del formulario_). El valor del atributo debe ser el atributo **id** de un elemento {{HTMLElement("form")}} en el mismo documento. Si este atributo no está especificado, el elemento `<button>` debe ser hijo de un elemento "formulario". Este atributo le permite colocar elementos `<button>` en cualquier lugar de un documento, y no únicamento como hijos del elemento {{HTMLElement("form")}}.
 - {{htmlattrdef("formenctype")}}
 
@@ -132,7 +132,7 @@ Este elemento puede tener cualquiera de los [atributos globales](/es/docs/HTML/G
 
     Si este atributo se especifica, ignora el atributo {{htmlattrxref("enctype","form")}} del formulario dueño del botón.
 
-- {{htmlattrdef("formaction")}} {{HTMLVersionInline(5)}}
+- {{htmlattrdef("formaction")}} 
   - : La URI de la aplicación que procesa la información enviada por le botón. Si se especifica se anula el atributo {{htmlattrxref("action","form")}} del formulario dueño del botón.
 - {{htmlattrdef("formmethod")}}
 

--- a/files/es/web/html/element/input/index.md
+++ b/files/es/web/html/element/input/index.md
@@ -69,19 +69,19 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
 
     - `button`: Botón sin un comportamiento específico.
     - `checkbox`: Casilla de selección. Se debe usar el atributo **value** para definir el valor que se enviará por este elemento. Se usa el atributo **checked** para indicar si el elemento está seleccionado. También se puede usar el atributo **indeterminate** (el cual solo se puede establecer programaticamente) para indicar que la casilla está en un estado indeterminado (en la mayoría de las plataformas, se dibuja una línea horizontal a través de la casilla).
-    - `color`: {{HTMLVersionInline("5")}} Control para espicificar un color. Una interfaz de selección de color no requiere más funcionalidad que la de aceptar colores simples como texto ([más información](<http://www.w3.org/TR/html5/forms.html#color-state-(type=color)>)).
-    - `date`: {{HTMLVersionInline("5")}} Control para introducir una fecha (año, mes y día, sin tiempo).
-    - `datetime`: {{HTMLVersionInline("5")}} {{deprecated_inline}} {{obsolete_inline}} Control para introducir una fecha y hora (horas, minutos, segundos y fracción de segundo), basado en la zona horaria UTC. **Esta característica ha sido [removida de WHATWG HTML.](https://github.com/whatwg/html/issues/336)**
-    - `datetime-local`: {{HTMLVersionInline("5")}} Control para introducir fecha y hora, sin zona horaria específica.
-    - `email`: {{HTMLVersionInline("5")}} Campo para introducir una dirección de correo electrónico. El valor introducido se valida para que contenga una cadena vacía o una dirección de correo válida antes de enviarse. Las pseudo-clases {{cssxref(":valid")}} y {{cssxref(":invalid")}} son aplicadas segun corresponda.
+    - `color`:  Control para espicificar un color. Una interfaz de selección de color no requiere más funcionalidad que la de aceptar colores simples como texto ([más información](<http://www.w3.org/TR/html5/forms.html#color-state-(type=color)>)).
+    - `date`:  Control para introducir una fecha (año, mes y día, sin tiempo).
+    - `datetime`:  {{deprecated_inline}} {{obsolete_inline}} Control para introducir una fecha y hora (horas, minutos, segundos y fracción de segundo), basado en la zona horaria UTC. **Esta característica ha sido [removida de WHATWG HTML.](https://github.com/whatwg/html/issues/336)**
+    - `datetime-local`:  Control para introducir fecha y hora, sin zona horaria específica.
+    - `email`: Campo para introducir una dirección de correo electrónico. El valor introducido se valida para que contenga una cadena vacía o una dirección de correo válida antes de enviarse. Las pseudo-clases {{cssxref(":valid")}} y {{cssxref(":invalid")}} son aplicadas segun corresponda.
     - `file`: Control que permite al usuario seleccionar un archivo. Se puede usar el atributo **accept** para definir los tipos de archivo que el control podrá seleccionar.
     - `hidden`: Control que no es mostrado en pantalla, pero cuyo valor es enviado al servidor.
     - `image`: Botón de envío de formulario con gráfico. Se debe usar el atributo **src** para definir el origen de la imagen y el atributo **alt** para definir un texto alternativo. Se puede usar los atributos **height** y **width** para definir el tamaño de la imagen en píxeles.
-    - `month`: {{HTMLVersionInline("5")}} Control para introducir un mes y año, sin zona horaria específica.
-    - `number`: {{HTMLVersionInline("5")}} Control para introducir un número de punto flotante.
+    - `month`:  Control para introducir un mes y año, sin zona horaria específica.
+    - `number`:  Control para introducir un número de punto flotante.
     - `password`: Control de línea simple cuyo valor permanece oculto. Se puede usar el atributo **maxlength** para especificar la longitud máxima del valor que se puede introducir.
     - `radio`: Botón radio. Se debe usar el atributo **value** para definir el valor que se enviará por este elemento. Se usa el atributo **checked** para indicar si el elemento está seleccionado de forma predeterminada. Los botones radio que tengan el mismo valor para su atributo **name** están dentro del mismo "grupo de botones radio". Solo un botón radio dentro de un grupo puede ser seleccionado a la vez.
-    - `range`: {{HTMLVersionInline("5")}} Control para introducir un número cuyo valor exacto no es importante. Este control usa los siguientes valores predeterminados si no se especifica cada atributo:
+    - `range`:  Control para introducir un número cuyo valor exacto no es importante. Este control usa los siguientes valores predeterminados si no se especifica cada atributo:
 
       - `min`: 0
       - `max`: 100
@@ -89,13 +89,13 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
       - `step`: 1
 
     - `reset`: Botón que restaura los contenidos de un formulario a sus valores predeterminados.
-    - `search`: {{HTMLVersionInline("5")}} Cuadro de texto de línea simple para introducir textos de búsqueda. Los saltos de línea son eliminados automáticamente del valor introducido.
+    - `search`: Cuadro de texto de línea simple para introducir textos de búsqueda. Los saltos de línea son eliminados automáticamente del valor introducido.
     - `submit`: Botón que envía el formulario.
-    - `tel`: {{HTMLVersionInline("5")}} Control para introducir un número telefónico. Los saltos de línea son eliminados automáticamente del valor introducido, pero no hay otra sintaxis forzada. Se pueden usar atributos como **pattern** y **maxlength** para restringir los valores introducidos en este control. Las pseudo-clases CSS {{cssxref(":valid")}} y {{cssxref(":invalid")}} son aplicadas segun corresponda.
+    - `tel`: Control para introducir un número telefónico. Los saltos de línea son eliminados automáticamente del valor introducido, pero no hay otra sintaxis forzada. Se pueden usar atributos como **pattern** y **maxlength** para restringir los valores introducidos en este control. Las pseudo-clases CSS {{cssxref(":valid")}} y {{cssxref(":invalid")}} son aplicadas segun corresponda.
     - `text`: Campo de texto de línea simple. Los saltos de línea son eliminados automáticamente del valor introducido.
-    - `time`: {{HTMLVersionInline("5")}} Control para introducir un valor de tiempo sin zona horaria específica.
-    - `url`: {{HTMLVersionInline("5")}} Campo para editar una URL. El valor introducido se valida para que contenga una cadena vacía o una ruta URL absoluta antes de enviarse. Los saltos de línea y espacios en blanco al principio o al final del valor son eliminados automáticamente. Se pueden usar atributos como **pattern** y **maxlength** para restringir los valores introducidos en el control. Las pseudo-clases {{cssxref(":valid")}} y {{cssxref(":invalid")}} son aplicadas segun corresponda.
-    - `week`: {{HTMLVersionInline("5")}} Control para introducir una fecha que consiste en número de semana del año y número de semana sin zona horaria específica.
+    - `time`: Control para introducir un valor de tiempo sin zona horaria específica.
+    - `url`: Campo para editar una URL. El valor introducido se valida para que contenga una cadena vacía o una ruta URL absoluta antes de enviarse. Los saltos de línea y espacios en blanco al principio o al final del valor son eliminados automáticamente. Se pueden usar atributos como **pattern** y **maxlength** para restringir los valores introducidos en el control. Las pseudo-clases {{cssxref(":valid")}} y {{cssxref(":invalid")}} son aplicadas segun corresponda.
+    - `week`: Control para introducir una fecha que consiste en número de semana del año y número de semana sin zona horaria específica.
 
 - {{htmlattrdef("accept")}}
 
@@ -103,11 +103,11 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
 
     - Una extensión de archivo, comenzando por el caracter STOP (U+002E). (Ejemplos: ".jpg,.png,.doc")
     - Un tipo MIME válido sin extensiones
-    - `audio/*`, que representa archivos de audio {{HTMLVersionInline("5")}}
-    - `video/*`, que representa archivos de vídeo {{HTMLVersionInline("5")}}
-    - `image/*`, que representa archivos de imagen {{HTMLVersionInline("5")}}
+    - `audio/*`, que representa archivos de audio 
+    - `video/*`, que representa archivos de vídeo 
+    - `image/*`, que representa archivos de imagen 
 
-- {{htmlattrdef("accesskey")}} sólo {{HTMLVersionInline(4)}} {{deprecated_inline}}
+- {{htmlattrdef("accesskey")}} sólo HTML4 {{deprecated_inline}}
   - : Un caracter que el usuario puede presionar para establecer el cursor en el control. Este atributo es global en HTML5.
 - {{htmlattrdef("mozactionhint")}} {{non-standard_inline}}
   - : Especifica una "pista de acción" usada para determinar cómo etiquetar la tecla "enter" en dispositivos móviles con teclados virtuales. Los valores soportados son `go`, `done`, `next`, `search`, y `send`. Esto queda automáticamente mapeado al texto apropiado y no son sensibles al uso de mayúsculas.
@@ -124,7 +124,7 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
 
     [Documentation sobre `autocapitalize` en la Referencia HTML de Safari](https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/Attributes.html#//apple_ref/doc/uid/TP40008058-autocapitalize)
 
-- {{htmlattrdef("autocomplete")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("autocomplete")}} 
 
   - : Este atributo indica si el valor del control puede ser completado automáticamente por el navegador.
     Los valores posibles son:
@@ -188,7 +188,7 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
 
     [Documentación de `autocorrect` en la Referencia HTML de Safari](https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/Attributes.html#//apple_ref/doc/uid/TP40008058-autocorrect)
 
-- {{htmlattrdef("autofocus")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("autofocus")}} 
   - : Este atributo Booleano permite especificar que un control de formulario tenga el cursor cuando la página se carga, a menos que el usuario lo reemplace, por ejemplo, escribiendo en un control diferente. Solo un elemento de formulario en un mismo documento puede tener el atributo **autofocus**, el cual es Booleano. No puede ser aplicado si el atributo **type** tiene valor `hidden` (es decir, no se puede establecer automáticamente el cursor en un control oculto). Nótese que el cursor se podría establecer en el control antes de disparar el evento [`DOMContentLoaded`.](/es/docs/Web/Events/DOMContentLoaded)
 - {{htmlattrdef("capture")}}
   - : Cuando el valor del atributo **type** es `file`, la presencia de este atributo Booleano indica que se le dará preferencia a la captura del medio directamente del ambiente del dispositivo, usando algún [mecanismo de captura de medios](https://www.w3.org/TR/html-media-capture/#dfn-media-capture-mechanism).
@@ -204,11 +204,11 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
 
     En Firefox, a diferencia de otros navegadores, de forma predeterminada, [se persiste el estado de selección dinámico](http://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing) en un `<input>` a través de las cargas de la página. Para controlar esta característica se usa el atributo {{htmlattrxref("autocomplete","input")}}.
 
-- {{htmlattrdef("form")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("form")}} 
   - : El elemento form al que está asociado el elemento (su _formulario propietario_). El valor del atributo debe ser el **id** de un elemento {{HTMLElement("form")}} en el mismo documento. Si el atributo no es especificado, este elemento `<input>` deberá ser descendiente de un elemento {{HTMLElement("form")}}. Este atributo permite poner elementos `<input>` en cualquier parte dentro de un documento, no solamente como descendientes de su formulario. Un input puede ser asociado sólo con un formulario.
-- {{htmlattrdef("formaction")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("formaction")}} 
   - : El URI de un programa que procesa la información enviada por el elemento input, cuando es un botón de tipo `submit` o `image`. Si se especifica, reemplaza al atributo {{htmlattrxref("action","form")}} del formulario al que pertenece el elemento.
-- {{htmlattrdef("formenctype")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("formenctype")}} 
 
   - : Si el elemento es de tipo `submit` o `image`, este atributo especifica el tipo de contenido que es usado para enviar el formulario al servidor. Los valores posibles son:
 
@@ -218,7 +218,7 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
 
     Si este atributo está especificado, reemplaza al atributo {{htmlattrxref("enctype","form")}} del formulario al que pertenece el elemento.
 
-- {{htmlattrdef("formmethod")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("formmethod")}} 
 
   - : Si el elemento input es un botón de tipo `submit` o `image`, este atributo especifica el método HTTP que el navegador usará para enviar el formulario. Los valores posibles son:
 
@@ -227,9 +227,9 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
 
     Si este atributo está especificado, reemplaza al atributo {{htmlattrxref("method","form")}} del formulario al que pertenece el elemento.
 
-- {{htmlattrdef("formnovalidate")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("formnovalidate")}} 
   - : Si el elemento input es de tipo `submit` o `image`, este atributo Booleano especifica que el formulario no será validado cuando se envíe. Si este atributo está especificado, reemplaza al atributo {{htmlattrxref("novalidate","form")}} del formulario al que pertenece el elemento.
-- {{htmlattrdef("formtarget")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("formtarget")}} 
 
   - : Si el elemento input es de tipo `submit` o `image`, este atributo es el nombre o palabra clave que indica dónde mostrar la respuesta que se recibe después de enviar el formulario. Este es el nombre, o palabra clave, de un _contexto de navegación_ (por ejemplo, pestaña, ventana o frame incrustado). Si este atributo está especificado, reemplaza al atributo {{htmlattrxref("target", "form")}} del formulario al que pertenece el elemento. Las siguientes palabras clave tienen significado especial:
 
@@ -238,11 +238,11 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
     - `_parent`: Carga la respuesta en el contexto de navegación padre del actual. Si no hay contexto padre, se comporta de la misma forma que `_self`.
     - `_top`: Carga la respuesta en el contexto de navegación principal (es decir, el contexto que es ancestro del actual y que no tenga padre). Si no hay contexto padre, se comporta de la misma forma que `_self`.
 
-- {{htmlattrdef("height")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("height")}} 
   - : Si el valor del atributo **type** es `image`, este atributo define la altura de la imagen mostrada para el botón.
 - {{htmlattrdef("incremental")}} {{non-standard_inline}}
   - : Es un atributo no estándar, soportado por WebKit (Safari) y Blink (Chrome), que solo aplica cuando el atributo **type** es `search`. Si el atributo está presente, sin importar su valor, el `<input>` dispara eventos [`search`](/es/docs/Web/Events/search) conforme el usuario edita el valor. El evento solo es disparado después de que un tiempo definido en implementación haya pasado desde la última vez que se presionó una tecla. Si el atributo está ausente, el evento [`search`](/es/docs/Web/Events/search) solo se disparará cuando el usuario explícitamente inicie una búsqueda (por ejemplo, presionando la tecla Enter dentro del control). [Documentación de `incremental en la Referencia HTML de Safari`](https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/Attributes.html#//apple_ref/doc/uid/TP40008058-incremental)
-- {{htmlattrdef("inputmode")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("inputmode")}} 
 
   - : Una pista para el navegador sobre qué teclado mostrar. Este atributo aplica cuando el valor del atributo **type** es text, password, email, o url. Los valores posibles son:
 
@@ -258,35 +258,35 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
     - `email`: Escritura de correo electrónico. Es preferible el uso de \<input type="email"> en lugar de este atributo.
     - `url`: Escritura de URL. Es preferible el uso de \<input type="url"> en lugar de este atributo.
 
-- {{htmlattrdef("list")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("list")}} 
   - : Identifica una lista de opciones predefinidas como sugerencias al usuario. El valor debe ser el **id** de un elemento {{HTMLElement("datalist")}} en el mismo documento. El navegador muestra solamente las opciones que son válidas para el elemento. Este atributo es ignorado cuando el atributo **type** tiene valor `hidden`, `checkbox`, `radio`, `file`, o algun tipo de botón.
-- {{htmlattrdef("max")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("max")}} 
   - : El valor máximo (numérico o fecha-hora) para este elemento, el cual no debe ser menor que su valor mínimo (atributo **min**).
 - {{htmlattrdef("maxlength")}}
   - : Si el valor del atributo **type** es `text`, `email`, `search`, `password`, `tel`, o `url`, este atributo especifica el número máximo de caracteres (en puntos de código Unicode) que el usuario puede introducir. Para los otros tipos de control, es ignorado. Puede exceder el valor del atributo **size**. Si no se especifica, el usuario puede introducir una cantidad ilimitada de caracteres. Especificar un número negativo resulta en el comportamiento predeterminado (es decir, el usuario puede introducir una cantidad ilimitada de caracteres). La restricción es evaluada sólo cuando el valor del atributo ha sido modificado.
-- {{htmlattrdef("min")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("min")}} 
   - : El valor mínimo (numérico o fecha-hora) para este elemento, el cual no debe ser mayor a su valor máximo (atributo **max**).
-- {{htmlattrdef("minlength")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("minlength")}} 
   - : Si el valor del atributo **type** es `text`, `email`, `search`, `password`, `tel`, o `url`, este atributo especifica la longitud mínima de caracteres (en puntos de código Unicode) que el usuario puede introducir. Para los otros tipos de control, es ignorado.
-- {{htmlattrdef("multiple")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("multiple")}} 
   - : Este atributo Booleano indica si el usuario puede introducir más de un valor. Este atributo aplica cuando el atributo **type** es `email` o `file`, y en caso contrario es ignorado.
 - {{htmlattrdef("name")}}
   - : El nombre del control, el cual es enviado con los datos del formulario.
-- {{htmlattrdef("pattern")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("pattern")}} 
   - : Una expresión regular contra la que el valor es evaluado. El patrón debe coincidir con el valor completo, no solo una parte. Se puede usar el atributo **title** para describir el patrón como ayuda al usuario. Este atributo aplica cuando el atributo **type** es `text`, `search`, `tel`, `url`, `email`, o `password`, y en caso contrario es ignorado. El lenguaje de expresión regular es el mismo que el algoritmo {{jsxref("RegExp")}} de JavaScript, con el parámetro `'u'` que permite tratar al patrón como una secuencia de código Unicode. El patrón no va rodeado por diagonales.
-- {{htmlattrdef("placeholder")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("placeholder")}} 
 
   - : Una pista para el usuario sobre lo que puede introducir en el control. El texto no debe contener saltos de línea.
 
     > **Nota:** No se debe usar el atributo `placeholder` en lugar de un elemento {{HTMLElement("label")}}, pues sus propósitos son diferentes. El elemento {{HTMLElement("label")}} describe el rol del elemento en el formulario (es decir, indica qué tipo de información se espera), y el atributo `placeholder` es una pista sobre el formato que debe tener el contenido. Hay casos en los que el atributo `placeholder` no es visible para el usuario, por lo que el formulario debe ser comprensible para el usuario aunque este atributo no esté presente.
 
-- {{htmlattrdef("readonly")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("readonly")}} 
   - : Este atributo indica que el usuario no puede modificar el valor del control. El valor del atributo es irrelevante. De ser necesario el acceso lectura-escritura al valor, _no_ se debe agregar el atributo "**readonly**". Es ignorado si el atributo **type** es `hidden`, `range`, `color`, `checkbox`, `radio`, `file`, o de tipo botón (como `button` o `submit`).
-- {{htmlattrdef("required")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("required")}} 
   - : Este atributo especifica que el usuario debe llenar el control antes de enviarlo al formulario. No puede ser usado cuando el atributo **type** es `hidden`, `image`, o de tipo botón (`submit`, `reset`, o `button`). Las pseudo-clases {{cssxref(":optional")}} y {{cssxref(":required")}} se aplicarán al campo según sea apropiado.
 - {{htmlattrdef("results")}} {{non-standard_inline}}
   - : Este es un atributo no estándar, soportado por Safari, que sólo aplica cuando el atributo **type** es `search`. Es usado para controlar el máximo número de entradas que se deben mostrar en el listado nativo del `<input>` de búsquedas pasadas. Este valor debe ser un número entero no negativo.
-- {{htmlattrdef("selectionDirection")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("selectionDirection")}} 
   - : La dirección en la que ocurre la selección. Esto es "forward" (hacia adelante) si la selección fue hecha de izquierda a derecha en una escritura LTR o izquierda a derecha en una escritura RTL, o "backward" (hacia atrás) si la selección fue hecha de forma opuesta. Puede ser "none" si la dirección de selección es desconocida.
 - {{htmlattrdef("selectionEnd")}}
   - : La separación dentro del contenido de texto del último caracter seleccionado. Si no hay selección, este valor indica la separación para el caracter que sigue a la posición actual del cursor (es decir, la posición que el siguiente caracter que se escriba ocupará).
@@ -294,22 +294,22 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
   - : La separación dentro del contenido del primer caracter seleccionado. Si no hay selección, este valor indica la separación para el caracter que sigue a la posición actual del cursor (es decir, la posición que el siguiente caracter que se escriba ocupará).
 - {{htmlattrdef("size")}}
   - : El tamaño inicial del control. Este valor es en píxeles, a menos que el atributo **type** sea `text` o `password`, en cuyo caso será el número entero de caracteres. A partir de HTML5, este atributo aplica sólo cuando el atributo **type** es `text`, `search`, `tel`, `url`, `email`, o `password`, de otro modo es ignorado. Además, el tamaño debe ser mayor a cero. Si no se especifica un tamaño, se usa un valor predeterminado de 20. HTML5 simplemente establece que "el agente usuario debe asegurarse que al menos esa cantidad de caracteres sea visible", pero los caracteres pueden tener anchuras diferentes en ciertas fuentes. En algunos navegadores, una cadena con _x_ caracteres no será completamente visible aunque su tamaño esté definido con un mínimo de _x_.
-- {{htmlattrdef("spellcheck")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("spellcheck")}} 
   - : Si se establece este atributo con valor `true`, se está indicando que se debe revisar la ortografía y gramática del elemento. El valor `default` indica que el elemento va a actuar acorde al comportamiento predeterminado del navegador, posiblemente basado en el valor del atributo `spellcheck` de su elemento padre. El valor `false` indica que el elemento no debe ser revisado.
 - {{htmlattrdef("src")}}
   - : Si el atributo **type** es `image`, este atributo especifica el URI para la ubicación de la imagen a mostrar en el botón de envío gráfico. En caso contrario, es ignorado.
-- {{htmlattrdef("step")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("step")}} 
   - : Trabaja con los atributos **min** y **max**, para limitar el incremento de valores numéricos o de fecha-hora. Puede ser el valor `any` o un número positivo de punto flotante. Si no se establece este atributo como `any`, el control acepta solamente valores múltiplos del valor del atributo, mayores al mínimo.
-- {{htmlattrdef("tabindex")}} específico para el elemento en {{HTMLVersionInline(4)}}, global en {{HTMLVersionInline("5")}}
+- {{htmlattrdef("tabindex")}} específico para el elemento en HTML$, global en HTML5
   - : La posición del elemento en el orden de navegación por la tecla Tab dentro del documento.
-- {{htmlattrdef("usemap")}} solo para {{HTMLVersionInline(4)}}
+- {{htmlattrdef("usemap")}} solo para HTML4
   - : El nombre de un elemento {{HTMLElement("map")}} usado como mapa de imagen.
 - {{htmlattrdef("value")}}
   - : El valor inicial del control. Este atributo es opcional, excepto cuando el atributo **type** es `radio` o `checkbox`.
     Nótese que cuando se recarga la página, Gecko e IE [ignorarán el valor especificado en el código fuente HTML](https://bugzilla.mozilla.org/show_bug.cgi?id=46845#c186), si el valor fue modificado antes de recargar.
 - {{htmlattrdef("webkitdirectory")}} {{non-standard_inline}}
   - : Este atributo Booleano indica si el selector usado cuando el atributo **type** es `file` debe permitir la selección de directorios solamente.
-- {{htmlattrdef("width")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("width")}} 
   - : Si el valor del atributo **type** es `image`, este atributo define la anchura de la imagen mostrada en el botón.
 - {{htmlattrdef("x-moz-errormessage")}} {{non-standard_inline}}
   - : Esta extensión de Mozilla permite especificar el mensaje de error cuando un campo no es validado exitosamente.

--- a/files/es/web/html/element/input/password/index.md
+++ b/files/es/web/html/element/input/password/index.md
@@ -57,15 +57,15 @@ Los elementos `<input>` de tipo **`"password"`** proporcionan una forma para que
 
 Además de los atributos listados abajo, este elemento puede tener cualquier [global attributes](/es/docs/HTML/Global_attributes).
 
-- {{htmlattrdef("autocomplete")}}{{HTMLVersionInline("5")}}
+- {{htmlattrdef("autocomplete")}}
   - : Establece el valor del atributo de autocompletado en el campo de una contraseña. En caso de ser cierto, automaticamente se rellena con el valor previamente almacenado.
-- {{htmlattrdef("autofocus")}}{{HTMLVersionInline("5")}}
+- {{htmlattrdef("autofocus")}}
   - : Este atributo Booleano te permite especificar que la página ponga el foco en un campo a menos que el usuario lo revoque, por ejemplo, escribir en un campo diferente. Solo un elemento en el documento puede tener el atributo Booleano **autofocus**.
 - {{htmlattrdef("disabled")}}
   - : Este atributo Booleano indica que el campo de la contraseña no está disponible. Además, deshabilita los valores que no son enviados por el campo.
 - {{htmlattrdef("defaultvalue")}}
   - : Define un valor predeterminado en el campo de la contraseña.
-- {{htmlattrdef("inputmode")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("inputmode")}} 
 
   - : Le da proporciona información al buscador sobre que teclado mostrar. Los valores posibles son:
 
@@ -83,13 +83,13 @@ Además de los atributos listados abajo, este elemento puede tener cualquier [gl
   - : Establece el valor del atributo minlength en el campo de una contraseña.
 - {{htmlattrdef("name")}}
   - : Nombre del campo, usado para datos enviados desde formulario.
-- {{htmlattrdef("pattern")}}{{HTMLVersionInline("5")}}
+- {{htmlattrdef("pattern")}}
   - : Establece el valor del atributo pattern del campo de una contraseña.
-- {{htmlattrdef("placeholder")}}{{HTMLVersionInline("5")}}
+- {{htmlattrdef("placeholder")}}
   - : Establece el valor del atributo placeholder del campo de una contraseña.
 - {{htmlattrdef("readonly")}}
   - : Este atributo Booleano indica que el usuario no puede modificar el valor del campo de una contraseña.
-- {{htmlattrdef("required")}}{{HTMLVersionInline("5")}}
+- {{htmlattrdef("required")}}
   - : Este atributo Booleano especifica que el usuario debe rellenar con un valor antes de enviar un formulario.
 - {{htmlattrdef("size")}}
   - : Establece el valor del atributo size del campo de una contraseña.

--- a/files/es/web/html/element/label/index.md
+++ b/files/es/web/html/element/label/index.md
@@ -18,7 +18,7 @@ El **Elemento HTML `<label>`** representa una etiqueta para un elemento en una i
 
 Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attributes).
 
-- {{htmlattrdef("accesskey")}} {{HTMLVersionInline("4")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("accesskey")}} 
   - : Una tecla de atajo para acceder a este elemento desde el teclado.
 - {{htmlattrdef("for")}}
 
@@ -26,7 +26,7 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
 
     > **Nota:** Un elemento label puede contener ambos; El atributo for y el elemento de control anidado, siempre y cuando el atributo for apunte al mismo elemento.
 
-- {{htmlattrdef("form")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("form")}} 
   - : El formulario con el cual el label está asociado (su formulario dueño). El valor de este atributo debe ser un ID del elemento {{HTMLElement("form")}} en el mismo documento. Si este atributo no es especificado, este elemento `<label>` deberia ser descendiente de un elemento {{HTMLElement("form")}}. Este atributo permite ubicar el elemento label en cualquier lugar dentro del documento y no solo como descendiente de su respectivo formulario.
 
 ## Ejemplos

--- a/files/es/web/html/element/object/index.md
+++ b/files/es/web/html/element/object/index.md
@@ -93,33 +93,33 @@ La fuente original de este ejemplo interactivo está almacenada en un repositori
 
 Este elemento incluye los [global attributes](/es/docs/Web/HTML/Global_attributes).
 
-- {{HTMLAttrDef("archive")}}{{HTMLVersionInline(4)}} only{{Obsolete_Inline("HTML5")}}
+- {{HTMLAttrDef("archive")}} only {{Obsolete_Inline("HTML5")}}
   - : Una lista separada por espacios de las URl's de archivos o recursos para el objeto.
 - {{HTMLAttrDef("border")}}{{Deprecated_Inline("HTML4.01")}}{{Obsolete_Inline("HTML5")}}
   - : El grosor de una línea de margen alrededor del control, en pixeles.
-- {{HTMLAttrDef("classid")}}{{HTMLVersionInline(4)}} only{{Obsolete_Inline("HTML5")}}
+- {{HTMLAttrDef("classid")}} only {{Obsolete_Inline("HTML5")}}
   - : The URI of the object's implementation. It can be used together with, or in place of, the **data** attribute.
-- {{HTMLAttrDef("codebase")}}{{HTMLVersionInline(4)}} only{{Obsolete_Inline("HTML5")}}
+- {{HTMLAttrDef("codebase")}} only {{Obsolete_Inline("HTML5")}}
   - : The base path used to resolve relative URIs specified by **classid**, **data**, or **archive**. If not specified, the default is the base URI of the current document.
-- {{HTMLAttrDef("codetype")}}{{HTMLVersionInline(4)}} only{{Obsolete_Inline("HTML5")}}
+- {{HTMLAttrDef("codetype")}} only {{Obsolete_Inline("HTML5")}}
   - : The content type of the data specified by **classid**.
 - {{HTMLAttrDef("data")}}
   - : La dirección de la fuente, escrita como una URL válida. Al menos uno de los dos atributos, **data** o **type**, deben estar definidos.
-- {{HTMLAttrDef("declare")}}{{HTMLVersionInline(4)}} only{{Obsolete_Inline("HTML5")}}
+- {{HTMLAttrDef("declare")}} only {{Obsolete_Inline("HTML5")}}
   - : The presence of this Boolean attribute makes this element a declaration only. The object must be instantiated by a subsequent `<object>` element. In HTML5, repeat the \<object> element completely each that that the resource is reused.
-- {{HTMLAttrDef("form")}}{{HTMLVersionInline(5)}}
+- {{HTMLAttrDef("form")}}
   - : El elemento form, si es que hay alguno, al que el objeto está asociado (su _form propietario_). El valor de este atributo debe ser el ID de un elemento {{HTMLElement("form")}} del mismo documento.
 - {{HTMLAttrDef("height")}}
   - : La altura del recurso mostrado, en [CSS pixels](https://drafts.csswg.org/css-values/#px). -- (Valores absolutos unicamente. [NO percentages](https://html.spec.whatwg.org/multipage/embedded-content.html#dimension-attributes))
 - {{HTMLAttrDef("name")}}
   - : El nombre de un contexto de navegación válido (HTML5), o el nombre del control (HTML4).
-- {{HTMLAttrDef("standby")}}{{HTMLVersionInline(4)}} only{{Obsolete_Inline("HTML5")}}
+- {{HTMLAttrDef("standby")}} only {{Obsolete_Inline("HTML5")}}
   - : A message that the browser can show while loading the object's implementation and data.
-- {{HTMLAttrDef("tabindex")}}{{HTMLVersionInline(4)}} only{{Obsolete_Inline("HTML5")}}
+- {{HTMLAttrDef("tabindex")}} only {{Obsolete_Inline("HTML5")}}
   - : The position of the element in the tabbing navigation order for the current document.
 - {{HTMLAttrDef("type")}}
   - : El [content type](/es/docs/Glossary/Content_type) del recurso especificado mediante **data**. Al menos uno de los dos atributos, **data** o **type**, deben estar definidos.
-- {{HTMLAttrDef("typemustmatch")}}{{HTMLVersionInline(5)}}
+- {{HTMLAttrDef("typemustmatch")}}
   - : Este valor booleano indica si el atributo **type** y el [content type](/es/docs/Glossary/Content_type) real del recurso deben coincidir para porder ser usados.
 - {{HTMLAttrDef("usemap")}}
   - : Una refercia hash-name a un elemento {{HTMLElement("map")}}; es decir un '#' seguido del valor de un {{htmlattrxref("name", "map")}} de un elemento map.

--- a/files/es/web/html/element/select/index.md
+++ b/files/es/web/html/element/select/index.md
@@ -27,17 +27,17 @@ El elemento select (`<select>`) de HTML representa un control que muestra un men
 
 Este elemento incluye [global attributes](/es/docs/Web/HTML/Global_attributes).
 
-- {{htmlattrdef("autofocus")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("autofocus")}} 
   - : Este atributo permite especificar un formulario de control que debería tener enfoque de entrada cuando se carga la página, a no ser que el usuario lo sobreescriba, por ejemplo, escribiendo un control diferente. Solo un elemento formulario puede tener el elemento de enfoque de entrada por documento, por lo cual es un atributo booleano.
 - {{htmlattrdef("disabled")}}
   - : El atributo booleano especifica que el usuario no puede interactuar con el control. Si este atributo no está especificado, el control hereda los ajustes del campo que lo contiene, por ejemplo del fielset; si no hay elemento contenido con el atributo disabled, entonces el control se considera enable (activado).
-- {{htmlattrdef("form")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("form")}} 
   - : El elemento formulario al cual el select está asociado (su propietario del formulario). Si este atributo está especificado, su valor deberá ser el ID de un formulario en el mismo documento. Esto te permite situar elementos en cualquier parte del documento, no solo de manera descendiente con respecto a su elemento formulario.
 - {{htmlattrdef("multiple")}}
   - : Este elemento booleano indica que se pueden seleccionar múltiples opciones de la lista. Si no está especificado, solo se podrá seleccionar una opción cada vez.
 - {{htmlattrdef("name")}}
   - : El nombre del elemento de control.
-- {{htmlattrdef("required")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("required")}} 
   - : Es un elemento boooleano que indica si la opcion puede quedar sin seleccionar o si es requerida.
 - {{htmlattrdef("size")}}
   - : Si el control se presenta como una lista con scroll en caja, este atributo representa el numero de filas que la list tendrá visible la primera vez. Los navegadores no están requeridos a presentar un elemento select como una lista con escroll en caja. El valor por defecto es cero.

--- a/files/es/web/html/element/td/index.md
+++ b/files/es/web/html/element/td/index.md
@@ -48,7 +48,7 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
     > - Para lograr el mismo efecto de los valores `left`, `center`, `right`, o `justify` , usa la propiedad CSS {{cssxref("text-align")}} en el.
     > - Para lograr el mismo efecto que el valor `char` , en CSS3,puedes usar el valor de la {{htmlattrxref("char", "td")}} como el valor de la propiedad {{cssxref("text-align")}} {{unimplemented_inline}}.
 
-- {{htmlattrdef("axis")}} {{obsolete_inline}} en {{HTMLVersionInline(5)}}
+- {{htmlattrdef("axis")}} {{obsolete_inline}}
 
   - : Este atributo contiene una lista de cadenas separadas por espacios . Cada cadena es el ID de un grupo de celdas a las que esta cabecera se aplica.
 
@@ -71,13 +71,13 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
     > **Nota:** Nota: No usar este atributo ya que esta obsoleto en la ultima version del estandar y solo implementado en algunas versiones de Microsoft Internet Explorer: El elemento {{HTMLElement("td")}} debe ser estilizado en CSS.
     > Para crear un efecto similar en CSS en su lugar use la propiedad {{cssxref("background-color")}}.
 
-- {{htmlattrdef("char")}} {{Deprecated_inline}} in {{HTMLVersionInline(4.01)}}, {{obsolete_inline}} in {{HTMLVersionInline(5)}}
+- {{htmlattrdef("char")}} {{Deprecated_inline}} in HTML4.01 {{obsolete_inline}} in HTML5
 
   - : Este atributo se utiliza para establecer el carácter para alinear las celdas de una columna . Los valores típicos de esto incluyen un punto (. ) al intentar alinear los números o valores monetarios . Si {{ htmlattrxref ( "align" , "td" ) }} no está ajustado a char, este atributo se ignora.
 
     > **Nota:** No usar este atributo ya que está obsoleto (y no soportado) en las últimas versiones estándares). Para lograr el mismo que el {{htmlattrxref("char", "thead")}}, en CSS3, puedes usar el character set usando el atributo {{htmlattrxref("char", "th")}} como el valor de la propiedad {{cssxref("text-align")}} {{unimplemented_inline}}.
 
-- {{htmlattrdef("charoff")}} {{Deprecated_inline}} in {{HTMLVersionInline(4.01)}}, {{obsolete_inline}} in {{HTMLVersionInline(5)}}
+- {{htmlattrdef("charoff")}} {{Deprecated_inline}} in HTML4.01 {{obsolete_inline}} in HTML5
 
   - : Este atributo se utiliza para indicar el número de caracteres para compensar los datos de la columna de los personajes de alineación especificado por el atributo de carbón .
 
@@ -87,15 +87,15 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
 
   - :  Este atributo contiene un valor entero no negativo que indica por el número de columnas se extiende la célula. Su valor por defecto es 1 ; si su valor se establece en 0 , se extiende hasta el final de la {{ HTMLElement ( "colgroup" ) }} , aunque implícitamente definido , que la célula pertenece. Los valores superiores a 1000 serán consideradas como incorrectas y se establecen en el valor predeterminado ( 1 ) .
 
-    > **Nota:** En {{HTMLVersionInline(5)}} este atributo solo acepta valores mayores que 0 this attribute only accepts values greater than zero since it [must not be used to overlap cells](http://dev.w3.org/html5/spec/single-page.html#attr-tdth-colspan). Además, Firefox is the only browser to support the 0 value as defined in the {{HTMLVersionInline(4.01)}} specification.
+    > **Nota:** En HTML5 este atributo solo acepta valores mayores que 0 this attribute only accepts values greater than zero since it [must not be used to overlap cells](http://dev.w3.org/html5/spec/single-page.html#attr-tdth-colspan). Además, Firefox is the only browser to support the 0 value as defined in the HTML4.01 specification.
 
 - {{htmlattrdef("headers")}}
   - : Este atributo contiene una lista de cadenas separadas por espacios , cada uno correspondiente al atributo ID de la {{ HTMLElement ( "th" ) }} elementos que se aplican a este elemento.
 - {{htmlattrdef("rowspan")}}
   - : Este atributo contiene un valor entero no negativo que indica a cuántas filas se extiende la célula. Su valor por defecto es 1 ; si su valor se establece en 0 , se extiende hasta el final de la sección de la tabla ( {{ HTMLElement ( "thead" ) }} , {{ HTMLElement ( "tbody" ) }} , {{ HTMLElement ( "tfoot" ) }} , incluso si define implícitamente , que la célula pertenece. los valores superiores a 65534 se recortan hasta 65534 .
-- {{htmlattrdef("scope")}} {{obsolete_inline}} in {{HTMLVersionInline(5)}}
+- {{htmlattrdef("scope")}} {{obsolete_inline}} in HTML5
   - : Empty
-- {{htmlattrdef("valign")}} {{Deprecated_inline}} in {{HTMLVersionInline(4.01)}}, {{obsolete_inline}} in {{HTMLVersionInline(5)}}
+- {{htmlattrdef("valign")}} {{Deprecated_inline}} in HTML4.01, {{obsolete_inline}} in HTML5
 
   - : Este atributo especifica la alineación vertical del texto dentro de cada fila de células de la cabecera de la tabla . Los valores posibles para este atributo son :
 
@@ -106,7 +106,7 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
 
     > **Nota:** Do not use this attribute as it is obsolete (and not supported) in the latest standard: instead set the CSS {{cssxref("vertical-align")}} property on it.
 
-- {{htmlattrdef("width")}} {{Deprecated_inline}} in {{HTMLVersionInline(4.01)}}
+- {{htmlattrdef("width")}} {{Deprecated_inline}} in HTML4.01
 
   - : Este atributo se utiliza para definir una anchura de celda recomendada. Propiedades CELLSPACING y cellpadding pueden añadir espacio adicional, y el elemento {{ HTMLElement ( "col" ) }} anchura pueden también tener algún efecto . En general, si el ancho de una columna es demasiado estrecha para mostrar una célula particular correctamente, y por lo tanto las células en el mismo, se puede ensanchar cuando se muestra .
 

--- a/files/es/web/html/element/textarea/index.md
+++ b/files/es/web/html/element/textarea/index.md
@@ -35,43 +35,43 @@ Este elemento contiene [global attributes](/es/docs/HTML/Global_attributes).
     - `characters`: Automáticamente escribe con mayúscula todos los caracteres.
     - `on`: {{deprecated_inline()}} En desuso desde la versión 5 de iOS.
     - `off`: {{deprecated_inline()}} En desuso desde la versión 5 de iOS.
-- {{htmlattrdef("autocomplete")}} {{HTMLVersionInline("5")}}
+- {{htmlattrdef("autocomplete")}} 
   - : Este atributo indica si el valor del control puede ser completado automáticamente por el navegador. Los posibles valores son:
     - `off`: El usuario debe explícitamente introducir el valor del campo para cada uso, o el documento proporciona su propio método de auto-completado; el navegador no completa automáticamente.
     - `on`: El navegador puede completar automáticamente el valor basándose en valores que el usuario haya insertado durante usos previos.
 
     Si el atributo **autocomplete** no está definidio en el elemento textarea, entonces el navegador usa el valor del atributo **autocomplete** del propietario del elemento `<textarea>` . El propietario del formulario es o bien el elemento form del cual el \<textarea> es descendiente o el elemento form cuyo id está especificado en el atributo form del elemento. Para más información, ver el atributo {{htmlattrxref("autocomplete", "form")}} en {{HTMLElement("form")}}.
-- {{ htmlattrdef("autofocus") }} {{ HTMLVersionInline("5") }}
+- {{ htmlattrdef("autofocus") }} 
   - : Este atributo booleano te permite especificar que un control de un formulario adquiera el foco cuando se carga la página, salvo que el usuario anule esto , por ejemplo tecleando en un control diferente. Sólo se puede especificar este atributo en los elementos asociados a formularios.
 - {{ htmlattrdef("cols") }}
   - : La anchura visible del control de texto, en caracteres de anchura media. Si está definido debe ser positivo. Si no, por defecto, el valor es 20 (HTML 5).
 - {{ htmlattrdef("disabled") }}
   - : Este atributo booleano indica que el usuario no puede interactuar con el control. Si el atributo no está definido se hereda su valor del elemento en el que está contenido, por ejemplo {{ HTMLElement("fieldset") }}; Si no está dentro de un elemento contenedor con el atributo disable establecido, entonces el control estará habilitado.
-- {{ htmlattrdef("form") }} {{ HTMLVersionInline("5") }}
+- {{ htmlattrdef("form") }} 
   - : El formulario al cual el elemento textarea está asociado (el propietario del formulario). El valor del atributo debe ser un ID de un elemento formulario del mismo documento. Si no se especifica este atributo, el textarea debe ser un descendiente de un elemento formulario. Permite colocar elementos textarea en cualquier lugar dentro de un documento, no sólo como descendientes de formularios.
-- {{ htmlattrdef("maxlength") }} {{ HTMLVersionInline("5") }}
+- {{ htmlattrdef("maxlength") }} 
   - : Indica el número máximo de caracteres (Unicode code points) que el usuario puede insertar. Si no está especificado entonces el usuario puede insertar un número ilimitado de caracteres.
-- {{ htmlattrdef("minlength") }} {{ HTMLVersionInline("5") }}
+- {{ htmlattrdef("minlength") }} 
   - : El mínimo número de caracteres (Unicode code points) que el usuaurio debe insertar.
 - {{ htmlattrdef("name") }}
   - : El nombre del control
-- {{ htmlattrdef("placeholder") }} {{ HTMLVersionInline("5") }}
+- {{ htmlattrdef("placeholder") }} 
   - : Se puede añadir un indicación para el usuario que defina que se debe insertar en el control. Los retornos de carro y las nuevas líneas dentro lso marcadores de posición deben ser tratado como nuevas líneas al representar dicha indicación.
 - {{ htmlattrdef("readonly") }}
   - : Este atributo booleano indica que el usuario no puede modificar el valor del control. Al contrario que el atributo `disable`, el atributo `readonly` no evita que el usuario haga click o seleccione el control. El valor del control read-only si que se envía con el formulario.
-- {{ htmlattrdef("required") }} {{ HTMLVersionInline("5") }}
+- {{ htmlattrdef("required") }} 
   - : Este atributo indica que el usuario debe rellenar el contro con un valor antes de poder enviar el formulario.
 - {{ htmlattrdef("rows") }}
   - : El número de líneas visibles en el control
-- {{ htmlattrdef("selectionDirection") }} {{ HTMLVersionInline("5") }}
+- {{ htmlattrdef("selectionDirection") }} 
   - : La dirección en la que la selección ocurre dentro del control. Es "forward" si la selección ocurre de izquierda a derecha en una localización LTR, o "backward" si la selección fue hecha en sentido contrario. Puede ser "none" si se desconoce la dirección.
 - {{ htmlattrdef("selectionEnd") }}
   - : El índice del último caracter de la selección actual.
 - {{ htmlattrdef("selectionStart") }}
   - : El índice del primer caracter de la selección actual.
-- {{ htmlattrdef("spellcheck") }} {{ HTMLVersionInline(5) }}
+- {{ htmlattrdef("spellcheck") }} 
   - : Un valor `true` en este atributo indica que el elemento necesita tener `checked` el corrector ortográfico y gramatical. El caloor `default` indica que el elemento va a comportarse de acuerdo al comportamiento por defecto, basado en el `spellcheck` del padre. El valor `false` indica que no se deben hacer esas comprobaciones.
-- {{ htmlattrdef("wrap") }} {{ HTMLVersionInline("5") }}
+- {{ htmlattrdef("wrap") }} 
   - : Indica como el control envuelve al texto. Los posibles valores son:
     - `hard`: El navegador insertar automáticamente caracteres de nueva línea (CR+LF) para que ninguna línea tenga más anchura que la del control; el atributo `cols` debe estar espeficicado.
     - `soft`: El navegador asegura que todas las nuevas líneas constan de la pareja de caracteres CR+LF , pero no insertar nuevas líneas adicionales.Soft es el valor por defecto si no se especifica nada.

--- a/files/es/web/html/element/th/index.md
+++ b/files/es/web/html/element/th/index.md
@@ -55,13 +55,13 @@ El elemento **HTML `<th>`** define una celda como encabezado de un grupo de celd
 
 Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attributes).
 
-- {{htmlattrdef("abbr")}} {{obsolete_inline}} in {{HTMLVersionInline("5")}}
+- {{htmlattrdef("abbr")}} {{obsolete_inline}} in HTML5
 
   - : Este atributo contiene una breve descripción del contenido de las celdas. Algunos agentes de usuario (e.g., a speech reader) pueden presentar esta descripción antes que el propio contenido.
 
     > **Nota:** **Nota de uso:** No uses este atributo, ya que se ha vuelto obsoleto en el último estandar. Alternativamente, puedes poner la descripción abreviada dentro de la celda y colocarla el largo contenido en el atributo de **title**.
 
-- {{htmlattrdef("align")}} {{Deprecated_inline}} in {{HTMLVersionInline("4")}}, {{obsolete_inline}} in {{HTMLVersionInline("5")}}
+- {{htmlattrdef("align")}} {{Deprecated_inline}} in HTML4, {{obsolete_inline}} in HTML5
 
   - : Este atributo enumerado especifica cómo se tratará el alineado horizontal de la celda. Los valores posibles son:
 
@@ -78,7 +78,7 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
     > - Para lograr el mismo efecto que con los valores `left`, `center`, `right` o `justify`, aplicar la propiedad CSS {{cssxref("text-align")}} al elemento.
     > - Para lograr el mismo efecto que con el valor `char`, dar a la propiedad {{cssxref("text-align")}} el mismo valor que usarías para {{htmlattrxref("char", "th")}}. {{unimplemented_inline}} in CSS3.
 
-- {{htmlattrdef("axis")}} {{obsolete_inline}} in {{HTMLVersionInline("5")}}
+- {{htmlattrdef("axis")}} {{obsolete_inline}} in HTML5
 
   - : Este atributo contiene una lista de cadenas separadas por espacios. Cada cadena es el `id` de un grupo de celdas a las que se les aplica esta cabecera.
 
@@ -102,7 +102,7 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
 
 <!---->
 
-- {{htmlattrdef("char")}} {{Deprecated_inline}} in {{HTMLVersionInline("4")}}, {{obsolete_inline}} in {{HTMLVersionInline("5")}}
+- {{htmlattrdef("char")}} {{Deprecated_inline}} in HTML4, {{obsolete_inline}} in HTML5
 
   - : El contenido de la celda se alinea con un caracter en el elemento `<th>`. Los valores típicos incluyen un punto (.) para alinear números o valores monetarios. Si no se establece {{htmlattrxref("align", "th")}} como char, el atributo es ignorado.
 
@@ -110,7 +110,7 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
 
 <!---->
 
-- {{htmlattrdef("charoff")}} {{Deprecated_inline}} in {{HTMLVersionInline("4")}}, {{obsolete_inline}} in {{HTMLVersionInline("5")}}
+- {{htmlattrdef("charoff")}} {{Deprecated_inline}} in HTML4, {{obsolete_inline}} in HTML5
 
   - : This attribute is used to shift column data to the right of the character specified by the **char** attribute. Its value specifies the length of this shift.
 
@@ -134,7 +134,7 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
     - `colgroup`: The header belongs to a colgroup and relates to all of its cells.
     - `auto`
 
-- {{htmlattrdef("valign")}} {{Deprecated_inline}} in {{HTMLVersionInline("4")}}, {{obsolete_inline}} in {{HTMLVersionInline("5")}}
+- {{htmlattrdef("valign")}} {{Deprecated_inline}} in HTML4, {{obsolete_inline}} in HTML5
 
   - : This attribute specifies how a text is vertically aligned inside a cell. Possible values for this attribute are:
 
@@ -145,7 +145,7 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
 
     > **Nota:** **Usage Note:** Do not use this attribute as it is no longer supported by the latest standard: use the CSS {{cssxref("vertical-align")}} property instead.
 
-- {{htmlattrdef("width")}} {{Deprecated_inline}} in {{HTMLVersionInline(4.01)}}
+- {{htmlattrdef("width")}} {{Deprecated_inline}} in HTML4.01
 
   - : This attribute is used to define a recommended cell width. Additional space can be added with the [cellspacing](/es/docs/Web/API/HTMLTableElement/cellSpacing) and [cellpadding](/es/docs/Web/API/HTMLTableElement/cellPadding) properties and the width of the {{HTMLElement("col")}} element can also create extra width. But, if a column's width is too narrow to show a particular cell properly, it will be widened when displayed.
 

--- a/files/es/web/html/link_types/index.md
+++ b/files/es/web/html/link_types/index.md
@@ -82,8 +82,7 @@ En HTML, los siguientes tipos de enlaces indican la relación entre dos document
       <td><em>None.</em></td>
      </tr>
      <tr>
-      <td><code>help</code><br>
-       {{HTMLVersionInline("5")}}</td>
+      <td><code>help</code></td>
       <td>
        <ul>
         <li>If the element is {{HTMLElement("a")}} or {{HTMLElement("area")}}, it indicates that the hyperlink leads to a resource giving further help about the parent of the element, and its descendants.</li>

--- a/files/es/web/svg/element/script/index.md
+++ b/files/es/web/svg/element/script/index.md
@@ -79,7 +79,7 @@ Los scripts sin atributo `async` o `defer`, así como las secuencias de comandos
 
 Este elemento contiene los [atributos globales](/es/docs/Web/HTML/Atributos_Globales).
 
-- {{htmlattrdef("async")}} {{HTMLVersionInline(5)}}
+- {{htmlattrdef("async")}} 
 
   - : Establece este atributo booleano para indicar al navegador, si es posible, ejecutar el código asincrónicamente. Esto no afecta a los scripts escritos dentro de la etiqueta (es decir a aquellos que no tienen el atributo **src**).
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Remove deprecated HTMLVersionInline macro from es

Process: remove the macro and replace with the rendered content when apply

### Motivation

The chore of deprecated macros removal

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Relates to https://github.com/orgs/mdn/discussions/263
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
