### PR TITLE
Background fetch managerの翻訳

### DIFF
--- a/files/ja/web/api/backgroundfetchmanager/fetch/index.md
+++ b/files/ja/web/api/backgroundfetchmanager/fetch/index.md
@@ -8,7 +8,7 @@ l10n:
 
 {{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
-{{domxref("BackgroundFetchManager")}} インターフェイスの **`fetch()`** メソッドは、与えられた配列( URL や {{domxref("Request")}} オブジェクトで構成される) に対して、{{domxref("BackgroundFetchRegistration")}} オブジェクトで解決される {{jsxref("Promise")}} を返します。
+{{domxref("BackgroundFetchManager")}} インターフェイスの **`fetch()`** メソッドは、引数に与えられた配列( URL や {{domxref("Request")}} オブジェクトで構成される) に対して、{{domxref("BackgroundFetchRegistration")}} オブジェクトで解決される {{jsxref("Promise")}} を返します。
 
 ## 構文
 

--- a/files/ja/web/api/backgroundfetchmanager/fetch/index.md
+++ b/files/ja/web/api/backgroundfetchmanager/fetch/index.md
@@ -1,7 +1,6 @@
 ---
 title: BackgroundFetchManager.fetch()
 slug: Web/API/BackgroundFetchManager/fetch
-page-type: web-api-instance-method
 l10n:
   sourceCommit: 418f9cf461de0c7845665c0c677ad0667740f52a
 ---

--- a/files/ja/web/api/backgroundfetchmanager/fetch/index.md
+++ b/files/ja/web/api/backgroundfetchmanager/fetch/index.md
@@ -1,0 +1,72 @@
+---
+title: BackgroundFetchManager.fetch()
+slug: Web/API/BackgroundFetchManager/fetch
+page-type: web-api-instance-method
+l10n:
+  sourceCommit: 418f9cf461de0c7845665c0c677ad0667740f52a
+---
+
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+
+{{domxref("BackgroundFetchManager")}} インターフェイスの **`fetch()`** メソッドは、与えられた配列( URL や {{domxref("Request")}} オブジェクトで構成される) に対して、{{domxref("BackgroundFetchRegistration")}} オブジェクトで解決される {{jsxref("Promise")}} を返します。
+
+## 構文
+
+```js-nolint
+fetch(id, requests)
+fetch(id, requests, options)
+```
+
+### 引数
+
+- `id`
+  - : {{domxref("backgroundFetchRegistration")}} を取得するために他のメソッドに渡すことができる、開発者定義の識別子。
+- `requests`
+  - : {{domxref("RequestInfo")}} オブジェクトか、その配列。
+- `options` {{optional_inline}}
+  - : {{domxref("BackgroundFetchOptions")}} オブジェクト。
+
+### 返値
+
+{{domxref("BackgroundFetchRegistration")}} オブジェクトで解決される {{jsxref("Promise")}} 。
+
+### 例外
+
+- {{jsxref("TypeError")}}
+  - : 次のような場合に発生します。リクエストが与えられていない場合、リクエストのモードが 'no-cors' の場合、サービスワーカーが存在しない場合、リクエストされた `id` のリクエストが既に存在する場合、またはリクエストが失敗した場合。
+- `AbortError` {{domxref("DOMException")}}
+  - : fetch が失敗したことを示します。
+- `NotAllowedError` {{domxref("DOMException")}}
+  - : バックグラウンド fetch を作成するためのユーザー権限が与えられていないことを示します。
+
+## 例
+
+下記の例は `fetch()` を使用して {{domxref("BackgroundFetchRegistration")}} を作成する方法を示しています。 アクティブな {{domxref('ServiceWorker', 'service worker')}} で、 {{domxref('ServiceWorkerRegistration.backgroundFetch')}} プロパティを使用して `BackgroundFetchManager` オブジェクトにアクセスし、その `fetch()` メソッドを呼び出しています。
+
+```js
+navigator.serviceWorker.ready.then(async (swReg) => {
+  const bgFetch = await swReg.backgroundFetch.fetch(
+    "my-fetch",
+    ["/ep-5.mp3", "ep-5-artwork.jpg"],
+    {
+      title: "Episode 5: Interesting things.",
+      icons: [
+        {
+          sizes: "300x300",
+          src: "/ep-5-icon.png",
+          type: "image/png",
+        },
+      ],
+      downloadTotal: 60 * 1024 * 1024,
+    }
+  );
+});
+```
+
+## 仕様書
+
+{{Specifications}}
+
+## ブラウザーの互換性
+
+{{Compat}}

--- a/files/ja/web/api/backgroundfetchmanager/get/index.md
+++ b/files/ja/web/api/backgroundfetchmanager/get/index.md
@@ -1,0 +1,53 @@
+---
+title: BackgroundFetchManager.get()
+slug: Web/API/BackgroundFetchManager/get
+page-type: web-api-instance-method
+tags:
+  - API
+  - Method
+  - Reference
+  - get
+  - BackgroundFetchManager
+  - Experimental
+  - Service Workers
+  - Fetch
+browser-compat: api.BackgroundFetchManager.get
+---
+
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+
+The **`get()`** method of the {{domxref("BackgroundFetchManager")}} interface returns a {{jsxref("Promise")}} that resolves with the {{domxref("BackgroundFetchRegistration")}} associated with the provided `id` or {{jsxref("undefined")}} if the `id` is not found.
+
+## Syntax
+
+```js-nolint
+get(id)
+```
+
+### Parameters
+
+- `id`
+  - : the ID of a {{domxref("backgroundFetchRegistration")}} defined by calling {{domxref("BackgroundFetchRegistration.fetch","fetch()")}}.
+
+### Return value
+
+A {{jsxref("Promise")}} that resolves with a {{domxref("BackgroundFetchRegistration")}} or {{jsxref("undefined")}}.
+
+## Examples
+
+The following examples shows how to use `get()` to retrieve a {{domxref("BackgroundFetchRegistration")}}. With an active {{domxref('ServiceWorker', 'service worker')}}, use the {{domxref('ServiceWorkerRegistration.backgroundFetch')}} to access the `BackgroundFetchManager` object and call its `get()` method.
+
+```js
+navigator.serviceWorker.ready.then(async (swReg) => {
+  const bgFetch = await swReg.backgroundFetch.get("my-fetch");
+});
+// my code block
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/ja/web/api/backgroundfetchmanager/get/index.md
+++ b/files/ja/web/api/backgroundfetchmanager/get/index.md
@@ -8,7 +8,7 @@ l10n:
 
 {{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
-The **`get()`** method of the {{domxref("BackgroundFetchManager")}} interface returns a {{jsxref("Promise")}} that resolves with the {{domxref("BackgroundFetchRegistration")}} associated with the provided `id` or {{jsxref("undefined")}} if the `id` is not found.
+{{domxref("BackgroundFetchManager")}} インターフェイスの **`get()`** メソッドは、引数に与えられた `id` に紐づく {{domxref("BackgroundFetchRegistration")}} で解決される {{jsxref("Promise")}} を返します。 `id` が見つからない場合は {{jsxref("undefined")}} を返します。
 
 ## 構文
 
@@ -19,15 +19,15 @@ get(id)
 ### 引数
 
 - `id`
-  - : the ID of a {{domxref("backgroundFetchRegistration")}} defined by calling {{domxref("BackgroundFetchRegistration.fetch","fetch()")}}.
+  - : {{domxref("BackgroundFetchRegistration.fetch","fetch()")}} を呼び出すことで定義された {{domxref("backgroundFetchRegistration")}} の ID 。
 
 ### 返値
 
-A {{jsxref("Promise")}} that resolves with a {{domxref("BackgroundFetchRegistration")}} or {{jsxref("undefined")}}.
+{{domxref("BackgroundFetchRegistration")}} で解決される {{jsxref("Promise")}} または {{jsxref("undefined")}} 。
 
 ## 例
 
-The following examples shows how to use `get()` to retrieve a {{domxref("BackgroundFetchRegistration")}}. With an active {{domxref('ServiceWorker', 'service worker')}}, use the {{domxref('ServiceWorkerRegistration.backgroundFetch')}} to access the `BackgroundFetchManager` object and call its `get()` method.
+下記の例では、 `get()` を呼び出して {{domxref("BackgroundFetchRegistration")}} を取得する方法を紹介しています。アクティブな {{domxref('ServiceWorker', 'service worker')}} の {{domxref('ServiceWorkerRegistration.backgroundFetch')}} を参照して `BackgroundFetchManager` オブジェクトにアクセスし、その `get()` メソッドを呼び出しています。
 
 ```js
 navigator.serviceWorker.ready.then(async (swReg) => {

--- a/files/ja/web/api/backgroundfetchmanager/get/index.md
+++ b/files/ja/web/api/backgroundfetchmanager/get/index.md
@@ -10,22 +10,22 @@ l10n:
 
 The **`get()`** method of the {{domxref("BackgroundFetchManager")}} interface returns a {{jsxref("Promise")}} that resolves with the {{domxref("BackgroundFetchRegistration")}} associated with the provided `id` or {{jsxref("undefined")}} if the `id` is not found.
 
-## Syntax
+## 構文
 
 ```js-nolint
 get(id)
 ```
 
-### Parameters
+### 引数
 
 - `id`
   - : the ID of a {{domxref("backgroundFetchRegistration")}} defined by calling {{domxref("BackgroundFetchRegistration.fetch","fetch()")}}.
 
-### Return value
+### 返値
 
 A {{jsxref("Promise")}} that resolves with a {{domxref("BackgroundFetchRegistration")}} or {{jsxref("undefined")}}.
 
-## Examples
+## 例
 
 The following examples shows how to use `get()` to retrieve a {{domxref("BackgroundFetchRegistration")}}. With an active {{domxref('ServiceWorker', 'service worker')}}, use the {{domxref('ServiceWorkerRegistration.backgroundFetch')}} to access the `BackgroundFetchManager` object and call its `get()` method.
 
@@ -36,10 +36,10 @@ navigator.serviceWorker.ready.then(async (swReg) => {
 // my code block
 ```
 
-## Specifications
+## 仕様書
 
 {{Specifications}}
 
-## Browser compatibility
+## ブラウザーの互換性
 
 {{Compat}}

--- a/files/ja/web/api/backgroundfetchmanager/get/index.md
+++ b/files/ja/web/api/backgroundfetchmanager/get/index.md
@@ -2,16 +2,8 @@
 title: BackgroundFetchManager.get()
 slug: Web/API/BackgroundFetchManager/get
 page-type: web-api-instance-method
-tags:
-  - API
-  - Method
-  - Reference
-  - get
-  - BackgroundFetchManager
-  - Experimental
-  - Service Workers
-  - Fetch
-browser-compat: api.BackgroundFetchManager.get
+l10n:
+  sourceCommit: 02e1bfcad5fd0de845fb033d331c3c027afa2d6e
 ---
 
 {{APIRef("Background Fetch API")}}{{SeeCompatTable}}

--- a/files/ja/web/api/backgroundfetchmanager/get/index.md
+++ b/files/ja/web/api/backgroundfetchmanager/get/index.md
@@ -1,7 +1,6 @@
 ---
 title: BackgroundFetchManager.get()
 slug: Web/API/BackgroundFetchManager/get
-page-type: web-api-instance-method
 l10n:
   sourceCommit: 02e1bfcad5fd0de845fb033d331c3c027afa2d6e
 ---

--- a/files/ja/web/api/backgroundfetchmanager/getids/index.md
+++ b/files/ja/web/api/backgroundfetchmanager/getids/index.md
@@ -10,25 +10,25 @@ l10n:
 
 The **`getIds()`** method of the {{domxref("BackgroundFetchManager")}} interface returns the IDs of all registered background fetches.
 
-## Syntax
+## 構文
 
 ```js-nolint
 getIds()
 ```
 
-### Parameters
+### 引数
 
 None.
 
-### Return value
+### 返値
 
 A {{jsxref("Promise")}} that resolves with an {{jsxref('Array')}} of {{jsxref('String', 'strings')}}.
 
-### Exceptions
+### 例外
 
 None.
 
-## Examples
+## 例
 
 The following examples shows how to retrieve the IDs of all registered background fetches. With an active {{domxref('ServiceWorker', 'service worker')}}, use the {{domxref('ServiceWorkerRegistration.backgroundFetch')}} property to access the `BackgroundFetchManager` object and call its `get()` method.
 
@@ -38,10 +38,10 @@ navigator.serviceWorker.ready.then(async (swReg) => {
 });
 ```
 
-## Specifications
+## 仕様書
 
 {{Specifications}}
 
-## Browser compatibility
+## ブラウザーの互換性
 
 {{Compat}}

--- a/files/ja/web/api/backgroundfetchmanager/getids/index.md
+++ b/files/ja/web/api/backgroundfetchmanager/getids/index.md
@@ -2,16 +2,8 @@
 title: BackgroundFetchManager.getIds()
 slug: Web/API/BackgroundFetchManager/getIds
 page-type: web-api-instance-method
-tags:
-  - API
-  - Method
-  - Reference
-  - getIds
-  - BackgroundFetchManager
-  - Experimental
-  - Service Workers
-  - Fetch
-browser-compat: api.BackgroundFetchManager.getIds
+l10n:
+  sourceCommit: 23aea0fbb04893c64890c89a634250283e2beb71
 ---
 
 {{APIRef("Background Fetch API")}}{{SeeCompatTable}}

--- a/files/ja/web/api/backgroundfetchmanager/getids/index.md
+++ b/files/ja/web/api/backgroundfetchmanager/getids/index.md
@@ -1,0 +1,55 @@
+---
+title: BackgroundFetchManager.getIds()
+slug: Web/API/BackgroundFetchManager/getIds
+page-type: web-api-instance-method
+tags:
+  - API
+  - Method
+  - Reference
+  - getIds
+  - BackgroundFetchManager
+  - Experimental
+  - Service Workers
+  - Fetch
+browser-compat: api.BackgroundFetchManager.getIds
+---
+
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+
+The **`getIds()`** method of the {{domxref("BackgroundFetchManager")}} interface returns the IDs of all registered background fetches.
+
+## Syntax
+
+```js-nolint
+getIds()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A {{jsxref("Promise")}} that resolves with an {{jsxref('Array')}} of {{jsxref('String', 'strings')}}.
+
+### Exceptions
+
+None.
+
+## Examples
+
+The following examples shows how to retrieve the IDs of all registered background fetches. With an active {{domxref('ServiceWorker', 'service worker')}}, use the {{domxref('ServiceWorkerRegistration.backgroundFetch')}} property to access the `BackgroundFetchManager` object and call its `get()` method.
+
+```js
+navigator.serviceWorker.ready.then(async (swReg) => {
+  const ids = await swReg.backgroundFetch.getIds();
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/ja/web/api/backgroundfetchmanager/getids/index.md
+++ b/files/ja/web/api/backgroundfetchmanager/getids/index.md
@@ -1,7 +1,6 @@
 ---
 title: BackgroundFetchManager.getIds()
 slug: Web/API/BackgroundFetchManager/getIds
-page-type: web-api-instance-method
 l10n:
   sourceCommit: 23aea0fbb04893c64890c89a634250283e2beb71
 ---

--- a/files/ja/web/api/backgroundfetchmanager/getids/index.md
+++ b/files/ja/web/api/backgroundfetchmanager/getids/index.md
@@ -8,7 +8,7 @@ l10n:
 
 {{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
-The **`getIds()`** method of the {{domxref("BackgroundFetchManager")}} interface returns the IDs of all registered background fetches.
+{{domxref("BackgroundFetchManager")}} インターフェイスの **`getIds()`** メソッドは、登録済みのすべてのバックグラウンドフェッチの ID を返します。
 
 ## 構文
 
@@ -18,15 +18,15 @@ getIds()
 
 ### 引数
 
-None.
+なし。
 
 ### 返値
 
-A {{jsxref("Promise")}} that resolves with an {{jsxref('Array')}} of {{jsxref('String', 'strings')}}.
+{{jsxref('String', 'strings')}} の {{jsxref('Array')}} で解決される {{jsxref("Promise")}} を返します。
 
 ### 例外
 
-None.
+なし。
 
 ## 例
 

--- a/files/ja/web/api/backgroundfetchmanager/index.md
+++ b/files/ja/web/api/backgroundfetchmanager/index.md
@@ -1,0 +1,63 @@
+---
+title: BackgroundFetchManager
+slug: Web/API/BackgroundFetchManager
+page-type: web-api-interface
+tags:
+  - API
+  - Interface
+  - Reference
+  - BackgroundFetchManager
+  - Experimental
+  - Service Workers
+  - Fetch
+browser-compat: api.BackgroundFetchManager
+---
+
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+
+The **`BackgroundFetchManager`** interface of the {{domxref('Background Fetch API','','',' ')}} is a map where the keys are background fetch IDs and the values are {{domxref("BackgroundFetchRegistration")}} objects.
+
+## Instance properties
+
+None.
+
+## Instance methods
+
+- {{domxref('BackgroundFetchManager.fetch','fetch()' )}} {{Experimental_Inline}}
+  - : Returns a {{jsxref("Promise")}} that resolves with a {{domxref("BackgroundFetchRegistration")}} object for a supplied array of URLs and {{domxref("Request")}} objects.
+- {{domxref('BackgroundFetchManager.get','get()')}} {{Experimental_Inline}}
+  - : Returns a {{jsxref("Promise")}} that resolves with the {{domxref("BackgroundFetchRegistration")}} associated with the provided `id` or {{jsxref("undefined")}} if the `id` is not found.
+- {{domxref('BackgroundFetchManager.getIds','getIds()')}} {{Experimental_Inline}}
+  - : Returns the IDs of all registered background fetches.
+
+## Examples
+
+The example below shows how to get an instance of {{domxref("BackgroundFetchManager")}} from a {{domxref("ServiceWorkerRegistration")}} object and calls `fetch()` to download a video in the background.
+
+```js
+navigator.serviceWorker.ready.then(async (swReg) => {
+  const bgFetch = await swReg.backgroundFetch.fetch(
+    "my-fetch",
+    ["/ep-5.mp3", "ep-5-artwork.jpg"],
+    {
+      title: "Episode 5: Interesting things.",
+      icons: [
+        {
+          sizes: "300x300",
+          src: "/ep-5-icon.png",
+          type: "image/png",
+        },
+      ],
+      downloadTotal: 60 * 1024 * 1024,
+    }
+  );
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/ja/web/api/backgroundfetchmanager/index.md
+++ b/files/ja/web/api/backgroundfetchmanager/index.md
@@ -8,24 +8,24 @@ l10n:
 
 {{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
-The **`BackgroundFetchManager`** interface of the {{domxref('Background Fetch API','','',' ')}} is a map where the keys are background fetch IDs and the values are {{domxref("BackgroundFetchRegistration")}} objects.
+{{domxref('Background Fetch API','','',' ')}} の **`BackgroundFetchManager`** インターフェイスは、バックグラウンドフェッチ ID をキー、 {{domxref("BackgroundFetchRegistration")}} オブジェクトを値とするマップです。
 
 ## プロパティ
 
-None.
+なし。
 
 ## メソッド
 
 - {{domxref('BackgroundFetchManager.fetch','fetch()' )}} {{Experimental_Inline}}
-  - : Returns a {{jsxref("Promise")}} that resolves with a {{domxref("BackgroundFetchRegistration")}} object for a supplied array of URLs and {{domxref("Request")}} objects.
+  - : 引数に与えられた配列( URL や {{domxref("Request")}} オブジェクトで構成される) に対して、{{domxref("BackgroundFetchRegistration")}} オブジェクトで解決される {{jsxref("Promise")}} を返します。
 - {{domxref('BackgroundFetchManager.get','get()')}} {{Experimental_Inline}}
-  - : Returns a {{jsxref("Promise")}} that resolves with the {{domxref("BackgroundFetchRegistration")}} associated with the provided `id` or {{jsxref("undefined")}} if the `id` is not found.
+  - : 引数に与えられた `id` に紐づく {{domxref("BackgroundFetchRegistration")}} で解決される {{jsxref("Promise")}} を返します。 `id` が見つからない場合は {{jsxref("undefined")}} を返します。
 - {{domxref('BackgroundFetchManager.getIds','getIds()')}} {{Experimental_Inline}}
-  - : Returns the IDs of all registered background fetches.
+  - : 登録済みのすべてのバックグラウンドフェッチの ID を返します。
 
 ## 例
 
-The example below shows how to get an instance of {{domxref("BackgroundFetchManager")}} from a {{domxref("ServiceWorkerRegistration")}} object and calls `fetch()` to download a video in the background.
+下記の例は、 {{domxref("ServiceWorkerRegistration")}} オブジェクトから {{domxref("BackgroundFetchManager")}} のインスタンスを取得し、バックグラウンドで動画をダウンロードするために `fetch()` メソッドを呼び出しています。
 
 ```js
 navigator.serviceWorker.ready.then(async (swReg) => {

--- a/files/ja/web/api/backgroundfetchmanager/index.md
+++ b/files/ja/web/api/backgroundfetchmanager/index.md
@@ -2,15 +2,8 @@
 title: BackgroundFetchManager
 slug: Web/API/BackgroundFetchManager
 page-type: web-api-interface
-tags:
-  - API
-  - Interface
-  - Reference
-  - BackgroundFetchManager
-  - Experimental
-  - Service Workers
-  - Fetch
-browser-compat: api.BackgroundFetchManager
+l10n:
+  sourceCommit: 164d2b6e6c9ce32fcb8ad19436fe44766cb5c3eb
 ---
 
 {{APIRef("Background Fetch API")}}{{SeeCompatTable}}

--- a/files/ja/web/api/backgroundfetchmanager/index.md
+++ b/files/ja/web/api/backgroundfetchmanager/index.md
@@ -10,11 +10,11 @@ l10n:
 
 The **`BackgroundFetchManager`** interface of the {{domxref('Background Fetch API','','',' ')}} is a map where the keys are background fetch IDs and the values are {{domxref("BackgroundFetchRegistration")}} objects.
 
-## Instance properties
+## プロパティ
 
 None.
 
-## Instance methods
+## メソッド
 
 - {{domxref('BackgroundFetchManager.fetch','fetch()' )}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} that resolves with a {{domxref("BackgroundFetchRegistration")}} object for a supplied array of URLs and {{domxref("Request")}} objects.
@@ -23,7 +23,7 @@ None.
 - {{domxref('BackgroundFetchManager.getIds','getIds()')}} {{Experimental_Inline}}
   - : Returns the IDs of all registered background fetches.
 
-## Examples
+## 例
 
 The example below shows how to get an instance of {{domxref("BackgroundFetchManager")}} from a {{domxref("ServiceWorkerRegistration")}} object and calls `fetch()` to download a video in the background.
 
@@ -47,10 +47,10 @@ navigator.serviceWorker.ready.then(async (swReg) => {
 });
 ```
 
-## Specifications
+## 仕様書
 
 {{Specifications}}
 
-## Browser compatibility
+## ブラウザーの互換性
 
 {{Compat}}

--- a/files/ja/web/api/backgroundfetchmanager/index.md
+++ b/files/ja/web/api/backgroundfetchmanager/index.md
@@ -1,7 +1,6 @@
 ---
 title: BackgroundFetchManager
 slug: Web/API/BackgroundFetchManager
-page-type: web-api-interface
 l10n:
   sourceCommit: 164d2b6e6c9ce32fcb8ad19436fe44766cb5c3eb
 ---


### PR DESCRIPTION
# 元ページ
https://developer.mozilla.org/en-US/docs/Web/API/BackgroundFetchManager
https://developer.mozilla.org/en-US/docs/Web/API/BackgroundFetchManager/fetch
https://developer.mozilla.org/en-US/docs/Web/API/BackgroundFetchManager/get
https://developer.mozilla.org/en-US/docs/Web/API/BackgroundFetchManager/getIds

# 補足
getIds()について、原文に誤記がありそうなので、該当文のみ翻訳せずに残しています。
https://github.com/mdn/content/issues/21988

# 関連issue
https://github.com/mozilla-japan/translation/issues/658


