### PR TITLE
[fr] HTMLRef -> HTMLSidebar

### DIFF
--- a/files/fr/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
+++ b/files/fr/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
@@ -197,7 +197,7 @@ Pour la macro [`PreviousNext`](https://github.com/mdn/yari/blob/main/kumascript/
 Pour chaque grand ensemble de pages, on a des macros qui aident à la navigation sous la forme d'une barre à gauche. Elles permettent généralement de remonter à la page racine de la référence/du guide/du tutoriel et placent l'article dans la catégorie correspondante au sein de cette barre.
 
 - [`CSSRef`](https://github.com/mdn/yari/blob/main/kumascript/macros/CSSRef.ejs) génère la barre latérale pour les pages de la référence CSS.
-- [`HTMLRef`](https://github.com/mdn/yari/blob/main/kumascript/macros/HTMLRef.ejs) génère la barre latérale pour les pages de la référence HTML.
+- [`HTMLSidebar`](https://github.com/mdn/yari/blob/main/kumascript/macros/HTMLSidebar.ejs) génère la barre latérale pour les pages de la référence HTML.
 - [`APIRef`](https://github.com/mdn/yari/blob/main/kumascript/macros/APIRef.ejs) génère la barre latérale pour les pages des références des API web.
 
 ## Mise en forme

--- a/files/fr/web/css/css_colors/applying_color/index.md
+++ b/files/fr/web/css/css_colors/applying_color/index.md
@@ -16,7 +16,7 @@ translation_of: Web/HTML/Applying_color
 original_slug: Web/HTML/Applying_color
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 La couleur fait partie intégrante des moyens d'expressions. Lorsqu'on écrit un site web, il est naturel d'y ajouter des couleurs dans la mise en forme. Avec [CSS](/fr/docs/Web/CSS), il existe de nombreuses façons d'ajouter de la couleur aux [éléments](/fr/docs/Web/HTML/Element) [HTML](/fr/docs/Web/HTML) afin d'obtenir le résultat souhaité. Cet article est une introduction détaillée aux différentes méthodes permettant d'appliquer des couleurs CSS en HTML.
 

--- a/files/fr/web/html/date_and_time_formats/index.md
+++ b/files/fr/web/html/date_and_time_formats/index.md
@@ -23,7 +23,7 @@ translation_of: Web/HTML/Date_and_time_formats
 original_slug: Web/HTML/Formats_date_heure_HTML
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Certains éléments HTML manipulent des valeurs temporelles pour des dates ou des heures. Les formats utilisés pour les chaînes de caractères qui définissent ces valeurs sont décrits dans cet article. Les éléments qui utilisent ces données sont notamment les éléments [`<input>`](/fr/docs/Web/HTML/Element/Input) qui permettent de choisir une date, une heure ou les deux, les éléments [`<ins>`](/fr/docs/Web/HTML/Element/ins) et [`<del>`](/fr/docs/Web/HTML/Element/del) dont l'attribut [`ins`](/fr/docs/Web/HTML/Element/ins#attr-datetime) indique la date (ou la date et l'heure) à laquelle l'ajout ou la suppression de contenu a eu lieu.
 

--- a/files/fr/web/html/element/a/index.md
+++ b/files/fr/web/html/element/a/index.md
@@ -17,7 +17,7 @@ translation_of: Web/HTML/Element/a
 browser-compat: html.elements.a
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<a>`** (pour ancre ou _anchor_ en anglais), avec [son attribut `href`](#href), crée un lien hypertexte vers des pages web, des fichiers, des adresses e-mail, des emplacements se trouvant dans la même page, ou tout ce qu'une URL peut adresser. Le contenu de chaque élément `<a>` **doit** indiquer la destination du lien. Si [l'attribut `href`](#href) est présent, appuyer sur la touche entrée en se concentrant sur l'élément `<a>` l'activera.
 

--- a/files/fr/web/html/element/abbr/index.md
+++ b/files/fr/web/html/element/abbr/index.md
@@ -19,7 +19,7 @@ translation_of: Web/HTML/Element/abbr
 browser-compat: html.elements.abbr
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<abbr>`** (**abréviation** en français) représente une abréviation ou un acronyme ; l'attribut facultatif [`title`](/fr/docs/Web/HTML/Global_attributes#attr-title) peut fournir une explication ou une description de l'abréviation. S'il est présent, `title` doit contenir cette description complète et rien d'autre.
 

--- a/files/fr/web/html/element/acronym/index.md
+++ b/files/fr/web/html/element/acronym/index.md
@@ -12,7 +12,7 @@ translation_of: Web/HTML/Element/acronym
 browser-compat: html.elements.acronym
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 > **Attention :** Cette fonctionnalité a été supprimée des standards du Web. Bien que quelques navigateurs puissent encore la supporter, elle est en cours d'éradication. Ne l'utilisez ni dans d'anciens projets, ni dans de nouveaux. Les pages et applications Web l'utilisant peuvent cesser de fonctionner à tout moment.
 

--- a/files/fr/web/html/element/address/index.md
+++ b/files/fr/web/html/element/address/index.md
@@ -19,7 +19,7 @@ translation_of: Web/HTML/Element/address
 browser-compat: html.elements.address
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<address>`** indique des informations de contact pour une personne, un groupe de personnes ou une organisation.
 

--- a/files/fr/web/html/element/applet/index.md
+++ b/files/fr/web/html/element/applet/index.md
@@ -12,7 +12,7 @@ tags:
 translation_of: Web/HTML/Element/applet
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 > **Attention :** Cette fonctionnalité a été supprimée des standards du Web. Bien que quelques navigateurs puissent encore la supporter, elle est en cours d'éradication. Ne l'utilisez ni dans d'anciens projets, ni dans de nouveaux. Les pages et applications Web l'utilisant peuvent cesser de fonctionner à tout moment.
 

--- a/files/fr/web/html/element/area/index.md
+++ b/files/fr/web/html/element/area/index.md
@@ -14,7 +14,7 @@ translation_of: Web/HTML/Element/area
 browser-compat: html.elements.area
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<area>`** définit une zone particulière d'une image et peut lui associer un [lien hypertexte](/fr/docs/Glossary/Hyperlink). Cet élément n'est utilisé qu'au sein d'un élément [`<map>`](/fr/docs/Web/HTML/Element/map).
 

--- a/files/fr/web/html/element/article/index.md
+++ b/files/fr/web/html/element/article/index.md
@@ -11,7 +11,7 @@ translation_of: Web/HTML/Element/article
 browser-compat: html.elements.article
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément **`<article>`** représente une composition autonome dans un document, une page, une application ou un site, destinée à être distribuée ou réutilisée de manière indépendante (par exemple, dans le cadre d'une syndication). Exemples : un message de forum, un article de magazine ou de journal, ou un article de blog, une fiche produit, un commentaire soumis par un utilisateur, un widget ou gadget interactif, ou tout autre élément de contenu indépendant.
 

--- a/files/fr/web/html/element/aside/index.md
+++ b/files/fr/web/html/element/aside/index.md
@@ -15,7 +15,7 @@ translation_of: Web/HTML/Element/aside
 browser-compat: html.elements.aside
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément **`<aside>`** (en français, « aparté ») représente une partie d'un document dont le contenu n'a qu'un rapport indirect avec le contenu principal du document. Les apartés sont fréquemment présents sous la forme d'encadrés ou de boîtes de légende.
 

--- a/files/fr/web/html/element/audio/index.md
+++ b/files/fr/web/html/element/audio/index.md
@@ -19,7 +19,7 @@ translation_of: Web/HTML/Element/audio
 browser-compat: html.elements.audio
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<audio>`** est utilisé afin d'intégrer un contenu sonore dans un document. Il peut contenir une ou plusieurs sources audio représentées avec l'attribut `src` ou l'élément [`<source>`](/fr/docs/Web/HTML/Element/Source) : le navigateur choisira celle qui convient le mieux. Il peut également être la destination de médias diffusés en continu, en utilisant un [`MediaStream`](/fr/docs/Web/API/MediaStream).
 

--- a/files/fr/web/html/element/b/index.md
+++ b/files/fr/web/html/element/b/index.md
@@ -15,7 +15,7 @@ translation_of: Web/HTML/Element/b
 browser-compat: html.elements.b
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<b>`** permet d'attirer l'attention du lecteur sur un contenu qui n'a pas, pour autant, d'importance significative. Anciennement utilisé pour mettre le texte en gras. Cet élément ne doit pas être utilisé pour mettre en forme des éléments, c'est la propriété CSS [`font-weight`](/fr/docs/Web/CSS/font-weight) qu'il faut utiliser. Si l'élément est d'une importance particulière, on utilisera l'élément HTML [`<strong>`](/fr/docs/Web/HTML/Element/strong).
 

--- a/files/fr/web/html/element/base/index.md
+++ b/files/fr/web/html/element/base/index.md
@@ -11,7 +11,7 @@ translation_of: Web/HTML/Element/base
 browser-compat: html.elements.base
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément **`<base>`** définit l'URL de base à utiliser pour recomposer toutes les URL relatives contenues dans un document. Il ne peut y avoir qu'un seul élément `<base>` au sein d'un document.
 

--- a/files/fr/web/html/element/bdi/index.md
+++ b/files/fr/web/html/element/bdi/index.md
@@ -25,7 +25,7 @@ translation_of: Web/HTML/Element/bdi
 browser-compat: html.elements.bdi
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément **`<bdi>`** (ou élément d'isolation de texte bidirectionnel) isole une portée (_span_) de texte pouvant être formatée dans une direction différente de celle du texte qui l'entoure. Cela permet, par exemple, de présenter correctement une citation en arabe (écrit de droite à gauche) au sein d'un texte écrit en français (écrit de gauche à droite).
 

--- a/files/fr/web/html/element/bdo/index.md
+++ b/files/fr/web/html/element/bdo/index.md
@@ -23,7 +23,7 @@ translation_of: Web/HTML/Element/bdo
 browser-compat: html.elements.bdo
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<bdo>`** (pour élément de remplacement du texte bidirectionnel) est utilisé afin d'outrepasser la direction du texte. Cela permet d'imposer une direction donnée à un texte. L'orientation du texte est inversée mais pas celle des caractères.
 

--- a/files/fr/web/html/element/bgsound/index.md
+++ b/files/fr/web/html/element/bgsound/index.md
@@ -15,7 +15,7 @@ translation_of: Web/HTML/Element/bgsound
 browser-compat: html.elements.bgsound
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 > **Attention :** Cette fonctionnalité a été supprimée des standards du Web. Bien que quelques navigateurs puissent encore la supporter, elle est en cours d'éradication. Ne l'utilisez ni dans d'anciens projets, ni dans de nouveaux. Les pages et applications Web l'utilisant peuvent cesser de fonctionner à tout moment.
 

--- a/files/fr/web/html/element/big/index.md
+++ b/files/fr/web/html/element/big/index.md
@@ -11,7 +11,7 @@ translation_of: Web/HTML/Element/big
 browser-compat: html.elements.big
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 > **Attention :** Cette fonctionnalité a été supprimée des standards du Web. Bien que quelques navigateurs puissent encore la supporter, elle est en cours d'éradication. Ne l'utilisez ni dans d'anciens projets, ni dans de nouveaux. Les pages et applications Web l'utilisant peuvent cesser de fonctionner à tout moment.
 

--- a/files/fr/web/html/element/blink/index.md
+++ b/files/fr/web/html/element/blink/index.md
@@ -12,7 +12,7 @@ translation_of: Web/HTML/Element/blink
 browser-compat: html.elements.blink
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 > **Attention :** Cette fonctionnalité a été supprimée des standards du Web. Bien que quelques navigateurs puissent encore la supporter, elle est en cours d'éradication. Ne l'utilisez ni dans d'anciens projets, ni dans de nouveaux. Les pages et applications Web l'utilisant peuvent cesser de fonctionner à tout moment.
 

--- a/files/fr/web/html/element/blockquote/index.md
+++ b/files/fr/web/html/element/blockquote/index.md
@@ -16,7 +16,7 @@ translation_of: Web/HTML/Element/blockquote
 browser-compat: html.elements.blockquote
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<blockquote>`** (qui signifie _bloc de citation_) indique que le texte contenu dans l'élément est une citation longue. Le texte est généralement affiché avec une indentation (voir [les notes](#usage_notes) ci-après). Une URL indiquant la source de la citation peut être donnée grâce à l'attribut **`cite`** tandis qu'un texte représentant la source peut être donné via l'élément [`<cite>`](/fr/docs/Web/HTML/Element/cite).
 

--- a/files/fr/web/html/element/body/index.md
+++ b/files/fr/web/html/element/body/index.md
@@ -12,7 +12,7 @@ translation_of: Web/HTML/Element/body
 browser-compat: html.elements.body
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<body>`** représente le contenu principal du document HTML. Il ne peut y avoir qu'un élément `<body>` par document.
 

--- a/files/fr/web/html/element/br/index.md
+++ b/files/fr/web/html/element/br/index.md
@@ -11,7 +11,7 @@ translation_of: Web/HTML/Element/br
 browser-compat: html.elements.br
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<br>`** crée un saut de ligne (un retour chariot) dans le texte. Il s'avère utile lorsque les sauts de ligne ont une importance (par exemple lorsqu'on écrit une adresse ou un poème).
 

--- a/files/fr/web/html/element/button/index.md
+++ b/files/fr/web/html/element/button/index.md
@@ -12,7 +12,7 @@ translation_of: Web/HTML/Element/button
 browser-compat: html.elements.button
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément **`<button>`** représente un bouton cliquable, utilisé pour soumettre [des formulaires](/fr/docs/Learn/Forms) ou n'importe où dans un document pour une fonctionnalité de bouton accessible et standard. Par défaut, les boutons HTML sont présentés dans un style ressemblant à la plate-forme d'exécution de [l'agent utilisateur](/fr/docs/Glossary/User_agent), mais vous pouvez modifier l'apparence des boutons avec [CSS](/fr/docs/Web/CSS).
 

--- a/files/fr/web/html/element/canvas/index.md
+++ b/files/fr/web/html/element/canvas/index.md
@@ -13,7 +13,7 @@ translation_of: Web/HTML/Element/canvas
 browser-compat: html.elements.canvas
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 On utilise l'élément **HTML `<canvas>`** avec l'API [canvas](/fr/docs/Web/API/Canvas_API), ou l'API [WebGL](/fr/docs/Web/API/WebGL_API) pour dessiner des graphiques et des animations.
 

--- a/files/fr/web/html/element/caption/index.md
+++ b/files/fr/web/html/element/caption/index.md
@@ -16,7 +16,7 @@ translation_of: Web/HTML/Element/caption
 browser-compat: html.elements.caption
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément **`<caption>`** définit la légende (ou le titre) d'un tableau.
 

--- a/files/fr/web/html/element/center/index.md
+++ b/files/fr/web/html/element/center/index.md
@@ -15,7 +15,7 @@ translation_of: Web/HTML/Element/center
 browser-compat: html.elements.center
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 > **Attention :** Cette fonctionnalité est obsolète. Bien qu'encore supportée par des navigateurs, son utilisation est découragée pour tout nouveau projet. Évitez de l'utiliser.
 

--- a/files/fr/web/html/element/cite/index.md
+++ b/files/fr/web/html/element/cite/index.md
@@ -16,7 +16,7 @@ translation_of: Web/HTML/Element/cite
 browser-compat: html.elements.cite
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément **`<cite>`** contient le titre d'une œuvre telle qu'un livre, une chanson, un film, une sculpture… Cet élément doit inclure le titre de l'œuvre. Cette référence peut-être abrégée en accord avec les conventions d'usages pour l'ajout des métadonnées de citations.
 

--- a/files/fr/web/html/element/code/index.md
+++ b/files/fr/web/html/element/code/index.md
@@ -13,7 +13,7 @@ translation_of: Web/HTML/Element/code
 browser-compat: html.elements.code
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<code>`** représente un court fragment de code machine. Par défaut, l'agent utilisateur utilise une police à chasse fixe (_monospace_) afin d'afficher le texte contenu dans cet élément.
 

--- a/files/fr/web/html/element/col/index.md
+++ b/files/fr/web/html/element/col/index.md
@@ -12,7 +12,7 @@ translation_of: Web/HTML/Element/col
 browser-compat: html.elements.col
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<col>`** définit une colonne appartenant à un tableau et est utilisé afin de définir la sémantique commune à toutes ses cellules. On trouve généralement cet élément au sein d'un élément [`<colgroup>`](/fr/docs/Web/HTML/Element/colgroup).
 

--- a/files/fr/web/html/element/colgroup/index.md
+++ b/files/fr/web/html/element/colgroup/index.md
@@ -12,7 +12,7 @@ translation_of: Web/HTML/Element/colgroup
 browser-compat: html.elements.colgroup
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<colgroup>`** définit un groupe de colonnes au sein d'un tableau.
 

--- a/files/fr/web/html/element/content/index.md
+++ b/files/fr/web/html/element/content/index.md
@@ -17,7 +17,7 @@ translation_of: Web/HTML/Element/content
 browser-compat: html.elements.content
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 > **Attention :** Cette fonctionnalité a été supprimée des standards du Web. Bien que quelques navigateurs puissent encore la supporter, elle est en cours d'éradication. Ne l'utilisez ni dans d'anciens projets, ni dans de nouveaux. Les pages et applications Web l'utilisant peuvent cesser de fonctionner à tout moment.
 

--- a/files/fr/web/html/element/data/index.md
+++ b/files/fr/web/html/element/data/index.md
@@ -11,7 +11,7 @@ translation_of: Web/HTML/Element/data
 browser-compat: html.elements.data
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<data>`** relie un contenu à une version de ce contenu interprétable par un ordinateur. Si le contenu possède une composante temporelle, l'élément [`<time>`](/fr/docs/Web/HTML/Element/time) doit être utilisé.
 

--- a/files/fr/web/html/element/datalist/index.md
+++ b/files/fr/web/html/element/datalist/index.md
@@ -12,7 +12,7 @@ translation_of: Web/HTML/Element/datalist
 browser-compat: html.elements.datalist
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<datalist>`** contient un ensemble d'éléments [`<option>`](/fr/docs/Web/HTML/Element/Option) qui représentent les valeurs possibles pour d'autres contrôles.
 

--- a/files/fr/web/html/element/dd/index.md
+++ b/files/fr/web/html/element/dd/index.md
@@ -16,7 +16,7 @@ translation_of: Web/HTML/Element/dd
 browser-compat: html.elements.dd
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<dd>`** fournit la description, la définition ou la valeur du terme précédent ([`<dt>`](/fr/docs/Web/HTML/Element/dt)) dans une liste de description ([`<dl>`](/fr/docs/Web/HTML/Element/dl)).
 

--- a/files/fr/web/html/element/del/index.md
+++ b/files/fr/web/html/element/del/index.md
@@ -13,7 +13,7 @@ translation_of: Web/HTML/Element/del
 browser-compat: html.elements.del
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<del>`** représente une portion de texte ayant été supprimée d'un document. Cet élément est souvent (mais pas nécessairement) affiché rayé. L'élément [`<ins>`](/fr/docs/Web/HTML/Element/ins) est quant à lui utilisé pour représenter des portions de texte ajoutées.
 

--- a/files/fr/web/html/element/details/index.md
+++ b/files/fr/web/html/element/details/index.md
@@ -14,7 +14,7 @@ translation_of: Web/HTML/Element/details
 browser-compat: html.elements.details
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<details>`** est utilisé comme un outil permettant de révéler une information. Un résumé ou un intitulé peuvent être fournis grâce à un élément [`<summary>`](/fr/docs/Web/HTML/Element/summary).
 

--- a/files/fr/web/html/element/dfn/index.md
+++ b/files/fr/web/html/element/dfn/index.md
@@ -15,7 +15,7 @@ translation_of: Web/HTML/Element/dfn
 browser-compat: html.elements.dfn
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<dfn>`** (aussi nommé « définition ») est utilisé pour indiquer le terme défini dans le contexte d'une expression ou d'une phrase de définition. L'élément [`<p>`](/fr/docs/Web/HTML/Element/p), le couple [`<dt>`](/fr/docs/Web/HTML/Element/dt)/[`<dd>`](/fr/docs/Web/HTML/Element/dd) ou l'élément [`<section>`](/fr/docs/Web/HTML/Element/section) qui est le plus proche ancêtre de `<dfn>` est considéré comme la définition du terme.
 

--- a/files/fr/web/html/element/dialog/index.md
+++ b/files/fr/web/html/element/dialog/index.md
@@ -13,7 +13,7 @@ translation_of: Web/HTML/Element/dialog
 browser-compat: html.elements.dialog
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<dialog>`** représente une boite de dialogue ou un composant interactif (par exemple un inspecteur ou une fenêtre).
 

--- a/files/fr/web/html/element/dir/index.md
+++ b/files/fr/web/html/element/dir/index.md
@@ -15,7 +15,7 @@ translation_of: Web/HTML/Element/dir
 browser-compat: html.elements.dir
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 > **Attention :** Cette fonctionnalité est obsolète. Bien qu'encore supportée par des navigateurs, son utilisation est découragée pour tout nouveau projet. Évitez de l'utiliser.
 

--- a/files/fr/web/html/element/div/index.md
+++ b/files/fr/web/html/element/div/index.md
@@ -15,7 +15,7 @@ translation_of: Web/HTML/Element/div
 browser-compat: html.elements.div
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<div>`** (ou division) est le conteneur générique du contenu du flux. Il n'a aucun effet sur le contenu ou la mise en page tant qu'il n'est pas mis en forme d'une manière quelconque à l'aide de [CSS](/fr/docs/Web/CSS).
 

--- a/files/fr/web/html/element/dl/index.md
+++ b/files/fr/web/html/element/dl/index.md
@@ -15,7 +15,7 @@ translation_of: Web/HTML/Element/dl
 browser-compat: html.elements.dl
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<dl>`** représente une liste de descriptions sous la forme d'une liste de paires associant des termes (fournis par des éléments [`<dt>`](/fr/docs/Web/HTML/Element/dt)) et leurs descriptions ou définitions (fournies par des éléments [`<dd>`](/fr/docs/Web/HTML/Element/dd)). On utilisera par exemple cet élément pour implémenter un glossaire.
 

--- a/files/fr/web/html/element/dt/index.md
+++ b/files/fr/web/html/element/dt/index.md
@@ -17,7 +17,7 @@ translation_of: Web/HTML/Element/dt
 browser-compat: html.elements.dt
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<dt>`** identifie un terme dans une liste de définitions ou de descriptions. Cet élément n'apparaît qu'en tant qu'élément enfant d'un élément [`<dl>`](/fr/docs/Web/HTML/Element/dl) et est généralement suivi d'un élément [`<dd>`](/fr/docs/Web/HTML/Element/dd). Plusieurs éléments `<dt>` qui se suivent indiqueront qu'ils partagent la définition/description fournie par le prochain élément [`<dd>`](/fr/docs/Web/HTML/Element/dd).
 

--- a/files/fr/web/html/element/em/index.md
+++ b/files/fr/web/html/element/em/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/em
 browser-compat: html.elements.em
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<em>`** (pour emphase) est utilisé afin de marquer un texte sur lequel on veut insister. Les éléments `<em>` peuvent être imbriqués, chaque degré d'imbrication indiquant un degré d'insistance plus élevé.
 

--- a/files/fr/web/html/element/embed/index.md
+++ b/files/fr/web/html/element/embed/index.md
@@ -16,7 +16,7 @@ translation_of: Web/HTML/Element/embed
 browser-compat: html.elements.embed
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<embed>`** permet d'intégrer du contenu externe à cet endroit dans le document. Le contenu peut être fourni par une application externe ou une autre source telle qu'un _plugin_ du navigateur.
 

--- a/files/fr/web/html/element/fieldset/index.md
+++ b/files/fr/web/html/element/fieldset/index.md
@@ -12,7 +12,7 @@ translation_of: Web/HTML/Element/fieldset
 browser-compat: html.elements.fieldset
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<fieldset>`** est utilisé afin de regrouper plusieurs contrôles interactifs ainsi que des étiquettes ([`<label>`](/fr/docs/Web/HTML/Element/Label)) dans un formulaire HTML.
 

--- a/files/fr/web/html/element/figcaption/index.md
+++ b/files/fr/web/html/element/figcaption/index.md
@@ -10,7 +10,7 @@ translation_of: Web/HTML/Element/figcaption
 browser-compat: html.elements.figcaption
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<figcaption>`** représente une légende décrivant le reste du contenu de son élément parent [`<figure>`](/fr/docs/Web/HTML/Element/figure).
 

--- a/files/fr/web/html/element/figure/index.md
+++ b/files/fr/web/html/element/figure/index.md
@@ -13,7 +13,7 @@ translation_of: Web/HTML/Element/figure
 browser-compat: html.elements.figure
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<figure>`** représente un contenu autonome, éventuellement accompagné d'une légende facultative, qui est spécifiée à l'aide de l'élément [`<figcaption>`](/fr/docs/Web/HTML/Element/figcaption). La figure, sa légende et son contenu sont référencés comme une seule unité.
 

--- a/files/fr/web/html/element/font/index.md
+++ b/files/fr/web/html/element/font/index.md
@@ -11,7 +11,7 @@ translation_of: Web/HTML/Element/font
 browser-compat: html.elements.font
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 > **Attention :** Cette fonctionnalité a été supprimée des standards du Web. Bien que quelques navigateurs puissent encore la prendre en charge, elle est en cours d'éradication. Ne l'utilisez ni dans d'anciens projets, ni dans de nouveaux. Les pages et applications web l'utilisant peuvent cesser de fonctionner à tout moment.
 

--- a/files/fr/web/html/element/footer/index.md
+++ b/files/fr/web/html/element/footer/index.md
@@ -10,7 +10,7 @@ translation_of: Web/HTML/Element/footer
 browser-compat: html.elements.footer
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<footer>`** représente le pied de page de la [section](/fr/docs/Web/Guide/HTML/Content_categories#sectioning_content) ou de la [racine de sectionnement](/fr/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines#sectioning_root) la plus proche. Un élément `<footer>` contient habituellement des informations sur l'autrice ou l'auteur de la section, les données relatives au droit d'auteur (_copyright_) ou les liens vers d'autres documents en relation.
 

--- a/files/fr/web/html/element/form/index.md
+++ b/files/fr/web/html/element/form/index.md
@@ -14,7 +14,7 @@ translation_of: Web/HTML/Element/form
 browser-compat: html.elements.form
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<form>`** représente un formulaire, c'est-à-dire une section d'un document qui contient des contrôles interactifs permettant à un utilisateur de fournir des informations.
 

--- a/files/fr/web/html/element/frame/index.md
+++ b/files/fr/web/html/element/frame/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/frame
 browser-compat: html.elements.frame
 ---
 
-{{HTMLRef}}{{deprecated_header}}
+{{HTMLSidebar}}{{deprecated_header}}
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<frame>`** définit une zone particulière dans laquelle un autre document HTML est affiché. Une `<frame>` (un «&nbsp;cadre&nbsp;» en français) doit être utilisée dans un élément [`<frameset>`](/fr/docs/Web/HTML/Element/frameset).
 

--- a/files/fr/web/html/element/frameset/index.md
+++ b/files/fr/web/html/element/frameset/index.md
@@ -11,7 +11,7 @@ translation_of: Web/HTML/Element/frameset
 browser-compat: html.elements.frameset
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 > **Attention :** Cette fonctionnalité a été supprimée des standards du Web. Bien que quelques navigateurs puissent encore la prendre en charge, elle est en cours d'éradication. Ne l'utilisez ni dans d'anciens projets, ni dans de nouveaux. Les pages et applications web l'utilisant peuvent cesser de fonctionner à tout moment.
 

--- a/files/fr/web/html/element/head/index.md
+++ b/files/fr/web/html/element/head/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/head
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **\<head>** fournit des informations générales (métadonnées) sur le document, incluant son titre et des liens ou des définitions vers des scripts et feuilles de style.
 

--- a/files/fr/web/html/element/header/index.md
+++ b/files/fr/web/html/element/header/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/header
 browser-compat: html.elements.header
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<header>`** représente du contenu introductif, généralement un groupe de contenu introductif ou de contenu aidant à la navigation. Il peut contenir des éléments de titre, mais aussi d'autres éléments tels qu'un logo, un formulaire de recherche, le nom d'auteur, etc.
 

--- a/files/fr/web/html/element/heading_elements/index.md
+++ b/files/fr/web/html/element/heading_elements/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/Heading_Elements
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Les éléments **`<h1>`** à **`<h6>`** représentent six niveaux de titres dans un document, `<h1>` est le plus important et `<h6>` est le moins important. Un élément de titre décrit brièvement le sujet de la section qu'il introduit.
 

--- a/files/fr/web/html/element/hgroup/index.md
+++ b/files/fr/web/html/element/hgroup/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/hgroup
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<hgroup>`** représente un titre de plusieurs niveaux pour une section d'un document. Il regroupe un ensemble d'éléments [`<h1>–<h6>`](/fr/docs/Web/HTML/Element/Heading_Elements).
 

--- a/files/fr/web/html/element/hr/index.md
+++ b/files/fr/web/html/element/hr/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/hr
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<hr>`** représente un changement thématique entre des éléments de paragraphe (par exemple, un changement de décor dans un récit, un changement de sujet au sein d'une section).
 

--- a/files/fr/web/html/element/html/index.md
+++ b/files/fr/web/html/element/html/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/html
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<html>`** représente la racine d'un document HTML ou XHTML. Tout autre élément du document doit être un descendant de cet élément.
 

--- a/files/fr/web/html/element/i/index.md
+++ b/files/fr/web/html/element/i/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/i
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<i>`** représente un morceau de texte qui se différencie du texte principal. Cela peut par exemple être le cas pour des termes techniques, des phrases dans une langue étrangère ou encore l'expression des pensées d'un personnage. Le contenu de cet élément est généralement affiché en italique.
 

--- a/files/fr/web/html/element/iframe/index.md
+++ b/files/fr/web/html/element/iframe/index.md
@@ -18,7 +18,7 @@ translation_of: Web/HTML/Element/iframe
 browser-compat: html.elements.iframe
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<iframe>`** représente un [contexte de navigation](/fr/docs/Glossary/Browsing_context) imbriqué qui permet en fait d'obtenir une page HTML intégrée dans la page courante.
 

--- a/files/fr/web/html/element/image/index.md
+++ b/files/fr/web/html/element/image/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/image
 ---
 
-{{HTMLRef}}{{deprecated_header}}{{non-standard_header}}
+{{HTMLSidebar}}{{deprecated_header}}{{non-standard_header}}
 
 L'élément HTML **`<image>`** est un élément obsolète, remplacé depuis longtemps par l'élément standard {{HTMLElement("img")}}.
 

--- a/files/fr/web/html/element/img/index.md
+++ b/files/fr/web/html/element/img/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/img
 browser-compat: html.elements.img
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<img>`** permet d'intégrer une image dans un document.
 

--- a/files/fr/web/html/element/input/button/index.md
+++ b/files/fr/web/html/element/input/button/index.md
@@ -3,7 +3,7 @@ title: <input type ="button">
 slug: Web/HTML/Element/input/button
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Les éléments {{HTMLElement("input")}} de type **`button`** sont affichés comme des boutons poussoirs qui peuvent être programmés afin de contrôler des fonctionnalités de la page via un gestionnaire d'évènement (la plupart du temps pour l'évènement [`click`](/fr/docs/Web/API/Element/click_event)).
 

--- a/files/fr/web/html/element/input/checkbox/index.md
+++ b/files/fr/web/html/element/input/checkbox/index.md
@@ -3,7 +3,7 @@ title: <input type="checkbox">
 slug: Web/HTML/Element/input/checkbox
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Les éléments {{htmlelement("input")}} de type **`checkbox`** sont affichés sous la forme de boîtes à cocher qui sont cochées lorsqu'elles sont activées. Elles permettent de sélectionner une ou plusieurs valeurs dans un formulaire.
 

--- a/files/fr/web/html/element/input/color/index.md
+++ b/files/fr/web/html/element/input/color/index.md
@@ -3,7 +3,7 @@ title: <input type="color">
 slug: Web/HTML/Element/input/color
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Les éléments {{HTMLElement("input")}} de type **`"color"`** permettent de sélectionner une couleur via une interface (un sélecteur de couleur) ou en saisissant le code hexadécimal de la couleur au format `"#rrggbb"`. Ce format de valeur peut être utilisé en CSS.
 

--- a/files/fr/web/html/element/input/date/index.md
+++ b/files/fr/web/html/element/input/date/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/input/date
 browser-compat: html.elements.input.input-date
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Les éléments [`<input>`](/fr/docs/Web/HTML/Element/Input) dont l'attribut `type` vaut **`date`** permettent de créer des champs où saisir des dates, via un champ texte dont la valeur est validée ou avec un sélecteur de date.
 

--- a/files/fr/web/html/element/input/datetime-local/index.md
+++ b/files/fr/web/html/element/input/datetime-local/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/input/datetime-local
 browser-compat: html.elements.input.input-datetime-local
 ---
 
-{{HTMLRef("Input_types")}}
+{{HTMLSidebar("Input_types")}}
 
 Les éléments [`<input>`](/fr/docs/Web/HTML/Element/Input) dont l'attribut `type` vaut **`"datetime-local"`** permettent de créer des champs destinés à saisir simplement une date (définie par une année, un mois, et un jour) et une heure (définie par une heure et une minute). Il n'y a pas de secondes dans ce contrôle.
 

--- a/files/fr/web/html/element/input/datetime-local/index.md
+++ b/files/fr/web/html/element/input/datetime-local/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/input/datetime-local
 browser-compat: html.elements.input.input-datetime-local
 ---
 
-{{HTMLSidebar("Input_types")}}
+{{HTMLSidebar}}
 
 Les éléments [`<input>`](/fr/docs/Web/HTML/Element/Input) dont l'attribut `type` vaut **`"datetime-local"`** permettent de créer des champs destinés à saisir simplement une date (définie par une année, un mois, et un jour) et une heure (définie par une heure et une minute). Il n'y a pas de secondes dans ce contrôle.
 

--- a/files/fr/web/html/element/input/email/index.md
+++ b/files/fr/web/html/element/input/email/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/input/email
 browser-compat: html.elements.input.input-email
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Les éléments [`<input>`](/fr/docs/Web/HTML/Element/Input) dont l'attribut `type` vaut **`email`** permettent à une utilisatrice ou un utilisateur de saisir et d'éditer une adresse mail ou, si l'attribut [`multiple`](/fr/docs/Web/HTML/Attributes/multiple) est indiqué, une liste d'adresses mail. La valeur saisie est automatiquement validée afin de vérifier que le champ est vide ou que l'adresse (ou la liste d'adresses) est correcte. Les pseudo-classes CSS [`:valid`](/fr/docs/Web/CSS/:valid) et [`:invalid`](/fr/docs/Web/CSS/:invalid) sont appliquées automatiquement selon le cas.
 

--- a/files/fr/web/html/element/input/file/index.md
+++ b/files/fr/web/html/element/input/file/index.md
@@ -3,7 +3,7 @@ title: <input type="file">
 slug: Web/HTML/Element/input/file
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Les éléments {{HTMLElement("input")}} dont l'attribut `type` vaut **`"file"`** permettent à un utilisateur de sélectionner un ou plusieurs fichiers depuis leur appareil et de les _uploader_ vers un serveur via [un formulaire](/fr/docs/Web/Guide/HTML/Formulaires) ou grâce à du code JavaScript [via l'API _File_](/fr/docs/Using_files_from_web_applications).
 

--- a/files/fr/web/html/element/input/hidden/index.md
+++ b/files/fr/web/html/element/input/hidden/index.md
@@ -3,7 +3,7 @@ title: <input type="hidden">
 slug: Web/HTML/Element/input/hidden
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Les éléments {{HTMLElement("input")}} de type **`"hidden"`** permettent aux développeurs web d'inclure des données qui ne peuvent pas être vues ou modifiées lorsque le formulaire est envoyé. Cela permet par exemple d'envoyer l'identifiant d'une commande ou un jeton de sécurité unique. Les champs de ce type sont invisibles sur la page.
 

--- a/files/fr/web/html/element/input/image/index.md
+++ b/files/fr/web/html/element/input/image/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/input/image
 browser-compat: html.elements.input.type_image
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Les éléments [`<input>`](/fr/docs/Web/HTML/Element/input) dont l'attribut `type` vaut **`image`** sont utilisés pour créer des boutons d'envoi de formulaire graphiques. Autrement dit, il s'agit de boutons d'envoi qui affichent une image plutôt qu'un texte.
 

--- a/files/fr/web/html/element/input/index.md
+++ b/files/fr/web/html/element/input/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/input
 browser-compat: html.elements.input
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<input>`** est utilisé pour créer un contrôle interactif dans un formulaire web qui permet à l'utilisatrice ou l'utilisateur de saisir des données. Les saisies possibles et le comportement de l'élément `<input>` dépendent fortement de la valeur indiquée dans son attribut `type` et de ses autres attributs. Il existe différents contrôles pour la saisie, qui dépendent de l'appareil utilisé et de [l'agent utilisateur](/fr/docs/Glossary/User_agent).
 

--- a/files/fr/web/html/element/input/month/index.md
+++ b/files/fr/web/html/element/input/month/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/input/month
 browser-compat: html.elements.input.input-month
 ---
 
-{{HTMLRef("Input_types")}}
+{{HTMLSidebar("Input_types")}}
 
 Les éléments [`<input>`](/fr/docs/Web/HTML/Element/Input) dont l'attribut `type` vaut **`month`** permettent de créer des contrôles où l'utilisatrice ou l'utilisateur peut saisir un mois et année. La valeur associée à un tel élément suit le format `YYYY-MM`, où `YYYY` représente l'année sur quatre chiffre et `MM` le mois sur deux chiffres.
 

--- a/files/fr/web/html/element/input/month/index.md
+++ b/files/fr/web/html/element/input/month/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/input/month
 browser-compat: html.elements.input.input-month
 ---
 
-{{HTMLSidebar("Input_types")}}
+{{HTMLSidebar}}
 
 Les éléments [`<input>`](/fr/docs/Web/HTML/Element/Input) dont l'attribut `type` vaut **`month`** permettent de créer des contrôles où l'utilisatrice ou l'utilisateur peut saisir un mois et année. La valeur associée à un tel élément suit le format `YYYY-MM`, où `YYYY` représente l'année sur quatre chiffre et `MM` le mois sur deux chiffres.
 

--- a/files/fr/web/html/element/input/number/index.md
+++ b/files/fr/web/html/element/input/number/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/input/number
 browser-compat: html.elements.input.input-number
 ---
 
-{{HTMLSidebar("Input_types")}}
+{{HTMLSidebar}}
 
 Les éléments [`<input>`](/fr/docs/Web/HTML/Element/Input) dont l'attribut `type` vaut **`number`** permettent à une utilisatrice ou un utilisateur de saisir des nombres dans un formulaire. De tels contrôles incluent des mécanismes de validation natifs afin de rejeter les valeurs non-numériques.
 

--- a/files/fr/web/html/element/input/number/index.md
+++ b/files/fr/web/html/element/input/number/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/input/number
 browser-compat: html.elements.input.input-number
 ---
 
-{{HTMLRef("Input_types")}}
+{{HTMLSidebar("Input_types")}}
 
 Les éléments [`<input>`](/fr/docs/Web/HTML/Element/Input) dont l'attribut `type` vaut **`number`** permettent à une utilisatrice ou un utilisateur de saisir des nombres dans un formulaire. De tels contrôles incluent des mécanismes de validation natifs afin de rejeter les valeurs non-numériques.
 

--- a/files/fr/web/html/element/input/password/index.md
+++ b/files/fr/web/html/element/input/password/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/input/password
 browser-compat: html.elements.input.input-password
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Les éléments [`<input>`](/fr/docs/Web/HTML/Element/Input) de type **`password`** permettent à l'utilisatrice ou l'utilisateur de saisir un mot de passe sans que celui-ci ne soit lisible à l'écran.
 

--- a/files/fr/web/html/element/input/radio/index.md
+++ b/files/fr/web/html/element/input/radio/index.md
@@ -3,7 +3,7 @@ title: <input type="radio">
 slug: Web/HTML/Element/input/radio
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Les éléments `<input>` dont l'attribut `type` vaut **`radio`** sont généralement utilisés pour construire des groupes d'options parmi lesquelles on ne peut choisir qu'une valeur. Les « boutons radio » sont représentés par des cercles remplis lorsqu'ils sont sélectionnés.
 

--- a/files/fr/web/html/element/input/range/index.md
+++ b/files/fr/web/html/element/input/range/index.md
@@ -5,7 +5,7 @@ browser-compat: html.elements.input.input-range
 translation_of: Web/HTML/Element/input/range
 ---
 
-{{HTMLSidebar("Input_types")}}
+{{HTMLSidebar}}
 
 Les éléments [`<input>`](/fr/docs/Web/HTML/Element/Input) dont l'attribut `type` vaut **`range`** permettent à l'utilisatrice ou l'utilisateur d'indiquer une valeur numérique comprise entre deux bornes. La valeur précise n'est pas considérée comme importante. Ces éléments sont généralement représentés avec un curseur sur une ligne ou comme un bouton de potentiel et non pas comme un champ de saisie (à la façon de [`number`](/fr/docs/Web/HTML/Element/input/number) par exemple).
 

--- a/files/fr/web/html/element/input/range/index.md
+++ b/files/fr/web/html/element/input/range/index.md
@@ -5,7 +5,7 @@ browser-compat: html.elements.input.input-range
 translation_of: Web/HTML/Element/input/range
 ---
 
-{{HTMLRef("Input_types")}}
+{{HTMLSidebar("Input_types")}}
 
 Les éléments [`<input>`](/fr/docs/Web/HTML/Element/Input) dont l'attribut `type` vaut **`range`** permettent à l'utilisatrice ou l'utilisateur d'indiquer une valeur numérique comprise entre deux bornes. La valeur précise n'est pas considérée comme importante. Ces éléments sont généralement représentés avec un curseur sur une ligne ou comme un bouton de potentiel et non pas comme un champ de saisie (à la façon de [`number`](/fr/docs/Web/HTML/Element/input/number) par exemple).
 

--- a/files/fr/web/html/element/input/reset/index.md
+++ b/files/fr/web/html/element/input/reset/index.md
@@ -3,7 +3,7 @@ title: <input type="reset">
 slug: Web/HTML/Element/input/reset
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Les éléments {{HTMLElement("input")}} de type **`"reset"`** sont affichés sous la forme de boutons permettant de réinitialiser l'ensemble des champs du formulaire avec leurs valeurs initiales.
 

--- a/files/fr/web/html/element/input/search/index.md
+++ b/files/fr/web/html/element/input/search/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/input/search
 browser-compat: html.elements.input.input-search
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Les éléments [`<input>`](/fr/docs/Web/HTML/Element/Input) dont l'attribut `type` vaut **`search`** permettent de saisir des termes de recherche. Sur le plan fonctionnel, ils sont identiques aux champs de saisie textuels ([`<input type="text">`](/fr/docs/Web/HTML/Element/Input/text)), c'est leur mise en forme qui peut être différente selon [les agents utilisateurs](/fr/docs/Glossary/User_agent).
 

--- a/files/fr/web/html/element/input/submit/index.md
+++ b/files/fr/web/html/element/input/submit/index.md
@@ -3,7 +3,7 @@ title: <input type="submit">
 slug: Web/HTML/Element/input/submit
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Les éléments {{HTMLElement("input")}} dont l'attribut `type` vaut **`"submit"`** sont affichés comme des boutons permettant d'envoyer les données d'un formulaire. Cliquer sur un tel bouton déclenchera l'envoi des données du formulaire vers le serveur.
 

--- a/files/fr/web/html/element/input/tel/index.md
+++ b/files/fr/web/html/element/input/tel/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/input/tel
 browser-compat: html.elements.input.input-tel
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Les éléments [`<input>`](/fr/docs/Web/HTML/Element/Input) dont l'attribut `type` vaut **`tel`** permettent de saisir un numéro de téléphone. Contrairement aux contrôles utilisés pour [`<input type="email">`](/fr/docs/Web/HTML/Element/input/email) et [`<input type="url">`](/fr/docs/Web/HTML/Element/input/url), la valeur saisie n'est pas automatiquement validée selon un format donné, car les formats des numéros de téléphone varient à travers le monde.
 

--- a/files/fr/web/html/element/input/text/index.md
+++ b/files/fr/web/html/element/input/text/index.md
@@ -3,7 +3,7 @@ title: <input type="text">
 slug: Web/HTML/Element/input/text
 ---
 
-{{HTMLSidebar("Input_types")}}
+{{HTMLSidebar}}
 
 Les éléments [`<input>`](/fr/docs/Web/HTML/Element/Input) dont l'attribut `type` vaut **`text`** permettent de créer des champs de saisie pour du texte sur une seule ligne.
 

--- a/files/fr/web/html/element/input/text/index.md
+++ b/files/fr/web/html/element/input/text/index.md
@@ -3,7 +3,7 @@ title: <input type="text">
 slug: Web/HTML/Element/input/text
 ---
 
-{{HTMLRef("Input_types")}}
+{{HTMLSidebar("Input_types")}}
 
 Les éléments [`<input>`](/fr/docs/Web/HTML/Element/Input) dont l'attribut `type` vaut **`text`** permettent de créer des champs de saisie pour du texte sur une seule ligne.
 

--- a/files/fr/web/html/element/input/time/index.md
+++ b/files/fr/web/html/element/input/time/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/input/time
 browser-compat: html.elements.input.input-time
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Les éléments [`<input>`](/fr/docs/Web/HTML/Element/Input) dont l'attribut `type` vaut **`time`** permettent de créer des contrôles où l'utilisatrice ou l'utilisateur peut saisir une heure (avec des minutes et éventuellement des secondes).
 

--- a/files/fr/web/html/element/input/url/index.md
+++ b/files/fr/web/html/element/input/url/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/input/url
 browser-compat: html.elements.input.input-url
 ---
 
-{{HTMLSidebar("Input_types")}}
+{{HTMLSidebar}}
 
 Les éléments [`<input>`](/fr/docs/Web/HTML/Element/Input) dont l'attribut `type` vaut **`url`** sont employées afin de permettre à une utilisatrice ou un utilisateur de saisir ou d'éditer une URL.
 

--- a/files/fr/web/html/element/input/url/index.md
+++ b/files/fr/web/html/element/input/url/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/input/url
 browser-compat: html.elements.input.input-url
 ---
 
-{{HTMLRef("Input_types")}}
+{{HTMLSidebar("Input_types")}}
 
 Les éléments [`<input>`](/fr/docs/Web/HTML/Element/Input) dont l'attribut `type` vaut **`url`** sont employées afin de permettre à une utilisatrice ou un utilisateur de saisir ou d'éditer une URL.
 

--- a/files/fr/web/html/element/input/week/index.md
+++ b/files/fr/web/html/element/input/week/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/input/week
 browser-compat: html.elements.input.input-week
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Les éléments [`<input>`](/fr/docs/Web/HTML/Element/Input) dont l'attribut `type` vaut **`week`** permettent de créer des champs de saisie où l'on peut saisir une année et le numéro de la semaine pendant cette année (allant de 1 à 52 ou 53, suivant la norme [ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601#Numéro_de_semaine)).
 

--- a/files/fr/web/html/element/ins/index.md
+++ b/files/fr/web/html/element/ins/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/ins
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<ins>`** représente un fragment de texte qui a été ajouté dans un document.
 

--- a/files/fr/web/html/element/kbd/index.md
+++ b/files/fr/web/html/element/kbd/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/kbd
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<kbd>`** représente une plage de texte en ligne indiquant la saisie de texte par l'utilisateur à partir d'un clavier, d'une saisie vocale ou de tout autre dispositif de saisie de texte. Par convention, le {{Glossary("user agent")}} rend par défaut le contenu d'un élément `<kbd>` en utilisant sa police monospace, bien que cela ne soit pas requis par le standard HTML.
 

--- a/files/fr/web/html/element/keygen/index.md
+++ b/files/fr/web/html/element/keygen/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/keygen
 ---
 
-{{deprecated_header}}{{HTMLRef}}
+{{deprecated_header}}{{HTMLSidebar}}
 
 L'élément HTML **`<keygen>`** existe afin de faciliter la génération de clés et l'envoi d'une clé publique via un formulaire HTML. Le mécanisme utilisé est conçu pour être utilisé avec les systèmes de gestion de certificats électroniques. L'élément `keygen` est prévu pour être utilisé dans un formulaire HTML avec d'autres informations permettant de construire une requête de certificat, le résultat du processus étant un certificat signé.
 

--- a/files/fr/web/html/element/label/index.md
+++ b/files/fr/web/html/element/label/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/label
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<label>`** représente une légende pour un objet d'une interface utilisateur. Il peut être associé à un contrôle en utilisant l'attribut `for` ou en plaçant l'élément du contrôle à l'intérieur de l'élément `<label>`. Un tel contrôle est appelé _contrôle étiqueté_ par l'élément `<label>`.
 

--- a/files/fr/web/html/element/legend/index.md
+++ b/files/fr/web/html/element/legend/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/legend
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **\<legend>** représente une légende pour le contenu de son élément parent {{HTMLElement("fieldset")}}.
 

--- a/files/fr/web/html/element/li/index.md
+++ b/files/fr/web/html/element/li/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/li
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<li>`** est utilisé pour représenter un élément dans une liste. Il doit être contenu dans un élément parent : une liste ordonnée ({{HTMLElement("ol")}}), une liste non ordonnée ({{HTMLElement("ul")}}) ou un menu ({{HTMLElement("menu")}}). Dans les menus et les listes non ordonnées, les éléments de liste sont habituellement affichés en utilisant des puces. Dans les listes ordonnées, ils sont habituellement affichés avec compteur croissant à gauche, tel qu'un nombre ou une lettre.
 

--- a/files/fr/web/html/element/link/index.md
+++ b/files/fr/web/html/element/link/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/link
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<link>`** définit la relation entre le document courant et une ressource externe. Cet élément peut être utilisé pour définir un lien vers [une feuille de style](/fr/docs/Glossaire/CSS), vers les icônes utilisées en barre de titre ou comme icône d'application sur les appareils mobiles.
 

--- a/files/fr/web/html/element/main/index.md
+++ b/files/fr/web/html/element/main/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/main
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L’élément HTML **`<main>`** représente le contenu majoritaire du {{HTMLElement("body")}} du document. Le contenu principal de la zone est constitué de contenu directement en relation, ou qui étend le sujet principal du document ou de la fonctionnalité principale d'une application.
 

--- a/files/fr/web/html/element/map/index.md
+++ b/files/fr/web/html/element/map/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/map
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<map>`** est utilisé avec des éléments {{HTMLElement("area")}} afin de définir une image cliquable divisée en régions.
 

--- a/files/fr/web/html/element/mark/index.md
+++ b/files/fr/web/html/element/mark/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/mark
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<mark>`** représente un texte marqué ou surligné à cause de sa pertinence dans le contexte. Il peut par exemple être utilisé afin d'indiquer les correspondances d'un mot-clé recherché au sein d'un document.
 

--- a/files/fr/web/html/element/marquee/index.md
+++ b/files/fr/web/html/element/marquee/index.md
@@ -11,7 +11,7 @@ tags:
 translation_of: Web/HTML/Element/marquee
 ---
 
-{{HTMLRef}}{{non-standard_header}}{{deprecated_header}}
+{{HTMLSidebar}}{{non-standard_header}}{{deprecated_header}}
 
 L'élément HTML **`<marquee>`** est utilisé pour insérer une zone de texte défilant.
 

--- a/files/fr/web/html/element/menu/index.md
+++ b/files/fr/web/html/element/menu/index.md
@@ -5,7 +5,7 @@ browser-compat: html.elements.menu
 translation_of: Web/HTML/Element/menu
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<menu>`** est une alternative sémantique à [`<ul>`](/fr/docs/Web/HTML/Element/ul), mais est traité par les navigateurs, et en termes d'accessibilité comme un élément [`<ul>`](/fr/docs/Web/HTML/Element/ul). Il représente une liste d'éléments non-ordonnée (chaque élément de la liste étant représenté par un élément [`<li>`](/fr/docs/Web/HTML/Element/li)).
 

--- a/files/fr/web/html/element/menuitem/index.md
+++ b/files/fr/web/html/element/menuitem/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/menuitem
 ---
 
-{{HTMLRef}}{{Deprecated_Header("HTML5.2")}}
+{{HTMLSidebar}}{{Deprecated_Header("HTML5.2")}}
 
 L'élément HTML **`<menuitem>`** représente une commande qu'un utilisateur peut utiliser via un menu contextuel ou un menu rattaché à un bouton.
 

--- a/files/fr/web/html/element/meta/index.md
+++ b/files/fr/web/html/element/meta/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/meta
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<meta>`** représente toute information de métadonnées qui ne peut pas être représentée par un des éléments ({{HTMLElement("base")}}, {{HTMLElement("link")}}, {{HTMLElement("script")}}, {{HTMLElement("style")}} ou {{HTMLElement("title")}})
 

--- a/files/fr/web/html/element/meta/name/index.md
+++ b/files/fr/web/html/element/meta/name/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/meta/name
 browser-compat: html.elements.meta.name
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément [`<meta>`](/fr/docs/Web/HTML/Element/meta) permet de fournir des métadonnées sous forme de paires clé/valeur où l'attribut [`name`](/fr/docs/Web/HTML/Element/meta#attr-name) représente le nom et où l'attribut [`content`](/fr/docs/Web/HTML/Element/meta#attr-content) fournit la valeur.
 

--- a/files/fr/web/html/element/meta/name/theme-color/index.md
+++ b/files/fr/web/html/element/meta/name/theme-color/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/meta/name/theme-color
 browser-compat: html.elements.meta.name.theme-color
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 La valeur de **`theme-color`** comme attribut [`name`](/fr/docs/Web/HTML/Element/meta#attr-name) de l'élément [`<meta>`](/fr/docs/Web/HTML/Element/meta), indique une suggestion de couleur que les agents utilisateur devraient utiliser pour personnaliser l'affichage de la page ou l'interface utilisateur environnante. Si elle est utilisée, l'attribut [`content`](http://localhost:5042/fr/docs/Web/HTML/Element/meta#attr-content) devra avoir une valeur CSS de type [`<color>`](/fr/docs/Web/CSS/color_value).
 

--- a/files/fr/web/html/element/meter/index.md
+++ b/files/fr/web/html/element/meter/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/meter
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<meter>`** représente une valeur scalaire dans un intervalle donné ou une valeur fractionnaire.
 

--- a/files/fr/web/html/element/nav/index.md
+++ b/files/fr/web/html/element/nav/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/nav
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **\<nav>** représente une section d'une page ayant des liens vers d'autres pages ou des fragments de cette page. Autrement dit, c'est une section destinée à la navigation dans un document (avec des menus, des tables des matières, des index, etc.).
 

--- a/files/fr/web/html/element/nobr/index.md
+++ b/files/fr/web/html/element/nobr/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/nobr
 ---
 
-{{HTMLRef}}{{deprecated_header}}{{non-standard_header}}
+{{HTMLSidebar}}{{deprecated_header}}{{non-standard_header}}
 
 L'élément HTML **`<nobr>`** évite qu'un texte soit coupé par un retour à la ligne automatique ; il est donc affiché sur une seule ligne. Il peut être alors nécessaire d'utiliser les barres de défilement pour lire le texte en intégralité.
 

--- a/files/fr/web/html/element/noembed/index.md
+++ b/files/fr/web/html/element/noembed/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/noembed
 ---
 
-{{HTMLRef}}{{Non-standard_header}}{{deprecated_header}}
+{{HTMLSidebar}}{{Non-standard_header}}{{deprecated_header}}
 
 L'élément **`<noembed>`** est une façon obsolète et non standardisée de fournir une alternative de contenu pour les navigateurs ne supportant pas l'élément {{HTMLElement("embed")}} ou des [catégories de contenu](/fr/docs/Web/HTML/Catégorie_de_contenu) qu'un auteur aimerait utiliser.
 Cet élément a été rendu obsolète à partir de la version HTML 4.01 et a été remplacé par {{HTMLElement("object")}}. Le contenu alternatif doit être inséré entre la balise d'ouverture et celle de fermeture de {{HTMLElement("object")}}

--- a/files/fr/web/html/element/noframes/index.md
+++ b/files/fr/web/html/element/noframes/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/noframes
 ---
 
-{{HTMLRef}}{{deprecated_header}}
+{{HTMLSidebar}}{{deprecated_header}}
 
 L'élément HTML obsolète **`<noframes>`** est utilisé par les navigateurs qui ne supportent pas les éléments {{HTMLElement("frame")}}, ou qui sont configurés afin de ne pas les supporter.
 

--- a/files/fr/web/html/element/noscript/index.md
+++ b/files/fr/web/html/element/noscript/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/noscript
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<noscript>`** définit un fragment HTML qui doit être affiché si les fonctionnalités de script ne sont pas prises en charge ou si elles sont désactivées.
 

--- a/files/fr/web/html/element/object/index.md
+++ b/files/fr/web/html/element/object/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/object
 browser-compat: html.elements.object
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<object>`** représente une ressource externe qui peut être interprétée comme une image, un contexte de navigation imbriqué ou une ressource à traiter comme un _plugin_.
 

--- a/files/fr/web/html/element/ol/index.md
+++ b/files/fr/web/html/element/ol/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/ol
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<ol>`** représente une liste ordonnée. Les éléments d'une telle liste sont généralement affichés avec un indicateur ordinal pouvant prendre la forme de nombres, de lettres, de chiffres romains ou de points. La mise en forme de la numérotation n'est pas utilisée dans la description HTML mais dans la feuille de style CSS associée grâce à la propriété [`list-style-type`](/fr/docs/Web/CSS/list-style-type).
 

--- a/files/fr/web/html/element/optgroup/index.md
+++ b/files/fr/web/html/element/optgroup/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/optgroup
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<optgroup>`**, utilisé dans un formulaire, permet de créer un groupe d'options parmi lesquelles on peut choisir dans un élément {{HTMLElement("select")}}.
 

--- a/files/fr/web/html/element/option/index.md
+++ b/files/fr/web/html/element/option/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/option
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<option>`**, utilisé dans un formulaire, permet de représenter un contrôle au sein d'un élément {{HTMLElement("select")}}, {{HTMLElement("optgroup")}} ou {{HTMLElement("datalist")}}. Cet élément peut donc représenter des éléments d'un menu dans un document HTML.
 

--- a/files/fr/web/html/element/output/index.md
+++ b/files/fr/web/html/element/output/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/output
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<output>`** représente un conteneur dans lequel un site ou une application peut injecter le résultat d'un calcul ou d'une action utilisateur.
 

--- a/files/fr/web/html/element/p/index.md
+++ b/files/fr/web/html/element/p/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/p
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<p>`** représente un paragraphe de texte. Les paragraphes sont généralement représentés comme des blocs et séparés par un espace vertical, leur première ligne est également parfois indentée. Les paragraphes sont [des éléments blocs](/fr/docs/Web/HTML/Éléments_en_bloc).
 

--- a/files/fr/web/html/element/param/index.md
+++ b/files/fr/web/html/element/param/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/param
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<param>`** définit les paramètres qui peuvent être employés dans un élément {{HTMLElement("object")}}.
 

--- a/files/fr/web/html/element/picture/index.md
+++ b/files/fr/web/html/element/picture/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/picture
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<picture>`** est un conteneur utilisé afin de définir zéro ou plusieurs éléments {{HTMLElement("source")}} destinés à un élément {{HTMLElement("img")}}. Le navigateur choisira la source la plus pertinente selon la disposition de la page (les contraintes qui s'appliquent à la boîte dans laquelle l'image devra être affichée), selon l'appareil utilisé (la densité de pixels de l'affichage par exemple avec les appareils hiDPI) et selon les formats pris en charge (ex. WebP pour les navigateurs Chromium ou PNG pour les autres). Si aucune correspondance n'est trouvée parmi les éléments `<source>`, c'est le fichier défini par l'attribut {{htmlattrxref("src", "img")}} de l'élément `<img>` qui sera utilisé.
 

--- a/files/fr/web/html/element/plaintext/index.md
+++ b/files/fr/web/html/element/plaintext/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/plaintext
 ---
 
-{{HTMLRef}}{{deprecated_header}}
+{{HTMLSidebar}}{{deprecated_header}}
 
 L'élément HTML **`<plaintext>`** permet d'afficher du texte qui n'est pas interprété comme du HTML. Il ne possède pas de balise de fermeture, car tout ce qui suit n'est plus considéré comme du HTML.
 

--- a/files/fr/web/html/element/portal/index.md
+++ b/files/fr/web/html/element/portal/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/portal
 browser-compat: html.elements.portal
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<portal>`** permet d'embarquer une autre page HTML à l'intérieur de la page courante afin de permettre une navigation plus souple vers de nouvelles pages.
 

--- a/files/fr/web/html/element/pre/index.md
+++ b/files/fr/web/html/element/pre/index.md
@@ -5,7 +5,7 @@ l10n:
   sourceCommit: 6aa2d63aef51ada47960f4754b601af66a99d63c
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<pre>`** représente du texte préformaté, généralement écrit avec une [police à chasse fixe](https://fr.wikipedia.org/wiki/Police_d%27%C3%A9criture_%C3%A0_chasse_fixe). Le texte est affiché tel quel, les espaces utilisés dans le document HTML seront retranscrits.
 

--- a/files/fr/web/html/element/progress/index.md
+++ b/files/fr/web/html/element/progress/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/progress
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<progress>`** indique l'état de complétion d'une tâche et est généralement représenté par une barre de progression.
 

--- a/files/fr/web/html/element/q/index.md
+++ b/files/fr/web/html/element/q/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/q
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<q>`** indique que le texte qu'il contient est une citation en incise. La plupart des navigateurs modernes entoure le texte de cet élément avec des marques de citation. Cet élément est destiné aux citations courtes qui ne nécessitent pas de sauts de paragraphe. Pour les plus grandes citations, on utilisera l'élément {{HTMLElement("blockquote")}}.
 

--- a/files/fr/web/html/element/rb/index.md
+++ b/files/fr/web/html/element/rb/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/rb
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément de **base ruby (`<rb>`)** est utilisé afin de délimiter le composant texte de base d'une annotation {{HTMLElement("ruby")}}. Autrement dit, le texte qui est annoté. Un élément `<rb>` devrait encadrer chaque segment atomique du texte de base.
 

--- a/files/fr/web/html/element/rp/index.md
+++ b/files/fr/web/html/element/rp/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/rp
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<rp>`** est utilisé pour fournir ce qui fera office de parenthèse aux navigateurs qui ne prennent pas en charge les annotations Ruby.
 

--- a/files/fr/web/html/element/rt/index.md
+++ b/files/fr/web/html/element/rt/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/rt
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<rt>`** indique la composante texte d'une annotation Ruby, il est notamment utilisé pour la prononciation, la traduction ou la translitération des caractères d'Asie orientale. Cet élément est toujours contenu dans un élément {{HTMLElement("ruby")}}.
 

--- a/files/fr/web/html/element/rtc/index.md
+++ b/files/fr/web/html/element/rtc/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/rtc
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément **`<rtc>`** permet d'ajouter des notations Ruby sémantiques. Il est donc « proche » des éléments liées à la représentation Ruby comme {{HTMLElement("rb")}}, {{HTMLElement("ruby")}}. Les éléments {{HTMLElement("rb")}} peuvent être annotés pour la prononciation ({{HTMLElement("rt")}}) ou pour la sémantique ({{HTMLElement("rtc")}}).
 

--- a/files/fr/web/html/element/ruby/index.md
+++ b/files/fr/web/html/element/ruby/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/ruby
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<ruby>`** représente une annotation ruby. Les annotations Ruby servent à afficher la prononciation des caractères d'Asie orientale.
 

--- a/files/fr/web/html/element/s/index.md
+++ b/files/fr/web/html/element/s/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/s
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<s>`** permet d'afficher du texte qui est barré car il n'est plus pertinent ou car il est obsolète. `<s>` ne doit pas être employé pour indiquer des éditions dans un document (on utilisera alors {{HTMLElement("del")}} et {{HTMLElement("ins")}}).
 

--- a/files/fr/web/html/element/samp/index.md
+++ b/files/fr/web/html/element/samp/index.md
@@ -5,7 +5,7 @@ l10n:
   sourceCommit: 20f58e36e34d79bac99aa527865a754e9c29c81b
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<samp>`** est un élément qui permet de représenter un résultat produit par un programme informatique en incise dans du texte. Il est généralement affiché avec la police à chasse fixe du navigateur (par exemple en [Courier](https://fr.wikipedia.org/wiki/Courier_(police_d%27%C3%A9criture)) ou en Lucida Console).
 

--- a/files/fr/web/html/element/script/index.md
+++ b/files/fr/web/html/element/script/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/script
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<script>`** est utilisé pour intégrer ou faire référence à un script exécutable. Cela fait généralement référence à du code JavaScript mais ce peut également être un autre type de script (par exemple [WebGL](/fr/docs/Apprendre/WebGL)).
 

--- a/files/fr/web/html/element/section/index.md
+++ b/files/fr/web/html/element/section/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/section
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<section>`** représente une section générique d'un document, par exemple un groupe de contenu thématique. Une section commence généralement avec un titre.
 

--- a/files/fr/web/html/element/select/index.md
+++ b/files/fr/web/html/element/select/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/select
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<select>`** représente un contrôle qui fournit une liste d'options parmi lesquelles l'utilisateur pourra choisir.
 

--- a/files/fr/web/html/element/shadow/index.md
+++ b/files/fr/web/html/element/shadow/index.md
@@ -11,7 +11,7 @@ tags:
 translation_of: Web/HTML/Element/shadow
 ---
 
-{{deprecated_header}}{{HTMLRef}}
+{{deprecated_header}}{{HTMLSidebar}}
 
 L'élément HTML **`<shadow>`** était utilisé comme un point d'insertion ({{glossary("insertion point")}}) du _shadow DOM_. Cet élément a été retiré de la spécification et est [désormais obsolète](https://github.com/w3c/webcomponents/commit/041ba5518b9372768234d2766de503b98a03fa45).
 

--- a/files/fr/web/html/element/slot/index.md
+++ b/files/fr/web/html/element/slot/index.md
@@ -11,7 +11,7 @@ tags:
 translation_of: Web/HTML/Element/slot
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<slot>`** représente un emplacement d'un composant web qu'on peut remplir avec son propre balisage. On peut ainsi obtenir un document construit avec différents arbres DOM. Cet élément fait partie des outils relatifs [aux composants web (Web Components)](/fr/docs/Web/Web_Components).
 

--- a/files/fr/web/html/element/small/index.md
+++ b/files/fr/web/html/element/small/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/small
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<small>`** permet de représenter des commentaires ou des textes à écrire en petits caractères (des termes d'un contrat, des mentions relatives au droit d'auteur, etc.) quelle que soit la présentation.
 

--- a/files/fr/web/html/element/source/index.md
+++ b/files/fr/web/html/element/source/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/source
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<source>`** définit différentes ressources média pour un élément {{HTMLElement("picture")}}, {{HTMLElement("audio")}} ou {{HTMLElement("video")}}. C'est un élément vide : il ne possède pas de contenu et ne nécessite pas de balise fermante. Il est généralement utilisé pour distribuer le même contenu en utilisant [les différents formats pris en charge par les différents navigateurs](/fr/docs/Web/HTML/formats_media_support).
 

--- a/files/fr/web/html/element/spacer/index.md
+++ b/files/fr/web/html/element/spacer/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/spacer
 ---
 
-{{non-standard_header}}{{deprecated_header}}{{HTMLRef}}
+{{non-standard_header}}{{deprecated_header}}{{HTMLSidebar}}
 
 L'élément HTML **`<spacer>`** était utilisé pour insérer des blancs au sein d'une page web. Il a été créé par Netscape pour obtenir le même effet que celui qui était créé avec des images GIF d'un pixel, permettant d'ajouter des espaces blancs. Cependant, `<spacer>` n'est pas pris en charge par les principaux navigateurs principaux et il faut utiliser les règles CSS pour obtenir ces effets d'alignement. Firefox ne prend plus en charge cet élément depuis la version 4.
 

--- a/files/fr/web/html/element/span/index.md
+++ b/files/fr/web/html/element/span/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/span
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<span>`** est un conteneur générique en ligne (_inline_) pour les contenus phrasés. Il ne représente rien de particulier. Il peut être utilisé pour grouper des éléments afin de les mettre en forme (grâce aux attributs {{htmlattrxref("class")}} ou {{htmlattrxref("id")}} et aux règles [CSS](/fr/docs/Web/CSS)) ou parce qu'ils partagent certaines valeurs d'attribut comme {{htmlattrxref("lang")}}. Il doit uniquement être utilisé lorsqu'aucun autre élément sémantique n'est approprié. `<span>` est très proche de l'élément {{HTMLElement("div")}}, mais l'élément `<div>` est [un élément de bloc](/fr/docs/Web/HTML/Éléments_en_bloc), alors que `<span>` est [un élément en ligne](/fr/docs/Web/HTML/Éléments_en_ligne).
 

--- a/files/fr/web/html/element/strike/index.md
+++ b/files/fr/web/html/element/strike/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/strike
 ---
 
-{{deprecated_header}}{{HTMLRef}}
+{{deprecated_header}}{{HTMLSidebar}}
 
 L'élément HTML **`<strike>`** permet de représenter du texte barré ou avec une ligne le traversant.
 

--- a/files/fr/web/html/element/strong/index.md
+++ b/files/fr/web/html/element/strong/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/strong
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<strong>`** indique que le texte a une importance particulière ou un certain sérieux voire un caractère urgent. Cela se traduit généralement par un affichage en gras.
 

--- a/files/fr/web/html/element/style/index.md
+++ b/files/fr/web/html/element/style/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/style
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<style>`** contient des informations de mise en forme pour un document ou une partie d'un document. Par défaut, les instructions de mise en forme écrites dans cet élément sont écrites en [CSS](/fr/docs/Web/CSS).
 

--- a/files/fr/web/html/element/sub/index.md
+++ b/files/fr/web/html/element/sub/index.md
@@ -5,7 +5,7 @@ l10n:
   sourceCommit: ca8d6889ade7fc6121aaf4d59158fa6a795f1a1b
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<sub>`** est utilisé, pour des raisons typographiques, afin d'afficher du texte en indice (sous la ligne de base et généralement plus petit) par rapport au bloc de texte environnant.
 

--- a/files/fr/web/html/element/summary/index.md
+++ b/files/fr/web/html/element/summary/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/summary
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<summary>`** représente une boîte permettant de révéler le contenu d'un résumé ou d'une légende pour le contenu d'un élément {{HTMLElement("details")}}. En cliquant sur l'élément `<summary>`, on passe de l'état affiché à l'état masqué (et vice versa) de l'élément `<details>` parent.
 

--- a/files/fr/web/html/element/sup/index.md
+++ b/files/fr/web/html/element/sup/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/sup
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<sup>`** est utilisé, pour des raisons typographiques, afin d'afficher du texte en exposant (plus haut et généralement plus petit) par rapport au bloc de texte environnant.
 

--- a/files/fr/web/html/element/table/index.md
+++ b/files/fr/web/html/element/table/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/table
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<table>`** permet de représenter un tableau de données, c'est-à-dire des informations exprimées sur un tableau en deux dimensions.
 

--- a/files/fr/web/html/element/tbody/index.md
+++ b/files/fr/web/html/element/tbody/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/tbody
 browser-compat: html.elements.tbody
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<tbody>`** permet de regrouper un ou plusieurs éléments [`<tr>`](/fr/docs/Web/HTML/Element/tr) afin de former le corps d'un tableau HTML ([`<table>`](/fr/docs/Web/HTML/Element/table)).
 

--- a/files/fr/web/html/element/td/index.md
+++ b/files/fr/web/html/element/td/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/td
 browser-compat: html.elements.td
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<td>`** définit une cellule d'un tableau qui contient des données. Cet élément fait partie du _modèle de tableau_.
 

--- a/files/fr/web/html/element/template/index.md
+++ b/files/fr/web/html/element/template/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/template
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<template>`** (ou **_Template Content_** ou modèle de contenu) est un mécanisme utilisé pour stocker du contenu HTML (côté client) qui ne doit pas être affiché lors du chargement de la page mais qui peut être instancié et affiché par la suite grâce à un script JavaScript.
 

--- a/files/fr/web/html/element/textarea/index.md
+++ b/files/fr/web/html/element/textarea/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/textarea
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<textarea>`** représente un contrôle qui permet d'éditer du texte sur plusieurs lignes.
 

--- a/files/fr/web/html/element/tfoot/index.md
+++ b/files/fr/web/html/element/tfoot/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/tfoot
 browser-compat: html.elements.tfoot
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<tfoot>`** permet de définir un ensemble de lignes qui résument les colonnes d'un tableau.
 

--- a/files/fr/web/html/element/th/index.md
+++ b/files/fr/web/html/element/th/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/th
 browser-compat: html.elements.th
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<th>`** définit une cellule d'un tableau comme une cellule d'en-tête pour un groupe de cellule. La nature de ce groupe est définie grâce aux attributs [`scope`](#scope) et [`headers`](#headers).
 

--- a/files/fr/web/html/element/thead/index.md
+++ b/files/fr/web/html/element/thead/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/thead
 browser-compat: html.elements.thead
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément [HTML](/fr/docs/Web/HTML) **`<thead>`** définit un ensemble de lignes qui définit l'en-tête des colonnes d'un tableau.
 

--- a/files/fr/web/html/element/time/index.md
+++ b/files/fr/web/html/element/time/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/time
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<time>`** permet de représenter une période donnée. Cet élément permet d'utiliser l'attribut `datetime` afin de traduire la date ou l'instant dans un format informatique (permettant aux moteurs de recherche d'exploiter ces données ou de créer des rappels).
 

--- a/files/fr/web/html/element/title/index.md
+++ b/files/fr/web/html/element/title/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/title
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément **`<title>`** définit le titre du document (qui est affiché dans la barre de titre du navigateur ou dans l'onglet de la page). Cet élément ne peut contenir que du texte, les balises qu'il contiendrait seraient ignorées.
 

--- a/files/fr/web/html/element/tr/index.md
+++ b/files/fr/web/html/element/tr/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/tr
 browser-compat: html.elements.tr
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<tr>`** définit une ligne de cellules dans un tableau. Une ligne peut être constituée d'éléments [`<td>`](/fr/docs/Web/HTML/Element/td) (les données des cellules) et [`<th>`](/fr/docs/Web/HTML/Element/th) (les cellules d'en-têtes).
 

--- a/files/fr/web/html/element/track/index.md
+++ b/files/fr/web/html/element/track/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/track
 browser-compat: html.elements.track
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<track>`** est utilisé comme élément fils d'un élément [`<audio>`](/fr/docs/Web/HTML/Element/audio) ou [`<video>`](/fr/docs/Web/HTML/Element/video) et permet de fournir une piste texte pour le média (par exemple afin de gérer automatiquement les sous-titres). Les pistes texte utilisées avec cet élément sont formatées selon [le format WebVTT](/fr/docs/Web/API/WebVTT_API) (ce sont des fichiers `.vtt`) (WebVTT pour <i lang="en">Web Video Text Tracks</i>).
 

--- a/files/fr/web/html/element/tt/index.md
+++ b/files/fr/web/html/element/tt/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/tt
 ---
 
-{{deprecated_header}}{{HTMLRef}}
+{{deprecated_header}}{{HTMLSidebar}}
 
 L'élément HTML **`<tt>`** (pour _Teletype Text_) crée un élément en ligne, écrit dans la police à chasse fixe par défaut du navigateur. Cet élément a été conçu pour mettre en forme du texte comme s'il apparaissait sur un affichage à largeur fixe tel qu'un téléscripteur.
 

--- a/files/fr/web/html/element/u/index.md
+++ b/files/fr/web/html/element/u/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/u
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<u>`** permet d'afficher un fragment de texte qui est annoté avec des éléments non textuels. Par défaut, le contenu de l'élément est souligné. Cela pourra par exemple être le cas pour marquer un texte comme étant un nom propre chinois, ou pour marquer un texte qui a été mal orthographié.
 

--- a/files/fr/web/html/element/ul/index.md
+++ b/files/fr/web/html/element/ul/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/ul
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<ul>`** représente une liste d'éléments sans ordre particulier. Il est souvent représenté par une liste à puces.
 

--- a/files/fr/web/html/element/var/index.md
+++ b/files/fr/web/html/element/var/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/var
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<var>`** représente une variable dans une expression mathématique ou un texte lié à la programmation. Son contenu est généralement représenté avec une version italique de la police environnante utilisée, toutefois, ce comportement peut dépendre du navigateur utilisé.
 

--- a/files/fr/web/html/element/video/index.md
+++ b/files/fr/web/html/element/video/index.md
@@ -12,7 +12,7 @@ tags:
 translation_of: Web/HTML/Element/video
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<video>`** intègre un contenu vidéo dans un document.
 

--- a/files/fr/web/html/element/wbr/index.md
+++ b/files/fr/web/html/element/wbr/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/wbr
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 L'élément HTML **`<wbr>`** permet de représenter un emplacement où casser la ligne si nécessaire. Le navigateur pourra alors utiliser cet emplacement pour effectuer un saut de ligne si le texte est trop long et qu'en temps normal, une règle empêche le saut de ligne.
 

--- a/files/fr/web/html/element/xmp/index.md
+++ b/files/fr/web/html/element/xmp/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/xmp
 ---
 
-{{deprecated_header}}{{HTMLRef}}
+{{deprecated_header}}{{HTMLSidebar}}
 
 L'élément HTML **`<xmp>`** (pour _example_) affiche le texte entre les balises d'ouverture et de fermeture sans interpréter le HTML qu'il contient et en utilisant une police à chasse fixe. La spécification HTML 2 recommande un affichage suffisamment large pour contenir 80 caractères par ligne.
 

--- a/files/fr/web/html/quirks_mode_and_standards_mode/index.md
+++ b/files/fr/web/html/quirks_mode_and_standards_mode/index.md
@@ -11,7 +11,7 @@ tags:
 translation_of: Web/HTML/Quirks_Mode_and_Standards_Mode
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Par le passé, les pages web étaient souvent écrites sous deux versions : une destinée à Netscape Navigator et l'autre à Microsoft Internet Explorer. Lorsque les standards du Web sont apparus avec le W3C, les navigateurs ne pouvaient pas simplement commencer à les utiliser car leur mise en place rendrait inutilisable la plupart des sites web existant. Les navigateurs ont alors introduit deux modes afin de traiter les sites respectants les standards des autres sites historiques.
 


### PR DESCRIPTION
We are deprecating `HTMLRef` macro. The [mdn/content repo doesn't have it anymore](https://github.com/mdn/content/pull/21997#event-7719645576).

The PR replaces it with `HTMLSidebar` (now this macro has almost all HTML document links [[ref](https://github.com/mdn/content/pull/21956)]).