### PR TITLE
[pt-br] HTMLRef -> HTMLSidebar

### DIFF
--- a/files/pt-br/web/css/css_colors/applying_color/index.md
+++ b/files/pt-br/web/css/css_colors/applying_color/index.md
@@ -4,7 +4,7 @@ slug: Web/CSS/CSS_Colors/Applying_color
 translation_of: Web/HTML/Applying_color
 original_slug: Web/HTML/Applying_color
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 O uso de cores é uma forma fundamental da expressão humana. Crianças experimentam com cores antes mesmo de ter a destreza manual para desenhar. Talvez por isso, a cor é uma das primeiras coisas com a qual as pessoas querem experimentar quando estão aprendendo a desenvolver websites. Com [CSS](/pt-BR/docs/Web/CSS), há muitas maneiras de acrescentar cor nos seus [elementos HTML](/pt-BR/docs/Web/HTML/Element) para criar exatamente o visual que você quiser. Esse artigo é um preparativo introduzindo cada uma das formas que a cor CSS pode ser usada no HTML.
 

--- a/files/pt-br/web/html/element/a/index.md
+++ b/files/pt-br/web/html/element/a/index.md
@@ -12,7 +12,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/a
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 O **elemento** **`<a>` **em **HTML** (ou elemento âncora), com o atributo [`href`](#href) cria-se um hiperligação nas páginas web, arquivos, endereços de emails, ligações na mesma página ou endereços na URL. O conteúdo dentro de cada `<a>` **precisará** indicar o destino do link.
 

--- a/files/pt-br/web/html/element/abbr/index.md
+++ b/files/pt-br/web/html/element/abbr/index.md
@@ -78,4 +78,4 @@ Obama é presidente dos EUA
 
 - Outros elementos que possuem [semântica à nível de texto](/pt-BR/docs/HTML/Text_level_semantics_conveying_elements): {{HTMLElement("a")}}, {{HTMLElement("em")}}, {{HTMLElement("strong")}}, {{HTMLElement("small")}}, {{HTMLElement("cite")}}, {{HTMLElement("q")}}, {{HTMLElement("dfn")}}, {{HTMLElement("time")}}, {{HTMLElement("code")}}, {{HTMLElement("var")}}, {{HTMLElement("samp")}}, {{HTMLElement("kbd")}}, {{HTMLElement("sub")}}, {{HTMLElement("sup")}}, {{HTMLElement("b")}}, {{HTMLElement("i")}}, {{HTMLElement("mark")}}, {{HTMLElement("ruby")}}, {{HTMLElement("rp")}}, {{HTMLElement("rt")}}, {{HTMLElement("bdo")}}, {{HTMLElement("span")}}, {{HTMLElement("br")}}, {{HTMLElement("wbr")}}.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/acronym/index.md
+++ b/files/pt-br/web/html/element/acronym/index.md
@@ -53,4 +53,4 @@ Embo is purely for the convenira o propósito desta tag seja meramente a conveni
 
 - O elemento HTML {{HTMLElement("abbr")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/applet/index.md
+++ b/files/pt-br/web/html/element/applet/index.md
@@ -61,4 +61,4 @@ The HTML Applet Element (`<applet>`) identifies the inclusion of a Java applet.
 
 The W3C specification does not encourage the use of `<applet>` and prefers the use of the {{HTMLElement("object")}} tag. Under the strict definition of HTML 4.01, this element is deprecated and entirely obsolete in HTML5.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/area/index.md
+++ b/files/pt-br/web/html/element/area/index.md
@@ -93,4 +93,4 @@ Netscape 1 de nível não entendem o **alvo** atributo que se refere aos quadros
 
 HTML 3.2 define apenas **alt** , **coords** , **href** , **nohref** e shape .
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/aside/index.md
+++ b/files/pt-br/web/html/element/aside/index.md
@@ -54,4 +54,4 @@ Este elemento inclui apenas os [atributos globais](/pt-BR/docs/HTML/Global_attri
 - Outros elementos de seçao relacionados: {{HTMLElement("body")}}, {{HTMLElement("article")}}, {{HTMLElement("section")}}, {{HTMLElement("nav")}}, {{HTMLElement("h1")}}, {{HTMLElement("h2")}}, {{HTMLElement("h3")}}, {{HTMLElement("h4")}}, {{HTMLElement("h5")}}, {{HTMLElement("h6")}}, {{HTMLElement("hgroup")}}, {{HTMLElement("header")}}, {{HTMLElement("footer")}}, {{HTMLElement("address")}};
 - [Seçoes e outlines de um documento HTML5](/pt-BR/docs/Sections_and_Outlines_of_an_HTML5_document).
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/b/index.md
+++ b/files/pt-br/web/html/element/b/index.md
@@ -62,4 +62,4 @@ Palavras-chave são exibidas com o estilo padrão do elemento \<b>, provavelment
 - Outros elementos de transporte [text-level semantics](/pt-BR/docs/HTML/Text_level_semantics_conveying_elements): {{HTMLElement("a")}}, {{HTMLElement("em")}}, {{HTMLElement("strong")}}, {{HTMLElement("small")}}, {{HTMLElement("cite")}}, {{HTMLElement("q")}}, {{HTMLElement("dfn")}}, {{HTMLElement("abbr")}}, {{HTMLElement("time")}}, {{HTMLElement("code")}}, {{HTMLElement("var")}}, {{HTMLElement("samp")}}, {{HTMLElement("kbd")}}, {{HTMLElement("sub")}}, {{HTMLElement("sup")}}, {{HTMLElement("i")}}, {{HTMLElement("mark")}}, {{HTMLElement("ruby")}}, {{HTMLElement("rp")}}, {{HTMLElement("rt")}}, {{HTMLElement("bdo")}}, {{HTMLElement("span")}}, {{HTMLElement("br")}}, {{HTMLElement("wbr")}}.
 - [Using \<b> and \<i> elements (W3C)](http://www.w3.org/International/questions/qa-b-and-i-tags)
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/base/index.md
+++ b/files/pt-br/web/html/element/base/index.md
@@ -54,4 +54,4 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/HTML/Global_attributes).
 - HTML 2.0 and 3.2 define only the `href` attribute
 - XHTML requires a trailing slash: `<base />`
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/bdi/index.md
+++ b/files/pt-br/web/html/element/bdi/index.md
@@ -43,4 +43,4 @@ Como todos os outros elementos do HTML, este elemento tem os atributos globais, 
 - Related HTML element: {{HTMLElement("bdo")}}
 - Related HTML properties: {{cssxref("direction")}}, {{cssxref("unicode-bidi")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/bdo/index.md
+++ b/files/pt-br/web/html/element/bdo/index.md
@@ -8,7 +8,7 @@ tags:
   - rtl
 translation_of: Web/HTML/Element/bdo
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 O **_elemento_ HTML `<bdo>` **(_bidirectional override_) é usado para substituir a direcionalidade atual do texto. Isso faz com que a direcionalidade dos personagens seja ignorada em favor da direcionalidade especificada.
 

--- a/files/pt-br/web/html/element/big/index.md
+++ b/files/pt-br/web/html/element/big/index.md
@@ -75,4 +75,4 @@ This element implements the {{domxref('HTMLElement')}} interface.
 - HTML: {{htmlelement("small")}}, {{htmlelement("font")}}, {{htmlelement("style")}}
 - HTML 4.01 Specification: [Font Styles](http://www.w3.org/TR/html4/present/graphics.html#h-15.2)
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/blink/index.md
+++ b/files/pt-br/web/html/element/blink/index.md
@@ -46,4 +46,4 @@ Este elemento não é padrão e não faz parte de nenhuma especificação. Se vo
 - {{htmlelement("marquee")}}, outro elemento não-padrão semelhante.
 - [CSS animations](/pt-BR/docs/Web/Guide/CSS/Using_CSS_animations) são o caminho correto para obter este efeito.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/blockquote/index.md
+++ b/files/pt-br/web/html/element/blockquote/index.md
@@ -66,4 +66,4 @@ O código HTML acima vai resultar em:
 - O elemento {{HTMLElement("q")}} para citações em linha.
 - O elemento {{HTMLElement("q")}} para citações de origem.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/body/index.md
+++ b/files/pt-br/web/html/element/body/index.md
@@ -10,7 +10,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/body
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 O **elemento** `<body>` do **HTML** representa o conteúdo de um documento HTML. è permitido apenas um `<body>` por documento.
 

--- a/files/pt-br/web/html/element/br/index.md
+++ b/files/pt-br/web/html/element/br/index.md
@@ -102,4 +102,4 @@ USA
 - O elemento {{HTMLElement("address")}}
 - O elemento {{HTMLElement("p")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/button/index.md
+++ b/files/pt-br/web/html/element/button/index.md
@@ -128,4 +128,4 @@ Firefox <35 para Android define um padrão {{ cssxref("background-image") }} gra
 
 Outros elementos que são usados para criar formulários: {{HTMLElement("form")}}, {{HTMLElement("datalist")}}, {{HTMLElement("fieldset")}}, {{HTMLElement("input")}},{{HTMLElement("keygen")}}, {{HTMLElement("label")}}, {{HTMLElement("legend")}}, {{HTMLElement("meter")}}, {{HTMLElement("optgroup")}}, {{HTMLElement("option")}}, {{HTMLElement("output")}}, {{HTMLElement("progress")}}, {{HTMLElement("select")}}, {{HTMLElement("textarea")}}.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/caption/index.md
+++ b/files/pt-br/web/html/element/caption/index.md
@@ -131,4 +131,4 @@ table, th, td {
 
   - {{cssxref("text-align")}}, {{cssxref("caption-side")}}.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/center/index.md
+++ b/files/pt-br/web/html/element/center/index.md
@@ -63,4 +63,4 @@ Apesar de obsoleto, o elemento é aceito em todos os navegadores do mercado.
 - {{Cssxref("text-align")}}
 - {{Cssxref("display")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/cite/index.md
+++ b/files/pt-br/web/html/element/cite/index.md
@@ -94,4 +94,4 @@ Mais informações podem ser encontradas em \[ISO-0000].
 - O elemento {{HTMLElement("blockquote")}} é para citações longas.
 - O elemento {{HTMLElement("q")}} é para citações curtas ou na mesma linha.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/code/index.md
+++ b/files/pt-br/web/html/element/code/index.md
@@ -3,7 +3,7 @@ title: '<code>: O Elemento Inline Code'
 slug: Web/HTML/Element/code
 translation_of: Web/HTML/Element/code
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 O **elemento** **HTML `<code>` **apresenta seu conteúdo estilizado de maneira a indicar que o texto é um pequeno fragmento de código. Por padrão, o conteúdo é exibido utilizando a fonte monoespaçada padrão do {{Glossary("user agent", "user agent's")}}.
 

--- a/files/pt-br/web/html/element/col/index.md
+++ b/files/pt-br/web/html/element/col/index.md
@@ -3,7 +3,9 @@ title: <col>
 slug: Web/HTML/Element/col
 translation_of: Web/HTML/Element/col
 ---
-{{HTMLRef}}O elemento **HTML `<col>` **define uma tabela contendo colunas e sendo utilizada para definições semanticas em todas as colunas comuns. É normalmente encontrada dentro do elemento("colgroup")}} .Este elemento permite a estilização de colunas utilizando-se do CSS, porém apenas um numero pequeno de atributos que terão efeito dentro das colunas ([veja as especificações do CSS 2.1](https://www.w3.org/TR/CSS21/tables.html#columns) a partir dessa lista).
+{{HTMLSidebar}}
+
+O elemento **HTML `<col>` **define uma tabela contendo colunas e sendo utilizada para definições semanticas em todas as colunas comuns. É normalmente encontrada dentro do elemento("colgroup")}} .Este elemento permite a estilização de colunas utilizando-se do CSS, porém apenas um numero pequeno de atributos que terão efeito dentro das colunas ([veja as especificações do CSS 2.1](https://www.w3.org/TR/CSS21/tables.html#columns) a partir dessa lista).
 
 <table class="properties">
   <tbody>

--- a/files/pt-br/web/html/element/content/index.md
+++ b/files/pt-br/web/html/element/content/index.md
@@ -104,4 +104,4 @@ This element is no longer defined by any specifications.
 - [Web Components](/pt-BR/docs/Web/Web_Components)
 - {{HTMLElement("shadow")}}, {{HTMLElement("slot")}}, {{HTMLElement("template")}}, {{HTMLElement("element")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/data/index.md
+++ b/files/pt-br/web/html/element/data/index.md
@@ -48,4 +48,4 @@ The following example displays product names but also associates each name with 
 
 - The HTML {{HTMLElement("time")}} element.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/del/index.md
+++ b/files/pt-br/web/html/element/del/index.md
@@ -48,4 +48,4 @@ This element includes the [global attributes](/pt-BR/docs/HTML/Global_attributes
 
 - {{HTMLElement("ins")}} element for insertions into a text
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/dfn/index.md
+++ b/files/pt-br/web/html/element/dfn/index.md
@@ -79,4 +79,4 @@ _A Internet_ é um sistema global de redes interconectadas que usam o Internet P
 - Elementos relacionados à lista de definições: {{HTMLElement("dl")}}, {{HTMLElement("dt")}}, {{HTMLElement("dd")}}
 - {{HTMLElement("abbr")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/dialog/index.md
+++ b/files/pt-br/web/html/element/dialog/index.md
@@ -159,4 +159,4 @@ Inclua este polyfill para suportar browsers antigos.
 - O {{event("cancel")}} evento
 - Guia de formulários HTML.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/dir/index.md
+++ b/files/pt-br/web/html/element/dir/index.md
@@ -48,4 +48,4 @@ Como todos os outros elementos HTML, este elemento suporta os [global attributes
   - A propriedade {{Cssxref('line-height')}}, útil para simular o atributo obsoleto {{htmlattrxref("compact", "dir")}}.
   - A propriedade {{cssxref('margin')}}, útil para controlar o recuo da lista.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/div/index.md
+++ b/files/pt-br/web/html/element/div/index.md
@@ -48,4 +48,4 @@ Qualquer tipo de conteúdo aqui. Como \<p>, \<table>. Você dá o nome!
 - Semantic sectioning elements: {{HTMLElement("section")}}, {{HTMLElement("article")}}, {{HTMLElement("nav")}}, {{HTMLElement("header")}}, {{HTMLElement("footer")}}
 - {{HTMLElement("span")}} element for styling of phrasing content
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/dl/index.md
+++ b/files/pt-br/web/html/element/dl/index.md
@@ -107,4 +107,4 @@ Para mudar a indentação de um termo, use a propriedade [CSS](/en/CSS) [margin]
 - Elemento {{ HTMLElement("dt") }}
 - Elemento {{ HTMLElement("dd") }}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/dt/index.md
+++ b/files/pt-br/web/html/element/dt/index.md
@@ -37,4 +37,4 @@ Para exemplo veja [definição de lista](/pt-BR/docs/HTML/Element/dl#Examples).
 
 - {{HTMLElement("dd")}}, {{HTMLElement("dl")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/em/index.md
+++ b/files/pt-br/web/html/element/em/index.md
@@ -118,4 +118,4 @@ Um exemplo para `<i>` poderia ser: "A _Rainha Mary_ velejou na noite passada". A
 
 - {{HTMLElement("i")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/embed/index.md
+++ b/files/pt-br/web/html/element/embed/index.md
@@ -70,4 +70,4 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/HTML/Global_attributes).
 - Outros elementos usados para incorporar conteúdo de vários tipos, incluem: {{HTMLElement("audio")}}, {{HTMLElement("canvas")}}, {{HTMLElement("iframe")}}, {{HTMLElement("img")}}, {{MathMLElement("math")}}, {{HTMLElement("object")}}, {{SVGElement("svg")}}, and {{HTMLElement("video")}}.
 - Posicionamento e dimensionamento de conteúdos incorporados dentro da janela de exibição: {{cssxref("object-position")}} and {{cssxref("object-fit")}}
 
-{{ HTMLRef }}
+{{ HTMLSidebar }}

--- a/files/pt-br/web/html/element/fieldset/index.md
+++ b/files/pt-br/web/html/element/fieldset/index.md
@@ -3,7 +3,7 @@ title: <fieldset>
 slug: Web/HTML/Element/fieldset
 translation_of: Web/HTML/Element/fieldset
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 O **elemento** **HTML `<fieldset>`** é usado para agrupar elementos, assim como labels ({{HTMLElement("label")}}), dentro de um formulário web.
 

--- a/files/pt-br/web/html/element/figcaption/index.md
+++ b/files/pt-br/web/html/element/figcaption/index.md
@@ -6,7 +6,7 @@ tags:
   - HTML
 translation_of: Web/HTML/Element/figcaption
 ---
-{{HTMLRef}}O **Elemento HTML Figcaption** (`<figcaption>`) representa uma legenda ou uma legenda associada com uma figura ou ilustração descrita pelo resto dos dados do elemento {{ HTMLElement("figure") }} que seu elemento pai.{{EmbedInteractiveExample("pages/tabbed/figcaption.html","tabbed-shorter")}}
+{{HTMLSidebar}}O **Elemento HTML Figcaption** (`<figcaption>`) representa uma legenda ou uma legenda associada com uma figura ou ilustração descrita pelo resto dos dados do elemento {{ HTMLElement("figure") }} que seu elemento pai.{{EmbedInteractiveExample("pages/tabbed/figcaption.html","tabbed-shorter")}}
 
 <table class="properties">
   <tbody>

--- a/files/pt-br/web/html/element/figure/index.md
+++ b/files/pt-br/web/html/element/figure/index.md
@@ -83,4 +83,4 @@ Este elemento só inclui os [atributos globais](/pt-BR/docs/HTML/Global_attribut
 
 - O {{HTMLElement("figcaption")}} elemento.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/form/index.md
+++ b/files/pt-br/web/html/element/form/index.md
@@ -117,4 +117,4 @@ Este elemento inclue os [Atributos global](/pt-BR/docs/HTML/Global_attributes).
 - [HTML forms guide](/pt-BR/docs/Web/Guide/HTML/Forms)
 - Other elements that are used for creating forms: {{HTMLElement("button")}}, {{HTMLElement("datalist")}}, {{HTMLElement("fieldset")}}, {{HTMLElement("input")}},{{HTMLElement("keygen")}}, {{HTMLElement("label")}}, {{HTMLElement("legend")}}, {{HTMLElement("meter")}}, {{HTMLElement("optgroup")}}, {{HTMLElement("option")}}, {{HTMLElement("output")}}, {{HTMLElement("progress")}}, {{HTMLElement("select")}}, {{HTMLElement("textarea")}}.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/head/index.md
+++ b/files/pt-br/web/html/element/head/index.md
@@ -6,7 +6,7 @@ tags:
   - head
 translation_of: Web/HTML/Element/head
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 O elemento **HTML `<head>` providencia informações gerais** (metadados) sobre o documento, incluindo seu título e links para scripts e folhas de estilos.
 

--- a/files/pt-br/web/html/element/header/index.md
+++ b/files/pt-br/web/html/element/header/index.md
@@ -47,4 +47,4 @@ Este elemento não possui outros atributos além dos [atributos globais](/pt-BR/
 - Outros elementos relacionados a seção: {{HTMLElement("body")}}, {{HTMLElement("nav")}}, {{HTMLElement("article")}}, {{HTMLElement("aside")}}, {{HTMLElement("h1")}}, {{HTMLElement("h2")}}, {{HTMLElement("h3")}}, {{HTMLElement("h4")}}, {{HTMLElement("h5")}}, {{HTMLElement("h6")}}, {{HTMLElement("hgroup")}}, {{HTMLElement("footer")}}, {{HTMLElement("section")}}, {{HTMLElement("address")}};
 - [Seções e outlines de um documento HTML5](/pt-BR/docs/Sections_and_Outlines_of_an_HTML5_document).
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/heading_elements/index.md
+++ b/files/pt-br/web/html/element/heading_elements/index.md
@@ -3,7 +3,7 @@ title: '<h1>–<h6>: Os elementos HTML de cabeçalho da seção'
 slug: Web/HTML/Element/Heading_Elements
 translation_of: Web/HTML/Element/Heading_Elements
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Os **elementos HTML** **`<h1>`–`<h6>`** representam seis níveis de título de seção. `<h1>` é o nível de seção mais alto e `<h6>` é o mais baixo.
 
@@ -93,5 +93,3 @@ Em {{HTMLVersionInline(5)}}, use o elemento {{HTMLElement("section")}} para defi
 - {{HTMLElement("p")}}
 - {{HTMLElement("div")}}
 - {{HTMLElement("section")}}
-
-{{HTMLRef}}

--- a/files/pt-br/web/html/element/hgroup/index.md
+++ b/files/pt-br/web/html/element/hgroup/index.md
@@ -3,7 +3,7 @@ title: <hgroup>
 slug: Web/HTML/Element/hgroup
 translation_of: Web/HTML/Element/hgroup
 ---
-{{HTMLRef}}{{seeCompatTable}}
+{{HTMLSidebar}}{{seeCompatTable}}
 
 O **elemento HTML `<hgroup>` **destina-se a agrupar cabeçalhos de diferentes níveis para uma seção do documento. Ele agrupa (é um container para) um conjunto de elementos [`<h1>–<h6>`](/pt-BR/docs/Web/HTML/Element/Heading_Elements).
 

--- a/files/pt-br/web/html/element/hr/index.md
+++ b/files/pt-br/web/html/element/hr/index.md
@@ -69,4 +69,4 @@ Para alterar a aparencia da linha ou as lacunas entre ela e os parágrafos, util
 
 - [Elemento HTML parágrafo](/pt-BR/docs/HTML/Element/p)
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/html/index.md
+++ b/files/pt-br/web/html/element/html/index.md
@@ -64,4 +64,4 @@ Desde que o elemento `<html>` seja o primeiro em documento outro que comenta, es
 - Elemento de alto nível MathML: {{MathMLElement("math")}}
 - Elemento de alto nível SVG: {{SVGElement("svg")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/iframe/index.md
+++ b/files/pt-br/web/html/element/iframe/index.md
@@ -134,4 +134,4 @@ Scripts trying to access a frame's content are subject to the [same-origin polic
 
 {{Compat("html.elements.iframe", 3)}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/img/index.md
+++ b/files/pt-br/web/html/element/img/index.md
@@ -207,4 +207,4 @@ O valor do atributo `title` é geralmente mostrado ao usuário como uma dica, qu
 
 - {{HTMLElement("object")}} and {{HTMLElement("embed")}} elements
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/input/button/index.md
+++ b/files/pt-br/web/html/element/input/button/index.md
@@ -15,7 +15,7 @@ tags:
   - formulários
 translation_of: Web/HTML/Element/input/button
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Elementos {{HTMLElement("input")}} do tipo **`button`** são renderizados como um simples botão, que podem ser programados para controlar funcionalidades customizadas em qualquer lugar de uma página web quando for atribuído um evento (tipicamente para um evento {{event("click")}}).
 

--- a/files/pt-br/web/html/element/input/checkbox/index.md
+++ b/files/pt-br/web/html/element/input/checkbox/index.md
@@ -3,7 +3,7 @@ title: <input type="checkbox">
 slug: Web/HTML/Element/Input/checkbox
 translation_of: Web/HTML/Element/input/checkbox
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 {{htmlelement ("input")}} elementos do tipo **`checkbox`** são renderizados por padrão como caixas quadradas que são marcadas (com uma marca de verificação) quando ativadas, como as que você veria em um formulário do governo. A aparência exata depende de da configuração de sistema operacional sobre o qual o navegador está sendo executado. Caixas de seleção permitem que você selecione valores únicos para envio em um formulário (ou não).
 

--- a/files/pt-br/web/html/element/input/index.md
+++ b/files/pt-br/web/html/element/input/index.md
@@ -284,4 +284,4 @@ Você pode usar o atributo {{htmlattrxref("mozactionhint", "input")}} para espec
 - Outros elementos relacionados a formulários: {{HTMLElement("form")}}, {{HTMLElement("button")}}, {{HTMLElement("datalist")}}, {{HTMLElement("legend")}}, {{HTMLElement("label")}}, {{HTMLElement("select")}}, {{HTMLElement("optgroup")}}, {{HTMLElement("option")}}, {{HTMLElement("textarea")}}, {{HTMLElement("keygen")}}, {{HTMLElement("fieldset")}}, {{HTMLElement("output")}}, {{HTMLElement("progress")}} e {{HTMLElement("meter")}}.
 - [Cross-browser HTML5 placeholder text](http://webdesignerwall.com/tutorials/cross-browser-html5-placeholder-text)
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/input/password/index.md
+++ b/files/pt-br/web/html/element/input/password/index.md
@@ -7,7 +7,7 @@ tags:
   - senha
 translation_of: Web/HTML/Element/input/password
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Elementos `<input>` do tipo **`"password"`** são uma maneira do usuário digitar senhas com segurança. O elemento é mostrado como um controle de edição de texto de uma linha, no qual o texto é omitido para que não possa ser lido, geralmente substituindo cada caractere por um símbolo como o astesrisco ("\*") ou um ponto ("•"). Esse caracter varia dependendo do {{Glossary("agente de usuário")}} e do {{Glossary("OS")}}.
 

--- a/files/pt-br/web/html/element/input/range/index.md
+++ b/files/pt-br/web/html/element/input/range/index.md
@@ -3,7 +3,7 @@ title: <input type="range">
 slug: Web/HTML/Element/Input/range
 translation_of: Web/HTML/Element/input/range
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 {{HTMLElement("input")}} elementos do tipo **`"range"`** deixam o usuário especificar um valor numérico que não deve ser inferior a um determinado valor, e não mais do que um valor máximo especificado. O valor preciso, no entanto, não é considerado importante. Este geralmente é representado por um controle deslizante ou o mesmo tipo de controle de "number" input. Como este tipo de elemento é impreciso, não deve ser usado a menos que o valor exato do controle não seja importante.
 

--- a/files/pt-br/web/html/element/input/time/index.md
+++ b/files/pt-br/web/html/element/input/time/index.md
@@ -7,7 +7,7 @@ tags:
   - tipo
 translation_of: Web/HTML/Element/input/time
 ---
-{{HTMLRef("Input_types")}}
+{{HTMLSidebar("Input_types")}}
 
 Elementos `<input>` do tipo **`time`** (hora) criam campos de inserção que permitem que o usuário digite horários facilmente (horas e minutos e, opcionalmente, segundos).
 

--- a/files/pt-br/web/html/element/input/time/index.md
+++ b/files/pt-br/web/html/element/input/time/index.md
@@ -7,7 +7,7 @@ tags:
   - tipo
 translation_of: Web/HTML/Element/input/time
 ---
-{{HTMLSidebar("Input_types")}}
+{{HTMLSidebar}}
 
 Elementos `<input>` do tipo **`time`** (hora) criam campos de inserção que permitem que o usuário digite horários facilmente (horas e minutos e, opcionalmente, segundos).
 

--- a/files/pt-br/web/html/element/ins/index.md
+++ b/files/pt-br/web/html/element/ins/index.md
@@ -44,4 +44,4 @@ This element includes the [global attributes](/pt-BR/docs/HTML/Global_attributes
 
 - {{HTMLElement("del")}} element for marking deletion into a document
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/label/index.md
+++ b/files/pt-br/web/html/element/label/index.md
@@ -63,4 +63,4 @@ A tecla de atalho para acessar este elemento a partir do teclado.
 
 - Other form-related elements: {{HTMLElement("form")}}, {{HTMLElement("button")}}, {{HTMLElement("datalist")}}, {{HTMLElement("legend")}}, {{HTMLElement("select")}}, {{HTMLElement("optgroup")}}, {{HTMLElement("option")}}, {{HTMLElement("textarea")}}, {{HTMLElement("keygen")}}, {{HTMLElement("fieldset")}}, {{HTMLElement("output")}}, {{HTMLElement("progress")}} and {{HTMLElement("meter")}}.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/legend/index.md
+++ b/files/pt-br/web/html/element/legend/index.md
@@ -48,4 +48,4 @@ Veja {{HTMLElement("form")}} para exemplos sobre `<legend>`.
 
 - Outros elementos relacionados a formulários: {{HTMLElement("form")}}, {{HTMLElement("option")}}, {{HTMLElement("label")}}, {{HTMLElement("button")}}, {{HTMLElement("select")}}, {{HTMLElement("datalist")}}, {{HTMLElement("optgroup")}}, {{HTMLElement("fieldset")}}, {{HTMLElement("textarea")}}, {{HTMLElement("keygen")}}, {{HTMLElement("input")}}, {{HTMLElement("output")}}, {{HTMLElement("progress")}} and {{HTMLElement("meter")}}.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/li/index.md
+++ b/files/pt-br/web/html/element/li/index.md
@@ -98,4 +98,4 @@ Para exemplos mais detalhados veja as páginas [\<ol>](/pt-BR/docs/Web/HTML/Elem
   - [contadores CSS](/Web/Guide/CSS/Counters) para controlar listas aninhadas complexas,
   - a propriedade {{cssxref("margin")}}, para controlar a indentação dos itens da lista.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/link/index.md
+++ b/files/pt-br/web/html/element/link/index.md
@@ -150,4 +150,4 @@ function sheetError() {
 
 - [Ryan Grove's \<script> and \<link> node event compatibility chart](http://pieisgood.org/test/script-link-events/)
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/map/index.md
+++ b/files/pt-br/web/html/element/map/index.md
@@ -46,4 +46,4 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/HTML/Global_attributes).
 - {{HTMLElement ("a")}}
 - {{HTMLElement ("area")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/mark/index.md
+++ b/files/pt-br/web/html/element/mark/index.md
@@ -58,4 +58,4 @@ Este elemento inclue apenas [atributos Globais](/pt-BR/docs/HTML/Global_attribut
 
 - Outros [text-level semantics elements](/pt-BR/docs/HTML/Text-level_semantics_elements): {{HTMLElement("a")}}, {{HTMLElement("em")}}, {{HTMLElement("strong")}}, {{HTMLElement("cite")}}, {{HTMLElement("q")}}, {{HTMLElement("dfn")}}, {{HTMLElement("abbr")}}, {{HTMLElement("time")}}, {{HTMLElement("code")}}, {{HTMLElement("var")}}, {{HTMLElement("samp")}}, {{HTMLElement("kbd")}}, {{HTMLElement("sub")}}, {{HTMLElement("sup")}}, {{HTMLElement("i")}}, {{HTMLElement("b")}}, {{HTMLElement("mark")}}, {{HTMLElement("ruby")}}, {{HTMLElement("rp")}}, {{HTMLElement("rt")}}, {{HTMLElement("bdo")}}, {{HTMLElement("span")}}, {{HTMLElement("br")}}, {{HTMLElement("wbr")}}.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/marquee/index.md
+++ b/files/pt-br/web/html/element/marquee/index.md
@@ -3,7 +3,7 @@ title: <marquee>
 slug: Web/HTML/Element/marquee
 translation_of: Web/HTML/Element/marquee
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 {{obsolete_header}}
 

--- a/files/pt-br/web/html/element/meta/index.md
+++ b/files/pt-br/web/html/element/meta/index.md
@@ -3,7 +3,7 @@ title: <meta>
 slug: Web/HTML/Element/meta
 translation_of: Web/HTML/Element/meta
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 O elemento **HTML `<meta>` **define qualquer informação de metadados que não podem ser definidos por outros elementos **HTML.** ({{HTMLElement("base")}}, {{HTMLElement("link")}}, {{HTMLElement("script")}}, {{HTMLElement("style")}} ou {{HTMLElement("title")}}).
 

--- a/files/pt-br/web/html/element/nav/index.md
+++ b/files/pt-br/web/html/element/nav/index.md
@@ -62,4 +62,4 @@ Este elemento implementa a interface [`HTMLElement`](/en/DOM/element).
 - Outros elementos relacionados à seções: {{ HTMLElement("body") }}, {{ HTMLElement("article") }}, {{ HTMLElement("section") }}, {{ HTMLElement("aside") }}, {{ HTMLElement("h1") }}, {{ HTMLElement("h2") }}, {{ HTMLElement("h3") }}, {{ HTMLElement("h4") }}, {{ HTMLElement("h5") }}, {{ HTMLElement("h6") }}, {{ HTMLElement("hgroup") }}, {{ HTMLElement("header") }}, {{ HTMLElement("footer") }}, {{ HTMLElement("address") }};
 - [Seções e esboços de um documento HTML5](/pt-BR/docs/Seções_e_estrutura_HTML5)
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/nobr/index.md
+++ b/files/pt-br/web/html/element/nobr/index.md
@@ -23,4 +23,4 @@ translation_of: Web/HTML/Element/nobr
 - {{Cssxref("white-space")}}
 - {{Cssxref("overflow")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/noscript/index.md
+++ b/files/pt-br/web/html/element/noscript/index.md
@@ -9,7 +9,7 @@ tags:
   - script HTML
 translation_of: Web/HTML/Element/noscript
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 ## Resumo
 

--- a/files/pt-br/web/html/element/ol/index.md
+++ b/files/pt-br/web/html/element/ol/index.md
@@ -157,4 +157,4 @@ A saída HTML acima será:
   - a propriedade {{cssxref("line-height")}}, proficiente para simular o atributo obsoleto {{htmlattrxref("compact", "ol")}},
   - a propriedade {{cssxref("margin")}}, aplicável para controlar a indentação da lista.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/optgroup/index.md
+++ b/files/pt-br/web/html/element/optgroup/index.md
@@ -71,4 +71,4 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/HTML/Global_attributes).
 
 - Outros elementos de formularios relacionados: {{HTMLElement("form")}}, {{HTMLElement("legend")}}, {{HTMLElement("label")}}, {{HTMLElement("button")}}, {{HTMLElement("select")}}, {{HTMLElement("datalist")}}, {{HTMLElement("option")}}, {{HTMLElement("fieldset")}}, {{HTMLElement("textarea")}}, {{HTMLElement("keygen")}}, {{HTMLElement("input")}}, {{HTMLElement("output")}}, {{HTMLElement("progress")}} e {{HTMLElement("meter")}}.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/option/index.md
+++ b/files/pt-br/web/html/element/option/index.md
@@ -53,4 +53,4 @@ Veja os exemplos do elemento {{HTMLElement("select")}}.
 
 - Outros elementos relacionados a formulários: {{HTMLElement("form")}}, {{HTMLElement("legend")}}, {{HTMLElement("label")}}, {{HTMLElement("button")}}, {{HTMLElement("select")}}, {{HTMLElement("datalist")}}, {{HTMLElement("optgroup")}}, {{HTMLElement("fieldset")}}, {{HTMLElement("textarea")}}, {{HTMLElement("keygen")}}, {{HTMLElement("input")}}, {{HTMLElement("output")}}, {{HTMLElement("progress")}} e {{HTMLElement("meter")}}.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/output/index.md
+++ b/files/pt-br/web/html/element/output/index.md
@@ -54,4 +54,4 @@ O elemento implementa a interface [HTMLOutputElement](/en/DOM/HTMLOutputElement)
 
 Outros elementos relacionados ao form: {{ HTMLElement("form") }}, {{ HTMLElement("input") }}, {{ HTMLElement("button") }}, {{ HTMLElement("datalist") }}, {{ HTMLElement("legend") }}, {{ HTMLElement("label") }}, {{ HTMLElement("select") }}, {{ HTMLElement("optgroup") }}, {{ HTMLElement("option") }}, {{ HTMLElement("textarea") }}, {{ HTMLElement("keygen") }}, {{ HTMLElement("fieldset") }}, {{ HTMLElement("progress") }} and {{ HTMLElement("meter") }}.
 
-{{ HTMLRef }}
+{{ HTMLSidebar }}

--- a/files/pt-br/web/html/element/pre/index.md
+++ b/files/pt-br/web/html/element/pre/index.md
@@ -62,4 +62,4 @@ body {
 
 - CSS: {{ Cssxref('white-space') }}, {{ Cssxref('word-break') }}
 
-{{ HTMLRef }}
+{{ HTMLSidebar }}

--- a/files/pt-br/web/html/element/q/index.md
+++ b/files/pt-br/web/html/element/q/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/q
 ---
-{{HTMLRef}}O elemento HTML \<q> indica que o texto dentro da tag é uma pequena citação. Este elemento destina-se a citações curtas que não requerem marcações de parágrafo; para citações maiores use o elemento {{HTMLElement("blockquote")}}.
+{{HTMLSidebar}}O elemento HTML \<q> indica que o texto dentro da tag é uma pequena citação. Este elemento destina-se a citações curtas que não requerem marcações de parágrafo; para citações maiores use o elemento {{HTMLElement("blockquote")}}.
 
 <table class="properties">
   <tbody>

--- a/files/pt-br/web/html/element/rt/index.md
+++ b/files/pt-br/web/html/element/rt/index.md
@@ -42,4 +42,4 @@ This element only includes the [global attributes](/pt-BR/docs/Web/HTML/Global_a
 - {{HTMLElement("ruby")}}
 - {{HTMLElement("rp")}}
 
-{{ HTMLRef }}
+{{ HTMLSidebar }}

--- a/files/pt-br/web/html/element/ruby/index.md
+++ b/files/pt-br/web/html/element/ruby/index.md
@@ -58,4 +58,4 @@ Esse elemento somente inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_
 - {{HTMLElement("rt")}}
 - {{HTMLElement("rp")}}
 
-{{ HTMLRef }}
+{{ HTMLSidebar }}

--- a/files/pt-br/web/html/element/s/index.md
+++ b/files/pt-br/web/html/element/s/index.md
@@ -3,7 +3,7 @@ title: <s>
 slug: Web/HTML/Element/s
 translation_of: Web/HTML/Element/s
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 O **elemento HTML `<s>`** renderiza um texto tachado ou uma linha cortando o texto. Use o elemento `<s>` para representar texto que não sejam relevante ou que não estam corretos. Não é apropriado o uso do `<s>` indicar edições no texto; para indicar edições no texto utilize {{HTMLElement("del")}} e {{HTMLElement("ins")}}, que são elementos mais apropriados.
 

--- a/files/pt-br/web/html/element/script/index.md
+++ b/files/pt-br/web/html/element/script/index.md
@@ -143,4 +143,4 @@ The script should be served with the `text/javascript` MIME type, but browsers a
 - {{domxref("document.currentScript")}}
 - [Ryan Grove's \<script> and \<link> node event compatibility chart](https://pie.gd/test/script-link-events/)
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/select/index.md
+++ b/files/pt-br/web/html/element/select/index.md
@@ -75,4 +75,4 @@ A seguir um exemplo de como simular uma lista de seleção com opções editáve
 
 - Outros elementos relacionados a formulários: {{HTMLElement("form")}}, {{HTMLElement("legend")}}, {{HTMLElement("label")}}, {{HTMLElement("button")}}, {{HTMLElement("option")}}, {{HTMLElement("datalist")}}, {{HTMLElement("optgroup")}}, {{HTMLElement("fieldset")}}, {{HTMLElement("textarea")}}, {{HTMLElement("keygen")}}, {{HTMLElement("input")}}, {{HTMLElement("output")}}, {{HTMLElement("progress")}} e {{HTMLElement("meter")}}.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/span/index.md
+++ b/files/pt-br/web/html/element/span/index.md
@@ -57,4 +57,4 @@ Some text
 
 - Elemento HTML {{HTMLElement("div")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/strong/index.md
+++ b/files/pt-br/web/html/element/strong/index.md
@@ -122,4 +122,4 @@ Ao fazer x é **imperativo** que se faça y antes de prosseguir.
 
 - [HTML bold element](/pt-BR/docs/HTML/Element/b)
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/style/index.md
+++ b/files/pt-br/web/html/element/style/index.md
@@ -76,4 +76,4 @@ body {
 
 - O elemento {{HTMLElement("link")}} que permite usar folhas de estilo externas.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/table/index.md
+++ b/files/pt-br/web/html/element/table/index.md
@@ -331,4 +331,4 @@ border: 1px solid black;
   - {{cssxref("margin")}} and {{cssxref("padding")}} to style the individual cell content;
   - {{cssxref("text-align")}} and {{cssxref("vertical-align")}} to define alignment of text and cell content.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/template/index.md
+++ b/files/pt-br/web/html/element/template/index.md
@@ -170,4 +170,4 @@ table td {
 
 - Web components: {{HTMLElement("content")}}, {{HTMLElement("shadow")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/pt-br/web/html/element/textarea/index.md
+++ b/files/pt-br/web/html/element/textarea/index.md
@@ -3,7 +3,7 @@ title: <textarea>
 slug: Web/HTML/Element/textarea
 translation_of: Web/HTML/Element/textarea
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 O **elemento** HTML `<textarea>` representa um controle de edição para uma caixa de texto, útil quando você quer permitir ao usuário informar um texto extenso em formato livre, como um comentário ou formulário de retorno.
 

--- a/files/pt-br/web/html/element/tfoot/index.md
+++ b/files/pt-br/web/html/element/tfoot/index.md
@@ -3,7 +3,7 @@ title: '<tfoot>: Elemento para o rodapé da tabela'
 slug: Web/HTML/Element/tfoot
 translation_of: Web/HTML/Element/tfoot
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 O **`<tfoot>` **é um **elemento HTML** que define um conjunto de linhas as quais farão parte do rodapé de uma tabela HTML
 

--- a/files/pt-br/web/html/element/th/index.md
+++ b/files/pt-br/web/html/element/th/index.md
@@ -3,7 +3,7 @@ title: <th>
 slug: Web/HTML/Element/th
 translation_of: Web/HTML/Element/th
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 O **elemento** **HTML `<th>` **define uma célula cabeçalho do grupo de células de sua tabela. A exatidão natural deste grupo é definida pelos atributos {{htmlattrxref("scope", "th")}} e {{htmlattrxref("headers", "th")}}.
 

--- a/files/pt-br/web/html/element/track/index.md
+++ b/files/pt-br/web/html/element/track/index.md
@@ -9,7 +9,7 @@ tags:
   - legenda
 translation_of: Web/HTML/Element/track
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 O **elemento HTML `<track>` **é usado como filho dos elementos de mídia{{HTMLElement("audio")}} e {{HTMLElement("video")}}. Ele permite que você especifique faixas de texto temporizadas (ou dados baseados em tempo), por exemplo, para lidar automaticamente com legendas. As faixas são formatadas em [WebVTT format](/pt-BR/docs/Web/API/Web_Video_Text_Tracks_Format) (arquivos `.vtt`) — Web Video Text Tracks or [Timed Text Markup Language (TTML).](https://w3c.github.io/ttml2/index.html)
 

--- a/files/pt-br/web/html/element/ul/index.md
+++ b/files/pt-br/web/html/element/ul/index.md
@@ -179,4 +179,4 @@ A saída HTML acima será:
   - a propriedade [line-height](/en/CSS/line-height), válida para simular o atributo ultrapassado {{ htmlattrxref("compact", "ul") }},
   - a propriedade [margin](/en/CSS/margin), proveitosa para controlar a indentação da lista.
 
-{{ HTMLRef }}
+{{ HTMLSidebar }}

--- a/files/pt-br/web/html/element/var/index.md
+++ b/files/pt-br/web/html/element/var/index.md
@@ -41,4 +41,4 @@ var {
 
 A simple equation: _x_ = _y_ + 2
 
-{{HTMLRef}}
+{{HTMLSidebar}}


### PR DESCRIPTION
We are deprecating `HTMLRef` macro. The [mdn/content repo doesn't have it anymore](https://github.com/mdn/content/pull/21997#event-7719645576).

The PR replaces it with `HTMLSidebar` (now this macro has almost all HTML document links [[ref](https://github.com/mdn/content/pull/21956)]).