### PR TITLE
[es] HTMLRef -> HTMLSidebar

### DIFF
--- a/files/es/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
@@ -74,7 +74,7 @@ Hay varias macros para vincular páginas en áreas de referencia específicas de
 Hay plantillas para casi todas las grandes colecciones de páginas. Por lo general, enlazan a la página principal de `reference/guide/tutorial` (esto, a menudo es necesario porque nuestras rutas de navegación a veces no lo pueden hacer) y colocan el artículo en la categoría apropiada.
 
 - [`CSSRef`](https://github.com/mdn/yari/tree/main/kumascript/macros/CSSRef.ejs) genera la barra lateral para las páginas de referencia CSS.
-- [`HTMLRef`](https://github.com/mdn/yari/tree/main/kumascript/macros/HTMLRef.ejs) genera la barra lateral para las páginas de referencia HTML.
+- [`HTMLSidebar`](https://github.com/mdn/yari/tree/main/kumascript/macros/HTMLSidebar.ejs) genera la barra lateral para las páginas de referencia HTML.
 - [`APIRef`](https://github.com/mdn/yari/tree/main/kumascript/macros/APIRef.ejs) genera la barra lateral para las páginas de referencia de la API web.
 
 ## Formato de propósito general

--- a/files/es/web/html/element/a/index.md
+++ b/files/es/web/html/element/a/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/a
 original_slug: Web/HTML/Elemento/a
 browser-compat: html.elements.a
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El _Elemento HTML `Anchor`_ **`<a>`** crea un enlace a otras páginas de internet, archivos o ubicaciones dentro de la misma página, direcciones de correo, o cualquier otra URL.
 

--- a/files/es/web/html/element/abbr/index.md
+++ b/files/es/web/html/element/abbr/index.md
@@ -8,7 +8,7 @@ tags:
 translation_of: Web/HTML/Element/abbr
 original_slug: Web/HTML/Elemento/abbr
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El **elemento HTML `<abbr>`** (_o Elemento de Abreviación HTML_) representa una abreviación o acrónimo; el atributo opcional {{htmlattrxref("title")}} puede ampliar o describir la abreviatura. Si está presente, el atributo `title` debe contener la descripción completa y nada más.
 

--- a/files/es/web/html/element/address/index.md
+++ b/files/es/web/html/element/address/index.md
@@ -8,7 +8,7 @@ tags:
 translation_of: Web/HTML/Element/address
 original_slug: Web/HTML/Elemento/address
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El **elemento HTML `<address>`** aporta información de contacto para su {{HTMLElement("article")}} más cercano o ancestro {{HTMLElement("body")}}; en el último caso lo aplica a todo el documento.
 

--- a/files/es/web/html/element/base/index.md
+++ b/files/es/web/html/element/base/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/base
 original_slug: Web/HTML/Elemento/base
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 ## Resumen
 

--- a/files/es/web/html/element/bdi/index.md
+++ b/files/es/web/html/element/bdi/index.md
@@ -56,4 +56,4 @@ Esta palabra arábica REDLOHECALP_CIBARA se muestra automáticamente de derecha 
 - Elementos HTML relacionados: {{HTMLElement("bdo")}}
 - Propiedades HTML relacionadas: {{cssxref("direction")}}, {{cssxref("unicode-bidi")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/es/web/html/element/bgsound/index.md
+++ b/files/es/web/html/element/bgsound/index.md
@@ -50,4 +50,4 @@ Puedes escribir bgsound con una etiqueta de cierre automático \<bgsound /> . Ah
 
 - {{htmlelement("audio")}}, el cual es el elemento estándar para incrustar audio en un documento.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/es/web/html/element/blink/index.md
+++ b/files/es/web/html/element/blink/index.md
@@ -45,4 +45,4 @@ Este elemento no es parte del estándar ni de alguna espeficación . Si no nos c
 - {{htmlelement("marquee")}}, otro elemento similar que no pertenece a un estándar.
 - Las [animaciones CSS](/es/docs/Web/CSS/CSS_Animations/Usando_animaciones_CSS) son la forma correcta de crear tal efecto .
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/es/web/html/element/body/index.md
+++ b/files/es/web/html/element/body/index.md
@@ -11,7 +11,7 @@ tags:
 translation_of: Web/HTML/Element/body
 original_slug: Web/HTML/Elemento/body
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El **elemento `<body>` de HTML** representa el contenido de un documento HTML. Solo puede haber un elemento `<body>` en un documento.
 

--- a/files/es/web/html/element/br/index.md
+++ b/files/es/web/html/element/br/index.md
@@ -58,4 +58,4 @@ USA
 - Elemento {{HTMLElement("address")}}
 - Elemento {{HTMLElement("p")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/es/web/html/element/content/index.md
+++ b/files/es/web/html/element/content/index.md
@@ -105,4 +105,4 @@ Si muestras esto en un explorador web , debe de verse como lo siguiente .
 - [Web Components](/es/docs/Web/Web_Components)
 - {{HTMLElement("shadow")}}, {{HTMLElement("template")}}, {{HTMLElement("element")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/es/web/html/element/data/index.md
+++ b/files/es/web/html/element/data/index.md
@@ -55,4 +55,4 @@ El siguiente ejemplo muestra nombres de productos pero también asocia a cada un
 
 - The HTML {{HTMLElement("time")}} element.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/es/web/html/element/datalist/index.md
+++ b/files/es/web/html/element/datalist/index.md
@@ -106,4 +106,4 @@ Incluya este polyfill para proporcionar soporte para navegadores antiguos y actu
 - El elemento {{HTMLElement("input")}}, y más especificamente este atributo {{htmlattrxref("list", "input")}};
 - El elemento {{HTMLElement("option")}}.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/es/web/html/element/dd/index.md
+++ b/files/es/web/html/element/dd/index.md
@@ -15,7 +15,7 @@ tags:
 translation_of: Web/HTML/Element/dd
 original_slug: Web/HTML/Elemento/dd
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El **elemento HTML `<dd>`** provee detalles acerca de o la definición de un término precedente ({{HTMLElement("dt")}}) en una lista de descripciones ({{HTMLElement("dl")}}).
 

--- a/files/es/web/html/element/details/index.md
+++ b/files/es/web/html/element/details/index.md
@@ -99,4 +99,4 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
 
 - {{HTMLElement("summary")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/es/web/html/element/dialog/index.md
+++ b/files/es/web/html/element/dialog/index.md
@@ -4,7 +4,7 @@ slug: Web/HTML/Element/dialog
 translation_of: Web/HTML/Element/dialog
 original_slug: Web/HTML/Elemento/dialog
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El **elemento** **HTML `<dialog>`** representa una caja de diálogo u otro componente interactivo, como inspector o ventana.
 

--- a/files/es/web/html/element/dl/index.md
+++ b/files/es/web/html/element/dl/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/dl
 original_slug: Web/HTML/Elemento/dl
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El elemento **HTML `<dl>`** representa una lista descriptiva. El elemento encierra una lista de grupos de términos (especificados con el uso del elemento {{HTMLElement("dt")}}) y de descripciones (proveídas con elementos {{HTMLElement("dd")}}). Algunos usos comunes para este elemento son implementar un glosario o para desplegar metadatos (lista de pares llave-valor).
 

--- a/files/es/web/html/element/dt/index.md
+++ b/files/es/web/html/element/dt/index.md
@@ -15,7 +15,7 @@ tags:
 translation_of: Web/HTML/Element/dt
 original_slug: Web/HTML/Elemento/dt
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El **elemento HTML `<dt>`** especifica un término en una descripción o lista de definiciones, y como tal debe utilizarse dentro de un elemento {{HTMLElement("dl")}} Es usualmente seguido por un elemento {{HTMLElement("dd")}}; sin embargo, múltiples elementos `<dt>` en un renglón indican diferentes términos los cuales todos son definidos por el siguiente elemento {{HTMLElement("dd")}}.
 

--- a/files/es/web/html/element/em/index.md
+++ b/files/es/web/html/element/em/index.md
@@ -8,7 +8,7 @@ tags:
 translation_of: Web/HTML/Element/em
 original_slug: Web/HTML/Elemento/em
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El **elemento HTML `<em>`** es el apropiado para marcar con énfasis las partes importantes de un texto. El elemento `<em>` puede ser anidado, con cada nivel de anidamiento indicando un mayor grado de énfasis.
 

--- a/files/es/web/html/element/figcaption/index.md
+++ b/files/es/web/html/element/figcaption/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/figcaption
 original_slug: Web/HTML/Elemento/figcaption
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El elemento **HTML `<figcaption>`** representa un subtítulo o leyenda asociado al contenido del elemento padre {{HTMLElement("figure")}}, pudiendo ser colocado como primer o último hijo. Es importante destacar que el elemento **`<figcaption>`** es opcional.
 

--- a/files/es/web/html/element/head/index.md
+++ b/files/es/web/html/element/head/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/head
 original_slug: Web/HTML/Elemento/head
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El **elemento HTML `<head>`** provee información general (metadatos) acerca del documento, incluyendo su título y enlaces a scripts y hojas de estilos.
 

--- a/files/es/web/html/element/heading_elements/index.md
+++ b/files/es/web/html/element/heading_elements/index.md
@@ -143,4 +143,4 @@ Las etiquetas de cabecera pueden anidarse para generar sub-secciones en nuestros
 - {{HTMLElement("div")}}
 - {{HTMLElement("section")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/es/web/html/element/html/index.md
+++ b/files/es/web/html/element/html/index.md
@@ -15,7 +15,7 @@ tags:
 translation_of: Web/HTML/Element/html
 original_slug: Web/HTML/Elemento/html
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El **elemento HTML `<html>`** (o _elemento HTML raiz_) representa la raiz de un documento HTML. El resto de elementos descienden de este elemento.
 

--- a/files/es/web/html/element/iframe/index.md
+++ b/files/es/web/html/element/iframe/index.md
@@ -14,7 +14,7 @@ tags:
 translation_of: Web/HTML/Element/iframe
 original_slug: Web/HTML/Elemento/iframe
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El **elemento HTML `<iframe>`** (de inline frame) representa un {{Glossary("contexto de navegación")}} anidado, el cual permite incrustrar otra página HTML en la página actual.
 

--- a/files/es/web/html/element/input/button/index.md
+++ b/files/es/web/html/element/input/button/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/input/button
 original_slug: Web/HTML/Elemento/input/Botón
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El elemento HTML **`<input type="button">`** es una versión específica del elemento **`<input>`**`,` que se usa para crear un botón en el que se puede hacer click sin ningún valor por defecto, es decir, **no tiene un comportamiento predeterminado** como por ejemplo **`<input type="reset">`** . En HTML5 ha sido sustituido por el elemento **[\<button>](/es/docs/Web/HTML/Element/button)**.
 

--- a/files/es/web/html/element/input/color/index.md
+++ b/files/es/web/html/element/input/color/index.md
@@ -13,7 +13,7 @@ tags:
 translation_of: Web/HTML/Element/input/color
 original_slug: Web/HTML/Elemento/input/color
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Los elementos {{HTMLElement("input")}} del tipo «**`color`**» proporciona un elemento de interfaz de usuario que permite a los usuarios especificar un color, bien mediante una interfaz visual de selección, bien a través de un cuadro de texto donde ingresar un valor hexadecimal en el formato «`#rrggbb`». Solo se permiten colores simples (sin canal alfa). Los valores son compatibles con CSS.
 

--- a/files/es/web/html/element/input/date/index.md
+++ b/files/es/web/html/element/input/date/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/input/date
 browser-compat: html.elements.input.input-date
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Los elementos {{HTMLElement("input")}} de **`type="date"`** crean un campo de entrada que le permite al usuario introducir una fecha, que puede ser tanto como una caja de texto para validar el campo como una interfaz especial que le permite escoger una fecha.
 

--- a/files/es/web/html/element/input/email/index.md
+++ b/files/es/web/html/element/input/email/index.md
@@ -6,7 +6,7 @@ translation_of: Web/HTML/Element/input/email
 original_slug: Web/HTML/Elemento/input/email
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Los elementos {{HTMLElement("input")}} de tipo **`email`** se utilizan para permitir que el usuario ingrese y edite una dirección de correo electrónico o, si se especifica el atributo [`multiple`](/es/docs/Web/HTML/Attributes/multiple), una lista de direcciones de correo.
 

--- a/files/es/web/html/element/input/hidden/index.md
+++ b/files/es/web/html/element/input/hidden/index.md
@@ -13,7 +13,7 @@ tags:
 translation_of: Web/HTML/Element/input/hidden
 original_slug: Web/HTML/Elemento/input/hidden
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 {{HTMLElement("input")}} elements of type **`"hidden"`** let web developers include data that cannot be seen or modified by users when a form is submitted. For example, the ID of the content that is currently being ordered or edited, or a unique security token. Hidden inputs are completely invisible in the rendered page, and there is no way to make it visible in the page's content.
 

--- a/files/es/web/html/element/input/number/index.md
+++ b/files/es/web/html/element/input/number/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/input/number
 browser-compat: html.elements.input.type_number
 ---
 
-{{HTMLRef("Input_types")}}
+{{HTMLSidebar("Input_types")}}
 
 Los elementos {{HTMLElement("input")}} del tipo **`number`** son usados para permitir al usuario ingresar un número. Éstos incluyen validación incorporada para rechazar entradas no numéricas.
 

--- a/files/es/web/html/element/input/number/index.md
+++ b/files/es/web/html/element/input/number/index.md
@@ -5,7 +5,6 @@ translation_of: Web/HTML/Element/input/number
 browser-compat: html.elements.input.type_number
 ---
 
-
 {{HTMLSidebar}}
 
 Los elementos {{HTMLElement("input")}} del tipo **`number`** son usados para permitir al usuario ingresar un número. Éstos incluyen validación incorporada para rechazar entradas no numéricas.

--- a/files/es/web/html/element/input/number/index.md
+++ b/files/es/web/html/element/input/number/index.md
@@ -5,7 +5,8 @@ translation_of: Web/HTML/Element/input/number
 browser-compat: html.elements.input.type_number
 ---
 
-{{HTMLSidebar("Input_types")}}
+
+{{HTMLSidebar}}
 
 Los elementos {{HTMLElement("input")}} del tipo **`number`** son usados para permitir al usuario ingresar un número. Éstos incluyen validación incorporada para rechazar entradas no numéricas.
 

--- a/files/es/web/html/element/input/password/index.md
+++ b/files/es/web/html/element/input/password/index.md
@@ -8,7 +8,7 @@ tags:
 translation_of: Web/HTML/Element/input/password
 original_slug: Web/HTML/Elemento/input/password
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Los elementos `<input>` de tipo **`"password"`** proporcionan una forma para que el usuario ingrese una contraseña de forma segura. El elemento se presenta como un control de editor de texto, sin formato, de una línea, en el que el texto está oculto para que no pueda leerse, generalmente reemplazando cada carácter con un símbolo como el asterisco ("\*") o un punto ("•"). Este carácter variará dependiendo del {{Glossary("user agent")}} y del {{Glossary("OS")}}.
 

--- a/files/es/web/html/element/input/range/index.md
+++ b/files/es/web/html/element/input/range/index.md
@@ -16,7 +16,7 @@ tags:
 translation_of: Web/HTML/Element/input/range
 original_slug: Web/HTML/Elemento/input/range
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El elemento {{HTMLElement("input")}} del tipo **`"range"`** permite que el usuario especifique un valor numérico comprendido entre un valor mínimo y máximo. El valor exacto, sin embargo, no se considera importante. Se repesenta típicamente como un "tirador" o un control deslizante en lugar de un campo de texto como otros tipos de {{HTMLElement("input")}}. Como este tipo de widget es bastante inmpreciso, no debe utilizarse normalmente a menos que el valor exacto del control no sea importante.
 

--- a/files/es/web/html/element/input/text/index.md
+++ b/files/es/web/html/element/input/text/index.md
@@ -16,7 +16,7 @@ tags:
 translation_of: Web/HTML/Element/input/text
 original_slug: Web/HTML/Elemento/input/text
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 Los elementos {{HTMLElement("input")}} de tipo {{HTMLAttrDef("text")}} crean campos de texto básicos de una sola línea.
 

--- a/files/es/web/html/element/label/index.md
+++ b/files/es/web/html/element/label/index.md
@@ -58,4 +58,4 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
 
 - Other form-related elements: {{HTMLElement("form")}}, {{HTMLElement("button")}}, {{HTMLElement("datalist")}}, {{HTMLElement("legend")}}, {{HTMLElement("select")}}, {{HTMLElement("optgroup")}}, {{HTMLElement("option")}}, {{HTMLElement("textarea")}}, {{HTMLElement("keygen")}}, {{HTMLElement("fieldset")}}, {{HTMLElement("output")}}, {{HTMLElement("progress")}} and {{HTMLElement("meter")}}.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/es/web/html/element/link/index.md
+++ b/files/es/web/html/element/link/index.md
@@ -12,7 +12,7 @@ tags:
 translation_of: Web/HTML/Element/link
 original_slug: Web/HTML/Elemento/link
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El **elemento HTML `<link>`** especifica la relación entre el documento actual y un recurso externo. Los usos posibles de este elemento incluyen la definición de un marco relacional para navegación. Este elemento es más frecuentemente usado para enlazar hojas de estilos.
 

--- a/files/es/web/html/element/mark/index.md
+++ b/files/es/web/html/element/mark/index.md
@@ -10,7 +10,7 @@ tags:
 translation_of: Web/HTML/Element/mark
 original_slug: Web/HTML/Elemento/mark
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El **Elemento HTML Mark `<mark>`** representa un texto **marcado** o **resaltado** como referencia o anotación, debido a su relevancia o importancia en un contexto particular.
 

--- a/files/es/web/html/element/marquee/index.md
+++ b/files/es/web/html/element/marquee/index.md
@@ -13,7 +13,7 @@ tags:
 translation_of: Web/HTML/Element/marquee
 original_slug: Web/HTML/Elemento/marquee
 ---
-{{HTMLRef}}{{obsolete_header}}
+{{HTMLSidebar}}{{obsolete_header}}
 
 ## Resumen
 

--- a/files/es/web/html/element/nav/index.md
+++ b/files/es/web/html/element/nav/index.md
@@ -12,7 +12,7 @@ tags:
 translation_of: Web/HTML/Element/nav
 original_slug: Web/HTML/Elemento/nav
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El **elemento** **HTML `<nav>`** representa una sección de una página cuyo propósito es proporcionar enlaces de navegación, ya sea dentro del documento actual o a otros documentos. Ejemplos comunes de secciones de navegación son menús, tablas de contenido e índices.
 

--- a/files/es/web/html/element/nobr/index.md
+++ b/files/es/web/html/element/nobr/index.md
@@ -27,4 +27,4 @@ El elemento HTML `<nobr>` previene que una línea de texto se divida en una nuev
 - {{Cssxref("white-space")}}
 - {{Cssxref("overflow")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/es/web/html/element/object/index.md
+++ b/files/es/web/html/element/object/index.md
@@ -11,7 +11,7 @@ tags:
 translation_of: Web/HTML/Element/object
 original_slug: Web/HTML/Elemento/object
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El **elemento HTML `<object>`** representa un recurso externo, que puede ser tratado como una imagen, un contexto de navegación anidado, o como un recurso que debe ser manejado por un plugin.
 

--- a/files/es/web/html/element/option/index.md
+++ b/files/es/web/html/element/option/index.md
@@ -11,7 +11,7 @@ tags:
 translation_of: Web/HTML/Element/option
 original_slug: Web/HTML/Elemento/option
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 En un formulario Web , el **elemento** **HTML `<option>`** se usa para representar un item dentro de un {{HTMLElement("select")}}, un {{HTMLElement("optgroup")}} o un elemento HTML5 {{HTMLElement("datalist")}} .
 

--- a/files/es/web/html/element/picture/index.md
+++ b/files/es/web/html/element/picture/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/picture
 original_slug: Web/HTML/Elemento/picture
 ---
-{{HTMLRef}}{{SeeCompatTable}}
+{{HTMLSidebar}}{{SeeCompatTable}}
 
 El **elemento HTML `<picture>`** es un contenedor usado para especificar múltiples elementos {{HTMLElement("source")}} y un elemento {{HTMLElement("img")}} contenido en él para proveer versiones de una imagen para diferentes escenarios de dispositivos. Si no hay coincidencias con los elementos `<source>`, el archivo especificado en los atributos {{htmlattrxref("src", "img")}} del elemento `<img>` es utilizado. La imagen seleccionada es entonces presentada en el espacio ocupado por el elemento `<img>`.
 

--- a/files/es/web/html/element/progress/index.md
+++ b/files/es/web/html/element/progress/index.md
@@ -4,7 +4,7 @@ slug: Web/HTML/Element/progress
 translation_of: Web/HTML/Element/progress
 original_slug: Web/HTML/Elemento/progress
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 La etiqueta **HTML `<progress>`** se utiliza para visualizar el progreso de una tarea. Aunque los detalles de como se muestran depende directamente del navegador que utiliza el cliente, aunque básicamente aparece una barra de progreso.
 

--- a/files/es/web/html/element/q/index.md
+++ b/files/es/web/html/element/q/index.md
@@ -15,7 +15,7 @@ tags:
 translation_of: Web/HTML/Element/q
 original_slug: Web/HTML/Elemento/q
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El **elemento HTML `<q>`** indica que el texto adjunto es una cita corta en línea. La mayoría de los navegadores modernos implementan esto rodeando el texto entre comillas. Este elemento está destinado a citas breves que no requieren saltos de párrafo; para citas de bloque independiente, utiliza el elemento {{HTMLElement("blockquote")}}.
 

--- a/files/es/web/html/element/samp/index.md
+++ b/files/es/web/html/element/samp/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/samp
 original_slug: Web/HTML/Elemento/samp
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El elemento HTML Sample (**`<samp>`**) se utiliza para incluir texto en línea que representa una muestra (o cita) de la salida de un programa de ordenador. El contenido de esta etiqueta es renderizado generalmente usando la tipografía monoespaciada por defecto del navegador.
 

--- a/files/es/web/html/element/select/index.md
+++ b/files/es/web/html/element/select/index.md
@@ -84,4 +84,4 @@ El siguiente ejemplo muestra como simular una lista con opciones editables, pero
 
 - Otros elementos relacionados de formularios: {{HTMLElement("form")}}, {{HTMLElement("legend")}}, {{HTMLElement("label")}}, {{HTMLElement("button")}}, {{HTMLElement("option")}}, {{HTMLElement("datalist")}}, {{HTMLElement("optgroup")}}, {{HTMLElement("fieldset")}}, {{HTMLElement("textarea")}}, {{HTMLElement("keygen")}}, {{HTMLElement("input")}}, {{HTMLElement("output")}}, {{HTMLElement("progress")}} and {{HTMLElement("meter")}}.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/es/web/html/element/slot/index.md
+++ b/files/es/web/html/element/slot/index.md
@@ -12,7 +12,7 @@ tags:
 translation_of: Web/HTML/Element/slot
 original_slug: Web/HTML/Elemento/slot
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **El elemento HTML `<slot>`** —parte de la suite tecnologica [Web Components](/es/docs/Web/Web_Components) — es un placeholder en un componente que tu puedes llenar con tu propio marcado, que te permite crear árboles DOM por separado y presentarlos juntos.
 

--- a/files/es/web/html/element/source/index.md
+++ b/files/es/web/html/element/source/index.md
@@ -124,4 +124,4 @@ Para obtener más ejemplos, consulte [Uso de audio y video en Firefox](/es/docs/
 - Elemento {{HTMLElement("audio")}}
 - Elemento {{HTMLElement("video")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/es/web/html/element/sub/index.md
+++ b/files/es/web/html/element/sub/index.md
@@ -8,7 +8,7 @@ tags:
 translation_of: Web/HTML/Element/sub
 original_slug: Web/HTML/Elemento/sub
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El **elemento HTML** \<sub> define un fragmento de texto que se debe mostrar, por razones tipográficas, más bajo, y generalmente más pequeño, que el tramo principal del texto, es decir, en subíndice.
 

--- a/files/es/web/html/element/sup/index.md
+++ b/files/es/web/html/element/sup/index.md
@@ -127,4 +127,4 @@ Este elemento sólo incluye los [atributos globales](/es/docs/HTML/Global_attrib
 
 - Los elementos MathML[`<msub>`](/es/docs/MathML/Element/msub), [`<msup>`](/es/docs/MathML/Element/msup), y [`<msubsup>`](/es/docs/MathML/Element/msubsup) .
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/es/web/html/element/td/index.md
+++ b/files/es/web/html/element/td/index.md
@@ -6,7 +6,7 @@ original_slug: Web/HTML/Elemento/td
 browser-compat: html.elements.td
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 ## Resumen
 

--- a/files/es/web/html/element/textarea/index.md
+++ b/files/es/web/html/element/textarea/index.md
@@ -120,4 +120,4 @@ Un _textarea_ tiene dimensiones intrínsecas, como una imagen agrandada.
 
 Otros elementos relacionados con formularios: {{ HTMLElement("form") }}, {{ HTMLElement("button") }}, {{ HTMLElement("datalist") }}, {{ HTMLElement("legend") }}, {{ HTMLElement("label") }}, {{ HTMLElement("select") }}, {{ HTMLElement("optgroup") }}, {{ HTMLElement("option") }}, {{ HTMLElement("input") }}, {{ HTMLElement("keygen") }}, {{ HTMLElement("fieldset") }}, {{ HTMLElement("output") }}, {{ HTMLElement("progress") }} and {{ HTMLElement("meter") }}.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/es/web/html/element/th/index.md
+++ b/files/es/web/html/element/th/index.md
@@ -170,4 +170,4 @@ See {{HTMLElement("table")}} for examples on `<th>`.
 
 - Other table-related HTML Elements: {{HTMLElement("caption")}}, {{HTMLElement("col")}}, {{HTMLElement("colgroup")}}, {{HTMLElement("table")}}, {{HTMLElement("tbody")}}, {{HTMLElement("td")}}, {{HTMLElement("tfoot")}}, {{HTMLElement("thead")}}, {{HTMLElement("tr")}}.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/es/web/html/element/title/index.md
+++ b/files/es/web/html/element/title/index.md
@@ -6,7 +6,7 @@ original_slug: Web/HTML/Elemento/title
 browser-compat: html.elements.title
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El elemento **`<title>`** [HTML](/es/docs/Web/HTML) define el título del documento que se muestra en un {{glossary("Browser", "browser")}} la barra de título o la pestaña de una página. Solo contiene texto; las etiquetas dentro del elemento se ignoran.
 

--- a/files/es/web/html/element/tr/index.md
+++ b/files/es/web/html/element/tr/index.md
@@ -80,4 +80,4 @@ Ver {{HTMLElement("table")}} para ejemplos de `<tr>`.
   - El {{cssxref(":nth-child")}} pseudo-clase para establecer la alineación en las células de la columna;
   - El {{cssxref("text-align")}} propiedad para alinear todas las células contenidos en el mismo carácter, como '.'. <
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/es/web/html/element/track/index.md
+++ b/files/es/web/html/element/track/index.md
@@ -5,7 +5,7 @@ translation_of: Web/HTML/Element/track
 original_slug: Web/HTML/Element/track
 browser-compat: html.elements.track
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El elemento [HTML](/es/docs/Web/HTML) **`<track>`** se utiliza como elemento hijo de los elementos multimedia, {{HTMLElement("audio")}} y {{HTMLElement("video")}}. Le permite especificar pistas de texto cronometradas (o datos basados en el tiempo), por ejemplo, para manejar subtítulos automáticamente. Las pistas están formateadas en [formato WebVTT](/es/docs/Web/API/WebVTT_API) (archivos `.vtt`): _Web Video Text Tracks_ (pistas de texto de video web).
 

--- a/files/es/web/html/element/var/index.md
+++ b/files/es/web/html/element/var/index.md
@@ -8,7 +8,7 @@ tags:
 translation_of: Web/HTML/Element/var
 original_slug: Web/HTML/Elemento/var
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 ### Definición
 

--- a/files/es/web/html/element/wbr/index.md
+++ b/files/es/web/html/element/wbr/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/HTML/Element/wbr
 original_slug: Web/HTML/Elemento/wbr
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 El elemento HTML _word break opportunity_ `<wbr>` representa una posición dentro del texto donde el explorador puede opcionalmente saltar una línea , aunque sus reglas de salto de línea de otra manera no crearían un salto en esa posición .En páginas codificadas en UTF-8 , \<wbr> se comporta como el punto de código `U+200B ZERO-WIDTH SPACE`. En particular se comporta como un punto de código unicode bidi BN , significando esto que no tiene efecto en ordenamiento bidi : `<div dir=rtl>123,<wbr>456</div>` muestra , cuando no se rompa en dos líneas , 123, 456 y no 456 , 123 .
 

--- a/files/es/web/html/element/xmp/index.md
+++ b/files/es/web/html/element/xmp/index.md
@@ -37,4 +37,4 @@ Este elemento implementa la interface {{domxref('HTMLElement')}} .
 - Los elementos {{HTMLElement("pre")}} y {{HTMLElement("code")}} que se usan en su lugar .
 - Los elementos {{HTMLElement("plaintext")}} y {{HTMLElement("listing")}} , similares a {{HTMLElement("xmp")}} pero también obsoletos .
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/es/web/svg/element/script/index.md
+++ b/files/es/web/svg/element/script/index.md
@@ -139,4 +139,4 @@ Este elemento contiene los [atributos globales](/es/docs/Web/HTML/Atributos_Glob
 - {{domxref("document.currentScript")}}
 - [Ryan Grove's \<script> and \<link> node event compatibility chart](http://pieisgood.org/test/script-link-events/)
 
-{{HTMLRef}}
+{{HTMLSidebar}}


### PR DESCRIPTION
We are deprecating `HTMLRef` macro. The [mdn/content repo doesn't have it anymore](https://github.com/mdn/content/pull/21997#event-7719645576).

The PR replaces it with `HTMLSidebar` (now this macro has almost all HTML document links [[ref](https://github.com/mdn/content/pull/21956)]).