### PR TITLE
[ko] HTMLRef -> HTMLSidebar

### DIFF
--- a/files/ko/web/css/css_colors/applying_color/index.md
+++ b/files/ko/web/css/css_colors/applying_color/index.md
@@ -13,7 +13,7 @@ tags:
 translation_of: Web/HTML/Applying_color
 original_slug: Web/HTML/Applying_color
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 색은 인간의 감정을 표현하는 기본적인 형태입니다. 아이들은 뭔가 그릴 수 있는 민첩성을 갖추기도 전에 색을 가지고 놉니다. 사람들이 웹 사이트를 개발할 때 보통 색을 제일 먼저 입혀보고 싶어 하는 건 이런 이유일지도 모릅니다. [CSS](/ko/docs/Web/CSS)와 함께라면 무궁무진한 방법으로 여러분의 [HTML](/ko/docs/Web/HTML) [요소](/ko/docs/Web/HTML/Element)에 색을 넣어 원하는 모습을 만들 수 있습니다. 이 글은 CSS 색을 HTML에 적용하는 기초를 소개합니다.
 

--- a/files/ko/web/html/element/a/index.md
+++ b/files/ko/web/html/element/a/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/a
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<a>` 요소**(앵커 요소)는 {{htmlattrxref("href", "a")}} 특성을 통해 다른 페이지나 같은 페이지의 어느 위치, 파일, 이메일 주소와 그 외 다른 URL로 연결할 수 있는 하이퍼링크를 만듭니다. `<a>` 안의 콘텐츠는 링크 목적지의 설명을 **나타내야 합니다**.
 

--- a/files/ko/web/html/element/abbr/index.md
+++ b/files/ko/web/html/element/abbr/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/abbr
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<abbr>` 요소**는 준말 또는 머리글자를 나타냅니다. 선택 속성인 {{htmlattrxref("title")}}을 사용하면 준말의 전체 뜻이나 설명을 제공할 수 있습니다. `title` 속성은 전체 설명만을 가져야 하며 다른건 포함할 수 없습니다.
 

--- a/files/ko/web/html/element/address/index.md
+++ b/files/ko/web/html/element/address/index.md
@@ -11,7 +11,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/address
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<address>` 요소**는 가까운 HTML 요소의 사람, 단체, 조직 등에 대한 연락처 정보를 나타냅니다.
 

--- a/files/ko/web/html/element/applet/index.md
+++ b/files/ko/web/html/element/applet/index.md
@@ -59,4 +59,4 @@ HTML의 Applet 태그 (`<applet>`) 는 자바 애플릿을 보이게 하는 곳�
 
 The W3C specification does not encourage the use of `<applet>` and prefers the use of the {{HTMLElement("object")}} tag. Under the strict definition of HTML 4.01, this element is deprecated and entirely obsolete in HTML5.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/ko/web/html/element/area/index.md
+++ b/files/ko/web/html/element/area/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/area
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<area>` 요소**는 이미지의 핫스팟 영역을 정의하고 {{glossary("hyperlink", "하이퍼링크")}}를 추가할 수 있습니다. {{htmlelement("map")}} 요소 안에서만 사용할 수 있습니다.
 

--- a/files/ko/web/html/element/article/index.md
+++ b/files/ko/web/html/element/article/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/article
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<article>` 요소**는 문서, 페이지, 애플리케이션, 또는 사이트 안에서 독립적으로 구분해 배포하거나 재사용할 수 있는 구획을 나타냅니다. 사용 예제로 게시판과 블로그 글, 매거진이나 뉴스 기사 등이 있습니다.
 

--- a/files/ko/web/html/element/aside/index.md
+++ b/files/ko/web/html/element/aside/index.md
@@ -10,7 +10,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/aside
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<aside>` 요소**는 문서의 주요 내용과 간접적으로만 연관된 부분을 나타냅니다. 주로 사이드바 혹은 콜아웃 박스로 표현합니다.
 

--- a/files/ko/web/html/element/audio/index.md
+++ b/files/ko/web/html/element/audio/index.md
@@ -14,7 +14,7 @@ tags:
   - 오디오
 translation_of: Web/HTML/Element/audio
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<audio>` 요소**는 문서에 소리 콘텐츠를 포함할 때 사용합니다. `src` 특성 또는 {{htmlelement("source")}} 요소를 사용해 한 개 이상의 오디오 소스를 지정할 수 있으며, 다수를 지정한 경우 가장 적절한 소스를 브라우저가 고릅니다. {{domxref("MediaStream")}}을 사용하면 미디어 스트림을 바라볼 수도 있습니다.
 

--- a/files/ko/web/html/element/b/index.md
+++ b/files/ko/web/html/element/b/index.md
@@ -11,7 +11,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/b
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<b>` 요소**는 독자의 주의를 요소의 콘텐츠로 끌기 위한 용도로 사용합니다. 그 외의 다른 특별한 중요도는 주어지지 않습니다. 원래는 "굵은 글씨 요소"로 불렸으며, 대부분의 브라우저도 여전히 텍스트를 굵은 글씨체로 강조합니다. 그러나 `<b>`를 사용해 텍스트를 꾸미면 안됩니다. 대신 CSS {{cssxref("font-weight")}}를 사용해 굵은 글씨체를 적용하거나, {{htmlelement("strong")}} 요소를 사용해 특별히 중요한 텍스트를 나타내세요.
 

--- a/files/ko/web/html/element/base/index.md
+++ b/files/ko/web/html/element/base/index.md
@@ -9,7 +9,7 @@ tags:
   - Reference
 translation_of: Web/HTML/Element/base
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<base>` 요소**는 문서 안의 모든 상대 {{glossary("URL")}}이 사용할 기준 URL을 지정합니다. 문서에는 하나의 `<base>` 요소만 존재할 수 있습니다.
 

--- a/files/ko/web/html/element/bdo/index.md
+++ b/files/ko/web/html/element/bdo/index.md
@@ -10,7 +10,7 @@ tags:
   - 쓰기 방향
 translation_of: Web/HTML/Element/bdo
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<bdo>` 요소**는 현재 텍스트의 쓰기 방향을 덮어쓰고 다른 방향으로 렌더링 할 때 사용합니다.
 

--- a/files/ko/web/html/element/blockquote/index.md
+++ b/files/ko/web/html/element/blockquote/index.md
@@ -11,7 +11,7 @@ tags:
   - 인용
 translation_of: Web/HTML/Element/blockquote
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<blockquote>` 요소**는 안쪽의 텍스트가 긴 인용문임을 나타냅니다. 주로 들여쓰기를 한 것으로 그려집니다. (외형을 바꾸는 법은 [사용 일람](#사용_일람)을 참고하세요) 인용문의 출처 URL은 {{htmlattrxref("cite", "blockquote")}} 특성으로, 출처 텍스트는 {{htmlelement("cite")}} 요소로 제공할 수 있습니다.
 

--- a/files/ko/web/html/element/body/index.md
+++ b/files/ko/web/html/element/body/index.md
@@ -8,7 +8,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/body
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<body>` 요소**는 HTML 문서의 내용을 나타냅니다. 한 문서에 하나의 `<body>` 요소만 존재할 수 있습니다.
 

--- a/files/ko/web/html/element/br/index.md
+++ b/files/ko/web/html/element/br/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/br
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<br>` 요소**는 텍스트 안에 줄바꿈(캐리지 리턴)을 생성합니다. 주소나 시조 등 줄의 구분이 중요한 내용을 작성할 때 유용합니다.
 

--- a/files/ko/web/html/element/button/index.md
+++ b/files/ko/web/html/element/button/index.md
@@ -10,7 +10,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/button
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<button>` 요소**는 클릭 가능한 버튼을 나타냅니다. 버튼은 [양식](/ko/docs/Learn/HTML/Forms) 내부는 물론 간단한 표준 버튼 기능이 필요한 곳이라면 문서 어디에나 배치할 수 있습니다. 기본값의 HTML 버튼은 {{glossary("user agent", "사용자 에이전트")}}의 호스트 플랫폼과 비슷한 디자인을 따라가지만, 외형은 [CSS](/ko/docs/Web/CSS)로 변경할 수 있습니다.
 

--- a/files/ko/web/html/element/canvas/index.md
+++ b/files/ko/web/html/element/canvas/index.md
@@ -10,7 +10,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/canvas
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<canvas>` 요소**는 [캔버스 스크립팅 API](/ko/docs/Web/HTML/Canvas) 또는 [WebGL API](/ko/docs/Web/API/WebGL_API)와 함께 사용해 그래픽과 애니메이션을 그릴 수 있습니다.
 

--- a/files/ko/web/html/element/caption/index.md
+++ b/files/ko/web/html/element/caption/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/caption
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<caption>` 요소**는 표의 설명 또는 제목을 나타냅니다.
 

--- a/files/ko/web/html/element/center/index.md
+++ b/files/ko/web/html/element/center/index.md
@@ -47,4 +47,4 @@ Applying {{Cssxref("text-align")}}`:center` to a {{HTMLElement("div")}} or {{HTM
 - {{Cssxref("text-align")}}
 - {{Cssxref("display")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/ko/web/html/element/cite/index.md
+++ b/files/ko/web/html/element/cite/index.md
@@ -11,7 +11,7 @@ tags:
   - 출처
 translation_of: Web/HTML/Element/cite
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<cite>` 요소**는 저작물의 출처를 표기할 때 사용하며, 제목을 반드시 포함해야 합니다. 적절한 맥락 아래에서는 출처를 축약해서 표기할 수 있습니다.
 

--- a/files/ko/web/html/element/code/index.md
+++ b/files/ko/web/html/element/code/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/code
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<code>` 요소**는 짧은 코드 조각을 나타내는 스타일을 사용해 자신의 콘텐츠를 표시합니다. 기본 스타일은 {{glossary("user agent", "사용자 에이전트")}}의 고정폭 글씨체입니다.
 

--- a/files/ko/web/html/element/col/index.md
+++ b/files/ko/web/html/element/col/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/col
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<col>` 요소**는 표의 열을 나타내며, 열에 속하는 칸에 공통된 의미를 부여할 때 사용합니다. {{htmlelement("colgroup")}} 안에서 찾을 수 있습니다.
 

--- a/files/ko/web/html/element/colgroup/index.md
+++ b/files/ko/web/html/element/colgroup/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/colgroup
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<colgroup>` 요소**는 표의 열을 묶는 그룹을 정의합니다.
 

--- a/files/ko/web/html/element/content/index.md
+++ b/files/ko/web/html/element/content/index.md
@@ -105,4 +105,4 @@ If you display this in a web browser it should look like the following.
 - [Web Components](/ko/docs/Web/Web_Components)
 - {{HTMLElement("shadow")}}, {{HTMLElement("slot")}}, {{HTMLElement("template")}}, {{HTMLElement("element")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/ko/web/html/element/data/index.md
+++ b/files/ko/web/html/element/data/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/data
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<data>` 요소**는 주어진 콘텐츠를 기계가 읽을 수 있는 해석본과 연결합니다. 콘텐츠가 시간 혹은 날짜 관련 정보라면 대신 {{htmlelement("time")}} 요소를 사용하세요.
 

--- a/files/ko/web/html/element/datalist/index.md
+++ b/files/ko/web/html/element/datalist/index.md
@@ -10,7 +10,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/datalist
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<datalist>` 요소**는 다른 컨트롤에서 고를 수 있는 가능한, 혹은 추천하는 선택지를 나타내는 {{htmlelement("option")}} 요소 여럿을 담습니다.
 

--- a/files/ko/web/html/element/dd/index.md
+++ b/files/ko/web/html/element/dd/index.md
@@ -10,7 +10,7 @@ tags:
   - 요소
 translation_of: Web/HTML/Element/dd
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<dd>` 요소**는 정의 목록 요소({{HTMLElement("dl")}})에서 앞선 용어({{htmlelement("dt")}})에 대한 설명, 정의, 또는 값을 제공합니다.
 

--- a/files/ko/web/html/element/del/index.md
+++ b/files/ko/web/html/element/del/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/del
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<del>` 요소**는 문서에서 제거된 텍스트의 범위를 나타냅니다. 문서나 소스 코드의 변경점 추적 등에 사용할 수 있습니다. {{htmlelement("ins")}} 요소를 추가된 텍스트의 범위를 나타낼 수 있습니다.
 

--- a/files/ko/web/html/element/details/index.md
+++ b/files/ko/web/html/element/details/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/details
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<details>` 요소**는 "열림" 상태일 때만 내부 정보를 보여주는 정보 공개 위젯을 생성합니다. 요약이나 레이블은 {{htmlelement("summary")}} 요소를 통해 제공할 수 있습니다.
 

--- a/files/ko/web/html/element/dfn/index.md
+++ b/files/ko/web/html/element/dfn/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/dfn
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<dfn>` 요소**는 현재 맥락이나 문장에서 정의하고 있는 용어를 나타냅니다. `<dfn>`에서 가장 가까운 {{htmlelement("p")}}, {{htmlelement("dt")}}/{{htmlelement("dd")}} 쌍, {{htmlelement("section")}} 조상 요소를 용어 정의로 간주합니다.
 

--- a/files/ko/web/html/element/dialog/index.md
+++ b/files/ko/web/html/element/dialog/index.md
@@ -11,7 +11,7 @@ tags:
   - 대화 상자
 translation_of: Web/HTML/Element/dialog
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<dialog>` 요소**는 닫을 수 있는 경고, 검사기, 창 등 대화 상자 및 기타 다른 상호작용 가능한 컴포넌트를 나타냅니다.
 

--- a/files/ko/web/html/element/div/index.md
+++ b/files/ko/web/html/element/div/index.md
@@ -11,7 +11,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/div
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<div>` 요소**는 플로우 콘텐츠를 위한 통용 컨테이너입니다. {{glossary("CSS")}}로 꾸미기 전에는 콘텐츠나 레이아웃에 어떤 영향도 주지 않습니다.
 

--- a/files/ko/web/html/element/dl/index.md
+++ b/files/ko/web/html/element/dl/index.md
@@ -11,7 +11,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/dl
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<dl>` 요소**는 설명 목록을 나타냅니다. `<dl>`은 {{htmlelement("dt")}}로 표기한 용어와 {{htmlelement("dd")}} 요소로 표기한 설명 그룹의 목록을 감싸서 설명 목록을 생성합니다. 주로 용어사전 구현이나 메타데이터(키-값 쌍 목록)를 표시할 때 사용합니다.
 

--- a/files/ko/web/html/element/dt/index.md
+++ b/files/ko/web/html/element/dt/index.md
@@ -8,7 +8,7 @@ tags:
   - Reference
 translation_of: Web/HTML/Element/dt
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<dt>` 요소**는 설명 혹은 정의 리스트에서 용어를 나타냅니다. {{htmlelement("dl")}} 요소 안에 위치해야 합니다. 보통 {{htmlelement("dd")}} 요소가 뒤따르지만, 여러 개의 \<dt> 요소를 연속해 배치하면 바로 다음 {{htmlelement("dd")}} 요소로 한꺼번에 서술할 수 있습니다.
 

--- a/files/ko/web/html/element/em/index.md
+++ b/files/ko/web/html/element/em/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/em
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<em>` 요소**는 텍스트의 강세를 나타냅니다. `<em>` 요소를 중첩하면 더 큰 강세를 뜻하게 됩니다.
 

--- a/files/ko/web/html/element/embed/index.md
+++ b/files/ko/web/html/element/embed/index.md
@@ -10,7 +10,7 @@ tags:
   - 웹
 translation_of: Web/HTML/Element/embed
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<embed>` 요소**는 외부 어플리케이션이나 대화형 컨텐츠와의 통합점을 나타냅니다.
 

--- a/files/ko/web/html/element/fieldset/index.md
+++ b/files/ko/web/html/element/fieldset/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/fieldset
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<fieldset>` 요소**는 웹 양식의 여러 컨트롤과 레이블({{htmlelement("label")}})을 묶을 때 사용합니다.
 

--- a/files/ko/web/html/element/figcaption/index.md
+++ b/files/ko/web/html/element/figcaption/index.md
@@ -8,7 +8,7 @@ tags:
   - Reference
 translation_of: Web/HTML/Element/figcaption
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<figcaption>` 요소는** 부모 {{HTMLElement("figure")}} 요소가 포함하는 다른 콘텐츠에 대한 설명 혹은 범례를 나타냅니다.
 

--- a/files/ko/web/html/element/figure/index.md
+++ b/files/ko/web/html/element/figure/index.md
@@ -8,7 +8,7 @@ tags:
   - Reference
 translation_of: Web/HTML/Element/figure
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<figure>` 요소**는 독립적인 콘텐츠를 표현합니다. {{htmlelement("figcaption")}} 요소를 사용해 설명을 붙일 수 있습니다. 피규어, 설명, 콘텐츠는 하나의 단위로 참조됩니다.
 

--- a/files/ko/web/html/element/font/index.md
+++ b/files/ko/web/html/element/font/index.md
@@ -37,4 +37,4 @@ This element implements the {{domxref("HTMLFontElement")}} interface.
 
 {{Compat("html.elements.font")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/ko/web/html/element/footer/index.md
+++ b/files/ko/web/html/element/footer/index.md
@@ -8,7 +8,7 @@ tags:
   - Reference
 translation_of: Web/HTML/Element/footer
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<footer>` 요소**는 가장 가까운 [구획 콘텐츠](/ko/docs/Web/HTML/HTML5_문서의_섹션과_윤곽)나 [구획 루트](/ko/docs/Web/HTML/HTML5_문서의_섹션과_윤곽)의 푸터를 나타냅니다. 푸터는 일반적으로 구획의 작성자, 저작권 정보, 관련 문서 등의 내용을 담습니다.
 

--- a/files/ko/web/html/element/form/index.md
+++ b/files/ko/web/html/element/form/index.md
@@ -10,7 +10,7 @@ tags:
   - 양식
 translation_of: Web/HTML/Element/form
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<form>` 요소**는 정보를 제출하기 위한 대화형 컨트롤을 포함하는 문서 구획을 나타냅니다.
 

--- a/files/ko/web/html/element/frame/index.md
+++ b/files/ko/web/html/element/frame/index.md
@@ -49,4 +49,4 @@ translation_of: Web/HTML/Element/frame
 - {{HTMLElement("frameset")}}
 - {{HTMLElement("iframe")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/ko/web/html/element/frameset/index.md
+++ b/files/ko/web/html/element/frameset/index.md
@@ -34,4 +34,4 @@ translation_of: Web/HTML/Element/frameset
 - {{HTMLElement("frame")}}
 - {{HTMLElement("iframe")}}
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/ko/web/html/element/head/index.md
+++ b/files/ko/web/html/element/head/index.md
@@ -11,7 +11,7 @@ tags:
   - 요소
 translation_of: Web/HTML/Element/head
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<head>` 요소**는 기계가 식별할 수 있는 문서 정보(메타데이터)를 담습니다. 정보로는 문서가 사용할 [제목](/ko/docs/Web/HTML/Element/title), [스크립트](/ko/docs/Web/HTML/Element/script), [스타일 시트](/ko/docs/Web/HTML/Element/style) 등이 있습니다.
 

--- a/files/ko/web/html/element/header/index.md
+++ b/files/ko/web/html/element/header/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/header
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<header>` 요소**는 소개 및 탐색에 도움을 주는 콘텐츠를 나타냅니다. 제목, 로고, 검색 폼, 작성자 이름 등의 요소도 포함할 수 있습니다.
 

--- a/files/ko/web/html/element/heading_elements/index.md
+++ b/files/ko/web/html/element/heading_elements/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/Heading_Elements
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<h1>`–`<h6>` 요소**는 6단계의 구획 제목을 나타냅니다. 구획 단계는 `<h1>`이 가장 높고 `<h6>`은 가장 낮습니다.
 

--- a/files/ko/web/html/element/hgroup/index.md
+++ b/files/ko/web/html/element/hgroup/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/hgroup
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<hgroup>` 요소**는 문서 구획의 다단계 제목을 나타냅니다. 다수의 `{{htmlelement("Heading_Elements", "&lt;h1&gt;-&lt;h6&gt;")}}` 요소를 묶을 때 사용합니다.
 

--- a/files/ko/web/html/element/hr/index.md
+++ b/files/ko/web/html/element/hr/index.md
@@ -8,7 +8,7 @@ tags:
   - Reference
 translation_of: Web/HTML/Element/hr
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<hr>` 요소**는 이야기 장면 전환, 구획 내 주제 변경 등, 문단 레벨 요소에서 주제의 분리를 나타냅니다.
 

--- a/files/ko/web/html/element/html/index.md
+++ b/files/ko/web/html/element/html/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/html
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<html>` 요소**는 HTML 문서의 루트(최상단 요소)를 나타내며, "루트 요소"라고도 부릅니다. 모든 다른 요소는 `<html>` 요소의 후손이어야 합니다.
 

--- a/files/ko/web/html/element/i/index.md
+++ b/files/ko/web/html/element/i/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/i
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<i>` 요소**는 텍스트에서 어떤 이유로 주위와 구분해야 하는 부분을 나타냅니다. 기술 용어, 외국어 구절, 등장인물의 생각 등을 예시로 들 수 있습니다. 보통 기울임꼴로 표시합니다.
 

--- a/files/ko/web/html/element/iframe/index.md
+++ b/files/ko/web/html/element/iframe/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/iframe
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<iframe>` 요소**는 중첩 {{glossary("browsing context", "브라우징 맥락")}}을 나타내는 요소로, 현재 문서 안에 다른 HTML 페이지를 삽입합니다.
 

--- a/files/ko/web/html/element/img/index.md
+++ b/files/ko/web/html/element/img/index.md
@@ -13,7 +13,7 @@ tags:
 translation_of: Web/HTML/Element/img
 browser-compat: html.elements.img
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<img>` 요소**는 문서에 이미지를 넣습니다.
 

--- a/files/ko/web/html/element/input/button/index.md
+++ b/files/ko/web/html/element/input/button/index.md
@@ -10,7 +10,7 @@ tags:
   - Input Type
 translation_of: Web/HTML/Element/input/button
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **`button`** 유형의 {{htmlelement("input")}} 요소는 단순한 푸시 버튼으로 렌더링 됩니다. 이벤트 처리기(주로 {{event("click")}} 이벤트)를 부착하면, 사용자 지정 기능을 웹 페이지 어느 곳에나 제공할 수 있습니다.
 

--- a/files/ko/web/html/element/input/date/index.md
+++ b/files/ko/web/html/element/input/date/index.md
@@ -11,7 +11,7 @@ tags:
   - Reference
 translation_of: Web/HTML/Element/input/date
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **`date`** 유형의 {{HTMLElement("input")}} 요소는 유효성 검증을 포함하는 텍스트 상자 또는 특별한 날짜 선택 인터페이스를 사용해 날짜를 입력할 수 있는 입력 칸을 생성합니다.
 

--- a/files/ko/web/html/element/input/file/index.md
+++ b/files/ko/web/html/element/input/file/index.md
@@ -9,7 +9,7 @@ tags:
   - 파일
 translation_of: Web/HTML/Element/input/file
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **`file`** 유형의 {{htmlelement("input")}} 요소에는 저장 장치의 파일을 하나 혹은 여러 개 선택할 수 있습니다. 그 후, [양식을 제출](/ko/docs/Learn/HTML/Forms)해 서버로 전송하거나, [File API](/ko/docs/Web/API/File/Using_files_from_web_applications)를 사용한 JavaScript 코드로 조작할 수 있습니다.
 

--- a/files/ko/web/html/element/input/index.md
+++ b/files/ko/web/html/element/input/index.md
@@ -11,7 +11,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/input
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<input>` 요소**는 웹 기반 양식에서 사용자의 데이터를 받을 수 있는 대화형 컨트롤을 생성합니다. {{glossary("user agent", "사용자 에이전트")}}에 따라서 다양한 종류의 입력 데이터 유형과 컨트롤 위젯이 존재합니다. 입력 유형과 특성의 다양한 조합 가능성으로 인해, `<input>` 요소는 HTML에서 제일 강력하고 복잡한 요소 중 하나입니다.
 

--- a/files/ko/web/html/element/input/radio/index.md
+++ b/files/ko/web/html/element/input/radio/index.md
@@ -15,7 +15,7 @@ tags:
   - 라디오 버튼
 translation_of: Web/HTML/Element/input/radio
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **`radio`** 유형의 {{htmlelement("input")}} 요소는 보통 서로 관련된 옵션을 나타내는 라디오 버튼 콜렉션, **라디오 그룹**에 사용합니다. 임의의 그룹 내에서는 동시에 하나의 라디오 버튼만 선택할 수 있습니다. 라디오 버튼은 흔히 원형으로 그려지며, 선택한 경우 속을 채우거나 강조 표시를 합니다.
 

--- a/files/ko/web/html/element/ins/index.md
+++ b/files/ko/web/html/element/ins/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/ins
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<ins>` 요소**는 문서에 추가된 텍스트의 범위를 나타냅니다. {{htmlelement("del")}} 요소를 사용하면 삭제된 텍스트의 범위를 나타낼 수 있습니다.
 

--- a/files/ko/web/html/element/kbd/index.md
+++ b/files/ko/web/html/element/kbd/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/kbd
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<kbd>` 요소**는 키보드 입력, 음성 입력 등 임의의 장치를 사용한 사용자의 입력을 나타냅니다. 관례에 따라 {{glossary("user agent", "사용자 에이전트")}}의 고정폭 글꼴로 표시하지만, HTML 표준은 그런 점을 강제하지 않습니다.
 

--- a/files/ko/web/html/element/label/index.md
+++ b/files/ko/web/html/element/label/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/label
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<label>` 요소**는 사용자 인터페이스 항목의 설명을 나타냅니다.
 

--- a/files/ko/web/html/element/legend/index.md
+++ b/files/ko/web/html/element/legend/index.md
@@ -10,7 +10,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/legend
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<legend>` 요소**는 부모 {{HTMLElement("fieldset")}} 콘텐츠의 설명을 나타냅니다.
 

--- a/files/ko/web/html/element/li/index.md
+++ b/files/ko/web/html/element/li/index.md
@@ -8,7 +8,7 @@ tags:
   - Reference
 translation_of: Web/HTML/Element/li
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<li>` 요소**는 목록의 항목을 나타냅니다. 반드시 정렬 목록({{htmlelement("ol")}}), 비정렬 목록({{htmlelement("ul")}}, 혹은 메뉴({{htmlelement("menu")}}) 안에 위치해야 합니다. 메뉴와 비정렬 목록에서는 보통 불릿으로 항목을 나타내고, 정렬 목록에서는 숫자나 문자를 사용한 오름차순 카운터로 나타냅니다.
 

--- a/files/ko/web/html/element/link/index.md
+++ b/files/ko/web/html/element/link/index.md
@@ -13,7 +13,7 @@ tags:
   - 파비콘
 translation_of: Web/HTML/Element/link
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<link>`** 요소는 현재 문서와 외부 리소스의 관계를 명시합니다. `<link>`는 {{glossary("CSS", "스타일 시트")}}를 연결할 때 제일 많이 사용하지만, 사이트 아이콘("파비콘"과 홈 화면 아이콘) 연결 등 여러가지로 쓰일 수 있습니다.
 

--- a/files/ko/web/html/element/main/index.md
+++ b/files/ko/web/html/element/main/index.md
@@ -9,7 +9,7 @@ tags:
   - Reference
 translation_of: Web/HTML/Element/main
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<main>` 요소**는 문서 {{HTMLElement("body")}}의 주요 콘텐츠를 나타냅니다. 주요 콘텐츠 영역은 문서의 핵심 주제나 앱의 핵심 기능에 직접적으로 연결됐거나 확장하는 콘텐츠로 이루어집니다.
 

--- a/files/ko/web/html/element/map/index.md
+++ b/files/ko/web/html/element/map/index.md
@@ -10,7 +10,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/map
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<map>` 요소**는 {{htmlelement("area")}} 요소와 함께 이미지 맵(클릭 가능한 링크 영역)을 정의할 때 사용합니다.
 

--- a/files/ko/web/html/element/mark/index.md
+++ b/files/ko/web/html/element/mark/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/mark
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<mark>` 요소**는 현재 맥락에 관련이 깊거나 중요해 표시 또는 하이라이트한 부분을 나타냅니다.
 

--- a/files/ko/web/html/element/menu/index.md
+++ b/files/ko/web/html/element/menu/index.md
@@ -3,7 +3,7 @@ title: <menu>
 slug: Web/HTML/Element/menu
 translation_of: Web/HTML/Element/menu
 ---
-{{HTMLRef}}{{SeeCompatTable}}
+{{HTMLSidebar}}{{SeeCompatTable}}
 
 **HTML `<menu>` 요소**는 사용자가 수행하거나 하는 명령 묶음을 말합니다. 이것은 스크린 위에 나오는 목록 메뉴와 눌려진 버튼 아래에 나오는 것과 같은 맥락 메뉴를 포함합니다.
 

--- a/files/ko/web/html/element/meta/index.md
+++ b/files/ko/web/html/element/meta/index.md
@@ -10,7 +10,7 @@ tags:
   - metadata
 translation_of: Web/HTML/Element/meta
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<meta>` 요소**는 {{HTMLElement("base")}}, {{HTMLElement("link")}}, {{HTMLElement("script")}}, {{HTMLElement("style")}}, {{HTMLElement("title")}}과 같은 다른 메타관련 요소로 나타낼 수 없는 {{glossary("Metadata", "메타데이터")}}를 나타냅니다.
 

--- a/files/ko/web/html/element/meta/name/index.md
+++ b/files/ko/web/html/element/meta/name/index.md
@@ -10,7 +10,7 @@ tags:
   - 메타데이터
 translation_of: Web/HTML/Element/meta/name
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 {{htmlelement("meta")}} 요소는 {{htmlattrxref("name", "meta")}} 특성을 메타데이터 이름으로, {{htmlattrxref("content", "meta")}} 특성을 값으로 하여 문서 메타데이터를 이름-값 쌍의 형태로 제공할 때 사용할 수 있습니다.
 

--- a/files/ko/web/html/element/meter/index.md
+++ b/files/ko/web/html/element/meter/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/meter
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<meter>` 요소**는 특정 범위 내에서의 스칼라 값, 또는 백분율 값을 나타냅니다.
 

--- a/files/ko/web/html/element/nav/index.md
+++ b/files/ko/web/html/element/nav/index.md
@@ -10,7 +10,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/nav
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<nav>` 요소**는 문서의 부분 중 현재 페이지 내, 또는 다른 페이지로의 링크를 보여주는 구획을 나타냅니다. 자주 쓰이는 예제는 메뉴, 목차, 색인입니다.
 

--- a/files/ko/web/html/element/noscript/index.md
+++ b/files/ko/web/html/element/noscript/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/noscript
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<noscript>` 요소**는 페이지의 스크립트 유형을 지원하지 않거나, 브라우저가 스크립트를 비활성화한 경우 보여줄 HTML 구획을 정의합니다.
 

--- a/files/ko/web/html/element/object/index.md
+++ b/files/ko/web/html/element/object/index.md
@@ -8,7 +8,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/object
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<object>` 요소**는 이미지나, 중첩된 브라우저 컨텍스트, 플러그인에 의해 다뤄질수 있는 리소스와 같은 외부 리소스를 나타냅니다.
 

--- a/files/ko/web/html/element/ol/index.md
+++ b/files/ko/web/html/element/ol/index.md
@@ -9,7 +9,7 @@ tags:
   - Reference
 translation_of: Web/HTML/Element/ol
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<ol>` 요소**는 정렬된 목록을 나타냅니다. 보통 숫자 목록으로 표현합니다.
 

--- a/files/ko/web/html/element/optgroup/index.md
+++ b/files/ko/web/html/element/optgroup/index.md
@@ -10,7 +10,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/optgroup
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<optgroup>` 요소**는 {{HTMLElement("select")}} 요소의 옵션을 묶을 수 있습니다.
 

--- a/files/ko/web/html/element/option/index.md
+++ b/files/ko/web/html/element/option/index.md
@@ -9,7 +9,7 @@ tags:
   - Reference
 translation_of: Web/HTML/Element/option
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<option>` 요소**는 {{HTMLElement("select")}}, {{HTMLElement("optgroup")}}, {{HTMLElement("datalist")}} 요소의 항목을 정의합니다. 그러므로, `<option>`을 사용해 팝업 메뉴 등 목록에서 하나의 항목을 나타낼 수 있습니다.
 

--- a/files/ko/web/html/element/output/index.md
+++ b/files/ko/web/html/element/output/index.md
@@ -10,7 +10,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/output
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<output>` 요소**는 웹 사이트나 앱에서 계산이나 사용자 행동의 결과를 삽입할 수 있는 컨테이너 요소입니다.
 

--- a/files/ko/web/html/element/p/index.md
+++ b/files/ko/web/html/element/p/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/p
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<p>` 요소**는 하나의 문단을 나타냅니다. 시각적인 매체에서, 문단은 보통 인접 블록과의 여백과 첫 줄의 들여쓰기로 구분하지만, HTML에서 문단은 이미지나 입력 폼 등 서로 관련있는 콘텐츠 무엇이나 될 수 있습니다.
 

--- a/files/ko/web/html/element/param/index.md
+++ b/files/ko/web/html/element/param/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/param
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<param>` 요소**는 {{HTMLElement("object")}} 요소의 매개변수를 정의합니다.
 

--- a/files/ko/web/html/element/pre/index.md
+++ b/files/ko/web/html/element/pre/index.md
@@ -10,7 +10,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/pre
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<pre>` 요소**는 미리 서식을 지정한 텍스트를 나타내며, HTML에 작성한 내용 그대로 표현합니다. 텍스트는 보통 고정폭 글꼴을 사용해 렌더링하고, 요소 내 공백문자를 그대로 유지합니다.
 

--- a/files/ko/web/html/element/progress/index.md
+++ b/files/ko/web/html/element/progress/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/progress
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<progress>` 요소**는 어느 작업의 완료 정도를 나타내며, 주로 진행 표시줄의 형태를 띕니다.
 

--- a/files/ko/web/html/element/q/index.md
+++ b/files/ko/web/html/element/q/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/q
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<q>`요소**는 둘러싼 텍스트가 짧은 인라인 인용문이라는것을 나타냅니다. 대부분의 브라우저에서는 앞과 뒤에 따옴표를 붙여 표현합니다. `<q>`는 줄 바꿈이 없는 짧은 경우에 적합합니다. 긴 인용문은 {{htmlelement("blockquote")}} 요소를 사용하세요.
 

--- a/files/ko/web/html/element/rb/index.md
+++ b/files/ko/web/html/element/rb/index.md
@@ -11,7 +11,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/rb
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<rb>` 요소**는 {{HTMLElement("ruby")}} 표기의 기반 텍스트 구성요소(루비 주석을 적용하려는 글자)를 나눌 때 사용합니다. 하나의 `<rb>` 요소는 기반 텍스트에서의 최소 단위를 하나 감싸야 합니다.
 

--- a/files/ko/web/html/element/rp/index.md
+++ b/files/ko/web/html/element/rp/index.md
@@ -10,7 +10,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/rp
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<rp>` 요소**는 {{htmlelement("ruby")}} 요소를 사용한 루비 주석을 지원하지 않는 경우 보여줄 괄호를 제공할 때 사용합니다. {{htmlelement("rt")}} 요소를 감싸는 여는 괄호와 닫는 괄호를 각각의 `<rp>` 요소로 나타내야 합니다.
 

--- a/files/ko/web/html/element/rt/index.md
+++ b/files/ko/web/html/element/rt/index.md
@@ -10,7 +10,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/rt
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<rt>` 요소**는 동아시아 문자의 루비 주석에서 발음, 번역 등을 나타내는 텍스트 부분을 지정합니다.
 

--- a/files/ko/web/html/element/rtc/index.md
+++ b/files/ko/web/html/element/rtc/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/rtc
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<rtc>` 요소**는 {{htmlelement("rb")}} 요소가 표시하는 문자의 의미에 대한 주석을 나타냅니다. `<rb>`는 발음({{htmlelement("rt")}})과 의미(`<rtc>`) 둘 다 가질 수 있습니다.
 

--- a/files/ko/web/html/element/ruby/index.md
+++ b/files/ko/web/html/element/ruby/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/ruby
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<ruby>` 요소**는 루비 주석을 나타냅니다. 루비 주석은 동아시아 문자의 발음을 표기할 때 사용합니다.
 

--- a/files/ko/web/html/element/s/index.md
+++ b/files/ko/web/html/element/s/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/s
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<s>` 요소**는 글자에 취소선, 즉 글자를 가로지르는 선을 그립니다. `<s>` 요소를 사용해 이제 관계 없거나 더 이상 정확하지 않은 부분을 나타내세요. 그러나, `<s>`는 문서의 편집 기록을 나타내는 용도로는 적합하지 않습니다. 상황에 따라 {{HTMLElement("del")}}과 {{HTMLElement("ins")}} 요소를 대신 사용하세요.
 

--- a/files/ko/web/html/element/samp/index.md
+++ b/files/ko/web/html/element/samp/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/samp
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<samp>` 요소**는 컴퓨터 프로그램 출력의 예시(혹은 인용문)를 나타냅니다. 보통 브라우저의 기본 고정폭 글씨체(보통 Courier, Lucida Console)를 사용해 렌더링합니다.
 

--- a/files/ko/web/html/element/script/index.md
+++ b/files/ko/web/html/element/script/index.md
@@ -13,7 +13,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/script
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<script>` 요소**는 데이터와 실행 가능한 코드를 문서에 포함할 때 사용하며 보통 JavaScript 코드와 함께 씁니다. [WebGL](/ko/docs/Web/API/WebGL_API)의 GLSL 셰이더 프로그래밍 언어, [JSON](/ko/docs/Glossary/JSON) 등 다른 언어와도 사용할 수 있습니다.
 

--- a/files/ko/web/html/element/section/index.md
+++ b/files/ko/web/html/element/section/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/section
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<section>` 요소**는 HTML 문서의 독립적인 구획을 나타내며, 더 적합한 의미를 가진 요소가 없을 때 사용합니다. 보통 `<section>`은 제목을 포함하지만, 항상 그런 것은 아닙니다.
 

--- a/files/ko/web/html/element/select/index.md
+++ b/files/ko/web/html/element/select/index.md
@@ -10,7 +10,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/select
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<select>` 요소**는 옵션 메뉴를 제공하는 컨트롤을 나타냅니다.
 

--- a/files/ko/web/html/element/slot/index.md
+++ b/files/ko/web/html/element/slot/index.md
@@ -11,7 +11,7 @@ tags:
   - 웹 컴포넌트
 translation_of: Web/HTML/Element/slot
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<slot>` 요소**는 웹 컴포넌트 사용자가 자신만의 마크업으로 채워 별도의 DOM 트리를 생성하고, 컴포넌트와 함께 표현할 수 있는 웹 컴포넌트 내부의 플레이스홀더입니다.
 

--- a/files/ko/web/html/element/small/index.md
+++ b/files/ko/web/html/element/small/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/small
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<small>`** **요소**는 덧붙이는 글이나, 저작권과 법률 표기 등의 작은 텍스트를 나타냅니다. 기본 상태에서 `<small>`은 자신의 콘텐츠를 한 사이즈 작은 글꼴(`small`에서 `x-small` 등)로 표시하지만, 스타일을 적용한 후에도 글씨 크기가 작을 필요는 없습니다.
 

--- a/files/ko/web/html/element/span/index.md
+++ b/files/ko/web/html/element/span/index.md
@@ -10,7 +10,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/span
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<span>` 요소**는 구문 콘텐츠를 위한 통용 인라인 컨테이너로, 본질적으로는 아무것도 나타내지 않습니다. 스타일을 적용하기 위해서, 또는 {{htmlattrxref("lang")}} 등 어떤 특성의 값을 서로 공유하는 요소를 묶을 때 사용할 수 있습니다. 적절한 의미를 가진 다른 요소가 없을 때에만 사용해야 합니다. `<span>`은 {{htmlelement("div")}}와 매우 유사하지만, {{htmlelement("div")}}는 [블록 레벨 요소](/ko/docs/Web/HTML/Block-level_elements)인 반면 `<span>`은 [인라인 요소](/ko/docs/Web/HTML/Inline_elements)입니다.
 

--- a/files/ko/web/html/element/strong/index.md
+++ b/files/ko/web/html/element/strong/index.md
@@ -12,7 +12,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/strong
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<strong>` 요소**는 중대하거나 긴급한 콘텐츠를 나타냅니다. 보통 브라우저는 굵은 글씨로 표시합니다.
 

--- a/files/ko/web/html/element/style/index.md
+++ b/files/ko/web/html/element/style/index.md
@@ -10,7 +10,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/style
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<style>` 요소**는 문서나 문서 일부에 대한 스타일 정보를 포함합니다.
 

--- a/files/ko/web/html/element/sub/index.md
+++ b/files/ko/web/html/element/sub/index.md
@@ -12,7 +12,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/sub
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML** **`<sub>`** 요소는 활자 배치를 아래 첨자로 해야 하는 인라인 텍스트를 지정합니다. 아래 첨자는 보통 더 작은 글씨 크기를 가지고, 기준선을 아래로 내려 렌더링 합니다.
 

--- a/files/ko/web/html/element/summary/index.md
+++ b/files/ko/web/html/element/summary/index.md
@@ -8,7 +8,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/summary
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML 공개 요약 요소** (**`<요약>`**) 요소는 ("상세") 요소의 공개 상자에 대한 요약, 캡션 또는 범례를 지정한다. `<요약>` 요소를 클릭하면 부모 `<상세>` 요소의 상태가 열리거나 닫힌다.
 

--- a/files/ko/web/html/element/sup/index.md
+++ b/files/ko/web/html/element/sup/index.md
@@ -12,7 +12,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/sup
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML** **`<sup>`** 요소는 활자 배치를 위 첨자로 해야 하는 인라인 텍스트를 지정합니다. 위 첨자는 보통 더 작은 글씨 크기를 가지고, 기준선을 위로 올려 렌더링 합니다.
 

--- a/files/ko/web/html/element/table/index.md
+++ b/files/ko/web/html/element/table/index.md
@@ -10,7 +10,7 @@ tags:
   - 표
 translation_of: Web/HTML/Element/table
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<table>` 요소**는 행과 열로 이루어진 표를 나타냅니다.
 

--- a/files/ko/web/html/element/tbody/index.md
+++ b/files/ko/web/html/element/tbody/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/tbody
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML** **`<tbody>`** 요소는 표의 여러 행({{htmlelement("tr")}})을 묶어서 표 본문을 구성합니다.
 

--- a/files/ko/web/html/element/td/index.md
+++ b/files/ko/web/html/element/td/index.md
@@ -7,7 +7,7 @@ tags:
   - Reference
 translation_of: Web/HTML/Element/td
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 _Table cell_ [HTML](/ko/docs/Web/HTML) 요소 (**`<td>`**) 는 데이터를 포함하는 표의 셀을 정의합니다. 이것은 *표 모델*에 참여합니다.
 
@@ -92,4 +92,4 @@ Please see the {{HTMLElement("table")}} page for examples on `<td>`.
 
 - 다른 표 관련 요소들: {{HTMLElement("caption")}}, {{HTMLElement("col")}}, {{HTMLElement("colgroup")}}, {{HTMLElement("table")}}, {{HTMLElement("tbody")}}, {{HTMLElement("tfoot")}}, {{HTMLElement("th")}}, {{HTMLElement("thead")}}, {{HTMLElement("tr")}}.
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/ko/web/html/element/template/index.md
+++ b/files/ko/web/html/element/template/index.md
@@ -15,7 +15,7 @@ tags:
   - 웹 컴포넌트
 translation_of: Web/HTML/Element/template
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<template>` 요소**는 페이지를 불러온 순간 즉시 그려지지는 않지만, 이후 JavaScript를 사용해 인스턴스를 생성할 수 있는 {{glossary("HTML")}} 코드를 담을 방법을 제공합니다.
 

--- a/files/ko/web/html/element/textarea/index.md
+++ b/files/ko/web/html/element/textarea/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/textarea
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<textarea>` 요소**는 멀티라인 일반 텍스트 편집 컨트롤을 나타냅니다.
 

--- a/files/ko/web/html/element/tfoot/index.md
+++ b/files/ko/web/html/element/tfoot/index.md
@@ -10,7 +10,7 @@ tags:
   - Web
 browser-compat: html.elements.tfoot
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 [HTML](/ko/docs/Web/HTML) 요소는 테이블의 열을 요약하는 행들의 집합입니다.
 {{EmbedInteractiveExample("pages/tabbed/tfoot.html","tabbed-taller")}}

--- a/files/ko/web/html/element/th/index.md
+++ b/files/ko/web/html/element/th/index.md
@@ -9,7 +9,7 @@ tags:
   - 표
 translation_of: Web/HTML/Element/th
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 The **HTML `<th>` element** defines a cell as header of a group of table cells. The exact nature of this group is defined by the {{htmlattrxref("scope", "th")}} and {{htmlattrxref("headers", "th")}} attributes.
 

--- a/files/ko/web/html/element/thead/index.md
+++ b/files/ko/web/html/element/thead/index.md
@@ -11,7 +11,7 @@ tags:
 browser-compat: html.elements.thead
 ---
 
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **`<thead>`** [HTML](/ko/docs/Web/HTML) 요소는 테이블의 열의 머리글인 행들의 집합입니다.
 

--- a/files/ko/web/html/element/time/index.md
+++ b/files/ko/web/html/element/time/index.md
@@ -12,7 +12,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/time
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<time>` 요소**는 시간의 특정 지점 또는 구간을 나타냅니다. `datetime` 특성의 값을 지정해 보다 적절한 검색 결과나, 알림 같은 특정 기능을 구현할 때 사용할 수 있습니다.
 

--- a/files/ko/web/html/element/title/index.md
+++ b/files/ko/web/html/element/title/index.md
@@ -14,7 +14,7 @@ tags:
   - 페이지 제목
 translation_of: Web/HTML/Element/title
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<title>` 요소**는 브라우저의 제목 표시줄이나 페이지 탭에 보이는 문서 제목을 정의합니다. 텍스트만 포함할 수 있으며 태그를 포함하더라도 무시합니다.
 

--- a/files/ko/web/html/element/tr/index.md
+++ b/files/ko/web/html/element/tr/index.md
@@ -93,4 +93,4 @@ See {{HTMLElement("table")}} for examples on `<tr>`.
   - the {{cssxref(":nth-child")}} pseudo-class to set the alignment on the cells of the column;
   - the {{cssxref("text-align")}} property to align all cells content on the same character, like '.'.<
 
-{{HTMLRef}}
+{{HTMLSidebar}}

--- a/files/ko/web/html/element/track/index.md
+++ b/files/ko/web/html/element/track/index.md
@@ -13,7 +13,7 @@ tags:
   - 자막
 translation_of: Web/HTML/Element/track
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<track>` 요소**는 미디어 요소({{HTMLElement("audio")}}, {{HTMLElement("video")}})의 자식으로서, 자막 등 시간별 텍스트 트랙(시간 기반 데이터)를 지정할 때 사용합니다. 트랙은 [WebVTT](/ko/docs/Web/API/WebVTT_API)(Web Video Text Tracks, `.vtt` 파일) 또는 [Timed Text Markup Language(TTML)](https://w3c.github.io/ttml2/index.html)형식을 사용해야 합니다.
 

--- a/files/ko/web/html/element/u/index.md
+++ b/files/ko/web/html/element/u/index.md
@@ -12,7 +12,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/u
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<u>` 요소**는 글자로 표현하지 않는 주석을 가진 것으로 렌더링 해야 하는 텍스트를 나타냅니다. 기본값에서는 단순한 밑줄로 표시하지만 CSS를 사용해 바꿀 수 있습니다.
 

--- a/files/ko/web/html/element/ul/index.md
+++ b/files/ko/web/html/element/ul/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/ul
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<ul>` 요소**는 정렬되지 않은 목록을 나타냅니다. 보통 불릿으로 표현합니다.
 

--- a/files/ko/web/html/element/var/index.md
+++ b/files/ko/web/html/element/var/index.md
@@ -12,7 +12,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/var
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTM `<var>` 요소**는 수학 표현 또는 프로그래밍에서 변수의 이름을 나타냅니다. 보통 현재 글씨체의 기울임꼴로 표시하지만, 브라우저마다 다를 수 있습니다.
 

--- a/files/ko/web/html/element/video/index.md
+++ b/files/ko/web/html/element/video/index.md
@@ -13,7 +13,7 @@ tags:
   - 비디오
 translation_of: Web/HTML/Element/video
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<video>` 요소**는 비디오 플레이백을 지원하는 미디어 플레이어를 문서에 삽입합니다. 오디오 콘텐츠에도 사용할 수 있으나, {{htmlelement("audio")}} 요소가 사용자 경험에 좀 더 적합합니다.
 

--- a/files/ko/web/html/element/wbr/index.md
+++ b/files/ko/web/html/element/wbr/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
 translation_of: Web/HTML/Element/wbr
 ---
-{{HTMLRef}}
+{{HTMLSidebar}}
 
 **HTML `<wbr>` 요소**는 현재 요소의 줄 바꿈 규칙을 무시하고 브라우저가 줄을 바꿀 수 있는 위치를 나타냅니다.
 


### PR DESCRIPTION
We are deprecating `HTMLRef` macro. The [mdn/content repo doesn't have it anymore](https://github.com/mdn/content/pull/21997#event-7719645576).

The PR replaces it with `HTMLSidebar` (now this macro has almost all HTML document links [[ref](https://github.com/mdn/content/pull/21956)]).