### PR TITLE
Add techniques for game development [es] #7470

### DIFF
--- a/files/es/games/techniques/index.md
+++ b/files/es/games/techniques/index.md
@@ -1,0 +1,22 @@
+---
+title: Técnicas para el desarrollo de juegos web
+slug: Games/Techniques
+translation_of: Games/Techniques
+---
+
+{{GamesSidebar}}
+
+Esta página muestra las técnicas básicas esenciales para cualquiera que quiera desarrollar juego web usando tecnologías web abiertas.
+
+- [Utilizar scripts asíncronos para asm.js (en-US)](/en-US/docs/Games/Techniques/Async_scripts)
+  - : Especialmente cuando se trabaje en juegos medianos y grandes, los scripts asíncronos son una técnica esencial de la que aprovecharse, para poder compilar JavaScript fuera del hilo principal y que pueda ser almacenado en caché para próximos usos, resultando en una mejora significativa del rendimiento para los usuarios. Este artículo explica cómo.
+- [Mejorando rendimiento inicial](/es/docs/Web/Performance/Optimizing_startup_performance)
+  - : Cómo asegurarse de que un juego se inicia rápidamente, sin dificultad y sin parecer que bloquea el navegador o el dispositivo del usuario.
+- [Utilizar canales de datos peer-to-peer WebRTC](/es/docs/Games/Techniques/WebRTC_data_channels)
+  - : Además de proporcionar soporte para comunicaciones de audio y video, WebRTC permite al desarellador configurar canales de datos peer-to-peer para intercambiar activamente texto o datos binarios entre usuarios. Este artículo explica lo que esto puede significar, y muestra como usar librerías que facilitan el trabajo.
+- [Audio para juegos web (en-US)](/en-US/docs/Games/Techniques/Audio_for_Web_Games)
+  - : El audio es una parte importante de cualquier juego - añade ambiente y feedback para el usuario. El audio basado en web está creciendo rápidamente, pero aún hay muchas diferencias entre navegadores con las que tratar. Este artículo proporciona una guía detallada de cómo implementar audio para juegos web, mirando que funciona actualmente para la mayor cantidad de plataformas posible.
+- [Detección de colisiones en 2D](/es/docs/Games/Techniques/2D_collision_detection)
+  - : Una introducción breve a la detección de colisiones en un juego en 2D.
+- [Mapa de baldosas (Tilemap) (en-US)](/en-US/docs/Games/Techniques/Tilemaps)
+  - : El uso de baldosas (tiles) es una técnica muy popular para contruir el mundo de juego en 2D. Estos artículos proporcionan una introducción al uso de mapas de baldosas y cómo implimentarlos con la API Canvas.

--- a/files/es/games/techniques/index.md
+++ b/files/es/games/techniques/index.md
@@ -2,21 +2,23 @@
 title: Técnicas para el desarrollo de juegos web
 slug: Games/Techniques
 translation_of: Games/Techniques
+l10n:
+  sourceCommit: 048f6b1c75e22103ddb0304d67ee79d6d8a014f0
 ---
 
 {{GamesSidebar}}
 
 Esta página muestra las técnicas básicas esenciales para cualquiera que quiera desarrollar juego web usando tecnologías web abiertas.
 
-- [Utilizar scripts asíncronos para asm.js (en-US)](/en-US/docs/Games/Techniques/Async_scripts)
+- [Utilizar scripts asíncronos para asm.js](/es/docs/Games/Techniques/Async_scripts)
   - : Especialmente cuando se trabaje en juegos medianos y grandes, los scripts asíncronos son una técnica esencial de la que aprovecharse, para poder compilar JavaScript fuera del hilo principal y que pueda ser almacenado en caché para próximos usos, resultando en una mejora significativa del rendimiento para los usuarios. Este artículo explica cómo.
 - [Mejorando rendimiento inicial](/es/docs/Web/Performance/Optimizing_startup_performance)
   - : Cómo asegurarse de que un juego se inicia rápidamente, sin dificultad y sin parecer que bloquea el navegador o el dispositivo del usuario.
 - [Utilizar canales de datos peer-to-peer WebRTC](/es/docs/Games/Techniques/WebRTC_data_channels)
-  - : Además de proporcionar soporte para comunicaciones de audio y video, WebRTC permite al desarellador configurar canales de datos peer-to-peer para intercambiar activamente texto o datos binarios entre usuarios. Este artículo explica lo que esto puede significar, y muestra como usar librerías que facilitan el trabajo.
-- [Audio para juegos web (en-US)](/en-US/docs/Games/Techniques/Audio_for_Web_Games)
-  - : El audio es una parte importante de cualquier juego - añade ambiente y feedback para el usuario. El audio basado en web está creciendo rápidamente, pero aún hay muchas diferencias entre navegadores con las que tratar. Este artículo proporciona una guía detallada de cómo implementar audio para juegos web, mirando que funciona actualmente para la mayor cantidad de plataformas posible.
-- [Detección de colisiones en 2D](/es/docs/Games/Techniques/2D_collision_detection)
+  - :  Además de proporcionar soporte para comunicaciones de audio y video, WebRTC permite al desarrollador configurar canales de datos _peer-to-peer_ para intercambiar activamente texto o datos binarios entre usuarios. Este artículo explica lo que esto puede significar, y muestra como usar librerías que facilitan el trabajo.
+- [Audio para juegos web](/es/docs/Games/Techniques/Audio_for_Web_Games)
+  - : El audio es una parte importante de cualquier juego - añade ambiente y retroalimentación para el usuario. El audio basado en web está creciendo rápidamente, pero aún hay muchas diferencias entre navegadores con las que tratar. Este artículo proporciona una guía detallada de cómo implementar audio para juegos web, mirando que funciona actualmente para la mayor cantidad de plataformas posible.
+  - [Detección de colisiones en 2D](/es/docs/Games/Techniques/2D_collision_detection)
   - : Una introducción breve a la detección de colisiones en un juego en 2D.
-- [Mapa de baldosas (Tilemap) (en-US)](/en-US/docs/Games/Techniques/Tilemaps)
+- [Mapa de baldosas (Tilemap)](/es/docs/Games/Techniques/Tilemaps)
   - : El uso de baldosas (tiles) es una técnica muy popular para contruir el mundo de juego en 2D. Estos artículos proporcionan una introducción al uso de mapas de baldosas y cómo implimentarlos con la API Canvas.


### PR DESCRIPTION
Added index.md for techniques for game development in spanish (`translated-content/files/es/games/techniques`), translated from the English version. 

Fix #7470
