### PR TITLE
remove `{{event}}` macro documation

### DIFF
--- a/files/zh-cn/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
+++ b/files/zh-cn/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
@@ -1,14 +1,13 @@
 ---
 title: 常用的宏
 slug: MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros
-original_slug: MDN/Structures/Macros/Commonly-used_macros
 ---
 
 {{MDNSidebar}}
 
-本页列举了一些 MDN 中的常用宏命令。对于使用这些宏的入门信息，请阅读[使用宏](/zh-CN/docs/MDN/Structures/Macros)这篇文章。
+本页列举了一些 MDN 中的常用宏命令。对于使用这些宏的入门信息，请阅读[使用宏](/zh-CN/docs/MDN/Writing_guidelines/Page_structures/Macros)这篇文章。
 
-还有一些不常用或只在特定内容中适用，以及一些弃用的宏的信息，参见[其它宏](/zh-CN/docs/MDN/Structures/Macros/Other)。
+还有一些不常用或只在特定内容中适用，以及一些弃用的宏的信息，参见[其它宏](/zh-CN/docs/MDN/Writing_guidelines/Page_structures/Macros/Other)。
 
 ## 链接
 
@@ -21,13 +20,13 @@ original_slug: MDN/Structures/Macros/Commonly-used_macros
 [`Glossary`](https://github.com/mdn/yari/blob/main/kumascript/macros/Glossary.ejs) 这个宏可用于创建指向 MDN 中[术语库](/zh-CN/docs/Glossary)内一个具体词条的链接。调用这个宏时，有一个必需的参数和一个可选参数。
 
 1. 术语的名字（比如“HTML”）：`\{{Glossary("HTML")}}` 会指向 {{Glossary("HTML")}}。
-2. 可选参数：使用参数中的文本内容，替代术语的名字显示在页面中：`\{{Glossary("CSS", "层叠样式表")}}` 会生成 {{Glossary("CSS", "层叠样式表")}}。
+2. 可选参数：使用参数中的文本内容，替代术语的名字显示在页面中：`\{{Glossary("CSS", "层叠样式表")}}` 会生成{{Glossary("CSS", "层叠样式表")}}。
 
 ### 链接到 MDN 的参考文档页面
 
-下面列出的宏可链接到 MDN 站内不同技术领域的参考文档，如 Javascript,、CSS、HTML、elements、SVG 等。
+下面列出的宏可链接到 MDN 站内不同技术领域的参考文档，如 Javascript、CSS、HTML 元素、SVG 等。
 
-这些宏都很容易上手，大多数情况下只需一个参数——所涉及的 Web 组件的名字（如标签、对象、方法、属性等的名字）。在[链接到术语库](#链接到术语库)中提到的，可修改实际显示的文本的可选参数，也存在于下面大多数宏中。如果你想了解其他参数，表格中最左列的链接中可以查看相关宏的文档。
+这些宏都很容易上手，大多数情况下只需一个参数——链接的组件的名称。大多数宏也接受第二个可选的、用于修改实际显示的文本的参数（相关的文档可在下方表格中最左列的链接中找到）。
 
 <table class="standard-table">
   <thead>
@@ -91,7 +90,7 @@ original_slug: MDN/Structures/Macros/Commonly-used_macros
       <td>
         <a href="https://github.com/mdn/yari/blob/main/kumascript/macros/httpheader.ejs">HTTPHeader</a>
       </td>
-      <td><a href="/zh-CN/docs/Web/HTTP/Headers">HTTP 消息头</a>（/Web/HTTP/Headers）</td>
+      <td><a href="/zh-CN/docs/Web/HTTP/Headers">HTTP 标头</a>（/Web/HTTP/Headers）</td>
       <td><code>\{{HTTPHeader("ACCEPT")}}</code> 会指向 {{HTTPHeader("ACCEPT")}}。</td>
     </tr>
     <tr>
@@ -108,26 +107,12 @@ original_slug: MDN/Structures/Macros/Commonly-used_macros
       <td><a href="/zh-CN/docs/Web/HTTP/Status">HTTP 响应代码</a>（/Web/HTTP/Status）</td>
       <td><code>\{{HTTPStatus("404")}}</code> 会指向 {{HTTPStatus("404")}}。</td>
     </tr>
-    <tr>
-      <td>
-        <a href="https://github.com/mdn/yari/blob/main/kumascript/macros/event.ejs">Event</a>
-      </td>
-      <td><a href="/zh-CN/docs/Web/Events">事件参考</a>（/Web/Events）</td>
-      <td>
-        <div class="notecard note">
-          <p>
-            <strong>备注：</strong> 因为事件关联在具体的元素下，这个宏不是特别有用。例如想指向 wheel 事件的页面，需要使用
-            <code>\{{DOMxRef("Document.wheel_event")}}</code>：{{DOMxRef("Document.wheel_event")}}
-          </p>
-        </div>
-      </td>
-    </tr>
   </tbody>
 </table>
 
 ### 链接到某个 Bug
 
-- Bugs
+- Bug
 
   - 通过编号，[`bug`](https://github.com/mdn/yari/blob/main/kumascript/macros/bug.ejs) 宏可以指向 bugzilla.mozilla.org 站内相应的 bug，`\{{Bug(123456)}}` 会指向 {{Bug(123456)}}。
   - 类似的，[`WebkitBug`](https://github.com/mdn/yari/blob/main/kumascript/macros/WebkitBug.ejs) 宏同样可以借助编号，指向 WebKit bug 库里对应的 bug。例如，`\{{WebkitBug(31277)}}` 会指向 {{WebkitBug(31277)}}。
@@ -140,8 +125,8 @@ original_slug: MDN/Structures/Macros/Commonly-used_macros
 
 ### 运行实例
 
-- [`EmbedLiveSample`](https://github.com/mdn/yari/blob/main/kumascript/macros/EmbedLiveSample.ejs) 可以在当前页面中嵌入一个代码示例的实际展示效果（使用方法参见[运行实例](/zh-CN/docs/MDN/Structures/Live_samples)）。
-- [`LiveSampleLink`](https://github.com/mdn/yari/blob/main/kumascript/macros/LiveSampleLink.ejs) 创建指向包含页面上代码示例输出的页面的链接，如[运行实例](/zh-CN/docs/MDN/Structures/Live_samples)中所述。
+- [`EmbedLiveSample`](https://github.com/mdn/yari/blob/main/kumascript/macros/EmbedLiveSample.ejs) 可以在当前页面中嵌入一个代码示例的实际展示效果（使用方法参见[运行实例](/zh-CN/docs/MDN/Writing_guidelines/Page_structures/Live_samples)）。
+- [`LiveSampleLink`](https://github.com/mdn/yari/blob/main/kumascript/macros/LiveSampleLink.ejs) 创建指向包含页面上代码示例输出的页面的链接，如[运行实例](/zh-CN/docs/MDN/Writing_guidelines/Page_structures/Live_samples)中所述。
 - [`EmbedGHLiveSample`](https://github.com/mdn/yari/blob/main/kumascript/macros/EmbedGHLiveSample.ejs) 提供了一种新的运行实例编写和使用方式，你可以在 [Github 运行实例](/zh-CN/docs/MDN/Structures/Code_examples#github_live_samples)中了解更多信息。
 
 ## 添加侧边栏

--- a/files/zh-cn/mdn/writing_guidelines/page_structures/macros/other/index.md
+++ b/files/zh-cn/mdn/writing_guidelines/page_structures/macros/other/index.md
@@ -1,12 +1,11 @@
 ---
-title: 其他宏
+title: 其它宏
 slug: MDN/Writing_guidelines/Page_structures/Macros/Other
-original_slug: MDN/Structures/Macros/Other
 ---
 
 {{MDNSidebar}}
 
-与[常用的宏](/zh-CN/docs/MDN/Structures/Macros/Commonly-used_macros)中列出的宏相比，本文中记录的宏很少使用或仅在特定上下文中使用，或者已弃用。
+与[常用的宏](/zh-CN/docs/MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros)中列出的宏相比，本文中记录的宏很少使用或仅在特定上下文中使用，或者已弃用。
 
 ## 特定上下文
 
@@ -23,7 +22,7 @@ original_slug: MDN/Structures/Macros/Other
 - [`ListSubpages`](https://github.com/mdn/yari/blob/main/kumascript/macros/ListSubpages.ejs) 生成指向当前页面所有直接子级的无序列表；用于自动生成文档集的目录。
 - [`LandingPageListSubpages`](https://github.com/mdn/yari/blob/main/kumascript/macros/LandingPageListSubpages.ejs) 输出当前页面所有直接子页面的两列定义列表，其标题为 {{HTMLElement("dt")}}，其 SEO 摘要为 {{HTMLElement("dd")}}。这使得自动生成相当有吸引力的着陆页变得容易。
 - [`APIListAlpha`](https://github.com/mdn/yari/blob/main/kumascript/macros/APIListAlpha.ejs) 构建当前页面的子页面列表，格式为 API 术语列表，按首字母划分。有三个参数。对于第一个参数，如果要包含所有顶级子页面则将其设为 0，如果要包含带有“.”的子页面则将其设为 1。以他们的名字。第二个和第三个让您添加文本以在每个链接中显示为名称的一部分。这可用于为元素链接添加“<”和“>”，或在方法名称列表的末尾添加“()”。
-- [`SubpagesWithSummaries`](https://github.com/mdn/yari/blob/main/kumascript/macros/SubpagesWithSummaries.ejs) 构造当前页面的所有直接子级的定义列表。没有进行其他的格式化。您可以使用 [`LandingPageListSubpages`](https://github.com/mdn/yari/blob/main/kumascript/macros/LandingPageListSubpages.ejs) 获得一个两栏式列表，准备用作多栏式着陆页。
+- [`SubpagesWithSummaries`](https://github.com/mdn/yari/blob/main/kumascript/macros/SubpagesWithSummaries.ejs) 构造当前页面的所有直接子级的定义列表。没有进行其它的格式化。您可以使用 [`LandingPageListSubpages`](https://github.com/mdn/yari/blob/main/kumascript/macros/LandingPageListSubpages.ejs) 获得一个两栏式列表，准备用作多栏式着陆页。
 
 ### 快速链接
 
@@ -33,9 +32,8 @@ original_slug: MDN/Structures/Macros/Other
 
 ## 已弃用的宏
 
-这些宏已被其他做同样事情的方式所取代，不应再使用。如果您在现有文章中发现了它们，请替换它们。
+这些宏已被其它做同样事情的方式所取代，不应再使用。如果您在现有文章中发现了它们，请替换它们。
 
 ### 链接
 
 - [`SectionOnPage`](https://github.com/mdn/yari/blob/main/kumascript/macros/SectionOnPage.ejs) 宏创建一个链接到一个部分的名称和包含该部分的文章的短语。例如，`\{{SectionOnPage("/en-US/docs/Mozilla/Firefox/Releases/21", "Changes for Web developers")}}` 输出以下内容：_{{SectionOnPage("/en-US/docs/Mozilla/Firefox/Releases/21", "Changes for Web developers")}}_。
-- [`Link`](https://github.com/mdn/yari/blob/main/kumascript/macros/Link.ejs) 宏在 MDN 上插入到指定页面的链接，使用页面标题作为要单击的可见字符串，并从页面的 SEO 摘要中提取工具提示。


### PR DESCRIPTION
### Description

remove `{{event}}` macro documation. This macro has been deprecated and we are removing this from l10n-zh (see: #9729 as a part)

