### PR TITLE
fix: add newline after metadata block - ES - Part 1

### DIFF
--- a/files/es/conflicting/learn/javascript/objects/classes_in_javascript/index.md
+++ b/files/es/conflicting/learn/javascript/objects/classes_in_javascript/index.md
@@ -22,6 +22,7 @@ tags:
 translation_of: Learn/JavaScript/Objects/Object-oriented_JS
 original_slug: Learn/JavaScript/Objects/Object-oriented_JS
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Objects/Basics", "Learn/JavaScript/Objects/Object_prototypes", "Learn/JavaScript/Objects")}}
 
 Con lo básico fuera del camino, nos enfocaremos en Javascript Orientado a Objetos (JSOO) — este artículo presenta una descripción básica de la teoría de la Programación Orientada a Objetos (POO), luego explora cómo Javascript emula classes de objetos via funciones constructoras, y cómo crea instancias de objetos.

--- a/files/es/conflicting/mdn/writing_guidelines/index.md
+++ b/files/es/conflicting/mdn/writing_guidelines/index.md
@@ -7,6 +7,7 @@ tags:
 translation_of: MDN/Guidelines
 original_slug: MDN/Guidelines
 ---
+
 {{MDNSidebar}}
 
 Estas guías proveen detalles de cómo debería estar escrita y qué formato debería tener la documentación MDN, así como también cómo deberían ser presentados nuestros códigos de ejemplo y otro contenido. Siguiendo estas guías, puedes asegurarte de que el material que produces es limpio y fácil de usar.

--- a/files/es/conflicting/mdn/writing_guidelines/page_structures/index.md
+++ b/files/es/conflicting/mdn/writing_guidelines/page_structures/index.md
@@ -10,6 +10,7 @@ tags:
 translation_of: MDN/Structures
 original_slug: MDN/Structures
 ---
+
 {{MDNSidebar}}
 
 Throughout MDN, there are various document structures that are used repeatedly, to provide consistent presentation of information in MDN articles. Here are articles describing these structures, so that, as an MDN author, you can recognize, apply, and modify them as appropriate for documents you write, edit, or translate.

--- a/files/es/conflicting/mdn/writing_guidelines/page_structures_479b8c93d0b37a3f2a020112ae60e692/index.md
+++ b/files/es/conflicting/mdn/writing_guidelines/page_structures_479b8c93d0b37a3f2a020112ae60e692/index.md
@@ -5,6 +5,7 @@ slug: >-
 translation_of: MDN/Structures/Live_samples
 original_slug: MDN/Structures/Live_samples
 ---
+
 {{MDNSidebar}}
 
 MDN puede convertir ejemplos de código de los artículos a ejemplos ejecutables que el lector puede ver en acción. Estos ejemplos ejecutables pueden contener HTML, CSS, y JavaScript en cualquier combinación. Ten en cuenta que los ejemplos "ejecutables" _no son interactivos_; sin embargo, aseguran que el output coincida exactamente con el código de ejemplo, porque es generado por este.

--- a/files/es/conflicting/web/accessibility/aria/index.md
+++ b/files/es/conflicting/web/accessibility/aria/index.md
@@ -10,6 +10,7 @@ tags:
 translation_of: Web/Accessibility/ARIA/forms/alerts
 original_slug: Web/Accessibility/ARIA/forms/alerts
 ---
+
 ## El problema
 
 Tienes un formulario — un formulario de contacto — por ejemplo, en el que deseas poner algún control de error accesible. Ejemplos de problemas comunes incluyen direcciones de correo electrónico que no son válidas o un campo de nombre que no contiene al menos un nombre o apellido.

--- a/files/es/conflicting/web/accessibility/aria_64707ba1917a56654679cbe273e2f4ea/index.md
+++ b/files/es/conflicting/web/accessibility/aria_64707ba1917a56654679cbe273e2f4ea/index.md
@@ -8,6 +8,7 @@ tags:
 translation_of: Web/Accessibility/ARIA/forms/Basic_form_hints
 original_slug: Web/Accessibility/ARIA/forms/Basic_form_hints
 ---
+
 Cuando se implementan formularios utilizando elementos relacionados con los formularios HTML tradicionales, es importante proveer etiquetas para los controles y explicitamente asociar una etiqueta con su control. Cuando un usuario de lector de pantalla navega una página, el lector de pantalla describirá los controles del formulario. Sin una asociación directa entre el control y su etiqueta, el lector de pantalla no tiene forma de saber que etiqueta es la correcta para el control.
 
 El ejemplo siguiente muestra un formulario sencillo con etiquetas. Note que cada elemento {{ HTMLElement("input") }} tiene un `id`, y cada elemento {{ HTMLElement("label") }} tiene un atributo `for`, indicando el `id` asociado al {{ HTMLElement("input") }}.

--- a/files/es/conflicting/web/api/canvasrenderingcontext2d/index.md
+++ b/files/es/conflicting/web/api/canvasrenderingcontext2d/index.md
@@ -9,6 +9,7 @@ tags:
 translation_of: Web/API/CanvasImageSource
 original_slug: Web/API/CanvasImageSource
 ---
+
 {{APIRef("Canvas API")}}
 
 El tipo auxiliar **`CanvasImageSource`** representa cualquiera de los siguientes tipos:

--- a/files/es/conflicting/web/api/element/click_event/index.md
+++ b/files/es/conflicting/web/api/element/click_event/index.md
@@ -4,6 +4,7 @@ slug: conflicting/Web/API/Element/click_event
 translation_of: Web/API/GlobalEventHandlers/onclick
 original_slug: Web/API/GlobalEventHandlers/onclick
 ---
+
 {{ ApiRef("HTML DOM") }}
 
 La propiedad **onclick** devuelve el manejador del evento `click` del elemento actual.

--- a/files/es/conflicting/web/api/element/keydown_event/index.md
+++ b/files/es/conflicting/web/api/element/keydown_event/index.md
@@ -4,6 +4,7 @@ slug: conflicting/Web/API/Element/keydown_event
 translation_of: Web/API/GlobalEventHandlers/onkeydown
 original_slug: Web/API/GlobalEventHandlers/onkeydown
 ---
+
 {{ApiRef("HTML DOM")}}
 
 La propiedad **`onkeydown`** devuelve un manejador para el evento `onKeyDown` del elemento actual.

--- a/files/es/conflicting/web/api/element/keyup_event/index.md
+++ b/files/es/conflicting/web/api/element/keyup_event/index.md
@@ -4,6 +4,7 @@ slug: conflicting/Web/API/Element/keyup_event
 translation_of: Web/API/GlobalEventHandlers/onkeyup
 original_slug: Web/API/GlobalEventHandlers/onkeyup
 ---
+
 {{ApiRef("HTML DOM")}}
 
 La propiedad **onkeyup** devuelve un manejador para el evento onKeyUp del elemento actual.

--- a/files/es/conflicting/web/api/element/wheel_event/index.md
+++ b/files/es/conflicting/web/api/element/wheel_event/index.md
@@ -10,6 +10,7 @@ tags:
 translation_of: Web/API/GlobalEventHandlers/onwheel
 original_slug: Web/API/GlobalEventHandlers/onwheel
 ---
+
 {{ ApiRef("DOM") }}
 
 {{ non-standard_header() }}

--- a/files/es/conflicting/web/api/eventtarget/addeventlistener/index.md
+++ b/files/es/conflicting/web/api/eventtarget/addeventlistener/index.md
@@ -4,6 +4,7 @@ slug: conflicting/Web/API/EventTarget/addEventListener
 translation_of: Web/API/EventListener
 original_slug: Web/API/EventListener
 ---
+
 {{APIRef("DOM Events")}}
 
 ## Información General del Método

--- a/files/es/conflicting/web/api/geolocation/getcurrentposition/index.md
+++ b/files/es/conflicting/web/api/geolocation/getcurrentposition/index.md
@@ -9,6 +9,7 @@ translation_of: Web/API/PositionOptions
 original_slug: Web/API/PositionOptions
 browser-compat: api.Geolocation.getCurrentPosition
 ---
+
 {{APIRef("Geolocation API")}}
 
 La interfaz **`PositionOptions`** describe las opciones disponibles cuando invocamos el "backend" de geolocalización. El navegador no crea este objeto directamente: es el script que invoca quien lo crea y usa como un parámetro de {{domxref("Geolocation.getCurrentPosition()")}} y {{domxref("Geolocation.watchPosition()")}}.

--- a/files/es/conflicting/web/api/htmlelement/change_event/index.md
+++ b/files/es/conflicting/web/api/htmlelement/change_event/index.md
@@ -4,6 +4,7 @@ slug: conflicting/Web/API/HTMLElement/change_event
 translation_of: Web/API/GlobalEventHandlers/onchange
 original_slug: Web/API/GlobalEventHandlers/onchange
 ---
+
 {{ ApiRef("HTML DOM") }}
 
 La propiedad `onchange` establece y devuelve el [event handler](/docs/Web/Guide/Events/Event_handlers) para el evento {{event("change")}}.

--- a/files/es/conflicting/web/api/htmlelement/input_event/index.md
+++ b/files/es/conflicting/web/api/htmlelement/input_event/index.md
@@ -4,6 +4,7 @@ slug: conflicting/Web/API/HTMLElement/input_event
 translation_of: Web/API/GlobalEventHandlers/oninput
 original_slug: Web/API/GlobalEventHandlers/oninput
 ---
+
 {{ ApiRef("HTML DOM") }}
 
 Un controlador de eventos para el evento input en la ventana. El evento input es llamado cuando el valor de un elemento {{ HTMLElement("input") }} ha cambiado.

--- a/files/es/conflicting/web/api/window/beforeunload_event/index.md
+++ b/files/es/conflicting/web/api/window/beforeunload_event/index.md
@@ -5,6 +5,7 @@ translation_of: Web/API/WindowEventHandlers/onbeforeunload
 original_slug: Web/API/WindowEventHandlers/onbeforeunload
 browser-compat: api.Window.beforeunload_event
 ---
+
 {{ApiRef}}
 
 ## Introducción

--- a/files/es/conflicting/web/api/window/hashchange_event/index.md
+++ b/files/es/conflicting/web/api/window/hashchange_event/index.md
@@ -11,6 +11,7 @@ tags:
 translation_of: Web/API/WindowEventHandlers/onhashchange
 original_slug: Web/API/WindowEventHandlers/onhashchange
 ---
+
 {{APIRef("HTML DOM")}}
 
 El evento **hashchange** se dispara cuando la almohadilla ha cambiado (ver {{domxref("Window.location", "location.hash")}}).

--- a/files/es/conflicting/web/api/window/load_event/index.md
+++ b/files/es/conflicting/web/api/window/load_event/index.md
@@ -6,6 +6,7 @@ tags:
 translation_of: Web/API/GlobalEventHandlers/onload
 original_slug: Web/API/GlobalEventHandlers/onload
 ---
+
 {{ ApiRef() }}
 
 ### Sumario

--- a/files/es/conflicting/web/css/css_fonts/index.md
+++ b/files/es/conflicting/web/css/css_fonts/index.md
@@ -8,6 +8,7 @@ tags:
 translation_of: Web/HTML/Element/basefont
 original_slug: Web/HTML/Element/basefont
 ---
+
 ### Definición
 
 - **basefont** -_fuente base_ . Permite cambiar algunas propiedades del texto.

--- a/files/es/conflicting/web/css/cursor/index.md
+++ b/files/es/conflicting/web/css/cursor/index.md
@@ -7,6 +7,7 @@ tags:
 translation_of: Web/CSS/CSS_Basic_User_Interface/Using_URL_values_for_the_cursor_property
 original_slug: Web/CSS/CSS_Basic_User_Interface/Using_URL_values_for_the_cursor_property
 ---
+
 [Gecko](/es/Gecko) 1.8 ([Firefox 1.5](/es/Firefox_1.5_para_Desarrolladores), SeaMonkey 1.0) soporta el uso de URLs como valores para la [propiedad cursor](http://www.sidar.org/recur/desdi/traduc/es/css/ui.html#propdef-cursor) (CSS2). Esto nos permite definir la imagen que queremos como puntero del ratón, además podemos usar cualquiera de los formatos gráficos soportados por Gecko.
 
 ### Sintaxis

--- a/files/es/conflicting/web/css/index.md
+++ b/files/es/conflicting/web/css/index.md
@@ -6,6 +6,7 @@ tags:
 translation_of: Web/CSS/Tools
 original_slug: Web/CSS/Tools
 ---
+
 CSS ofrece una serie de características poderosas que puede ser difíciles de usar, o tener un gran número de parámetros, por lo que es muy útil visualizarlos mientras se trabaja en ellos. Esta página ofrece enlaces a una serie de herramientas que le ayudarán a construir sus estilos usando estas caracteristicas.
 
 {{LandingPageListSubpages}}

--- a/files/es/conflicting/web/html/global_attributes/contenteditable/index.md
+++ b/files/es/conflicting/web/html/global_attributes/contenteditable/index.md
@@ -14,6 +14,7 @@ tags:
 translation_of: Web/Guide/HTML/Editable_content
 original_slug: Web/Guide/HTML/Editable_content
 ---
+
 En HTML, cualquier elemento puede ser editable. Con el uso de algunos manejadores de eventos de JavaScript, puedes transformar tu página web en un completo y rápido editor de texto. Este artículo brinda información sobre esta funcionalidad.
 
 ## ¿Cómo funciona?

--- a/files/es/conflicting/web/http/status/404/index.md
+++ b/files/es/conflicting/web/http/status/404/index.md
@@ -9,6 +9,7 @@ tags:
 translation_of: Glossary/404
 original_slug: Glossary/404
 ---
+
 Una respuesta 404 es una respuesta estándar que significa que el {{Glossary("Server", "server")}} no puede encontrar el recursos solicitado.
 
 ## Aprender más

--- a/files/es/conflicting/web/http/status/502/index.md
+++ b/files/es/conflicting/web/http/status/502/index.md
@@ -10,6 +10,7 @@ tags:
 translation_of: Glossary/502
 original_slug: Glossary/502
 ---
+
 Un código código de error {{Glossary("HTTP")}} que significa "Bad Gateway" (Pasarela incorrecta).
 
 Un {{Glossary("Server", "server")}} puede actuar como gateway (pasarela) o proxy entre un cliente (como tu navegador) y otros servidores. Cuando realizas una petición para acceder a una {{Glossary("URL")}}, el gateway (la pasarela) retransmite tu petición al otro servidor."502" significa que ese otro servidor, al que accedemos mediante el gateway o proxy, ha devuelto una respuesta inválida.

--- a/files/es/conflicting/web/javascript/inheritance_and_the_prototype_chain/index.md
+++ b/files/es/conflicting/web/javascript/inheritance_and_the_prototype_chain/index.md
@@ -10,6 +10,7 @@ tags:
 translation_of: Web/JavaScript/Guide/Details_of_the_Object_Model
 original_slug: Web/JavaScript/Guide/Details_of_the_Object_Model
 ---
+
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Working_with_Objects", "Web/JavaScript/Guide/Iterators_and_Generators")}}
 
 JavaScript es un lenguaje orientado a objetos basado en prototipos en lugar de clases. Debido a esta diferencia, puede ser menos evidente cómo JavaScript te permite crear jerarquías de objetos y herencia de propiedades y sus valores. Este capítulo intenta clarificar estos puntos.

--- a/files/es/conflicting/web/javascript/javascript_technologies_overview/index.md
+++ b/files/es/conflicting/web/javascript/javascript_technologies_overview/index.md
@@ -7,6 +7,7 @@ tags:
 translation_of: Web/JavaScript/Language_Resources
 original_slug: Web/JavaScript/Language_Resources
 ---
+
 {{JsSidebar}}
 
 **ECMAScript** es el lenguaje de scripting que forma la base de [JavaScript](/es/docs/JavaScript). ECMAScript está estandarizado por la organización de estándares [ECMA Internacional](http://www.ecma-international.org/) en las especificaciones **ECMA-262 y ECMA-402**. Los siguientes estándares de ECMAScript han sido aprobados o estas siendo trabajados:

--- a/files/es/conflicting/web/javascript/javascript_technologies_overview_0191f05ec18a4ee4d771b548feb0701d/index.md
+++ b/files/es/conflicting/web/javascript/javascript_technologies_overview_0191f05ec18a4ee4d771b548feb0701d/index.md
@@ -5,6 +5,7 @@ slug: >-
 translation_of: Web/JavaScript/Shells
 original_slug: Web/JavaScript/Shells
 ---
+
 {{JsSidebar}}
 
 Un shell(\*) JavaScript te permite probar rápidamente fragmentos de código [JavaScript](/es/docs/Web/JavaScript) si tener que recargar un sitio web. Éstos son extremadamente útiles para desarrollar y depurar código.

--- a/files/es/conflicting/web/javascript/reference/global_objects/array/tostring/index.md
+++ b/files/es/conflicting/web/javascript/reference/global_objects/array/tostring/index.md
@@ -4,6 +4,7 @@ slug: conflicting/Web/JavaScript/Reference/Global_Objects/Array/toString
 translation_of: Web/JavaScript/Reference/Global_Objects/Array/toSource
 original_slug: Web/JavaScript/Reference/Global_Objects/Array/toSource
 ---
+
 {{JSRef}} {{non-standard_header}}
 
 El método **`toSource()`** devuelve un string representando el código fuente de un arreglo.

--- a/files/es/conflicting/web/javascript/reference/global_objects/error/tostring/index.md
+++ b/files/es/conflicting/web/javascript/reference/global_objects/error/tostring/index.md
@@ -9,6 +9,7 @@ tags:
 translation_of: Web/JavaScript/Reference/Global_Objects/Error/toSource
 original_slug: Web/JavaScript/Reference/Global_Objects/Error/toSource
 ---
+
 {{JSRef}} {{non-standard_header}}
 
 El método **`toSource()`** devuelve código que podría evaluar el mismo error.

--- a/files/es/conflicting/web/javascript/reference/global_objects/function/tostring/index.md
+++ b/files/es/conflicting/web/javascript/reference/global_objects/function/tostring/index.md
@@ -4,6 +4,7 @@ slug: conflicting/Web/JavaScript/Reference/Global_Objects/Function/toString
 translation_of: Web/JavaScript/Reference/Global_Objects/Function/toSource
 original_slug: Web/JavaScript/Reference/Global_Objects/Function/toSource
 ---
+
 {{JSRef}} {{non-standard_header}}
 
 El método **`toSource()`** devuelve un string representando el código fuente del objeto.

--- a/files/es/conflicting/web/javascript/reference/global_objects/object/tostring/index.md
+++ b/files/es/conflicting/web/javascript/reference/global_objects/object/tostring/index.md
@@ -4,6 +4,7 @@ slug: conflicting/Web/JavaScript/Reference/Global_Objects/Object/toString
 translation_of: Web/JavaScript/Reference/Global_Objects/Object/toSource
 original_slug: Web/JavaScript/Reference/Global_Objects/Object/toSource
 ---
+
 {{JSRef}} {{non-standard_header}}
 
 El método **`toSource()`** regresa una cadena representando el código fuente del objeto.

--- a/files/es/conflicting/web/javascript/reference/global_objects/string/index.md
+++ b/files/es/conflicting/web/javascript/reference/global_objects/string/index.md
@@ -12,6 +12,7 @@ tags:
 translation_of: Web/API/DOMString
 original_slug: Web/API/DOMString
 ---
+
 {{APIRef("DOM")}}
 
 **`DOMString`** es un String UTF-16. Dado que JavaScript ya usa estos strings, se mapea `DOMString` directamente a {{jsxref("String")}}.

--- a/files/es/conflicting/web/javascript/reference/global_objects/string/tostring/index.md
+++ b/files/es/conflicting/web/javascript/reference/global_objects/string/tostring/index.md
@@ -11,6 +11,7 @@ tags:
 translation_of: Web/JavaScript/Reference/Global_Objects/String/toSource
 original_slug: Web/JavaScript/Reference/Global_Objects/String/toSource
 ---
+
 {{JSRef}} {{non-standard_header}}
 
 El método **`toSource()`** devuelve una cadena que representa el código fuente del objeto.

--- a/files/es/conflicting/webassembly/javascript_interface/index.md
+++ b/files/es/conflicting/webassembly/javascript_interface/index.md
@@ -11,6 +11,7 @@ tags:
 translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly
 ---
+
 {{JSRef}}
 
 El objeto **`WebAssembly`** de JavaScript actua como un namespace para todas las funcionalidades realcionados con [WebAssembly](/es/docs/WebAssembly).

--- a/files/es/games/index.md
+++ b/files/es/games/index.md
@@ -10,6 +10,7 @@ tags:
   - juegos
 translation_of: Games
 ---
+
 {{GamesSidebar}}
 
 ## Introducción de los juegos para la Web

--- a/files/es/games/introduction/index.md
+++ b/files/es/games/introduction/index.md
@@ -8,6 +8,7 @@ tags:
 translation_of: Games/Introduction
 original_slug: Games/Introduccion
 ---
+
 {{GamesSidebar}}
 
 La Web rapidamente se ha convertido en una plataforma viable no solo para crear impresionantes juegos de alta calidad, sino también para distruibuirlos.El rango de juegos que pueden ser creados está a la par tanto de los juegos de escritorio como de SO nativos (Android, iOS). Con tecnologias Web modernas y un navegador reciente es totalmente posible hacer juegos de primera categoria para la Web. Y no estamos hablando sobre simples juegos de cartas o juegos sociales multijugadores que en tiempos anteriores se podian hacer con Flash®. Estamos hablando sobre juegos 3D _shooters_ de accion, RPGs, y más. Gracias a las masivas mejoras de rendimiento en [JavaScript](/en-US/docs/JavaScript) con tecnologia de compilación _just-in-time_ y nuevas APIs, se pueden construir juegos que pueden correr en el navegador (o en dispositivos [HTML5](/en-US/docs/HTML/HTML5) como [Firefox OS](/en-US/docs/Mozilla/Firefox_OS)) sin problemas.

--- a/files/es/games/introduction_to_html5_game_development/index.md
+++ b/files/es/games/introduction_to_html5_game_development/index.md
@@ -9,6 +9,7 @@ tags:
 translation_of: Games/Introduction_to_HTML5_Game_Development_(summary)
 original_slug: Games/Introducción_al_desarrollo_de_juegos_HTML5_(resumen)
 ---
+
 {{GamesSidebar}}
 
 ## Ventajas

--- a/files/es/games/publishing_games/game_distribution/index.md
+++ b/files/es/games/publishing_games/game_distribution/index.md
@@ -15,6 +15,7 @@ tags:
   - juegos
 translation_of: Games/Publishing_games/Game_distribution
 ---
+
 {{GamesSidebar}}
 
 Has seguido un tutorial o dos y creado un juego de HTLM5 — eso es genial. Este artículo cubre todo lo que necesitas saber sobre las formas en que puedes distribuir tu juego recién creado al mundo. Esto incluye alojarlo tu mismo en línea, enviarlo a mercados abiertos, y enviándolo a aplicaciones cerradas como Google Play o iOS App Store.

--- a/files/es/games/publishing_games/game_monetization/index.md
+++ b/files/es/games/publishing_games/game_monetization/index.md
@@ -12,6 +12,7 @@ tags:
 translation_of: Games/Publishing_games/Game_monetization
 original_slug: Games/Publishing_games/Monetización_de_los_juegos
 ---
+
 {{GamesSidebar}}
 
 Cuando empleas tu tiempo en crear un juego, [distribuirlo](/en-US/docs/Games/Techniques/Publishing_games/Game_distribution) y [promocionarlo](/en-US/docs/Games/Techniques/Publishing_games/Game_promotion) deberías considerar ganar un poco de dinero con ello. Si tu trabajo es un esfuerzo serio en tu camino para ser un desarrollador independiente de juegos capaz de ganarse la vida, sigue leyendo y verás cuales son tus opciones. La tecnología es lo suficientemente madura; ahora es cuestión de elegir el enfoque adecuado.

--- a/files/es/games/publishing_games/index.md
+++ b/files/es/games/publishing_games/index.md
@@ -15,6 +15,7 @@ tags:
   - publishing
 translation_of: Games/Publishing_games
 ---
+
 {{GamesSidebar}}
 
 Los juegos desarrollados en HTML5 tienen una gran ventaja sobre los nativos en términos de publicación y distribución: tienen la libertad de distribución, promoción y monetización de su juego en la Web, en lugar de que cada versión esté restringida a una única tienda controlada por una empresa. Pueden, beneficiándose de la web, ser verdaderamente multiplataforma. Esta serie de artículos analiza las opciones que tienes a la hora de publicar y distribuir tu juego, y ganar algo con él mientras esperas que se haga famoso.

--- a/files/es/games/techniques/2d_collision_detection/index.md
+++ b/files/es/games/techniques/2d_collision_detection/index.md
@@ -4,6 +4,7 @@ slug: Games/Techniques/2D_collision_detection
 translation_of: Games/Techniques/2D_collision_detection
 original_slug: Games/Techniques/2D_collision_detection
 ---
+
 {{GamesSidebar}}
 
 Los algoritmos para detectar colisiones en juegos 2D dependen del tipo de formas que pueden colisionar (p. ej., Rectángulo con rectángulo, Rectángulo con círculo, Círculo con círculo). En general, tendrá una forma genérica simple que cubre la entidad conocida como _"hitbox"_, por lo que, aunque la colisión no sea perfecta en píxeles, se verá lo suficientemente bien y tendrá un rendimiento eficiente en varias entidades. Este artículo proporciona una revisión de las técnicas más comunes utilizadas para proporcionar detección de colisiones en juegos 2D.

--- a/files/es/games/techniques/webrtc_data_channels/index.md
+++ b/files/es/games/techniques/webrtc_data_channels/index.md
@@ -3,6 +3,7 @@ title: WebRTC data channels
 slug: Games/Techniques/WebRTC_data_channels
 translation_of: Games/Techniques/WebRTC_data_channels
 ---
+
 {{GamesSidebar}}
 
 {{SeeCompatTable}}

--- a/files/es/games/tools/asm.js/index.md
+++ b/files/es/games/tools/asm.js/index.md
@@ -7,6 +7,7 @@ tags:
 translation_of: Games/Tools/asm.js
 original_slug: Games/Herramients/asm.js
 ---
+
 {{GamesSidebar}}
 
 [Asm.js](http://asmjs.org/) es un subconjunto de JavaScript que es altamente optimizable. Este artículo analiza exactamente lo que está permitido en el subconjunto asm.js, las mejoras que confiere, donde y cómo puedo utilizarlo, y otros recursos y ejemplos.

--- a/files/es/games/tools/index.md
+++ b/files/es/games/tools/index.md
@@ -9,6 +9,7 @@ tags:
 translation_of: Games/Tools
 original_slug: Games/Herramients
 ---
+
 {{GamesSidebar}}
 
 En esta pagina puedes encontrar enlaces a nuestros articulos de desarrollo de juegos, que enventualmente apuenta a cubrir frameworks, compiladores y herramientas de depuracion.

--- a/files/es/games/tutorials/2d_breakout_game_phaser/animations_and_tweens/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/animations_and_tweens/index.md
@@ -13,6 +13,7 @@ tags:
   - juegos
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Animations_and_tweens
 ---
+
 {{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Extra_lives", "Games/Workflows/2D_Breakout_game_Phaser/Buttons")}}

--- a/files/es/games/tutorials/2d_breakout_game_phaser/bounce_off_the_walls/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/bounce_off_the_walls/index.md
@@ -13,6 +13,7 @@ tags:
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Bounce_off_the_walls
 original_slug: Games/Tutorials/2D_breakout_game_Phaser/Rebotar_en_las_paredes
 ---
+
 {{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Physics", "Games/Workflows/2D_Breakout_game_Phaser/Player_paddle_and_controls")}}

--- a/files/es/games/tutorials/2d_breakout_game_phaser/buttons/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/buttons/index.md
@@ -13,6 +13,7 @@ tags:
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Buttons
 original_slug: Games/Tutorials/2D_breakout_game_Phaser/Botones
 ---
+
 {{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Animations_and_tweens", "Games/Workflows/2D_Breakout_game_Phaser/Randomizing_gameplay")}}

--- a/files/es/games/tutorials/2d_breakout_game_phaser/collision_detection/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/collision_detection/index.md
@@ -12,6 +12,7 @@ tags:
   - juegos
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Collision_detection
 ---
+
 {{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Build_the_brick_field", "Games/Workflows/2D_Breakout_game_Phaser/The_score")}}

--- a/files/es/games/tutorials/2d_breakout_game_phaser/extra_lives/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/extra_lives/index.md
@@ -13,6 +13,7 @@ tags:
   - juegos
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Extra_lives
 ---
+
 {{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Win_the_game", "Games/Workflows/2D_Breakout_game_Phaser/Animations_and_tweens")}}

--- a/files/es/games/tutorials/2d_breakout_game_phaser/game_over/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/game_over/index.md
@@ -12,6 +12,7 @@ tags:
   - juego terminado
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Game_over
 ---
+
 {{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Player_paddle_and_controls", "Games/Workflows/2D_Breakout_game_Phaser/Build_the_brick_field")}}

--- a/files/es/games/tutorials/2d_breakout_game_phaser/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/index.md
@@ -13,6 +13,7 @@ tags:
   - Tutorial
 translation_of: Games/Tutorials/2D_breakout_game_Phaser
 ---
+
 {{GamesSidebar}}
 
 {{Next("Games/Workflows/2D_Breakout_game_Phaser/Initialize_the_framework")}}

--- a/files/es/games/tutorials/2d_breakout_game_phaser/initialize_the_framework/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/initialize_the_framework/index.md
@@ -3,6 +3,7 @@ title: Inicializar el framework
 slug: Games/Tutorials/2D_breakout_game_Phaser/Initialize_the_framework
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Initialize_the_framework
 ---
+
 {{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser", "Games/Workflows/2D_Breakout_game_Phaser/Scaling")}}

--- a/files/es/games/tutorials/2d_breakout_game_phaser/move_the_ball/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/move_the_ball/index.md
@@ -12,6 +12,7 @@ tags:
   - juegos
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Move_the_ball
 ---
+
 {{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Load_the_assets_and_print_them_on_screen", "Games/Workflows/2D_Breakout_game_Phaser/Physics")}}

--- a/files/es/games/tutorials/2d_breakout_game_phaser/scaling/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/scaling/index.md
@@ -3,6 +3,7 @@ title: Scaling
 slug: Games/Tutorials/2D_breakout_game_Phaser/Scaling
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Scaling
 ---
+
 {{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Initialize_the_framework", "Games/Workflows/2D_Breakout_game_Phaser/Load_the_assets_and_print_them_on_screen")}}

--- a/files/es/games/tutorials/2d_breakout_game_phaser/the_score/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/the_score/index.md
@@ -12,6 +12,7 @@ tags:
   - juegos
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/The_score
 ---
+
 {{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/Collision_detection", "Games/Workflows/2D_Breakout_game_Phaser/Win_the_game")}}

--- a/files/es/games/tutorials/2d_breakout_game_phaser/win_the_game/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/win_the_game/index.md
@@ -11,6 +11,7 @@ tags:
   - ganando
 translation_of: Games/Tutorials/2D_breakout_game_Phaser/Win_the_game
 ---
+
 {{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/2D_Breakout_game_Phaser/The_score", "Games/Workflows/2D_Breakout_game_Phaser/Extra_lives")}}

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/bounce_off_the_walls/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/bounce_off_the_walls/index.md
@@ -4,6 +4,7 @@ slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Bounce_off_the_walls
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Bounce_off_the_walls
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Bounce_off_the_walls
 ---
+
 {{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Mueve_la_bola", "Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Control_pala_y_teclado")}}

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.md
@@ -4,6 +4,7 @@ slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Build_the_brick_field
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Build_the_brick_field
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Construye_grupo_bloques
 ---
+
 {{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Fin_del_juego", "Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Deteccion_colisiones")}}

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.md
@@ -4,6 +4,7 @@ slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Collision_detection
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Collision_detection
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Deteccion_colisiones
 ---
+
 {{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Construye_grupo_bloques", "Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Track_the_score_and_win")}}

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/create_the_canvas_and_draw_on_it/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/create_the_canvas_and_draw_on_it/index.md
@@ -7,6 +7,7 @@ translation_of: >-
 original_slug: >-
   Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Create_the_Canvas_and_draw_on_it
 ---
+
 {{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro", "Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Mueve_la_bola")}}

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.md
@@ -4,6 +4,7 @@ slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Finishing_up
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Finishing_up
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Terminando
 ---
+
 {{GamesSidebar}}
 
 {{Previous("Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Controles_raton")}}

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/game_over/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/game_over/index.md
@@ -10,6 +10,7 @@ tags:
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Game_over
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Fin_del_juego
 ---
+
 {{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Control_pala_y_teclado", "Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Construye_grupo_bloques")}}

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/index.md
@@ -7,6 +7,7 @@ tags:
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro
 ---
+
 {{GamesSidebar}}
 
 {{Next("Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Create_the_Canvas_and_draw_on_it")}}

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/mouse_controls/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/mouse_controls/index.md
@@ -4,6 +4,7 @@ slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Mouse_controls
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Mouse_controls
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Controles_raton
 ---
+
 {{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Track_the_score_and_win", "Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Terminando")}}

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/move_the_ball/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/move_the_ball/index.md
@@ -4,6 +4,7 @@ slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Move_the_ball
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Move_the_ball
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Mueve_la_bola
 ---
+
 {{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Create_the_Canvas_and_draw_on_it", "Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Bounce_off_the_walls")}}

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/paddle_and_keyboard_controls/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/paddle_and_keyboard_controls/index.md
@@ -4,6 +4,7 @@ slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Paddle_and_keyboard_contr
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Paddle_and_keyboard_controls
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Control_pala_y_teclado
 ---
+
 {{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Bounce_off_the_walls", "Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Fin_del_juego")}}

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.md
@@ -4,6 +4,7 @@ slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Track_the_score_and_win
 translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Track_the_score_and_win
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Track_the_score_and_win
 ---
+
 {{GamesSidebar}}
 
 {{PreviousNext("Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Deteccion_colisiones", "Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Controles_raton")}}

--- a/files/es/games/tutorials/html5_gamedev_phaser_device_orientation/index.md
+++ b/files/es/games/tutorials/html5_gamedev_phaser_device_orientation/index.md
@@ -13,6 +13,7 @@ tags:
 translation_of: Games/Tutorials/HTML5_Gamedev_Phaser_Device_Orientation
 original_slug: Games/Workflows/HTML5_Gamedev_Phaser_Device_Orientation
 ---
+
 {{GamesSidebar}}
 
 ## Introducción

--- a/files/es/glossary/abstraction/index.md
+++ b/files/es/glossary/abstraction/index.md
@@ -9,6 +9,7 @@ tags:
   - programacion
 translation_of: Glossary/Abstraction
 ---
+
 En {{Glossary("computer programming", "programación")}}, una abstracción es una manera de reducir la complejidad y permitir un diseño e implementación más eficientes en sistemas de software complejos. Oculta la dificultad técnica de los sistemas detrás de {{Glossary("API", "APIs")}} más simples.
 
 ## Ventajas de la Abstracción

--- a/files/es/glossary/accessibility/index.md
+++ b/files/es/glossary/accessibility/index.md
@@ -7,6 +7,7 @@ tags:
   - Glossary
 translation_of: Glossary/Accessibility
 ---
+
 _La accesibilidad web_ (**A11Y**) hace referencia a las buenas prácticas para mantener la usabilidad de un sitio web a pesar de las restricciones físicas y técnicas. La accesibilidad web se define formalmente y es discutida en el {{Glossary("W3C")}} a través del {{Glossary("WAI","Web Accessibility Initiative")}} (WAI).
 
 ## Saber más

--- a/files/es/glossary/accessibility_tree/index.md
+++ b/files/es/glossary/accessibility_tree/index.md
@@ -8,6 +8,7 @@ tags:
   - Glosario
 translation_of: Glossary/Accessibility_tree
 ---
+
 El **árbol de accesibilidad** o **modelo de objeto de accesibillidad (AOM)**, contiene información relacionada con {{Glossary("accessibility")}} para la mayoría de los elementos HTML.
 
 Los navegadores convierten el lenguaje markup en una representación interna denominada _[DOM tree](/en-US/docs/Web/API/Document_object_model/How_to_create_a_DOM_tree)_ (árbol DOM). El árbol DOM contiene objetos para todos los elementos de markup, atributos y nodos de texto. Luego, los navegadores crean un árbol de accesibilidad basado en el árbol de DOM, el cual es usado por Accessibility APIs de plataformas específicas para las tecnologías asistenciales como los lectores de pantalla.

--- a/files/es/glossary/adobe_flash/index.md
+++ b/files/es/glossary/adobe_flash/index.md
@@ -8,6 +8,7 @@ tags:
   - Infrastructure
 translation_of: Glossary/Adobe_Flash
 ---
+
 Flash es una tecnología obsolescente desarrollada por Adobe que hace posible crear aplicaciones Web ricas, gráficos vectoriales y multimedia. Para utilizar Flash dentro de un {{Glossary("Browser","web browser")}} es necesario instalar el complemento adecuado.
 
 ## Aprende más

--- a/files/es/glossary/ajax/index.md
+++ b/files/es/glossary/ajax/index.md
@@ -8,6 +8,7 @@ tags:
   - Infrastructure
 translation_of: Glossary/AJAX
 ---
+
 AJAX (de las siglas en Inglés **A**synchronous {{glossary("JavaScript")}} **A**nd {{glossary("XML")}} ) es una práctica de programación utilizada para construir páginas web más complejas y dinámicas, utilizando una tecnología conocida como {{Glossary("XHR_(XMLHttpRequest)","XMLHttpRequest")}}.
 
 Lo que AJAX nos permite hacer, es modificar partes específicas del {{Glossary("DOM")}} de una página {{Glossary("HTML")}} sin la necesidad de refrescar la página entera. AJAX tambien nos permite trabajar asincrónicamente; esto significa que tu código seguirá corriendo mientras esa parte de la página de tu sitio web intenta recargarse (en comparación, una carga síncrona bloquearía tu código hasta que esa parte de la página web terminara de recargarse)

--- a/files/es/glossary/algorithm/index.md
+++ b/files/es/glossary/algorithm/index.md
@@ -7,4 +7,5 @@ tags:
 translation_of: Glossary/Algorithm
 original_slug: Glossary/Algoritmo
 ---
+
 Un algoritmo es un conjunto de instrucciones autocontenidas que realiza una función.

--- a/files/es/glossary/api/index.md
+++ b/files/es/glossary/api/index.md
@@ -3,6 +3,7 @@ title: API
 slug: Glossary/API
 translation_of: Glossary/API
 ---
+
 ## Resumen
 
 Una **_Interfaz de Programación de Aplicaciones_** (API, por sus siglas en inglés) define un conjunto de directivas que pueden ser usadas para tener una pieza de software funcionando con algunas otras.

--- a/files/es/glossary/apple_safari/index.md
+++ b/files/es/glossary/apple_safari/index.md
@@ -9,6 +9,7 @@ tags:
   - navegación
 translation_of: Glossary/Apple_Safari
 ---
+
 [Safari](http://www.apple.com/safari/) es un {{Glossary("Browser","navegador web")}} desarrollado por Apple y ligado a Mac OS X y iOS. Está basado en el motor de código abierto [WebKit](http://www.webkit.org/).
 
 ## Saber más

--- a/files/es/glossary/application_context/index.md
+++ b/files/es/glossary/application_context/index.md
@@ -6,6 +6,7 @@ tags:
   - Glossary
 translation_of: Glossary/application_context
 ---
+
 Un contexto de aplicación es un [contexto de navegación](/es/docs/Glossary/Browsing_context) de nivel superior que tiene aplicado un [manifiesto](/es/docs/Web/Manifest).
 
 Si un contexto de aplicación es creado como resultado de una petición al agente usuario para que navegue a un enlace profundo, el agente usuario debe navegar inmediatamente hacia al enlace profundo con sustitución habilitada. De otra manera, cuando se crea el contexto de aplicación, el agente usuario debe navegar inmediatamente a la URL de inicio con sustitución habilitada.

--- a/files/es/glossary/argument/index.md
+++ b/files/es/glossary/argument/index.md
@@ -4,6 +4,7 @@ slug: Glossary/Argument
 translation_of: Glossary/Argument
 original_slug: Glossary/Argumento
 ---
+
 Un argumento es un valor (primitivo u objeto) (Véase {{glossary("value")}}, {{Glossary("primitive")}}, {{Glossary("object")}}) pasado como valor de entrada a una función ({{Glossary("function")}}).
 
 ## Saber más

--- a/files/es/glossary/aria/index.md
+++ b/files/es/glossary/aria/index.md
@@ -3,6 +3,7 @@ title: ARIA
 slug: Glossary/ARIA
 translation_of: Glossary/ARIA
 ---
+
 **ARIA** (_Accessible Rich {{glossary("Internet")}} Applications_) es una especificación de la {{Glossary("W3C")}} para agregar semantica y otros metadatos a {{Glossary("HTML")}} para ayudar a los usuarios con tecnologia de apoyo.
 
 Por ejemplo, puedes agregar el atributo `role="alert"` a un {{HTMLElement("p")}} {{glossary("tag")}} para notificar a un usuario con discapacidad visual que una información es importante .

--- a/files/es/glossary/arpa/index.md
+++ b/files/es/glossary/arpa/index.md
@@ -5,6 +5,7 @@ tags:
   - ARPA
 translation_of: Glossary/ARPA
 ---
+
 **.arpa** (parametros de dirección y enrutamiento) es un {{glossary("TLD","dominio de alto nivel")}} usado para propositos de infraestructura de Internet, especialmente busqueda inversa de DNS (ej., encontrar el {{glossary('nombre de dominio')}} para una {{glossary("dirección IP")}}) suministrada.
 
 ## Learn more

--- a/files/es/glossary/arpanet/index.md
+++ b/files/es/glossary/arpanet/index.md
@@ -3,6 +3,7 @@ title: Arpanet
 slug: Glossary/Arpanet
 translation_of: Glossary/Arpanet
 ---
+
 La **ARPAnet** (advanced research projects agency network) o Red de Angencias de Proyectos de Investigación Avanzada en español, era una red de computadoras construida en 1969 como un medio resistente para enviar datos militares y conectar principales grupos de investigación a través de los Estados Unidos. ARPAnet ejecutó NCP (network control protocol/protocolo de control de red) y subsequentemente la primera versión del protocolo de Internet o la suite {{glossary("TCP")}}/{{glossary("IPv6","IP")}}, teniendo la ARPAnet una descatada parte en la naciente {{glossary("Internet")}}. ARPAnet finalizó a comienzos de 1990.
 
 ## Saber más

--- a/files/es/glossary/array/index.md
+++ b/files/es/glossary/array/index.md
@@ -11,6 +11,7 @@ tags:
 translation_of: Glossary/array
 original_slug: Glossary/Arreglos
 ---
+
 Un arreglo (matriz) es una colección ordenada de datos (tanto {{glossary("Primitivo", "primitivos")}} u {{glossary("Object", "objetos")}} dependiendo del lenguaje). Los arreglos (matrices) se emplean para almacenar multiples valores en una sola variable, frente a las variables que sólo pueden almacenar un valor (por cada variable).
 
 Cada elemento del arreglo (matriz) tiene un número al que está asociado, llamado **"índice numérico"** (numeric index), que permite acceder a él.

--- a/files/es/glossary/ascii/index.md
+++ b/files/es/glossary/ascii/index.md
@@ -6,6 +6,7 @@ tags:
   - Infraestructura
 translation_of: Glossary/ASCII
 ---
+
 **ASCII** (_American Standard Code for Information Interchange_) es uno de los métodos de codificación más utilizados por las computadoras para convertir letras, números, signos de puntuación y códigos de control en formato digital. Desde 2007, {{Glossary("UTF-8")}} lo reemplazó en la Web.
 
 ## Aprender más

--- a/files/es/glossary/asynchronous/index.md
+++ b/files/es/glossary/asynchronous/index.md
@@ -9,6 +9,7 @@ tags:
 translation_of: Glossary/Asynchronous
 original_slug: Glossary/Asíncrono
 ---
+
 El término **asíncrono** se refiere al concepto de que más de una cosa ocurre al mismo tiempo, o múltiples cosas relacionadas ocurren sin esperar a que la previa se haya completado. En informática, la palabra "asíncrono" se usa en los siguientes contextos:
 
 - Redes y comunicaciones

--- a/files/es/glossary/atag/index.md
+++ b/files/es/glossary/atag/index.md
@@ -3,6 +3,7 @@ title: ATAG
 slug: Glossary/ATAG
 translation_of: Glossary/ATAG
 ---
+
 ATAG (Authoring Tool {{glossary("Accessibility")}} Guidelines/Pautas de accesibilidad de herramientas de autor) es una recomendación de la {{Glossary("W3C")}} para la construcción de herramientas de autor y producir contenido accesible.
 
 ## Saber más

--- a/files/es/glossary/attribute/index.md
+++ b/files/es/glossary/attribute/index.md
@@ -4,6 +4,7 @@ slug: Glossary/Attribute
 translation_of: Glossary/Attribute
 original_slug: Glossary/Atributo
 ---
+
 Un atributo amplía una etiqueta ({{Glossary("tag")}}), cambiando su comportamiento o proporcionando metadatos. Un atributo tiene la forma nombre=valor (especificando el identificador del atributo y el valor asociado al atributo).
 
 ## Saber más

--- a/files/es/glossary/bandwidth/index.md
+++ b/files/es/glossary/bandwidth/index.md
@@ -3,6 +3,7 @@ title: Ancho de banda
 slug: Glossary/Bandwidth
 translation_of: Glossary/Bandwidth
 ---
+
 El ancho de banda es la medida de cuanta información puede pasar a través de una conexión de datos en un momento dado. El ancho de banda suele medirse en múltipos de bits-por-segundo (bps), por ejemplo, megabits-por-segundo (Mbps) o gigabits-por-segundo (Gbps).
 
 ## Saber más

--- a/files/es/glossary/base64/index.md
+++ b/files/es/glossary/base64/index.md
@@ -4,6 +4,7 @@ slug: Glossary/Base64
 translation_of: Glossary/Base64
 original_slug: Web/API/WindowBase64/Base64_codificando_y_decodificando
 ---
+
 **Base64** es un grupo de esquemas de [codificación de binario a texto](https://es.wikipedia.org/wiki/Codificaci%C3%B3n_de_binario_a_texto) que representa los datos binarios mediante una cadena ASCII, traduciéndolos en una representación radix-64. El término _Base64_ se origina de un [sistema de codificación de transmisión de contenido MIME](https://es.wikipedia.org/wiki/Multipurpose_Internet_Mail_Extensions#Content-Transfer-Encoding) específico.
 
 Los esquemas de codificación Base64 son comúnmente usados cuando se necesita codificar datos binarios para que sean almacenados y transferidos sobre un medio diseñado para tratar con datos textuales. Esto es para asegurar que los datos se mantienen intactos y sin modificaciones durante la transmisión. Base64 es comúnmente usado en muchas aplicaciones, incluyendo la escritura de emails vía [MIME](https://es.wikipedia.org/wiki/Multipurpose_Internet_Mail_Extensions) y el almacenamiento de datos complejos en [XML](/es/docs/XML).

--- a/files/es/glossary/bigint/index.md
+++ b/files/es/glossary/bigint/index.md
@@ -3,6 +3,7 @@ title: BigInt
 slug: Glossary/BigInt
 translation_of: Glossary/BigInt
 ---
+
 En {{Glossary("JavaScript")}}, **BigInt** es un tipo de dato numerico que puede representar números enteros en el [formato de precision arbitrario](https://en.wikipedia.org/wiki/Arbitrary-precision_arithmetic). En otros lenguajes de programación pueden existir diferentes tipos numéricos, por ejemplo: enteros, flotantes, dobles o bignums (numeros grandes).
 
 ## Aprende más

--- a/files/es/glossary/blink/index.md
+++ b/files/es/glossary/blink/index.md
@@ -12,6 +12,7 @@ tags:
   - WebKit
 translation_of: Glossary/Blink
 ---
+
 Blink es un motor de renderizado para [navegadores](/es/docs/Glossary/Browser) de código abierto desarrollado por Google, que forma parte de Chromium (y por lo tanto también de [Chrome](/es/docs/Glossary/Google_Chrome)). Concretamente, Blink es una copia de la librería WebCore de [WebKit](/es/docs/Glossary/WebKit), que se encarga del diseño, renderizado, y del [DOM](/es/docs/Glossary/DOM).
 
 ## Para saber más...

--- a/files/es/glossary/block/css/index.md
+++ b/files/es/glossary/block/css/index.md
@@ -3,6 +3,7 @@ title: Block (CSS)
 slug: Glossary/Block/CSS
 translation_of: Glossary/Block/CSS
 ---
+
 Un **bloque** en una página web es un {{glossary("elemento")}} {{glossary("HTML")}} que aparece en una nueva línea, por ejemplo debajo del elemento precedente y encima del siguiente elemento (comúnmente conocido como _block-level element)_. Por ejemplo, visto que {{htmlelement("a")}} es un _elemento en línea_ — puedes colocar varios enlaces uno al lado del otro en el código HTML y no se posicionarán en la misma línea como uno al otro en la salida representada.
 
 Usando la propiedad {{cssxref("display")}} puedes cambiar si un elemento se muestre en línea o en bloque (entre muchas otras opciones); los **bloques** también están sujetos a los efectos de posicionaresquemas y usar la propiedad {{cssxref("position")}}.

--- a/files/es/glossary/block/index.md
+++ b/files/es/glossary/block/index.md
@@ -3,6 +3,7 @@ title: Block
 slug: Glossary/Block
 translation_of: Glossary/Block
 ---
+
 El término **bloque** puede tener diferentes significados dependiendo del conexto. Puede referirse a:
 
 {{GlossaryDisambiguation}}

--- a/files/es/glossary/boolean/index.md
+++ b/files/es/glossary/boolean/index.md
@@ -7,6 +7,7 @@ tags:
   - Tipos de datos
 translation_of: Glossary/Boolean
 ---
+
 En ciencias de informática, un **boolean** es un dato lógico que solo puede tener los valores true o false.
 
 ## Aprender más

--- a/files/es/glossary/breadcrumb/index.md
+++ b/files/es/glossary/breadcrumb/index.md
@@ -9,6 +9,7 @@ tags:
 translation_of: Glossary/Breadcrumb
 original_slug: Glossary/miga-de-pan
 ---
+
 Una **miga de pan**, o rastro de migas de pan, es una ayuda a la navegación que se sitúa normalmente entre la cabecera del sitio y el contenido principal y muestra, bien la jerarquía de la página actual en relación con la estructura del sitio desde el nivel superior o bien una lista de los enlaces utilizados para llegar a la página actual en el orden en que se han visitado.
 
 Una miga de pan para este documento se vería más o menos así:

--- a/files/es/glossary/browser/index.md
+++ b/files/es/glossary/browser/index.md
@@ -11,6 +11,7 @@ tags:
   - Web
 translation_of: Glossary/Browser
 ---
+
 Un _Navegador web_ es un programa o aplicación que da acceso a la [Web](/es/docs/Glossary/World_Wide_Web), y permite a los usuarios el acceso a más páginas a través de [hipervínculos](/es/docs/Glossary/Hyperlink).
 
 ## Para saber más...

--- a/files/es/glossary/browsing_context/index.md
+++ b/files/es/glossary/browsing_context/index.md
@@ -3,6 +3,7 @@ title: Contexto de navegación
 slug: Glossary/Browsing_context
 translation_of: Glossary/Browsing_context
 ---
+
 Un **contexto de navegación** es el entorno en el que un {{glossary("navegador")}} muestra un {{domxref("Documento")}} (normalmente una pestaña, pero posiblemente también una ventana o un marco (_frame_) dentro de una página).
 
 Cada contexto de navegación tiene un {{glossary("origen")}} específico, el origen del documento activo y un historial que enumera todos los documentos mostrados en orden.

--- a/files/es/glossary/buffer/index.md
+++ b/files/es/glossary/buffer/index.md
@@ -6,6 +6,7 @@ tags:
   - Glosario
 translation_of: Glossary/buffer
 ---
+
 Un búfer es un espacio de memoria en el que se almacenan datos de forma temporal mientras se están transfiriendo de un sitio a otro.
 
 ## Saber más

--- a/files/es/glossary/cache/index.md
+++ b/files/es/glossary/cache/index.md
@@ -7,6 +7,7 @@ tags:
 translation_of: Glossary/Cache
 original_slug: Glossary/Caché
 ---
+
 La **caché** (o caché web) es un componente que almacena temporalmente respuestas HTTP para que puedan ser usadas por peticiones HTTP posteriores mientras cumplan ciertas condiciones.
 
 ## Saber más

--- a/files/es/glossary/cacheable/index.md
+++ b/files/es/glossary/cacheable/index.md
@@ -3,6 +3,7 @@ title: Cacheable
 slug: Glossary/cacheable
 translation_of: Glossary/cacheable
 ---
+
 Una respuesta **_cacheable_** es una respuesta HTTP que se puede almacenar en caché, que se almacena para recuperarla y usarla más tarde, guardando una nueva solicitud en el servidor. No todas las respuestas HTTP se pueden almacenar en caché, estas son las siguientes restricciones para que una respuesta HTTP se almacene en caché:
 
 - El método utilizado en la solicitud se puede almacenar en caché, es decir, un método {{HTTPMethod("GET")}} o {{HTTPMethod("HEAD")}}. Una respuesta a una solicitud {{HTTPMethod("POST")}} o {{HTTPMethod("PATCH")}} también se puede almacenar en caché si se indica frescura y el encabezado {{HTTPHeader("Content-Location")}} es establecido, pero esto rara vez se implementa. (Por ejemplo, Firefox no lo admite según <https://bugzilla.mozilla.org/show_bug.cgi?id=109553>.) Otros métodos, como {{HTTPMethod("PUT")}} o {{HTTPMethod("DELETE")}} no se pueden almacenar en caché y su resultado no se puede almacenar en caché.

--- a/files/es/glossary/call_stack/index.md
+++ b/files/es/glossary/call_stack/index.md
@@ -8,6 +8,7 @@ tags:
 translation_of: Glossary/Call_stack
 original_slug: Glossary/Pila_llamadas
 ---
+
 Una **pila de llamadas** es un mecanismo para que un intérprete (como el intérprete de JavaScript en un navegador web) realice un seguimiento de en que lugar se llama a múltiples {{glossary("function","funciones")}}, qué función se esta ejecutando actualmente y qué funciones son llamadas desde esa función, etc.
 
 - Cuando un script llama a una función, el intérprete la añade a la pila de llamadas y luego empieza a ejecutar la función.

--- a/files/es/glossary/callback_function/index.md
+++ b/files/es/glossary/callback_function/index.md
@@ -3,6 +3,7 @@ title: Función Callback
 slug: Glossary/Callback_function
 translation_of: Glossary/Callback_function
 ---
+
 Una función de callback es una función que se pasa a otra función como un argumento, que luego se invoca dentro de la función externa para completar algún tipo de rutina o acción.
 
 Ejemplo:

--- a/files/es/glossary/canvas/index.md
+++ b/files/es/glossary/canvas/index.md
@@ -6,6 +6,7 @@ tags:
   - HTML5
 translation_of: Glossary/Canvas
 ---
+
 El **elemento canvas** forma parte de [HTML5](https://en.wikipedia.org/wiki/HTML5) y habilita dinamismo,[de scripts](https://en.wikipedia.org/wiki/Scripting_language) [lenguaje](<https://en.wikipedia.org/wiki/Rendering_(computer_graphics)>) de figuras en 2D & 3 3D e imágenes de[mapas de Bits](https://en.wikipedia.org/wiki/Bitmap) images. esta en un bajo nivel, el modelo de procedimiento actualiza el[mapa de bits](https://en.wikipedia.org/wiki/Bitmap) y no tiene que construir en él[scene graph](https://en.wikipedia.org/wiki/Scene_graph). Ofrece una zona gráfica vacía en la cual especifica {{Glossary("JavaScript")}} {{Glossary("API","APIs")}} puede dibujar (como en Canvas 2D o {{Glossary("WebGL")}}).
 
 ## Aprende más

--- a/files/es/glossary/card_sorting/index.md
+++ b/files/es/glossary/card_sorting/index.md
@@ -8,6 +8,7 @@ tags:
 translation_of: Glossary/Card_sorting
 original_slug: Glossary/Clasificación_por_tarjetas_(card_sorting)
 ---
+
 La clasificación por tarjetas (card sorting) es una técnica simple utilizada en la {{glossary("Information architecture", "arquitectura de la información")}} en la cual las personas involucradas en el diseño de una página web (u otro tipo de producto) están invitadas a describir el contenido / servicios / características que creen que el producto debería contener, para luego organizar estas características dentro de categorías o grupos. Esto se puede usar, por ejemplo, para determinar qué debe aparecer en cada página de una aplicación web. El nombre proviene del hecho de que a menudo la clasificación de las cartas se lleva a cabo literalmente escribiendo los elementos que se van a clasificar en tarjetas, y luego apilando las tarjetas.
 
 ## Saber más

--- a/files/es/glossary/cdn/index.md
+++ b/files/es/glossary/cdn/index.md
@@ -6,6 +6,7 @@ tags:
   - Glosario
 translation_of: Glossary/CDN
 ---
+
 Una **Red de distribución de contenidos** (_CDN en inglés_) es un grupo de servidores distribuidos en muchas ubicaciones. Estos servidores almacenan copias duplicadas de datos para que los servidores puedan cumplir con las solicitudes de datos en función de qué servidores están más cerca de los respectivos usuarios finales. Las CDN hacen que el servicio rápido se vea menos afectado por el alto tráfico.
 
 Los CDN se usan ampliamente para entregar hojas de estilo y archivos Javascript (activos estáticos) de bibliotecas como Bootstrap, jQuery, etc. Es preferible usar CDN para esos archivos de biblioteca por varias razones:

--- a/files/es/glossary/challenge/index.md
+++ b/files/es/glossary/challenge/index.md
@@ -5,6 +5,7 @@ tags:
   - Seguridad
 translation_of: Glossary/challenge
 ---
+
 En protocolos de seguridad, un _desafío_ es una información enviada al cliente por el servidor con el fin de generar una respuesta diferente cada vez . Los protocolos desafío-respuesta son una forma de batallar contra los [ataques de REPLAY](https://es.wikipedia.org/wiki/Ataque_de_REPLAY) donde un atacante escucha los mensajes previos y los reenvía en un momento posterior para obtener las mismas credenciales que el mensaje original.
 
 El [protocolo de autenticación HTTP](/es/docs/Web/HTTP/Authentication) está basado en los protocolos desafío-respuesta, aunque la autenticación "Basic" no usa un desafío real (el _realm_ siempre es el mismo).

--- a/files/es/glossary/character/index.md
+++ b/files/es/glossary/character/index.md
@@ -8,6 +8,7 @@ tags:
 translation_of: Glossary/Character
 original_slug: Glossary/Caracter
 ---
+
 Un _caracter_ es un símbolo (letras, números, puntuación) o un caracter de "control" que no se imprime (p. ej., Retorno de carro o guión suave — `soft hypen`). {{Glossary("UTF-8")}} es el conjunto de caracteres más común e incluye los grafemas de los lenguajes humanos más populares.
 
 ## Aprende más

--- a/files/es/glossary/character_encoding/index.md
+++ b/files/es/glossary/character_encoding/index.md
@@ -8,6 +8,7 @@ tags:
   - Glosario
 translation_of: Glossary/character_encoding
 ---
+
 Una codificación define cómo se traducen los bytes a texto y viceversa. Una secuencia de bytes se pueden interpretar de diferentes formas. Eligiendo una codificación en particular (como UTF-8), decimos como la secuencia de bytes debe ser interpretada.
 
 Por ejemplo, en HTML normalmente especificamos que la codificiación va a ser UTF-8 con la siguiente linea:

--- a/files/es/glossary/character_set/index.md
+++ b/files/es/glossary/character_set/index.md
@@ -8,6 +8,7 @@ tags:
 translation_of: Glossary/character_set
 original_slug: Glossary/conjunto_de_caracteres
 ---
+
 Un **conjunto de caracteres** es un sistema de codificación para que las computadoras sepan cómo reconocer un {{Glossary("Character", "caracter")}}, incluidas letras, números, signos de puntuación y espacios en blanco.
 
 En épocas anteriores, los países desarrollaron sus propios conjuntos de caracteres debido a los diferentes idiomas utilizados, como los códigos Kanji JIS (por ejemplo, Shift-JIS, EUC-JP, etc.) para japonés, Big5 para chino tradicional y KOI8-R para ruso. Sin embargo, {{Glossary("Unicode")}} se convirtió gradualmente en el conjunto de caracteres más aceptable por su soporte de idiomas universal.

--- a/files/es/glossary/chrome/index.md
+++ b/files/es/glossary/chrome/index.md
@@ -8,6 +8,7 @@ tags:
   - WebMechanics
 translation_of: Glossary/Chrome
 ---
+
 En un navegador, Chrome es cualquier aspecto visible de un navegador aparte de las páginas web en sí (por ejemplo, barras de herramientas, barra de menús, pestañas). Esto no debe confundirse con el navegador {{glossary("Google Chrome")}}.
 
 ## Leer más

--- a/files/es/glossary/cia/index.md
+++ b/files/es/glossary/cia/index.md
@@ -7,6 +7,7 @@ tags:
 translation_of: Glossary/CIA
 original_slug: Glossary/CID
 ---
+
 CID (Confidencialidad, Integridad, Disponibilidad) (también llamado la triada CID o la triada DIC) es un modelo que guía las políticas de una organización para la seguridad de la información.
 
 ## Saber más

--- a/files/es/glossary/cipher/index.md
+++ b/files/es/glossary/cipher/index.md
@@ -9,6 +9,7 @@ tags:
 translation_of: Glossary/Cipher
 original_slug: Glossary/Cifrado
 ---
+
 En {{glossary("cryptography", "criptografía")}}, un algoritmo criptográfico es un algoritmo que puede {{glossary("encryption", "encriptar")}} {{glossary("cleartext", "texto en lenguaje natural")}} para hacerlo ilegible, y para que sea {{glossary("decryption", "desencriptado")}} con el fin de recuperar el texto original.
 
 Los algoritmos de cifrado eran muy comunes mucho antes de la era de la información (e.g., [cifrados por sustitucion](https://es.wikipedia.org/wiki/Cifrado_por_sustituci%C3%B3n) y [cifrados por transposición](https://es.wikipedia.org/wiki/Cifrado_por_transposici%C3%B3n)), pero ninguno de ellos era criptográficamente seguros excepto [one-time pad](https://es.wikipedia.org/wiki/Libreta_de_un_solo_uso).

--- a/files/es/glossary/ciphertext/index.md
+++ b/files/es/glossary/ciphertext/index.md
@@ -9,6 +9,7 @@ tags:
 translation_of: Glossary/Ciphertext
 original_slug: Glossary/TextoCifrado
 ---
+
 En {{glossary("Cryptography", "Criptografía")}}, un texto cifrado es un mensaje codificado que transmite información pero no es legible a menos que se {{glossary("decryption","descifre")}} con el {{glossary("cipher", "algoritmo criptográfico")}} correcto y el secreto correcto (generalmente una {{glossary("key","clave")}}), reproduciendo el {{glossary("cleartext", "texto simple")}} original. La seguridad de un texto cifrado, y por lo tanto el secreto de la información contenida, depende de usar un cifrado seguro y mantener la clave en secreto.
 
 ## Saber más

--- a/files/es/glossary/class/index.md
+++ b/files/es/glossary/class/index.md
@@ -8,6 +8,7 @@ tags:
   - POO
 translation_of: Glossary/Class
 ---
+
 En {{glossary("OOP","programación orientada a objetos")}}, una clase define las características de un {{glossary("object","objeto")}}. Una clase es una plantilla que define {{glossary("property","propiedades")}} y {{glossary("method","métodos")}}, es un modelo abstracto a partir del cual se pueden crear instancias más específicas.
 
 ## Saber más

--- a/files/es/glossary/clickjacking/index.md
+++ b/files/es/glossary/clickjacking/index.md
@@ -2,6 +2,7 @@
 title: Clickjacking
 slug: Glossary/Clickjacking
 ---
+
 Clickjacking es un ataque basado en la interfaz que engaña a los usuarios de un sitio web para que sin saberlo hagan clic en enlaces maliciosos. En clickjacking, los atacantes incrustan sus enlaces maliciosos en botones o páginas legítimas en un sitio web. En un {{glossary("Site")}} infectado, cada vez que un usuario hace clic en un enlace legítimo, el atacante obtiene información confidencial de ese usuario, lo que finalmente compromete la privacidad del usuario en Internet.
 
 El clickjacking puede ser evitado implementando una [Política de Seguridad de Contenido (frame-ancestors)](/es/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors) e implementando [atributos de Set-Cookie](/es/docs/Web/HTTP/Headers/Set-Cookie#attributes).

--- a/files/es/glossary/closure/index.md
+++ b/files/es/glossary/closure/index.md
@@ -6,6 +6,7 @@ tags:
 translation_of: Glossary/Closure
 original_slug: Glossary/Clausura
 ---
+
 Una clausura o _closure_ es una función que guarda referencias del estado adyacente (**{{glossary("scope", "ámbito léxico")}}**). En otras palabras, una clausura permite acceder al ámbito de una función exterior desde una función interior. En {{glossary("JavaScript")}}, las clausuras se crean cada vez que una **{{glossary("function","función")}}** es creada.
 
 ## Saber más

--- a/files/es/glossary/cms/index.md
+++ b/files/es/glossary/cms/index.md
@@ -8,6 +8,7 @@ tags:
 translation_of: Glossary/CMS
 original_slug: Glossary/Sistema_gestion_contenidos
 ---
+
 Un sistema de gestión de contenidos o CMS es un programa informático que permite a los usuarios publicar, organizar, cambiar o eliminar diferentes tipos de contenido como texto, imágenes incrustadas, video, audio y código interactivo.
 
 ## Saber más

--- a/files/es/glossary/codec/index.md
+++ b/files/es/glossary/codec/index.md
@@ -6,6 +6,7 @@ tags:
   - TecnologíasWeb
 translation_of: Glossary/Codec
 ---
+
 Un _códec_ (acrónimo de "***co***dificador-***dec***odificador") es un programa, algoritmo, o dispositivo que codifica o decodifica un flujo de datos. Cada códec sabe cómo tratar un estándar específico de codificado o compresión.
 
 ## Saber más

--- a/files/es/glossary/compile/index.md
+++ b/files/es/glossary/compile/index.md
@@ -8,6 +8,7 @@ tags:
   - compilar
 translation_of: Glossary/Compile
 ---
+
 Compilar es el proceso de transformar un programa informático escrito en un {{Glossary("computer programming", "lenguaje")}} en un programa equivalente en otro formato. Al programa que se encarga de compilar se le llama compilador. A veces, a esta tarea se le llama "ensamblar" o "construir", lo que suele implicar otros procesos adicionales, e.j. empaquetarlo en formato binario.
 
 Normalmente, un compilador transforma un lenguaje de alto nivel como C o {{Glossary("Java")}}, el cual es legible por los humanos, en un lenguaje máquina que la CPU puede entender. Algunos compiladores que traducen de un lenguaje a otro del mismo nivel son llamados transpiladores, por ejemplo al compilar de TypeScript a {{Glossary("JavaScript")}}. Son considerados herramientas de productividad.

--- a/files/es/glossary/compile_time/index.md
+++ b/files/es/glossary/compile_time/index.md
@@ -3,6 +3,7 @@ title: Tiempo de compilación
 slug: Glossary/compile_time
 translation_of: Glossary/Compile_time
 ---
+
 El _tiempo de compilación_ es el tiempo desde que el programa es cargado por primera vez hasta que el programa es {{Glossary("parse","parsed")}}.
 
 ## Aprende más

--- a/files/es/glossary/computer_programming/index.md
+++ b/files/es/glossary/computer_programming/index.md
@@ -7,6 +7,7 @@ tags:
   - programacion
 translation_of: Glossary/Computer_Programming
 ---
+
 Programación de computadoras es un proceso de componer y organizar un conjunto de instrucciones. Éstas le indican a una computadora/software qué hacer en un lenguaje comprensible para la computadora. Estas instrucciones pueden presentarse en diferentes lenguajes, tales como C++, Java, JavaScript, HTML, Python, Ruby y Rust.
 
 Usando un lenguaje apropiado, puedes programar/crear todo tipo de software. Por ejemplo, un programa que ayude a científicos con cálculos complejos; una base de datos que almacene grandes cantidades de datos; un sitio web que permita a la gente descargar música, o un software de animación que permita a la gente crear películas animadas.

--- a/files/es/glossary/constant/index.md
+++ b/files/es/glossary/constant/index.md
@@ -8,6 +8,7 @@ tags:
 translation_of: Glossary/Constant
 original_slug: Glossary/Constante
 ---
+
 Una constante es un valor que el programador no puede cambiar, por ejemplo números (1, 2, 42). Con {{glossary("variable","variables")}}, por otra parte, el programador puede asignar un nuevo {{glossary("value", "valor")}} a una variable cuyo nombre ya esté en uso.
 
 Al igual que las variables, algunas constantes están unidas a identificadores. Por ejemplo, el identificador `pi` podría estar vinculado al valor 3.14... .

--- a/files/es/glossary/constructor/index.md
+++ b/files/es/glossary/constructor/index.md
@@ -5,6 +5,7 @@ tags:
   - Glosario
 translation_of: Glossary/Constructor
 ---
+
 Un **constructor** pertenece a una clase objeto ({{glossary("object")}}) particular la cual es instanciada. El constructor inicializa este objeto y puede otorgar acceso a su información privada. El concepto de objeto puede ser aplicado a la mayoría de los lenguajes orientados a objetos ({{glossary("OOP","object-oriented programming")}}). En esencia, un constructor en {{glossary("JavaScript")}} suele ser declarado al comienzo de una instancia de una clase ({{glossary("class")}}).
 
 ## Sintaxis

--- a/files/es/glossary/cookie/index.md
+++ b/files/es/glossary/cookie/index.md
@@ -6,6 +6,7 @@ tags:
   - TecnologíasWeb
 translation_of: Glossary/Cookie
 ---
+
 Una cookie es una pequeña información enviada por un sitio web que se almacena en el navegador del ordenador del usuario.
 
 Las cookies sirven para personalizar la experiencia que tiene el usuario al navegar por un sitio web. Pueden contener las preferencias del usuario o entradas de información al acceder a dicha web. El usuario puede personalizar su navegador para aceptar, rechazar, o borrar las cookies.

--- a/files/es/glossary/copyleft/index.md
+++ b/files/es/glossary/copyleft/index.md
@@ -10,6 +10,7 @@ tags:
   - Licencia
 translation_of: Glossary/Copyleft
 ---
+
 _Copyleft_ es un término, que normalmente se refiere a una licencia, y que se utiliza para indicar que toda redistribución de un trabajo bajo esta licencia **es obligatorio** que esté sujeta a la **misma licencia** **que el original**. Un buen ejemplo de copyleft es la licencia GNU [GPL](/es/docs/Glossary/GPL) (para aplicaciones software) y la licencia _Creative Commons SA_ (_Share Alike_ en español Compartir Igual) (para trabajos y obras de arte).
 
 ## Para saber más...

--- a/files/es/glossary/cross-site_scripting/index.md
+++ b/files/es/glossary/cross-site_scripting/index.md
@@ -3,6 +3,7 @@ title: Cross-site scripting
 slug: Glossary/Cross-site_scripting
 translation_of: Glossary/Cross-site_scripting
 ---
+
 Cross-site scripting (XSS) es una vulnerabilidad de seguridad que permite a un atacante inyectar en un sitio web código malicioso del lado del cliente. Este código es ejecutado por las vícitmas y permite a los atacante eludir los controles de acceso y hacerce pasar por usuarios. Según el Open Web Application Security Project, XSS fue la [séptima vulnerabilidad más común de las aplicaciones web](https://www.owasp.org/images/7/72/OWASP_Top_10-2017_%28en%29.pdf.pdf) en 2017.
 
 Estos ataques tienen éxito si la aplicación web no emplea suficiente validación o codificación. El navegador del usuario no puede detectar que el script malicioso no es confiable, por lo que da acceso a cookies, tokens de sesión u otra información sensible específica del sitio, o permite que el escript reescriba contenido {{glossary("HTML")}}.

--- a/files/es/glossary/crud/index.md
+++ b/files/es/glossary/crud/index.md
@@ -6,6 +6,7 @@ tags:
   - Infraestructura
 translation_of: Glossary/CRUD
 ---
+
 **CRUD** (Create, Read, Update, Delete) es un acrónimo para las maneras en las que se puede operar sobre información almacenada. Es un nemónico para las cuatro funciones del almacenamiento persistente. CRUD usualmente se refiere a operaciones llevadas a cabo en una base de datos o un almácen de datos, pero también pude aplicar a funciones de un nivel superior de una aplicación como soft deletes donde la información no es realmente eliminada, sino es marcada como eliminada a tráves de un estatus.
 
 ## Aprende más

--- a/files/es/glossary/cryptanalysis/index.md
+++ b/files/es/glossary/cryptanalysis/index.md
@@ -9,6 +9,7 @@ tags:
 translation_of: Glossary/Cryptanalysis
 original_slug: Glossary/Criptoanálisis
 ---
+
 El criptoanálisis es la rama de {{glossary ("cryptography","criptografía")}} que estudia cómo romper códigos y criptosistemas. El criptoanálisis crea técnicas para romper {{glossary ("cipher", "cifrados")}}, en particular por métodos más eficientes que una búsqueda por fuerza bruta. Además de los métodos tradicionales como el análisis de frecuencia y el índice de coincidencia, el criptoanálisis incluye métodos más recientes, como el criptoanálisis lineal o el criptoanálisis diferencial, que puede romper cifrados más avanzados.
 
 ## Saber más

--- a/files/es/glossary/cryptography/index.md
+++ b/files/es/glossary/cryptography/index.md
@@ -9,6 +9,7 @@ tags:
 translation_of: Glossary/Cryptography
 original_slug: Glossary/Criptografía
 ---
+
 Criptografía, o criptología, es la ciencia que estudia como codificar y transmitir mensajes de manera segura. La criptografía diseña y estudia algoritmos que son usados para la codificación y decoficación de mensajes en un entorno inseguro y sus aplicaciones. Más que confidencialidad de información, la criptografía también aborda la identificación, autenticación, el no repudio y la integridad de la información. Para ello tambien estudia el uso de métodos criptográficos en contexto, criptosistemas.
 
 ## Aprende más

--- a/files/es/glossary/csrf/index.md
+++ b/files/es/glossary/csrf/index.md
@@ -6,6 +6,7 @@ tags:
   - Seguridad
 translation_of: Glossary/CSRF
 ---
+
 **CSRF** (Cross-Site Request Forgery) es un ataque que falsifica una petición a un servidor web haciéndose pasar por un usuario de confianza. Esto se puede hacer, por ejemplo, incluyendo parámetros maliciosos en una {{glossary("URL")}} después de un enlace que pretende redirigir a otro sitio.
 
 ## Saber más

--- a/files/es/glossary/css/index.md
+++ b/files/es/glossary/css/index.md
@@ -10,6 +10,7 @@ tags:
   - Web
 translation_of: Glossary/CSS
 ---
+
 **CSS,** de las siglas en inglés **C**ascading **S**tyle **S**heets (Hojas de Estilo en Cascada), es un lenguaje declarativo que controla el aspecto de las páginas web en el {{glossary("browser","navegador")}}. El navegador aplica declaraciones de estilo CSS a los elementos seleccionados para exhibirlos correctamente. Una declaración de estilos contiene las propiedades y sus respectivos valores, los cuales determinan cómo se verá una página web.
 
 CSS es una de las tres principales tecnologias web, junto con {{Glossary("HTML")}} y {{Glossary("JavaScript")}}. CSS usualmente le da estilo a los ({{Glossary("Element","elementos HTML")}}), pero también puede ser utilizado con otros lenguajes de marcado como {{Glossary("SVG")}} o {{Glossary("XML")}}.

--- a/files/es/glossary/css_preprocessor/index.md
+++ b/files/es/glossary/css_preprocessor/index.md
@@ -4,6 +4,7 @@ slug: Glossary/CSS_preprocessor
 translation_of: Glossary/CSS_preprocessor
 original_slug: Glossary/Preprocesador_CSS
 ---
+
 Un preprocesador CSS es un programa que te permite generar {{Glossary("CSS")}} a partir de la {{Glossary("syntax")}} única del preprocesador. Existen varios preprocesadores CSS de los cuales escoger, sin embargo la mayoría de preprocesadores CSS añadiran algunas características que no existen en CSS puro, como {{Glossary("variable")}}, mixins, selectores anidados, entre otros. Estas características hacen la estructura de CSS más legible y fácil de mantener.
 
 Para utilizar un preprocesador CSS debes instalar un compilador CSS en tu web {{Glossary("server")}}.

--- a/files/es/glossary/data_structure/index.md
+++ b/files/es/glossary/data_structure/index.md
@@ -8,6 +8,7 @@ tags:
 translation_of: Glossary/Data_structure
 original_slug: Glossary/Estructura_de_datos
 ---
+
 **Estructura de datos** es una forma particular de organizar datos para que puedan ser usados eficientemente.
 
 ## Aprende más

--- a/files/es/glossary/decryption/index.md
+++ b/files/es/glossary/decryption/index.md
@@ -9,6 +9,7 @@ tags:
 translation_of: Glossary/Decryption
 original_slug: Glossary/Descifrado
 ---
+
 En {{glossary("cryptography" ,"criptografía")}}, el descifrado es la conversión de {{glossary("Ciphertext", "texto cifrado")}} en {{glossary("Plaintext", "texto simple")}}.
 
 El descifrado es una primitiva criptográfica: transforma un mensaje de texto cifrado en texto simple utilizando un algoritmo criptográfico llamado {{glossary("cipher", "cifrado")}}. Al igual que el cifrado, el descifrado en cifrados modernos se realiza mediante un algoritmo específico y una {{glossary("Key", "clave")}}. Dado que el algoritmo suele ser público, la clave debe permanecer secreta si el cifrado se mantiene seguro.

--- a/files/es/glossary/doctype/index.md
+++ b/files/es/glossary/doctype/index.md
@@ -3,6 +3,7 @@ title: Doctype
 slug: Glossary/Doctype
 translation_of: Glossary/Doctype
 ---
+
 `<!DOCTYPE>` informa al {{Glossary("navegador")}} que versión de {{Glossary("HTML")}} (o {{glossary("XML")}}) se usó para escribir el documento. Doctype es una declaración no una {{Glossary("etiqueta")}}. Además, podemos referirnos a ella como "document type declaration" o por las siglas "DTD".
 
 ## Learn more

--- a/files/es/glossary/dom/index.md
+++ b/files/es/glossary/dom/index.md
@@ -8,6 +8,7 @@ tags:
   - scripts
 translation_of: Glossary/DOM
 ---
+
 El _DOM_ (Document Object Model en español **Modelo de Objetos del Documento**) es una [API](/es/docs/Glossary/API) definida para representar e interactuar con cualquier documento [HTML](/es/docs/Glossary/HTML) o [XML](/es/docs/Glossary/XML). El DOM es un modelo de documento que se carga en el [navegador web](/es/docs/Glossary/Browser) y que representa el documento como un árbol de nodos, en donde cada nodo representa una parte del documento (puede tratarse de un [elemento](/es/docs/Glossary/element), una cadena de texto o un comentario).
 
 El DOM es una de las APIs más usadas en la [Web](/es/docs/Glossary/World_Wide_Web), pues permite ejecutar código en el navegador para acceder e interactuar con cualquier nodo del documento. Estos nodos pueden crearse, moverse o modificarse. Pueden añadirse a estos nodos manejadores de eventos (_event listeners_ en inglés) que se ejecutarán/activarán cuando ocurra el evento indicado en este manejador.

--- a/files/es/glossary/domain/index.md
+++ b/files/es/glossary/domain/index.md
@@ -9,6 +9,7 @@ tags:
   - Redes
 translation_of: Glossary/Domain
 ---
+
 Un dominio es una autoridad dentro de internet que controla sus propios recursos. Su "nombre de dominio" es una forma de dirigirse a esta autoridad como parte de la jerarquía en una {{Glossary("URL")}}, que generalmente es la parte más significativa de la misma, por ejemplo, un nombre de marca.
 
 Un nombre de dominio completo (FQDN, por sus siglas en inglés) contiene todas las partes necesarias para buscar esta autoridad por su nombre sin ambigüedades utilizando el sistema {{Glossary("DNS")}} de Internet.

--- a/files/es/glossary/domain_name/index.md
+++ b/files/es/glossary/domain_name/index.md
@@ -4,6 +4,7 @@ slug: Glossary/Domain_name
 translation_of: Glossary/Domain_name
 original_slug: Glossary/Nombre_de_dominio
 ---
+
 Un nombre de dominio es la dirección de un sitio web en {{Glossary("Internet")}}. Los nombres de dominio se utilizan en {{Glossary("URL","URLs")}} para identificar a qué servidor pertenece una página web específica. El nombre de dominio consiste en una secuencia jerárquica de nombres (etiquetas) separados por puntos y que terminan con una {{glossary("TLD","extensión")}}.
 
 ## Saber más

--- a/files/es/glossary/dynamic_typing/index.md
+++ b/files/es/glossary/dynamic_typing/index.md
@@ -8,6 +8,7 @@ tags:
 translation_of: Glossary/Dynamic_typing
 original_slug: Glossary/Tipado_dinámico
 ---
+
 **Los lenguajes de tipado dinámico** son aquellos (como {{glossary("JavaScript")}}) donde el intérprete asigna a las {{glossary("variable","variables")}} un {{glossary("tipo")}} durante el tiempo de ejecución basado en su {{glossary("valor")}} en ese momento.
 
 ## Ver más

--- a/files/es/glossary/ecmascript/index.md
+++ b/files/es/glossary/ecmascript/index.md
@@ -6,6 +6,7 @@ tags:
   - WebMechanics
 translation_of: Glossary/ECMAScript
 ---
+
 **ECMAScript** es una especificación de lenguaje de scripting en la que se basa {{Glossary("JavaScript")}}. [Ecma International](http://www.ecma-international.org) está a cargo de estandarizar ECMAScript.
 
 ## Aprende más

--- a/files/es/glossary/element/index.md
+++ b/files/es/glossary/element/index.md
@@ -3,6 +3,7 @@ title: Elemento
 slug: Glossary/Element
 translation_of: Glossary/Element
 ---
+
 Un elemento es parte de una página web. En XML y HTML, un elemento puede contener un elemento de datos o un fragmento de texto o una imagen, o tal vez nada. Un elemento típico incluye una etiqueta de apertura con algunos atributos, contenido de texto cerrado y una etiqueta de cierre.
 ![Example: in &lt;p class="nice"&gt;Hello world!&lt;/p&gt;, '&lt;p class="nice"&gt;' is an opening tag, 'class="nice"' is an attribute and its value, 'Hello world!' is enclosed text content, and '&lt;/p&gt;' is a closing tag.](https://mdn.mozillademos.org/files/7659/anatomy-of-an-html-element.png)
 

--- a/files/es/glossary/encapsulation/index.md
+++ b/files/es/glossary/encapsulation/index.md
@@ -6,6 +6,7 @@ tags:
   - Glosario
 translation_of: Glossary/Encapsulation
 ---
+
 La encapsulación es el empaquetamiento de datos y {{glossary("function","funciones")}} en un componente (por ejemplo, una {{glossary("class", "clase")}}) y para luego controlar el acceso a ese componente para hacer un ejecto de "caja negra" fuera del {{glossary("object", "objeto")}}. Debido a esto, un usuario de esa clase solo necesita conocer su interfaz (es decir, los datos y las funciones expuestas fuera de la clase), no la implementación oculta.
 
 ## Saber más

--- a/files/es/glossary/encryption/index.md
+++ b/files/es/glossary/encryption/index.md
@@ -9,6 +9,7 @@ tags:
 translation_of: Glossary/Encryption
 original_slug: Glossary/Encriptación
 ---
+
 En {{glossary("cryptography", "criptografía")}}, la **encriptación** es la conversión del {{glossary("cleartext", "lenguaje natural")}} en un texto codificado o {{glossary("ciphertext", "cifrado")}}. Un texto cifrado es utilizado para ser ilegible por lectores no autorizados.
 
 La encriptación es una primitiva criptográfica: transforma un mensaje en texto plano en un texto cifrado usando un {{glossary("cipher", "algoritmo criptográfico")}}. La encriptación en los algoritmos modernos se lleva a cabo usando un algoritmo específico y un secreto, llamado la {{glossary("key", "clave")}}. Ya que la mayoría de los algoritmos son públicos, la clave debe ser secreta para que la encriptación sea segura.

--- a/files/es/glossary/entity/index.md
+++ b/files/es/glossary/entity/index.md
@@ -8,6 +8,7 @@ tags:
 translation_of: Glossary/Entity
 original_slug: Glossary/Entidad
 ---
+
 Una **entidad** {{glossary("HTML")}} es un conjunto de caracteres ("string") que comienza con un ampersand (`&`) y termina con un punto y coma (`;`) . Las entidades son utilizadas frecuentemente para imprimir en pantalla caracteres reservados (aquellos que serían interpretados como HTML por el navegador) o invisibles (cómo tabulaciones). También pueden usarse para representar caracteres que no existan en algunos teclados, por ejemplo caracterés con tilde o diéresis.
 
 > **Nota:** Muchos caracteres tienen entidades con nombres fáciles de recordar, como las vocales con tilde (`á`) es `&aacute;`, (`é`) es `&eacute;` y así sucesivamente. Otro ejempo es el simbolo de copyright, (`©`) representado por la entidad `&copy;`. Al lidiar con entidades menos representativas de los caracteres que representan, es de gran ayuda utilizar una [tabla de referencia](https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references) o un [decodificador](https://mothereff.in/html-entities).

--- a/files/es/glossary/event/index.md
+++ b/files/es/glossary/event/index.md
@@ -6,6 +6,7 @@ tags:
   - Glosario
 translation_of: Glossary/event
 ---
+
 Los eventos son sucesos generados por elementos del [DOM](/en-US/docs/Glossary/DOM), que pueden ser manipulados por un código Javascript
 
 ## Saber más

--- a/files/es/glossary/first-class_function/index.md
+++ b/files/es/glossary/first-class_function/index.md
@@ -4,6 +4,7 @@ slug: Glossary/First-class_Function
 translation_of: Glossary/First-class_Function
 original_slug: Glossary/Funcion_de_primera_clase
 ---
+
 Un lenguaje de programación se dice que tiene **Funciones de primera clase** cuando las funciones en ese lenguaje son tratadas como cualquier otra variable. Por ejemplo, en ese lenguaje, una función puede ser pasada como argumento a otras funciones, puede ser retornada por otra función y puede ser asignada a una variable.
 
 ## Ejemplo | Asignar función a una variable

--- a/files/es/glossary/flex/index.md
+++ b/files/es/glossary/flex/index.md
@@ -3,6 +3,7 @@ title: Flex
 slug: Glossary/Flex
 translation_of: Glossary/Flex
 ---
+
 flex es una nueva herramienta agregada a la propiedad CSS {{cssxref ("display")}}. Junto con inline-flex, hace que el elemento al que se aplica se convierta en un {{glossary("flex container")}}, y los hijos del elemento se conviertan cada uno en un {{glossary("flex item")}}.
 
 Luego, los elementos participan en el diseño flexible y se pueden aplicar todas las propiedades definidas en el módulo de diseño de caja flexible CSS (CSS Flexible Box).

--- a/files/es/glossary/flex_container/index.md
+++ b/files/es/glossary/flex_container/index.md
@@ -3,6 +3,7 @@ title: Flex Container
 slug: Glossary/Flex_Container
 translation_of: Glossary/Flex_Container
 ---
+
 Una plantilla con {{glossary("flexbox")}} puede ser definida usando los valores `flex` o `inline-flex` en las propiedades de `display`. Este elemento es un **contenedor flex**, y cada uno de los contenedores que heredan propiedades de este, son conocidos como {{glossary("flex item")}}.
 
 El valor asignado a la variable `flex` ocasiona que este tipo de elementos sean un bloque de elementos del tipo (Flex Container), y la variable `inline-flex` genera un Contenedor Flex de nivel Inline (Interno. Estos Valores crean un Contexto de formato Flex para los elementos que es similar a un bloque flotante no introducido en el contenedor, y los margenes del contenedor no chocaran con otros items.

--- a/files/es/glossary/flexbox/index.md
+++ b/files/es/glossary/flexbox/index.md
@@ -3,6 +3,7 @@ title: Flexbox
 slug: Glossary/Flexbox
 translation_of: Glossary/Flexbox
 ---
+
 Flexbox es como se llama comúnmente a [Módulo de diseño de caja flexible CSS](https://www.w3.org/TR/css-flexbox-1/), un modelo de diseño para mostrar elementos en una sola dimensión, como una fila o como una columna.
 
 En la especificación, flexbox se describe como un modelo de diseño para la interfaz de usuario. La característica clave de Flexbox es el hecho de que los elementos en un diseño flexible pueden crecer y reducirse. El espacio se puede asignar a los mismos elementos, o distribuidos entre o alrededor de los elementos.

--- a/files/es/glossary/forbidden_header_name/index.md
+++ b/files/es/glossary/forbidden_header_name/index.md
@@ -10,6 +10,7 @@ tags:
 translation_of: Glossary/Forbidden_header_name
 original_slug: Glossary/Nombre_de_encabezado_prohibido
 ---
+
 Un nombre de encabezado prohibido es un nombre de [encabezado HTTP](/en-US/docs/Web/HTTP/Headers) que no se puede modificar mediante programación; específicamente, un nombre de encabezado de HTTP **solicitud** HTTP.
 
 Contrasta con el {{Glossary("Forbidden response header name")}}.

--- a/files/es/glossary/fps/index.md
+++ b/files/es/glossary/fps/index.md
@@ -3,6 +3,7 @@ title: frame rate (FPS)
 slug: Glossary/FPS
 translation_of: Glossary/FPS
 ---
+
 Un **cuadro por segundo** es la velocidad en la cual el navegador web, es capaz de recalcular la disposición y dibujar el contenido de la pantalla.
 
 **FPS (frames per second)**, refiere a la cantidad de cuadros que pueden ser redibujados en un segundo. El ideal de esta metrica para un sitio web es de **60fps**

--- a/files/es/glossary/ftp/index.md
+++ b/files/es/glossary/ftp/index.md
@@ -3,6 +3,7 @@ title: FTP
 slug: Glossary/FTP
 translation_of: Glossary/FTP
 ---
+
 FTP (del inglés _File Transfer Protocol_, Protocolo de transferencia de archivos) fue el [protocolo](/es/docs/Glossary/Protocol) estándar durante muchos años para transferir archivos entre equipos a través de Internet. Sin embargo, cada vez más los equipos y las cuentas de alojamiento no permiten el FTP y en su lugar dependen de un sistema de control de versiones como Git. Se encuentra todavía en funcionamiento en las cuentas de alojamiento más antiguas, pero no es exagerado decir que el FTP ya no es considerada la mejor práctica.
 
 ## Aprenda más

--- a/files/es/glossary/function/index.md
+++ b/files/es/glossary/function/index.md
@@ -9,6 +9,7 @@ tags:
 translation_of: Glossary/Function
 original_slug: Glossary/Función
 ---
+
 Una **función** es un fragmento de código que puede ser llamado por otro código o por sí mismo, o por una {{Glossary("variable")}} que haga referencia a la función. Cuando se llama a una función, los {{Glossary("Argument", "argumentos")}} se pasan a la función como entrada, y la función puede devolver opcionalmente una salida. Una función en {{glossary("JavaScript")}} es también un {{glossary("object", "objeto")}}.
 
 El nombre de la función es un {{Glossary("identifier", "identificador")}} declarado como parte de una declaración de función o expresión de función. El {{Glossary("scope", "ámbito")}} de la función depende de si el nombre de la función es una declaración o una expresión.

--- a/files/es/glossary/general_header/index.md
+++ b/files/es/glossary/general_header/index.md
@@ -4,6 +4,7 @@ slug: Glossary/General_header
 translation_of: Glossary/General_header
 original_slug: Glossary/Cabecera_general
 ---
+
 Una **cabecera general** es una {{glossary('Header', 'cabecera HTTP')}} que puede ser utilizada tanto en mensajes de consultas como de respuestas pero que no se aplican al contenido en sí mismo. Dependiendo del contexto en que son usadas, las cabeceras generales pueden ser de {{glossary("Response header", "respuesta")}} o de {{glossary("request header", "consulta")}}. Sin embargo, no son {{glossary("entity header", "cabeceras de entidad.")}}.
 
 Las cabeceras generales más comunes son {{HTTPHeader('Date')}}, {{HTTPheader("Cache-Control")}} y {{HTTPHeader("Connection")}}.

--- a/files/es/glossary/gif/index.md
+++ b/files/es/glossary/gif/index.md
@@ -8,6 +8,7 @@ tags:
   - Imagen
 translation_of: Glossary/gif
 ---
+
 **GIF** (**G**raphics **I**nterchange **F**ormat en español **Formato de Intercambio de Gráficos**) es un formato de imagen con una baja compresión y se puede usar para animaciones. Un GIF usa hasta 8 bits por pixel y contiene un máximo de 256 colores con un rango de 24-bit.
 
 ## Aprender más

--- a/files/es/glossary/git/index.md
+++ b/files/es/glossary/git/index.md
@@ -6,6 +6,7 @@ tags:
   - Glosario
 translation_of: Glossary/Git
 ---
+
 **Git** es un software de control de versiones ({{Glossary("SCM", "SCV", 1)}}) distribuido, libre y de código abierto. Facilita el manejo de código fuente con equipos de desarrollo distribuidos. La principal diferencia con SCV previos es la habilidad para hacer operaciones comunes (branching, committing, etc.) en el equipo de desarrollo local, sin tener que modificar el repositorio master o tener de acceso de escritura a él.
 
 ## Saber más

--- a/files/es/glossary/google_chrome/index.md
+++ b/files/es/glossary/google_chrome/index.md
@@ -13,6 +13,7 @@ tags:
   - google chrome
 translation_of: Glossary/Google_Chrome
 ---
+
 _Google Chrome_ es un [navegador](/es/docs/Glossary/Browser) web gratuito desarrollado por Google. Está basado en el proyecto open source (código abierto / software libre) [Chromium](http://www.chromium.org/). Algunas de las principales diferencias se encuentran en [Chromium wiki](https://code.google.com/p/chromium/wiki/ChromiumBrowserVsGoogleChrome). El motor de diseño que utilizan ambos es una copia del motor [Blink](/es/docs/Glossary/Blink) de [WebKit](/es/docs/Glossary/WebKit). Cabe señalar que en la versión de Chrome en iOS se utiliza WebKit y no Blink.
 
 ## Para saber más...

--- a/files/es/glossary/gpl/index.md
+++ b/files/es/glossary/gpl/index.md
@@ -12,6 +12,7 @@ tags:
   - Open Source
 translation_of: Glossary/GPL
 ---
+
 La lincencia GNU _GPL_ (GNU General Public License en español **Licencia Pública General de GNU**) es una licencia de software libre [copyleft](/es/docs/Glossary/copyleft) publicada por la _Free Software Foundation_. Los usuarios de un programa con licencia GPL son libres para usarlo, acceder al código fuente, modificarlo y distribuir los cambios; siempre que redistribuyan el programa completo (modificado o no modificado) bajo la misma licencia.
 
 ## Para saber más...

--- a/files/es/glossary/grid/index.md
+++ b/files/es/glossary/grid/index.md
@@ -6,6 +6,7 @@ tags:
   - CSS Grids
 translation_of: Glossary/Grid
 ---
+
 _CSS grid_ es definido usando el valor grid en la propiedad `display`; puedes definir columnas y filas en tu diseño grid, con las propiedades {{cssxref("grid-template-rows")}} y {{cssxref("grid-template-columns")}} .
 
 El grid que configures usando estas propiedades es definido como la grilla explícita (_explicit grid_).

--- a/files/es/glossary/grid_areas/index.md
+++ b/files/es/glossary/grid_areas/index.md
@@ -3,6 +3,7 @@ title: Grid Areas
 slug: Glossary/Grid_Areas
 translation_of: Glossary/Grid_Areas
 ---
+
 Un **grid area** es una o más {{glossary("grid cell", "grid cells")}} que forman un área rectangular en la cuadrícula. Los grid areas se crean cuando se coloca un ítem usando [disposición basada en líneas](/en-US/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid) o cuando se definen áreas usando [grid areas con nombre](/en-US/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas).
 
 ![Image showing a highlighted grid area](https://mdn.mozillademos.org/files/14771/1_Grid_Area.png)

--- a/files/es/glossary/grid_column/index.md
+++ b/files/es/glossary/grid_column/index.md
@@ -3,6 +3,7 @@ title: Grid Column
 slug: Glossary/Grid_Column
 translation_of: Glossary/Grid_Column
 ---
+
 Una **columna de grid** es una pista vertical en un [CSS Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout), y es el espacio entre dos líneas verticales de cuadrícula. Está definido por la propiedad {{cssxref("grid-template-columns")}} o por las propiedades abreviadas {{cssxref("grid")}} o {{cssxref("grid-template")}}.
 
 Además, se pueden crear columnas en la _cuadrícula implícita_ cuando los elementos se colocan fuera de las columnas creadas en la _cuadrícula explícita_. Estas columnas serán de tamaño automático por defecto, o pueden tener un tamaño especificado con la propiedad {{cssxref("grid-auto-columns")}}.

--- a/files/es/glossary/grid_lines/index.md
+++ b/files/es/glossary/grid_lines/index.md
@@ -3,6 +3,7 @@ title: Lineas de Cuadricula
 slug: Glossary/Grid_Lines
 translation_of: Glossary/Grid_Lines
 ---
+
 Las **Lineas de Cuadricula** se crean cuando defines las {{glossary("tracks", "Pistas de Cuadricula")}} esto sucede dentro de un contenedor que este usando [CSS Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout).
 
 En el siguiente ejemplo hay una cuadricula con tres pistas de columna y dos pistas de filas. Esto nos da **4 Lineas de Columnas** y **3 Lineas de Fila**.

--- a/files/es/glossary/grid_rows/index.md
+++ b/files/es/glossary/grid_rows/index.md
@@ -3,6 +3,7 @@ title: Grid Row
 slug: Glossary/Grid_Rows
 translation_of: Glossary/Grid_Rows
 ---
+
 Una **grid row** es una pista horizontal en un [CSS Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout), es el espacio entre dos líneas de cuadrícula horizontales. Se define por la propiedad {{cssxref("grid-template-rows")}} o con la propiedad shorthand {{cssxref("grid")}} o {{cssxref("grid-template")}}.
 
 Además, se pueden crear filas en la _cuadrícula implícita_ cuando los elementos se colocan fuera de las filas creadas en la _cuadrícula explícita_. Estas filas serán de tamaño automático por defecto, o pueden tener un tamaño especificado con la propiedad {{cssxref("grid-auto-rows")}}.

--- a/files/es/glossary/head/index.md
+++ b/files/es/glossary/head/index.md
@@ -8,6 +8,7 @@ tags:
   - head
 translation_of: Glossary/Head
 ---
+
 La cabecera (en inglés _Head_) es la parte de un documento [HTML](/es/docs/Glossary/Head) que contiene [metadatos](/es/docs/Glossary/Metadato) sobre ese documento, como el autor, la descripción y los enlaces a los archivos [CSS](/es/docs/Glossary/CSS) o [JavaScript](/es/docs/Glossary/JavaScript) que se deben aplicar al documento HTML. Es la parte del documento web que no es visible al usuario.
 
 ## Aprenda más

--- a/files/es/glossary/hoisting/index.md
+++ b/files/es/glossary/hoisting/index.md
@@ -6,6 +6,7 @@ tags:
   - hoisting
 translation_of: Glossary/Hoisting
 ---
+
 Hoisting es un término que _no_ encontrará utilizado en ninguna especificación previa a [ECMAScript® 2015 Language Specification](http://www.ecma-international.org/ecma-262/6.0/index.html). El concepto de Hoisting fue pensado como una manera general de referirse a cómo funcionan los contextos de ejecución en JavaScript (específicamente las fases de creación y ejecución). Sin embargo, el concepto puede ser un poco confuso al principio.
 
 Conceptualmente, por ejemplo, una estricta definición de hoisting sugiere que las declaraciones de variables y funciones son físicamente movidas al comienzo del código, pero esto no es lo que ocurre en realidad. Lo que sucede es que las declaraciones de variables y funciones son **asignadas en memoria** durante la fase de __compilación__, pero quedan exactamente en dónde las has escrito en el código.

--- a/files/es/glossary/host/index.md
+++ b/files/es/glossary/host/index.md
@@ -5,6 +5,7 @@ tags:
   - Glosario
 translation_of: Glossary/Host
 ---
+
 Un anfitrión (del ingles _host_) es un dispositivo conectado a {{glossary("Internet")}} (o una red de área local). Algunos anfitriones denominados {{glossary("server","servidores")}} ofrecen servicios adicionales como servir páginas web o alojar archivos y correos electrónicos.
 
 El anfitrión no es necesariamente un elemento hardware. Pueden ser generado como máquinas virtuales. El anfitrión generado en una máquina virtual se suele denominar "Alojamiento virtual".

--- a/files/es/glossary/html/index.md
+++ b/files/es/glossary/html/index.md
@@ -6,6 +6,7 @@ tags:
   - HTML
 translation_of: Glossary/HTML
 ---
+
 HTML (Lenguaje de marcado de hipertexto o HyperText Markup Language por sus siglas en inglés) es un lenguaje descriptivo que especifica la estructura de las páginas web.
 
 ## Breve historia

--- a/files/es/glossary/html5/index.md
+++ b/files/es/glossary/html5/index.md
@@ -3,6 +3,7 @@ title: HTML5
 slug: Glossary/HTML5
 translation_of: Glossary/HTML5
 ---
+
 La última versión estable de [HTML](/es/docs/Glossary/HTML), HTML5 convierte a HTML de un simple formato de marcado para estructurar documentos en una plataforma completa de desarrollo de aplicaciones. Entre otras características, HTML5 incluye nuevos elementos y [API](/es/docs/Glossary/API) de [JavaScript](/es/docs/Glossary/JavaScript) para mejorar el almacenamiento, la multimedia y el acceso al hardware.
 
 ## Aprenda más

--- a/files/es/glossary/http/index.md
+++ b/files/es/glossary/http/index.md
@@ -7,6 +7,7 @@ tags:
   - Web
 translation_of: Glossary/HTTP
 ---
+
 El protocolo de transferencia de hipertexto o HTTP (HyperText Transfer Protocol) es el protocolo de red que permite la transferencia de documentos de hipermedia en la red, generalmente entre un navegador y un servidor, para que los humanos puedan leerlos. La versión actual de la especificación se llama HTTP/2.
 
 En un {{glossary("URI")}}, como por ejemplo <https://developer.mozilla.org>, se indica en el esquema y puede tomar los valores: 'http:' o 'https:'. 'https:' se refiere a la versión segura del protocolo.

--- a/files/es/glossary/https/index.md
+++ b/files/es/glossary/https/index.md
@@ -3,6 +3,7 @@ title: HTTPS
 slug: Glossary/https
 translation_of: Glossary/https
 ---
+
 HTTPS (HTTP Secure) es una versión encriptada del protocolo {{Glossary("HTTP")}}. Normalmente utiliza {{Glossary("SSL")}} o {{Glossary("TLS")}} para cifrar toda la comunicación entre un cliente y un servidor. Esta conexión segura permite a los clientes intercambiar datos confidenciales de forma segura con un servidor, por ejemplo, para actividades bancarias o compras en línea.
 
 ## Aprender más

--- a/files/es/glossary/hyperlink/index.md
+++ b/files/es/glossary/hyperlink/index.md
@@ -11,6 +11,7 @@ tags:
   - enlace
 translation_of: Glossary/Hyperlink
 ---
+
 Los _Hipervínculos_ ó _enlaces_ permiten conectar entre sí datos ó páginas web. En [HTML](/es/docs/Glossary/HTML), los elementos {{HTMLElement("a")}} representan hipervínculos que tienen como origen un elemento de la página web (por ejemplo cadenas de texto o imágenes), y que pueden tener como destino un elemento de otro sitio web (incluso pueden enlazar a otro punto de la misma página).
 
 ## Para saber más...

--- a/files/es/glossary/hypertext/index.md
+++ b/files/es/glossary/hypertext/index.md
@@ -5,6 +5,7 @@ tags:
   - Glosario
 translation_of: Glossary/Hypertext
 ---
+
 El hipertexto es texto que contiene enlaces a otros textos, y no un flujo único y lineal como el de una novela.
 
 El término fue acuñado por Ted Nelson alrededor del año 1965.

--- a/files/es/glossary/ide/index.md
+++ b/files/es/glossary/ide/index.md
@@ -10,6 +10,7 @@ tags:
   - editor de texto
 translation_of: Glossary/IDE
 ---
+
 Un entorno de desarrollo integrado (**IDE**) o entorno de desarrollo interactivo es una aplicación que proporciona facilidades a los programadores para el desarrollo de software. Un IDE normalmente consta de un editor de código, herramientas automatizadas para producir el proyecto y un depurador.
 
 ## Saber más

--- a/files/es/glossary/identifier/index.md
+++ b/files/es/glossary/identifier/index.md
@@ -10,6 +10,7 @@ tags:
 translation_of: Glossary/Identifier
 original_slug: Glossary/Identificador
 ---
+
 Un **Identificador** es una secuencia de caracteres en el código que identifica una {{Glossary("Variable")}}, {{Glossary("Function", "función")}} o {{Glossary("Property", "propiedad")}}.
 
 En {{Glossary("JavaScript")}}, los identificadores distinguen entre mayúsculas y minúsculas y pueden contener letras {{Glossary("Unicode")}}, `$`, `_`, y dígitos (0-9), pero no puede comenzar con un dígito.

--- a/files/es/glossary/iife/index.md
+++ b/files/es/glossary/iife/index.md
@@ -5,6 +5,7 @@ tags:
   - Funciones
 translation_of: Glossary/IIFE
 ---
+
 Las expresiones de función ejecutadas inmediatamente (**IIFE** por su sigla en inglés) son funciones que se ejecutan tan pronto como se definen.
 
 ```js

--- a/files/es/glossary/immutable/index.md
+++ b/files/es/glossary/immutable/index.md
@@ -7,6 +7,7 @@ tags:
 translation_of: Glossary/Immutable
 original_slug: Glossary/Inmutable
 ---
+
 Un {{glossary("object", "objeto")}} inmutable es aquel cuyo contenido no se puede cambiar.Un objeto puede ser inmutable por varias razones, por ejemplo:
 
 - Para mejorar el rendimiento (al no haber planificados cambios futuros del objeto)

--- a/files/es/glossary/indexeddb/index.md
+++ b/files/es/glossary/indexeddb/index.md
@@ -3,6 +3,7 @@ title: IndexedDB
 slug: Glossary/IndexedDB
 translation_of: Glossary/IndexedDB
 ---
+
 IndexedDB es una {{glossary("API")}} Web diseñada para almacenar estructuras de datos grandes en los navegadores e indexarlas para realizar búsquedas de alto rendimiento. Al igual que los sistemas [RDBMS](https://es.wikipedia.org/wiki/Sistema_de_gesti%C3%B3n_de_bases_de_datos_relacionales) basados en {{glossary("SQL")}}, IndexedDB es un sistema de base de datos transaccional. Sin embargo, usa objetos de {{glossary("JavaScript")}} en vez de columnas fijas para almacenar los datos.
 
 ## Conoce más

--- a/files/es/glossary/information_architecture/index.md
+++ b/files/es/glossary/information_architecture/index.md
@@ -8,6 +8,7 @@ tags:
 translation_of: Glossary/Information_architecture
 original_slug: Glossary/Arquitectura_de_la_información
 ---
+
 La arquitectura de la información, aplicada al diseño y desarrollo web, es la práctica de organizar la información, contenido y funcionalidad de un sitio web para que presente la mejor experiencia de usuario posible, con información y servicios fáciles de usar y encontrar.
 
 ## Aprende más

--- a/files/es/glossary/internet/index.md
+++ b/files/es/glossary/internet/index.md
@@ -3,6 +3,7 @@ title: Internet
 slug: Glossary/Internet
 translation_of: Glossary/Internet
 ---
+
 La Internet es una red mundial de redes que utiliza el conjunto de protocolos de Internet (tambien conocidos como {{glossary("TCP")}}/{{glossary("IPv6","IP")}} (art. en ingles) siendo sus dos mas importantes {{glossary("protocol","protocolos")}}).
 
 ## Aprender más

--- a/files/es/glossary/ip_address/index.md
+++ b/files/es/glossary/ip_address/index.md
@@ -3,6 +3,7 @@ title: Dirección IP
 slug: Glossary/IP_Address
 translation_of: Glossary/IP_Address
 ---
+
 Una dirección IP es un número asignado a cada dispositivo conectado a una red que utiliza el protocolo de Internet.
 
 La «dirección IP» normalmente se sigue refiriendo a las direcciones IPv4 de 32 bits hasta que el IPv6 se despliegue más ampliamente.

--- a/files/es/glossary/ipv6/index.md
+++ b/files/es/glossary/ipv6/index.md
@@ -6,6 +6,7 @@ tags:
   - Web
 translation_of: Glossary/IPv6
 ---
+
 **IPv6** es la versión actual del protocolo de comunicación subyacente a Internet. Lentamente, IPv6 está reemplazando a IPv4, entre otras razones porque IPv6 permite muchas direcciones de IP diferentes.
 
 ## Aprende más

--- a/files/es/glossary/irc/index.md
+++ b/files/es/glossary/irc/index.md
@@ -3,6 +3,7 @@ title: IRC
 slug: Glossary/IRC
 translation_of: Glossary/IRC
 ---
+
 **IRC** (_Internet Relay Chat_) es un sistema de chat mundial que requiere una conexión a Internet y un cliente IRC, que envía y recibe mensajes atravéz del servidor IRC.
 
 Diseñado a finales de la década de 1980 por Jarrko Oikarinen, IRC usa {{glossary("TCP")}} y es un protocolo abierto. El servidor IRC transmite mensajes a todos los que están conectados a uno de los muchos canales de IRC (cada uno con su propio ID).

--- a/files/es/glossary/isp/index.md
+++ b/files/es/glossary/isp/index.md
@@ -8,6 +8,7 @@ tags:
   - Web
 translation_of: Glossary/ISP
 ---
+
 Un ISP (del inglés _Internet Service Provider_, Proveedor de servicios de Internet) es una empresa (en su mayoría compañías telefónicas) que vende acceso a Internet y, a veces, correo electrónico, alojamiento de páginas web y voz sobre IP, ya sea mediante una conexión de marcación a través de una línea telefónica (antes más común), o a través de una conexión de banda ancha como un módem de cable o un servicio DSL.
 
 ## Aprenda más

--- a/files/es/glossary/java/index.md
+++ b/files/es/glossary/java/index.md
@@ -7,6 +7,7 @@ tags:
   - Lenguaje de programación
 translation_of: Glossary/Java
 ---
+
 Java es un lenguaje de {{Glossary("computer programming", "programación")}} semi-compilado, {{glossary("OOP", "orientado a objetos")}} y portable.
 
 Java está tipado estáticamente y tiene una sintaxis parecida a la de C. Tiene una gran librería de funciones fáciles de usar, el Java Software Development Kit (SDK).

--- a/files/es/glossary/jpeg/index.md
+++ b/files/es/glossary/jpeg/index.md
@@ -3,6 +3,7 @@ title: JPEG
 slug: Glossary/jpeg
 translation_of: Glossary/jpeg
 ---
+
 **JPEG** (_Joint Photographic Experts Group_) es un método comúnmente utilizado en la compresión con pérdida de información en imágenes digitales.
 
 ## Saber más

--- a/files/es/glossary/json/index.md
+++ b/files/es/glossary/json/index.md
@@ -9,6 +9,7 @@ tags:
   - introducción
 translation_of: Glossary/JSON
 ---
+
 **JSON (notación de objetos javascript)** es un formato de intercambio de datos. Es muy parecido a un subconjunto de sintaxis JavaScript, aunque no es un subconjunto en sentido estricto. (Ver JSON en la Referencia JavaScript para más detalles.) Aunque muchos lenguajes de programación lo soportan, JSON es especialmente útil al escribir cualquier tipo de aplicación basada en JavaScript, incluyendo sitios web y extensiones del navegador. Por ejemplo, es posible almacenar la información del usuario en formato JSON en una cookie o almacenar las preferencias de extensión en JSON en una cadena de valores de preferencias del navegador.
 
 JSON es capaz de representar números, valores lógicos, cadenas, valores nulos, arreglos y matrices (secuencias ordenadas de valores) y objetos (mapas de cadena de valores) compuestos de estos valores (o de otras matrices y objetos). JSON no representa de manera nativa tipos de datos más complejos como funciones, expresiones regulares, fechas, y así sucesivamente (en objetos de fecha serializados por defecto como una cadena que contiene la fecha en formato ISO, al no hacerlo de ida y vuelta, la información no se pierde por completo). Si se necesita que JSON represente tipos de datos adicionales, se puede transformar los valores, ya que son serializados, o antes de su deserialización.

--- a/files/es/glossary/key/index.md
+++ b/files/es/glossary/key/index.md
@@ -8,6 +8,7 @@ tags:
 translation_of: Glossary/Key
 original_slug: Glossary/Clave
 ---
+
 Una clave es una pieza de información utilizada por un algoritmo criptográfico para el {{Glossary("encryption", "cifrado")}} y/o {{Glossary("decryption", "descifrado")}}. Los mensajes cifrados deben permanecer seguros incluso si todo lo relacionado con el {{Glossary("cryptosystem","sistema de cifrado")}}, excepto la clave, es de conocimiento público.
 
 En la {{Glossary("symmetric-key cryptography", "criptografía de clave simétrica")}}, la misma clave se utiliza tanto para el cifrado como para el descifrado. En la criptografía de clave pública, existen un par de claves relacionadas conocidas como _clave pública_ y _clave privada_. La clave pública está disponible libremente, mientras que la clave privada se mantiene secreta. La clave pública puede cifrar mensajes que sólo la clave privada correspondiente puede descifrar, y viceversa.

--- a/files/es/glossary/keyword/index.md
+++ b/files/es/glossary/keyword/index.md
@@ -9,6 +9,7 @@ tags:
   - busqueda
 translation_of: Glossary/Keyword
 ---
+
 Una **palabra clave** es una palabra o frase que describe contenido. Las palabras clave en línea se utilizan como consultas para los motores de búsqueda o como palabras que identifican el contenido de los sitios web.
 
 Cuando usas un motor de búsqueda, utilizas palabras clave para especificar lo que estás buscando y el motor de búsqueda devuelve páginas web relevantes. Para obtener resultados más precisos, prueba con palabras clave más específicas, como "Mustang GTO azul" en lugar de simplemente "Mustang". Las páginas web también utilizan palabras clave en una etiqueta `<meta>` (en la sección {{htmlelement("head")}}) para describir el contenido de la página, de manera que los motores de búsqueda puedan identificar y organizar mejor las páginas web.

--- a/files/es/glossary/lgpl/index.md
+++ b/files/es/glossary/lgpl/index.md
@@ -12,6 +12,7 @@ tags:
   - Software Libre
 translation_of: Glossary/LGPL
 ---
+
 _LGPL_ (GNU Lesser General Public License en español **Licencia Pública General Reducida de GNU**) es una licencia de software libre publicada por la _Free Software Foundation_. LGPL es una alternativa más permisiva que la estricta licencia [copyleft](/es/docs/Glossary/copyleft) [GPL](/es/docs/Glossary/GPL).
 
 Esto supone que cualquier trabajo que use un elemento con licencia GPL **tiene la obligación** de ser publicado bajo las mismas condiciones (libre de usar, compartir, estudiar, y modificar). Por otro lado, LGPL solo requiere que los componentes derivados del elemento bajo LGPL continuen con esta licencia, y no el programa al completo.

--- a/files/es/glossary/long_task/index.md
+++ b/files/es/glossary/long_task/index.md
@@ -8,6 +8,7 @@ tags:
   - Rendimiento Web
 translation_of: Glossary/Long_task
 ---
+
 Una '**long task'** (tarea larga) es una tarea que tarda más de 50 ms en completarse. Es un período ininterrumpido en el que el subproceso de la interfaz de usuario principal está ocupado durante 50 ms o más. Los ejemplos comunes incluyen controladores de eventos de ejecución prolongada, [reflujos](/es/docs/Glossary/Reflow) costosos y otras representaciones, y el trabajo que realiza el navegador entre diferentes turnos del bucle de eventos que supera los 50 ms.
 
 Ver también

--- a/files/es/glossary/main_thread/index.md
+++ b/files/es/glossary/main_thread/index.md
@@ -9,6 +9,7 @@ tags:
 translation_of: Glossary/Main_thread
 original_slug: Glossary/Hilo_principal
 ---
+
 El hilo principal es donde un navegador procesa eventos y pinturas del usuario. De manera predeterminada, el navegador usa un solo hilo para ejecutar todo el JavaScript en su página, así como para realizar el diseño, los reflujos y la recolección de basura. Esto significa que las funciones de JavaScript de larga duración pueden bloquear el hilo, lo que lleva a una página que no responde y a una mala experiencia del usuario.
 
 A menos que use intencionalmente un trabajador web, como un trabajador de servicio, JavaScript se ejecuta en el hilo principal, por lo que es fácil que un script provoque retrasos en el procesamiento o la pintura de eventos. Cuanto menos trabajo se requiera del hilo principal, más puede responder ese hilo a los eventos del usuario, pintar y, en general, responder al usuario.

--- a/files/es/glossary/metadata/index.md
+++ b/files/es/glossary/metadata/index.md
@@ -8,6 +8,7 @@ tags:
 translation_of: Glossary/Metadata
 original_slug: Glossary/Metadato
 ---
+
 Los **metadatos** son, en su definición más simple, datos que describen otros datos. Por ejemplo, un documento {{glossary("HTML")}} son datos, pero HTML también puede contener metadatos en su elemento {{htmlelement("head")}} que describe el documento, como por ejemplo, quién lo escribió y su resumen.
 
 ## Saber más

--- a/files/es/glossary/method/index.md
+++ b/files/es/glossary/method/index.md
@@ -7,6 +7,7 @@ tags:
 translation_of: Glossary/Method
 original_slug: Glossary/Método
 ---
+
 Un **metodo** es una {{glossary("function", "función")}} la cual es {{glossary("property", "propiedad")}} de un {{glossary("Objecto", "Objeto")}}. Existen dos tipos de métodos: _Métodos de Instancia_ los cuales son tareas integradas realizadas por la instacia de un objeto, y los _Métodos Estáticos_ que son tareas que pueden ser llamadas directamente en el constructor de un objeto.
 
 > **Nota:** en JavaScript las funciones en si son objetos, asi que, en ese contexto, un método es de hecho un {{glossary("Object Reference", "objeto de referencia")}} a una función.

--- a/files/es/glossary/mitm/index.md
+++ b/files/es/glossary/mitm/index.md
@@ -6,6 +6,7 @@ tags:
   - Seguridad
 translation_of: Glossary/MitM
 ---
+
 Un ataque de Intermediario \[**Man-in-the-middle attack** (MitM)] intercepta una comunicación entre dos sistemas. Por ejemplo, un router Wi-Fi puede estar en peligro.
 
 Comparémoslo con un correo físico: si usted está escribiendo una carta a una persona, el cartero puede interceptar cada carta que envíe. Ellos la abren, la leen y finalmente la modifican, y entonces la reempaquetan y solamente entonces la envían a los destinatarios que usted pretendió. El receptor original podría entonces contestarle y el cartero abriría de nuevo la carta, la leería y finalmente la modificaria, la reempaquetaría y se la da. Usted ignoraría que hay un hombre en medio de su canal de comunicación – el cartero es invisible para usted y para su destinatario.

--- a/files/es/glossary/mixin/index.md
+++ b/files/es/glossary/mixin/index.md
@@ -3,6 +3,7 @@ title: Mixin
 slug: Glossary/Mixin
 translation_of: Glossary/Mixin
 ---
+
 Un _mixin_ es un conjunto coherente de {{glossary("method","métodos")}} y {{glossary("property","propiedades")}} implementadas por otras interfaces y {{glossary("class","clases")}}.
 
 Ejemplo

--- a/files/es/glossary/mobile_first/index.md
+++ b/files/es/glossary/mobile_first/index.md
@@ -7,4 +7,5 @@ tags:
   - Glosario
 translation_of: Glossary/Mobile_First
 ---
+
 **Mobile first**, una forma de {{Glossary("mejora progresiva")}}, es un enfoque de desarrollo y diseño web que se enfoca en la priorización del diseño y el desarrollo para dispositivos móviles por encima del diseño y desarrollo para pantallas de escritorio. El fundamento detrás del enfoque "mobile-first" es proveer al usuario una buena experiencia para todos los tamaños de pantalla—empezando por una experiencia de usuario que funcione bien para dispositivos pequeños, para posteriormente, basada en dicha experiencia, continuar desarrollando para enriquecer la experiencia de usuario conforme el tamaño de pantalla es mayor. El enfoque "mobile-first" contrasta con el antiguo enfoque de diseño para escritorio en el que se pensaba primero en el diseño/desarrollo para tamaños de pantalla de escritorio y posteriormente se realizaban ajustes para conseguir que dichos diseños y desarrollos funcionases correctamente en dispositivos móbilies.

--- a/files/es/glossary/mozilla_firefox/index.md
+++ b/files/es/glossary/mozilla_firefox/index.md
@@ -9,6 +9,7 @@ tags:
   - Navegador
 translation_of: Glossary/Mozilla_Firefox
 ---
+
 Mozilla Firefox es un {{Glossary("navegador")}} gratuito de codigo abierto cuyo desarrollo es supervisado por Mozilla Corporation. Firefox functiona sobre Windows, OS X, Linus y Android.
 
 Lanzado en Noviembre del 2004, Firefox es completamente personalizable con temas y [complementos](/es/Add-ons). Firefox usa {{glossary("Gecko")}} para renderizar paginas webs, e implementa tanto actuales como próximos estandares Web.

--- a/files/es/glossary/mvc/index.md
+++ b/files/es/glossary/mvc/index.md
@@ -3,6 +3,7 @@ title: MVC
 slug: Glossary/MVC
 translation_of: Glossary/MVC
 ---
+
 **MVC** (Modelo-Vista-Controlador) es un patrón en el diseño de software comúnmente utilizado para implementar interfaces de usuario, datos y lógica de control. Enfatiza una separación entre la lógica de negocios y su visualización. Esta "separación de preocupaciones" proporciona una mejor división del trabajo y una mejora de mantenimiento. Algunos otros patrones de diseño se basan en MVC, como MVVM (Modelo-Vista-modelo de vista), MVP (Modelo-Vista-Presentador) y MVW (Modelo-Vista-Whatever).
 
 Las tres partes del patrón de diseño de software MVC se pueden describir de la siguiente manera:

--- a/files/es/glossary/node.js/index.md
+++ b/files/es/glossary/node.js/index.md
@@ -8,6 +8,7 @@ tags:
   - node.js
 translation_of: Glossary/Node.js
 ---
+
 Node.js es un entorno de ejecucion multiplataforma en {{Glossary("JavaScript")}} que permite a los desarrolladores construir aplicaciones del lado del servidor y de red con JavaScript.
 
 ## Saber más

--- a/files/es/glossary/node/dom/index.md
+++ b/files/es/glossary/node/dom/index.md
@@ -3,6 +3,7 @@ title: Node (DOM)
 slug: Glossary/Node/DOM
 translation_of: Glossary/Node/DOM
 ---
+
 En el contexto del {{Glossary("DOM")}}, un **nodo** es un único punto en el arbol de nodos. Los nodos pueden ser varias cosas el documento mismo, elementos, texto y comentarios.
 
 ## Saber más

--- a/files/es/glossary/node/index.md
+++ b/files/es/glossary/node/index.md
@@ -6,6 +6,7 @@ tags:
   - Glosario
 translation_of: Glossary/Node
 ---
+
 El término **nodo** puede tener varios significados según el contexto. Puede referirse a:
 
 {{GlossaryDisambiguation}}

--- a/files/es/glossary/null/index.md
+++ b/files/es/glossary/null/index.md
@@ -5,6 +5,7 @@ tags:
   - Glosario
 translation_of: Glossary/Null
 ---
+
 En ciencias informáticas, un valor **null** representa una referencia que apunta, generalmente intencionadamente, a una inexistente o inválido {{glossary("objecto","objeto")}} o dirección. El significado de una referencia null varía entre las implementaciones de lenguajes.
 
 En {{Glossary("JavaScript")}}, null es uno de los {{Glossary("Primitivo", "valores primitivos")}}.

--- a/files/es/glossary/number/index.md
+++ b/files/es/glossary/number/index.md
@@ -7,6 +7,7 @@ tags:
 translation_of: Glossary/Number
 original_slug: Glossary/Numero
 ---
+
 En {{Glossary("JavaScript")}}, **Number** es un tipo de datos numérico ([double-precision 64-bit floating point format (IEEE 754)](https://es.wikipedia.org/wiki/Formato_en_coma_flotante_de_doble_precisi%C3%B3n)). En otros lenguajes de programación puede existir diferentes tipos numéricos, por ejemplo: Integers, Floats, Doubles, or Bignums.
 
 ## Aprende más

--- a/files/es/glossary/object/index.md
+++ b/files/es/glossary/object/index.md
@@ -4,6 +4,7 @@ slug: Glossary/Object
 translation_of: Glossary/Object
 original_slug: Glossary/Objecto
 ---
+
 El [Object](/es/docs/Web/JavaScript/Referencia/Objetos_globales/Object) se refiere a una estructura de datos que contiene datos e instrucciones para trabajar con los datos. Algunas veces los Objects se refieren a cosas del mundo real, por ejemplo, un object de un coche o mapa en un juego de carreras. {{glossary("JavaScript")}}, Java, C++, y Python son ejemplos de {{glossary("OOP","programación orientada a objetos")}}.
 
 ## Aprender más

--- a/files/es/glossary/oop/index.md
+++ b/files/es/glossary/oop/index.md
@@ -8,6 +8,7 @@ tags:
   - programacion
 translation_of: Glossary/OOP
 ---
+
 **OOP** (Programación orientada a objetos) es un paradigma de programación en el que los datos son encapsulados en **{{glossary("object","objetos")}},** los cuales tienen su propio comportamiento.
 
 {{glossary("JavaScript")}} esta altamente orientado a objetos. Sigue el modelo basado en prototipado (en oposición al modelo basado en **{{glossary("Class","clases")}}**).

--- a/files/es/glossary/operand/index.md
+++ b/files/es/glossary/operand/index.md
@@ -7,6 +7,7 @@ tags:
 translation_of: Glossary/Operand
 original_slug: Glossary/Operando
 ---
+
 **Un operando** es la parte de una instruccion que representa los datos manipulados por el {{glossary("Operator")}}. por ejemplo, cuando sumas dos numeros, los numeros son el operando y "+" es el operador.
 
 ## Aprende mas

--- a/files/es/glossary/operator/index.md
+++ b/files/es/glossary/operator/index.md
@@ -7,6 +7,7 @@ tags:
 translation_of: Glossary/Operator
 original_slug: Glossary/Operador
 ---
+
 Parte de la sintaxis reservada consistente en signos de puntuación o carácteres alfanuméricos que tienen funcionalidades incorporadas. Por ejemplo, "+" indica el operador suma y "!" indica el operador "not" (negación).
 
 ## Aprende más

--- a/files/es/glossary/parse/index.md
+++ b/files/es/glossary/parse/index.md
@@ -3,6 +3,7 @@ title: Parse (análisis sintáctico)
 slug: Glossary/Parse
 translation_of: Glossary/Parse
 ---
+
 "Parsing" significa analizar y convertir un programa en un formato interno que un entorno de ejecución pueda realmente ejecutar, por ejemplo el motor {{glossary("JavaScript")}} dentro de los navegadores.
 
 El [navegador analiza el HTML](/docs/Web/Guide/HTML/HTML5/HTML5_Parser) en un árbol {{glossary('DOM')}}. El análisis de HTML implica la "[tokenización](/docs/Web/API/DOMTokenList)" (dividir en fragmentos) y en la construcción del árbol. Los "tokens" HTML incluyen etiquetas de inicio y final, así como nombres de atributos y valores. Si el documento está bien formado, el análisis sintáctico es más sencillo y rápido. El "parser" analiza la entrada simbólica en el documento, construyendo el árbol del documento.

--- a/files/es/glossary/php/index.md
+++ b/files/es/glossary/php/index.md
@@ -6,6 +6,7 @@ tags:
   - Infraestructura
 translation_of: Glossary/PHP
 ---
+
 PHP (una inicialización recursiva para PHP: preprocesador de hipertexto) es un lenguaje de script de código abierto del lado del servidor que puede integrarse en HTML para crear aplicaciones web y sitios web dinámicos.
 
 ## Examples

--- a/files/es/glossary/plaintext/index.md
+++ b/files/es/glossary/plaintext/index.md
@@ -8,6 +8,7 @@ tags:
 translation_of: Glossary/Plaintext
 original_slug: Glossary/TextoSimple
 ---
+
 Texto simple se refiere a la información que se está utilizando como entrada para un {{Glossary("algorithm", "algoritmo")}} de {{Glossary("encryption","cifrado")}}, o para el {{Glossary("ciphertext", "texto cifrado")}} que se ha descifrado.
 
 Con frecuencia se usa indistintamente con el término texto claro, que se refiere de manera más general a cualquier información, como un documento de texto, una imagen, etc., que no se haya cifrado y que un humano o una computadora puedan leer sin procesamiento adicional.

--- a/files/es/glossary/polyfill/index.md
+++ b/files/es/glossary/polyfill/index.md
@@ -5,6 +5,7 @@ tags:
   - Glosario
 translation_of: Glossary/Polyfill
 ---
+
 Un polyfill es un fragmento de código (generalmente JavaScript en la Web) que se utiliza para proporcionar una funcionalidad moderna en navegadores antiguos que no lo admiten de forma nativa.
 
 Por ejemplo, se podría usar un polyfill para imitar la funcionalidad de un elemento HTML Canvas en Microsoft Internet Explorer 7 usando un complemento de Silverlight, o un soporte mímico para las unidades rem CSS, o {{cssxref("text-shadow")}}, o lo que tu quieras.

--- a/files/es/glossary/pop/index.md
+++ b/files/es/glossary/pop/index.md
@@ -9,6 +9,7 @@ tags:
   - Protocolo
 translation_of: Glossary/POP
 ---
+
 **POP3** (Protocolo de Oficina de Correo por sus siglas en inglés) es un [protocolo](/es/docs/Glossary/Protocol) muy común para obtener correos desde un servidor de correos por medio de una conexión [TCP](/es/docs/Glossary/TCP). POP3 no soporta directorios, a diferencia del más reciente [IMAP4](/es/docs/Glossary/IMAP), el cual es más difícil de implementar dada su extructura más compleja.
 
 Los clientes usualmente recuperan todos los mensajes y luego los eliminan del servidor, pero POP3 permite retener una copia en el servidor. Casi todos los servidores y clientes de correo actualmente soportan POP3.

--- a/files/es/glossary/port/index.md
+++ b/files/es/glossary/port/index.md
@@ -9,6 +9,7 @@ tags:
   - red de computadoras
 translation_of: Glossary/Port
 ---
+
 Para un ordenador conectado a una red con una [dirección IP](/es/docs/Glossary/IP_address), un **puerto** es el destino de la comunicación. Los puertos están designados por números, por debajo de 1024 cada puerto está asociado por defecto con un [protocolo](/es/docs/Glossary/Protocol) específico.
 
 Por ejemplo, el puerto por defecto para el protocolo [HTTP](/es/docs/Glossary/HTTP) es 80 y el puerto por defecto para el protocolo [HTTPS](/es/docs/Glossary/https) es 443, por lo tanto un servidor HTTP espera peticiones en esos puertos. Cada protocolo de internet está asociado con un puerto por defecto: [SMTP](/es/docs/Glossary/SMTP) (25), [POP3](/es/docs/Glossary/POP) (110), [IMAP](/es/docs/Glossary/IMAP) (143), [IRC](/es/docs/Glossary/IRC) (194), y así sucesivamente.

--- a/files/es/glossary/preflight_request/index.md
+++ b/files/es/glossary/preflight_request/index.md
@@ -4,6 +4,7 @@ slug: Glossary/Preflight_request
 translation_of: Glossary/Preflight_request
 original_slug: Glossary/Preflight_peticion
 ---
+
 Una petición preflight CORS es una petición [CORS](/en-US/docs/Glossary/CORS) realizada para comprobar si el protocolo {{Glossary("CORS")}} es comprendido.
 
 Es una petición {{HTTPMethod("OPTIONS")}}, que emplea tres cabeceras HTTP: {{HTTPHeader("Access-Control-Request-Method")}}, {{HTTPHeader("Access-Control-Request-Headers")}}, y la cabecera {{HTTPHeader("Origin")}} .

--- a/files/es/glossary/progressive_enhancement/index.md
+++ b/files/es/glossary/progressive_enhancement/index.md
@@ -7,6 +7,7 @@ tags:
   - Glosario
 translation_of: Glossary/Progressive_Enhancement
 ---
+
 **Mejora progresiva** es una filosofía de diseño que se centra en proporcionar una base de contenido y funcionalidad esenciales para la mayor cantidad de usuarios posible. Al mismo tiempo va más allá y trata de ofrecer la mejor experiencia posible sólo a los usuarios de los navegadores más modernos los cuales pueden ejecutar todo código requerido.
 
 La [detección de características](/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Feature_detection) se usa generalmente para determinar si los navegadores pueden manejar todo el contenido de alto nivel o no. Habitualmente se usan los [polyfills](/en-US/docs/Glossary/Polyfill) para incorporar las características faltantes con JavaScript.

--- a/files/es/glossary/promise/index.md
+++ b/files/es/glossary/promise/index.md
@@ -8,6 +8,7 @@ tags:
   - Promesas
 translation_of: Glossary/Promise
 ---
+
 Una **{{jsxref("Promesa")}}** es un {{Glossary("objeto")}} devuelto por una {{Glossary("función")}} que no ha completado su tarea. La promesa representa literalmente una promesa creada por una función a la que le llegará un resultado en un futuro.
 
 Cuando la función termina su tarea {{Glossary("asynchronous", "de forma asíncrona")}}, una función del objeto "promesa" será ejecutada.

--- a/files/es/glossary/property/index.md
+++ b/files/es/glossary/property/index.md
@@ -7,6 +7,7 @@ tags:
 translation_of: Glossary/property
 original_slug: Glossary/propiedad
 ---
+
 El término **propiedad** puede tener varios significados según el contexto. Se puede referir a:
 
 {{GlossaryDisambiguation}}

--- a/files/es/glossary/prototype-based_programming/index.md
+++ b/files/es/glossary/prototype-based_programming/index.md
@@ -3,6 +3,7 @@ title: Prototype-based programming
 slug: Glossary/Prototype-based_programming
 translation_of: Glossary/Prototype-based_programming
 ---
+
 **La programación basada en prototipos** es un estilo de {{Glossary("OOP", "programación orientada a objetos")}} en el que las {{Glossary('Clase', 'clases')}} no se definen explícitamente, sino que se derivan de agregar propiedades y métodos a una instancia de otra clase o, con menos frecuencia, agregarlos a un objeto vacío.
 
 En palabras simples: este tipo de estilo permite la creación de un {{Glossary('Objeto', 'objeto')}} sin definir primero su {{Glossary('Clase', 'clase')}}.

--- a/files/es/glossary/prototype/index.md
+++ b/files/es/glossary/prototype/index.md
@@ -3,6 +3,7 @@ title: Prototipo
 slug: Glossary/Prototype
 translation_of: Glossary/Prototype
 ---
+
 Un prototipo es un modelo que muestra pronto en el ciclo de desarrollo la apariencia y el comportamiento de una aplicación o producto.
 
 Mira [La herencia y la cadena de prototipado.](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain)

--- a/files/es/glossary/pseudo-class/index.md
+++ b/files/es/glossary/pseudo-class/index.md
@@ -10,6 +10,7 @@ tags:
 translation_of: Glossary/Pseudo-class
 original_slug: Glossary/Pseudo-clase
 ---
+
 En CSS, un selector de **pseudo-clase** apunta a elementos dependiendo de su estado en lugar de en su información en el arbol del documento. Por ejemplo, el selector `a` {{cssxref(":visited")}} aplica estilos solamente a los links que el usuario ha visitado.
 
 ## Aprender más

--- a/files/es/glossary/public-key_cryptography/index.md
+++ b/files/es/glossary/public-key_cryptography/index.md
@@ -3,6 +3,7 @@ title: Criptografía de clave pública
 slug: Glossary/Public-key_cryptography
 translation_of: Glossary/Public-key_cryptography
 ---
+
 La criptografía de clave pública es un sistema criptográfico en el que las claves vienen en pares. La transformación realizada por una de las claves solo se puede deshacer con la otra clave. Una clave (la clave privada) se mantiene secreta mientras que la otra se hace pública.
 
 Cuando se usa para firmas digitales, la clave privada se usa para firmar y la clave pública para verificar. Esto significa que cualquier persona puede verificar una firma, pero solo el propietario de la clave privada correspondiente podría haberla generado.

--- a/files/es/glossary/python/index.md
+++ b/files/es/glossary/python/index.md
@@ -10,6 +10,7 @@ tags:
   - programacion
 translation_of: Glossary/Python
 ---
+
 **Python** es un leguaje de programación de alto nivel y de propósito general. Utiliza un enfoque multiparadigma, lo que significa que soporta programación orientada a objetos, procedural y en menor medida, programación funcional.
 
 Fue creado por Guido van Rossun como sucesor a otro lenguaje (llamado ABC) entre 1985 y 1990, y es usado actualmente en una gran variedad de campos, como el desarrollo web, en la creación de aplicaciones actuales y para la construcción de archivos de procesamiento por lotes (Scripts).

--- a/files/es/glossary/recursion/index.md
+++ b/files/es/glossary/recursion/index.md
@@ -7,6 +7,7 @@ tags:
 translation_of: Glossary/Recursion
 original_slug: Glossary/Recursión
 ---
+
 Es el acto de una función llamándose a sí misma. La recursión es utilizada para resolver problemas que contienen subproblemas más pequeños. Una función recursiva puede recibir 2 entradas: un caso base (finaliza la recursión) o un un caso recursivo (continúa la recursión).
 
 ## Saber más

--- a/files/es/glossary/reflow/index.md
+++ b/files/es/glossary/reflow/index.md
@@ -3,6 +3,7 @@ title: Reflow
 slug: Glossary/Reflow
 translation_of: Glossary/Reflow
 ---
+
 **Un Reflow** sucede cuando un {{glossary("navegador")}} debe procesar y pintar parte de, o toda una pagina web nuevamente, Como despues de actualizar un sitio web interactivo
 
 ## Aprende más

--- a/files/es/glossary/regular_expression/index.md
+++ b/files/es/glossary/regular_expression/index.md
@@ -8,6 +8,7 @@ tags:
   - JavaScript
 translation_of: Glossary/Regular_expression
 ---
+
 **Expresiones regulares** (o _regex_) son reglas que definen las secuencias de caracteres obtenidas en una busqueda.
 
 Las expresiones regulares están incluidas en varios lenguages, pero las más conocida es la de Perl, que ha dado lugar a su propio ecosistema llamado PCRE (_Perl Compatible Regular Expression_). En la web, {{glossary("JavaScript")}} proporciona otra implementación de expresiones regulares a través del objeto {{jsxref("RegExp")}}.

--- a/files/es/glossary/response_header/index.md
+++ b/files/es/glossary/response_header/index.md
@@ -3,6 +3,7 @@ title: Cabecera de respuesta
 slug: Glossary/Response_header
 translation_of: Glossary/Response_header
 ---
+
 Una **cabecera de respuesta** (en inglés _response header_) es una {{Glossary("HTTP header")}} que puede ser usada en una respuesta HTTP y que no tiene que ver con el contenido del mensaje. Las cabeceras de respuesta, como {{HTTPHeader("Age")}}, {{HTTPHeader("Location")}} o {{HTTPHeader("Server")}} son usadas para dar un contexto más detallado de la respuesta.
 
 No todas las cabeceras que aparecen en una respuesta son categorizada como *cabeceras de respuesta* por la especificación. Por ejemplo, la cabecera {{HTTPHeader("Content-Type")}} es una {{glossary("representation header")}} indicando el tipo original de datos en el cuerpo del mensaje de respuesta (previo a que la codificación en la cabecera de representación {{HTTPHeader("Content-Encoding")}} sea aplicada). Sin embargo, en un mensaje de respuesta, "conversacionalmente" todas las cabeceras son usualmente llamadas como cabeceras de respuesta.

--- a/files/es/glossary/responsive_web_design/index.md
+++ b/files/es/glossary/responsive_web_design/index.md
@@ -3,6 +3,7 @@ title: Diseño web responsivo
 slug: Glossary/Responsive_web_design
 translation_of: Glossary/Responsive_web_design
 ---
+
 Diseño web responsivo (del inglés _**R**esponsive **W**eb **D**esign_) o **RWD** es un concepto de desarrollo web que se centra en hacer que los sitios se vean y se comporten de manera óptima en todos los dispositivos informáticos personales, desde el escritorio hasta el móvil.
 
 ## Aprender más

--- a/files/es/glossary/rest/index.md
+++ b/files/es/glossary/rest/index.md
@@ -7,6 +7,7 @@ tags:
   - Rest
 translation_of: Glossary/REST
 ---
+
 El término "Transferencia de Estado Representacional" (**REST**) representa un conjunto de características de diseño de arquitecturas software que aportan confiabilidad, eficiencia y escalibilidad a los sistemas distribuidos. Un sistema es llamado RESTful cuando se ajusta a estas características.
 
 La idea básica de REST es que un recurso, e.j. un documento, es transferido con su estado y su relaciones (hipertexto) mediante formatos y operaciones estandarizadas bien definidas.

--- a/files/es/glossary/rgb/index.md
+++ b/files/es/glossary/rgb/index.md
@@ -8,6 +8,7 @@ tags:
   - Principiante
 translation_of: Glossary/RGB
 ---
+
 Red Green Blue (RGB) es un modelo de color que representa los colores como mezclas de tres componentes subyacentes (o canales), rojo, verde y azul. Cada color se describe mediante una secuencia de tres números (normalmente entre 0.0 y 1.0, o entre 0 y 255) que representan las diferentes intensidades (o contribuciones) de rojo, verde y azul para determinar el color final.
 
 Hay muchas formas de describir los componentes RGB de un color. En {{Glossary("CSS")}} se pueden representar como un solo entero de 24 bits en notación hexadecimal (por ejemplo, `#ADD8E6` is azul claro), o en notación funcional como tres enteros de 8 bits separados (por ejemplo , rgb (46, 139, 87) es verde mar). En {{Glossary("OpenGL")}}, {{Glossary("WebGL")}}, y {{Glossary("GLSL")}} los componentes rojo-verde-azul son fracciones (números en coma flotante entre 0.0 y 1.0), aunque en el búfer de color real normalmente se almacenan como enteros de 8 bits. Gráficamente, un color se puede representar como un punto en una cuadrícula o cubo tridimensional, donde cada dimensión (o eje) corresponde a un canal diferente.

--- a/files/es/glossary/rss/index.md
+++ b/files/es/glossary/rss/index.md
@@ -10,6 +10,7 @@ tags:
   - XML
 translation_of: Glossary/RSS
 ---
+
 _RSS_ (Really Simple Syndication en español Sindicación Realmente Simple) hace referencia a los diferentes formatos de [XML](/es/docs/Glossary/XML) diseñados para sitios web de noticias.
 
 Cuando te subscribes a un _feed_ RSS (boletín de noticias de servicios web), éste te envía información y actualizaciones al _feed_ de tu lector RSS, y de esta manera no es necesario que el usuario busque manuelmente en cada sitio web.

--- a/files/es/glossary/ruby/index.md
+++ b/files/es/glossary/ruby/index.md
@@ -6,6 +6,7 @@ tags:
   - Ruby
 translation_of: Glossary/Ruby
 ---
+
 _Ruby_ es un lenguaje de programación de código abierto. En el contexto {{glossary("world wide web","Web")}}, Ruby se suele usar en el lado del servidor con el marco _Ruby On Rails_ (ROR) para producir sitios web y aplicaciones.
 
 ## Saber más

--- a/files/es/glossary/safe/index.md
+++ b/files/es/glossary/safe/index.md
@@ -4,6 +4,7 @@ slug: Glossary/safe
 translation_of: Glossary/safe
 original_slug: Glossary/seguro
 ---
+
 Un método HTTP es **seguro** cuando no altera el estado del servidor. En otras palabras, un método HTTP es seguro solo cuando ejecuta una operación de lectura. Todos los métodos seguros también son {{glossary("idempotent")}} así como algunos, pero no todos, métodos inseguros como {{HTTPMethod("PUT")}}, o {{HTTPMethod("DELETE")}}.
 
 Incluso si los métodos seguros tienen una semántica de solo lectura, los servidores pueden alterar su estado: por ejemplo, pueden registrar o mantener estadísticas. Lo importante aquí es que al llamar a un método seguro, el cliente no solicita ningún cambio en el servidor y, por lo tanto, no creará una carga o carga innecesaria para el servidor. Los navegadores pueden llamar a métodos seguros sin temor a causar ningún daño al servidor: esto les permite realizar actividades como la búsqueda previa sin riesgos. Los rastreadores web también confían en llamar a métodos seguros.

--- a/files/es/glossary/scm/index.md
+++ b/files/es/glossary/scm/index.md
@@ -8,6 +8,7 @@ tags:
 translation_of: Glossary/SCM
 original_slug: Glossary/SCV
 ---
+
 Un SCV (sistema de control de versiones) es un sistema para gestionar código fuente. Normalmente se refiere al uso de software para manejar versiones de ficheros fuente. Un programador puede modificar ficheros de código fuente sin miedo a eliminar código que funciona, porque un SCV realiza un seguimiento de cómo el código fuente ha cambiado y quién ha realizado los cambios.
 
 Algunos sistemas SCV son CVS, SVN y Git.

--- a/files/es/glossary/scope/index.md
+++ b/files/es/glossary/scope/index.md
@@ -3,6 +3,7 @@ title: Scope
 slug: Glossary/Scope
 translation_of: Glossary/Scope
 ---
+
 El contexto actual de ejecución. El contexto en el que los valores y las expresiones son "visibles" o pueden ser referenciados. Si una variable u otra expresión no está "en el Scope- alcance actual", entonces no está disponible para su uso. Los Scope también se pueden superponer en una jerarquía, de modo que los Scope secundarios tengan acceso a los ámbitos primarios, pero no al revés.
 
 Una función sirve como un cierre en JavaScript y, por lo tanto, crea un ámbito, de modo que (por ejemplo) no se puede acceder a una variable definida exclusivamente dentro de la función desde fuera de la función o dentro de otras funciones. Por ejemplo, lo siguiente no es válido:

--- a/files/es/glossary/seo/index.md
+++ b/files/es/glossary/seo/index.md
@@ -8,6 +8,7 @@ tags:
   - posicionamiento web
 translation_of: Glossary/SEO
 ---
+
 **SEO** (Search Engine Optimization) también conocido como posicionamiento web, es el proceso de hacer un sitio web más visible en los resultados de búsqueda o mejorar el ranking de búsqueda.
 
 Los motores de búsqueda siguen los enlaces de una página a otra, y el índice del contenido encontrado. Al realizar una búsqueda, el motor de búsqueda muestra el contenido indexado en base a su tabla de contenidos organizándolos guiados por las reglas de su algoritmo. El cumplimiento de las directrices de los buscadores con exactitud no implica el correcto posicionamiento del proyecto asociado en los mejores resultados, pero sí la ausencia de una penalización por parte del algoritmo del buscador.

--- a/files/es/glossary/sgml/index.md
+++ b/files/es/glossary/sgml/index.md
@@ -9,6 +9,7 @@ tags:
   - es
 translation_of: Glossary/SGML
 ---
+
 El _Lenguaje de marcado generalizado estándar_ (**SGML**) es una especificación {{Glossary("ISO")}} para definir lenguajes de marcado declarativos.
 
 En la Web, {{Glossary("HTML")}} 4, {{Glossary("XHTML")}}, y {{Glossary("XML")}} son lenguajes populares basados en SGML. Vale la pena señalar que desde la quinta edición, HTML ya no está basado en SGML y tiene sus propias reglas de análisis.

--- a/files/es/glossary/simd/index.md
+++ b/files/es/glossary/simd/index.md
@@ -7,6 +7,7 @@ tags:
   - SIMD
 translation_of: Glossary/SIMD
 ---
+
 SIMD (pronunciado "sim-dee" en inglés) son las siglas de **Single Instruction/Multiple Data**, el cual es un tipo de {{Interwiki("wikipedia","Taxonomía_de_Flynn","clasificación de arquitecturas de computadores")}}. SIMD permite realizar la misma operación en distintos datos lo que permite paralelismo mejorando el rendimiento — por ejemplo, en la compresión de gráficos 3D y videos, simulaciones físicas, criptografía y otros entornos.
 
 En contraposición, {{Glossary("SISD")}} es una arquitectura que funciona de forma secuencial tanto para datos como para instrucciones.

--- a/files/es/glossary/sisd/index.md
+++ b/files/es/glossary/sisd/index.md
@@ -7,6 +7,7 @@ tags:
   - SISD
 translation_of: Glossary/SISD
 ---
+
 SISD son las siglas de **Single Instruction/Single Data** la cual es una {{Interwiki("wikipedia","Flynn%27s_taxonomy","clasificación de arquitecturas")}}. En las arquitecturas SISD, un único procesador ejecuta una única instrucción sobre un único punto de la memoria.
 
 En contraposición {{Glossary("SIMD")}} es una arquitectura que permite realizar una operación sobre distintos puntos de memoria.

--- a/files/es/glossary/sld/index.md
+++ b/files/es/glossary/sld/index.md
@@ -3,6 +3,7 @@ title: SLD
 slug: Glossary/SLD
 translation_of: Glossary/SLD
 ---
+
 Un dominio de nivel secundario, o SLD (Second Level Domain) es el nombre que se encuentra antes del dominio de nivel primario, o TLD (Top Level Domain).
 
 Por ejemplo, en el dominio `mozilla.org`, `mozilla` es el dominio de nivel secundario del TLD `.org`.

--- a/files/es/glossary/sloppy_mode/index.md
+++ b/files/es/glossary/sloppy_mode/index.md
@@ -9,6 +9,7 @@ tags:
   - Sloppy
 translation_of: Glossary/Sloppy_mode
 ---
+
 {{Glossary("ECMAScript")}} 5 y versiones posteriores permiten que los scripts opten por un nuevo {{jsxref("Strict_mode", "Modo estricto", "", 1)}}, que modifica la semántica de JavaScript de varias formas para mejorar su capacidad de recuperación y facilitar la comprensión de lo que sucede cuando hay problemas.
 
 El modo normal, no estricto de JavaScript a veces se denomina **sloppy mode — modo poco riguroso**. Esta no es una designación oficial, pero es probable que la encuentres si pasas tiempo haciendo código JavaScript serio.

--- a/files/es/glossary/slug/index.md
+++ b/files/es/glossary/slug/index.md
@@ -8,6 +8,7 @@ tags:
   - Web
 translation_of: Glossary/Slug
 ---
+
 Un "slug" es un identificador único parte de una dirección web, típicamente al final de una "URL". por ejemplo, en el contexto de MDN (página actual), el "slug" es la parte del url después de "\<locale>/docs/" es decir "Glossary/Slug"
 
 Ver también

--- a/files/es/glossary/smtp/index.md
+++ b/files/es/glossary/smtp/index.md
@@ -9,6 +9,7 @@ tags:
   - Principiante
 translation_of: Glossary/SMTP
 ---
+
 **SMTP** (Protocolo de Transferencia de Correo Simple por sus siglas en inglés) es un [protocolo](/es/docs/Glossary/Protocol) utilizado para enviar un nuevo correo. Como [POP3](/es/docs/Glossary/POP) y [NNTP](/es/docs/Glossary/NNTP), es un protocolo dirigido por [estado de máquina](/es/docs/Glossary/State_machine).
 
 El protocolo es relativamente simple. Las complicaciones principales incluyen soportar varios mecanismos de autenticación ([GSSAPI](http://en.wikipedia.org/wiki/Generic_Security_Services_Application_Program_Interface), [CRAM-MD5](http://en.wikipedia.org/wiki/CRAM-MD5), [NTLM](http://en.wikipedia.org/wiki/NTLM), MSN, AUTH LOGIN, AUTH PLAIN, etc.), manejo de respuestas de error, y retroceder cuando los mecanismos de autenticación fallan (p. ej., el servidor asegura que soporta un mecanismo, pero no).

--- a/files/es/glossary/speculative_parsing/index.md
+++ b/files/es/glossary/speculative_parsing/index.md
@@ -9,6 +9,7 @@ tags:
 translation_of: Glossary/speculative_parsing
 original_slug: Web/HTML/Optimizing_your_pages_for_speculative_parsing
 ---
+
 Tradicionalmente en los navegadores el analizador de HTML corre en el hilo de ejecución principal y se queda bloqueado después de una etiqueta \</script> hasta que el código se haya recuperado y ejecutado. El analizador de HTML de Firefox 4 y posteriores soporta análisis especulativo fuera del hilo de ejecución principal. Este analiza anticipadamente mientras el codigo está siendo descargado y ejecutado. Como en Firefox 3.5 y 3.6, el analizador de HTML es el que inicia la carga especulativa de código, las hojas de estilos y las imagenes que va encontrando en el flujo de la página. Sin embargo en Firefox 4 y posteriores el analizador de HTML también ejecuta el algoritmo especulativo de la construcción del árbol HTML. La ventaja es que cuando lo especulado tiene exito, no hay necesidad de reanalizar la parte del archivo de entrada que ya fue analizada junto la descarga de código, hojas de estilo y las imágenes. La desventaja es que se ha realizado un trabajo inútil cuando la especulación fracasa.
 
 Este documento le ayuda a evitar este tipo de situaciones que hacen que la especulación falle y ralentize la carga de la página.

--- a/files/es/glossary/sql/index.md
+++ b/files/es/glossary/sql/index.md
@@ -5,6 +5,7 @@ translation_of: Glossary/SQL
 l10n:
   sourceCommit: d2a9f2e26a8139d4bb270d7dc3cddd8b848719fe
 ---
+
 **SQL** por sus siglas en inglés significa Lenguaje de Consulta Estructurada (Structured Query Language), es un lenguaje de programación diseñado para actualizar, obtener, y calcular información en bases de datos relacionales.
 
 ## Véase también

--- a/files/es/glossary/statement/index.md
+++ b/files/es/glossary/statement/index.md
@@ -7,6 +7,7 @@ tags:
 translation_of: Glossary/Statement
 original_slug: Glossary/Sentencias
 ---
+
 En un lenguaje de programación, una **sentencia** es una línea de código al mando de una tarea Cada programa consiste en una secuencia de sentencias.
 
 ## Aprender más

--- a/files/es/glossary/static_typing/index.md
+++ b/files/es/glossary/static_typing/index.md
@@ -8,6 +8,7 @@ tags:
 translation_of: Glossary/Static_typing
 original_slug: Glossary/Tipificación_estática
 ---
+
 Un lenguaje de **tipo estático** es un lenguaje (como Java, C, o C++) en donde los tipos de variables se conocen en tiempo de compilación. En la mayoria de estos lenguajes, los tipos deben ser expresamente indicados por el programador; en otros casos (como en OCaml), la inferencia de tipos permite al programador no indicar sus tipos de variables.
 
 ## Learn more

--- a/files/es/glossary/string/index.md
+++ b/files/es/glossary/string/index.md
@@ -8,6 +8,7 @@ tags:
   - String
 translation_of: Glossary/String
 ---
+
 En cualquier lenguaje de programación, un string es una secuencia de {{Glossary("character","caracteres")}} usado para representar el texto.
 
 En {{Glossary("JavaScript","JavaScript")}}, un String es uno de los {{Glossary("Primitivo", "valores primitivos")}} y el objeto {{jsxref("String")}} es un {{Glossary("wrapper","envoltorio")}} alrededor de un String primitivo.

--- a/files/es/glossary/svg/index.md
+++ b/files/es/glossary/svg/index.md
@@ -3,6 +3,7 @@ title: SVG
 slug: Glossary/SVG
 translation_of: Glossary/SVG
 ---
+
 Gráficos vectoriales escalables (del inglés _**S**calable **V**ector **G**raphics_) o **SVG** es un formato de imagen vectorial 2D basado en una sintaxis de {{Glossary("XML")}} .
 
 {{Glossary("W3C")}} comenzó a trabajar en SVG a finales de la década de 1990, pero SVG solo se hizo popular cuando {{Glossary("Microsoft Internet Explorer", "Internet Explorer")}} 9 salió con soporte para SVG. Todos los principales {{Glossary("browser","navegadores")}} ahora son compatibles con SVG.

--- a/files/es/glossary/svn/index.md
+++ b/files/es/glossary/svn/index.md
@@ -6,6 +6,7 @@ tags:
   - Glosario
 translation_of: Glossary/SVN
 ---
+
 Apache Subversion (**SVN**) es un sistema ({{Glossary("SCM")}}) de código abierto de control de almacenamiento. Permite a los desarrolladores mantener un historial de modificaciones de texto y código. Aunque SVN también puede manejar archivos binarios, no recomendamos su utilización para tales archivos.
 
 ## Saber más

--- a/files/es/glossary/symmetric-key_cryptography/index.md
+++ b/files/es/glossary/symmetric-key_cryptography/index.md
@@ -3,6 +3,7 @@ title: Criptografía de clave simétrica
 slug: Glossary/Symmetric-key_cryptography
 translation_of: Glossary/Symmetric-key_cryptography
 ---
+
 La criptografía de clave simétrica es un término utilizado para los algoritmos criptográficos que utilizan la misma clave para el cifrado y el descifrado. La clave se suele llamar "clave simétrica" o "clave secreta".
 
 Esto generalmente se contrasta con {{Glossary ("public-key cryptography","criptografía de clave pública")}} en el que las claves se generan en pares, y la transformación realizada por una clave solo se puede revertir utilizando la otra clave.

--- a/files/es/glossary/synchronous/index.md
+++ b/files/es/glossary/synchronous/index.md
@@ -9,6 +9,7 @@ tags:
 translation_of: Glossary/Synchronous
 original_slug: Glossary/Sincronico
 ---
+
 Sincrónico _se_ refiere a la comunicación en tiempo real donde cada lado recibe (y si es necesario, procesa y responde) mensajes instantáneamente (o lo más cerca posible a instantáneamente).
 
 Un ejemplo humano es el teléfono — durante una llamada telefónica tiendes a responder a la otra persona inmediatamente.

--- a/files/es/glossary/tag/index.md
+++ b/files/es/glossary/tag/index.md
@@ -6,6 +6,7 @@ tags:
   - etiqueta
 translation_of: Glossary/Tag
 ---
+
 En {{Glossary("HTML")}} una etiqueta es usada para crear un {{Glossary("elemento")}}. El **nombre** de un elemento HTML es el **nombre** utilizado entre paréntesis angulares así como la etiqueta `<p>` para el párrafo. Tenga en cuenta que el nombre de la etiqueta de cierre está precedido por un carácter de barra inclinada, `</p>`, y que en los elementos vacíos la etiqueta final no es necesaria ni permitida. Si no se mencionan atributos, se utilizan valores por defecto en cada caso.
 
 ## Aprende más

--- a/files/es/glossary/tcp/index.md
+++ b/files/es/glossary/tcp/index.md
@@ -10,6 +10,7 @@ tags:
   - red
 translation_of: Glossary/TCP
 ---
+
 **TCP** (**Protocolo de Control de Transmisión**, por sus siglas en inglés _Transmission Control Protocol_) es {{Glossary("protocol","protocolo")}} de red importante que permite que dos anfitriones (_hosts_) se conecten e intercambien flujos de datos. TCP garantiza la entrega de datos y {{Glossary("Packet","paquetes")}} en el mismo orden en que se enviaron. Vint Cerf y Bob Kahn, científicos de DARPA por aquél entonces, diseñaron TCP en la década de los 70.
 
 El rol de TCP es garantizar que los paquetes se entreguen de forma confiable y sin errores. TCP tiene control de concurrencia, lo que significa que las solicitudes iniciales serán pequeñas, aumentando de tamaño a los niveles de ancho de banda que los ordenadores, servidores y redes puedan soportar.

--- a/files/es/glossary/truthy/index.md
+++ b/files/es/glossary/truthy/index.md
@@ -7,6 +7,7 @@ tags:
   - JavaScript
 translation_of: Glossary/Truthy
 ---
+
 En {{Glossary("JavaScript")}}, un **valor verdadero** es un valor que se considera `true/verdadero` cuando es evaluado en un contexto {{Glossary("Booleano")}}. Todos los valores son verdaderos a menos que se definan como {{Glossary("Falso", "falso")}} (es decir, excepto `false`, `0`, `""`, `null`, `undefined`, y `NaN`).
 
 {{Glossary("JavaScript")}} usa {{Glossary("Type_Conversion", "coerción")}} en los contextos Booleanos.

--- a/files/es/glossary/type/index.md
+++ b/files/es/glossary/type/index.md
@@ -7,6 +7,7 @@ tags:
   - JavaScript
 translation_of: Glossary/Type
 ---
+
 El **tipo** (_type_ o _data type_) es una característica of una {{glossary("value", "valor")}} que afecta al tipo de datos que puede almacenar; por ejemplo, en JavaScript un {{domxref("Boolean")}} solo tiene valores `true`/`false`, mientras que un {{domxref("String")}} contiene cadenas de texto, un {{domxref("Number")}} contiene números de cualquier tipo, y así sucesivamente.
 
 El tipo de datos de un valor también afecta a qué operaciones son válidas en ese valor. Por ejemplo, un entero puede multiplicarse por un entero, pero no por una cadena.

--- a/files/es/glossary/type_coercion/index.md
+++ b/files/es/glossary/type_coercion/index.md
@@ -4,6 +4,7 @@ slug: Glossary/Type_coercion
 translation_of: Glossary/Type_coercion
 original_slug: Glossary/coercion
 ---
+
 La coerción es la conversión automática o implicita de valores de un tipo de dato a otro (Ejemplo: de cadena de texto a número). La conversión es similar a la coerción porque ambas convierten valores de un tipo de dato a otro pero con una diferencia clave - la coerción es implícita mientras que la conversión puede ser implícita o explícita.
 
 ## Examples

--- a/files/es/glossary/undefined/index.md
+++ b/files/es/glossary/undefined/index.md
@@ -3,6 +3,7 @@ title: undefined
 slug: Glossary/undefined
 translation_of: Glossary/undefined
 ---
+
 Un valor **{{Glossary("primitivo")}}** automáticamente asignado a las **variables** que solo han sido declarados o a los **{{Glossary("Argument","argumentos")}}** formales para los cuales no existe argumentos reales.
 
 ## Aprender más

--- a/files/es/glossary/unicode/index.md
+++ b/files/es/glossary/unicode/index.md
@@ -5,6 +5,7 @@ tags:
   - Infraestructura
 translation_of: Glossary/Unicode
 ---
+
 Unicode es un {{Glossary("Character set", "conjunto de caracteres")}} estándar que numera y define {{Glossary("Character", "caracteres")}} de diferentes idiomas, sistemas de escritura y símbolos. Al asignar un número a cada caracter, los programadores pueden crear {{Glossary("Character encoding", "codificaciones de caracteres")}}, para permitir que las computadoras almacenen, procesen y transmitan cualquier combinación de idiomas en el mismo archivo o programa.
 
 Antes de Unicode, era difícil y propenso a errores mezclar idiomas en los mismos datos. Por ejemplo, un juego de caracteres almacenaría caracteres japoneses y otro almacenaría el alfabeto árabe. Si no estuviera claramente marcado qué partes de los datos estaban en qué juego de caracteres, otros programas y computadoras mostrarían el texto incorrectamente o lo dañarían durante el procesamiento. Si alguna vez has visto texto en el que caracteres como comillas entrecruzadas (`“”`) fueron reemplazadas por un galimatías como `Ã‚Â£`, entonces has visto este problema, conocido como {{Interwiki("wikipedia", "Mojibake")}}.

--- a/files/es/glossary/uri/index.md
+++ b/files/es/glossary/uri/index.md
@@ -6,6 +6,7 @@ tags:
   - Identificador Uniforme de Recursos
 translation_of: Glossary/URI
 ---
+
 Un **URI** _(Identificador Uniforme de Recursos de sus siglas en inglés: Uniform Resource Identifier)_ es una cadena que se refiere a un recurso. Los más comunes son {{Glossary("URL","URLs")}}, que identifican el recurso dando su ubicación en la Web. {{Glossary("URN","URNs")}}, por el contrario, se refiere a un recurso por un nombre, en un espacio de nombres determinados, como el ISBN(International Standard Book Number) de un libro.
 
 ## Aprende más

--- a/files/es/glossary/utf-8/index.md
+++ b/files/es/glossary/utf-8/index.md
@@ -13,6 +13,7 @@ tags:
   - Utf-8
 translation_of: Glossary/UTF-8
 ---
+
 UTF-8 (UCS Transformation Format 8) es la {{Glossary("Character encoding", "Codificación de caracteres")}} más común en la red. El número de bytes que representan un carácter pueden ser desde uno hasta cuatro. UTF-8 es retrocompatible con {{Glossary("ASCII")}} y puede representar cualquier carácter Unicode estandar.
 
 Los primeros 128 carácteres UTF-8 se ajustan a los 128 primeros carácteres ASCII, lo cual significa que los textos escritos en ASCII son válidos en UTF-8. El resto de caracteres usan de dos a cuatro bytes. Cada byte reserva unos bits para albergar información sobre la codificación. Como los caracteres que no son ASCII necesitan más de un byte cuando son almacenados, corren el riesgo de corromperse si estos bytes son separados y no se vuelven a juntar.

--- a/files/es/glossary/ux/index.md
+++ b/files/es/glossary/ux/index.md
@@ -9,6 +9,7 @@ tags:
   - Navigation
 translation_of: Glossary/UX
 ---
+
 **UX** es un acrónimo de User eXperience. Es el estudio de la interacción entre usuarios y un sistema. Su objetivo es hacer que un sistema sea fácil de interactuar desde el punto de vista del usuario.
 
 El sistema puede ser cualquier tipo de producto o aplicación con el que un usuario final deba interactuar. Los estudios de UX realizados en una página web, por ejemplo, pueden demostrar si es fácil para los usuarios entender la página, navegar a diferentes áreas y completar tareas comunes, y dónde dichos procesos podrían tener menos fricciones.

--- a/files/es/glossary/validator/index.md
+++ b/files/es/glossary/validator/index.md
@@ -8,6 +8,7 @@ tags:
 translation_of: Glossary/Validator
 original_slug: Glossary/Validador
 ---
+
 Un validador es un programa que comprueba errores de sintaxis en el código. Las validadores pueden ser creados para cualquier formato o lenguaje, pero en este contexto se habla de herramientas que comprueban {{Glossary("HTML")}}, {{Glossary("CSS")}}, y {{Glossary("XML")}}.
 
 ## Saber más

--- a/files/es/glossary/value/index.md
+++ b/files/es/glossary/value/index.md
@@ -7,6 +7,7 @@ tags:
 translation_of: Glossary/Value
 original_slug: Glossary/Valor
 ---
+
 {{jsSidebar}}
 
 En el contexto de datos o un objeto **{{Glossary("Wrapper", "wrapper")}}** alrededor de esos datos, el valor es el **{{Glossary("Primitive", "valor primitivo")}}** que contiene el contenedor de objetos. En el contexto de una **{{Glossary("Variable", "variable")}}** o **{{Glossary("Property", "property")}}**, el El valor puede ser primitivo o **{{Glossary("Object reference", "Referencia de objeto")}}**.

--- a/files/es/glossary/variable/index.md
+++ b/files/es/glossary/variable/index.md
@@ -7,6 +7,7 @@ tags:
   - JavaScript
 translation_of: Glossary/Variable
 ---
+
 {{jsSidebar}}
 
 Una variable es una ubicación nombrada para almacenar un {{Glossary("Value", "valor")}}. De esta manera se puede acceder a un valor impredecible por medio de un nombre predeterminado.

--- a/files/es/glossary/vendor_prefix/index.md
+++ b/files/es/glossary/vendor_prefix/index.md
@@ -6,6 +6,7 @@ tags:
   - Glossary
 translation_of: Glossary/Vendor_Prefix
 ---
+
 Los proveedores de navegadores a veces agregan prefijos a las propiedades de CSS experimentales o no estándar y las API de JavaScript, por lo que los desarrolladores pueden experimentar con nuevas ideas mientras que, en teoría, evitan que se confíe en sus experimentos y luego rompan el código de los desarrolladores web durante el proceso de estandarización. Los desarrolladores deben esperar para incluir la propiedad sin prefijar hasta que se estandarice el comportamiento del navegador.
 
 > **Nota:** Los proveedores de navegadores están trabajando para dejar de usar los prefijos de proveedores para funciones experimentales. Los desarrolladores web los han estado utilizando en sitios web de producción, a pesar de su naturaleza experimental. Esto ha hecho que sea más difícil para los proveedores de navegadores garantizar la compatibilidad y trabajar en nuevas características; También ha sido perjudicial para los navegadores más pequeños que terminan obligados a agregar prefijos de otros navegadores para cargar sitios web populares.

--- a/files/es/glossary/viewport/index.md
+++ b/files/es/glossary/viewport/index.md
@@ -6,6 +6,7 @@ tags:
   - Glosario
 translation_of: Glossary/Viewport
 ---
+
 Un viewport representa la región poligonal (normalmente rectangular) en gráficas de computación que está siendo visualizada en ese instante. En términos de navegadores web, se refiere a la parte del documento que usted está viendo, la cual es actualmente visible en su ventana (o la pantalla, si el documento está siendo visto en modo pantalla completa). El contenido fuera del viewport no es visible en la pantalla hasta que sea desplazado dentro de él.
 
 La porción del viewport que se encuentra visible en ese momento se denomina **visual viewport**. Este puede ser más pequeño que el viewport de diseño, por ejemplo, cuando el usuario hace uso del zoom. El viewport de diseño (**layout viewport**), sigue siendo el mismo, pero el visual viewport se empequeñeció.

--- a/files/es/glossary/void_element/index.md
+++ b/files/es/glossary/void_element/index.md
@@ -4,6 +4,7 @@ slug: Glossary/Void_element
 translation_of: Glossary/Empty_element
 original_slug: Glossary/Empty_element
 ---
+
 Un **elemento vacío** es un {{Glossary("elemento")}} de HTML, SVG, o MathML que **no puede** tener nodos secundarios (es decir, elementos anidados o nodos de texto).
 
 Las especificaciones [HTML](https://html.spec.whatwg.org/multipage/), [SVG](https://www.w3.org/TR/SVG2/), y [MathML](https://www.w3.org/TR/MathML3/) definen con precisión lo que cada elemento puede contener. Muchas combinaciones no tienen sentido semántico, por ejemplo un elemento {{HTMLElement("audio")}} anidado dentro de un elemento {{HTMLElement("hr")}}.

--- a/files/es/glossary/wcag/index.md
+++ b/files/es/glossary/wcag/index.md
@@ -8,6 +8,7 @@ tags:
   - WCAG
 translation_of: Glossary/WCAG
 ---
+
 Las _Pautas de Accesibilidad para el Contenido Web_ (**WCAG**, por us siglas en inglés) son una recomendación publicada por el grupo {{Glossary("WAI","Web Accessibility Initiative")}} en el {{Glossary("W3C")}}. Describen un conjunto de pautas para hacer que el contenido sea accesible principalmente para personas con discapacidades, pero también para dispositivos de recursos limitados, como los teléfonos móviles.
 
 WCAG 2.0, que reemplazó a WCAG 1.0, se publicó como una recomendación del W3C el 11 de diciembre de 2008. Consta de 12 directrices organizadas en 4 principios (perceptibles, operables, comprensibles y robustos) y cada guía tiene criterios de éxito comprobables.

--- a/files/es/glossary/webkit/index.md
+++ b/files/es/glossary/webkit/index.md
@@ -11,6 +11,7 @@ tags:
   - WebKit
 translation_of: Glossary/WebKit
 ---
+
 _WebKit_ es un _framework_ (marco o interfaz) que proporciona páginas web "bien formadas" basadas es su lenguaje de marcado. El principal navegador que utiliza este framework es [Safari](/es/docs/Glossary/Apple_Safari), aunque también lo hacen muchos otros navegadores web para dispositivos móviles (debido a que WebKit es muy portable y customizable).
 
 WebKit comenzó como una copia del KHTML de KDE y sus librerías KJS, pero desde entonces ha habido una gran multitud de particulares y empresas que han contribuido en su desarrollo (incluyendo KDE, Apple, Google, y Nokia).

--- a/files/es/glossary/websockets/index.md
+++ b/files/es/glossary/websockets/index.md
@@ -11,6 +11,7 @@ tags:
   - WebSocket
 translation_of: Glossary/WebSockets
 ---
+
 _WebSocket_ es un {{Glossary("protocolo")}} que permite establecer conexiones {{Glossary("TCP")}} entre el {{Glossary("Server", "servidor")}} y el cliente, permitiendo así el transporte de datos en cualquier momento.
 
 Cualquier cliente o servidor de aplicaciones puede usar WebSockets, pero principalmente es usado por {{Glossary("Navegador", "browsers")}} y el servidor web. WebScoket permite enviar datos al cliente sin la necesidad de recibir ningún tipo de notificación, permitiendo la actualización dinámica del contenido.

--- a/files/es/glossary/webvtt/index.md
+++ b/files/es/glossary/webvtt/index.md
@@ -9,6 +9,7 @@ tags:
   - WebVTT
 translation_of: Glossary/WebVTT
 ---
+
 WebVTT (Pistas de Texto para Videos Wev) es una especificación del {{Glossary("W3C")}} para un formato de archivo para crear pistas de texto en combinación con el elemento HTML {{HTMLElement("track")}}.
 
 WebVTT files provide metadata that is time-aligned with audio or video content like captions or subtitles for video content, text video descriptions, chapters for content navigation, and more.

--- a/files/es/glossary/whatwg/index.md
+++ b/files/es/glossary/whatwg/index.md
@@ -10,6 +10,7 @@ tags:
   - Web
 translation_of: Glossary/WHATWG
 ---
+
 EL ( Grupo de trabajo de tecnología de aplicaciones de hipertexto web) por sus siglas en inglés WHATWG es una organización que mantinene y desarrolla {{Glossary("HTML")}} y {{Glossary("API", "APIs")}} para las aplicaciones Web. Antiguos empleados de Apple, Mozilla y Opera establecieron el WHATWG en el 2004.
 
 Los editores de especificación en el WHATWG investigan y recopilan comentarios para los documentos de especificación. El grupo también tiene un pequeño comité de miembros invitados y autorizados para anular o reemplazar editores de especificación. Puedes unirte como un colaborador registrándote en la [lista de correo](https://whatwg.org/mailing-list).

--- a/files/es/glossary/whitespace/index.md
+++ b/files/es/glossary/whitespace/index.md
@@ -8,6 +8,7 @@ tags:
 translation_of: Glossary/Whitespace
 original_slug: Glossary/Espacio_en_blanco
 ---
+
 El **espacio en blanco** es un conjunto de {{Glossary("Caracter", "caracteres")}} que se utiliza para mostrar espacios horizontales o verticales entre otros caracteres. A menudo se utilizan para separar fragmentos en {{Glossary("HTML")}}, {{Glossary("CSS")}}, {{Glossary("JavaScript")}} y otros lenguajes informáticos.Los caracteres de espacio en blanco y su uso varía de un lenguaje a otro.
 
 ## En HTML

--- a/files/es/glossary/world_wide_web/index.md
+++ b/files/es/glossary/world_wide_web/index.md
@@ -9,6 +9,7 @@ tags:
   - Web
 translation_of: Glossary/World_Wide_Web
 ---
+
 La _World Wide Web_ —comúnmente conocida como **WWW**, **W3**, o **la Web**— es un sistema interconectado de páginas web públicas accesibles a través de {{Glossary("Internet")}} (art. en inglés). La Web no es lo mismo que el Internet: la Web es una de las muchas aplicaciones construidas sobre Internet.
 
 Tim Berners-Lee propuso la arquitectura de lo que es conocido como la World Wide Web. Él creó el primer servidor web ({{Glossary("Server","server")}}) (art. en inglés), el primer navegador de internet ({{Glossary("Browser","browser")}}) (art. en inglés), y la primera página web, en su computadora del laboratorio de investigación de física del CERN en 1990. En 1991, anunció su creación en el grupo de noticias alt.hypertext, marcando con esto el momento en que la Web se hizo pública.

--- a/files/es/glossary/wrapper/index.md
+++ b/files/es/glossary/wrapper/index.md
@@ -7,6 +7,7 @@ tags:
   - Wrapper
 translation_of: Glossary/Wrapper
 ---
+
 En lenguajes de programación como JavaScript, un wrapper o envoltorio es una función que llama a una o varias funciones, unas veces únicamente por convenio y otras para adaptarlas con el objetivo de hacer una tarea ligeramente diferente.
 
 Por ejemplo, las librerías SDK de AWS son un ejemplo de wrappers.

--- a/files/es/glossary/xforms/index.md
+++ b/files/es/glossary/xforms/index.md
@@ -4,6 +4,7 @@ slug: Glossary/XForms
 translation_of: Glossary/XForms
 original_slug: Glossary/XForm
 ---
+
 **XForms** es una norma para la creación de formularios web y el procesamiento de datos de formulario en formato {{glossary("XML")}}. Actualmente ningún navegador soporta Xforms—sugerimos en su lugar utilizar los formularios en [HTML5 forms](/en-US/docs/Web/Guide/HTML/Forms).
 
 ## Saber más

--- a/files/es/glossary/xhtml/index.md
+++ b/files/es/glossary/xhtml/index.md
@@ -9,6 +9,7 @@ tags:
 translation_of: Glossary/XHTML
 original_slug: XHTML
 ---
+
 **XHTML** es a [XML](/es/XML) como [HTML](/es/HTML) es a [SGML](/es/SGML). Es decir, XHTML es un lenguaje de marcado que es similar al HTML, pero con un sintaxis más estricta. Dos versiones de XHTML han sido terminadas por el [W3C](http://www.w3.org/):
 
 - [XHTML 1.0](http://www.sidar.org/recur/desdi/traduc/es/xhtml/xhtml11.htm) es HTML4 reformulado como una aplicación XML, y es compatible con versiones anteriores de HTML en casos limitados.

--- a/files/es/glossary/xml/index.md
+++ b/files/es/glossary/xml/index.md
@@ -14,6 +14,7 @@ tags:
   - lenguaje de marcado
 translation_of: Glossary/XML
 ---
+
 _XML_ (eXtensible Markup Language en español **Lenguaje de Marcado eXtensible**) es un lenguaje de marcado genérico especificado por la W3C. La industria de tecnologías de la información (_IT Industry_) utiliza muchos lenguajes de descripción de datos (_data-description language_) que están basados en XML.
 
 Las etiquetas XML ó _tags_ son muy similares a las de [HTML](/es/docs/Glossary/HTML), pero en el caso de XML, es mucho más flexible debido a que permite a los usuarios definir sus propias etiquetas. En este sentido XML actúa como un metalenguaje (debido a esto, puede ser usado para definir otros lenguajes como por ejemplo [RSS](/es/docs/Glossary/RSS)). Además de esto, cabe señalar que HTML es un lenguaje de presentación, miestras que XML es un lenguaje descripción de datos.

--- a/files/es/learn/accessibility/accessibility_troubleshooting/index.md
+++ b/files/es/learn/accessibility/accessibility_troubleshooting/index.md
@@ -12,6 +12,7 @@ tags:
   - WAI-ARIA
 translation_of: Learn/Accessibility/Accessibility_troubleshooting
 ---
+
 {{LearnSidebar}}{{PreviousMenu("Learn/Accessibility/Mobile", "Learn/Accessibility")}}
 
 En la evaluación de este módulo, le presentamos un sitio simple con una serie de problemas de accesibilidad que necesita diagnosticar y corregir.

--- a/files/es/learn/accessibility/css_and_javascript/index.md
+++ b/files/es/learn/accessibility/css_and_javascript/index.md
@@ -3,6 +3,7 @@ title: Buenas prácticas de accesibilidad CSS y JavaScript
 slug: Learn/Accessibility/CSS_and_JavaScript
 translation_of: Learn/Accessibility/CSS_and_JavaScript
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Accessibility/HTML","Learn/Accessibility/WAI-ARIA_basics", "Learn/Accessibility")}}
 
 CSS y JavaScript, cuando se usan correctamente, también tienen el potencial de permitir experiencias web accesibles... o pueden dañar significativamente la accesibilidad si se usan incorrectamente. Este artículo describe algunas de las mejores prácticas de CSS y JavaScript que deben tenerse en cuenta para garantizar que incluso el contenido complejo sea lo más accesible posible.

--- a/files/es/learn/accessibility/html/index.md
+++ b/files/es/learn/accessibility/html/index.md
@@ -3,6 +3,7 @@ title: 'HTML: Una buena base para la accesibilidad'
 slug: Learn/Accessibility/HTML
 translation_of: Learn/Accessibility/HTML
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Accessibility/What_is_Accessibility","Learn/Accessibility/CSS_and_JavaScript", "Learn/Accessibility")}}
 
 Se puede hacer accesible una gran cantidad de contenido web solo asegurándose de que se utilizan los elementos HTML con el propósito correcto todo el tiempo. Este artículo muestra en detalle como HTML puede ser usado para asegurar máxima accesibilidad.

--- a/files/es/learn/accessibility/index.md
+++ b/files/es/learn/accessibility/index.md
@@ -15,6 +15,7 @@ tags:
   - modulo
 translation_of: Learn/Accessibility
 ---
+
 {{LearnSidebar}}
 
 Aprender algo de HTML, CSS y JavaScript es útil si deseas convertirte en un desarrollador web, pero tu conocimiento debe ir más allá de simplemente usar esas tecnologías, debes usarlas de manera responsable para maximizar la audiencia de tus sitios web y evitar impedir su uso a nadie. Para lograr esto, debes adherirte a las mejores prácticas generales (que se muestran en los temas de [HTML](/en-US/docs/Learn/HTML), [CSS](/en-US/docs/Learn/CSS) y [JavaScript](/en-US/docs/Learn/JavaScript)), [pruebas cruzadas del navegador](/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing) y considerar la accesibilidad desde el principio. En este módulo, cubriremos este último en detalle.

--- a/files/es/learn/accessibility/mobile/index.md
+++ b/files/es/learn/accessibility/mobile/index.md
@@ -3,6 +3,7 @@ title: Mobile accessibility
 slug: Learn/Accessibility/Mobile
 translation_of: Learn/Accessibility/Mobile
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Accessibility/Multimedia","Learn/Accessibility/Accessibility_troubleshooting", "Learn/Accessibility")}}
 
 Dado que el acceso a la web en dispositivos móviles es tan popular, y las plataformas populares como iOS y Android tienen herramientas de accesibilidad completas, es importante considerar la accesibilidad de su contenido web en estas plataformas. Este artículo analiza las consideraciones de accesibilidad específicas para dispositivos móviles.

--- a/files/es/learn/accessibility/what_is_accessibility/index.md
+++ b/files/es/learn/accessibility/what_is_accessibility/index.md
@@ -4,6 +4,7 @@ slug: Learn/Accessibility/What_is_accessibility
 translation_of: Learn/Accessibility/What_is_accessibility
 original_slug: Learn/Accessibility/Qué_es_la_accesibilidad
 ---
+
 {{LearnSidebar}}{{NextMenu("Learn/Accessibility/HTML", "Learn/Accessibility")}}
 
 En este artículo se inicia el módulo con una explicación ampliada sobre qué es la accesibilidad. Esta visión general incluye qué grupos de personas necesitamos tener en cuenta y por qué, qué herramientas utilizan estas personas para interactuar con la web y cómo podemos hacer que la accesibilidad sea parte de nuestro flujo de trabajo de desarrollo web.

--- a/files/es/learn/common_questions/how_does_the_internet_work/index.md
+++ b/files/es/learn/common_questions/how_does_the_internet_work/index.md
@@ -8,6 +8,7 @@ tags:
   - Web
 translation_of: Learn/Common_questions/How_does_the_Internet_work
 ---
+
 En este artículo se describe qué es Internet y cómo funciona.
 
 <table>

--- a/files/es/learn/common_questions/how_much_does_it_cost/index.md
+++ b/files/es/learn/common_questions/how_much_does_it_cost/index.md
@@ -11,6 +11,7 @@ tags:
 translation_of: Learn/Common_questions/How_much_does_it_cost
 original_slug: Learn/Common_questions/Cuanto_cuesta
 ---
+
 Dedicarse a la web no es tan barato como parece. En este artículo discutimos cuánto puedes tener que gastar, y por qué.
 
 <table>

--- a/files/es/learn/common_questions/index.md
+++ b/files/es/learn/common_questions/index.md
@@ -11,6 +11,7 @@ tags:
   - WebMechanics
 translation_of: Learn/Common_questions
 ---
+
 {{LearnSidebar}}
 
 Esta sección del área de aprendizaje está diseñada para proveer respuestas a preguntas frecuentes que pueden surgir, las cuales no son necesariamente parte del núcleo estructurado de formas de aprendizaje (ej. los artículos de aprendizaje de [HTML](/en-US/docs/Learn/HTML) o [CSS](/en-US/docs/Learn/CSS)). Éstos artículos están diseñados para trabajar por su cuenta.

--- a/files/es/learn/common_questions/pages_sites_servers_and_search_engines/index.md
+++ b/files/es/learn/common_questions/pages_sites_servers_and_search_engines/index.md
@@ -4,6 +4,7 @@ title: ¿Cuál es la diferencia entre la página web, el sitio web, el servidor 
 slug: Learn/Common_questions/Pages_sites_servers_and_search_engines
 translation_of: Learn/Common_questions/Pages_sites_servers_and_search_engines
 ---
+
 En este artículo se describen varios conceptos referidos a la web: Páginas web, sitios web, servidores web, y motores de búsqueda. Estos términos con frecuencia son confundidos por recién llegados a la web, o son incorrectamente usados. ¡Vamos a aprender qué significa cada uno!
 
 <table>

--- a/files/es/learn/common_questions/set_up_a_local_testing_server/index.md
+++ b/files/es/learn/common_questions/set_up_a_local_testing_server/index.md
@@ -15,6 +15,7 @@ tags:
   - servidores
 translation_of: Learn/Common_questions/set_up_a_local_testing_server
 ---
+
 En este artículo explica cómo configurar un servidor de prueba local simple en su equipo y los conceptos básicos de cómo utilizarlo.
 
 <table>

--- a/files/es/learn/common_questions/thinking_before_coding/index.md
+++ b/files/es/learn/common_questions/thinking_before_coding/index.md
@@ -9,6 +9,7 @@ tags:
   - proyecto
 translation_of: Learn/Common_questions/Thinking_before_coding
 ---
+
 Este artículo cubre el primer paso importante de cada proyecto: definir lo que se desea lograr con él.
 
 <table>

--- a/files/es/learn/common_questions/using_github_pages/index.md
+++ b/files/es/learn/common_questions/using_github_pages/index.md
@@ -4,6 +4,7 @@ slug: Learn/Common_questions/Using_Github_pages
 translation_of: Learn/Common_questions/Using_Github_pages
 original_slug: Learn/Using_Github_pages
 ---
+
 [GitHub](https://github.com/) es un sitio "social coding". Te permite subir repositorios de código para almacenarlo en el **sistema de control de versiones** [Git](http://git-scm.com/). Tu puedes colaborar en proyectos de código, y el sistema es código abierto por defecto, lo que significa que cualquiera en el mundo puede encontrar tu código en GitHub, usarlo, aprender de el, y mejorarlo. ¡Tú puedes hacer eso con el código de otras personas tambien! Este artículo provee una guía básica para publicar contenido usando la característica gh-pages de Github.
 
 ## Publicando contenido

--- a/files/es/learn/common_questions/what_are_hyperlinks/index.md
+++ b/files/es/learn/common_questions/what_are_hyperlinks/index.md
@@ -3,6 +3,7 @@ title: Qué son los hipervínculos?
 slug: Learn/Common_questions/What_are_hyperlinks
 translation_of: Learn/Common_questions/What_are_hyperlinks
 ---
+
 En este artículo, repasaremos qué son los hipervínculos y por qué son importantes.
 
 <table>

--- a/files/es/learn/common_questions/what_is_a_domain_name/index.md
+++ b/files/es/learn/common_questions/what_is_a_domain_name/index.md
@@ -8,6 +8,7 @@ tags:
   - Web
 translation_of: Learn/Common_questions/What_is_a_domain_name
 ---
+
 En este artículo discutiremos acerca de los nombres de los dominios: qué son, cómo se estructuran y cómo conseguir uno.
 
 <table>

--- a/files/es/learn/common_questions/what_is_a_url/index.md
+++ b/files/es/learn/common_questions/what_is_a_url/index.md
@@ -4,6 +4,7 @@ slug: Learn/Common_questions/What_is_a_URL
 translation_of: Learn/Common_questions/What_is_a_URL
 original_slug: Learn/Common_questions/Qué_es_una_URL
 ---
+
 Este artículo habla sobre las Uniform Resource Locators (URLs), explicando qué son y cómo se estructuran.
 
 <table>

--- a/files/es/learn/common_questions/what_is_a_web_server/index.md
+++ b/files/es/learn/common_questions/what_is_a_web_server/index.md
@@ -8,6 +8,7 @@ tags:
 translation_of: Learn/Common_questions/What_is_a_web_server
 original_slug: Learn/Common_questions/Que_es_un_servidor_WEB
 ---
+
 En este articulo veremos que son los servidores, cómo funcionan y por qué son importantes.
 
 <table>

--- a/files/es/learn/common_questions/what_software_do_i_need/index.md
+++ b/files/es/learn/common_questions/what_software_do_i_need/index.md
@@ -10,6 +10,7 @@ tags:
 translation_of: Learn/Common_questions/What_software_do_I_need
 original_slug: Learn/Common_questions/Que_software_necesito
 ---
+
 En este artículo se explican cuales componentes de software necesita para editar, cargar, o visualizar un sitio web.
 
 <table>

--- a/files/es/learn/css/building_blocks/backgrounds_and_borders/index.md
+++ b/files/es/learn/css/building_blocks/backgrounds_and_borders/index.md
@@ -4,6 +4,7 @@ slug: Learn/CSS/Building_blocks/Backgrounds_and_borders
 translation_of: Learn/CSS/Building_blocks/Backgrounds_and_borders
 original_slug: Learn/CSS/Building_blocks/Fondos_y_bordes
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/The_box_model", "Learn/CSS/Building_blocks/Handling_different_text_directions", "Learn/CSS/Building_blocks")}}
 
 En este artículo, veremos algunas de las cosas creativas que puedes hacer con los fondos y los bordes de CSS. Añadir degradados, imágenes de fondo o redondear esquinas; los fondos y los bordes son la solución para una gran cantidad de cuestiones de estilo en CSS.

--- a/files/es/learn/css/building_blocks/cascade_and_inheritance/index.md
+++ b/files/es/learn/css/building_blocks/cascade_and_inheritance/index.md
@@ -4,6 +4,7 @@ slug: Learn/CSS/Building_blocks/Cascade_and_inheritance
 translation_of: Learn/CSS/Building_blocks/Cascade_and_inheritance
 original_slug: Learn/CSS/Building_blocks/Cascada_y_herencia
 ---
+
 {{LearnSidebar}}{{NextMenu("Learn/CSS/Building_blocks/Selectors", "Learn/CSS/Building_blocks")}}
 
 El objetivo de este artículo es desarrollar la comprensión de algunos de los conceptos fundamentales de CSS (cascada, especificidad y herencia) que controlan cómo se aplica el CSS al HTML y cómo se resuelven los conflictos.

--- a/files/es/learn/css/building_blocks/debugging_css/index.md
+++ b/files/es/learn/css/building_blocks/debugging_css/index.md
@@ -4,6 +4,7 @@ slug: Learn/CSS/Building_blocks/Debugging_CSS
 translation_of: Learn/CSS/Building_blocks/Debugging_CSS
 original_slug: Learn/CSS/Building_blocks/Depurar_el_CSS
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Styling_tables", "Learn/CSS/Building_blocks/Organizing", "Learn/CSS/Building_blocks")}}
 
 Al escribir CSS te puedes encontrar que, a veces, alguna parte de tu CSS no hace lo que esperas. Tal vez creas que cierto selector debería coincidir con un elemento, pero no sucede nada; o una caja tiene un tamaño diferente al que esperabas. Este artículo te orientará sobre cómo solucionar un problema de CSS y te mostrará cómo las DevTools incluidas en todos los navegadores modernos pueden ayudarte a descubrir qué sucede.

--- a/files/es/learn/css/building_blocks/fundamental_css_comprehension/index.md
+++ b/files/es/learn/css/building_blocks/fundamental_css_comprehension/index.md
@@ -14,6 +14,7 @@ tags:
 translation_of: Learn/CSS/Building_blocks/Fundamental_CSS_comprehension
 original_slug: Learn/CSS/Introduction_to_CSS/Fundamental_CSS_comprehension
 ---
+
 {{LearnSidebar}}{{PreviousMenu("Learn/CSS/Introduction_to_CSS/Debugging_CSS", "Learn/CSS/Introduction_to_CSS")}}
 
 Has avanzado mucho en este módulo, debes sentirte orgulloso de haber llegado hasta el final. El último paso antes de terminar es intentar el examen del módulo — que incluye completar varios ejercicios para crear el último diseño — una tarjeta de presentación/de jugador/perfil de redes sociales.

--- a/files/es/learn/css/building_blocks/handling_different_text_directions/index.md
+++ b/files/es/learn/css/building_blocks/handling_different_text_directions/index.md
@@ -12,6 +12,7 @@ tags:
 translation_of: Learn/CSS/Building_blocks/Handling_different_text_directions
 original_slug: Learn/CSS/Building_blocks/Manejando_diferentes_direcciones_de_texto
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Backgrounds_and_borders", "Learn/CSS/Building_blocks/Overflowing_content", "Learn/CSS/Building_blocks")}}
 
 Muchas de las propiedades y valores que hemos encontrado hasta ahora en nuestro aprendizaje de CSS han estado ligadas a las dimensiones físicas de nuestra pantalla. Creamos bordes arriba, a la derecha, abajo y a la izquierda de una caja, por ejemplo. Estas dimensiones físicas se ajustan adecuadamente al contenido que se visualiza de forma horizontal, y por defecto, la web tiende a apoyar lenguajes de izquierda a derecha, como el castellano o el francés, mejor que aquellos que se escriben de derecha a izquierda, como el árabe.

--- a/files/es/learn/css/building_blocks/images_media_form_elements/index.md
+++ b/files/es/learn/css/building_blocks/images_media_form_elements/index.md
@@ -4,6 +4,7 @@ slug: Learn/CSS/Building_blocks/Images_media_form_elements
 translation_of: Learn/CSS/Building_blocks/Images_media_form_elements
 original_slug: Learn/CSS/Building_blocks/Imágenes_medios_y_elementos_de_formulario
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Sizing_items_in_CSS", "Learn/CSS/Building_blocks/Styling_tables", "Learn/CSS/Building_blocks")}}
 
 En este artículo vamos a ver cómo se tratan ciertos elementos especiales en CSS. Las imágenes y otros medios y los elementos de formulario presentan un comportamiento algo distinto que otros elementos CSS, como las cajas, en cuanto a aplicación de estilo. Comprender qué es y qué no es posible te ahorrará frustraciones, y en este artículo vamos a destacar algunas de las cuestiones principales que necesitas saber.

--- a/files/es/learn/css/building_blocks/overflowing_content/index.md
+++ b/files/es/learn/css/building_blocks/overflowing_content/index.md
@@ -4,6 +4,7 @@ slug: Learn/CSS/Building_blocks/Overflowing_content
 translation_of: Learn/CSS/Building_blocks/Overflowing_content
 original_slug: Learn/CSS/Building_blocks/Contenido_desbordado
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Handling_different_text_directions", "Learn/CSS/Building_blocks/Values_and_units", "Learn/CSS/Building_blocks")}}
 
 En este artículo veremos otro concepto importante en CSS: el **desbordamiento**. El desbordamiento es lo que sucede cuando hay demasiado contenido para que pueda caber cómodamente en una caja. En esta guía aprenderás qué es y cómo administrarlo.

--- a/files/es/learn/css/building_blocks/selectors/attribute_selectors/index.md
+++ b/files/es/learn/css/building_blocks/selectors/attribute_selectors/index.md
@@ -4,6 +4,7 @@ slug: Learn/CSS/Building_blocks/Selectors/Attribute_selectors
 translation_of: Learn/CSS/Building_blocks/Selectors/Attribute_selectors
 original_slug: Learn/CSS/Building_blocks/Selectores_CSS/Selectores_de_atributos
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Selectors/Type_Class_and_ID_Selectors", "Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements", "Learn/CSS/Building_blocks")}}
 
 Como ya explicamos en los artículos de HTML, los elementos pueden tener atributos que proporcionan un nivel de detalle mayor sobre el elemento que delimitan. En el CSS puedes utilizar selectores de atributo para seleccionar elementos definidos con unos atributos determinados. En este artículo veremos cómo utilizar estos selectores tan útiles.

--- a/files/es/learn/css/building_blocks/selectors/combinators/index.md
+++ b/files/es/learn/css/building_blocks/selectors/combinators/index.md
@@ -4,6 +4,7 @@ slug: Learn/CSS/Building_blocks/Selectors/Combinators
 translation_of: Learn/CSS/Building_blocks/Selectors/Combinators
 original_slug: Learn/CSS/Building_blocks/Selectores_CSS/Combinadores
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements", "Learn/CSS/Building_blocks/The_box_model", "Learn/CSS/Building_blocks")}}
 
 Los últimos selectores que veremos son los llamados selectores de combinación. Se llaman así porqué combinan otros selectores de manera que proporciona una relación útil entre ellos y la ubicación del contenido en el documento.

--- a/files/es/learn/css/building_blocks/selectors/index.md
+++ b/files/es/learn/css/building_blocks/selectors/index.md
@@ -4,6 +4,7 @@ slug: Learn/CSS/Building_blocks/Selectors
 translation_of: Learn/CSS/Building_blocks/Selectors
 original_slug: Learn/CSS/Building_blocks/Selectores_CSS
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Cascade_and_inheritance", "Learn/CSS/Building_blocks/Selectors/Type_Class_and_ID_Selectors", "Learn/CSS/Building_blocks")}}
 
 En {{Glossary( "CSS")}} los selectores se utilizan para delimitar los elementos {{glossary("HTML")}} de nuestra página web a los que queremos aplicar estilo. Hay una amplia variedad de selectores CSS, lo que permite una gran precisión a la hora de seleccionar elementos a los que aplicar estilo. En este artículo y sus subartículos veremos con detalle todos los tipos y el modo como funcionan.

--- a/files/es/learn/css/building_blocks/selectors/pseudo-classes_and_pseudo-elements/index.md
+++ b/files/es/learn/css/building_blocks/selectors/pseudo-classes_and_pseudo-elements/index.md
@@ -4,6 +4,7 @@ slug: Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements
 translation_of: Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements
 original_slug: Learn/CSS/Building_blocks/Selectores_CSS/Pseudo-clases_y_pseudo-elementos
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Selectors/Attribute_selectors", "Learn/CSS/Building_blocks/Selectors/Combinators", "Learn/CSS/Building_blocks")}}
 
 El conjunto de selectores que estudiaremos en este artículo se conocen como **pseudoclases** y **pseudoelementos**. Hay muchos y a menudo sirven para fines muy específicos. Una vez que sepas cómo usarlos, puedes echar un vistazo a la lista para ver si alguno sirve para la página que quieres crear. Una vez más, la página correspondiente de MDN resulta muy útil para conocer qué navegadores los admiten o no.

--- a/files/es/learn/css/building_blocks/selectors/type_class_and_id_selectors/index.md
+++ b/files/es/learn/css/building_blocks/selectors/type_class_and_id_selectors/index.md
@@ -4,6 +4,7 @@ slug: Learn/CSS/Building_blocks/Selectors/Type_Class_and_ID_Selectors
 translation_of: Learn/CSS/Building_blocks/Selectors/Type_Class_and_ID_Selectors
 original_slug: Learn/CSS/Building_blocks/Selectores_CSS/Selectores_de_tipo_clase_e_ID
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Selectors", "Learn/CSS/Building_blocks/Selectors/Attribute_selectors", "Learn/CSS/Building_blocks")}}
 
 En este artículo vamos a echar un vistazo a los selectores más simples de que dispones y que seguramente serán los que utilices con mayor frecuencia.

--- a/files/es/learn/css/building_blocks/sizing_items_in_css/index.md
+++ b/files/es/learn/css/building_blocks/sizing_items_in_css/index.md
@@ -4,6 +4,7 @@ slug: Learn/CSS/Building_blocks/Sizing_items_in_CSS
 translation_of: Learn/CSS/Building_blocks/Sizing_items_in_CSS
 original_slug: Learn/CSS/Building_blocks/Dimensionar_elementos_en_CSS
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Values_and_units", "Learn/CSS/Building_blocks/Images_media_form_elements", "Learn/CSS/Building_blocks")}}
 
 En los diversos artículos vistos hasta ahora, has aprendido varias formas de dimensionar elementos en una página web utilizando CSS. Es importante que comprendas qué tamaños van a tener los diferentes elementos de tu diseño, y en este artículo vamos a resumir las diversas formas en que puedes asignar tamaños a los elementos con CSS y definir algunos términos relativos al dimensionado que te ayudarán en el futuro.

--- a/files/es/learn/css/building_blocks/styling_tables/index.md
+++ b/files/es/learn/css/building_blocks/styling_tables/index.md
@@ -3,6 +3,7 @@ title: Estilizando tablas
 slug: Learn/CSS/Building_blocks/Styling_tables
 translation_of: Learn/CSS/Building_blocks/Styling_tables
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Images_media_form_elements", "Learn/CSS/Building_blocks/Debugging_CSS", "Learn/CSS/Building_blocks")}}
 
 Aplicar estilos a una tabla HTML no es el trabajo más interesante del mundo, pero a veces hay que hacerlo. Este artículo proporciona una guía para hacer que las tablas HTML presenten un aspecto agradable, para ello usaremos algunas de las características específicas para tablas que hemos destacado en artículos anteriores.

--- a/files/es/learn/css/building_blocks/the_box_model/index.md
+++ b/files/es/learn/css/building_blocks/the_box_model/index.md
@@ -4,6 +4,7 @@ slug: Learn/CSS/Building_blocks/The_box_model
 translation_of: Learn/CSS/Building_blocks/The_box_model
 original_slug: Learn/CSS/Building_blocks/El_modelo_de_caja
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Selectors/Combinators", "Learn/CSS/Building_blocks/Backgrounds_and_borders", "Learn/CSS/Building_blocks")}}
 
 Todo en CSS tiene una caja alrededor, y comprender estas cajas es clave para poder crear diseños con CSS o para alinear elementos con otros elementos. En este artículo, echaremos un vistazo más de cerca al _modelo de cajas_ en CSS con el que vas a poder crear diseños de compaginación más complejos con una comprensión de cómo funciona y la terminología relacionada.

--- a/files/es/learn/css/building_blocks/values_and_units/index.md
+++ b/files/es/learn/css/building_blocks/values_and_units/index.md
@@ -4,6 +4,7 @@ slug: Learn/CSS/Building_blocks/Values_and_units
 translation_of: Learn/CSS/Building_blocks/Values_and_units
 original_slug: Learn/CSS/Building_blocks/Valores_y_unidades_CSS
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Overflowing_content", "Learn/CSS/Building_blocks/Sizing_items_in_CSS", "Learn/CSS/Building_blocks")}}
 
 Todas las propiedades que se utilizan en CSS tienen un valor o un conjunto de valores que esa propiedad admite, y echar un vistazo a cualquier página de propiedades en MDN te ayudará a comprender qué valores admite una propiedad en particular. En este artículo veremos algunos de los valores y unidades más comunes en uso.

--- a/files/es/learn/css/css_layout/flexbox/index.md
+++ b/files/es/learn/css/css_layout/flexbox/index.md
@@ -3,6 +3,7 @@ title: Flexbox
 slug: Learn/CSS/CSS_layout/Flexbox
 translation_of: Learn/CSS/CSS_layout/Flexbox
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/CSS_layout/Normal_Flow", "Learn/CSS/CSS_layout/Grids", "Learn/CSS/CSS_layout")}}
 
 [Flexbox](/es/docs/Web/CSS/CSS_Flexible_Box_Layout) es un método de diseño de página unidimensional para compaginar elementos en filas o columnas. Los elementos de contenido se ensanchan para rellenar el espacio adicional y se encogen para caber en espacios más pequeños. En este artículo expondremos todas sus características básicas.

--- a/files/es/learn/css/css_layout/floats/index.md
+++ b/files/es/learn/css/css_layout/floats/index.md
@@ -3,6 +3,7 @@ title: Floats
 slug: Learn/CSS/CSS_layout/Floats
 translation_of: Learn/CSS/CSS_layout/Floats
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/CSS_layout/Grids", "Learn/CSS/CSS_layout/Positioning", "Learn/CSS/CSS_layout")}}
 
 Originalmente pensada para flotar imágenes dentro de bloques de texto, la propiedad {{cssxref("float")}} se convirtió en una de las herramientas más usadas para crear diseños multicolumna en las páginas web. Con la llegada de Flexbox y Grid ha vuelto ahora a su propósito original, como se explica en este artículo.

--- a/files/es/learn/css/css_layout/grids/index.md
+++ b/files/es/learn/css/css_layout/grids/index.md
@@ -3,6 +3,7 @@ title: Cuadrículas
 slug: Learn/CSS/CSS_layout/Grids
 translation_of: Learn/CSS/CSS_layout/Grids
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/CSS_layout/Flexbox", "Learn/CSS/CSS_layout/Floats", "Learn/CSS/CSS_layout")}}
 
 La compaginación en cuadrícula con CSS es un método de diseño de páginas web en dos dimensiones. Te permite distribuir el contenido en filas y columnas, y tiene muchas características que facilitan la creación de diseños complejos. Este artículo te proporciona todo lo que necesitas saber para comenzar con el diseño de páginas web.

--- a/files/es/learn/css/css_layout/index.md
+++ b/files/es/learn/css/css_layout/index.md
@@ -18,6 +18,7 @@ tags:
   - float
 translation_of: Learn/CSS/CSS_layout
 ---
+
 {{LearnSidebar}}
 
 Llegados a este punto, hemos examinado los fundamentos básicos de CSS: cómo dar estilo al texto y cómo manipular las cajas que incluyen tu contenido. Llegó el momento de explorar cómo colocar tus cajas en el lugar que elijas con respecto a la ventana principal y el resto de cajas. Hemos cubierto ya los prerrequisitos necesarios, así que vamos a sumergirnos en la maquetación CSS, fijándonos en diferentes configuraciones de visualización, métodos de maquetación tradicionales que implican _floats_ y posicionamiento, así como a nuevas herramientas de maquetación en voga, como _flexbox_.

--- a/files/es/learn/css/css_layout/introduction/index.md
+++ b/files/es/learn/css/css_layout/introduction/index.md
@@ -4,6 +4,7 @@ slug: Learn/CSS/CSS_layout/Introduction
 translation_of: Learn/CSS/CSS_layout/Introduction
 original_slug: Learn/CSS/CSS_layout/Introducción
 ---
+
 {{LearnSidebar}}{{NextMenu("Learn/CSS/CSS_layout/Normal_Flow", "Learn/CSS/CSS_layout")}}
 
 Este artículo resumirá algunas de las características de diseño de páginas web con CSS que ya hemos mencionado en módulos anteriores, como los diferentes valores de {{cssxref ("display")}}, e introducirá algunos de los conceptos que vamos a tratar en este módulo.

--- a/files/es/learn/css/css_layout/normal_flow/index.md
+++ b/files/es/learn/css/css_layout/normal_flow/index.md
@@ -4,6 +4,7 @@ slug: Learn/CSS/CSS_layout/Normal_Flow
 translation_of: Learn/CSS/CSS_layout/Normal_Flow
 original_slug: Learn/CSS/CSS_layout/Flujo_normal
 ---
+
 {{LearnSidebar}}
 
 {{PreviousMenuNext("Learn/CSS/CSS_layout/Introduction", "Learn/CSS/CSS_layout/Flexbox", "Learn/CSS/CSS_layout")}}

--- a/files/es/learn/css/css_layout/responsive_design/index.md
+++ b/files/es/learn/css/css_layout/responsive_design/index.md
@@ -4,6 +4,7 @@ slug: Learn/CSS/CSS_layout/Responsive_Design
 translation_of: Learn/CSS/CSS_layout/Responsive_Design
 original_slug: Learn/CSS/CSS_layout/Diseño_receptivo
 ---
+
 {{learnsidebar}}{{PreviousMenuNext("Learn/CSS/CSS_layout/Multiple-column_Layout", "Learn/CSS/CSS_layout/Media_queries", "Learn/CSS/CSS_layout")}}
 
 En los primeros días del diseño web, las páginas se diseñaban para llenar un tamaño de pantalla en particular. Si el usuario tenía una pantalla más grande o más pequeña que la del diseñador, los resultados esperados iban desde barras de desplazamiento no deseadas hasta longitudes de línea excesivamente largas y un mal uso del espacio. A medida que estuvieron disponibles tamaños de pantalla más diversos, apareció el concepto de _diseño web responsivo_ (RWD, _responsive web design_), un conjunto de prácticas que permite a las páginas web alterar su diseño y apariencia para adaptarse a diferentes anchos de pantalla, resoluciones, etc. Es una idea que cambió la forma en que diseñamos para una web multidispositivo, y en este artículo te ayudaremos a comprender las principales técnicas que necesitas saber para dominarlo.

--- a/files/es/learn/css/css_layout/supporting_older_browsers/index.md
+++ b/files/es/learn/css/css_layout/supporting_older_browsers/index.md
@@ -4,6 +4,7 @@ slug: Learn/CSS/CSS_layout/Supporting_Older_Browsers
 translation_of: Learn/CSS/CSS_layout/Supporting_Older_Browsers
 original_slug: Learn/CSS/CSS_layout/Soporte_a_navegadores_antiguos
 ---
+
 {{LearnSidebar}}
 
 {{PreviousMenuNext("Learn/CSS/CSS_layout/Legacy_Layout_methods", "Learn/CSS/CSS_layout/Fundamental_Layout_Comprehension", "Learn/CSS/CSS_layout")}}

--- a/files/es/learn/css/first_steps/getting_started/index.md
+++ b/files/es/learn/css/first_steps/getting_started/index.md
@@ -14,6 +14,7 @@ tags:
 translation_of: Learn/CSS/First_steps/Getting_started
 original_slug: Learn/CSS/First_steps/Comenzando_CSS
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/First_steps/What_is_CSS", "Learn/CSS/First_steps/How_CSS_is_structured", "Learn/CSS/First_steps")}}
 
 En este artículo aplicaremos CSS a un documento HTML sencillo para aprender algunos elementos prácticos sobre este lenguaje.

--- a/files/es/learn/css/first_steps/how_css_is_structured/index.md
+++ b/files/es/learn/css/first_steps/how_css_is_structured/index.md
@@ -4,6 +4,7 @@ slug: Learn/CSS/First_steps/How_CSS_is_structured
 translation_of: Learn/CSS/First_steps/How_CSS_is_structured
 original_slug: Learn/CSS/First_steps/Como_se_estructura_CSS
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/First_steps/Getting_started", "Learn/CSS/First_steps/How_CSS_works", "Learn/CSS/First_steps")}}
 
 Ahora que ya sabes qué es el CSS y conoces sus conceptos básicos, es hora de profundizar un poco más en la estructura del lenguaje en sí. Ya hemos visto muchos de los conceptos que aparecen en este artículo; puedes volver para recapitular si más adelante encuentras conceptos confusos.

--- a/files/es/learn/css/first_steps/how_css_works/index.md
+++ b/files/es/learn/css/first_steps/how_css_works/index.md
@@ -4,6 +4,7 @@ slug: Learn/CSS/First_steps/How_CSS_works
 translation_of: Learn/CSS/First_steps/How_CSS_works
 original_slug: Learn/CSS/First_steps/Como_funciona_CSS
 ---
+
 {{LearnSidebar}}
 {{PreviousMenuNext("Learn/CSS/First_steps/How_CSS_is_structured", "Learn/CSS/First_steps/Using_your_new_knowledge", "Learn/CSS/First_steps")}}
 

--- a/files/es/learn/css/first_steps/index.md
+++ b/files/es/learn/css/first_steps/index.md
@@ -9,6 +9,7 @@ tags:
   - primeros pasos
 translation_of: Learn/CSS/First_steps
 ---
+
 {{LearnSidebar}}
 
 CSS (Cascading Style Sheets - en español Hojas de Estilo en Cascadas) es usado para darle estilo y diseño a las páginas Web — por ejemplo, para cambiar la fuente de letra, color, tamaño y el espaciado de tu contenido; dividir en múltiples columnas, o agregar animaciones y otras propiedades decorativas. Este modulo provee un inicio suave para tu ruta de aprendizaje hacia el dominio de CSS con su funcionamiento básico, como luce su sintaxis, y cómo puedes comenzar a utilizarlo y añadir estilo a HTML.

--- a/files/es/learn/css/first_steps/styling_a_biography_page/index.md
+++ b/files/es/learn/css/first_steps/styling_a_biography_page/index.md
@@ -8,6 +8,7 @@ tags:
 translation_of: Learn/CSS/First_steps/Using_your_new_knowledge
 original_slug: Learn/CSS/First_steps/Using_your_new_knowledge
 ---
+
 {{LearnSidebar}}{{PreviousMenu("Learn/CSS/First_steps/How_CSS_works", "Learn/CSS/First_steps")}}
 
 Con las cosas que has aprendido en las últimas lecciones, puedes darle formato a documentos de texto simple utilizando CSS para agregar tu propio estilo a ellos. Esta evaluación te da una posibilidad de hacer eso.

--- a/files/es/learn/css/first_steps/what_is_css/index.md
+++ b/files/es/learn/css/first_steps/what_is_css/index.md
@@ -12,6 +12,7 @@ tags:
 translation_of: Learn/CSS/First_steps/What_is_CSS
 original_slug: Learn/CSS/First_steps/Qué_es_CSS
 ---
+
 {{LearnSidebar}}{{NextMenu("Learn/CSS/First_steps/Getting_started", "Learn/CSS/First_steps")}}
 
 Las hojas de estilo en cascada (**{{Glossary("CSS")}}**, cascading style sheets) permiten crear páginas web atractivas. Pero ¿cómo funcionan realmente? En este artículo explicaremos qué es el CSS con un ejemplo de sintaxis sencillo y describiremos algunos términos clave sobre este lenguaje.

--- a/files/es/learn/css/howto/css_faq/index.md
+++ b/files/es/learn/css/howto/css_faq/index.md
@@ -7,6 +7,7 @@ tags:
 translation_of: Learn/CSS/Howto/CSS_FAQ
 original_slug: Web/CSS/Preguntas_frecuentes_sobre_CSS
 ---
+
 #### Mi CSS es válida, pero no se representa correctamente
 
 Los navegadores utilizan la declaración `DOCTYPE` para elegir entre mostrar el documento usando un modo que sea más compatible con los estándares de la Web o mostrarlo con los fallos de los navegadores antiguos. El uso de una declaración `DOCTYPE` correcta y moderna al inicio del código HTML mejorará el cumplimiento de los estándares del navegador.

--- a/files/es/learn/css/howto/generated_content/index.md
+++ b/files/es/learn/css/howto/generated_content/index.md
@@ -4,6 +4,7 @@ slug: Learn/CSS/Howto/Generated_content
 translation_of: Learn/CSS/Howto/Generated_content
 original_slug: Learn/CSS/Howto/Generated_content
 ---
+
 {{LearnSidebar}}
 
 Este artículo describe algunas formas en las que puedes usar CSS para agregar contenido cuando se muestra un documento. Modificas tu hoja de estilo para agregar contenido de texto o imágenes.

--- a/files/es/learn/css/howto/index.md
+++ b/files/es/learn/css/howto/index.md
@@ -4,6 +4,7 @@ slug: Learn/CSS/Howto
 translation_of: Learn/CSS/Howto
 original_slug: Learn/CSS/Sábercomo
 ---
+
 {{LearnSidebar}}
 
 Los siguientes enlaces apuntan a soluciones comunes a los problemas cotidianos que necesitará resolver con CSS.

--- a/files/es/learn/css/index.md
+++ b/files/es/learn/css/index.md
@@ -12,6 +12,7 @@ tags:
   - longitud
 translation_of: Learn/CSS
 ---
+
 {{LearnSidebar}}
 
 Las Hojas de estilo en cascada (del ingles _Cascading Stylesheets_ {{glossary("CSS")}}) es la siguiente tecnología que aprenderemos después de {{glossary("HTML")}}. Mientras que HTML se utiliza para definir la estructura y la semántica del contenido, CSS se usa para darle estilo y posicionarlo visualmente. CSS se puede usar, por ejemplo, para cambiar la fuente, el color, el tamaño y el espaciado del contenido, para formar multiples columnas, añadir animaciones y otros elementos decorativos.

--- a/files/es/learn/css/styling_text/fundamentals/index.md
+++ b/files/es/learn/css/styling_text/fundamentals/index.md
@@ -3,6 +3,7 @@ title: Fundamentos de texto y fuentes tipográficas
 slug: Learn/CSS/Styling_text/Fundamentals
 translation_of: Learn/CSS/Styling_text/Fundamentals
 ---
+
 {{LearnSidebar}}{{NextMenu("Learn/CSS/Styling_text/Styling_lists", "Learn/CSS/Styling_text")}}
 
 En este artículo vas a iniciar tu viaje hacia el dominio la aplicación de estilos a textos con {{glossary("CSS")}}. Aquí trataremos en detalle todos los fundamentos básicos del diseño del texto y las fuentes tipográficas, incluyendo la configuración de su grosor, la familia y el estilo de letra, las propiedades abreviadas para los tipos de letra, la alineación del texto, el espaciado entre líneas y letras, y otros efectos.

--- a/files/es/learn/css/styling_text/index.md
+++ b/files/es/learn/css/styling_text/index.md
@@ -20,6 +20,7 @@ tags:
   - web fonts
 translation_of: Learn/CSS/Styling_text
 ---
+
 {{LearnSidebar}}
 
 Con los conceptos básicos del lenguaje CSS cubiertos, el siguiente tema de CSS para concentrarse es estilizar texto — una de las cosas más comunes que hará con CSS. Aquí observamos los fundamentos para estilizar texto, incluyendo la configuración de fuente, negrita, cursiva, linea y espacios entre letras, sombras paralelas y otras funciones de texto. Completamos el módulo observando la aplicación de fuentes personalizadas en su página, y el diseño de listas y enlaces.

--- a/files/es/learn/css/styling_text/styling_links/index.md
+++ b/files/es/learn/css/styling_text/styling_links/index.md
@@ -3,6 +3,7 @@ title: Dar estilo a los enlaces
 slug: Learn/CSS/Styling_text/Styling_links
 translation_of: Learn/CSS/Styling_text/Styling_links
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Styling_text/Styling_lists", "Learn/CSS/Styling_text/Web_fonts", "Learn/CSS/Styling_text")}}
 
 A la hora de dar estilo a los [enlaces](/es/docs/Learn/HTML/Introduccion_a_HTML/Creating_hyperlinks), es importante comprender cómo utilizar las pseudoclases para diseñar los estados de un enlace de manera efectiva y cómo diseñar enlaces para su uso en diversas funciones de interfaz comunes, como menús y pestañas de navegación. Veremos todos estos temas en este artículo.

--- a/files/es/learn/css/styling_text/styling_lists/index.md
+++ b/files/es/learn/css/styling_text/styling_lists/index.md
@@ -3,6 +3,7 @@ title: Aplicación de estilo a listas
 slug: Learn/CSS/Styling_text/Styling_lists
 translation_of: Learn/CSS/Styling_text/Styling_lists
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Styling_text/Fundamentals", "Learn/CSS/Styling_text/Styling_links", "Learn/CSS/Styling_text")}}
 
 Las [listas](/en-US/Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals#Lists) se comportan como cualquier otro texto en su mayor parte, pero hay algunas propiedades CSS específicas de las listas que debes conocer y algunas prácticas recomendadas a tener en cuenta. Este artículo te lo explica.

--- a/files/es/learn/css/styling_text/web_fonts/index.md
+++ b/files/es/learn/css/styling_text/web_fonts/index.md
@@ -4,6 +4,7 @@ slug: Learn/CSS/Styling_text/Web_fonts
 translation_of: Learn/CSS/Styling_text/Web_fonts
 original_slug: Learn/CSS/Styling_text/Fuentes_web
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Styling_text/Styling_links", "Learn/CSS/Styling_text/Typesetting_a_homepage", "Learn/CSS/Styling_text")}}
 
 En el primer artículo del módulo, exploramos las características básicas del CSS disponibles para aplicar estilos a tipos de letra y al texto. En este artículo vamos a ir más lejos: exploraremos en detalle las tipografías web, que permiten que te descargues tipos de letra personalizados junto con tu página web para lograr un estilo de texto más variado y personalizado.

--- a/files/es/learn/forms/basic_native_form_controls/index.md
+++ b/files/es/learn/forms/basic_native_form_controls/index.md
@@ -4,6 +4,7 @@ slug: Learn/Forms/Basic_native_form_controls
 translation_of: Learn/Forms/Basic_native_form_controls
 original_slug: Learn/HTML/Forms/The_native_form_widgets
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Forms/How_to_structure_an_HTML_form", "Learn/Forms/HTML5_input_types", "Learn/Forms")}}
 
 En el [artículo anterior](/es/docs/Learn/HTML/Forms/How_to_structure_an_HTML_form), marcamos un ejemplo de formulario web funcional, presentamos algunos controles de formulario y elementos estructurales comunes, y nos centramos en las mejores prácticas de accesibilidad. A continuación, veremos con detalle las funciones de los diferentes controles de formulario, o _widgets_, y estudiaremos todas las diferentes opciones de que se dispone para la recopilación de diferentes tipos de datos. En este artículo en particular, veremos el conjunto original de controles de formulario, disponible en todos los navegadores desde los primeros días de la web.

--- a/files/es/learn/forms/form_validation/index.md
+++ b/files/es/learn/forms/form_validation/index.md
@@ -12,6 +12,7 @@ tags:
 translation_of: Learn/Forms/Form_validation
 original_slug: Learn/HTML/Forms/Validacion_formulario_datos
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Forms/UI_pseudo-classes", "Learn/Forms/Sending_and_retrieving_form_data", "Learn/HTML/Forms")}}
 
 Antes de enviar datos al servidor, es importante asegurarse de que se completan todos los controles de formulario requeridos, y en el formato correcto. Esto se denomina **validación de formulario en el lado del cliente** y ayuda a garantizar que los datos que se envían coinciden con los requisitos establecidos en los diversos controles de formulario. Este artículo te guiará por los conceptos básicos y ejemplos de validación de formularios en el lado del cliente.

--- a/files/es/learn/forms/how_to_build_custom_form_controls/index.md
+++ b/files/es/learn/forms/how_to_build_custom_form_controls/index.md
@@ -4,6 +4,7 @@ slug: Learn/Forms/How_to_build_custom_form_controls
 translation_of: Learn/Forms/How_to_build_custom_form_controls
 original_slug: Learn/HTML/Forms/como_crear_widgets_de_formularios_personalizados
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Forms/Form_validation", "Learn/HTML/Forms/Sending_forms_through_JavaScript", "Learn/HTML/Forms")}}
 
 Hay muchos casos donde los [widgets de formularios HTML disponibles](/es/docs/HTML/Forms/The_native_form_widgets) simplemente no son suficientes. si desea [establecer un estilo avanzado](/es/docs/Advanced_styling_for_HTML_forms) en algunos widgets como el elemento {{HTMLElement("select")}} o si desea proporcionar comportamientos personalizados, no tiene más opción que crear sus propios widgets.

--- a/files/es/learn/forms/how_to_structure_a_web_form/index.md
+++ b/files/es/learn/forms/how_to_structure_a_web_form/index.md
@@ -4,6 +4,7 @@ slug: Learn/Forms/How_to_structure_a_web_form
 translation_of: Learn/Forms/How_to_structure_a_web_form
 original_slug: Learn/HTML/Forms/How_to_structure_an_HTML_form
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Forms/Your_first_form", "Learn/Forms/Basic_native_form_controls", "Learn/Forms")}}
 
 Una vez examinados los conceptos básicos, vamos a ver más en detalle los elementos que se utilizan para proporcionar estructura y significado a las diferentes partes de un formulario.

--- a/files/es/learn/forms/html5_input_types/index.md
+++ b/files/es/learn/forms/html5_input_types/index.md
@@ -4,6 +4,7 @@ slug: Learn/Forms/HTML5_input_types
 translation_of: Learn/Forms/HTML5_input_types
 original_slug: Learn/HTML/Forms/Tipos_input_HTML5
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Forms/Basic_native_form_controls", "Learn/Forms/Other_form_controls", "Learn/Forms")}}
 
 En el [artículo anterior](/es/docs/Learn/Forms/Basic_native_form_controls) vimos el elemento {{htmlelement("input")}} y los valores de su atributo `type`, disponibles desde los inicios de HTML. Ahora veremos en detalle la funcionalidad de los controles de formulario más recientes, incluyendo algunos tipos de input nuevos, los cuales fueron añadidos en HTML5 para permitir la recolección de tipos de datos específicos

--- a/files/es/learn/forms/index.md
+++ b/files/es/learn/forms/index.md
@@ -7,6 +7,7 @@ tags:
   - HTML5
 original_slug: HTML/HTML5/Forms_in_HTML5
 ---
+
 Los elementos y atributos para formularios en HTML5 proveen un mayor grado de marcado semántico que en HTML4 y eliminan gran parte del tedioso trabajo de programar y diseñar que se necesitaba en HTML4. Las funcionalidades de los formularios en HTML5 brindan una experiencia mejor para los usuarios al permitir que los formularios tengan un comportamiento más consistente entre diferentes sitios web y al darle una devolución inmediata acerca de la información ingresada. También proveen esta experiencia a los usuarios que han deshabilitado javascript en sus navegadores.
 
 Este documento describe los elementos nuevos o que han cambiado que están disponibles en Gecko/Firefox.

--- a/files/es/learn/forms/sending_and_retrieving_form_data/index.md
+++ b/files/es/learn/forms/sending_and_retrieving_form_data/index.md
@@ -4,6 +4,7 @@ slug: Learn/Forms/Sending_and_retrieving_form_data
 translation_of: Learn/Forms/Sending_and_retrieving_form_data
 original_slug: Learn/HTML/Forms/Sending_and_retrieving_form_data
 ---
+
 {{LearnSidebar}} {{PreviousMenuNext("Aprende / HTML / Formularios / The_native_form_widgets", "Aprender / html / Formularios / Form_validation", "Aprender / html / Forms")}}
 
 En este artículo se analiza lo que sucede cuando un usuario envía un formulario - ¿A dónde van los datos y cómo los manejamos cuando llegan allí? - También tenemos en cuenta algunos de los problemas de seguridad asociados con el envío de los datos del formulario.

--- a/files/es/learn/forms/styling_web_forms/index.md
+++ b/files/es/learn/forms/styling_web_forms/index.md
@@ -4,6 +4,7 @@ slug: Learn/Forms/Styling_web_forms
 translation_of: Learn/Forms/Styling_web_forms
 original_slug: Learn/HTML/Forms/Styling_HTML_forms
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Forms/Other_form_controls","Learn/Forms/Advanced_form_styling","Learn/Forms")}}
 
 En los artículos anteriores vimos todo el HTML que necesitas para crear y estructurar tus formularios HTML. En este artículo veremos como usar [CSS](/es/docs/Web/CSS) para estilizar nuestros formularios. Esto historicamente ha sido díficil — cada control tiene un nivel de dificultad distinta — pero se esta volviendo más fácil a medida de que los navegadores antiguos son retirados, y los modernos nos abren más posibilidades.

--- a/files/es/learn/forms/test_your_skills_colon__html5_controls/index.md
+++ b/files/es/learn/forms/test_your_skills_colon__html5_controls/index.md
@@ -10,6 +10,7 @@ tags:
 translation_of: Learn/Forms/Test_your_skills:_HTML5_controls
 original_slug: Learn/HTML/Forms/Prueba_tus_habilidades:_controles_HTML5
 ---
+
 {{learnsidebar}}
 
 El objetivo de esta prueba es evaluar si has comprendido nuestro artículo [The HTML5 input types](/es/docs/Learn/Forms/HTML5_input_types).

--- a/files/es/learn/forms/test_your_skills_colon__other_controls/index.md
+++ b/files/es/learn/forms/test_your_skills_colon__other_controls/index.md
@@ -4,6 +4,7 @@ slug: Learn/Forms/Test_your_skills:_Other_controls
 translation_of: Learn/Forms/Test_your_skills:_Other_controls
 original_slug: Learn/HTML/Forms/Prueba_tus_habilidades:_Otros_controles
 ---
+
 {{learnsidebar}}
 
 El objetivo de esta pueba de habilidad es evaluar si has comprendido nuestro artículo [Otros controles de formulario](/es/docs/Learn/Forms/Other_form_controls).

--- a/files/es/learn/forms/your_first_form/index.md
+++ b/files/es/learn/forms/your_first_form/index.md
@@ -11,6 +11,7 @@ tags:
 translation_of: Learn/Forms/Your_first_form
 original_slug: Learn/HTML/Forms/Your_first_HTML_form
 ---
+
 {{LearnSidebar}}{{NextMenu("Learn/Forms/How_to_structure_a_web_form", "Learn/Forms")}}
 
 El primer artículo de nuestra serie te proporciona una primera experiencia de creación de un formulario web, que incluye diseñar un formulario sencillo con controles de formulario adecuados y otros elementos HTML, añadir un poco de estilo muy simple con CSS y describir cómo se envían los datos a un servidor. Ampliaremos cada uno de estos subtemas más adelante.

--- a/files/es/learn/getting_started_with_the_web/css_basics/index.md
+++ b/files/es/learn/getting_started_with_the_web/css_basics/index.md
@@ -10,6 +10,7 @@ tags:
   - aprende
 translation_of: Learn/Getting_started_with_the_web/CSS_basics
 ---
+
 {{LearnSideBar}}{{PreviousMenuNext("Learn/Getting_started_with_the_web/HTML_basics", "Learn/Getting_started_with_the_web/JavaScript_basics","Learn/Getting_started_with_the_web")}}
 
 CSS (_Hojas de Estilo en Cascada_) es el código que usas para dar estilo a tu página web. _CSS Básico_ te lleva a través de lo que tú necesitas para empezar. Contestará a preguntas del tipo: ¿Cómo hago mi texto rojo o negro? ¿Cómo hago que mi contenido se muestre en tal y tal lugar de la pantalla? ¿Cómo decoro mi página web con imágenes de fondo y colores?

--- a/files/es/learn/getting_started_with_the_web/how_the_web_works/index.md
+++ b/files/es/learn/getting_started_with_the_web/how_the_web_works/index.md
@@ -16,6 +16,7 @@ tags:
 translation_of: Learn/Getting_started_with_the_web/How_the_Web_works
 original_slug: Learn/Getting_started_with_the_web/Cómo_funciona_la_Web
 ---
+
 {{LearnSidebar()}}{{PreviousMenu("Learn/Getting_started_with_the_web/Publishing_your_website", "Learn/Getting_started_with_the_web")}}
 
 _Cómo funciona la web_ proporciona una vista simplificada de lo que sucede cuando ves una página web en un navegador web de tu computador o teléfono.

--- a/files/es/learn/getting_started_with_the_web/html_basics/index.md
+++ b/files/es/learn/getting_started_with_the_web/html_basics/index.md
@@ -8,6 +8,7 @@ tags:
   - Web
 translation_of: Learn/Getting_started_with_the_web/HTML_basics
 ---
+
 {{LearnSideBar}}
 
 {{PreviousMenuNext("Learn/Getting_started_with_the_web/Dealing_with_files", "Learn/Getting_started_with_the_web/CSS_basics","Learn/Getting_started_with_the_web")}}

--- a/files/es/learn/getting_started_with_the_web/javascript_basics/index.md
+++ b/files/es/learn/getting_started_with_the_web/javascript_basics/index.md
@@ -11,6 +11,7 @@ tags:
   - l10n:priority
 translation_of: Learn/Getting_started_with_the_web/JavaScript_basics
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext( "Learn/Getting_started_with_the_web/CSS_basics","Learn/Getting_started_with_the_web/Publishing_your_website","Learn/Getting_started_with_the_web")}}
 
 JavaScript es el lenguaje de programación que debes usar para añadir características interactivas a tu sitio web, (por ejemplo, juegos, eventos que ocurren cuando los botones son presionados o los datos son introducidos en los formularios, efectos de estilo dinámicos, animación, y mucho más). Este artículo te ayudará a comenzar con este lenguaje extraordinario y te dará una idea de qué es posible hacer con él.

--- a/files/es/learn/getting_started_with_the_web/publishing_your_website/index.md
+++ b/files/es/learn/getting_started_with_the_web/publishing_your_website/index.md
@@ -15,6 +15,7 @@ tags:
   - web server
 translation_of: Learn/Getting_started_with_the_web/Publishing_your_website
 ---
+
 {{LearnSidebar()}}
 
 {{PreviousMenuNext("Learn/Getting_started_with_the_web/JavaScript_basics", "Learn/Getting_started_with_the_web/How_the_Web_works","Learn/Getting_started_with_the_web")}}

--- a/files/es/learn/html/howto/author_fast-loading_html_pages/index.md
+++ b/files/es/learn/html/howto/author_fast-loading_html_pages/index.md
@@ -9,6 +9,7 @@ tags:
 translation_of: Learn/HTML/Howto/Author_fast-loading_HTML_pages
 original_slug: Web/HTML/Consejos_para_la_creación_de_páginas_HTML_de_carga_rápida
 ---
+
 ## Consejos para la creación de páginas HTML de carga rápida
 
 Estos consejos estan basados en conocimiento común y experimentación.

--- a/files/es/learn/html/howto/index.md
+++ b/files/es/learn/html/howto/index.md
@@ -7,6 +7,7 @@ tags:
 translation_of: Learn/HTML/Howto
 original_slug: Learn/HTML/como
 ---
+
 {{LearnSidebar}}
 
 Los siguientes enlaces brindan soluciones puntuales a los problemas más comunes a los que te enfrentarás a diario en HTML.

--- a/files/es/learn/html/howto/use_data_attributes/index.md
+++ b/files/es/learn/html/howto/use_data_attributes/index.md
@@ -4,6 +4,7 @@ slug: Learn/HTML/Howto/Use_data_attributes
 translation_of: Learn/HTML/Howto/Use_data_attributes
 original_slug: Learn/HTML/como/Usando_atributos_de_datos
 ---
+
 {{LearnSidebar}}
 
 [HTML5](/es/docs/Web/Guide/HTML/HTML5) está diseñado de forma tal que sea fácil extender los datos asociados a un elemento en particular sin necesidad de que tengan un significado definido. Los atributos [`data-*`](/es/docs/Web/HTML/Global_attributes#attr-dataset) permiten almacenar información adicional sobre un elemento HTML cualquiera sin tener que recurrir a artilugios tales como la utilización de atributos no estándar, propiedades adicionales en el DOM o {{domxref("Node.setUserData()")}}.

--- a/files/es/learn/html/introduction_to_html/debugging_html/index.md
+++ b/files/es/learn/html/introduction_to_html/debugging_html/index.md
@@ -13,6 +13,7 @@ tags:
 translation_of: Learn/HTML/Introduction_to_HTML/Debugging_HTML
 original_slug: Learn/HTML/Introduccion_a_HTML/Debugging_HTML
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/Document_and_website_structure", "Learn/HTML/Introduction_to_HTML/Marking_up_a_letter", "Learn/HTML/Introduction_to_HTML")}}
 
 Escribir HTML es fácil, pero ¿qué pasa si algo va mal y desconocemos dónde está el error de codificación? En este artículo veremos varias herramientas que nos ayudarán a arreglar errores en HTML.

--- a/files/es/learn/html/introduction_to_html/marking_up_a_letter/index.md
+++ b/files/es/learn/html/introduction_to_html/marking_up_a_letter/index.md
@@ -11,6 +11,7 @@ tags:
 translation_of: Learn/HTML/Introduction_to_HTML/Marking_up_a_letter
 original_slug: Learn/HTML/Introduccion_a_HTML/Marking_up_a_letter
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Introduction_to_HTML/Debugging_HTML", "Learn/HTML/Introduction_to_HTML/Structuring_a_page_of_content", "Learn/HTML/Introduction_to_HTML")}}
 
 Todos aprendemos a escribir una carta más tarde o más temprano; es también práctico practicar con nuestras habilidades para dar forma a los textos. En esta prueba deberás demostrar tus habilidades para dar forma a textos, incluyendo enlaces, además pondremos a prueba tu familiaridad con algunos contenidos de encabezamiento `<head>` en HTML.

--- a/files/es/learn/html/introduction_to_html/structuring_a_page_of_content/index.md
+++ b/files/es/learn/html/introduction_to_html/structuring_a_page_of_content/index.md
@@ -14,6 +14,7 @@ tags:
 translation_of: Learn/HTML/Introduction_to_HTML/Structuring_a_page_of_content
 original_slug: Learn/HTML/Introduccion_a_HTML/Estructuración_de_una_página_de_contenido
 ---
+
 {{LearnSidebar}}{{PreviousMenu("Learn/HTML/Introduction_to_HTML/Marking_up_a_letter", "Learn/HTML/Introduction_to_HTML")}}
 
 La estructuración de una página de contenido lista para su uso mediante CSS es una habilidad muy importante para dominar, por lo que en esta evaluación verá su capacidad para pensar en cómo podría finalizar una página buscando y eligiendo la semántica estructural adecuada para construir un diseño en la parte superior.

--- a/files/es/learn/html/introduction_to_html/test_your_skills_colon__advanced_html_text/index.md
+++ b/files/es/learn/html/introduction_to_html/test_your_skills_colon__advanced_html_text/index.md
@@ -4,6 +4,7 @@ slug: Learn/HTML/Introduction_to_HTML/Test_your_skills:_Advanced_HTML_text
 translation_of: Learn/HTML/Introduction_to_HTML/Test_your_skills:_Advanced_HTML_text
 original_slug: Learn/HTML/Introduccion_a_HTML/Test_your_skills:_Advanced_HTML_text
 ---
+
 {{learnsidebar}}
 
 El objetivo de esta prueba de habilidad es evaluar si ha entendido nuestras __[formato de texto avanzado](/es/docs//en-US/docs/Learn/HTML/Introduction_to_HTML/Advanced_text_formatting)__ articulo.

--- a/files/es/learn/html/introduction_to_html/test_your_skills_colon__html_text_basics/index.md
+++ b/files/es/learn/html/introduction_to_html/test_your_skills_colon__html_text_basics/index.md
@@ -10,6 +10,7 @@ tags:
 translation_of: Learn/HTML/Introduction_to_HTML/Test_your_skills:_HTML_text_basics
 original_slug: Learn/HTML/Introduccion_a_HTML/Prueba_tus_habilidades:_Texto_básico_HTML
 ---
+
 {{learnsidebar}}
 
 El objetivo de esta prueba de habilidad es evaluar si has comprendido el artículo [Fundamentos de texto en HTML](/es/docs/Learn/HTML/Introduccion_a_HTML/texto).

--- a/files/es/learn/html/introduction_to_html/test_your_skills_colon__links/index.md
+++ b/files/es/learn/html/introduction_to_html/test_your_skills_colon__links/index.md
@@ -4,6 +4,7 @@ slug: Learn/HTML/Introduction_to_HTML/Test_your_skills:_Links
 translation_of: Learn/HTML/Introduction_to_HTML/Test_your_skills:_Links
 original_slug: Learn/HTML/Introduccion_a_HTML/Prueba_tus_habilidades:_Enlaces
 ---
+
 {{learnsidebar}}
 
 El objetivo de esta pueba de habilidad es evaluar si has comprendido nuestro artículo [Creando hipervínculos](/es/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks).

--- a/files/es/learn/html/multimedia_and_embedding/adding_vector_graphics_to_the_web/index.md
+++ b/files/es/learn/html/multimedia_and_embedding/adding_vector_graphics_to_the_web/index.md
@@ -15,6 +15,7 @@ tags:
   - img
 translation_of: Learn/HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies", "Learn/HTML/Multimedia_and_embedding/Responsive_images", "Learn/HTML/Multimedia_and_embedding")}}
 
 Los gráficos vectoriales son muy útiles en muchas circunstancias — tienen tamaño de archivo pequeños y son altamente escalables, por lo que no se pixelan cuando se amplían a un tamaño más grande. En este artículo le mostraremos cómo incluir uno en su página web.

--- a/files/es/learn/html/multimedia_and_embedding/images_in_html/index.md
+++ b/files/es/learn/html/multimedia_and_embedding/images_in_html/index.md
@@ -14,6 +14,7 @@ tags:
   - texto alt
 translation_of: Learn/HTML/Multimedia_and_embedding/Images_in_HTML
 ---
+
 {{LearnSidebar}}
 
 {{NextMenu("Learn/HTML/Multimedia_and_embedding/Video_and_audio_content", "Learn/HTML/Multimedia_and_embedding")}}

--- a/files/es/learn/html/multimedia_and_embedding/index.md
+++ b/files/es/learn/html/multimedia_and_embedding/index.md
@@ -24,6 +24,7 @@ tags:
   - receptivo
 translation_of: Learn/HTML/Multimedia_and_embedding
 ---
+
 Hemos visto mucho texto hasta ahora en este curso, pero la web sería realmente aburrida solo usando textos. ¡Comencemos observando como hacer que la web cobre vida, con mucho más contenido interesante! Este módulo te acompañará a explorar maneras de usar HTML para incluir multimedia a tus páginas web, y las diferentes formas en la que podrás hacerlo, incluyendo como enlazar videos, audios e incluso otras páginas webs.
 
 ## Requisitos previos

--- a/files/es/learn/html/multimedia_and_embedding/mozilla_splash_page/index.md
+++ b/files/es/learn/html/multimedia_and_embedding/mozilla_splash_page/index.md
@@ -21,6 +21,7 @@ tags:
   - srcset
 translation_of: Learn/HTML/Multimedia_and_embedding/Mozilla_splash_page
 ---
+
 {{LearnSidebar}}{{PreviousMenu("Learn/HTML/Multimedia_and_embedding/Responsive_images", "Learn/HTML/Multimedia_and_embedding")}}
 
 En esta evaluación, pondremos a prueba tu conocimiento de algunas de las técnicas mostradas en los artículos de este módulo, ¡para que tú agregues algunas imágenes y videos a una página de bienvenida de Mozzilla!.

--- a/files/es/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
+++ b/files/es/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
@@ -3,6 +3,7 @@ title: Desde object hasta iframe - otras tecnologías de incrustación
 slug: Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies
 translation_of: Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Multimedia_and_embedding/Video_and_audio_content", "Learn/HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web", "Learn/HTML/Multimedia_and_embedding")}}
 
 Ahora ya deberías estar acostumbrado a integrar cosas en tus páginas web, incluyendo imágenes, video y audio. En este punto nos gustaría que des algo así como un paso al costado, prestando atención a elementos que te permiten integrar una amplia variedad de tipos de contenido en tus páginas web: los elementos {{htmlelement("iframe")}}, {{htmlelement("embed")}} y {{htmlelement("object")}}. Los `<iframe>`s son para incrustar otras páginas web, y los otros dos te permiten incrustar PDFs, SVG e incluso Flash — una tecnología que está en su camino de despedida, pero la cual seguirás viendo semi-regularmente.

--- a/files/es/learn/html/multimedia_and_embedding/responsive_images/index.md
+++ b/files/es/learn/html/multimedia_and_embedding/responsive_images/index.md
@@ -3,6 +3,7 @@ title: Imágenes adaptables
 slug: Learn/HTML/Multimedia_and_embedding/Responsive_images
 translation_of: Learn/HTML/Multimedia_and_embedding/Responsive_images
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web", "Learn/HTML/Multimedia_and_embedding/Mozilla_splash_page", "Learn/HTML/Multimedia_and_embedding")}}
 
 En este artículo, aprenderemos sobre el concepto de imágenes adaptables — imágenes que funcionan bien en dispositivos con una amplia diferencia de tamaño de pantallas, resoluciones y otras tantas características — y observar qué herramientas proporciona HTML para ayudar a implementarlas. Esto ayuda a mejorar el rendimiento en diferentes dispositivos.

--- a/files/es/learn/html/multimedia_and_embedding/video_and_audio_content/index.md
+++ b/files/es/learn/html/multimedia_and_embedding/video_and_audio_content/index.md
@@ -3,6 +3,7 @@ title: Contenido de audio y video
 slug: Learn/HTML/Multimedia_and_embedding/Video_and_audio_content
 translation_of: Learn/HTML/Multimedia_and_embedding/Video_and_audio_content
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Multimedia_and_embedding/Images_in_HTML", "Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies", "Learn/HTML/Multimedia_and_embedding")}}
 
 Ahora que estamos cómodos añadiendo imágenes simples a una página web, el siguiente paso será empezar a agregar reproductores de audio y video a tu documento HTML. En este artículo veremos cómo hacerlo con los elementos {{htmlelement("video")}} y {{htmlelement("audio")}}; luego terminaremos viendo como agregar subtítulos a nuestros videos.

--- a/files/es/learn/html/tables/advanced/index.md
+++ b/files/es/learn/html/tables/advanced/index.md
@@ -4,6 +4,7 @@ slug: Learn/HTML/Tables/Advanced
 translation_of: Learn/HTML/Tables/Advanced
 original_slug: Learn/HTML/Tablas/Funciones_avanzadas_de_las_tablas_HTML_y_accesibilidad
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/HTML/Tables/Basics", "Learn/HTML/Tables/Structuring_planet_data", "Learn/HTML/Tables")}}
 
 En el segundo artículo de este módulo, analizamos algunas características más avanzadas de las tablas HTML, como los subtítulos/resúmenes, la agrupación de filas en las secciones del encabezado, el cuerpo y el pie de página; y también analizamos la accesibilidad de las tablas para usuarios con discapacidad visual.

--- a/files/es/learn/html/tables/basics/index.md
+++ b/files/es/learn/html/tables/basics/index.md
@@ -4,6 +4,7 @@ slug: Learn/HTML/Tables/Basics
 translation_of: Learn/HTML/Tables/Basics
 original_slug: Learn/HTML/Tablas/Conceptos_básicos_de_las_tablas_HTML
 ---
+
 {{LearnSidebar}}{{NextMenu("Learn/HTML/Tables/Advanced", "Learn/HTML/Tables")}}
 
 Este artículo te ayudará a comenzar con las tablas HTML. Vamos a exponer conceptos básicos como filas y celdas, encabezados, celdas que abarcan múltiples columnas y filas, y la forma de agrupar todas las celdas de una columna para aplicarles estilo.

--- a/files/es/learn/html/tables/index.md
+++ b/files/es/learn/html/tables/index.md
@@ -4,6 +4,7 @@ slug: Learn/HTML/Tables
 translation_of: Learn/HTML/Tables
 original_slug: Learn/HTML/Tablas
 ---
+
 {{LearnSidebar}}
 
 Una tarea muy común en HTML es la estructuración de datos, y para esto hay múltiples elementos y atributos. Esto unido a un poco de CSS, hace que en HTML sea sencillo mostrar tablas con información sobre tu horario escolar, los horarios de una piscina local o las estadisticas de tu equipo de dinosaurios o fútbol preferido. Este módulo te guiará en todo lo que necesitas saber sobre la estructuración tabular de datos en HTML.

--- a/files/es/learn/html/tables/structuring_planet_data/index.md
+++ b/files/es/learn/html/tables/structuring_planet_data/index.md
@@ -4,6 +4,7 @@ slug: Learn/HTML/Tables/Structuring_planet_data
 translation_of: Learn/HTML/Tables/Structuring_planet_data
 original_slug: Learn/HTML/Tablas/Structuring_planet_data
 ---
+
 {{LearnSidebar}}{{PreviousMenu("Learn/HTML/Tables/Advanced", "Learn/HTML/Tables")}}
 
 En nuestra evaluación te proporcionamos datos sobre los planetas de nuestro sistema solar y tu los estructurarás en una tabla HTML.

--- a/files/es/learn/javascript/asynchronous/index.md
+++ b/files/es/learn/javascript/asynchronous/index.md
@@ -3,6 +3,7 @@ title: JavaScript asíncrono
 slug: Learn/JavaScript/Asynchronous
 translation_of: Learn/JavaScript/Asynchronous
 ---
+
 {{LearnSidebar}}
 
 En este módulo echamos un vistazo a {{Glossary("JavaScript")}} {{Glossary("asíncrono")}}, por qué es importante y cómo se puede utilizar para manejar eficazmente las posibles operaciones de bloqueo, como recuperar recursos desde un servidor

--- a/files/es/learn/javascript/asynchronous/introducing/index.md
+++ b/files/es/learn/javascript/asynchronous/introducing/index.md
@@ -11,6 +11,7 @@ tags:
 translation_of: Learn/JavaScript/Asynchronous/Concepts
 original_slug: Learn/JavaScript/Asynchronous/Concepts
 ---
+
 {{LearnSidebar}}{{NextMenu("Learn/JavaScript/Asynchronous/Introducing", "Learn/JavaScript/Asynchronous")}}
 
 En este artículo, repasaremos una serie de conceptos importantes relacionados con la programación asincrónica y cómo se ve esto en los navegadores web y JavaScript. Debe comprender estos conceptos antes de trabajar con los demás artículos del módulo.

--- a/files/es/learn/javascript/building_blocks/build_your_own_function/index.md
+++ b/files/es/learn/javascript/building_blocks/build_your_own_function/index.md
@@ -13,6 +13,7 @@ tags:
 translation_of: Learn/JavaScript/Building_blocks/Build_your_own_function
 original_slug: Learn/JavaScript/Building_blocks/Construyendo_tu_propia_funcion
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Building_blocks/Functions","Learn/JavaScript/Building_blocks/Return_values", "Learn/JavaScript/Building_blocks")}}
 
 Con la mayor parte de la teoría esencial tratada en el artículo anterior, este artículo proporciona experiencia práctica. Aquí obtendrás práctica construyendo tu propia función personalizada. En el camino, también explicaremos algunos detalles útiles sobre cómo tratar las funciones.

--- a/files/es/learn/javascript/building_blocks/conditionals/index.md
+++ b/files/es/learn/javascript/building_blocks/conditionals/index.md
@@ -10,6 +10,7 @@ tags:
   - Principiante
 translation_of: Learn/JavaScript/Building_blocks/conditionals
 ---
+
 {{LearnSidebar}}
 
 {{NextMenu("Learn/JavaScript/Building_blocks/Looping_code", "Learn/JavaScript/Building_blocks")}}

--- a/files/es/learn/javascript/building_blocks/index.md
+++ b/files/es/learn/javascript/building_blocks/index.md
@@ -19,6 +19,7 @@ tags:
   - modulo
 translation_of: Learn/JavaScript/Building_blocks
 ---
+
 {{LearnSidebar}}
 
 En este módulo, continuamos nuestra cobertura de todas las características clave de JavaScript, tornando nuestra atención a tipos de código comúnmente encontrados tales como enunciados condicionales, bucles (loops), funciones, y eventos. Ya has visto estas cosas en este curso, pero solo de pasada aquí lo hablaremos mas explícitamente.

--- a/files/es/learn/javascript/building_blocks/looping_code/index.md
+++ b/files/es/learn/javascript/building_blocks/looping_code/index.md
@@ -4,6 +4,7 @@ slug: Learn/JavaScript/Building_blocks/Looping_code
 translation_of: Learn/JavaScript/Building_blocks/Looping_code
 original_slug: Learn/JavaScript/Building_blocks/Bucle_codigo
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Building_blocks/conditionals","Learn/JavaScript/Building_blocks/Functions", "Learn/JavaScript/Building_blocks")}}
 
 Los lenguajes de programación son muy útiles para completar rápidamente tareas repetitivas, desde múltimples cálculos básicos hasta cualquier otra situación en donde tengas un montón de elementos de trabajo similares que completar. Aquí vamos a ver las estructuras de bucles disponibles en JavaScript que pueden manejar tales necesidades.

--- a/files/es/learn/javascript/building_blocks/return_values/index.md
+++ b/files/es/learn/javascript/building_blocks/return_values/index.md
@@ -3,6 +3,7 @@ title: Una función retorna valores
 slug: Learn/JavaScript/Building_blocks/Return_values
 translation_of: Learn/JavaScript/Building_blocks/Return_values
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Building_blocks/Build_your_own_function","Learn/JavaScript/Building_blocks/Events", "Learn/JavaScript/Building_blocks")}}
 
 Hay un último concepto esencial para que discutamos en este curso, para cerrar nuestra visión de las funciones: — lo valores que se devuelven. Algunas funciones no devuelven un valor significativo después de su finalización, pero otras sí, y es importante comprender cuáles son sus valores, cómo utilizarlos en su código y cómo hacer que sus propias funciones personalizadas devuelvan valores útiles. Cubriremos todos estos a continuación.

--- a/files/es/learn/javascript/client-side_web_apis/index.md
+++ b/files/es/learn/javascript/client-side_web_apis/index.md
@@ -19,6 +19,7 @@ tags:
   - data
 translation_of: Learn/JavaScript/Client-side_web_APIs
 ---
+
 {{LearnSidebar}}
 
 Cuando se escribe JavaScript para sitios web o aplicaciones del lado del cliente, no pasará mucho tiempo antes de que comience a usar APIs ("Application Programming Interfaces"). Estas son interfaces para manipular diferentes aspectos del navegador y el sistema operativo sobre el cuál se esta ejecutando, o incluso datos de otros sitios web o servicios. En este módulo, vamos a aprender que son las APIs y cómo utilizar algunas de las API más comunes que encuentran al momento de desarrollar.

--- a/files/es/learn/javascript/client-side_web_apis/introduction/index.md
+++ b/files/es/learn/javascript/client-side_web_apis/introduction/index.md
@@ -4,6 +4,7 @@ slug: Learn/JavaScript/Client-side_web_APIs/Introduction
 translation_of: Learn/JavaScript/Client-side_web_APIs/Introduction
 original_slug: Learn/JavaScript/Client-side_web_APIs/Introducción
 ---
+
 {{LearnSidebar}}{{NextMenu("Learn/JavaScript/Client-side_web_APIs/Manipulating_documents", "Learn/JavaScript/Client-side_web_APIs")}}
 
 En primer lugar empezaremos echando un vistazo a las APIS desde un nivel superior — ¿qué son, cómo funcionan, cómo usarlas en el código, y cómo están estructuradas?. También echaremos un vistazo a cuáles son los principales tipos de APIs, y para qué se usan.

--- a/files/es/learn/javascript/first_steps/a_first_splash/index.md
+++ b/files/es/learn/javascript/first_steps/a_first_splash/index.md
@@ -16,6 +16,7 @@ tags:
   - l10n:priority
 translation_of: Learn/JavaScript/First_steps/A_first_splash
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/First_steps/What_is_JavaScript", "Learn/JavaScript/First_steps/What_went_wrong", "Learn/JavaScript/First_steps")}}
 
 Ahora que has aprendido algo sobre la teoría de JavaScript y lo que puedes hacer con ella, te daremos un curso intensivo sobre las características básicas de JavaScript a través de un tutorial completamente práctico. Aquí crearás un sencillo juego de "Adivina el número", paso a paso.

--- a/files/es/learn/javascript/first_steps/arrays/index.md
+++ b/files/es/learn/javascript/first_steps/arrays/index.md
@@ -3,6 +3,7 @@ title: Arrays
 slug: Learn/JavaScript/First_steps/Arrays
 translation_of: Learn/JavaScript/First_steps/Arrays
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/First_steps/Useful_string_methods", "Learn/JavaScript/First_steps/Silly_story_generator", "Learn/JavaScript/First_steps")}}
 
 ## Arreglos o Matrices

--- a/files/es/learn/javascript/first_steps/math/index.md
+++ b/files/es/learn/javascript/first_steps/math/index.md
@@ -17,6 +17,7 @@ tags:
 translation_of: Learn/JavaScript/First_steps/Math
 original_slug: Learn/JavaScript/First_steps/Matemáticas
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/First_steps/Variables", "Learn/JavaScript/First_steps/Strings", "Learn/JavaScript/First_steps")}}
 
 En este punto del curso, hablaremos de matemáticas en JavaScript — cómo podemos usar {{Glossary("Operator","operadores")}} y otras características para manipular con éxito números y conseguir lo que nos hayamos propuesto.

--- a/files/es/learn/javascript/first_steps/silly_story_generator/index.md
+++ b/files/es/learn/javascript/first_steps/silly_story_generator/index.md
@@ -10,6 +10,7 @@ tags:
 translation_of: Learn/JavaScript/First_steps/Silly_story_generator
 original_slug: Learn/JavaScript/First_steps/Generador_de_historias_absurdas
 ---
+
 {{LearnSidebar}}{{PreviousMenu("Learn/JavaScript/First_steps/Arrays", "Learn/JavaScript/First_steps")}}
 
 En esta evaluación, deberás tomar parte del conocimiento que has aprendido en los artículos de este módulo y aplicarlo a la creación de una aplicación divertida que genere historias aleatorias. ¡Que te diviertas!

--- a/files/es/learn/javascript/first_steps/strings/index.md
+++ b/files/es/learn/javascript/first_steps/strings/index.md
@@ -16,6 +16,7 @@ tags:
   - strings
 translation_of: Learn/JavaScript/First_steps/Strings
 ---
+
 {{LearnSidebar}}
 
 {{PreviousMenuNext("Learn/JavaScript/First_steps/Math", "Learn/JavaScript/First_steps/Useful_string_methods", "Learn/JavaScript/First_steps")}}

--- a/files/es/learn/javascript/first_steps/test_your_skills_colon__math/index.md
+++ b/files/es/learn/javascript/first_steps/test_your_skills_colon__math/index.md
@@ -9,6 +9,7 @@ tags:
   - aprende
 translation_of: Learn/JavaScript/First_steps/Test_your_skills:_Math
 ---
+
 {{learnsidebar}}
 
 El objetivo de esta prueba de habilidad es conocer si has entendido nuestra clase sobre el articulo [Matematica basica en JavaScript — números y operadores](/es/docs/Learn/JavaScript/First_steps/Math).

--- a/files/es/learn/javascript/first_steps/test_your_skills_colon__strings/index.md
+++ b/files/es/learn/javascript/first_steps/test_your_skills_colon__strings/index.md
@@ -12,6 +12,7 @@ tags:
 translation_of: Learn/JavaScript/First_steps/Test_your_skills:_Strings
 original_slug: Learn/JavaScript/First_steps/Prueba_tus_habilidades:_Strings
 ---
+
 {{learnsidebar}}
 
 El objetivo de esta prueba de habilidad es evaluar si has entendido nuestros artículos [Manejo de texto — cadenas en JavaScript](/es/docs/Learn/JavaScript/First_steps/Strings) y [Métodos de cadena útiles](/es/docs/Learn/JavaScript/First_steps/Useful_string_methods).

--- a/files/es/learn/javascript/first_steps/test_your_skills_colon__variables/index.md
+++ b/files/es/learn/javascript/first_steps/test_your_skills_colon__variables/index.md
@@ -9,6 +9,7 @@ tags:
   - aprende
 translation_of: Learn/JavaScript/First_steps/Test_your_skills:_variables
 ---
+
 {{learnsidebar}}
 
 El objetivo de esta prueba de habilidad es evaluar si has entendido nuestro artículo [Almacenando la información que necesitas — Variables](/es/docs/Learn/JavaScript/First_steps/Variables).

--- a/files/es/learn/javascript/first_steps/useful_string_methods/index.md
+++ b/files/es/learn/javascript/first_steps/useful_string_methods/index.md
@@ -9,6 +9,7 @@ tags:
   - Principiante
 translation_of: Learn/JavaScript/First_steps/Useful_string_methods
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/First_steps/Strings", "Learn/JavaScript/First_steps/Arrays", "Learn/JavaScript/First_steps")}}
 
 Ahora que hemos analizado los conceptos básicos de las cadenas, aumentemos la velocidad y comencemos a pensar qué operaciones útiles podemos hacer en cadenas con métodos integados, como encontrar la longitud de una cadena de texto, unir y dividir cadenas, sustituyendo un caracter de una cadena por otro, y más.

--- a/files/es/learn/javascript/first_steps/variables/index.md
+++ b/files/es/learn/javascript/first_steps/variables/index.md
@@ -14,6 +14,7 @@ tags:
   - strings
 translation_of: Learn/JavaScript/First_steps/Variables
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/First_steps/What_went_wrong", "Learn/JavaScript/First_steps/Math", "Learn/JavaScript/First_steps")}}
 
 Después de leer los últimos artículos, deberías saber qué es JavaScript, qué puede hacer por ti, cómo usarlo junto con otras tecnologías web y cómo se ven sus características principales desde un alto nivel. En este artículo, llegaremos a los conceptos básicos reales, y veremos cómo trabajar con los bloques de construcción más básicos de JavaScript — Variables.

--- a/files/es/learn/javascript/first_steps/what_is_javascript/index.md
+++ b/files/es/learn/javascript/first_steps/what_is_javascript/index.md
@@ -19,6 +19,7 @@ tags:
 translation_of: Learn/JavaScript/First_steps/What_is_JavaScript
 original_slug: Learn/JavaScript/First_steps/Qué_es_JavaScript
 ---
+
 {{LearnSidebar}}{{NextMenu("Learn/JavaScript/First_steps/A_first_splash", "Learn/JavaScript/First_steps")}}
 
 ¡Bienvenido al curso de JavaScript para principiantes de MDN! En este artículo veremos JavaScript desde un alto nivel, respondiendo preguntas como "¿Qué es?" y "¿Qué puedes hacer con él?", y asegúrate de estar cómodo con el propósito de JavaScript.

--- a/files/es/learn/javascript/first_steps/what_went_wrong/index.md
+++ b/files/es/learn/javascript/first_steps/what_went_wrong/index.md
@@ -18,6 +18,7 @@ tags:
   - l10n:priority
 translation_of: Learn/JavaScript/First_steps/What_went_wrong
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/First_steps/A_first_splash", "Learn/JavaScript/First_steps/Variables", "Learn/JavaScript/First_steps")}}
 
 Cuando construiste el juego "Adivina el número" en el artículo anterior, es posible que hayas descubierto que no funcionó. Tranquilo — este artículo tiene como objetivo evitar que te rasques la cabeza por este tipo de problemas brindándote algunos consejos sobre cómo encontrar y corregir errores en programas JavaScript.

--- a/files/es/learn/javascript/howto/index.md
+++ b/files/es/learn/javascript/howto/index.md
@@ -7,6 +7,7 @@ tags:
   - Principante
 translation_of: Learn/JavaScript/Howto
 ---
+
 {{LearnSidebar}}
 
 Los siguientes enlaces apuntan a soluciones a problemas comunes de todos los días que deberá solucionar para que su código JavaScript se ejecute correctamente..

--- a/files/es/learn/javascript/index.md
+++ b/files/es/learn/javascript/index.md
@@ -12,6 +12,7 @@ tags:
   - princiante JavaScript
 translation_of: Learn/JavaScript
 ---
+
 {{LearnSidebar}}
 
 {{Glossary("JavaScript")}} es un lenguaje de programación que te permite implementar cosas complejas en páginas web. Cada vez que una página web hace algo más que sentarse ahí y mostrar información estática para que la veas — mostrando actualizaciones de contenido oportunas, mapas interactivos, gráficos animados 2D/3D, desplazando máquinas reproductoras de video, o más, puedes apostar que probablemente JavaScript esté involucrado .

--- a/files/es/learn/javascript/objects/adding_bouncing_balls_features/index.md
+++ b/files/es/learn/javascript/objects/adding_bouncing_balls_features/index.md
@@ -10,6 +10,7 @@ tags:
   - Principiante
 translation_of: Learn/JavaScript/Objects/Adding_bouncing_balls_features
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Objects/Object_building_practice", "", "Learn/JavaScript/Objects")}}
 
 En esta evaluación, se espera que use la demo de bouncing balls del artículo anterior como punto de partida y le agregue algunas características nuevas e interesantes.

--- a/files/es/learn/javascript/objects/basics/index.md
+++ b/files/es/learn/javascript/objects/basics/index.md
@@ -20,6 +20,7 @@ tags:
   - this
 translation_of: Learn/JavaScript/Objects/Basics
 ---
+
 {{LearnSidebar}}{{NextMenu("Learn/JavaScript/Objects/Object_prototypes", "Learn/JavaScript/Objects")}}
 
 En éste artículo, veremos fundamentos de sintaxis de los objetos de JavaScript y revisaremos algunas características de JavaScript que ya hemos analizado anteriormente en el curso, reiterando el hecho de que muchas de las funciones con las que ya has tratado de hecho son objetos.

--- a/files/es/learn/javascript/objects/classes_in_javascript/index.md
+++ b/files/es/learn/javascript/objects/classes_in_javascript/index.md
@@ -4,6 +4,7 @@ slug: Learn/JavaScript/Objects/Classes_in_JavaScript
 translation_of: Learn/JavaScript/Objects/Inheritance
 original_slug: Learn/JavaScript/Objects/Inheritance
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Objects/Object_prototypes", "Learn/JavaScript/Objects/JSON", "Learn/JavaScript/Objects")}}
 
 Con la mayoría de los detalles internos de OOJS (_JavaScript Orientado a Objetos)_ explicados, este artículo muestra cómo crear clases "hijo" (constructores) que heredan características de sus clases "padre". Además, presentamos algunos consejos sobre cuándo y dónde puedes usar OOJS y cómo se crean las clases con la sintaxis moderna de ECMAScript.

--- a/files/es/learn/javascript/objects/index.md
+++ b/files/es/learn/javascript/objects/index.md
@@ -15,6 +15,7 @@ tags:
   - Tutorial
 translation_of: Learn/JavaScript/Objects
 ---
+
 {{LearnSidebar}}
 
 En JavaScript, la mayoría de las cosas son objetos, desde características del núcleo de JavaScript como arrays hasta el explorador {{Glossary("API", "APIs")}} construído sobre JavaScript. Incluso puedes crear tus propios objetos para encapsular funciones y variables relacionadas dentro de paquetes eficientes que actúan como prácticos contenedores de datos. La naturaleza de JavaScript basada-en-objetos es importante de entender, si quieres avanzar con tu conocimiento del lenguaje, y por ello hemos hecho este módulo para ayudarte. Aquí enseñamos teoría de objetos y sintaxis en detalle, y luego veremos como crear tus propios objetos.

--- a/files/es/learn/javascript/objects/json/index.md
+++ b/files/es/learn/javascript/objects/json/index.md
@@ -13,6 +13,7 @@ tags:
   - Tutorial
 translation_of: Learn/JavaScript/Objects/JSON
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Objects/Inheritance", "Learn/JavaScript/Objects/Object_building_practice", "Learn/JavaScript/Objects")}}
 
 JavaScript Object Notation (JSON) es un formato basado en texto estándar para representar datos estructurados en la sintaxis de objetos de JavaScript. Es comúnmente utilizado para transmitir datos en aplicaciones web (por ejemplo: enviar algunos datos desde el servidor al cliente, así estos datos pueden ser mostrados en páginas web, o vice versa). Se enfrentará a menudo con él, así que este artículo le entrega todo lo que necesita saber para trabajar con JSON utilizando JavaScript, incluyendo el análisis JSON para acceder a los datos en su interior, y cómo crear JSON.

--- a/files/es/learn/javascript/objects/object_building_practice/index.md
+++ b/files/es/learn/javascript/objects/object_building_practice/index.md
@@ -4,6 +4,7 @@ slug: Learn/JavaScript/Objects/Object_building_practice
 translation_of: Learn/JavaScript/Objects/Object_building_practice
 original_slug: Learn/JavaScript/Objects/Ejercicio_práctico_de_construcción_de_objetos
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Objects/JSON", "Learn/JavaScript/Objects/Adding_bouncing_balls_features", "Learn/JavaScript/Objects")}}
 
 En los artículos anteriores se explicó lo fundamental de la teoría de los objetos en JavaScript asi como su sintaxis, para que Usted tenga un punto de partida sólido. En éste artículo, desarrollaremos un ejercicio práctico para ganar experiencia en la programación de objetos en JavaScript, con un resultado divertido y colorido.

--- a/files/es/learn/javascript/objects/object_prototypes/index.md
+++ b/files/es/learn/javascript/objects/object_prototypes/index.md
@@ -13,6 +13,7 @@ tags:
   - create()
 translation_of: Learn/JavaScript/Objects/Object_prototypes
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Objects/Object-oriented_JS", "Learn/JavaScript/Objects/Inheritance", "Learn/JavaScript/Objects")}}
 
 Los prototipos son un mecanismo mediante el cual los objetos en JavaScript heredan características entre sí. En este artículo, explicaremos como funcionan los prototipos y también cómo se pueden usar las propiedades de estos para añadir métodos a los contructores existentes.

--- a/files/es/learn/performance/index.md
+++ b/files/es/learn/performance/index.md
@@ -3,6 +3,7 @@ title: Rendimiento web
 slug: Learn/Performance
 translation_of: Learn/Performance
 ---
+
 {{LearnSidebar}}
 
 La construcción de sitios web requiere HTML, CSS y JavaScript. Para crear sitios web y aplicaciones que la gente quiera usar, que atraigan y retengan a los usuarios, debe crear una buena experiencia de usuario. Parte de la buena experiencia del usuario es garantizar que el contenido se cargue rápidamente y responda a la interacción del usuario. Esto se conoce como rendimiento web, y en este módulo aprenderá todo lo que necesita para crear sitios web de rendimiento.

--- a/files/es/learn/server-side/configuring_server_mime_types/index.md
+++ b/files/es/learn/server-side/configuring_server_mime_types/index.md
@@ -9,6 +9,7 @@ tags:
 translation_of: Learn/Server-side/Configuring_server_MIME_types
 original_slug: Configurar_correctamente_los_tipos_MIME_del_servidor
 ---
+
 ### Introduccion
 
 Por omisión, muchos servidores web estan configurados para reportar un tipo MIME de `texto/plano` ó `aplicacion/de fuente de octeto` para tipos de contenidos desconocidos. A medida son desarrollados nuevos tipos de contenidos, los administradores de red pueden equivocarse al añadirlos a la configuración del servidor web, y esta es la principal causa de problemas para usuarios de navegadores basados en Gecko, el cual respeta los tipos MIME tal y como son reportados por los servidores y las aplicaciones web.

--- a/files/es/learn/server-side/django/admin_site/index.md
+++ b/files/es/learn/server-side/django/admin_site/index.md
@@ -14,6 +14,7 @@ tags:
   - programacion
 translation_of: Learn/Server-side/Django/Admin_site
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Django/Models", "Learn/Server-side/Django/Home_page", "Learn/Server-side/Django")}}
 
 Ahora que hemos creado modelos para el sitio web de la [BibliotecaLocal](/es/docs/Learn/Server-side/Django/Tutorial_local_library_website), usaremos el sitio de administración de Django para añadir algunos datos de libros "reales". Primero mostraremos cómo registrar los modelos en el sitio de administración y luego te mostraremos cómo iniciar sesión y crear algunos datos. Al final del artículo mostraremos algunas formas en las que puedes mejorar más adelante la presentación del sitio de Administración.

--- a/files/es/learn/server-side/django/authentication/index.md
+++ b/files/es/learn/server-side/django/authentication/index.md
@@ -14,6 +14,7 @@ tags:
   - permisos
 translation_of: Learn/Server-side/Django/Authentication
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Django/Sessions", "Learn/Server-side/Django/Forms", "Learn/Server-side/Django")}}
 
 En este tutorial mostraremos cómo permitir a los usuarios iniciar sesión en tu sitio con sus propias cuentas, y cómo controlar lo que pueden hacer basándose en si han iniciado sesión o no y sus _permisos_. Como parte de esta demostración extenderemos el sitio web de la [BibliotecaLocal](/en-US/docs/Learn/Server-side/Django/Tutorial_local_library_website), añadiendo páginas de inicio y cierre de sesión, y páginas específicas de usuarios y personal de la biblioteca para ver libros que han sido prestados.

--- a/files/es/learn/server-side/django/deployment/index.md
+++ b/files/es/learn/server-side/django/deployment/index.md
@@ -3,6 +3,7 @@ title: 'Tutorial de Django Parte 11: Desplegando Django a producción'
 slug: Learn/Server-side/Django/Deployment
 translation_of: Learn/Server-side/Django/Deployment
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Django/Testing", "Learn/Server-side/Django/web_application_security", "Learn/Server-side/Django")}}
 
 Ahora que has creado (y probado) un fantastico sitio web para la [Biblioteca Local](/en-US/docs/Learn/Server-side/Django/Tutorial_local_library_website), querrás instalarlo en un servidor web público de manera que pueda ser accedido por el personal y los miembros de la biblioteca a través de Internet. Este artículo proporciona una visión general de cómo buscar un host para desplegar tu sitio web y de lo que necesitas hacer para conseguir que tu sitio esté listo en producción.

--- a/files/es/learn/server-side/django/development_environment/index.md
+++ b/files/es/learn/server-side/django/development_environment/index.md
@@ -12,6 +12,7 @@ tags:
   - introducción
 translation_of: Learn/Server-side/Django/development_environment
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Django/Introduction", "Learn/Server-side/Django/Tutorial_local_library_website", "Learn/Server-side/Django")}}
 
 Ahora que sabes para qué se utiliza Django, te enseñaremos cómo configurar y probar un entorno de desarrollo Django en Windows, Linux (Ubuntu), y Mac OS X — cualquiera que sea el sistema operativo común que estés utilizando, este artículo te dará lo que necesitas para ser capaz de empezar a desarrollar aplicaciones Django.

--- a/files/es/learn/server-side/django/forms/index.md
+++ b/files/es/learn/server-side/django/forms/index.md
@@ -3,6 +3,7 @@ title: 'Tutorial de Django Parte 9: Trabajo con formularios'
 slug: Learn/Server-side/Django/Forms
 translation_of: Learn/Server-side/Django/Forms
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Django/authentication", "Learn/Server-side/Django/Testing", "Learn/Server-side/Django")}}
 
 En este tutorial te mostraremos cómo trabajar con Formularios HTML en Django, y en particular, la forma más fácil de escribir formularios para crear, actualizar y borrar instancias de modelo. Como parte de esta demostración extenderemos el sitio web [LocalLibrary](/en-US/docs/Learn/Server-side/Django/Tutorial_local_library_website) de manera que los bibliotecarios puedan renovar libros, y crear, actualizar y borrar autores utilizando nuestros propios formularios (en vez de utilizar la aplicación de administración).

--- a/files/es/learn/server-side/django/generic_views/index.md
+++ b/files/es/learn/server-side/django/generic_views/index.md
@@ -10,6 +10,7 @@ tags:
   - vistas django
 translation_of: Learn/Server-side/Django/Generic_views
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Django/Home_page", "Learn/Server-side/Django/Sessions", "Learn/Server-side/Django")}}
 
 Este tutorial extiende nuestro sitio web de la [BibliotecaLocal](/es/docs/Learn/Server-side/Django/Tutorial_local_library_website), añadiendo páginas de listas y detalles de libros y autores. Aquí aprenderemos sobre vistas genéricas basadas en clases, y mostraremos cómo éstas pueden reducir la cantidad de código que tienes que escribir para casos de uso común. También entraremos en el manejo de URL en gran detalle, mostrando cómo realizar un emparejamiento de patrones básico.

--- a/files/es/learn/server-side/django/home_page/index.md
+++ b/files/es/learn/server-side/django/home_page/index.md
@@ -3,6 +3,7 @@ title: 'Tutorial de Django Parte 5: Creación de tu página de inicio'
 slug: Learn/Server-side/Django/Home_page
 translation_of: Learn/Server-side/Django/Home_page
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Django/Admin_site", "Learn/Server-side/Django/Generic_views", "Learn/Server-side/Django")}}
 
 Estamos listos ahora para añadir el código para mostrar nuestra primera página entera — una página de inicio del sitio web de la [BibliotecaLocal](/es/docs/Learn/Server-side/Django/Tutorial_local_library_website) que muestra cuántos registros tenemos de cada tipo de modelo y proporciona una barra lateral con enlaces de navegación a nuestras otras páginas. Por el camino ganaremos experiencia práctica en escritura básica de mapeos de URL y vistas, obtención de resgistros de la base de datos y uso de plantillas.

--- a/files/es/learn/server-side/django/index.md
+++ b/files/es/learn/server-side/django/index.md
@@ -11,6 +11,7 @@ tags:
   - introducción
 translation_of: Learn/Server-side/Django
 ---
+
 Django es un framework web extremadamente popular y completamente funcional, escrito en Python. El módulo muestra por qué Django es uno de los frameworks de servidores web más populares, cómo configurar un entorno de desarrollo y cómo empezar a usarlo para crear tus propias aplicaciones web.
 
 ## Requisitos Previos

--- a/files/es/learn/server-side/django/introduction/index.md
+++ b/files/es/learn/server-side/django/introduction/index.md
@@ -12,6 +12,7 @@ tags:
 translation_of: Learn/Server-side/Django/Introduction
 original_slug: Learn/Server-side/Django/Introducción
 ---
+
 {{LearnSidebar}}{{NextMenu("Learn/Server-side/Django/development_environment", "Learn/Server-side/Django")}}
 
 En este primer artículo de Django responderemos la pregunta ¿Qué es Django? y daremos una visión general de lo que hace que este framework sea tan especial. Vamos a delinear las características principales, incluidas algunas de las funcionalidades avanzadas que no tendremos tiempo de cubrir con detalle en este módulo. Tambien mostraremos algunos de los componentes principales de una aplicación de Django. (aunque en este momento no cuentes con un entorno de desarrollo en el cual probarlo).

--- a/files/es/learn/server-side/django/models/index.md
+++ b/files/es/learn/server-side/django/models/index.md
@@ -12,6 +12,7 @@ tags:
   - lado-servidor
 translation_of: Learn/Server-side/Django/Models
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Django/skeleton_website", "Learn/Server-side/Django/Admin_site", "Learn/Server-side/Django")}}
 
 Este artículo muestra cómo definir modelos para el sitio web de la [BibliotecaLocal](/es/docs/Learn/Server-side/Django/Tutorial_local_library_website). En él se explica lo que es un modelo, cómo se declara, y cuáles son algunos de los principales tipos de campos de un modelo. También veremos, brevemente, cuáles son algunas de las maneras en que puede accederse a los datos del modelo.

--- a/files/es/learn/server-side/django/sessions/index.md
+++ b/files/es/learn/server-side/django/sessions/index.md
@@ -14,6 +14,7 @@ tags:
   - lado-servidor
 translation_of: Learn/Server-side/Django/Sessions
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Django/Generic_views", "Learn/Server-side/Django/authentication", "Learn/Server-side/Django")}}
 
 Este tutorial extiende nuestro sitio web de la [BibliotecaLocal](/es/docs/Learn/Server-side/Django/Tutorial_local_library_website), añadiendo un contador de visitas a tu página de inicio basado en sesiones. Es un ejemplo relativamente simple, pero muestra cómo puedes usar el framework de sesión para proporcionar persistencia a usuarios anónimos en tus propios sitios.

--- a/files/es/learn/server-side/django/skeleton_website/index.md
+++ b/files/es/learn/server-side/django/skeleton_website/index.md
@@ -13,6 +13,7 @@ tags:
   - lado servidor
 translation_of: Learn/Server-side/Django/skeleton_website
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Django/Tutorial_local_library_website", "Learn/Server-side/Django/Models", "Learn/Server-side/Django")}}
 
 Este segundo artículo de nuestro [Tutorial Django](/es/docs/Learn/Server-side/Django/Tutorial_local_library_website) muestra cómo puedes crear un proyecto de "esqueleto" de sitio web como base, que puedes continuar luego llenado de configuraciones específicas del sitio, urls, modelos, vistas y plantillas.

--- a/files/es/learn/server-side/django/testing/index.md
+++ b/files/es/learn/server-side/django/testing/index.md
@@ -3,6 +3,7 @@ title: 'Tutorial de Django Parte 10: Probando una aplicación web Django'
 slug: Learn/Server-side/Django/Testing
 translation_of: Learn/Server-side/Django/Testing
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Django/Forms", "Learn/Server-side/Django/Deployment", "Learn/Server-side/Django")}}
 
 A medida que crecen los sitios web se vuelven más difíciles de probar a mano — no sólo hay más para probar, sino que además, a medida que las interacciones entre los componentes se vuelven más complejas, un pequeño cambio en un área puede suponer muchas pruebas adicionales para verificar su impacto en otras áreas. Una forma de mitigar estos problemas es escribir tests automatizados, que pueden ser ejecutados de manera fácil y fiable cada vez que hagas un cambio. Este tutorial muestra cómo automatizar la unidad de pruebas de tu sitio web usando el framework de pruebas de Django.

--- a/files/es/learn/server-side/django/tutorial_local_library_website/index.md
+++ b/files/es/learn/server-side/django/tutorial_local_library_website/index.md
@@ -12,6 +12,7 @@ tags:
   - lado servidor
 translation_of: Learn/Server-side/Django/Tutorial_local_library_website
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Django/development_environment", "Learn/Server-side/Django/skeleton_website", "Learn/Server-side/Django")}}
 
 El primer artículo de nuestra serie de tutoriales prácticos explica qué puedes aprender, y proporciona una visión general del sitio web de ejemplo de "biblioteca local" en el que estaremos trabajando y evolucionando en artículos subsiguientes.

--- a/files/es/learn/server-side/express_nodejs/development_environment/index.md
+++ b/files/es/learn/server-side/express_nodejs/development_environment/index.md
@@ -11,6 +11,7 @@ tags:
   - npm
 translation_of: Learn/Server-side/Express_Nodejs/development_environment
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Express_Nodejs/Introduction", "Learn/Server-side/Express_Nodejs/Tutorial_local_library_website", "Learn/Server-side/Express_Nodejs")}}
 
 Ahora que sabes para que sirve Express, nosotros te vamos a mostrar como preparar y testear un entorno de desarrollo Node/Express en: Windows, Linux (Ubuntu), y macOS. Este artículo te va a dar todo lo que se necesita para poder empezar a desarrollar apps en Express, sin importar el sistema operativo que se use.

--- a/files/es/learn/server-side/express_nodejs/index.md
+++ b/files/es/learn/server-side/express_nodejs/index.md
@@ -14,6 +14,7 @@ tags:
   - programacion
 translation_of: Learn/Server-side/Express_Nodejs
 ---
+
 {{LearnSidebar}}
 
 Express es un framework web transigente, escrito en JavaScript y alojado dentro del entorno de ejecución NodeJS. El modulo explica algunos de los beneficios clave de este framework, como configurar tu entorno de desarrollo y como realizar tareas comunes en desarrollo y publicación web.

--- a/files/es/learn/server-side/express_nodejs/introduction/index.md
+++ b/files/es/learn/server-side/express_nodejs/introduction/index.md
@@ -12,6 +12,7 @@ tags:
   - nodejs
 translation_of: Learn/Server-side/Express_Nodejs/Introduction
 ---
+
 {{LearnSidebar}}{{NextMenu("Aprendizaje/Lado-Servidor/Express_Nodejs/Ambiente-Desarrollo", "Aprendizaje/Lado-Servidor/Express_Nodejs")}}
 
 En este primer articulo de Express resolveremos las preguntas "¿Qué es Node?" y "¿Qué es Express?", y te daremos una visión general de que hace especial al framework web "Express". Delinearemos las características principales, y te mostraremos algunos de los principales bloques de construcción de una aplicación en Express (aunque en este punto no tendrás todavía un entorno de desarrollo en que probarlo).

--- a/files/es/learn/server-side/express_nodejs/skeleton_website/index.md
+++ b/files/es/learn/server-side/express_nodejs/skeleton_website/index.md
@@ -3,6 +3,7 @@ title: 'Express Tutorial Part 2: Creating a skeleton website'
 slug: Learn/Server-side/Express_Nodejs/skeleton_website
 translation_of: Learn/Server-side/Express_Nodejs/skeleton_website
 ---
+
 {{LearnSidebar}}
 
 {{PreviousMenuNext("Learn/Server-side/Express_Nodejs/Tutorial_local_library_website", "Learn/Server-side/Express_Nodejs/mongoose", "Learn/Server-side/Express_Nodejs")}}

--- a/files/es/learn/server-side/express_nodejs/tutorial_local_library_website/index.md
+++ b/files/es/learn/server-side/express_nodejs/tutorial_local_library_website/index.md
@@ -3,6 +3,7 @@ title: 'Express Tutorial: The Local Library website'
 slug: Learn/Server-side/Express_Nodejs/Tutorial_local_library_website
 translation_of: Learn/Server-side/Express_Nodejs/Tutorial_local_library_website
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/Express_Nodejs/development_environment", "Learn/Server-side/Express_Nodejs/skeleton_website", "Learn/Server-side/Express_Nodejs")}}
 
 El primer artículo de nuestra serie de tutoriales prácticos explica lo que aprenderá y proporciona una descripción general del sitio web de ejemplo de la "biblioteca local" en el que trabajaremos y evolucionaremos en artículos posteriores.

--- a/files/es/learn/server-side/first_steps/client-server_overview/index.md
+++ b/files/es/learn/server-side/first_steps/client-server_overview/index.md
@@ -12,6 +12,7 @@ tags:
 translation_of: Learn/Server-side/First_steps/Client-Server_overview
 original_slug: Learn/Server-side/Primeros_pasos/Vision_General_Cliente_Servidor
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/First_steps/Introduction", "Learn/Server-side/First_steps/Web_frameworks", "Learn/Server-side/First_steps")}}
 
 Ahora que conoces el propósito y los beneficios potenciales de la programación de lado-servidor vamos a examinar en detalle lo que ocurre cuando un servidor recibe una "petición dinámica" desde un explorador web. Ya que el código de lado servidor de la mayoría de los sitios web gestiona peticiones y respuestas de formas similares, este artículo te ayudará a entender lo que necesitas hacer para escribir la mayor parte de tu propio código.

--- a/files/es/learn/server-side/first_steps/index.md
+++ b/files/es/learn/server-side/first_steps/index.md
@@ -12,6 +12,7 @@ tags:
 translation_of: Learn/Server-side/First_steps
 original_slug: Learn/Server-side/Primeros_pasos
 ---
+
 {{LearnSidebar}}
 
 En este, nuestro módulo sobre programación de Lado-Servidor, contestaremos a unas pocas preguntas fundamentales - "¿Qué es?", "¿En qué se diferencia de la programación de Lado-Cliente?" y "¿Porqué es tan útil?". Proporcionaremos un vistazo de algunos de los "web-frameworks" de lado-servidor más populares, junto con indicaciones de cómo seleccionar el framework más adecuado para crear tu primer sitio. Finalmente proporcionaremos un artículo introductorio de alto nivel sobre seguridad en el servidor web.

--- a/files/es/learn/server-side/first_steps/introduction/index.md
+++ b/files/es/learn/server-side/first_steps/introduction/index.md
@@ -12,6 +12,7 @@ tags:
 translation_of: Learn/Server-side/First_steps/Introduction
 original_slug: Learn/Server-side/Primeros_pasos/Introducción
 ---
+
 {{LearnSidebar}}{{NextMenu("Learn/Server-side/First_steps/Client-Server_overview", "Learn/Server-side/First_steps")}}
 
 ¡Bienvenidos al curso MDN de programación para principiantes de lado servidor! En este primer artículo enfocamos la programación de Lado-Servidor desde un nivel alto, respondiendo a preguntas tales como "¿qué es?", "¿en qué se diferencia de la programación de Lado-Cliente?" y "¿porqué es tan útil?". Después de leer este artículo entenderás el poder adicional para los sitios web disponible a través de la codificación lado-servidor.

--- a/files/es/learn/server-side/first_steps/web_frameworks/index.md
+++ b/files/es/learn/server-side/first_steps/web_frameworks/index.md
@@ -13,6 +13,7 @@ tags:
 translation_of: Learn/Server-side/First_steps/Web_frameworks
 original_slug: Learn/Server-side/Primeros_pasos/Web_frameworks
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Server-side/First_steps/Client-Server_overview", "Learn/Server-side/First_steps/Website_security", "Learn/Server-side/First_steps")}}
 
 El artículo anterior te mostró que pinta tiene la comunicación entre los clientes web y los servidores, la naturaleza de las peticiones y respuestas HTTP, y lo que necesita hacer una aplicación web de lado servidor para responder a las peticiones de un explorador web. Con este conocimiento en nuestra mochila, es hora de explorar cómo los frameworks web pueden simplificar estas tareas, y darte una idea de cómo escogerías un framework para tu primera aplicación web de lado servidor.

--- a/files/es/learn/server-side/first_steps/website_security/index.md
+++ b/files/es/learn/server-side/first_steps/website_security/index.md
@@ -14,6 +14,7 @@ tags:
 translation_of: Learn/Server-side/First_steps/Website_security
 original_slug: Learn/Server-side/Primeros_pasos/seguridad_sitios_web
 ---
+
 {{LearnSidebar}}{{PreviousMenu("Learn/Server-side/First_steps/Web_frameworks", "Learn/Server-side/First_steps")}}
 
 La Seguridad web require vigilancia en todos los aspectos del diseño y uso de un sitio web. Este artículo introductorio no te hará un gurú de la seguridad en sitios web, pero te ayudará a entender de donde vienen las amenazas y qué puedes hacer para fortalecer tu aplicación web contra los ataques más comunes.

--- a/files/es/learn/server-side/index.md
+++ b/files/es/learn/server-side/index.md
@@ -12,6 +12,7 @@ tags:
   - introducción
 translation_of: Learn/Server-side
 ---
+
 {{LearnSidebar}}
 
 El tema **_Páginas Dinámicas – Programación lado servidor_** contiene una serie de módulos en los que se enseña como crear sitios web dinámicos, sitios que entregan información personalizada como respuesta a las peticiones HTTP. El modulo ofrece una introducción generica a la programación de lado servidor además de guías para principiantes sobre como usar frameworks como Django (Python) y Express(Node.js/JavaScript) para crear aplicaciones web basicas.

--- a/files/es/learn/server-side/node_server_without_framework/index.md
+++ b/files/es/learn/server-side/node_server_without_framework/index.md
@@ -3,6 +3,7 @@ title: Servidor Node sin framework
 slug: Learn/Server-side/Node_server_without_framework
 translation_of: Learn/Server-side/Node_server_without_framework
 ---
+
 {{LearnSidebar}}
 
 Este artículo proporciona un servidor de ficheros estático simple construido con Node.js puro, para aquellos de vosotros que no quieran usar un framework.

--- a/files/es/learn/tools_and_testing/client-side_javascript_frameworks/index.md
+++ b/files/es/learn/tools_and_testing/client-side_javascript_frameworks/index.md
@@ -7,6 +7,7 @@ tags:
 translation_of: Learn/Tools_and_testing/Client-side_JavaScript_frameworks
 original_slug: Learn/Herramientas_y_pruebas/Lado-del-cliente_JavaScript_frameworks
 ---
+
 {{LearnSidebar}}
 
 Los frameworks de JavaScript son una parte esencial del desarrollo web front-end moderno, los cuales proveen a los desarrolladores herramientas probadas y testeadas para la creación de aplicaciones web interactivas y escalables. Muchas empresas modernas utilizan frameworks como parte estándar de sus herramientas, por lo que muchos trabajos de desarrollo front-end en la actualidad requieren experiencia en frameworks.

--- a/files/es/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.md
+++ b/files/es/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.md
@@ -11,6 +11,7 @@ translation_of: >-
 original_slug: >-
   Learn/Herramientas_y_pruebas/Lado-del-cliente_JavaScript_frameworks/React_getting_started
 ---
+
 {{LearnSidebar}}{{PreviousMenuNext("Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Main_features","Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_todo_list_beginning", "Learn/Tools_and_testing/Client-side_JavaScript_frameworks")}}
 
 En este artículo conoceremos React. Descubriremos algunos detalles sobre su trasfondo y casos de uso, configuraremos una cadena básica de herramientas para React en nuestra computadora local, crearemos y jugaremos con una aplicación inicial sencilla, mientras aprendemos —durante el proceso— un poco acerca de cómo funciona React.

--- a/files/es/learn/tools_and_testing/cross_browser_testing/index.md
+++ b/files/es/learn/tools_and_testing/cross_browser_testing/index.md
@@ -4,6 +4,7 @@ slug: Learn/Tools_and_testing/Cross_browser_testing
 translation_of: Learn/Tools_and_testing/Cross_browser_testing
 original_slug: Learn/Herramientas_y_pruebas/Cross_browser_testing
 ---
+
 {{LearnSidebar}}
 
 Este módulo se centra en probar proyectos web en diferentes navegadores. Nos fijamos en la identificación de su público objetivo (por ejemplo, qué usuarios, navegadores y dispositivos son los que más le preocupan?), cómo realizar las pruebas, los principales problemas a los que se enfrentará con los diferentes tipos de código y cómo mitigarlos, qué herramientas son las más útiles para ayudarle a probar y solucionar problemas, y cómo utilizar la automatización para acelerar las pruebas.

--- a/files/es/learn/tools_and_testing/github/index.md
+++ b/files/es/learn/tools_and_testing/github/index.md
@@ -10,6 +10,7 @@ tags:
 translation_of: Learn/Tools_and_testing/GitHub
 original_slug: Learn/Herramientas_y_pruebas/GitHub
 ---
+
 {{LearnSidebar}}
 
 Todos los desarrolladores utilizarán algún tipo de **sistema de control de versiones** (**VCS**), una herramienta que les permita colaborar con otros desarrolladores en un proyecto sin peligro de que sobrescriban el trabajo de los demás, y volver a las versiones anteriores de la base de código si existe un problema descubierto más tarde. El VCS más popular (al menos entre los desarrolladores web) es **Git**, junto con **GitHub**, un sitio que proporciona alojamiento para tus repositorios y varias herramientas para trabajar con ellos. Este módulo tiene como objetivo enseñarte lo que necesitas saber sobre ambos.

--- a/files/es/learn/tools_and_testing/index.md
+++ b/files/es/learn/tools_and_testing/index.md
@@ -19,6 +19,7 @@ tags:
 translation_of: Learn/Tools_and_testing
 original_slug: Learn/Herramientas_y_pruebas
 ---
+
 {{LearnSidebar}}
 
 Una vez que haya comenzado a sentirse cómodo programando con tecnologías web básicas (como HTML, CSS y JavaScript), y comience a adquirir más experiencia, leer más recursos y aprender más trucos y consejos, comenzará a encontrar todos tipo de herramientas, desde CSS y JavaScript ya enrollados, aplicaciones de prueba y automatización, y muchas más. A medida que sus proyectos web se vuelvan más grandes y complejos, querrá comenzar a aprovechar algunas de estas herramientas y elaborar planes de prueba confiables para su código. Esta parte del área de aprendizaje tiene como objetivo brindarle lo que necesita para comenzar y tomar decisiones informadas.

--- a/files/es/learn/tools_and_testing/understanding_client-side_tools/index.md
+++ b/files/es/learn/tools_and_testing/understanding_client-side_tools/index.md
@@ -15,6 +15,7 @@ tags:
 translation_of: Learn/Tools_and_testing/Understanding_client-side_tools
 original_slug: Learn/Herramientas_y_pruebas/Understanding_client-side_tools
 ---
+
 {{LearnSidebar}}
 
 Las herramientas del lado del cliente (_client-side_ en inglés) pueden ser intimidantes, pero esta serie de artículos tiene como propósito ilustrar el propósito de algunos de los tipos de herramientas _client-side_, explicar las herramientas que puedes integrar, cómo instalarlas usando administradores de paquetes y cómo controlarlas usando la línea de comandos. Terminanos esta sección dando un ejemplo de cadena de herramientas para mostrarte cómo puedes ser más productivo


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Adding the newline after the metadata block to match upstream cleanups from Prettier

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
