### PR TITLE
間違えて削除されてしまったSTUNを復活。

### DIFF
--- a/files/ja/glossary/stun/index.md
+++ b/files/ja/glossary/stun/index.md
@@ -1,0 +1,17 @@
+---
+title: STUN
+slug: Glossary/STUN
+l10n: 
+  sourceCommit: ed947b2c608428b62a60f07d09dc543f732dc09b
+---
+
+**STUN** (Session Traversal Utilities for NAT) は、{{glossary("NAT")}} (Network Address Translator) を介してデータを転送する際の補助プロトコルです。STUNは、NATの内側にあるコンピュータの {{glossary("IP address", "IP アドレス")}}、{{glossary("port", "ポート")}}、接続状態を返します。
+
+## 参考情報
+
+- [STUN](https://ja.wikipedia.org/wiki/STUN)  (ウィキペディア)
+- [WebRTC プロトコル](/ja/docs/Web/API/WebRTC_API/Protocols)
+
+### 技術リファレンス
+
+- [仕様](https://datatracker.ietf.org/doc/html/rfc5389)


### PR DESCRIPTION
### Description
わたしが間違えて、消してしまったSTUNの項目を復活させるために再度プルリクします。
確認をお願いします。やり方が間違っている場合は教えてもらえると助かります。

### Motivation
「用語集 - Self-Executing Anonymous Function の翻訳」のときに間違ってSTUNの変更が紛れ込んでいたので、削除したのですが、これがおそらく「STUNを削除する」という変更とみなされたものと思われます。

### Additional details
ファイルの内容は以前と同じです。

### Related issues and pull requests
https://github.com/mozilla-japan/translation/issues/663
