### PR TITLE
remove event macro from zh-CN (Part 5)

### DIFF
--- a/files/zh-cn/web/api/rtcpeerconnection/addtrack/index.md
+++ b/files/zh-cn/web/api/rtcpeerconnection/addtrack/index.md
@@ -7,7 +7,7 @@ slug: Web/API/RTCPeerConnection/addTrack
 
 {{domxref("RTCPeerConnection")}} 对象的 **`addTrack()`** 方法将一个新的媒体音轨添加到一组音轨中，这些音轨将被传输给另一个对等点。
 
-> **备注：** 通过触发一个{{event("negotiationneeded")}}事件，向连接添加一个跟踪将触发重新协商。详情请参见{{SectionOnPage("/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling", "Starting negotiation")}}。
+> **备注：** 通过触发一个 {{DOMxRef("RTCPeerConnection/negotiationneeded_event", "negotiationneeded")}} 事件，向连接添加一个跟踪将触发重新协商。详情请参见{{SectionOnPage("/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling", "Starting negotiation")}}。
 
 ## 语法
 
@@ -59,7 +59,7 @@ async openCall(pc) {
 }
 ```
 
-结果是一组没有流关联的跟踪被发送到远程对等点。远程对等点上的{{event("track")}}事件的处理程序将负责决定将每个跟踪添加到哪个流中，即使这意味着只是将它们全部添加到同一个流中。{{domxref("RTCPeerConnection.ontrack", "ontrack")}}方法如下：
+结果是一组没有流关联的跟踪被发送到远程对等点。远程对等点上的 {{DOMxRef("RTCPeerConnection/track_event", "track")}} 事件的处理程序将负责决定将每个跟踪添加到哪个流中，即使这意味着只是将它们全部添加到同一个流中。{{domxref("RTCPeerConnection.ontrack", "ontrack")}} 方法如下：
 
 ```js
 let inboundStream = null;
@@ -108,10 +108,10 @@ async openCall(pc) {
 }
 ```
 
-远程对等点然后可以使用一个看起来像这样的{{event("track")}}事件处理程序：
+远程对等点然后可以使用一个看起来像这样的 {{DOMxRef("RTCPeerConnection/track_event", "track")}} 事件处理程序：
 
 ```js
-pc.ontrack = ({streams: [stream]} => videoElem.srcObject = stream;
+pc.ontrack = ({streams: [stream]} => videoElem.srcObject = stream);
 ```
 
 这将把视频元素的当前流设置为包含已添加到连接中的音轨的流。
@@ -173,13 +173,12 @@ pc.setRemoteDescription(desc).then(function () {
 
 {{Specifications}}
 
-## 浏览器支持
+## 浏览器兼容性
 
 {{Compat}}
 
-## 参考
+## 参见
 
-- [WebRTC](/zh-CN/docs/Web/Guide/API/WebRTC)
-- [Introduction to the Real-time Transport Protocol (RTP)](/zh-CN/docs/Web/API/WebRTC_API/Intro_to_RTP)
-- {{domxref("RTCPeerConnection.ontrack")}}
-- {{event("track")}}
+- [WebRTC](/zh-CN/docs/Web/API/WebRTC_API)
+- [实时传输协议（RTP）简介](/zh-CN/docs/Web/API/WebRTC_API/Intro_to_RTP)
+- {{DOMxRef("RTCPeerConnection/track_event", "track")}}

--- a/files/zh-cn/web/api/rtcpeerconnection/createdatachannel/index.md
+++ b/files/zh-cn/web/api/rtcpeerconnection/createdatachannel/index.md
@@ -7,7 +7,7 @@ slug: Web/API/RTCPeerConnection/createDataChannel
 
 {{domxref("RTCPeerConnection")}} 的 `createDataChannel()` 方法创建一个可以发送任意数据的数据通道 (data channel)。常用于后台传输内容，例如：图像，文件传输，聊天文字，游戏数据更新包，等等。
 
-基于某个连接创建第一个 data channel 时，会通过发送一个{{event("negotiationneeded")}} event 来开始重新谈判 (renegotiation)。
+基于某个连接创建第一个 data channel 时，会通过发送一个 {{DOMxRef("RTCPeerConnection/negotiationneeded_event", "negotiationneeded")}} 事件来开始重新谈判（renegotiation）。
 
 ## 语法
 
@@ -65,7 +65,7 @@ A new {{domxref("RTCDataChannel")}} object with the specified `label`, configure
 
 ## Examples
 
-This example shows how to create a data channel and set up handlers for the {{event("open")}} and [`message`](/zh-CN/docs/Web/API/BroadcastChannel/message_event) events to send and receive messages on it (For brievity, the example assumes onnegotiationneeded is set up).
+This example shows how to create a data channel and set up handlers for the {{DOMxRef("RTCDataChannel/open_event", "open")}} and [`message`](/zh-CN/docs/Web/API/BroadcastChannel/message_event) events to send and receive messages on it (For brievity, the example assumes onnegotiationneeded is set up).
 
 ```js
 // Offerer side

--- a/files/zh-cn/web/api/rtcpeerconnection/createoffer/index.md
+++ b/files/zh-cn/web/api/rtcpeerconnection/createoffer/index.md
@@ -72,7 +72,7 @@ myPeerConnection.createOffer(successCallback, failureCallback, [options]) {{depr
 
 ## 举例
 
-在这里，我们看到了{{event("negotiationneeded")}}事件的处理程序，该处理程序创建了要约，并通过信令通道将其发送到远程系统。
+在这里，我们看到了 {{DOMxRef("RTCPeerConnection/negotiationneeded_event", "negotiationneeded")}} 事件的处理程序，该处理程序创建了要约，并通过信令通道将其发送到远程系统。
 
 > **备注：** 请记住，这是信令过程的一部分，传输层的实现细节完全由您决定。在这种情况下，[WebSocket](/zh-CN/docs/Web/API/WebSocket_API)连接用于向其他端点发送带有值为“video-offer”的类型字段的{{Glossary("JSON")}}消息。传递给`sendToServer()`函数的对象的内容，以及承诺履行处理程序中的所有其他内容，完全取决于您的设计。
 

--- a/files/zh-cn/web/api/rtcpeerconnection/datachannel_event/index.md
+++ b/files/zh-cn/web/api/rtcpeerconnection/datachannel_event/index.md
@@ -5,9 +5,9 @@ slug: Web/API/RTCPeerConnection/datachannel_event
 
 {{APIRef("WebRTC")}}{{SeeCompatTable}}
 
-**`RTCPeerConnection.ondatachannel`** 属性是一个 {{event("Event_handlers", "event handler")}}，当这个 {{event("datachannel")}} 事件在 {{domxref("RTCPeerConnection")}} 发生时，它指定的那个事件处理函数就会被调用。这个事件继承于 {{domxref("RTCDataChannelEvent")}}，当远方伙伴调用{{domxref("RTCPeerConnection.createDataChannel", "createDataChannel()")}}时这个事件被加到这个连接（RTCPeerConnection）中。
+**`RTCPeerConnection.ondatachannel`** 属性是一个事件处理器，当 `datachannel` 事件在 {{domxref("RTCPeerConnection")}} 发生时，它指定的那个事件处理函数就会被调用。这个事件继承于 {{domxref("RTCDataChannelEvent")}}，当远方伙伴调用 {{domxref("RTCPeerConnection.createDataChannel", "createDataChannel()")}} 时这个事件被加到这个连接（RTCPeerConnection）中。
 
-在这个事件被收到的同时，这个{{domxref("RTCDataChannel")}} 实际上并没有打开，确保在 open 这个事件在`RTCDataChannel`触发以后才去使用它。
+在这个事件被收到的同时，这个 {{domxref("RTCDataChannel")}} 实际上并没有打开，确保在 open 这个事件在`RTCDataChannel`触发以后才去使用它。
 
 ## 语法
 
@@ -34,12 +34,14 @@ pc.ondatachannel = function(ev) {
 
 {{Specifications}}
 
-## 浏览器支持
+## 浏览器兼容性
 
 {{Compat}}
 
-## 相关阅读
+## 参见
 
-- The {{event("datachannel")}} event and its type, {{domxref("RTCDataChannelEvent")}}.
+- [WebRTC API](/zh-CN/docs/Web/API/WebRTC_API)
+- [使用 WebRTC data channel](/zh-CN/docs/Web/API/WebRTC_API/Using_data_channels)
+- [RTCDataChannel 简单示例](/zh-CN/docs/Web/API/WebRTC_API/Simple_RTCDataChannel_sample)
+- {{domxref("RTCDataChannelEvent")}}
 - {{domxref("RTCPeerConnection.createDataChannel()")}}
-- [A simple RTCDataChannel sample](/zh-CN/docs/Web/API/WebRTC_API/Simple_RTCDataChannel_sample)

--- a/files/zh-cn/web/api/rtcpeerconnection/track_event/index.md
+++ b/files/zh-cn/web/api/rtcpeerconnection/track_event/index.md
@@ -3,7 +3,9 @@ title: RTCPeerConnection.ontrack
 slug: Web/API/RTCPeerConnection/track_event
 ---
 
-{{APIRef("WebRTC")}}{{SeeCompatTable}}**`RTCPeerConnection.ontrack`** 属性是一个 {{event("Event_handlers", "event handler")}} 此属性指定了在{{domxref("RTCPeerConnection")}}接口上触发 {{event("track")}} 事件时调用的方法。该方法接收一个{{domxref("RTCTrackEvent")}}类型的 event 对象，该 event 对象将在{{domxref("MediaStreamTrack")}}被创建时或者是关联到已被添加到接收集合的{{domxref("RTCRtpReceiver")}}对象中时被发送。
+{{APIRef("WebRTC")}}{{SeeCompatTable}}
+
+**`RTCPeerConnection.ontrack`** 属性是一个事件处理器，此属性指定了在 {{domxref("RTCPeerConnection")}}接口上触发 `track` 事件时调用的方法。该方法接收一个 {{domxref("RTCTrackEvent")}} 类型的 event 对象，该 event 对象将在 {{domxref("MediaStreamTrack")}} 被创建时或者是关联到已被添加到接收集合的 {{domxref("RTCRtpReceiver")}} 对象中时被发送。
 
 ## 语法
 
@@ -35,7 +37,3 @@ pc.ontrack = function(event) {
 ## 浏览器兼容性
 
 {{Compat}}
-
-## 参见
-
-- {{event("track")}} 事件和它的类型 {{domxref("RTCTrackEvent")}}.

--- a/files/zh-cn/web/api/serviceworkerglobalscope/index.md
+++ b/files/zh-cn/web/api/serviceworkerglobalscope/index.md
@@ -26,26 +26,30 @@ slug: Web/API/ServiceWorkerGlobalScope
 - {{domxref("ServiceWorkerGlobalScope.caches")}} {{readonlyinline}}
   - : Contains the {{domxref("CacheStorage")}} object associated with the service worker.
 
-### Event handlers
+## 事件
 
-- {{domxref("ServiceWorkerGlobalScope.onactivate")}}
-  - : An event handler fired whenever an {{Event("activate")}} event occurs — when a {{domxref("ServiceWorkerRegistration")}} acquires a new {{domxref("ServiceWorkerRegistration.active")}} worker.
-- {{domxref("ServiceWorkerGlobalScope.onfetch")}}
-  - : An event handler fired whenever a {{Event("fetch")}} event occurs — when a {{domxref("GlobalFetch.fetch", "fetch()")}} is called.
-- {{domxref("ServiceWorkerGlobalScope.oninstall")}}
-  - : An event handler fired whenever an {{Event("install")}} event occurs — when a {{domxref("ServiceWorkerRegistration")}} acquires a new {{domxref("ServiceWorkerRegistration.installing")}} worker.
-- {{domxref("ServiceWorkerGlobalScope.onmessage")}}
-  - : An event handler fired whenever a [`message`](/zh-CN/docs/Web/API/BroadcastChannel/message_event) event occurs — when incoming messages are received. Controlled pages can use the {{domxref("MessagePort.postMessage()")}} method to send messages to service workers. The service worker can optionally send a response back via the {{domxref("MessagePort")}} exposed in [`event.data.port`](https://html.spec.whatwg.org/multipage/comms.html#messageport), corresponding to the controlled page.
-- {{domxref("ServiceWorkerGlobalScope.onnotificationclick")}}
-  - : An event handler fired whenever a {{Event("notificationclick")}} event occurs — when a user clicks on a displayed notification.
-- {{domxref("ServiceWorkerGlobalScope.onnotificationclose")}}
-  - : An event handler fired whenever a {{Event("notificationclose")}} event occurs — when a user closes a displayed notification.
-- {{domxref("ServiceWorkerGlobalScope.onpush")}}
-  - : An event handler fired whenever a {{Event("push")}} event occurs — when a server push notification is received.
-- {{domxref("ServiceWorkerGlobalScope.onpushsubscriptionchange")}}
-  - : An event handler fired whenever a {{Event("pushsubscriptionchange")}} event occurs — when a push subscription has been invalidated, or is about to be invalidated (e.g. when a push service sets an expiration time.)
-- {{domxref("ServiceWorkerGlobalScope.onsync")}}
-  - : An event handler fired whenever a {{Event("SyncEvent")}} event occurs. This is triggered when a call to {{domxref("SyncManager.register")}} is made from a service worker client page. The attempt to sync is made either immediately if the network is available or as soon as the network becomes available.
+- {{domxref("ServiceWorkerGlobalScope/activate_event", "activate")}}
+  - : Occurs when a {{domxref("ServiceWorkerRegistration")}} acquires a new {{domxref("ServiceWorkerRegistration.active")}} worker.
+- {{domxref("ServiceWorkerGlobalScope/contentdelete_event", "contentdelete")}} {{Experimental_Inline}}
+  - : Occurs when an item is removed from the {{domxref("ContentIndex", "Content Index")}}.
+- {{domxref("ServiceWorkerGlobalScope/fetch_event", "fetch")}}
+  - : Occurs when a {{domxref("fetch()")}} is called.
+- {{domxref("ServiceWorkerGlobalScope/install_event", "install")}}
+  - : Occurs when a {{domxref("ServiceWorkerRegistration")}} acquires a new {{domxref("ServiceWorkerRegistration.installing")}} worker.
+- {{domxref("ServiceWorkerGlobalScope/message_event", "message")}}
+  - : Occurs when incoming messages are received. Controlled pages can use the {{domxref("MessagePort.postMessage()")}} method to send messages to service workers. The service worker can optionally send a response back via the {{domxref("MessagePort")}} exposed in [`event.data.port`](https://html.spec.whatwg.org/multipage/comms.html#messageport), corresponding to the controlled page.
+- {{domxref("ServiceWorkerGlobalScope/notificationclick_event", "notificationclick")}}
+  - : Occurs when a user clicks on a displayed notification.
+- {{domxref("ServiceWorkerGlobalScope/notificationclose_event", "notificationclose")}}
+  - : Occurs when a user closes a displayed notification.
+- {{domxref("ServiceWorkerGlobalScope/sync_event", "sync")}}
+  - : Triggered when a call to {{domxref("SyncManager.register")}} is made from a service worker client page. The attempt to sync is made either immediately if the network is available or as soon as the network becomes available.
+- {{domxref("ServiceWorkerGlobalScope/periodicsync_event", "periodicsync")}} {{Experimental_Inline}}
+  - : Occurs at periodic intervals, which were specified when registering a {{domxref("PeriodicSyncManager")}}.
+- {{domxref("ServiceWorkerGlobalScope/push_event", "push")}}
+  - : Occurs when a server push notification is received.
+- {{domxref("ServiceWorkerGlobalScope/pushsubscriptionchange_event", "pushsubscriptionchange")}}
+  - : Occurs when a push subscription has been invalidated, or is about to be invalidated (e.g. when a push service sets an expiration time).
 
 ## 方法
 

--- a/files/zh-cn/web/api/videotracklist/index.md
+++ b/files/zh-cn/web/api/videotracklist/index.md
@@ -18,14 +18,17 @@ _This interface also inherits properties from its parent interface, {{domxref("E
 - {{domxref("VideoTrackList.selectedIndex", "selectedIndex")}} {{ReadOnlyInline}}
   - : The index of the currently selected track, if any, or `−1` otherwise.
 
-## Event handlers
+## 事件
 
-- {{domxref("VideoTrackList.onaddtrack", "onaddtrack")}}
-  - : An event handler to be called when the {{event("addtrack")}} event is fired, indicating that a new video track has been added to the media element.
-- {{domxref("VideoTrackList.onchange", "onchange")}}
-  - : An event handler to be called when the [`change`](/zh-CN/docs/Web/API/HTMLElement/change_event) event occurs — that is, when the value of the {{domxref("VideoTrack.selected", "selected")}} property for a track has changed, due to the track being made active or inactive.
-- {{domxref("VideoTrackList.onremovetrack", "onremovetrack")}}
-  - : An event handler to call when the {{event("removetrack")}} event is sent, indicating that a video track has been removed from the media element.
+- {{domxref("VideoTrackList/addtrack_event", "addtrack")}}
+  - : Fired when a new video track has been added to the media element.
+    Also available via the `onaddtrack` property.
+- {{domxref("VideoTrackList.change_event", "change")}}
+  - : Fired when a video track has been made active or inactive.
+    Also available via the `onchange` property.
+- {{domxref("VideoTrackList/removetrack_event", "removetrack")}}
+  - : Fired when a new video track has been removed from the media element.
+    Also available via the `onremovetrack` property.
 
 ## Methods
 
@@ -48,9 +51,9 @@ _This interface also inherits methods from its parent interface, {{domxref("Even
 
 ## Usage notes
 
-In addition to being able to obtain direct access to the video tracks present on a media element, `VideoTrackList` lets you set event handlers on the {{event("addtrack")}} and {{event("removetrack")}} events, so that you can detect when tracks are added to or removed from the media element's stream. See {{domxref("VideoTrackList.onaddtrack", "onaddtrack")}} and {{domxref("VideoTrackList.onremovetrack", "onremovetrack")}} for details and examples.
+In addition to being able to obtain direct access to the video tracks present on a media element, `VideoTrackList` lets you set event handlers on the {{domxref("VideoTrackList/addtrack_event", "addtrack")}} and {{domxref("VideoTrackList/removetrack_event", "removetrack")}} events, so that you can detect when tracks are added to or removed from the media element's stream.
 
-## Examples
+## 示例
 
 ### Getting a media element's video track list
 
@@ -62,7 +65,7 @@ var videoTracks = document.querySelector("video").videoTracks;
 
 ### Monitoring track count changes
 
-In this example, we have an app that displays information about the number of channels available. To keep it up to date, handlers for the {{event("addtrack")}} and {{event("removetrack")}} events are set up.
+In this example, we have an app that displays information about the number of channels available. To keep it up to date, handlers for the {{domxref("VideoTrackList/addtrack_event", "addtrack")}} and {{domxref("VideoTrackList/removetrack_event", "removetrack")}} events are set up.
 
 ```js
 videoTracks.onaddtrack = updateTrackCount;
@@ -74,10 +77,10 @@ function updateTrackCount(event) {
 }
 ```
 
-## Specifications
+## 规范
 
 {{Specifications}}
 
-## Browser compatibility
+## 浏览器兼容性
 
 {{Compat}}

--- a/files/zh-cn/web/api/web_speech_api/index.md
+++ b/files/zh-cn/web/api/web_speech_api/index.md
@@ -27,7 +27,7 @@ Web Speech API 使 Web 应用能够处理语音数据，该项 API 包含以下�
 - {{domxref("SpeechRecognitionError")}}
   - : 表示语音识别服务发出的报错信息。
 - {{domxref("SpeechRecognitionEvent")}}
-  - : {{event("result")}} 和 {{event("nomatch")}} 的事件对象，包含了与语音识别过程中间或最终结果相关的全部数据。
+  - : {{domxref("SpeechRecognition.result_event", "result")}} 和 {{domxref("SpeechRecognition.nomatch_event", "nomatch")}} 的事件对象，包含了与语音识别过程中间或最终结果相关的全部数据。
 - {{domxref("SpeechGrammar")}}
   - : 我们将要交由语音识别服务进行识别的词汇或者词汇的模式。
 - {{domxref("SpeechGrammarList")}}

--- a/files/zh-cn/web/api/web_storage_api/using_the_web_storage_api/index.md
+++ b/files/zh-cn/web/api/web_storage_api/using_the_web_storage_api/index.md
@@ -9,7 +9,7 @@ Web Storage API 提供了存储机制，通过该机制，浏览器可以安全�
 
 存储对象是简单的键值存储，类似于对象，但是它们在页面加载时保持完整。键和值始终是字符串（请注意，与对象一样，整数键将自动转换为字符串）。您可以像访问对象一样访问这些值，或者使用 {{domxref("Storage.getItem()")}} 和 {{domxref("Storage.setItem()")}} 方法。这三行都设置了（相同的）colorSetting 条目：
 
-```
+```js
 localStorage.colorSetting = '#a4509b';
 localStorage['colorSetting'] = '#a4509b';
 localStorage.setItem('colorSetting', '#a4509b');
@@ -36,7 +36,7 @@ Web Storage 包含如下两种机制：
 
 这是一个检测 localStorage 是否同时受支持和可用的函数：
 
-```
+```js
 function storageAvailable(type) {
     var storage;
     try {
@@ -65,7 +65,7 @@ function storageAvailable(type) {
 
 这是您将如何使用它：
 
-```
+```js
 if (storageAvailable('localStorage')) {
   // Yippee! We can use localStorage awesomeness
 }
@@ -78,13 +78,13 @@ else {
 
 请参阅此处，[brief history of feature-detecting localStorage](https://gist.github.com/paulirish/5558557).。
 
-## 一个简单的示例
+## 示例
 
 为了展示 Web Storage 的用法，我们创建了一个简单的示例，假设称为 **Web Storage Demo**。[示例页面](https://mdn.github.io/dom-examples/web-storage/)提供了控制表单，用于自定义颜色、字体和装饰图片：
 
 ![](landing.png)当你选择不同的选项后，页面会立即更新；除此之外，你的选择会被存到 `localStorage` 里，这样，当你关闭页面之后重新加载时，你的选择会被记住。
 
-我们还提供了一个[存储事件结果页面](https://mdn.github.io/dom-examples/web-storage/event.html) — 如果你在另一个标签页加载该页面，然后改变之前示例页面的选项，则随着 {{event("StorageEvent")}} 事件的触发，更新的存储信息会显示出来。
+我们还提供了一个[存储事件结果页面](https://mdn.github.io/dom-examples/web-storage/event.html) — 如果你在另一个标签页加载该页面，然后改变之前示例页面的选项，则随着 {{domxref("StorageEvent")}} 事件的触发，更新的存储信息会显示出来。
 
 ![](event-output.png)
 
@@ -154,7 +154,7 @@ imageForm.onchange = populateStorage;
 
 ### 通过 StorageEvent 响应存储的变化
 
-无论何时，{{domxref("Storage")}} 对象发生变化时（即创建/更新/删除数据项时，重复设置相同的键值不会触发该事件，{{domxref("Storage.clear()")}} 方法至多触发一次该事件），{{event("StorageEvent")}} 事件会触发。在同一个页面内发生的改变不会起作用——在相同域名下的其他页面（如一个新标签或 iframe）发生的改变才会起作用。在其他域名下的页面不能访问相同的 Storage 对象。
+无论何时，{{domxref("Storage")}} 对象发生变化时（即创建/更新/删除数据项时，重复设置相同的键值不会触发该事件，{{domxref("Storage.clear()")}} 方法至多触发一次该事件），{{domxref("StorageEvent")}} 事件会触发。在同一个页面内发生的改变不会起作用——在相同域名下的其他页面（如一个新标签或 iframe）发生的改变才会起作用。在其他域名下的页面不能访问相同的 Storage 对象。
 
 在事件结果页面中的 JavaScript 如下所示（可见 [events.js](https://github.com/mdn/dom-examples/blob/master/web-storage/event.js)）：
 

--- a/files/zh-cn/web/api/webgl_lose_context/index.md
+++ b/files/zh-cn/web/api/webgl_lose_context/index.md
@@ -20,7 +20,7 @@ WebGL 扩展可以通过 {{domxref("WebGLRenderingContext.getExtension()")}} 方
 
 ## 示例
 
-使用这个扩展，你可以模拟 {{Event("webglcontextlost")}} 和 {{Event("webglcontextrestored")}} 事件：
+使用这个扩展，你可以模拟 [`webglcontextlost`](/zh-CN/docs/Web/API/HTMLCanvasElement/webglcontextlost_event) 和 [`webglcontextrestored`](/zh-CN/docs/Web/API/HTMLCanvasElement/webglcontextrestored_event) 事件：
 
 ```js
 var canvas = document.getElementById('canvas');
@@ -43,7 +43,7 @@ gl.getExtension('WEBGL_lose_context').loseContext();
 
 {{Compat}}
 
-## 参阅
+## 参见
 
 - {{domxref("WebGLRenderingContext.isContextLost()")}}
-- 事件：{{Event("webglcontextlost")}}, {{Event("webglcontextrestored")}}, {{Event("webglcontextcreationerror")}}
+- 事件：[`webglcontextlost`](/zh-CN/docs/Web/API/HTMLCanvasElement/webglcontextlost_event)、[`webglcontextrestored`](/zh-CN/docs/Web/API/HTMLCanvasElement/webglcontextrestored_event)、[`webglcontextcreationerror`](/zh-CN/docs/Web/API/HTMLCanvasElement/webglcontextcreationerror_event)

--- a/files/zh-cn/web/api/webglcontextevent/index.md
+++ b/files/zh-cn/web/api/webglcontextevent/index.md
@@ -26,7 +26,7 @@ _此接口本身并没有定义任何方法，而是从它的父接口 {{domxref
 
 ## 示例
 
-使用 {{domxref("WEBGL_lose_context")}} 插件，你可以模拟 {{Event("webglcontextlost")}} 和 {{Event("webglcontextrestored")}} 事件：
+使用 {{domxref("WEBGL_lose_context")}} 插件，你可以模拟 {{domxref("HTMLCanvasElement/webglcontextlost_event", "webglcontextlost")}} 和 {{domxref("HTMLCanvasElement/webglcontextrestored_event", "webglcontextrestored")}} 事件：
 
 ```js
 var canvas = document.getElementById('canvas');

--- a/files/zh-cn/web/api/webrtc_api/signaling_and_video_calling/index.md
+++ b/files/zh-cn/web/api/webrtc_api/signaling_and_video_calling/index.md
@@ -271,7 +271,7 @@ function invite(evt) {
 
 然后遍历流中的磁道，调用 {{domxref("RTCPeerConnection.addTrack", "addTrack()")}} 将每个磁道添加到 `RTCPeerConnection`。尽管连接尚未完全建立，但必须尽快开始向其发送媒体数据，因为媒体数据将帮助 ICE 层决定采取的最佳连接方式，这有助于协商过程。
 
-一旦媒体数据连接到 `RTCPeerConnection`，就会在连接处触发事件{{event("negotiationneeded")}} 事件，以便启动 ICE 协商。
+一旦媒体数据连接到 `RTCPeerConnection`，就会在连接处触发 {{domxref("RTCPeerConnection.negotiationneeded_event", "negotiationneeded")}} 事件，以便启动 ICE 协商。
 
 如果在尝试获取本地媒体流时发生错误，catch 子句将调用`handleGetUserMediaError()`，根据需要向用户显示适当的错误。
 
@@ -338,23 +338,23 @@ function createPeerConnection() {
 前三个事件处理程序是必需的；你必须处理它们才能使用 WebRTC 执行任何涉及流媒体的操作。其余的并不是严格要求的，但可能有用，我们将对此进行探讨。在这个例子中，还有一些其他的事件我们没有使用。下面是我们将要实现的每个事件处理程序的摘要：
 
 - {{domxref("RTCPeerConnection.onicecandidate")}}
-  - : 当需要你通过信令服务器将一个 ICE 候选发送给另一个对等端时，本地 ICE 层将会调用你的 {{event("icecandidate")}} 事件处理程序。有关更多信息，请参阅[交换 ICE 候选](#交换_ice_候选) 以查看此示例的代码。
+  - : 当需要你通过信令服务器将一个 ICE 候选发送给另一个对等端时，本地 ICE 层将会调用你的 `icecandidate` 事件处理程序。有关更多信息，请参阅[交换 ICE 候选](#交换_ice_候选) 以查看此示例的代码。
 - {{domxref("RTCPeerConnection.ontrack")}}
-  - : 当向连接中添加磁道时，{{event("track")}} 事件的此处理程序由本地 WebRTC 层调用。例如，可以将传入媒体连接到元素以显示它。详见[接收新的流数据](#接收新的流数据) 。
+  - : 当向连接中添加磁道时，`track` 事件的此处理程序由本地 WebRTC 层调用。例如，可以将传入媒体连接到元素以显示它。详见[接收新的流数据](#接收新的流数据) 。
 - {{domxref("RTCPeerConnection.onnegotiationneeded")}}
   - : 每当 WebRTC 基础结构需要你重新启动会话协商过程时，都会调用此函数。它的工作是创建和发送一个请求，给被叫方，要求它与我们联系。参见[开始协商](#开始协商)了解我们如何处理这一问题。
 - {{domxref("RTCPeerConnection.onremovetrack")}}
-  - : 调用与 `ontrack`相对应的对象来处理 {{event("removetrack")}} 事件；当远程对等端从正在发送的媒体中删除磁道时，它将发送到`RTCPeerConnection`。参见 [处理流的移除](#处理流的移除) 。
+  - : 调用与 `ontrack`相对应的对象来处理 `removetrack` 事件；当远程对等端从正在发送的媒体中删除磁道时，它将发送到`RTCPeerConnection`。参见[处理流的移除](#处理流的移除) 。
 - {{domxref("RTCPeerConnection.oniceconnectionstatechange")}}
-  - : ICE 层发送{{event("iceconnectionstatechange")}} 事件，让你了解 ICE 连接状态的更改。这可以帮助你了解连接何时失败或丢失。我们将在下面的[ICE 连接状态](#ice_连接状态)中查看此示例的代码。
+  - : ICE 层发送 `iceconnectionstatechange` 事件，让你了解 ICE 连接状态的更改。这可以帮助你了解连接何时失败或丢失。我们将在下面的[ICE 连接状态](#ice_连接状态)中查看此示例的代码。
 - {{domxref("RTCPeerConnection.onicegatheringstatechange")}}
   - : 当 ICE 代理收集候选对象的过程从一个状态切换到另一个状态（例如开始收集候选对象或完成协商）时，ICE 层将向你发送事件（“ICegulatingStateChange”）事件。见下文 [ICE 收集状态](#ice_收集状态)。
 - {{domxref("RTCPeerConnection.onsignalingstatechange")}}
-  - : 当信令进程的状态更改时（或如果到信令服务器的连接更改时），WebRTC 架构将向你发送 {{event("signalingstatechange")}} 消息。参见[ICE 信令状态](#ice_信令状态)查看我们的代码。
+  - : 当信令进程的状态更改时（或如果到信令服务器的连接更改时），WebRTC 架构将向你发送 `signalingstatechange` 消息。参见[ICE 信令状态](#ice_信令状态)查看我们的代码。
 
 #### 开始协商
 
-一旦调用者创建了其 {{domxref("RTCPeerConnection")}} ，创建了媒体流，并将其磁道添加到连接中，如 [开始通话的交互](#开始通话的交互) 所示，浏览器将向 {{domxref("RTCPeerConnection")}} 传递一个 {{event("negotiationneeded")}} 事件，以指示它已准备好开始与其他对等方协商。以下是我们处理 {{event("negotiationneeded")}} 事件的代码：
+一旦调用者创建了其 {{domxref("RTCPeerConnection")}} ，创建了媒体流，并将其磁道添加到连接中，如 [开始通话的交互](#开始通话的交互) 所示，浏览器将向 {{domxref("RTCPeerConnection")}} 传递一个 {{domxref("RTCPeerConnection.negotiationneeded_event", "negotiationneeded")}} 事件，以指示它已准备好开始与其他对等方协商。以下是我们处理 {{domxref("RTCPeerConnection.negotiationneeded_event", "negotiationneeded")}} 事件的代码：
 
 ```js
 function handleNegotiationNeededEvent() {
@@ -392,7 +392,7 @@ function handleNegotiationNeededEvent() {
 
 如果在初始 `createOffer()` 或后面的任何实现处理程序中发生错误，则通过调用 `reportError()` 函数报告错误。
 
-在 `setLocalDescription()`的实现处理程序运行后，ICE 代理开始向其发现的每个潜在 {{domxref("RTCPeerConnection")}} 配置发送 {{event("icecandidate")}} 事件。我们的 `icecandidate` 事件处理程序负责将候选对象传输到另一个对等方。
+在 `setLocalDescription()`的实现处理程序运行后，ICE 代理开始向其发现的每个潜在 {{domxref("RTCPeerConnection")}} 配置发送 {{domxref("RTCPeerConnection.icecandidate_event", "icecandidate")}} 事件。我们的 `icecandidate` 事件处理程序负责将候选对象传输到另一个对等方。
 
 #### 会话协商
 
@@ -400,7 +400,7 @@ function handleNegotiationNeededEvent() {
 
 ##### 处理请求
 
-当请求到达时，调用被调用方的 `handleVideoOfferMsg()` 函数时会收到`"video-offer"` 消息。这个函数需要做两件事。首先，它需要创建自己的{{domxref("RTCPeerConnection")}} 并添加包含麦克风和网络摄像头的音频和视频的磁道。其次，它需要对收到的请求进行处理，构建并返回应答。
+当请求到达时，调用被调用方的 `handleVideoOfferMsg()` 函数时会收到`"video-offer"` 消息。这个函数需要做两件事。首先，它需要创建自己的 {{domxref("RTCPeerConnection")}} 并添加包含麦克风和网络摄像头的音频和视频的磁道。其次，它需要对收到的请求进行处理，构建并返回应答。
 
 ```
 function handleVideoOfferMsg(msg) {
@@ -448,11 +448,11 @@ function handleVideoOfferMsg(msg) {
 
 捕捉到的任何错误都会被传递给 `handleGetUserMediaError()`，详见 [处理 getUserMedia() 错误](#处理_getusermedia_错误) 。
 
-> **备注：** 与调用者的情况一样，一旦 `setLocalDescription()`实现处理程序运行完毕，浏览器将开始触发被调用者必须处理的{{event("icecandidate")}} 事件，每个需要传输到远程对等方的候选事件对应一个事件。
+> **备注：** 与调用者的情况一样，一旦 `setLocalDescription()`实现处理程序运行完毕，浏览器将开始触发被调用者必须处理的 {{domxref("RTCPeerConnection.icecandidate_event", "icecandidate")}} 事件，每个需要传输到远程对等方的候选事件对应一个事件。
 
 ##### 发送 ICE 候选
 
-ICE 协商过程涉及到每一个对等端不断地向另一个对等端发送候选，直到它用尽了支持 `RTCPeerConnection`的媒体传输需求的潜在方法。因为 ICE 不知道你的信令服务器，所以你的处理程序代码需要处理 {{event("icecandidate")}} 事件中每个候选的传输。
+ICE 协商过程涉及到每一个对等端不断地向另一个对等端发送候选，直到它用尽了支持 `RTCPeerConnection`的媒体传输需求的潜在方法。因为 ICE 不知道你的信令服务器，所以你的处理程序代码需要处理 {{domxref("RTCPeerConnection.icecandidate_event", "icecandidate")}} 事件中每个候选的传输。
 
 你的 {{domxref("RTCPeerConnection.onicecandidate", "onicecandidate")}} 处理程序接收一个事件，该事件的候选属性是描述该候选的 SDP（或为 `null` ，表示 ICE 层已耗尽建议的潜在配置）。候选的内容是你需要使用信令服务器传输的内容。下面是我们的示例实现：
 
@@ -479,7 +479,7 @@ function handleICECandidateEvent(event) {
 
 此消息的格式（与处理信号时所做的所有操作一样）完全取决于你的需要；你可以根据需要提供其他信息。
 
-> **备注：** 重要的是要记住， {{event("icecandidate")}} 事件**不会**在 ICE 候选从呼叫的另一端到达时发送。相反，它们是由你自己的呼叫端发送的，这样你就可以承担通过你选择的任何通道传输数据的任务。当你刚接触 WebRTC 时，这会让人困惑。
+> **备注：** 重要的是要记住，{{domxref("RTCPeerConnection.icecandidate_event", "icecandidate")}} 事件**不会**在 ICE 候选从呼叫的另一端到达时发送。相反，它们是由你自己的呼叫端发送的，这样你就可以承担通过你选择的任何通道传输数据的任务。当你刚接触 WebRTC 时，这会让人困惑。
 
 ##### 接收 ICE 候选
 
@@ -498,7 +498,7 @@ function handleNewICECandidateMsg(msg) {
 
 每一个对等端向另一个对等端发送一个候选的可能传输配置，它认为这对于正在交换的媒体可能是可行的。在某种程度上，这两端认为，一个给定的候选是一个很好的选择，于是他们打开连接，开始分享媒体数据。然而，重点要注意的是，一旦媒体数据开始流动，ICE 上协商就不会停止。相反，在对话开始后，候选对象可能仍然在不断地进行交换，可能是在试图找到更好的连接方法的同时，也可能只是因为在对等方成功建立连接时，他们已经在传输中了。
 
-此外，如果发生什么事情导致流场景发生变化，协商将再次开始，将事件{{event("negotiationneeded")}}事件发送到{{domxref("RTCPeerConnection")}}，整个过程将如前所述重新开始。这可能发生在各种情况下，包括：
+此外，如果发生什么事情导致流场景发生变化，协商将再次开始，将事件 {{domxref("RTCPeerConnection.negotiationneeded_event", "negotiationneeded")}} 事件发送到{{domxref("RTCPeerConnection")}}，整个过程将如前所述重新开始。这可能发生在各种情况下，包括：
 
 - 网络状态的变化，如带宽变化、从 WiFi 过渡到蜂窝连接等。
 - 在手机的前后摄像头之间切换。
@@ -506,7 +506,7 @@ function handleNewICECandidateMsg(msg) {
 
 ##### 接收新的流数据
 
-当新的磁道添加到 `RTCPeerConnection`时——通过调用其{{domxref("RTCPeerConnection.addTrack", "addTrack()")}} 方法，或者由于重新协商流的格式——对于添加到连接的每个磁道，一个{{event("track")}}事件设置为 `RTCPeerConnection` 。使用新添加的媒体需要实现 `track` 事件的处理程序。常见的需要是将传入的媒体附加到适当的 HTML 元素。在我们的示例中，我们将磁道的流添加到显示传入视频的 {{HTMLElement("video")}} 元素：
+当新的磁道添加到 `RTCPeerConnection`时——通过调用其{{domxref("RTCPeerConnection.addTrack", "addTrack()")}} 方法，或者由于重新协商流的格式——对于添加到连接的每个磁道，一个 {{domxref("RTCPeerConnection.track_event", "track")}} 事件设置为 `RTCPeerConnection` 。使用新添加的媒体需要实现 `track` 事件的处理程序。常见的需要是将传入的媒体附加到适当的 HTML 元素。在我们的示例中，我们将磁道的流添加到显示传入视频的 {{HTMLElement("video")}} 元素：
 
 ```js
 function handleAddStreamEvent(event) {
@@ -521,7 +521,7 @@ function handleAddStreamEvent(event) {
 
 ##### 处理流的移除
 
-当远程对等方通过调用{{domxref("RTCPeerConnection.removeTrack()")}}.从连接中删除磁道时，你的代码将接收事件{{event("removetrack")}}事件。 `"removetrack"` 的处理程序是：
+当远程对等方通过调用{{domxref("RTCPeerConnection.removeTrack()")}}.从连接中删除磁道时，你的代码将接收事件 {{domxref("MediaStream/removetrack_event", "removetrack")}} 事件。`"removetrack"` 的处理程序是：
 
 ```
 function handleRemoveTrackEvent(event) {
@@ -613,11 +613,11 @@ function closeVideoCall() {
 
 #### 处理状态变更
 
-还有许多其他事件可以设置监听器，用于通知代码各种状态更改。我们使用三种方法： {{event("iceconnectionstatechange")}}，{{event("icegatheringstatechange")}}，和 {{event("signalingstatechange")}}。
+还有许多其他事件可以设置监听器，用于通知代码各种状态更改。我们使用三种方法：{{domxref("RTCPeerConnection.iceconnectionstatechange_event", "iceconnectionstatechange")}}、{{domxref("RTCPeerConnection.icegatheringstatechange_event", "icegatheringstatechange")}} 和 {{domxref("RTCPeerConnection.signalingstatechange_event", "signalingstatechange")}}。
 
 ##### ICE 连接状态
 
-事件{{event("iceconnectionstatechange")}}当连接状态更改时（例如，当从另一端终止调用时），由 ICE 层将事件发送到{{domxref("RTCPeerConnection")}} 。
+事件 {{domxref("RTCPeerConnection.iceconnectionstatechange_event", "iceconnectionstatechange")}} 当连接状态更改时（例如，当从另一端终止调用时），由 ICE 层将事件发送到{{domxref("RTCPeerConnection")}} 。
 
 ```js
 function handleICEConnectionStateChangeEvent(event) {
@@ -635,7 +635,7 @@ function handleICEConnectionStateChangeEvent(event) {
 
 ##### ICE 信令状态
 
-同样，我们监听{{event("signalingstatechange")}}事件。如果信号状态变为 `closed`，我们同样关闭呼叫。
+同样，我们监听 {{domxref("RTCPeerConnection.signalingstatechange_event", "signalingstatechange")}} 事件。如果信号状态变为 `closed`，我们同样关闭呼叫。
 
 ```js
   myPeerConnection.onsignalingstatechange = function(event) {
@@ -651,7 +651,7 @@ function handleICEConnectionStateChangeEvent(event) {
 
 ##### ICE 收集状态
 
-{{event("icegatheringstatechange")}} 事件用于让你知道何时 ICE 候选收集进程状态发生更改。我们的示例并没有将其用于任何用途，但是为了调试的目的观察这些事件以及检测候选集合何时完成都是有用的。
+{{domxref("RTCPeerConnection.icegatheringstatechange_event", "icegatheringstatechange")}} 事件用于让你知道何时 ICE 候选收集进程状态发生更改。我们的示例并没有将其用于任何用途，但是为了调试的目的观察这些事件以及检测候选集合何时完成都是有用的。
 
 ```js
 function handleICEGatheringStateChangeEvent(event) {

--- a/files/zh-cn/web/api/webrtc_api/simple_rtcdatachannel_sample/index.md
+++ b/files/zh-cn/web/api/webrtc_api/simple_rtcdatachannel_sample/index.md
@@ -99,7 +99,7 @@ remoteConnection = new RTCPeerConnection();
 remoteConnection.ondatachannel = receiveChannelCallback;
 ```
 
-远程端的建立过程类似“local”端，但它无需自己创建 {{domxref("RTCDataChannel")}} ，因为我们将通过上面建立的渠道进行连接。我们创建对 {{event("datachannel")}} 的事件处理回调；数据通道打开时该逻辑将被执行，该回调处理将接收到一个 `RTCDataChannel` 对象，此过程将在文章后面部分描述。
+远程端的建立过程类似“local”端，但它无需自己创建 {{domxref("RTCDataChannel")}} ，因为我们将通过上面建立的渠道进行连接。我们创建对 {{domxref("RTCPeerConnection.datachannel_event", "datachannel")}} 的事件处理回调；数据通道打开时该逻辑将被执行，该回调处理将接收到一个 `RTCDataChannel` 对象，此过程将在文章后面部分描述。
 
 #### 设立 ICE 候选人
 
@@ -117,7 +117,7 @@ remoteConnection.ondatachannel = receiveChannelCallback;
         .catch(handleAddCandidateError);
 ```
 
-我们配置每个 {{domxref("RTCPeerConnection")}} 对于事件 {{event("icecandidate")}} 建立事件处理。
+我们配置每个 {{domxref("RTCPeerConnection")}} 对于事件 {{domxref("RTCPeerConnection.icecandidate_event", "icecandidate")}} 建立事件处理。
 
 #### 启动连接尝试
 
@@ -147,7 +147,7 @@ remoteConnection.ondatachannel = receiveChannelCallback;
 
 #### 对成功的对等连接的处理
 
-当 peer-to-peer 连接的任何一方成功连接，相应的 {{domxref("RTCPeerConnection")}}的{{event("icecandidate")}} 事件将被触发。在事件的处理中可以执行任何需要的操作，但在本例中，我们所需要做的只是更新用户界面。
+当 peer-to-peer 连接的任何一方成功连接，相应的 {{domxref("RTCPeerConnection")}} 的 {{domxref("RTCPeerConnection.icecandidate_event", "icecandidate")}} 事件将被触发。在事件的处理中可以执行任何需要的操作，但在本例中，我们所需要做的只是更新用户界面。
 
 ```js
   function handleLocalAddCandidateSuccess() {
@@ -163,7 +163,7 @@ remoteConnection.ondatachannel = receiveChannelCallback;
 
 #### 数据通道（data channel）的连接
 
-{{domxref("RTCPeerConnection")}} 一旦 open，事件{{event("datachannel")}} 被发送到远端以完成打开数据通道的处理，该事件触发 `receiveChannelCallback()` 方法，如下所示：
+{{domxref("RTCPeerConnection")}} 一旦 open，事件{{domxref("RTCPeerConnection.datachannel_event", "datachannel")}} 被发送到远端以完成打开数据通道的处理，该事件触发 `receiveChannelCallback()` 方法，如下所示：
 
 ```js
   function receiveChannelCallback(event) {
@@ -174,7 +174,7 @@ remoteConnection.ondatachannel = receiveChannelCallback;
   }
 ```
 
-事件{{event("datachannel")}} 在它的 channel 属性中包括了：对代表 remote 节点的 channel 的{{domxref("RTCDataChannel")}} 的指向，它保存了我们用以在该 channel 上对我们希望处理的事件建立的事件监听。一旦侦听建立，每当 remote 节点接收到数据 `handleReceiveMessage()` 方法将被调用，每当通道的连接状态发生改变 `handleReceiveChannelStatusChange()` 方法将被调用，因此通道完全打开或者关闭时我们都可以作出相应的相应。
+事件 {{domxref("RTCPeerConnection.datachannel_event", "datachannel")}} 在它的 channel 属性中包括了：对代表 remote 节点的 channel 的{{domxref("RTCDataChannel")}} 的指向，它保存了我们用以在该 channel 上对我们希望处理的事件建立的事件监听。一旦侦听建立，每当 remote 节点接收到数据 `handleReceiveMessage()` 方法将被调用，每当通道的连接状态发生改变 `handleReceiveChannelStatusChange()` 方法将被调用，因此通道完全打开或者关闭时我们都可以作出相应的相应。
 
 ### 对通道状态变化的处理
 

--- a/files/zh-cn/web/api/window/index.md
+++ b/files/zh-cn/web/api/window/index.md
@@ -331,7 +331,7 @@ _This interface inherits event handlers from the {{domxref("EventTarget")}} inte
 > **备注：** Starting in {{Gecko("9.0")}}, you can now use the syntax `if ("onabort" in window)` to determine whether or not a given event handler property exists. This is because event handler interfaces have been updated to be proper web IDL interfaces. See [DOM event handlers](/zh-CN/docs/DOM/DOM_event_handlers) for details.
 
 - {{domxref("Window.onappinstalled")}}
-  - : Called when the page is installed as a webapp. See {{event('appinstalled')}} event.
+  - : Called when the page is installed as a webapp. See `appinstalled` event.
 - {{domxref("Window.onbeforeinstallprompt")}}
   - : An event handler property dispatched before a user is prompted to save a web site to a home screen on mobile.
 - {{domxref("Window.ondevicelight")}}
@@ -355,19 +355,19 @@ _This interface inherits event handlers from the {{domxref("EventTarget")}} inte
 - {{domxref("Window.onuserproximity")}}
   - : An event handler property for user proximity events.
 - {{domxref("Window.onvrdisplayconnect")}}
-  - : Represents an event handler that will run when a compatible VR device has been connected to the computer (when the {{event("vrdisplayconnected")}} event fires).
+  - : Represents an event handler that will run when a compatible VR device has been connected to the computer (when the `vrdisplayconnected` event fires).
 - {{domxref("Window.onvrdisplaydisconnect")}}
-  - : Represents an event handler that will run when a compatible VR device has been disconnected from the computer (when the {{event("vrdisplaydisconnected")}} event fires).
+  - : Represents an event handler that will run when a compatible VR device has been disconnected from the computer (when the `vrdisplaydisconnected` event fires).
 - {{domxref("Window.onvrdisplayactivate")}}
-  - : Represents an event handler that will run when a display is able to be presented to (when the {{event("vrdisplayactivate")}} event fires), for example if an HMD has been moved to bring it out of standby, or woken up by being put on.
+  - : Represents an event handler that will run when a display is able to be presented to (when the `vrdisplayactivate` event fires), for example if an HMD has been moved to bring it out of standby, or woken up by being put on.
 - {{domxref("Window.onvrdisplaydeactivate")}}
-  - : Represents an event handler that will run when a display can no longer be presented to (when the {{event("vrdisplaydeactivate")}} event fires), for example if an HMD has gone into standby or sleep mode due to a period of inactivity.
+  - : Represents an event handler that will run when a display can no longer be presented to (when the `vrdisplaydeactivate` event fires), for example if an HMD has gone into standby or sleep mode due to a period of inactivity.
 - {{domxref("Window.onvrdisplayblur")}}
-  - : Represents an event handler that will run when presentation to a display has been paused for some reason by the browser, OS, or VR hardware (when the {{event("vrdisplayblur")}} event fires) — for example, while the user is interacting with a system menu or browser, to prevent tracking or loss of experience.
+  - : Represents an event handler that will run when presentation to a display has been paused for some reason by the browser, OS, or VR hardware (when the `vrdisplayblur` event fires) — for example, while the user is interacting with a system menu or browser, to prevent tracking or loss of experience.
 - {{domxref("Window.onvrdisplayfocus")}}
-  - : Represents an event handler that will run when presentation to a display has resumed after being blurred (when the {{event("vrdisplayfocus")}} event fires).
+  - : Represents an event handler that will run when presentation to a display has resumed after being blurred (when the `vrdisplayfocus` event fires).
 - {{domxref("Window.onvrdisplaypresentchange")}}
-  - : represents an event handler that will run when the presenting state of a VR device changes — i.e. goes from presenting to not presenting, or vice versa (when the {{event("vrdisplaypresentchange")}} event fires).
+  - : represents an event handler that will run when the presenting state of a VR device changes — i.e. goes from presenting to not presenting, or vice versa (when the `vrdisplaypresentchange` event fires).
 
 ### Event handlers implemented from elsewhere
 
@@ -410,7 +410,7 @@ _This interface inherits event handlers from the {{domxref("EventTarget")}} inte
 - {{domxref("GlobalEventHandlers.onload")}}
   - : Called after all resources and the DOM are fully loaded. WILL NOT get called when the page is loaded from cache, such as with back button.
 - {{domxref("WindowEventHandlers.onmessage")}}
-  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the [`message`](/zh-CN/docs/Web/API/BroadcastChannel/message_event) event is raised.
+  - : Is an event handler representing the code to be called when the [`message`](/zh-CN/docs/Web/API/BroadcastChannel/message_event) event is raised.
 - {{domxref("GlobalEventHandlers.onmousedown")}}
   - : Called when ANY mouse button is pressed.
 - {{domxref("GlobalEventHandlers.onmousemove")}}
@@ -442,7 +442,7 @@ _This interface inherits event handlers from the {{domxref("EventTarget")}} inte
 - {{domxref("GlobalEventHandlers.onselect")}}
   - : Called after text in an input field is selected
 - {{domxref("GlobalEventHandlers.onselectionchange")}}
-  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("selectionchange")}} event is raised.
+  - : Is an event handler representing the code to be called when the `selectionchange` event is raised.
 - {{domxref("WindowEventHandlers.onstorage")}}
   - : Called when there is a change in session storage or local storage. See [`storage`](/zh-CN/docs/Web/API/Window/storage_event) event
 - {{domxref("GlobalEventHandlers.onsubmit")}}

--- a/files/zh-cn/web/api/workerglobalscope/index.md
+++ b/files/zh-cn/web/api/workerglobalscope/index.md
@@ -36,15 +36,15 @@ _This interface inherits properties from the {{domxref("EventTarget")}} interfac
 _This interface inherits event handlers from the {{domxref("EventTarget")}} interface and implements event handlers from {{domxref("WindowTimers")}}, and {{domxref("WindowBase64")}}._
 
 - {{domxref("WorkerGlobalScope.onerror")}}
-  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the [`error`](/zh-CN/docs/Web/API/Element/error_event) event is raised.
+  - : Is an event handler representing the code to be called when the [`error`](/zh-CN/docs/Web/API/Element/error_event) event is raised.
 - {{domxref("WorkerGlobalScope.onoffline")}}
-  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the [`offline`](/zh-CN/docs/Web/API/Window/offline_event) event is raised.
+  - : Is an event handler representing the code to be called when the [`offline`](/zh-CN/docs/Web/API/Window/offline_event) event is raised.
 - {{domxref("WorkerGlobalScope.ononline")}}
-  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the [`online`](/zh-CN/docs/Web/API/Window/online_event) event is raised.
+  - : Is an event handler representing the code to be called when the [`online`](/zh-CN/docs/Web/API/Window/online_event) event is raised.
 - {{domxref("WorkerGlobalScope.onlanguagechange")}}
-  - : An {{event("Event_handlers", "event handler")}} fired at the global/worker scope object when the user's preferred languages change.
+  - : An event handler fired at the global/worker scope object when the user's preferred languages change.
 - {{domxref("WorkerGlobalScope.onclose")}} {{non-standard_inline}}
-  - : Is an {{event("Event_handlers", "event handler")}} representing the code to be called when the {{event("close")}} event is raised.
+  - : Is an event handler representing the code to be called when the `close` event is raised.
 - {{domxref("WorkerGlobalScope.onrejectionhandled")}} {{non-standard_inline}}
   - : An event handler for handled [`Promise`](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Promise) rejection events.
 - {{domxref("WorkerGlobalScope.onunhandledrejection")}} {{non-standard_inline}}

--- a/files/zh-cn/web/api/xmlhttprequest/index.md
+++ b/files/zh-cn/web/api/xmlhttprequest/index.md
@@ -23,7 +23,7 @@ slug: Web/API/XMLHttpRequest
 _此接口继承了 {{domxref("XMLHttpRequestEventTarget")}} 和 {{domxref("EventTarget")}} 的属性。_
 
 - {{domxref("XMLHttpRequest.onreadystatechange")}}
-  - : 当 `readyState` 属性发生变化时，调用的 {{event("Event_handlers", "event handler")}}。
+  - : 当 `readyState` 属性发生变化时，调用的事件处理器。
 - {{domxref("XMLHttpRequest.readyState")}} {{readonlyinline}}
   - : 返回 一个无符号短整型（`unsigned short`）数字，代表请求的状态码。
 - {{domxref("XMLHttpRequest.response")}} {{readonlyinline}}
@@ -46,7 +46,7 @@ _此接口继承了 {{domxref("XMLHttpRequestEventTarget")}} 和 {{domxref("Even
 - {{domxref("XMLHttpRequest.timeout")}}
   - : 一个无符号长整型（`unsigned long`）数字，表示该请求的最大请求时间（毫秒），若超出该时间，请求会自动终止。
 - {{domxref("XMLHttpRequestEventTarget.ontimeout")}}
-  - : 当请求超时调用的 {{event("Event_handlers", "event handler")}}。
+  - : 当请求超时调用的事件处理器。
 - {{domxref("XMLHttpRequest.upload")}} {{readonlyinline}}
   - : {{domxref("XMLHttpRequestUpload")}}，代表上传进度。
 - {{domxref("XMLHttpRequest.withCredentials")}}

--- a/files/zh-cn/web/html/element/audio/index.md
+++ b/files/zh-cn/web/html/element/audio/index.md
@@ -119,7 +119,7 @@ slug: Web/HTML/Element/audio
 
 ### 检测音轨添加和移除
 
-你能够通过 {{event("addtrack")}} and {{event("removetrack")}} 事件来检测何时音轨从 `<audio>` 元素中添加和移除了。然而，这些事件并不是直接传递给 `<audio>` 元素自己的。相反，它们是发送给 `<audio>` 元素的{{domxref("HTMLMediaElement")}} 中的音轨列表对象的。这些对象与添加进元素的音轨类型一一对应。
+你能够通过 {{domxref("AudioTrackList/addtrack_event", "addtrack")}} 和 {{domxref("AudioTrackList/removetrack_event", "removetrack")}} 事件来检测何时音轨从 `<audio>` 元素中添加和移除了。然而，这些事件并不是直接传递给 `<audio>` 元素自己的。相反，它们是发送给 `<audio>` 元素的{{domxref("HTMLMediaElement")}} 中的音轨列表对象的。这些对象与添加进元素的音轨类型一一对应。
 
 - {{domxref("HTMLMediaElement.audioTracks")}}
   - : 一个 {{domxref("AudioTrackList")}} 包含所有的媒体对象的音轨。你能在为 `addtrack` 事件添加监听，以在新音轨添加进元素时获得通知。
@@ -146,7 +146,7 @@ elem.audioTrackList.onremovetrack = function(event) {
 
 这份代码监听音轨从目标元素中添加删除的事件，并且调用了一个轨道编辑器上的虚拟函数，来从编辑器上的可用音轨列表中注册和移除音轨。
 
-你也可以使用 {{domxref("EventTarget.addEventListener", "addEventListener()")}} 来监听 {{event("addtrack")}} 和 {{event("removetrack")}} 事件。
+你也可以使用 {{domxref("EventTarget.addEventListener", "addEventListener()")}} 来监听 {{domxref("AudioTrackList/addtrack_event", "addtrack")}} 和 {{domxref("AudioTrackList/removetrack_event", "removetrack")}} 事件。
 
 ## 示例
 

--- a/files/zh-cn/web/html/element/input/search/index.md
+++ b/files/zh-cn/web/html/element/input/search/index.md
@@ -96,7 +96,7 @@ searchTerms = mySearch.value;
 | 属性                              | 描述                                                                                                                                                              |
 | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`autocorrect`](#autocorrect)     | 编辑此输入字段时是否允许自动更正。**Safari only.**                                                                                                                |
-| [`incremental`](#incremental)     | 是否发送重复的 {{event("search")}} 事件以允许在用户仍在编辑字段的值时更新实时搜索结果。**WebKit and Blink only (Safari, Chrome, Opera, etc.).**              |
+| [`incremental`](#incremental)     | 是否发送重复的 {{domxref("HTMLInputElement/search_event", "search")}} 事件以允许在用户仍在编辑字段的值时更新实时搜索结果。**WebKit and Blink only (Safari, Chrome, Opera, etc.).**              |
 | [`mozactionhint`](#mozactionhint) | 一个字符串，指示当用户在编辑字段时按 <kbd>Enter</kbd> 或 <kbd>Return</kbd> 键时将执行的操作类型；用于确定虚拟键盘上该键的适当标签。**Firefox for Android only.** |
 | [`results`](#results)             | 先前搜索查询的下拉列表中应显示的最大项目数。**Safari only.**                                                                                                      |
 
@@ -106,9 +106,9 @@ searchTerms = mySearch.value;
 
 ### incremental
 
-布尔值 `incremental` 属性是 WebKit 和 Blink 扩展（因此被 Safari, Opera, Chrome 等支持）如果存在，它会告诉 {{Glossary("user agent")}} 将输入作为实时搜索进行处理。当用户编辑字段的值时，用户代理将 `{{event("search")}}` 事件发送到代表搜索框的 `{{domxref("HTMLInputElement")}}` 对象。这允许您的代码在用户编辑搜索时实时更新搜索结果。
+布尔值 `incremental` 属性是 WebKit 和 Blink 扩展（因此被 Safari, Opera, Chrome 等支持）如果存在，它会告诉 {{Glossary("user agent")}} 将输入作为实时搜索进行处理。当用户编辑字段的值时，用户代理将 {{domxref("HTMLInputElement/search_event", "search")}} 事件发送到代表搜索框的 `{{domxref("HTMLInputElement")}}` 对象。这允许您的代码在用户编辑搜索时实时更新搜索结果。
 
-如果 `incremental` 没有被指定，则仅当用户显式启动搜索时（例如，在编辑字段时按 <kbd>Enter</kbd> 或 <kbd>Return</kbd> ）才发送 `{{event("search")}}` 事件。
+如果 `incremental` 没有被指定，则仅当用户显式启动搜索时（例如，在编辑字段时按 <kbd>Enter</kbd> 或 <kbd>Return</kbd> ）才发送 {{domxref("HTMLInputElement/search_event", "search")}} 事件。
 
 `search` 事件受速率限制，因此发送事件的频率不会超过实现定义的间隔。
 

--- a/files/zh-cn/web/progressive_web_apps/re-engageable_notifications_push/index.md
+++ b/files/zh-cn/web/progressive_web_apps/re-engageable_notifications_push/index.md
@@ -77,7 +77,7 @@ registration.pushManager.getSubscription() .then( /* ... */ );
 
 从服务端的角度来看，出于安全的目的，这整个过程必须使用非对称加密技术进行保护：允许任何人用你的应用发送未加密的消息就大有问题了。你可以通过阅读[Web 推送数据加密测试页](https://jrconlin.github.io/WebPushDataTestPage/)里面的详细信息来保护你的服务器。当用户订阅服务时，服务器会储存所有接收到的信息，以便在后续需要的时候能将信息推送出去。
 
-为了能够接收到推送的消息，我们需要在 Service Worker 文件里面监听 {{event("push")}} 事件：
+为了能够接收到推送的消息，我们需要在 Service Worker 文件里面监听 {{domxref("ServiceWorkerGlobalScope.push_event", "push")}} 事件：
 
 ```js
 self.addEventListener('push', function(e) { /* ... */ });
@@ -256,7 +256,7 @@ self.addEventListener('push', function(event) {
 });
 ```
 
-它做的就只是监听 {{event("push")}} 事件，创建 payload 变量，这个变量包含了来自 event.data 的文本（如果 data 是空的，就设置成 "no payload" 字符串），然后一直等到通知推送给用户为止。
+它做的就只是监听 {{domxref("ServiceWorkerGlobalScope.push_event", "push")}} 事件，创建 payload 变量，这个变量包含了来自 event.data 的文本（如果 data 是空的，就设置成 "no payload" 字符串），然后一直等到通知推送给用户为止。
 
 如果你想知道它们具体是怎么处理的，请随意探索 [Service Worker Cookbook](https://github.com/mdn/serviceworker-cookbook/) 里面剩下的例子。[GitHub 上面提供了完整的源代码](https://github.com/mozilla/serviceworker-cookbook/)，也有大量的示例展示了各种用法，包括 Web 推送、缓存策略、性能、离线运行等等。
 


### PR DESCRIPTION
### Description

remove event macro from zh-CN (Part 5). It's the final part of {{event}} macro removal for l10n-zh.

### Related issues and pull requests

continue #9791
