### PR TITLE
Remove deprecated Interwiki macro from es 1/2

### DIFF
--- a/files/es/glossary/accessibility/index.md
+++ b/files/es/glossary/accessibility/index.md
@@ -15,7 +15,7 @@ _La accesibilidad web_ (**A11Y**) hace referencia a las buenas prácticas para m
 ### Conocimiento general
 
 - [Accessibility resources at MDN](/en-US/docs/Web/Accessibility)
-- {{Interwiki("wikipedia", "Web accessibility")}} on Wikipedia
+- [Web accessibility](https://es.wikipedia.org/wiki/Web_accessibility) on Wikipedia
 
 ### Aprende accesibilidad web
 

--- a/files/es/glossary/ajax/index.md
+++ b/files/es/glossary/ajax/index.md
@@ -19,7 +19,7 @@ Con los sitios web interactivos y los estándares web modernos, AJAX está siend
 
 ### Conocimiento general
 
-- {{interwiki("wikipedia", "AJAX")}} en Wikipedia
+- [AJAX](https://es.wikipedia.org/wiki/AJAX) en Wikipedia
 - [Comunicación sincrona vs asincrona](http://peoplesofttutorial.com/difference-between-synchronous-and-asynchronous-messaging/)
 
 ### Información técnica

--- a/files/es/glossary/apple_safari/index.md
+++ b/files/es/glossary/apple_safari/index.md
@@ -16,7 +16,7 @@ translation_of: Glossary/Apple_Safari
 
 ### Conocimiento general
 
-- {{Interwiki("wikipedia", "Safari (web browser)", "Safari")}} en Wikipedia
+- [Safari](https://es.wikipedia.org/wiki/Safari_(web_browser)) en Wikipedia
 - [Safari en apple.com](http://www.apple.com/safari/)
 
 ### Información técnica

--- a/files/es/glossary/argument/index.md
+++ b/files/es/glossary/argument/index.md
@@ -11,7 +11,7 @@ Un argumento es un valor (primitivo u objeto) (Véase {{glossary("value")}}, {{G
 
 ### Conocimiento general
 
-- {{Interwiki("wikipedia", "Parameter_(computer_programming)", "Difference between Parameter and Argument")}} on Wikipedia
+- [Difference between Parameter and Argument](https://es.wikipedia.org/wiki/Parameter_(computer_programming)) on Wikipedia
 
 ### Referencia técnica
 

--- a/files/es/glossary/arpa/index.md
+++ b/files/es/glossary/arpa/index.md
@@ -13,4 +13,4 @@ translation_of: Glossary/ARPA
 ### General knowledge
 
 - [Official website](http://www.iana.org/domains/arpa)
-- {{Interwiki("wikipedia", ".arpa")}} on Wikipedia
+- [.arpa](https://es.wikipedia.org/wiki/.arpa) on Wikipedia

--- a/files/es/glossary/arpanet/index.md
+++ b/files/es/glossary/arpanet/index.md
@@ -10,4 +10,4 @@ La **ARPAnet** (advanced research projects agency network) o Red de Angencias de
 
 ### Conocimiento general
 
-- {{Interwiki("wikipedia", "Arpanet")}} on Wikipedia
+- [Arpanet](https://es.wikipedia.org/wiki/Arpanet) on Wikipedia

--- a/files/es/glossary/array/index.md
+++ b/files/es/glossary/array/index.md
@@ -32,7 +32,7 @@ var catNamesArray = ["Jacqueline", "Sophia", "Autumn"];
 
 ### Conocimiento general
 
-- {{Interwiki("wikipedia", "Array data structure", "Array")}} en Wikipedia
+- [Array](https://es.wikipedia.org/wiki/Array_data_structure) en Wikipedia
 
 ### Referencia técnica
 

--- a/files/es/glossary/ascii/index.md
+++ b/files/es/glossary/ascii/index.md
@@ -13,4 +13,4 @@ translation_of: Glossary/ASCII
 
 ### Conocimientos generales
 
-{{Interwiki("wikipedia", "ASCII")}} en Wikipedia
+[ASCII](https://es.wikipedia.org/wiki/ASCII) en Wikipedia

--- a/files/es/glossary/bandwidth/index.md
+++ b/files/es/glossary/bandwidth/index.md
@@ -8,4 +8,4 @@ El ancho de banda es la medida de cuanta información puede pasar a través de u
 
 ## Saber más
 
-- {{Interwiki("wikipedia", "Bandwidth")}} on Wikipedia
+- [Bandwidth](https://es.wikipedia.org/wiki/Bandwidth) on Wikipedia

--- a/files/es/glossary/bigint/index.md
+++ b/files/es/glossary/bigint/index.md
@@ -10,7 +10,7 @@ En {{Glossary("JavaScript")}}, **BigInt** es un tipo de dato numerico que puede 
 
 ### Conocimientos generales
 
-- {{Interwiki("wikipedia", "Data type#Numeric_types", "Tipos numéricos")}} en Wikipedia
+- [Tipos numéricos](https://es.wikipedia.org/wiki/Data_type#Numeric_types) en Wikipedia
 
 ### Referencia tecnica
 

--- a/files/es/glossary/blink/index.md
+++ b/files/es/glossary/blink/index.md
@@ -20,5 +20,5 @@ Blink es un motor de renderizado para [navegadores](/es/docs/Glossary/Browser) d
 ### Cultura General
 
 - Página principal de [Blink](http://www.chromium.org/blink)
-- {{interwiki("wikipedia", "Blink")}} en Wikipedia
+- [Blink](https://es.wikipedia.org/wiki/Blink) en Wikipedia
 - [FAQ](http://www.chromium.org/blink/developer-faq) de Blink

--- a/files/es/glossary/browser/index.md
+++ b/files/es/glossary/browser/index.md
@@ -18,7 +18,7 @@ Un _Navegador web_ es un programa o aplicación que da acceso a la [Web](/es/doc
 
 ### Cultura general
 
-- {{interwiki("wikipedia", "Navegador_web")}} en Wikipedia
+- [Navegador_web](https://es.wikipedia.org/wiki/Navegador_web) en Wikipedia
 - [La evolución de la web](http://www.evolutionoftheweb.com/)
 
 ### Descargar un navegador

--- a/files/es/glossary/card_sorting/index.md
+++ b/files/es/glossary/card_sorting/index.md
@@ -15,4 +15,4 @@ La clasificación por tarjetas (card sorting) es una técnica simple utilizada e
 
 ### Conocimientos generales
 
-- {{interwiki("wikipedia", "Card_sorting", "Card sorting")}} en Wikipedia
+- [Card sorting](https://es.wikipedia.org/wiki/Card_sorting) en Wikipedia

--- a/files/es/glossary/character/index.md
+++ b/files/es/glossary/character/index.md
@@ -15,8 +15,8 @@ Un _caracter_ es un símbolo (letras, números, puntuación) o un caracter de "c
 
 ### Conocimientos generales
 
-- {{interwiki("wikipedia", "Character (informática)")}} en Wikipedia
-- {{interwiki("wikipedia", "Character encoding")}} en Wikipedia
-- {{interwiki("wikipedia", "ASCII")}} en Wikipedia
-- {{interwiki("wikipedia", "UTF-8")}} en Wikipedia
-- {{interwiki("wikipedia", "Unicode")}} en Wikipedia
+- [Character (informática)](https://es.wikipedia.org/wiki/Character_(informática)) en Wikipedia
+- [Character encoding](https://es.wikipedia.org/wiki/Character_encoding) en Wikipedia
+- [ASCII](https://es.wikipedia.org/wiki/ASCII) en Wikipedia
+- [UTF-8](https://es.wikipedia.org/wiki/UTF-8) en Wikipedia
+- [Unicode](https://es.wikipedia.org/wiki/Unicode) en Wikipedia

--- a/files/es/glossary/character_encoding/index.md
+++ b/files/es/glossary/character_encoding/index.md
@@ -24,4 +24,4 @@ Con esto te aseguras de que usando caracteres propios de cualquier lenguaje huma
 ### Conocimientos generales
 
 - [Character encoding on W3C](https://www.w3.org/International/articles/definitions-characters/)
-- {{Interwiki("wikipedia", "Codificación_de_caracteres", "Codificación de caracteres")}} en Wikipedia
+- [Codificación de caracteres](https://es.wikipedia.org/wiki/Codificación_de_caracteres) en Wikipedia

--- a/files/es/glossary/character_set/index.md
+++ b/files/es/glossary/character_set/index.md
@@ -13,14 +13,14 @@ Un **conjunto de caracteres** es un sistema de codificación para que las comput
 
 En épocas anteriores, los países desarrollaron sus propios conjuntos de caracteres debido a los diferentes idiomas utilizados, como los códigos Kanji JIS (por ejemplo, Shift-JIS, EUC-JP, etc.) para japonés, Big5 para chino tradicional y KOI8-R para ruso. Sin embargo, {{Glossary("Unicode")}} se convirtió gradualmente en el conjunto de caracteres más aceptable por su soporte de idiomas universal.
 
-Si un conjunto de caracteres se usa incorrectamente (por ejemplo, Unicode para un artículo codificado en Big5), es posible que no vean más que caracteres rotos, que se llaman {{Interwiki("wikipedia", "Mojibake")}}.
+Si un conjunto de caracteres se usa incorrectamente (por ejemplo, Unicode para un artículo codificado en Big5), es posible que no vean más que caracteres rotos, que se llaman [Mojibake](https://es.wikipedia.org/wiki/Mojibake).
 
 <section id="Quick_links">
   <ol>
     <li>Artículos de Wikipedia
      <ol>
-      <li>{{Interwiki("wikipedia", "Codificación_de_caracteres", "Codificación de caracteres")}}</li>
-      <li>{{Interwiki("wikipedia", "Mojibake")}}</li>
+      <li>[Codificación de caracteres](https://es.wikipedia.org/wiki/Codificación_de_caracteres)</li>
+      <li>[Mojibake](https://es.wikipedia.org/wiki/Mojibake)</li>
      </ol>
     </li>
     <li><a href="/es/docs/Glossary">Glosario</a>

--- a/files/es/glossary/cia/index.md
+++ b/files/es/glossary/cia/index.md
@@ -14,4 +14,4 @@ CID (Confidencialidad, Integridad, Disponibilidad) (también llamado la triada C
 
 ### Conocimiento general
 
-- {{Interwiki("wikipedia", "Seguridad_de_la_información#Concepción_de_la_seguridad_de_la_información", "CIA")}} en Wikipedia
+- [CIA](https://es.wikipedia.org/wiki/Seguridad_de_la_información#Concepción_de_la_seguridad_de_la_información) en Wikipedia

--- a/files/es/glossary/ciphertext/index.md
+++ b/files/es/glossary/ciphertext/index.md
@@ -16,4 +16,4 @@ En {{glossary("Cryptography", "Criptografía")}}, un texto cifrado es un mensaje
 
 ### Conocimiento general
 
-- {{Interwiki("wikipedia", "Ciphertext")}} on Wikipedia
+- [Ciphertext](https://es.wikipedia.org/wiki/Ciphertext) on Wikipedia

--- a/files/es/glossary/closure/index.md
+++ b/files/es/glossary/closure/index.md
@@ -13,7 +13,7 @@ Una clausura o _closure_ es una función que guarda referencias del estado adyac
 
 ### Conocimiento general
 
-- {{Interwiki("wikipedia", "Clausura (informática)", "Clausura")}} en Wikipedia
+- [Clausura](https://es.wikipedia.org/wiki/Clausura_(informática)) en Wikipedia
 
 ### Referencia técnica
 

--- a/files/es/glossary/cms/index.md
+++ b/files/es/glossary/cms/index.md
@@ -15,4 +15,4 @@ Un sistema de gestión de contenidos o CMS es un programa informático que permi
 
 ### Conocimiento general
 
-- {{Interwiki("wikipedia", "Sistema de gestión de contenidos")}} en Wikipedia
+- [Sistema de gestión de contenidos](https://es.wikipedia.org/wiki/Sistema_de_gestión_de_contenidos) en Wikipedia

--- a/files/es/glossary/codec/index.md
+++ b/files/es/glossary/codec/index.md
@@ -13,7 +13,7 @@ Un _códec_ (acrónimo de "***co***dificador-***dec***odificador") es un program
 
 ### Conocimiento general
 
-- {{Interwiki("wikipedia", "Códec")}} en Wikipedia
+- [Códec](https://es.wikipedia.org/wiki/Códec) en Wikipedia
 
 ### Referencias técnicas
 

--- a/files/es/glossary/compile/index.md
+++ b/files/es/glossary/compile/index.md
@@ -21,7 +21,7 @@ Los compiladores JIT suelen ser transparentes para el programador. Por ejemplo e
 
 ### Conocimientos generales
 
-- {{Interwiki("wikipedia", "Compiler")}} on Wikipedia
+- [Compiler](https://es.wikipedia.org/wiki/Compiler) on Wikipedia
 - The [GNU Compiler Collection (GCC)](https://gcc.gnu.org)
 
 ### Véase también

--- a/files/es/glossary/compile_time/index.md
+++ b/files/es/glossary/compile_time/index.md
@@ -10,5 +10,5 @@ El _tiempo de compilación_ es el tiempo desde que el programa es cargado por pr
 
 ### Conocimiento general
 
-- {{Interwiki("wikipedia", "Compile time")}} en Wikipedia (inglés)
+- [Compile time](https://es.wikipedia.org/wiki/Compile_time) en Wikipedia (inglés)
 - [Tiempo de compilación](https://es.wikipedia.org/wiki/Tiempo_de_compilaci%C3%B3n) en Wikipedia

--- a/files/es/glossary/constant/index.md
+++ b/files/es/glossary/constant/index.md
@@ -17,4 +17,4 @@ Al igual que las variables, algunas constantes están unidas a identificadores. 
 
 ### Conocimientos generales
 
-- {{Interwiki("wikipedia", "Constante_(informática)", "Constante")}} en Wikipedia
+- [Constante](https://es.wikipedia.org/wiki/Constante_(informática)) en Wikipedia

--- a/files/es/glossary/constructor/index.md
+++ b/files/es/glossary/constructor/index.md
@@ -36,7 +36,7 @@ var defaultReference = new Default();
 
 ### Conocimiento general
 
-- {{Interwiki("wikipedia", "Constructor_%28object-oriented_programming%29", "Constructor")}} en Wikipedia
+- [Constructor](https://es.wikipedia.org/wiki/Constructor_%28object-oriented_programming%29) en Wikipedia
 
 ### Referencia técnica
 

--- a/files/es/glossary/copyleft/index.md
+++ b/files/es/glossary/copyleft/index.md
@@ -17,4 +17,4 @@ _Copyleft_ es un término, que normalmente se refiere a una licencia, y que se u
 
 ### Cultura General
 
-- {{Interwiki("wikipedia", "Copyleft")}} en Wikipedia
+- [Copyleft](https://es.wikipedia.org/wiki/Copyleft) en Wikipedia

--- a/files/es/glossary/crud/index.md
+++ b/files/es/glossary/crud/index.md
@@ -13,4 +13,4 @@ translation_of: Glossary/CRUD
 
 ### Conocimiento general
 
-- {{Interwiki("wikipedia", "CRUD")}} en Wikipedia
+- [CRUD](https://es.wikipedia.org/wiki/CRUD) en Wikipedia

--- a/files/es/glossary/cryptography/index.md
+++ b/files/es/glossary/cryptography/index.md
@@ -16,6 +16,6 @@ Criptografía, o criptología, es la ciencia que estudia como codificar y transm
 
 ### Conocimiento general
 
-- {{Interwiki("wikipedia", "Criptografía")}} en Wikipedia
+- [Criptografía](https://es.wikipedia.org/wiki/Criptografía) en Wikipedia
 - {{glossary("Cryptanalysis")}}
 - [Tutorial de seguridad de la información](/en-US/docs/Web/Security/Information_Security_Basics)

--- a/files/es/glossary/css/index.md
+++ b/files/es/glossary/css/index.md
@@ -35,7 +35,7 @@ El término "en cascada" se refiere a las reglas que determinan cómo los select
 ### Conocimiento general
 
 - [Aprende CSS](/es/Learn/CSS)
-- {{interwiki("wikipedia", "CSS")}} en Wikipedia
+- [CSS](https://es.wikipedia.org/wiki/CSS) en Wikipedia
 
 ### Referencia Técnica
 

--- a/files/es/glossary/data_structure/index.md
+++ b/files/es/glossary/data_structure/index.md
@@ -15,4 +15,4 @@ original_slug: Glossary/Estructura_de_datos
 
 ### Conocimiento general
 
-- {{interwiki("wikipedia", "Estructura_de_datos", "Estructura de datos")}} en Wikipedia
+- [Estructura de datos](https://es.wikipedia.org/wiki/Estructura_de_datos) en Wikipedia

--- a/files/es/glossary/doctype/index.md
+++ b/files/es/glossary/doctype/index.md
@@ -10,7 +10,7 @@ translation_of: Glossary/Doctype
 
 ### General Knowledge
 
-- {{interwiki("wikipedia", "Document_type_declaration", "Document Type Declaration")}} on Wikipedia
+- [Document Type Declaration](https://es.wikipedia.org/wiki/Document_type_declaration) on Wikipedia
 - [Quirks Mode and Standards Mode](/en-US/docs/Quirks_Mode_and_Standards_Mode)
 
 ### Technical reference

--- a/files/es/glossary/dom/index.md
+++ b/files/es/glossary/dom/index.md
@@ -19,7 +19,7 @@ El DOM surgió a partir de la implementación de [JavaScript](/es/docs/Glossary/
 
 ### Cultura General
 
-- {{Interwiki("wikipedia","DOM")}} en Wikipedia
+- [DOM](https://es.wikipedia.org/wiki/DOM) en Wikipedia
 
 ### Información Técnica
 

--- a/files/es/glossary/domain/index.md
+++ b/files/es/glossary/domain/index.md
@@ -16,10 +16,10 @@ Un nombre de dominio completo (FQDN, por sus siglas en inglés) contiene todas l
 
 For example, in "developer.mozilla.org":
 
-1. "org" es llamado un {{interwiki("wikipedia", "Dominio_de_nivel_superior", "dominio de nivel superior")}}. Están registrados como estándar de Internet por la entidad {{interwiki("wikipedia", "Internet_Assigned_Numbers_Authority", "IANA")}} . Aquí, "org" significa "organización" que se define en un _registro de dominio_ de nivel superior.
-2. "mozilla" es el dominio. Si quieres tener un dominio, debes registrarlo con uno de los muchos {{interwiki("wikipedia", "Registrador_de_dominios", "registradores")}} que tienen permiso para hacerlo con un registro de dominios de nivel superior.
+1. "org" es llamado un [dominio de nivel superior](https://es.wikipedia.org/wiki/Dominio_de_nivel_superior). Están registrados como estándar de Internet por la entidad [IANA](https://es.wikipedia.org/wiki/Internet_Assigned_Numbers_Authority) . Aquí, "org" significa "organización" que se define en un _registro de dominio_ de nivel superior.
+2. "mozilla" es el dominio. Si quieres tener un dominio, debes registrarlo con uno de los muchos [registradores](https://es.wikipedia.org/wiki/Registrador_de_dominios) que tienen permiso para hacerlo con un registro de dominios de nivel superior.
 3. "developer" es un "subdominio", algo que usted mismo como propietario de un dominio puede definir usted mismo. Muchos propietarios eligen tener un subdominio "www" para que apunte a su recurso {{Glossary("World_Wide_Web")}}, pero eso no es necesario (e incluso ha caído en desgracia).
 
 ## Saber más
 
-- {{interwiki("wikipedia", "Dominio_de_Internet", "Dominio de internet")}} en Wikipedia
+- [Dominio de internet](https://es.wikipedia.org/wiki/Dominio_de_Internet) en Wikipedia

--- a/files/es/glossary/domain_name/index.md
+++ b/files/es/glossary/domain_name/index.md
@@ -11,5 +11,5 @@ Un nombre de dominio es la dirección de un sitio web en {{Glossary("Internet")}
 
 ### Conocimientos generales
 
-- {{interwiki("wikipedia", "Dominio_de_Internet", "Dominio de Internet")}} en Wikipedia
+- [Dominio de Internet](https://es.wikipedia.org/wiki/Dominio_de_Internet) en Wikipedia
 - [Entendiendo los nombres de los dominios](/en-US/Learn/Understanding_domain_names)

--- a/files/es/glossary/dynamic_typing/index.md
+++ b/files/es/glossary/dynamic_typing/index.md
@@ -19,4 +19,4 @@ original_slug: Glossary/Tipado_dinámico
 
 ### Conocimientos generales
 
-- {{interwiki("wikipedia", "Sistema_de_tipos", "Sistema de tipos")}} en Wikipedia
+- [Sistema de tipos](https://es.wikipedia.org/wiki/Sistema_de_tipos) en Wikipedia

--- a/files/es/glossary/ecmascript/index.md
+++ b/files/es/glossary/ecmascript/index.md
@@ -13,7 +13,7 @@ translation_of: Glossary/ECMAScript
 
 ### Conocimientos generales
 
-- {{Interwiki("wikipedia", "ECMAScript")}} en Wikipedia
+- [ECMAScript](https://es.wikipedia.org/wiki/ECMAScript) en Wikipedia
 
 ### Referencia técnica
 

--- a/files/es/glossary/event/index.md
+++ b/files/es/glossary/event/index.md
@@ -18,4 +18,4 @@ Los eventos son sucesos generados por elementos del [DOM](/en-US/docs/Glossary/D
 ### Conocimientos generales
 
 - [Web oficial](https://www.w3.org/TR/DOM-Level-2-Events/events.html)
-- {{Interwiki("wikipedia", "DOM Events")}} en Wikipedia
+- [DOM Events](https://es.wikipedia.org/wiki/DOM_Events) en Wikipedia

--- a/files/es/glossary/first-class_function/index.md
+++ b/files/es/glossary/first-class_function/index.md
@@ -95,7 +95,7 @@ Usamos paréntesis doble `()()` para invocar también a la función retornada.
 
 <section id="Quick_links">
  <ol>
-  <li>{{Interwiki("wikipedia", "First-class_function", "First-class functions")}} on Wikipedia</li>
+  <li>[First-class functions](https://es.wikipedia.org/wiki/First-class_function) on Wikipedia</li>
   <li><a href="/en-US/docs/Glossary">MDN Web Docs Glossary</a>
    <ul>
     <li>{{glossary("Callback function")}}</li>

--- a/files/es/glossary/gif/index.md
+++ b/files/es/glossary/gif/index.md
@@ -15,4 +15,4 @@ translation_of: Glossary/gif
 
 ### Conocimientos generales
 
-- {{Interwiki("wikipedia","GIF")}} en Wikipedia
+- [GIF](https://es.wikipedia.org/wiki/GIF) en Wikipedia

--- a/files/es/glossary/google_chrome/index.md
+++ b/files/es/glossary/google_chrome/index.md
@@ -20,7 +20,7 @@ _Google Chrome_ es un [navegador](/es/docs/Glossary/Browser) web gratuito desarr
 
 ### Cultura general
 
-- {{Interwiki("wikipedia", "WebKit")}} en Wikipedia
+- [WebKit](https://es.wikipedia.org/wiki/WebKit) en Wikipedia
 
 ### Para usuarios de Chrome
 

--- a/files/es/glossary/gpl/index.md
+++ b/files/es/glossary/gpl/index.md
@@ -19,7 +19,7 @@ La lincencia GNU _GPL_ (GNU General Public License en español **Licencia Públi
 
 ### Cultura General
 
-- {{Interwiki("wikipedia","GNU_General_Public_License")}} en Wikipedia
+- [GNU_General_Public_License](https://es.wikipedia.org/wiki/GNU_General_Public_License) en Wikipedia
 
 ### Referencia Técnica
 

--- a/files/es/glossary/host/index.md
+++ b/files/es/glossary/host/index.md
@@ -14,4 +14,4 @@ El anfitrión no es necesariamente un elemento hardware. Pueden ser generado com
 
 ### Conocimiento general
 
-- {{interwiki("wikipedia", "Host")}} en la Wikipedia
+- [Host](https://es.wikipedia.org/wiki/Host) en la Wikipedia

--- a/files/es/glossary/http/index.md
+++ b/files/es/glossary/http/index.md
@@ -19,4 +19,4 @@ También se puede utilizar como base para los servicios web {{glossary("REST")}}
 ## Learn more
 
 - [HTTP en MDN](/es/docs/Web/HTTP)
-- {{interwiki("wikipedia", "Hypertext Transfer Protocol", "HTTP")}} on Wikipedia
+- [HTTP](https://es.wikipedia.org/wiki/Hypertext_Transfer_Protocol) on Wikipedia

--- a/files/es/glossary/hyperlink/index.md
+++ b/files/es/glossary/hyperlink/index.md
@@ -18,7 +18,7 @@ Los _Hipervínculos_ ó _enlaces_ permiten conectar entre sí datos ó páginas 
 
 ### Cultura General
 
-- {{interwiki("wikipedia", "Hiperenlace")}} en Wikipedia
+- [Hiperenlace](https://es.wikipedia.org/wiki/Hiperenlace) en Wikipedia
 - [Guía de Hipervínculos](/es/docs/Learn/HTML/Introduccion_a_HTML/Creating_hyperlinks) en MDN
 
 ### Referencias técnicas

--- a/files/es/glossary/hypertext/index.md
+++ b/files/es/glossary/hypertext/index.md
@@ -14,7 +14,7 @@ El término fue acuñado por Ted Nelson alrededor del año 1965.
 
 ### Conocimiento general
 
-- {{interwiki("wikipedia", "Hipertexto", "Hipertexto")}} en Wikipedia
+- [Hipertexto](https://es.wikipedia.org/wiki/Hipertexto) en Wikipedia
 
 ### Referencia Técnica
 

--- a/files/es/glossary/identifier/index.md
+++ b/files/es/glossary/identifier/index.md
@@ -21,7 +21,7 @@ Un identificador se diferencia de una cadena en que una {{Glossary("String", "ca
 
 ### Conocimientos generales
 
-- {{interwiki("wikipedia", "Identificador#Identificadores_en_lenguajes_informáticos", "Identificador")}} en Wikipedia
+- [Identificador](https://es.wikipedia.org/wiki/Identificador#Identificadores_en_lenguajes_informáticos) en Wikipedia
 
 <section id="Quick_links">
  <ol>
@@ -33,6 +33,6 @@ Un identificador se diferencia de una cadena en que una {{Glossary("String", "ca
     <li>{{Glossary("Unicode")}}</li>
    </ol>
   </li>
-  <li>{{interwiki("wikipedia", "Identificador#Identificadores_en_lenguajes_informáticos", "Identificador")}} en Wikipedia</li>
+  <li>[Identificador](https://es.wikipedia.org/wiki/Identificador#Identificadores_en_lenguajes_informáticos) en Wikipedia</li>
  </ol>
 </section>

--- a/files/es/glossary/iife/index.md
+++ b/files/es/glossary/iife/index.md
@@ -50,4 +50,4 @@ result; // "Barry"
 
 ### General knowledge
 
-- {{interwiki("wikipedia", "Immediately-invoked function expression", "IIFE")}} on Wikipedia
+- [IIFE](https://es.wikipedia.org/wiki/Immediately-invoked_function_expression) on Wikipedia

--- a/files/es/glossary/immutable/index.md
+++ b/files/es/glossary/immutable/index.md
@@ -18,4 +18,4 @@ Un {{glossary("object", "objeto")}} inmutable es aquel cuyo contenido no se pued
 
 ### Conocimientos generales
 
-- {{interwiki("wikipedia", "Objeto_inmutable", "Objeto Inmutable")}} en Wikipedia
+- [Objeto Inmutable](https://es.wikipedia.org/wiki/Objeto_inmutable) en Wikipedia

--- a/files/es/glossary/information_architecture/index.md
+++ b/files/es/glossary/information_architecture/index.md
@@ -15,4 +15,4 @@ La arquitectura de la información, aplicada al diseño y desarrollo web, es la 
 
 ### Conocimientos generales
 
-- {{Interwiki("wikipedia", "Arquitectura_de_la_información", "Arquitectura de la información")}} en Wikipedia
+- [Arquitectura de la información](https://es.wikipedia.org/wiki/Arquitectura_de_la_información) en Wikipedia

--- a/files/es/glossary/java/index.md
+++ b/files/es/glossary/java/index.md
@@ -18,5 +18,5 @@ Los programas son {{glossary("Compile", "compilados")}} primero una única vez a
 
 ### Conocimientos generales
 
-- {{interwiki("wikipedia", "Java_(lenguaje_de_programación)", "Java")}} en Wikipedia
+- [Java](https://es.wikipedia.org/wiki/Java_(lenguaje_de_programación)) en Wikipedia
 - {{QuickLinksWithSubpages("/en-US/docs/Glossary")}}

--- a/files/es/glossary/javascript/index.md
+++ b/files/es/glossary/javascript/index.md
@@ -14,7 +14,7 @@ translation_of: Glossary/JavaScript
 
 JavaScript (o "JS") es un lenguaje de programación que se usa con mayor frecuencia para scripts dinámicos de lado del cliente en páginas web, pero también se usa a menudo en el lado del {{Glossary("Server", "servidor")}} — usando un entorno de ejecución como [Node.js](https://nodejs.org/).
 
-JavaScript **no se debe** confundir con el {{interwiki("wikipedia", "Java_(programming_language)", "lenguaje de programación Java")}}. Aunque _"Java"_ y _"JavaScript"_ son marcas comerciales (o marcas comerciales registradas) de Oracle en EE. UU. y otros países, los dos lenguajes de programación son significativamente diferentes en su sintaxis, semántica y casos de uso.
+JavaScript **no se debe** confundir con el [lenguaje de programación Java](https://es.wikipedia.org/wiki/Java_(programming_language)). Aunque _"Java"_ y _"JavaScript"_ son marcas comerciales (o marcas comerciales registradas) de Oracle en EE. UU. y otros países, los dos lenguajes de programación son significativamente diferentes en su sintaxis, semántica y casos de uso.
 
 JavaScript se utiliza principalmente en el navegador, lo que permite a los desarrolladores manipular el contenido de la página web a través del {{Glossary("DOM")}}, manipular datos con {{Glossary("AJAX")}} y {{Glossary("IndexedDB")}}, dibujar gráficos con {{Glossary("canvas")}}, interactuar con el dispositivo que ejecuta el navegador a través de varias {{Glossary("API", "APIs")}} y más. JavaScript es uno de los lenguajes más utilizados en el mundo, debido al reciente crecimiento y mejora en el rendimiento de las {{Glossary("API", "APIs")}} disponibles en los navegadores.
 
@@ -30,7 +30,7 @@ Recientemente, la popularidad de JavaScript se ha expandido aún más gracias a 
 
 ### Conocimientos generales
 
-- {{interwiki("wikipedia", "JavaScript", "JavaScript")}} en Wikipedia
+- [JavaScript](https://es.wikipedia.org/wiki/JavaScript) en Wikipedia
 
 ### Aprende JavaScript
 

--- a/files/es/glossary/jpeg/index.md
+++ b/files/es/glossary/jpeg/index.md
@@ -10,4 +10,4 @@ translation_of: Glossary/jpeg
 
 ### Conocimiento general
 
-- {{Interwiki("wikipedia", "JPEG")}} on Wikipedia
+- [JPEG](https://es.wikipedia.org/wiki/JPEG) on Wikipedia

--- a/files/es/glossary/keyword/index.md
+++ b/files/es/glossary/keyword/index.md
@@ -18,4 +18,4 @@ Cuando usas un motor de búsqueda, utilizas palabras clave para especificar lo q
 
 ### Conocimientos generales
 
-- {{interwiki("wikipedia", "Keyword_research", "Keyword")}} on Wikipedia
+- [Keyword](https://es.wikipedia.org/wiki/Keyword_research) on Wikipedia

--- a/files/es/glossary/lgpl/index.md
+++ b/files/es/glossary/lgpl/index.md
@@ -23,5 +23,5 @@ LGPL es usado habitualmente para licencias de componentes compartidos como por e
 
 ### Cultura General
 
-- {{interwiki("wikipedia", "GNU Lesser General Public License", "GNU LGPL")}} en Wikipedia
+- [GNU LGPL](https://es.wikipedia.org/wiki/GNU_Lesser_General_Public_License) en Wikipedia
 - [LGPL License](http://www.gnu.org/copyleft/lesser.html) en gnu.org

--- a/files/es/glossary/metadata/index.md
+++ b/files/es/glossary/metadata/index.md
@@ -15,7 +15,7 @@ Los **metadatos** son, en su definición más simple, datos que describen otros 
 
 ### Conocimientos generales
 
-- {{interwiki("wikipedia", "Metadatos", "Metadatos")}} en Wikipedia
+- [Metadatos](https://es.wikipedia.org/wiki/Metadatos) en Wikipedia
 
 ### HTML metadata
 

--- a/files/es/glossary/method/index.md
+++ b/files/es/glossary/method/index.md
@@ -16,7 +16,7 @@ Un **metodo** es una {{glossary("function", "función")}} la cual es {{glossary(
 
 ### Aprender acerca de esto
 
-- {{InterWiki("wikipedia","Método (informática)")}} en Wikipedia
+- [Método (informática)](https://es.wikipedia.org/wiki/Método_%28informática%29) en Wikipedia
 - [Definiendo un método en JavaScript](/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions) (comparacion de la sintaxis tradicionas y la nueva abreviación)
 
 ### Referencia Técnica

--- a/files/es/glossary/mvc/index.md
+++ b/files/es/glossary/mvc/index.md
@@ -48,4 +48,4 @@ Los frameworks de desarrollo web como AngularJS y Ember.js implementan una arqui
 
 ### General knowledge
 
-- {{interwiki("wikipedia", "Model–view–controller")}} on Wikipedia
+- [Model–view–controller](https://es.wikipedia.org/wiki/Model–view–controller) on Wikipedia

--- a/files/es/glossary/node.js/index.md
+++ b/files/es/glossary/node.js/index.md
@@ -15,7 +15,7 @@ Node.js es un entorno de ejecucion multiplataforma en {{Glossary("JavaScript")}}
 
 Conocimientos generales
 
-- {{Interwiki("wikipedia", "Node.js")}} en Wikipedia
+- [Node.js](https://es.wikipedia.org/wiki/Node.js) en Wikipedia
 - [Sitio web de](https://nodejs.org/) [Node.js](https://nodejs.org/)
 
 ### Información técnica

--- a/files/es/glossary/oop/index.md
+++ b/files/es/glossary/oop/index.md
@@ -17,5 +17,5 @@ translation_of: Glossary/OOP
 
 ### Conocimientos generales
 
-- {{Interwiki("wikipedia", "Programación_orientada_a_objetos", "Programaci'ón orientada a objetos")}} en Wikipedia
+- [Programaci'ón orientada a objetos](https://es.wikipedia.org/wiki/Programación_orientada_a_objetos) en Wikipedia
 - [Introducción a JavaScript prientado a objetos](/es/docs/Learn/JavaScript/Objects)

--- a/files/es/glossary/operand/index.md
+++ b/files/es/glossary/operand/index.md
@@ -12,4 +12,4 @@ original_slug: Glossary/Operando
 
 ## Aprende mas
 
-- {{Interwiki("wikipedia", "Operador")}} en Wikipedia
+- [Operador](https://es.wikipedia.org/wiki/Operador) en Wikipedia

--- a/files/es/glossary/php/index.md
+++ b/files/es/glossary/php/index.md
@@ -50,7 +50,7 @@ PHP (una inicialización recursiva para PHP: preprocesador de hipertexto) es un 
 <section id="Quick_links">
  <ol>
   <li><a href="http://php.net/">Official website</a></li>
-  <li>{{Interwiki("wikipedia", "PHP")}} en Wikipedia</li>
+  <li>[PHP](https://es.wikipedia.org/wiki/PHP) en Wikipedia</li>
   <li><a href="https://en.wikibooks.org/wiki/PHP_Programming">PHP</a> en Wikibooks</li>
   <li><a href="/es/docs/Glossary">MDN Web Docs Glossary</a>
    <ol>

--- a/files/es/glossary/primitive/index.md
+++ b/files/es/glossary/primitive/index.md
@@ -100,7 +100,7 @@ El método {{JSxRef("Objetos_globales/Object/valueOf"," valueOf()")}} del conten
 ### Conocimientos generales
 
 - {{JSxRef("Data_structures", "Introducción a los tipos de datos de JavaScript")}}
-- {{Interwiki("wikipedia", "Tipo de dato primitivo")}} en Wikipedia
+- [Tipo de dato primitivo](https://es.wikipedia.org/wiki/Tipo_de_dato_primitivo) en Wikipedia
 
 <section id="Quick_links">
  <ol>

--- a/files/es/glossary/progressive_enhancement/index.md
+++ b/files/es/glossary/progressive_enhancement/index.md
@@ -20,4 +20,4 @@ Es una técnica útil que permite a los desarrolladores web centrarse en desarro
 
 ### Conocimientos generales
 
-- {{Interwiki("wikipedia", "Mejora progresiva")}} en Wikipedia
+- [Mejora progresiva](https://es.wikipedia.org/wiki/Mejora_progresiva) en Wikipedia

--- a/files/es/glossary/promise/index.md
+++ b/files/es/glossary/promise/index.md
@@ -19,7 +19,7 @@ Para obtener más información, echa un vistazo a los siguientes enlaces
 
 ### Conocimientos generales
 
-- {{interwiki("wikipedia", "Valor_futuro_(informática)", "Valor futuro")}}
+- [Valor futuro](https://es.wikipedia.org/wiki/Valor_futuro_(informática))
 
 ### Referencias técnicas
 

--- a/files/es/glossary/protocol/index.md
+++ b/files/es/glossary/protocol/index.md
@@ -13,7 +13,7 @@ Un **protocolo** es un conjunto de reglas que definen cómo se intercambian los 
 
 ### Conocimiento general
 
-- {{Interwiki("wikipedia", "Protocolo de comunicaciones")}} en Wikipedia
+- [Protocolo de comunicaciones](https://es.wikipedia.org/wiki/Protocolo_de_comunicaciones) en Wikipedia
 - [RFC Official Internet Protocol Standards](http://www.rfc-editor.org/search/standards.php)
 
 ## Vea también

--- a/files/es/glossary/prototype-based_programming/index.md
+++ b/files/es/glossary/prototype-based_programming/index.md
@@ -12,4 +12,4 @@ En palabras simples: este tipo de estilo permite la creación de un {{Glossary('
 
 ### Conocimiento general
 
-- {{Interwiki("wikipedia", "Prototype-based programming", "Prototype-based programming")}} on Wikipedia
+- [Prototype-based programming](https://es.wikipedia.org/wiki/Prototype-based_programming) on Wikipedia

--- a/files/es/glossary/prototype/index.md
+++ b/files/es/glossary/prototype/index.md
@@ -12,4 +12,4 @@ Mira [La herencia y la cadena de prototipado.](/en-US/docs/Web/JavaScript/Inheri
 
 ### Conocimiento general
 
-- {{Interwiki("wikipedia", "Software Prototyping")}} en la Wikipedia
+- [Software Prototyping](https://es.wikipedia.org/wiki/Software_Prototyping) en la Wikipedia

--- a/files/es/glossary/pseudocode/index.md
+++ b/files/es/glossary/pseudocode/index.md
@@ -14,4 +14,4 @@ El pseudocódigo se refiere a la sintaxis del código que generalmente se usa pa
 
 ### Conocimientos generales
 
-- {{interwiki("wikipedia", "Pseudocódigo", "Pseudocódigo")}} en Wikipedia.
+- [Pseudocódigo](https://es.wikipedia.org/wiki/Pseudocódigo) en Wikipedia.

--- a/files/es/glossary/python/index.md
+++ b/files/es/glossary/python/index.md
@@ -19,5 +19,5 @@ Python es administrado y soportado por la [Python Software Foundation](https://w
 
 ## Aprende Más
 
-- {{interwiki('wikipedia','Python','Python')}} en Wikipedia
+- [Python](https://es.wikipedia.org/wiki/Python) en Wikipedia
 - [Tutorial de Python en Español](https://docs.python.org/es/3/tutorial/index.html)

--- a/files/es/glossary/regular_expression/index.md
+++ b/files/es/glossary/regular_expression/index.md
@@ -17,7 +17,7 @@ Las expresiones regulares están incluidas en varios lenguages, pero las más co
 
 ### Conocimientos generales
 
-- {{Interwiki("wikipedia", "Regular expressions")}} en Wikipedia
+- [Regular expressions](https://es.wikipedia.org/wiki/Regular_expressions) en Wikipedia
 - [Interactive tutorial](http://regexone.com/)
 - [Visualized Regular Expression](http://regexper.com/)
 

--- a/files/es/glossary/rss/index.md
+++ b/files/es/glossary/rss/index.md
@@ -19,7 +19,7 @@ Cuando te subscribes a un _feed_ RSS (boletín de noticias de servicios web), é
 
 ### Cultura General
 
-- {{Interwiki("wikipedia", "RSS")}} en Wikipedia
+- [RSS](https://es.wikipedia.org/wiki/RSS) en Wikipedia
 
 ### Referencia Técnica
 

--- a/files/es/glossary/scope/index.md
+++ b/files/es/glossary/scope/index.md
@@ -38,4 +38,4 @@ console.log(x);
 
 ### Conocimentos Generales
 
-- {{Interwiki("wikipedia", "Scope (computer science)")}} on Wikipedia
+- [Scope (computer science)](https://es.wikipedia.org/wiki/Scope_(computer_science)) on Wikipedia

--- a/files/es/glossary/seo/index.md
+++ b/files/es/glossary/seo/index.md
@@ -24,7 +24,7 @@ Métodos de SEO se dividen en dos grandes clases:
 
 ## Aprende más en
 
-- {{Interwiki("wikipedia", "SEO")}} on Wikipedia
+- [SEO](https://es.wikipedia.org/wiki/SEO) on Wikipedia
 
 ### Aprende SEO
 

--- a/files/es/glossary/sgml/index.md
+++ b/files/es/glossary/sgml/index.md
@@ -16,5 +16,5 @@ En la Web, {{Glossary("HTML")}} 4, {{Glossary("XHTML")}}, y {{Glossary("XML")}} 
 
 ## Aprender más
 
-- {{Interwiki("wikipedia", "SGML")}} en Wikipedia
+- [SGML](https://es.wikipedia.org/wiki/SGML) en Wikipedia
 - [Introduction to SGML](http://www.isgmlug.org/)

--- a/files/es/glossary/simd/index.md
+++ b/files/es/glossary/simd/index.md
@@ -8,7 +8,7 @@ tags:
 translation_of: Glossary/SIMD
 ---
 
-SIMD (pronunciado "sim-dee" en inglés) son las siglas de **Single Instruction/Multiple Data**, el cual es un tipo de {{Interwiki("wikipedia","Taxonomía_de_Flynn","clasificación de arquitecturas de computadores")}}. SIMD permite realizar la misma operación en distintos datos lo que permite paralelismo mejorando el rendimiento — por ejemplo, en la compresión de gráficos 3D y videos, simulaciones físicas, criptografía y otros entornos.
+SIMD (pronunciado "sim-dee" en inglés) son las siglas de **Single Instruction/Multiple Data**, el cual es un tipo de [clasificación de arquitecturas de computadores](https://es.wikipedia.org/wiki/Taxonomía_de_Flynn). SIMD permite realizar la misma operación en distintos datos lo que permite paralelismo mejorando el rendimiento — por ejemplo, en la compresión de gráficos 3D y videos, simulaciones físicas, criptografía y otros entornos.
 
 En contraposición, {{Glossary("SISD")}} es una arquitectura que funciona de forma secuencial tanto para datos como para instrucciones.
 
@@ -16,4 +16,4 @@ En contraposición, {{Glossary("SISD")}} es una arquitectura que funciona de for
 
 ### Conocimientos generales
 
-- {{Interwiki("wikipedia", "SIMD")}} en Wikipedia
+- [SIMD](https://es.wikipedia.org/wiki/SIMD) en Wikipedia

--- a/files/es/glossary/sisd/index.md
+++ b/files/es/glossary/sisd/index.md
@@ -8,7 +8,7 @@ tags:
 translation_of: Glossary/SISD
 ---
 
-SISD son las siglas de **Single Instruction/Single Data** la cual es una {{Interwiki("wikipedia","Flynn%27s_taxonomy","clasificación de arquitecturas")}}. En las arquitecturas SISD, un único procesador ejecuta una única instrucción sobre un único punto de la memoria.
+SISD son las siglas de **Single Instruction/Single Data** la cual es una [clasificación de arquitecturas](https://es.wikipedia.org/wiki/Flynn%27s_taxonomy). En las arquitecturas SISD, un único procesador ejecuta una única instrucción sobre un único punto de la memoria.
 
 En contraposición {{Glossary("SIMD")}} es una arquitectura que permite realizar una operación sobre distintos puntos de memoria.
 
@@ -16,4 +16,4 @@ En contraposición {{Glossary("SIMD")}} es una arquitectura que permite realizar
 
 ### General knowledge
 
-- {{Interwiki("wikipedia", "SISD")}} on Wikipedia
+- [SISD](https://es.wikipedia.org/wiki/SISD) on Wikipedia

--- a/files/es/glossary/sld/index.md
+++ b/files/es/glossary/sld/index.md
@@ -16,4 +16,4 @@ Otro ejemplo es el de `developer.mozilla.org`, el subdominio `developer` es util
 
 ### General knowledge
 
-- {{Interwiki("wikipedia", "Second-level domain", "SLD")}} on Wikipedia
+- [SLD](https://es.wikipedia.org/wiki/Second-level_domain) on Wikipedia

--- a/files/es/glossary/static_typing/index.md
+++ b/files/es/glossary/static_typing/index.md
@@ -15,4 +15,4 @@ Un lenguaje de **tipo estático** es un lenguaje (como Java, C, o C++) en donde 
 
 ### General knowledge
 
-- {{Interwiki("wikipedia", "Type system")}} on Wikipedia
+- [Type system](https://es.wikipedia.org/wiki/Type_system) on Wikipedia

--- a/files/es/glossary/tag/index.md
+++ b/files/es/glossary/tag/index.md
@@ -13,7 +13,7 @@ En {{Glossary("HTML")}} una etiqueta es usada para crear un {{Glossary("elemento
 
 ### Conocimientos generales
 
-- {{Interwiki("wikipedia", "HTML element")}} en Wikipedia
+- [HTML element](https://es.wikipedia.org/wiki/HTML_element) en Wikipedia
 - [HTML Tags on W3](http://www.w3.org/History/19921103-hypertext/hypertext/WWW/MarkUp/Tags.html)
 
 ### Referencia técnica

--- a/files/es/glossary/tcp/index.md
+++ b/files/es/glossary/tcp/index.md
@@ -22,7 +22,7 @@ El rol de TCP es garantizar que los paquetes se entreguen de forma confiable y s
 - [IPv4](/es/docs/Glossary/IPv4)
 - [IPv6](/es/docs/Glossary/IPv6)
 - [Paquete](/es/docs/Glossary/Packet)
-- {{Interwiki("wikipedia", "Protocolo de control de transmisión")}} en Wikipedia
+- [Protocolo de control de transmisión](https://es.wikipedia.org/wiki/Protocolo_de_control_de_transmisión) en Wikipedia
 
 ## Vea también
 

--- a/files/es/glossary/three_js/index.md
+++ b/files/es/glossary/three_js/index.md
@@ -15,5 +15,5 @@ La biblioteca three.js proporciona muchas funciones y {{Glossary("API","APIs")}}
 
 ### Conocimientos Generales
 
-- {{Interwiki("wikipedia", "Three.js")}} en Wikipedia
+- [Three.js](https://es.wikipedia.org/wiki/Three.js) en Wikipedia
 - [sitio oficial de three.js](http://threejs.org/)

--- a/files/es/glossary/type/index.md
+++ b/files/es/glossary/type/index.md
@@ -16,5 +16,5 @@ El tipo de datos de un valor también afecta a qué operaciones son válidas en 
 
 ### Conocimientos generales
 
-- {{Interwiki("wikipedia", "Tipo_de_dato", "Data Type")}} en Wikipedia
+- [Data Type](https://es.wikipedia.org/wiki/Tipo_de_dato) en Wikipedia
 - [Data types en JavaScript](/es/docs/Web/JavaScript/Data_structures)

--- a/files/es/glossary/unicode/index.md
+++ b/files/es/glossary/unicode/index.md
@@ -8,11 +8,11 @@ translation_of: Glossary/Unicode
 
 Unicode es un {{Glossary("Character set", "conjunto de caracteres")}} estándar que numera y define {{Glossary("Character", "caracteres")}} de diferentes idiomas, sistemas de escritura y símbolos. Al asignar un número a cada caracter, los programadores pueden crear {{Glossary("Character encoding", "codificaciones de caracteres")}}, para permitir que las computadoras almacenen, procesen y transmitan cualquier combinación de idiomas en el mismo archivo o programa.
 
-Antes de Unicode, era difícil y propenso a errores mezclar idiomas en los mismos datos. Por ejemplo, un juego de caracteres almacenaría caracteres japoneses y otro almacenaría el alfabeto árabe. Si no estuviera claramente marcado qué partes de los datos estaban en qué juego de caracteres, otros programas y computadoras mostrarían el texto incorrectamente o lo dañarían durante el procesamiento. Si alguna vez has visto texto en el que caracteres como comillas entrecruzadas (`“”`) fueron reemplazadas por un galimatías como `Ã‚Â£`, entonces has visto este problema, conocido como {{Interwiki("wikipedia", "Mojibake")}}.
+Antes de Unicode, era difícil y propenso a errores mezclar idiomas en los mismos datos. Por ejemplo, un juego de caracteres almacenaría caracteres japoneses y otro almacenaría el alfabeto árabe. Si no estuviera claramente marcado qué partes de los datos estaban en qué juego de caracteres, otros programas y computadoras mostrarían el texto incorrectamente o lo dañarían durante el procesamiento. Si alguna vez has visto texto en el que caracteres como comillas entrecruzadas (`“”`) fueron reemplazadas por un galimatías como `Ã‚Â£`, entonces has visto este problema, conocido como [Mojibake](https://es.wikipedia.org/wiki/Mojibake).
 
 La codificación de caracteres Unicode más común en la Web es {{Glossary("UTF-8")}}. Existen otras codificaciones, como UTF-16 o la obsoleta UCS-2, pero se recomienda UTF-8.
 
 ## Aprende más
 
-- {{Interwiki("wikipedia", "Unicode")}} en Wikipedia
+- [Unicode](https://es.wikipedia.org/wiki/Unicode) en Wikipedia
 - [El estándar Unicode: Introducción técnica](http://www.unicode.org/standard/principles.html)

--- a/files/es/glossary/uri/index.md
+++ b/files/es/glossary/uri/index.md
@@ -13,7 +13,7 @@ Un **URI** _(Identificador Uniforme de Recursos de sus siglas en inglés: Unifor
 
 ### Conocimientos Generales
 
-- {{Interwiki("wikipedia", "URI")}} en Wikipedia
+- [URI](https://es.wikipedia.org/wiki/URI) en Wikipedia
 - [RFC 3986 on URI](http://tools.ietf.org/html/rfc3986)
 - [data URIs](/en-US/docs/Web/HTTP/data_URIs)
 - [www vs non-www](/en-US/docs/URI/www_vs_non-www_URLs)

--- a/files/es/glossary/url/index.md
+++ b/files/es/glossary/url/index.md
@@ -18,7 +18,7 @@ Las URLs también se pueden utilizar para la transferencia de archivos ({{Glossa
 
 ### Conocimientos generales
 
-- {{Interwiki("wikipedia", "URL")}} en Wikipedia
+- [URL](https://es.wikipedia.org/wiki/URL) en Wikipedia
 
 ### Aprende sobre esto
 

--- a/files/es/glossary/utf-8/index.md
+++ b/files/es/glossary/utf-8/index.md
@@ -22,5 +22,5 @@ Los primeros 128 carácteres UTF-8 se ajustan a los 128 primeros carácteres ASC
 
 ### Conocimientos generales
 
-- {{Interwiki("wikipedia", "UTF-8")}} en Wikipedia
+- [UTF-8](https://es.wikipedia.org/wiki/UTF-8) en Wikipedia
 - [PF sobre UTF-8 en el sitio web de Unicode](http://www.unicode.org/faq/utf_bom.html#UTF8)

--- a/files/es/glossary/ux/index.md
+++ b/files/es/glossary/ux/index.md
@@ -18,4 +18,4 @@ El sistema puede ser cualquier tipo de producto o aplicación con el que un usua
 
 ### Conocimiento general
 
-- {{Interwiki("wikipedia", "User experience")}} on Wikipedia
+- [User experience](https://es.wikipedia.org/wiki/User_experience) on Wikipedia

--- a/files/es/glossary/value/index.md
+++ b/files/es/glossary/value/index.md
@@ -16,4 +16,4 @@ En el contexto de datos o un objeto **{{Glossary("Wrapper", "wrapper")}}** alred
 
 ### Conocimientos generales
 
-- {{Interwiki("wikipedia", "Primitive wrapper class")}} en Wikipedia
+- [Primitive wrapper class](https://es.wikipedia.org/wiki/Primitive_wrapper_class) en Wikipedia

--- a/files/es/glossary/variable/index.md
+++ b/files/es/glossary/variable/index.md
@@ -16,7 +16,7 @@ Una variable es una ubicación nombrada para almacenar un {{Glossary("Value", "v
 
 ### Conocimientos generales
 
-- {{Interwiki("wikipedia", "Variable (computer science)")}} en Wikipedia
+- [Variable (computer science)](https://es.wikipedia.org/wiki/Variable_(computer_science)) en Wikipedia
 
 ### Referencia técnica
 

--- a/files/es/glossary/vendor_prefix/index.md
+++ b/files/es/glossary/vendor_prefix/index.md
@@ -48,6 +48,6 @@ Los prefijos para propiedades y métodos son minúsculas:
 
 ### Conocimientos generales
 
-- {{Interwiki("wikipedia", "CSS_hack#Browser_prefixes", "Vendor prefix")}} on Wikipedia
+- [Vendor prefix](https://es.wikipedia.org/wiki/CSS_hack#Browser_prefixes) on Wikipedia
 
 {{QuickLinksWithSubpages("/en-US/docs/Glossary")}}

--- a/files/es/glossary/viewport/index.md
+++ b/files/es/glossary/viewport/index.md
@@ -15,7 +15,7 @@ La porción del viewport que se encuentra visible en ese momento se denomina **v
 
 ### Conocimiento General
 
-- {{Interwiki("wikipedia", "Viewport")}} en Wikipedia
+- [Viewport](https://es.wikipedia.org/wiki/Viewport) en Wikipedia
 - [What is viewport in HTML](https://stackoverflow.com/questions/2939693/what-is-viewport-in-html) en Stackoverflow
 - [Get viewport/window size (width and height) with javascript](https://andylangton.co.uk/blog/development/get-viewportwindow-size-width-and-height-javascript)
 - [A tale of two viewports](https://www.quirksmode.org/mobile/viewports.html) (Quirksmode)

--- a/files/es/glossary/wcag/index.md
+++ b/files/es/glossary/wcag/index.md
@@ -23,7 +23,7 @@ WCAG uses three levels of conformance:
 
 ### Conocimientos generales
 
-- {{Interwiki("wikipedia", "Web_Content_Accessibility_Guidelines", "WCAG")}} en Wikipedia
+- [WCAG](https://es.wikipedia.org/wiki/Web_Content_Accessibility_Guidelines) en Wikipedia
 
 ### Technical knowledge
 

--- a/files/es/glossary/webkit/index.md
+++ b/files/es/glossary/webkit/index.md
@@ -22,7 +22,7 @@ WebKit es una marca registrada de Apple, y es distribuido bajo la licencia BSD. 
 
 ### Cultura General
 
-- {{Interwiki("wikipedia", "WebKit")}} en Wikipedia
+- [WebKit](https://es.wikipedia.org/wiki/WebKit) en Wikipedia
 
 ### Referencia técnica
 

--- a/files/es/glossary/websockets/index.md
+++ b/files/es/glossary/websockets/index.md
@@ -20,7 +20,7 @@ Cualquier cliente o servidor de aplicaciones puede usar WebSockets, pero princip
 
 ### Conocimiento general
 
-- {{Interwiki("wikipedia", "Websocket")}} en Wikipedia
+- [Websocket](https://es.wikipedia.org/wiki/Websocket) en Wikipedia
 
 ### Referencia técnica
 

--- a/files/es/glossary/webvtt/index.md
+++ b/files/es/glossary/webvtt/index.md
@@ -18,7 +18,7 @@ WebVTT files provide metadata that is time-aligned with audio or video content l
 
 ### Conocimiento general
 
-- {{Interwiki("wikipedia", "WebVTT")}} en Wikipedia
+- [WebVTT](https://es.wikipedia.org/wiki/WebVTT) en Wikipedia
 
 ### Referencia técnica
 

--- a/files/es/glossary/whatwg/index.md
+++ b/files/es/glossary/whatwg/index.md
@@ -23,5 +23,5 @@ El WHATWG mantiene especifiaciones para {{Glossary("HTML")}}, {{Glossary("DOM")}
 
 ### General Knowledge
 
-- {{Interwiki("wikipedia", "WHATWG")}} en Wikipedia
+- [WHATWG](https://es.wikipedia.org/wiki/WHATWG) en Wikipedia
 - [WHATWG.org Official Website](http://wiki.whatwg.org/)

--- a/files/es/glossary/whitespace/index.md
+++ b/files/es/glossary/whitespace/index.md
@@ -35,7 +35,7 @@ La [especificación del lenguaje ECMAScript® 2015](https://www.ecma-internation
   </li>
   <li>Artículos de Wikipedia
    <ol>
-    <li>{{interwiki("wikipedia", "El caracter de espacio en blanco")}}</li>
+    <li>[El caracter de espacio en blanco](https://es.wikipedia.org/wiki/El_caracter_de_espacio_en_blanco)</li>
    </ol>
   </li>
   <li><a href="/es/docs/Glossary">Glosario</a>

--- a/files/es/glossary/world_wide_web/index.md
+++ b/files/es/glossary/world_wide_web/index.md
@@ -33,5 +33,5 @@ Tan pronto como inventó la Web, Tim Berners-Lee fundó el Consorcio de la World
 
 ### General knowledge
 
-- {{Interwiki("wikipedia", "World Wide Web")}} en Wikipedia
+- [World Wide Web](https://es.wikipedia.org/wiki/World_Wide_Web) en Wikipedia
 - [The W3C website (sitio en inglés)](http://w3.org)

--- a/files/es/glossary/wrapper/index.md
+++ b/files/es/glossary/wrapper/index.md
@@ -16,7 +16,7 @@ Por ejemplo, las librerías SDK de AWS son un ejemplo de wrappers.
 
 ### Conocimientos generales
 
-{{Interwiki("wikipedia", "Wrapper function")}} on Wikipedia
+[Wrapper function](https://es.wikipedia.org/wiki/Wrapper_function) on Wikipedia
 
 <section id="Quick_links">
  <ol>

--- a/files/es/glossary/xml/index.md
+++ b/files/es/glossary/xml/index.md
@@ -25,5 +25,5 @@ Esto significa que XML tiene una mayor aplicación; por ejemplo, a través de XM
 
 ### General knowledge
 
-- {{Interwiki("wikipedia","XML")}} en Wikipedia
+- [XML](https://es.wikipedia.org/wiki/XML) en Wikipedia
 - [Introducción a XML](/es/docs/Introducción_a_XML)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove deprecated Interwiki macro from es

Process: replace with rendered content

### Motivation

The chore of deprecated macros removal

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Relates to https://github.com/orgs/mdn/discussions/263
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
