### PR TITLE
Remove deprecated spec2 macro from es 1/9

### DIFF
--- a/files/es/conflicting/web/api/canvasrenderingcontext2d/index.md
+++ b/files/es/conflicting/web/api/canvasrenderingcontext2d/index.md
@@ -26,6 +26,4 @@ Este es un tipo auxiliar usado para simplificar la especificación, no es una in
 
 ## Especificaciones
 
-| Specification                                                                                                    | Status                           | Comment             |
-| ---------------------------------------------------------------------------------------------------------------- | -------------------------------- | ------------------- |
-| {{SpecName('HTML WHATWG', "scripting.html#canvasimagesource", "CanvasImageSource")}} | {{Spec2('HTML WHATWG')}} | Definición inicial. |
+{{Specifications}}

--- a/files/es/conflicting/web/api/element/click_event/index.md
+++ b/files/es/conflicting/web/api/element/click_event/index.md
@@ -66,11 +66,9 @@ El evento `click` se genera cuando el usuario hace clic en un elemento. El event
 
 Solo se puede asignar un controlador `click` a un objeto a la vez con esta propiedad. Puede que prefiera utilizar el método {{domxref ("EventTarget.addEventListener()")}} en su lugar, ya que es más flexible y forma parte de la especificación DOM Events.
 
-## Especificación
+## Especificaciones
 
-| Especificación                                                                                   | Estatus                          | Comentario |
-| ------------------------------------------------------------------------------------------------ | -------------------------------- | ---------- |
-| {{SpecName('HTML WHATWG','webappapis.html#handler-onclick','onclick')}} | {{Spec2('HTML WHATWG')}} |            |
+{{Specifications}}
 
 ## Compatibilidad de Navegadores
 

--- a/files/es/conflicting/web/api/element/keydown_event/index.md
+++ b/files/es/conflicting/web/api/element/keydown_event/index.md
@@ -21,9 +21,7 @@ El evento `keydown` se lanza cuando el usuario presiona una tecla.
 
 ## Especificaciones
 
-| Specification                                                                                        | Status                           | Comment |
-| ---------------------------------------------------------------------------------------------------- | -------------------------------- | ------- |
-| {{SpecName('HTML WHATWG','webappapis.html#handler-onkeydown','onkeydown')}} | {{Spec2('HTML WHATWG')}} |         |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/conflicting/web/api/element/keyup_event/index.md
+++ b/files/es/conflicting/web/api/element/keyup_event/index.md
@@ -28,9 +28,7 @@ El evento keyup se lanza cuando el usuario suelta la tecla que ha sido presionad
 
 ## Especificaciones
 
-| Specification                                                                                    | Status                           | Comment |
-| ------------------------------------------------------------------------------------------------ | -------------------------------- | ------- |
-| {{SpecName('HTML WHATWG','webappapis.html#handler-onkeyup','onkeyup')}} | {{Spec2('HTML WHATWG')}} |         |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/conflicting/web/api/htmlelement/change_event/index.md
+++ b/files/es/conflicting/web/api/htmlelement/change_event/index.md
@@ -26,9 +26,7 @@ Mira la documentación para el evento [`change`](/es/docs/Web/Reference/Events/c
 
 ## Especificaciones
 
-| Especificación                                                                                   | Estatus                          | Comentario |
-| ------------------------------------------------------------------------------------------------ | -------------------------------- | ---------- |
-| {{SpecName('HTML WHATWG','webappapis.html#handler-onchange','onchange')}} | {{Spec2('HTML WHATWG')}} |            |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/conflicting/web/api/window/hashchange_event/index.md
+++ b/files/es/conflicting/web/api/window/hashchange_event/index.md
@@ -66,11 +66,7 @@ El evento `hashchange` enviado, tiene los siguientes campos:
 
 ## Especificaciones
 
-| Especificacion                                                                                       | Estado                           | Comentario |
-| ---------------------------------------------------------------------------------------------------- | -------------------------------- | ---------- |
-| {{SpecName('HTML WHATWG', '#windoweventhandlers', 'GlobalEventHandlers')}} | {{Spec2('HTML WHATWG')}} |            |
-| {{SpecName('HTML5.1', '#windoweventhandlers', 'GlobalEventHandlers')}}         | {{Spec2('HTML5.1')}}     |            |
-| {{SpecName("HTML5 W3C", "#windoweventhandlers", "GlobalEventHandlers")}}     | {{Spec2('HTML5 W3C')}}     |            |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/conflicting/web/javascript/reference/global_objects/string/index.md
+++ b/files/es/conflicting/web/javascript/reference/global_objects/string/index.md
@@ -21,12 +21,7 @@ Pasarle [`null`](/es/docs/Web/JavaScript/Reference/Global_Objects/null) a un mé
 
 ## Especificaciones
 
-| Especificación                                                                               | Estado                       | Comentarios                                              |
-| -------------------------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------------- |
-| {{SpecName('WebIDL', '#idl-DOMString', 'DOMString')}}                     | {{Spec2('WebIDL')}}     | Reescritura de la definición que elimina casos extraños. |
-| {{SpecName('DOM3 Core', 'core.html#DOMString', 'DOMString')}}             | {{Spec2('DOM3 Core')}} | Sin cambios desde {{SpecName('DOM2 Core')}}       |
-| {{SpecName('DOM2 Core', 'core.html#ID-C74D1578', 'DOMString')}}         | {{Spec2('DOM2 Core')}} | Sin cambios desde {{SpecName('DOM1')}}           |
-| {{SpecName('DOM1', 'level-one-core.html#ID-C74D1578', 'DOMString')}} | {{Spec2('DOM1')}}     | Definición inicial.                                      |
+{{Specifications}}
 
 ## Ver también
 

--- a/files/es/conflicting/webassembly/javascript_interface/index.md
+++ b/files/es/conflicting/webassembly/javascript_interface/index.md
@@ -82,9 +82,7 @@ fetch('simple.wasm').then(response =>
 
 ## Especificaciones
 
-| Especificación                                                                                   | Estado                               | Comentario                       |
-| ------------------------------------------------------------------------------------------------ | ------------------------------------ | -------------------------------- |
-| {{SpecName('WebAssembly JS', '#the-webassembly-object', 'WebAssembly')}} | {{Spec2('WebAssembly JS')}} | Definición inicial del borrador. |
+{{Specifications}}
 
 ## Compatibilidad de Navegadores
 

--- a/files/es/web/javascript/reference/functions/arguments/length/index.md
+++ b/files/es/web/javascript/reference/functions/arguments/length/index.md
@@ -44,12 +44,7 @@ function adder(base /*, n2, ... */) {
 
 ## Especificaciones
 
-| Especificación                                                                                                   | Estado                       | Comentario                                         |
-| ---------------------------------------------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                                         | {{Spec2('ES1')}}         | Definición inicial. Implementado en JavaScript 1.1 |
-| {{SpecName('ES5.1', '#sec-10.6', 'Arguments Object')}}                                         | {{Spec2('ES5.1')}}     |                                                    |
-| {{SpecName('ES6', '#sec-arguments-exotic-objects', 'Arguments Exotic Objects')}}     | {{Spec2('ES6')}}         |                                                    |
-| {{SpecName('ESDraft', '#sec-arguments-exotic-objects', 'Arguments Exotic Objects')}} | {{Spec2('ESDraft')}} |                                                    |
+{{Specifications}}
 
 ## Compatibilidad con los navegadores
 

--- a/files/es/web/javascript/reference/functions/method_definitions/index.md
+++ b/files/es/web/javascript/reference/functions/method_definitions/index.md
@@ -118,13 +118,9 @@ console.log(bar.foo1()); // 1
 console.log(bar.foo2()); // 2
 ```
 
-## Especificaciónes
+## Especificaciones
 
-| Especificación                                                                                   | Estado                       | Observaciones                                                                                                              |
-| ------------------------------------------------------------------------------------------------ | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| {{SpecName('ES6', '#sec-method-definitions', 'Method definitions')}}     | {{Spec2('ES6')}}         | Definición inicial.                                                                                                        |
-| {{SpecName('ES7', '#sec-method-definitions', 'Method definitions')}}     | {{Spec2('ES7')}}         | Cambiado el que los métodos generadores no deban tener una trampa \[\[Construct]] y deban fallar cuando se usen con `new`. |
-| {{SpecName('ESDraft', '#sec-method-definitions', 'Method definitions')}} | {{Spec2('ESDraft')}} |                                                                                                                            |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/functions/rest_parameters/index.md
+++ b/files/es/web/javascript/reference/functions/rest_parameters/index.md
@@ -192,10 +192,7 @@ Para poder usar los métodos de `Array` en el objeto `arguments`, se debe conver
 
 ## Especificaciones
 
-| Especificación                                                                                       | Estado                       | Comentario         |
-| ---------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------ |
-| {{SpecName('ES6', '#sec-function-definitions', 'Function Definitions')}}     | {{Spec2('ES6')}}         | definción inicial. |
-| {{SpecName('ESDraft', '#sec-function-definitions', 'Function Definitions')}} | {{Spec2('ESDraft')}} |                    |
+{{Specifications}}
 
 ## Compatibilidad en Navegadores
 

--- a/files/es/web/javascript/reference/functions/set/index.md
+++ b/files/es/web/javascript/reference/functions/set/index.md
@@ -101,11 +101,7 @@ console.log(obj.baz); // "baz"
 
 ## Especificaciones
 
-| Specification                                                                                    | Status                       | Comment                               |
-| ------------------------------------------------------------------------------------------------ | ---------------------------- | ------------------------------------- |
-| {{SpecName('ES5.1', '#sec-11.1.5', 'Object Initializer')}}                     | {{Spec2('ES5.1')}}     | Definición inicial.                   |
-| {{SpecName('ES6', '#sec-method-definitions', 'Method definitions')}}     | {{Spec2('ES6')}}         | Se añaden las propiedades computadas. |
-| {{SpecName('ESDraft', '#sec-method-definitions', 'Method definitions')}} | {{Spec2('ESDraft')}} |                                       |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/arraybuffer/@@species/index.md
+++ b/files/es/web/javascript/reference/global_objects/arraybuffer/@@species/index.md
@@ -43,10 +43,7 @@ class MyArrayBuffer extends ArrayBuffer {
 
 ## Especificaciones
 
-| Especificación                                                                                                           | Estado                       | Comentario          |
-| ------------------------------------------------------------------------------------------------------------------------ | ---------------------------- | ------------------- |
-| {{SpecName('ES6', '#sec-get-arraybuffer-@@species', 'get ArrayBuffer [ @@species ]')}}     | {{Spec2('ES6')}}         | Definición inicial. |
-| {{SpecName('ESDraft', '#sec-get-arraybuffer-@@species', 'get ArrayBuffer [ @@species ]')}} | {{Spec2('ESDraft')}} |                     |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/arraybuffer/bytelength/index.md
+++ b/files/es/web/javascript/reference/global_objects/arraybuffer/bytelength/index.md
@@ -35,11 +35,7 @@ buffer.byteLength; // 8
 
 ## Especificaciones
 
-| Especificación                                                                                                                               | Estado                           | Comentario                              |
-| -------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | --------------------------------------- |
-| {{SpecName('Typed Array')}}                                                                                                         | {{Spec2('Typed Array')}} | Reemplazado por ECMAScript 2015.        |
-| {{SpecName('ES2015', '#sec-get-arraybuffer.prototype.bytelength', 'ArrayBuffer.prototype.byteLength')}}     | {{Spec2('ES2015')}}         | Definición inicial en un estándar ECMA. |
-| {{SpecName('ESDraft', '#sec-get-arraybuffer.prototype.bytelength', 'ArrayBuffer.prototype.byteLength')}} | {{Spec2('ESDraft')}}     |                                         |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/error/message/index.md
+++ b/files/es/web/javascript/reference/global_objects/error/message/index.md
@@ -27,12 +27,7 @@ throw e;
 
 ## Especificaciones
 
-| Especificación                                                                                               | Estado                       | Comentario          |
-| ------------------------------------------------------------------------------------------------------------ | ---------------------------- | ------------------- |
-| {{SpecName('ES1')}}                                                                                     | {{Spec2('ES1')}}         | Definición inicial. |
-| {{SpecName('ES5.1', '#sec-15.11.4.3', 'Error.prototype.message')}}                     | {{Spec2('ES5.1')}}     |                     |
-| {{SpecName('ES6', '#sec-error.prototype.message', 'Error.prototype.message')}}     | {{Spec2('ES6')}}         |                     |
-| {{SpecName('ESDraft', '#sec-error.prototype.message', 'Error.prototype.message')}} | {{Spec2('ESDraft')}} |                     |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/eval/index.md
+++ b/files/es/web/javascript/reference/global_objects/eval/index.md
@@ -227,12 +227,7 @@ var fct2 = eval(fctStr2)  // deuelve una función
 
 ## Especificaciones
 
-| Especificaciones                                             | Status                       | Comentario          |
-| ------------------------------------------------------------ | ---------------------------- | ------------------- |
-| {{SpecName('ES1')}}                                     | {{Spec2('ES1')}}         | Definición inicial. |
-| {{SpecName('ES5.1', '#sec-15.1.2.1', 'eval')}} | {{Spec2('ES5.1')}}     |                     |
-| {{SpecName('ES6', '#sec-eval-x', 'eval')}}     | {{Spec2('ES6')}}         |                     |
-| {{SpecName('ESDraft', '#sec-eval-x', 'eval')}} | {{Spec2('ESDraft')}} |                     |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/javascript/reference/global_objects/generator/index.md
+++ b/files/es/web/javascript/reference/global_objects/generator/index.md
@@ -104,12 +104,7 @@ console.log(it.next());   // throws StopIteration (as the generator is now close
 
 ## Especificaciones
 
-| Especificación                                                                               | Estado                       | Comentario         |
-| -------------------------------------------------------------------------------------------- | ---------------------------- | ------------------ |
-| {{SpecName('ES2015', '#sec-generator-objects', 'Generator objects')}} | {{Spec2('ES2015')}}     | Definición inicial |
-| {{SpecName('ESDraft', '#sec-generator-objects', 'Generator objects')}} | {{Spec2('ESDraft')}} |                    |
-|                                                                                              |                              |                    |
-|                                                                                              |                              |                    |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/infinity/index.md
+++ b/files/es/web/javascript/reference/global_objects/infinity/index.md
@@ -31,11 +31,7 @@ Para la especificación ECMAScript 5, `Infinity` es de solo lectura (implementad
 
 ## Especificaciones
 
-| Especificación                                                                                                       | Estado                   | Comentario                                         |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------------- |
-| ECMAScript 1ra edición.                                                                                              | Estándar                 | Definición inicial. Implementada en JavaScript 1.3 |
-| {{SpecName('ES5.1', '#sec-15.1.1.2', 'Infinity')}}                                                 | {{Spec2('ES5.1')}} |                                                    |
-| {{SpecName('ES6', '#sec-value-properties-of-the-global-object-infinity', 'Infinity')}} | {{Spec2('ES6')}}     |                                                    |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/isfinite/index.md
+++ b/files/es/web/javascript/reference/global_objects/isfinite/index.md
@@ -47,11 +47,7 @@ isFinite("0");         // verdadero, hubiera sido falso en el caso de usar Numbe
 
 ## Especificaciones
 
-| Especificaciones                                                         | Estado                   | Comentarios        |
-| ------------------------------------------------------------------------ | ------------------------ | ------------------ |
-| ECMAScript 2nd Edition.                                                  | Estándar                 | Definición inicial |
-| {{SpecName('ES5.1', '#sec-15.1.2.5', 'isFinite')}}     | {{Spec2('ES5.1')}} |                    |
-| {{SpecName('ES6', '#sec-isfinite-number', 'isFinite')}} | {{Spec2('ES6')}}     |                    |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/json/index.md
+++ b/files/es/web/javascript/reference/global_objects/json/index.md
@@ -124,10 +124,7 @@ Los objectos [JSON2](https://github.com/douglascrockford/JSON-js) y [JSON3](http
 
 ## Especificaciones
 
-| Especificación                                                   | Estado                   | Comentario |
-| ---------------------------------------------------------------- | ------------------------ | ---------- |
-| {{SpecName('ES5.1', '#sec-15.12', 'JSON')}}         | {{Spec2('ES5.1')}} |            |
-| {{SpecName('ES6', '#sec-json-object', 'JSON')}} | {{Spec2('ES6')}}     |            |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/json/parse/index.md
+++ b/files/es/web/javascript/reference/global_objects/json/parse/index.md
@@ -86,11 +86,7 @@ JSON.parse('{"foo" : 1, }');
 
 ## Especificaciones
 
-| Especificación                                                               | Estado                       | Comentario                                          |
-| ---------------------------------------------------------------------------- | ---------------------------- | --------------------------------------------------- |
-| {{SpecName('ES5.1', '#sec-15.12.2', 'JSON.parse')}}         | {{Spec2('ES5.1')}}     | Definición inicial. Implementado en JavaScript 1.7. |
-| {{SpecName('ES6', '#sec-json.parse', 'JSON.parse')}}         | {{Spec2('ES6')}}         |                                                     |
-| {{SpecName('ESDraft', '#sec-json.parse', 'JSON.parse')}} | {{Spec2('ESDraft')}} |                                                     |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/javascript/reference/global_objects/json/stringify/index.md
+++ b/files/es/web/javascript/reference/global_objects/json/stringify/index.md
@@ -227,11 +227,7 @@ console.log(restoredSession);
 
 ## Especificaciones
 
-| Especificación                                                                       | Estado                       | Comentario                                         |
-| ------------------------------------------------------------------------------------ | ---------------------------- | -------------------------------------------------- |
-| {{SpecName('ES5.1', '#sec-15.12.3', 'JSON.stringify')}}             | {{Spec2('ES5.1')}}     | Definición incial. Implementada en JavaScript 1.7. |
-| {{SpecName('ES6', '#sec-json.stringify', 'JSON.stringify')}}     | {{Spec2('ES6')}}         |                                                    |
-| {{SpecName('ESDraft', '#sec-json.stringify', 'JSON.stringify')}} | {{Spec2('ESDraft')}} |                                                    |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/number/isfinite/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/isfinite/index.md
@@ -54,12 +54,9 @@ Number.isFinite = Number.isFinite || function(value) {
 }
 ```
 
-## Specificaciones
+## Especificaciones
 
-| Specification                                                                            | Status                       | Comment             |
-| ---------------------------------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('ES6', '#sec-number.isfinite', 'Number.isInteger')}}     | {{Spec2('ES6')}}         | Definición inicial. |
-| {{SpecName('ESDraft', '#sec-number.isfinite', 'Number.isInteger')}} | {{Spec2('ESDraft')}} |                     |
+{{Specifications}}
 
 ## Compatibilidad de navegador
 

--- a/files/es/web/javascript/reference/global_objects/number/min_value/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/min_value/index.md
@@ -35,12 +35,7 @@ if (num1 / num2 >= Number.MIN_VALUE) {
 
 ## Especificaciones
 
-| Specification                                                                                | Status                       | Comment                                            |
-| -------------------------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------- |
-| {{SpecName('ES1')}}                                                                     | {{Spec2('ES1')}}         | Initial definition. Implemented in JavaScript 1.1. |
-| {{SpecName('ES5.1', '#sec-15.7.3.3', 'Number.MIN_VALUE')}}                 | {{Spec2('ES5.1')}}     |                                                    |
-| {{SpecName('ES6', '#sec-number.min_value', 'Number.MIN_VALUE')}}         | {{Spec2('ES6')}}         |                                                    |
-| {{SpecName('ESDraft', '#sec-number.min_value', 'Number.MIN_VALUE')}} | {{Spec2('ESDraft')}} |                                                    |
+{{Specifications}}
 
 ## Compatibilidad de navegador
 

--- a/files/es/web/javascript/reference/global_objects/object/__definegetter__/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/__definegetter__/index.md
@@ -64,9 +64,7 @@ console.log(o.gimmeFive); // 5
 
 ## Especificaciones
 
-| Especificación                                                                                                                           | Estado                           | Comentario |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ---------- |
-| {{SpecName('JavaScript', '#object.prototype.__definegetter__', 'Object.prototype.__defineGetter__()')}} | {{Spec2('JavaScript')}} |            |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/javascript/reference/global_objects/object/assign/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/assign/index.md
@@ -254,10 +254,7 @@ if (typeof Object.assign != 'function') {
 
 ## Especificaciones
 
-| Especificación                                                                       | Estado                       | Comentario          |
-| ------------------------------------------------------------------------------------ | ---------------------------- | ------------------- |
-| {{SpecName('ES2015', '#sec-object.assign', 'Object.assign')}}     | {{Spec2('ES2015')}}     | Definición inicial. |
-| {{SpecName('ESDraft', '#sec-object.assign', 'Object.assign')}} | {{Spec2('ESDraft')}} |                     |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/object/constructor/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/constructor/index.md
@@ -91,11 +91,7 @@ console.log( types.join( "\n" ) );
 
 ## Especificaciones
 
-| Especificaciones                                                                                                     | Estatus                  | Comentario          |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | ------------------- |
-| ECMAScript 1ra. Edición. Implementado en JavaScript 1.1                                                              | Estandar.                | Definición inicial. |
-| {{SpecName('ES5.1', '#sec-15.2.4.1', 'Objectprototype.constructor')}}                         | {{Spec2('ES5.1')}} |                     |
-| {{SpecName('ES6', '#sec-object.prototype.constructor', 'Object.prototype.constructor')}} | {{Spec2('ES6')}}     |                     |
+{{Specifications}}
 
 ## Compatibilidad con Navegadores
 

--- a/files/es/web/javascript/reference/global_objects/object/create/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/create/index.md
@@ -351,11 +351,7 @@ Note that while the setting of `null` as `[[Prototype]]` is supported in the rea
 
 ## Especificaciones
 
-| Especificación                                                                       | Estado                       | Comentario                                           |
-| ------------------------------------------------------------------------------------ | ---------------------------- | ---------------------------------------------------- |
-| {{SpecName('ES5.1', '#sec-15.2.3.5', 'Object.create')}}             | {{Spec2('ES5.1')}}     | Definición inicial. Implementado en JavaScript 1.8.5 |
-| {{SpecName('ES6', '#sec-object.create', 'Object.create')}}         | {{Spec2('ES2015')}}     |                                                      |
-| {{SpecName('ESDraft', '#sec-object.create', 'Object.create')}} | {{Spec2('ESDraft')}} |                                                      |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/object/defineproperties/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/defineproperties/index.md
@@ -119,10 +119,7 @@ function defineProperties(obj, properties) {
 
 ## Especificaciones
 
-| Especificación                                                                                           | Estado                   | Comentario                                           |
-| -------------------------------------------------------------------------------------------------------- | ------------------------ | ---------------------------------------------------- |
-| {{SpecName('ES5.1', '#sec-15.2.3.7', 'Object.defineProperties')}}                 | {{Spec2('ES5.1')}} | Definición inicial. Implementada en JavaScript 1.8.5 |
-| {{SpecName('ES6', '#sec-object.defineproperties', 'Object.defineProperties')}} | {{Spec2('ES6')}}     |                                                      |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/javascript/reference/global_objects/object/defineproperty/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/defineproperty/index.md
@@ -312,10 +312,7 @@ console.log(instance.myname); // this is my name string
 
 ## Especificaciones
 
-| Specification                                                                                        | Status                   | Comment                                              |
-| ---------------------------------------------------------------------------------------------------- | ------------------------ | ---------------------------------------------------- |
-| {{SpecName('ES5.1', '#sec-15.2.3.6', 'Object.defineProperty')}}                 | {{Spec2('ES5.1')}} | Initial definition. Implemented in JavaScript 1.8.5. |
-| {{SpecName('ES6', '#sec-object.defineproperty', 'Object.defineProperty')}} | {{Spec2('ES6')}}     |                                                      |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/object/entries/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/entries/index.md
@@ -76,12 +76,9 @@ console.log(map); // Map { foo: "bar", baz: 42 }
 
 To add compatible `Object.entries` support in older environments that do not natively support it, you can find a Polyfill in the [tc39/proposal-object-values-entries](https://github.com/tc39/proposal-object-values-entries) or in the [es-shims/Object.entries](https://github.com/es-shims/Object.entries) repositories.
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                        | Status                       | Comment             |
-| ------------------------------------------------------------------------------------ | ---------------------------- | ------------------- |
-| {{SpecName('ESDraft', '#sec-object.entries', 'Object.entries')}} | {{Spec2('ESDraft')}} | Initial definition. |
-| {{SpecName('ES8', '#sec-object.entries', 'Object.entries')}}     | {{Spec2('ES8')}}         |                     |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/javascript/reference/global_objects/object/freeze/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/freeze/index.md
@@ -139,11 +139,7 @@ TypeError: 1 is not an object // Código ES5
 
 ## Especificaciones
 
-| Specification                                                                        | Status                       | Comment                                               |
-| ------------------------------------------------------------------------------------ | ---------------------------- | ----------------------------------------------------- |
-| {{SpecName('ES5.1', '#sec-15.2.3.9', 'Object.freeze')}}             | {{Spec2('ES5.1')}}     | Definición inicial. Implementado en JavaScript 1.8.5. |
-| {{SpecName('ES6', '#sec-object.freeze', 'Object.freeze')}}         | {{Spec2('ES6')}}         |                                                       |
-| {{SpecName('ESDraft', '#sec-object.freeze', 'Object.freeze')}} | {{Spec2('ESDraft')}} |                                                       |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/javascript/reference/global_objects/object/getownpropertydescriptor/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/getownpropertydescriptor/index.md
@@ -83,10 +83,7 @@ Object.getOwnPropertyDescriptor("foo", 0);
 
 ## Especificaciones
 
-| Especificación                                                                                                               | Estado                   | Comentario                                            |
-| ---------------------------------------------------------------------------------------------------------------------------- | ------------------------ | ----------------------------------------------------- |
-| {{SpecName('ES5.1', '#sec-15.2.3.3', 'Object.getOwnPropertyDescriptor')}}                             | {{Spec2('ES5.1')}} | Definición inicial. Implementado en JavaScript 1.8.5. |
-| {{SpecName('ES6', '#sec-object.getownpropertydescriptor', 'Object.getOwnPropertyDescriptor')}} | {{Spec2('ES6')}}     |                                                       |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/object/getownpropertydescriptors/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/getownpropertydescriptors/index.md
@@ -82,10 +82,7 @@ subclass.prototype = Object.create(
 
 ## Especificaciones
 
-| Specification                                                                                                                        | Status                       | Comment                                |
-| ------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------- | -------------------------------------- |
-| {{SpecName('ESDraft', '#sec-object.getownpropertydescriptors', 'Object.getOwnPropertyDescriptors')}} | {{Spec2('ESDraft')}} | Definición inicial en ECMAScript 2017. |
-| {{SpecName('ES2017', '#sec-object.getownpropertydescriptors', 'Object.getOwnPropertyDescriptors')}} | {{Spec2('ES2017')}}     |                                        |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/javascript/reference/global_objects/object/getownpropertynames/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/getownpropertynames/index.md
@@ -100,10 +100,7 @@ console.log(nonenum_only);
 
 ## Especificaciones
 
-| Especificación                                                                                                   | Status                   | Comentario                                          |
-| ---------------------------------------------------------------------------------------------------------------- | ------------------------ | --------------------------------------------------- |
-| {{SpecName('ES5.1', '#sec-15.2.3.4', 'Object.getOwnPropertyNames')}}                     | {{Spec2('ES5.1')}} | Initial definition. Implemented in JavaScript 1.8.5 |
-| {{SpecName('ES6', '#sec-object.getownpropertynames', 'Object.getOwnPropertyNames')}} | {{Spec2('ES6')}}     |                                                     |
+{{Specifications}}
 
 ## Compatibilidad con Navegadores
 

--- a/files/es/web/javascript/reference/global_objects/object/getownpropertysymbols/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/getownpropertysymbols/index.md
@@ -51,9 +51,7 @@ console.log(objectSymbols[0]);     // Symbol(a)
 
 ## Especificaciones
 
-| Especificación                                                                                                       | Estado               | Comentario          |
-| -------------------------------------------------------------------------------------------------------------------- | -------------------- | ------------------- |
-| {{SpecName('ES6', '#sec-object.getownpropertysymbols', 'Object.getOwnPropertySymbols')}} | {{Spec2('ES6')}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/object/getprototypeof/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/getprototypeof/index.md
@@ -52,10 +52,7 @@ String.prototype                   // ES6 code
 
 ## Especificaciones
 
-| Especificación                                                                                   | Estado                   | Comentario          |
-| ------------------------------------------------------------------------------------------------ | ------------------------ | ------------------- |
-| {{SpecName('ES5.1', '#sec-15.2.3.2', 'Object.getPrototypeOf')}}             | {{Spec2('ES5.1')}} | Definición inicial. |
-| {{SpecName('ES6', '#sec-object.getprototypeof', 'Object.getProtoypeOf')}} | {{Spec2('ES6')}}     |                     |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/object/hasownproperty/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/hasownproperty/index.md
@@ -107,11 +107,7 @@ Observe que en el último caso no han habido nuevos objetos creados.
 
 ## Especificaciones
 
-| Especificaciones                                                                                                             | Estado                   | Comentario          |
-| ---------------------------------------------------------------------------------------------------------------------------- | ------------------------ | ------------------- |
-| ECMAScript 3rd Edition. Implemented in JavaScript 1.5                                                                        | Standard                 | Initial definition. |
-| {{SpecName('ES5.1', '#sec-15.2.4.5', 'Object.prototype.hasOwnProperty')}}                             | {{Spec2('ES5.1')}} |                     |
-| {{SpecName('ES6', '#sec-object.prototype.hasownproperty', 'Object.prototype.hasOwnProperty')}} | {{Spec2('ES6')}}     |                     |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/javascript/reference/global_objects/object/is/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/is/index.md
@@ -96,9 +96,7 @@ if (!Object.is) {
 
 ## Especificaciones
 
-| Especificación                                                       | Estado               | Comentario          |
-| -------------------------------------------------------------------- | -------------------- | ------------------- |
-| {{SpecName('ES6', '#sec-object.is', 'Object.is')}} | {{Spec2('ES6')}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/javascript/reference/global_objects/object/isextensible/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/isextensible/index.md
@@ -64,10 +64,7 @@ Object.isExtensible(1);
 
 ## Especificaciones
 
-| Especificación                                                                               | Estado                   | Comentario                                            |
-| -------------------------------------------------------------------------------------------- | ------------------------ | ----------------------------------------------------- |
-| {{SpecName('ES5.1', '#sec-15.2.3.13', 'Object.isExtensible')}}         | {{Spec2('ES5.1')}} | Definición inicial. Implementada en JavaScript 1.8.5. |
-| {{SpecName('ES6', '#sec-object.isextensible', 'Object.isExtensible')}} | {{Spec2('ES6')}}     |                                                       |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/object/isfrozen/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/isfrozen/index.md
@@ -109,10 +109,7 @@ Object.isFrozen(1);
 
 ## Especificaciones
 
-| Especificación                                                                       | Estado                   | Comentario                                            |
-| ------------------------------------------------------------------------------------ | ------------------------ | ----------------------------------------------------- |
-| {{SpecName('ES5.1', '#sec-15.2.3.12', 'Object.isFrozen')}}         | {{Spec2('ES5.1')}} | Definición inicial. Implementada en JavaScript 1.8.5. |
-| {{SpecName('ES6', '#sec-object.isfrozen', 'Object.isFrozen')}} | {{Spec2('ES6')}}     |                                                       |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/object/isprototypeof/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/isprototypeof/index.md
@@ -66,12 +66,7 @@ Esto, junto con el operador {{jsxref("Operators/instanceof", "instanceof")}} res
 
 ## Especificaciones
 
-| Especificación                                                                                                                       | Estado                       | Observaciones       |
-| ------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------- | ------------------- |
-| {{SpecName('ES3')}}                                                                                                             | {{Spec2('ES3')}}         | Definición inicial. |
-| {{SpecName('ES5.1', '#sec-15.2.4.5', 'Object.prototype.hasOwnProperty')}}                                     | {{Spec2('ES5.1')}}     |                     |
-| {{SpecName('ES6', '#sec-object.prototype.hasownproperty', 'Object.prototype.hasOwnProperty')}}         | {{Spec2('ES6')}}         |                     |
-| {{SpecName('ESDraft', '#sec-object.prototype.hasownproperty', 'Object.prototype.hasOwnProperty')}} | {{Spec2('ESDraft')}} |                     |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/object/issealed/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/issealed/index.md
@@ -98,11 +98,7 @@ Object.isSealed(1);
 
 ## Especificaciones
 
-| Specification                                                                            | Status                       | Comment                                               |
-| ---------------------------------------------------------------------------------------- | ---------------------------- | ----------------------------------------------------- |
-| {{SpecName('ES5.1', '#sec-15.2.3.11', 'Object.isSealed')}}             | {{Spec2('ES5.1')}}     | Definición inicial. Implementada en JavaScript 1.8.5. |
-| {{SpecName('ES6', '#sec-object.issealed', 'Object.isSealed')}}     | {{Spec2('ES6')}}         |                                                       |
-| {{SpecName('ESDraft', '#sec-object.issealed', 'Object.isSealed')}} | {{Spec2('ESDraft')}} |                                                       |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/javascript/reference/global_objects/object/keys/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/keys/index.md
@@ -119,11 +119,7 @@ Para un simple Polyfill del Navegador, mira [Javascript - Compatibilidad de Obje
 
 ## Especificaciones
 
-| Especificación                                                               | Estado                       | Comentarios                                           |
-| ---------------------------------------------------------------------------- | ---------------------------- | ----------------------------------------------------- |
-| {{SpecName('ES5.1', '#sec-15.2.3.14', 'Object.keys')}}     | {{Spec2('ES5.1')}}     | Definición inicial. Implementado en JavaScript 1.8.5. |
-| {{SpecName('ES2015', '#sec-object.keys', 'Object.keys')}} | {{Spec2('ES2015')}}     |                                                       |
-| {{SpecName('ESDraft', '#sec-object.keys', 'Object.keys')}} | {{Spec2('ESDraft')}} |                                                       |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/object/preventextensions/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/preventextensions/index.md
@@ -77,12 +77,9 @@ Object.preventExtensions(1);
 // 1                             (ES6 code)
 ```
 
-## Especificación
+## Especificaciones
 
-| Especificación                                                                                               | Estado                   | Comentario                                            |
-| ------------------------------------------------------------------------------------------------------------ | ------------------------ | ----------------------------------------------------- |
-| {{SpecName('ES5.1', '#sec-15.2.3.10', 'Object.preventExtensions')}}                     | {{Spec2('ES5.1')}} | Definición inicial. Implementada en JavaScript 1.8.5. |
-| {{SpecName('ES6', '#sec-object.preventextensions', 'Object.preventExtensions')}} | {{Spec2('ES6')}}     |                                                       |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/javascript/reference/global_objects/object/propertyisenumerable/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/propertyisenumerable/index.md
@@ -99,11 +99,7 @@ o.propertyIsEnumerable('firstMethod'); // regresa false
 
 ## Especificaciones
 
-| Especificación                                                                                                                               | Estatus                  | Comentario          |
-| -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | ------------------- |
-| {{SpecName('ES3')}}                                                                                                                     | {{Spec2('ES3')}}     | Definición inicial. |
-| {{SpecName('ES5.1', '#sec-15.2.4.7', 'Object.prototype.propertyIsEnumerable')}}                                     | {{Spec2('ES5.1')}} |                     |
-| {{SpecName('ES6', '#sec-object.prototype.propertyisenumerable', 'Object.prototype.propertyIsEnumerable')}} | {{Spec2('ES6')}}     |                     |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/javascript/reference/global_objects/object/proto/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/proto/index.md
@@ -45,9 +45,7 @@ La propiedad `__proto__` es una simple propiedad de acceso a {{jsxref("Object.pr
 
 ## Especificaciones
 
-| Especificaciones                                                                                                                                     | Estado               | Comentario                                                                                                                                                                                  |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| {{SpecName('ES6', '#sec-additional-properties-of-the-object.prototype-object', 'Object.prototype.__proto__')}} | {{Spec2('ES6')}} | Incluída en el anexo (normativa) para características de legado ECMAScript para navegadores web (observar que la especificación de codificación es lo que ya está en las implementaciones). |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/javascript/reference/global_objects/object/seal/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/seal/index.md
@@ -83,11 +83,7 @@ Object.seal(1);
 
 ## Especificaciones
 
-| Especificación                                                               | Estado                       | Observaciones                                         |
-| ---------------------------------------------------------------------------- | ---------------------------- | ----------------------------------------------------- |
-| {{SpecName('ES5.1', '#sec-15.2.3.8', 'Object.seal')}}     | {{Spec2('ES5.1')}}     | Definición inicial. Implementado en JavaScript 1.8.5. |
-| {{SpecName('ES6', '#sec-object.seal', 'Object.seal')}}     | {{Spec2('ES6')}}         |                                                       |
-| {{SpecName('ESDraft', '#sec-object.seal', 'Object.seal')}} | {{Spec2('ESDraft')}} |                                                       |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/object/setprototypeof/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/setprototypeof/index.md
@@ -166,9 +166,7 @@ george(); // 'Hello guys!!'
 
 ## Especificaciones
 
-| Especificación                                                                                   | Estado               | Comentario          |
-| ------------------------------------------------------------------------------------------------ | -------------------- | ------------------- |
-| {{SpecName('ES6', '#sec-object.setprototypeof', 'Object.setProtoypeOf')}} | {{Spec2('ES6')}} | Initial definition. |
+{{Specifications}}
 
 ## Compatibilidad del navegador
 

--- a/files/es/web/javascript/reference/global_objects/object/valueof/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/valueof/index.md
@@ -68,12 +68,7 @@ myObj + 3; // 7
 
 ## Especificaciones
 
-| Especificación                                                                                                   | Estado                       | Commentario                                         |
-| ---------------------------------------------------------------------------------------------------------------- | ---------------------------- | --------------------------------------------------- |
-| ECMAScript 1ra Edición.                                                                                          | Estándar                     | Definición inicial. Implementado en JavaScript 1.1. |
-| {{SpecName('ES5.1', '#sec-15.2.4.4', 'Object.prototype.valueOf')}}                         | {{Spec2('ES5.1')}}     |                                                     |
-| {{SpecName('ES6', '#sec-object.prototype.valueof', 'Object.prototype.valueOf')}}     | {{Spec2('ES6')}}         |                                                     |
-| {{SpecName('ESDraft', '#sec-object.prototype.valueof', 'Object.prototype.valueOf')}} | {{Spec2('ESDraft')}} |                                                     |
+{{Specifications}}
 
 ## Compatibilidad con Navegadores
 

--- a/files/es/web/javascript/reference/global_objects/object/values/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/values/index.md
@@ -64,10 +64,7 @@ Para dar soporte compatible con `Object.values()` a entornos antiguos que no la 
 
 ## Especificaciones
 
-| Especificación                                                                       | Estado                       | Comentario          |
-| ------------------------------------------------------------------------------------ | ---------------------------- | ------------------- |
-| {{SpecName('ESDraft', '#sec-object.values', 'Object.values')}} | {{Spec2('ESDraft')}} | Definición inicial. |
-| {{SpecName('ES8', '#sec-object.values', 'Object.values')}}         | {{Spec2('ES8')}}         |                     |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/javascript/reference/global_objects/promise/all/index.md
+++ b/files/es/web/javascript/reference/global_objects/promise/all/index.md
@@ -95,10 +95,7 @@ Promise.all([p1, p2, p3, p4, p5]).then(values => {
 
 ## Especificaciones
 
-| Especificación                                                               | Status                       | Comentario                              |
-| ---------------------------------------------------------------------------- | ---------------------------- | --------------------------------------- |
-| {{SpecName('ES6', '#sec-promise.all', 'Promise.all')}}     | {{Spec2('ES6')}}         | Initial definition in an ECMA standard. |
-| {{SpecName('ESDraft', '#sec-promise.all', 'Promise.all')}} | {{Spec2('ESDraft')}} |                                         |
+{{Specifications}}
 
 ## Compatibilidad entre navegadores
 

--- a/files/es/web/javascript/reference/global_objects/promise/catch/index.md
+++ b/files/es/web/javascript/reference/global_objects/promise/catch/index.md
@@ -149,12 +149,9 @@ p2.then(function (value) {
 });
 ```
 
-## Especificación
+## Especificaciones
 
-| Specification                                                                                                | Status                       | Comment                                |
-| ------------------------------------------------------------------------------------------------------------ | ---------------------------- | -------------------------------------- |
-| {{SpecName('ES2015', '#sec-promise.prototype.catch', 'Promise.prototype.catch')}} | {{Spec2('ES2015')}}     | Definición inicial en el standar ECMA. |
-| {{SpecName('ESDraft', '#sec-promise.prototype.catch', 'Promise.prototype.catch')}} | {{Spec2('ESDraft')}} |                                        |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/javascript/reference/global_objects/promise/finally/index.md
+++ b/files/es/web/javascript/reference/global_objects/promise/finally/index.md
@@ -62,9 +62,7 @@ fetch(myRequest).then(function(response) {
 
 ## Especificaciones
 
-| Especificación                                                                                                       | Estado                       | Comentario |
-| -------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ---------- |
-| {{SpecName('ESDraft', '#sec-promise.prototype.finally', 'Promise.prototype.finally')}} | {{Spec2('ESDraft')}} |            |
+{{Specifications}}
 
 ## Compatibilidad en navegador
 

--- a/files/es/web/javascript/reference/global_objects/promise/race/index.md
+++ b/files/es/web/javascript/reference/global_objects/promise/race/index.md
@@ -83,14 +83,7 @@ Promise.race([p5, p6]).then( value => {
 
 ## Especificaciones
 
-| Especificación                                                                   | Status                       | Comentar                                |
-| -------------------------------------------------------------------------------- | ---------------------------- | --------------------------------------- |
-| {{SpecName('ES6', '#sec-promise.race', 'Promise.race')}}     | {{Spec2('ES6')}}         | Initial definition in an ECMA standard. |
-| {{SpecName('ESDraft', '#sec-promise.race', 'Promise.race')}} | {{Spec2('ESDraft')}} |                                         |
-
-## Compatibilidad entre navegadores
-
-{{Compat}}
+{{Specifications}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/global_objects/promise/reject/index.md
+++ b/files/es/web/javascript/reference/global_objects/promise/reject/index.md
@@ -44,10 +44,7 @@ Promise.reject(new Error('fail')).then(function() {
 
 ## Especificaciones
 
-| Specification                                                                        | Status                       | Comment                                 |
-| ------------------------------------------------------------------------------------ | ---------------------------- | --------------------------------------- |
-| {{SpecName('ES2015', '#sec-promise.reject', 'Promise.reject')}} | {{Spec2('ES2015')}}     | Initial definition in an ECMA standard. |
-| {{SpecName('ESDraft', '#sec-promise.reject', 'Promise.reject')}} | {{Spec2('ESDraft')}} |                                         |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/javascript/reference/global_objects/promise/resolve/index.md
+++ b/files/es/web/javascript/reference/global_objects/promise/resolve/index.md
@@ -123,10 +123,7 @@ p3.then(function(v) {
 
 ## Especificaciones
 
-| Especificación                                                                           | Estado                       | Comentario                                 |
-| ---------------------------------------------------------------------------------------- | ---------------------------- | ------------------------------------------ |
-| {{SpecName('ES2015', '#sec-promise.resolve', 'Promise.resolve')}} | {{Spec2('ES2015')}}     | Definición inicial en un estándar de ECMA. |
-| {{SpecName('ESDraft', '#sec-promise.resolve', 'Promise.resolve')}} | {{Spec2('ESDraft')}} |                                            |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/promise/then/index.md
+++ b/files/es/web/javascript/reference/global_objects/promise/then/index.md
@@ -282,10 +282,7 @@ const nextTick = (() => {
 
 ## Especificaciones
 
-| Especificación                                                                                               | Estado                       | Comentario                              |
-| ------------------------------------------------------------------------------------------------------------ | ---------------------------- | --------------------------------------- |
-| {{SpecName('ES2015', '#sec-promise.prototype.then', 'Promise.prototype.then')}}     | {{Spec2('ES2015')}}     | Definición inicial en el estándar ECMA. |
-| {{SpecName('ESDraft', '#sec-promise.prototype.then', 'Promise.prototype.then')}} | {{Spec2('ESDraft')}} |                                         |
+{{Specifications}}
 
 ## Compatibilidad en navegador
 

--- a/files/es/web/javascript/reference/global_objects/proxy/proxy/getownpropertydescriptor/index.md
+++ b/files/es/web/javascript/reference/global_objects/proxy/proxy/getownpropertydescriptor/index.md
@@ -88,10 +88,7 @@ Object.getOwnPropertyDescriptor(p, 'a'); // TypeError is thrown
 
 ## Especificaciones
 
-| Especificación                                                                                                                                                   | Estado                       | Comentario          |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('ES2015', '#sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p', '[[GetOwnProperty]]')}}     | {{Spec2('ES2015')}}     | Definición Inicial. |
-| {{SpecName('ESDraft', '#sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p', '[[GetOwnProperty]]')}} | {{Spec2('ESDraft')}} |                     |
+{{Specifications}}
 
 ## Compatibilidad con buscadores
 

--- a/files/es/web/javascript/reference/global_objects/proxy/proxy/index.md
+++ b/files/es/web/javascript/reference/global_objects/proxy/proxy/index.md
@@ -49,12 +49,9 @@ All traps are optional. If a trap has not been defined, the default behavior is 
 
 Some non-standard traps are [obsolete and have been removed](/es/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#Proxy).
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                                                                                                                    | Status                       | Comment                                   |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ----------------------------------------- |
-| {{SpecName('ES2015', '#sec-proxy-object-internal-methods-and-internal-slots', 'Proxy Object Internal Methods and Internal Slots')}} | {{Spec2('ES2015')}}     | Initial definition.                       |
-| {{SpecName('ESDraft', '#sec-proxy-object-internal-methods-and-internal-slots', 'Proxy Object Internal Methods and Internal Slots')}} | {{Spec2('ESDraft')}} | The `enumerate` handler has been removed. |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/javascript/reference/global_objects/proxy/proxy/set/index.md
+++ b/files/es/web/javascript/reference/global_objects/proxy/proxy/set/index.md
@@ -84,10 +84,7 @@ console.log(p.a)       // 10
 
 ## Especificaciones
 
-| Especificación                                                                                                                                   | Estado                       | Comentario          |
-| ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------- | ------------------- |
-| {{SpecName('ES2015', '#sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver', '[[Set]]')}} | {{Spec2('ES2015')}}     | Definición inicial. |
-| {{SpecName('ESDraft', '#sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver', '[[Set]]')}} | {{Spec2('ESDraft')}} |                     |
+{{Specifications}}
 
 ## Compatibilidad con los buscadores
 

--- a/files/es/web/javascript/reference/global_objects/set/@@iterator/index.md
+++ b/files/es/web/javascript/reference/global_objects/set/@@iterator/index.md
@@ -57,10 +57,7 @@ for (const v of mySet) {
 
 ## Especificaciones
 
-| Especificación                                                                                                   | Estado                       | Comentario          |
-| ---------------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('ES2015', '#sec-set.prototype-@@iterator', 'Set.prototype[@@iterator]')}} | {{Spec2('ES2015')}}     | Definición inicial. |
-| {{SpecName('ESDraft', '#sec-set.prototype-@@iterator', 'Set.prototype[@@iterator]')}} | {{Spec2('ESDraft')}} |                     |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/javascript/reference/global_objects/set/add/index.md
+++ b/files/es/web/javascript/reference/global_objects/set/add/index.md
@@ -38,12 +38,9 @@ console.log(mySet);
 // Set [1, 5, "some text"]
 ```
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                                | Status                       | Comment             |
-| -------------------------------------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('ES6', '#sec-set.prototype.add', 'Set.prototype.add')}}     | {{Spec2('ES6')}}         | Initial definition. |
-| {{SpecName('ESDraft', '#sec-set.prototype.add', 'Set.prototype.add')}} | {{Spec2('ESDraft')}} |                     |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/javascript/reference/global_objects/set/clear/index.md
+++ b/files/es/web/javascript/reference/global_objects/set/clear/index.md
@@ -44,10 +44,7 @@ mySet.has("bar")  // false
 
 ## Especificaciones
 
-| Especificación                                                                                       | Estado                       | Comentario          |
-| ---------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('ES6', '#sec-set.prototype.clear', 'Set.prototype.clear')}}         | {{Spec2('ES6')}}         | Initial definition. |
-| {{SpecName('ESDraft', '#sec-set.prototype.clear', 'Set.prototype.clear')}} | {{Spec2('ESDraft')}} |                     |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/javascript/reference/global_objects/set/delete/index.md
+++ b/files/es/web/javascript/reference/global_objects/set/delete/index.md
@@ -40,10 +40,7 @@ mySet.has("foo");    // Retorna false. El elemento "foo" ya no está presente.
 
 ## Especificaciones
 
-| Especificación                                                                                       | Estado                       | Comentario          |
-| ---------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('ES6', '#sec-set.prototype.delete', 'Set.prototype.delete')}}     | {{Spec2('ES6')}}         | Definición inicial. |
-| {{SpecName('ESDraft', '#sec-set.prototype.delete', 'Set.prototype.delete')}} | {{Spec2('ESDraft')}} |                     |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/javascript/reference/global_objects/set/entries/index.md
+++ b/files/es/web/javascript/reference/global_objects/set/entries/index.md
@@ -42,10 +42,7 @@ console.log(setIter.next().value); // ["baz", "baz"]
 
 ## Especificaciones
 
-| Especificación                                                                                           | Estado                       | Commentario         |
-| -------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('ES2015', '#sec-set.prototype.entries', 'Set.prototype.entries')}} | {{Spec2('ES2015')}}     | Definición inicial. |
-| {{SpecName('ESDraft', '#sec-set.prototype.entries', 'Set.prototype.entries')}} | {{Spec2('ESDraft')}} |                     |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/javascript/reference/global_objects/set/has/index.md
+++ b/files/es/web/javascript/reference/global_objects/set/has/index.md
@@ -44,10 +44,7 @@ mySet.has("bar");  // retorna false
 
 ## Especificaciones
 
-| Especificación                                                                               | Estado                       | Comentario          |
-| -------------------------------------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('ES6', '#sec-set.prototype.has', 'Set.prototype.has')}}     | {{Spec2('ES6')}}         | Definición inicial. |
-| {{SpecName('ESDraft', '#sec-set.prototype.has', 'Set.prototype.has')}} | {{Spec2('ESDraft')}} |                     |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/javascript/reference/global_objects/set/size/index.md
+++ b/files/es/web/javascript/reference/global_objects/set/size/index.md
@@ -28,10 +28,7 @@ mySet.size; // 3
 
 ## Especificaciones
 
-| Especificación                                                                                       | Estatus                      | Comentario         |
-| ---------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------ |
-| {{SpecName('ES6', '#sec-get-set.prototype.size', 'Set.prototype.size')}}     | {{Spec2('ES6')}}         | Definición inicial |
-| {{SpecName('ESDraft', '#sec-get-set.prototype.size', 'Set.prototype.size')}} | {{Spec2('ESDraft')}} |                    |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/javascript/reference/global_objects/set/values/index.md
+++ b/files/es/web/javascript/reference/global_objects/set/values/index.md
@@ -40,12 +40,9 @@ console.log(setIter.next().value); // "bar"
 console.log(setIter.next().value); // "baz"
 ```
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                                        | Status                       | Comment             |
-| ---------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('ES2015', '#sec-set.prototype.values', 'Set.prototype.values')}} | {{Spec2('ES2015')}}     | Initial definition. |
-| {{SpecName('ESDraft', '#sec-set.prototype.values', 'Set.prototype.values')}} | {{Spec2('ESDraft')}} |                     |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/javascript/reference/global_objects/string/charat/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/charat/index.md
@@ -59,13 +59,9 @@ El carácter en el índice 4 es 'e'
 El carácter en el índice 999 es ''
 ```
 
-## Especificaciónes
+## Especificaciones
 
-| Especificación                                                                                           | Estado                   | Comentario         |
-| -------------------------------------------------------------------------------------------------------- | ------------------------ | ------------------ |
-| ECMAScript 1st Edition.                                                                                  | Estándar                 | Primera definición |
-| {{SpecName('ES5.1', '#sec-15.5.4.4', 'String.prototype.charAt')}}                 | {{Spec2('ES5.1')}} |                    |
-| {{SpecName('ES6', '#sec-string.prototype.charat', 'String.prototype.charAt')}} | {{Spec2('ES6')}}     |                    |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/javascript/reference/global_objects/string/codepointat/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/codepointat/index.md
@@ -91,12 +91,9 @@ if (!String.prototype.codePointAt) {
 }
 ```
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                                                                | Status                       | Comment             |
-| ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('ES2015', '#sec-string.prototype.codepointat', 'String.prototype.codePointAt')}}     | {{Spec2('ES2015')}}     | Initial definition. |
-| {{SpecName('ESDraft', '#sec-string.prototype.codepointat', 'String.prototype.codePointAt')}} | {{Spec2('ESDraft')}} |                     |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/javascript/reference/global_objects/string/fontcolor/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/fontcolor/index.md
@@ -50,9 +50,7 @@ document.getElementById('yourElemId').style.color = 'red';
 
 ## Especificaciones
 
-| Especificación                                                                                                   | Estatus              | Comentario                                                                                                                                 |
-| ---------------------------------------------------------------------------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| {{SpecName('ES6', '#sec-string.prototype.fontcolor', 'String.prototype.fontcolor')}} | {{Spec2('ES6')}} | Initial definition. Implemented in JavaScript 1.0. Defined in the (normative) Annex B for Additional ECMAScript Features for Web Browsers. |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/string/fontsize/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/fontsize/index.md
@@ -48,11 +48,9 @@ With the {{domxref("HTMLElement.style", "element.style")}} object you can get th
 document.getElementById('yourElemId').style.fontSize = '0.7em';
 ```
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                                                | Status               | Comment                                                                                                                                    |
-| ------------------------------------------------------------------------------------------------------------ | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| {{SpecName('ES6', '#sec-string.prototype.fontsize', 'String.prototype.fontsize')}} | {{Spec2('ES6')}} | Initial definition. Implemented in JavaScript 1.0. Defined in the (normative) Annex B for Additional ECMAScript Features for Web Browsers. |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/javascript/reference/global_objects/string/fromcharcode/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/fromcharcode/index.md
@@ -43,13 +43,9 @@ El siguiene ejemplo devuelve la cadena "ABC".
 String.fromCharCode(65,66,67)
 ```
 
-## Especificaciónes
+## Especificaciones
 
-| Especificación                                                                                   | Estatus                  | Comentario                                        |
-| ------------------------------------------------------------------------------------------------ | ------------------------ | ------------------------------------------------- |
-| ECMAScript 1st Edition.                                                                          | Estándar                 | Primera definicíon Implementada en JavaScript 1.2 |
-| {{SpecName('ES5.1', '#sec-15.5.3.2', 'StringfromCharCode')}}                 | {{Spec2('ES5.1')}} |                                                   |
-| {{SpecName('ES6', '#sec-string.fromcharcodes', 'String.fromCharCode')}} | {{Spec2('ES6')}}     |                                                   |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/javascript/reference/global_objects/string/fromcodepoint/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/fromcodepoint/index.md
@@ -128,11 +128,9 @@ if (!String.fromCodePoint) {
 }
 ```
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                                    | Status               | Comment             |
-| ------------------------------------------------------------------------------------------------ | -------------------- | ------------------- |
-| {{SpecName('ES6', '#sec-string.fromcodepoint', 'String.fromCodePoint')}} | {{Spec2('ES6')}} | Initial definition. |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/javascript/reference/global_objects/string/length/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/length/index.md
@@ -60,12 +60,7 @@ console.log(myString);
 
 ## Especificaciones
 
-| Especificación                                                                                                                   | Estatus                      | Comentario                                          |
-| -------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | --------------------------------------------------- |
-| ECMAScript 1st Edition.                                                                                                          | Estándar                     | Primera definicíon. Implementado en JavaScript 1.0. |
-| {{SpecName('ES5.1', '#sec-15.5.5.1', 'String.prototype.length')}}                                         | {{Spec2('ES5.1')}}     |                                                     |
-| {{SpecName('ES6', '#sec-properties-of-string-instances-length', 'String.prototype.length')}}     | {{Spec2('ES6')}}         |                                                     |
-| {{SpecName('ESDraft', '#sec-properties-of-string-instances-length', 'String.prototype.length')}} | {{Spec2('ESDraft')}} |                                                     |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/string/matchall/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/matchall/index.md
@@ -114,9 +114,7 @@ array[1];
 
 ## Especificaciones
 
-| Especificación                                                                                                       | Estado                       | Comentario |
-| -------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ---------- |
-| {{SpecName('ESDraft', '#sec-string.prototype.matchall', 'String.prototype.matchAll')}} | {{Spec2('ESDraft')}} |            |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/javascript/reference/global_objects/string/normalize/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/normalize/index.md
@@ -90,10 +90,7 @@ str.normalize('NFKD'); // '\u0073\u0323\u0307'
 
 ## Especificaciones
 
-| Especificación                                                                                                       | Estado                       | Comentario          |
-| -------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('ES2015', '#sec-string.prototype.normalize', 'String.prototype.normalize')}} | {{Spec2('ES2015')}}     | Definición inicial. |
-| {{SpecName('ESDraft', '#sec-string.prototype.normalize', 'String.prototype.normalize')}} | {{Spec2('ESDraft')}} |                     |
+{{Specifications}}
 
 ## Compatibilidad de Navegadores
 

--- a/files/es/web/javascript/reference/global_objects/string/raw/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/raw/index.md
@@ -74,12 +74,9 @@ String.raw({
 }, 2 + 3, 'Java' + 'Script'); // 'foo5barJavaScriptbaz'
 ```
 
-## Especificaciónes
+## Especificaciones
 
-| Especificación                                                               | Estado                       | Comentario          |
-| ---------------------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('ES2015', '#sec-string.raw', 'String.raw')}}     | {{Spec2('ES2015')}}     | Definicion inicial. |
-| {{SpecName('ESDraft', '#sec-string.raw', 'String.raw')}} | {{Spec2('ESDraft')}} |                     |
+{{Specifications}}
 
 ## Compatibilidad de navegador
 

--- a/files/es/web/javascript/reference/global_objects/string/repeat/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/repeat/index.md
@@ -100,10 +100,7 @@ if (!String.prototype.repeat) {
 
 ## Especificaciones
 
-| Especificación                                                                                               | Estado                       | Comentarios         |
-| ------------------------------------------------------------------------------------------------------------ | ---------------------------- | ------------------- |
-| {{SpecName('ES6', '#sec-string.prototype.repeat', 'String.prototype.repeat')}}     | {{Spec2('ES2015')}}     | Definición inicial. |
-| {{SpecName('ESDraft', '#sec-string.prototype.repeat', 'String.prototype.repeat')}} | {{Spec2('ESDraft')}} |                     |
+{{Specifications}}
 
 ## Compatibilidad en Navegadores
 

--- a/files/es/web/javascript/reference/global_objects/string/search/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/search/index.md
@@ -57,12 +57,7 @@ function testinput(re, str) {
 
 ## Especificaciones
 
-| Especificaciones                                                                                             | Estado                       | Comentario                                          |
-| ------------------------------------------------------------------------------------------------------------ | ---------------------------- | --------------------------------------------------- |
-| {{SpecName('ES3')}}                                                                                     | {{Spec2('ES3')}}         | Definición inicial. Implementado en JavaScript 1.2. |
-| {{SpecName('ES5.1', '#sec-15.5.4.12', 'String.prototype.search')}}                     | {{Spec2('ES5.1')}}     |                                                     |
-| {{SpecName('ES6', '#sec-string.prototype.search', 'String.prototype.search')}}     | {{Spec2('ES6')}}         |                                                     |
-| {{SpecName('ESDraft', '#sec-string.prototype.search', 'String.prototype.search')}} | {{Spec2('ESDraft')}} |                                                     |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/global_objects/string/slice/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/slice/index.md
@@ -74,12 +74,7 @@ cad.slice(0, -1);  // retorna 'La mañana se nos echa encima'
 
 ## Especificaciones
 
-| Especificación                                                                                               | Estado                       | Comentario                                          |
-| ------------------------------------------------------------------------------------------------------------ | ---------------------------- | --------------------------------------------------- |
-| {{SpecName('ES3')}}                                                                                     | {{Spec2('ES3')}}         | Definición inicial. Implementado en JavaScript 1.2. |
-| {{SpecName('ES5.1', '#sec-15.5.4.13', 'String.prototype.slice')}}                     | {{Spec2('ES5.1')}}     |                                                     |
-| {{SpecName('ES6', '#sec-string.prototype.slice', 'String.prototype.slice')}}         | {{Spec2('ES6')}}         |                                                     |
-| {{SpecName('ESDraft', '#sec-string.prototype.slice', 'String.prototype.slice')}} | {{Spec2('ESDraft')}} |                                                     |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/javascript/reference/global_objects/string/split/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/split/index.md
@@ -149,13 +149,9 @@ var strReverse = str.split('').reverse().join(''); // 'lkjhgfdsa'
 
 **Extra:** usar el operador [===](</es/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Identity_.2F_strict_equality_(.3D.3D.3D)>) para verificar si la cadena anterior era un palíndromo.
 
-## Specifications
+## Especificaciones
 
-| Especificación                                                                                       | Estado                   | Comentario                                          |
-| ---------------------------------------------------------------------------------------------------- | ------------------------ | --------------------------------------------------- |
-| ECMAScript 3rd Edition.                                                                              | Estándar                 | Definición inicial. Implementado en JavaScript 1.1. |
-| {{SpecName('ES5.1', '#sec-15.5.4.14', 'String.prototype.split')}}             | {{Spec2('ES5.1')}} |                                                     |
-| {{SpecName('ES6', '#sec-string.prototype.split', 'String.prototype.split')}} | {{Spec2('ES6')}}     |                                                     |
+{{Specifications}}
 
 ## Compatibilidad con los navegadores
 

--- a/files/es/web/javascript/reference/global_objects/string/tolocalelowercase/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/tolocalelowercase/index.md
@@ -57,13 +57,7 @@ let locales = ['tr', 'TR', 'tr-TR', 'tr-u-co-search', 'tr-x-turkish'];
 
 ## Especificaciones
 
-| Especificación                                                                                                                                   | Estatus                          | Comentario                                         |
-| ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- | -------------------------------------------------- |
-| {{SpecName('ES3')}}                                                                                                                         | {{Spec2('ES3')}}             | Initial definition. Implemented in JavaScript 1.2. |
-| {{SpecName('ES5.1', '#sec-15.5.4.17', 'String.prototype.toLocaleLowerCase')}}                                         | {{Spec2('ES5.1')}}         |                                                    |
-| {{SpecName('ES6', '#sec-string.prototype.tolocalelowercase', 'String.prototype.toLocaleLowerCase')}}             | {{Spec2('ES6')}}             |                                                    |
-| {{SpecName('ESDraft', '#sec-string.prototype.tolocalelowercase', 'String.prototype.toLocaleLowerCase')}}     | {{Spec2('ESDraft')}}     |                                                    |
-| {{SpecName('ES Int Draft', '#sup-string.prototype.tolocalelowercase', 'String.prototype.toLocaleLowerCase')}} | {{Spec2('ES Int Draft')}} | ES Intl 2017 added the `locale` parameter.         |
+{{Specifications}}
 
 ## Compatibilidad entre navegadores
 

--- a/files/es/web/javascript/reference/global_objects/string/tolocaleuppercase/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/tolocaleuppercase/index.md
@@ -50,13 +50,7 @@ let locales = ['lt', 'LT', 'lt-LT', 'lt-u-co-phonebk', 'lt-x-lietuva'];
 
 ## Especificaciones
 
-| Especificación                                                                                                                                   | Status                           | Comentario                                         |
-| ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- | -------------------------------------------------- |
-| {{SpecName('ES3')}}                                                                                                                         | {{Spec2('ES3')}}             | Initial definition. Implemented in JavaScript 1.2. |
-| {{SpecName('ES5.1', '#sec-15.5.4.19', 'String.prototype.toLocaleUpperCase')}}                                         | {{Spec2('ES5.1')}}         |                                                    |
-| {{SpecName('ES6', '#sec-string.prototype.tolocaleuppercase', 'String.prototype.toLocaleUpperCase')}}             | {{Spec2('ES6')}}             |                                                    |
-| {{SpecName('ESDraft', '#sec-string.prototype.tolocaleuppercase', 'String.prototype.toLocaleUpperCase')}}     | {{Spec2('ESDraft')}}     |                                                    |
-| {{SpecName('ES Int Draft', '#sup-string.prototype.tolocaleuppercase', 'String.prototype.toLocaleUpperCase')}} | {{Spec2('ES Int Draft')}} | ES Intl 2017 added the `locale` parameter.         |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/javascript/reference/global_objects/string/trim/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/trim/index.md
@@ -57,10 +57,7 @@ if (!String.prototype.trim) {
 
 ## Especificaciones
 
-| Especificación                                                                                       | Estatus                  | Comentario                                            |
-| ---------------------------------------------------------------------------------------------------- | ------------------------ | ----------------------------------------------------- |
-| {{SpecName('ES5.1', '#sec-15.5.4.20', 'String.prototype.trim')}}                 | {{Spec2('ES5.1')}} | Definición inicial. Implementado en JavaScript 1.8.1. |
-| {{SpecName('ES6', '#sec-string.prototype.trim', 'String.prototype.trim')}} | {{Spec2('ES6')}}     |                                                       |
+{{Specifications}}
 
 ## Compatibilidad en Navegadores
 

--- a/files/es/web/javascript/reference/global_objects/undefined/index.md
+++ b/files/es/web/javascript/reference/global_objects/undefined/index.md
@@ -105,12 +105,7 @@ if (y === void 0) {
 
 ## Especificaciones
 
-| Especificación                                                           | Estado                       | Comentario                                          |
-| ------------------------------------------------------------------------ | ---------------------------- | --------------------------------------------------- |
-| {{SpecName('ES1', '#sec-4.3.9', 'undefined')}}             | {{Spec2('ES1')}}         | Definición inicial. Implementado en JavaScript 1.3. |
-| {{SpecName('ES5.1', '#sec-15.1.1.3', 'undefined')}}     | {{Spec2('ES5.1')}}     |                                                     |
-| {{SpecName('ES6', '#sec-undefined', 'undefined')}}     | {{Spec2('ES6')}}         |                                                     |
-| {{SpecName('ESDraft', '#sec-undefined', 'undefined')}} | {{Spec2('ESDraft')}} |                                                     |
+{{Specifications}}
 
 ## Compatibilidad en Navegadores
 

--- a/files/es/web/javascript/reference/global_objects/unescape/index.md
+++ b/files/es/web/javascript/reference/global_objects/unescape/index.md
@@ -34,14 +34,9 @@ unescape("%E4%F6%FC");  // "äöü"
 unescape("%u0107");     // "ć"
 ```
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                    | Status                       | Comment                                                                                |
-| -------------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------------------------------------------- |
-| {{SpecName('ES1', '#sec-15.1.2.5', 'unescape')}}                 | {{Spec2('ES1')}}         | Initial definition.                                                                    |
-| {{SpecName('ES5.1', '#sec-B.2.2', 'unescape')}}                 | {{Spec2('ES5.1')}}     | Defined in the (informative) Compatibility Annex B                                     |
-| {{SpecName('ES6', '#sec-unescape-string', 'unescape')}}         | {{Spec2('ES6')}}         | Defined in the (normative) Annex B for Additional ECMAScript Features for Web Browsers |
-| {{SpecName('ESDraft', '#sec-unescape-string', 'unescape')}} | {{Spec2('ESDraft')}} | Defined in the (normative) Annex B for Additional ECMAScript Features for Web Browsers |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/javascript/reference/statements/async_function/index.md
+++ b/files/es/web/javascript/reference/statements/async_function/index.md
@@ -127,10 +127,7 @@ Observe que, en el ejemplo anterior, no hay ninguna instrucción `await` dentro 
 
 ## Especificaciones
 
-| Especificación                                                                                       | Estado                       | Comentario                    |
-| ---------------------------------------------------------------------------------------------------- | ---------------------------- | ----------------------------- |
-| {{SpecName('ESDraft', '#sec-async-function-definitions', 'Función async')}} | {{Spec2('ESDraft')}} | Definición inicial en ES2017. |
-| {{SpecName('ES8', '#sec-async-function-definitions', 'Función async')}}     | {{Spec2('ES8')}}         |                               |
+{{Specifications}}
 
 ## Compatibilidad entre navegadores
 

--- a/files/es/web/javascript/reference/statements/class/index.md
+++ b/files/es/web/javascript/reference/statements/class/index.md
@@ -50,10 +50,7 @@ class Square extends Polygon {
 
 ## Especificaciones
 
-| Especificación                                                                               | Estado                       | Comentarios         |
-| -------------------------------------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('ES6', '#sec-class-definitions', 'Class definitions')}}     | {{Spec2('ES6')}}         | Definición inicial. |
-| {{SpecName('ESDraft', '#sec-class-definitions', 'Class definitions')}} | {{Spec2('ESDraft')}} |                     |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/javascript/reference/statements/debugger/index.md
+++ b/files/es/web/javascript/reference/statements/debugger/index.md
@@ -36,13 +36,7 @@ Cuando el depurador es invocado, la ejecución se detiene en la sentencia debugg
 
 ## Especificaciones
 
-| Specification                                                                                    | Status                       | Comment                                |
-| ------------------------------------------------------------------------------------------------ | ---------------------------- | -------------------------------------- |
-| {{SpecName('ESDraft', '#sec-debugger-statement', 'Debugger statement')}} | {{Spec2('ESDraft')}} |                                        |
-| {{SpecName('ES6', '#sec-debugger-statement', 'Debugger statement')}}     | {{Spec2('ES6')}}         |                                        |
-| {{SpecName('ES5.1', '#sec-12.15', 'Debugger statement')}}                     | {{Spec2('ES5.1')}}     | Definición inicial                     |
-| {{SpecName('ES3', '#sec-7.5.3', 'Debugger statement')}}                         | {{Spec2('ES3')}}         |                                        |
-| {{SpecName('ES1', '#sec-7.4.3', 'Debugger statement')}}                         | {{Spec2('ES1')}}         | Solo mencionada como palabra reservada |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/statements/empty/index.md
+++ b/files/es/web/javascript/reference/statements/empty/index.md
@@ -54,13 +54,7 @@ console.log(b); // 0
 
 ## Especificaciones
 
-| Especificación                                                                           | Estado                       | Comentario          |
-| ---------------------------------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('ESDraft', '#sec-empty-statement', 'Empty statement')}} | {{Spec2('ESDraft')}} |                     |
-| {{SpecName('ES6', '#sec-empty-statement', 'Empty statement')}}     | {{Spec2('ES6')}}         |                     |
-| {{SpecName('ES5.1', '#sec-12.3', 'Empty statement')}}                 | {{Spec2('ES5.1')}}     |                     |
-| {{SpecName('ES3', '#sec-12.3', 'Empty statement')}}                     | {{Spec2('ES3')}}         |                     |
-| {{SpecName('ES1', '#sec-12.3', 'Empty statement')}}                     | {{Spec2('ES1')}}         | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad en Navegadores
 

--- a/files/es/web/javascript/reference/statements/export/index.md
+++ b/files/es/web/javascript/reference/statements/export/index.md
@@ -158,10 +158,7 @@ Tenga en cuenta que no es posible usar `var`, `let` o `const` con `export defaul
 
 ## Especificaciones
 
-| Especificación                                                       | Estado                       | Comentario          |
-| -------------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('ES6', '#sec-exports', 'Exports')}}         | {{Spec2('ES6')}}         | Definición inicial. |
-| {{SpecName('ESDraft', '#sec-exports', 'Exports')}} | {{Spec2('ESDraft')}} |                     |
+{{Specifications}}
 
 ## Compatiblidad en navegadores
 

--- a/files/es/web/javascript/reference/statements/for-await...of/index.md
+++ b/files/es/web/javascript/reference/statements/for-await...of/index.md
@@ -122,9 +122,7 @@ getResponseSize('https://jsonplaceholder.typicode.com/photos');
 
 ## Especificaciones
 
-| Especificación                                                                                                                                                                   | Estado                       | Comentarios |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ----------- |
-| {{SpecName('ESDraft', '#sec-for-in-and-for-of-statements', 'ECMAScript Language: The for-in, for-of, and for-await-of Statements')}} | {{Spec2('ESDraft')}} |             |
+{{Specifications}}
 
 ## Compatibilidad de Navegadores
 

--- a/files/es/web/javascript/reference/statements/for...of/index.md
+++ b/files/es/web/javascript/reference/statements/for...of/index.md
@@ -250,10 +250,7 @@ for (let i of arr) {
 
 ## Especificaciones
 
-| Especificación                                                                                               | Estado                       | Cometario           |
-| ------------------------------------------------------------------------------------------------------------ | ---------------------------- | ------------------- |
-| {{SpecName('ES6', '#sec-for-in-and-for-of-statements', 'for...of statement')}}     | {{Spec2('ES6')}}         | Definición inicial. |
-| {{SpecName('ESDraft', '#sec-for-in-and-for-of-statements', 'for...of statement')}} | {{Spec2('ESDraft')}} |                     |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/javascript/reference/statements/function_star_/index.md
+++ b/files/es/web/javascript/reference/statements/function_star_/index.md
@@ -86,9 +86,7 @@ console.log(gen.next().value); // 20
 
 ## Especificaciones
 
-| Especificaciones                                     | Status                   | Comentarios         |
-| ---------------------------------------------------- | ------------------------ | ------------------- |
-| {{SpecName('ES2015', '#', 'function*')}} | {{Spec2('ES2015')}} | Initial definition. |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/javascript/reference/statements/import/index.md
+++ b/files/es/web/javascript/reference/statements/import/index.md
@@ -160,10 +160,7 @@ getUsefulContents('http://www.example.com',
 
 ## Especificaciones
 
-| Especificación                                                       | Estado                       | Comentario        |
-| -------------------------------------------------------------------- | ---------------------------- | ----------------- |
-| {{SpecName('ES6', '#sec-imports', 'Imports')}}         | {{Spec2('ES6')}}         | Definición inical |
-| {{SpecName('ESDraft', '#sec-imports', 'Imports')}} | {{Spec2('ESDraft')}} |                   |
+{{Specifications}}
 
 ## Compatibilidad entre navegadores
 

--- a/files/es/web/javascript/reference/statements/index.md
+++ b/files/es/web/javascript/reference/statements/index.md
@@ -89,13 +89,7 @@ Puedes encontrarlas por orden alfabético en la columna de la izquierda .
 
 ## Especificaciones
 
-| Especificación                                                                                                                                                                   | Status                       | Comentario                                     |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ---------------------------------------------- |
-| {{SpecName('ES1', '#sec-12', 'Statements')}}                                                                                                                     | {{Spec2('ES1')}}         | Definición inicial                             |
-| {{SpecName('ES3', '#sec-12', 'Statements')}}                                                                                                                     | {{Spec2('ES3')}}         |                                                |
-| {{SpecName('ES5.1', '#sec-12', 'Statements')}}                                                                                                                     | {{Spec2('ES5.1')}}     |                                                |
-| {{SpecName('ES6', '#sec-ecmascript-language-statements-and-declarations', 'ECMAScript Language: Statements and Declarations')}}         | {{Spec2('ES6')}}         | Nuevo: function\*, let, for...of, yield, class |
-| {{SpecName('ESDraft', '#sec-ecmascript-language-statements-and-declarations', 'ECMAScript Language: Statements and Declarations')}} | {{Spec2('ESDraft')}} |                                                |
+{{Specifications}}
 
 ## Vea También
 

--- a/files/es/webassembly/index.md
+++ b/files/es/webassembly/index.md
@@ -71,9 +71,7 @@ Y lo mejor es que está siendo desarrollado como un estándar web a través del 
 
 ## Especificaciones
 
-| Especificación                           | Estado                               | Comentarios                                                |
-| ---------------------------------------- | ------------------------------------ | ---------------------------------------------------------- |
-| {{SpecName('WebAssembly JS')}} | {{Spec2('WebAssembly JS')}} | Borrador inicial de la definición de la API de JavaScript. |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/webassembly/javascript_interface/index.md
+++ b/files/es/webassembly/javascript_interface/index.md
@@ -82,9 +82,7 @@ fetch('simple.wasm').then(response =>
 
 ## Especificaciones
 
-| Especificación                                                                                   | Estado                               | Comentario                       |
-| ------------------------------------------------------------------------------------------------ | ------------------------------------ | -------------------------------- |
-| {{SpecName('WebAssembly JS', '#the-webassembly-object', 'WebAssembly')}} | {{Spec2('WebAssembly JS')}} | Definición inicial del borrador. |
+{{Specifications}}
 
 ## Compatibilidad de Navegadores
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove deprecated spec2 macro from es

Process: replace the section with the `{{Specifications}}` macro

### Motivation

The chore of deprecated macros removal

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Relates to https://github.com/orgs/mdn/discussions/263
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
