### PR TITLE
 Remove deprecated spec2 macro from es 5/9

### DIFF
--- a/files/es/orphaned/web/api/globaleventhandlers/index.md
+++ b/files/es/orphaned/web/api/globaleventhandlers/index.md
@@ -214,13 +214,7 @@ _Esta interfaz no define métodos_
 
 ## Especificaciones
 
-| Especificación                                                                                                                   | Estado                               | Comentario                                                                                                                                             |
-| -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| {{SpecName("Selection API",'', 'Extensión a GlobalEventHandlers')}}                                     | {{Spec2('Selection API')}} | Agrega `en el cambio de selección.`                                                                                                                    |
-| {{SpecName('Pointer Lock', '#extensions-to-the-document-interface', 'Extensión de Document')}} | {{Spec2('Pointer Lock')}}     | Agrega `onpointerlockchange` y `onpointerlockerror` en {{DOMxRef("Document")}}. Está implementado experimentalmente en `GlobalEventHandlers`. |
-| {{SpecName('HTML WHATWG', '#globaleventhandlers', 'GlobalEventHandlers')}}                             | {{ Spec2('HTML WHATWG') }} | Sin cambios desde la última instantánea, {{SpecName("HTML5.1")}}.                                                                             |
-| {{SpecName('HTML5.1', '#globaleventhandlers', 'GlobalEventHandlers')}}                                     | {{Spec2('HTML5.1')}}         | Instantánea de {{SpecName("HTML WHATWG")}}. Agregó `onsort` desde la instantánea de {{SpecName("HTML5 W3C")}}.                         |
-| {{SpecName("HTML5 W3C", "#globaleventhandlers", "GlobalEventHandlers")}}                                 | {{ Spec2('HTML5 W3C') }}     | Instantánea de {{SpecName("HTML WHATWG")}}. Creación de `GlobalEventHandlers` (propiedades en el destino anterior).                           |
+{{Specifications}}
 
 ## Compatibilidad del navegador
 

--- a/files/es/orphaned/web/api/htmlorforeignelement/focus/index.md
+++ b/files/es/orphaned/web/api/htmlorforeignelement/focus/index.md
@@ -109,15 +109,9 @@ focusNoScrollMethod = function getFocusWithoutScrolling() {
 
 {{ EmbedLiveSample('Focus_prevent_scroll') }}
 
-## Especificación
+## Especificaciones
 
-| Especificación                                                                           | Estado                           | Comentarios |
-| ---------------------------------------------------------------------------------------- | -------------------------------- | ----------- |
-| {{SpecName('HTML WHATWG', 'editing.html#dom-focus', 'focus')}}     | {{Spec2('HTML WHATWG')}} |             |
-| {{SpecName('HTML5.1', 'editing.html#focus()-0', 'focus')}}             | {{Spec2('HTML5.1')}}     |             |
-| {{SpecName('HTML5 W3C', 'editing.html#dom-focus', 'focus')}}         | {{Spec2('HTML5 W3C')}}     |             |
-| {{SpecName('DOM2 HTML', 'html.html#ID-32130014', 'focus')}}         | {{Spec2('DOM2 HTML')}}     |             |
-| {{SpecName('DOM1', 'level-one-html.html#method-focus', 'focus')}} | {{Spec2('DOM1')}}         |             |
+{{Specifications}}
 
 ## Notas
 

--- a/files/es/orphaned/web/api/navigatorconcurrenthardware/hardwareconcurrency/index.md
+++ b/files/es/orphaned/web/api/navigatorconcurrenthardware/hardwareconcurrency/index.md
@@ -41,11 +41,9 @@ for (let i = 0; i < window.navigator.hardwareConcurrency; i++) {
 }
 ```
 
-## Specification
+## Especificaciones
 
-| Specification                                                                                                                        | Status                           | Comment             |
-| ------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- | ------------------- |
-| {{SpecName('HTML WHATWG', '#dom-navigator-hardwareconcurrency', 'navigator.hardwareConcurrency')}} | {{Spec2('HTML WHATWG')}} | Initial definition. |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/orphaned/web/api/navigatorconcurrenthardware/index.md
+++ b/files/es/orphaned/web/api/navigatorconcurrenthardware/index.md
@@ -38,11 +38,9 @@ The number of **logical processor cores** is a way to measure the number of thre
 
 _The `NavigatorConcurrentHardware`_ _mixin has no methods._
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                                                            | Status                           | Comment             |
-| ------------------------------------------------------------------------------------------------------------------------ | -------------------------------- | ------------------- |
-| {{SpecName('HTML WHATWG', '#navigatorconcurrenthardware', 'NavigatorConcurrentHardware')}} | {{Spec2('HTML WHATWG')}} | Initial definition. |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/orphaned/web/api/windoweventhandlers/index.md
+++ b/files/es/orphaned/web/api/windoweventhandlers/index.md
@@ -50,13 +50,9 @@ _The events properties, of the form `onXYZ`, are defined on the {{domxref("Windo
 
 _This interface defines no method._
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                                        | Status                           | Comment                                                                                                                         |
-| ---------------------------------------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| {{SpecName('HTML WHATWG', '#windoweventhandlers', 'GlobalEventHandlers')}} | {{Spec2('HTML WHATWG')}} | No change since the latest snapshot, {{SpecName("HTML5.1")}}.                                                          |
-| {{SpecName('HTML5.1', '#windoweventhandlers', 'GlobalEventHandlers')}}         | {{Spec2('HTML5.1')}}     | Snapshot of {{SpecName("HTML WHATWG")}}. Added `onlanguage` since the {{SpecName("HTML 5")}} snapshot.           |
-| {{SpecName("HTML5 W3C", "#windoweventhandlers", "GlobalEventHandlers")}}     | {{Spec2('HTML5 W3C')}}     | Snapshot of {{SpecName("HTML WHATWG")}}. Creation of `WindowEventHandlers` (properties where on the target before it). |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/orphaned/web/api/windoworworkerglobalscope/index.md
+++ b/files/es/orphaned/web/api/windoworworkerglobalscope/index.md
@@ -58,13 +58,7 @@ Estas propiedades se definen en el mixin {{domxref("WindowOrWorkerGlobalScope")}
 
 ## Especificaciones
 
-| Especificación                                                                                                                                                           | Estado                               | Comentario                                    |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------ | --------------------------------------------- |
-| {{SpecName("HTML WHATWG",'webappapis.html#windoworworkerglobalscope-mixin', '<code>WindowOrWorkerGlobalScope</code> mixin')}} | {{Spec2('HTML WHATWG')}}     | Aquí es donde se define el mixin principal.   |
-| {{SpecName('Fetch','#fetch-method','fetch()')}}                                                                                                         | {{Spec2('Fetch')}}             | Definición del método `fetch().`              |
-| {{SpecName('Service Workers', '#self-caches', 'caches')}}                                                                                             | {{Spec2('Service Workers')}} | Definición de la propiedad `caches`.          |
-| {{SpecName('IndexedDB 2', '#dom-windoworworkerglobalscope-indexeddb', 'indexedDB')}}                                                         | {{Spec2('IndexedDB 2')}}     | Definición de la propiedad `indexedDB`.       |
-| {{SpecName('Secure Contexts', 'webappapis.html#dom-origin', 'isSecureContext')}}                                                             | {{Spec2('Secure Contexts')}} | Definición de la propiedad `isSecureContext.` |
+{{Specifications}}
 
 ## Ver también
 

--- a/files/es/web/api/analysernode/index.md
+++ b/files/es/web/api/analysernode/index.md
@@ -136,11 +136,9 @@ function draw() {
     draw();
 ```
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                                        | Status                               | Comment |
-| ---------------------------------------------------------------------------------------------------- | ------------------------------------ | ------- |
-| {{SpecName('Web Audio API', '#the-analysernode-interface', 'AnalyserNode')}} | {{Spec2('Web Audio API')}} |         |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/api/animationevent/animationname/index.md
+++ b/files/es/web/api/animationevent/animationname/index.md
@@ -24,9 +24,7 @@ name = AnimationEvent.animationName
 
 ## Especificaciones
 
-| Especificación                                                                                                                       | Estatus                                  | Comentario          |
-| ------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------- | ------------------- |
-| {{ SpecName('CSS3 Animations', '#AnimationEvent-animationName', 'AnimationEvent.animationName') }} | {{ Spec2('CSS3 Animations')}} | Definición Inicial. |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/api/animationevent/index.md
+++ b/files/es/web/api/animationevent/index.md
@@ -41,9 +41,7 @@ _También hereda los métodos de su padre {{domxref("Event")}}_.
 
 ## Especificaciones
 
-| Especificación                                                                                               | Estatus                                  | Comentario          |
-| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------- | ------------------- |
-| {{ SpecName('CSS3 Animations', '#AnimationEvent-interface', 'AnimationEvent') }} | {{ Spec2('CSS3 Animations') }} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad de Navegadores
 

--- a/files/es/web/api/atob/index.md
+++ b/files/es/web/api/atob/index.md
@@ -23,13 +23,9 @@ var encodedData = window.btoa("Hello, world"); // encode a string
 var decodedData = window.atob(encodedData); // decode the string
 ```
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                                        | Status                           | Comment                                                                                                                  |
-| ---------------------------------------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| {{SpecName('HTML WHATWG', '#dom-windowbase64-atob', 'WindowBase64.atob()')}} | {{Spec2('HTML WHATWG')}} | No change since the latest snapshot, {{SpecName("HTML5.1")}}.                                                   |
-| {{SpecName('HTML5.1', '#dom-windowbase64-atob', 'WindowBase64.atob()')}}     | {{Spec2('HTML5.1')}}     | Snapshot of {{SpecName("HTML WHATWG")}}. No change.                                                             |
-| {{SpecName("HTML5 W3C", "#dom-windowbase64-atob", "WindowBase64.atob()")}} | {{Spec2('HTML5 W3C')}}     | Snapshot of {{SpecName("HTML WHATWG")}}. Creation of `WindowBase64` (properties where on the target before it). |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/api/audiobuffer/index.md
+++ b/files/es/web/api/audiobuffer/index.md
@@ -74,9 +74,7 @@ source.start();
 
 ## Especificaciones
 
-| Specification                                                                                        | Status                               | Comment             |
-| ---------------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------- |
-| {{SpecName('Web Audio API', '#the-audiobuffer-interface', 'AudioBuffer')}} | {{Spec2('Web Audio API')}} | Initial definition. |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/api/clearinterval/index.md
+++ b/files/es/web/api/clearinterval/index.md
@@ -21,10 +21,9 @@ window.clearInterval(intervalID)
 
 Vea el [ejemplo de`setInterval()`](/es/docs/DOM/window.setInterval#Example).
 
-## Especificación
+## Especificaciones
 
-| {{SpecName('HTML WHATWG', 'timers.html#timers', 'clearInterval')}} | {{Spec2('HTML WHATWG')}} |
-| ---------------------------------------------------------------------------------------- | -------------------------------- |
+{{Specifications}}
 
 ## Vea también
 

--- a/files/es/web/api/clipboard_api/index.md
+++ b/files/es/web/api/clipboard_api/index.md
@@ -33,9 +33,7 @@ Esta pieza de código lee el texto que hay en el portapapeles y lo añade al pri
 
 ## Especificaciones
 
-| Especificación                           | Estado                               | Observaciones         |
-| ---------------------------------------- | ------------------------------------ | --------------------- |
-| {{SpecName('Clipboard API')}} | {{Spec2('Clipboard API')}} | Definición primitiva. |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/api/comment/index.md
+++ b/files/es/web/api/comment/index.md
@@ -31,12 +31,7 @@ _Esta interfaz no tiene ninguna propiedad específica, pero hereda las de su pad
 
 ## Especificaciones
 
-| Specification                                                                                | Status                           | Comment                                         |
-| -------------------------------------------------------------------------------------------- | -------------------------------- | ----------------------------------------------- |
-| {{SpecName('DOM WHATWG', '#comment', 'Comment')}}                             | {{Spec2('DOM WHATWG')}} | Agregado el constructor.                        |
-| {{SpecName('DOM3 Core', 'core.html#ID-1728279322', 'Comment')}}         | {{Spec2('DOM3 Core')}}     | Sin cambios de {{SpecName('DOM2 Core')}} |
-| {{SpecName('DOM2 Core', 'core.html#ID-1728279322', 'Comment')}}         | {{Spec2('DOM2 Core')}}     | Sin cambios de {{SpecName('DOM1')}}     |
-| {{SpecName('DOM1', 'level-one-core.html#ID-1728279322', 'Comment')}} | {{Spec2('DOM1')}}         | Definición inicial                              |
+{{Specifications}}
 
 ## Compatibilidad entre navegadores
 

--- a/files/es/web/api/createimagebitmap/index.md
+++ b/files/es/web/api/createimagebitmap/index.md
@@ -81,9 +81,7 @@ image.src = 'sprites.png';
 
 ## Especificaciones
 
-| Especificación                                                                                                           | Estado                           | Comentario |
-| ------------------------------------------------------------------------------------------------------------------------ | -------------------------------- | ---------- |
-| {{SpecName('HTML WHATWG', "webappapis.html#dom-createimagebitmap", "createImageBitmap")}} | {{Spec2('HTML WHATWG')}} |            |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/api/crypto/getrandomvalues/index.md
+++ b/files/es/web/api/crypto/getrandomvalues/index.md
@@ -45,11 +45,9 @@ for (var i = 0; i < array.length; i++) {
 }
 ```
 
-## Especificación
+## Especificaciones
 
-| Especificación                                                                               | Estado                               | Comentario         |
-| -------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------ |
-| {{SpecName('Web Crypto API', '#RandomSource-method-getRandomValues')}} | {{Spec2('Web Crypto API')}} | Definición Inicial |
+{{Specifications}}
 
 ## Compatibilidad del navegador
 

--- a/files/es/web/api/crypto/index.md
+++ b/files/es/web/api/crypto/index.md
@@ -31,9 +31,7 @@ _Esta interfaz implementa las propiedades definidas en {{domxref("RandomSource")
 
 ## Especificaciones
 
-| Especificación                                                                   | Estado                               | Comentario         |
-| -------------------------------------------------------------------------------- | ------------------------------------ | ------------------ |
-| {{SpecName("Web Crypto API", "#crypto-interface", "Crypto")}} | {{Spec2("Web Crypto API")}} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad del navegador
 

--- a/files/es/web/api/crypto/subtle/index.md
+++ b/files/es/web/api/crypto/subtle/index.md
@@ -23,9 +23,7 @@ var crypto = crypto.subtle;
 
 ## Especificaciones
 
-| Especificación                                                                       | Estado                                   | Comentario          |
-| ------------------------------------------------------------------------------------ | ---------------------------------------- | ------------------- |
-| {{ SpecName('Web Crypto API', '#dfn-Crypto', 'Crypto.subtle') }} | {{ Spec2('Web Crypto API') }} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad del navegador
 

--- a/files/es/web/api/crypto_property/index.md
+++ b/files/es/web/api/crypto_property/index.md
@@ -17,9 +17,7 @@ var cryptoObj = window.crypto || window.msCrypto; // para IE 11
 
 ## Especificaciones
 
-| Especificación                           | Estado                               | Comentario         |
-| ---------------------------------------- | ------------------------------------ | ------------------ |
-| {{SpecName('Web Crypto API')}} | {{Spec2('Web Crypto API')}} | Definición Inicial |
+{{Specifications}}
 
 ## Compatibilidad de Navegadores
 

--- a/files/es/web/api/cssstylerule/index.md
+++ b/files/es/web/api/cssstylerule/index.md
@@ -30,10 +30,7 @@ interface CSSStyleRule : CSSRule {
 
 ## Especificaciones
 
-| Especificación                                                                               | Estatus                          | Comentario  |
-| -------------------------------------------------------------------------------------------- | -------------------------------- | ----------- |
-| {{ SpecName('CSSOM', '#the-cssstylerule-interface', 'CSSStyleRule') }} | {{ Spec2('CSSOM') }}     | Sin cambios |
-| {{ SpecName('DOM2 Style', 'css.html#CSS-CSSStyleRule', 'CSSRule') }} | {{ Spec2('DOM2 Style') }} |             |
+{{Specifications}}
 
 ## Compatibilidad entre Navegadores
 

--- a/files/es/web/api/devicemotionevent/index.md
+++ b/files/es/web/api/devicemotionevent/index.md
@@ -36,9 +36,7 @@ window.addEventListener('devicemotion', function(event) {
 
 ## Especificaciones
 
-| Especificación                                                                                           | Estado                                   | Comentario          |
-| -------------------------------------------------------------------------------------------------------- | ---------------------------------------- | ------------------- |
-| {{SpecName("Device Orientation", "#devicemotionevent", "DeviceMotionEvent")}} | {{Spec2("Device Orientation")}} | Initial definition. |
+{{Specifications}}
 
 ## Compativilidad con los navegadores
 

--- a/files/es/web/api/documentfragment/index.md
+++ b/files/es/web/api/documentfragment/index.md
@@ -74,15 +74,9 @@ list.appendChild(fragment)
 
 {{EmbedLiveSample('Example')}}
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                                            | Status                                       | Comment                                                                           |
-| -------------------------------------------------------------------------------------------------------- | -------------------------------------------- | --------------------------------------------------------------------------------- |
-| {{SpecName('DOM WHATWG', '#interface-documentfragment', 'DocumentFragment')}} | {{Spec2('DOM WHATWG')}}             | Added the constructor and the implementation of {{domxref("ParentNode")}}. |
-| {{SpecName('Selectors API Level 1', '#the-apis', 'DocumentFragment')}}             | {{Spec2('Selectors API Level 1')}} | Added the `querySelector()` and `querySelectorAll()` methods.                     |
-| {{SpecName('DOM3 Core', 'core.html#ID-B63ED1A3', 'DocumentFragment')}}             | {{Spec2('DOM3 Core')}}                 | No change from {{SpecName('DOM2 Core')}}                                   |
-| {{SpecName('DOM2 Core', 'core.html#ID-B63ED1A3', 'DocumentFragment')}}             | {{Spec2('DOM2 Core')}}                 | No change from {{SpecName('DOM1')}}                                       |
-| {{SpecName('DOM1', 'level-one-core.html#ID-B63ED1A3', 'DocumentFragment')}}     | {{Spec2('DOM1')}}                     | Initial definition                                                                |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/api/element/touchstart_event/index.md
+++ b/files/es/web/api/element/touchstart_event/index.md
@@ -11,7 +11,7 @@ Un {{domxref("GlobalEventHandlers","global event handler")}} para el evento [`to
 
 {{SeeCompatTable}}
 
-> **Nota:** Este atributo _no_ ha sido estandarizado formalmente. Está especificado en la especificación {{SpecName('Touch Events 2')}} {{Spec2('Touch Events 2')}} y no en {{SpecName('Touch Events')}} {{Spec2('Touch Events')}}. Este atributo no está totalmente implementado.
+> **Nota:** Este atributo _no_ ha sido estandarizado formalmente. Está especificado en la especificación [Touch Events – Level 2](https://w3c.github.io/touch-events/) Draft y no en [Touch Events](https://www.w3.org/TR/touch-events/) Recommendation. Este atributo no está totalmente implementado.
 
 ## Sintaxis
 

--- a/files/es/web/api/eventsource/index.md
+++ b/files/es/web/api/eventsource/index.md
@@ -62,9 +62,7 @@ evtSource.onmessage = function(e) {
 
 ## Especificaciones
 
-| Especificación                                                                                               | Estado                           | Comentario |
-| ------------------------------------------------------------------------------------------------------------ | -------------------------------- | ---------- |
-| {{SpecName('HTML WHATWG', "comms.html#the-eventsource-interface", "EventSource")}} | {{Spec2('HTML WHATWG')}} |            |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/api/eventsource/open_event/index.md
+++ b/files/es/web/api/eventsource/open_event/index.md
@@ -27,9 +27,7 @@ evtSource.onopen = function() {
 
 ## Especificaciones
 
-| Especificación                                                                                           | Estado                           | Comentario         |
-| -------------------------------------------------------------------------------------------------------- | -------------------------------- | ------------------ |
-| {{SpecName('HTML WHATWG', "comms.html#handler-eventsource-onopen", "onopen")}} | {{Spec2('HTML WHATWG')}} | Initial definition |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/api/eventtarget/index.md
+++ b/files/es/web/api/eventtarget/index.md
@@ -25,11 +25,7 @@ Muchos objetivos de eventos tales como: elementos, documentos y ventanas, tambi√
 
 ## Especificaciones
 
-| Specification                                                                                                    | Status                           | Comment                                                                                     |
-| ---------------------------------------------------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------- |
-| {{SpecName('DOM WHATWG', '#interface-eventtarget', 'EventTarget')}}                         | {{Spec2('DOM WHATWG')}} | No change.                                                                                  |
-| {{SpecName('DOM3 Events', 'DOM3-Events.html#interface-EventTarget', 'EventTarget')}} | {{Spec2('DOM3 Events')}} | A few parameters are now optional (`listener`), or accepts the `null` value (`useCapture`). |
-| {{SpecName('DOM2 Events', 'events.html#Events-EventTarget', 'EventTarget')}}             | {{Spec2('DOM2 Events')}} | Initial definition.                                                                         |
+{{Specifications}}
 
 ## Compatibilidad
 

--- a/files/es/web/api/eventtarget/removeeventlistener/index.md
+++ b/files/es/web/api/eventtarget/removeeventlistener/index.md
@@ -129,11 +129,7 @@ mouseOverTarget.addEventListener('mouseover', function () {
 
 ## Especificaciones
 
-| Especificación                                                                                                                                   | Estado                           | Comentario         |
-| ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- | ------------------ |
-| {{SpecName("DOM WHATWG", "#dom-eventtarget-removeeventlistener", "EventTarget.removeEventListener()")}}         | {{Spec2("DOM WHATWG")}} |                    |
-| {{SpecName("DOM4", "#dom-eventtarget-removeeventlistener", "EventTarget.removeEventListener()")}}                 | {{Spec2("DOM4")}}         |                    |
-| {{SpecName("DOM2 Events", "#Events-EventTarget-removeEventListener", "EventTarget.removeEventListener()")}} | {{Spec2("DOM2 Events")}} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad de los navegadores
 

--- a/files/es/web/api/file/index.md
+++ b/files/es/web/api/file/index.md
@@ -61,9 +61,7 @@ _La interfaz `File` no define algún método, pero los hereda de la interfaz {{d
 
 ## Especificaciones
 
-| Especificación                   | Estado                       | Comentario          |
-| -------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('File API')}} | {{Spec2('File API')}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad en Navegadores
 

--- a/files/es/web/api/file/name/index.md
+++ b/files/es/web/api/file/name/index.md
@@ -46,9 +46,7 @@ Prueba el resultado:
 
 ## Especificaciones
 
-| Especificacion                                                   | Estado                       | Comentario          |
-| ---------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('File API', '#file-attrs', 'name')}} | {{Spec2('File API')}} | Definicion inicial. |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/api/file/webkitrelativepath/index.md
+++ b/files/es/web/api/file/webkitrelativepath/index.md
@@ -58,11 +58,7 @@ document.getElementById("filepicker").addEventListener("change", function(event)
 
 ## Especificaciones
 
-| Especificacion                                                                                                       | Estado                                   | Comentario              |
-| -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- | ----------------------- |
-| {{ SpecName('File System API', '#dom-file-webkitrelativepath', 'webkitRelativePath') }} | {{ Spec2('File System API') }} | Especificacion inicial. |
-
-Esta API no tiene especificacion W3C o WHATWG.
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/api/formdata/index.md
+++ b/files/es/web/api/formdata/index.md
@@ -49,9 +49,7 @@ Un objeto que implementa `FormData` puede usarse directamente en una estructura 
 
 ## Especificaciones
 
-| Especificación                                                                       | Estado                               | Comentario                    |
-| ------------------------------------------------------------------------------------ | ------------------------------------ | ----------------------------- |
-| {{SpecName('XMLHttpRequest','#interface-formdata','FormData')}} | {{Spec2('XMLHttpRequest')}} | FormData definido en XHR spec |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/api/fullscreen_api/index.md
+++ b/files/es/web/api/fullscreen_api/index.md
@@ -128,9 +128,7 @@ De momento, no todos los navegadores están implementando la versión sin prefij
 
 ## Especificaciones
 
-| Especificación                       | Estatus                          | Comentarios      |
-| ------------------------------------ | -------------------------------- | ---------------- |
-| {{SpecName("Fullscreen")}} | {{Spec2("Fullscreen")}} | Versión inicial. |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/api/gamepadbutton/index.md
+++ b/files/es/web/api/gamepadbutton/index.md
@@ -65,9 +65,7 @@ function gameLoop() {
 
 ## Especificaciones
 
-| Specification                                                                                | Status                       | Comment            |
-| -------------------------------------------------------------------------------------------- | ---------------------------- | ------------------ |
-| {{SpecName("Gamepad", "#gamepadbutton-interface", "GamepadButton")}} | {{Spec2("Gamepad")}} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad de Navegadores
 

--- a/files/es/web/api/htmlcanvaselement/getcontext/index.md
+++ b/files/es/web/api/htmlcanvaselement/getcontext/index.md
@@ -84,11 +84,7 @@ Ahora tienes el [contexto de renderizado 2D](/es/docs/Web/API/CanvasRenderingCon
 
 ## Especificaciones
 
-| Especificación                                                                                                                       | Estado                           | Comentarios                                                                           |
-| ------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- | ------------------------------------------------------------------------------------- |
-| {{SpecName('HTML WHATWG', "scripting.html#dom-canvas-getcontext", "HTMLCanvasElement.getContext")}} | {{Spec2('HTML WHATWG')}} | Sin cambios desde el último snapshot, {{SpecName('HTML5 W3C')}}                |
-| {{SpecName('HTML5.1', "scripting-1.html#dom-canvas-getcontext", "HTMLCanvasElement.getContext")}}     | {{Spec2('HTML5.1')}}     |                                                                                       |
-| {{SpecName('HTML5 W3C', "scripting-1.html#dom-canvas-getcontext", "HTMLCanvasElement.getContext")}} | {{Spec2('HTML5 W3C')}}     | Snapshot del {{SpecName('HTML WHATWG')}} que contiene la definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/api/htmlcanvaselement/height/index.md
+++ b/files/es/web/api/htmlcanvaselement/height/index.md
@@ -36,11 +36,7 @@ console.log(canvas.height); // 300
 
 ## Especificaciones
 
-| Especificación                                                                                                               | Status                           | Comentarios                                                                   |
-| ---------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ----------------------------------------------------------------------------- |
-| {{SpecName('HTML WHATWG', "scripting.html#attr-canvas-height", "HTMLCanvasElement.height")}} | {{Spec2('HTML WHATWG')}} | No hay cambios desde la ultima foto {{SpecName('HTML5 W3C')}}          |
-| {{SpecName('HTML5.1', "scripting-1.html#attr-canvas-height", "HTMLCanvasElement.height")}}     | {{Spec2('HTML5.1')}}     |                                                                               |
-| {{SpecName('HTML5 W3C', "scripting-1.html#attr-canvas-height", "HTMLCanvasElement.height")}} | {{Spec2('HTML5 W3C')}}     | Foto que contiene la definición inicial {{SpecName('HTML WHATWG')}}. |
+{{Specifications}}
 
 ## Compatibilidad de Navegadores
 

--- a/files/es/web/api/htmlcanvaselement/index.md
+++ b/files/es/web/api/htmlcanvaselement/index.md
@@ -39,12 +39,7 @@ _Herada métodos de la interfaz padre,_ _{{domxref("HTMLElement")}}._
 
 ## Especificaciones
 
-| Especificación                                                                                                                                       | Estado                                               | Comentario                                                                                                                                                                                                                  |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| {{SpecName('Media Capture DOM Elements', '#html-media-element-media-capture-extensions', 'HTMLCanvasElement')}} | {{Spec2('Media Capture DOM Elements')}} | Añade el método `captureStream()`.                                                                                                                                                                                          |
-| {{SpecName('HTML WHATWG', "#the-canvas-element", "HTMLCanvasElement")}}                                                     | {{Spec2('HTML WHATWG')}}                     | El método `getContext()` ahora retorna un objeto {{domxref("RenderingContext")}} en vez de un objeto opaco. Los métodos `probablySupportsContext()`, `setContext()` y `transferControlToProxy() han sido añadidos`. |
-| {{SpecName('HTML5.1', "scripting-1.html#the-canvas-element", "HTMLCanvasElement")}}                                     | {{Spec2('HTML5.1')}}                         |                                                                                                                                                                                                                             |
-| {{SpecName('HTML5 W3C', "scripting-1.html#the-canvas-element", "HTMLCanvasElement")}}                                     | {{Spec2('HTML5 W3C')}}                         | Definición Inicial.                                                                                                                                                                                                         |
+{{Specifications}}
 
 ## Compatibilidad en Navegadores
 

--- a/files/es/web/api/htmlcanvaselement/todataurl/index.md
+++ b/files/es/web/api/htmlcanvaselement/todataurl/index.md
@@ -121,11 +121,7 @@ function quitarColor() {
 
 ## Especificaciones
 
-| Especificación                                                                                                                   | Estado                           | Comentarios                                                                  |
-| -------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ---------------------------------------------------------------------------- |
-| {{SpecName('HTML WHATWG', "scripting.html#dom-canvas-todataurl", "HTMLCanvasElement.toDataURL")}} | {{Spec2('HTML WHATWG')}} | Sin cambios desde el último snapshot, {{SpecName('HTML5 W3C')}}       |
-| {{SpecName('HTML5.1', "scripting-1.html#dom-canvas-todataurl", "HTMLCanvasElement.toDataURL")}} | {{Spec2('HTML5.1')}}     |                                                                              |
-| {{SpecName('HTML5 W3C', "scripting-1.html#dom-canvas-todataurl", "HTMLCanvasElement.toDataURL")}} | {{Spec2('HTML5 W3C')}}     | Snapshot del {{SpecName('HTML WHATWG')}} con la definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/api/htmlcanvaselement/width/index.md
+++ b/files/es/web/api/htmlcanvaselement/width/index.md
@@ -34,11 +34,7 @@ console.log(canvas.width); // 300
 
 ## Especificaciones
 
-| Especificación                                                                                                           | Status                           | Comentarios                                                                   |
-| ------------------------------------------------------------------------------------------------------------------------ | -------------------------------- | ----------------------------------------------------------------------------- |
-| {{SpecName('HTML WHATWG', "scripting.html#attr-canvas-width", "HTMLCanvasElement.width")}} | {{Spec2('HTML WHATWG')}} | No hay cambios desde la ultima foto {{SpecName('HTML5 W3C')}}          |
-| {{SpecName('HTML5.1', "scripting-1.html#attr-canvas-width", "HTMLCanvasElement.width")}}     | {{Spec2('HTML5.1')}}     |                                                                               |
-| {{SpecName('HTML5 W3C', "scripting-1.html#attr-canvas-width", "HTMLCanvasElement.width")}} | {{Spec2('HTML5 W3C')}}     | Foto que contiene la definición inicial {{SpecName('HTML WHATWG')}}. |
+{{Specifications}}
 
 ## Compatibilidad de Navegadores
 

--- a/files/es/web/api/htmlcollection/index.md
+++ b/files/es/web/api/htmlcollection/index.md
@@ -57,13 +57,9 @@ alert(elem1 === elem2); // muestra: "true"
 elem1 = document.forms["named.item.with.periods"];
 ```
 
-## Especificación
+## Especificaciones
 
-| Especificación                                                                                   | Estado                           | Comentario          |
-| ------------------------------------------------------------------------------------------------ | -------------------------------- | ------------------- |
-| {{SpecName('DOM WHATWG', '#htmlcollection', 'HTMLCollection')}}             | {{ Spec2('DOM WHATWG') }} |                     |
-| {{SpecName('DOM2 HTML', 'html.html#ID-75708506', 'HTMLCollection')}}     | {{ Spec2('DOM2 HTML') }} |                     |
-| {{SpecName('DOM1', 'level-one-html.html#ID-75708506', 'HTMLCollection')}} | {{ Spec2('DOM1') }}         | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/api/htmldialogelement/close_event/index.md
+++ b/files/es/web/api/htmldialogelement/close_event/index.md
@@ -30,9 +30,7 @@ window.onclose = resetThatServerThing;
 
 ## Especificaciones
 
-| Especificación                                                                                   | Estado                           | Comentario |
-| ------------------------------------------------------------------------------------------------ | -------------------------------- | ---------- |
-| {{SpecName('HTML WHATWG','webappapis.html#handler-onclose','onclose')}} | {{Spec2('HTML WHATWG')}} |            |
+{{Specifications}}
 
 ## Compatibilidad con Navegadores
 

--- a/files/es/web/api/htmlheadelement/index.md
+++ b/files/es/web/api/htmlheadelement/index.md
@@ -23,13 +23,7 @@ _No hay un método especifico; hereda los métodos del padre, {{domxref("HTMLEle
 
 ## Especificaciones
 
-| Especificación                                                                                                       | Estado                           | Comentarios                                         |
-| -------------------------------------------------------------------------------------------------------------------- | -------------------------------- | --------------------------------------------------- |
-| {{SpecName('HTML WHATWG', "#htmlheadelement", "HTMLHeadElement")}}                             | {{Spec2('HTML WHATWG')}} |                                                     |
-| {{SpecName('HTML5.1', "document-metadata.html#the-head-element", "HTMLHeadElement")}}     | {{Spec2('HTML5.1')}}     | Sin cambio desde {{SpecName('HTML5 W3C')}}.  |
-| {{SpecName('HTML5 W3C', "document-metadata.html#the-head-element", "HTMLHeadElement")}} | {{Spec2('HTML5 W3C')}}     | La siguiente propiedad ha sido removida: `profile`. |
-| {{SpecName('DOM2 HTML', 'html.html#ID-77253168', 'HTMLHeadElement')}}                         | {{Spec2('DOM2 HTML')}}     | Sin cambio                                          |
-| {{SpecName('DOM1', 'level-one-html.html#ID-77253168', 'HTMLHeadElement')}}                 | {{Spec2('DOM1')}}         | Definición inicial                                  |
+{{Specifications}}
 
 ## Compatibilidad con Navegadores
 

--- a/files/es/web/api/htmllielement/index.md
+++ b/files/es/web/api/htmllielement/index.md
@@ -26,12 +26,7 @@ _No specific method; inherits properties from its parent, {{domxref("HTMLElement
 
 ## Especificaciones
 
-| Especificacion                                                                                                   | Estado                           | Comentario                                       |
-| ---------------------------------------------------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------ |
-| {{SpecName('HTML WHATWG', "grouping-content.html#the-li-element", "HTMLLIElement")}} | {{Spec2('HTML WHATWG')}} | No change from {{SpecName("HTML5 W3C")}}. |
-| {{SpecName('HTML5 W3C', "grouping-content.html#the-li-element", "HTMLLIElement")}}     | {{Spec2('HTML5 W3C')}}     | The following property is now obsolete: `type`.  |
-| {{SpecName('DOM2 HTML', 'html.html#ID-74680021', 'HTMLLIElement')}}                         | {{Spec2('DOM2 HTML')}}     | No change from {{SpecName("DOM1")}}.     |
-| {{SpecName('DOM1', 'level-one-html.html#ID-74680021', 'HTMLLIElement')}}                 | {{Spec2('DOM1')}}         | Initial definition.                              |
+{{Specifications}}
 
 ## Compatibilidad con Navegadores
 

--- a/files/es/web/api/htmlvideoelement/index.md
+++ b/files/es/web/api/htmlvideoelement/index.md
@@ -52,11 +52,7 @@ _Hereda los métodos anteriores de_ _{{domxref("HTMLMediaElement")}} y_ _{{domxr
 
 ## Especificaciones
 
-| Especificacion                                                                                                                           | Estado                                           | Comentario                                        |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------- |
-| {{SpecName('Media Source Extensions', '#idl-def-HTMLVideoElement', 'Extensions to HTMLVideoElement')}} | {{Spec2("Media Source Extensions")}} | Anadio el metodo `getVideoPlaybackQuality()` .    |
-| {{SpecName('HTML WHATWG', "the-video-element.html#the-video-element", "HTMLAreaElement")}}                 | {{Spec2('HTML WHATWG')}}                 | Sin cambios del {{SpecName('HTML5 W3C')}}. |
-| {{SpecName('HTML5 W3C', "embedded-content-0.html#the-video-element", "HTMLAreaElement")}}                 | {{Spec2('HTML5 W3C')}}                     | Definicion incial.                                |
+{{Specifications}}
 
 ## Compatibilidad con Navegador
 

--- a/files/es/web/api/idbcursor/continue/index.md
+++ b/files/es/web/api/idbcursor/continue/index.md
@@ -73,9 +73,7 @@ function displayData() {
 
 ## Especificaciones
 
-| Specification                                                                                                | Estado                       | Comentarios |
-| ------------------------------------------------------------------------------------------------------------ | ---------------------------- | ----------- |
-| {{SpecName('IndexedDB', '#widl-IDBCursor-continue-void-any-key', 'continue()')}} | {{Spec2('IndexedDB')}} |             |
+{{Specifications}}
 
 ## Compatibilidad del navegador
 

--- a/files/es/web/api/idbcursor/index.md
+++ b/files/es/web/api/idbcursor/index.md
@@ -88,11 +88,9 @@ function displayData() {
 }
 ```
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                | Status                       | Comment |
-| ---------------------------------------------------------------------------- | ---------------------------- | ------- |
-| {{SpecName('IndexedDB', '#idl-def-IDBCursor', 'cursor')}} | {{Spec2('IndexedDB')}} |         |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/api/idbobjectstore/add/index.md
+++ b/files/es/web/api/idbobjectstore/add/index.md
@@ -107,11 +107,9 @@ function addData() {
 - key
   - : La llave a usar para identificar el registro. Si no es especificada, el resultado es nulo.
 
-## Especificación
+## Especificaciones
 
-| Especificación                                                                                                           | Estado                       | Comentario |
-| ------------------------------------------------------------------------------------------------------------------------ | ---------------------------- | ---------- |
-| {{SpecName('IndexedDB', '#widl-IDBObjectStore-add-IDBRequest-any-value-any-key', 'add()')}} | {{Spec2('IndexedDB')}} |            |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/api/idbobjectstore/index.md
+++ b/files/es/web/api/idbobjectstore/index.md
@@ -118,11 +118,9 @@ objectStoreRequest.onsuccess = function(event) {
 }
 ```
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                                | Status                       | Comment |
-| -------------------------------------------------------------------------------------------- | ---------------------------- | ------- |
-| {{SpecName('IndexedDB', '#idl-def-IDBObjectStore', 'IDBObjectStore')}} | {{Spec2('IndexedDB')}} |         |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/api/imagebitmap/index.md
+++ b/files/es/web/api/imagebitmap/index.md
@@ -25,11 +25,9 @@ The **`ImageBitmap`** interface represents a bitmap image which can be drawn to 
 - {{domxref("ImageBitmap.close()")}}
   - : Disposes of all graphical resources associated with an `ImageBitmap`.
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                                    | Status                           | Comment |
-| ------------------------------------------------------------------------------------------------ | -------------------------------- | ------- |
-| {{SpecName('HTML WHATWG', "webappapis.html#imagebitmap", "ImageBitmap")}} | {{Spec2('HTML WHATWG')}} |         |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/api/indexeddb/index.md
+++ b/files/es/web/api/indexeddb/index.md
@@ -33,10 +33,7 @@ function openDB() {
 
 ## Especificaciones
 
-| Especificación                                                                                                   | Estado                           | Comentario                                                                      |
-| ---------------------------------------------------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------------- |
-| {{SpecName('IndexedDB 2', '#dom-windoworworkerglobalscope-indexeddb', 'indexedDB')}} | {{Spec2('IndexedDB 2')}} | Definido en un `WindowOrWorkerGlobalScope` parcial en la última especificación. |
-| {{SpecName('IndexedDB', '#widl-IDBEnvironment-indexedDB', 'indexedDB')}}                 | {{Spec2('IndexedDB')}}     | Definición inicial.                                                             |
+{{Specifications}}
 
 ## Compatibilidad de Navegadores
 

--- a/files/es/web/api/issecurecontext/index.md
+++ b/files/es/web/api/issecurecontext/index.md
@@ -21,9 +21,7 @@ Un {{domxref("Boolean")}}.
 
 ## Especificaciones
 
-| Especificación                                                                                                                               | Estado                               | Comentario          |
-| -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------- |
-| {{SpecName('Secure Contexts', 'webappapis.html#dom-origin', 'WindowOrWorkerGlobalScope.isSecureContext')}} | {{Spec2('Secure Contexts')}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad de Navegadores
 

--- a/files/es/web/api/keyboardevent/index.md
+++ b/files/es/web/api/keyboardevent/index.md
@@ -186,13 +186,9 @@ function metaKeyUp (event) {
 </html>
 ```
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                                    | Status                           | Comment             |
-| ------------------------------------------------------------------------------------------------ | -------------------------------- | ------------------- |
-| {{SpecName('DOM3 Events', '#interface-KeyboardEvent', 'KeyboardEvent')}} | {{Spec2('DOM3 Events')}} | Initial definition. |
-
-The `KeyboardEvent` interface specification went through numerous draft versions, first under DOM Events Level 2 where it was dropped as no consensus arose, then under DOM Events Level 3. This led to the implementation of non-standard initialization methods, the early DOM Events Level 2 version, {{domxref("KeyboardEvent.initKeyEvent()")}} by Gecko browsers and the early DOM Events Level 3 version, {{domxref("KeyboardEvent.initKeyboardEvent()")}} by others. Both have been superseded by the modern usage of a constructor: {{domxref("KeyboardEvent.KeyboardEvent", "KeyboardEvent()")}}.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/api/location/index.md
+++ b/files/es/web/api/location/index.md
@@ -74,10 +74,7 @@ console.log(url.origin);    // https://developer.mozilla.org
 
 ## Especificaciones
 
-| Especificacion                                                                                           | Estado                           | Comentario                                       |
-| -------------------------------------------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------ |
-| {{SpecName('HTML WHATWG', "browsers.html#the-location-interface", "Location")}} | {{Spec2('HTML WHATWG')}} | No change from {{SpecName("HTML5 W3C")}}. |
-| {{SpecName('HTML5 W3C', "browsers.html#the-location-interface", "Location")}} | {{Spec2('HTML5 W3C')}}     | Definicion inicial.                              |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/api/location/origin/index.md
+++ b/files/es/web/api/location/origin/index.md
@@ -35,9 +35,7 @@ var result = window.location.origin; // Devuelve:'https://developer.mozilla.org'
 
 ## Especificaciones
 
-| Especificación                                                                   | Estado                           | Comentario          |
-| -------------------------------------------------------------------------------- | -------------------------------- | ------------------- |
-| {{SpecName('HTML WHATWG', '#dom-location-origin', 'origin')}} | {{Spec2('HTML WHATWG')}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/api/location/reload/index.md
+++ b/files/es/web/api/location/reload/index.md
@@ -44,10 +44,7 @@ reload.addEventListener('click', _ => { // el _ es para indicar la ausencia de p
 
 ## Especificaciones
 
-| Specification                                                                                                    | Status                           | Comment                                          |
-| ---------------------------------------------------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------ |
-| {{SpecName('HTML WHATWG', "history.html#dom-location-reload", "Location.reload()")}} | {{Spec2('HTML WHATWG')}} | No change from {{SpecName("HTML5 W3C")}}. |
-| {{SpecName('HTML5 W3C', "browsers.html#dom-location-reload", "Location.reload()")}} | {{Spec2('HTML5 W3C')}}     | Initial definition.                              |
+{{Specifications}}
 
 ## Compatibilidad del navegador
 

--- a/files/es/web/api/mediadevices/getusermedia/index.md
+++ b/files/es/web/api/mediadevices/getusermedia/index.md
@@ -226,9 +226,7 @@ Ver [permission: audio-capture](/en-US/Apps/Developing/App_permissions#audio-cap
 
 ## Especificaciones
 
-| Specification                                                                                                                | Status                               | Comment            |
-| ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------ |
-| {{SpecName('Media Capture', '#dom-mediadevices-getusermedia', 'MediaDevices.getUserMedia()')}} | {{Spec2('Media Capture')}} | Initial definition |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/api/mediadevices/index.md
+++ b/files/es/web/api/mediadevices/index.md
@@ -71,11 +71,9 @@ function errorMsg(msg, error) {
 }
 ```
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                        | Status                               | Comment            |
-| ------------------------------------------------------------------------------------ | ------------------------------------ | ------------------ |
-| {{SpecName('Media Capture', '#mediadevices', 'MediaDevices')}} | {{Spec2('Media Capture')}} | Initial definition |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/api/mediastreamtrack/index.md
+++ b/files/es/web/api/mediastreamtrack/index.md
@@ -64,9 +64,7 @@ La interfaz **`MediaStream`** representa un flujo de contenido de los medios. Un
 
 ## Especificaciones
 
-| Specification                                                                                | Status                               | Comment            |
-| -------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------ |
-| {{SpecName('Media Capture', '#mediastreamtrack', 'MediaStreamTrack')}} | {{Spec2('Media Capture')}} | Initial definition |
+{{Specifications}}
 
 ## Compatibilidad de los navegadores
 

--- a/files/es/web/api/network_information_api/index.md
+++ b/files/es/web/api/network_information_api/index.md
@@ -55,9 +55,7 @@ if (connection) {
 
 ## Especificaciones
 
-| Especifiación                                                                            | Estado                                       | Comentario            |
-| ---------------------------------------------------------------------------------------- | -------------------------------------------- | --------------------- |
-| {{SpecName('Network Information', '', 'Network Information API')}} | {{Spec2('Network Information')}} | Initial specification |
+{{Specifications}}
 
 ## Compatibilidad en Navegadores
 

--- a/files/es/web/api/nodelist/foreach/index.md
+++ b/files/es/web/api/nodelist/foreach/index.md
@@ -102,12 +102,7 @@ El comportamiento ateriror esta implementado en muchos navegadores. NodeList.pro
 
 ## Especificaciones
 
-Especificación
-
-|                                                                                  | Status                           | Comentarios                                |
-| -------------------------------------------------------------------------------- | -------------------------------- | ------------------------------------------ |
-| {{SpecName('DOM WHATWG', '#interface-nodelist', 'NodeList')}} | {{ Spec2('DOM WHATWG') }} | Define `NodeList` como `<Nodo>iterable`      |
-| {{SpecName("WebIDL", "#es-forEach", "forEach")}}                 | {{Spec2("WebIDL")}}         | Define `forEach` en declaraciones `iterables` |
+{{Specifications}}
 
 ## Compatibilidad en Navegadores
 

--- a/files/es/web/api/nodelist/index.md
+++ b/files/es/web/api/nodelist/index.md
@@ -83,12 +83,7 @@ Array.prototype.forEach.call(list, function (item) {
 
 ## Especificaciones
 
-| Especificación                                                                               | Estado                           | Comentario          |
-| -------------------------------------------------------------------------------------------- | -------------------------------- | ------------------- |
-| {{SpecName('DOM WHATWG', '#interface-nodelist', 'NodeList')}}             | {{ Spec2('DOM WHATWG') }} |                     |
-| {{SpecName('DOM3 Core', 'core.html#ID-536297177', 'NodeList')}}         | {{ Spec2('DOM3 Core') }} |                     |
-| {{SpecName('DOM2 Core', 'core.html#ID-536297177', 'NodeList')}}         | {{ Spec2('DOM2 Core') }} |                     |
-| {{SpecName('DOM1', 'level-one-core.html#ID-536297177', 'NodeList')}} | {{ Spec2('DOM1') }}         | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/api/notification/index.md
+++ b/files/es/web/api/notification/index.md
@@ -175,11 +175,9 @@ function spawnNotification(theBody,theIcon,theTitle) {
 }
 ```
 
-## Specifications
+## Especificaciones
 
-| Specification                                | Status                                   | Comment         |
-| -------------------------------------------- | ---------------------------------------- | --------------- |
-| {{SpecName('Web Notifications')}} | {{Spec2('Web Notifications')}} | Living standard |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/api/pushmanager/index.md
+++ b/files/es/web/api/pushmanager/index.md
@@ -76,11 +76,9 @@ navigator.serviceWorker.register('serviceworker.js').then(
   });
 ```
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                        | Status                       | Comment             |
-| ------------------------------------------------------------------------------------ | ---------------------------- | ------------------- |
-| {{SpecName('Push API','#pushmanager-interface','PushManager')}} | {{Spec2('Push API')}} | Initial definition. |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/api/pushmanager/supportedcontentencodings/index.md
+++ b/files/es/web/api/pushmanager/supportedcontentencodings/index.md
@@ -18,11 +18,9 @@ var encodings[] = PushManager.supportedContentEncodings
 
 Un _array_ de _Strings_
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                                                                    | Status                       | Comment             |
-| -------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('Push API','#dom-pushmanager-supportedcontentencodings','supportedContentEncodings')}} | {{Spec2('Push API')}} | Initial definition. |
+{{Specifications}}
 
 ## Browser Compatibility
 

--- a/files/es/web/api/response/index.md
+++ b/files/es/web/api/response/index.md
@@ -95,9 +95,7 @@ var myResponse = new Response();
 
 ## Especificaciones
 
-| Specification                                                        | Status                   | Comment            |
-| -------------------------------------------------------------------- | ------------------------ | ------------------ |
-| {{SpecName('Fetch','#response-class','Response')}} | {{Spec2('Fetch')}} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad entre navegadores
 

--- a/files/es/web/api/response/ok/index.md
+++ b/files/es/web/api/response/ok/index.md
@@ -39,9 +39,7 @@ fetch(peticion).then(function(respuesta) {
 
 ## Especificaciones
 
-| Especificación           | Estado                   | Comentario         |
-| ------------------------ | ------------------------ | ------------------ |
-| {{Spec2('Fetch')}} | {{Spec2('Fetch')}} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/api/response/response/index.md
+++ b/files/es/web/api/response/response/index.md
@@ -47,9 +47,7 @@ var miRespuesta = new Response(miBlob,opciones);
 
 ## Especificaciones
 
-| Especificación                                                       | Estado                   | Comentarios        |
-| -------------------------------------------------------------------- | ------------------------ | ------------------ |
-| {{SpecName('Fetch','#dom-response','Response()')}} | {{Spec2('Fetch')}} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/api/response/status/index.md
+++ b/files/es/web/api/response/status/index.md
@@ -48,9 +48,7 @@ fetch(myRequest).then(function(response) {
 
 ## Especificaciones
 
-| Especificación                                                           | Estatus                  | Comentario         |
-| ------------------------------------------------------------------------ | ------------------------ | ------------------ |
-| {{SpecName('Fetch','#dom-response-status','status')}} | {{Spec2('Fetch')}} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad del navegador
 

--- a/files/es/web/api/rtcrtpreceiver/index.md
+++ b/files/es/web/api/rtcrtpreceiver/index.md
@@ -36,9 +36,7 @@ La interfaz **`RTCRtpReceiver`** de la [WebRTC API](/es/docs/Web/API/WebRTC_API)
 
 ## Especificaciones
 
-| Especificación                                                                                   | Status                           | Comentario          |
-| ------------------------------------------------------------------------------------------------ | -------------------------------- | ------------------- |
-| {{SpecName('WebRTC 1.0','#rtcrtpreceiver-interface','RTCRtpReceiver')}} | {{Spec2('WebRTC 1.0')}} | Initial definition. |
+{{Specifications}}
 
 ## Compatibilidad
 

--- a/files/es/web/api/service_worker_api/index.md
+++ b/files/es/web/api/service_worker_api/index.md
@@ -122,9 +122,7 @@ En el futuro, los service workers podrán hacer una cantidad de cosas útiles pa
 
 ## Especificaciones
 
-| Specification                            | Status                               | Comment             |
-| ---------------------------------------- | ------------------------------------ | ------------------- |
-| {{SpecName('Service Workers')}} | {{Spec2('Service Workers')}} | Definición inicial. |
+{{Specifications}}
 
 ## Ver también
 

--- a/files/es/web/api/serviceworkercontainer/index.md
+++ b/files/es/web/api/serviceworkercontainer/index.md
@@ -88,11 +88,9 @@ if ('serviceWorker' in navigator) {
 }
 ```
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                                                        | Status                               | Comment             |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------- |
-| {{SpecName('Service Workers', '#service-worker-container', 'ServiceWorkerContainer')}} | {{Spec2('Service Workers')}} | Initial definition. |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/api/serviceworkercontainer/register/index.md
+++ b/files/es/web/api/serviceworkercontainer/register/index.md
@@ -69,11 +69,9 @@ if ('serviceWorker' in navigator) {
 }
 ```
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                                                        | Status                               | Comment             |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------- |
-| {{SpecName('Service Workers', '#service-worker-container', 'ServiceWorkerContainer')}} | {{Spec2('Service Workers')}} | Initial definition. |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/api/storage/index.md
+++ b/files/es/web/api/storage/index.md
@@ -76,9 +76,7 @@ function setStyles() {
 
 ## Especificaciones
 
-| Especificación                                                                       | Estado                           | Comentario |
-| ------------------------------------------------------------------------------------ | -------------------------------- | ---------- |
-| {{SpecName('Web Storage', '#the-storage-interface', 'Storage')}} | {{Spec2('Web Storage')}} |            |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/api/storage/length/index.md
+++ b/files/es/web/api/storage/length/index.md
@@ -36,9 +36,7 @@ function populateStorage() {
 
 ## Especificaciones
 
-| Especificacíon                                                                   | Estado                           | Comentario |
-| -------------------------------------------------------------------------------- | -------------------------------- | ---------- |
-| {{SpecName('Web Storage', '#dom-storage-length', 'length')}} | {{Spec2('Web Storage')}} |            |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/api/storage/removeitem/index.md
+++ b/files/es/web/api/storage/removeitem/index.md
@@ -61,9 +61,7 @@ function populateSessionStorage() {
 
 ## Especificaciones
 
-| Especificación                                                                                                           | Estado                           | Comentarios |
-| ------------------------------------------------------------------------------------------------------------------------ | -------------------------------- | ----------- |
-| {{SpecName('HTML WHATWG', 'webstorage.html#dom-storage-removeitem', 'Storage.removeItem')}} | {{Spec2('Web Storage')}} |             |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/api/storage/setitem/index.md
+++ b/files/es/web/api/storage/setitem/index.md
@@ -53,9 +53,7 @@ function populateStorage() {
 
 ## Especificaciones
 
-| Especificación                                                                       | Estado                           | Comentario |
-| ------------------------------------------------------------------------------------ | -------------------------------- | ---------- |
-| {{SpecName('Web Storage', '#dom-storage-setitem', 'setItem()')}} | {{Spec2('Web Storage')}} |            |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/api/storagemanager/estimate/index.md
+++ b/files/es/web/api/storagemanager/estimate/index.md
@@ -64,9 +64,7 @@ navigator.storage.estimate().then(function(estimate) {
 
 ## Especificaciones
 
-| Especificación                                                                           | Estado                       | Comentario          |
-| ---------------------------------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('Storage','#dom-storagemanager-estimate','estimate()')}} | {{Spec2('Storage')}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/api/storagemanager/index.md
+++ b/files/es/web/api/storagemanager/index.md
@@ -30,11 +30,9 @@ The **`StorageManager`** interface of the the [Storage API](/es/docs/Web/API/Sto
 - {{domxref("StorageManager.persisted()")}} {{securecontext_inline}}
   - : Returns a {{jsxref('Promise')}} that resolves to `true` if persistence has already been granted for your site's storage.
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                | Status                       | Comment             |
-| ---------------------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('Storage','#storagemanager','StorageManger')}} | {{Spec2('Storage')}} | Initial definition. |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/api/storagemanager/persist/index.md
+++ b/files/es/web/api/storagemanager/persist/index.md
@@ -42,9 +42,7 @@ if (navigator.storage && navigator.storage.persist)
 
 ## Especificaciones
 
-| Especificación                                                                       | Estado                       | Comentario          |
-| ------------------------------------------------------------------------------------ | ---------------------------- | ------------------- |
-| {{SpecName('Storage','#dom-storagemanager-persist','persist')}} | {{Spec2('Storage')}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/api/storagemanager/persisted/index.md
+++ b/files/es/web/api/storagemanager/persisted/index.md
@@ -42,9 +42,7 @@ if (navigator.storage && navigator.storage.persist)
 
 ## Especificaciones
 
-| Especificación                                                                           | Estado                       | Comentario          |
-| ---------------------------------------------------------------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName('Storage','#dom-storagemanager-persisted','persisted')}} | {{Spec2('Storage')}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/api/subtlecrypto/digest/index.md
+++ b/files/es/web/api/subtlecrypto/digest/index.md
@@ -96,9 +96,7 @@ console.log(digestHex);
 
 ## Especificaciones
 
-| Especificación                                                                                                           | Estado                               | Comentario          |
-| ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------ | ------------------- |
-| {{SpecName('Web Crypto API', '#dfn-SubtleCrypto-method-digest', 'SubtleCrypto.digest()')}} | {{Spec2('Web Crypto API')}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad del navegador
 

--- a/files/es/web/api/subtlecrypto/index.md
+++ b/files/es/web/api/subtlecrypto/index.md
@@ -118,9 +118,7 @@ _Esta interfaz no hereda ningún método._
 
 ## Especificaciones
 
-| Especificación                                                                                       | Estado                                   | Comentario          |
-| ---------------------------------------------------------------------------------------------------- | ---------------------------------------- | ------------------- |
-| {{ SpecName('Web Crypto API', '#subtlecrypto-interface', 'SubtleCrypto') }} | {{ Spec2('Web Crypto API') }} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad del navegador
 

--- a/files/es/web/api/texttrack/cuechange_event/index.md
+++ b/files/es/web/api/texttrack/cuechange_event/index.md
@@ -88,9 +88,7 @@ textTrackElem.oncuechange = (event) => {
 
 ## Especificaciones
 
-| Especificación                                                                           | Estado                           |
-| ---------------------------------------------------------------------------------------- | -------------------------------- |
-| {{SpecName('HTML WHATWG', '#event-media-cuechange', 'cuechange')}} | {{Spec2('HTML WHATWG')}} |
+{{Specifications}}
 
 ## Compatibilidad de los navegadores
 

--- a/files/es/web/api/texttrack/index.md
+++ b/files/es/web/api/texttrack/index.md
@@ -60,11 +60,9 @@ _This interface also inherits methods from {{domxref("EventTarget")}}._
 
 tbd
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                | Status                               | Comment |
-| ---------------------------------------------------------------------------- | ------------------------------------ | ------- |
-| {{ SpecName('HTML WHATWG', '#texttrack', 'TextTrack') }} | {{ Spec2('HTML WHATWG') }} |         |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/api/touchevent/index.md
+++ b/files/es/web/api/touchevent/index.md
@@ -87,10 +87,7 @@ See the [example on the main Touch events article](/en/DOM/Touch_events#Example)
 
 ## Especificaciones
 
-| Specification                                                                                | Status                               | Comment                                                                                   |
-| -------------------------------------------------------------------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------- |
-| {{SpecName('Touch Events 2','#touchevent-interface', 'TouchEvent')}} | {{Spec2('Touch Events 2')}} | Added `ontouchstart`, `ontouchend`, `ontouchmove`, `ontouchend` global attribute handlers |
-| {{SpecName('Touch Events', '#touchevent-interface', 'TouchEvent')}}     | {{Spec2('Touch Events')}}     | Definición inicial.                                                                       |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/api/url/createobjecturl/index.md
+++ b/files/es/web/api/url/createobjecturl/index.md
@@ -44,9 +44,7 @@ Cada vez que se llama a `createObjectURL()`, un nuevo objeto URL es creado, incl
 
 ## Especificaciones
 
-| Especificación                                                           | Estado                       | Comentario          |
-| ------------------------------------------------------------------------ | ---------------------------- | ------------------- |
-| {{SpecName('File API', '#dfn-createObjectURL', 'URL')}} | {{Spec2('File API')}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/api/url/host/index.md
+++ b/files/es/web/api/url/host/index.md
@@ -35,11 +35,9 @@ url = new URL('https://developer.mozilla.org:4097/en-US/docs/Web/API/URL/host');
 console.log(url.host); // "developer.mozilla.org:4097"
 ```
 
-## Specifications
+## Especificaciones
 
-| Specification                                                    | Status               | Comment            |
-| ---------------------------------------------------------------- | -------------------- | ------------------ |
-| {{SpecName('URL', '#dom-url-host', 'URL.host')}} | {{Spec2('URL')}} | Initial definition |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/api/url/port/index.md
+++ b/files/es/web/api/url/port/index.md
@@ -30,9 +30,7 @@ var result = url.port; // Devuelve:'80'
 
 ## Especificaciones
 
-| Especificación                                                   | Estado               | Comentario          |
-| ---------------------------------------------------------------- | -------------------- | ------------------- |
-| {{SpecName('URL', '#dom-url-port', 'URL.port')}} | {{Spec2('URL')}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad del navegador
 

--- a/files/es/web/api/url/url/index.md
+++ b/files/es/web/api/url/url/index.md
@@ -57,11 +57,9 @@ var d = new URL('/en-US/docs', b);                     // => 'https://developer.
         new URL("//foo.com", "https://example.com")    // => 'https://foo.com' (ver URL relativas)
 ```
 
-## Especificación
+## Especificaciones
 
-| Especificación                                                   | Estado               | Comentario          |
-| ---------------------------------------------------------------- | -------------------- | ------------------- |
-| {{SpecName('URL', '#constructors', 'URL.URL()')}} | {{Spec2('URL')}} | Initial definition. |
+{{Specifications}}
 
 ## Compatibilidad del navegador
 

--- a/files/es/web/api/web_crypto_api/index.md
+++ b/files/es/web/api/web_crypto_api/index.md
@@ -56,6 +56,4 @@ La Web Crypto API puede ser usada para:
 
 ## Especificaciones
 
-| Especificación                           | Estado                               | Comentario         |
-| ---------------------------------------- | ------------------------------------ | ------------------ |
-| {{SpecName("Web Crypto API")}} | {{Spec2("Web Crypto API")}} | Initial definition |
+{{Specifications}}

--- a/files/es/web/api/web_workers_api/index.md
+++ b/files/es/web/api/web_workers_api/index.md
@@ -60,9 +60,7 @@ You can find out more information on how these demos work in [Using web workers]
 
 ## Especificaciones
 
-| Specification                                        | Status                           | Comment |
-| ---------------------------------------------------- | -------------------------------- | ------- |
-| {{SpecName('HTML WHATWG', '#workers')}} | {{Spec2('HTML WHATWG')}} |         |
+{{Specifications}}
 
 ## See also
 

--- a/files/es/web/api/webrtc_api/index.md
+++ b/files/es/web/api/webrtc_api/index.md
@@ -77,13 +77,7 @@ WebRTC consta de varias API y protocolos interrelacionados que trabajan juntos p
 
 ## Especificaciones
 
-| Specification                                            | Status                                               | Comment                                                                     |
-| -------------------------------------------------------- | ---------------------------------------------------- | --------------------------------------------------------------------------- |
-| {{SpecName('WebRTC 1.0')}}                     | {{Spec2('WebRTC 1.0')}}                     | The initial definition of the API of WebRTC.                                |
-| {{SpecName('Media Capture')}}                 | {{Spec2('Media Capture')}}                 | The initial definition of the object conveying the stream of media content. |
-| {{SpecName('Media Capture DOM Elements')}} | {{Spec2('Media Capture DOM Elements')}} | The initial definition on how to obtain stream of content from DOM Elements |
-
-In additions to these specifications defining the API needed to use WebRTC, there are several protocols, listed under [resources](#Protocols).
+{{Specifications}}
 
 ## Ver también
 

--- a/files/es/web/api/websocket/error_event/index.md
+++ b/files/es/web/api/websocket/error_event/index.md
@@ -29,9 +29,7 @@ Un {{domxref("EventListener")}}.
 
 ## Especificaciones
 
-| Especificación                                                                                           | Estado                           | Comentarios         |
-| -------------------------------------------------------------------------------------------------------- | -------------------------------- | ------------------- |
-| {{SpecName('HTML WHATWG', '#handler-websocket-onerror', 'WebSocket: onerror')}} | {{Spec2('HTML WHATWG')}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/api/websocket/index.md
+++ b/files/es/web/api/websocket/index.md
@@ -144,9 +144,7 @@ socket.addEventListener('message', function (event) {
 
 ## Especificaciones
 
-| Specification                                                                            | Status                           | Comment            |
-| ---------------------------------------------------------------------------------------- | -------------------------------- | ------------------ |
-| {{SpecName("Websockets", "#the-websocket-interface", "WebSocket")}} | {{Spec2("Websockets")}} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/api/webvr_api/index.md
+++ b/files/es/web/api/webvr_api/index.md
@@ -116,12 +116,9 @@ You can find a number of examples at these locations:
 - [WebVR.rocks Firefox demos](https://webvr.rocks/firefox#demos) — showcase examples
 - [A-Frame homepage](https://aframe.io/) — examples showing A-Frame usage
 
-## Specifications
+## Especificaciones
 
-| Specification                                | Status                                   | Comment                                                                                                      |
-| -------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| {{SpecName("GamepadExtensions")}} | {{Spec2("GamepadExtensions")}} | Defines the [Experimental Gamepad extensions](/es/docs/Web/API/Gamepad_API#Experimental_Gamepad_extensions). |
-| {{SpecName('WebVR 1.1')}}             | {{Spec2('WebVR 1.1')}}             | Initial definition                                                                                           |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/api/xmlhttprequest/abort/index.md
+++ b/files/es/web/api/xmlhttprequest/abort/index.md
@@ -47,9 +47,7 @@ xhr.abort();
 
 ## Especificaciones
 
-| Especificación                                                           | Estado                               | Comentario             |
-| ------------------------------------------------------------------------ | ------------------------------------ | ---------------------- |
-| {{SpecName('XMLHttpRequest', '#the-abort()-method')}} | {{Spec2('XMLHttpRequest')}} | WHATWG living standard |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/http/cors/index.md
+++ b/files/es/web/http/cors/index.md
@@ -412,10 +412,7 @@ Ejemplos de esta utilización pueden ser encontrados [arriba](/En/HTTP_access_co
 
 ## Especificaciones
 
-| Especificación                                                   | Estado                   | Comentario                                                              |
-| ---------------------------------------------------------------- | ------------------------ | ----------------------------------------------------------------------- |
-| {{SpecName('Fetch', '#cors-protocol', 'CORS')}} | {{Spec2('Fetch')}} | Nueva definición; tiene como objetivo suplantar la especificación CORS. |
-| {{SpecName('CORS')}}                                     | {{Spec2('CORS')}} | Definición inicial.                                                     |
+{{Specifications}}
 
 ## Compatibilidad con Exploradores
 

--- a/files/es/web/http/headers/access-control-allow-headers/index.md
+++ b/files/es/web/http/headers/access-control-allow-headers/index.md
@@ -40,9 +40,7 @@ Access-Control-Allow-Headers: X-Custom-Header
 
 ## Especificaciones
 
-| Specification                                                                                                            | Status                   | Comment             |
-| ------------------------------------------------------------------------------------------------------------------------ | ------------------------ | ------------------- |
-| {{SpecName('Fetch','#http-access-control-allow-headers', 'Access-Control-Allow-Headers')}} | {{Spec2("Fetch")}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/http/headers/digest/index.md
+++ b/files/es/web/http/headers/digest/index.md
@@ -104,9 +104,7 @@ console.log(digestHex);
 
 ## Especificaciones
 
-| Especificación                                                                                                           | Estado                               | Comentario          |
-| ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------ | ------------------- |
-| {{SpecName('Web Crypto API', '#dfn-SubtleCrypto-method-digest', 'SubtleCrypto.digest()')}} | {{Spec2('Web Crypto API')}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad del navegador
 

--- a/files/es/web/http/headers/strict-transport-security/index.md
+++ b/files/es/web/http/headers/strict-transport-security/index.md
@@ -72,9 +72,7 @@ Strict-Transport-Security: max-age=31536000; includeSubDomains
 
 ## Especificaciones
 
-| Especificación               | Estado                   | Comentario         |
-| ---------------------------- | ------------------------ | ------------------ |
-| {{SpecName('HSTS')}} | {{Spec2('HSTS')}} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/web_components/index.md
+++ b/files/es/web/web_components/index.md
@@ -143,13 +143,7 @@ Se están construyendo varios ejemplos en nuestro repositorio de GitHub [web-com
 
 ## Especificaciones
 
-| Especificación                                                                                                               | Estado                           | Comentario                                                                                                                  |
-| ---------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| {{SpecName("HTML WHATWG","scripting.html#the-template-element","&lt;template&gt; element")}} | {{Spec2("HTML WHATWG")}} | La definición de {{HTMLElement("template")}}.                                                                      |
-| {{SpecName("HTML WHATWG","custom-elements.html#custom-elements","custom elements")}}             | {{Spec2("HTML WHATWG")}} | La definición de [elementos personalizados HTML (HTML Custom Elements)](/es/docs/Web/Web_Components/Using_custom_elements). |
-| {{SpecName("DOM WHATWG","#shadow-trees","shadow trees")}}                                                 | {{Spec2("DOM WHATWG")}} | La definición de [Shadow DOM](/es/docs/Web/Web_Components/Using_shadow_DOM).                                                |
-| {{SpecName("HTML Imports", "", "")}}                                                                             | {{Spec2("HTML Imports")}} | Definición inicial de [HTML Imports](/es/docs/Web/Web_Components/HTML_Imports).                                             |
-| {{SpecName("Shadow DOM", "", "")}}                                                                                 | {{Spec2("Shadow DOM")}} | Definición inicial de [Shadow DOM](/es/docs/Web/Web_Components/Using_shadow_DOM).                                           |
+{{Specifications}}
 
 ## Compatibilidad de los navegadores
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove deprecated spec2 macro from es

Process: replace the section with the `{{Specifications}}` macro and replace with rendered content when apply

### Motivation

The chore of deprecated macros removal

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Relates to https://github.com/orgs/mdn/discussions/263
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
