### PR TITLE
Remove deprecated spec2 macro from es 9/9

### DIFF
--- a/files/es/web/css/-webkit-text-fill-color/index.md
+++ b/files/es/web/css/-webkit-text-fill-color/index.md
@@ -17,10 +17,7 @@ La propiedad CSS -**`webkit-text-fill-color`** especifica el [color](/es/docs/We
 
 ## Especificaciones
 
-| Especificación                                                                                                                                                                                                                                                    | Estado                                | Comentario               |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | ------------------------ |
-| {{SpecName('Compat', '#the-webkit-text-fill-color', '-webkit-text-fill-color')}}                                                                                                                                                      | {{Spec2('Compat')}}              | Estandarización estándar |
-| [Referencia CSS Safari '-webkit-text-fill-color' en ese documento.](https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariCSSRef/Articles/StandardCSSProperties.html#//apple_ref/doc/uid/TP30001266--webkit-text-fill-color) | Documentanción no oficial no estándar | Documentación inicial    |
+{{Specifications}}
 
 ## Compatibilidad con los distintos navegadores
 

--- a/files/es/web/css/@import/index.md
+++ b/files/es/web/css/@import/index.md
@@ -42,11 +42,7 @@ Dónde :
 
 ## Especificaciones
 
-| Especificación                                                                   | Estado                                       | Comentario                                                                                                                                                                                  |
-| -------------------------------------------------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| {{ SpecName('CSS3 Media Queries', '#media0', '@import') }}     | {{ Spec2('CSS3 Media Queries') }} | Extiende la sintaxis para soportar cualquier [consultas de medios (media query)](/en/CSS/Media_queries) y no sólo los [tipos de medios](/en/CSS/@media#Media_types) simples.                |
-| {{ SpecName('CSS2.1', 'cascade.html#at-import', '@import') }} | {{ Spec2('CSS2.1') }}                 | Añade soporte para {{cssxref("&lt;string&gt;")}} para denotar la _url_ de una hoja de estilo, y es requerida para insertar la regla `@import` en el principio del documento CSS. |
-| {{ SpecName('CSS1', '#the-cascade', '@import') }}                 | {{ Spec2('CSS1') }}                     |                                                                                                                                                                                             |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/css/@keyframes/index.md
+++ b/files/es/web/css/@keyframes/index.md
@@ -80,11 +80,9 @@ Mira los ejemplos del [CSS animations](/en/CSS/CSS_animations).
 
 ## Especificaciones
 
-Compatibilidad del navegador
+{{Specifications}}
 
-| Especificaciones                                                                 | Estadp                                   | Comentario |
-| -------------------------------------------------------------------------------- | ---------------------------------------- | ---------- |
-| {{ SpecName('CSS3 Animations', '#keyframes', '@keyframes') }} | {{ Spec2('CSS3 Animations') }} |            |
+## Compatibilidad del navegador
 
 {{Compat("css.at-rules.keyframes")}}
 

--- a/files/es/web/css/_colon_blank/index.md
+++ b/files/es/web/css/_colon_blank/index.md
@@ -21,9 +21,7 @@ La [pseudo-clase CSS](/es/docs/Web/CSS) **`:blank`** selecciona elementos de ent
 
 ## Especificaciones
 
-| Especificación                                                               | Estado                               | Comentario         |
-| ---------------------------------------------------------------------------- | ------------------------------------ | ------------------ |
-| {{SpecName("CSS4 Selectors", "#blank-pseudo", ":blank")}} | {{Spec2("CSS4 Selectors")}} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad de los navegadores
 

--- a/files/es/web/css/_colon_default/index.md
+++ b/files/es/web/css/_colon_default/index.md
@@ -65,12 +65,7 @@ input:default + label {
 
 ## Especificaciones
 
-| Especificación                                                                   | Estado                               | Comentarios                                                         |
-| -------------------------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------- |
-| {{SpecName('HTML WHATWG', '#selector-default', ':default')}} | {{Spec2('HTML WHATWG')}}     | Ningún cambio.                                                      |
-| {{SpecName('HTML5 W3C', '#selector-default', ':default')}}     | {{Spec2('HTML5 W3C')}}         | Define la semántica HTML asociada y la validación de restricciones. |
-| {{SpecName('CSS4 Selectors', '#default-pseudo', ':default')}} | {{Spec2('CSS4 Selectors')}} | Ningún cambio.                                                      |
-| {{SpecName('CSS3 Basic UI', '#pseudo-default', ':default')}} | {{Spec2('CSS3 Basic UI')}} | Definición inicial, pero sin la semántica asociada.                 |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/_colon_first-child/index.md
+++ b/files/es/web/css/_colon_first-child/index.md
@@ -97,11 +97,7 @@ ul li:first-child {
 
 ## Especificaciones
 
-| Especificación                                                                               | Estado                               | Comentarios                                             |
-| -------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------- |
-| {{SpecName('CSS4 Selectors', '#first-child-pseudo', ':first-child')}} | {{Spec2('CSS4 Selectors')}} | Los elementos coincidentes no requieren tener un padre. |
-| {{SpecName('CSS3 Selectors', '#first-child-pseudo', ':first-child')}} | {{Spec2('CSS3 Selectors')}} | Ningún cambio.                                          |
-| {{SpecName('CSS2.1', 'selector.html#first-child', ':first-child')}}     | {{Spec2('CSS2.1')}}             | Definición Inicial.                                     |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/_colon_fullscreen/index.md
+++ b/files/es/web/css/_colon_fullscreen/index.md
@@ -134,9 +134,7 @@ fullscreenButton.addEventListener('click', enterFullscreen);
 
 ## Especificaciones
 
-| Especificación                                                                               | Estado                           | Comentarios         |
-| -------------------------------------------------------------------------------------------- | -------------------------------- | ------------------- |
-| {{SpecName('Fullscreen', '#:fullscreen-pseudo-class', ':fullscreen')}} | {{Spec2('Fullscreen')}} | Definición Inicial. |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/_colon_invalid/index.md
+++ b/files/es/web/css/_colon_invalid/index.md
@@ -112,11 +112,7 @@ Puede inhabilitar el brillo con el siguiente CSS o anularlo por completo para mo
 
 ## Especificaciones
 
-| Especificación                                                                       | Estado                               | Comentarios                                                   |
-| ------------------------------------------------------------------------------------ | ------------------------------------ | ------------------------------------------------------------- |
-| {{SpecName('HTML WHATWG', '#selector-invalid', ':invalid')}}     | {{Spec2('HTML WHATWG')}}     | Ningún cambio.                                                |
-| {{SpecName('HTML5 W3C', '#selector-invalid', ':invalid')}}         | {{Spec2('HTML5 W3C')}}         | Define la semántica de HTML y la validación de restricciones. |
-| {{SpecName('CSS4 Selectors', '#validity-pseudos', ':invalid')}} | {{Spec2('CSS4 Selectors')}} | Definición Inicial.                                           |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/_colon_left/index.md
+++ b/files/es/web/css/_colon_left/index.md
@@ -40,10 +40,7 @@ La dirección principal de escritura del documento determina si una página es "
 
 ## Especificaciones
 
-| Especificaciones                                                                     | Estatus                                  | Comentario          |
-| ------------------------------------------------------------------------------------ | ---------------------------------------- | ------------------- |
-| {{ SpecName('CSS3 Paged Media', '#left-right-first', ':left') }} | {{ Spec2('CSS3 Paged Media') }} | Sin Cambio.         |
-| {{ SpecName('CSS2.1', 'page.html#page-selectors', ':left') }}     | {{ Spec2('CSS2.1') }}             | Definición Inicial. |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/_colon_nth-last-child/index.md
+++ b/files/es/web/css/_colon_nth-last-child/index.md
@@ -159,10 +159,7 @@ tr:nth-last-child(n+1){
 
 ## Especificaciones
 
-| Especificación                                                                                       | Estado                               | Comentarios                                             |
-| ---------------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------- |
-| {{SpecName('CSS4 Selectors', '#nth-last-child-pseudo', ':nth-last-child')}} | {{Spec2('CSS4 Selectors')}} | Los elementos coincidentes no requieren tener un padre. |
-| {{SpecName('CSS3 Selectors', '#nth-last-child-pseudo', ':nth-last-child')}} | {{Spec2('CSS3 Selectors')}} | Definición Inicial.                                     |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/_colon_optional/index.md
+++ b/files/es/web/css/_colon_optional/index.md
@@ -44,12 +44,7 @@ Las entradas requeridas también deben indicarse visualmente, utilizando un trat
 
 ## Especificaciones
 
-| Especificación                                                                               | Estado                                   | Comentario                                                    |
-| -------------------------------------------------------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------- |
-| {{ SpecName('HTML WHATWG', '#selector-optional', ':optional') }}         | {{ Spec2('HTML WHATWG') }}     | Ningún cambio.                                                |
-| {{ SpecName('HTML5 W3C', '#selector-optional', ':optional') }}         | {{ Spec2('HTML5 W3C') }}         | Define la semántica de HTML y la validación de restricciones. |
-| {{ SpecName('CSS4 Selectors', '#opt-pseudos', ':optional') }}             | {{ Spec2('CSS4 Selectors') }} | Ningún cambio.                                                |
-| {{ SpecName('CSS3 Basic UI', '#pseudo-required-value', ':optional') }} | {{ Spec2('CSS3 Basic UI') }}     | Define la pseudoclase, pero no la semántica asociada.         |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/_colon_read-only/index.md
+++ b/files/es/web/css/_colon_read-only/index.md
@@ -67,11 +67,7 @@ p[contenteditable="true"] { color: blue; }
 
 ## Especificaciones
 
-| Especificación                                                                           | Estado                                   | Comentarios                                                                       |
-| ---------------------------------------------------------------------------------------- | ---------------------------------------- | --------------------------------------------------------------------------------- |
-| {{ SpecName('HTML WHATWG', '#selector-read-only', ':read-only') }} | {{ Spec2('HTML WHATWG') }}     | Ningún cambio.                                                                    |
-| {{ SpecName('HTML5 W3C', '#selector-read-only', ':read-only') }}     | {{ Spec2('HTML5 W3C') }}         | Define la semántica relacionada con HTML y de la validación de las restricciones. |
-| {{ SpecName('CSS4 Selectors', '#rw-pseudos', ':read-only') }}         | {{ Spec2('CSS4 Selectors') }} | Define la pseudoclase, pero no la semántica asociada.                             |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/_colon_read-write/index.md
+++ b/files/es/web/css/_colon_read-write/index.md
@@ -62,11 +62,7 @@ p[contenteditable="true"] { color: blue; }
 
 ## Especificaciones
 
-| Especificación                                                                               | Estado                                   | Comentarios                                                            |
-| -------------------------------------------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------- |
-| {{ SpecName('HTML WHATWG', '#selector-read-write', ':read-write') }} | {{ Spec2('HTML WHATWG') }}     | Ningún cambio.                                                         |
-| {{ SpecName('HTML5 W3C', '#selector-read-write', ':read-write') }}     | {{ Spec2('HTML5 W3C') }}         | Define la semántica con respecto a HTML y validación de restricciones. |
-| {{ SpecName('CSS4 Selectors', '#rw-pseudos', ':read-write') }}         | {{ Spec2('CSS4 Selectors') }} | Define la pseudo-clase, pero no la semántica asociada.                 |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/_colon_target/index.md
+++ b/files/es/web/css/_colon_target/index.md
@@ -187,11 +187,7 @@ Puede usar la pseudo-clase `:target` para crear un lightbox sin usar JavaScript.
 
 ## Especificaciones
 
-| Especificación                                                                                   | Estado                               | Comentarios                             |
-| ------------------------------------------------------------------------------------------------ | ------------------------------------ | --------------------------------------- |
-| {{SpecName("HTML WHATWG", "browsers.html#selector-target", ":target")}} | {{Spec2("HTML WHATWG")}}     | Define la semántica específica de HTML. |
-| {{SpecName("CSS4 Selectors", "#the-target-pseudo", ":target")}}             | {{Spec2("CSS4 Selectors")}} | Ningún cambio.                          |
-| {{SpecName("CSS3 Selectors", "#target-pseudo", ":target")}}                 | {{Spec2("CSS3 Selectors")}} | Definición Inicial.                     |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/_colon_visited/index.md
+++ b/files/es/web/css/_colon_visited/index.md
@@ -72,13 +72,7 @@ a:visited {
 
 ## Especificaciones
 
-| Especificación                                                                                       | Estado                                   | Comentario                                                                                                                                                                      |
-| ---------------------------------------------------------------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| {{ SpecName('HTML WHATWG', 'scripting.html#selector-visited', ':visited') }} | {{ Spec2('HTML WHATWG') }}     |                                                                                                                                                                                 |
-| {{ SpecName('CSS4 Selectors', '#link', ':visited') }}                             | {{ Spec2('CSS4 Selectors') }} | Ningún cambio.                                                                                                                                                                  |
-| {{ SpecName('CSS3 Selectors', '#link', ':visited') }}                             | {{ Spec2('CSS3 Selectors') }} | Ningún cambio.                                                                                                                                                                  |
-| {{ SpecName('CSS2.1', 'selector.html#link-pseudo-classes', ':visited') }}     | {{ Spec2('CSS2.1') }}             | Levanta la restricción para aplicar `:visited` solo al elemento {{ HTMLElement("a") }}. Permite a los navegadores restringir su comportamiento por razones de privacidad. |
-| {{ SpecName('CSS1', '#anchor-pseudo-classes', ':visited') }}                     | {{ Spec2('CSS1') }}                 | Definición inicial.                                                                                                                                                             |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/_doublecolon_after/index.md
+++ b/files/es/web/css/_doublecolon_after/index.md
@@ -136,13 +136,7 @@ span[data-descr]:focus::after {
 
 ## Especificaciones
 
-| Especificación                                                                                                                           | Estatus                                      | Comentarios                                                            |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | ---------------------------------------------------------------------- |
-| {{SpecName('CSS4 Pseudo-Elements', '#selectordef-after', '::after')}}                                             | {{Spec2('CSS4 Pseudo-Elements')}} | Sin cambios significativos desde la especificación previa.             |
-| {{Specname("CSS3 Transitions", "#animatable-properties", "transitions on pseudo-element properties")}} | {{Spec2("CSS3 Transitions")}}     | Permite transiciones en propiedades definidas en los pseudo-elementos. |
-| {{Specname("CSS3 Animations", "", "animations on pseudo-element properties")}}                                 | {{Spec2("CSS3 Animations")}}         | Permite animaciones en propiedades definidas en los pseudo-elementos.  |
-| {{SpecName('CSS3 Selectors', '#gen-content', '::after')}}                                                             | {{Spec2('CSS3 Selectors')}}         | Introduce la sintaxis de doble símbolo `:`                             |
-| {{SpecName('CSS2.1', 'generate.html#before-after-content', '::after')}}                                         | {{Spec2('CSS2.1')}}                     | Definición inicial, usando sintáxis de un solo símbolo `:`             |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/css/_doublecolon_cue/index.md
+++ b/files/es/web/css/_doublecolon_cue/index.md
@@ -85,9 +85,7 @@ El siguiente CSS ajusta el estilo de las anotaciones para que el texto sea blanc
 
 ## Especificaciones
 
-| Especificacion                                                               | Estado                   | Comentario          |
-| ---------------------------------------------------------------------------- | ------------------------ | ------------------- |
-| {{SpecName("WebVTT", "#the-cue-pseudo-element", "::cue")}} | {{Spec2("WebVTT")}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad con los navegadores
 

--- a/files/es/web/css/_doublecolon_first-letter/index.md
+++ b/files/es/web/css/_doublecolon_first-letter/index.md
@@ -84,13 +84,7 @@ p::first-letter {
 
 ## Especificaciones
 
-| Specification                                                                                                        | Status                                       | Comment                                                                                                                                          |
-| -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| {{ SpecName('CSS4 Pseudo-Elements', '#first-letter-pseudo', '::first-letter')}}             | {{ Spec2('CSS4 Pseudo-Elements')}} | Generaliza propiedades permitidas, {{ cssxref("opacity") }}, and {{ cssxref("box-shadow") }}.                                   |
-| {{ SpecName('CSS3 Text Decoration', '#text-shadow', 'text-shadow with ::first-letter')}} | {{ Spec2('CSS3 Text Decoration')}} | Permite el uso de {{cssxref("text-shadow")}} con `::first-letter`.                                                                     |
-| {{ SpecName('CSS3 Selectors', '#first-letter', '::first-letter') }}                             | {{ Spec2('CSS3 Selectors') }}     | Introducción de la sintaxis de doble dos puntos. Definición de casos particulares, como con idiomas específicos (ej., el dígrafo holandés `IJ`). |
-| {{ SpecName('CSS2.1', 'selector.html#first-letter', '::first-letter') }}                     | {{ Spec2('CSS2.1') }}                 | Sin cambios.                                                                                                                                     |
-| {{ SpecName('CSS1', '#the-first-letter-pseudo-element', '::first-letter') }}                 | {{ Spec2('CSS1') }}                     | Definición inicial, uso de la sintaxis de doble dos puntos.                                                                                      |
+{{Specifications}}
 
 ## Compatibilidad
 

--- a/files/es/web/css/_doublecolon_placeholder/index.md
+++ b/files/es/web/css/_doublecolon_placeholder/index.md
@@ -119,9 +119,7 @@ El texto provisional no es un reemplazo para el elemento {{htmlelement("label")}
 
 ## Especificaciones
 
-| Especificación                                                                                       | Estado                                       | Comentarios        |
-| ---------------------------------------------------------------------------------------------------- | -------------------------------------------- | ------------------ |
-| {{SpecName('CSS4 Pseudo-Elements', '#placeholder-pseudo', '::placeholder')}} | {{Spec2('CSS4 Pseudo-Elements')}} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad de los navegadores
 

--- a/files/es/web/css/animation-fill-mode/index.md
+++ b/files/es/web/css/animation-fill-mode/index.md
@@ -112,9 +112,7 @@ CSS
 
 ## Especificaciones
 
-| Especificación                                                                                               | Estado                                   | Comentario |
-| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------- | ---------- |
-| {{ SpecName('CSS3 Animations', '#animation-fill-mode', 'animation-fill-mode') }} | {{ Spec2('CSS3 Animations') }} |            |
+{{Specifications}}
 
 ## Compatibilidad entre navegadores
 

--- a/files/es/web/css/animation-name/index.md
+++ b/files/es/web/css/animation-name/index.md
@@ -54,9 +54,7 @@ Ver ejemplos [CSS animations](/es/docs/CSS/CSS_animations).
 
 ## Especificaciones
 
-| Especificación                                                                               | Estado                               | Comentario |
-| -------------------------------------------------------------------------------------------- | ------------------------------------ | ---------- |
-| {{SpecName('CSS3 Animations', '#animation-name', 'animation-name')}} | {{Spec2('CSS3 Animations')}} |            |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/css/animation-play-state/index.md
+++ b/files/es/web/css/animation-play-state/index.md
@@ -47,9 +47,7 @@ Visita [animaciones CSS](/es/CSS/Usando_animaciones_CSS) para ver algunos ejempl
 
 ## Especificaciones
 
-| Especificación                                                                                               | Estado                               | Comentario        |
-| ------------------------------------------------------------------------------------------------------------ | ------------------------------------ | ----------------- |
-| {{SpecName('CSS3 Animations', '#animation-play-state', 'animation-play-state')}} | {{Spec2('CSS3 Animations')}} | Definición incial |
+{{Specifications}}
 
 ## Compatibilidad entre navegadores
 

--- a/files/es/web/css/attribute_selectors/index.md
+++ b/files/es/web/css/attribute_selectors/index.md
@@ -207,11 +207,7 @@ ol[type="A" s] {
 
 ## Especificaciones
 
-| Especificación                                                                                               | Estado                               | Comentarios                                                                                                  |
-| ------------------------------------------------------------------------------------------------------------ | ------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| {{SpecName('CSS4 Selectors', '#attribute-selectors', 'attribute selectors')}}     | {{Spec2('CSS4 Selectors')}} | Agrega un modificador para la selección de valores de atributos insensibles a mayúsculas / minúsculas ASCII. |
-| {{SpecName('CSS3 Selectors', '#attribute-selectors', 'attribute selectors')}}     | {{Spec2('CSS3 Selectors')}} |                                                                                                              |
-| {{SpecName('CSS2.1', 'selector.html#attribute-selectors', 'attribute selectors')}} | {{Spec2('CSS2.1')}}             | Definición Inicial.                                                                                          |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/backdrop-filter/index.md
+++ b/files/es/web/css/backdrop-filter/index.md
@@ -117,9 +117,7 @@ body {
 
 ## Especificaciones
 
-| Especificación                                                                                   | Estado                           | Comentario          |
-| ------------------------------------------------------------------------------------------------ | -------------------------------- | ------------------- |
-| {{SpecName('Filters 2.0', '#BackdropFilterProperty', 'backdrop-filter')}} | {{Spec2('Filters 2.0')}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/backface-visibility/index.md
+++ b/files/es/web/css/backface-visibility/index.md
@@ -184,9 +184,7 @@ th, p, td {
 
 ## Especificaciones
 
-| Especificación                                                                                                       | Estatus                              | Comentarios        |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------ |
-| {{SpecName('CSS3 Transforms', '#backface-visibility-property', 'backface-visibility')}} | {{Spec2('CSS3 Transforms')}} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/css/background-blend-mode/index.md
+++ b/files/es/web/css/background-blend-mode/index.md
@@ -81,9 +81,7 @@ console.log(document.getElementById('div'));
 
 ## Especificaciones
 
-| Especificación                                                                                               | Estado                               | Comentarios        |
-| ------------------------------------------------------------------------------------------------------------ | ------------------------------------ | ------------------ |
-| {{ SpecName('Compositing', '#background-blend-mode', 'background-blend-mode') }} | {{ Spec2('Compositing') }} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/css/background-repeat/index.md
+++ b/files/es/web/css/background-repeat/index.md
@@ -159,11 +159,7 @@ En este ejemplo,cada elemento de la listcoincide con un valor diferente de `back
 
 ## Especificaciones
 
-| Especificación                                                                                                   | Estado                                   | Comentario                                                                                                                                                                                                                                                                                                                                    |
-| ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| {{SpecName('CSS3 Backgrounds', '#the-background-repeat', 'background-repeat')}}         | {{Spec2('CSS3 Backgrounds')}} | Añade soporte para diferentes imágenes de fondo, el atributo de doble valor equivalente permite un comportamiento de repetición diferente para las direcciones verticales y horizontales, las palabras clave `space` y `round` , y para fondos en elementos en la misma línea mediante la definición precisa de la zona disponible del fondo. |
-| {{SpecName('CSS2.1', 'colors.html#propdef-background-repeat', 'background-repeat')}} | {{Spec2('CSS2.1')}}                 | Sin cambios significativos.                                                                                                                                                                                                                                                                                                                   |
-| {{SpecName('CSS1', '#background-repeat', 'background-repeat')}}                             | {{Spec2('CSS1')}}                 | Definición inicial.                                                                                                                                                                                                                                                                                                                           |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/css/block-size/index.md
+++ b/files/es/web/css/block-size/index.md
@@ -76,11 +76,9 @@ La propiedad `block-size` toma los mismos valores que las propiedades {{cssxref(
 
 {{EmbedLiveSample("Ejemplo")}}
 
-## Especificación
+## Especificaciones
 
-| Especificación                                                                                                   | Estatus                                          | Comentarios        |
-| ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------ |
-| {{SpecName("CSS Logical Properties", "#logical-dimension-properties", "block-size")}} | {{Spec2("CSS Logical Properties")}} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/css/border-block-end-style/index.md
+++ b/files/es/web/css/border-block-end-style/index.md
@@ -63,11 +63,9 @@ div {
 
 {{EmbedLiveSample("Ejemplo", 140, 140)}}
 
-## Especificación
+## Especificaciones
 
-| Especificación                                                                                                                       | Estatus                                          | Comentarios        |
-| ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ | ------------------ |
-| {{SpecName("CSS Logical Properties", "#propdef-border-block-end-style", "border-block-end-style")}} | {{Spec2("CSS Logical Properties")}} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/css/border-block-end-width/index.md
+++ b/files/es/web/css/border-block-end-width/index.md
@@ -59,11 +59,9 @@ div {
 
 {{EmbedLiveSample("Ejemplo", 140, 140)}}
 
-## Especificación
+## Especificaciones
 
-| Especificación                                                                                                                       | Estado                                           | Comentario         |
-| ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ | ------------------ |
-| {{SpecName("CSS Logical Properties", "#propdef-border-block-end-width", "border-block-end-width")}} | {{Spec2("CSS Logical Properties")}} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad en Navegadores
 

--- a/files/es/web/css/border-bottom-left-radius/index.md
+++ b/files/es/web/css/border-bottom-left-radius/index.md
@@ -151,9 +151,7 @@ div {
 
 ## Especificaciones
 
-| Especificación                                                                                                           | Estado                                   | Comentarios        |
-| ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------- | ------------------ |
-| {{SpecName('CSS3 Backgrounds', '#border-bottom-left-radius', 'border-bottom-left-radius')}} | {{Spec2('CSS3 Backgrounds')}} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/css/border-image-outset/index.md
+++ b/files/es/web/css/border-image-outset/index.md
@@ -63,9 +63,7 @@ border-image-outset: inherit;
 
 ## Especificaciones
 
-| Especificación                                                                                           | Estatus                                  | Comentarios        |
-| -------------------------------------------------------------------------------------------------------- | ---------------------------------------- | ------------------ |
-| {{SpecName('CSS3 Backgrounds', '#border-image-outset', 'border-image-outset')}} | {{Spec2('CSS3 Backgrounds')}} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/css/border-inline-end-style/index.md
+++ b/files/es/web/css/border-inline-end-style/index.md
@@ -60,11 +60,9 @@ div {
 
 {{EmbedLiveSample("Ejemplo", 140, 140)}}
 
-## Especificación
+## Especificaciones
 
-| Especificación                                                                                                                           | Estado                                           | Comentario          |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------- |
-| {{SpecName("CSS Logical Properties", "#propdef-border-inline-end-style", "border-inline-end-style")}} | {{Spec2("CSS Logical Properties")}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/css/border-inline-end-width/index.md
+++ b/files/es/web/css/border-inline-end-width/index.md
@@ -59,11 +59,9 @@ div {
 
 {{EmbedLiveSample("Ejemplo", 140, 140)}}
 
-## Especificación
+## Especificaciones
 
-| Especificación                                                                                                                           | Estado                                           | Comentario          |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------- |
-| {{SpecName("CSS Logical Properties", "#propdef-border-inline-end-width", "border-inline-end-width")}} | {{Spec2("CSS Logical Properties")}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/css/border-inline-end/index.md
+++ b/files/es/web/css/border-inline-end/index.md
@@ -66,11 +66,9 @@ div {
 
 {{EmbedLiveSample("Ejemplo", 140, 140)}}
 
-## Especificación
+## Especificaciones
 
-| Especificación                                                                                                           | Estado                                           | Comentario          |
-| ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ | ------------------- |
-| {{SpecName("CSS Logical Properties", "#propdef-border-inline-end", "border-inline-end")}} | {{Spec2("CSS Logical Properties")}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/css/border-inline-start-color/index.md
+++ b/files/es/web/css/border-inline-start-color/index.md
@@ -58,11 +58,9 @@ div {
 
 {{EmbedLiveSample("Ejemplo", 140, 140)}}
 
-## Especificación
+## Especificaciones
 
-| Especificación                                                                                                                               | Estado                                           | Comentario          |
-| -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------- |
-| {{SpecName("CSS Logical Properties", "#propdef-border-inline-start-color", "border-inline-start-color")}} | {{Spec2("CSS Logical Properties")}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/css/border-left/index.md
+++ b/files/es/web/css/border-left/index.md
@@ -39,13 +39,9 @@ element {
 
 Si las reglas no especifican un color de borde, el borde tendrá la propiedad {{ Cssxref("color") }}
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                                    | Status                                   | Comment                                                                                                                   |
-| ------------------------------------------------------------------------------------------------ | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| {{ SpecName('CSS3 Backgrounds', '#border-left', 'border-left') }}         | {{ Spec2('CSS3 Backgrounds') }} | No direct changes, though the modification of values for the {{ cssxref("border-left-color") }} do apply to it. |
-| {{ SpecName('CSS2.1', 'box.html#propdef-border-left', 'border-left') }} | {{ Spec2('CSS2.1') }}             | No significant changes                                                                                                    |
-| {{ SpecName('CSS1', '#border-left', 'border-left') }}                         | {{ Spec2('CSS1') }}                 | Initial definition                                                                                                        |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/css/border-top-color/index.md
+++ b/files/es/web/css/border-top-color/index.md
@@ -72,10 +72,7 @@ La propiedad `border-top-color` es especificada con un valor unico.
 
 ## Especificaciones
 
-| Especificación                                                                                           | Estado                                   | Comentarios                                                                                                                                                                  |
-| -------------------------------------------------------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| {{SpecName('CSS3 Backgrounds', '#border-top-color', 'border-top-color')}}         | {{Spec2('CSS3 Backgrounds')}} | Sin cambios significativos, aunque la palabra clave `transparent` , ahora incluida en {{cssxref("&lt;color&gt;")}} que se ha extendido, se ha eliminado formalmente. |
-| {{SpecName('CSS2.1', 'box.html#border-color-properties', 'border-top-color')}} | {{Spec2('CSS2.1')}}                 | Definición inicial                                                                                                                                                           |
+{{Specifications}}
 
 ## Compatibilidad entre navegadores
 

--- a/files/es/web/css/box-shadow/index.md
+++ b/files/es/web/css/box-shadow/index.md
@@ -131,11 +131,7 @@ Se ha añadido un margen del tamaño de la sombra más ancha para asegurarse de 
 
 ## Especificaciones
 
-| Especificación                                                                   | Estado                                   | Comentario         |
-| -------------------------------------------------------------------------------- | ---------------------------------------- | ------------------ |
-| {{SpecName('CSS3 Backgrounds', '#box-shadow', 'box-shadow')}} | {{Spec2('CSS3 Backgrounds')}} | Definición inicial |
-
-cssinfo}}
+{{Specifications}}
 
 ## Compatibilidad de los navegadores
 

--- a/files/es/web/css/caret-color/index.md
+++ b/files/es/web/css/caret-color/index.md
@@ -69,9 +69,7 @@ input {
 
 ## Especificaciones
 
-| Especificación                                                                       | Estatus                      | Comentarios         |
-| ------------------------------------------------------------------------------------ | ---------------------------- | ------------------- |
-| {{SpecName("CSS3 UI", "#propdef-caret-color", "caret-color")}} | {{Spec2("CSS3 UI")}} | Initial definition. |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/css/child_combinator/index.md
+++ b/files/es/web/css/child_combinator/index.md
@@ -41,11 +41,7 @@ div > span {
 
 ## Especificaciones
 
-| Especificación                                                                                       | Estatus                              | Comentarios        |
-| ---------------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------ |
-| {{SpecName('CSS4 Selectors', '#child-combinators', 'child combinator')}}     | {{Spec2('CSS4 Selectors')}} |                    |
-| {{SpecName('CSS3 Selectors', '#child-combinators', 'child combinators')}}     | {{Spec2('CSS3 Selectors')}} | Sin cambios        |
-| {{SpecName('CSS2.1', 'selector.html#child-selectors', 'child selectors')}} | {{Spec2('CSS2.1')}}             | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/css/clip/index.md
+++ b/files/es/web/css/clip/index.md
@@ -74,10 +74,7 @@ p { border:dotted;  position:relative; }
 
 ## Especificaciones
 
-| Especificación                                                                   | Estado                                   | Comentario                     |
-| -------------------------------------------------------------------------------- | ---------------------------------------- | ------------------------------ |
-| {{ SpecName('CSS3 Transitions', '#animatable-css', 'clip') }} | {{ Spec2('CSS3 Transitions') }} | Define `clip` como animatable. |
-| {{ SpecName('CSS2.1', 'visufx.html#clipping', 'clip') }}     | {{ Spec2('CSS2.1') }}             |                                |
+{{Specifications}}
 
 ## Compatibilidad entre exploradores
 

--- a/files/es/web/css/css_box_model/index.md
+++ b/files/es/web/css/css_box_model/index.md
@@ -67,8 +67,4 @@ original_slug: Web/CSS/CSS_Modelo_Caja
 
 ## Especificaciones
 
-| Especificación                               | Estado                       | Comentario         |
-| -------------------------------------------- | ---------------------------- | ------------------ |
-| {{SpecName("CSS3 Box")}}             | {{Spec2("CSS3 Box")}} |                    |
-| {{SpecName("CSS2.1", "box.html")}} | {{Spec2("CSS2.1")}}     |                    |
-| {{SpecName("CSS1")}}                 | {{Spec2("CSS1")}}     | Definición Inicial |
+{{Specifications}}

--- a/files/es/web/css/css_box_model/mastering_margin_collapsing/index.md
+++ b/files/es/web/css/css_box_model/mastering_margin_collapsing/index.md
@@ -66,9 +66,7 @@ p {
 
 ## Especificaciones
 
-| Specification                                                                                        | Status                   | Comment            |
-| ---------------------------------------------------------------------------------------------------- | ------------------------ | ------------------ |
-| {{SpecName("CSS2.1", "box.html#collapsing-margins", "margin collapsing")}} | {{Spec2("CSS2.1")}} | Initial definition |
+{{Specifications}}
 
 ## También puedes ver
 

--- a/files/es/web/css/css_flexible_box_layout/index.md
+++ b/files/es/web/css/css_flexible_box_layout/index.md
@@ -78,9 +78,7 @@ Las propiedades `align-content`, `align-self`, `align-items` y `justify-content`
 
 ## Especificaciones
 
-| Especificación                           | Estado                               | Comentario          |
-| ---------------------------------------- | ------------------------------------ | ------------------- |
-| {{ SpecName('CSS3 Flexbox') }} | {{ Spec2('CSS3 Flexbox') }} | Definición inicial. |
+{{Specifications}}
 
 ## Ver también
 

--- a/files/es/web/css/css_logical_properties/index.md
+++ b/files/es/web/css/css_logical_properties/index.md
@@ -118,9 +118,7 @@ Las propiedades y valores lógicos usan los términos abstractos de bloque (_blo
 
 ## Especificaciones
 
-| Especificación                                       | Estado                                           | Comentario          |
-| ---------------------------------------------------- | ------------------------------------------------ | ------------------- |
-| {{SpecName("CSS Logical Properties")}} | {{Spec2("CSS Logical Properties")}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad en los Navegadores
 

--- a/files/es/web/css/css_transitions/index.md
+++ b/files/es/web/css/css_transitions/index.md
@@ -31,9 +31,7 @@ translation_of: Web/CSS/CSS_Transitions
 
 ## Especificaciones
 
-| Especificación                               | Estado                                   | Comentario         |
-| -------------------------------------------- | ---------------------------------------- | ------------------ |
-| {{SpecName('CSS3 Transitions')}} | {{Spec2('CSS3 Transitions')}} | Definición Inicial |
+{{Specifications}}
 
 ## Ver además
 

--- a/files/es/web/css/filter-function/index.md
+++ b/files/es/web/css/filter-function/index.md
@@ -38,11 +38,9 @@ El tipo de datos `<filter-function>` se especifica utilizando una de las funcion
 - [`sepia()`](/en-US/docs/Web/CSS/filter-function/sepia)
   - : Convierte la imagen a sepia.
 
-## Especificación
+## Especificaciones
 
-| Especificación                                                                                                   | Estado                               | Comentarios         |
-| ---------------------------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------- |
-| {{ SpecName('Filters 1.0', '#typedef-filter-function', '&lt;filter-function&gt;') }} | {{ Spec2('Filters 1.0') }} | Definición inicial. |
+{{Specifications}}
 
 ## Ver también
 

--- a/files/es/web/css/flex-basis/index.md
+++ b/files/es/web/css/flex-basis/index.md
@@ -174,9 +174,7 @@ flex-basis: unset;
 
 ## Especificaciones
 
-| Especificación                                                                           | Estado                           | Comentario         |
-| ---------------------------------------------------------------------------------------- | -------------------------------- | ------------------ |
-| {{SpecName('CSS3 Flexbox', '#propdef-flex-basis', 'flex-basis')}} | {{Spec2('CSS3 Flexbox')}} | Definición Inicial |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/css/flex-grow/index.md
+++ b/files/es/web/css/flex-grow/index.md
@@ -98,9 +98,7 @@ flex-grow: unset;
 
 ## Especificaciones
 
-| Especificación                                                           | Estado                           | Comentario         |
-| ------------------------------------------------------------------------ | -------------------------------- | ------------------ |
-| {{SpecName('CSS3 Flexbox','#flex-grow','flex-grow')}} | {{Spec2('CSS3 Flexbox')}} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad de Navegadores
 

--- a/files/es/web/css/frequency/index.md
+++ b/files/es/web/css/frequency/index.md
@@ -47,11 +47,7 @@ Aunque todas las unidades representen la misma frecuencia para el valor `0`, la 
 
 ## Especificaciones
 
-| Especificación                                                                       | Estatus                          | Comentarios        |
-| ------------------------------------------------------------------------------------ | -------------------------------- | ------------------ |
-| {{SpecName('CSS3 Values', '#frequency', '&lt;frequency&gt;')}} | {{Spec2('CSS3 Values')}} | Definición inicial |
-
-Este tipo de dato fue introducido inicialmente en [CSS Nivel 2](http://www.w3.org/TR/CSS2/) para el ya obsoleto [grupo de merios aural](/en/CSS/Aural), donde era usado para definir el tono de la voz. Dicho grupo fue descontinuado desde entonces, pero el tipo de datos `<frequency>` ha sido reintroducido en CSS3, aunque ninguna propiedad CSS lo usa por el momento.
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/css/gradient/index.md
+++ b/files/es/web/css/gradient/index.md
@@ -86,11 +86,9 @@ background: repeating-linear-gradient(to top left, red, red 5px, white 5px, whit
 
 Al igual que con cualquier caso de interpolación de colores, los gradientes se calculan en el espacio de color alfa-premultiplicado. Esto impide que sombras de gris inesperadas aparezcan cuando el color o la opacidad están variando. (debe tener en cuenta que los navegadores mas antiguos no tienen incorporado este tipo de comportamient cuando utiliza la palabra clave "[transparent](/es/docs/Web/CSS/color_value#transparent_keyword)" del inglés transparente ( para más información hacer clic en el link))
 
-## Especificación
+## Especificaciones
 
-| Especificación                                                                   | Estado                           | Comentario |
-| -------------------------------------------------------------------------------- | -------------------------------- | ---------- |
-| {{SpecName('CSS3 Images', '#gradients', '&lt;gradient&gt;')}} | {{Spec2('CSS3 Images')}} |            |
+{{Specifications}}
 
 ## Compatibilidad del navegador
 

--- a/files/es/web/css/grid-template-areas/index.md
+++ b/files/es/web/css/grid-template-areas/index.md
@@ -90,11 +90,9 @@ Estas áreas no están asociadas a ningún elemento particular de la cuadrícula
 
 _{{EmbedLiveSample("Example", "100%", "250px")}}_
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                                                | Status                       | Comment            |
-| ------------------------------------------------------------------------------------------------------------ | ---------------------------- | ------------------ |
-| {{SpecName("CSS3 Grid", "#propdef-grid-template-areas", "grid-template-areas")}} | {{Spec2("CSS3 Grid")}} | Initial definition |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/css/id_selectors/index.md
+++ b/files/es/web/css/id_selectors/index.md
@@ -55,12 +55,7 @@ Nótese que esto es equivalente al siguiente {{Cssxref("Attribute_selectors", "a
 
 ## Especificaciones
 
-| Especificación                                                                               | Estado                               | Comentarios         |
-| -------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------- |
-| {{SpecName("CSS4 Selectors", "#id-selectors", "ID selectors")}}         | {{Spec2("CSS4 Selectors")}} |                     |
-| {{SpecName("CSS3 Selectors", "#id-selectors", "ID selectors")}}         | {{Spec2("CSS3 Selectors")}} |                     |
-| {{SpecName("CSS2.1", "selector.html#id-selectors", "ID selectors")}} | {{Spec2("CSS2.1")}}             |                     |
-| {{SpecName("CSS1", "#id-as-selector", "ID selectors")}}                     | {{Spec2("CSS1")}}             | Definición Inicial. |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/inline-size/index.md
+++ b/files/es/web/css/inline-size/index.md
@@ -67,11 +67,9 @@ La propiedad `inline-size` toma los mismos valores de las propiedades {{cssxref(
 
 {{EmbedLiveSample("Ejemplo")}}
 
-## Especificación
+## Especificaciones
 
-| Especificación                                                                                                       | Estado                                           | Comentario          |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------- |
-| {{SpecName("CSS Logical Properties", "#logical-dimension-properties", "inline-size")}} | {{Spec2("CSS Logical Properties")}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/css/inset-block/index.md
+++ b/files/es/web/css/inset-block/index.md
@@ -69,11 +69,9 @@ div {
 
 {{EmbedLiveSample("Ejemplo", 140, 140)}}
 
-## Especificación
+## Especificaciones
 
-| Especificación                                                                                           | Estado                                           | Comentario          |
-| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------- |
-| {{SpecName("CSS Logical Properties", "#propdef-inset-block", "inset-block")}} | {{Spec2("CSS Logical Properties")}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/css/inset-inline-start/index.md
+++ b/files/es/web/css/inset-inline-start/index.md
@@ -66,11 +66,9 @@ div {
 
 {{EmbedLiveSample("Ejemplo", 140, 140)}}
 
-## Especificación
+## Especificaciones
 
-| Especificación                                                                                                           | Estado                                           | Comentario          |
-| ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ | ------------------- |
-| {{SpecName("CSS Logical Properties", "#propdef-inset-inline-start", "inset-inline-start")}} | {{Spec2("CSS Logical Properties")}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/css/justify-content/index.md
+++ b/files/es/web/css/justify-content/index.md
@@ -145,9 +145,7 @@ Resultados en:
 
 ## Especificaciones
 
-| Especificación                                                                           | Estado                           | Comentario         |
-| ---------------------------------------------------------------------------------------- | -------------------------------- | ------------------ |
-| {{SpecName('CSS3 Flexbox', '#justify-content', 'justify-content')}} | {{Spec2('CSS3 Flexbox')}} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/css/margin-bottom/index.md
+++ b/files/es/web/css/margin-bottom/index.md
@@ -49,14 +49,9 @@ margin-bottom: inherit; /*margen heredado*/
 
 [Ver en el JSFiddle](https://jsfiddle.net/V3hrF)
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                                | Status                                   | Comment                                |
-| -------------------------------------------------------------------------------------------- | ---------------------------------------- | -------------------------------------- |
-| {{SpecName('CSS3 Box', '#the-margin', 'margin-bottom')}}                 | {{Spec2('CSS3 Box')}}             | No significant change.                 |
-| {{SpecName('CSS3 Transitions', '#animatable-css', 'margin-bottom')}} | {{Spec2('CSS3 Transitions')}} | Defines `margin-bottom` as animatable. |
-| {{SpecName('CSS2.1', 'box.html#margin-properties', 'margin-bottom')}} | {{Spec2('CSS2.1')}}                 | Removes its effect on inline elements. |
-| {{SpecName('CSS1', '#margin-bottom', 'margin-bottom')}}                     | {{Spec2('CSS1')}}                 | Initial definition.                    |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/css/margin-inline-start/index.md
+++ b/files/es/web/css/margin-inline-start/index.md
@@ -65,11 +65,9 @@ div {
 
 {{EmbedLiveSample("Ejemplo", 140, 140)}}
 
-## Especificación
+## Especificaciones
 
-| Especificación                                                                                                               | Estado                                           | Comentario          |
-| ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------- |
-| {{SpecName("CSS Logical Properties", "#propdef-margin-inline-start", "margin-inline-start")}} | {{Spec2("CSS Logical Properties")}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/css/object-fit/index.md
+++ b/files/es/web/css/object-fit/index.md
@@ -132,10 +132,7 @@ img {
 
 ## Especificaciones
 
-| Especificación                                                                   | Estado                           | Comentario          |
-| -------------------------------------------------------------------------------- | -------------------------------- | ------------------- |
-| {{SpecName('CSS4 Images', '#the-object-fit', 'object-fit')}} | {{Spec2('CSS4 Images')}} |                     |
-| {{SpecName('CSS3 Images', '#the-object-fit', 'object-fit')}} | {{Spec2('CSS3 Images')}} | Definicion inicial. |
+{{Specifications}}
 
 ## Compatibilidad
 

--- a/files/es/web/css/order/index.md
+++ b/files/es/web/css/order/index.md
@@ -80,9 +80,7 @@ Para más información por favor, referirse a estos artículos:
 
 ## Especificaciones
 
-| Especificación                                                               | Estado                           | Comentario         |
-| ---------------------------------------------------------------------------- | -------------------------------- | ------------------ |
-| {{SpecName('CSS3 Flexbox', '#order-property', 'order')}} | {{Spec2('CSS3 Flexbox')}} | Definición Inicial |
+{{Specifications}}
 
 ## Compatibilidad de Navegadores
 

--- a/files/es/web/css/padding-block-start/index.md
+++ b/files/es/web/css/padding-block-start/index.md
@@ -66,11 +66,9 @@ div {
 
 {{EmbedLiveSample("Ejemplo", 140, 140)}}
 
-## Especificación
+## Especificaciones
 
-| Especificación                                                                                                               | Estado                                           | Comentario          |
-| ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------- |
-| {{SpecName("CSS Logical Properties", "#propdef-padding-block-start", "padding-block-start")}} | {{Spec2("CSS Logical Properties")}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/css/padding-inline/index.md
+++ b/files/es/web/css/padding-inline/index.md
@@ -68,11 +68,9 @@ div {
 
 {{EmbedLiveSample("Ejemplo", 140, 140)}}
 
-## Especificación
+## Especificaciones
 
-| Especificación                                                                                                   | Estado                                           | Comentario          |
-| ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------- |
-| {{SpecName("CSS Logical Properties", "#propdef-padding-inline", "padding-inline")}} | {{Spec2("CSS Logical Properties")}} | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad en navegadores
 

--- a/files/es/web/css/position/index.md
+++ b/files/es/web/css/position/index.md
@@ -284,12 +284,7 @@ Los elementos que se desplazan que contienen contenido `fixed` o `sticky` conten
 
 ## Especificaciones
 
-| Especificación                                                                           | Status                                   | Comentario                            |
-| ---------------------------------------------------------------------------------------- | ---------------------------------------- | ------------------------------------- |
-| {{SpecName('CSS2.1', 'visuren.html#propdef-position', 'position')}} | {{Spec2('CSS2.1')}}                 |                                       |
-| {{SpecName('CSS3 Positioning','#position-property','position')}}     | {{Spec2('CSS3 Positioning')}} | Añade valor de la propiedad `sticky`. |
-
-{{cssinfo}}
+{{Specifications}}
 
 ## Compatibilidad
 

--- a/files/es/web/css/repeat/index.md
+++ b/files/es/web/css/repeat/index.md
@@ -126,9 +126,7 @@ repeat(4, 10px [col-start] 30% [col-middle] 400px [col-end])
 
 ## Especificaciones
 
-| Specification                                                            | Status                       | Comment            |
-| ------------------------------------------------------------------------ | ---------------------------- | ------------------ |
-| {{SpecName("CSS Grid", "#funcdef-repeat", "repeat()")}} | {{Spec2("CSS Grid")}} | Initial definition |
+{{Specifications}}
 
 ## Compatibilidad del navegador
 

--- a/files/es/web/css/scroll-behavior/index.md
+++ b/files/es/web/css/scroll-behavior/index.md
@@ -98,9 +98,7 @@ scroll-page {
 
 ## Especificaciones
 
-| Especificación                                                                                   | Estado                           | Comentarios           |
-| ------------------------------------------------------------------------------------------------ | -------------------------------- | --------------------- |
-| {{SpecName('CSSOM View', "#propdef-scroll-behavior", 'scroll-behavior')}} | {{Spec2('CSSOM View')}} | Initial specification |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/text-decoration-line/index.md
+++ b/files/es/web/css/text-decoration-line/index.md
@@ -75,9 +75,7 @@ p {
 
 ## Especificaciones
 
-| Especificación                                                                                                   | Estado                                       | Comentarios                                                                                                        |
-| ---------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| {{SpecName('CSS3 Text Decoration', '#text-decoration-line', 'text-decoration-line')}} | {{Spec2('CSS3 Text Decoration')}} | Definición inicial. La propiedad {{cssxref("text-decoration")}} no era una forma reducida anteriormente. |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/css/text-decoration-style/index.md
+++ b/files/es/web/css/text-decoration-style/index.md
@@ -84,9 +84,7 @@ text-decoration-style: unset;
 
 ## Especificaciones
 
-| Especificación                                                                                                           | Estado                                           | Comentarios                                                                                                        |
-| ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
-| {{ SpecName('CSS3 Text Decoration', '#text-decoration-style', 'text-decoration-style') }} | {{ Spec2('CSS3 Text Decoration') }} | Definición inicial. La propiedad {{cssxref("text-decoration")}} no era una forma reducida anteriormente. |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/css/transform-function/index.md
+++ b/files/es/web/css/transform-function/index.md
@@ -122,9 +122,7 @@ Existen varias funciones disponibles para describir transformaciones en CSS. Cad
 
 ## Especificaciones
 
-| Especificación                                                                           | Estado                               | Comentarios        |
-| ---------------------------------------------------------------------------------------- | ------------------------------------ | ------------------ |
-| {{SpecName('CSS3 Transforms', '#transform-property', 'transform')}} | {{Spec2('CSS3 Transforms')}} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/css/transform-function/translate/index.md
+++ b/files/es/web/css/transform-function/translate/index.md
@@ -160,9 +160,7 @@ div {
 
 ## Especificaciones
 
-| Especificación                                                                                           | Estado                               | Comentario         |
-| -------------------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------ |
-| {{SpecName('CSS3 Transforms', '#funcdef-transform-translate', 'translate()')}} | {{Spec2('CSS3 Transforms')}} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/transform-function/translatey/index.md
+++ b/files/es/web/css/transform-function/translatey/index.md
@@ -129,9 +129,7 @@ div {
 
 ## Especificaciones
 
-| Especificación                                                                                               | Estatus                              | Comentarios        |
-| ------------------------------------------------------------------------------------------------------------ | ------------------------------------ | ------------------ |
-| {{SpecName("CSS3 Transforms", "#funcdef-transform-translatey", "translateY()")}} | {{Spec2("CSS3 Transforms")}} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/css/transform-function/translatez/index.md
+++ b/files/es/web/css/transform-function/translatez/index.md
@@ -140,9 +140,7 @@ Si el valor `perspective()` es menor que el valor `translateZ()`, como `transfor
 
 ## Especificaciones
 
-| Especificación                                                                               | Estado                                   | Comentario                                                       |
-| -------------------------------------------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------- |
-| {{SpecName('CSS Transforms 2', '#transform-functions', 'transform')}} | {{Spec2('CSS Transforms 2')}} | Agrega funciones de transformación 3D al CSS Transform estándar. |
+{{Specifications}}
 
 ## Compatibilidad con navegador
 

--- a/files/es/web/css/transition-delay/index.md
+++ b/files/es/web/css/transition-delay/index.md
@@ -306,11 +306,9 @@ var intervalID = window.setInterval(updateTransition, 7000);
 
 {{EmbedLiveSample("delay_4s",275,150)}}
 
-## Specifications
+## Especificaciones
 
-| Specification                                                                                        | Status                                   | Comment |
-| ---------------------------------------------------------------------------------------------------- | ---------------------------------------- | ------- |
-| {{ SpecName('CSS3 Transitions', '#transition-delay', 'transition-delay') }} | {{ Spec2('CSS3 Transitions') }} |         |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/es/web/css/transition-duration/index.md
+++ b/files/es/web/css/transition-duration/index.md
@@ -302,11 +302,7 @@ var intervalID = window.setInterval(updateTransition, 7000);
 
 ## Especificaciones
 
-| Specification                                                                                                            | Status                                   | Comment            |
-| ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------- | ------------------ |
-| {{ SpecName('CSS3 Transitions', '#transition-duration-property', 'transition-duration') }} | {{ Spec2('CSS3 Transitions') }} | Definición Inicial |
-
-{{cssinfo}}
+{{Specifications}}
 
 ## Compatibilidad con Navegadores
 

--- a/files/es/web/css/transition/index.md
+++ b/files/es/web/css/transition/index.md
@@ -48,9 +48,7 @@ Hay muchos ejemplos de transiciones CSS en el artículo principal [CSS transitio
 
 ## Especificaciones
 
-| Specification                                                                        | Status                                   | Comment |
-| ------------------------------------------------------------------------------------ | ---------------------------------------- | ------- |
-| {{ SpecName('CSS3 Transitions', '#transition', 'transition') }} | {{ Spec2('CSS3 Transitions') }} |         |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/css/type_selectors/index.md
+++ b/files/es/web/css/type_selectors/index.md
@@ -48,12 +48,7 @@ span {
 
 ## Especificaciones
 
-| Especificación                                                                                           | Estado                               | Comentarios         |
-| -------------------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------- |
-| {{SpecName('CSS4 Selectors', '#type-selectors', 'Type (tag name) selector')}} | {{Spec2('CSS4 Selectors')}} | Ningún cambio.      |
-| {{SpecName('CSS3 Selectors', '#type-selectors', 'type selectors')}}                 | {{Spec2('CSS3 Selectors')}} | Ningún cambio.      |
-| {{SpecName('CSS2.1', 'selector.html#type-selectors', 'type selectors')}}         | {{Spec2('CSS2.1')}}             |                     |
-| {{SpecName('CSS1', '#basic-concepts', 'type selectors')}}                             | {{Spec2('CSS1')}}             | Definición inicial. |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/writing-mode/index.md
+++ b/files/es/web/css/writing-mode/index.md
@@ -122,11 +122,9 @@ th {background-color: lightgray; }
 
 ![](https://mdn.mozillademos.org/files/12201/writing-mode-actual-result.png)
 
-## Especificación
+## Especificaciones
 
-| Especificación                                                                           | Estado                                   | Comentario         |
-| ---------------------------------------------------------------------------------------- | ---------------------------------------- | ------------------ |
-| {{SpecName("CSS3 Writing Modes", "#block-flow", "writing-mode")}} | {{Spec2("CSS3 Writing Modes")}} | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad entre navegadores
 

--- a/files/es/web/mathml/element/math/index.md
+++ b/files/es/web/mathml/element/math/index.md
@@ -118,10 +118,7 @@ Además de los siguientes atributos, el elemento `<math>` acepta cualquier atrib
 
 ## Especificaciones
 
-| Especificación                                                                                                       | Estado                       | Comentario             |
-| -------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ---------------------- |
-| {{ SpecName('MathML3', 'chapter2.html#interf.toplevel', 'The Top-Level math Element') }} | {{ Spec2('MathML3') }} | Especificación actual  |
-| {{ SpecName('MathML2', 'chapter7.html#interf.toplevel', 'The Top-Level math Element') }} | {{ Spec2('MathML2') }} | Especificación inicial |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/svg/element/a/index.md
+++ b/files/es/web/svg/element/a/index.md
@@ -110,11 +110,7 @@ svgns|a:hover, svgns|a:active {
 
 ## Especificaciones
 
-| Especificación                                                                                                                           | Estado                               | Comentatio                                                                             |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | -------------------------------------------------------------------------------------- |
-| {{SpecName('Referrer Policy', '#referrer-policy-delivery-referrer-attribute', 'referrer attribute')}} | {{Spec2('Referrer Policy')}} | Añadido el atributo `referrerpolicy`.                                                  |
-| {{SpecName("SVG2", "linking.html#Links", "&lt;a&gt;")}}                                                                 | {{Spec2("SVG2")}}             | Se sustituye el atributo {{SVGAttr("xlink:href")}} por {{SVGAttr("href")}} |
-| {{SpecName("SVG1.1", "linking.html#Links", "&lt;a&gt;")}}                                                             | {{Spec2("SVG1.1")}}             | Definición inicial                                                                     |
+{{Specifications}}
 
 ## Compatibilidad del navegador
 

--- a/files/es/web/svg/element/animate/index.md
+++ b/files/es/web/svg/element/animate/index.md
@@ -73,10 +73,7 @@ Para más información (en inglés):
 
 ## Especificaciones
 
-| Specification                                                                                    | Status                                   | Comment            |
-| ------------------------------------------------------------------------------------------------ | ---------------------------------------- | ------------------ |
-| {{SpecName("SVG Animations 2", "#AnimateElement", "&lt;animate&gt;")}}     | {{Spec2("SVG Animations 2")}} | Sin cambios        |
-| {{SpecName("SVG1.1", "animate.html#AnimateElement", "&lt;animate&gt;")}} | {{Spec2("SVG1.1")}}                 | Definición inicial |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/svg/element/script/index.md
+++ b/files/es/web/svg/element/script/index.md
@@ -124,12 +124,7 @@ Este elemento contiene los [atributos globales](/es/docs/Web/HTML/Atributos_Glob
 
 ## Especificaciones
 
-| Especificación                                                                                               | Estado                                       | Comentario                    |
-| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------- | ----------------------------- |
-| {{SpecName('HTML WHATWG', "scripting.html#the-script-element", "&lt;script&gt;")}} | {{Spec2('HTML WHATWG')}}             | Agrega el tipo module.        |
-| {{SpecName('HTML5 W3C', 'scripting-1.html#script', '&lt;script&gt;')}}                 | {{Spec2('HTML5 W3C')}}                 |                               |
-| {{SpecName('HTML4.01', 'interact/scripts.html#h-18.2.1', '&lt;script&gt;')}}         | {{Spec2('HTML4.01')}}                 |                               |
-| {{SpecName('Subresource Integrity', '#htmlscriptelement', '&lt;script&gt;')}}     | {{Spec2('Subresource Integrity')}} | Agrega el atributo integrity. |
+{{Specifications}}
 
 ## Compatibilidad de navegadores
 

--- a/files/es/web/svg/element/svg/index.md
+++ b/files/es/web/svg/element/svg/index.md
@@ -82,12 +82,9 @@ Esta puede ser incluida en un docuemnto HTML5 de la siguiente manera:
 
 Este elemento implementa [`SVGSVGElement`](/en-US/docs/Web/API/SVGSVGElement) en la interfaz.
 
-## Specificaciones
+## Especificaciones
 
-| Specificación                                                                        | Estado                   | Comentario         |
-| ------------------------------------------------------------------------------------ | ------------------------ | ------------------ |
-| {{SpecName('SVG2', 'struct.html#NewDocument', '&lt;svg&gt;')}} | {{Spec2('SVG2')}} |                    |
-| {{SpecName('SVG1.1', 'struct.html#NewDocument', '&lt;svg&gt;')}} | {{Spec2('SVG1.1')}} | Initial definition |
+{{Specifications}}
 
 ## Compatibilidad de Navegador
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove deprecated spec2 macro from es

Process: replace the section with the `{{Specifications}}` macro

### Motivation

The chore of deprecated macros removal

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Relates to https://github.com/orgs/mdn/discussions/263
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
