### PR TITLE
misinterpretation of audiodescription

### DIFF
--- a/files/fr/learn/accessibility/multimedia/index.md
+++ b/files/fr/learn/accessibility/multimedia/index.md
@@ -268,7 +268,7 @@ Si vous créez votre propre interface utilisateur pour présenter votre audio et
 
 ### Descriptions audio
 
-Dans les cas où des éléments visuels accompagnent votre son, vous devez fournir une description de l’audio pour décrire ce contenu supplémentaire.
+Dans les cas où des éléments visuels accompagnent votre son, vous devez fournir une piste sonore vocale pour décrire ce contenu supplémentaire.
 
 Dans de nombreux cas, il s'agira simplement d'une vidéo. Dans ce cas, vous pouvez implémenter des légendes à l'aide des techniques décrites dans la section suivante de l'article.
 


### PR DESCRIPTION
audio description is a voice description of visual elements to help blind and visually impaired people. Not text or image description of sounds to help hard of hearing or deaf people aka « description de l’audio » (description of audio).

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The sentence « audio description » is ambiguous in the English language. It can be a text or visual explanation of a sound or a voice description of visual elements. In the accessibility domain it is the latter.

### Motivation

Because the initial translation is a misinterpretation because of the ambiguity of the English sentence and the required expertise about the accessibility domain.

### Additional details

W3C WAI reference: https://www.w3.org/WAI/media/av/description/

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->

I didn't find any related issue containing "audiodescription" or "audio description"

<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

I didn't find any related PR containing "audiodescription" or "audio description"

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
