### PR TITLE
fix(ru): code example in `flatMap` article

### DIFF
--- a/files/ru/web/javascript/reference/global_objects/array/flatmap/index.md
+++ b/files/ru/web/javascript/reference/global_objects/array/flatmap/index.md
@@ -47,7 +47,7 @@ var new_array = arr.flatMap(function callback(currentValue[, index[, array]]) {
 ### `map` и `flatMap`
 
 ```js
-let arr1 = 1, 2, 3, 4];
+let arr1 = [1, 2, 3, 4];
 
 arr1.map(x => [x * 2]);
 // [[2], [4], [6], [8]]


### PR DESCRIPTION
### Adding missing bracket in `arr1` array declaration

### Missing bracket

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Array declaration is incomplete because a bracket is messing at the beginning

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

- Fixes https://github.com/mdn/translated-content/issues/9815
