### PR TITLE
Correct web storage link

### DIFF
--- a/files/ru/web/api/storage/getitem/index.md
+++ b/files/ru/web/api/storage/getitem/index.md
@@ -42,7 +42,7 @@ function setStyles() {
 }
 ```
 
-> **Примечание:** Чтобы вживую посмотреть на работу функции, посетите страницу демонстрации [Web Storage](https://github.com/mdn/web-storage-demo).
+> **Примечание:** Чтобы вживую посмотреть на работу функции, посетите страницу демонстрации [Web Storage](https://mdn.github.io/dom-examples/web-storage/).
 
 ## Спецификации
 


### PR DESCRIPTION
### Description

Web Storage Demo redirect to a not found page, the right link is https://mdn.github.io/dom-examples/web-storage/

### Motivation

Users can not see the correct `web-storage` page


### Related issues and pull requests

- Fixes: https://github.com/mdn/translated-content/issues/9694

