### PR TITLE
Correct not found image

### DIFF
--- a/files/es/learn/css/css_layout/normal_flow/index.md
+++ b/files/es/learn/css/css_layout/normal_flow/index.md
@@ -60,7 +60,7 @@ Echemos un vistazo a un ejemplo sencillo que explica todo esto:
 
 <p>Estamos separados por nuestros márgenes. Debido al colapso del margen, estamos separados por el ancho de uno de nuestros márgenes, no por ambos.</p>
 
-<p>Los elementos en línea <span>como este</span> y <span>este otro</span> se ubican en la misma y la de los nodos de texto adyacentes, mientras hay espacio en la misma línea. Si un elemento en línea desborda, <span>sigue por la línea siguiente, si es posible (como la que contiene este texto)</span>, o simplemente pasa a una línea nueva, como hace esta imagen: <img src="https://mdn.mozillademos.org/files/13360/long.jpg"></p>
+<p>Los elementos en línea <span>como este</span> y <span>este otro</span> se ubican en la misma y la de los nodos de texto adyacentes, mientras hay espacio en la misma línea. Si un elemento en línea desborda, <span>sigue por la línea siguiente, si es posible (como la que contiene este texto)</span>, o simplemente pasa a una línea nueva, como hace esta imagen: <img src="https://yari-demos.prod.mdn.mozit.cloud/en-US/docs/Learn/CSS/CSS_layout/Normal_Flow/long.jpg"></p>
 ```
 
 ```css


### PR DESCRIPTION
### Description

Wrong image corrected based on the US documentation

### Motivation

An image is broken in the `Basic document flow` part

### Additional details

- Fixes: https://github.com/mdn/translated-content/issues/9516

