### PR TITLE
Remove transclusion calls of `EmbedLiveSample` [es]

### DIFF
--- a/files/es/learn/forms/how_to_build_custom_form_controls/index.md
+++ b/files/es/learn/forms/how_to_build_custom_form_controls/index.md
@@ -288,13 +288,13 @@ So here's the result with our three states:
   <tbody>
     <tr>
       <td>
-        {{EmbedLiveSample("Basic_state",120,130, "", "HTML/Forms/How_to_build_custom_form_widgets/Example_1")}}
+        {{EmbedLiveSample("Basic_state",120,130, "", "Learn/Forms/How_to_build_custom_form_controls/Example_1")}}
       </td>
       <td>
-        {{EmbedLiveSample("Active_state",120,130, "", "HTML/Forms/How_to_build_custom_form_widgets/Example_1")}}
+        {{EmbedLiveSample("Active_state",120,130, "", "Learn/Forms/How_to_build_custom_form_controls/Example_1")}}
       </td>
       <td>
-        {{EmbedLiveSample("Open_state",120,130, "", "HTML/Forms/How_to_build_custom_form_widgets/Example_1")}}
+        {{EmbedLiveSample("Open_state",120,130, "", "Learn/Forms/How_to_build_custom_form_controls/Example_1")}}
       </td>
     </tr>
     <tr>
@@ -395,10 +395,10 @@ window.addEventListener("load", function () {
   <tbody>
     <tr>
       <td>
-        {{EmbedLiveSample("No_JS",120,130, "", "HTML/Forms/How_to_build_custom_form_widgets/Example_2")}}
+        {{EmbedLiveSample("No_JS",120,130, "", "Learn/Forms/How_to_build_custom_form_controls/Example_2")}}
       </td>
       <td>
-        {{EmbedLiveSample("JS",120,130, "", "HTML/Forms/How_to_build_custom_form_widgets/Example_2")}}
+        {{EmbedLiveSample("JS",120,130, "", "Learn/Forms/How_to_build_custom_form_controls/Example_2")}}
       </td>
     </tr>
     <tr>
@@ -571,7 +571,7 @@ At that point, our widget will change state according to our design, but its val
 
 | Live example                                                                                                                                                       |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| {{EmbedLiveSample("Change_states",120,130, "", "HTML/Forms/How_to_build_custom_form_widgets/Example_3")}}                       |
+| {{EmbedLiveSample("Change_states",120,130, "", "Learn/Forms/How_to_build_custom_form_controls/Example_3")}} |
 | [Check out the source code](/es/docs/HTML/Forms/How_to_build_custom_form_widgets/Example_3) |
 
 ### Handling the widget's value
@@ -671,7 +671,7 @@ With that, we're done! Here's the result:
 
 | Live example                                                                                                                                                       |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| {{EmbedLiveSample("Change_states",120,130, "", "HTML/Forms/How_to_build_custom_form_widgets/Example_4")}}                       |
+| {{EmbedLiveSample("Change_states",120,130, "", "Learn/Forms/How_to_build_custom_form_controls/Example_4")}} |
 | [Check out the source code](/es/docs/HTML/Forms/How_to_build_custom_form_widgets/Example_4) |
 
 But wait a second, are we really done?
@@ -738,7 +738,7 @@ Here is the final result of all these changes (you'll get a better feel for this
 
 | Live example                                                                                                                                                             |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| {{EmbedLiveSample("Change_states",120,130, "", "HTML/Forms/How_to_build_custom_form_widgets/Example_5")}}                             |
+| {{EmbedLiveSample("Change_states",120,130, "", "Learn/Forms/How_to_build_custom_form_controls/Example_5")}} |
 | [Check out the final source code](/es/docs/HTML/Forms/How_to_build_custom_form_widgets/Example_5) |
 
 ## Conclusion

--- a/files/es/learn/forms/how_to_structure_a_web_form/index.md
+++ b/files/es/learn/forms/how_to_structure_a_web_form/index.md
@@ -298,7 +298,7 @@ Pongamos en práctica estas ideas y creemos un formulario un poco más complicad
 
 Debajo puedes ver en acción el formulario terminado (también lo encontrarás en GitHub; consulta el [código fuente](https://github.com/mdn/learning-area/blob/master/html/forms/html-form-structure/payment-form.html) de nuestro payment-form.html y [ejecútalo en vivo](https://mdn.github.io/learning-area/html/forms/html-form-structure/payment-form.html)):
 
-{{EmbedLiveSample("A_payment_form","100%",620, "", "/en-US/Learn/Forms/How_to_structure_a_web_form/Example")}}
+{{EmbedLiveSample('',"100%",620)}}
 
 ## ¡Prueba tus habilidades!
 

--- a/files/es/learn/forms/your_first_form/index.md
+++ b/files/es/learn/forms/your_first_form/index.md
@@ -281,7 +281,82 @@ En el lado del servidor, la secuencia de comandos de la URL «`/my-handling-form
 
 ¡Enhorabuena!, has creado tu primer formulario web. Debería verse así:
 
-{{ EmbedLiveSample('A_simple_form', '100%', '240', '', 'Learn/Forms/Your_first_form/Example') }}
+```html hidden
+<form action="/my-handling-form-page" method="post">
+  <div>
+    <label for="name">Nombre:</label>
+    <input type="text" id="name" name="user_name" />
+  </div>
+  <div>
+    <label for="mail">Correo electrónico:</label>
+    <input type="email" id="mail" name="user_email" />
+  </div>
+  <div>
+    <label for="msg">Mensaje:</label>
+    <textarea id="msg" name="user_message"></textarea>
+  </div>
+  <div class="button">
+    <button type="submit">Envia tu mensaje</button>
+  </div>
+</form>
+```
+```css hidden
+form {
+  /* Just to center the form on the page */
+  margin: 0 auto;
+  width: 400px;
+  /* To see the limits of the form */
+  padding: 1em;
+  border: 1px solid #ccc;
+  border-radius: 1em;
+}
+div + div {
+  margin-top: 1em;
+}
+label {
+  /* To make sure that all label have the same size and are properly align */
+  display: inline-block;
+  width: 90px;
+  text-align: right;
+}
+input,
+textarea {
+  /* To make sure that all text field have the same font settings
+     By default, textarea are set with a monospace font */
+  font: 1em sans-serif;
+  /* To give the same size to all text field */
+  width: 300px;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  /* To harmonize the look & feel of text field border */
+  border: 1px solid #999;
+}
+input:focus,
+textarea:focus {
+  /* To give a little highlight on active elements */
+  border-color: #000;
+}
+textarea {
+  /* To properly align multiline text field with their label */
+  vertical-align: top;
+  /* To give enough room to type some text */
+  height: 5em;
+  /* To allow users to resize any textarea vertically
+     It works only on Chrome, Firefox and Safari */
+  resize: vertical;
+}
+.button {
+  /* To position the buttons to the same position of the text fields */
+  padding-left: 90px; /* same size as the label elements */
+}
+button {
+  /* This extra margin represent the same space as the space between
+     the labels and their text fields */
+  margin-left: 0.5em;
+}
+```
+
+{{EmbedLiveSample('', '100%', '240')}}
 
 Pero esto es solo el comienzo: ahora ha llegado el momento de profundizar en el tema. Los formularios tienen mucho más potencial de lo que hemos visto aquí y los artículos siguientes de este módulo te ayudarán a dominarlo.
 

--- a/files/es/web/api/canvas_api/tutorial/compositing/index.md
+++ b/files/es/web/api/canvas_api/tutorial/compositing/index.md
@@ -28,7 +28,7 @@ No solo podemos dibujar formas nuevas detrás de las ya existentes sino que las 
 
 Vea [ejemplos de composición](/es/docs/Web/API/Canvas_API/Tutorial/Compositing/Example) para el código de los siguientes ejemplos.
 
-{{EmbedLiveSample("Compositing_example", 750, 6750, "" ,"Web/API/Canvas_API/Tutorial/Compositing/Example")}}
+{{EmbedLiveSample("Ejemplo_de_composición", 750, 6750, "" ,"Web/API/Canvas_API/Tutorial/Compositing/Example")}}
 
 ## Trazado de Recorte
 
@@ -110,6 +110,6 @@ En las primeras líneas de código, dibujamos un rectángulo negro del tamaño d
 
 Todo lo que se dibuja después de crear un recorte aparecerá dentro de su trazado. Se puede ver claramente esto en el dibujo de gradiente lineal que realizamos a continuación. Después se ubican estrellas en 50 posiciones alteatorias y escaladas utilizando la función `drawStar()`. Una vez más, las estrellas solo aparecen dentro del recorte trazado en el lienzo.
 
-{{EmbedLiveSample("A_clip_example", "180", "180", "https://mdn.mozillademos.org/files/208/Canvas_clip.png")}}
+{{EmbedLiveSample("A_clip_example", "180", "190", "canvas_clip.png")}}
 
 {{PreviousNext("Web/API/Canvas_API/Tutorial/Transformations", "Web/API/Canvas_API/Tutorial/Basic_animations")}}

--- a/files/es/web/css/-moz-outline-radius/index.md
+++ b/files/es/web/css/-moz-outline-radius/index.md
@@ -86,7 +86,7 @@ border: 1px solid black; outline: dotted red;
 
 ### Result
 
-{{ EmbedLiveSample('Example', '', '', '', 'Web/CSS/-moz-outline-radius') }}
+{{EmbedLiveSample('', '', '')}}
 
 ## Notas
 

--- a/files/es/web/css/@counter-style/symbols/index.md
+++ b/files/es/web/css/@counter-style/symbols/index.md
@@ -67,7 +67,7 @@ symbols: indic-numbers;
 
 ### Resultado
 
-{{ EmbedLiveSample('Example', '', '', '', 'Web/CSS/@counter-style/symbols') }}
+{{EmbedLiveSample('', '', '')}}
 
 ## Especificaciones
 

--- a/files/es/web/css/css_positioning/understanding_z_index/adding_z-index/index.md
+++ b/files/es/web/css/css_positioning/understanding_z_index/adding_z-index/index.md
@@ -34,8 +34,6 @@ Esta propiedad es asignada con un valor entero (positivo o negativo), el cuál r
 
 En el siguiente ejempo, el orden de apilamiento de las capas es organizado usando z-index. El z-index del DIV#5 no hace efecto ya que este no es un elemento posicionado.
 
-{{ EmbedLiveSample('Example_source_code', '468', '365', '', 'Web/Guide/CSS/Understanding_z_index/Adding_z-index') }}
-
 ### Código fuente de ejemplo
 
 ```html
@@ -149,6 +147,8 @@ En el siguiente ejempo, el orden de apilamiento de las capas es organizado usand
 </body>
 </html>
 ```
+
+{{EmbedLiveSample('', '468', '365')}}
 
 ### También puedes ver
 

--- a/files/es/web/css/css_positioning/understanding_z_index/stacking_and_float/index.md
+++ b/files/es/web/css/css_positioning/understanding_z_index/stacking_and_float/index.md
@@ -35,8 +35,6 @@ Este comportamiento puede ser explicado con una versión mejorada de la lista pr
 
 > **Nota:** En el ejemplo debajo, todos los bloques excepto el no posicionado son translúcidos para mostrar el orden de apilamiento. Si la opacidad del bloque no posicionado (DIV #4) es reducida, entonces algo extraño ocurre: el fondo y el borde de ese bloque sobresale por encima de los bloques flotantes, pero aun debajo de los bloques posicionados. Yo no pude entender si esto es un bug o una interpretación peculiar de la especificación. (Aplicar opacidad debería crear implícitamente un contexto de apilamiento.)
 
-{{ EmbedLiveSample('Example_source_code', '563', '255', '', 'Web/Guide/CSS/Understanding_z_index/Stacking_and_float') }}
-
 ## Código fuente de ejemplo
 
 ### HTML
@@ -118,6 +116,10 @@ b {
   background-color: #fdd;
 }
 ```
+
+### Resultado
+
+{{EmbedLiveSample('', '563', '255')}}
 
 ### También puedes ver
 

--- a/files/es/web/css/css_positioning/understanding_z_index/stacking_context_example_1/index.md
+++ b/files/es/web/css/css_positioning/understanding_z_index/stacking_context_example_1/index.md
@@ -107,7 +107,7 @@ En términos de contextos de apilamiento, el DIV #1 y el DIV #3 son simplemente 
 
 ### Resultado
 
-{{ EmbedLiveSample('Example', '', '', '', 'Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_1') }}
+{{EmbedLiveSample('', '', '')}}
 
 ### También puedes ver
 

--- a/files/es/web/css/css_positioning/understanding_z_index/stacking_context_example_2/index.md
+++ b/files/es/web/css/css_positioning/understanding_z_index/stacking_context_example_2/index.md
@@ -10,8 +10,6 @@ original_slug: >-
 
 Este es un ejemplo muy simple, pero es la clave para entender el concepto de _contexto de apilamiento._ Tenemos los mismos 4 DIVs del ejemplo previo, pero ahora las propiedades z-index son asignadas en ambos niveles de la jerarquía.
 
-{{ EmbedLiveSample('Example_source_code', '352', '270', '', 'Web/Guide/CSS/Understanding_z_index/Stacking_context_example_2') }}
-
 Puedes ver que el DIV #2 (z-index: 2) está encima del DIV #3 (z-index: 1), porque ambos pertenecen al mismo contexto de apilamiento (el contexto raíz), así que los valores z-index indican cómo son apilados los elementos.
 
 Lo que puede ser considerado extraño es que el DIV #2 (z-index: 2) está encima del DIV #4 (z-index: 10), a pesar de sus valores z-index. La razón es que ellos no pertenecen al mismo contexto de apilamiento. El DIV #4 pertenece al contexto de apilamiento creado por el DIV #3, y como explicamos previamente el DIV #3 (y todos su contenido) está debajo del DIV #2.
@@ -109,6 +107,8 @@ span.bold { font-weight: bold; }
 </body>
 </html>
 ```
+
+{{EmbedLiveSample('', '352', '270')}}
 
 ### También puedes ver
 

--- a/files/es/web/css/css_positioning/understanding_z_index/stacking_context_example_3/index.md
+++ b/files/es/web/css/css_positioning/understanding_z_index/stacking_context_example_3/index.md
@@ -14,8 +14,6 @@ Tomemos como ejemplo un menú jerárquico de tres niveles formado por varios DIV
 
 Si los tres niveles del menú se superponen parcialmente, entonces gestionar el apilamiento se podría convertir en un problema.
 
-{{ EmbedLiveSample('Example_source_code', '320', '330', '', 'Web/Guide/CSS/Understanding_z_index/Stacking_context_example_3') }}
-
 El menú de primer nivel solo tiene posición relativa, así que ningún contexto de apilamiento es creado.
 
 El menú de segundo nivel tiene posición absoluta dentro del elemento padre. Para colocarlo encima de todos los menus de primer nivel, usamos z-index. El problema es que para cada menú de segundo nivel, un contexto de apilamiento es creado y cada menú de tercer nivel pertenece al contexto de su padre.
@@ -155,6 +153,8 @@ div.lev3 {
 
 </body></html>
 ```
+
+{{EmbedLiveSample('', '320', '330')}}
 
 ### También puedes ver
 

--- a/files/es/web/css/css_positioning/understanding_z_index/stacking_without_z-index/index.md
+++ b/files/es/web/css/css_positioning/understanding_z_index/stacking_without_z-index/index.md
@@ -107,7 +107,7 @@ En el siguiente ejemplo, los bloques con posiciones absolutas y relativas son ap
 
 (Si la imagen no aparece en CodePen, haz clic en el botón Tidy en la sección CSS)
 
-{{ EmbedLiveSample('Example', '', '', '', 'Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_without_z-index') }}
+{{EmbedLiveSample('', '', '')}}
 
 ### También puedes ver
 

--- a/files/es/web/css/css_transforms/using_css_transforms/index.md
+++ b/files/es/web/css/css_transforms/using_css_transforms/index.md
@@ -21,7 +21,7 @@ Se usan dos propiedades principalmente para definir las transformaciones CSS: {{
 
 Esta es una imagen inalterada del logo de MDN:
 
-![MDN Logo](https://mdn.mozillademos.org/files/12539/Screen%20Shot%202016-02-16%20at%2015.53.54.png)
+![MDN Logo](logo.png)
 
 ### Ejemplo: Rotando
 
@@ -30,10 +30,10 @@ Aquí está el logo MDN en un iframe rotado 90 grados desde su esquina inferior 
 ```html
 <img style="transform: rotate(90deg);
             transform-origin: bottom left;"
-     src="https://mdn.mozillademos.org/files/12539/Screen%20Shot%202016-02-16%20at%2015.53.54.png">
+     src="logo.png">
 ```
 
-{{ EmbedLiveSample('Ejemplo_Rotando', 'auto', 240, '', 'Web/CSS/CSS_Transforms/Using_CSS_transforms') }}
+{{EmbedLiveSample('', 'auto', 240)}}
 
 ### Ejemplo: Torciendo y desplazando
 
@@ -42,8 +42,10 @@ Aquí está el logo MDN torcido 10 grados y desplazado 150 pixels en el eje X.
 ```html
 <img style="transform: skewx(10deg) translatex(150px);
             transform-origin: bottom left;"
-     src="https://mdn.mozillademos.org/files/12539/Screen%20Shot%202016-02-16%20at%2015.53.54.png">
+     src="logo.png">
 ```
+
+{{EmbedLiveSample('', '', '')}}
 
 ## Propiedades CSS específicas para 3D
 
@@ -59,11 +61,7 @@ Definímos como de rápido se encogen con la propiedad {{ cssxref("perspective")
 | ---------------- | -------------------- | ------ | ------ |
 | 123456           | 123456               | 123456 | 123456 |
 
-El segundo elemento a configurar es la posición del espectador, con la propiedad {{ cssxref("perspective-origin") }}. Por defecto, la perspectiva está centrada en el espectad
-
-{{ EmbedLiveSample('Definiendo_una_perspectiva', '', '', '', 'Web/CSS/CSS_Transforms/Using_CSS_transforms') }}
-
-or, pero no siempre es lo adecuado.
+El segundo elemento a configurar es la posición del espectador, con la propiedad {{ cssxref("perspective-origin") }}. Por defecto, la perspectiva está centrada en el espectador, pero no siempre es lo adecuado.
 
 | `perspective-origin:150px 150px;` | `perspective-origin:50% 50%;` | `perspective-origin:-50px -50px;` |
 | --------------------------------- | ----------------------------- | --------------------------------- |

--- a/files/es/web/css/flex-basis/index.md
+++ b/files/es/web/css/flex-basis/index.md
@@ -170,7 +170,7 @@ flex-basis: unset;
 
 ### Resultados
 
-{{EmbedLiveSample('Example', '860', '360', '', 'Web/CSS/flex-basis')}}
+{{EmbedLiveSample('', '860', '360')}}
 
 ## Especificaciones
 

--- a/files/es/web/css/flex-direction/index.md
+++ b/files/es/web/css/flex-direction/index.md
@@ -111,7 +111,7 @@ Se aceptan los siguientes valores:
 
 ### Resultado
 
-{{ EmbedLiveSample('Example', '', '300', '', 'Web/CSS/flex-direction') }}
+{{EmbedLiveSample('', '', '300')}}
 
 ## Sobre Accesibilidad
 

--- a/files/es/web/css/flex-grow/index.md
+++ b/files/es/web/css/flex-grow/index.md
@@ -94,7 +94,7 @@ flex-grow: unset;
 
 ### Resultado
 
-{{EmbedLiveSample('Example', '700px', '300px', '', 'Web/CSS/flex-grow')}}
+{{EmbedLiveSample('', '700px', '300px')}}
 
 ## Especificaciones
 

--- a/files/es/web/css/flex-shrink/index.md
+++ b/files/es/web/css/flex-shrink/index.md
@@ -149,7 +149,7 @@ La propiedad `flex-shrink` se especifica como un único [`<número>`](#number).
 
 ### Result
 
-{{ EmbedLiveSample('Example', '500px', '300px', '', 'Web/CSS/flex-shrink') }}
+{{EmbedLiveSample('', '500px', '300px')}}
 
 ## Especificaciones
 

--- a/files/es/web/css/font-variant-alternates/index.md
+++ b/files/es/web/css/font-variant-alternates/index.md
@@ -86,7 +86,7 @@ p.variant {
 
 **Nota:** se necesita la fuente Open Type [Leitura Display Swashes](http://ufonts.com/download/leituradisplay-swashes-opentype/470776.html) instalada para que este ejemplo funcione
 
-{{ EmbedLiveSample('Example', '', '', '', 'Web/CSS/font-variant-alternates') }}
+{{EmbedLiveSample('', '', '')}}
 
 ## Especificaciones
 

--- a/files/es/web/css/order/index.md
+++ b/files/es/web/css/order/index.md
@@ -55,9 +55,8 @@ Aquí tiene un trozo de HTML básico:
 
 El siguiente código CSS debería crear un diseño clásico de dos barra laterales que rodea a un bloque de contenido. EL Módulo de Diseño de Caja Flexible crea automáticamente bloques de tamaño vertical igual y utiliza todo el espacio horizontal disponible.
 
-\#main { display: flex; text-align:center; }
-
 ```css
+#main { display: flex; text-align:center; }
 #main > article { flex:1;        order: 2; }
 #main > nav     { width: 200px;  order: 1; }
 #main > aside   { width: 200px;  order: 3; }
@@ -65,7 +64,7 @@ El siguiente código CSS debería crear un diseño clásico de dos barra lateral
 
 ### Resultado
 
-{{ EmbedLiveSample('Examples' ,'','','','Web/CSS/order') }}
+{{EmbedLiveSample('','','')}}
 
 ## Sobre Accesibilidad
 

--- a/files/es/web/css/text-overflow/index.md
+++ b/files/es/web/css/text-overflow/index.md
@@ -94,7 +94,7 @@ p {
 
 ### Result
 
-{{EmbedLiveSample('Examples', 300, 220, '', 'Web/CSS/text-overflow')}}
+{{EmbedLiveSample('', 300, 220)}}
 
 <table class="standard-table">
   <thead>

--- a/files/es/web/html/element/input/index.md
+++ b/files/es/web/html/element/input/index.md
@@ -351,7 +351,7 @@ Nótese, sin embargo, que esto no es estándar, y no tendrá efecto en otros nav
 
 ### Resultado
 
-{{ EmbedLiveSample('Example_1_Simple_input_box', '', '100', '', 'Web/HTML/Element/input') }}
+{{EmbedLiveSample('', '', '100')}}
 
 ## Ejemplo 2: Escenario de uso común
 
@@ -369,7 +369,7 @@ Nótese, sin embargo, que esto no es estándar, y no tendrá efecto en otros nav
 
 ### Resultado
 
-{{ EmbedLiveSample('Example_2_Common_use-case_scenario', '', '200', '', 'Web/HTML/Element/input') }}
+{{EmbedLiveSample('', '', '200')}}
 
 ### Usando mozactionhint en Firefox mobile
 

--- a/files/es/web/html/global_attributes/itemref/index.md
+++ b/files/es/web/html/global_attributes/itemref/index.md
@@ -83,7 +83,7 @@ El atributo itemref puede ser solo especificado en elementos que tienen un atrib
 
 ### Resultado
 
-{{ EmbedLiveSample('Example', '', '', '', 'Web/HTML/Global_attributes/itemref') }}
+{{EmbedLiveSample('', '', '')}}
 
 ## Especificación
 

--- a/files/es/web/html/microdata/index.md
+++ b/files/es/web/html/microdata/index.md
@@ -149,7 +149,7 @@ _[itemref](/es/docs/Web/HTML/Global_attributes/itemref)_: las propiedades que no
 
 ### Resultado
 
-{{ EmbedLiveSample('HTML', '', '100', '', 'Web/HTML/Microdata') }}
+{{EmbedLiveSample('', '', '100')}}
 
 > **Nota:** una útil herramienta para extraer estructuras de microdatos a partir de HTML es la [Herramienta de pruebas de datos estructurados](<https://developers.google.com/structured-data/testing-tool/ Structured Data Testing Tool>) de Google. Ponla a prueba en el HTML mostrado más arriba.
 

--- a/files/es/web/javascript/guide/regular_expressions/index.md
+++ b/files/es/web/javascript/guide/regular_expressions/index.md
@@ -332,7 +332,7 @@ function testInfo(phoneInput) {
 
 #### Resultado
 
-{{ EmbedLiveSample('Using_special_characters_to_verify_input', '', '', '', 'Web/JavaScript/Guide/Regular_Expressions') }}
+{{EmbedLiveSample('', '', '')}}
 
 ## Herramientas
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove transclusion calls of `EmbedLiveSample` in `es` and fix examples when apply

### Motivation

The chore of remove transclusion calls of `{{EmbedLiveSample}}` (Parity with mdn/content/issues/15872)

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fix #6509, contains:

- Fix #6786
- Fix #6832
- Fix #6833
- Fix #6834
- Fix #6835
- Fix #6836
- Fix #6837
- Fix #6838
- Fix #6839
- Fix #6840
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
