### PR TITLE
stroke-dasharray: add "space at start" example

### DIFF
--- a/files/fr/web/svg/attribute/stroke-dasharray/index.md
+++ b/files/fr/web/svg/attribute/stroke-dasharray/index.md
@@ -33,7 +33,7 @@ html,body,svg { height:100% }
 ```
 
 ```html
-<svg viewBox="0 0 30 10" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 30 12" xmlns="http://www.w3.org/2000/svg">
   <!-- Pas de tirets ou d'espaces -->
   <line x1="0" y1="1" x2="30" y2="1" stroke="black" />
 
@@ -52,6 +52,10 @@ html,body,svg { height:100% }
   <!-- Traits et espaces de tailles différentes avec un nombre pair de valeurs -->
   <line x1="0" y1="9" x2="30" y2="9" stroke="black"
           stroke-dasharray="4 1 2 3" />
+
+  <!-- Traits commençant par un espace -->
+  <line x1="0" y1="11" x2="30" y2="11" stroke="black"
+          stroke-dasharray="0 4 0" />
 </svg>
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add "space at start" example for `stroke-dasharray`.

Notice that this is for the `fr` version.

### Motivation

It is not clear that we can start our "pattern" using a space. Doing that clarify that this is possible and show a simple way to achieve our result.

### Additional details

N/A
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

I did not open an issue for this.
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
