### PR TITLE
Fix markup for the type of orientation

### DIFF
--- a/files/ja/web/manifest/orientation/index.md
+++ b/files/ja/web/manifest/orientation/index.md
@@ -9,7 +9,7 @@ slug: Web/Manifest/orientation
   <tbody>
     <tr>
       <th scope="row">型</th>
-      <td>`String`</td>
+      <td><code>String</code></td>
     </tr>
     <tr>
       <th scope="row">必須</th>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Use `<code>String</code>` instead of `` `String` `` like other pages.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The type is displayed as `` `String` `` and it looked weird for me.

The proposing markup `<code>String</code>` is used in other pages. For example, it is used here:

https://github.com/mdn/translated-content/blob/62b2b82989340ed4ca079f197c6ce7a20c2816fe/files/ja/web/manifest/name/index.md?plain=1#L12

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
