### PR TITLE
Improve translation about waitUntil()

### DIFF
--- a/files/ja/web/api/service_worker_api/index.md
+++ b/files/ja/web/api/service_worker_api/index.md
@@ -52,7 +52,7 @@ slug: Web/API/Service_Worker_API
 
 サービスワーカーは {{DOMxRef("FetchEvent")}} イベントを使用してリクエストに応答することができます。{{DOMxRef("FetchEvent.respondWith()")}} メソッドを使用して、これらのリクエストに対するレスポンスを何でも思うように変更できます。
 
-> **メモ:** `install`/`activate` イベントは完了するまでに時間がかかる可能性があるため、サービスワーカーの仕様書では {{domxref("ExtendableEvent.waitUntil", "waitUntil()")}} メソッドを提供しており、これが `install` または `activate` を呼び出すと、プロミスを渡します。プロミスが正常に解決されるまで、関数イベントはサービスワーカーに配信されません。
+> **メモ:** `install`/`activate` イベントは完了するまでに時間がかかる可能性があるため、サービスワーカーの仕様書では {{domxref("ExtendableEvent.waitUntil", "waitUntil()")}} メソッドを提供しています。 `install` または `activate` イベント内でプロミスを指定してこのメソッドを呼び出すと、プロミスが正常に解決されるまで、 `fetch` や `push` などの関数イベントはサービスワーカーに配信されません。
 
 最初の基本的な例をどのように構築するかについての完全なチュートリアルは、[サービスワーカーの使用](/ja/docs/Web/API/Service_Worker_API/Using_Service_Workers)を読んでください。
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Improve translation of the note about `waitUntil()` in the Service Worker API page.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Current translation looks like the `waitUntil()` method calls `install` or `activate` and hands promises.

This looks weird because, according to the English version, the `waitUntil()` method is actually called from `install` or `activate` and handed promises.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
