### PR TITLE
「Arpanet」や「ARPAnet」を「ARPANET」に統一

### DIFF
--- a/files/ja/glossary/arpanet/index.md
+++ b/files/ja/glossary/arpanet/index.md
@@ -1,9 +1,9 @@
 ---
-title: Arpanet
+title: ARPANET
 slug: Glossary/Arpanet
 ---
 
-**ARPAnet** (Advanced Research Projects Agency NETwork、高等研究計画局ネットワーク) は、初期のコンピューターネットワークであり、機密軍事情報を送信し、アメリカ全土の有力な研究グループを結ぶ堅牢な媒体として 1969 年に構築されました。ARPAnet は、最初に NCP (network control protocol、ネットワーク制御プロトコル) を実行し、その後、インターネットプロトコルまたは {{glossary("TCP")}}/{{glossary("IPv6","IP")}} スイートの最初のバージョンを実行し、ARPAnet を初期の{{glossary("Internet","インターネット")}}の重要な部分にしました。ARPAnet は 1990 年の初めに閉鎖されました。
+**ARPANET** (Advanced Research Projects Agency NETwork、高等研究計画局ネットワーク) は、初期のコンピューターネットワークであり、機密軍事情報を送信し、アメリカ全土の有力な研究グループを結ぶ堅牢な媒体として 1969 年に構築されました。ARPANET は、最初に NCP (network control protocol、ネットワーク制御プロトコル) を実行し、その後、インターネットプロトコルまたは {{glossary("TCP")}}/{{glossary("IPv6","IP")}} スイートの最初のバージョンを実行し、ARPANET を初期の{{glossary("Internet","インターネット")}}の重要な部分にしました。ARPANET は 1990 年の初めに閉鎖されました。
 
 ## より詳しく知る
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

見出しを始め、英語版の表記に寄せました。slugについては英語版でも「Arpanet」と表記されているのでそのままにしています。

### Related issues and pull requests

Fix https://github.com/mozilla-japan/translation/issues/664
