### PR TITLE
Fix links: File/ to File_API/

### DIFF
--- a/files/ja/web/api/blob/index.md
+++ b/files/ja/web/api/blob/index.md
@@ -131,4 +131,4 @@ const text = await blob.text();
 - {{DOMxRef("FileReader")}}
 - {{DOMxRef("File")}}
 - {{DOMxRef("URL.createObjectURL")}}
-- [ウェブアプリケーションからのファイルの使用](/ja/docs/Web/API/File/Using_files_from_web_applications)
+- [ウェブアプリケーションからのファイルの使用](/ja/docs/Web/API/File_API/Using_files_from_web_applications)

--- a/files/ja/web/api/blob/size/index.md
+++ b/files/ja/web/api/blob/size/index.md
@@ -46,4 +46,4 @@ for (var i = 0; i < files.length; i++) {
 ## あわせて参照
 
 - {{domxref("Blob")}}
-- [Web アプリケーションからのファイルの使用](/ja/docs/Web/API/File/Using_files_from_web_applications)
+- [Web アプリケーションからのファイルの使用](/ja/docs/Web/API/File_API/Using_files_from_web_applications)

--- a/files/ja/web/api/blob/slice/index.md
+++ b/files/ja/web/api/blob/slice/index.md
@@ -39,4 +39,4 @@ var newBlob = blob.slice(start, end, contentType);
 ## あわせて参照
 
 - {{domxref("Blob")}}
-- [Web アプリケーションからのファイルの使用](/ja/docs/Web/API/File/Using_files_from_web_applications)
+- [Web アプリケーションからのファイルの使用](/ja/docs/Web/API/File_API/Using_files_from_web_applications)

--- a/files/ja/web/api/blob/type/index.md
+++ b/files/ja/web/api/blob/type/index.md
@@ -54,4 +54,4 @@ for (i = 0; i < files.length; i++) {
 ## あわせて参照
 
 - {{domxref("Blob")}}
-- [Web アプリケーションからのファイルの使用](/ja/docs/Web/API/File/Using_files_from_web_applications)
+- [Web アプリケーションからのファイルの使用](/ja/docs/Web/API/File_API/Using_files_from_web_applications)

--- a/files/ja/web/api/file/index.md
+++ b/files/ja/web/api/file/index.md
@@ -11,7 +11,7 @@ slug: Web/API/File
 
 `File` オブジェクトは特別な種類の {{DOMxRef("Blob")}} オブジェクトであり、 Blob が利用できる場面ではどこでも利用できます。特に、{{DOMxRef("FileReader")}}、{{DOMxRef("URL.createObjectURL()")}}、{{DOMxRef("createImageBitmap()")}}、{{DOMxRef("XMLHttpRequest", "", "send()")}} は、`Blob` と `File` の両方を受け付けます。
 
-詳しい情報や例は、[ウェブアプリケーションからのファイルの使用](/ja/docs/Web/API/File/Using_files_from_web_applications) を参照してください。
+詳しい情報や例は、[ウェブアプリケーションからのファイルの使用](/ja/docs/Web/API/File_API/Using_files_from_web_applications) を参照してください。
 
 {{InheritanceDiagram}}
 
@@ -61,6 +61,6 @@ _`File` インターフェイスはメソッドを定義せず、{{DOMxRef("Blob
 
 ## 関連情報
 
-- [ウェブアプリケーションからのファイルの使用](/ja/docs/Web/API/File/Using_files_from_web_applications)
+- [ウェブアプリケーションからのファイルの使用](/ja/docs/Web/API/File_API/Using_files_from_web_applications)
 - {{DOMxRef("FileReader")}}
 - [DOM の File API をクロームコードで使う](/ja/docs/Extensions/Using_the_DOM_File_API_in_chrome_code) (Firefox アドオンのような Gecko で実行される特権コード向け)

--- a/files/ja/web/api/file/name/index.md
+++ b/files/ja/web/api/file/name/index.md
@@ -58,4 +58,4 @@ function processSelectedFiles(fileInput) {
 
 ## 関連情報
 
-- [ウェブアプリケーションからのファイルの使用](/ja/docs/Web/API/File/Using_files_from_web_applications)
+- [ウェブアプリケーションからのファイルの使用](/ja/docs/Web/API/File_API/Using_files_from_web_applications)

--- a/files/ja/web/api/file/type/index.md
+++ b/files/ja/web/api/file/type/index.md
@@ -47,5 +47,5 @@ function showType(fileInput) {
 
 ## 関連情報
 
-- [ウェブアプリケーションからのファイルの使用](/ja/docs/Web/API/File/Using_files_from_web_applications)
+- [ウェブアプリケーションからのファイルの使用](/ja/docs/Web/API/File_API/Using_files_from_web_applications)
 - ブログ記事: [Be skeptical of client-reported MIME types](https://textslashplain.com/2018/07/26/be-skeptical-of-client-reported-mime-content-types/)

--- a/files/ja/web/api/filelist/index.md
+++ b/files/ja/web/api/filelist/index.md
@@ -148,6 +148,6 @@ document.querySelector("#myfiles").onchange=pullfiles;
 
 ## 関連情報
 
-- [ウェブアプリケーションからのファイルを使用](/ja/docs/Web/API/File/Using_files_from_web_applications)
+- [ウェブアプリケーションからのファイルの使用](/ja/docs/Web/API/File_API/Using_files_from_web_applications)
 - [`File`](/ja/docs/Web/API/File)
 - [`FileReader`](/ja/docs/Web/API/FileReader)

--- a/files/ja/web/api/filereader/filereader/index.md
+++ b/files/ja/web/api/filereader/filereader/index.md
@@ -5,7 +5,7 @@ slug: Web/API/FileReader/FileReader
 
 **`FileReader()`** コンストラクタは、新しい FileReader を作成します。
 
-`FileReader` の使用方法の詳細については、[Web アプリケーションからのファイルの使用](/ja/docs/Web/API/File/Using_files_from_web_applications) を参照してください。
+`FileReader` の使用方法の詳細については、[Web アプリケーションからのファイルの使用](/ja/docs/Web/API/File_API/Using_files_from_web_applications) を参照してください。
 
 ## シンタックス
 
@@ -39,4 +39,4 @@ function printFile(file) {
 
 ## あわせて参照
 
-- [Web アプリケーションからのファイルの使用](/ja/docs/Web/API/File/Using_files_from_web_applications)
+- [Web アプリケーションからのファイルの使用](/ja/docs/Web/API/File_API/Using_files_from_web_applications)

--- a/files/ja/web/api/filereader/index.md
+++ b/files/ja/web/api/filereader/index.md
@@ -20,7 +20,7 @@ File オブジェクトは、{{HTMLElement("input")}} 要素を使用してフ�
 - {{domxref("FileReader.FileReader", "FileReader()")}}
   - : 新しく作成された `FileReader` を返します。
 
-詳細や例については[ウェブアプリケーションからのファイルの使用](/ja/docs/Web/API/File/Using_files_from_web_applications)を参照してください。
+詳細や例については[ウェブアプリケーションからのファイルの使用](/ja/docs/Web/API/File_API/Using_files_from_web_applications)を参照してください。
 
 ## プロパティ
 
@@ -79,7 +79,7 @@ File オブジェクトは、{{HTMLElement("input")}} 要素を使用してフ�
 
 ## 関連情報
 
-- [ウェブアプリケーションからのファイルの使用](/ja/docs/Web/API/File/Using_files_from_web_applications)
+- [ウェブアプリケーションからのファイルの使用](/ja/docs/Web/API/File_API/Using_files_from_web_applications)
 - {{domxref("File")}}
 - {{domxref("Blob")}}
 - {{domxref("FileReaderSync")}}

--- a/files/ja/web/api/url/createobjecturl/index.md
+++ b/files/ja/web/api/url/createobjecturl/index.md
@@ -28,7 +28,7 @@ objectURL = URL.createObjectURL(object);
 
 ## 例
 
-[オブジェクト URL で画像を表示](/ja/docs/Web/API/File/Using_files_from_web_applications#例_オブジェクト_url_で画像を表示)を参照してください。
+[オブジェクト URL で画像を表示](/ja/docs/Web/API/File_API/Using_files_from_web_applications#例_オブジェクト_url_で画像を表示)を参照してください。
 
 ## 使用上のメモ
 
@@ -57,8 +57,8 @@ objectURL = URL.createObjectURL(object);
 
 ## 関連情報
 
-- [Web アプリケーションからファイルを扱う](/ja/docs/Web/API/File/Using_files_from_web_applications)
-- [オブジェクト URL で画像を表示](/ja/docs/Web/API/File/Using_files_from_web_applications#例_オブジェクト_url_で画像を表示)
+- [ウェブアプリケーションからのファイルの使用](/ja/docs/Web/API/File_API/Using_files_from_web_applications)
+- [オブジェクト URL で画像を表示](/ja/docs/Web/API/File_API/Using_files_from_web_applications#例_オブジェクト_url_で画像を表示)
 - {{domxref("URL.revokeObjectURL()")}}
 - {{domxref("HTMLMediaElement.srcObject")}}
 - {{domxref("FileReader.readAsDataURL()")}}

--- a/files/ja/web/api/url/revokeobjecturl/index.md
+++ b/files/ja/web/api/url/revokeobjecturl/index.md
@@ -28,7 +28,7 @@ window.URL.revokeObjectURL(objectURL);
 
 ## 例
 
-[オブジェクト URL で画像を表示](/ja/docs/Web/API/File/Using_files_from_web_applications#例_オブジェクト_url_で画像を表示)を参照してください。
+[オブジェクト URL で画像を表示](/ja/docs/Web/API/File_API/Using_files_from_web_applications#例_オブジェクト_url_で画像を表示)を参照してください。
 
 ## 仕様
 
@@ -42,6 +42,6 @@ window.URL.revokeObjectURL(objectURL);
 
 ## 関連情報
 
-- [Web アプリケーションからファイルを扱う](/ja/docs/Web/API/File/Using_files_from_web_applications)
-- [オブジェクト URL で画像を表示](/ja/docs/Web/API/File/Using_files_from_web_applications#例_オブジェクト_url_で画像を表示)
+- [ウェブアプリケーションからのファイルの使用](/ja/docs/Web/API/File_API/Using_files_from_web_applications)
+- [オブジェクト URL で画像を表示](/ja/docs/Web/API/File_API/Using_files_from_web_applications#例_オブジェクト_url_で画像を表示)
 - {{domxref("URL.createObjectURL()") }}

--- a/files/ja/web/html/attributes/capture/index.md
+++ b/files/ja/web/html/attributes/capture/index.md
@@ -51,6 +51,6 @@ slug: Web/HTML/Attributes/capture
 
 ## 関連情報
 
-- [ウェブアプリケーションからのファイルの使用](/ja/docs/Web/API/File/Using_files_from_web_applications)
+- [ウェブアプリケーションからのファイルの使用](/ja/docs/Web/API/File_API/Using_files_from_web_applications)
 - [ファイル API](/ja/docs/Web/API/File)
 - {{domxref('HTMLInputElement.files')}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
`/ja/docs/Web/API/File/Using_files_from_web_applications`
へのリンクを、
`/ja/docs/Web/API/File_API/Using_files_from_web_applications`
に張り替える。
ついでにリンクテキストを修正する。

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
該当の記事は日本語版があるのに英語版しかないような表示になっていたので、日本語版が認識されるようにする。

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
