### PR TITLE
Update index.md

### DIFF
--- a/files/pt-br/web/javascript/reference/global_objects/bigint/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/bigint/index.md
@@ -5,7 +5,7 @@ slug: Web/JavaScript/Reference/Global_Objects/BigInt
 
 {{JSRef}}
 
-`BigInt` é um objeto nativo que fornece um modo de representar números inteiros maiores que 253, que é o maior número que o JavaScript consegue, com exatidão, representar com o tipo primitivo {{jsxref("Number")}}.
+`BigInt` é um objeto nativo que fornece um modo de representar números inteiros maiores que 2^53, que é o maior número que o JavaScript consegue, com exatidão, representar com o tipo primitivo {{jsxref("Number")}}.
 
 ## Sintaxe
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- 
   In the first line it says the following about data type bigInt:
  "fornece um modo de representar números inteiros maiores que 253"
  and that statement is incorrect. 

  The correct one would be ".. maiores que 2^53"
-->

### Motivation

<!-- 
  I just added a "^" to show that this is an exponentiation, resulting in ".. números inteiros maiores que 2^53".

  Without this change the reader will think that the number data type is unreliable for values greater than 253, which is wrong. 
  number safely supports values up to Number.MAX_SAFE_INTEGER and bigInt comes as an alternative for values greater than 
  this.
 -->
