### PR TITLE
Fix #9635

### DIFF
--- a/files/fr/learn/javascript/objects/index.md
+++ b/files/fr/learn/javascript/objects/index.md
@@ -1,51 +1,51 @@
 ---
-title: Introduction aux objets JS
+title: Introduction aux objets en JavaScript
 slug: Learn/JavaScript/Objects
-tags:
-  - Apprendre
-  - Article
-  - Auto-évaluation
-  - Débutant
-  - Guide
-  - JavaScript
-  - Objets
-  - Tutoriel
-translation_of: Learn/JavaScript/Objects
+l10n:
+  sourceCommit: 72d4c8678b172f558eca279d98abf23395e0d9a4
 ---
 
-{{JsSidebar}}{{PreviousNext("Apprendre/JavaScript/Building_blocks", "Learn/JavaScript/Objects/Basics")}}
+{{LearnSidebar}}
 
-En JavaScript, la plupart des choses sont des objets, des éléments du cœur de JavaScript, comme les chaînes de caractères et les tableaux, aux interfaces de programmation (APIs) des navigateurs construites sur la base de JavaScript. Vous pouvez même créer vos propres objets pour encapsuler des fonctions liées et des variables au sein de paquets efficaces, et se comportant comme des conteneurs de données. Il est important de comprendre la nature orientée objet du JavaScript si vous souhaitez aller loin dans votre connaissance du langage, aussi, avons-nous fourni ce module afin de vous aider. Ici, nous enseignons la théorie de l’objet et sa syntaxe en détail, ensuite, ce sera à vous de voir comment vous souhaitez créer vos propres objets.
+En JavaScript, la plupart des valeurs manipulées sont des objets, qu'ils proviennent des fonctionnalités natives du langage, comme les tableaux, ou qu'ils soient fournis par les API du navigateur. Il est aussi possible de créer ses propres objets qui contiendront des propriétés avec des données ou des fonctions. JavaScript est un langage orienté objet et la compréhension de cette notion est nécessaire pour approfondir ses connaissances dans ce langage. Nous avons donc construit un module pour vous aider, où nous vous apprendrons la théorie du modèle objet et les détails de la syntaxe JavaScript associée. Nous verrons ensuite comment créer ses propres objets.
+
+> **Remarque :**
+>
+> #### Vous souhaitez devenir développeuse ou développeur web ?
+>
+> Nous avons construit un cursus contenant toutes les informations essentielles pour parvenir à cet objectif.
+>
+> [**Commencer**](/fr/docs/Learn/Front-end_web_developer)
 
 ## Prérequis
 
-Avant de commencer ce module, vous devriez avoir quelques familiarités avec le HTML et le CSS. Il serait raisonnable de travailler sur les modules [Introduction au HTML](/fr/Apprendre/HTML/Introduction_%C3%A0_HTML) et [Introduction au CSS](/fr/Apprendre/CSS/Introduction_%C3%A0_CSS) avant de commencer avec le JavaScript.
+Avant de commencer ce module, vous devriez connaître les bases de [HTML](/fr/docs/Glossary/HTML) et de [CSS](/fr/docs/Glossary/CSS). Nous vous conseillons de réaliser les modules [Introduction à HTML](/fr/docs/Learn/HTML/Introduction_to_HTML) et [Introduction à CSS](/fr/docs/Learn/CSS/First_steps) avant de commencer celui-ci sur JavaScript.
 
-Vous devriez également être familiarisé avec les bases du JavaScript avant de poursuivre en détails avec les objets JavaScript. Avant de commencer ce module, travaillez sur [Premiers pas avec JavaScript](/fr/docs/Learn/JavaScript/First_steps) et [Les blocs de construction en JavaScript](/fr/Apprendre/JavaScript/Building_blocks).
+Vous devriez également connaître les notions de bases sur JavaScript avant d'étudier les objets JavaScript en détails. Avant de démarrer ce module, lisez [Premiers pas en JavaScript](/fr/docs/Learn/JavaScript/First_steps) et [Blocs de construction de JavaScript](/fr/docs/Learn/JavaScript/Building_blocks).
 
-> **Note :** Si vous travaillez sur un ordinateur, une tablette ou un autre appareil où vous n’avez pas la possibilité de créer vos propres fichiers, vous pouvez essayer les (la plupart des) exemples de code grâce à un programme en ligne comme [JSBin](http://jsbin.com/) ou [Thimble](https://thimble.mozilla.org/).
+> **Note :** Si vous travaillez depuis un appareil où vous ne pouvez pas créer vos propres fichiers, vous pouvez essayer la plupart des exemples de code dans un outil de programmation en ligne tel que [JSBin](https://jsbin.com/) ou [Glitch](https://glitch.com/).
 
 ## Guides
 
-- [Les bases de JavaScript orienté objet](/fr/docs/Learn/JavaScript/Objects/Basics)
-  - : Dans le premier article concernant les objets JavaScript, nous découvrirons la syntaxe fondamentale d’un objet JavaScript, et nous revisiterons certaines fonctionnalités du JavaScript que nous avions vues précédemment dans le cours, en insistant sur le fait que bon nombre d'éléments précedemment abordés sont en fait des objets.
+- [Notions de base sur les objets](/fr/docs/Learn/JavaScript/Objects/Basics)
+  - : Dans ce premier article consacré aux objets en JavaScript, nous verrons les fondamentaux de la syntaxe objet en JavaScript et reverrons certaines des fonctionnalités abordées précédemment dans le cours et qui manipulaient déjà des objets.
+- [Prototypes d'objets](/fr/docs/Learn/JavaScript/Objects/Object_prototypes)
+  - : Les prototypes sont le mécanisme par lequel les objets JavaScript héritent des fonctionnalités d'autres objets. Il s'agit d'un mécanisme différent de l'héritage basé sur les classes. Dans cet article, nous verrons comment la chaîne de prototypes fonctionne.
+- [Programmation orientée objet](/fr/docs/Learn/JavaScript/Objects/Object-oriented_programming)
+  - : Dans cet article, nous décrirons certaines notions de base sur la programmation orientée objet à l'aide de classes et verrons en quoi cela diffère du modèle JavaScript qui utilise les prototypes.
+- [Classes en JavaScript](/fr/docs/Learn/JavaScript/Objects/Classes_in_JavaScript)
+  - : JavaScript fournit certaines fonctionnalités pour les personnes qui souhaitent implémenter des programmes utilisant des classes. Dans cet article, nous décrirons ces fonctionnalités.
+- [Manipuler des données en JSON](/fr/docs/Learn/JavaScript/Objects/JSON)
+  - : JSON (<i lang="en">JavaScript Object Notation</i>) est un format textuel standardisé de représentation des données, utilisant la syntaxe objet de JavaScript. Il est utilisé pour la représentation et la transmission de données sur le Web (par exemple transmettre des données d'un serveur à un client afin qu'elles puissent être affichées sur une page web). Ce format étant fréquemment utilisé, nous aborderons dans cet article les outils pour manipuler des données JSON en JavaScript et notamment l'analyse de texte JSON et l'écriture de données en JSON.
+- [Construire des objets en pratique](/fr/docs/Learn/JavaScript/Objects/Object_building_practice)
+  - : Dans les articles qui précèdent, nous avons étudié la théorie objet et la syntaxe JavaScript, fournissant ainsi les notions de bases nécessaires. Dans cet article, nous verrons un exercice concret, vous permettant de mettre en pratique la construction d'objets afin de produire une démo colorée avec des balles rebondissantes.
 
-<!---->
+## Évaluations
 
-- [JavaScript orienté objet pour les débutants](/fr/docs/Learn/JavaScript/Objects/JS_orient%C3%A9-objet)
-  - : Après avoir vu les notions de base, nous nous pencherons sur le JavaScript orienté objet (JSOO) — cet article présente une vue basique de la théorie de la programmation orientée objet (POO), et explore ensuite comment le JavaScript émule les classes d’objet via les fonctions des constructeurs et comment créer des instances d’objet.
-- [Objets prototypes](/fr/docs/Learn/JavaScript/Objects/Prototypes_Objet)
-  - : Les prototypes sont des mécanismes par lesquels les objets JavaScript héritent les fonctionnalités d’un autre objet, et ils fonctionnent différemment des mécanismes d’héritage des langages classiques de programmation orientée objet. Dans cet article, nous explorons cette différence, expliquant comment les chaînes de prototypes fonctionnent et jetant un regard sur comment la propriété prototype peut être utilisée pour ajouter des méthodes aux constructeurs existants.
-- [L’héritage au sein de JavaScript](/fr/docs/Learn/JavaScript/Objects/Heritage)
-  - : Avec la plupart des redoutables détails du JSOO maintenant expliqués, cet article montre comment créer les classes (constructeurs) d’objet “enfant” qui héritent des fonctionnalités de leur classes “parents”. De plus, nous présentons certains conseils sur où et comment utiliser le JSOO.
-- [Manipuler des données JSON](/fr/docs/Learn/JavaScript/Objects/JSON)
-  - : JavaScript Object Notation (JSON) est un format standard pour la représentation de données structurées comme les objets JavaScript, qui est communément utilisé pour représenter et transmettre les données sur les sites web (ex. : Envoyer certaines données du serveur au client, afin d’être affichées sur une page web). Vous le rencontrerez assez souvent. Aussi, dans cet article, nous vous donnons tout ce dont vous avez besoin pour travailler avec le format JSON utilisant le JavaScript, incluant l’accès aux éléments des données dans un objet JSON et l’écriture de votre propre JSON.
-- [Pratiques sur la construction d’objet](/fr/docs/Learn/JavaScript/Objects/Object_building_practice)
-  - : Dans l’article précédent nous avons fait le tour de l’essentiel de la théorie de l’objet JavaScript et les détails de sa syntaxe, vous donnant ainsi une solide base sur laquelle débuter. Dans cet article nous plongeons dans un exercice, vous donnant plus de pratique dans la construction d’objets JavaScript personnalisés, qui produisent quelque chose d’amusant et de plus coloré — quelques balles colorées et bondissantes.
+- [Ajouter des fonctionnalités à notre démo de balles rebondissantes](/fr/docs/Learn/JavaScript/Objects/Adding_bouncing_balls_features)
+  - : Dans cette évaluation, nous vous demandons de repartir de la démo construite précédemment et d'y ajouter certaines fonctionnalités intéressantes.
 
-## Auto-évaluation
+## Voir aussi
 
-- [Ajoutez des fonctionnalitée à notre démo des ballons bondissants](/fr/docs/Learn/JavaScript/Objects/Adding_bouncing_balls_features)
-  - : Dans cette évaluation, vous devrez utiliser la démo des balles bondissantes de l’article précédent comme un point de départ et y ajouter quelques nouvelles et intéressantes fonctionnalités.
-
-{{PreviousNext("Apprendre/JavaScript/Building_blocks", "JavaScript/Guide")}}
+- [JavaScript de Zéro - Module débutant](https://www.javascriptdezero.com/module-debutant)
+  - : Un module de formation en ligne en français avec des leçons vidéo et des exercices et quiz.

--- a/files/fr/learn/javascript/objects/index.md
+++ b/files/fr/learn/javascript/objects/index.md
@@ -11,7 +11,7 @@ En JavaScript, la plupart des valeurs manipulées sont des objets, qu'ils provie
 
 > **Remarque :**
 >
-> #### Vous souhaitez devenir développeuse ou développeur web ?
+> #### Vous souhaitez devenir développeuse ou développeur web&nbsp;?
 >
 > Nous avons construit un cursus contenant toutes les informations essentielles pour parvenir à cet objectif.
 >

--- a/files/fr/learn/javascript/objects/object-oriented_programming/index.md
+++ b/files/fr/learn/javascript/objects/object-oriented_programming/index.md
@@ -1,0 +1,249 @@
+---
+title: Programmation orientée objet
+slug: Learn/JavaScript/Objects/Object-oriented_programming
+l10n:
+  sourceCommit: 72d4c8678b172f558eca279d98abf23395e0d9a4
+---
+
+{{LearnSidebar}}{{PreviousMenuNext("Learn/JavaScript/Objects/Object_prototypes", "Learn/JavaScript/Objects/Classes_in_JavaScript", "Learn/JavaScript/Objects")}}
+
+La programmation orientée objet est un paradigme de programmation fondamental pour de nombreux langages de programmation, dont Java et C++. Dans cet article, nous fournirons un aperçu des notions de base de la programmation orientée objet et décrirons trois concepts&nbsp;:
+
+- Les classes et instances
+- L'héritage
+- L'encapsulation
+
+Nous décrirons ces concepts sans référence particulière à JavaScript, les exemples seront écrits en [pseudo-code](/fr/docs/Glossary/Pseudocode).
+
+> **Note :** Pour être tout à fait précis, les fonctionnalités décrites ici appartiennent à un style particulier de programmation orienté objet basé sur les classes. La plupart du temps, quand on parle de programmation orientée objet, on parle de ce modèle utilisant des classes.
+
+Après ces descriptions, nous verrons en JavaScript comment les constructeurs et la chaîne de prototypes peuvent être rapprochés de ces concepts objets et leurs différences. Dans l'article suivant, nous verrons d'autres fonctionnalités de JavaScript qui simplifient l'implémentation de programmes orientés objet.
+
+<table>
+  <tbody>
+    <tr>
+      <th scope="row">Prérequis&nbsp;:</th>
+      <td>Compréhension des fonctions en JavaScript, notions de bases de JavaScript (voir <a href="/fr/docs/Learn/JavaScript/First_steps">Premiers pas</a> et <a href="/fr/docs/Learn/JavaScript/Building_blocks">Blocs de construction</a >), et notions de base sur les objets (voir <a href="/fr/docs/Learn/JavaScript/Objects/Basics">Introduction aux objets</a> et <a href="/fr/docs/Learn/JavaScript/Objects/Object_prototypes">Prototypes d'objet</a>).</td>
+    </tr>
+    <tr>
+      <th scope="row">Objectifs&nbsp;:</th>
+      <td>Comprendre les concepts élémentaires de la programmation orientée objet basée sur les classes.</td>
+    </tr>
+  </tbody>
+</table>
+
+La programmation orientée objet consiste à modéliser un système comme un ensemble d'objets, où chaque objet représente un aspect donné du système. Les objets contiennent des fonctions (ou méthodes) et des données. Un objet fournit une interface publique pour le reste du code qui voudrait l'utiliser, mais maintient son propre état interne&nbsp;; les autres parties du système n'ont pas à se soucier du fonctionnement interne de l'objet.
+
+## Classes et instances
+
+Lorsqu'on modélise un problème sous la forme d'objets, on crée des définitions abstraites qui représentent les types d'objet qui existent dans le système. Par exemple, si on modélise une école, on pourra avoir des objets pour représenter les enseignants. Les enseignants auront certaines caractéristiques communes&nbsp;: un nom et un sujet d'enseignement. De plus, chaque enseignant pourra réaliser des actions similaires comme noter un devoir ou se présenter au début de l'année.
+
+Ainsi, `Enseignant` pourrait être une **classe** de notre système. La définition d'une classe liste les données et les méthodes dont chaque enseignant dispose.
+
+En pseudo-code, une telle classe pourrait être écrite ainsi&nbsp;:
+
+```
+classe Enseignant
+    propriétés
+        nom
+        matière
+    méthodes
+        noter(devoir)
+        sePrésenter()
+```
+
+On a donc défini une classe `Enseignant` avec&nbsp;:
+
+- Deux propriétés de données&nbsp;: `nom` et `matière`
+- Deux méthodes&nbsp;: `noter()` pour noter un devoir et `sePrésenter()` pour se présenter.
+
+Toute seule, une classe ne fait rien. Il s'agit d'un modèle pour créer des objets réels avec ce type. Chaque enseignant qu'on créera à partir de ce modèle sera appelé une **instance** de la classe `Enseignant`. Le processus de création d'une instance est réalisé par une fonction spéciale appelée **constructeur**. On passera des valeurs au constructeur pour initialiser l'état interne de l'instance.
+
+Généralement, le constructeur fait partie de la définition de la classe et possède le même nom que la classe&nbsp;:
+
+```
+classe Enseignant
+    propriétés
+        nom
+        matière
+    constructeur
+        Enseignant(nom, matière)
+    méthodes
+        noter(devoir)
+        sePrésenter()
+```
+
+Ce constructeur prend deux paramètres afin d'initialiser les propriétés `nom` et `matière` lorsqu'on crée un nouvel enseignant.
+
+Maintenant que nous disposons d'un constructeur, nous pouvons créer des enseignants. Les langages de programmation utilisent souvent le mot-clé  `new` afin d'indiquer qu'un constructeur est appelé.
+
+```js
+guillaume = new Enseignant("Guillaume", "Psychologie");
+liliane = new Enseignant("Liliane", "Poésie");
+
+guillaume.matière; // "Psychologie"
+guillaume.sePrésenter(); // "Je m'appelle Guillaume et je serai votre enseignant·e en psychologie."
+
+liliane.matière; // "Poésie"
+liliane.sePrésenter(); // "Je m'appelle Liliane et je serai votre enseignant·e en poésie."
+```
+
+On a ici créé deux objets, tous les deux des instances de la classe `Enseignant`.
+
+## Héritage
+
+Imaginons qu'on veuille également représenter les étudiants dans notre système. À la différence des enseignants, un élève ne peut pas noter de devoirs, n'enseigne pas une matière donnée et appartient à une promotion d'une année donnée.
+
+Toutefois, les élèves ont également un nom et peuvent aussi se présenter. On pourrait alors écrire la définition de la classe d'un élève ainsi&nbsp;:
+
+```
+classe Élève
+    propriétés
+        nom
+        année
+    constructeur
+        Élève(nom, année)
+    méthodes
+        sePrésenter()
+```
+
+Il serait utile de représenter le fait que les élèves et enseignants partagent des caractéristiques. En fait, il s'agit à un certain niveau du même type de choses. C'est là que **l'héritage** entre en jeu.
+
+On peut déjà observer que les élèves et enseignants sont des personnes et que les personnes ont un nom et peuvent se présenter. On peut alors modifier notre modèle en définissant une nouvelle classe, `Personne`, où on définit les propriétés communes à toutes les personnes. Ensuite, les deux classes `Enseignant` et `Élève` peuvent **dériver** de la classe `Personne`, et ajouter leurs propriétés supplémentaires&nbsp;:
+
+```
+classe Personne
+    propriétés
+        nom
+    constructeur
+        Personne(nom)
+    méthodes
+        sePrésenter()
+
+classe Enseignant : étend Personne
+    propriétés
+        matière
+    constructeur
+        Enseignant(nom, matière)
+    méthodes
+        noter(devoir)
+        sePrésenter()
+
+classe Élève : étend Personne
+    propriétés
+        année
+    constructeur
+        Élève(nom, année)
+    méthodes
+        sePrésenter()
+```
+
+Dans ce cas, on dit alors que `Personne` est la **classe parente** (ou surclasse) des classes `Enseignant` et `Élève`. Réciproquement, `Enseignant` et `Élèves` sont des **classes enfants** (ou sous-classes) de `Personne`.
+
+On peut voir ici que la méthode `sePrésenter()` est définie pour les trois classes. En effet, ces personnes peuvent se présenter différemment&nbsp;:
+
+```js
+guillaume = new Enseignant("Guillaume", "Psychologie");
+guillaume.sePrésenter(); // "Je m'appelle Guillaume et je serai votre enseignant·e en psychologie."
+
+suzanne = new Élève("Suzanne", 1);
+suzanne.sePrésenter(); // "Je m'appelle Suzanne et je suis en première année."
+```
+
+On pourrait avoir une implémentation par défaut de `sePrésenter()` pour les personnes qui ne sont pas des étudiants ou des enseignants&nbsp;:
+
+```js
+thomas = new Person("Thomas");
+thomas.sePrésenter(); // "Je m'appelle Thomas.'
+```
+
+Cette fonctionnalité où une méthode possède le même nom mais différentes implémentations dans différentes classes est appelée **polymorphisme**. Lorsqu'une méthode d'une classe enfant remplace l'implémentation de sa classe parente, on dit qu'elle **surcharge** la version de la classe parente.
+
+## Encapsulation
+
+Les objets fournissent une interface au reste du code qui voudrait les utiliser et ils maintiennent leur propre état interne. L'état interne d'un objet est **privé**, et peut uniquement être manipulé par les méthodes de l'objet (mais pas par celles des autres objets). Séparer l'état privé interne d'un objet et son interface publique est ce qu'on appelle **l'encapsulation**.
+
+Il s'agit d'une fonctionnalité utile, car elle permet de modifier l'implémentation interne d'un objet sans avoir à identifier et à modifier le reste du code qui l'utilise. On a ainsi un pare-feu entre l'objet et le reste du système.
+
+Par exemple, si les élèves ne sont autorisés à étudier le tir à l'arc qu'à partir de la deuxième année, on pourrait implémenter cette règle en exposant la propriété `année` pour que le code externe puisse la consulter et décider si l'élève peut s'inscrire au cours&nbsp;:
+
+```js
+if (élève.année > 1) {
+  // Autoriser l'inscription dans cette classe
+}
+```
+
+Toutefois, on a un problème si on décide de changer le critère permettant d'autoriser les élèves à étudier le tir à l'arc (par exemple en demandant à ce qu'un représentant légal ait fourni sa permission)&nbsp;: il faudrait alors mettre à jour tous les endroits du code qui réalisent ce test. Mieux vaudrait avoir une méthode `peutEtudierTirArc()` sur les objets `Élève` et qui implémente cette règle logique&nbsp;:
+
+```
+classe Élève : étend Personne
+    propriétés
+       année
+    constructeur
+        Élève(nom, année)
+    méthodes
+       sePrésenter()
+       peutEtudierTirArc() { renvoyer ceci.année > 1 }
+```
+
+```js
+if (student.peutEtudierTirArc()) {
+  // Autoriser l'inscription dans cette classe
+}
+```
+
+Ainsi, si on change les règles pour l'accès à ce cours, il suffira de mettre à jour la classe `Élève` et le reste du code qui l'utilise continuera de fonctionner.
+
+Dans de nombreux langages de programmation orientés objet, on peut empêcher l'accès à l'état interne de l'objet en marquant des propriétés comme étant privée avec le mot-clé `private`. Cela génèrera une erreur si du code externe tente d'y accéder&nbsp;:
+
+```
+classe Élève : étend Personne
+    propriétés
+       privée année
+    constructeur
+        Élève(nom, année)
+    méthodes
+       sePrésenter()
+       peutEtudierTirArc() { renvoyer ceci.année > 1 }
+
+unÉlève = nouvel Élève('Weber', 1)
+unÉlève.année // erreur : 'année' est une propriété privée de Élève
+```
+
+Pour les langages qui n'ont pas cette notion, les développeuses et développeurs peuvent utiliser des conventions de nommage (par exemple commencer le nom de la propriété avec un tiret bas) afin d'indiquer qu'une propriété devrait être considérée comme privée.
+
+## La programmation orientée objet et JavaScript
+
+Dans cet article, nous avons décrit les fonctionnalités de base d'un langage de programmation orienté objet et qui utilise les classes, comme Java ou C++.
+
+Dans les deux articles précédents, nous avions vu deux fonctionnalités de JavaScript&nbsp;: [les constructeurs](/fr/docs/Learn/JavaScript/Objects/Basics) et [les prototypes](/fr/docs/Learn/JavaScript/Objects/Object_prototypes). Ces fonctionnalités sont liées à certains des concepts orientés objet vus ci-dessus.
+
+- **Les constructeurs** JavaScript fournissent de quoi écrire une définition de classe pour définir la structure d'un objet, dont ses méthodes, à un seul endroit. Toutefois, les prototypes peuvent aussi être utilisés dans ce cas. Ainsi, si une méthode est définie sur la propriété `prototype` du constructeur, tous les objets créés avec le constructeur auront la méthode via leur prototype et il ne sera pas nécessaire de la définir dans le constructeur.
+
+- **La chaîne de prototypes** semble un outil naturel pour implémenter l'héritage. Ainsi, si on a un objet `Élève` dont le prototype est `Personne`, il pourra hériter de la propriété `nom` et surcharger `sePrésenter()`.
+
+Ceci étant écrit, il y a quelques différences avec le modèle objet basé sur les classes et mieux vaut les comprendre avant d'aller plus loin. En voici quelques-unes.
+
+Pour commencer, dans un modèle objet basé sur les classes, les classes et les objets sont deux notions séparées et les objets sont toujours créés comme des instances d'une classe. De plus, il existe une distinction entre la fonctionnalité qui permet de définir une classe (la syntaxe même de la classe) et la fonctionnalité permettant d'instancier la classe en un objet (le constructeur). En JavaScript, on peut (et on le fait souvent) créer des objets sans déclaration de classe préalable, en utilisant une fonction ou un littéral objet. La création d'objets est alors beaucoup plus légère qu'avec les classes.
+
+Ensuite, bien que la chaîne de prototypes ressemble à une hiérarchie d'héritage et en partage quelques aspects, elle en diffère sur d'autres. Lorsqu'une classe enfant est instanciée, un seul objet est créé qui combine les propriétés définies par la sous-classe et les propriétés définies plus haut dans la hiérarchie. Avec les prototypes, chaque niveau de la hiérarchie est représenté par un objet différent et le lien se fait avec le prototype (voir [`Object.getPrototypeOf()`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf)). Le comportement de la chaîne de prototype se rapproche plus de la **délégation** que de l'héritage. La délégation est une approche où un objet, lorsqu'on lui demande de réaliser une tâche, peut le faire lui-même ou demander à un autre objet de réaliser la tâche à sa place (lui **déléguer**). Sous plusieurs aspects, la délégation est une méthode plus flexible que l'héritage pour combiner les objets (on peut, entre autres, changer l'objet délégué au moment de l'exécution).
+
+Ceci étant posé, les constructeurs et les prototypes peuvent être utilisés afin d'implémenter une programmation orientée objet basée sur les classes en JavaScript. Toutefois, les utiliser directement afin d'implémenter des fonctionnalités comme l'héritage peut s'avérer délicat. C'est pourquoi JavaScript fournit des fonctionnalités supplémentaires, construites par dessus le modèle prototypal et qui correspondent mieux aux concepts de la programmation orientée objet basée sur les classes. Ces fonctionnalités supplémentaires seront abordées dans l'article suivant.
+
+## Résumé
+
+Dans cet article, nous avons vu les fonctionnalités de base offertes par la programmation orientée objet et rapidement comment les constructeurs et prototypes JavaScript étaient liés à ces fonctionnalités.
+
+Dans le prochain article, nous verrons les fonctionnalités de JavaScript qui permettent de réaliser une programmation orientée objet basée sur des classes.
+
+{{PreviousMenuNext("Learn/JavaScript/Objects/Object_prototypes", "Learn/JavaScript/Objects/Classes_in_JavaScript", "Learn/JavaScript/Objects")}}
+
+## Dans ce module
+
+- [Notions de base sur les objets](/fr/docs/Learn/JavaScript/Objects/Basics)
+- [Prototypes d'objet](/fr/docs/Learn/JavaScript/Objects/Object_prototypes)
+- **Concepts sur la programmation orientée objet**
+- [Classes en JavaScript](/fr/docs/Learn/JavaScript/Objects/Classes_in_JavaScript)
+- [Manipuler des données JSON](/fr/docs/Learn/JavaScript/Objects/JSON)
+- [Construire des objets en pratique](/fr/docs/Learn/JavaScript/Objects/Object_building_practice)
+- [Ajouter des fonctionnalités à notre démo de balles rebondissantes](/fr/docs/Learn/JavaScript/Objects/Adding_bouncing_balls_features)

--- a/files/fr/learn/javascript/objects/object-oriented_programming/index.md
+++ b/files/fr/learn/javascript/objects/object-oriented_programming/index.md
@@ -154,7 +154,7 @@ On pourrait avoir une implémentation par défaut de `sePrésenter()` pour les p
 
 ```js
 thomas = new Person("Thomas");
-thomas.sePrésenter(); // "Je m'appelle Thomas.'
+thomas.sePrésenter(); // "Je m'appelle Thomas."
 ```
 
 Cette fonctionnalité où une méthode possède le même nom mais différentes implémentations dans différentes classes est appelée **polymorphisme**. Lorsqu'une méthode d'une classe enfant remplace l'implémentation de sa classe parente, on dit qu'elle **surcharge** la version de la classe parente.
@@ -228,7 +228,7 @@ Pour commencer, dans un modèle objet basé sur les classes, les classes et les 
 
 Ensuite, bien que la chaîne de prototypes ressemble à une hiérarchie d'héritage et en partage quelques aspects, elle en diffère sur d'autres. Lorsqu'une classe enfant est instanciée, un seul objet est créé qui combine les propriétés définies par la sous-classe et les propriétés définies plus haut dans la hiérarchie. Avec les prototypes, chaque niveau de la hiérarchie est représenté par un objet différent et le lien se fait avec le prototype (voir [`Object.getPrototypeOf()`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf)). Le comportement de la chaîne de prototype se rapproche plus de la **délégation** que de l'héritage. La délégation est une approche où un objet, lorsqu'on lui demande de réaliser une tâche, peut le faire lui-même ou demander à un autre objet de réaliser la tâche à sa place (lui **déléguer**). Sous plusieurs aspects, la délégation est une méthode plus flexible que l'héritage pour combiner les objets (on peut, entre autres, changer l'objet délégué au moment de l'exécution).
 
-Ceci étant posé, les constructeurs et les prototypes peuvent être utilisés afin d'implémenter une programmation orientée objet basée sur les classes en JavaScript. Toutefois, les utiliser directement afin d'implémenter des fonctionnalités comme l'héritage peut s'avérer délicat. C'est pourquoi JavaScript fournit des fonctionnalités supplémentaires, construites par dessus le modèle prototypal et qui correspondent mieux aux concepts de la programmation orientée objet basée sur les classes. Ces fonctionnalités supplémentaires seront abordées dans l'article suivant.
+Ceci étant posé, les constructeurs et les prototypes peuvent être utilisés afin d'implémenter une programmation orientée objet basée sur les classes en JavaScript. Toutefois, les utiliser directement afin d'implémenter des fonctionnalités comme l'héritage peut s'avérer délicat. C'est pourquoi JavaScript fournit des fonctionnalités supplémentaires, construites par-dessus le modèle prototypal et qui correspondent mieux aux concepts de la programmation orientée objet basée sur les classes. Ces fonctionnalités supplémentaires seront abordées dans l'article suivant.
 
 ## Résumé
 


### PR DESCRIPTION
This is an update of https://developer.mozilla.org/fr/docs/Learn/JavaScript/Objects and a new translation for https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Objects/Object-oriented_programming (which is a child page of the first one).

This should be a fix for #9635 (links aligned vs en-US and missing subpage now translated)