### PR TITLE
data structures(PT-BR) typo fixing

### DIFF
--- a/files/pt-br/web/javascript/data_structures/index.md
+++ b/files/pt-br/web/javascript/data_structures/index.md
@@ -209,7 +209,7 @@ Além disso, arrays herdam de `Array.prototype`, que fornece a eles um punhado d
 
 ### Coleções chaveadas: Maps, Sets, WeakMaps, WeakSets
 
-Essas estruturas de dados usam referências de objetos como chaves. {{jsxref("Set")}} e {{jsxref("WeakSet")}} representantereenviam um conjunto de objetos, enquanto {{jsxref("Map")}} e {{jsxref("WeakMap")}} associam um valor a um objeto.
+Essas estruturas de dados usam referências de objetos como chaves. {{jsxref("Set")}} e {{jsxref("WeakSet")}} representante reenviam um conjunto de objetos, enquanto {{jsxref("Map")}} e {{jsxref("WeakMap")}} associam um valor a um objeto.
 
 A diferença entre `Map`s e `WeakMap`s é que no primeiro, as chaves de objeto podem ser enumeradas. Isso permite otimizações de coleta de lixo no último caso.
 


### PR DESCRIPTION
Fixed a typo in data structures page (PT-BR version).

### Description

changed from `representantereenviam` to `representante reenviam`.

### Motivation

I love MDN articles, so for me is a pleasure to help something that helps me a lot


