### PR TITLE
Remove duplicated frontmatter keys from conflicting folder [es]

### DIFF
--- a/files/es/conflicting/learn/javascript/objects/classes_in_javascript/index.md
+++ b/files/es/conflicting/learn/javascript/objects/classes_in_javascript/index.md
@@ -1,25 +1,6 @@
 ---
 title: JavaScript orientado a objetos para principiantes
 slug: conflicting/Learn/JavaScript/Objects/Classes_in_JavaScript
-tags:
-  - Aprender
-  - Artículo
-  - Constructor
-  - Crear
-  - Create
-  - JSOO
-  - JavaScript
-  - OOJS
-  - OOP
-  - Object
-  - Objeto
-  - Orientado a Objeto
-  - Principiante
-  - Programación orientada a objetos
-  - instance
-  - instanciar
-  - l10n:priority
-translation_of: Learn/JavaScript/Objects/Object-oriented_JS
 original_slug: Learn/JavaScript/Objects/Object-oriented_JS
 ---
 

--- a/files/es/conflicting/mdn/writing_guidelines/index.md
+++ b/files/es/conflicting/mdn/writing_guidelines/index.md
@@ -1,10 +1,6 @@
 ---
 title: Guías de contenido y estilo de MDN
 slug: conflicting/MDN/Writing_guidelines
-tags:
-  - Estilo
-  - Guías
-translation_of: MDN/Guidelines
 original_slug: MDN/Guidelines
 ---
 

--- a/files/es/conflicting/mdn/writing_guidelines/page_structures/index.md
+++ b/files/es/conflicting/mdn/writing_guidelines/page_structures/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document structures
 slug: conflicting/MDN/Writing_guidelines/Page_structures
-tags:
-  - Landing
-  - MDN Meta
-  - NeedsTranslation
-  - Structures
-  - TopicStub
-translation_of: MDN/Structures
 original_slug: MDN/Structures
 ---
 

--- a/files/es/conflicting/mdn/writing_guidelines/page_structures_479b8c93d0b37a3f2a020112ae60e692/index.md
+++ b/files/es/conflicting/mdn/writing_guidelines/page_structures_479b8c93d0b37a3f2a020112ae60e692/index.md
@@ -1,8 +1,6 @@
 ---
 title: Ejemplos ejecutables
-slug: >-
-  conflicting/MDN/Writing_guidelines/Page_structures_479b8c93d0b37a3f2a020112ae60e692
-translation_of: MDN/Structures/Live_samples
+slug: conflicting/MDN/Writing_guidelines/Page_structures_479b8c93d0b37a3f2a020112ae60e692
 original_slug: MDN/Structures/Live_samples
 ---
 

--- a/files/es/conflicting/web/accessibility/aria/index.md
+++ b/files/es/conflicting/web/accessibility/aria/index.md
@@ -1,13 +1,6 @@
 ---
 title: Alertas
 slug: conflicting/Web/Accessibility/ARIA
-tags:
-  - ARIA
-  - Accesibilidad
-  - Forms
-  - Web
-  - formulários
-translation_of: Web/Accessibility/ARIA/forms/alerts
 original_slug: Web/Accessibility/ARIA/forms/alerts
 ---
 

--- a/files/es/conflicting/web/accessibility/aria_64707ba1917a56654679cbe273e2f4ea/index.md
+++ b/files/es/conflicting/web/accessibility/aria_64707ba1917a56654679cbe273e2f4ea/index.md
@@ -1,11 +1,6 @@
 ---
 title: Consejos básicos para formularios
 slug: conflicting/Web/Accessibility/ARIA_64707ba1917a56654679cbe273e2f4ea
-tags:
-  - ARIA
-  - Accesibilidad
-  - formulários
-translation_of: Web/Accessibility/ARIA/forms/Basic_form_hints
 original_slug: Web/Accessibility/ARIA/forms/Basic_form_hints
 ---
 

--- a/files/es/conflicting/web/api/canvasrenderingcontext2d/index.md
+++ b/files/es/conflicting/web/api/canvasrenderingcontext2d/index.md
@@ -1,12 +1,6 @@
 ---
 title: CanvasImageSource
 slug: conflicting/Web/API/CanvasRenderingContext2D
-tags:
-  - API
-  - Auxiliar
-  - Canvas
-  - Referencia
-translation_of: Web/API/CanvasImageSource
 original_slug: Web/API/CanvasImageSource
 ---
 

--- a/files/es/conflicting/web/api/element/click_event/index.md
+++ b/files/es/conflicting/web/api/element/click_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: GlobalEventHandlers.onclick
 slug: conflicting/Web/API/Element/click_event
-translation_of: Web/API/GlobalEventHandlers/onclick
 original_slug: Web/API/GlobalEventHandlers/onclick
 ---
 

--- a/files/es/conflicting/web/api/element/keydown_event/index.md
+++ b/files/es/conflicting/web/api/element/keydown_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: GlobalEventHandlers.onkeydown
 slug: conflicting/Web/API/Element/keydown_event
-translation_of: Web/API/GlobalEventHandlers/onkeydown
 original_slug: Web/API/GlobalEventHandlers/onkeydown
 ---
 

--- a/files/es/conflicting/web/api/element/keyup_event/index.md
+++ b/files/es/conflicting/web/api/element/keyup_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: GlobalEventHandlers.onkeyup
 slug: conflicting/Web/API/Element/keyup_event
-translation_of: Web/API/GlobalEventHandlers/onkeyup
 original_slug: Web/API/GlobalEventHandlers/onkeyup
 ---
 

--- a/files/es/conflicting/web/api/element/wheel_event/index.md
+++ b/files/es/conflicting/web/api/element/wheel_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: Element.onwheel
 slug: conflicting/Web/API/Element/wheel_event
-tags:
-  - API
-  - DOM
-  - Gecko
-  - Propiedad
-  - Referencia
-translation_of: Web/API/GlobalEventHandlers/onwheel
 original_slug: Web/API/GlobalEventHandlers/onwheel
 ---
 

--- a/files/es/conflicting/web/api/eventtarget/addeventlistener/index.md
+++ b/files/es/conflicting/web/api/eventtarget/addeventlistener/index.md
@@ -1,7 +1,6 @@
 ---
 title: EventListener
 slug: conflicting/Web/API/EventTarget/addEventListener
-translation_of: Web/API/EventListener
 original_slug: Web/API/EventListener
 ---
 

--- a/files/es/conflicting/web/api/geolocation/getcurrentposition/index.md
+++ b/files/es/conflicting/web/api/geolocation/getcurrentposition/index.md
@@ -1,13 +1,7 @@
 ---
 title: PositionOptions
 slug: conflicting/Web/API/Geolocation/getCurrentPosition
-tags:
-  - Geolocalización
-  - Interfaz
-  - Referencia
-translation_of: Web/API/PositionOptions
 original_slug: Web/API/PositionOptions
-browser-compat: api.Geolocation.getCurrentPosition
 ---
 
 {{APIRef("Geolocation API")}}

--- a/files/es/conflicting/web/api/htmlelement/change_event/index.md
+++ b/files/es/conflicting/web/api/htmlelement/change_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: GlobalEventHandlers.onchange
 slug: conflicting/Web/API/HTMLElement/change_event
-translation_of: Web/API/GlobalEventHandlers/onchange
 original_slug: Web/API/GlobalEventHandlers/onchange
 ---
 

--- a/files/es/conflicting/web/api/htmlelement/input_event/index.md
+++ b/files/es/conflicting/web/api/htmlelement/input_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: GlobalEventHandlers.oninput
 slug: conflicting/Web/API/HTMLElement/input_event
-translation_of: Web/API/GlobalEventHandlers/oninput
 original_slug: Web/API/GlobalEventHandlers/oninput
 ---
 

--- a/files/es/conflicting/web/api/window/beforeunload_event/index.md
+++ b/files/es/conflicting/web/api/window/beforeunload_event/index.md
@@ -1,9 +1,7 @@
 ---
 title: Window.onbeforeunload
 slug: conflicting/Web/API/Window/beforeunload_event
-translation_of: Web/API/WindowEventHandlers/onbeforeunload
 original_slug: Web/API/WindowEventHandlers/onbeforeunload
-browser-compat: api.Window.beforeunload_event
 ---
 
 {{ApiRef}}

--- a/files/es/conflicting/web/api/window/hashchange_event/index.md
+++ b/files/es/conflicting/web/api/window/hashchange_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: WindowEventHandlers.onhashchange
 slug: conflicting/Web/API/Window/hashchange_event
-tags:
-  - HTML-DOM
-  - JavaScript
-  - Propiedades
-  - Referencia
-  - WindowEventHandlers
-  - eventos
-translation_of: Web/API/WindowEventHandlers/onhashchange
 original_slug: Web/API/WindowEventHandlers/onhashchange
 ---
 

--- a/files/es/conflicting/web/api/window/load_event/index.md
+++ b/files/es/conflicting/web/api/window/load_event/index.md
@@ -1,9 +1,6 @@
 ---
 title: window.onload
 slug: conflicting/Web/API/Window/load_event
-tags:
-  - window.onload
-translation_of: Web/API/GlobalEventHandlers/onload
 original_slug: Web/API/GlobalEventHandlers/onload
 ---
 

--- a/files/es/conflicting/web/css/css_fonts/index.md
+++ b/files/es/conflicting/web/css/css_fonts/index.md
@@ -1,11 +1,6 @@
 ---
 title: basefont
 slug: conflicting/Web/CSS/CSS_Fonts
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/basefont
 original_slug: Web/HTML/Element/basefont
 ---
 

--- a/files/es/conflicting/web/css/cursor/index.md
+++ b/files/es/conflicting/web/css/cursor/index.md
@@ -1,10 +1,6 @@
 ---
 title: Uso de URL como valor de la propiedad cursor
 slug: conflicting/Web/CSS/cursor
-tags:
-  - CSS
-  - Todas_las_Categorías
-translation_of: Web/CSS/CSS_Basic_User_Interface/Using_URL_values_for_the_cursor_property
 original_slug: Web/CSS/CSS_Basic_User_Interface/Using_URL_values_for_the_cursor_property
 ---
 

--- a/files/es/conflicting/web/css/index.md
+++ b/files/es/conflicting/web/css/index.md
@@ -1,9 +1,6 @@
 ---
 title: Herramientas
 slug: conflicting/Web/CSS
-tags:
-  - CSS
-translation_of: Web/CSS/Tools
 original_slug: Web/CSS/Tools
 ---
 

--- a/files/es/conflicting/web/html/global_attributes/contenteditable/index.md
+++ b/files/es/conflicting/web/html/global_attributes/contenteditable/index.md
@@ -1,17 +1,6 @@
 ---
 title: Making content editable
 slug: conflicting/Web/HTML/Global_attributes/contenteditable
-tags:
-  - Avanzado
-  - Ejemplo
-  - Entrada de texto
-  - Guía
-  - HTML
-  - HTML5
-  - Texto
-  - Web
-  - contentediatable
-translation_of: Web/Guide/HTML/Editable_content
 original_slug: Web/Guide/HTML/Editable_content
 ---
 

--- a/files/es/conflicting/web/http/status/404/index.md
+++ b/files/es/conflicting/web/http/status/404/index.md
@@ -1,12 +1,6 @@
 ---
 title: '404'
 slug: conflicting/Web/HTTP/Status/404
-tags:
-  - Errores HTTP
-  - Glosario
-  - Insfraestructura
-  - navegación
-translation_of: Glossary/404
 original_slug: Glossary/404
 ---
 

--- a/files/es/conflicting/web/http/status/502/index.md
+++ b/files/es/conflicting/web/http/status/502/index.md
@@ -1,13 +1,6 @@
 ---
 title: '502'
 slug: conflicting/Web/HTTP/Status/502
-tags:
-  - '502'
-  - Errores HTTP
-  - Glosario
-  - Infraestructura
-  - navegación
-translation_of: Glossary/502
 original_slug: Glossary/502
 ---
 

--- a/files/es/conflicting/web/javascript/inheritance_and_the_prototype_chain/index.md
+++ b/files/es/conflicting/web/javascript/inheritance_and_the_prototype_chain/index.md
@@ -1,13 +1,6 @@
 ---
 title: Detalles del modelo de objetos
 slug: conflicting/Web/JavaScript/Inheritance_and_the_prototype_chain
-tags:
-  - Guía
-  - Intermedio
-  - JavaScript
-  - Objeto
-  - l10n:priority
-translation_of: Web/JavaScript/Guide/Details_of_the_Object_Model
 original_slug: Web/JavaScript/Guide/Details_of_the_Object_Model
 ---
 

--- a/files/es/conflicting/web/javascript/javascript_technologies_overview/index.md
+++ b/files/es/conflicting/web/javascript/javascript_technologies_overview/index.md
@@ -1,10 +1,6 @@
 ---
 title: Recursos de lenguaje JavaScript
 slug: conflicting/Web/JavaScript/JavaScript_technologies_overview
-tags:
-  - Avanzado
-  - JavaScript
-translation_of: Web/JavaScript/Language_Resources
 original_slug: Web/JavaScript/Language_Resources
 ---
 

--- a/files/es/conflicting/web/javascript/javascript_technologies_overview_0191f05ec18a4ee4d771b548feb0701d/index.md
+++ b/files/es/conflicting/web/javascript/javascript_technologies_overview_0191f05ec18a4ee4d771b548feb0701d/index.md
@@ -1,8 +1,6 @@
 ---
 title: JavaScript shells
-slug: >-
-  conflicting/Web/JavaScript/JavaScript_technologies_overview_0191f05ec18a4ee4d771b548feb0701d
-translation_of: Web/JavaScript/Shells
+slug: conflicting/Web/JavaScript/JavaScript_technologies_overview_0191f05ec18a4ee4d771b548feb0701d
 original_slug: Web/JavaScript/Shells
 ---
 

--- a/files/es/conflicting/web/javascript/reference/global_objects/array/tostring/index.md
+++ b/files/es/conflicting/web/javascript/reference/global_objects/array/tostring/index.md
@@ -1,7 +1,6 @@
 ---
 title: Array.prototype.toSource()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Array/toString
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/toSource
 original_slug: Web/JavaScript/Reference/Global_Objects/Array/toSource
 ---
 

--- a/files/es/conflicting/web/javascript/reference/global_objects/error/tostring/index.md
+++ b/files/es/conflicting/web/javascript/reference/global_objects/error/tostring/index.md
@@ -1,12 +1,6 @@
 ---
 title: Error.prototype.toSource()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Error/toString
-tags:
-  - JavaScript
-  - No estandar
-  - Prototipo
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Error/toSource
 original_slug: Web/JavaScript/Reference/Global_Objects/Error/toSource
 ---
 

--- a/files/es/conflicting/web/javascript/reference/global_objects/function/tostring/index.md
+++ b/files/es/conflicting/web/javascript/reference/global_objects/function/tostring/index.md
@@ -1,7 +1,6 @@
 ---
 title: Function.prototype.toSource()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Function/toString
-translation_of: Web/JavaScript/Reference/Global_Objects/Function/toSource
 original_slug: Web/JavaScript/Reference/Global_Objects/Function/toSource
 ---
 

--- a/files/es/conflicting/web/javascript/reference/global_objects/object/tostring/index.md
+++ b/files/es/conflicting/web/javascript/reference/global_objects/object/tostring/index.md
@@ -1,7 +1,6 @@
 ---
 title: Object.prototype.toSource()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/Object/toString
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/toSource
 original_slug: Web/JavaScript/Reference/Global_Objects/Object/toSource
 ---
 

--- a/files/es/conflicting/web/javascript/reference/global_objects/string/index.md
+++ b/files/es/conflicting/web/javascript/reference/global_objects/string/index.md
@@ -1,15 +1,6 @@
 ---
 title: DOMString
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/String
-tags:
-  - API
-  - DOM
-  - Referencia
-  - Referencia DOM Gecko
-  - Referência DOM
-  - String
-  - WebAPI
-translation_of: Web/API/DOMString
 original_slug: Web/API/DOMString
 ---
 

--- a/files/es/conflicting/web/javascript/reference/global_objects/string/tostring/index.md
+++ b/files/es/conflicting/web/javascript/reference/global_objects/string/tostring/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.toSource()
 slug: conflicting/Web/JavaScript/Reference/Global_Objects/String/toString
-tags:
-  - Cadena
-  - JavaScript
-  - No estandar
-  - Prototipo
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/String/toSource
 original_slug: Web/JavaScript/Reference/Global_Objects/String/toSource
 ---
 

--- a/files/es/conflicting/webassembly/javascript_interface/index.md
+++ b/files/es/conflicting/webassembly/javascript_interface/index.md
@@ -1,14 +1,6 @@
 ---
 title: WebAssembly
 slug: conflicting/WebAssembly/JavaScript_interface
-tags:
-  - API
-  - Experimental
-  - JavaScript
-  - Objeto
-  - Referencia
-  - WebAssembly
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly
 ---
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove duplicated frontmatter keys from localized content

### Motivation

Remove innecesarry duplicated data

### Additional details

```
{
  "tags": 22,
  "translation_of": 34,
  "browser-compat": 2
}
```

### Related issues and pull requests

Fix #10130
Relates to #7412
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
