### PR TITLE
Remove duplicated frontmatter keys from games folder [es]

### DIFF
--- a/files/es/games/index.md
+++ b/files/es/games/index.md
@@ -1,14 +1,6 @@
 ---
 title: Desarrollo de Videojuegos
 slug: Games
-tags:
-  - Apps
-  - Games
-  - NeedsContent
-  - TopicStub
-  - aplicaciones
-  - juegos
-translation_of: Games
 ---
 
 {{GamesSidebar}}

--- a/files/es/games/introduction/index.md
+++ b/files/es/games/introduction/index.md
@@ -1,11 +1,6 @@
 ---
 title: Introduccion para desarrollo de juegos para la Web
 slug: Games/Introduction
-tags:
-  - Firefox OS
-  - juegos
-  - moviles
-translation_of: Games/Introduction
 original_slug: Games/Introduccion
 ---
 

--- a/files/es/games/introduction_to_html5_game_development/index.md
+++ b/files/es/games/introduction_to_html5_game_development/index.md
@@ -1,12 +1,6 @@
 ---
 title: Introducción al desarrollo de juegos HTML5 (resumen)
 slug: Games/Introduction_to_HTML5_Game_Development
-tags:
-  - Firefox OS
-  - HTML5
-  - Móvil
-  - juegos
-translation_of: Games/Introduction_to_HTML5_Game_Development_(summary)
 original_slug: Games/Introducción_al_desarrollo_de_juegos_HTML5_(resumen)
 ---
 

--- a/files/es/games/publishing_games/game_distribution/index.md
+++ b/files/es/games/publishing_games/game_distribution/index.md
@@ -1,19 +1,6 @@
 ---
 title: Distrbución de juegos
 slug: Games/Publishing_games/Game_distribution
-tags:
-  - CocoonIO
-  - Distribución
-  - Distribución de juegos para móviles
-  - HTML5
-  - JavaScript
-  - Juego de azar
-  - Phonegap
-  - Publicación de un juego
-  - Tiendas web
-  - juego
-  - juegos
-translation_of: Games/Publishing_games/Game_distribution
 ---
 
 {{GamesSidebar}}

--- a/files/es/games/publishing_games/game_monetization/index.md
+++ b/files/es/games/publishing_games/game_monetization/index.md
@@ -1,15 +1,6 @@
 ---
 title: Monetización de videojuegos
 slug: Games/Publishing_games/Game_monetization
-tags:
-  - HTLM5
-  - JavaScript
-  - Licencias
-  - anuncios
-  - juegos
-  - marca
-  - monetización
-translation_of: Games/Publishing_games/Game_monetization
 original_slug: Games/Publishing_games/Monetización_de_los_juegos
 ---
 

--- a/files/es/games/publishing_games/index.md
+++ b/files/es/games/publishing_games/index.md
@@ -1,19 +1,6 @@
 ---
 title: Publicación de juegos
 slug: Games/Publishing_games
-tags:
-  - Games
-  - HTML5
-  - JavaScript
-  - Monetization
-  - NeedsTranslation
-  - Promotion
-  - Publicacion
-  - TopicStub
-  - distribution
-  - juegos
-  - publishing
-translation_of: Games/Publishing_games
 ---
 
 {{GamesSidebar}}

--- a/files/es/games/techniques/2d_collision_detection/index.md
+++ b/files/es/games/techniques/2d_collision_detection/index.md
@@ -1,7 +1,6 @@
 ---
 title: Detección de colisiones 2D
 slug: Games/Techniques/2D_collision_detection
-translation_of: Games/Techniques/2D_collision_detection
 original_slug: Games/Techniques/2D_collision_detection
 ---
 

--- a/files/es/games/techniques/index.md
+++ b/files/es/games/techniques/index.md
@@ -1,9 +1,8 @@
 ---
 title: Técnicas para el desarrollo de juegos web
 slug: Games/Techniques
-translation_of: Games/Techniques
 l10n:
-  sourceCommit: 048f6b1c75e22103ddb0304d67ee79d6d8a014f0
+  sourceCommit: '048f6b1c75e22103ddb0304d67ee79d6d8a014f0'
 ---
 
 {{GamesSidebar}}

--- a/files/es/games/techniques/webrtc_data_channels/index.md
+++ b/files/es/games/techniques/webrtc_data_channels/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebRTC data channels
 slug: Games/Techniques/WebRTC_data_channels
-translation_of: Games/Techniques/WebRTC_data_channels
 ---
 
 {{GamesSidebar}}

--- a/files/es/games/tools/asm.js/index.md
+++ b/files/es/games/tools/asm.js/index.md
@@ -1,10 +1,6 @@
 ---
 title: asm.js
 slug: Games/Tools/asm.js
-tags:
-  - JavaScript
-  - asm.js
-translation_of: Games/Tools/asm.js
 original_slug: Games/Herramients/asm.js
 ---
 

--- a/files/es/games/tools/index.md
+++ b/files/es/games/tools/index.md
@@ -1,12 +1,6 @@
 ---
 title: Herramientas para desarrolladores de juegos
 slug: Games/Tools
-tags:
-  - NeedsContent
-  - NeedsTranslation
-  - aplicaciones
-  - juegos
-translation_of: Games/Tools
 original_slug: Games/Herramients
 ---
 

--- a/files/es/games/tutorials/2d_breakout_game_phaser/animations_and_tweens/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/animations_and_tweens/index.md
@@ -1,17 +1,6 @@
 ---
 title: Animaciones e interpolaciones
 slug: Games/Tutorials/2D_breakout_game_Phaser/Animations_and_tweens
-tags:
-  - 2D
-  - Animacion
-  - Canvas
-  - Interpolaciones
-  - JavaScript
-  - Phaser
-  - Principiante
-  - Tutorial
-  - juegos
-translation_of: Games/Tutorials/2D_breakout_game_Phaser/Animations_and_tweens
 ---
 
 {{GamesSidebar}}

--- a/files/es/games/tutorials/2d_breakout_game_phaser/bounce_off_the_walls/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/bounce_off_the_walls/index.md
@@ -1,16 +1,6 @@
 ---
 title: Rebotar en las paredes
 slug: Games/Tutorials/2D_breakout_game_Phaser/Bounce_off_the_walls
-tags:
-  - 2D
-  - Canvas
-  - JavaScript
-  - Phaser
-  - Principiante
-  - Tutorial
-  - fuerte
-  - juegos
-translation_of: Games/Tutorials/2D_breakout_game_Phaser/Bounce_off_the_walls
 original_slug: Games/Tutorials/2D_breakout_game_Phaser/Rebotar_en_las_paredes
 ---
 

--- a/files/es/games/tutorials/2d_breakout_game_phaser/buttons/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/buttons/index.md
@@ -1,16 +1,6 @@
 ---
 title: Botones
 slug: Games/Tutorials/2D_breakout_game_Phaser/Buttons
-tags:
-  - 2D
-  - Botones
-  - JavaScript
-  - Lienzo
-  - Phaser
-  - Principiante
-  - Tutorial
-  - juegos
-translation_of: Games/Tutorials/2D_breakout_game_Phaser/Buttons
 original_slug: Games/Tutorials/2D_breakout_game_Phaser/Botones
 ---
 

--- a/files/es/games/tutorials/2d_breakout_game_phaser/collision_detection/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/collision_detection/index.md
@@ -1,16 +1,6 @@
 ---
 title: Collision detection
 slug: Games/Tutorials/2D_breakout_game_Phaser/Collision_detection
-tags:
-  - 2D
-  - Deteccion de colision
-  - JavaScript
-  - Lienzo
-  - Phaser
-  - Principiante
-  - Tutorial
-  - juegos
-translation_of: Games/Tutorials/2D_breakout_game_Phaser/Collision_detection
 ---
 
 {{GamesSidebar}}

--- a/files/es/games/tutorials/2d_breakout_game_phaser/extra_lives/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/extra_lives/index.md
@@ -1,17 +1,6 @@
 ---
 title: Extra lives
 slug: Games/Tutorials/2D_breakout_game_Phaser/Extra_lives
-tags:
-  - 2D
-  - JavaScript
-  - Lienzo
-  - Lona
-  - Phaser
-  - Principiante
-  - Tutorial
-  - Vidas
-  - juegos
-translation_of: Games/Tutorials/2D_breakout_game_Phaser/Extra_lives
 ---
 
 {{GamesSidebar}}

--- a/files/es/games/tutorials/2d_breakout_game_phaser/game_over/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/game_over/index.md
@@ -1,16 +1,6 @@
 ---
 title: Game over
 slug: Games/Tutorials/2D_breakout_game_Phaser/Game_over
-tags:
-  - 2D
-  - Canvas
-  - JavaScript
-  - Principiante
-  - Tutorial
-  - game over
-  - juego
-  - juego terminado
-translation_of: Games/Tutorials/2D_breakout_game_Phaser/Game_over
 ---
 
 {{GamesSidebar}}

--- a/files/es/games/tutorials/2d_breakout_game_phaser/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/index.md
@@ -1,14 +1,6 @@
 ---
 title: Juego breakout en 2D usando Phaser
 slug: Games/Tutorials/2D_breakout_game_Phaser
-tags:
-  - 2D
-  - Principiante
-  - Canvas
-  - Juegos
-  - JavaScript
-  - Phaser
-  - Tutorial
 l10n:
   sourceCommit: e4783c03e39807e0060a2f4df3bf3962d25d8388
 ---

--- a/files/es/games/tutorials/2d_breakout_game_phaser/initialize_the_framework/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/initialize_the_framework/index.md
@@ -1,7 +1,6 @@
 ---
 title: Inicializar el framework
 slug: Games/Tutorials/2D_breakout_game_Phaser/Initialize_the_framework
-translation_of: Games/Tutorials/2D_breakout_game_Phaser/Initialize_the_framework
 ---
 
 {{GamesSidebar}}

--- a/files/es/games/tutorials/2d_breakout_game_phaser/move_the_ball/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/move_the_ball/index.md
@@ -1,16 +1,6 @@
 ---
 title: Move the ball
 slug: Games/Tutorials/2D_breakout_game_Phaser/Move_the_ball
-tags:
-  - 2D
-  - Emocionante
-  - JavaScript
-  - Lienzo
-  - Phaser
-  - Principiante
-  - Tutorial
-  - juegos
-translation_of: Games/Tutorials/2D_breakout_game_Phaser/Move_the_ball
 ---
 
 {{GamesSidebar}}

--- a/files/es/games/tutorials/2d_breakout_game_phaser/scaling/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/scaling/index.md
@@ -1,7 +1,6 @@
 ---
 title: Scaling
 slug: Games/Tutorials/2D_breakout_game_Phaser/Scaling
-translation_of: Games/Tutorials/2D_breakout_game_Phaser/Scaling
 ---
 
 {{GamesSidebar}}

--- a/files/es/games/tutorials/2d_breakout_game_phaser/the_score/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/the_score/index.md
@@ -1,16 +1,6 @@
 ---
 title: The score
 slug: Games/Tutorials/2D_breakout_game_Phaser/The_score
-tags:
-  - 2D
-  - JavaScript
-  - Lienzo
-  - Phaser
-  - Principiantes
-  - Puntuación
-  - Tutorial
-  - juegos
-translation_of: Games/Tutorials/2D_breakout_game_Phaser/The_score
 ---
 
 {{GamesSidebar}}

--- a/files/es/games/tutorials/2d_breakout_game_phaser/win_the_game/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_phaser/win_the_game/index.md
@@ -1,15 +1,6 @@
 ---
 title: Win the game
 slug: Games/Tutorials/2D_breakout_game_Phaser/Win_the_game
-tags:
-  - 2D
-  - JavaS
-  - Lienzo
-  - Phaser
-  - Principiante
-  - Tutorial
-  - ganando
-translation_of: Games/Tutorials/2D_breakout_game_Phaser/Win_the_game
 ---
 
 {{GamesSidebar}}

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/bounce_off_the_walls/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/bounce_off_the_walls/index.md
@@ -1,7 +1,6 @@
 ---
 title: Rebota en las paredes
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Bounce_off_the_walls
-translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Bounce_off_the_walls
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Bounce_off_the_walls
 ---
 

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/build_the_brick_field/index.md
@@ -1,7 +1,6 @@
 ---
 title: Construye el muro de ladrillos
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Build_the_brick_field
-translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Build_the_brick_field
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Construye_grupo_bloques
 ---
 

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/collision_detection/index.md
@@ -1,7 +1,6 @@
 ---
 title: Detección de colisiones
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Collision_detection
-translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Collision_detection
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Deteccion_colisiones
 ---
 

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/create_the_canvas_and_draw_on_it/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/create_the_canvas_and_draw_on_it/index.md
@@ -1,11 +1,7 @@
 ---
 title: Crea el lienzo (canvas) y dibuja en él
-slug: >-
-  Games/Tutorials/2D_Breakout_game_pure_JavaScript/Create_the_Canvas_and_draw_on_it
-translation_of: >-
-  Games/Tutorials/2D_Breakout_game_pure_JavaScript/Create_the_Canvas_and_draw_on_it
-original_slug: >-
-  Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Create_the_Canvas_and_draw_on_it
+slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Create_the_Canvas_and_draw_on_it
+original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Create_the_Canvas_and_draw_on_it
 ---
 
 {{GamesSidebar}}

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/finishing_up/index.md
@@ -1,7 +1,6 @@
 ---
 title: Terminando
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Finishing_up
-translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Finishing_up
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Terminando
 ---
 

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/game_over/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/game_over/index.md
@@ -1,13 +1,6 @@
 ---
 title: Fin del juego
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Game_over
-tags:
-  - Canvas
-  - Fin del juego
-  - JavaScript
-  - Tutorial
-  - graficos
-translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Game_over
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Fin_del_juego
 ---
 

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/index.md
@@ -1,10 +1,6 @@
 ---
 title: Famoso juego 2D usando JavaScript puro
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript
-tags:
-  - 2D Canvas JavaScript Tutorial
-  - Principiante Juegos
-translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro
 ---
 

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/mouse_controls/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/mouse_controls/index.md
@@ -1,7 +1,6 @@
 ---
 title: Controles del ratón
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Mouse_controls
-translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Mouse_controls
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Controles_raton
 ---
 

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/move_the_ball/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/move_the_ball/index.md
@@ -1,7 +1,6 @@
 ---
 title: Mueve la bola
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Move_the_ball
-translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Move_the_ball
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Mueve_la_bola
 ---
 

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/paddle_and_keyboard_controls/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/paddle_and_keyboard_controls/index.md
@@ -1,7 +1,6 @@
 ---
 title: Control de la pala y el teclado
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Paddle_and_keyboard_controls
-translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Paddle_and_keyboard_controls
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Control_pala_y_teclado
 ---
 

--- a/files/es/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.md
+++ b/files/es/games/tutorials/2d_breakout_game_pure_javascript/track_the_score_and_win/index.md
@@ -1,7 +1,6 @@
 ---
 title: Poner un contador y terminar ganando
 slug: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Track_the_score_and_win
-translation_of: Games/Tutorials/2D_Breakout_game_pure_JavaScript/Track_the_score_and_win
 original_slug: Games/Workflows/Famoso_juego_2D_usando_JavaScript_puro/Track_the_score_and_win
 ---
 

--- a/files/es/games/tutorials/html5_gamedev_phaser_device_orientation/index.md
+++ b/files/es/games/tutorials/html5_gamedev_phaser_device_orientation/index.md
@@ -1,16 +1,7 @@
 ---
-title: >-
-  Introducción al Desarrollo de Juegos en HTML5 con Phaser y la API de
-  Orientación a Dispositivos
+title: Introducción al Desarrollo de Juegos en HTML5 con Phaser y la API de Orientación
+  a Dispositivos
 slug: Games/Tutorials/HTML5_Gamedev_Phaser_Device_Orientation
-tags:
-  - API Vibración
-  - API orientacion de dispositivos
-  - Canvas
-  - Desarrollo de videojuegos
-  - HTML5
-  - Phaser
-translation_of: Games/Tutorials/HTML5_Gamedev_Phaser_Device_Orientation
 original_slug: Games/Workflows/HTML5_Gamedev_Phaser_Device_Orientation
 ---
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove duplicated frontmatter keys from localized content

### Motivation

Remove innecesarry duplicated data

### Additional details

```
{
  "tags": 21,
  "translation_of": 34
}
```

### Related issues and pull requests

Fix #10132
Relates to #7412
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
