### PR TITLE
Remove duplicated frontmatter keys from glossary folder [es]

### DIFF
--- a/files/es/glossary/abstraction/index.md
+++ b/files/es/glossary/abstraction/index.md
@@ -1,13 +1,6 @@
 ---
 title: Abstracción
 slug: Glossary/Abstraction
-tags:
-  - Abstracción
-  - Glosario
-  - Lenguaje de programación
-  - Scripting
-  - programacion
-translation_of: Glossary/Abstraction
 ---
 
 En {{Glossary("computer programming", "programación")}}, una abstracción es una manera de reducir la complejidad y permitir un diseño e implementación más eficientes en sistemas de software complejos. Oculta la dificultad técnica de los sistemas detrás de {{Glossary("API", "APIs")}} más simples.

--- a/files/es/glossary/accessibility/index.md
+++ b/files/es/glossary/accessibility/index.md
@@ -1,11 +1,6 @@
 ---
 title: Accesibilidad
 slug: Glossary/Accessibility
-tags:
-  - Accesibilidad
-  - Accessibility
-  - Glossary
-translation_of: Glossary/Accessibility
 ---
 
 _La accesibilidad web_ (**A11Y**) hace referencia a las buenas prácticas para mantener la usabilidad de un sitio web a pesar de las restricciones físicas y técnicas. La accesibilidad web se define formalmente y es discutida en el {{Glossary("W3C")}} a través del {{Glossary("WAI","Web Accessibility Initiative")}} (WAI).

--- a/files/es/glossary/accessibility_tree/index.md
+++ b/files/es/glossary/accessibility_tree/index.md
@@ -1,12 +1,6 @@
 ---
 title: Árbol de accesibilidad (AOM)
 slug: Glossary/Accessibility_tree
-tags:
-  - AOM
-  - Accesibilidad
-  - DOM
-  - Glosario
-translation_of: Glossary/Accessibility_tree
 ---
 
 El **árbol de accesibilidad** o **modelo de objeto de accesibillidad (AOM)**, contiene información relacionada con {{Glossary("accessibility")}} para la mayoría de los elementos HTML.

--- a/files/es/glossary/adobe_flash/index.md
+++ b/files/es/glossary/adobe_flash/index.md
@@ -1,12 +1,6 @@
 ---
 title: Adobe Flash
 slug: Glossary/Adobe_Flash
-tags:
-  - CodingScripting
-  - Flash
-  - Glossary
-  - Infrastructure
-translation_of: Glossary/Adobe_Flash
 ---
 
 Flash es una tecnología obsolescente desarrollada por Adobe que hace posible crear aplicaciones Web ricas, gráficos vectoriales y multimedia. Para utilizar Flash dentro de un {{Glossary("Browser","web browser")}} es necesario instalar el complemento adecuado.

--- a/files/es/glossary/ajax/index.md
+++ b/files/es/glossary/ajax/index.md
@@ -1,12 +1,6 @@
 ---
 title: AJAX
 slug: Glossary/AJAX
-tags:
-  - AJAX
-  - CodingScripting
-  - Glosario
-  - Infrastructure
-translation_of: Glossary/AJAX
 ---
 
 AJAX (de las siglas en Inglés **A**synchronous {{glossary("JavaScript")}} **A**nd {{glossary("XML")}} ) es una práctica de programación utilizada para construir páginas web más complejas y dinámicas, utilizando una tecnología conocida como {{Glossary("XHR_(XMLHttpRequest)","XMLHttpRequest")}}.

--- a/files/es/glossary/algorithm/index.md
+++ b/files/es/glossary/algorithm/index.md
@@ -1,10 +1,6 @@
 ---
 title: Algoritmo
 slug: Glossary/Algorithm
-tags:
-  - CodingScripting
-  - Glossary
-translation_of: Glossary/Algorithm
 original_slug: Glossary/Algoritmo
 ---
 

--- a/files/es/glossary/api/index.md
+++ b/files/es/glossary/api/index.md
@@ -1,7 +1,6 @@
 ---
 title: API
 slug: Glossary/API
-translation_of: Glossary/API
 ---
 
 ## Resumen

--- a/files/es/glossary/apple_safari/index.md
+++ b/files/es/glossary/apple_safari/index.md
@@ -1,13 +1,6 @@
 ---
 title: Apple Safari
 slug: Glossary/Apple_Safari
-tags:
-  - Glosario
-  - Glossary
-  - Navigation
-  - WebMechanics
-  - navegación
-translation_of: Glossary/Apple_Safari
 ---
 
 [Safari](http://www.apple.com/safari/) es un {{Glossary("Browser","navegador web")}} desarrollado por Apple y ligado a Mac OS X y iOS. Está basado en el motor de código abierto [WebKit](http://www.webkit.org/).

--- a/files/es/glossary/application_context/index.md
+++ b/files/es/glossary/application_context/index.md
@@ -1,10 +1,6 @@
 ---
 title: Contexto de aplicación
 slug: Glossary/application_context
-tags:
-  - CodingScripting
-  - Glossary
-translation_of: Glossary/application_context
 ---
 
 Un contexto de aplicación es un [contexto de navegación](/es/docs/Glossary/Browsing_context) de nivel superior que tiene aplicado un [manifiesto](/es/docs/Web/Manifest).

--- a/files/es/glossary/argument/index.md
+++ b/files/es/glossary/argument/index.md
@@ -1,7 +1,6 @@
 ---
 title: Argumento
 slug: Glossary/Argument
-translation_of: Glossary/Argument
 original_slug: Glossary/Argumento
 ---
 

--- a/files/es/glossary/aria/index.md
+++ b/files/es/glossary/aria/index.md
@@ -1,7 +1,6 @@
 ---
 title: ARIA
 slug: Glossary/ARIA
-translation_of: Glossary/ARIA
 ---
 
 **ARIA** (_Accessible Rich {{glossary("Internet")}} Applications_) es una especificación de la {{Glossary("W3C")}} para agregar semantica y otros metadatos a {{Glossary("HTML")}} para ayudar a los usuarios con tecnologia de apoyo.

--- a/files/es/glossary/arpa/index.md
+++ b/files/es/glossary/arpa/index.md
@@ -1,9 +1,6 @@
 ---
 title: ARPA
 slug: Glossary/ARPA
-tags:
-  - ARPA
-translation_of: Glossary/ARPA
 ---
 
 **.arpa** (parametros de dirección y enrutamiento) es un {{glossary("TLD","dominio de alto nivel")}} usado para propositos de infraestructura de Internet, especialmente busqueda inversa de DNS (ej., encontrar el {{glossary('nombre de dominio')}} para una {{glossary("dirección IP")}}) suministrada.

--- a/files/es/glossary/arpanet/index.md
+++ b/files/es/glossary/arpanet/index.md
@@ -1,7 +1,6 @@
 ---
 title: Arpanet
 slug: Glossary/Arpanet
-translation_of: Glossary/Arpanet
 ---
 
 La **ARPAnet** (advanced research projects agency network) o Red de Angencias de Proyectos de Investigación Avanzada en español, era una red de computadoras construida en 1969 como un medio resistente para enviar datos militares y conectar principales grupos de investigación a través de los Estados Unidos. ARPAnet ejecutó NCP (network control protocol/protocolo de control de red) y subsequentemente la primera versión del protocolo de Internet o la suite {{glossary("TCP")}}/{{glossary("IPv6","IP")}}, teniendo la ARPAnet una descatada parte en la naciente {{glossary("Internet")}}. ARPAnet finalizó a comienzos de 1990.

--- a/files/es/glossary/array/index.md
+++ b/files/es/glossary/array/index.md
@@ -1,14 +1,6 @@
 ---
 title: Arreglos (Matrices)
 slug: Glossary/array
-tags:
-  - Arreglos
-  - CodificaciónScripting
-  - Glosario
-  - JavaScript
-  - Matriz
-  - programacion
-translation_of: Glossary/array
 original_slug: Glossary/Arreglos
 ---
 

--- a/files/es/glossary/ascii/index.md
+++ b/files/es/glossary/ascii/index.md
@@ -1,10 +1,6 @@
 ---
 title: ASCII
 slug: Glossary/ASCII
-tags:
-  - Glosario
-  - Infraestructura
-translation_of: Glossary/ASCII
 ---
 
 **ASCII** (_American Standard Code for Information Interchange_) es uno de los métodos de codificación más utilizados por las computadoras para convertir letras, números, signos de puntuación y códigos de control en formato digital. Desde 2007, {{Glossary("UTF-8")}} lo reemplazó en la Web.

--- a/files/es/glossary/asynchronous/index.md
+++ b/files/es/glossary/asynchronous/index.md
@@ -1,12 +1,6 @@
 ---
 title: Asíncrono
 slug: Glossary/Asynchronous
-tags:
-  - Asíncrono
-  - Glosario
-  - Mecánicas de la Web
-  - Web
-translation_of: Glossary/Asynchronous
 original_slug: Glossary/Asíncrono
 ---
 

--- a/files/es/glossary/atag/index.md
+++ b/files/es/glossary/atag/index.md
@@ -1,7 +1,6 @@
 ---
 title: ATAG
 slug: Glossary/ATAG
-translation_of: Glossary/ATAG
 ---
 
 ATAG (Authoring Tool {{glossary("Accessibility")}} Guidelines/Pautas de accesibilidad de herramientas de autor) es una recomendación de la {{Glossary("W3C")}} para la construcción de herramientas de autor y producir contenido accesible.

--- a/files/es/glossary/attribute/index.md
+++ b/files/es/glossary/attribute/index.md
@@ -1,7 +1,6 @@
 ---
 title: Atributo
 slug: Glossary/Attribute
-translation_of: Glossary/Attribute
 original_slug: Glossary/Atributo
 ---
 

--- a/files/es/glossary/bandwidth/index.md
+++ b/files/es/glossary/bandwidth/index.md
@@ -1,7 +1,6 @@
 ---
 title: Ancho de banda
 slug: Glossary/Bandwidth
-translation_of: Glossary/Bandwidth
 ---
 
 El ancho de banda es la medida de cuanta información puede pasar a través de una conexión de datos en un momento dado. El ancho de banda suele medirse en múltipos de bits-por-segundo (bps), por ejemplo, megabits-por-segundo (Mbps) o gigabits-por-segundo (Gbps).

--- a/files/es/glossary/base64/index.md
+++ b/files/es/glossary/base64/index.md
@@ -1,7 +1,6 @@
 ---
 title: Base64 codificando y decodificando
 slug: Glossary/Base64
-translation_of: Glossary/Base64
 original_slug: Web/API/WindowBase64/Base64_codificando_y_decodificando
 ---
 

--- a/files/es/glossary/bigint/index.md
+++ b/files/es/glossary/bigint/index.md
@@ -1,7 +1,6 @@
 ---
 title: BigInt
 slug: Glossary/BigInt
-translation_of: Glossary/BigInt
 ---
 
 En {{Glossary("JavaScript")}}, **BigInt** es un tipo de dato numerico que puede representar números enteros en el [formato de precision arbitrario](https://en.wikipedia.org/wiki/Arbitrary-precision_arithmetic). En otros lenguajes de programación pueden existir diferentes tipos numéricos, por ejemplo: enteros, flotantes, dobles o bignums (numeros grandes).

--- a/files/es/glossary/blink/index.md
+++ b/files/es/glossary/blink/index.md
@@ -1,16 +1,6 @@
 ---
 title: Blink
 slug: Glossary/Blink
-tags:
-  - Chrome
-  - DOM
-  - Diseño
-  - Glosario
-  - Infraestructura
-  - Navegador
-  - Web
-  - WebKit
-translation_of: Glossary/Blink
 ---
 
 Blink es un motor de renderizado para [navegadores](/es/docs/Glossary/Browser) de código abierto desarrollado por Google, que forma parte de Chromium (y por lo tanto también de [Chrome](/es/docs/Glossary/Google_Chrome)). Concretamente, Blink es una copia de la librería WebCore de [WebKit](/es/docs/Glossary/WebKit), que se encarga del diseño, renderizado, y del [DOM](/es/docs/Glossary/DOM).

--- a/files/es/glossary/block/css/index.md
+++ b/files/es/glossary/block/css/index.md
@@ -1,7 +1,6 @@
 ---
 title: Block (CSS)
 slug: Glossary/Block/CSS
-translation_of: Glossary/Block/CSS
 ---
 
 Un **bloque** en una página web es un {{glossary("elemento")}} {{glossary("HTML")}} que aparece en una nueva línea, por ejemplo debajo del elemento precedente y encima del siguiente elemento (comúnmente conocido como _block-level element)_. Por ejemplo, visto que {{htmlelement("a")}} es un _elemento en línea_ — puedes colocar varios enlaces uno al lado del otro en el código HTML y no se posicionarán en la misma línea como uno al otro en la salida representada.

--- a/files/es/glossary/block/index.md
+++ b/files/es/glossary/block/index.md
@@ -1,7 +1,6 @@
 ---
 title: Block
 slug: Glossary/Block
-translation_of: Glossary/Block
 ---
 
 El término **bloque** puede tener diferentes significados dependiendo del conexto. Puede referirse a:

--- a/files/es/glossary/boolean/index.md
+++ b/files/es/glossary/boolean/index.md
@@ -1,11 +1,6 @@
 ---
 title: Boolean
 slug: Glossary/Boolean
-tags:
-  - Glosario
-  - JavaScript
-  - Tipos de datos
-translation_of: Glossary/Boolean
 ---
 
 En ciencias de informática, un **boolean** es un dato lógico que solo puede tener los valores true o false.

--- a/files/es/glossary/breadcrumb/index.md
+++ b/files/es/glossary/breadcrumb/index.md
@@ -1,12 +1,6 @@
 ---
 title: Miga de pan
 slug: Glossary/Breadcrumb
-tags:
-  - Accesibilidad
-  - Glosario
-  - Miga de pan
-  - navegación
-translation_of: Glossary/Breadcrumb
 original_slug: Glossary/miga-de-pan
 ---
 

--- a/files/es/glossary/browser/index.md
+++ b/files/es/glossary/browser/index.md
@@ -1,15 +1,6 @@
 ---
 title: Navegador
 slug: Glossary/Browser
-tags:
-  - Chrome
-  - Explorer
-  - Glosario
-  - Mozilla
-  - Navegador
-  - Opera
-  - Web
-translation_of: Glossary/Browser
 ---
 
 Un _Navegador web_ es un programa o aplicación que da acceso a la [Web](/es/docs/Glossary/World_Wide_Web), y permite a los usuarios el acceso a más páginas a través de [hipervínculos](/es/docs/Glossary/Hyperlink).

--- a/files/es/glossary/browsing_context/index.md
+++ b/files/es/glossary/browsing_context/index.md
@@ -1,7 +1,6 @@
 ---
 title: Contexto de navegación
 slug: Glossary/Browsing_context
-translation_of: Glossary/Browsing_context
 ---
 
 Un **contexto de navegación** es el entorno en el que un {{glossary("navegador")}} muestra un {{domxref("Documento")}} (normalmente una pestaña, pero posiblemente también una ventana o un marco (_frame_) dentro de una página).

--- a/files/es/glossary/buffer/index.md
+++ b/files/es/glossary/buffer/index.md
@@ -1,10 +1,6 @@
 ---
 title: Buffer
 slug: Glossary/Buffer
-tags:
-  - Buffer
-  - Glosario
-translation_of: Glossary/buffer
 ---
 
 Un búfer es un espacio de memoria en el que se almacenan datos de forma temporal mientras se están transfiriendo de un sitio a otro.

--- a/files/es/glossary/cache/index.md
+++ b/files/es/glossary/cache/index.md
@@ -1,10 +1,6 @@
 ---
 title: Caché
 slug: Glossary/Cache
-tags:
-  - Glosario
-  - HTTP
-translation_of: Glossary/Cache
 original_slug: Glossary/Caché
 ---
 

--- a/files/es/glossary/cacheable/index.md
+++ b/files/es/glossary/cacheable/index.md
@@ -1,7 +1,6 @@
 ---
 title: Cacheable
 slug: Glossary/cacheable
-translation_of: Glossary/cacheable
 ---
 
 Una respuesta **_cacheable_** es una respuesta HTTP que se puede almacenar en caché, que se almacena para recuperarla y usarla más tarde, guardando una nueva solicitud en el servidor. No todas las respuestas HTTP se pueden almacenar en caché, estas son las siguientes restricciones para que una respuesta HTTP se almacene en caché:

--- a/files/es/glossary/call_stack/index.md
+++ b/files/es/glossary/call_stack/index.md
@@ -1,11 +1,6 @@
 ---
 title: Pila de llamadas
 slug: Glossary/Call_stack
-tags:
-  - Glosario
-  - JavaScript
-  - Pila de llamadas
-translation_of: Glossary/Call_stack
 original_slug: Glossary/Pila_llamadas
 ---
 

--- a/files/es/glossary/callback_function/index.md
+++ b/files/es/glossary/callback_function/index.md
@@ -1,7 +1,6 @@
 ---
 title: Función Callback
 slug: Glossary/Callback_function
-translation_of: Glossary/Callback_function
 ---
 
 Una función de callback es una función que se pasa a otra función como un argumento, que luego se invoca dentro de la función externa para completar algún tipo de rutina o acción.

--- a/files/es/glossary/canvas/index.md
+++ b/files/es/glossary/canvas/index.md
@@ -1,10 +1,6 @@
 ---
 title: Canvas
 slug: Glossary/Canvas
-tags:
-  - Canvas
-  - HTML5
-translation_of: Glossary/Canvas
 ---
 
 El **elemento canvas** forma parte de [HTML5](https://es.wikipedia.org/wiki/HTML5) y habilita la [representación (rendering)](https://es.wikipedia.org/wiki/Renderizaci%C3%B3n) dinámica y en [scripts](https://es.wikipedia.org/wiki/Script) de figuras en 2D y 3D de imágenes de [mapas de Bits](https://es.wikipedia.org/wiki/Bitmap).

--- a/files/es/glossary/card_sorting/index.md
+++ b/files/es/glossary/card_sorting/index.md
@@ -1,11 +1,6 @@
 ---
 title: Clasificación por tarjetas (card sorting)
 slug: Glossary/Card_sorting
-tags:
-  - Card sorting
-  - Diseño
-  - Glosario
-translation_of: Glossary/Card_sorting
 original_slug: Glossary/Clasificación_por_tarjetas_(card_sorting)
 ---
 

--- a/files/es/glossary/cdn/index.md
+++ b/files/es/glossary/cdn/index.md
@@ -1,10 +1,6 @@
 ---
 title: CDN
 slug: Glossary/CDN
-tags:
-  - Estructura
-  - Glosario
-translation_of: Glossary/CDN
 ---
 
 Una **Red de distribución de contenidos** (_CDN en inglés_) es un grupo de servidores distribuidos en muchas ubicaciones. Estos servidores almacenan copias duplicadas de datos para que los servidores puedan cumplir con las solicitudes de datos en función de qué servidores están más cerca de los respectivos usuarios finales. Las CDN hacen que el servicio rápido se vea menos afectado por el alto tráfico.

--- a/files/es/glossary/challenge/index.md
+++ b/files/es/glossary/challenge/index.md
@@ -1,9 +1,6 @@
 ---
 title: Protocolos desafío-respuesta
 slug: Glossary/challenge
-tags:
-  - Seguridad
-translation_of: Glossary/challenge
 ---
 
 En protocolos de seguridad, un _desafío_ es una información enviada al cliente por el servidor con el fin de generar una respuesta diferente cada vez . Los protocolos desafío-respuesta son una forma de batallar contra los [ataques de REPLAY](https://es.wikipedia.org/wiki/Ataque_de_REPLAY) donde un atacante escucha los mensajes previos y los reenvía en un momento posterior para obtener las mismas credenciales que el mensaje original.

--- a/files/es/glossary/character/index.md
+++ b/files/es/glossary/character/index.md
@@ -1,11 +1,6 @@
 ---
 title: Caracter
 slug: Glossary/Character
-tags:
-  - CodingScripting
-  - Glosario
-  - String
-translation_of: Glossary/Character
 original_slug: Glossary/Caracter
 ---
 

--- a/files/es/glossary/character_encoding/index.md
+++ b/files/es/glossary/character_encoding/index.md
@@ -1,12 +1,6 @@
 ---
 title: Codificación de caracteres
 slug: Glossary/character_encoding
-tags:
-  - Caracter
-  - Caractères
-  - Codificación
-  - Glosario
-translation_of: Glossary/character_encoding
 ---
 
 Una codificación define cómo se traducen los bytes a texto y viceversa. Una secuencia de bytes se pueden interpretar de diferentes formas. Eligiendo una codificación en particular (como UTF-8), decimos como la secuencia de bytes debe ser interpretada.

--- a/files/es/glossary/character_set/index.md
+++ b/files/es/glossary/character_set/index.md
@@ -1,11 +1,6 @@
 ---
 title: Conjunto de caracteres
 slug: Glossary/character_set
-tags:
-  - Codificación de caracteres
-  - Conjunto de caracteres
-  - Glosario
-translation_of: Glossary/character_set
 original_slug: Glossary/conjunto_de_caracteres
 ---
 

--- a/files/es/glossary/chrome/index.md
+++ b/files/es/glossary/chrome/index.md
@@ -1,12 +1,6 @@
 ---
 title: Chrome
 slug: Glossary/Chrome
-tags:
-  - Chrome
-  - Glosario
-  - Navegador
-  - WebMechanics
-translation_of: Glossary/Chrome
 ---
 
 En un navegador, Chrome es cualquier aspecto visible de un navegador aparte de las páginas web en sí (por ejemplo, barras de herramientas, barra de menús, pestañas). Esto no debe confundirse con el navegador {{glossary("Google Chrome")}}.

--- a/files/es/glossary/cia/index.md
+++ b/files/es/glossary/cia/index.md
@@ -1,10 +1,6 @@
 ---
 title: CID
 slug: Glossary/CIA
-tags:
-  - Glosario
-  - Seguridad
-translation_of: Glossary/CIA
 original_slug: Glossary/CID
 ---
 

--- a/files/es/glossary/cipher/index.md
+++ b/files/es/glossary/cipher/index.md
@@ -1,12 +1,6 @@
 ---
 title: Algoritmo criptográfico
 slug: Glossary/Cipher
-tags:
-  - Criptografía
-  - Glosario
-  - Seguridad
-  - privacidad
-translation_of: Glossary/Cipher
 original_slug: Glossary/Cifrado
 ---
 

--- a/files/es/glossary/ciphertext/index.md
+++ b/files/es/glossary/ciphertext/index.md
@@ -1,12 +1,6 @@
 ---
 title: Texto Cifrado
 slug: Glossary/Ciphertext
-tags:
-  - Cryptography
-  - Glossary
-  - Privacy
-  - Security
-translation_of: Glossary/Ciphertext
 original_slug: Glossary/TextoCifrado
 ---
 

--- a/files/es/glossary/class/index.md
+++ b/files/es/glossary/class/index.md
@@ -1,12 +1,6 @@
 ---
 title: Clase
 slug: Glossary/Class
-tags:
-  - Clase
-  - Glosario
-  - OOP
-  - POO
-translation_of: Glossary/Class
 ---
 
 En {{glossary("OOP","programación orientada a objetos")}}, una clase define las características de un {{glossary("object","objeto")}}. Una clase es una plantilla que define {{glossary("property","propiedades")}} y {{glossary("method","métodos")}}, es un modelo abstracto a partir del cual se pueden crear instancias más específicas.

--- a/files/es/glossary/closure/index.md
+++ b/files/es/glossary/closure/index.md
@@ -1,9 +1,6 @@
 ---
 title: Clausura
 slug: Glossary/Closure
-tags:
-  - Glosario
-translation_of: Glossary/Closure
 original_slug: Glossary/Clausura
 ---
 

--- a/files/es/glossary/cms/index.md
+++ b/files/es/glossary/cms/index.md
@@ -1,11 +1,6 @@
 ---
 title: Sistema de gestión de contenidos
 slug: Glossary/CMS
-tags:
-  - CMS
-  - Glosario
-  - Sistema de gestión de contenidos
-translation_of: Glossary/CMS
 original_slug: Glossary/Sistema_gestion_contenidos
 ---
 

--- a/files/es/glossary/codec/index.md
+++ b/files/es/glossary/codec/index.md
@@ -1,10 +1,6 @@
 ---
 title: Códec
 slug: Glossary/Codec
-tags:
-  - Glosario
-  - TecnologíasWeb
-translation_of: Glossary/Codec
 ---
 
 Un _códec_ (acrónimo de "***co***dificador-***dec***odificador") es un programa, algoritmo, o dispositivo que codifica o decodifica un flujo de datos. Cada códec sabe cómo tratar un estándar específico de codificado o compresión.

--- a/files/es/glossary/compile/index.md
+++ b/files/es/glossary/compile/index.md
@@ -1,12 +1,6 @@
 ---
 title: Compilar
 slug: Glossary/Compile
-tags:
-  - CodingScripting
-  - Compilador
-  - Glossary
-  - compilar
-translation_of: Glossary/Compile
 l10n:
   sourceCommit: ed947b2c608428b62a60f07d09dc543f732dc09b
 ---

--- a/files/es/glossary/compile_time/index.md
+++ b/files/es/glossary/compile_time/index.md
@@ -1,7 +1,6 @@
 ---
 title: Tiempo de compilación
 slug: Glossary/compile_time
-translation_of: Glossary/Compile_time
 ---
 
 El _tiempo de compilación_ es el tiempo desde que el programa es cargado por primera vez hasta que el programa es {{Glossary("parse","parsed")}}.

--- a/files/es/glossary/computer_programming/index.md
+++ b/files/es/glossary/computer_programming/index.md
@@ -1,11 +1,6 @@
 ---
 title: Programación de computadoras
 slug: Glossary/Computer_Programming
-tags:
-  - Lenguaje de programación
-  - Scripting
-  - programacion
-translation_of: Glossary/Computer_Programming
 ---
 
 Programación de computadoras es un proceso de componer y organizar un conjunto de instrucciones. Éstas le indican a una computadora/software qué hacer en un lenguaje comprensible para la computadora. Estas instrucciones pueden presentarse en diferentes lenguajes, tales como C++, Java, JavaScript, HTML, Python, Ruby y Rust.

--- a/files/es/glossary/constant/index.md
+++ b/files/es/glossary/constant/index.md
@@ -1,11 +1,6 @@
 ---
 title: Constante
 slug: Glossary/Constant
-tags:
-  - CodingScripting
-  - Constante
-  - Glosario
-translation_of: Glossary/Constant
 original_slug: Glossary/Constante
 ---
 

--- a/files/es/glossary/constructor/index.md
+++ b/files/es/glossary/constructor/index.md
@@ -1,9 +1,6 @@
 ---
 title: Constructor
 slug: Glossary/Constructor
-tags:
-  - Glosario
-translation_of: Glossary/Constructor
 ---
 
 Un **constructor** pertenece a una clase objeto ({{glossary("object")}}) particular la cual es instanciada. El constructor inicializa este objeto y puede otorgar acceso a su información privada. El concepto de objeto puede ser aplicado a la mayoría de los lenguajes orientados a objetos ({{glossary("OOP","object-oriented programming")}}). En esencia, un constructor en {{glossary("JavaScript")}} suele ser declarado al comienzo de una instancia de una clase ({{glossary("class")}}).

--- a/files/es/glossary/cookie/index.md
+++ b/files/es/glossary/cookie/index.md
@@ -1,10 +1,6 @@
 ---
 title: Cookie
 slug: Glossary/Cookie
-tags:
-  - Glosario
-  - TecnologíasWeb
-translation_of: Glossary/Cookie
 ---
 
 Una cookie es una pequeña información enviada por un sitio web que se almacena en el navegador del ordenador del usuario.

--- a/files/es/glossary/copyleft/index.md
+++ b/files/es/glossary/copyleft/index.md
@@ -1,14 +1,6 @@
 ---
 title: Copyleft
 slug: Glossary/Copyleft
-tags:
-  - CC SA
-  - Copyleft
-  - Creative Commons
-  - GPL
-  - Glosario
-  - Licencia
-translation_of: Glossary/Copyleft
 ---
 
 _Copyleft_ es un término, que normalmente se refiere a una licencia, y que se utiliza para indicar que toda redistribución de un trabajo bajo esta licencia **es obligatorio** que esté sujeta a la **misma licencia** **que el original**. Un buen ejemplo de copyleft es la licencia GNU [GPL](/es/docs/Glossary/GPL) (para aplicaciones software) y la licencia _Creative Commons SA_ (_Share Alike_ en español Compartir Igual) (para trabajos y obras de arte).

--- a/files/es/glossary/cors-safelisted_request_header/index.md
+++ b/files/es/glossary/cors-safelisted_request_header/index.md
@@ -1,10 +1,6 @@
 ---
 title: Encabezado de solicitud incluido en la lista segura de CORS
 slug: Glossary/CORS-safelisted_request_header
-tags:
-  - CORS
-  - Fetch
-translation_of: Glossary/CORS-safelisted_request_header
 ---
 
 Un [encabezado de solicitud incluido en la lista segura de CORS](https://fetch.spec.whatwg.org/#cors-safelisted-request-header)

--- a/files/es/glossary/cors/index.md
+++ b/files/es/glossary/cors/index.md
@@ -1,11 +1,6 @@
 ---
 title: CORS
 slug: Glossary/CORS
-tags:
-  - Infrastructure
-  - infraestructura
-  - Security
-  - Seguridad
 ---
 
 **CORS** (*Cross-Origin Resource Sharing* o en español Intercambio de recursos de origen cruzado) es un sistema que consiste en transmitir {{Glossary("HTTP_header", "HTTP headers")}}, que determina si los navegadores bloquean el acceso del código JavaScript frontend a las respuestas de peticiones de origen cruzado.

--- a/files/es/glossary/cross-site_scripting/index.md
+++ b/files/es/glossary/cross-site_scripting/index.md
@@ -1,7 +1,6 @@
 ---
 title: Cross-site scripting
 slug: Glossary/Cross-site_scripting
-translation_of: Glossary/Cross-site_scripting
 ---
 
 Cross-site scripting (XSS) es una vulnerabilidad de seguridad que permite a un atacante inyectar en un sitio web código malicioso del lado del cliente. Este código es ejecutado por las vícitmas y permite a los atacante eludir los controles de acceso y hacerce pasar por usuarios. Según el Open Web Application Security Project, XSS fue la [séptima vulnerabilidad más común de las aplicaciones web](https://www.owasp.org/images/7/72/OWASP_Top_10-2017_%28en%29.pdf.pdf) en 2017.

--- a/files/es/glossary/crud/index.md
+++ b/files/es/glossary/crud/index.md
@@ -1,10 +1,6 @@
 ---
 title: CRUD
 slug: Glossary/CRUD
-tags:
-  - Glosario
-  - Infraestructura
-translation_of: Glossary/CRUD
 ---
 
 **CRUD** (Create, Read, Update, Delete) es un acrónimo para las maneras en las que se puede operar sobre información almacenada. Es un nemónico para las cuatro funciones del almacenamiento persistente. CRUD usualmente se refiere a operaciones llevadas a cabo en una base de datos o un almácen de datos, pero también pude aplicar a funciones de un nivel superior de una aplicación como soft deletes donde la información no es realmente eliminada, sino es marcada como eliminada a tráves de un estatus.

--- a/files/es/glossary/cryptanalysis/index.md
+++ b/files/es/glossary/cryptanalysis/index.md
@@ -1,12 +1,6 @@
 ---
 title: Criptoanálisis
 slug: Glossary/Cryptanalysis
-tags:
-  - Criptografía
-  - Glosario
-  - Seguridad
-  - privacidad
-translation_of: Glossary/Cryptanalysis
 original_slug: Glossary/Criptoanálisis
 ---
 

--- a/files/es/glossary/cryptography/index.md
+++ b/files/es/glossary/cryptography/index.md
@@ -1,12 +1,6 @@
 ---
 title: Criptografía
 slug: Glossary/Cryptography
-tags:
-  - Criptografía
-  - Glosario
-  - Seguridad
-  - privacidad
-translation_of: Glossary/Cryptography
 original_slug: Glossary/Criptografía
 ---
 

--- a/files/es/glossary/csrf/index.md
+++ b/files/es/glossary/csrf/index.md
@@ -1,10 +1,6 @@
 ---
 title: CSRF
 slug: Glossary/CSRF
-tags:
-  - Glosario
-  - Seguridad
-translation_of: Glossary/CSRF
 ---
 
 **CSRF** (Cross-Site Request Forgery) es un ataque que falsifica una petición a un servidor web haciéndose pasar por un usuario de confianza. Esto se puede hacer, por ejemplo, incluyendo parámetros maliciosos en una {{glossary("URL")}} después de un enlace que pretende redirigir a otro sitio.

--- a/files/es/glossary/css/index.md
+++ b/files/es/glossary/css/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSS
 slug: Glossary/CSS
-tags:
-  - Beginner
-  - CSS
-  - Glosario
-  - Hojas de estilo
-  - Intro
-  - Web
-translation_of: Glossary/CSS
 ---
 
 **CSS,** de las siglas en inglés **C**ascading **S**tyle **S**heets (Hojas de Estilo en Cascada), es un lenguaje declarativo que controla el aspecto de las páginas web en el {{glossary("browser","navegador")}}. El navegador aplica declaraciones de estilo CSS a los elementos seleccionados para exhibirlos correctamente. Una declaración de estilos contiene las propiedades y sus respectivos valores, los cuales determinan cómo se verá una página web.

--- a/files/es/glossary/css_preprocessor/index.md
+++ b/files/es/glossary/css_preprocessor/index.md
@@ -1,7 +1,6 @@
 ---
 title: Preprocesador CSS
 slug: Glossary/CSS_preprocessor
-translation_of: Glossary/CSS_preprocessor
 original_slug: Glossary/Preprocesador_CSS
 ---
 

--- a/files/es/glossary/data_structure/index.md
+++ b/files/es/glossary/data_structure/index.md
@@ -1,11 +1,6 @@
 ---
 title: Estructura de datos
 slug: Glossary/Data_structure
-tags:
-  - Codificación
-  - Estructura de datos
-  - Glosario
-translation_of: Glossary/Data_structure
 original_slug: Glossary/Estructura_de_datos
 ---
 

--- a/files/es/glossary/decryption/index.md
+++ b/files/es/glossary/decryption/index.md
@@ -1,12 +1,6 @@
 ---
 title: Descifrado
 slug: Glossary/Decryption
-tags:
-  - Criptografía
-  - Glosario
-  - Seguridad
-  - privacidad
-translation_of: Glossary/Decryption
 original_slug: Glossary/Descifrado
 ---
 

--- a/files/es/glossary/doctype/index.md
+++ b/files/es/glossary/doctype/index.md
@@ -1,7 +1,6 @@
 ---
 title: Doctype
 slug: Glossary/Doctype
-translation_of: Glossary/Doctype
 ---
 
 `<!DOCTYPE>` informa al {{Glossary("navegador")}} qué versión de {{Glossary("HTML")}} (o {{glossary("XML")}}) se usó para escribir el documento. Doctype es una declaración no una {{Glossary("etiqueta")}}. Además, podemos referirnos a ella como "document type declaration" o por las siglas "DTD".

--- a/files/es/glossary/dom/index.md
+++ b/files/es/glossary/dom/index.md
@@ -1,12 +1,6 @@
 ---
 title: DOM
 slug: Glossary/DOM
-tags:
-  - API
-  - DOM
-  - Glosario
-  - scripts
-translation_of: Glossary/DOM
 ---
 
 El _DOM_ (Document Object Model, en español **Modelo de Objetos del Documento**) es una [API](/es/docs/Glossary/API) definida para representar e interactuar con cualquier documento [HTML](/es/docs/Glossary/HTML) o [XML](/es/docs/Glossary/XML). El DOM es un modelo de documento que se carga en el [navegador web](/es/docs/Glossary/Browser) y que representa el documento como un árbol de nodos, en donde cada nodo representa una parte del documento (puede tratarse de un [elemento](/es/docs/Glossary/element), una cadena de texto o un comentario).

--- a/files/es/glossary/domain/index.md
+++ b/files/es/glossary/domain/index.md
@@ -1,13 +1,6 @@
 ---
 title: Dominio
 slug: Glossary/Domain
-tags:
-  - Domínio
-  - Glosario
-  - Infraestructura
-  - Navegador
-  - Redes
-translation_of: Glossary/Domain
 ---
 
 Un dominio es una autoridad dentro de internet que controla sus propios recursos. Su "nombre de dominio" es una forma de dirigirse a esta autoridad como parte de la jerarquía en una {{Glossary("URL")}}, que generalmente es la parte más significativa de la misma, por ejemplo, un nombre de marca.

--- a/files/es/glossary/domain_name/index.md
+++ b/files/es/glossary/domain_name/index.md
@@ -1,7 +1,6 @@
 ---
 title: Nombre de dominio
 slug: Glossary/Domain_name
-translation_of: Glossary/Domain_name
 original_slug: Glossary/Nombre_de_dominio
 ---
 

--- a/files/es/glossary/dynamic_typing/index.md
+++ b/files/es/glossary/dynamic_typing/index.md
@@ -1,11 +1,6 @@
 ---
 title: Tipado Dinámico
 slug: Glossary/Dynamic_typing
-tags:
-  - Código
-  - Glosario
-  - LenguajeDeProgramación
-translation_of: Glossary/Dynamic_typing
 original_slug: Glossary/Tipado_dinámico
 ---
 

--- a/files/es/glossary/ecmascript/index.md
+++ b/files/es/glossary/ecmascript/index.md
@@ -1,10 +1,6 @@
 ---
 title: ECMAScript
 slug: Glossary/ECMAScript
-tags:
-  - Glosario
-  - WebMechanics
-translation_of: Glossary/ECMAScript
 ---
 
 **ECMAScript** es una especificación de lenguaje de scripting en la que se basa {{Glossary("JavaScript")}}. [Ecma International](http://www.ecma-international.org) está a cargo de estandarizar ECMAScript.

--- a/files/es/glossary/element/index.md
+++ b/files/es/glossary/element/index.md
@@ -1,7 +1,6 @@
 ---
 title: Elemento
 slug: Glossary/Element
-translation_of: Glossary/Element
 ---
 
 Un elemento es parte de una página web. En XML y HTML, un elemento puede contener un elemento de datos o un fragmento de texto o una imagen, o tal vez nada. Un elemento típico incluye una etiqueta de apertura con algunos atributos, contenido de texto cerrado y una etiqueta de cierre.

--- a/files/es/glossary/encapsulation/index.md
+++ b/files/es/glossary/encapsulation/index.md
@@ -1,10 +1,6 @@
 ---
 title: Encapsulación
 slug: Glossary/Encapsulation
-tags:
-  - CodingScripting
-  - Glosario
-translation_of: Glossary/Encapsulation
 ---
 
 La encapsulación es el empaquetamiento de datos y {{glossary("function","funciones")}} en un componente (por ejemplo, una {{glossary("class", "clase")}}) y para luego controlar el acceso a ese componente para hacer un ejecto de "caja negra" fuera del {{glossary("object", "objeto")}}. Debido a esto, un usuario de esa clase solo necesita conocer su interfaz (es decir, los datos y las funciones expuestas fuera de la clase), no la implementación oculta.

--- a/files/es/glossary/encryption/index.md
+++ b/files/es/glossary/encryption/index.md
@@ -1,12 +1,6 @@
 ---
 title: Encriptación
 slug: Glossary/Encryption
-tags:
-  - Criptografía
-  - Glosario
-  - Seguridad
-  - privacidad
-translation_of: Glossary/Encryption
 original_slug: Glossary/Encriptación
 ---
 

--- a/files/es/glossary/entity/index.md
+++ b/files/es/glossary/entity/index.md
@@ -1,11 +1,6 @@
 ---
 title: Entidad
 slug: Glossary/Entity
-tags:
-  - Caractères
-  - HTML
-  - entidad
-translation_of: Glossary/Entity
 original_slug: Glossary/Entidad
 ---
 

--- a/files/es/glossary/event/index.md
+++ b/files/es/glossary/event/index.md
@@ -1,10 +1,6 @@
 ---
 title: Evento
 slug: Glossary/event
-tags:
-  - CodingScripting
-  - Glosario
-translation_of: Glossary/event
 ---
 
 Los eventos son sucesos generados por elementos del [DOM](/en-US/docs/Glossary/DOM), que pueden ser manipulados por un código Javascript

--- a/files/es/glossary/first-class_function/index.md
+++ b/files/es/glossary/first-class_function/index.md
@@ -1,7 +1,6 @@
 ---
 title: Funcion de primera clase
 slug: Glossary/First-class_Function
-translation_of: Glossary/First-class_Function
 original_slug: Glossary/Funcion_de_primera_clase
 ---
 

--- a/files/es/glossary/flex/index.md
+++ b/files/es/glossary/flex/index.md
@@ -1,7 +1,6 @@
 ---
 title: Flex
 slug: Glossary/Flex
-translation_of: Glossary/Flex
 ---
 
 flex es una nueva herramienta agregada a la propiedad CSS {{cssxref ("display")}}. Junto con inline-flex, hace que el elemento al que se aplica se convierta en un {{glossary("flex container")}}, y los hijos del elemento se conviertan cada uno en un {{glossary("flex item")}}.

--- a/files/es/glossary/flex_container/index.md
+++ b/files/es/glossary/flex_container/index.md
@@ -1,7 +1,6 @@
 ---
 title: Flex Container
 slug: Glossary/Flex_Container
-translation_of: Glossary/Flex_Container
 ---
 
 Una plantilla con {{glossary("flexbox")}} puede ser definida usando los valores `flex` o `inline-flex` en las propiedades de `display`. Este elemento es un **contenedor flex**, y cada uno de los contenedores que heredan propiedades de este, son conocidos como {{glossary("flex item")}}.

--- a/files/es/glossary/flexbox/index.md
+++ b/files/es/glossary/flexbox/index.md
@@ -1,7 +1,6 @@
 ---
 title: Flexbox
 slug: Glossary/Flexbox
-translation_of: Glossary/Flexbox
 ---
 
 Flexbox es como se llama comúnmente a [Módulo de diseño de caja flexible CSS](https://www.w3.org/TR/css-flexbox-1/), un modelo de diseño para mostrar elementos en una sola dimensión, como una fila o como una columna.

--- a/files/es/glossary/forbidden_header_name/index.md
+++ b/files/es/glossary/forbidden_header_name/index.md
@@ -1,13 +1,6 @@
 ---
 title: Nombre de encabezado prohibido
 slug: Glossary/Forbidden_header_name
-tags:
-  - Encabezados
-  - Fetch
-  - Glosario
-  - HTTP
-  - prohibido
-translation_of: Glossary/Forbidden_header_name
 original_slug: Glossary/Nombre_de_encabezado_prohibido
 ---
 

--- a/files/es/glossary/fps/index.md
+++ b/files/es/glossary/fps/index.md
@@ -1,7 +1,6 @@
 ---
 title: frame rate (FPS)
 slug: Glossary/FPS
-translation_of: Glossary/FPS
 ---
 
 Un **cuadro por segundo** es la velocidad en la cual el navegador web, es capaz de recalcular la disposición y dibujar el contenido de la pantalla.

--- a/files/es/glossary/ftp/index.md
+++ b/files/es/glossary/ftp/index.md
@@ -1,7 +1,6 @@
 ---
 title: FTP
 slug: Glossary/FTP
-translation_of: Glossary/FTP
 ---
 
 FTP (del inglés _File Transfer Protocol_, Protocolo de transferencia de archivos) fue el [protocolo](/es/docs/Glossary/Protocol) estándar durante muchos años para transferir archivos entre equipos a través de Internet. Sin embargo, cada vez más los equipos y las cuentas de alojamiento no permiten el FTP y en su lugar dependen de un sistema de control de versiones como Git. Se encuentra todavía en funcionamiento en las cuentas de alojamiento más antiguas, pero no es exagerado decir que el FTP ya no es considerada la mejor práctica.

--- a/files/es/glossary/function/index.md
+++ b/files/es/glossary/function/index.md
@@ -1,12 +1,6 @@
 ---
 title: Función
 slug: Glossary/Function
-tags:
-  - CodingScripting
-  - Glosario
-  - IIFE
-  - JavaScript
-translation_of: Glossary/Function
 original_slug: Glossary/Función
 ---
 

--- a/files/es/glossary/general_header/index.md
+++ b/files/es/glossary/general_header/index.md
@@ -1,7 +1,6 @@
 ---
 title: Cabecera general
 slug: Glossary/General_header
-translation_of: Glossary/General_header
 original_slug: Glossary/Cabecera_general
 ---
 

--- a/files/es/glossary/gif/index.md
+++ b/files/es/glossary/gif/index.md
@@ -1,12 +1,6 @@
 ---
 title: GIF
 slug: Glossary/gif
-tags:
-  - Animacion
-  - Composición
-  - Glosario
-  - Imagen
-translation_of: Glossary/gif
 ---
 
 **GIF** (**G**raphics **I**nterchange **F**ormat en español **Formato de Intercambio de Gráficos**) es un formato de imagen con una baja compresión y se puede usar para animaciones. Un GIF usa hasta 8 bits por pixel y contiene un máximo de 256 colores con un rango de 24-bit.

--- a/files/es/glossary/git/index.md
+++ b/files/es/glossary/git/index.md
@@ -1,10 +1,6 @@
 ---
 title: Git
 slug: Glossary/Git
-tags:
-  - Colaboración
-  - Glosario
-translation_of: Glossary/Git
 ---
 
 **Git** es un software de control de versiones ({{Glossary("SCM", "SCV", 1)}}) distribuido, libre y de código abierto. Facilita el manejo de código fuente con equipos de desarrollo distribuidos. La principal diferencia con SCV previos es la habilidad para hacer operaciones comunes (branching, committing, etc.) en el equipo de desarrollo local, sin tener que modificar el repositorio master o tener de acceso de escritura a él.

--- a/files/es/glossary/google_chrome/index.md
+++ b/files/es/glossary/google_chrome/index.md
@@ -1,17 +1,6 @@
 ---
 title: Google Chrome
 slug: Glossary/Google_Chrome
-tags:
-  - Chrome
-  - Chrome canary
-  - Chrome stable
-  - Chromium
-  - Glosario
-  - Navegador
-  - Web
-  - google
-  - google chrome
-translation_of: Glossary/Google_Chrome
 ---
 
 _Google Chrome_ es un [navegador](/es/docs/Glossary/Browser) web gratuito desarrollado por Google. Está basado en el proyecto open source (código abierto / software libre) [Chromium](http://www.chromium.org/). Algunas de las principales diferencias se encuentran en [Chromium wiki](https://code.google.com/p/chromium/wiki/ChromiumBrowserVsGoogleChrome). El motor de diseño que utilizan ambos es una copia del motor [Blink](/es/docs/Glossary/Blink) de [WebKit](/es/docs/Glossary/WebKit). Cabe señalar que en la versión de Chrome en iOS se utiliza WebKit y no Blink.

--- a/files/es/glossary/gpl/index.md
+++ b/files/es/glossary/gpl/index.md
@@ -1,16 +1,6 @@
 ---
 title: GPL
 slug: Glossary/GPL
-tags:
-  - Compartir
-  - Copyleft
-  - GNU
-  - GPL
-  - Glosario
-  - Libre
-  - Licencia
-  - Open Source
-translation_of: Glossary/GPL
 ---
 
 La lincencia GNU _GPL_ (GNU General Public License en español **Licencia Pública General de GNU**) es una licencia de software libre [copyleft](/es/docs/Glossary/copyleft) publicada por la _Free Software Foundation_. Los usuarios de un programa con licencia GPL son libres para usarlo, acceder al código fuente, modificarlo y distribuir los cambios; siempre que redistribuyan el programa completo (modificado o no modificado) bajo la misma licencia.

--- a/files/es/glossary/grid/index.md
+++ b/files/es/glossary/grid/index.md
@@ -1,10 +1,6 @@
 ---
 title: Grid
 slug: Glossary/Grid
-tags:
-  - CSS
-  - CSS Grids
-translation_of: Glossary/Grid
 ---
 
 _CSS grid_ es definido usando el valor grid en la propiedad `display`; puedes definir columnas y filas en tu diseño grid, con las propiedades {{cssxref("grid-template-rows")}} y {{cssxref("grid-template-columns")}} .

--- a/files/es/glossary/grid_areas/index.md
+++ b/files/es/glossary/grid_areas/index.md
@@ -1,7 +1,6 @@
 ---
 title: Grid Areas
 slug: Glossary/Grid_Areas
-translation_of: Glossary/Grid_Areas
 ---
 
 Un **grid area** es una o más {{glossary("grid cell", "grid cells")}} que forman un área rectangular en la cuadrícula. Los grid areas se crean cuando se coloca un elemento usando [disposición basada en líneas](/es/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid) o cuando se definen áreas usando [grid areas con nombre](/es/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas).

--- a/files/es/glossary/grid_column/index.md
+++ b/files/es/glossary/grid_column/index.md
@@ -1,7 +1,6 @@
 ---
 title: Grid Column
 slug: Glossary/Grid_Column
-translation_of: Glossary/Grid_Column
 ---
 
 Una **columna de grid** es una pista vertical en un [CSS Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout), y es el espacio entre dos líneas verticales de cuadrícula. Está definido por la propiedad {{cssxref("grid-template-columns")}} o por las propiedades abreviadas {{cssxref("grid")}} o {{cssxref("grid-template")}}.

--- a/files/es/glossary/grid_lines/index.md
+++ b/files/es/glossary/grid_lines/index.md
@@ -1,7 +1,6 @@
 ---
 title: Líneas de Cuadrícula
 slug: Glossary/Grid_Lines
-translation_of: Glossary/Grid_Lines
 ---
 
 Las **Líneas de Cuadrícula** se crean cuando defines las {{glossary("tracks", "Pistas de Cuadrícula")}} esto sucede dentro de un contenedor que este usando [CSS Grid Layout](/es/docs/Web/CSS/CSS_Grid_Layout).

--- a/files/es/glossary/grid_row/index.md
+++ b/files/es/glossary/grid_row/index.md
@@ -1,7 +1,6 @@
 ---
 title: Grid Row
 slug: Glossary/Grid_Row
-translation_of: Glossary/Grid_Rows
 original_slug: Glossary/Grid_Rows
 ---
 

--- a/files/es/glossary/head/index.md
+++ b/files/es/glossary/head/index.md
@@ -1,12 +1,6 @@
 ---
 title: Head
 slug: Glossary/Head
-tags:
-  - Glosario
-  - HTML
-  - Metadatos
-  - head
-translation_of: Glossary/Head
 ---
 
 La cabecera (en inglés _Head_) es la parte de un documento [HTML](/es/docs/Glossary/Head) que contiene [metadatos](/es/docs/Glossary/Metadato) sobre ese documento, como el autor, la descripción y los enlaces a los archivos [CSS](/es/docs/Glossary/CSS) o [JavaScript](/es/docs/Glossary/JavaScript) que se deben aplicar al documento HTML. Es la parte del documento web que no es visible al usuario.

--- a/files/es/glossary/hoisting/index.md
+++ b/files/es/glossary/hoisting/index.md
@@ -1,10 +1,6 @@
 ---
 title: Hoisting
 slug: Glossary/Hoisting
-tags:
-  - JavaScript
-  - hoisting
-translation_of: Glossary/Hoisting
 ---
 
 Hoisting es un término que _no_ encontrará utilizado en ninguna especificación previa a [ECMAScript® 2015 Language Specification](http://www.ecma-international.org/ecma-262/6.0/index.html). El concepto de Hoisting fue pensado como una manera general de referirse a cómo funcionan los contextos de ejecución en JavaScript (específicamente las fases de creación y ejecución). Sin embargo, el concepto puede ser un poco confuso al principio.

--- a/files/es/glossary/host/index.md
+++ b/files/es/glossary/host/index.md
@@ -1,9 +1,6 @@
 ---
 title: Anfitrión
 slug: Glossary/Host
-tags:
-  - Glosario
-translation_of: Glossary/Host
 ---
 
 Un anfitrión (del ingles _host_) es un dispositivo conectado a {{glossary("Internet")}} (o una red de área local). Algunos anfitriones denominados {{glossary("server","servidores")}} ofrecen servicios adicionales como servir páginas web o alojar archivos y correos electrónicos.

--- a/files/es/glossary/html/index.md
+++ b/files/es/glossary/html/index.md
@@ -1,10 +1,6 @@
 ---
 title: HTML
 slug: Glossary/HTML
-tags:
-  - Glosario
-  - HTML
-translation_of: Glossary/HTML
 ---
 
 HTML (Lenguaje de marcado de hipertexto o HyperText Markup Language por sus siglas en inglés) es un lenguaje descriptivo que especifica la estructura de las páginas web.

--- a/files/es/glossary/html5/index.md
+++ b/files/es/glossary/html5/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTML5
 slug: Glossary/HTML5
-translation_of: Glossary/HTML5
 ---
 
 La última versión estable de [HTML](/es/docs/Glossary/HTML), HTML5 convierte a HTML de un simple formato de marcado para estructurar documentos en una plataforma completa de desarrollo de aplicaciones. Entre otras características, HTML5 incluye nuevos elementos y [API](/es/docs/Glossary/API) de [JavaScript](/es/docs/Glossary/JavaScript) para mejorar el almacenamiento, la multimedia y el acceso al hardware.

--- a/files/es/glossary/http/index.md
+++ b/files/es/glossary/http/index.md
@@ -1,11 +1,6 @@
 ---
 title: HTTP
 slug: Glossary/HTTP
-tags:
-  - Beginner
-  - Intro
-  - Web
-translation_of: Glossary/HTTP
 ---
 
 El protocolo de transferencia de hipertexto o HTTP (HyperText Transfer Protocol) es el protocolo de red que permite la transferencia de documentos de hipermedia en la red, generalmente entre un navegador y un servidor, para que los humanos puedan leerlos. La versión actual de la especificación se llama HTTP/2.

--- a/files/es/glossary/https/index.md
+++ b/files/es/glossary/https/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTTPS
 slug: Glossary/https
-translation_of: Glossary/https
 ---
 
 HTTPS (HTTP Secure) es una versión encriptada del protocolo {{Glossary("HTTP")}}. Normalmente utiliza {{Glossary("SSL")}} o {{Glossary("TLS")}} para cifrar toda la comunicación entre un cliente y un servidor. Esta conexión segura permite a los clientes intercambiar datos confidenciales de forma segura con un servidor, por ejemplo, para actividades bancarias o compras en línea.

--- a/files/es/glossary/hyperlink/index.md
+++ b/files/es/glossary/hyperlink/index.md
@@ -1,15 +1,6 @@
 ---
 title: Hipervínculo
 slug: Glossary/Hyperlink
-tags:
-  - Glosario
-  - HTML
-  - Hipervínculo
-  - Navegador
-  - Web
-  - a
-  - enlace
-translation_of: Glossary/Hyperlink
 ---
 
 Los _Hipervínculos_ ó _enlaces_ permiten conectar entre sí datos ó páginas web. En [HTML](/es/docs/Glossary/HTML), los elementos {{HTMLElement("a")}} representan hipervínculos que tienen como origen un elemento de la página web (por ejemplo cadenas de texto o imágenes), y que pueden tener como destino un elemento de otro sitio web (incluso pueden enlazar a otro punto de la misma página).

--- a/files/es/glossary/hypertext/index.md
+++ b/files/es/glossary/hypertext/index.md
@@ -1,9 +1,6 @@
 ---
 title: Hipertexto
 slug: Glossary/Hypertext
-tags:
-  - Glosario
-translation_of: Glossary/Hypertext
 ---
 
 El hipertexto es texto que contiene enlaces a otros textos, y no un flujo único y lineal como el de una novela.

--- a/files/es/glossary/ide/index.md
+++ b/files/es/glossary/ide/index.md
@@ -1,14 +1,6 @@
 ---
 title: IDE
 slug: Glossary/IDE
-tags:
-  - Compilador
-  - Debugger
-  - Depurador
-  - Glosario
-  - IDE
-  - editor de texto
-translation_of: Glossary/IDE
 ---
 
 Un entorno de desarrollo integrado (**IDE**) o entorno de desarrollo interactivo es una aplicación que proporciona facilidades a los programadores para el desarrollo de software. Un IDE normalmente consta de un editor de código, herramientas automatizadas para producir el proyecto y un depurador.

--- a/files/es/glossary/identifier/index.md
+++ b/files/es/glossary/identifier/index.md
@@ -1,13 +1,6 @@
 ---
 title: Identificador
 slug: Glossary/Identifier
-tags:
-  - Campartir
-  - CodingScripting
-  - Glosario
-  - Novato
-  - Principiante
-translation_of: Glossary/Identifier
 original_slug: Glossary/Identificador
 ---
 

--- a/files/es/glossary/iife/index.md
+++ b/files/es/glossary/iife/index.md
@@ -1,9 +1,6 @@
 ---
 title: 'IIFE: Expresión de función ejecutada inmediatamente'
 slug: Glossary/IIFE
-tags:
-  - Funciones
-translation_of: Glossary/IIFE
 ---
 
 Las expresiones de función ejecutadas inmediatamente (**IIFE** por su sigla en inglés) son funciones que se ejecutan tan pronto como se definen.

--- a/files/es/glossary/immutable/index.md
+++ b/files/es/glossary/immutable/index.md
@@ -1,10 +1,6 @@
 ---
 title: Inmutable
 slug: Glossary/Immutable
-tags:
-  - CodingScripting
-  - Glosario
-translation_of: Glossary/Immutable
 original_slug: Glossary/Inmutable
 ---
 

--- a/files/es/glossary/index.md
+++ b/files/es/glossary/index.md
@@ -1,7 +1,6 @@
 ---
-title: "Glosario de MDN Web Docs: Definiciones de términos relacionados con la Web"
+title: 'Glosario de MDN Web Docs: Definiciones de términos relacionados con la Web'
 slug: Glossary
-translation_of: Glossary
 l10n:
   sourceCommit: ed947b2c608428b62a60f07d09dc543f732dc09bed947b2c608428b62a60f07d09dc543f732dc09b
 ---

--- a/files/es/glossary/indexeddb/index.md
+++ b/files/es/glossary/indexeddb/index.md
@@ -1,7 +1,6 @@
 ---
 title: IndexedDB
 slug: Glossary/IndexedDB
-translation_of: Glossary/IndexedDB
 ---
 
 IndexedDB es una {{glossary("API")}} Web diseñada para almacenar estructuras de datos grandes en los navegadores e indexarlas para realizar búsquedas de alto rendimiento. Al igual que los sistemas [RDBMS](https://es.wikipedia.org/wiki/Sistema_de_gesti%C3%B3n_de_bases_de_datos_relacionales) basados en {{glossary("SQL")}}, IndexedDB es un sistema de base de datos transaccional. Sin embargo, usa objetos de {{glossary("JavaScript")}} en vez de columnas fijas para almacenar los datos.

--- a/files/es/glossary/information_architecture/index.md
+++ b/files/es/glossary/information_architecture/index.md
@@ -1,11 +1,6 @@
 ---
 title: Arquitectura de la información
 slug: Glossary/Information_architecture
-tags:
-  - Arquitectura informacional
-  - Diseño
-  - Glosario
-translation_of: Glossary/Information_architecture
 original_slug: Glossary/Arquitectura_de_la_información
 ---
 

--- a/files/es/glossary/internet/index.md
+++ b/files/es/glossary/internet/index.md
@@ -1,7 +1,6 @@
 ---
 title: Internet
 slug: Glossary/Internet
-translation_of: Glossary/Internet
 ---
 
 La Internet es una red mundial de redes que utiliza el conjunto de protocolos de Internet (tambien conocidos como {{glossary("TCP")}}/{{glossary("IPv6","IP")}} (art. en ingles) siendo sus dos mas importantes {{glossary("protocol","protocolos")}}).

--- a/files/es/glossary/ip_address/index.md
+++ b/files/es/glossary/ip_address/index.md
@@ -1,7 +1,6 @@
 ---
 title: Dirección IP
 slug: Glossary/IP_Address
-translation_of: Glossary/IP_Address
 ---
 
 Una dirección IP es un número asignado a cada dispositivo conectado a una red que utiliza el protocolo de Internet.

--- a/files/es/glossary/ipv6/index.md
+++ b/files/es/glossary/ipv6/index.md
@@ -1,10 +1,6 @@
 ---
 title: IPv6
 slug: Glossary/IPv6
-tags:
-  - IPv6
-  - Web
-translation_of: Glossary/IPv6
 ---
 
 **IPv6** es la versión actual del protocolo de comunicación subyacente a Internet. Lentamente, IPv6 está reemplazando a IPv4, entre otras razones porque IPv6 permite muchas direcciones de IP diferentes.

--- a/files/es/glossary/irc/index.md
+++ b/files/es/glossary/irc/index.md
@@ -1,7 +1,6 @@
 ---
 title: IRC
 slug: Glossary/IRC
-translation_of: Glossary/IRC
 ---
 
 **IRC** (_Internet Relay Chat_) es un sistema de chat mundial que requiere una conexión a Internet y un cliente IRC, que envía y recibe mensajes atravéz del servidor IRC.

--- a/files/es/glossary/isp/index.md
+++ b/files/es/glossary/isp/index.md
@@ -1,12 +1,6 @@
 ---
 title: ISP
 slug: Glossary/ISP
-tags:
-  - Glosario
-  - ISP
-  - Proveedor de servicios de Internet
-  - Web
-translation_of: Glossary/ISP
 ---
 
 Un ISP (del inglés _Internet Service Provider_, Proveedor de servicios de Internet) es una empresa (en su mayoría compañías telefónicas) que vende acceso a Internet y, a veces, correo electrónico, alojamiento de páginas web y voz sobre IP, ya sea mediante una conexión de marcación a través de una línea telefónica (antes más común), o a través de una conexión de banda ancha como un módem de cable o un servicio DSL.

--- a/files/es/glossary/java/index.md
+++ b/files/es/glossary/java/index.md
@@ -1,11 +1,6 @@
 ---
 title: Java
 slug: Glossary/Java
-tags:
-  - Glosario
-  - Java
-  - Lenguaje de programación
-translation_of: Glossary/Java
 ---
 
 Java es un lenguaje de {{Glossary("computer programming", "programación")}} semi-compilado, {{glossary("OOP", "orientado a objetos")}} y portable.

--- a/files/es/glossary/javascript/index.md
+++ b/files/es/glossary/javascript/index.md
@@ -1,12 +1,6 @@
 ---
 title: JavaScript
 slug: Glossary/JavaScript
-tags:
-  - CodingScripting
-  - Glosario
-  - JavaScript
-  - l10n:priority
-translation_of: Glossary/JavaScript
 ---
 {{jsSidebar}}
 

--- a/files/es/glossary/jpeg/index.md
+++ b/files/es/glossary/jpeg/index.md
@@ -1,7 +1,6 @@
 ---
 title: JPEG
 slug: Glossary/jpeg
-translation_of: Glossary/jpeg
 ---
 
 **JPEG** (_Joint Photographic Experts Group_) es un método comúnmente utilizado en la compresión con pérdida de información en imágenes digitales.

--- a/files/es/glossary/json/index.md
+++ b/files/es/glossary/json/index.md
@@ -1,13 +1,6 @@
 ---
 title: JSON
 slug: Glossary/JSON
-tags:
-  - Glosario
-  - I10n:prioridad
-  - JSON
-  - Script de codificación
-  - introducción
-translation_of: Glossary/JSON
 ---
 
 **JSON (notación de objetos javascript)** es un formato de intercambio de datos. Es muy parecido a un subconjunto de sintaxis JavaScript, aunque no es un subconjunto en sentido estricto. (Ver JSON en la Referencia JavaScript para más detalles.) Aunque muchos lenguajes de programación lo soportan, JSON es especialmente útil al escribir cualquier tipo de aplicación basada en JavaScript, incluyendo sitios web y extensiones del navegador. Por ejemplo, es posible almacenar la información del usuario en formato JSON en una cookie o almacenar las preferencias de extensión en JSON en una cadena de valores de preferencias del navegador.

--- a/files/es/glossary/key/index.md
+++ b/files/es/glossary/key/index.md
@@ -1,11 +1,6 @@
 ---
 title: Clave
 slug: Glossary/Key
-tags:
-  - Criptografía
-  - Glosario
-  - Seguridad
-translation_of: Glossary/Key
 original_slug: Glossary/Clave
 ---
 

--- a/files/es/glossary/keyword/index.md
+++ b/files/es/glossary/keyword/index.md
@@ -1,13 +1,6 @@
 ---
 title: Palabra clave
 slug: Glossary/Keyword
-tags:
-  - Buscar
-  - Buscar palabra clave
-  - Glosario
-  - Palabra clave
-  - busqueda
-translation_of: Glossary/Keyword
 ---
 
 Una **palabra clave** es una palabra o frase que describe contenido. Las palabras clave en línea se utilizan como consultas para los motores de búsqueda o como palabras que identifican el contenido de los sitios web.

--- a/files/es/glossary/lgpl/index.md
+++ b/files/es/glossary/lgpl/index.md
@@ -1,16 +1,6 @@
 ---
 title: LGPL
 slug: Glossary/LGPL
-tags:
-  - Compartir
-  - Free
-  - Free Software Foundation
-  - GNU
-  - GPL
-  - Licencia
-  - Open Source
-  - Software Libre
-translation_of: Glossary/LGPL
 ---
 
 _LGPL_ (GNU Lesser General Public License en español **Licencia Pública General Reducida de GNU**) es una licencia de software libre publicada por la _Free Software Foundation_. LGPL es una alternativa más permisiva que la estricta licencia [copyleft](/es/docs/Glossary/copyleft) [GPL](/es/docs/Glossary/GPL).

--- a/files/es/glossary/long_task/index.md
+++ b/files/es/glossary/long_task/index.md
@@ -1,12 +1,6 @@
 ---
 title: Long task
 slug: Glossary/Long_task
-tags:
-  - Api de tareas largas
-  - Glosario
-  - Referencia
-  - Rendimiento Web
-translation_of: Glossary/Long_task
 ---
 
 Una '**long task'** (tarea larga) es una tarea que tarda más de 50 ms en completarse. Es un período ininterrumpido en el que el subproceso de la interfaz de usuario principal está ocupado durante 50 ms o más. Los ejemplos comunes incluyen controladores de eventos de ejecución prolongada, [reflujos](/es/docs/Glossary/Reflow) costosos y otras representaciones, y el trabajo que realiza el navegador entre diferentes turnos del bucle de eventos que supera los 50 ms.

--- a/files/es/glossary/main_thread/index.md
+++ b/files/es/glossary/main_thread/index.md
@@ -1,12 +1,6 @@
 ---
 title: Hilo principal
 slug: Glossary/Main_thread
-tags:
-  - Actualización Web
-  - Glosario
-  - Referencia
-  - Web de rendimiento
-translation_of: Glossary/Main_thread
 original_slug: Glossary/Hilo_principal
 ---
 

--- a/files/es/glossary/metadata/index.md
+++ b/files/es/glossary/metadata/index.md
@@ -1,11 +1,6 @@
 ---
 title: Metadato
 slug: Glossary/Metadata
-tags:
-  - CodingScripting
-  - Glosario
-  - HTML
-translation_of: Glossary/Metadata
 original_slug: Glossary/Metadato
 ---
 

--- a/files/es/glossary/method/index.md
+++ b/files/es/glossary/method/index.md
@@ -1,10 +1,6 @@
 ---
 title: Método
 slug: Glossary/Method
-tags:
-  - Glosario
-  - JavaScript
-translation_of: Glossary/Method
 original_slug: Glossary/Método
 ---
 

--- a/files/es/glossary/mitm/index.md
+++ b/files/es/glossary/mitm/index.md
@@ -1,10 +1,6 @@
 ---
 title: MitM
 slug: Glossary/MitM
-tags:
-  - Glosario
-  - Seguridad
-translation_of: Glossary/MitM
 ---
 
 Un ataque de Intermediario \[**Man-in-the-middle attack** (MitM)] intercepta una comunicación entre dos sistemas. Por ejemplo, un router Wi-Fi puede estar en peligro.

--- a/files/es/glossary/mixin/index.md
+++ b/files/es/glossary/mixin/index.md
@@ -1,7 +1,6 @@
 ---
 title: Mixin
 slug: Glossary/Mixin
-translation_of: Glossary/Mixin
 ---
 
 Un _mixin_ es un conjunto coherente de {{glossary("method","métodos")}} y {{glossary("property","propiedades")}} implementadas por otras interfaces y {{glossary("class","clases")}}.

--- a/files/es/glossary/mobile_first/index.md
+++ b/files/es/glossary/mobile_first/index.md
@@ -1,11 +1,6 @@
 ---
 title: Mobile First
 slug: Glossary/Mobile_First
-tags:
-  - Diseño
-  - Diseño móvil
-  - Glosario
-translation_of: Glossary/Mobile_First
 ---
 
 **Mobile first**, una forma de {{Glossary("mejora progresiva")}}, es un enfoque de desarrollo y diseño web que se enfoca en la priorización del diseño y el desarrollo para dispositivos móviles por encima del diseño y desarrollo para pantallas de escritorio. El fundamento detrás del enfoque "mobile-first" es proveer al usuario una buena experiencia para todos los tamaños de pantalla—empezando por una experiencia de usuario que funcione bien para dispositivos pequeños, para posteriormente, basada en dicha experiencia, continuar desarrollando para enriquecer la experiencia de usuario conforme el tamaño de pantalla es mayor. El enfoque "mobile-first" contrasta con el antiguo enfoque de diseño para escritorio en el que se pensaba primero en el diseño/desarrollo para tamaños de pantalla de escritorio y posteriormente se realizaban ajustes para conseguir que dichos diseños y desarrollos funcionases correctamente en dispositivos móbilies.

--- a/files/es/glossary/mozilla_firefox/index.md
+++ b/files/es/glossary/mozilla_firefox/index.md
@@ -1,13 +1,6 @@
 ---
 title: Mozilla Firefox
 slug: Glossary/Mozilla_Firefox
-tags:
-  - Glosario
-  - Infraestructura
-  - Mozilla
-  - Mozilla Firefox
-  - Navegador
-translation_of: Glossary/Mozilla_Firefox
 ---
 
 Mozilla Firefox es un {{Glossary("navegador")}} gratuito de codigo abierto cuyo desarrollo es supervisado por Mozilla Corporation. Firefox functiona sobre Windows, OS X, Linus y Android.

--- a/files/es/glossary/mvc/index.md
+++ b/files/es/glossary/mvc/index.md
@@ -1,7 +1,6 @@
 ---
 title: MVC
 slug: Glossary/MVC
-translation_of: Glossary/MVC
 ---
 
 **MVC** (Modelo-Vista-Controlador) es un patrón en el diseño de software comúnmente utilizado para implementar interfaces de usuario, datos y lógica de control. Enfatiza una separación entre la lógica de negocios y su visualización. Esta "separación de preocupaciones" proporciona una mejor división del trabajo y una mejora de mantenimiento. Algunos otros patrones de diseño se basan en MVC, como MVVM (Modelo-Vista-modelo de vista), MVP (Modelo-Vista-Presentador) y MVW (Modelo-Vista-Whatever).

--- a/files/es/glossary/node.js/index.md
+++ b/files/es/glossary/node.js/index.md
@@ -1,12 +1,6 @@
 ---
 title: Node.js
 slug: Glossary/Node.js
-tags:
-  - Glosario
-  - Infraestructura
-  - JavaScript
-  - node.js
-translation_of: Glossary/Node.js
 ---
 
 Node.js es un entorno de ejecucion multiplataforma en {{Glossary("JavaScript")}} que permite a los desarrolladores construir aplicaciones del lado del servidor y de red con JavaScript.

--- a/files/es/glossary/node/dom/index.md
+++ b/files/es/glossary/node/dom/index.md
@@ -1,7 +1,6 @@
 ---
 title: Node (DOM)
 slug: Glossary/Node/DOM
-translation_of: Glossary/Node/DOM
 ---
 
 En el contexto del {{Glossary("DOM")}}, un **nodo** es un único punto en el arbol de nodos. Los nodos pueden ser varias cosas el documento mismo, elementos, texto y comentarios.

--- a/files/es/glossary/node/index.md
+++ b/files/es/glossary/node/index.md
@@ -1,10 +1,6 @@
 ---
 title: Node
 slug: Glossary/Node
-tags:
-  - Desambiguación
-  - Glosario
-translation_of: Glossary/Node
 ---
 
 El término **nodo** puede tener varios significados según el contexto. Puede referirse a:

--- a/files/es/glossary/null/index.md
+++ b/files/es/glossary/null/index.md
@@ -1,9 +1,6 @@
 ---
 title: 'Null'
 slug: Glossary/Null
-tags:
-  - Glosario
-translation_of: Glossary/Null
 ---
 
 En ciencias informáticas, un valor **null** representa una referencia que apunta, generalmente intencionadamente, a una inexistente o inválido {{glossary("objecto","objeto")}} o dirección. El significado de una referencia null varía entre las implementaciones de lenguajes.

--- a/files/es/glossary/number/index.md
+++ b/files/es/glossary/number/index.md
@@ -1,10 +1,6 @@
 ---
 title: Number
 slug: Glossary/Number
-tags:
-  - Glosario
-  - JavaScript
-translation_of: Glossary/Number
 original_slug: Glossary/Numero
 ---
 

--- a/files/es/glossary/object/index.md
+++ b/files/es/glossary/object/index.md
@@ -1,7 +1,6 @@
 ---
 title: Object
 slug: Glossary/Object
-translation_of: Glossary/Object
 original_slug: Glossary/Objecto
 ---
 

--- a/files/es/glossary/oop/index.md
+++ b/files/es/glossary/oop/index.md
@@ -1,12 +1,6 @@
 ---
 title: Programación orientada a objetos
 slug: Glossary/OOP
-tags:
-  - OPP
-  - Objeto
-  - Programación orientada a objetos
-  - programacion
-translation_of: Glossary/OOP
 ---
 
 **OOP** (Programación orientada a objetos) es un paradigma de programación en el que los datos son encapsulados en **{{glossary("object","objetos")}},** los cuales tienen su propio comportamiento.

--- a/files/es/glossary/operand/index.md
+++ b/files/es/glossary/operand/index.md
@@ -1,10 +1,6 @@
 ---
 title: Operando
 slug: Glossary/Operand
-tags:
-  - Codificación
-  - Glosario
-translation_of: Glossary/Operand
 original_slug: Glossary/Operando
 ---
 

--- a/files/es/glossary/operator/index.md
+++ b/files/es/glossary/operator/index.md
@@ -1,10 +1,6 @@
 ---
 title: Operador
 slug: Glossary/Operator
-tags:
-  - Glosario
-  - Scripting
-translation_of: Glossary/Operator
 original_slug: Glossary/Operador
 ---
 

--- a/files/es/glossary/parse/index.md
+++ b/files/es/glossary/parse/index.md
@@ -1,7 +1,6 @@
 ---
 title: Parse (análisis sintáctico)
 slug: Glossary/Parse
-translation_of: Glossary/Parse
 ---
 
 "Parsing" significa analizar y convertir un programa en un formato interno que un entorno de ejecución pueda realmente ejecutar, por ejemplo el motor {{glossary("JavaScript")}} dentro de los navegadores.

--- a/files/es/glossary/php/index.md
+++ b/files/es/glossary/php/index.md
@@ -1,10 +1,6 @@
 ---
 title: PHP
 slug: Glossary/PHP
-tags:
-  - Glosario
-  - Infraestructura
-translation_of: Glossary/PHP
 ---
 
 PHP (una inicialización recursiva para PHP: preprocesador de hipertexto) es un lenguaje de script de código abierto del lado del servidor que puede integrarse en HTML para crear aplicaciones web y sitios web dinámicos.

--- a/files/es/glossary/plaintext/index.md
+++ b/files/es/glossary/plaintext/index.md
@@ -1,11 +1,6 @@
 ---
 title: Texto Simple
 slug: Glossary/Plaintext
-tags:
-  - Cryptography
-  - Glossary
-  - Security
-translation_of: Glossary/Plaintext
 original_slug: Glossary/TextoSimple
 ---
 

--- a/files/es/glossary/polyfill/index.md
+++ b/files/es/glossary/polyfill/index.md
@@ -1,9 +1,6 @@
 ---
 title: Polyfill
 slug: Glossary/Polyfill
-tags:
-  - Glosario
-translation_of: Glossary/Polyfill
 ---
 
 Un polyfill es un fragmento de código (generalmente JavaScript en la Web) que se utiliza para proporcionar una funcionalidad moderna en navegadores antiguos que no lo admiten de forma nativa.

--- a/files/es/glossary/pop/index.md
+++ b/files/es/glossary/pop/index.md
@@ -1,13 +1,6 @@
 ---
 title: POP3
 slug: Glossary/POP
-tags:
-  - Correo
-  - Glosario
-  - Infraestructura
-  - Principiante
-  - Protocolo
-translation_of: Glossary/POP
 ---
 
 **POP3** (Protocolo de Oficina de Correo por sus siglas en inglés) es un [protocolo](/es/docs/Glossary/Protocol) muy común para obtener correos desde un servidor de correos por medio de una conexión [TCP](/es/docs/Glossary/TCP). POP3 no soporta directorios, a diferencia del más reciente [IMAP4](/es/docs/Glossary/IMAP), el cual es más difícil de implementar dada su extructura más compleja.

--- a/files/es/glossary/port/index.md
+++ b/files/es/glossary/port/index.md
@@ -1,13 +1,6 @@
 ---
 title: Puerto
 slug: Glossary/Port
-tags:
-  - Glosario
-  - Intro
-  - Puerto
-  - Seguridad
-  - red de computadoras
-translation_of: Glossary/Port
 ---
 
 Para un ordenador conectado a una red con una [dirección IP](/es/docs/Glossary/IP_address), un **puerto** es el destino de la comunicación. Los puertos están designados por números, por debajo de 1024 cada puerto está asociado por defecto con un [protocolo](/es/docs/Glossary/Protocol) específico.

--- a/files/es/glossary/preflight_request/index.md
+++ b/files/es/glossary/preflight_request/index.md
@@ -1,7 +1,6 @@
 ---
 title: Preflight petición
 slug: Glossary/Preflight_request
-translation_of: Glossary/Preflight_request
 original_slug: Glossary/Preflight_peticion
 ---
 

--- a/files/es/glossary/primitive/index.md
+++ b/files/es/glossary/primitive/index.md
@@ -1,11 +1,6 @@
 ---
 title: Primitivo
 slug: Glossary/Primitive
-tags:
-  - CodingScripting
-  - Glosario
-  - JavaScript
-translation_of: Glossary/Primitive
 original_slug: Glossary/Primitivo
 ---
 

--- a/files/es/glossary/progressive_enhancement/index.md
+++ b/files/es/glossary/progressive_enhancement/index.md
@@ -1,11 +1,6 @@
 ---
 title: Mejora Progresiva
 slug: Glossary/Progressive_Enhancement
-tags:
-  - Accesibilidad
-  - Diseño
-  - Glosario
-translation_of: Glossary/Progressive_Enhancement
 ---
 
 **Mejora progresiva** es una filosofía de diseño que se centra en proporcionar una base de contenido y funcionalidad esenciales para la mayor cantidad de usuarios posible. Al mismo tiempo va más allá y trata de ofrecer la mejor experiencia posible sólo a los usuarios de los navegadores más modernos los cuales pueden ejecutar todo código requerido.

--- a/files/es/glossary/promise/index.md
+++ b/files/es/glossary/promise/index.md
@@ -1,12 +1,6 @@
 ---
 title: Promesa
 slug: Glossary/Promise
-tags:
-  - Asíncrono
-  - Glosario
-  - Promesa
-  - Promesas
-translation_of: Glossary/Promise
 ---
 
 Una **{{jsxref("Promesa")}}** es un {{Glossary("objeto")}} devuelto por una {{Glossary("función")}} que no ha completado su tarea. La promesa representa literalmente una promesa creada por una función a la que le llegará un resultado en un futuro.

--- a/files/es/glossary/property/index.md
+++ b/files/es/glossary/property/index.md
@@ -1,10 +1,6 @@
 ---
 title: Propiedad
 slug: Glossary/property
-tags:
-  - Desambiguación
-  - Glosario
-translation_of: Glossary/property
 original_slug: Glossary/propiedad
 ---
 

--- a/files/es/glossary/protocol/index.md
+++ b/files/es/glossary/protocol/index.md
@@ -1,11 +1,6 @@
 ---
 title: Protocolo
 slug: Glossary/Protocol
-tags:
-  - Glosario
-  - Infraestructura
-  - Protocolos
-translation_of: Glossary/Protocol
 ---
 Un **protocolo** es un conjunto de reglas que definen cómo se intercambian los datos dentro o entre ordenadores. La comunicación entre dispositivos requiere que estos estén de acuerdo con el formato de los datos que están siendo intercambiados. Al conjunto de reglas que definen este formato se le llama protocolo.
 

--- a/files/es/glossary/prototype-based_programming/index.md
+++ b/files/es/glossary/prototype-based_programming/index.md
@@ -1,7 +1,6 @@
 ---
 title: Prototype-based programming
 slug: Glossary/Prototype-based_programming
-translation_of: Glossary/Prototype-based_programming
 ---
 
 **La programación basada en prototipos** es un estilo de {{Glossary("OOP", "programación orientada a objetos")}} en el que las {{Glossary('Clase', 'clases')}} no se definen explícitamente, sino que se derivan de agregar propiedades y métodos a una instancia de otra clase o, con menos frecuencia, agregarlos a un objeto vacío.

--- a/files/es/glossary/prototype/index.md
+++ b/files/es/glossary/prototype/index.md
@@ -1,7 +1,6 @@
 ---
 title: Prototipo
 slug: Glossary/Prototype
-translation_of: Glossary/Prototype
 ---
 
 Un prototipo es un modelo que muestra pronto en el ciclo de desarrollo la apariencia y el comportamiento de una aplicación o producto.

--- a/files/es/glossary/pseudo-class/index.md
+++ b/files/es/glossary/pseudo-class/index.md
@@ -1,13 +1,6 @@
 ---
 title: Pseudo-clase
 slug: Glossary/Pseudo-class
-tags:
-  - CSS
-  - Glosario
-  - Pseudo-clase
-  - Selector
-  - Selectores
-translation_of: Glossary/Pseudo-class
 original_slug: Glossary/Pseudo-clase
 ---
 

--- a/files/es/glossary/pseudocode/index.md
+++ b/files/es/glossary/pseudocode/index.md
@@ -1,11 +1,6 @@
 ---
 title: Pseudocódigo
 slug: Glossary/Pseudocode
-tags:
-  - CodingScripting
-  - Glosario
-  - Pseudocódigo
-translation_of: Glossary/Pseudocode
 original_slug: Glossary/Pseudocódigo
 ---
 El pseudocódigo se refiere a la sintaxis del código que generalmente se usa para indicar a los humanos cómo funciona dicho código, o para ilustrar el diseño de un elemento. No funcionará si intentas ejecutarlo como código.

--- a/files/es/glossary/public-key_cryptography/index.md
+++ b/files/es/glossary/public-key_cryptography/index.md
@@ -1,7 +1,6 @@
 ---
 title: Criptografía de clave pública
 slug: Glossary/Public-key_cryptography
-translation_of: Glossary/Public-key_cryptography
 ---
 
 La criptografía de clave pública es un sistema criptográfico en el que las claves vienen en pares. La transformación realizada por una de las claves solo se puede deshacer con la otra clave. Una clave (la clave privada) se mantiene secreta mientras que la otra se hace pública.

--- a/files/es/glossary/python/index.md
+++ b/files/es/glossary/python/index.md
@@ -1,14 +1,6 @@
 ---
 title: Python
 slug: Glossary/Python
-tags:
-  - Glosario
-  - Lenguaje
-  - Principiante
-  - Python
-  - introducción
-  - programacion
-translation_of: Glossary/Python
 ---
 
 **Python** es un leguaje de programación de alto nivel y de propósito general. Utiliza un enfoque multiparadigma, lo que significa que soporta programación orientada a objetos, procedural y en menor medida, programación funcional.

--- a/files/es/glossary/recursion/index.md
+++ b/files/es/glossary/recursion/index.md
@@ -1,10 +1,6 @@
 ---
 title: Recursión
 slug: Glossary/Recursion
-tags:
-  - CodingScripting
-  - Glosario
-translation_of: Glossary/Recursion
 original_slug: Glossary/Recursión
 ---
 

--- a/files/es/glossary/reflow/index.md
+++ b/files/es/glossary/reflow/index.md
@@ -1,7 +1,6 @@
 ---
 title: Reflow
 slug: Glossary/Reflow
-translation_of: Glossary/Reflow
 ---
 
 **Un Reflow** sucede cuando un {{glossary("navegador")}} debe procesar y pintar parte de, o toda una pagina web nuevamente, Como despues de actualizar un sitio web interactivo

--- a/files/es/glossary/regular_expression/index.md
+++ b/files/es/glossary/regular_expression/index.md
@@ -1,12 +1,6 @@
 ---
 title: Expresiones regulares
 slug: Glossary/Regular_expression
-tags:
-  - Expresion Regular
-  - Expresiones Regulares
-  - Glosario
-  - JavaScript
-translation_of: Glossary/Regular_expression
 ---
 
 **Expresiones regulares** (o _regex_) son reglas que definen las secuencias de caracteres obtenidas en una busqueda.

--- a/files/es/glossary/response_header/index.md
+++ b/files/es/glossary/response_header/index.md
@@ -1,7 +1,6 @@
 ---
 title: Cabecera de respuesta
 slug: Glossary/Response_header
-translation_of: Glossary/Response_header
 ---
 
 Una **cabecera de respuesta** (en inglés _response header_) es una {{Glossary("HTTP header")}} que puede ser usada en una respuesta HTTP y que no tiene que ver con el contenido del mensaje. Las cabeceras de respuesta, como {{HTTPHeader("Age")}}, {{HTTPHeader("Location")}} o {{HTTPHeader("Server")}} son usadas para dar un contexto más detallado de la respuesta.

--- a/files/es/glossary/responsive_web_design/index.md
+++ b/files/es/glossary/responsive_web_design/index.md
@@ -1,7 +1,6 @@
 ---
 title: Diseño web responsivo
 slug: Glossary/Responsive_web_design
-translation_of: Glossary/Responsive_web_design
 ---
 
 Diseño web responsivo (del inglés _**R**esponsive **W**eb **D**esign_) o **RWD** es un concepto de desarrollo web que se centra en hacer que los sitios se vean y se comporten de manera óptima en todos los dispositivos informáticos personales, desde el escritorio hasta el móvil.

--- a/files/es/glossary/rest/index.md
+++ b/files/es/glossary/rest/index.md
@@ -1,11 +1,6 @@
 ---
 title: REST
 slug: Glossary/REST
-tags:
-  - Arquitectura
-  - HTTP
-  - Rest
-translation_of: Glossary/REST
 ---
 
 El término "Transferencia de Estado Representacional" (**REST**) representa un conjunto de características de diseño de arquitecturas software que aportan confiabilidad, eficiencia y escalibilidad a los sistemas distribuidos. Un sistema es llamado RESTful cuando se ajusta a estas características.

--- a/files/es/glossary/rgb/index.md
+++ b/files/es/glossary/rgb/index.md
@@ -1,12 +1,6 @@
 ---
 title: RGB
 slug: Glossary/RGB
-tags:
-  - CSS
-  - Diseño
-  - Guía
-  - Principiante
-translation_of: Glossary/RGB
 ---
 
 Red Green Blue (RGB) es un modelo de color que representa los colores como mezclas de tres componentes subyacentes (o canales), rojo, verde y azul. Cada color se describe mediante una secuencia de tres números (normalmente entre 0.0 y 1.0, o entre 0 y 255) que representan las diferentes intensidades (o contribuciones) de rojo, verde y azul para determinar el color final.

--- a/files/es/glossary/rss/index.md
+++ b/files/es/glossary/rss/index.md
@@ -1,14 +1,6 @@
 ---
 title: RSS
 slug: Glossary/RSS
-tags:
-  - Compartit
-  - Glosario
-  - Noticias
-  - RSS
-  - Web
-  - XML
-translation_of: Glossary/RSS
 ---
 
 _RSS_ (Really Simple Syndication en español Sindicación Realmente Simple) hace referencia a los diferentes formatos de [XML](/es/docs/Glossary/XML) diseñados para sitios web de noticias.

--- a/files/es/glossary/ruby/index.md
+++ b/files/es/glossary/ruby/index.md
@@ -1,10 +1,6 @@
 ---
 title: Ruby
 slug: Glossary/Ruby
-tags:
-  - Glosario
-  - Ruby
-translation_of: Glossary/Ruby
 ---
 
 _Ruby_ es un lenguaje de programación de código abierto. En el contexto {{glossary("world wide web","Web")}}, Ruby se suele usar en el lado del servidor con el marco _Ruby On Rails_ (ROR) para producir sitios web y aplicaciones.

--- a/files/es/glossary/safe/index.md
+++ b/files/es/glossary/safe/index.md
@@ -1,7 +1,6 @@
 ---
 title: Seguro
 slug: Glossary/safe
-translation_of: Glossary/safe
 original_slug: Glossary/seguro
 ---
 

--- a/files/es/glossary/scm/index.md
+++ b/files/es/glossary/scm/index.md
@@ -1,11 +1,6 @@
 ---
 title: SCV
 slug: Glossary/SCM
-tags:
-  - CodingScripting
-  - Glosario
-  - SCV
-translation_of: Glossary/SCM
 original_slug: Glossary/SCV
 ---
 

--- a/files/es/glossary/scope/index.md
+++ b/files/es/glossary/scope/index.md
@@ -1,7 +1,6 @@
 ---
 title: Scope
 slug: Glossary/Scope
-translation_of: Glossary/Scope
 ---
 
 El contexto actual de ejecución. El contexto en el que los valores y las expresiones son "visibles" o pueden ser referenciados. Si una variable u otra expresión no está "en el Scope- alcance actual", entonces no está disponible para su uso. Los Scope también se pueden superponer en una jerarquía, de modo que los Scope secundarios tengan acceso a los ámbitos primarios, pero no al revés.

--- a/files/es/glossary/seo/index.md
+++ b/files/es/glossary/seo/index.md
@@ -1,12 +1,6 @@
 ---
 title: SEO
 slug: Glossary/SEO
-tags:
-  - SEO
-  - buscadores
-  - busquedas
-  - posicionamiento web
-translation_of: Glossary/SEO
 ---
 
 **SEO** (Search Engine Optimization) también conocido como posicionamiento web, es el proceso de hacer un sitio web más visible en los resultados de búsqueda o mejorar el ranking de búsqueda.

--- a/files/es/glossary/sgml/index.md
+++ b/files/es/glossary/sgml/index.md
@@ -1,13 +1,6 @@
 ---
 title: SGML
 slug: Glossary/SGML
-tags:
-  - CodingScripting
-  - Composing
-  - Glossary
-  - SGML
-  - es
-translation_of: Glossary/SGML
 ---
 
 El _Lenguaje de marcado generalizado estándar_ (**SGML**) es una especificación {{Glossary("ISO")}} para definir lenguajes de marcado declarativos.

--- a/files/es/glossary/simd/index.md
+++ b/files/es/glossary/simd/index.md
@@ -1,11 +1,6 @@
 ---
 title: SIMD
 slug: Glossary/SIMD
-tags:
-  - Arquitectura
-  - Glosario
-  - SIMD
-translation_of: Glossary/SIMD
 ---
 
 SIMD (pronunciado "sim-dee" en inglés) son las siglas de **Single Instruction/Multiple Data**, el cual es un tipo de [clasificación de arquitecturas de computadores](https://es.wikipedia.org/wiki/Taxonomía_de_Flynn). SIMD permite realizar la misma operación en distintos datos lo que permite paralelismo mejorando el rendimiento — por ejemplo, en la compresión de gráficos 3D y videos, simulaciones físicas, criptografía y otros entornos.

--- a/files/es/glossary/sisd/index.md
+++ b/files/es/glossary/sisd/index.md
@@ -1,11 +1,6 @@
 ---
 title: SISD
 slug: Glossary/SISD
-tags:
-  - Arquitectura
-  - Glosario
-  - SISD
-translation_of: Glossary/SISD
 ---
 
 SISD son las siglas de **Single Instruction/Single Data** la cual es una [clasificación de arquitecturas](https://es.wikipedia.org/wiki/Flynn%27s_taxonomy). En las arquitecturas SISD, un único procesador ejecuta una única instrucción sobre un único punto de la memoria.

--- a/files/es/glossary/sld/index.md
+++ b/files/es/glossary/sld/index.md
@@ -1,7 +1,6 @@
 ---
 title: SLD
 slug: Glossary/SLD
-translation_of: Glossary/SLD
 ---
 
 Un dominio de nivel secundario, o SLD (Second Level Domain) es el nombre que se encuentra antes del dominio de nivel primario, o TLD (Top Level Domain).

--- a/files/es/glossary/sloppy_mode/index.md
+++ b/files/es/glossary/sloppy_mode/index.md
@@ -1,13 +1,6 @@
 ---
 title: Modo poco riguroso — Sloppy
 slug: Glossary/Sloppy_mode
-tags:
-  - CodingScripting
-  - Glosario
-  - JavaScript
-  - Scripting
-  - Sloppy
-translation_of: Glossary/Sloppy_mode
 ---
 
 {{Glossary("ECMAScript")}} 5 y versiones posteriores permiten que los scripts opten por un nuevo {{jsxref("Strict_mode", "Modo estricto", "", 1)}}, que modifica la semántica de JavaScript de varias formas para mejorar su capacidad de recuperación y facilitar la comprensión de lo que sucede cuando hay problemas.

--- a/files/es/glossary/slug/index.md
+++ b/files/es/glossary/slug/index.md
@@ -1,12 +1,6 @@
 ---
 title: Slug
 slug: Glossary/Slug
-tags:
-  - Comunidad
-  - Slug
-  - URL
-  - Web
-translation_of: Glossary/Slug
 ---
 
 Un "slug" es un identificador único parte de una dirección web, típicamente al final de una "URL". por ejemplo, en el contexto de MDN (página actual), el "slug" es la parte del url después de "\<locale>/docs/" es decir "Glossary/Slug"

--- a/files/es/glossary/smtp/index.md
+++ b/files/es/glossary/smtp/index.md
@@ -1,13 +1,6 @@
 ---
 title: SMTP
 slug: Glossary/SMTP
-tags:
-  - Colaboración
-  - Compartiendo
-  - Glosario
-  - Infraestructura
-  - Principiante
-translation_of: Glossary/SMTP
 ---
 
 **SMTP** (Protocolo de Transferencia de Correo Simple por sus siglas en inglés) es un [protocolo](/es/docs/Glossary/Protocol) utilizado para enviar un nuevo correo. Como [POP3](/es/docs/Glossary/POP) y [NNTP](/es/docs/Glossary/NNTP), es un protocolo dirigido por [estado de máquina](/es/docs/Glossary/State_machine).

--- a/files/es/glossary/speculative_parsing/index.md
+++ b/files/es/glossary/speculative_parsing/index.md
@@ -1,12 +1,6 @@
 ---
 title: Optimizar sus páginas para análisis especulativo
 slug: Glossary/speculative_parsing
-tags:
-  - Avanzado
-  - Desarrollo web
-  - HTML
-  - HTML5
-translation_of: Glossary/speculative_parsing
 original_slug: Web/HTML/Optimizing_your_pages_for_speculative_parsing
 ---
 

--- a/files/es/glossary/sql/index.md
+++ b/files/es/glossary/sql/index.md
@@ -1,7 +1,6 @@
 ---
 title: SQL
 slug: Glossary/SQL
-translation_of: Glossary/SQL
 l10n:
   sourceCommit: d2a9f2e26a8139d4bb270d7dc3cddd8b848719fe
 ---

--- a/files/es/glossary/statement/index.md
+++ b/files/es/glossary/statement/index.md
@@ -1,10 +1,6 @@
 ---
 title: Sentencias
 slug: Glossary/Statement
-tags:
-  - Glosario
-  - Principiante
-translation_of: Glossary/Statement
 original_slug: Glossary/Sentencias
 ---
 

--- a/files/es/glossary/static_typing/index.md
+++ b/files/es/glossary/static_typing/index.md
@@ -1,11 +1,6 @@
 ---
 title: Tipificación estática
 slug: Glossary/Static_typing
-tags:
-  - CodingScripting
-  - Glossary
-  - Type
-translation_of: Glossary/Static_typing
 original_slug: Glossary/Tipificación_estática
 ---
 

--- a/files/es/glossary/string/index.md
+++ b/files/es/glossary/string/index.md
@@ -1,12 +1,6 @@
 ---
 title: String
 slug: Glossary/String
-tags:
-  - Cadena de caracteres
-  - Glosario
-  - Principiante
-  - String
-translation_of: Glossary/String
 ---
 
 En cualquier lenguaje de programación, un string es una secuencia de {{Glossary("character","caracteres")}} usado para representar el texto.

--- a/files/es/glossary/svg/index.md
+++ b/files/es/glossary/svg/index.md
@@ -1,7 +1,6 @@
 ---
 title: SVG
 slug: Glossary/SVG
-translation_of: Glossary/SVG
 ---
 
 Gráficos vectoriales escalables (del inglés _**S**calable **V**ector **G**raphics_) o **SVG** es un formato de imagen vectorial 2D basado en una sintaxis de {{Glossary("XML")}} .

--- a/files/es/glossary/svn/index.md
+++ b/files/es/glossary/svn/index.md
@@ -1,10 +1,6 @@
 ---
 title: SVN
 slug: Glossary/SVN
-tags:
-  - Colaboración
-  - Glosario
-translation_of: Glossary/SVN
 ---
 
 Apache Subversion (**SVN**) es un sistema ({{Glossary("SCM")}}) de código abierto de control de almacenamiento. Permite a los desarrolladores mantener un historial de modificaciones de texto y código. Aunque SVN también puede manejar archivos binarios, no recomendamos su utilización para tales archivos.

--- a/files/es/glossary/symmetric-key_cryptography/index.md
+++ b/files/es/glossary/symmetric-key_cryptography/index.md
@@ -1,7 +1,6 @@
 ---
 title: Criptografía de clave simétrica
 slug: Glossary/Symmetric-key_cryptography
-translation_of: Glossary/Symmetric-key_cryptography
 ---
 
 La criptografía de clave simétrica es un término utilizado para los algoritmos criptográficos que utilizan la misma clave para el cifrado y el descifrado. La clave se suele llamar "clave simétrica" o "clave secreta".

--- a/files/es/glossary/synchronous/index.md
+++ b/files/es/glossary/synchronous/index.md
@@ -1,12 +1,6 @@
 ---
 title: Sincrónico
 slug: Glossary/Synchronous
-tags:
-  - Glosario
-  - Mecánicas
-  - Web
-  - WebMechanics
-translation_of: Glossary/Synchronous
 original_slug: Glossary/Sincronico
 ---
 

--- a/files/es/glossary/tag/index.md
+++ b/files/es/glossary/tag/index.md
@@ -1,10 +1,6 @@
 ---
 title: Etiqueta
 slug: Glossary/Tag
-tags:
-  - HTML
-  - etiqueta
-translation_of: Glossary/Tag
 ---
 
 En {{Glossary("HTML")}} una etiqueta es usada para crear un {{Glossary("elemento")}}. El **nombre** de un elemento HTML es el **nombre** utilizado entre paréntesis angulares así como la etiqueta `<p>` para el párrafo. Tenga en cuenta que el nombre de la etiqueta de cierre está precedido por un carácter de barra inclinada, `</p>`, y que en los elementos vacíos la etiqueta final no es necesaria ni permitida. Si no se mencionan atributos, se utilizan valores por defecto en cada caso.

--- a/files/es/glossary/tcp/index.md
+++ b/files/es/glossary/tcp/index.md
@@ -1,14 +1,6 @@
 ---
 title: TCP
 slug: Glossary/TCP
-tags:
-  - Datos
-  - Glosario
-  - Infraestructura
-  - Protocolo de Control de Transmisión
-  - TCP
-  - red
-translation_of: Glossary/TCP
 ---
 
 **TCP** (**Protocolo de Control de Transmisión**, por sus siglas en inglés _Transmission Control Protocol_) es {{Glossary("protocol","protocolo")}} de red importante que permite que dos anfitriones (_hosts_) se conecten e intercambien flujos de datos. TCP garantiza la entrega de datos y {{Glossary("Packet","paquetes")}} en el mismo orden en que se enviaron. Vint Cerf y Bob Kahn, científicos de DARPA por aquél entonces, diseñaron TCP en la década de los 70.

--- a/files/es/glossary/three_js/index.md
+++ b/files/es/glossary/three_js/index.md
@@ -1,13 +1,6 @@
 ---
 title: Three js
 slug: Glossary/Three_js
-tags:
-  - JavaScript
-  - Lenguaje de programación
-  - Scripting de Código
-  - buscador
-  - three.js
-translation_of: Glossary/Three_js
 ---
 three.js es un motor {{Glossary("WebGL")}} basado en {{Glossary("JavaScript")}} que puede ejecutar juegos con GPU y otras aplicaciones con gráficos directamente desde el {{Glossary("browser")}}
 

--- a/files/es/glossary/truthy/index.md
+++ b/files/es/glossary/truthy/index.md
@@ -1,11 +1,6 @@
 ---
 title: Truthy
 slug: Glossary/Truthy
-tags:
-  - CodingScripting
-  - Glosario
-  - JavaScript
-translation_of: Glossary/Truthy
 ---
 
 En {{Glossary("JavaScript")}}, un **valor verdadero** es un valor que se considera `true/verdadero` cuando es evaluado en un contexto {{Glossary("Booleano")}}. Todos los valores son verdaderos a menos que se definan como {{Glossary("Falso", "falso")}} (es decir, excepto `false`, `0`, `""`, `null`, `undefined`, y `NaN`).

--- a/files/es/glossary/type/index.md
+++ b/files/es/glossary/type/index.md
@@ -1,11 +1,6 @@
 ---
 title: Type
 slug: Glossary/Type
-tags:
-  - CodingScripting
-  - Glosario
-  - JavaScript
-translation_of: Glossary/Type
 ---
 
 El **tipo** (_type_ o _data type_) es una característica of una {{glossary("value", "valor")}} que afecta al tipo de datos que puede almacenar; por ejemplo, en JavaScript un {{domxref("Boolean")}} solo tiene valores `true`/`false`, mientras que un {{domxref("String")}} contiene cadenas de texto, un {{domxref("Number")}} contiene números de cualquier tipo, y así sucesivamente.

--- a/files/es/glossary/type_coercion/index.md
+++ b/files/es/glossary/type_coercion/index.md
@@ -1,7 +1,6 @@
 ---
 title: Coerción
 slug: Glossary/Type_coercion
-translation_of: Glossary/Type_coercion
 original_slug: Glossary/coercion
 ---
 

--- a/files/es/glossary/ui/index.md
+++ b/files/es/glossary/ui/index.md
@@ -1,11 +1,6 @@
 ---
 title: IU
 slug: Glossary/UI
-tags:
-  - Accesibilidad
-  - Diseño
-  - Glosario
-translation_of: Glossary/UI
 original_slug: Glossary/IU
 ---
 La _Interfaz de Usuario_ (IU) es el medio que facilita la interacción entre el usuario y la máquina. En el campo de la informática, puede ser un teclado, un joystick, una pantalla, o un programa. En el caso del software, puede ser una entrada de línea de comandos, una página web, un formulario, o el front-end de cualquier aplicación.

--- a/files/es/glossary/undefined/index.md
+++ b/files/es/glossary/undefined/index.md
@@ -1,7 +1,6 @@
 ---
 title: undefined
 slug: Glossary/undefined
-translation_of: Glossary/undefined
 ---
 
 Un valor **{{Glossary("primitivo")}}** automáticamente asignado a las **variables** que solo han sido declarados o a los **{{Glossary("Argument","argumentos")}}** formales para los cuales no existe argumentos reales.

--- a/files/es/glossary/unicode/index.md
+++ b/files/es/glossary/unicode/index.md
@@ -1,9 +1,6 @@
 ---
 title: Unicode
 slug: Glossary/Unicode
-tags:
-  - Infraestructura
-translation_of: Glossary/Unicode
 ---
 
 Unicode es un {{Glossary("Character set", "conjunto de caracteres")}} estándar que numera y define {{Glossary("Character", "caracteres")}} de diferentes idiomas, sistemas de escritura y símbolos. Al asignar un número a cada caracter, los programadores pueden crear {{Glossary("Character encoding", "codificaciones de caracteres")}}, para permitir que las computadoras almacenen, procesen y transmitan cualquier combinación de idiomas en el mismo archivo o programa.

--- a/files/es/glossary/uri/index.md
+++ b/files/es/glossary/uri/index.md
@@ -1,10 +1,6 @@
 ---
 title: URI
 slug: Glossary/URI
-tags:
-  - Glosario
-  - Identificador Uniforme de Recursos
-translation_of: Glossary/URI
 ---
 
 Un **URI** _(Identificador Uniforme de Recursos de sus siglas en inglés: Uniform Resource Identifier)_ es una cadena que se refiere a un recurso. Los más comunes son {{Glossary("URL","URLs")}}, que identifican el recurso dando su ubicación en la Web. {{Glossary("URN","URNs")}}, por el contrario, se refiere a un recurso por un nombre, en un espacio de nombres determinados, como el ISBN(International Standard Book Number) de un libro.

--- a/files/es/glossary/url/index.md
+++ b/files/es/glossary/url/index.md
@@ -1,11 +1,6 @@
 ---
 title: URL
 slug: Glossary/URL
-tags:
-  - Glosario
-  - Infraestructura
-  - l10n:priority
-translation_of: Glossary/URL
 ---
 
 La «**_Uniform Resource Locator_**» (**URL** o _Localizadora Uniforme de Recursos_ en Español) es una cadena de texto que especifica dónde se puede encontrar un recurso (como una página web, una imagen o un video) en Internet.

--- a/files/es/glossary/utf-8/index.md
+++ b/files/es/glossary/utf-8/index.md
@@ -1,17 +1,6 @@
 ---
 title: UTF-8
 slug: Glossary/UTF-8
-tags:
-  - ASCII
-  - Caracter
-  - Caractères
-  - Codificación
-  - CodingScripting
-  - Glosario
-  - HTML
-  - JavaScript
-  - Utf-8
-translation_of: Glossary/UTF-8
 ---
 
 UTF-8 (UCS Transformation Format 8) es la {{Glossary("Character encoding", "Codificación de caracteres")}} más común en la red. El número de bytes que representan un carácter pueden ser desde uno hasta cuatro. UTF-8 es retrocompatible con {{Glossary("ASCII")}} y puede representar cualquier carácter Unicode estandar.

--- a/files/es/glossary/ux/index.md
+++ b/files/es/glossary/ux/index.md
@@ -1,13 +1,6 @@
 ---
 title: UX
 slug: Glossary/UX
-tags:
-  - Accessibility
-  - Composing
-  - Design
-  - Glossary
-  - Navigation
-translation_of: Glossary/UX
 ---
 
 **UX** es un acrónimo de User eXperience. Es el estudio de la interacción entre usuarios y un sistema. Su objetivo es hacer que un sistema sea fácil de interactuar desde el punto de vista del usuario.

--- a/files/es/glossary/validator/index.md
+++ b/files/es/glossary/validator/index.md
@@ -1,11 +1,6 @@
 ---
 title: Validador
 slug: Glossary/Validator
-tags:
-  - Glosario
-  - Principiante
-  - Seguridad
-translation_of: Glossary/Validator
 original_slug: Glossary/Validador
 ---
 

--- a/files/es/glossary/value/index.md
+++ b/files/es/glossary/value/index.md
@@ -1,10 +1,6 @@
 ---
 title: Valor
 slug: Glossary/Value
-tags:
-  - CodingScripting
-  - Glosario
-translation_of: Glossary/Value
 original_slug: Glossary/Valor
 ---
 

--- a/files/es/glossary/variable/index.md
+++ b/files/es/glossary/variable/index.md
@@ -1,11 +1,6 @@
 ---
 title: Variable
 slug: Glossary/Variable
-tags:
-  - CodingScripting
-  - Glosario
-  - JavaScript
-translation_of: Glossary/Variable
 ---
 
 {{jsSidebar}}

--- a/files/es/glossary/vendor_prefix/index.md
+++ b/files/es/glossary/vendor_prefix/index.md
@@ -1,10 +1,6 @@
 ---
 title: Vendor Prefix
 slug: Glossary/Vendor_Prefix
-tags:
-  - CodingScripting
-  - Glossary
-translation_of: Glossary/Vendor_Prefix
 ---
 
 Los proveedores de navegadores a veces agregan prefijos a las propiedades de CSS experimentales o no estándar y las API de JavaScript, por lo que los desarrolladores pueden experimentar con nuevas ideas mientras que, en teoría, evitan que se confíe en sus experimentos y luego rompan el código de los desarrolladores web durante el proceso de estandarización. Los desarrolladores deben esperar para incluir la propiedad sin prefijar hasta que se estandarice el comportamiento del navegador.

--- a/files/es/glossary/viewport/index.md
+++ b/files/es/glossary/viewport/index.md
@@ -1,10 +1,6 @@
 ---
 title: Viewport
 slug: Glossary/Viewport
-tags:
-  - Codificación
-  - Glosario
-translation_of: Glossary/Viewport
 ---
 
 Un viewport representa la región poligonal (normalmente rectangular) en gráficas de computación que está siendo visualizada en ese instante. En términos de navegadores web, se refiere a la parte del documento que usted está viendo, la cual es actualmente visible en su ventana (o la pantalla, si el documento está siendo visto en modo pantalla completa). El contenido fuera del viewport no es visible en la pantalla hasta que sea desplazado dentro de él.

--- a/files/es/glossary/void_element/index.md
+++ b/files/es/glossary/void_element/index.md
@@ -1,7 +1,6 @@
 ---
 title: Elemento vacío
 slug: Glossary/Void_element
-translation_of: Glossary/Empty_element
 original_slug: Glossary/Empty_element
 ---
 

--- a/files/es/glossary/wcag/index.md
+++ b/files/es/glossary/wcag/index.md
@@ -1,12 +1,6 @@
 ---
 title: WCAG
 slug: Glossary/WCAG
-tags:
-  - Accesibilidad
-  - Glosario
-  - Pautas Web
-  - WCAG
-translation_of: Glossary/WCAG
 ---
 
 Las _Pautas de Accesibilidad para el Contenido Web_ (**WCAG**, por us siglas en inglés) son una recomendación publicada por el grupo {{Glossary("WAI","Web Accessibility Initiative")}} en el {{Glossary("W3C")}}. Describen un conjunto de pautas para hacer que el contenido sea accesible principalmente para personas con discapacidades, pero también para dispositivos de recursos limitados, como los teléfonos móviles.

--- a/files/es/glossary/webkit/index.md
+++ b/files/es/glossary/webkit/index.md
@@ -1,15 +1,6 @@
 ---
 title: WebKit
 slug: Glossary/WebKit
-tags:
-  - Glosario
-  - HTML
-  - Intro
-  - LGPL
-  - Navegador
-  - Web
-  - WebKit
-translation_of: Glossary/WebKit
 ---
 
 _WebKit_ es un _framework_ (marco o interfaz) que proporciona páginas web "bien formadas" basadas es su lenguaje de marcado. El principal navegador que utiliza este framework es [Safari](/es/docs/Glossary/Apple_Safari), aunque también lo hacen muchos otros navegadores web para dispositivos móviles (debido a que WebKit es muy portable y customizable).

--- a/files/es/glossary/websockets/index.md
+++ b/files/es/glossary/websockets/index.md
@@ -1,15 +1,6 @@
 ---
 title: WebSockets
 slug: Glossary/WebSockets
-tags:
-  - Connection
-  - Glossary
-  - Infrastructure
-  - Networking
-  - Protocols
-  - Web
-  - WebSocket
-translation_of: Glossary/WebSockets
 ---
 
 _WebSocket_ es un {{Glossary("protocolo")}} que permite establecer conexiones {{Glossary("TCP")}} entre el {{Glossary("Server", "servidor")}} y el cliente, permitiendo así el transporte de datos en cualquier momento.

--- a/files/es/glossary/webvtt/index.md
+++ b/files/es/glossary/webvtt/index.md
@@ -1,13 +1,6 @@
 ---
 title: WebVTT
 slug: Glossary/WebVTT
-tags:
-  - Audio
-  - Glosario
-  - Video
-  - Web
-  - WebVTT
-translation_of: Glossary/WebVTT
 ---
 
 WebVTT (Pistas de Texto para Videos Wev) es una especificación del {{Glossary("W3C")}} para un formato de archivo para crear pistas de texto en combinación con el elemento HTML {{HTMLElement("track")}}.

--- a/files/es/glossary/whatwg/index.md
+++ b/files/es/glossary/whatwg/index.md
@@ -1,14 +1,6 @@
 ---
 title: WHATWG
 slug: Glossary/WHATWG
-tags:
-  - Community
-  - Glossary
-  - HTML
-  - HTML5
-  - WHATWG
-  - Web
-translation_of: Glossary/WHATWG
 ---
 
 EL ( Grupo de trabajo de tecnología de aplicaciones de hipertexto web) por sus siglas en inglés WHATWG es una organización que mantinene y desarrolla {{Glossary("HTML")}} y {{Glossary("API", "APIs")}} para las aplicaciones Web. Antiguos empleados de Apple, Mozilla y Opera establecieron el WHATWG en el 2004.

--- a/files/es/glossary/whitespace/index.md
+++ b/files/es/glossary/whitespace/index.md
@@ -1,11 +1,6 @@
 ---
 title: Espacio en blanco
 slug: Glossary/Whitespace
-tags:
-  - Glosario
-  - Gramática léxica
-  - espacioenblanco
-translation_of: Glossary/Whitespace
 original_slug: Glossary/Espacio_en_blanco
 ---
 

--- a/files/es/glossary/world_wide_web/index.md
+++ b/files/es/glossary/world_wide_web/index.md
@@ -1,13 +1,6 @@
 ---
 title: World Wide Web
 slug: Glossary/World_Wide_Web
-tags:
-  - Glosario
-  - Intro
-  - Principiante
-  - WWW
-  - Web
-translation_of: Glossary/World_Wide_Web
 ---
 
 La _World Wide Web_ —comúnmente conocida como **WWW**, **W3**, o **la Web**— es un sistema interconectado de páginas web públicas accesibles a través de {{Glossary("Internet")}} (art. en inglés). La Web no es lo mismo que el Internet: la Web es una de las muchas aplicaciones construidas sobre Internet.

--- a/files/es/glossary/wrapper/index.md
+++ b/files/es/glossary/wrapper/index.md
@@ -1,11 +1,6 @@
 ---
 title: Wrapper
 slug: Glossary/Wrapper
-tags:
-  - Envoltorio
-  - Glosario
-  - Wrapper
-translation_of: Glossary/Wrapper
 ---
 
 En lenguajes de programación como JavaScript, un wrapper o envoltorio es una función que llama a una o varias funciones, unas veces únicamente por convenio y otras para adaptarlas con el objetivo de hacer una tarea ligeramente diferente.

--- a/files/es/glossary/xforms/index.md
+++ b/files/es/glossary/xforms/index.md
@@ -1,7 +1,6 @@
 ---
 title: XForm
 slug: Glossary/XForms
-translation_of: Glossary/XForms
 original_slug: Glossary/XForm
 ---
 

--- a/files/es/glossary/xhtml/index.md
+++ b/files/es/glossary/xhtml/index.md
@@ -1,12 +1,6 @@
 ---
 title: XHTML
 slug: Glossary/XHTML
-tags:
-  - HTML
-  - Todas_las_Categorías
-  - XHTML
-  - XML
-translation_of: Glossary/XHTML
 original_slug: XHTML
 ---
 

--- a/files/es/glossary/xml/index.md
+++ b/files/es/glossary/xml/index.md
@@ -1,18 +1,6 @@
 ---
 title: XML
 slug: Glossary/XML
-tags:
-  - Bases de datos
-  - Datos
-  - Glosario
-  - HTML
-  - Lenguaje
-  - Tags
-  - Web
-  - XML
-  - l10n:priority
-  - lenguaje de marcado
-translation_of: Glossary/XML
 ---
 
 _XML_ (eXtensible Markup Language en español **Lenguaje de Marcado eXtensible**) es un lenguaje de marcado genérico especificado por la W3C. La industria de tecnologías de la información (_IT Industry_) utiliza muchos lenguajes de descripción de datos (_data-description language_) que están basados en XML.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove duplicated frontmatter keys from localized content

### Motivation

Remove innecesarry duplicated data

### Additional details

```
{
  "translation_of": 217,
  "tags": 157
}
```

### Related issues and pull requests

Fix #10134
Relates to #7412
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
