### PR TITLE
Remove duplicated frontmatter keys from mdn folder [es]

### DIFF
--- a/files/es/mdn/at_ten/index.md
+++ b/files/es/mdn/at_ten/index.md
@@ -1,9 +1,6 @@
 ---
 title: MDN en 10
 slug: MDN/At_ten
-tags:
-  - MDN
-translation_of: MDN_at_ten
 original_slug: MDN_en_diez
 ---
 

--- a/files/es/mdn/community/contributing/getting_started/index.md
+++ b/files/es/mdn/community/contributing/getting_started/index.md
@@ -1,7 +1,6 @@
 ---
 title: Primeros pasos en MDN
 slug: MDN/Community/Contributing/Getting_started
-translation_of: MDN/Contribute/Getting_started
 original_slug: MDN/Contribute/Getting_started
 ---
 

--- a/files/es/mdn/community/index.md
+++ b/files/es/mdn/community/index.md
@@ -1,7 +1,6 @@
 ---
 title: Enviar feedback sobre MDN
 slug: MDN/Community
-translation_of: MDN/Contribute/Feedback
 original_slug: MDN/Contribute/Feedback
 ---
 

--- a/files/es/mdn/contribute/howto/index.md
+++ b/files/es/mdn/contribute/howto/index.md
@@ -1,12 +1,6 @@
 ---
 title: Guías prácticas
 slug: MDN/Contribute/Howto
-tags:
-  - Documentation
-  - Landing
-  - MDN
-  - TopicStub
-translation_of: MDN/Contribute/Howto
 ---
 
 {{MDNSidebar}}

--- a/files/es/mdn/contribute/index.md
+++ b/files/es/mdn/contribute/index.md
@@ -1,11 +1,6 @@
 ---
 title: Contribuir a MDN
 slug: MDN/Contribute
-tags:
-  - Guide
-  - Landing
-  - MDN Meta
-translation_of: MDN/Contribute
 ---
 
 {{MDNSidebar}}

--- a/files/es/mdn/contribute/processes/index.md
+++ b/files/es/mdn/contribute/processes/index.md
@@ -1,11 +1,6 @@
 ---
 title: Procesos de documentación
 slug: MDN/Contribute/Processes
-tags:
-  - Landing
-  - MDN Meta
-  - Procesos
-translation_of: MDN/Contribute/Processes
 original_slug: MDN/Contribute/Procesos
 ---
 

--- a/files/es/mdn/index.md
+++ b/files/es/mdn/index.md
@@ -1,11 +1,6 @@
 ---
 title: El proyecto MDN
 slug: MDN
-tags:
-  - Comunidad
-  - Landing
-  - MDN Meta
-translation_of: MDN
 ---
 
 {{MDNSidebar}}

--- a/files/es/mdn/tools/index.md
+++ b/files/es/mdn/tools/index.md
@@ -1,12 +1,6 @@
 ---
 title: Herramientas de MDN y Utilidades
 slug: MDN/Tools
-tags:
-  - Documentacion(2)
-  - Documentación
-  - MDN
-  - Proyecto MDC
-translation_of: MDN/Tools
 ---
 
 {{MDNSidebar}}

--- a/files/es/mdn/tools/kumascript/index.md
+++ b/files/es/mdn/tools/kumascript/index.md
@@ -1,7 +1,6 @@
 ---
 title: Introducción a KumaScript
 slug: MDN/Tools/KumaScript
-translation_of: MDN/Tools/KumaScript
 original_slug: MDN/Tools/Introduction_to_KumaScript
 ---
 

--- a/files/es/mdn/writing_guidelines/experimental_deprecated_obsolete/index.md
+++ b/files/es/mdn/writing_guidelines/experimental_deprecated_obsolete/index.md
@@ -1,13 +1,6 @@
 ---
 title: MDN convenciones y definiciones
 slug: MDN/Writing_guidelines/Experimental_deprecated_obsolete
-tags:
-  - Directrices
-  - Documentación
-  - Guía
-  - MDN
-  - Meta MDN
-translation_of: MDN/Guidelines/Conventions_definitions
 original_slug: MDN/Guidelines/Conventions_definitions
 ---
 

--- a/files/es/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/es/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -1,11 +1,6 @@
 ---
 title: Bloques de contenido
 slug: MDN/Writing_guidelines/Howto/Markdown_in_MDN
-tags:
-  - MDN
-  - Meta
-translation_of: MDN/Guidelines/CSS_style_guide
-translation_of_original: MDN/Structures/Content_blocks
 original_slug: MDN/Contribute/Markdown_in_MDN
 ---
 

--- a/files/es/mdn/writing_guidelines/howto/tag/index.md
+++ b/files/es/mdn/writing_guidelines/howto/tag/index.md
@@ -1,14 +1,6 @@
 ---
 title: Cómo etiquetar correctamente las páginas
 slug: MDN/Writing_guidelines/Howto/Tag
-tags:
-  - Colaborar
-  - Etiquetas
-  - Guia(2)
-  - Guía
-  - MDN
-  - Principiante
-translation_of: MDN/Contribute/Howto/Tag
 original_slug: MDN/Contribute/Howto/Tag
 ---
 

--- a/files/es/mdn/writing_guidelines/howto/write_a_new_entry_in_the_glossary/index.md
+++ b/files/es/mdn/writing_guidelines/howto/write_a_new_entry_in_the_glossary/index.md
@@ -1,12 +1,6 @@
 ---
 title: Cómo escribir una nueva entrada en el Glosario
 slug: MDN/Writing_guidelines/Howto/Write_a_new_entry_in_the_glossary
-tags:
-  - Glosario
-  - Guía
-  - Howto
-  - MDN Meta
-translation_of: MDN/Contribute/Howto/Write_a_new_entry_in_the_Glossary
 original_slug: MDN/Contribute/Howto/Write_a_new_entry_in_the_Glossary
 ---
 

--- a/files/es/mdn/writing_guidelines/index.md
+++ b/files/es/mdn/writing_guidelines/index.md
@@ -1,15 +1,6 @@
 ---
 title: Acerca de MDN
 slug: MDN/Writing_guidelines
-tags:
-  - Colaboración
-  - Comunidad
-  - Derechos de Autor
-  - Documentación
-  - Guía
-  - Licencias
-  - MDN Meta
-translation_of: MDN/About
 original_slug: MDN/About
 ---
 

--- a/files/es/mdn/writing_guidelines/page_structures/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/index.md
@@ -1,15 +1,7 @@
 ---
-title: >-
-  Tablas de compatibilidad y repositorio de datos de compatibilidad del
-  navegador (DCN)
+title: Tablas de compatibilidad y repositorio de datos de compatibilidad del navegador
+  (DCN)
 slug: MDN/Writing_guidelines/Page_structures
-tags:
-  - Estructuras
-  - Guía
-  - Meta MDN
-  - compatibilidad con el navegador
-  - tablas de compatibilidad
-translation_of: MDN/Structures/Compatibility_tables
 original_slug: MDN/Structures/Compatibility_tables
 ---
 

--- a/files/es/mdn/writing_guidelines/page_structures/live_samples/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/live_samples/index.md
@@ -1,11 +1,6 @@
 ---
 title: Cómo convertir códigos de demostración para que estén "en vivo"
 slug: MDN/Writing_guidelines/Page_structures/Live_samples
-tags:
-  - Código
-  - Demostración
-  - Sample
-translation_of: MDN/Contribute/Howto/Convert_code_samples_to_be_live
 original_slug: MDN/Contribute/Howto/Convert_code_samples_to_be_live
 ---
 

--- a/files/es/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
@@ -1,12 +1,6 @@
 ---
 title: Macros usadas comunmente
 slug: MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros
-tags:
-  - CSS
-  - Estructuras
-  - Macros
-  - Referencia
-translation_of: MDN/Structures/Macros/Commonly-used_macros
 original_slug: MDN/Structures/Macros/Commonly-used_macros
 ---
 

--- a/files/es/mdn/writing_guidelines/page_structures/macros/other/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/macros/other/index.md
@@ -1,7 +1,6 @@
 ---
 title: Otras macros
 slug: MDN/Writing_guidelines/Page_structures/Macros/Other
-translation_of: MDN/Structures/Macros/Other
 original_slug: MDN/Structures/Macros/Other
 ---
 

--- a/files/es/mdn/writing_guidelines/writing_style_guide/index.md
+++ b/files/es/mdn/writing_guidelines/writing_style_guide/index.md
@@ -1,10 +1,6 @@
 ---
 title: Guía de estilo
 slug: MDN/Writing_guidelines/Writing_style_guide
-tags:
-  - Proyecto_MDC
-  - Todas_las_Categorías
-translation_of: MDN/Guidelines/Writing_style_guide
 original_slug: MDN/Guidelines/Writing_style_guide
 ---
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove duplicated frontmatter keys from localized content

### Motivation

Remove innecesarry duplicated data

### Additional details

```
{
  "translation_of": 19,
  "tags": 15,
  "translation_of_original": 1
}
```

### Related issues and pull requests

Fix #10138
Relates to #7412
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
