### PR TITLE
Remove duplicated frontmatter keys from mozilla folder [es]

### DIFF
--- a/files/es/mozilla/add-ons/index.md
+++ b/files/es/mozilla/add-ons/index.md
@@ -1,12 +1,6 @@
 ---
 title: Complementos
 slug: Mozilla/Add-ons
-tags:
-  - Complementos
-  - Destino
-  - Mozilla
-  - extensiones
-translation_of: Mozilla/Add-ons
 ---
 
 {{AddonSidebar}}

--- a/files/es/mozilla/add-ons/webextensions/add_a_button_to_the_toolbar/index.md
+++ b/files/es/mozilla/add-ons/webextensions/add_a_button_to_the_toolbar/index.md
@@ -1,7 +1,6 @@
 ---
 title: Agregar botón a la barra de herramientas
 slug: Mozilla/Add-ons/WebExtensions/Add_a_button_to_the_toolbar
-translation_of: Mozilla/Add-ons/WebExtensions/Add_a_button_to_the_toolbar
 ---
 
 {{AddonSidebar}}

--- a/files/es/mozilla/add-ons/webextensions/anatomy_of_a_webextension/index.md
+++ b/files/es/mozilla/add-ons/webextensions/anatomy_of_a_webextension/index.md
@@ -1,9 +1,6 @@
 ---
 title: Anatomía de una extension
 slug: Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension
-tags:
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension
 original_slug: Mozilla/Add-ons/WebExtensions/Anatomia_de_una_WebExtension
 ---
 

--- a/files/es/mozilla/add-ons/webextensions/api/i18n/index.md
+++ b/files/es/mozilla/add-ons/webextensions/api/i18n/index.md
@@ -1,16 +1,6 @@
 ---
 title: i18n
 slug: Mozilla/Add-ons/WebExtensions/API/i18n
-tags:
-  - API
-  - Complementos
-  - Interfaz
-  - No estandar
-  - Reference
-  - WebExtensions
-  - extensiones
-  - i18n
-translation_of: Mozilla/Add-ons/WebExtensions/API/i18n
 ---
 
 {{AddonSidebar}}

--- a/files/es/mozilla/add-ons/webextensions/api/index.md
+++ b/files/es/mozilla/add-ons/webextensions/api/index.md
@@ -1,9 +1,6 @@
 ---
 title: API
 slug: Mozilla/Add-ons/WebExtensions/API
-tags:
-  - Extenciones Web
-translation_of: Mozilla/Add-ons/WebExtensions/API
 ---
 
 Las API de JavaScript para las Extensiones Web se pueden usar dentro de los [scripts en segundo plano](/en-US/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#Background_scripts) de la extensión y en cualquier otro documento contenido en la extensión, incluyendo las ventanas emergentes de [acción de página](/es/docs/Mozilla/Add-ons/WebExtensions/Page_actions) o [acción del navegador](/es/docs/Mozilla/Add-ons/WebExtensions/Browser_action), [barras laterales](/es/docs/Mozilla/Add-ons/WebExtensions/Sidebars), [páginas de opciones](/es/docs/Mozilla/Add-ons/WebExtensions/Options_pages) o [páginas de pestañas nuevas](/en-US/Add-ons/WebExtensions/manifest.json/chrome_url_overrides). A algunas de estas API también se puede acceder mediante los [scripts de contenido](/en-US/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#Content_scripts) de una extensión ( consulte la [lista en la guía de script de contenido](/en-US/Add-ons/WebExtensions/Content_scripts#WebExtension_APIs)).

--- a/files/es/mozilla/add-ons/webextensions/api/storage/index.md
+++ b/files/es/mozilla/add-ons/webextensions/api/storage/index.md
@@ -1,20 +1,6 @@
 ---
 title: storage
 slug: Mozilla/Add-ons/WebExtensions/API/storage
-tags:
-  - API
-  - Add-ons
-  - Complentos
-  - Extensions
-  - Interface
-  - NeedsTranslation
-  - Non-standard
-  - Reference
-  - Storage
-  - TopicStub
-  - WebExtensions
-  - extensiones
-translation_of: Mozilla/Add-ons/WebExtensions/API/storage
 ---
 
 {{AddonSidebar}}

--- a/files/es/mozilla/add-ons/webextensions/api/storage/local/index.md
+++ b/files/es/mozilla/add-ons/webextensions/api/storage/local/index.md
@@ -1,14 +1,6 @@
 ---
 title: storage.local
 slug: Mozilla/Add-ons/WebExtensions/API/storage/local
-tags:
-  - API
-  - Complentos
-  - Storage
-  - WebExtension
-  - extensiones
-  - local
-translation_of: Mozilla/Add-ons/WebExtensions/API/storage/local
 ---
 
 {{AddonSidebar()}}

--- a/files/es/mozilla/add-ons/webextensions/api/storage/sync/index.md
+++ b/files/es/mozilla/add-ons/webextensions/api/storage/sync/index.md
@@ -1,9 +1,6 @@
 ---
 title: storage.sync
 slug: Mozilla/Add-ons/WebExtensions/API/storage/sync
-tags:
-  - Complementos Extensiones
-translation_of: Mozilla/Add-ons/WebExtensions/API/storage/sync
 ---
 
 {{AddonSidebar()}}

--- a/files/es/mozilla/add-ons/webextensions/browser_support_for_javascript_apis/index.md
+++ b/files/es/mozilla/add-ons/webextensions/browser_support_for_javascript_apis/index.md
@@ -1,7 +1,6 @@
 ---
 title: Browser support for JavaScript APIs
 slug: Mozilla/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs
-translation_of: Mozilla/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs
 ---
 
 {{AddonSidebar}}

--- a/files/es/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
+++ b/files/es/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
@@ -1,9 +1,6 @@
 ---
 title: Incompatibilidades con Chrome
 slug: Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities
-tags:
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities
 ---
 
 WebExtensions está diseñado para ser compatible con las extensiones de Chrome y Opera: en la medida de lo posible, las extensiones escritas para esos navegadores deberían ejecutarse en Firefox con cambios mínimos.

--- a/files/es/mozilla/add-ons/webextensions/examples/index.md
+++ b/files/es/mozilla/add-ons/webextensions/examples/index.md
@@ -1,9 +1,6 @@
 ---
 title: Ejemplos de extensiones
 slug: Mozilla/Add-ons/WebExtensions/Examples
-tags:
-  - WebExgtensions
-translation_of: Mozilla/Add-ons/WebExtensions/Examples
 ---
 
 {{AddonSidebar}}

--- a/files/es/mozilla/add-ons/webextensions/implement_a_settings_page/index.md
+++ b/files/es/mozilla/add-ons/webextensions/implement_a_settings_page/index.md
@@ -1,9 +1,6 @@
 ---
 title: Implementar una página de configuración
 slug: Mozilla/Add-ons/WebExtensions/Implement_a_settings_page
-tags:
-  - JavaScript
-translation_of: Mozilla/Add-ons/WebExtensions/Implement_a_settings_page
 ---
 
 {{AddonSidebar}}

--- a/files/es/mozilla/add-ons/webextensions/index.md
+++ b/files/es/mozilla/add-ons/webextensions/index.md
@@ -1,13 +1,6 @@
 ---
 title: Extensiones del navegador
 slug: Mozilla/Add-ons/WebExtensions
-tags:
-  - Complementos
-  - Dónde empezar
-  - Manifiesto
-  - WebExtensions
-  - extensiones
-translation_of: Mozilla/Add-ons/WebExtensions
 ---
 
 {{AddonSidebar}}

--- a/files/es/mozilla/add-ons/webextensions/intercept_http_requests/index.md
+++ b/files/es/mozilla/add-ons/webextensions/intercept_http_requests/index.md
@@ -1,7 +1,6 @@
 ---
 title: Interceptar peticiones HTTP
 slug: Mozilla/Add-ons/WebExtensions/Intercept_HTTP_requests
-translation_of: Mozilla/Add-ons/WebExtensions/Intercept_HTTP_requests
 ---
 
 {{AddonSidebar}}

--- a/files/es/mozilla/add-ons/webextensions/manifest.json/icons/index.md
+++ b/files/es/mozilla/add-ons/webextensions/manifest.json/icons/index.md
@@ -1,7 +1,6 @@
 ---
 title: icons
 slug: Mozilla/Add-ons/WebExtensions/manifest.json/icons
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json/icons
 ---
 
 {{AddonSidebar}}

--- a/files/es/mozilla/add-ons/webextensions/manifest.json/index.md
+++ b/files/es/mozilla/add-ons/webextensions/manifest.json/index.md
@@ -1,7 +1,6 @@
 ---
 title: manifest.json
 slug: Mozilla/Add-ons/WebExtensions/manifest.json
-translation_of: Mozilla/Add-ons/WebExtensions/manifest.json
 ---
 
 {{AddonSidebar}}

--- a/files/es/mozilla/add-ons/webextensions/modify_a_web_page/index.md
+++ b/files/es/mozilla/add-ons/webextensions/modify_a_web_page/index.md
@@ -1,7 +1,6 @@
 ---
 title: Modify a web page
 slug: Mozilla/Add-ons/WebExtensions/Modify_a_web_page
-translation_of: Mozilla/Add-ons/WebExtensions/Modify_a_web_page
 ---
 
 {{AddonSidebar}}Uno de los usos más comunes para las extensiones es modificar páginas web. Por ejemplo, una extension puede querer cambiar el estilo de la página, esconder determinados nodos DOM o incluir otros nuevos.Existen dos maneras de hacer esto con extensiones Web y APIs:

--- a/files/es/mozilla/add-ons/webextensions/prerequisites/index.md
+++ b/files/es/mozilla/add-ons/webextensions/prerequisites/index.md
@@ -1,7 +1,6 @@
 ---
 title: Prerequisitos
 slug: Mozilla/Add-ons/WebExtensions/Prerequisites
-translation_of: Mozilla/Add-ons/WebExtensions/Prerequisites
 original_slug: Mozilla/Add-ons/WebExtensions/Prerequisitos
 ---
 

--- a/files/es/mozilla/add-ons/webextensions/user_interface/browser_action/index.md
+++ b/files/es/mozilla/add-ons/webextensions/user_interface/browser_action/index.md
@@ -1,9 +1,6 @@
 ---
 title: Botón de la Barra de Herramientas
 slug: Mozilla/Add-ons/WebExtensions/user_interface/Browser_action
-tags:
-  - WebExtension
-translation_of: Mozilla/Add-ons/WebExtensions/user_interface/Browser_action
 original_slug: Mozilla/Add-ons/WebExtensions/user_interface/Accion_navegador
 ---
 

--- a/files/es/mozilla/add-ons/webextensions/user_interface/index.md
+++ b/files/es/mozilla/add-ons/webextensions/user_interface/index.md
@@ -1,13 +1,6 @@
 ---
 title: User interface
 slug: Mozilla/Add-ons/WebExtensions/user_interface
-tags:
-  - Landing
-  - NeedsTranslation
-  - TopicStub
-  - User Interface
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/user_interface
 ---
 
 {{AddonSidebar}}

--- a/files/es/mozilla/add-ons/webextensions/user_interface/page_actions/index.md
+++ b/files/es/mozilla/add-ons/webextensions/user_interface/page_actions/index.md
@@ -1,7 +1,6 @@
 ---
 title: Address bar button
 slug: Mozilla/Add-ons/WebExtensions/user_interface/Page_actions
-translation_of: Mozilla/Add-ons/WebExtensions/user_interface/Page_actions
 ---
 
 {{AddonSidebar}}

--- a/files/es/mozilla/add-ons/webextensions/what_are_webextensions/index.md
+++ b/files/es/mozilla/add-ons/webextensions/what_are_webextensions/index.md
@@ -1,10 +1,6 @@
 ---
 title: ¿Qué son las extensiones?
 slug: Mozilla/Add-ons/WebExtensions/What_are_WebExtensions
-tags:
-  - WebExtensions
-  - extensiones
-translation_of: Mozilla/Add-ons/WebExtensions/What_are_WebExtensions
 original_slug: Mozilla/Add-ons/WebExtensions/Que_son_las_WebExtensions
 ---
 

--- a/files/es/mozilla/add-ons/webextensions/what_next_/index.md
+++ b/files/es/mozilla/add-ons/webextensions/what_next_/index.md
@@ -1,7 +1,6 @@
 ---
 title: What next?
 slug: Mozilla/Add-ons/WebExtensions/What_next_
-translation_of: Mozilla/Add-ons/WebExtensions/What_next_
 ---
 
 {{AddonSidebar}}

--- a/files/es/mozilla/add-ons/webextensions/your_first_webextension/index.md
+++ b/files/es/mozilla/add-ons/webextensions/your_first_webextension/index.md
@@ -1,10 +1,6 @@
 ---
 title: Tu primera extensión
 slug: Mozilla/Add-ons/WebExtensions/Your_first_WebExtension
-tags:
-  - Guía
-  - WebExtension
-translation_of: Mozilla/Add-ons/WebExtensions/Your_first_WebExtension
 original_slug: Mozilla/Add-ons/WebExtensions/Tu_primera_WebExtension
 ---
 

--- a/files/es/mozilla/add-ons/webextensions/your_second_webextension/index.md
+++ b/files/es/mozilla/add-ons/webextensions/your_second_webextension/index.md
@@ -1,9 +1,6 @@
 ---
 title: Tu segunda extensión
 slug: Mozilla/Add-ons/WebExtensions/Your_second_WebExtension
-tags:
-  - WebExtensions
-translation_of: Mozilla/Add-ons/WebExtensions/Your_second_WebExtension
 original_slug: Mozilla/Add-ons/WebExtensions/Tutorial
 ---
 

--- a/files/es/mozilla/firefox/experimental_features/index.md
+++ b/files/es/mozilla/firefox/experimental_features/index.md
@@ -1,12 +1,6 @@
 ---
 title: Funciones experimentales de Firefox
 slug: Mozilla/Firefox/Experimental_features
-tags:
-  - Experimental
-  - Firefox
-  - Preferencias
-  - características
-translation_of: Mozilla/Firefox/Experimental_features
 ---
 
 {{FirefoxSidebar}}

--- a/files/es/mozilla/firefox/index.md
+++ b/files/es/mozilla/firefox/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox
 slug: Mozilla/Firefox
-tags:
-  - Firefox
-  - Mozilla
-  - Página de Llegada
-translation_of: Mozilla/Firefox
 ---
 
 {{FirefoxSidebar}}

--- a/files/es/mozilla/firefox/releases/1.5/index.md
+++ b/files/es/mozilla/firefox/releases/1.5/index.md
@@ -1,23 +1,6 @@
 ---
 title: Firefox 1.5 para Desarrolladores
 slug: Mozilla/Firefox/Releases/1.5
-tags:
-  - CSS
-  - Complementos
-  - DOM
-  - Desarrollo_Web
-  - Estándares_Web
-  - HTML
-  - JavaScript
-  - RDF
-  - SVG
-  - Servicios_Web_XML
-  - Todas_las_Categorías
-  - XML
-  - XSLT
-  - XUL
-  - extensiones
-translation_of: Mozilla/Firefox/Releases/1.5
 original_slug: Firefox_1.5_para_Desarrolladores
 ---
 

--- a/files/es/mozilla/firefox/releases/2/adding_feed_readers_to_firefox/index.md
+++ b/files/es/mozilla/firefox/releases/2/adding_feed_readers_to_firefox/index.md
@@ -1,10 +1,6 @@
 ---
 title: Añadir lectores de canales a Firefox
 slug: Mozilla/Firefox/Releases/2/Adding_feed_readers_to_Firefox
-tags:
-  - RSS
-  - Todas_las_Categorías
-translation_of: Mozilla/Firefox/Releases/2/Adding_feed_readers_to_Firefox
 original_slug: Añadir_lectores_de_canales_a_Firefox
 ---
 

--- a/files/es/mozilla/firefox/releases/2/index.md
+++ b/files/es/mozilla/firefox/releases/2/index.md
@@ -1,23 +1,6 @@
 ---
 title: Firefox 2 para desarrolladores
 slug: Mozilla/Firefox/Releases/2
-tags:
-  - CSS
-  - Complementos
-  - DOM
-  - Desarrollo_Web
-  - Estándares_Web
-  - HTML
-  - JavaScript
-  - RDF
-  - SVG
-  - Servicios_Web_XML
-  - Todas_las_Categorías
-  - XML
-  - XSLT
-  - XUL
-  - extensiones
-translation_of: Mozilla/Firefox/Releases/2
 original_slug: Firefox_2_para_desarrolladores
 ---
 

--- a/files/es/mozilla/firefox/releases/2/security_changes/index.md
+++ b/files/es/mozilla/firefox/releases/2/security_changes/index.md
@@ -1,10 +1,6 @@
 ---
 title: Seguridad en Firefox 2
 slug: Mozilla/Firefox/Releases/2/Security_changes
-tags:
-  - Seguridad
-  - Todas_las_Categorías
-translation_of: Mozilla/Firefox/Releases/2/Security_changes
 original_slug: Seguridad_en_Firefox_2
 ---
 

--- a/files/es/mozilla/firefox/releases/3.5/index.md
+++ b/files/es/mozilla/firefox/releases/3.5/index.md
@@ -1,7 +1,6 @@
 ---
 title: Firefox 3.5 para desarrolladores
 slug: Mozilla/Firefox/Releases/3.5
-translation_of: Mozilla/Firefox/Releases/3.5
 original_slug: Firefox_3.5_para_desarrolladores
 ---
 

--- a/files/es/mozilla/firefox/releases/3/dom_improvements/index.md
+++ b/files/es/mozilla/firefox/releases/3/dom_improvements/index.md
@@ -1,11 +1,6 @@
 ---
 title: Mejoras DOM en Firefox 3
 slug: Mozilla/Firefox/Releases/3/DOM_improvements
-tags:
-  - DOM
-  - Firefox 3
-  - Todas_las_Categorías
-translation_of: Mozilla/Firefox/Releases/3/DOM_improvements
 original_slug: Mejoras_DOM_en_Firefox_3
 ---
 

--- a/files/es/mozilla/firefox/releases/3/full_page_zoom/index.md
+++ b/files/es/mozilla/firefox/releases/3/full_page_zoom/index.md
@@ -1,7 +1,6 @@
 ---
 title: Zoom a página completa
 slug: Mozilla/Firefox/Releases/3/Full_page_zoom
-translation_of: Mozilla/Firefox/Releases/3/Full_page_zoom
 original_slug: Zoom_a_página_completa
 ---
 

--- a/files/es/mozilla/firefox/releases/3/index.md
+++ b/files/es/mozilla/firefox/releases/3/index.md
@@ -1,9 +1,6 @@
 ---
 title: Firefox 3 para desarrolladores
 slug: Mozilla/Firefox/Releases/3
-tags:
-  - Firefox 3
-translation_of: Mozilla/Firefox/Releases/3
 original_slug: Firefox_3_para_desarrolladores
 ---
 

--- a/files/es/mozilla/firefox/releases/3/notable_bugs_fixed/index.md
+++ b/files/es/mozilla/firefox/releases/3/notable_bugs_fixed/index.md
@@ -1,9 +1,6 @@
 ---
 title: Bugs importantes solucionados en Firefox 3
 slug: Mozilla/Firefox/Releases/3/Notable_bugs_fixed
-tags:
-  - Firefox 3
-translation_of: Mozilla/Firefox/Releases/3/Notable_bugs_fixed
 original_slug: Bugs_importantes_solucionados_en_Firefox_3
 ---
 

--- a/files/es/mozilla/firefox/releases/3/svg_improvements/index.md
+++ b/files/es/mozilla/firefox/releases/3/svg_improvements/index.md
@@ -1,11 +1,6 @@
 ---
 title: Mejoras SVG en Firefox 3
 slug: Mozilla/Firefox/Releases/3/SVG_improvements
-tags:
-  - Firefox 3
-  - SVG
-  - Todas_las_Categorías
-translation_of: Mozilla/Firefox/Releases/3/SVG_improvements
 original_slug: Mejoras_SVG_en_Firefox_3
 ---
 

--- a/files/es/mozilla/firefox/releases/3/templates/index.md
+++ b/files/es/mozilla/firefox/releases/3/templates/index.md
@@ -1,7 +1,6 @@
 ---
 title: Plantillas en Firefox 3
 slug: Mozilla/Firefox/Releases/3/Templates
-translation_of: Mozilla/Firefox/Releases/3/Templates
 original_slug: Plantillas_en_Firefox_3
 l10n:
   sourceCommit: 2aaa075dd310f0de930bab617bb6fe1033970da3

--- a/files/es/mozilla/firefox/releases/3/updating_extensions/index.md
+++ b/files/es/mozilla/firefox/releases/3/updating_extensions/index.md
@@ -1,9 +1,6 @@
 ---
 title: Actualizar extensiones para Firefox 3
 slug: Mozilla/Firefox/Releases/3/Updating_extensions
-tags:
-  - Firefox 3
-translation_of: Mozilla/Firefox/Releases/3/Updating_extensions
 original_slug: Actualizar_extensiones_para_Firefox_3
 ---
 

--- a/files/es/mozilla/firefox/releases/3/updating_web_applications/index.md
+++ b/files/es/mozilla/firefox/releases/3/updating_web_applications/index.md
@@ -1,9 +1,6 @@
 ---
 title: Actualizar aplicaciones web para Firefox 3
 slug: Mozilla/Firefox/Releases/3/Updating_web_applications
-tags:
-  - Firefox 3
-translation_of: Mozilla/Firefox/Releases/3/Updating_web_applications
 original_slug: Actualizar_aplicaciones_web_para_Firefox_3
 ---
 

--- a/files/es/mozilla/firefox/releases/3/xul_improvements_in_firefox_3/index.md
+++ b/files/es/mozilla/firefox/releases/3/xul_improvements_in_firefox_3/index.md
@@ -1,11 +1,6 @@
 ---
 title: Mejoras XUL en Firefox 3
 slug: Mozilla/Firefox/Releases/3/XUL_improvements_in_Firefox_3
-tags:
-  - Firefox 3
-  - Todas_las_Categorías
-  - XUL
-translation_of: Mozilla/Firefox/Releases/3/XUL_improvements_in_Firefox_3
 original_slug: Mejoras_XUL_en_Firefox_3
 ---
 

--- a/files/es/mozilla/firefox/releases/30/index.md
+++ b/files/es/mozilla/firefox/releases/30/index.md
@@ -1,7 +1,6 @@
 ---
 title: Firefox 30 for developers
 slug: Mozilla/Firefox/Releases/30
-translation_of: Mozilla/Firefox/Releases/30
 ---
 
 {{FirefoxSidebar}}

--- a/files/es/mozilla/firefox/releases/50/index.md
+++ b/files/es/mozilla/firefox/releases/50/index.md
@@ -1,10 +1,6 @@
 ---
 title: Firefox 50 para desarrolladores
 slug: Mozilla/Firefox/Releases/50
-tags:
-  - Firefox
-  - Release Notes
-translation_of: Mozilla/Firefox/Releases/50
 ---
 
 {{FirefoxSidebar}}

--- a/files/es/mozilla/firefox/releases/57/index.md
+++ b/files/es/mozilla/firefox/releases/57/index.md
@@ -1,11 +1,6 @@
 ---
 title: Firefox Quantum 57 para programadores
 slug: Mozilla/Firefox/Releases/57
-tags:
-  - "57"
-  - Firefox
-  - Notas de publicación
-translation_of: Mozilla/Firefox/Releases/57
 ---
 
 {{FirefoxSidebar}}

--- a/files/es/mozilla/firefox/releases/61/index.md
+++ b/files/es/mozilla/firefox/releases/61/index.md
@@ -1,7 +1,6 @@
 ---
 title: Firefox 61 for developers
 slug: Mozilla/Firefox/Releases/61
-translation_of: Mozilla/Firefox/Releases/61
 ---
 
 {{FirefoxSidebar}}

--- a/files/es/mozilla/firefox/releases/66/index.md
+++ b/files/es/mozilla/firefox/releases/66/index.md
@@ -1,12 +1,6 @@
 ---
 title: Firefox 66 para desarrolladores
 slug: Mozilla/Firefox/Releases/66
-tags:
-  - "66"
-  - Firefox
-  - Lanzamiento
-  - Mozilla
-translation_of: Mozilla/Firefox/Releases/66
 ---
 
 {{FirefoxSidebar}}

--- a/files/es/mozilla/firefox/releases/9/index.md
+++ b/files/es/mozilla/firefox/releases/9/index.md
@@ -1,13 +1,6 @@
 ---
 title: Firefox 9 for developers
 slug: Mozilla/Firefox/Releases/9
-tags:
-  - Firefox
-  - Firefox 9
-  - Gecko 9
-  - NeedsTranslation
-  - TopicStub
-translation_of: Mozilla/Firefox/Releases/9
 ---
 
 Firefox 9 was released for Windows on December 20, 2011. Mac and Linux version 9.0.1, which fixed a crashing bug discovered at the last minute, were released on December 21, 2011.

--- a/files/es/mozilla/firefox/releases/9/updating_add-ons/index.md
+++ b/files/es/mozilla/firefox/releases/9/updating_add-ons/index.md
@@ -1,7 +1,6 @@
 ---
 title: Actualizar add-ons para Firefox 9
 slug: Mozilla/Firefox/Releases/9/Updating_add-ons
-translation_of: Mozilla/Firefox/Releases/9/Updating_add-ons
 ---
 
 {{FirefoxSidebar}}

--- a/files/es/mozilla/firefox/releases/index.md
+++ b/files/es/mozilla/firefox/releases/index.md
@@ -1,10 +1,6 @@
 ---
 title: Notas de desarrollo de Firefox
 slug: Mozilla/Firefox/Releases
-tags:
-  - Firefox
-  - TopicStub
-translation_of: Mozilla/Firefox/Releases
 ---
 
 {{FirefoxSidebar}}

--- a/files/es/mozilla/index.md
+++ b/files/es/mozilla/index.md
@@ -1,7 +1,6 @@
 ---
 title: Mozilla
 slug: Mozilla
-translation_of: Mozilla
 ---
 
 Esta página fue auto-generada ya que un usuario creó una sub-página a esta página.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove duplicated frontmatter keys from localized content

### Motivation

Remove innecesarry duplicated data

### Additional details

```
{
  "translation_of": 50,
  "tags": 34
}
```

### Related issues and pull requests

Fix #10140
Relates to #7412
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
