### PR TITLE
Remove duplicated frontmatter keys from orphaned folder [es]

### DIFF
--- a/files/es/orphaned/glossary/dynamic_programming_language/index.md
+++ b/files/es/orphaned/glossary/dynamic_programming_language/index.md
@@ -1,7 +1,6 @@
 ---
 title: Lenguaje de programación dinámico
 slug: orphaned/Glossary/Dynamic_programming_language
-translation_of: Glossary/Dynamic_programming_language
 original_slug: Glossary/Dynamic_programming_language
 ---
 

--- a/files/es/orphaned/glossary/jquery/index.md
+++ b/files/es/orphaned/glossary/jquery/index.md
@@ -1,11 +1,6 @@
 ---
 title: jQuery
 slug: orphaned/Glossary/jQuery
-tags:
-  - Glosario
-  - JQuery
-  - JavaScript
-translation_of: Glossary/jQuery
 original_slug: Glossary/jQuery
 ---
 

--- a/files/es/orphaned/mdn/yari/index.md
+++ b/files/es/orphaned/mdn/yari/index.md
@@ -1,7 +1,6 @@
 ---
 title: Kuma
 slug: orphaned/MDN/Yari
-translation_of: MDN/Kuma
 original_slug: MDN/Yari
 ---
 

--- a/files/es/orphaned/web/accessibility/aria/aria_techniques/using_the_aria-label_attribute/index.md
+++ b/files/es/orphaned/web/accessibility/aria/aria_techniques/using_the_aria-label_attribute/index.md
@@ -1,11 +1,6 @@
 ---
 title: Utilizando el atributo  aria-label
 slug: orphaned/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute
-tags:
-  - Accesibilidad
-  - Referencia
-  - agente
-translation_of: Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute
 original_slug: Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute
 ---
 

--- a/files/es/orphaned/web/accessibility/aria/aria_techniques/using_the_aria-required_attribute/index.md
+++ b/files/es/orphaned/web/accessibility/aria/aria_techniques/using_the_aria-required_attribute/index.md
@@ -1,10 +1,6 @@
 ---
 title: Usando el atributo aria-required
-slug: >-
-  orphaned/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_attribute
-tags:
-  - Accesibilidad
-translation_of: Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_attribute
+slug: orphaned/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_attribute
 original_slug: Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_attribute
 ---
 

--- a/files/es/orphaned/web/api/canvas_api/a_basic_ray-caster/index.md
+++ b/files/es/orphaned/web/api/canvas_api/a_basic_ray-caster/index.md
@@ -1,16 +1,6 @@
 ---
 title: A basic ray-caster
 slug: orphaned/Web/API/Canvas_API/A_basic_ray-caster
-tags:
-  - Avanzado
-  - Canvas
-  - Ejemplo
-  - Espanol(2)
-  - Gráficos(2)
-  - HTML
-  - Necesita traducción
-  - Web
-translation_of: Web/API/Canvas_API/A_basic_ray-caster
 original_slug: Web/API/Canvas_API/A_basic_ray-caster
 ---
 

--- a/files/es/orphaned/web/api/document/documenturiobject/index.md
+++ b/files/es/orphaned/web/api/document/documenturiobject/index.md
@@ -1,9 +1,6 @@
 ---
 title: document.documentURIObject
 slug: orphaned/Web/API/Document/documentURIObject
-tags:
-  - Referencia_DOM_de_Gecko
-translation_of: Web/API/Document/documentURIObject
 original_slug: Web/API/Document/documentURIObject
 ---
 

--- a/files/es/orphaned/web/api/globaleventhandlers/index.md
+++ b/files/es/orphaned/web/api/globaleventhandlers/index.md
@@ -1,15 +1,6 @@
 ---
 title: GlobalEventHandlers
 slug: orphaned/Web/API/GlobalEventHandlers
-tags:
-  - API
-  - DOM HTML
-  - GlobalEventHandlers
-  - Mixin
-  - Referencia
-  - combinación
-  - eventos
-translation_of: Web/API/GlobalEventHandlers
 original_slug: Web/API/GlobalEventHandlers
 ---
 

--- a/files/es/orphaned/web/api/htmlorforeignelement/focus/index.md
+++ b/files/es/orphaned/web/api/htmlorforeignelement/focus/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLElement.focus()
 slug: orphaned/Web/API/HTMLOrForeignElement/focus
-tags:
-  - API
-  - HTML DOM
-  - HTMLElement
-  - Referencia
-  - metodo
-translation_of: Web/API/HTMLOrForeignElement/focus
 original_slug: Web/API/HTMLOrForeignElement/focus
 ---
 

--- a/files/es/orphaned/web/api/navigatorconcurrenthardware/hardwareconcurrency/index.md
+++ b/files/es/orphaned/web/api/navigatorconcurrenthardware/hardwareconcurrency/index.md
@@ -1,7 +1,6 @@
 ---
 title: navigator.hardwareConcurrency
 slug: orphaned/Web/API/NavigatorConcurrentHardware/hardwareConcurrency
-translation_of: Web/API/NavigatorConcurrentHardware/hardwareConcurrency
 original_slug: Web/API/NavigatorConcurrentHardware/hardwareConcurrency
 ---
 

--- a/files/es/orphaned/web/api/navigatorconcurrenthardware/index.md
+++ b/files/es/orphaned/web/api/navigatorconcurrenthardware/index.md
@@ -1,23 +1,6 @@
 ---
 title: NavigatorConcurrentHardware
 slug: orphaned/Web/API/NavigatorConcurrentHardware
-tags:
-  - API
-  - Concurrency
-  - HTML DOM
-  - Interface
-  - Navigator
-  - NavigatorCPU
-  - NavigatorConcurrentHardware
-  - NeedsBrowserCompatibility
-  - NeedsTranslation
-  - Reference
-  - Threading
-  - Threads
-  - TopicStub
-  - WorkerNavigator
-  - Workers
-translation_of: Web/API/NavigatorConcurrentHardware
 original_slug: Web/API/NavigatorConcurrentHardware
 ---
 

--- a/files/es/orphaned/web/api/navigatorlanguage/index.md
+++ b/files/es/orphaned/web/api/navigatorlanguage/index.md
@@ -1,16 +1,7 @@
 ---
 title: NavigatorLanguage
 slug: orphaned/Web/API/NavigatorLanguage
-tags:
-  - API
-  - HTML-DOM
-  - NeedsTranslation
-  - No Interface
-  - Reference
-  - TopicStub
-translation_of: Web/API/NavigatorLanguage
 original_slug: Web/API/NavigatorLanguage
-browser-compat: api.NavigatorLanguage
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/es/orphaned/web/api/navigatorlanguage/language/index.md
+++ b/files/es/orphaned/web/api/navigatorlanguage/language/index.md
@@ -1,19 +1,7 @@
 ---
 title: NavigatorLanguage.language
 slug: orphaned/Web/API/NavigatorLanguage/language
-tags:
-  - API
-  - Gecko
-  - Idioma
-  - Lenguaje
-  - NavigatorLanguage
-  - Propiedad
-  - Referencia
-  - Referencia DOM de Gecko
-  - Solo lectura
-translation_of: Web/API/NavigatorLanguage/language
 original_slug: Web/API/NavigatorLanguage/language
-browser-compat: api.NavigatorLanguage.language
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/es/orphaned/web/api/navigatoronline/index.md
+++ b/files/es/orphaned/web/api/navigatoronline/index.md
@@ -1,14 +1,7 @@
 ---
 title: NavigatorOnLine
 slug: orphaned/Web/API/NavigatorOnLine
-tags:
-  - API
-  - HTML-DOM
-  - NeedsTranslation
-  - TopicStub
-translation_of: Web/API/NavigatorOnLine
 original_slug: Web/API/NavigatorOnLine
-browser-compat: api.NavigatorOnLine
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/es/orphaned/web/api/navigatoronline/online/index.md
+++ b/files/es/orphaned/web/api/navigatoronline/online/index.md
@@ -1,9 +1,7 @@
 ---
 title: Navigator.onLine
 slug: orphaned/Web/API/NavigatorOnLine/onLine
-translation_of: Web/API/NavigatorOnLine/onLine
 original_slug: Web/API/NavigatorOnLine/onLine
-browser-compat: api.NavigatorOnLine.onLine
 ---
 
 {{ApiRef("HTML DOM")}}

--- a/files/es/orphaned/web/api/navigatoronline/online_and_offline_events/index.md
+++ b/files/es/orphaned/web/api/navigatoronline/online_and_offline_events/index.md
@@ -1,12 +1,6 @@
 ---
 title: Eventos online y offline
 slug: orphaned/Web/API/NavigatorOnLine/Online_and_offline_events
-tags:
-  - AJAX
-  - DOM
-  - Desarrollo_Web
-  - Todas_las_Categorías
-translation_of: Web/API/NavigatorOnLine/Online_and_offline_events
 original_slug: Web/API/NavigatorOnLine/Online_and_offline_events
 ---
 

--- a/files/es/orphaned/web/api/window/dialogarguments/index.md
+++ b/files/es/orphaned/web/api/window/dialogarguments/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.dialogArguments
 slug: orphaned/Web/API/Window/dialogArguments
-translation_of: Web/API/Window/dialogArguments
 original_slug: Web/API/Window/dialogArguments
 ---
 

--- a/files/es/orphaned/web/api/windoweventhandlers/index.md
+++ b/files/es/orphaned/web/api/windoweventhandlers/index.md
@@ -1,9 +1,6 @@
 ---
 title: WindowEventHandlers
 slug: orphaned/Web/API/WindowEventHandlers
-tags:
-  - API
-translation_of: Web/API/WindowEventHandlers
 original_slug: Web/API/WindowEventHandlers
 ---
 

--- a/files/es/orphaned/web/api/windoworworkerglobalscope/index.md
+++ b/files/es/orphaned/web/api/windoworworkerglobalscope/index.md
@@ -1,18 +1,6 @@
 ---
 title: WindowOrWorkerGlobalScope
 slug: orphaned/Web/API/WindowOrWorkerGlobalScope
-tags:
-  - API
-  - DOM
-  - DOM API
-  - NeedsTranslation
-  - Service Worker
-  - TopicStub
-  - Window
-  - WindowOrWorkerGlobalScope
-  - Worker
-  - WorkerGlobalScope
-translation_of: Web/API/WindowOrWorkerGlobalScope
 original_slug: Web/API/WindowOrWorkerGlobalScope
 ---
 

--- a/files/es/orphaned/web/css/-moz-context-properties/index.md
+++ b/files/es/orphaned/web/css/-moz-context-properties/index.md
@@ -1,7 +1,6 @@
 ---
 title: '-moz-context-properties'
 slug: orphaned/Web/CSS/-moz-context-properties
-translation_of: Web/CSS/-moz-context-properties
 original_slug: Web/CSS/-moz-context-properties
 ---
 

--- a/files/es/orphaned/web/css/css_animations/detecting_css_animation_support/index.md
+++ b/files/es/orphaned/web/css/css_animations/detecting_css_animation_support/index.md
@@ -1,7 +1,6 @@
 ---
 title: Detectar soporte de animación CSS
 slug: orphaned/Web/CSS/CSS_Animations/Detecting_CSS_animation_support
-translation_of: Web/CSS/CSS_Animations/Detecting_CSS_animation_support
 original_slug: Web/CSS/CSS_Animations/Detecting_CSS_animation_support
 ---
 

--- a/files/es/orphaned/web/css/css_properties_reference/index.md
+++ b/files/es/orphaned/web/css/css_properties_reference/index.md
@@ -1,12 +1,6 @@
 ---
 title: CSS Properties Reference
 slug: orphaned/Web/CSS/CSS_Properties_Reference
-tags:
-  - CSS
-  - Estilos
-  - Propiedades
-  - Referencia
-translation_of: Web/CSS/CSS_Properties_Reference
 original_slug: Web/CSS/CSS_Properties_Reference
 ---
 

--- a/files/es/orphaned/web/progressive_web_apps/developer_guide/index.md
+++ b/files/es/orphaned/web/progressive_web_apps/developer_guide/index.md
@@ -1,20 +1,6 @@
 ---
 title: PWA developer guide
 slug: orphaned/Web/Progressive_web_apps/Developer_guide
-tags:
-  - Applications
-  - Apps
-  - Developer Guide
-  - Landing
-  - NeedsTranslation
-  - Offline
-  - PWA
-  - Persistent
-  - Progressive web apps
-  - TopicStub
-  - Web
-  - progressive
-translation_of: Web/Progressive_web_apps/Developer_guide
 original_slug: Web/Progressive_web_apps/Developer_guide
 ---
 

--- a/files/es/orphaned/web/svg/svg_1.1_support_in_firefox/index.md
+++ b/files/es/orphaned/web/svg/svg_1.1_support_in_firefox/index.md
@@ -1,11 +1,6 @@
 ---
 title: SVG en Firefox
 slug: orphaned/Web/SVG/SVG_1.1_Support_in_Firefox
-tags:
-  - NecesitaRevisiónTécnica
-  - SVG
-  - Todas_las_Categorías
-translation_of: Web/SVG/SVG_1.1_Support_in_Firefox
 original_slug: Web/SVG/SVG_1.1_Support_in_Firefox
 ---
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove duplicated frontmatter keys from localized content

### Motivation

Remove innecesarry duplicated data

### Additional details

```
{
  "tags": 17,
  "translation_of": 24,
  "browser-compat": 4
}
```

### Related issues and pull requests

Fix #10142
Relates to #7412
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
