### PR TITLE
Remove duplicated frontmatter keys from webassembly folder [es]

### DIFF
--- a/files/es/webassembly/concepts/index.md
+++ b/files/es/webassembly/concepts/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebAssembly Concepts
 slug: WebAssembly/Concepts
-translation_of: WebAssembly/Concepts
 ---
 
 {{WebAssemblySidebar}}

--- a/files/es/webassembly/index.md
+++ b/files/es/webassembly/index.md
@@ -1,11 +1,6 @@
 ---
 title: WebAssembly
 slug: WebAssembly
-tags:
-  - Aterrizaje
-  - WebAssembly
-  - wasm
-translation_of: WebAssembly
 ---
 
 {{WebAssemblySidebar}}

--- a/files/es/webassembly/javascript_interface/index.md
+++ b/files/es/webassembly/javascript_interface/index.md
@@ -1,14 +1,6 @@
 ---
 title: WebAssembly
 slug: WebAssembly/JavaScript_interface
-tags:
-  - API
-  - Experimental
-  - JavaScript
-  - Objeto
-  - Referencia
-  - WebAssembly
-translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly
 ---
 

--- a/files/es/webassembly/loading_and_running/index.md
+++ b/files/es/webassembly/loading_and_running/index.md
@@ -1,13 +1,6 @@
 ---
 title: Loading and running WebAssembly code
 slug: WebAssembly/Loading_and_running
-tags:
-  - JavaScript
-  - Traer
-  - WebAssembly
-  - XMLHttpRequest
-  - bytecode
-translation_of: WebAssembly/Loading_and_running
 ---
 
 {{WebAssemblySidebar}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove duplicated frontmatter keys from localized content

### Motivation

Remove innecesarry duplicated data

### Additional details

```
{
  "tags": 3,
  "translation_of": 4
}
```

### Related issues and pull requests

Fix #10144
Relates to #7412
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
