### PR TITLE
Remove duplicated frontmatter keys from web folder 1/10 [es]

### DIFF
--- a/files/es/web/demos/index.md
+++ b/files/es/web/demos/index.md
@@ -1,17 +1,6 @@
 ---
 title: Demostraciones de tecnologías de Web Abierta
 slug: Web/Demos
-tags:
-  - 2D
-  - 3D
-  - CSS
-  - Canvas
-  - Design
-  - HTML
-  - SVG
-  - Video
-  - transform
-translation_of: Web/Demos_of_open_web_technologies
 original_slug: Web/Demos_of_open_web_technologies
 ---
 

--- a/files/es/web/html/attributes/accept/index.md
+++ b/files/es/web/html/attributes/accept/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'HTML el atributo: accept'
 slug: Web/HTML/Attributes/accept
-tags:
-  - Accept
-  - Archivo
-  - Entrada
-  - Input
-  - Referencia
-  - atributo
-translation_of: Web/HTML/Attributes/accept
 original_slug: Web/HTML/Atributos/accept
 ---
 

--- a/files/es/web/html/attributes/crossorigin/index.md
+++ b/files/es/web/html/attributes/crossorigin/index.md
@@ -1,7 +1,6 @@
 ---
 title: Atributos de configuración CORS
 slug: Web/HTML/Attributes/crossorigin
-translation_of: Web/HTML/Attributes/crossorigin
 original_slug: Web/HTML/Atributos_de_configuracion_CORS
 ---
 

--- a/files/es/web/html/attributes/index.md
+++ b/files/es/web/html/attributes/index.md
@@ -1,12 +1,6 @@
 ---
 title: Referencia de Atributos HTML
 slug: Web/HTML/Attributes
-tags:
-  - HTML
-  - Referencia
-  - Web
-  - atributo
-translation_of: Web/HTML/Attributes
 original_slug: Web/HTML/Atributos
 ---
 

--- a/files/es/web/html/attributes/min/index.md
+++ b/files/es/web/html/attributes/min/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'HTML el atributo: min'
 slug: Web/HTML/Attributes/min
-tags:
-  - Atributos
-  - Restricción de validación
-  - atributo
-  - min
-translation_of: Web/HTML/Attributes/min
 original_slug: Web/HTML/Atributos/min
 ---
 

--- a/files/es/web/html/attributes/minlength/index.md
+++ b/files/es/web/html/attributes/minlength/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'HTML el atributo: minlength'
 slug: Web/HTML/Attributes/minlength
-tags:
-  - Entrada
-  - Input
-  - Referencia
-  - atributo
-  - minlength
-  - textarea
-translation_of: Web/HTML/Attributes/minlength
 original_slug: Web/HTML/Atributos/minlength
 ---
 

--- a/files/es/web/html/attributes/multiple/index.md
+++ b/files/es/web/html/attributes/multiple/index.md
@@ -1,11 +1,6 @@
 ---
-title: "HTML el atributo: multiple"
+title: 'HTML el atributo: multiple'
 slug: Web/HTML/Attributes/multiple
-tags:
-  - Atributos
-  - Resticción de validación
-  - atributo
-translation_of: Web/HTML/Attributes/multiple
 original_slug: Web/HTML/Atributos/multiple
 ---
 

--- a/files/es/web/html/block-level_elements/index.md
+++ b/files/es/web/html/block-level_elements/index.md
@@ -1,14 +1,6 @@
 ---
 title: Elementos en bloque
 slug: Web/HTML/Block-level_elements
-tags:
-  - Guía
-  - HTML
-  - HTML5
-  - Principiante
-  - Web
-  - desarrollo
-translation_of: Web/HTML/Block-level_elements
 ---
 
 Los elementos, en HTML (lenguaje de marcas de hipertexto - **Hypertext Markup Language**) usualmente son elementos "en bloque" o [elementos "en línea"](/es/docs/Web/HTML/Elementos_en_línea). Un elemento en bloque ocupa todo el espacio de su elemento padre (contenedor), creando así un "bloque". Este artículo ayuda a explicar lo que esto significa.

--- a/files/es/web/html/cors_enabled_image/index.md
+++ b/files/es/web/html/cors_enabled_image/index.md
@@ -1,14 +1,6 @@
 ---
 title: Imagen con CORS habilitado
 slug: Web/HTML/CORS_enabled_image
-tags:
-  - Avanzado
-  - CORS
-  - Canvas
-  - HTML
-  - Referencia
-  - Seguridad
-translation_of: Web/HTML/CORS_enabled_image
 original_slug: Web/HTML/Imagen_con_CORS_habilitado
 ---
 

--- a/files/es/web/html/element/a/index.md
+++ b/files/es/web/html/element/a/index.md
@@ -1,9 +1,7 @@
 ---
 title: '<a>: El elemento ancla'
 slug: Web/HTML/Element/a
-translation_of: Web/HTML/Element/a
 original_slug: Web/HTML/Elemento/a
-browser-compat: html.elements.a
 ---
 
 {{HTMLSidebar}}

--- a/files/es/web/html/element/abbr/index.md
+++ b/files/es/web/html/element/abbr/index.md
@@ -1,11 +1,6 @@
 ---
 title: <abbr>
 slug: Web/HTML/Element/abbr
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/abbr
 original_slug: Web/HTML/Elemento/abbr
 ---
 

--- a/files/es/web/html/element/acronym/index.md
+++ b/files/es/web/html/element/acronym/index.md
@@ -1,11 +1,6 @@
 ---
 title: acronym
 slug: Web/HTML/Element/acronym
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/acronym
 original_slug: Web/HTML/Elemento/acronym
 ---
 ### Definición

--- a/files/es/web/html/element/address/index.md
+++ b/files/es/web/html/element/address/index.md
@@ -1,11 +1,6 @@
 ---
 title: <address>
 slug: Web/HTML/Element/address
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/address
 original_slug: Web/HTML/Elemento/address
 ---
 

--- a/files/es/web/html/element/applet/index.md
+++ b/files/es/web/html/element/applet/index.md
@@ -1,11 +1,6 @@
 ---
 title: applet
 slug: Web/HTML/Element/applet
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/applet
 original_slug: Web/HTML/Elemento/applet
 ---
 

--- a/files/es/web/html/element/area/index.md
+++ b/files/es/web/html/element/area/index.md
@@ -1,11 +1,6 @@
 ---
 title: area
 slug: Web/HTML/Element/area
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/area
 original_slug: Web/HTML/Elemento/area
 ---
 ### Definición

--- a/files/es/web/html/element/article/index.md
+++ b/files/es/web/html/element/article/index.md
@@ -1,8 +1,6 @@
 ---
 title: '<article>: El elemento con contendio del artículo'
 slug: Web/HTML/Element/article
-translation_of: Web/HTML/Element/article
-browser-compat: html.elements.article
 l10n:
   sourceCommit: 8507170b71a6612358bdf2d9ec47b4e9b825bd78
 ---

--- a/files/es/web/html/element/aside/index.md
+++ b/files/es/web/html/element/aside/index.md
@@ -1,13 +1,6 @@
 ---
 title: aside
 slug: Web/HTML/Element/aside
-tags:
-  - HTML
-  - HTML5
-  - HTML:Elemento
-  - HTML:Referencia_de_elementos
-  - para_revisar
-translation_of: Web/HTML/Element/aside
 original_slug: Web/HTML/Elemento/aside
 ---
 

--- a/files/es/web/html/element/audio/index.md
+++ b/files/es/web/html/element/audio/index.md
@@ -1,7 +1,6 @@
 ---
 title: Audio
 slug: Web/HTML/Element/audio
-translation_of: Web/HTML/Element/audio
 original_slug: Web/HTML/Elemento/audio
 ---
 

--- a/files/es/web/html/element/b/index.md
+++ b/files/es/web/html/element/b/index.md
@@ -1,11 +1,6 @@
 ---
 title: b
 slug: Web/HTML/Element/b
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/b
 original_slug: Web/HTML/Elemento/b
 ---
 

--- a/files/es/web/html/element/base/index.md
+++ b/files/es/web/html/element/base/index.md
@@ -1,12 +1,6 @@
 ---
 title: <base>
 slug: Web/HTML/Element/base
-tags:
-  - Elemento
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/base
 original_slug: Web/HTML/Elemento/base
 ---
 

--- a/files/es/web/html/element/bdi/index.md
+++ b/files/es/web/html/element/bdi/index.md
@@ -1,14 +1,6 @@
 ---
 title: <bdi>
 slug: Web/HTML/Element/bdi
-tags:
-  - BiDi
-  - Elemento
-  - HTML
-  - Referencia
-  - Semántica HTML a nivel de texto
-  - Web
-translation_of: Web/HTML/Element/bdi
 original_slug: Web/HTML/Elemento/bdi
 ---
 

--- a/files/es/web/html/element/bdo/index.md
+++ b/files/es/web/html/element/bdo/index.md
@@ -1,11 +1,6 @@
 ---
 title: bdo
 slug: Web/HTML/Element/bdo
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/bdo
 original_slug: Web/HTML/Elemento/bdo
 ---
 ### Definición

--- a/files/es/web/html/element/bgsound/index.md
+++ b/files/es/web/html/element/bgsound/index.md
@@ -1,12 +1,6 @@
 ---
 title: <bgsound>
 slug: Web/HTML/Element/bgsound
-tags:
-  - Elemento
-  - HTML
-  - Referencia
-  - Web
-translation_of: Web/HTML/Element/bgsound
 original_slug: Web/HTML/Elemento/bgsound
 ---
 

--- a/files/es/web/html/element/big/index.md
+++ b/files/es/web/html/element/big/index.md
@@ -1,11 +1,6 @@
 ---
 title: big
 slug: Web/HTML/Element/big
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/big
 original_slug: Web/HTML/Elemento/big
 ---
 

--- a/files/es/web/html/element/blink/index.md
+++ b/files/es/web/html/element/blink/index.md
@@ -1,13 +1,6 @@
 ---
 title: <blink>
 slug: Web/HTML/Element/blink
-tags:
-  - Elemento
-  - HTML
-  - Obsoleto
-  - Referencia
-  - Web
-translation_of: Web/HTML/Element/blink
 original_slug: Web/HTML/Elemento/blink
 ---
 

--- a/files/es/web/html/element/blockquote/index.md
+++ b/files/es/web/html/element/blockquote/index.md
@@ -1,11 +1,6 @@
 ---
 title: blockquote
 slug: Web/HTML/Element/blockquote
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/blockquote
 original_slug: Web/HTML/Elemento/blockquote
 ---
 

--- a/files/es/web/html/element/body/index.md
+++ b/files/es/web/html/element/body/index.md
@@ -1,14 +1,6 @@
 ---
 title: '<body>: El elemento body del documento'
 slug: Web/HTML/Element/body
-tags:
-  - Elemento
-  - HTML
-  - Referencia
-  - Seleccionar el elemento raíz
-  - Web
-  - secciones
-translation_of: Web/HTML/Element/body
 original_slug: Web/HTML/Elemento/body
 ---
 

--- a/files/es/web/html/element/br/index.md
+++ b/files/es/web/html/element/br/index.md
@@ -1,9 +1,7 @@
 ---
 title: '<br>: El elemento de salto de línea'
 slug: Web/HTML/Element/br
-translation_of: Web/HTML/Element/br
 original_slug: Web/HTML/Elemento/br
-browser-compat: html.elements.br
 ---
 
 ## Resumen

--- a/files/es/web/html/element/button/index.md
+++ b/files/es/web/html/element/button/index.md
@@ -1,11 +1,6 @@
 ---
 title: button
 slug: Web/HTML/Element/button
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/button
 original_slug: Web/HTML/Elemento/button
 ---
 

--- a/files/es/web/html/element/canvas/index.md
+++ b/files/es/web/html/element/canvas/index.md
@@ -1,12 +1,6 @@
 ---
 title: canvas
 slug: Web/HTML/Element/canvas
-tags:
-  - Canvas
-  - HTML
-  - HTML:Elemento
-  - para_revisar
-translation_of: Web/HTML/Element/canvas
 original_slug: Web/HTML/Elemento/canvas
 ---
 

--- a/files/es/web/html/element/caption/index.md
+++ b/files/es/web/html/element/caption/index.md
@@ -1,11 +1,6 @@
 ---
 title: caption
 slug: Web/HTML/Element/caption
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/caption
 original_slug: Web/HTML/Elemento/caption
 ---
 

--- a/files/es/web/html/element/center/index.md
+++ b/files/es/web/html/element/center/index.md
@@ -1,11 +1,6 @@
 ---
 title: <center> (obsoleto)
 slug: Web/HTML/Element/center
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/center
 original_slug: Web/HTML/Elemento/center
 ---
 

--- a/files/es/web/html/element/cite/index.md
+++ b/files/es/web/html/element/cite/index.md
@@ -1,11 +1,6 @@
 ---
 title: cite
 slug: Web/HTML/Element/cite
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/cite
 original_slug: Web/HTML/Elemento/cite
 ---
 

--- a/files/es/web/html/element/code/index.md
+++ b/files/es/web/html/element/code/index.md
@@ -1,11 +1,6 @@
 ---
 title: code
 slug: Web/HTML/Element/code
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/code
 original_slug: Web/HTML/Elemento/code
 ---
 

--- a/files/es/web/html/element/col/index.md
+++ b/files/es/web/html/element/col/index.md
@@ -1,11 +1,6 @@
 ---
 title: col
 slug: Web/HTML/Element/col
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/col
 original_slug: Web/HTML/Elemento/col
 ---
 

--- a/files/es/web/html/element/colgroup/index.md
+++ b/files/es/web/html/element/colgroup/index.md
@@ -1,11 +1,6 @@
 ---
 title: colgroup
 slug: Web/HTML/Element/colgroup
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/colgroup
 original_slug: Web/HTML/Elemento/colgroup
 ---
 

--- a/files/es/web/html/element/content/index.md
+++ b/files/es/web/html/element/content/index.md
@@ -1,14 +1,6 @@
 ---
 title: <content>
 slug: Web/HTML/Element/content
-tags:
-  - Deprecado
-  - Elemento
-  - HTML
-  - Referencia
-  - Web
-  - Web Components
-translation_of: Web/HTML/Element/content
 original_slug: Web/HTML/Elemento/content
 ---
 

--- a/files/es/web/html/element/data/index.md
+++ b/files/es/web/html/element/data/index.md
@@ -1,12 +1,6 @@
 ---
 title: <data>
 slug: Web/HTML/Element/data
-tags:
-  - Elemento
-  - HTML
-  - Referencia
-  - Web
-translation_of: Web/HTML/Element/data
 original_slug: Web/HTML/Elemento/data
 ---
 

--- a/files/es/web/html/element/datalist/index.md
+++ b/files/es/web/html/element/datalist/index.md
@@ -1,10 +1,6 @@
 ---
 title: datalist
 slug: Web/HTML/Element/datalist
-tags:
-  - HTML5
-  - datalist
-translation_of: Web/HTML/Element/datalist
 original_slug: Web/HTML/Elemento/datalist
 ---
 

--- a/files/es/web/html/element/dd/index.md
+++ b/files/es/web/html/element/dd/index.md
@@ -1,18 +1,6 @@
 ---
 title: dd
 slug: Web/HTML/Element/dd
-tags:
-  - Contenido agrupado HTML
-  - Definición
-  - Detalles
-  - Detalles de descripción
-  - Elemento
-  - HTML
-  - Lista de descripciones
-  - Referencia
-  - Web
-  - dd
-translation_of: Web/HTML/Element/dd
 original_slug: Web/HTML/Elemento/dd
 ---
 

--- a/files/es/web/html/element/del/index.md
+++ b/files/es/web/html/element/del/index.md
@@ -1,11 +1,6 @@
 ---
 title: del
 slug: Web/HTML/Element/del
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/del
 original_slug: Web/HTML/Elemento/del
 ---
 

--- a/files/es/web/html/element/details/index.md
+++ b/files/es/web/html/element/details/index.md
@@ -1,14 +1,6 @@
 ---
 title: <details>
 slug: Web/HTML/Element/details
-tags:
-  - Elemento
-  - Elementos HTML interactivos
-  - HTML
-  - HTML5
-  - Referencia
-  - Web
-translation_of: Web/HTML/Element/details
 original_slug: Web/HTML/Elemento/details
 ---
 

--- a/files/es/web/html/element/dfn/index.md
+++ b/files/es/web/html/element/dfn/index.md
@@ -1,11 +1,6 @@
 ---
 title: dfn
 slug: Web/HTML/Element/dfn
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/dfn
 original_slug: Web/HTML/Elemento/dfn
 ---
 

--- a/files/es/web/html/element/dialog/index.md
+++ b/files/es/web/html/element/dialog/index.md
@@ -1,7 +1,6 @@
 ---
 title: <dialog>
 slug: Web/HTML/Element/dialog
-translation_of: Web/HTML/Element/dialog
 original_slug: Web/HTML/Elemento/dialog
 ---
 

--- a/files/es/web/html/element/dir/index.md
+++ b/files/es/web/html/element/dir/index.md
@@ -1,11 +1,6 @@
 ---
 title: dir
 slug: Web/HTML/Element/dir
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/dir
 original_slug: Web/HTML/Elemento/dir
 ---
 

--- a/files/es/web/html/element/div/index.md
+++ b/files/es/web/html/element/div/index.md
@@ -1,11 +1,6 @@
 ---
 title: div
 slug: Web/HTML/Element/div
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/div
 original_slug: Web/HTML/Elemento/div
 ---
 

--- a/files/es/web/html/element/dl/index.md
+++ b/files/es/web/html/element/dl/index.md
@@ -1,13 +1,6 @@
 ---
 title: dl
 slug: Web/HTML/Element/dl
-tags:
-  - Agrupando contenido HTML
-  - Elemento
-  - HTML
-  - Referencia
-  - Web
-translation_of: Web/HTML/Element/dl
 original_slug: Web/HTML/Elemento/dl
 ---
 

--- a/files/es/web/html/element/dt/index.md
+++ b/files/es/web/html/element/dt/index.md
@@ -1,18 +1,6 @@
 ---
 title: dt
 slug: Web/HTML/Element/dt
-tags:
-  - Contenido agrupado HTML
-  - Definición
-  - Elemento
-  - HTML
-  - Lista de definiciones
-  - Referencia
-  - Término
-  - Término de definición
-  - dt
-  - listas
-translation_of: Web/HTML/Element/dt
 original_slug: Web/HTML/Elemento/dt
 ---
 

--- a/files/es/web/html/element/em/index.md
+++ b/files/es/web/html/element/em/index.md
@@ -1,11 +1,6 @@
 ---
 title: em
 slug: Web/HTML/Element/em
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/em
 original_slug: Web/HTML/Elemento/em
 ---
 

--- a/files/es/web/html/element/embed/index.md
+++ b/files/es/web/html/element/embed/index.md
@@ -1,12 +1,6 @@
 ---
 title: embed
 slug: Web/HTML/Element/embed
-tags:
-  - HTML
-  - HTML5
-  - HTML:Elemento
-  - para_revisar
-translation_of: Web/HTML/Element/embed
 original_slug: Web/HTML/Elemento/embed
 ---
 

--- a/files/es/web/html/element/fieldset/index.md
+++ b/files/es/web/html/element/fieldset/index.md
@@ -1,11 +1,6 @@
 ---
 title: fieldset
 slug: Web/HTML/Element/fieldset
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/fieldset
 original_slug: Web/HTML/Elemento/fieldset
 ---
 

--- a/files/es/web/html/element/figcaption/index.md
+++ b/files/es/web/html/element/figcaption/index.md
@@ -1,12 +1,6 @@
 ---
 title: <figcaption>
 slug: Web/HTML/Element/figcaption
-tags:
-  - Elemento
-  - Elementos de agrupación de contenido en HTML
-  - HTML
-  - Referencia
-translation_of: Web/HTML/Element/figcaption
 original_slug: Web/HTML/Elemento/figcaption
 ---
 

--- a/files/es/web/html/element/figure/index.md
+++ b/files/es/web/html/element/figure/index.md
@@ -1,13 +1,6 @@
 ---
 title: figure
 slug: Web/HTML/Element/figure
-tags:
-  - HTML
-  - HTML5
-  - HTML:Elemento
-  - figure
-  - para_revisar
-translation_of: Web/HTML/Element/figure
 original_slug: Web/HTML/Elemento/figure
 ---
 

--- a/files/es/web/html/element/font/index.md
+++ b/files/es/web/html/element/font/index.md
@@ -1,11 +1,6 @@
 ---
 title: font
 slug: Web/HTML/Element/font
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/font
 original_slug: Web/HTML/Elemento/font
 ---
 

--- a/files/es/web/html/element/footer/index.md
+++ b/files/es/web/html/element/footer/index.md
@@ -1,11 +1,6 @@
 ---
 title: footer
 slug: Web/HTML/Element/footer
-tags:
-  - HTML5
-  - footer
-  - para_revisar
-translation_of: Web/HTML/Element/footer
 original_slug: Web/HTML/Elemento/footer
 ---
 

--- a/files/es/web/html/element/form/index.md
+++ b/files/es/web/html/element/form/index.md
@@ -1,7 +1,6 @@
 ---
 title: form
 slug: Web/HTML/Element/form
-translation_of: Web/HTML/Element/form
 original_slug: Web/HTML/Elemento/form
 ---
 

--- a/files/es/web/html/element/frame/index.md
+++ b/files/es/web/html/element/frame/index.md
@@ -1,11 +1,6 @@
 ---
 title: frame
 slug: Web/HTML/Element/frame
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/frame
 original_slug: Web/HTML/Elemento/frame
 ---
 

--- a/files/es/web/html/element/frameset/index.md
+++ b/files/es/web/html/element/frameset/index.md
@@ -1,11 +1,6 @@
 ---
 title: frameset
 slug: Web/HTML/Element/frameset
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/frameset
 original_slug: Web/HTML/Elemento/frameset
 ---
 

--- a/files/es/web/html/element/head/index.md
+++ b/files/es/web/html/element/head/index.md
@@ -1,12 +1,6 @@
 ---
 title: head
 slug: Web/HTML/Element/head
-tags:
-  - HTML
-  - HTML:Elemento
-  - Metadatos de documento HTML
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/head
 original_slug: Web/HTML/Elemento/head
 ---
 

--- a/files/es/web/html/element/header/index.md
+++ b/files/es/web/html/element/header/index.md
@@ -1,11 +1,6 @@
 ---
 title: header
 slug: Web/HTML/Element/header
-tags:
-  - HTML5
-  - header
-  - para_revisar
-translation_of: Web/HTML/Element/header
 original_slug: Web/HTML/Elemento/header
 ---
 

--- a/files/es/web/html/element/heading_elements/index.md
+++ b/files/es/web/html/element/heading_elements/index.md
@@ -1,14 +1,6 @@
 ---
 title: Elementos títulos
 slug: Web/HTML/Element/Heading_Elements
-tags:
-  - HTML
-  - HTML:Elemento
-  - Referencia
-  - Secciones HTML
-  - Todas_las_Categorías
-  - Web
-translation_of: Web/HTML/Element/Heading_Elements
 original_slug: Web/HTML/Elemento/Elementos_títulos
 ---
 

--- a/files/es/web/html/element/hgroup/index.md
+++ b/files/es/web/html/element/hgroup/index.md
@@ -1,7 +1,6 @@
 ---
 title: hgroup
 slug: Web/HTML/Element/hgroup
-translation_of: Web/HTML/Element/hgroup
 original_slug: Web/HTML/Elemento/hgroup
 ---
 

--- a/files/es/web/html/element/hr/index.md
+++ b/files/es/web/html/element/hr/index.md
@@ -1,11 +1,6 @@
 ---
 title: <hr>
 slug: Web/HTML/Element/hr
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/hr
 original_slug: Web/HTML/Elemento/hr
 ---
 

--- a/files/es/web/html/element/html/index.md
+++ b/files/es/web/html/element/html/index.md
@@ -1,18 +1,6 @@
 ---
 title: <html>
 slug: Web/HTML/Element/html
-tags:
-  - Element
-  - Elemento
-  - HTML
-  - HTML Root Element
-  - HTML elemento raiz
-  - HTML:Elemento
-  - Reference
-  - Referencia
-  - Todas_las_Categorías
-  - Web
-translation_of: Web/HTML/Element/html
 original_slug: Web/HTML/Elemento/html
 ---
 

--- a/files/es/web/html/element/i/index.md
+++ b/files/es/web/html/element/i/index.md
@@ -1,11 +1,6 @@
 ---
 title: i
 slug: Web/HTML/Element/i
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/i
 original_slug: Web/HTML/Elemento/i
 ---
 

--- a/files/es/web/html/element/iframe/index.md
+++ b/files/es/web/html/element/iframe/index.md
@@ -1,17 +1,6 @@
 ---
 title: '<iframe>: el elemento Inline Frame'
 slug: Web/HTML/Element/iframe
-tags:
-  - Contenido
-  - Contenido incrustado
-  - Elemento
-  - Embebido
-  - HTML
-  - Incrustado
-  - Marcos
-  - Web
-  - iframe
-translation_of: Web/HTML/Element/iframe
 original_slug: Web/HTML/Elemento/iframe
 ---
 

--- a/files/es/web/html/element/image/index.md
+++ b/files/es/web/html/element/image/index.md
@@ -1,9 +1,6 @@
 ---
 title: <image>
 slug: Web/HTML/Element/image
-tags:
-  - HTML
-translation_of: Web/HTML/Element/image
 original_slug: Web/HTML/Elemento/image
 ---
 

--- a/files/es/web/html/element/img/index.md
+++ b/files/es/web/html/element/img/index.md
@@ -1,9 +1,7 @@
 ---
 title: "<img>: El elemento incrustado de imagen"
 slug: Web/HTML/Element/img
-translation_of: Web/HTML/Element/img
 original_slug: Web/HTML/Elemento/img
-browser-compat: html.elements.img
 ---
 
 El elemento de imagen HTML **`<img>`** representa una imagen en el documento.

--- a/files/es/web/html/element/index.md
+++ b/files/es/web/html/element/index.md
@@ -1,13 +1,6 @@
 ---
 title: Referencia de Elementos HTML
 slug: Web/HTML/Element
-tags:
-  - Elemento
-  - HTML
-  - Referencia
-  - Web
-  - básico
-translation_of: Web/HTML/Element
 original_slug: Web/HTML/Elemento
 ---
 

--- a/files/es/web/html/element/input/button/index.md
+++ b/files/es/web/html/element/input/button/index.md
@@ -1,12 +1,6 @@
 ---
 title: <input type ="button">
 slug: Web/HTML/Element/input/button
-tags:
-  - Elemento
-  - Elemento Input
-  - HTML
-  - Referencia
-translation_of: Web/HTML/Element/input/button
 original_slug: Web/HTML/Elemento/input/Botón
 ---
 

--- a/files/es/web/html/element/input/checkbox/index.md
+++ b/files/es/web/html/element/input/checkbox/index.md
@@ -1,7 +1,6 @@
 ---
 title: <input type="checkbox">
 slug: Web/HTML/Element/input/checkbox
-translation_of: Web/HTML/Element/input/checkbox
 original_slug: Web/HTML/Elemento/input/checkbox
 ---
 

--- a/files/es/web/html/element/input/color/index.md
+++ b/files/es/web/html/element/input/color/index.md
@@ -1,16 +1,6 @@
 ---
 title: <input type="color">
 slug: Web/HTML/Element/input/color
-tags:
-  - Elemento
-  - Entrada
-  - Formulários HTML
-  - HTML
-  - Referencia
-  - Selector de colores
-  - color
-  - formulários
-translation_of: Web/HTML/Element/input/color
 original_slug: Web/HTML/Elemento/input/color
 ---
 

--- a/files/es/web/html/element/input/date/index.md
+++ b/files/es/web/html/element/input/date/index.md
@@ -1,8 +1,6 @@
 ---
 title: <input type="date">
 slug: Web/HTML/Element/input/date
-translation_of: Web/HTML/Element/input/date
-browser-compat: html.elements.input.input-date
 ---
 
 {{HTMLSidebar}}

--- a/files/es/web/html/element/input/datetime-local/index.md
+++ b/files/es/web/html/element/input/datetime-local/index.md
@@ -1,11 +1,6 @@
 ---
 title: <input type="datetime">
 slug: Web/HTML/Element/input/datetime-local
-tags:
-  - Elemento
-  - HTML
-  - Referencia
-translation_of: Web/HTML/Element/input/datetime
 original_slug: Web/HTML/Element/input/datetime
 ---
 

--- a/files/es/web/html/element/input/email/index.md
+++ b/files/es/web/html/element/input/email/index.md
@@ -1,8 +1,6 @@
 ---
 title: <input type="email">
 slug: Web/HTML/Element/input/email
-browser-compat: html.elements.input.input-email
-translation_of: Web/HTML/Element/input/email
 original_slug: Web/HTML/Elemento/input/email
 ---
 

--- a/files/es/web/html/element/input/hidden/index.md
+++ b/files/es/web/html/element/input/hidden/index.md
@@ -1,16 +1,6 @@
 ---
 title: <input type="hidden">
 slug: Web/HTML/Element/input/hidden
-tags:
-  - Element
-  - Forms
-  - HTML
-  - HTML Form
-  - Input
-  - Tipos de Input
-  - formulários
-  - hidden
-translation_of: Web/HTML/Element/input/hidden
 original_slug: Web/HTML/Elemento/input/hidden
 ---
 

--- a/files/es/web/html/element/input/index.md
+++ b/files/es/web/html/element/input/index.md
@@ -1,9 +1,7 @@
 ---
 title: input
 slug: Web/HTML/Element/input
-translation_of: Web/HTML/Element/input
 original_slug: Web/HTML/Elemento/input
-browser-compat: html.elements.input
 ---
 
 ## Resumen

--- a/files/es/web/html/element/input/number/index.md
+++ b/files/es/web/html/element/input/number/index.md
@@ -1,8 +1,6 @@
 ---
 title: <input type="number">
 slug: Web/HTML/Element/input/number
-translation_of: Web/HTML/Element/input/number
-browser-compat: html.elements.input.type_number
 ---
 
 {{HTMLSidebar}}

--- a/files/es/web/html/element/input/password/index.md
+++ b/files/es/web/html/element/input/password/index.md
@@ -1,11 +1,6 @@
 ---
 title: <input type="password">
 slug: Web/HTML/Element/input/password
-tags:
-  - Element
-  - HTML
-  - Reference
-translation_of: Web/HTML/Element/input/password
 original_slug: Web/HTML/Elemento/input/password
 ---
 

--- a/files/es/web/html/element/input/range/index.md
+++ b/files/es/web/html/element/input/range/index.md
@@ -1,19 +1,6 @@
 ---
 title: <input type="range">
 slug: Web/HTML/Element/input/range
-tags:
-  - Elementos
-  - Formulários HTML
-  - HTML etiqueta input
-  - Input
-  - Range
-  - Rango
-  - Referencia
-  - Web
-  - deslizador
-  - formulários
-  - slider
-translation_of: Web/HTML/Element/input/range
 original_slug: Web/HTML/Elemento/input/range
 ---
 

--- a/files/es/web/html/element/input/text/index.md
+++ b/files/es/web/html/element/input/text/index.md
@@ -1,19 +1,6 @@
 ---
 title: <input type="text">
 slug: Web/HTML/Element/input/text
-tags:
-  - Entrada de texto
-  - Form input
-  - Formulários HTML
-  - HTML
-  - Input
-  - Input Type
-  - Referencia
-  - Text
-  - Texto
-  - formulários
-  - text input
-translation_of: Web/HTML/Element/input/text
 original_slug: Web/HTML/Elemento/input/text
 ---
 

--- a/files/es/web/html/element/ins/index.md
+++ b/files/es/web/html/element/ins/index.md
@@ -1,11 +1,6 @@
 ---
 title: ins
 slug: Web/HTML/Element/ins
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/ins
 original_slug: Web/HTML/Elemento/ins
 ---
 

--- a/files/es/web/html/element/kbd/index.md
+++ b/files/es/web/html/element/kbd/index.md
@@ -1,11 +1,6 @@
 ---
 title: kbd
 slug: Web/HTML/Element/kbd
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/kbd
 original_slug: Web/HTML/Elemento/kbd
 ---
 

--- a/files/es/web/html/element/keygen/index.md
+++ b/files/es/web/html/element/keygen/index.md
@@ -1,9 +1,6 @@
 ---
 title: keygen
 slug: Web/HTML/Element/keygen
-tags:
-  - para_revisar
-translation_of: Web/HTML/Element/keygen
 original_slug: Web/HTML/Elemento/keygen
 ---
 

--- a/files/es/web/html/element/label/index.md
+++ b/files/es/web/html/element/label/index.md
@@ -1,7 +1,6 @@
 ---
 title: <label>
 slug: Web/HTML/Element/label
-translation_of: Web/HTML/Element/label
 original_slug: Web/HTML/Elemento/label
 ---
 

--- a/files/es/web/html/element/legend/index.md
+++ b/files/es/web/html/element/legend/index.md
@@ -1,11 +1,6 @@
 ---
 title: legend
 slug: Web/HTML/Element/legend
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/legend
 original_slug: Web/HTML/Elemento/legend
 ---
 

--- a/files/es/web/html/element/li/index.md
+++ b/files/es/web/html/element/li/index.md
@@ -1,11 +1,6 @@
 ---
 title: li
 slug: Web/HTML/Element/li
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/li
 original_slug: Web/HTML/Elemento/li
 ---
 

--- a/files/es/web/html/element/link/index.md
+++ b/files/es/web/html/element/link/index.md
@@ -1,15 +1,6 @@
 ---
 title: link
 slug: Web/HTML/Element/link
-tags:
-  - HTML
-  - HTML:Elemento
-  - Metadatos
-  - Metadatos de documento HTML
-  - Referencia
-  - Todas_las_Categorías
-  - Web
-translation_of: Web/HTML/Element/link
 original_slug: Web/HTML/Elemento/link
 ---
 

--- a/files/es/web/html/element/main/index.md
+++ b/files/es/web/html/element/main/index.md
@@ -1,7 +1,6 @@
 ---
 title: <main>
 slug: Web/HTML/Element/main
-translation_of: Web/HTML/Element/main
 original_slug: Web/HTML/Elemento/main
 ---
 

--- a/files/es/web/html/element/map/index.md
+++ b/files/es/web/html/element/map/index.md
@@ -1,11 +1,6 @@
 ---
 title: map
 slug: Web/HTML/Element/map
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/map
 original_slug: Web/HTML/Elemento/map
 ---
 

--- a/files/es/web/html/element/mark/index.md
+++ b/files/es/web/html/element/mark/index.md
@@ -1,13 +1,6 @@
 ---
 title: '<mark>: el elemento de resaltado de texto'
 slug: Web/HTML/Element/mark
-tags:
-  - HTML
-  - HTML5
-  - HTML:Elemento
-  - mark
-  - para_revisar
-translation_of: Web/HTML/Element/mark
 original_slug: Web/HTML/Elemento/mark
 ---
 

--- a/files/es/web/html/element/marquee/index.md
+++ b/files/es/web/html/element/marquee/index.md
@@ -1,16 +1,6 @@
 ---
 title: <marquee>
 slug: Web/HTML/Element/marquee
-tags:
-  - Elemento
-  - HTML
-  - Referencia
-  - Web
-  - etiqueta
-  - marquee
-  - marquesina
-  - obsoleta
-translation_of: Web/HTML/Element/marquee
 original_slug: Web/HTML/Elemento/marquee
 ---
 

--- a/files/es/web/html/element/menu/index.md
+++ b/files/es/web/html/element/menu/index.md
@@ -1,11 +1,6 @@
 ---
 title: menu
 slug: Web/HTML/Element/menu
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/menu
 original_slug: Web/HTML/Elemento/menu
 ---
 

--- a/files/es/web/html/element/meta/index.md
+++ b/files/es/web/html/element/meta/index.md
@@ -1,11 +1,6 @@
 ---
 title: meta
 slug: Web/HTML/Element/meta
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/meta
 original_slug: Web/HTML/Elemento/meta
 ---
 

--- a/files/es/web/html/element/nav/index.md
+++ b/files/es/web/html/element/nav/index.md
@@ -1,15 +1,6 @@
 ---
 title: '<nav>: El elemento de sección de navegación'
 slug: Web/HTML/Element/nav
-tags:
-  - Elemento
-  - HTML5
-  - menu
-  - nav
-  - navegación
-  - programacion
-  - sección
-translation_of: Web/HTML/Element/nav
 original_slug: Web/HTML/Elemento/nav
 ---
 

--- a/files/es/web/html/element/nobr/index.md
+++ b/files/es/web/html/element/nobr/index.md
@@ -1,15 +1,6 @@
 ---
 title: <nobr>
 slug: Web/HTML/Element/nobr
-tags:
-  - Elemento
-  - HTML
-  - No-estándar
-  - Obsoleto
-  - Referencia
-  - Web
-  - nobr
-translation_of: Web/HTML/Element/nobr
 original_slug: Web/HTML/Elemento/nobr
 ---
 

--- a/files/es/web/html/element/noframes/index.md
+++ b/files/es/web/html/element/noframes/index.md
@@ -1,11 +1,6 @@
 ---
 title: noframes
 slug: Web/HTML/Element/noframes
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/noframes
 original_slug: Web/HTML/Elemento/noframes
 ---
 

--- a/files/es/web/html/element/noscript/index.md
+++ b/files/es/web/html/element/noscript/index.md
@@ -1,11 +1,6 @@
 ---
 title: noscript
 slug: Web/HTML/Element/noscript
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/noscript
 original_slug: Web/HTML/Elemento/noscript
 ---
 

--- a/files/es/web/html/element/object/index.md
+++ b/files/es/web/html/element/object/index.md
@@ -1,14 +1,6 @@
 ---
 title: <object>
 slug: Web/HTML/Element/object
-tags:
-  - Contenido incrustado
-  - Elemento
-  - HTML
-  - Referencia
-  - Web
-  - incrustar
-translation_of: Web/HTML/Element/object
 original_slug: Web/HTML/Elemento/object
 ---
 

--- a/files/es/web/html/element/ol/index.md
+++ b/files/es/web/html/element/ol/index.md
@@ -1,11 +1,6 @@
 ---
 title: ol
 slug: Web/HTML/Element/ol
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/ol
 original_slug: Web/HTML/Elemento/ol
 ---
 

--- a/files/es/web/html/element/option/index.md
+++ b/files/es/web/html/element/option/index.md
@@ -1,14 +1,6 @@
 ---
 title: <option>
 slug: Web/HTML/Element/option
-tags:
-  - Elemento
-  - Formulários HTML
-  - Referencia
-  - Web
-  - formulários
-  - htmls
-translation_of: Web/HTML/Element/option
 original_slug: Web/HTML/Elemento/option
 ---
 

--- a/files/es/web/html/element/p/index.md
+++ b/files/es/web/html/element/p/index.md
@@ -1,11 +1,6 @@
 ---
 title: p
 slug: Web/HTML/Element/p
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/p
 original_slug: Web/HTML/Elemento/p
 ---
 

--- a/files/es/web/html/element/param/index.md
+++ b/files/es/web/html/element/param/index.md
@@ -1,11 +1,6 @@
 ---
 title: param
 slug: Web/HTML/Element/param
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/param
 original_slug: Web/HTML/Elemento/param
 ---
 

--- a/files/es/web/html/element/picture/index.md
+++ b/files/es/web/html/element/picture/index.md
@@ -1,12 +1,6 @@
 ---
 title: <picture>
 slug: Web/HTML/Element/picture
-tags:
-  - Elemento
-  - Fotografía
-  - Imagen
-  - graficos
-translation_of: Web/HTML/Element/picture
 original_slug: Web/HTML/Elemento/picture
 ---
 

--- a/files/es/web/html/element/pre/index.md
+++ b/files/es/web/html/element/pre/index.md
@@ -1,7 +1,6 @@
 ---
 title: <pre>
 slug: Web/HTML/Element/pre
-translation_of: Web/HTML/Element/pre
 original_slug: Web/HTML/Elemento/pre
 ---
 

--- a/files/es/web/html/element/progress/index.md
+++ b/files/es/web/html/element/progress/index.md
@@ -1,7 +1,6 @@
 ---
 title: '<progress>: Elemento indicador de progreso'
 slug: Web/HTML/Element/progress
-translation_of: Web/HTML/Element/progress
 original_slug: Web/HTML/Elemento/progress
 ---
 

--- a/files/es/web/html/element/q/index.md
+++ b/files/es/web/html/element/q/index.md
@@ -1,18 +1,6 @@
 ---
 title: '<q>: El elemento de cita en línea'
 slug: Web/HTML/Element/q
-tags:
-  - Cita de bloque independiente
-  - Citación
-  - Elemento
-  - HTML
-  - Marca de cita
-  - Q
-  - Referencia
-  - Semántica HTML a nivel de texto
-  - Web
-  - cita
-translation_of: Web/HTML/Element/q
 original_slug: Web/HTML/Elemento/q
 ---
 

--- a/files/es/web/html/element/s/index.md
+++ b/files/es/web/html/element/s/index.md
@@ -1,11 +1,6 @@
 ---
 title: s
 slug: Web/HTML/Element/s
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/s
 original_slug: Web/HTML/Elemento/s
 ---
 

--- a/files/es/web/html/element/samp/index.md
+++ b/files/es/web/html/element/samp/index.md
@@ -1,12 +1,6 @@
 ---
 title: samp
 slug: Web/HTML/Element/samp
-tags:
-  - Elemento
-  - HTML
-  - Referencia
-  - Web
-translation_of: Web/HTML/Element/samp
 original_slug: Web/HTML/Elemento/samp
 ---
 

--- a/files/es/web/html/element/section/index.md
+++ b/files/es/web/html/element/section/index.md
@@ -1,7 +1,6 @@
 ---
 title: section
 slug: Web/HTML/Element/section
-translation_of: Web/HTML/Element/section
 original_slug: Web/HTML/Elemento/section
 ---
 

--- a/files/es/web/html/element/select/index.md
+++ b/files/es/web/html/element/select/index.md
@@ -1,14 +1,6 @@
 ---
 title: <select>
 slug: Web/HTML/Element/select
-tags:
-  - Elemento
-  - Formulario(2)
-  - HTML
-  - Referencia
-  - Web
-  - formularios html(2)
-translation_of: Web/HTML/Element/select
 original_slug: Web/HTML/Elemento/select
 ---
 

--- a/files/es/web/html/element/slot/index.md
+++ b/files/es/web/html/element/slot/index.md
@@ -1,15 +1,6 @@
 ---
 title: <slot>
 slug: Web/HTML/Element/slot
-tags:
-  - Componentes Web
-  - Componentes Web HTML
-  - Elemento
-  - HTML
-  - Referencia
-  - slot
-  - sombra dom
-translation_of: Web/HTML/Element/slot
 original_slug: Web/HTML/Elemento/slot
 ---
 {{HTMLSidebar}}

--- a/files/es/web/html/element/small/index.md
+++ b/files/es/web/html/element/small/index.md
@@ -1,11 +1,6 @@
 ---
 title: small
 slug: Web/HTML/Element/small
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/small
 original_slug: Web/HTML/Elemento/small
 ---
 

--- a/files/es/web/html/element/source/index.md
+++ b/files/es/web/html/element/source/index.md
@@ -1,13 +1,6 @@
 ---
 title: <source>
 slug: Web/HTML/Element/source
-tags:
-  - Elemento
-  - HTML
-  - Media
-  - Referencia
-  - Web
-translation_of: Web/HTML/Element/source
 original_slug: Web/HTML/Elemento/source
 ---
 

--- a/files/es/web/html/element/span/index.md
+++ b/files/es/web/html/element/span/index.md
@@ -1,11 +1,6 @@
 ---
 title: span
 slug: Web/HTML/Element/span
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/span
 original_slug: Web/HTML/Elemento/span
 ---
 

--- a/files/es/web/html/element/strike/index.md
+++ b/files/es/web/html/element/strike/index.md
@@ -1,11 +1,6 @@
 ---
 title: strike
 slug: Web/HTML/Element/strike
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/strike
 original_slug: Web/HTML/Elemento/strike
 ---
 

--- a/files/es/web/html/element/strong/index.md
+++ b/files/es/web/html/element/strong/index.md
@@ -1,11 +1,6 @@
 ---
 title: strong
 slug: Web/HTML/Element/strong
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/strong
 original_slug: Web/HTML/Elemento/strong
 ---
 

--- a/files/es/web/html/element/style/index.md
+++ b/files/es/web/html/element/style/index.md
@@ -1,11 +1,6 @@
 ---
 title: style
 slug: Web/HTML/Element/style
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/style
 original_slug: Web/HTML/Elemento/style
 ---
 

--- a/files/es/web/html/element/sub/index.md
+++ b/files/es/web/html/element/sub/index.md
@@ -1,11 +1,6 @@
 ---
 title: sub
 slug: Web/HTML/Element/sub
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/sub
 original_slug: Web/HTML/Elemento/sub
 ---
 

--- a/files/es/web/html/element/sup/index.md
+++ b/files/es/web/html/element/sup/index.md
@@ -1,11 +1,6 @@
 ---
 title: sup
 slug: Web/HTML/Element/sup
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/sup
 original_slug: Web/HTML/Elemento/sup
 ---
 

--- a/files/es/web/html/element/table/index.md
+++ b/files/es/web/html/element/table/index.md
@@ -1,7 +1,6 @@
 ---
 title: tabla
 slug: Web/HTML/Element/table
-translation_of: Web/HTML/Element/table
 original_slug: Web/HTML/Elemento/table
 ---
 

--- a/files/es/web/html/element/td/index.md
+++ b/files/es/web/html/element/td/index.md
@@ -1,9 +1,7 @@
 ---
 title: <td>
 slug: Web/HTML/Element/td
-translation_of: Web/HTML/Element/td
 original_slug: Web/HTML/Elemento/td
-browser-compat: html.elements.td
 ---
 
 {{HTMLSidebar}}

--- a/files/es/web/html/element/template/index.md
+++ b/files/es/web/html/element/template/index.md
@@ -1,9 +1,6 @@
 ---
 title: <template>
 slug: Web/HTML/Element/template
-tags:
-  - Plantilla
-translation_of: Web/HTML/Element/template
 original_slug: Web/HTML/Elemento/template
 ---
 

--- a/files/es/web/html/element/textarea/index.md
+++ b/files/es/web/html/element/textarea/index.md
@@ -1,13 +1,6 @@
 ---
 title: <textarea>
 slug: Web/HTML/Element/textarea
-tags:
-  - Elemento
-  - Formularios(2)
-  - HTML
-  - Referencia
-  - Web
-translation_of: Web/HTML/Element/textarea
 original_slug: Web/HTML/Elemento/textarea
 ---
 

--- a/files/es/web/html/element/th/index.md
+++ b/files/es/web/html/element/th/index.md
@@ -1,7 +1,6 @@
 ---
 title: <th>
 slug: Web/HTML/Element/th
-translation_of: Web/HTML/Element/th
 original_slug: Web/HTML/Elemento/th
 ---
 

--- a/files/es/web/html/element/time/index.md
+++ b/files/es/web/html/element/time/index.md
@@ -1,15 +1,6 @@
 ---
 title: time
 slug: Web/HTML/Element/time
-tags:
-  - Elemento
-  - Fecha
-  - HTML
-  - HTML5
-  - Hora
-  - Referencia
-  - Web
-translation_of: Web/HTML/Element/time
 original_slug: Web/HTML/Elemento/time
 ---
 

--- a/files/es/web/html/element/title/index.md
+++ b/files/es/web/html/element/title/index.md
@@ -1,9 +1,7 @@
 ---
 title: '<title>: El elemento Título del documento'
 slug: Web/HTML/Element/title
-translation_of: Web/HTML/Element/title
 original_slug: Web/HTML/Elemento/title
-browser-compat: html.elements.title
 ---
 
 {{HTMLSidebar}}

--- a/files/es/web/html/element/tr/index.md
+++ b/files/es/web/html/element/tr/index.md
@@ -1,9 +1,7 @@
 ---
 title: '<tr>: El elemento Fila de la tabla'
 slug: Web/HTML/Element/tr
-translation_of: Web/HTML/Element/tr
 original_slug: Web/HTML/Elemento/tr
-browser-compat: html.elements.tr
 ---
 
 ## Resumen

--- a/files/es/web/html/element/track/index.md
+++ b/files/es/web/html/element/track/index.md
@@ -1,9 +1,7 @@
 ---
 title: '<track>: El elemento pista de texto incrustado'
 slug: Web/HTML/Element/track
-translation_of: Web/HTML/Element/track
 original_slug: Web/HTML/Element/track
-browser-compat: html.elements.track
 ---
 
 {{HTMLSidebar}}

--- a/files/es/web/html/element/tt/index.md
+++ b/files/es/web/html/element/tt/index.md
@@ -1,11 +1,6 @@
 ---
 title: tt
 slug: Web/HTML/Element/tt
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/tt
 original_slug: Web/HTML/Elemento/tt
 ---
 

--- a/files/es/web/html/element/u/index.md
+++ b/files/es/web/html/element/u/index.md
@@ -1,11 +1,6 @@
 ---
 title: u
 slug: Web/HTML/Element/u
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/u
 original_slug: Web/HTML/Elemento/u
 ---
 

--- a/files/es/web/html/element/ul/index.md
+++ b/files/es/web/html/element/ul/index.md
@@ -1,11 +1,6 @@
 ---
 title: ul
 slug: Web/HTML/Element/ul
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/ul
 original_slug: Web/HTML/Elemento/ul
 ---
 

--- a/files/es/web/html/element/var/index.md
+++ b/files/es/web/html/element/var/index.md
@@ -1,11 +1,6 @@
 ---
 title: var
 slug: Web/HTML/Element/var
-tags:
-  - HTML
-  - HTML:Elemento
-  - Todas_las_Categorías
-translation_of: Web/HTML/Element/var
 original_slug: Web/HTML/Elemento/var
 ---
 

--- a/files/es/web/html/element/video/index.md
+++ b/files/es/web/html/element/video/index.md
@@ -1,12 +1,6 @@
 ---
 title: video
 slug: Web/HTML/Element/video
-tags:
-  - HTML
-  - HTML5
-  - Multimedia
-  - para_revisar
-translation_of: Web/HTML/Element/video
 original_slug: Web/HTML/Elemento/video
 ---
 

--- a/files/es/web/html/element/wbr/index.md
+++ b/files/es/web/html/element/wbr/index.md
@@ -1,12 +1,6 @@
 ---
 title: <wbr>
 slug: Web/HTML/Element/wbr
-tags:
-  - Elemento
-  - HTML
-  - Referencia
-  - Web
-translation_of: Web/HTML/Element/wbr
 original_slug: Web/HTML/Elemento/wbr
 ---
 

--- a/files/es/web/html/element/xmp/index.md
+++ b/files/es/web/html/element/xmp/index.md
@@ -1,13 +1,6 @@
 ---
 title: <xmp>
 slug: Web/HTML/Element/xmp
-tags:
-  - Elemento
-  - HTML
-  - Obsoleto
-  - Referencia
-  - Web
-translation_of: Web/HTML/Element/xmp
 original_slug: Web/HTML/Elemento/xmp
 ---
 

--- a/files/es/web/html/global_attributes/accesskey/index.md
+++ b/files/es/web/html/global_attributes/accesskey/index.md
@@ -1,11 +1,6 @@
 ---
 title: accesskey
 slug: Web/HTML/Global_attributes/accesskey
-tags:
-  - Atributos globales
-  - HTML
-  - Referencia
-translation_of: Web/HTML/Global_attributes/accesskey
 original_slug: Web/HTML/Atributos_Globales/accesskey
 ---
 

--- a/files/es/web/html/global_attributes/autocapitalize/index.md
+++ b/files/es/web/html/global_attributes/autocapitalize/index.md
@@ -1,13 +1,6 @@
 ---
 title: autocapitalización
 slug: Web/HTML/Global_attributes/autocapitalize
-tags:
-  - Atributos globales
-  - HTML
-  - Reference
-  - Referencia
-  - autocapitalización
-translation_of: Web/HTML/Global_attributes/autocapitalize
 original_slug: Web/HTML/Atributos_Globales/autocapitalize
 ---
 

--- a/files/es/web/html/global_attributes/class/index.md
+++ b/files/es/web/html/global_attributes/class/index.md
@@ -1,11 +1,6 @@
 ---
 title: class
 slug: Web/HTML/Global_attributes/class
-tags:
-  - Atributos globales
-  - HTML
-  - Referencia
-translation_of: Web/HTML/Global_attributes/class
 original_slug: Web/HTML/Atributos_Globales/class
 ---
 

--- a/files/es/web/html/global_attributes/contenteditable/index.md
+++ b/files/es/web/html/global_attributes/contenteditable/index.md
@@ -1,11 +1,6 @@
 ---
 title: contenteditable
 slug: Web/HTML/Global_attributes/contenteditable
-tags:
-  - Atributos globales
-  - HTM
-  - Referencia
-translation_of: Web/HTML/Global_attributes/contenteditable
 original_slug: Web/HTML/Atributos_Globales/contenteditable
 ---
 

--- a/files/es/web/html/global_attributes/contextmenu/index.md
+++ b/files/es/web/html/global_attributes/contextmenu/index.md
@@ -1,11 +1,6 @@
 ---
 title: contextmenu
 slug: Web/HTML/Global_attributes/contextmenu
-tags:
-  - Atributos globales
-  - HTML
-  - Referencia
-translation_of: Web/HTML/Global_attributes/contextmenu
 original_slug: Web/HTML/Atributos_Globales/contextmenu
 ---
 

--- a/files/es/web/html/global_attributes/data-_star_/index.md
+++ b/files/es/web/html/global_attributes/data-_star_/index.md
@@ -1,7 +1,6 @@
 ---
 title: data-*
 slug: Web/HTML/Global_attributes/data-*
-translation_of: Web/HTML/Global_attributes/data-*
 original_slug: Web/HTML/Atributos_Globales/data-*
 ---
 

--- a/files/es/web/html/global_attributes/dir/index.md
+++ b/files/es/web/html/global_attributes/dir/index.md
@@ -1,13 +1,7 @@
 ---
 title: dir
 slug: Web/HTML/Global_attributes/dir
-tags:
-  - Atributos globales
-  - HTML
-  - Referencia
-translation_of: Web/HTML/Global_attributes/dir
 original_slug: Web/HTML/Atributos_Globales/dir
-browser-compat: html.global_attributes.dir
 ---
 
 {{HTMLSidebar("Global_attributes")}}

--- a/files/es/web/html/global_attributes/draggable/index.md
+++ b/files/es/web/html/global_attributes/draggable/index.md
@@ -1,14 +1,7 @@
 ---
 title: draggable
 slug: Web/HTML/Global_attributes/draggable
-tags:
-  - Atributos globales
-  - Experimental
-  - HTML
-  - Referencia
-translation_of: Web/HTML/Global_attributes/draggable
 original_slug: Web/HTML/Atributos_Globales/draggable
-browser-compat: html.global_elements.draggable
 ---
 
 {{HTMLSidebar("Global_attributes")}}{{SeeCompatTable}}

--- a/files/es/web/html/global_attributes/hidden/index.md
+++ b/files/es/web/html/global_attributes/hidden/index.md
@@ -1,11 +1,6 @@
 ---
 title: hidden
 slug: Web/HTML/Global_attributes/hidden
-tags:
-  - Atributos globales
-  - HTML
-  - Referencia
-translation_of: Web/HTML/Global_attributes/hidden
 original_slug: Web/HTML/Atributos_Globales/hidden
 ---
 

--- a/files/es/web/html/global_attributes/id/index.md
+++ b/files/es/web/html/global_attributes/id/index.md
@@ -1,11 +1,6 @@
 ---
 title: id
 slug: Web/HTML/Global_attributes/id
-tags:
-  - Atributos globales
-  - HTML
-  - Referencia
-translation_of: Web/HTML/Global_attributes/id
 original_slug: Web/HTML/Atributos_Globales/id
 ---
 {{HTMLSidebar("Global_attributes")}}

--- a/files/es/web/html/global_attributes/index.md
+++ b/files/es/web/html/global_attributes/index.md
@@ -1,12 +1,6 @@
 ---
 title: Atributos globales
 slug: Web/HTML/Global_attributes
-tags:
-  - Atributos globales
-  - HTML
-  - Referencia
-  - Web
-translation_of: Web/HTML/Global_attributes
 original_slug: Web/HTML/Atributos_Globales
 ---
 

--- a/files/es/web/html/global_attributes/is/index.md
+++ b/files/es/web/html/global_attributes/is/index.md
@@ -1,12 +1,6 @@
 ---
 title: is
 slug: Web/HTML/Global_attributes/is
-tags:
-  - Atributos globales
-  - HTML
-  - Referencia
-  - is
-translation_of: Web/HTML/Global_attributes/is
 original_slug: Web/HTML/Atributos_Globales/is
 ---
 

--- a/files/es/web/html/global_attributes/itemid/index.md
+++ b/files/es/web/html/global_attributes/itemid/index.md
@@ -1,9 +1,7 @@
 ---
 title: itemid
 slug: Web/HTML/Global_attributes/itemid
-translation_of: Web/HTML/Global_attributes/itemid
 original_slug: Web/HTML/Global_attributes/itemid
-browser-compat: html.global_attributes.itemid
 ---
 
 {{HTMLSidebar("Global_attributes")}}

--- a/files/es/web/html/global_attributes/itemprop/index.md
+++ b/files/es/web/html/global_attributes/itemprop/index.md
@@ -1,10 +1,6 @@
 ---
 title: itemprop
 slug: Web/HTML/Global_attributes/itemprop
-tags:
-  - atributo
-  - metatag
-translation_of: Web/HTML/Global_attributes/itemprop
 original_slug: Web/HTML/Atributos_Globales/itemprop
 ---
 

--- a/files/es/web/html/global_attributes/itemref/index.md
+++ b/files/es/web/html/global_attributes/itemref/index.md
@@ -1,7 +1,6 @@
 ---
 title: itemref
 slug: Web/HTML/Global_attributes/itemref
-translation_of: Web/HTML/Global_attributes/itemref
 original_slug: Web/HTML/Atributos_Globales/itemref
 ---
 

--- a/files/es/web/html/global_attributes/itemscope/index.md
+++ b/files/es/web/html/global_attributes/itemscope/index.md
@@ -1,11 +1,6 @@
 ---
 title: itemscope
 slug: Web/HTML/Global_attributes/itemscope
-tags:
-  - Ejemplo
-  - itemscope
-  - itemtype
-translation_of: Web/HTML/Global_attributes/itemscope
 original_slug: Web/HTML/Atributos_Globales/itemscope
 ---
 

--- a/files/es/web/html/global_attributes/lang/index.md
+++ b/files/es/web/html/global_attributes/lang/index.md
@@ -1,11 +1,6 @@
 ---
 title: lang
 slug: Web/HTML/Global_attributes/lang
-tags:
-  - Atributos globales
-  - HTML
-  - Referencia
-translation_of: Web/HTML/Global_attributes/lang
 original_slug: Web/HTML/Atributos_Globales/lang
 ---
 

--- a/files/es/web/html/global_attributes/slot/index.md
+++ b/files/es/web/html/global_attributes/slot/index.md
@@ -1,11 +1,6 @@
 ---
 title: slot
 slug: Web/HTML/Global_attributes/slot
-tags:
-  - Atributos globales
-  - HTML
-  - Referencia
-translation_of: Web/HTML/Global_attributes/slot
 original_slug: Web/HTML/Atributos_Globales/slot
 ---
 

--- a/files/es/web/html/global_attributes/spellcheck/index.md
+++ b/files/es/web/html/global_attributes/spellcheck/index.md
@@ -1,12 +1,6 @@
 ---
 title: spellcheck
 slug: Web/HTML/Global_attributes/spellcheck
-tags:
-  - Atributos globales
-  - Experimental
-  - HTML
-  - Referencia
-translation_of: Web/HTML/Global_attributes/spellcheck
 original_slug: Web/HTML/Atributos_Globales/spellcheck
 ---
 

--- a/files/es/web/html/global_attributes/style/index.md
+++ b/files/es/web/html/global_attributes/style/index.md
@@ -1,11 +1,6 @@
 ---
 title: style
 slug: Web/HTML/Global_attributes/style
-tags:
-  - Atributos globales
-  - HTML
-  - Referencia
-translation_of: Web/HTML/Global_attributes/style
 original_slug: Web/HTML/Atributos_Globales/style
 ---
 

--- a/files/es/web/html/global_attributes/tabindex/index.md
+++ b/files/es/web/html/global_attributes/tabindex/index.md
@@ -1,11 +1,6 @@
 ---
 title: tabindex
 slug: Web/HTML/Global_attributes/tabindex
-tags:
-  - Atributos globales
-  - HTML
-  - Referencia
-translation_of: Web/HTML/Global_attributes/tabindex
 original_slug: Web/HTML/Atributos_Globales/tabindex
 ---
 

--- a/files/es/web/html/global_attributes/title/index.md
+++ b/files/es/web/html/global_attributes/title/index.md
@@ -1,11 +1,6 @@
 ---
 title: title
 slug: Web/HTML/Global_attributes/title
-tags:
-  - Atributos globales
-  - HTML
-  - Referencia
-translation_of: Web/HTML/Global_attributes/title
 original_slug: Web/HTML/Atributos_Globales/title
 ---
 

--- a/files/es/web/html/global_attributes/translate/index.md
+++ b/files/es/web/html/global_attributes/translate/index.md
@@ -1,12 +1,6 @@
 ---
 title: translate
 slug: Web/HTML/Global_attributes/translate
-tags:
-  - Atributos globales
-  - Experimental
-  - HTML
-  - Referencia
-translation_of: Web/HTML/Global_attributes/translate
 original_slug: Web/HTML/Atributos_Globales/translate
 ---
 

--- a/files/es/web/html/global_attributes/x-ms-acceleratorkey/index.md
+++ b/files/es/web/html/global_attributes/x-ms-acceleratorkey/index.md
@@ -1,7 +1,6 @@
 ---
 title: x-ms-acceleratorkey
 slug: Web/HTML/Global_attributes/x-ms-acceleratorkey
-translation_of: Web/HTML/Global_attributes/x-ms-acceleratorkey
 original_slug: Web/HTML/Atributos_Globales/x-ms-acceleratorkey
 ---
 

--- a/files/es/web/html/index.md
+++ b/files/es/web/html/index.md
@@ -1,17 +1,6 @@
 ---
 title: 'HTML: Lenguaje de etiquetas de hipertexto'
 slug: Web/HTML
-tags:
-  - Avanzado
-  - Guía
-  - HTML
-  - HTML5
-  - Hipertexto
-  - Intermedio
-  - Principiante
-  - Referencia
-  - Web
-translation_of: Web/HTML
 ---
 
 {{HTMLSidebar}}

--- a/files/es/web/html/inline_elements/index.md
+++ b/files/es/web/html/inline_elements/index.md
@@ -1,14 +1,6 @@
 ---
 title: Elementos en línea
 slug: Web/HTML/Inline_elements
-tags:
-  - Guía
-  - HTML
-  - HTML5
-  - Principiante
-  - Web
-  - desarrollo
-translation_of: Web/HTML/Inline_elements
 original_slug: Web/HTML/Elementos_en_línea
 ---
 

--- a/files/es/web/html/link_types/index.md
+++ b/files/es/web/html/link_types/index.md
@@ -1,7 +1,6 @@
 ---
 title: Tipos de enlaces
 slug: Web/HTML/Link_types
-translation_of: Web/HTML/Link_types
 original_slug: Web/HTML/Tipos_de_enlaces
 ---
 

--- a/files/es/web/html/microdata/index.md
+++ b/files/es/web/html/microdata/index.md
@@ -1,12 +1,6 @@
 ---
 title: Microdatos
 slug: Web/HTML/Microdata
-tags:
-  - HTML
-  - Microdatos
-  - Referencia
-  - busquedas
-translation_of: Web/HTML/Microdata
 original_slug: Web/HTML/Microdatos
 ---
 

--- a/files/es/web/html/microformats/index.md
+++ b/files/es/web/html/microformats/index.md
@@ -1,7 +1,6 @@
 ---
 title: Microformatos
 slug: Web/HTML/microformats
-translation_of: Web/HTML/microformats
 original_slug: Web/HTML/microformatos
 ---
 

--- a/files/es/web/html/quirks_mode_and_standards_mode/index.md
+++ b/files/es/web/html/quirks_mode_and_standards_mode/index.md
@@ -1,14 +1,6 @@
 ---
 title: Modo Quirks y Modo Estándar
 slug: Web/HTML/Quirks_Mode_and_Standards_Mode
-tags:
-  - Desarrollo web
-  - Estándar Web
-  - Gecko
-  - Guía
-  - HTML
-  - XHTML
-translation_of: Web/HTML/Quirks_Mode_and_Standards_Mode
 ---
 
 En los viejos días de la web, las páginas eran comúnmente escritas de dos formas: Una para navegador Netscape y otra para Microsoft Internet Explorer. Cuando los estándares de la web fueron creador por W3C, los navegadores no sólo empezaron a utilizarlos, tan pronto lo hicieron romperían los más existentes sitios en la Web. Sin embargo los navegadores introdujeron dos modos para tratar los nuevos estándares que cumplan que los sitios diferentemente de los viejos legados de sitios.

--- a/files/es/web/html/reference/index.md
+++ b/files/es/web/html/reference/index.md
@@ -1,11 +1,6 @@
 ---
 title: Referencia HTML
 slug: Web/HTML/Reference
-tags:
-  - HTML
-  - Referencia
-  - Web
-translation_of: Web/HTML/Reference
 original_slug: Web/HTML/Referencia
 ---
 

--- a/files/es/web/progressive_web_apps/app_structure/index.md
+++ b/files/es/web/progressive_web_apps/app_structure/index.md
@@ -1,17 +1,6 @@
 ---
 title: Estructura de una aplicación web progresiva
 slug: Web/Progressive_web_apps/App_structure
-tags:
-  - Estructura
-  - Intérprete de la aplicación
-  - PWAs
-  - Servicio workers
-  - Streams
-  - Transmisiones
-  - aplicaciones web progresivas
-  - js13kGames
-  - progresiva
-translation_of: Web/Progressive_web_apps/App_structure
 ---
 
 {{PreviousMenuNext("Web/Progressive_web_apps/Introduction", "Web/Progressive_web_apps/Offline_Service_workers", "Web/Progressive_web_apps")}}

--- a/files/es/web/progressive_web_apps/index.md
+++ b/files/es/web/progressive_web_apps/index.md
@@ -1,14 +1,6 @@
 ---
 title: Aplicaciones Web Progresivas
 slug: Web/Progressive_web_apps
-tags:
-  - Aplicaciones Web
-  - Aplicaciones web modernas
-  - Aplicación Web Progresiva
-  - Aplicación web
-  - PWA
-  - aplicación
-translation_of: Web/Progressive_web_apps
 ---
 
 ![Logotipo de la comunidad PWA](https://mdn.mozillademos.org/files/16742/pwa.png)Las **_aplicaciones web progresivas_** (mejor conocidas como **PWA**s por «_**P**rogressive **W**eb **A**pps_») son aplicaciones web que utilizan APIs y funciones emergentes del navegador web junto a una estrategia tradicional de mejora progresiva para ofrecer una aplicación nativa —como la experiencia del usuario para aplicaciones web multiplataforma. Las aplicaciones web progresivas son un patrón de diseño útil, aunque no son un estándar formalizado. Se puede pensar que PWA es similar a AJAX u otros patrones similares que abarcan un conjunto de atributos de aplicación, incluido el uso de tecnologías y técnicas web específicas. Este conjunto de documentos te dice todo lo que necesitas saber sobre ellas.

--- a/files/es/web/progressive_web_apps/installable_pwas/index.md
+++ b/files/es/web/progressive_web_apps/installable_pwas/index.md
@@ -1,15 +1,6 @@
 ---
 title: Cómo hacer PWAs instalables
 slug: Web/Progressive_web_apps/Installable_PWAs
-tags:
-  - Instalable
-  - PWAs
-  - aapi
-  - agregar a pantalla de inicio
-  - aplicaciones web progresivas
-  - js13kGames
-  - progresiva
-translation_of: Web/Progressive_web_apps/Installable_PWAs
 ---
 
 {{PreviousMenuNext("Web/Apps/Progressive/Offline_Service_workers", "Web/Apps/Progressive/Re-engageable_Notifications_Push", "Web/Apps/Progressive")}}

--- a/files/es/web/progressive_web_apps/installing/index.md
+++ b/files/es/web/progressive_web_apps/installing/index.md
@@ -1,23 +1,6 @@
 ---
 title: Instalar y desinstalar aplicaciones web
 slug: Web/Progressive_web_apps/Installing
-tags:
-  - Android
-  - Apps
-  - Chrome
-  - Desinstalar
-  - Firefox
-  - Guía
-  - Lanzar
-  - PWA
-  - Pantalla de inicio
-  - Principiante
-  - Samsung
-  - Web
-  - aplicaciones
-  - aplicaciones web progresivas
-  - instalar
-translation_of: Web/Progressive_web_apps/Developer_guide/Installing
 original_slug: Web/Progressive_web_apps/Developer_guide/Installing
 ---
 

--- a/files/es/web/progressive_web_apps/introduction/index.md
+++ b/files/es/web/progressive_web_apps/introduction/index.md
@@ -1,18 +1,6 @@
 ---
 title: Introducción a  aplicaciones web progresivas
 slug: Web/Progressive_web_apps/Introduction
-tags:
-  - Aplicaciones web prograsivas
-  - Guía
-  - Intermedio
-  - Intruducción
-  - PWA
-  - Servicio Worker
-  - aplicaciones
-  - js13kGames
-  - manifiesto web
-  - progresiva
-translation_of: Web/Progressive_web_apps/Introduction
 ---
 
 {{NextMenu("Web/Progressive_web_apps/App_structure", "Web/Progressive_web_apps")}}

--- a/files/es/web/progressive_web_apps/loading/index.md
+++ b/files/es/web/progressive_web_apps/loading/index.md
@@ -1,13 +1,6 @@
 ---
 title: Carga progresiva
 slug: Web/Progressive_web_apps/Loading
-tags:
-  - Cargar
-  - PWAs
-  - aplicaciones web progresivas
-  - js13kGames
-  - progresiva
-translation_of: Web/Progressive_web_apps/Loading
 ---
 
 {{PreviousMenu("Web/Progressive_web_apps/Re-engageable_Notifications_Push", "Web/Progressive_web_apps")}}

--- a/files/es/web/progressive_web_apps/offline_service_workers/index.md
+++ b/files/es/web/progressive_web_apps/offline_service_workers/index.md
@@ -1,14 +1,6 @@
 ---
 title: Hacer que las PWAs trabajen desconectadas con servicio workers
 slug: Web/Progressive_web_apps/Offline_Service_workers
-tags:
-  - Desconectada
-  - PWAs
-  - Servicio workers
-  - aplicaciones web progresivas
-  - js13kGames
-  - progresiva
-translation_of: Web/Progressive_web_apps/Offline_Service_workers
 ---
 
 {{PreviousMenuNext("Web/Progressive_web_apps/App_structure", "Web/Progressive_web_apps/Installable_PWAs", "Web/Progressive_web_apps")}}

--- a/files/es/web/progressive_web_apps/re-engageable_notifications_push/index.md
+++ b/files/es/web/progressive_web_apps/re-engageable_notifications_push/index.md
@@ -1,16 +1,7 @@
 ---
-title: >-
-  Cómo hacer que las PWAs se puedan volver a conectar usando Notificaciones y
+title: Cómo hacer que las PWAs se puedan volver a conectar usando Notificaciones y
   Push
 slug: Web/Progressive_web_apps/Re-engageable_Notifications_Push
-tags:
-  - Notificaciones
-  - PWAs
-  - Push
-  - aplicaciones web progresivas
-  - js13kGames
-  - progresiva
-translation_of: Web/Progressive_web_apps/Re-engageable_Notifications_Push
 ---
 
 {{PreviousMenuNext("Web/Apps/Progressive/Installable_PWAs", "Web/Apps/Progressive/Loading", "Web/Apps/Progressive")}}

--- a/files/es/web/xslt/element/apply-imports/index.md
+++ b/files/es/web/xslt/element/apply-imports/index.md
@@ -1,10 +1,6 @@
 ---
 title: apply-imports
 slug: Web/XSLT/Element/apply-imports
-tags:
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/XSLT/Element/apply-imports
 original_slug: Web/XSLT/apply-imports
 ---
 

--- a/files/es/web/xslt/element/apply-templates/index.md
+++ b/files/es/web/xslt/element/apply-templates/index.md
@@ -1,10 +1,6 @@
 ---
 title: apply-templates
 slug: Web/XSLT/Element/apply-templates
-tags:
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/XSLT/Element/apply-templates
 original_slug: Web/XSLT/apply-templates
 ---
 

--- a/files/es/web/xslt/element/attribute-set/index.md
+++ b/files/es/web/xslt/element/attribute-set/index.md
@@ -1,10 +1,6 @@
 ---
 title: attribute-set
 slug: Web/XSLT/Element/attribute-set
-tags:
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/XSLT/Element/attribute-set
 original_slug: Web/XSLT/attribute-set
 ---
 

--- a/files/es/web/xslt/element/attribute/index.md
+++ b/files/es/web/xslt/element/attribute/index.md
@@ -1,10 +1,6 @@
 ---
 title: attribute
 slug: Web/XSLT/Element/attribute
-tags:
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/XSLT/Element/attribute
 original_slug: Web/XSLT/attribute
 ---
 

--- a/files/es/web/xslt/element/call-template/index.md
+++ b/files/es/web/xslt/element/call-template/index.md
@@ -1,10 +1,6 @@
 ---
 title: call-template
 slug: Web/XSLT/Element/call-template
-tags:
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/XSLT/Element/call-template
 original_slug: Web/XSLT/call-template
 ---
 

--- a/files/es/web/xslt/element/choose/index.md
+++ b/files/es/web/xslt/element/choose/index.md
@@ -1,10 +1,6 @@
 ---
 title: choose
 slug: Web/XSLT/Element/choose
-tags:
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/XSLT/Element/choose
 original_slug: Web/XSLT/choose
 ---
 

--- a/files/es/web/xslt/element/comment/index.md
+++ b/files/es/web/xslt/element/comment/index.md
@@ -1,10 +1,6 @@
 ---
 title: comment
 slug: Web/XSLT/Element/comment
-tags:
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/XSLT/Element/comment
 original_slug: Web/XSLT/comment
 ---
 

--- a/files/es/web/xslt/element/copy-of/index.md
+++ b/files/es/web/xslt/element/copy-of/index.md
@@ -1,10 +1,6 @@
 ---
 title: copy-of
 slug: Web/XSLT/Element/copy-of
-tags:
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/XSLT/Element/copy-of
 original_slug: Web/XSLT/copy-of
 ---
 

--- a/files/es/web/xslt/element/copy/index.md
+++ b/files/es/web/xslt/element/copy/index.md
@@ -1,10 +1,6 @@
 ---
 title: copy
 slug: Web/XSLT/Element/copy
-tags:
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/XSLT/Element/copy
 original_slug: Web/XSLT/copy
 ---
 

--- a/files/es/web/xslt/element/decimal-format/index.md
+++ b/files/es/web/xslt/element/decimal-format/index.md
@@ -1,10 +1,6 @@
 ---
 title: decimal-format
 slug: Web/XSLT/Element/decimal-format
-tags:
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/XSLT/Element/decimal-format
 original_slug: Web/XSLT/decimal-format
 ---
 

--- a/files/es/web/xslt/element/element/index.md
+++ b/files/es/web/xslt/element/element/index.md
@@ -1,10 +1,6 @@
 ---
 title: element
 slug: Web/XSLT/Element/element
-tags:
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/XSLT/Element/element
 ---
 
 {{XsltRef}}

--- a/files/es/web/xslt/element/fallback/index.md
+++ b/files/es/web/xslt/element/fallback/index.md
@@ -1,10 +1,6 @@
 ---
 title: fallback
 slug: Web/XSLT/Element/fallback
-tags:
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/XSLT/Element/fallback
 original_slug: Web/XSLT/fallback
 ---
 

--- a/files/es/web/xslt/element/for-each/index.md
+++ b/files/es/web/xslt/element/for-each/index.md
@@ -1,10 +1,6 @@
 ---
 title: for-each
 slug: Web/XSLT/Element/for-each
-tags:
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/XSLT/Element/for-each
 original_slug: Web/XSLT/for-each
 ---
 

--- a/files/es/web/xslt/element/if/index.md
+++ b/files/es/web/xslt/element/if/index.md
@@ -1,10 +1,6 @@
 ---
 title: if
 slug: Web/XSLT/Element/if
-tags:
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/XSLT/Element/if
 original_slug: Web/XSLT/if
 ---
 

--- a/files/es/web/xslt/element/import/index.md
+++ b/files/es/web/xslt/element/import/index.md
@@ -1,10 +1,6 @@
 ---
 title: import
 slug: Web/XSLT/Element/import
-tags:
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/XSLT/Element/import
 original_slug: Web/XSLT/import
 ---
 

--- a/files/es/web/xslt/element/include/index.md
+++ b/files/es/web/xslt/element/include/index.md
@@ -1,10 +1,6 @@
 ---
 title: include
 slug: Web/XSLT/Element/include
-tags:
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/XSLT/Element/include
 original_slug: Web/XSLT/include
 ---
 

--- a/files/es/web/xslt/element/index.md
+++ b/files/es/web/xslt/element/index.md
@@ -1,11 +1,6 @@
 ---
 title: Elementos
 slug: Web/XSLT/Element
-tags:
-  - Todas_las_Categorías
-  - XSLT
-  - XSLT:Referencia
-translation_of: Web/XSLT/Element
 ---
 
 {{XsltRef}} En este documento se discutiran dos tipos de elementos: elementos raíz e instrucciones. Un elemento raíz debe aparecer como un hijo ya sea de `<xsl:stylesheet>` o `<xsl:transform>`. Por otro lado, una instrucción está asociada con una plantilla. Una hoja de estilo puede incluir varias plantillas. Un tercer tipo de elemento, no discutido aquí, es el elemento de resultado literal (LRE por sus siglas en inglés). Un LRE también aparece dentro de una plantilla, y consiste de cualquier elemento que no sea instrucción y que debe ser copiado tal cual al documento resultante, por ejemplo el elemento `<hr>` cuando se usa en una hoja de estilo para general HTML.

--- a/files/es/web/xslt/element/key/index.md
+++ b/files/es/web/xslt/element/key/index.md
@@ -1,10 +1,6 @@
 ---
 title: key
 slug: Web/XSLT/Element/key
-tags:
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/XSLT/Element/key
 original_slug: Web/XSLT/key
 ---
 

--- a/files/es/web/xslt/element/message/index.md
+++ b/files/es/web/xslt/element/message/index.md
@@ -1,10 +1,6 @@
 ---
 title: message
 slug: Web/XSLT/Element/message
-tags:
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/XSLT/Element/message
 original_slug: Web/XSLT/message
 ---
 {{XsltRef}}

--- a/files/es/web/xslt/element/namespace-alias/index.md
+++ b/files/es/web/xslt/element/namespace-alias/index.md
@@ -1,10 +1,6 @@
 ---
 title: namespace-alias
 slug: Web/XSLT/Element/namespace-alias
-tags:
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/XSLT/Element/namespace-alias
 original_slug: Web/XSLT/namespace-alias
 ---
 

--- a/files/es/web/xslt/element/otherwise/index.md
+++ b/files/es/web/xslt/element/otherwise/index.md
@@ -1,10 +1,6 @@
 ---
 title: otherwise
 slug: Web/XSLT/Element/otherwise
-tags:
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/XSLT/Element/otherwise
 original_slug: Web/XSLT/otherwise
 ---
 

--- a/files/es/web/xslt/element/when/index.md
+++ b/files/es/web/xslt/element/when/index.md
@@ -1,10 +1,6 @@
 ---
 title: when
 slug: Web/XSLT/Element/when
-tags:
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/XSLT/Element/when
 original_slug: Web/XSLT/when
 ---
 

--- a/files/es/web/xslt/element/with-param/index.md
+++ b/files/es/web/xslt/element/with-param/index.md
@@ -1,10 +1,6 @@
 ---
 title: with-param
 slug: Web/XSLT/Element/with-param
-tags:
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/XSLT/Element/with-param
 original_slug: Web/XSLT/with-param
 ---
 

--- a/files/es/web/xslt/index.md
+++ b/files/es/web/xslt/index.md
@@ -1,7 +1,6 @@
 ---
 title: XSLT
 slug: Web/XSLT
-translation_of: Web/XSLT
 ---
 
 **[Tutorial XSLT (en)](http://www.w3schools.com/xsl/)**

--- a/files/es/web/xslt/transforming_xml_with_xslt/index.md
+++ b/files/es/web/xslt/transforming_xml_with_xslt/index.md
@@ -1,11 +1,6 @@
 ---
 title: Transformando XML con XSLT
 slug: Web/XSLT/Transforming_XML_with_XSLT
-tags:
-  - Todas_las_Categorías
-  - Transformando_XML_con_XSLT
-  - XSLT
-translation_of: Web/XSLT/Transforming_XML_with_XSLT
 original_slug: Web/XSLT/Transformando_XML_con_XSLT
 ---
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove duplicated frontmatter keys from localized content

### Motivation

Remove innecesarry duplicated data

### Additional details

Folders: (html|xslt|progressive_web_apps|demos)

```
{
  "tags": 168,
  "translation_of": 200,
  "browser-compat": 15
}
```

### Related issues and pull requests

Relates to #10129
Relates to #7412
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
