### PR TITLE
Remove duplicated frontmatter keys from web folder 2/10 [es]

### DIFF
--- a/files/es/web/accessibility/aria/aria_techniques/index.md
+++ b/files/es/web/accessibility/aria/aria_techniques/index.md
@@ -1,12 +1,6 @@
 ---
 title: ARIA techniques
 slug: Web/Accessibility/ARIA/ARIA_Techniques
-tags:
-  - ARIA
-  - Accessibility
-  - NeedsTranslation
-  - TopicStub
-translation_of: Web/Accessibility/ARIA/ARIA_Techniques
 ---
 
 ### Roles

--- a/files/es/web/accessibility/aria/forms/index.md
+++ b/files/es/web/accessibility/aria/forms/index.md
@@ -1,10 +1,6 @@
 ---
 title: Formularios
 slug: Web/Accessibility/ARIA/forms
-tags:
-  - ARIA
-  - Accesibilidad
-translation_of: Web/Accessibility/ARIA/forms
 ---
 
 Las siguientes páginas proporcionan diversas técnicas para mejorar la accesibilidad de los formularios web:

--- a/files/es/web/accessibility/aria/forms/multipart_labels/index.md
+++ b/files/es/web/accessibility/aria/forms/multipart_labels/index.md
@@ -1,19 +1,7 @@
 ---
-title: >-
-  Etiquetas complejas: Utilizando ARIA para etiquetas con campos embebidos
-  dentro de ellos
+title: 'Etiquetas complejas: Utilizando ARIA para etiquetas con campos embebidos dentro
+  de ellos'
 slug: Web/Accessibility/ARIA/forms/Multipart_labels
-tags:
-  - ARIA
-  - Accesibilidad
-  - Firefox
-  - Guía
-  - HTML
-  - NeedsContent
-  - aria-labelledby
-  - etiqueta
-  - label
-translation_of: Web/Accessibility/ARIA/forms/Multipart_labels
 original_slug: Web/Accessibility/ARIA/forms/Etiquetas_complejas
 ---
 

--- a/files/es/web/accessibility/aria/index.md
+++ b/files/es/web/accessibility/aria/index.md
@@ -1,7 +1,6 @@
 ---
 title: ARIA
 slug: Web/Accessibility/ARIA
-translation_of: Web/Accessibility/ARIA
 ---
 
 Accessible Rich Internet Applications **(<abbr>ARIA</abbr>)** es una colección de atributos que definen como realizar contenido y aplicaciónes web (especialmente las desarrolladas con Javascript) más accesibles para las personas con discapacidades.

--- a/files/es/web/accessibility/aria/roles/alert_role/index.md
+++ b/files/es/web/accessibility/aria/roles/alert_role/index.md
@@ -1,16 +1,6 @@
 ---
 title: Using the alert role
 slug: Web/Accessibility/ARIA/Roles/alert_role
-tags:
-  - ARIA
-  - Accesibilidad
-  - CSS
-  - HTML
-  - alert
-  - alerta
-  - rol de alerta
-  - tecnología asistencial
-translation_of: Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role
 original_slug: Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role
 ---
 

--- a/files/es/web/accessibility/aria/roles/alertdialog_role/index.md
+++ b/files/es/web/accessibility/aria/roles/alertdialog_role/index.md
@@ -1,16 +1,6 @@
 ---
 title: Usando el rol alertdialog
 slug: Web/Accessibility/ARIA/Roles/alertdialog_role
-tags:
-  - ARIA
-  - Accesibilidad
-  - Alertas
-  - Desarrollo web
-  - HTML
-  - agente
-  - alertdialog
-  - modal
-translation_of: Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alertdialog_role
 original_slug: Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alertdialog_role
 ---
 

--- a/files/es/web/accessibility/community/index.md
+++ b/files/es/web/accessibility/community/index.md
@@ -1,7 +1,6 @@
 ---
 title: Comunidad
 slug: Web/Accessibility/Community
-translation_of: Web/Accessibility/Community
 original_slug: Web/Accesibilidad/Comunidad
 ---
 

--- a/files/es/web/accessibility/index.md
+++ b/files/es/web/accessibility/index.md
@@ -1,7 +1,6 @@
 ---
 title: Accesibilidad
 slug: Web/Accessibility
-translation_of: Web/Accessibility
 l10n:
   sourceCommit: acebfb2b738c2b3d7caf73607000f1aa4b4393d1
 ---

--- a/files/es/web/accessibility/understanding_wcag/index.md
+++ b/files/es/web/accessibility/understanding_wcag/index.md
@@ -1,7 +1,6 @@
 ---
 title: Understanding the Web Content Accessibility Guidelines
 slug: Web/Accessibility/Understanding_WCAG
-translation_of: Web/Accessibility/Understanding_WCAG
 original_slug: Web/Accesibilidad/Understanding_WCAG
 ---
 

--- a/files/es/web/accessibility/understanding_wcag/keyboard/index.md
+++ b/files/es/web/accessibility/understanding_wcag/keyboard/index.md
@@ -1,10 +1,6 @@
 ---
 title: Teclado (Keyboard)
 slug: Web/Accessibility/Understanding_WCAG/Keyboard
-tags:
-  - Accesibilidad
-  - teclado
-translation_of: Web/Accessibility/Understanding_WCAG/Keyboard
 original_slug: Web/Accesibilidad/Understanding_WCAG/Teclado
 ---
 

--- a/files/es/web/accessibility/understanding_wcag/perceivable/color_contrast/index.md
+++ b/files/es/web/accessibility/understanding_wcag/perceivable/color_contrast/index.md
@@ -1,11 +1,6 @@
 ---
 title: Contraste del color
 slug: Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast
-tags:
-  - Accesibilidad
-  - Perceptible
-  - contraste
-translation_of: Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast
 original_slug: Web/Accesibilidad/Understanding_WCAG/Perceivable/Color_contraste
 ---
 

--- a/files/es/web/accessibility/understanding_wcag/perceivable/index.md
+++ b/files/es/web/accessibility/understanding_wcag/perceivable/index.md
@@ -1,7 +1,6 @@
 ---
 title: Perceivable
 slug: Web/Accessibility/Understanding_WCAG/Perceivable
-translation_of: Web/Accessibility/Understanding_WCAG/Perceivable
 original_slug: Web/Accesibilidad/Understanding_WCAG/Perceivable
 ---
 

--- a/files/es/web/accessibility/understanding_wcag/text_labels_and_names/index.md
+++ b/files/es/web/accessibility/understanding_wcag/text_labels_and_names/index.md
@@ -1,11 +1,6 @@
 ---
 title: Etiquetas de texto y nombres
 slug: Web/Accessibility/Understanding_WCAG/Text_labels_and_names
-tags:
-  - Accesibilidad
-  - Etiquetas de texto
-  - WCAG
-translation_of: Web/Accessibility/Understanding_WCAG/Text_labels_and_names
 original_slug: Web/Accesibilidad/Understanding_WCAG/Etiquetas_de_texto_y_nombres
 ---
 

--- a/files/es/web/events/index.md
+++ b/files/es/web/events/index.md
@@ -1,7 +1,6 @@
 ---
 title: Referencia de Eventos
 slug: Web/Events
-translation_of: Web/Events
 ---
 
 Los eventos se envían para notificar al código de cosas interesantes que han ocurrido. Cada evento está representado por un objeto que se basa en la interfaz {{domxref("Event")}}, y puede tener campos y/o funciones personalizadas adicionales para obtener más información acerca de lo sucedido. Los eventos pueden representar cualquier cosa desde las interacciones básicas del usuario para notificaciones automatizadas de las cosas que suceden en el modelo de representación.

--- a/files/es/web/guide/ajax/community/index.md
+++ b/files/es/web/guide/ajax/community/index.md
@@ -1,7 +1,6 @@
 ---
 title: Comunidad
 slug: Web/Guide/AJAX/Community
-translation_of: Web/Guide/AJAX/Community
 original_slug: Web/Guide/AJAX/Comunidad
 ---
 

--- a/files/es/web/guide/ajax/getting_started/index.md
+++ b/files/es/web/guide/ajax/getting_started/index.md
@@ -1,13 +1,6 @@
 ---
 title: Primeros Pasos
 slug: Web/Guide/AJAX/Getting_Started
-tags:
-  - AJAX
-  - API
-  - Avanzado
-  - Todas_las_Categorías
-  - XMLHttpRequest
-translation_of: Web/Guide/AJAX/Getting_Started
 original_slug: Web/Guide/AJAX/Primeros_Pasos
 ---
 

--- a/files/es/web/guide/ajax/index.md
+++ b/files/es/web/guide/ajax/index.md
@@ -1,7 +1,6 @@
 ---
 title: AJAX
 slug: Web/Guide/AJAX
-translation_of: Web/Guide/AJAX
 ---
 
 **[Primeros Pasos](/es/docs/Web/Guide/AJAX/Getting_Started)**

--- a/files/es/web/guide/api/index.md
+++ b/files/es/web/guide/api/index.md
@@ -1,13 +1,6 @@
 ---
 title: Guide to Web APIs
 slug: Web/Guide/API
-tags:
-  - API
-  - Guía
-  - Landing
-  - TopicStub
-  - Web
-translation_of: Web/Guide/API
 ---
 
 Aquí encontrarás links a cada una de las guías introduciendo y explicando cada una de las APIs que conforman la la arquitectura del desarrollo web.

--- a/files/es/web/guide/api/webrtc/peer-to-peer_communications_with_webrtc/index.md
+++ b/files/es/web/guide/api/webrtc/peer-to-peer_communications_with_webrtc/index.md
@@ -1,7 +1,6 @@
 ---
 title: Comunicaciones peer-to-peer (P2P) con WebRTC
 slug: Web/Guide/API/WebRTC/Peer-to-peer_communications_with_WebRTC
-translation_of: Web/Guide/API/WebRTC/Peer-to-peer_communications_with_WebRTC
 original_slug: WebRTC/Peer-to-peer_communications_with_WebRTC
 ---
 

--- a/files/es/web/guide/css/block_formatting_context/index.md
+++ b/files/es/web/guide/css/block_formatting_context/index.md
@@ -1,13 +1,6 @@
 ---
 title: Contexto de formato de bloque
 slug: Web/Guide/CSS/Block_formatting_context
-tags:
-  - CSS
-  - Guía
-  - Necesita ejemplos
-  - Referencia
-  - Web
-translation_of: Web/Guide/CSS/Block_formatting_context
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/guide/graphics/index.md
+++ b/files/es/web/guide/graphics/index.md
@@ -1,21 +1,6 @@
 ---
 title: Gráficas en la web
 slug: Web/Guide/Graphics
-tags:
-  - 2D
-  - 3D
-  - 3ra Dimensión
-  - Canvas
-  - Gráficas
-  - Gráficos(2)
-  - HTML5
-  - Líneas
-  - RTCWeb
-  - SVG
-  - WebGL
-  - WebRTC
-  - graficos
-translation_of: Web/Guide/Graphics
 ---
 
 Los sitios web modernos a menudo necesitan aplicaciones para presentar y/o visualizar gráficos . Se

--- a/files/es/web/guide/html/content_categories/index.md
+++ b/files/es/web/guide/html/content_categories/index.md
@@ -1,13 +1,6 @@
 ---
 title: Categorías de contenido
 slug: Web/Guide/HTML/Content_categories
-tags:
-  - Avanzado
-  - Guía
-  - HTML
-  - HTML5
-  - Web
-translation_of: Web/Guide/HTML/Content_categories
 original_slug: Web/Guide/HTML/categorias_de_contenido
 ---
 

--- a/files/es/web/guide/index.md
+++ b/files/es/web/guide/index.md
@@ -1,14 +1,6 @@
 ---
 title: Guía de Desarrollo Web
 slug: Web/Guide
-tags:
-  - Guia(2)
-  - Guía
-  - Landing
-  - NeedsTranslation
-  - TopicStub
-  - Web
-translation_of: Web/Guide
 ---
 
 Este artículo proporciona información para ayudarte a hacer uso de tecnologías y APIs.

--- a/files/es/web/guide/mobile/index.md
+++ b/files/es/web/guide/mobile/index.md
@@ -1,10 +1,6 @@
 ---
 title: Desarrollo Web Móvil
 slug: Web/Guide/Mobile
-tags:
-  - Intermedio
-  - NecesitaEjemplo
-translation_of: Web/Guide/Mobile
 original_slug: Web/Guide/Movil
 ---
 

--- a/files/es/web/guide/parsing_and_serializing_xml/index.md
+++ b/files/es/web/guide/parsing_and_serializing_xml/index.md
@@ -1,9 +1,6 @@
 ---
-title: >-
-  Convertir código a cadena de texto (serializing) y visceversa (parsing) a un 
-  XML
+title: Convertir código a cadena de texto (serializing) y visceversa (parsing) a un  XML
 slug: Web/Guide/Parsing_and_serializing_XML
-translation_of: Web/Guide/Parsing_and_serializing_XML
 ---
 
 La plataforma web proveé Los siguientes objetos para hacer parsing (convertir una cadena de texto a código) y serializing (visceversa) a un XML:

--- a/files/es/web/guide/performance/index.md
+++ b/files/es/web/guide/performance/index.md
@@ -1,11 +1,6 @@
 ---
 title: Optimización y rendimiento
 slug: Web/Guide/Performance
-tags:
-  - Optimizacion
-  - Rendimiento
-  - Web
-translation_of: Web/Guide/Performance
 ---
 
 Cuando se construyen aplicaciones o sitios Web modernos, es importante hacer que su contenido funcione bien. Es decir, hacer que trabaje de forma rápida y eficiente. Esto permite que funcione eficazmente tanto para usuarios de potentes sistemas de escritorio así como para dispositivos móviles con menos potencia.

--- a/files/es/web/http/authentication/index.md
+++ b/files/es/web/http/authentication/index.md
@@ -1,13 +1,6 @@
 ---
 title: Autenticación HTTP
 slug: Web/HTTP/Authentication
-tags:
-  - Acceso de control
-  - Autenticación
-  - Guía
-  - HTTP
-  - HTTP Basic
-translation_of: Web/HTTP/Authentication
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/basics_of_http/choosing_between_www_and_non-www_urls/index.md
+++ b/files/es/web/http/basics_of_http/choosing_between_www_and_non-www_urls/index.md
@@ -1,13 +1,6 @@
 ---
 title: Elección entre www y no-www URLs
 slug: Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs
-tags:
-  - Guía
-  - HTTP
-  - URL
-  - WWW
-  - no www
-translation_of: Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs
 ---
 {{HTTPSidebar}}
 

--- a/files/es/web/http/basics_of_http/data_urls/index.md
+++ b/files/es/web/http/basics_of_http/data_urls/index.md
@@ -1,13 +1,6 @@
 ---
 title: Datos URIs
 slug: Web/HTTP/Basics_of_HTTP/Data_URLs
-tags:
-  - Base 64
-  - Guia(2)
-  - Intermedio
-  - URI
-  - URL
-translation_of: Web/HTTP/Basics_of_HTTP/Data_URIs
 original_slug: Web/HTTP/Basics_of_HTTP/Data_URIs
 ---
 

--- a/files/es/web/http/basics_of_http/evolution_of_http/index.md
+++ b/files/es/web/http/basics_of_http/evolution_of_http/index.md
@@ -1,7 +1,6 @@
 ---
 title: Evolución del protocolo HTTP
 slug: Web/HTTP/Basics_of_HTTP/Evolution_of_HTTP
-translation_of: Web/HTTP/Basics_of_HTTP/Evolution_of_HTTP
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/basics_of_http/identifying_resources_on_the_web/index.md
+++ b/files/es/web/http/basics_of_http/identifying_resources_on_the_web/index.md
@@ -1,7 +1,6 @@
 ---
 title: Identificación de recursos web
 slug: Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web
-translation_of: Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web
 original_slug: Web/HTTP/Basics_of_HTTP/Identificación_recursos_en_la_Web
 ---
 

--- a/files/es/web/http/basics_of_http/index.md
+++ b/files/es/web/http/basics_of_http/index.md
@@ -1,12 +1,6 @@
 ---
 title: Conceptos básicos de HTTP
 slug: Web/HTTP/Basics_of_HTTP
-tags:
-  - HTTP
-  - NeedsTranslation
-  - Overview
-  - TopicStub
-translation_of: Web/HTTP/Basics_of_HTTP
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/basics_of_http/mime_types/common_types/index.md
+++ b/files/es/web/http/basics_of_http/mime_types/common_types/index.md
@@ -1,18 +1,6 @@
 ---
 title: Lista completa de tipos MIME
 slug: Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
-tags:
-  - Archivos
-  - Audio
-  - HTTP
-  - MIME
-  - Referencia
-  - Texto
-  - Tipos
-  - Tipos MIME
-  - Tipos de archivo
-  - Video
-translation_of: Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/basics_of_http/mime_types/index.md
+++ b/files/es/web/http/basics_of_http/mime_types/index.md
@@ -1,15 +1,6 @@
 ---
 title: Tipos MIME
 slug: Web/HTTP/Basics_of_HTTP/MIME_types
-tags:
-  - Cabecera de solicitud
-  - Guide
-  - HTTP
-  - Meta
-  - Tipos MIME
-  - Tipos de contenido
-  - application/json
-translation_of: Web/HTTP/Basics_of_HTTP/MIME_types
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/conditional_requests/index.md
+++ b/files/es/web/http/conditional_requests/index.md
@@ -1,11 +1,6 @@
 ---
 title: Peticiones condicionales en HTTP
 slug: Web/HTTP/Conditional_requests
-tags:
-  - Guía
-  - HTTP
-  - Peticiones condicionales
-translation_of: Web/HTTP/Conditional_requests
 original_slug: Web/HTTP/Peticiones_condicionales
 ---
 

--- a/files/es/web/http/connection_management_in_http_1.x/index.md
+++ b/files/es/web/http/connection_management_in_http_1.x/index.md
@@ -1,7 +1,6 @@
 ---
 title: Gestión de la conexión en  HTTP/1.x
 slug: Web/HTTP/Connection_management_in_HTTP_1.x
-translation_of: Web/HTTP/Connection_management_in_HTTP_1.x
 original_slug: Web/HTTP/Gestion_de_la_conexion_en_HTTP_1.x
 ---
 

--- a/files/es/web/http/cookies/index.md
+++ b/files/es/web/http/cookies/index.md
@@ -1,21 +1,6 @@
 ---
 title: HTTP cookies
 slug: Web/HTTP/Cookies
-tags:
-  - Almacenamiento
-  - Articulo sobre Cookies
-  - Cookies
-  - Datos
-  - Desarrollo web
-  - HTTP
-  - JavaScript
-  - Navegador
-  - Petición
-  - Protocolos
-  - Servidor
-  - privacidad
-  - seguimiento
-translation_of: Web/HTTP/Cookies
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/cors/errors/corsdidnotsucceed/index.md
+++ b/files/es/web/http/cors/errors/corsdidnotsucceed/index.md
@@ -1,18 +1,6 @@
 ---
 title: 'Reason: CORS request did not succeed'
 slug: Web/HTTP/CORS/Errors/CORSDidNotSucceed
-tags:
-  - CORS
-  - CORSNoTuvoExito
-  - Consola
-  - Error
-  - HTTP
-  - HTTPS
-  - Messages
-  - Reasons
-  - Security
-  - solución de problemas
-translation_of: Web/HTTP/CORS/Errors/CORSDidNotSucceed
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/cors/errors/corsmissingalloworigin/index.md
+++ b/files/es/web/http/cors/errors/corsmissingalloworigin/index.md
@@ -1,10 +1,6 @@
 ---
 title: 'Reason: CORS header ''Access-Control-Allow-Origin'' missing'
 slug: Web/HTTP/CORS/Errors/CORSMissingAllowOrigin
-tags:
-  - Cabeceras
-  - Seguridad
-translation_of: Web/HTTP/CORS/Errors/CORSMissingAllowOrigin
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/cors/errors/corspreflightdidnotsucceed/index.md
+++ b/files/es/web/http/cors/errors/corspreflightdidnotsucceed/index.md
@@ -1,7 +1,6 @@
 ---
 title: 'Reason: CORS preflight channel did not succeed'
 slug: Web/HTTP/CORS/Errors/CORSPreflightDidNotSucceed
-translation_of: Web/HTTP/CORS/Errors/CORSPreflightDidNotSucceed
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/cors/errors/corsrequestnothttp/index.md
+++ b/files/es/web/http/cors/errors/corsrequestnothttp/index.md
@@ -1,7 +1,6 @@
 ---
 title: 'Reason: CORS request not HTTP'
 slug: Web/HTTP/CORS/Errors/CORSRequestNotHttp
-translation_of: Web/HTTP/CORS/Errors/CORSRequestNotHttp
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/cors/errors/index.md
+++ b/files/es/web/http/cors/errors/index.md
@@ -1,19 +1,6 @@
 ---
 title: CORS errors
 slug: Web/HTTP/CORS/Errors
-tags:
-  - CORS
-  - Errors
-  - HTTP
-  - HTTPS
-  - Messages
-  - NeedsTranslation
-  - Same-origin
-  - Security
-  - TopicStub
-  - console
-  - troubleshooting
-translation_of: Web/HTTP/CORS/Errors
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/cors/index.md
+++ b/files/es/web/http/cors/index.md
@@ -1,7 +1,6 @@
 ---
 title: Control de acceso HTTP (CORS)
 slug: Web/HTTP/CORS
-translation_of: Web/HTTP/CORS
 original_slug: Web/HTTP/Access_control_CORS
 ---
 

--- a/files/es/web/http/csp/index.md
+++ b/files/es/web/http/csp/index.md
@@ -1,9 +1,6 @@
 ---
 title: Content Security Policy (CSP)
 slug: Web/HTTP/CSP
-tags:
-  - Política de Seguridad del Contenido
-translation_of: Web/HTTP/CSP
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/accept-ranges/index.md
+++ b/files/es/web/http/headers/accept-ranges/index.md
@@ -1,7 +1,6 @@
 ---
 title: Accept-Ranges
 slug: Web/HTTP/Headers/Accept-Ranges
-translation_of: Web/HTTP/Headers/Accept-Ranges
 ---
 
 El encabezado de respuesta HTTP **`Accept-Ranges`** es un marcador usado por el servidor para notificar que soporta solicitudes parciales. El valor de este campo indica la unidad que puede ser usada para definir el rango.

--- a/files/es/web/http/headers/accept/index.md
+++ b/files/es/web/http/headers/accept/index.md
@@ -1,12 +1,6 @@
 ---
 title: Accept
 slug: Web/HTTP/Headers/Accept
-tags:
-  - Cabecera HTTP
-  - Cabecera de Pedido
-  - HTTP
-  - Referencia
-translation_of: Web/HTTP/Headers/Accept
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/access-control-allow-credentials/index.md
+++ b/files/es/web/http/headers/access-control-allow-credentials/index.md
@@ -1,14 +1,6 @@
 ---
 title: Access-Control-Allow-Credentials
 slug: Web/HTTP/Headers/Access-Control-Allow-Credentials
-tags:
-  - Access-Control-Allow-Credencials
-  - CORS
-  - HTTP
-  - Referencia
-  - credenciales
-  - encabezado
-translation_of: Web/HTTP/Headers/Access-Control-Allow-Credentials
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/access-control-allow-headers/index.md
+++ b/files/es/web/http/headers/access-control-allow-headers/index.md
@@ -1,12 +1,6 @@
 ---
 title: Access-Control-Allow-Headers
 slug: Web/HTTP/Headers/Access-Control-Allow-Headers
-tags:
-  - CORS
-  - encabezado
-  - encabezado HTTP
-  - header
-translation_of: Web/HTTP/Headers/Access-Control-Allow-Headers
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/access-control-allow-methods/index.md
+++ b/files/es/web/http/headers/access-control-allow-methods/index.md
@@ -1,7 +1,6 @@
 ---
 title: Access-Control-Allow-Methods
 slug: Web/HTTP/Headers/Access-Control-Allow-Methods
-translation_of: Web/HTTP/Headers/Access-Control-Allow-Methods
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/access-control-allow-origin/index.md
+++ b/files/es/web/http/headers/access-control-allow-origin/index.md
@@ -1,18 +1,6 @@
 ---
 title: Access-Control-Allow-Origin
 slug: Web/HTTP/Headers/Access-Control-Allow-Origin
-tags:
-  - Access Control
-  - Access-Control-Allow-Origin
-  - CORS
-  - HTTP
-  - Lidiando con CORS
-  - Origen
-  - Referencia
-  - Seguridad
-  - encabezado HTTP
-  - error cross-origin
-translation_of: Web/HTTP/Headers/Access-Control-Allow-Origin
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/access-control-expose-headers/index.md
+++ b/files/es/web/http/headers/access-control-expose-headers/index.md
@@ -1,11 +1,6 @@
 ---
 title: Access-Control-Expose-Headers
 slug: Web/HTTP/Headers/Access-Control-Expose-Headers
-tags:
-  - CORS
-  - Cabecera
-  - HTTP
-translation_of: Web/HTTP/Headers/Access-Control-Expose-Headers
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/age/index.md
+++ b/files/es/web/http/headers/age/index.md
@@ -1,9 +1,6 @@
 ---
 title: Age
 slug: Web/HTTP/Headers/Age
-tags:
-  - Encabezado HTTP Age
-translation_of: Web/HTTP/Headers/Age
 ---
 
 El encabezado **`Age`** contiene el tiempo medido en segundos que el objeto ha estado en la memoria caché de servidor proxy.El encabezado **`Age`** suele estar seteado en 0 (cero). Si **`Age : 0`** probablemente en ese instante se acaba de obtener la respuesta del servidor de origen, de lo contrario, por lo general esto se calcula como la diferencia entre la fecha actual del proxy y la fecha dada por el parámetro en cabecera "Date" ({{HTTPHeader("Date")}} ) incluído en la respuesta HTTP.

--- a/files/es/web/http/headers/allow/index.md
+++ b/files/es/web/http/headers/allow/index.md
@@ -1,7 +1,6 @@
 ---
 title: Allow
 slug: Web/HTTP/Headers/Allow
-translation_of: Web/HTTP/Headers/Allow
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/authorization/index.md
+++ b/files/es/web/http/headers/authorization/index.md
@@ -1,7 +1,6 @@
 ---
 title: Authorization
 slug: Web/HTTP/Headers/Authorization
-translation_of: Web/HTTP/Headers/Authorization
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/cache-control/index.md
+++ b/files/es/web/http/headers/cache-control/index.md
@@ -1,8 +1,6 @@
 ---
 title: Cache-Control
 slug: Web/HTTP/Headers/Cache-Control
-browser-compat: http.headers.Cache-Control
-translation_of: Web/HTTP/Headers/Cache-Control
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/content-disposition/index.md
+++ b/files/es/web/http/headers/content-disposition/index.md
@@ -1,7 +1,6 @@
 ---
 title: Content-Disposition
 slug: Web/HTTP/Headers/Content-Disposition
-translation_of: Web/HTTP/Headers/Content-Disposition
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/content-encoding/index.md
+++ b/files/es/web/http/headers/content-encoding/index.md
@@ -1,10 +1,6 @@
 ---
 title: Content-Encoding
 slug: Web/HTTP/Headers/Content-Encoding
-tags:
-  - Cabecera
-  - Referencia
-translation_of: Web/HTTP/Headers/Content-Encoding
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/content-length/index.md
+++ b/files/es/web/http/headers/content-length/index.md
@@ -1,7 +1,6 @@
 ---
 title: Content-Length
 slug: Web/HTTP/Headers/Content-Length
-translation_of: Web/HTTP/Headers/Content-Length
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/content-location/index.md
+++ b/files/es/web/http/headers/content-location/index.md
@@ -1,7 +1,6 @@
 ---
 title: Content-Location
 slug: Web/HTTP/Headers/Content-Location
-translation_of: Web/HTTP/Headers/Content-Location
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/content-security-policy/index.md
+++ b/files/es/web/http/headers/content-security-policy/index.md
@@ -1,12 +1,6 @@
 ---
 title: Content-Security-Policy
 slug: Web/HTTP/Headers/Content-Security-Policy
-tags:
-  - CSP
-  - HTTP
-  - Reference
-  - header
-translation_of: Web/HTTP/Headers/Content-Security-Policy
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/content-type/index.md
+++ b/files/es/web/http/headers/content-type/index.md
@@ -1,7 +1,6 @@
 ---
 title: Content-Type
 slug: Web/HTTP/Headers/Content-Type
-translation_of: Web/HTTP/Headers/Content-Type
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/cookie/index.md
+++ b/files/es/web/http/headers/cookie/index.md
@@ -1,11 +1,6 @@
 ---
 title: Cookie
 slug: Web/HTTP/Headers/Cookie
-tags:
-  - Cookies
-  - encabezado
-  - solicitud
-translation_of: Web/HTTP/Headers/Cookie
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/cross-origin-resource-policy/index.md
+++ b/files/es/web/http/headers/cross-origin-resource-policy/index.md
@@ -1,13 +1,6 @@
 ---
 title: Cross-Origin-Resource-Policy
 slug: Web/HTTP/Headers/Cross-Origin-Resource-Policy
-tags:
-  - HTTP
-  - Referencia
-  - Respuesta de encabezado
-  - encabezado
-  - encabezado HTTP
-translation_of: Web/HTTP/Headers/Cross-Origin-Resource-Policy
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/digest/index.md
+++ b/files/es/web/http/headers/digest/index.md
@@ -1,14 +1,6 @@
 ---
 title: SubtleCrypto.digest()
 slug: Web/HTTP/Headers/Digest
-tags:
-  - API
-  - Encriptación
-  - Referencia
-  - SubtleCrypto
-  - Web Crypto API
-  - encrypt
-translation_of: Web/HTTP/Headers/Digest
 original_slug: Web/API/SubtleCrypto/encrypt
 ---
 

--- a/files/es/web/http/headers/etag/index.md
+++ b/files/es/web/http/headers/etag/index.md
@@ -1,7 +1,6 @@
 ---
 title: ETag
 slug: Web/HTTP/Headers/ETag
-translation_of: Web/HTTP/Headers/ETag
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/expires/index.md
+++ b/files/es/web/http/headers/expires/index.md
@@ -1,13 +1,6 @@
 ---
 title: Expires
 slug: Web/HTTP/Headers/Expires
-tags:
-  - Cache
-  - Expires
-  - HTTP
-  - Respuesta
-  - encabezado
-translation_of: Web/HTTP/Headers/Expires
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/host/index.md
+++ b/files/es/web/http/headers/host/index.md
@@ -1,11 +1,6 @@
 ---
 title: Host
 slug: Web/HTTP/Headers/Host
-tags:
-  - Cabecera
-  - HTTP
-  - Referencia
-translation_of: Web/HTTP/Headers/Host
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/index.md
+++ b/files/es/web/http/headers/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTTP headers
 slug: Web/HTTP/Headers
-tags:
-  - HTTP
-  - Headers
-  - Networking
-  - Reference
-  - TopicStub
-translation_of: Web/HTTP/Headers
 ---
 
 {{HTTPSidebar}}Las cabeceras (en inglés _headers_) HTTP permiten al cliente y al servidor enviar información adicional junto a una petición o respuesta. Una cabecera de petición esta compuesta por su nombre (no sensible a las mayusculas) seguido de dos puntos '`:`', y a continuación su valor (sin saltos de línea). Los espacios en blanco a la izquierda del valor son ignoradosSe pueden agregar cabeceras propietarias personalizadas usando el prefijo 'X-', pero esta convención se encuentra desfasada desde Julio de 2012, debido a los inconvenientes causados cuando se estandarizaron campos no estandar en el [RFC 6648](https://tools.ietf.org/html/rfc6648); otras están listadas en un [registro IANA](http://www.iana.org/assignments/message-headers/perm-headers.html), cuyo contenido original fue definido en el [RFC 4229](http://tools.ietf.org/html/rfc4229), IANA tambien mantiene un [registro de propuestas para nuevas cabeceras HTTP](http://www.iana.org/assignments/message-headers/prov-headers.html)

--- a/files/es/web/http/headers/keep-alive/index.md
+++ b/files/es/web/http/headers/keep-alive/index.md
@@ -1,12 +1,6 @@
 ---
 title: Keep-Alive
 slug: Web/HTTP/Headers/Keep-Alive
-tags:
-  - HTTP
-  - encabezado
-  - header
-  - keep-alive
-translation_of: Web/HTTP/Headers/Keep-Alive
 ---
 
 {{HTTPSidebar}}{{Non-standard_header}}

--- a/files/es/web/http/headers/link/index.md
+++ b/files/es/web/http/headers/link/index.md
@@ -1,13 +1,6 @@
 ---
 title: Link
 slug: Web/HTTP/Headers/Link
-tags:
-  - Enlaces
-  - HTTP
-  - HTTP Headers
-  - Links
-  - Referencia
-translation_of: Web/HTTP/Headers/Link
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/origin/index.md
+++ b/files/es/web/http/headers/origin/index.md
@@ -1,13 +1,6 @@
 ---
 title: Origin
 slug: Web/HTTP/Headers/Origin
-tags:
-  - Cabecera
-  - HTTP
-  - Petición del encabezado
-  - Referencia
-  - origin
-translation_of: Web/HTTP/Headers/Origin
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/pragma/index.md
+++ b/files/es/web/http/headers/pragma/index.md
@@ -1,7 +1,6 @@
 ---
 title: Pragma
 slug: Web/HTTP/Headers/Pragma
-translation_of: Web/HTTP/Headers/Pragma
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/referer/index.md
+++ b/files/es/web/http/headers/referer/index.md
@@ -1,11 +1,6 @@
 ---
 title: Referer
 slug: Web/HTTP/Headers/Referer
-tags:
-  - Cabecera
-  - HTTP
-  - Referencia
-translation_of: Web/HTTP/Headers/Referer
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/referrer-policy/index.md
+++ b/files/es/web/http/headers/referrer-policy/index.md
@@ -1,12 +1,6 @@
 ---
 title: Referrer-Policy
 slug: Web/HTTP/Headers/Referrer-Policy
-tags:
-  - Cabecera
-  - HTTP
-  - Respuesta
-  - privacidad
-translation_of: Web/HTTP/Headers/Referrer-Policy
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/server/index.md
+++ b/files/es/web/http/headers/server/index.md
@@ -1,7 +1,6 @@
 ---
 title: Server
 slug: Web/HTTP/Headers/Server
-translation_of: Web/HTTP/Headers/Server
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/set-cookie/index.md
+++ b/files/es/web/http/headers/set-cookie/index.md
@@ -1,14 +1,6 @@
 ---
 title: Set-Cookie
 slug: Web/HTTP/Headers/Set-Cookie
-tags:
-  - Cookies
-  - HTTP
-  - Referencia
-  - Respuesta
-  - encabezado
-  - samesite
-translation_of: Web/HTTP/Headers/Set-Cookie
 ---
 
 {{HTTPSidebar}}La cabecera de respuesta HTTP **Set-Cookie** se usa para enviar cookies desde el servidor al agente de usuario, así el agente de usuario puede enviarlos de vuelta al servidor.Para más información, visite la [guía para cookies HTTP](/es/docs/Web/HTTP/Cookies).

--- a/files/es/web/http/headers/strict-transport-security/index.md
+++ b/files/es/web/http/headers/strict-transport-security/index.md
@@ -1,7 +1,6 @@
 ---
 title: Strict-Transport-Security
 slug: Web/HTTP/Headers/Strict-Transport-Security
-translation_of: Web/HTTP/Headers/Strict-Transport-Security
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/transfer-encoding/index.md
+++ b/files/es/web/http/headers/transfer-encoding/index.md
@@ -1,14 +1,6 @@
 ---
 title: Transfer-Encoding
 slug: Web/HTTP/Headers/Transfer-Encoding
-tags:
-  - Castellano Transfer encoding
-  - HTTP Header
-  - Métodos HTTP
-  - Referências
-  - header
-  - transfer encoding español
-translation_of: Web/HTTP/Headers/Transfer-Encoding
 ---
 
 El encabezado Transfer-Encoding especifica la forma de codificación utilizada para transferir de forma segura el {{Glossary("Payload body", "cuerpo del payload")}} al usuario.

--- a/files/es/web/http/headers/user-agent/firefox/index.md
+++ b/files/es/web/http/headers/user-agent/firefox/index.md
@@ -1,10 +1,6 @@
 ---
 title: Cadenas del User Agent de Gecko
 slug: Web/HTTP/Headers/User-Agent/Firefox
-tags:
-  - Desarrollo_Web
-  - Todas_las_Categorías
-translation_of: Web/HTTP/Headers/User-Agent/Firefox
 original_slug: Cadenas_del_User_Agent_de_Gecko
 ---
 

--- a/files/es/web/http/headers/user-agent/index.md
+++ b/files/es/web/http/headers/user-agent/index.md
@@ -1,8 +1,6 @@
 ---
 title: User-Agent
 slug: Web/HTTP/Headers/User-Agent
-translation_of: Web/HTTP/Headers/User-Agent
-browser-compat: http.headers.User-Agent
 l10n:
   sourceCommit: 281e3b21178946c8301232a8eb50d11770ee8450
 ---

--- a/files/es/web/http/headers/vary/index.md
+++ b/files/es/web/http/headers/vary/index.md
@@ -1,7 +1,6 @@
 ---
 title: Vary
 slug: Web/HTTP/Headers/Vary
-translation_of: Web/HTTP/Headers/Vary
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/www-authenticate/index.md
+++ b/files/es/web/http/headers/www-authenticate/index.md
@@ -1,7 +1,6 @@
 ---
 title: WWW-Authenticate
 slug: Web/HTTP/Headers/WWW-Authenticate
-translation_of: Web/HTTP/Headers/WWW-Authenticate
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/x-content-type-options/index.md
+++ b/files/es/web/http/headers/x-content-type-options/index.md
@@ -1,12 +1,6 @@
 ---
 title: X-Content-Type-Options
 slug: Web/HTTP/Headers/X-Content-Type-Options
-tags:
-  - Encabezado de respuesta
-  - Encabezados HTTP
-  - HTTP
-  - Referencia
-translation_of: Web/HTTP/Headers/X-Content-Type-Options
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/x-forwarded-for/index.md
+++ b/files/es/web/http/headers/x-forwarded-for/index.md
@@ -1,7 +1,6 @@
 ---
 title: X-Forwarded-For
 slug: Web/HTTP/Headers/X-Forwarded-For
-translation_of: Web/HTTP/Headers/X-Forwarded-For
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/x-frame-options/index.md
+++ b/files/es/web/http/headers/x-frame-options/index.md
@@ -1,15 +1,6 @@
 ---
 title: X-Frame-Options
 slug: Web/HTTP/Headers/X-Frame-Options
-translation_of: Web/HTTP/Headers/X-Frame-Options
-tags:
-  - Gecko
-  - HAProxy
-  - HTTP
-  - Response Header
-  - Security
-  - nginx
-browser-compat: http.headers.X-Frame-Options
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/headers/x-xss-protection/index.md
+++ b/files/es/web/http/headers/x-xss-protection/index.md
@@ -1,13 +1,6 @@
 ---
 title: X-XSS-Protection
 slug: Web/HTTP/Headers/X-XSS-Protection
-tags:
-  - HTTP
-  - Referencia
-  - Seguridad
-  - XSS
-  - encabezado
-translation_of: Web/HTTP/Headers/X-XSS-Protection
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/index.md
+++ b/files/es/web/http/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTTP
 slug: Web/HTTP
-tags:
-  - HTTP
-  - Hypertext
-  - Reference
-  - TCP/IP
-  - Web
-  - Web Development
-  - "l10n:priority"
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/messages/index.md
+++ b/files/es/web/http/messages/index.md
@@ -1,7 +1,6 @@
 ---
 title: Mensajes HTTP
 slug: Web/HTTP/Messages
-translation_of: Web/HTTP/Messages
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/methods/connect/index.md
+++ b/files/es/web/http/methods/connect/index.md
@@ -1,10 +1,6 @@
 ---
 title: CONNECT
 slug: Web/HTTP/Methods/CONNECT
-tags:
-  - HTTP
-  - Método de petición
-translation_of: Web/HTTP/Methods/CONNECT
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/methods/get/index.md
+++ b/files/es/web/http/methods/get/index.md
@@ -1,7 +1,6 @@
 ---
 title: GET
 slug: Web/HTTP/Methods/GET
-translation_of: Web/HTTP/Methods/GET
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/methods/index.md
+++ b/files/es/web/http/methods/index.md
@@ -1,7 +1,6 @@
 ---
 title: Métodos de petición HTTP
 slug: Web/HTTP/Methods
-translation_of: Web/HTTP/Methods
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/methods/patch/index.md
+++ b/files/es/web/http/methods/patch/index.md
@@ -1,12 +1,6 @@
 ---
 title: PATCH
 slug: Web/HTTP/Methods/PATCH
-tags:
-  - HTTP
-  - Método HTTP
-  - Referencia
-  - Request method
-translation_of: Web/HTTP/Methods/PATCH
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/methods/post/index.md
+++ b/files/es/web/http/methods/post/index.md
@@ -1,11 +1,6 @@
 ---
 title: POST
 slug: Web/HTTP/Methods/POST
-tags:
-  - HTTP
-  - Metodo de pedido
-  - Referencia
-translation_of: Web/HTTP/Methods/POST
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/methods/put/index.md
+++ b/files/es/web/http/methods/put/index.md
@@ -1,11 +1,6 @@
 ---
 title: PUT
 slug: Web/HTTP/Methods/PUT
-tags:
-  - HTTP
-  - Método HTTP
-  - Petición
-translation_of: Web/HTTP/Methods/PUT
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/methods/trace/index.md
+++ b/files/es/web/http/methods/trace/index.md
@@ -1,7 +1,6 @@
 ---
 title: TRACE
 slug: Web/HTTP/Methods/TRACE
-translation_of: Web/HTTP/Methods/TRACE
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/overview/index.md
+++ b/files/es/web/http/overview/index.md
@@ -1,12 +1,6 @@
 ---
 title: Generalidades del protocolo HTTP
 slug: Web/HTTP/Overview
-tags:
-  - HTML
-  - HTTP
-  - Mecánica Web
-  - Visión general
-translation_of: Web/HTTP/Overview
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/protocol_upgrade_mechanism/index.md
+++ b/files/es/web/http/protocol_upgrade_mechanism/index.md
@@ -1,7 +1,6 @@
 ---
 title: Mecanismo de actualización del protocolo
 slug: Web/HTTP/Protocol_upgrade_mechanism
-translation_of: Web/HTTP/Protocol_upgrade_mechanism
 original_slug: Web/HTTP/mecanismo_actualizacion_protocolo
 ---
 

--- a/files/es/web/http/resources_and_specifications/index.md
+++ b/files/es/web/http/resources_and_specifications/index.md
@@ -1,7 +1,6 @@
 ---
 title: Recursos y especificaciones de HTTP
 slug: Web/HTTP/Resources_and_specifications
-translation_of: Web/HTTP/Resources_and_specifications
 original_slug: Web/HTTP/recursos_y_especificaciones
 ---
 

--- a/files/es/web/http/session/index.md
+++ b/files/es/web/http/session/index.md
@@ -1,7 +1,6 @@
 ---
 title: Una típica sesión de HTTP
 slug: Web/HTTP/Session
-translation_of: Web/HTTP/Session
 original_slug: Web/HTTP/Sesión
 ---
 

--- a/files/es/web/http/status/100/index.md
+++ b/files/es/web/http/status/100/index.md
@@ -1,12 +1,6 @@
 ---
 title: 100 Continue
 slug: Web/HTTP/Status/100
-tags:
-  - Códigos de estado
-  - HTTP
-  - Informativa
-  - continue
-translation_of: Web/HTTP/Status/100
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/status/101/index.md
+++ b/files/es/web/http/status/101/index.md
@@ -1,15 +1,6 @@
 ---
 title: 101 Switching Protocols
 slug: Web/HTTP/Status/101
-tags:
-  - Códigos de estado
-  - Estados
-  - HTTP
-  - HTTP Status Code
-  - Información
-  - Referencia
-  - WebSockets
-translation_of: Web/HTTP/Status/101
 ---
 
 {{HTTPSidebar}}El código de respuesta **`101 Switching Protocols`** que el servidor está cambiando de protocolo al solicitado por un cliente que mandó un mensaje incluyendo la cabecera {{HTTPHeader("Upgrade")}}.

--- a/files/es/web/http/status/200/index.md
+++ b/files/es/web/http/status/200/index.md
@@ -1,11 +1,6 @@
 ---
 title: 200 OK
 slug: Web/HTTP/Status/200
-tags:
-  - Codigo de Estado
-  - HTTP
-  - Éxito
-translation_of: Web/HTTP/Status/200
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/status/201/index.md
+++ b/files/es/web/http/status/201/index.md
@@ -1,7 +1,6 @@
 ---
 title: 201 Created
 slug: Web/HTTP/Status/201
-translation_of: Web/HTTP/Status/201
 ---
 
 El código de respuesta de estado de éxito creado HTTP **`201 Created`** indica que la solicitud ha tenido éxito y ha llevado a la creación de un recurso. El nuevo recurso se crea efectivamente antes de enviar esta respuesta. y el nuevo recurso se devuelve en el cuerpo del mensaje, su ubicación es la URL de la solicitud o el contenido del encabezado de la Ubicacion

--- a/files/es/web/http/status/202/index.md
+++ b/files/es/web/http/status/202/index.md
@@ -1,12 +1,6 @@
 ---
 title: 202 Aceptado
 slug: Web/HTTP/Status/202
-tags:
-  - Codigo de Estado
-  - HTTP
-  - Referencia
-  - Respuesta satisfactoria
-translation_of: Web/HTTP/Status/202
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/status/203/index.md
+++ b/files/es/web/http/status/203/index.md
@@ -1,13 +1,6 @@
 ---
 title: 203 Non-Authoritative Information
 slug: Web/HTTP/Status/203
-tags:
-  - Códigos de respuesta
-  - Códigos de respuestas HTTP
-  - HTTP
-  - Referências
-  - Respuesta satisfactoria
-translation_of: Web/HTTP/Status/203
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/status/206/index.md
+++ b/files/es/web/http/status/206/index.md
@@ -1,7 +1,6 @@
 ---
 title: 206 Partial Content
 slug: Web/HTTP/Status/206
-translation_of: Web/HTTP/Status/206
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/status/302/index.md
+++ b/files/es/web/http/status/302/index.md
@@ -1,12 +1,6 @@
 ---
 title: 302 Found
 slug: Web/HTTP/Status/302
-tags:
-  - Códigos de estado
-  - HTTP
-  - Referencia
-  - redirecciones
-translation_of: Web/HTTP/Status/302
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/status/304/index.md
+++ b/files/es/web/http/status/304/index.md
@@ -1,7 +1,6 @@
 ---
 title: 304 Not Modified
 slug: Web/HTTP/Status/304
-translation_of: Web/HTTP/Status/304
 ---
 
 El código HTTP de redirección **`304 Not Modified`** en el response de la petición indica que no hay necesidad de retransmitir los recursos solicitados. Es una redirección implícita a un elemento/recurso de caché.Esto sucede cuando el método de la solicitud es {{glossary("seguro")}} ({{glossary("safe")}}), como en el las peticiones con métodos {{HTTPMethod("GET")}} o {{HTTPMethod("HEAD")}}, o cuando el request (petición) está condicionada y usa la cabecera {{HTTPHeader("If-None-Match")}} o un {{HTTPHeader("If-Modified-Since")}}El response {{HTTPStatus("200")}} `OK` habría incluido los encabezados {{HTTPHeader("Cache-Control")}}, {{HTTPHeader("Content-Location")}}, {{HTTPHeader("Date")}}, {{HTTPHeader("ETag")}}, {{HTTPHeader("Expires")}}, y {{HTTPHeader("Vary")}}.

--- a/files/es/web/http/status/400/index.md
+++ b/files/es/web/http/status/400/index.md
@@ -1,12 +1,6 @@
 ---
 title: 400 Petición mala
 slug: Web/HTTP/Status/400
-tags:
-  - Codigo de Estado
-  - Error del cliente
-  - HTTP
-  - Referencia
-translation_of: Web/HTTP/Status/400
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/status/401/index.md
+++ b/files/es/web/http/status/401/index.md
@@ -1,7 +1,6 @@
 ---
 title: 401 Unauthorized
 slug: Web/HTTP/Status/401
-translation_of: Web/HTTP/Status/401
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/status/403/index.md
+++ b/files/es/web/http/status/403/index.md
@@ -1,13 +1,6 @@
 ---
 title: 403 Forbidden
 slug: Web/HTTP/Status/403
-translation_of: Web/HTTP/Status/403
-tags:
-  - Client error
-  - HTTP
-  - Reference
-  - Status code
-browser-compat: http.status.403
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/status/404/index.md
+++ b/files/es/web/http/status/404/index.md
@@ -1,11 +1,6 @@
 ---
 title: 404 Not Found
 slug: Web/HTTP/Status/404
-tags:
-  - Codigo de Estado
-  - Error de Cliente
-  - HTTP
-translation_of: Web/HTTP/Status/404
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/status/408/index.md
+++ b/files/es/web/http/status/408/index.md
@@ -1,7 +1,6 @@
 ---
 title: 408 Request Timeout
 slug: Web/HTTP/Status/408
-translation_of: Web/HTTP/Status/408
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/status/413/index.md
+++ b/files/es/web/http/status/413/index.md
@@ -1,7 +1,6 @@
 ---
 title: 413 Payload Too Large
 slug: Web/HTTP/Status/413
-translation_of: Web/HTTP/Status/413
 original_slug: Web/HTTP/Status/8080
 ---
 

--- a/files/es/web/http/status/418/index.md
+++ b/files/es/web/http/status/418/index.md
@@ -1,12 +1,6 @@
 ---
 title: 418 Soy una tetera
 slug: Web/HTTP/Status/418
-tags:
-  - HTTP
-  - HTTP Status Code
-  - Protocolo HTTP
-  - Referencia
-translation_of: Web/HTTP/Status/418
 ---
 
 El código de error HTTP **`418 Soy una tetera`** indica que el servidor se rehusa a preparar café porque es una tetera. Este error es una referencia al Hyper Text Coffee Pot Control Protocol, creado como parte de una broma del April Fools' de 1998.

--- a/files/es/web/http/status/500/index.md
+++ b/files/es/web/http/status/500/index.md
@@ -1,11 +1,6 @@
 ---
 title: 500 Error Interno del Servidor
 slug: Web/HTTP/Status/500
-tags:
-  - Codigo de Estado
-  - Error del servidor
-  - HTTP
-translation_of: Web/HTTP/Status/500
 ---
 
 El código de respuesta **`500 Error Interno del Servidor`** del Protocolo de Transferencia de Hipertexto (HTTP) indica que el servidor encontró una condición inesperada que le impide completar la petición.

--- a/files/es/web/http/status/502/index.md
+++ b/files/es/web/http/status/502/index.md
@@ -1,11 +1,6 @@
 ---
 title: 502 Puerta de enlace no válida
 slug: Web/HTTP/Status/502
-tags:
-  - Codigo de Estado
-  - Error de servidor
-  - HTTP
-translation_of: Web/HTTP/Status/502
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/status/503/index.md
+++ b/files/es/web/http/status/503/index.md
@@ -1,12 +1,6 @@
 ---
 title: 503 Servicio No Disponible
 slug: Web/HTTP/Status/503
-tags:
-  - Codigo de Estado
-  - Error de servidor
-  - HTTP
-  - error 503
-translation_of: Web/HTTP/Status/503
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/status/504/index.md
+++ b/files/es/web/http/status/504/index.md
@@ -1,7 +1,6 @@
 ---
 title: 504 Gateway Timeout
 slug: Web/HTTP/Status/504
-translation_of: Web/HTTP/Status/504
 ---
 
 El código de respuesta de error del servidor de HTTP **`504 Gateway Timeout`** indica que el servidor, mientras actuaba como una puerta de enlace o proxy, no pudo obtener una respuesta a tiempo.

--- a/files/es/web/http/status/505/index.md
+++ b/files/es/web/http/status/505/index.md
@@ -1,7 +1,6 @@
 ---
 title: 505 HTTP Version Not Supported
 slug: Web/HTTP/Status/505
-translation_of: Web/HTTP/Status/505
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/http/status/index.md
+++ b/files/es/web/http/status/index.md
@@ -1,12 +1,6 @@
 ---
 title: Códigos de estado de respuesta HTTP
 slug: Web/HTTP/Status
-tags:
-  - Códigos de estado
-  - HTTP
-  - NeedsTranslation
-  - TopicStub
-translation_of: Web/HTTP/Status
 ---
 
 {{HTTPSidebar}}

--- a/files/es/web/manifest/index.md
+++ b/files/es/web/manifest/index.md
@@ -1,7 +1,6 @@
 ---
 title: Web App Manifest
 slug: Web/Manifest
-translation_of: Web/Manifest
 ---
 
 El manifiesto de aplicaciones web proporciona información sobre una aplicación (como nombre, autor, icono y descripción) en un documento simplificado. Su principal propósito es crear [progressive web apps](/es/docs/Web/Apps/Progressive): aplicaciones web que se pueden instalar desde la pantalla principal de un dispositivo sin necesidad de hacerlo a traves de una app store (y otras ventajas como disponibilidad offline y enviar notificaciones push cuando cambia el contenido de la aplicación.)

--- a/files/es/web/mathml/attribute/index.md
+++ b/files/es/web/mathml/attribute/index.md
@@ -1,7 +1,6 @@
 ---
 title: MathML attribute reference
 slug: Web/MathML/Attribute
-translation_of: Web/MathML/Attribute
 ---
 
 Esta es una lista alfabetica de atributos de MathML. Más detalles de cada atributo está disponible en cada [página de los elementos](/es/docs/MathML/Element).

--- a/files/es/web/mathml/element/index.md
+++ b/files/es/web/mathml/element/index.md
@@ -1,7 +1,6 @@
 ---
 title: Referencia de elementos de MathML
 slug: Web/MathML/Element
-translation_of: Web/MathML/Element
 original_slug: Web/MathML/Elemento
 ---
 

--- a/files/es/web/mathml/element/math/index.md
+++ b/files/es/web/mathml/element/math/index.md
@@ -1,7 +1,6 @@
 ---
 title: <math>
 slug: Web/MathML/Element/math
-translation_of: Web/MathML/Element/math
 original_slug: Web/MathML/Elemento/math
 ---
 

--- a/files/es/web/mathml/examples/index.md
+++ b/files/es/web/mathml/examples/index.md
@@ -1,11 +1,6 @@
 ---
 title: Examples
 slug: Web/MathML/Examples
-tags:
-  - MathML
-  - NeedsTranslation
-  - TopicStub
-translation_of: Web/MathML/Examples
 ---
 
 Below you'll find some examples you can look at to help you to understand how to use MathML to display increasingly complex mathematical concepts in Web content.

--- a/files/es/web/mathml/examples/mathml_pythagorean_theorem/index.md
+++ b/files/es/web/mathml/examples/mathml_pythagorean_theorem/index.md
@@ -1,7 +1,6 @@
 ---
 title: MathML Pythagorean Theorem
 slug: Web/MathML/Examples/MathML_Pythagorean_Theorem
-translation_of: Web/MathML/Examples/MathML_Pythagorean_Theorem
 ---
 
 <math><mrow><msup><mi>a</mi>

--- a/files/es/web/mathml/index.md
+++ b/files/es/web/mathml/index.md
@@ -1,7 +1,6 @@
 ---
 title: MathML
 slug: Web/MathML
-translation_of: Web/MathML
 ---
 
 **Lenguaje de Marcado Matemático (MathML)** es un lenguaje de marcado [XML](/es/docs/Introducción_a_XML) para describir expresiones matemáticas capturando tanto su contenido como su estructura.

--- a/files/es/web/media/dash_adaptive_streaming_for_html_5_video/index.md
+++ b/files/es/web/media/dash_adaptive_streaming_for_html_5_video/index.md
@@ -1,7 +1,6 @@
 ---
 title: Transmisión Adaptativa DASH para Video en HTML 5
 slug: Web/Media/DASH_Adaptive_Streaming_for_HTML_5_Video
-translation_of: Web/Media/DASH_Adaptive_Streaming_for_HTML_5_Video
 original_slug: Web/HTML/Transision_adaptativa_DASH
 ---
 

--- a/files/es/web/media/index.md
+++ b/files/es/web/media/index.md
@@ -1,15 +1,6 @@
 ---
 title: Web media technologies
 slug: Web/Media
-tags:
-  - Audio
-  - Landing
-  - Media
-  - NeedsTranslation
-  - TopicStub
-  - Video
-  - Web
-translation_of: Web/Media
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Media")}}

--- a/files/es/web/opensearch/index.md
+++ b/files/es/web/opensearch/index.md
@@ -1,14 +1,6 @@
 ---
 title: Creacion de plugins OpenSearch para Firefox
 slug: Web/OpenSearch
-tags:
-  - Agregados
-  - Complementos
-  - OpenSearch
-  - Plugins
-  - Plugins_de_búsqueda
-  - para_revisar
-translation_of: Web/OpenSearch
 original_slug: Creacion_de_plugins_OpenSearch_para_Firefox
 ---
 

--- a/files/es/web/performance/fundamentals/index.md
+++ b/files/es/web/performance/fundamentals/index.md
@@ -1,7 +1,6 @@
 ---
 title: Performance fundamentals
 slug: Web/Performance/Fundamentals
-translation_of: Web/Performance/Fundamentals
 ---
 
 Performance significa eficiencia. En el contexto de Open Web Apps, este documento explica en general qué es performance, cómo la plataforma del navegador ayuda a mejorarlo y qué herramientas y procesos puede usar para probarlo y mejorarlo.

--- a/files/es/web/performance/index.md
+++ b/files/es/web/performance/index.md
@@ -1,12 +1,6 @@
 ---
 title: Rendimiento Web
 slug: Web/Performance
-tags:
-  - Mejores Practicas
-  - Pagina de Inicio
-  - Rendimiento
-  - Rendimiento Web
-translation_of: Web/Performance
 ---
 
 El rendimiento web es la medición objetiva y la experiencia percibida por el usuario del tiempo de carga y el tiempo de ejecución; es el tiempo que tarda un sitio en cargarse, ser interactivo y responsivo, y que tan fluido es el contenido durante las interacciones del usuario: ¿el desplazamiento es suave? ¿Se puede hacer clic en los botones? ¿Las ventanas emergentes se abren rápidamente y se animan fluidamente al hacerlo? El rendimiento web incluye mediciones objetivas como el tiempo de carga, cuadros por segundo y tiempo para interactuar y subjetivas de cuánto tiempo se sintió que tardó en cargarse el contenido.

--- a/files/es/web/performance/optimizing_startup_performance/index.md
+++ b/files/es/web/performance/optimizing_startup_performance/index.md
@@ -1,11 +1,6 @@
 ---
 title: Mejorando el Rendimiento Inicial
 slug: Web/Performance/Optimizing_startup_performance
-tags:
-  - Apps
-  - Performance
-  - Rendimiento
-translation_of: Web/Performance/Optimizing_startup_performance
 original_slug: Web/Performance/mejorando_rendimienot_inicial
 ---
 

--- a/files/es/web/security/index.md
+++ b/files/es/web/security/index.md
@@ -1,12 +1,6 @@
 ---
 title: Seguridad Web
 slug: Web/Security
-tags:
-  - Landing
-  - NeedsTranslation
-  - Security
-  - TopicStub
-translation_of: Web/Security
 ---
 
 Asegurarse de que su sitio o aplicación web es segura es fundamental. Incluso un simple error en tu código puede dar como resultado que tu información privada sea filtrada y gente mala está ahí fuera intentando encontrar la manera de robar datos. Estos artículos proporcionan información que puede ayudarle a asegurar tu sitio y su código de ataques y robo de información.

--- a/files/es/web/security/same-origin_policy/index.md
+++ b/files/es/web/security/same-origin_policy/index.md
@@ -1,13 +1,6 @@
 ---
 title: Política Same-origin
 slug: Web/Security/Same-origin_policy
-tags:
-  - CORS
-  - JavaScript
-  - Mismo-Origen
-  - Política Same-Origin
-  - Seguridad
-translation_of: Web/Security/Same-origin_policy
 original_slug: Web/Security/Same-origin_politica
 ---
 

--- a/files/es/web/security/securing_your_site/index.md
+++ b/files/es/web/security/securing_your_site/index.md
@@ -1,13 +1,6 @@
 ---
 title: Securing your site
 slug: Web/Security/Securing_your_site
-tags:
-  - HTTP
-  - NeedsTranslation
-  - Security
-  - TopicStub
-  - Web Development
-translation_of: Web/Security/Securing_your_site
 ---
 
 Hay varias cosas que puede hacer para ayudar a proteger su sitio. Este artículo ofrece varias sugerencias, así como enlaces a otros artículos que proveen más información útil.

--- a/files/es/web/security/securing_your_site/turning_off_form_autocompletion/index.md
+++ b/files/es/web/security/securing_your_site/turning_off_form_autocompletion/index.md
@@ -1,11 +1,6 @@
 ---
 title: ¿Cómo desactivar el autocompletado del formulario?
 slug: Web/Security/Securing_your_site/Turning_off_form_autocompletion
-tags:
-  - Desarrollo web
-  - Seguridad
-  - formulários
-translation_of: Web/Security/Securing_your_site/Turning_off_form_autocompletion
 original_slug: Web/Security/Securing_your_site/desactivar_autocompletado_formulario
 ---
 

--- a/files/es/web/svg/applying_svg_effects_to_html_content/index.md
+++ b/files/es/web/svg/applying_svg_effects_to_html_content/index.md
@@ -1,14 +1,6 @@
 ---
 title: Aplicación de efectos de SVG para el contenido HTML
 slug: Web/SVG/Applying_SVG_effects_to_HTML_content
-tags:
-  - CSS
-  - Firefox 3.5
-  - Firefox 4.0
-  - HTML
-  - HTML 5
-  - SVG
-  - XHTML
 original_slug: Applying_SVG_effects_to_HTML_content
 ---
 

--- a/files/es/web/svg/attribute/index.md
+++ b/files/es/web/svg/attribute/index.md
@@ -1,12 +1,6 @@
 ---
 title: Referencia atributos SVG
 slug: Web/SVG/Attribute
-tags:
-  - Atributo SVG
-  - Dibujo
-  - Gráficos vectoriales
-  - SVG
-translation_of: Web/SVG/Attribute
 ---
 
 {{SVGRef}}

--- a/files/es/web/svg/attribute/stop-color/index.md
+++ b/files/es/web/svg/attribute/stop-color/index.md
@@ -1,9 +1,6 @@
 ---
 title: stop-color
 slug: Web/SVG/Attribute/stop-color
-tags:
-  - Atributos SVG
-translation_of: Web/SVG/Attribute/stop-color
 ---
 
 « [SVG Attribute reference hom](/en/SVG/Attribute)e

--- a/files/es/web/svg/attribute/transform/index.md
+++ b/files/es/web/svg/attribute/transform/index.md
@@ -1,7 +1,6 @@
 ---
 title: transform
 slug: Web/SVG/Attribute/transform
-translation_of: Web/SVG/Attribute/transform
 ---
 
 « Indice de atributos SVG

--- a/files/es/web/svg/element/a/index.md
+++ b/files/es/web/svg/element/a/index.md
@@ -1,7 +1,6 @@
 ---
 title: <a>
 slug: Web/SVG/Element/a
-translation_of: Web/SVG/Element/a
 ---
 
 {{SVGRef}}

--- a/files/es/web/svg/element/animate/index.md
+++ b/files/es/web/svg/element/animate/index.md
@@ -1,7 +1,6 @@
 ---
 title: <animate>
 slug: Web/SVG/Element/animate
-translation_of: Web/SVG/Element/animate
 ---
 
 {{SVGRef}}El elemento `animate` de SVG se utiliza para animar un atributo o propiedad a través del tiempo. Normalmente se inserta dentro del elemento o referenciado con el atributo `href`.

--- a/files/es/web/svg/element/circle/index.md
+++ b/files/es/web/svg/element/circle/index.md
@@ -1,12 +1,6 @@
 ---
 title: circle
 slug: Web/SVG/Element/circle
-tags:
-  - Elemento
-  - Gráficos SVG
-  - Referencia
-  - SVG
-translation_of: Web/SVG/Element/circle
 ---
 
 {{SVGRef}}

--- a/files/es/web/svg/element/g/index.md
+++ b/files/es/web/svg/element/g/index.md
@@ -1,13 +1,6 @@
 ---
 title: g
 slug: Web/SVG/Element/g
-tags:
-  - Contenedor
-  - Contenedor SVG
-  - Elemento
-  - Referencia
-  - SVG
-translation_of: Web/SVG/Element/g
 ---
 
 {{SVGRef}}El elemento `g` es un contenedor usado para agrupar objetos. Las transformaciones aplicadas al elemento `g` son realizadas sobre todos los elementos hijos del mismo. Los atributos aplicados son heredados por los elementos hijos. Además, puede ser usado para definir objetos complejos que pueden luego ser referenciados con el elemento {{SVGElement("use")}}.

--- a/files/es/web/svg/element/glyph/index.md
+++ b/files/es/web/svg/element/glyph/index.md
@@ -1,15 +1,6 @@
 ---
 title: glyph
 slug: Web/SVG/Element/glyph
-tags:
-  - Contenido de texto SVG
-  - Elemento
-  - Fuentes SVG
-  - Glifos
-  - NeedsCompatTable
-  - Referencia
-  - SVG
-translation_of: Web/SVG/Element/glyph
 original_slug: Web/SVG/Element/glifo
 ---
 

--- a/files/es/web/svg/element/index.md
+++ b/files/es/web/svg/element/index.md
@@ -1,12 +1,6 @@
 ---
 title: Referencia de Elementos SVG
 slug: Web/SVG/Element
-tags:
-  - NeedsTranslation
-  - SVG
-  - SVG Reference
-  - TopicStub
-translation_of: Web/SVG/Element
 ---
 
 « [SVG](/es/docs/SVG) / [SVG Attribute reference](/es/docs/SVG/Attribute) »

--- a/files/es/web/svg/element/rect/index.md
+++ b/files/es/web/svg/element/rect/index.md
@@ -1,12 +1,6 @@
 ---
 title: rect
 slug: Web/SVG/Element/rect
-tags:
-  - Elemento
-  - Gráficos SVG
-  - Referencia
-  - SVG
-translation_of: Web/SVG/Element/rect
 ---
 
 {{SVGRef}}

--- a/files/es/web/svg/element/script/index.md
+++ b/files/es/web/svg/element/script/index.md
@@ -1,15 +1,6 @@
 ---
 title: <script>
 slug: Web/SVG/Element/script
-tags:
-  - Elemento
-  - HTML
-  - HTML scripting
-  - Referencia
-  - Scripting
-  - Web
-  - etiqueta
-translation_of: Web/SVG/Element/script
 original_slug: Web/HTML/Elemento/script
 ---
 

--- a/files/es/web/svg/element/style/index.md
+++ b/files/es/web/svg/element/style/index.md
@@ -1,7 +1,6 @@
 ---
 title: style
 slug: Web/SVG/Element/style
-translation_of: Web/SVG/Element/style
 ---
 
 {{SVGRef}}

--- a/files/es/web/svg/element/svg/index.md
+++ b/files/es/web/svg/element/svg/index.md
@@ -1,13 +1,6 @@
 ---
 title: <svg>
 slug: Web/SVG/Element/svg
-tags:
-  - Contenedor SVG
-  - Elemento
-  - Referencia
-  - SVG
-  - red
-translation_of: Web/SVG/Element/svg
 ---
 
 El elemento `svg` es un contenedor que define un nuevo sistema de coordenadas y [viewport](/es/docs/Web/SVG/Attribute/viewBox). Es usado como el elemento más externo de cualquier documento SVG, pero también puede ser usado para agregar un fragmento de un SVG dentro de un documento SVG o HTML.

--- a/files/es/web/svg/element/text/index.md
+++ b/files/es/web/svg/element/text/index.md
@@ -1,7 +1,6 @@
 ---
 title: text
 slug: Web/SVG/Element/text
-translation_of: Web/SVG/Element/text
 ---
 
 {{SVGRef}}

--- a/files/es/web/svg/element/use/index.md
+++ b/files/es/web/svg/element/use/index.md
@@ -1,12 +1,6 @@
 ---
 title: <use>
 slug: Web/SVG/Element/use
-tags:
-  - Elementos
-  - Gráficos SVG
-  - Referencia
-  - SVG
-translation_of: Web/SVG/Element/use
 ---
 
 {{SVGRef}}

--- a/files/es/web/svg/element/view/index.md
+++ b/files/es/web/svg/element/view/index.md
@@ -1,14 +1,6 @@
 ---
 title: <view>
 slug: Web/SVG/Element/view
-tags:
-  - Element
-  - Elemento
-  - NeedsExample
-  - Referencia
-  - Reference
-  - SVG
-browser-compat: svg.elements.view
 ---
 
 {{SVGRef}}

--- a/files/es/web/svg/index.md
+++ b/files/es/web/svg/index.md
@@ -1,7 +1,6 @@
 ---
 title: SVG
 slug: Web/SVG
-translation_of: Web/SVG
 ---
 
 **[Comenzando con SVG](/es/docs/SVG/Tutorial)**

--- a/files/es/web/svg/tutorial/getting_started/index.md
+++ b/files/es/web/svg/tutorial/getting_started/index.md
@@ -1,7 +1,6 @@
 ---
 title: Getting Started
 slug: Web/SVG/Tutorial/Getting_Started
-translation_of: Web/SVG/Tutorial/Getting_Started
 ---
 
 {{ PreviousNext("SVG/Tutorial/Introduction", "SVG/Tutorial/Positions") }}

--- a/files/es/web/svg/tutorial/index.md
+++ b/files/es/web/svg/tutorial/index.md
@@ -1,16 +1,6 @@
 ---
 title: Tutorial de SVG
 slug: Web/SVG/Tutorial
-tags:
-  - Intermedio
-  - NeedsTranslation
-  - NesecitaActualizacion
-  - NesecitaAyuda
-  - NesecitaContenido
-  - SVG
-  - TopicStub
-  - Tutorial de SVG
-translation_of: Web/SVG/Tutorial
 ---
 
 Los graficos de vectores escalables, SVG , es un dialecto XML de W#C usado para describir graficos. Esta parcialente implementado en Firefox, Opera, WebKit , Internet Explorer y otros.

--- a/files/es/web/svg/tutorial/introduction/index.md
+++ b/files/es/web/svg/tutorial/introduction/index.md
@@ -1,7 +1,6 @@
 ---
 title: Introducción
 slug: Web/SVG/Tutorial/Introduction
-translation_of: Web/SVG/Tutorial/Introduction
 original_slug: Web/SVG/Tutorial/Introducción
 ---
 

--- a/files/es/web/svg/tutorial/tools_for_svg/index.md
+++ b/files/es/web/svg/tutorial/tools_for_svg/index.md
@@ -1,7 +1,6 @@
 ---
 title: Tools for SVG
 slug: Web/SVG/Tutorial/Tools_for_SVG
-translation_of: Web/SVG/Tutorial/Tools_for_SVG
 ---
 
 {{ PreviousNext("Web/SVG/Tutorial/SVG_Image_Tag") }}

--- a/files/es/web/tutorials/index.md
+++ b/files/es/web/tutorials/index.md
@@ -1,15 +1,6 @@
 ---
 title: Tutoriales
 slug: Web/Tutorials
-tags:
-  - Articulo Web
-  - Código
-  - Diseño Web
-  - Guía
-  - Principiante
-  - Programa Web
-  - Tutoriales
-translation_of: Web/Tutorials
 original_slug: Web/Tutoriales
 ---
 

--- a/files/es/web/web_components/index.md
+++ b/files/es/web/web_components/index.md
@@ -1,13 +1,6 @@
 ---
 title: Web Components
 slug: Web/Web_Components
-tags:
-  - Componentes
-  - Componentes Web
-  - Landing
-  - TopicStub
-  - Web Components
-translation_of: Web/Web_Components
 ---
 
 {{DefaultAPISidebar("Web Components")}}

--- a/files/es/web/web_components/using_custom_elements/index.md
+++ b/files/es/web/web_components/using_custom_elements/index.md
@@ -1,14 +1,6 @@
 ---
 title: Usando elementos personalizados
 slug: Web/Web_Components/Using_custom_elements
-tags:
-  - Autonomos
-  - Clases
-  - Guía
-  - HTML
-  - Preconstruidos
-  - elementos personalizados
-translation_of: Web/Web_Components/Using_custom_elements
 ---
 
 {{DefaultAPISidebar("Web Components")}}

--- a/files/es/web/web_components/using_shadow_dom/index.md
+++ b/files/es/web/web_components/using_shadow_dom/index.md
@@ -1,7 +1,6 @@
 ---
 title: Usando shadow DOM
 slug: Web/Web_Components/Using_shadow_DOM
-translation_of: Web/Web_Components/Using_shadow_DOM
 ---
 
 {{DefaultAPISidebar("Web Components")}}

--- a/files/es/web/web_components/using_templates_and_slots/index.md
+++ b/files/es/web/web_components/using_templates_and_slots/index.md
@@ -1,12 +1,6 @@
 ---
 title: Usando plantillas y slots
 slug: Web/Web_Components/Using_templates_and_slots
-tags:
-  - Componentes Web
-  - Template
-  - shadow dom
-  - slot
-translation_of: Web/Web_Components/Using_templates_and_slots
 ---
 
 {{DefaultAPISidebar("Web Components")}}

--- a/files/es/web/xml/index.md
+++ b/files/es/web/xml/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'XML: Extensible Markup Language'
 slug: Web/XML
-tags:
-  - Draft
-  - Landing
-  - NeedsTranslation
-  - TopicStub
-  - Web
-  - XML
-translation_of: Web/XML
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/XML")}}

--- a/files/es/web/xml/xml_introduction/index.md
+++ b/files/es/web/xml/xml_introduction/index.md
@@ -1,11 +1,6 @@
 ---
 title: Introducción a XML
 slug: Web/XML/XML_introduction
-tags:
-  - Principiante
-  - XML
-  - introducción
-translation_of: Web/XML/XML_introduction
 original_slug: Web/XML/Introducción_a_XML
 ---
 

--- a/files/es/web/xpath/axes/ancestor-or-self/index.md
+++ b/files/es/web/xpath/axes/ancestor-or-self/index.md
@@ -1,7 +1,6 @@
 ---
 title: ancestor-or-self
 slug: Web/XPath/Axes/ancestor-or-self
-translation_of: Web/XPath/Axes/ancestor-or-self
 original_slug: Web/XPath/Ejes/ancestor-or-self
 ---
 

--- a/files/es/web/xpath/axes/ancestor/index.md
+++ b/files/es/web/xpath/axes/ancestor/index.md
@@ -1,7 +1,6 @@
 ---
 title: ancestor
 slug: Web/XPath/Axes/ancestor
-translation_of: Web/XPath/Axes/ancestor
 original_slug: Web/XPath/Ejes/ancestor
 ---
 

--- a/files/es/web/xpath/axes/attribute/index.md
+++ b/files/es/web/xpath/axes/attribute/index.md
@@ -1,7 +1,6 @@
 ---
 title: attribute
 slug: Web/XPath/Axes/attribute
-translation_of: Web/XPath/Axes/attribute
 original_slug: Web/XPath/Ejes/attribute
 ---
 

--- a/files/es/web/xpath/axes/child/index.md
+++ b/files/es/web/xpath/axes/child/index.md
@@ -1,7 +1,6 @@
 ---
 title: child
 slug: Web/XPath/Axes/child
-translation_of: Web/XPath/Axes/child
 original_slug: Web/XPath/Ejes/child
 ---
 

--- a/files/es/web/xpath/axes/descendant-or-self/index.md
+++ b/files/es/web/xpath/axes/descendant-or-self/index.md
@@ -1,7 +1,6 @@
 ---
 title: descendant-or-self
 slug: Web/XPath/Axes/descendant-or-self
-translation_of: Web/XPath/Axes/descendant-or-self
 original_slug: Web/XPath/Ejes/descendant-or-self
 ---
 

--- a/files/es/web/xpath/axes/descendant/index.md
+++ b/files/es/web/xpath/axes/descendant/index.md
@@ -1,7 +1,6 @@
 ---
 title: descendant
 slug: Web/XPath/Axes/descendant
-translation_of: Web/XPath/Axes/descendant
 original_slug: Web/XPath/Ejes/descendant
 ---
 

--- a/files/es/web/xpath/axes/following-sibling/index.md
+++ b/files/es/web/xpath/axes/following-sibling/index.md
@@ -1,7 +1,6 @@
 ---
 title: following-sibling
 slug: Web/XPath/Axes/following-sibling
-translation_of: Web/XPath/Axes/following-sibling
 original_slug: Web/XPath/Ejes/following-sibling
 ---
 

--- a/files/es/web/xpath/axes/following/index.md
+++ b/files/es/web/xpath/axes/following/index.md
@@ -1,7 +1,6 @@
 ---
 title: following
 slug: Web/XPath/Axes/following
-translation_of: Web/XPath/Axes/following
 original_slug: Web/XPath/Ejes/following
 ---
 

--- a/files/es/web/xpath/axes/index.md
+++ b/files/es/web/xpath/axes/index.md
@@ -1,11 +1,6 @@
 ---
 title: Ejes
 slug: Web/XPath/Axes
-tags:
-  - Todas_las_Categorías
-  - XPath
-  - XSLT
-translation_of: Web/XPath/Axes
 original_slug: Web/XPath/Ejes
 ---
 

--- a/files/es/web/xpath/axes/namespace/index.md
+++ b/files/es/web/xpath/axes/namespace/index.md
@@ -1,7 +1,6 @@
 ---
 title: namespace
 slug: Web/XPath/Axes/namespace
-translation_of: Web/XPath/Axes/namespace
 original_slug: Web/XPath/Ejes/namespace
 ---
 

--- a/files/es/web/xpath/axes/parent/index.md
+++ b/files/es/web/xpath/axes/parent/index.md
@@ -1,7 +1,6 @@
 ---
 title: parent
 slug: Web/XPath/Axes/parent
-translation_of: Web/XPath/Axes/parent
 original_slug: Web/XPath/Ejes/parent
 ---
 

--- a/files/es/web/xpath/axes/preceding-sibling/index.md
+++ b/files/es/web/xpath/axes/preceding-sibling/index.md
@@ -1,7 +1,6 @@
 ---
 title: preceding-sibling
 slug: Web/XPath/Axes/preceding-sibling
-translation_of: Web/XPath/Axes/preceding-sibling
 original_slug: Web/XPath/Ejes/preceding-sibling
 ---
 

--- a/files/es/web/xpath/axes/preceding/index.md
+++ b/files/es/web/xpath/axes/preceding/index.md
@@ -1,7 +1,6 @@
 ---
 title: preceding
 slug: Web/XPath/Axes/preceding
-translation_of: Web/XPath/Axes/preceding
 original_slug: Web/XPath/Ejes/preceding
 ---
 

--- a/files/es/web/xpath/functions/contains/index.md
+++ b/files/es/web/xpath/functions/contains/index.md
@@ -1,7 +1,6 @@
 ---
 title: contains
 slug: Web/XPath/Functions/contains
-translation_of: Web/XPath/Functions/contains
 original_slug: Web/XPath/Funciones/contains
 ---
 

--- a/files/es/web/xpath/functions/index.md
+++ b/files/es/web/xpath/functions/index.md
@@ -1,13 +1,6 @@
 ---
 title: Funciones
 slug: Web/XPath/Functions
-tags:
-  - Referência_XPath
-  - Referência_XSLT
-  - Transformando_XML_con_XSLT
-  - XPath
-  - XSLT
-translation_of: Web/XPath/Functions
 original_slug: Web/XPath/Funciones
 ---
 

--- a/files/es/web/xpath/functions/substring/index.md
+++ b/files/es/web/xpath/functions/substring/index.md
@@ -1,7 +1,6 @@
 ---
 title: substring
 slug: Web/XPath/Functions/substring
-translation_of: Web/XPath/Functions/substring
 original_slug: Web/XPath/Funciones/substring
 ---
 

--- a/files/es/web/xpath/functions/true/index.md
+++ b/files/es/web/xpath/functions/true/index.md
@@ -1,10 +1,6 @@
 ---
 title: 'true'
 slug: Web/XPath/Functions/true
-tags:
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/XPath/Functions/true
 original_slug: Web/XPath/Funciones/true
 ---
 

--- a/files/es/web/xpath/index.md
+++ b/files/es/web/xpath/index.md
@@ -1,10 +1,6 @@
 ---
 title: XPath
 slug: Web/XPath
-tags:
-  - Todas_las_Categorías
-  - XPath
-translation_of: Web/XPath
 ---
 
 El **Lenguaje de Caminos XML**

--- a/files/es/web/xpath/introduction_to_using_xpath_in_javascript/index.md
+++ b/files/es/web/xpath/introduction_to_using_xpath_in_javascript/index.md
@@ -1,7 +1,6 @@
 ---
 title: Introducción al uso de XPath en Javascript
 slug: Web/XPath/Introduction_to_using_XPath_in_JavaScript
-translation_of: Web/XPath/Introduction_to_using_XPath_in_JavaScript
 original_slug: Web/JavaScript/Introduction_to_using_XPath_in_JavaScript
 ---
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove duplicated frontmatter keys from localized content

### Motivation

Remove innecesarry duplicated data

### Additional details

Folders: (http|svg|xpath|accessibility|guide|mathml|security|web_components|performance|xml|media|tutorials|opensearch|manifest|events)

```
{
  "translation_of": 183,
  "tags": 105,
  "browser-compat": 5
}
```

### Related issues and pull requests

Relates to #10129
Relates to #7412
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
