### PR TITLE
Remove duplicated frontmatter keys from web folder 3/10 [es]

### DIFF
--- a/files/es/web/api/analysernode/index.md
+++ b/files/es/web/api/analysernode/index.md
@@ -1,7 +1,6 @@
 ---
 title: AnalyserNode
 slug: Web/API/AnalyserNode
-translation_of: Web/API/AnalyserNode
 ---
 
 {{APIRef("Web Audio API")}}

--- a/files/es/web/api/animation/animation/index.md
+++ b/files/es/web/api/animation/animation/index.md
@@ -1,9 +1,6 @@
 ---
 title: Animation()
 slug: Web/API/Animation/Animation
-tags:
-  - Animacion
-translation_of: Web/API/Animation/Animation
 original_slug: Web/API/Animation/Animación
 ---
 

--- a/files/es/web/api/animation/cancel/index.md
+++ b/files/es/web/api/animation/cancel/index.md
@@ -1,16 +1,6 @@
 ---
 title: Animation.cancel()
 slug: Web/API/Animation/cancel
-tags:
-  - API
-  - Animacion
-  - Animaciones Web
-  - Experimental
-  - Reference
-  - cancel
-  - metodo
-  - waapi
-translation_of: Web/API/Animation/cancel
 ---
 
 {{ APIRef("Web Animations") }}

--- a/files/es/web/api/animation/cancel_event/index.md
+++ b/files/es/web/api/animation/cancel_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: Animation.oncancel
 slug: Web/API/Animation/cancel_event
-tags:
-  - API
-  - Animacion
-  - Animaciones Web
-  - Experimental
-  - Reference
-  - oncancel
-translation_of: Web/API/Animation/oncancel
 original_slug: Web/API/Animation/oncancel
 ---
 

--- a/files/es/web/api/animation/currenttime/index.md
+++ b/files/es/web/api/animation/currenttime/index.md
@@ -1,9 +1,6 @@
 ---
 title: Animation.currentTime
 slug: Web/API/Animation/currentTime
-tags:
-  - Animacion
-translation_of: Web/API/Animation/currentTime
 original_slug: Web/API/Animation/tiempoActual
 ---
 

--- a/files/es/web/api/animation/effect/index.md
+++ b/files/es/web/api/animation/effect/index.md
@@ -1,14 +1,6 @@
 ---
 title: Animation.effect
 slug: Web/API/Animation/effect
-tags:
-  - API
-  - Animacion
-  - Animaciones Web
-  - Experimental
-  - Reference
-  - efecto
-translation_of: Web/API/Animation/effect
 ---
 
  {{ APIRef("Web Animations") }}

--- a/files/es/web/api/animation/finish/index.md
+++ b/files/es/web/api/animation/finish/index.md
@@ -1,16 +1,6 @@
 ---
 title: Animation.finish()
 slug: Web/API/Animation/finish
-tags:
-  - API
-  - Animacion
-  - Animaciones Web
-  - Experimental
-  - Finish
-  - Reference
-  - metodo
-  - waapi
-translation_of: Web/API/Animation/finish
 ---
 
 {{APIRef("Web Animations")}}

--- a/files/es/web/api/animation/finish_event/index.md
+++ b/files/es/web/api/animation/finish_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: Animation.onfinish
 slug: Web/API/Animation/finish_event
-tags:
-  - API
-  - Animacion
-  - Animaciones Web
-  - Experimental
-  - Reference
-  - onfinish
-  - waapi
-translation_of: Web/API/Animation/onfinish
 original_slug: Web/API/Animation/onfinish
 ---
 

--- a/files/es/web/api/animation/finished/index.md
+++ b/files/es/web/api/animation/finished/index.md
@@ -1,13 +1,6 @@
 ---
 title: Animation.finished
 slug: Web/API/Animation/finished
-tags:
-  - API
-  - Animacion
-  - Animaciones Web
-  - Experimental
-  - Reference
-translation_of: Web/API/Animation/finished
 original_slug: Web/API/Animation/terminado
 ---
 

--- a/files/es/web/api/animation/id/index.md
+++ b/files/es/web/api/animation/id/index.md
@@ -1,14 +1,6 @@
 ---
 title: Animation.id
 slug: Web/API/Animation/id
-tags:
-  - API
-  - Animacion
-  - Animaciones Web
-  - Experimental
-  - Reference
-  - id
-translation_of: Web/API/Animation/id
 ---
 
 {{ APIRef("Web Animations") }}

--- a/files/es/web/api/animation/index.md
+++ b/files/es/web/api/animation/index.md
@@ -1,16 +1,6 @@
 ---
 title: Animation
 slug: Web/API/Animation
-tags:
-  - API
-  - Animacion
-  - Experimental
-  - Interfaz
-  - Reeferencia
-  - Web Animations
-  - waapi
-  - web animation api
-translation_of: Web/API/Animation
 ---
 
 {{ APIRef("Web Animations") }}

--- a/files/es/web/api/animation/pause/index.md
+++ b/files/es/web/api/animation/pause/index.md
@@ -1,16 +1,6 @@
 ---
 title: Animation.pause()
 slug: Web/API/Animation/pause
-tags:
-  - API
-  - Animacion
-  - Animaciones Web
-  - Experimental
-  - Referencia
-  - pausar
-  - pause
-  - waapi
-translation_of: Web/API/Animation/pause
 ---
 
 {{ APIRef("Web Animations") }}

--- a/files/es/web/api/animation/play/index.md
+++ b/files/es/web/api/animation/play/index.md
@@ -1,17 +1,6 @@
 ---
 title: Animation.play()
 slug: Web/API/Animation/play
-tags:
-  - API
-  - Animacion
-  - Animaciones Web
-  - Experimental
-  - Interface
-  - Reference
-  - metodo
-  - play
-  - waapi
-translation_of: Web/API/Animation/play
 ---
 
 {{ APIRef("Web Animations") }}

--- a/files/es/web/api/animation/playbackrate/index.md
+++ b/files/es/web/api/animation/playbackrate/index.md
@@ -1,15 +1,6 @@
 ---
 title: Animation.playbackRate
 slug: Web/API/Animation/playbackRate
-tags:
-  - API
-  - Animacion
-  - Animaciones Web
-  - Experimental
-  - Interface
-  - Reference
-  - playbackRate
-translation_of: Web/API/Animation/playbackRate
 ---
 
 {{APIRef("Web Animations")}}

--- a/files/es/web/api/animation/playstate/index.md
+++ b/files/es/web/api/animation/playstate/index.md
@@ -1,14 +1,6 @@
 ---
 title: Animation.playState
 slug: Web/API/Animation/playState
-tags:
-  - API
-  - Animacion
-  - Animaciones Web
-  - Experimental
-  - Reference
-  - playState
-translation_of: Web/API/Animation/playState
 ---
 
 {{APIRef("Web Animations")}}

--- a/files/es/web/api/animation/ready/index.md
+++ b/files/es/web/api/animation/ready/index.md
@@ -1,14 +1,6 @@
 ---
 title: Animation.ready
 slug: Web/API/Animation/ready
-tags:
-  - API
-  - Animacion
-  - Animaciones Web
-  - Experimental
-  - Ready Promise
-  - Reference
-translation_of: Web/API/Animation/ready
 ---
 
 {{ APIRef("Web Animations") }}

--- a/files/es/web/api/animation/reverse/index.md
+++ b/files/es/web/api/animation/reverse/index.md
@@ -1,17 +1,6 @@
 ---
 title: Animation.reverse()
 slug: Web/API/Animation/reverse
-tags:
-  - API
-  - Animacion
-  - Animaciones Web
-  - Experimental
-  - Interface
-  - Reference
-  - metodo
-  - reverse
-  - waapi
-translation_of: Web/API/Animation/reverse
 ---
 
 {{APIRef("Web Animations")}}

--- a/files/es/web/api/animation/starttime/index.md
+++ b/files/es/web/api/animation/starttime/index.md
@@ -1,15 +1,6 @@
 ---
 title: Animation.startTime
 slug: Web/API/Animation/startTime
-tags:
-  - API
-  - Animacion
-  - Animaciones Web
-  - Experimental
-  - Interface
-  - Reference
-  - startTime
-translation_of: Web/API/Animation/startTime
 ---
 
 {{ APIRef("Web Animations") }}

--- a/files/es/web/api/animation/timeline/index.md
+++ b/files/es/web/api/animation/timeline/index.md
@@ -1,14 +1,6 @@
 ---
 title: Animation.timeline
 slug: Web/API/Animation/timeline
-tags:
-  - API
-  - Animacion
-  - Animaciones Web
-  - Experimental
-  - Reference
-  - timeline
-translation_of: Web/API/Animation/timeline
 ---
 
 {{ APIRef("Web Animations") }}

--- a/files/es/web/api/animationevent/animationname/index.md
+++ b/files/es/web/api/animationevent/animationname/index.md
@@ -1,15 +1,6 @@
 ---
 title: AnimationEvent.animationName
 slug: Web/API/AnimationEvent/animationName
-tags:
-  - API
-  - Animaciones Web
-  - AnimationEvent
-  - CSSOM
-  - Experimental
-  - Propiedad
-  - Referencia
-translation_of: Web/API/AnimationEvent/animationName
 ---
 
 {{SeeCompatTable}}{{ apiref("Web Animations API") }}

--- a/files/es/web/api/animationevent/index.md
+++ b/files/es/web/api/animationevent/index.md
@@ -1,13 +1,6 @@
 ---
 title: AnimationEvent
 slug: Web/API/AnimationEvent
-tags:
-  - API
-  - Animaciones Web
-  - Experimental
-  - Interface
-  - Referencia
-translation_of: Web/API/AnimationEvent
 ---
 
 {{SeeCompatTable}}{{APIRef("Web Animations API")}}

--- a/files/es/web/api/atob/index.md
+++ b/files/es/web/api/atob/index.md
@@ -1,7 +1,6 @@
 ---
 title: WindowBase64.atob()
 slug: Web/API/atob
-translation_of: Web/API/WindowOrWorkerGlobalScope/atob
 original_slug: Web/API/WindowOrWorkerGlobalScope/atob
 ---
 {{APIRef}}

--- a/files/es/web/api/attr/index.md
+++ b/files/es/web/api/attr/index.md
@@ -1,7 +1,6 @@
 ---
 title: Attr
 slug: Web/API/Attr
-translation_of: Web/API/Attr
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/audiobuffer/index.md
+++ b/files/es/web/api/audiobuffer/index.md
@@ -1,7 +1,6 @@
 ---
 title: AudioBuffer
 slug: Web/API/AudioBuffer
-translation_of: Web/API/AudioBuffer
 ---
 
 {{APIRef("Web Audio API")}}

--- a/files/es/web/api/audionode/index.md
+++ b/files/es/web/api/audionode/index.md
@@ -1,9 +1,7 @@
 ---
 title: AudioNode
 slug: Web/API/AudioNode
-translation_of: Web/API/AudioNode
 original_slug: Web/API/AudioNode
-browser-compat: api.AudioNode
 ---
 
 {{APIRef("Web Audio API")}}

--- a/files/es/web/api/baseaudiocontext/createbiquadfilter/index.md
+++ b/files/es/web/api/baseaudiocontext/createbiquadfilter/index.md
@@ -1,7 +1,6 @@
 ---
 title: BaseAudioContext.createBiquadFilter()
 slug: Web/API/BaseAudioContext/createBiquadFilter
-translation_of: Web/API/BaseAudioContext/createBiquadFilter
 ---
 
 {{ APIRef("Web Audio API") }}

--- a/files/es/web/api/baseaudiocontext/index.md
+++ b/files/es/web/api/baseaudiocontext/index.md
@@ -1,16 +1,6 @@
 ---
 title: BaseAudioContext
 slug: Web/API/BaseAudioContext
-tags:
-  - API
-  - Audio
-  - BaseAudioContext
-  - Interface
-  - NeedsTranslation
-  - Reference
-  - TopicStub
-  - Web Audio API
-translation_of: Web/API/BaseAudioContext
 ---
 
 {{APIRef("Web Audio API")}}

--- a/files/es/web/api/battery_status_api/index.md
+++ b/files/es/web/api/battery_status_api/index.md
@@ -1,14 +1,7 @@
 ---
 title: API de Estado de Bateria
 slug: Web/API/Battery_Status_API
-tags:
-  - API
-  - Apps
-  - Firefox OS
-  - Mobile
-translation_of: Web/API/Battery_Status_API
 original_slug: Web/API/Estado_de_Bateria
-browser-compat: api.BatteryManager
 ---
 
 {{DefaultAPISidebar("Battery API")}}{{deprecated_header}}

--- a/files/es/web/api/batterymanager/charging/index.md
+++ b/files/es/web/api/batterymanager/charging/index.md
@@ -1,16 +1,6 @@
 ---
 title: BatteryManager.charging
 slug: Web/API/BatteryManager/charging
-tags:
-  - Apps
-  - Batería
-  - Battery
-  - Firefox OS
-  - Mobile
-  - Móvil
-  - WebAPI
-translation_of: Web/API/BatteryManager/charging
-browser-compat: api.BatteryManager.charging
 ---
 
 {{deprecated_header}}{{APIRef("Battery API")}}

--- a/files/es/web/api/batterymanager/chargingchange_event/index.md
+++ b/files/es/web/api/batterymanager/chargingchange_event/index.md
@@ -1,16 +1,7 @@
 ---
 title: BatteryManager.onchargingchange
 slug: Web/API/BatteryManager/chargingchange_event
-tags:
-  - API
-  - Battery API
-  - Event Handler
-  - NeedsMarkupWork
-  - Property
-  - Reference
-translation_of: Web/API/BatteryManager/onchargingchange
 original_slug: Web/API/BatteryManager/onchargingchange
-browser-compat: api.BatteryManager.onchargingchange
 ---
 
 {{deprecated_header}}

--- a/files/es/web/api/batterymanager/chargingtime/index.md
+++ b/files/es/web/api/batterymanager/chargingtime/index.md
@@ -1,8 +1,6 @@
 ---
 title: BatteryManager.chargingTime
 slug: Web/API/BatteryManager/chargingTime
-translation_of: Web/API/BatteryManager/chargingTime
-browser-compat: api.BatteryManager.chargingTime
 ---
 
 {{deprecated_header}}

--- a/files/es/web/api/batterymanager/dischargingtime/index.md
+++ b/files/es/web/api/batterymanager/dischargingtime/index.md
@@ -1,17 +1,6 @@
 ---
 title: BatteryManager.dischargingTime
 slug: Web/API/BatteryManager/dischargingTime
-tags:
-  - API
-  - Apps
-  - Batería
-  - Battery
-  - Firefox OS
-  - Gecko DOM Reference
-  - WebAPI
-  - aplicaciones
-translation_of: Web/API/BatteryManager/dischargingTime
-browser-compat: api.BatteryManager.dischargingTime
 ---
 
 {{deprecated_header}}{{APIRef("Battery API")}}

--- a/files/es/web/api/batterymanager/index.md
+++ b/files/es/web/api/batterymanager/index.md
@@ -1,15 +1,6 @@
 ---
 title: BatteryManager
 slug: Web/API/BatteryManager
-translation_of: Web/API/BatteryManager
-tags:
-  - API
-  - Batería API
-  - Dispositivo API
-  - Interface
-  - Obsoleto
-  - Referencia
-browser-compat: api.BatteryManager
 ---
 
 {{APIRef}}{{deprecated_header}}

--- a/files/es/web/api/batterymanager/level/index.md
+++ b/files/es/web/api/batterymanager/level/index.md
@@ -1,10 +1,7 @@
 ---
 title: BatteryManager.level
 slug: Web/API/BatteryManager/level
-page-type: web-api-instance-property
-translation_of: Web/API/BatteryManager/level
 original_slug: Web/API/BatteryManager/level
-browser-compat: api.BatteryManager.level
 ---
 
 {{APIRef("Battery API")}}

--- a/files/es/web/api/batterymanager/levelchange_event/index.md
+++ b/files/es/web/api/batterymanager/levelchange_event/index.md
@@ -1,9 +1,7 @@
 ---
 title: BatteryManager.onlevelchange
 slug: Web/API/BatteryManager/levelchange_event
-translation_of: Web/API/BatteryManager/onlevelchange
 original_slug: Web/API/BatteryManager/onlevelchange
-browser-compat: api.BatteryManager.onlevelchange
 ---
 
 {{deprecated_header}} {{APIRef("Battery API")}}

--- a/files/es/web/api/beforeunloadevent/index.md
+++ b/files/es/web/api/beforeunloadevent/index.md
@@ -1,7 +1,6 @@
 ---
 title: BeforeUnloadEvent
 slug: Web/API/BeforeUnloadEvent
-translation_of: Web/API/BeforeUnloadEvent
 ---
 
 {{APIRef}}

--- a/files/es/web/api/blob/blob/index.md
+++ b/files/es/web/api/blob/blob/index.md
@@ -1,13 +1,6 @@
 ---
 title: Blob()
 slug: Web/API/Blob/Blob
-tags:
-  - API
-  - Archivo
-  - Blob
-  - File API
-  - Referencia
-translation_of: Web/API/Blob/Blob
 ---
 
 {{APIRef("File API")}}

--- a/files/es/web/api/blob/index.md
+++ b/files/es/web/api/blob/index.md
@@ -1,7 +1,6 @@
 ---
 title: Blob
 slug: Web/API/Blob
-translation_of: Web/API/Blob
 ---
 
 {{ APIRef("File API") }}

--- a/files/es/web/api/blob/type/index.md
+++ b/files/es/web/api/blob/type/index.md
@@ -1,14 +1,6 @@
 ---
 title: Blob.type
 slug: Web/API/Blob/type
-tags:
-  - API
-  - Archivo
-  - Archivos
-  - DOM
-  - Propiedad
-  - Referencia
-translation_of: Web/API/Blob/type
 ---
 
 {{APIRef("File API")}}

--- a/files/es/web/api/btoa/index.md
+++ b/files/es/web/api/btoa/index.md
@@ -1,15 +1,6 @@
 ---
 title: Cadenas binarias
 slug: Web/API/btoa
-tags:
-  - Arreglos tipados JavaScript
-  - Cadena
-  - Cadena de caracteres
-  - DOM
-  - JavaScript
-  - Referencia
-  - String
-translation_of: Web/API/DOMString/Binary
 original_slug: Web/API/DOMString/Binary
 ---
 

--- a/files/es/web/api/caches/index.md
+++ b/files/es/web/api/caches/index.md
@@ -1,7 +1,6 @@
 ---
 title: WindowOrWorkerGlobalScope.caches
 slug: Web/API/caches
-translation_of: Web/API/WindowOrWorkerGlobalScope/caches
 original_slug: Web/API/WindowOrWorkerGlobalScope/caches
 ---
 

--- a/files/es/web/api/cachestorage/index.md
+++ b/files/es/web/api/cachestorage/index.md
@@ -1,17 +1,6 @@
 ---
 title: CacheStorage
 slug: Web/API/CacheStorage
-tags:
-  - API
-  - CacheStorage
-  - Experimental
-  - Interface
-  - NeedsTranslation
-  - Reference
-  - Service Workers
-  - ServiceWorker
-  - TopicStub
-translation_of: Web/API/CacheStorage
 ---
 
 {{APIRef("Service Workers API")}}

--- a/files/es/web/api/cachestorage/keys/index.md
+++ b/files/es/web/api/cachestorage/keys/index.md
@@ -1,7 +1,6 @@
 ---
 title: CacheStorage.keys()
 slug: Web/API/CacheStorage/keys
-translation_of: Web/API/CacheStorage/keys
 ---
 
 {{APIRef ("API de Service Workers")}}

--- a/files/es/web/api/cachestorage/open/index.md
+++ b/files/es/web/api/cachestorage/open/index.md
@@ -1,17 +1,6 @@
 ---
 title: CacheStorage.open()
 slug: Web/API/CacheStorage/open
-page-type: web-api-instance-method
-tags:
-  - API
-  - CacheStorage
-  - Method
-  - Reference
-  - Service Workers
-  - Service worker API
-  - ServiceWorker
-  - open
-browser-compat: api.CacheStorage.open
 ---
 
 {{APIRef("Service Workers API")}}

--- a/files/es/web/api/canvas_api/index.md
+++ b/files/es/web/api/canvas_api/index.md
@@ -1,13 +1,6 @@
 ---
 title: API Canvas
 slug: Web/API/Canvas_API
-tags:
-  - API
-  - Canvas
-  - JavaScript
-  - Referencia
-  - introducción
-translation_of: Web/API/Canvas_API
 original_slug: Web/HTML/Canvas
 ---
 

--- a/files/es/web/api/canvas_api/manipulating_video_using_canvas/index.md
+++ b/files/es/web/api/canvas_api/manipulating_video_using_canvas/index.md
@@ -1,12 +1,6 @@
 ---
 title: Manipular video por medio de canvas
 slug: Web/API/Canvas_API/Manipulating_video_using_canvas
-tags:
-  - Canvas
-  - Firefox 3.5
-  - Video
-  - para_revisar
-translation_of: Web/API/Canvas_API/Manipulating_video_using_canvas
 original_slug: Web/HTML/anipular_video_por_medio_de_canvas
 ---
 

--- a/files/es/web/api/canvas_api/tutorial/advanced_animations/index.md
+++ b/files/es/web/api/canvas_api/tutorial/advanced_animations/index.md
@@ -1,11 +1,6 @@
 ---
 title: Advanced animations
 slug: Web/API/Canvas_API/Tutorial/Advanced_animations
-tags:
-  - Canvas
-  - Tutoria
-  - graficos
-translation_of: Web/API/Canvas_API/Tutorial/Advanced_animations
 original_slug: Web/Guide/HTML/Canvas_tutorial/Advanced_animations
 ---
 

--- a/files/es/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/es/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -1,13 +1,6 @@
 ---
 title: Animaciones básicas
 slug: Web/API/Canvas_API/Tutorial/Basic_animations
-tags:
-  - Canvas
-  - HTML5
-  - Intermedio
-  - Tutorial
-  - graficos
-translation_of: Web/API/Canvas_API/Tutorial/Basic_animations
 original_slug: Web/Guide/HTML/Canvas_tutorial/Basic_animations
 ---
 

--- a/files/es/web/api/canvas_api/tutorial/basic_usage/index.md
+++ b/files/es/web/api/canvas_api/tutorial/basic_usage/index.md
@@ -1,7 +1,6 @@
 ---
 title: Uso básico de Canvas
 slug: Web/API/Canvas_API/Tutorial/Basic_usage
-translation_of: Web/API/Canvas_API/Tutorial/Basic_usage
 original_slug: Web/Guide/HTML/Canvas_tutorial/Basic_usage
 ---
 

--- a/files/es/web/api/canvas_api/tutorial/compositing/example/index.md
+++ b/files/es/web/api/canvas_api/tutorial/compositing/example/index.md
@@ -1,14 +1,6 @@
 ---
 title: Ejemplo de composición
 slug: Web/API/Canvas_API/Tutorial/Compositing/Example
-tags:
-  - Canvas
-  - Ejemplo
-  - HTML
-  - HTML5
-  - Tutorial
-  - graficos
-translation_of: Web/API/Canvas_API/Tutorial/Compositing/Example
 original_slug: Web/API/Canvas_API/Tutorial/Compositing/Ejemplo
 ---
 

--- a/files/es/web/api/canvas_api/tutorial/compositing/index.md
+++ b/files/es/web/api/canvas_api/tutorial/compositing/index.md
@@ -1,18 +1,6 @@
 ---
 title: Compositing and clipping
 slug: Web/API/Canvas_API/Tutorial/Compositing
-tags:
-  - Canvas
-  - Graphics
-  - HTML
-  - HTML5
-  - Intermediate
-  - Lienzo
-  - NeedsTranslation
-  - Recorte
-  - TopicStub
-  - Tutorial
-translation_of: Web/API/Canvas_API/Tutorial/Compositing
 ---
 
 {{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Transformations", "Web/API/Canvas_API/Tutorial/Basic_animations")}}

--- a/files/es/web/api/canvas_api/tutorial/drawing_shapes/index.md
+++ b/files/es/web/api/canvas_api/tutorial/drawing_shapes/index.md
@@ -1,7 +1,6 @@
 ---
 title: Dibujando formas con canvas
 slug: Web/API/Canvas_API/Tutorial/Drawing_shapes
-translation_of: Web/API/Canvas_API/Tutorial/Drawing_shapes
 original_slug: Web/API/Canvas_API/Tutorial/Dibujando_formas
 l10n:
   sourceCommit: 411e3bb536f858a9d58600b4017979c79b2a4408

--- a/files/es/web/api/canvas_api/tutorial/drawing_text/index.md
+++ b/files/es/web/api/canvas_api/tutorial/drawing_text/index.md
@@ -1,9 +1,6 @@
 ---
 title: Dibujar texto usando canvas
 slug: Web/API/Canvas_API/Tutorial/Drawing_text
-tags:
-  - HTML:Canvas
-translation_of: Web/API/Canvas_API/Tutorial/Drawing_text
 original_slug: Dibujar_texto_usando_canvas
 ---
 

--- a/files/es/web/api/canvas_api/tutorial/index.md
+++ b/files/es/web/api/canvas_api/tutorial/index.md
@@ -1,11 +1,6 @@
 ---
 title: Tutorial Canvas
 slug: Web/API/Canvas_API/Tutorial
-tags:
-  - Canvas
-  - HTML5
-  - graficos
-translation_of: Web/API/Canvas_API/Tutorial
 original_slug: Web/Guide/HTML/Canvas_tutorial
 ---
 

--- a/files/es/web/api/canvas_api/tutorial/optimizing_canvas/index.md
+++ b/files/es/web/api/canvas_api/tutorial/optimizing_canvas/index.md
@@ -1,7 +1,6 @@
 ---
 title: Optimizing canvas
 slug: Web/API/Canvas_API/Tutorial/Optimizing_canvas
-translation_of: Web/API/Canvas_API/Tutorial/Optimizing_canvas
 original_slug: Web/Guide/HTML/Canvas_tutorial/Optimizing_canvas
 ---
 

--- a/files/es/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
+++ b/files/es/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
@@ -1,7 +1,6 @@
 ---
 title: Pixel manipulation with canvas
 slug: Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas
-translation_of: Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas
 original_slug: Web/Guide/HTML/Canvas_tutorial/Pixel_manipulation_with_canvas
 ---
 

--- a/files/es/web/api/canvasrenderingcontext2d/arc/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/arc/index.md
@@ -1,7 +1,6 @@
 ---
 title: CanvasRenderingContext2D.arc()
 slug: Web/API/CanvasRenderingContext2D/arc
-translation_of: Web/API/CanvasRenderingContext2D/arc
 ---
 
 {{APIRef}}

--- a/files/es/web/api/canvasrenderingcontext2d/beginpath/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/beginpath/index.md
@@ -1,13 +1,6 @@
 ---
 title: CanvasRenderingContext2D.beginPath()
 slug: Web/API/CanvasRenderingContext2D/beginPath
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - Referencia
-  - metodo
-translation_of: Web/API/CanvasRenderingContext2D/beginPath
 ---
 
 {{APIRef}}

--- a/files/es/web/api/canvasrenderingcontext2d/clearrect/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/clearrect/index.md
@@ -1,7 +1,6 @@
 ---
 title: CanvasRenderingContext2D.clearRect()
 slug: Web/API/CanvasRenderingContext2D/clearRect
-translation_of: Web/API/CanvasRenderingContext2D/clearRect
 ---
 
 {{APIRef}}

--- a/files/es/web/api/canvasrenderingcontext2d/drawimage/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/drawimage/index.md
@@ -1,13 +1,6 @@
 ---
 title: CanvasRenderingContext2D.drawImage()
 slug: Web/API/CanvasRenderingContext2D/drawImage
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContect2D
-  - Métodos
-  - Referencia
-translation_of: Web/API/CanvasRenderingContext2D/drawImage
 ---
 
 {{APIRef}}

--- a/files/es/web/api/canvasrenderingcontext2d/fillrect/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/fillrect/index.md
@@ -1,7 +1,6 @@
 ---
 title: CanvasRenderingContext2D.fillRect()
 slug: Web/API/CanvasRenderingContext2D/fillRect
-translation_of: Web/API/CanvasRenderingContext2D/fillRect
 ---
 {{APIRef}}
 

--- a/files/es/web/api/canvasrenderingcontext2d/getimagedata/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/getimagedata/index.md
@@ -1,14 +1,6 @@
 ---
 title: CanvasRenderingContext2D.getImageData()
 slug: Web/API/CanvasRenderingContext2D/getImageData
-tags:
-  - CanvasRenderingContext2D
-  - Context 2D
-  - Español
-  - Method
-  - Reference
-  - getImageData
-translation_of: Web/API/CanvasRenderingContext2D/getImageData
 ---
 
 {{APIRef}}

--- a/files/es/web/api/canvasrenderingcontext2d/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/index.md
@@ -1,7 +1,6 @@
 ---
 title: CanvasRenderingContext2D
 slug: Web/API/CanvasRenderingContext2D
-translation_of: Web/API/CanvasRenderingContext2D
 ---
 
 {{APIRef}}

--- a/files/es/web/api/canvasrenderingcontext2d/linecap/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/linecap/index.md
@@ -1,7 +1,6 @@
 ---
 title: CanvasRenderingContext2D.lineCap
 slug: Web/API/CanvasRenderingContext2D/lineCap
-translation_of: Web/API/CanvasRenderingContext2D/lineCap
 ---
 
 {{APIRef}}

--- a/files/es/web/api/canvasrenderingcontext2d/rotate/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/rotate/index.md
@@ -1,9 +1,6 @@
 ---
 title: CanvasRenderingContext2D.rotate()
 slug: Web/API/CanvasRenderingContext2D/rotate
-tags:
-  - metodo
-translation_of: Web/API/CanvasRenderingContext2D/rotate
 ---
 
 {{APIRef}}

--- a/files/es/web/api/canvasrenderingcontext2d/save/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/save/index.md
@@ -1,13 +1,6 @@
 ---
 title: CanvasRenderingContext2D.save()
 slug: Web/API/CanvasRenderingContext2D/save
-tags:
-  - API
-  - Canvas
-  - CanvasRenderingContext2D
-  - Referencia
-  - metodo
-translation_of: Web/API/CanvasRenderingContext2D/save
 ---
 
 {{APIRef}}

--- a/files/es/web/api/clearinterval/index.md
+++ b/files/es/web/api/clearinterval/index.md
@@ -1,7 +1,6 @@
 ---
 title: WindowTimers.clearInterval()
 slug: Web/API/clearInterval
-translation_of: Web/API/WindowOrWorkerGlobalScope/clearInterval
 original_slug: Web/API/WindowOrWorkerGlobalScope/clearInterval
 ---
 

--- a/files/es/web/api/cleartimeout/index.md
+++ b/files/es/web/api/cleartimeout/index.md
@@ -1,7 +1,6 @@
 ---
 title: window.clearTimeout
 slug: Web/API/clearTimeout
-translation_of: Web/API/WindowOrWorkerGlobalScope/clearTimeout
 original_slug: Web/API/WindowOrWorkerGlobalScope/clearTimeout
 ---
 

--- a/files/es/web/api/clipboard_api/index.md
+++ b/files/es/web/api/clipboard_api/index.md
@@ -1,7 +1,6 @@
 ---
 title: API del portapapeles
 slug: Web/API/Clipboard_API
-translation_of: Web/API/Clipboard_API
 original_slug: Web/API/API_del_portapapeles
 ---
 

--- a/files/es/web/api/clipboardevent/clipboarddata/index.md
+++ b/files/es/web/api/clipboardevent/clipboarddata/index.md
@@ -1,14 +1,6 @@
 ---
 title: ClipboardEvent.clipboardData
 slug: Web/API/ClipboardEvent/clipboardData
-tags:
-  - API
-  - Clipboard API
-  - Experimental
-  - Portapapeles
-  - Solo lectura
-  - metodo
-translation_of: Web/API/ClipboardEvent/clipboardData
 ---
 
 {{ apiref("Clipboard API") }} {{SeeCompatTable}}

--- a/files/es/web/api/clipboardevent/index.md
+++ b/files/es/web/api/clipboardevent/index.md
@@ -1,15 +1,6 @@
 ---
 title: ClipboardEvent
 slug: Web/API/ClipboardEvent
-tags:
-  - API
-  - Clipboard API
-  - Event
-  - Experimental
-  - Interface
-  - NeedsTranslation
-  - TopicStub
-translation_of: Web/API/ClipboardEvent
 ---
 
 {{APIRef("Clipboard API")}} {{SeeCompatTable}}

--- a/files/es/web/api/closeevent/index.md
+++ b/files/es/web/api/closeevent/index.md
@@ -1,7 +1,6 @@
 ---
 title: CloseEvent
 slug: Web/API/CloseEvent
-translation_of: Web/API/CloseEvent
 ---
 
 {{APIRef("Websockets API")}}

--- a/files/es/web/api/comment/index.md
+++ b/files/es/web/api/comment/index.md
@@ -1,12 +1,6 @@
 ---
 title: Comment
 slug: Web/API/Comment
-tags:
-  - API
-  - DOM
-  - Referências
-  - comentários
-translation_of: Web/API/Comment
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/console/assert/index.md
+++ b/files/es/web/api/console/assert/index.md
@@ -1,17 +1,6 @@
 ---
 title: Console.assert()
 slug: Web/API/console/assert
-tags:
-  - API
-  - Consola
-  - DOM
-  - Debug
-  - Debugging
-  - Gecko DOM Referencia
-  - Métodos
-  - afirmación
-  - consola web
-translation_of: Web/API/console/assert
 ---
 
 {{APIRef("Console API")}}{{Non-standard_header}}

--- a/files/es/web/api/console/count/index.md
+++ b/files/es/web/api/console/count/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.count()
 slug: Web/API/Console/count
-translation_of: Web/API/Console/count
 ---
 
 {{APIRef("Console API")}}

--- a/files/es/web/api/console/dir/index.md
+++ b/files/es/web/api/console/dir/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.dir()
 slug: Web/API/Console/dir
-translation_of: Web/API/Console/dir
 ---
 
 {{APIRef("Console API")}}

--- a/files/es/web/api/console/dirxml/index.md
+++ b/files/es/web/api/console/dirxml/index.md
@@ -1,12 +1,6 @@
 ---
 title: Console.dirxml()
 slug: Web/API/Console/dirxml
-tags:
-  - API
-  - DOM
-  - Depuración
-  - metodo
-translation_of: Web/API/Console/dirxml
 ---
 
 {{APIRef("Console API")}}{{Non-standard_header}}

--- a/files/es/web/api/console/error/index.md
+++ b/files/es/web/api/console/error/index.md
@@ -1,14 +1,6 @@
 ---
 title: console.error()
 slug: Web/API/Console/error
-tags:
-  - API
-  - DOM
-  - Depurando
-  - Desarrollo web
-  - consola web
-  - metodo
-translation_of: Web/API/Console/error
 ---
 
 {{APIRef("Console API")}}

--- a/files/es/web/api/console/index.md
+++ b/files/es/web/api/console/index.md
@@ -1,10 +1,7 @@
 ---
 title: Consola
 slug: Web/API/Console
-page-type: web-api-interface
-translation_of: Web/API/Console
 original_slug: Web/API/Console
-browser-compat: api.console
 l10n:
   sourceCommit: 71aac3e50b8bc5afea791d69d232dab98e1c5c0d
 ---

--- a/files/es/web/api/console/info/index.md
+++ b/files/es/web/api/console/info/index.md
@@ -1,14 +1,6 @@
 ---
 title: Console.info()
 slug: Web/API/Console/info
-tags:
-  - API
-  - Depuración
-  - Desarrollo web
-  - NecesidadNavegadorCompatible
-  - consola web
-  - metodo
-translation_of: Web/API/Console/info
 ---
 
 {{APIRef("Console API")}}Emite un mensaje informativo a la Consola Web. En Firefox y Chrome, se muestra un pequeño ícono "i" junto a estos elementos en el registro de la Consola Web.

--- a/files/es/web/api/console/log/index.md
+++ b/files/es/web/api/console/log/index.md
@@ -1,22 +1,6 @@
 ---
 title: Console.log()
 slug: Web/API/Console/log
-tags:
-  - API
-  - Compatibilidad necesaria con navegadores
-  - Consola
-  - DOM
-  - Desarrollo web
-  - Método(2)
-  - consola web
-  - console.dir()
-  - console.log()
-  - debuguear
-  - depurar
-  - diferencia
-  - Árbol HTML
-  - Árbol JSON
-translation_of: Web/API/Console/log
 ---
 
 {{APIRef("Console API")}}Muestra un mensaje en la consola web (o del intérprete JavaScript).

--- a/files/es/web/api/console/table/index.md
+++ b/files/es/web/api/console/table/index.md
@@ -1,12 +1,6 @@
 ---
 title: Console.table()
 slug: Web/API/Console/table
-tags:
-  - API
-  - Consola
-  - DOM
-  - Depuración
-translation_of: Web/API/Console/table
 original_slug: Web/API/Console/tabla
 ---
 

--- a/files/es/web/api/console/time/index.md
+++ b/files/es/web/api/console/time/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.time()
 slug: Web/API/Console/time
-translation_of: Web/API/Console/time
 ---
 
 {{APIRef("Console API")}}

--- a/files/es/web/api/console/timeend/index.md
+++ b/files/es/web/api/console/timeend/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.timeEnd()
 slug: Web/API/Console/timeEnd
-translation_of: Web/API/Console/timeEnd
 ---
 
 {{APIRef("Console API")}}

--- a/files/es/web/api/console/trace/index.md
+++ b/files/es/web/api/console/trace/index.md
@@ -1,7 +1,6 @@
 ---
 title: Console.trace()
 slug: Web/API/Console/trace
-translation_of: Web/API/Console/trace
 ---
 
 {{APIRef("Console API")}}{{Non-standard_header}}

--- a/files/es/web/api/console/warn/index.md
+++ b/files/es/web/api/console/warn/index.md
@@ -1,9 +1,6 @@
 ---
 title: Console.warn()
 slug: Web/API/Console/warn
-tags:
-  - Desarrollo web
-translation_of: Web/API/Console/warn
 ---
 
 {{APIRef("Console API")}}

--- a/files/es/web/api/createimagebitmap/index.md
+++ b/files/es/web/api/createimagebitmap/index.md
@@ -1,15 +1,6 @@
 ---
 title: self.createImageBitmap()
 slug: Web/API/createImageBitmap
-tags:
-  - API
-  - Canvas
-  - DOM
-  - Referencia
-  - WindowOrWorkerGlobalScope
-  - createImageBitmap
-  - metodo
-translation_of: Web/API/WindowOrWorkerGlobalScope/createImageBitmap
 original_slug: Web/API/WindowOrWorkerGlobalScope/createImageBitmap
 ---
 

--- a/files/es/web/api/crypto/getrandomvalues/index.md
+++ b/files/es/web/api/crypto/getrandomvalues/index.md
@@ -1,12 +1,6 @@
 ---
 title: Crypto.getRandomValues()
 slug: Web/API/Crypto/getRandomValues
-tags:
-  - API
-  - Criptografía
-  - Referencia
-  - metodo
-translation_of: Web/API/Crypto/getRandomValues
 original_slug: Web/API/RandomSource/Obtenervaloresaleatorios
 ---
 

--- a/files/es/web/api/crypto/index.md
+++ b/files/es/web/api/crypto/index.md
@@ -1,12 +1,6 @@
 ---
 title: Crypto
 slug: Web/API/Crypto
-tags:
-  - API
-  - Interfaz
-  - Referencia
-  - Web Crypto API
-translation_of: Web/API/Crypto
 ---
 
 {{APIRef("Web Crypto API")}}

--- a/files/es/web/api/crypto/subtle/index.md
+++ b/files/es/web/api/crypto/subtle/index.md
@@ -1,14 +1,6 @@
 ---
 title: Crypto.subtle
 slug: Web/API/Crypto/subtle
-tags:
-  - API
-  - Criptografía
-  - Propiedad
-  - Referencia
-  - Sólo-Lectura
-  - Web Crypto API
-translation_of: Web/API/Crypto/subtle
 ---
 
 {{APIRef("Web Crypto API")}}

--- a/files/es/web/api/crypto_property/index.md
+++ b/files/es/web/api/crypto_property/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.crypto
 slug: Web/API/crypto_property
-translation_of: Web/API/Window/crypto
 original_slug: Web/API/Window/crypto
 ---
 

--- a/files/es/web/api/css_object_model/index.md
+++ b/files/es/web/api/css_object_model/index.md
@@ -1,11 +1,6 @@
 ---
 title: CSS Object Model
 slug: Web/API/CSS_Object_Model
-tags:
-  - API
-  - CSSOM
-  - Referencia
-translation_of: Web/API/CSS_Object_Model
 ---
 
 {{DefaultAPISidebar('CSSOM')}}

--- a/files/es/web/api/cssrule/csstext/index.md
+++ b/files/es/web/api/cssrule/csstext/index.md
@@ -1,7 +1,6 @@
 ---
 title: CssRule.cssText
 slug: Web/API/CSSRule/cssText
-translation_of: Web/API/CSSRule/cssText
 ---
 
 {{APIRef}}

--- a/files/es/web/api/cssrule/index.md
+++ b/files/es/web/api/cssrule/index.md
@@ -1,7 +1,6 @@
 ---
 title: CssRule
 slug: Web/API/CSSRule
-translation_of: Web/API/CSSRule
 ---
 
 {{ ApiRef("CSSOM") }}

--- a/files/es/web/api/cssstyledeclaration/index.md
+++ b/files/es/web/api/cssstyledeclaration/index.md
@@ -1,10 +1,6 @@
 ---
 title: CSSStyleDeclaration
 slug: Web/API/CSSStyleDeclaration
-tags:
-  - Interfaz
-  - Referencia
-translation_of: Web/API/CSSStyleDeclaration
 ---
 
 {{ APIRef("CSSOM") }}

--- a/files/es/web/api/cssstylerule/index.md
+++ b/files/es/web/api/cssstylerule/index.md
@@ -1,9 +1,6 @@
 ---
 title: CSSStyleRule
 slug: Web/API/CSSStyleRule
-tags:
-  - API
-translation_of: Web/API/CSSStyleRule
 ---
 
 {{ APIRef("CSSOM") }}

--- a/files/es/web/api/cssstylerule/selectortext/index.md
+++ b/files/es/web/api/cssstylerule/selectortext/index.md
@@ -1,7 +1,6 @@
 ---
 title: CssRule.selectorText
 slug: Web/API/CSSStyleRule/selectorText
-translation_of: Web/API/CSSStyleRule/selectorText
 ---
 
 {{ ApiRef() }}

--- a/files/es/web/api/cssstylesheet/deleterule/index.md
+++ b/files/es/web/api/cssstylesheet/deleterule/index.md
@@ -1,7 +1,6 @@
 ---
 title: Stylesheet.deleteRule
 slug: Web/API/CSSStyleSheet/deleteRule
-translation_of: Web/API/CSSStyleSheet/deleteRule
 ---
 
 {{ ApiRef() }}

--- a/files/es/web/api/cssstylesheet/index.md
+++ b/files/es/web/api/cssstylesheet/index.md
@@ -1,7 +1,6 @@
 ---
 title: CSSStyleSheet
 slug: Web/API/CSSStyleSheet
-translation_of: Web/API/CSSStyleSheet
 ---
 
 {{ ApiRef() }}

--- a/files/es/web/api/cssstylesheet/insertrule/index.md
+++ b/files/es/web/api/cssstylesheet/insertrule/index.md
@@ -1,9 +1,6 @@
 ---
 title: CSSStyleSheet.insertRule()
 slug: Web/API/CSSStyleSheet/insertRule
-tags:
-  - CSSStyleSheet
-translation_of: Web/API/CSSStyleSheet/insertRule
 ---
 
 {{APIRef}}

--- a/files/es/web/api/customelementregistry/define/index.md
+++ b/files/es/web/api/customelementregistry/define/index.md
@@ -1,7 +1,6 @@
 ---
 title: CustomElementRegistry.define()
 slug: Web/API/CustomElementRegistry/define
-translation_of: Web/API/CustomElementRegistry/define
 ---
 
 {{APIRef("CustomElementRegistry")}}

--- a/files/es/web/api/customelementregistry/index.md
+++ b/files/es/web/api/customelementregistry/index.md
@@ -1,17 +1,6 @@
 ---
 title: CustomElementRegistry
 slug: Web/API/CustomElementRegistry
-tags:
-  - API
-  - CustomElementRegistry
-  - Experimental
-  - Interface
-  - NeedsTranslation
-  - Reference
-  - TopicStub
-  - Web Components
-  - custom elements
-translation_of: Web/API/CustomElementRegistry
 ---
 
 {{DefaultAPISidebar("Web Components")}}

--- a/files/es/web/api/customevent/index.md
+++ b/files/es/web/api/customevent/index.md
@@ -1,8 +1,6 @@
 ---
 title: CustomEvent
 slug: Web/API/CustomEvent
-translation_of: Web/API/CustomEvent
-browser-compat: api.CustomEvent
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/devicemotionevent/index.md
+++ b/files/es/web/api/devicemotionevent/index.md
@@ -1,7 +1,6 @@
 ---
 title: DeviceMotionEvent
 slug: Web/API/DeviceMotionEvent
-translation_of: Web/API/DeviceMotionEvent
 ---
 
 {{APIRef("Device Orientation Events")}}{{SeeCompatTable}}

--- a/files/es/web/api/document/adoptnode/index.md
+++ b/files/es/web/api/document/adoptnode/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.adoptNode()
 slug: Web/API/Document/adoptNode
-tags:
-  - API
-  - DOM
-  - DOM Reference
-  - Referencia
-  - metodo
-translation_of: Web/API/Document/adoptNode
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/document/alinkcolor/index.md
+++ b/files/es/web/api/document/alinkcolor/index.md
@@ -1,7 +1,6 @@
 ---
 title: document.alinkColor
 slug: Web/API/Document/alinkColor
-translation_of: Web/API/Document/alinkColor
 ---
 
 {{APIRef("DOM")}}{{ Deprecated_header() }}

--- a/files/es/web/api/document/anchors/index.md
+++ b/files/es/web/api/document/anchors/index.md
@@ -1,14 +1,6 @@
 ---
 title: document.anchors
 slug: Web/API/Document/anchors
-tags:
-  - API
-  - Desaprobado
-  - Documento
-  - HTML DOM
-  - Propiedad
-  - Referencia
-translation_of: Web/API/Document/anchors
 ---
 
 {{APIRef("DOM")}}{{deprecated_header()}}La propiedad de solo lectura **`anchors`** de la interfaz {{domxref("Document")}} devuelve una lista de todas las anclas (anchors) del documento.

--- a/files/es/web/api/document/applets/index.md
+++ b/files/es/web/api/document/applets/index.md
@@ -1,7 +1,6 @@
 ---
 title: document.applets
 slug: Web/API/Document/applets
-translation_of: Web/API/Document/applets
 ---
 
 {{APIRef("DOM")}}{{ Deprecated_header() }}

--- a/files/es/web/api/document/bgcolor/index.md
+++ b/files/es/web/api/document/bgcolor/index.md
@@ -1,7 +1,6 @@
 ---
 title: document.bgColor
 slug: Web/API/Document/bgColor
-translation_of: Web/API/Document/bgColor
 ---
 
 {{APIRef("DOM")}}{{ Deprecated_header() }}

--- a/files/es/web/api/document/body/index.md
+++ b/files/es/web/api/document/body/index.md
@@ -1,7 +1,6 @@
 ---
 title: document.body
 slug: Web/API/Document/body
-translation_of: Web/API/Document/body
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/document/characterset/index.md
+++ b/files/es/web/api/document/characterset/index.md
@@ -1,7 +1,6 @@
 ---
 title: document.characterSet
 slug: Web/API/Document/characterSet
-translation_of: Web/API/Document/characterSet
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/document/clear/index.md
+++ b/files/es/web/api/document/clear/index.md
@@ -1,17 +1,6 @@
 ---
 title: Document.clear()
 slug: Web/API/Document/clear
-tags:
-  - API
-  - Document
-  - HTML DOM
-  - Method
-  - NeedsCompatTable
-  - NeedsExample
-  - NeedsMarkupWork
-  - NeedsSpectTable
-  - Referencia
-translation_of: Web/API/Document/clear
 ---
 
 {{APIRef("DOM")}}{{ Deprecated_header() }}

--- a/files/es/web/api/document/close/index.md
+++ b/files/es/web/api/document/close/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.close()
 slug: Web/API/Document/close
-translation_of: Web/API/Document/close
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/document/contenttype/index.md
+++ b/files/es/web/api/document/contenttype/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.contentType
 slug: Web/API/Document/contentType
-translation_of: Web/API/Document/contentType
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/document/cookie/index.md
+++ b/files/es/web/api/document/cookie/index.md
@@ -1,9 +1,6 @@
 ---
 title: document.cookie
 slug: Web/API/Document/cookie
-tags:
-  - NeedsContent
-translation_of: Web/API/Document/cookie
 original_slug: DOM/document.cookie
 ---
 

--- a/files/es/web/api/document/createattribute/index.md
+++ b/files/es/web/api/document/createattribute/index.md
@@ -1,12 +1,6 @@
 ---
 title: Document.createAttribute()
 slug: Web/API/Document/createAttribute
-tags:
-  - Atributos
-  - Crear Atributo
-  - JavaScript
-  - Métodos
-translation_of: Web/API/Document/createAttribute
 original_slug: Web/API/Document/crearAtributo
 ---
 

--- a/files/es/web/api/document/createdocumentfragment/index.md
+++ b/files/es/web/api/document/createdocumentfragment/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.createDocumentFragment()
 slug: Web/API/Document/createDocumentFragment
-translation_of: Web/API/Document/createDocumentFragment
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/document/createelement/index.md
+++ b/files/es/web/api/document/createelement/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.createElement()
 slug: Web/API/Document/createElement
-tags:
-  - API
-  - DOM
-  - Documento
-  - Referencia
-  - metodo
-translation_of: Web/API/Document/createElement
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/document/createelementns/index.md
+++ b/files/es/web/api/document/createelementns/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.createElementNS()
 slug: Web/API/Document/createElementNS
-translation_of: Web/API/Document/createElementNS
 ---
 
 {{ApiRef("DOM")}}

--- a/files/es/web/api/document/createevent/index.md
+++ b/files/es/web/api/document/createevent/index.md
@@ -1,13 +1,6 @@
 ---
 title: Event.createEvent()
 slug: Web/API/Document/createEvent
-tags:
-  - API
-  - DOM
-  - Evento
-  - metodo
-translation_of: Web/API/Document/createEvent
-translation_of_original: Web/API/Event/createEvent
 original_slug: Web/API/Event/createEvent
 ---
 

--- a/files/es/web/api/document/createrange/index.md
+++ b/files/es/web/api/document/createrange/index.md
@@ -1,11 +1,6 @@
 ---
 title: document.createRange
 slug: Web/API/Document/createRange
-tags:
-  - Rango
-  - Referencia_DOM_de_Gecko
-  - crear rango
-translation_of: Web/API/Document/createRange
 ---
 
 {{ ApiRef() }}

--- a/files/es/web/api/document/createtextnode/index.md
+++ b/files/es/web/api/document/createtextnode/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.createTextNode()
 slug: Web/API/Document/createTextNode
-tags:
-  - API
-  - DOM
-  - Documento
-  - Referencia
-  - createTextNode
-  - metodo
-translation_of: Web/API/Document/createTextNode
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/document/defaultview/index.md
+++ b/files/es/web/api/document/defaultview/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.defaultView
 slug: Web/API/Document/defaultView
-tags:
-  - API
-  - Document
-  - HTML DOM
-  - NeedsUpdate
-  - Property
-  - Reference
-translation_of: Web/API/Document/defaultView
 ---
 
 {{ ApiRef() }}

--- a/files/es/web/api/document/designmode/index.md
+++ b/files/es/web/api/document/designmode/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.designMode
 slug: Web/API/Document/designMode
-tags:
-  - API
-  - Documento
-  - HTML DOM
-  - Propiedad
-  - Referencia
-  - editor
-translation_of: Web/API/Document/designMode
 ---
 
 {{ ApiRef() }}

--- a/files/es/web/api/document/dir/index.md
+++ b/files/es/web/api/document/dir/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.dir
 slug: Web/API/Document/dir
-translation_of: Web/API/Document/dir
 ---
 
 {{ApiRef("DOM")}}

--- a/files/es/web/api/document/doctype/index.md
+++ b/files/es/web/api/document/doctype/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.doctype
 slug: Web/API/Document/doctype
-tags:
-  - API
-  - DOCTYPE
-  - DOM
-  - Document
-  - Propiedad
-  - Referencia
-translation_of: Web/API/Document/doctype
 ---
 
 {{ApiRef("DOM")}}

--- a/files/es/web/api/document/documentelement/index.md
+++ b/files/es/web/api/document/documentelement/index.md
@@ -1,9 +1,6 @@
 ---
 title: document.documentElement
 slug: Web/API/Document/documentElement
-tags:
-  - Referencia_DOM_de_Gecko
-translation_of: Web/API/Document/documentElement
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/document/documenturi/index.md
+++ b/files/es/web/api/document/documenturi/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.documentURI
 slug: Web/API/Document/documentURI
-tags:
-  - API
-  - ContenidoNecesario
-  - DOM
-  - EjemploNecesario
-  - Propiedad
-  - Referencia
-  - UbicaciónDocumento
-translation_of: Web/API/Document/documentURI
 ---
 
 {{ApiRef("DOM")}}

--- a/files/es/web/api/document/embeds/index.md
+++ b/files/es/web/api/document/embeds/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.embeds
 slug: Web/API/Document/embeds
-tags:
-  - API
-  - Documento
-  - Ejemplo
-  - HTML DOM
-  - Propiedad
-translation_of: Web/API/Document/embeds
 ---
 
 {{ApiRef}}

--- a/files/es/web/api/document/execcommand/index.md
+++ b/files/es/web/api/document/execcommand/index.md
@@ -1,14 +1,6 @@
 ---
 title: Document.execCommand()
 slug: Web/API/Document/execCommand
-tags:
-  - API
-  - DOM
-  - Método(2)
-  - NecesitaEjemplo
-  - Referencia
-  - editor
-translation_of: Web/API/Document/execCommand
 ---
 
 {{ApiRef("DOM")}}{{ Deprecated_header() }}

--- a/files/es/web/api/document/exitfullscreen/index.md
+++ b/files/es/web/api/document/exitfullscreen/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.exitFullscreen()
 slug: Web/API/Document/exitFullscreen
-translation_of: Web/API/Document/exitFullscreen
 ---
 
 {{ApiRef("Fullscreen API")}}

--- a/files/es/web/api/document/getelementbyid/index.md
+++ b/files/es/web/api/document/getelementbyid/index.md
@@ -1,16 +1,6 @@
 ---
 title: document.getElementById
 slug: Web/API/Document/getElementById
-tags:
-  - API
-  - DOM
-  - Documento
-  - Elementos
-  - Referencia
-  - Web
-  - id
-  - metodo
-translation_of: Web/API/Document/getElementById
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/document/getelementsbyclassname/index.md
+++ b/files/es/web/api/document/getelementsbyclassname/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.getElementsByClassName()
 slug: Web/API/Document/getElementsByClassName
-translation_of: Web/API/Document/getElementsByClassName
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/document/getelementsbyname/index.md
+++ b/files/es/web/api/document/getelementsbyname/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.getElementsByName()
 slug: Web/API/Document/getElementsByName
-translation_of: Web/API/Document/getElementsByName
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/document/getelementsbytagname/index.md
+++ b/files/es/web/api/document/getelementsbytagname/index.md
@@ -1,9 +1,6 @@
 ---
 title: document.getElementsByTagName
 slug: Web/API/Document/getElementsByTagName
-tags:
-  - Referencia_DOM_de_Gecko
-translation_of: Web/API/Document/getElementsByTagName
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/document/getelementsbytagnamens/index.md
+++ b/files/es/web/api/document/getelementsbytagnamens/index.md
@@ -1,9 +1,6 @@
 ---
 title: document.getElementsByTagNameNS
 slug: Web/API/Document/getElementsByTagNameNS
-tags:
-  - Referencia_DOM_de_Gecko
-translation_of: Web/API/Document/getElementsByTagNameNS
 ---
 
 {{ ApiRef() }}

--- a/files/es/web/api/document/getselection/index.md
+++ b/files/es/web/api/document/getselection/index.md
@@ -1,12 +1,6 @@
 ---
 title: Document.getSelection()
 slug: Web/API/Document/getSelection
-tags:
-  - Referencia
-  - Selección
-  - metodo
-translation_of: Web/API/DocumentOrShadowRoot/getSelection
-translation_of_original: Web/API/Document/getSelection
 original_slug: Web/API/DocumentOrShadowRoot/getSelection
 ---
 

--- a/files/es/web/api/document/hasfocus/index.md
+++ b/files/es/web/api/document/hasfocus/index.md
@@ -1,9 +1,6 @@
 ---
 title: element.hasFocus
 slug: Web/API/Document/hasFocus
-tags:
-  - Referencia_DOM_de_Gecko
-translation_of: Web/API/Document/hasFocus
 ---
 
 {{ ApiRef() }}

--- a/files/es/web/api/document/head/index.md
+++ b/files/es/web/api/document/head/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.head
 slug: Web/API/Document/head
-translation_of: Web/API/Document/head
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/document/hidden/index.md
+++ b/files/es/web/api/document/hidden/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.hidden
 slug: Web/API/Document/hidden
-translation_of: Web/API/Document/hidden
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/document/importnode/index.md
+++ b/files/es/web/api/document/importnode/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.importNode()
 slug: Web/API/Document/importNode
-translation_of: Web/API/Document/importNode
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/document/index.md
+++ b/files/es/web/api/document/index.md
@@ -1,8 +1,6 @@
 ---
 title: Document
 slug: Web/API/Document
-browser-compat: api.Document
-translation_of: Web/API/Document
 original_slug: Web/API/Document
 ---
 

--- a/files/es/web/api/document/open/index.md
+++ b/files/es/web/api/document/open/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.open()
 slug: Web/API/Document/open
-translation_of: Web/API/Document/open
 original_slug: Web/API/Document/abrir
 ---
 

--- a/files/es/web/api/document/pointerlockchange_event/index.md
+++ b/files/es/web/api/document/pointerlockchange_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: pointerlockchange
 slug: Web/API/Document/pointerlockchange_event
-translation_of: Web/API/Document/pointerlockchange_event
 original_slug: Web/API/Element/pointerlockchange_event
 ---
 

--- a/files/es/web/api/document/pointerlockelement/index.md
+++ b/files/es/web/api/document/pointerlockelement/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.pointerLockElement
 slug: Web/API/Document/pointerLockElement
-translation_of: Web/API/DocumentOrShadowRoot/pointerLockElement
 original_slug: Web/API/DocumentOrShadowRoot/pointerLockElement
 ---
 

--- a/files/es/web/api/document/queryselector/index.md
+++ b/files/es/web/api/document/queryselector/index.md
@@ -1,15 +1,6 @@
 ---
 title: Document.querySelector()
 slug: Web/API/Document/querySelector
-tags:
-  - API
-  - Consulta
-  - DOM
-  - Referencias(2)
-  - Referências
-  - Selectores
-  - metodo
-translation_of: Web/API/Document/querySelector
 ---
 
 {{ ApiRef("DOM") }}Devuelve el primer elemento del documento (utilizando un [recorrido primero en profundidad pre ordenado](http://en.wikipedia.org/wiki/Tree_traversal#Pre-order_2) de los nodos del documento) que coincida con el grupo especificado de selectores.

--- a/files/es/web/api/document/queryselectorall/index.md
+++ b/files/es/web/api/document/queryselectorall/index.md
@@ -1,20 +1,6 @@
 ---
 title: Document.querySelectorAll()
 slug: Web/API/Document/querySelectorAll
-tags:
-  - API
-  - Buscando Elementos
-  - DOM
-  - Document
-  - Encontrando Elementos
-  - Localizando Elementos
-  - Métodos
-  - Referencia
-  - Seleccionando Elementos
-  - Selectores
-  - Selectores CSS
-  - querySelectorAll
-translation_of: Web/API/Document/querySelectorAll
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/document/readystate/index.md
+++ b/files/es/web/api/document/readystate/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.readyState
 slug: Web/API/Document/readyState
-translation_of: Web/API/Document/readyState
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/document/registerelement/index.md
+++ b/files/es/web/api/document/registerelement/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.registerElement()
 slug: Web/API/Document/registerElement
-translation_of: Web/API/Document/registerElement
 ---
 
 {{APIRef("DOM")}}{{Deprecated_header}}

--- a/files/es/web/api/document/scripts/index.md
+++ b/files/es/web/api/document/scripts/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.scripts
 slug: Web/API/Document/scripts
-translation_of: Web/API/Document/scripts
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/document/scroll_event/index.md
+++ b/files/es/web/api/document/scroll_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: scroll
 slug: Web/API/Document/scroll_event
-translation_of: Web/API/Document/scroll_event
 ---
 
 {{ ApiRef() }}

--- a/files/es/web/api/document/stylesheets/index.md
+++ b/files/es/web/api/document/stylesheets/index.md
@@ -1,8 +1,6 @@
 ---
 title: Document.styleSheets
 slug: Web/API/Document/styleSheets
-translation_of: Web/API/DocumentOrShadowRoot/styleSheets
-translation_of_original: Web/API/Document/styleSheets
 original_slug: Web/API/DocumentOrShadowRoot/styleSheets
 ---
 

--- a/files/es/web/api/document/url/index.md
+++ b/files/es/web/api/document/url/index.md
@@ -1,13 +1,6 @@
 ---
 title: document.URL
 slug: Web/API/Document/URL
-tags:
-  - API
-  - Documento
-  - HTML DOM
-  - Propiedad
-  - Referencia
-translation_of: Web/API/Document/URL
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/document/write/index.md
+++ b/files/es/web/api/document/write/index.md
@@ -1,13 +1,6 @@
 ---
 title: Document.write()
 slug: Web/API/Document/write
-tags:
-  - API
-  - DOM
-  - Documentación
-  - Referencia
-  - metodo
-translation_of: Web/API/Document/write
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/document/writeln/index.md
+++ b/files/es/web/api/document/writeln/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.writeln()
 slug: Web/API/Document/writeln
-translation_of: Web/API/Document/writeln
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/document_object_model/examples/index.md
+++ b/files/es/web/api/document_object_model/examples/index.md
@@ -1,12 +1,6 @@
 ---
 title: Ejemplos
 slug: Web/API/Document_Object_Model/Examples
-tags:
-  - DOM
-  - Referencia_DOM_de_Gecko
-  - Todas_las_Categorías
-  - páginas_a_traducir
-translation_of: Web/API/Document_Object_Model/Examples
 original_slug: Referencia_DOM_de_Gecko/Ejemplos
 ---
 

--- a/files/es/web/api/document_object_model/how_to_create_a_dom_tree/index.md
+++ b/files/es/web/api/document_object_model/how_to_create_a_dom_tree/index.md
@@ -1,7 +1,6 @@
 ---
 title: Cómo crear un DOM tree
 slug: Web/API/Document_object_model/How_to_create_a_DOM_tree
-translation_of: Web/API/Document_object_model/How_to_create_a_DOM_tree
 original_slug: How_to_create_a_DOM_tree
 ---
 

--- a/files/es/web/api/document_object_model/index.md
+++ b/files/es/web/api/document_object_model/index.md
@@ -1,11 +1,6 @@
 ---
 title: Referencia DOM de Gecko
 slug: Web/API/Document_Object_Model
-tags:
-  - DOM
-  - NecesitaRevisiónTécnica
-  - Todas_las_Categorías
-translation_of: Web/API/Document_Object_Model
 original_slug: Referencia_DOM_de_Gecko
 ---
 

--- a/files/es/web/api/document_object_model/introduction/index.md
+++ b/files/es/web/api/document_object_model/introduction/index.md
@@ -1,12 +1,6 @@
 ---
 title: Introducción
 slug: Web/API/Document_Object_Model/Introduction
-tags:
-  - DOM
-  - Gecko
-  - Manuales
-  - Todas_las_Categorías
-translation_of: Web/API/Document_Object_Model/Introduction
 original_slug: Referencia_DOM_de_Gecko/Introducción
 ---
 

--- a/files/es/web/api/document_object_model/locating_dom_elements_using_selectors/index.md
+++ b/files/es/web/api/document_object_model/locating_dom_elements_using_selectors/index.md
@@ -1,11 +1,6 @@
 ---
 title: Localizando elementos DOM usando selectores
 slug: Web/API/Document_object_model/Locating_DOM_elements_using_selectors
-tags:
-  - DOM
-  - Necesita actualizacion para principiantes
-  - Principiante
-translation_of: Web/API/Document_object_model/Locating_DOM_elements_using_selectors
 original_slug: Referencia_DOM_de_Gecko/Localizando_elementos_DOM_usando_selectores
 ---
 

--- a/files/es/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
+++ b/files/es/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
@@ -1,9 +1,6 @@
 ---
 title: Trazado de una tabla HTML mediante JavaScript y la Interface DOM
-slug: >-
-  Web/API/Document_Object_Model/Traversing_an_HTML_table_with_JavaScript_and_DOM_Interfaces
-translation_of: >-
-  Web/API/Document_Object_Model/Traversing_an_HTML_table_with_JavaScript_and_DOM_Interfaces
+slug: Web/API/Document_Object_Model/Traversing_an_HTML_table_with_JavaScript_and_DOM_Interfaces
 original_slug: Trazado_de_una_tabla_HTML_mediante_JavaScript_y_la_Interface_DOM
 ---
 

--- a/files/es/web/api/document_object_model/using_the_w3c_dom_level_1_core/example/index.md
+++ b/files/es/web/api/document_object_model/using_the_w3c_dom_level_1_core/example/index.md
@@ -1,10 +1,6 @@
 ---
 title: Example
 slug: Web/API/Document_object_model/Using_the_W3C_DOM_Level_1_Core/Example
-tags:
-  - DOM
-  - Ejemplo
-translation_of: Web/API/Document_object_model/Using_the_W3C_DOM_Level_1_Core/Example
 ---
 
 ```

--- a/files/es/web/api/document_object_model/using_the_w3c_dom_level_1_core/index.md
+++ b/files/es/web/api/document_object_model/using_the_w3c_dom_level_1_core/index.md
@@ -1,12 +1,6 @@
 ---
 title: Using the W3C DOM Level 1 Core
 slug: Web/API/Document_object_model/Using_the_W3C_DOM_Level_1_Core
-tags:
-  - DOM
-  - NeedsTranslation
-  - NeedsUpdate
-  - TopicStub
-translation_of: Web/API/Document_object_model/Using_the_W3C_DOM_Level_1_Core
 original_slug: Using_the_W3C_DOM_Level_1_Core
 ---
 

--- a/files/es/web/api/document_object_model/whitespace/index.md
+++ b/files/es/web/api/document_object_model/whitespace/index.md
@@ -1,14 +1,6 @@
 ---
 title: Cómo manejan el espacio en blanco HTML, CSS y el DOM
 slug: Web/API/Document_Object_Model/Whitespace
-tags:
-  - CSS
-  - DOM
-  - HTML
-  - JavaScript
-  - espacioenblanco
-  - whitespace
-translation_of: Web/API/Document_Object_Model/Whitespace
 original_slug: Referencia_DOM_de_Gecko/Cómo_espacioenblanco
 ---
 

--- a/files/es/web/api/documentfragment/index.md
+++ b/files/es/web/api/documentfragment/index.md
@@ -1,7 +1,6 @@
 ---
 title: DocumentFragment
 slug: Web/API/DocumentFragment
-translation_of: Web/API/DocumentFragment
 ---
 
 {{ APIRef("DOM") }}

--- a/files/es/web/api/domerror/index.md
+++ b/files/es/web/api/domerror/index.md
@@ -1,7 +1,6 @@
 ---
 title: DOMError
 slug: Web/API/DOMError
-translation_of: Web/API/DOMError
 ---
 
 {{ APIRef("DOM") }}

--- a/files/es/web/api/domexception/index.md
+++ b/files/es/web/api/domexception/index.md
@@ -1,8 +1,6 @@
 ---
 title: DOMException
 slug: Web/API/DomException
-page-type: web-api-instance-method
-browser-compat: api.Notification.close
 ---
 
 La interfaz **`DOMException`** representa un evento anormal (llamado **excepción**) que ocurre como el resultado de llamar a un método o acceder a una propiedad de una API web. Asi es como las condiciones de error se describen en las API web.

--- a/files/es/web/api/domparser/index.md
+++ b/files/es/web/api/domparser/index.md
@@ -1,7 +1,6 @@
 ---
 title: DOMParser
 slug: Web/API/DOMParser
-translation_of: Web/API/DOMParser
 ---
 
 {{APIRef("DOM")}}{{SeeCompatTable}}

--- a/files/es/web/api/dragevent/index.md
+++ b/files/es/web/api/dragevent/index.md
@@ -1,8 +1,6 @@
 ---
 title: DragEvent
 slug: Web/API/DragEvent
-translation_of: Web/API/DragEvent
-browser-compat: api.DragEvent
 ---
 
 {{APIRef("HTML Drag and Drop API")}}

--- a/files/es/web/api/element/animate/index.md
+++ b/files/es/web/api/element/animate/index.md
@@ -1,8 +1,6 @@
 ---
 title: Element.animate()
 slug: Web/API/Element/animate
-translation_of: Web/API/Element/animate
-browser-compat: api.Element.animate
 ---
 
 {{APIRef}}

--- a/files/es/web/api/element/animationend_event/index.md
+++ b/files/es/web/api/element/animationend_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: animationend
 slug: Web/API/Element/animationend_event
-translation_of: Web/API/HTMLElement/animationend_event
 original_slug: Web/API/HTMLElement/animationend_event
 ---
 

--- a/files/es/web/api/element/attachshadow/index.md
+++ b/files/es/web/api/element/attachshadow/index.md
@@ -1,7 +1,6 @@
 ---
 title: Element.attachShadow()
 slug: Web/API/Element/attachShadow
-translation_of: Web/API/Element/attachShadow
 ---
 
 {{APIRef}}

--- a/files/es/web/api/element/attributes/index.md
+++ b/files/es/web/api/element/attributes/index.md
@@ -1,7 +1,6 @@
 ---
 title: Element.attributes
 slug: Web/API/Element/attributes
-translation_of: Web/API/Element/attributes
 ---
 
 {{ APIRef }}

--- a/files/es/web/api/element/blur_event/index.md
+++ b/files/es/web/api/element/blur_event/index.md
@@ -1,9 +1,6 @@
 ---
 title: blur (evento)
 slug: Web/API/Element/blur_event
-tags:
-  - DOM
-translation_of: Web/API/Element/blur_event
 original_slug: Web/Events/blur
 ---
 

--- a/files/es/web/api/element/childelementcount/index.md
+++ b/files/es/web/api/element/childelementcount/index.md
@@ -1,14 +1,6 @@
 ---
 title: ParentNode.childElementCount
 slug: Web/API/Element/childElementCount
-tags:
-  - API
-  - ChildNode
-  - DOM
-  - ParentNode
-  - childElement
-  - children
-translation_of: Web/API/ParentNode/childElementCount
 original_slug: Web/API/ParentNode/childElementCount
 ---
 

--- a/files/es/web/api/element/classlist/index.md
+++ b/files/es/web/api/element/classlist/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.classList
 slug: Web/API/Element/classList
-tags:
-  - API
-  - DOM
-  - Elemento
-  - Propiedad
-  - Referencia
-  - Sólo-Lectura
-translation_of: Web/API/Element/classList
 ---
 
 {{APIRef}}

--- a/files/es/web/api/element/classname/index.md
+++ b/files/es/web/api/element/classname/index.md
@@ -1,13 +1,6 @@
 ---
 title: Element.className
 slug: Web/API/Element/className
-tags:
-  - API
-  - DOM
-  - Gecko
-  - Propiedad
-  - Referencia
-translation_of: Web/API/Element/className
 ---
 
 {{APIRef}}

--- a/files/es/web/api/element/click_event/index.md
+++ b/files/es/web/api/element/click_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: click
 slug: Web/API/Element/click_event
-translation_of: Web/API/Element/click_event
 ---
 
 {{ APIRef }}

--- a/files/es/web/api/element/clientheight/index.md
+++ b/files/es/web/api/element/clientheight/index.md
@@ -1,9 +1,6 @@
 ---
 title: Element.clientHeight
 slug: Web/API/Element/clientHeight
-tags:
-  - Propiedad
-translation_of: Web/API/Element/clientHeight
 ---
 
 {{ APIRef }}

--- a/files/es/web/api/element/clientleft/index.md
+++ b/files/es/web/api/element/clientleft/index.md
@@ -1,9 +1,6 @@
 ---
 title: element.clientLeft
 slug: Web/API/Element/clientLeft
-tags:
-  - Referencia_DOM_de_Gecko
-translation_of: Web/API/Element/clientLeft
 ---
 
 {{ APIRef }}

--- a/files/es/web/api/element/clienttop/index.md
+++ b/files/es/web/api/element/clienttop/index.md
@@ -1,9 +1,6 @@
 ---
 title: element.clientTop
 slug: Web/API/Element/clientTop
-tags:
-  - Referencia_DOM_de_Gecko
-translation_of: Web/API/Element/clientTop
 ---
 
 {{ ApiRef }}

--- a/files/es/web/api/element/clientwidth/index.md
+++ b/files/es/web/api/element/clientwidth/index.md
@@ -1,7 +1,6 @@
 ---
 title: Element.clientWidth
 slug: Web/API/Element/clientWidth
-translation_of: Web/API/Element/clientWidth
 ---
 
 {{ APIRef }}

--- a/files/es/web/api/element/closest/index.md
+++ b/files/es/web/api/element/closest/index.md
@@ -1,13 +1,6 @@
 ---
 title: Element.closest()
 slug: Web/API/Element/closest
-tags:
-  - API
-  - DOM
-  - Elemento
-  - Referencia
-  - metodo
-translation_of: Web/API/Element/closest
 ---
 
 {{APIRef}}

--- a/files/es/web/api/element/computedstylemap/index.md
+++ b/files/es/web/api/element/computedstylemap/index.md
@@ -1,17 +1,6 @@
 ---
 title: Element.computedStyleMap()
 slug: Web/API/Element/computedStyleMap
-tags:
-  - API
-  - CSS Typed Object Model API
-  - Element
-  - Experimental
-  - Houdini
-  - Method
-  - Reference
-  - StylePropertyMapReadOnly
-  - computedStyleMap()
-translation_of: Web/API/Element/computedStyleMap
 ---
 
 {{APIRef}}{{SeeCompatTable}}

--- a/files/es/web/api/element/getattribute/index.md
+++ b/files/es/web/api/element/getattribute/index.md
@@ -1,11 +1,6 @@
 ---
 title: Element.getAttribute()
 slug: Web/API/Element/getAttribute
-tags:
-  - API
-  - DOM
-  - metodo
-translation_of: Web/API/Element/getAttribute
 ---
 
 {{APIRef}}

--- a/files/es/web/api/element/getattributenodens/index.md
+++ b/files/es/web/api/element/getattributenodens/index.md
@@ -1,12 +1,6 @@
 ---
 title: Element.getAttributeNodeNS()
 slug: Web/API/Element/getAttributeNodeNS
-tags:
-  - API
-  - DOM
-  - Referencia
-  - metodo
-translation_of: Web/API/Element/getAttributeNodeNS
 ---
 
 {{ APIRef }}

--- a/files/es/web/api/element/getboundingclientrect/index.md
+++ b/files/es/web/api/element/getboundingclientrect/index.md
@@ -1,19 +1,6 @@
 ---
 title: element.getBoundingClientRect
 slug: Web/API/Element/getBoundingClientRect
-tags:
-  - API
-  - Boundary
-  - Bounding
-  - Bounds
-  - CSSOM View
-  - Cliente
-  - DOM
-  - Elemento
-  - Minimo
-  - Referencia
-  - metodo
-translation_of: Web/API/Element/getBoundingClientRect
 ---
 
 {{APIRef}}

--- a/files/es/web/api/element/getclientrects/index.md
+++ b/files/es/web/api/element/getclientrects/index.md
@@ -1,13 +1,6 @@
 ---
 title: element.getClientRects
 slug: Web/API/Element/getClientRects
-tags:
-  - NeedsBrowserCompatibility
-  - NeedsExample
-  - NeedsLiveSample
-  - NeedsUpdate
-  - Referencia_DOM_de_Gecko
-translation_of: Web/API/Element/getClientRects
 ---
 
 {{ APIRef }}

--- a/files/es/web/api/element/getelementsbyclassname/index.md
+++ b/files/es/web/api/element/getelementsbyclassname/index.md
@@ -1,7 +1,6 @@
 ---
 title: Element.getElementsByClassName()
 slug: Web/API/Element/getElementsByClassName
-translation_of: Web/API/Element/getElementsByClassName
 ---
 
 {{APIRef}}

--- a/files/es/web/api/element/getelementsbytagname/index.md
+++ b/files/es/web/api/element/getelementsbytagname/index.md
@@ -1,9 +1,6 @@
 ---
 title: element.getElementsByTagName
 slug: Web/API/Element/getElementsByTagName
-tags:
-  - Referencia_DOM_de_Gecko
-translation_of: Web/API/Element/getElementsByTagName
 ---
 
 {{ APIRef }}

--- a/files/es/web/api/element/getelementsbytagnamens/index.md
+++ b/files/es/web/api/element/getelementsbytagnamens/index.md
@@ -1,7 +1,6 @@
 ---
 title: Element.getElementsByTagNameNS()
 slug: Web/API/Element/getElementsByTagNameNS
-translation_of: Web/API/Element/getElementsByTagNameNS
 ---
 
 {{APIRef}}

--- a/files/es/web/api/element/gotpointercapture_event/index.md
+++ b/files/es/web/api/element/gotpointercapture_event/index.md
@@ -1,16 +1,6 @@
 ---
 title: Element.ongotpointercapture
 slug: Web/API/Element/gotpointercapture_event
-tags:
-  - API
-  - Controlador
-  - DOM
-  - Elemento
-  - Eventos Puntero
-  - Propiedad
-  - Referencia
-translation_of: Web/API/GlobalEventHandlers/ongotpointercapture
-translation_of_original: Web/API/Element/ongotpointercapture
 original_slug: Web/API/GlobalEventHandlers/ongotpointercapture
 ---
 

--- a/files/es/web/api/element/hasattribute/index.md
+++ b/files/es/web/api/element/hasattribute/index.md
@@ -1,7 +1,6 @@
 ---
 title: Element.hasAttribute()
 slug: Web/API/Element/hasAttribute
-translation_of: Web/API/Element/hasAttribute
 ---
 
 {{APIRef}}

--- a/files/es/web/api/element/id/index.md
+++ b/files/es/web/api/element/id/index.md
@@ -1,13 +1,6 @@
 ---
 title: Element.id
 slug: Web/API/Element/id
-tags:
-  - API
-  - DOM
-  - Elemento
-  - Propiedad
-  - Referencia
-translation_of: Web/API/Element/id
 ---
 
 {{ APIRef }}

--- a/files/es/web/api/element/index.md
+++ b/files/es/web/api/element/index.md
@@ -1,9 +1,6 @@
 ---
 title: element
 slug: Web/API/Element
-tags:
-  - Referencia_DOM_de_Gecko
-translation_of: Web/API/Element
 ---
 
 {{ APIRef }}

--- a/files/es/web/api/element/innerhtml/index.md
+++ b/files/es/web/api/element/innerhtml/index.md
@@ -1,13 +1,6 @@
 ---
 title: element.innerHTML
 slug: Web/API/Element/innerHTML
-tags:
-  - API
-  - DOM
-  - Gecko
-  - Propiedad
-  - Referencia
-translation_of: Web/API/Element/innerHTML
 ---
 
 {{APIRef}}

--- a/files/es/web/api/element/insertadjacentelement/index.md
+++ b/files/es/web/api/element/insertadjacentelement/index.md
@@ -1,7 +1,6 @@
 ---
 title: Element.insertAdjacentElement()
 slug: Web/API/Element/insertAdjacentElement
-translation_of: Web/API/Element/insertAdjacentElement
 ---
 
 {{APIRef}}

--- a/files/es/web/api/element/insertadjacenthtml/index.md
+++ b/files/es/web/api/element/insertadjacenthtml/index.md
@@ -1,17 +1,6 @@
 ---
 title: Element.insertAdjacentHTML()
 slug: Web/API/Element/insertAdjacentHTML
-tags:
-  - API
-  - Cambiando el DOM
-  - DOM
-  - HTML
-  - Insertando Elementos
-  - Insertando Nodos
-  - Referencia
-  - insertAdjacentHTML
-  - metodo
-translation_of: Web/API/Element/insertAdjacentHTML
 ---
 
 {{APIRef}}

--- a/files/es/web/api/element/keydown_event/index.md
+++ b/files/es/web/api/element/keydown_event/index.md
@@ -1,10 +1,6 @@
 ---
 title: keydown
 slug: Web/API/Element/keydown_event
-tags:
-  - Evento
-  - keydown
-translation_of: Web/API/Document/keydown_event
 original_slug: Web/API/Document/keydown_event
 ---
 

--- a/files/es/web/api/element/keyup_event/index.md
+++ b/files/es/web/api/element/keyup_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: Tecla Arriba
 slug: Web/API/Element/keyup_event
-translation_of: Web/API/Document/keyup_event
 original_slug: Web/API/Document/keyup_event
 ---
 

--- a/files/es/web/api/element/localname/index.md
+++ b/files/es/web/api/element/localname/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.localName
 slug: Web/API/Element/localName
-tags:
-  - API
-  - Compatibilidad de los Navegadores en Móviles
-  - Compatibilidad de los navegadores
-  - DOM
-  - Propiedad
-  - Referencia
-translation_of: Web/API/Element/localName
 ---
 
 {{APIRef}}

--- a/files/es/web/api/element/lostpointercapture_event/index.md
+++ b/files/es/web/api/element/lostpointercapture_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: Element.onlostpointercapture
 slug: Web/API/Element/lostpointercapture_event
-tags:
-  - API
-  - Controlador de Eventos
-  - DOM
-  - Eventos Puntero
-  - Propiedad
-  - Referencia
-translation_of: Web/API/GlobalEventHandlers/onlostpointercapture
-translation_of_original: Web/API/Element/onlostpointercapture
 original_slug: Web/API/GlobalEventHandlers/onlostpointercapture
 ---
 

--- a/files/es/web/api/element/matches/index.md
+++ b/files/es/web/api/element/matches/index.md
@@ -1,15 +1,6 @@
 ---
 title: Element.matches()
 slug: Web/API/Element/matches
-tags:
-  - API
-  - DOM
-  - Elemento
-  - Referencia
-  - metodo
-  - msMatchesSelector
-  - webkitMatchesSelector
-translation_of: Web/API/Element/matches
 ---
 
 {{APIRef}}

--- a/files/es/web/api/element/mousedown_event/index.md
+++ b/files/es/web/api/element/mousedown_event/index.md
@@ -1,12 +1,6 @@
 ---
 title: mousedown
 slug: Web/API/Element/mousedown_event
-tags:
-  - API
-  - DOM
-  - Evento
-  - Interfaz
-translation_of: Web/API/Element/mousedown_event
 ---
 
 {{ APIRef }}

--- a/files/es/web/api/element/namespaceuri/index.md
+++ b/files/es/web/api/element/namespaceuri/index.md
@@ -1,13 +1,6 @@
 ---
 title: Element.namespaceURI
 slug: Web/API/Element/namespaceURI
-tags:
-  - API
-  - Compatibilidad de los navegadores
-  - DOM
-  - Propiedad
-  - Referencia
-translation_of: Web/API/Element/namespaceURI
 ---
 
 {{APIRef}}

--- a/files/es/web/api/element/nextelementsibling/index.md
+++ b/files/es/web/api/element/nextelementsibling/index.md
@@ -1,12 +1,6 @@
 ---
 title: NonDocumentTypeChildNode.nextElementSibling
 slug: Web/API/Element/nextElementSibling
-tags:
-  - API
-  - DOM
-  - NonDocumentTypeChildNode
-  - Propiedad
-translation_of: Web/API/NonDocumentTypeChildNode/nextElementSibling
 original_slug: Web/API/NonDocumentTypeChildNode/nextElementSibling
 ---
 

--- a/files/es/web/api/element/outerhtml/index.md
+++ b/files/es/web/api/element/outerhtml/index.md
@@ -1,7 +1,6 @@
 ---
 title: Element.outerHTML
 slug: Web/API/Element/outerHTML
-translation_of: Web/API/Element/outerHTML
 ---
 
 {{APIRef}}

--- a/files/es/web/api/element/prefix/index.md
+++ b/files/es/web/api/element/prefix/index.md
@@ -1,14 +1,6 @@
 ---
 title: Element.prefix
 slug: Web/API/Element/prefix
-tags:
-  - API
-  - Compatibilidad de los Navegadores en Móviles
-  - Compatibilidad de los navegadores
-  - DOM
-  - Propiedad
-  - Referencia
-translation_of: Web/API/Element/prefix
 ---
 
 {{APIRef}}

--- a/files/es/web/api/element/previouselementsibling/index.md
+++ b/files/es/web/api/element/previouselementsibling/index.md
@@ -1,7 +1,6 @@
 ---
 title: NonDocumentTypeChildNode.previousElementSibling
 slug: Web/API/Element/previousElementSibling
-translation_of: Web/API/NonDocumentTypeChildNode/previousElementSibling
 original_slug: Web/API/NonDocumentTypeChildNode/previousElementSibling
 ---
 

--- a/files/es/web/api/element/queryselector/index.md
+++ b/files/es/web/api/element/queryselector/index.md
@@ -1,7 +1,6 @@
 ---
 title: Element.querySelector()
 slug: Web/API/Element/querySelector
-translation_of: Web/API/Element/querySelector
 ---
 
 {{APIRef}}

--- a/files/es/web/api/element/removeattribute/index.md
+++ b/files/es/web/api/element/removeattribute/index.md
@@ -1,12 +1,6 @@
 ---
 title: Element.removeAttribute()
 slug: Web/API/Element/removeAttribute
-tags:
-  - API
-  - DOM
-  - Elemento
-  - Referencia
-translation_of: Web/API/Element/removeAttribute
 ---
 
 {{ APIRef }}

--- a/files/es/web/api/element/requestfullscreen/index.md
+++ b/files/es/web/api/element/requestfullscreen/index.md
@@ -1,9 +1,6 @@
 ---
 title: Element.requestFullscreen()
 slug: Web/API/Element/requestFullScreen
-tags:
-  - Pantalla completa
-translation_of: Web/API/Element/requestFullScreen
 ---
 
 {{APIRef}}{{seeCompatTable}}

--- a/files/es/web/api/element/scroll_event/index.md
+++ b/files/es/web/api/element/scroll_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: GlobalEventHandlers.onscroll
 slug: Web/API/Element/scroll_event
-translation_of: Web/API/GlobalEventHandlers/onscroll
 original_slug: Web/API/GlobalEventHandlers/onscroll
 ---
 

--- a/files/es/web/api/element/scrollheight/index.md
+++ b/files/es/web/api/element/scrollheight/index.md
@@ -1,13 +1,6 @@
 ---
 title: Element.scrollHeight
 slug: Web/API/Element/scrollHeight
-tags:
-  - API
-  - Necesidad de Ejemplo de eliminación DHTML
-  - Propiedad
-  - Referencia
-  - Vista CSSOM
-translation_of: Web/API/Element/scrollHeight
 ---
 
 {{APIRef}}

--- a/files/es/web/api/element/scrollintoview/index.md
+++ b/files/es/web/api/element/scrollintoview/index.md
@@ -1,11 +1,6 @@
 ---
 title: Element.scrollIntoView()
 slug: Web/API/Element/scrollIntoView
-tags:
-  - Experimental
-  - Expérimental(2)
-  - metodo
-translation_of: Web/API/Element/scrollIntoView
 ---
 
 {{ APIRef("DOM")}}

--- a/files/es/web/api/element/scrollleft/index.md
+++ b/files/es/web/api/element/scrollleft/index.md
@@ -1,15 +1,6 @@
 ---
 title: Element.scrollLeft
 slug: Web/API/Element/scrollLeft
-tags:
-  - API
-  - Necesita Tabla de Compatibilidad
-  - Necesita Trabajo de Markup
-  - Necesita tabla de Especificaciones
-  - Propiedad
-  - Referencia
-  - Vista CSSOM
-translation_of: Web/API/Element/scrollLeft
 ---
 
 {{ APIRef }}

--- a/files/es/web/api/element/scrolltop/index.md
+++ b/files/es/web/api/element/scrolltop/index.md
@@ -1,7 +1,6 @@
 ---
 title: Element.scrollTop
 slug: Web/API/Element/scrollTop
-translation_of: Web/API/Element/scrollTop
 ---
 
 {{ APIRef }}

--- a/files/es/web/api/element/scrolltopmax/index.md
+++ b/files/es/web/api/element/scrolltopmax/index.md
@@ -1,15 +1,6 @@
 ---
 title: Element.scrollTopMax
 slug: Web/API/Element/scrollTopMax
-tags:
-  - API
-  - CSSOM View
-  - Elemento
-  - Propiedad
-  - Read-only
-  - Referencia
-  - Solo lectura
-translation_of: Web/API/Element/scrollTopMax
 ---
 
 {{APIRef}}{{Non-standard_header}}

--- a/files/es/web/api/element/scrollwidth/index.md
+++ b/files/es/web/api/element/scrollwidth/index.md
@@ -1,7 +1,6 @@
 ---
 title: Element.scrollWidth
 slug: Web/API/Element/scrollWidth
-translation_of: Web/API/Element/scrollWidth
 ---
 
 {{ APIRef }}

--- a/files/es/web/api/element/setattribute/index.md
+++ b/files/es/web/api/element/setattribute/index.md
@@ -1,16 +1,6 @@
 ---
 title: Element.setAttribute
 slug: Web/API/Element/setAttribute
-tags:
-  - API
-  - DOM
-  - Elemento
-  - NeedsBrowserCompatibility
-  - NeedsSpecTable
-  - Referencia
-  - metodo
-  - setAttribute
-translation_of: Web/API/Element/setAttribute
 ---
 
 {{APIRef}}

--- a/files/es/web/api/element/setattributens/index.md
+++ b/files/es/web/api/element/setattributens/index.md
@@ -1,7 +1,6 @@
 ---
 title: Element.setAttributeNS()
 slug: Web/API/Element/setAttributeNS
-translation_of: Web/API/Element/setAttributeNS
 ---
 
 {{ APIRef }}

--- a/files/es/web/api/element/setcapture/index.md
+++ b/files/es/web/api/element/setcapture/index.md
@@ -1,13 +1,6 @@
 ---
 title: Element.setCapture()
 slug: Web/API/Element/setCapture
-tags:
-  - API
-  - DOM
-  - Element
-  - Método(2)
-  - Referencia
-translation_of: Web/API/Element/setCapture
 ---
 
 {{ APIRef }}

--- a/files/es/web/api/element/tagname/index.md
+++ b/files/es/web/api/element/tagname/index.md
@@ -1,9 +1,6 @@
 ---
 title: element.tagName
 slug: Web/API/Element/tagName
-tags:
-  - Referencia_DOM_de_Gecko
-translation_of: Web/API/Element/tagName
 ---
 
 {{ APIRef }}

--- a/files/es/web/api/element/touchstart_event/index.md
+++ b/files/es/web/api/element/touchstart_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: GlobalEventHandlers.ontouchstart
 slug: Web/API/Element/touchstart_event
-translation_of: Web/API/GlobalEventHandlers/ontouchstart
 original_slug: Web/API/GlobalEventHandlers/ontouchstart
 ---
 

--- a/files/es/web/api/element/transitioncancel_event/index.md
+++ b/files/es/web/api/element/transitioncancel_event/index.md
@@ -1,12 +1,6 @@
 ---
 title: transitioncancel
 slug: Web/API/Element/transitioncancel_event
-tags:
-  - DOM
-  - Evento
-  - Referencia
-  - eventos
-translation_of: Web/API/HTMLElement/transitioncancel_event
 original_slug: Web/API/HTMLElement/transitioncancel_event
 ---
 

--- a/files/es/web/api/element/transitionend_event/index.md
+++ b/files/es/web/api/element/transitionend_event/index.md
@@ -1,15 +1,6 @@
 ---
 title: transitionend
 slug: Web/API/Element/transitionend_event
-tags:
-  - DOM
-  - Event
-  - Referencia
-  - Transiciones CSS
-  - Transiciones CSS3
-  - TransitionEvent
-  - transitionend
-translation_of: Web/API/HTMLElement/transitionend_event
 original_slug: Web/API/HTMLElement/transitionend_event
 ---
 

--- a/files/es/web/api/element/wheel_event/index.md
+++ b/files/es/web/api/element/wheel_event/index.md
@@ -1,9 +1,7 @@
 ---
 title: 'Element: wheel event'
 slug: Web/API/Element/wheel_event
-translation_of: Web/API/Element/wheel_event
 original_slug: Web/API/Element/wheel_event
-browser-compat: api.Element.wheel_event
 ---
 
 {{APIRef}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove duplicated frontmatter keys from localized content

### Motivation

Remove innecesarry duplicated data

### Additional details

Folders: api/(a|b|c|d|el)*

```
{
  "translation_of": 225,
  "tags": 133,
  "browser-compat": 17,
  "page-type": 4,
  "translation_of_original": 5
}
```

### Related issues and pull requests

Relates to #10129
Relates to #7412
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
