### PR TITLE
Fix typo in french locale on web clipboard API

### DIFF
--- a/files/fr/web/api/clipboard/write/index.md
+++ b/files/fr/web/api/clipboard/write/index.md
@@ -29,7 +29,7 @@ Une {{jsxref("Promise")}} qui sera résolut quand les données seront écrite da
 
 ## Exemple
 
-Cette fonction d'exemple remplace l'actuel contenut du presse-papier par le texte spécifié en paramètre.
+Cette fonction d'exemple remplace l'actuel contenu du presse-papier par le texte spécifié en paramètre.
 
 ```js
 function setClipboard(text) {


### PR DESCRIPTION

### Description

Fixed a typo.

### Motivation

This makes things easier to read.

