### PR TITLE
Remove duplicated frontmatter keys from web folder 4/10 [es]

### DIFF
--- a/files/es/web/api/event/bubbles/index.md
+++ b/files/es/web/api/event/bubbles/index.md
@@ -1,14 +1,6 @@
 ---
 title: event.bubbles
 slug: Web/API/Event/bubbles
-tags:
-  - Anidado
-  - DOM
-  - Propagación
-  - Referencia
-  - Referência(2)
-  - eventos
-translation_of: Web/API/Event/bubbles
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/event/cancelable/index.md
+++ b/files/es/web/api/event/cancelable/index.md
@@ -1,9 +1,6 @@
 ---
 title: event.cancelable
 slug: Web/API/Event/cancelable
-tags:
-  - Referencia_DOM_de_Gecko
-translation_of: Web/API/Event/cancelable
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/event/currenttarget/index.md
+++ b/files/es/web/api/event/currenttarget/index.md
@@ -1,12 +1,6 @@
 ---
 title: Event.currentTarget
 slug: Web/API/Event/currentTarget
-tags:
-  - API
-  - DOM
-  - Gecko
-  - Property
-translation_of: Web/API/Event/currentTarget
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/event/defaultprevented/index.md
+++ b/files/es/web/api/event/defaultprevented/index.md
@@ -1,7 +1,6 @@
 ---
 title: event.defaultPrevented
 slug: Web/API/Event/defaultPrevented
-translation_of: Web/API/Event/defaultPrevented
 ---
 
 {{ ApiRef() }}

--- a/files/es/web/api/event/event/index.md
+++ b/files/es/web/api/event/event/index.md
@@ -1,8 +1,6 @@
 ---
 title: Event()
 slug: Web/API/Event/Event
-translation_of: Web/API/Event/Event
-browser-compat: api.Event.Event
 l10n:
   sourceCommit: 4e233c16c6f0d347972c5c762f5b836318a461244e233c16c6f0d347972c5c762f5b836318a46124
 ---

--- a/files/es/web/api/event/index.md
+++ b/files/es/web/api/event/index.md
@@ -1,9 +1,6 @@
 ---
 title: evento
 slug: Web/API/Event
-tags:
-  - para_revisar
-translation_of: Web/API/Event
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/event/initevent/index.md
+++ b/files/es/web/api/event/initevent/index.md
@@ -1,9 +1,6 @@
 ---
 title: event.initEvent
 slug: Web/API/Event/initEvent
-tags:
-  - Referencia_DOM_de_Gecko
-translation_of: Web/API/Event/initEvent
 ---
 
 {{ ApiRef("DOM") }}{{deprecated_header}}

--- a/files/es/web/api/event/preventdefault/index.md
+++ b/files/es/web/api/event/preventdefault/index.md
@@ -1,9 +1,6 @@
 ---
 title: event.preventDefault
 slug: Web/API/Event/preventDefault
-tags:
-  - Referencia_DOM_de_Gecko
-translation_of: Web/API/Event/preventDefault
 ---
 
 {{ApiRef("DOM")}}

--- a/files/es/web/api/event/stoppropagation/index.md
+++ b/files/es/web/api/event/stoppropagation/index.md
@@ -1,7 +1,6 @@
 ---
 title: Event.stopPropagation()
 slug: Web/API/Event/stopPropagation
-translation_of: Web/API/Event/stopPropagation
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/event/target/index.md
+++ b/files/es/web/api/event/target/index.md
@@ -1,11 +1,6 @@
 ---
 title: Event.target
 slug: Web/API/Event/target
-tags:
-  - Evento
-  - Propiedad
-  - Referencia
-translation_of: Web/API/Event/target
 ---
 
 {{ApiRef("DOM")}}

--- a/files/es/web/api/event/type/index.md
+++ b/files/es/web/api/event/type/index.md
@@ -1,13 +1,6 @@
 ---
 title: event.type
 slug: Web/API/Event/type
-tags:
-  - API
-  - DOM
-  - Evento
-  - Propiedad
-  - Referencia
-translation_of: Web/API/Event/type
 ---
 
 {{APIRef}}

--- a/files/es/web/api/eventsource/index.md
+++ b/files/es/web/api/eventsource/index.md
@@ -1,11 +1,6 @@
 ---
 title: EventSource
 slug: Web/API/EventSource
-tags:
-  - API
-  - Eventos Server-sent
-  - Interfaz
-translation_of: Web/API/EventSource
 ---
 
 {{APIRef("Websockets API")}}

--- a/files/es/web/api/eventsource/open_event/index.md
+++ b/files/es/web/api/eventsource/open_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: EventSource.onopen
 slug: Web/API/EventSource/open_event
-translation_of: Web/API/EventSource/onopen
 original_slug: Web/API/EventSource/onopen
 ---
 

--- a/files/es/web/api/eventtarget/addeventlistener/index.md
+++ b/files/es/web/api/eventtarget/addeventlistener/index.md
@@ -1,7 +1,6 @@
 ---
 title: element.addEventListener
 slug: Web/API/EventTarget/addEventListener
-translation_of: Web/API/EventTarget/addEventListener
 ---
 
 {{apiref("DOM Events")}}

--- a/files/es/web/api/eventtarget/dispatchevent/index.md
+++ b/files/es/web/api/eventtarget/dispatchevent/index.md
@@ -1,9 +1,6 @@
 ---
 title: element.dispatchEvent
 slug: Web/API/EventTarget/dispatchEvent
-tags:
-  - Referencia_DOM_de_Gecko
-translation_of: Web/API/EventTarget/dispatchEvent
 ---
 
 {{ ApiRef("DOM Events")}}

--- a/files/es/web/api/eventtarget/index.md
+++ b/files/es/web/api/eventtarget/index.md
@@ -1,9 +1,6 @@
 ---
 title: EventTarget
 slug: Web/API/EventTarget
-tags:
-  - API
-translation_of: Web/API/EventTarget
 ---
 
 {{ ApiRef("DOM Events") }}

--- a/files/es/web/api/eventtarget/removeeventlistener/index.md
+++ b/files/es/web/api/eventtarget/removeeventlistener/index.md
@@ -1,11 +1,6 @@
 ---
 title: EventTarget.removeEventListener()
 slug: Web/API/EventTarget/removeEventListener
-tags:
-  - API
-  - DOM
-  - Event
-translation_of: Web/API/EventTarget/removeEventListener
 ---
 
 {{APIRef("DOM Events")}}

--- a/files/es/web/api/fetch/index.md
+++ b/files/es/web/api/fetch/index.md
@@ -1,17 +1,6 @@
 ---
 title: WindowOrWorkerGlobalScope.fetch()
 slug: Web/API/fetch
-tags:
-  - API
-  - Experimental
-  - Fetch
-  - Fetch API
-  - GlobalFetch
-  - Petición
-  - Referencia
-  - metodo
-  - solicitud
-translation_of: Web/API/WindowOrWorkerGlobalScope/fetch
 original_slug: Web/API/WindowOrWorkerGlobalScope/fetch
 ---
 

--- a/files/es/web/api/fetch_api/basic_concepts/index.md
+++ b/files/es/web/api/fetch_api/basic_concepts/index.md
@@ -1,7 +1,6 @@
 ---
 title: Conceptos básicos de Fetch
 slug: Web/API/Fetch_API/Basic_concepts
-translation_of: Web/API/Fetch_API/Basic_concepts
 original_slug: Web/API/Fetch_API/Conceptos_basicos
 ---
 

--- a/files/es/web/api/fetch_api/index.md
+++ b/files/es/web/api/fetch_api/index.md
@@ -1,8 +1,6 @@
 ---
 title: Fetch API
 slug: Web/API/Fetch_API
-translation_of: Web/API/Fetch_API
-browser-compat: api.fetch
 ---
 
 {{DefaultAPISidebar("Fetch API")}}

--- a/files/es/web/api/fetch_api/using_fetch/index.md
+++ b/files/es/web/api/fetch_api/using_fetch/index.md
@@ -1,9 +1,7 @@
 ---
 title: Uso de Fetch
 slug: Web/API/Fetch_API/Using_Fetch
-translation_of: Web/API/Fetch_API/Using_Fetch
 original_slug: Web/API/Fetch_API/Utilizando_Fetch
-browser-compat: api.fetch
 ---
 
 {{DefaultAPISidebar("Fetch API")}}{{ SeeCompatTable }}

--- a/files/es/web/api/fetchevent/index.md
+++ b/files/es/web/api/fetchevent/index.md
@@ -1,15 +1,6 @@
 ---
 title: FetchEvent
 slug: Web/API/FetchEvent
-tags:
-  - API
-  - FetchEvent
-  - Interfaz
-  - Offline
-  - Referencia
-  - Service Workers
-  - Workers
-translation_of: Web/API/FetchEvent
 ---
 
 {{APIRef("Service Workers API")}}{{ SeeCompatTable() }}

--- a/files/es/web/api/file/index.md
+++ b/files/es/web/api/file/index.md
@@ -1,13 +1,6 @@
 ---
 title: File
 slug: Web/API/File
-tags:
-  - API
-  - File API
-  - Interfaz
-  - Referencia
-  - Web
-translation_of: Web/API/File
 ---
 
 {{APIRef }}

--- a/files/es/web/api/file/lastmodifieddate/index.md
+++ b/files/es/web/api/file/lastmodifieddate/index.md
@@ -1,16 +1,6 @@
 ---
 title: File.lastModifiedDate
 slug: Web/API/File/lastModifiedDate
-tags:
-  - API
-  - Archivo
-  - Archivos
-  - Deprecado
-  - File API
-  - Propiedad
-  - Referencia
-  - Solo lectura
-translation_of: Web/API/File/lastModifiedDate
 ---
 
 {{APIRef("File API") }} {{deprecated_header}}

--- a/files/es/web/api/file/name/index.md
+++ b/files/es/web/api/file/name/index.md
@@ -1,13 +1,6 @@
 ---
 title: File.name
 slug: Web/API/File/name
-tags:
-  - API
-  - Archivo
-  - Archivos
-  - Propiedad
-  - Referencia
-translation_of: Web/API/File/name
 ---
 
 {{APIRef("File API")}}

--- a/files/es/web/api/file/webkitrelativepath/index.md
+++ b/files/es/web/api/file/webkitrelativepath/index.md
@@ -1,15 +1,6 @@
 ---
 title: File.webkitRelativePath
 slug: Web/API/File/webkitRelativePath
-tags:
-  - Archivo
-  - Entidades Archivo y Directorio de la API
-  - File API
-  - Propiedad
-  - Referencia
-  - Solo lectura
-  - Web
-translation_of: Web/API/File/webkitRelativePath
 ---
 
 {{APIRef("File API")}}{{non-standard_header}}

--- a/files/es/web/api/file_api/using_files_from_web_applications/index.md
+++ b/files/es/web/api/file_api/using_files_from_web_applications/index.md
@@ -1,16 +1,6 @@
 ---
 title: Utilizar ficheros desde aplicaciones web
 slug: Web/API/File_API/Using_files_from_web_applications
-tags:
-  - Basura
-  - Ficheros
-  - HTML5
-  - HacerNavegadorAgnóstico
-  - Intermedio
-  - NecesitaActualizar
-  - Subir
-  - ajax actualización
-translation_of: Web/API/File/Using_files_from_web_applications
 original_slug: Web/API/File/Using_files_from_web_applications
 ---
 

--- a/files/es/web/api/filereader/index.md
+++ b/files/es/web/api/filereader/index.md
@@ -1,7 +1,6 @@
 ---
 title: FileReader
 slug: Web/API/FileReader
-translation_of: Web/API/FileReader
 ---
 
 {{ APIRef("File API") }}

--- a/files/es/web/api/filereader/load_event/index.md
+++ b/files/es/web/api/filereader/load_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: FileReader.onload
 slug: Web/API/FileReader/load_event
-tags:
-  - Archivo
-  - Controlador de Eventos
-  - Lector de Archivos
-  - Propiedad
-  - Referencia
-translation_of: Web/API/FileReader/onload
 original_slug: Web/API/FileReader/onload
 ---
 

--- a/files/es/web/api/filereader/readasarraybuffer/index.md
+++ b/files/es/web/api/filereader/readasarraybuffer/index.md
@@ -1,17 +1,6 @@
 ---
 title: FileReader.readAsArrayBuffer()
 slug: Web/API/FileReader/readAsArrayBuffer
-tags:
-  - API
-  - DOM
-  - File API
-  - FileReader
-  - Files
-  - Method
-  - Reference
-  - readAsArrayBuffer
-browser-compat: api.FileReader.readAsArrayBuffer
-translation_of: Web/API/FileReader/readAsArrayBuffer
 ---
 
 {{APIRef("File API")}}

--- a/files/es/web/api/filereader/readasdataurl/index.md
+++ b/files/es/web/api/filereader/readasdataurl/index.md
@@ -1,8 +1,6 @@
 ---
 title: FileReader.readAsDataURL()
 slug: Web/API/FileReader/readAsDataURL
-translation_of: Web/API/FileReader/readAsDataURL
-browser-compat: api.FileReader.readAsDataURL
 ---
 
 El método `readAsDataURL` es usado para leer el contenido del especificado {{domxref("Blob")}} o {{domxref("File")}}.  Cuando la operación de lectura es terminada, el {{domxref("FileReader.readyState","readyState")}} se convierte en `DONE`, y el [`loadend`](/es/docs/Web/Reference/Events/loadend) es lanzado. En ese momento, el atributo {{domxref("FileReader.result","result")}} contiene la información como un [datos: URL](/es/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) representando la información del archivo como una cadena de caracteres codificados en base64.

--- a/files/es/web/api/filereader/readastext/index.md
+++ b/files/es/web/api/filereader/readastext/index.md
@@ -1,12 +1,6 @@
 ---
 title: FileReader.readAsText()
 slug: Web/API/FileReader/readAsText
-tags:
-  - API
-  - File API
-  - api de lectura de archivos
-  - leer archivos
-translation_of: Web/API/FileReader/readAsText
 ---
 
 {{APIRef("File API")}}

--- a/files/es/web/api/filereader/result/index.md
+++ b/files/es/web/api/filereader/result/index.md
@@ -1,11 +1,6 @@
 ---
 title: FileReader.result
 slug: Web/API/FileReader/result
-tags:
-  - API
-  - Archivos
-  - Ficheros
-translation_of: Web/API/FileReader/result
 ---
 
 {{APIRef("File API")}}La propiedad **`result`** de {{domxref("FileReader")}} retorna el contenido del archivo. Esta propiedad es válida únicamente después de que la operación de lectura del archivo es completada. El formato de la infomación devuelta depende de cuál de los métodos de lectura fue usado.

--- a/files/es/web/api/formdata/index.md
+++ b/files/es/web/api/formdata/index.md
@@ -1,13 +1,6 @@
 ---
 title: FormData
 slug: Web/API/FormData
-tags:
-  - API
-  - FormData
-  - Interfaz
-  - Referencia
-  - XMLHttpRequest
-translation_of: Web/API/FormData
 original_slug: Web/API/XMLHttpRequest/FormData
 ---
 

--- a/files/es/web/api/formdata/using_formdata_objects/index.md
+++ b/files/es/web/api/formdata/using_formdata_objects/index.md
@@ -1,8 +1,6 @@
 ---
 title: Usando Objetos FormData
 slug: Web/API/FormData/Using_FormData_Objects
-translation_of: Web/API/FormData/Using_FormData_Objects
-translation_of_original: Web/Guide/Using_FormData_Objects
 original_slug: Web/Guide/Usando_Objetos_FormData
 ---
 

--- a/files/es/web/api/fullscreen_api/index.md
+++ b/files/es/web/api/fullscreen_api/index.md
@@ -1,7 +1,6 @@
 ---
 title: Fullscreen API
 slug: Web/API/Fullscreen_API
-translation_of: Web/API/Fullscreen_API
 ---
 
 {{DefaultAPISidebar("Fullscreen API")}}

--- a/files/es/web/api/gamepad_api/index.md
+++ b/files/es/web/api/gamepad_api/index.md
@@ -1,12 +1,6 @@
 ---
 title: Gamepad API
 slug: Web/API/Gamepad_API
-tags:
-  - API
-  - Experimental
-  - Gamepad API
-  - juegos
-translation_of: Web/API/Gamepad_API
 ---
 
 {{DefaultAPISidebar("Gamepad API")}}

--- a/files/es/web/api/gamepadbutton/index.md
+++ b/files/es/web/api/gamepadbutton/index.md
@@ -1,12 +1,6 @@
 ---
 title: GamepadButton
 slug: Web/API/GamepadButton
-tags:
-  - API
-  - API Gamepad
-  - Referencia
-  - juegos
-translation_of: Web/API/GamepadButton
 ---
 
 {{APIRef("Gamepad API")}}

--- a/files/es/web/api/geolocation/clearwatch/index.md
+++ b/files/es/web/api/geolocation/clearwatch/index.md
@@ -1,8 +1,6 @@
 ---
 title: Geolocation.clearWatch()
 slug: Web/API/Geolocation/clearWatch
-page-type: web-api-instance-method
-browser-compat: api.Geolocation.clearWatch
 l10n:
   sourceCommit: 8573240024adc1eef906b4b2df35567144fd733e
 ---

--- a/files/es/web/api/geolocation/getcurrentposition/index.md
+++ b/files/es/web/api/geolocation/getcurrentposition/index.md
@@ -1,8 +1,6 @@
 ---
 title: Geolocation.getCurrentPosition()
 slug: Web/API/Geolocation/getCurrentPosition
-page-type: web-api-instance-method
-browser-compat: api.Geolocation.getCurrentPosition
 l10n:
   sourceCommit: 8573240024adc1eef906b4b2df35567144fd733e
 ---

--- a/files/es/web/api/geolocation/index.md
+++ b/files/es/web/api/geolocation/index.md
@@ -1,7 +1,6 @@
 ---
 title: Geolocalización
 slug: Web/API/Geolocation
-translation_of: Web/API/Geolocation
 ---
 
 {{APIRef("Geolocation API")}}

--- a/files/es/web/api/geolocation/watchposition/index.md
+++ b/files/es/web/api/geolocation/watchposition/index.md
@@ -1,8 +1,6 @@
 ---
 title: Geolocation.watchPosition()
 slug: Web/API/Geolocation/watchPosition
-page-type: web-api-instance-method
-browser-compat: api.Geolocation.watchPosition
 l10n:
   sourceCommit: 8573240024adc1eef906b4b2df35567144fd733e
 ---

--- a/files/es/web/api/geolocation_api/index.md
+++ b/files/es/web/api/geolocation_api/index.md
@@ -1,7 +1,6 @@
 ---
 title: API de geolocalización
 slug: Web/API/Geolocation_API
-translation_of: Web/API/Geolocation_API
 original_slug: WebAPI/Using_geolocation
 ---
 

--- a/files/es/web/api/geolocationcoordinates/index.md
+++ b/files/es/web/api/geolocationcoordinates/index.md
@@ -1,7 +1,6 @@
 ---
 title: Coordinates
 slug: Web/API/GeolocationCoordinates
-translation_of: Web/API/GeolocationCoordinates
 ---
 {{APIRef("Geolocation API")}}
 

--- a/files/es/web/api/geolocationcoordinates/latitude/index.md
+++ b/files/es/web/api/geolocationcoordinates/latitude/index.md
@@ -1,7 +1,6 @@
 ---
 title: Coordinates.latitude
 slug: Web/API/GeolocationCoordinates/latitude
-translation_of: Web/API/GeolocationCoordinates/latitude
 ---
 
 {{APIRef("Geolocation API")}}

--- a/files/es/web/api/geolocationposition/index.md
+++ b/files/es/web/api/geolocationposition/index.md
@@ -1,15 +1,6 @@
 ---
 title: Position
 slug: Web/API/GeolocationPosition
-tags:
-  - API
-  - Contexto seguro
-  - Geolocalización
-  - Geolocation API
-  - Interfaz
-  - Posición
-  - Position
-translation_of: Web/API/GeolocationPosition
 ---
 
 {{securecontext_header}}{{APIRef("Geolocation API")}}

--- a/files/es/web/api/history/index.md
+++ b/files/es/web/api/history/index.md
@@ -1,15 +1,6 @@
 ---
 title: History
 slug: Web/API/History
-tags:
-  - API
-  - HTML DOM
-  - History API
-  - Interface
-  - NeedsTranslation
-  - TopicStub
-  - Web
-translation_of: Web/API/History
 ---
 
 {{ APIRef("History API") }}

--- a/files/es/web/api/history/length/index.md
+++ b/files/es/web/api/history/length/index.md
@@ -1,16 +1,6 @@
 ---
 title: History.length
 slug: Web/API/History/length
-tags:
-  - API
-  - DOM HTML
-  - Historial de navegación
-  - History
-  - Lectura
-  - Navegador
-  - Propiedad
-  - historial
-translation_of: Web/API/History/length
 ---
 
 {{APIRef("History API")}}

--- a/files/es/web/api/history/pushstate/index.md
+++ b/files/es/web/api/history/pushstate/index.md
@@ -1,19 +1,6 @@
 ---
 title: History.pushState()
 slug: Web/API/History/pushState
-tags:
-  - API
-  - DOM HTML
-  - Historial de navegación
-  - History
-  - History API
-  - Navegador
-  - Sesion
-  - URL
-  - Web
-  - historial
-  - pushState
-translation_of: Web/API/History/pushState
 ---
 
 {{APIRef("History API")}}

--- a/files/es/web/api/history_api/index.md
+++ b/files/es/web/api/history_api/index.md
@@ -1,11 +1,6 @@
 ---
 title: Manipulando el historial del navegador
 slug: Web/API/History_API
-tags:
-  - HTML5
-  - historial
-  - para_revisar
-translation_of: Web/API/History_API
 original_slug: DOM/Manipulando_el_historial_del_navegador
 ---
 

--- a/files/es/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
+++ b/files/es/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
@@ -1,13 +1,6 @@
 ---
 title: Drag & Drop archivo
 slug: Web/API/HTML_Drag_and_Drop_API/File_drag_and_drop
-tags:
-  - Guía
-  - arrastra y suelta
-  - drag and drop
-  - drop zone
-  - zona de arrastre
-translation_of: Web/API/HTML_Drag_and_Drop_API/File_drag_and_drop
 original_slug: DragDrop/Drag_and_Drop/drag_and_drop_archivo
 ---
 

--- a/files/es/web/api/html_drag_and_drop_api/index.md
+++ b/files/es/web/api/html_drag_and_drop_api/index.md
@@ -1,10 +1,6 @@
 ---
 title: Arrastrar y soltar
 slug: Web/API/HTML_Drag_and_Drop_API
-tags:
-  - HTML5
-  - XUL
-translation_of: Web/API/HTML_Drag_and_Drop_API
 original_slug: DragDrop/Drag_and_Drop
 ---
 

--- a/files/es/web/api/htmlanchorelement/index.md
+++ b/files/es/web/api/htmlanchorelement/index.md
@@ -1,12 +1,6 @@
 ---
 title: HTMLAnchorElement
 slug: Web/API/HTMLAnchorElement
-tags:
-  - API
-  - HTML DOM
-  - Interfaz
-  - Referencia
-translation_of: Web/API/HTMLAnchorElement
 ---
 
 {{APIRef ("HTML DOM")}}

--- a/files/es/web/api/htmlaudioelement/index.md
+++ b/files/es/web/api/htmlaudioelement/index.md
@@ -1,12 +1,6 @@
 ---
 title: HTMLAudioElement
 slug: Web/API/HTMLAudioElement
-tags:
-  - DOM
-  - HTML
-  - Media
-  - para_revisar
-translation_of: Web/API/HTMLAudioElement
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/es/web/api/htmlcanvaselement/getcontext/index.md
+++ b/files/es/web/api/htmlcanvaselement/getcontext/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLCanvasElement.getContext()
 slug: Web/API/HTMLCanvasElement/getContext
-translation_of: Web/API/HTMLCanvasElement/getContext
 ---
 
 {{APIRef("Canvas API")}}

--- a/files/es/web/api/htmlcanvaselement/height/index.md
+++ b/files/es/web/api/htmlcanvaselement/height/index.md
@@ -1,9 +1,6 @@
 ---
 title: HTMLCanvasElement.height
 slug: Web/API/HTMLCanvasElement/height
-tags:
-  - Propiedad
-translation_of: Web/API/HTMLCanvasElement/height
 ---
 
 {{APIRef("Canvas API")}}

--- a/files/es/web/api/htmlcanvaselement/index.md
+++ b/files/es/web/api/htmlcanvaselement/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLCanvasElement
 slug: Web/API/HTMLCanvasElement
-translation_of: Web/API/HTMLCanvasElement
 ---
 
 {{APIRef("Canvas API")}}

--- a/files/es/web/api/htmlcanvaselement/todataurl/index.md
+++ b/files/es/web/api/htmlcanvaselement/todataurl/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLCanvasElement.toDataURL()
 slug: Web/API/HTMLCanvasElement/toDataURL
-tags:
-  - API
-  - Canvas
-  - HTMLCanvasElement
-  - Lienzo
-  - Referencia
-  - metodo
-translation_of: Web/API/HTMLCanvasElement/toDataURL
 ---
 
 {{APIRef("Canvas API")}}

--- a/files/es/web/api/htmlcanvaselement/width/index.md
+++ b/files/es/web/api/htmlcanvaselement/width/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLCanvasElement.width
 slug: Web/API/HTMLCanvasElement/width
-translation_of: Web/API/HTMLCanvasElement/width
 ---
 
 {{APIRef("Canvas API")}}

--- a/files/es/web/api/htmlcollection/index.md
+++ b/files/es/web/api/htmlcollection/index.md
@@ -1,16 +1,6 @@
 ---
 title: HTMLCollection
 slug: Web/API/HTMLCollection
-tags:
-  - API
-  - DOM
-  - HTML DOM
-  - HTMLCollection
-  - Interfaz
-  - Lista de elementos
-  - Referencia
-  - Referência DOM
-translation_of: Web/API/HTMLCollection
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/es/web/api/htmldialogelement/close_event/index.md
+++ b/files/es/web/api/htmldialogelement/close_event/index.md
@@ -1,10 +1,6 @@
 ---
 title: GlobalEventHandlers.onclose
 slug: Web/API/HTMLDialogElement/close_event
-tags:
-  - Propiedad
-  - Referencia
-translation_of: Web/API/GlobalEventHandlers/onclose
 original_slug: Web/API/GlobalEventHandlers/onclose
 ---
 

--- a/files/es/web/api/htmldivelement/index.md
+++ b/files/es/web/api/htmldivelement/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLDivElement
 slug: Web/API/HTMLDivElement
-tags:
-  - API
-  - HTML DOM
-  - Interfaz
-  - NeedsNewLayout
-  - Referencia
-translation_of: Web/API/HTMLDivElement
 ---
 
 {{ APIRef("HTML DOM") }}

--- a/files/es/web/api/htmlelement/accesskey/index.md
+++ b/files/es/web/api/htmlelement/accesskey/index.md
@@ -1,12 +1,6 @@
 ---
 title: Element.accessKey
 slug: Web/API/HTMLElement/accessKey
-tags:
-  - API
-  - Propiedad
-  - necesidades de contenido
-translation_of: Web/API/HTMLElement/accessKey
-translation_of_original: Web/API/Element/accessKey
 original_slug: Web/API/Element/accessKey
 ---
 

--- a/files/es/web/api/htmlelement/change_event/index.md
+++ b/files/es/web/api/htmlelement/change_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'HTMLElement: Evento change'
 slug: Web/API/HTMLElement/change_event
-tags:
-  - Change
-  - DOM
-  - Evento
-  - HTML
-  - Referencia
-  - Web
-translation_of: Web/API/HTMLElement/change_event
 ---
 
 {{APIRef}}

--- a/files/es/web/api/htmlelement/click/index.md
+++ b/files/es/web/api/htmlelement/click/index.md
@@ -1,11 +1,6 @@
 ---
 title: HTMLElement.click()
 slug: Web/API/HTMLElement/click
-tags:
-  - HTMLElement
-  - Referencia
-  - metodo
-translation_of: Web/API/HTMLElement/click
 ---
 
 {{ APIRef("HTML DOM") }}

--- a/files/es/web/api/htmlelement/contenteditable/index.md
+++ b/files/es/web/api/htmlelement/contenteditable/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLElement.contentEditable
 slug: Web/API/HTMLElement/contentEditable
-translation_of: Web/API/HTMLElement/contentEditable
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/es/web/api/htmlelement/dragover_event/index.md
+++ b/files/es/web/api/htmlelement/dragover_event/index.md
@@ -1,10 +1,7 @@
 ---
-title: "HTMLElement: dragover event"
+title: 'HTMLElement: dragover event'
 slug: Web/API/HTMLElement/dragover_event
-translation_of: Web/API/HTMLElement/dragover_event
 original_slug: Web/API/HTMLElement/dragover_event
-page-type: web-api-event
-browser-compat: api.HTMLElement.dragover_event
 ---
 
 {{APIRef}}

--- a/files/es/web/api/htmlelement/dragstart_event/index.md
+++ b/files/es/web/api/htmlelement/dragstart_event/index.md
@@ -1,10 +1,7 @@
 ---
-title: "HTMLElement: dragstart event"
+title: 'HTMLElement: dragstart event'
 slug: Web/API/HTMLElement/dragstart_event
-translation_of: Web/API/HTMLElement/dragstart_event
 original_slug: Web/API/HTMLElement/dragstart_event
-page-type: web-api-event
-browser-compat: api.HTMLElement.dragstart_event
 ---
 
 El evento `dragstart` se dispara cuando el usuario arrastra un elemento o una selección de texto.

--- a/files/es/web/api/htmlelement/index.md
+++ b/files/es/web/api/htmlelement/index.md
@@ -1,9 +1,6 @@
 ---
 title: HTMLElement
 slug: Web/API/HTMLElement
-tags:
-  - API
-translation_of: Web/API/HTMLElement
 ---
 
 {{ APIRef("HTML DOM") }}La interfaz **`HTMLElement`** representa cualquier elemento [HTML](/es/docs/Web/HTML). Algunos elementos implementan directamente esta interfaz, otros la implementan a través de una interfaz que hereda de ella.

--- a/files/es/web/api/htmlelement/input_event/index.md
+++ b/files/es/web/api/htmlelement/input_event/index.md
@@ -1,12 +1,6 @@
 ---
 title: Evento input
 slug: Web/API/HTMLElement/input_event
-tags:
-  - DOM
-  - Evento
-  - InputEvent
-  - Referencia
-translation_of: Web/API/HTMLElement/input_event
 ---
 
 {{APIRef}}

--- a/files/es/web/api/htmlelement/offsetheight/index.md
+++ b/files/es/web/api/htmlelement/offsetheight/index.md
@@ -1,11 +1,6 @@
 ---
 title: HTMLElement.offsetHeight
 slug: Web/API/HTMLElement/offsetHeight
-tags:
-  - API
-  - Propiedad
-  - Referencia
-translation_of: Web/API/HTMLElement/offsetHeight
 ---
 
 {{ APIRef("HTML DOM") }}

--- a/files/es/web/api/htmlelement/offsetleft/index.md
+++ b/files/es/web/api/htmlelement/offsetleft/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLElement.offsetLeft
 slug: Web/API/HTMLElement/offsetLeft
-translation_of: Web/API/HTMLElement/offsetLeft
 ---
 
 {{ APIRef("HTML DOM") }}

--- a/files/es/web/api/htmlelement/offsetparent/index.md
+++ b/files/es/web/api/htmlelement/offsetparent/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLElement.offsetParent
 slug: Web/API/HTMLElement/offsetParent
-tags:
-  - API
-  - CSSOM View
-  - Propiedad
-  - Reference
-  - Referencia
-translation_of: Web/API/HTMLElement/offsetParent
 ---
 
 {{ APIRef("HTML DOM") }}

--- a/files/es/web/api/htmlelement/offsettop/index.md
+++ b/files/es/web/api/htmlelement/offsettop/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLElement.offsetTop
 slug: Web/API/HTMLElement/offsetTop
-translation_of: Web/API/HTMLElement/offsetTop
 ---
 
 {{ APIRef("HTML DOM") }}

--- a/files/es/web/api/htmlelement/offsetwidth/index.md
+++ b/files/es/web/api/htmlelement/offsetwidth/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLElement.offsetWidth
 slug: Web/API/HTMLElement/offsetWidth
-translation_of: Web/API/HTMLElement/offsetWidth
 ---
 
 {{ APIRef("HTML DOM") }}

--- a/files/es/web/api/htmlformelement/index.md
+++ b/files/es/web/api/htmlformelement/index.md
@@ -1,11 +1,6 @@
 ---
 title: form
 slug: Web/API/HTMLFormElement
-tags:
-  - DOM
-  - Referencia_DOM_de_Gecko
-  - Todas_las_Categorías
-translation_of: Web/API/HTMLFormElement
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/es/web/api/htmlformelement/reset/index.md
+++ b/files/es/web/api/htmlformelement/reset/index.md
@@ -1,15 +1,6 @@
 ---
 title: HTMLFormElement.reset()
 slug: Web/API/HTMLFormElement/reset
-tags:
-  - API
-  - HTML DOM
-  - HTMLFormElement
-  - Method
-  - NeedsMarkupWork
-  - NeedsSpecTable
-  - Referencia
-translation_of: Web/API/HTMLFormElement/reset
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/es/web/api/htmlformelement/submit_event/index.md
+++ b/files/es/web/api/htmlformelement/submit_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: GlobalEventHandlers.onsubmit
 slug: Web/API/HTMLFormElement/submit_event
-translation_of: Web/API/GlobalEventHandlers/onsubmit
 original_slug: Web/API/GlobalEventHandlers/onsubmit
 ---
 

--- a/files/es/web/api/htmlheadelement/index.md
+++ b/files/es/web/api/htmlheadelement/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLHeadElement
 slug: Web/API/HTMLHeadElement
-translation_of: Web/API/HTMLHeadElement
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/es/web/api/htmlimageelement/image/index.md
+++ b/files/es/web/api/htmlimageelement/image/index.md
@@ -1,7 +1,6 @@
 ---
 title: Image()
 slug: Web/API/HTMLImageElement/Image
-translation_of: Web/API/HTMLImageElement/Image
 ---
 
 {{ APIRef("HTML DOM") }}

--- a/files/es/web/api/htmlimageelement/index.md
+++ b/files/es/web/api/htmlimageelement/index.md
@@ -1,12 +1,6 @@
 ---
 title: HTMLImageElement
 slug: Web/API/HTMLImageElement
-tags:
-  - API
-  - HTML DOM
-  - Interfaz
-  - Reference
-translation_of: Web/API/HTMLImageElement
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/es/web/api/htmlinputelement/index.md
+++ b/files/es/web/api/htmlinputelement/index.md
@@ -1,18 +1,6 @@
 ---
 title: HTMLInputElement
 slug: Web/API/HTMLInputElement
-tags:
-  - API
-  - HTML DOM
-  - HTMLInputElement
-  - Input
-  - Interface
-  - NeedsContent
-  - NeedsMarkupWork
-  - NeedsTranslation
-  - Reference
-  - TopicStub
-translation_of: Web/API/HTMLInputElement
 ---
 
 {{ APIRef("HTML DOM") }}

--- a/files/es/web/api/htmlinputelement/invalid_event/index.md
+++ b/files/es/web/api/htmlinputelement/invalid_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: Evento invalid
 slug: Web/API/HTMLInputElement/invalid_event
-tags:
-  - Evento
-  - Referencia
-  - eventos
-  - formulários
-  - invalid
-  - inválido
-translation_of: Web/API/HTMLInputElement/invalid_event
 ---
 
 {{APIRef}}

--- a/files/es/web/api/htmlinputelement/select/index.md
+++ b/files/es/web/api/htmlinputelement/select/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLInputElement.select()
 slug: Web/API/HTMLInputElement/select
-tags:
-  - API
-  - HTML DOM
-  - HTMLInputElement
-  - NeedsCompatTable
-  - Referencia
-  - metodo
-translation_of: Web/API/HTMLInputElement/select
 ---
 
 {{ APIRef("HTML DOM") }}

--- a/files/es/web/api/htmlinputelement/select_event/index.md
+++ b/files/es/web/api/htmlinputelement/select_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: GlobalEventHandlers.onselect
 slug: Web/API/HTMLInputElement/select_event
-translation_of: Web/API/GlobalEventHandlers/onselect
 original_slug: Web/API/GlobalEventHandlers/onselect
 ---
 

--- a/files/es/web/api/htmllabelelement/index.md
+++ b/files/es/web/api/htmllabelelement/index.md
@@ -1,13 +1,6 @@
 ---
 title: HTMLLabelElement
 slug: Web/API/HTMLLabelElement
-tags:
-  - API
-  - HTML DOM
-  - HTMLLabeledElement
-  - Interface
-  - Referencia
-translation_of: Web/API/HTMLLabelElement
 ---
 
 {{ APIRef("HTML DOM") }}

--- a/files/es/web/api/htmllielement/index.md
+++ b/files/es/web/api/htmllielement/index.md
@@ -1,10 +1,6 @@
 ---
 title: HTMLLIElement
 slug: Web/API/HTMLLIElement
-tags:
-  - API
-  - HTML DOM
-translation_of: Web/API/HTMLLIElement
 ---
 
 {{ APIRef("HTML DOM") }}

--- a/files/es/web/api/htmlmediaelement/canplay_event/index.md
+++ b/files/es/web/api/htmlmediaelement/canplay_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: 'HTMLMediaElement: canplay'
 slug: Web/API/HTMLMediaElement/canplay_event
-translation_of: Web/API/HTMLMediaElement/canplay_event
 ---
 
 El evento canplay es lanzado cuando el elemento [\<video>](/es/docs/Web/HTML/Elemento/video) o [\<audio>](/es/docs/Web/HTML/Elemento/Audio) puede ser iniciado o fue iniciado satisfactoriamente.

--- a/files/es/web/api/htmlmediaelement/index.md
+++ b/files/es/web/api/htmlmediaelement/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLMediaElement
 slug: Web/API/HTMLMediaElement
-translation_of: Web/API/HTMLMediaElement
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/es/web/api/htmlmediaelement/loadeddata_event/index.md
+++ b/files/es/web/api/htmlmediaelement/loadeddata_event/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'HTMLMediaElement: loadeddata event'
 slug: Web/API/HTMLMediaElement/loadeddata_event
-tags:
-  - Audio
-  - HTMLMediaElement
-  - Referências
-  - Video
-  - eventos
-translation_of: Web/API/HTMLMediaElement/loadeddata_event
 ---
 
 {{APIRef("HTMLMediaElement")}}

--- a/files/es/web/api/htmlmediaelement/pause/index.md
+++ b/files/es/web/api/htmlmediaelement/pause/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLMediaElement.pause()
 slug: Web/API/HTMLMediaElement/pause
-translation_of: Web/API/HTMLMediaElement/pause
 ---
 {{APIRef("HTML DOM")}}
 

--- a/files/es/web/api/htmlmediaelement/paused/index.md
+++ b/files/es/web/api/htmlmediaelement/paused/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLMediaElement.paused
 slug: Web/API/HTMLMediaElement/paused
-translation_of: Web/API/HTMLMediaElement/paused
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/es/web/api/htmlmediaelement/play/index.md
+++ b/files/es/web/api/htmlmediaelement/play/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLMediaElement.play()
 slug: Web/API/HTMLMediaElement/play
-translation_of: Web/API/HTMLMediaElement/play
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/es/web/api/htmlmediaelement/timeupdate_event/index.md
+++ b/files/es/web/api/htmlmediaelement/timeupdate_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: 'HTMLMediaElement: timeupdate'
 slug: Web/API/HTMLMediaElement/timeupdate_event
-translation_of: Web/API/HTMLMediaElement/timeupdate_event
 ---
 
 El evento `timeupdate` es llamado cuando el tiempo indicado por el atributo `currentTime` es actualizado.

--- a/files/es/web/api/htmlselectelement/checkvalidity/index.md
+++ b/files/es/web/api/htmlselectelement/checkvalidity/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLSelectElement.checkValidity()
 slug: Web/API/HTMLSelectElement/checkValidity
-tags:
-  - API
-  - Constraint Validation API
-  - HTML DOM
-  - HTMLSelectElement
-  - Referencia
-  - metodo
-translation_of: Web/API/HTMLSelectElement/checkValidity
 ---
 
 {{ APIRef("HTML DOM") }}

--- a/files/es/web/api/htmlselectelement/index.md
+++ b/files/es/web/api/htmlselectelement/index.md
@@ -1,14 +1,6 @@
 ---
 title: HTMLSelectElement
 slug: Web/API/HTMLSelectElement
-tags:
-  - API
-  - HTML DOM
-  - Interface
-  - NeedsTranslation
-  - Reference
-  - TopicStub
-translation_of: Web/API/HTMLSelectElement
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/es/web/api/htmlselectelement/setcustomvalidity/index.md
+++ b/files/es/web/api/htmlselectelement/setcustomvalidity/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLSelectElement.setCustomValidity()
 slug: Web/API/HTMLSelectElement/setCustomValidity
-translation_of: Web/API/HTMLSelectElement/setCustomValidity
 ---
 
 {{ APIRef("HTML DOM") }}

--- a/files/es/web/api/htmlshadowelement/getdistributednodes/index.md
+++ b/files/es/web/api/htmlshadowelement/getdistributednodes/index.md
@@ -1,9 +1,6 @@
 ---
 title: HTMLShadowElement.getDistributedNodes()
 slug: Web/API/HTMLShadowElement/getDistributedNodes
-tags:
-  - Necesita traducción
-translation_of: Web/API/HTMLShadowElement/getDistributedNodes
 ---
 
 {{APIRef("Web Components")}}

--- a/files/es/web/api/htmlshadowelement/index.md
+++ b/files/es/web/api/htmlshadowelement/index.md
@@ -1,9 +1,6 @@
 ---
 title: HTMLShadowElement
 slug: Web/API/HTMLShadowElement
-tags:
-  - Necesita traducción
-translation_of: Web/API/HTMLShadowElement
 ---
 
 {{APIRef("Web Components")}}{{Deprecated_Header}}

--- a/files/es/web/api/htmlstyleelement/index.md
+++ b/files/es/web/api/htmlstyleelement/index.md
@@ -1,12 +1,6 @@
 ---
 title: HTMLStyleElement
 slug: Web/API/HTMLStyleElement
-tags:
-  - DOM
-  - Referencia_DOM_de_Gecko
-  - Todas_las_Categorías
-  - para_revisar
-translation_of: Web/API/HTMLStyleElement
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/es/web/api/htmltableelement/align/index.md
+++ b/files/es/web/api/htmltableelement/align/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLTableElement.align
 slug: Web/API/HTMLTableElement/align
-translation_of: Web/API/HTMLTableElement/align
 ---
 
 {{APIRef("HTML DOM")}}{{deprecated_header()}}

--- a/files/es/web/api/htmltableelement/index.md
+++ b/files/es/web/api/htmltableelement/index.md
@@ -1,12 +1,6 @@
 ---
 title: table
 slug: Web/API/HTMLTableElement
-tags:
-  - DOM
-  - Referencia_DOM_de_Gecko
-  - Todas_las_Categorías
-  - para_revisar
-translation_of: Web/API/HTMLTableElement
 ---
 
 {{ ApiRef() }}

--- a/files/es/web/api/htmltableelement/insertrow/index.md
+++ b/files/es/web/api/htmltableelement/insertrow/index.md
@@ -1,7 +1,6 @@
 ---
 title: HTMLTableElement.insertRow()
 slug: Web/API/HTMLTableElement/insertRow
-translation_of: Web/API/HTMLTableElement/insertRow
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/es/web/api/htmlvideoelement/index.md
+++ b/files/es/web/api/htmlvideoelement/index.md
@@ -1,7 +1,6 @@
 ---
 title: Elementos HTML para Video
 slug: Web/API/HTMLVideoElement
-translation_of: Web/API/HTMLVideoElement
 original_slug: Web/API/ElementosHTMLparaVideo
 ---
 

--- a/files/es/web/api/idbcursor/continue/index.md
+++ b/files/es/web/api/idbcursor/continue/index.md
@@ -1,16 +1,6 @@
 ---
 title: IDBCursor.continue()
 slug: Web/API/IDBCursor/continue
-tags:
-  - API
-  - Almacen
-  - Basededatos
-  - Continuar
-  - CursorIDB
-  - IndexadoIDB
-  - Referencia
-  - metodo
-translation_of: Web/API/IDBCursor/continue
 ---
 
 {{APIRef("IndexedDB")}}

--- a/files/es/web/api/idbcursor/index.md
+++ b/files/es/web/api/idbcursor/index.md
@@ -1,18 +1,6 @@
 ---
 title: IDBCursor
 slug: Web/API/IDBCursor
-tags:
-  - API
-  - Database
-  - IDBCursor
-  - IndexedDB
-  - Interface
-  - NeedsTranslation
-  - Reference
-  - Référence(2)
-  - Storage
-  - TopicStub
-translation_of: Web/API/IDBCursor
 ---
 
 {{APIRef("IndexedDB")}}

--- a/files/es/web/api/idbdatabase/index.md
+++ b/files/es/web/api/idbdatabase/index.md
@@ -1,20 +1,6 @@
 ---
 title: IDBDatabase
 slug: Web/API/IDBDatabase
-tags:
-  - API
-  - Database
-  - IDBDatabase
-  - IndexedDB
-  - Interface
-  - NeedsTranslation
-  - Reference
-  - Storage
-  - TopicStub
-  - accessing data
-  - asynchronous access
-  - transactions
-translation_of: Web/API/IDBDatabase
 ---
 
 {{APIRef("IndexedDB")}}

--- a/files/es/web/api/idbdatabase/transaction/index.md
+++ b/files/es/web/api/idbdatabase/transaction/index.md
@@ -1,13 +1,6 @@
 ---
 title: IDBDatabase.transaction()
 slug: Web/API/IDBDatabase/transaction
-tags:
-  - Almacenamiento
-  - Base de datos
-  - Referencia
-  - metodo
-  - transacción
-translation_of: Web/API/IDBDatabase/transaction
 ---
 
 {{ APIRef("IndexedDB") }}

--- a/files/es/web/api/idbobjectstore/add/index.md
+++ b/files/es/web/api/idbobjectstore/add/index.md
@@ -1,15 +1,6 @@
 ---
 title: IDBObjectStore.add
 slug: Web/API/IDBObjectStore/add
-tags:
-  - API
-  - Add
-  - Almacenamiento
-  - Base de datos
-  - IDBObjectStore
-  - IndexedDB
-  - Referencia
-translation_of: Web/API/IDBObjectStore/add
 ---
 
 {{ APIRef("IDBObjectStore") }}

--- a/files/es/web/api/idbobjectstore/index.md
+++ b/files/es/web/api/idbobjectstore/index.md
@@ -1,9 +1,6 @@
 ---
 title: IDBObjectStore
 slug: Web/API/IDBObjectStore
-tags:
-  - API
-translation_of: Web/API/IDBObjectStore
 ---
 
 {{APIRef("IndexedDB")}}

--- a/files/es/web/api/imagebitmap/index.md
+++ b/files/es/web/api/imagebitmap/index.md
@@ -1,12 +1,6 @@
 ---
 title: ImageBitmap
 slug: Web/API/ImageBitmap
-tags:
-  - API
-  - Canvas
-  - Imagen de mapa de bits
-  - Referencia
-translation_of: Web/API/ImageBitmap
 ---
 
 {{APIRef("Canvas API")}}

--- a/files/es/web/api/imagebitmaprenderingcontext/index.md
+++ b/files/es/web/api/imagebitmaprenderingcontext/index.md
@@ -1,7 +1,6 @@
 ---
 title: ImageBitmapRenderingContext
 slug: Web/API/ImageBitmapRenderingContext
-translation_of: Web/API/ImageBitmapRenderingContext
 ---
 
 {{APIRef("Canvas API")}} {{SeeCompatTable}}

--- a/files/es/web/api/indexeddb/index.md
+++ b/files/es/web/api/indexeddb/index.md
@@ -1,7 +1,6 @@
 ---
 title: WindowOrWorkerGlobalScope.indexedDB
 slug: Web/API/indexedDB
-translation_of: Web/API/WindowOrWorkerGlobalScope/indexedDB
 original_slug: Web/API/WindowOrWorkerGlobalScope/indexedDB
 ---
 

--- a/files/es/web/api/indexeddb_api/index.md
+++ b/files/es/web/api/indexeddb_api/index.md
@@ -1,7 +1,6 @@
 ---
 title: IndexedDB
 slug: Web/API/IndexedDB_API
-translation_of: Web/API/IndexedDB_API
 ---
 
 {{ SeeCompatTable() }}

--- a/files/es/web/api/indexeddb_api/using_indexeddb/index.md
+++ b/files/es/web/api/indexeddb_api/using_indexeddb/index.md
@@ -1,16 +1,6 @@
 ---
 title: Usando IndexedDB
 slug: Web/API/IndexedDB_API/Using_IndexedDB
-tags:
-  - API
-  - Almacenamiento
-  - Avanzado
-  - Base de datos
-  - Guía
-  - IndexedDB
-  - Tutorial
-  - jsstore
-translation_of: Web/API/IndexedDB_API/Using_IndexedDB
 original_slug: Web/API/IndexedDB_API/Usando_IndexedDB
 ---
 

--- a/files/es/web/api/intersection_observer_api/index.md
+++ b/files/es/web/api/intersection_observer_api/index.md
@@ -1,7 +1,6 @@
 ---
 title: Intersection Observer API
 slug: Web/API/Intersection_Observer_API
-translation_of: Web/API/Intersection_Observer_API
 ---
 
 {{DefaultAPISidebar("Intersection Observer API")}}

--- a/files/es/web/api/issecurecontext/index.md
+++ b/files/es/web/api/issecurecontext/index.md
@@ -1,7 +1,6 @@
 ---
 title: WindowOrWorkerGlobalScope.isSecureContext
 slug: Web/API/isSecureContext
-translation_of: Web/API/WindowOrWorkerGlobalScope/isSecureContext
 original_slug: Web/API/WindowOrWorkerGlobalScope/isSecureContext
 ---
 

--- a/files/es/web/api/keyboardevent/index.md
+++ b/files/es/web/api/keyboardevent/index.md
@@ -1,9 +1,6 @@
 ---
 title: KeyboardEvent
 slug: Web/API/KeyboardEvent
-tags:
-  - API
-translation_of: Web/API/KeyboardEvent
 ---
 
 {{APIRef("DOM Events")}}

--- a/files/es/web/api/keyboardevent/metakey/index.md
+++ b/files/es/web/api/keyboardevent/metakey/index.md
@@ -1,8 +1,6 @@
 ---
 title: KeyboardEvent.metaKey
 slug: Web/API/KeyboardEvent/metaKey
-translation_of: Web/API/KeyboardEvent/metaKey
-browser-compat: api.KeyboardEvent.metaKey
 ---
 
 {{APIRef("DOM Events")}}

--- a/files/es/web/api/location/index.md
+++ b/files/es/web/api/location/index.md
@@ -1,13 +1,6 @@
 ---
 title: Location
 slug: Web/API/Location
-tags:
-  - API
-  - HTML DOM
-  - Interface
-  - Location
-  - Referencia
-translation_of: Web/API/Location
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/es/web/api/location/origin/index.md
+++ b/files/es/web/api/location/origin/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'Location: origin'
 slug: Web/API/Location/origin
-tags:
-  - API
-  - Location
-  - Propiedad
-  - Referencia
-  - Ubicación
-translation_of: Web/API/Location/origin
 ---
 
 {{APIRef("Location")}}

--- a/files/es/web/api/location/reload/index.md
+++ b/files/es/web/api/location/reload/index.md
@@ -1,15 +1,6 @@
 ---
 title: 'Location: reload()'
 slug: Web/API/Location/reload
-tags:
-  - API
-  - HTML
-  - HTML DOM
-  - Location
-  - Method
-  - Referencia
-  - metodo
-translation_of: Web/API/Location/reload
 ---
 
 {{ APIRef("HTML DOM") }}

--- a/files/es/web/api/media_capture_and_streams_api/index.md
+++ b/files/es/web/api/media_capture_and_streams_api/index.md
@@ -1,7 +1,6 @@
 ---
 title: API de MediaStream
 slug: Web/API/Media_Capture_and_Streams_API
-translation_of: Web/API/Media_Streams_API
 original_slug: Web/API/Media_Streams_API
 ---
 

--- a/files/es/web/api/media_capture_and_streams_api/taking_still_photos/index.md
+++ b/files/es/web/api/media_capture_and_streams_api/taking_still_photos/index.md
@@ -1,12 +1,6 @@
 ---
 title: Capturar fotografías con la cámara web
 slug: Web/API/Media_Capture_and_Streams_API/Taking_still_photos
-tags:
-  - Canvas
-  - WebRTC
-  - cámara web
-  - getusermedia
-translation_of: Web/API/WebRTC_API/Taking_still_photos
 original_slug: Web/API/Media_Streams_API/Taking_still_photos
 ---
 

--- a/files/es/web/api/mediadevices/getusermedia/index.md
+++ b/files/es/web/api/mediadevices/getusermedia/index.md
@@ -1,7 +1,6 @@
 ---
 title: MediaDevices.getUserMedia()
 slug: Web/API/MediaDevices/getUserMedia
-translation_of: Web/API/MediaDevices/getUserMedia
 ---
 
 {{APIRef("WebRTC")}}{{SeeCompatTable}}

--- a/files/es/web/api/mediadevices/index.md
+++ b/files/es/web/api/mediadevices/index.md
@@ -1,15 +1,6 @@
 ---
 title: MediaDevices
 slug: Web/API/MediaDevices
-tags:
-  - API
-  - Experimental
-  - Interface
-  - Media
-  - MediaDevices
-  - NeedsTranslation
-  - TopicStub
-translation_of: Web/API/MediaDevices
 ---
 
 {{APIRef("WebRTC")}}{{SeeCompatTable}}

--- a/files/es/web/api/mediaquerylist/addlistener/index.md
+++ b/files/es/web/api/mediaquerylist/addlistener/index.md
@@ -1,7 +1,6 @@
 ---
 title: MediaQueryList.addListener()
 slug: Web/API/MediaQueryList/addListener
-translation_of: Web/API/MediaQueryList/addListener
 ---
 
 {{APIRef("CSSOM View")}}El método **`addListener()`** de la interfaz {{domxref ("MediaQueryList")}} añade un escucha al `MediaQueryListener` que ejecutará una función de devolución de llamada personalizada en respuesta al cambio de estado de consulta de medios.

--- a/files/es/web/api/mediaquerylist/index.md
+++ b/files/es/web/api/mediaquerylist/index.md
@@ -1,14 +1,6 @@
 ---
 title: MediaQueryList
 slug: Web/API/MediaQueryList
-tags:
-  - API
-  - CSSOM Vista
-  - CompatibilidadDeNavegadores
-  - Interface
-  - MediaQueryList
-  - Refetencia
-translation_of: Web/API/MediaQueryList
 ---
 
 {{APIRef("CSSOM View")}}{{SeeCompatTable}}

--- a/files/es/web/api/mediaquerylist/matches/index.md
+++ b/files/es/web/api/mediaquerylist/matches/index.md
@@ -1,7 +1,6 @@
 ---
 title: MediaQueryList.matches
 slug: Web/API/MediaQueryList/matches
-translation_of: Web/API/MediaQueryList/matches
 ---
 
 {{APIRef("CSSOM View")}}

--- a/files/es/web/api/mediaquerylist/removelistener/index.md
+++ b/files/es/web/api/mediaquerylist/removelistener/index.md
@@ -1,7 +1,6 @@
 ---
 title: MediaQueryList.removeListener()
 slug: Web/API/MediaQueryList/removeListener
-translation_of: Web/API/MediaQueryList/removeListener
 ---
 
 {{APIRef("CSSOM View")}}

--- a/files/es/web/api/mediastreamaudiosourcenode/index.md
+++ b/files/es/web/api/mediastreamaudiosourcenode/index.md
@@ -1,8 +1,6 @@
 ---
 title: MediaStreamAudioSourceNode
 slug: Web/API/MediaStreamAudioSourceNode
-browser-compat: api.MediaStreamAudioSourceNode
-translation_of: Web/API/MediaStreamAudioSourceNode
 original_slug: Web/API/MediaStreamAudioSourceNode
 ---
 

--- a/files/es/web/api/mediastreamtrack/index.md
+++ b/files/es/web/api/mediastreamtrack/index.md
@@ -1,7 +1,6 @@
 ---
 title: MediaStreamTrack
 slug: Web/API/MediaStreamTrack
-translation_of: Web/API/MediaStreamTrack
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/es/web/api/messageevent/index.md
+++ b/files/es/web/api/messageevent/index.md
@@ -1,7 +1,6 @@
 ---
 title: MessageEvent
 slug: Web/API/MessageEvent
-translation_of: Web/API/MessageEvent
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/es/web/api/mimetype/index.md
+++ b/files/es/web/api/mimetype/index.md
@@ -1,12 +1,6 @@
 ---
 title: MimeType
 slug: Web/API/MimeType
-tags:
-  - API
-  - Interface
-  - Plugins
-  - Referencia
-translation_of: Web/API/MimeType
 ---
 
 {{SeeCompatTable}}{{APIRef("HTML DOM")}}

--- a/files/es/web/api/mouseevent/index.md
+++ b/files/es/web/api/mouseevent/index.md
@@ -1,9 +1,6 @@
 ---
 title: MouseEvent
 slug: Web/API/MouseEvent
-tags:
-  - API
-translation_of: Web/API/MouseEvent
 ---
 
 {{APIRef("DOM Events")}}

--- a/files/es/web/api/mouseevent/initmouseevent/index.md
+++ b/files/es/web/api/mouseevent/initmouseevent/index.md
@@ -1,9 +1,6 @@
 ---
 title: event.initMouseEvent
 slug: Web/API/MouseEvent/initMouseEvent
-tags:
-  - Referencia_DOM_de_Gecko
-translation_of: Web/API/MouseEvent/initMouseEvent
 ---
 
 {{ApiRef("DOM Events")}}{{deprecated_header}}

--- a/files/es/web/api/mouseevent/pagex/index.md
+++ b/files/es/web/api/mouseevent/pagex/index.md
@@ -1,11 +1,6 @@
 ---
 title: event.pageX
 slug: Web/API/MouseEvent/pageX
-tags:
-  - DOM
-  - Referencia_DOM_de_Gecko
-  - Todas_las_Categorías
-translation_of: Web/API/UIEvent/pageX
 original_slug: Web/API/UIEvent/pageX
 ---
 

--- a/files/es/web/api/mouseevent/shiftkey/index.md
+++ b/files/es/web/api/mouseevent/shiftkey/index.md
@@ -1,7 +1,6 @@
 ---
 title: MouseEvent.shiftKey
 slug: Web/API/MouseEvent/shiftKey
-translation_of: Web/API/MouseEvent/shiftKey
 ---
 
 {{APIRef("DOM Events")}}

--- a/files/es/web/api/mutationobserver/index.md
+++ b/files/es/web/api/mutationobserver/index.md
@@ -1,7 +1,6 @@
 ---
 title: MutationObserver
 slug: Web/API/MutationObserver
-translation_of: Web/API/MutationObserver
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/mutationobserver/mutationobserver/index.md
+++ b/files/es/web/api/mutationobserver/mutationobserver/index.md
@@ -1,7 +1,6 @@
 ---
 title: MutationObserver.MutationObserver()
 slug: Web/API/MutationObserver/MutationObserver
-translation_of: Web/API/MutationObserver/MutationObserver
 ---
 {{APIRef("DOM WHATWG")}}
 

--- a/files/es/web/api/mutationobserver/observe/index.md
+++ b/files/es/web/api/mutationobserver/observe/index.md
@@ -1,7 +1,6 @@
 ---
 title: MutationObserver.observe()
 slug: Web/API/MutationObserver/observe
-translation_of: Web/API/MutationObserver/observe
 ---
 
 {{APIRef("DOM WHATWG")}}

--- a/files/es/web/api/navigationpreloadmanager/index.md
+++ b/files/es/web/api/navigationpreloadmanager/index.md
@@ -1,16 +1,6 @@
 ---
 title: NavigationPreloadManager
 slug: Web/API/NavigationPreloadManager
-page-type: web-api-interface
-tags:
-  - API
-  - Interfaz
-  - Navegación
-  - NavigationPreloadManager
-  - Offline
-  - Referencia
-  - Service Workers
-browser-compat: api.NavigationPreloadManager
 ---
 
 {{APIRef("Service Workers API")}}

--- a/files/es/web/api/navigator/donottrack/index.md
+++ b/files/es/web/api/navigator/donottrack/index.md
@@ -1,13 +1,6 @@
 ---
 title: Navigator.doNotTrack
 slug: Web/API/Navigator/doNotTrack
-tags:
-  - API
-  - DOM
-  - Experimental
-  - Propiedad
-  - Referencia
-translation_of: Web/API/Navigator/doNotTrack
 ---
 
 {{ApiRef("HTML DOM")}}{{SeeCompatTable}}

--- a/files/es/web/api/navigator/geolocation/index.md
+++ b/files/es/web/api/navigator/geolocation/index.md
@@ -1,7 +1,6 @@
 ---
 title: window.navigator.geolocation
 slug: Web/API/Navigator/geolocation
-translation_of: Web/API/Navigator/geolocation
 original_slug: Web/API/NavigatorGeolocation/geolocation
 ---
 

--- a/files/es/web/api/navigator/getbattery/index.md
+++ b/files/es/web/api/navigator/getbattery/index.md
@@ -1,8 +1,6 @@
 ---
 title: Navigator.getBattery()
 slug: Web/API/Navigator/getBattery
-translation_of: Web/API/Navigator/getBattery
-browser-compat: api.Navigator.getBattery
 ---
 
 {{ ApiRef("Battery API") }}

--- a/files/es/web/api/navigator/getusermedia/index.md
+++ b/files/es/web/api/navigator/getusermedia/index.md
@@ -1,7 +1,6 @@
 ---
 title: Navigator.getUserMedia
 slug: Web/API/Navigator/getUserMedia
-translation_of: Web/API/Navigator/getUserMedia
 ---
 
 Pide al usuario permiso para usar un dispositivo multimedia como una cámara o micrófono. Si el usuario concede este permiso, el successCallback es invocado en la aplicación llamada con un objeto [LocalMediaStream](/es/docs/WebRTC/MediaStream_API#LocalMediaStream) como argumento.

--- a/files/es/web/api/navigator/index.md
+++ b/files/es/web/api/navigator/index.md
@@ -1,11 +1,8 @@
 ---
 title: Navigator
 slug: Web/API/Navigator
-page-type: web-api-interface
-translation_of: Web/API/Navigator
 l10n:
   sourceCommit: 165b70e57270af4ba85526d92cce74d51d12c39d165b70e57270af4ba85526d92cce74d51d12c39d
-browser-compat: api.Navigator
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/navigator/registerprotocolhandler/index.md
+++ b/files/es/web/api/navigator/registerprotocolhandler/index.md
@@ -1,9 +1,6 @@
 ---
 title: window.navigator.registerProtocolHandler
 slug: Web/API/Navigator/registerProtocolHandler
-page-type: web-api-instance-method
-translation_of: Web/API/Navigator/registerProtocolHandler
-browser-compat: api.Navigator.registerProtocolHandler
 ---
 
 {{ ApiRef() }}

--- a/files/es/web/api/navigator/registerprotocolhandler/web-based_protocol_handlers/index.md
+++ b/files/es/web/api/navigator/registerprotocolhandler/web-based_protocol_handlers/index.md
@@ -1,11 +1,6 @@
 ---
 title: Controladores de protocolos basados en web
 slug: Web/API/Navigator/registerProtocolHandler/Web-based_protocol_handlers
-tags:
-  - Avanzado
-  - Controladores de Protocolos Basados en Web
-  - HTML5
-translation_of: Web/API/Navigator/registerProtocolHandler/Web-based_protocol_handlers
 ---
 
 ## Antecedentes

--- a/files/es/web/api/navigator/vibrate/index.md
+++ b/files/es/web/api/navigator/vibrate/index.md
@@ -1,7 +1,6 @@
 ---
 title: window.navigator.vibrate
 slug: Web/API/Navigator/vibrate
-translation_of: Web/API/Navigator/vibrate
 ---
 
 {{ApiRef}}{{SeeCompatTable}}

--- a/files/es/web/api/network_information_api/index.md
+++ b/files/es/web/api/network_information_api/index.md
@@ -1,12 +1,6 @@
 ---
 title: Network Information API
 slug: Web/API/Network_Information_API
-tags:
-  - API
-  - Experimental
-  - JSAPI Reference
-  - Referencia
-translation_of: Web/API/Network_Information_API
 ---
 
 {{DefaultAPISidebar("Network Information API")}}{{SeeCompatTable}}

--- a/files/es/web/api/node/appendchild/index.md
+++ b/files/es/web/api/node/appendchild/index.md
@@ -1,13 +1,6 @@
 ---
 title: Nodo appendChild
 slug: Web/API/Node/appendChild
-tags:
-  - API
-  - DOM
-  - Node
-  - Referencia
-  - metodo
-translation_of: Web/API/Node/appendChild
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/node/childnodes/index.md
+++ b/files/es/web/api/node/childnodes/index.md
@@ -1,13 +1,6 @@
 ---
 title: Node.childNodes
 slug: Web/API/Node/childNodes
-tags:
-  - API
-  - DOM
-  - Propiedad
-  - Referencia
-  - Referência DOM
-translation_of: Web/API/Node/childNodes
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/node/clonenode/index.md
+++ b/files/es/web/api/node/clonenode/index.md
@@ -1,13 +1,6 @@
 ---
 title: Node.cloneNode()
 slug: Web/API/Node/cloneNode
-tags:
-  - API
-  - DOM
-  - Referencia
-  - Referência DOM
-  - metodo
-translation_of: Web/API/Node/cloneNode
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/node/contains/index.md
+++ b/files/es/web/api/node/contains/index.md
@@ -1,12 +1,6 @@
 ---
 title: Node.contains()
 slug: Web/API/Node/contains
-tags:
-  - API
-  - DOM
-  - Nodo
-  - metodo
-translation_of: Web/API/Node/contains
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/node/haschildnodes/index.md
+++ b/files/es/web/api/node/haschildnodes/index.md
@@ -1,12 +1,6 @@
 ---
 title: Node.hasChildNodes()
 slug: Web/API/Node/hasChildNodes
-tags:
-  - API
-  - DOM
-  - Nodo
-  - metodo
-translation_of: Web/API/Node/hasChildNodes
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/node/index.md
+++ b/files/es/web/api/node/index.md
@@ -1,13 +1,6 @@
 ---
 title: Node
 slug: Web/API/Node
-tags:
-  - API
-  - DOM
-  - Interfaz
-  - Nodo
-  - Referencia
-translation_of: Web/API/Node
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/node/insertbefore/index.md
+++ b/files/es/web/api/node/insertbefore/index.md
@@ -1,13 +1,6 @@
 ---
 title: Node.insertBefore()
 slug: Web/API/Node/insertBefore
-tags:
-  - API
-  - DOM
-  - Nodo
-  - Referencia
-  - metodo
-translation_of: Web/API/Node/insertBefore
 original_slug: Web/API/Node/insertarAntes
 ---
 

--- a/files/es/web/api/node/issamenode/index.md
+++ b/files/es/web/api/node/issamenode/index.md
@@ -1,7 +1,6 @@
 ---
 title: Node.isSameNode()
 slug: Web/API/Node/isSameNode
-translation_of: Web/API/Node/isSameNode
 ---
 
 {{APIRef("DOM")}} {{Deprecated_Header}}

--- a/files/es/web/api/node/lastchild/index.md
+++ b/files/es/web/api/node/lastchild/index.md
@@ -1,13 +1,6 @@
 ---
 title: Node.lastChild
 slug: Web/API/Node/lastChild
-tags:
-  - API
-  - DOM
-  - NecesitaCompatibilidadNavegador
-  - Propiedad
-  - Referencia
-translation_of: Web/API/Node/lastChild
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/node/nextsibling/index.md
+++ b/files/es/web/api/node/nextsibling/index.md
@@ -1,13 +1,6 @@
 ---
 title: Node.nextSibling
 slug: Web/API/Node/nextSibling
-tags:
-  - API
-  - DOM
-  - Gecko
-  - Nodo
-  - Propiedad
-translation_of: Web/API/Node/nextSibling
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/node/nodename/index.md
+++ b/files/es/web/api/node/nodename/index.md
@@ -1,9 +1,6 @@
 ---
 title: element.nodeName
 slug: Web/API/Node/nodeName
-tags:
-  - Referencia_DOM_de_Gecko
-translation_of: Web/API/Node/nodeName
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/node/nodetype/index.md
+++ b/files/es/web/api/node/nodetype/index.md
@@ -1,7 +1,6 @@
 ---
 title: Node.nodeType
 slug: Web/API/Node/nodeType
-translation_of: Web/API/Node/nodeType
 ---
 
 {{APIRef("DOM")}}La propiedad de solo lectura **`Node.nodeType`** retornará un valor positivo entero representando el tipo de nodo.

--- a/files/es/web/api/node/nodevalue/index.md
+++ b/files/es/web/api/node/nodevalue/index.md
@@ -1,7 +1,6 @@
 ---
 title: Node.nodeValue
 slug: Web/API/Node/nodeValue
-translation_of: Web/API/Node/nodeValue
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/node/ownerdocument/index.md
+++ b/files/es/web/api/node/ownerdocument/index.md
@@ -1,13 +1,6 @@
 ---
 title: Node.ownerDocument
 slug: Web/API/Node/ownerDocument
-tags:
-  - API
-  - DOM
-  - Nodo
-  - Propiedad
-  - Referencia
-translation_of: Web/API/Node/ownerDocument
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/node/parentelement/index.md
+++ b/files/es/web/api/node/parentelement/index.md
@@ -1,13 +1,6 @@
 ---
 title: Node.parentElement
 slug: Web/API/Node/parentElement
-tags:
-  - API
-  - DOM
-  - NecesitaCompatiblidadNavegador
-  - Nodo
-  - Propiedad
-translation_of: Web/API/Node/parentElement
 original_slug: Web/API/Node/elementoPadre
 ---
 

--- a/files/es/web/api/node/parentnode/index.md
+++ b/files/es/web/api/node/parentnode/index.md
@@ -1,7 +1,6 @@
 ---
 title: Node.parentNode
 slug: Web/API/Node/parentNode
-translation_of: Web/API/Node/parentNode
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/node/previoussibling/index.md
+++ b/files/es/web/api/node/previoussibling/index.md
@@ -1,12 +1,6 @@
 ---
 title: Node.previousSibling
 slug: Web/API/Node/previousSibling
-tags:
-  - API
-  - DOM
-  - Gecko
-  - Propiedad
-translation_of: Web/API/Node/previousSibling
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/node/removechild/index.md
+++ b/files/es/web/api/node/removechild/index.md
@@ -1,7 +1,6 @@
 ---
 title: Node.removeChild()
 slug: Web/API/Node/removeChild
-translation_of: Web/API/Node/removeChild
 ---
 
 {{APIRef ( "DOM")}}

--- a/files/es/web/api/node/replacechild/index.md
+++ b/files/es/web/api/node/replacechild/index.md
@@ -1,13 +1,6 @@
 ---
 title: Node.replaceChild()
 slug: Web/API/Node/replaceChild
-tags:
-  - API
-  - DOM
-  - Nodo
-  - Referencia
-  - metodo
-translation_of: Web/API/Node/replaceChild
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/node/selectstart_event/index.md
+++ b/files/es/web/api/node/selectstart_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: GlobalEventHandlers.onselectstart
 slug: Web/API/Node/selectstart_event
-translation_of: Web/API/GlobalEventHandlers/onselectstart
 original_slug: Web/API/Document/selectstart_event
 ---
 

--- a/files/es/web/api/node/textcontent/index.md
+++ b/files/es/web/api/node/textcontent/index.md
@@ -1,7 +1,6 @@
 ---
 title: Node.textContent
 slug: Web/API/Node/textContent
-translation_of: Web/API/Node/textContent
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/nodelist/foreach/index.md
+++ b/files/es/web/api/nodelist/foreach/index.md
@@ -1,14 +1,6 @@
 ---
 title: NodeList.prototype.forEach()
 slug: Web/API/NodeList/forEach
-tags:
-  - DOM
-  - Iterable
-  - Métodos
-  - NodeList
-  - Referencia
-  - Web
-translation_of: Web/API/NodeList/forEach
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/nodelist/index.md
+++ b/files/es/web/api/nodelist/index.md
@@ -1,12 +1,6 @@
 ---
 title: NodeList
 slug: Web/API/NodeList
-tags:
-  - API
-  - DOM
-  - Interfaz
-  - NodeList
-translation_of: Web/API/NodeList
 ---
 
 {{APIRef("DOM")}}

--- a/files/es/web/api/notification/body/index.md
+++ b/files/es/web/api/notification/body/index.md
@@ -1,12 +1,6 @@
 ---
 title: Notification.body
 slug: Web/API/notification/body
-tags:
-  - API
-  - API Notificaciones
-  - Javascript Notificador
-  - Notificaciones
-translation_of: Web/API/Notification/body
 ---
 
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}

--- a/files/es/web/api/notification/click_event/index.md
+++ b/files/es/web/api/notification/click_event/index.md
@@ -1,16 +1,7 @@
 ---
 title: Notification.onclick
 slug: Web/API/Notification/click_event
-tags:
-  - API
-  - DOM
-  - Notifications
-  - Propiedad
-  - Referencia
-  - onclick
-translation_of: Web/API/Notification/onclick
 original_slug: Web/API/Notification/onclick
-browser-compat: api.Notification.onclick
 ---
 
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}

--- a/files/es/web/api/notification/close/index.md
+++ b/files/es/web/api/notification/close/index.md
@@ -1,8 +1,6 @@
 ---
 title: Notification.close()
 slug: Web/API/Notification/close
-page-type: web-api-instance-method
-browser-compat: api.Notification.close
 ---
 
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}

--- a/files/es/web/api/notification/close_event/index.md
+++ b/files/es/web/api/notification/close_event/index.md
@@ -1,8 +1,6 @@
 ---
 title: 'Notification: evento close'
 slug: Web/API/Notification/close_event
-page-type: web-api-event
-browser-compat: api.Notification.close_event
 ---
 
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}

--- a/files/es/web/api/notification/dir/index.md
+++ b/files/es/web/api/notification/dir/index.md
@@ -1,16 +1,6 @@
 ---
 title: Notification.dir
 slug: Web/API/notification/dir
-tags:
-  - API
-  - Notification
-  - Notifications
-  - Notifications API
-  - Property
-  - Reference
-  - dir
-translation_of: Web/API/Notification/dir
-browser-compat: api.Notification.dir
 ---
 
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}

--- a/files/es/web/api/notification/error_event/index.md
+++ b/files/es/web/api/notification/error_event/index.md
@@ -1,8 +1,6 @@
 ---
 title: 'Notification: evento error'
 slug: Web/API/Notification/error_event
-page-type: web-api-event
-browser-compat: api.Notification.error_event
 ---
 
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}

--- a/files/es/web/api/notification/icon/index.md
+++ b/files/es/web/api/notification/icon/index.md
@@ -1,8 +1,6 @@
 ---
 title: Notification.icon
 slug: Web/API/Notification/icon
-translation_of: Web/API/Notification/icon
-browser-compat: api.Notification.icon
 ---
 
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}

--- a/files/es/web/api/notification/index.md
+++ b/files/es/web/api/notification/index.md
@@ -1,7 +1,6 @@
 ---
 title: Notification
 slug: Web/API/notification
-translation_of: Web/API/Notification
 ---
 
 {{APIRef("Web Notifications")}}

--- a/files/es/web/api/notification/permission/index.md
+++ b/files/es/web/api/notification/permission/index.md
@@ -1,15 +1,6 @@
 ---
 title: Notification.permission
 slug: Web/API/notification/permission
-tags:
-  - API
-  - Notification
-  - Notifications
-  - Notifications API
-  - Property
-  - Reference
-translation_of: Web/API/Notification/permission
-browser-compat: api.Notification.permission
 ---
 
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}

--- a/files/es/web/api/notification/requestpermission/index.md
+++ b/files/es/web/api/notification/requestpermission/index.md
@@ -1,15 +1,6 @@
 ---
 title: Notification.requestPermission()
 slug: Web/API/Notification/requestPermission
-tags:
-  - API
-  - Method
-  - Notification
-  - Notifications
-  - Notifications API
-  - Reference
-translation_of: Web/API/Notification/requestPermission
-browser-compat: api.Notification.requestPermission
 ---
 
 {{APIRef("Web Notifications")}}{{securecontext_header}}

--- a/files/es/web/api/notification/show_event/index.md
+++ b/files/es/web/api/notification/show_event/index.md
@@ -1,8 +1,6 @@
 ---
 title: 'Notification: evento show'
 slug: Web/API/Notification/show_event
-page-type: web-api-event
-browser-compat: api.Notification.show_event
 ---
 
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}

--- a/files/es/web/api/notifications_api/index.md
+++ b/files/es/web/api/notifications_api/index.md
@@ -1,14 +1,6 @@
 ---
 title: Notifications API
 slug: Web/API/Notifications_API
-tags:
-  - Landing
-  - NeedsTranslation
-  - Notifications
-  - TopicStub
-  - permission
-  - system
-translation_of: Web/API/Notifications_API
 ---
 
 {{DefaultAPISidebar("Web Notifications")}}

--- a/files/es/web/api/notifications_api/using_the_notifications_api/index.md
+++ b/files/es/web/api/notifications_api/using_the_notifications_api/index.md
@@ -1,7 +1,6 @@
 ---
 title: Usando la API de Notificaciones
 slug: Web/API/Notifications_API/Using_the_Notifications_API
-translation_of: Web/API/Notifications_API/Using_the_Notifications_API
 original_slug: Web/API/Notifications_API/Usando_la_API_de_Notificaciones
 ---
 

--- a/files/es/web/api/payment_request_api/index.md
+++ b/files/es/web/api/payment_request_api/index.md
@@ -1,17 +1,6 @@
 ---
 title: API de Solicitud de Pago
 slug: Web/API/Payment_Request_API
-tags:
-  - API
-  - API de Solicitud de Pago
-  - Comercio
-  - Contexto seguro
-  - Intermediário
-  - Pago
-  - Referencia
-  - Solicitud de Pago
-  - Tarjeta de Crédito
-translation_of: Web/API/Payment_Request_API
 ---
 
 {{DefaultAPISidebar("Payment Request API")}}{{securecontext_header}}

--- a/files/es/web/api/performance/clearmarks/index.md
+++ b/files/es/web/api/performance/clearmarks/index.md
@@ -1,12 +1,6 @@
 ---
 title: performance.clearMarks()
 slug: Web/API/Performance/clearMarks
-tags:
-  - API
-  - Referencia
-  - Rendimiento Web
-  - metodo
-translation_of: Web/API/Performance/clearMarks
 ---
 
 {{APIRef("User Timing API")}}

--- a/files/es/web/api/performance/clearmeasures/index.md
+++ b/files/es/web/api/performance/clearmeasures/index.md
@@ -1,12 +1,6 @@
 ---
 title: performance.clearMeasures()
 slug: Web/API/Performance/clearMeasures
-tags:
-  - API
-  - Referencia
-  - Rendimiento Web
-  - metodo
-translation_of: Web/API/Performance/clearMeasures
 ---
 
 {{APIRef("User Timing API")}}

--- a/files/es/web/api/performance/index.md
+++ b/files/es/web/api/performance/index.md
@@ -1,14 +1,6 @@
 ---
 title: Performance
 slug: Web/API/Performance
-tags:
-  - API
-  - Interfaz
-  - Referencia
-  - Rendimiento
-  - Rendimiento Web
-  - Tiempo de navegación
-translation_of: Web/API/Performance
 ---
 
 {{APIRef("High Resolution Time")}}

--- a/files/es/web/api/performance/memory/index.md
+++ b/files/es/web/api/performance/memory/index.md
@@ -1,7 +1,6 @@
 ---
 title: Performance.memory
 slug: Web/API/Performance/memory
-translation_of: Web/API/Performance/memory
 ---
 
 {{APIRef}}

--- a/files/es/web/api/performance/navigation/index.md
+++ b/files/es/web/api/performance/navigation/index.md
@@ -1,16 +1,6 @@
 ---
 title: Performance.navigation
 slug: Web/API/Performance/navigation
-tags:
-  - API
-  - Deprecado
-  - HTTP
-  - Legado
-  - Propiedad
-  - Rendimiento
-  - Solo lectura
-  - Tiempo de navegación
-translation_of: Web/API/Performance/navigation
 ---
 
 {{APIRef("Navigation Timing")}}

--- a/files/es/web/api/performance/now/index.md
+++ b/files/es/web/api/performance/now/index.md
@@ -1,13 +1,6 @@
 ---
 title: performance.now()
 slug: Web/API/Performance/now
-tags:
-  - API
-  - Referencia
-  - Rendimiento
-  - Web Performance API
-  - metodo
-translation_of: Web/API/Performance/now
 ---
 
 {{APIRef("High Resolution Timing")}}

--- a/files/es/web/api/performance/timeorigin/index.md
+++ b/files/es/web/api/performance/timeorigin/index.md
@@ -1,14 +1,6 @@
 ---
 title: Performance.timeOrigin
 slug: Web/API/Performance/timeOrigin
-tags:
-  - API
-  - Experimental
-  - Propiedad
-  - Referencia
-  - Rendimiento
-  - timeOrigin
-translation_of: Web/API/Performance/timeOrigin
 ---
 
 {{SeeCompatTable}}{{APIRef("High Resolution Time")}}

--- a/files/es/web/api/performance/timing/index.md
+++ b/files/es/web/api/performance/timing/index.md
@@ -1,15 +1,6 @@
 ---
 title: Performance.timing
 slug: Web/API/Performance/timing
-tags:
-  - API
-  - Deprecada
-  - Legado
-  - Propiedad
-  - Rendimiento
-  - Solo lectura
-  - Tiempo de navegación
-translation_of: Web/API/Performance/timing
 ---
 
 {{APIRef("Navigation Timing")}}{{deprecated_header}}

--- a/files/es/web/api/performancenavigation/index.md
+++ b/files/es/web/api/performancenavigation/index.md
@@ -1,18 +1,6 @@
 ---
 title: PerformanceNavigation
 slug: Web/API/PerformanceNavigation
-tags:
-  - API
-  - API de tiempo de navegación
-  - Compatibilidad
-  - Deprecada
-  - Interfaz
-  - Legado
-  - Referencia
-  - Rendimiento
-  - TIempo
-  - Tiempo de navegación
-translation_of: Web/API/PerformanceNavigation
 ---
 
 {{APIRef("Navigation Timing")}}

--- a/files/es/web/api/pointer_lock_api/index.md
+++ b/files/es/web/api/pointer_lock_api/index.md
@@ -1,7 +1,6 @@
 ---
 title: API Pointer Lock
 slug: Web/API/Pointer_Lock_API
-translation_of: Web/API/Pointer_Lock_API
 original_slug: WebAPI/Pointer_Lock
 ---
 

--- a/files/es/web/api/push_api/index.md
+++ b/files/es/web/api/push_api/index.md
@@ -1,13 +1,6 @@
 ---
 title: Push API
 slug: Web/API/Push_API
-tags:
-  - API
-  - Experimental
-  - Notificaciones
-  - Push
-  - Referencia
-translation_of: Web/API/Push_API
 ---
 
 {{DefaultAPISidebar("Push API")}}{{SeeCompatTable}}

--- a/files/es/web/api/pushmanager/index.md
+++ b/files/es/web/api/pushmanager/index.md
@@ -1,18 +1,6 @@
 ---
 title: PushManager
 slug: Web/API/PushManager
-tags:
-  - API
-  - Experimental
-  - Interface
-  - NeedsTranslation
-  - Push
-  - Push API
-  - Reference
-  - Service Workers
-  - TopicStub
-  - WebAPI
-translation_of: Web/API/PushManager
 ---
 
 {{SeeCompatTable}}{{ApiRef("Push API")}}

--- a/files/es/web/api/pushmanager/supportedcontentencodings/index.md
+++ b/files/es/web/api/pushmanager/supportedcontentencodings/index.md
@@ -1,7 +1,6 @@
 ---
 title: PushManager.supportedContentEncodings
 slug: Web/API/PushManager/supportedContentEncodings
-translation_of: Web/API/PushManager/supportedContentEncodings
 ---
 
 {{SeeCompatTable}}{{APIRef("Push API")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove duplicated frontmatter keys from localized content

### Motivation

Remove innecesarry duplicated data

### Additional details

Folders: api/(ev|f|g|h|i|j|k|l|m|n|o|p)*

```
{
  "tags": 118,
  "translation_of": 193,
  "browser-compat": 25,
  "translation_of_original": 2,
  "page-type": 12
}
```

### Related issues and pull requests

Relates to #10129
Relates to #7412
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
