### PR TITLE
Remove duplicated frontmatter keys from web folder 5/10 [es]

### DIFF
--- a/files/es/web/css/--_star_/index.md
+++ b/files/es/web/css/--_star_/index.md
@@ -1,7 +1,6 @@
 ---
 title: 'Propiedades personalizadas (--*): variables CSS'
 slug: Web/CSS/--*
-translation_of: Web/CSS/--*
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/-moz-float-edge/index.md
+++ b/files/es/web/css/-moz-float-edge/index.md
@@ -1,7 +1,6 @@
 ---
 title: '-moz-float-edge'
 slug: Web/CSS/-moz-float-edge
-browser-compat: css.properties.-moz-float-edge
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/-moz-force-broken-image-icon/index.md
+++ b/files/es/web/css/-moz-force-broken-image-icon/index.md
@@ -1,11 +1,6 @@
 ---
 title: '-moz-force-broken-image-icon'
 slug: Web/CSS/-moz-force-broken-image-icon
-tags:
-  - CSS
-  - CSS Reference
-  - Non-standard
-translation_of: Web/CSS/-moz-force-broken-image-icon
 ---
 
 {{Non-standard_header}}{{ CSSRef() }}

--- a/files/es/web/css/-moz-image-rect/index.md
+++ b/files/es/web/css/-moz-image-rect/index.md
@@ -1,12 +1,6 @@
 ---
 title: '-moz-image-rect'
 slug: Web/CSS/-moz-image-rect
-tags:
-  - CSS
-  - No estandar
-  - Propiedad CSS
-  - Referencia CSS
-translation_of: Web/CSS/-moz-image-rect
 ---
 
 {{Non-standard_header}}{{CSSRef}}

--- a/files/es/web/css/-moz-image-region/index.md
+++ b/files/es/web/css/-moz-image-region/index.md
@@ -1,12 +1,6 @@
 ---
 title: '-moz-image-region'
 slug: Web/CSS/-moz-image-region
-tags:
-  - CSS
-  - No estandar
-  - Referencia
-  - Referencia CSS
-translation_of: Web/CSS/-moz-image-region
 ---
 
 {{Non-standard_header}}{{CSSRef}}

--- a/files/es/web/css/-moz-orient/index.md
+++ b/files/es/web/css/-moz-orient/index.md
@@ -1,7 +1,6 @@
 ---
 title: '-moz-orient'
 slug: Web/CSS/-moz-orient
-translation_of: Web/CSS/-moz-orient
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/-moz-outline-radius-bottomleft/index.md
+++ b/files/es/web/css/-moz-outline-radius-bottomleft/index.md
@@ -1,12 +1,6 @@
 ---
 title: '-moz-outline-radius-bottomleft'
 slug: Web/CSS/-moz-outline-radius-bottomleft
-tags:
-  - CSS
-  - No estandar
-  - Propiedad CSS
-  - Referencia CSS
-translation_of: Web/CSS/-moz-outline-radius-bottomleft
 ---
 
 {{Non-standard_header}}{{CSSRef}}

--- a/files/es/web/css/-moz-outline-radius-bottomright/index.md
+++ b/files/es/web/css/-moz-outline-radius-bottomright/index.md
@@ -1,12 +1,6 @@
 ---
 title: '-moz-outline-radius-bottomright'
 slug: Web/CSS/-moz-outline-radius-bottomright
-tags:
-  - CSS
-  - No estandar
-  - Propiedad CSS
-  - Referencia CSS
-translation_of: Web/CSS/-moz-outline-radius-bottomright
 ---
 
 {{Non-standard_header}}{{CSSRef}}

--- a/files/es/web/css/-moz-outline-radius-topleft/index.md
+++ b/files/es/web/css/-moz-outline-radius-topleft/index.md
@@ -1,12 +1,6 @@
 ---
 title: '-moz-outline-radius-topleft'
 slug: Web/CSS/-moz-outline-radius-topleft
-tags:
-  - CSS
-  - No estandar
-  - Propiedad CSS
-  - Referencia CSS
-translation_of: Web/CSS/-moz-outline-radius-topleft
 ---
 
 {{Non-standard_header}}{{CSSRef}}

--- a/files/es/web/css/-moz-outline-radius-topright/index.md
+++ b/files/es/web/css/-moz-outline-radius-topright/index.md
@@ -1,12 +1,6 @@
 ---
 title: '-moz-outline-radius-topright'
 slug: Web/CSS/-moz-outline-radius-topright
-tags:
-  - CSS
-  - No estandar
-  - Propiedad CSS
-  - Referencia CSS
-translation_of: Web/CSS/-moz-outline-radius-topright
 ---
 
 {{Non-standard_header}}{{CSSRef}}

--- a/files/es/web/css/-moz-outline-radius/index.md
+++ b/files/es/web/css/-moz-outline-radius/index.md
@@ -1,11 +1,6 @@
 ---
 title: '-moz-outline-radius'
 slug: Web/CSS/-moz-outline-radius
-tags:
-  - CSS
-  - No estándar(2)
-  - Referencia CSS
-translation_of: Web/CSS/-moz-outline-radius
 ---
 
 {{Non-standard_header}}{{CSSRef}}

--- a/files/es/web/css/-moz-user-focus/index.md
+++ b/files/es/web/css/-moz-user-focus/index.md
@@ -1,11 +1,6 @@
 ---
 title: '-moz-user-focus'
 slug: Web/CSS/-moz-user-focus
-tags:
-  - CSS
-  - CSS:Extensiones Mozilla
-  - Referencia CSS
-translation_of: Web/CSS/-moz-user-focus
 ---
 
 {{Non-standard_header}}

--- a/files/es/web/css/-moz-user-input/index.md
+++ b/files/es/web/css/-moz-user-input/index.md
@@ -1,11 +1,6 @@
 ---
 title: '-moz-user-input'
 slug: Web/CSS/-moz-user-input
-tags:
-  - CSS
-  - No estandar
-  - Referencia CSS
-translation_of: Web/CSS/-moz-user-input
 ---
 {{Non-standard_header}}{{CSSRef}}
 

--- a/files/es/web/css/-webkit-border-before/index.md
+++ b/files/es/web/css/-webkit-border-before/index.md
@@ -1,12 +1,6 @@
 ---
 title: '-webkit-border-before'
 slug: Web/CSS/-webkit-border-before
-tags:
-  - CSS
-  - No estándar(2)
-  - Propiedad CSS
-  - Referencia CSS
-translation_of: Web/CSS/-webkit-border-before
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/-webkit-box-reflect/index.md
+++ b/files/es/web/css/-webkit-box-reflect/index.md
@@ -1,12 +1,6 @@
 ---
 title: '-webkit-box-reflect'
 slug: Web/CSS/-webkit-box-reflect
-tags:
-  - CSS
-  - No estándar(2)
-  - Propiedad
-  - Referencia
-translation_of: Web/CSS/-webkit-box-reflect
 ---
 
 {{Non-standard_header}}{{CSSRef}}

--- a/files/es/web/css/-webkit-mask-attachment/index.md
+++ b/files/es/web/css/-webkit-mask-attachment/index.md
@@ -1,12 +1,6 @@
 ---
 title: '-webkit-mask-attachment'
 slug: Web/CSS/-webkit-mask-attachment
-tags:
-  - CSS
-  - Diseño
-  - Referencia
-  - Web
-translation_of: Web/CSS/-webkit-mask-attachment
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/-webkit-mask-box-image/index.md
+++ b/files/es/web/css/-webkit-mask-box-image/index.md
@@ -1,12 +1,6 @@
 ---
 title: '-webkit-mask-box-image'
 slug: Web/CSS/-webkit-mask-box-image
-tags:
-  - CSS
-  - Diseño
-  - Referencia
-  - Web
-translation_of: Web/CSS/-webkit-mask-box-image
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/-webkit-mask-composite/index.md
+++ b/files/es/web/css/-webkit-mask-composite/index.md
@@ -1,9 +1,6 @@
 ---
 title: '-webkit-mask-composite'
 slug: Web/CSS/-webkit-mask-composite
-tags:
-  - CSS
-translation_of: Web/CSS/-webkit-mask-composite
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/-webkit-mask-position-x/index.md
+++ b/files/es/web/css/-webkit-mask-position-x/index.md
@@ -1,13 +1,6 @@
 ---
 title: '-webkit-mask-position-x'
 slug: Web/CSS/-webkit-mask-position-x
-tags:
-  - CSS
-  - Máscaras CSS
-  - No estándar(2)
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/-webkit-mask-position-x
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/-webkit-mask-position-y/index.md
+++ b/files/es/web/css/-webkit-mask-position-y/index.md
@@ -1,13 +1,6 @@
 ---
 title: '-webkit-mask-position-y'
 slug: Web/CSS/-webkit-mask-position-y
-tags:
-  - CSS
-  - Máscaras CSS
-  - No estándar(2)
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/-webkit-mask-position-y
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/-webkit-mask-repeat-x/index.md
+++ b/files/es/web/css/-webkit-mask-repeat-x/index.md
@@ -1,15 +1,6 @@
 ---
 title: '-webkit-mask-repeat-x'
 slug: Web/CSS/-webkit-mask-repeat-x
-tags:
-  - CSS
-  - Máscara CSS
-  - NeedsBrowserCompatibility
-  - NeedsMobileBrowserCompatibility
-  - No estandar
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/-webkit-mask-repeat-x
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/-webkit-mask-repeat-y/index.md
+++ b/files/es/web/css/-webkit-mask-repeat-y/index.md
@@ -1,15 +1,6 @@
 ---
 title: '-webkit-mask-repeat-y'
 slug: Web/CSS/-webkit-mask-repeat-y
-tags:
-  - CSS
-  - Máscara CSS
-  - NeedsBrowserCompatibility
-  - NeedsMobileBrowserCompatibility
-  - No estandar
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/-webkit-mask-repeat-y
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/-webkit-overflow-scrolling/index.md
+++ b/files/es/web/css/-webkit-overflow-scrolling/index.md
@@ -1,12 +1,6 @@
 ---
 title: '-webkit-overflow-scrolling'
 slug: Web/CSS/-webkit-overflow-scrolling
-tags:
-  - CSS
-  - No estándar(2)
-  - Propiedad CSS
-  - Referencia CSS
-translation_of: Web/CSS/-webkit-overflow-scrolling
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/-webkit-tap-highlight-color/index.md
+++ b/files/es/web/css/-webkit-tap-highlight-color/index.md
@@ -1,15 +1,6 @@
 ---
 title: '-webkit-tap-highlight-color'
 slug: Web/CSS/-webkit-tap-highlight-color
-tags:
-  - CSS
-  - NeedsCompatTable
-  - NeedsExample
-  - NeedsMobileBrowserCompatibility
-  - No estandar
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/-webkit-tap-highlight-color
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/-webkit-text-fill-color/index.md
+++ b/files/es/web/css/-webkit-text-fill-color/index.md
@@ -1,12 +1,6 @@
 ---
 title: '-webkit-text-fill-color'
 slug: Web/CSS/-webkit-text-fill-color
-tags:
-  - CSS
-  - No estandar
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/-webkit-text-fill-color
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/-webkit-text-stroke-color/index.md
+++ b/files/es/web/css/-webkit-text-stroke-color/index.md
@@ -1,11 +1,6 @@
 ---
 title: '-webkit-text-stroke-color'
 slug: Web/CSS/-webkit-text-stroke-color
-tags:
-  - CSS
-  - No estándar(2)
-  - Propiedad CSS
-translation_of: Web/CSS/-webkit-text-stroke-color
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/-webkit-text-stroke-width/index.md
+++ b/files/es/web/css/-webkit-text-stroke-width/index.md
@@ -1,12 +1,6 @@
 ---
 title: '-webkit-text-stroke-width'
 slug: Web/CSS/-webkit-text-stroke-width
-tags:
-  - CSS
-  - Experimental
-  - No estandar
-  - Referencia
-translation_of: Web/CSS/-webkit-text-stroke-width
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/-webkit-text-stroke/index.md
+++ b/files/es/web/css/-webkit-text-stroke/index.md
@@ -1,12 +1,6 @@
 ---
 title: '-webkit-text-stroke'
 slug: Web/CSS/-webkit-text-stroke
-tags:
-  - CSS
-  - No estándar(2)
-  - Propiedad
-  - Referencia
-translation_of: Web/CSS/-webkit-text-stroke
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/-webkit-touch-callout/index.md
+++ b/files/es/web/css/-webkit-touch-callout/index.md
@@ -1,12 +1,6 @@
 ---
 title: '-webkit-touch-callout'
 slug: Web/CSS/-webkit-touch-callout
-tags:
-  - CSS
-  - No estándar(2)
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/-webkit-touch-callout
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/@charset/index.md
+++ b/files/es/web/css/@charset/index.md
@@ -1,9 +1,6 @@
 ---
 title: '@charset'
 slug: Web/CSS/@charset
-tags:
-  - Regla-at
-translation_of: Web/CSS/@charset
 ---
 
 {{ CSSRef }}

--- a/files/es/web/css/@counter-style/additive-symbols/index.md
+++ b/files/es/web/css/@counter-style/additive-symbols/index.md
@@ -1,11 +1,6 @@
 ---
 title: additive-symbols
 slug: Web/CSS/@counter-style/additive-symbols
-tags:
-  - Descriptor CSS
-  - Estilos de Contador CSS
-  - Referencia
-translation_of: Web/CSS/@counter-style/additive-symbols
 ---
 
 ## Resumen

--- a/files/es/web/css/@counter-style/index.md
+++ b/files/es/web/css/@counter-style/index.md
@@ -1,15 +1,6 @@
 ---
 title: '@counter-style'
 slug: Web/CSS/@counter-style
-tags:
-  - At-rule
-  - CSS
-  - NeedsTranslation
-  - Reference
-  - Styles
-  - TopicStub
-  - counter
-translation_of: Web/CSS/@counter-style
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/@counter-style/symbols/index.md
+++ b/files/es/web/css/@counter-style/symbols/index.md
@@ -1,10 +1,6 @@
 ---
 title: symbols
 slug: Web/CSS/@counter-style/symbols
-tags:
-  - Descriptor CSS
-  - Estilos de contadores CSS
-translation_of: Web/CSS/@counter-style/symbols
 ---
 
 ## Summary

--- a/files/es/web/css/@font-face/font-display/index.md
+++ b/files/es/web/css/@font-face/font-display/index.md
@@ -1,16 +1,6 @@
 ---
 title: font-display
 slug: Web/CSS/@font-face/font-display
-tags:
-  - '@font-face'
-  - CSS
-  - Descriptor CSS
-  - Experimental
-  - Fuentes CSS
-  - Referencia
-  - font-display
-  - web fonts
-translation_of: Web/CSS/@font-face/font-display
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/@font-face/font-family/index.md
+++ b/files/es/web/css/@font-face/font-family/index.md
@@ -1,10 +1,6 @@
 ---
 title: font-family
 slug: Web/CSS/@font-face/font-family
-tags:
-  - CSS
-  - font-family
-translation_of: Web/CSS/@font-face/font-family
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/@font-face/font-style/index.md
+++ b/files/es/web/css/@font-face/font-style/index.md
@@ -1,12 +1,6 @@
 ---
 title: font-style
 slug: Web/CSS/@font-face/font-style
-tags:
-  - '@font-face'
-  - CSS
-  - Fuentes
-  - Referências
-translation_of: Web/CSS/@font-face/font-style
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/@font-face/index.md
+++ b/files/es/web/css/@font-face/index.md
@@ -1,7 +1,6 @@
 ---
 title: '@font-face'
 slug: Web/CSS/@font-face
-translation_of: Web/CSS/@font-face
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/@font-face/src/index.md
+++ b/files/es/web/css/@font-face/src/index.md
@@ -1,11 +1,6 @@
 ---
 title: src
 slug: Web/CSS/@font-face/src
-tags:
-  - Descriptor CSS
-  - Fuentes CSS
-  - Referencia
-translation_of: Web/CSS/@font-face/src
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/@font-face/unicode-range/index.md
+++ b/files/es/web/css/@font-face/unicode-range/index.md
@@ -1,12 +1,6 @@
 ---
 title: unicode-range
 slug: Web/CSS/@font-face/unicode-range
-tags:
-  - CSS
-  - Experimental
-  - Layout
-  - Reference
-translation_of: Web/CSS/@font-face/unicode-range
 ---
 
 {{cssref}}

--- a/files/es/web/css/@font-feature-values/index.md
+++ b/files/es/web/css/@font-feature-values/index.md
@@ -1,12 +1,6 @@
 ---
 title: '@font-feature-values'
 slug: Web/CSS/@font-feature-values
-tags:
-  - CSS
-  - Fuentes
-  - Referencia
-  - Regla-at
-translation_of: Web/CSS/@font-feature-values
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/@import/index.md
+++ b/files/es/web/css/@import/index.md
@@ -1,7 +1,6 @@
 ---
 title: '@import'
 slug: Web/CSS/@import
-translation_of: Web/CSS/@import
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/@keyframes/index.md
+++ b/files/es/web/css/@keyframes/index.md
@@ -1,7 +1,6 @@
 ---
 title: '@keyframes'
 slug: Web/CSS/@keyframes
-translation_of: Web/CSS/@keyframes
 ---
 
 {{ CSSRef() }} {{ SeeCompatTable() }}

--- a/files/es/web/css/@media/color/index.md
+++ b/files/es/web/css/@media/color/index.md
@@ -1,10 +1,6 @@
 ---
 title: color
 slug: Web/CSS/@media/color
-tags:
-  - CSS
-  - Referencia
-translation_of: Web/CSS/@media/color
 ---
 
 **`color`** es una característica CSS relativa al medio de presentación cuyo valor es un [`<integer>`](/es/docs/Web/CSS/integer) que contiene el número de bits por componente de color en el dispositivo de salida, o cero si el dispositivivo no es en color.

--- a/files/es/web/css/@media/display-mode/index.md
+++ b/files/es/web/css/@media/display-mode/index.md
@@ -1,17 +1,6 @@
 ---
 title: display-mode
 slug: Web/CSS/@media/display-mode
-tags:
-  - '@media'
-  - CSS
-  - Media Queries
-  - Referencia
-  - características de medio
-  - consultas de medio
-  - display
-  - display-mode
-  - media feature
-translation_of: Web/CSS/@media/display-mode
 ---
 
 {{cssref}}

--- a/files/es/web/css/@media/height/index.md
+++ b/files/es/web/css/@media/height/index.md
@@ -1,13 +1,6 @@
 ---
 title: Altura
 slug: Web/CSS/@media/height
-tags:
-  - '@media'
-  - CSS
-  - Media Queries
-  - Referencia
-  - características media
-translation_of: Web/CSS/@media/height
 original_slug: Web/CSS/@media/altura
 ---
 

--- a/files/es/web/css/@media/hover/index.md
+++ b/files/es/web/css/@media/hover/index.md
@@ -1,15 +1,6 @@
 ---
 title: hover
 slug: Web/CSS/@media/hover
-tags:
-  - '@media'
-  - CSS
-  - Consulta de medios
-  - Media Queires
-  - Referencia
-  - característica de medios
-  - media feature
-translation_of: Web/CSS/@media/hover
 ---
 
 {{cssref}}

--- a/files/es/web/css/@media/index.md
+++ b/files/es/web/css/@media/index.md
@@ -1,7 +1,6 @@
 ---
 title: '@media'
 slug: Web/CSS/@media
-translation_of: Web/CSS/@media
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/@media/pointer/index.md
+++ b/files/es/web/css/@media/pointer/index.md
@@ -1,7 +1,6 @@
 ---
 title: pointer
 slug: Web/CSS/@media/pointer
-translation_of: Web/CSS/@media/pointer
 ---
 
 {{cssref}}

--- a/files/es/web/css/@media/resolution/index.md
+++ b/files/es/web/css/@media/resolution/index.md
@@ -1,10 +1,6 @@
 ---
 title: Resolución
 slug: Web/CSS/@media/resolution
-tags:
-  - Referencia
-  - resolución
-translation_of: Web/CSS/@media/resolution
 original_slug: Web/CSS/@media/resolución
 ---
 

--- a/files/es/web/css/@media/width/index.md
+++ b/files/es/web/css/@media/width/index.md
@@ -1,7 +1,6 @@
 ---
 title: width
 slug: Web/CSS/@media/width
-translation_of: Web/CSS/@media/width
 ---
 
 {{cssref}}

--- a/files/es/web/css/@namespace/index.md
+++ b/files/es/web/css/@namespace/index.md
@@ -1,7 +1,6 @@
 ---
 title: '@namespace'
 slug: Web/CSS/@namespace
-translation_of: Web/CSS/@namespace
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/@page/index.md
+++ b/files/es/web/css/@page/index.md
@@ -1,7 +1,6 @@
 ---
 title: '@page'
 slug: Web/CSS/@page
-translation_of: Web/CSS/@page
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/@supports/index.md
+++ b/files/es/web/css/@supports/index.md
@@ -1,7 +1,6 @@
 ---
 title: '@supports'
 slug: Web/CSS/@supports
-translation_of: Web/CSS/@supports
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/_colon_-moz-broken/index.md
+++ b/files/es/web/css/_colon_-moz-broken/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':-moz-broken'
 slug: Web/CSS/:-moz-broken
-tags:
-  - CSS
-  - NeedsCompatTable
-  - NeedsExample
-  - No estandar
-  - Referencia CSS
-translation_of: Web/CSS/:-moz-broken
 ---
 
 {{Non-standard_header}}{{CSSRef}}

--- a/files/es/web/css/_colon_-moz-drag-over/index.md
+++ b/files/es/web/css/_colon_-moz-drag-over/index.md
@@ -1,12 +1,6 @@
 ---
 title: ':-moz-drag-over'
 slug: Web/CSS/:-moz-drag-over
-tags:
-  - CSS
-  - NeedsCompatTable
-  - No estandar
-  - Referencia CSS
-translation_of: Web/CSS/:-moz-drag-over
 ---
 
 {{Non-standard_header}}{{CSSRef}}

--- a/files/es/web/css/_colon_-moz-first-node/index.md
+++ b/files/es/web/css/_colon_-moz-first-node/index.md
@@ -1,12 +1,6 @@
 ---
 title: ':-moz-first-node'
 slug: Web/CSS/:-moz-first-node
-tags:
-  - CSS
-  - NeedsCompatTable
-  - No estandar
-  - Referencia CSS
-translation_of: Web/CSS/:-moz-first-node
 ---
 
 {{Non-standard_header}}{{CSSRef}}

--- a/files/es/web/css/_colon_-moz-focusring/index.md
+++ b/files/es/web/css/_colon_-moz-focusring/index.md
@@ -1,12 +1,6 @@
 ---
 title: ':-moz-focusring'
 slug: Web/CSS/:-moz-focusring
-tags:
-  - CSS
-  - NeedsLiveSample
-  - No estándar(2)
-  - Referencia CSS
-translation_of: Web/CSS/:-moz-focusring
 ---
 
 {{Non-standard_header}}{{CSSRef}}

--- a/files/es/web/css/_colon_-moz-handler-blocked/index.md
+++ b/files/es/web/css/_colon_-moz-handler-blocked/index.md
@@ -1,11 +1,6 @@
 ---
 title: ':-moz-handler-blocked'
 slug: Web/CSS/:-moz-handler-blocked
-tags:
-  - CSS
-  - No estandar
-  - Referencia CSS
-translation_of: Web/CSS/:-moz-handler-blocked
 ---
 
 {{Non-standard_header}}{{ CSSRef() }}

--- a/files/es/web/css/_colon_-moz-handler-crashed/index.md
+++ b/files/es/web/css/_colon_-moz-handler-crashed/index.md
@@ -1,11 +1,6 @@
 ---
 title: ':-moz-handler-crashed'
 slug: Web/CSS/:-moz-handler-crashed
-tags:
-  - CSS
-  - No estandar
-  - Referencia CSS
-translation_of: Web/CSS/:-moz-handler-crashed
 ---
 
 {{Non-standard_header}}{{ CSSRef() }}

--- a/files/es/web/css/_colon_-moz-handler-disabled/index.md
+++ b/files/es/web/css/_colon_-moz-handler-disabled/index.md
@@ -1,11 +1,6 @@
 ---
 title: ':-moz-handler-disabled'
 slug: Web/CSS/:-moz-handler-disabled
-tags:
-  - CSS
-  - No estandar
-  - Referencia CSS
-translation_of: Web/CSS/:-moz-handler-disabled
 ---
 
 {{Non-standard_header}}{{ CSSRef() }}

--- a/files/es/web/css/_colon_-moz-last-node/index.md
+++ b/files/es/web/css/_colon_-moz-last-node/index.md
@@ -1,12 +1,6 @@
 ---
 title: ':-moz-last-node'
 slug: Web/CSS/:-moz-last-node
-tags:
-  - CSS
-  - NeedsCompatTable
-  - No estandar
-  - Referencia CSS
-translation_of: Web/CSS/:-moz-last-node
 ---
 
 {{Non-standard_header}}{{CSSRef}}

--- a/files/es/web/css/_colon_-moz-list-bullet/index.md
+++ b/files/es/web/css/_colon_-moz-list-bullet/index.md
@@ -1,7 +1,6 @@
 ---
 title: '::-moz-list-bullet'
 slug: Web/CSS/:-moz-list-bullet
-translation_of: Web/CSS/:-moz-list-bullet
 original_slug: Web/CSS/:-moz-list-bullet
 ---
 

--- a/files/es/web/css/_colon_-moz-list-number/index.md
+++ b/files/es/web/css/_colon_-moz-list-number/index.md
@@ -1,13 +1,6 @@
 ---
 title: '::-moz-list-number'
 slug: Web/CSS/:-moz-list-number
-tags:
-  - CSS
-  - NeedsCompatTable
-  - No estandar
-  - Pseudo-elemento
-  - Referencia CSS
-translation_of: Web/CSS/:-moz-list-number
 ---
 
 {{Non-standard_header}}{{CSSRef}}

--- a/files/es/web/css/_colon_-moz-loading/index.md
+++ b/files/es/web/css/_colon_-moz-loading/index.md
@@ -1,14 +1,6 @@
 ---
 title: ':-moz-loading'
 slug: Web/CSS/:-moz-loading
-tags:
-  - CSS
-  - NeedsCompatTable
-  - NeedsContent
-  - NeedsExample
-  - No estandar
-  - Referencia CSS
-translation_of: Web/CSS/:-moz-loading
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/_colon_-moz-locale-dir(ltr)/index.md
+++ b/files/es/web/css/_colon_-moz-locale-dir(ltr)/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':-moz-locale-dir(ltr)'
 slug: Web/CSS/:-moz-locale-dir(ltr)
-tags:
-  - CSS
-  - Localización
-  - NeedsCompatTable
-  - NeedsExample
-  - No estandar
-  - Pseudo-clase
-  - Referencia CSS
-translation_of: Web/CSS/:-moz-locale-dir(ltr)
 ---
 
 {{Non-standard_header}}{{CSSRef}}

--- a/files/es/web/css/_colon_-moz-locale-dir(rtl)/index.md
+++ b/files/es/web/css/_colon_-moz-locale-dir(rtl)/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':-moz-locale-dir(rtl)'
 slug: Web/CSS/:-moz-locale-dir(rtl)
-tags:
-  - CSS
-  - Localización
-  - NeedsCompatTable
-  - NeedsExample
-  - No estandar
-  - Pseudo-clase
-  - Referencia CSS
-translation_of: Web/CSS/:-moz-locale-dir(rtl)
 ---
 
 {{Non-standard_header}}{{CSSRef}}

--- a/files/es/web/css/_colon_-moz-only-whitespace/index.md
+++ b/files/es/web/css/_colon_-moz-only-whitespace/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':-moz-only-whitespace'
 slug: Web/CSS/:-moz-only-whitespace
-tags:
-  - CSS
-  - NeedsCompatTable
-  - No estandar
-  - Pseudo-clase
-  - Referencia CSS
-translation_of: Web/CSS/:-moz-only-whitespace
 ---
 
 {{Non-standard_header}}{{CSSRef}}

--- a/files/es/web/css/_colon_-moz-submit-invalid/index.md
+++ b/files/es/web/css/_colon_-moz-submit-invalid/index.md
@@ -1,12 +1,6 @@
 ---
 title: ':-moz-submit-invalid'
 slug: Web/CSS/:-moz-submit-invalid
-tags:
-  - CSS
-  - No estandar
-  - Pseudo clase CSS
-  - Referencia CSS
-translation_of: Web/CSS/:-moz-submit-invalid
 ---
 
 {{Non-standard_header}}{{ CSSRef() }}

--- a/files/es/web/css/_colon_-moz-suppressed/index.md
+++ b/files/es/web/css/_colon_-moz-suppressed/index.md
@@ -1,14 +1,6 @@
 ---
 title: ':-moz-suppressed'
 slug: Web/CSS/:-moz-suppressed
-tags:
-  - CSS
-  - NeedsCompatTable
-  - NeedsContent
-  - NeedsExample
-  - No estandar
-  - Referencia CSS
-translation_of: Web/CSS/:-moz-suppressed
 ---
 
 {{Non-standard_header}}{{CSSRef}}

--- a/files/es/web/css/_colon_-moz-user-disabled/index.md
+++ b/files/es/web/css/_colon_-moz-user-disabled/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':-moz-user-disabled'
 slug: Web/CSS/:-moz-user-disabled
-tags:
-  - CSS
-  - NeedsCompatTable
-  - NeedsExample
-  - No estandar
-  - Referencia CSS
-translation_of: Web/CSS/:-moz-user-disabled
 ---
 
 {{Non-standard_header}}{{CSSRef}}

--- a/files/es/web/css/_colon_-moz-window-inactive/index.md
+++ b/files/es/web/css/_colon_-moz-window-inactive/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':-moz-window-inactive'
 slug: Web/CSS/:-moz-window-inactive
-tags:
-  - CSS
-  - CSS:Extensiones Mozilla
-  - NeedsMobileBrowserCompatibility
-  - No estándar(2)
-  - Referencia CSS
-translation_of: Web/CSS/:-moz-window-inactive
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_active/index.md
+++ b/files/es/web/css/_colon_active/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':active'
 slug: Web/CSS/:active
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:active
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_any-link/index.md
+++ b/files/es/web/css/_colon_any-link/index.md
@@ -1,15 +1,6 @@
 ---
 title: ':any-link'
 slug: Web/CSS/:any-link
-tags:
-  - CSS
-  - Diseño
-  - Experimental
-  - Presentación
-  - Pseudo-Clase CSS
-  - Referencia
-  - Web
-translation_of: Web/CSS/:any-link
 ---
 
 {{CSSRef}} {{SeeCompatTable}}La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) `:any-link` de [CSS](/es/docs/Web/CSS) representa a un elemento que actúa como el ancla origen de un hipervínculo independientemente de si ha sido visitado, es decir, coincide con cualquier elemento {{HTMLElement("a")}}, {{HTMLElement("area")}} o {{HTMLElement("link")}} con un atributo `href`. Por lo tanto, coincide con todos los elementos que coincidan con {{cssxref(":link")}} o {{cssxref(":visited")}}.

--- a/files/es/web/css/_colon_autofill/index.md
+++ b/files/es/web/css/_colon_autofill/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':-webkit-autofill'
 slug: Web/CSS/:autofill
-tags:
-  - CSS
-  - NeedsExample
-  - No estándar(2)
-  - Pseudo-clase
-  - Referencia
-translation_of: Web/CSS/:-webkit-autofill
 original_slug: Web/CSS/:-webkit-autofill
 ---
 

--- a/files/es/web/css/_colon_blank/index.md
+++ b/files/es/web/css/_colon_blank/index.md
@@ -1,12 +1,6 @@
 ---
 title: ':blank'
 slug: Web/CSS/:blank
-tags:
-  - ':blank'
-  - Borrador
-  - CSS
-  - Experimental
-translation_of: Web/CSS/:blank
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/_colon_checked/index.md
+++ b/files/es/web/css/_colon_checked/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':checked'
 slug: Web/CSS/:checked
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:checked
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/_colon_default/index.md
+++ b/files/es/web/css/_colon_default/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':default'
 slug: Web/CSS/:default
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:default
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/_colon_defined/index.md
+++ b/files/es/web/css/_colon_defined/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':defined'
 slug: Web/CSS/:defined
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:defined
 ---
 
 {{ CSSRef }}

--- a/files/es/web/css/_colon_dir/index.md
+++ b/files/es/web/css/_colon_dir/index.md
@@ -1,12 +1,6 @@
 ---
 title: ':dir()'
 slug: Web/CSS/:dir
-tags:
-  - CSS
-  - Experimental
-  - Pseudo-clase
-  - Referencia
-translation_of: Web/CSS/:dir
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/_colon_disabled/index.md
+++ b/files/es/web/css/_colon_disabled/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':disabled'
 slug: Web/CSS/:disabled
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:disabled
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_empty/index.md
+++ b/files/es/web/css/_colon_empty/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':empty'
 slug: Web/CSS/:empty
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:empty
 ---
 
 {{ CSSRef() }}La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:empty`** de [CSS](/es/docs/Web/CSS) representa cualquier elemento que no tenga hijos. Los hijos pueden ser nodos de elemento o texto (incluido el espacio en blanco). Los comentarios o las instrucciones de procesamiento no afectan si un elemento se considera vacío.

--- a/files/es/web/css/_colon_enabled/index.md
+++ b/files/es/web/css/_colon_enabled/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':enabled'
 slug: Web/CSS/:enabled
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:enabled
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_first-child/index.md
+++ b/files/es/web/css/_colon_first-child/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':first-child'
 slug: Web/CSS/:first-child
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:first-child
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_first-of-type/index.md
+++ b/files/es/web/css/_colon_first-of-type/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':first-of-type'
 slug: Web/CSS/:first-of-type
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:first-of-type
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_first/index.md
+++ b/files/es/web/css/_colon_first/index.md
@@ -1,14 +1,6 @@
 ---
 title: ':first'
 slug: Web/CSS/:first
-tags:
-  - '@page'
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:first
 ---
 
 {{CSSRef}}La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) `:first` de [CSS](/es/docs/Web/CSS), utilizada con la [regla-at](/es/docs/Web/CSS/At-rule) {{cssxref("@page")}}, representa la primera página de un documento impreso.

--- a/files/es/web/css/_colon_focus-visible/index.md
+++ b/files/es/web/css/_colon_focus-visible/index.md
@@ -1,7 +1,6 @@
 ---
 title: ':focus-visible'
 slug: Web/CSS/:focus-visible
-translation_of: Web/CSS/:focus-visible
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_focus-within/index.md
+++ b/files/es/web/css/_colon_focus-within/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':focus-within'
 slug: Web/CSS/:focus-within
-tags:
-  - CSS
-  - Diseño
-  - Referencia
-  - Web
-  - pseudo-clases
-translation_of: Web/CSS/:focus-within
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_focus/index.md
+++ b/files/es/web/css/_colon_focus/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':focus'
 slug: Web/CSS/:focus
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:focus
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_fullscreen/index.md
+++ b/files/es/web/css/_colon_fullscreen/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':fullscreen'
 slug: Web/CSS/:fullscreen
-tags:
-  - CSS
-  - Experimental
-  - Pantalla completa
-  - Pseudo-clase
-  - Referencia
-translation_of: Web/CSS/:fullscreen
 ---
 
 {{CSSRef}} {{SeeCompatTable}}

--- a/files/es/web/css/_colon_has/index.md
+++ b/files/es/web/css/_colon_has/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':has'
 slug: Web/CSS/:has
-tags:
-  - CSS
-  - Experimental
-  - Pseudo clase
-  - Referencia
-  - Selectores CSS
-translation_of: Web/CSS/:has
 ---
 
 {{ CSSRef() }}{{SeeCompatTable}}

--- a/files/es/web/css/_colon_host/index.md
+++ b/files/es/web/css/_colon_host/index.md
@@ -1,14 +1,6 @@
 ---
 title: ':host'
 slug: Web/CSS/:host
-tags:
-  - ':host'
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:host
 ---
 
 {{ CSSRef }}

--- a/files/es/web/css/_colon_hover/index.md
+++ b/files/es/web/css/_colon_hover/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':hover'
 slug: Web/CSS/:hover
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:hover
 ---
 
 {{ CSSRef }}

--- a/files/es/web/css/_colon_in-range/index.md
+++ b/files/es/web/css/_colon_in-range/index.md
@@ -1,12 +1,6 @@
 ---
 title: ':in-range'
 slug: Web/CSS/:in-range
-tags:
-  - CSS
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:in-range
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_indeterminate/index.md
+++ b/files/es/web/css/_colon_indeterminate/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':indeterminate'
 slug: Web/CSS/:indeterminate
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:indeterminate
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_invalid/index.md
+++ b/files/es/web/css/_colon_invalid/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':invalid'
 slug: Web/CSS/:invalid
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:invalid
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_is/index.md
+++ b/files/es/web/css/_colon_is/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':any'
 slug: Web/CSS/:is
-tags:
-  - CSS
-  - Experimental
-  - Pseudo-Clase CSS
-  - Referencia
-translation_of: Web/CSS/:is
-translation_of_original: Web/CSS/:any
 original_slug: Web/CSS/:any
 ---
 

--- a/files/es/web/css/_colon_lang/index.md
+++ b/files/es/web/css/_colon_lang/index.md
@@ -1,11 +1,6 @@
 ---
 title: ':lang'
 slug: Web/CSS/:lang
-tags:
-  - CSS
-  - Pseudo-clase
-  - Web
-translation_of: Web/CSS/:lang
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_last-child/index.md
+++ b/files/es/web/css/_colon_last-child/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':last-child'
 slug: Web/CSS/:last-child
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:last-child
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_last-of-type/index.md
+++ b/files/es/web/css/_colon_last-of-type/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':last-of-type'
 slug: Web/CSS/:last-of-type
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:last-of-type
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_left/index.md
+++ b/files/es/web/css/_colon_left/index.md
@@ -1,14 +1,6 @@
 ---
 title: ':left'
 slug: Web/CSS/:left
-tags:
-  - '@page'
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:left
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/_colon_link/index.md
+++ b/files/es/web/css/_colon_link/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':link'
 slug: Web/CSS/:link
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:link
 ---
 
 {{ CSSRef }}

--- a/files/es/web/css/_colon_not/index.md
+++ b/files/es/web/css/_colon_not/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':not()'
 slug: Web/CSS/:not
-tags:
-  - CSS
-  - Diseño
-  - Referencia
-  - Web
-  - pseudoclase
-translation_of: Web/CSS/:not
 original_slug: Web/CSS/:not()
 ---
 

--- a/files/es/web/css/_colon_nth-child/index.md
+++ b/files/es/web/css/_colon_nth-child/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':nth-child'
 slug: Web/CSS/:nth-child
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:nth-child
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_nth-last-child/index.md
+++ b/files/es/web/css/_colon_nth-last-child/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':nth-last-child'
 slug: Web/CSS/:nth-last-child
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:nth-last-child
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_nth-last-of-type/index.md
+++ b/files/es/web/css/_colon_nth-last-of-type/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':nth-last-of-type()'
 slug: Web/CSS/:nth-last-of-type
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:nth-last-of-type
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_nth-of-type/index.md
+++ b/files/es/web/css/_colon_nth-of-type/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':nth-of-type'
 slug: Web/CSS/:nth-of-type
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:nth-of-type
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_only-child/index.md
+++ b/files/es/web/css/_colon_only-child/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':only-child'
 slug: Web/CSS/:only-child
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:only-child
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_only-of-type/index.md
+++ b/files/es/web/css/_colon_only-of-type/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':only-of-type'
 slug: Web/CSS/:only-of-type
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:only-of-type
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_optional/index.md
+++ b/files/es/web/css/_colon_optional/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':optional'
 slug: Web/CSS/:optional
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:optional
 ---
 
 {{ CSSRef }}

--- a/files/es/web/css/_colon_out-of-range/index.md
+++ b/files/es/web/css/_colon_out-of-range/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':out-of-range'
 slug: Web/CSS/:out-of-range
-tags:
-  - CSS
-  - Presentación
-  - Pseudo-Clase CSS
-  - Referencia CSS
-  - Web
-translation_of: Web/CSS/:out-of-range
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_placeholder-shown/index.md
+++ b/files/es/web/css/_colon_placeholder-shown/index.md
@@ -1,12 +1,6 @@
 ---
 title: ':placeholder-shown'
 slug: Web/CSS/:placeholder-shown
-tags:
-  - CSS
-  - Experimental
-  - Pseudo-clase
-  - Referencia
-translation_of: Web/CSS/:placeholder-shown
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/_colon_read-only/index.md
+++ b/files/es/web/css/_colon_read-only/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':read-only'
 slug: Web/CSS/:read-only
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:read-only
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_read-write/index.md
+++ b/files/es/web/css/_colon_read-write/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':read-write'
 slug: Web/CSS/:read-write
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:read-write
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_required/index.md
+++ b/files/es/web/css/_colon_required/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':required'
 slug: Web/CSS/:required
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:required
 ---
 
 {{ CSSRef }}

--- a/files/es/web/css/_colon_right/index.md
+++ b/files/es/web/css/_colon_right/index.md
@@ -1,14 +1,6 @@
 ---
 title: ':right'
 slug: Web/CSS/:right
-tags:
-  - '@page'
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:right
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/_colon_root/index.md
+++ b/files/es/web/css/_colon_root/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':root'
 slug: Web/CSS/:root
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:root
 ---
 {{CSSRef}}
 

--- a/files/es/web/css/_colon_target/index.md
+++ b/files/es/web/css/_colon_target/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':target'
 slug: Web/CSS/:target
-tags:
-  - CSS
-  - Layout
-  - Pseudo clase CSS
-  - Referencia
-  - Web
-translation_of: Web/CSS/:target
 ---
 {{CSSRef}}
 

--- a/files/es/web/css/_colon_user-invalid/index.md
+++ b/files/es/web/css/_colon_user-invalid/index.md
@@ -1,14 +1,6 @@
 ---
 title: ':-moz-ui-invalid'
 slug: Web/CSS/:user-invalid
-tags:
-  - CSS
-  - NeedsExample
-  - NeedsMobileBrowserCompatibility
-  - No estándar(2)
-  - Pseudo clase
-  - Referencia CSS
-translation_of: Web/CSS/:user-invalid
 original_slug: Web/CSS/:-moz-ui-invalid
 ---
 

--- a/files/es/web/css/_colon_valid/index.md
+++ b/files/es/web/css/_colon_valid/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':valid'
 slug: Web/CSS/:valid
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:valid
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_colon_visited/index.md
+++ b/files/es/web/css/_colon_visited/index.md
@@ -1,13 +1,6 @@
 ---
 title: ':visited'
 slug: Web/CSS/:visited
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-clase
-  - Referencia
-  - Web
-translation_of: Web/CSS/:visited
 ---
 
 {{ CSSRef }}

--- a/files/es/web/css/_doublecolon_-moz-color-swatch/index.md
+++ b/files/es/web/css/_doublecolon_-moz-color-swatch/index.md
@@ -1,7 +1,6 @@
 ---
 title: '::-moz-color-swatch'
 slug: Web/CSS/::-moz-color-swatch
-translation_of: Web/CSS/::-moz-color-swatch
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/_doublecolon_-moz-page-sequence/index.md
+++ b/files/es/web/css/_doublecolon_-moz-page-sequence/index.md
@@ -1,14 +1,6 @@
 ---
 title: '::-moz-page-sequence'
 slug: Web/CSS/::-moz-page-sequence
-tags:
-  - CSS
-  - NeedsBrowserCompatibility
-  - NeedsExample
-  - No estándar(2)
-  - Pseudo-elemento
-  - Referencia CSS
-translation_of: Web/CSS/::-moz-page-sequence
 ---
 
 {{CSSRef}}{{non-standard_header}}

--- a/files/es/web/css/_doublecolon_-moz-page/index.md
+++ b/files/es/web/css/_doublecolon_-moz-page/index.md
@@ -1,13 +1,6 @@
 ---
 title: '::-moz-page'
 slug: Web/CSS/::-moz-page
-tags:
-  - CSS
-  - NeedsCompatTable
-  - NeedsE
-  - No estándar(2)
-  - Referencia CSS
-translation_of: Web/CSS/::-moz-page
 ---
 
 {{Non-standard_header}}{{CSSRef}}

--- a/files/es/web/css/_doublecolon_-moz-progress-bar/index.md
+++ b/files/es/web/css/_doublecolon_-moz-progress-bar/index.md
@@ -1,14 +1,6 @@
 ---
 title: '::-moz-progress-bar'
 slug: Web/CSS/::-moz-progress-bar
-tags:
-  - CSS
-  - 'CSS: Extensiones Mozilla'
-  - NeedsCompatTable
-  - No estandar
-  - Pseudo-elemento
-  - Referencia
-translation_of: Web/CSS/::-moz-progress-bar
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/_doublecolon_-moz-range-progress/index.md
+++ b/files/es/web/css/_doublecolon_-moz-range-progress/index.md
@@ -1,13 +1,6 @@
 ---
 title: '::-moz-range-progress'
 slug: Web/CSS/::-moz-range-progress
-tags:
-  - CSS
-  - No estándar(2)
-  - Pseudo-elemento
-  - Pseudo-elemento CSS
-  - Referencia
-translation_of: Web/CSS/::-moz-range-progress
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/_doublecolon_-moz-range-thumb/index.md
+++ b/files/es/web/css/_doublecolon_-moz-range-thumb/index.md
@@ -1,13 +1,6 @@
 ---
 title: '::-moz-range-thumb'
 slug: Web/CSS/::-moz-range-thumb
-tags:
-  - CSS
-  - No estándar(2)
-  - Pseudo-elemento
-  - Pseudo-elemento CSS
-  - Referencia
-translation_of: Web/CSS/::-moz-range-thumb
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/_doublecolon_-moz-range-track/index.md
+++ b/files/es/web/css/_doublecolon_-moz-range-track/index.md
@@ -1,13 +1,6 @@
 ---
 title: '::-moz-range-track'
 slug: Web/CSS/::-moz-range-track
-tags:
-  - CSS
-  - No estándar(2)
-  - Pseudo-elemento
-  - Pseudo-elemento CSS
-  - Referencia
-translation_of: Web/CSS/::-moz-range-track
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/_doublecolon_-moz-scrolled-page-sequence/index.md
+++ b/files/es/web/css/_doublecolon_-moz-scrolled-page-sequence/index.md
@@ -1,13 +1,6 @@
 ---
 title: '::-moz-scrolled-page-sequence'
 slug: Web/CSS/::-moz-scrolled-page-sequence
-tags:
-  - CSS
-  - NeedsExample
-  - No estándar(2)
-  - Referencia
-  - Referencia CSS
-translation_of: Web/CSS/::-moz-scrolled-page-sequence
 ---
 
 {{CSSRef}}{{non-standard_header}}

--- a/files/es/web/css/_doublecolon_-webkit-inner-spin-button/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-inner-spin-button/index.md
@@ -1,12 +1,6 @@
 ---
 title: '::-webkit-inner-spin-button'
 slug: Web/CSS/::-webkit-inner-spin-button
-tags:
-  - CSS
-  - No estándar(2)
-  - Pseudo-elemento
-  - Referencia
-translation_of: Web/CSS/::-webkit-inner-spin-button
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/_doublecolon_-webkit-meter-bar/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-meter-bar/index.md
@@ -1,12 +1,6 @@
 ---
 title: '::-webkit-meter-bar'
 slug: Web/CSS/::-webkit-meter-bar
-tags:
-  - CSS
-  - No estándar(2)
-  - Pseudo-elemento
-  - Referencia
-translation_of: Web/CSS/::-webkit-meter-bar
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/_doublecolon_-webkit-meter-even-less-good-value/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-meter-even-less-good-value/index.md
@@ -1,7 +1,6 @@
 ---
 title: '::-webkit-meter-even-less-good-value'
 slug: Web/CSS/::-webkit-meter-even-less-good-value
-translation_of: Web/CSS/::-webkit-meter-even-less-good-value
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/_doublecolon_-webkit-meter-inner-element/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-meter-inner-element/index.md
@@ -1,12 +1,6 @@
 ---
 title: '::-webkit-meter-inner-element'
 slug: Web/CSS/::-webkit-meter-inner-element
-tags:
-  - CSS
-  - No estándar(2)
-  - Pseudo-elemento
-  - Referencia
-translation_of: Web/CSS/::-webkit-meter-inner-element
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/_doublecolon_-webkit-meter-optimum-value/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-meter-optimum-value/index.md
@@ -1,12 +1,6 @@
 ---
 title: '::-webkit-meter-optimum-value'
 slug: Web/CSS/::-webkit-meter-optimum-value
-tags:
-  - CSS
-  - No estándar(2)
-  - Pseudo-elemento
-  - Referencia
-translation_of: Web/CSS/::-webkit-meter-optimum-value
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/_doublecolon_-webkit-meter-suboptimum-value/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-meter-suboptimum-value/index.md
@@ -1,12 +1,6 @@
 ---
 title: '::-webkit-meter-suboptimum-value'
 slug: Web/CSS/::-webkit-meter-suboptimum-value
-tags:
-  - CSS
-  - No estándar(2)
-  - Pseudo-elemento
-  - Referencia
-translation_of: Web/CSS/::-webkit-meter-suboptimum-value
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/_doublecolon_-webkit-outer-spin-button/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-outer-spin-button/index.md
@@ -1,12 +1,6 @@
 ---
 title: '::-webkit-outer-spin-button'
 slug: Web/CSS/::-webkit-outer-spin-button
-tags:
-  - CSS
-  - No estándar(2)
-  - Pseudo-elemento
-  - Referencia
-translation_of: Web/CSS/::-webkit-outer-spin-button
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/_doublecolon_-webkit-progress-bar/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-progress-bar/index.md
@@ -1,12 +1,6 @@
 ---
 title: '::-webkit-progress-bar'
 slug: Web/CSS/::-webkit-progress-bar
-tags:
-  - CSS
-  - No estándar(2)
-  - Pseudo-elemento
-  - Referencia
-translation_of: Web/CSS/::-webkit-progress-bar
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/_doublecolon_-webkit-progress-inner-element/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-progress-inner-element/index.md
@@ -1,12 +1,6 @@
 ---
 title: '::-webkit-progress-inner-element'
 slug: Web/CSS/::-webkit-progress-inner-element
-tags:
-  - CSS
-  - No estándar(2)
-  - Pseudo-elemento
-  - Referencia
-translation_of: Web/CSS/::-webkit-progress-inner-element
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/_doublecolon_-webkit-progress-value/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-progress-value/index.md
@@ -1,12 +1,6 @@
 ---
 title: '::-webkit-progress-value'
 slug: Web/CSS/::-webkit-progress-value
-tags:
-  - CSS
-  - No estándar(2)
-  - Pseudo-elemento
-  - Referencia
-translation_of: Web/CSS/::-webkit-progress-value
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/_doublecolon_-webkit-scrollbar/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-scrollbar/index.md
@@ -1,12 +1,6 @@
 ---
 title: '::-webkit-scrollbar'
 slug: Web/CSS/::-webkit-scrollbar
-tags:
-  - CSS
-  - NeedsCompatTable
-  - Pseudo-elemento
-  - Referencia
-translation_of: Web/CSS/::-webkit-scrollbar
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_doublecolon_-webkit-slider-runnable-track/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-slider-runnable-track/index.md
@@ -1,17 +1,6 @@
 ---
 title: '::-webkit-slider-runnable-track'
 slug: Web/CSS/::-webkit-slider-runnable-track
-tags:
-  - CSS
-  - NeedsBrowserCompatibility
-  - NeedsCompatTable
-  - NeedsExample
-  - NeedsMobileBrowserCompatibility
-  - No estándar(2)
-  - Pseudo-elemento
-  - Pseudo-elemento CSS
-  - Referencia
-translation_of: Web/CSS/::-webkit-slider-runnable-track
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/_doublecolon_-webkit-slider-thumb/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-slider-thumb/index.md
@@ -1,17 +1,6 @@
 ---
 title: '::-webkit-slider-thumb'
 slug: Web/CSS/::-webkit-slider-thumb
-tags:
-  - CSS
-  - NeedsBrowserCompatibility
-  - NeedsCompatTable
-  - NeedsExample
-  - NeedsMobileBrowserCompatibility
-  - No estándar(2)
-  - Pseudo-elemento
-  - Pseudo-elemento CSS
-  - Referencia
-translation_of: Web/CSS/::-webkit-slider-thumb
 ---
 
 admi{{CSSRef}}{{Non-standard_header}}

--- a/files/es/web/css/_doublecolon_after/index.md
+++ b/files/es/web/css/_doublecolon_after/index.md
@@ -1,13 +1,6 @@
 ---
 title: '::after (:after)'
 slug: Web/CSS/::after
-tags:
-  - CSS
-  - Presentación
-  - Pseudo-elemento CSS
-  - Referencia
-  - Web
-translation_of: Web/CSS/::after
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_doublecolon_backdrop/index.md
+++ b/files/es/web/css/_doublecolon_backdrop/index.md
@@ -1,15 +1,6 @@
 ---
 title: '::backdrop'
 slug: Web/CSS/::backdrop
-tags:
-  - CSS
-  - Layout
-  - NeedsContent
-  - Pantalla completa
-  - Pseudo Elemento CSS
-  - Referencia
-  - Web
-translation_of: Web/CSS/::backdrop
 ---
 
 {{CSSRef}} {{SeeCompatTable}}

--- a/files/es/web/css/_doublecolon_before/index.md
+++ b/files/es/web/css/_doublecolon_before/index.md
@@ -1,13 +1,6 @@
 ---
 title: '::before (:before)'
 slug: Web/CSS/::before
-tags:
-  - CSS
-  - Presentación
-  - Pseudo-elemento CSS
-  - Referencia
-  - Web
-translation_of: Web/CSS/::before
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_doublecolon_cue/index.md
+++ b/files/es/web/css/_doublecolon_cue/index.md
@@ -1,18 +1,6 @@
 ---
 title: '::cue'
 slug: Web/CSS/::cue
-tags:
-  - '::cue'
-  - Archivos multimedia
-  - CSS
-  - Formato de pistas de texto para la web
-  - Pseudo-elemento
-  - Referencia
-  - Selector
-  - WebVTT
-  - anotaciones
-  - subtítulos
-translation_of: Web/CSS/::cue
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_doublecolon_file-selector-button/index.md
+++ b/files/es/web/css/_doublecolon_file-selector-button/index.md
@@ -1,9 +1,7 @@
 ---
 title: '::file-selector-button'
 slug: Web/CSS/::file-selector-button
-translation_of: Web/CSS/::file-selector-button
 original_slug: Web/CSS/::file-selector-button
-browser-compat: css.selectors.file-selector-button
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_doublecolon_first-letter/index.md
+++ b/files/es/web/css/_doublecolon_first-letter/index.md
@@ -1,12 +1,6 @@
 ---
 title: '::first-letter (:first-letter)'
 slug: Web/CSS/::first-letter
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-element
-  - Reference
-translation_of: Web/CSS/::first-letter
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_doublecolon_first-line/index.md
+++ b/files/es/web/css/_doublecolon_first-line/index.md
@@ -1,12 +1,6 @@
 ---
 title: '::first-line (:first-line)'
 slug: Web/CSS/::first-line
-tags:
-  - CSS
-  - Diseño
-  - Pseudo-element
-  - Reference
-translation_of: Web/CSS/::first-line
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_doublecolon_marker/index.md
+++ b/files/es/web/css/_doublecolon_marker/index.md
@@ -1,7 +1,6 @@
 ---
 title: '::marker'
 slug: Web/CSS/::marker
-translation_of: Web/CSS/::marker
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/_doublecolon_placeholder/index.md
+++ b/files/es/web/css/_doublecolon_placeholder/index.md
@@ -1,12 +1,6 @@
 ---
 title: '::placeholder'
 slug: Web/CSS/::placeholder
-tags:
-  - '::placeholder'
-  - CSS
-  - Pseudo-elemento
-  - Referencia
-translation_of: Web/CSS/::placeholder
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/_doublecolon_selection/index.md
+++ b/files/es/web/css/_doublecolon_selection/index.md
@@ -1,7 +1,6 @@
 ---
 title: '::selection'
 slug: Web/CSS/::selection
-translation_of: Web/CSS/::selection
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/_doublecolon_spelling-error/index.md
+++ b/files/es/web/css/_doublecolon_spelling-error/index.md
@@ -1,13 +1,6 @@
 ---
 title: '::spelling-error'
 slug: Web/CSS/::spelling-error
-tags:
-  - CSS
-  - Experimental
-  - Pseudo-elemento
-  - Referencia
-  - Web
-translation_of: Web/CSS/::spelling-error
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/actual_value/index.md
+++ b/files/es/web/css/actual_value/index.md
@@ -1,7 +1,6 @@
 ---
 title: Valor real
 slug: Web/CSS/actual_value
-translation_of: Web/CSS/actual_value
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/adjacent_sibling_combinator/index.md
+++ b/files/es/web/css/adjacent_sibling_combinator/index.md
@@ -1,12 +1,6 @@
 ---
 title: Selectores de hermanos adyacentes
 slug: Web/CSS/Adjacent_sibling_combinator
-tags:
-  - CSS
-  - NeedsMobileBrowserCompatibility
-  - Referencia CSS
-  - Selectores
-translation_of: Web/CSS/Adjacent_sibling_combinator
 original_slug: Web/CSS/Selectores_hermanos_adyacentes
 ---
 

--- a/files/es/web/css/align-content/index.md
+++ b/files/es/web/css/align-content/index.md
@@ -1,10 +1,6 @@
 ---
 title: align-content
 slug: Web/CSS/align-content
-tags:
-  - Cajas Flexibles CSS
-  - Propiedad CSS
-translation_of: Web/CSS/align-content
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/align-items/index.md
+++ b/files/es/web/css/align-items/index.md
@@ -1,11 +1,6 @@
 ---
 title: align-items
 slug: Web/CSS/align-items
-tags:
-  - Cajas Flexibles CSS
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/align-items
 ---
 
 La propiedad [CSS](/es/docs/Web/CSS) **`align-items`** establece el valor {{cssxref("align-self")}} sobre todos los descendientes directos de un grupo. La propiedad align-self indica la alineación de un elemento dentro del bloque que lo contiene. En Flexbox controla la alineación de los elementos del {{glossary("Cross Axis")}}, en Grid Layout controla la alineación de los elementos en el eje Block dentro de su [área grid](/es/docs/Glossary/Grid_Areas).

--- a/files/es/web/css/align-self/index.md
+++ b/files/es/web/css/align-self/index.md
@@ -1,11 +1,6 @@
 ---
 title: align-self
 slug: Web/CSS/align-self
-tags:
-  - Cajas Flexibles CSS
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/align-self
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/all/index.md
+++ b/files/es/web/css/all/index.md
@@ -1,11 +1,6 @@
 ---
 title: all
 slug: Web/CSS/all
-tags:
-  - Cascada CSS
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/all
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/angle/index.md
+++ b/files/es/web/css/angle/index.md
@@ -1,9 +1,6 @@
 ---
 title: <angle>
 slug: Web/CSS/angle
-tags:
-  - Ángulo
-translation_of: Web/CSS/angle
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/animation-delay/index.md
+++ b/files/es/web/css/animation-delay/index.md
@@ -1,13 +1,6 @@
 ---
 title: animation-delay
 slug: Web/CSS/animation-delay
-tags:
-  - CSS
-  - CSS Animations
-  - CSS Property
-  - Experimental
-  - Reference
-translation_of: Web/CSS/animation-delay
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/animation-direction/index.md
+++ b/files/es/web/css/animation-direction/index.md
@@ -1,13 +1,6 @@
 ---
 title: animation-direction
 slug: Web/CSS/animation-direction
-tags:
-  - CSS
-  - CSS Animations
-  - CSS Property
-  - Experemiental
-  - Reference
-translation_of: Web/CSS/animation-direction
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/animation-duration/index.md
+++ b/files/es/web/css/animation-duration/index.md
@@ -1,13 +1,6 @@
 ---
 title: animation-duration
 slug: Web/CSS/animation-duration
-tags:
-  - CSS
-  - CSS Animations
-  - CSS Property
-  - Experimental
-  - Reference
-translation_of: Web/CSS/animation-duration
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/animation-fill-mode/index.md
+++ b/files/es/web/css/animation-fill-mode/index.md
@@ -1,13 +1,6 @@
 ---
 title: animation-fill-mode
 slug: Web/CSS/animation-fill-mode
-tags:
-  - CSS
-  - CSS Animations
-  - CSS Property
-  - Experimental
-  - Reference
-translation_of: Web/CSS/animation-fill-mode
 ---
 
 {{ CSSRef() }}{{ SeeCompatTable() }}

--- a/files/es/web/css/animation-iteration-count/index.md
+++ b/files/es/web/css/animation-iteration-count/index.md
@@ -1,13 +1,6 @@
 ---
 title: animation-iteration-count
 slug: Web/CSS/animation-iteration-count
-tags:
-  - CSS
-  - CSS Animations
-  - CSS Property
-  - Experimental
-  - Reference
-translation_of: Web/CSS/animation-iteration-count
 ---
 
 {{ CSSRef() }}{{ SeeCompatTable() }}

--- a/files/es/web/css/animation-name/index.md
+++ b/files/es/web/css/animation-name/index.md
@@ -1,13 +1,6 @@
 ---
 title: animation-name
 slug: Web/CSS/animation-name
-tags:
-  - CSS
-  - CSS Animations
-  - CSS Property
-  - Experimental
-  - Reference
-translation_of: Web/CSS/animation-name
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/animation-play-state/index.md
+++ b/files/es/web/css/animation-play-state/index.md
@@ -1,7 +1,6 @@
 ---
 title: animation-play-state
 slug: Web/CSS/animation-play-state
-translation_of: Web/CSS/animation-play-state
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/animation-timing-function/index.md
+++ b/files/es/web/css/animation-timing-function/index.md
@@ -1,7 +1,6 @@
 ---
 title: animation-timing-function
 slug: Web/CSS/animation-timing-function
-translation_of: Web/CSS/animation-timing-function
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/animation/index.md
+++ b/files/es/web/css/animation/index.md
@@ -1,13 +1,6 @@
 ---
 title: animation
 slug: Web/CSS/animation
-tags:
-  - CSS
-  - CSS Animations
-  - CSS Property
-  - Experimental
-  - Reference
-translation_of: Web/CSS/animation
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/appearance/index.md
+++ b/files/es/web/css/appearance/index.md
@@ -1,11 +1,6 @@
 ---
 title: '-moz-appearance (-webkit-appearance)'
 slug: Web/CSS/appearance
-tags:
-  - Apariencia CSS
-  - CSS Referencia(2)
-  - No-estándar
-translation_of: Web/CSS/appearance
 ---
 
 {{non-standard_header}}{{CSSRef}}

--- a/files/es/web/css/at-rule/index.md
+++ b/files/es/web/css/at-rule/index.md
@@ -1,7 +1,6 @@
 ---
 title: Regla-At
 slug: Web/CSS/At-rule
-translation_of: Web/CSS/At-rule
 ---
 
 {{cssref}}

--- a/files/es/web/css/attr/index.md
+++ b/files/es/web/css/attr/index.md
@@ -1,7 +1,6 @@
 ---
 title: attr
 slug: Web/CSS/attr
-translation_of: Web/CSS/attr()
 original_slug: Web/CSS/attr()
 ---
 

--- a/files/es/web/css/attribute_selectors/index.md
+++ b/files/es/web/css/attribute_selectors/index.md
@@ -1,12 +1,6 @@
 ---
 title: Selectores de atributo
 slug: Web/CSS/Attribute_selectors
-tags:
-  - Atributos
-  - CSS
-  - Selectores
-  - Selectores de Atributo
-translation_of: Web/CSS/Attribute_selectors
 original_slug: Web/CSS/Selectores_atributo
 ---
 

--- a/files/es/web/css/backdrop-filter/index.md
+++ b/files/es/web/css/backdrop-filter/index.md
@@ -1,16 +1,6 @@
 ---
 title: backdrop-filter
 slug: Web/CSS/backdrop-filter
-tags:
-  - CSS
-  - Diseño
-  - Filtro SVG
-  - Propiedad CSS
-  - Referencia
-  - SVG
-  - Web
-  - graficos
-translation_of: Web/CSS/backdrop-filter
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/backface-visibility/index.md
+++ b/files/es/web/css/backface-visibility/index.md
@@ -1,12 +1,6 @@
 ---
 title: backface-visibility
 slug: Web/CSS/backface-visibility
-tags:
-  - CSS
-  - Experimental
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/backface-visibility
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/background-attachment/index.md
+++ b/files/es/web/css/background-attachment/index.md
@@ -1,9 +1,6 @@
 ---
 title: background-attachment
 slug: Web/CSS/background-attachment
-tags:
-  - CSS
-translation_of: Web/CSS/background-attachment
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/background-blend-mode/index.md
+++ b/files/es/web/css/background-blend-mode/index.md
@@ -1,10 +1,6 @@
 ---
 title: background-blend-mode
 slug: Web/CSS/background-blend-mode
-tags:
-  - Composición CSS
-  - Propiedad CSS
-translation_of: Web/CSS/background-blend-mode
 ---
 
 {{CSSRef()}}

--- a/files/es/web/css/background-clip/index.md
+++ b/files/es/web/css/background-clip/index.md
@@ -1,15 +1,6 @@
 ---
 title: background-clip
 slug: Web/CSS/background-clip
-tags:
-  - CSS
-  - Diseño
-  - Fondo CSS
-  - Propiedad CSS
-  - Referencia
-  - Referência(2)
-  - Web
-translation_of: Web/CSS/background-clip
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/background-color/index.md
+++ b/files/es/web/css/background-color/index.md
@@ -1,11 +1,6 @@
 ---
 title: background-color
 slug: Web/CSS/background-color
-tags:
-  - CSS
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/background-color
 ---
 
 ### Resumen

--- a/files/es/web/css/background-image/index.md
+++ b/files/es/web/css/background-image/index.md
@@ -1,9 +1,6 @@
 ---
 title: background-image
 slug: Web/CSS/background-image
-page-type: css-property
-translation_of: Web/CSS/background-image
-browser-compat: css.properties.background-image
 l10n:
   sourceCommit: 642f2385b7cf791b3a40a81a17752f5b0c3208ea
 ---

--- a/files/es/web/css/background-origin/index.md
+++ b/files/es/web/css/background-origin/index.md
@@ -1,10 +1,6 @@
 ---
 title: background-origin
 slug: Web/CSS/background-origin
-tags:
-  - CSS
-  - CSS Referência
-translation_of: Web/CSS/background-origin
 ---
 
 ## Resumen

--- a/files/es/web/css/background-position/index.md
+++ b/files/es/web/css/background-position/index.md
@@ -1,11 +1,6 @@
 ---
 title: background-position
 slug: Web/CSS/background-position
-tags:
-  - CSS
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/background-position
 ---
 
 {{ PreviousNext("CSS:background-image", "CSS:background-repeat") }}

--- a/files/es/web/css/background-repeat/index.md
+++ b/files/es/web/css/background-repeat/index.md
@@ -1,14 +1,6 @@
 ---
 title: background-repeat
 slug: Web/CSS/background-repeat
-tags:
-  - CSS
-  - CSS:Referencias
-  - Fondos CSS
-  - Propiedades de CSS
-  - Referências
-  - Todas_las_Categorías
-translation_of: Web/CSS/background-repeat
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/background-size/index.md
+++ b/files/es/web/css/background-size/index.md
@@ -1,12 +1,6 @@
 ---
 title: background-size
 slug: Web/CSS/background-size
-tags:
-  - CSS
-  - CSS Background
-  - CSS Property
-  - Reference
-translation_of: Web/CSS/background-size
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/background/index.md
+++ b/files/es/web/css/background/index.md
@@ -1,11 +1,6 @@
 ---
 title: background
 slug: Web/CSS/background
-tags:
-  - CSS
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/background
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/basic-shape/index.md
+++ b/files/es/web/css/basic-shape/index.md
@@ -1,11 +1,6 @@
 ---
 title: <basic-shape>
 slug: Web/CSS/basic-shape
-tags:
-  - CSS
-  - Referencia
-  - Tipo de Dato CSS
-translation_of: Web/CSS/basic-shape
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/blend-mode/index.md
+++ b/files/es/web/css/blend-mode/index.md
@@ -1,13 +1,6 @@
 ---
 title: <blend-mode>
 slug: Web/CSS/blend-mode
-tags:
-  - Composición
-  - Composición CSS
-  - Modos de mezcla
-  - Referencia
-  - Tipo de Dato CSS
-translation_of: Web/CSS/blend-mode
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/block-size/index.md
+++ b/files/es/web/css/block-size/index.md
@@ -1,12 +1,6 @@
 ---
 title: block-size
 slug: Web/CSS/block-size
-tags:
-  - Experimental
-  - Propiedad CSS
-  - Propiedad Lógica CSS
-  - Referencia
-translation_of: Web/CSS/block-size
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-block-color/index.md
+++ b/files/es/web/css/border-block-color/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-block-color
 slug: Web/CSS/border-block-color
-translation_of: Web/CSS/border-block-color
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-block-end-color/index.md
+++ b/files/es/web/css/border-block-end-color/index.md
@@ -1,13 +1,6 @@
 ---
 title: border-block-end-color
 slug: Web/CSS/border-block-end-color
-tags:
-  - CSS
-  - Experimental
-  - Propiedad CSS
-  - Propiedad Lógica CSS
-  - Referencia
-translation_of: Web/CSS/border-block-end-color
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-block-end-style/index.md
+++ b/files/es/web/css/border-block-end-style/index.md
@@ -1,13 +1,6 @@
 ---
 title: border-block-end-style
 slug: Web/CSS/border-block-end-style
-tags:
-  - CSS
-  - Experimental
-  - Propiedad CSS
-  - Propiedad Lógica CSS
-  - Referencia
-translation_of: Web/CSS/border-block-end-style
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-block-end-width/index.md
+++ b/files/es/web/css/border-block-end-width/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-block-end-width
 slug: Web/CSS/border-block-end-width
-translation_of: Web/CSS/border-block-end-width
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-block-end/index.md
+++ b/files/es/web/css/border-block-end/index.md
@@ -1,13 +1,6 @@
 ---
 title: border-block-end
 slug: Web/CSS/border-block-end
-tags:
-  - CSS
-  - Experimental
-  - Propiedad CSS
-  - Propiedad Lógica CSS
-  - Referencia
-translation_of: Web/CSS/border-block-end
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-block-start-color/index.md
+++ b/files/es/web/css/border-block-start-color/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-block-start-color
 slug: Web/CSS/border-block-start-color
-translation_of: Web/CSS/border-block-start-color
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-block-start-style/index.md
+++ b/files/es/web/css/border-block-start-style/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-block-start-style
 slug: Web/CSS/border-block-start-style
-translation_of: Web/CSS/border-block-start-style
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-block-start-width/index.md
+++ b/files/es/web/css/border-block-start-width/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-block-start-width
 slug: Web/CSS/border-block-start-width
-translation_of: Web/CSS/border-block-start-width
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-block-start/index.md
+++ b/files/es/web/css/border-block-start/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-block-start
 slug: Web/CSS/border-block-start
-translation_of: Web/CSS/border-block-start
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-block-style/index.md
+++ b/files/es/web/css/border-block-style/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-block-style
 slug: Web/CSS/border-block-style
-translation_of: Web/CSS/border-block-style
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-block-width/index.md
+++ b/files/es/web/css/border-block-width/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-block-width
 slug: Web/CSS/border-block-width
-translation_of: Web/CSS/border-block-width
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-block/index.md
+++ b/files/es/web/css/border-block/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-block
 slug: Web/CSS/border-block
-translation_of: Web/CSS/border-block
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-bottom-color/index.md
+++ b/files/es/web/css/border-bottom-color/index.md
@@ -1,11 +1,6 @@
 ---
 title: border-bottom-color
 slug: Web/CSS/border-bottom-color
-tags:
-  - CSS
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/border-bottom-color
 ---
 
 << [Volver](/es/Guía_de_referencia_de_CSS)

--- a/files/es/web/css/border-bottom-left-radius/index.md
+++ b/files/es/web/css/border-bottom-left-radius/index.md
@@ -1,11 +1,6 @@
 ---
 title: border-bottom-left-radius
 slug: Web/CSS/border-bottom-left-radius
-tags:
-  - Bordes CSS
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/border-bottom-left-radius
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/border-bottom-right-radius/index.md
+++ b/files/es/web/css/border-bottom-right-radius/index.md
@@ -1,11 +1,6 @@
 ---
 title: border-bottom-right-radius
 slug: Web/CSS/border-bottom-right-radius
-tags:
-  - Bordes CSS
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/border-bottom-right-radius
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/border-bottom-style/index.md
+++ b/files/es/web/css/border-bottom-style/index.md
@@ -1,11 +1,6 @@
 ---
 title: border-bottom-style
 slug: Web/CSS/border-bottom-style
-tags:
-  - CSS
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/border-bottom-style
 ---
 
 << [Volver](/es/Guía_de_referencia_de_CSS)

--- a/files/es/web/css/border-bottom-width/index.md
+++ b/files/es/web/css/border-bottom-width/index.md
@@ -1,11 +1,6 @@
 ---
 title: border-bottom-width
 slug: Web/CSS/border-bottom-width
-tags:
-  - CSS
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/border-bottom-width
 ---
 
 << [Volver](/es/Guía_de_referencia_de_CSS)

--- a/files/es/web/css/border-bottom/index.md
+++ b/files/es/web/css/border-bottom/index.md
@@ -1,11 +1,6 @@
 ---
 title: border-bottom
 slug: Web/CSS/border-bottom
-tags:
-  - CSS
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/border-bottom
 ---
 
 << [Volver](/es/Guía_de_referencia_de_CSS)

--- a/files/es/web/css/border-collapse/index.md
+++ b/files/es/web/css/border-collapse/index.md
@@ -1,11 +1,6 @@
 ---
 title: border-collapse
 slug: Web/CSS/border-collapse
-tags:
-  - CSS
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/border-collapse
 ---
 
 << [Volver](es/Gu%c3%ada_de_referencia_de_CSS)

--- a/files/es/web/css/border-color/index.md
+++ b/files/es/web/css/border-color/index.md
@@ -1,11 +1,6 @@
 ---
 title: border-color
 slug: Web/CSS/border-color
-tags:
-  - CSS
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/border-color
 ---
 
 {{ PreviousNext("CSS:border", "CSS:border-style") }}

--- a/files/es/web/css/border-end-end-radius/index.md
+++ b/files/es/web/css/border-end-end-radius/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-end-end-radius
 slug: Web/CSS/border-end-end-radius
-translation_of: Web/CSS/border-end-end-radius
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-end-start-radius/index.md
+++ b/files/es/web/css/border-end-start-radius/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-end-start-radius
 slug: Web/CSS/border-end-start-radius
-translation_of: Web/CSS/border-end-start-radius
 ---
 {{CSSRef}}{{SeeCompatTable}}
 

--- a/files/es/web/css/border-image-outset/index.md
+++ b/files/es/web/css/border-image-outset/index.md
@@ -1,12 +1,6 @@
 ---
 title: border-image-outset
 slug: Web/CSS/border-image-outset
-tags:
-  - Bordes CSS
-  - CSS
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/border-image-outset
 ---
 {{CSSRef}}
 

--- a/files/es/web/css/border-image-repeat/index.md
+++ b/files/es/web/css/border-image-repeat/index.md
@@ -1,12 +1,6 @@
 ---
 title: border-image-repeat
 slug: Web/CSS/border-image-repeat
-tags:
-  - Bordes CSS
-  - CSS
-  - Propiedades CSS
-  - Referencia
-translation_of: Web/CSS/border-image-repeat
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/border-image-slice/index.md
+++ b/files/es/web/css/border-image-slice/index.md
@@ -1,12 +1,6 @@
 ---
 title: border-image-slice
 slug: Web/CSS/border-image-slice
-tags:
-  - Bordes CSS
-  - CSS
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/border-image-slice
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/border-image/index.md
+++ b/files/es/web/css/border-image/index.md
@@ -1,12 +1,6 @@
 ---
 title: border-image
 slug: Web/CSS/border-image
-tags:
-  - CSS
-  - CSS Borders
-  - CSS Property
-  - Reference
-translation_of: Web/CSS/border-image
 ---
 
 {{CSSRef("CSS Borders")}}

--- a/files/es/web/css/border-inline-color/index.md
+++ b/files/es/web/css/border-inline-color/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-inline-color
 slug: Web/CSS/border-inline-color
-translation_of: Web/CSS/border-inline-color
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-inline-end-color/index.md
+++ b/files/es/web/css/border-inline-end-color/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-inline-end-color
 slug: Web/CSS/border-inline-end-color
-translation_of: Web/CSS/border-inline-end-color
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-inline-end-style/index.md
+++ b/files/es/web/css/border-inline-end-style/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-inline-end-style
 slug: Web/CSS/border-inline-end-style
-translation_of: Web/CSS/border-inline-end-style
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-inline-end-width/index.md
+++ b/files/es/web/css/border-inline-end-width/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-inline-end-width
 slug: Web/CSS/border-inline-end-width
-translation_of: Web/CSS/border-inline-end-width
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-inline-end/index.md
+++ b/files/es/web/css/border-inline-end/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-inline-end
 slug: Web/CSS/border-inline-end
-translation_of: Web/CSS/border-inline-end
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-inline-start-color/index.md
+++ b/files/es/web/css/border-inline-start-color/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-inline-start-color
 slug: Web/CSS/border-inline-start-color
-translation_of: Web/CSS/border-inline-start-color
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-inline-start-style/index.md
+++ b/files/es/web/css/border-inline-start-style/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-inline-start-style
 slug: Web/CSS/border-inline-start-style
-translation_of: Web/CSS/border-inline-start-style
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-inline-start-width/index.md
+++ b/files/es/web/css/border-inline-start-width/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-inline-start-width
 slug: Web/CSS/border-inline-start-width
-translation_of: Web/CSS/border-inline-start-width
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-inline-start/index.md
+++ b/files/es/web/css/border-inline-start/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-inline-start
 slug: Web/CSS/border-inline-start
-translation_of: Web/CSS/border-inline-start
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-inline-style/index.md
+++ b/files/es/web/css/border-inline-style/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-inline-style
 slug: Web/CSS/border-inline-style
-translation_of: Web/CSS/border-inline-style
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-inline-width/index.md
+++ b/files/es/web/css/border-inline-width/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-inline-width
 slug: Web/CSS/border-inline-width
-translation_of: Web/CSS/border-inline-width
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-inline/index.md
+++ b/files/es/web/css/border-inline/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-inline
 slug: Web/CSS/border-inline
-translation_of: Web/CSS/border-inline
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-left-color/index.md
+++ b/files/es/web/css/border-left-color/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-left-color
 slug: Web/CSS/border-left-color
-translation_of: Web/CSS/border-left-color
 ---
 
 ### Resumen

--- a/files/es/web/css/border-left/index.md
+++ b/files/es/web/css/border-left/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-left
 slug: Web/CSS/border-left
-translation_of: Web/CSS/border-left
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/border-right/index.md
+++ b/files/es/web/css/border-right/index.md
@@ -1,11 +1,6 @@
 ---
 title: border-right
 slug: Web/CSS/border-right
-tags:
-  - Bordes CSS
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/border-right
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/border-spacing/index.md
+++ b/files/es/web/css/border-spacing/index.md
@@ -1,11 +1,6 @@
 ---
 title: border-spacing
 slug: Web/CSS/border-spacing
-tags:
-  - CSS
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/border-spacing
 ---
 
 << [Volver](es/Gu%c3%ada_de_referencia_de_CSS)

--- a/files/es/web/css/border-start-end-radius/index.md
+++ b/files/es/web/css/border-start-end-radius/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-start-end-radius
 slug: Web/CSS/border-start-end-radius
-translation_of: Web/CSS/border-start-end-radius
 ---
 {{CSSRef}}{{SeeCompatTable}}
 

--- a/files/es/web/css/border-start-start-radius/index.md
+++ b/files/es/web/css/border-start-start-radius/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-start-start-radius
 slug: Web/CSS/border-start-start-radius
-translation_of: Web/CSS/border-start-start-radius
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/border-style/index.md
+++ b/files/es/web/css/border-style/index.md
@@ -1,12 +1,6 @@
 ---
 title: border-style
 slug: Web/CSS/border-style
-tags:
-  - Bordes CSS
-  - CSS
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/border-style
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/border-top-color/index.md
+++ b/files/es/web/css/border-top-color/index.md
@@ -1,7 +1,6 @@
 ---
 title: border-top-color
 slug: Web/CSS/border-top-color
-translation_of: Web/CSS/border-top-color
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/border-top-left-radius/index.md
+++ b/files/es/web/css/border-top-left-radius/index.md
@@ -1,11 +1,6 @@
 ---
 title: border-top-left-radius
 slug: Web/CSS/border-top-left-radius
-tags:
-  - Bordes CSS
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/border-top-left-radius
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/border-top-right-radius/index.md
+++ b/files/es/web/css/border-top-right-radius/index.md
@@ -1,11 +1,6 @@
 ---
 title: border-top-right-radius
 slug: Web/CSS/border-top-right-radius
-tags:
-  - Bordes CSS
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/border-top-right-radius
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/border-top/index.md
+++ b/files/es/web/css/border-top/index.md
@@ -1,12 +1,6 @@
 ---
 title: border-top
 slug: Web/CSS/border-top
-tags:
-  - Bordes
-  - CSS
-  - Propiedades CSS
-  - Referencia
-translation_of: Web/CSS/border-top
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/border-width/index.md
+++ b/files/es/web/css/border-width/index.md
@@ -1,11 +1,6 @@
 ---
 title: border-width
 slug: Web/CSS/border-width
-tags:
-  - CSS
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/border-width
 ---
 
 ### Resumen

--- a/files/es/web/css/border/index.md
+++ b/files/es/web/css/border/index.md
@@ -1,11 +1,6 @@
 ---
 title: border
 slug: Web/CSS/border
-tags:
-  - CSS
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/border
 ---
 
 {{ PreviousNext("Guía de referencia de CSS", "CSS:border-color") }}

--- a/files/es/web/css/bottom/index.md
+++ b/files/es/web/css/bottom/index.md
@@ -1,11 +1,6 @@
 ---
 title: bottom
 slug: Web/CSS/bottom
-tags:
-  - CSS
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/bottom
 ---
 
 << [Volver](es/Gu%c3%ada_de_referencia_de_CSS)

--- a/files/es/web/css/box-flex/index.md
+++ b/files/es/web/css/box-flex/index.md
@@ -1,11 +1,6 @@
 ---
 title: '-moz-box-flex'
 slug: Web/CSS/box-flex
-tags:
-  - CSS
-  - No estándar(2)
-  - Referencia CSS
-translation_of: Web/CSS/box-flex
 original_slug: Web/CSS/-moz-box-flex
 ---
 

--- a/files/es/web/css/box-ordinal-group/index.md
+++ b/files/es/web/css/box-ordinal-group/index.md
@@ -1,14 +1,6 @@
 ---
 title: '-moz-box-ordinal-group'
 slug: Web/CSS/box-ordinal-group
-tags:
-  - CSS
-  - 'CSS: Extensiones Mozilla'
-  - Caja Flexible
-  - No estandar
-  - Referencia CSS
-translation_of: Web/CSS/box-ordinal-group
-translation_of_original: Web/CSS/-moz-box-ordinal-group
 original_slug: Web/CSS/-moz-box-ordinal-group
 ---
 

--- a/files/es/web/css/box-pack/index.md
+++ b/files/es/web/css/box-pack/index.md
@@ -1,13 +1,6 @@
 ---
 title: '-moz-box-pack'
 slug: Web/CSS/box-pack
-tags:
-  - CSS
-  - Diseño
-  - No estándar(2)
-  - Propiedad CSS
-  - Referencia CSS
-translation_of: Web/CSS/box-pack
 original_slug: Web/CSS/-moz-box-pack
 ---
 

--- a/files/es/web/css/box-shadow/index.md
+++ b/files/es/web/css/box-shadow/index.md
@@ -1,15 +1,6 @@
 ---
 title: box-shadow
 slug: Web/CSS/box-shadow
-tags:
-  - CSS
-  - CSS Background
-  - Estilos
-  - Reference
-  - Referencia
-  - Sombras
-  - box-shadow
-translation_of: Web/CSS/box-shadow
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/box-sizing/index.md
+++ b/files/es/web/css/box-sizing/index.md
@@ -1,12 +1,6 @@
 ---
 title: box-sizing
 slug: Web/CSS/box-sizing
-tags:
-  - CSS
-  - Layout
-  - Propiedades CSS
-  - Web
-translation_of: Web/CSS/box-sizing
 ---
 
 {{CSSRef}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove duplicated frontmatter keys from localized content

### Motivation

Remove innecesarry duplicated data

### Additional details

Folders: css/(-|@|_|a|b)*

```
{
  "translation_of": 243,
  "browser-compat": 3,
  "tags": 191,
  "translation_of_original": 2,
  "page-type": 1
}
```

### Related issues and pull requests

Relates to #10129
Relates to #7412
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
