### PR TITLE
Remove duplicated frontmatter keys from web folder 6/10 [es]

### DIFF
--- a/files/es/web/css/calc/index.md
+++ b/files/es/web/css/calc/index.md
@@ -1,7 +1,6 @@
 ---
 title: calc
 slug: Web/CSS/calc
-translation_of: Web/CSS/calc()
 original_slug: Web/CSS/calc()
 ---
 

--- a/files/es/web/css/caret-color/index.md
+++ b/files/es/web/css/caret-color/index.md
@@ -1,12 +1,6 @@
 ---
 title: caret-color
 slug: Web/CSS/caret-color
-tags:
-  - CSS
-  - CSS UI
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/caret-color
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/child_combinator/index.md
+++ b/files/es/web/css/child_combinator/index.md
@@ -1,12 +1,6 @@
 ---
 title: Selectores de hijo
 slug: Web/CSS/Child_combinator
-tags:
-  - CSS
-  - Principiante
-  - Referencia CSS
-  - Selectores
-translation_of: Web/CSS/Child_combinator
 ---
 
 {{CSSRef("Selectors")}}

--- a/files/es/web/css/class_selectors/index.md
+++ b/files/es/web/css/class_selectors/index.md
@@ -1,12 +1,6 @@
 ---
 title: Selectores de clase
 slug: Web/CSS/Class_selectors
-tags:
-  - CSS
-  - Principiante
-  - Referencia CSS
-  - Selectores
-translation_of: Web/CSS/Class_selectors
 ---
 
 {{CSSRef("Selectors")}}

--- a/files/es/web/css/clear/index.md
+++ b/files/es/web/css/clear/index.md
@@ -1,10 +1,6 @@
 ---
 title: clear
 slug: Web/CSS/clear
-tags:
-  - CSS
-  - Reference
-translation_of: Web/CSS/clear
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/clip/index.md
+++ b/files/es/web/css/clip/index.md
@@ -1,7 +1,6 @@
 ---
 title: clip
 slug: Web/CSS/clip
-translation_of: Web/CSS/clip
 ---
 
 {{CSSRef}}{{deprecated_header}}

--- a/files/es/web/css/color/index.md
+++ b/files/es/web/css/color/index.md
@@ -1,20 +1,6 @@
 ---
 title: color
 slug: Web/CSS/color
-tags:
-  - CSS
-  - Colores CSS
-  - Colores HTML
-  - Diseño
-  - Estilo HTML
-  - Estilo Texto
-  - Estilos HTML
-  - Propiedad CSS
-  - Referencia
-  - Referencia_CSS
-  - Web
-  - color
-translation_of: Web/CSS/color
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/color_value/index.md
+++ b/files/es/web/css/color_value/index.md
@@ -1,14 +1,6 @@
 ---
 title: <color>
 slug: Web/CSS/color_value
-tags:
-  - CSS
-  - Layout
-  - Necesita Compatibilidad con Navegadores Móviles
-  - Referencia
-  - Tipos de datos CSS
-  - Web
-translation_of: Web/CSS/color_value
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/column-count/index.md
+++ b/files/es/web/css/column-count/index.md
@@ -1,12 +1,6 @@
 ---
 title: column-count
 slug: Web/CSS/column-count
-tags:
-  - CSS
-  - CSS Multicolumna
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/column-count
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/column-gap/index.md
+++ b/files/es/web/css/column-gap/index.md
@@ -1,8 +1,6 @@
 ---
 title: grid-column-gap
 slug: Web/CSS/column-gap
-translation_of: Web/CSS/column-gap
-translation_of_original: Web/CSS/grid-column-gap
 original_slug: Web/CSS/grid-column-gap
 ---
 

--- a/files/es/web/css/column-span/index.md
+++ b/files/es/web/css/column-span/index.md
@@ -1,11 +1,6 @@
 ---
 title: column-span
 slug: Web/CSS/column-span
-tags:
-  - CSS
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/column-span
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/comments/index.md
+++ b/files/es/web/css/comments/index.md
@@ -1,11 +1,6 @@
 ---
 title: Comentarios
 slug: Web/CSS/Comments
-tags:
-  - CSS
-  - Principiante
-  - Referencia CSS
-translation_of: Web/CSS/Comments
 original_slug: Web/CSS/Comentarios
 ---
 

--- a/files/es/web/css/computed_value/index.md
+++ b/files/es/web/css/computed_value/index.md
@@ -1,9 +1,6 @@
 ---
 title: Valor calculado
 slug: Web/CSS/computed_value
-tags:
-  - Referencia_CSS
-translation_of: Web/CSS/computed_value
 original_slug: Web/CSS/Valor_calculado
 ---
 

--- a/files/es/web/css/content/index.md
+++ b/files/es/web/css/content/index.md
@@ -1,11 +1,6 @@
 ---
 title: content
 slug: Web/CSS/content
-tags:
-  - CSS
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/content
 ---
 
 << [Volver](es/Gu%c3%ada_de_referencia_de_CSS)

--- a/files/es/web/css/css_animations/index.md
+++ b/files/es/web/css/css_animations/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS Animations
 slug: Web/CSS/CSS_Animations
-tags:
-  - CSS
-  - CSS Animations
-  - Experimental
-  - Overview
-  - Reference
-translation_of: Web/CSS/CSS_Animations
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/css_animations/tips/index.md
+++ b/files/es/web/css/css_animations/tips/index.md
@@ -1,7 +1,6 @@
 ---
 title: Animaciones CSS tips y trucos
 slug: Web/CSS/CSS_Animations/Tips
-translation_of: Web/CSS/CSS_Animations/Tips
 ---
 
 {{cssref}}Las Animaciones con CSS hacen posible crear cosas increíbles con los elementos que forman parte de tus documentos y apps . Sin embargo, hay cosas que deseas hacer que no son evidentes, o soluciones inteligentes que quizás no encuentres de inmediato. Este artículo es una colección de tips y trucos que hemos encontrado que podrían hacer más fácil el trabajo, incluido cómo volver a ejecutar una animación detenida.

--- a/files/es/web/css/css_animations/using_css_animations/index.md
+++ b/files/es/web/css/css_animations/using_css_animations/index.md
@@ -1,14 +1,6 @@
 ---
 title: Usando animaciones CSS
 slug: Web/CSS/CSS_Animations/Using_CSS_animations
-tags:
-  - Advanced
-  - CSS
-  - CSS Animations
-  - Example
-  - Experimental
-  - Guide
-translation_of: Web/CSS/CSS_Animations/Using_CSS_animations
 original_slug: Web/CSS/CSS_Animations/Usando_animaciones_CSS
 ---
 

--- a/files/es/web/css/css_backgrounds_and_borders/border-image_generator/index.md
+++ b/files/es/web/css/css_backgrounds_and_borders/border-image_generator/index.md
@@ -1,10 +1,6 @@
 ---
 title: Generador Border-image
 slug: Web/CSS/CSS_Backgrounds_and_Borders/Border-image_generator
-tags:
-  - CSS
-  - Herramientas
-translation_of: Web/CSS/CSS_Background_and_Borders/Border-image_generator
 original_slug: Web/CSS/CSS_Background_and_Borders/Border-image_generator
 ---
 

--- a/files/es/web/css/css_backgrounds_and_borders/border-radius_generator/index.md
+++ b/files/es/web/css/css_backgrounds_and_borders/border-radius_generator/index.md
@@ -1,9 +1,6 @@
 ---
 title: Generador de border-radius
 slug: Web/CSS/CSS_Backgrounds_and_Borders/Border-radius_generator
-tags:
-  - Herramientas
-translation_of: Web/CSS/CSS_Background_and_Borders/Border-radius_generator
 original_slug: Web/CSS/CSS_Background_and_Borders/Border-radius_generator
 ---
 

--- a/files/es/web/css/css_backgrounds_and_borders/index.md
+++ b/files/es/web/css/css_backgrounds_and_borders/index.md
@@ -1,15 +1,6 @@
 ---
 title: CSS Background and Borders
 slug: Web/CSS/CSS_Backgrounds_and_Borders
-tags:
-  - CSS
-  - CSS Backgrounds and Borders
-  - CSS Reference
-  - NeedsTranslation
-  - Overview
-  - TopicStub
-translation_of: Web/CSS/CSS_Backgrounds_and_Borders
-translation_of_original: Web/CSS/CSS_Background_and_Borders
 original_slug: Web/CSS/CSS_Background_and_Borders
 ---
 

--- a/files/es/web/css/css_backgrounds_and_borders/using_multiple_backgrounds/index.md
+++ b/files/es/web/css/css_backgrounds_and_borders/using_multiple_backgrounds/index.md
@@ -1,14 +1,6 @@
 ---
 title: Usando múltiples fondos con CSS
 slug: Web/CSS/CSS_Backgrounds_and_Borders/Using_multiple_backgrounds
-tags:
-  - CSS
-  - Ejemplo
-  - Fondos CSS
-  - Guía
-  - Intermedio
-translation_of: Web/CSS/CSS_Backgrounds_and_Borders/Using_multiple_backgrounds
-translation_of_original: Web/CSS/CSS_Background_and_Borders/Using_CSS_multiple_backgrounds
 original_slug: Web/CSS/CSS_Background_and_Borders/Using_CSS_multiple_backgrounds
 ---
 

--- a/files/es/web/css/css_box_model/index.md
+++ b/files/es/web/css/css_box_model/index.md
@@ -1,12 +1,6 @@
 ---
 title: Modelo de Caja de CSS
 slug: Web/CSS/CSS_Box_Model
-tags:
-  - CSS
-  - Modelo de Caja CSS
-  - Referencia CSS
-  - Visión general
-translation_of: Web/CSS/CSS_Box_Model
 original_slug: Web/CSS/CSS_Modelo_Caja
 ---
 

--- a/files/es/web/css/css_box_model/introduction_to_the_css_box_model/index.md
+++ b/files/es/web/css/css_box_model/introduction_to_the_css_box_model/index.md
@@ -1,8 +1,6 @@
 ---
 title: Introducción al modelo de caja básico de CSS
 slug: Web/CSS/CSS_Box_Model/introduction_to_the_CSS_box_model
-page-type: guide
-spec-urls: https://drafts.csswg.org/css-box/#intro
 l10n:
   sourceCommit: 71c4bc0b6329ec40ddbefd8d3124547e91cfa612
 ---

--- a/files/es/web/css/css_box_model/mastering_margin_collapsing/index.md
+++ b/files/es/web/css/css_box_model/mastering_margin_collapsing/index.md
@@ -1,12 +1,6 @@
 ---
 title: Entendiendo el colapso de margen
 slug: Web/CSS/CSS_Box_Model/Mastering_margin_collapsing
-tags:
-  - CSS
-  - CSS Box Model
-  - Guía
-  - Referencia
-translation_of: Web/CSS/CSS_Box_Model/Mastering_margin_collapsing
 original_slug: Web/CSS/CSS_Modelo_Caja/Mastering_margin_collapsing
 ---
 

--- a/files/es/web/css/css_colors/color_picker_tool/index.md
+++ b/files/es/web/css/css_colors/color_picker_tool/index.md
@@ -1,10 +1,6 @@
 ---
 title: Herramienta para seleccionar color
 slug: Web/CSS/CSS_Colors/Color_picker_tool
-tags:
-  - CSS
-  - Herramientas
-translation_of: Web/CSS/CSS_Colors/Color_picker_tool
 original_slug: Web/CSS/CSS_Colors/Herramienta_para_seleccionar_color
 ---
 

--- a/files/es/web/css/css_colors/index.md
+++ b/files/es/web/css/css_colors/index.md
@@ -1,15 +1,6 @@
 ---
 title: CSS Colors
 slug: Web/CSS/CSS_Colors
-tags:
-  - CSS
-  - CSS Colors
-  - NeedsTranslation
-  - Overview
-  - Reference
-  - TopicStub
-translation_of: Web/CSS/CSS_Color
-translation_of_original: Web/CSS/CSS_Colors
 original_slug: Web/CSS/CSS_Color
 ---
 

--- a/files/es/web/css/css_columns/index.md
+++ b/files/es/web/css/css_columns/index.md
@@ -1,11 +1,6 @@
 ---
 title: Columnas CSS
 slug: Web/CSS/CSS_Columns
-tags:
-  - CSS
-  - Referencia CSS
-  - Visión general
-translation_of: Web/CSS/CSS_Columns
 original_slug: Web/CSS/Columnas_CSS
 ---
 

--- a/files/es/web/css/css_columns/using_multi-column_layouts/index.md
+++ b/files/es/web/css/css_columns/using_multi-column_layouts/index.md
@@ -1,10 +1,6 @@
 ---
 title: Columnas con CSS-3
 slug: Web/CSS/CSS_Columns/Using_multi-column_layouts
-tags:
-  - CSS
-  - Todas_las_Categorías
-translation_of: Web/CSS/CSS_Columns/Using_multi-column_layouts
 original_slug: Columnas_con_CSS-3
 ---
 ### Introducción

--- a/files/es/web/css/css_conditional_rules/index.md
+++ b/files/es/web/css/css_conditional_rules/index.md
@@ -1,10 +1,6 @@
 ---
 title: CSS Reglas Condicionales
 slug: Web/CSS/CSS_Conditional_Rules
-tags:
-  - CSS
-  - Referencia
-translation_of: Web/CSS/CSS_Conditional_Rules
 original_slug: Web/CSS/CSS_Reglas_Condicionales
 ---
 

--- a/files/es/web/css/css_containment/index.md
+++ b/files/es/web/css/css_containment/index.md
@@ -1,7 +1,6 @@
 ---
 title: CSS Containment
 slug: Web/CSS/CSS_Containment
-translation_of: Web/CSS/CSS_Containment
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.md
+++ b/files/es/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.md
@@ -1,21 +1,6 @@
 ---
 title: Aligning Items in a Flex Container
 slug: Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container
-tags:
-  - Align
-  - CSS
-  - Flex
-  - Guía
-  - Tutorial
-  - align-content
-  - align-self
-  - alineación
-  - alinear
-  - flexbox
-  - justify
-  - justify-content
-  - rejillas
-translation_of: Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/css_flexible_box_layout/backwards_compatibility_of_flexbox/index.md
+++ b/files/es/web/css/css_flexible_box_layout/backwards_compatibility_of_flexbox/index.md
@@ -1,7 +1,6 @@
 ---
 title: Compatibilidad con versiones anteriores de Flexbox
 slug: Web/CSS/CSS_Flexible_Box_Layout/Backwards_Compatibility_of_Flexbox
-translation_of: Web/CSS/CSS_Flexible_Box_Layout/Backwards_Compatibility_of_Flexbox
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
+++ b/files/es/web/css/css_flexible_box_layout/basic_concepts_of_flexbox/index.md
@@ -1,7 +1,6 @@
 ---
 title: Conceptos Básicos de flexbox
 slug: Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox
-translation_of: Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox
 original_slug: Web/CSS/CSS_Flexible_Box_Layout/Conceptos_Basicos_de_Flexbox
 ---
 

--- a/files/es/web/css/css_flexible_box_layout/index.md
+++ b/files/es/web/css/css_flexible_box_layout/index.md
@@ -1,11 +1,6 @@
 ---
 title: Diseño de caja flexible CSS
 slug: Web/CSS/CSS_Flexible_Box_Layout
-tags:
-  - CSS
-  - CSS Flexible
-  - flexbox
-translation_of: Web/CSS/CSS_Flexible_Box_Layout
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/css_flexible_box_layout/typical_use_cases_of_flexbox/index.md
+++ b/files/es/web/css/css_flexible_box_layout/typical_use_cases_of_flexbox/index.md
@@ -1,7 +1,6 @@
 ---
 title: Casos de uso típicos de Flexbox
 slug: Web/CSS/CSS_Flexible_Box_Layout/Typical_Use_Cases_of_Flexbox
-translation_of: Web/CSS/CSS_Flexible_Box_Layout/Typical_Use_Cases_of_Flexbox
 original_slug: Web/CSS/CSS_Flexible_Box_Layout/Casos_de_uso_tipicos_de_Flexbox.
 ---
 

--- a/files/es/web/css/css_flow_layout/index.md
+++ b/files/es/web/css/css_flow_layout/index.md
@@ -1,7 +1,6 @@
 ---
 title: CSS Flow Layout
 slug: Web/CSS/CSS_Flow_Layout
-translation_of: Web/CSS/CSS_Flow_Layout
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/css_fonts/index.md
+++ b/files/es/web/css/css_fonts/index.md
@@ -1,11 +1,6 @@
 ---
 title: CSS Fonts
 slug: Web/CSS/CSS_Fonts
-tags:
-  - CCS
-  - CSS Fonts
-  - Reference
-translation_of: Web/CSS/CSS_Fonts
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/css_grid_layout/auto-placement_in_css_grid_layout/index.md
+++ b/files/es/web/css/css_grid_layout/auto-placement_in_css_grid_layout/index.md
@@ -1,7 +1,6 @@
 ---
 title: Colocación automática en diseño de cuadrícula CSS
 slug: Web/CSS/CSS_Grid_Layout/Auto-placement_in_CSS_Grid_Layout
-translation_of: Web/CSS/CSS_Grid_Layout/Auto-placement_in_CSS_Grid_Layout
 ---
 
 Además de la capacidad de colocar elementos con precisión en una cuadrícula creada, la especificación de diseño de cuadrícula CSS contiene reglas que controlan lo que sucede cuando crea una cuadrícula y no coloca algunos o todos los elementos secundarios. Puede ver la colocación automática en acción de la manera más simple creando una cuadrícula en un conjunto de elementos. Si no proporciona información de ubicación a los elementos, se colocarán en la cuadrícula, uno en cada celda de la cuadrícula.

--- a/files/es/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
+++ b/files/es/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
@@ -1,12 +1,6 @@
 ---
 title: Basic concepts of grid layout
 slug: Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout
-tags:
-  - CSS
-  - Guía
-  - Posicionamiento
-  - Rejillas CSS
-translation_of: Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout
 original_slug: Web/CSS/CSS_Grid_Layout/Conceptos_Básicos_del_Posicionamiento_con_Rejillas
 ---
 

--- a/files/es/web/css/css_grid_layout/box_alignment_in_css_grid_layout/index.md
+++ b/files/es/web/css/css_grid_layout/box_alignment_in_css_grid_layout/index.md
@@ -1,7 +1,6 @@
 ---
 title: Box alignment in CSS Grid Layout
 slug: Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout
-translation_of: Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout
 ---
 
 Si estás familiarizado con [flexbox](/es/docs/Web/CSS/CSS_Flexible_Box_Layout) Entonces ya habrás encontrado la forma en que los items flexibles pueden ser alineados correctamente dentro de un contendor flex. Estas propiedades de alineación que encontramos por primera vez en la especificación de flexbox se han trasladado a una nueva especificación llamada [Box Alignment Level 3](https://drafts.csswg.org/css-align/). Esta especificación tiene detalles de cómo debería funcionar la alineación en todos los diferentes métodos de diseño.

--- a/files/es/web/css/css_grid_layout/index.md
+++ b/files/es/web/css/css_grid_layout/index.md
@@ -1,7 +1,6 @@
 ---
 title: CSS Grid Layout
 slug: Web/CSS/CSS_Grid_Layout
-translation_of: Web/CSS/CSS_Grid_Layout
 ---
 
 **CSS Grid layout** contiene funciones de diseño dirigidas a los desarrolladores de aplicaciones web. El CSS grid se puede utilizar para lograr muchos diseños diferentes. También se destaca por permitir dividir una página en áreas o regiones principales, por definir la relación en términos de tamaño, posición y capas entre partes de un control construido a partir de primitivas HTML.

--- a/files/es/web/css/css_grid_layout/realizing_common_layouts_using_css_grid_layout/index.md
+++ b/files/es/web/css/css_grid_layout/realizing_common_layouts_using_css_grid_layout/index.md
@@ -1,11 +1,6 @@
 ---
 title: Realizing common layouts using CSS Grid Layout
 slug: Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout
-tags:
-  - CSS
-  - CSS Grids
-  - Guía
-translation_of: Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout
 ---
 
 Para completar este conjunto de guías de CSS Grid Layout, voy a recorrer algunos diseños diferentes, que demuestran algunas de las diferentes técnicas que puede utilizar al diseñar con grid layout. Vamos a ver un ejemplo usando [grid-template-areas](/es/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas) un típico sistema de cuadrícula flexible de 12 columnas, y también un listado de productos usando el emplazamiento automático. Como puedes ver en este conjunto de ejemplos, a menudo hay más de una manera de lograr el resultado que deseas con el diseño de cuadrícula. Escoge el método que encuentres más útil para los problemas que estás resolviendo y los diseños que necesitas implementar.

--- a/files/es/web/css/css_grid_layout/relationship_of_grid_layout/index.md
+++ b/files/es/web/css/css_grid_layout/relationship_of_grid_layout/index.md
@@ -1,14 +1,6 @@
 ---
 title: Relación de Grid Layout con otros métodos de diseño y posicionamiento - CSS
 slug: Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout
-tags:
-  - CSS
-  - CSS Cuadrícula
-  - CSS Grids
-  - CSS Grilla
-  - CSS Rejilla
-  - Guía
-translation_of: Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout
 original_slug: Web/CSS/CSS_Grid_Layout/Relacion_de_Grid_Layout
 ---
 

--- a/files/es/web/css/css_images/using_css_gradients/index.md
+++ b/files/es/web/css/css_images/using_css_gradients/index.md
@@ -1,7 +1,6 @@
 ---
 title: Usando gradientes con CSS
 slug: Web/CSS/CSS_Images/Using_CSS_gradients
-translation_of: Web/CSS/CSS_Images/Using_CSS_gradients
 original_slug: CSS/Using_CSS_gradients
 ---
 

--- a/files/es/web/css/css_logical_properties/basic_concepts/index.md
+++ b/files/es/web/css/css_logical_properties/basic_concepts/index.md
@@ -1,7 +1,6 @@
 ---
 title: Conceptos básicos de las Propiedades y Valores Lógicos
 slug: Web/CSS/CSS_Logical_Properties/Basic_concepts
-translation_of: Web/CSS/CSS_Logical_Properties/Basic_concepts
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/css_logical_properties/floating_and_positioning/index.md
+++ b/files/es/web/css/css_logical_properties/floating_and_positioning/index.md
@@ -1,7 +1,6 @@
 ---
 title: Propiedades lógicas para flotantes y posicionamiento
 slug: Web/CSS/CSS_Logical_Properties/Floating_and_positioning
-translation_of: Web/CSS/CSS_Logical_Properties/Floating_and_positioning
 ---
 {{CSSRef}}
 

--- a/files/es/web/css/css_logical_properties/index.md
+++ b/files/es/web/css/css_logical_properties/index.md
@@ -1,13 +1,6 @@
 ---
 title: Propiedades y Valores Lógicos de CSS
 slug: Web/CSS/CSS_Logical_Properties
-tags:
-  - CSS
-  - Propiedades lógicas
-  - Referencia
-  - Valores lógicos
-  - Visión general
-translation_of: Web/CSS/CSS_Logical_Properties
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/css_logical_properties/margins_borders_padding/index.md
+++ b/files/es/web/css/css_logical_properties/margins_borders_padding/index.md
@@ -1,7 +1,6 @@
 ---
 title: Propiedades lógicas para márgenes, bordes y rellenos
 slug: Web/CSS/CSS_Logical_Properties/Margins_borders_padding
-translation_of: Web/CSS/CSS_Logical_Properties/Margins_borders_padding
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/css_logical_properties/sizing/index.md
+++ b/files/es/web/css/css_logical_properties/sizing/index.md
@@ -1,7 +1,6 @@
 ---
 title: Dimensionamiento para propiedades lógicas
 slug: Web/CSS/CSS_Logical_Properties/Sizing
-translation_of: Web/CSS/CSS_Logical_Properties/Sizing
 original_slug: Web/CSS/CSS_Logical_Properties/Dimensionamiento
 ---
 {{CSSRef}}

--- a/files/es/web/css/css_motion_path/index.md
+++ b/files/es/web/css/css_motion_path/index.md
@@ -1,7 +1,6 @@
 ---
 title: CSS Motion Path
 slug: Web/CSS/CSS_Motion_Path
-translation_of: Web/CSS/CSS_Motion_Path
 ---
 
 {{CSSRef}}{{seecompattable}}

--- a/files/es/web/css/css_positioning/index.md
+++ b/files/es/web/css/css_positioning/index.md
@@ -1,14 +1,6 @@
 ---
 title: Posicionamiento CSS
 slug: Web/CSS/CSS_Positioning
-tags:
-  - CSS
-  - CSS Positioning
-  - CSS Reference
-  - NeedsTranslation
-  - Overview
-  - TopicStub
-translation_of: Web/CSS/CSS_Positioning
 ---
 {{CSSRef}}
 

--- a/files/es/web/css/css_positioning/understanding_z_index/adding_z-index/index.md
+++ b/files/es/web/css/css_positioning/understanding_z_index/adding_z-index/index.md
@@ -1,7 +1,6 @@
 ---
 title: Agregando z-index
 slug: Web/CSS/CSS_Positioning/Understanding_z_index/Adding_z-index
-translation_of: Web/CSS/CSS_Positioning/Understanding_z_index/Adding_z-index
 original_slug: Web/CSS/CSS_Positioning/entendiendo_z_index/Agregando_z-index
 ---
 

--- a/files/es/web/css/css_positioning/understanding_z_index/index.md
+++ b/files/es/web/css/css_positioning/understanding_z_index/index.md
@@ -1,14 +1,6 @@
 ---
 title: Entendiendo la propiedad CSS z-index
 slug: Web/CSS/CSS_Positioning/Understanding_z_index
-tags:
-  - Avanzado
-  - CSS
-  - Entendiendo_CSS_Z_Index
-  - Guía
-  - Referencia
-  - z-index
-translation_of: Web/CSS/CSS_Positioning/Understanding_z_index
 original_slug: Web/CSS/CSS_Positioning/entendiendo_z_index
 ---
 

--- a/files/es/web/css/css_positioning/understanding_z_index/stacking_and_float/index.md
+++ b/files/es/web/css/css_positioning/understanding_z_index/stacking_and_float/index.md
@@ -1,14 +1,6 @@
 ---
 title: Apilamiento y float
 slug: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_and_float
-tags:
-  - Avanzado
-  - CSS
-  - Entendiendo_CSS_z-index
-  - Guía
-  - Referencia
-  - z-index
-translation_of: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_and_float
 original_slug: Web/CSS/CSS_Positioning/entendiendo_z_index/Apilamiento_y_float
 ---
 

--- a/files/es/web/css/css_positioning/understanding_z_index/stacking_context_example_1/index.md
+++ b/files/es/web/css/css_positioning/understanding_z_index/stacking_context_example_1/index.md
@@ -1,9 +1,7 @@
 ---
 title: Ejemplo 1 del contexto de apilamiento
 slug: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_1
-translation_of: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_1
-original_slug: >-
-  Web/CSS/CSS_Positioning/entendiendo_z_index/ejemplo_1_del_contexto_de_apilamiento
+original_slug: Web/CSS/CSS_Positioning/entendiendo_z_index/ejemplo_1_del_contexto_de_apilamiento
 ---
 
 « [CSS](/es/CSS) « [ENTENDIENDO LA PROPIEDAD CSS Z-INDEX](/es/docs/Web/CSS/CSS_Positioning/entendiendo_z_index)

--- a/files/es/web/css/css_positioning/understanding_z_index/stacking_context_example_2/index.md
+++ b/files/es/web/css/css_positioning/understanding_z_index/stacking_context_example_2/index.md
@@ -1,9 +1,7 @@
 ---
 title: Ejemplo 2 del contexto de apilamiento
 slug: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_2
-translation_of: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_2
-original_slug: >-
-  Web/CSS/CSS_Positioning/entendiendo_z_index/ejemplo_2_del_contexto_de_apilamiento
+original_slug: Web/CSS/CSS_Positioning/entendiendo_z_index/ejemplo_2_del_contexto_de_apilamiento
 ---
 
 « [CSS](/es/CSS) « [ENTENDIENDO LA PROPIEDAD CSS Z-INDEX](/es/docs/Web/CSS/CSS_Positioning/entendiendo_z_index)

--- a/files/es/web/css/css_positioning/understanding_z_index/stacking_context_example_3/index.md
+++ b/files/es/web/css/css_positioning/understanding_z_index/stacking_context_example_3/index.md
@@ -1,9 +1,7 @@
 ---
 title: Ejemplo 3 del contexto de apilamiento
 slug: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_3
-translation_of: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_3
-original_slug: >-
-  Web/CSS/CSS_Positioning/entendiendo_z_index/ejemplo_3_del_contexto_de_apilamiento
+original_slug: Web/CSS/CSS_Positioning/entendiendo_z_index/ejemplo_3_del_contexto_de_apilamiento
 ---
 
 « [CSS](/en/CSS) « [Understanding CSS z-index](/en/CSS/Understanding_z-index)

--- a/files/es/web/css/css_positioning/understanding_z_index/stacking_without_z-index/index.md
+++ b/files/es/web/css/css_positioning/understanding_z_index/stacking_without_z-index/index.md
@@ -1,7 +1,6 @@
 ---
 title: Apilando sin z-index
 slug: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_without_z-index
-translation_of: Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_without_z-index
 original_slug: Web/CSS/CSS_Positioning/entendiendo_z_index/Stacking_without_z-index
 ---
 

--- a/files/es/web/css/css_positioning/understanding_z_index/the_stacking_context/index.md
+++ b/files/es/web/css/css_positioning/understanding_z_index/the_stacking_context/index.md
@@ -1,7 +1,6 @@
 ---
 title: El contexto de apilamiento
 slug: Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
-translation_of: Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
 original_slug: Web/CSS/CSS_Positioning/entendiendo_z_index/El_contexto_de_apilamiento
 ---
 

--- a/files/es/web/css/css_selectors/index.md
+++ b/files/es/web/css/css_selectors/index.md
@@ -1,13 +1,6 @@
 ---
 title: Selectores CSS
 slug: Web/CSS/CSS_Selectors
-tags:
-  - CSS
-  - Referencia
-  - Selectores
-  - Selectores de CSS
-  - Visión general
-translation_of: Web/CSS/CSS_Selectors
 original_slug: Web/CSS/Selectores_CSS
 ---
 

--- a/files/es/web/css/css_selectors/using_the__colon_target_pseudo-class_in_selectors/index.md
+++ b/files/es/web/css/css_selectors/using_the__colon_target_pseudo-class_in_selectors/index.md
@@ -1,11 +1,6 @@
 ---
 title: Usando la pseudo-clase :target en selectores
 slug: Web/CSS/CSS_Selectors/Using_the_:target_pseudo-class_in_selectors
-tags:
-  - CSS
-  - CSS3
-  - Selectores
-translation_of: Web/CSS/CSS_Selectors/Using_the_:target_pseudo-class_in_selectors
 original_slug: Web/CSS/Selectores_CSS/Usando_la_pseudo-clase_:target_en_selectores
 ---
 

--- a/files/es/web/css/css_text/index.md
+++ b/files/es/web/css/css_text/index.md
@@ -1,11 +1,6 @@
 ---
 title: Texto CSS
 slug: Web/CSS/CSS_Text
-tags:
-  - CSS
-  - Texto CSS
-  - Vista general
-translation_of: Web/CSS/CSS_Text
 original_slug: Web/CSS/Texto_CSS
 ---
 

--- a/files/es/web/css/css_transforms/index.md
+++ b/files/es/web/css/css_transforms/index.md
@@ -1,7 +1,6 @@
 ---
 title: CSS Transforms
 slug: Web/CSS/CSS_Transforms
-translation_of: Web/CSS/CSS_Transforms
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/css_transforms/using_css_transforms/index.md
+++ b/files/es/web/css/css_transforms/using_css_transforms/index.md
@@ -1,7 +1,6 @@
 ---
 title: Uso de CSS transforms
 slug: Web/CSS/CSS_Transforms/Using_CSS_transforms
-translation_of: Web/CSS/CSS_Transforms/Using_CSS_transforms
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/css_transitions/index.md
+++ b/files/es/web/css/css_transitions/index.md
@@ -1,13 +1,6 @@
 ---
 title: CSS Transitions
 slug: Web/CSS/CSS_Transitions
-tags:
-  - CSS
-  - Experimental
-  - Referencia
-  - Transiciones CSS
-  - Vista general
-translation_of: Web/CSS/CSS_Transitions
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/css_transitions/using_css_transitions/index.md
+++ b/files/es/web/css/css_transitions/using_css_transitions/index.md
@@ -1,11 +1,6 @@
 ---
 title: Transiciones de CSS
 slug: Web/CSS/CSS_Transitions/Using_CSS_transitions
-tags:
-  - CSS
-  - Gecko
-  - Transiciones de CSS
-translation_of: Web/CSS/CSS_Transitions/Using_CSS_transitions
 original_slug: Web/CSS/Transiciones_de_CSS
 ---
 

--- a/files/es/web/css/css_types/index.md
+++ b/files/es/web/css/css_types/index.md
@@ -1,12 +1,6 @@
 ---
 title: Tipos de datos básicos de CSS
 slug: Web/CSS/CSS_Types
-tags:
-  - CSS
-  - Referencia
-  - Tipo de Dato CSS
-  - Visión general
-translation_of: Web/CSS/CSS_Types
 ---
 
 {{CssRef}}

--- a/files/es/web/css/css_writing_modes/index.md
+++ b/files/es/web/css/css_writing_modes/index.md
@@ -1,7 +1,6 @@
 ---
 title: CSS Writing Modes
 slug: Web/CSS/CSS_Writing_Modes
-translation_of: Web/CSS/CSS_Writing_Modes
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/cursor/index.md
+++ b/files/es/web/css/cursor/index.md
@@ -1,9 +1,6 @@
 ---
 title: cursor
 slug: Web/CSS/cursor
-tags:
-  - Referencia_CSS
-translation_of: Web/CSS/cursor
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/descendant_combinator/index.md
+++ b/files/es/web/css/descendant_combinator/index.md
@@ -1,7 +1,6 @@
 ---
 title: Los selectores descendientes
 slug: Web/CSS/Descendant_combinator
-translation_of: Web/CSS/Descendant_combinator
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/direction/index.md
+++ b/files/es/web/css/direction/index.md
@@ -1,12 +1,6 @@
 ---
 title: direction
 slug: Web/CSS/direction
-tags:
-  - CSS
-  - CSS:Referencias
-  - Referencia_CSS
-  - Todas_las_Categorías
-translation_of: Web/CSS/direction
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/display/index.md
+++ b/files/es/web/css/display/index.md
@@ -1,11 +1,6 @@
 ---
 title: display
 slug: Web/CSS/display
-tags:
-  - CSS
-  - CSS Display
-  - Propiedades CSS
-translation_of: Web/CSS/display
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/env/index.md
+++ b/files/es/web/css/env/index.md
@@ -1,14 +1,6 @@
 ---
 title: env()
 slug: Web/CSS/env
-tags:
-  - CSS
-  - Experimental
-  - Función CSS
-  - Variables CSS
-  - env
-  - env()
-translation_of: Web/CSS/env()
 original_slug: Web/CSS/env()
 ---
 

--- a/files/es/web/css/filter-function/blur/index.md
+++ b/files/es/web/css/filter-function/blur/index.md
@@ -1,12 +1,6 @@
 ---
 title: blur()
 slug: Web/CSS/filter-function/blur
-tags:
-  - CSS
-  - Efectos de Filtro
-  - Función CSS
-  - Referencia
-translation_of: Web/CSS/filter-function/blur()
 original_slug: Web/CSS/filter-function/blur()
 ---
 

--- a/files/es/web/css/filter-function/brightness/index.md
+++ b/files/es/web/css/filter-function/brightness/index.md
@@ -1,7 +1,6 @@
 ---
 title: brightness()
 slug: Web/CSS/filter-function/brightness
-translation_of: Web/CSS/filter-function/brightness()
 original_slug: Web/CSS/filter-function/brightness()
 ---
 

--- a/files/es/web/css/filter-function/index.md
+++ b/files/es/web/css/filter-function/index.md
@@ -1,12 +1,6 @@
 ---
 title: <filter-function>
 slug: Web/CSS/filter-function
-tags:
-  - CSS
-  - Efectos de Filtro
-  - Referencia
-  - Tipos de dato CSS
-translation_of: Web/CSS/filter-function
 ---
 
 {{cssref}}

--- a/files/es/web/css/filter/index.md
+++ b/files/es/web/css/filter/index.md
@@ -1,14 +1,6 @@
 ---
 title: filter
 slug: Web/CSS/filter
-tags:
-  - CSS
-  - Filtro
-  - Filtro SVG
-  - Propiedad CSS
-  - Referencia
-  - SVG
-translation_of: Web/CSS/filter
 ---
 
 {{SeeCompatTable}}{{CSSRef}}

--- a/files/es/web/css/fit-content/index.md
+++ b/files/es/web/css/fit-content/index.md
@@ -1,15 +1,6 @@
 ---
 title: fit-content()
 slug: Web/CSS/fit-content
-tags:
-  - CSS
-  - CSS Grid
-  - Experimental
-  - Función CSS
-  - Layout
-  - Referencia
-  - Web
-translation_of: Web/CSS/fit-content
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/flex-basis/index.md
+++ b/files/es/web/css/flex-basis/index.md
@@ -1,11 +1,6 @@
 ---
 title: flex-basis
 slug: Web/CSS/flex-basis
-tags:
-  - CSS
-  - Cajas Flexibles de CSS
-  - Propiedad de CSS
-translation_of: Web/CSS/flex-basis
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/flex-direction/index.md
+++ b/files/es/web/css/flex-direction/index.md
@@ -1,13 +1,6 @@
 ---
 title: flex-direction
 slug: Web/CSS/flex-direction
-tags:
-  - CCS
-  - Cajas Flexibles CSS
-  - Propiedad CSS
-  - Referencia
-  - flexbox
-translation_of: Web/CSS/flex-direction
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/flex-flow/index.md
+++ b/files/es/web/css/flex-flow/index.md
@@ -1,12 +1,6 @@
 ---
 title: flex-flow
 slug: Web/CSS/flex-flow
-tags:
-  - CSS
-  - CSS Flexible Boxes
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/flex-flow
 ---
 
 {{ CSSRef}}

--- a/files/es/web/css/flex-grow/index.md
+++ b/files/es/web/css/flex-grow/index.md
@@ -1,11 +1,6 @@
 ---
 title: flex-grow
 slug: Web/CSS/flex-grow
-tags:
-  - CSS
-  - Elementos flexibles
-  - Propiedades CSS
-translation_of: Web/CSS/flex-grow
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/flex-shrink/index.md
+++ b/files/es/web/css/flex-shrink/index.md
@@ -1,7 +1,6 @@
 ---
 title: flex-shrink
 slug: Web/CSS/flex-shrink
-translation_of: Web/CSS/flex-shrink
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/flex-wrap/index.md
+++ b/files/es/web/css/flex-wrap/index.md
@@ -1,7 +1,6 @@
 ---
 title: flex-wrap
 slug: Web/CSS/flex-wrap
-translation_of: Web/CSS/flex-wrap
 ---
 
 {{ CSSRef("CSS Flexible Boxes") }}

--- a/files/es/web/css/flex/index.md
+++ b/files/es/web/css/flex/index.md
@@ -1,7 +1,6 @@
 ---
 title: flex
 slug: Web/CSS/flex
-translation_of: Web/CSS/flex
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/float/index.md
+++ b/files/es/web/css/float/index.md
@@ -1,14 +1,6 @@
 ---
 title: float
 slug: Web/CSS/float
-tags:
-  - CSS
-  - CSS Float
-  - CSS Posicionamiento
-  - CSS Propiedad
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/float
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/font-family/index.md
+++ b/files/es/web/css/font-family/index.md
@@ -1,11 +1,6 @@
 ---
 title: font-family
 slug: Web/CSS/font-family
-tags:
-  - CSS
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/font-family
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/font-language-override/index.md
+++ b/files/es/web/css/font-language-override/index.md
@@ -1,8 +1,6 @@
 ---
 title: '-moz-font-language-override'
 slug: Web/CSS/font-language-override
-translation_of: Web/CSS/font-language-override
-translation_of_original: Web/CSS/-moz-font-language-override
 original_slug: Web/CSS/-moz-font-language-override
 ---
 

--- a/files/es/web/css/font-size-adjust/index.md
+++ b/files/es/web/css/font-size-adjust/index.md
@@ -1,12 +1,6 @@
 ---
 title: font-size-adjust
 slug: Web/CSS/font-size-adjust
-tags:
-  - CSS
-  - CSS:Referencias
-  - Referencia_CSS
-  - Todas_las_Categorías
-translation_of: Web/CSS/font-size-adjust
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/font-size/index.md
+++ b/files/es/web/css/font-size/index.md
@@ -1,11 +1,6 @@
 ---
 title: font-size
 slug: Web/CSS/font-size
-tags:
-  - CSS
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/font-size
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/font-style/index.md
+++ b/files/es/web/css/font-style/index.md
@@ -1,14 +1,6 @@
 ---
 title: font-style
 slug: Web/CSS/font-style
-tags:
-  - CSS
-  - Propiedad de CSS
-  - Referencia
-  - Tipos de letra de CSS
-  - Web
-  - tipo de letra
-translation_of: Web/CSS/font-style
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/font-variant-alternates/index.md
+++ b/files/es/web/css/font-variant-alternates/index.md
@@ -1,11 +1,6 @@
 ---
 title: font-variant-alternates
 slug: Web/CSS/font-variant-alternates
-tags:
-  - Fuentes CSS
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/font-variant-alternates
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/font-variant/index.md
+++ b/files/es/web/css/font-variant/index.md
@@ -1,11 +1,6 @@
 ---
 title: font-variant
 slug: Web/CSS/font-variant
-tags:
-  - CSS
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/font-variant
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/font-weight/index.md
+++ b/files/es/web/css/font-weight/index.md
@@ -1,12 +1,6 @@
 ---
 title: font-weight
 slug: Web/CSS/font-weight
-tags:
-  - CSS
-  - Propiedad de CSS
-  - Referencia
-  - Tipos de letra de CSS
-translation_of: Web/CSS/font-weight
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/font/index.md
+++ b/files/es/web/css/font/index.md
@@ -1,11 +1,6 @@
 ---
 title: font
 slug: Web/CSS/font
-tags:
-  - CSS
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/font
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/frequency/index.md
+++ b/files/es/web/css/frequency/index.md
@@ -1,14 +1,6 @@
 ---
 title: <frequency>
 slug: Web/CSS/frequency
-tags:
-  - CSS
-  - Presentación
-  - Referencia
-  - Tipos de datos CSS
-  - Unidad CSS
-  - Web
-translation_of: Web/CSS/frequency
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/gap/index.md
+++ b/files/es/web/css/gap/index.md
@@ -1,8 +1,6 @@
 ---
 title: grid-gap
 slug: Web/CSS/gap
-translation_of: Web/CSS/gap
-translation_of_original: Web/CSS/grid-gap
 original_slug: Web/CSS/grid-gap
 ---
 

--- a/files/es/web/css/general_sibling_combinator/index.md
+++ b/files/es/web/css/general_sibling_combinator/index.md
@@ -1,12 +1,6 @@
 ---
 title: Selectores de hermanos generales
 slug: Web/CSS/General_sibling_combinator
-tags:
-  - CSS
-  - NeedsMobileBrowserCompatibility
-  - Referencia CSS
-  - Selectores
-translation_of: Web/CSS/General_sibling_combinator
 original_slug: Web/CSS/Selectores_hermanos_generales
 ---
 

--- a/files/es/web/css/gradient/index.md
+++ b/files/es/web/css/gradient/index.md
@@ -1,15 +1,6 @@
 ---
 title: <gradient>
 slug: Web/CSS/gradient
-tags:
-  - CSS
-  - CSS tipo de datos
-  - Degradado
-  - Diseño
-  - Gradiente
-  - Referencia
-  - graficos
-translation_of: Web/CSS/gradient
 original_slug: Web/CSS/Gradiente
 ---
 

--- a/files/es/web/css/grid-auto-columns/index.md
+++ b/files/es/web/css/grid-auto-columns/index.md
@@ -1,13 +1,6 @@
 ---
 title: grid-auto-columns
 slug: Web/CSS/grid-auto-columns
-tags:
-  - CSS
-  - CSS Grid
-  - Experimental
-  - Propiedades CSS
-  - Referencia
-translation_of: Web/CSS/grid-auto-columns
 ---
 
 La propiedad de css **`grid-auto-columns`** especifíca el tamaño de una columna de cuadrícula creada implícitamente {{glossary("grid tracks", "track")}}.

--- a/files/es/web/css/grid-auto-rows/index.md
+++ b/files/es/web/css/grid-auto-rows/index.md
@@ -1,11 +1,6 @@
 ---
 title: grid-auto-rows
 slug: Web/CSS/grid-auto-rows
-tags:
-  - CSS
-  - Grilla CSS
-  - Propiedad CSS
-translation_of: Web/CSS/grid-auto-rows
 ---
 
 La propiedad **`grid-auto-rows`** de CSS especifíca el tamaño de una nueva fila creada de forma implícita.

--- a/files/es/web/css/grid-template-areas/index.md
+++ b/files/es/web/css/grid-template-areas/index.md
@@ -1,7 +1,6 @@
 ---
 title: grid-template-areas
 slug: Web/CSS/grid-template-areas
-translation_of: Web/CSS/grid-template-areas
 ---
 
 `La propiedad CSS grid-template-areas` especifica nombres para cada una de las {{glossary("grid areas")}}.

--- a/files/es/web/css/grid-template-columns/index.md
+++ b/files/es/web/css/grid-template-columns/index.md
@@ -1,7 +1,6 @@
 ---
 title: grid-template-columns
 slug: Web/CSS/grid-template-columns
-translation_of: Web/CSS/grid-template-columns
 ---
 
 La propiedad CSS **`grid-template-columns`** define el nombre de las líneas y las funciones de tamaño de línea de {{glossary("grid column", "grid columns")}}.

--- a/files/es/web/css/grid-template-rows/index.md
+++ b/files/es/web/css/grid-template-rows/index.md
@@ -1,12 +1,6 @@
 ---
 title: grid-template-rows
 slug: Web/CSS/grid-template-rows
-tags:
-  - CSS
-  - Propiedad CSS
-  - Referencia
-  - grid css
-translation_of: Web/CSS/grid-template-rows
 ---
 
 La propiedad CSS **`grid-template-rows`** define el nombre de las líneas y las funciones de tamaño de línea de {{glossary("grid rows", "grid rows")}}.

--- a/files/es/web/css/grid/index.md
+++ b/files/es/web/css/grid/index.md
@@ -1,7 +1,6 @@
 ---
 title: grid
 slug: Web/CSS/grid
-translation_of: Web/CSS/grid
 ---
 
 La propiedad CSS **`grid`** es un [shorthand](/es/docs/Web/CSS/Shorthand_properties) que permite definir todas las propiedades _grid_ explícitas ({{cssxref("grid-template-rows")}}, {{cssxref("grid-template-columns")}}, y {{cssxref("grid-template-areas")}}), implícitas ({{cssxref("grid-auto-rows")}}, {{cssxref("grid-auto-columns")}}, y {{cssxref("grid-auto-flow")}}), y relativas a _gutter_ ({{cssxref("grid-column-gap")}} y {{cssxref("grid-row-gap")}}) en una sola declaración.

--- a/files/es/web/css/height/index.md
+++ b/files/es/web/css/height/index.md
@@ -1,7 +1,6 @@
 ---
 title: height
 slug: Web/CSS/height
-browser-compat: css.properties.height
 l10n:
   sourceCommit: abcebf471d56ef12239e2565f26d952e8a8cab2eabcebf471d56ef12239e2565f26d952e8a8cab2e
 ---

--- a/files/es/web/css/hyphens/index.md
+++ b/files/es/web/css/hyphens/index.md
@@ -1,7 +1,6 @@
 ---
 title: hyphens
 slug: Web/CSS/hyphens
-translation_of: Web/CSS/hyphens
 ---
 
 {{CSSRef}}La propiedad [CSS](/es/docs/Web/CSS) **`hyphens`** especifica cómo deben dividirse las palabras cuando el texto se ajusta a través de múltiples líneas. Puede impedir la separación de sílabas por completo, usar guiones manualmente en puntos específicos del texto o dejar que el navegador inserte los guiones automáticamente donde corresponda.{{EmbedInteractiveExample("pages/css/hyphens.html")}}

--- a/files/es/web/css/id_selectors/index.md
+++ b/files/es/web/css/id_selectors/index.md
@@ -1,12 +1,6 @@
 ---
 title: Selectores de ID
 slug: Web/CSS/ID_selectors
-tags:
-  - CSS
-  - Referencia
-  - Referencia CSS
-  - Selectores
-translation_of: Web/CSS/ID_selectors
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/image-rendering/index.md
+++ b/files/es/web/css/image-rendering/index.md
@@ -1,7 +1,6 @@
 ---
 title: image-rendering
 slug: Web/CSS/image-rendering
-translation_of: Web/CSS/image-rendering
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/image/index.md
+++ b/files/es/web/css/image/index.md
@@ -1,11 +1,6 @@
 ---
 title: <image>
 slug: Web/CSS/image
-tags:
-  - Gráfico
-  - Imagen CSS
-  - Tipo de Dato CSS
-translation_of: Web/CSS/image
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/ime-mode/index.md
+++ b/files/es/web/css/ime-mode/index.md
@@ -1,12 +1,6 @@
 ---
 title: ime-mode
 slug: Web/CSS/ime-mode
-tags:
-  - CSS
-  - CSS:Referencias
-  - Referencia_CSS
-  - Todas_las_Categorías
-translation_of: Web/CSS/ime-mode
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/inherit/index.md
+++ b/files/es/web/css/inherit/index.md
@@ -1,11 +1,6 @@
 ---
 title: inherit
 slug: Web/CSS/inherit
-tags:
-  - CSS
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/inherit
 ---
 
 << [Volver](es/Gu%c3%ada_de_referencia_de_CSS)

--- a/files/es/web/css/inheritance/index.md
+++ b/files/es/web/css/inheritance/index.md
@@ -1,12 +1,6 @@
 ---
 title: Herencia
 slug: Web/CSS/inheritance
-tags:
-  - CSS
-  - CSS:Referencias
-  - Referencia_CSS
-  - Todas_las_Categorías
-translation_of: Web/CSS/inheritance
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/initial/index.md
+++ b/files/es/web/css/initial/index.md
@@ -1,11 +1,6 @@
 ---
 title: initial
 slug: Web/CSS/initial
-tags:
-  - CSS
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/initial
 ---
 
 [Guía de referencia de CSS](es/Gu%c3%ada_de_referencia_de_CSS)

--- a/files/es/web/css/initial_value/index.md
+++ b/files/es/web/css/initial_value/index.md
@@ -1,11 +1,6 @@
 ---
 title: Valor inicial
 slug: Web/CSS/initial_value
-tags:
-  - CSS
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/initial_value
 original_slug: Web/CSS/Valor_inicial
 ---
 

--- a/files/es/web/css/inline-size/index.md
+++ b/files/es/web/css/inline-size/index.md
@@ -1,7 +1,6 @@
 ---
 title: inline-size
 slug: Web/CSS/inline-size
-translation_of: Web/CSS/inline-size
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/inset-block-end/index.md
+++ b/files/es/web/css/inset-block-end/index.md
@@ -1,7 +1,6 @@
 ---
 title: inset-block-end
 slug: Web/CSS/inset-block-end
-translation_of: Web/CSS/inset-block-end
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/inset-block-start/index.md
+++ b/files/es/web/css/inset-block-start/index.md
@@ -1,7 +1,6 @@
 ---
 title: inset-block-start
 slug: Web/CSS/inset-block-start
-translation_of: Web/CSS/inset-block-start
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/inset-block/index.md
+++ b/files/es/web/css/inset-block/index.md
@@ -1,7 +1,6 @@
 ---
 title: inset-block
 slug: Web/CSS/inset-block
-translation_of: Web/CSS/inset-block
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/inset-inline-end/index.md
+++ b/files/es/web/css/inset-inline-end/index.md
@@ -1,7 +1,6 @@
 ---
 title: inset-inline-end
 slug: Web/CSS/inset-inline-end
-translation_of: Web/CSS/inset-inline-end
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/inset-inline-start/index.md
+++ b/files/es/web/css/inset-inline-start/index.md
@@ -1,7 +1,6 @@
 ---
 title: inset-inline-start
 slug: Web/CSS/inset-inline-start
-translation_of: Web/CSS/inset-inline-start
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/inset-inline/index.md
+++ b/files/es/web/css/inset-inline/index.md
@@ -1,7 +1,6 @@
 ---
 title: inset-inline
 slug: Web/CSS/inset-inline
-translation_of: Web/CSS/inset-inline
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/inset/index.md
+++ b/files/es/web/css/inset/index.md
@@ -1,7 +1,6 @@
 ---
 title: inset
 slug: Web/CSS/inset
-translation_of: Web/CSS/inset
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/integer/index.md
+++ b/files/es/web/css/integer/index.md
@@ -1,7 +1,6 @@
 ---
 title: <integer>
 slug: Web/CSS/integer
-translation_of: Web/CSS/integer
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/isolation/index.md
+++ b/files/es/web/css/isolation/index.md
@@ -1,11 +1,6 @@
 ---
 title: Isolation
 slug: Web/CSS/isolation
-tags:
-  - CSS
-  - Composición CSS
-  - Propieiedad CSS
-translation_of: Web/CSS/isolation
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/justify-content/index.md
+++ b/files/es/web/css/justify-content/index.md
@@ -1,7 +1,6 @@
 ---
 title: justify-content
 slug: Web/CSS/justify-content
-translation_of: Web/CSS/justify-content
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/layout_cookbook/index.md
+++ b/files/es/web/css/layout_cookbook/index.md
@@ -1,7 +1,6 @@
 ---
 title: Libro de recetas de maquetación CSS
 slug: Web/CSS/Layout_cookbook
-translation_of: Web/CSS/Layout_cookbook
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/layout_mode/index.md
+++ b/files/es/web/css/layout_mode/index.md
@@ -1,11 +1,6 @@
 ---
 title: Layout mode
 slug: Web/CSS/Layout_mode
-tags:
-  - CSS
-  - Layout
-  - Referencia
-translation_of: Web/CSS/Layout_mode
 ---
 
 {{cssref}}

--- a/files/es/web/css/left/index.md
+++ b/files/es/web/css/left/index.md
@@ -1,7 +1,6 @@
 ---
 title: left
 slug: Web/CSS/left
-translation_of: Web/CSS/left
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/length/index.md
+++ b/files/es/web/css/length/index.md
@@ -1,10 +1,6 @@
 ---
 title: <length>
 slug: Web/CSS/length
-tags:
-  - Referencia
-  - Tipo de Dato CSS
-translation_of: Web/CSS/length
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/line-height/index.md
+++ b/files/es/web/css/line-height/index.md
@@ -1,14 +1,6 @@
 ---
 title: line-height
 slug: Web/CSS/line-height
-tags:
-  - CSS
-  - CSS:Referencias
-  - Referencia_CSS
-  - Todas_las_Categorías
-  - para_revisar
-  - páginas_a_traducir
-translation_of: Web/CSS/line-height
 ---
 
 ```

--- a/files/es/web/css/list-style-image/index.md
+++ b/files/es/web/css/list-style-image/index.md
@@ -1,12 +1,6 @@
 ---
 title: list-style-image
 slug: Web/CSS/list-style-image
-tags:
-  - CSS
-  - CSS:Referencias
-  - Referencia_CSS
-  - Todas_las_Categorías
-translation_of: Web/CSS/list-style-image
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/list-style-position/index.md
+++ b/files/es/web/css/list-style-position/index.md
@@ -1,12 +1,6 @@
 ---
 title: list-style-position
 slug: Web/CSS/list-style-position
-tags:
-  - CSS
-  - CSS:Referencias
-  - Referencia_CSS
-  - Todas_las_Categorías
-translation_of: Web/CSS/list-style-position
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/list-style-type/index.md
+++ b/files/es/web/css/list-style-type/index.md
@@ -1,12 +1,6 @@
 ---
 title: list-style-type
 slug: Web/CSS/list-style-type
-tags:
-  - CSS
-  - CSS:Referencias
-  - Referencia_CSS
-  - Todas_las_Categorías
-translation_of: Web/CSS/list-style-type
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/list-style/index.md
+++ b/files/es/web/css/list-style/index.md
@@ -1,12 +1,6 @@
 ---
 title: list-style
 slug: Web/CSS/list-style
-tags:
-  - CSS
-  - CSS:Referencias
-  - Referencia_CSS
-  - Todas_las_Categorías
-translation_of: Web/CSS/list-style
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/margin-block-start/index.md
+++ b/files/es/web/css/margin-block-start/index.md
@@ -1,7 +1,6 @@
 ---
 title: margin-block-start
 slug: Web/CSS/margin-block-start
-translation_of: Web/CSS/margin-block-start
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/margin-block/index.md
+++ b/files/es/web/css/margin-block/index.md
@@ -1,7 +1,6 @@
 ---
 title: margin-block
 slug: Web/CSS/margin-block
-translation_of: Web/CSS/margin-block
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/margin-bottom/index.md
+++ b/files/es/web/css/margin-bottom/index.md
@@ -1,7 +1,6 @@
 ---
 title: margin-bottom
 slug: Web/CSS/margin-bottom
-translation_of: Web/CSS/margin-bottom
 ---
 
 {{CSSRef()}}

--- a/files/es/web/css/margin-inline-end/index.md
+++ b/files/es/web/css/margin-inline-end/index.md
@@ -1,7 +1,6 @@
 ---
 title: margin-inline-end
 slug: Web/CSS/margin-inline-end
-translation_of: Web/CSS/margin-inline-end
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/margin-inline-start/index.md
+++ b/files/es/web/css/margin-inline-start/index.md
@@ -1,7 +1,6 @@
 ---
 title: margin-inline-start
 slug: Web/CSS/margin-inline-start
-translation_of: Web/CSS/margin-inline-start
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/margin-inline/index.md
+++ b/files/es/web/css/margin-inline/index.md
@@ -1,7 +1,6 @@
 ---
 title: margin-inline
 slug: Web/CSS/margin-inline
-translation_of: Web/CSS/margin-inline
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/margin-right/index.md
+++ b/files/es/web/css/margin-right/index.md
@@ -1,7 +1,6 @@
 ---
 title: margin-right
 slug: Web/CSS/margin-right
-translation_of: Web/CSS/margin-right
 ---
 
 ### Definicion

--- a/files/es/web/css/margin/index.md
+++ b/files/es/web/css/margin/index.md
@@ -1,8 +1,6 @@
 ---
 title: margin
 slug: Web/CSS/margin
-translation_of: Web/CSS/margin
-translation_of_original: Web/CSS/margin-new
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/mask-clip/index.md
+++ b/files/es/web/css/mask-clip/index.md
@@ -1,10 +1,6 @@
 ---
 title: '-webkit-mask-clip'
 slug: Web/CSS/mask-clip
-tags:
-  - CSS
-translation_of: Web/CSS/mask-clip
-translation_of_original: Web/CSS/-webkit-mask-clip
 original_slug: Web/CSS/-webkit-mask-clip
 ---
 

--- a/files/es/web/css/mask-image/index.md
+++ b/files/es/web/css/mask-image/index.md
@@ -1,13 +1,6 @@
 ---
 title: '-webkit-mask-image'
 slug: Web/CSS/mask-image
-tags:
-  - CSS
-  - No estándar(2)
-  - Propiedad CSS
-  - Referencia CSS
-translation_of: Web/CSS/mask-image
-translation_of_original: Web/CSS/-webkit-mask-image
 original_slug: Web/CSS/-webkit-mask-image
 ---
 

--- a/files/es/web/css/mask-origin/index.md
+++ b/files/es/web/css/mask-origin/index.md
@@ -1,11 +1,6 @@
 ---
 title: '-webkit-mask-origin'
 slug: Web/CSS/mask-origin
-tags:
-  - CSS
-  - Referencia
-translation_of: Web/CSS/mask-origin
-translation_of_original: Web/CSS/-webkit-mask-origin
 original_slug: Web/CSS/-webkit-mask-origin
 ---
 

--- a/files/es/web/css/mask-position/index.md
+++ b/files/es/web/css/mask-position/index.md
@@ -1,13 +1,6 @@
 ---
 title: '-webkit-mask-position'
 slug: Web/CSS/mask-position
-tags:
-  - CSS
-  - No estándar(2)
-  - Propiedad CSS
-  - Referencia CSS
-translation_of: Web/CSS/mask-position
-translation_of_original: Web/CSS/-webkit-mask-position
 original_slug: Web/CSS/-webkit-mask-position
 ---
 

--- a/files/es/web/css/mask-repeat/index.md
+++ b/files/es/web/css/mask-repeat/index.md
@@ -1,14 +1,6 @@
 ---
 title: '-webkit-mask-repeat'
 slug: Web/CSS/mask-repeat
-tags:
-  - CSS
-  - No estandar
-  - Propiedad CSS
-  - Referencia
-  - Web
-translation_of: Web/CSS/mask-repeat
-translation_of_original: Web/CSS/-webkit-mask-repeat
 original_slug: Web/CSS/-webkit-mask-repeat
 ---
 

--- a/files/es/web/css/mask/index.md
+++ b/files/es/web/css/mask/index.md
@@ -1,13 +1,6 @@
 ---
 title: '-webkit-mask'
 slug: Web/CSS/mask
-tags:
-  - CSS
-  - No estandar
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/mask
-translation_of_original: Web/CSS/-webkit-mask
 original_slug: Web/CSS/-webkit-mask
 ---
 

--- a/files/es/web/css/max-block-size/index.md
+++ b/files/es/web/css/max-block-size/index.md
@@ -1,7 +1,6 @@
 ---
 title: max-block-size
 slug: Web/CSS/max-block-size
-browser-compat: css.properties.max-block-size
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/max-height/index.md
+++ b/files/es/web/css/max-height/index.md
@@ -1,11 +1,6 @@
 ---
 title: max-height
 slug: Web/CSS/max-height
-tags:
-  - CSS
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/max-height
 ---
 
 << [Volver](es/Gu%c3%ada_de_referencia_de_CSS)

--- a/files/es/web/css/max-inline-size/index.md
+++ b/files/es/web/css/max-inline-size/index.md
@@ -1,7 +1,6 @@
 ---
 title: max-inline-size
 slug: Web/CSS/max-inline-size
-translation_of: Web/CSS/max-inline-size
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/media_queries/index.md
+++ b/files/es/web/css/media_queries/index.md
@@ -1,7 +1,6 @@
 ---
 title: Media queries
 slug: Web/CSS/Media_Queries
-translation_of: Web/CSS/Media_Queries
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/media_queries/using_media_queries/index.md
+++ b/files/es/web/css/media_queries/using_media_queries/index.md
@@ -1,12 +1,6 @@
 ---
 title: CSS media queries
 slug: Web/CSS/Media_Queries/Using_media_queries
-tags:
-  - CSS
-  - Media
-  - Media Queries
-  - query
-translation_of: Web/CSS/Media_Queries/Using_media_queries
 original_slug: CSS/Media_queries
 ---
 

--- a/files/es/web/css/min-block-size/index.md
+++ b/files/es/web/css/min-block-size/index.md
@@ -1,7 +1,6 @@
 ---
 title: min-block-size
 slug: Web/CSS/min-block-size
-translation_of: Web/CSS/min-block-size
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/min-height/index.md
+++ b/files/es/web/css/min-height/index.md
@@ -1,11 +1,6 @@
 ---
 title: min-height
 slug: Web/CSS/min-height
-tags:
-  - CSS
-  - CSS:Referencias
-  - Todas_las_Categorías
-translation_of: Web/CSS/min-height
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/min-inline-size/index.md
+++ b/files/es/web/css/min-inline-size/index.md
@@ -1,7 +1,6 @@
 ---
 title: min-inline-size
 slug: Web/CSS/min-inline-size
-translation_of: Web/CSS/min-inline-size
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/min-width/index.md
+++ b/files/es/web/css/min-width/index.md
@@ -1,9 +1,6 @@
 ---
 title: min-width
 slug: Web/CSS/min-width
-tags:
-  - Referencia_CSS
-translation_of: Web/CSS/min-width
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/min/index.md
+++ b/files/es/web/css/min/index.md
@@ -1,17 +1,6 @@
 ---
 title: min()
 slug: Web/CSS/min
-tags:
-  - CSS
-  - CSS Function
-  - CSS Grid
-  - Calculate
-  - Compute
-  - Function
-  - Layout
-  - Reference
-  - min
-translation_of: Web/CSS/min()
 original_slug: Web/CSS/min()
 ---
 

--- a/files/es/web/css/minmax/index.md
+++ b/files/es/web/css/minmax/index.md
@@ -1,15 +1,6 @@
 ---
 title: minmax()
 slug: Web/CSS/minmax
-tags:
-  - CSS
-  - CSS Grid
-  - Diseño
-  - Función CSS
-  - Referencia
-  - Rejilla CSS
-  - Web
-translation_of: Web/CSS/minmax()
 original_slug: Web/CSS/minmax()
 ---
 

--- a/files/es/web/css/mix-blend-mode/index.md
+++ b/files/es/web/css/mix-blend-mode/index.md
@@ -1,9 +1,6 @@
 ---
 title: mix-blend-mode
 slug: Web/CSS/mix-blend-mode
-tags:
-  - CSS
-translation_of: Web/CSS/mix-blend-mode
 original_slug: Web/CSS/Referencia_CSS/mix-blend-mode
 ---
 

--- a/files/es/web/css/mozilla_extensions/index.md
+++ b/files/es/web/css/mozilla_extensions/index.md
@@ -1,7 +1,6 @@
 ---
 title: Extensiones CSS de Mozilla
 slug: Web/CSS/Mozilla_Extensions
-translation_of: Web/CSS/Mozilla_Extensions
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/number/index.md
+++ b/files/es/web/css/number/index.md
@@ -1,7 +1,6 @@
 ---
 title: <number>
 slug: Web/CSS/number
-translation_of: Web/CSS/number
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/object-fit/index.md
+++ b/files/es/web/css/object-fit/index.md
@@ -1,17 +1,6 @@
 ---
 title: object-fit
 slug: Web/CSS/object-fit
-tags:
-  - CSS
-  - Imágenes CSS
-  - Layout
-  - Propiedad CSS
-  - Referencia
-  - css layout
-  - object-fit
-  - recipe:css-property
-  - size
-translation_of: Web/CSS/object-fit
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/object-position/index.md
+++ b/files/es/web/css/object-position/index.md
@@ -1,7 +1,6 @@
 ---
 title: object-position
 slug: Web/CSS/object-position
-translation_of: Web/CSS/object-position
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/opacity/index.md
+++ b/files/es/web/css/opacity/index.md
@@ -1,12 +1,6 @@
 ---
 title: opacity
 slug: Web/CSS/opacity
-tags:
-  - CSS
-  - CSS Reference
-  - CSS3
-  - css3-color
-translation_of: Web/CSS/opacity
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/order/index.md
+++ b/files/es/web/css/order/index.md
@@ -1,7 +1,6 @@
 ---
 title: order
 slug: Web/CSS/order
-translation_of: Web/CSS/order
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/outline-color/index.md
+++ b/files/es/web/css/outline-color/index.md
@@ -1,9 +1,7 @@
 ---
 title: outline-color
 slug: Web/CSS/outline-color
-translation_of: Web/CSS/outline-color
 original_slug: Web/CSS/outline-color
-browser-compat: css.properties.outline-color
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/outline-offset/index.md
+++ b/files/es/web/css/outline-offset/index.md
@@ -1,10 +1,6 @@
 ---
 title: outline-offset
 slug: Web/CSS/outline-offset
-tags:
-  - Contorno CSS
-  - Propiedad CSS
-translation_of: Web/CSS/outline-offset
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/outline-style/index.md
+++ b/files/es/web/css/outline-style/index.md
@@ -1,10 +1,6 @@
 ---
 title: outline-style
 slug: Web/CSS/outline-style
-tags:
-  - Contorno CSS
-  - Propiedad CSS
-translation_of: Web/CSS/outline-style
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/outline-width/index.md
+++ b/files/es/web/css/outline-width/index.md
@@ -1,10 +1,6 @@
 ---
 title: outline-width
 slug: Web/CSS/outline-width
-tags:
-  - Contorno CSS
-  - Propiedad CSS
-translation_of: Web/CSS/outline-width
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/outline/index.md
+++ b/files/es/web/css/outline/index.md
@@ -1,10 +1,6 @@
 ---
 title: outline
 slug: Web/CSS/outline
-tags:
-  - Contorno CSS
-  - Propiedad CSS
-translation_of: Web/CSS/outline
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/overflow-y/index.md
+++ b/files/es/web/css/overflow-y/index.md
@@ -1,11 +1,6 @@
 ---
 title: overflow-y
 slug: Web/CSS/overflow-y
-tags:
-  - CSS
-  - CSS Modelo de Caja
-  - Propiedad CSS
-translation_of: Web/CSS/overflow-y
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/overflow/index.md
+++ b/files/es/web/css/overflow/index.md
@@ -1,7 +1,6 @@
 ---
 title: overflow (excedente)
 slug: Web/CSS/overflow
-translation_of: Web/CSS/overflow
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/padding-block-end/index.md
+++ b/files/es/web/css/padding-block-end/index.md
@@ -1,7 +1,6 @@
 ---
 title: padding-block-end
 slug: Web/CSS/padding-block-end
-translation_of: Web/CSS/padding-block-end
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/padding-block-start/index.md
+++ b/files/es/web/css/padding-block-start/index.md
@@ -1,7 +1,6 @@
 ---
 title: padding-block-start
 slug: Web/CSS/padding-block-start
-translation_of: Web/CSS/padding-block-start
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/padding-block/index.md
+++ b/files/es/web/css/padding-block/index.md
@@ -1,7 +1,6 @@
 ---
 title: padding-block
 slug: Web/CSS/padding-block
-translation_of: Web/CSS/padding-block
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/padding-bottom/index.md
+++ b/files/es/web/css/padding-bottom/index.md
@@ -1,7 +1,6 @@
 ---
 title: padding-bottom
 slug: Web/CSS/padding-bottom
-translation_of: Web/CSS/padding-bottom
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/padding-inline-end/index.md
+++ b/files/es/web/css/padding-inline-end/index.md
@@ -1,7 +1,6 @@
 ---
 title: padding-inline-end
 slug: Web/CSS/padding-inline-end
-translation_of: Web/CSS/padding-inline-end
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/padding-inline-start/index.md
+++ b/files/es/web/css/padding-inline-start/index.md
@@ -1,7 +1,6 @@
 ---
 title: padding-inline-start
 slug: Web/CSS/padding-inline-start
-translation_of: Web/CSS/padding-inline-start
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/padding-inline/index.md
+++ b/files/es/web/css/padding-inline/index.md
@@ -1,7 +1,6 @@
 ---
 title: padding-inline
 slug: Web/CSS/padding-inline
-translation_of: Web/CSS/padding-inline
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/padding-top/index.md
+++ b/files/es/web/css/padding-top/index.md
@@ -1,7 +1,6 @@
 ---
 title: padding-top
 slug: Web/CSS/padding-top
-translation_of: Web/CSS/padding-top
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/padding/index.md
+++ b/files/es/web/css/padding/index.md
@@ -1,9 +1,6 @@
 ---
 title: padding
 slug: Web/CSS/padding
-tags:
-  - Propiedades CSS
-translation_of: Web/CSS/padding
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/percentage/index.md
+++ b/files/es/web/css/percentage/index.md
@@ -1,7 +1,6 @@
 ---
 title: <percentage>
 slug: Web/CSS/percentage
-translation_of: Web/CSS/percentage
 original_slug: Web/CSS/porcentaje
 ---
 

--- a/files/es/web/css/perspective/index.md
+++ b/files/es/web/css/perspective/index.md
@@ -1,15 +1,6 @@
 ---
 title: perspective
 slug: Web/CSS/perspective
-tags:
-  - CSS
-  - Capas
-  - Propiedad CSS
-  - Referencia
-  - Transformaciones CSS
-  - Web
-  - graficos
-translation_of: Web/CSS/perspective
 ---
 
 {{ CSSRef("CSS Transforms") }} {{ SeeCompatTable() }}

--- a/files/es/web/css/position/index.md
+++ b/files/es/web/css/position/index.md
@@ -1,9 +1,6 @@
 ---
 title: position
 slug: Web/CSS/position
-tags:
-  - Referencia_CSS
-translation_of: Web/CSS/position
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/print-color-adjust/index.md
+++ b/files/es/web/css/print-color-adjust/index.md
@@ -1,13 +1,6 @@
 ---
 title: '-webkit-print-color-adjust'
 slug: Web/CSS/print-color-adjust
-tags:
-  - CSS
-  - Diseño
-  - No estándar(2)
-  - Propiedad CSS
-  - Web
-translation_of: Web/CSS/-webkit-print-color-adjust
 original_slug: Web/CSS/-webkit-print-color-adjust
 ---
 

--- a/files/es/web/css/pseudo-classes/index.md
+++ b/files/es/web/css/pseudo-classes/index.md
@@ -1,12 +1,6 @@
 ---
 title: Pseudo-classes
 slug: Web/CSS/Pseudo-classes
-tags:
-  - CSS
-  - Referencia CSS
-  - Selectores
-  - pseudo-clases
-translation_of: Web/CSS/Pseudo-classes
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/pseudo-elements/index.md
+++ b/files/es/web/css/pseudo-elements/index.md
@@ -1,12 +1,6 @@
 ---
 title: Pseudoelementos
 slug: Web/CSS/Pseudo-elements
-tags:
-  - CSS
-  - Pseudo-element
-  - Pseudo-elementos
-  - Selectores
-translation_of: Web/CSS/Pseudo-elements
 original_slug: Web/CSS/Pseudoelementos
 ---
 

--- a/files/es/web/css/quotes/index.md
+++ b/files/es/web/css/quotes/index.md
@@ -1,13 +1,6 @@
 ---
 title: quotes
 slug: Web/CSS/quotes
-tags:
-  - CSS
-  - Layout
-  - Maquetación
-  - Referencia
-  - Web
-translation_of: Web/CSS/quotes
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/reference/index.md
+++ b/files/es/web/css/reference/index.md
@@ -1,11 +1,6 @@
 ---
 title: Referencia CSS
 slug: Web/CSS/Reference
-tags:
-  - CSS
-  - Referencia CSS
-  - para_revisar
-translation_of: Web/CSS/Reference
 original_slug: Web/CSS/Referencia_CSS
 ---
 

--- a/files/es/web/css/repeat/index.md
+++ b/files/es/web/css/repeat/index.md
@@ -1,15 +1,6 @@
 ---
 title: repeat()
 slug: Web/CSS/repeat
-tags:
-  - CSS
-  - CSS Grid
-  - Función CSS
-  - Layout
-  - Maquetado
-  - Referencia
-  - Web
-translation_of: Web/CSS/repeat()
 original_slug: Web/CSS/repeat()
 ---
 

--- a/files/es/web/css/replaced_element/index.md
+++ b/files/es/web/css/replaced_element/index.md
@@ -1,11 +1,6 @@
 ---
 title: Elemento de reemplazo
 slug: Web/CSS/Replaced_element
-tags:
-  - CSS
-  - CSS Referência
-  - Intermediate
-translation_of: Web/CSS/Replaced_element
 original_slug: Web/CSS/Elemento_reemplazo
 ---
 

--- a/files/es/web/css/resize/index.md
+++ b/files/es/web/css/resize/index.md
@@ -1,7 +1,6 @@
 ---
 title: resize
 slug: Web/CSS/resize
-translation_of: Web/CSS/resize
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/resolution/index.md
+++ b/files/es/web/css/resolution/index.md
@@ -1,13 +1,6 @@
 ---
 title: <resolution>
 slug: Web/CSS/resolution
-tags:
-  - CSS
-  - CSS tipo de datos
-  - Diseño
-  - Estilos
-  - Referencia
-translation_of: Web/CSS/resolution
 original_slug: Web/CSS/resolución
 ---
 

--- a/files/es/web/css/resolved_value/index.md
+++ b/files/es/web/css/resolved_value/index.md
@@ -1,10 +1,6 @@
 ---
 title: Valor resuelto
 slug: Web/CSS/resolved_value
-tags:
-  - CSS
-  - Referencia CSS
-translation_of: Web/CSS/resolved_value
 ---
 
 {{cssref}}

--- a/files/es/web/css/right/index.md
+++ b/files/es/web/css/right/index.md
@@ -1,11 +1,6 @@
 ---
 title: right
 slug: Web/CSS/right
-tags:
-  - CSS Reference
-  - NeedsTechnicalReview
-  - Referencia_CSS
-translation_of: Web/CSS/right
 ---
 
 {{ CSSRef() }}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove duplicated frontmatter keys from localized content

### Motivation

Remove innecesarry duplicated data

### Additional details

Folders: css/(c|d|e|f|g|h|i|j|l|m|n|o|p|q|r)*

```
{
  "translation_of": 194,
  "tags": 115,
  "translation_of_original": 13,
  "page-type": 1,
  "spec-urls": 1,
  "browser-compat": 3
}
```

### Related issues and pull requests

Relates to #10129
Relates to #7412
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
