### PR TITLE
chore: remove deprecated {{ServiceWorkerSidebar}} macro

### DIFF
--- a/files/zh-cn/web/api/service_worker_api/index.md
+++ b/files/zh-cn/web/api/service_worker_api/index.md
@@ -3,7 +3,7 @@ title: Service Worker API
 slug: Web/API/Service_Worker_API
 ---
 
-{{ServiceWorkerSidebar}}
+{{DefaultAPISidebar("Service Workers API")}}
 
 Service workers 本质上充当 Web 应用程序、浏览器与网络（可用时）之间的代理服务器。这个 API 旨在创建有效的离线体验，它会拦截网络请求并根据网络是否可用来采取适当的动作、更新来自服务器的的资源。它还提供入口以推送通知和访问后台同步 API。
 

--- a/files/zh-cn/web/api/service_worker_api/using_service_workers/index.md
+++ b/files/zh-cn/web/api/service_worker_api/using_service_workers/index.md
@@ -1,9 +1,9 @@
 ---
-title: 使用 Service Workers
+title: 使用 Service Worker
 slug: Web/API/Service_Worker_API/Using_Service_Workers
 ---
 
-{{ServiceWorkerSidebar}}
+{{DefaultAPISidebar("Service Workers API")}}
 
 本文是关于使用 service workers 的教程，包括讲解 service worker 的基本架构、怎么注册一个 service worker、一个新 service worker 的 install 及 activation 过程、怎么更新 service worker 还有它的缓存控制和自定义响应，这一切都在一个简单的离线的应用程序中。
 


### PR DESCRIPTION
### Description

chore: remove deprecated {{ServiceWorkerSidebar}} macro

replaced by {{DefaultAPISidebar}}.

### Additional details

See: mdn/content#22469

### Related issues and pull requests

See: mdn/yari#7645
