### PR TITLE
Remove deprecated ServiceWorkerSidebar macro from es

### DIFF
--- a/files/es/web/api/service_worker_api/index.md
+++ b/files/es/web/api/service_worker_api/index.md
@@ -14,7 +14,7 @@ tags:
 translation_of: Web/API/Service_Worker_API
 ---
 
-{{ServiceWorkerSidebar}}
+{{DefaultAPISidebar}}
 
 Los Service workers actúan esencialmente como proxy servers asentados entre las aplicaciones web, el navegador y la red (cuando está accesible). Están destinados, entre otras cosas, a permitir la creación de experiencias offline efectivas, interceptando peticiones de red y realizando la acción apropiada si la conexión de red está disponible y hay disponibles contenidos actualizados en el servidor. También permitirán el acceso a notificaciones tipo push y APIs de sincronización en segundo plano.
 

--- a/files/es/web/api/service_worker_api/using_service_workers/index.md
+++ b/files/es/web/api/service_worker_api/using_service_workers/index.md
@@ -5,7 +5,7 @@ page-type: guide
 translation_of: Web/API/Service_Worker_API/Using_Service_Workers
 ---
 
-{{ServiceWorkerSidebar}}
+{{DefaultAPISidebar}}
 
 Este artículo brinda información sobre cómo comenzar con el *service worker*, incluida la arquitectura básica, el registro de un *service worker*, el proceso de instalación y activación de un nuevo *service worker*, la actualización de tu *service worker*, el control de caché y las respuestas personalizadas, todo en el contexto de una aplicación simple, con funcionalidad fuera de línea.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove deprecated ServiceWorkerSidebar macro from es

Process: replace `{{ServiceWorkerSidebar}}` macro with `{{DefaultAPISidebar}}`

### Motivation

The chore of deprecated macros removal

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Relates to https://github.com/orgs/mdn/discussions/263
Relates to https://github.com/mdn/translated-content/issues/10170
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
