### PR TITLE
ci: use AUTOMERGE_TOKEN for PR creation

### DIFF
--- a/.github/workflows/markdown-lint-fix.yml
+++ b/.github/workflows/markdown-lint-fix.yml
@@ -47,6 +47,7 @@ jobs:
           branch: markdownlint-auto-cleanup-${{ matrix.lang }}
           title: "Markdownlint auto-cleanup for ${{ matrix.lang }}"
           author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
+          token: ${{ secrets.AUTOMERGE_TOKEN }}
           body: |
             All issues auto-fixed
 
@@ -58,6 +59,7 @@ jobs:
           branch: markdownlint-auto-cleanup-${{ matrix.lang }}
           title: "Markdownlint auto-cleanup for ${{ matrix.lang }}"
           author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
+          token: ${{ secrets.AUTOMERGE_TOKEN }}
           body: |
             Auto-fix was run, but additional issues found.
             Please review the run log: https://github.com/mdn/translated-content/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Use the AUTOMERGE token when Markdownlint creates PRs

### Motivation

Found this out in the Sync CI job, that the built-in token won't trigger CI runs or the auto-assignment. This was the same work-around in that job

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
