### PR TITLE
fix(ci): run markdownlint only in upstream and trigger workflow

### DIFF
--- a/.github/workflows/markdown-lint-fix.yml
+++ b/.github/workflows/markdown-lint-fix.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   fix:
+    if: github.repository == 'mdn/translated-content'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -49,6 +50,7 @@ jobs:
           author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
           body: |
             All issues auto-fixed
+          token: ${{ secrets.AUTOMERGE_TOKEN }}
 
       - name: Create PR with notice on unfixed issues
         if: failure()
@@ -61,3 +63,4 @@ jobs:
           body: |
             Auto-fix was run, but additional issues found.
             Please review the run log: https://github.com/mdn/translated-content/actions/runs/${{ github.run_id }}
+          token: ${{ secrets.AUTOMERGE_TOKEN }}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- add `github.repository == 'mdn/translated-content'` condition to run ci in upstream
- use `AUTOMERGE_TOKEN` token to trigger workflow in markdownlint-fix created PR (as we have done before mdn/translated-content#8744).
