### PR TITLE
[pt-br] Fix a typo

### DIFF
--- a/files/pt-br/learn/getting_started_with_the_web/javascript_basics/index.md
+++ b/files/pt-br/learn/getting_started_with_the_web/javascript_basics/index.md
@@ -120,7 +120,7 @@ Observe que as variáveis ​​podem conter valores que têm diferentes [tipos 
       <th scope="col">Exemplo</th>
     </tr>
   </thead>
-  <corpo>
+  <tbody>
     <tr>
       <th scope="row">{{Glossary("String")}}</th>
       <td>


### PR DESCRIPTION
The typo caused [daily lint fix job to fail](https://github.com/mdn/translated-content/actions/runs/3560652002/jobs/5980835290):
```bash
Run yarn markdownlint-cli2-fix "**/pt-br/**/*.md"
yarn run v1.22.19
$ /home/runner/work/translated-content/translated-content/node_modules/.bin/markdownlint-cli2-fix '**/pt-br/**/*.md'
markdownlint-cli2-fix v0.5.1 (markdownlint v0.26.2)
Finding: **/pt-br/**/*.md !node_modules !**/conflicting/** !**/orphaned/** !.github/ !files/**/web/api/window/frames/index.md
Linting: 208[4](https://github.com/mdn/translated-content/actions/runs/3560652002/jobs/5980835290#step:5:5) file(s)
Summary: 1 error(s)
files/pt-br/learn/getting_started_with_the_web/javascript_basics/index.md:123:3 MD033/no-inline-html Inline HTML [Element: corpo]
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Process completed with exit code 1.
```
