### PR TITLE
Fix markdown code bold not work

### DIFF
--- a/files/zh-cn/web/api/window/domcontentloaded_event/index.md
+++ b/files/zh-cn/web/api/window/domcontentloaded_event/index.md
@@ -3,7 +3,7 @@ title: DOMContentLoaded
 slug: Web/API/Window/DOMContentLoaded_event
 ---
 
-当初始的 **HTML** 文档被完全加载和解析完成之后，**`DOMContentLoaded` **事件被触发，而无需等待样式表、图像和子框架的完全加载。
+当初始的 **HTML** 文档被完全加载和解析完成之后，**`DOMContentLoaded`** 事件被触发，而无需等待样式表、图像和子框架的完全加载。
 
 模拟的 css 文件：CSS.php
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Markdown code bold is not working because the incorrect spaces.

![image](https://user-images.githubusercontent.com/56097729/204191608-22e9c23a-7622-46a5-ba1c-e551e45d6f05.png)


<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Make the docs more readable.

### Additional details

Here is the docs link: https://developer.mozilla.org/zh-CN/docs/Web/API/Window/DOMContentLoaded_event

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
