### PR TITLE
fix(fr/cors): "ressoure" to "ressource"

### DIFF
--- a/files/fr/web/http/cors/index.md
+++ b/files/fr/web/http/cors/index.md
@@ -446,7 +446,7 @@ Access-Control-Allow-Credentials: true
 
 ### `Access-Control-Allow-Methods`
 
-L'en-tête {{HTTPHeader("Access-Control-Allow-Methods")}} indique la ou les méthodes qui sont autorisées pour accéder à la ressoure. Cet en-tête est utilisé dans la réponse à la requête préliminaire (voir ci-avant [les conditions dans lesquelles une requête préliminaire est nécessaire](#preflight)).
+L'en-tête {{HTTPHeader("Access-Control-Allow-Methods")}} indique la ou les méthodes qui sont autorisées pour accéder à la ressource. Cet en-tête est utilisé dans la réponse à la requête préliminaire (voir ci-avant [les conditions dans lesquelles une requête préliminaire est nécessaire](#preflight)).
 
 ```
 Access-Control-Allow-Methods: <methode>[, <methode>]*


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix typo _"ressoure"_ on [fr/docs/Web/HTTP/CORS](https://developer.mozilla.org/fr/docs/Web/HTTP/CORS).

### Motivation

The letter _"c"_ is missing in the word.