### PR TITLE
add zh-CN translation for a subtitle

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/string/fixed/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/string/fixed/index.md
@@ -13,7 +13,7 @@ fixed() 方法创建了一个 \<tt> 标签元素将字符串包裹起来，从�
 str.fixed()
 ```
 
-### Return value
+### 返回值
 
 返回一个表示 {{HTMLElement("tt")}} HTML 元素的字符串。
 


### PR DESCRIPTION
### Description

String.prototype.fixed() 中有一个小标题没有翻译成中文。
A subtitle in String.prototype.fixed() has not been translated into zh-CN.