### PR TITLE
chore: replace `WebRTCSidebar` in ko

### DIFF
--- a/files/ko/web/api/rtcpeerconnection/currentlocaldescription/index.md
+++ b/files/ko/web/api/rtcpeerconnection/currentlocaldescription/index.md
@@ -16,7 +16,7 @@ tags:
 browser-compat: api.RTCPeerConnection.currentLocalDescription
 ---
 
-{{DefaultAPISidebar("WebRTC")}}
+{{APIRef("WebRTC")}}
 
 읽기 속성인 `RTCPeerConnection.currentLocalDescription`은 가장 최근에 {{domxref("RTCPeerConnection")}}가 성공적으로 네고시에이션을 마치고 원격 피어와 연결된, 연결인터페이스의 로컬 엔드를 설명하는 {{domxref("RTCSessionDescription")}} 객체를 반환합니다. 이외에도 설명에 의해 offer 혹은 answer가 처음으로 인스턴스화 되면 ICE 에이전트에 의해 이미 생성됬을수도 있는 ICE candidate 목록이 포함되어 있습니다.
 

--- a/files/ko/web/api/rtcpeerconnection/currentlocaldescription/index.md
+++ b/files/ko/web/api/rtcpeerconnection/currentlocaldescription/index.md
@@ -2,18 +2,6 @@
 title: RTCPeerConnection.currentLocalDescription
 slug: Web/API/RTCPeerConnection/currentLocalDescription
 translation_of: Web/API/RTCPeerConnection/currentLocalDescription
-page-type: web-api-instance-property
-tags:
-  - API
-  - Media
-  - Property
-  - RTCPeerConnection
-  - Read-only
-  - Reference
-  - SDP
-  - WebRTC
-  - currentLocalConnection
-browser-compat: api.RTCPeerConnection.currentLocalDescription
 ---
 
 {{APIRef("WebRTC")}}
@@ -66,4 +54,4 @@ else {
 
 - {{domxref("RTCPeerConnection.setLocalDescription()")}}, {{domxref("RTCPeerConnection.pendingLocalDescription")}}, {{domxref("RTCPeerConnection.localDescription")}}
 - {{domxref("RTCPeerConnection.setRemoteDescription()")}}, {{domxref("RTCPeerConnection.remoteDescription")}}, {{domxref("RTCPeerConnection.pendingRemoteDescription")}}, {{domxref("RTCPeerConnection.currentRemoteDescription")}}
-- [WebRTC](/en-US/docs/Web/API/WebRTC_API)
+- [WebRTC](/ko/docs/Web/API/WebRTC_API)

--- a/files/ko/web/api/rtcpeerconnection/currentlocaldescription/index.md
+++ b/files/ko/web/api/rtcpeerconnection/currentlocaldescription/index.md
@@ -18,7 +18,7 @@ browser-compat: api.RTCPeerConnection.currentLocalDescription
 
 {{APIRef("WebRTC")}}
 
-읽기 속성인 `RTCPeerConnection.currentLocalDescription`은 가장 최근에 {{domxref("RTCPeerConnection")}}가 성공적으로 네고시에이션을 마치고 원격 피어와 연결된, 연결인터페이스의 로컬 엔드를 설명하는 {{domxref("RTCSessionDescription")}} 객체를 반환합니다. 이외에도 설명에 의해 offer 혹은 answer가 처음으로 인스턴스화 되면 ICE 에이전트에 의해 이미 생성됬을수도 있는 ICE candidate 목록이 포함되어 있습니다.
+읽기 속성인 **`RTCPeerConnection.currentLocalDescription`** 은 가장 최근에 {{domxref("RTCPeerConnection")}}가 성공적으로 네고시에이션을 마치고 원격 피어와 연결된, 연결인터페이스의 로컬 엔드를 설명하는 {{domxref("RTCSessionDescription")}} 객체를 반환합니다. 이외에도 설명에 의해 offer 혹은 answer가 처음으로 인스턴스화 되면 ICE 에이전트에 의해 이미 생성됬을수도 있는 ICE candidate 목록이 포함되어 있습니다.
 
 `currentLocalDescription`을 바꾸기 위해서는, 이 값을 설정하도록 연쇄 이벤트를 작동시키는 {{domxref("RTCPeerConnection.setLocalDescription()")}}를 호출하십시오. 이 연쇄 이벤트가 어떻게 값을 바꾸고, 왜 즉시 값이 바뀌지 않는지에 대해 궁금하다면, {{SectionOnPage("/en-US/docs/Web/API/WebRTC_API/Connectivity", "Pending and current descriptions")}}를 살펴보십시오.
 

--- a/files/ko/web/api/rtcpeerconnection/currentlocaldescription/index.md
+++ b/files/ko/web/api/rtcpeerconnection/currentlocaldescription/index.md
@@ -2,11 +2,23 @@
 title: RTCPeerConnection.currentLocalDescription
 slug: Web/API/RTCPeerConnection/currentLocalDescription
 translation_of: Web/API/RTCPeerConnection/currentLocalDescription
+page-type: web-api-instance-property
+tags:
+  - API
+  - Media
+  - Property
+  - RTCPeerConnection
+  - Read-only
+  - Reference
+  - SDP
+  - WebRTC
+  - currentLocalConnection
+browser-compat: api.RTCPeerConnection.currentLocalDescription
 ---
 
-{{WebRTCSidebar}}
+{{DefaultAPISidebar("WebRTC")}}
 
-읽기 속성인 **`RTCPeerConnection.currentLocalDescription`**은 가장 최근에 {{domxref("RTCPeerConnection")}}가 성공적으로 네고시에이션을 마치고 원격 피어와 연결된, 연결인터페이스의 로컬 엔드를 설명하는 {{domxref("RTCSessionDescription")}} 객체를 반환합니다. 이외에도 설명에 의해 offer 혹은 answer가 처음으로 인스턴스화 되면 ICE 에이전트에 의해 이미 생성됬을수도 있는 ICE candidate 목록이 포함되어 있습니다.
+읽기 속성인 `RTCPeerConnection.currentLocalDescription`은 가장 최근에 {{domxref("RTCPeerConnection")}}가 성공적으로 네고시에이션을 마치고 원격 피어와 연결된, 연결인터페이스의 로컬 엔드를 설명하는 {{domxref("RTCSessionDescription")}} 객체를 반환합니다. 이외에도 설명에 의해 offer 혹은 answer가 처음으로 인스턴스화 되면 ICE 에이전트에 의해 이미 생성됬을수도 있는 ICE candidate 목록이 포함되어 있습니다.
 
 `currentLocalDescription`을 바꾸기 위해서는, 이 값을 설정하도록 연쇄 이벤트를 작동시키는 {{domxref("RTCPeerConnection.setLocalDescription()")}}를 호출하십시오. 이 연쇄 이벤트가 어떻게 값을 바꾸고, 왜 즉시 값이 바뀌지 않는지에 대해 궁금하다면, {{SectionOnPage("/en-US/docs/Web/API/WebRTC_API/Connectivity", "Pending and current descriptions")}}를 살펴보십시오.
 
@@ -54,4 +66,4 @@ else {
 
 - {{domxref("RTCPeerConnection.setLocalDescription()")}}, {{domxref("RTCPeerConnection.pendingLocalDescription")}}, {{domxref("RTCPeerConnection.localDescription")}}
 - {{domxref("RTCPeerConnection.setRemoteDescription()")}}, {{domxref("RTCPeerConnection.remoteDescription")}}, {{domxref("RTCPeerConnection.pendingRemoteDescription")}}, {{domxref("RTCPeerConnection.currentRemoteDescription")}}
-- [WebRTC](/ko/docs/Web/Guide/API/WebRTC)
+- [WebRTC](/en-US/docs/Web/API/WebRTC_API)

--- a/files/ko/web/api/rtcpeerconnection/currentremotedescription/index.md
+++ b/files/ko/web/api/rtcpeerconnection/currentremotedescription/index.md
@@ -2,18 +2,6 @@
 title: RTCPeerConnection.currentRemoteDescription
 slug: Web/API/RTCPeerConnection/currentRemoteDescription
 translation_of: Web/API/RTCPeerConnection/currentRemoteDescription
-page-type: web-api-instance-property
-tags:
-  - API
-  - Media
-  - Property
-  - RTCPeerConnection
-  - Read-only
-  - Reference
-  - SDP
-  - WebRTC
-  - currentRemoteDescription
-browser-compat: api.RTCPeerConnection.currentRemoteDescription
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/ko/web/api/rtcpeerconnection/currentremotedescription/index.md
+++ b/files/ko/web/api/rtcpeerconnection/currentremotedescription/index.md
@@ -2,11 +2,23 @@
 title: RTCPeerConnection.currentRemoteDescription
 slug: Web/API/RTCPeerConnection/currentRemoteDescription
 translation_of: Web/API/RTCPeerConnection/currentRemoteDescription
+page-type: web-api-instance-property
+tags:
+  - API
+  - Media
+  - Property
+  - RTCPeerConnection
+  - Read-only
+  - Reference
+  - SDP
+  - WebRTC
+  - currentRemoteDescription
+browser-compat: api.RTCPeerConnection.currentRemoteDescription
 ---
 
-{{WebRTCSidebar}}
+{{APIRef("WebRTC")}}
 
-읽기 속성인 **`RTCPeerConnection.currentRemoteDescription`**은 마지막 {{domxref("RTCPeerConnection")}} 이후 가장 최근에 원격 유저와의 네고시에이션 및 연결을 성공적으로 마친 연결의 원격 엔드 포인트를 알려주는 {{domxref("RTCSessionDescription")}} 객체를 반환합니다. 추가적으로 이 속성은 description에 의해 표현되는 마지막 offer 및 answer가 처음 시작되면 ICE 에이전트에 의해 생성이 되었을 수도 있는 모든 ICE candidate들의 리스트를 포함합니다.
+읽기 속성인 `RTCPeerConnection.currentRemoteDescription`은 마지막 {{domxref("RTCPeerConnection")}} 이후 가장 최근에 원격 유저와의 네고시에이션 및 연결을 성공적으로 마친 연결의 원격 엔드 포인트를 알려주는 {{domxref("RTCSessionDescription")}} 객체를 반환합니다. 추가적으로 이 속성은 description에 의해 표현되는 마지막 offer 및 answer가 처음 시작되면 ICE 에이전트에 의해 생성이 되었을 수도 있는 모든 ICE candidate들의 리스트를 포함합니다.
 
 `currentRemoteDescription`를 바꾸기 위해서는, {{domxref("RTCPeerConnection.setRemoteDescription()")}}를 호출해서 이 값이 설정되도록 만들어주는 연속된 이벤트를 활성화하십시오. 왜 바꾸는 것이 바로 적용이 안되는지 및 어떻게 작동하는지 더 자세히 알고 싶다면, {{SectionOnPage("/en-US/docs/Web/API/WebRTC_API/Connectivity", "Pending and current descriptions")}}를 참조하십시오.
 
@@ -27,13 +39,11 @@ sessionDescription = RTCPeerConnection.currentRemoteDescription;
 아래 예제는 `currentRemoteDescription` 를 확인하고 객체의 `type` 및 `sdp` 필드를 경고로 띄워줍니다.
 
 ```js
-var pc = new RTCPeerConnection();
-…
-var sd = pc.currentRemoteDescription;
+const pc = new RTCPeerConnection();
+// ...
+const sd = pc.currentRemoteDescription;
 if (sd) {
-  alert("Local session: type='" +
-        sd.type + "'; sdp description='" +
-        sd.sdp + "'");
+  alert(`Local session: type='${sd.type}'; sdp description='${sd.sdp}'`);
 }
 else {
   alert("No local session yet.");
@@ -52,4 +62,4 @@ else {
 
 - {{domxref("RTCPeerConnection.setRemoteDescription()")}}, {{domxref("RTCPeerConnection.pendingRemoteDescription")}}, {{domxref("RTCPeerConnection.remoteDescription")}}
 - {{domxref("RTCPeerConnection.setRemoteDescription()")}}, {{domxref("RTCPeerConnection.remoteDescription")}}, {{domxref("RTCPeerConnection.pendingRemoteDescription")}}, {{domxref("RTCPeerConnection.currentRemoteDescription")}}
-- [WebRTC](/ko/docs/Web/Guide/API/WebRTC)
+- [WebRTC](/en-US/docs/Web/API/WebRTC_API)

--- a/files/ko/web/api/rtcpeerconnection/localdescription/index.md
+++ b/files/ko/web/api/rtcpeerconnection/localdescription/index.md
@@ -4,14 +4,16 @@ slug: Web/API/RTCPeerConnection/localDescription
 translation_of: Web/API/RTCPeerConnection/localDescription
 ---
 
-{{WebRTCSidebar}}{{SeeCompatTable}}
+{{DefaultAPISidebar("WebRTC")}}
 
-읽기 속성인 **`RTCPeerConnection.localDescription`**는 연결의 로컬 엔드에 대한 세션을 설명하는 {{domxref("RTCSessionDescription")}}를 반환합니다. 아직 설정이 안되어있다면, **null** 입니다.
+{{SeeCompatTable}}
+
+읽기 속성인 `RTCPeerConnection.localDescription`는 연결의 로컬 엔드에 대한 세션을 설명하는 {{domxref("RTCSessionDescription")}}를 반환합니다. 아직 설정이 안되어있다면, **null** 입니다.
 
 ## Syntax
 
 ```js
-var sessionDescription = peerConnection.localDescription;
+const sessionDescription = peerConnection.localDescription;
 ```
 
 기본적으로 반환 값은 해당 속성이 `null`이 아닐 때에만 {{domxref("RTCPeerConnection.pendingLocalDescription")}}의 값입니다. 그렇지 않은 경우에는 {{domxref("RTCPeerConnection.currentLocalDescription")}}의 값이 반환됩니다. 이 알고리즘 및 사용하는 이유에 대한 자세한 설명은 {{SectionOnPage("/en-US/docs/Web/API/WebRTC_API/Connectivity", "Pending and current descriptions")}}를 참조하십시오.
@@ -21,13 +23,11 @@ var sessionDescription = peerConnection.localDescription;
 아래의 예시에서는 `localDescription`를 확인하고, {{domxref("RTCSessionDescription")}} 객체의 타입과 sdp필드를 담고있는 경고를 띄웁니다.
 
 ```js
-var pc = new RTCPeerConnection();
-…
-var sd = pc.localDescription;
+const pc = new RTCPeerConnection();
+// ...
+const sd = pc.localDescription;
 if (sd) {
-  alert("Local session: type='" +
-        sd.type + "'; sdp description='" +
-        sd.sdp + "'");
+  alert(`Local session: type='${sd.type}'; sdp description='${sd.sdp}'`);
 }
 else {
   alert("No local session yet.");

--- a/files/ko/web/api/rtcpeerconnection/localdescription/index.md
+++ b/files/ko/web/api/rtcpeerconnection/localdescription/index.md
@@ -4,7 +4,7 @@ slug: Web/API/RTCPeerConnection/localDescription
 translation_of: Web/API/RTCPeerConnection/localDescription
 ---
 
-{{DefaultAPISidebar("WebRTC")}}
+{{APIRef("WebRTC")}}
 
 {{SeeCompatTable}}
 

--- a/files/ko/web/api/webrtc_api/adapter.js/index.md
+++ b/files/ko/web/api/webrtc_api/adapter.js/index.md
@@ -2,11 +2,18 @@
 title: Improving compatibility using WebRTC adapter.js
 slug: Web/API/WebRTC_API/adapter.js
 translation_of: Web/API/WebRTC_API/adapter.js
+page-type: guide
+tags:
+  - API
+  - Audio
+  - Guide
+  - Video
+  - WebRTC
 ---
 
-{{WebRTCSidebar}}
+{{DefaultAPISidebar("WebRTC")}}
 
-WebRTC [사양](http://www.w3.org/TR/webrtc/)은 비교적 인정적이지만, 모든 브라우저가 모든 기능이 구현되어 있는 것은 아니다. 또한, 일부 브라우저는 여전히 일부 혹은 모든 WebRTC API에 접두사가 붙어 있는상황이다. 이러한 문제에 대해 수동적으로 코딩을 할 수 있지만, 더 쉬운 방법이 있다.WebRTC 단체는 다른 브라우저의 WebRTC 구현에서 호환성 문제를 해결하기 위해 [WebRTC 어댑터를 GitHub에서 제공한다.](https://github.com/webrtc/adapter/) 어댑터는 WebRTC가 지원되는 모든 브라우저에서 "그냥 작동"되도록 당신이 작성한 코드가 사양에 적합하도록 해 주는 JavaScript 코드 모음이다. 더이상 접두사 API를 조건부로 사용하거나 다른 해결 방법을 구현할 필요가 없다.
+WebRTC [사양](https://www.w3.org/TR/webrtc/)은 비교적 인정적이지만, 모든 브라우저가 모든 기능이 구현되어 있는 것은 아니다. 또한, 일부 브라우저는 여전히 일부 혹은 모든 WebRTC API에 접두사가 붙어 있는상황이다. 이러한 문제에 대해 수동적으로 코딩을 할 수 있지만, 더 쉬운 방법이 있다.WebRTC 단체는 다른 브라우저의 WebRTC 구현에서 호환성 문제를 해결하기 위해 [WebRTC 어댑터를 GitHub에서 제공한다.](https://github.com/webrtc/adapter/) 어댑터는 WebRTC가 지원되는 모든 브라우저에서 "그냥 작동"되도록 당신이 작성한 코드가 사양에 적합하도록 해 주는 JavaScript 코드 모음이다. 더이상 접두사 API를 조건부로 사용하거나 다른 해결 방법을 구현할 필요가 없다.
 
 > **참고:** WebRTC 및 지원 브라우저에서 API 용어의 기능과 이름 지정이 지속적으로 변경되고 있기 때문에, 일반적으로 이 어댑터의 사용을 권장한다.
 

--- a/files/ko/web/api/webrtc_api/adapter.js/index.md
+++ b/files/ko/web/api/webrtc_api/adapter.js/index.md
@@ -2,13 +2,6 @@
 title: Improving compatibility using WebRTC adapter.js
 slug: Web/API/WebRTC_API/adapter.js
 translation_of: Web/API/WebRTC_API/adapter.js
-page-type: guide
-tags:
-  - API
-  - Audio
-  - Guide
-  - Video
-  - WebRTC
 ---
 
 {{DefaultAPISidebar("WebRTC")}}

--- a/files/ko/web/api/webrtc_api/protocols/index.md
+++ b/files/ko/web/api/webrtc_api/protocols/index.md
@@ -2,9 +2,25 @@
 title: WebRTC 프로토콜 소개
 slug: Web/API/WebRTC_API/Protocols
 translation_of: Web/API/WebRTC_API/Protocols
+page-type: guide
+tags:
+  - API
+  - Audio
+  - Beginner
+  - Draft
+  - Guide
+  - ICE
+  - Media
+  - NAT
+  - SDP
+  - STUN
+  - TURN
+  - Video
+  - WebRTC
+  - WebRTC API
 ---
 
-{{WebRTCSidebar}}
+{{DefaultAPISidebar("WebRTC")}}
 
 이 글은 WebRTC API에 대한 프로토콜을 소개하기 위해 작성 되었습니다.
 

--- a/files/ko/web/api/webrtc_api/protocols/index.md
+++ b/files/ko/web/api/webrtc_api/protocols/index.md
@@ -2,22 +2,6 @@
 title: WebRTC 프로토콜 소개
 slug: Web/API/WebRTC_API/Protocols
 translation_of: Web/API/WebRTC_API/Protocols
-page-type: guide
-tags:
-  - API
-  - Audio
-  - Beginner
-  - Draft
-  - Guide
-  - ICE
-  - Media
-  - NAT
-  - SDP
-  - STUN
-  - TURN
-  - Video
-  - WebRTC
-  - WebRTC API
 ---
 
 {{DefaultAPISidebar("WebRTC")}}

--- a/files/ko/web/api/webrtc_api/signaling_and_video_calling/index.md
+++ b/files/ko/web/api/webrtc_api/signaling_and_video_calling/index.md
@@ -399,7 +399,7 @@ Negotiation 프로세스를 시작하기 위해, 우리가 연결하고자 하�
 
 `createOffer()`이나 다른 fulfillment 핸들러에서 에러가 발생한다면, `reportError()`함수가 실행되어 에러를 보고한다.
 
-`setLocalDescription()`의 fulfillment 핸들러가 실행되면, ICE agent는 [`icecandidate`](/en-US/docs/Web/API/RTCPeerConnection/icecandidate_event)event들을 처리하기 시작한다.
+`setLocalDescription()`의 fulfillment 핸들러가 실행되면, ICE agent는 [`icecandidate`](/ko/docs/Web/API/RTCPeerConnection/icecandidate_event)event들을 처리하기 시작한다.
 
 #### Session negotiation
 

--- a/files/ko/web/api/webrtc_api/signaling_and_video_calling/index.md
+++ b/files/ko/web/api/webrtc_api/signaling_and_video_calling/index.md
@@ -4,14 +4,14 @@ slug: Web/API/WebRTC_API/Signaling_and_video_calling
 translation_of: Web/API/WebRTC_API/Signaling_and_video_calling
 ---
 
-{{WebRTCSidebar}}
+{{DefaultAPISidebar("WebRTC")}}
 
-> **참고:** s이 글은 편집 및 검토가 필요하다. [도움을 줄 수 있는 방법](/docs/MDN/Contribute/Howto/Do_an_editorial_review)을 살펴보자.WebRTC는 아직까지 **실험적인 기술이다.**
-> 일부의 기술 스펙이 안정화가 되지 않았기 때문에 각 브라우져에서 사용가능한 [호환성 정보](/ko/docs/Web/API/WebRTC_API/Signaling_and_video_calling#Browser_compatibility)를 확인해야한다. 또한, 기술의 문법과 패턴들은 스펙이 바뀌는 것처럼 브라우져의 버전이 높아진다면 변경될 수 있다.
+> **참고:** 이 글은 편집 및 검토가 필요하다. [도움을 줄 수 있는 방법](/docs/MDN/Contribute/Howto/Do_an_editorial_review)을 살펴보자.WebRTC는 아직까지 **실험적인 기술이다.**
+> 일부의 기술 스펙이 안정화가 되지 않았기 때문에 각 브라우져에서 사용가능한 [호환성 정보](#browser_compatibility)를 확인해야한다. 또한, 기술의 문법과 패턴들은 스펙이 바뀌는 것처럼 브라우져의 버전이 높아진다면 변경될 수 있다.
 
 ## Summary
 
-[WebRTC](/ko/docs/Web/API/WebRTC_API) 는 리얼 타임 음성, 영상, 데이터 교환을 할 수 있는 완전한 p2p 기술이다. [다른 곳에서 논의한 것 처럼](/ko/docs/Web/API/WebRTC_API/Session_lifetime#Establishing_a_connection) 서로 다른 네트워크에 있는 2개의 디바이스들을 서로 위치시키기 위해서는, 각 디바이스들의 위치를 발견하는 방법과 미디어 포맷 협의가 필요하다. 이 프로세스를 **시그널링** **signaling** 이라 부르고 각 디바이스들을 상호간에 동의된 서버(socket.io 혹은 websocket을 이용한 서버)에 연결시킨다. 이 서버는 각 디바이스들이 **negotiation**(협의) 메세지들을 교환할 수 있도록 한다.
+[WebRTC](/ko/docs/Web/API/WebRTC_API) 는 리얼 타임 음성, 영상, 데이터 교환을 할 수 있는 완전한 p2p 기술이다. [다른 곳에서 논의한 것 처럼](/en-US/docs/Web/API/WebRTC_API/Session_lifetime#establishing_a_connection) 서로 다른 네트워크에 있는 2개의 디바이스들을 서로 위치시키기 위해서는, 각 디바이스들의 위치를 발견하는 방법과 미디어 포맷 협의가 필요하다. 이 프로세스를 **시그널링** **signaling** 이라 부르고 각 디바이스들을 상호간에 동의된 서버(socket.io 혹은 websocket을 이용한 서버)에 연결시킨다. 이 서버는 각 디바이스들이 **negotiation**(협의) 메세지들을 교환할 수 있도록 한다.
 
 이 글에서 우리는 더 나아가 유저들간에 양방향으로 화상 통화가 되는 예제인 [WebSocket chat](https://mdn-samples.mozilla.org/s/websocket-chat)(웹소켓 문서를 작성하기 위해 만들어졌으며, 링크는 곧 활성화 될 것이다. 아직은 온라인으로 테스트가 불가능하다.)을 작동이 되도록 만들 예정이다. 이것에 관해 [샘플](https://mdn-samples.mozilla.org/s/webrtc-from-chat) 을 확인해 보거나 Github에서 전체 [프로젝트](https://github.com/mdn/samples-server/tree/master/s/webrtc-from-chat)를 확인해볼 수 있다.
 
@@ -23,13 +23,13 @@ translation_of: Web/API/WebRTC_API/Signaling_and_video_calling
 
 두 디바이스들 사이에 WebRTC 커넥션을 만들기 위해, 인터넷 네트워크에서 그 둘을 연결 시키는 작업을 해줄 **signaling server** 가 필요하다. 어떻게 이 서버를 만들고 실제로 시그널링 과정이 어떻게 되는지 살펴보자.
 
-가장 먼저, 시그널링 서버 자체가 필요하다. WebRTC는 시그널링 정보에 관한 transport 메커니즘을 제시하진 않는다. 두 피어들 사이에서 해리포터의 부엉이처럼 시그널링에 관련된 정보들을 전달해줄 수 있는 것이면 [WebSocket](/ko/docs/Web/API/WebSocket_API) 이든 [XMLHttpRequest](/ko/docs/Web/API/XMLHttpRequest) 든 상관없다.
+가장 먼저, 시그널링 서버 자체가 필요하다. WebRTC는 시그널링 정보에 관한 transport 메커니즘을 제시하진 않는다. 두 피어들 사이에서 해리포터의 부엉이처럼 시그널링에 관련된 정보들을 전달해줄 수 있는 것이면 [WebSocket](/en-US/docs/Web/API/WebSockets_API) 이든 [XMLHttpRequest](/ko/docs/Web/API/XMLHttpRequest) 든 상관없다.
 
 여기서 중요한 점은 시그널링 서버는 시그널링 데이터 내용을 몰라도 된다는 것이다. 비록 이것은 [SDP](https://www.gitbook.com/book/gustnxodjs/webrtc-kor/edit#) 이지만, 몰라도 큰 문제가 되진 않는다. 메세지의 내용들은 그저 시그널링 서버를 통해 상대편으로 가기만 하면된다. 중요한 점은 ICE subsystem이 신호 데이터를 다른 피어에게 보내도록 지시하면, 다른 피어는 이 정보를 수신하여 자체 ICE subsystem에 전달하는 방법을 알고 있다는 것이다.
 
 ### Readying the chat server for signaling
 
-이 [chat server](https://github.com/mdn/samples-server/tree/master/s/websocket-chat) 는 클라이언트와 서버 사이에 [WebSocket API](/ko/docs/Web/API/WebSocket_API)을 통해 JSON string으로 데이터를 전송한다. 서버는 새로운 유저를 등록하는 것, username을 세팅하는 것, 채팅 메세지를 전송하는 것 등등의 작업들을 하기 위해 다양한 메세지 타입들을 다룬다. 시그널링과 ICE negotiation 을 서버가 처리하기 위해서 코드를 작성해야한다. 모든 로그인된 유저들에게 브로드캐스팅하는 것이 아니라, 특정한 유저에게 직접 메세지를 전달해야한다. 그리고 서버가 따로 처리할 필요 없이, 수신된 원하지 않은 메세지 타입들을 처리한다. 이를 통해 여러 서버를 만들 필요없이 동일한 서버를 이용하여 시그널 메시지를 보낼 수 있다. 이 개념은 WebRTC가 아니라 WebSocket에 관한 개념이다.
+이 [chat server](https://github.com/mdn/samples-server/tree/master/s/websocket-chat) 는 클라이언트와 서버 사이에 [WebSocket API](/en-US/docs/Web/API/WebSockets_API)을 통해 JSON string으로 데이터를 전송한다. 서버는 새로운 유저를 등록하는 것, username을 세팅하는 것, 채팅 메세지를 전송하는 것 등등의 작업들을 하기 위해 다양한 메세지 타입들을 다룬다. 시그널링과 ICE negotiation 을 서버가 처리하기 위해서 코드를 작성해야한다. 모든 로그인된 유저들에게 브로드캐스팅하는 것이 아니라, 특정한 유저에게 직접 메세지를 전달해야한다. 그리고 서버가 따로 처리할 필요 없이, 수신된 원하지 않은 메세지 타입들을 처리한다. 이를 통해 여러 서버를 만들 필요없이 동일한 서버를 이용하여 시그널 메시지를 보낼 수 있다. 이 개념은 WebRTC가 아니라 WebSocket에 관한 개념이다.
 
 이제, WebRTC 시그널링을 지원하는 chat server를 만들기 위해 어떻게 해야하는지 보자. 앞으로 나오는 코드들은 [chatserver.js](https://github.com/mdn/samples-server/tree/master/s/webrtc-from-chat/chatserver.js) 안에 있는 코드이다.
 
@@ -112,7 +112,7 @@ SDP를 서로 교환한 후에, 두 피어들은 **ICE candidate**(ICE 후보)�
 
 각 ICE 메세지들은 두 개의 컴퓨터를 서로 연결하기 위한 정보들에 덧붙여 프로토콜(TCP or UDP), IP 주소, 포트 넘버, 커넥션 타입 등을 제안한다. 여기에는 NAT 혹은 다른 복잡한 네트워킹을 포함한다.
 
-> **참고:** 중요. ICE negotiation 동안 너의 코드가 해야할 것은 오직 ICE layer에서 외부로 나갈 candidate들을 선택하는 것과, [`onicecandidate`](/ko/docs/Web/API/RTCPeerConnection/onicecandidate)handler가 불렸을 때 시그널링 서버를 통해 그것들을 다른 피어에 보내는 것이다. 그리고 시그널링 서버로부터 ICE candidate 메세지를 받고 [`RTCPeerConnection.addIceCandidate()`](/ko/docs/Web/API/RTCPeerConnection/addIceCandidate)를 호출하여 너의 ICE layer에 그들을 전달한다. 그것 뿐이다. 정확히 무엇을 하는지 알기 전까진, 더 이상 깊이 생각하지 말자!
+> **참고:** 중요. ICE negotiation 동안 너의 코드가 해야할 것은 오직 ICE layer에서 외부로 나갈 candidate들을 선택하는 것과, [`icecandidate_event`](/ko/docs/Web/API/RTCPeerConnection/icecandidate_event)handler가 불렸을 때 시그널링 서버를 통해 그것들을 다른 피어에 보내는 것이다. 그리고 시그널링 서버로부터 ICE candidate 메세지를 받고 [`RTCPeerConnection.addIceCandidate()`](/ko/docs/Web/API/RTCPeerConnection/addIceCandidate)를 호출하여 너의 ICE layer에 그들을 전달한다. 그것 뿐이다. 정확히 무엇을 하는지 알기 전까진, 더 이상 깊이 생각하지 말자!
 
 너의 시그널링 서버가 이제 해야할 일은 요청된 메세지를 보내는 것이다. 부가적으로 login/authentication 같은 기능들이 필요할 수도 있는데, 자세한 내용은 달라질 수 있다.
 
@@ -138,7 +138,7 @@ Naomi와 Priya는 채팅 소프트웨어를 사용해 대화에 참여했고 Nao
 
 만약 조건들이 바뀐다면, 예를들어 네트워크 커넥션이 악화되면, 하나 혹은 양 피어들은 낮은 bandwidth의 미디어 해상도로 바꾸거나 다른 코덱을 사용하자고 제안할 것이다. 다음 candidate 교환에서 양 피어 모두 새로운 포맷에 동의한다면, 다른 미디어 포맷 혹은 다른 코덱으로 바뀔 수도 있다.
 
-부가적으로 만약 ICE layer 내부의 프로세스를 더 자세히 이해하고 싶다면 [RFC 5245: Interactive Connectivity Establishment](http://tools.ietf.org/html/5245),[section 2.6 ("Concluding ICE")](https://tools.ietf.org/html/rfc5245#section-2.6) 를 참조해라. ICE layer가 준비 되자마자 candiate들이 교환되고 미디어들은 통신되기 시작한다는 것을 기억해라. 이 모든 것은 뒤에서 알아서 돌아간다. 우리의 역할은 그저 시그널링 서버를 통해 candidate들을 서로에게 보내는 것이다.
+부가적으로 만약 ICE layer 내부의 프로세스를 더 자세히 이해하고 싶다면 [RFC 5245: Interactive Connectivity Establishment](https://tools.ietf.org/html/5245),[section 2.6 ("Concluding ICE")](https://tools.ietf.org/html/rfc5245#section-2.6) 를 참조해라. ICE layer가 준비 되자마자 candiate들이 교환되고 미디어들은 통신되기 시작한다는 것을 기억해라. 이 모든 것은 뒤에서 알아서 돌아간다. 우리의 역할은 그저 시그널링 서버를 통해 candidate들을 서로에게 보내는 것이다.
 
 ## The client application
 
@@ -162,7 +162,7 @@ Naomi와 Priya는 채팅 소프트웨어를 사용해 대화에 참여했고 Nao
       </div>
 ```
 
-위에 있는 page structure은 [`<div>`](/ko/docs/Web/HTML/Element/div)태그를 이용하고 CSS 사용을 허용함으로써 페이지 레이아웃 전체를 구성한다. 여기서는 레이아웃에 관한 자세한 내용은 스킵하지만, 위의 코드가 어떻게 돌아가는지 확인해보자. [take a look at the CSS](https://www.gitbook.com/book/gustnxodjs/webrtc-kor/edit#) on Github. 두개의 [`<video>`](/ko/docs/Web/HTML/Element/video) 중 하나는 너의 self video이고 다른 하나는 상대방의 video를 위한 요소이다.
+위에 있는 page structure은 [`<div>`](/ko/docs/Web/HTML/Element/div)태그를 이용하고 CSS 사용을 허용함으로써 페이지 레이아웃 전체를 구성한다. 여기서는 레이아웃에 관한 자세한 내용은 스킵하지만, 위의 코드가 어떻게 돌아가는지 확인해보자. [take a look at the CSS](https://www.gitbook.com/book/gustnxodjs/webrtc-kor/edit#) on Github. 두개의 [`<video>`](/ko/docs/Web/HTML/Element/Video) 중 하나는 너의 self video이고 다른 하나는 상대방의 video를 위한 요소이다.
 
 `id`가 "`received_video`" 인 `<video>`element는 연결된 상대방으로부터 수신되는 비디오를 보여주는 곳이다. `autoplay`attribute는 비디오가 도달하기 시작하면 즉시 재생시키는 역할을 한다. 이것은 따로 재생에 관련된 코드를 처리할 필요를 없애준다. `id`가 "`local_video`" 인 `<video>`element에는 너의 카메라의 영상이 나오게된다. `muted` attribute는 너의 로컬 오디오를 음소거한다.
 
@@ -184,7 +184,7 @@ function sendToServer(msg) {
 }
 ```
 
-전달된 메세지 object는 [`JSON.stringify()`](/ko/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)함수에 의해 JSON string으로 바뀐다. 그 후, WebSocket 커넥션의 [`send()`](/ko/docs/Web/API/WebSocket/send)함수를 통해 서버로 전달된다.
+전달된 메세지 object는 [`JSON.stringify()`](/ko/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)함수에 의해 JSON string으로 바뀐다. 그 후, WebSocket 커넥션의 [`send()`](/en-US/docs/Web/API/WebSocket/send)함수를 통해 서버로 전달된다.
 
 #### UI to start a call
 
@@ -226,7 +226,7 @@ function handleUserlistMsg(msg) {
 
 #### Starting a call
 
-통화를 하고 싶은 유저의 username을 클릭을 하면, [`click`](/ko/docs/Web/Events/click) event의 handler인`invite()`함수가 실행된다.
+통화를 하고 싶은 유저의 username을 클릭을 하면, [`click`](/ko/docs/Web/API/Element/click_event) event의 handler인`invite()`함수가 실행된다.
 
 ```js
 var mediaConstraints = {
@@ -263,9 +263,9 @@ function invite(evt) {
 
 그 다음에 call을 하려는 유저의 이름을 `targetUsername`변수 안에 넣고 `createPeerConnection()`함수를 실행시킨다. 이 함수는 [`RTCPeerConnection`](/ko/docs/Web/API/RTCPeerConnection) 의 기본적인 구성과 기능을 수행한다.
 
-`RTCPeerConnection` 이 생성되면, [`Navigator.mediaDevices.getUserMedia`](/ko/docs/Web/API/Navigator/mediaDevices/getUserMedia)함수를 통해 유저의 카메라와 마이크에 권한을 요청한다. 카메라와 마이크에서 나오는 로컬 스트림을 로컬 비디오 preview의 [`srcObject`](/ko/docs/Web/API/MediaElement/srcObject)property에 설정한다. 그리고 [`<video>`](/ko/docs/Web/HTML/Element/video)element가 자동으로 들어오는 비디오를 재생하도록 구성되었기 때문에, stream은 로컬 preview box에서 재생을 시작한다.
+`RTCPeerConnection` 이 생성되면, [`Navigator.mediaDevices.getUserMedia`](/en-US/docs/Web/API/MediaDevices/getUserMedia)함수를 통해 유저의 카메라와 마이크에 권한을 요청한다. 카메라와 마이크에서 나오는 로컬 스트림을 로컬 비디오 preview의 [`srcObject`](/ko/docs/Web/API/MediaElement/srcObject)property에 설정한다. 그리고 [`<video>`](/ko/docs/Web/HTML/Element/Video)element가 자동으로 들어오는 비디오를 재생하도록 구성되었기 때문에, stream은 로컬 preview box에서 재생을 시작한다.
 
-그 다음에 [`RTCPeerConnection`](/ko/docs/Web/API/RTCPeerConnection)에 stream을 추가하기 위해 [`myPeerConnection.addStream()`](/ko/docs/Web/API/RTCPeerConnection/addStream)함수를 실행한다. WebRTC 커녁션이 완전히 준비되지 않았더라도 WebRTC 커넥션에 stream을 보내기 시작한다.
+그 다음에 [`RTCPeerConnection`](/ko/docs/Web/API/RTCPeerConnection)에 stream을 추가하기 위해 [`myPeerConnection.addStream()`](/en-US/docs/Web/API/RTCPeerConnection/addStream)함수를 실행한다. WebRTC 커녁션이 완전히 준비되지 않았더라도 WebRTC 커넥션에 stream을 보내기 시작한다.
 
 만약 local media stream을 가져오는 동안 에러가 발생한다면, `catch` clause가 `handleGetUserMediaError()`함수를 불러 필요에 따라 유저에게 적절한 에러 메세지를 보여줄 것이다.
 
@@ -320,9 +320,9 @@ function createPeerConnection() {
 // …
 ```
 
-웹서버와 같은 호스트에 STUN/TURN 서버를 돌리고 있기 때문에, STUN/TURN 서버의 도메인 이름을 [`location.hostname`](/ko/docs/Web/API/Location/hostname)을 사용하여 설정했다. 만약 다른 서버의 STUN/TURN 서버를 사용한다면 urls 값을 그 서버로 바꿔주면 된다.
+웹서버와 같은 호스트에 STUN/TURN 서버를 돌리고 있기 때문에, STUN/TURN 서버의 도메인 이름을 [`location.hostname`](/en-US/docs/Web/API/Location/hostname)을 사용하여 설정했다. 만약 다른 서버의 STUN/TURN 서버를 사용한다면 urls 값을 그 서버로 바꿔주면 된다.
 
-`RTCPeerConnection`을 만들 때, call을 구성하는 파라미터들을 명시해줘야한다. 가장 중요한 것은 STUN/TURN 서버의 리스트([ICE](/ko/docs/Glossary/ICE) layer에서 caller와 callee의 경로를 찾는데 사용되는 서버)를 담고 있는 `iceServers`이다**(주의. 웹소켓을 이용한 시그널링 서버와 전혀 다른 개념이다)**. WebRTC는 두 피어가 방화벽이나 NAT 뒤에 숨어 있어도, 각 피어들의 서로 연결될 수 있도록 피어간 연결 경로를 찾아주는 프로토콜(STUN, TURN)을 사용한다.
+`RTCPeerConnection`을 만들 때, call을 구성하는 파라미터들을 명시해줘야한다. 가장 중요한 것은 STUN/TURN 서버의 리스트([ICE](/en-US/docs/Glossary/ICE) layer에서 caller와 callee의 경로를 찾는데 사용되는 서버)를 담고 있는 `iceServers`이다**(주의. 웹소켓을 이용한 시그널링 서버와 전혀 다른 개념이다)**. WebRTC는 두 피어가 방화벽이나 NAT 뒤에 숨어 있어도, 각 피어들의 서로 연결될 수 있도록 피어간 연결 경로를 찾아주는 프로토콜(STUN, TURN)을 사용한다.
 
 > **참고:** 직접 만든 혹은 사용할 권한을 가지고 있는 STUN/TURN 서버를 사용해야 한다.
 
@@ -347,23 +347,23 @@ function createPeerConnection() {
 위에 있는 이벤트 핸들러 중 처음 두 개는 필수이다. WebRTC로 스트리밍된 미디어와 관련된 것들을 다루기위해 두 핸들러를 설정해야한다. [`removestream`](/ko/docs/Web/Reference/Events/removestream)event는 스트리밍이 중단된 것을 감지하는데 유용하다. 따라서 아마 이것도 사용하게 될 것이다. 남아 있는 4개는 필수적인 것은 아니나, 직접 사용해보자. 이것들 외에도 다른 이벤트들을 사용할 수 있으나 여기에서는 다루지 않겠다. 각 핸들러에 관한 요약 설명이다.
 
 - {{domxref("RTCPeerConnection.onicecandidate")}}
-  - : 로컬 ICE layer는 시그널링 서버를 통해 다른 피어에 ICE candidate를 전송하고자 할 때, 너의 [`icecandidate`](/ko/docs/Web/Events/icecandidate)event handler를 호출한다.
+  - : 로컬 ICE layer는 시그널링 서버를 통해 다른 피어에 ICE candidate를 전송하고자 할 때, 너의 [`icecandidate`](/en-US/docs/Web/API/RTCPeerConnection/icecandidate_event)event handler를 호출한다.
 - {{domxref("RTCPeerConnection.onaddstream")}}
   - : [`addstream`](/ko/docs/Web/Events/addstream)event를 위한 이 핸들러는 너의 커넥션에 remote stream이 추가된 것을 알려주기 위해, 로컬 WebRTC layer에 의해 불려진다. 예를들어, 이것은 들어오는 stream을 element에 연결시켜 디스플레이 되게 만들 때 사용된다. 더 자세한 내용은 [Receiving new streams](/ko/docs/Web/API/WebRTC_API/Signaling_and_video_calling?document_saved=true#Receiving_new_streams) 을 참조해라.
 - {{domxref("RTCPeerConnection.onremovestream")}}
-  - : 커넥션에서 remote가 stream을 제거할 때, `onaddstream`의 반대인 `onremovestream은` [`removestream`](/ko/docs/Web/Events/removestream) event을 처리하기위해 실행된다.
+  - : 커넥션에서 remote가 stream을 제거할 때, `onaddstream`의 반대인 `onremovestream은` [`removestream`](/en-US/docs/Web/API/RTCPeerConnection/removestream_event) event을 처리하기위해 실행된다.
 - {{domxref("RTCPeerConnection.oniceconnectionstatechange")}}
-  - : ICE 커넥션의 상태 변경을 알리기위해 ICE layer가 [`iceconnectionstatechange`](/ko/docs/Web/Events/iceconnectionstatechange) event 를 보낸다. 이것을 통해 커넥션이 실패하거나 끊어지는 것을 알 수 있다. 이 것에 대한 예제를 아래의 [ICE connection state](/ko/docs/Web/API/WebRTC_API/Signaling_and_video_calling?document_saved=true#ICE_connection_state) 에서 볼 것이다.
+  - : ICE 커넥션의 상태 변경을 알리기위해 ICE layer가 [`iceconnectionstatechange`](/en-US/docs/Web/API/RTCPeerConnection/iceconnectionstatechange_event) event 를 보낸다. 이것을 통해 커넥션이 실패하거나 끊어지는 것을 알 수 있다. 이 것에 대한 예제를 아래의 [ICE connection state](/ko/docs/Web/API/WebRTC_API/Signaling_and_video_calling?document_saved=true#ICE_connection_state) 에서 볼 것이다.
 - {{domxref("RTCPeerConnection.onicegatheringstatechange")}}
-  - : 하나의 상태에서 다른 상태(예를들어, candidate를 모으기 시작하거나 negotiation이 끝났을 때)로 ICE agent의 candidate 수집 프로세스가 변하면, ICE layer는 [`icegatheringstatechange`](/ko/docs/Web/Events/icegatheringstatechange) event를 보낸다. 아래의 [ICE gathering state](/ko/docs/Web/API/WebRTC_API/Signaling_and_video_calling?document_saved=true#ICE_gathering_state) 을 참조해라.
+  - : 하나의 상태에서 다른 상태(예를들어, candidate를 모으기 시작하거나 negotiation이 끝났을 때)로 ICE agent의 candidate 수집 프로세스가 변하면, ICE layer는 [`icegatheringstatechange`](/en-US/docs/Web/API/RTCPeerConnection/icegatheringstatechange_event) event를 보낸다. 아래의 [ICE gathering state](/ko/docs/Web/API/WebRTC_API/Signaling_and_video_calling?document_saved=true#ICE_gathering_state) 을 참조해라.
 - {{domxref("RTCPeerConnection.onsignalingstatechange")}}
-  - : 시그널링 프로세스의 state가 바뀌게 될 때, WebRTC 인프라는 너에게 [`signalingstatechange`](/ko/docs/Web/Events/signalingstatechange) message를 보낸다. [Signaling state](https://www.gitbook.com/book/gustnxodjs/webrtc-kor/edit#) 에서 코드를 볼 수 있다.
+  - : 시그널링 프로세스의 state가 바뀌게 될 때, WebRTC 인프라는 너에게 [`signalingstatechange`](/en-US/docs/Web/API/RTCPeerConnection/signalingstatechange_event) message를 보낸다. [Signaling state](https://www.gitbook.com/book/gustnxodjs/webrtc-kor/edit#) 에서 코드를 볼 수 있다.
 - {{domxref("RTCPeerConnection.onnegotiationneeded")}}
   - : 이 함수는 WebRTC 인프라가 session negotiation 프로세스를 새로 시작해야할 때마다 불린다. 이것의 일은 callee에게 offer를 생성 후 전달하고, 우리에게 연결을 할 것인지 물어보는 것이다. 어떻게 처리하는지 [Starting negotiation](/ko/docs/Web/API/WebRTC_API/Signaling_and_video_calling?document_saved=true#Starting_negotiation) 를 참조해라.
 
 #### Starting negotiation
 
-Caller가 자신의 [`RTCPeerConnection`](/ko/docs/Web/API/RTCPeerConnection)과 media stream을 생성하고 [Starting a call](/ko/docs/Web/API/WebRTC_API/Signaling_and_video_calling?document_saved=true#Starting_a_call)에서 보이는 것처럼 커넥션에 추가하면, 브라우져는 다른 피어와 커넥션이 준비가 될 때 [`negotiationneeded`](/ko/docs/Web/Events/negotiationneeded) event를 활성화 시킬 것이다. 밑에는 이벤트를 핸들링하는 코드이다.
+Caller가 자신의 [`RTCPeerConnection`](/ko/docs/Web/API/RTCPeerConnection)과 media stream을 생성하고 [Starting a call](/ko/docs/Web/API/WebRTC_API/Signaling_and_video_calling?document_saved=true#Starting_a_call)에서 보이는 것처럼 커넥션에 추가하면, 브라우져는 다른 피어와 커넥션이 준비가 될 때 [`negotiationneeded`](/en-US/docs/Web/API/RTCPeerConnection/negotiationneeded_event) event를 활성화 시킬 것이다. 밑에는 이벤트를 핸들링하는 코드이다.
 
 ```js
 function handleNegotiationNeededEvent() {
@@ -384,7 +384,7 @@ function handleNegotiationNeededEvent() {
 
 Negotiation 프로세스를 시작하기 위해, 우리가 연결하고자 하는 피어에게 SDP offer를 생성하고 전송해야한다. 이 offer는 커넥션에 로컬로 추가한 media stream 정보(call의 다른 피어에게 전달하고 싶은 비디오)와 ICE layer에 의해 미리 모아 놓은 ICE candidates 정보들을 포함해, 커넥션에 지원되는 구성 목록들을 포함한다. [`myPeerConnection.createOffer()`](https://www.gitbook.com/book/gustnxodjs/webrtc-kor/edit#)를 호출함으로써 이 offer를 생성한다. 이 것이 성공한다면(promise에서 fulfill되면), [`myPeerConnection.setLocalDescription()`](https://www.gitbook.com/book/gustnxodjs/webrtc-kor/edit#)으로 생성된 offer 정보를 전달한다.[`myPeerConnection.setLocalDescription()`](/ko/docs/Web/API/RTCPeerConnection/setLocalDescription)은 커넥션에서 자신의 미디어 구성 상태나 연결 정보들을 구성한다.
 
-> **참고:** 기술적으로 말하자면, `createOffer()`에 의해 리턴되는 blob은 [RFC 3264](http://tools.ietf.org/html/3264) offer 이다.
+> **참고:** 기술적으로 말하자면, `createOffer()`에 의해 리턴되는 blob은 [RFC 3264](https://tools.ietf.org/html/3264) offer 이다.
 
 `setLocalDescription()`이 완료되어 promise를 리턴하면, description 이 유효하고 세팅 되었음을 알 수 있다. 그 이후에 local description을 포함하는 새로운 `"video-offer"`message를 만들어 시그널링 서버를 통해 다른 피어에게 전송한다. 이 offer는 다음과 같은 내용을 가진다.
 
@@ -399,7 +399,7 @@ Negotiation 프로세스를 시작하기 위해, 우리가 연결하고자 하�
 
 `createOffer()`이나 다른 fulfillment 핸들러에서 에러가 발생한다면, `reportError()`함수가 실행되어 에러를 보고한다.
 
-`setLocalDescription()`의 fulfillment 핸들러가 실행되면, ICE agent는 [`icecandidate`](/ko/docs/Web/Events/icecandidate)event들을 처리하기 시작한다.
+`setLocalDescription()`의 fulfillment 핸들러가 실행되면, ICE agent는 [`icecandidate`](/en-US/docs/Web/API/RTCPeerConnection/icecandidate_event)event들을 처리하기 시작한다.
 
 #### Session negotiation
 
@@ -432,9 +432,9 @@ function handleVideoOfferMsg(msg) {
 // …
 ```
 
-이 코드는 [Starting a call](/ko/docs/Web/API/WebRTC_API/Signaling_and_video_calling#Starting_a_call)에 있는 `invite()`함수와 매우 비슷하다. 먼저, `createPeerConnection()`함수를 이용해서 [`RTCPeerConnection`](/ko/docs/Web/API/RTCPeerConnection)를 생성하고 구성한다. 그 후에, `"video-offer"`message로부터 얻은 SDP offer를 가지고 caller의 session description을 나타내는 [`RTCSessionDescription`](/ko/docs/Web/API/RTCSessionDescription)object를 생성한다.
+이 코드는 [Starting a call](#starting_a_call)에 있는 `invite()`함수와 매우 비슷하다. 먼저, `createPeerConnection()`함수를 이용해서 [`RTCPeerConnection`](/ko/docs/Web/API/RTCPeerConnection)를 생성하고 구성한다. 그 후에, `"video-offer"`message로부터 얻은 SDP offer를 가지고 caller의 session description을 나타내는 [`RTCSessionDescription`](/ko/docs/Web/API/RTCSessionDescription)object를 생성한다.
 
-그 후에, session description은 [`myPeerConnection.setRemoteDescription()`](/ko/docs/Web/API/RTCPeerConnection/setRemoteDescription) 안으로 전달된다. 이를 통해, 받은 offer를 caller의 session 정보로 저장한다. 설정에 성공했다면, promise fulfillment handler(`then()`clause)은 callee의 카메라와 마이크에 접근하고 stream을 설정하는 등 이전에 `invite()`에서 본 것과 같은 프로세스를 시작한다.
+그 후에, session description은 [`myPeerConnection.setRemoteDescription()`](/en-US/docs/Web/API/RTCPeerConnection/setRemoteDescription) 안으로 전달된다. 이를 통해, 받은 offer를 caller의 session 정보로 저장한다. 설정에 성공했다면, promise fulfillment handler(`then()`clause)은 callee의 카메라와 마이크에 접근하고 stream을 설정하는 등 이전에 `invite()`에서 본 것과 같은 프로세스를 시작한다.
 
 local stream이 작동한다면, 이제 SDP answer를 만든 후 caller에게 보내야 한다.
 
@@ -459,19 +459,19 @@ local stream이 작동한다면, 이제 SDP answer를 만든 후 caller에게 �
 }
 ```
 
-[`RTCPeerConnection.addStream()`](/ko/docs/Web/API/RTCPeerConnection/addStream) 이 성공적으로 완료되었다면, 그 다음 fulfillment handler가 실행될 것이다. SDP answer string을 만들기 위해 [`myPeerConnection.createAnswer()`](/ko/docs/Web/API/RTCPeerConnection/createAnswer)를 실행한다. 커넥션에서 callee의 로컬 description을 설정하기 위해 [`myPeerConnection.setLocalDescription`](/ko/docs/Web/API/RTCPeerConnection/setLocalDescription)에 생성한 SDP를 전달한다.
+[`RTCPeerConnection.addStream()`](/en-US/docs/Web/API/RTCPeerConnection/addStream) 이 성공적으로 완료되었다면, 그 다음 fulfillment handler가 실행될 것이다. SDP answer string을 만들기 위해 [`myPeerConnection.createAnswer()`](/ko/docs/Web/API/RTCPeerConnection/createAnswer)를 실행한다. 커넥션에서 callee의 로컬 description을 설정하기 위해 [`myPeerConnection.setLocalDescription`](/ko/docs/Web/API/RTCPeerConnection/setLocalDescription)에 생성한 SDP를 전달한다.
 
 최종 answer는 caller에게 보내져서, 어떻게 callee에게 닿을 수 있는지 알게해준다. `"video-answer"`message의 `sdp`property에 callee의 answer를 포함하고, caller에게 이 메세지를 전달한다.
 
 에러가 발생하면 `handleGetUserMediaError()`으로 전달되고, [Handling getUserMedia() errors](/ko/docs/Web/API/WebRTC_API/Signaling_and_video_calling#Handling_getUserMedia%28%29_errors)에 잘 설명되어 있다.
 
-> **참고:** caller와 마찬가지로 `setLocalDescription()`fulfillment handler가 실행되면, 브라우져는 callee가 반드시 처리해야하는 [`icecandidate`](/ko/docs/Web/Events/icecandidate)event들을 처리하기 시작한다.
+> **참고:** caller와 마찬가지로 `setLocalDescription()`fulfillment handler가 실행되면, 브라우져는 callee가 반드시 처리해야하는 [`icecandidate`](/en-US/docs/Web/API/RTCPeerConnection/icecandidate_event)event들을 처리하기 시작한다.
 
 ##### Sending ICE candidates
 
-caller가 callee로부터 answer를 받으면 모든 것이 끝났다고 생각할 수 있지만, 그렇지 않다. 뒷단 에서는 각 피어들의 ICE agent들이 열심히 ICE candidate message들을 교환한다. 미디어 통신이 어떻게 연결될 수 있는지에 대한 방법들을 알릴 때까지, 각 피어들은 상대방에게 계속해서 candidate들을 보낸다. 이 candidate들은 너의 시그널링 서버를 통해서 전송되어야 한다. ICE는 너의 시그널링 서버에 대해 모르기 때문에, 너는 [`icecandidate`](/ko/docs/Web/Events/icecandidate)event를 위한 핸들러를 불러서 전송된 candidate 들을 너의 코드로 직접 처리해야한다.
+caller가 callee로부터 answer를 받으면 모든 것이 끝났다고 생각할 수 있지만, 그렇지 않다. 뒷단 에서는 각 피어들의 ICE agent들이 열심히 ICE candidate message들을 교환한다. 미디어 통신이 어떻게 연결될 수 있는지에 대한 방법들을 알릴 때까지, 각 피어들은 상대방에게 계속해서 candidate들을 보낸다. 이 candidate들은 너의 시그널링 서버를 통해서 전송되어야 한다. ICE는 너의 시그널링 서버에 대해 모르기 때문에, 너는 [`icecandidate`](/en-US/docs/Web/API/RTCPeerConnection/icecandidate_event)event를 위한 핸들러를 불러서 전송된 candidate 들을 너의 코드로 직접 처리해야한다.
 
-너의 [`onicecandidate`](/ko/docs/Web/API/RTCPeerConnection/onicecandidate)handler는 `candidate`property가 candidate의 정보를 담고 있는 SDP(단, candidate들의 끝에는`null`이 찍혀있다) 인 이벤트들을 받는다. 이것이 너의 시그널링 서버를 통해 다른 피어에게 전송해야할 것들이다. 밑에 구현 예제가 있다.
+너의 [`onicecandidate`](/ko/docs/Web/API/RTCPeerConnection/icecandidate_event)handler는 `candidate`property가 candidate의 정보를 담고 있는 SDP(단, candidate들의 끝에는`null`이 찍혀있다) 인 이벤트들을 받는다. 이것이 너의 시그널링 서버를 통해 다른 피어에게 전송해야할 것들이다. 밑에 구현 예제가 있다.
 
 ```js
 function handleICECandidateEvent(event) {
@@ -485,7 +485,7 @@ function handleICECandidateEvent(event) {
 }
 ```
 
-이 코드에서 candidate를 포함하는 object를 만들고 다른 피어에 보낸다. `sendToServer()`함수는 위에서 이미 다뤘으며 [Sending messages to the signaling server](/ko/docs/Web/API/WebRTC_API/Signaling_and_video_calling#Sending_messages_to_the_signaling_server)에 코드가 있다. message의 property들이 의미하는 것은 다음과 같다.
+이 코드에서 candidate를 포함하는 object를 만들고 다른 피어에 보낸다. `sendToServer()`함수는 위에서 이미 다뤘으며 [Sending messages to the signaling server](#sending_messages_to_the_signaling_server)에 코드가 있다. message의 property들이 의미하는 것은 다음과 같다.
 
 - `target`
   - : ICE candidate가 보내야하는 곳의 username. 이것을 통해 시그널링 서버가 메세지를 타겟에게 전달한다.
@@ -496,7 +496,7 @@ function handleICECandidateEvent(event) {
 
 메세지의 포맷(시그널링을 처리하는 모든 메세지들은)은 모두 너의 영역이고, 너가 필요한 것에 달렸다. 너가 또다른 필요한 정보가 있다면 추가할 수 있다. 메세지는 그저 JSON stringfied 되어 상대방에게 전달될 뿐이다.
 
-> **참고:** Call의 다른 피어로부터 ICE candidate가 도착할 때, [`icecandidate`](/ko/docs/Web/Events/icecandidate)event가 전송되는 것이 **아님을 항상 명심해라**. 대신에 너 자신이 call을 할 때 보내는 것으로, 너가 원하는 채널을 통해 data를 보낼 수 있다. WebRTC를 처음 접한다면 매우 헷갈릴 것이다.
+> **참고:** Call의 다른 피어로부터 ICE candidate가 도착할 때, [`icecandidate`](/en-US/docs/Web/API/RTCPeerConnection/icecandidate_event)event가 전송되는 것이 **아님을 항상 명심해라**. 대신에 너 자신이 call을 할 때 보내는 것으로, 너가 원하는 채널을 통해 data를 보낼 수 있다. WebRTC를 처음 접한다면 매우 헷갈릴 것이다.
 
 ##### Receiving ICE candidates
 
@@ -517,7 +517,7 @@ function handleNewICECandidateMsg(msg) {
 
 ##### Receiving new streams
 
-리모트 피어가 [`RTCPeerConnection.addStream()`](/ko/docs/Web/API/RTCPeerConnection/addStream)를 부름으로써, 또는 stream format에 대한 renegotiation(재협상)에 의해 새로운 스트림이 커넥션에 추가되었을 때, [`addstream`](/ko/docs/Web/Events/addstream)event가 발생한다. 어떻게 처리하는지 아래 코드를 보자.
+리모트 피어가 [`RTCPeerConnection.addStream()`](/en-US/docs/Web/API/RTCPeerConnection/addStream)를 부름으로써, 또는 stream format에 대한 renegotiation(재협상)에 의해 새로운 스트림이 커넥션에 추가되었을 때, [`addstream`](/en-US/docs/Web/API/RTCPeerConnection/addstream_event)event가 발생한다. 어떻게 처리하는지 아래 코드를 보자.
 
 ```js
 function handleAddStreamEvent(event) {
@@ -526,13 +526,13 @@ function handleAddStreamEvent(event) {
 }
 ```
 
-이 함수는 들어오는 stream을 id가 `"received_video"`인 [`<video>`](/ko/docs/Web/HTML/Element/video)element에 할당하고, 유저가 전화를 받을 수 있도록 버튼을 활성화한다.
+이 함수는 들어오는 stream을 id가 `"received_video"`인 [`<video>`](/ko/docs/Web/HTML/Element/Video)element에 할당하고, 유저가 전화를 받을 수 있도록 버튼을 활성화한다.
 
 이 코드가 제대로 실행된다면, 드디어 다른 피어에서 오는 비디오를 로컬 브라우저에서 볼 수 있게 된다!
 
 ##### Handling the removal of streams
 
-리모트 피어가 [`RTCPeerConnection.removeStream()`](/ko/docs/Web/API/RTCPeerConnection/removeStream)를 호출하여 커넥션으로부터 스트림을 없애면, [`removestream`](/ko/docs/Web/Events/removestream)event가 발생하게 된다.
+리모트 피어가 [`RTCPeerConnection.removeStream()`](/en-US/docs/Web/API/RTCPeerConnection/removeStream)를 호출하여 커넥션으로부터 스트림을 없애면, [`removestream`](/en-US/docs/Web/API/RTCPeerConnection/removeStream)event가 발생하게 된다.
 
 ```js
 function handleRemoveStreamEvent(event) {
@@ -540,7 +540,7 @@ function handleRemoveStreamEvent(event) {
 }
 ```
 
-이 함수는 `closeVideoCall()`함수를 실행시켜 call이 닫히도록 만들고, 다른 커넥션을 시작할 수 있도록 기존 인터페이스를 버린다. 어떻게 코드가 동작하는지 [Ending the call](/ko/docs/Web/API/WebRTC_API/Signaling_and_video_calling#Ending_the_call)을 참조해라.
+이 함수는 `closeVideoCall()`함수를 실행시켜 call이 닫히도록 만들고, 다른 커넥션을 시작할 수 있도록 기존 인터페이스를 버린다. 어떻게 코드가 동작하는지 [Ending the call](#ending_the_call)을 참조해라.
 
 #### Ending the call
 
@@ -593,10 +593,10 @@ function closeVideoCall() {
 }
 ```
 
-2개의 [`<video>`](/ko/docs/Web/HTML/Element/video)element를 참조한 이후에, WebRTC 커넥션이 존재하는지 체크한다. 만약 있다면, call을 끊고 닫는다:
+2개의 [`<video>`](/ko/docs/Web/HTML/Element/Video)element를 참조한 이후에, WebRTC 커넥션이 존재하는지 체크한다. 만약 있다면, call을 끊고 닫는다:
 
 1. 리모트와 로컬 비디오 stream에 대해서, 각 track들 마다 [`MediaTrack.stop()`](/ko/docs/Web/API/MediaTrack/stop)를 실행시킨다.
-2. 양 비디오의 [`HTMLMediaElement.srcObject`](/ko/docs/Web/API/HTMLMediaElement/srcObject)property를 `null`로 바꿔 stream에 관한 모든 참조를 푼다.
+2. 양 비디오의 [`HTMLMediaElement.srcObject`](/en-US/docs/Web/API/HTMLMediaElement/srcObject)property를 `null`로 바꿔 stream에 관한 모든 참조를 푼다.
 3. [`myPeerConnection.close()`](/ko/docs/Web/API/RTCPeerConnection/close)를 불러 [`RTCPeerConnection`](/ko/docs/Web/API/RTCPeerConnection)을 닫는다.
 4. `myPeerConnection`변수의 값을 `null`로 바꿔서 계속 진행중인 call이 없다는 것을 전체 코드가 알게 한다. 이것은 유저가 유저 리스트에서 username을 클릭할 때 사용된다.
 
@@ -626,7 +626,7 @@ ICE connection state가 `"closed"`, 또는`"failed"`, 또는 `"disconnected"`으
 
 ##### ICE signaling state
 
-마찬가지로 [`signalingstatechange`](/ko/docs/Web/Events/signalingstatechange)event를 받을 수 있는데, 시그널링 상태가 `"closed"`으로 바뀌면 call을 완전히 종료시킨다.
+마찬가지로 [`signalingstatechange`](/en-US/docs/Web/API/RTCPeerConnection/signalingstatechange_event)event를 받을 수 있는데, 시그널링 상태가 `"closed"`으로 바뀌면 call을 완전히 종료시킨다.
 
 ```js
   myPeerConnection.onsignalingstatechange = function(event) {

--- a/files/ko/web/api/webrtc_api/using_data_channels/index.md
+++ b/files/ko/web/api/webrtc_api/using_data_channels/index.md
@@ -2,9 +2,21 @@
 title: WebRTC data channel 사용하기
 slug: Web/API/WebRTC_API/Using_data_channels
 translation_of: Web/API/WebRTC_API/Using_data_channels
+page-type: guide
+tags:
+  - Communications
+  - Data Transfer
+  - Draft
+  - Guide
+  - NeedsContent
+  - Networking
+  - RTCDataChannel
+  - WebRTC
+  - WebRTC API
+  - buffering
 ---
 
-{{WebRTCSidebar}}
+{{DefaultAPISidebar('WebRTC')}}
 
 {{domxref("RTCPeerConnection")}} 인터페이스를 사용하여 WebRTC Peerconnction을 연결하면 이제 두 Peer간의 커넥션을 통하여 미디어 데이터를 주고 받을수 있게됩니다. 그뿐아니라 WebRTC로 할수 있는 일은 더 있습니다. 이 가이드에서 우리는 peer connection에 데이터 채널을 추가하는 방법과 임의의 데이터, 즉 우리가 원하는 어떠한 포멧의 데이터들을 안전하게 주고 받는 방법을 배우게 될 것 입니다.
 

--- a/files/ko/web/api/webrtc_api/using_data_channels/index.md
+++ b/files/ko/web/api/webrtc_api/using_data_channels/index.md
@@ -2,18 +2,6 @@
 title: WebRTC data channel 사용하기
 slug: Web/API/WebRTC_API/Using_data_channels
 translation_of: Web/API/WebRTC_API/Using_data_channels
-page-type: guide
-tags:
-  - Communications
-  - Data Transfer
-  - Draft
-  - Guide
-  - NeedsContent
-  - Networking
-  - RTCDataChannel
-  - WebRTC
-  - WebRTC API
-  - buffering
 ---
 
 {{DefaultAPISidebar('WebRTC')}}


### PR DESCRIPTION
### Description
Removed `{{WebRTCSidebar}}` macros and changed to `{{DefaultAPISidebar('WebRTC')}}`

### Additional details
  * add header `page-type`, `tags` which are missing in ko header
  * fixable link flaws and typos are fixed 

### Related issues and pull requests
* issue: #10177
