### PR TITLE
用語集 - XQuery から「技術参考資料」を削除

### DIFF
--- a/files/ja/glossary/xquery/index.md
+++ b/files/ja/glossary/xquery/index.md
@@ -11,7 +11,3 @@ slug: Glossary/XQuery
 
 - [公式ウェブサイト](http://www.w3.org/XML/Query/)
 - Wikipedia の [XQuery](https://ja.wikipedia.org/wiki/XQuery)
-
-### 技術参考資料
-
-- [Firefox から XQuery を使用することについての議論](/ja/docs/Archive/XQuery)

--- a/files/ja/glossary/xquery/index.md
+++ b/files/ja/glossary/xquery/index.md
@@ -9,5 +9,5 @@ slug: Glossary/XQuery
 
 ### 一般知識
 
-- [公式ウェブサイト](http://www.w3.org/XML/Query/)
+- [公式ウェブサイト](https://www.w3.org/XML/Query/)
 - Wikipedia の [XQuery](https://ja.wikipedia.org/wiki/XQuery)


### PR DESCRIPTION
### Description
英語版にはなくなった「技術参考資料」を削除
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

### Additional details

### Related issues and pull requests
https://github.com/mozilla-japan/translation/issues/669