### PR TITLE
add zh-CN translation for some subtitles

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/intl/getcanonicallocales/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/intl/getcanonicallocales/index.md
@@ -9,7 +9,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales
 
 {{EmbedInteractiveExample("pages/js/intl-getcanonicallocales.html")}}
 
-## Syntax
+## 语法
 
 ```plain
 Intl.getCanonicalLocales(locales)
@@ -20,7 +20,7 @@ Intl.getCanonicalLocales(locales)
 - `locales`
   - : 想要规范化的字符串数组。
 
-### Return value
+### 返回值
 
 一个包含规范区域语言代码的数组。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/intl/getcanonicallocales/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/intl/getcanonicallocales/index.md
@@ -11,7 +11,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales
 
 ## 语法
 
-```plain
+```js-nolint
 Intl.getCanonicalLocales(locales)
 ```
 


### PR DESCRIPTION
### Description

Intl.getCanonicalLocales() 中有几个小标题没有翻译成中文。 
Some subtitles in Intl.getCanonicalLocales() has not been translated into zh-CN.