### PR TITLE
Change emscripten links of ko translation

### DIFF
--- a/files/ko/webassembly/c_to_wasm/index.md
+++ b/files/ko/webassembly/c_to_wasm/index.md
@@ -5,7 +5,7 @@ slug: WebAssembly/C_to_wasm
 
 {{WebAssemblySidebar}}
 
-당신이 C/C++ 같은 언어로 새로운 모듈을 작성하고 있다면, 당신은 [Emscripten](/ko/docs/Mozilla/Projects/Emscripten)같은 툴을 이용해서 WebAssembly로 컴파일 할 수 있습니다. 이것이 어떻게 가능한지 봅시다.
+당신이 C/C++ 같은 언어로 새로운 모듈을 작성하고 있다면, 당신은 [Emscripten](https://emscripten.org/)같은 툴을 이용해서 WebAssembly로 컴파일 할 수 있습니다. 이것이 어떻게 가능한지 봅시다.
 
 ## Emscripten 환경 준비하기
 

--- a/files/ko/webassembly/concepts/index.md
+++ b/files/ko/webassembly/concepts/index.md
@@ -66,7 +66,7 @@ WebAssembly는 자바스크립트와는 다른 언어이지만, 자바스크립�
 
 웹어셈블리 생태계는 이제 막 태동하는 단계입니다. 더 많은 도구들이 앞으로 쏟아져나오겠죠. 현재 네가지 방법이 있습니다:
 
-- [엠스크립튼](/ko/docs/Mozilla/Projects/Emscripten)으로 c/c++ 애플리케이션 포팅하기.
+- [엠스크립튼](https://emscripten.org/)으로 c/c++ 애플리케이션 포팅하기.
 - 어셈블리 수준에서 바로 WebAssembly를 작성하거나 생성하기.
 - Rust 응용 프로그램을 작성하고 WebAssembly를 출력으로 지정합니다.
 - TypeScript와 비슷한 [AssemblyScript](https://www.assemblyscript.org/)를 사용하여 WebAssembly바이너리 컴파일.
@@ -75,7 +75,7 @@ WebAssembly는 자바스크립트와는 다른 언어이지만, 자바스크립�
 
 ### C/C++로부터 포팅하기
 
-WASM 코드를 작성하기위한 많은 옵션 중 두 가지는 온라인 Wasm 어셈블러 또는 [Emscripten](/ko/docs/Mozilla/Projects/Emscripten)입니다. 다음과 같은 수많은 WASM 어셈블러 선택 항목이 있습니다.
+WASM 코드를 작성하기위한 많은 옵션 중 두 가지는 온라인 Wasm 어셈블러 또는 [Emscripten](https://emscripten.org/)입니다. 다음과 같은 수많은 WASM 어셈블러 선택 항목이 있습니다.
 
 - [WasmFiddle](https://wasdk.github.io/WasmFiddle/)
 - [WasmFiddle++](https://anonyco.github.io/WasmFiddle/)

--- a/files/ko/webassembly/index.md
+++ b/files/ko/webassembly/index.md
@@ -19,7 +19,7 @@ WebAssembly는 JavaScript와 함께 보완되고 실행되도록 설계되었습
 - [WebAssembly concepts](/ko/docs/WebAssembly/Concepts)
   - : 웹 어셈블리가 무엇인지, 왜 그렇게 유용한지, 어떻게 기존의 웹 플랫폼(혹은 그 이상)에 적응시켜 사용할 수 있는지 기본 개념을 알아봅시다.
 - [Compiling a New C/C++ Module to WebAssembly](/ko/docs/WebAssembly/C_to_wasm)
-  - : [Emscripten](/ko/docs/Mozilla/Projects/Emscripten/) 같은 도구를 사용해서 C/C++ 로 작성된 코드를 .wasm으로 컴파일할 수 있습니다. 어떻게 컴파일할 수 있는지 알아봅시다.
+  - : [Emscripten](https://emscripten.org/) 같은 도구를 사용해서 C/C++ 로 작성된 코드를 .wasm으로 컴파일할 수 있습니다. 어떻게 컴파일할 수 있는지 알아봅시다.
 - [Compiling an Existing C Module to WebAssembly](/ko/docs/WebAssembly/existing_C_to_wasm)
   - : WebAssembly의 핵심 기능은 기존의 C 라이브러리 개발 생태계을 활용해 개발자가 웹에서 사용할 수 있도록하는 것입니다.
 - [Compiling from Rust to WebAssembly](/ko/docs/WebAssembly/rust_to_wasm)


### PR DESCRIPTION
엠스크립튼 링크가 없는 페이지로 연결되는 문제가 있었습니다.
엠스크립튼 공식 홈페이지로 링크를 변경했습니다.