### PR TITLE
Remove deprecated WebRTCSidebar macro from es

### DIFF
--- a/files/es/web/api/webrtc_api/index.md
+++ b/files/es/web/api/webrtc_api/index.md
@@ -7,7 +7,7 @@ tags:
 translation_of: Web/API/WebRTC_API
 ---
 
-{{WebRTCSidebar}}
+{{APIRef("WebRTC")}}
 
 **WebRTC** (_Web real-time communications_ o comunicaciones web en tiempo real) es una tecnología que permite a aplicaciones y sitios web capturar y opcionalmente retransmitir audio/vídeo, así como intercambiar datos arbitrarios entre navegadores sin necesidad de un intermediario. El conjunto de estándares que comprende WebRTC hace posible compartir datos y realizar teleconferencias de igual-a-igual (_peer-to-peer_), sin requerir que el usuario instale complementos (_plug-ins_) o cualquier otro software de terceros.
 

--- a/files/es/web/api/webrtc_api/index.md
+++ b/files/es/web/api/webrtc_api/index.md
@@ -7,7 +7,7 @@ tags:
 translation_of: Web/API/WebRTC_API
 ---
 
-{{APIRef("WebRTC")}}
+{{DefaultAPISidebar("WebRTC")}}
 
 **WebRTC** (_Web real-time communications_ o comunicaciones web en tiempo real) es una tecnología que permite a aplicaciones y sitios web capturar y opcionalmente retransmitir audio/vídeo, así como intercambiar datos arbitrarios entre navegadores sin necesidad de un intermediario. El conjunto de estándares que comprende WebRTC hace posible compartir datos y realizar teleconferencias de igual-a-igual (_peer-to-peer_), sin requerir que el usuario instale complementos (_plug-ins_) o cualquier otro software de terceros.
 

--- a/files/es/web/api/webrtc_api/protocols/index.md
+++ b/files/es/web/api/webrtc_api/protocols/index.md
@@ -4,7 +4,7 @@ slug: Web/API/WebRTC_API/Protocols
 translation_of: Web/API/WebRTC_API/Protocols
 ---
 
-{{WebRTCSidebar}}
+{{APIRef("WebRTC")}}
 
 Este artículo presenta los protocolos sobre los cuales se construye la API WebRTC.
 

--- a/files/es/web/api/webrtc_api/protocols/index.md
+++ b/files/es/web/api/webrtc_api/protocols/index.md
@@ -4,7 +4,7 @@ slug: Web/API/WebRTC_API/Protocols
 translation_of: Web/API/WebRTC_API/Protocols
 ---
 
-{{APIRef("WebRTC")}}
+{{DefaultAPISidebar("WebRTC")}}
 
 Este artículo presenta los protocolos sobre los cuales se construye la API WebRTC.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove deprecated WebRTCSidebar macro from es

Process: replace `{{WebRTCSidebar}}` macro with `{{DefaultAPISidebar("WebRTC")}}` for files in `/web/api/webrtc_api/`

### Motivation

The chore of deprecated macros removal

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Relates to #10177
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
