### PR TITLE
Fix doctype declaration in the French language

### DIFF
--- a/files/fr/glossary/doctype/index.md
+++ b/files/fr/glossary/doctype/index.md
@@ -12,7 +12,7 @@ translation_of: Glossary/Doctype
 original_slug: Glossaire/Doctype
 ---
 
-En {{Glossary("HTML")}}, le doctype est le préambule "`<! DOCTYPE html>`" requis en haut de tous les documents. Son seul but est d'empêcher un {{Glossary("Browser","navigateur")}} de passer en soi-disant [“quirks mode”](/fr/docs/Mode_quirks_de_Mozilla) lors du rendu d'un document ; c'est-à-dire que le doctype "`<!DOCTYPE html>`" garantit que le navigateur fait de son mieux pour suivre les spécifications pertinentes, plutôt que d'utiliser un mode de rendu différent incompatible avec certaines spécifications.
+En {{Glossary("HTML")}}, le doctype est le préambule "`<!DOCTYPE html>`" requis en haut de tous les documents. Son seul but est d'empêcher un {{Glossary("Browser","navigateur")}} de passer en soi-disant [“quirks mode”](/fr/docs/Mode_quirks_de_Mozilla) lors du rendu d'un document ; c'est-à-dire que le doctype "`<!DOCTYPE html>`" garantit que le navigateur fait de son mieux pour suivre les spécifications pertinentes, plutôt que d'utiliser un mode de rendu différent incompatible avec certaines spécifications.
 
 ## Voir aussi
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I removed a space in the doctype declaration description in the French language.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

The previous doctype declaration was invalid.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
