### PR TITLE
Correct errors on the titles of two links

### DIFF
--- a/files/zh-cn/learn/javascript/building_blocks/conditionals/index.md
+++ b/files/zh-cn/learn/javascript/building_blocks/conditionals/index.md
@@ -397,7 +397,7 @@ select.onchange = function() {
 
 {{ EmbedLiveSample('Ternary_operator_example', '100%', 300) }}
 
-在这里，我们有一个[元素表示一个控件，提供一个选项菜单：">`<select>`](/zh-CN/docs/Web/HTML/Element/select)选择主题（黑色或白色）的元素，加上一个简单[是最重要的，\<h6>是最少的。标题元素简要介绍了它介绍的部分的主题。标题信息可以由用户代理使用，例如，自动构建文档的目录。">`<h1>`](/zh-CN/docs/Web/HTML/Element/h1)的显示网站标题。我们也有一个函数叫做`update()`，它将两种颜色作为参数（输入）。网站的背景颜色设置为第一个提供的颜色，其文本颜色设置为第二个提供的颜色。
+在这里，我们有一个[`<select>`](/zh-CN/docs/Web/HTML/Element/select)选择主题（黑色或白色）的元素，加上一个简单[`<h1>`](/zh-CN/docs/Web/HTML/Element/h1)的显示网站标题。我们也有一个函数叫做`update()`，它将两种颜色作为参数（输入）。网站的背景颜色设置为第一个提供的颜色，其文本颜色设置为第二个提供的颜色。
 
 最后，我们还有一个[onchange](/zh-CN/docs/Web/API/GlobalEventHandlers/onchange)事件监听器，用于运行一个包含三元运算符的函数。它以测试条件开始`select.value === 'black'`。如果这返回`true`，我们运行`update()`带有黑色和白色参数的函数，这意味着我们最终得到黑色的背景颜色和白色的文字颜色。如果返回`false`，我们运行`update()`带有白色和黑色参数的函数，这意味着站点颜色被反转。
 

--- a/files/zh-cn/learn/javascript/building_blocks/conditionals/index.md
+++ b/files/zh-cn/learn/javascript/building_blocks/conditionals/index.md
@@ -397,7 +397,7 @@ select.onchange = function() {
 
 {{ EmbedLiveSample('Ternary_operator_example', '100%', 300) }}
 
-在这里，我们有一个[`<select>`](/zh-CN/docs/Web/HTML/Element/select)选择主题（黑色或白色）的元素，加上一个简单[`<h1>`](/zh-CN/docs/Web/HTML/Element/h1)的显示网站标题。我们也有一个函数叫做`update()`，它将两种颜色作为参数（输入）。网站的背景颜色设置为第一个提供的颜色，其文本颜色设置为第二个提供的颜色。
+在这里，我们有一个 [`<select>`](/zh-CN/docs/Web/HTML/Element/select) 选择主题（黑色或白色）的元素，加上一个简单 [`<h1>`](/zh-CN/docs/Web/HTML/Element/h1) 的显示网站标题。我们也有一个函数叫做 `update()`，它将两种颜色作为参数（输入）。网站的背景颜色设置为第一个提供的颜色，其文本颜色设置为第二个提供的颜色。
 
 最后，我们还有一个[onchange](/zh-CN/docs/Web/API/GlobalEventHandlers/onchange)事件监听器，用于运行一个包含三元运算符的函数。它以测试条件开始`select.value === 'black'`。如果这返回`true`，我们运行`update()`带有黑色和白色参数的函数，这意味着我们最终得到黑色的背景颜色和白色的文字颜色。如果返回`false`，我们运行`update()`带有白色和黑色参数的函数，这意味着站点颜色被反转。
 


### PR DESCRIPTION
The title links that link to `<select>` element and `<h1>` element contained too much information.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- Change the title of link that points at introduction of `<select>` element from
```
元素表示一个控件，提供一个选项菜单：">`<select>`
```
to ``<select>``
- Change the title of link that points at introduction of `<h1>` elements from
```
是最重要的，\<h6>是最少的。标题元素简要介绍了它介绍的部分的主题。标题信息可以由用户代理使用，例如，自动构建文档的目录。">`<h1>`
```
to `<h1>`.

### Motivation

The original title contained too much unnecessary and unrelated information. I shorten it to make to easier to understand.

### Additional details

[Commit Link](https://github.com/mdn/translated-content/commit/f40604ad9616de7f97c6b88b576be03d923f6d82)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
