### PR TITLE
chore(redirects): remove unnecessary redirects to en-US

### DIFF
--- a/files/es/_redirects.txt
+++ b/files/es/_redirects.txt
@@ -2191,7 +2191,6 @@
 /es/docs/Web/JavaScript/Guide/Obsolete_Pages/Guía_JavaScript_1.5/Valores	/es/docs/Web/JavaScript/Guide/Grammar_and_types
 /es/docs/Web/JavaScript/Guide/Obsolete_Pages/Guía_JavaScript_1.5/Variables	/es/docs/Web/JavaScript/Guide/Grammar_and_types
 /es/docs/Web/JavaScript/Guide/Obsolete_Pages/Predefined_Functions	/en-US/docs/Web/JavaScript/Guide/Functions
-/es/docs/Web/JavaScript/Guide/Obsolete_Pages/The_Employee_Example	/en-US/docs/Web/JavaScript/Guide/Details_of_the_Object_Model
 /es/docs/Web/JavaScript/Guide/Regular_Expressions/Aserciones	/es/docs/Web/JavaScript/Guide/Regular_Expressions/Assertions
 /es/docs/Web/JavaScript/Guide/Regular_Expressions/Clases_de_caracteres	/es/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes
 /es/docs/Web/JavaScript/Guide/Regular_Expressions/Cuantificadores	/es/docs/Web/JavaScript/Guide/Regular_Expressions/Quantifiers

--- a/files/zh-tw/_redirects.txt
+++ b/files/zh-tw/_redirects.txt
@@ -539,7 +539,6 @@
 /zh-TW/docs/Web/API/Coordinates/longitude	/zh-TW/docs/Web/API/GeolocationCoordinates/longitude
 /zh-TW/docs/Web/API/Coordinates/speed	/zh-TW/docs/Web/API/GeolocationCoordinates/speed
 /zh-TW/docs/Web/API/DOMString	/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/String
-/zh-TW/docs/Web/API/Detecting_device_orientation	/en-US/docs/Web/Events/Detecting_device_orientation
 /zh-TW/docs/Web/API/Document/keyup_event	/zh-TW/docs/Web/API/Element/keyup_event
 /zh-TW/docs/Web/API/Document/width	/zh-TW/docs/Web/API/Element/clientWidth
 /zh-TW/docs/Web/API/DocumentTemp	/zh-TW/docs/Web/API/Document
@@ -850,7 +849,6 @@
 /zh-TW/docs/Web/性能	/zh-TW/docs/Web/Performance
 /zh-TW/docs/WebAPI	/zh-TW/docs/Web/API
 /zh-TW/docs/WebAPI/Battery_Status	/zh-TW/docs/Web/API/Battery_Status_API
-/zh-TW/docs/WebAPI/Detecting_device_orientation	/en-US/docs/Web/Events/Detecting_device_orientation
 /zh-TW/docs/WebAPI/FileHandle	/zh-TW/docs/Web/API/File_and_Directory_Entries_API
 /zh-TW/docs/WebAPI/Managing_screen_orientation	/zh-TW/docs/Web/API/CSS_Object_Model/Managing_screen_orientation
 /zh-TW/docs/WebAPI/Network_Information	/zh-TW/docs/Web/API/Network_Information_API


### PR DESCRIPTION
If these URLs are visited, MDN already suggests the en-US page, even if it redirects to a different en-US page.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Removes unnecessary redirects (currently skipped by the `validate-redirects` script) to `en-US`, as MDN suggests these anyways.

See: https://github.com/mdn/yari/issues/2993#issuecomment-1332081480

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
