### PR TITLE
chore: remove `{{TemplateLink}}` macro

### DIFF
--- a/files/pt-br/conflicting/mdn/writing_guidelines/page_structures/live_samples/index.md
+++ b/files/pt-br/conflicting/mdn/writing_guidelines/page_structures/live_samples/index.md
@@ -168,7 +168,7 @@ Você pode ver um exemplo mais avançado de tal ajuste sobre [a página API do C
 
 O exemplo anterior está certo se você deseja incorporar conteúdo básico de aprendizagem ativa. No entanto, se você quiser lidar com um código complexo, pode tornar-se um pouco estranho para lidar com esse wrapper de classe `oculto`.
 
-Então, outra opção e escreva o código do seu conteúdo de aprendizagem em uma página MDN e, em seguida, incorpora-lo em outra página. Para fazer isso, podemos usar o {{TemplateLink ("EmbedDistLiveSample")}} macro em vez de {{TemplateLink ("EmbedLiveSample")}} macro.
+Então, outra opção e escreva o código do seu conteúdo de aprendizagem em uma página MDN e, em seguida, incorpora-lo em outra página. Para fazer isso, podemos usar o [EmbedDistLiveSample](https://github.com/mdn/yari/blob/main/kumascript/macros/EmbedLiveSample.ejs) macro em vez de [EmbedLiveSample](https://github.com/mdn/yari/blob/main/kumascript/macros/EmbedLiveSample.ejs) macro.
 
 Vamos ver como esse exemplo quando configurado como se estivesse sendo incorporado de uma origem remota:
 

--- a/files/pt-br/mdn/writing_guidelines/writing_style_guide/index.md
+++ b/files/pt-br/mdn/writing_guidelines/writing_style_guide/index.md
@@ -56,7 +56,7 @@ Quando estiver escrevendo qualquer documento é importante conhecer o quanto fal
 
 ### Seções, parágrafos e novas linhas
 
-Use os níveis de cabeçalho em ordem decrescente na hierarquia: {{HTMLElement("h2")}} depois {{HTMLElement("h3")}} depois {{HTMLElement("h4")}}, sem pular níveis. {{HTMLElement("h2")}} é o maior nível permitido, pois {{HTMLElement("h1")}} está reservado para o título da página. Se perceber que precisará de mais de 3 ou 4 níveis de cabeçalho, considere fragmentar seu artigo em artigos menores, ou colocando uma landing page, linkando estes com o {{TemplateLink("Next")}}, {{TemplateLink("Previous")}}, e {{TemplateLink("PreviousNext")}} macros.
+Use os níveis de cabeçalho em ordem decrescente na hierarquia: {{HTMLElement("h2")}} depois {{HTMLElement("h3")}} depois {{HTMLElement("h4")}}, sem pular níveis. {{HTMLElement("h2")}} é o maior nível permitido, pois {{HTMLElement("h1")}} está reservado para o título da página. Se perceber que precisará de mais de 3 ou 4 níveis de cabeçalho, considere fragmentar seu artigo em artigos menores, ou colocando uma landing page, linkando estes com o [Next](https://github.com/mdn/yari/blob/main/kumascript/macros/Next.ejs), [Previous](https://github.com/mdn/yari/blob/main/kumascript/macros/Previous.ejs), e [PreviousNext](https://github.com/mdn/yari/blob/main/kumascript/macros/PreviousNext.ejs) macros.
 
 O Enter (ou Return) do seu teclado inicia um novo parágrafo. Para inserir uma nova linha sem espaço, faça Shift + Enter.
 

--- a/files/ru/conflicting/mdn/writing_guidelines/page_structures/live_samples/index.html
+++ b/files/ru/conflicting/mdn/writing_guidelines/page_structures/live_samples/index.html
@@ -172,7 +172,7 @@ document.addEventListener('keyup', function () {
 
 <p>The previous example is okay if you want to embed basic active learning content. However, if you want to deal with complex code, it can become a bit awkward to deal with that <code>hidden</code> class wrapper.</p>
 
-<p>So another option is to write the code of your learning content on an MDN page and then embed it into another page. To do this we can use the {{TemplateLink("EmbedDistLiveSample")}} macro instead of the {{TemplateLink("EmbedLiveSample")}} macro.</p>
+<p>So another option is to write the code of your learning content on an MDN page and then embed it into another page. To do this we can use the <a href="https://github.com/mdn/yari/blob/main/kumascript/macros/EmbedLiveSample.ejs">EmbedLiveSample</a> macro instead of the {{TemplateLink("EmbedLiveSample")}} macro.</p>
 
 <p>Let's how that sample looks when configured as if it were being embedded from a remote origin:</p>
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Remove the `{{TemplateLink}}` macro.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Its deprecated.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
#5603
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
