### PR TITLE
[ko] translate cors-errors originheadernotadded in ko

### DIFF
--- a/files/ko/web/http/cors/errors/corsoriginheadernotadded/index.md
+++ b/files/ko/web/http/cors/errors/corsoriginheadernotadded/index.md
@@ -1,0 +1,38 @@
+---
+title: "Reason: CORS header 'Origin' cannot be added"
+slug: Web/HTTP/CORS/Errors/CORSOriginHeaderNotAdded
+tags:
+  - CORS
+  - CORSOriginHeaderNotAdded
+  - Cross-Origin
+  - HTTP
+  - HTTPS
+  - 메세지
+  - 문제해결
+  - 보안
+  - 에러
+  - 이유
+  - 콘솔
+translation_of: Web/HTTP/CORS/Errors/CORSOriginHeaderNotAdded
+---
+
+{{HTTPSidebar}}
+
+## 이유
+
+```plain
+Reason: CORS header 'Origin' cannot be added
+```
+
+## 무엇이 잘못되었는가?
+
+사용자 에이전트({{Glossary("user agent")}})가 필요한 {{HTTPHeader("Origin")}}
+헤더를 {{Glossary("HTTP")}} 요청에 추가할 수 없습니다. 모든 CORS 요청에는 `Origin` 헤더가 있어야 합니다.
+
+예를 들어, JavaScript 코드가 여러 도메인의 콘텐츠에 접근할 수 있는 향상된 권한으로 실행되는 경우에 발생할 수 있습니다.
+
+## See also
+
+- [CORS 에러](/en-US/docs/Web/HTTP/CORS/Errors)
+- Glossary: {{Glossary("CORS")}}
+- [CORS 소개](/en-US/docs/Web/HTTP/CORS)

--- a/files/ko/web/http/cors/errors/corsoriginheadernotadded/index.md
+++ b/files/ko/web/http/cors/errors/corsoriginheadernotadded/index.md
@@ -1,19 +1,4 @@
 ---
-title: "Reason: CORS header 'Origin' cannot be added"
-slug: Web/HTTP/CORS/Errors/CORSOriginHeaderNotAdded
-tags:
-  - CORS
-  - CORSOriginHeaderNotAdded
-  - Cross-Origin
-  - HTTP
-  - HTTPS
-  - 메세지
-  - 문제해결
-  - 보안
-  - 에러
-  - 이유
-  - 콘솔
-translation_of: Web/HTTP/CORS/Errors/CORSOriginHeaderNotAdded
 ---
 
 {{HTTPSidebar}}
@@ -31,7 +16,7 @@ Reason: CORS header 'Origin' cannot be added
 
 예를 들어, JavaScript 코드가 여러 도메인의 콘텐츠에 접근할 수 있는 향상된 권한으로 실행되는 경우에 발생할 수 있습니다.
 
-## See also
+## 같이 보기
 
 - [CORS 에러](/en-US/docs/Web/HTTP/CORS/Errors)
 - Glossary: {{Glossary("CORS")}}

--- a/files/ko/web/http/cors/errors/corsoriginheadernotadded/index.md
+++ b/files/ko/web/http/cors/errors/corsoriginheadernotadded/index.md
@@ -1,4 +1,6 @@
 ---
+title: "Reason: CORS header 'Origin' cannot be added"
+slug: Web/HTTP/CORS/Errors/CORSOriginHeaderNotAdded
 ---
 
 {{HTTPSidebar}}


### PR DESCRIPTION

### Description
CORS errors - Reason: CORS header 'Origin' cannot be added 에 대해 한국어 번역을 진행하였습니다.

### Motivation
CORS 관련해서 공부하다가 번역하게 되었습니다.

