### PR TITLE
Remove duplicated frontmatter keys from web folder 7/10 [es]

### DIFF
--- a/files/es/web/javascript/reference/global_objects/aggregateerror/index.md
+++ b/files/es/web/javascript/reference/global_objects/aggregateerror/index.md
@@ -1,13 +1,6 @@
 ---
 title: AggregateError
 slug: Web/JavaScript/Reference/Global_Objects/AggregateError
-tags:
-  - AggregateError
-  - Clase
-  - Experimental
-  - Interfaz
-  - JavaScript
-translation_of: Web/JavaScript/Reference/Global_Objects/AggregateError
 original_slug: Web/JavaScript/Referencia/Objetos_globales/AggregateError
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/@@iterator/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/@@iterator/index.md
@@ -1,15 +1,6 @@
 ---
 title: Array.prototype[@@iterator]()
 slug: Web/JavaScript/Reference/Global_Objects/Array/@@iterator
-tags:
-  - Array
-  - ECMAScript 2015
-  - Iterator
-  - JavaScript
-  - Prototipo
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/@@iterator
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/@@iterator
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/@@species/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/@@species/index.md
@@ -1,12 +1,6 @@
 ---
 title: get Array[@@species]
 slug: Web/JavaScript/Reference/Global_Objects/Array/@@species
-tags:
-  - Array
-  - JavaScript
-  - Prototipo
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/@@species
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/@@species
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/@@unscopables/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/@@unscopables/index.md
@@ -1,13 +1,6 @@
 ---
 title: Array.prototype[@@unscopables]
 slug: Web/JavaScript/Reference/Global_Objects/Array/@@unscopables
-tags:
-  - Array
-  - JavaScript
-  - Matriz
-  - Propiedad
-  - Prototipo
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/@@unscopables
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/@@unscopables
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/array/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/array/index.md
@@ -1,9 +1,7 @@
 ---
 title: Array() constructor
 slug: Web/JavaScript/Reference/Global_Objects/Array/Array
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/Array
 original_slug: Web/JavaScript/Reference/Global_Objects/Array/Array
-browser-compat: javascript.builtins.Array.Array
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/array/at/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/at/index.md
@@ -1,9 +1,7 @@
 ---
 title: Array.prototype.at()
 slug: Web/JavaScript/Reference/Global_Objects/Array/at
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/at
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/at
-browser-compat: javascript.builtins.Array.at
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/array/concat/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/concat/index.md
@@ -1,15 +1,6 @@
 ---
 title: Array.prototype.concat()
 slug: Web/JavaScript/Reference/Global_Objects/Array/concat
-tags:
-  - Array
-  - JavaScript
-  - Métodos
-  - Prototipo
-  - Referencia
-  - array.concat
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/concat
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/concat
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/copywithin/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/copywithin/index.md
@@ -1,15 +1,6 @@
 ---
 title: Array.prototype.copyWithin()
 slug: Web/JavaScript/Reference/Global_Objects/Array/copyWithin
-tags:
-  - Array
-  - ECMAScript 2015
-  - JavaScript
-  - Prototipo
-  - Referencia
-  - metodo
-  - polyfill
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/copyWithin
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/copyWithin
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/entries/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/entries/index.md
@@ -1,15 +1,6 @@
 ---
 title: Array.prototype.entries()
 slug: Web/JavaScript/Reference/Global_Objects/Array/entries
-tags:
-  - Array
-  - ECMAScript 2015
-  - Iterador
-  - Iterator
-  - JavaScript
-  - Prototipo
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/entries
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/entries
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/every/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/every/index.md
@@ -1,14 +1,6 @@
 ---
 title: Array.prototype.every()
 slug: Web/JavaScript/Reference/Global_Objects/Array/every
-tags:
-  - Arreglo
-  - ECMAScript 5
-  - JavaScript
-  - Prototipo
-  - metodo
-  - polyfill
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/every
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/every
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/fill/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/fill/index.md
@@ -1,14 +1,6 @@
 ---
 title: Array.prototype.fill()
 slug: Web/JavaScript/Reference/Global_Objects/Array/fill
-tags:
-  - Array
-  - ECMAScript 2015
-  - JavaScript
-  - Prototipo
-  - metodo
-  - polyfill
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/fill
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/fill
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/filter/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/filter/index.md
@@ -1,15 +1,6 @@
 ---
 title: Array.prototype.filter()
 slug: Web/JavaScript/Reference/Global_Objects/Array/filter
-tags:
-  - Array
-  - ECMAScript 5
-  - JavaScript
-  - Prototipo
-  - Referencia
-  - metodo
-  - polyfill
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/filter
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/filter
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/find/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/find/index.md
@@ -1,15 +1,6 @@
 ---
 title: Array.prototype.find()
 slug: Web/JavaScript/Reference/Global_Objects/Array/find
-tags:
-  - Array
-  - ECMAScript 2015
-  - JavaScript
-  - Prototipo
-  - Referencia
-  - metodo
-  - polyfill
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/find
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/find
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/findindex/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/findindex/index.md
@@ -1,15 +1,6 @@
 ---
 title: Array.prototype.findIndex()
 slug: Web/JavaScript/Reference/Global_Objects/Array/findIndex
-tags:
-  - Array
-  - ECMAScript 2015
-  - JavaScript
-  - Protitipo
-  - Referencia
-  - metodo
-  - polyfill
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/findIndex
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/findIndex
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/flat/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/flat/index.md
@@ -1,13 +1,6 @@
 ---
 title: Array.prototype.flat()
 slug: Web/JavaScript/Reference/Global_Objects/Array/flat
-tags:
-  - Array
-  - JavaScript
-  - Prototipo
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/flat
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/flat
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/flatmap/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/flatmap/index.md
@@ -1,13 +1,6 @@
 ---
 title: Array.prototype.flatMap()
 slug: Web/JavaScript/Reference/Global_Objects/Array/flatMap
-tags:
-  - Array
-  - JavaScript
-  - Prototipo
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/flatMap
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/flatMap
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/foreach/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/foreach/index.md
@@ -1,16 +1,6 @@
 ---
 title: Array.prototype.forEach()
 slug: Web/JavaScript/Reference/Global_Objects/Array/forEach
-tags:
-  - Array
-  - ECMAScript5
-  - JavaScript
-  - JavaScript 1.6
-  - Method
-  - Prototype
-  - Referencia
-  - polyfill
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/forEach
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/forEach
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/from/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/from/index.md
@@ -1,14 +1,6 @@
 ---
 title: Array.from()
 slug: Web/JavaScript/Reference/Global_Objects/Array/from
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Referencia
-  - Vector
-  - metodo
-  - polyfill
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/from
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/from
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/includes/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/includes/index.md
@@ -1,14 +1,6 @@
 ---
 title: Array.prototype.includes()
 slug: Web/JavaScript/Reference/Global_Objects/Array/includes
-tags:
-  - Array
-  - JavaScript
-  - Prototipo
-  - Referencia
-  - metodo
-  - polyfill
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/includes
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/includes
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/index.md
@@ -1,13 +1,6 @@
 ---
 title: Array
 slug: Web/JavaScript/Reference/Global_Objects/Array
-tags:
-  - Array
-  - JavaScript
-  - Matriz unidimensional
-  - Referencia
-  - Vector
-translation_of: Web/JavaScript/Reference/Global_Objects/Array
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/indexof/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/indexof/index.md
@@ -1,14 +1,6 @@
 ---
 title: Array.prototype.indexOf()
 slug: Web/JavaScript/Reference/Global_Objects/Array/indexOf
-tags:
-  - Array
-  - JavaScript
-  - Method
-  - Prototype
-  - Referencia
-  - polyfill
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/indexOf
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/indexOf
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/isarray/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/isarray/index.md
@@ -1,14 +1,6 @@
 ---
 title: Array.isArray()
 slug: Web/JavaScript/Reference/Global_Objects/Array/isArray
-tags:
-  - Array
-  - ECMAScript5
-  - JavaScript
-  - Referencia
-  - metodo
-  - polyfill
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/isArray
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/isArray
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/join/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/join/index.md
@@ -1,14 +1,6 @@
 ---
 title: Array.prototype.join()
 slug: Web/JavaScript/Reference/Global_Objects/Array/join
-tags:
-  - Array
-  - JavaScript
-  - Matriz
-  - Prototipo
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/join
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/join
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/keys/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/keys/index.md
@@ -1,15 +1,6 @@
 ---
 title: Array.prototype.keys()
 slug: Web/JavaScript/Reference/Global_Objects/Array/keys
-tags:
-  - Array
-  - ECMAScript 2015
-  - Iterator
-  - JavaScript
-  - Matriz
-  - Prototipo
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/keys
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/keys
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/lastindexof/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/lastindexof/index.md
@@ -1,16 +1,6 @@
 ---
 title: Array.prototype.lastIndexOf()
 slug: Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf
-tags:
-  - Array
-  - Arreglo
-  - ECMAScript 5
-  - JavaScript
-  - Matriz
-  - Prototipo
-  - metodo
-  - polyfill
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/lastIndexOf
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/length/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/length/index.md
@@ -1,13 +1,6 @@
 ---
 title: Array.prototype.length
 slug: Web/JavaScript/Reference/Global_Objects/Array/length
-tags:
-  - Array
-  - JavaScript
-  - Propiedad
-  - Referencia
-  - Vector
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/length
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/length
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/map/index.md
@@ -1,15 +1,6 @@
 ---
 title: Array.prototype.map()
 slug: Web/JavaScript/Reference/Global_Objects/Array/map
-tags:
-  - Array
-  - Arreglo
-  - Callback
-  - ECMAScript5
-  - Polifill
-  - Prototype
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/map
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/map
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/of/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/of/index.md
@@ -1,13 +1,6 @@
 ---
 title: Array.of()
 slug: Web/JavaScript/Reference/Global_Objects/Array/of
-tags:
-  - Array
-  - ECMAScript 2015
-  - JavaScript
-  - metodo
-  - polyfill
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/of
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/of
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/pop/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/pop/index.md
@@ -1,13 +1,6 @@
 ---
 title: Array.prototype.pop()
 slug: Web/JavaScript/Reference/Global_Objects/Array/pop
-tags:
-  - Array
-  - JavaScript
-  - Prototipo
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/pop
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/pop
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/push/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/push/index.md
@@ -1,13 +1,6 @@
 ---
 title: Array.prototype.push()
 slug: Web/JavaScript/Reference/Global_Objects/Array/push
-tags:
-  - Array
-  - JavaScript
-  - Prototipo
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/push
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/push
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/reduce/index.md
@@ -1,15 +1,6 @@
 ---
 title: Array.prototype.reduce()
 slug: Web/JavaScript/Reference/Global_Objects/Array/Reduce
-tags:
-  - Array
-  - ECMAScript 5
-  - JavaScript
-  - Prototype
-  - Reduce
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/Reduce
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/reduce
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/reduceright/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/reduceright/index.md
@@ -1,14 +1,6 @@
 ---
 title: Array.prototype.reduceRight()
 slug: Web/JavaScript/Reference/Global_Objects/Array/ReduceRight
-tags:
-  - Array
-  - ECMAScript5
-  - JavaScript
-  - JavaScript 1.8
-  - Method
-  - Prototype
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/ReduceRight
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/reduceRight
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/reverse/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/reverse/index.md
@@ -1,12 +1,6 @@
 ---
 title: Array.prototype.reverse()
 slug: Web/JavaScript/Reference/Global_Objects/Array/reverse
-tags:
-  - Array
-  - JavaScript
-  - Prototipo
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/reverse
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/reverse
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/shift/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/shift/index.md
@@ -1,7 +1,6 @@
 ---
 title: Array.prototype.shift()
 slug: Web/JavaScript/Reference/Global_Objects/Array/shift
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/shift
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/shift
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/slice/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/slice/index.md
@@ -1,9 +1,6 @@
 ---
 title: Array.prototype.slice()
 slug: Web/JavaScript/Reference/Global_Objects/Array/slice
-tags:
-  - Arreglo
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/slice
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/slice
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/some/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/some/index.md
@@ -1,14 +1,6 @@
 ---
 title: Array.prototype.some()
 slug: Web/JavaScript/Reference/Global_Objects/Array/some
-tags:
-  - Array
-  - ECMAScript5
-  - JavaScript
-  - Prototipo
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/some
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/some
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/sort/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/sort/index.md
@@ -1,12 +1,6 @@
 ---
 title: Array.prototype.sort()
 slug: Web/JavaScript/Reference/Global_Objects/Array/sort
-tags:
-  - Array
-  - JavaScript
-  - Método(2)
-  - Prototipo
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/sort
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/sort
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/splice/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/splice/index.md
@@ -1,13 +1,6 @@
 ---
 title: Array.prototype.splice()
 slug: Web/JavaScript/Reference/Global_Objects/Array/splice
-tags:
-  - Array
-  - JavaScript
-  - Prototipo
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/splice
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/splice
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/tolocalestring/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/tolocalestring/index.md
@@ -1,7 +1,6 @@
 ---
 title: Array.prototype.toLocaleString()
 slug: Web/JavaScript/Reference/Global_Objects/Array/toLocaleString
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/toLocaleString
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/toLocaleString
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/tostring/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/tostring/index.md
@@ -1,12 +1,6 @@
 ---
 title: Array.prototype.toString()
 slug: Web/JavaScript/Reference/Global_Objects/Array/toString
-tags:
-  - Array
-  - JavaScript
-  - Prototipo
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/toString
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/toString
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/unshift/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/unshift/index.md
@@ -1,13 +1,6 @@
 ---
 title: Array.prototype.unshift()
 slug: Web/JavaScript/Reference/Global_Objects/Array/unshift
-tags:
-  - Array
-  - JavaScript
-  - Prototipo
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/unshift
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/unshift
 ---
 

--- a/files/es/web/javascript/reference/global_objects/array/values/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/values/index.md
@@ -1,14 +1,6 @@
 ---
 title: Array.prototype.values()
 slug: Web/JavaScript/Reference/Global_Objects/Array/values
-tags:
-  - Array
-  - ECMAScript 2015
-  - Iterador
-  - JavaScript
-  - Prototipo
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Array/values
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Array/values
 ---
 

--- a/files/es/web/javascript/reference/global_objects/arraybuffer/@@species/index.md
+++ b/files/es/web/javascript/reference/global_objects/arraybuffer/@@species/index.md
@@ -1,12 +1,6 @@
 ---
 title: get ArrayBuffer[@@species]
 slug: Web/JavaScript/Reference/Global_Objects/ArrayBuffer/@@species
-tags:
-  - ArrayBuffer
-  - JavaScript
-  - Propiedad
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/ArrayBuffer/@@species
 original_slug: Web/JavaScript/Referencia/Objetos_globales/ArrayBuffer/@@species
 ---
 

--- a/files/es/web/javascript/reference/global_objects/arraybuffer/bytelength/index.md
+++ b/files/es/web/javascript/reference/global_objects/arraybuffer/bytelength/index.md
@@ -1,12 +1,6 @@
 ---
 title: ArrayBuffer.prototype.byteLength
 slug: Web/JavaScript/Reference/Global_Objects/ArrayBuffer/byteLength
-tags:
-  - ArrayBuffer
-  - JavaScript
-  - Propiedad
-  - Prototipo
-translation_of: Web/JavaScript/Reference/Global_Objects/ArrayBuffer/byteLength
 original_slug: Web/JavaScript/Referencia/Objetos_globales/ArrayBuffer/byteLength
 ---
 

--- a/files/es/web/javascript/reference/global_objects/arraybuffer/index.md
+++ b/files/es/web/javascript/reference/global_objects/arraybuffer/index.md
@@ -1,9 +1,7 @@
 ---
 title: ArrayBuffer
 slug: Web/JavaScript/Reference/Global_Objects/ArrayBuffer
-translation_of: Web/JavaScript/Reference/Global_Objects/ArrayBuffer
 original_slug: Web/JavaScript/Reference/Global_Objects/ArrayBuffer
-browser-compat: javascript.builtins.ArrayBuffer
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/asyncfunction/index.md
+++ b/files/es/web/javascript/reference/global_objects/asyncfunction/index.md
@@ -1,9 +1,7 @@
 ---
 title: Funciones asíncronas
 slug: Web/JavaScript/Reference/Global_Objects/AsyncFunction
-translation_of: Web/JavaScript/Reference/Global_Objects/AsyncFunction
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Funcionesasíncronas
-browser-compat: javascript.builtins.AsyncFunction
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/boolean/boolean/index.md
+++ b/files/es/web/javascript/reference/global_objects/boolean/boolean/index.md
@@ -1,12 +1,6 @@
 ---
 title: Boolean() constructor
 slug: Web/JavaScript/Reference/Global_Objects/Boolean/Boolean
-tags:
-  - Booleano
-  - Constructor
-  - JavaScript
-  - Referencia
-translation_of: Web/JavaScript/Reference/Global_Objects/Boolean/Boolean
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Boolean/Boolean
 ---
 

--- a/files/es/web/javascript/reference/global_objects/boolean/index.md
+++ b/files/es/web/javascript/reference/global_objects/boolean/index.md
@@ -1,14 +1,6 @@
 ---
 title: Booleano
 slug: Web/JavaScript/Reference/Global_Objects/Boolean
-tags:
-  - Boolean
-  - Clase
-  - Class
-  - Constructor
-  - JavaScript
-  - Referencia
-translation_of: Web/JavaScript/Reference/Global_Objects/Boolean
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Boolean
 ---
 

--- a/files/es/web/javascript/reference/global_objects/boolean/tostring/index.md
+++ b/files/es/web/javascript/reference/global_objects/boolean/tostring/index.md
@@ -1,13 +1,6 @@
 ---
 title: Boolean.prototype.toSource()
 slug: Web/JavaScript/Reference/Global_Objects/Boolean/toString
-tags:
-  - Boolean
-  - JavaScript
-  - Method
-  - Non-standard
-  - Prototype
-translation_of: Web/JavaScript/Reference/Global_Objects/Boolean/toSource
 original_slug: Web/JavaScript/Reference/Global_Objects/Boolean/toSource
 ---
 

--- a/files/es/web/javascript/reference/global_objects/date/getdate/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/getdate/index.md
@@ -1,7 +1,6 @@
 ---
 title: Date.prototype.getDate()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getDate
-translation_of: Web/JavaScript/Reference/Global_Objects/Date/getDate
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Date/getDate
 ---
 

--- a/files/es/web/javascript/reference/global_objects/date/getday/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/getday/index.md
@@ -1,12 +1,6 @@
 ---
 title: Date.prototype.getDay()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getDay
-tags:
-  - Date
-  - JavaScript
-  - Prototype
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Date/getDay
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Date/getDay
 ---
 

--- a/files/es/web/javascript/reference/global_objects/date/getfullyear/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/getfullyear/index.md
@@ -1,13 +1,6 @@
 ---
 title: Date.prototype.getFullYear()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getFullYear
-tags:
-  - Fecha
-  - JavaScript
-  - Prototipo
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Date/getFullYear
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Date/getFullYear
 ---
 

--- a/files/es/web/javascript/reference/global_objects/date/gethours/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/gethours/index.md
@@ -1,7 +1,6 @@
 ---
 title: Date.prototype.getHours()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getHours
-translation_of: Web/JavaScript/Reference/Global_Objects/Date/getHours
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Date/getHours
 ---
 

--- a/files/es/web/javascript/reference/global_objects/date/getmilliseconds/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/getmilliseconds/index.md
@@ -1,13 +1,7 @@
 ---
 title: Date.prototype.getMilliseconds()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getMilliseconds
-tags:
-  - Fecha
-  - Milisegundos
-  - Prototipo
-translation_of: Web/JavaScript/Reference/Global_Objects/Date/getMilliseconds
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Date/getMilliseconds
-browser-compat: javascript.builtins.Date.getMilliseconds
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/date/getminutes/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/getminutes/index.md
@@ -1,7 +1,6 @@
 ---
 title: Date.prototype.getMinutes()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getMinutes
-translation_of: Web/JavaScript/Reference/Global_Objects/Date/getMinutes
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Date/getMinutes
 ---
 

--- a/files/es/web/javascript/reference/global_objects/date/getmonth/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/getmonth/index.md
@@ -1,12 +1,6 @@
 ---
 title: Date.prototype.getMonth()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getMonth
-tags:
-  - Date
-  - JavaScript
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Date/getMonth
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Date/getMonth
 ---
 

--- a/files/es/web/javascript/reference/global_objects/date/getseconds/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/getseconds/index.md
@@ -1,13 +1,6 @@
 ---
 title: Date.prototype.getSeconds()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getSeconds
-tags:
-  - Fecha
-  - JavaScript
-  - Prototipo
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Date/getSeconds
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Date/getSeconds
 ---
 

--- a/files/es/web/javascript/reference/global_objects/date/gettime/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/gettime/index.md
@@ -1,12 +1,6 @@
 ---
 title: Date.prototype.getTime()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getTime
-tags:
-  - Date
-  - Metodo getTime()
-  - Referencia
-  - getTime
-translation_of: Web/JavaScript/Reference/Global_Objects/Date/getTime
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Date/getTime
 ---
 

--- a/files/es/web/javascript/reference/global_objects/date/getutcfullyear/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/getutcfullyear/index.md
@@ -1,7 +1,6 @@
 ---
 title: Date.prototype.getUTCFullYear()
 slug: Web/JavaScript/Reference/Global_Objects/Date/getUTCFullYear
-translation_of: Web/JavaScript/Reference/Global_Objects/Date/getUTCFullYear
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Date/getUTCFullYear
 ---
 

--- a/files/es/web/javascript/reference/global_objects/date/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/index.md
@@ -1,9 +1,7 @@
 ---
 title: Date
 slug: Web/JavaScript/Reference/Global_Objects/Date
-translation_of: Web/JavaScript/Reference/Global_Objects/Date
 original_slug: Web/JavaScript/Referencia/Objetos_Globales/Date
-browser-compat: javascript.builtins.Date
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/date/now/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/now/index.md
@@ -1,12 +1,6 @@
 ---
 title: Date.now()
 slug: Web/JavaScript/Reference/Global_Objects/Date/now
-tags:
-  - Date
-  - JavaScript
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Date/now
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Date/now
 ---
 

--- a/files/es/web/javascript/reference/global_objects/date/parse/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/parse/index.md
@@ -1,11 +1,6 @@
 ---
 title: Date.parse()
 slug: Web/JavaScript/Reference/Global_Objects/Date/parse
-tags:
-  - Date
-  - JavaScript
-  - Method
-translation_of: Web/JavaScript/Reference/Global_Objects/Date/parse
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Date/parse
 ---
 

--- a/files/es/web/javascript/reference/global_objects/date/setfullyear/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/setfullyear/index.md
@@ -1,7 +1,6 @@
 ---
 title: Date.prototype.setFullYear()
 slug: Web/JavaScript/Reference/Global_Objects/Date/setFullYear
-translation_of: Web/JavaScript/Reference/Global_Objects/Date/setFullYear
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Date/setFullYear
 ---
 

--- a/files/es/web/javascript/reference/global_objects/date/setmonth/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/setmonth/index.md
@@ -1,7 +1,6 @@
 ---
 title: Date.prototype.setMonth()
 slug: Web/JavaScript/Reference/Global_Objects/Date/setMonth
-translation_of: Web/JavaScript/Reference/Global_Objects/Date/setMonth
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Date/setMonth
 ---
 

--- a/files/es/web/javascript/reference/global_objects/date/todatestring/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/todatestring/index.md
@@ -1,13 +1,6 @@
 ---
 title: Date.prototype.toDateString()
 slug: Web/JavaScript/Reference/Global_Objects/Date/toDateString
-tags:
-  - Fecha
-  - JavaScript
-  - Prototipo
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Date/toDateString
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Date/toDateString
 ---
 

--- a/files/es/web/javascript/reference/global_objects/date/toisostring/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/toisostring/index.md
@@ -1,12 +1,6 @@
 ---
 title: Date.prototype.toISOString()
 slug: Web/JavaScript/Reference/Global_Objects/Date/toISOString
-tags:
-  - Date
-  - JavaScript
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Date/toISOString
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Date/toISOString
 ---
 

--- a/files/es/web/javascript/reference/global_objects/date/tojson/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/tojson/index.md
@@ -1,7 +1,6 @@
 ---
 title: Date.prototype.toJSON()
 slug: Web/JavaScript/Reference/Global_Objects/Date/toJSON
-translation_of: Web/JavaScript/Reference/Global_Objects/Date/toJSON
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Date/toJSON
 ---
 

--- a/files/es/web/javascript/reference/global_objects/date/tolocaledatestring/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/tolocaledatestring/index.md
@@ -1,7 +1,6 @@
 ---
 title: Date.prototype.toLocaleDateString()
 slug: Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString
-browser-compat: javascript.builtins.Date.toLocaleDateString
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/date/tolocalestring/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/tolocalestring/index.md
@@ -1,7 +1,6 @@
 ---
 title: Date.prototype.toLocaleString()
 slug: Web/JavaScript/Reference/Global_Objects/Date/toLocaleString
-translation_of: Web/JavaScript/Reference/Global_Objects/Date/toLocaleString
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Date/toLocaleString
 ---
 

--- a/files/es/web/javascript/reference/global_objects/date/tolocaletimestring/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/tolocaletimestring/index.md
@@ -1,15 +1,6 @@
 ---
 title: Date.prototype.toLocaleTimeString()
 slug: Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
-tags:
-  - Date
-  - Fecha
-  - Internacionalizacion
-  - JavaScript
-  - Method
-  - Prototype
-  - Referencia
-translation_of: Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Date/toLocaleTimeString
 ---
 

--- a/files/es/web/javascript/reference/global_objects/date/toutcstring/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/toutcstring/index.md
@@ -1,14 +1,6 @@
 ---
 title: Date.prototype.toUTCString()
 slug: Web/JavaScript/Reference/Global_Objects/Date/toUTCString
-tags:
-  - Date
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - UTC
-translation_of: Web/JavaScript/Reference/Global_Objects/Date/toUTCString
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Date/toUTCString
 ---
 

--- a/files/es/web/javascript/reference/global_objects/date/utc/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/utc/index.md
@@ -1,12 +1,6 @@
 ---
 title: Date.UTC()
 slug: Web/JavaScript/Reference/Global_Objects/Date/UTC
-tags:
-  - Date
-  - JavaScript
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Date/UTC
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Date/UTC
 ---
 

--- a/files/es/web/javascript/reference/global_objects/decodeuri/index.md
+++ b/files/es/web/javascript/reference/global_objects/decodeuri/index.md
@@ -1,10 +1,6 @@
 ---
 title: decodeURI()
 slug: Web/JavaScript/Reference/Global_Objects/decodeURI
-tags:
-  - JavaScript
-  - URI
-translation_of: Web/JavaScript/Reference/Global_Objects/decodeURI
 original_slug: Web/JavaScript/Referencia/Objetos_globales/decodeURI
 ---
 

--- a/files/es/web/javascript/reference/global_objects/decodeuricomponent/index.md
+++ b/files/es/web/javascript/reference/global_objects/decodeuricomponent/index.md
@@ -1,11 +1,6 @@
 ---
 title: decodeURIComponent
 slug: Web/JavaScript/Reference/Global_Objects/decodeURIComponent
-tags:
-  - JavaScript
-  - JavaScript Reference
-  - URI
-translation_of: Web/JavaScript/Reference/Global_Objects/decodeURIComponent
 original_slug: Web/JavaScript/Referencia/Objetos_globales/decodeURIComponent
 ---
 

--- a/files/es/web/javascript/reference/global_objects/encodeuri/index.md
+++ b/files/es/web/javascript/reference/global_objects/encodeuri/index.md
@@ -1,10 +1,6 @@
 ---
 title: encodeURI
 slug: Web/JavaScript/Reference/Global_Objects/encodeURI
-tags:
-  - JavaScript
-  - URI
-translation_of: Web/JavaScript/Reference/Global_Objects/encodeURI
 original_slug: Web/JavaScript/Referencia/Objetos_globales/encodeURI
 ---
 

--- a/files/es/web/javascript/reference/global_objects/error/error/index.md
+++ b/files/es/web/javascript/reference/global_objects/error/error/index.md
@@ -1,11 +1,6 @@
 ---
 title: Constructor Error()
 slug: Web/JavaScript/Reference/Global_Objects/Error/Error
-tags:
-  - Constructor
-  - JavaScript
-  - Referencia
-translation_of: Web/JavaScript/Reference/Global_Objects/Error/Error
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Error/constructor_Error
 ---
 

--- a/files/es/web/javascript/reference/global_objects/error/filename/index.md
+++ b/files/es/web/javascript/reference/global_objects/error/filename/index.md
@@ -1,12 +1,6 @@
 ---
 title: Error.prototype.fileName
 slug: Web/JavaScript/Reference/Global_Objects/Error/fileName
-tags:
-  - JavaScript
-  - No estandar
-  - Propiedad
-  - Prototipo
-translation_of: Web/JavaScript/Reference/Global_Objects/Error/fileName
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Error/fileName
 ---
 

--- a/files/es/web/javascript/reference/global_objects/error/index.md
+++ b/files/es/web/javascript/reference/global_objects/error/index.md
@@ -1,10 +1,6 @@
 ---
 title: Error
 slug: Web/JavaScript/Reference/Global_Objects/Error
-tags:
-  - Error
-  - JavaScript
-translation_of: Web/JavaScript/Reference/Global_Objects/Error
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Error
 ---
 

--- a/files/es/web/javascript/reference/global_objects/error/linenumber/index.md
+++ b/files/es/web/javascript/reference/global_objects/error/linenumber/index.md
@@ -1,7 +1,6 @@
 ---
 title: Error.prototype.lineNumber
 slug: Web/JavaScript/Reference/Global_Objects/Error/lineNumber
-translation_of: Web/JavaScript/Reference/Global_Objects/Error/lineNumber
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Error/lineNumber
 ---
 

--- a/files/es/web/javascript/reference/global_objects/error/message/index.md
+++ b/files/es/web/javascript/reference/global_objects/error/message/index.md
@@ -1,7 +1,6 @@
 ---
 title: Error.prototype.message
 slug: Web/JavaScript/Reference/Global_Objects/Error/message
-translation_of: Web/JavaScript/Reference/Global_Objects/Error/message
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Error/message
 ---
 

--- a/files/es/web/javascript/reference/global_objects/error/name/index.md
+++ b/files/es/web/javascript/reference/global_objects/error/name/index.md
@@ -1,12 +1,6 @@
 ---
 title: Error.prototype.name
 slug: Web/JavaScript/Reference/Global_Objects/Error/name
-tags:
-  - Error
-  - JavaScript
-  - Propiedad
-  - Prototipo
-translation_of: Web/JavaScript/Reference/Global_Objects/Error/name
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Error/name
 ---
 

--- a/files/es/web/javascript/reference/global_objects/error/tostring/index.md
+++ b/files/es/web/javascript/reference/global_objects/error/tostring/index.md
@@ -1,11 +1,6 @@
 ---
 title: Error.prototype.toString()
 slug: Web/JavaScript/Reference/Global_Objects/Error/toString
-tags:
-  - JavaScript
-  - Prototipo
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Error/toString
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Error/toString
 ---
 

--- a/files/es/web/javascript/reference/global_objects/escape/index.md
+++ b/files/es/web/javascript/reference/global_objects/escape/index.md
@@ -1,11 +1,6 @@
 ---
 title: escape()
 slug: Web/JavaScript/Reference/Global_Objects/escape
-tags:
-  - JavaScript
-  - Obsoleto
-  - escape
-translation_of: Web/JavaScript/Reference/Global_Objects/escape
 original_slug: Web/JavaScript/Referencia/Objetos_globales/escape
 ---
 

--- a/files/es/web/javascript/reference/global_objects/eval/index.md
+++ b/files/es/web/javascript/reference/global_objects/eval/index.md
@@ -1,10 +1,6 @@
 ---
 title: eval
 slug: Web/JavaScript/Reference/Global_Objects/eval
-tags:
-  - JavaScript
-  - eval
-translation_of: Web/JavaScript/Reference/Global_Objects/eval
 original_slug: Web/JavaScript/Referencia/Objetos_globales/eval
 ---
 

--- a/files/es/web/javascript/reference/global_objects/evalerror/evalerror/index.md
+++ b/files/es/web/javascript/reference/global_objects/evalerror/evalerror/index.md
@@ -1,7 +1,6 @@
 ---
 title: EvalError() constructor
 slug: Web/JavaScript/Reference/Global_Objects/EvalError/EvalError
-browser-compat: javascript.builtins.EvalError.EvalError
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/evalerror/index.md
+++ b/files/es/web/javascript/reference/global_objects/evalerror/index.md
@@ -1,7 +1,6 @@
 ---
 title: EvalError
 slug: Web/JavaScript/Reference/Global_Objects/EvalError
-browser-compat: javascript.builtins.EvalError
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/function/apply/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/apply/index.md
@@ -1,13 +1,6 @@
 ---
 title: Function.prototype.apply()
 slug: Web/JavaScript/Reference/Global_Objects/Function/apply
-tags:
-  - Function
-  - JavaScript
-  - Method
-  - función
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Function/apply
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Function/apply
 ---
 

--- a/files/es/web/javascript/reference/global_objects/function/arguments/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/arguments/index.md
@@ -1,7 +1,6 @@
 ---
 title: Function.arguments
 slug: Web/JavaScript/Reference/Global_Objects/Function/arguments
-translation_of: Web/JavaScript/Reference/Global_Objects/Function/arguments
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Function/arguments
 ---
 

--- a/files/es/web/javascript/reference/global_objects/function/bind/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/bind/index.md
@@ -1,7 +1,6 @@
 ---
 title: Function.prototype.bind()
 slug: Web/JavaScript/Reference/Global_Objects/Function/bind
-translation_of: Web/JavaScript/Reference/Global_Objects/Function/bind
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Function/bind
 ---
 

--- a/files/es/web/javascript/reference/global_objects/function/call/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/call/index.md
@@ -1,11 +1,6 @@
 ---
 title: Function.prototype.call()
 slug: Web/JavaScript/Reference/Global_Objects/Function/call
-tags:
-  - Function
-  - JavaScript
-  - Method
-translation_of: Web/JavaScript/Reference/Global_Objects/Function/call
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Function/call
 ---
 

--- a/files/es/web/javascript/reference/global_objects/function/caller/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/caller/index.md
@@ -1,9 +1,6 @@
 ---
 title: Function.caller
 slug: Web/JavaScript/Reference/Global_Objects/Function/caller
-tags:
-  - Función Javascript No-standard Propiedad
-translation_of: Web/JavaScript/Reference/Global_Objects/Function/caller
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Function/caller
 ---
 

--- a/files/es/web/javascript/reference/global_objects/function/displayname/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/displayname/index.md
@@ -1,7 +1,6 @@
 ---
 title: Function.displayName
 slug: Web/JavaScript/Reference/Global_Objects/Function/displayName
-translation_of: Web/JavaScript/Reference/Global_Objects/Function/displayName
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Function/displayName
 ---
 

--- a/files/es/web/javascript/reference/global_objects/function/function/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/function/index.md
@@ -1,13 +1,6 @@
 ---
 title: Function() constructor
 slug: Web/JavaScript/Reference/Global_Objects/Function/Function
-tags:
-  - Constructor
-  - Function
-  - JavaScript
-  - Referencia
-  - función
-translation_of: Web/JavaScript/Reference/Global_Objects/Function/Function
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Function/Función
 ---
 

--- a/files/es/web/javascript/reference/global_objects/function/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/index.md
@@ -1,15 +1,6 @@
 ---
 title: Function
 slug: Web/JavaScript/Reference/Global_Objects/Function
-tags:
-  - Clase
-  - Class
-  - Declaración
-  - Expresión
-  - Function
-  - JavaScript
-  - función
-translation_of: Web/JavaScript/Reference/Global_Objects/Function
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Function
 ---
 

--- a/files/es/web/javascript/reference/global_objects/function/length/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/length/index.md
@@ -1,11 +1,6 @@
 ---
 title: Function.length
 slug: Web/JavaScript/Reference/Global_Objects/Function/length
-tags:
-  - JavaScript
-  - Propiedad
-  - función
-translation_of: Web/JavaScript/Reference/Global_Objects/Function/length
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Function/length
 ---
 

--- a/files/es/web/javascript/reference/global_objects/function/name/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/name/index.md
@@ -1,7 +1,6 @@
 ---
 title: Function.name
 slug: Web/JavaScript/Reference/Global_Objects/Function/name
-translation_of: Web/JavaScript/Reference/Global_Objects/Function/name
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Function/name
 ---
 

--- a/files/es/web/javascript/reference/global_objects/function/tostring/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/tostring/index.md
@@ -1,7 +1,6 @@
 ---
 title: Function.prototype.toString()
 slug: Web/JavaScript/Reference/Global_Objects/Function/toString
-translation_of: Web/JavaScript/Reference/Global_Objects/Function/toString
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Function/toString
 ---
 

--- a/files/es/web/javascript/reference/global_objects/generator/index.md
+++ b/files/es/web/javascript/reference/global_objects/generator/index.md
@@ -1,15 +1,6 @@
 ---
 title: Generador
 slug: Web/JavaScript/Reference/Global_Objects/Generator
-tags:
-  - ECMAScript2015
-  - ECMAScript6
-  - Generador
-  - Generador Legado
-  - Iterador Legado
-  - JavaScript
-  - Referencia
-translation_of: Web/JavaScript/Reference/Global_Objects/Generator
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Generador
 ---
 

--- a/files/es/web/javascript/reference/global_objects/generator/next/index.md
+++ b/files/es/web/javascript/reference/global_objects/generator/next/index.md
@@ -1,7 +1,6 @@
 ---
 title: Generator.prototype.next()
 slug: Web/JavaScript/Reference/Global_Objects/Generator/next
-translation_of: Web/JavaScript/Reference/Global_Objects/Generator/next
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Generador/next
 ---
 

--- a/files/es/web/javascript/reference/global_objects/generator/return/index.md
+++ b/files/es/web/javascript/reference/global_objects/generator/return/index.md
@@ -1,14 +1,6 @@
 ---
 title: Generator.prototype.return()
 slug: Web/JavaScript/Reference/Global_Objects/Generator/return
-tags:
-  - ECMAScript 2015
-  - Generador
-  - JavaScript
-  - Prototipo
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Generator/return
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Generador/return
 ---
 

--- a/files/es/web/javascript/reference/global_objects/generator/throw/index.md
+++ b/files/es/web/javascript/reference/global_objects/generator/throw/index.md
@@ -1,7 +1,6 @@
 ---
 title: Generator.prototype.throw()
 slug: Web/JavaScript/Reference/Global_Objects/Generator/throw
-translation_of: Web/JavaScript/Reference/Global_Objects/Generator/throw
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Generador/throw
 ---
 

--- a/files/es/web/javascript/reference/global_objects/infinity/index.md
+++ b/files/es/web/javascript/reference/global_objects/infinity/index.md
@@ -1,9 +1,6 @@
 ---
 title: Infinity
 slug: Web/JavaScript/Reference/Global_Objects/Infinity
-tags:
-  - JavaScript
-translation_of: Web/JavaScript/Reference/Global_Objects/Infinity
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Infinity
 ---
 

--- a/files/es/web/javascript/reference/global_objects/internalerror/index.md
+++ b/files/es/web/javascript/reference/global_objects/internalerror/index.md
@@ -1,13 +1,6 @@
 ---
 title: InternalError
 slug: Web/JavaScript/Reference/Global_Objects/InternalError
-tags:
-  - Clase
-  - Class
-  - InternalError
-  - JavaScript
-  - Objeto
-translation_of: Web/JavaScript/Reference/Global_Objects/InternalError
 original_slug: Web/JavaScript/Referencia/Objetos_globales/InternalError
 ---
 

--- a/files/es/web/javascript/reference/global_objects/internalerror/internalerror/index.md
+++ b/files/es/web/javascript/reference/global_objects/internalerror/internalerror/index.md
@@ -1,13 +1,7 @@
 ---
 title: Constructor InternalError()
 slug: Web/JavaScript/Reference/Global_Objects/InternalError/InternalError
-tags:
-  - Constructor
-  - JavaScript
-  - Referencia
-translation_of: Web/JavaScript/Reference/Global_Objects/InternalError/InternalError
-original_slug: >-
-  Web/JavaScript/Referencia/Objetos_globales/InternalError/Constructor_InternalError
+original_slug: Web/JavaScript/Referencia/Objetos_globales/InternalError/Constructor_InternalError
 ---
 
 {{JSRef}} {{non-standard_header}}

--- a/files/es/web/javascript/reference/global_objects/intl/index.md
+++ b/files/es/web/javascript/reference/global_objects/intl/index.md
@@ -1,7 +1,6 @@
 ---
 title: Intl
 slug: Web/JavaScript/Reference/Global_Objects/Intl
-translation_of: Web/JavaScript/Reference/Global_Objects/Intl
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Intl
 ---
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/intl/numberformat/format/index.md
+++ b/files/es/web/javascript/reference/global_objects/intl/numberformat/format/index.md
@@ -1,7 +1,6 @@
 ---
 title: Intl.NumberFormat.prototype.format()
 slug: Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/format
-translation_of: Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/format
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Intl/NumberFormat/format
 ---
 

--- a/files/es/web/javascript/reference/global_objects/intl/numberformat/index.md
+++ b/files/es/web/javascript/reference/global_objects/intl/numberformat/index.md
@@ -1,9 +1,7 @@
 ---
 title: Intl.NumberFormat
 slug: Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat
-translation_of: Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Intl/NumberFormat
-browser-compat: javascript.builtins.Intl.NumberFormat
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/intl/relativetimeformat/index.md
+++ b/files/es/web/javascript/reference/global_objects/intl/relativetimeformat/index.md
@@ -1,9 +1,6 @@
 ---
 title: Intl.RelativeTimeFormat
 slug: Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat
-tags:
-  - RelatimeTimeFormat
-translation_of: Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Intl/RelativeTimeFormat
 ---
 

--- a/files/es/web/javascript/reference/global_objects/isfinite/index.md
+++ b/files/es/web/javascript/reference/global_objects/isfinite/index.md
@@ -1,11 +1,6 @@
 ---
 title: isFinite()
 slug: Web/JavaScript/Reference/Global_Objects/isFinite
-tags:
-  - Function
-  - JavaScript
-  - isFinite()
-translation_of: Web/JavaScript/Reference/Global_Objects/isFinite
 original_slug: Web/JavaScript/Referencia/Objetos_globales/isFinite
 ---
 

--- a/files/es/web/javascript/reference/global_objects/isnan/index.md
+++ b/files/es/web/javascript/reference/global_objects/isnan/index.md
@@ -1,7 +1,6 @@
 ---
 title: isNaN
 slug: Web/JavaScript/Reference/Global_Objects/isNaN
-translation_of: Web/JavaScript/Reference/Global_Objects/isNaN
 original_slug: Web/JavaScript/Referencia/Objetos_globales/isNaN
 ---
 

--- a/files/es/web/javascript/reference/global_objects/json/index.md
+++ b/files/es/web/javascript/reference/global_objects/json/index.md
@@ -1,13 +1,6 @@
 ---
 title: JSON
 slug: Web/JavaScript/Reference/Global_Objects/JSON
-tags:
-  - JSON
-  - JavaScript
-  - NeedsTranslation
-  - Object
-  - TopicStub
-translation_of: Web/JavaScript/Reference/Global_Objects/JSON
 original_slug: Web/JavaScript/Referencia/Objetos_globales/JSON
 ---
 

--- a/files/es/web/javascript/reference/global_objects/json/parse/index.md
+++ b/files/es/web/javascript/reference/global_objects/json/parse/index.md
@@ -1,13 +1,6 @@
 ---
 title: JSON.parse()
 slug: Web/JavaScript/Reference/Global_Objects/JSON/parse
-tags:
-  - ECMAScript5
-  - JSON
-  - JavaScript
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/JSON/parse
 original_slug: Web/JavaScript/Referencia/Objetos_globales/JSON/parse
 ---
 

--- a/files/es/web/javascript/reference/global_objects/json/stringify/index.md
+++ b/files/es/web/javascript/reference/global_objects/json/stringify/index.md
@@ -1,12 +1,6 @@
 ---
 title: JSON.stringify()
 slug: Web/JavaScript/Reference/Global_Objects/JSON/stringify
-tags:
-  - JSON
-  - JavaScript
-  - Method
-  - stringify
-translation_of: Web/JavaScript/Reference/Global_Objects/JSON/stringify
 original_slug: Web/JavaScript/Referencia/Objetos_globales/JSON/stringify
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/abs/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/abs/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.abs()
 slug: Web/JavaScript/Reference/Global_Objects/Math/abs
-tags:
-  - JavaScript
-  - Math
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/abs
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/abs
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/acos/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/acos/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.acos()
 slug: Web/JavaScript/Reference/Global_Objects/Math/acos
-tags:
-  - JavaScript
-  - Math
-  - Métodos
-  - Referências
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/acos
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/acos
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/acosh/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/acosh/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.acosh()
 slug: Web/JavaScript/Reference/Global_Objects/Math/acosh
-tags:
-  - JavaScript
-  - Math
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/acosh
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/acosh
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/asin/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/asin/index.md
@@ -1,7 +1,6 @@
 ---
 title: Math.asin()
 slug: Web/JavaScript/Reference/Global_Objects/Math/asin
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/asin
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/asin
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/asinh/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/asinh/index.md
@@ -1,7 +1,6 @@
 ---
 title: Math.asinh()
 slug: Web/JavaScript/Reference/Global_Objects/Math/asinh
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/asinh
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/asinh
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/atan/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/atan/index.md
@@ -1,13 +1,6 @@
 ---
 title: Math.atan()
 slug: Web/JavaScript/Reference/Global_Objects/Math/atan
-tags:
-  - JavaScript
-  - Matemática
-  - Math
-  - Method
-  - Trigonometría
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/atan
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/atan
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/atan2/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/atan2/index.md
@@ -1,7 +1,6 @@
 ---
 title: Math.atan2()
 slug: Web/JavaScript/Reference/Global_Objects/Math/atan2
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/atan2
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/atan2
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/atanh/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/atanh/index.md
@@ -1,7 +1,6 @@
 ---
 title: Math.atanh()
 slug: Web/JavaScript/Reference/Global_Objects/Math/atanh
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/atanh
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/atanh
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/cbrt/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/cbrt/index.md
@@ -1,7 +1,6 @@
 ---
 title: Math.cbrt()
 slug: Web/JavaScript/Reference/Global_Objects/Math/cbrt
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/cbrt
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/cbrt
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/ceil/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/ceil/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.ceil()
 slug: Web/JavaScript/Reference/Global_Objects/Math/ceil
-tags:
-  - JavaScript
-  - Math
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/ceil
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/ceil
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/cos/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/cos/index.md
@@ -1,7 +1,6 @@
 ---
 title: Math.cos()
 slug: Web/JavaScript/Reference/Global_Objects/Math/cos
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/cos
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/cos
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/e/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/e/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.E
 slug: Web/JavaScript/Reference/Global_Objects/Math/E
-tags:
-  - JavaScript
-  - Math
-  - Property
-  - Referencia
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/E
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/E
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/exp/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/exp/index.md
@@ -1,7 +1,6 @@
 ---
 title: Math.exp()
 slug: Web/JavaScript/Reference/Global_Objects/Math/exp
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/exp
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/exp
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/expm1/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/expm1/index.md
@@ -1,14 +1,6 @@
 ---
 title: Math.expm1()
 slug: Web/JavaScript/Reference/Global_Objects/Math/expm1
-tags:
-  - JavaScript
-  - Matemáticas
-  - Math
-  - Method
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/expm1
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/expm1
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/floor/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/floor/index.md
@@ -1,11 +1,6 @@
 ---
 title: Math.floor()
 slug: Web/JavaScript/Reference/Global_Objects/Math/floor
-tags:
-  - JavaScript
-  - Math
-  - Method
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/floor
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/floor
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/hypot/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/hypot/index.md
@@ -1,10 +1,6 @@
 ---
 title: Math.hypot()
 slug: Web/JavaScript/Reference/Global_Objects/Math/hypot
-tags:
-  - JavaScript
-  - Math
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/hypot
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/hypot
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/index.md
@@ -1,11 +1,6 @@
 ---
 title: Math
 slug: Web/JavaScript/Reference/Global_Objects/Math
-tags:
-  - JavaScript
-  - Math
-  - Referencia
-translation_of: Web/JavaScript/Reference/Global_Objects/Math
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/ln10/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/ln10/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.LN10
 slug: Web/JavaScript/Reference/Global_Objects/Math/LN10
-tags:
-  - JavaScript
-  - Math
-  - Property
-  - Referencia
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/LN10
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/LN10
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/ln2/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/ln2/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.LN2
 slug: Web/JavaScript/Reference/Global_Objects/Math/LN2
-tags:
-  - JavaScript
-  - Math
-  - Property
-  - Referencia
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/LN2
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/LN2
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/log/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/log/index.md
@@ -1,7 +1,6 @@
 ---
 title: Math.log()
 slug: Web/JavaScript/Reference/Global_Objects/Math/log
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/log
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/log
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/log10/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/log10/index.md
@@ -1,7 +1,6 @@
 ---
 title: Math.log10()
 slug: Web/JavaScript/Reference/Global_Objects/Math/log10
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/log10
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/log10
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/log10e/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/log10e/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.LOG10E
 slug: Web/JavaScript/Reference/Global_Objects/Math/LOG10E
-tags:
-  - JavaScript
-  - Math
-  - Propiedad
-  - Referencia
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/LOG10E
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/LOG10E
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/log2/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/log2/index.md
@@ -1,7 +1,6 @@
 ---
 title: Math.log2()
 slug: Web/JavaScript/Reference/Global_Objects/Math/log2
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/log2
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/log2
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/log2e/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/log2e/index.md
@@ -1,11 +1,6 @@
 ---
 title: Math.LOG2E
 slug: Web/JavaScript/Reference/Global_Objects/Math/LOG2E
-tags:
-  - JavaScript
-  - Math
-  - Property
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/LOG2E
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/LOG2E
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/max/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/max/index.md
@@ -1,7 +1,6 @@
 ---
 title: Math.max()
 slug: Web/JavaScript/Reference/Global_Objects/Math/max
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/max
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/math/min/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/min/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.min()
 slug: Web/JavaScript/Reference/Global_Objects/Math/min
-tags:
-  - JavaScript
-  - Math
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/min
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/min
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/pi/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/pi/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.PI
 slug: Web/JavaScript/Reference/Global_Objects/Math/PI
-tags:
-  - JavaScript
-  - Math
-  - Propiedad
-  - Referencia
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/PI
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/PI
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/pow/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/pow/index.md
@@ -1,7 +1,6 @@
 ---
 title: Math.pow()
 slug: Web/JavaScript/Reference/Global_Objects/Math/pow
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/pow
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/pow
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/random/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/random/index.md
@@ -1,7 +1,6 @@
 ---
 title: Math.random()
 slug: Web/JavaScript/Reference/Global_Objects/Math/random
-browser-compat: javascript.builtins.Math.random
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/math/round/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/round/index.md
@@ -1,7 +1,6 @@
 ---
 title: Math.round()
 slug: Web/JavaScript/Reference/Global_Objects/Math/round
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/round
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/round
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/sign/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/sign/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.sign()
 slug: Web/JavaScript/Reference/Global_Objects/Math/sign
-tags:
-  - JavaScript
-  - Math
-  - Method
-  - Reference
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/sign
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/sign
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/sin/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/sin/index.md
@@ -1,7 +1,6 @@
 ---
 title: Math.sin()
 slug: Web/JavaScript/Reference/Global_Objects/Math/sin
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/sin
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/seno
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/sqrt/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/sqrt/index.md
@@ -1,7 +1,6 @@
 ---
 title: Math.sqrt()
 slug: Web/JavaScript/Reference/Global_Objects/Math/sqrt
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/sqrt
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/sqrt
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/sqrt1_2/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/sqrt1_2/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.SQRT1_2
 slug: Web/JavaScript/Reference/Global_Objects/Math/SQRT1_2
-tags:
-  - JavaScript
-  - Math
-  - Propiedad
-  - Referencia
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/SQRT1_2
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/SQRT1_2
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/sqrt2/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/sqrt2/index.md
@@ -1,7 +1,6 @@
 ---
 title: Math.SQRT2
 slug: Web/JavaScript/Reference/Global_Objects/Math/SQRT2
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/SQRT2
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/SQRT2
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/tan/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/tan/index.md
@@ -1,11 +1,6 @@
 ---
 title: Math.tan()
 slug: Web/JavaScript/Reference/Global_Objects/Math/tan
-tags:
-  - Matemáticas
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/tan
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/tan
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/tanh/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/tanh/index.md
@@ -1,12 +1,6 @@
 ---
 title: Math.tanh()
 slug: Web/JavaScript/Reference/Global_Objects/Math/tanh
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/tanh
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/tanh
 ---
 

--- a/files/es/web/javascript/reference/global_objects/math/trunc/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/trunc/index.md
@@ -1,13 +1,6 @@
 ---
 title: Math.trunc()
 slug: Web/JavaScript/Reference/Global_Objects/Math/trunc
-tags:
-  - ECMAScript6
-  - JavaScript
-  - Math
-  - Método(2)
-  - Referencia
-translation_of: Web/JavaScript/Reference/Global_Objects/Math/trunc
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/trunc
 ---
 

--- a/files/es/web/javascript/reference/global_objects/nan/index.md
+++ b/files/es/web/javascript/reference/global_objects/nan/index.md
@@ -1,11 +1,6 @@
 ---
 title: NaN
 slug: Web/JavaScript/Reference/Global_Objects/NaN
-tags:
-  - JavaScript
-  - Propiedad
-  - Referencia
-translation_of: Web/JavaScript/Reference/Global_Objects/NaN
 original_slug: Web/JavaScript/Referencia/Objetos_globales/NaN
 ---
 

--- a/files/es/web/javascript/reference/global_objects/number/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/index.md
@@ -1,12 +1,6 @@
 ---
 title: Number
 slug: Web/JavaScript/Reference/Global_Objects/Number
-tags:
-  - JavaScript
-  - Number
-  - Referencia
-  - Referência(2)
-translation_of: Web/JavaScript/Reference/Global_Objects/Number
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Number
 ---
 

--- a/files/es/web/javascript/reference/global_objects/number/isfinite/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/isfinite/index.md
@@ -1,7 +1,6 @@
 ---
 title: Number.isFinite()
 slug: Web/JavaScript/Reference/Global_Objects/Number/isFinite
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/isFinite
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Number/isFinite
 ---
 

--- a/files/es/web/javascript/reference/global_objects/number/isinteger/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/isinteger/index.md
@@ -1,12 +1,6 @@
 ---
 title: Number.isInteger()
 slug: Web/JavaScript/Reference/Global_Objects/Number/isInteger
-tags:
-  - JavaScript
-  - Number
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/isInteger
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Number/isInteger
 ---
 

--- a/files/es/web/javascript/reference/global_objects/number/isnan/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/isnan/index.md
@@ -1,7 +1,6 @@
 ---
 title: Number.isNaN()
 slug: Web/JavaScript/Reference/Global_Objects/Number/isNaN
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/isNaN
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Number/isNaN
 ---
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/number/issafeinteger/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/issafeinteger/index.md
@@ -1,12 +1,6 @@
 ---
 title: Number.isSafeInteger()
 slug: Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger
-tags:
-  - ECMAScript6
-  - JavaScript
-  - Number
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Number/isSafeInteger
 ---
 

--- a/files/es/web/javascript/reference/global_objects/number/max_safe_integer/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/max_safe_integer/index.md
@@ -1,12 +1,6 @@
 ---
 title: Number.MAX_SAFE_INTEGER
 slug: Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Number
-  - Property
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Number/MAX_SAFE_INTEGER
 ---
 

--- a/files/es/web/javascript/reference/global_objects/number/max_value/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/max_value/index.md
@@ -1,7 +1,6 @@
 ---
 title: Number.MAX_VALUE
 slug: Web/JavaScript/Reference/Global_Objects/Number/MAX_VALUE
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/MAX_VALUE
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Number/MAX_VALUE
 ---
 

--- a/files/es/web/javascript/reference/global_objects/number/min_value/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/min_value/index.md
@@ -1,7 +1,6 @@
 ---
 title: Number.MIN_VALUE
 slug: Web/JavaScript/Reference/Global_Objects/Number/MIN_VALUE
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/MIN_VALUE
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Number/MIN_VALUE
 ---
 

--- a/files/es/web/javascript/reference/global_objects/number/nan/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/nan/index.md
@@ -1,11 +1,6 @@
 ---
 title: Number.NaN
 slug: Web/JavaScript/Reference/Global_Objects/Number/NaN
-tags:
-  - JavaScript
-  - Número
-  - Propiedad
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/NaN
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Number/NaN
 ---
 

--- a/files/es/web/javascript/reference/global_objects/number/negative_infinity/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/negative_infinity/index.md
@@ -1,11 +1,6 @@
 ---
 title: Number.NEGATIVE_INFINITY
 slug: Web/JavaScript/Reference/Global_Objects/Number/NEGATIVE_INFINITY
-tags:
-  - JavaScript
-  - Number
-  - Property
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/NEGATIVE_INFINITY
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Number/NEGATIVE_INFINITY
 ---
 

--- a/files/es/web/javascript/reference/global_objects/number/parsefloat/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/parsefloat/index.md
@@ -1,9 +1,7 @@
 ---
 title: Number.parseFloat()
 slug: Web/JavaScript/Reference/Global_Objects/Number/parseFloat
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/parseFloat
 original_slug: Web/JavaScript/Reference/Global_Objects/Number/parseFloat
-browser-compat: javascript.builtins.Number.parseFloat
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/number/parseint/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/parseint/index.md
@@ -1,9 +1,6 @@
 ---
 title: Number.parseInt()
 slug: Web/JavaScript/Reference/Global_Objects/Number/parseInt
-tags:
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/parseInt
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Number/parseInt
 ---
 

--- a/files/es/web/javascript/reference/global_objects/number/positive_infinity/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/positive_infinity/index.md
@@ -1,11 +1,6 @@
 ---
 title: Number.POSITIVE_INFINITY
 slug: Web/JavaScript/Reference/Global_Objects/Number/POSITIVE_INFINITY
-tags:
-  - JavaScript
-  - Number
-  - Property
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/POSITIVE_INFINITY
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Number/POSITIVE_INFINITY
 ---
 

--- a/files/es/web/javascript/reference/global_objects/number/tofixed/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/tofixed/index.md
@@ -1,7 +1,6 @@
 ---
 title: Number.prototype.toFixed()
 slug: Web/JavaScript/Reference/Global_Objects/Number/toFixed
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/toFixed
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Number/toFixed
 ---
 

--- a/files/es/web/javascript/reference/global_objects/number/tolocalestring/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/tolocalestring/index.md
@@ -1,11 +1,6 @@
 ---
 title: Number.prototype.toLocaleString()
 slug: Web/JavaScript/Reference/Global_Objects/Number/toLocaleString
-tags:
-  - Internacionalizacion
-  - JavaScript
-  - Número
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/toLocaleString
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Number/toLocaleString
 ---
 

--- a/files/es/web/javascript/reference/global_objects/number/toprecision/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/toprecision/index.md
@@ -1,7 +1,6 @@
 ---
 title: Number.prototype.toPrecision()
 slug: Web/JavaScript/Reference/Global_Objects/Number/toPrecision
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/toPrecision
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Number/toPrecision
 ---
 

--- a/files/es/web/javascript/reference/global_objects/number/tostring/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/tostring/index.md
@@ -1,13 +1,6 @@
 ---
 title: Number.prototype.toString()
 slug: Web/JavaScript/Reference/Global_Objects/Number/toString
-tags:
-  - JavaScript
-  - Method
-  - Number
-  - Prototype
-  - Referencia
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/toString
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Number/toString
 ---
 

--- a/files/es/web/javascript/reference/global_objects/number/valueof/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/valueof/index.md
@@ -1,12 +1,6 @@
 ---
 title: Number.prototype.valueOf()
 slug: Web/JavaScript/Reference/Global_Objects/Number/valueOf
-tags:
-  - JavaScript
-  - Métodos
-  - Number
-  - Prototype
-translation_of: Web/JavaScript/Reference/Global_Objects/Number/valueOf
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Number/valueOf
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/__definegetter__/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/__definegetter__/index.md
@@ -1,13 +1,6 @@
 ---
 title: Object.prototype.__defineGetter__()
 slug: Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__
-tags:
-  - JavaScript
-  - Objeto
-  - Prototipo
-  - Prototype
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/__defineGetter__
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/assign/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/assign/index.md
@@ -1,14 +1,6 @@
 ---
 title: Object.assign()
 slug: Web/JavaScript/Reference/Global_Objects/Object/assign
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Objeto
-  - Referencia
-  - metodo
-  - polyfill
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/assign
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/assign
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/constructor/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/constructor/index.md
@@ -1,12 +1,6 @@
 ---
 title: Object.prototype.constructor
 slug: Web/JavaScript/Reference/Global_Objects/Object/constructor
-tags:
-  - JavaScript
-  - Object
-  - Property
-  - Prototype
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/constructor
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/constructor
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/create/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/create/index.md
@@ -1,15 +1,6 @@
 ---
 title: Object.create()
 slug: Web/JavaScript/Reference/Global_Objects/Object/create
-tags:
-  - ECMAScript5
-  - JavaScript
-  - 'Null'
-  - Objeto
-  - Referencia
-  - metodo
-  - polyfill
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/create
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/create
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/defineproperties/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/defineproperties/index.md
@@ -1,13 +1,6 @@
 ---
 title: Object.defineProperties()
 slug: Web/JavaScript/Reference/Global_Objects/Object/defineProperties
-tags:
-  - ECMAScript5
-  - JavaScript
-  - JavaScript 1.8.5
-  - Método(2)
-  - Objeto
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/defineProperties
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/defineProperties
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/defineproperty/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/defineproperty/index.md
@@ -1,13 +1,6 @@
 ---
 title: Object.defineProperty()
 slug: Web/JavaScript/Reference/Global_Objects/Object/defineProperty
-tags:
-  - ECMAScript5
-  - JavaScript
-  - JavaScript 1.8.5
-  - Método(2)
-  - Objeto
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/defineProperty
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/defineProperty
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/entries/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/entries/index.md
@@ -1,7 +1,6 @@
 ---
 title: Object.entries()
 slug: Web/JavaScript/Reference/Global_Objects/Object/entries
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/entries
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/entries
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/freeze/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/freeze/index.md
@@ -1,7 +1,6 @@
 ---
 title: Object.freeze()
 slug: Web/JavaScript/Reference/Global_Objects/Object/freeze
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/freeze
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/freeze
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/fromentries/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/fromentries/index.md
@@ -1,12 +1,6 @@
 ---
 title: Object.fromEntries()
 slug: Web/JavaScript/Reference/Global_Objects/Object/fromEntries
-tags:
-  - JavaScript
-  - Objeto
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/fromEntries
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/fromEntries
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/getownpropertydescriptor/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/getownpropertydescriptor/index.md
@@ -1,12 +1,6 @@
 ---
 title: Object.getOwnPropertyDescriptor()
 slug: Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor
-tags:
-  - ECMAScript5
-  - JavaScript
-  - Método(2)
-  - Objeto
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/getOwnPropertyDescriptor
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/getownpropertydescriptors/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/getownpropertydescriptors/index.md
@@ -1,11 +1,6 @@
 ---
 title: Object.getOwnPropertyDescriptors()
 slug: Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptors
-tags:
-  - JavaScript
-  - Objeto
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptors
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/getOwnPropertyDescriptors
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/getownpropertynames/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/getownpropertynames/index.md
@@ -1,7 +1,6 @@
 ---
 title: Object.getOwnPropertyNames()
 slug: Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/getOwnPropertyNames
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/getownpropertysymbols/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/getownpropertysymbols/index.md
@@ -1,13 +1,6 @@
 ---
 title: Object.getOwnPropertySymbols()
 slug: Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols
-tags:
-  - ECMAScript6
-  - Experimental
-  - JavaScript
-  - Método(2)
-  - Objeto
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/getOwnPropertySymbols
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/getprototypeof/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/getprototypeof/index.md
@@ -1,12 +1,6 @@
 ---
 title: Object.getPrototypeOf()
 slug: Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf
-tags:
-  - ECMAScript5
-  - JavaScript
-  - Objeto
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/getPrototypeOf
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/hasownproperty/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/hasownproperty/index.md
@@ -1,12 +1,6 @@
 ---
 title: Object.prototype.hasOwnProperty()
 slug: Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty
-tags:
-  - JavaScript
-  - Method
-  - Object
-  - Prototype
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/hasOwnProperty
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/index.md
@@ -1,9 +1,7 @@
 ---
 title: Object
 slug: Web/JavaScript/Reference/Global_Objects/Object
-translation_of: Web/JavaScript/Reference/Global_Objects/Object
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object
-browser-compat: javascript.builtins.Object
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/object/is/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/is/index.md
@@ -1,16 +1,6 @@
 ---
 title: Object.is()
 slug: Web/JavaScript/Reference/Global_Objects/Object/is
-tags:
-  - Comparación
-  - Condición
-  - ECMAScript2015
-  - JavaScript
-  - Objeto
-  - condicional
-  - igualdad
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/is
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/is
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/isextensible/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/isextensible/index.md
@@ -1,13 +1,6 @@
 ---
 title: Object.isExtensible()
 slug: Web/JavaScript/Reference/Global_Objects/Object/isExtensible
-tags:
-  - ECMAScript5
-  - JavaScript
-  - JavaScript 1.8.5
-  - Objeto
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/isExtensible
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/isExtensible
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/isfrozen/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/isfrozen/index.md
@@ -1,13 +1,6 @@
 ---
 title: Object.isFrozen()
 slug: Web/JavaScript/Reference/Global_Objects/Object/isFrozen
-tags:
-  - ECMAScript5
-  - JavaScript
-  - JavaScript 1.8.5
-  - Objeto
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/isFrozen
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/isFrozen
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/isprototypeof/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/isprototypeof/index.md
@@ -1,7 +1,6 @@
 ---
 title: Object.prototype.isPrototypeOf()
 slug: Web/JavaScript/Reference/Global_Objects/Object/isPrototypeOf
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/isPrototypeOf
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/isPrototypeOf
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/issealed/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/issealed/index.md
@@ -1,13 +1,6 @@
 ---
 title: Object.isSealed()
 slug: Web/JavaScript/Reference/Global_Objects/Object/isSealed
-tags:
-  - ECMAScript5
-  - JavaScript
-  - JavaScript 1.8.5
-  - Objeto
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/isSealed
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/isSealed
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/keys/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/keys/index.md
@@ -1,7 +1,6 @@
 ---
 title: Object.keys()
 slug: Web/JavaScript/Reference/Global_Objects/Object/keys
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/keys
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/keys
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/preventextensions/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/preventextensions/index.md
@@ -1,7 +1,6 @@
 ---
 title: Object.preventExtensions()
 slug: Web/JavaScript/Reference/Global_Objects/Object/preventExtensions
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/preventExtensions
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/preventExtensions
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/propertyisenumerable/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/propertyisenumerable/index.md
@@ -1,12 +1,6 @@
 ---
 title: Object.prototype.propertyIsEnumerable()
 slug: Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable
-tags:
-  - JavaScript
-  - Objecto
-  - Property
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/propertyIsEnumerable
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/proto/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/proto/index.md
@@ -1,7 +1,6 @@
 ---
 title: Object.prototype.__proto__
 slug: Web/JavaScript/Reference/Global_Objects/Object/proto
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/proto
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/proto
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/seal/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/seal/index.md
@@ -1,7 +1,6 @@
 ---
 title: Object.seal()
 slug: Web/JavaScript/Reference/Global_Objects/Object/seal
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/seal
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/seal
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/setprototypeof/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/setprototypeof/index.md
@@ -1,13 +1,6 @@
 ---
 title: Object.setPrototypeOf()
 slug: Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf
-tags:
-  - ECMAScript6
-  - Experimental
-  - JavaScript
-  - Método(2)
-  - Objeto
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/setPrototypeOf
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/tolocalestring/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/tolocalestring/index.md
@@ -1,7 +1,6 @@
 ---
 title: Object.prototype.toLocaleString()
 slug: Web/JavaScript/Reference/Global_Objects/Object/toLocaleString
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/toLocaleString
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/toLocaleString
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/tostring/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/tostring/index.md
@@ -1,12 +1,6 @@
 ---
 title: Object.prototype.toString()
 slug: Web/JavaScript/Reference/Global_Objects/Object/toString
-tags:
-  - JavaScript
-  - Method
-  - Object
-  - Prototype
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/toString
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/toString
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/valueof/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/valueof/index.md
@@ -1,7 +1,6 @@
 ---
 title: Object.prototype.valueOf()
 slug: Web/JavaScript/Reference/Global_Objects/Object/valueOf
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/valueOf
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/valueOf
 ---
 

--- a/files/es/web/javascript/reference/global_objects/object/values/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/values/index.md
@@ -1,12 +1,6 @@
 ---
 title: Object.values()
 slug: Web/JavaScript/Reference/Global_Objects/Object/values
-tags:
-  - JavaScript
-  - Objeto
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Object/values
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Object/values
 ---
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove duplicated frontmatter keys from localized content

### Motivation

Remove innecesarry duplicated data

### Additional details

Folders: global_objects/(a|b|d|e|f|g|i|j|m|n|o)*

```
{
  "tags": 135,
  "translation_of": 197,
  "browser-compat": 13
}
```

### Related issues and pull requests

Relates to #10129
Relates to #7412
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
