### PR TITLE
Remove duplicated frontmatter keys from web folder 8/10 [es]

### DIFF
--- a/files/es/web/api/index.md
+++ b/files/es/web/api/index.md
@@ -1,13 +1,6 @@
 ---
 title: Referencia de la API Web
 slug: Web/API
-tags:
-  - API
-  - Aterrizaje
-  - DOM
-  - Referencia
-  - Web
-translation_of: Web/API
 ---
 
 Cuando escribimos código para la web utilizando JavaScript, podemos usar gran número de APIs disponibles. A continuación mostramos una lista de todas las interfaces (es decir, tipos de objetos) que puedes usar al desarrollar tu aplicación o sitio Web. Para obtener una lista de las API que contiene cada una de estas interfaces, consulta la referencia de la API Web.

--- a/files/es/web/api/range/collapsed/index.md
+++ b/files/es/web/api/range/collapsed/index.md
@@ -1,7 +1,6 @@
 ---
 title: range.collapsed
 slug: Web/API/Range/collapsed
-translation_of: Web/API/Range/collapsed
 ---
 
 {{ APIRef("DOM") }}

--- a/files/es/web/api/range/commonancestorcontainer/index.md
+++ b/files/es/web/api/range/commonancestorcontainer/index.md
@@ -1,7 +1,6 @@
 ---
 title: range.commonAncestorContainer
 slug: Web/API/Range/commonAncestorContainer
-translation_of: Web/API/Range/commonAncestorContainer
 ---
 
 {{ApiRef("DOM")}}

--- a/files/es/web/api/range/getclientrects/index.md
+++ b/files/es/web/api/range/getclientrects/index.md
@@ -1,13 +1,6 @@
 ---
 title: Range.getClientRects()
 slug: Web/API/Range/getClientRects
-tags:
-  - API
-  - Experimental
-  - Rango
-  - Vista CSSOM
-  - metodo
-translation_of: Web/API/Range/getClientRects
 ---
 
 {{ApiRef("DOM")}}{{ seeCompatTable }}

--- a/files/es/web/api/range/index.md
+++ b/files/es/web/api/range/index.md
@@ -1,10 +1,6 @@
 ---
 title: range
 slug: Web/API/Range
-tags:
-  - DOM
-  - Todas_las_Categorías
-translation_of: Web/API/Range
 ---
 
 {{ APIRef("DOM") }}

--- a/files/es/web/api/range/setstart/index.md
+++ b/files/es/web/api/range/setstart/index.md
@@ -1,7 +1,6 @@
 ---
 title: Range.setStart()
 slug: Web/API/Range/setStart
-translation_of: Web/API/Range/setStart
 ---
 
 {{ApiRef("DOM")}}

--- a/files/es/web/api/request/headers/index.md
+++ b/files/es/web/api/request/headers/index.md
@@ -1,7 +1,6 @@
 ---
 title: Request.headers
 slug: Web/API/Request/headers
-translation_of: Web/API/Request/headers
 ---
 
 {{APIRef("Fetch")}}

--- a/files/es/web/api/request/index.md
+++ b/files/es/web/api/request/index.md
@@ -1,17 +1,6 @@
 ---
 title: Request
 slug: Web/API/Request
-tags:
-  - API
-  - Experimental
-  - Fetch
-  - Fetch API
-  - Interface
-  - NeedsTranslation
-  - Reference
-  - TopicStub
-  - request
-translation_of: Web/API/Request
 ---
 
 {{APIRef("Fetch")}}

--- a/files/es/web/api/response/index.md
+++ b/files/es/web/api/response/index.md
@@ -1,14 +1,6 @@
 ---
 title: Response
 slug: Web/API/Response
-tags:
-  - API
-  - Experimental
-  - Fetch
-  - Interface
-  - Referencia
-  - Respuesta
-translation_of: Web/API/Response
 ---
 
 {{APIRef("Fetch API")}}

--- a/files/es/web/api/response/ok/index.md
+++ b/files/es/web/api/response/ok/index.md
@@ -1,7 +1,6 @@
 ---
 title: Response.ok
 slug: Web/API/Response/ok
-translation_of: Web/API/Response/ok
 ---
 
 {{APIRef("Fetch")}}

--- a/files/es/web/api/response/response/index.md
+++ b/files/es/web/api/response/response/index.md
@@ -1,7 +1,6 @@
 ---
 title: Response()
 slug: Web/API/Response/Response
-translation_of: Web/API/Response/Response
 ---
 
 {{APIRef("Fetch")}}

--- a/files/es/web/api/response/status/index.md
+++ b/files/es/web/api/response/status/index.md
@@ -1,15 +1,6 @@
 ---
 title: Response.status
 slug: Web/API/Response/status
-tags:
-  - API
-  - Experimental
-  - Fetch
-  - Property
-  - Reference
-  - Response
-  - status
-translation_of: Web/API/Response/status
 ---
 
 {{APIRef("Fetch")}}

--- a/files/es/web/api/rtcpeerconnection/cantrickleicecandidates/index.md
+++ b/files/es/web/api/rtcpeerconnection/cantrickleicecandidates/index.md
@@ -1,7 +1,6 @@
 ---
 title: RTCPeerConnection.canTrickleIceCandidates
 slug: Web/API/RTCPeerConnection/canTrickleIceCandidates
-translation_of: Web/API/RTCPeerConnection/canTrickleIceCandidates
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/es/web/api/rtcpeerconnection/index.md
+++ b/files/es/web/api/rtcpeerconnection/index.md
@@ -1,7 +1,6 @@
 ---
 title: RTCPeerConnection
 slug: Web/API/RTCPeerConnection
-translation_of: Web/API/RTCPeerConnection
 ---
 
 {{APIRef('WebRTC')}}

--- a/files/es/web/api/rtcrtpreceiver/index.md
+++ b/files/es/web/api/rtcrtpreceiver/index.md
@@ -1,7 +1,6 @@
 ---
 title: RTCRtpReceiver
 slug: Web/API/RTCRtpReceiver
-translation_of: Web/API/RTCRtpReceiver
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/es/web/api/screen/index.md
+++ b/files/es/web/api/screen/index.md
@@ -1,8 +1,6 @@
 ---
 title: Screen
 slug: Web/API/Screen
-translation_of: Web/API/Screen
-browser-compat: api.Screen
 ---
 
 {{APIRef("CSSOM")}}

--- a/files/es/web/api/selection/addrange/index.md
+++ b/files/es/web/api/selection/addrange/index.md
@@ -1,9 +1,6 @@
 ---
 title: addRange
 slug: Web/API/Selection/addRange
-tags:
-  - páginas_a_traducir
-translation_of: Web/API/Selection/addRange
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/selection/anchornode/index.md
+++ b/files/es/web/api/selection/anchornode/index.md
@@ -1,9 +1,6 @@
 ---
 title: anchorNode
 slug: Web/API/Selection/anchorNode
-tags:
-  - páginas_a_traducir
-translation_of: Web/API/Selection/anchorNode
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/selection/anchoroffset/index.md
+++ b/files/es/web/api/selection/anchoroffset/index.md
@@ -1,9 +1,6 @@
 ---
 title: anchorOffset
 slug: Web/API/Selection/anchorOffset
-tags:
-  - páginas_a_traducir
-translation_of: Web/API/Selection/anchorOffset
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/selection/collapse/index.md
+++ b/files/es/web/api/selection/collapse/index.md
@@ -1,9 +1,6 @@
 ---
 title: collapse
 slug: Web/API/Selection/collapse
-tags:
-  - páginas_a_traducir
-translation_of: Web/API/Selection/collapse
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/selection/collapsetoend/index.md
+++ b/files/es/web/api/selection/collapsetoend/index.md
@@ -1,9 +1,6 @@
 ---
 title: collapseToEnd
 slug: Web/API/Selection/collapseToEnd
-tags:
-  - páginas_a_traducir
-translation_of: Web/API/Selection/collapseToEnd
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/selection/collapsetostart/index.md
+++ b/files/es/web/api/selection/collapsetostart/index.md
@@ -1,9 +1,6 @@
 ---
 title: collapseToStart
 slug: Web/API/Selection/collapseToStart
-tags:
-  - páginas_a_traducir
-translation_of: Web/API/Selection/collapseToStart
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/selection/containsnode/index.md
+++ b/files/es/web/api/selection/containsnode/index.md
@@ -1,9 +1,6 @@
 ---
 title: containsNode
 slug: Web/API/Selection/containsNode
-tags:
-  - páginas_a_traducir
-translation_of: Web/API/Selection/containsNode
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/selection/deletefromdocument/index.md
+++ b/files/es/web/api/selection/deletefromdocument/index.md
@@ -1,9 +1,6 @@
 ---
 title: deleteFromDocument
 slug: Web/API/Selection/deleteFromDocument
-tags:
-  - páginas_a_traducir
-translation_of: Web/API/Selection/deleteFromDocument
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/selection/extend/index.md
+++ b/files/es/web/api/selection/extend/index.md
@@ -1,9 +1,6 @@
 ---
 title: extend
 slug: Web/API/Selection/extend
-tags:
-  - páginas_a_traducir
-translation_of: Web/API/Selection/extend
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/selection/focusnode/index.md
+++ b/files/es/web/api/selection/focusnode/index.md
@@ -1,9 +1,6 @@
 ---
 title: focusNode
 slug: Web/API/Selection/focusNode
-tags:
-  - páginas_a_traducir
-translation_of: Web/API/Selection/focusNode
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/selection/focusoffset/index.md
+++ b/files/es/web/api/selection/focusoffset/index.md
@@ -1,9 +1,6 @@
 ---
 title: focusOffset
 slug: Web/API/Selection/focusOffset
-tags:
-  - páginas_a_traducir
-translation_of: Web/API/Selection/focusOffset
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/selection/getrangeat/index.md
+++ b/files/es/web/api/selection/getrangeat/index.md
@@ -1,9 +1,6 @@
 ---
 title: getRangeAt
 slug: Web/API/Selection/getRangeAt
-tags:
-  - páginas_a_traducir
-translation_of: Web/API/Selection/getRangeAt
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/selection/index.md
+++ b/files/es/web/api/selection/index.md
@@ -1,10 +1,6 @@
 ---
 title: Selection
 slug: Web/API/Selection
-tags:
-  - DOM
-  - Todas_las_Categorías
-translation_of: Web/API/Selection
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/selection/iscollapsed/index.md
+++ b/files/es/web/api/selection/iscollapsed/index.md
@@ -1,9 +1,6 @@
 ---
 title: isCollapsed
 slug: Web/API/Selection/isCollapsed
-tags:
-  - páginas_a_traducir
-translation_of: Web/API/Selection/isCollapsed
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/selection/rangecount/index.md
+++ b/files/es/web/api/selection/rangecount/index.md
@@ -1,9 +1,6 @@
 ---
 title: rangeCount
 slug: Web/API/Selection/rangeCount
-tags:
-  - páginas_a_traducir
-translation_of: Web/API/Selection/rangeCount
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/selection/removeallranges/index.md
+++ b/files/es/web/api/selection/removeallranges/index.md
@@ -1,9 +1,6 @@
 ---
 title: removeAllRanges
 slug: Web/API/Selection/removeAllRanges
-tags:
-  - páginas_a_traducir
-translation_of: Web/API/Selection/removeAllRanges
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/selection/removerange/index.md
+++ b/files/es/web/api/selection/removerange/index.md
@@ -1,9 +1,6 @@
 ---
 title: removeRange
 slug: Web/API/Selection/removeRange
-tags:
-  - páginas_a_traducir
-translation_of: Web/API/Selection/removeRange
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/selection/selectallchildren/index.md
+++ b/files/es/web/api/selection/selectallchildren/index.md
@@ -1,9 +1,6 @@
 ---
 title: selectAllChildren
 slug: Web/API/Selection/selectAllChildren
-tags:
-  - páginas_a_traducir
-translation_of: Web/API/Selection/selectAllChildren
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/selection/tostring/index.md
+++ b/files/es/web/api/selection/tostring/index.md
@@ -1,9 +1,6 @@
 ---
 title: toString
 slug: Web/API/Selection/toString
-tags:
-  - páginas_a_traducir
-translation_of: Web/API/Selection/toString
 ---
 
 {{ ApiRef("DOM") }}

--- a/files/es/web/api/server-sent_events/index.md
+++ b/files/es/web/api/server-sent_events/index.md
@@ -1,11 +1,6 @@
 ---
 title: Server-sent events
 slug: Web/API/Server-sent_events
-tags:
-  - NeedsTranslation
-  - Server-sent events
-  - TopicStub
-translation_of: Web/API/Server-sent_events
 original_slug: Server-sent_events
 ---
 

--- a/files/es/web/api/server-sent_events/using_server-sent_events/index.md
+++ b/files/es/web/api/server-sent_events/using_server-sent_events/index.md
@@ -1,7 +1,6 @@
 ---
 title: Utilizando eventos enviados por el servidor (server-sent event)
 slug: Web/API/Server-sent_events/Using_server-sent_events
-translation_of: Web/API/Server-sent_events/Using_server-sent_events
 original_slug: Server-sent_events/utilizando_server_sent_events_sse
 ---
 

--- a/files/es/web/api/service_worker_api/index.md
+++ b/files/es/web/api/service_worker_api/index.md
@@ -1,17 +1,6 @@
 ---
 title: Service Worker API
 slug: Web/API/Service_Worker_API
-tags:
-  - API
-  - Landing
-  - NeedsTranslation
-  - Offline
-  - Overview
-  - Reference
-  - Service Workers
-  - TopicStub
-  - Workers
-translation_of: Web/API/Service_Worker_API
 ---
 
 {{DefaultAPISidebar}}

--- a/files/es/web/api/service_worker_api/using_service_workers/index.md
+++ b/files/es/web/api/service_worker_api/using_service_workers/index.md
@@ -1,8 +1,6 @@
 ---
 title: Usar Service Workers
 slug: Web/API/Service_Worker_API/Using_Service_Workers
-page-type: guide
-translation_of: Web/API/Service_Worker_API/Using_Service_Workers
 ---
 
 {{DefaultAPISidebar}}

--- a/files/es/web/api/serviceworkercontainer/index.md
+++ b/files/es/web/api/serviceworkercontainer/index.md
@@ -1,19 +1,6 @@
 ---
 title: ServiceWorkerContainer
 slug: Web/API/ServiceWorkerContainer
-tags:
-  - API
-  - Draft
-  - Interface
-  - NeedsTranslation
-  - Offline
-  - Reference
-  - Service Workers
-  - Service worker API
-  - ServiceWorkerContainer
-  - TopicStub
-  - Workers
-translation_of: Web/API/ServiceWorkerContainer
 ---
 
 {{SeeCompatTable}}{{APIRef("Service Workers API")}}

--- a/files/es/web/api/serviceworkercontainer/register/index.md
+++ b/files/es/web/api/serviceworkercontainer/register/index.md
@@ -1,7 +1,6 @@
 ---
 title: ServiceWorkerContainer.register()
 slug: Web/API/ServiceWorkerContainer/register
-translation_of: Web/API/ServiceWorkerContainer/register
 ---
 
 {{SeeCompatTable}}{{APIRef("Service Workers API")}}

--- a/files/es/web/api/setinterval/index.md
+++ b/files/es/web/api/setinterval/index.md
@@ -1,10 +1,7 @@
 ---
 title: setInterval()
 slug: Web/API/setInterval
-translation_of: Web/API/WindowOrWorkerGlobalScope/setInterval
 original_slug: Web/API/WindowOrWorkerGlobalScope/setInterval
-browser-compat: api.setInterval
-page-type: web-api-global-function
 l10n:
   sourceCommit: 0717d1c0a7528b2dd44d065fe90d860e3bdc2e6a
 ---

--- a/files/es/web/api/settimeout/index.md
+++ b/files/es/web/api/settimeout/index.md
@@ -1,12 +1,6 @@
 ---
 title: WindowOrWorkerGlobalScope.setTimeout
 slug: Web/API/setTimeout
-tags:
-  - API
-  - HTML DOM
-  - WindowOrWorkerGlobalScope
-  - setTimeout
-translation_of: Web/API/WindowOrWorkerGlobalScope/setTimeout
 original_slug: Web/API/WindowOrWorkerGlobalScope/setTimeout
 ---
 

--- a/files/es/web/api/storage/clear/index.md
+++ b/files/es/web/api/storage/clear/index.md
@@ -1,13 +1,6 @@
 ---
 title: Storage.clear()
 slug: Web/API/Storage/clear
-tags:
-  - API
-  - Almacenamiento local
-  - Storage
-  - Web Storage
-  - sessionStorage
-translation_of: Web/API/Storage/clear
 ---
 
 {{APIRef("Web Storage API")}}

--- a/files/es/web/api/storage/getitem/index.md
+++ b/files/es/web/api/storage/getitem/index.md
@@ -1,15 +1,6 @@
 ---
 title: Storage.getItem()
 slug: Web/API/Storage/getItem
-tags:
-  - API
-  - Almacenamiento
-  - Almacenamiento web
-  - Referencia
-  - Storage
-  - Web Storage
-  - metodo
-translation_of: Web/API/Storage/getItem
 ---
 
 {{APIRef("Web Storage API")}}

--- a/files/es/web/api/storage/index.md
+++ b/files/es/web/api/storage/index.md
@@ -1,15 +1,6 @@
 ---
 title: Almacenamiento
 slug: Web/API/Storage
-tags:
-  - API
-  - Almacenamiento
-  - Almacenamiento web
-  - Interface
-  - Reference
-  - TopicStub
-  - data
-translation_of: Web/API/Storage
 ---
 {{APIRef("Web Storage API")}}
 

--- a/files/es/web/api/storage/length/index.md
+++ b/files/es/web/api/storage/length/index.md
@@ -1,7 +1,6 @@
 ---
 title: Storage.length
 slug: Web/API/Storage/length
-translation_of: Web/API/Storage/length
 ---
 
 {{APIRef("Web Storage API")}}

--- a/files/es/web/api/storage/removeitem/index.md
+++ b/files/es/web/api/storage/removeitem/index.md
@@ -1,15 +1,6 @@
 ---
 title: Storage.removeItem()
 slug: Web/API/Storage/removeItem
-tags:
-  - API
-  - Almacenamiento
-  - Almacenamiento web
-  - Referencia
-  - Storage
-  - Web Storage
-  - metodo
-translation_of: Web/API/Storage/removeItem
 ---
 
 {{APIRef("Web Storage API")}}

--- a/files/es/web/api/storage/setitem/index.md
+++ b/files/es/web/api/storage/setitem/index.md
@@ -1,14 +1,6 @@
 ---
 title: Storage.setItem()
 slug: Web/API/Storage/setItem
-tags:
-  - API
-  - Almacenamiento
-  - Almacenamiento web
-  - Storage
-  - Web Storage
-  - metodo
-translation_of: Web/API/Storage/setItem
 ---
 
 {{APIRef("Web Storage API")}}

--- a/files/es/web/api/storagemanager/estimate/index.md
+++ b/files/es/web/api/storagemanager/estimate/index.md
@@ -1,19 +1,6 @@
 ---
 title: StorageManager.estimate()
 slug: Web/API/StorageManager/estimate
-tags:
-  - API
-  - Almacenamiento
-  - Contexto seguro
-  - Cuota
-  - Referencia
-  - Storage API
-  - StorageManager
-  - Uso
-  - estimación
-  - estimate
-  - metodo
-translation_of: Web/API/StorageManager/estimate
 ---
 
 {{securecontext_header}}{{APIRef("Storage")}}

--- a/files/es/web/api/storagemanager/index.md
+++ b/files/es/web/api/storagemanager/index.md
@@ -1,20 +1,6 @@
 ---
 title: StorageManager
 slug: Web/API/StorageManager
-tags:
-  - API
-  - Interface
-  - NeedsTranslation
-  - Persistence
-  - Quotas
-  - Reference
-  - Secure context
-  - Storage
-  - Storage API
-  - StorageManager
-  - TopicStub
-  - Usage
-translation_of: Web/API/StorageManager
 ---
 
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef("Storage")}}

--- a/files/es/web/api/storagemanager/persist/index.md
+++ b/files/es/web/api/storagemanager/persist/index.md
@@ -1,13 +1,6 @@
 ---
 title: StorageManager.persist()
 slug: Web/API/StorageManager/persist
-tags:
-  - Contexto seguro
-  - Referencia
-  - Storage API
-  - metodo
-  - persist()
-translation_of: Web/API/StorageManager/persist
 ---
 
 {{securecontext_header}}{{APIRef("Storage")}}{{SeeCompatTable}}

--- a/files/es/web/api/storagemanager/persisted/index.md
+++ b/files/es/web/api/storagemanager/persisted/index.md
@@ -1,13 +1,6 @@
 ---
 title: StorageManager.persisted()
 slug: Web/API/StorageManager/persisted
-tags:
-  - Contexto seguro
-  - Referencia
-  - Storage API
-  - metodo
-  - persisted()
-translation_of: Web/API/StorageManager/persisted
 ---
 
 {{securecontext_header}}{{APIRef("Storage")}}{{SeeCompatTable}}

--- a/files/es/web/api/stylesheet/disabled/index.md
+++ b/files/es/web/api/stylesheet/disabled/index.md
@@ -1,7 +1,6 @@
 ---
 title: Stylesheet.disabled
 slug: Web/API/StyleSheet/disabled
-translation_of: Web/API/StyleSheet/disabled
 ---
 
 {{ ApiRef() }}

--- a/files/es/web/api/stylesheet/href/index.md
+++ b/files/es/web/api/stylesheet/href/index.md
@@ -1,7 +1,6 @@
 ---
 title: stylesheet.href
 slug: Web/API/StyleSheet/href
-translation_of: Web/API/StyleSheet/href
 ---
 
 {{ ApiRef() }}

--- a/files/es/web/api/stylesheet/index.md
+++ b/files/es/web/api/stylesheet/index.md
@@ -1,7 +1,6 @@
 ---
 title: objeto Stylesheet
 slug: Web/API/StyleSheet
-translation_of: Web/API/StyleSheet
 ---
 
 {{ ApiRef("CSSOM") }}

--- a/files/es/web/api/stylesheet/media/index.md
+++ b/files/es/web/api/stylesheet/media/index.md
@@ -1,7 +1,6 @@
 ---
 title: Stylesheet.media
 slug: Web/API/StyleSheet/media
-translation_of: Web/API/StyleSheet/media
 ---
 
 {{ ApiRef() }}

--- a/files/es/web/api/stylesheet/ownernode/index.md
+++ b/files/es/web/api/stylesheet/ownernode/index.md
@@ -1,7 +1,6 @@
 ---
 title: Stylesheet.ownerNode
 slug: Web/API/StyleSheet/ownerNode
-translation_of: Web/API/StyleSheet/ownerNode
 ---
 
 {{ ApiRef() }}

--- a/files/es/web/api/stylesheet/parentstylesheet/index.md
+++ b/files/es/web/api/stylesheet/parentstylesheet/index.md
@@ -1,7 +1,6 @@
 ---
 title: Stylesheet.parentStyleSheet
 slug: Web/API/StyleSheet/parentStyleSheet
-translation_of: Web/API/StyleSheet/parentStyleSheet
 ---
 
 {{ ApiRef() }}

--- a/files/es/web/api/stylesheet/title/index.md
+++ b/files/es/web/api/stylesheet/title/index.md
@@ -1,7 +1,6 @@
 ---
 title: Stylesheet.title
 slug: Web/API/StyleSheet/title
-translation_of: Web/API/StyleSheet/title
 ---
 
 {{ ApiRef() }}

--- a/files/es/web/api/stylesheet/type/index.md
+++ b/files/es/web/api/stylesheet/type/index.md
@@ -1,7 +1,6 @@
 ---
 title: Stylesheet.type
 slug: Web/API/StyleSheet/type
-translation_of: Web/API/StyleSheet/type
 ---
 
 {{ ApiRef() }}

--- a/files/es/web/api/subtlecrypto/digest/index.md
+++ b/files/es/web/api/subtlecrypto/digest/index.md
@@ -1,7 +1,6 @@
 ---
 title: SubtleCrypto.digest()
 slug: Web/API/SubtleCrypto/digest
-translation_of: Web/API/SubtleCrypto/digest
 ---
 
 {{APIRef("Web Crypto API")}}

--- a/files/es/web/api/subtlecrypto/index.md
+++ b/files/es/web/api/subtlecrypto/index.md
@@ -1,13 +1,6 @@
 ---
 title: SubtleCrypto
 slug: Web/API/SubtleCrypto
-tags:
-  - API
-  - Interfaz
-  - Referencia
-  - SubtleCrypto
-  - Web Crypto API
-translation_of: Web/API/SubtleCrypto
 ---
 
 {{APIRef("Web Crypto API")}}

--- a/files/es/web/api/svgpoint/index.md
+++ b/files/es/web/api/svgpoint/index.md
@@ -1,12 +1,6 @@
 ---
 title: SVGPoint
 slug: Web/API/SVGPoint
-tags:
-  - SVGPoint
-  - createSVGPoint
-  - getScreenCTM
-  - matrixTransform
-translation_of: Web/API/SVGPoint
 ---
 
 {{APIRef("SVG")}}

--- a/files/es/web/api/texttrack/cuechange_event/index.md
+++ b/files/es/web/api/texttrack/cuechange_event/index.md
@@ -1,20 +1,6 @@
 ---
 title: 'TextTrack: evento cuechange'
 slug: Web/API/TextTrack/cuechange_event
-tags:
-  - API
-  - Audio
-  - Event
-  - Media
-  - Reference
-  - TextTrack
-  - Video
-  - WebVTT
-  - cuechange
-  - events
-  - oncuechange
-  - track
-translation_of: Web/API/TextTrack/cuechange_event
 ---
 
 {{APIRef}}

--- a/files/es/web/api/texttrack/index.md
+++ b/files/es/web/api/texttrack/index.md
@@ -1,17 +1,6 @@
 ---
 title: TextTrack
 slug: Web/API/TextTrack
-tags:
-  - API
-  - Interface
-  - Media
-  - NeedsTranslation
-  - Reference
-  - TextTrack
-  - TopicStub
-  - Web
-  - WebVTT
-translation_of: Web/API/TextTrack
 ---
 
 {{APIRef("WebVTT")}}

--- a/files/es/web/api/touch_events/index.md
+++ b/files/es/web/api/touch_events/index.md
@@ -1,13 +1,6 @@
 ---
 title: Eventos de toque
 slug: Web/API/Touch_events
-tags:
-  - DOM
-  - Event
-  - Mobile
-  - NeedsMobileBrowserCompatTable
-  - eventos
-translation_of: Web/API/Touch_events
 original_slug: DOM/Touch_events
 ---
 

--- a/files/es/web/api/touchevent/index.md
+++ b/files/es/web/api/touchevent/index.md
@@ -1,7 +1,6 @@
 ---
 title: TouchEvent
 slug: Web/API/TouchEvent
-translation_of: Web/API/TouchEvent
 ---
 
 {{ APIRef("Touch Events") }}

--- a/files/es/web/api/uievent/index.md
+++ b/files/es/web/api/uievent/index.md
@@ -1,10 +1,6 @@
 ---
 title: UIEvent
 slug: Web/API/UIEvent
-tags:
-  - API
-translation_of: Web/API/UIEvent
-browser-compat: api.UIEvent
 ---
 
 {{APIRef("DOM Events")}}

--- a/files/es/web/api/uievent/which/index.md
+++ b/files/es/web/api/uievent/which/index.md
@@ -1,12 +1,6 @@
 ---
 title: event.which
 slug: Web/API/UIEvent/which
-tags:
-  - DOM
-  - events
-  - metodo
-  - which
-translation_of: Web/API/KeyboardEvent/which
 original_slug: Web/API/KeyboardEvent/which
 ---
 

--- a/files/es/web/api/url/createobjecturl/index.md
+++ b/files/es/web/api/url/createobjecturl/index.md
@@ -1,14 +1,6 @@
 ---
 title: URL.createObjectURL()
 slug: Web/API/URL/createObjectURL
-tags:
-  - API
-  - Experimental
-  - Method
-  - URL
-  - URL API
-  - createObjectURL
-translation_of: Web/API/URL/createObjectURL
 ---
 
 {{ApiRef("URL")}}{{SeeCompatTable}}

--- a/files/es/web/api/url/host/index.md
+++ b/files/es/web/api/url/host/index.md
@@ -1,7 +1,6 @@
 ---
 title: Estabilidad
 slug: Web/API/URL/Host
-translation_of: Web/API/URL/host
 ---
 
 {{ApiRef("URL API")}}

--- a/files/es/web/api/url/index.md
+++ b/files/es/web/api/url/index.md
@@ -1,14 +1,6 @@
 ---
 title: URL
 slug: Web/API/URL
-tags:
-  - API
-  - Experimental
-  - Expérimental(2)
-  - NeedsTranslation
-  - TopicStub
-  - URL API
-translation_of: Web/API/URL
 ---
 
 {{ApiRef("URL API")}} {{SeeCompatTable}}

--- a/files/es/web/api/url/port/index.md
+++ b/files/es/web/api/url/port/index.md
@@ -1,7 +1,6 @@
 ---
 title: URL.port
 slug: Web/API/URL/port
-translation_of: Web/API/URL/port
 ---
 
 {{ApiRef("URL API")}}

--- a/files/es/web/api/url/url/index.md
+++ b/files/es/web/api/url/url/index.md
@@ -1,7 +1,6 @@
 ---
 title: URL()
 slug: Web/API/URL/URL
-translation_of: Web/API/URL/URL
 ---
 
 {{APIRef("URL API")}}

--- a/files/es/web/api/urlsearchparams/index.md
+++ b/files/es/web/api/urlsearchparams/index.md
@@ -1,7 +1,6 @@
 ---
 title: URLSearchParams
 slug: Web/API/URLSearchParams
-translation_of: Web/API/URLSearchParams
 ---
 
 {{ApiRef("URL API")}}

--- a/files/es/web/api/urlsearchparams/urlsearchparams/index.md
+++ b/files/es/web/api/urlsearchparams/urlsearchparams/index.md
@@ -1,13 +1,6 @@
 ---
 title: URLSearchParams()
 slug: Web/API/URLSearchParams/URLSearchParams
-tags:
-  - API
-  - API URL
-  - Constructor
-  - Referencia
-  - URLSearchParams
-translation_of: Web/API/URLSearchParams/URLSearchParams
 ---
 
 {{ApiRef("URL API")}}

--- a/files/es/web/api/vibration_api/index.md
+++ b/files/es/web/api/vibration_api/index.md
@@ -1,16 +1,6 @@
 ---
 title: Vibración API
 slug: Web/API/Vibration_API
-tags:
-  - API
-  - Firefox OS
-  - Mobile
-  - Principiante
-  - Vibración
-  - Vibrado
-  - Vibrar
-  - WebAPI
-translation_of: Web/API/Vibration_API
 original_slug: Web/Guide/API/Vibration
 ---
 

--- a/files/es/web/api/web_audio_api/index.md
+++ b/files/es/web/api/web_audio_api/index.md
@@ -1,7 +1,6 @@
 ---
 title: Web Audio API
 slug: Web/API/Web_Audio_API
-translation_of: Web/API/Web_Audio_API
 original_slug: Web_Audio_API
 ---
 

--- a/files/es/web/api/web_crypto_api/index.md
+++ b/files/es/web/api/web_crypto_api/index.md
@@ -1,11 +1,6 @@
 ---
 title: Web Crypto API
 slug: Web/API/Web_Crypto_API
-tags:
-  - Referencia
-  - Vista general
-  - Web Crypto API
-translation_of: Web/API/Web_Crypto_API
 ---
 
 {{DefaultAPISidebar("Web Crypto API")}}{{SeeCompatTable}}

--- a/files/es/web/api/web_speech_api/index.md
+++ b/files/es/web/api/web_speech_api/index.md
@@ -1,18 +1,6 @@
 ---
 title: Web Speech API
 slug: Web/API/Web_Speech_API
-tags:
-  - API
-  - Experimental
-  - Landing
-  - NeedsTranslation
-  - Reference
-  - TopicStub
-  - Web Speech API
-  - recognition
-  - speech
-  - synthesis
-translation_of: Web/API/Web_Speech_API
 ---
 
 {{DefaultAPISidebar("Web Speech API")}}{{seecompattable}}

--- a/files/es/web/api/web_speech_api/using_the_web_speech_api/index.md
+++ b/files/es/web/api/web_speech_api/using_the_web_speech_api/index.md
@@ -1,7 +1,6 @@
 ---
 title: Uso de la Web Speech API
 slug: Web/API/Web_Speech_API/Using_the_Web_Speech_API
-translation_of: Web/API/Web_Speech_API/Using_the_Web_Speech_API
 original_slug: Web/API/Web_Speech_API/Uso_de_la_Web_Speech_API
 ---
 

--- a/files/es/web/api/web_storage_api/index.md
+++ b/files/es/web/api/web_storage_api/index.md
@@ -1,14 +1,6 @@
 ---
 title: API de almacenamiento web
 slug: Web/API/Web_Storage_API
-tags:
-  - API
-  - API de almacenamiento web
-  - Almacenamiento web
-  - Storage
-  - localStorage
-  - sessionStorage
-translation_of: Web/API/Web_Storage_API
 original_slug: Web/API/API_de_almacenamiento_web
 ---
 

--- a/files/es/web/api/web_storage_api/using_the_web_storage_api/index.md
+++ b/files/es/web/api/web_storage_api/using_the_web_storage_api/index.md
@@ -1,13 +1,6 @@
 ---
 title: Usando la API de almacenamiento web
 slug: Web/API/Web_Storage_API/Using_the_Web_Storage_API
-tags:
-  - API
-  - API de almacenamiento web
-  - Guía
-  - localStorage
-  - sessionStorage
-translation_of: Web/API/Web_Storage_API/Using_the_Web_Storage_API
 original_slug: Web/API/API_de_almacenamiento_web/Usando_la_API_de_almacenamiento_web
 ---
 

--- a/files/es/web/api/web_workers_api/index.md
+++ b/files/es/web/api/web_workers_api/index.md
@@ -1,7 +1,6 @@
 ---
 title: Web Workers API
 slug: Web/API/Web_Workers_API
-translation_of: Web/API/Web_Workers_API
 ---
 
 {{DefaultAPISidebar("Web Workers API")}}

--- a/files/es/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/es/web/api/web_workers_api/using_web_workers/index.md
@@ -1,7 +1,6 @@
 ---
 title: Usando Web Workers
 slug: Web/API/Web_Workers_API/Using_web_workers
-translation_of: Web/API/Web_Workers_API/Using_web_workers
 original_slug: Web/Guide/Performance/Usando_web_workers
 ---
 

--- a/files/es/web/api/webgl_api/index.md
+++ b/files/es/web/api/webgl_api/index.md
@@ -1,9 +1,6 @@
 ---
 title: WebGL
 slug: Web/API/WebGL_API
-tags:
-  - WebGL
-translation_of: Web/API/WebGL_API
 ---
 
 {{WebGLSidebar}}

--- a/files/es/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
+++ b/files/es/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
@@ -1,7 +1,6 @@
 ---
 title: Agregando Contenido 2D en el Contexto WebGL
 slug: Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context
-translation_of: Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context
 ---
 
 {{WebGLSidebar("Tutorial")}} {{PreviousNext("Web/API/WebGL_API/Tutorial/Getting_started_with_WebGL", "Web/API/WebGL_API/Tutorial/Using_shaders_to_apply_color_in_WebGL")}}

--- a/files/es/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
+++ b/files/es/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
@@ -1,7 +1,6 @@
 ---
 title: Animating textures in WebGL
 slug: Web/API/WebGL_API/Tutorial/Animating_textures_in_WebGL
-translation_of: Web/API/WebGL_API/Tutorial/Animating_textures_in_WebGL
 ---
 
 {{WebGLSidebar("Tutorial") }} {{Previous("Web/API/WebGL_API/Tutorial/Lighting_in_WebGL")}}

--- a/files/es/web/api/webgl_api/tutorial/creating_3d_objects_using_webgl/index.md
+++ b/files/es/web/api/webgl_api/tutorial/creating_3d_objects_using_webgl/index.md
@@ -1,12 +1,6 @@
 ---
 title: Creación de objetos 3D utilizando WebGL
 slug: Web/API/WebGL_API/Tutorial/Creating_3D_objects_using_WebGL
-tags:
-  - Cubo 3D
-  - Objetos 3D
-  - Tutorial
-  - WebGL
-translation_of: Web/API/WebGL_API/Tutorial/Creating_3D_objects_using_WebGL
 original_slug: Web/API/WebGL_API/Tutorial/Objetos_3D_utilizando_WebGL
 ---
 

--- a/files/es/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
+++ b/files/es/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
@@ -1,11 +1,6 @@
 ---
 title: Primeros pasos con WebGL
 slug: Web/API/WebGL_API/Tutorial/Getting_started_with_WebGL
-tags:
-  - Intro
-  - Tutorial
-  - WebGL
-translation_of: Web/API/WebGL_API/Tutorial/Getting_started_with_WebGL
 ---
 
 {{WebGLSidebar("Tutorial")}} {{Next("Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context")}}

--- a/files/es/web/api/webgl_api/tutorial/index.md
+++ b/files/es/web/api/webgl_api/tutorial/index.md
@@ -1,10 +1,6 @@
 ---
 title: Tutoral de WebGL
 slug: Web/API/WebGL_API/Tutorial
-tags:
-  - Tutorial
-  - WebGL
-translation_of: Web/API/WebGL_API/Tutorial
 ---
 
 {{WebGLSidebar}}

--- a/files/es/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
+++ b/files/es/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
@@ -1,7 +1,6 @@
 ---
 title: Utilizar los shaders para aplicar color en WebGL
 slug: Web/API/WebGL_API/Tutorial/Using_shaders_to_apply_color_in_WebGL
-translation_of: Web/API/WebGL_API/Tutorial/Using_shaders_to_apply_color_in_WebGL
 ---
 
 {{WebGLSidebar("Tutorial")}} {{PreviousNext("Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context", "Web/API/WebGL_API/Tutorial/Animating_objects_with_WebGL")}}

--- a/files/es/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/es/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -1,11 +1,6 @@
 ---
 title: Utilizando texturas en WebGL
 slug: Web/API/WebGL_API/Tutorial/Using_textures_in_WebGL
-tags:
-  - Texturas
-  - Tutorial
-  - WebGL
-translation_of: Web/API/WebGL_API/Tutorial/Using_textures_in_WebGL
 original_slug: Web/API/WebGL_API/Tutorial/Wtilizando_texturas_en_WebGL
 ---
 

--- a/files/es/web/api/webrtc_api/index.md
+++ b/files/es/web/api/webrtc_api/index.md
@@ -1,10 +1,6 @@
 ---
 title: API de WebRTC
 slug: Web/API/WebRTC_API
-tags:
-  - API
-  - WebRTC
-translation_of: Web/API/WebRTC_API
 ---
 
 {{DefaultAPISidebar("WebRTC")}}

--- a/files/es/web/api/webrtc_api/protocols/index.md
+++ b/files/es/web/api/webrtc_api/protocols/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebRTC protocols
 slug: Web/API/WebRTC_API/Protocols
-translation_of: Web/API/WebRTC_API/Protocols
 ---
 
 {{DefaultAPISidebar("WebRTC")}}

--- a/files/es/web/api/webrtc_api/session_lifetime/index.md
+++ b/files/es/web/api/webrtc_api/session_lifetime/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebRTC Introduction
 slug: Web/API/WebRTC_API/Session_lifetime
-translation_of: Web/API/WebRTC_API/Session_lifetime
 original_slug: WebRTC/Introduction
 ---
 

--- a/files/es/web/api/websocket/close_event/index.md
+++ b/files/es/web/api/websocket/close_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: close
 slug: Web/API/WebSocket/close_event
-translation_of: Web/API/WebSocket/close_event
 ---
 
 El manejador `close` es ejecutado cuando una conexión con un websocket es cerrada.

--- a/files/es/web/api/websocket/error_event/index.md
+++ b/files/es/web/api/websocket/error_event/index.md
@@ -1,14 +1,6 @@
 ---
 title: WebSocket.onerror
 slug: Web/API/WebSocket/error_event
-tags:
-  - API
-  - Error
-  - Propiedad
-  - Referencia
-  - Web API
-  - WebSocket
-translation_of: Web/API/WebSocket/onerror
 original_slug: Web/API/WebSocket/onerror
 ---
 

--- a/files/es/web/api/websocket/index.md
+++ b/files/es/web/api/websocket/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebSocket
 slug: Web/API/WebSocket
-translation_of: Web/API/WebSocket
 ---
 
 {{APIRef("Web Sockets API")}}{{SeeCompatTable}}El objeto WebSocket provee la API para la creación y administración de una conexión [WebSocket](/es/docs/Web/API/WebSockets_API)a un servidor, así como también para enviar y recibir datos en la conexión.El constructor de WebSocket acepta un parámetro requerido y otro opcional.

--- a/files/es/web/api/websockets_api/index.md
+++ b/files/es/web/api/websockets_api/index.md
@@ -1,7 +1,6 @@
 ---
 title: WebSockets
 slug: Web/API/WebSockets_API
-translation_of: Web/API/WebSockets_API
 ---
 
 {{DefaultAPISidebar("Websockets API")}}

--- a/files/es/web/api/websockets_api/writing_websocket_client_applications/index.md
+++ b/files/es/web/api/websockets_api/writing_websocket_client_applications/index.md
@@ -1,9 +1,6 @@
 ---
 title: Escribiendo aplicaciones con WebSockets
 slug: Web/API/WebSockets_API/Writing_WebSocket_client_applications
-tags:
-  - Guía WebSocket WebSockets
-translation_of: Web/API/WebSockets_API/Writing_WebSocket_client_applications
 ---
 
 WebSockets es una tecnología basada en el protocolo ws, este hace posible establecer una conexión continua full-duplex, entre un cliente y servidor. Un cliente websocket podría ser el navegador del usuario, pero el protocolo es una plataforma independiente.

--- a/files/es/web/api/websockets_api/writing_websocket_server/index.md
+++ b/files/es/web/api/websockets_api/writing_websocket_server/index.md
@@ -1,11 +1,6 @@
 ---
 title: Escribiendo un servidor WebSocket en C#
 slug: Web/API/WebSockets_API/Writing_WebSocket_server
-tags:
-  - HTML5
-  - Tutorial
-  - WebSockets
-translation_of: Web/API/WebSockets_API/Writing_WebSocket_server
 original_slug: Web/API/WebSockets_API/Escribiendo_servidor_WebSocket
 ---
 

--- a/files/es/web/api/websockets_api/writing_websocket_servers/index.md
+++ b/files/es/web/api/websockets_api/writing_websocket_servers/index.md
@@ -1,7 +1,6 @@
 ---
 title: Escribir servidores WebSocket
 slug: Web/API/WebSockets_API/Writing_WebSocket_servers
-translation_of: Web/API/WebSockets_API/Writing_WebSocket_servers
 original_slug: Web/API/WebSockets_API/Escribiendo_servidores_con_WebSocket
 ---
 

--- a/files/es/web/api/webvr_api/index.md
+++ b/files/es/web/api/webvr_api/index.md
@@ -1,17 +1,6 @@
 ---
 title: WebVR API
 slug: Web/API/WebVR_API
-tags:
-  - API
-  - Experimental
-  - Landing
-  - NeedsTranslation
-  - Reference
-  - TopicStub
-  - VR
-  - Virtual Reality
-  - WebVR
-translation_of: Web/API/WebVR_API
 ---
 
 {{SeeCompatTable}}{{APIRef("WebVR API")}}

--- a/files/es/web/api/webvr_api/using_the_webvr_api/index.md
+++ b/files/es/web/api/webvr_api/using_the_webvr_api/index.md
@@ -1,16 +1,6 @@
 ---
 title: Uso de la API de WebVR
 slug: Web/API/WebVR_API/Using_the_WebVR_API
-tags:
-  - '1.1'
-  - API
-  - Canvas
-  - Realidad Virtual
-  - Tutorial
-  - VR
-  - WebGL
-  - WebVR
-translation_of: Web/API/WebVR_API/Using_the_WebVR_API
 ---
 
 {{APIRef("WebVR API")}}

--- a/files/es/web/api/wheelevent/deltay/index.md
+++ b/files/es/web/api/wheelevent/deltay/index.md
@@ -1,7 +1,6 @@
 ---
 title: WheelEvent.deltaY
 slug: Web/API/WheelEvent/deltaY
-translation_of: Web/API/WheelEvent/deltaY
 ---
 
 {{APIRef("DOM Events")}}

--- a/files/es/web/api/wheelevent/index.md
+++ b/files/es/web/api/wheelevent/index.md
@@ -1,14 +1,6 @@
 ---
 title: WheelEvent
 slug: Web/API/WheelEvent
-tags:
-  - API
-  - DOM
-  - Interface
-  - Referencia
-  - WheelEvent
-  - eventos
-translation_of: Web/API/WheelEvent
 ---
 
 {{APIRef("DOM Events")}}

--- a/files/es/web/api/window/alert/index.md
+++ b/files/es/web/api/window/alert/index.md
@@ -1,8 +1,6 @@
 ---
 title: Window.alert()
 slug: Web/API/Window/alert
-translation_of: Web/API/Window/alert
-browser-compat: api.Window.alert
 ---
 
 {{ APIRef }}

--- a/files/es/web/api/window/applicationcache/index.md
+++ b/files/es/web/api/window/applicationcache/index.md
@@ -1,9 +1,6 @@
 ---
 title: Window.applicationCache
 slug: Web/API/Window/applicationCache
-translation_of: Web/API/Window/applicationCache
-page-type: web-api-instance-property
-browser-compat: api.SharedWorkerGlobalScope.applicationCache
 ---
 
 {{APIRef}}{{Deprecated_Header}}{{Non-standard_Header}}{{securecontext_header}}

--- a/files/es/web/api/window/beforeunload_event/index.md
+++ b/files/es/web/api/window/beforeunload_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: beforeunload
 slug: Web/API/Window/beforeunload_event
-translation_of: Web/API/Window/beforeunload_event
 original_slug: Web/Events/beforeunload
 ---
 

--- a/files/es/web/api/window/blur_event/index.md
+++ b/files/es/web/api/window/blur_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: GlobalEventHandlers.onblur
 slug: Web/API/Window/blur_event
-translation_of: Web/API/GlobalEventHandlers/onblur
 original_slug: Web/API/GlobalEventHandlers/onblur
 ---
 

--- a/files/es/web/api/window/cancelanimationframe/index.md
+++ b/files/es/web/api/window/cancelanimationframe/index.md
@@ -1,7 +1,6 @@
 ---
 title: window.cancelAnimationFrame()
 slug: Web/API/Window/cancelAnimationFrame
-translation_of: Web/API/Window/cancelAnimationFrame
 ---
 
 {{APIRef}}{{SeeCompatTable}}

--- a/files/es/web/api/window/close/index.md
+++ b/files/es/web/api/window/close/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.close()
 slug: Web/API/Window/close
-translation_of: Web/API/Window/close
 ---
 
 {{ ApiRef() }}

--- a/files/es/web/api/window/closed/index.md
+++ b/files/es/web/api/window/closed/index.md
@@ -1,13 +1,6 @@
 ---
 title: Window.closed
 slug: Web/API/Window/closed
-tags:
-  - API
-  - HTML DOM
-  - Propiedad
-  - Referencia
-  - Ventana
-translation_of: Web/API/Window/closed
 ---
 
 {{APIRef}}

--- a/files/es/web/api/window/confirm/index.md
+++ b/files/es/web/api/window/confirm/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.confirm()
 slug: Web/API/Window/confirm
-translation_of: Web/API/Window/confirm
 ---
 
 {{ApiRef("Window")}}

--- a/files/es/web/api/window/devicepixelratio/index.md
+++ b/files/es/web/api/window/devicepixelratio/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.devicePixelRatio
 slug: Web/API/Window/devicePixelRatio
-translation_of: Web/API/Window/devicePixelRatio
 ---
 
 {{APIRef}}

--- a/files/es/web/api/window/document/index.md
+++ b/files/es/web/api/window/document/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.document
 slug: Web/API/Window/document
-translation_of: Web/API/Window/document
 ---
 
 {{APIRef}}

--- a/files/es/web/api/window/error_event/index.md
+++ b/files/es/web/api/window/error_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: GlobalEventHandlers.onerror
 slug: Web/API/Window/error_event
-translation_of: Web/API/GlobalEventHandlers/onerror
 original_slug: Web/API/GlobalEventHandlers/onerror
 ---
 

--- a/files/es/web/api/window/focus_event/index.md
+++ b/files/es/web/api/window/focus_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: GlobalEventHandlers.onfocus
 slug: Web/API/Window/focus_event
-translation_of: Web/API/GlobalEventHandlers/onfocus
 original_slug: Web/API/GlobalEventHandlers/onfocus
 ---
 

--- a/files/es/web/api/window/frameelement/index.md
+++ b/files/es/web/api/window/frameelement/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.frameElement
 slug: Web/API/Window/frameElement
-translation_of: Web/API/Window/frameElement
 ---
 
 {{ ApiRef }}

--- a/files/es/web/api/window/fullscreen/index.md
+++ b/files/es/web/api/window/fullscreen/index.md
@@ -1,10 +1,6 @@
 ---
 title: window.fullScreen
 slug: Web/API/Window/fullScreen
-tags:
-  - Referencia_DOM_de_Gecko
-  - páginas_a_traducir
-translation_of: Web/API/Window/fullScreen
 ---
 
 {{APIRef}}

--- a/files/es/web/api/window/getcomputedstyle/index.md
+++ b/files/es/web/api/window/getcomputedstyle/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.getComputedStyle
 slug: Web/API/Window/getComputedStyle
-translation_of: Web/API/Window/getComputedStyle
 ---
 
 {{ ApiRef() }}

--- a/files/es/web/api/window/getselection/index.md
+++ b/files/es/web/api/window/getselection/index.md
@@ -1,9 +1,6 @@
 ---
 title: window.getSelection
 slug: Web/API/Window/getSelection
-tags:
-  - páginas_a_traducir
-translation_of: Web/API/Window/getSelection
 ---
 
 {{ ApiRef() }}

--- a/files/es/web/api/window/hashchange_event/index.md
+++ b/files/es/web/api/window/hashchange_event/index.md
@@ -1,11 +1,6 @@
 ---
 title: hashchange
 slug: Web/API/Window/hashchange_event
-tags:
-  - Referencia
-  - URL
-  - Web
-translation_of: Web/API/Window/hashchange_event
 ---
 
 {{ APIRef }}

--- a/files/es/web/api/window/history/index.md
+++ b/files/es/web/api/window/history/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.history
 slug: Web/API/Window/history
-translation_of: Web/API/Window/history
 ---
 
 {{ APIRef }}

--- a/files/es/web/api/window/index.md
+++ b/files/es/web/api/window/index.md
@@ -1,12 +1,6 @@
 ---
 title: window
 slug: Web/API/Window
-tags:
-  - API
-  - DOM
-  - Window
-  - páginas_a_traducir
-translation_of: Web/API/Window
 ---
 
 {{APIRef}}

--- a/files/es/web/api/window/innerheight/index.md
+++ b/files/es/web/api/window/innerheight/index.md
@@ -1,12 +1,6 @@
 ---
 title: window.innerHeight
 slug: Web/API/Window/innerHeight
-tags:
-  - API
-  - Propiedades
-  - Referências
-  - Window
-translation_of: Web/API/Window/innerHeight
 ---
 
 {{APIRef}}

--- a/files/es/web/api/window/load_event/index.md
+++ b/files/es/web/api/window/load_event/index.md
@@ -1,9 +1,6 @@
 ---
 title: load
 slug: Web/API/Window/load_event
-tags:
-  - Evento
-translation_of: Web/API/Window/load_event
 original_slug: Web/Events/load
 ---
 

--- a/files/es/web/api/window/localstorage/index.md
+++ b/files/es/web/api/window/localstorage/index.md
@@ -1,14 +1,6 @@
 ---
 title: Window.localStorage
 slug: Web/API/Window/localStorage
-tags:
-  - API
-  - Propiedad
-  - Referencia
-  - Web Storage
-  - WindowLocalStorage
-  - localStorage
-translation_of: Web/API/Window/localStorage
 ---
 
 {{APIRef()}}

--- a/files/es/web/api/window/location/index.md
+++ b/files/es/web/api/window/location/index.md
@@ -1,11 +1,6 @@
 ---
 title: Window.location
 slug: Web/API/Window/location
-tags:
-  - Location
-  - contexto
-  - navegación
-translation_of: Web/API/Window/location
 ---
 
 {{APIRef}}

--- a/files/es/web/api/window/locationbar/index.md
+++ b/files/es/web/api/window/locationbar/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.locationbar
 slug: Web/API/Window/locationbar
-translation_of: Web/API/Window/locationbar
 ---
 
 {{APIRef}}

--- a/files/es/web/api/window/matchmedia/index.md
+++ b/files/es/web/api/window/matchmedia/index.md
@@ -1,15 +1,6 @@
 ---
 title: Window.matchMedia()
 slug: Web/API/Window/matchMedia
-tags:
-  - API
-  - CSSOM View
-  - JavaScript
-  - Media Queries
-  - Referencia
-  - Window
-  - metodo
-translation_of: Web/API/Window/matchMedia
 ---
 
 {{APIRef}}

--- a/files/es/web/api/window/menubar/index.md
+++ b/files/es/web/api/window/menubar/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.menubar
 slug: Web/API/Window/menubar
-translation_of: Web/API/Window/menubar
 ---
 
 {{ APIRef() }}

--- a/files/es/web/api/window/moveby/index.md
+++ b/files/es/web/api/window/moveby/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.moveBy()
 slug: Web/API/Window/moveBy
-translation_of: Web/API/Window/moveBy
 ---
 
 {{APIRef}}

--- a/files/es/web/api/window/navigator/index.md
+++ b/files/es/web/api/window/navigator/index.md
@@ -1,17 +1,6 @@
 ---
 title: Window.navigator
 slug: Web/API/Window/navigator
-tags:
-  - API
-  - DOM
-  - DOM Reference
-  - HTML-DOM
-  - Property
-  - Reference
-  - WebAPI
-  - Window
-  - Window.navigator
-translation_of: Web/API/Window/navigator
 ---
 
 {{ApiRef}}

--- a/files/es/web/api/window/offline_event/index.md
+++ b/files/es/web/api/window/offline_event/index.md
@@ -1,12 +1,6 @@
 ---
 title: Offline
 slug: Web/API/Window/offline_event
-tags:
-  - Event
-  - Evento
-  - Reference
-  - Referencia
-translation_of: Web/API/Window/offline_event
 ---
 
 {{APIRef}}

--- a/files/es/web/api/window/open/index.md
+++ b/files/es/web/api/window/open/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.open()
 slug: Web/API/Window/open
-translation_of: Web/API/Window/open
 ---
 
 {{APIRef}}

--- a/files/es/web/api/window/opener/index.md
+++ b/files/es/web/api/window/opener/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.opener
 slug: Web/API/Window/opener
-translation_of: Web/API/Window/opener
 ---
 
 {{APIRef}}

--- a/files/es/web/api/window/outerheight/index.md
+++ b/files/es/web/api/window/outerheight/index.md
@@ -1,11 +1,6 @@
 ---
 title: Window.outerHeight
 slug: Web/API/Window/outerHeight
-tags:
-  - API
-  - Propiedad
-  - Referencia
-translation_of: Web/API/Window/outerHeight
 ---
 
 {{APIRef}}

--- a/files/es/web/api/window/outerwidth/index.md
+++ b/files/es/web/api/window/outerwidth/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.outerWidth
 slug: Web/API/Window/outerWidth
-translation_of: Web/API/Window/outerWidth
 ---
 
 {{APIRef}}

--- a/files/es/web/api/window/popstate_event/index.md
+++ b/files/es/web/api/window/popstate_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: WindowEventHandlers.onpopstate
 slug: Web/API/Window/popstate_event
-translation_of: Web/API/WindowEventHandlers/onpopstate
 original_slug: Web/API/WindowEventHandlers/onpopstate
 ---
 

--- a/files/es/web/api/window/print/index.md
+++ b/files/es/web/api/window/print/index.md
@@ -1,15 +1,6 @@
 ---
 title: Window.print()
 slug: Web/API/Window/print
-tags:
-  - API
-  - Compatibilidad
-  - Compatibilidad en móviles
-  - DOM
-  - Referencia
-  - Window
-  - metodo
-translation_of: Web/API/Window/print
 ---
 
 {{ ApiRef() }}

--- a/files/es/web/api/window/prompt/index.md
+++ b/files/es/web/api/window/prompt/index.md
@@ -1,10 +1,6 @@
 ---
 title: Window.prompt()
 slug: Web/API/Window/prompt
-tags:
-  - Referencia
-  - metodo
-translation_of: Web/API/Window/prompt
 ---
 
 {{ApiRef("Window")}}

--- a/files/es/web/api/window/requestanimationframe/index.md
+++ b/files/es/web/api/window/requestanimationframe/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.requestAnimationFrame()
 slug: Web/API/Window/requestAnimationFrame
-translation_of: Web/API/window/requestAnimationFrame
 ---
 
 {{APIRef}}El método **`window.requestAnimationFrame`** informa al navegador que quieres realizar una animación y solicita que el navegador programe el repintado de la ventana para el próximo ciclo de animación. El método acepta como argumento una función a la que llamar antes de efectuar el repintado.

--- a/files/es/web/api/window/requestidlecallback/index.md
+++ b/files/es/web/api/window/requestidlecallback/index.md
@@ -1,7 +1,6 @@
 ---
 title: requestIdleCallback
 slug: Web/API/Window/requestIdleCallback
-translation_of: Web/API/Window/requestIdleCallback
 ---
 
 {{APIRef("HTML DOM")}}{{SeeCompatTable}}

--- a/files/es/web/api/window/resize_event/index.md
+++ b/files/es/web/api/window/resize_event/index.md
@@ -1,11 +1,6 @@
 ---
 title: GlobalEventHandlers.onresize
 slug: Web/API/Window/resize_event
-tags:
-  - API
-  - DOM
-  - Propiedad
-translation_of: Web/API/GlobalEventHandlers/onresize
 original_slug: Web/API/GlobalEventHandlers/onresize
 ---
 

--- a/files/es/web/api/window/scroll/index.md
+++ b/files/es/web/api/window/scroll/index.md
@@ -1,12 +1,6 @@
 ---
 title: Window.scroll()
 slug: Web/API/Window/scroll
-tags:
-  - API
-  - CSSOM View
-  - Referencia
-  - metodo
-translation_of: Web/API/Window/scroll
 ---
 
 {{APIRef}}

--- a/files/es/web/api/window/scrollby/index.md
+++ b/files/es/web/api/window/scrollby/index.md
@@ -1,14 +1,6 @@
 ---
 title: Window.scrollBy()
 slug: Web/API/Window/scrollBy
-tags:
-  - API
-  - CSSOM View
-  - Método(2)
-  - NeedsCompatTable
-  - NeedsSpecTable
-  - Referencia
-translation_of: Web/API/Window/scrollBy
 ---
 
 {{ APIRef() }}

--- a/files/es/web/api/window/scrollto/index.md
+++ b/files/es/web/api/window/scrollto/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.scrollTo()
 slug: Web/API/Window/scrollTo
-translation_of: Web/API/Window/scrollTo
 ---
 
 {{ APIRef }}

--- a/files/es/web/api/window/scrollx/index.md
+++ b/files/es/web/api/window/scrollx/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.scrollX
 slug: Web/API/Window/scrollX
-translation_of: Web/API/Window/scrollX
 ---
 
 {{ APIRef() }}

--- a/files/es/web/api/window/scrolly/index.md
+++ b/files/es/web/api/window/scrolly/index.md
@@ -1,12 +1,6 @@
 ---
 title: Window.scrollY
 slug: Web/API/Window/scrollY
-tags:
-  - API
-  - Propiedad
-  - Rerencia
-  - Scroll Vertical
-translation_of: Web/API/Window/scrollY
 ---
 
 {{APIRef}}

--- a/files/es/web/api/window/sessionstorage/index.md
+++ b/files/es/web/api/window/sessionstorage/index.md
@@ -1,12 +1,6 @@
 ---
 title: Window.sessionStorage
 slug: Web/API/Window/sessionStorage
-tags:
-  - Almacenaje
-  - Propiedad
-  - Referencia
-  - Sesion
-translation_of: Web/API/Window/sessionStorage
 ---
 
 {{APIRef()}}

--- a/files/es/web/api/window/showmodaldialog/index.md
+++ b/files/es/web/api/window/showmodaldialog/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.showModalDialog()
 slug: Web/API/Window/showModalDialog
-translation_of: Web/API/Window/showModalDialog
 ---
 
 {{ deprecated_header() }}{{APIRef}}

--- a/files/es/web/api/window/statusbar/index.md
+++ b/files/es/web/api/window/statusbar/index.md
@@ -1,7 +1,6 @@
 ---
 title: Window.statusbar
 slug: Web/API/Window/statusbar
-translation_of: Web/API/Window/statusbar
 ---
 
 {{APIRef}}

--- a/files/es/web/api/worker/index.md
+++ b/files/es/web/api/worker/index.md
@@ -1,17 +1,6 @@
 ---
 title: Worker
 slug: Web/API/Worker
-tags:
-  - API
-  - DOM
-  - Interface
-  - NeedsTranslation
-  - Reference
-  - TopicStub
-  - Web Workers
-  - Worker
-  - Workers
-translation_of: Web/API/Worker
 ---
 
 {{APIRef("Web Workers API")}}

--- a/files/es/web/api/worker/terminate/index.md
+++ b/files/es/web/api/worker/terminate/index.md
@@ -1,7 +1,6 @@
 ---
 title: Worker.terminate()
 slug: Web/API/Worker/terminate
-translation_of: Web/API/Worker/terminate
 ---
 
 {{APIRef("Web Workers API")}}

--- a/files/es/web/api/workernavigator/index.md
+++ b/files/es/web/api/workernavigator/index.md
@@ -1,8 +1,6 @@
 ---
 title: WorkerNavigator
 slug: Web/API/WorkerNavigator
-translation_of: Web/API/WorkerNavigator
-browser-compat: api.WorkerNavigator
 ---
 
 {{APIRef("Web Workers API")}}

--- a/files/es/web/api/xmldocument/async/index.md
+++ b/files/es/web/api/xmldocument/async/index.md
@@ -1,7 +1,6 @@
 ---
 title: Document.async
 slug: Web/API/XMLDocument/async
-translation_of: Web/API/XMLDocument/async
 original_slug: Web/API/Document/async
 ---
 

--- a/files/es/web/api/xmlhttprequest/abort/index.md
+++ b/files/es/web/api/xmlhttprequest/abort/index.md
@@ -1,17 +1,6 @@
 ---
 title: XMLHttpRequest.abort()
 slug: Web/API/XMLHttpRequest/abort
-tags:
-  - AJAX
-  - API
-  - HTTP
-  - HttpRequest
-  - Referencia
-  - XHR
-  - XMLHttpRequest
-  - abortar
-  - metodo
-translation_of: Web/API/XMLHttpRequest/abort
 ---
 
 {{APIRef('XMLHttpRequest')}}

--- a/files/es/web/api/xmlhttprequest/index.md
+++ b/files/es/web/api/xmlhttprequest/index.md
@@ -1,12 +1,6 @@
 ---
 title: XMLHttpRequest
 slug: Web/API/XMLHttpRequest
-tags:
-  - AJAX
-  - Todas_las_Categorías
-  - XMLHttpRequest
-  - páginas_a_traducir
-translation_of: Web/API/XMLHttpRequest
 ---
 
 `XMLHttpRequest` es un objeto [JavaScript](/en/JavaScript) que fue diseñado por Microsoft y adoptado por Mozilla, Apple y Google. Actualmente es un [estándar de la W3C](http://www.w3.org/TR/XMLHttpRequest/). Proporciona una forma fácil de obtener información de una URL sin tener que recargar la página completa. Una página web puede actualizar sólo una parte de la página sin interrumpir lo que el usuario está haciendo. `XMLHttpRequest` es ampliamente usado en la programación AJAX.

--- a/files/es/web/api/xmlhttprequest/loadend_event/index.md
+++ b/files/es/web/api/xmlhttprequest/loadend_event/index.md
@@ -1,9 +1,6 @@
 ---
 title: loadend
 slug: Web/API/XMLHttpRequest/loadend_event
-tags:
-  - eventos
-translation_of: Web/API/XMLHttpRequest/loadend_event
 original_slug: Web/Events/loadend
 ---
 

--- a/files/es/web/api/xmlhttprequest/readystatechange_event/index.md
+++ b/files/es/web/api/xmlhttprequest/readystatechange_event/index.md
@@ -1,7 +1,6 @@
 ---
 title: XMLHttpRequest.onreadystatechange
 slug: Web/API/XMLHttpRequest/readystatechange_event
-translation_of: Web/API/XMLHttpRequest/onreadystatechange
 original_slug: Web/API/XMLHttpRequest/onreadystatechange
 ---
 

--- a/files/es/web/api/xmlhttprequest/responsetext/index.md
+++ b/files/es/web/api/xmlhttprequest/responsetext/index.md
@@ -1,7 +1,6 @@
 ---
 title: XMLHttpRequest.responseText
 slug: Web/API/XMLHttpRequest/responseText
-translation_of: Web/API/XMLHttpRequest/responseText
 ---
 
 {{APIRef('XMLHttpRequest')}}

--- a/files/es/web/api/xmlhttprequest/timeout/index.md
+++ b/files/es/web/api/xmlhttprequest/timeout/index.md
@@ -1,17 +1,6 @@
 ---
 title: XMLHttpRequest.timeout
 slug: Web/API/XMLHttpRequest/timeout
-tags:
-  - AJAX
-  - Propiedad
-  - Referencia
-  - XHR
-  - XHR asincrónico
-  - XMLHttpRequest
-  - XMLHttpRequest asincrónico
-  - tiempo de espera
-  - timeout
-translation_of: Web/API/XMLHttpRequest/timeout
 ---
 
 {{APIRef('XMLHttpRequest')}}

--- a/files/es/web/api/xmlhttprequest/using_xmlhttprequest/index.md
+++ b/files/es/web/api/xmlhttprequest/using_xmlhttprequest/index.md
@@ -1,7 +1,6 @@
 ---
 title: Utilizando XMLHttpRequest
 slug: Web/API/XMLHttpRequest/Using_XMLHttpRequest
-translation_of: Web/API/XMLHttpRequest/Using_XMLHttpRequest
 ---
 
 {{APIRef("XMLHttpRequest")}}

--- a/files/es/web/css/index.md
+++ b/files/es/web/css/index.md
@@ -1,14 +1,6 @@
 ---
 title: CSS
 slug: Web/CSS
-tags:
-  - CSS
-  - Diseño
-  - Estilo
-  - Hojas de Estilo en Cascada
-  - Hojas de estilo
-  - Referencia
-translation_of: Web/CSS
 ---
 
 **Hojas de Estilo en Cascada** (del inglés _**C**ascading **S**tyle **S**heets_) o **CSS** es el lenguaje de [estilos](/es/docs/Web/API/StyleSheet) utilizado para describir la presentación de documentos [HTML](/es/docs/HTML) o [XML](/es/docs/XML) (incluyendo varios languages basados en XML como [SVG](/es/docs/Web/SVG), [MathML](/es/docs/Web/MathML) o {{Glossary("XHTML")}}). CSS describe como debe ser renderizado el elemento estructurado en la pantalla, en papel, en el habla o en otros medios.

--- a/files/es/web/css/scroll-behavior/index.md
+++ b/files/es/web/css/scroll-behavior/index.md
@@ -1,12 +1,6 @@
 ---
 title: scroll-behavior
 slug: Web/CSS/scroll-behavior
-tags:
-  - CSS
-  - Propiedad CSS
-  - Referencia
-  - Vista CSSOM
-translation_of: Web/CSS/scroll-behavior
 ---
 
 {{ CSSRef }}

--- a/files/es/web/css/shorthand_properties/index.md
+++ b/files/es/web/css/shorthand_properties/index.md
@@ -1,7 +1,6 @@
 ---
 title: Propiedades abreviadas
 slug: Web/CSS/Shorthand_properties
-translation_of: Web/CSS/Shorthand_properties
 original_slug: Web/CSS/Shorthand_properties
 ---
 

--- a/files/es/web/css/specificity/index.md
+++ b/files/es/web/css/specificity/index.md
@@ -1,13 +1,6 @@
 ---
 title: Especificidad
 slug: Web/CSS/Specificity
-tags:
-  - CSS
-  - Ejemplo
-  - Guía
-  - Principiante
-  - Web
-translation_of: Web/CSS/Specificity
 original_slug: Web/CSS/Especificidad
 ---
 

--- a/files/es/web/css/specified_value/index.md
+++ b/files/es/web/css/specified_value/index.md
@@ -1,10 +1,6 @@
 ---
 title: Valor especificado
 slug: Web/CSS/specified_value
-tags:
-  - CSS
-  - Referencia CSS
-translation_of: Web/CSS/specified_value
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/syntax/index.md
+++ b/files/es/web/css/syntax/index.md
@@ -1,12 +1,6 @@
 ---
 title: Sintaxis
 slug: Web/CSS/Syntax
-tags:
-  - CSS
-  - Guía
-  - Principiante
-  - Web
-translation_of: Web/CSS/Syntax
 ---
 {{cssref}}
 

--- a/files/es/web/css/text-decoration-color/index.md
+++ b/files/es/web/css/text-decoration-color/index.md
@@ -1,11 +1,6 @@
 ---
 title: text-decoration-color
 slug: Web/CSS/text-decoration-color
-tags:
-  - Propiedad CSS
-  - Referencia
-  - Texto CSS
-translation_of: Web/CSS/text-decoration-color
 ---
 
 {{ CSSRef }}

--- a/files/es/web/css/text-decoration-line/index.md
+++ b/files/es/web/css/text-decoration-line/index.md
@@ -1,10 +1,6 @@
 ---
 title: text-decoration-line
 slug: Web/CSS/text-decoration-line
-tags:
-  - Propiedad CSS
-  - Texto CSS
-translation_of: Web/CSS/text-decoration-line
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/text-decoration-style/index.md
+++ b/files/es/web/css/text-decoration-style/index.md
@@ -1,10 +1,6 @@
 ---
 title: text-decoration-style
 slug: Web/CSS/text-decoration-style
-tags:
-  - Propiedad CSS
-  - Texto CSS
-translation_of: Web/CSS/text-decoration-style
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/text-decoration/index.md
+++ b/files/es/web/css/text-decoration/index.md
@@ -1,10 +1,6 @@
 ---
 title: text-decoration
 slug: Web/CSS/text-decoration
-tags:
-  - Propiedad CSS
-  - Texto CSS
-translation_of: Web/CSS/text-decoration
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/text-emphasis-color/index.md
+++ b/files/es/web/css/text-emphasis-color/index.md
@@ -1,17 +1,6 @@
 ---
 title: text-emphasis-color
 slug: Web/CSS/text-emphasis-color
-tags:
-  - CSS
-  - Colores HTML
-  - Decoración de Texto CSS
-  - Estilizando HTML
-  - Estilos CSS
-  - Propiedad CSS
-  - Referencia
-  - text-decoration-color
-  - Énfasis de Texto
-translation_of: Web/CSS/text-emphasis-color
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/text-emphasis/index.md
+++ b/files/es/web/css/text-emphasis/index.md
@@ -1,7 +1,6 @@
 ---
 title: text-emphasis
 slug: Web/CSS/text-emphasis
-translation_of: Web/CSS/text-emphasis
 ---
 
 La **propiedad** **[CSS](/es/docs/Web/CSS)** de **text-emphasis**, es una propiedad _abreviada_ para establecer los valores de [text-empahasis-style](/es/docs/Web/CSS/text-emphasis-style) y [text-emphasis-color](/es/docs/Web/CSS/text-emphasis-color), en una sola declaración.

--- a/files/es/web/css/text-orientation/index.md
+++ b/files/es/web/css/text-orientation/index.md
@@ -1,13 +1,6 @@
 ---
 title: text-orientation
 slug: Web/CSS/text-orientation
-tags:
-  - CSS
-  - Formas de Escritura CSS
-  - Orientacion del Texto CSS
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/text-orientation
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/text-overflow/index.md
+++ b/files/es/web/css/text-overflow/index.md
@@ -1,7 +1,6 @@
 ---
 title: text-overflow
 slug: Web/CSS/text-overflow
-translation_of: Web/CSS/text-overflow
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/text-shadow/index.md
+++ b/files/es/web/css/text-shadow/index.md
@@ -1,10 +1,6 @@
 ---
 title: text-shadow
 slug: Web/CSS/text-shadow
-tags:
-  - Propiedad CSS
-  - Texto CSS
-translation_of: Web/CSS/text-shadow
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/text-transform/index.md
+++ b/files/es/web/css/text-transform/index.md
@@ -1,13 +1,6 @@
 ---
 title: text-transform
 slug: Web/CSS/text-transform
-tags:
-  - CSS
-  - Layout
-  - Propiedad CSS
-  - Referencia
-  - Texto
-translation_of: Web/CSS/text-transform
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/time/index.md
+++ b/files/es/web/css/time/index.md
@@ -1,13 +1,6 @@
 ---
 title: <time>
 slug: Web/CSS/time
-tags:
-  - CSS
-  - Presentación
-  - Referencia
-  - Tipo de Dato CSS
-  - Web
-translation_of: Web/CSS/time
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/top/index.md
+++ b/files/es/web/css/top/index.md
@@ -1,14 +1,6 @@
 ---
 title: Top
 slug: Web/CSS/top
-tags:
-  - CSS
-  - CSS Reference
-  - Referencia_CSS
-  - Todas_las_Categorías
-  - para_revisar
-  - páginas_a_traducir
-translation_of: Web/CSS/top
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/transform-function/index.md
+++ b/files/es/web/css/transform-function/index.md
@@ -1,9 +1,6 @@
 ---
 title: transform-function
 slug: Web/CSS/transform-function
-tags:
-  - Transformaciones CSS
-translation_of: Web/CSS/transform-function
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/transform-function/rotate/index.md
+++ b/files/es/web/css/transform-function/rotate/index.md
@@ -1,12 +1,6 @@
 ---
 title: rotate()
 slug: Web/CSS/transform-function/rotate
-tags:
-  - CSS
-  - NeedsCompatTable
-  - Referencia
-  - Transformaciones CSS
-translation_of: Web/CSS/transform-function/rotate()
 original_slug: Web/CSS/transform-function/rotate()
 ---
 

--- a/files/es/web/css/transform-function/rotate3d/index.md
+++ b/files/es/web/css/transform-function/rotate3d/index.md
@@ -1,9 +1,7 @@
 ---
 title: rotate3d()
 slug: Web/CSS/transform-function/rotate3d
-translation_of: Web/CSS/transform-function/rotate3d()
 original_slug: Web/CSS/transform-function/rotate3d()
-browser-compat: css.types.transform-function.rotate3d
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/transform-function/scale/index.md
+++ b/files/es/web/css/transform-function/scale/index.md
@@ -1,12 +1,6 @@
 ---
 title: scale()
 slug: Web/CSS/transform-function/scale
-tags:
-  - CSS Scale
-  - scale()
-  - scaleX()
-  - scaleY()
-translation_of: Web/CSS/transform-function/scale()
 original_slug: Web/CSS/transform-function/scale()
 ---
 

--- a/files/es/web/css/transform-function/translate/index.md
+++ b/files/es/web/css/transform-function/translate/index.md
@@ -1,13 +1,6 @@
 ---
 title: translate()
 slug: Web/CSS/transform-function/translate
-tags:
-  - CSS
-  - CSS Function
-  - CSS Transforms
-  - Función CSS
-  - Referencia
-translation_of: Web/CSS/transform-function/translate()
 original_slug: Web/CSS/transform-function/translate()
 ---
 

--- a/files/es/web/css/transform-function/translatey/index.md
+++ b/files/es/web/css/transform-function/translatey/index.md
@@ -1,11 +1,6 @@
 ---
 title: translateY()
 slug: Web/CSS/transform-function/translateY
-tags:
-  - Funciones CSS
-  - Referencia
-  - Transformaciones CSS
-translation_of: Web/CSS/transform-function/translateY()
 original_slug: Web/CSS/transform-function/translateY()
 ---
 

--- a/files/es/web/css/transform-function/translatez/index.md
+++ b/files/es/web/css/transform-function/translatez/index.md
@@ -1,10 +1,6 @@
 ---
 title: translateZ()
 slug: Web/CSS/transform-function/translateZ
-tags:
-  - 3D
-  - CSS
-translation_of: Web/CSS/transform-function/translateZ()
 original_slug: Web/CSS/transform-function/translateZ()
 ---
 

--- a/files/es/web/css/transform-origin/index.md
+++ b/files/es/web/css/transform-origin/index.md
@@ -1,7 +1,6 @@
 ---
 title: transform-origin
 slug: Web/CSS/transform-origin
-translation_of: Web/CSS/transform-origin
 ---
 
 {{ CSSRef("CSS Transforms") }} {{ SeeCompatTable() }}

--- a/files/es/web/css/transform-style/index.md
+++ b/files/es/web/css/transform-style/index.md
@@ -1,7 +1,6 @@
 ---
 title: transform-style
 slug: Web/CSS/transform-style
-translation_of: Web/CSS/transform-style
 ---
 
 La propiedad **`transform-style`** [CSS](/es/docs/Web/CSS) establece si el elemento hijo esta posicionado en el espacio 3D (preserve-3d) o esta integrado(flat) en el plano del elemento.

--- a/files/es/web/css/transform/index.md
+++ b/files/es/web/css/transform/index.md
@@ -1,14 +1,6 @@
 ---
 title: transform
 slug: Web/CSS/transform
-tags:
-  - CSS
-  - Compatibilidad con los navegadores
-  - Experimental
-  - Propiedad CSS
-  - Referencia
-  - Transformación
-translation_of: Web/CSS/transform
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/transition-delay/index.md
+++ b/files/es/web/css/transition-delay/index.md
@@ -1,7 +1,6 @@
 ---
 title: transition-delay
 slug: Web/CSS/transition-delay
-translation_of: Web/CSS/transition-delay
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/transition-duration/index.md
+++ b/files/es/web/css/transition-duration/index.md
@@ -1,7 +1,6 @@
 ---
 title: transition-duration
 slug: Web/CSS/transition-duration
-translation_of: Web/CSS/transition-duration
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/transition-property/index.md
+++ b/files/es/web/css/transition-property/index.md
@@ -1,12 +1,6 @@
 ---
 title: transition-property
 slug: Web/CSS/transition-property
-tags:
-  - CSS
-  - Propiedad CSS
-  - Referencia
-  - Transiciones CSS
-translation_of: Web/CSS/transition-property
 ---
 
 {{CSSRef("CSS Transitions")}}

--- a/files/es/web/css/transition/index.md
+++ b/files/es/web/css/transition/index.md
@@ -1,7 +1,6 @@
 ---
 title: transition
 slug: Web/CSS/transition
-translation_of: Web/CSS/transition
 ---
 
 {{ CSSRef("CSS Transitions") }}

--- a/files/es/web/css/tutorials/index.md
+++ b/files/es/web/css/tutorials/index.md
@@ -1,11 +1,6 @@
 ---
 title: CSS Tutorials
 slug: Web/CSS/Tutorials
-tags:
-  - CSS
-  - Guía
-  - Tutorial
-translation_of: Web/CSS/Tutorials
 ---
 
 Aprender CSS puede ser una tarea desalentadora. Para ayudarte, hemos escrito numerosos **tutoriales acerca de CSS.** Algunos estan dirigidos a principiantes, y mientras que otros presentan complejas características para ser usadas por usuarios mas avanzados.

--- a/files/es/web/css/type_selectors/index.md
+++ b/files/es/web/css/type_selectors/index.md
@@ -1,12 +1,6 @@
 ---
 title: Selectores de tipo
 slug: Web/CSS/Type_selectors
-tags:
-  - CSS
-  - Principiante
-  - Referencia CSS
-  - Selectores
-translation_of: Web/CSS/Type_selectors
 ---
 
 {{CSSRef}}El selector de tipo CSS selecciona elementos por nombre de nodo. En otras palabras, selecciona todos los elementos del tipo dado dentro de un documento.

--- a/files/es/web/css/universal_selectors/index.md
+++ b/files/es/web/css/universal_selectors/index.md
@@ -1,12 +1,6 @@
 ---
 title: Selectores universales
 slug: Web/CSS/Universal_selectors
-tags:
-  - CSS
-  - Principiante
-  - Referencia CSS
-  - Selectores
-translation_of: Web/CSS/Universal_selectors
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/url/index.md
+++ b/files/es/web/css/url/index.md
@@ -1,11 +1,6 @@
 ---
 title: url()
 slug: Web/CSS/url
-tags:
-  - CSS
-  - Referencia
-translation_of: Web/CSS/url()
-translation_of_original: Web/CSS/filter-function/url
 original_slug: Web/CSS/url()
 ---
 

--- a/files/es/web/css/user-modify/index.md
+++ b/files/es/web/css/user-modify/index.md
@@ -1,11 +1,6 @@
 ---
 title: '-moz-user-modify'
 slug: Web/CSS/user-modify
-tags:
-  - CSS
-  - No estándar(2)
-  - Referencia CSS
-translation_of: Web/CSS/user-modify
 original_slug: Web/CSS/-moz-user-modify
 ---
 

--- a/files/es/web/css/user-select/index.md
+++ b/files/es/web/css/user-select/index.md
@@ -1,7 +1,6 @@
 ---
 title: user-select
 slug: Web/CSS/user-select
-translation_of: Web/CSS/user-select
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/using_css_custom_properties/index.md
+++ b/files/es/web/css/using_css_custom_properties/index.md
@@ -1,13 +1,6 @@
 ---
 title: Uso de propiedades personalizadas (variables) en CSS
 slug: Web/CSS/Using_CSS_custom_properties
-tags:
-  - CSS
-  - Guía
-  - Propiedades personalizadas CSS
-  - Varables CSS
-  - Web
-translation_of: Web/CSS/Using_CSS_custom_properties
 ---
 
 {{cssref}}

--- a/files/es/web/css/value_definition_syntax/index.md
+++ b/files/es/web/css/value_definition_syntax/index.md
@@ -1,7 +1,6 @@
 ---
 title: Sintaxis de definición de valor
 slug: Web/CSS/Value_definition_syntax
-translation_of: Web/CSS/Value_definition_syntax
 original_slug: Web/CSS/Sintaxis_definición_de_valor
 ---
 

--- a/files/es/web/css/var/index.md
+++ b/files/es/web/css/var/index.md
@@ -1,7 +1,6 @@
 ---
 title: var()
 slug: Web/CSS/var
-translation_of: Web/CSS/var()
 original_slug: Web/CSS/var()
 ---
 

--- a/files/es/web/css/vertical-align/index.md
+++ b/files/es/web/css/vertical-align/index.md
@@ -1,7 +1,6 @@
 ---
 title: vertical-align
 slug: Web/CSS/vertical-align
-translation_of: Web/CSS/vertical-align
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/visibility/index.md
+++ b/files/es/web/css/visibility/index.md
@@ -1,12 +1,6 @@
 ---
 title: visibility
 slug: Web/CSS/visibility
-tags:
-  - CSS
-  - CSS:Referencias
-  - Referencia_CSS
-  - Todas_las_Categorías
-translation_of: Web/CSS/visibility
 ---
 
 {{ CSSRef() }}

--- a/files/es/web/css/white-space/index.md
+++ b/files/es/web/css/white-space/index.md
@@ -1,7 +1,6 @@
 ---
 title: white-space
 slug: Web/CSS/white-space
-translation_of: Web/CSS/white-space
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/widows/index.md
+++ b/files/es/web/css/widows/index.md
@@ -1,7 +1,6 @@
 ---
 title: widows
 slug: Web/CSS/widows
-translation_of: Web/CSS/widows
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/width/index.md
+++ b/files/es/web/css/width/index.md
@@ -1,8 +1,6 @@
 ---
 title: width
 slug: Web/CSS/width
-translation_of: Web/CSS/width
-browser-compat: css.properties.width
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/writing-mode/index.md
+++ b/files/es/web/css/writing-mode/index.md
@@ -1,12 +1,6 @@
 ---
 title: writing-mode
 slug: Web/CSS/writing-mode
-tags:
-  - CSS
-  - Disposición
-  - Propiedad CSS
-  - Referencia
-translation_of: Web/CSS/writing-mode
 ---
 
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/es/web/css/z-index/index.md
+++ b/files/es/web/css/z-index/index.md
@@ -1,7 +1,6 @@
 ---
 title: z-index
 slug: Web/CSS/z-index
-translation_of: Web/CSS/z-index
 ---
 
 {{CSSRef}}

--- a/files/es/web/css/zoom/index.md
+++ b/files/es/web/css/zoom/index.md
@@ -1,7 +1,6 @@
 ---
 title: zoom
 slug: Web/CSS/zoom
-translation_of: Web/CSS/zoom
 ---
 
 {{CSSRef}}{{Non-standard_header}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove duplicated frontmatter keys from localized content

### Motivation

Remove innecesarry duplicated data

### Additional details

Folders: web/(a|c)*

```
{
  "translation_of": 215,
  "tags": 121,
  "page-type": 3,
  "browser-compat": 8,
  "translation_of_original": 1
}
```

### Related issues and pull requests

Relates to #10129
Relates to #7412
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
