### PR TITLE
ci(markdownlint): use GitHub API to get changed files

### DIFF
--- a/.github/workflows/pr-check_markdownlint.yml
+++ b/.github/workflows/pr-check_markdownlint.yml
@@ -17,17 +17,16 @@ jobs:
       - name: Get Changed files
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CHANGED_FILES: /tmp/changed-files.txt
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # Use the GitHub API to get the list of changed files
           # documenation: https://docs.github.com/rest/commits/commits#compare-two-commits
-          gh api repos/{owner}/{repo}/compare/${{ env.BASE_SHA }}...${{ env.HEAD_SHA }} \
+          DIFF_DOCUMENTS=$(gh api repos/{owner}/{repo}/compare/${{ env.BASE_SHA }}...${{ env.HEAD_SHA }} \
             --paginate \
-            --jq '.files | .[] | select(.status|IN("added", "modified", "renamed", "copied", "changed")) | .filename' > ${{ env.CHANGED_FILES }}
+            --jq '.files | .[] | select(.status|IN("added", "modified", "renamed", "copied", "changed")) | .filename')
           # filter out files that are not markdown
-          DIFF_DOCUMENTS=$(egrep -i "^files/.*\.md$" ${{ env.CHANGED_FILES }} | xargs)
+          DIFF_DOCUMENTS=$(echo "${DIFF_DOCUMENTS}" | egrep -i "^files/.*\.md$" | xargs)
           echo "DIFF_DOCUMENTS=${DIFF_DOCUMENTS}" >> $GITHUB_ENV
 
       - name: Setup Node.js environment

--- a/.github/workflows/pr-check_markdownlint.yml
+++ b/.github/workflows/pr-check_markdownlint.yml
@@ -14,12 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v34
-        with:
-          files: |
-            **/*.md
+      - name: Get Changed files
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHANGED_FILES: /tmp/changed-files.txt
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Use the GitHub API to get the list of changed files
+          # documenation: https://docs.github.com/rest/commits/commits#compare-two-commits
+          gh api repos/{owner}/{repo}/compare/${{ env.BASE_SHA }}...${{ env.HEAD_SHA }} \
+            --paginate \
+            --jq '.files | .[] | select(.status|IN("added", "modified", "renamed", "copied", "changed")) | .filename' > ${{ env.CHANGED_FILES }}
+          # filter out files that are not markdown
+          DIFF_DOCUMENTS=$(cat ${{ env.CHANGED_FILES }} | egrep -i "^files/.*/.*\.md$" | tr "\n" " ")
+          echo "DIFF_DOCUMENTS=${DIFF_DOCUMENTS}" >> $GITHUB_ENV
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
@@ -34,5 +43,4 @@ jobs:
       - name: Lint markdown files
         run: |
           echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
-          files_to_lint="${{ steps.changed-files.outputs.all_changed_files }}"
-          yarn markdownlint-cli2 ${files_to_lint}
+          yarn markdownlint-cli2 ${{ env.DIFF_DOCUMENTS }}

--- a/.github/workflows/pr-check_markdownlint.yml
+++ b/.github/workflows/pr-check_markdownlint.yml
@@ -27,7 +27,7 @@ jobs:
             --paginate \
             --jq '.files | .[] | select(.status|IN("added", "modified", "renamed", "copied", "changed")) | .filename' > ${{ env.CHANGED_FILES }}
           # filter out files that are not markdown
-          DIFF_DOCUMENTS=$(cat ${{ env.CHANGED_FILES }} | egrep -i "^files/.*/.*\.md$" | tr "\n" " ")
+          DIFF_DOCUMENTS=$(egrep -i "^files/.*\.md$" ${{ env.CHANGED_FILES }} | xargs)
           echo "DIFF_DOCUMENTS=${DIFF_DOCUMENTS}" >> $GITHUB_ENV
 
       - name: Setup Node.js environment

--- a/.github/workflows/pr-check_markdownlint.yml
+++ b/.github/workflows/pr-check_markdownlint.yml
@@ -43,4 +43,5 @@ jobs:
       - name: Lint markdown files
         run: |
           echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
-          yarn markdownlint-cli2 ${{ env.DIFF_DOCUMENTS }}
+          files_to_lint="${{ env.DIFF_DOCUMENTS }}"
+          yarn markdownlint-cli2 ${files_to_lint}


### PR DESCRIPTION
### Description

fix(ci): use GitHub API to get changed files

### Motivation

The [tj-actions/changed-files@v34 action in Markdownlint (PR files)](https://github.com/mdn/translated-content/actions/workflows/pr-check_markdownlint.yml) may failed to get changed files. And as a test for mdn/translated-content#8952.

I've made a test [before](https://github.com/yin1999/translated-content/actions/runs/3293826528/jobs/5430706523) to get changed via GitHub API. It works, but I'm not sure whether it's always ok. I just find out a limitation in `gh` cli as [here](https://github.com/mdn/translated-content/pull/8952#issuecomment-1293201541) before, so I've tried another way to get changed files (by [commit compare REST API](https://docs.github.com/rest/commits/commits?apiVersion=2022-11-28#compare-two-commits)).

And for the API I used for now, it could list 30 commits per REST API request, so the files limitation maybe resolved, see below:

> PR info: https://api.github.com/repos/mdn/translated-content/pulls/9513
Compare info (all the 183 files in in the single rest response, see field files): https://api.github.com/repos/mdn/translated-content/compare/a9df62bb4885e5d9cdccd3834d5a24c921ef7cfa...16f5fc0db4ab1f5cb3858ab7878c428c19e9a79e

Is there any other things I've ignored? @nschonni @OnkarRuikar

### Related issues and pull requests

more information can be found in those PR:

- #8952
- yin1999/translated-content#8
