### PR TITLE
chore: remove {{page}} macros from zh-TW

### DIFF
--- a/files/zh-tw/web/api/document/index.md
+++ b/files/zh-tw/web/api/document/index.md
@@ -78,10 +78,6 @@ _這個介面繼承了 {{domxref("Node")}} 以及 {{domxref("EventTarget")}} 介
 - {{domxref("Document.xmlVersion")}} {{Deprecated_Inline}}
   - : Returns the version number as specified in the XML declaration or `"1.0"` if the declaration is absent.
 
-The `Document` interface is extended with the {{domxref("ParentNode")}} interface:
-
-{{page("/en-US/docs/Web/API/ParentNode","Properties")}}
-
 ### HTML 文件擴充
 
 _**`window.document`** 物件的部分屬性繼承自 HTML 文件的 {{domxref("HTMLDocument")}} 介面，或是來自 `Document` 從 HTML5 之後擴充的屬性。_
@@ -171,10 +167,6 @@ _**`window.document`** 物件的部分屬性繼承自 HTML 文件的 {{domxref("
   - : Is an event handler representing the code to be called when the [`selectionchange`](/zh-TW/docs/Web/API/Document/selectionchange_event) event is raised.
 - {{domxref("Document.onwheel")}} {{non-standard_inline}}
   - : Represents the event handling code for the [`wheel`](/zh-TW/docs/Web/API/Element/wheel_event) event.
-
-_此介面繼承了 {{domxref("GlobalEventHandlers")}} 的事件處理器：_
-
-{{Page("/zh-TW/docs/Web/API/GlobalEventHandlers", "屬性")}}
 
 ## 方法
 

--- a/files/zh-tw/web/api/filereader/readystate/index.md
+++ b/files/zh-tw/web/api/filereader/readystate/index.md
@@ -17,7 +17,11 @@ var state = instanceOfFileReader.readyState
 
 數字代表 {{domxref("FileReader")}} API 三個可能的狀態：
 
-{{page("/en-US/docs/Web/API/FileReader","State constants")}}
+| Value | State     | Description                                                   |
+| ----- | --------- | ------------------------------------------------------------- |
+| `0`   | `EMPTY`   | Reader has been created. None of the read methods called yet. |
+| `1`   | `LOADING` | A read method has been called.                                |
+| `2`   | `DONE`    | The operation is complete.                                    |
 
 ## 規格
 

--- a/files/zh-tw/web/api/gainnode/gain/index.md
+++ b/files/zh-tw/web/api/gainnode/gain/index.md
@@ -23,7 +23,7 @@ gainNode.gain.value = 0.5;
 
 ## 範例
 
-{{page("/en-US/docs/Web/API/AudioContext.createGain","Example")}}
+See [`BaseAudioContext.createGain()`](/zh-TW/docs/Web/API/BaseAudioContext/createGain#examples) for example code showing how to use an `AudioContext` to create a `GainNode`, which is then used to mute and unmute the audio by changing the gain property value.
 
 ## 規格
 

--- a/files/zh-tw/web/api/gainnode/index.md
+++ b/files/zh-tw/web/api/gainnode/index.md
@@ -54,7 +54,7 @@ _No specific method; inherits methods from its parent,_ _{{domxref("AudioNode")}
 
 ## Example
 
-{{page("/en-US/docs/Web/API/AudioContext.createGain","Example")}}
+See [`BaseAudioContext.createGain()`](/zh-TW/docs/Web/API/BaseAudioContext/createGain#example) for example code showing how to use an `AudioContext` to create a `GainNode`.
 
 ## Specifications
 

--- a/files/zh-tw/web/api/screen/index.md
+++ b/files/zh-tw/web/api/screen/index.md
@@ -45,14 +45,12 @@ slug: Web/API/Screen
 
 ## 方法
 
-- {{domxref("Screen.lockOrientation")}}
+_Also inherits methods from its parent {{domxref("EventTarget")}}_.
+
+- {{DOMxRef("Screen.lockOrientation")}} {{Deprecated_Inline}}
   - : Lock the screen orientation (only works in fullscreen or for installed apps)
-- {{domxref("Screen.unlockOrientation")}}
+- {{DOMxRef("Screen.unlockOrientation")}} {{Deprecated_Inline}}
   - : Unlock the screen orientation (only works in fullscreen or for installed apps)
-
-Methods inherit from {{domxref("EventTarget")}}
-
-{{page("/en-US/docs/Web/API/EventTarget","Methods")}}
 
 ## 範例
 

--- a/files/zh-tw/web/http/basics_of_http/mime_types/index.md
+++ b/files/zh-tw/web/http/basics_of_http/mime_types/index.md
@@ -124,9 +124,20 @@ Some content you find may have a `charset` parameter at the end of the `text/jav
 
 ### Image types
 
-Files whose MIME type is `image` contain image data. The subtype specifies which specific image file format the data represents. Only a few image types are used commonly enough to be considered safe for use on web pages:
+Files whose MIME type is `image` contain image data.
+The subtype specifies which specific image file format the data represents.
 
-{{page("en-US/docs/Web/Media/Formats/Image_types", "table-of-image-file-types")}}
+The following image types are used commonly enough to be considered _safe_ for use on web pages:
+
+- [`image/apng`](/zh-TW/docs/Web/Media/Formats/Image_types#apng_animated_portable_network_graphics): Animated Portable Network Graphics (APNG)
+- [`image/avif`](/zh-TW/docs/Web/Media/Formats/Image_types#avif_image) : AV1 Image File Format (AVIF)
+- [`image/gif`](/zh-TW/docs/Web/Media/Formats/Image_types#gif_graphics_interchange_format): Graphics Interchange Format (GIF)
+- [`image/jpeg`](/zh-TW/docs/Web/Media/Formats/Image_types#jpeg_joint_photographic_experts_group_image): Joint Photographic Expert Group image (JPEG)
+- [`image/png`](/zh-TW/docs/Web/Media/Formats/Image_types#png_portable_network_graphics): Portable Network Graphics (PNG)
+- [`image/svg+xml`](/zh-TW/docs/Web/Media/Formats/Image_types#svg_scalable_vector_graphics): Scalable Vector Graphics (SVG)
+- [`image/webp`](/zh-TW/docs/Web/Media/Formats/Image_types#webp_image): Web Picture format (WEBP)
+
+The [Image file type and format guide](/zh-TW/docs/Web/Media/Formats/Image_types#common_image_file_types) provides information and recommendations about when to use the different image formats.
 
 ### Audio and video types
 

--- a/files/zh-tw/web/javascript/data_structures/index.md
+++ b/files/zh-tw/web/javascript/data_structures/index.md
@@ -143,11 +143,11 @@ When representing dates, the best choice is to use the built-in [`Date` utility]
 
 ### Indexed collections: Arrays and typed Arrays
 
-[Arrays](/zh-TW/docs/JavaScript/Reference/Global_Objects/Array) are regular objects for which there is a particular relationship between integer-key-ed properties and the 'length' property. Additionally, arrays inherit from `Array.prototype` which provides to them a handful of convenient methods to manipulate arrays. For example, [`indexOf`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf) (searching a value in the array) or [`push`](/zh-TW/docs/JavaScript/Reference/Global_Objects/Array/push) (adding an element to the array), etc. This makes Arrays a perfect candidate to represent lists or sets.
+[Arrays](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Array) are regular objects for which there is a particular relationship between integer-keyed properties and the `length` property.
 
-[Typed Arrays](/zh-TW/docs/Web/JavaScript/Typed_arrays) are new to JavaScript with ECMAScript Edition 6 and present an array-like view of an underlying binary data buffer. The following table helps you to find the equivalent C data types:
+Additionally, arrays inherit from `Array.prototype`, which provides a handful of convenient methods to manipulate arrays. For example, [`indexOf()`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf) searches a value in the array and [`push()`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Array/push) appends an element to the array. This makes Arrays a perfect candidate to represent ordered lists.
 
-{{page("/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray", "TypedArray_objects", "", 0, 3)}}
+[Typed Arrays](/zh-TW/docs/Web/JavaScript/Typed_arrays) present an array-like view of an underlying binary data buffer, and offer many methods that have similar semantics to the array counterparts. "Typed array" is an umbrella term for a range of data structures, including `Int8Array`, `Float32Array`, etc. Check the [typed array](/zh-TW/docs/Web/JavaScript/Typed_arrays) page for more information. Typed arrays are often used in conjunction with {{jsxref("ArrayBuffer")}} and {{jsxref("DataView")}}.
 
 ### Keyed collections: Maps, Sets, WeakMaps, WeakSets
 

--- a/files/zh-tw/web/javascript/guide/indexed_collections/index.md
+++ b/files/zh-tw/web/javascript/guide/indexed_collections/index.md
@@ -474,12 +474,4 @@ To achieve maximum flexibility and efficiency, JavaScript typed arrays split the
 
 The {{jsxref("ArrayBuffer")}} is a data type that is used to represent a generic, fixed-length binary data buffer. You can't directly manipulate the contents of an `ArrayBuffer`; instead, you create a typed array view or a {{jsxref("DataView")}} which represents the buffer in a specific format, and use that to read and write the contents of the buffer.
 
-### Typed array views
-
-Typed array views have self descriptive names and provide views for all the usual numeric types like `Int8`, `Uint32`, `Float64` and so forth. There is one special typed array view, the `Uint8ClampedArray`. It clamps the values between 0 and 255. This is useful for [Canvas data processing](/zh-TW/docs/Web/API/ImageData), for example.
-
-{{page("/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray", "TypedArray_objects")}}
-
-For more information, see [JavaScript typed arrays](/zh-TW/docs/Web/JavaScript/Typed_arrays) and the reference documentation for the different {{jsxref("TypedArray")}} objects.
-
 {{PreviousNext("Web/JavaScript/Guide/Regular_Expressions", "Web/JavaScript/Guide/Keyed_Collections")}}

--- a/files/zh-tw/web/javascript/reference/global_objects/array/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/array/index.md
@@ -263,55 +263,87 @@ var myArray = myRe.exec('cdbBdbsbz');
 
 ### 屬性
 
-{{page('/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Array/prototype', 'Properties')}}
+- {{jsxref("Array.prototype.length")}}
+  - : Reflects the number of elements in an array.
+- {{jsxref("Array/@@unscopables", "Array.prototype[@@unscopables]")}}
+  - : Contains property names that were not included in the ECMAScript standard prior to the ES2015 version and that are ignored for [`with`](/zh-TW/docs/Web/JavaScript/Reference/Statements/with) statement-binding purposes.
 
 ### 方法
 
-#### Mutator methods
-
-{{page('zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Array/prototype', 'Mutator_methods')}}
-
-#### Accessor methods
-
-{{page('zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Array/prototype', 'Accessor_methods')}}
-
-#### Iteration methods
-
-{{page('zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Array/prototype', 'Iteration_methods')}}
-
-## `Array` 泛型方法
-
-> **警告：** 泛型陣列並非標準且已被棄用，將會在不久之後被去除。
-
-有時你想將陣列方法用於字串或其他類陣列物件（像是函數 {{jsxref("Functions/arguments", "arguments", "", 1)}}）。藉此操作，你將此字串視為由字元組成的陣列（反之為將其他非陣列視為物件）。如範例，若要確認字串中的每個字元是不是字母，你可能會這樣寫：
-
-```js
-function isLetter(character) {
-  return character >= 'a' && character <= 'z';
-}
-
-if (Array.prototype.every.call(str, isLetter)) {
-  console.log("The string '" + str + "' contains only letters!");
-}
-```
-
-這種表示法相當浪費，JavaScript 1.6 導入了一個通用方法：
-
-```js
-if (Array.every(str, isLetter)) {
-  console.log("The string '" + str + "' contains only letters!");
-}
-```
-
-{{jsxref("Global_Objects/String", "Generics", "#String_generic_methods", 1)}} 也同樣可用於 {{jsxref("String")}}.
-
-這**並非** ECMAScript 的標準，且不被非 Gecko 引擎的瀏覽器支援。你應該將你的物件用 {{jsxref("Array.from()")}} 轉為陣列，以標準替代原有的方法；雖然此方法可能不被舊的瀏覽器所支援：
-
-```js
-if (Array.from(str).every(isLetter)) {
-  console.log("The string '" + str + "' contains only letters!");
-}
-```
+- {{jsxref("Array.prototype.at()")}}
+  - : Returns the array item at the given index. Accepts negative integers, which count back from the last item.
+- {{jsxref("Array.prototype.concat()")}}
+  - : Returns a new array that is the calling array joined with other array(s) and/or value(s).
+- {{jsxref("Array.prototype.copyWithin()")}}
+  - : Copies a sequence of array elements within an array.
+- {{jsxref("Array.prototype.entries()")}}
+  - : Returns a new [_array iterator_](/zh-TW/docs/Web/JavaScript/Guide/Iterators_and_Generators) object that contains the key/value pairs for each index in an array.
+- {{jsxref("Array.prototype.every()")}}
+  - : Returns `true` if every element in the calling array satisfies the testing function.
+- {{jsxref("Array.prototype.fill()")}}
+  - : Fills all the elements of an array from a start index to an end index with a static value.
+- {{jsxref("Array.prototype.filter()")}}
+  - : Returns a new array containing all elements of the calling array for which the provided filtering function returns `true`.
+- {{jsxref("Array.prototype.find()")}}
+  - : Returns the value of the first element in the array that satisfies the provided testing function, or `undefined` if no appropriate element is found.
+- {{jsxref("Array.prototype.findIndex()")}}
+  - : Returns the index of the first element in the array that satisfies the provided testing function, or `-1` if no appropriate element was found.
+- {{jsxref("Array.prototype.findLast()")}}
+  - : Returns the value of the last element in the array that satisfies the provided testing function, or `undefined` if no appropriate element is found.
+- {{jsxref("Array.prototype.findLastIndex()")}}
+  - : Returns the index of the last element in the array that satisfies the provided testing function, or `-1` if no appropriate element was found.
+- {{jsxref("Array.prototype.flat()")}}
+  - : Returns a new array with all sub-array elements concatenated into it recursively up to the specified depth.
+- {{jsxref("Array.prototype.flatMap()")}}
+  - : Returns a new array formed by applying a given callback function to each element of the calling array, and then flattening the result by one level.
+- {{jsxref("Array.prototype.forEach()")}}
+  - : Calls a function for each element in the calling array.
+- {{jsxref("Array.prototype.group()")}} {{Experimental_Inline}}
+  - : Groups the elements of an array into an object according to the strings returned by a test function.
+- {{jsxref("Array.prototype.groupToMap()")}} {{Experimental_Inline}}
+  - : Groups the elements of an array into a {{jsxref("Map")}} according to values returned by a test function.
+- {{jsxref("Array.prototype.includes()")}}
+  - : Determines whether the calling array contains a value, returning `true` or `false` as appropriate.
+- {{jsxref("Array.prototype.indexOf()")}}
+  - : Returns the first (least) index at which a given element can be found in the calling array.
+- {{jsxref("Array.prototype.join()")}}
+  - : Joins all elements of an array into a string.
+- {{jsxref("Array.prototype.keys()")}}
+  - : Returns a new [_array iterator_](/zh-TW/docs/Web/JavaScript/Guide/Iterators_and_Generators) that contains the keys for each index in the calling array.
+- {{jsxref("Array.prototype.lastIndexOf()")}}
+  - : Returns the last (greatest) index at which a given element can be found in the calling array, or `-1` if none is found.
+- {{jsxref("Array.prototype.map()")}}
+  - : Returns a new array containing the results of invoking a function on every element in the calling array.
+- {{jsxref("Array.prototype.pop()")}}
+  - : Removes the last element from an array and returns that element.
+- {{jsxref("Array.prototype.push()")}}
+  - : Adds one or more elements to the end of an array, and returns the new `length` of the array.
+- {{jsxref("Array.prototype.reduce()")}}
+  - : Executes a user-supplied "reducer" callback function on each element of the array (from left to right), to reduce it to a single value.
+- {{jsxref("Array.prototype.reduceRight()")}}
+  - : Executes a user-supplied "reducer" callback function on each element of the array (from right to left), to reduce it to a single value.
+- {{jsxref("Array.prototype.reverse()")}}
+  - : Reverses the order of the elements of an array _in place_. (First becomes the last, last becomes first.)
+- {{jsxref("Array.prototype.shift()")}}
+  - : Removes the first element from an array and returns that element.
+- {{jsxref("Array.prototype.slice()")}}
+  - : Extracts a section of the calling array and returns a new array.
+- {{jsxref("Array.prototype.some()")}}
+  - : Returns `true` if at least one element in the calling array satisfies the provided testing function.
+- {{jsxref("Array.prototype.sort()")}}
+  - : Sorts the elements of an array in place and returns the array.
+- {{jsxref("Array.prototype.splice()")}}
+  - : Adds and/or removes elements from an array.
+- {{jsxref("Array.prototype.toLocaleString()")}}
+  - : Returns a localized string representing the calling array and its elements. Overrides the {{jsxref("Object.prototype.toLocaleString()")}} method.
+- {{jsxref("Array.prototype.toString()")}}
+  - : Returns a string representing the calling array and its elements. Overrides the {{jsxref("Object.prototype.toString()")}} method.
+- {{jsxref("Array.prototype.unshift()")}}
+  - : Adds one or more elements to the front of an array, and returns the new `length` of the array.
+- {{jsxref("Array.prototype.values()")}}
+  - : Returns a new [_array iterator_](/zh-TW/docs/Web/JavaScript/Guide/Iterators_and_Generators) object that contains the values for each index in the array.
+- [`Array.prototype[@@iterator]()`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator)
+  - : An alias for the [`values()`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Array/values) method by default.
 
 ## 範例
 

--- a/files/zh-tw/web/javascript/reference/global_objects/arraybuffer/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/arraybuffer/index.md
@@ -57,14 +57,15 @@ The `ArrayBuffer` constructor creates a new `ArrayBuffer` of the given length in
 
 ### 屬性
 
-{{page('zh-TW/Web/JavaScript/JavaScript_typed_arrays/ArrayBuffer/prototype','屬性')}}
+- `ArrayBuffer.prototype[@@toStringTag]`
+  - : The initial value of the [`@@toStringTag`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) property is the string `"ArrayBuffer"`. This property is used in {{jsxref("Object.prototype.toString()")}}.
+- {{jsxref("ArrayBuffer.prototype.byteLength")}}
+  - : The read-only size, in bytes, of the `ArrayBuffer`. This is established when the array is constructed and cannot be changed.
 
 ### 方法
 
-{{page('/zh-TW/docs/Web/JavaScript/JavaScript_typed_arrays/ArrayBuffer/prototype','方法')}}
-
-- {{jsxref("ArrayBuffer.slice()")}} {{non-standard_inline}}
-  - : Has the same functionality as {{jsxref("ArrayBuffer.prototype.slice()")}}.
+- {{jsxref("ArrayBuffer.prototype.slice()")}}
+  - : Returns a new `ArrayBuffer` whose contents are a copy of this `ArrayBuffer`'s bytes from `begin` (inclusive) up to `end` (exclusive). If either `begin` or `end` is negative, it refers to an index from the end of the array, as opposed to from the beginning.
 
 ## 範例
 

--- a/files/zh-tw/web/javascript/reference/global_objects/asyncfunction/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/asyncfunction/index.md
@@ -43,16 +43,6 @@ All arguments passed to the function are treated as the names of the identifiers
 - {{jsxref("AsyncFunction.prototype")}}
   - : 可加入屬性至所有陣列物件。
 
-## `AsyncFunction` 原型物件
-
-### 屬性
-
-{{page('/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncFunction/prototype', 'Properties')}}
-
-## `AsyncFunction` 實例
-
-`AsyncFunction` 實例繼承 {{jsxref("AsyncFunction.prototype")}} 的屬性和方法. 和所有的建構子一樣，變更該建構子 (constructor) 的原型物件 (prototype object)將會影響所有的 `AsyncFunction` 實例。
-
 ## 範例
 
 ### `AsyncFunction` 建構子建立一個非同步函數

--- a/files/zh-tw/web/javascript/reference/global_objects/bigint/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/bigint/index.md
@@ -204,7 +204,12 @@ All `BigInt` instances inherit from `BigInt.prototype`. The prototype object of 
 
 ### 方法
 
-{{page("/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/prototype", "Methods")}}
+- [`BigInt.prototype.toLocaleString()`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toLocaleString)
+  - : Returns a string with a language-sensitive representation of this BigInt value. Overrides the [`Object.prototype.toLocaleString()`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Object/toLocaleString) method.
+- [`BigInt.prototype.toString()`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toString)
+  - : Returns a string representing this BigInt value in the specified radix (base). Overrides the [`Object.prototype.toString()`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Object/toString) method.
+- [`BigInt.prototype.valueOf()`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/BigInt/valueOf)
+  - : Returns this BigInt value. Overrides the [`Object.prototype.valueOf()`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Object/valueOf) method.
 
 ## 建議用法
 

--- a/files/zh-tw/web/javascript/reference/global_objects/boolean/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/boolean/index.md
@@ -75,13 +75,12 @@ var s = new Boolean(myString);      // 依舊為true
 
 所有 `Boolean` 實體會繼承 {{jsxref("Boolean.prototype")}} 。和所有建構式一樣，原型物件會指派給實體那些繼承的屬性和方法。
 
-### 屬性
-
-{{page('/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean/prototype', 'Properties')}}
-
 ### 方法
 
-{{page('/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean/prototype', 'Methods')}}
+- {{jsxref("Boolean.prototype.toString()")}}
+  - : Returns a string of either `true` or `false` depending upon the value of the object. Overrides the {{jsxref("Object.prototype.toString()")}} method.
+- {{jsxref("Boolean.prototype.valueOf()")}}
+  - : Returns the primitive value of the {{jsxref("Boolean")}} object. Overrides the {{jsxref("Object.prototype.valueOf()")}} method.
 
 ## 範例
 

--- a/files/zh-tw/web/javascript/reference/global_objects/dataview/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/dataview/index.md
@@ -60,11 +60,57 @@ All `DataView` instances inherit from {{jsxref("DataView.prototype")}}.
 
 ### 屬性
 
-{{page('en-US/Web/JavaScript/Reference/Global_Objects/DataView/prototype','Properties')}}
+- `DataView.prototype[@@toStringTag]`
+  - : The initial value of the [`@@toStringTag`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) property is the string `"DataView"`. This property is used in {{jsxref("Object.prototype.toString()")}}.
+- {{jsxref("DataView.prototype.buffer")}}
+  - : The {{jsxref("ArrayBuffer")}} referenced by this view. Fixed at construction time and thus **read only.**
+- {{jsxref("DataView.prototype.byteLength")}}
+  - : The length (in bytes) of this view. Fixed at construction time and thus **read only.**
+- {{jsxref("DataView.prototype.byteOffset")}}
+  - : The offset (in bytes) of this view from the start of its {{jsxref("ArrayBuffer")}}. Fixed at construction time and thus **read only.**
 
 ### 方法
 
-{{page('en-US/Web/JavaScript/Reference/Global_Objects/DataView/prototype','Methods')}}
+- {{jsxref("DataView.prototype.getInt8()")}}
+  - : Gets a signed 8-bit integer (byte) at the specified byte offset from the start of the view.
+- {{jsxref("DataView.prototype.getUint8()")}}
+  - : Gets an unsigned 8-bit integer (unsigned byte) at the specified byte offset from the start of the view.
+- {{jsxref("DataView.prototype.getInt16()")}}
+  - : Gets a signed 16-bit integer (short) at the specified byte offset from the start of the view.
+- {{jsxref("DataView.prototype.getUint16()")}}
+  - : Gets an unsigned 16-bit integer (unsigned short) at the specified byte offset from the start of the view.
+- {{jsxref("DataView.prototype.getInt32()")}}
+  - : Gets a signed 32-bit integer (long) at the specified byte offset from the start of the view.
+- {{jsxref("DataView.prototype.getUint32()")}}
+  - : Gets an unsigned 32-bit integer (unsigned long) at the specified byte offset from the start of the view.
+- {{jsxref("DataView.prototype.getFloat32()")}}
+  - : Gets a signed 32-bit float (float) at the specified byte offset from the start of the view.
+- {{jsxref("DataView.prototype.getFloat64()")}}
+  - : Gets a signed 64-bit float (double) at the specified byte offset from the start of the view.
+- {{jsxref("DataView.prototype.getBigInt64()")}}
+  - : Gets a signed 64-bit integer (long long) at the specified byte offset from the start of the view.
+- {{jsxref("DataView.prototype.getBigUint64()")}}
+  - : Gets an unsigned 64-bit integer (unsigned long long) at the specified byte offset from the start of the view.
+- {{jsxref("DataView.prototype.setInt8()")}}
+  - : Stores a signed 8-bit integer (byte) value at the specified byte offset from the start of the view.
+- {{jsxref("DataView.prototype.setUint8()")}}
+  - : Stores an unsigned 8-bit integer (unsigned byte) value at the specified byte offset from the start of the view.
+- {{jsxref("DataView.prototype.setInt16()")}}
+  - : Stores a signed 16-bit integer (short) value at the specified byte offset from the start of the view.
+- {{jsxref("DataView.prototype.setUint16()")}}
+  - : Stores an unsigned 16-bit integer (unsigned short) value at the specified byte offset from the start of the view.
+- {{jsxref("DataView.prototype.setInt32()")}}
+  - : Stores a signed 32-bit integer (long) value at the specified byte offset from the start of the view.
+- {{jsxref("DataView.prototype.setUint32()")}}
+  - : Stores an unsigned 32-bit integer (unsigned long) value at the specified byte offset from the start of the view.
+- {{jsxref("DataView.prototype.setFloat32()")}}
+  - : Stores a signed 32-bit float (float) value at the specified byte offset from the start of the view.
+- {{jsxref("DataView.prototype.setFloat64()")}}
+  - : Stores a signed 64-bit float (double) value at the specified byte offset from the start of the view.
+- {{jsxref("DataView.prototype.setBigInt64()")}}
+  - : Stores a signed 64-bit integer (long long) value at the specified byte offset from the start of the view.
+- {{jsxref("DataView.prototype.setBigUint64()")}}
+  - : Stores an unsigned 64-bit integer (unsigned long long) value at the specified byte offset from the start of the view.
 
 ## 範例
 

--- a/files/zh-tw/web/javascript/reference/global_objects/date/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/date/index.md
@@ -82,7 +82,16 @@ new Date(year, month[, day[, hour[, minutes[, seconds[, milliseconds]]]]]);
 
 ### Date.prototype 方法
 
-{{page('/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Date/prototype', '方法')}}
+- {{jsxref("Date.now()")}}
+  - : 回傳對應於當下時間的數值 - 1970/01/01 00:00:00 (UTC) 到當下的毫秒數。
+- {{jsxref("Date.parse()")}}
+
+  - : 解析字串所表示的時間，回傳由 1970/01/01 00:00:00 (UTC) 到該時間的毫秒數值。
+
+    > **備註：** 由於瀏覽器之間的不同與差異，強烈不建議使用 `Date.parse` 。
+
+- {{jsxref("Date.UTC()")}}
+  - : 需要傳入與建構子相同的參數數目（即 2 到 7 個），會得到由 1970-01-01 00:00:00 UTC 到該日期時間的毫秒數。（輸入的參數會視為世界標準時間，而非本地時間）
 
 ## 範例
 

--- a/files/zh-tw/web/javascript/reference/global_objects/error/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/error/index.md
@@ -58,15 +58,31 @@ The global `Error` object contains no methods of its own, however, it does inher
 
 ## `Error` 實體
 
-{{page('en-US/docs/JavaScript/Reference/Global_Objects/Error/prototype', 'Description')}}
+Runtime errors result in new `Error` objects being created and thrown.
+
+`Error` is a {{Glossary("serializable object")}}, so it can be cloned with {{domxref("structuredClone()")}} or copied between [Workers](/zh-TW/docs/Web/API/Worker) using {{domxref("Worker/postMessage()", "postMessage()")}}.
 
 ### 屬性
 
-{{page('en-US/docs/JavaScript/Reference/Global_Objects/Error/prototype', 'Properties')}}
+- {{jsxref("Error.prototype.message")}}
+  - : Error message. For user-created `Error` objects, this is the string provided as the constructor's first argument.
+- {{jsxref("Error.prototype.name")}}
+  - : Error name. This is determined by the constructor function.
+- {{jsxref("Error.prototype.cause")}}
+  - : Error cause indicating the reason why the current error is thrown — usually another caught error. For user-created `Error` objects, this is the value provided as the `cause` property of the constructor's second argument.
+- {{jsxref("Error.prototype.fileName")}} {{non-standard_inline}}
+  - : A non-standard Mozilla property for the path to the file that raised this error.
+- {{jsxref("Error.prototype.lineNumber")}} {{non-standard_inline}}
+  - : A non-standard Mozilla property for the line number in the file that raised this error.
+- {{jsxref("Error.prototype.columnNumber")}} {{non-standard_inline}}
+  - : A non-standard Mozilla property for the column number in the line that raised this error.
+- {{jsxref("Error.prototype.stack")}} {{non-standard_inline}}
+  - : A non-standard property for a stack trace.
 
 ### 方法
 
-{{page('en-US/docs/JavaScript/Reference/Global_Objects/Error/prototype', 'Methods')}}
+- {{jsxref("Error.prototype.toString()")}}
+  - : Returns a string representing the specified object. Overrides the {{jsxref("Object.prototype.toString()")}} method.
 
 ## 範例
 

--- a/files/zh-tw/web/javascript/reference/global_objects/function/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/function/index.md
@@ -36,11 +36,32 @@ The global `Function` object has no methods or properties of its own, however, s
 
 ### 屬性 Properties
 
-{{page('/zh-TW/docs/JavaScript/Reference/Global_Objects/Function/prototype', 'Properties')}}
+- {{jsxref("Function.prototype.arguments")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
+  - : An array corresponding to the arguments passed to a function.
+    This is deprecated as a property of {{jsxref("Function")}}. Use the {{jsxref("Functions/arguments", "arguments")}} object (available within the function) instead.
+- {{jsxref("Function.prototype.caller")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
+  - : Specifies the function that invoked the currently executing function.
+    This property is deprecated, and is only functional for some non-strict functions.
+- {{jsxref("Function.prototype.displayName")}} {{Non-standard_Inline}} {{Optional_Inline}}
+  - : The display name of the function.
+- {{jsxref("Function.prototype.length")}}
+  - : Specifies the number of arguments expected by the function.
+- {{jsxref("Function.prototype.name")}}
+  - : The name of the function.
+- {{jsxref("Function.prototype.prototype")}}
+  - : Used when the function is used as a constructor with the [`new`](/zh-TW/docs/Web/JavaScript/Reference/Operators/new) operator. It will become the new object's prototype.
 
 ### 方法 Methods
 
-{{page('/zh-TW/docs/JavaScript/Reference/Global_Objects/Function/prototype', 'Methods')}}
+- {{jsxref("Function.prototype.apply()")}}
+  - : Calls a function with a given `this` value and optional arguments provided as an array (or an [array-like object](/zh-TW/docs/Web/JavaScript/Guide/Indexed_collections#working_with_array-like_objects)).
+- {{jsxref("Function.prototype.bind()")}}
+  - : Creates a new function that, when called, has its `this` keyword set to a provided value, optionally with a given sequence of arguments preceding any provided when the new function is called.
+- {{jsxref("Function.prototype.call()")}}
+  - : Calls a function with a given `this` value and optional arguments.
+- {{jsxref("Function.prototype.toString()")}}
+  - : Returns a string representing the source code of the function.
+    Overrides the {{jsxref("Object.prototype.toString")}} method.
 
 ## `Function` 實例
 

--- a/files/zh-tw/web/javascript/reference/global_objects/map/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/map/index.md
@@ -53,11 +53,35 @@ new Map([iterable])
 
 ### 屬性
 
-{{page('zh-TW/Web/JavaScript/Reference/Global_Objects/Map/prototype','Properties')}}
+- `Map.prototype[@@toStringTag]`
+  - : The initial value of the [`@@toStringTag`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) property is the string `"Map"`. This property is used in {{jsxref("Object.prototype.toString()")}}.
+- {{jsxref("Map.prototype.size")}}
+  - : Returns the number of key/value pairs in the `Map` object.
 
 ### 方法
 
-{{page('zh-TW/Web/JavaScript/Reference/Global_Objects/Map/prototype','Methods')}}
+- {{jsxref("Map.prototype.clear()")}}
+  - : Removes all key-value pairs from the `Map` object.
+- {{jsxref("Map.prototype.delete()")}}
+  - : Returns `true` if an element in the `Map` object existed and has been
+    removed, or `false` if the element does not exist. `map.has(key)`
+    will return `false` afterwards.
+- {{jsxref("Map.prototype.get()")}}
+  - : Returns the value associated to the passed key, or `undefined` if there is none.
+- {{jsxref("Map.prototype.has()")}}
+  - : Returns a boolean indicating whether a value has been associated with the passed key in the `Map` object or not.
+- {{jsxref("Map.prototype.set()")}}
+  - : Sets the value for the passed key in the `Map` object. Returns the `Map` object.
+- {{jsxref("Map/@@iterator", "Map.prototype[@@iterator]()")}}
+  - : Returns a new Iterator object that contains a two-member array of `[key, value]` for each element in the `Map` object in insertion order.
+- {{jsxref("Map.prototype.keys()")}}
+  - : Returns a new Iterator object that contains the keys for each element in the `Map` object in insertion order.
+- {{jsxref("Map.prototype.values()")}}
+  - : Returns a new Iterator object that contains the values for each element in the `Map` object in insertion order.
+- {{jsxref("Map.prototype.entries()")}}
+  - : Returns a new Iterator object that contains a two-member array of `[key, value]` for each element in the `Map` object in insertion order.
+- {{jsxref("Map.prototype.forEach()")}}
+  - : Calls `callbackFn` once for each key-value pair present in the `Map` object, in insertion order. If a `thisArg` parameter is provided to `forEach`, it will be used as the `this` value for each callback.
 
 ## 範例
 

--- a/files/zh-tw/web/javascript/reference/global_objects/number/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/number/index.md
@@ -67,7 +67,18 @@ new Number(value);
 
 ### 方法
 
-{{page('/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Number/prototype', '方法')}}
+- {{jsxref("Number.isNaN()")}}
+  - : 判斷傳入的值是不是 NaN.
+- {{jsxref("Number.isFinite()")}}
+  - : 判斷傳入的值是不是一個有限的數值。
+- {{jsxref("Number.isInteger()")}}
+  - : 判斷傳入的值是不是一個整數。
+- {{jsxref("Number.isSafeInteger()")}}
+  - : 判斷傳入的值是不是在 IEEE-754 雙精度範圍間 (即介於 `-(2^53 - 1)` 和 `2^53 - 1`之前)。
+- {{jsxref("Number.parseFloat()")}}
+  - : 這個方法和全域物件的 {{jsxref("parseFloat", "parseFloat()")}} 相同。
+- {{jsxref("Number.parseInt()")}}
+  - : 這個方法和全域物件的 {{jsxref("parseInt", "parseInt()")}} 相同。
 
 ## 範例
 

--- a/files/zh-tw/web/javascript/reference/global_objects/object/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/object/index.md
@@ -88,11 +88,33 @@ All objects in JavaScript are descended from `Object`; all objects inherit metho
 
 ### 屬性
 
-{{page('/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Object/prototype', '屬性') }}
+- {{jsxref("Object.prototype.constructor")}}
+  - : Specifies the function that creates an object's prototype.
+- [`Object.prototype.__proto__`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Object/proto) {{Deprecated_Inline}}
+  - : Points to the object which was used as prototype when the object was instantiated.
 
 ### 方法
 
-{{page('/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Object/prototype', '方法') }}
+- [`Object.prototype.__defineGetter__()`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__)
+  - : Associates a function with a property that, when accessed, executes that function and returns its return value.
+- [`Object.prototype.__defineSetter__()`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineSetter__)
+  - : Associates a function with a property that, when set, executes that function which modifies the property.
+- [`Object.prototype.__lookupGetter__()`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__)
+  - : Returns the function bound as a getter to the specified property.
+- [`Object.prototype.__lookupSetter__()`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupSetter__)
+  - : Returns the function bound as a setter to the specified property.
+- {{jsxref("Object.prototype.hasOwnProperty()")}}
+  - : Returns a boolean indicating whether an object contains the specified property as a direct property of that object and not inherited through the prototype chain.
+- {{jsxref("Object.prototype.isPrototypeOf()")}}
+  - : Returns a boolean indicating whether the object this method is called upon is in the prototype chain of the specified object.
+- {{jsxref("Object.prototype.propertyIsEnumerable()")}}
+  - : Returns a boolean indicating whether the specified property is the object's [enumerable own](/zh-TW/docs/Web/JavaScript/Enumerability_and_ownership_of_properties) property.
+- {{jsxref("Object.prototype.toLocaleString()")}}
+  - : Calls {{jsxref("Object/toString", "toString()")}}.
+- {{jsxref("Object.prototype.toString()")}}
+  - : Returns a string representation of the object.
+- {{jsxref("Object.prototype.valueOf()")}}
+  - : Returns the primitive value of the specified object.
 
 ## 範例
 

--- a/files/zh-tw/web/javascript/reference/global_objects/promise/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/promise/index.md
@@ -65,11 +65,19 @@ new Promise( /* executor */ function(resolve, reject) { ... } );
 
 ### 屬性
 
-{{page('zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Promise/prototype','屬性')}}
+- `Promise.prototype[@@toStringTag]`
+  - : The initial value of the [`@@toStringTag`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) property is the string `"Promise"`. This property is used in {{jsxref("Object.prototype.toString()")}}.
 
 ### 方法
 
-{{page('zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Promise/prototype','方法')}}
+See the [Microtask guide](/zh-TW/docs/Web/API/HTML_DOM_API/Microtask_guide) to learn more about how these methods use the Microtask queue and services.
+
+- {{jsxref("Promise.prototype.catch()")}}
+  - : Appends a rejection handler callback to the promise, and returns a new promise resolving to the return value of the callback if it is called, or to its original fulfillment value if the promise is instead fulfilled.
+- {{jsxref("Promise.prototype.then()")}}
+  - : Appends fulfillment and rejection handlers to the promise, and returns a new promise resolving to the return value of the called handler, or to its original settled value if the promise was not handled (i.e. if the relevant handler `onFulfilled` or `onRejected` is not a function).
+- {{jsxref("Promise.prototype.finally()")}}
+  - : Appends a handler to the promise, and returns a new promise that is resolved when the original promise is resolved. The handler is called when the promise is settled, whether fulfilled or rejected.
 
 ## 建立 Promise
 

--- a/files/zh-tw/web/javascript/reference/global_objects/proxy/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/proxy/index.md
@@ -34,12 +34,6 @@ var p = new Proxy(target, handler);
 - {{jsxref("Proxy.revocable()")}}
   - : Creates a revocable `Proxy` object.
 
-## Methods of the handler object
-
-The handler object is a placeholder object which contains traps for `Proxy`.
-
-{{page('/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler', 'Methods') }}
-
 ## 範例
 
 ### Basic example

--- a/files/zh-tw/web/javascript/reference/global_objects/rangeerror/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/rangeerror/index.md
@@ -39,11 +39,20 @@ new RangeError([message[, fileName[, lineNumber]]])
 
 ### 屬性
 
-{{page('/en-US/docs/Web/JavaScript/Reference/Global_Objects/RangeError/prototype', 'Properties')}}
-
-### 方法
-
-{{page('/en-US/docs/Web/JavaScript/Reference/Global_Objects/RangeError/prototype', 'Methods')}}
+- {{jsxref("Error.prototype.message", "RangeError.prototype.message")}}
+  - : Error message. Inherited from {{jsxref("Error")}}.
+- {{jsxref("Error.prototype.name", "RangeError.prototype.name")}}
+  - : Error name. Inherited from {{jsxref("Error")}}.
+- {{jsxref("Error.prototype.cause", "RangeError.prototype.cause")}}
+  - : Error cause. Inherited from {{jsxref("Error")}}.
+- {{jsxref("Error.prototype.fileName", "RangeError.prototype.fileName")}} {{non-standard_inline}}
+  - : Path to file that raised this error. Inherited from {{jsxref("Error")}}.
+- {{jsxref("Error.prototype.lineNumber", "RangeError.prototype.lineNumber")}} {{non-standard_inline}}
+  - : Line number in file that raised this error. Inherited from {{jsxref("Error")}}.
+- {{jsxref("Error.prototype.columnNumber", "RangeError.prototype.columnNumber")}} {{non-standard_inline}}
+  - : Column number in line that raised this error. Inherited from {{jsxref("Error")}}.
+- {{jsxref("Error.prototype.stack", "RangeError.prototype.stack")}} {{non-standard_inline}}
+  - : Stack trace. Inherited from {{jsxref("Error")}}.
 
 ## 範例
 

--- a/files/zh-tw/web/javascript/reference/global_objects/set/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/set/index.md
@@ -47,11 +47,35 @@ All `Set` instances inherit from {{jsxref("Set.prototype")}}.
 
 ### 屬性
 
-{{page('en-US/Web/JavaScript/Reference/Global_Objects/Set/prototype','Properties')}}
+- `Set.prototype[@@toStringTag]`
+  - : The initial value of the [`@@toStringTag`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) property is the string `"Set"`. This property is used in {{jsxref("Object.prototype.toString()")}}.
+- {{jsxref("Set.prototype.size")}}
+  - : Returns the number of values in the `Set` object.
 
 ### 方法
 
-{{page('en-US/Web/JavaScript/Reference/Global_Objects/Set/prototype','Methods')}}
+- {{jsxref("Set.prototype.add()")}}
+  - : Inserts a new element with a specified value in to a `Set` object, if there isn't an element with the same value already in the `Set`.
+- {{jsxref("Set.prototype.clear()")}}
+  - : Removes all elements from the `Set` object.
+- {{jsxref("Set.prototype.delete()")}}
+  - : Removes the element associated to the `value` and returns a boolean asserting whether an element was successfully removed or not. `Set.prototype.has(value)` will return `false` afterwards.
+- {{jsxref("Set.prototype.has()")}}
+  - : Returns a boolean asserting whether an element is present with the given value in the `Set` object or not.
+- {{jsxref("Set.prototype.@@iterator()", "Set.prototype[@@iterator]()")}}
+  - : Returns a new iterator object that yields the **values** for each element in the `Set` object in insertion order.
+- {{jsxref("Set.prototype.values()")}}
+  - : Returns a new iterator object that yields the **values** for each element in the `Set` object in insertion order.
+- {{jsxref("Set.prototype.keys()")}}
+  - : An alias for {{jsxref("Set.prototype.values()")}}.
+- {{jsxref("Set.prototype.entries()")}}
+
+  - : Returns a new iterator object that contains **an array of `[value, value]`** for each element in the `Set` object, in insertion order.
+
+    This is similar to the {{jsxref("Map")}} object, so that each entry's _key_ is the same as its _value_ for a `Set`.
+
+- {{jsxref("Set.prototype.forEach()")}}
+  - : Calls `callbackFn` once for each value present in the `Set` object, in insertion order. If a `thisArg` parameter is provided, it will be used as the `this` value for each invocation of `callbackFn`.
 
 ## 範例
 

--- a/files/zh-tw/web/javascript/reference/global_objects/string/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/string/index.md
@@ -212,9 +212,114 @@ The following is a shim to provide support to non-supporting browsers:
 
 ### Properties
 
-{{page('en-US/docs/Web/JavaScript/Reference/Global_Objects/String/prototype', 'Properties')}}
+- {{jsxref("String.prototype.length")}}
+  - : Reflects the `length` of the string. Read-only.
 
-{{page('en-US/docs/Web/JavaScript/Reference/Global_Objects/String/prototype', 'Methods')}}
+### Methods
+
+- {{jsxref("String.prototype.at()")}}
+  - : Returns the character (exactly one UTF-16 code unit) at the specified `index`. Accepts negative integers, which count back from the last string character.
+- {{jsxref("String.prototype.charAt()")}}
+  - : Returns the character (exactly one UTF-16 code unit) at the specified
+    `index`.
+- {{jsxref("String.prototype.charCodeAt()")}}
+  - : Returns a number that is the UTF-16 code unit value at the given
+    `index`.
+- {{jsxref("String.prototype.codePointAt()")}}
+  - : Returns a nonnegative integer Number that is the code point value of the UTF-16
+    encoded code point starting at the specified `pos`.
+- {{jsxref("String.prototype.concat()")}}
+  - : Combines the text of two (or more) strings and returns a new string.
+- {{jsxref("String.prototype.includes()")}}
+  - : Determines whether the calling string contains `searchString`.
+- {{jsxref("String.prototype.endsWith()")}}
+  - : Determines whether a string ends with the characters of the string
+    `searchString`.
+- {{jsxref("String.prototype.indexOf()")}}
+  - : Returns the index within the calling {{jsxref("String")}} object of the first
+    occurrence of `searchValue`, or `-1` if not found.
+- {{jsxref("String.prototype.lastIndexOf()")}}
+  - : Returns the index within the calling {{jsxref("String")}} object of the last
+    occurrence of `searchValue`, or `-1` if not found.
+- {{jsxref("String.prototype.localeCompare()")}}
+  - : Returns a number indicating whether the reference string
+    `compareString` comes before, after, or is equivalent to the
+    given string in sort order.
+- {{jsxref("String.prototype.match()")}}
+  - : Used to match regular expression `regexp` against a string.
+- {{jsxref("String.prototype.matchAll()")}}
+  - : Returns an iterator of all `regexp`'s matches.
+- {{jsxref("String.prototype.normalize()")}}
+  - : Returns the Unicode Normalization Form of the calling string value.
+- {{jsxref("String.prototype.padEnd()")}}
+  - : Pads the current string from the end with a given string and returns a new string of
+    the length `targetLength`.
+- {{jsxref("String.prototype.padStart()")}}
+  - : Pads the current string from the start with a given string and returns a new string
+    of the length `targetLength`.
+- {{jsxref("String.prototype.repeat()")}}
+  - : Returns a string consisting of the elements of the object repeated
+    `count` times.
+- {{jsxref("String.prototype.replace()")}}
+  - : Used to replace occurrences of `searchFor` using
+    `replaceWith`. `searchFor` may be a string
+    or Regular Expression, and `replaceWith` may be a string or
+    function.
+- {{jsxref("String.prototype.replaceAll()")}}
+  - : Used to replace all occurrences of `searchFor` using
+    `replaceWith`. `searchFor` may be a string
+    or Regular Expression, and `replaceWith` may be a string or
+    function.
+- {{jsxref("String.prototype.search()")}}
+  - : Search for a match between a regular expression `regexp` and
+    the calling string.
+- {{jsxref("String.prototype.slice()")}}
+  - : Extracts a section of a string and returns a new string.
+- {{jsxref("String.prototype.split()")}}
+  - : Returns an array of strings populated by splitting the calling string at occurrences
+    of the substring `sep`.
+- {{jsxref("String.prototype.startsWith()")}}
+  - : Determines whether the calling string begins with the characters of string
+    `searchString`.
+- {{jsxref("String.prototype.substring()")}}
+  - : Returns a new string containing characters of the calling string from (or between)
+    the specified index (or indices).
+- {{jsxref("String.prototype.toLocaleLowerCase()")}}
+
+  - : The characters within a string are converted to lowercase while respecting the
+    current locale.
+
+    For most languages, this will return the same as
+    {{jsxref("String.prototype.toLowerCase()", "toLowerCase()")}}.
+
+- {{jsxref("String.prototype.toLocaleUpperCase()",
+    "String.prototype.toLocaleUpperCase( [<var>locale</var>, ...<var>locales</var>])")}}
+
+  - : The characters within a string are converted to uppercase while respecting the
+    current locale.
+
+    For most languages, this will return the same as
+    {{jsxref("String.prototype.toUpperCase()", "toUpperCase()")}}.
+
+- {{jsxref("String.prototype.toLowerCase()")}}
+  - : Returns the calling string value converted to lowercase.
+- {{jsxref("String.prototype.toString()")}}
+  - : Returns a string representing the specified object. Overrides the
+    {{jsxref("Object.prototype.toString()")}} method.
+- {{jsxref("String.prototype.toUpperCase()")}}
+  - : Returns the calling string value converted to uppercase.
+- {{jsxref("String.prototype.trim()")}}
+  - : Trims whitespace from the beginning and end of the string.
+- {{jsxref("String.prototype.trimStart()")}}
+  - : Trims whitespace from the beginning of the string.
+- {{jsxref("String.prototype.trimEnd()")}}
+  - : Trims whitespace from the end of the string.
+- {{jsxref("String.prototype.valueOf()")}}
+  - : Returns the primitive value of the specified object. Overrides the
+    {{jsxref("Object.prototype.valueOf()")}} method.
+- {{jsxref("String.prototype.@@iterator()", "String.prototype[@@iterator]()")}}
+  - : Returns a new iterator object that iterates over the code points of a String value,
+    returning each code point as a String value.
 
 ## Examples
 

--- a/files/zh-tw/web/javascript/reference/global_objects/typedarray/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/typedarray/index.md
@@ -114,11 +114,86 @@ All *TypedArray*s inherit from {{jsxref("TypedArray.prototype")}}.
 
 ### 屬性
 
-{{page('en-US/Web/JavaScript/Reference/Global_Objects/TypedArray/prototype','Properties')}}
+These properties are all [getters](/zh-TW/docs/Web/JavaScript/Reference/Functions/get) defined on the `TypedArray` prototype object and are thus read-only and shared by all `TypedArray` subclass instances.
+
+- `TypedArray.prototype[@@toStringTag]`
+  - : The initial value of a typed array's [`@@toStringTag`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) property is the same string as its [name](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/name). This property is used in {{jsxref("Object.prototype.toString()")}}. However, because `TypedArray` also has its own [`toString()`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toString) method, this property is not used unless you call [`Object.prototype.toString.call()`](/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Function/call) with a typed array as `thisArg`.
+- {{jsxref("TypedArray.prototype.buffer")}}
+  - : Returns the {{jsxref("ArrayBuffer")}} referenced by the typed array.
+- {{jsxref("TypedArray.prototype.byteLength")}}
+  - : Returns the length (in bytes) of the typed array.
+- {{jsxref("TypedArray.prototype.byteOffset")}}
+  - : Returns the offset (in bytes) of the typed array from the start of its {{jsxref("ArrayBuffer")}}.
+- {{jsxref("TypedArray.prototype.length")}}
+  - : Returns the number of elements held in the typed array.
+
+All `TypedArray` subclasses also have the following instance properties:
+
+- {{jsxref("TypedArray.prototype.BYTES_PER_ELEMENT")}}
+  - : Returns a number value of the element size for the different `TypedArray` objects.
 
 ### 方法
 
-{{page('en-US/Web/JavaScript/Reference/Global_Objects/TypedArray/prototype','Methods')}}
+These methods are defined on the `TypedArray` prototype object and are thus shared by all `TypedArray` subclass instances.
+
+- {{jsxref("TypedArray.prototype.at()")}}
+  - : Takes an integer value and returns the item at that index. This method allows for negative integers, which count back from the last item.
+- {{jsxref("TypedArray.prototype.copyWithin()")}}
+  - : Copies a sequence of array elements within the array. See also {{jsxref("Array.prototype.copyWithin()")}}.
+- {{jsxref("TypedArray.prototype.entries()")}}
+  - : Returns a new _array iterator_ object that contains the key/value pairs for each index in the array. See also {{jsxref("Array.prototype.entries()")}}.
+- {{jsxref("TypedArray.prototype.every()")}}
+  - : Tests whether all elements in the array pass the test provided by a function. See also {{jsxref("Array.prototype.every()")}}.
+- {{jsxref("TypedArray.prototype.fill()")}}
+  - : Fills all the elements of an array from a start index to an end index with a static value. See also {{jsxref("Array.prototype.fill()")}}.
+- {{jsxref("TypedArray.prototype.filter()")}}
+  - : Creates a new array with all of the elements of this array for which the provided filtering function returns `true`. See also {{jsxref("Array.prototype.filter()")}}.
+- {{jsxref("TypedArray.prototype.find()")}}
+  - : Returns the first `element` in the array that satisfies a provided testing function, or `undefined` if no appropriate element is found. See also {{jsxref("Array.prototype.find()")}}.
+- {{jsxref("TypedArray.prototype.findIndex()")}}
+  - : Returns the first index value of in the array that has an element that satisfies a provided testing function, or `-1` if no appropriate element was found. See also {{jsxref("Array.prototype.findIndex()")}}.
+- {{jsxref("TypedArray.prototype.findLast()")}}
+  - : Returns the value of the last element in the array that satisfies a provided testing function, or `undefined` if no appropriate element is found. See also {{jsxref("Array.prototype.findLast()")}}.
+- {{jsxref("TypedArray.prototype.findLastIndex()")}}
+  - : Returns the index of the last element in the array that satisfies a provided testing function, or `-1` if no appropriate element was found. See also {{jsxref("Array.prototype.findLastIndex()")}}.
+- {{jsxref("TypedArray.prototype.forEach()")}}
+  - : Calls a function for each element in the array. See also {{jsxref("Array.prototype.forEach()")}}.
+- {{jsxref("TypedArray.prototype.includes()")}}
+  - : Determines whether a typed array includes a certain element, returning `true` or `false` as appropriate. See also {{jsxref("Array.prototype.includes()")}}.
+- {{jsxref("TypedArray.prototype.indexOf()")}}
+  - : Returns the first (least) index of an element within the array equal to the specified value, or `-1` if none is found. See also {{jsxref("Array.prototype.indexOf()")}}.
+- {{jsxref("TypedArray.prototype.join()")}}
+  - : Joins all elements of an array into a string. See also {{jsxref("Array.prototype.join()")}}.
+- {{jsxref("TypedArray.prototype.keys()")}}
+  - : Returns a new array iterator that contains the keys for each index in the array. See also {{jsxref("Array.prototype.keys()")}}.
+- {{jsxref("TypedArray.prototype.lastIndexOf()")}}
+  - : Returns the last (greatest) index of an element within the array equal to the specified value, or `-1` if none is found. See also {{jsxref("Array.prototype.lastIndexOf()")}}.
+- {{jsxref("TypedArray.prototype.map()")}}
+  - : Creates a new array with the results of calling a provided function on every element in this array. See also {{jsxref("Array.prototype.map()")}}.
+- {{jsxref("TypedArray.prototype.reduce()")}}
+  - : Apply a function against an accumulator and each value of the array (from left-to-right) as to reduce it to a single value. See also {{jsxref("Array.prototype.reduce()")}}.
+- {{jsxref("TypedArray.prototype.reduceRight()")}}
+  - : Apply a function against an accumulator and each value of the array (from right-to-left) as to reduce it to a single value. See also {{jsxref("Array.prototype.reduceRight()")}}.
+- {{jsxref("TypedArray.prototype.reverse()")}}
+  - : Reverses the order of the elements of an array — the first becomes the last, and the last becomes the first. See also {{jsxref("Array.prototype.reverse()")}}.
+- {{jsxref("TypedArray.prototype.set()")}}
+  - : Stores multiple values in the typed array, reading input values from a specified array.
+- {{jsxref("TypedArray.prototype.slice()")}}
+  - : Extracts a section of an array and returns a new array. See also {{jsxref("Array.prototype.slice()")}}.
+- {{jsxref("TypedArray.prototype.some()")}}
+  - : Returns `true` if at least one element in this array satisfies the provided testing function. See also {{jsxref("Array.prototype.some()")}}.
+- {{jsxref("TypedArray.prototype.sort()")}}
+  - : Sorts the elements of an array in place and returns the array. See also {{jsxref("Array.prototype.sort()")}}.
+- {{jsxref("TypedArray.prototype.subarray()")}}
+  - : Returns a new `TypedArray` from the given start and end element index.
+- {{jsxref("TypedArray.prototype.values()")}}
+  - : Returns a new _array iterator_ object that contains the values for each index in the array. See also {{jsxref("Array.prototype.values()")}}.
+- {{jsxref("TypedArray.prototype.toLocaleString()")}}
+  - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
+- {{jsxref("TypedArray.prototype.toString()")}}
+  - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
+- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]()")}}
+  - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ### Methods Polyfill
 

--- a/files/zh-tw/web/javascript/reference/global_objects/urierror/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/urierror/index.md
@@ -39,11 +39,20 @@ new URIError([message[, fileName[, lineNumber]]])
 
 ### 屬性
 
-{{page('/en-US/docs/Web/JavaScript/Reference/Global_Objects/URIError/prototype', 'Properties')}}
-
-### 方法
-
-{{page('/en-US/docs/Web/JavaScript/Reference/Global_Objects/URIError/prototype', 'Methods')}}
+- {{jsxref("Error.prototype.message", "URIError.prototype.message")}}
+  - : Error message. Inherited from {{jsxref("Error")}}.
+- {{jsxref("Error.prototype.name", "URIError.prototype.name")}}
+  - : Error name. Inherited from {{jsxref("Error")}}.
+- {{jsxref("Error.prototype.cause", "URIError.prototype.cause")}}
+  - : Error cause. Inherited from {{jsxref("Error")}}.
+- {{jsxref("Error.prototype.fileName", "URIError.prototype.fileName")}} {{non-standard_inline}}
+  - : Path to file that raised this error. Inherited from {{jsxref("Error")}}.
+- {{jsxref("Error.prototype.lineNumber", "URIError.prototype.lineNumber")}} {{non-standard_inline}}
+  - : Line number in file that raised this error. Inherited from {{jsxref("Error")}}.
+- {{jsxref("Error.prototype.columnNumber", "URIError.prototype.columnNumber")}} {{non-standard_inline}}
+  - : Column number in line that raised this error. Inherited from {{jsxref("Error")}}.
+- {{jsxref("Error.prototype.stack", "URIError.prototype.stack")}} {{non-standard_inline}}
+  - : Stack trace. Inherited from {{jsxref("Error")}}.
 
 ## 範例
 

--- a/files/zh-tw/web/javascript/typed_arrays/index.md
+++ b/files/zh-tw/web/javascript/typed_arrays/index.md
@@ -27,7 +27,17 @@ JavaScript 型別陣列提供了存取二進制資料更有效率的機制。
 
 型別陣列視圖具有自述性名稱，並為所有常用的數字類型（如 `Int8`, `Uint32`, `Float64` 等）提供視圖。 有一個特殊的型別陣列視圖 `Uint8ClampedArray`。 它的範圍值在 0 到 255 之間。它對於 [Canvas 的資料處理](/zh-TW/docs/Web/API/Canvas_API/Tutorial)非常有用。
 
-{{page("/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/TypedArray", "TypedArray_objects")}}
+| Type                                     | Value Range               | Size in bytes | Description                                                               | Web IDL type          | Equivalent C type |
+| ---------------------------------------- | ------------------------- | ------------- | ------------------------------------------------------------------------- | --------------------- | ----------------- |
+| {{jsxref("Int8Array")}}         | -128 to 127               | 1             | 8-bit two's complement signed integer                                     | `byte`                | `int8_t`          |
+| {{jsxref("Uint8Array")}}         | 0 to 255                  | 1             | 8-bit unsigned integer                                                    | `octet`               | `uint8_t`         |
+| {{jsxref("Uint8ClampedArray")}} | 0 to 255                  | 1             | 8-bit unsigned integer (clamped)                                          | `octet`               | `uint8_t`         |
+| {{jsxref("Int16Array")}}         | -32768 to 32767           | 2             | 16-bit two's complement signed integer                                    | `short`               | `int16_t`         |
+| {{jsxref("Uint16Array")}}         | 0 to 65535                | 2             | 16-bit unsigned integer                                                   | `unsigned short`      | `uint16_t`        |
+| {{jsxref("Int32Array")}}         | -2147483648 to 2147483647 | 4             | 32-bit two's complement signed integer                                    | `long`                | `int32_t`         |
+| {{jsxref("Uint32Array")}}         | 0 to 4294967295           | 4             | 32-bit unsigned integer                                                   | `unsigned long`       | `uint32_t`        |
+| {{jsxref("Float32Array")}}     | 1.2x10^-38 to 3.4x10^38   | 4             | 32-bit IEEE floating point number ( 7 significant digits e.g. 1.1234567)  | `unrestricted float`  | `float`           |
+| {{jsxref("Float64Array")}}     | 5.0x10^-324 to 1.8x10^308 | 8             | 64-bit IEEE floating point number (16 significant digits e.g. 1.123...15) | `unrestricted double` | `double`          |
 
 ### DataView
 


### PR DESCRIPTION
### Description

chore: remove page macros from zh-TW

This is a simple replace with the referenced resources (also removed some outdated content).

### Related issues and pull requests

Fixes: #3894
