### PR TITLE
docs: update errors/deprecated_string_generics

### DIFF
--- a/files/zh-cn/web/javascript/reference/errors/deprecated_string_generics/index.md
+++ b/files/zh-cn/web/javascript/reference/errors/deprecated_string_generics/index.md
@@ -5,9 +5,11 @@ slug: Web/JavaScript/Reference/Errors/Deprecated_String_generics
 
 {{jsSidebar("Errors")}}
 
-## 错误提示
+关于字符串泛型的 JavaScript 警告出现在 Firefox 68 之前的版本。从 Firefox 68 开始，字符串泛型已经被移除，这些警告信息已经过时了。
 
-```plain
+## 信息
+
+```
 Warning: String.charAt            is deprecated; use String.prototype.charAt            instead
 Warning: String.charCodeAt        is deprecated; use String.prototype.charCodeAt        instead
 Warning: String.concat            is deprecated; use String.prototype.concat            instead
@@ -41,65 +43,24 @@ Warning: String.trimRight         is deprecated; use String.prototype.trimRight 
 
 ## 哪里出错了？
 
-非标准的泛型 {{jsxref("String")}} 方法已经被废弃，将来会被移除（这些方法仅在 Firefox 浏览器中得到实现）。String 泛型在 String 对象上提供了一系列的 String 实例方法，使得这些 String 方法可以应用于任何类型的对象。
-
-Firefox {{bug(1222552)}} 对 String 泛型方法的移除进行了追踪。
+非标准的泛型 {{jsxref("String")}} 方法已经被废弃，已经在 Firefox 68 及更新版本移除。String 泛型在 `String` 对象上提供了一系列的 `String` 实例方法，使得这些方法可以应用于任何类型的对象。
 
 ## 示例
 
 ### 废弃的语法
 
 ```js example-bad
-var num = 15;
+const num = 15;
 String.replace(num, /5/, '2');
 ```
 
 ### 标准语法
 
 ```js example-good
-var num = 15;
+const num = 15;
 String(num).replace(/5/, '2');
 ```
 
-## 垫片
-
-以下是一个垫片脚本来为不支持 String 泛型方法浏览器提供支持：
-
-```js
-/*globals define*/
-// Assumes all supplied String instance methods already present
-// (one may use shims for these if not available)
-(function() {
-  'use strict';
-
-  var i,
-    // We could also build the array of methods with the following, but the
-    //   getOwnPropertyNames() method is non-shimable:
-    // Object.getOwnPropertyNames(String).filter(function(methodName) {
-    //   return typeof String[methodName] === 'function';
-    // });
-    methods = [
-      'contains', 'substring', 'toLowerCase', 'toUpperCase', 'charAt',
-      'charCodeAt', 'indexOf', 'lastIndexOf', 'startsWith', 'endsWith',
-      'trim', 'trimLeft', 'trimRight', 'toLocaleLowerCase', 'normalize',
-      'toLocaleUpperCase', 'localeCompare', 'match', 'search', 'slice',
-      'replace', 'split', 'substr', 'concat', 'localeCompare'
-    ],
-    methodCount = methods.length,
-    assignStringGeneric = function(methodName) {
-      var method = String.prototype[methodName];
-      String[methodName] = function(arg1) {
-        return method.apply(arg1, Array.prototype.slice.call(arguments, 1));
-      };
-    };
-
-  for (i = 0; i < methodCount; i++) {
-    assignStringGeneric(methods[i]);
-  }
-}());
-```
-
-## 相关内容
+## 参见
 
 - {{jsxref("String")}}
-- {{jsxref("Global_Objects/Array", "Generics", "#Array_generic_methods", 1)}} 同样存在于 {{jsxref("Array")}} 的方法中（也同样被废弃了）。

--- a/files/zh-cn/web/javascript/reference/errors/deprecated_string_generics/index.md
+++ b/files/zh-cn/web/javascript/reference/errors/deprecated_string_generics/index.md
@@ -39,11 +39,11 @@ Warning: String.trimRight         is deprecated; use String.prototype.trimRight 
 
 ## 错误类型
 
-警告。JavaScript 引擎不会停止运行。
+警告。JavaScript 的执行不会停止。
 
 ## 哪里出错了？
 
-非标准的泛型 {{jsxref("String")}} 方法已经被废弃，已经在 Firefox 68 及更新版本移除。String 泛型在 `String` 对象上提供了一系列的 `String` 实例方法，使得这些方法可以应用于任何类型的对象。
+非标准的泛型 {{jsxref("String")}} 方法已经被废弃，已经在 Firefox 68 及更新版本中移除。String 泛型在 `String` 对象上提供了一系列的 `String` 实例方法，使得这些方法可以应用于任何类型的对象。
 
 ## 示例
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

sync content of javascript error 'Warning: String.x is deprecated; use String.prototype.x instead'

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
