### PR TITLE
[zh] Replace mdn.mozillademos.org images that exist in content

### DIFF
--- a/files/zh-cn/learn/css/building_blocks/advanced_styling_effects/index.md
+++ b/files/zh-cn/learn/css/building_blocks/advanced_styling_effects/index.md
@@ -242,7 +242,7 @@ div {
   padding: 10px;
   margin: 10px;
   display: inline-block;
-  background: url(https://mdn.mozillademos.org/files/13090/colorful-heart.png) no-repeat center 20px;
+  background: url(colorful-heart.png) no-repeat center 20px;
   background-color: green;
 }
 
@@ -301,7 +301,7 @@ article div:first-child {
   position: absolute;
   top: 10px;
   left: 0;
-  background: url(https://mdn.mozillademos.org/files/13090/colorful-heart.png) no-repeat center 20px;
+  background: url(colorful-heart.png) no-repeat center 20px;
   background-color: green;
 }
 
@@ -363,7 +363,7 @@ article div:last-child {
   margin: 10px;
   display: inline-block;
   background-color: red;
-  background: url(https://mdn.mozillademos.org/files/13090/colorful-heart.png) no-repeat center 20px,
+  background: url(colorful-heart.png) no-repeat center 20px,
               linear-gradient(to bottom right, #f33, #a33);
 } </textarea>
 

--- a/files/zh-cn/learn/css/css_layout/positioning/index.md
+++ b/files/zh-cn/learn/css/css_layout/positioning/index.md
@@ -52,7 +52,7 @@ original_slug: Learn/CSS/CSS_layout/定位
 
 <p>We are separated by our margins. Because of margin collapsing, we are separated by the width of one of our margins, not both.</p>
 
-<p>inline elements <span>like this one</span> and <span>this one</span> sit on the same line as one another, and adjacent text nodes, if there is space on the same line. Overflowing inline elements will <span>wrap onto a new line if possible (like this one containing text)</span>, or just go on to a new line if not, much like this image will do: <img src="https://mdn.mozillademos.org/files/13360/long.jpg"></p>
+<p>inline elements <span>like this one</span> and <span>this one</span> sit on the same line as one another, and adjacent text nodes, if there is space on the same line. Overflowing inline elements will <span>wrap onto a new line if possible (like this one containing text)</span>, or just go on to a new line if not, much like this image will do: <img src="long.jpg"></p>
 ```
 
 ```css
@@ -141,7 +141,7 @@ left: 30px;
 
 <p>We are separated by our margins. Because of margin collapsing, we are separated by the width of one of our margins, not both.</p>
 
-<p>inline elements <span>like this one</span> and <span>this one</span> sit on the same line as one another, and adjacent text nodes, if there is space on the same line. Overflowing inline elements <span>wrap onto a new line if possible — like this one containing text</span>, or just go on to a new line if not, much like this image will do: <img src="https://mdn.mozillademos.org/files/13360/long.jpg"></p>
+<p>inline elements <span>like this one</span> and <span>this one</span> sit on the same line as one another, and adjacent text nodes, if there is space on the same line. Overflowing inline elements <span>wrap onto a new line if possible — like this one containing text</span>, or just go on to a new line if not, much like this image will do: <img src="long.jpg"></p>
 ```
 
 ```css hidden
@@ -195,7 +195,7 @@ position: absolute;
 
 <p>We are separated by our margins. Because of margin collapsing, we are separated by the width of one of our margins, not both.</p>
 
-<p>inline elements <span>like this one</span> and <span>this one</span> sit on the same line as one another, and adjacent text nodes, if there is space on the same line. Overflowing inline elements <span>wrap onto a new line if possible — like this one containing text</span>, or just go on to a new line if not, much like this image will do: <img src="https://mdn.mozillademos.org/files/13360/long.jpg"></p>
+<p>inline elements <span>like this one</span> and <span>this one</span> sit on the same line as one another, and adjacent text nodes, if there is space on the same line. Overflowing inline elements <span>wrap onto a new line if possible — like this one containing text</span>, or just go on to a new line if not, much like this image will do: <img src="long.jpg"></p>
 ```
 
 ```css hidden
@@ -259,7 +259,7 @@ position: relative;
 
 <p>We are separated by our margins. Because of margin collapsing, we are separated by the width of one of our margins, not both.</p>
 
-<p>inline elements <span>like this one</span> and <span>this one</span> sit on the same line as one another, and adjacent text nodes, if there is space on the same line. Overflowing inline elements <span>wrap onto a new line if possible — like this one containing text</span>, or just go on to a new line if not, much like this image will do: <img src="https://mdn.mozillademos.org/files/13360/long.jpg"></p>
+<p>inline elements <span>like this one</span> and <span>this one</span> sit on the same line as one another, and adjacent text nodes, if there is space on the same line. Overflowing inline elements <span>wrap onto a new line if possible — like this one containing text</span>, or just go on to a new line if not, much like this image will do: <img src="long.jpg"></p>
 ```
 
 ```css hidden
@@ -333,7 +333,7 @@ z-index: 1;
 
 <p>We are separated by our margins. Because of margin collapsing, we are separated by the width of one of our margins, not both.</p>
 
-<p>inline elements <span>like this one</span> and <span>this one</span> sit on the same line as one another, and adjacent text nodes, if there is space on the same line. Overflowing inline elements <span>wrap onto a new line if possible — like this one containing text</span>, or just go on to a new line if not, much like this image will do: <img src="https://mdn.mozillademos.org/files/13360/long.jpg"></p>
+<p>inline elements <span>like this one</span> and <span>this one</span> sit on the same line as one another, and adjacent text nodes, if there is space on the same line. Overflowing inline elements <span>wrap onto a new line if possible — like this one containing text</span>, or just go on to a new line if not, much like this image will do: <img src="long.jpg"></p>
 ```
 
 ```css hidden
@@ -427,7 +427,7 @@ p:nth-of-type(1) {
 
 <p>We are separated by our margins. Because of margin collapsing, we are separated by the width of one of our margins, not both.</p>
 
-<p>inline elements <span>like this one</span> and <span>this one</span> sit on the same line as one another, and adjacent text nodes, if there is space on the same line. Overflowing inline elements <span>wrap onto a new line if possible — like this one containing text</span>, or just go on to a new line if not, much like this image will do: <img src="https://mdn.mozillademos.org/files/13360/long.jpg"></p>
+<p>inline elements <span>like this one</span> and <span>this one</span> sit on the same line as one another, and adjacent text nodes, if there is space on the same line. Overflowing inline elements <span>wrap onto a new line if possible — like this one containing text</span>, or just go on to a new line if not, much like this image will do: <img src="long.jpg"></p>
 ```
 
 ```css hidden

--- a/files/zh-cn/learn/css/styling_text/styling_links/index.md
+++ b/files/zh-cn/learn/css/styling_text/styling_links/index.md
@@ -336,7 +336,7 @@ a:active {
 }
 
 a[href*="http"] {
-  background: url('https://mdn.mozillademos.org/files/12982/external-link-52.png') no-repeat 100% 0;
+  background: url('external-link-52.png') no-repeat 100% 0;
   background-size: 16px 16px;
   padding-right: 19px;
 }

--- a/files/zh-cn/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
+++ b/files/zh-cn/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
@@ -55,7 +55,7 @@ draw();
 
 结果如下：
 
-{{EmbedLiveSample("A_fillStyle_example", 160, 160, "https://mdn.mozillademos.org/files/5417/Canvas_fillstyle.png")}}
+{{EmbedLiveSample("A_fillStyle_example", 160, 160, "canvas_fillstyle.png")}}
 
 ### `strokeStyle` 示例
 
@@ -86,7 +86,7 @@ draw();
 
 结果如下：
 
-{{EmbedLiveSample("A_strokeStyle_example", "180", "180", "https://mdn.mozillademos.org/files/253/Canvas_strokestyle.png")}}
+{{EmbedLiveSample("A_strokeStyle_example", "180", "180", "canvas_strokestyle.png")}}
 
 ## 透明度 Transparency
 
@@ -145,7 +145,7 @@ function draw() {
 draw();
 ```
 
-{{EmbedLiveSample("A_globalAlpha_example", "180", "180", "https://mdn.mozillademos.org/files/232/Canvas_globalalpha.png")}}
+{{EmbedLiveSample("A_globalAlpha_example", "180", "180", "canvas_globalalpha.png")}}
 
 ### `rgba()` 示例
 
@@ -183,7 +183,7 @@ function draw() {
 draw();
 ```
 
-{{EmbedLiveSample("An_example_using_rgba", "180", "180", "https://mdn.mozillademos.org/files/246/Canvas_rgba.png")}}
+{{EmbedLiveSample("An_example_using_rgba", "180", "180", "canvas_rgba.png")}}
 
 ## 线型 Line styles
 
@@ -235,7 +235,7 @@ function draw() {
 draw();
 ```
 
-{{EmbedLiveSample("A_lineWidth_example", "180", "180", "https://mdn.mozillademos.org/files/239/Canvas_linewidth.png")}}
+{{EmbedLiveSample("A_lineWidth_example", "180", "180", "canvas_linewidth.png")}}
 
 想要获得精确的线条，必须对线条是如何描绘出来的有所理解。见下图，用网格来代表 canvas 的坐标格，每一格对应屏幕上一个像素点。在第一个图中，填充了 (2,1) 至 (5,5) 的矩形，整个区域的边界刚好落在像素边缘上，这样就可以得到的矩形有着清晰的边缘。
 
@@ -296,7 +296,7 @@ function draw() {
 draw();
 ```
 
-{{EmbedLiveSample("A_lineCap_example", "180", "180", "https://mdn.mozillademos.org/files/236/Canvas_linecap.png")}}
+{{EmbedLiveSample("A_lineCap_example", "180", "180", "canvas_linecap.png")}}
 
 #### `lineJoin` 属性的例子
 
@@ -330,7 +330,7 @@ function draw() {
 draw();
 ```
 
-{{EmbedLiveSample("A_lineJoin_example", "180", "180", "https://mdn.mozillademos.org/files/237/Canvas_linejoin.png")}}
+{{EmbedLiveSample("A_lineJoin_example", "180", "180", "canvas_linejoin.png")}}
 
 #### `miterLimit` 属性的演示例子
 
@@ -405,7 +405,7 @@ document.getElementById('miterLimit').value = document.getElementById('canvas').
 draw();
 ```
 
-{{EmbedLiveSample("A_demo_of_the_miterLimit_property", "500", "240", "https://mdn.mozillademos.org/files/240/Canvas_miterlimit.png")}}
+{{EmbedLiveSample("A_demo_of_the_miterLimit_property", "500", "240", "canvas_miterlimit.png")}}
 
 ### 使用虚线
 
@@ -440,7 +440,7 @@ function march() {
 march();
 ```
 
-{{EmbedLiveSample("Using_line_dashes", "120", "120", "https://mdn.mozillademos.org/files/9853/marching-ants.png")}}
+{{EmbedLiveSample("Using_line_dashes", "120", "120", "marching-ants.png")}}
 
 ## 渐变 Gradients
 
@@ -511,7 +511,7 @@ function draw() {
 draw();
 ```
 
-{{EmbedLiveSample("A_createLinearGradient_example", "180", "180", "https://mdn.mozillademos.org/files/235/Canvas_lineargradient.png")}}
+{{EmbedLiveSample("A_createLinearGradient_example", "180", "180", "canvas_lineargradient.png")}}
 
 ### `createRadialGradient` 的例子
 
@@ -566,7 +566,7 @@ draw();
 
 4 个径向渐变效果的最后一个色标都是透明色。如果想要两色标直接的过渡柔和一些，只要两个颜色值一致就可以了。代码里面看不出来，是因为我用了两种不同的颜色表示方法，但其实是相同的，`#019F62 = rgba(1,159,98,1)`。
 
-{{EmbedLiveSample("A_createRadialGradient_example", "180", "180", "https://mdn.mozillademos.org/files/244/Canvas_radialgradient.png")}}
+{{EmbedLiveSample("A_createRadialGradient_example", "180", "180", "canvas_radialgradient.png")}}
 
 ## 图案样式 Patterns
 
@@ -597,7 +597,7 @@ function draw() {
 
   // 创建新 image 对象，用作图案
   var img = new Image();
-  img.src = 'https://mdn.mozillademos.org/files/222/Canvas_createpattern.png';
+  img.src = 'canvas_createpattern.png';
   img.onload = function() {
 
     // 创建图案
@@ -619,7 +619,7 @@ draw();
 
 The result looks like this:
 
-{{EmbedLiveSample("createPattern_的例子", "180", "180", "https://mdn.mozillademos.org/files/222/Canvas_createpattern.png")}}
+{{EmbedLiveSample("createPattern_的例子", "180", "180", "canvas_createpattern.png")}}
 
 ## 阴影 Shadows
 
@@ -659,7 +659,7 @@ function draw() {
 draw();
 ```
 
-{{EmbedLiveSample("A_shadowed_text_example", "180", "100", "https://mdn.mozillademos.org/files/2505/shadowed-string.png")}}
+{{EmbedLiveSample("A_shadowed_text_example", "180", "100", "shadowed-string.png")}}
 
 我们可以通过下一章来了解文字属性和 fillText 方法相关的内容。
 
@@ -694,6 +694,6 @@ function draw() {
 draw();
 ```
 
-{{EmbedLiveSample("Canvas_fill_rules", "110", "110", "https://mdn.mozillademos.org/files/9855/fill-rule.png")}}
+{{EmbedLiveSample("Canvas_fill_rules", "110", "110", "fill-rule.png")}}
 
 {{PreviousNext("Web/API/Canvas_API/Tutorial/Drawing_shapes", "Web/API/Canvas_API/Tutorial/Drawing_text")}}

--- a/files/zh-cn/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/zh-cn/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -52,9 +52,9 @@ var sun = new Image();
 var moon = new Image();
 var earth = new Image();
 function init(){
-  sun.src = 'https://mdn.mozillademos.org/files/1456/Canvas_sun.png';
-  moon.src = 'https://mdn.mozillademos.org/files/1443/Canvas_moon.png';
-  earth.src = 'https://mdn.mozillademos.org/files/1429/Canvas_earth.png';
+  sun.src = 'canvas_sun.png';
+  moon.src = 'canvas_moon.png';
+  earth.src = 'canvas_earth.png';
   window.requestAnimationFrame(draw);
 }
 

--- a/files/zh-cn/web/api/canvas_api/tutorial/basic_usage/index.md
+++ b/files/zh-cn/web/api/canvas_api/tutorial/basic_usage/index.md
@@ -137,6 +137,6 @@ if (canvas.getContext){
 
 例子看起来像是这样：:
 
-{{EmbedLiveSample("一个简单例子", 160, 160, "https://mdn.mozillademos.org/files/228/canvas_ex1.png")}}
+{{EmbedLiveSample("一个简单例子", 160, 160, "canvas_ex1.png")}}
 
 {{PreviousNext("Web/API/Canvas_API/Tutorial", "Web/API/Canvas_API/Tutorial/Drawing_shapes")}}

--- a/files/zh-cn/web/api/canvas_api/tutorial/compositing/index.md
+++ b/files/zh-cn/web/api/canvas_api/tutorial/compositing/index.md
@@ -97,6 +97,6 @@ draw();
 
 裁切路径创建之后所有出现在它里面的东西才会画出来。在画线性渐变时我们就会注意到这点。然后会绘制出 50 颗随机位置分布（经过缩放）的星星，当然也只有在裁切路径里面的星星才会绘制出来。
 
-{{EmbedLiveSample("A_clip_example", "180", "180", "https://mdn.mozillademos.org/files/208/Canvas_clip.png")}}
+{{EmbedLiveSample("A_clip_example", "180", "180", "canvas_clip.png")}}
 
 {{PreviousNext("Web/API/Canvas_API/Tutorial/Transformations", "Web/API/Canvas_API/Tutorial/Basic_animations")}}

--- a/files/zh-cn/web/api/canvas_api/tutorial/drawing_shapes/index.md
+++ b/files/zh-cn/web/api/canvas_api/tutorial/drawing_shapes/index.md
@@ -55,7 +55,7 @@ function draw() {
 
 该例子的输出如下图所示。
 
-{{EmbedLiveSample("矩形（Rectangular）例子", 160, 160, "https://mdn.mozillademos.org/files/245/Canvas_rect.png")}}
+{{EmbedLiveSample("矩形（Rectangular）例子", 160, 160, "canvas_rect.png")}}
 
 `fillRect()`函数绘制了一个边长为 100px 的黑色正方形。`clearRect()`函数从正方形的中心开始擦除了一个 60\*60px 的正方形，接着`strokeRect()`在清除区域内生成一个 50\*50 的正方形边框。
 
@@ -122,7 +122,7 @@ function draw() {
 
 输出看上去如下：
 
-{{EmbedLiveSample("绘制一个三角形", 110, 110, "https://mdn.mozillademos.org/files/9847/triangle.png")}}
+{{EmbedLiveSample("绘制一个三角形", 110, 110, "triangle.png")}}
 
 ### 移动笔触
 
@@ -164,7 +164,7 @@ function draw() {
 
 结果看起来是这样的：
 
-{{EmbedLiveSample("%E7%A7%BB%E5%8A%A8%E7%AC%94%E8%A7%A6", 160, 160, "https://mdn.mozillademos.org/files/252/Canvas_smiley.png")}}
+{{EmbedLiveSample("%E7%A7%BB%E5%8A%A8%E7%AC%94%E8%A7%A6", 160, 160, "canvas_smiley.png")}}
 
 如果你想看到连续的线，你可以移除调用的 moveTo()。
 
@@ -215,7 +215,7 @@ function draw() {
 
 这里从调用`beginPath()`函数准备绘制一个新的形状路径开始。然后使用`moveTo()`函数移动到目标位置上。然后下面，两条线段绘制后构成三角形的两条边。
 
-{{EmbedLiveSample("%E7%BA%BF", 160, 160, "https://mdn.mozillademos.org/files/238/Canvas_lineTo.png")}}
+{{EmbedLiveSample("%E7%BA%BF", 160, 160, "canvas_lineto.png")}}
 
 你会注意到填充与描边三角形步骤有所不同。正如上面所提到的，因为路径使用填充（fill）时，路径自动闭合，使用描边（stroke）则不会闭合路径。如果没有添加闭合路径`closePath()`到描边三角形函数中，则只绘制了两条线段，并不是一个完整的三角形。
 
@@ -281,7 +281,7 @@ function draw() {
 }
 ```
 
-{{EmbedLiveSample("%E5%9C%86%E5%BC%A7", 160, 210, "https://mdn.mozillademos.org/files/204/Canvas_arc.png")}}
+{{EmbedLiveSample("%E5%9C%86%E5%BC%A7", 160, 210, "canvas_arc.png")}}
 
 ### 二次贝塞尔曲线及三次贝塞尔曲线
 
@@ -332,7 +332,7 @@ function draw() {
 }
 ```
 
-{{EmbedLiveSample("%E4%BA%8C%E6%AC%A1%E8%B4%9D%E5%A1%9E%E5%B0%94%E6%9B%B2%E7%BA%BF", 160, 160, "https://mdn.mozillademos.org/files/243/Canvas_quadratic.png")}}
+{{EmbedLiveSample("%E4%BA%8C%E6%AC%A1%E8%B4%9D%E5%A1%9E%E5%B0%94%E6%9B%B2%E7%BA%BF", 160, 160, "canvas_quadratic.png")}}
 
 #### 三次贝塞尔曲线
 
@@ -366,7 +366,7 @@ function draw() {
 }
 ```
 
-{{EmbedLiveSample("%E4%B8%89%E6%AC%A1%E8%B4%9D%E5%A1%9E%E5%B0%94%E6%9B%B2%E7%BA%BF", 160, 160, "https://mdn.mozillademos.org/files/207/Canvas_bezier.png")}}
+{{EmbedLiveSample("%E4%B8%89%E6%AC%A1%E8%B4%9D%E5%A1%9E%E5%B0%94%E6%9B%B2%E7%BA%BF", 160, 160, "canvas_bezier.png")}}
 
 ### 矩形
 
@@ -477,7 +477,7 @@ function roundedRect(ctx, x, y, width, height, radius){
 
 结果画面如下：
 
-{{EmbedLiveSample("%E7%BB%84%E5%90%88%E4%BD%BF%E7%94%A8", 160, 160, "https://mdn.mozillademos.org/files/9849/combinations.png")}}
+{{EmbedLiveSample("%E7%BB%84%E5%90%88%E4%BD%BF%E7%94%A8", 160, 160, "combinations.png")}}
 
 我们不会很详细地讲解上面的代码，因为事实上这很容易理解。重点是绘制上下文中使用到了 fillStyle 属性，以及封装函数（例子中的`roundedRect()`）。使用封装函数对于减少代码量以及复杂度十分有用。
 
@@ -536,7 +536,7 @@ function draw() {
 }
 ```
 
-{{EmbedLiveSample("Path2D_%E7%A4%BA%E4%BE%8B", 130, 110, "https://mdn.mozillademos.org/files/9851/path2d.png")}}
+{{EmbedLiveSample("Path2D_%E7%A4%BA%E4%BE%8B", 130, 110, "path2d.png")}}
 
 ### 使用 SVG paths
 

--- a/files/zh-cn/web/api/canvas_api/tutorial/transformations/index.md
+++ b/files/zh-cn/web/api/canvas_api/tutorial/transformations/index.md
@@ -34,7 +34,7 @@ Canvas 状态存储在栈中，每当`save()`方法被调用后，当前的状�
 
 当第二次调用 `restore` 时，已经恢复到最初的状态，因此最后是再一次绘制出一个黑色的四方形。
 
-{{EmbedLiveSample("A_save_and_restore_canvas_state_example", "180", "180", "https://mdn.mozillademos.org/files/249/Canvas_savestate.png")}}
+{{EmbedLiveSample("A_save_and_restore_canvas_state_example", "180", "180", "canvas_savestate.png")}}
 
 ```js
 function draw() {
@@ -107,7 +107,7 @@ function draw() {
 draw();
 ```
 
-{{EmbedLiveSample("A_translate_example", "160", "160", "https://mdn.mozillademos.org/files/9857/translate.png")}}
+{{EmbedLiveSample("A_translate_example", "160", "160", "translate.png")}}
 
 ## 旋转 Rotating
 
@@ -136,7 +136,7 @@ draw();
 draw();
 ```
 
-{{EmbedLiveSample("A_rotate_example", "310", "210", "https://mdn.mozillademos.org/files/9859/rotate.png")}}
+{{EmbedLiveSample("A_rotate_example", "310", "210", "rotate.png")}}
 
 ```js
 function draw() {
@@ -199,7 +199,7 @@ function draw() {
 draw();
 ```
 
-{{EmbedLiveSample("A_scale_example", "160", "160", "https://mdn.mozillademos.org/files/9861/scale.png")}}
+{{EmbedLiveSample("A_scale_example", "160", "160", "scale.png")}}
 
 ## 变形 Transforms
 
@@ -264,6 +264,6 @@ function draw() {
 draw();
 ```
 
-{{EmbedLiveSample("transform_setTransform_的例子", "230", "280", "https://mdn.mozillademos.org/files/255/Canvas_transform.png")}}
+{{EmbedLiveSample("transform_setTransform_的例子", "230", "280", "canvas_transform.png")}}
 
 {{PreviousNext("Web/API/Canvas_API/Tutorial/Using_images", "Web/API/Canvas_API/Tutorial/Compositing")}}

--- a/files/zh-cn/web/api/canvas_api/tutorial/using_images/index.md
+++ b/files/zh-cn/web/api/canvas_api/tutorial/using_images/index.md
@@ -135,13 +135,13 @@ function getMyVideo() {
       ctx.lineTo(170,15);
       ctx.stroke();
     }
-    img.src = 'https://mdn.mozillademos.org/files/5395/backdrop.png';
+    img.src = 'backdrop.png';
   }
 ```
 
 结果看起来是这样的：
 
-{{EmbedLiveSample("Example_A_simple_line_graph", 220, 160, "https://mdn.mozillademos.org/files/206/Canvas_backdrop.png")}}
+{{EmbedLiveSample("Example_A_simple_line_graph", 220, 160, "canvas_backdrop.png")}}
 
 ## 缩放 Scaling
 
@@ -177,13 +177,13 @@ function draw() {
       }
     }
   };
-  img.src = 'https://mdn.mozillademos.org/files/5397/rhino.jpg';
+  img.src = 'rhino.jpg';
 }
 ```
 
 结果看起来像这样：
 
-{{EmbedLiveSample("Example_Tiling_an_image", 160, 160, "https://mdn.mozillademos.org/files/251/Canvas_scale_image.png")}}
+{{EmbedLiveSample("Example_Tiling_an_image", 160, 160, "canvas_scale_image.png")}}
 
 ## 切片 Slicing
 
@@ -209,8 +209,8 @@ function draw() {
  <body onload="draw();">
    <canvas id="canvas" width="150" height="150"></canvas>
    <div style="display:none;">
-     <img id="source" src="https://mdn.mozillademos.org/files/5397/rhino.jpg" width="300" height="227">
-     <img id="frame" src="https://mdn.mozillademos.org/files/242/Canvas_picture_frame.png" width="132" height="150">
+     <img id="source" src="rhino.jpg" width="300" height="227">
+     <img id="frame" src="canvas_picture_frame.png" width="132" height="150">
    </div>
  </body>
 </html>
@@ -230,7 +230,7 @@ function draw() {
 }
 ```
 
-{{EmbedLiveSample("Example_Framing_an_image", 160, 160, "https://mdn.mozillademos.org/files/226/Canvas_drawimage2.jpg")}}
+{{EmbedLiveSample("Example_Framing_an_image", 160, 160, "canvas_drawimage2.jpg")}}
 
 ## 示例：画廊 Art gallery example
 
@@ -247,26 +247,26 @@ function draw() {
  <body onload="draw();">
      <table>
       <tr>
-        <td><img src="https://mdn.mozillademos.org/files/5399/gallery_1.jpg"></td>
-        <td><img src="https://mdn.mozillademos.org/files/5401/gallery_2.jpg"></td>
-        <td><img src="https://mdn.mozillademos.org/files/5403/gallery_3.jpg"></td>
-        <td><img src="https://mdn.mozillademos.org/files/5405/gallery_4.jpg"></td>
+        <td><img src="gallery_1.jpg"></td>
+        <td><img src="gallery_2.jpg"></td>
+        <td><img src="gallery_3.jpg"></td>
+        <td><img src="gallery_4.jpg"></td>
       </tr>
       <tr>
-        <td><img src="https://mdn.mozillademos.org/files/5407/gallery_5.jpg"></td>
-        <td><img src="https://mdn.mozillademos.org/files/5409/gallery_6.jpg"></td>
-        <td><img src="https://mdn.mozillademos.org/files/5411/gallery_7.jpg"></td>
-        <td><img src="https://mdn.mozillademos.org/files/5413/gallery_8.jpg"></td>
+        <td><img src="gallery_5.jpg"></td>
+        <td><img src="gallery_6.jpg"></td>
+        <td><img src="gallery_7.jpg"></td>
+        <td><img src="gallery_8.jpg"></td>
       </tr>
      </table>
-     <img id="frame" src="https://mdn.mozillademos.org/files/242/Canvas_picture_frame.png" width="132" height="150">
+     <img id="frame" src="canvas_picture_frame.png" width="132" height="150">
  </body>
 </html>
 ```
 
 ```css
 body {
-  background: 0 -100px repeat-x url(https://mdn.mozillademos.org/files/5415/bg_gallery.png) #4F191A;
+  background: 0 -100px repeat-x url(bg_gallery.png) #4F191A;
   margin: 10px;
 }
 

--- a/files/zh-cn/web/api/canvaspattern/settransform/index.md
+++ b/files/zh-cn/web/api/canvaspattern/settransform/index.md
@@ -41,7 +41,7 @@ var svg1 = document.getElementById("svg1");
 var matrix = svg1.createSVGMatrix();
 
 var img = new Image();
-img.src = 'https://mdn.mozillademos.org/files/222/Canvas_createpattern.png';
+img.src = 'canvas_createpattern.png';
 
 img.onload = function() {
   var pattern = ctx.createPattern(img, 'repeat');
@@ -62,7 +62,7 @@ img.onload = function() {
 </div>
 <textarea id="code" class="playable-code" style="height:120px">
 var img = new Image();
-img.src = 'https://mdn.mozillademos.org/files/222/Canvas_createpattern.png';
+img.src = 'canvas_createpattern.png';
 img.onload = function() {
   var pattern = ctx.createPattern(img, 'repeat');
   pattern.setTransform(matrix.rotate(-45).scale(1.5));

--- a/files/zh-cn/web/api/canvasrenderingcontext2d/arc/index.md
+++ b/files/zh-cn/web/api/canvasrenderingcontext2d/arc/index.md
@@ -127,7 +127,7 @@ for (i=0;i<4;i++){
 }
 ```
 
-{{ EmbedLiveSample('Different_shapes_demonstrated', 160, 210, "https://mdn.mozillademos.org/files/204/Canvas_arc.png") }}
+{{ EmbedLiveSample('Different_shapes_demonstrated', 160, 210, "canvas_arc.png") }}
 
 ## 规范描述
 

--- a/files/zh-cn/web/api/canvasrenderingcontext2d/createpattern/index.md
+++ b/files/zh-cn/web/api/canvasrenderingcontext2d/createpattern/index.md
@@ -62,7 +62,7 @@ var canvas = document.getElementById("canvas");
 var ctx = canvas.getContext("2d");
 
 var img = new Image();
-img.src = 'https://mdn.mozillademos.org/files/222/Canvas_createpattern.png';
+img.src = 'canvas_createpattern.png';
 img.onload = function() {
   var pattern = ctx.createPattern(img, 'repeat');
   ctx.fillStyle = pattern;
@@ -80,7 +80,7 @@ img.onload = function() {
 </div>
 <textarea id="code" class="playable-code" style="height:120px">
 var img = new Image();
-img.src = 'https://mdn.mozillademos.org/files/222/Canvas_createpattern.png';
+img.src = 'canvas_createpattern.png';
 img.onload = function() {
   var pattern = ctx.createPattern(img, 'repeat');
   ctx.fillStyle = pattern;

--- a/files/zh-cn/web/api/canvasrenderingcontext2d/fillstyle/index.md
+++ b/files/zh-cn/web/api/canvasrenderingcontext2d/fillstyle/index.md
@@ -110,7 +110,7 @@ for (var i=0;i<6;i++){
 
 结果看起来像是这样的：
 
-{{EmbedLiveSample("fillStyle_使用_for_循环的例子", 160, 160, "https://mdn.mozillademos.org/files/5417/Canvas_fillstyle.png")}}
+{{EmbedLiveSample("fillStyle_使用_for_循环的例子", 160, 160, "canvas_fillstyle.png")}}
 
 ## 规格描述
 

--- a/files/zh-cn/web/api/canvasrenderingcontext2d/globalalpha/index.md
+++ b/files/zh-cn/web/api/canvasrenderingcontext2d/globalalpha/index.md
@@ -126,7 +126,7 @@ for (i=0;i<7;i++){
 <canvas id="canvas" width="150" height="150"></canvas>
 ```
 
-{{EmbedLiveSample("A_globalAlpha_example", "180", "180", "https://mdn.mozillademos.org/files/232/Canvas_globalalpha.png")}}
+{{EmbedLiveSample("A_globalAlpha_example", "180", "180", "canvas_globalalpha.png")}}
 
 ## 规范描述
 

--- a/files/zh-cn/web/api/canvasrenderingcontext2d/imagesmoothingquality/index.md
+++ b/files/zh-cn/web/api/canvasrenderingcontext2d/imagesmoothingquality/index.md
@@ -38,7 +38,7 @@ var canvas = document.getElementById("canvas");
 var ctx = canvas.getContext("2d");
 
 var img = new Image();
-img.src = 'https://mdn.mozillademos.org/files/222/Canvas_createpattern.png';
+img.src = 'canvas_createpattern.png';
 img.onload = function() {
  ctx.mozImageSmoothingEnabled = false;
  ctx.imageSmoothingQuality = "Medium";
@@ -59,7 +59,7 @@ img.onload = function() {
 </div>
 <textarea id="code" class="playable-code" style="height:140px;">
 var img = new Image();
-img.src = 'https://mdn.mozillademos.org/files/222/Canvas_createpattern.png';
+img.src = 'canvas_createpattern.png';
 img.onload = function() {
  ctx.mozImageSmoothingEnabled = false;
  ctx.webkitImageSmoothingEnabled = false;

--- a/files/zh-cn/web/api/canvasrenderingcontext2d/linecap/index.md
+++ b/files/zh-cn/web/api/canvasrenderingcontext2d/linecap/index.md
@@ -132,7 +132,7 @@ for (var i = 0; i < lineCap.length; i++) {
 <canvas id="canvas" width="150" height="150"></canvas>
 ```
 
-{{EmbedLiveSample("A_lineCap_example", "180", "180", "https://mdn.mozillademos.org/files/236/Canvas_linecap.png")}}
+{{EmbedLiveSample("A_lineCap_example", "180", "180", "canvas_linecap.png")}}
 
 ## 规范描述
 

--- a/files/zh-cn/web/api/canvasrenderingcontext2d/linejoin/index.md
+++ b/files/zh-cn/web/api/canvasrenderingcontext2d/linejoin/index.md
@@ -128,7 +128,7 @@ for (var i = 0; i < lineJoin.length; i++) {
 <canvas id="canvas" width="150" height="150"></canvas>
 ```
 
-{{EmbedLiveSample("A_lineJoin_example", "180", "180", "https://mdn.mozillademos.org/files/237/Canvas_linejoin.png")}}
+{{EmbedLiveSample("A_lineJoin_example", "180", "180", "canvas_linejoin.png")}}
 
 ## 规范描述
 

--- a/files/zh-cn/web/api/canvasrenderingcontext2d/miterlimit/index.md
+++ b/files/zh-cn/web/api/canvasrenderingcontext2d/miterlimit/index.md
@@ -74,7 +74,7 @@ textarea.addEventListener("input", drawCanvas);
 window.addEventListener("load", drawCanvas);
 ```
 
-{{EmbedLiveSample("A_demo_of_the_miterLimit_property", "400", "180", "https://mdn.mozillademos.org/files/240/Canvas_miterlimit.png", "Web/API/Canvas_API/Tutorial/Applying_styles_and_colors")}}
+{{EmbedLiveSample("A_demo_of_the_miterLimit_property", "400", "180", "canvas_miterlimit.png", "Web/API/Canvas_API/Tutorial/Applying_styles_and_colors")}}
 
 ## 规范描述
 

--- a/files/zh-cn/web/api/canvasrenderingcontext2d/strokestyle/index.md
+++ b/files/zh-cn/web/api/canvasrenderingcontext2d/strokestyle/index.md
@@ -112,7 +112,7 @@ for (var i=0;i<6;i++){
 
 结果如下显示：
 
-{{EmbedLiveSample("A_strokeStyle_example", "180", "180", "https://mdn.mozillademos.org/files/253/Canvas_strokestyle.png")}}
+{{EmbedLiveSample("A_strokeStyle_example", "180", "180", "canvas_strokestyle.png")}}
 
 ## 规范描述
 

--- a/files/zh-cn/web/api/console/timelog/index.md
+++ b/files/zh-cn/web/api/console/timelog/index.md
@@ -3,7 +3,9 @@ title: Console.timeLog()
 slug: Web/API/Console/timeLog
 ---
 
-{{APIRef("Console API")}}在控制台输出计时器的值，该计时器必须已经通过 {{domxref("console.time()")}} 启动。
+{{APIRef("Console API")}}
+
+在控制台输出计时器的值，该计时器必须已经通过 {{domxref("console.time()")}} 启动。
 
 参阅文档中的 [Timers](/zh-CN/docs/Web/API/console#Timers) 部分获取详细说明和示例。
 
@@ -60,7 +62,7 @@ console.timeEnd("answer time");
 
 上例中的输出分别显示了用户从打开页面到关闭第一个 alert 和第二个 alert 框的时间间隔：
 
-[![](timer_output.png)](timer_output.png)
+![Timer output in Firefox console](timer_output.png)
 
 注意：使用 `timelog()` 输出计时器的值会显示计时器名称。使用 `timeEnd()` 停止也会显示计时器名称和输出计时器的值，并且，最后的 " - timer ended" 可以清楚的显示计时器不再计时的信息。
 

--- a/files/zh-cn/web/api/console/timelog/index.md
+++ b/files/zh-cn/web/api/console/timelog/index.md
@@ -60,7 +60,7 @@ console.timeEnd("answer time");
 
 上例中的输出分别显示了用户从打开页面到关闭第一个 alert 和第二个 alert 框的时间间隔：
 
-[![](timer_output.png)](https://mdn.mozillademos.org/files/16741/timer_output.png)
+[![](timer_output.png)](timer_output.png)
 
 注意：使用 `timelog()` 输出计时器的值会显示计时器名称。使用 `timeEnd()` 停止也会显示计时器名称和输出计时器的值，并且，最后的 " - timer ended" 可以清楚的显示计时器不再计时的信息。
 

--- a/files/zh-cn/web/api/service_worker_api/using_service_workers/index.md
+++ b/files/zh-cn/web/api/service_worker_api/using_service_workers/index.md
@@ -433,7 +433,7 @@ Firefox 也开始实现一些关于 service worker 的有用的工具：
 
 - [The Service Worker Cookbook](https://github.com/mdn/serviceworker-cookbook/)
 - [Is ServiceWorker ready?](https://jakearchibald.github.io/isserviceworkerready/)
-- 下载 [Service Workers 101 cheatsheet](https://mdn.mozillademos.org/files/12638/sw101.png).
+- 下载 [Service Workers 101 cheatsheet](sw101.png).
 - [Promises](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Promise)
 - [Using web workers](/zh-CN/docs/Web/Guide/Performance/Using_web_workers)
 - Fetch API

--- a/files/zh-cn/web/api/web_audio_api/index.md
+++ b/files/zh-cn/web/api/web_audio_api/index.md
@@ -23,7 +23,7 @@ Web Audio API 使用户可以在**音频上下文**（AudioContext）中进行�
 4. 为音频选择一个目的地，例如你的系统扬声器
 5. 连接源到效果器，对目的地进行效果输出
 
-![A simple box diagram with an outer box labeled Audio context, and three inner boxes labeled Sources, Effects and Destination. The three inner boxes have arrow between them pointing from left to right, indicating the flow of audio information.](webaudioapi_en.svg)
+![A simple box diagram with an outer box labeled Audio context, and three inner boxes labeled Sources, Effects and Destination. The three inner boxes have arrow between them pointing from left to right, indicating the flow of audio information.](audio-context_.png)
 
 使用这个 API，时间可以被非常精确地控制，几乎没有延迟，这样开发人员可以准确地响应事件，并且可以针对采样数据进行编程，甚至是较高的采样率。这样，鼓点和节拍是准确无误的。
 

--- a/files/zh-cn/web/api/web_audio_api/index.md
+++ b/files/zh-cn/web/api/web_audio_api/index.md
@@ -23,7 +23,7 @@ Web Audio API 使用户可以在**音频上下文**（AudioContext）中进行�
 4. 为音频选择一个目的地，例如你的系统扬声器
 5. 连接源到效果器，对目的地进行效果输出
 
-![A simple box diagram with an outer box labeled Audio context, and three inner boxes labeled Sources, Effects and Destination. The three inner boxes have arrow between them pointing from left to right, indicating the flow of audio information.](https://mdn.mozillademos.org/files/12241/webaudioAPI_en.svg)
+![A simple box diagram with an outer box labeled Audio context, and three inner boxes labeled Sources, Effects and Destination. The three inner boxes have arrow between them pointing from left to right, indicating the flow of audio information.](webaudioapi_en.svg)
 
 使用这个 API，时间可以被非常精确地控制，几乎没有延迟，这样开发人员可以准确地响应事件，并且可以针对采样数据进行编程，甚至是较高的采样率。这样，鼓点和节拍是准确无误的。
 

--- a/files/zh-cn/web/api/webrtc_api/signaling_and_video_calling/index.md
+++ b/files/zh-cn/web/api/webrtc_api/signaling_and_video_calling/index.md
@@ -133,7 +133,7 @@ if (sendToClients) {
 
 假设 Naomi 和 Priya 正在使用聊天软件进行讨论，Naomi 决定在两人之间打开一个视频通话。以下是预期的事件顺序：
 
-[![Diagram of the signaling process](webrtc_-_signaling_diagram.svg)](https://mdn.mozillademos.org/files/12363/WebRTC%20-%20Signaling%20Diagram.svg)
+[![Diagram of the signaling process](webrtc_-_signaling_diagram.svg)](webrtc_-_signaling_diagram.svg)
 
 在本文的整个过程中，我们将看到更详细的信息。
 
@@ -141,7 +141,7 @@ if (sendToClients) {
 
 当每端的 ICE 层开始发送候选时，它会在链中的各个点之间进行交换，如下所示：
 
-[![Diagram of ICE candidate exchange process](webrtc_-_ice_candidate_exchange.svg)](https://mdn.mozillademos.org/files/12365/WebRTC%20-%20ICE%20Candidate%20Exchange.svg)
+[![Diagram of ICE candidate exchange process](webrtc_-_ice_candidate_exchange.svg)](webrtc_-_ice_candidate_exchange.svg)
 
 每一端从本地的 ICE 层接收候选时，都会将其发送给另一方；不存在轮流或成批的候选。一旦两端就一个候选达成一致，双方就都可以用此候选来交换媒体数据，媒体数据就开始流动。即使在媒体数据已经开始流动之后，每一端都会继续向候选发送消息，直到他们没有选择的余地。这样做是为了找到比最初选择的更好的选择。
 

--- a/files/zh-cn/web/api/xmlhttprequest/abort_event/index.md
+++ b/files/zh-cn/web/api/xmlhttprequest/abort_event/index.md
@@ -91,7 +91,7 @@ function runXHR(url) {
 }
 
 xhrButtonSuccess.addEventListener('click', () => {
-    runXHR('https://mdn.mozillademos.org/files/16553/DgsZYJNXcAIPwzy.jpg');
+    runXHR('dgszyjnxcaipwzy.jpg');
 });
 
 xhrButtonError.addEventListener('click', () => {
@@ -99,7 +99,7 @@ xhrButtonError.addEventListener('click', () => {
 });
 
 xhrButtonAbort.addEventListener('click', () => {
-    runXHR('https://mdn.mozillademos.org/files/16553/DgsZYJNXcAIPwzy.jpg').abort();
+    runXHR('dgszyjnxcaipwzy.jpg').abort();
 });
 ```
 

--- a/files/zh-cn/web/api/xmlhttprequest/error_event/index.md
+++ b/files/zh-cn/web/api/xmlhttprequest/error_event/index.md
@@ -93,7 +93,7 @@ function runXHR(url) {
 }
 
 xhrButtonSuccess.addEventListener('click', () => {
-    runXHR('https://mdn.mozillademos.org/files/16553/DgsZYJNXcAIPwzy.jpg');
+    runXHR('dgszyjnxcaipwzy.jpg');
 });
 
 xhrButtonError.addEventListener('click', () => {
@@ -101,7 +101,7 @@ xhrButtonError.addEventListener('click', () => {
 });
 
 xhrButtonAbort.addEventListener('click', () => {
-    runXHR('https://mdn.mozillademos.org/files/16553/DgsZYJNXcAIPwzy.jpg').abort();
+    runXHR('dgszyjnxcaipwzy.jpg').abort();
 });
 ```
 

--- a/files/zh-cn/web/css/-moz-image-rect/index.md
+++ b/files/zh-cn/web/css/-moz-image-rect/index.md
@@ -63,7 +63,7 @@ Then the four boxes defining the segments of the image are defined. Let's look a
 
 ```css
 #box1 {
-  background-image: -moz-image-rect(url(https://mdn.mozillademos.org/files/12053/firefox.png), 0%, 50%, 50%, 0%);
+  background-image: -moz-image-rect(url(firefox.png), 0%, 50%, 50%, 0%);
   width:133px;
   height:136px;
   position:absolute;
@@ -74,7 +74,7 @@ This is the top-left corner of the image. It defines a rectangle containing the 
 
 ```css
 #box2 {
-  background-image: -moz-image-rect(url(https://mdn.mozillademos.org/files/12053/firefox.png), 0%, 100%, 50%, 50%);
+  background-image: -moz-image-rect(url(firefox.png), 0%, 100%, 50%, 50%);
   width:133px;
   height:136px;
   position:absolute;
@@ -87,13 +87,13 @@ The other corners follow a similar pattern:
 
 ```css
 #box3 {
-  background-image: -moz-image-rect(url(https://mdn.mozillademos.org/files/12053/firefox.png), 50%, 50%, 100%, 0%);
+  background-image: -moz-image-rect(url(firefox.png), 50%, 50%, 100%, 0%);
   width:133px;
   height:136px;
   position:absolute;
 }
 #box4 {
-  background-image: -moz-image-rect(url(https://mdn.mozillademos.org/files/12053/firefox.png), 50%, 100%, 100%, 50%);
+  background-image: -moz-image-rect(url(firefox.png), 50%, 100%, 100%, 50%);
   width:133px;
   height:136px;
   position:absolute;

--- a/files/zh-cn/web/css/background-attachment/index.md
+++ b/files/zh-cn/web/css/background-attachment/index.md
@@ -44,7 +44,7 @@ background-attachment: unset;
 
 ```css
 p {
-  background-image: url("https://mdn.mozillademos.org/files/12057/starsolid.gif");
+  background-image: url("starsolid.gif");
   background-attachment: fixed;
 }
 ```
@@ -72,7 +72,7 @@ p {
 
 ```css
 p {
-  background-image: url("https://mdn.mozillademos.org/files/12057/starsolid.gif"), url("https://mdn.mozillademos.org/files/12059/startransparent.gif");
+  background-image: url("starsolid.gif"), url("startransparent.gif");
   background-attachment: fixed, scroll;
   background-repeat: no-repeat, repeat-y;
 }

--- a/files/zh-cn/web/css/background-blend-mode/index.md
+++ b/files/zh-cn/web/css/background-blend-mode/index.md
@@ -61,7 +61,7 @@ background-blend-mode: unset;
 #div {
     width: 300px;
     height: 300px;
-    background: url('https://mdn.mozillademos.org/files/8543/br.png'),url('https://mdn.mozillademos.org/files/8545/tr.png');
+    background: url('br.png'),url('tr.png');
     background-blend-mode: screen;
 }
 ```

--- a/files/zh-cn/web/css/background-blend-mode/index.md
+++ b/files/zh-cn/web/css/background-blend-mode/index.md
@@ -33,29 +33,32 @@ background-blend-mode: unset;
 
 ### 值
 
-- \<blend-mode>
-  - : 一个{{cssxref("&lt;blend-mode&gt;")}}定义混合的模式，可以有多个值，用逗号间隔。
+- {{cssxref("&lt;blend-mode&gt;")}}
+  - : 一个定义混合的模式，可以有多个值，用逗号间隔。
 
 ## 示例
 
-\<select id="select">
-\<option>normal\</option>
-\<option>multiply\</option>
-\<option selected>screen\</option>
-\<option>overlay\</option>
-\<option>darken\</option>
-\<option>lighten\</option>
-\<option>color-dodge\</option>
-\<option>color-burn\</option>
-\<option>hard-light\</option>
-\<option>soft-light\</option>
-\<option>difference\</option>
-\<option>exclusion\</option>
-\<option>hue\</option>
-\<option>saturation\</option>
-\<option>color\</option>
-\<option>luminosity\</option>
-\</select>
+```html hidden
+<div id="div"></div>
+<select id="select">
+  <option>normal</option>
+  <option>multiply</option>
+  <option selected>screen</option>
+  <option>overlay</option>
+  <option>darken</option>
+  <option>lighten</option>
+  <option>color-dodge</option>
+  <option>color-burn</option>
+  <option>hard-light</option>
+  <option>soft-light</option>
+  <option>difference</option>
+  <option>exclusion</option>
+  <option>hue</option>
+  <option>saturation</option>
+  <option>color</option>
+  <option>luminosity</option>
+</select>
+```
 
 ```css
 #div {
@@ -73,7 +76,7 @@ document.getElementById("select").onchange = function(event) {
 console.log(document.getElementById('div'));
 ```
 
-{{ EmbedLiveSample('Examples', "330", "330") }}
+{{ EmbedLiveSample('示例', "330", "330") }}
 
 ## 规范
 

--- a/files/zh-cn/web/css/background-image/index.md
+++ b/files/zh-cn/web/css/background-image/index.md
@@ -26,7 +26,7 @@ slug: Web/CSS/background-image
 ```css
 background-image:
   linear-gradient(to bottom, rgba(255,255,0,0.5), rgba(0,0,255,0.5)),
-  url('https://mdn.mozillademos.org/files/7693/catfront.png');
+  url('catfront.png');
 ```
 
 ### 取值
@@ -71,13 +71,13 @@ p {
 
 div {
   background-image:
-      url("https://mdn.mozillademos.org/files/6457/mdn_logo_only_color.png");
+      url("mdn_logo_only_color.png");
 }
 
 .catsandstars {
   background-image:
-      url("https://mdn.mozillademos.org/files/11991/startransparent.gif"),
-      url("https://mdn.mozillademos.org/files/7693/catfront.png");
+      url("startransparent.gif"),
+      url("catfront.png");
   background-color: transparent;
 }
 ```

--- a/files/zh-cn/web/css/background-repeat/index.md
+++ b/files/zh-cn/web/css/background-repeat/index.md
@@ -111,7 +111,7 @@ div {
 /* Multiple images */
 .five {
     background-image:  url(starsolid.gif),
-                       url(https://developer.mozilla.org/static/img/favicon32.png);
+                       url(favicon32.png);
     background-repeat: repeat-x,
                        repeat-y;
     height: 144px;
@@ -120,7 +120,7 @@ div {
 
 ### 结果
 
-在这个例子中，每一个列表项都使用了不同的`background-repeat 语法。`
+在这个例子中，每一个列表项都使用了不同的`background-repeat` 语法。
 
 {{EmbedLiveSample("例子", 240, 360)}}
 

--- a/files/zh-cn/web/css/background-repeat/index.md
+++ b/files/zh-cn/web/css/background-repeat/index.md
@@ -89,7 +89,7 @@ background-repeat: inherit;
 /* Shared for all DIVS in example */
 li {margin-bottom: 12px;}
 div {
-    background-image: url(https://mdn.mozillademos.org/files/12005/starsolid.gif);
+    background-image: url(starsolid.gif);
     width: 144px;
     height: 84px;
 }
@@ -110,7 +110,7 @@ div {
 
 /* Multiple images */
 .five {
-    background-image:  url(https://mdn.mozillademos.org/files/12005/starsolid.gif),
+    background-image:  url(starsolid.gif),
                        url(https://developer.mozilla.org/static/img/favicon32.png);
     background-repeat: repeat-x,
                        repeat-y;

--- a/files/zh-cn/web/css/background/index.md
+++ b/files/zh-cn/web/css/background/index.md
@@ -91,7 +91,7 @@ background: no-repeat center/80% url("../img/image.png");
 }
 
 .topbanner {
-  background: url("https://mdn.mozillademos.org/files/11983/starsolid.gif") #99f repeat-y fixed;
+  background: url("starsolid.gif") #99f repeat-y fixed;
 }
 ```
 

--- a/files/zh-cn/web/css/background/index.md
+++ b/files/zh-cn/web/css/background/index.md
@@ -51,19 +51,19 @@ background: no-repeat center/80% url("../img/image.png");
 
 下面的一个或多个值，可以按任意顺序放置：
 
-- ">`<attachment>`
+- `<attachment>`
   - : 参见 {{ cssxref("background-attachment") }}
-- ">`<box>`
+- `<box>`
   - : 参见 {{ cssxref("background-clip") }} 和 {{cssxref("background-origin")}}
-- ">`<background-color>`
+- `<background-color>`
   - : 参见 {{ cssxref("background-color") }}
-- ">`<bg-image>`
+- `<bg-image>`
   - : 参见 {{ Cssxref("background-image") }}
-- ">`<position>`
+- `<position>`
   - : 参见 {{ cssxref("background-position") }}
-- ">`<repeat-style>`
+- `<repeat-style>`
   - : 参见 {{ cssxref("background-repeat") }}
-- ">`<bg-size>`
+- `<bg-size>`
   - : 参见 {{ cssxref("background-size") }}。
 
 ### 标准语法
@@ -97,7 +97,7 @@ background: no-repeat center/80% url("../img/image.png");
 
 ### 结果
 
-{{EmbedLiveSample("Examples")}}
+{{EmbedLiveSample("示例")}}
 
 ## 规范
 

--- a/files/zh-cn/web/css/blend-mode/index.md
+++ b/files/zh-cn/web/css/blend-mode/index.md
@@ -27,8 +27,8 @@ slug: Web/CSS/blend-mode
       #div {
         width: 300px;
         height: 300px;
-        background: url('https://mdn.mozillademos.org/files/8543/br.png'),
-                    url('https://mdn.mozillademos.org/files/8545/tr.png');
+        background: url('br.png'),
+                    url('tr.png');
         background-blend-mode: normal;
       }
       ```
@@ -49,8 +49,8 @@ slug: Web/CSS/blend-mode
       #div {
         width: 300px;
         height: 300px;
-        background: url('https://mdn.mozillademos.org/files/8543/br.png'),
-                    url('https://mdn.mozillademos.org/files/8545/tr.png');
+        background: url('br.png'),
+                    url('tr.png');
         background-blend-mode: multiply;
       }
       ```
@@ -70,8 +70,8 @@ slug: Web/CSS/blend-mode
       #div {
         width: 300px;
         height: 300px;
-        background: url('https://mdn.mozillademos.org/files/8543/br.png'),
-                    url('https://mdn.mozillademos.org/files/8545/tr.png');
+        background: url('br.png'),
+                    url('tr.png');
         background-blend-mode: screen;
       }
       ```
@@ -90,8 +90,8 @@ slug: Web/CSS/blend-mode
       #div {
         width: 300px;
         height: 300px;
-        background: url('https://mdn.mozillademos.org/files/8543/br.png'),
-                    url('https://mdn.mozillademos.org/files/8545/tr.png');
+        background: url('br.png'),
+                    url('tr.png');
         background-blend-mode: overlay;
       }
       ```
@@ -109,8 +109,8 @@ slug: Web/CSS/blend-mode
       #div {
         width: 300px;
         height: 300px;
-        background: url('https://mdn.mozillademos.org/files/8543/br.png'),
-                    url('https://mdn.mozillademos.org/files/8545/tr.png');
+        background: url('br.png'),
+                    url('tr.png');
         background-blend-mode: darken;
       }
       ```
@@ -128,8 +128,8 @@ slug: Web/CSS/blend-mode
       #div {
         width: 300px;
         height: 300px;
-        background: url('https://mdn.mozillademos.org/files/8543/br.png'),
-                    url('https://mdn.mozillademos.org/files/8545/tr.png');
+        background: url('br.png'),
+                    url('tr.png');
         background-blend-mode: lighten;
       }
       ```
@@ -149,8 +149,8 @@ slug: Web/CSS/blend-mode
       #div {
         width: 300px;
         height: 300px;
-        background: url('https://mdn.mozillademos.org/files/8543/br.png'),
-                    url('https://mdn.mozillademos.org/files/8545/tr.png');
+        background: url('br.png'),
+                    url('tr.png');
         background-blend-mode: color-dodge;
       }
       ```
@@ -170,8 +170,8 @@ slug: Web/CSS/blend-mode
       #div {
         width: 300px;
         height: 300px;
-        background: url('https://mdn.mozillademos.org/files/8543/br.png'),
-                    url('https://mdn.mozillademos.org/files/8545/tr.png');
+        background: url('br.png'),
+                    url('tr.png');
         background-blend-mode: color-burn;
       }
       ```
@@ -191,8 +191,8 @@ slug: Web/CSS/blend-mode
       #div {
         width: 300px;
         height: 300px;
-        background: url('https://mdn.mozillademos.org/files/8543/br.png'),
-                    url('https://mdn.mozillademos.org/files/8545/tr.png');
+        background: url('br.png'),
+                    url('tr.png');
         background-blend-mode: hard-light;
       }
       ```
@@ -212,8 +212,8 @@ slug: Web/CSS/blend-mode
       #div {
         width: 300px;
         height: 300px;
-        background: url('https://mdn.mozillademos.org/files/8543/br.png'),
-                    url('https://mdn.mozillademos.org/files/8545/tr.png');
+        background: url('br.png'),
+                    url('tr.png');
         background-blend-mode: soft-light;
       }
       ```
@@ -232,8 +232,8 @@ slug: Web/CSS/blend-mode
       #div {
         width: 300px;
         height: 300px;
-        background: url('https://mdn.mozillademos.org/files/8543/br.png'),
-                    url('https://mdn.mozillademos.org/files/8545/tr.png');
+        background: url('br.png'),
+                    url('tr.png');
         background-blend-mode: difference;
       }
       ```
@@ -252,8 +252,8 @@ slug: Web/CSS/blend-mode
       #div {
         width: 300px;
         height: 300px;
-        background: url('https://mdn.mozillademos.org/files/8543/br.png'),
-                    url('https://mdn.mozillademos.org/files/8545/tr.png');
+        background: url('br.png'),
+                    url('tr.png');
         background-blend-mode: exclusion;
       }
       ```
@@ -271,8 +271,8 @@ slug: Web/CSS/blend-mode
       #div {
         width: 300px;
         height: 300px;
-        background: url('https://mdn.mozillademos.org/files/8543/br.png'),
-                    url('https://mdn.mozillademos.org/files/8545/tr.png');
+        background: url('br.png'),
+                    url('tr.png');
         background-blend-mode: hue;
       }
       ```
@@ -291,8 +291,8 @@ slug: Web/CSS/blend-mode
       #div {
         width: 300px;
         height: 300px;
-        background: url('https://mdn.mozillademos.org/files/8543/br.png'),
-                    url('https://mdn.mozillademos.org/files/8545/tr.png');
+        background: url('br.png'),
+                    url('tr.png');
         background-blend-mode: saturation;
       }
       ```
@@ -311,8 +311,8 @@ slug: Web/CSS/blend-mode
       #div {
         width: 300px;
         height: 300px;
-        background: url('https://mdn.mozillademos.org/files/8543/br.png'),
-                    url('https://mdn.mozillademos.org/files/8545/tr.png');
+        background: url('br.png'),
+                    url('tr.png');
         background-blend-mode: color;
       }
       ```
@@ -331,8 +331,8 @@ slug: Web/CSS/blend-mode
       #div {
         width: 300px;
         height: 300px;
-        background: url('https://mdn.mozillademos.org/files/8543/br.png'),
-                    url('https://mdn.mozillademos.org/files/8545/tr.png');
+        background: url('br.png'),
+                    url('tr.png');
         background-blend-mode: luminosity;
       }
       ```

--- a/files/zh-cn/web/css/border-image-width/index.md
+++ b/files/zh-cn/web/css/border-image-width/index.md
@@ -89,7 +89,7 @@ border-image-width: unset;
 ```css
 p {
   border: 20px solid;
-  border-image: url("https://mdn.mozillademos.org/files/10470/border.png") 30 round;
+  border-image: url("border.png") 30 round;
   border-image-width: 16px;
   padding: 40px;
 }

--- a/files/zh-cn/web/css/border-image/index.md
+++ b/files/zh-cn/web/css/border-image/index.md
@@ -43,7 +43,7 @@ border-image: url("/images/border.png") 30 30 stretch;
 #bitmap {
   border: 30px solid transparent;
   padding: 20px;
-  border-image: url("https://mdn.mozillademos.org/files/4127/border.png") 30;
+  border-image: url("border.png") 30;
 }
 ```
 

--- a/files/zh-cn/web/css/content/index.md
+++ b/files/zh-cn/web/css/content/index.md
@@ -206,7 +206,7 @@ a::after {
 }
 
 #mdn::before {
-    content:url(https://mdn.mozillademos.org/files/7691/mdn-favicon16.png) ;
+    content:url(mdn-favicon16.png) ;
 }
 
 #w3c::before {

--- a/files/zh-cn/web/css/content/index.md
+++ b/files/zh-cn/web/css/content/index.md
@@ -7,7 +7,7 @@ slug: Web/CSS/content
 
 ## 概要
 
-CSS 的 `content` CSS 属性用于在元素的 {{ cssxref("::before") }} 和 {{ cssxref("::after") }} 伪元素中插入内容。使用`content` 属性插入的内容都是匿名的*[可替换元素](/zh-CN/docs/Web/CSS/Replaced_element)。*
+CSS 的 `content` CSS 属性用于在元素的 {{ cssxref("::before") }} 和 {{ cssxref("::after") }} 伪元素中插入内容。使用 `content` 属性插入的内容都是匿名的[*可替换元素*](/zh-CN/docs/Web/CSS/Replaced_element)。
 
 {{cssinfo}}
 
@@ -207,10 +207,6 @@ a::after {
 
 #mdn::before {
     content:url(mdn-favicon16.png) ;
-}
-
-#w3c::before {
-    content:url(http://w3c.org/2008/site/images/favicon.ico) ;
 }
 
 li {

--- a/files/zh-cn/web/css/css_backgrounds_and_borders/using_multiple_backgrounds/index.md
+++ b/files/zh-cn/web/css/css_backgrounds_and_borders/using_multiple_backgrounds/index.md
@@ -33,8 +33,8 @@ slug: Web/CSS/CSS_Backgrounds_and_Borders/Using_multiple_backgrounds
 .multi-bg-example {
   width: 100%;
   height: 400px;
-  background-image: url(https://mdn.mozillademos.org/files/11305/firefox.png),
-      url(https://mdn.mozillademos.org/files/11307/bubbles.png),
+  background-image: url(firefox.png),
+      url(bubbles.png),
       linear-gradient(to right, rgba(30, 75, 115, 1), rgba(255, 255, 255, 0));
   background-repeat: no-repeat,
       no-repeat,

--- a/files/zh-cn/web/css/css_images/using_css_gradients/index.md
+++ b/files/zh-cn/web/css/css_images/using_css_gradients/index.md
@@ -297,7 +297,7 @@ div {
 ```css
 .layered-image {
   background: linear-gradient(to right, transparent, mistyrose),
-      url("https://mdn.mozillademos.org/files/15525/critters.png");
+      url("critters.png");
 }
 ```
 

--- a/files/zh-cn/web/css/image-rendering/index.md
+++ b/files/zh-cn/web/css/image-rendering/index.md
@@ -48,9 +48,9 @@ image-rendering: unset;
 
 ```html hidden
 <div>
-  <img class="auto" alt="auto" src="https://mdn.mozillademos.org/files/2765/blumen.jpg" />
-  <img class="pixelated" alt="pixelated" src="https://mdn.mozillademos.org/files/2765/blumen.jpg" />
-  <img class="crisp-edges" alt="crisp-edges" src="https://mdn.mozillademos.org/files/2765/blumen.jpg" />
+  <img class="auto" alt="auto" src="blumen.jpg" />
+  <img class="pixelated" alt="pixelated" src="blumen.jpg" />
+  <img class="crisp-edges" alt="crisp-edges" src="blumen.jpg" />
 </div>
 ```
 

--- a/files/zh-cn/web/css/list-style-image/index.md
+++ b/files/zh-cn/web/css/list-style-image/index.md
@@ -54,7 +54,7 @@ list-style-image: unset;
 
 ```css
 ul {
-  list-style-image: url("https://mdn.mozillademos.org/files/11981/starsolid.gif")
+  list-style-image: url("starsolid.gif")
 }
 ```
 

--- a/files/zh-cn/web/css/list-style-position/index.md
+++ b/files/zh-cn/web/css/list-style-position/index.md
@@ -73,7 +73,7 @@ list-style-position: unset;
 }
 
 .three {
-  list-style-image: url("https://mdn.mozillademos.org/files/11979/starsolid.gif");
+  list-style-image: url("starsolid.gif");
   list-style-position: inherit;
 }
 ```

--- a/files/zh-cn/web/css/mask-border/index.md
+++ b/files/zh-cn/web/css/mask-border/index.md
@@ -3,9 +3,9 @@ title: mask-border
 slug: Web/CSS/mask-border
 ---
 
-{{cssref}}{{SeeCompatTable}}
+{{CSSRef}}
 
-[CSS](/zh-CN/docs/Web/CSS) 属性 **`mask-border`** 允许你创建一个紧贴元素边框边缘的 mask.
+[CSS](/zh-CN/docs/Web/CSS) 属性 **`mask-border`** 允许你创建一个紧贴元素边框边缘的 mask。
 
 该属性为以下属性的[简写](/zh-CN/docs/Web/CSS/Shorthand_properties): {{cssxref("mask-border-source")}}, {{cssxref("mask-border-slice")}}, {{cssxref("mask-border-width")}}, {{cssxref("mask-border-outset")}}, {{cssxref("mask-border-repeat")}}, and {{cssxref("mask-border-mode")}}. 与其他简写的属性一样，任何一个漏写的子属性，将会被设置为他们的[初始值](/zh-CN/docs/Web/CSS/initial_value).
 

--- a/files/zh-cn/web/css/mask-border/index.md
+++ b/files/zh-cn/web/css/mask-border/index.md
@@ -70,7 +70,7 @@ div {
   padding: 10px;
 
   mask-border:
-    url("https://mdn.mozillademos.org/files/15836/mask-border-diamonds.png")  /* source */
+    url("mask-border-diamonds.png")  /* source */
     30 /         /* slice */
     36px 18px    /* width */
     round;       /* repeat */

--- a/files/zh-cn/web/css/object-position/index.md
+++ b/files/zh-cn/web/css/object-position/index.md
@@ -44,8 +44,8 @@ Here we see HTML that includes two {{HTMLElement("img")}} elements, each display
 这里我们看到包含两个 img 元素的 HTML，分别展示了 MDN 的 logo
 
 ```html
-<img id="object-position-1" src="https://mdn.mozillademos.org/files/12668/MDN.svg" alt="MDN Logo"/>
-<img id="object-position-2" src="https://mdn.mozillademos.org/files/12668/MDN.svg" alt="MDN Logo"/>
+<img id="object-position-1" src="mdn.svg" alt="MDN Logo"/>
+<img id="object-position-2" src="mdn.svg" alt="MDN Logo"/>
 ```
 
 ### CSS

--- a/files/zh-cn/web/css/vertical-align/index.md
+++ b/files/zh-cn/web/css/vertical-align/index.md
@@ -15,19 +15,19 @@ vertical-align 属性可被用于两种环境：
 
 ```html hidden
 <p>
-top:<img style="vertical-align:top" src="https://mdn.mozillademos.org/files/15189/star.png"/>
-middle:<img style="vertical-align:middle" src="https://mdn.mozillademos.org/files/15189/star.png"/>
-bottom:<img style="vertical-align:bottom" src="https://mdn.mozillademos.org/files/15189/star.png"/>
-super:<img style="vertical-align:super" src="https://mdn.mozillademos.org/files/15189/star.png"/>
-sub:<img style="vertical-align:sub" src="https://mdn.mozillademos.org/files/15189/star.png"/>
+top:<img style="vertical-align:top" src="star.png"/>
+middle:<img style="vertical-align:middle" src="star.png"/>
+bottom:<img style="vertical-align:bottom" src="star.png"/>
+super:<img style="vertical-align:super" src="star.png"/>
+sub:<img style="vertical-align:sub" src="star.png"/>
 </p>
 <p>
-text-top:<img style="vertical-align:text-top" src="https://mdn.mozillademos.org/files/15189/star.png"/>
-text-bottom:<img  style="vertical-align:text-bottom" src="https://mdn.mozillademos.org/files/15189/star.png"/>
-0.2em:<img style="vertical-align:0.2em" src="https://mdn.mozillademos.org/files/15189/star.png"/>
--1em:<img  style="vertical-align:-1em" src="https://mdn.mozillademos.org/files/15189/star.png"/>
-20%:<img style="vertical-align:20%" src="https://mdn.mozillademos.org/files/15189/star.png"/>
--100%:<img  style="vertical-align:-100%" src="https://mdn.mozillademos.org/files/15189/star.png"/>
+text-top:<img style="vertical-align:text-top" src="star.png"/>
+text-bottom:<img  style="vertical-align:text-bottom" src="star.png"/>
+0.2em:<img style="vertical-align:0.2em" src="star.png"/>
+-1em:<img  style="vertical-align:-1em" src="star.png"/>
+20%:<img style="vertical-align:20%" src="star.png"/>
+-100%:<img  style="vertical-align:-100%" src="star.png"/>
 </p>
 ```
 
@@ -175,10 +175,10 @@ vertical-align: unset;
 ### HTML
 
 ```html
-<div>An <img src="https://mdn.mozillademos.org/files/12245/frame_image.svg" alt="link" width="32" height="32" /> image with a default alignment.</div>
-<div>An <img class="top" src="https://mdn.mozillademos.org/files/12245/frame_image.svg" alt="link" width="32" height="32" /> image with a text-top alignment.</div>
-<div>An <img class="bottom" src="https://mdn.mozillademos.org/files/12245/frame_image.svg" alt="link" width="32" height="32" /> image with a text-bottom alignment.</div>
-<div>An <img class="middle" src="https://mdn.mozillademos.org/files/12245/frame_image.svg" alt="link" width="32" height="32" /> image with a middle alignment.</div>
+<div>An <img src="frame_image.svg" alt="link" width="32" height="32" /> image with a default alignment.</div>
+<div>An <img class="top" src="frame_image.svg" alt="link" width="32" height="32" /> image with a text-top alignment.</div>
+<div>An <img class="bottom" src="frame_image.svg" alt="link" width="32" height="32" /> image with a text-bottom alignment.</div>
+<div>An <img class="middle" src="frame_image.svg" alt="link" width="32" height="32" /> image with a middle alignment.</div>
 ```
 
 ### CSS

--- a/files/zh-tw/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/zh-tw/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -119,7 +119,7 @@ function draw() {
 init();
 ```
 
-{{EmbedLiveSample("An_animated_solar_system", "310", "310", "https://mdn.mozillademos.org/files/202/Canvas_animation1.png")}}
+{{EmbedLiveSample("太陽系動畫", "310", "340")}}
 
 #### 時鐘動畫
 

--- a/files/zh-tw/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/zh-tw/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -70,9 +70,9 @@ var sun = new Image();
 var moon = new Image();
 var earth = new Image();
 function init(){
-  sun.src = 'https://mdn.mozillademos.org/files/1456/Canvas_sun.png';
-  moon.src = 'https://mdn.mozillademos.org/files/1443/Canvas_moon.png';
-  earth.src = 'https://mdn.mozillademos.org/files/1429/Canvas_earth.png';
+  sun.src = 'canvas_sun.png';
+  moon.src = 'canvas_moon.png';
+  earth.src = 'canvas_earth.png';
   setInterval(draw,100);
 }
 

--- a/files/zh-tw/web/api/canvas_api/tutorial/using_images/index.md
+++ b/files/zh-tw/web/api/canvas_api/tutorial/using_images/index.md
@@ -134,13 +134,13 @@ function draw() {
     ctx.lineTo(170,15);
     ctx.stroke();
   };
-  img.src = 'https://mdn.mozillademos.org/files/5395/backdrop.png';
+  img.src = 'backdrop.png';
 }
 ```
 
 結果如下:
 
-{{EmbedLiveSample("Example.3A_A_simple_line_graph", 220, 160, "https://mdn.mozillademos.org/files/206/Canvas_backdrop.png")}}
+{{EmbedLiveSample("Example.3A_A_simple_line_graph", 220, 160, "canvas_backdrop.png")}}
 
 ## 縮放
 
@@ -174,13 +174,13 @@ function draw() {
       }
     }
   };
-  img.src = 'https://mdn.mozillademos.org/files/5397/rhino.jpg';
+  img.src = 'rhino.jpg';
 }
 ```
 
 結果如下:
 
-{{EmbedLiveSample("Example.3A_Tiling_an_image", 160, 160, "https://mdn.mozillademos.org/files/251/Canvas_scale_image.png")}}
+{{EmbedLiveSample("Example.3A_Tiling_an_image", 160, 160, "canvas_scale_image.png")}}
 
 ## 切割影像
 
@@ -202,8 +202,8 @@ drawImage()第三個型態接受 9 個參數，其中 8 個讓我們從原始影
  <body onload="draw();">
    <canvas id="canvas" width="150" height="150"></canvas>
    <div style="display:none;">
-     <img id="source" src="https://mdn.mozillademos.org/files/5397/rhino.jpg" width="300" height="227">
-     <img id="frame" src="https://mdn.mozillademos.org/files/242/Canvas_picture_frame.png" width="132" height="150">
+     <img id="source" src="rhino.jpg" width="300" height="227">
+     <img id="frame" src="canvas_picture_frame.png" width="132" height="150">
    </div>
  </body>
 </html>
@@ -225,7 +225,7 @@ function draw() {
 
 這次我們不產生新的{{domxref("HTMLImageElement")}}物件，改採用直接把影像包入 HTML 的{{HTMLElement("img")}}標籤，然後再取得影像元素，其中 HTML 上的影像已經透過設定 CSS 屬性{{cssxref("display")}}為 none 來隱藏起來了.
 
-{{EmbedLiveSample("Example.3A_Framing_an_image", 160, 160, "https://mdn.mozillademos.org/files/226/Canvas_drawimage2.jpg")}}
+{{EmbedLiveSample("Example.3A_Framing_an_image", 160, 160, "canvas_drawimage2.jpg")}}
 
 程式碼相當簡單，每個{{HTMLElement("img")}}有自己的 ID 屬性，這樣便可以利用{{domxref("document.getElementById()")}}輕易取得，之後再簡單地用 drawImage()方法切割犀牛影像然後縮放並放到畫布上，最後第二個 drawImage()再把畫框放到上面.
 
@@ -242,19 +242,19 @@ function draw() {
  <body onload="draw();">
      <table>
       <tr>
-        <td><img src="https://mdn.mozillademos.org/files/5399/gallery_1.jpg"></td>
-        <td><img src="https://mdn.mozillademos.org/files/5401/gallery_2.jpg"></td>
-        <td><img src="https://mdn.mozillademos.org/files/5403/gallery_3.jpg"></td>
-        <td><img src="https://mdn.mozillademos.org/files/5405/gallery_4.jpg"></td>
+        <td><img src="gallery_1.jpg"></td>
+        <td><img src="gallery_2.jpg"></td>
+        <td><img src="gallery_3.jpg"></td>
+        <td><img src="gallery_4.jpg"></td>
       </tr>
       <tr>
-        <td><img src="https://mdn.mozillademos.org/files/5407/gallery_5.jpg"></td>
-        <td><img src="https://mdn.mozillademos.org/files/5409/gallery_6.jpg"></td>
-        <td><img src="https://mdn.mozillademos.org/files/5411/gallery_7.jpg"></td>
-        <td><img src="https://mdn.mozillademos.org/files/5413/gallery_8.jpg"></td>
+        <td><img src="gallery_5.jpg"></td>
+        <td><img src="gallery_6.jpg"></td>
+        <td><img src="gallery_7.jpg"></td>
+        <td><img src="gallery_8.jpg"></td>
       </tr>
      </table>
-     <img id="frame" src="https://mdn.mozillademos.org/files/242/Canvas_picture_frame.png" width="132" height="150">
+     <img id="frame" src="canvas_picture_frame.png" width="132" height="150">
  </body>
 </html>
 ```
@@ -263,7 +263,7 @@ function draw() {
 
 ```css
 body {
-  background: 0 -100px repeat-x url(https://mdn.mozillademos.org/files/5415/bg_gallery.png) #4F191A;
+  background: 0 -100px repeat-x url(bg_gallery.png) #4F191A;
   margin: 10px;
 }
 

--- a/files/zh-tw/web/api/canvas_api/tutorial/using_images/index.md
+++ b/files/zh-tw/web/api/canvas_api/tutorial/using_images/index.md
@@ -311,7 +311,7 @@ function draw() {
 }
 ```
 
-{{EmbedLiveSample("Art_gallery_example", 725, 400, "https://mdn.mozillademos.org/files/205/Canvas_art_gallery.jpg")}}
+{{EmbedLiveSample("畫廊範例", 725, 400)}}
 
 ## 控制影像縮放行為
 

--- a/files/zh-tw/web/css/background-attachment/index.md
+++ b/files/zh-tw/web/css/background-attachment/index.md
@@ -57,7 +57,7 @@ background-attachment: unset;
 
 ```css
 p {
-  background-image: url("https://mdn.mozillademos.org/files/12057/starsolid.gif");
+  background-image: url("starsolid.gif");
   background-attachment: fixed;
 }
 ```
@@ -94,8 +94,8 @@ p {
 
 ```css
 p {
-  background-image: url("https://mdn.mozillademos.org/files/12057/starsolid.gif"),
-      url("https://mdn.mozillademos.org/files/12059/startransparent.gif");
+  background-image: url("starsolid.gif"),
+      url("startransparent.gif");
   background-attachment: fixed, scroll;
   background-repeat: no-repeat, repeat-y;
 }

--- a/files/zh-tw/web/css/css_backgrounds_and_borders/using_multiple_backgrounds/index.md
+++ b/files/zh-tw/web/css/css_backgrounds_and_borders/using_multiple_backgrounds/index.md
@@ -37,8 +37,8 @@ original_slug: Web/CSS/CSS_Background_and_Borders/Using_CSS_multiple_backgrounds
 
 ```css
 .multi_bg_example {
-  background-image   : url(https://mdn.mozillademos.org/files/11305/firefox.png),
-                       url(https://mdn.mozillademos.org/files/11307/bubbles.png),
+  background-image   : url(firefox.png),
+                       url(bubbles.png),
                        linear-gradient(to right, rgba(30, 75, 115, 1),  rgba(255, 255, 255, 0));
 
   background-repeat  : no-repeat,
@@ -59,8 +59,8 @@ original_slug: Web/CSS/CSS_Background_and_Borders/Using_CSS_multiple_backgrounds
 .multi_bg_example{
 width:100%;
 height:400px;
-background: url(https://mdn.mozillademos.org/files/11305/firefox.png),
-            url(https://mdn.mozillademos.org/files/11307/bubbles.png),
+background: url(firefox.png),
+            url(bubbles.png),
             -moz-linear-gradient(to right, rgba(30, 75, 115, 1), rgba(255, 255, 255, 0)),
             -webkit-gradient(to right, rgba(30, 75, 115, 1), rgba(255, 255, 255, 0)),
             -ms-linear-gradient(to right, rgba(30, 75, 115, 1), rgba(255, 255, 255, 0)),

--- a/files/zh-tw/web/css/object-fit/index.md
+++ b/files/zh-tw/web/css/object-fit/index.md
@@ -53,29 +53,29 @@ object-fit: unset;
 ```html
 <div>
   <h2>object-fit: fill</h2>
-  <img src="https://mdn.mozillademos.org/files/6457/mdn_logo_only_color.png" alt="MDN Logo" class="fill"/>
+  <img src="mdn_logo_only_color.png" alt="MDN Logo" class="fill"/>
 
-  <img src="https://mdn.mozillademos.org/files/6457/mdn_logo_only_color.png" alt="MDN Logo" class="fill narrow"/>
+  <img src="mdn_logo_only_color.png" alt="MDN Logo" class="fill narrow"/>
 
   <h2>object-fit: contain</h2>
-  <img src="https://mdn.mozillademos.org/files/6457/mdn_logo_only_color.png" alt="MDN Logo" class="contain"/>
+  <img src="mdn_logo_only_color.png" alt="MDN Logo" class="contain"/>
 
-  <img src="https://mdn.mozillademos.org/files/6457/mdn_logo_only_color.png" alt="MDN Logo" class="contain narrow"/>
+  <img src="mdn_logo_only_color.png" alt="MDN Logo" class="contain narrow"/>
 
   <h2>object-fit: cover</h2>
-  <img src="https://mdn.mozillademos.org/files/6457/mdn_logo_only_color.png" alt="MDN Logo" class="cover"/>
+  <img src="mdn_logo_only_color.png" alt="MDN Logo" class="cover"/>
 
-  <img src="https://mdn.mozillademos.org/files/6457/mdn_logo_only_color.png" alt="MDN Logo" class="cover narrow"/>
+  <img src="mdn_logo_only_color.png" alt="MDN Logo" class="cover narrow"/>
 
   <h2>object-fit: none</h2>
-  <img src="https://mdn.mozillademos.org/files/6457/mdn_logo_only_color.png" alt="MDN Logo" class="none"/>
+  <img src="mdn_logo_only_color.png" alt="MDN Logo" class="none"/>
 
-  <img src="https://mdn.mozillademos.org/files/6457/mdn_logo_only_color.png" alt="MDN Logo" class="none narrow"/>
+  <img src="mdn_logo_only_color.png" alt="MDN Logo" class="none narrow"/>
 
   <h2>object-fit: scale-down</h2>
-  <img src="https://mdn.mozillademos.org/files/6457/mdn_logo_only_color.png" alt="MDN Logo" class="scale-down"/>
+  <img src="mdn_logo_only_color.png" alt="MDN Logo" class="scale-down"/>
 
-  <img src="https://mdn.mozillademos.org/files/6457/mdn_logo_only_color.png" alt="MDN Logo" class="scale-down narrow"/>
+  <img src="mdn_logo_only_color.png" alt="MDN Logo" class="scale-down narrow"/>
 
 </div>
 ```


### PR DESCRIPTION
### Description

Replaces occurrences of images that reference https://mdn.mozillademos.org/files/ with the (normalized) filename, but only those that exist in mdn/content (at the same slug location).

(Missing images are added in https://github.com/mdn/translated-content/pull/10485.)

### Motivation

The domain no longer serves images (it used to redirect).

### Additional details

**Note**: Unfortunately, the "Preview URLs" don't include images from content, so the only way to test that this works is to check out this PR and visit the URLs locally.

### Related issues and pull requests

Extracted from https://github.com/mdn/translated-content/pull/10402.
Part of https://github.com/mdn/translated-content/issues/10400.
