### PR TITLE
fix(Web/CSS/font-face): use VeraSeBd.ttf from css-examples

### DIFF
--- a/files/es/web/css/@font-face/index.md
+++ b/files/es/web/css/@font-face/index.md
@@ -51,7 +51,7 @@ Este ejemplo simplemente especifica una fuente que puede ser descargada para uti
   <style type="text/css" media="screen, print">
     @font-face {
       font-family: "Bitstream Vera Serif Bold";
-      src: url("https://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");
+      src: url("https://mdn.github.io/css-examples/web-fonts/VeraSeBd.ttf");
     }
 
     body { font-family: "Bitstream Vera Serif Bold", serif }

--- a/files/ja/web/css/@font-face/index.md
+++ b/files/ja/web/css/@font-face/index.md
@@ -112,7 +112,7 @@ slug: Web/CSS/@font-face
   <style type="text/css" media="screen, print">
     @font-face {
       font-family: "Bitstream Vera Serif Bold";
-      src: url("https://mdn.mozillademos.org/files/2468/VeraSeBd.ttf");
+      src: url("https://mdn.github.io/css-examples/web-fonts/VeraSeBd.ttf");
     }
 
     body { font-family: "Bitstream Vera Serif Bold", serif }

--- a/files/ko/web/css/@font-face/index.md
+++ b/files/ko/web/css/@font-face/index.md
@@ -47,7 +47,7 @@ browser-compat: css.at-rules.font-face
   <style type="text/css" media="screen, print">
     @font-face {
       font-family: "Bitstream Vera Serif Bold";
-      src: url("https://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");
+      src: url("https://mdn.github.io/css-examples/web-fonts/VeraSeBd.ttf");
     }
 
     body { font-family: "Bitstream Vera Serif Bold", serif }

--- a/files/pt-br/web/css/@font-face/index.md
+++ b/files/pt-br/web/css/@font-face/index.md
@@ -72,7 +72,7 @@ Este exemplo simplesmente especifica uma fonte para download a ser usada, aplica
 ```css
 @font-face {
   font-family: "Bitstream Vera Serif Bold";
-  src: url("https://mdn.mozillademos.org/files/2468/VeraSeBd.ttf");
+  src: url("https://mdn.github.io/css-examples/web-fonts/VeraSeBd.ttf");
 }
 
 p { font-family: "Bitstream Vera Serif Bold", serif }

--- a/files/ru/web/css/@font-face/index.md
+++ b/files/ru/web/css/@font-face/index.md
@@ -75,7 +75,7 @@ translation_of: Web/CSS/@font-face
   <style type="text/css" media="screen, print">
     @font-face {
       font-family: "Bitstream Vera Serif Bold";
-      src: url("https://mdn.mozillademos.org/files/2468/VeraSeBd.ttf");
+      src: url("https://mdn.github.io/css-examples/web-fonts/VeraSeBd.ttf");
     }
 
     body { font-family: "Bitstream Vera Serif Bold", serif }

--- a/files/zh-cn/web/css/@font-face/index.md
+++ b/files/zh-cn/web/css/@font-face/index.md
@@ -53,7 +53,7 @@ slug: Web/CSS/@font-face
   <style type="text/css" media="screen, print">
     @font-face {
       font-family: "Bitstream Vera Serif Bold";
-      src: url("https://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");
+      src: url("https://mdn.github.io/css-examples/web-fonts/VeraSeBd.ttf");
     }
 
     body { font-family: "Bitstream Vera Serif Bold", serif }

--- a/files/zh-tw/web/css/@font-face/index.md
+++ b/files/zh-tw/web/css/@font-face/index.md
@@ -56,7 +56,7 @@ You can specify a font on the user's local computer by name using the `local()` 
   <style type="text/css" media="screen, print">
     @font-face {
       font-family: "Bitstream Vera Serif Bold";
-      src: url("https://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");
+      src: url("https://mdn.github.io/css-examples/web-fonts/VeraSeBd.ttf");
     }
 
     body { font-family: "Bitstream Vera Serif Bold", serif }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

References the `VeraSeBd.ttf` font via MDN's [css-examples](https://github.com/mdn/css-examples) served via GitHub pages.

### Motivation

Consistency, and replaces occurrences of `https://mdn.mozillademos.org/files` (see below).

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Extracted from https://github.com/mdn/translated-content/pull/10402.
Part of https://github.com/mdn/translated-content/issues/10400.
