### PR TITLE
JavaScript: int16array, int32array, uint32array 수정

### DIFF
--- a/files/ko/web/javascript/reference/global_objects/int16array/index.md
+++ b/files/ko/web/javascript/reference/global_objects/int16array/index.md
@@ -5,7 +5,9 @@ slug: Web/JavaScript/Reference/Global_Objects/Int16Array
 
 {{JSRef}}
 
-**`Int16Array`** 유형 배열(TypedArray)은 플랫폼의 바이트 순서를 따르는 2의 보수 16비트의 부호있는 정수의 배열을 나타냅니다. 바이트 순서를 제어해야 하는 경우 대신 {{jsxref("DataView")}}를 사용합니다. 배열의 내용은 0으로 초기화됩니다. 배열이 생성되면 객체의 메서드를 사용하거나 표준 배열 인덱스 구문(즉, 대괄호 표기법 사용)을 사용하여 배열의 요소를 참조할 수 있습니다.
+**`Int16Array`** 형식화 배열(TypedArray)은 플랫폼의 바이트 순서를 따르는 2의 보수 16비트의 부호있는 정수의
+배열입니다. 바이트 순서를 제어해야 하는 경우 대신 {{jsxref("DataView")}}를 사용합니다. 배열의 내용은 0으로 초기화됩니다.
+배열이 생성되면 객체의 메서드를 사용하거나 표준 배열 인덱스 구문(즉, 대괄호 표기법 사용)을 사용하여 배열의 요소를 참조할 수 있습니다.
 
 ## 생성자
 
@@ -17,9 +19,9 @@ slug: Web/JavaScript/Reference/Global_Objects/Int16Array
 부모 {{jsxref("TypedArray")}}에서 정적 속성을 상속합니다.
 
 - {{jsxref("TypedArray.BYTES_PER_ELEMENT", "Int16Array.BYTES_PER_ELEMENT")}}
-  - : 요소 크기의 숫자 값을 반환합니다. `Int16Array`의 경우 `2` 입니다.
+  - : 요소 크기를 숫자로 반환합니다. `Int16Array`의 경우 `2` 입니다.
 - {{jsxref("TypedArray.name", "Int16Array.name")}}
-  - : 생성자 이름의 문자열 값을 반환합니다. `Int16Array` 타입의 경우 "`Int16Array`"입니다.
+  - : 생성자 이름을 문자열로 반환합니다. `Int16Array` 타입의 경우 `"Int16Array"`입니다.
 
 ## 정적 메서드
 
@@ -30,7 +32,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Int16Array
 부모 {{jsxref("TypedArray")}}에서 인스턴스 속성을 상속합니다.
 
 - {{jsxref("TypedArray.BYTES_PER_ELEMENT", "Int16Array.prototype.BYTES_PER_ELEMENT")}}
-  - : 요소 크기의 숫자 값을 반환합니다. `Int16Array`의 경우 `2` 입니다.
+  - : 요소 크기를 숫자로 반환합니다. `Int16Array`의 경우 `2` 입니다.
 
 ## 인스턴스 메서드
 
@@ -81,6 +83,6 @@ console.log(int16FromIterable);
 ## 같이 보기
 
 - [`core-js`에서 `Int16Array` 폴리필](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
-- [JavaScript 유형 배열](/ko/docs/Web/JavaScript/Typed_arrays)
+- [JavaScript 형식화 배열](/ko/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/ko/web/javascript/reference/global_objects/int16array/int16array/index.md
+++ b/files/ko/web/javascript/reference/global_objects/int16array/int16array/index.md
@@ -5,7 +5,9 @@ slug: Web/JavaScript/Reference/Global_Objects/Int16Array/Int16Array
 
 {{JSRef}}
 
-**`Int16Array`** 유형 배열의 생성자는 플랫폼의 바이트 순서를 따르는 2의 보수 16비트의 부호있는 정수의 배열을 나타냅니다. 바이트 순서를 제어해야 하는 경우 대신 {{jsxref("DataView")}}를 사용합니다. 배열의 내용은 0으로 초기화됩니다. 배열이 생성되면 객체의 메서드를 사용하거나 표준 배열 인덱스 구문(즉, 대괄호 표기법 사용)을 사용하여 배열의 요소를 참조할 수 있습니다.
+**`Int16Array`** 형식화 배열의 생성자는 플랫폼의 바이트 순서를 따르는 2의 보수 16비트의 부호있는 정수 배열을 생성합니다.
+바이트 순서를 제어해야 하는 경우 대신 {{jsxref("DataView")}}를 사용합니다. 배열의 내용은 0으로 초기화됩니다.
+배열이 생성되면 객체의 메서드를 사용하거나 표준 배열 인덱스 구문(즉, 대괄호 표기법 사용)을 사용하여 배열의 요소를 참조할 수 있습니다.
 
 ## 구문
 
@@ -14,6 +16,7 @@ new Int16Array()
 new Int16Array(length)
 new Int16Array(typedArray)
 new Int16Array(object)
+
 new Int16Array(buffer)
 new Int16Array(buffer, byteOffset)
 new Int16Array(buffer, byteOffset, length)
@@ -74,6 +77,6 @@ console.log(int16FromIterable);
 ## 같이 보기
 
 - [`core-js`에서 `Int16Array` 폴리필](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
-- [JavaScript 유형 배열](/ko/docs/Web/JavaScript/Typed_arrays)
+- [JavaScript 형식화 배열](/ko/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/ko/web/javascript/reference/global_objects/int32array/index.md
+++ b/files/ko/web/javascript/reference/global_objects/int32array/index.md
@@ -5,7 +5,9 @@ slug: Web/JavaScript/Reference/Global_Objects/Int32Array
 
 {{JSRef}}
 
-**`Int32Array`** 유형 배열(TypedArray)은 플랫폼의 바이트 순서를 따르는 2의 보수 32비트의 부호있는 정수의 배열을 나타냅니다. 바이트 순서를 제어해야 하는 경우 대신 {{jsxref("DataView")}}를 사용합니다. 배열의 내용은 0으로 초기화됩니다. 배열이 생성되면 객체의 메서드를 사용하거나 표준 배열 인덱스 구문(즉, 대괄호 표기법 사용)을 사용하여 배열의 요소를 참조할 수 있습니다.
+**`Int32Array`** 형식화 배열(TypedArray)은 플랫폼의 바이트 순서를 따르는 2의 보수 32비트의 부호있는 정수
+배열입니다. 바이트 순서를 제어해야 하는 경우 대신 {{jsxref("DataView")}}를 사용합니다. 배열의 내용은 0으로 초기화됩니다.
+배열이 생성되면 객체의 메서드를 사용하거나 표준 배열 인덱스 구문(즉, 대괄호 표기법 사용)을 사용하여 배열의 요소를 참조할 수 있습니다.
 
 ## 생성자
 
@@ -19,7 +21,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Int32Array
 - {{jsxref("TypedArray.BYTES_PER_ELEMENT", "Int32Array.BYTES_PER_ELEMENT")}}
   - : 요소 크기의 숫자 값을 반환합니다. `Int32Array`의 경우 `4` 입니다.
 - {{jsxref("TypedArray.name", "Int32Array.name")}}
-  - : 생성자 이름의 문자열 값을 반환합니다. `Int32Array` 타입의 경우 "`Int32Array`"입니다.
+  - : 생성자 이름을 문자열로 반환합니다. `Int32Array` 타입의 경우 `"Int32Array"`입니다.
 
 ## 정적 메서드
 
@@ -81,6 +83,6 @@ console.log(int32FromIterable);
 ## 같이 보기
 
 - [`core-js`에서 `Int32Array` 폴리필](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
-- [JavaScript 유형 배열](/ko/docs/Web/JavaScript/Typed_arrays)
+- [JavaScript 형식화 배열](/ko/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/ko/web/javascript/reference/global_objects/int32array/int32array/index.md
+++ b/files/ko/web/javascript/reference/global_objects/int32array/int32array/index.md
@@ -5,7 +5,10 @@ slug: Web/JavaScript/Reference/Global_Objects/Int32Array/Int32Array
 
 {{JSRef}}
 
-**`Int32Array`** 유형 배열(TypedArray)은 플랫폼의 바이트 순서를 따르는 2의 보수 32비트의 부호있는 정수의 배열을 나타냅니다. 바이트 순서를 제어해야 하는 경우 대신 {{jsxref("DataView")}}를 사용합니다. 배열의 내용은 0으로 초기화됩니다. 배열이 생성되면 객체의 메서드를 사용하거나 표준 배열 인덱스 구문(즉, 대괄호 표기법 사용)을 사용하여 배열의 요소를 참조할 수 있습니다.
+**`Int32Array`** 형식화 배열(TypedArray) 생성자는 플랫폼의 바이트 순서를 따르는 2의 보수 32비트의 부호있는 정수
+배열을 생성합니다. 바이트 순서를 제어해야 하는 경우 대신 {{jsxref("DataView")}}를 사용합니다. 배열의 내용은 0으로
+초기화됩니다. 배열이 생성되면 객체의 메서드를 사용하거나 표준 배열 인덱스 구문(즉, 대괄호 표기법 사용)을 사용하여 배열의 요소를
+참조할 수있습니다.
 
 ## 구문
 
@@ -75,6 +78,6 @@ console.log(int32FromIterable);
 ## 같이 보기
 
 - [`core-js`에서 `Int32Array` 폴리필](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
-- [JavaScript 유형 배열](/ko/docs/Web/JavaScript/Typed_arrays)
+- [JavaScript 형식화 배열](/ko/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/ko/web/javascript/reference/global_objects/uint32array/index.md
+++ b/files/ko/web/javascript/reference/global_objects/uint32array/index.md
@@ -5,7 +5,9 @@ slug: Web/JavaScript/Reference/Global_Objects/Uint32Array
 
 {{JSRef}}
 
-**`Uint32Array`** 유형 배열(TypedArray)은 플랫폼의 바이트 순서를 따르는 32비트 부호 없는 정수의 배열을 나타냅니다. 바이트 순서를 제어해야 하는 경우 대신 {{jsxref("DataView")}}를 사용합니다. 배열의 내용은 0으로 초기화됩니다. 배열이 생성되면 객체의 메서드를 사용하거나 표준 배열 인덱스 구문(즉, 대괄호 표기법 사용)을 사용하여 배열의 요소를 참조할 수 있습니다.
+**`Uint32Array`** 형식화 배열(TypedArray)은 플랫폼의 바이트 순서를 따르는 32비트 부호 없는 정수의 배열입니다.
+바이트 순서를 제어해야 하는 경우 대신 {{jsxref("DataView")}}를 사용합니다. 배열의 내용은 0으로 초기화됩니다.
+배열이 생성되면 객체의 메서드를 사용하거나 표준 배열 인덱스 구문(즉, 대괄호 표기법 사용)을 사용하여 배열의 요소를 참조할 수 있습니다.
 
 ## 생성자
 
@@ -17,9 +19,9 @@ slug: Web/JavaScript/Reference/Global_Objects/Uint32Array
 부모 {{jsxref("TypedArray")}}에서 정적 속성을 상속합니다.
 
 - {{jsxref("TypedArray.BYTES_PER_ELEMENT", "Uint32Array.BYTES_PER_ELEMENT")}}
-  - : 요소 크기를 숫자 값으로 반환합니다. `Uint32Array`의 경우 `4` 입니다.
+  - : 요소 크기를 숫자로 반환합니다. `Uint32Array`의 경우 `4` 입니다.
 - {{jsxref("TypedArray.name", "Uint32Array.name")}}
-  - : 생성자 이름의 문자열 값을 반환합니다. `Uint32Array` 타입의 경우 "`Uint32Array`"입니다.
+  - : 생성자 이름을 문자열로 반환합니다. `Uint32Array` 타입의 경우 `"Uint32Array"`입니다.
 
 ## 정적 메서드
 
@@ -81,6 +83,6 @@ console.log(uint32FromIterable);
 ## 같이 보기
 
 - [`core-js`에서 `Uint32Array` 폴리필](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
-- [JavaScript 유형 배열](/ko/docs/Web/JavaScript/Typed_arrays)
+- [JavaScript 형식화 배열](/ko/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}

--- a/files/ko/web/javascript/reference/global_objects/uint32array/uint32array/index.md
+++ b/files/ko/web/javascript/reference/global_objects/uint32array/uint32array/index.md
@@ -5,7 +5,9 @@ slug: Web/JavaScript/Reference/Global_Objects/Uint32Array/Uint32Array
 
 {{JSRef}}
 
-**`Uint32Array`** 유형 배열(TypedArray)은 플랫폼의 바이트 순서를 따르는 32비트 부호 없는 정수의 배열을 나타냅니다. 바이트 순서를 제어해야 하는 경우 대신 {{jsxref("DataView")}}를 사용합니다. 배열의 내용은 0으로 초기화됩니다. 배열이 생성되면 객체의 메서드를 사용하거나 표준 배열 인덱스 구문(즉, 대괄호 표기법 사용)을 사용하여 배열의 요소를 참조할 수 있습니다.
+**`Uint32Array`** 형식화 배열(TypedArray)의 생성자는 플랫폼의 바이트 순서를 따르는 32비트 부호 없는 정수 배열을
+생성합니다. 바이트 순서를 제어해야 하는 경우 대신 {{jsxref("DataView")}}를 사용합니다. 배열의 내용은 0으로 초기화됩니다.
+배열이 생성되면 객체의 메서드를 사용하거나 표준 배열 인덱스 구문(즉, 대괄호 표기법 사용)을 사용하여 배열의 요소를 참조할 수 있습니다.
 
 ## 구문
 
@@ -75,6 +77,6 @@ console.log(uint32FromIterable);
 ## 같이 보기
 
 - [`core-js`에서 `Uint32Array` 폴리필](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
-- [JavaScript 유형 배열](/ko/docs/Web/JavaScript/Typed_arrays)
+- [JavaScript 형식화 배열](/ko/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("DataView")}}


### PR DESCRIPTION
전체
 - `유형 배열` -> `형식화 배열`로 수정하였습니다. TypedArray는 MDN에서 `형식화 배열`로 번역하고 있습니다.

항목별
- int16array, int32array, uint32array: 설명을 다듬음
- int32array(), uint32array(): 실수로 int32array, uint32array에 대한 설명을 그대로 생성자에 적었습니다. 생성자에 맞는 설명으로 수정하였습니다.
