### PR TITLE
Remove duplicated frontmatter keys from web folder 9-10/10 [es]

### DIFF
--- a/files/es/conflicting/web/javascript/index.md
+++ b/files/es/conflicting/web/javascript/index.md
@@ -1,9 +1,6 @@
 ---
 title: Acerca de JavaScript
 slug: conflicting/Web/JavaScript
-tags:
-  - JavaScript
-translation_of: Web/JavaScript/About_JavaScript
 original_slug: Web/JavaScript/About_JavaScript
 ---
 

--- a/files/es/conflicting/web/javascript/reference/index.md
+++ b/files/es/conflicting/web/javascript/reference/index.md
@@ -1,9 +1,6 @@
 ---
 title: Acerca de
 slug: conflicting/Web/JavaScript/Reference
-tags:
-  - JavaScript
-translation_of: Web/JavaScript/Reference/About
 original_slug: Web/JavaScript/Reference/About
 ---
 

--- a/files/es/web/exslt/exsl/index.md
+++ b/files/es/web/exslt/exsl/index.md
@@ -1,7 +1,6 @@
 ---
 title: Common (exsl)
 slug: Web/EXSLT/exsl
-translation_of: Web/EXSLT/exsl
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/es/docs/Web/EXSLT")}}

--- a/files/es/web/exslt/exsl/node-set/index.md
+++ b/files/es/web/exslt/exsl/node-set/index.md
@@ -1,11 +1,6 @@
 ---
 title: node-set
 slug: Web/EXSLT/exsl/node-set
-tags:
-  - EXSLT
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/EXSLT/exsl/node-set
 ---
 
 {{XsltRef}}

--- a/files/es/web/exslt/exsl/object-type/index.md
+++ b/files/es/web/exslt/exsl/object-type/index.md
@@ -1,11 +1,6 @@
 ---
 title: object-type
 slug: Web/EXSLT/exsl/object-type
-tags:
-  - EXSLT
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/EXSLT/exsl/object-type
 ---
 
 {{ XsltRef() }}

--- a/files/es/web/exslt/index.md
+++ b/files/es/web/exslt/index.md
@@ -1,11 +1,6 @@
 ---
 title: EXSLT
 slug: Web/EXSLT
-tags:
-  - EXSLT
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/EXSLT
 ---
 
 {{XsltRef}}EXSLT es un conjunto de extensiones de [XSLT](/es/XSLT). Existen varios módulos; aquellos que están implementados por Firefox se listan a continuación:

--- a/files/es/web/exslt/math/highest/index.md
+++ b/files/es/web/exslt/math/highest/index.md
@@ -1,11 +1,6 @@
 ---
 title: highest
 slug: Web/EXSLT/math/highest
-tags:
-  - EXSLT
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/EXSLT/math/highest
 ---
 
 {{XsltRef}}

--- a/files/es/web/exslt/math/index.md
+++ b/files/es/web/exslt/math/index.md
@@ -1,7 +1,6 @@
 ---
 title: Math (math)
 slug: Web/EXSLT/math
-translation_of: Web/EXSLT/math
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/es/docs/Web/EXSLT")}}

--- a/files/es/web/exslt/math/lowest/index.md
+++ b/files/es/web/exslt/math/lowest/index.md
@@ -1,11 +1,6 @@
 ---
 title: lowest
 slug: Web/EXSLT/math/lowest
-tags:
-  - EXSLT
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/EXSLT/math/lowest
 ---
 
 {{XsltRef}}

--- a/files/es/web/exslt/math/max/index.md
+++ b/files/es/web/exslt/math/max/index.md
@@ -1,11 +1,6 @@
 ---
 title: max
 slug: Web/EXSLT/math/max
-tags:
-  - EXSLT
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/EXSLT/math/max
 ---
 
 {{XsltRef}}

--- a/files/es/web/exslt/math/min/index.md
+++ b/files/es/web/exslt/math/min/index.md
@@ -1,11 +1,6 @@
 ---
 title: min
 slug: Web/EXSLT/math/min
-tags:
-  - EXSLT
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/EXSLT/math/min
 ---
 
 {{XsltRef}}

--- a/files/es/web/exslt/regexp/index.md
+++ b/files/es/web/exslt/regexp/index.md
@@ -1,7 +1,6 @@
 ---
 title: Expresiones regulares (regexp)
 slug: Web/EXSLT/regexp
-translation_of: Web/EXSLT/regexp
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/es/docs/Web/EXSLT")}}

--- a/files/es/web/exslt/regexp/match/index.md
+++ b/files/es/web/exslt/regexp/match/index.md
@@ -1,11 +1,6 @@
 ---
 title: match
 slug: Web/EXSLT/regexp/match
-tags:
-  - EXSLT
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/EXSLT/regexp/match
 ---
 
 {{XsltRef}}

--- a/files/es/web/exslt/regexp/replace/index.md
+++ b/files/es/web/exslt/regexp/replace/index.md
@@ -1,11 +1,6 @@
 ---
 title: replace
 slug: Web/EXSLT/regexp/replace
-tags:
-  - EXSLT
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/EXSLT/regexp/replace
 ---
 
 {{XsltRef}}

--- a/files/es/web/exslt/regexp/test/index.md
+++ b/files/es/web/exslt/regexp/test/index.md
@@ -1,11 +1,6 @@
 ---
 title: test
 slug: Web/EXSLT/regexp/test
-tags:
-  - EXSLT
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/EXSLT/regexp/test
 ---
 
 {{XsltRef}}

--- a/files/es/web/exslt/set/difference/index.md
+++ b/files/es/web/exslt/set/difference/index.md
@@ -1,11 +1,6 @@
 ---
 title: difference
 slug: Web/EXSLT/set/difference
-tags:
-  - EXSLT
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/EXSLT/set/difference
 ---
 
 {{XsltRef}}

--- a/files/es/web/exslt/set/distinct/index.md
+++ b/files/es/web/exslt/set/distinct/index.md
@@ -1,11 +1,6 @@
 ---
 title: distinct
 slug: Web/EXSLT/set/distinct
-tags:
-  - EXSLT
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/EXSLT/set/distinct
 ---
 
 {{XsltRef}}

--- a/files/es/web/exslt/set/has-same-node/index.md
+++ b/files/es/web/exslt/set/has-same-node/index.md
@@ -1,11 +1,6 @@
 ---
 title: has-same-node
 slug: Web/EXSLT/set/has-same-node
-tags:
-  - EXSLT
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/EXSLT/set/has-same-node
 ---
 
 {{XsltRef}}

--- a/files/es/web/exslt/set/index.md
+++ b/files/es/web/exslt/set/index.md
@@ -1,7 +1,6 @@
 ---
 title: Sets (set)
 slug: Web/EXSLT/set
-translation_of: Web/EXSLT/set
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/es/docs/Web/EXSLT")}}

--- a/files/es/web/exslt/set/intersection/index.md
+++ b/files/es/web/exslt/set/intersection/index.md
@@ -1,11 +1,6 @@
 ---
 title: intersection
 slug: Web/EXSLT/set/intersection
-tags:
-  - EXSLT
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/EXSLT/set/intersection
 ---
 
 {{XsltRef}}

--- a/files/es/web/exslt/set/leading/index.md
+++ b/files/es/web/exslt/set/leading/index.md
@@ -1,11 +1,6 @@
 ---
 title: leading
 slug: Web/EXSLT/set/leading
-tags:
-  - EXSLT
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/EXSLT/set/leading
 ---
 
 {{XsltRef}}

--- a/files/es/web/exslt/set/trailing/index.md
+++ b/files/es/web/exslt/set/trailing/index.md
@@ -1,11 +1,6 @@
 ---
 title: trailing
 slug: Web/EXSLT/set/trailing
-tags:
-  - EXSLT
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/EXSLT/set/trailing
 ---
 
 {{XsltRef}}

--- a/files/es/web/exslt/str/concat/index.md
+++ b/files/es/web/exslt/str/concat/index.md
@@ -1,11 +1,6 @@
 ---
 title: concat
 slug: Web/EXSLT/str/concat
-tags:
-  - EXSLT
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/EXSLT/str/concat
 ---
 
 {{XsltRef}}

--- a/files/es/web/exslt/str/index.md
+++ b/files/es/web/exslt/str/index.md
@@ -1,7 +1,6 @@
 ---
 title: Strings (str)
 slug: Web/EXSLT/str
-translation_of: Web/EXSLT/str
 ---
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/es/docs/Web/EXSLT")}}

--- a/files/es/web/exslt/str/split/index.md
+++ b/files/es/web/exslt/str/split/index.md
@@ -1,11 +1,6 @@
 ---
 title: split
 slug: Web/EXSLT/str/split
-tags:
-  - EXSLT
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/EXSLT/str/split
 ---
 
 {{XsltRef}}

--- a/files/es/web/exslt/str/tokenize/index.md
+++ b/files/es/web/exslt/str/tokenize/index.md
@@ -1,11 +1,6 @@
 ---
 title: tokenize
 slug: Web/EXSLT/str/tokenize
-tags:
-  - EXSLT
-  - Todas_las_Categorías
-  - XSLT
-translation_of: Web/EXSLT/str/tokenize
 ---
 
 {{XsltRef}}

--- a/files/es/web/index.md
+++ b/files/es/web/index.md
@@ -1,13 +1,6 @@
 ---
 title: Tecnología para desarrolladores web
 slug: Web
-tags:
-  - API
-  - Desarrollo web
-  - Landing
-  - Lanzamiento
-  - Web
-translation_of: Web
 ---
 
 La Web abierta presenta increíbles oportunidades para los desarrolladores. Para aprovechar al máximo estas tecnologías, debes saber cómo utilizarlas. A continuación, encontrarás enlaces a nuestra documentación de tecnología web.

--- a/files/es/web/javascript/closures/index.md
+++ b/files/es/web/javascript/closures/index.md
@@ -1,7 +1,6 @@
 ---
 title: Closures
 slug: Web/JavaScript/Closures
-translation_of: Web/JavaScript/Closures
 original_slug: Web/JavaScript/Closures
 ---
 

--- a/files/es/web/javascript/data_structures/index.md
+++ b/files/es/web/javascript/data_structures/index.md
@@ -1,12 +1,6 @@
 ---
 title: Tipos de datos y estructuras en JavaScript
 slug: Web/JavaScript/Data_structures
-tags:
-  - JavaScript
-  - Novato
-  - Principiante
-  - Tipado
-translation_of: Web/JavaScript/Data_structures
 ---
 
 {{jsSidebar("More", "Más")}}

--- a/files/es/web/javascript/enumerability_and_ownership_of_properties/index.md
+++ b/files/es/web/javascript/enumerability_and_ownership_of_properties/index.md
@@ -1,13 +1,6 @@
 ---
 title: Enumerabilidad y posesión de propiedades
 slug: Web/JavaScript/Enumerability_and_ownership_of_properties
-tags:
-  - Enumerabilidad
-  - Enumeración
-  - Guía
-  - JavaScript
-  - Propiedades
-translation_of: Web/JavaScript/Enumerability_and_ownership_of_properties
 original_slug: Web/JavaScript/enumeracion_y_propietario_de_propiedades
 ---
 

--- a/files/es/web/javascript/equality_comparisons_and_sameness/index.md
+++ b/files/es/web/javascript/equality_comparisons_and_sameness/index.md
@@ -1,15 +1,6 @@
 ---
 title: Comparadores de igualdad e identidad
 slug: Web/JavaScript/Equality_comparisons_and_sameness
-tags:
-  - Comparación
-  - Identidad
-  - Intermedio
-  - JavaScript
-  - SameValue
-  - SameValueZero
-  - igualdad
-translation_of: Web/JavaScript/Equality_comparisons_and_sameness
 ---
 
 {{jsSidebar("Intermediate")}}

--- a/files/es/web/javascript/eventloop/index.md
+++ b/files/es/web/javascript/eventloop/index.md
@@ -1,10 +1,6 @@
 ---
 title: Modelo de concurrencia y loop de eventos
 slug: Web/JavaScript/EventLoop
-tags:
-  - Avanzado
-  - JavaScript
-translation_of: Web/JavaScript/EventLoop
 ---
 
 {{JsSidebar("Advanced")}}JavaScript poseé un modelo de concurrencia basado en un "loop de eventos". Este modelo es bastante diferente al modelo de otros lenguajes como C o Java.

--- a/files/es/web/javascript/guide/control_flow_and_error_handling/index.md
+++ b/files/es/web/javascript/guide/control_flow_and_error_handling/index.md
@@ -1,18 +1,6 @@
 ---
 title: Control de flujo y manejo de errores
 slug: Web/JavaScript/Guide/Control_flow_and_error_handling
-tags:
-  - Control de flujo
-  - Guía
-  - JavaScript
-  - Lógica
-  - Manejo de errores
-  - Novato
-  - Principiantes
-  - Promesas
-  - declaraciones
-  - l10n:priority
-translation_of: Web/JavaScript/Guide/Control_flow_and_error_handling
 original_slug: Web/JavaScript/Guide/Control_de_flujo_y_manejo_de_errores
 ---
 

--- a/files/es/web/javascript/guide/expressions_and_operators/index.md
+++ b/files/es/web/javascript/guide/expressions_and_operators/index.md
@@ -1,14 +1,6 @@
 ---
 title: Expresiones y operadores
 slug: Web/JavaScript/Guide/Expressions_and_Operators
-tags:
-  - Expresiones
-  - Guía
-  - JavaScript
-  - Operadores
-  - Principiante
-  - '|10n_prioridad'
-translation_of: Web/JavaScript/Guide/Expressions_and_Operators
 ---
 
 {{jsSidebar("JavaScript Guide", "Guía JavaScript")}} {{PreviousNext("Web/JavaScript/Guide/Functions", "Web/JavaScript/Guide/Numbers_and_dates")}}

--- a/files/es/web/javascript/guide/functions/index.md
+++ b/files/es/web/javascript/guide/functions/index.md
@@ -1,14 +1,6 @@
 ---
 title: Funciones
 slug: Web/JavaScript/Guide/Functions
-tags:
-  - Funciones
-  - Guía
-  - JavaScript
-  - Novato
-  - Principiante
-  - l10n:priority
-translation_of: Web/JavaScript/Guide/Functions
 original_slug: Web/JavaScript/Guide/Funciones
 ---
 

--- a/files/es/web/javascript/guide/grammar_and_types/index.md
+++ b/files/es/web/javascript/guide/grammar_and_types/index.md
@@ -1,13 +1,6 @@
 ---
 title: Gramática y Tipos
 slug: Web/JavaScript/Guide/Grammar_and_types
-tags:
-  - Guia(2)
-  - Guía
-  - JavaScript
-  - Variables
-  - literales
-translation_of: Web/JavaScript/Guide/Grammar_and_types
 ---
 
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Introduction", "Web/JavaScript/Guide/Control_flow_and_error_handling")}}

--- a/files/es/web/javascript/guide/index.md
+++ b/files/es/web/javascript/guide/index.md
@@ -1,11 +1,6 @@
 ---
 title: Guía de JavaScript
 slug: Web/JavaScript/Guide
-tags:
-  - Guía
-  - JavaScript
-  - l10n:priority
-translation_of: Web/JavaScript/Guide
 ---
 
 {{jsSidebar("JavaScript Guide")}}

--- a/files/es/web/javascript/guide/indexed_collections/index.md
+++ b/files/es/web/javascript/guide/indexed_collections/index.md
@@ -1,13 +1,6 @@
 ---
 title: Colecciones indexadas
 slug: Web/JavaScript/Guide/Indexed_collections
-tags:
-  - Array
-  - Arreglo
-  - Guía
-  - JavaScript
-  - l10n:priority
-translation_of: Web/JavaScript/Guide/Indexed_collections
 original_slug: Web/JavaScript/Guide/colecciones_indexadas
 ---
 

--- a/files/es/web/javascript/guide/introduction/index.md
+++ b/files/es/web/javascript/guide/introduction/index.md
@@ -1,14 +1,6 @@
 ---
 title: Introducción
 slug: Web/JavaScript/Guide/Introduction
-tags:
-  - Guía
-  - Introducion
-  - JavaScript
-  - Novato
-  - Principiante
-  - l10n:priority
-translation_of: Web/JavaScript/Guide/Introduction
 original_slug: Web/JavaScript/Guide/Introducción
 ---
 

--- a/files/es/web/javascript/guide/iterators_and_generators/index.md
+++ b/files/es/web/javascript/guide/iterators_and_generators/index.md
@@ -1,11 +1,6 @@
 ---
 title: Iteradores y generadores
 slug: Web/JavaScript/Guide/Iterators_and_Generators
-tags:
-  - Guía
-  - Intermedio
-  - JavaScript
-translation_of: Web/JavaScript/Guide/Iterators_and_Generators
 ---
 
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Details_of_the_Object_Model", "Web/JavaScript/Guide/Meta_programming")}}

--- a/files/es/web/javascript/guide/keyed_collections/index.md
+++ b/files/es/web/javascript/guide/keyed_collections/index.md
@@ -1,15 +1,6 @@
 ---
 title: Colecciones con clave
 slug: Web/JavaScript/Guide/Keyed_collections
-tags:
-  - Colecciones
-  - Conjunto
-  - Guía
-  - JavaScript
-  - Map
-  - l10n:priority
-  - set
-translation_of: Web/JavaScript/Guide/Keyed_collections
 ---
 
 {{jsSidebar("JavaScript Guide", "Guía de JavaScript")}} {{PreviousNext("Web/JavaScript/Guide/Indexed_Collections", "Web/JavaScript/Guide/Working_with_Objects")}}

--- a/files/es/web/javascript/guide/loops_and_iteration/index.md
+++ b/files/es/web/javascript/guide/loops_and_iteration/index.md
@@ -1,14 +1,6 @@
 ---
 title: Bucles e iteración
 slug: Web/JavaScript/Guide/Loops_and_iteration
-tags:
-  - Bucle
-  - Guia(2)
-  - Guía
-  - Iteración
-  - JavaScript
-  - Sintaxis
-translation_of: Web/JavaScript/Guide/Loops_and_iteration
 original_slug: Web/JavaScript/Guide/Bucles_e_iteración
 ---
 

--- a/files/es/web/javascript/guide/meta_programming/index.md
+++ b/files/es/web/javascript/guide/meta_programming/index.md
@@ -1,14 +1,6 @@
 ---
 title: Metaprogramación
 slug: Web/JavaScript/Guide/Meta_programming
-tags:
-  - ECMAScript 2015
-  - Guía
-  - JavaScript
-  - Proxy
-  - Reflejar
-  - l10n:priority
-translation_of: Web/JavaScript/Guide/Meta_programming
 ---
 
 {{jsSidebar("Guía de JavaScript")}}{{PreviousNext("Web/JavaScript/Guide/Iterators_and_Generators", "Web/JavaScript/Guide/Modules")}}

--- a/files/es/web/javascript/guide/modules/index.md
+++ b/files/es/web/javascript/guide/modules/index.md
@@ -1,14 +1,6 @@
 ---
 title: Módulos JavaScript
 slug: Web/JavaScript/Guide/Modules
-tags:
-  - Guía
-  - JavaScript
-  - Modules
-  - Módulos
-  - export
-  - import
-translation_of: Web/JavaScript/Guide/Modules
 original_slug: Web/JavaScript/Guide/Módulos
 ---
 

--- a/files/es/web/javascript/guide/numbers_and_dates/index.md
+++ b/files/es/web/javascript/guide/numbers_and_dates/index.md
@@ -1,20 +1,6 @@
 ---
 title: Números y fechas
 slug: Web/JavaScript/Guide/Numbers_and_dates
-tags:
-  - Coma flotante
-  - Cálculo
-  - Enteros
-  - Fechas
-  - Guía
-  - JavaScript
-  - Math
-  - Numeros
-  - Numérico
-  - PF
-  - Punto flotante
-  - l10n:priority
-translation_of: Web/JavaScript/Guide/Numbers_and_dates
 ---
 
 {{jsSidebar("JavaScript Guide", "Guía JavaScript")}} {{PreviousNext("Web/JavaScript/Guide/Expressions_and_Operators", "Web/JavaScript/Guide/Text_formatting")}}

--- a/files/es/web/javascript/guide/regular_expressions/assertions/index.md
+++ b/files/es/web/javascript/guide/regular_expressions/assertions/index.md
@@ -1,14 +1,6 @@
 ---
 title: Aserciones
 slug: Web/JavaScript/Guide/Regular_Expressions/Assertions
-tags:
-  - Aserciones
-  - Expresiones Regulares
-  - Guía
-  - JavaScript
-  - Referencia
-  - regex
-translation_of: Web/JavaScript/Guide/Regular_Expressions/Assertions
 original_slug: Web/JavaScript/Guide/Regular_Expressions/Aserciones
 ---
 

--- a/files/es/web/javascript/guide/regular_expressions/character_classes/index.md
+++ b/files/es/web/javascript/guide/regular_expressions/character_classes/index.md
@@ -1,14 +1,6 @@
 ---
 title: Clases de caracteres
 slug: Web/JavaScript/Guide/Regular_Expressions/Character_Classes
-tags:
-  - Expresiones Regulares
-  - Guía
-  - JavaScript
-  - Referencia
-  - RegExp
-  - clases de caracteres
-translation_of: Web/JavaScript/Guide/Regular_Expressions/Character_Classes
 original_slug: Web/JavaScript/Guide/Regular_Expressions/Clases_de_caracteres
 ---
 

--- a/files/es/web/javascript/guide/regular_expressions/cheatsheet/index.md
+++ b/files/es/web/javascript/guide/regular_expressions/cheatsheet/index.md
@@ -1,14 +1,6 @@
 ---
 title: Hoja de referencia de sintaxis de expresiones regulares
 slug: Web/JavaScript/Guide/Regular_Expressions/Cheatsheet
-tags:
-  - Cheatsheet
-  - Expresiones Regulares
-  - Guía
-  - Hoja de referencia
-  - JavaScript
-  - RegExp
-translation_of: Web/JavaScript/Guide/Regular_Expressions/Cheatsheet
 original_slug: Web/JavaScript/Guide/Regular_Expressions/Hoja_de_referencia
 ---
 

--- a/files/es/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
+++ b/files/es/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
@@ -1,15 +1,6 @@
 ---
 title: Grupos y rangos
 slug: Web/JavaScript/Guide/Regular_Expressions/Groups_and_Backreferences
-tags:
-  - Expresiones Regulares
-  - Guía
-  - JavaScript
-  - Rangos
-  - Referencia
-  - grupos
-  - regex
-translation_of: Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges
 original_slug: Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges
 ---
 

--- a/files/es/web/javascript/guide/regular_expressions/index.md
+++ b/files/es/web/javascript/guide/regular_expressions/index.md
@@ -1,15 +1,6 @@
 ---
 title: Expresiones Regulares
 slug: Web/JavaScript/Guide/Regular_Expressions
-tags:
-  - Expresiones Regulares
-  - Guía
-  - Intermedio
-  - JavaScript
-  - Referencia
-  - RegExp
-  - regex
-translation_of: Web/JavaScript/Guide/Regular_Expressions
 ---
 
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Text_formatting", "Web/JavaScript/Guide/Indexed_collections")}}

--- a/files/es/web/javascript/guide/regular_expressions/quantifiers/index.md
+++ b/files/es/web/javascript/guide/regular_expressions/quantifiers/index.md
@@ -1,14 +1,6 @@
 ---
 title: Cuantificadores
 slug: Web/JavaScript/Guide/Regular_Expressions/Quantifiers
-tags:
-  - Expresiones Regulares
-  - Guía
-  - JavaScript
-  - Referencia
-  - cuantificadores
-  - regex
-translation_of: Web/JavaScript/Guide/Regular_Expressions/Quantifiers
 original_slug: Web/JavaScript/Guide/Regular_Expressions/Cuantificadores
 ---
 

--- a/files/es/web/javascript/guide/regular_expressions/unicode_property_escapes/index.md
+++ b/files/es/web/javascript/guide/regular_expressions/unicode_property_escapes/index.md
@@ -1,14 +1,6 @@
 ---
 title: Escapes de propiedades Unicode
 slug: Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes
-tags:
-  - Expresiones Regulares
-  - Guía
-  - JavaScript
-  - Referencia
-  - escapes de propiedades unicode
-  - regex
-translation_of: Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes
 original_slug: Web/JavaScript/Guide/Regular_Expressions/Escapes_de_propiedades_Unicode
 ---
 

--- a/files/es/web/javascript/guide/text_formatting/index.md
+++ b/files/es/web/javascript/guide/text_formatting/index.md
@@ -1,10 +1,6 @@
 ---
 title: Formato de texto
 slug: Web/JavaScript/Guide/Text_formatting
-tags:
-  - Guía
-  - JavaScript
-translation_of: Web/JavaScript/Guide/Text_formatting
 ---
 
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Numbers_and_dates", "Web/JavaScript/Guide/Regular_Expressions")}}

--- a/files/es/web/javascript/guide/using_promises/index.md
+++ b/files/es/web/javascript/guide/using_promises/index.md
@@ -1,13 +1,6 @@
 ---
 title: Usar promesas
 slug: Web/JavaScript/Guide/Using_promises
-tags:
-  - Asíncrono
-  - Guía
-  - Intermedio
-  - Promesa
-  - Promesas
-translation_of: Web/JavaScript/Guide/Using_promises
 original_slug: Web/JavaScript/Guide/Usar_promesas
 ---
 

--- a/files/es/web/javascript/guide/working_with_objects/index.md
+++ b/files/es/web/javascript/guide/working_with_objects/index.md
@@ -1,15 +1,6 @@
 ---
 title: Trabajando con objetos
 slug: Web/JavaScript/Guide/Working_with_Objects
-tags:
-  - Comparación de objetos
-  - Constructor
-  - Documento
-  - Guía
-  - JavaScript
-  - Objeto
-  - Principiante
-translation_of: Web/JavaScript/Guide/Working_with_Objects
 original_slug: Web/JavaScript/Guide/Trabajando_con_objectos
 ---
 

--- a/files/es/web/javascript/index.md
+++ b/files/es/web/javascript/index.md
@@ -1,11 +1,6 @@
 ---
 title: JavaScript
 slug: Web/JavaScript
-tags:
- - Aprender
- - JavaScript
- - 'l10n:priority'
-translation_of: Web/JavaScript
 ---
 
 {{JsSidebar}}

--- a/files/es/web/javascript/inheritance_and_the_prototype_chain/index.md
+++ b/files/es/web/javascript/inheritance_and_the_prototype_chain/index.md
@@ -1,12 +1,6 @@
 ---
 title: Herencia y la cadena de prototipos
 slug: Web/JavaScript/Inheritance_and_the_prototype_chain
-tags:
-  - Herencia
-  - Intermedio
-  - JavaScript
-  - Programación orientada a objetos
-translation_of: Web/JavaScript/Inheritance_and_the_prototype_chain
 original_slug: Web/JavaScript/Herencia_y_la_cadena_de_protipos
 ---
 

--- a/files/es/web/javascript/javascript_technologies_overview/index.md
+++ b/files/es/web/javascript/javascript_technologies_overview/index.md
@@ -1,7 +1,6 @@
 ---
 title: Descripción de las tecnologías JavaScript
 slug: Web/JavaScript/JavaScript_technologies_overview
-translation_of: Web/JavaScript/JavaScript_technologies_overview
 original_slug: Web/JavaScript/Descripción_de_las_tecnologías_JavaScript
 ---
 

--- a/files/es/web/javascript/language_overview/index.md
+++ b/files/es/web/javascript/language_overview/index.md
@@ -1,15 +1,6 @@
 ---
 title: Una reintroducción a JavaScript (Tutorial de JS)
 slug: Web/JavaScript/Language_Overview
-tags:
-  - Aprender
-  - Guía
-  - Intermedio
-  - Intro
-  - JavaScript
-  - Tutorial
-  - introducción
-translation_of: Web/JavaScript/A_re-introduction_to_JavaScript
 original_slug: Web/JavaScript/A_re-introduction_to_JavaScript
 ---
 {{jsSidebar}}

--- a/files/es/web/javascript/memory_management/index.md
+++ b/files/es/web/javascript/memory_management/index.md
@@ -1,15 +1,6 @@
 ---
 title: Gestión de Memoria
 slug: Web/JavaScript/Memory_Management
-tags:
-  - Advanced
-  - JavaScript
-  - Performance
-  - Reference
-  - Referencia
-  - Rendimiento
-  - memoria
-translation_of: Web/JavaScript/Memory_Management
 original_slug: Web/JavaScript/Gestion_de_Memoria
 ---
 

--- a/files/es/web/javascript/reference/classes/constructor/index.md
+++ b/files/es/web/javascript/reference/classes/constructor/index.md
@@ -1,11 +1,6 @@
 ---
 title: constructor
 slug: Web/JavaScript/Reference/Classes/constructor
-tags:
-  - Clases
-  - ECMAScript6
-  - JavaScript
-translation_of: Web/JavaScript/Reference/Classes/constructor
 original_slug: Web/JavaScript/Referencia/Classes/constructor
 ---
 

--- a/files/es/web/javascript/reference/classes/extends/index.md
+++ b/files/es/web/javascript/reference/classes/extends/index.md
@@ -1,7 +1,6 @@
 ---
 title: extends
 slug: Web/JavaScript/Reference/Classes/extends
-translation_of: Web/JavaScript/Reference/Classes/extends
 original_slug: Web/JavaScript/Referencia/Classes/extends
 ---
 

--- a/files/es/web/javascript/reference/classes/index.md
+++ b/files/es/web/javascript/reference/classes/index.md
@@ -1,17 +1,6 @@
 ---
 title: Clases
 slug: Web/JavaScript/Reference/Classes
-tags:
-  - Classes
-  - ECMAScript 2015
-  - Herencia
-  - Intermedio
-  - JavaScript
-  - NeedsContent
-  - NeedsTranslation
-  - Reference
-  - TopicStub
-translation_of: Web/JavaScript/Reference/Classes
 original_slug: Web/JavaScript/Referencia/Classes
 ---
 

--- a/files/es/web/javascript/reference/classes/private_class_fields/index.md
+++ b/files/es/web/javascript/reference/classes/private_class_fields/index.md
@@ -1,7 +1,6 @@
 ---
 title: Private class fields
 slug: Web/JavaScript/Reference/Classes/Private_class_fields
-translation_of: Web/JavaScript/Reference/Classes/Private_class_fields
 original_slug: Web/JavaScript/Referencia/Classes/Private_class_fields
 ---
 

--- a/files/es/web/javascript/reference/classes/public_class_fields/index.md
+++ b/files/es/web/javascript/reference/classes/public_class_fields/index.md
@@ -1,10 +1,6 @@
 ---
 title: Class fields
 slug: Web/JavaScript/Reference/Classes/Public_class_fields
-tags:
-  - Clases
-  - JavaScript
-translation_of: Web/JavaScript/Reference/Classes/Public_class_fields
 original_slug: Web/JavaScript/Referencia/Classes/Class_fields
 ---
 

--- a/files/es/web/javascript/reference/classes/static/index.md
+++ b/files/es/web/javascript/reference/classes/static/index.md
@@ -1,7 +1,6 @@
 ---
 title: static
 slug: Web/JavaScript/Reference/Classes/static
-translation_of: Web/JavaScript/Reference/Classes/static
 original_slug: Web/JavaScript/Referencia/Classes/static
 ---
 

--- a/files/es/web/javascript/reference/deprecated_and_obsolete_features/index.md
+++ b/files/es/web/javascript/reference/deprecated_and_obsolete_features/index.md
@@ -1,11 +1,6 @@
 ---
 title: Características en desuso y obsoletas
 slug: Web/JavaScript/Reference/Deprecated_and_obsolete_features
-tags:
-  - Deprecated
-  - JavaScript
-  - Obsolete
-translation_of: Web/JavaScript/Reference/Deprecated_and_obsolete_features
 original_slug: Web/JavaScript/Referencia/Características_Desaprobadas
 ---
 

--- a/files/es/web/javascript/reference/errors/bad_octal/index.md
+++ b/files/es/web/javascript/reference/errors/bad_octal/index.md
@@ -1,7 +1,6 @@
 ---
 title: 'SyntaxError: "x" is not a legal ECMA-262 octal constant'
 slug: Web/JavaScript/Reference/Errors/Bad_octal
-translation_of: Web/JavaScript/Reference/Errors/Bad_octal
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/es/web/javascript/reference/errors/bad_regexp_flag/index.md
+++ b/files/es/web/javascript/reference/errors/bad_regexp_flag/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'SyntaxError: indicador de expresión regular no válido "x"'
 slug: Web/JavaScript/Reference/Errors/Bad_regexp_flag
-tags:
-  - Error
-  - Error de sintaxis
-  - JavaScript
-  - SyntaxError
-translation_of: Web/JavaScript/Reference/Errors/Bad_regexp_flag
 original_slug: Web/JavaScript/Reference/Errors/Indicador_regexp_no-val
 ---
 

--- a/files/es/web/javascript/reference/errors/deprecated_source_map_pragma/index.md
+++ b/files/es/web/javascript/reference/errors/deprecated_source_map_pragma/index.md
@@ -1,13 +1,7 @@
 ---
-title: >-
-  SyntaxError: Using //@ to indicate sourceURL pragmas is deprecated. Use //#
-  instead
+title: 'SyntaxError: Using //@ to indicate sourceURL pragmas is deprecated. Use //#
+  instead'
 slug: Web/JavaScript/Reference/Errors/Deprecated_source_map_pragma
-tags:
-  - Error
-  - Fuente
-  - JavaScript
-translation_of: Web/JavaScript/Reference/Errors/Deprecated_source_map_pragma
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/es/web/javascript/reference/errors/illegal_character/index.md
+++ b/files/es/web/javascript/reference/errors/illegal_character/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'ErrorDeSintaxis: Caracter ilegal'
 slug: Web/JavaScript/Reference/Errors/Illegal_character
-tags:
-  - Error
-  - Error de sintaxis
-  - JavaScript
-  - SyntaxError
-  - errores
-translation_of: Web/JavaScript/Reference/Errors/Illegal_character
 original_slug: Web/JavaScript/Reference/Errors/caracter_ilegal
 ---
 

--- a/files/es/web/javascript/reference/errors/in_operator_no_object/index.md
+++ b/files/es/web/javascript/reference/errors/in_operator_no_object/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'TypeError: cannot use ''in'' operator to search for ''x'' in ''y'''
 slug: Web/JavaScript/Reference/Errors/in_operator_no_object
-tags:
-  - Error
-  - JavaScript
-  - TiposError
-  - TypeError
-  - errores
-translation_of: Web/JavaScript/Reference/Errors/in_operator_no_object
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/es/web/javascript/reference/errors/index.md
+++ b/files/es/web/javascript/reference/errors/index.md
@@ -1,14 +1,6 @@
 ---
 title: JavaScript error reference
 slug: Web/JavaScript/Reference/Errors
-tags:
-  - Depuración
-  - Error
-  - Excepciones
-  - Excepción
-  - JavaScript
-  - errores
-translation_of: Web/JavaScript/Reference/Errors
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/es/web/javascript/reference/errors/invalid_array_length/index.md
+++ b/files/es/web/javascript/reference/errors/invalid_array_length/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'RangeError: invalid array length'
 slug: Web/JavaScript/Reference/Errors/Invalid_array_length
-tags:
-  - Array
-  - JavaScript
-  - RangeError
-  - errores
-translation_of: Web/JavaScript/Reference/Errors/Invalid_array_length
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/es/web/javascript/reference/errors/invalid_date/index.md
+++ b/files/es/web/javascript/reference/errors/invalid_date/index.md
@@ -1,11 +1,6 @@
 ---
 title: 'RangeError: invalid date'
 slug: Web/JavaScript/Reference/Errors/Invalid_date
-tags:
-  - ErrorDeRango
-  - JavaScript
-  - errores
-translation_of: Web/JavaScript/Reference/Errors/Invalid_date
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/es/web/javascript/reference/errors/malformed_formal_parameter/index.md
+++ b/files/es/web/javascript/reference/errors/malformed_formal_parameter/index.md
@@ -1,11 +1,6 @@
 ---
 title: 'SyntaxError: Malformed formal parameter'
 slug: Web/JavaScript/Reference/Errors/Malformed_formal_parameter
-tags:
-  - JavaScript
-  - SyntaxError
-  - errores
-translation_of: Web/JavaScript/Reference/Errors/Malformed_formal_parameter
 ---
 
 ## Mensaje

--- a/files/es/web/javascript/reference/errors/missing_curly_after_property_list/index.md
+++ b/files/es/web/javascript/reference/errors/missing_curly_after_property_list/index.md
@@ -1,7 +1,6 @@
 ---
 title: 'SyntaxError: missing } after property list'
 slug: Web/JavaScript/Reference/Errors/Missing_curly_after_property_list
-translation_of: Web/JavaScript/Reference/Errors/Missing_curly_after_property_list
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/es/web/javascript/reference/errors/missing_formal_parameter/index.md
+++ b/files/es/web/javascript/reference/errors/missing_formal_parameter/index.md
@@ -1,7 +1,6 @@
 ---
 title: 'SyntaxError: missing formal parameter'
 slug: Web/JavaScript/Reference/Errors/Missing_formal_parameter
-translation_of: Web/JavaScript/Reference/Errors/Missing_formal_parameter
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/es/web/javascript/reference/errors/missing_parenthesis_after_argument_list/index.md
+++ b/files/es/web/javascript/reference/errors/missing_parenthesis_after_argument_list/index.md
@@ -1,7 +1,6 @@
 ---
 title: 'SyntaxError: missing ) after argument list'
 slug: Web/JavaScript/Reference/Errors/Missing_parenthesis_after_argument_list
-translation_of: Web/JavaScript/Reference/Errors/Missing_parenthesis_after_argument_list
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/es/web/javascript/reference/errors/missing_semicolon_before_statement/index.md
+++ b/files/es/web/javascript/reference/errors/missing_semicolon_before_statement/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'ErrordeSintaxis: Punto y coma ; faltante antes de la declaracion'
 slug: Web/JavaScript/Reference/Errors/Missing_semicolon_before_statement
-tags:
-  - JavaScript
-  - errores
-  - errorsintaxis
-  - puntoycoma
-translation_of: Web/JavaScript/Reference/Errors/Missing_semicolon_before_statement
 original_slug: Web/JavaScript/Reference/Errors/Falta_puntoycoma_antes_de_declaracion
 ---
 

--- a/files/es/web/javascript/reference/errors/more_arguments_needed/index.md
+++ b/files/es/web/javascript/reference/errors/more_arguments_needed/index.md
@@ -1,13 +1,6 @@
 ---
 title: 'TypeError: More arguments needed'
 slug: Web/JavaScript/Reference/Errors/More_arguments_needed
-tags:
-  - Errors
-  - JavaScript
-  - Tipo de Error
-  - TypeError
-  - errores
-translation_of: Web/JavaScript/Reference/Errors/More_arguments_needed
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/es/web/javascript/reference/errors/no_variable_name/index.md
+++ b/files/es/web/javascript/reference/errors/no_variable_name/index.md
@@ -1,11 +1,6 @@
 ---
 title: 'SyntaxError: missing variable name'
 slug: Web/JavaScript/Reference/Errors/No_variable_name
-tags:
-  - Error
-  - Error de sintaxis
-  - errores
-translation_of: Web/JavaScript/Reference/Errors/No_variable_name
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/es/web/javascript/reference/errors/not_a_codepoint/index.md
+++ b/files/es/web/javascript/reference/errors/not_a_codepoint/index.md
@@ -1,7 +1,6 @@
 ---
 title: 'RangeError: argument is not a valid code point'
 slug: Web/JavaScript/Reference/Errors/Not_a_codepoint
-translation_of: Web/JavaScript/Reference/Errors/Not_a_codepoint
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/es/web/javascript/reference/errors/not_a_function/index.md
+++ b/files/es/web/javascript/reference/errors/not_a_function/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'TypeError: "x" is not a function'
 slug: Web/JavaScript/Reference/Errors/Not_a_function
-tags:
-  - Error
-  - ErrorDeTipo
-  - JavaScript
-  - errores
-translation_of: Web/JavaScript/Reference/Errors/Not_a_function
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/es/web/javascript/reference/errors/not_defined/index.md
+++ b/files/es/web/javascript/reference/errors/not_defined/index.md
@@ -1,11 +1,6 @@
 ---
 title: 'ReferenceError: "x" is not defined'
 slug: Web/JavaScript/Reference/Errors/Not_defined
-tags:
-  - Error
-  - JavaScript
-  - ReferenceError
-translation_of: Web/JavaScript/Reference/Errors/Not_defined
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/es/web/javascript/reference/errors/property_access_denied/index.md
+++ b/files/es/web/javascript/reference/errors/property_access_denied/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'Error: Permission denied to access property "x"'
 slug: Web/JavaScript/Reference/Errors/Property_access_denied
-tags:
-  - Error
-  - JavaScript
-  - Seguridad
-  - errores
-translation_of: Web/JavaScript/Reference/Errors/Property_access_denied
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/es/web/javascript/reference/errors/stmt_after_return/index.md
+++ b/files/es/web/javascript/reference/errors/stmt_after_return/index.md
@@ -1,7 +1,6 @@
 ---
 title: 'Advertencia: codigo inaccesible despues de sentencia de retorno'
 slug: Web/JavaScript/Reference/Errors/Stmt_after_return
-translation_of: Web/JavaScript/Reference/Errors/Stmt_after_return
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/es/web/javascript/reference/errors/strict_non_simple_params/index.md
+++ b/files/es/web/javascript/reference/errors/strict_non_simple_params/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'SyntaxError: "use strict" no permitida en función con parámetros complejos'
 slug: Web/JavaScript/Reference/Errors/Strict_Non_Simple_Params
-tags:
-  - Error
-  - JavaScript
-  - TypeError
-  - errores
-translation_of: Web/JavaScript/Reference/Errors/Strict_Non_Simple_Params
 original_slug: Web/JavaScript/Reference/Errors/Strict_y_parámetros_complejos
 ---
 

--- a/files/es/web/javascript/reference/errors/too_much_recursion/index.md
+++ b/files/es/web/javascript/reference/errors/too_much_recursion/index.md
@@ -1,14 +1,6 @@
 ---
 title: 'InternalError: too much recursion'
 slug: Web/JavaScript/Reference/Errors/Too_much_recursion
-tags:
-  - Error
-  - InternalError
-  - JavaScript
-  - Recursiva
-  - Recursividad
-  - Recursión(2)
-translation_of: Web/JavaScript/Reference/Errors/Too_much_recursion
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/es/web/javascript/reference/errors/undefined_prop/index.md
+++ b/files/es/web/javascript/reference/errors/undefined_prop/index.md
@@ -1,12 +1,6 @@
 ---
 title: 'ReferenceError: reference to undefined property "x"'
 slug: Web/JavaScript/Reference/Errors/Undefined_prop
-tags:
-  - JavaScript
-  - Modo estricto
-  - ReferenceError
-  - errores
-translation_of: Web/JavaScript/Reference/Errors/Undefined_prop
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/es/web/javascript/reference/errors/unexpected_token/index.md
+++ b/files/es/web/javascript/reference/errors/unexpected_token/index.md
@@ -1,11 +1,6 @@
 ---
 title: 'SyntaxError: Unexpected token'
 slug: Web/JavaScript/Reference/Errors/Unexpected_token
-tags:
-  - JavaScript
-  - SyntaxError
-  - errores
-translation_of: Web/JavaScript/Reference/Errors/Unexpected_token
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/es/web/javascript/reference/errors/unexpected_type/index.md
+++ b/files/es/web/javascript/reference/errors/unexpected_type/index.md
@@ -1,7 +1,6 @@
 ---
 title: 'TypeError: "x" is (not) "y"'
 slug: Web/JavaScript/Reference/Errors/Unexpected_type
-translation_of: Web/JavaScript/Reference/Errors/Unexpected_type
 ---
 
 {{jsSidebar("Errors")}}

--- a/files/es/web/javascript/reference/functions/arguments/callee/index.md
+++ b/files/es/web/javascript/reference/functions/arguments/callee/index.md
@@ -1,11 +1,6 @@
 ---
 title: callee
 slug: Web/JavaScript/Reference/Functions/arguments/callee
-tags:
-  - JavaScript
-  - JavaScript Reference
-  - Referencia
-translation_of: Web/JavaScript/Reference/Functions/arguments/callee
 original_slug: Web/JavaScript/Referencia/Funciones/arguments/callee
 ---
 

--- a/files/es/web/javascript/reference/functions/arguments/index.md
+++ b/files/es/web/javascript/reference/functions/arguments/index.md
@@ -1,15 +1,6 @@
 ---
 title: El objeto arguments
 slug: Web/JavaScript/Reference/Functions/arguments
-tags:
-  - Funciones
-  - JavaScript
-  - Namespace
-  - argumentos
-  - arguments
-  - espacio de nombres
-  - multiples
-translation_of: Web/JavaScript/Reference/Functions/arguments
 original_slug: Web/JavaScript/Referencia/Funciones/arguments
 ---
 

--- a/files/es/web/javascript/reference/functions/arguments/length/index.md
+++ b/files/es/web/javascript/reference/functions/arguments/length/index.md
@@ -1,12 +1,6 @@
 ---
 title: arguments.length
 slug: Web/JavaScript/Reference/Functions/arguments/length
-tags:
-  - Funciones
-  - JavaScript
-  - Propiedades
-  - argumentos
-translation_of: Web/JavaScript/Reference/Functions/arguments/length
 original_slug: Web/JavaScript/Referencia/Funciones/arguments/length
 ---
 

--- a/files/es/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/es/web/javascript/reference/functions/arrow_functions/index.md
@@ -1,13 +1,6 @@
 ---
 title: Funciones Flecha
 slug: Web/JavaScript/Reference/Functions/Arrow_functions
-tags:
-  - ECMAScript6
-  - Intermedio
-  - JavaScript
-  - Referencia
-  - función
-translation_of: Web/JavaScript/Reference/Functions/Arrow_functions
 original_slug: Web/JavaScript/Referencia/Funciones/Arrow_functions
 ---
 

--- a/files/es/web/javascript/reference/functions/default_parameters/index.md
+++ b/files/es/web/javascript/reference/functions/default_parameters/index.md
@@ -1,12 +1,6 @@
 ---
 title: Parámetros predeterminados
 slug: Web/JavaScript/Reference/Functions/Default_parameters
-tags:
-  - Característica del lenguaje
-  - ECMAScript 2015
-  - Funciones
-  - JavaScript
-translation_of: Web/JavaScript/Reference/Functions/Default_parameters
 original_slug: Web/JavaScript/Referencia/Funciones/Parametros_por_defecto
 ---
 

--- a/files/es/web/javascript/reference/functions/get/index.md
+++ b/files/es/web/javascript/reference/functions/get/index.md
@@ -1,11 +1,6 @@
 ---
 title: get
 slug: Web/JavaScript/Reference/Functions/get
-tags:
-  - ECMAScript5
-  - JavaScript
-  - Operator
-translation_of: Web/JavaScript/Reference/Functions/get
 original_slug: Web/JavaScript/Referencia/Funciones/get
 ---
 

--- a/files/es/web/javascript/reference/functions/index.md
+++ b/files/es/web/javascript/reference/functions/index.md
@@ -1,12 +1,6 @@
 ---
 title: Funciones
 slug: Web/JavaScript/Reference/Functions
-tags:
-  - Funciones
-  - Guia(2)
-  - JavaScript
-  - función
-translation_of: Web/JavaScript/Reference/Functions
 original_slug: Web/JavaScript/Referencia/Funciones
 ---
 

--- a/files/es/web/javascript/reference/functions/method_definitions/index.md
+++ b/files/es/web/javascript/reference/functions/method_definitions/index.md
@@ -1,7 +1,6 @@
 ---
 title: Method definitions
 slug: Web/JavaScript/Reference/Functions/Method_definitions
-translation_of: Web/JavaScript/Reference/Functions/Method_definitions
 original_slug: Web/JavaScript/Referencia/Funciones/Method_definitions
 ---
 

--- a/files/es/web/javascript/reference/functions/rest_parameters/index.md
+++ b/files/es/web/javascript/reference/functions/rest_parameters/index.md
@@ -1,11 +1,6 @@
 ---
 title: Parámetros Rest
 slug: Web/JavaScript/Reference/Functions/rest_parameters
-tags:
-  - Funciones
-  - JavaScript
-  - Parametros Rest
-translation_of: Web/JavaScript/Reference/Functions/rest_parameters
 original_slug: Web/JavaScript/Referencia/Funciones/parametros_rest
 ---
 

--- a/files/es/web/javascript/reference/functions/set/index.md
+++ b/files/es/web/javascript/reference/functions/set/index.md
@@ -1,7 +1,6 @@
 ---
 title: setter
 slug: Web/JavaScript/Reference/Functions/set
-translation_of: Web/JavaScript/Reference/Functions/set
 original_slug: Web/JavaScript/Referencia/Funciones/set
 ---
 

--- a/files/es/web/javascript/reference/global_objects/index.md
+++ b/files/es/web/javascript/reference/global_objects/index.md
@@ -1,10 +1,6 @@
 ---
 title: Objetos globales
 slug: Web/JavaScript/Reference/Global_Objects
-tags:
-  - JavaScript
-  - Referencia
-translation_of: Web/JavaScript/Reference/Global_Objects
 original_slug: Web/JavaScript/Referencia/Objetos_globales
 ---
 

--- a/files/es/web/javascript/reference/global_objects/parsefloat/index.md
+++ b/files/es/web/javascript/reference/global_objects/parsefloat/index.md
@@ -1,9 +1,7 @@
 ---
 title: parseFloat()
 slug: Web/JavaScript/Reference/Global_Objects/parseFloat
-translation_of: Web/JavaScript/Reference/Global_Objects/parseFloat
 original_slug: Web/JavaScript/Referencia/Objetos_globales/parseFloat
-browser-compat: javascript.builtins.parseFloat
 ---
 
 {{jsSidebar("Objects")}}

--- a/files/es/web/javascript/reference/global_objects/parseint/index.md
+++ b/files/es/web/javascript/reference/global_objects/parseint/index.md
@@ -1,7 +1,6 @@
 ---
 title: parseInt()
 slug: Web/JavaScript/Reference/Global_Objects/parseInt
-translation_of: Web/JavaScript/Reference/Global_Objects/parseInt
 original_slug: Web/JavaScript/Referencia/Objetos_globales/parseInt
 ---
 

--- a/files/es/web/javascript/reference/global_objects/promise/all/index.md
+++ b/files/es/web/javascript/reference/global_objects/promise/all/index.md
@@ -1,13 +1,6 @@
 ---
 title: Promise.all()
 slug: Web/JavaScript/Reference/Global_Objects/Promise/all
-tags:
-  - ECMAScript6
-  - JavaScript
-  - Método(2)
-  - Promesa
-  - Promise
-translation_of: Web/JavaScript/Reference/Global_Objects/Promise/all
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Promise/all
 ---
 

--- a/files/es/web/javascript/reference/global_objects/promise/catch/index.md
+++ b/files/es/web/javascript/reference/global_objects/promise/catch/index.md
@@ -1,7 +1,6 @@
 ---
 title: Promise.prototype.catch()
 slug: Web/JavaScript/Reference/Global_Objects/Promise/catch
-translation_of: Web/JavaScript/Reference/Global_Objects/Promise/catch
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Promise/catch
 ---
 

--- a/files/es/web/javascript/reference/global_objects/promise/finally/index.md
+++ b/files/es/web/javascript/reference/global_objects/promise/finally/index.md
@@ -1,7 +1,6 @@
 ---
 title: Promise.prototype.finally()
 slug: Web/JavaScript/Reference/Global_Objects/Promise/finally
-translation_of: Web/JavaScript/Reference/Global_Objects/Promise/finally
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Promise/finally
 ---
 

--- a/files/es/web/javascript/reference/global_objects/promise/index.md
+++ b/files/es/web/javascript/reference/global_objects/promise/index.md
@@ -1,9 +1,7 @@
 ---
 title: Promise
 slug: Web/JavaScript/Reference/Global_Objects/Promise
-translation_of: Web/JavaScript/Reference/Global_Objects/Promise
 original_slug: Web/JavaScript/Reference/Global_Objects/Promise
-browser-compat: javascript.builtins.Promise
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/promise/race/index.md
+++ b/files/es/web/javascript/reference/global_objects/promise/race/index.md
@@ -1,13 +1,6 @@
 ---
 title: Promise.race()
 slug: Web/JavaScript/Reference/Global_Objects/Promise/race
-tags:
-  - ECMAScript2015
-  - ECMAScript6
-  - JavaScript
-  - Promesa
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Promise/race
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Promise/race
 ---
 

--- a/files/es/web/javascript/reference/global_objects/promise/reject/index.md
+++ b/files/es/web/javascript/reference/global_objects/promise/reject/index.md
@@ -1,7 +1,6 @@
 ---
 title: Promise.reject()
 slug: Web/JavaScript/Reference/Global_Objects/Promise/reject
-translation_of: Web/JavaScript/Reference/Global_Objects/Promise/reject
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Promise/reject
 ---
 

--- a/files/es/web/javascript/reference/global_objects/promise/resolve/index.md
+++ b/files/es/web/javascript/reference/global_objects/promise/resolve/index.md
@@ -1,12 +1,6 @@
 ---
 title: Promise.resolve()
 slug: Web/JavaScript/Reference/Global_Objects/Promise/resolve
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Promise
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Promise/resolve
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Promise/resolve
 ---
 

--- a/files/es/web/javascript/reference/global_objects/promise/then/index.md
+++ b/files/es/web/javascript/reference/global_objects/promise/then/index.md
@@ -1,13 +1,6 @@
 ---
 title: Promise.prototype.then()
 slug: Web/JavaScript/Reference/Global_Objects/Promise/then
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Promise
-  - Prototype
-translation_of: Web/JavaScript/Reference/Global_Objects/Promise/then
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Promise/then
 ---
 

--- a/files/es/web/javascript/reference/global_objects/proxy/index.md
+++ b/files/es/web/javascript/reference/global_objects/proxy/index.md
@@ -1,8 +1,6 @@
 ---
 title: Proxy
 slug: Web/JavaScript/Reference/Global_Objects/Proxy
-browser-compat: javascript.builtins.Proxy
-translation_of: Web/JavaScript/Reference/Global_Objects/Proxy
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/proxy/proxy/getownpropertydescriptor/index.md
+++ b/files/es/web/javascript/reference/global_objects/proxy/proxy/getownpropertydescriptor/index.md
@@ -1,12 +1,6 @@
 ---
 title: handler.getOwnPropertyDescriptor()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/getOwnPropertyDescriptor
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Proxy
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/getOwnPropertyDescriptor
 original_slug: Web/JavaScript/Reference/Global_Objects/Proxy/handler/getOwnPropertyDescriptor
 ---
 

--- a/files/es/web/javascript/reference/global_objects/proxy/proxy/index.md
+++ b/files/es/web/javascript/reference/global_objects/proxy/proxy/index.md
@@ -1,14 +1,6 @@
 ---
 title: Proxy handler
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - NeedsTranslation
-  - Proxy
-  - TopicStub
-translation_of: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy
-translation_of_original: Web/JavaScript/Reference/Global_Objects/Proxy/handler
 original_slug: Web/JavaScript/Reference/Global_Objects/Proxy/handler
 ---
 

--- a/files/es/web/javascript/reference/global_objects/proxy/proxy/set/index.md
+++ b/files/es/web/javascript/reference/global_objects/proxy/proxy/set/index.md
@@ -1,12 +1,6 @@
 ---
 title: handler.set()
 slug: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/set
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Proxy
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/set
 original_slug: Web/JavaScript/Reference/Global_Objects/Proxy/handler/set
 ---
 

--- a/files/es/web/javascript/reference/global_objects/rangeerror/index.md
+++ b/files/es/web/javascript/reference/global_objects/rangeerror/index.md
@@ -1,8 +1,6 @@
 ---
 title: RangeError
 slug: Web/JavaScript/Reference/Global_Objects/RangeError
-translation_of: Web/JavaScript/Reference/Global_Objects/RangeError
-browser-compat: javascript.builtins.RangeError
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/referenceerror/index.md
+++ b/files/es/web/javascript/reference/global_objects/referenceerror/index.md
@@ -1,15 +1,6 @@
 ---
 title: ReferenceError
 slug: Web/JavaScript/Reference/Global_Objects/ReferenceError
-tags:
-  - Clase
-  - Class
-  - JavaScript
-  - Object
-  - Objeto
-  - ReferenceError
-  - Referencia
-translation_of: Web/JavaScript/Reference/Global_Objects/ReferenceError
 original_slug: Web/JavaScript/Referencia/Objetos_globales/ReferenceError
 ---
 

--- a/files/es/web/javascript/reference/global_objects/reflect/index.md
+++ b/files/es/web/javascript/reference/global_objects/reflect/index.md
@@ -1,14 +1,6 @@
 ---
 title: Reflect
 slug: Web/JavaScript/Reference/Global_Objects/Reflect
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - NeedsTranslation
-  - Overview
-  - Reflect
-  - TopicStub
-translation_of: Web/JavaScript/Reference/Global_Objects/Reflect
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/reflect/set/index.md
+++ b/files/es/web/javascript/reference/global_objects/reflect/set/index.md
@@ -1,7 +1,6 @@
 ---
 title: Reflect.set()
 slug: Web/JavaScript/Reference/Global_Objects/Reflect/set
-translation_of: Web/JavaScript/Reference/Global_Objects/Reflect/set
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/regexp/compile/index.md
+++ b/files/es/web/javascript/reference/global_objects/regexp/compile/index.md
@@ -1,16 +1,6 @@
 ---
 title: RegExp.prototype.compile()
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/compile
-tags:
-  - Desaprovado
-  - Expresion Regular
-  - JavaScript
-  - Obsoleto
-  - Prototype
-  - Referencia
-  - RegExp
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/compile
 original_slug: Web/JavaScript/Referencia/Objetos_globales/RegExp/compile
 ---
 

--- a/files/es/web/javascript/reference/global_objects/regexp/exec/index.md
+++ b/files/es/web/javascript/reference/global_objects/regexp/exec/index.md
@@ -1,14 +1,6 @@
 ---
 title: RegExp.prototype.exec()
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/exec
-tags:
-  - Expresiones Regulares
-  - JavaScript
-  - Prototipo
-  - Referencia
-  - RegExp
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/exec
 original_slug: Web/JavaScript/Referencia/Objetos_globales/RegExp/exec
 ---
 

--- a/files/es/web/javascript/reference/global_objects/regexp/ignorecase/index.md
+++ b/files/es/web/javascript/reference/global_objects/regexp/ignorecase/index.md
@@ -1,7 +1,6 @@
 ---
 title: RegExp.prototype.ignoreCase
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/ignoreCase
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/ignoreCase
 original_slug: Web/JavaScript/Referencia/Objetos_globales/RegExp/ignoreCase
 ---
 

--- a/files/es/web/javascript/reference/global_objects/regexp/index.md
+++ b/files/es/web/javascript/reference/global_objects/regexp/index.md
@@ -1,13 +1,6 @@
 ---
 title: RegExp
 slug: Web/JavaScript/Reference/Global_Objects/RegExp
-tags:
-  - Clase
-  - Expresiones Regulares
-  - JavaScript
-  - Referencia
-  - RegExp
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp
 original_slug: Web/JavaScript/Referencia/Objetos_globales/RegExp
 ---
 

--- a/files/es/web/javascript/reference/global_objects/regexp/regexp/index.md
+++ b/files/es/web/javascript/reference/global_objects/regexp/regexp/index.md
@@ -1,12 +1,6 @@
 ---
 title: Constructor RegExp()
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/RegExp
-tags:
-  - Constructor
-  - JavaScript
-  - Referencia
-  - RegExp
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/RegExp
 original_slug: Web/JavaScript/Referencia/Objetos_globales/RegExp/RegExp
 ---
 

--- a/files/es/web/javascript/reference/global_objects/regexp/rightcontext/index.md
+++ b/files/es/web/javascript/reference/global_objects/regexp/rightcontext/index.md
@@ -1,7 +1,6 @@
 ---
 title: RegExp.rightContext ($')
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/rightContext
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/rightContext
 original_slug: Web/JavaScript/Referencia/Objetos_globales/RegExp/rightContext
 ---
 

--- a/files/es/web/javascript/reference/global_objects/regexp/test/index.md
+++ b/files/es/web/javascript/reference/global_objects/regexp/test/index.md
@@ -1,11 +1,6 @@
 ---
 title: RegExp.prototype.test()
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/test
-tags:
-  - Expresion Regular
-  - Prototipo
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/test
 original_slug: Web/JavaScript/Referencia/Objetos_globales/RegExp/test
 ---
 

--- a/files/es/web/javascript/reference/global_objects/regexp/tostring/index.md
+++ b/files/es/web/javascript/reference/global_objects/regexp/tostring/index.md
@@ -1,11 +1,6 @@
 ---
 title: RegExp.prototype.toString()
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/toString
-tags:
-  - Expresion Regular
-  - Prototipo
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/RegExp/toString
 original_slug: Web/JavaScript/Referencia/Objetos_globales/RegExp/toString
 ---
 

--- a/files/es/web/javascript/reference/global_objects/set/@@iterator/index.md
+++ b/files/es/web/javascript/reference/global_objects/set/@@iterator/index.md
@@ -1,9 +1,6 @@
 ---
 title: Set.prototype[@@iterator]()
 slug: Web/JavaScript/Reference/Global_Objects/Set/@@iterator
-tags:
-  - Iteradores
-translation_of: Web/JavaScript/Reference/Global_Objects/Set/@@iterator
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Set/@@iterator
 ---
 

--- a/files/es/web/javascript/reference/global_objects/set/add/index.md
+++ b/files/es/web/javascript/reference/global_objects/set/add/index.md
@@ -1,7 +1,6 @@
 ---
 title: Set.prototype.add()
 slug: Web/JavaScript/Reference/Global_Objects/Set/add
-translation_of: Web/JavaScript/Reference/Global_Objects/Set/add
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Set/add
 ---
 

--- a/files/es/web/javascript/reference/global_objects/set/clear/index.md
+++ b/files/es/web/javascript/reference/global_objects/set/clear/index.md
@@ -1,12 +1,6 @@
 ---
 title: Set.prototype.clear()
 slug: Web/JavaScript/Reference/Global_Objects/Set/clear
-tags:
-  - ECMAScript6
-  - JavaScript
-  - Prototype
-  - set
-translation_of: Web/JavaScript/Reference/Global_Objects/Set/clear
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Set/clear
 ---
 

--- a/files/es/web/javascript/reference/global_objects/set/delete/index.md
+++ b/files/es/web/javascript/reference/global_objects/set/delete/index.md
@@ -1,7 +1,6 @@
 ---
 title: Set.prototype.delete()
 slug: Web/JavaScript/Reference/Global_Objects/Set/delete
-translation_of: Web/JavaScript/Reference/Global_Objects/Set/delete
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Set/delete
 ---
 

--- a/files/es/web/javascript/reference/global_objects/set/entries/index.md
+++ b/files/es/web/javascript/reference/global_objects/set/entries/index.md
@@ -1,7 +1,6 @@
 ---
 title: Set.prototype.entries()
 slug: Web/JavaScript/Reference/Global_Objects/Set/entries
-translation_of: Web/JavaScript/Reference/Global_Objects/Set/entries
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Set/entries
 ---
 

--- a/files/es/web/javascript/reference/global_objects/set/has/index.md
+++ b/files/es/web/javascript/reference/global_objects/set/has/index.md
@@ -1,12 +1,6 @@
 ---
 title: Set.prototype.has()
 slug: Web/JavaScript/Reference/Global_Objects/Set/has
-tags:
-  - ECMAScript6
-  - JavaScript
-  - Prototype
-  - set
-translation_of: Web/JavaScript/Reference/Global_Objects/Set/has
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Set/has
 ---
 

--- a/files/es/web/javascript/reference/global_objects/set/index.md
+++ b/files/es/web/javascript/reference/global_objects/set/index.md
@@ -1,9 +1,7 @@
 ---
 title: Set
 slug: Web/JavaScript/Reference/Global_Objects/Set
-translation_of: Web/JavaScript/Reference/Global_Objects/Set
 original_slug: Web/JavaScript/Reference/Global_Objects/Set
-browser-compat: javascript.builtins.Set
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/set/size/index.md
+++ b/files/es/web/javascript/reference/global_objects/set/size/index.md
@@ -1,7 +1,6 @@
 ---
 title: Set.prototype.size
 slug: Web/JavaScript/Reference/Global_Objects/Set/size
-translation_of: Web/JavaScript/Reference/Global_Objects/Set/size
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Set/size
 ---
 

--- a/files/es/web/javascript/reference/global_objects/set/values/index.md
+++ b/files/es/web/javascript/reference/global_objects/set/values/index.md
@@ -1,7 +1,6 @@
 ---
 title: Set.prototype.values()
 slug: Web/JavaScript/Reference/Global_Objects/Set/values
-translation_of: Web/JavaScript/Reference/Global_Objects/Set/values
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Set/values
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/anchor/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/anchor/index.md
@@ -1,13 +1,6 @@
 ---
 title: String.prototype.anchor()
 slug: Web/JavaScript/Reference/Global_Objects/String/anchor
-tags:
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/anchor
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/anchor
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/big/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/big/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.big()
 slug: Web/JavaScript/Reference/Global_Objects/String/big
-tags:
-  - Deprecated
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/big
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/big
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/blink/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/blink/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.blink()
 slug: Web/JavaScript/Reference/Global_Objects/String/blink
-tags:
-  - Deprecated
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/blink
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/blink
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/bold/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/bold/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.bold()
 slug: Web/JavaScript/Reference/Global_Objects/String/bold
-tags:
-  - Deprecated
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/bold
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/bold
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/charat/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/charat/index.md
@@ -1,12 +1,6 @@
 ---
 title: String.prototype.charAt()
 slug: Web/JavaScript/Reference/Global_Objects/String/charAt
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/charAt
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/charAt
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/charcodeat/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/charcodeat/index.md
@@ -1,13 +1,6 @@
 ---
 title: String.prototype.charCodeAt()
 slug: Web/JavaScript/Reference/Global_Objects/String/charCodeAt
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - String
-  - Unicode
-translation_of: Web/JavaScript/Reference/Global_Objects/String/charCodeAt
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/charCodeAt
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/codepointat/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/codepointat/index.md
@@ -1,7 +1,6 @@
 ---
 title: String.prototype.codePointAt()
 slug: Web/JavaScript/Reference/Global_Objects/String/codePointAt
-translation_of: Web/JavaScript/Reference/Global_Objects/String/codePointAt
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/codePointAt
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/concat/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/concat/index.md
@@ -1,13 +1,6 @@
 ---
 title: String.prototype.concat()
 slug: Web/JavaScript/Reference/Global_Objects/String/concat
-tags:
-  - JavaScript
-  - Prototipo
-  - Referencia
-  - String
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/String/concat
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/concat
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/endswith/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/endswith/index.md
@@ -1,13 +1,6 @@
 ---
 title: String.prototype.endsWith()
 slug: Web/JavaScript/Reference/Global_Objects/String/endsWith
-tags:
-  - JavaScript
-  - Prototipo
-  - Referencia
-  - String
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/String/endsWith
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/endsWith
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/fixed/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/fixed/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.fixed()
 slug: Web/JavaScript/Reference/Global_Objects/String/fixed
-tags:
-  - Deprecated
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/fixed
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/fixed
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/fontcolor/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/fontcolor/index.md
@@ -1,7 +1,6 @@
 ---
 title: String.prototype.fontcolor()
 slug: Web/JavaScript/Reference/Global_Objects/String/fontcolor
-translation_of: Web/JavaScript/Reference/Global_Objects/String/fontcolor
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/fontcolor
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/fontsize/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/fontsize/index.md
@@ -1,7 +1,6 @@
 ---
 title: String.prototype.fontsize()
 slug: Web/JavaScript/Reference/Global_Objects/String/fontsize
-translation_of: Web/JavaScript/Reference/Global_Objects/String/fontsize
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/fontsize
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/fromcharcode/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/fromcharcode/index.md
@@ -1,12 +1,6 @@
 ---
 title: String.fromCharCode()
 slug: Web/JavaScript/Reference/Global_Objects/String/fromCharCode
-tags:
-  - JavaScript
-  - Method
-  - String
-  - Unicode
-translation_of: Web/JavaScript/Reference/Global_Objects/String/fromCharCode
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/fromCharCode
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/fromcodepoint/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/fromcodepoint/index.md
@@ -1,7 +1,6 @@
 ---
 title: String.fromCodePoint()
 slug: Web/JavaScript/Reference/Global_Objects/String/fromCodePoint
-translation_of: Web/JavaScript/Reference/Global_Objects/String/fromCodePoint
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/fromCodePoint
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/includes/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/includes/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.includes()
 slug: Web/JavaScript/Reference/Global_Objects/String/includes
-tags:
-  - Cadena de texto
-  - JavaScript
-  - Prototipo
-  - Referencia
-  - String
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/String/includes
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/includes
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/index.md
@@ -1,14 +1,6 @@
 ---
 title: String — Cadena de caracteres
 slug: Web/JavaScript/Reference/Global_Objects/String
-tags:
-  - Clase
-  - Class
-  - ECMAScript 2015
-  - JavaScript
-  - Referencia
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/indexof/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/indexof/index.md
@@ -1,12 +1,6 @@
 ---
 title: String.prototype.indexOf()
 slug: Web/JavaScript/Reference/Global_Objects/String/indexOf
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/indexOf
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/indexOf
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/italics/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/italics/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.italics()
 slug: Web/JavaScript/Reference/Global_Objects/String/italics
-tags:
-  - Deprecated
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/italics
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/italics
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/lastindexof/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/lastindexof/index.md
@@ -1,13 +1,6 @@
 ---
 title: String.prototype.lastIndexOf()
 slug: Web/JavaScript/Reference/Global_Objects/String/lastIndexOf
-tags:
-  - Cadena
-  - JavaScript
-  - Prototipo
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/String/lastIndexOf
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/lastIndexOf
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/length/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/length/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.length
 slug: Web/JavaScript/Reference/Global_Objects/String/length
-tags:
-  - JavaScript
-  - Propiedad
-  - Prototipo
-  - Referencia
-  - String
-  - length
-translation_of: Web/JavaScript/Reference/Global_Objects/String/length
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/length
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/link/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/link/index.md
@@ -1,13 +1,6 @@
 ---
 title: String.prototype.link()
 slug: Web/JavaScript/Reference/Global_Objects/String/link
-tags:
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/link
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/link
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/localecompare/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/localecompare/index.md
@@ -1,8 +1,6 @@
 ---
 title: String.prototype.localeCompare()
 slug: Web/JavaScript/Reference/Global_Objects/String/localeCompare
-translation_of: Web/JavaScript/Reference/Global_Objects/String/localeCompare
-browser-compat: javascript.builtins.String.localeCompare
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/string/match/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/match/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.match()
 slug: Web/JavaScript/Reference/Global_Objects/String/match
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - RegExp
-  - Regular Expressions
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/match
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/match
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/matchall/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/matchall/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.matchAll()
 slug: Web/JavaScript/Reference/Global_Objects/String/matchAll
-tags:
-  - Cadena
-  - Expresiones Regulares
-  - JavaScript
-  - Prototipo
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/String/matchAll
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/matchAll
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/normalize/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/normalize/index.md
@@ -1,16 +1,6 @@
 ---
 title: String.prototype.normalize()
 slug: Web/JavaScript/Reference/Global_Objects/String/normalize
-tags:
-  - Cadena
-  - ECMAScript 2015
-  - JavaScript
-  - Prototipo
-  - Referencia
-  - String
-  - Unicode
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/String/normalize
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/normalize
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/padstart/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/padstart/index.md
@@ -1,13 +1,6 @@
 ---
 title: String.prototype.padStart()
 slug: Web/JavaScript/Reference/Global_Objects/String/padStart
-tags:
-  - Cadena
-  - Experimental
-  - JavaScript
-  - Método(2)
-  - Referencia
-translation_of: Web/JavaScript/Reference/Global_Objects/String/padStart
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/padStart
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/raw/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/raw/index.md
@@ -1,7 +1,6 @@
 ---
 title: String.raw()
 slug: Web/JavaScript/Reference/Global_Objects/String/raw
-translation_of: Web/JavaScript/Reference/Global_Objects/String/raw
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/raw
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/repeat/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/repeat/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.repeat()
 slug: Web/JavaScript/Reference/Global_Objects/String/repeat
-tags:
-  - ECMAScript2015
-  - JavaScript
-  - Prototype
-  - Referencia
-  - String
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/String/repeat
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/repeat
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/replace/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/replace/index.md
@@ -1,13 +1,6 @@
 ---
 title: String.prototype.replace()
 slug: Web/JavaScript/Reference/Global_Objects/String/replace
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Regular Expressions
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/replace
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/replace
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/search/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/search/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.search()
 slug: Web/JavaScript/Reference/Global_Objects/String/search
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Reference
-  - Regular Expressions
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/search
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/search
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/slice/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/slice/index.md
@@ -1,13 +1,6 @@
 ---
 title: String.prototype.slice()
 slug: Web/JavaScript/Reference/Global_Objects/String/slice
-tags:
-  - Cadena
-  - JavaScript
-  - Método(2)
-  - Prototipo
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/slice
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/slice
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/small/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/small/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.small()
 slug: Web/JavaScript/Reference/Global_Objects/String/small
-tags:
-  - Deprecated
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/small
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/small
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/split/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/split/index.md
@@ -1,13 +1,6 @@
 ---
 title: String.prototype.split()
 slug: Web/JavaScript/Reference/Global_Objects/String/split
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - Regular Expressions
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/split
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/split
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/startswith/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/startswith/index.md
@@ -1,17 +1,6 @@
 ---
 title: String.prototype.startsWith()
 slug: Web/JavaScript/Reference/Global_Objects/String/startsWith
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Method
-  - Prototipo
-  - Prototype
-  - Reference
-  - Referencia
-  - String
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/String/startsWith
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/startsWith
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/strike/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/strike/index.md
@@ -1,14 +1,6 @@
 ---
 title: String.prototype.strike()
 slug: Web/JavaScript/Reference/Global_Objects/String/strike
-tags:
-  - Deprecated
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/strike
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/strike
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/sub/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/sub/index.md
@@ -1,13 +1,6 @@
 ---
 title: String.prototype.sub()
 slug: Web/JavaScript/Reference/Global_Objects/String/sub
-tags:
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/sub
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/sub
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/substr/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/substr/index.md
@@ -1,12 +1,6 @@
 ---
 title: String.prototype.substr()
 slug: Web/JavaScript/Reference/Global_Objects/String/substr
-tags:
-  - JavaScript
-  - Método(2)
-  - Prototipo
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/substr
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/substr
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/substring/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/substring/index.md
@@ -1,12 +1,6 @@
 ---
 title: String.prototype.substring()
 slug: Web/JavaScript/Reference/Global_Objects/String/substring
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/substring
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/substring
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/sup/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/sup/index.md
@@ -1,13 +1,6 @@
 ---
 title: String.prototype.sup()
 slug: Web/JavaScript/Reference/Global_Objects/String/sup
-tags:
-  - HTML wrapper methods
-  - JavaScript
-  - Method
-  - Prototype
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/sup
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/sup
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/tolocalelowercase/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/tolocalelowercase/index.md
@@ -1,13 +1,6 @@
 ---
 title: String.prototype.toLocaleLowerCase()
 slug: Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase
-tags:
-  - Cadena
-  - Internacionalizacion
-  - Prototipo
-  - Referencia
-  - metodo
-translation_of: Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/toLocaleLowerCase
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/tolocaleuppercase/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/tolocaleuppercase/index.md
@@ -1,7 +1,6 @@
 ---
 title: String.prototype.toLocaleUpperCase()
 slug: Web/JavaScript/Reference/Global_Objects/String/toLocaleUpperCase
-translation_of: Web/JavaScript/Reference/Global_Objects/String/toLocaleUpperCase
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/toLocaleUpperCase
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/tolowercase/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/tolowercase/index.md
@@ -1,12 +1,6 @@
 ---
 title: String.prototype.toLowerCase()
 slug: Web/JavaScript/Reference/Global_Objects/String/toLowerCase
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/toLowerCase
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/toLowerCase
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/tostring/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/tostring/index.md
@@ -1,12 +1,6 @@
 ---
 title: String.prototype.toString()
 slug: Web/JavaScript/Reference/Global_Objects/String/toString
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/toString
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/toString
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/touppercase/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/touppercase/index.md
@@ -1,12 +1,6 @@
 ---
 title: String.prototype.toUpperCase()
 slug: Web/JavaScript/Reference/Global_Objects/String/toUpperCase
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/toUpperCase
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/toUpperCase
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/trim/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/trim/index.md
@@ -1,7 +1,6 @@
 ---
 title: String.prototype.trim()
 slug: Web/JavaScript/Reference/Global_Objects/String/Trim
-translation_of: Web/JavaScript/Reference/Global_Objects/String/Trim
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/Trim
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/trimend/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/trimend/index.md
@@ -1,15 +1,6 @@
 ---
 title: String.prototype.trimEnd()
 slug: Web/JavaScript/Reference/Global_Objects/String/trimEnd
-tags:
-  - Espacios en blanco
-  - JavaScript
-  - Métodos
-  - Prototype
-  - String
-  - Texto
-  - cadenas de texto
-translation_of: Web/JavaScript/Reference/Global_Objects/String/trimEnd
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/trimEnd
 ---
 

--- a/files/es/web/javascript/reference/global_objects/string/valueof/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/valueof/index.md
@@ -1,12 +1,6 @@
 ---
 title: String.prototype.valueOf()
 slug: Web/JavaScript/Reference/Global_Objects/String/valueOf
-tags:
-  - JavaScript
-  - Method
-  - Prototype
-  - String
-translation_of: Web/JavaScript/Reference/Global_Objects/String/valueOf
 original_slug: Web/JavaScript/Referencia/Objetos_globales/String/valueOf
 ---
 

--- a/files/es/web/javascript/reference/global_objects/symbol/@@toprimitive/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/@@toprimitive/index.md
@@ -1,9 +1,7 @@
 ---
 title: Symbol.prototype[@@toPrimitive]
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/@@toPrimitive
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/@@toPrimitive
 original_slug: Web/JavaScript/Reference/Global_Objects/Symbol/@@toPrimitive
-browser-compat: javascript.builtins.Symbol.@@toPrimitive
 l10n:
   sourceCommit: cf607d68522cd35ee7670782d3ee3a361eaef2e4
 ---

--- a/files/es/web/javascript/reference/global_objects/symbol/asynciterator/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/asynciterator/index.md
@@ -1,9 +1,7 @@
 ---
 title: Symbol.asyncIterator
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator
 original_slug: Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator
-browser-compat: javascript.builtins.Symbol.asyncIterator
 l10n:
   sourceCommit: 12da8f89b59995a777e13d518ffd39c331fb95d4
 ---

--- a/files/es/web/javascript/reference/global_objects/symbol/description/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/description/index.md
@@ -1,9 +1,7 @@
 ---
 title: Symbol.prototype.description
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/description
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/description
 original_slug: Web/JavaScript/Reference/Global_Objects/Symbol/description
-browser-compat: javascript.builtins.Symbol.description
 l10n:
   sourceCommit: 88508ebe5c73264be2cf03f1a949d8099d68d1ea
 ---

--- a/files/es/web/javascript/reference/global_objects/symbol/for/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/for/index.md
@@ -1,9 +1,7 @@
 ---
 title: Symbol.for()
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/for
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/for
 original_slug: Web/JavaScript/Reference/Global_Objects/Symbol/for
-browser-compat: javascript.builtins.Symbol.for
 l10n:
   sourceCommit: ef59c2d0399ba62ec2632810564ab12a198af868
 ---

--- a/files/es/web/javascript/reference/global_objects/symbol/hasinstance/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/hasinstance/index.md
@@ -1,9 +1,7 @@
 ---
 title: Symbol.hasInstance
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance
 original_slug: Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance
-browser-compat: javascript.builtins.Symbol.hasInstance
 l10n:
   sourceCommit: d4b12e290fce9ae43a9ae23b9b9c8a5812b82ebd
 ---

--- a/files/es/web/javascript/reference/global_objects/symbol/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/index.md
@@ -1,9 +1,7 @@
 ---
 title: Symbol
 slug: Web/JavaScript/Reference/Global_Objects/Symbol
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol
 original_slug: Web/JavaScript/Reference/Global_Objects/Symbol
-browser-compat: javascript.builtins.Symbol
 l10n:
   sourceCommit: 54ae754f4d18601ee91f741c7b774d2238e2656e
 ---

--- a/files/es/web/javascript/reference/global_objects/symbol/isconcatspreadable/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/isconcatspreadable/index.md
@@ -1,9 +1,7 @@
 ---
 title: Symbol.isConcatSpreadable
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/isConcatSpreadable
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/isConcatSpreadable
 original_slug: Web/JavaScript/Reference/Global_Objects/Symbol/isConcatSpreadable
-browser-compat: javascript.builtins.Symbol.isConcatSpreadable
 l10n:
   sourceCommit: 88508ebe5c73264be2cf03f1a949d8099d68d1ea
 ---

--- a/files/es/web/javascript/reference/global_objects/symbol/iterator/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/iterator/index.md
@@ -1,9 +1,7 @@
 ---
 title: Symbol.iterator
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/iterator
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/iterator
 original_slug: Web/JavaScript/Reference/Global_Objects/Symbol/iterator
-browser-compat: javascript.builtins.Symbol.iterator
 l10n:
   sourceCommit: 552892d8fc6707c47ae879aef32e6ac3023166ee
 ---

--- a/files/es/web/javascript/reference/global_objects/symbol/keyfor/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/keyfor/index.md
@@ -1,9 +1,7 @@
 ---
 title: Symbol.keyFor()
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/keyFor
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/keyFor
 original_slug: Web/JavaScript/Reference/Global_Objects/Symbol/keyFor
-browser-compat: javascript.builtins.Symbol.keyFor
 l10n:
   sourceCommit: ef59c2d0399ba62ec2632810564ab12a198af868
 ---

--- a/files/es/web/javascript/reference/global_objects/symbol/match/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/match/index.md
@@ -1,9 +1,7 @@
 ---
 title: Symbol.match
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/match
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/match
 original_slug: Web/JavaScript/Reference/Global_Objects/Symbol/match
-browser-compat: javascript.builtins.Symbol.match
 l10n:
   sourceCommit: 7e90bb68293370a2419eb28016f1803b594111ba
 ---

--- a/files/es/web/javascript/reference/global_objects/symbol/matchall/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/matchall/index.md
@@ -1,9 +1,7 @@
 ---
 title: Symbol.matchAll
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/matchAll
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/matchAll
 original_slug: Web/JavaScript/Reference/Global_Objects/Symbol/matchAll
-browser-compat: javascript.builtins.Symbol.matchAll
 l10n:
   sourceCommit: c20a54b3a4b713b2636f171d00162779e67b99b7
 ---

--- a/files/es/web/javascript/reference/global_objects/symbol/replace/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/replace/index.md
@@ -1,9 +1,7 @@
 ---
 title: Symbol.replace
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/replace
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/replace
 original_slug: Web/JavaScript/Reference/Global_Objects/Symbol/replace
-browser-compat: javascript.builtins.Symbol.replace
 l10n:
   sourceCommit: 88508ebe5c73264be2cf03f1a949d8099d68d1ea
 ---

--- a/files/es/web/javascript/reference/global_objects/symbol/search/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/search/index.md
@@ -1,9 +1,7 @@
 ---
 title: Symbol.search
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/search
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/search
 original_slug: Web/JavaScript/Reference/Global_Objects/Symbol/search
-browser-compat: javascript.builtins.Symbol.search
 l10n:
   sourceCommit: 88508ebe5c73264be2cf03f1a949d8099d68d1ea
 ---

--- a/files/es/web/javascript/reference/global_objects/symbol/species/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/species/index.md
@@ -1,9 +1,7 @@
 ---
 title: Symbol.species
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/species
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/species
 original_slug: Web/JavaScript/Reference/Global_Objects/Symbol/species
-browser-compat: javascript.builtins.Symbol.species
 l10n:
   sourceCommit: 8bf018f0a39d012a0d98afe3f15e0ed0fb7c8ce5
 ---

--- a/files/es/web/javascript/reference/global_objects/symbol/split/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/split/index.md
@@ -1,9 +1,7 @@
 ---
 title: Symbol.split
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/split
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/split
 original_slug: Web/JavaScript/Reference/Global_Objects/Symbol/split
-browser-compat: javascript.builtins.Symbol.split
 l10n:
   sourceCommit: 88508ebe5c73264be2cf03f1a949d8099d68d1ea
 ---

--- a/files/es/web/javascript/reference/global_objects/symbol/symbol/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/symbol/index.md
@@ -1,9 +1,7 @@
 ---
 title: Symbol() constructor
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/Symbol
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/Symbol
 original_slug: Web/JavaScript/Reference/Global_Objects/Symbol/Symbol
-browser-compat: javascript.builtins.Symbol.Symbol
 l10n:
   sourceCommit: dc3dc7a9522107392cfea07243ff3c2cb34cb9a4
 ---

--- a/files/es/web/javascript/reference/global_objects/symbol/toprimitive/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/toprimitive/index.md
@@ -1,9 +1,7 @@
 ---
 title: Symbol.toPrimitive
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive
 original_slug: Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive
-browser-compat: javascript.builtins.Symbol.toPrimitive
 l10n:
   sourceCommit: 02024642bdb12940509cb4c7e2e60cbc3d62bf21
 ---

--- a/files/es/web/javascript/reference/global_objects/symbol/tostring/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/tostring/index.md
@@ -1,9 +1,7 @@
 ---
 title: Symbol.prototype.toString()
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/toString
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/toString
 original_slug: Web/JavaScript/Reference/Global_Objects/Symbol/toString
-browser-compat: javascript.builtins.Symbol.toString
 l10n:
   sourceCommit: cf607d68522cd35ee7670782d3ee3a361eaef2e4
 ---

--- a/files/es/web/javascript/reference/global_objects/symbol/tostringtag/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/tostringtag/index.md
@@ -1,9 +1,7 @@
 ---
 title: Symbol.toStringTag
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag
 original_slug: Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag
-browser-compat: javascript.builtins.Symbol.toStringTag
 l10n:
   sourceCommit: d5d9a70d1f8bc041c4ff226c3ff7e02382c5efef
 ---

--- a/files/es/web/javascript/reference/global_objects/symbol/unscopables/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/unscopables/index.md
@@ -1,9 +1,7 @@
 ---
 title: Symbol.unscopables
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/unscopables
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/unscopables
 original_slug: Web/JavaScript/Reference/Global_Objects/Symbol/unscopables
-browser-compat: javascript.builtins.Symbol.unscopables
 l10n:
   sourceCommit: 552892d8fc6707c47ae879aef32e6ac3023166ee
 ---

--- a/files/es/web/javascript/reference/global_objects/symbol/valueof/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/valueof/index.md
@@ -1,9 +1,7 @@
 ---
 title: Symbol.prototype.valueOf()
 slug: Web/JavaScript/Reference/Global_Objects/Symbol/valueOf
-translation_of: Web/JavaScript/Reference/Global_Objects/Symbol/valueOf
 original_slug: Web/JavaScript/Reference/Global_Objects/Symbol/valueOf
-browser-compat: javascript.builtins.Symbol.valueOf
 l10n:
   sourceCommit: cf607d68522cd35ee7670782d3ee3a361eaef2e4
 ---

--- a/files/es/web/javascript/reference/global_objects/syntaxerror/index.md
+++ b/files/es/web/javascript/reference/global_objects/syntaxerror/index.md
@@ -1,9 +1,7 @@
 ---
 title: SyntaxError
 slug: Web/JavaScript/Reference/Global_Objects/SyntaxError
-translation_of: Web/JavaScript/Reference/Global_Objects/SyntaxError
 original_slug: Web/JavaScript/Referencia/Objetos_globales/SyntaxError
-browser-compat: javascript.builtins.SyntaxError
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/typedarray/buffer/index.md
+++ b/files/es/web/javascript/reference/global_objects/typedarray/buffer/index.md
@@ -1,11 +1,6 @@
 ---
 title: TypedArray.prototype.buffer
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray/buffer
-tags:
-  - Buffer
-  - JavaScript
-  - Propiedad
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray/buffer
 original_slug: Web/JavaScript/Referencia/Objetos_globales/TypedArray/buffer
 ---
 

--- a/files/es/web/javascript/reference/global_objects/typedarray/index.md
+++ b/files/es/web/javascript/reference/global_objects/typedarray/index.md
@@ -1,13 +1,6 @@
 ---
 title: TypedArray
 slug: Web/JavaScript/Reference/Global_Objects/TypedArray
-tags:
-  - Clase
-  - Class
-  - JavaScript
-  - TypedArray
-  - TypedArrays
-translation_of: Web/JavaScript/Reference/Global_Objects/TypedArray
 original_slug: Web/JavaScript/Referencia/Objetos_globales/TypedArray
 ---
 

--- a/files/es/web/javascript/reference/global_objects/typeerror/index.md
+++ b/files/es/web/javascript/reference/global_objects/typeerror/index.md
@@ -1,7 +1,6 @@
 ---
 title: TypeError
 slug: Web/JavaScript/Reference/Global_Objects/TypeError
-browser-compat: javascript.builtins.TypeError
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/typeerror/typeerror/index.md
+++ b/files/es/web/javascript/reference/global_objects/typeerror/typeerror/index.md
@@ -1,7 +1,6 @@
 ---
 title: TypeError() constructor
 slug: Web/JavaScript/Reference/Global_Objects/TypeError/TypeError
-browser-compat: javascript.builtins.TypeError.TypeError
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/uint8array/index.md
+++ b/files/es/web/javascript/reference/global_objects/uint8array/index.md
@@ -1,11 +1,6 @@
 ---
 title: Uint8Array
 slug: Web/JavaScript/Reference/Global_Objects/Uint8Array
-tags:
-  - Arreglo
-  - JavaScript
-  - array de enteros
-translation_of: Web/JavaScript/Reference/Global_Objects/Uint8Array
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Uint8Array
 ---
 

--- a/files/es/web/javascript/reference/global_objects/undefined/index.md
+++ b/files/es/web/javascript/reference/global_objects/undefined/index.md
@@ -1,9 +1,6 @@
 ---
 title: undefined
 slug: Web/JavaScript/Reference/Global_Objects/undefined
-tags:
-  - JavaScript
-translation_of: Web/JavaScript/Reference/Global_Objects/undefined
 original_slug: Web/JavaScript/Referencia/Objetos_globales/undefined
 ---
 

--- a/files/es/web/javascript/reference/global_objects/unescape/index.md
+++ b/files/es/web/javascript/reference/global_objects/unescape/index.md
@@ -1,7 +1,6 @@
 ---
 title: unescape()
 slug: Web/JavaScript/Reference/Global_Objects/unescape
-translation_of: Web/JavaScript/Reference/Global_Objects/unescape
 original_slug: Web/JavaScript/Referencia/Objetos_globales/unescape
 ---
 

--- a/files/es/web/javascript/reference/global_objects/urierror/index.md
+++ b/files/es/web/javascript/reference/global_objects/urierror/index.md
@@ -1,8 +1,6 @@
 ---
 title: URIError
 slug: Web/JavaScript/Reference/Global_Objects/URIError
-translation_of: Web/JavaScript/Reference/Global_Objects/URIError
-browser-compat: javascript.builtins.URIError
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/weakmap/delete/index.md
+++ b/files/es/web/javascript/reference/global_objects/weakmap/delete/index.md
@@ -1,12 +1,6 @@
 ---
 title: WeakMap.prototype.delete()
 slug: Web/JavaScript/Reference/Global_Objects/WeakMap/delete
-tags:
-  - ECMAScript6
-  - JavaScript
-  - Prototype
-  - WeakMap
-translation_of: Web/JavaScript/Reference/Global_Objects/WeakMap/delete
 original_slug: Web/JavaScript/Referencia/Objetos_globales/WeakMap/delete
 ---
 

--- a/files/es/web/javascript/reference/global_objects/weakmap/get/index.md
+++ b/files/es/web/javascript/reference/global_objects/weakmap/get/index.md
@@ -1,13 +1,6 @@
 ---
 title: WeakMap.prototype.get()
 slug: Web/JavaScript/Reference/Global_Objects/WeakMap/get
-tags:
-  - ECMAScript6
-  - JavaScript
-  - Method
-  - Prototype
-  - WeakMap
-translation_of: Web/JavaScript/Reference/Global_Objects/WeakMap/get
 original_slug: Web/JavaScript/Referencia/Objetos_globales/WeakMap/get
 ---
 

--- a/files/es/web/javascript/reference/global_objects/weakmap/has/index.md
+++ b/files/es/web/javascript/reference/global_objects/weakmap/has/index.md
@@ -1,13 +1,6 @@
 ---
 title: WeakMap.prototype.has()
 slug: Web/JavaScript/Reference/Global_Objects/WeakMap/has
-tags:
-  - ECMAScript6
-  - JavaScript
-  - Method
-  - Protocols
-  - WeakMap
-translation_of: Web/JavaScript/Reference/Global_Objects/WeakMap/has
 original_slug: Web/JavaScript/Referencia/Objetos_globales/WeakMap/has
 ---
 

--- a/files/es/web/javascript/reference/global_objects/weakmap/index.md
+++ b/files/es/web/javascript/reference/global_objects/weakmap/index.md
@@ -1,9 +1,7 @@
 ---
 title: WeakMap
 slug: Web/JavaScript/Reference/Global_Objects/WeakMap
-translation_of: Web/JavaScript/Reference/Global_Objects/WeakMap
 original_slug: Web/JavaScript/Referencia/Objetos_globales/WeakMap
-browser-compat: javascript.builtins.WeakMap
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/global_objects/weakmap/set/index.md
+++ b/files/es/web/javascript/reference/global_objects/weakmap/set/index.md
@@ -1,13 +1,6 @@
 ---
 title: WeakMap.prototype.set()
 slug: Web/JavaScript/Reference/Global_Objects/WeakMap/set
-tags:
-  - ECMAScript6
-  - JavaScript
-  - Method
-  - Protocols
-  - WeakMap
-translation_of: Web/JavaScript/Reference/Global_Objects/WeakMap/set
 original_slug: Web/JavaScript/Referencia/Objetos_globales/WeakMap/set
 ---
 

--- a/files/es/web/javascript/reference/global_objects/weakset/index.md
+++ b/files/es/web/javascript/reference/global_objects/weakset/index.md
@@ -1,9 +1,7 @@
 ---
 title: WeakSet
 slug: Web/JavaScript/Reference/Global_Objects/WeakSet
-translation_of: Web/JavaScript/Reference/Global_Objects/WeakSet
 original_slug: Web/JavaScript/Referencia/Objetos_globales/WeakSet
-browser-compat: javascript.builtins.WeakSet
 ---
 
 {{JSRef}}

--- a/files/es/web/javascript/reference/index.md
+++ b/files/es/web/javascript/reference/index.md
@@ -1,7 +1,6 @@
 ---
 title: Referencia de JavaScript
 slug: Web/JavaScript/Reference
-translation_of: Web/JavaScript/Reference
 original_slug: Web/JavaScript/Referencia
 ---
 

--- a/files/es/web/javascript/reference/iteration_protocols/index.md
+++ b/files/es/web/javascript/reference/iteration_protocols/index.md
@@ -1,14 +1,6 @@
 ---
 title: Protocolos de Iteración
 slug: Web/JavaScript/Reference/Iteration_protocols
-tags:
-  - ECMAScript6
-  - Experimental
-  - Intermedio
-  - Iterable
-  - Iterador
-  - JavaScript
-translation_of: Web/JavaScript/Reference/Iteration_protocols
 original_slug: Web/JavaScript/Referencia/Iteration_protocols
 ---
 

--- a/files/es/web/javascript/reference/lexical_grammar/index.md
+++ b/files/es/web/javascript/reference/lexical_grammar/index.md
@@ -1,13 +1,6 @@
 ---
 title: Gramática léxica
 slug: Web/JavaScript/Reference/Lexical_grammar
-tags:
-  - Gramática léxica
-  - Guía
-  - JaveScript
-  - Literal
-  - Palabra clave
-translation_of: Web/JavaScript/Reference/Lexical_grammar
 original_slug: Web/JavaScript/Referencia/Gramatica_lexica
 ---
 

--- a/files/es/web/javascript/reference/operators/addition/index.md
+++ b/files/es/web/javascript/reference/operators/addition/index.md
@@ -1,7 +1,6 @@
 ---
 title: Adición (+)
 slug: Web/JavaScript/Reference/Operators/Addition
-translation_of: Web/JavaScript/Reference/Operators/Addition
 original_slug: Web/JavaScript/Referencia/Operadores/Adición
 ---
 

--- a/files/es/web/javascript/reference/operators/assignment/index.md
+++ b/files/es/web/javascript/reference/operators/assignment/index.md
@@ -1,13 +1,6 @@
 ---
 title: Asignacion (=)
 slug: Web/JavaScript/Reference/Operators/Assignment
-tags:
-  - JS
-  - JavaScript
-  - Operador de Asignacion
-  - Operadores JavaScript
-  - Referências
-translation_of: Web/JavaScript/Reference/Operators/Assignment
 original_slug: Web/JavaScript/Referencia/Operadores/Asignacion
 ---
 

--- a/files/es/web/javascript/reference/operators/async_function/index.md
+++ b/files/es/web/javascript/reference/operators/async_function/index.md
@@ -1,12 +1,6 @@
 ---
 title: Expresión de función asíncrona
 slug: Web/JavaScript/Reference/Operators/async_function
-tags:
-  - Expresión Primaria
-  - JavaScript
-  - Operador
-  - función
-translation_of: Web/JavaScript/Reference/Operators/async_function
 original_slug: Web/JavaScript/Referencia/Operadores/async_function
 ---
 

--- a/files/es/web/javascript/reference/operators/await/index.md
+++ b/files/es/web/javascript/reference/operators/await/index.md
@@ -1,7 +1,6 @@
 ---
 title: await
 slug: Web/JavaScript/Reference/Operators/await
-translation_of: Web/JavaScript/Reference/Operators/await
 original_slug: Web/JavaScript/Referencia/Operadores/await
 ---
 

--- a/files/es/web/javascript/reference/operators/class/index.md
+++ b/files/es/web/javascript/reference/operators/class/index.md
@@ -1,14 +1,6 @@
 ---
 title: expresión class
 slug: Web/JavaScript/Reference/Operators/class
-tags:
-  - Classes
-  - ECMAScript6
-  - Expression
-  - JavaScript
-  - Operator
-  - Reference
-translation_of: Web/JavaScript/Reference/Operators/class
 original_slug: Web/JavaScript/Referencia/Operadores/class
 ---
 

--- a/files/es/web/javascript/reference/operators/comma_operator/index.md
+++ b/files/es/web/javascript/reference/operators/comma_operator/index.md
@@ -1,9 +1,6 @@
 ---
 title: Operador Coma
 slug: Web/JavaScript/Reference/Operators/Comma_Operator
-tags:
-  - JavaScript
-translation_of: Web/JavaScript/Reference/Operators/Comma_Operator
 original_slug: Web/JavaScript/Referencia/Operadores/operador_coma
 ---
 

--- a/files/es/web/javascript/reference/operators/conditional_operator/index.md
+++ b/files/es/web/javascript/reference/operators/conditional_operator/index.md
@@ -1,10 +1,6 @@
 ---
 title: Operador condicional (ternario)
 slug: Web/JavaScript/Reference/Operators/Conditional_Operator
-tags:
-  - JavaScript
-  - Operador
-translation_of: Web/JavaScript/Reference/Operators/Conditional_Operator
 original_slug: Web/JavaScript/Referencia/Operadores/Conditional_Operator
 ---
 

--- a/files/es/web/javascript/reference/operators/decrement/index.md
+++ b/files/es/web/javascript/reference/operators/decrement/index.md
@@ -1,12 +1,6 @@
 ---
 title: Decremento(--)
 slug: Web/JavaScript/Reference/Operators/Decrement
-tags:
-  - Decremento
-  - JavaScript
-  - JavaScript basico
-  - Operadores
-translation_of: Web/JavaScript/Reference/Operators/Decrement
 original_slug: Web/JavaScript/Referencia/Operadores/Decremento
 ---
 

--- a/files/es/web/javascript/reference/operators/delete/index.md
+++ b/files/es/web/javascript/reference/operators/delete/index.md
@@ -1,7 +1,6 @@
 ---
 title: Operador delete
 slug: Web/JavaScript/Reference/Operators/delete
-translation_of: Web/JavaScript/Reference/Operators/delete
 ---
 
 {{jsSidebar("Operators")}}

--- a/files/es/web/javascript/reference/operators/destructuring_assignment/index.md
+++ b/files/es/web/javascript/reference/operators/destructuring_assignment/index.md
@@ -1,16 +1,6 @@
 ---
 title: La desestructuración
 slug: Web/JavaScript/Reference/Operators/Destructuring_assignment
-tags:
-  - Característica del lenguaje
-  - Desestructuración
-  - Desestructurar arreglos y objetos anidados
-  - ECMAScript 2015
-  - ES6
-  - JavaScript
-  - Objetos anidados y desestructuración de array
-  - Operador
-translation_of: Web/JavaScript/Reference/Operators/Destructuring_assignment
 original_slug: Web/JavaScript/Referencia/Operadores/Destructuring_assignment
 ---
 

--- a/files/es/web/javascript/reference/operators/division/index.md
+++ b/files/es/web/javascript/reference/operators/division/index.md
@@ -1,13 +1,6 @@
 ---
 title: Division (/)
 slug: Web/JavaScript/Reference/Operators/Division
-tags:
-  - JS
-  - JavaScript
-  - Operador de Division
-  - Operadores
-  - Referências
-translation_of: Web/JavaScript/Reference/Operators/Division
 original_slug: Web/JavaScript/Referencia/Operadores/Division
 ---
 

--- a/files/es/web/javascript/reference/operators/equality/index.md
+++ b/files/es/web/javascript/reference/operators/equality/index.md
@@ -1,13 +1,6 @@
 ---
 title: Comparación (==)
 slug: Web/JavaScript/Reference/Operators/Equality
-tags:
-  - JS
-  - JavaScript
-  - Operador de comparacion
-  - Operadores
-  - Referências
-translation_of: Web/JavaScript/Reference/Operators/Equality
 original_slug: Web/JavaScript/Referencia/Operadores/Comparacion
 ---
 

--- a/files/es/web/javascript/reference/operators/function/index.md
+++ b/files/es/web/javascript/reference/operators/function/index.md
@@ -1,12 +1,6 @@
 ---
 title: function
 slug: Web/JavaScript/Reference/Operators/function
-tags:
-  - Function
-  - JavaScript
-  - Operator
-  - Primary Expressions
-translation_of: Web/JavaScript/Reference/Operators/function
 original_slug: Web/JavaScript/Referencia/Operadores/function
 ---
 

--- a/files/es/web/javascript/reference/operators/function_star_/index.md
+++ b/files/es/web/javascript/reference/operators/function_star_/index.md
@@ -1,14 +1,6 @@
 ---
 title: expresión function*
 slug: Web/JavaScript/Reference/Operators/function*
-tags:
-  - ECMAScript 2015
-  - Expresión Primaria
-  - Function
-  - Iterator
-  - JavaScript
-  - Operator
-translation_of: Web/JavaScript/Reference/Operators/function*
 original_slug: Web/JavaScript/Referencia/Operadores/function*
 ---
 

--- a/files/es/web/javascript/reference/operators/grouping/index.md
+++ b/files/es/web/javascript/reference/operators/grouping/index.md
@@ -1,11 +1,6 @@
 ---
 title: Operador de agrupación
 slug: Web/JavaScript/Reference/Operators/Grouping
-tags:
-  - Expresiones primarias
-  - JavaScript
-  - Operador
-translation_of: Web/JavaScript/Reference/Operators/Grouping
 original_slug: Web/JavaScript/Referencia/Operadores/Grouping
 ---
 

--- a/files/es/web/javascript/reference/operators/import.meta/index.md
+++ b/files/es/web/javascript/reference/operators/import.meta/index.md
@@ -1,7 +1,6 @@
 ---
 title: import.meta
 slug: Web/JavaScript/Reference/Operators/import.meta
-translation_of: Web/JavaScript/Reference/Statements/import.meta
 original_slug: Web/JavaScript/Reference/Statements/import.meta
 ---
 

--- a/files/es/web/javascript/reference/operators/in/index.md
+++ b/files/es/web/javascript/reference/operators/in/index.md
@@ -1,11 +1,6 @@
 ---
 title: in
 slug: Web/JavaScript/Reference/Operators/in
-tags:
-  - JavaScript
-  - Operator
-  - Relational Operators
-translation_of: Web/JavaScript/Reference/Operators/in
 original_slug: Web/JavaScript/Referencia/Operadores/in
 ---
 

--- a/files/es/web/javascript/reference/operators/index.md
+++ b/files/es/web/javascript/reference/operators/index.md
@@ -1,13 +1,6 @@
 ---
 title: Expresiones y operadores
 slug: Web/JavaScript/Reference/Operators
-tags:
-  - Descripción
-  - JavaScript
-  - Operadores
-  - Operators
-  - Referencia
-translation_of: Web/JavaScript/Reference/Operators
 original_slug: Web/JavaScript/Referencia/Operadores
 ---
 

--- a/files/es/web/javascript/reference/operators/instanceof/index.md
+++ b/files/es/web/javascript/reference/operators/instanceof/index.md
@@ -1,11 +1,6 @@
 ---
 title: instanceof
 slug: Web/JavaScript/Reference/Operators/instanceof
-tags:
-  - JavaScript
-  - Operator
-  - Relational Operators
-translation_of: Web/JavaScript/Reference/Operators/instanceof
 original_slug: Web/JavaScript/Referencia/Operadores/instanceof
 ---
 

--- a/files/es/web/javascript/reference/operators/new.target/index.md
+++ b/files/es/web/javascript/reference/operators/new.target/index.md
@@ -1,12 +1,6 @@
 ---
 title: new.target
 slug: Web/JavaScript/Reference/Operators/new.target
-tags:
-  - Clases
-  - ECMAScript6
-  - JavaScript
-  - Referencia
-translation_of: Web/JavaScript/Reference/Operators/new.target
 original_slug: Web/JavaScript/Referencia/Operadores/new.target
 ---
 

--- a/files/es/web/javascript/reference/operators/new/index.md
+++ b/files/es/web/javascript/reference/operators/new/index.md
@@ -1,14 +1,6 @@
 ---
 title: Operador new
 slug: Web/JavaScript/Reference/Operators/new
-tags:
-  - Expresiones del lado izquierdo
-  - JavaScript
-  - Left-hand-side expressions
-  - Operador
-  - Operator
-  - Referencia
-translation_of: Web/JavaScript/Reference/Operators/new
 original_slug: Web/JavaScript/Referencia/Operadores/new
 ---
 

--- a/files/es/web/javascript/reference/operators/null/index.md
+++ b/files/es/web/javascript/reference/operators/null/index.md
@@ -1,11 +1,6 @@
 ---
 title: 'null'
 slug: Web/JavaScript/Reference/Operators/null
-tags:
-  - JavaScript
-  - Literal
-  - Primitivo
-translation_of: Web/JavaScript/Reference/Global_Objects/null
 original_slug: Web/JavaScript/Reference/Global_Objects/null
 ---
 

--- a/files/es/web/javascript/reference/operators/operator_precedence/index.md
+++ b/files/es/web/javascript/reference/operators/operator_precedence/index.md
@@ -1,7 +1,6 @@
 ---
 title: Precedencia de operadores
 slug: Web/JavaScript/Reference/Operators/Operator_Precedence
-translation_of: Web/JavaScript/Reference/Operators/Operator_Precedence
 ---
 
 {{jsSidebar("Operators")}}

--- a/files/es/web/javascript/reference/operators/optional_chaining/index.md
+++ b/files/es/web/javascript/reference/operators/optional_chaining/index.md
@@ -1,7 +1,6 @@
 ---
 title: Encadenamiento opcional
 slug: Web/JavaScript/Reference/Operators/Optional_chaining
-translation_of: Web/JavaScript/Reference/Operators/Optional_chaining
 original_slug: Web/JavaScript/Referencia/Operadores/Encadenamiento_opcional
 ---
 

--- a/files/es/web/javascript/reference/operators/property_accessors/index.md
+++ b/files/es/web/javascript/reference/operators/property_accessors/index.md
@@ -1,10 +1,6 @@
 ---
 title: Miembros
 slug: Web/JavaScript/Reference/Operators/Property_Accessors
-tags:
-  - JavaScript
-  - Operator
-translation_of: Web/JavaScript/Reference/Operators/Property_Accessors
 original_slug: Web/JavaScript/Referencia/Operadores/Miembros
 ---
 

--- a/files/es/web/javascript/reference/operators/remainder/index.md
+++ b/files/es/web/javascript/reference/operators/remainder/index.md
@@ -1,7 +1,6 @@
 ---
 title: Resto (%)
 slug: Web/JavaScript/Reference/Operators/Remainder
-translation_of: Web/JavaScript/Reference/Operators/Remainder
 original_slug: Web/JavaScript/Referencia/Operadores/Resto
 ---
 

--- a/files/es/web/javascript/reference/operators/spread_syntax/index.md
+++ b/files/es/web/javascript/reference/operators/spread_syntax/index.md
@@ -1,11 +1,6 @@
 ---
 title: Sintaxis Spread
 slug: Web/JavaScript/Reference/Operators/Spread_syntax
-tags:
-  - ECMAScript6
-  - Iteradores
-  - JavaScript
-translation_of: Web/JavaScript/Reference/Operators/Spread_syntax
 original_slug: Web/JavaScript/Referencia/Operadores/Sintaxis_Spread
 ---
 

--- a/files/es/web/javascript/reference/operators/strict_equality/index.md
+++ b/files/es/web/javascript/reference/operators/strict_equality/index.md
@@ -1,7 +1,6 @@
 ---
 title: Igualdad Estricta (===)
 slug: Web/JavaScript/Reference/Operators/Strict_equality
-translation_of: Web/JavaScript/Reference/Operators/Strict_equality
 original_slug: Web/JavaScript/Referencia/Operadores/Strict_equality
 ---
 

--- a/files/es/web/javascript/reference/operators/subtraction/index.md
+++ b/files/es/web/javascript/reference/operators/subtraction/index.md
@@ -1,9 +1,6 @@
 ---
 title: Sustracción (-)
 slug: Web/JavaScript/Reference/Operators/Subtraction
-tags:
-  - JavaScript
-translation_of: Web/JavaScript/Reference/Operators/Subtraction
 original_slug: Web/JavaScript/Referencia/Operadores/Sustracción
 ---
 

--- a/files/es/web/javascript/reference/operators/super/index.md
+++ b/files/es/web/javascript/reference/operators/super/index.md
@@ -1,12 +1,6 @@
 ---
 title: super
 slug: Web/JavaScript/Reference/Operators/super
-tags:
-  - Clases
-  - ECMAScript 2015
-  - JavaScript
-  - Operador
-translation_of: Web/JavaScript/Reference/Operators/super
 original_slug: Web/JavaScript/Referencia/Operadores/super
 ---
 

--- a/files/es/web/javascript/reference/operators/this/index.md
+++ b/files/es/web/javascript/reference/operators/this/index.md
@@ -1,7 +1,6 @@
 ---
 title: this
 slug: Web/JavaScript/Reference/Operators/this
-translation_of: Web/JavaScript/Reference/Operators/this
 original_slug: Web/JavaScript/Referencia/Operadores/this
 ---
 

--- a/files/es/web/javascript/reference/operators/typeof/index.md
+++ b/files/es/web/javascript/reference/operators/typeof/index.md
@@ -1,11 +1,6 @@
 ---
 title: typeof
 slug: Web/JavaScript/Reference/Operators/typeof
-tags:
-  - JavaScript
-  - Operator
-  - Unary
-translation_of: Web/JavaScript/Reference/Operators/typeof
 original_slug: Web/JavaScript/Referencia/Operadores/typeof
 ---
 

--- a/files/es/web/javascript/reference/operators/void/index.md
+++ b/files/es/web/javascript/reference/operators/void/index.md
@@ -1,11 +1,6 @@
 ---
 title: void
 slug: Web/JavaScript/Reference/Operators/void
-tags:
-  - JavaScript
-  - Operator
-  - Unary
-translation_of: Web/JavaScript/Reference/Operators/void
 original_slug: Web/JavaScript/Referencia/Operadores/void
 ---
 

--- a/files/es/web/javascript/reference/operators/yield/index.md
+++ b/files/es/web/javascript/reference/operators/yield/index.md
@@ -1,14 +1,6 @@
 ---
 title: yield
 slug: Web/JavaScript/Reference/Operators/yield
-tags:
-  - Característica del lenguaje
-  - ECMAScript 2015
-  - Generadores
-  - Iterador
-  - JavaScript
-  - Operador
-translation_of: Web/JavaScript/Reference/Operators/yield
 original_slug: Web/JavaScript/Referencia/Operadores/yield
 ---
 

--- a/files/es/web/javascript/reference/operators/yield_star_/index.md
+++ b/files/es/web/javascript/reference/operators/yield_star_/index.md
@@ -1,10 +1,6 @@
 ---
 title: yield*
 slug: Web/JavaScript/Reference/Operators/yield*
-tags:
-  - ECMAScript6
-  - JavaScript
-translation_of: Web/JavaScript/Reference/Operators/yield*
 original_slug: Web/JavaScript/Referencia/Operadores/yield*
 ---
 

--- a/files/es/web/javascript/reference/statements/async_function/index.md
+++ b/files/es/web/javascript/reference/statements/async_function/index.md
@@ -1,12 +1,6 @@
 ---
 title: Función async
 slug: Web/JavaScript/Reference/Statements/async_function
-tags:
-  - Declaración
-  - Ejemplo
-  - JavaScript
-  - función
-translation_of: Web/JavaScript/Reference/Statements/async_function
 original_slug: Web/JavaScript/Referencia/Sentencias/funcion_asincrona
 ---
 

--- a/files/es/web/javascript/reference/statements/block/index.md
+++ b/files/es/web/javascript/reference/statements/block/index.md
@@ -1,12 +1,6 @@
 ---
 title: block
 slug: Web/JavaScript/Reference/Statements/block
-tags:
-  - JavaScript
-  - Referencia
-  - Referência(2)
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/block
 original_slug: Web/JavaScript/Referencia/Sentencias/block
 ---
 

--- a/files/es/web/javascript/reference/statements/break/index.md
+++ b/files/es/web/javascript/reference/statements/break/index.md
@@ -1,10 +1,6 @@
 ---
 title: break
 slug: Web/JavaScript/Reference/Statements/break
-tags:
-  - JavaScript
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/break
 original_slug: Web/JavaScript/Referencia/Sentencias/break
 ---
 

--- a/files/es/web/javascript/reference/statements/class/index.md
+++ b/files/es/web/javascript/reference/statements/class/index.md
@@ -1,7 +1,6 @@
 ---
 title: class
 slug: Web/JavaScript/Reference/Statements/class
-translation_of: Web/JavaScript/Reference/Statements/class
 original_slug: Web/JavaScript/Referencia/Sentencias/class
 ---
 

--- a/files/es/web/javascript/reference/statements/const/index.md
+++ b/files/es/web/javascript/reference/statements/const/index.md
@@ -1,13 +1,6 @@
 ---
 title: const
 slug: Web/JavaScript/Reference/Statements/const
-tags:
-  - ECMAScript6
-  - Experimental
-  - Expérimental(2)
-  - JavaScript
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/const
 original_slug: Web/JavaScript/Referencia/Sentencias/const
 ---
 

--- a/files/es/web/javascript/reference/statements/continue/index.md
+++ b/files/es/web/javascript/reference/statements/continue/index.md
@@ -1,10 +1,6 @@
 ---
 title: continue
 slug: Web/JavaScript/Reference/Statements/continue
-tags:
-  - JavaScript
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/continue
 original_slug: Web/JavaScript/Referencia/Sentencias/continue
 ---
 

--- a/files/es/web/javascript/reference/statements/debugger/index.md
+++ b/files/es/web/javascript/reference/statements/debugger/index.md
@@ -1,10 +1,6 @@
 ---
 title: debugger
 slug: Web/JavaScript/Reference/Statements/debugger
-tags:
-  - JavaScript
-  - Sentencia
-translation_of: Web/JavaScript/Reference/Statements/debugger
 original_slug: Web/JavaScript/Referencia/Sentencias/debugger
 ---
 

--- a/files/es/web/javascript/reference/statements/do...while/index.md
+++ b/files/es/web/javascript/reference/statements/do...while/index.md
@@ -1,10 +1,6 @@
 ---
 title: do...while
 slug: Web/JavaScript/Reference/Statements/do...while
-tags:
-  - JavaScript
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/do...while
 original_slug: Web/JavaScript/Referencia/Sentencias/do...while
 ---
 

--- a/files/es/web/javascript/reference/statements/empty/index.md
+++ b/files/es/web/javascript/reference/statements/empty/index.md
@@ -1,11 +1,6 @@
 ---
 title: empty
 slug: Web/JavaScript/Reference/Statements/Empty
-tags:
-  - JavaScript
-  - Sentencia
-  - Vacía
-translation_of: Web/JavaScript/Reference/Statements/Empty
 original_slug: Web/JavaScript/Referencia/Sentencias/Empty
 ---
 

--- a/files/es/web/javascript/reference/statements/export/index.md
+++ b/files/es/web/javascript/reference/statements/export/index.md
@@ -1,13 +1,6 @@
 ---
 title: export
 slug: Web/JavaScript/Reference/Statements/export
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Módulos
-  - Sentencia
-  - export
-translation_of: Web/JavaScript/Reference/Statements/export
 original_slug: Web/JavaScript/Referencia/Sentencias/export
 ---
 

--- a/files/es/web/javascript/reference/statements/for-await...of/index.md
+++ b/files/es/web/javascript/reference/statements/for-await...of/index.md
@@ -1,15 +1,6 @@
 ---
 title: for await...of
 slug: Web/JavaScript/Reference/Statements/for-await...of
-tags:
-  - Iteración
-  - JavaScript
-  - Referencia
-  - Sentencia
-  - asincrónico
-  - await
-  - iterar
-translation_of: Web/JavaScript/Reference/Statements/for-await...of
 original_slug: Web/JavaScript/Referencia/Sentencias/for-await...of
 ---
 

--- a/files/es/web/javascript/reference/statements/for...in/index.md
+++ b/files/es/web/javascript/reference/statements/for...in/index.md
@@ -1,11 +1,6 @@
 ---
 title: for...in
 slug: Web/JavaScript/Reference/Statements/for...in
-tags:
-  - Característica del lenguaje
-  - Declaración
-  - JavaScript
-translation_of: Web/JavaScript/Reference/Statements/for...in
 original_slug: Web/JavaScript/Referencia/Sentencias/for...in
 ---
 

--- a/files/es/web/javascript/reference/statements/for...of/index.md
+++ b/files/es/web/javascript/reference/statements/for...of/index.md
@@ -1,12 +1,6 @@
 ---
 title: for...of
 slug: Web/JavaScript/Reference/Statements/for...of
-tags:
-  - ECMAScript6
-  - JavaScript
-  - Referencia
-  - Sentencia
-translation_of: Web/JavaScript/Reference/Statements/for...of
 original_slug: Web/JavaScript/Referencia/Sentencias/for...of
 ---
 

--- a/files/es/web/javascript/reference/statements/for/index.md
+++ b/files/es/web/javascript/reference/statements/for/index.md
@@ -1,10 +1,6 @@
 ---
 title: for
 slug: Web/JavaScript/Reference/Statements/for
-tags:
-  - JavaScript
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/for
 original_slug: Web/JavaScript/Referencia/Sentencias/for
 ---
 

--- a/files/es/web/javascript/reference/statements/function/index.md
+++ b/files/es/web/javascript/reference/statements/function/index.md
@@ -1,10 +1,6 @@
 ---
 title: function
 slug: Web/JavaScript/Reference/Statements/function
-tags:
-  - JavaScript
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/function
 original_slug: Web/JavaScript/Referencia/Sentencias/function
 ---
 

--- a/files/es/web/javascript/reference/statements/function_star_/index.md
+++ b/files/es/web/javascript/reference/statements/function_star_/index.md
@@ -1,13 +1,6 @@
 ---
 title: function*
 slug: Web/JavaScript/Reference/Statements/function*
-tags:
-  - Declaración
-  - Experimental
-  - Expérimental(2)
-  - Iterador
-  - función
-translation_of: Web/JavaScript/Reference/Statements/function*
 original_slug: Web/JavaScript/Referencia/Sentencias/function*
 ---
 

--- a/files/es/web/javascript/reference/statements/if...else/index.md
+++ b/files/es/web/javascript/reference/statements/if...else/index.md
@@ -1,10 +1,6 @@
 ---
 title: if...else
 slug: Web/JavaScript/Reference/Statements/if...else
-tags:
-  - JavaScript
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/if...else
 original_slug: Web/JavaScript/Referencia/Sentencias/if...else
 ---
 

--- a/files/es/web/javascript/reference/statements/import/index.md
+++ b/files/es/web/javascript/reference/statements/import/index.md
@@ -1,13 +1,6 @@
 ---
 title: import
 slug: Web/JavaScript/Reference/Statements/import
-tags:
-  - ECMAScript 2015
-  - JavaScript
-  - Módulos
-  - Sentencia
-  - import
-translation_of: Web/JavaScript/Reference/Statements/import
 original_slug: Web/JavaScript/Referencia/Sentencias/import
 ---
 

--- a/files/es/web/javascript/reference/statements/index.md
+++ b/files/es/web/javascript/reference/statements/index.md
@@ -1,11 +1,6 @@
 ---
 title: Sentencias
 slug: Web/JavaScript/Reference/Statements
-tags:
-  - JavaScript
-  - Referencia
-  - sentencias
-translation_of: Web/JavaScript/Reference/Statements
 original_slug: Web/JavaScript/Referencia/Sentencias
 ---
 

--- a/files/es/web/javascript/reference/statements/label/index.md
+++ b/files/es/web/javascript/reference/statements/label/index.md
@@ -1,10 +1,6 @@
 ---
 title: label
 slug: Web/JavaScript/Reference/Statements/label
-tags:
-  - JavaScript
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/label
 original_slug: Web/JavaScript/Referencia/Sentencias/label
 ---
 

--- a/files/es/web/javascript/reference/statements/let/index.md
+++ b/files/es/web/javascript/reference/statements/let/index.md
@@ -1,17 +1,7 @@
 ---
 title: let
 slug: Web/JavaScript/Reference/Statements/let
-tags:
-  - Característica del lenguaje
-  - Declaración de variable
-  - ECMAScript 2015
-  - JavaScript
-  - Variables
-  - let
-  - sentencias
-translation_of: Web/JavaScript/Reference/Statements/let
 original_slug: Web/JavaScript/Referencia/Sentencias/let
-browser-compat: javascript.statements.let
 ---
 
 {{jsSidebar("Statements")}}

--- a/files/es/web/javascript/reference/statements/return/index.md
+++ b/files/es/web/javascript/reference/statements/return/index.md
@@ -1,10 +1,6 @@
 ---
 title: return
 slug: Web/JavaScript/Reference/Statements/return
-tags:
-  - JavaScript
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/return
 original_slug: Web/JavaScript/Referencia/Sentencias/return
 ---
 

--- a/files/es/web/javascript/reference/statements/switch/index.md
+++ b/files/es/web/javascript/reference/statements/switch/index.md
@@ -1,7 +1,6 @@
 ---
 title: switch
 slug: Web/JavaScript/Reference/Statements/switch
-translation_of: Web/JavaScript/Reference/Statements/switch
 original_slug: Web/JavaScript/Referencia/Sentencias/switch
 ---
 

--- a/files/es/web/javascript/reference/statements/throw/index.md
+++ b/files/es/web/javascript/reference/statements/throw/index.md
@@ -1,10 +1,6 @@
 ---
 title: throw
 slug: Web/JavaScript/Reference/Statements/throw
-tags:
-  - JavaScript
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/throw
 original_slug: Web/JavaScript/Referencia/Sentencias/throw
 ---
 

--- a/files/es/web/javascript/reference/statements/try...catch/index.md
+++ b/files/es/web/javascript/reference/statements/try...catch/index.md
@@ -1,12 +1,6 @@
 ---
 title: try...catch
 slug: Web/JavaScript/Reference/Statements/try...catch
-tags:
-  - Error
-  - Excepción
-  - JavaScript
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/try...catch
 original_slug: Web/JavaScript/Referencia/Sentencias/try...catch
 ---
 

--- a/files/es/web/javascript/reference/statements/var/index.md
+++ b/files/es/web/javascript/reference/statements/var/index.md
@@ -1,10 +1,6 @@
 ---
 title: var
 slug: Web/JavaScript/Reference/Statements/var
-tags:
-  - JavaScript
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/var
 original_slug: Web/JavaScript/Referencia/Sentencias/var
 ---
 

--- a/files/es/web/javascript/reference/statements/while/index.md
+++ b/files/es/web/javascript/reference/statements/while/index.md
@@ -1,10 +1,6 @@
 ---
 title: while
 slug: Web/JavaScript/Reference/Statements/while
-tags:
-  - JavaScript
-  - Statement
-translation_of: Web/JavaScript/Reference/Statements/while
 original_slug: Web/JavaScript/Referencia/Sentencias/while
 ---
 

--- a/files/es/web/javascript/reference/strict_mode/index.md
+++ b/files/es/web/javascript/reference/strict_mode/index.md
@@ -1,12 +1,6 @@
 ---
 title: Modo Estricto
 slug: Web/JavaScript/Reference/Strict_mode
-tags:
-  - ECMAScript5
-  - Guía
-  - JavaScript
-  - Modo estricto
-translation_of: Web/JavaScript/Reference/Strict_mode
 original_slug: Web/JavaScript/Referencia/Modo_estricto
 ---
 

--- a/files/es/web/javascript/reference/template_literals/index.md
+++ b/files/es/web/javascript/reference/template_literals/index.md
@@ -1,12 +1,6 @@
 ---
 title: Plantillas literales (plantillas de cadenas)
 slug: Web/JavaScript/Reference/Template_literals
-tags:
-  - ECMAScript 2015
-  - Experimental
-  - Expérimental(2)
-  - JavaScript
-translation_of: Web/JavaScript/Reference/Template_literals
 original_slug: Web/JavaScript/Referencia/template_strings
 ---
 

--- a/files/es/web/javascript/typed_arrays/index.md
+++ b/files/es/web/javascript/typed_arrays/index.md
@@ -1,11 +1,6 @@
 ---
 title: Arreglos tipados de JavaScript
 slug: Web/JavaScript/Typed_arrays
-tags:
-  - Arreglo tipado
-  - Guía
-  - JavaScript
-translation_of: Web/JavaScript/Typed_arrays
 original_slug: Web/JavaScript/Vectores_tipados
 ---
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove duplicated frontmatter keys from localized content

### Motivation

Remove innecesarry duplicated data

### Additional details

```
{
  "tags": 205,
  "translation_of": 287,
  "browser-compat": 34,
  "translation_of_original": 1
}
```

### Related issues and pull requests

Relates to #10129
Relates to #7412
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
