### PR TITLE
fix: missing minus in `Math.sqrt(1)`

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/nan/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/nan/index.md
@@ -20,7 +20,7 @@ slug: Web/JavaScript/Reference/Global_Objects/NaN
 有五种不同类型的操作返回 `NaN`：
 
 - 失败的数字转换（例如，显式转换，如 `parseInt("blabla")`、`Number(undefined)`，或隐式转换，如 `Math.abs(undefined)`）
-- 计算结果不是实数的数学运算（例如，`Math.sqrt(1)`）
+- 计算结果不是实数的数学运算（例如，`Math.sqrt(-1)`）
 - 不定式（例如，`0 * Infinity`、`1 ** Infinity`、`Infinity / Infinity`、`Infinity - Infinity`）
 - 一个操作数被强制转换为 `NaN` 的方法或表达式（例如，`7 ** NaN`、`7 * "blabla"`）——这意味着 `NaN` 具有传染性
 - 将无效值表示为数字的其他情况（例如，无效的 [Date](/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Date) `new Date("blabla").getTime()`、`"".charCodeAt(1)`）


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

> Math operation where the result is not a real number (e.g. Math.sqrt(-1))

there is a missing minus compared to the original text

### Motivation

Mistake fixing.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
null

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
null
