### PR TITLE
fix: change wrong translated word in files/ko/web/css/min-width

### DIFF
--- a/files/ko/web/css/min-width/index.md
+++ b/files/ko/web/css/min-width/index.md
@@ -14,7 +14,7 @@ translation_of: Web/CSS/min-width
 
 {{EmbedInteractiveExample("pages/css/min-width.html")}}
 
-`min-width`가 {{cssxref("max-width")}} 또는 {{cssxref("width")}}보다 커지면 요소의 높이는 `min-width`의 값을 사용합니다.
+`min-width`가 {{cssxref("max-width")}} 또는 {{cssxref("width")}}보다 커지면 요소의 너비는 `min-width`의 값을 사용합니다.
 
 ## 구문
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

change word `높이` to `너비`

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

![image](https://user-images.githubusercontent.com/66409882/207353299-57bbc6a5-3119-4e3e-93b1-404fbefbf0fe.png)
![image](https://user-images.githubusercontent.com/66409882/207353694-c8ce71a7-c93f-4318-8855-990b34415f65.png)

i found wrong translated word in https://developer.mozilla.org/ko/docs/Web/CSS/min-width compare with https://developer.mozilla.org/en-US/docs/Web/CSS/min-width

> The element's <b>width</b> is set to the value of min-width whenever min-width is larger than [max-width](https://developer.mozilla.org/en-US/docs/Web/CSS/max-width) or [width](https://developer.mozilla.org/en-US/docs/Web/CSS/width).

> min-width가 [max-width](https://developer.mozilla.org/ko/docs/Web/CSS/max-width) 또는 [width](https://developer.mozilla.org/ko/docs/Web/CSS/width)보다 커지면 요소의 <b>높이</b>는 min-width의 값을 사용합니다.

in ko `width` is `너비` and `height` is `높이` but in this translated-ko page `width` has been translated `높이`

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
