### PR TITLE
ci(pr-test): remove html support

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -52,8 +52,8 @@ jobs:
           DIFF_DOCUMENTS=$(gh api repos/{owner}/{repo}/compare/${{ env.BASE_SHA }}...${{ env.HEAD_SHA }} \
             --jq '.files | .[] | select(.status|IN("added", "modified", "renamed", "copied", "changed")) | .filename')
 
-          # filter out files that are not markdown or html
-          GIT_DIFF_CONTENT=$(echo "${DIFF_DOCUMENTS}" | egrep -i "^files/.*\.(html|md)$" | xargs)
+          # filter out files that are not markdown files
+          GIT_DIFF_CONTENT=$(echo "${DIFF_DOCUMENTS}" | egrep -i "^files/.*\.md$" | xargs)
           echo "GIT_DIFF_CONTENT=${GIT_DIFF_CONTENT}" >> $GITHUB_ENV
 
           # filter out files that are not attachments


### PR DESCRIPTION
### Description

We are now 100% markdown, and plan to [remove html support](https://github.com/mdn/yari/issues/7574).

So we'd better to remove html support in PR test, as we did in [content](https://github.com/mdn/content/blob/4c14928fa57a1cc6ec3a7678a7220784abbd24fa/.github/workflows/pr-test.yml#L44-L45)

### Related issues and pull requests

mdn/yari#7574
