### PR TITLE
chore: fix zh-cn Object.seal markdown

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/object/seal/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/object/seal/index.md
@@ -3,7 +3,11 @@ title: Object.seal()
 slug: Web/JavaScript/Reference/Global_Objects/Object/seal
 ---
 
-{{JSRef}} **`Object.seal()`** 方法封闭一个对象，阻止添加新属性并将所有现有属性标记为不可配置。当前属性的值只要原来是可写的就可以改变。{{EmbedInteractiveExample("pages/js/object-seal.html")}}
+{{JSRef}}
+
+**`Object.seal()`** 方法封闭一个对象，阻止添加新属性并将所有现有属性标记为不可配置。当前属性的值只要原来是可写的就可以改变。
+
+{{EmbedInteractiveExample("pages/js/object-seal.html")}}
 
 ## 语法
 

--- a/files/zh-cn/web/javascript/reference/global_objects/object/seal/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/object/seal/index.md
@@ -3,7 +3,7 @@ title: Object.seal()
 slug: Web/JavaScript/Reference/Global_Objects/Object/seal
 ---
 
-{{JSRef}}**`Object.seal()`**方法封闭一个对象，阻止添加新属性并将所有现有属性标记为不可配置。当前属性的值只要原来是可写的就可以改变。{{EmbedInteractiveExample("pages/js/object-seal.html")}}
+{{JSRef}} **`Object.seal()`** 方法封闭一个对象，阻止添加新属性并将所有现有属性标记为不可配置。当前属性的值只要原来是可写的就可以改变。{{EmbedInteractiveExample("pages/js/object-seal.html")}}
 
 ## 语法
 


### PR DESCRIPTION
修复中文文档的Object.seal方法的markdown格式
修改前：
<img width="450" alt="image" src="https://user-images.githubusercontent.com/73089592/208334567-57d280b0-2071-404e-a6c1-5fc02d5926e7.png">
修改后：
<img width="397" alt="image" src="https://user-images.githubusercontent.com/73089592/208334585-9f61c597-6b10-4320-abb0-3afd2c429f35.png">
