### PR TITLE
fix: add zh-cn community

### DIFF
--- a/files/zh-cn/mdn/community/contributing/translated_content/index.md
+++ b/files/zh-cn/mdn/community/contributing/translated_content/index.md
@@ -21,9 +21,8 @@ original_slug: MDN/Contribute/Localize
 
 ### 汉语（zh-CN，zh-TW）
 
-- Moz://TW 讨论组：[Telegram (MozTW L10n channel)](https://moztw.org/tg)
-- Mozilla China 讨论组：[Mozilla China](https://t.me/mozilla_china)
-- 目前的志愿者：[Irvin](https://github.com/irvin)、[t7yang](https://github.com/t7yang)、[yin1999](https://github.com/yin1999)、[LaoshuBaby](https://github.com/LaoshuBaby)
+- 讨论组：[Telegram (MozTW L10n channel)](https://moztw.org/tg)、[Telegram (Mozilla China channel)](https://t.me/mozilla_china)
+- 目前的志愿者：[Irvin](https://github.com/irvin)、[t7yang](https://github.com/t7yang)、[yin1999](https://github.com/yin1999)
 
 ### 法语（fr）
 

--- a/files/zh-cn/mdn/community/contributing/translated_content/index.md
+++ b/files/zh-cn/mdn/community/contributing/translated_content/index.md
@@ -21,8 +21,9 @@ original_slug: MDN/Contribute/Localize
 
 ### 汉语（zh-CN，zh-TW）
 
-- 讨论组：[Telegram (MozTW L10n channel)](https://moztw.org/tg)
-- 目前的志愿者：[Irvin](https://github.com/irvin)、[t7yang](https://github.com/t7yang)、[yin1999](https://github.com/yin1999)
+- Moz://TW 讨论组：[Telegram (MozTW L10n channel)](https://moztw.org/tg)
+- Mozilla China 讨论组：[Mozilla China](https://t.me/mozilla_china)
+- 目前的志愿者：[Irvin](https://github.com/irvin)、[t7yang](https://github.com/t7yang)、[yin1999](https://github.com/yin1999)、[LaoshuBaby](https://github.com/LaoshuBaby)
 
 ### 法语（fr）
 

--- a/files/zh-cn/mdn/community/contributing/translated_content/index.md
+++ b/files/zh-cn/mdn/community/contributing/translated_content/index.md
@@ -19,7 +19,7 @@ original_slug: MDN/Contribute/Localize
 - 讨论组：[Telegram (MDN localization in Brazilian Portuguese)](https://t.me/mdn_l10n_pt_br)
 - 目前的志愿者：[Luisa Migueres](https://github.com/lumigueres)、[Julio Sampaio](https://github.com/juliosampaio)、[Josiel Rocha](https://github.com/josielrocha)、[Clóvis Lima Júnior](https://github.com/clovislima)
 
-### 汉语（zh-CN，zh-TW）
+### 汉语（zh-CN、zh-TW）
 
 - 讨论组：[Telegram (MozTW L10n channel)](https://moztw.org/tg)、[Telegram (Mozilla China channel)](https://t.me/mozilla_china)
 - 目前的志愿者：[Irvin](https://github.com/irvin)、[t7yang](https://github.com/t7yang)、[yin1999](https://github.com/yin1999)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add community link of zh-cn localization team from China

### Motivation

Many times translator complaining that they can't find a discussion forum in Simplified Chinese in Taiwan's group

### Additional details

None.
