### PR TITLE
Correction faute de frappe

### DIFF
--- a/files/fr/web/api/element/wheel_event/index.md
+++ b/files/fr/web/api/element/wheel_event/index.md
@@ -13,7 +13,7 @@ original_slug: Web/API/GlobalEventHandlers/onwheel
 
 {{ ApiRef("DOM") }}
 
-La propriété `onwheel` renvoie le code du gestionnaire d'évènements `onwheel` de l'élément courrant.
+La propriété `onwheel` renvoie le code du gestionnaire d'évènements `onwheel` de l'élément courant.
 
 ## Syntaxe
 


### PR DESCRIPTION
### Description
Suppression d'une lettre (`r`) dans le mot `courant`. (`courrant` -> `courant`).
Page : https://developer.mozilla.org/fr/docs/Web/API/Element/wheel_event 
