### PR TITLE
Error in end of sentence

### DIFF
--- a/files/fr/learn/accessibility/multimedia/index.md
+++ b/files/fr/learn/accessibility/multimedia/index.md
@@ -248,7 +248,7 @@ Nous avons également créé un exemple avancé pour montrer comment créer un s
 
 ## Transcriptions audio
 
-Pour permettre aux sourds d'accéder au contenu audio, vous devez créer des transcriptions de texte. Ceux-ci peuvent être soit inclus sur la même page que l'audio d'une manière ou d'une autre, soit inclus sur une page séparée et liés à.
+Pour permettre aux sourds d'accéder au contenu audio, vous devez créer des transcriptions de texte. Ceux-ci peuvent être soit inclus sur la même page que l'audio d'une manière ou d'une autre, soit inclus sur une page séparée et liée à la page principale.
 
 En termes de création de la transcription, vos options sont les suivantes:
 


### PR DESCRIPTION
The sentence ends with "à", which is not normal.

### Description

complete the sentence to make sense of it, because the end of the sentence has been mistranslated

### Motivation

These changes will ensure that the reference at the end of the sentence is not misunderstood

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
