### PR TITLE
fix(ja): fix typo in Element.previousElementSibling

### DIFF
--- a/files/ja/web/api/element/previouselementsibling/index.md
+++ b/files/ja/web/api/element/previouselementsibling/index.md
@@ -36,7 +36,7 @@ element = el.previousElementSibling;
 </script>
 ```
 
-この例は読み込み時に、ぺ0時に以下のような出力を行います。
+この例は読み込み時に、ページに以下のような出力を行います。
 
 ```
 Siblings of div-03


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

`Element.previousElementSibling` 内の誤字を修正しました

https://developer.mozilla.org/en-US/docs/Web/API/Element/previousElementSibling

原文：

> This example outputs the following into the page when it loads:

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
N/A
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
N/A
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
N/A
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
