### PR TITLE
feat: translate window/innerwidth in ko (latest)

### DIFF
--- a/files/ko/web/api/window/innerwidth/index.md
+++ b/files/ko/web/api/window/innerwidth/index.md
@@ -4,45 +4,71 @@ slug: Web/API/Window/innerWidth
 ---
 
 {{APIRef}}
-브라우저 윈도우의 뷰포트 너비로, 수직 스크롤바가 존재한다면 포함합니다.
 
-## 구문
+읽기 전용인 {{domxref("Window")}} 속성 **`innerWidth`** 은 픽셀로 창 내부의 너비를 반환합니다. 하나가 존재하는 경우, 수직 스크롤 막대의 너비를 포함합니다.
 
-```js
-var intViewportWidth = window.innerWidth;
-```
+더 정확하게는, `innerWidth`은 창의 {{Glossary("layout viewport")}}의 너비를 반환합니다. 창 내부의 높이, 레이아웃 뷰포트의 높이는 {{domxref("Window.innerHeight", "innerHeight")}} 속성으로부터 얻을 수 있습니다.
 
-### Value
+## 값
 
-**_intViewportWidth_** stores the `window.innerWidth` property value.
+창의 레이아웃 뷰포트 너비를 픽셀로 나타낸 정수 값입니다. 속성은 읽기 전용이며, 기본 값이 없습니다.
 
-The `window.innerWidth` property is read only; it has no default value.
+창의 너비를 변경하려면, {{domxref("Window.resizeBy", "resizeBy()")}}나 {{domxref("Window.resizeTo", "resizeTo()")}}와 같은 크기를 조정하는 메서드 중 하나를 사용해야합니다.
 
-## 참고
+## 사용 일람
 
-innerWidth 값은 window, frame, frameset이나 다른 윈도우들처럼 모든 window 형식의 객체에서 사용할 수 있습니다.
+스크롤 막대와 테두리를 제외한 창의 너비를 구하려면, 루트 {{HTMLElement("html")}} 요소의 {{domxref("Element.clientWidth", "clientWidth")}} 속성을 대신 사용하십시오.
 
-There is [an algorithm](https://bugzilla.mozilla.org/show_bug.cgi?id=189112#c7) to obtain the width of the viewport excluding, if rendered, the vertical scrollbar.
+`innerWidth` 속성은 탭이나 프레임같은 창처럼 행동하는 모든 창이나 모든 객체에서 사용할 수 있습니다.
 
 ## 예제
 
 ```js
-// 다음과 같이 뷰포트의 폭을 받아올 수 있습니다.
-var intFrameWidth = window.innerWidth;
+// 뷰포트의 너비를 기록합니다.
+console.log(window.innerWidth);
 
-// 다음과 같이 frameset 안의 어떤 frame의 뷰포트 폭을 받아올 수 있습니다.
-var intFrameWidth = self.innerWidth;
+// 프레임셋 내의 프레임 뷰포트의 너비를 기록합니다.
+console.log(self.innerWidth);
 
-// 다음과 같이 가장 가까운 frameset의 뷰포트 폭을 받아올 수 있습니다.
-var intFramesetWidth = parent.innerWidth;
+// 가장 가까운 프레임셋의 뷰포트의 너비를 기록합니다.
+console.log(parent.innerWidth);
 
-// 다음과 같이 가장 바깥쪽 프레임셋의 뷰포트 폭을 받아올 수 있습니다.
-var intOuterFramesetWidth = top.innerWidth;
+// 가장 먼 프레임셋의 뷰포트의 너비를 기록합니다.
+console.log(top.innerWidth);
 ```
 
-윈도우의 사이즈를 변경하려면, {{domxref("window.resizeBy")}} 또는 {{domxref("window.resizeTo")}}를 참조하세요.
+## 데모
 
-## 명세
+### HTML
+
+```html
+<p>Resize the browser window to fire the <code>resize</code> event.</p>
+<p>Window height: <span id="height"></span></p>
+<p>Window width: <span id="width"></span></p>
+```
+
+### JavaScript
+
+```js
+const heightOutput = document.querySelector("#height");
+const widthOutput = document.querySelector("#width");
+
+function updateSize() {
+  heightOutput.textContent = window.innerHeight;
+  widthOutput.textContent = window.innerWidth;
+}
+
+updateSize();
+window.addEventListener("resize", updateSize);
+```
+
+### 결과
+
+{{EmbedLiveSample('Demo')}}
+
+당신은 또한 {{LiveSampleLink('Demo', 'view the results of the demo code in a separate page')}}에 방문하여 데모 코드 결과를 볼 수 있습니다.
+
+## 명세서
 
 {{Specifications}}
 
@@ -50,7 +76,7 @@ var intOuterFramesetWidth = top.innerWidth;
 
 {{Compat}}
 
-## 참고 자료
+## 같이 보기
 
 - {{domxref("window.outerWidth")}}
 - {{domxref("window.innerHeight")}}

--- a/files/ko/web/api/window/innerwidth/index.md
+++ b/files/ko/web/api/window/innerwidth/index.md
@@ -66,7 +66,7 @@ window.addEventListener("resize", updateSize);
 
 {{EmbedLiveSample('Demo')}}
 
-당신은 또한 {{LiveSampleLink('Demo', 'view the results of the demo code in a separate page')}}에 방문하여 데모 코드 결과를 볼 수 있습니다.
+당신은 또한 {{LiveSampleLink('Demo', '별도의 페이지에서 데모 코드의 결과를 볼 수 있습니다')}}.
 
 ## 명세서
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

translate web/api/window/innerwidth in korean latest version

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

[Window/innerWidth(en-US)](https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth) and [Window/innerWidth(ko)](https://developer.mozilla.org/ko/docs/Web/API/Window/innerWidth) don't match.
cause of korean doc is previous version, so i translated it latest version

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
