### PR TITLE
Sync Access-Control-Expose-Headers Doc

### DIFF
--- a/files/zh-cn/web/http/headers/access-control-expose-headers/index.md
+++ b/files/zh-cn/web/http/headers/access-control-expose-headers/index.md
@@ -52,13 +52,13 @@ Access-Control-Expose-Headers: Content-Encoding
 Access-Control-Expose-Headers: Content-Encoding, Kuma-Revision
 ```
 
-有凭证信息的请求，可以指定一个配置符：
+有凭证信息的请求，可以指定一个通配符：
 
 ```plain
 Access-Control-Expose-Headers: *
 ```
 
-但是，”*“ 对 [Authorization 头](/zh-CN/docs/Web/HTTP/Headers/Authorization) 不生效，需要显式指定：
+但是，“*” 对 [Authorization 头](/zh-CN/docs/Web/HTTP/Headers/Authorization) 不生效，需要显式指定：
 
 ```plain
 Access-Control-Expose-Headers: *, Authorization
@@ -73,7 +73,7 @@ Access-Control-Expose-Headers: *, Authorization
 {{Compat}}
 
 
-## 相关内容
+## 参见
 
 - {{HTTPHeader("Access-Control-Allow-Headers")}}
 - {{HTTPHeader("Access-Control-Allow-Origin")}}

--- a/files/zh-cn/web/http/headers/access-control-expose-headers/index.md
+++ b/files/zh-cn/web/http/headers/access-control-expose-headers/index.md
@@ -26,7 +26,8 @@ slug: Web/HTTP/Headers/Access-Control-Expose-Headers
 ## 语法
 
 ```plain
-Access-Control-Expose-Headers: <header-name>, <header-name>, ...
+Access-Control-Expose-Headers: [<header-name>[, <header-name>]*]
+Access-Control-Expose-Headers: *
 ```
 
 ## 指令
@@ -34,18 +35,33 @@ Access-Control-Expose-Headers: <header-name>, <header-name>, ...
 - \<header-name>
   - : 包含 0 个或多个除 {{Glossary("Simple response header", "simple response headers")}}（简单响应首部）之外的[首部名称](/zh-CN/docs/Web/HTTP/Headers)列表，可以暴露给外部，供页面资源使用。
 
+- \*（通配符）
+  - : 若请求没有 [HTTP Cookie](/zh-CN/docs/Web/HTTP/Cookies)或认证信息，通配符 ”*“ 会暴露所有响应头部。对于有凭证信息的请求，会被简单地识别为头部名 ”*“，没有通配的语义。
+
 ## 示例
 
 想要暴露一个非简单响应首部，可以这样指定：
 
 ```plain
-Access-Control-Expose-Headers: Content-Length
+Access-Control-Expose-Headers: Content-Encoding
 ```
 
-想要额外暴露自定义的首部，例如 `X-Kuma-Revision`，可以指定多个，用逗号隔开：
+想要额外暴露自定义的首部，例如 `Kuma-Revision`，可以指定多个，用逗号隔开：
 
 ```plain
-Access-Control-Expose-Headers: Content-Length, X-Kuma-Revision
+Access-Control-Expose-Headers: Content-Encoding, Kuma-Revision
+```
+
+有凭证信息的请求，可以指定一个配置符：
+
+```plain
+Access-Control-Expose-Headers: *
+```
+
+但是，”*“ 对 [Authorization 头](/zh-CN/docs/Web/HTTP/Headers/Authorization) 不生效，需要显式指定：
+
+```plain
+Access-Control-Expose-Headers: *, Authorization
 ```
 
 ## 规范
@@ -56,13 +72,6 @@ Access-Control-Expose-Headers: Content-Length, X-Kuma-Revision
 
 {{Compat}}
 
-## 关于兼容性的注意事项
-
-- 在最新规范中提出的通配符 (\*)，尚未被如下浏览器实现：
-
-  - Chromium: [Issue 615313](https://bugs.chromium.org/p/chromium/issues/detail?id=615313)
-  - Firefox: {{bug(1309358)}}
-  - Servo: [Issue 13283](https://github.com/servo/servo/issues/13283)
 
 ## 相关内容
 

--- a/files/zh-cn/web/http/headers/access-control-expose-headers/index.md
+++ b/files/zh-cn/web/http/headers/access-control-expose-headers/index.md
@@ -5,23 +5,22 @@ slug: Web/HTTP/Headers/Access-Control-Expose-Headers
 
 {{HTTPSidebar}}
 
-响应首部 **`Access-Control-Expose-Headers`** 列出了哪些首部可以作为响应的一部分暴露给外部。
+响应标头 **`Access-Control-Expose-Headers`** 允许服务器指示那些响应标头可以暴露给浏览器中运行的脚本，以响应跨源请求。
 
-默认情况下，只有七种 {{Glossary("Simple response header", "simple response headers")}}（简单响应首部）可以暴露给外部：
+默认情况下，仅暴露 {{Glossary("CORS-safelisted response header", "CORS 安全列表的响应标头")}}。如果想要让客户端可以访问到其它的标头，服务器必须将它们在 `Access-Control-Expose-Headers` 里面列出来。
 
-- {{HTTPHeader("Cache-Control")}}
-- {{HTTPHeader("Content-Language")}}
-- {{HTTPHeader("Content-Length")}}
-- {{HTTPHeader("Content-Type")}}
-- {{HTTPHeader("Expires")}}
-- {{HTTPHeader("Last-Modified")}}
-- {{HTTPHeader("Pragma")}}
-
-如果想要让客户端可以访问到其他的首部信息，可以将它们在 `Access-Control-Expose-Headers` 里面列出来。
-
-| Header type                                      | {{Glossary("Response header")}} |
-| ------------------------------------------------ | ---------------------------------------- |
-| {{Glossary("Forbidden header name")}} | no                                       |
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">标头类型</th>
+      <td>{{Glossary("Response header", "响应标头")}}</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Forbidden header name", "禁止修改的标头")}}</th>
+      <td>否</td>
+    </tr>
+  </tbody>
+</table>
 
 ## 语法
 
@@ -33,8 +32,7 @@ Access-Control-Expose-Headers: *
 ## 指令
 
 - \<header-name>
-  - : 包含 0 个或多个除{{Glossary("Simple response header", "简单响应标头")}}之外的[标头名称](/zh-CN/docs/Web/HTTP/Headers)列表，可以暴露给外部，供页面资源使用。
-
+  - : 允许客户端从响应中访问的 0 个或多个使用逗号分隔的[标头名称](/zh-CN/docs/Web/HTTP/Headers)列表。这些标头是对 {{Glossary("CORS-safelisted response header", "CORS 安全列表的响应标头")}}的*补充*。
 - `*`（通配符）
   - : 若请求没有携带凭据（请求没有 [HTTP Cookie](/zh-CN/docs/Web/HTTP/Cookies)或认证信息），“`*`”才会被当作一个特殊的通配符。对于带有凭据的请求，会被简单地当作标头名称“`*`”，没有特殊的语义。
 
@@ -46,7 +44,7 @@ Access-Control-Expose-Headers: *
 Access-Control-Expose-Headers: Content-Encoding
 ```
 
-想要额外暴露自定义的首部，例如 `Kuma-Revision`，可以指定多个，用逗号隔开：
+想要额外暴露自定义的标头，例如 `Kuma-Revision`，可以指定多个，用逗号隔开：
 
 ```http
 Access-Control-Expose-Headers: Content-Encoding, Kuma-Revision

--- a/files/zh-cn/web/http/headers/access-control-expose-headers/index.md
+++ b/files/zh-cn/web/http/headers/access-control-expose-headers/index.md
@@ -25,7 +25,7 @@ slug: Web/HTTP/Headers/Access-Control-Expose-Headers
 
 ## 语法
 
-```plain
+```http
 Access-Control-Expose-Headers: [<header-name>[, <header-name>]*]
 Access-Control-Expose-Headers: *
 ```
@@ -33,34 +33,34 @@ Access-Control-Expose-Headers: *
 ## 指令
 
 - \<header-name>
-  - : 包含 0 个或多个除 {{Glossary("Simple response header", "simple response headers")}}（简单响应首部）之外的[首部名称](/zh-CN/docs/Web/HTTP/Headers)列表，可以暴露给外部，供页面资源使用。
+  - : 包含 0 个或多个除{{Glossary("Simple response header", "简单响应标头")}}之外的[标头名称](/zh-CN/docs/Web/HTTP/Headers)列表，可以暴露给外部，供页面资源使用。
 
-- \*（通配符）
-  - : 若请求没有 [HTTP Cookie](/zh-CN/docs/Web/HTTP/Cookies)或认证信息，通配符 ”*“ 会暴露所有响应头部。对于有凭证信息的请求，会被简单地识别为头部名 ”*“，没有通配的语义。
+- `*`（通配符）
+  - : 若请求没有携带凭据（请求没有 [HTTP Cookie](/zh-CN/docs/Web/HTTP/Cookies)或认证信息），“`*`”才会被当作一个特殊的通配符。对于带有凭据的请求，会被简单地当作标头名称“`*`”，没有特殊的语义。
 
 ## 示例
 
-想要暴露一个非简单响应首部，可以这样指定：
+想要暴露一个非简单响应标头，可以这样指定：
 
-```plain
+```http
 Access-Control-Expose-Headers: Content-Encoding
 ```
 
 想要额外暴露自定义的首部，例如 `Kuma-Revision`，可以指定多个，用逗号隔开：
 
-```plain
+```http
 Access-Control-Expose-Headers: Content-Encoding, Kuma-Revision
 ```
 
-有凭证信息的请求，可以指定一个通配符：
+服务器可以为不带凭据的请求响应通配符：
 
-```plain
+```http
 Access-Control-Expose-Headers: *
 ```
 
-但是，“*” 对 [Authorization 头](/zh-CN/docs/Web/HTTP/Headers/Authorization) 不生效，需要显式指定：
+但是，这并不会匹配 {{HTTPHeader("Authorization")}} 标头，所以如果你要暴露它，需要显式指定：
 
-```plain
+```http
 Access-Control-Expose-Headers: *, Authorization
 ```
 
@@ -71,7 +71,6 @@ Access-Control-Expose-Headers: *, Authorization
 ## 浏览器兼容性
 
 {{Compat}}
-
 
 ## 参见
 


### PR DESCRIPTION
sync with english version for  [Access-Control-Expose-Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers) into Chinese
