### PR TITLE
Fix: Image not showing 

### DIFF
--- a/files/ru/web/css/css_positioning/understanding_z_index/the_stacking_context/index.md
+++ b/files/ru/web/css/css_positioning/understanding_z_index/the_stacking_context/index.md
@@ -38,7 +38,7 @@ translation_of: Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_conte
 
 ## Пример
 
-![Example of stacking rules modified using z-index](/@api/deki/files/913/=Understanding_zindex_04.png)
+![Example of stacking rules modified using z-index](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context/understanding_zindex_04.png)
 
 В примере каждый позиционированный элемент создаёт свой контекст наложения, так как имеет свойства position и z-index. Иерархия контекстов наложения выглядит следующим образом:
 


### PR DESCRIPTION
Image not showing in "Контекст наложения (stacking context)"

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Image was not showing in "Контекст наложения (stacking context)" in ru, it is working well in en-US. I use en-US img https://developer.mozilla.org/en-US/docs/Web/CSS/C…/The_stacking_context/understanding_zindex_04.png
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Fixes #8671
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
