### PR TITLE
fix: markdown bold rule invalid

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/symbol/hasinstance/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/symbol/hasinstance/index.md
@@ -5,7 +5,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance
 
 {{JSRef}}
 
-**`Symbol.hasInstance`**用于判断某对象是否为某构造器的实例。因此你可以用它自定义 {{jsxref("Operators/instanceof", "instanceof")}} 操作符在某个类上的行为。
+**`Symbol.hasInstance`** 用于判断某对象是否为某构造器的实例。因此你可以用它自定义 {{jsxref("Operators/instanceof", "instanceof")}} 操作符在某个类上的行为。
 
 {{EmbedInteractiveExample("pages/js/symbol-hasinstance.html")}}{{js_property_attributes(0,0,0)}}
 


### PR DESCRIPTION
### Description
**`Symbol.hasInstance`**xxx
As you can see，the above markdown rules are invalid，Because there is no space after `**`

### Motivation
**`Symbol.hasInstance`** xxx
To make it effective, just add a space after `**`
