### PR TITLE
[ko] remove mediawiki.external macro

### DIFF
--- a/files/ko/mozilla/firefox/releases/3/index.md
+++ b/files/ko/mozilla/firefox/releases/3/index.md
@@ -162,7 +162,7 @@ If you're a developer trying to get a handle on all the new features in Firefox 
 - **Web-based protocol handlers.** Web applications, such as your favorite web mail provider, can now be used instead of desktop applications for handling `mailto:` links from other sites. Similar support is provided for other protocols as well. (Note that web applications do have to register themselves with Firefox before this will work.)
 - **Easy to use Download Actions.** A new Applications preferences pane provides an improved user interface for configuring handlers for various file types and protocol schemes.
 - **Improved look and feel.** Graphics and font handling have been improved to make web sites look better on your screen, including sharper text rendering and better support for fonts with ligatures and complex scripts. In addition, Mac and Linux (Gnome) users will find that Firefox feels more like a native application for their platform than ever, with a new, native, look and feel.
-- **Color management support.** By setting the `gfx.color_management.enabled` preference in `{{mediawiki.external('about:config')}}`, you can ask Firefox to use the color profiles embedded in images to adjust the colors to match your computer's display.
+- **Color management support.** By setting the `gfx.color_management.enabled` preference in `about:config`, you can ask Firefox to use the color profiles embedded in images to adjust the colors to match your computer's display.
 - **Offline support.** Web applications can take advantage of new features to support being used even when you don't have an Internet connection.
 
 ### Security and privacy

--- a/files/ko/web/api/node/childnodes/index.md
+++ b/files/ko/web/api/node/childnodes/index.md
@@ -3,7 +3,7 @@ title: element.childNodes
 slug: Web/API/Node/childNodes
 ---
 
-{{ ApiRef() }}
+{{APIRef("DOM")}}
 
 ## 요약
 
@@ -45,12 +45,6 @@ while (box.firstChild)
   };
 ```
 
-## 주의
-
-노드 모음의 항목은 문자열이 아니라 개체입니다. 그 노드 개체에서 데이터를 얻으려면, 속성(예컨대 이름을 얻으려면 `elementNodeReference.childNodes{{ mediawiki.external(1) }}.nodeName` 등)을 써야 합니다.
-
-`document` 개체는 자식이 둘입니다. Doctype 선언과 `HTML` 요소.
-
 ## 명세
 
 {{Specifications}}
@@ -58,3 +52,11 @@ while (box.firstChild)
 ## 브라우저 호환성
 
 {{Compat}}
+
+## 같이 보기
+
+- {{domxref("Node.firstChild")}}
+- {{domxref("Node.lastChild")}}
+- {{domxref("Node.nextSibling")}}
+- {{domxref("Node.previousSibling")}}
+- {{domxref("Element.children")}}


### PR DESCRIPTION
### Description

미지원 mediawiki.external macro 제거

### Related issues and pull requests

https://github.com/orgs/mdn/discussions/263#discussioncomment-4743530
