### PR TITLE
fixed incorrect reference links

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/array/find/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/array/find/index.md
@@ -10,7 +10,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Array/find
 {{EmbedInteractiveExample("pages/js/array-find.html")}}
 
 - 如果需要在数组中找到对应元素的索引，请使用 {{jsxref("Array.findIndex", "findIndex()")}}。
-- 如果需要查找某个值的索引，请使用 {{jsxref("Array.prototype.indexOf()")}}。（它类似于 {{jsxref("Array.prototype.indexOf()")}}，但只是检查每个元素是否与值相等，而不是使用测试函数。）
+- 如果需要查找某个值的索引，请使用 {{jsxref("Array.prototype.indexOf()")}}。（它类似于 {{jsxref("Array/findIndex", "findIndex()")}}，但只是检查每个元素是否与值相等，而不是使用测试函数。）
 - 如果需要查找数组中是否存在值，请使用 {{jsxref("Array.prototype.includes()")}}。同样，它检查每个元素是否与值相等，而不是使用测试函数。
 - 如果需要查找是否有元素满足所提供的测试函数，请使用 {{jsxref("Array.prototype.some()")}}。
 


### PR DESCRIPTION
Change "...类似于 Array.prototype.indexOf()，但只是..." to "...类似于 Array.prototype.findIndex()，但只是..."

This is a very obvious problem caused by carelessness (in the translation process), and in the English document (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find) it is "...similar to findIndex(), but...".

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
