### PR TITLE
fix: numComponents

### DIFF
--- a/files/zh-cn/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
+++ b/files/zh-cn/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
@@ -239,7 +239,7 @@ function drawScene(gl, programInfo, buffers) {
   // Tell WebGL how to pull out the positions from the position
   // buffer into the vertexPosition attribute.
   {
-    const numComponents = 3;  // pull out 3 values per iteration
+    const numComponents = 2;  // pull out 2 values per iteration
     const type = gl.FLOAT;    // the data in the buffer is 32bit floats
     const normalize = false;  // don't normalize
     const stride = 0;         // how many bytes to get from one set of values to the next


### PR DESCRIPTION
### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
For this 2d vertex buffer, the numComponents value should be 2.

### Motivation
When I was learning and testing my code with the guide on this page, I found it didn't work.
After comparing it with the source of [demo page](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample3/), I noticed that the value of numComponents is different. It works well when the variable equals 2.
