### PR TITLE
fix (scrollto): [es] typofixes

### DIFF
--- a/files/es/web/api/window/scrollto/index.md
+++ b/files/es/web/api/window/scrollto/index.md
@@ -7,7 +7,7 @@ slug: Web/API/Window/scrollTo
 
 ## Resumen
 
-Desplaza el visor a un conjunto específico de coodenadas en el documento.
+Desplaza el visor a un conjunto específico de coordenadas en el documento.
 
 ## Sintaxis
 


### PR DESCRIPTION
### Description

* 'coodenadas' instead of 'coordenadas'.
