### PR TITLE
[ko] Gecko 매크로 삭제

### DIFF
--- a/files/ko/web/api/document/cookie/index.md
+++ b/files/ko/web/api/document/cookie/index.md
@@ -28,7 +28,7 @@ In the code above, `newCookie` is a string of form `key=value`. Note that you ca
 
   - `;path=path` (e.g., '`/`', '`/mydir`') If not specified, defaults to the current path of the current document location.
 
-    > **참고:** Prior to {{Gecko("6.0")}}, paths with quotes were treated as if the quotes were part of the string, instead of as if they were delimiters surrounding the actual path string. This has been fixed.
+    > **참고:** Prior to Gecko, paths with quotes were treated as if the quotes were part of the string, instead of as if they were delimiters surrounding the actual path string. This has been fixed.
 
   - `;domain=domain` (e.g., '`example.com`' or '`subdomain.example.com`'). If not specified, this defaults to the host portion of the current document location. Contrary to earlier specifications, leading dots in domain names are ignored, but browsers may decline to set the cookie containing such dots. If a domain is specified, subdomains are always included.
 

--- a/files/ko/web/api/document/cookie/index.md
+++ b/files/ko/web/api/document/cookie/index.md
@@ -28,7 +28,7 @@ In the code above, `newCookie` is a string of form `key=value`. Note that you ca
 
   - `;path=path` (e.g., '`/`', '`/mydir`') If not specified, defaults to the current path of the current document location.
 
-    > **참고:** Prior to Gecko, paths with quotes were treated as if the quotes were part of the string, instead of as if they were delimiters surrounding the actual path string. This has been fixed.
+    > **참고:** Prior to Gecko 6.0, paths with quotes were treated as if the quotes were part of the string, instead of as if they were delimiters surrounding the actual path string. This has been fixed.
 
   - `;domain=domain` (e.g., '`example.com`' or '`subdomain.example.com`'). If not specified, this defaults to the host portion of the current document location. Contrary to earlier specifications, leading dots in domain names are ignored, but browsers may decline to set the cookie containing such dots. If a domain is specified, subdomains are always included.
 

--- a/files/ko/web/api/window/status/index.md
+++ b/files/ko/web/api/window/status/index.md
@@ -10,7 +10,7 @@ slug: Web/API/Window/status
 
 이 프로퍼티는 파이어폭스나 기타 브라우저의 기본 설정값에서는 동작하지 않는다. window\.status를 변경한다고 하더라도 상태 표시줄의 메시지에 출력되지 않을 것이다. 상태바 텍스트를 변경할 수 있게 하려면 유저가 about:config 창에서 dom.disable_window_status_change 를 허용해 주어야 한다.(인터넷 익스플로러의 경우 \[인터넷 옵션 - 보안 - 사용자 지정 수준 - 스크립트를 통해 상태 표시줄 업데이트 허용]을 '사용'으로 바꾸어야 한다.)
 
-> **참고:** Starting in Gecko, users can let websites change the status text by enabling the "Change status bar" preference in the Advanced options panel.
+> **참고:** Starting in Gecko 1.9.1, users can let websites change the status text by enabling the "Change status bar" preference in the Advanced options panel.
 
 ## 문법
 

--- a/files/ko/web/api/window/status/index.md
+++ b/files/ko/web/api/window/status/index.md
@@ -10,7 +10,7 @@ slug: Web/API/Window/status
 
 이 프로퍼티는 파이어폭스나 기타 브라우저의 기본 설정값에서는 동작하지 않는다. window\.status를 변경한다고 하더라도 상태 표시줄의 메시지에 출력되지 않을 것이다. 상태바 텍스트를 변경할 수 있게 하려면 유저가 about:config 창에서 dom.disable_window_status_change 를 허용해 주어야 한다.(인터넷 익스플로러의 경우 \[인터넷 옵션 - 보안 - 사용자 지정 수준 - 스크립트를 통해 상태 표시줄 업데이트 허용]을 '사용'으로 바꾸어야 한다.)
 
-> **참고:** Starting in {{Gecko("1.9.1")}}, users can let websites change the status text by enabling the "Change status bar" preference in the Advanced options panel.
+> **참고:** Starting in Gecko, users can let websites change the status text by enabling the "Change status bar" preference in the Advanced options panel.
 
 ## 문법
 

--- a/files/ko/web/api/xmlhttprequest/synchronous_and_asynchronous_requests/index.md
+++ b/files/ko/web/api/xmlhttprequest/synchronous_and_asynchronous_requests/index.md
@@ -126,7 +126,7 @@ loadFile("message.txt", 2000, showMessage, "New message!\n");
 
 Here, we're specifying a timeout of 2000 ms.
 
-> **참고:** Support for `timeout` was added in Gecko.
+> **참고:** Support for `timeout` was added in Gecko 12.0.
 
 ## Synchronous request
 

--- a/files/ko/web/api/xmlhttprequest/synchronous_and_asynchronous_requests/index.md
+++ b/files/ko/web/api/xmlhttprequest/synchronous_and_asynchronous_requests/index.md
@@ -126,7 +126,7 @@ loadFile("message.txt", 2000, showMessage, "New message!\n");
 
 Here, we're specifying a timeout of 2000 ms.
 
-> **참고:** Support for `timeout` was added in {{Gecko("12.0")}}.
+> **참고:** Support for `timeout` was added in Gecko.
 
 ## Synchronous request
 


### PR DESCRIPTION
### Description

- remove {{gecko}} macro from translated-content
- {{gecko}} 매크로를 Gecko로 변경

### Related issues and pull requests

Part of: #11284
