### PR TITLE
HTML tabld documentation (French) - Fix example and typos

### DIFF
--- a/files/fr/learn/html/tables/advanced/index.md
+++ b/files/fr/learn/html/tables/advanced/index.md
@@ -282,7 +282,7 @@ Voici la sortie qui en résulte :
 
 ## Tableaux pour utilisateurs malvoyants
 
-Rappelons brièvement comment nous utilisons les tableaux de données. Un tableau peut être un outil pratique pour accéder rapidement à une donnée et rechercher différentes valeurs. Par exemple, un bref coup d'oeil sur le tableau suivant suffit pour savoir combien de bagues ont été vendues à Gand en août dernier. Pour comprendre ces informations, nous faisons visuellement l'association entre les données du tableau et les en-têtes de colonnes et/ou de lignes.
+Rappelons brièvement comment nous utilisons les tableaux de données. Un tableau peut être un outil pratique pour accéder rapidement à une donnée et rechercher différentes valeurs. Par exemple, un bref coup d'œil sur le tableau suivant suffit pour savoir combien de bagues ont été vendues à Gand en août dernier. Pour comprendre ces informations, nous faisons visuellement l'association entre les données du tableau et les en-têtes de colonnes et/ou de lignes.
 
 <table>
   <caption>
@@ -330,7 +330,7 @@ Rappelons brièvement comment nous utilisons les tableaux de données. Un tablea
       <td>28</td>
     </tr>
     <tr>
-      <th rowspan="2" scope="rowgroup">Pays-bas</th>
+      <th rowspan="2" scope="rowgroup">Pays-Bas</th>
       <th scope="row">Amsterdam</th>
       <td>89</td>
       <td>34</td>
@@ -349,7 +349,7 @@ Rappelons brièvement comment nous utilisons les tableaux de données. Un tablea
   </tbody>
 </table>
 
-Mais que faire si vous ne pouvez pas créer ces associations visuelles ? Comment pouvez-vous lire un tableau comme celui ci-dessus ? Les personnes malvoyantes utilisent souvent un lecteur d'écran qui leur lit les informations des pages web. Ce n'est pas un problème quand vous lisez du texte brut, mais l'interprêtation d'un tableau peut constituer un défi pour une personne aveugle. Néanmoins, avec le balisage approprié, nous pouvons remplacer des associations visuelles par des associations programmées.
+Mais que faire si vous ne pouvez pas créer ces associations visuelles ? Comment pouvez-vous lire un tableau comme celui ci-dessus ? Les personnes malvoyantes utilisent souvent un lecteur d'écran qui leur lit les informations des pages web. Ce n'est pas un problème quand vous lisez du texte brut, mais l'interprétation d'un tableau peut constituer un défi pour une personne aveugle. Néanmoins, avec le balisage approprié, nous pouvons remplacer des associations visuelles par des associations programmées.
 
 > **Note :** Il y a environ 253 millions de personnes vivant avec des déficiences visuelles selon les [données de l'OMS en 2017](http://www.who.int/mediacentre/factsheets/fs282/fr/).
 
@@ -357,13 +357,13 @@ Cette partie de l'article indique des techniques avancées pour rendre les table
 
 ### Utilisation des en-têtes de colonnes et de lignes
 
-Les lecteurs d'écran identifieront tous les en-têtes et les utiliseront pour réaliser automatiquement les associations entre ces en-têtes et les cellules correspondantes. La combinaison des en-têtes des colonnes et des lignes doit permettre d'identifier et d'interprêter les données de chaque cellule. Ainsi, les utilisateurs de lecteurs d'écran peuvent accéder aux données d'une façon similaire à celle des utilisateurs voyants.
+Les lecteurs d'écran identifieront tous les en-têtes et les utiliseront pour réaliser automatiquement les associations entre ces en-têtes et les cellules correspondantes. La combinaison des en-têtes des colonnes et des lignes doit permettre d'identifier et d'interpréter les données de chaque cellule. Ainsi, les utilisateurs de lecteurs d'écran peuvent accéder aux données d'une façon similaire à celle des utilisateurs voyants.
 
 Nous avons déjà traité des en-têtes dans notre article précédent — voir [Ajouter des en-têtes avec \<th>](/fr/docs/Learn/HTML/Tables/Basics#Adding_headers_with_%3Cth%3E_elements) .
 
 ### L'attribut `scope`
 
-Aux balises `<th>`, sujet de l'article précédent, ajoutons l'attribut {{htmlattrxref("scope","th")}}. Il peut être mentionné dans un élément `<th>` pour indiquer précisément à un lecteur d'écran si la cellule contient un en-tête de colonne ou de ligne — par exemple, sommes‑nous dans un en-tête de ligne, ou de colonne ? En revenant à notre exemple d'enregistrement de dépenses vu plus tôt, il est possible de définir sans ambiguité un en-tête de colonne comme étant un en-tête de colonne ainsi&nbsp;:
+Aux balises `<th>`, sujet de l'article précédent, ajoutons l'attribut {{htmlattrxref("scope","th")}}. Il peut être mentionné dans un élément `<th>` pour indiquer précisément à un lecteur d'écran si la cellule contient un en-tête de colonne ou de ligne — par exemple, sommes‑nous dans un en-tête de ligne, ou de colonne ? En revenant à notre exemple d'enregistrement de dépenses vu plus tôt, il est possible de définir sans ambiguïté un en-tête de colonne comme étant un en-tête de colonne ainsi&nbsp;:
 
 ```html
 <thead>
@@ -391,7 +391,7 @@ Et chaque ligne pourrait également avoir une définition de son en-tête comme 
 
 Les lecteurs d'écran reconnaîtront un balisage structuré comme celui-ci et permettront à leurs utilisateurs de lire en une fois une colonne ou une ligne entière par exemple.
 
-`scope` a deux autres valeurs possibles — `colgroup` et `rowgroup`. Elles sont utilisées pour les en-têtes qui couvrent plusieurs colonnes ou lignes. Si vous revenez au tableau «&nbsp;Articles vendus...&nbsp;» au début de ce paragraphe du présent article, vous voyez que la cellule «&nbsp;Vêtements&nbsp;» se trouve au-dessus des cellules «&nbsp;Pantalons&nbsp;», «&nbsp;Jupes&nbsp;» et «&nbsp;Robes&nbsp;». Toutes ces cellules sont marquées comme en-têtes (`<th>`), mais «&nbsp;Vêtements&nbsp;» est un en-tête de niveau supérieur qui définit trois «&nbsp;sous-en-têtes&nbsp;». «&nbsp;Vêtements&nbsp;» comportera donc un attribut `scope="colgroup"`, alors que les autres doivent recevront un attribut `scope="col"`.
+`scope` a deux autres valeurs possibles — `colgroup` et `rowgroup`. Elles sont utilisées pour les en-têtes qui couvrent plusieurs colonnes ou lignes. Si vous revenez au tableau «&nbsp;Articles vendus...&nbsp;» au début de ce paragraphe du présent article, vous voyez que la cellule «&nbsp;Vêtements&nbsp;» se trouve au-dessus des cellules «&nbsp;Pantalons&nbsp;», «&nbsp;Jupes&nbsp;» et «&nbsp;Robes&nbsp;». Toutes ces cellules sont marquées comme en-têtes (`<th>`), mais «&nbsp;Vêtements&nbsp;» est un en-tête de niveau supérieur qui définit trois «&nbsp;sous-en-têtes&nbsp;». «&nbsp;Vêtements&nbsp;» comportera donc un attribut `scope="colgroup"`, alors que les autres recevront un attribut `scope="col"`.
 
 ### Les attributs `id` et `headers`
 

--- a/files/fr/learn/html/tables/basics/index.md
+++ b/files/fr/learn/html/tables/basics/index.md
@@ -62,9 +62,9 @@ L'avantage du tableau tient dans sa rigueur. L'information est facilement interp
 
 <table>
   <caption>
-    Données sur les planètes du système solaire (repris de
+    Données sur les planètes du système solaire (repris de la
     <a href="http://nssdc.gsfc.nasa.gov/planetary/factsheet/"
-      >Nasa's Planetary Fact Sheet - Metric</a
+      >Planetary Fact Sheet - Metric de la NASA</a
     >).
   </caption>
   <thead>
@@ -75,7 +75,7 @@ L'avantage du tableau tient dans sa rigueur. L'information est facilement interp
       <th scope="col">Diamètre (km)</th>
       <th scope="col">Densité (kg/m<sup>3</sup>)</th>
       <th scope="col">Gravité (m/s<sup>2</sup>)</th>
-      <th scope="col">Durée du jour (hours)</th>
+      <th scope="col">Durée du jour (heures)</th>
       <th scope="col">Distance du Soleil (10<sup>6</sup>km)</th>
       <th scope="col">Température moyenne (°C)</th>
       <th scope="col">Nombre de lunes</th>
@@ -195,7 +195,7 @@ L'avantage du tableau tient dans sa rigueur. L'information est facilement interp
       <td>-225</td>
       <td>5</td>
       <td>
-        Déclassée en tant que planète en 2006 mais décision controverséee.
+        Déclassée en tant que planète en 2006 mais décision controversée.
       </td>
     </tr>
   </tbody>
@@ -213,11 +213,11 @@ Nous n'approfondirons pas le CSS dans ce module, mais nous avons écrit une feui
 
 ### Quand NE PAS utiliser de tableaux en HTML ?
 
-Les tableaux HTML ne doivent être utilisés que pour des données tabulaires — c'est pour cela qu'ils sont conçus. Malheureusement, beaucoup de gens ont utilisé les tableaux HTML pour organiser des pages Web, par exemple : une ligne pour contenir l'en-tête, une ligne pour les colonnes de contenu, une ligne pour le pied de page, etc. Vous pouvez trouver plus de détails et un exemple avec [Mises en page](/fr/docs/Learn/Accessibility/HTML#Page_layouts) dans notre [Module d'apprentissage à l'Accessibilité](/fr/docs/Learn/Accessibility). Cette dispostion a été couramment utilisée car la prise en charge des CSS parmi les navigateurs avait pour coutume d'être effroyable ; ces mises en page sont beaucoup moins fréquentes de nos jours, mais vous pouvez toujours les voir dans certains recoins du Web.
+Les tableaux HTML ne doivent être utilisés que pour des données tabulaires — c'est pour cela qu'ils sont conçus. Malheureusement, beaucoup de gens ont utilisé les tableaux HTML pour organiser des pages Web, par exemple : une ligne pour contenir l'en-tête, une ligne pour les colonnes de contenu, une ligne pour le pied de page, etc. Vous pouvez trouver plus de détails et un exemple avec [Mises en page](/fr/docs/Learn/Accessibility/HTML#Page_layouts) dans notre [Module d'apprentissage à l'Accessibilité](/fr/docs/Learn/Accessibility). Cette disposition a été couramment utilisée car la prise en charge des CSS parmi les navigateurs avait pour coutume d'être effroyable ; ces mises en page sont beaucoup moins fréquentes de nos jours, mais vous pouvez toujours les voir dans certains recoins du Web.
 
 Bref, utiliser les tableaux pour la mise en page [au lieu des techniques des CSS](/fr/docs/Learn/CSS/CSS_layout) est une mauvaise idée. En voici les principales raisons&nbsp;:
 
-1. **Les tableaux de mise en page diminuent l'accessibilité aux malvoyants** : les [lecteurs d'écran](/fr/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Screenreaders), utilisés par les non-voyants, interprêtent les balises d'une page HTML et lisent à haute voix le contenu à l'utilisateur. Comme les tables ne sont pas le bon outil pour la mise en page et que le balisage est plus complexe qu'avec les techniques de mise en page des CSS, la sortie des lecteurs d'écran sera source de confusion pour leurs utilisateurs.
+1. **Les tableaux de mise en page diminuent l'accessibilité aux malvoyants** : les [lecteurs d'écran](/fr/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Screenreaders), utilisés par les non-voyants, interprètent les balises d'une page HTML et lisent à haute voix le contenu à l'utilisateur. Comme les tables ne sont pas le bon outil pour la mise en page et que le balisage est plus complexe qu'avec les techniques de mise en page des CSS, la sortie des lecteurs d'écran sera source de confusion pour leurs utilisateurs.
 2. **Les tables produisent de la bouillie :** Comme mentionné ci-dessus, les mises en page sur la base de tableaux comportent généralement des structures de balisage plus complexes que des techniques de mise en page appropriées. Le code résultant sera plus difficile à écrire, à maintenir et à déboguer.
 3. **Les tableaux ne s'adaptent pas automatiquement** : Si vous utilisez les propriétés de mise en page ({{htmlelement("header")}}, {{htmlelement("section")}}, {{htmlelement("article")}} ou {{htmlelement("div")}}), leur largeur est par défaut 100% de celle du parent. Par contre, les tableaux sont dimensionnés en fonction de leur contenu par défaut, de sorte que des mesures supplémentaires sont nécessaires pour que le style du tableau fonctionne effectivement sur les différents types d'écran.
 
@@ -312,12 +312,12 @@ Intéressons-nous maintenant aux en-têtes du tableau — cellules spéciales qu
     <td>Belle-mère</td>
     <td>Moi</td>
     <td>Moi</td>
-    <td>Belle-soeur</td>
+    <td>Belle-sœur</td>
   </tr>
   <tr>
     <td>Habitudes alimentaires</td>
     <td>Mange tous les restes</td>
-    <td>Grignotte la nourriture</td>
+    <td>Grignote la nourriture</td>
     <td>Mange copieusement</td>
     <td>Mange jusqu'à ce qu'il éclate</td>
   </tr>
@@ -354,12 +354,12 @@ Maintenant, le rendu du tableau réel :
       <td>Belle-mère</td>
       <td>Moi</td>
       <td>Moi</td>
-      <td>Belle-soeur</td>
+      <td>Belle-sœur</td>
     </tr>
     <tr>
       <td>Habitudes alimentaires</td>
       <td>Mange tous les restes</td>
-      <td>Grignotte la nourriture</td>
+      <td>Grignote la nourriture</td>
       <td>Mange copieusement</td>
       <td>Mange jusqu'à ce qu'il éclate</td>
     </tr>
@@ -412,7 +412,7 @@ Le code initial ressemble à cela :
   </tr>
   <tr>
     <th>Poulet</th>
-    <td>Coq</td>
+    <td>Poule</td>
   </tr>
   <tr>
     <td>Coq</td>
@@ -442,7 +442,7 @@ Mais le résultat ne nous donne pas ce que nous voulions :
     </tr>
     <tr>
       <th>Poulet</th>
-      <td>Coq</td>
+      <td>Poule</td>
     </tr>
     <tr>
       <td>Coq</td>
@@ -450,7 +450,7 @@ Mais le résultat ne nous donne pas ce que nous voulions :
   </tbody>
 </table>
 
-Nous avons besoin d'un moyen pour étendre "Animaux", "Hippopotame" et "Crocodile" sur deux colonnes, and "Cheval" et "Poulet" sur deux lignes. Heureusement, les en-têtes de tableau et les cellules ont les attributs `colspan` et `rowspan`, ce qui nous permet justement de faire cela. Les deux acceptent une valeur numérique correspondant au nombre de colonnes ou de lignes à couvrir. Par exemple, `colspan="2"` génère une cellule sur deux colonnes.
+Nous avons besoin d'un moyen pour étendre "Animaux", "Hippopotame" et "Crocodile" sur deux colonnes, et "Cheval" et "Poulet" sur deux lignes. Heureusement, les en-têtes de tableau et les cellules ont les attributs `colspan` et `rowspan`, ce qui nous permet justement de faire cela. Les deux acceptent une valeur numérique correspondant au nombre de colonnes ou de lignes à couvrir. Par exemple, `colspan="2"` génère une cellule sur deux colonnes.
 
 Utilisons `colspan` et `rowspan` pour améliorer ce tableau.
 
@@ -463,7 +463,7 @@ Utilisons `colspan` et `rowspan` pour améliorer ce tableau.
 
 ## Attribuer un style commun aux colonnes
 
-Il y a une dernière fonctionnalité dont nous devons parler dans cet article avant de passer à autre chose. HTML a une méthode de définition des styles pour une colonne entière de données en un seul endroit — les éléments **[`<col>`](/fr/docs/Web/HTML/Element/col)** and **[`<colgroup>`](/fr/docs/Web/HTML/Element/colgroup)**. Ils existent parce qu'il peut être ennuyeux et inefficace de préciser le style dans chaque colonne — vous devez généralement spécifier les éléments de style dans chaque `<td>` ou `<th>` de la colonne, ou utiliser un selecteur complexe tel que {{cssxref(":nth-child()")}}.
+Il y a une dernière fonctionnalité dont nous devons parler dans cet article avant de passer à autre chose. HTML a une méthode de définition des styles pour une colonne entière de données en un seul endroit — les éléments **[`<col>`](/fr/docs/Web/HTML/Element/col)** and **[`<colgroup>`](/fr/docs/Web/HTML/Element/colgroup)**. Ils existent parce qu'il peut être ennuyeux et inefficace de préciser le style dans chaque colonne — vous devez généralement spécifier les éléments de style dans chaque `<td>` ou `<th>` de la colonne, ou utiliser un sélecteur complexe tel que {{cssxref(":nth-child()")}}.
 
 ### Premier exemple
 

--- a/files/fr/learn/html/tables/structuring_planet_data/index.md
+++ b/files/fr/learn/html/tables/structuring_planet_data/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Revue : structurer les données des planètes"
+title: "Structurer les données des planètes"
 slug: Learn/HTML/Tables/Structuring_planet_data
 translation_of: Learn/HTML/Tables/Structuring_planet_data
 original_slug: Apprendre/HTML/Tableaux/Structuring_planet_data
@@ -46,7 +46,7 @@ Vous pouvez aussi [regarder l'exemple ici](https://mdn.github.io/learning-area/h
 
 ## Étapes à suivre
 
-Les étapes suivantes décrivent ce que vous devez faire pour complèter l'exemple de tableau. Toutes les données dont vous avez besoin sont contenues dans le fichier `planets-data.txt`. Si vous avez du mal à visualiser les données, regardez l'exemple donné dans le lien ci-dessus, ou essayez de dessiner un diagramme.
+Les étapes suivantes décrivent ce que vous devez faire pour compléter l'exemple de tableau. Toutes les données dont vous avez besoin sont contenues dans le fichier `planets-data.txt`. Si vous avez du mal à visualiser les données, regardez l'exemple donné dans le lien ci-dessus, ou essayez de dessiner un diagramme.
 
 1. Ouvrez votre copie de `blank-template.html`, et commencez le tableau en lui donnant un conteneur extérieur, un en-tête et un corps de tableau. Vous n'avez pas besoin d'un pied de tableau dans cet exemple.
 2. Ajoutez la légende fournie à votre tableau.
@@ -59,7 +59,7 @@ Les étapes suivantes décrivent ce que vous devez faire pour complèter l'exemp
 ## Conseils et astuces
 
 - La première cellule de la ligne d'en-tête doit être vierge et couvrir deux colonnes.
-- Les en-têtes regrouppant des lignes (_exemple : les planètes joviennes_) qui sont à gauche des en-têtes de lignes des noms des planètes (exemple : _Saturne_) sont un peu difficiles à trier — vous devez vous assurer que chacun d'eux couvre le bon nombre de lignes et colonnes.
+- Les en-têtes regroupant des lignes (_exemple : les planètes joviennes_) qui sont à gauche des en-têtes de lignes des noms des planètes (exemple : _Saturne_) sont un peu difficiles à trier — vous devez vous assurer que chacun d'eux couvre le bon nombre de lignes et colonnes.
 - une des méthodes d'association des en-têtes avec leurs lignes et colonnes est un peu plus facile que l'autre.
 
 ## Correction


### PR DESCRIPTION
### Description

On the page [Tableaux HTML : notions de base](https://developer.mozilla.org/fr/docs/Learn/HTML/Tables/Basics), the animals table example show two times "coq" (i.e. male) instead of once "coq" (male) and once "poule" (femelle).

While at it, I have fixed some typo in the pages related to HTML tables.


### Motivation

The example in the English page takes advantage that some animals have a specific name for male and another for female. This should also be the case in the translated example.

### Additional details

N/A

### Related issues and pull requests

None
