### PR TITLE
fr/web/api/performance/memory: Replace {{Non-standardGeneric}} call with {{Non-standard_Header}}

### DIFF
--- a/files/fr/web/api/performance/memory/index.md
+++ b/files/fr/web/api/performance/memory/index.md
@@ -10,7 +10,7 @@ translation_of: Web/API/Performance/memory
 
 {{APIRef}}
 
-{{Non-standardGeneric('header')}}
+{{Non-standard_Header}}
 
 ## Syntaxe
 


### PR DESCRIPTION
This PR replaces the final `{{Non-standardGeneric}}` call with `{{Non-standard_Header}}`.  In https://github.com/mdn/yari/pull/8101, `{{Non-standardGeneric}}` will be merged into `{{Non-standard_Header}}` as the second is simply a shortcut to call the first with specific parameters and is widely used in all content.  This is the only page that calls `{{Non-standardGeneric}}` directly.