### PR TITLE
fr: Remove {{ARIARole}} macro

### DIFF
--- a/files/fr/web/html/element/heading_elements/index.md
+++ b/files/fr/web/html/element/heading_elements/index.md
@@ -209,7 +209,7 @@ Dans l'exemple qui précède, un lecteur d'écran annoncerait deux section {{HTM
     </tr>
     <tr>
       <th scope="row">Rôles ARIA autorisés</th>
-      <td>{{ARIARole("tab")}}, {{ARIARole("presentation")}}</td>
+      <td><code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/tab_role">tab</a></code>, <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code></td>
     </tr>
     <tr>
       <th scope="row">Interface DOM</th>

--- a/files/fr/web/html/element/hgroup/index.md
+++ b/files/fr/web/html/element/hgroup/index.md
@@ -127,7 +127,7 @@ Ici, le titre secondaire est placé entre parenthèses après le titre principal
     </tr>
     <tr>
       <th scope="row">Rôles ARIA autorisés</th>
-      <td>{{ARIARole("tab")}}, {{ARIARole("presentation")}}</td>
+      <td><code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/tab_role">tab</a></code>, <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code></td>
     </tr>
     <tr>
       <th scope="row">Interface DOM</th>

--- a/files/fr/web/html/element/hr/index.md
+++ b/files/fr/web/html/element/hr/index.md
@@ -102,7 +102,7 @@ Cet élément prend en charge [les attributs universels](/fr/docs/Web/HTML/Attri
     </tr>
     <tr>
       <th scope="row">Rôles ARIA autorisés</th>
-      <td>{{ARIARole("presentation")}}</td>
+      <td><code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code></td>
     </tr>
     <tr>
       <th scope="row">Interface DOM</th>

--- a/files/fr/web/html/element/li/index.md
+++ b/files/fr/web/html/element/li/index.md
@@ -133,12 +133,12 @@ Cet élément inclut les [attributs universels](/fr/docs/Web/HTML/Attributs_univ
     <tr>
       <th scope="row">Rôles ARIA autorisés</th>
       <td>
-        {{ARIARole("menuitem")}},
-        {{ARIARole("menuitemcheckbox")}},
-        {{ARIARole("menuitemradio")}}, {{ARIARole("option")}},
-        {{ARIARole("presentation")}}, {{ARIARole("radio")}},
-        {{ARIARole("separator")}}, {{ARIARole("tab")}},
-        {{ARIARole("treeitem")}}.
+        <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/menuitem_role">menuitem</a></code>,
+        <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/menuitemcheckbox_role">menuitemcheckbox</a></code>,
+        <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/menuitemradio_role">menuitemradio</a></code>, <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/option_role">option</a></code>,
+        <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code>, <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/radio_role">radio</a></code>,
+        <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/separator_role">separator</a></code>, <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/tab_role">tab</a></code>,
+        <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/treeitem_role">treeitem</a></code>.
       </td>
     </tr>
     <tr>

--- a/files/fr/web/html/element/section/index.md
+++ b/files/fr/web/html/element/section/index.md
@@ -91,15 +91,15 @@ Cet élément inclut uniquement [les attributs universels](/fr/docs/Web/HTML/Att
     <tr>
       <th scope="row">Rôles ARIA autorisés</th>
       <td>
-        {{ARIARole("alert")}}, {{ARIARole("alertdialog")}},
-        {{ARIARole("application")}}, {{ARIARole("banner")}},
-        {{ARIARole("complementary")}},
-        {{ARIARole("contentinfo")}}, {{ARIARole("dialog")}},
-        {{ARIARole("document")}}, {{ARIARole("feed")}},
-        {{ARIARole("log")}}, {{ARIARole("main")}},
-        {{ARIARole("marquee")}}, {{ARIARole("navigation")}},
-        {{ARIARole("search")}}, {{ARIARole("status")}},
-        {{ARIARole("tabpanel")}}
+        <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/alert_role">alert</a></code>, <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/alertdialog_role">alertdialog</a></code>,
+        <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/application_role">application</a></code>, <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/banner_role">banner</a></code>,
+        <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/complementary_role">complementary</a></code>,
+        <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/contentinfo_role">contentinfo</a></code>, <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/dialog_role">dialog</a></code>,
+        <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/document_role">document</a></code>, <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/feed_role">feed</a></code>,
+        <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/log_role">log</a></code>, <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/main_role">main</a></code>,
+        <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/marquee_role">marquee</a></code>, <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/navigation_role">navigation</a></code>,
+        <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/search_role">search</a></code>, <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/status_role">status</a></code>,
+        <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/tabpanel_role">tabpanel</a></code>
       </td>
     </tr>
     <tr>

--- a/files/fr/web/html/element/select/index.md
+++ b/files/fr/web/html/element/select/index.md
@@ -227,7 +227,7 @@ Les utilisateurs du clavier pourront sélectionner des options non-contigües de
     </tr>
     <tr>
       <th scope="row">Rôles ARIA autorisé</th>
-      <td>{{ARIARole("menu")}}</td>
+      <td><code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/menu_role">menu</a></code></td>
     </tr>
     <tr>
       <th scope="row">Interface DOM</th>

--- a/files/fr/web/html/element/summary/index.md
+++ b/files/fr/web/html/element/summary/index.md
@@ -123,7 +123,7 @@ Il est possible d'utiliser des titres au sein d'un résumé.
     </tr>
     <tr>
       <th scope="row">Rôles ARIA autorisés</th>
-      <td>{{ARIARole("button")}}</td>
+      <td><code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/button_role">button</a></code></td>
     </tr>
     <tr>
       <th scope="row">Interface DOM</th>

--- a/files/fr/web/html/element/ul/index.md
+++ b/files/fr/web/html/element/ul/index.md
@@ -165,11 +165,11 @@ L'élément HTML **`<ul>`** représente une liste d'éléments sans ordre partic
     <tr>
       <th scope="row">Rôles ARIA autorisés</th>
       <td>
-        {{ARIARole("directory")}}, {{ARIARole("group")}},
-        {{ARIARole("listbox")}}, {{ARIARole("menu")}},
-        {{ARIARole("menubar")}}, {{ARIARole("radiogroup")}},
-        {{ARIARole("tablist")}}, {{ARIARole("toolbar")}},
-        {{ARIARole("tree")}}, {{ARIARole("presentation")}}
+        <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/directory_role">directory</a></code>, <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/group_role">group</a></code>,
+        <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/listbox_role">listbox</a></code>, <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/menu_role">menu</a></code>,
+        <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/menubar_role">menubar</a></code>, <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/radiogroup_role">radiogroup</a></code>,
+        <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/tablist_role">tablist</a></code>, <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/toolbar_role">toolbar</a></code>,
+        <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/tree_role">tree</a></code>, <code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code>
       </td>
     </tr>
     <tr>

--- a/files/fr/web/html/element/video/index.md
+++ b/files/fr/web/html/element/video/index.md
@@ -333,7 +333,7 @@ Les sous-titres ne doivent pas masquer le sujet principal de la vidéo. Ils peuv
     </tr>
     <tr>
       <th scope="row">Rôles ARIA autorisés</th>
-      <td>{{ARIARole("application")}}</td>
+      <td><code><a href="/fr/docs/Web/Accessibility/ARIA/Roles/application_role">application</a></code></td>
     </tr>
     <tr>
       <th scope="row">Interface DOM</th>


### PR DESCRIPTION
This PR replaces the `{{ARIARole}}` macro calls with direct links.  Part of work for #11185.
