### PR TITLE
ja: Remove {{ARIARole}} macro

### DIFF
--- a/files/ja/web/html/element/a/index.md
+++ b/files/ja/web/html/element/a/index.md
@@ -144,7 +144,7 @@ slug: Web/HTML/Element/a
     <tr>
       <th scope="row">暗黙の ARIA ロール</th>
       <td>
-        {{ARIARole("link")}} （<code>href</code> 属性がある場合）、
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/link_role">link</a></code> （<code>href</code> 属性がある場合）、
         それ以外は<a href="https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role">対応するロールなし</a>
       </td>
     </tr>
@@ -153,16 +153,16 @@ slug: Web/HTML/Element/a
       <td>
         <p><code>href</code> 属性がある場合</p>
         <ul>
-          <li>{{ARIARole("button")}}</li>
-          <li>{{ARIARole("checkbox")}}</li>
-          <li>{{ARIARole("menuitem")}}</li>
-          <li>{{ARIARole("menuitemcheckbox")}}</li>
-          <li>{{ARIARole("menuitemradio")}}</li>
-          <li>{{ARIARole("option")}}</li>
-          <li>{{ARIARole("radio")}}</li>
-          <li>{{ARIARole("switch")}}</li>
-          <li>{{ARIARole("tab")}}</li>
-          <li>{{ARIARole("treeitem")}}</li>
+          <li><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/button_role">button</a></code></li>
+          <li><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/checkbox_role">checkbox</a></code></li>
+          <li><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menuitem_role">menuitem</a></code></li>
+          <li><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menuitemcheckbox_role">menuitemcheckbox</a></code></li>
+          <li><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menuitemradio_role">menuitemradio</a></code></li>
+          <li><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/option_role">option</a></code></li>
+          <li><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/radio_role">radio</a></code></li>
+          <li><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/switch_role">switch</a></code></li>
+          <li><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/tab_role">tab</a></code></li>
+          <li><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/treeitem_role">treeitem</a></code></li>
         </ul>
         <p><code>href</code> 属性がない場合</p>
         <ul>

--- a/files/ja/web/html/element/area/index.md
+++ b/files/ja/web/html/element/area/index.md
@@ -49,7 +49,7 @@ slug: Web/HTML/Element/area
       <th scope="row">暗黙の ARIA ロール</th>
       <td>
         {{htmlattrxref("href", "area")}} 属性がある場合は
-        {{ARIARole("link")}}、そうでなければ<a
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/link_role">link</a></code>、そうでなければ<a
           href="https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role"
           >対応するロールなし</a
         >

--- a/files/ja/web/html/element/article/index.md
+++ b/files/ja/web/html/element/article/index.md
@@ -63,10 +63,10 @@ slug: Web/HTML/Element/article
     <tr>
       <th scope="row">許可されている ARIA ロール</th>
       <td>
-        {{ARIARole("application")}}, {{ARIARole("document")}},
-        {{ARIARole("feed")}}, {{ARIARole("main")}},
-        {{ARIARole("none")}}, {{ARIARole("presentation")}},
-        {{ARIARole("region")}}
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/application_role">application</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/document_role">document</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/feed_role">feed</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/main_role">main</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/none_role">none</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/region_role">region</a></code>
       </td>
     </tr>
     <tr>

--- a/files/ja/web/html/element/aside/index.md
+++ b/files/ja/web/html/element/aside/index.md
@@ -63,9 +63,9 @@ slug: Web/HTML/Element/aside
     <tr>
       <th scope="row">許可されている ARIA ロール</th>
       <td>
-        {{ARIARole("feed")}}, {{ARIARole("none")}},
-        {{ARIARole("note")}}, {{ARIARole("presentation")}},
-        {{ARIARole("region")}}, {{ARIARole("search")}}
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/feed_role">feed</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/none_role">none</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/note_role">note</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/region_role">region</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/search_role">search</a></code>
       </td>
     </tr>
     <tr>

--- a/files/ja/web/html/element/audio/index.md
+++ b/files/ja/web/html/element/audio/index.md
@@ -427,7 +427,7 @@ elem.audioTrackList.onremovetrack = (event) => {
     </tr>
     <tr>
       <th scope="row">許可されている ARIA ロール</th>
-      <td>{{ARIARole("application")}}</td>
+      <td><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/application_role">application</a></code></td>
     </tr>
     <tr>
       <th scope="row">DOM インターフェイス</th>

--- a/files/ja/web/html/element/br/index.md
+++ b/files/ja/web/html/element/br/index.md
@@ -102,7 +102,7 @@ USA<br>
     <tr>
       <th scope="row">許可されている ARIA ロール</th>
       <td>
-        {{ARIARole("none")}}, {{ARIARole("presentation")}}
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/none_role">none</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code>
       </td>
     </tr>
     <tr>

--- a/files/ja/web/html/element/button/index.md
+++ b/files/ja/web/html/element/button/index.md
@@ -74,12 +74,12 @@ slug: Web/HTML/Element/button
     <tr>
       <th scope="row">許可されている ARIA ロール</th>
       <td>
-        {{ARIARole("checkbox")}}, {{ARIARole("link")}},
-        {{ARIARole("menuitem")}},
-        {{ARIARole("menuitemcheckbox")}},
-        {{ARIARole("menuitemradio")}}, {{ARIARole("option")}},
-        {{ARIARole("radio")}}, {{ARIARole("switch")}},
-        {{ARIARole("tab")}}
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/checkbox_role">checkbox</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/link_role">link</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menuitem_role">menuitem</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menuitemcheckbox_role">menuitemcheckbox</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menuitemradio_role">menuitemradio</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/option_role">option</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/radio_role">radio</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/switch_role">switch</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/tab_role">tab</a></code>
       </td>
     </tr>
     <tr>

--- a/files/ja/web/html/element/dd/index.md
+++ b/files/ja/web/html/element/dd/index.md
@@ -37,7 +37,7 @@ slug: Web/HTML/Element/dd
     </tr>
     <tr>
       <th scope="row">暗黙の ARIA ロール</th>
-      <td>{{ARIARole("definition")}}</td>
+      <td><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/definition_role">definition</a></code></td>
     </tr>
     <tr>
       <th scope="row">許可されている ARIA ロール</th>

--- a/files/ja/web/html/element/details/index.md
+++ b/files/ja/web/html/element/details/index.md
@@ -49,7 +49,7 @@ CSS を使用して折り畳みウィジェットのスタイルを設定する�
     </tr>
     <tr>
       <th scope="row">暗黙的な ARIA ロール</th>
-      <td>{{ARIARole("group")}}</td>
+      <td><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/group_role">group</a></code></td>
     </tr>
     <tr>
       <th scope="row">許可されている ARIA ロール</th>

--- a/files/ja/web/html/element/dfn/index.md
+++ b/files/ja/web/html/element/dfn/index.md
@@ -48,7 +48,7 @@ slug: Web/HTML/Element/dfn
     </tr>
     <tr>
       <th scope="row">暗黙の ARIA ロール</th>
-      <td>{{ARIARole("term")}}</td>
+      <td><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/term_role">term</a></code></td>
     </tr>
     <tr>
       <th scope="row">許可されている ARIA ロール</th>

--- a/files/ja/web/html/element/dialog/index.md
+++ b/files/ja/web/html/element/dialog/index.md
@@ -51,7 +51,7 @@ slug: Web/HTML/Element/dialog
     </tr>
     <tr>
       <th scope="row">許可された ARIA ロール</th>
-      <td>{{ARIARole("alertdialog")}}</td>
+      <td><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/alertdialog_role">alertdialog</a></code></td>
     </tr>
     <tr>
       <th scope="row">DOM インターフェイス</th>

--- a/files/ja/web/html/element/dl/index.md
+++ b/files/ja/web/html/element/dl/index.md
@@ -47,7 +47,7 @@ slug: Web/HTML/Element/dl
     <tr>
       <th scope="row">許可されている ARIA ロール</th>
       <td>
-        {{ARIARole("group")}}, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/List_role">list</a></code>, {{ARIARole("none")}}, {{ARIARole("presentation")}}
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/group_role">group</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/List_role">list</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/none_role">none</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code>
       </td>
     </tr>
     <tr>

--- a/files/ja/web/html/element/dt/index.md
+++ b/files/ja/web/html/element/dt/index.md
@@ -40,7 +40,7 @@ slug: Web/HTML/Element/dt
     </tr>
     <tr>
       <th scope="row">暗黙の ARIA ロール</th>
-      <td>{{ARIARole("term")}}</td>
+      <td><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/term_role">term</a></code></td>
     </tr>
     <tr>
       <th scope="row">許可されている ARIA ロール</th>

--- a/files/ja/web/html/element/embed/index.md
+++ b/files/ja/web/html/element/embed/index.md
@@ -57,9 +57,9 @@ slug: Web/HTML/Element/embed
     <tr>
       <th scope="row">許可されている ARIA ロール</th>
       <td>
-        {{ARIARole("application")}}, {{ARIARole("document")}},
-        {{ARIARole("img")}}, {{ARIARole("none")}},
-        {{ARIARole("presentation")}}
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/application_role">application</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/document_role">document</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/img_role">img</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/none_role">none</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code>
       </td>
     </tr>
     <tr>

--- a/files/ja/web/html/element/fieldset/index.md
+++ b/files/ja/web/html/element/fieldset/index.md
@@ -119,13 +119,13 @@ slug: Web/HTML/Element/fieldset
     </tr>
     <tr>
       <th scope="row">暗黙の ARIA ロール</th>
-      <td>{{ARIARole("group")}}</td>
+      <td><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/group_role">group</a></code></td>
     </tr>
     <tr>
       <th scope="row">許可されている ARIA ロール</th>
       <td>
-        {{ARIARole("radiogroup")}},
-        {{ARIARole("presentation")}}, {{ARIARole("none")}}
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/radiogroup_role">radiogroup</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/none_role">none</a></code>
       </td>
     </tr>
     <tr>

--- a/files/ja/web/html/element/figcaption/index.md
+++ b/files/ja/web/html/element/figcaption/index.md
@@ -50,8 +50,8 @@ slug: Web/HTML/Element/figcaption
     <tr>
       <th scope="row">許可されている ARIA ロール</th>
       <td>
-        {{ARIARole("group")}}, {{ARIARole("none")}},
-        {{ARIARole("presentation")}}
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/group_role">group</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/none_role">none</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code>
       </td>
     </tr>
     <tr>

--- a/files/ja/web/html/element/footer/index.md
+++ b/files/ja/web/html/element/footer/index.md
@@ -76,8 +76,8 @@ slug: Web/HTML/Element/footer
     <tr>
       <th scope="row">許可されている ARIA ロール</th>
       <td>
-        {{ARIARole("group")}}, {{ARIARole("presentation")}},
-        {{ARIARole("none")}}
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/group_role">group</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/none_role">none</a></code>
       </td>
     </tr>
     <tr>

--- a/files/ja/web/html/element/form/index.md
+++ b/files/ja/web/html/element/form/index.md
@@ -55,7 +55,7 @@ CSS の {{cssxref(':valid')}} および {{cssxref(':invalid')}} [擬似クラス
           ><a href="/ja/docs/Web/Accessibility/ARIA/Roles/search_role"
             >search</a
           ></code
-        >, {{ARIARole("none")}}, {{ARIARole("presentation")}}
+        >, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/none_role">none</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code>
       </td>
     </tr>
     <tr>

--- a/files/ja/web/html/element/header/index.md
+++ b/files/ja/web/html/element/header/index.md
@@ -93,8 +93,8 @@ slug: Web/HTML/Element/header
     <tr>
       <th scope="row">許可されている ARIA ロール</th>
       <td>
-        {{ARIARole("group")}}, {{ARIARole("presentation")}},
-        {{ARIARole("none")}}
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/group_role">group</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/none_role">none</a></code>
       </td>
     </tr>
     <tr>
@@ -123,7 +123,7 @@ slug: Web/HTML/Element/header
 ```html
 <header>
   <h1>Main Page Title</h1>
-  <img src="mdn-logo-sm.png" alt="MDN logo">
+  <img src="mdn-logo-sm.png" alt="MDN logo" />
 </header>
 ```
 
@@ -133,10 +133,17 @@ slug: Web/HTML/Element/header
 <article>
   <header>
     <h2>The Planet Earth</h2>
-    <p>Posted on Wednesday, <time datetime="2017-10-04">4 October 2017</time> by Jane Smith</p>
+    <p>
+      Posted on Wednesday, <time datetime="2017-10-04">4 October 2017</time> by
+      Jane Smith
+    </p>
   </header>
-  <p>We live on a planet that's blue and green, with so many things still unseen.</p>
-  <p><a href="https://janesmith.com/the-planet-earth/">Continue reading....</a></p>
+  <p>
+    We live on a planet that's blue and green, with so many things still unseen.
+  </p>
+  <p>
+    <a href="https://janesmith.com/the-planet-earth/">Continue reading....</a>
+  </p>
 </article>
 ```
 

--- a/files/ja/web/html/element/heading_elements/index.md
+++ b/files/ja/web/html/element/heading_elements/index.md
@@ -35,7 +35,7 @@ l10n:
     </tr>
     <tr>
       <th scope="row">許可されている ARIA ロール</th>
-      <td>{{ARIARole("tab")}}, {{ARIARole("presentation")}} または {{ARIARole("none")}}</td>
+      <td><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/tab_role">tab</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code> または <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/none_role">none</a></code></td>
     </tr>
     <tr>
       <th scope="row">DOM インターフェイス</th>

--- a/files/ja/web/html/element/hr/index.md
+++ b/files/ja/web/html/element/hr/index.md
@@ -45,12 +45,12 @@ slug: Web/HTML/Element/hr
     </tr>
     <tr>
       <th scope="row">暗黙の ARIA ロール</th>
-      <td>{{ARIARole("separator")}}</td>
+      <td><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/separator_role">separator</a></code></td>
     </tr>
     <tr>
       <th scope="row">許可されている ARIA ロール</th>
       <td>
-        {{ARIARole("presentation")}} または {{ARIARole("none")}}
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code> または <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/none_role">none</a></code>
       </td>
     </tr>
     <tr>

--- a/files/ja/web/html/element/iframe/index.md
+++ b/files/ja/web/html/element/iframe/index.md
@@ -51,9 +51,9 @@ slug: Web/HTML/Element/iframe
     <tr>
       <th scope="row">許可されている ARIA ロール</th>
       <td>
-        {{ARIARole("application")}}, {{ARIARole("document")}},
-        {{ARIARole("img")}}, {{ARIARole("none")}},
-        {{ARIARole("presentation")}}
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/application_role">application</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/document_role">document</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/img_role">img</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/none_role">none</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code>
       </td>
     </tr>
     <tr>

--- a/files/ja/web/html/element/img/index.md
+++ b/files/ja/web/html/element/img/index.md
@@ -383,15 +383,15 @@ SVGは、異なるサイズでも正確に描画する必要がある画像に�
                   ></code
                 >
               </li>
-              <li>{{ARIARole("link")}}</li>
-              <li>{{ARIARole("menuitem")}}</li>
-              <li>{{ARIARole("menuitemcheckbox")}}</li>
-              <li>{{ARIARole("menuitemradio")}}</li>
-              <li>{{ARIARole("option")}}</li>
-              <li>{{ARIARole("progressbar")}}</li>
-              <li>{{ARIARole("scrollbar")}}</li>
-              <li>{{ARIARole("separator")}}</li>
-              <li>{{ARIARole("slider")}}</li>
+              <li><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/link_role">link</a></code></li>
+              <li><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menuitem_role">menuitem</a></code></li>
+              <li><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menuitemcheckbox_role">menuitemcheckbox</a></code></li>
+              <li><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menuitemradio_role">menuitemradio</a></code></li>
+              <li><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/option_role">option</a></code></li>
+              <li><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/progressbar_role">progressbar</a></code></li>
+              <li><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/scrollbar_role">scrollbar</a></code></li>
+              <li><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/separator_role">separator</a></code></li>
+              <li><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/slider_role">slider</a></code></li>
               <li>
                 <code
                   ><a
@@ -407,12 +407,12 @@ SVGは、異なるサイズでも正確に描画する必要がある画像に�
                   ></code
                 >
               </li>
-              <li>{{ARIARole("treeitem")}}</li>
+              <li><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/treeitem_role">treeitem</a></code></li>
             </ul>
           </li>
           <li>
-            空の <code>alt</code> 属性がある場合、 {{ARIARole("none")}}
-            または {{ARIARole("presentation")}}
+            空の <code>alt</code> 属性がある場合、 <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/none_role">none</a></code>
+            または <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code>
           </li>
           <li>
             <code>alt</code> 属性がない場合、許可されている <code>role</code> なし

--- a/files/ja/web/html/element/input/index.md
+++ b/files/ja/web/html/element/input/index.md
@@ -1170,7 +1170,7 @@ Firefox は（少なくとも `type="number"` において）ユーザーの入�
               </li>
               <li>
                 <code>list</code> 属性あり:
-                {{ARIARole("combobox")}}
+                <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/combobox_role">combobox</a></code>
               </li>
             </ul>
           </li>
@@ -1179,10 +1179,10 @@ Firefox は（少なくとも `type="number"` において）ユーザーの入�
             <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/button_role">button</a></code>
           </li>
           <li>
-            <code>type=number</code>: {{ARIARole("spinbutton")}}
+            <code>type=number</code>: <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/spinbutton_role">spinbutton</a></code>
           </li>
-          <li><code>type=radio</code>: {{ARIARole("radio")}}</li>
-          <li><code>type=range</code>: {{ARIARole("slider")}}</li>
+          <li><code>type=radio</code>: <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/radio_role">radio</a></code></li>
+          <li><code>type=range</code>: <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/slider_role">slider</a></code></li>
           <li>
             <code>type=reset</code>:
             <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/button_role">button</a></code>
@@ -1191,10 +1191,10 @@ Firefox は（少なくとも `type="number"` において）ユーザーの入�
             <code>type=search</code>
             <ul>
               <li>
-                <code>list</code> 属性なし: {{ARIARole("searchbox")}}
+                <code>list</code> 属性なし: <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/searchbox_role">searchbox</a></code>
               </li>
               <li>
-                <code>list</code> 属性あり: {{ARIARole("combobox")}}
+                <code>list</code> 属性あり: <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/combobox_role">combobox</a></code>
               </li>
             </ul>
           </li>
@@ -1210,7 +1210,7 @@ Firefox は（少なくとも `type="number"` において）ユーザーの入�
                 <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/textbox_role">textbox</a></code>
               </li>
               <li>
-                <code>list</code> 属性あり: {{ARIARole("combobox")}}
+                <code>list</code> 属性あり: <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/combobox_role">combobox</a></code>
               </li>
             </ul>
           </li>
@@ -1222,7 +1222,7 @@ Firefox は（少なくとも `type="number"` において）ユーザーの入�
                 <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/textbox_role">textbox</a></code>
               </li>
               <li>
-                <code>list</code> 属性あり: {{ARIARole("combobox")}}
+                <code>list</code> 属性あり: <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/combobox_role">combobox</a></code>
               </li>
             </ul>
           </li>
@@ -1234,7 +1234,7 @@ Firefox は（少なくとも `type="number"` において）ユーザーの入�
                 <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/textbox_role">textbox</a></code>
               </li>
               <li>
-                <code>list</code> 属性あり: {{ARIARole("combobox")}}
+                <code>list</code> 属性あり: <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/combobox_role">combobox</a></code>
               </li>
             </ul>
           </li>
@@ -1250,32 +1250,32 @@ Firefox は（少なくとも `type="number"` において）ユーザーの入�
       <td>
         <ul>
           <li>
-            <code>type=button</code>: {{ARIARole("link")}},
-            {{ARIARole("menuitem")}},
-            {{ARIARole("menuitemcheckbox")}},
-            {{ARIARole("menuitemradio")}},
-            {{ARIARole("option")}}, {{ARIARole("radio")}},
-            {{ARIARole("switch")}}, {{ARIARole("tab")}}
+            <code>type=button</code>: <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/link_role">link</a></code>,
+            <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menuitem_role">menuitem</a></code>,
+            <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menuitemcheckbox_role">menuitemcheckbox</a></code>,
+            <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menuitemradio_role">menuitemradio</a></code>,
+            <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/option_role">option</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/radio_role">radio</a></code>,
+            <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/switch_role">switch</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/tab_role">tab</a></code>
           </li>
           <li>
-            <code>type=checkbox</code>: {{ARIARole("button")}} ただし <code>aria-pressed</code>,
-            {{ARIARole("menuitemcheckbox")}},
-            {{ARIARole("option")}}, {{ARIARole("switch")}} と共に使用されたとき
+            <code>type=checkbox</code>: <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/button_role">button</a></code> ただし <code>aria-pressed</code>,
+            <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menuitemcheckbox_role">menuitemcheckbox</a></code>,
+            <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/option_role">option</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/switch_role">switch</a></code> と共に使用されたとき
           </li>
           <li>
-            <code>type=image</code>: {{ARIARole("link")}},
-            {{ARIARole("menuitem")}},
-            {{ARIARole("menuitemcheckbox")}},
-            {{ARIARole("menuitemradio")}},
-            {{ARIARole("radio")}}, {{ARIARole("switch")}}
+            <code>type=image</code>: <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/link_role">link</a></code>,
+            <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menuitem_role">menuitem</a></code>,
+            <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menuitemcheckbox_role">menuitemcheckbox</a></code>,
+            <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menuitemradio_role">menuitemradio</a></code>,
+            <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/radio_role">radio</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/switch_role">switch</a></code>
           </li>
           <li>
-            <code>type=radio</code>: {{ARIARole("menuitemradio")}}
+            <code>type=radio</code>: <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menuitemradio_role">menuitemradio</a></code>
           </li>
           <li>
             <code>type=text</code> で <code>list</code> 属性なし:
-            {{ARIARole("combobox")}}, {{ARIARole("searchbox")}},
-            {{ARIARole("spinbutton")}}
+            <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/combobox_role">combobox</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/searchbox_role">searchbox</a></code>,
+            <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/spinbutton_role">spinbutton</a></code>
           </li>
           <li>
             <code>type=color|date|datetime-local|email|file|hidden|</code>

--- a/files/ja/web/html/element/li/index.md
+++ b/files/ja/web/html/element/li/index.md
@@ -56,12 +56,12 @@ slug: Web/HTML/Element/li
     <tr>
       <th scope="row">許可されている ARIA ロール</th>
       <td>
-        {{ARIARole("menuitem")}},
-        {{ARIARole("menuitemcheckbox")}},
-        {{ARIARole("menuitemradio")}}, {{ARIARole("option")}},
-        {{ARIARole("none")}}, {{ARIARole("presentation")}},
-        {{ARIARole("radio")}}, {{ARIARole("separator")}},
-        {{ARIARole("tab")}}, {{ARIARole("treeitem")}}
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menuitem_role">menuitem</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menuitemcheckbox_role">menuitemcheckbox</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menuitemradio_role">menuitemradio</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/option_role">option</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/none_role">none</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/radio_role">radio</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/separator_role">separator</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/tab_role">tab</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/treeitem_role">treeitem</a></code>
       </td>
     </tr>
     <tr>

--- a/files/ja/web/html/element/link/index.md
+++ b/files/ja/web/html/element/link/index.md
@@ -362,7 +362,7 @@ myStylesheet.onerror = function() {
     </tr>
     <tr>
       <th scope="row">暗黙の ARIA ロール</th>
-      <td><code>href</code> 属性つきの {{ARIARole("link")}}</td>
+      <td><code>href</code> 属性つきの <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/link_role">link</a></code></td>
     </tr>
     <tr>
       <th scope="row">許可されている ARIA ロール</th>

--- a/files/ja/web/html/element/menu/index.md
+++ b/files/ja/web/html/element/menu/index.md
@@ -75,15 +75,15 @@ slug: Web/HTML/Element/menu
     <tr>
       <th scope="row">許可されている ARIA ロール</th>
       <td>
-        {{ARIARole("directory")}}, {{ARIARole("group")}},
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/directory_role">directory</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/group_role">group</a></code>,
         <code
           ><a href="/ja/docs/Web/Accessibility/ARIA/Roles/listbox_role"
             >listbox</a
           ></code
-        >, {{ARIARole("menu")}}, {{ARIARole("menubar")}},
-        {{ARIARole("none")}}, {{ARIARole("presentation")}},
-        {{ARIARole("radiogroup")}}, {{ARIARole("tablist")}},
-        {{ARIARole("toolbar")}}, {{ARIARole("tree")}}
+        >, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menu_role">menu</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menubar_role">menubar</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/none_role">none</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/radiogroup_role">radiogroup</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/tablist_role">tablist</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/toolbar_role">toolbar</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/tree_role">tree</a></code>
       </td>
     </tr>
     <tr>

--- a/files/ja/web/html/element/object/index.md
+++ b/files/ja/web/html/element/object/index.md
@@ -42,7 +42,7 @@ slug: Web/HTML/Element/object
     </tr>
     <tr>
       <th scope="row">許可されている ARIA ロール</th>
-      <td>{{ARIARole("application")}}, {{ARIARole("document")}}, {{ARIARole("image")}}</td>
+      <td><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/application_role">application</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/document_role">document</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/image_role">image</a></code></td>
     </tr>
     <tr>
       <th scope="row">DOM インターフェイス</th>

--- a/files/ja/web/html/element/ol/index.md
+++ b/files/ja/web/html/element/ol/index.md
@@ -44,12 +44,12 @@ slug: Web/HTML/Element/ol
     <tr>
       <th scope="row">許可されている ARIA ロール</th>
       <td>
-        {{ARIARole("directory")}}, {{ARIARole("group")}},
-        {{ARIARole("listbox")}}, {{ARIARole("menu")}},
-        {{ARIARole("menubar")}}, {{ARIARole("none")}},
-        {{ARIARole("presentation")}},
-        {{ARIARole("radiogroup")}}, {{ARIARole("tablist")}},
-        {{ARIARole("toolbar")}}, {{ARIARole("tree")}}
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/directory_role">directory</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/group_role">group</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/listbox_role">listbox</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menu_role">menu</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menubar_role">menubar</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/none_role">none</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/radiogroup_role">radiogroup</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/tablist_role">tablist</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/toolbar_role">toolbar</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/tree_role">tree</a></code>
       </td>
     </tr>
     <tr>

--- a/files/ja/web/html/element/optgroup/index.md
+++ b/files/ja/web/html/element/optgroup/index.md
@@ -33,7 +33,7 @@ slug: Web/HTML/Element/optgroup
     </tr>
     <tr>
       <th scope="row">暗黙の ARIA ロール</th>
-      <td>{{ARIARole("group")}}</td>
+      <td><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/group_role">group</a></code></td>
     </tr>
     <tr>
       <th scope="row">許可されている ARIA ロール</th>

--- a/files/ja/web/html/element/option/index.md
+++ b/files/ja/web/html/element/option/index.md
@@ -41,7 +41,7 @@ slug: Web/HTML/Element/option
     </tr>
     <tr>
       <th scope="row">暗黙の ARIA ロール</th>
-      <td>{{ARIARole("option")}}</td>
+      <td><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/option_role">option</a></code></td>
     </tr>
     <tr>
       <th scope="row">許可されている ARIA ロール</th>

--- a/files/ja/web/html/element/output/index.md
+++ b/files/ja/web/html/element/output/index.md
@@ -51,7 +51,7 @@ slug: Web/HTML/Element/output
     </tr>
     <tr>
       <th scope="row">暗黙の ARIA ロール</th>
-      <td>{{ARIARole("status")}}</td>
+      <td><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/status_role">status</a></code></td>
     </tr>
     <tr>
       <th scope="row">許可された ARIA ロール</th>

--- a/files/ja/web/html/element/progress/index.md
+++ b/files/ja/web/html/element/progress/index.md
@@ -47,7 +47,7 @@ slug: Web/HTML/Element/progress
     </tr>
     <tr>
       <th scope="row">暗黙の ARIA ロール</th>
-      <td>{{ARIARole("progressbar")}}</td>
+      <td><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/progressbar_role">progressbar</a></code></td>
     </tr>
     <tr>
       <th scope="row">許可されている ARIA ロール</th>

--- a/files/ja/web/html/element/section/index.md
+++ b/files/ja/web/html/element/section/index.md
@@ -70,16 +70,16 @@ slug: Web/HTML/Element/section
     <tr>
       <th scope="row">許可されている ARIA ロール</th>
       <td>
-        {{ARIARole("alert")}}, {{ARIARole("alertdialog")}},
-        {{ARIARole("application")}}, {{ARIARole("banner")}},
-        {{ARIARole("complementary")}},
-        {{ARIARole("contentinfo")}}, {{ARIARole("dialog")}},
-        {{ARIARole("document")}}, {{ARIARole("feed")}},
-        {{ARIARole("log")}}, {{ARIARole("main")}},
-        {{ARIARole("marquee")}}, {{ARIARole("navigation")}},
-        {{ARIARole("none")}}, {{ARIARole("note")}},
-        {{ARIARole("presentation")}}, {{ARIARole("search")}},
-        {{ARIARole("status")}}, {{ARIARole("tabpanel")}}
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/alert_role">alert</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/alertdialog_role">alertdialog</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/application_role">application</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/banner_role">banner</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/complementary_role">complementary</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/contentinfo_role">contentinfo</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/dialog_role">dialog</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/document_role">document</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/feed_role">feed</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/log_role">log</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/main_role">main</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/marquee_role">marquee</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/navigation_role">navigation</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/none_role">none</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/note_role">note</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/search_role">search</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/status_role">status</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/tabpanel_role">tabpanel</a></code>
       </td>
     </tr>
     <tr>

--- a/files/ja/web/html/element/select/index.md
+++ b/files/ja/web/html/element/select/index.md
@@ -630,8 +630,8 @@ document.forms[0].onsubmit = function(e) {
       <td>
         <code>multiple</code> 属性が<strong>なく</strong>、 1 よりも大きい
         <code>size</code> 属性が<strong>ない</strong>ならば
-        {{ARIARole("combobox")}}、それ以外の場合は
-        {{ARIARole("listbox")}}
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/combobox_role">combobox</a></code>、それ以外の場合は
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/listbox_role">listbox</a></code>
       </td>
     </tr>
     <tr>
@@ -639,7 +639,7 @@ document.forms[0].onsubmit = function(e) {
       <td>
         <code>multiple</code> 属性が<strong>なく</strong>、 1 よりも大きい
         <code>size</code> 属性が<strong>ない</strong>ならば
-        {{ARIARole("menu")}}、それ以外の場合は許可されている
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menu_role">menu</a></code>、それ以外の場合は許可されている
         <code>role</code> はなし
       </td>
     </tr>

--- a/files/ja/web/html/element/th/index.md
+++ b/files/ja/web/html/element/th/index.md
@@ -38,7 +38,7 @@ slug: Web/HTML/Element/th
     <tr>
       <th scope="row">暗黙の ARIA ロール</th>
       <td>
-        {{ARIARole("columnheader")}} または {{ARIARole("rowheader")}}
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/columnheader_role">columnheader</a></code> または <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/rowheader_role">rowheader</a></code>
       </td>
     </tr>
     <tr>

--- a/files/ja/web/html/element/ul/index.md
+++ b/files/ja/web/html/element/ul/index.md
@@ -60,12 +60,12 @@ slug: Web/HTML/Element/ul
     <tr>
       <th scope="row">許可されている ARIA ロール</th>
       <td>
-        {{ARIARole("directory")}}, {{ARIARole("group")}},
-        {{ARIARole("listbox")}}, {{ARIARole("menu")}},
-        {{ARIARole("menubar")}}, {{ARIARole("none")}},
-        {{ARIARole("presentation")}},
-        {{ARIARole("radiogroup")}}, {{ARIARole("tablist")}},
-        {{ARIARole("toolbar")}}, {{ARIARole("tree")}}
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/directory_role">directory</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/group_role">group</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/listbox_role">listbox</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menu_role">menu</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/menubar_role">menubar</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/none_role">none</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/radiogroup_role">radiogroup</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/tablist_role">tablist</a></code>,
+        <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/toolbar_role">toolbar</a></code>, <code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/tree_role">tree</a></code>
       </td>
     </tr>
     <tr>

--- a/files/ja/web/html/element/video/index.md
+++ b/files/ja/web/html/element/video/index.md
@@ -468,7 +468,7 @@ AddType video/webm .webm
     </tr>
     <tr>
       <th scope="row">許可されている ARIA ロール</th>
-      <td>{{ARIARole("application")}}</td>
+      <td><code><a href="/ja/docs/Web/Accessibility/ARIA/Roles/application_role">application</a></code></td>
     </tr>
     <tr>
       <th scope="row">DOM インターフェイス</th>


### PR DESCRIPTION
This PR replaces the `{{ARIARole}}` macro calls with direct links.  Part of work for #11185.
