### PR TITLE
pt-BR: Remove {{ARIARole}} macro

### DIFF
--- a/files/pt-br/web/html/element/a/index.md
+++ b/files/pt-br/web/html/element/a/index.md
@@ -145,7 +145,7 @@ Os atributos do elemento incluem os [atributos globais](/pt-BR/docs/Web/HTML/Glo
     <tr>
       <th scope="row">Implicit ARIA role</th>
       <td>
-        {{ARIARole("link")}} when <code>href</code> attribute is
+        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code> when <code>href</code> attribute is
         present, otherwise
         <a href="https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role"
           >no corresponding role</a
@@ -157,16 +157,16 @@ Os atributos do elemento incluem os [atributos globais](/pt-BR/docs/Web/HTML/Glo
       <td>
         <p>When <code>href</code> attribute is present:</p>
         <ul>
-          <li>{{ARIARole("button")}}</li>
-          <li>{{ARIARole("checkbox")}}</li>
-          <li>{{ARIARole("menuitem")}}</li>
-          <li>{{ARIARole("menuitemcheckbox")}}</li>
-          <li>{{ARIARole("menuitemradio")}}</li>
-          <li>{{ARIARole("option")}}</li>
-          <li>{{ARIARole("radio")}}</li>
-          <li>{{ARIARole("switch")}}</li>
-          <li>{{ARIARole("tab")}}</li>
-          <li>{{ARIARole("treeitem")}}</li>
+          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code></li>
+          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code></li>
+          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code></li>
+          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code></li>
+          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code></li>
+          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code></li>
+          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code></li>
+          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code></li>
+          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code></li>
+          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code></li>
         </ul>
         <p>When <code>href</code> attribute is not present:</p>
         <ul>

--- a/files/pt-br/web/html/element/dialog/index.md
+++ b/files/pt-br/web/html/element/dialog/index.md
@@ -42,7 +42,7 @@ O **elemento HTML `<dialog>`** representa uma caixa de diálogo ou outro compone
     </tr>
     <tr>
       <th scope="row">Permitted ARIA roles</th>
-      <td>{{ARIARole("alertdialog")}}</td>
+      <td><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code></td>
     </tr>
     <tr>
       <th scope="row">DOM interface</th>

--- a/files/pt-br/web/html/element/section/index.md
+++ b/files/pt-br/web/html/element/section/index.md
@@ -50,15 +50,15 @@ Por exemplo, um menu de navegação deve estar dentro um elemento {{htmlelement 
     <tr>
       <th scope="row">Regras ARIA permitidas</th>
       <td>
-        {{ARIARole("alert")}}, {{ARIARole("alertdialog")}},
-        {{ARIARole("application")}}, {{ARIARole("banner")}},
-        {{ARIARole("complementary")}},
-        {{ARIARole("contentinfo")}}, {{ARIARole("dialog")}},
-        {{ARIARole("document")}}, {{ARIARole("feed")}},
-        {{ARIARole("log")}}, {{ARIARole("main")}},
-        {{ARIARole("marquee")}}, {{ARIARole("navigation")}},
-        {{ARIARole("search")}}, {{ARIARole("status")}},
-        {{ARIARole("tabpanel")}}
+        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>, <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>,
+        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>, <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>,
+        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>,
+        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>, <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>,
+        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>, <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>,
+        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>, <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>,
+        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>, <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>,
+        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>, <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>,
+        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
This PR replaces the `{{ARIARole}}` macro calls with direct links.  Part of work for #11185.

