### PR TITLE
Remove `{{Gecko}}`  macro from es

### DIFF
--- a/files/es/web/api/element/localname/index.md
+++ b/files/es/web/api/element/localname/index.md
@@ -62,7 +62,7 @@ El nombre local de un nodo es la parte del nombre completo del nodo que va situa
 6  </ecomm:business>
 ```
 
-> **Nota:** En {{Gecko("1.9.2")}} y anteriores,devuelve la versión en mayúsculas del nombre local para elementos HTML en HTML DOMs (en contraposición a elementos XHTML en XML DOMs). En versiones posteriores, en concordancia con HTML5,la propiedad devuelve en el caso de almacenamiento interno DOM , minúscula para ambos elementos HTML en HTML DOM y elementos XHTML en DOM XML. La propiedad {{domxref("element.tagName","tagName")}} continua devolviéndolo en mayúsculas para elementos HTML en HTML DOMs.
+> **Nota:** En Gecko 1.9.2 y anteriores,devuelve la versión en mayúsculas del nombre local para elementos HTML en HTML DOMs (en contraposición a elementos XHTML en XML DOMs). En versiones posteriores, en concordancia con HTML5,la propiedad devuelve en el caso de almacenamiento interno DOM , minúscula para ambos elementos HTML en HTML DOM y elementos XHTML en DOM XML. La propiedad {{domxref("element.tagName","tagName")}} continua devolviéndolo en mayúsculas para elementos HTML en HTML DOMs.
 
 ## Especificaciones
 

--- a/files/es/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/es/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -197,12 +197,12 @@ La carga de texturas WebGL esta sujeta a controles de acceso entre dominios. Par
 
 Ver este articulo [hacks.mozilla.org](http://hacks.mozilla.org/2011/11/using-cors-to-load-webgl-textures-from-cross-domain-images/) para una explicacion de como usar imágenes CORS-approved como texturas WebGL , con un [ejemplo auto-contenido](http://people.mozilla.org/~bjacob/webgltexture-cors-js.html).
 
-> **Nota:** El soporte CORS para texturas WebGL y el atributo crossOrigin para elementos de imagen se implementan en {{Gecko ("8.0")}}.
+> **Nota:** El soporte CORS para texturas WebGL y el atributo crossOrigin para elementos de imagen se implementan en Gecko 8.0.
 
 Canvas 2D contaminados (Solo lectura) no pueden ser utilizados como texturas WebGL. una 2D {{ HTMLElement("canvas") }} se convierte en contaminada, por ejemplo, cuando una imagen de dominio cruzado (cross-domain) es dibujada en el.
 
-> **Nota:** El soporte de CORS para Canvas 2D drawImage se implementa en {{Gecko ("9.0")}}. Esto significa que el uso de una imagen de dominio cruzado con aprobación de CORS ya no pinta el lienzo 2D, por lo que el lienzo 2D sigue siendo utilizable como fuente de una textura WebGL.
+> **Nota:** El soporte de CORS para Canvas 2D drawImage se implementa en Gecko 9.0. Esto significa que el uso de una imagen de dominio cruzado con aprobación de CORS ya no pinta el lienzo 2D, por lo que el lienzo 2D sigue siendo utilizable como fuente de una textura WebGL.
 
-> **Nota:** El soporte de CORS para videos de dominio cruzado y el atributo de crossorigin para elementos {{HTMLElement("video")}} se implementa en {{Gecko ("12.0")}}.
+> **Nota:** El soporte de CORS para videos de dominio cruzado y el atributo de crossorigin para elementos {{HTMLElement("video")}} se implementa en Gecko 12.0.
 
 {{PreviousNext("Web/API/WebGL_API/Tutorial/Creating_3D_objects_using_WebGL", "Web/API/WebGL_API/Tutorial/Lighting_in_WebGL")}}

--- a/files/es/web/api/websocket/index.md
+++ b/files/es/web/api/websocket/index.md
@@ -120,9 +120,9 @@ void send(
 - `SYNTAX_ERR`
   - : La data tiene caracteres no válidos que no se pueden decodificar.
 
-> **Nota:** La implementación del método `send()` en el motor de renderizado Gecko puede cambiar de la especificación en {{Gecko("6.0")}}; Gecko devuelve un `boolean` indicando si la conexión esta todavía abierta (y, por extensión, que los datos son encolados o trasmitidos satisfactoriamente). Esto ha sido corregido en {{Gecko("8.0")}}.
+> **Nota:** La implementación del método `send()` en el motor de renderizado Gecko puede cambiar de la especificación en Gecko 6.0; Gecko devuelve un `boolean` indicando si la conexión esta todavía abierta (y, por extensión, que los datos son encolados o trasmitidos satisfactoriamente). Esto ha sido corregido en Gecko 8.0.
 >
-> A partir de {{Gecko("11.0")}}, implementa {{jsxref("ArrayBuffer")}} pero no tipos de datos {{domxref("Blob")}}.
+> A partir de Gecko 11.0, implementa {{jsxref("ArrayBuffer")}} pero no tipos de datos {{domxref("Blob")}}.
 
 ## Ejemplo
 

--- a/files/es/web/api/window/index.md
+++ b/files/es/web/api/window/index.md
@@ -285,7 +285,7 @@ Estas son propiedades del objeto ventana que pueden ser fijadas para establecer 
 
 _Esta interfaz hereda controladores de eventos de la interfaz {{domxref("EventTarget")}} e implementa controladores de eventos desde {{domxref("WindowTimers")}}, {{domxref("WindowBase64")}}, y {{domxref("WindowEventHandlers")}}._
 
-> **Nota:** Empezando en {{Gecko("9.0")}}, se puede usar el sintaxis `if ("onabort" in window)` para determinar si existe una propiedad dada de controlador de eventos o no. Esto es porque interfazes de controlador de eventos han sido actualizadas al respectivo web IDL interfaz. Ver [DOM event handlers](/es/docs/DOM/DOM_event_handlers) para mas detalles.
+> **Nota:** Empezando en Gecko 9.0, se puede usar el sintaxis `if ("onabort" in window)` para determinar si existe una propiedad dada de controlador de eventos o no. Esto es porque interfazes de controlador de eventos han sido actualizadas al respectivo web IDL interfaz. Ver [DOM event handlers](/es/docs/DOM/DOM_event_handlers) para mas detalles.
 
 - {{domxref("GlobalEventHandlers.onabort")}}
   - : An event handler property for abort events on the window.

--- a/files/es/web/api/window/open/index.md
+++ b/files/es/web/api/window/open/index.md
@@ -173,7 +173,7 @@ The following features require the `UniversalBrowserWrite` privilege, otherwise 
 
   - : **Note**: Starting with Mozilla 1.2.1, this feature requires the `UniversalBrowserWrite` privilege ({{Bug(180048)}}). Without this privilege, it is ignored. If on, the new window is said to be modal. The user cannot return to the main window until the modal window is closed. A typical modal window is created by the [alert() function](/es/docs/DOM/window.alert). The exact behavior of modal windows depends on the platform and on the Mozilla release version.
 
-    > **Nota:** As of {{Gecko("1.9")}}, the Internet Explorer equivalent to this feature is the {{domxref("window.showModalDialog()")}} method. For compatibility reasons, it's now supported in Firefox. Note also that starting in {{Gecko("2.0")}}, you can use {{domxref("window.showModalDialog()")}} without UniversalBrowserWrite privileges.
+    > **Nota:** As of Gecko 1.9, the Internet Explorer equivalent to this feature is the {{domxref("window.showModalDialog()")}} method. For compatibility reasons, it's now supported in Firefox. Note also that starting in Gecko 2.0, you can use {{domxref("window.showModalDialog()")}} without UniversalBrowserWrite privileges.
 
     Supported in: ![Netscape 6.x](/@api/deki/files/785/=Ns6.gif), ![Netscape 7.x](/@api/deki/files/281/=NS7_ico4.gif), ![Mozilla 1.x](/@api/deki/files/277/=Mozilla1_ico.png), ![Firefox 1.x](/@api/deki/files/200/=FF1x.png)
 

--- a/files/es/web/api/xmlhttprequest/using_xmlhttprequest/index.md
+++ b/files/es/web/api/xmlhttprequest/using_xmlhttprequest/index.md
@@ -220,14 +220,14 @@ oReq.open();
 > **Nota:** Los eventos de progreso no están disponibles para el
 > protocolo `file:`.
 
-> **Nota:** A partir de {{Gecko("9.0")}}, se puede confiar en que los eventos de progreso
+> **Nota:** A partir de Gecko 9.0, se puede confiar en que los eventos de progreso
 > lleguen para cada trozo de datos recibidos, incluyendo el último trozo en los casos
 > en los que se recibe el último paquete y se cierra la conexión antes de que se
 > dispare el evento de progreso. En este caso, el evento de progreso se dispara automáticamente
 > cuando se produce el evento de carga para ese paquete. Esto te permite ahora monitorizar
 > de forma fiable el progreso observando únicamente el evento "progress".
 
-> **Nota**: A partir de {{Gecko("12.0")}}, si su evento de progreso es llamado con
+> **Nota**: A partir de Gecko 12.0, si su evento de progreso es llamado con
 > un `responseType` de "moz-blob", el valor de la respuesta es un
 > {{domxref("Blob")}} que contiene los datos recibidos hasta el momento.
 

--- a/files/es/web/css/resize/index.md
+++ b/files/es/web/css/resize/index.md
@@ -49,7 +49,7 @@ resize: unset;
 
 #### CSS
 
-Por defecto, los elementos {{HTMLElement("textarea")}} permiten cambiar el tamaño en {{gecko("2.0")}} (Firefox 4). Se puede anular este comportamiento con el CSS mostrado abajo:
+Por defecto, los elementos {{HTMLElement("textarea")}} permiten cambiar el tamaño en Gecko 2.0 (Firefox 4). Se puede anular este comportamiento con el CSS mostrado abajo:
 
 ```css
 textarea.example {

--- a/files/es/web/html/element/input/index.md
+++ b/files/es/web/html/element/input/index.md
@@ -317,7 +317,7 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
 
 ### Introducción de archivos
 
-> **Nota:** A partir de {{Gecko("2.0")}}, llamar al método `click()` en un elemento `<input>` de tipo "file" abre el selector de archivos y permite al usuario seleccionar archivos. Véase [Utilizar ficheros desde aplicaciones web](/es/docs/Using_files_from_web_applications) para ejemplos y más detalles.
+> **Nota:** A partir de Gecko 2.0, llamar al método `click()` en un elemento `<input>` de tipo "file" abre el selector de archivos y permite al usuario seleccionar archivos. Véase [Utilizar ficheros desde aplicaciones web](/es/docs/Using_files_from_web_applications) para ejemplos y más detalles.
 
 No se puede establecer el valor de un selector de archivos desde un script. Hacer algo como lo siguiente no tiene efecto alguno:
 

--- a/files/es/web/html/element/textarea/index.md
+++ b/files/es/web/html/element/textarea/index.md
@@ -74,7 +74,7 @@ Este elemento contiene [global attributes](/es/docs/HTML/Global_attributes).
 
 Este elemento implementa el interfaz [`HTMLTextAreaElement`](/en/DOM/HTMLTextAreaElement) .
 
-{{ gecko("2.0") }} introduce el soporte para textareas redimensionable. Esto se controla con la propiedad CSS {{ cssxref("resize") }} . Por defecto la posibilidad de redimiensionar el control está habilitada, pero puede ser explícitamente deshabilitada mediante el uso del siguiente CSS:
+Gecko 2.0 introduce el soporte para textareas redimensionable. Esto se controla con la propiedad CSS {{ cssxref("resize") }} . Por defecto la posibilidad de redimiensionar el control está habilitada, pero puede ser explícitamente deshabilitada mediante el uso del siguiente CSS:
 
 ```css
 textarea {

--- a/files/es/web/http/cors/index.md
+++ b/files/es/web/http/cors/index.md
@@ -129,7 +129,7 @@ A diferencia de las solicitudes simples (discutidas arriba), las solicitudes "ve
 - Usa métodos **distintos** a `GET, HEAD` `o POST`. También, si `POST` es utilizado para enviar solicitudes de información con Content-Type **distinto** a `application/x-www-form-urlencoded`, `multipart/form-data`, o `text/plain`, ej. si la solicitud `POST` envía una carga XML al servidor utilizando `application/xml` or `text/xml`, entonces la solicitud **es** verificada.
 - Se establecen encabezados personalizados (ej. la solicitud usa un encabezado como `X-PINGOTHER`)
 
-> **Nota:** Empezando en {{Gecko("2.0")}}, las codificaciones de datos `text/plain`, `application/x-www-form-urlencoded`, y `multipart/form-data` pueden ser enviadas en sitios cruzados sin verificación. Anteriormente, solo `text/plain` podía ser enviado sin verificación.
+> **Nota:** Empezando en Gecko 2.0, las codificaciones de datos `text/plain`, `application/x-www-form-urlencoded`, y `multipart/form-data` pueden ser enviadas en sitios cruzados sin verificación. Anteriormente, solo `text/plain` podía ser enviado sin verificación.
 
 Un ejemplo de este tipo de invocación puede ser:
 

--- a/files/es/web/javascript/reference/global_objects/string/search/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/search/index.md
@@ -57,7 +57,7 @@ function testinput(re, str) {
 
 ## Notas específicas de Gecko
 
-- Antes de {{Gecko("8.0")}}, `search()` estaba mal implementado; cuando se invocaba sin parámetros o con {{jsxref("undefined")}}, buscaría coincidencias con la cadena 'undefined' en lugar de la cadena vacía. Esto está corregido; ahora `'a'.search()` y `'a'.search(undefined)` devuelven correctamente un 0.
+- Antes de Gecko 8.0, `search()` estaba mal implementado; cuando se invocaba sin parámetros o con {{jsxref("undefined")}}, buscaría coincidencias con la cadena 'undefined' en lugar de la cadena vacía. Esto está corregido; ahora `'a'.search()` y `'a'.search(undefined)` devuelven correctamente un 0.
 - Desde Gecko 39 (Firefox 39 / Thunderbird 39 / SeaMonkey 2.36), el argumento no estándar `flags` está obsoleto y muestra un aviso en la consola ({{bug(1142351)}}).
 - Desde Gecko 47 (Firefox 47 / Thunderbird 47 / SeaMonkey 2.44), el argumento no estándar `flags` no es soportado en compilaciones que no sean lanzamientos y pronto serán eliminadas por completo ({{bug(1245801)}}).
 - Desde Gecko 49 (Firefox 49 / Thunderbird 49 / SeaMonkey 2.46), el argumento no estándar `flags` no es soportado ({{bug(1108382)}}).


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove `{{Gecko}}`  macro from es

### Motivation

The chore of remove deprecated macros

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Relates to #11284
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->

Script:
```
grep -riE "\{\{\s?Gecko\s?\(\s?\"([^'\"]+)\"\s?\)\s?\}\}" files/es/ -l | xargs -I {} sed -i -E s/"\{\{\s?Gecko\s?\(\s?\"([^'\"]+)\"\s?\)\s?\}\}"/"Gecko \1"/ig {}
```
