### PR TITLE
Fixes wrong link

### DIFF
--- a/files/zh-cn/web/html/element/label/index.md
+++ b/files/zh-cn/web/html/element/label/index.md
@@ -34,7 +34,7 @@ slug: Web/HTML/Element/label
 该元素包含 [全局属性](/zh-CN/docs/Web/HTML/Global_attributes)。
 
 - {{htmlattrdef("for")}}
-  - : 即和 `<label>` 元素在同一文档中的 [可关联标签的元素](zh-CN/docs/Web/Guide/HTML/Content_categories#Form_labelable) 的 {{htmlattrxref("id")}}。文档中第一个 `id` 值与 `<label>` 元素 `for` 属性值相同的元素，如果可关联标签（labelable），则为*已关联标签的控件*，其标签就是这个 `<label>` 元素。如果这个元素不可关联标签，则 `for` 属性没有效果。如果文档中还有其他元素的 `id` 值也和 `for` 属性相同，`for` 属性对这些元素也没有影响。
+  - : 即和 `<label>` 元素在同一文档中的 [可关联标签的元素](/zh-CN/docs/Web/Guide/HTML/Content_categories#%E5%8F%AF%E6%A0%87%E8%AE%B0%E7%9A%84%E5%85%83%E7%B4%A0%EF%BC%88labelable%EF%BC%89) 的 {{htmlattrxref("id")}}。文档中第一个 `id` 值与 `<label>` 元素 `for` 属性值相同的元素，如果可关联标签（labelable），则为*已关联标签的控件*，其标签就是这个 `<label>` 元素。如果这个元素不可关联标签，则 `for` 属性没有效果。如果文档中还有其他元素的 `id` 值也和 `for` 属性相同，`for` 属性对这些元素也没有影响。
 
     > **备注：** `<label>` 元素可同时有一个 `for` 属性和一个子代控件元素，只是 `for` 属性需要指向这个控件元素。
 - {{htmlattrdef("form")}}

--- a/files/zh-cn/web/html/element/label/index.md
+++ b/files/zh-cn/web/html/element/label/index.md
@@ -5,7 +5,7 @@ slug: Web/HTML/Element/label
 
 {{HTMLSidebar}}
 
-**HTML `<label>` 元素（标签）**表示用户界面中某个元素的说明。
+**HTML `<label>` 元素**（标签）表示用户界面中某个元素的说明。
 
 {{EmbedInteractiveExample("pages/tabbed/label.html", "tabbed-shorter")}}
 
@@ -34,7 +34,7 @@ slug: Web/HTML/Element/label
 该元素包含 [全局属性](/zh-CN/docs/Web/HTML/Global_attributes)。
 
 - {{htmlattrdef("for")}}
-  - : 即和 `<label>` 元素在同一文档中的 [可关联标签的元素](/zh-CN/docs/Web/Guide/HTML/Content_categories#%E5%8F%AF%E6%A0%87%E8%AE%B0%E7%9A%84%E5%85%83%E7%B4%A0%EF%BC%88labelable%EF%BC%89) 的 {{htmlattrxref("id")}}。文档中第一个 `id` 值与 `<label>` 元素 `for` 属性值相同的元素，如果可关联标签（labelable），则为*已关联标签的控件*，其标签就是这个 `<label>` 元素。如果这个元素不可关联标签，则 `for` 属性没有效果。如果文档中还有其他元素的 `id` 值也和 `for` 属性相同，`for` 属性对这些元素也没有影响。
+  - : 即和 `<label>` 元素在同一文档中的 [可关联标签的元素](/zh-CN/docs/Web/Guide/HTML/Content_categories#可标记的元素（labelable）) 的 {{htmlattrxref("id")}}。文档中第一个 `id` 值与 `<label>` 元素 `for` 属性值相同的元素，如果可关联标签（labelable），则为*已关联标签的控件*，其标签就是这个 `<label>` 元素。如果这个元素不可关联标签，则 `for` 属性没有效果。如果文档中还有其他元素的 `id` 值也和 `for` 属性相同，`for` 属性对这些元素也没有影响。
 
     > **备注：** `<label>` 元素可同时有一个 `for` 属性和一个子代控件元素，只是 `for` 属性需要指向这个控件元素。
 - {{htmlattrdef("form")}}


### PR DESCRIPTION
### Description

- add the miss beginning `/`
- correct outdated anchor

### Additional details

__Note__: Link with urlencoded Chinese anchor didn't work in Chrome, but did work in FireFox.
