### PR TITLE
Update index.md

### DIFF
--- a/files/zh-cn/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
+++ b/files/zh-cn/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
@@ -128,8 +128,8 @@ original_slug: Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges
             >/apple(,)\sorange\1/</code
           >
           匹配“apple, orange, cherry, peach”中的 "apple, orange,"，其中
-          <code>\1</code> 引用了 之前使用 <code>（）</code> 捕获的
-          <code>，</code>
+          <code>\1</code> 引用了 之前使用 <code>()</code> 捕获的
+          <code>,</code>
         </p>
       </td>
     </tr>

--- a/files/zh-cn/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
+++ b/files/zh-cn/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
@@ -127,7 +127,7 @@ original_slug: Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges
           括号匹配的最后一个子字符串的反向引用 (计算左括号)。例如，<code
             >/apple(,)\sorange\1/</code
           >
-          匹配“apple，orange，cherry，peach”中的 "apple，orange，"，其中
+          匹配“apple, orange, cherry, peach”中的 "apple, orange,"，其中
           <code>\1</code> 引用了 之前使用 <code>（）</code> 捕获的
           <code>，</code>
         </p>


### PR DESCRIPTION
apple，orange， cherry， peach用了中文的逗号，与上面的正则不匹配，然后/apple(,)\sorange\1/中的\s无法匹配‘’，所以我觉得匹配的字符应该改成 apple,  orange,  cherry, peach(中文的逗号改成英文的逗号，并在后面加一个空格），匹配的结果也相应的更改

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
