### PR TITLE
[zh-cn] Remove '选择器参考表' section

### DIFF
--- a/files/zh-cn/learn/css/building_blocks/selectors/index.md
+++ b/files/zh-cn/learn/css/building_blocks/selectors/index.md
@@ -168,41 +168,23 @@ article > p { }
 
 {{PreviousMenuNext("Learn/CSS/Building_blocks/Cascade_and_inheritance", "Learn/CSS/Building_blocks/Selectors/Type_Class_and_ID_Selectors", "Learn/CSS/Building_blocks")}}
 
-## 选择器参考表
+## 本章目录
 
-下面的表格让你可以浏览你可以用的选择器，还有本指南中教你如何使用每种选择器的页面的链接。我还加上了一个能查看浏览器对每个选择器的支持信息的 MDN 页面链接。你可以把这个作为回头的参考，在你以后需要查询文献中提到的选择器的时候，或者是在你广义上实验 CSS 的时候。
-
-| 选择器                                                            | 示例                | 学习 CSS 的教程                                                                                                                |
-| ----------------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| [类型选择器](/zh-CN/docs/Web/CSS/Type_selectors)                  | `h1 { }`            | [类型选择器](/zh-CN/docs/user:chrisdavidmills/CSS_Learn/CSS_Selectors/Type_Class_and_ID_Selectors#Type_selectors)              |
-| [通配选择器](/zh-CN/docs/Web/CSS/Universal_selectors)             | `* { }`             | [通配选择器](/zh-CN/docs/user:chrisdavidmills/CSS_Learn/CSS_Selectors/Type_Class_and_ID_Selectors#The_universal_selector)      |
-| [类选择器](/zh-CN/docs/Web/CSS/Class_selectors)                   | `.box { }`          | [类选择器](/zh-CN/docs/user:chrisdavidmills/CSS_Learn/CSS_Selectors/Type_Class_and_ID_Selectors#Class_selectors)               |
-| [ID 选择器](/zh-CN/docs/Web/CSS/ID_selectors)                     | `#unique { }`       | [ID 选择器](/zh-CN/docs/user:chrisdavidmills/CSS_Learn/CSS_Selectors/Type_Class_and_ID_Selectors#ID_Selectors)                 |
-| [标签属性选择器](/zh-CN/docs/Web/CSS/Attribute_selectors)         | `a[title] { }`      | [标签属性选择器](/zh-CN/docs/User:chrisdavidmills/CSS_Learn/CSS_Selectors/Attribute_selectors)                                 |
-| [伪类选择器](/zh-CN/docs/Web/CSS/Pseudo-classes)                  | `p:first-child { }` | [伪类](/zh-CN/docs/User:chrisdavidmills/CSS_Learn/CSS_Selectors/Pseuso-classes_and_Pseudo-elements#What_is_a_pseudo-class)     |
-| [伪元素选择器](/zh-CN/docs/Web/CSS/Pseudo-elements)               | `p::first-line { }` | [伪元素](/zh-CN/docs/User:chrisdavidmills/CSS_Learn/CSS_Selectors/Pseuso-classes_and_Pseudo-elements#What_is_a_pseudo-element) |
-| [后代选择器](/zh-CN/docs/Web/CSS/Descendant_combinator)           | `article p`         | [后代运算符](/zh-CN/docs/User:chrisdavidmills/CSS_Learn/CSS_Selectors/Combinators#Descendant_Selector)                         |
-| [子代选择器](/zh-CN/docs/Web/CSS/Child_combinator)                | `article > p`       | [子代选择器](/zh-CN/docs/User:chrisdavidmills/CSS_Learn/CSS_Selectors/Combinators#Child_combinator)                            |
-| [相邻兄弟选择器](/zh-CN/docs/Web/CSS/Adjacent_sibling_combinator) | `h1 + p`            | [相邻兄弟](/zh-CN/docs/User:chrisdavidmills/CSS_Learn/CSS_Selectors/Combinators#Adjacent_sibling)                              |
-| [通用兄弟选择器](/zh-CN/docs/Web/CSS/General_sibling_combinator)  | `h1 ~ p`            | [通用兄弟](/zh-CN/docs/User:chrisdavidmills/CSS_Learn/CSS_Selectors/Combinators#General_sibling)                               |
-
-## 模块目录
-
-1. [层叠与继承](/zh-CN/docs/Learn/CSS/Building_blocks/Cascade_and_inheritance)
-2. [CSS 选择器](/zh-CN/docs/Learn/CSS/Building_blocks/Selectors)
+- [层叠与继承](/zh-CN/docs/Learn/CSS/Building_blocks/Cascade_and_inheritance)
+- [CSS 选择器](/zh-CN/docs/Learn/CSS/Building_blocks/Selectors)
 
     - [类型、类和 ID 选择器](/zh-CN/docs/Learn/CSS/Building_blocks/Selectors/Type_Class_and_ID_Selectors)
     - [属性选择器](/zh-CN/docs/Learn/CSS/Building_blocks/Selectors/Attribute_selectors)
     - [伪类和伪元素](/zh-CN/docs/Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements)
     - [关系选择器](/zh-CN/docs/Learn/CSS/Building_blocks/Selectors/Combinators)
 
-3. [盒模型](/zh-CN/docs/Learn/CSS/Building_blocks/The_box_model)
-4. [背景与边框](/zh-CN/docs/Learn/CSS/Building_blocks/Backgrounds_and_borders)
-5. [处理不同文字方向的文本](/zh-CN/docs/Learn/CSS/Building_blocks/Handling_different_text_directions)
-6. [溢出的内容](/zh-CN/docs/Learn/CSS/Building_blocks/Overflowing_content)
-7. [值和单位](/zh-CN/docs/Learn/CSS/Building_blocks/Values_and_units)
-8. [在 CSS 中调整大小](/zh-CN/docs/Learn/CSS/Building_blocks/Sizing_items_in_CSS)
-9. [图像、媒体和表单元素](/zh-CN/docs/Learn/CSS/Building_blocks/Images_media_form_elements)
-10. [样式化表格](/zh-CN/docs/Learn/CSS/Building_blocks/Styling_tables)
-11. [调试 CSS](/zh-CN/docs/Learn/CSS/Building_blocks/Debugging_CSS)
-12. [组织 CSS](/zh-CN/docs/Learn/CSS/Building_blocks/Organizing)
+- [盒模型](/zh-CN/docs/Learn/CSS/Building_blocks/The_box_model)
+- [背景与边框](/zh-CN/docs/Learn/CSS/Building_blocks/Backgrounds_and_borders)
+- [处理不同文字方向的文本](/zh-CN/docs/Learn/CSS/Building_blocks/Handling_different_text_directions)
+- [溢出的内容](/zh-CN/docs/Learn/CSS/Building_blocks/Overflowing_content)
+- [值和单位](/zh-CN/docs/Learn/CSS/Building_blocks/Values_and_units)
+- [在 CSS 中调整大小](/zh-CN/docs/Learn/CSS/Building_blocks/Sizing_items_in_CSS)
+- [图像、媒体和表单元素](/zh-CN/docs/Learn/CSS/Building_blocks/Images_media_form_elements)
+- [样式化表格](/zh-CN/docs/Learn/CSS/Building_blocks/Styling_tables)
+- [调试 CSS](/zh-CN/docs/Learn/CSS/Building_blocks/Debugging_CSS)
+- [组织 CSS](/zh-CN/docs/Learn/CSS/Building_blocks/Organizing)

--- a/files/zh-cn/learn/css/building_blocks/selectors/index.md
+++ b/files/zh-cn/learn/css/building_blocks/selectors/index.md
@@ -173,10 +173,10 @@ article > p { }
 - [层叠与继承](/zh-CN/docs/Learn/CSS/Building_blocks/Cascade_and_inheritance)
 - [CSS 选择器](/zh-CN/docs/Learn/CSS/Building_blocks/Selectors)
 
-    - [类型、类和 ID 选择器](/zh-CN/docs/Learn/CSS/Building_blocks/Selectors/Type_Class_and_ID_Selectors)
-    - [属性选择器](/zh-CN/docs/Learn/CSS/Building_blocks/Selectors/Attribute_selectors)
-    - [伪类和伪元素](/zh-CN/docs/Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements)
-    - [关系选择器](/zh-CN/docs/Learn/CSS/Building_blocks/Selectors/Combinators)
+  - [类型、类和 ID 选择器](/zh-CN/docs/Learn/CSS/Building_blocks/Selectors/Type_Class_and_ID_Selectors)
+  - [属性选择器](/zh-CN/docs/Learn/CSS/Building_blocks/Selectors/Attribute_selectors)
+  - [伪类和伪元素](/zh-CN/docs/Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements)
+  - [关系选择器](/zh-CN/docs/Learn/CSS/Building_blocks/Selectors/Combinators)
 
 - [盒模型](/zh-CN/docs/Learn/CSS/Building_blocks/The_box_model)
 - [背景与边框](/zh-CN/docs/Learn/CSS/Building_blocks/Backgrounds_and_borders)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove '选择器参考表' section from CSS selectors, as it contains a lot of bad links and the English version of the document do not contain this section anymore.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
