### PR TITLE
pt-BR: Fix removal of {{ARIARole}} macro

### DIFF
--- a/files/pt-br/web/html/element/a/index.md
+++ b/files/pt-br/web/html/element/a/index.md
@@ -145,7 +145,7 @@ Os atributos do elemento incluem os [atributos globais](/pt-BR/docs/Web/HTML/Glo
     <tr>
       <th scope="row">Implicit ARIA role</th>
       <td>
-        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code> when <code>href</code> attribute is
+        {{ARIARole("link")}} when <code>href</code> attribute is
         present, otherwise
         <a href="https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role"
           >no corresponding role</a
@@ -157,16 +157,16 @@ Os atributos do elemento incluem os [atributos globais](/pt-BR/docs/Web/HTML/Glo
       <td>
         <p>When <code>href</code> attribute is present:</p>
         <ul>
-          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code></li>
-          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code></li>
-          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code></li>
-          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code></li>
-          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code></li>
-          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code></li>
-          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code></li>
-          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code></li>
-          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code></li>
-          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code></li>
+          <li>{{ARIARole("button")}}</li>
+          <li>{{ARIARole("checkbox")}}</li>
+          <li>{{ARIARole("menuitem")}}</li>
+          <li>{{ARIARole("menuitemcheckbox")}}</li>
+          <li>{{ARIARole("menuitemradio")}}</li>
+          <li>{{ARIARole("option")}}</li>
+          <li>{{ARIARole("radio")}}</li>
+          <li>{{ARIARole("switch")}}</li>
+          <li>{{ARIARole("tab")}}</li>
+          <li>{{ARIARole("treeitem")}}</li>
         </ul>
         <p>When <code>href</code> attribute is not present:</p>
         <ul>

--- a/files/pt-br/web/html/element/a/index.md
+++ b/files/pt-br/web/html/element/a/index.md
@@ -145,7 +145,7 @@ Os atributos do elemento incluem os [atributos globais](/pt-BR/docs/Web/HTML/Glo
     <tr>
       <th scope="row">Implicit ARIA role</th>
       <td>
-        {{ARIARole("link")}} when <code>href</code> attribute is
+        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/link_role">link</a></code> when <code>href</code> attribute is
         present, otherwise
         <a href="https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role"
           >no corresponding role</a
@@ -157,16 +157,16 @@ Os atributos do elemento incluem os [atributos globais](/pt-BR/docs/Web/HTML/Glo
       <td>
         <p>When <code>href</code> attribute is present:</p>
         <ul>
-          <li>{{ARIARole("button")}}</li>
-          <li>{{ARIARole("checkbox")}}</li>
-          <li>{{ARIARole("menuitem")}}</li>
-          <li>{{ARIARole("menuitemcheckbox")}}</li>
-          <li>{{ARIARole("menuitemradio")}}</li>
-          <li>{{ARIARole("option")}}</li>
-          <li>{{ARIARole("radio")}}</li>
-          <li>{{ARIARole("switch")}}</li>
-          <li>{{ARIARole("tab")}}</li>
-          <li>{{ARIARole("treeitem")}}</li>
+          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/button_role">button</a></code></li>
+          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/checkbox_role">checkbox</a></code></li>
+          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/menuitem_role">menuitem</a></code></li>
+          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/menuitemcheckbox_role">menuitemcheckbox</a></code></li>
+          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/menuitemradio_role">menuitemradio</a></code></li>
+          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/option_role">option</a></code></li>
+          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/radio_role">radio</a></code></li>
+          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/switch_role">switch</a></code></li>
+          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/tab_role">tab</a></code></li>
+          <li><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/treeitem_role">treeitem</a></code></li>
         </ul>
         <p>When <code>href</code> attribute is not present:</p>
         <ul>
@@ -188,9 +188,7 @@ Os atributos do elemento incluem os [atributos globais](/pt-BR/docs/Web/HTML/Glo
 #### HTML
 
 ```html
-<a href="https://www.mozilla.com">
-  Mozilla
-</a>
+<a href="https://www.mozilla.com"> Mozilla </a>
 ```
 
 #### Result
@@ -208,7 +206,10 @@ Os atributos do elemento incluem os [atributos globais](/pt-BR/docs/Web/HTML/Glo
 ```
 
 ```css hidden
-a { display: block; margin-bottom: 0.5em }
+a {
+  display: block;
+  margin-bottom: 0.5em;
+}
 ```
 
 #### Result
@@ -219,9 +220,7 @@ a { display: block; margin-bottom: 0.5em }
 
 ```html
 <!-- <a> element links to the section below -->
-<p><a href="#Section_further_down">
-  Jump to the heading below
-</a></p>
+<p><a href="#Section_further_down"> Jump to the heading below </a></p>
 
 <!-- Heading to link to -->
 <h2 id="Section_further_down">Section further down</h2>
@@ -264,7 +263,8 @@ To save a {{HTMLElement("canvas")}} element’s contents as an image, you can cr
 ##### HTML
 
 ```html
-<p>Paint by holding down the mouse button and moving it.
+<p>
+  Paint by holding down the mouse button and moving it.
   <a href="" download="my_painting.png">Download my painting</a>
 </p>
 
@@ -292,28 +292,31 @@ a {
 ##### JavaScript
 
 ```js
-var canvas = document.querySelector('canvas'),
-    c = canvas.getContext('2d');
-c.fillStyle = 'hotpink';
+var canvas = document.querySelector("canvas"),
+  c = canvas.getContext("2d");
+c.fillStyle = "hotpink";
 
 function draw(x, y) {
   if (isDrawing) {
     c.beginPath();
-    c.arc(x, y, 10, 0, Math.PI*2);
+    c.arc(x, y, 10, 0, Math.PI * 2);
     c.closePath();
     c.fill();
   }
 }
 
-canvas.addEventListener('mousemove', event =>
+canvas.addEventListener("mousemove", (event) =>
   draw(event.offsetX, event.offsetY)
 );
-canvas.addEventListener('mousedown', () => isDrawing = true);
-canvas.addEventListener('mouseup', () => isDrawing = false);
+canvas.addEventListener("mousedown", () => (isDrawing = true));
+canvas.addEventListener("mouseup", () => (isDrawing = false));
 
-document.querySelector('a').addEventListener('click', event =>
-  event.target.href = canvas.toDataURL()
-);
+document
+  .querySelector("a")
+  .addEventListener(
+    "click",
+    (event) => (event.target.href = canvas.toDataURL())
+  );
 ```
 
 ##### Result
@@ -337,9 +340,7 @@ Using `target="_blank"` without `rel="noreferrer"` and `rel="noopener"` makes th
 A sadly common mistake is to only link the words “click here” or “here”:
 
 ```html example-bad
-<p>
-  Learn more about our products <a href="/products">here</a>.
-</p>
+<p>Learn more about our products <a href="/products">here</a>.</p>
 ```
 
 #### Strong link text
@@ -347,9 +348,7 @@ A sadly common mistake is to only link the words “click here” or “here”:
 Luckily, this is an easy fix, and it’s actually shorter than the inaccessible version!
 
 ```html example-good
-<p>
-  Learn more <a href="/products">about our products</a>.
-</p>
+<p>Learn more <a href="/products">about our products</a>.</p>
 ```
 
 Assistive software have shortcuts to list all links on a page. However, strong link text benefits all users — the “list all links” shortcut emulates how sighted users quickly scan pages.
@@ -379,22 +378,20 @@ People experiencing low vision conditions, navigating with the aid of screen rea
 #### Link to a non-HTML resource
 
 ```html
-<a href="2017-annual-report.ppt">
-  2017 Annual Report (PowerPoint)
-</a>
+<a href="2017-annual-report.ppt"> 2017 Annual Report (PowerPoint) </a>
 ```
 
 If an icon is used to signify link behavior, make sure it has {{HTMLAttrxRef("alt", "img", "alt text", "true")}}:
 
 ```html
-<a  target="_blank" href="https://www.wikipedia.org">
+<a target="_blank" href="https://www.wikipedia.org">
   Wikipedia
-  <img alt="(opens in new tab)" src="newtab.svg">
+  <img alt="(opens in new tab)" src="newtab.svg" />
 </a>
 
 <a href="2017-annual-report.ppt">
   2017 Annual Report
-  <img alt="(PowerPoint file)" src="ppt-icon.svg">
+  <img alt="(PowerPoint file)" src="ppt-icon.svg" />
 </a>
 ```
 
@@ -460,12 +457,12 @@ Spacing may be created using CSS properties like {{CSSxRef("margin")}}.
 
 ## Specifications
 
-| Specification                                                                                                                            | Status                               | Comment                               |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------------------------- |
+| Specification                                                                                         | Status                       | Comment                               |
+| ----------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------------------------- |
 | {{SpecName("Referrer Policy", "#referrer-policy-delivery-referrer-attribute", "referrer attribute")}} | {{Spec2("Referrer Policy")}} | Added the `referrerpolicy` attribute. |
-| {{SpecName("HTML WHATWG", "textlevel-semantics.html#the-a-element", "&lt;a&gt;")}}                             | {{Spec2("HTML WHATWG")}}     |                                       |
-| {{SpecName("HTML5 W3C", "textlevel-semantics.html#the-a-element", "&lt;a&gt;")}}                             | {{Spec2("HTML5 W3C")}}         |                                       |
-| {{SpecName("HTML4.01", "struct/links.html#h-12.2", "&lt;a&gt;")}}                                                 | {{Spec2("HTML4.01")}}         |                                       |
+| {{SpecName("HTML WHATWG", "textlevel-semantics.html#the-a-element", "&lt;a&gt;")}}                    | {{Spec2("HTML WHATWG")}}     |                                       |
+| {{SpecName("HTML5 W3C", "textlevel-semantics.html#the-a-element", "&lt;a&gt;")}}                      | {{Spec2("HTML5 W3C")}}       |                                       |
+| {{SpecName("HTML4.01", "struct/links.html#h-12.2", "&lt;a&gt;")}}                                     | {{Spec2("HTML4.01")}}        |                                       |
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/html/element/dialog/index.md
+++ b/files/pt-br/web/html/element/dialog/index.md
@@ -1,5 +1,5 @@
 ---
-title: '<dialog>: O elemento Dialog'
+title: "<dialog>: O elemento Dialog"
 slug: Web/HTML/Element/dialog
 ---
 
@@ -42,7 +42,7 @@ O **elemento HTML `<dialog>`** representa uma caixa de diálogo ou outro compone
     </tr>
     <tr>
       <th scope="row">Permitted ARIA roles</th>
-      <td>{{ARIARole("alertdialog")}}</td>
+      <td><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/alertdialog_role">alertdialog</a></code></td>
     </tr>
     <tr>
       <th scope="row">DOM interface</th>
@@ -84,13 +84,15 @@ Este exemplo abre uma caixa de diálogo contendo um formulário quando o botão 
 <dialog open id="favDialog">
   <form method="dialog">
     <section>
-      <p><label for="favAnimal">Favorite animal:</label>
-      <select id="favAnimal">
-        <option></option>
-        <option>Brine shrimp</option>
-        <option>Red panda</option>
-        <option>Spider monkey</option>
-      </select></p>
+      <p>
+        <label for="favAnimal">Favorite animal:</label>
+        <select id="favAnimal">
+          <option></option>
+          <option>Brine shrimp</option>
+          <option>Red panda</option>
+          <option>Spider monkey</option>
+        </select>
+      </p>
     </section>
     <menu>
       <button id="cancel" type="reset">Cancel</button>
@@ -107,18 +109,18 @@ Este exemplo abre uma caixa de diálogo contendo um formulário quando o botão 
 #### JavaScript
 
 ```js
-(function() {
-  var updateButton = document.getElementById('updateDetails');
-  var cancelButton = document.getElementById('cancel');
-  var favDialog = document.getElementById('favDialog');
+(function () {
+  var updateButton = document.getElementById("updateDetails");
+  var cancelButton = document.getElementById("cancel");
+  var favDialog = document.getElementById("favDialog");
 
   // O botão Update abre uma Dialog
-  updateButton.addEventListener('click', function() {
+  updateButton.addEventListener("click", function () {
     favDialog.showModal();
   });
 
   // O botão cancelButtom fecha uma Dialog
-  cancelButton.addEventListener('click', function() {
+  cancelButton.addEventListener("click", function () {
     favDialog.close();
   });
 })();
@@ -130,9 +132,9 @@ Este exemplo abre uma caixa de diálogo contendo um formulário quando o botão 
 
 ## Especificações
 
-| Especificação                                                                                                            | Status                           | Comentário        |
-| ------------------------------------------------------------------------------------------------------------------------ | -------------------------------- | ----------------- |
-| {{SpecName('HTML WHATWG', 'forms.html#the-dialog-element', '&lt;dialog&gt;')}}                 | {{Spec2('HTML WHATWG')}} |                   |
+| Especificação                                                                             | Status                   | Comentário        |
+| ----------------------------------------------------------------------------------------- | ------------------------ | ----------------- |
+| {{SpecName('HTML WHATWG', 'forms.html#the-dialog-element', '&lt;dialog&gt;')}}            | {{Spec2('HTML WHATWG')}} |                   |
 | {{SpecName('HTML5.2', 'interactive-elements.html#the-dialog-element', '&lt;dialog&gt;')}} | {{Spec2('HTML5.2')}}     | Difinição inicial |
 
 ## Compatibilidade com navegadores

--- a/files/pt-br/web/html/element/dialog/index.md
+++ b/files/pt-br/web/html/element/dialog/index.md
@@ -42,7 +42,7 @@ O **elemento HTML `<dialog>`** representa uma caixa de diálogo ou outro compone
     </tr>
     <tr>
       <th scope="row">Permitted ARIA roles</th>
-      <td><code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code></td>
+      <td>{{ARIARole("alertdialog")}}</td>
     </tr>
     <tr>
       <th scope="row">DOM interface</th>

--- a/files/pt-br/web/html/element/section/index.md
+++ b/files/pt-br/web/html/element/section/index.md
@@ -50,15 +50,15 @@ Por exemplo, um menu de navegação deve estar dentro um elemento {{htmlelement 
     <tr>
       <th scope="row">Regras ARIA permitidas</th>
       <td>
-        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>, <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>,
-        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>, <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>,
-        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>,
-        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>, <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>,
-        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>, <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>,
-        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>, <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>,
-        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>, <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>,
-        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>, <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>,
-        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/_role"></a></code>
+        {{ARIARole("alert")}}, {{ARIARole("alertdialog")}},
+        {{ARIARole("application")}}, {{ARIARole("banner")}},
+        {{ARIARole("complementary")}},
+        {{ARIARole("contentinfo")}}, {{ARIARole("dialog")}},
+        {{ARIARole("document")}}, {{ARIARole("feed")}},
+        {{ARIARole("log")}}, {{ARIARole("main")}},
+        {{ARIARole("marquee")}}, {{ARIARole("navigation")}},
+        {{ARIARole("search")}}, {{ARIARole("status")}},
+        {{ARIARole("tabpanel")}}
       </td>
     </tr>
     <tr>

--- a/files/pt-br/web/html/element/section/index.md
+++ b/files/pt-br/web/html/element/section/index.md
@@ -50,15 +50,15 @@ Por exemplo, um menu de navegação deve estar dentro um elemento {{htmlelement 
     <tr>
       <th scope="row">Regras ARIA permitidas</th>
       <td>
-        {{ARIARole("alert")}}, {{ARIARole("alertdialog")}},
-        {{ARIARole("application")}}, {{ARIARole("banner")}},
-        {{ARIARole("complementary")}},
-        {{ARIARole("contentinfo")}}, {{ARIARole("dialog")}},
-        {{ARIARole("document")}}, {{ARIARole("feed")}},
-        {{ARIARole("log")}}, {{ARIARole("main")}},
-        {{ARIARole("marquee")}}, {{ARIARole("navigation")}},
-        {{ARIARole("search")}}, {{ARIARole("status")}},
-        {{ARIARole("tabpanel")}}
+        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/alert_role">alert</a></code>, <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/alertdialog_role">alertdialog</a></code>,
+        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/application_role">application</a></code>, <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/banner_role">banner</a></code>,
+        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/complementary_role">complementary</a></code>,
+        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/contentinfo_role">contentinfo</a></code>, <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/dialog_role">dialog</a></code>,
+        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/document_role">document</a></code>, <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/feed_role">feed</a></code>,
+        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/log_role">log</a></code>, <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/main_role">main</a></code>,
+        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/marquee_role">marquee</a></code>, <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/navigation_role">navigation</a></code>,
+        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/search_role">search</a></code>, <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/status_role">status</a></code>,
+        <code><a href="/pt-br/docs/Web/Accessibility/ARIA/Roles/tabpanel_role">tabpanel</a></code>
       </td>
     </tr>
     <tr>
@@ -105,7 +105,7 @@ Este elemento inclui apenas os [atributos globais](/pt-BR/docs/Web/HTML/Global_a
 ```html
 <div>
   <h2>Cabeçalho</h2>
-  <img src="passaro.jpg" alt="pássaro">
+  <img src="passaro.jpg" alt="pássaro" />
 </div>
 ```
 
@@ -114,17 +114,18 @@ Este elemento inclui apenas os [atributos globais](/pt-BR/docs/Web/HTML/Global_a
 ```html
 <section>
   <h2>Cabeçalho</h2>
-  <img src="passaro.jpg" alt="pássaro">
-</section>​​​​​
+  <img src="passaro.jpg" alt="pássaro" />
+</section>
+​​​​​
 ```
 
 ## Especificações
 
-| Especificação                                                                                                    | Status                           | Comentários |
-| ---------------------------------------------------------------------------------------------------------------- | -------------------------------- | ----------- |
+| Especificação                                                                       | Status                   | Comentários |
+| ----------------------------------------------------------------------------------- | ------------------------ | ----------- |
 | {{SpecName('HTML WHATWG', 'sections.html#the-section-element', '&lt;section&gt;')}} | {{Spec2('HTML WHATWG')}} |             |
-| {{SpecName('HTML5.1', 'sections.html#the-section-element', '&lt;section&gt;')}}         | {{Spec2('HTML5.1')}}     |             |
-| {{SpecName('HTML5 W3C', 'sections.html#the-section-element', '&lt;section&gt;')}}     | {{Spec2('HTML5 W3C')}}     |             |
+| {{SpecName('HTML5.1', 'sections.html#the-section-element', '&lt;section&gt;')}}     | {{Spec2('HTML5.1')}}     |             |
+| {{SpecName('HTML5 W3C', 'sections.html#the-section-element', '&lt;section&gt;')}}   | {{Spec2('HTML5 W3C')}}   |             |
 
 ## Compatibilidade com navegadores
 


### PR DESCRIPTION
This PR fixes the changes made in #11341.  The regex search-and-replace had an issue that caused the links and text to break, thus unfortunately breaking the localizations.
