### PR TITLE
chore(fr): replace {{JSRef}} macro in webassembly

### DIFF
--- a/files/fr/webassembly/javascript_interface/compile/index.md
+++ b/files/fr/webassembly/javascript_interface/compile/index.md
@@ -11,7 +11,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/compile
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/compile
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 La méthode **`WebAssembly.compile()`**, permet de compiler un module ({{jsxref("WebAssembly.Module")}} à partir d'un code binaire WebAssembly. Cette fonction est utile lorsqu'il est nécessaire de compiler un module avant de l'instancier (dans les autres cas, la méthode {{jsxref("WebAssembly.instantiate()")}} sera plus pertinente).
 

--- a/files/fr/webassembly/javascript_interface/compileerror/compileerror/index.md
+++ b/files/fr/webassembly/javascript_interface/compileerror/compileerror/index.md
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError/
 browser-compat: javascript.builtins.WebAssembly.CompileError.CompileError
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 Le constructeur **`WebAssembly.CompileError()`** crée un nouvel objet `CompileError` WebAssembly qui représente une erreur qui se produit lors du décodage ou de la validation du code WebAssembly.
 

--- a/files/fr/webassembly/javascript_interface/compileerror/index.md
+++ b/files/fr/webassembly/javascript_interface/compileerror/index.md
@@ -14,7 +14,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 Le constructeur **`WebAssembly.CompileError()`** permet de créer une nouvelle instance de `CompileError` qui indique qu'une erreur s'est produite lors du décodage du code WebAssembly ou lors de sa validation.
 

--- a/files/fr/webassembly/javascript_interface/compilestreaming/index.md
+++ b/files/fr/webassembly/javascript_interface/compilestreaming/index.md
@@ -12,7 +12,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/compileStrea
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/compileStreaming
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 La fonction **`WebAssembly.compileStreaming()`** permet de compiler un module WebAssembly (c'est-à-dire un objet {{jsxref("WebAssembly.Module")}}) depuis un flux source. Cette fonction est utile si on doit compiler un module avant de l'instancier séparement, sinon on utilisera plutôt {{jsxref("WebAssembly.instantiateStreaming()")}}.
 

--- a/files/fr/webassembly/javascript_interface/exception/exception/index.md
+++ b/files/fr/webassembly/javascript_interface/exception/exception/index.md
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/Exc
 browser-compat: javascript.builtins.WebAssembly.Exception.Exception
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 Le constructeur **`WebAssembly.Exception()`** permet de créer des objets [`WebAssembly.Exception`](/fr/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception).
 

--- a/files/fr/webassembly/javascript_interface/exception/getarg/index.md
+++ b/files/fr/webassembly/javascript_interface/exception/getarg/index.md
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/get
 browser-compat: javascript.builtins.WebAssembly.Exception.getArg
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 La méthode **`getArg()`**, rattachée au prototype d'un objet [`Exception`](/fr/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception), permet d'obtenir la valeur d'un élément spécifique parmi les arguments de donnée d'une exception.
 

--- a/files/fr/webassembly/javascript_interface/exception/index.md
+++ b/files/fr/webassembly/javascript_interface/exception/index.md
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception
 browser-compat: javascript.builtins.WebAssembly.Exception
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 Un objet **`WebAssembly.Exception`** représente une exception d'exécution levée depuis WebAssembly vers JavaScript ou levée depuis JavaScript vers un gestionnaire d'exception WebAssembly.
 

--- a/files/fr/webassembly/javascript_interface/exception/is/index.md
+++ b/files/fr/webassembly/javascript_interface/exception/is/index.md
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/is
 browser-compat: javascript.builtins.WebAssembly.Exception.is
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 La méthode **`is()`**, rattachée au prototype d'un objet [`Exception`](/fr/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception), peut être utilisée afin de déterminer si l'objet `Exception` correspond à une balise donnée.
 

--- a/files/fr/webassembly/javascript_interface/exception/stack/index.md
+++ b/files/fr/webassembly/javascript_interface/exception/stack/index.md
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/sta
 browser-compat: javascript.builtins.WebAssembly.Exception.stack
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 La propriété en lecture seule **`stack`**, rattachée à une instance d'[`Exception`](/fr/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception) _peut_ contenir une trace de pile d'appels pour une exception levée par du code WebAssembly.
 

--- a/files/fr/webassembly/javascript_interface/global/global/index.md
+++ b/files/fr/webassembly/javascript_interface/global/global/index.md
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Global/Global
 browser-compat: javascript.builtins.WebAssembly.Global.Global
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 Le constructeur **`WebAssembly.Global()`** permet de créer un nouvel objet `Global` représentant une instance d'une variable globale, accessible depuis le code JavaScript et importable/exportable dans plusieurs instances de [`WebAssembly.Module`](/fr/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module). Cela permet la liaison dynamique de plusieurs modules.
 

--- a/files/fr/webassembly/javascript_interface/global/index.md
+++ b/files/fr/webassembly/javascript_interface/global/index.md
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Global
 browser-compat: javascript.builtins.WebAssembly.Global
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 Un objet **`WebAssembly.Global`** représente une instance d'une variable globale, accessible depuis le code JavaScript et importable/exportable pour un ou plusieurs modules WebAssembly ([`WebAssembly.Module`](/fr/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module)). Cela permet de lier dynamiquement plusieurs modules.
 

--- a/files/fr/webassembly/javascript_interface/index.md
+++ b/files/fr/webassembly/javascript_interface/index.md
@@ -11,7 +11,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 L'objet JavaScript **`WebAssembly`** est un objet global qui agit comme un espace de noms (_namespace_) pour les différentes fonctionnalités JavaScript relatives à [WebAssembly](/fr/docs/WebAssembly).
 

--- a/files/fr/webassembly/javascript_interface/instance/exports/index.md
+++ b/files/fr/webassembly/javascript_interface/instance/exports/index.md
@@ -13,7 +13,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/exp
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/exports
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 La propriété **`exports`** du prototype de {{jsxref("WebAssembly.Instance")}} est une propriété en lecture seul qui renvoie un objet dont les propriétés sont les différentes fonctions exportées depuis l'instance du module WebAssembly. Cela permet d'y accéder et de les manipuler en JavaScript.
 

--- a/files/fr/webassembly/javascript_interface/instance/index.md
+++ b/files/fr/webassembly/javascript_interface/instance/index.md
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance
 browser-compat: javascript.builtins.WebAssembly.Instance
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 Un objet **`WebAssembly.Instance`** représente un objet exécutable, avec un état, qui est une instance d'un [module WebAssembly](/fr/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module). Un objet `Instance` contient l'ensemble [des fonctions WebAssembly exportées](/fr/docs/WebAssembly/Exported_functions) qui permettent d'invoquer du code WebAssembly depuis du code JavaScript.
 

--- a/files/fr/webassembly/javascript_interface/instance/instance/index.md
+++ b/files/fr/webassembly/javascript_interface/instance/instance/index.md
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/Inst
 browser-compat: javascript.builtins.WebAssembly.Instance.Instance
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 Le constructeur **`WebAssembly.Instance()`** crée un nouvel objet `Instance` qui représente une instance sans état et exécutable d'un [`WebAssembly.Module`](/fr/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module).
 

--- a/files/fr/webassembly/javascript_interface/instantiate/index.md
+++ b/files/fr/webassembly/javascript_interface/instantiate/index.md
@@ -11,7 +11,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiate
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiate
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 La fonction **`WebAssembly.instantiate()`** permet de compiler et d'instancier du code WebAssembly. Cette fonction possède deux formes :
 

--- a/files/fr/webassembly/javascript_interface/instantiatestreaming/index.md
+++ b/files/fr/webassembly/javascript_interface/instantiatestreaming/index.md
@@ -12,7 +12,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateS
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 La fonction **`WebAssembly.instantiateStreaming()`** permet de compiler et d'instancier un module WebAssembly depuis un flux source. C'est la méthode la plus efficace, et la plus optimisée, permettant de charger du code WebAssembly.
 

--- a/files/fr/webassembly/javascript_interface/linkerror/index.md
+++ b/files/fr/webassembly/javascript_interface/linkerror/index.md
@@ -12,7 +12,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/LinkError
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/LinkError
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 Le constructeur **`WebAssembly.LinkError()`** permet de créer un nouvel objet WebAssembly `LinkError` qui indique qu'une erreur s'est produite lors de l'instanciation du module (en plus [des trappes](http://webassembly.org/docs/semantics/#traps) provenant de la fonction initiale).
 

--- a/files/fr/webassembly/javascript_interface/linkerror/linkerror/index.md
+++ b/files/fr/webassembly/javascript_interface/linkerror/linkerror/index.md
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/LinkError/Lin
 browser-compat: javascript.builtins.WebAssembly.LinkError.LinkError
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 Le constructeur **`WebAssembly.LinkError()`** crée un nouvel objet `LinkError` WebAssembly qui indique une erreur lors de l'instanciation du module (en dehors des [trapoess](https://webassembly.org/docs/semantics/#traps) de la fonction de départ).
 

--- a/files/fr/webassembly/javascript_interface/memory/buffer/index.md
+++ b/files/fr/webassembly/javascript_interface/memory/buffer/index.md
@@ -12,7 +12,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/buffe
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/buffer
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 La propriété **`buffer`**, rattachée au prototype de l'objet [`Memory`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/WebAssembly/Memory), renvoie le tampon (_buffer_) contenu dans l'espace mémoire.
 

--- a/files/fr/webassembly/javascript_interface/memory/grow/index.md
+++ b/files/fr/webassembly/javascript_interface/memory/grow/index.md
@@ -12,7 +12,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/grow
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/grow
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 La méthode **`grow()`**, rattachée au prototype de l'objet [`Memory`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/WebAssembly/Memory), permet d'augmenter la taille de l'espace mémoire correspondant d'un nombre de pages WebAssembly.
 

--- a/files/fr/webassembly/javascript_interface/memory/index.md
+++ b/files/fr/webassembly/javascript_interface/memory/index.md
@@ -12,7 +12,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 Le constructeur **`WebAssembly.Memory()`** crée un nouvel objet `Memory` dont la propriété {{jsxref("WebAssembly/Memory/buffer","buffer")}} est un {{jsxref("ArrayBuffer")}} redimensionnable qui contient les octets de mémoire bruts accessibles par une instance WebAssembly.
 

--- a/files/fr/webassembly/javascript_interface/memory/memory/index.md
+++ b/files/fr/webassembly/javascript_interface/memory/memory/index.md
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/Memory
 browser-compat: javascript.builtins.WebAssembly.Memory.Memory
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 Le constructeur **`WebAssembly.Memory()`** permet de créer un nouvel objet `Memory` dont la propriété [`buffer`](/fr/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/buffer) est un tableau tampon [`ArrayBuffer`](/fr/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) redimensionnable ou un `SharedArrayBuffer` contenant les octets bruts de mémoire à laquelle accède une `Instance` WebAssembly.
 

--- a/files/fr/webassembly/javascript_interface/module/customsections/index.md
+++ b/files/fr/webassembly/javascript_interface/module/customsections/index.md
@@ -14,7 +14,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/custo
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/customSections
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 La méthode **`WebAssembly.customSections()`** renvoie un tableau qui contient les sections personnalisées (_custom sections_) disponibles dans un module WebAssembly et qui ont un nom donné.
 

--- a/files/fr/webassembly/javascript_interface/module/exports/index.md
+++ b/files/fr/webassembly/javascript_interface/module/exports/index.md
@@ -14,7 +14,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/expor
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/exports
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 La fonction **`WebAssembly.Module.exports()`** renvoie un tableau qui contient les descriptions des exports déclarés pour un module donné.
 

--- a/files/fr/webassembly/javascript_interface/module/imports/index.md
+++ b/files/fr/webassembly/javascript_interface/module/imports/index.md
@@ -12,7 +12,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/impor
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/imports
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 La méthode **`WebAssembly.imports()`** renvoie un tableau qui contient les références des fonctions importées qui sont disponibles dans un module WebAssembly donné.
 

--- a/files/fr/webassembly/javascript_interface/module/index.md
+++ b/files/fr/webassembly/javascript_interface/module/index.md
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module
 browser-compat: javascript.builtins.WebAssembly.Module
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 Un objet **`WebAssembly.Module`** contient du code WebAssembly, sans état et qui a déjà été compilé par le navigateur. Ce code peut être [partagé avec des <i lang="en">web workers</i>](/fr/docs/Web/API/Worker/postMessage) et être instancié à plusieurs reprises.
 

--- a/files/fr/webassembly/javascript_interface/module/module/index.md
+++ b/files/fr/webassembly/javascript_interface/module/module/index.md
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/Module
 browser-compat: javascript.builtins.WebAssembly.Module.Module
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 Le constructeur **`WebAssembly.Module()`** crée un nouvel objet `Module` contenant du code WebAssembly sans état qui a déjà été compilé par le navigateur et qui peut efficacement [être partagé avec des workers](/fr/docs/Web/API/Worker/postMessage) et être instancié plusieurs fois.
 

--- a/files/fr/webassembly/javascript_interface/runtimeerror/index.md
+++ b/files/fr/webassembly/javascript_interface/runtimeerror/index.md
@@ -12,7 +12,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 Le constructeur **`WebAssembly.RuntimeError()`** permet de créer un nouvel objet WebAssembly `RuntimeError`. C'est ce type d'exception qui est déclenchée lorsque WebAssembly définit [une trappe](http://webassembly.org/docs/semantics/#traps).
 

--- a/files/fr/webassembly/javascript_interface/runtimeerror/runtimeerror/index.md
+++ b/files/fr/webassembly/javascript_interface/runtimeerror/runtimeerror/index.md
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError/
 browser-compat: javascript.builtins.WebAssembly.RuntimeError.RuntimeError
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 Le constructeur **`WebAssembly.RuntimeError()`** crée un nouvel objet `RuntimeError` WebAssembly, une erreur levée quand WebAssembly définit une [trappe](https://webassembly.org/docs/semantics/#traps).
 

--- a/files/fr/webassembly/javascript_interface/table/get/index.md
+++ b/files/fr/webassembly/javascript_interface/table/get/index.md
@@ -12,7 +12,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/get
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/get
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 La méthode **`get()`**, rattachéee au prototype de {{jsxref("WebAssembly.Table()")}}, permet de récupérer une référence à une fonction stockée dans le tableau WebAssembly grâce à sa position. dans le tableau.
 

--- a/files/fr/webassembly/javascript_interface/table/grow/index.md
+++ b/files/fr/webassembly/javascript_interface/table/grow/index.md
@@ -12,7 +12,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/grow
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/grow
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 La méthode **`grow()`**, rattachée au prototype de {{jsxref("WebAssembly.Table")}}, permet d'augmenter la taille du tableau WebAssembly d'un nombre d'éléments donné.
 

--- a/files/fr/webassembly/javascript_interface/table/index.md
+++ b/files/fr/webassembly/javascript_interface/table/index.md
@@ -12,7 +12,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 Le constructeur **`WebAssembly.Table()`** permet de créer un nouvel objet `Table`.
 

--- a/files/fr/webassembly/javascript_interface/table/length/index.md
+++ b/files/fr/webassembly/javascript_interface/table/length/index.md
@@ -12,7 +12,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/length
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/length
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 La propriété **`length`**, rattachée au prototype de l'objet {{jsxref("WebAssembly.Table")}}, renvoie la longueur du tableau WebAssembly, c'est-à-dire le nombre d'éléments qui y sont stockées.
 

--- a/files/fr/webassembly/javascript_interface/table/set/index.md
+++ b/files/fr/webassembly/javascript_interface/table/set/index.md
@@ -12,7 +12,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/set
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/set
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 La méthode **`set()`**, rattachée au prototype de {{jsxref("WebAssembly.Table")}}, permet de modifier une référence de fonction stockée dans un tableau WebAssembly.
 

--- a/files/fr/webassembly/javascript_interface/table/table/index.md
+++ b/files/fr/webassembly/javascript_interface/table/table/index.md
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/Table
 browser-compat: javascript.builtins.WebAssembly.Table.Table
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 Le constructeur **`WebAssembly.Table()`** crée un nouvel objet `Table` de la taille et du type d'élément donné.
 

--- a/files/fr/webassembly/javascript_interface/tag/index.md
+++ b/files/fr/webassembly/javascript_interface/tag/index.md
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag
 browser-compat: javascript.builtins.WebAssembly.Tag
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 L'objet **`WebAssembly.Tag`** définit un _type_ d'exception WebAssembly qui peut être levée depuis ou vers du code WebAssembly.
 

--- a/files/fr/webassembly/javascript_interface/tag/tag/index.md
+++ b/files/fr/webassembly/javascript_interface/tag/tag/index.md
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag/Tag
 browser-compat: javascript.builtins.WebAssembly.Tag.Tag
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 Le constructeur **`WebAssembly.Tag()`** crée un nouvel objet [`WebAssembly.Tag`](/fr/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag).
 

--- a/files/fr/webassembly/javascript_interface/tag/type/index.md
+++ b/files/fr/webassembly/javascript_interface/tag/type/index.md
@@ -6,7 +6,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag/type
 browser-compat: javascript.builtins.WebAssembly.Tag.type
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 La méthode **`type()`**, rattachée au prototype d'un objet [`Tag`](/fr/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag), permet d'accéder à la séquence des types de données associés à la balise.
 

--- a/files/fr/webassembly/javascript_interface/validate/index.md
+++ b/files/fr/webassembly/javascript_interface/validate/index.md
@@ -11,7 +11,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/validate
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/validate
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 La fonction **`WebAssembly.validate()`** permet de valider un [tableau typé](/fr/docs/Web/JavaScript/Tableaux_typés) de _bytecode_ WebAssembly et renvoie un booléen qui indique si le contenu du tableau forme un module WebAssembly valide (`true`) ou non (`false`).
 


### PR DESCRIPTION
### Description

chore(fr): remove {{JSRef}} macro in webassembly

### Related issues and pull requests

Part of: #11430
