### PR TITLE
chore(es): replace {{JSRef}} macro in webassembly

### DIFF
--- a/files/es/webassembly/javascript_interface/index.md
+++ b/files/es/webassembly/javascript_interface/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 El objeto **`WebAssembly`** de JavaScript actua como un namespace para todas las funcionalidades realcionados con [WebAssembly](/es/docs/WebAssembly).
 


### PR DESCRIPTION
### Description

chore(es): remove {{JSRef}} macro in webassembly

### Related issues and pull requests

Part of: #11430
