### PR TITLE
chore(ja): replace {{JSRef}} macro in webassembly

### DIFF
--- a/files/ja/webassembly/javascript_interface/compile/index.md
+++ b/files/ja/webassembly/javascript_interface/compile/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/compile
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/compile
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`WebAssembly.compile()`** 関数は WebAssembly バイナリーコードを {{jsxref("WebAssembly.Module")}} の形にコンパイルします。この関数は、モジュールをインスタンス化する前にコンパイルする必要がある場合に便利です (それ以外の場合は、 {{jsxref("WebAssembly.instantiate()")}} 関数を使用してください)。</p>
 

--- a/files/ja/webassembly/javascript_interface/compileerror/compileerror/index.md
+++ b/files/ja/webassembly/javascript_interface/compileerror/compileerror/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/CompileError/CompileError
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError/CompileError
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`WebAssembly.CompileError()`** コンストラクターは、新しい WebAssembly の `CompileError` オブジェクトを生成します。これは WebAssembly のデコードまたは検証中のエラーを示します。
 

--- a/files/ja/webassembly/javascript_interface/compileerror/index.md
+++ b/files/ja/webassembly/javascript_interface/compileerror/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/CompileError
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`WebAssembly.CompileError`** オブジェクトは、 WebAssembly のデコードや検証の間のエラーを示します。
 

--- a/files/ja/webassembly/javascript_interface/global/global/index.md
+++ b/files/ja/webassembly/javascript_interface/global/global/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/Global/Global
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Global/Global
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`WebAssembly.Global()`** コンストラクターは、グローバル変数のインスタンスを表す新しい `Global` オブジェクトを表し、これは JavaScript からアクセス可能で、 1 つ以上の {{jsxref("WebAssembly.Module")}} インスタンスの間でインポート/エクスポート可能です。これにより、複数のモジュールを動的リンクすることができます。
 

--- a/files/ja/webassembly/javascript_interface/global/index.md
+++ b/files/ja/webassembly/javascript_interface/global/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/Global
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Global
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`WebAssembly.Global`** はグローバル変数のインスタンスを表します。 JavaScript からアクセスでき、1つ以上の {{jsxref("WebAssembly.Module")}} インスタンス間でインポート/エクスポートすることができます。これにより複数のモジュールを動的にリンクすることができます。
 

--- a/files/ja/webassembly/javascript_interface/index.md
+++ b/files/ja/webassembly/javascript_interface/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`WebAssembly`** は JavaScript のオブジェクトで、 [WebAssembly](/ja/docs/WebAssembly) に関するすべての機能の名前空間の役割をします。
 

--- a/files/ja/webassembly/javascript_interface/instance/exports/index.md
+++ b/files/ja/webassembly/javascript_interface/instance/exports/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/Instance/exports
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/exports
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`exports`** は {{jsxref("WebAssembly.Instance")}} オブジェクトプロトタイプの読み取り専用プロパティで、 WebAssembly モジュールインスタンスからエクスポートされたすべての関数をメンバ－として持つオブジェクトを返します。これらは、 JavaScript からアクセスして使用することができます。
 

--- a/files/ja/webassembly/javascript_interface/instance/index.md
+++ b/files/ja/webassembly/javascript_interface/instance/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/Instance
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`WebAssembly.Instance`** オブジェクトは、ステートフルで実行可能な {{jsxref("WebAssembly.Module")}} のインスタンスです。 `Instance` オブジェクトには JavaScript から WebAssembly コードを呼び出すことができるすべての[エクスポートされた WebAssembly 関数](/ja/docs/WebAssembly/Exported_functions)が含まれます。
 

--- a/files/ja/webassembly/javascript_interface/instance/instance/index.md
+++ b/files/ja/webassembly/javascript_interface/instance/instance/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/Instance/Instance
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/Instance
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`WebAssembly.Instance()`** コンストラクターは、新しい `Instance` オブジェクトを生成します。これはステートフルで実行可能な {{jsxref("WebAssembly.Module")}} のインスタンスです。
 

--- a/files/ja/webassembly/javascript_interface/instantiate/index.md
+++ b/files/ja/webassembly/javascript_interface/instantiate/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/instantiate
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiate
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`WebAssembly.instantiate()`** 関数は WebAssembly コードをコンパイルおよびインスタンス化することができます。この関数は 2 つのオーバーロードを持ちます。
 

--- a/files/ja/webassembly/javascript_interface/linkerror/index.md
+++ b/files/ja/webassembly/javascript_interface/linkerror/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/LinkError
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/LinkError
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`WebAssembly.RuntimeLinkError`** オブジェクトは、モジュールのインスタンス化の際に発生したエラーを示します (開始した関数での[トラップ](https://webassembly.org/docs/semantics/#traps)を除く)。
 

--- a/files/ja/webassembly/javascript_interface/linkerror/linkerror/index.md
+++ b/files/ja/webassembly/javascript_interface/linkerror/linkerror/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/LinkError/LinkError
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/LinkError/LinkError
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`WebAssembly.LinkError()`** コンストラクターは、新しい WebAssembly `LinkError` オブジェクトを生成します。これは、 (関数開始後の[トラップ](https://webassembly.org/docs/semantics/#traps)ではなく) モジュールがインスタンス化される間に発生したエラーを発生します。
 

--- a/files/ja/webassembly/javascript_interface/memory/buffer/index.md
+++ b/files/ja/webassembly/javascript_interface/memory/buffer/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/Memory/buffer
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/buffer
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`buffer`** は {{jsxref("WebAssembly.Memory")}} オブジェクトのプロトタイププロパティで、メモリーに含まれるバッファーを返します。
 

--- a/files/ja/webassembly/javascript_interface/memory/grow/index.md
+++ b/files/ja/webassembly/javascript_interface/memory/grow/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/Memory/grow
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/grow
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`grow()`** は [`Memory`](/ja/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory) オブジェクトのプロトタイプメソッドで、指定した WebAssembly ページの数だけメモリーインスタンスの大きさを拡張します。
 

--- a/files/ja/webassembly/javascript_interface/memory/index.md
+++ b/files/ja/webassembly/javascript_interface/memory/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/Memory
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`WebAssembly.Memory`** オブジェクトはサイズ変更可能な {{jsxref("ArrayBuffer")}} または [`SharedArrayBuffer`](/ja/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) であり、 WebAssembly `Instance` からアクセスする生のバイト列のメモリーを持ちます。</p>
 

--- a/files/ja/webassembly/javascript_interface/memory/memory/index.md
+++ b/files/ja/webassembly/javascript_interface/memory/memory/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/Memory/Memory
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/Memory
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`WebAssembly.Memory()`** コンストラクターは新しい `Memory` オブジェクトを生成します。これは {{jsxref("WebAssembly/Memory/buffer","buffer")}} プロパティがサイズ変更可能な [`ArrayBuffer`](/ja/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) または `SharedArrayBuffer` であり、 WebAssembly の `Instance` からアクセスする生のバイト列のメモリーであるものです。
 

--- a/files/ja/webassembly/javascript_interface/module/customsections/index.md
+++ b/files/ja/webassembly/javascript_interface/module/customsections/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/Module/customSections
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/customSections
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`WebAssembly.customSections()`** 関数はモジュールと文字列名を指定して、すべてのカスタムセクションのコンテンツのコピーを返します。
 

--- a/files/ja/webassembly/javascript_interface/module/exports/index.md
+++ b/files/ja/webassembly/javascript_interface/module/exports/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/Module/exports
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/exports
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`WebAssembly.Module.exports()`** 関数は、指定された `Module` のエクスポート宣言の定義の配列を返します。
 

--- a/files/ja/webassembly/javascript_interface/module/imports/index.md
+++ b/files/ja/webassembly/javascript_interface/module/imports/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/Module/imports
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/imports
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`WebAssembly.imports()`** 関数は、指定された `Module` の全てのインポート宣言の定義を配列として返します。
 

--- a/files/ja/webassembly/javascript_interface/module/index.md
+++ b/files/ja/webassembly/javascript_interface/module/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/Module
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`WebAssembly.Module`** オブジェクトには、ブラウザーでコンパイルされたステートレスな WebAssembly コードが含まれています。これを効率的に[ワーカー間で共有](/ja/docs/Web/API/Worker/postMessage)したり、複数回インスタンス化したりすることができます。
 

--- a/files/ja/webassembly/javascript_interface/module/module/index.md
+++ b/files/ja/webassembly/javascript_interface/module/module/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/Module/Module
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/Module
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`WebAssembly.Module()`** コンストラクターは、ステートレスな WebAssembly コードを含む新しい Module オブジェクトを生成します。これはブラウザーでコンパイルされ、[Worker と効率的に共有する](/ja/docs/Web/API/Worker/postMessage)ことができ、複数回インスタンス化することができます。
 

--- a/files/ja/webassembly/javascript_interface/runtimeerror/index.md
+++ b/files/ja/webassembly/javascript_interface/runtimeerror/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/RuntimeError
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`WebAssembly.RuntimeError`** オブジェクトは、 WebAssembly が[トラップ](https://webassembly.org/docs/semantics/#traps)を指定するたびに例外として発生するエラー型です。
 

--- a/files/ja/webassembly/javascript_interface/runtimeerror/runtimeerror/index.md
+++ b/files/ja/webassembly/javascript_interface/runtimeerror/runtimeerror/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/RuntimeError/RuntimeError
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError/RuntimeError
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`WebAssembly.RuntimeError()`** コンストラクターは、新しい WebAssembly `RuntimeError` オブジェクトを生成します。これは、 WebAssembly が[トラップ](https://webassembly.org/docs/semantics/#traps)を指定するたびに例外として発生する型です。
 

--- a/files/ja/webassembly/javascript_interface/table/get/index.md
+++ b/files/ja/webassembly/javascript_interface/table/get/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/Table/get
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/get
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`get()`** は {{jsxref("WebAssembly.Table")}} オブジェクトのプロトタイプメソッドで、指定された位置に格納されている関数参照を取得します。
 

--- a/files/ja/webassembly/javascript_interface/table/grow/index.md
+++ b/files/ja/webassembly/javascript_interface/table/grow/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/Table/grow
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/grow
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`grow()`** は {{jsxref("WebAssembly.Table")}} オブジェクトのプロトタイプメソッドで、 Table インスタンスの大きさを指定された要素数だけ拡張します。
 

--- a/files/ja/webassembly/javascript_interface/table/index.md
+++ b/files/ja/webassembly/javascript_interface/table/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/Table
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`WebAssembly.Table()`** オブジェクトは JavaScript のラッパーオブジェクトであり、関数の参照を格納する WebAssembly Table を表す配列風の構造を持っています。 JavaScript や WebAssembly のコードで作成されたテーブルは、 JavaScript と WebAssembly の両方からアクセスでき、変更もできます。
 

--- a/files/ja/webassembly/javascript_interface/table/length/index.md
+++ b/files/ja/webassembly/javascript_interface/table/length/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/Table/length
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/length
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`length`** は {{jsxref("WebAssembly.Table")}} オブジェクトのプロトタイププロパティで、このテーブルの長さ、すなわち、テーブルの要素の数を返します。
 

--- a/files/ja/webassembly/javascript_interface/table/set/index.md
+++ b/files/ja/webassembly/javascript_interface/table/set/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/Table/set
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/set
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`set()`** は {{jsxref("WebAssembly.Table")}} オブジェクトのプロトタイプメソッドで、指定された位置に格納されている参照を別な値に変更します。
 

--- a/files/ja/webassembly/javascript_interface/table/table/index.md
+++ b/files/ja/webassembly/javascript_interface/table/table/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/Table/Table
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/Table
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`WebAssembly.Table()`** コンストラクターは、大きさと要素の型を指定して新しい `Table` オブジェクトを生成します。
 

--- a/files/ja/webassembly/javascript_interface/validate/index.md
+++ b/files/ja/webassembly/javascript_interface/validate/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/validate
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/validate
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 **`WebAssembly.validate()`** 関数は WebAssembly バイナリーコードの[型付き配列](/ja/docs/Web/JavaScript/Typed_arrays)を検証し、そのバイト列が有効な wasm モジュールか (`true`)、そうでないか (`false`) を返します。
 


### PR DESCRIPTION
### Description

chore(ja): remove {{JSRef}} macro in webassembly

### Related issues and pull requests

Part of: #11430
