### PR TITLE
chore(ru): replace {{JSRef}} macro in webassembly

### DIFF
--- a/files/ru/webassembly/javascript_interface/compile/index.md
+++ b/files/ru/webassembly/javascript_interface/compile/index.md
@@ -4,7 +4,8 @@ slug: WebAssembly/JavaScript_interface/compile
 translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/compile
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/compile
 ---
-{{JSRef}}
+
+{{WebAssemblySidebar}}
 
 Функция **`WebAssembly.compile()`** компилирует {{jsxref("WebAssembly.Module")}} из двоичного кода WebAssembly. Эта функция полезна, если необходимо компилировать модуль до того, как его можно создать (в противном случае следует использовать функцию {{jsxref("WebAssembly.instantiate()")}}.
 

--- a/files/ru/webassembly/javascript_interface/compilestreaming/index.md
+++ b/files/ru/webassembly/javascript_interface/compilestreaming/index.md
@@ -4,7 +4,8 @@ slug: WebAssembly/JavaScript_interface/compileStreaming
 translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/compileStreaming
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/compileStreaming
 ---
-{{JSRef}}
+
+{{WebAssemblySidebar}}
 
 Функция **`WebAssembly.compileStreaming()`** компилирует {{jsxref("WebAssembly.Module")}} непосредственно из потокового исходника. Эта функция полезна, если необходимо скомпилировать модуль до того, как его можно создать (в противном случае следует использовать функцию {{jsxref("WebAssembly.instantiateStreaming()")}}.
 

--- a/files/ru/webassembly/javascript_interface/index.md
+++ b/files/ru/webassembly/javascript_interface/index.md
@@ -5,7 +5,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly
 ---
 
-{{JSRef}}{{SeeCompatTable}}
+{{WebAssemblySidebar}}{{SeeCompatTable}}
 
 Объект JavaScript **`WebAssembly`** действует как пространство имён для всего [WebAssembly](/ru/docs/WebAssembly)-связанной функциональности.
 

--- a/files/ru/webassembly/javascript_interface/table/index.md
+++ b/files/ru/webassembly/javascript_interface/table/index.md
@@ -5,7 +5,7 @@ translation_of: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table
 original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table
 ---
 
-{{JSRef}}
+{{WebAssemblySidebar}}
 
 Объект **`WebAssembly.Table()`** - это JavaScript обёртка — структура похожая на массив, представляющая таблицу функций WebAssembly. Таблица, созданная через JavaScript или в коде WebAssembly, будет доступна и может быть изменена как из JavaScript, так и из WebAssembly.
 


### PR DESCRIPTION
### Description

chore(ru): replace {{JSRef}} macro in webassembly

### Related issues and pull requests

Part of: #11430
