### PR TITLE
pt-br: Remove {{CanvasSidebar}} macro

### DIFF
--- a/files/pt-br/orphaned/web/api/canvas_api/a_basic_ray-caster/index.md
+++ b/files/pt-br/orphaned/web/api/canvas_api/a_basic_ray-caster/index.md
@@ -4,7 +4,7 @@ slug: orphaned/Web/API/Canvas_API/A_basic_ray-caster
 original_slug: Web/API/Canvas_API/A_basic_ray-caster
 ---
 
-{{CanvasSidebar}}
+{{DefaultAPISidebar("Canvas API")}}
 
 Esse artigo disponibiliza um exemplo interessante do mundo real do uso do elemento {{HTMLElement("canvas")}} para fazer renderização via software de um ambiente em 3D utilizando _ray-casting_.
 

--- a/files/pt-br/web/api/canvas_api/index.md
+++ b/files/pt-br/web/api/canvas_api/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Canvas_API
 original_slug: Web/HTML/Canvas
 ---
 
-{{CanvasSidebar}}
+{{DefaultAPISidebar("Canvas API")}}
 
 A **Canvas API** provê maneiras de desenhar gráficos via [JavaScript](/pt-BR/docs/Web/JavaScript) e via elemento [HTML](/pt-BR/docs/Web/HTML) {{HtmlElement("canvas")}}. Entre outras coisas, ele pode ser utilizado para animação, gráficos de jogos, visualização de dados, manipulação de fotos e processamento de vídeo em tempo real.
 

--- a/files/pt-br/web/api/canvas_api/tutorial/advanced_animations/index.md
+++ b/files/pt-br/web/api/canvas_api/tutorial/advanced_animations/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Canvas_API/Tutorial/Advanced_animations
 original_slug: Web/Guide/HTML/Canvas_tutorial/Advanced_animations
 ---
 
-{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Basic_animations", "Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas")}}
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Basic_animations", "Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas")}}
 
 No último capítulo nós fizemos algumas [animações básicas](/pt-BR/docs/Web/API/Canvas_API/Tutorial/Basic_animations) e fomos conhecer caminhos para conseguir com que as coisas se movessem. Nesta parte prestaremos mais atenção nos movimentos e vamos adicionar algumas físicas para fazer nossas animações mais avançadas.
 

--- a/files/pt-br/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
+++ b/files/pt-br/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Canvas_API/Tutorial/Applying_styles_and_colors
 original_slug: Web/Guide/HTML/Canvas_tutorial/Applying_styles_and_colors
 ---
 
-{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Drawing_shapes", "Web/API/Canvas_API/Tutorial/Drawing_text")}}
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Drawing_shapes", "Web/API/Canvas_API/Tutorial/Drawing_text")}}
 
 No capítulo sobre [desenhando formas com canvas](/pt-BR/docs/Web/API/Canvas_API/Tutorial/Drawing_shapes), usamos apenas os estilos padrões de preenchimento e linha. Aqui vamos explorar as opções do canvas que temos à nossa disposição para tornar nossos desenhos um pouco mais atraentes. Você aprenderá a adicionar cores diferentes, estilos de linhas, gradientes, padrões e sombras aos seus desenhos.
 

--- a/files/pt-br/web/api/canvas_api/tutorial/basic_usage/index.md
+++ b/files/pt-br/web/api/canvas_api/tutorial/basic_usage/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Canvas_API/Tutorial/Basic_usage
 original_slug: Web/Guide/HTML/Canvas_tutorial/Utilizacao_basica
 ---
 
-{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial", "Web/API/Canvas_API/Tutorial/Drawing_shapes")}}Vamos começar este tutorial olhando para o elemento {{HTMLElement("canvas")}} {{Glossary("HTML")}} em si. No final desta página, você saberá como configurar um contexto de canvas 2D e desenhar um primeiro exemplo em seu navegador.
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial", "Web/API/Canvas_API/Tutorial/Drawing_shapes")}}Vamos começar este tutorial olhando para o elemento {{HTMLElement("canvas")}} {{Glossary("HTML")}} em si. No final desta página, você saberá como configurar um contexto de canvas 2D e desenhar um primeiro exemplo em seu navegador.
 
 ## O elemento `<canvas>`
 

--- a/files/pt-br/web/api/canvas_api/tutorial/compositing/example/index.md
+++ b/files/pt-br/web/api/canvas_api/tutorial/compositing/example/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Canvas_API/Tutorial/Compositing/Example
 original_slug: Web/Guide/HTML/Canvas_tutorial/Compositing/Exemplo
 ---
 
-{{CanvasSidebar}}
+{{DefaultAPISidebar("Canvas API")}}
 
 Esse exemplo demonstra várias [operações de composição](/pt-BR/docs/Web/API/CanvasRenderingContext2D/globalCompositeOperation). A saída se parece assim:
 

--- a/files/pt-br/web/api/canvas_api/tutorial/compositing/index.md
+++ b/files/pt-br/web/api/canvas_api/tutorial/compositing/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Canvas_API/Tutorial/Compositing
 original_slug: Web/Guide/HTML/Canvas_tutorial/Compositing
 ---
 
-{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Transformations", "Web/API/Canvas_API/Tutorial/Basic_animations")}}
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Transformations", "Web/API/Canvas_API/Tutorial/Basic_animations")}}
 
 Em todo os nossos [exemplos prévios](/pt-BR/docs/Web/API/Canvas_API/Tutorial/Transformations), formas estavam sempre desenhadas uma em cima das outras. Este é mais do que adequado para a maioria das situações, mas é limita a ordem no qual a composição das formas são construídas.
 

--- a/files/pt-br/web/api/canvas_api/tutorial/drawing_shapes/index.md
+++ b/files/pt-br/web/api/canvas_api/tutorial/drawing_shapes/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Canvas_API/Tutorial/Drawing_shapes
 original_slug: Web/Guide/HTML/Canvas_tutorial/Drawing_shapes
 ---
 
-{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Basic_usage", "Web/API/Canvas_API/Tutorial/Applying_styles_and_colors")}}
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Basic_usage", "Web/API/Canvas_API/Tutorial/Applying_styles_and_colors")}}
 
 Agora que criamos nosso [ambiente em canvas](/pt-BR/docs/Web/API/Canvas_API/Tutorial/Basic_usage), podemos entrar nos detalhes de como desenhar no canvas. No final deste artigo, você terá aprendido a desenhar retângulos, triângulos, linhas, arcos e curvas, proporcionando familiaridade com algumas das formas básicas. Trabalhar com caminhos (_shapes_) é essencial ao desenhar objetos na tela e veremos como isso pode ser feito.
 

--- a/files/pt-br/web/api/canvas_api/tutorial/drawing_text/index.md
+++ b/files/pt-br/web/api/canvas_api/tutorial/drawing_text/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Canvas_API/Tutorial/Drawing_text
 original_slug: Web/Guide/HTML/Canvas_tutorial/Drawing_text
 ---
 
-{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Applying_styles_and_colors", "Web/API/Canvas_API/Tutorial/Using_images")}}
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Applying_styles_and_colors", "Web/API/Canvas_API/Tutorial/Using_images")}}
 
 Após entender como [aplicar estilos e cores](/pt-BR/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors) no capítulo anterior, nós veremos agora como desenhar texto dentro do contexto de uma canvas.
 

--- a/files/pt-br/web/api/canvas_api/tutorial/finale/index.md
+++ b/files/pt-br/web/api/canvas_api/tutorial/finale/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Canvas_API/Tutorial/Finale
 original_slug: Web/Guide/HTML/Canvas_tutorial/Conclusão
 ---
 
-{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Optimizing_canvas")}}
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Optimizing_canvas")}}
 
 Parabéns! Você terminou o [Canvas tutorial](/pt-BR/docs/Web/API/Canvas_API/Tutorial)! Este conhecimento ajudará você a fazer ótimos gráficos 2D na web.
 

--- a/files/pt-br/web/api/canvas_api/tutorial/index.md
+++ b/files/pt-br/web/api/canvas_api/tutorial/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Canvas_API/Tutorial
 original_slug: Web/Guide/HTML/Canvas_tutorial
 ---
 
-{{CanvasSidebar}} [![](canvas_tut_examples.jpg)](/pt-BR/docs/Web/HTML/Canvas)
+{{DefaultAPISidebar("Canvas API")}} [![](canvas_tut_examples.jpg)](/pt-BR/docs/Web/HTML/Canvas)
 
 [**`<canvas>`**](/pt-BR/docs/HTML/Canvas) é um elemento [HTML](/pt-BR/docs/HTML) que pode ser usado para desenhar usando linguagem de "script" (normalmente [JavaScript](/pt-BR/docs/JavaScript)). Isto pode ser usado, por exemplo, para desenhar gráficos, fazer composições de fotos ou simples (e [não tão simples](/pt-BR/docs/HTML/Canvas/A_Basic_RayCaster)) animações. As imagens à direita mostram exemplos de implementações **[`<canvas>`](/pt-BR/docs/HTML/Canvas)** que serão parte deste tutorial.
 

--- a/files/pt-br/web/api/canvas_api/tutorial/optimizing_canvas/index.md
+++ b/files/pt-br/web/api/canvas_api/tutorial/optimizing_canvas/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Canvas_API/Tutorial/Optimizing_canvas
 original_slug: Web/Guide/HTML/Canvas_tutorial/Otimizando_Canvas
 ---
 
-{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility", "Web/API/Canvas_API/Tutorial/Finale")}}
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility", "Web/API/Canvas_API/Tutorial/Finale")}}
 
 O elemento {{HTMLElement("canvas")}} é um dos padrões mais largamente utilizados para renderização de gráficos 2D na Web. É muito usado em jogos e em visualizações complexas. Porém, quando sítios web e aplicativos utilizam canvas até seus limites, começam a surgir problemas de perda de performance. Este artigo tem o objetivo de prover sugestões de otimização de seu elemento canvas e garantir que seu site ou aplicativo funcione melhor.
 

--- a/files/pt-br/web/api/canvas_api/tutorial/using_images/index.md
+++ b/files/pt-br/web/api/canvas_api/tutorial/using_images/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Canvas_API/Tutorial/Using_images
 original_slug: Web/Guide/HTML/Canvas_tutorial/Using_images
 ---
 
-{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Drawing_text", "Web/API/Canvas_API/Tutorial/Transformations" )}}
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Drawing_text", "Web/API/Canvas_API/Tutorial/Transformations" )}}
 
 Até agora nós criamos nossos próprios [shapes](/pt-BR/docs/Web/API/Canvas_API/Tutorial/Drawing_shapes) e aplicamos estilos([applied styles](/pt-BR/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors)) a eles. Um dos recursos mais interessantes do {{HTMLElement("canvas")}} é a capacidade de usar imagens. Eles podem ser usados para composição dinâmica de fotos ou como pano de fundo de gráficos, como sprites em jogos e assim por diante. Imagens externas podem ser usadas em qualquer formato suportado pelo navegador, tais como PNG, GIF, ou JPEG. Você pode até usar a imagem produzida por outros elementos da tela na mesma página que a fonte!
 


### PR DESCRIPTION
This PR replaces all uses of the `{{CanvasSidebar}}` macro following its removal in English content.
