### PR TITLE
ru: Remove {{CanvasSidebar}} macro

### DIFF
--- a/files/ru/orphaned/web/api/canvas_api/a_basic_ray-caster/index.md
+++ b/files/ru/orphaned/web/api/canvas_api/a_basic_ray-caster/index.md
@@ -5,7 +5,7 @@ translation_of: Web/API/Canvas_API/A_basic_ray-caster
 original_slug: Web/API/Canvas_API/A_basic_ray-caster
 ---
 
-{{CanvasSidebar}}
+{{DefaultAPISidebar("Canvas API")}}
 
 В этой статье представлен интересный реальный пример использования элемента {{HTMLElement("canvas")}} для выполнения программного рендеринга 3D-среды с помощью Ray-casting.
 

--- a/files/ru/web/api/canvas_api/index.md
+++ b/files/ru/web/api/canvas_api/index.md
@@ -8,7 +8,8 @@ tags:
   - Справка
 translation_of: Web/API/Canvas_API
 ---
-{{CanvasSidebar}}
+
+{{DefaultAPISidebar("Canvas API")}}
 
 Элемент {{HTMLElement("canvas")}}, добавленный в [HTML5](/ru/docs/HTML/HTML5), предназначен для создания графики с помощью [JavaScript](/ru/docs/JavaScript). Например, его используют для рисования графиков, создания фотокомпозиций, анимаций и даже обработки и рендеринга видео в реальном времени.
 

--- a/files/ru/web/api/canvas_api/tutorial/advanced_animations/index.md
+++ b/files/ru/web/api/canvas_api/tutorial/advanced_animations/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Canvas_API/Tutorial/Advanced_animations
 translation_of: Web/API/Canvas_API/Tutorial/Advanced_animations
 ---
 
-{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Basic_animations", "Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas")}}
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Basic_animations", "Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas")}}
 
 В предыдущей главе мы сделали несколько [базовых анимаций](/ru/docs/Web/API/Canvas_API/Tutorial/Basic_animations) и узнали, как можно двигать вещи. В этой части мы более подробно рассмотрим само движение и собираемся добавить некоторую физику, чтобы сделать наши анимации более продвинутыми.
 

--- a/files/ru/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
+++ b/files/ru/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
@@ -5,7 +5,7 @@ translation_of: Web/API/Canvas_API/Tutorial/Applying_styles_and_colors
 original_slug: Web/API/Canvas_API/Tutorial/Применение_стилей_и_цветов
 ---
 
-{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Drawing_shapes", "Web/API/Canvas_API/Tutorial/Drawing_text")}}
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Drawing_shapes", "Web/API/Canvas_API/Tutorial/Drawing_text")}}
 
 В главе о [рисовании фигур](/ru/docs/Web/API/Canvas_API/Tutorial/Drawing_shapes), мы использовали для линий и заполнения только стили по умолчанию. Здесь мы будем исследовать опции canvas, которые мы имеем в нашем распоряжении, чтобы сделать наши рисунки немного более привлекательными. Вы узнаете, как добавлять различные цвета, стили линий, градиенты, узоры и тени вашим рисункам.
 

--- a/files/ru/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/ru/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -12,7 +12,7 @@ translation_of: Web/API/Canvas_API/Tutorial/Basic_animations
 original_slug: Web/API/Canvas_API/Tutorial/Основы_анимации
 ---
 
-{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Compositing", "Web/API/Canvas_API/Tutorial/Advanced_animations")}}
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Compositing", "Web/API/Canvas_API/Tutorial/Advanced_animations")}}
 
 Поскольку для управления элементами {{HTMLElement ("canvas")}} используется JavaScript, не составляет труда сделать (интерактивные) анимации. В этой главе мы рассмотрим, как делаются некоторые базовые анимации.
 

--- a/files/ru/web/api/canvas_api/tutorial/basic_usage/index.md
+++ b/files/ru/web/api/canvas_api/tutorial/basic_usage/index.md
@@ -6,7 +6,7 @@ tags:
 translation_of: Web/API/Canvas_API/Tutorial/Basic_usage
 ---
 
-{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial", "Web/API/Canvas_API/Tutorial/Drawing_shapes")}}
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial", "Web/API/Canvas_API/Tutorial/Drawing_shapes")}}
 
 Давайте начнём этот урок с изучения элемента {{HTMLElement("canvas")}} как такового. В конце этой страницы вы узнаете как устанавливать canvas 2D context и нарисуете первый пример в вашем браузере.
 

--- a/files/ru/web/api/canvas_api/tutorial/compositing/index.md
+++ b/files/ru/web/api/canvas_api/tutorial/compositing/index.md
@@ -7,7 +7,7 @@ translation_of: Web/API/Canvas_API/Tutorial/Compositing
 original_slug: Web/API/Canvas_API/Tutorial/Композиции
 ---
 
-{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Transformations", "Web/API/Canvas_API/Tutorial/Basic_animations")}}
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Transformations", "Web/API/Canvas_API/Tutorial/Basic_animations")}}
 
 Во всех наших [предыдущих примерах](/ru/docs/Web/API/Canvas_API/Tutorial/Transformations), фигуры всегда были нарисованы одна поверх другой. Это более чем достаточно для большинства ситуаций, но это ограничивает порядок, в котором построены композиционные формы. Однако, мы можем изменить это поведение, установив свойство `globalCompositeOperation`. Кроме того, свойства `clip` позволяет скрыть нежелательные части формы.
 

--- a/files/ru/web/api/canvas_api/tutorial/drawing_shapes/index.md
+++ b/files/ru/web/api/canvas_api/tutorial/drawing_shapes/index.md
@@ -5,7 +5,7 @@ translation_of: Web/API/Canvas_API/Tutorial/Drawing_shapes
 original_slug: Web/API/Canvas_API/Tutorial/Рисование_фигур
 ---
 
-{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Basic_usage", "Web/API/Canvas_API/Tutorial/Applying_styles_and_colors")}}
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Basic_usage", "Web/API/Canvas_API/Tutorial/Applying_styles_and_colors")}}
 
 Теперь, установив наше [окружение canvas](/ru/docs/Web/API/Canvas_API/Tutorial/Basic_usage), мы можем погрузиться в детали того, как рисовать в canvas. К концу этой статьи, вы научитесь рисовать прямоугольники, треугольники, линии, дуги и кривые, при условии что вы хорошо знакомы с основными геометрическими фигурами. Работа с путями весьма важна, когда рисуете объекты на canvas и мы увидим как это может быть сделано.
 

--- a/files/ru/web/api/canvas_api/tutorial/drawing_text/index.md
+++ b/files/ru/web/api/canvas_api/tutorial/drawing_text/index.md
@@ -11,7 +11,7 @@ translation_of: Web/API/Canvas_API/Tutorial/Drawing_text
 original_slug: Web/API/Canvas_API/Tutorial/Рисование_текста
 ---
 
-{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Applying_styles_and_colors", "Web/API/Canvas_API/Tutorial/Using_images")}}
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Applying_styles_and_colors", "Web/API/Canvas_API/Tutorial/Using_images")}}
 
 После того, как мы увидели в предыдущей главе, как [применять стили и цвета](/ru/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors), взглянем на написание текста в canvas.
 

--- a/files/ru/web/api/canvas_api/tutorial/finale/index.md
+++ b/files/ru/web/api/canvas_api/tutorial/finale/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Canvas_API/Tutorial/Finale
 translation_of: Web/API/Canvas_API/Tutorial/Finale
 ---
 
-{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Optimizing_canvas")}}
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Optimizing_canvas")}}
 
 Поздравляем! Вы завершили [Canvas tutorial](/ru/docs/Web/API/Canvas_API/Tutorial)! Эти знания помогут вам создавать великолепную 2d графику в сети.
 

--- a/files/ru/web/api/canvas_api/tutorial/index.md
+++ b/files/ru/web/api/canvas_api/tutorial/index.md
@@ -7,7 +7,7 @@ tags:
 translation_of: Web/API/Canvas_API/Tutorial
 ---
 
-[![](canvas_tut_examples.jpg)](/ru/docs/Web/API/Canvas_API){{CanvasSidebar}}
+[![](canvas_tut_examples.jpg)](/ru/docs/Web/API/Canvas_API){{DefaultAPISidebar("Canvas API")}}
 
 [**`<canvas>`**](/ru/docs/Web/HTML/Element/canvas) — это [HTML](/ru/docs/Web/HTML) элемент, использующийся для рисования графики средствами языков программирования (обычно это [JavaScript](/ru/docs/Glossary/JavaScript)). Он может, к примеру, использоваться для рисования графов, создания коллажей или простой ([и не очень](/ru/docs/Web/API/Canvas_API/A_basic_ray-caster)) анимации.
 Изображения в правой части статьи являются примерами использования `<canvas>.`

--- a/files/ru/web/api/canvas_api/tutorial/optimizing_canvas/index.md
+++ b/files/ru/web/api/canvas_api/tutorial/optimizing_canvas/index.md
@@ -13,7 +13,7 @@ tags:
 translation_of: Web/API/Canvas_API/Tutorial/Optimizing_canvas
 ---
 
-{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility", "Web/API/Canvas_API/Tutorial/Finale")}}
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility", "Web/API/Canvas_API/Tutorial/Finale")}}
 
 Элемент {{HTMLElement ("canvas")}} является одним из наиболее широко используемых инструментов для рендеринга 2D-графики в Интернете. Однако когда веб-сайты и приложения используют Canvas API на пределе его возможностей, производительность начинает снижаться. В этой статье приводятся предложения по оптимизации использования элемента canvas для обеспечения хорошей работы графики.
 

--- a/files/ru/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
+++ b/files/ru/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas
 ---
 
-{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Advanced_animations", "Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility")}}
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Advanced_animations", "Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility")}}
 
 До сих пор мы не смотрели на фактические пиксели нашего объекта canvas (далее "холст"). С объектом `ImageData` вы можете напрямую читать и писать массив данных для управления пиксельными данными. Мы также рассмотрим, как можно сгладить сглаживание изображения (сглаживание) и как сохранить изображения с вашего холста.
 

--- a/files/ru/web/api/canvas_api/tutorial/transformations/index.md
+++ b/files/ru/web/api/canvas_api/tutorial/transformations/index.md
@@ -3,7 +3,8 @@ title: Transformations
 slug: Web/API/Canvas_API/Tutorial/Transformations
 translation_of: Web/API/Canvas_API/Tutorial/Transformations
 ---
-{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Using_images", "Web/API/Canvas_API/Tutorial/Compositing")}}
+
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Using_images", "Web/API/Canvas_API/Tutorial/Compositing")}}
 
 Ранее в этом уроке мы узнали о [сетке холста](/en-US/docs/Web/API/Canvas_API/Tutorial/Drawing_shapes) и **координатном пространстве**. До сих пор мы использовали только сетку по умолчанию и изменили размер всего холста для наших нужд. При преобразованиях существуют более мощные способы изменения исходных координат в различные положение, поворот сетки и даже масштабирование.
 

--- a/files/ru/web/api/canvas_api/tutorial/using_images/index.md
+++ b/files/ru/web/api/canvas_api/tutorial/using_images/index.md
@@ -7,7 +7,7 @@ translation_of: Web/API/Canvas_API/Tutorial/Using_images
 original_slug: Web/API/Canvas_API/Tutorial/Использование_изображений
 ---
 
-{{CanvasSidebar}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Drawing_text", "Web/API/Canvas_API/Tutorial/Трансформации")}}
+{{DefaultAPISidebar("Canvas API")}} {{PreviousNext("Web/API/Canvas_API/Tutorial/Drawing_text", "Web/API/Canvas_API/Tutorial/Трансформации")}}
 
 До сих пор мы создавали наши собственные фигуры и применяли стили к ним. Одна из самых впечатляющих функций {{HTMLElement("canvas")}} это возможность использования изображений. Они могут быть использованы для динамического композитинга фото или как фоны графиков, для спрайтов в играх, и так далее. Внешние изображения могут быть использованы в любых поддерживаемых браузером форматах, таких как PNG, GIF, или JPEG. Вы можете даже использовать изображение, произведённое другими canvas элементами на той же странице как источник!
 


### PR DESCRIPTION
This PR removes the remaining uses of the `{{CanvasSidebar}}` from Russian content, following the removal in English content.
