### PR TITLE
Change words mas

### DIFF
--- a/files/es/web/api/console/index.md
+++ b/files/es/web/api/console/index.md
@@ -73,13 +73,13 @@ Esta página documenta los [Métodos](#métodos) disponibles en el objeto `conso
 
 ### Enviar texto a la consola
 
-La característica mas utilizada de la consola es la de mostrar texto y otros datos. Existen varias categorías de salida que se pueden generar, utilizando los métodos {{domxref("console.log()")}}, {{domxref("console.info()")}}, {{domxref("console.warn()")}}, {{domxref("console.error()")}} o {{domxref("console.debug()")}}. Cada uno de estos muestran resultados que lucen diferente en el registro y se pueden utilizar los controles de filtro proveídos por el navegador para ver únicamente los tipos de salida de interés.
+La característica más utilizada de la consola es la de mostrar texto y otros datos. Existen varias categorías de salida que se pueden generar, utilizando los métodos {{domxref("console.log()")}}, {{domxref("console.info()")}}, {{domxref("console.warn()")}}, {{domxref("console.error()")}} o {{domxref("console.debug()")}}. Cada uno de estos muestran resultados que lucen diferente en el registro y se pueden utilizar los controles de filtro proveídos por el navegador para ver únicamente los tipos de salida de interés.
 
-Hay dos maneras de usar cada uno de los métodos de salida; se puede ingresar una lista de objetos cuyas representaciones en cadena serán concatenadas en un único `string`, el cual se mostrará en la consola, o se puede ingresar una lista que contenga cero o mas sustituciones de cadena seguida por una lista de objetos con los cuales reemplazarlas.
+Hay dos maneras de usar cada uno de los métodos de salida; se puede ingresar una lista de objetos cuyas representaciones en cadena serán concatenadas en un único `string`, el cual se mostrará en la consola, o se puede ingresar una lista que contenga cero o más sustituciones de cadena seguida por una lista de objetos con los cuales reemplazarlas.
 
 #### Mostrando un solo objeto
 
-La manera mas simple de utilizar los métodos de registro es mostrar un solo objeto:
+La manera más simple de utilizar los métodos de registro es mostrar un solo objeto:
 
 ```js
 var someObject = { str: "Algún texto", id: 5 };


### PR DESCRIPTION
Change words mas by más

Some words that should have been written as "más" were written as "mas"

### Description

Some words that should have been written as "más" were written as "mas"

### Motivation

Fix spelling mistakes

### Related issues and pull requests

None

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
