### PR TITLE
pt-br: Remove {{Gecko}} macro

### DIFF
--- a/files/pt-br/web/api/attr/localname/index.md
+++ b/files/pt-br/web/api/attr/localname/index.md
@@ -45,7 +45,7 @@ element.addEventListener("click", function() {
 
 O nome local de um atributo é a parte do nome qualificado do atributo the vem depois da vírgula. Nome qualificados são tipicamente utilizados em XML como parte do namespace(s) de um documento XML em particular.
 
-> **Nota:** No {{Gecko("1.9.2")}} e anteriores, a propriedade retorna uma versão em letras maiúsculas do nome local para o atributo DOM do HTML (oposto a atributos XHTML no DOM do XML). Em versões posteriores, em conformidade com o HTML5, a propriedade retorna no caso de armazenamento interno do DOM, que é em letras minúsculas para ambos os atributos HTML no DOM do HTML e XHTML no DOM do XML.
+> **Nota:** No Gecko 1.9.2 e anteriores, a propriedade retorna uma versão em letras maiúsculas do nome local para o atributo DOM do HTML (oposto a atributos XHTML no DOM do XML). Em versões posteriores, em conformidade com o HTML5, a propriedade retorna no caso de armazenamento interno do DOM, que é em letras minúsculas para ambos os atributos HTML no DOM do HTML e XHTML no DOM do XML.
 
 ## Especificações
 

--- a/files/pt-br/web/api/console/index.md
+++ b/files/pt-br/web/api/console/index.md
@@ -199,7 +199,7 @@ The output in the console looks something like this:
 ## Notes
 
 - At least in Firefox, if a page defines a console object, that object overrides the one built into Firefox.
-- Prior to {{Gecko("12.0")}}, the console object's methods only work when the Web Console is open. Starting with {{Gecko("12.0")}}, output is cached until the Web Console is opened, then displayed at that time.
+- Prior to Gecko 12.0, the console object's methods only work when the Web Console is open. Starting with Gecko 12.0, output is cached until the Web Console is opened, then displayed at that time.
 - It's worth noting that the Firefox's built-in `console` object is compatible with the one provided by [Firebug](http://getfirebug.com/).
 
 ## See also

--- a/files/pt-br/web/api/document_object_model/index.md
+++ b/files/pt-br/web/api/document_object_model/index.md
@@ -267,7 +267,7 @@ Um objeto `HTMLDocument` também da acesso á vários recursos de navegadores co
 
 Aqui estão a DOM API para tipos de dados utilizados nas definições de propriedades SVG e atributos.
 
-> **Nota:** Starting in {{Gecko("5.0")}}, the following SVG-related DOM interfaces representing lists of objects are now indexable and can be accessed ; in addition, they have a length property indicating the number of items in the lists: {{domxref("SVGLengthList")}}, {{domxref("SVGNumberList")}}, {{domxref("SVGPathSegList")}}, and {{domxref("SVGPointList")}}.
+> **Nota:** Starting in Gecko 5.0, the following SVG-related DOM interfaces representing lists of objects are now indexable and can be accessed ; in addition, they have a length property indicating the number of items in the lists: {{domxref("SVGLengthList")}}, {{domxref("SVGNumberList")}}, {{domxref("SVGPathSegList")}}, and {{domxref("SVGPointList")}}.
 
 #### Static type
 

--- a/files/pt-br/web/api/element/clientheight/index.md
+++ b/files/pt-br/web/api/element/clientheight/index.md
@@ -6,7 +6,7 @@ original_slug: Web/API/Document/height
 
 {{APIRef("DOM")}} {{Obsolete_header}}
 
-> **Nota:** A partir do {{Gecko("6.0")}}, `document.height` não é mais suportado. Em seu lugar use `document.body.clientHeight`. Veja {{domxref("element.clientHeight")}}.
+> **Nota:** A partir do Gecko 6.0, `document.height` não é mais suportado. Em seu lugar use `document.body.clientHeight`. Veja {{domxref("element.clientHeight")}}.
 
 ## Sumário
 

--- a/files/pt-br/web/api/element/getboundingclientrect/index.md
+++ b/files/pt-br/web/api/element/getboundingclientrect/index.md
@@ -19,7 +19,7 @@ O valor de retorno é o objeto [DOMRect](/pt-BR/docs/XPCOM_Interface_Reference/n
 
 O valor retornado é um objeto `DOMRect`, que contém as propriedades apenas-leitura `left`, `top`, `right` e `bottom` que descrevem o border-box em pixels. `top` e `left` são relativos às propriedades top-left do _viewport_.
 
-> **Nota:** {{Gecko("1.9.1")}} adiciona as propriedades `width` e `height` ao objeto `DOMRect`.
+> **Nota:** Gecko 1.9.1 adiciona as propriedades `width` e `height` ao objeto `DOMRect`.
 
 Border-boxes vazias são completamente ignoradas. Se todos os border-boxes do elemento são vazias, então é retornado o retângulo com width e height como zero, e no lugar de `top` e `left` determina-se o top-left do border-box relacionado ao primeiro box CSS (determinado pela ordem do conteúdo) em relaçāo ao elemento.
 

--- a/files/pt-br/web/api/event/preventdefault/index.md
+++ b/files/pt-br/web/api/event/preventdefault/index.md
@@ -102,7 +102,7 @@ Aqui está o resultado do código anterior:
 
 Chamar preventDefault durante qualquer fase do fluxo de eventos cancela o evento, o que significa que qualquer ação padrão normalmente feita pela aplicação como um resultado do evento não ocorrerá.
 
-> **Nota:** A partir do {{Gecko("6.0")}}, chamar o `preventDefault()` faz com que o {{ domxref("event.defaultPrevented") }} se torne true.
+> **Nota:** A partir do Gecko 6.0, chamar o `preventDefault()` faz com que o {{ domxref("event.defaultPrevented") }} se torne true.
 
 Você pode usar o [event.cancelable](/pt-BR/docs/Web/API/event.cancelable) para checar se o evento é cancelável. Chamar o `preventDefault` para um evento não cancelável não fará efeito.
 

--- a/files/pt-br/web/api/filelist/index.md
+++ b/files/pt-br/web/api/filelist/index.md
@@ -7,7 +7,7 @@ slug: Web/API/FileList
 
 Um objeto desse tipo é retornado pela propriedade `files` do elemento HTML {{HTMLElement("input")}}; isso permite acessar a lista de arquivos selecionados com o elemento `<input type="file">`. Também é usado para uma lista de arquivos soltos no conteúdo web usando a API drag and drop; consulte o objeto [`DataTransfer`](/pt-BR/docs/DragDrop/DataTransfer) para detalhes de seu uso.
 
-> **Nota:** Antes do {{Gecko("1.9.2")}}, o elemento input suportava apenas um arquivo selecionado por vez, ou seja, o array FileList conteria apenas um arquivo. A partir do {{Gecko("1.9.2")}}, se o atributo multiple do elemento for definido, FileList pode conter múltiplos arquivos.
+> **Nota:** Antes do Gecko 1.9.2, o elemento input suportava apenas um arquivo selecionado por vez, ou seja, o array FileList conteria apenas um arquivo. A partir do Gecko 1.9.2, se o atributo multiple do elemento for definido, FileList pode conter múltiplos arquivos.
 
 ## Utilizando a lista de arquivos
 

--- a/files/pt-br/web/api/websocket/index.md
+++ b/files/pt-br/web/api/websocket/index.md
@@ -125,9 +125,9 @@ void send(
 - `SYNTAX_ERR`
   - : `Os dados são uma string que tem substituto não comparado.`
 
-> **Nota:** `Nota: A implementação do método send () de Gecko difere um pouco da especificação em {{Gecko("6.0")}}. Gecko retorna um boolean indicando se a conexão ainda está aberta (por extensão, ou os dados estão em fila ou transmitidos com sucesso). Isso é corrigido em {{Gecko("8.0")}}.`
+> **Nota:** `Nota: A implementação do método send () de Gecko difere um pouco da especificação em Gecko 6.0. Gecko retorna um boolean indicando se a conexão ainda está aberta (por extensão, ou os dados estão em fila ou transmitidos com sucesso). Isso é corrigido em Gecko 8.0.`
 >
-> `A partir de {{Gecko("11.0")}}, o suporte para {{jsxref ("ArrayBuffer")}} está implementado, mas não {{domxref("Blob")}} tipos de dados.`
+> `A partir de Gecko 11.0, o suporte para {{jsxref ("ArrayBuffer")}} está implementado, mas não {{domxref("Blob")}} tipos de dados.`
 
 ## `Especificações`
 

--- a/files/pt-br/web/api/window/index.md
+++ b/files/pt-br/web/api/window/index.md
@@ -262,7 +262,7 @@ These are properties of the window object that can be set to establish event han
 
 _This interface inherits event handlers from the {{domxref("EventTarget")}} interface and implements event handlers from {{domxref("WindowTimers")}}, {{domxref("WindowBase64")}}, and {{domxref("WindowEventHandlers")}}._
 
-> **Nota:** Starting in {{Gecko("9.0")}}, you can now use the syntax `if ("onabort" in window)` to determine whether or not a given event handler property exists. This is because event handler interfaces have been updated to be proper web IDL interfaces. See [DOM event handlers](/pt-BR/docs/DOM/DOM_event_handlers) for details.
+> **Nota:** Starting in Gecko 9.0, you can now use the syntax `if ("onabort" in window)` to determine whether or not a given event handler property exists. This is because event handler interfaces have been updated to be proper web IDL interfaces. See [DOM event handlers](/pt-BR/docs/DOM/DOM_event_handlers) for details.
 
 - {{domxref("GlobalEventHandlers.onabort")}}
   - : An event handler property for abort events on the window.

--- a/files/pt-br/web/api/xmlhttprequest/synchronous_and_asynchronous_requests/index.md
+++ b/files/pt-br/web/api/xmlhttprequest/synchronous_and_asynchronous_requests/index.md
@@ -130,7 +130,7 @@ loadFile("message.txt", 2000, showMessage, "New message!\n");
 
 Here, we're specifying a timeout of 2000 ms.
 
-> **Nota:** Support for `timeout` was added in {{Gecko("12.0")}}.
+> **Nota:** Support for `timeout` was added in Gecko 12.0.
 
 ## Synchronous request
 

--- a/files/pt-br/web/api/xmlhttprequest/using_xmlhttprequest/index.md
+++ b/files/pt-br/web/api/xmlhttprequest/using_xmlhttprequest/index.md
@@ -139,9 +139,9 @@ oReq.open();
 
 > **Nota:** Atualmente, existem bugs em aberto para o evento de progresso que continua fetando a versão 25 do Firefox sobre [OS X](https://bugzilla.mozilla.org/show_bug.cgi?id=908375) e [Linux](https://bugzilla.mozilla.org/show_bug.cgi?id=786953).
 
-> **Nota:** Iniciando no {{Gecko("9.0")}}, eventos de progresso agora podem ser invocados a entrar para cada pedaço de dados recebidos, incluindo o último bloco, nos casos em que o último pacote é recebido e a conexão fechada antes do evento progresso ser disparado. Neste caso, o evento de progresso é automaticamente acionado quando o evento load ocorre para esse pacote. Isso permite que você agora acompanhe de forma confiável apenas observando o evento de progresso
+> **Nota:** Iniciando no Gecko 9.0, eventos de progresso agora podem ser invocados a entrar para cada pedaço de dados recebidos, incluindo o último bloco, nos casos em que o último pacote é recebido e a conexão fechada antes do evento progresso ser disparado. Neste caso, o evento de progresso é automaticamente acionado quando o evento load ocorre para esse pacote. Isso permite que você agora acompanhe de forma confiável apenas observando o evento de progresso
 
-> **Nota:** A partir do {{Gecko("12.0")}}, se o seu evento de progresso e chamado com um `responseType` de "moz-blob", o valor da resposta será um {{domxref("Blob")}} contendo os dados recebidos até agorar.
+> **Nota:** A partir do Gecko 12.0, se o seu evento de progresso e chamado com um `responseType` de "moz-blob", o valor da resposta será um {{domxref("Blob")}} contendo os dados recebidos até agorar.
 
 POde-se também detectar todas as três condições de fim de carga (`abort`, `load`, or `error`) usando o evento `loadend`:
 

--- a/files/pt-br/web/css/privacy_and_the__colon_visited_selector/index.md
+++ b/files/pt-br/web/css/privacy_and_the__colon_visited_selector/index.md
@@ -8,7 +8,7 @@ original_slug: Web/CSS/Privacidade_e_o_seletor_:visited
 
 Antes de 2010, o seletor [CSS](/pt-BR/docs/Web/CSS) {{ cssxref(":visited") }} permitia que websites descobrissem o histórico de navegação dos usuários e quais sites estes haviam visitado. Isto foi feito por meio do {{domxref("window.getComputedStyle")}} e outras tecnicas. Este processo era fácil de ser feito, e tornou possível não somente determinar onde os usuários estiveram na internet, mas também poderia ser usado para descobrir um monte de informação sobre a identidade destes.
 
-Para contornar este problema, {{ Gecko("2") }} implementou atualizações de privacidade para limitar a quantidade de informações que poderiam ser obtidas através dos links visitados. Outros navegadores também fizeram mudanças similares.
+Para contornar este problema, Gecko 2 implementou atualizações de privacidade para limitar a quantidade de informações que poderiam ser obtidas através dos links visitados. Outros navegadores também fizeram mudanças similares.
 
 ## Pequenas mentiras brancas
 

--- a/files/pt-br/web/html/element/iframe/index.md
+++ b/files/pt-br/web/html/element/iframe/index.md
@@ -120,7 +120,7 @@ Scripts trying to access a frame's content are subject to the [same-origin polic
 
 ## Notas
 
-> **Note:** Starting in {{Gecko("6.0")}}, rendering of inline frames correctly respects the borders of their containing element when they're rounded using {{cssxref("border-radius")}}.
+> **Note:** Starting in Gecko 6.0, rendering of inline frames correctly respects the borders of their containing element when they're rounded using {{cssxref("border-radius")}}.
 
 ## Especificações
 

--- a/files/pt-br/web/html/element/input/index.md
+++ b/files/pt-br/web/html/element/input/index.md
@@ -215,7 +215,7 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/HTML/Atributos_globais).
 
 ### Entradas de arquivo
 
-> **Note:** **Nota:** a partir do {{Gecko("2.0")}}, chamar o método `click()` num elemento {{HTMLElement("input")}} do tipo `file` abre o seletor de arquivos e permite que o usuário selecione arquivos. Veja [Usando arquivos a partir de aplicações web](/pt-BR/docs/Usando_arquivos_a_partir_de_aplicações_web) para um exemplo e mais detalhes.
+> **Nota:** a partir do Gecko 2.0, chamar o método `click()` num elemento {{HTMLElement("input")}} do tipo `file` abre o seletor de arquivos e permite que o usuário selecione arquivos. Veja [Usando arquivos a partir de aplicações web](/pt-BR/docs/Usando_arquivos_a_partir_de_aplicações_web) para um exemplo e mais detalhes.
 
 Você não pode definir o valor de um seletor de arquivos a partir de um script; fazer algo como o seguinte não tem efeito:
 

--- a/files/pt-br/web/html/element/li/index.md
+++ b/files/pt-br/web/html/element/li/index.md
@@ -23,7 +23,7 @@ Este elemento inclui os [atributos globais](/pt-BR/docs/Web/HTML/Global_attribut
 
     > **Note:** **Nota**: Este atributo, abandonado na HTML4, foi reintroduzido na HTML5.
 
-    > **Note:** **Nota:** Antes de {{Gecko("9.0")}}, os valores negativos eram, incorretamente, convertidos a 0. A partir de {{Gecko("9.0")}} todos os valores inteiros são analisados corretamente.
+    > **Note:** **Nota:** Antes de Gecko 9.0, os valores negativos eram, incorretamente, convertidos a 0. A partir de Gecko 9.0 todos os valores inteiros são analisados corretamente.
 
 - {{htmlattrdef("type")}} {{Deprecated_inline}}
 

--- a/files/pt-br/web/javascript/reference/global_objects/string/search/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/string/search/index.md
@@ -57,7 +57,7 @@ console.log(str.search(reDot)) // retorna -1 pois não conseguiu encontrar o pon
 
 ## Notas específicas para a engine Gecko
 
-- Antes do {{Gecko("8.0")}}, `search()` foi implementado incorretamente. Quando era chamadosem parâmetros ou com {{jsxref("undefined")}}, ele buscava pela string '`undefined`', ao invés de buscar pela string vazia. Isto foi corrigido. Agora `'a'.search()` e `'a'.search(undefined)` corretamente retornam 0.
+- Antes do Gecko 8.0, `search()` foi implementado incorretamente. Quando era chamadosem parâmetros ou com {{jsxref("undefined")}}, ele buscava pela string '`undefined`', ao invés de buscar pela string vazia. Isto foi corrigido. Agora `'a'.search()` e `'a'.search(undefined)` corretamente retornam 0.
 - A partir do Gecko 39 {{geckoRelease(39)}}, o argumento não-padrão `flags` está defasado (deprecated) e dispara um aviso no console ({{bug(1142351)}}).
 - A partir do Gecko 47 {{geckoRelease(47)}}, o argumento não-padrão `flags` não é mais suportado em builds _non-release_ e em breve será removido inteiramente ({{bug(1245801)}}).
 - A partir do Gecko 49 {{geckoRelease(49)}}, o argumento não-padrão `flags` não é mais suportado ({{bug(1108382)}}).


### PR DESCRIPTION
This PR removes the `{{Gecko}}` macro from the Brazilian Portugese locale as a part of and fixes #11284.
