### PR TITLE
fix:  translation error

### DIFF
--- a/files/zh-cn/learn/css/building_blocks/the_box_model/index.md
+++ b/files/zh-cn/learn/css/building_blocks/the_box_model/index.md
@@ -133,8 +133,7 @@ CSS 中组成一个块级盒子需要：
 }
 ```
 
-如果使用标准模型,实际占用宽度 = 410px (350 + 25 + 25 + 5 + 5)，高度 = 210px (150 + 25 + 25 + 5 + 5)，padding 加 border 再加 content box。
-
+如果使用标准模型，实际占用空间的宽高分别为：宽度 = 410px (350 + 25 + 25 + 5 + 5)，高度 = 210px (150 + 25 + 25 + 5 + 5)，即 padding 加 border 再加 content box。
 ![Showing the size of the box when the standard box model is being used.](standard-box-model.png)
 
 > **备注：** margin 不计入实际大小 —— 当然，它会影响盒子在页面所占空间，但是影响的是盒子外部空间。盒子的范围到边框为止 —— 不会延伸到 margin。

--- a/files/zh-cn/learn/css/building_blocks/the_box_model/index.md
+++ b/files/zh-cn/learn/css/building_blocks/the_box_model/index.md
@@ -133,7 +133,7 @@ CSS 中组成一个块级盒子需要：
 }
 ```
 
-如果使用标准模型宽度 = 410px (350 + 25 + 25 + 5 + 5)，高度 = 210px (150 + 25 + 25 + 5 + 5)，padding 加 border 再加 content box。
+如果使用标准模型,实际占用宽度 = 410px (350 + 25 + 25 + 5 + 5)，高度 = 210px (150 + 25 + 25 + 5 + 5)，padding 加 border 再加 content box。
 
 ![Showing the size of the box when the standard box model is being used.](standard-box-model.png)
 

--- a/files/zh-cn/learn/css/building_blocks/the_box_model/index.md
+++ b/files/zh-cn/learn/css/building_blocks/the_box_model/index.md
@@ -133,7 +133,7 @@ CSS 中组成一个块级盒子需要：
 }
 ```
 
-如果使用标准模型，实际占用空间的宽高分别为：宽度 = 410px (350 + 25 + 25 + 5 + 5)，高度 = 210px (150 + 25 + 25 + 5 + 5)，即 padding 加 border 再加 content box。
+如果使用标准模型，实际占用空间的宽高分别为：宽度 = 410px (350 + 25 + 25 + 5 + 5)，高度 = 210px (150 + 25 + 25 + 5 + 5)。
 ![Showing the size of the box when the standard box model is being used.](standard-box-model.png)
 
 > **备注：** margin 不计入实际大小 —— 当然，它会影响盒子在页面所占空间，但是影响的是盒子外部空间。盒子的范围到边框为止 —— 不会延伸到 margin。

--- a/files/zh-cn/learn/css/building_blocks/the_box_model/index.md
+++ b/files/zh-cn/learn/css/building_blocks/the_box_model/index.md
@@ -134,6 +134,7 @@ CSS 中组成一个块级盒子需要：
 ```
 
 如果使用标准模型，实际占用空间的宽高分别为：宽度 = 410px (350 + 25 + 25 + 5 + 5)，高度 = 210px (150 + 25 + 25 + 5 + 5)。
+
 ![Showing the size of the box when the standard box model is being used.](standard-box-model.png)
 
 > **备注：** margin 不计入实际大小 —— 当然，它会影响盒子在页面所占空间，但是影响的是盒子外部空间。盒子的范围到边框为止 —— 不会延伸到 margin。


### PR DESCRIPTION
en:
The actual space taken up by the box
zhCn:
标准模型的实际占用宽度
reason:
'The actual space taken up by the box' should be translated into '标准模型实际占用宽度'  
 The 宽度 in Chinese generally refers to the width attribute of css

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
