### PR TITLE
pt-br: Remove {{spec}} macro

### DIFF
--- a/files/pt-br/conflicting/web/api/eventtarget/addeventlistener/index.md
+++ b/files/pt-br/conflicting/web/api/eventtarget/addeventlistener/index.md
@@ -33,6 +33,10 @@ void handleEvent(
 
 Conforme a interface for marcada com a flag `[function]`, todos os objetos [Function](/en/JavaScript/Reference/Global_Objects/Function "en/Core_JavaScript_1.5_Reference/Global_Objects/Function") automaticamente implementtam essa interface. Chamar o método [handleEvent](#handleevent) em uma dessas implementaçōes automaticamente invoca a função.
 
-## Veja também
+## Especificação
 
-- {{ spec("https://www.w3.org/TR/DOM-Level-2-Events/events.html#Events-EventListener","Document Object Model Events: EventListener","REC") }}
+{{Specifications}}
+
+## Compatibilidade com navegadores
+
+{{Compat}}

--- a/files/pt-br/conflicting/web/api/eventtarget/addeventlistener/index.md
+++ b/files/pt-br/conflicting/web/api/eventtarget/addeventlistener/index.md
@@ -35,7 +35,7 @@ Conforme a interface for marcada com a flag `[function]`, todos os objetos [Func
 
 ## Especificação
 
-{{Specifications}}
+Não faz parte de denhuma especificação.
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/api/document/scripts/index.md
+++ b/files/pt-br/web/api/document/scripts/index.md
@@ -27,10 +27,10 @@ if (scripts.length) {
 }
 ```
 
-## Compatibilidade do navegador
-
-{{Compat("api.Document.scripts")}}
-
 ## Especificação
 
-- {{spec("http://www.whatwg.org/specs/web-apps/current-work/multipage/dom.html#dom-document-scripts", "DOM: document scripts")}}
+{{Specifications}}
+
+## Compatibilidade com navegadores
+
+{{Compat}}

--- a/files/pt-br/web/api/element/queryselector/index.md
+++ b/files/pt-br/web/api/element/queryselector/index.md
@@ -34,21 +34,13 @@ querySelector() foi introduzido em WebApps API.
 
 O argumento de string do `querySelector` deve seguir a sintaxe CSS. Veja exemplos concretos em {{domxref("document.querySelector")}}
 
-## Compatibilidade com navegadores
-
-| Browser           | Suporte         | Notas                                                          |
-| ----------------- | --------------- | -------------------------------------------------------------- |
-| Internet Explorer | 8               | (IE8) apenas selectores CSS 2.1                                |
-| Firefox (Gecko)   | **3.5** (1.9.1) |                                                                |
-| Opera             | 10              |                                                                |
-| Chrome            | 1               |                                                                |
-| Safari (webkit)   | 3.2 (525.3)     | [webk.it/16587](https://bugs.webkit.org/show_bug.cgi?id=16587) |
-
 ## Especificação
 
-- {{spec("https://www.w3.org/TR/selectors-api/","Selectors API Level 1","rec")}}
-- {{spec("https://www.w3.org/TR/selectors-api2/","Selectors API Level 2","wd")}}
-- {{spec("http://dev.w3.org/2006/webapi/selectors-api2/","Selectors API Level 2","ed")}}
+{{Specifications}}
+
+## Compatibilidade com navegadores
+
+{{Compat}}
 
 ## Veja Também
 

--- a/files/pt-br/web/api/node/lastchild/index.md
+++ b/files/pt-br/web/api/node/lastchild/index.md
@@ -23,7 +23,10 @@ var ul = document.getElementById('lista');
 var li_last = ul.lastChild;
 ```
 
-## Specificações
+## Especificação
 
-- {{Spec("https://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-61AD09FB", "DOM nível 2: lastChild", "REC")}}
-- {{Spec("http://dom.spec.whatwg.org/#dom-node-lastchild", "DOM padrão: lastChild")}}
+{{Specifications}}
+
+## Compatibilidade com navegadores
+
+{{Compat}}

--- a/files/pt-br/web/api/window/applicationcache/index.md
+++ b/files/pt-br/web/api/window/applicationcache/index.md
@@ -21,7 +21,11 @@ cache = window.applicationCache
 
 ## Especificação
 
-- {{spec("https://www.w3.org/TR/2008/WD-html5-20080122/#appcache","HTML 5","WD")}}
+{{Specifications}}
+
+## Compatibilidade com navegadores
+
+{{Compat}}
 
 ## Veja também
 

--- a/files/pt-br/web/api/window/applicationcache/index.md
+++ b/files/pt-br/web/api/window/applicationcache/index.md
@@ -21,7 +21,7 @@ cache = window.applicationCache
 
 ## Especificação
 
-{{Specifications}}
+Não faz parte de denhuma especificação.
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/api/window/setimmediate/index.md
+++ b/files/pt-br/web/api/window/setimmediate/index.md
@@ -37,7 +37,7 @@ Todas essas técnicas são incorporadas em um [setImmediate polyfill](https://gi
 
 ## Especificação
 
-{{Specifications}}
+Não faz parte de denhuma especificação.
 
 ## Compatibilidade com navegadores
 

--- a/files/pt-br/web/api/window/setimmediate/index.md
+++ b/files/pt-br/web/api/window/setimmediate/index.md
@@ -35,18 +35,16 @@ Essa função pode ser emulada de algumas maneiras:
 
 Todas essas técnicas são incorporadas em um [setImmediate polyfill](https://github.com/NobleJS/setImmediate).
 
-## Especificações
+## Especificação
 
-Não faz parte de nenhuma especificação e não em uma faixa de padrões.
+{{Specifications}}
 
 ## Compatibilidade com navegadores
 
-{{Compat("api.Window.setImmediate")}}
+{{Compat}}
 
 ## Ver também
 
 {{ domxref("window.clearImmediate") }}
-
-{{ spec("https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/setImmediate/Overview.html", "Specification: Efficient Script Yielding") }}
 
 [Microsoft setImmediate API Demo](http://ie.microsoft.com/testdrive/Performance/setImmediateSorting/Default.html)


### PR DESCRIPTION
This PR removes the `{{spec}}` macro from Brazilian Portugese, replacing all such calls with calls to {{Specifications}}.  Consequentially, this also fixes up some BCD sections as well.
