### PR TITLE
docs: remove common translations for `In this module`

### DIFF
--- a/docs/zh-cn/translation-guide.md
+++ b/docs/zh-cn/translation-guide.md
@@ -205,7 +205,6 @@ Like this.
 | Accessibility concerns | 无障碍考虑 |
 | Browser compatibility | 浏览器兼容性 |
 | Examples | 示例 |
-| In this module | 本章目录 |
 | See also | 参见 |
 | Specifications | 规范 |
 | Technical summary | 技术概要 |

--- a/docs/zh-tw/translation-guide.md
+++ b/docs/zh-tw/translation-guide.md
@@ -131,7 +131,6 @@ For example, consider the [JavaScript](/en-US/docs/Web/JavaScript) guide, which 
 | --- | --- |
 | Browser compatibility | 瀏覽器相容性 |
 | Examples | 範例 |
-| In this module | 本系列課程 |
 | See also | 參見 |
 | Specifications | 規範 |
 


### PR DESCRIPTION
### Description

docs: remove common translations for `In this module`. As we are going to remove this section from content.

### Related issues and pull requests

#11653
