### PR TITLE
ci: only run pr-review-companion on upstream

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -20,7 +20,8 @@ jobs:
     runs-on: ubuntu-latest
 
     if: >
-      ${{ github.event.workflow_run.event == 'pull_request' &&
+      ${{ github.repository == 'mdn/translated-content' &&
+      github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' }}
 
     steps:


### PR DESCRIPTION
### Description

ci: only run pr-review-companion on upstream

### Related issues and pull requests

Follow: mdn/content#24456
