### PR TITLE
pt-br: Remove `{{geckoRelease}}` macro

### DIFF
--- a/files/pt-br/web/api/attr/index.md
+++ b/files/pt-br/web/api/attr/index.md
@@ -8,7 +8,7 @@ Este tipo representa um atributo de elemento DOM como um objeto. Na maioria dos 
 
 {{InheritanceDiagram}}
 
-> **Aviso:** Começando no Gecko 7.0 {{geckoRelease("7.0")}}, os que serão removidos mostram mensagens de aviso no console. Você deve revisar seu código de acordo. Veja [métodos e propriedades descontinuadas](#propriedades_e_métodos_descontinuados) para uma lista completa.
+> **Aviso:** Começando no Gecko 7.0, os que serão removidos mostram mensagens de aviso no console. Você deve revisar seu código de acordo. Veja [métodos e propriedades descontinuadas](#propriedades_e_métodos_descontinuados) para uma lista completa.
 
 ## Propriedades
 
@@ -28,7 +28,7 @@ Este tipo representa um atributo de elemento DOM como um objeto. Na maioria dos 
 > **Nota:** DOM Level 4 removeu esta propriedade. Foi suposto que como você recebe um objeto `Attr` de um {{domxref("Element")}}, você já deve saber qual é o elemento associado.
 > Como isto não é sempre verdadeiro em casos como objetos `Attr` sendo retornados pelo {{domxref("Document.evaluate")}}, o DOM Living Standard reintroduziu a propriedade.
 >
-> Gecko mostra uma mensagem de descontinuação começando no Gecko 7.0 {{geckoRelease("7.0")}}. Esta mensagem foi removida novamente no Gecko 49.0 {{geckoRelease("49.0")}}.
+> Gecko mostra uma mensagem de descontinuação começando no Gecko 7.0. Esta mensagem foi removida novamente no Gecko 49.0.
 
 ## Propriedades e métodos descontinuados
 

--- a/files/pt-br/web/api/blob/index.md
+++ b/files/pt-br/web/api/blob/index.md
@@ -94,7 +94,7 @@ Ao usar outros métodos de {{domxref("FileReader")}}, é possível ler o conteú
 
 ### Notas para Gecko
 
-Anterior ao Gecko 12.0 {{ geckoRelease("12.0") }}, havia um bug que afetava o comportamento do [slice](#slice); que não funcionava para as posições `start` e `end` fora do intervalo de valores assinados como 64-bit; este bug foi corrigido para dar suporte a valores assinados como 64-bit.
+Anterior ao Gecko 12.0, havia um bug que afetava o comportamento do [slice](#slice); que não funcionava para as posições `start` e `end` fora do intervalo de valores assinados como 64-bit; este bug foi corrigido para dar suporte a valores assinados como 64-bit.
 
 ## Chrome Code - Disponibilidade de Escopo
 

--- a/files/pt-br/web/api/canvasrenderingcontext2d/index.md
+++ b/files/pt-br/web/api/canvasrenderingcontext2d/index.md
@@ -320,7 +320,7 @@ Most of these APIs are [deprecated and will be removed in the future](https://co
 
 ## Compatibility notes
 
-- Starting with Gecko 5.0 {{geckoRelease("5.0")}}, specifying invalid values are now silently ignored for the following methods and properties: `translate()`, `transform()`, `rotate()`, `scale()`, `rect()`, `clearRect()`, `fillRect()`, `strokeRect()`, `lineTo()`, `moveTo()`, `quadraticCurveTo()`, `arc()`, `shadowOffsetX`, `shadowOffsetY`, `shadowBlur`.
+- Starting with Gecko 5.0, specifying invalid values are now silently ignored for the following methods and properties: `translate()`, `transform()`, `rotate()`, `scale()`, `rect()`, `clearRect()`, `fillRect()`, `strokeRect()`, `lineTo()`, `moveTo()`, `quadraticCurveTo()`, `arc()`, `shadowOffsetX`, `shadowOffsetY`, `shadowBlur`.
 
 ## Veja também
 

--- a/files/pt-br/web/api/console/index.md
+++ b/files/pt-br/web/api/console/index.md
@@ -93,7 +93,7 @@ O output será algo assim:
 
 #### Uso de substituição de string
 
-O Gecko 9.0 {{geckoRelease("9.0")}} introduziu o suporte à substituição de strings. Ao fornecer uma string para um dos métodos do console que aceitam uma string, você pode utilizar estas strings de substituição:
+O Gecko 9.0 introduziu o suporte à substituição de strings. Ao fornecer uma string para um dos métodos do console que aceitam uma string, você pode utilizar estas strings de substituição:
 
 | String de substituição | Descrição                                                                  |
 | ---------------------- | -------------------------------------------------------------------------- |

--- a/files/pt-br/web/api/document/createelement/index.md
+++ b/files/pt-br/web/api/document/createelement/index.md
@@ -62,9 +62,9 @@ function adcElemento () {
 
 - Quando chamada em um objeto de documento marcado como um documento HTML, `createElement()` torna seu argumento caixa-baixa antes de criá-lo.
 - Para criar um elemento com um nome qualificado e _namespace URI_, use {{ domxref("document.createElementNS()") }}.
-- Antes do Gecko 2.0 {{ geckoRelease("2.0") }} você podia incluir os símbolos de menor que e maior que em volta da `tagName` no modo _quirks_; a partir do Gecko 2.0, a função comporta-se da mesma forma em ambos os modos _quirks_ e estrito.
-- A partir do Gecko 19.0 {{geckoRelease("19.0")}}, `createElement(null)` funciona como `createElement("null")`. Note que o Opera torna `null` uma _string_, mas ambos Chrome e Internet Explorer lançarão erros.
-- A partir do Gecko 22.0 {{geckoRelease("22.0")}} `createElement()` não mais usa a interface {{domxref("HTMLSpanElement")}} quando o argumento é "bgsounds", "multicol", or "image". Ao invés disso, `HTMLUnknownElement` é usado para "bgsound", "multicol" e {{domxref("HTMLElement")}} `HTMLElement` é usado para "image".
+- Antes do Gecko 2.0 você podia incluir os símbolos de menor que e maior que em volta da `tagName` no modo _quirks_; a partir do Gecko 2.0, a função comporta-se da mesma forma em ambos os modos _quirks_ e estrito.
+- A partir do Gecko 19.0, `createElement(null)` funciona como `createElement("null")`. Note que o Opera torna `null` uma _string_, mas ambos Chrome e Internet Explorer lançarão erros.
+- A partir do Gecko 22.0 `createElement()` não mais usa a interface {{domxref("HTMLSpanElement")}} quando o argumento é "bgsounds", "multicol", or "image". Ao invés disso, `HTMLUnknownElement` é usado para "bgsound", "multicol" e {{domxref("HTMLElement")}} `HTMLElement` é usado para "image".
 - A implementação Gecko de `createElement` não se conforma à especificação DOM para documentos XUL e XHTML: `localName` e `namespaceURI` não estão definidos para `null` no elemento criado. Veja {{ Bug(280692) }} para detalhes.
 
 ## Especificações

--- a/files/pt-br/web/api/document/implementation/index.md
+++ b/files/pt-br/web/api/document/implementation/index.md
@@ -40,4 +40,4 @@ A Recomendação do W3C DOM Level 1 apenas especifica o método `hasFeature`, qu
 
 ## Notas específicas para o Gecko
 
-- À partir do Gecko 19.0 {{geckoRelease("19.0")}} o método {{domxref("DOMImplementation.hasFeature","hasFeature")}} irá sempre retornar _true_.
+- À partir do Gecko 19.0 o método {{domxref("DOMImplementation.hasFeature","hasFeature")}} irá sempre retornar _true_.

--- a/files/pt-br/web/api/document/importnode/index.md
+++ b/files/pt-br/web/api/document/importnode/index.md
@@ -20,9 +20,9 @@ var node = document.importNode(externalNode, deep);
 - `deep`
   - : `Um boolean, indicando se os nós filhos, do nó a ser importado, devem ser importados também.`
 
-> **Nota:** In the DOM4 specification (as implemented in Gecko 13.0 {{geckoRelease(13)}}), `deep` is an optional argument. If omitted, the method acts as if the value of `deep` was **`true`**, defaulting to using deep cloning as the default behavior. To create a shallow clone, `deep` must be set to `false`.
+> **Nota:** In the DOM4 specification (as implemented in Gecko 13.0), `deep` is an optional argument. If omitted, the method acts as if the value of `deep` was **`true`**, defaulting to using deep cloning as the default behavior. To create a shallow clone, `deep` must be set to `false`.
 >
-> This behavior has been changed in the latest spec, and if omitted, the method will act as if the value of `deep` was **`false`**. Though It's still optional, you should always provide the `deep` argument both for backward and forward compatibility. With Gecko 28.0 {{geckoRelease(28)}}, the console warned developers not to omit the argument. Starting with Gecko 29.0 {{geckoRelease(29)}}), a shallow clone is defaulted instead of a deep clone.
+> This behavior has been changed in the latest spec, and if omitted, the method will act as if the value of `deep` was **`false`**. Though It's still optional, you should always provide the `deep` argument both for backward and forward compatibility. With Gecko 28.0, the console warned developers not to omit the argument. Starting with Gecko 29.0), a shallow clone is defaulted instead of a deep clone.
 
 ## Exemplo
 

--- a/files/pt-br/web/api/document/index.md
+++ b/files/pt-br/web/api/document/index.md
@@ -303,13 +303,13 @@ Mozilla defines a set of non-standard properties made only for XUL content:
 Mozilla also define some non-standard methods:
 
 - {{domxref("Document.execCommandShowHelp")}} {{obsolete_inline("14.0")}}
-  - : This method never did anything and always threw an exception, so it was removed in Gecko 14.0 {{geckoRelease("14.0")}}.
+  - : This method never did anything and always threw an exception, so it was removed in Gecko 14.0.
 - {{domxref("Document.getBoxObjectFor")}} {{obsolete_inline}}
   - : Use the {{domxref("Element.getBoundingClientRect()")}} method instead.
 - {{domxref("Document.loadOverlay")}}
   - : Loads a [XUL overlay](/pt-BR/docs/XUL_Overlays) dynamically. This only works in XUL documents.
 - {{domxref("document.queryCommandText")}} {{obsolete_inline("14.0")}}
-  - : This method never did anything but throw an exception, and was removed in Gecko 14.0 {{geckoRelease("14.0")}}.
+  - : This method never did anything but throw an exception, and was removed in Gecko 14.0.
 
 ### Internet Explorer notes
 

--- a/files/pt-br/web/api/element/focus_event/index.md
+++ b/files/pt-br/web/api/element/focus_event/index.md
@@ -21,7 +21,7 @@ O evento `focus` é acionado assim que um elemento recebe um foco. O grande dife
 - Ação Padrão
   - : Nenhuma.
 
-> **Nota:** Note: The interface was {{ domxref("Event") }} prior to Gecko 24 {{ geckoRelease(24) }}. ({{ bug(855741) }})
+> **Nota:** Note: The interface was {{ domxref("Event") }} prior to Gecko 24. ({{ bug(855741) }})
 
 ## Propriedades
 

--- a/files/pt-br/web/api/eventtarget/removeeventlistener/index.md
+++ b/files/pt-br/web/api/eventtarget/removeeventlistener/index.md
@@ -50,7 +50,7 @@ div.removeEventListener('click', listener, false);
 
 ### Notas para Gecko
 
-- Antes do Firefox 6, o navegador poderia retornar um erro se o parâmetro `useCapture não estive explicitamente cofigurado como` false. Antes do Gecko 9.0 {{ geckoRelease("9.0") }}, `addEventListener()` retornaria uma exception se o parâmetro do listener fosse `null`; agora o método retorna sem erros, mas sem fazer nada.
+- Antes do Firefox 6, o navegador poderia retornar um erro se o parâmetro `useCapture não estive explicitamente cofigurado como` false. Antes do Gecko 9.0, `addEventListener()` retornaria uma exception se o parâmetro do listener fosse `null`; agora o método retorna sem erros, mas sem fazer nada.
 
 ### Notas para Opera
 

--- a/files/pt-br/web/api/file_api/using_files_from_web_applications/index.md
+++ b/files/pt-br/web/api/file_api/using_files_from_web_applications/index.md
@@ -28,7 +28,7 @@ In this case, the file list passed to the `handleFiles()` function contains one 
 
 ### Using hidden file input elements using the click() method
 
-Starting in Gecko 2.0 {{ geckoRelease("2.0") }}, you can hide the admittedly ugly file {{ HTMLElement("input") }} element and present your own interface for opening the file picker and displaying which file or files the user has selected. You can do this by styling the input element with `display:none` and calling the {{ domxref("element.click","click()") }} method on the {{ HTMLElement("input") }} element.
+Starting in Gecko 2.0, you can hide the admittedly ugly file {{ HTMLElement("input") }} element and present your own interface for opening the file picker and displaying which file or files the user has selected. You can do this by styling the input element with `display:none` and calling the {{ domxref("element.click","click()") }} method on the {{ HTMLElement("input") }} element.
 
 Consider this HTML:
 
@@ -72,7 +72,7 @@ Note that in this case, the `handleFiles()` function looks up the file list inst
 
 ## Using object URLs
 
-Gecko 2.0 {{ geckoRelease("2.0") }} introduces support for the DOM {{ domxref("window.URL.createObjectURL()") }} and {{ domxref("window.URL.revokeObjectURL()") }} methods. These let you create simple URL strings that can be used to reference any data that can be referred to using a DOM {{ domxref("File") }} object, including local files on the user's computer.
+Gecko 2.0 introduces support for the DOM {{ domxref("window.URL.createObjectURL()") }} and {{ domxref("window.URL.revokeObjectURL()") }} methods. These let you create simple URL strings that can be used to reference any data that can be referred to using a DOM {{ domxref("File") }} object, including local files on the user's computer.
 
 When you have a {{ domxref("File") }} object you'd like to reference by URL from HTML, you can create an object URL for it like this:
 

--- a/files/pt-br/web/api/history_api/index.md
+++ b/files/pt-br/web/api/history_api/index.md
@@ -79,7 +79,7 @@ Se clicarmos no botão Voltar novamente, a URL modificará para `http://mozilla.
 - **título** — Atualmente o Firefox ignora este parâmetro. Passar uma string vazia é suficiente contra futuras mudanças no método. Alternativamente, você pode passar um título curto para o estado.
 - **URL** — A URL da nova entrada no histórico é passada por este parâmetro. Note que o navegador não tentará carregar essa URL após uma chamada do método `pushState()`, porém pode tentar carregar a URL mais tarde, por exemplo depois que o usuário reinicie o navegador. A nova URL não precisa ser absoluta; caso seja relativa, é resolvida em relação a atual URL. A nova URL precisar ser da mesma origem que a URL atual; caso contrário, `pushState()` ativará uma exceção. Este parâmetro é opcional; caso seja especificado, é utilizado como a atual URL do documento.
 
-> **Nota:**No Gecko 2.0 {{ geckoRelease("2.0") }} até Gecko 5.0 {{ geckoRelease("5.0") }}, o objeto passado é serializado utilizando JSON. A partir do Gecko 6.0 {{ geckoRelease("6.0") }}, o objeto é serializado usando [o algorítmo de clonagem estruturada](/pt-BR/DOM/The_structured_clone_algorithm). Isso permite que uma variedade maior de objetos possam ser serializados.
+> **Nota:**No Gecko 2.0 até Gecko 5.0, o objeto passado é serializado utilizando JSON. A partir do Gecko 6.0, o objeto é serializado usando [o algorítmo de clonagem estruturada](/pt-BR/DOM/The_structured_clone_algorithm). Isso permite que uma variedade maior de objetos possam ser serializados.
 
 De certa forma, chamar o método `pushState()` é similar a executar `window.location = "#foo"`, no sentido de que ambos criarão e ativarão uma nova entrada no histórico associado com o documento atual. Porém `pushState()` tem algumas vantagens:
 
@@ -100,7 +100,7 @@ Em outros documentos, é criado um elemento com um namespace `null` de URI.
 
 `replaceState()` é particularmente útil quando você quer atualizar o objeto de estado ou a URL da atual entrada do histórico como resposta a alguma ação do usuário.
 
-> **Nota:**Em Gecko 2.0 {{ geckoRelease("2.0") }} até Gecko 5.0 {{ geckoRelease("5.0") }}, o objeto passado é serializado utilizando JSON. Começando do Gecko 6.0 {{ geckoRelease("6.0") }}, o objeto é serializado usando [o algorítmo de clonagem estruturada](/pt-BR/DOM/The_structured_clone_algorithm). Isso permite que uma variedade maior de objetos possam ser serializados.
+> **Nota:**Em Gecko 2.0 até Gecko 5.0, o objeto passado é serializado utilizando JSON. Começando do Gecko 6.0, o objeto é serializado usando [o algorítmo de clonagem estruturada](/pt-BR/DOM/The_structured_clone_algorithm). Isso permite que uma variedade maior de objetos possam ser serializados.
 
 ### Exemplo do método replaceState()
 

--- a/files/pt-br/web/api/keyboardevent/index.md
+++ b/files/pt-br/web/api/keyboardevent/index.md
@@ -171,7 +171,7 @@ In these environments, unfortunately, there's no way for web content to tell the
 
 #### Auto-repeat handling prior to Gecko 4.0
 
-Before Gecko 4.0 {{geckoRelease('4.0')}}, keyboard handling was less consistent across platforms.
+Before Gecko 4.0, keyboard handling was less consistent across platforms.
 
 - Windows
   - : Auto-repeat behavior is the same as in Gecko 4.0 and later.

--- a/files/pt-br/web/api/node/clonenode/index.md
+++ b/files/pt-br/web/api/node/clonenode/index.md
@@ -20,9 +20,9 @@ var dupNode = node.cloneNode(deep);
 - _deep {{optional_inline}} \[1]_
   - : true se os elementos filhos do nó que está sendo clonado devem ser clonados juntos, ou false para clonar apenas o nó específico dispensando, assim, qualquer elemento DOM filho. Veja os exemplos abaixo.
 
-> **Nota:** Na especificação do DOM4 (implementado no Gecko 13.0 {{geckoRelease(13)}}), o argumento `deep` é opcional. Se omitido, por padrão, o método age como se o valor de deep fosse setado como true durante a sua execução. Para criação de clones superficiais, o argumento `deep` deve ser setado como `false`.
+> **Nota:** Na especificação do DOM4 (implementado no Gecko 13.0), o argumento `deep` é opcional. Se omitido, por padrão, o método age como se o valor de deep fosse setado como true durante a sua execução. Para criação de clones superficiais, o argumento `deep` deve ser setado como `false`.
 >
-> Este comportamento foi alterado na última especificação. Se omitido o argumento deep, o método irá interpretar o valor de deep como se fosse false. Embora ele continue opcional, é recomendado que você sempre observe o argumento deep para fins de compatibilidade anterior e posterior. Com o Gecko 28.0 {{geckoRelease(28)}}), foi advertido aos desenvolvedores para não omitirem o argumento. Iniciado com o Gecko 29.0 {{geckoRelease(29)}}), um clone superficial é o padrão ao invés de um clone aprofundado.
+> Este comportamento foi alterado na última especificação. Se omitido o argumento deep, o método irá interpretar o valor de deep como se fosse false. Embora ele continue opcional, é recomendado que você sempre observe o argumento deep para fins de compatibilidade anterior e posterior. Com o Gecko 28.0), foi advertido aos desenvolvedores para não omitirem o argumento. Iniciado com o Gecko 29.0), um clone superficial é o padrão ao invés de um clone aprofundado.
 
 ## Exemplo
 

--- a/files/pt-br/web/api/setinterval/index.md
+++ b/files/pt-br/web/api/setinterval/index.md
@@ -313,7 +313,7 @@ var intervalID = setInterval(function(arg1) {}.bind(undefined, 10), 1000);
 
 ### Abas inativas
 
-Iniciado no Gecko 5.0 {{geckoRelease("5.0")}}, intervalos são fixados para disparar não mais do que uma vez por segundo em abas inativas.
+Iniciado no Gecko 5.0, intervalos são fixados para disparar não mais do que uma vez por segundo em abas inativas.
 
 ## O problema do "[`this`](/pt-BR/docs/Web/JavaScript/Reference/Operators/this)"
 

--- a/files/pt-br/web/api/websocket/index.md
+++ b/files/pt-br/web/api/websocket/index.md
@@ -92,7 +92,7 @@ void close(
 - `SYNTAX_ERR`
   - : A string `reason é muito longa ou contém substitutos não comparados.`
 
-> **Nota:** `Note: No Gecko, este método não suporta nenhum parâmetro antes do Gecko 8.0 {{geckoRelease("8.0")}}.`
+> **Nota:** `Note: No Gecko, este método não suporta nenhum parâmetro antes do Gecko 8.0.`
 
 ### `send()`
 

--- a/files/pt-br/web/api/window/requestanimationframe/index.md
+++ b/files/pt-br/web/api/window/requestanimationframe/index.md
@@ -57,7 +57,7 @@ window.requestAnimationFrame(step);
 
 {{Compat("api.Window.requestAnimationFrame")}}
 
-\[1] Anteriro ao Gecko 11.0 {{geckoRelease("11.0")}}, mozRequestAnimationFrame() podia ser chamado sem parâmetros de entrada. Isso não é mais suportado, como provavelmente não será parte do padrão
+\[1] Anteriro ao Gecko 11.0, mozRequestAnimationFrame() podia ser chamado sem parâmetros de entrada. Isso não é mais suportado, como provavelmente não será parte do padrão
 
 \[2] O parâmetro do callback é {{domxref("DOMTimeStamp")}} ao invés de {{domxref("DOMHighResTimeStamp")}} se a versão prefixada do método foi utilizada `DOMTimeStamp` possui apenas precisão de milisegundo, mas `DOMHighResTimeStamp` possui precisão mínima de microsegundos. Portanto, o tempo zero é diferente: `DOMHighResTimeStamp` possui o mesmo tempo zero que `performance.now()`, mas DOMTimeStamp possui o mesmo tempo zero que `Date.now().`
 

--- a/files/pt-br/web/api/xmlhttprequest/synchronous_and_asynchronous_requests/index.md
+++ b/files/pt-br/web/api/xmlhttprequest/synchronous_and_asynchronous_requests/index.md
@@ -134,7 +134,7 @@ Here, we're specifying a timeout of 2000 ms.
 
 ## Synchronous request
 
-> **Nota:** Starting with Gecko 30.0 {{ geckoRelease("30.0") }}, synchronous requests on the main thread have been deprecated due to the negative effects to the user experience.
+> **Nota:** Starting with Gecko 30.0, synchronous requests on the main thread have been deprecated due to the negative effects to the user experience.
 
 Em casos raros, o uso do método síncrono é preferível ao invés do método assíncrono.
 

--- a/files/pt-br/web/css/background-size/index.md
+++ b/files/pt-br/web/css/background-size/index.md
@@ -138,7 +138,7 @@ background-size: 50% 25%, contain, 3em;
 
 A interpretação dos possíveis valores depende das dimensões intrínsecas da imagem (largura e altura) e da proporção intrínseca (proporção da largura e altura). Um imagem bitmap sempre tem dimensões intrínsecas e uma proporção intrínseca. Uma imagem pode conter ambas as dimensões intrínsecas (e portanto deve ter uma proporção intrínseca). Poderá contar também uma ou nenhuma dimensão intrínseca, e portanto pode ou não pode conter uma proporção intrínseca. Gradients são tratados como imagens sem dimensões ou proporções intrínsecas.
 
-> **Note:** **Nota:** Esse comportamento mudou no Gecko 8.0 {{geckoRelease("8.0")}}. Antes disso, gradients eram tratados como imagens sem dimensões intrínsecas, porém com uma proporção intrínseca idêntica a da área do elemento pai.
+> **Note:** **Nota:** Esse comportamento mudou no Gecko 8.0. Antes disso, gradients eram tratados como imagens sem dimensões intrínsecas, porém com uma proporção intrínseca idêntica a da área do elemento pai.
 
 Imagens geradas por elementos usando {{cssxref("-moz-element")}} (que na realidade casa com um elemento) são atualmente tratadas como imagens com as dimensões do elemento, ou da área de posicionamento de fundo se o elemento é SVG, com a proporção intrínseca correspondente.
 

--- a/files/pt-br/web/css/text-rendering/index.md
+++ b/files/pt-br/web/css/text-rendering/index.md
@@ -60,7 +60,7 @@ body  { text-rendering: optimizeLegibility; }
 
 O valor padrão de 20px para `auto` pode ser alterado na propriedade `browser.display.auto_quality_min_font_size` do navegador.
 
-A opção optimizeSpeed não tem efeito na versão 2.0 do Gecko {{ geckoRelease("2.0") }}, devido ao código padrão de renderização de texto que já é muito rápido e não existe até o momento um código mais rápido para esse trabalho. Veja detalhes em {{ bug(595688) }}.
+A opção optimizeSpeed não tem efeito na versão 2.0 do Gecko, devido ao código padrão de renderização de texto que já é muito rápido e não existe até o momento um código mais rápido para esse trabalho. Veja detalhes em {{ bug(595688) }}.
 
 ## Especificações
 

--- a/files/pt-br/web/html/element/audio/index.md
+++ b/files/pt-br/web/html/element/audio/index.md
@@ -24,7 +24,7 @@ Como todos os elementos HTML, este elemento suporta os [global attributes](/pt-B
 - {{ htmlattrdef("autoplay") }}
   - : Um atributo Booleano; se especificado (mesmo se o valor for "false"!), o áudio iniciará automaticamente assim que possível sem parar de carregar os dados.
 - {{ htmlattrdef("autobuffer") }} {{ obsolete_inline("2.0") }}
-  - : Um atributo Booleano; se especificado, o audio será baixado automaticamente, mesmo se não está configurado para reprodução automática. Isto continua até que o cache de mídia esteja cheio, ou até que o o arquivo de áudio completo tenha sido baixado, o que vier primeiro. Isto deve ser utilizado apenas quando é esperado que o usuário escolherá tocar o áudio; por exemplo, se o usuário navegou para a página utilizando um link "Reproduzir". Este atributo foi removido no Gecko 2.0 {{ geckoRelease("2.0") }} em razão do atributo `preload`.
+  - : Um atributo Booleano; se especificado, o audio será baixado automaticamente, mesmo se não está configurado para reprodução automática. Isto continua até que o cache de mídia esteja cheio, ou até que o o arquivo de áudio completo tenha sido baixado, o que vier primeiro. Isto deve ser utilizado apenas quando é esperado que o usuário escolherá tocar o áudio; por exemplo, se o usuário navegou para a página utilizando um link "Reproduzir". Este atributo foi removido no Gecko 2.0 em razão do atributo `preload`.
 - {{ htmlattrdef("buffered") }}
   - : Um atributo que pode ser lido para determinar os intervalos do áudio que já foram carregados. Este atributo contém um objeto {{ domxref("TimeRanges") }}.
 - {{ htmlattrdef("controls") }}

--- a/files/pt-br/web/html/global_attributes/spellcheck/index.md
+++ b/files/pt-br/web/html/global_attributes/spellcheck/index.md
@@ -44,7 +44,7 @@ Por exemplo:
 
 Neste exemplo HTML acima, os dois primeiros campos de texto terão a verificação ortográfica e o terceiro não terá.
 
-Iniciando no Gecko 9.0 {{ geckoRelease("9.0") }}, a verificação ortográfica usa o atributo {{ htmlattrxref("lang", "input") }} do elemento {{ HTMLElement("input") }} para determinar o idioma padrão da verificação ortográfica. Se o {{ HTMLElement("input") }} não tiver o atributo `lang` setado, esse atributo é procurado em cada elemento pai superior até chegar ao elemento raiz do documento.
+Iniciando no Gecko 9.0, a verificação ortográfica usa o atributo {{ htmlattrxref("lang", "input") }} do elemento {{ HTMLElement("input") }} para determinar o idioma padrão da verificação ortográfica. Se o {{ HTMLElement("input") }} não tiver o atributo `lang` setado, esse atributo é procurado em cada elemento pai superior até chegar ao elemento raiz do documento.
 
 Fazendo assim, se o usuário tem os dicionários de Português e Inglês instalados, e um elemento editável tiver o atributo `lang="en"`, o dicionário inglês será automaticamente usado para este elemento.
 

--- a/files/pt-br/web/javascript/reference/errors/redeclared_parameter/index.md
+++ b/files/pt-br/web/javascript/reference/errors/redeclared_parameter/index.md
@@ -47,7 +47,7 @@ function f(arg) {
 
 ## Notas de compatibilidade
 
-- Antes do Firefox 49 {{geckoRelease(49)}}, isto foi lançado como um {{jsxref("TypeError")}} ({{bug(1275240)}}).
+- Antes do Firefox 49, isto foi lançado como um {{jsxref("TypeError")}} ({{bug(1275240)}}).
 
 ## Veja também
 

--- a/files/pt-br/web/javascript/reference/functions/default_parameters/index.md
+++ b/files/pt-br/web/javascript/reference/functions/default_parameters/index.md
@@ -154,7 +154,7 @@ withoutDefaults.call({value:"=^_^="});
 
 ### Funções definidadas dentro do corpo da função
 
-Introduzido no Gecko 33 {{geckoRelease(33)}}. Funções declaradas no corpo da função não podem ser referenciada dentro de parâmetos padrão e lançará um {{jsxref("ReferenceError")}} (atualmente um {{jsxref("TypeError")}} no SpiderMonkey, veja {{bug(1022967)}}). Parâmetros padrão são sempre executados primeiro, declarações de funções dentro do corpo de outra função são avaliadas depois.
+Introduzido no Gecko 33. Funções declaradas no corpo da função não podem ser referenciada dentro de parâmetos padrão e lançará um {{jsxref("ReferenceError")}} (atualmente um {{jsxref("TypeError")}} no SpiderMonkey, veja {{bug(1022967)}}). Parâmetros padrão são sempre executados primeiro, declarações de funções dentro do corpo de outra função são avaliadas depois.
 
 ```js
 // Não funciona! Throws ReferenceError.
@@ -165,7 +165,7 @@ function f(a = go()) {
 
 ### Parâmetros sem valor padrão depois de parâmetros com valores padrão
 
-Antes do Gecko 26 {{geckoRelease(26)}}, o seguinte código resultaria em um {{jsxref("SyntaxError")}}. Isto foi corrigido no {{bug(777060)}} e funciona como esperado em versões posteriores:
+Antes do Gecko 26, o seguinte código resultaria em um {{jsxref("SyntaxError")}}. Isto foi corrigido no {{bug(777060)}} e funciona como esperado em versões posteriores:
 
 ```js
 function f(x=1, y) {

--- a/files/pt-br/web/javascript/reference/global_objects/atomics/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/atomics/index.md
@@ -57,7 +57,7 @@ Os métodos `wait()` e `wake()` são modelados no Linux futexes ("fast user-spac
 
 ## Observações de compatibilidade
 
-\[3] A especificação de compartilhamento de memória está sendo estabilizada. Anterior ao SpiderMonkey 48 {{geckoRelease(48)}}, a última API e semântica não foram implementadas ainda. As alterações entre as versões 46 e 48 do Firefox são:
+\[3] A especificação de compartilhamento de memória está sendo estabilizada. Anterior ao SpiderMonkey 48, a última API e semântica não foram implementadas ainda. As alterações entre as versões 46 e 48 do Firefox são:
 
 - Os métodos `Atomics.futexWakeOrRequeue()` e `Atomics.fence()` foram totalmente removidos ({{bug(1259544)}} e {{bug(1225028)}}).
 - O método {{jsxref("Atomics.wait()")}} e {{jsxref("Atomics.wake()")}} foram nomeados como `Atomics.futexWait()` e `Atomics.futexWake()` ({{bug(1260910)}}). Os nomes antigos foram mantidos como alias, e serão removidos na versão 49 ({{bug(1262062)}}).

--- a/files/pt-br/web/javascript/reference/global_objects/object/getownpropertynames/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/object/getownpropertynames/index.md
@@ -128,7 +128,7 @@ Object.getOwnPropertyNames('foo');
 
 ## Notas específicas para SpiderMonkey
 
-Antes do SpiderMonkey 28 {{geckoRelease("28")}}, `Object.getOwnPropertyNames` não via propriedades não resolvidas de objetos {{jsxref("Error")}}. Isto foi resolvido em versões posteriores ({{bug("724768")}}).
+Antes do SpiderMonkey 28, `Object.getOwnPropertyNames` não via propriedades não resolvidas de objetos {{jsxref("Error")}}. Isto foi resolvido em versões posteriores ({{bug("724768")}}).
 
 ## Veja também
 

--- a/files/pt-br/web/javascript/reference/global_objects/regexp/test/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/regexp/test/index.md
@@ -69,7 +69,7 @@ function testinput(re, str){
 
 ## Gecko-specific notes
 
-A priori no Grecko 8.0 {{geckoRelease("8.0")}}, `test()` foi implementado incorretamente; quando chamado sem parâmetros, ele encontrária uma correspondência com o valor de entrada anterior (`RegExp.input` property) no lugar de uma correspondência com `"undefined"`. Isso está conrrigido; agora `/undefined/.test()` resultará em `true`, no lugar de um erro.
+A priori no Grecko 8.0, `test()` foi implementado incorretamente; quando chamado sem parâmetros, ele encontrária uma correspondência com o valor de entrada anterior (`RegExp.input` property) no lugar de uma correspondência com `"undefined"`. Isso está conrrigido; agora `/undefined/.test()` resultará em `true`, no lugar de um erro.
 
 ## See also
 

--- a/files/pt-br/web/javascript/reference/global_objects/set/add/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/set/add/index.md
@@ -49,7 +49,7 @@ console.log(mySet);
 
 ## Notas específicas para Firefox
 
-- Antes do Firefox 33 {{geckoRelease("33")}}, `Set.prototype.add retornava` `undefined` e não era possível encadear chamadas. Isto foi resolvido ({{bug(1031632)}}). O comportamento pode ser encontrado no Chrome/v8 ([issue](https://code.google.com/p/v8/issues/detail?id=3410)).
+- Antes do Firefox 33, `Set.prototype.add retornava` `undefined` e não era possível encadear chamadas. Isto foi resolvido ({{bug(1031632)}}). O comportamento pode ser encontrado no Chrome/v8 ([issue](https://code.google.com/p/v8/issues/detail?id=3410)).
 
 ## Veja também
 

--- a/files/pt-br/web/javascript/reference/global_objects/set/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/set/index.md
@@ -26,7 +26,7 @@ Objetos `Set` são coleções de valores nas quais é possível iterar os elemen
 
 ### Igualdade de valores
 
-Como cada valor no Set deve ser único, a igualdade será checada e não é baseada no mesmo algoritmo que aquele usado no operador ===. Especificamente, para `Set`s, `+0` (que é exatamente igual a - 0) e `- 0` são valores diferentes. No entanto, isto foi modificado na última especificação ECMAScript 2015. Iniciado com o Gecko 29.0 {{geckoRelease("29")}} ({{bug("952870")}}) e pelo [recent nightly Chrome](https://code.google.com/p/v8/issues/detail?id=3069), +0 e -0 são tratados com sendo o mesmo valor em objetos conjunto (Set). Também, `NaN` e `undefined` podem ser armazenados em um conjunto Set.
+Como cada valor no Set deve ser único, a igualdade será checada e não é baseada no mesmo algoritmo que aquele usado no operador ===. Especificamente, para `Set`s, `+0` (que é exatamente igual a - 0) e `- 0` são valores diferentes. No entanto, isto foi modificado na última especificação ECMAScript 2015. Iniciado com o Gecko 29.0 ({{bug("952870")}}) e pelo [recent nightly Chrome](https://code.google.com/p/v8/issues/detail?id=3069), +0 e -0 são tratados com sendo o mesmo valor em objetos conjunto (Set). Também, `NaN` e `undefined` podem ser armazenados em um conjunto Set.
 
 ## Propriedades
 

--- a/files/pt-br/web/javascript/reference/global_objects/string/search/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/string/search/index.md
@@ -58,9 +58,9 @@ console.log(str.search(reDot)) // retorna -1 pois não conseguiu encontrar o pon
 ## Notas específicas para a engine Gecko
 
 - Antes do Gecko 8.0, `search()` foi implementado incorretamente. Quando era chamadosem parâmetros ou com {{jsxref("undefined")}}, ele buscava pela string '`undefined`', ao invés de buscar pela string vazia. Isto foi corrigido. Agora `'a'.search()` e `'a'.search(undefined)` corretamente retornam 0.
-- A partir do Gecko 39 {{geckoRelease(39)}}, o argumento não-padrão `flags` está defasado (deprecated) e dispara um aviso no console ({{bug(1142351)}}).
-- A partir do Gecko 47 {{geckoRelease(47)}}, o argumento não-padrão `flags` não é mais suportado em builds _non-release_ e em breve será removido inteiramente ({{bug(1245801)}}).
-- A partir do Gecko 49 {{geckoRelease(49)}}, o argumento não-padrão `flags` não é mais suportado ({{bug(1108382)}}).
+- A partir do Gecko 39, o argumento não-padrão `flags` está defasado (deprecated) e dispara um aviso no console ({{bug(1142351)}}).
+- A partir do Gecko 47, o argumento não-padrão `flags` não é mais suportado em builds _non-release_ e em breve será removido inteiramente ({{bug(1245801)}}).
+- A partir do Gecko 49, o argumento não-padrão `flags` não é mais suportado ({{bug(1108382)}}).
 
 ## Veja também
 

--- a/files/pt-br/web/javascript/reference/global_objects/weakmap/set/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/weakmap/set/index.md
@@ -54,7 +54,7 @@ wm.set(obj, 'baz');
 
 ## Notas específicas ao Firefox
 
-- Antes do Firefox 33 {{geckoRelease("33")}}, `WeakMap.prototype.set` retornava `undefined` e, portanto, não era encadeável. Isso foi resolvido ({{bug(1031632)}}). O comportamento também podia ser encontrado no Chrome/v8 ([issue](https://code.google.com/p/v8/issues/detail?id=3410)).
+- Antes do Firefox 33, `WeakMap.prototype.set` retornava `undefined` e, portanto, não era encadeável. Isso foi resolvido ({{bug(1031632)}}). O comportamento também podia ser encontrado no Chrome/v8 ([issue](https://code.google.com/p/v8/issues/detail?id=3410)).
 
 ## Ver também
 

--- a/files/pt-br/web/javascript/reference/operators/destructuring_assignment/index.md
+++ b/files/pt-br/web/javascript/reference/operators/destructuring_assignment/index.md
@@ -352,8 +352,8 @@ console.log(foo); // "bar"
 
 ## Notas específicas do Firefox
 
-- O Firefox forneceu uma extensão não-padronizada de linguagem em [JS1.7](/pt-BR/docs/Web/JavaScript/New_in_JavaScript/1.7) para desestruturação. Esta extensão foi removida no Gecko 40 {{geckoRelease (40)}}. Consulte {{bug (1083498)}}.
-- A partir do Gecko 41 {{geckoRelease (41)}} e para cumprir com a especificação ES2015, padrões de desestruturação com parênteses, como `([a, b]) = [1, 2]` or `({a, b}) = { a: 1, b: 2 }`, agora são considerados inválidos e lançarão um {{jsxref ( "SyntaxError")}}. Veja a postagem no blog de Jeff Walden e {{bug (1146136)}} para mais detalhes.
+- O Firefox forneceu uma extensão não-padronizada de linguagem em [JS1.7](/pt-BR/docs/Web/JavaScript/New_in_JavaScript/1.7) para desestruturação. Esta extensão foi removida no Gecko 40. Consulte {{bug (1083498)}}.
+- A partir do Gecko 41 e para cumprir com a especificação ES2015, padrões de desestruturação com parênteses, como `([a, b]) = [1, 2]` or `({a, b}) = { a: 1, b: 2 }`, agora são considerados inválidos e lançarão um {{jsxref ( "SyntaxError")}}. Veja a postagem no blog de Jeff Walden e {{bug (1146136)}} para mais detalhes.
 
 ## Veja também
 

--- a/files/pt-br/web/javascript/reference/operators/yield/index.md
+++ b/files/pt-br/web/javascript/reference/operators/yield/index.md
@@ -70,8 +70,8 @@ console.log(iterator.next()); // { value: undefined, done: true }
 
 ## Notas específicas do Firefox
 
-- A partir do Gecko 29 {{geckoRelease(29)}}, uma generator function completada não invoca mais um {{jsxref("TypeError")}} "generator has already finished". Ao invés, isso retorna um objeto `IteratorResult` como `{ value: undefined, done: true }` ({{bug(958951)}}).
-- A partir do Gecko 33 {{geckoRelease(33)}}, a análise (parsing) de uma expressão `yield` foi atualizada para se conformar com a especificação do ES2015 ({{bug(981599)}}):
+- A partir do Gecko 29, uma generator function completada não invoca mais um {{jsxref("TypeError")}} "generator has already finished". Ao invés, isso retorna um objeto `IteratorResult` como `{ value: undefined, done: true }` ({{bug(958951)}}).
+- A partir do Gecko 33, a análise (parsing) de uma expressão `yield` foi atualizada para se conformar com a especificação do ES2015 ({{bug(981599)}}):
 
   - A expressão após a palavra-chave `yield` é opcional e omitir isso não invoca mais um {{jsxref("SyntaxError")}}: `function* foo() { yield; }`
 

--- a/files/pt-br/web/javascript/reference/operators/yield_star_/index.md
+++ b/files/pt-br/web/javascript/reference/operators/yield_star_/index.md
@@ -113,7 +113,7 @@ console.log(result);          // "foo"
 
 ## Notas específicas do Firefox
 
-- A partir do Gecko 33 {{geckoRelease(33)}}, o tratamento da expressão yield foi atualizado para se conformar com a espeficação do ES2015 ({{bug(981599)}}):
+- A partir do Gecko 33, o tratamento da expressão yield foi atualizado para se conformar com a espeficação do ES2015 ({{bug(981599)}}):
 
   - A restrição de linha finalizadora agora está implementada. Nenhuma linha finalizadora entre "yield" e "\*" é permitida. Código como o a seguir irá invocar uma exception {{jsxref("SyntaxError")}}:
 

--- a/files/pt-br/web/javascript/reference/statements/const/index.md
+++ b/files/pt-br/web/javascript/reference/statements/const/index.md
@@ -118,7 +118,7 @@ Em versões anteriores do Firefox & Chrome e a partir de Safari 5.1.7 e Opera 12
 
 A declaração `const` foi implementada no Firefox muito antes de `const` aparecer na especificação ECMAScript 6. For `const` ES6 compliance see {{bug(950547)}} and {{bug(611388)}}.
 
-- Iniciando com o Gecko 36 {{geckoRelease("36")}}:
+- Iniciando com o Gecko 36:
 
   - `{const a=1};a` passa a retornar [`ReferenceError`](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/ReferenceError) e não retorna `1` devido block-scoping.
   - `const a;` passa a retornar [`SyntaxError`](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError) ("missing = in const declaration`"`): É necessário incializar a constante.

--- a/files/pt-br/web/javascript/reference/statements/for...in/index.md
+++ b/files/pt-br/web/javascript/reference/statements/for...in/index.md
@@ -96,7 +96,7 @@ for (var prop in obj) {
 
 ## Compatibilidade: Initializer expressions
 
-Anterior ao SpiderMonkey 40 {{geckoRelease(40)}}, era possível usar uma expressão inicial com o laço for...in, conforme exemplo que se segue:
+Anterior ao SpiderMonkey 40, era possível usar uma expressão inicial com o laço for...in, conforme exemplo que se segue:
 
 ```js example-bad
 var obj = {a:1, b:2, c:3};

--- a/files/pt-br/web/javascript/reference/statements/function_star_/index.md
+++ b/files/pt-br/web/javascript/reference/statements/function_star_/index.md
@@ -154,7 +154,7 @@ Versões mais antigas do Firefox implementam uma versão antiga da proposta de _
 
 #### O retorno do objeto `IteratorResult` ao invés de um throw
 
-Iniciando com Gecko 29 {{geckoRelease(29)}}, o _generator_ finalizado não lança mais um {{jsxref("TypeError")}} "generator has already finished". Ao invés disso, ele retorna um objeto `IteratorResult`, como por exemplo `{ value: undefined, done: true }` ({{bug(958951)}}).
+Iniciando com Gecko 29, o _generator_ finalizado não lança mais um {{jsxref("TypeError")}} "generator has already finished". Ao invés disso, ele retorna um objeto `IteratorResult`, como por exemplo `{ value: undefined, done: true }` ({{bug(958951)}}).
 
 ## Veja também
 

--- a/files/pt-br/web/javascript/reference/statements/return/index.md
+++ b/files/pt-br/web/javascript/reference/statements/return/index.md
@@ -46,7 +46,7 @@ a + b;
 
 O console irá alertar "unreachable code after return statement" (código inacessível após a declaração return).
 
-> **Nota:** A partir do Gecko 40 {{geckoRelease(40)}}, um alerta é mostrado no console se um código inacessível é encontrado após uma declaração `return`.
+> **Nota:** A partir do Gecko 40, um alerta é mostrado no console se um código inacessível é encontrado após uma declaração `return`.
 
 ## Exemplos
 

--- a/files/pt-br/web/media/formats/index.md
+++ b/files/pt-br/web/media/formats/index.md
@@ -55,11 +55,11 @@ Grecko reconhece os seguintes tipos MIME como arquivos Ogg:
 
 ## Ogg Opus
 
-O container Ogg pode também conter um áudio codificado usando o [codec Opus](http://www.opus-codec.org/). Suporte para ele está disponível no Gecko 15.0 {{ geckoRelease("15.0") }} e versões superiores, em navegadores no desktop e dispositivos móveis.
+O container Ogg pode também conter um áudio codificado usando o [codec Opus](http://www.opus-codec.org/). Suporte para ele está disponível no Gecko 15.0 e versões superiores, em navegadores no desktop e dispositivos móveis.
 
 ## Ogg FLAC
 
-O contêiner Ogg pode também conter um áudio codificado usando o [codec FLAC](https://xiph.org/flac/index.html). Suporte para ele está disponível no Gecko 51.0 {{geckoRelease ("51.0")}} e versões superiores, somente no desktop.
+O contêiner Ogg pode também conter um áudio codificado usando o [codec FLAC](https://xiph.org/flac/index.html). Suporte para ele está disponível no Gecko 51.0 e versões superiores, somente no desktop.
 
 ## MP4 H.264 (AAC ou MP3)
 


### PR DESCRIPTION
This PR removes the `{{geckoRelease}}` macro from Brazilian Portuguese documents.  Regex used: `\s\{\{\s?geckoRelease\s?\(['"]?[\d.]+['"]?\)\s?\}\}` -> [Blank]
