### PR TITLE
Remove {{fx_minversion_note}} macro

### DIFF
--- a/files/pt-br/web/api/xmlhttprequest/using_xmlhttprequest/index.md
+++ b/files/pt-br/web/api/xmlhttprequest/using_xmlhttprequest/index.md
@@ -654,10 +654,6 @@ oReq.send(null);
 
 ## Security
 
-{{fx_minversion_note(3, "Versions of Firefox prior to Firefox 3 allowed you to set the preference <code>capability.policy..XMLHttpRequest.open</code> to <code>allAccess</code> to give specific sites cross-site access. This is no longer supported.")}}
-
-{{fx_minversion_note(5, "Versions of Firefox prior to Firefox 5 could use <code>netscape.security.PrivilegeManager.enablePrivilege(\"UniversalBrowserRead\");</code> to request cross-site access. This is no longer supported, even though it produces no warning and permission dialog is still presented.")}}
-
 The recommended way to enable cross-site scripting is to use the `Access-Control-Allow-Origin` HTTP header in the response to the XMLHttpRequest.
 
 ### XMLHttpRequests being stopped

--- a/files/pt-br/web/javascript/guide/regular_expressions/index.md
+++ b/files/pt-br/web/javascript/guide/regular_expressions/index.md
@@ -927,9 +927,6 @@ Isto imprime "Smith, John".
 
 As expressões regulares possuem quatro flags opcionais as quais se incluem a pesquisa global e case insensitive. Para realizar uma pesquisa global, utilize a flag g. Para realizar uma pesquisa sem diferenciar letras maiúsculas de minúsculas, utilize a flag i. Para realizar uma pesquisa multi-linhas, utilize a flag m. Ao realizar uma pesquisa "sticky", o ponto de partida será a posição corrente da string alvo, use com a flag y.Estas flags podem ser usadas separadamente ou juntas, em qualquer ordem, e serão inclusas como parte da expressão regular.
 
-{{Fx_minversion_note (3, "Suporte para o sinalizador <code>y </code>foi adicionado no Firefox 3. <br>
- O sinalizador <code>y </code>falha se a correspondência não for bem-sucedida na posição atual na cadeia de destino.")}}
-
 Para incluir um sinalizador com a expressão regular, use esta sintaxe:
 
 ```js

--- a/files/ru/web/api/xmlhttprequest/using_xmlhttprequest/index.md
+++ b/files/ru/web/api/xmlhttprequest/using_xmlhttprequest/index.md
@@ -713,10 +713,6 @@ oReq.send(null);
 
 ## Безопасность
 
-{{fx_minversion_note(3, "Versions of Firefox prior to Firefox 3 allowed you to set the preference `capability.policy.<policyname>.XMLHttpRequest.open</policyname>` to `allAccess` to give specific sites cross-site access. This is no longer supported.")}}
-
-{{fx_minversion_note(5, "Versions of Firefox prior to Firefox 5 could use `netscape.security.PrivilegeManager.enablePrivilege(\"UniversalBrowserRead\");` to request cross-site access. This is no longer supported, even though it produces no warning and permission dialog is still presented.")}}
-
 The recommended way to enable cross-site scripting is to use the `Access-Control-Allow-Origin` HTTP header in the response to the XMLHttpRequest.
 
 ### XMLHttpRequests being stopped


### PR DESCRIPTION
This PR removes the final instances of the `fx_minversion_note` macro from translated content.  As the content contained within this macro was removed upstream, I've opted to do the same here.  Fixes #11187.
