### PR TITLE
[ko] HTTP: `age`, `content-range`, `via` 헤더 수정 외

### DIFF
--- a/files/ko/web/http/headers/age/index.md
+++ b/files/ko/web/http/headers/age/index.md
@@ -1,34 +1,37 @@
 ---
 title: Age
 slug: Web/HTTP/Headers/Age
+l10n:
+  sourceCommit: 36001a269f4d7b2b3ac6de79e942a5f849bb87d8
 ---
 
 {{HTTPSidebar}}
 
 **`Age`** 헤더는 객체가 프록시 캐시 내에 머무는 초단위의 시간을 가집니다.
 
-`Age` 헤더는 보통 0에 가깝습니다. 만약 `Age: 0라면`, 그것은 아마도 원 서버로부터 막 내려받은 것일 겁니다; 그게 아니라면 프록시의 현재 시간과 HTTP 응답 내에 포함된 {{HTTPHeader("Date")}} 일반 헤더의 차로 계산됩니다.
+`Age` 헤더는 보통 0에 가깝습니다. 만약 `Age: 0라면`, 그것은 아마도 원 서버로부터 막 내려받은 것일 겁니다.
+그게 아니라면 프록시의 현재 시간과 HTTP 응답 내에 포함된 {{HTTPHeader("Date")}} 일반 헤더의 차로 계산됩니다.
 
 <table class="properties">
   <tbody>
     <tr>
-      <th scope="row">Header type</th>
-      <td>{{Glossary("Response header")}}</td>
+      <th scope="row">헤더 타입</th>
+      <td>{{Glossary("Response header", "응답 헤더")}}</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden header name", "금지된 헤더 이름")}}</th>
       <td>no</td>
     </tr>
   </tbody>
 </table>
 
-## 문법
+## 구문
 
-```
+```http
 Age: <delta-seconds>
 ```
 
-## 디렉티브
+## 지시자
 
 - `<delta-seconds>`
   - : 음수가 아닌 정수형으로, 객체가 프록시 캐시 내에 머문 초단위 시간을 나타냅니다.
@@ -39,7 +42,7 @@ Age: <delta-seconds>
 Age: 24
 ```
 
-## 명세
+## 명세서
 
 {{Specifications}}
 

--- a/files/ko/web/http/headers/content-range/index.md
+++ b/files/ko/web/http/headers/content-range/index.md
@@ -1,20 +1,30 @@
 ---
 title: Content-Range
 slug: Web/HTTP/Headers/Content-Range
+l10n:
+  sourceCommit: 36001a269f4d7b2b3ac6de79e942a5f849bb87d8
 ---
 
 {{HTTPSidebar}}
 
-**`Content-Range`** HTTP 응답 헤더는 전체 바디 메시지에 속한 부분 메시지의 위치를 알려줍니다.
+**`Content-Range`** HTTP 응답 헤더는 전체 바디 메시지에서 부분 메시지가 속한 위치를 알려줍니다.
 
 <table class="properties">
   <tbody>
     <tr>
       <th scope="row">헤더 타입</th>
-      <td>{{Glossary("Response header")}}</td>
+      <td>
+        {{Glossary("Response header")}},
+        {{Glossary("Payload header")}}
+      </td>
+    </tr>
+     <tr>
+      <th scope="row">{{Glossary("Forbidden header name", "금지된 헤더 이름")}}</th>
+      <td>아니오</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Simple response header", "CORS-safelisted
+        response-header")}}</th>
       <td>아니오</td>
     </tr>
     <tr>
@@ -28,7 +38,7 @@ slug: Web/HTTP/Headers/Content-Range
 
 ## 문법
 
-```
+```http
 Content-Range: <unit> <range-start>-<range-end>/<size>
 Content-Range: <unit> <range-start>-<range-end>/*
 Content-Range: <unit> */<size>
@@ -47,15 +57,13 @@ Content-Range: <unit> */<size>
 
 ## 예제
 
-```
+```http
 Content-Range: bytes 200-1000/67589
 ```
 
-## 기술 사양
+## 명세서
 
-| 기술 사양                                            | 제목                                                   |
-| ---------------------------------------------------- | ------------------------------------------------------ |
-| {{RFC("7233", "Content-Range", "4.2")}} | Hypertext Transfer Protocol (HTTP/1.1): Range Requests |
+{{Specifications}}
 
 ## 브라우저 호환성
 

--- a/files/ko/web/http/headers/via/index.md
+++ b/files/ko/web/http/headers/via/index.md
@@ -1,30 +1,34 @@
 ---
 title: Via
 slug: Web/HTTP/Headers/Via
+l10n:
+  sourceCommit: 36001a269f4d7b2b3ac6de79e942a5f849bb87d8
 ---
 
 {{HTTPSidebar}}
 
-**`Via`** 헤더는 요청헤더와 응답헤더에 포워드 프록시와 리버스 프록시에 의해서 추가 됩니다. 이 것은 포워드 메시지를 추적하거나, 요청 루프 방지, 요청과 응답 체인에 따라 송신자의 프로토콜 정보를 식별 합니다.
+**`Via`** 일반 헤더는 포워드 프록시와 리버스 프록시에 의해서 추가됩니다. 그리고 요청 또는 응답 헤더에 표시될 수 있습니다. 메시지 전달을 추적하고 요청 루프를 방지하며 요청/응답 체인에서 발신자의 프로토콜 기능을 식별하는 데 사용됩니다.
 
 <table class="properties">
   <tbody>
     <tr>
       <th scope="row">Header type</th>
-      <td>{{Glossary("General header")}}</td>
+      <td>
+        {{Glossary("Request header", "요청 헤더")}},
+        {{Glossary("Response header", "응답 헤더")}}
+      </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
-      <td>yes</td>
+      <th scope="row">{{Glossary("Forbidden header name", "금지된 헤더 이름")}}</th>
+      <td>예</td>
     </tr>
   </tbody>
 </table>
 
-## 문법
+## 구문
 
-```
+```http
 Via: [ <protocol-name> "/" ] <protocol-version> <host> [ ":" <port> ]
-or
 Via: [ <protocol-name> "/" ] <protocol-version> <pseudonym>
 ```
 
@@ -35,23 +39,21 @@ Via: [ <protocol-name> "/" ] <protocol-version> <pseudonym>
 - \<protocol-version>
   - : "1.1" 과 같이 사용된 프로토콜의 버전.
 - \<host> and \<port>
-  - : 공용 프록시의 URL 과 port.
+  - : 공용 프록시의 URL과 포트.
 - \<pseudonym>
   - : 내부 프록시의 이름 또는 별칭.
 
 ## 예제
 
-```
+```http
 Via: 1.1 vegur
 Via: HTTP/1.1 GWA
 Via: 1.0 fred, 1.1 p.example.net
 ```
 
-## 기술사양
+## 명세서
 
-| 기술사양                                 | 제목                                                               |
-| ---------------------------------------- | ------------------------------------------------------------------ |
-| {{RFC("7230", "Via", "5.7.1")}} | Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing |
+{{Specifications}}
 
 ## 브라우저 호환성
 

--- a/files/ko/web/http/status/401/index.md
+++ b/files/ko/web/http/status/401/index.md
@@ -1,29 +1,36 @@
 ---
 title: 401 Unauthorized
 slug: Web/HTTP/Status/401
+l10n:
+  sourceCommit: cab15d3616b63a8699e6c0cee0631a48edcec979
 ---
 
-{{HTTPSidebar}}**`401 Unauthorized`** 클라이언트 오류 상태 응답 코드는 해당 리소스에 유효한 인증 자격 증명이 없기 때문에 요청이 적용되지 않았음을 나타냅니다.
+{{HTTPSidebar}}
 
-이 상태는 {{HTTPHeader("WWW-Authenticate")}} 헤더와 함께 전송되며, 이 헤더는 올바르게 인증하는 방법에 대한 정보를 포함하고 있습니다.
+HTTP(하이퍼텍스트 전송 프로토콜) **`401 Unauthorized`** 응답 상태 코드는 요청된 리소스에 대한
+유효한 인증 자격 증명이 없기 때문에 클라이언트 요청이 완료되지 않았음을 나타냅니다.
 
-이 상태는 {{HTTPStatus("403")}}과 비슷하지만, `401 Unauthorized`의 경우에는 인증이 가능합니다.
+이 상태 코드는 사용자에게 인증 자격 증명을 입력하라는 메시지를 표시한 후 클라이언트가 리소스를 다시 요청할 수 있는
+방법이 포함된 HTTP {{HTTPHeader("WWW-Authenticate")}} 응답 헤더와 함께 전송됩니다.
+
+이 상태 코드는 {{HTTPStatus("403", "403 Forbidden")}} 상태 코드와 유사합니다.
+다만 이 상태 코드가 발생하는 상황에서 사용자 인증을 통해 리소스에 대한 액세스를 허용할 수 있습니다.
 
 ## 상태
 
-```
+```http
 401 Unauthorized
 ```
 
 ## 응답 예시
 
-```
+```http
 HTTP/1.1 401 Unauthorized
 Date: Wed, 21 Oct 2015 07:28:00 GMT
 WWW-Authenticate: Basic realm="Access to staging site"
 ```
 
-## 명세
+## 명세서
 
 {{Specifications}}
 


### PR DESCRIPTION
- HTTP 헤더 최신 동기화: `age`, `content-range`, `via`
- HTTP 상태 코드 401 동기화
