### PR TITLE
es: Update browser compat/spec sections (part 2)

### DIFF
--- a/files/es/learn/css/building_blocks/debugging_css/index.md
+++ b/files/es/learn/css/building_blocks/debugging_css/index.md
@@ -158,7 +158,7 @@ Los navegadores simplemente ignoran el CSS que no entienden. Si la propiedad o e
 
 También puedes echar un vistazo a las tablas de compatibilidad de navegadores en la parte inferior de cada página de propiedades del proyecto MDN. Te muestran la compatibilidad de cada navegador para esa propiedad, a menudo desglosado si hay compatibilidad para un uso de la propiedad y no para otros. La tabla siguiente muestra los datos de compatibilidad para la propiedad {{cssxref ("shape-outside")}}.
 
-{{compat("css.shape-outside")}}
+{{compat}}
 
 ### ¿Hay algo más que anule tu CSS?
 

--- a/files/es/learn/css/building_blocks/debugging_css/index.md
+++ b/files/es/learn/css/building_blocks/debugging_css/index.md
@@ -158,8 +158,6 @@ Los navegadores simplemente ignoran el CSS que no entienden. Si la propiedad o e
 
 También puedes echar un vistazo a las tablas de compatibilidad de navegadores en la parte inferior de cada página de propiedades del proyecto MDN. Te muestran la compatibilidad de cada navegador para esa propiedad, a menudo desglosado si hay compatibilidad para un uso de la propiedad y no para otros. La tabla siguiente muestra los datos de compatibilidad para la propiedad {{cssxref ("shape-outside")}}.
 
-{{compat}}
-
 ### ¿Hay algo más que anule tu CSS?
 
 Aquí es donde la información que has aprendido sobre la especificidad será muy útil. Si tienes algo más específico que anula lo que intentas hacer, puedes entrar en un juego muy frustrante de tratar de resolverlo sin saber qué tienes que resolver. Sin embargo, como hemos dicho, las DevTools te mostrarán qué CSS se ha aplicado y así puedes averiguar cómo hacer que el nuevo selector sea lo suficientemente específico como para anularlo.

--- a/files/es/learn/css/first_steps/what_is_css/index.md
+++ b/files/es/learn/css/first_steps/what_is_css/index.md
@@ -113,8 +113,6 @@ Una vez se ha especificado el CSS, solo es útil en el desarrollo de páginas we
 
 Lo que sigue es el gráfico de datos de compatibilidad para la propiedad CSS [`font-family`](/es/docs/Web/CSS/font-family).
 
-{{Compat}}
-
 ## ¿Qué viene ahora?
 
 Ahora que comprendes mínimamente qué es el CSS, pasemos a [Comenzar con CSS](/es/docs/Learn/CSS/First_steps/Comenzando_CSS), donde puedes empezar a escribir algo de CSS tú mismo.

--- a/files/es/learn/css/first_steps/what_is_css/index.md
+++ b/files/es/learn/css/first_steps/what_is_css/index.md
@@ -107,13 +107,13 @@ El CSS Working Group desarrolla o especifica características nuevas del CSS. Al
 
 Como recién llegado al CSS, es probable que encuentres las especificaciones abrumadoras: están destinadas a que los ingenieros las utilicen para implementar soporte de sus características en los agentes de usuario en que trabajan, no para que lo lean los desarrolladores web para comprender el CSS. Muchos desarrolladores experimentados preferirán consultar la documentación disponible en MDN u otros tutoriales. Sin embargo, vale la pena saber que existen y comprender la relación que hay entre el CSS que estás utilizando, el soporte del navegador (ver más abajo) y las especificaciones.
 
-## Soporte del navegador
+## Compatibilidad con navegadores
 
 Una vez se ha especificado el CSS, solo es útil en el desarrollo de páginas web si uno o más navegadores lo han implementado. Esto significa que el código se ha escrito para convertir las instrucciones que se especifican en nuestro archivo CSS en algo que se pueda mostrar en pantalla. Veremos este proceso más en profundidad en el artículo [Cómo funciona el CSS](/es/docs/Learn/CSS/First_steps/Como_funciona_CSS). Es inusual que todos los navegadores puedan implementar una misma característica al mismo tiempo, por lo que suele haber una brecha en la que se pueden usar algunas partes del CSS en algunos navegadores pero no en otros. Por este motivo, es útil poder verificar el estado de implementación. En cada una de las páginas de propiedades que hay en la MDN se puede ver el estado de la propiedad de interés, por lo que se puede saber si será posible utilizarla en un sitio web.
 
 Lo que sigue es el gráfico de datos de compatibilidad para la propiedad CSS [`font-family`](/es/docs/Web/CSS/font-family).
 
-{{Compat("css.properties.font-family")}}
+{{Compat}}
 
 ## ¿Qué viene ahora?
 

--- a/files/es/mozilla/add-ons/webextensions/api/i18n/index.md
+++ b/files/es/mozilla/add-ons/webextensions/api/i18n/index.md
@@ -30,9 +30,9 @@ Para obtener más información sobre el uso de i18n en su extensión, consulte:
 
 <!---->
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-{{Compat("webextensions.api.i18n")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/es/mozilla/add-ons/webextensions/api/storage/index.md
+++ b/files/es/mozilla/add-ons/webextensions/api/storage/index.md
@@ -45,9 +45,9 @@ El almacenamiento tiene tres propiedades, que representan los diferentes tipos d
 - {{WebExtAPIRef("storage.onChanged")}}
   - : Se dispara cuando uno o más elementos cambian en un área de almacenamiento.
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("webextensions.api.storage")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/es/mozilla/add-ons/webextensions/api/storage/local/index.md
+++ b/files/es/mozilla/add-ons/webextensions/api/storage/local/index.md
@@ -33,9 +33,9 @@ El objeto local implementa los métodos definidos en el{{WebExtAPIRef("storage.S
 - {{WebExtAPIRef("storage.StorageArea.clear()")}}
   - : Elimina todos los elementos del área de almacenamiento.
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("webextensions.api.storage.local")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/es/mozilla/add-ons/webextensions/api/storage/sync/index.md
+++ b/files/es/mozilla/add-ons/webextensions/api/storage/sync/index.md
@@ -28,9 +28,9 @@ El objeto de sincronización implementa los métodos definidos en el {{WebExtAPI
 - {{WebExtAPIRef("storage.StorageArea.clear()")}}
   - : Elimina todos los elementos del área de almacenamiento.
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("webextensions.api.storage.sync")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/es/mozilla/add-ons/webextensions/manifest.json/icons/index.md
+++ b/files/es/mozilla/add-ons/webextensions/manifest.json/icons/index.md
@@ -52,6 +52,6 @@ Puede usar SVG y el navegador escalará su icono adecuadamente. Sin embargo, hay
 
 > **Nota:** Si está usando un programa como Inkscape para crear SVG, puede que quiera guardarlo como un "SVG simple". Firefox podría confundirse con varios espacios de nombres especiales y no mostrar su icono.
 
-## Compatibilidad
+## Compatibilidad con navegadores
 
-{{Compat("webextensions.manifest.icons")}}
+{{Compat}}

--- a/files/es/mozilla/add-ons/webextensions/manifest.json/index.md
+++ b/files/es/mozilla/add-ons/webextensions/manifest.json/index.md
@@ -33,11 +33,9 @@ Puedes acceder a el manifest desde el código JavaScript de tu extensión utiliz
 browser.runtime.getManifest().version;
 ```
 
-## Compatibilidad de Navegadores
+## Compatibilidad con navegadores
 
-Para un resumen extendido de las llaves y sub-llaves ver la [tabla completa de compatibilidad de `manifest.json` en navegadores](/es/docs/Mozilla/Add-ons/WebExtensions/Browser_compatibility_for_manifest.json).
-
-{{Compat("webextensions.manifest")}}
+{{Compat}}
 
 ## Ver También
 

--- a/files/es/mozilla/add-ons/webextensions/manifest.json/index.md
+++ b/files/es/mozilla/add-ons/webextensions/manifest.json/index.md
@@ -35,6 +35,8 @@ browser.runtime.getManifest().version;
 
 ## Compatibilidad con navegadores
 
+Para un resumen extendido de las llaves y sub-llaves ver la [tabla completa de compatibilidad de `manifest.json` en navegadores](/es/docs/Mozilla/Add-ons/WebExtensions/Browser_compatibility_for_manifest.json).
+
 {{Compat}}
 
 ## Ver También

--- a/files/es/orphaned/web/api/globaleventhandlers/index.md
+++ b/files/es/orphaned/web/api/globaleventhandlers/index.md
@@ -207,9 +207,9 @@ _Esta interfaz no define métodos_
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.GlobalEventHandlers")}}
+{{Compat}}
 
 ## Ve también
 

--- a/files/es/orphaned/web/api/globaleventhandlers/index.md
+++ b/files/es/orphaned/web/api/globaleventhandlers/index.md
@@ -203,14 +203,6 @@ Estos controladores de eventos se definen en el mixin {{DOMxRef("GlobalEventHand
 
 _Esta interfaz no define métodos_
 
-## Especificaciones
-
-{{Specifications}}
-
-## Compatibilidad con navegadores
-
-{{Compat}}
-
 ## Ve también
 
 - {{DOMxRef("Element")}}

--- a/files/es/orphaned/web/api/htmlorforeignelement/focus/index.md
+++ b/files/es/orphaned/web/api/htmlorforeignelement/focus/index.md
@@ -102,17 +102,17 @@ focusNoScrollMethod = function getFocusWithoutScrolling() {
 
 {{ EmbedLiveSample('Focus_prevent_scroll') }}
 
-## Especificaciones
-
-{{Specifications}}
-
 ## Notas
 
 Si se llama a `HTMLElement.focus()` desde un gestor de eventos "mousedown" (ratón presionado), se debe también llamar al método `event.preventDefault()` para evitar que el foco abandone `HTMLElement`**.**
 
-## Compatibilidad en navegadores
+## Especificaciones
 
-{{Compat("api.HTMLElement.focus")}}
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/orphaned/web/api/htmlorforeignelement/focus/index.md
+++ b/files/es/orphaned/web/api/htmlorforeignelement/focus/index.md
@@ -2,6 +2,7 @@
 title: HTMLElement.focus()
 slug: orphaned/Web/API/HTMLOrForeignElement/focus
 original_slug: Web/API/HTMLOrForeignElement/focus
+browser-compat: api.HTMLElement.focus
 ---
 
 {{ APIRef("HTML DOM") }}

--- a/files/es/orphaned/web/api/navigatorconcurrenthardware/hardwareconcurrency/index.md
+++ b/files/es/orphaned/web/api/navigatorconcurrenthardware/hardwareconcurrency/index.md
@@ -44,9 +44,9 @@ for (let i = 0; i < window.navigator.hardwareConcurrency; i++) {
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.NavigatorConcurrentHardware.hardwareConcurrency")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/orphaned/web/api/navigatorconcurrenthardware/hardwareconcurrency/index.md
+++ b/files/es/orphaned/web/api/navigatorconcurrenthardware/hardwareconcurrency/index.md
@@ -2,6 +2,7 @@
 title: navigator.hardwareConcurrency
 slug: orphaned/Web/API/NavigatorConcurrentHardware/hardwareConcurrency
 original_slug: Web/API/NavigatorConcurrentHardware/hardwareConcurrency
+browser-compat: api.Navigator.hardwareConcurrency
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/es/orphaned/web/api/navigatorconcurrenthardware/index.md
+++ b/files/es/orphaned/web/api/navigatorconcurrenthardware/index.md
@@ -25,9 +25,9 @@ _The `NavigatorConcurrentHardware`_ _mixin has no methods._
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.NavigatorConcurrentHardware")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/orphaned/web/api/navigatorconcurrenthardware/index.md
+++ b/files/es/orphaned/web/api/navigatorconcurrenthardware/index.md
@@ -2,6 +2,7 @@
 title: NavigatorConcurrentHardware
 slug: orphaned/Web/API/NavigatorConcurrentHardware
 original_slug: Web/API/NavigatorConcurrentHardware
+browser-compat: api.Navigator.hardwareConcurrency
 ---
 
 {{APIRef("HTML DOM")}}

--- a/files/es/orphaned/web/api/windoweventhandlers/index.md
+++ b/files/es/orphaned/web/api/windoweventhandlers/index.md
@@ -47,14 +47,6 @@ _The events properties, of the form `onXYZ`, are defined on the {{domxref("Windo
 
 _This interface defines no method._
 
-## Especificaciones
-
-{{Specifications}}
-
-## Compatibilidad con navegadores
-
-{{Compat}}
-
 ## See also
 
 - {{domxref("Window")}} and {{domxref("WorkerGlobalScope")}}

--- a/files/es/orphaned/web/api/windoweventhandlers/index.md
+++ b/files/es/orphaned/web/api/windoweventhandlers/index.md
@@ -51,9 +51,9 @@ _This interface defines no method._
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.WindowEventHandlers")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/orphaned/web/css/-moz-context-properties/index.md
+++ b/files/es/orphaned/web/css/-moz-context-properties/index.md
@@ -71,7 +71,3 @@ Aqui hemos puesto que la imagen `src` sea una URL de datos que contiene una imag
 ## Especificaciones
 
 Esta propiedad no esta definida en ningun estándar de CSS.
-
-## Compatibilidad con navegadores
-
-{{Compat}}

--- a/files/es/orphaned/web/css/-moz-context-properties/index.md
+++ b/files/es/orphaned/web/css/-moz-context-properties/index.md
@@ -70,8 +70,8 @@ Aqui hemos puesto que la imagen `src` sea una URL de datos que contiene una imag
 
 ## Especificaciones
 
-Esta propiedad no esta definida en ningun estándar de CSS
+Esta propiedad no esta definida en ningun estándar de CSS.
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("css.properties.-moz-context-properties")}}
+{{Compat}}

--- a/files/es/web/api/analysernode/index.md
+++ b/files/es/web/api/analysernode/index.md
@@ -139,9 +139,9 @@ function draw() {
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.AnalyserNode")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/animationevent/animationname/index.md
+++ b/files/es/web/api/animationevent/animationname/index.md
@@ -17,9 +17,9 @@ name = AnimationEvent.animationName
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.AnimationEvent.animationName")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/animationevent/index.md
+++ b/files/es/web/api/animationevent/index.md
@@ -36,9 +36,9 @@ _También hereda los métodos de su padre {{domxref("Event")}}_.
 
 {{Specifications}}
 
-## Compatibilidad de Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.AnimationEvent")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/atob/index.md
+++ b/files/es/web/api/atob/index.md
@@ -26,9 +26,9 @@ var decodedData = window.atob(encodedData); // decode the string
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.atob")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/attr/index.md
+++ b/files/es/web/api/attr/index.md
@@ -114,4 +114,4 @@ Los siguientes metodos ahora son obsoletos.
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.Attr")}}
+{{Compat}}

--- a/files/es/web/api/audiobuffer/index.md
+++ b/files/es/web/api/audiobuffer/index.md
@@ -75,9 +75,9 @@ source.start();
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.AudioBuffer")}}
+{{Compat}}
 
 ## Mira también
 

--- a/files/es/web/api/baseaudiocontext/createbiquadfilter/index.md
+++ b/files/es/web/api/baseaudiocontext/createbiquadfilter/index.md
@@ -53,9 +53,9 @@ biquadFilter.gain.value = 25;
 
 {{Specifications}}
 
-## Compatibilidad con el navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.BaseAudioContext.createBiquadFilter")}}
+{{Compat}}
 
 ## Ver tambien
 

--- a/files/es/web/api/baseaudiocontext/index.md
+++ b/files/es/web/api/baseaudiocontext/index.md
@@ -100,9 +100,9 @@ var finish = audioCtx.destination;
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.BaseAudioContext")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/beforeunloadevent/index.md
+++ b/files/es/web/api/beforeunloadevent/index.md
@@ -54,9 +54,13 @@ window.addEventListener("beforeunload", function (e) {
 });
 ```
 
-## Compatibilidad del navegador
+## Especificaciones
 
-{{Compat("api.BeforeUnloadEvent")}}
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/blob/blob/index.md
+++ b/files/es/web/api/blob/blob/index.md
@@ -41,9 +41,9 @@ var oMiBlob = new Blob(unaParteDeArchivo, {type : 'text/html'}); // el blob
 
 {{Specifications}}
 
-## Compatibilidad de los navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Blob.Blob")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/api/blob/index.md
+++ b/files/es/web/api/blob/index.md
@@ -82,19 +82,9 @@ Al utilizar otros métodos de {{domxref("FileReader")}}, es posible leer los con
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Blob")}}
-
-## Disponilidad del alcance del código en Chrome
-
-El alcance JSM del `Blob`se encuentra disponible sin la necesidad de hacer nada en especial.
-
-En el alcance de arranque, este debe importarse de igual modo:
-
-```js
-const {Blob, Services} = Cu.import('resource://gre/modules/Services.jsm', {});
-```
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/blob/type/index.md
+++ b/files/es/web/api/blob/type/index.md
@@ -43,9 +43,9 @@ for (i = 0; i < files.length; i++) {
 
 {{Specifications}}
 
-## Compatibilidad con browsers
+## Compatibilidad con navegadores
 
-{{Compat("api.Blob.type")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/caches/index.md
+++ b/files/es/web/api/caches/index.md
@@ -47,9 +47,9 @@ this.addEventListener('install', function(event) {
 
 {{Specifications}}
 
-## Compatibilidad de Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.caches")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/cachestorage/index.md
+++ b/files/es/web/api/cachestorage/index.md
@@ -158,9 +158,9 @@ try {
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.CacheStorage")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/cachestorage/keys/index.md
+++ b/files/es/web/api/cachestorage/keys/index.md
@@ -49,9 +49,9 @@ then.addEventListener('activar', función (evento) {
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.CacheStorage.keys")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/canvasrenderingcontext2d/arc/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/arc/index.md
@@ -133,16 +133,9 @@ for (var i = 0; i < 4; i++) {
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.CanvasRenderingContext2D.arc")}}
-
-## Notas específicas de Gecko
-
-Comenzando con Gecko 2.0 (Firefox 4 / Thunderbird 3.3 / SeaMonkey 2.1):
-
-- El parámetro `anticlockwise` es opcional,
-- Especificar un radio negativo ahora arroja un error [`IndexSizeError`](/es/docs/Web/API/DOMError) ("Índice o tamaño es negativo o mayor que la cantidad permitida").
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/canvasrenderingcontext2d/beginpath/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/beginpath/index.md
@@ -102,9 +102,9 @@ window.addEventListener("load", drawCanvas);
 
 {{Specifications}}
 
-## Compatibilidad de los navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.CanvasRenderingContext2D.beginPath")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/canvasrenderingcontext2d/clearrect/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/clearrect/index.md
@@ -111,9 +111,9 @@ window.addEventListener("load", drawCanvas);
 
 {{Specifications}}
 
-## Compatibilidad con exploradores
+## Compatibilidad con navegadores
 
-{{Compat("api.CanvasRenderingContext2D.clearRect")}}
+{{Compat}}
 
 ## Vea También
 

--- a/files/es/web/api/canvasrenderingcontext2d/drawimage/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/drawimage/index.md
@@ -125,8 +125,8 @@ window.addEventListener("load", drawCanvas);
 
 ## Notas
 
--  `drawImage()` solo funciona correctamente en un {{domxref("HTMLVideoElement")}} cuando su {{domxref("HTMLMediaElement.readyState")}} es mayor que 1 (es decir, el evento de búsqueda se activa después de configurar la propiedad `currentTime).
-- `drawImage()` siempre utilizará del elemento de origen _el tamaño intrínseco  en píxeles de CSS_ al dibujar, recortar o escalar.
+- `drawImage()` solo funciona correctamente en un {{domxref("HTMLVideoElement")}} cuando su {{domxref("HTMLMediaElement.readyState")}} es mayor que 1 (es decir, el evento de búsqueda se activa después de configurar la propiedad `currentTime`).
+- `drawImage()` siempre utilizará del elemento de origen _el tamaño intrínseco en píxeles de CSS_ al dibujar, recortar o escalar.
 - En algunas versiones anteriores del navegador, `drawImage()` ignorará todos los metadatos EXIF en las imágenes, incluida la Orientación. Este comportamiento es especialmente problemático en dispositivos iOS. Debe detectar la Orientación usted mismo y usar la función `rotate()` para corregirla.
 
 ## Mira también

--- a/files/es/web/api/canvasrenderingcontext2d/drawimage/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/drawimage/index.md
@@ -123,6 +123,12 @@ window.addEventListener("load", drawCanvas);
 
 {{Compat}}
 
+## Notas
+
+-  `drawImage()` solo funciona correctamente en un {{domxref("HTMLVideoElement")}} cuando su {{domxref("HTMLMediaElement.readyState")}} es mayor que 1 (es decir, el evento de búsqueda se activa después de configurar la propiedad `currentTime).
+- `drawImage()` siempre utilizará del elemento de origen _el tamaño intrínseco  en píxeles de CSS_ al dibujar, recortar o escalar.
+- En algunas versiones anteriores del navegador, `drawImage()` ignorará todos los metadatos EXIF en las imágenes, incluida la Orientación. Este comportamiento es especialmente problemático en dispositivos iOS. Debe detectar la Orientación usted mismo y usar la función `rotate()` para corregirla.
+
 ## Mira también
 
 - Definiendo la interfaz, {{domxref("CanvasRenderingContext2D")}}.

--- a/files/es/web/api/canvasrenderingcontext2d/drawimage/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/drawimage/index.md
@@ -119,18 +119,9 @@ window.addEventListener("load", drawCanvas);
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.CanvasRenderingContext2D.drawImage")}}
-
-## Notas de compatibilidad
-
-- Soporte para voltear imagen usando valores negativos para `sw` y `sh` fue añadido en Gecko 5.0 (Firefox 5.0 / Thunderbird 5.0 / SeaMonkey 2.2).
-- Empezando con (Firefox 5.0 / Thunderbird 5.0 / SeaMonkey 2.2) `drawImage()` maneja argumentos negativos de acuerdo con la especificación, volteando el rectangulo alrededor del eje apopiado.
-- Especificación de una imagen `null` o `undefined` al llamar o `drawImage()` correctamente lanzando una excepción `TYPE_MISMATCH_ERR` empezando con (Firefox 5.0 / Thunderbird 5.0 / SeaMonkey 2.2).
-- antes de Gecko 7.0 (Firefox 7.0 / Thunderbird 7.0 / SeaMonkey 2.4), Firefox lanzó una excepción si alguno de los valores de las coordenadas no eran finitos o cero. De acuerado a la especificación esto ya no ocurre.
-- Gecko 9.0 (Firefox 9.0 / Thunderbird 9.0 / SeaMonkey 2.6) ahora soporta correctamente CORS para dibujar imágenes a través de dominios sin [manchar el canvas](/en/CORS_Enabled_Image#What_is_a_.22tainted.22_canvas.3F).
-- Gecko 11.0 (Firefox 11.0 / Thunderbird 11.0 / SeaMonkey 2.8) ahora permite SVG-como-una-imagen para ser dibujada en el canvas sin [manchar el canvas](/en/CORS_Enabled_Image#What_is_a_.22tainted.22_canvas.3F).
+{{Compat}}
 
 ## Mira también
 

--- a/files/es/web/api/canvasrenderingcontext2d/fillrect/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/fillrect/index.md
@@ -92,9 +92,9 @@ window.addEventListener("load", drawCanvas);
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.CanvasRenderingContext2D.fillRect")}}
+{{Compat}}
 
 ## Documentos relacionados
 

--- a/files/es/web/api/canvasrenderingcontext2d/getimagedata/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/getimagedata/index.md
@@ -65,7 +65,7 @@ console.log(ctx.getImageData(50, 50, 100, 100));
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.CanvasRenderingContext2D.getImageData")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/api/canvasrenderingcontext2d/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/index.md
@@ -316,9 +316,9 @@ Most of these APIs are [deprecated and will be removed in the future](https://co
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.CanvasRenderingContext2D")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/canvasrenderingcontext2d/linecap/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/linecap/index.md
@@ -96,13 +96,9 @@ for (let i = 0; i < lineCap.length; i++) {
 
 {{Specifications}}
 
-## Compatibilidad de navegador.
+## Compatibilidad con navegadores
 
-{{Compat("api.CanvasRenderingContext2D.lineCap")}}
-
-### WebKit/Blink-specific notes
-
-- En WebKit- y navegadores basados en Blink, el método no estandard y obsoleto `ctx.setLineCap()` es implementado ademas de esta propiedad.
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/canvasrenderingcontext2d/rotate/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/rotate/index.md
@@ -110,9 +110,9 @@ El rectángulo no rotado es gris, y el rectángulo rotado es rojo.
 
 {{Specifications}}
 
-## Compatibilidad con exploradores
+## Compatibilidad con navegadores
 
-{{Compat("api.CanvasRenderingContext2D.rotate")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/api/canvasrenderingcontext2d/save/index.md
+++ b/files/es/web/api/canvasrenderingcontext2d/save/index.md
@@ -60,9 +60,9 @@ ctx.fillRect(150, 40, 100, 100);
 
 {{Specifications}}
 
-## Compatibilidad con exploradores
+## Compatibilidad con navegadores
 
-{{Compat("api.CanvasRenderingContext2D.save")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/api/clipboard_api/index.md
+++ b/files/es/web/api/clipboard_api/index.md
@@ -36,17 +36,7 @@ Esta pieza de código lee el texto que hay en el portapapeles y lo añade al pri
 
 ## Compatibilidad con navegadores
 
-### Clipboard
-
-{{Compat("api.Clipboard")}}
-
-### ClipboardEvent
-
-{{Compat("api.ClipboardEvent")}}
-
-### ClipboardItem
-
-{{Compat("api.ClipboardItem")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/api/clipboardevent/clipboarddata/index.md
+++ b/files/es/web/api/clipboardevent/clipboarddata/index.md
@@ -24,7 +24,7 @@ data = ClipboardEvent.clipboardData
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.ClipboardEvent.clipboardData")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/clipboardevent/index.md
+++ b/files/es/web/api/clipboardevent/index.md
@@ -27,9 +27,9 @@ _No specific methods; inherits methods from its parent {{domxref("Event")}}_.
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.ClipboardEvent")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/closeevent/index.md
+++ b/files/es/web/api/closeevent/index.md
@@ -56,9 +56,13 @@ _Esta interface tambien hereda metodos de su padre, {{domxref("Event")}}._
 - {{domxref("CloseEvent.initCloseEvent()")}} {{Non-standard_inline}} {{deprecated_inline}}
   - : Inicializa el valor de un `CloseEvent` creado. Si el evento ya ha sido enviado, este método no funciona. No use más este método, use el {{domxref("CloseEvent.CloseEvent", "CloseEvent()")}} constructor en su lugar.
 
-## Compatibilidad entre Navegadores
+## Especificaciones
 
-{{Compat("api.CloseEvent")}}
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Ver tambien
 

--- a/files/es/web/api/comment/index.md
+++ b/files/es/web/api/comment/index.md
@@ -5,7 +5,7 @@ slug: Web/API/Comment
 
 {{ ApiRef("DOM") }}
 
-La interfaz **`Comment`** representa las anotaciones y comentarios dentro del código fuente; aunque generalmente no se muestran visualmente en el navegador, dichos comentarios están disponibles para ser leídos en la** [vista de código](/es/docs/Tools/View_source)**.
+La interfaz **`Comment`** representa las anotaciones y comentarios dentro del código fuente; aunque generalmente no se muestran visualmente en el navegador, dichos comentarios están disponibles para ser leídos en la **[vista de código](/es/docs/Tools/View_source)**.
 Los comentarios se representan en HTML y XML como contenido entre '\<!--' y '-->'. En XML, la secuencia de caracteres '--' no se puede usar dentro de un comentario.
 
 {{InheritanceDiagram}}
@@ -27,9 +27,9 @@ _Esta interfaz no tiene ninguna propiedad específica, pero hereda las de su pad
 
 {{Specifications}}
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Comment")}}
+{{Compat}}
 
 ## Lea también
 

--- a/files/es/web/api/console/assert/index.md
+++ b/files/es/web/api/console/assert/index.md
@@ -37,9 +37,9 @@ Para más detalles ver [Salida de texto a la consola](/es/docs/Web/API/console#O
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.console.assert")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/console/count/index.md
+++ b/files/es/web/api/console/count/index.md
@@ -86,6 +86,6 @@ console.count([label]);
 
 {{Specifications}}
 
-## Compatibilidad en los navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.console.count")}}
+{{Compat}}

--- a/files/es/web/api/console/dir/index.md
+++ b/files/es/web/api/console/dir/index.md
@@ -28,9 +28,9 @@ console.dir(objeto);
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.console.dir")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/console/dirxml/index.md
+++ b/files/es/web/api/console/dirxml/index.md
@@ -18,9 +18,13 @@ console.dirxml(objeto);
 - `objeto`
   - : Un objeto JavaScript cuyas propiedades deben ser mostradas.
 
-## Browser compatibility
+## Especificaciones
 
-{{Compat("api.console.dirxml")}}
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/console/error/index.md
+++ b/files/es/web/api/console/error/index.md
@@ -37,7 +37,7 @@ Vea "[Mostrando texto en la consola](/es/docs/Web/API/console#Outputting_text_to
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.console.error")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/api/console/info/index.md
+++ b/files/es/web/api/console/info/index.md
@@ -29,9 +29,9 @@ Ver [Salida de texto en la consola](/es/docs/Web/API/console#Outputting_text_to_
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.console.info")}}
+{{Compat}}
 
 ## Vea tambien
 

--- a/files/es/web/api/console/log/index.md
+++ b/files/es/web/api/console/log/index.md
@@ -31,24 +31,7 @@ Vea "[Mostrando texto en la consola](/es/docs/DOM/console#Outputting_text_to_the
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.console.log")}}
-
-## Diferencia con console.dir()
-
-Te preguntarás cual es la diferencia entre console.dir() y console.log().
-
-Una diferencia útil en Chrome es cuando envías elementos DOM a la consola.
-
-![](http://i.imgur.com/DozDcYR.png)
-
-Importante:
-
-- `console.log` muestra el elemento en un árbol HTML
-- `console.dir` muestra el elemento en un árbol JSON
-
-Específicamente, `console.log` brinda un tratamiento especial a los elementos del DOM, mientras que console.dir no. Esto es útil a menudo cuando intentas ver la representación completa del objeto JavaScript del DOM.
-
-Hay mas información en la [referencia de la API Console de Chrome](https://developers.google.com/chrome-developer-tools/docs/console-api#consoledirobject) acerca de esto y otras funciones.
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/console/table/index.md
+++ b/files/es/web/api/console/table/index.md
@@ -158,4 +158,4 @@ console.table(data [, columns]);
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.console.table")}}
+{{Compat}}

--- a/files/es/web/api/console/time/index.md
+++ b/files/es/web/api/console/time/index.md
@@ -26,9 +26,9 @@ console.time(label);
 
 {{Specifications}}
 
-## Compatibilidad con exploradores
+## Compatibilidad con navegadores
 
-{{Compat("api.console.time")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/console/trace/index.md
+++ b/files/es/web/api/console/trace/index.md
@@ -42,9 +42,9 @@ foo
 
 {{Specifications}}
 
-## Compatibilidad con el navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.console.trace")}}
+{{Compat}}
 
 ## Ver tambien
 

--- a/files/es/web/api/crypto/getrandomvalues/index.md
+++ b/files/es/web/api/crypto/getrandomvalues/index.md
@@ -43,11 +43,9 @@ for (var i = 0; i < array.length; i++) {
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-La tabla de compatibilidad de esta página se genera a partir de datos estructurados. Si desea contribuir a los datos, por favor, compruebe <https://github.com/mdn/browser-compat-data> y envianos un pull request.
-
-{{Compat("api.Crypto.getRandomValues")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/crypto/index.md
+++ b/files/es/web/api/crypto/index.md
@@ -27,9 +27,9 @@ _Esta interfaz implementa las propiedades definidas en {{domxref("RandomSource")
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.Crypto")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/crypto/subtle/index.md
+++ b/files/es/web/api/crypto/subtle/index.md
@@ -17,9 +17,9 @@ var crypto = crypto.subtle;
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.Crypto.subtle")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/crypto_property/index.md
+++ b/files/es/web/api/crypto_property/index.md
@@ -18,9 +18,9 @@ var cryptoObj = window.crypto || window.msCrypto; // para IE 11
 
 {{Specifications}}
 
-## Compatibilidad de Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.crypto")}}
+{{Compat}}
 
 ## Ver También
 

--- a/files/es/web/api/cssstylerule/index.md
+++ b/files/es/web/api/cssstylerule/index.md
@@ -29,8 +29,6 @@ interface CSSStyleRule : CSSRule {
 
 {{Specifications}}
 
-## Compatibilidad entre Navegadores
+## Compatibilidad con navegadores
 
-Para obtener informacion de compatibilidad en los distintos navegadores, por favor consulta la tabla de compatibilidad de la interfaz asociada.
-
-{{Compat("api.CSSStyleRule")}}
+{{Compat}}

--- a/files/es/web/api/cssstylesheet/insertrule/index.md
+++ b/files/es/web/api/cssstylesheet/insertrule/index.md
@@ -73,13 +73,13 @@ function addStylesheetRules (decls) {
 }
 ```
 
-## Specification
+## Especificaciones
 
-- [insertRule](http://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-CSSStyleSheet-insertRule)
+{{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.CSSStyleSheet.insertRule")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/customelementregistry/define/index.md
+++ b/files/es/web/api/customelementregistry/define/index.md
@@ -199,6 +199,6 @@ customElements.define('word-count', WordCount, { extends: 'p' });
 
 {{Specifications}}
 
-## Compatibilidad navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.CustomElementRegistry.define")}}
+{{Compat}}

--- a/files/es/web/api/customelementregistry/index.md
+++ b/files/es/web/api/customelementregistry/index.md
@@ -69,6 +69,6 @@ customElements.define('word-count', WordCount, { extends: 'p' });
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.CustomElementRegistry")}}
+{{Compat}}

--- a/files/es/web/api/devicemotionevent/index.md
+++ b/files/es/web/api/devicemotionevent/index.md
@@ -37,9 +37,9 @@ window.addEventListener('devicemotion', function(event) {
 
 {{Specifications}}
 
-## Compativilidad con los navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.DeviceMotionEvent")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/documentfragment/index.md
+++ b/files/es/web/api/documentfragment/index.md
@@ -77,9 +77,9 @@ list.appendChild(fragment)
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.DocumentFragment")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/domerror/index.md
+++ b/files/es/web/api/domerror/index.md
@@ -46,6 +46,6 @@ La interfaz **`DOMError`** describe un objeto de error que contiene un nombre de
 
 {{Compat}}
 
-## Vér también
+## Véase también
 
 - {{ domxref("DOMException") }}

--- a/files/es/web/api/domerror/index.md
+++ b/files/es/web/api/domerror/index.md
@@ -38,14 +38,14 @@ La interfaz **`DOMError`** describe un objeto de error que contiene un nombre de
 | `InvalidNodeTypeError`       | El nodo (o uno de sus antecedentes) es incorrecto.                      |
 | `DataCloneError`             | El objeto no puede clonarse.                                            |
 
-## Compatibilidad de Navegadores
-
-{{Compat("api.DOMError")}}
-
 ## Especificaciones
 
-- [DOM 4 DOMError specification](https://www.w3.org/TR/dom/#interface-domerror)
+{{Specifications}}
 
-## Véase también
+## Compatibilidad con navegadores
+
+{{Compat}}
+
+## Vér también
 
 - {{ domxref("DOMException") }}

--- a/files/es/web/api/domerror/index.md
+++ b/files/es/web/api/domerror/index.md
@@ -38,10 +38,6 @@ La interfaz **`DOMError`** describe un objeto de error que contiene un nombre de
 | `InvalidNodeTypeError`       | El nodo (o uno de sus antecedentes) es incorrecto.                      |
 | `DataCloneError`             | El objeto no puede clonarse.                                            |
 
-## Especificaciones
-
-{{Specifications}}
-
 ## Compatibilidad con navegadores
 
 {{Compat}}

--- a/files/es/web/api/domparser/index.md
+++ b/files/es/web/api/domparser/index.md
@@ -114,9 +114,9 @@ Ver artículo aquí: [nsIDOMParser](/es/docs/nsIDOMParser)
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.DOMParser")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/event/currenttarget/index.md
+++ b/files/es/web/api/event/currenttarget/index.md
@@ -36,7 +36,7 @@ document.body.addEventListener('click', hide, false);
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.Event.currentTarget")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/event/defaultprevented/index.md
+++ b/files/es/web/api/event/defaultprevented/index.md
@@ -25,6 +25,10 @@ bool = event.defaultPrevented
  }
 ```
 
-### Compatibilidad del Navegador
+## Especificaciones
 
-{{Compat("api.Event.defaultPrevented")}}
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}

--- a/files/es/web/api/event/stoppropagation/index.md
+++ b/files/es/web/api/event/stoppropagation/index.md
@@ -27,6 +27,6 @@ Ver las [Especificaciones del DOM](http://www.w3.org/TR/DOM-Level-2-Events/event
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Event.stopPropagation")}}
+{{Compat}}

--- a/files/es/web/api/event/target/index.md
+++ b/files/es/web/api/event/target/index.md
@@ -42,21 +42,9 @@ ul.addEventListener('click', hide, false);
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.Event.target")}}
-
-## Notas de compatibilidad
-
-En IE 6-8 el evento 'model' es diferente. Los eventos 'listeners' son are incluidos con el método no estándar {{domxref('EventTarget.attachEvent')}}. En este modelo, el evento 'object' tiene una propiedad {{domxref('Event.srcElement')}}, en vez de la propiedad `target`, y tiene la misma semántica que `event.target`.
-
-```js
-function hide(e) {
-  // Soporte en IE6-8
-  var target = e.target || e.srcElement;
-  target.style.visibility = 'hidden';
-}
-```
+{{Compat}}
 
 ## También ver
 

--- a/files/es/web/api/event/type/index.md
+++ b/files/es/web/api/event/type/index.md
@@ -72,6 +72,6 @@ event.type
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Event.type")}}
+{{Compat}}

--- a/files/es/web/api/eventsource/index.md
+++ b/files/es/web/api/eventsource/index.md
@@ -59,9 +59,9 @@ evtSource.onmessage = function(e) {
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.EventSource")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/eventtarget/addeventlistener/index.md
+++ b/files/es/web/api/eventtarget/addeventlistener/index.md
@@ -255,17 +255,16 @@ for(i=0 ; i<els.length ; i++){
 
 In the first case, a new (anonymous) function is created at each loop turn. In the second case, the same previously declared function is used as an event handler. This results in smaller memory consumption. Moreover, in the first case, since no reference to the anonymous functions is kept, it is not possible to call [`element.removeEventListener`](/en-US/docs/Web/API/EventTarget/removeEventListener) because we do not have a reference to the handler, while in the second case, it's possible to do `myElement.removeEventListener("click", processEvent, false)`.
 
-## Browser compatibility
+## Especificaciones
 
-{{Compat("api.EventTarget.addEventListener")}}
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## See Also
 
 - [element.removeEventListener()](/es/docs/DOM/element.removeEventListener)
 - [Creating and triggering custom events](/es/docs/DOM/Creating_and_triggering_events)
 - [More details on the use of `this` in event handlers](http://www.quirksmode.org/js/this.html)
-
-## Specification
-
-- [DOM Level 2 Events: EventTarget.addEventListener](http://www.w3.org/TR/DOM-Level-2-Events/events.html#Events-EventTarget-addEventListener)
-- [DOM Level 3 Events: EventTarget.addEventListener](http://dev.w3.org/2006/webapi/DOM-Level-3-Events/html/DOM3-Events.html#events-EventTarget-addEventListener)

--- a/files/es/web/api/eventtarget/index.md
+++ b/files/es/web/api/eventtarget/index.md
@@ -24,9 +24,9 @@ Muchos objetivos de eventos tales como: elementos, documentos y ventanas, tambi√
 
 {{Specifications}}
 
-## Compatibilidad
+## Compatibilidad con navegadores
 
-{{Compat("api.EventTarget")}}
+{{Compat}}
 
 ## Vea tambi√©n
 

--- a/files/es/web/api/eventtarget/removeeventlistener/index.md
+++ b/files/es/web/api/eventtarget/removeeventlistener/index.md
@@ -126,65 +126,9 @@ mouseOverTarget.addEventListener('mouseover', function () {
 
 {{Specifications}}
 
-## Compatibilidad de los navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.EventTarget.removeEventListener", 3)}}
-
-## Polyfill to support older browsers
-
-`addEventListener()` and `removeEventListener()` are not present in older browsers. You can work around this by inserting the following code at the beginning of your scripts, allowing use of `addEventListener()` and `removeEventListener()` in implementations which do not natively support it. However, this method will not work on Internet Explorer 7 or earlier, since extending the Element.prototype was not supported until Internet Explorer 8.
-
-```js
-if (!Element.prototype.addEventListener) {
-  var oListeners = {};
-  function runListeners(oEvent) {
-    if (!oEvent) { oEvent = window.event; }
-    for (var iLstId = 0, iElId = 0, oEvtListeners = oListeners[oEvent.type]; iElId < oEvtListeners.aEls.length; iElId++) {
-      if (oEvtListeners.aEls[iElId] === this) {
-        for (iLstId; iLstId < oEvtListeners.aEvts[iElId].length; iLstId++) { oEvtListeners.aEvts[iElId][iLstId].call(this, oEvent); }
-        break;
-      }
-    }
-  }
-  Element.prototype.addEventListener = function (sEventType, fListener /*, useCapture (will be ignored!) */) {
-    if (oListeners.hasOwnProperty(sEventType)) {
-      var oEvtListeners = oListeners[sEventType];
-      for (var nElIdx = -1, iElId = 0; iElId < oEvtListeners.aEls.length; iElId++) {
-        if (oEvtListeners.aEls[iElId] === this) { nElIdx = iElId; break; }
-      }
-      if (nElIdx === -1) {
-        oEvtListeners.aEls.push(this);
-        oEvtListeners.aEvts.push([fListener]);
-        this["on" + sEventType] = runListeners;
-      } else {
-        var aElListeners = oEvtListeners.aEvts[nElIdx];
-        if (this["on" + sEventType] !== runListeners) {
-          aElListeners.splice(0);
-          this["on" + sEventType] = runListeners;
-        }
-        for (var iLstId = 0; iLstId < aElListeners.length; iLstId++) {
-          if (aElListeners[iLstId] === fListener) { return; }
-        }
-        aElListeners.push(fListener);
-      }
-    } else {
-      oListeners[sEventType] = { aEls: [this], aEvts: [ [fListener] ] };
-      this["on" + sEventType] = runListeners;
-    }
-  };
-  Element.prototype.removeEventListener = function (sEventType, fListener /*, useCapture (will be ignored!) */) {
-    if (!oListeners.hasOwnProperty(sEventType)) { return; }
-    var oEvtListeners = oListeners[sEventType];
-    for (var nElIdx = -1, iElId = 0; iElId < oEvtListeners.aEls.length; iElId++) {
-      if (oEvtListeners.aEls[iElId] === this) { nElIdx = iElId; break; }
-    }
-    if (nElIdx === -1) { return; }
-    for (var iLstId = 0, aElListeners = oEvtListeners.aEvts[nElIdx]; iLstId < aElListeners.length; iLstId++) {
-      if (aElListeners[iLstId] === fListener) { aElListeners.splice(iLstId, 1); }
-    }
-  };
-}
-```
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/fetchevent/index.md
+++ b/files/es/web/api/fetchevent/index.md
@@ -67,9 +67,9 @@ addEventListener('fetch', event => {
 
 {{Specifications}}
 
-## Compatibilidad de Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.FetchEvent")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/file/index.md
+++ b/files/es/web/api/file/index.md
@@ -56,25 +56,9 @@ _La interfaz `File` no define algún método, pero los hereda de la interfaz {{d
 
 {{Specifications}}
 
-## Compatibilidad en Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.File")}}
-
-### Notas de Implementación
-
-- En Gecko, puedes hacer uso de esta API desde código chrome. Vea [Utilizando la API DOM File en código chrome (Using the DOM File API in chrome code)](/es/docs/Extensions/Using_the_DOM_File_API_in_chrome_code) para más detalles.
-- Empezando desde Gecko 6.0 (Firefox 6.0 / Thunderbird 6.0 / SeaMonkey 2.3), código privilegiado (como las extensiones por ejemplo) puede pasar un objeto `nsIFile` al constructor DOM `File` para especificar el archivo a referenciar.
-- Empezando desde Gecko 8.0 (Firefox 8.0 / Thunderbird 8.0 / SeaMonkey 2.5), usted puede usar `new File` para la creación de objetos `File` a partir de código de componentes XPCOM en lugar de tener que instanciar el objeto `nsIDOMFile` directamente. El constructor toma, en contraste a Blob, un segundo argumento como nombre de archivo. El nombre de archivo puede ser cualquier String.
-
-  ```
-  File File(
-    Array parts,
-    String filename,
-    BlobPropertyBag properties
-  );
-  ```
-
-- Las siguientes propiedades y métodos no estándar fueron removidos en Gecko 7 (Firefox 7.0 / Thunderbird 7.0 / SeaMonkey 2.4): {{DOMxRef("File.fileName")}}, {{DOMxRef("File.fileSize")}}, {{DOMxRef("File.getAsBinary()")}}, {{DOMxRef("File.getAsDataURL()")}}, {{DOMxRef("File.getAsText()","File.getAsText(string encoding)")}} ({{bug("661876")}}). Propiedades estándar {{DOMxRef("File.name")}}, {{DOMxRef("Blob.size")}}, y métodos en {{DOMxRef("FileReader")}} deberían ser usados en su lugar.
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/file/lastmodifieddate/index.md
+++ b/files/es/web/api/file/lastmodifieddate/index.md
@@ -33,11 +33,11 @@ for (var i = 0; i < files.length; i++) {
 
 ## Especificaciones
 
-_Aunque estaba presente en las primeras versiones de la especificacion de File API, esta propiedad ha sido eliminada de esta y ahora es no-estandar. Usar {{domxref("File.lastModified")}} como reemplazo._
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.File.lastModifiedDate")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/api/file/lastmodifieddate/index.md
+++ b/files/es/web/api/file/lastmodifieddate/index.md
@@ -33,7 +33,7 @@ for (var i = 0; i < files.length; i++) {
 
 ## Especificaciones
 
-{{Specifications}}
+_Aunque estaba presente en las primeras versiones de la especificacion de File API, esta propiedad ha sido eliminada de esta y ahora es no-estandar. Usar {{domxref("File.lastModified")}} como reemplazo._
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/api/file/name/index.md
+++ b/files/es/web/api/file/name/index.md
@@ -43,7 +43,7 @@ Prueba el resultado:
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.File.name")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/api/file/webkitrelativepath/index.md
+++ b/files/es/web/api/file/webkitrelativepath/index.md
@@ -53,7 +53,7 @@ document.getElementById("filepicker").addEventListener("change", function(event)
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.File.webkitRelativePath")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/api/filereader/index.md
+++ b/files/es/web/api/filereader/index.md
@@ -69,9 +69,9 @@ Mira el artículo _[Using files from web applications](/es/docs/Using_files_from
 
 {{Specifications}}
 
-## Soporte en los navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.FileReader")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/filereader/readastext/index.md
+++ b/files/es/web/api/filereader/readastext/index.md
@@ -24,9 +24,9 @@ instanceOfFileReader.readAsText(blob[, encoding]);
 
 {{Specifications}}
 
-## Compatibilidad en los navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.FileReader.readAsText")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/api/filereader/result/index.md
+++ b/files/es/web/api/filereader/result/index.md
@@ -51,7 +51,7 @@ function read(callback) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.FileReader.result")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/formdata/index.md
+++ b/files/es/web/api/formdata/index.md
@@ -46,7 +46,7 @@ Un objeto que implementa `FormData` puede usarse directamente en una estructura 
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.FormData")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/fullscreen_api/index.md
+++ b/files/es/web/api/fullscreen_api/index.md
@@ -129,27 +129,9 @@ De momento, no todos los navegadores están implementando la versión sin prefij
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-### `Document.fullscreen`
-
-{{Compat("api.Document.fullscreen")}}
-
-### `Document.fullscreenElement`
-
-{{Compat("api.Document.fullscreenElement")}}
-
-### `Document.fullscreenEnabled`
-
-{{Compat("api.Document.fullscreenEnabled")}}
-
-### `Document.exitFullscreen`
-
-{{Compat("api.Document.exitFullscreen")}}
-
-### `Element.requestFullscreen`
-
-{{Compat("api.Element.requestFullscreen")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/api/gamepad_api/index.md
+++ b/files/es/web/api/gamepad_api/index.md
@@ -48,9 +48,9 @@ Ver también las [extensiones para la interfaz del navegador](/es/docs/Web/API/G
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.Gamepad")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/gamepadbutton/index.md
+++ b/files/es/web/api/gamepadbutton/index.md
@@ -61,9 +61,9 @@ function gameLoop() {
 
 {{Specifications}}
 
-## Compatibilidad de Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.GamepadButton")}}
+{{Compat}}
 
 ## Recomendado
 

--- a/files/es/web/api/geolocation/index.md
+++ b/files/es/web/api/geolocation/index.md
@@ -33,9 +33,9 @@ Devuelve un valor de largo(`long`) que representa la función de devolución de 
 
 {{Specifications}}
 
-## Compatibilidad en navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.Geolocation")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/geolocation_api/index.md
+++ b/files/es/web/api/geolocation_api/index.md
@@ -53,11 +53,11 @@ Consulte [Uso de la API de geolocalización](/es/docs/Web/API/Geolocation_API/Us
 
 ## Especificaciones
 
-{{Specifications("api.Geolocation")}}
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.Geolocation")}}
+{{Compat}}
 
 ### Disponibilidad
 

--- a/files/es/web/api/geolocationcoordinates/index.md
+++ b/files/es/web/api/geolocationcoordinates/index.md
@@ -33,9 +33,9 @@ La interfaz `Coordinates` no implementa ni edita ningún método.
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.GeolocationCoordinates")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/geolocationcoordinates/latitude/index.md
+++ b/files/es/web/api/geolocationcoordinates/latitude/index.md
@@ -17,9 +17,9 @@ lat = coordinates.latitude
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.GeolocationCoordinates.latitude")}}
+{{Compat}}
 
 ## Mirar también
 

--- a/files/es/web/api/history/index.md
+++ b/files/es/web/api/history/index.md
@@ -45,9 +45,9 @@ _The `History`_ _interface doesn't inherit any methods._
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.History")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/history/length/index.md
+++ b/files/es/web/api/history/length/index.md
@@ -17,9 +17,9 @@ const length = history.length
 
 {{Specifications}}
 
-## Compatibilidad de Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.History.length")}}
+{{Compat}}
 
 ## Mira también
 

--- a/files/es/web/api/history/pushstate/index.md
+++ b/files/es/web/api/history/pushstate/index.md
@@ -56,9 +56,9 @@ history.pushState(state, title, url)
 
 {{Specifications}}
 
-## Compatibilidad en Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.History.pushState")}}
+{{Compat}}
 
 ## Mira también
 

--- a/files/es/web/api/history_api/index.md
+++ b/files/es/web/api/history_api/index.md
@@ -136,9 +136,9 @@ Para un ejemplo completo de un sitio AJAX, ver: [Ejemplo de navegación AJAX](/e
 
 {{Specifications}}
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.History")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/htmlanchorelement/index.md
+++ b/files/es/web/api/htmlanchorelement/index.md
@@ -84,9 +84,9 @@ Los métodos blur () y focus () se heredan de {{domxref ("HTMLElement")}} de HTM
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLAnchorElement")}}
+{{Compat}}
 
 ## Ver tambien
 

--- a/files/es/web/api/htmlcanvaselement/getcontext/index.md
+++ b/files/es/web/api/htmlcanvaselement/getcontext/index.md
@@ -87,7 +87,7 @@ Ahora tienes el [contexto de renderizado 2D](/es/docs/Web/API/CanvasRenderingCon
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.HTMLCanvasElement.getContext")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/htmlcanvaselement/height/index.md
+++ b/files/es/web/api/htmlcanvaselement/height/index.md
@@ -35,9 +35,9 @@ console.log(canvas.height); // 300
 
 {{Specifications}}
 
-## Compatibilidad de Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLCanvasElement.height")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/htmlcanvaselement/index.md
+++ b/files/es/web/api/htmlcanvaselement/index.md
@@ -40,9 +40,9 @@ _Herada métodos de la interfaz padre,_ _{{domxref("HTMLElement")}}._
 
 {{Specifications}}
 
-## Compatibilidad en Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLCanvasElement")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/htmlcanvaselement/todataurl/index.md
+++ b/files/es/web/api/htmlcanvaselement/todataurl/index.md
@@ -115,9 +115,9 @@ function quitarColor() {
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLCanvasElement.toDataURL")}}
+{{Compat}}
 
 ## Ver también
 


### PR DESCRIPTION
This PR updates some of the browser compatibility data and specification sections for the Spanish locale. Part of work for #11594.

Note: this may also include other minor updates, such as removal of old sections or other small bits of cleanup.
