### PR TITLE
es: Update browser compat/spec sections (part 3)

### DIFF
--- a/files/es/web/api/htmlcanvaselement/width/index.md
+++ b/files/es/web/api/htmlcanvaselement/width/index.md
@@ -35,9 +35,9 @@ console.log(canvas.width); // 300
 
 {{Specifications}}
 
-## Compatibilidad de Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLCanvasElement.width")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/htmlcollection/index.md
+++ b/files/es/web/api/htmlcollection/index.md
@@ -53,7 +53,7 @@ elem1 = document.forms["named.item.with.periods"];
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.HTMLCollection")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/api/htmldivelement/index.md
+++ b/files/es/web/api/htmldivelement/index.md
@@ -26,7 +26,7 @@ _No hay métodos específicos; hereda los métodos de su padre, {{domxref("HTMLE
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.HTMLDivElement")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/htmlelement/change_event/index.md
+++ b/files/es/web/api/htmlelement/change_event/index.md
@@ -126,3 +126,5 @@ function updateValue(e) {
 ## Compatibilidad con navegadores
 
 {{Compat}}
+
+Diferentes navegadores no siempre concuerdan cuando un evento `change` debería ser disparado para ciertos tipo de interacciones. Por ejemplo, navegación por teclado en en elementos {{HTMLElement("select")}} nunca disparan el evento `change` en Gecko hasta que el usuario presiona Enter o cambia el foco fuera del `<select>` (ver {{bug("126379")}}). A partir de Firefox 63 (Quantum), sin embargo, este comportamiento es consistente entre los mayores navegadores.

--- a/files/es/web/api/htmlelement/change_event/index.md
+++ b/files/es/web/api/htmlelement/change_event/index.md
@@ -123,8 +123,6 @@ function updateValue(e) {
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLElement.change_event")}}
-
-Diferentes navegadores no siempre concuerdan cuando un evento `change` debería ser disparado para ciertos tipo de interacciones. Por ejemplo, navegación por teclado en en elementos {{HTMLElement("select")}} nunca disparan el evento `change` en Gecko hasta que el usuario presiona Enter o cambia el foco fuera del `<select>` (ver {{bug("126379")}}). A partir de Firefox 63 (Quantum), sin embargo, este comportamiento es consistente entre los mayores navegadores.
+{{Compat}}

--- a/files/es/web/api/htmlelement/click/index.md
+++ b/files/es/web/api/htmlelement/click/index.md
@@ -19,10 +19,6 @@ elemento.click()
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLElement.click")}}
-
-### Traducción en Español:
-
-[¿Necesitas ayuda?](/es/docs/MDN/Community) • [Guía editorial](/es/docs/MDN/Contribute/Editor) • [Guía de estilo](/es/docs/MDN/Contribute/Content/Style_guide)Borrador autoguardado: 26/5/2018 21:51:54
+{{Compat}}

--- a/files/es/web/api/htmlelement/contenteditable/index.md
+++ b/files/es/web/api/htmlelement/contenteditable/index.md
@@ -24,11 +24,9 @@ element.contentEditable = 'true'
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLElement.contentEditable")}}
-
-In Internet Explorer, `contenteditable` cannot be applied to the {{htmlelement("table")}}, {{htmlelement("col")}}, {{htmlelement("colgroup")}}, {{htmlelement("tbody")}}, {{htmlelement("td")}}, {{htmlelement("tfoot")}}, {{htmlelement("th")}}, {{htmlelement("thead")}}, and {{htmlelement("tr")}} elements directly. A content editable {{htmlelement("span")}} or {{htmlelement("div")}} element can be placed inside the individual table cells.
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/htmlelement/index.md
+++ b/files/es/web/api/htmlelement/index.md
@@ -106,9 +106,9 @@ _Inherits methods from its parent, {{domxref("Element")}}._
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLElement")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/htmlelement/offsetleft/index.md
+++ b/files/es/web/api/htmlelement/offsetleft/index.md
@@ -59,9 +59,9 @@ This example shows a 'long' sentence that wraps within a div with a blue border,
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLElement.offsetLeft")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/htmlelement/offsetparent/index.md
+++ b/files/es/web/api/htmlelement/offsetparent/index.md
@@ -21,6 +21,6 @@ parentObj = element.offsetParent;
 
 {{Specifications}}
 
-## Compatibilidad de Browser
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLElement.offsetParent")}}
+{{Compat}}

--- a/files/es/web/api/htmlelement/offsettop/index.md
+++ b/files/es/web/api/htmlelement/offsettop/index.md
@@ -35,8 +35,4 @@ if (topPos > 10) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.HTMLElement.offsetTop")}}
-
-In compliance with the specification, this property will return `null` on Webkit if the element is hidden (the `style.display` of this element or any ancestor is `"none"`) or if the `style.position` of the element itself is set to `"fixed"`.
-
-This property will return `null` on Internet Explorer (9) if the `style.position` of the element itself is set to `"fixed"`. (Having `display:none` does not affect this browser.)
+{{Compat}}

--- a/files/es/web/api/htmlelement/offsettop/index.md
+++ b/files/es/web/api/htmlelement/offsettop/index.md
@@ -36,3 +36,7 @@ if (topPos > 10) {
 ## Compatibilidad con navegadores
 
 {{Compat}}
+
+De conformidad con la especificación, esta propiedad devolverá el valor `null` en Webkit si el elemento está oculto (`style.display` de este elemento o de cualquier padre es `"none"`) o si `style.position` del elemento en sí está configurada como `"fixed"`.
+
+Esta propiedad devolverá `null` en Internet Explorer (9) si `style.position` del elemento en sí se establece en `"fixed"`. (Tener `display:none` no afecta a este navegador).

--- a/files/es/web/api/htmlelement/offsetwidth/index.md
+++ b/files/es/web/api/htmlelement/offsetwidth/index.md
@@ -25,6 +25,10 @@ var offsetWidth =element.offsetWidth;
 
 {{Specifications}}
 
+### Notas
+
+`offsetWidth` es una propiedad del DHTML "object model" que fue inicialmente introducido por MSIE. A veces es referido como box-width.
+
 ## Compatibilidad con navegadores
 
 {{Compat}}

--- a/files/es/web/api/htmlelement/offsetwidth/index.md
+++ b/files/es/web/api/htmlelement/offsetwidth/index.md
@@ -25,13 +25,9 @@ var offsetWidth =element.offsetWidth;
 
 {{Specifications}}
 
-### Notas
+## Compatibilidad con navegadores
 
-`offsetWidth` es una propiedad del DHTML "object model" que fue inicialmente introducido por MSIE. A veces es referido como box-width.
-
-## Compatibilidad con Navegadores
-
-{{Compat("api.HTMLElement.offsetWidth")}}
+{{Compat}}
 
 ## Links Relacionados
 

--- a/files/es/web/api/htmlformelement/reset/index.md
+++ b/files/es/web/api/htmlformelement/reset/index.md
@@ -27,7 +27,7 @@ document.getElementById('myform').reset();
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.HTMLFormElement.reset")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/api/htmlheadelement/index.md
+++ b/files/es/web/api/htmlheadelement/index.md
@@ -24,9 +24,9 @@ _No hay un método especifico; hereda los métodos del padre, {{domxref("HTMLEle
 
 {{Specifications}}
 
-## Compatibilidad con Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLHeadElement")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/api/htmlimageelement/index.md
+++ b/files/es/web/api/htmlimageelement/index.md
@@ -86,9 +86,9 @@ alert(document.images[0].src);
 
 {{Specifications}}
 
-## Compatibilidad con navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLImageElement")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/htmlinputelement/index.md
+++ b/files/es/web/api/htmlinputelement/index.md
@@ -247,7 +247,7 @@ Responde a este elemento usando [`addEventListener()`](/es/docs/Web/API/EventTar
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.HTMLInputElement")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/api/htmllabelelement/index.md
+++ b/files/es/web/api/htmllabelelement/index.md
@@ -28,9 +28,9 @@ _No hay metodos específicos, hereda los metodos de los elelemtos padres, {{domx
 
 {{Specifications}}
 
-## Compatibilidad de Navegador Web
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLLabelElement")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/htmllielement/index.md
+++ b/files/es/web/api/htmllielement/index.md
@@ -24,9 +24,9 @@ _No specific method; inherits properties from its parent, {{domxref("HTMLElement
 
 {{Specifications}}
 
-## Compatibilidad con Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLLIElement")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/htmlmediaelement/index.md
+++ b/files/es/web/api/htmlmediaelement/index.md
@@ -169,9 +169,9 @@ These methods are obsolete and should not be used, even if a browser still suppo
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLMediaElement")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/htmlmediaelement/loadeddata_event/index.md
+++ b/files/es/web/api/htmlmediaelement/loadeddata_event/index.md
@@ -78,9 +78,9 @@ video.onloadeddata = (event) => {
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLMediaElement.loadeddata_event")}}
+{{Compat}}
 
 ## Eventos Relacionados
 

--- a/files/es/web/api/htmlmediaelement/pause/index.md
+++ b/files/es/web/api/htmlmediaelement/pause/index.md
@@ -28,6 +28,6 @@ Ninguno.
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLMediaElement.pause")}}
+{{Compat}}

--- a/files/es/web/api/htmlmediaelement/paused/index.md
+++ b/files/es/web/api/htmlmediaelement/paused/index.md
@@ -30,7 +30,7 @@ console.log(obj.paused); // true
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.HTMLMediaElement.paused")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/htmlmediaelement/play/index.md
+++ b/files/es/web/api/htmlmediaelement/play/index.md
@@ -86,7 +86,7 @@ Puedes [probar o remezclar este ejemplo en tiempo real en Glitch](https://media-
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.HTMLMediaElement.play")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/htmlselectelement/checkvalidity/index.md
+++ b/files/es/web/api/htmlselectelement/checkvalidity/index.md
@@ -17,9 +17,9 @@ var result = selectElt.checkValidity();
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLSelectElement.checkValidity")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/htmlselectelement/index.md
+++ b/files/es/web/api/htmlselectelement/index.md
@@ -97,9 +97,9 @@ A better way to track changes to the user's selection is to watch for the [`chan
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLSelectElement")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/htmlselectelement/setcustomvalidity/index.md
+++ b/files/es/web/api/htmlselectelement/setcustomvalidity/index.md
@@ -21,9 +21,9 @@ selectElt.setCustomValidity(string);
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLSelectElement.setCustomValidity")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/htmlshadowelement/getdistributednodes/index.md
+++ b/files/es/web/api/htmlshadowelement/getdistributednodes/index.md
@@ -24,9 +24,9 @@ var nodes = myShadowObject.getDistributedNodes();
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLShadowElement.getDistributedNodes")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/htmlshadowelement/getdistributednodes/index.md
+++ b/files/es/web/api/htmlshadowelement/getdistributednodes/index.md
@@ -22,7 +22,7 @@ var nodes = myShadowObject.getDistributedNodes();
 
 ## Especificaciones
 
-{{Specifications}}
+Esta función ya no está definida por ninguna especificación.
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/api/htmlshadowelement/index.md
+++ b/files/es/web/api/htmlshadowelement/index.md
@@ -24,9 +24,9 @@ _This interface inherits the methods of {{domxref("HTMLElement")}}._
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLShadowElement")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/htmlshadowelement/index.md
+++ b/files/es/web/api/htmlshadowelement/index.md
@@ -22,7 +22,7 @@ _This interface inherits the methods of {{domxref("HTMLElement")}}._
 
 ## Especificaciones
 
-{{Specifications}}
+Esta función ya no está definida por ninguna especificación.
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/api/htmltableelement/insertrow/index.md
+++ b/files/es/web/api/htmltableelement/insertrow/index.md
@@ -61,7 +61,7 @@ Observese que `insertRow` inserta la fila diréctamente en la tabla y retorna un
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.HTMLTableElement.insertRow")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/htmlvideoelement/index.md
+++ b/files/es/web/api/htmlvideoelement/index.md
@@ -53,9 +53,9 @@ _Hereda los métodos anteriores de_ _{{domxref("HTMLMediaElement")}} y_ _{{domxr
 
 {{Specifications}}
 
-## Compatibilidad con Navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.HTMLVideoElement")}}
+{{Compat}}
 
 ## Lea Tambien
 

--- a/files/es/web/api/idbcursor/continue/index.md
+++ b/files/es/web/api/idbcursor/continue/index.md
@@ -65,9 +65,9 @@ function displayData() {
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.IDBCursor.continue")}}
+{{Compat}}
 
 ## Te puede interesar
 

--- a/files/es/web/api/idbcursor/index.md
+++ b/files/es/web/api/idbcursor/index.md
@@ -80,9 +80,9 @@ function displayData() {
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.IDBCursor")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/idbdatabase/index.md
+++ b/files/es/web/api/idbdatabase/index.md
@@ -106,9 +106,9 @@ This next line opens up a transaction on the Database, then opens an object stor
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.IDBDatabase")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/idbdatabase/transaction/index.md
+++ b/files/es/web/api/idbdatabase/transaction/index.md
@@ -106,9 +106,9 @@ var objectStore = transaction.objectStore("toDoList");
 
 {{Specifications}}
 
-## Compatibilidad con Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.IDBDatabase.transaction")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/idbobjectstore/add/index.md
+++ b/files/es/web/api/idbobjectstore/add/index.md
@@ -102,9 +102,9 @@ function addData() {
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.IDBObjectStore.add")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/idbobjectstore/index.md
+++ b/files/es/web/api/idbobjectstore/index.md
@@ -119,9 +119,9 @@ objectStoreRequest.onsuccess = function(event) {
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.IDBObjectStore")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/imagebitmap/index.md
+++ b/files/es/web/api/imagebitmap/index.md
@@ -23,9 +23,9 @@ The **`ImageBitmap`** interface represents a bitmap image which can be drawn to 
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.ImageBitmap")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/imagebitmaprenderingcontext/index.md
+++ b/files/es/web/api/imagebitmaprenderingcontext/index.md
@@ -16,11 +16,11 @@ Esta interface es posible en ambos , la ventana y el ["worker context"](/es/docs
 
 ## Especificaciones
 
-Escrito como una propuesta en la especificaación [OffscreenCanvas](https://wiki.whatwg.org/wiki/OffscreenCanvas).
+{{Specifications}}
 
-## Compatibilidad del Buscador
+## Compatibilidad con navegadores
 
-{{Compat("api.ImageBitmapRenderingContext")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/indexeddb/index.md
+++ b/files/es/web/api/indexeddb/index.md
@@ -34,9 +34,9 @@ function openDB() {
 
 {{Specifications}}
 
-## Compatibilidad de Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.indexedDB")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/intersection_observer_api/index.md
+++ b/files/es/web/api/intersection_observer_api/index.md
@@ -501,9 +501,9 @@ Hay un ejemplo aún más extensivo en [Cronometrando la visibilidad de un elemen
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.IntersectionObserver")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/issecurecontext/index.md
+++ b/files/es/web/api/issecurecontext/index.md
@@ -22,6 +22,6 @@ Un {{domxref("Boolean")}}.
 
 {{Specifications}}
 
-## Compatibilidad de Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.isSecureContext")}}
+{{Compat}}

--- a/files/es/web/api/keyboardevent/index.md
+++ b/files/es/web/api/keyboardevent/index.md
@@ -187,6 +187,6 @@ function metaKeyUp (event) {
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.KeyboardEvent")}}
+{{Compat}}

--- a/files/es/web/api/location/index.md
+++ b/files/es/web/api/location/index.md
@@ -71,7 +71,7 @@ console.log(url.origin);    // https://developer.mozilla.org
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.Location")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/api/location/origin/index.md
+++ b/files/es/web/api/location/origin/index.md
@@ -30,6 +30,6 @@ var result = window.location.origin; // Devuelve:'https://developer.mozilla.org'
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Location.origin")}}
+{{Compat}}

--- a/files/es/web/api/location/reload/index.md
+++ b/files/es/web/api/location/reload/index.md
@@ -37,9 +37,9 @@ reload.addEventListener('click', _ => { // el _ es para indicar la ausencia de p
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.Location.reload")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/media_capture_and_streams_api/index.md
+++ b/files/es/web/api/media_capture_and_streams_api/index.md
@@ -216,9 +216,13 @@ Remueve una MediaStreamTrack de la lista de pistas.
 - Excepciones
   - : INVALID_STATE_ERR if the stream is finished (all tracks have ended).
 
+## Especificaciones
+
+{{Specifications}}
+
 ## Compatibilidad con navegadores
 
-{{Compat("api.MediaStream")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/mediadevices/getusermedia/index.md
+++ b/files/es/web/api/mediadevices/getusermedia/index.md
@@ -229,7 +229,7 @@ Ver [permission: audio-capture](/en-US/Apps/Developing/App_permissions#audio-cap
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.MediaDevices.getUserMedia")}}
+{{Compat}}
 
 ## Ver También
 

--- a/files/es/web/api/mediadevices/index.md
+++ b/files/es/web/api/mediadevices/index.md
@@ -66,9 +66,9 @@ function errorMsg(msg, error) {
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.MediaDevices")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/mediaquerylist/addlistener/index.md
+++ b/files/es/web/api/mediaquerylist/addlistener/index.md
@@ -46,9 +46,9 @@ mql.addListener(screenTest);
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.MediaQueryList.addListener")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/mediaquerylist/index.md
+++ b/files/es/web/api/mediaquerylist/index.md
@@ -65,9 +65,9 @@ mql.addListener(screenTest);
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.MediaQueryList")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/mediaquerylist/matches/index.md
+++ b/files/es/web/api/mediaquerylist/matches/index.md
@@ -31,9 +31,9 @@ if(mql.matches) {
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.MediaQueryList.matches")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/mediaquerylist/removelistener/index.md
+++ b/files/es/web/api/mediaquerylist/removelistener/index.md
@@ -51,9 +51,9 @@ mql.removeListener(screenTest);
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.MediaQueryList.removeListener")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/mediastreamtrack/index.md
+++ b/files/es/web/api/mediastreamtrack/index.md
@@ -65,9 +65,9 @@ La interfaz **`MediaStream`** representa un flujo de contenido de los medios. Un
 
 {{Specifications}}
 
-## Compatibilidad de los navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.MediaStreamTrack")}}
+{{Compat}}
 
 ## Ver támbien
 

--- a/files/es/web/api/messageevent/index.md
+++ b/files/es/web/api/messageevent/index.md
@@ -102,9 +102,9 @@ onconnect = function(e) {
 
 {{Specifications}}
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.MessageEvent")}}
+{{Compat}}
 
 ## Ver tambien
 

--- a/files/es/web/api/mimetype/index.md
+++ b/files/es/web/api/mimetype/index.md
@@ -22,6 +22,6 @@ La interfaz **`MimeType`** provee información acerca de un tipo MIME asociado c
 
 {{Specifications}}
 
-## Compatibilidad de Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.MimeType")}}
+{{Compat}}

--- a/files/es/web/api/mouseevent/index.md
+++ b/files/es/web/api/mouseevent/index.md
@@ -120,9 +120,9 @@ Click on the button to see how the sample works:
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.MouseEvent")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/mouseevent/shiftkey/index.md
+++ b/files/es/web/api/mouseevent/shiftkey/index.md
@@ -51,7 +51,7 @@ También puede utilizar SHIFT junto a la tecla ALT.</p>
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.MouseEvent.shiftKey")}}
+{{Compat}}
 
 ## Ver más
 

--- a/files/es/web/api/mutationobserver/index.md
+++ b/files/es/web/api/mutationobserver/index.md
@@ -154,6 +154,14 @@ observer.observe(target, config);
 observer.disconnect();
 ```
 
+## Especificaciones
+
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
+
 ## Lectura adicional
 
 - [A brief overview](http://updates.html5rocks.com/2012/02/Detect-DOM-changes-with-Mutation-Observers)
@@ -161,7 +169,3 @@ observer.disconnect();
 - [A screencast by Chromium developer Rafael Weinstein](http://www.youtube.com/watch?v=eRZ4pO0gVWw)
 - [The mutation summary library](http://code.google.com/p/mutation-summary/)
 - [The DOM standard](http://dom.spec.whatwg.org/#mutation-observers) which defines the `MutationObserver` interface
-
-## Compatibilidad en navegadores
-
-{{Compat("api.MutationObserver")}}

--- a/files/es/web/api/mutationobserver/mutationobserver/index.md
+++ b/files/es/web/api/mutationobserver/mutationobserver/index.md
@@ -75,6 +75,6 @@ Desde este momento y hasta que se llame al método {{domxref("MutationObserver.d
 
 {{Specifications}}
 
-## Compatibilidad
+## Compatibilidad con navegadores
 
-{{Compat("api.MutationObserver.MutationObserver")}}
+{{Compat}}

--- a/files/es/web/api/mutationobserver/observe/index.md
+++ b/files/es/web/api/mutationobserver/observe/index.md
@@ -61,6 +61,6 @@ De manera que en teoria si mantiene la pista de los objetos {{domxref("MutationR
 
 {{Specifications}}
 
-## Compatibilidad
+## Compatibilidad con navegadores
 
-{{Compat("api.MutationObserver.observe")}}
+{{Compat}}

--- a/files/es/web/api/navigator/donottrack/index.md
+++ b/files/es/web/api/navigator/donottrack/index.md
@@ -28,7 +28,7 @@ console.log(navigator.doNotTrack);
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.Navigator.doNotTrack")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/api/navigator/geolocation/index.md
+++ b/files/es/web/api/navigator/geolocation/index.md
@@ -28,9 +28,9 @@ geo = navigator.geolocation
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Navigator.geolocation")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/navigator/getusermedia/index.md
+++ b/files/es/web/api/navigator/getusermedia/index.md
@@ -88,9 +88,13 @@ La función `getUserMedia` llama a la función indicada en el errorCallback con 
 | MANDATORY_UNSATISFIED_ERROR | No se encontraron fuentes multimedia del tipo especificado en el constraints.                   |
 | NO_DEVICES_FOUND            | No se encontró ninguna webcam instalada.                                                        |
 
-## Compatibilidad con los navegadores
+## Especificaciones
 
-{{Compat("api.Navigator.getUserMedia")}}
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Vease también
 

--- a/files/es/web/api/navigator/vibrate/index.md
+++ b/files/es/web/api/navigator/vibrate/index.md
@@ -28,13 +28,13 @@ Si se especifica el valor 0, un array vacío o un array que contenga todos los v
 
 Podrá producirse una excepción si el patrón de vibración especificado es demasiado largo o si cualquiera de sus elementos son demasiado grandes.
 
-## Compatibilidad con navegadores
-
-{{Compat("api.Navigator.vibrate")}}
-
 ## Especificaciones
 
 {{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/api/network_information_api/index.md
+++ b/files/es/web/api/network_information_api/index.md
@@ -51,15 +51,9 @@ if (connection) {
 
 {{Specifications}}
 
-## Compatibilidad en Navegadores
+## Compatibilidad con navegadores
 
-### NetworkInformation
-
-{{Compat("api.NetworkInformation")}}
-
-### Navigator.connection
-
-{{Compat("api.Navigator.connection")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/api/node/appendchild/index.md
+++ b/files/es/web/api/node/appendchild/index.md
@@ -62,7 +62,7 @@ document.body.appendChild(p);
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.Node.appendChild")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/node/childnodes/index.md
+++ b/files/es/web/api/node/childnodes/index.md
@@ -57,7 +57,7 @@ El objeto `document` contiene 2 hijos: la declaración del Doctype y el elemento
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.Node.childNodes")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/api/node/clonenode/index.md
+++ b/files/es/web/api/node/clonenode/index.md
@@ -51,6 +51,6 @@ Para clonar un nodo con el fin de agregarlo a un domento distinto, utiliza {{dom
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Node.cloneNode")}}
+{{Compat}}

--- a/files/es/web/api/node/contains/index.md
+++ b/files/es/web/api/node/contains/index.md
@@ -27,9 +27,9 @@ function isInPage(node) {
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Node.contains")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/node/haschildnodes/index.md
+++ b/files/es/web/api/node/haschildnodes/index.md
@@ -45,14 +45,13 @@ Hay varias maneras de determinar si el nodo tiene nodos hijos.
 - node.firstChild != null (o sólo node.firstChild)
 - node.childNodes && node.childNodes.length (o node.childNodes.length > 0)
 
-## Especificación
+## Especificaciones
 
-- [WHATWG: hasChildNodes](https://dom.spec.whatwg.org/#dom-node-haschildnodes)
-- [hasChildNodes](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-810594187)
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.Node.hasChildNodes")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/node/index.md
+++ b/files/es/web/api/node/index.md
@@ -183,6 +183,6 @@ document.body.removeAll();
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.Node")}}
+{{Compat}}

--- a/files/es/web/api/node/insertbefore/index.md
+++ b/files/es/web/api/node/insertbefore/index.md
@@ -116,13 +116,13 @@ parentElement.insertBefore(newElement, theFirstChild);
 
 Cuando el elemento no tiene ub primer hijo, entonces `firstChild` es `null`. Aun así, el elemento se añade al padre después del último hijo. Puesto que el elemento padre no tenía primer hijo, tampoco tiene último hijo. Por tanto, el nuevo elemento es el único elemento después de ser insertado.
 
-## Compatibilidad en navegadores
-
-{{Compat("api.Node.insertBefore")}}
-
 ## Especificaciones
 
 {{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/node/issamenode/index.md
+++ b/files/es/web/api/node/issamenode/index.md
@@ -29,9 +29,9 @@ var isSameNode = node.isSameNode(other);
 
 {{Specifications}}
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Node.isSameNode")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/api/node/lastchild/index.md
+++ b/files/es/web/api/node/lastchild/index.md
@@ -24,6 +24,6 @@ var corner_td = tr.lastChild;
 
 {{Specifications}}
 
-## Compatibilidad en navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.Node.lastChild")}}
+{{Compat}}

--- a/files/es/web/api/node/nextsibling/index.md
+++ b/files/es/web/api/node/nextsibling/index.md
@@ -62,14 +62,13 @@ En el ejemplo anterior, se puede observar que los nodos `#text` se insertan en e
 
 La posible inclusión de los nodos de texto en el DOM se debe permitir cuando se atraviese el DOM utilizando `nextSibling`. Vea los recursos en la sección Notas.
 
-## Especificación
+## Especificaciones
 
-- [DOM Level 1 Core: nextSibling](http://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#attribute-nextSibling)
-- [DOM Level 2 Core: nextSibling](http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-6AC54C2F)
+{{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Node.nextSibling")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/node/ownerdocument/index.md
+++ b/files/es/web/api/node/ownerdocument/index.md
@@ -31,6 +31,6 @@ var html = d.documentElement;
 
 {{Specifications}}
 
-## Compatibilidad de navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.Node.ownerDocument")}}
+{{Compat}}

--- a/files/es/web/api/node/parentelement/index.md
+++ b/files/es/web/api/node/parentelement/index.md
@@ -24,15 +24,13 @@ if (node.parentElement) {
 }
 ```
 
-## Compatibilidad en navegadores
-
-En algunos navegadores, la propiedad `elementoPadre` es solo definida en nodos que ellos mismos son {{domxref("Element")}}. En particular, esto no está definido en nodos de texto.
-
-{{Compat("api.Node.parentElement")}}
-
 ## Especificaciones
 
 {{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/node/parentnode/index.md
+++ b/files/es/web/api/node/parentnode/index.md
@@ -31,14 +31,13 @@ Los nodos del tipo `Document` y `DocumentFragment` nunca van a tener un elemento
 
 También devuelve `null` si el nodo acaba de ser creado y no está atado/incorporado al árbol.
 
-## Compatiblidad de navegador
+## Especificaciones
 
-{{Compat("api.Node.parentNode")}}
+{{Specifications}}
 
-## Especificación
+## Compatibilidad con navegadores
 
-- [DOM Level 2 Core: Node.parentNode](http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-1060184317)
-- [DOM Level 3 Core: Node.parentNode](http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-1060184317)
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/node/previoussibling/index.md
+++ b/files/es/web/api/node/previoussibling/index.md
@@ -38,15 +38,13 @@ for more information.
 
 Para navegar en el sentido opuesto de la lista de nodos hijos se utiliza [Node.nextSibling](/es/docs/Web/API/Node.nextSibling).
 
-## Especificación
+## Especificaciones
 
-- [DOM Level 1 Core: previousSibling](http://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#attribute-previousSibling)
-- [DOM Level 2 Core: previousSibling](http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-640FB3C8)
-- [DOM Level 3 Core: previousSibling](http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-640FB3C8)
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.Node.previousSibling")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/node/textcontent/index.md
+++ b/files/es/web/api/node/textcontent/index.md
@@ -58,10 +58,10 @@ document.getElementById("divA").textContent = "Esto es un nuevo texto";
 //   <div id="divA">Esto es un nuevo texto</div>
 ```
 
-## Compatibilidad con navegadores
-
-{{Compat("api.Node.textContent")}}
-
 ## Especificaciones
 
 {{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}

--- a/files/es/web/api/nodelist/foreach/index.md
+++ b/files/es/web/api/nodelist/foreach/index.md
@@ -96,9 +96,9 @@ El comportamiento ateriror esta implementado en muchos navegadores. NodeList.pro
 
 {{Specifications}}
 
-## Compatibilidad en Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.NodeList.forEach")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/nodelist/index.md
+++ b/files/es/web/api/nodelist/index.md
@@ -79,6 +79,6 @@ Array.prototype.forEach.call(list, function (item) {
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.NodeList")}}
+{{Compat}}

--- a/files/es/web/api/notification/index.md
+++ b/files/es/web/api/notification/index.md
@@ -178,9 +178,9 @@ function spawnNotification(theBody,theIcon,theTitle) {
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.Notification")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/notifications_api/index.md
+++ b/files/es/web/api/notifications_api/index.md
@@ -43,19 +43,9 @@ In addition, the Notifications API spec specifies a number of additions to the [
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.Notification")}}
-
-## Firefox OS permissions
-
-When using notifications in a Firefox OS app, be sure to add the `desktop-notification` permission in your manifest file. Notifications can be used at any permission level, hosted or above:
-
-```json
-"permissions": {
-  "desktop-notification": {}
-}
-```
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/notifications_api/using_the_notifications_api/index.md
+++ b/files/es/web/api/notifications_api/using_the_notifications_api/index.md
@@ -256,11 +256,11 @@ window.addEventListener('load', function () {
 
 ## Especificaciones
 
-{{Specifications("api.Notification")}}
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.Notification")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/api/payment_request_api/index.md
+++ b/files/es/web/api/payment_request_api/index.md
@@ -68,11 +68,9 @@ Puedes encontrar una guía completa en [Usando la API de Solicitud de Pago](/es/
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-### Interfaz PaymentRequest
-
-{{Compat("api.PaymentRequest", 0)}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/performance/clearmarks/index.md
+++ b/files/es/web/api/performance/clearmarks/index.md
@@ -60,6 +60,6 @@ logMarkCount() // "Found this many entries: 0"
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Performance.clearMarks")}}
+{{Compat}}

--- a/files/es/web/api/performance/clearmeasures/index.md
+++ b/files/es/web/api/performance/clearmeasures/index.md
@@ -61,6 +61,6 @@ logMeasureCount() // "Found this many entries: 0"
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Performance.clearMeasures")}}
+{{Compat}}

--- a/files/es/web/api/performance/index.md
+++ b/files/es/web/api/performance/index.md
@@ -63,6 +63,6 @@ Escucha a estos eventos que están usando `addEventListener()` o por asignación
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Performance")}}
+{{Compat}}

--- a/files/es/web/api/performance/memory/index.md
+++ b/files/es/web/api/performance/memory/index.md
@@ -27,9 +27,9 @@ timingInfo = performance.memory
 
 Ninguna.
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Performance.memory")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/performance/navigation/index.md
+++ b/files/es/web/api/performance/navigation/index.md
@@ -19,7 +19,7 @@ navObject = performance.navigation;
 
 ## Especificaciones
 
-{{Specifications}}
+Esta característica ya no está en camino de convertirse en un estándar, ya que la especificación [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) la ha marcado como obsoleta. Utilice la interfaz {{domxref("PerformanceNavigationTiming")}} en su lugar.
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/api/performance/navigation/index.md
+++ b/files/es/web/api/performance/navigation/index.md
@@ -21,9 +21,9 @@ navObject = performance.navigation;
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Performance.navigation")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/performance/now/index.md
+++ b/files/es/web/api/performance/now/index.md
@@ -37,7 +37,7 @@ También a diferencia de `Date.now()`, los valores devueltos por `Performance.no
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.Performance.now")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/api/performance/timeorigin/index.md
+++ b/files/es/web/api/performance/timeorigin/index.md
@@ -23,6 +23,6 @@ Una marca de tiempo de alta precisión.
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Performance.timeOrigin")}}
+{{Compat}}

--- a/files/es/web/api/performance/timing/index.md
+++ b/files/es/web/api/performance/timing/index.md
@@ -21,9 +21,9 @@ var timingInfo = performance.timing;
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Performance.timing")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/performancenavigation/index.md
+++ b/files/es/web/api/performancenavigation/index.md
@@ -42,9 +42,9 @@ _La interfaz `PerformanceNavigation` no hereda ninguna propiedad._
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.PerformanceNavigation")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/pointer_lock_api/index.md
+++ b/files/es/web/api/pointer_lock_api/index.md
@@ -207,9 +207,9 @@ While iframes work by default, "sandboxed" iframes block Pointer lock. The abili
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.Element.requestPointerLock")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/push_api/index.md
+++ b/files/es/web/api/push_api/index.md
@@ -55,17 +55,11 @@ Mozilla's [ServiceWorker Cookbook](https://github.com/mdn/serviceworker-cookbook
 
 {{Specifications}}
 
-## Browser Compatibility
+## Compatibilidad con navegadores
 
-### `PushEvent`
+{{Compat}}
 
-{{Compat("api.PushEvent")}}
-
-### `PushMessageData`
-
-{{Compat("api.PushMessageData")}}
-
-## See also
+## Ver tambien
 
 - [¿Cómo usar la API Push?](/es/docs/Web/API/Push_API/Using_the_Push_API)
 - [Push API Demo](https://github.com/chrisdavidmills/push-api-demo), on Github

--- a/files/es/web/api/pushmanager/index.md
+++ b/files/es/web/api/pushmanager/index.md
@@ -68,9 +68,9 @@ navigator.serviceWorker.register('serviceworker.js').then(
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.PushManager")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/pushmanager/supportedcontentencodings/index.md
+++ b/files/es/web/api/pushmanager/supportedcontentencodings/index.md
@@ -21,6 +21,6 @@ Un _array_ de _Strings_
 
 {{Specifications}}
 
-## Browser Compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.PushManager.supportedContentEncodings")}}
+{{Compat}}

--- a/files/es/web/api/range/getclientrects/index.md
+++ b/files/es/web/api/range/getclientrects/index.md
@@ -25,9 +25,9 @@ rectList = range.getClientRects();
 
 {{Specifications}}
 
-## Compatibilidad en los Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Range.getClientRects")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/range/setstart/index.md
+++ b/files/es/web/api/range/setstart/index.md
@@ -39,9 +39,9 @@ range.setStart(startNode,startOffset);
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.Range.setStart")}}
+{{Compat}}
 
 ## Ver también
 


### PR DESCRIPTION
This PR updates some of the browser compatibility data and specification sections for the Spanish locale. Part of work for #11594.

Note: this may also include other minor updates, such as removal of old sections or other small bits of cleanup.
