### PR TITLE
es: Update browser compat/spec sections (part 4)

### DIFF
--- a/files/es/web/api/request/headers/index.md
+++ b/files/es/web/api/request/headers/index.md
@@ -48,7 +48,7 @@ myContentType = myRequest.headers.get('Content-Type'); // returns 'image/jpeg'
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.Request.headers")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/request/index.md
+++ b/files/es/web/api/request/index.md
@@ -124,9 +124,9 @@ fetch(myRequest)
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Request")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/response/index.md
+++ b/files/es/web/api/response/index.md
@@ -89,9 +89,9 @@ var myResponse = new Response();
 
 {{Specifications}}
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Response")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/response/ok/index.md
+++ b/files/es/web/api/response/ok/index.md
@@ -40,9 +40,9 @@ fetch(peticion).then(function(respuesta) {
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Response.ok")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/response/response/index.md
+++ b/files/es/web/api/response/response/index.md
@@ -48,9 +48,9 @@ var miRespuesta = new Response(miBlob,opciones);
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Response.Response")}}
+{{Compat}}
 
 ## Relacionado
 

--- a/files/es/web/api/response/status/index.md
+++ b/files/es/web/api/response/status/index.md
@@ -41,9 +41,9 @@ fetch(myRequest).then(function(response) {
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.Response.status")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/rtcpeerconnection/cantrickleicecandidates/index.md
+++ b/files/es/web/api/rtcpeerconnection/cantrickleicecandidates/index.md
@@ -58,9 +58,9 @@ pc.addEventListener('icecandidate', e => {
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.RTCPeerConnection.canTrickleIceCandidates")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/rtcpeerconnection/index.md
+++ b/files/es/web/api/rtcpeerconnection/index.md
@@ -105,9 +105,9 @@ The `RTCSignalingState` enum specifies the possible values of {{domxref("RTCPeer
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.RTCPeerConnection")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/rtcrtpreceiver/index.md
+++ b/files/es/web/api/rtcrtpreceiver/index.md
@@ -37,9 +37,9 @@ La interfaz **`RTCRtpReceiver`** de la [WebRTC API](/es/docs/Web/API/WebRTC_API)
 
 {{Specifications}}
 
-## Compatibilidad
+## Compatibilidad con navegadores
 
-{{Compat("api.RTCRtpReceiver")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/server-sent_events/using_server-sent_events/index.md
+++ b/files/es/web/api/server-sent_events/using_server-sent_events/index.md
@@ -189,4 +189,4 @@ data: {"username": "bobby", "time": "02:34:11", "text": "Hi everyone."}
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.EventSource")}}
+{{Compat}}

--- a/files/es/web/api/serviceworkercontainer/index.md
+++ b/files/es/web/api/serviceworkercontainer/index.md
@@ -79,9 +79,9 @@ if ('serviceWorker' in navigator) {
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.ServiceWorkerContainer")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/serviceworkercontainer/register/index.md
+++ b/files/es/web/api/serviceworkercontainer/register/index.md
@@ -72,6 +72,6 @@ if ('serviceWorker' in navigator) {
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.ServiceWorkerContainer.register")}}
+{{Compat}}

--- a/files/es/web/api/settimeout/index.md
+++ b/files/es/web/api/settimeout/index.md
@@ -260,13 +260,13 @@ Browsers including Internet Explorer, Chrome, Safari, and Firefox store the dela
 
 In (Firefox 5.0 / Thunderbird 5.0 / SeaMonkey 2.2) and Chrome 11, timeouts are clamped to firing no more often than once per second (1000ms) in inactive tabs; see {{ bug(633421) }} for more information about this in Mozilla or [crbug.com/66078](http://crbug.com/66078) for details about this in Chrome.
 
-## Compatibilidad de navegadores
+## Especificaciones
 
-{{Compat("api.setTimeout")}}
+{{Specifications}}
 
-## Especificación
+## Compatibilidad con navegadores
 
-Parte del DOM nivel 0, como se especifica en [HTML5](http://www.whatwg.org/specs/web-apps/current-work/multipage/browsers.html#timers).
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/api/storage/clear/index.md
+++ b/files/es/web/api/storage/clear/index.md
@@ -41,9 +41,9 @@ function populateStorage() {
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Storage.clear")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/api/storage/getitem/index.md
+++ b/files/es/web/api/storage/getitem/index.md
@@ -50,7 +50,7 @@ function setStyles() {
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.Storage.getItem")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/api/storage/index.md
+++ b/files/es/web/api/storage/index.md
@@ -69,9 +69,9 @@ function setStyles() {
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Storage")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/storage/length/index.md
+++ b/files/es/web/api/storage/length/index.md
@@ -37,9 +37,9 @@ function populateStorage() {
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Storage.length")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/api/storage/removeitem/index.md
+++ b/files/es/web/api/storage/removeitem/index.md
@@ -56,7 +56,7 @@ function populateSessionStorage() {
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.Storage.removeItem")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/api/storage/setitem/index.md
+++ b/files/es/web/api/storage/setitem/index.md
@@ -47,9 +47,9 @@ function populateStorage() {
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Storage.setItem")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/api/storagemanager/estimate/index.md
+++ b/files/es/web/api/storagemanager/estimate/index.md
@@ -55,7 +55,7 @@ navigator.storage.estimate().then(function(estimate) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.StorageManager.estimate")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/storagemanager/index.md
+++ b/files/es/web/api/storagemanager/index.md
@@ -20,6 +20,6 @@ The **`StorageManager`** interface of the the [Storage API](/es/docs/Web/API/Sto
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.StorageManager")}}
+{{Compat}}

--- a/files/es/web/api/storagemanager/persist/index.md
+++ b/files/es/web/api/storagemanager/persist/index.md
@@ -39,4 +39,4 @@ if (navigator.storage && navigator.storage.persist)
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.StorageManager.persist")}}
+{{Compat}}

--- a/files/es/web/api/storagemanager/persisted/index.md
+++ b/files/es/web/api/storagemanager/persisted/index.md
@@ -39,4 +39,4 @@ if (navigator.storage && navigator.storage.persist)
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.StorageManager.persisted")}}
+{{Compat}}

--- a/files/es/web/api/subtlecrypto/digest/index.md
+++ b/files/es/web/api/subtlecrypto/digest/index.md
@@ -97,11 +97,9 @@ console.log(digestHex);
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.SubtleCrypto.digest")}}
-
-> **Nota:** En Chrome 60, se añadió una característica que deshabilita crypto.subtle para conexiones no TLS.
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/subtlecrypto/index.md
+++ b/files/es/web/api/subtlecrypto/index.md
@@ -113,9 +113,9 @@ _Esta interfaz no hereda ningún método._
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.SubtleCrypto")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/texttrack/cuechange_event/index.md
+++ b/files/es/web/api/texttrack/cuechange_event/index.md
@@ -76,9 +76,9 @@ textTrackElem.oncuechange = (event) => {
 
 {{Specifications}}
 
-## Compatibilidad de los navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.TextTrack.cuechange_event")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/texttrack/index.md
+++ b/files/es/web/api/texttrack/index.md
@@ -53,9 +53,9 @@ tbd
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.TextTrack")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/touch_events/index.md
+++ b/files/es/web/api/touch_events/index.md
@@ -223,6 +223,10 @@ function onTouch(evt) {
 
 Una cosa para prevenir cosas como `pinchZoom` en una página es llamar a `preventDefault()` en el segundo toque de una serie. Este comportamiento no está bien definido en los eventos de toque, y resulta en diferentes comportamientos en diferentes navegadores (osea iOS evitará el zoom o acercamiento pero permitirá vista panorámica con ambos dedos. Android permitirá zoom o acercamiento pero no una panorámica. Opera and Firefox actualmente evita panorámica y zoom o acercamiento). Actualmente, no se recomienda depender de ningún comportamiento en particular en este caso, si no mas bien depender de una meta vista para evitar el zoom.
 
-## Compatibilidad de navegadores
+## Especificaciones
 
-{{Compat("api.Touch")}}
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}

--- a/files/es/web/api/touchevent/index.md
+++ b/files/es/web/api/touchevent/index.md
@@ -88,9 +88,9 @@ See the [example on the main Touch events article](/en/DOM/Touch_events#Example)
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.TouchEvent")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/uievent/index.md
+++ b/files/es/web/api/uievent/index.md
@@ -49,13 +49,13 @@ _This interface also inherits methods of its parent, {{domxref("Event")}}._
 - {{domxref("UIEvent.initUIEvent()")}} {{deprecated_inline}}
   - : Initializes a `UIEvent` object. If the event has already being dispatched, this method does nothing.
 
-## Specifications
+## Especificaciones
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.UIEvent")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/url/createobjecturl/index.md
+++ b/files/es/web/api/url/createobjecturl/index.md
@@ -38,9 +38,9 @@ Cada vez que se llama a `createObjectURL()`, un nuevo objeto URL es creado, incl
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.URL.createObjectURL")}}
+{{Compat}}
 
 ## Mirar también
 

--- a/files/es/web/api/url/host/index.md
+++ b/files/es/web/api/url/host/index.md
@@ -38,9 +38,9 @@ console.log(url.host); // "developer.mozilla.org:4097"
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.URL.host")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/url/index.md
+++ b/files/es/web/api/url/index.md
@@ -64,9 +64,9 @@ _The `URL` interface implements methods defined in {{domxref("URLUtils")}}._
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.URL")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/url/port/index.md
+++ b/files/es/web/api/url/port/index.md
@@ -31,9 +31,9 @@ var result = url.port; // Devuelve:'80'
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.URL.port")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/url/url/index.md
+++ b/files/es/web/api/url/url/index.md
@@ -60,9 +60,9 @@ var d = new URL('/en-US/docs', b);                     // => 'https://developer.
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.URL.URL")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/urlsearchparams/index.md
+++ b/files/es/web/api/urlsearchparams/index.md
@@ -74,11 +74,9 @@ searchParams.toString(); // "q=URLUtils.searchParams"
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.URLSearchParams")}}
+{{Compat}}
 
 ## Vea también
 
 - Otras interfaces relacionadas con URL: {{domxref("URL")}}, {{domxref("URLUtils")}}.
 - [Google Developers: Fácil manipulación de una URL con URLSearchParams](https://developers.google.com/web/updates/2016/01/urlsearchparams?hl=en)
-
-<!---->

--- a/files/es/web/api/urlsearchparams/urlsearchparams/index.md
+++ b/files/es/web/api/urlsearchparams/urlsearchparams/index.md
@@ -49,6 +49,6 @@ var params4 = new URLSearchParams({"foo" : 1 , "bar" : 2});
 
 {{Specifications}}
 
-## Compatibilidad de browsers
+## Compatibilidad con navegadores
 
-{{Compat("api.URLSearchParams.URLSearchParams")}}
+{{Compat}}

--- a/files/es/web/api/vibration_api/index.md
+++ b/files/es/web/api/vibration_api/index.md
@@ -77,9 +77,9 @@ Esta API es claramente accesible a través de dispositivos móbiles. Vibration A
 
 {{Specifications}}
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Navigator.vibrate")}}
+{{Compat}}
 
 ## Ver También
 

--- a/files/es/web/api/web_audio_api/index.md
+++ b/files/es/web/api/web_audio_api/index.md
@@ -340,9 +340,9 @@ function voiceMute() { // alternar para silenciar y activar el sonido
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.AudioContext", 0)}}
+{{Compat}}
 
 ## También ver
 

--- a/files/es/web/api/web_speech_api/index.md
+++ b/files/es/web/api/web_speech_api/index.md
@@ -63,15 +63,9 @@ The [Web Speech API repo](https://github.com/mdn/dom-examples/tree/main/web-spee
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-### `SpeechRecognition`
-
-{{Compat("api.SpeechRecognition", 0)}}
-
-### `SpeechSynthesis`
-
-{{Compat("api.SpeechSynthesis", 0)}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/web_storage_api/index.md
+++ b/files/es/web/api/web_storage_api/index.md
@@ -40,19 +40,9 @@ También creamos una[página de salida del evento](http://mdn.github.io/web-stor
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-### `Window.localStorage`
-
-{{Compat("api.Window.localStorage")}}
-
-### `Window.sessionStorage`
-
-{{Compat("api.Window.sessionStorage")}}
-
-Todos los navegadores tienen distintos niveles de capacidad tanto para localStorage como para sessionStorage. Aquí está una [análisis detallado de todas las capacidades de almacenamiento de diferentes navegadores](http://dev-test.nemikor.com/web-storage/support-test/).
-
-> **Nota:** Desde iOS 5.1, Safari Mobile almacena los datos de localStorage en la carpeta de caché, la cual está sujeta a limpiezas ocasionales, a petición del sistema operativo, típicamente cuando el espacio es reducido.
+{{Compat}}
 
 ## Navegación privada / Modo incógnito
 

--- a/files/es/web/api/web_storage_api/using_the_web_storage_api/index.md
+++ b/files/es/web/api/web_storage_api/using_the_web_storage_api/index.md
@@ -187,19 +187,9 @@ El almacenamiento web también provee un par de métodos simples para remover da
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-### `Window.localStorage`
-
-{{Compat("api.Window.localStorage")}}
-
-### `Window.sessionStorage`
-
-{{Compat("api.Window.sessionStorage")}}
-
-Todos los navegadores tienen distintos niveles de capacidad tanto para localStorage como para sessionStorage. Aquí está una [análisis detallado de todas las capacidades de almacenamiento de diferentes navegadores](http://dev-test.nemikor.com/web-storage/support-test/).
-
-> **Nota:** Desde iOS 5.1, Safari Mobile almacena los datos de localStorage en la carpeta de caché, la cual está sujeta a limpiezas ocasionales, a petición del sistema operativo, típicamente cuando el espacio es reducido.
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/websocket/index.md
+++ b/files/es/web/api/websocket/index.md
@@ -145,9 +145,9 @@ socket.addEventListener('message', function (event) {
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.WebSocket")}}
+{{Compat}}
 
 ## Referencias adicionales
 

--- a/files/es/web/api/websockets_api/index.md
+++ b/files/es/web/api/websockets_api/index.md
@@ -27,12 +27,16 @@ slug: Web/API/WebSockets_API
 
 - [AJAX](/es/docs/AJAX), [JavaScript](/es/docs/JavaScript)
 
+## Especificaciones
+
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
+
 ## Ver también
 
 - [RFC 6455 - The WebSocket Protocol](http://tools.ietf.org/html/rfc6455)
 - [WebSocket API Specification](http://www.w3.org/TR/websockets/)
 - [Server-Sent Events](/es/docs/Server-sent_events)
-
-## Compatibilidad con navegadores
-
-{{Compat("api.WebSocket")}}

--- a/files/es/web/api/webvr_api/index.md
+++ b/files/es/web/api/webvr_api/index.md
@@ -109,7 +109,7 @@ You can find a number of examples at these locations:
 
 Esta API se especificó en la antigua [API de WebVR](https://immersive-web.github.io/webvr/spec/1.1/) que fue reemplazada por la [API del dispositivo WebXR](https://immersive-web.github.io/webxr/). Ya no está en camino de convertirse en un estándar.
 
-Hasta que todos los navegadores hayan implementado las nuevas [API de WebXR](/es/docs/Web/API/WebXR_Device_API/Fundamentals), se recomienda confiar en _frameworks_, como  [A-Frame](https://aframe.io/), [Babylon.js](https://www.babylonjs.com/), o [Three.js](https://threejs.org/), o un [polyfill](https://github.com/immersive-web/webxr-polyfill), para desarrollar aplicaciones WebXR que funcionen en todos los navegadores [\[1\]](https://developer.oculus.com/documentation/web/port-vr-xr/).
+Hasta que todos los navegadores hayan implementado las nuevas [API de WebXR](/es/docs/Web/API/WebXR_Device_API/Fundamentals), se recomienda confiar en _frameworks_, como [A-Frame](https://aframe.io/), [Babylon.js](https://www.babylonjs.com/), o [Three.js](https://threejs.org/), o un [polyfill](https://github.com/immersive-web/webxr-polyfill), para desarrollar aplicaciones WebXR que funcionen en todos los navegadores [\[1\]](https://developer.oculus.com/documentation/web/port-vr-xr/).
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/api/webvr_api/index.md
+++ b/files/es/web/api/webvr_api/index.md
@@ -107,7 +107,9 @@ You can find a number of examples at these locations:
 
 ## Especificaciones
 
-{{Specifications}}
+Esta API se especificó en la antigua [API de WebVR](https://immersive-web.github.io/webvr/spec/1.1/) que fue reemplazada por la [API del dispositivo WebXR](https://immersive-web.github.io/webxr/). Ya no está en camino de convertirse en un estándar.
+
+Hasta que todos los navegadores hayan implementado las nuevas [API de WebXR](/es/docs/Web/API/WebXR_Device_API/Fundamentals), se recomienda confiar en _frameworks_, como  [A-Frame](https://aframe.io/), [Babylon.js](https://www.babylonjs.com/), o [Three.js](https://threejs.org/), o un [polyfill](https://github.com/immersive-web/webxr-polyfill), para desarrollar aplicaciones WebXR que funcionen en todos los navegadores [\[1\]](https://developer.oculus.com/documentation/web/port-vr-xr/).
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/api/webvr_api/index.md
+++ b/files/es/web/api/webvr_api/index.md
@@ -109,9 +109,9 @@ You can find a number of examples at these locations:
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("api.Navigator.getVRDisplays")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/wheelevent/deltay/index.md
+++ b/files/es/web/api/wheelevent/deltay/index.md
@@ -25,9 +25,9 @@ console.log(syntheticEvent.deltaY);
 
 {{Specifications}}
 
-## Compatibilidad de los navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.WheelEvent.deltaY")}}
+{{Compat}}
 
 ## Ver más
 

--- a/files/es/web/api/wheelevent/index.md
+++ b/files/es/web/api/wheelevent/index.md
@@ -46,9 +46,9 @@ _Este interfaz no define ningún método, pero hereda métodos de estos padres, 
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.WheelEvent")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/window/beforeunload_event/index.md
+++ b/files/es/web/api/window/beforeunload_event/index.md
@@ -81,7 +81,7 @@ Usando este manejador de evento tu pagina previene que Firefox cambie el cache d
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.Window.beforeunload_event")}}
+{{Compat}}
 
 ## Mire tambien
 

--- a/files/es/web/api/window/cancelanimationframe/index.md
+++ b/files/es/web/api/window/cancelanimationframe/index.md
@@ -45,13 +45,13 @@ myReq = requestAnimationFrame(step);
 window.cancelAnimationFrame(myReq);
 ```
 
-## Compatibilidad de navegadores
-
-{{Compat("api.Window.cancelAnimationFrame")}}
-
 ## Especificaciones
 
 {{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/window/close/index.md
+++ b/files/es/web/api/window/close/index.md
@@ -61,6 +61,6 @@ function closeCurrentWindow()
 
 {{Specifications}}
 
-## Referencia adicional
+## Compatibilidad con navegadores
 
-{{Compat("api.Window.close")}}
+{{Compat}}

--- a/files/es/web/api/window/devicepixelratio/index.md
+++ b/files/es/web/api/window/devicepixelratio/index.md
@@ -21,7 +21,7 @@ value = window.devicePixelRatio;
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.Window.devicePixelRatio")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/window/frameelement/index.md
+++ b/files/es/web/api/window/frameelement/index.md
@@ -33,7 +33,7 @@ if (frameEl) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.Window.frameElement")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/window/hashchange_event/index.md
+++ b/files/es/web/api/window/hashchange_event/index.md
@@ -83,7 +83,7 @@ En [esta página](https://github.com/Modernizr/Modernizr/wiki/HTML5-Cross-Browse
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.Window.hashchange_event")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/window/history/index.md
+++ b/files/es/web/api/window/history/index.md
@@ -30,8 +30,10 @@ Por razones de seguridad el objeto `History` no permite que el código sin privi
 
 No hay manera de limpiar el historial de la sesión o desactivar la parte de atrás/adelante desde la navegación de código sin privilegios. La solución más cercana disponible es el método [`location.replace()`](/es/docs/Web/API/Window/location#replace), que sustituye al elemento actual de la historia sesión con la URL proporcionada.
 
-{{Compat("api.Window.history")}}
-
 ## Especificaciones
 
-- [Historial de interface HTML5](http://whatwg.org/html#the-history-interface)
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}

--- a/files/es/web/api/window/localstorage/index.md
+++ b/files/es/web/api/window/localstorage/index.md
@@ -61,9 +61,9 @@ localStorage.clear();
 
 {{Specifications}}
 
-## Compatibilidad de Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Window.localStorage")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/window/location/index.md
+++ b/files/es/web/api/window/location/index.md
@@ -187,9 +187,9 @@ var showBookmark = (function () {
 
 {{Specifications}}
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Window.location")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/window/matchmedia/index.md
+++ b/files/es/web/api/window/matchmedia/index.md
@@ -33,9 +33,9 @@ Consulte [Probando media queries](/es/docs/DOM/Using_media_queries_from_code) pa
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Window.matchMedia")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/window/moveby/index.md
+++ b/files/es/web/api/window/moveby/index.md
@@ -41,9 +41,9 @@ Desde Firefox 7, no es posible para un sitio web mover una ventana en el navegad
 
 {{Specifications}}
 
-## Compatilidad de Navegador
+## Compatibilidad con navegadores
 
-{{Compat("api.Window.moveBy")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/window/outerheight/index.md
+++ b/files/es/web/api/window/outerheight/index.md
@@ -31,13 +31,13 @@ La siguiente figura muestra la diferencia entre `innerHeight` y `outerHeight`.
 
 ![innerHeight vs outerHeight illustration](firefoxinnervsouterheight2.png)
 
-## Compatibilidad del navegador
-
-{{Compat("api.Window.outerHeight")}}
-
 ## Especificaciones
 
 {{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/window/outerwidth/index.md
+++ b/files/es/web/api/window/outerwidth/index.md
@@ -25,13 +25,13 @@ Para cambiar el tamaño de la ventana, ver {{domxref("window.resizeBy()")}} y {{
 
 Para obtener el ancho exterior de la ventana, i.e. el ancho de la pagina desplegada, ver {{domxref("window.innerWidth")}}.
 
-## Compatibilidad del navegador
-
-{{Compat("api.Window.outerWidth")}}
-
 ## Especificaciones
 
 {{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/window/requestanimationframe/index.md
+++ b/files/es/web/api/window/requestanimationframe/index.md
@@ -51,13 +51,13 @@ function step(timestamp) {
 window.requestAnimationFrame(step);
 ```
 
-## Compatibilidad entre Navegadores
-
-{{Compat("api.Window.requestAnimationFrame")}}
-
 ## Especificaciones
 
 {{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/api/window/requestidlecallback/index.md
+++ b/files/es/web/api/window/requestidlecallback/index.md
@@ -40,9 +40,9 @@ Ver [ejemplo](/es/docs/Web/API/Background_Tasks_API#Example) en el artículo [Pl
 
 {{Specifications}}
 
-## Compatibilidad en Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Window.requestIdleCallback")}}
+{{Compat}}
 
 ## Vease también
 

--- a/files/es/web/api/window/scroll/index.md
+++ b/files/es/web/api/window/scroll/index.md
@@ -51,9 +51,9 @@ Para desplazarse sobre elementos, mira {{domxref("Element.scrollTop")}} y {{domx
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Window.scroll")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/window/scrollx/index.md
+++ b/files/es/web/api/window/scrollx/index.md
@@ -54,7 +54,7 @@ var y = (window.pageYOffset !== undefined)
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.Window.scrollX")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/window/sessionstorage/index.md
+++ b/files/es/web/api/window/sessionstorage/index.md
@@ -57,7 +57,7 @@ field.addEventListener("change", function() {
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.Window.sessionStorage")}}
+{{Compat}}
 
 ## Vea También
 

--- a/files/es/web/api/worker/index.md
+++ b/files/es/web/api/worker/index.md
@@ -57,11 +57,9 @@ For a full example, see our[Basic dedicated worker example](https://github.com/m
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-Support varies for different types of workers. See each worker type's page for specifics.
-
-{{Compat("api.Worker")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/api/worker/terminate/index.md
+++ b/files/es/web/api/worker/terminate/index.md
@@ -35,9 +35,9 @@ myWorker.terminate();
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("api.Worker.terminate")}}
+{{Compat}}
 
 ## Mirar también
 

--- a/files/es/web/api/xmlhttprequest/abort/index.md
+++ b/files/es/web/api/xmlhttprequest/abort/index.md
@@ -40,7 +40,7 @@ xhr.abort();
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.XMLHttpRequest.abort")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/api/xmlhttprequest/readystatechange_event/index.md
+++ b/files/es/web/api/xmlhttprequest/readystatechange_event/index.md
@@ -42,6 +42,6 @@ xhr.send();
 
 {{Specifications}}
 
-## Compatibilidad con navegadores Web
+## Compatibilidad con navegadores
 
-{{Compat("api.XMLHttpRequest.readystatechange_event")}}
+{{Compat}}

--- a/files/es/web/api/xmlhttprequest/responsetext/index.md
+++ b/files/es/web/api/xmlhttprequest/responsetext/index.md
@@ -34,4 +34,4 @@ xhr.send(null);
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.XMLHttpRequest.responseText")}}
+{{Compat}}

--- a/files/es/web/api/xmlhttprequest/timeout/index.md
+++ b/files/es/web/api/xmlhttprequest/timeout/index.md
@@ -38,4 +38,4 @@ xhr.send(null);
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.XMLHttpRequest.timeout")}}
+{{Compat}}

--- a/files/es/web/api/xmlhttprequest/using_xmlhttprequest/index.md
+++ b/files/es/web/api/xmlhttprequest/using_xmlhttprequest/index.md
@@ -904,11 +904,11 @@ Establecer `overrideMimeType` no funciona desde un {{domxref("Worker")}}. Ver
 
 ## Especificaciones
 
-{{Specifications("api.XMLHttpRequest")}}
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 
-{{Compat("api.XMLHttpRequest")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/css/--_star_/index.md
+++ b/files/es/web/css/--_star_/index.md
@@ -78,7 +78,7 @@ Las propiedades personalizadas tienen como alcance los elementos en los que se d
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.properties.custom-property")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/-moz-orient/index.md
+++ b/files/es/web/css/-moz-orient/index.md
@@ -60,9 +60,9 @@ The `-moz-orient` [CSS](/es/docs/Web/CSS) especifica la orientación del element
 
 Aunque [somete](https://lists.w3.org/Archives/Public/www-style/2014Jun/0396.html) al W3C , con retroalimentación positiva inicial , esta propiedad no es todavía parte de ninguna especificación ; Actualmente , esto es una extensión de Mozilla-specific (that is, `-moz-orient`).
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("css.properties.-moz-orient")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/-moz-outline-radius/index.md
+++ b/files/es/web/css/-moz-outline-radius/index.md
@@ -92,6 +92,6 @@ border: 1px solid black; outline: dotted red;
 
 Esta propiedad no se define es ningún estándar CSS.
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.properties.-moz-outline-radius")}}
+{{Compat}}

--- a/files/es/web/css/-moz-user-focus/index.md
+++ b/files/es/web/css/-moz-user-focus/index.md
@@ -53,6 +53,6 @@ Al poner el valor de esta propiedad a `ignore`, deshabilitas el hecho de que el 
 
 Esta propiedad no es parte de ninguna especificación. Una propiedad similar `user-focus` fue propuesta en [borradores previos de la especificación CSS 3 UI](http://www.w3.org/TR/2000/WD-css3-userint-20000216) pero finalmente fué rechazada por el grupo de trabajo.
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.properties.-moz-user-focus")}}
+{{Compat}}

--- a/files/es/web/css/-webkit-border-before/index.md
+++ b/files/es/web/css/-webkit-border-before/index.md
@@ -75,9 +75,9 @@ div {
 
 No es parte de ninguna especificación aunque está relacionada con la propiedad {{cssxref("border-block-start")}}.
 
-## Compatibilidad con los distintos navegadores.
+## Compatibilidad con navegadores
 
-{{Compat("css.properties.-webkit-border-before")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/-webkit-box-reflect/index.md
+++ b/files/es/web/css/-webkit-box-reflect/index.md
@@ -51,9 +51,9 @@ slug: Web/CSS/-webkit-box-reflect
 
 Esta propiedad no está entre los objetivos de la especificación estándar y no será parte de CSS. La manera estándar para conseguir reflexión en CSS es el uso de la función {{cssxref("element", "element()")}}.
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.properties.-webkit-box-reflect")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/-webkit-mask-attachment/index.md
+++ b/files/es/web/css/-webkit-mask-attachment/index.md
@@ -33,7 +33,7 @@ body {
 
 ## Especificaciones
 
-{{Specifications}}
+No forma parte de ningún estándar.
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/-webkit-mask-attachment/index.md
+++ b/files/es/web/css/-webkit-mask-attachment/index.md
@@ -31,9 +31,13 @@ body {
 }
 ```
 
-## Compatibilidad con los distintos navegadores
+## Especificaciones
 
-{{Compat("css.properties.-webkit-mask-attachment")}}
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/-webkit-mask-box-image/index.md
+++ b/files/es/web/css/-webkit-mask-box-image/index.md
@@ -66,7 +66,7 @@ Where:
 
 ## Especificaciones
 
-{{Specifications}}
+No forma parte de ningún estándar.
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/-webkit-mask-box-image/index.md
+++ b/files/es/web/css/-webkit-mask-box-image/index.md
@@ -64,9 +64,13 @@ Where:
 }
 ```
 
-## Compatibilidad con los distintos navegadores
+## Especificaciones
 
-{{Compat("css.properties.-webkit-mask-box-image")}}
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/-webkit-mask-composite/index.md
+++ b/files/es/web/css/-webkit-mask-composite/index.md
@@ -60,9 +60,13 @@ Donde:
 }
 ```
 
-## Compatibilidad con los distintos navegadores
+## Especificaciones
 
-{{Compat("css.properties.-webkit-mask-composite")}}
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/-webkit-mask-composite/index.md
+++ b/files/es/web/css/-webkit-mask-composite/index.md
@@ -62,7 +62,7 @@ Donde:
 
 ## Especificaciones
 
-{{Specifications}}
+No forma parte de ningún estándar. Esta propiedad se especifica como {{CSSxRef("mask-composite")}} utilizando diferentes valores.
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/-webkit-mask-position-x/index.md
+++ b/files/es/web/css/-webkit-mask-position-x/index.md
@@ -71,9 +71,9 @@ La propiedad CSS `-webkit-mask-position-x` CSS establece la posición horizontal
 
 No forma parte de ninguna especificación.
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.properties.-webkit-mask-position-x")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/css/-webkit-mask-position-y/index.md
+++ b/files/es/web/css/-webkit-mask-position-y/index.md
@@ -69,7 +69,7 @@ La propiedad CSS `-webkit-mask-position-y` fija la posición inicial vertical de
 
 ## Especificaciones
 
-{{Specifications}}
+No forma parte de ninguna especificación.
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/-webkit-mask-position-y/index.md
+++ b/files/es/web/css/-webkit-mask-position-y/index.md
@@ -69,11 +69,11 @@ La propiedad CSS `-webkit-mask-position-y` fija la posición inicial vertical de
 
 ## Especificaciones
 
-Not part of any specification.
+{{Specifications}}
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.properties.-webkit-mask-position-y")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/-webkit-mask-repeat-x/index.md
+++ b/files/es/web/css/-webkit-mask-repeat-x/index.md
@@ -71,9 +71,9 @@ Es posible especificar un `<repeat-style>` diferente para cada una de las imáge
 
 Cada imagen se asocia con el correspondiente estilo de repetición, desde la primera hasta la última y siguiendo el orden que se ha establecido.
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.properties.-webkit-mask-repeat-x")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/-webkit-mask-repeat-y/index.md
+++ b/files/es/web/css/-webkit-mask-repeat-y/index.md
@@ -74,9 +74,9 @@ Es posible especificar un `<repeat-style>` diferente para cada una de las imáge
 
 Cada imagen se asocia con el correspondiente estilo de repetición, desde la primera hasta la última y siguiendo el orden que se ha establecido.
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.properties.-webkit-mask-repeat-y")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/-webkit-overflow-scrolling/index.md
+++ b/files/es/web/css/-webkit-overflow-scrolling/index.md
@@ -69,9 +69,9 @@ p {
 
 No es parte de ninguna especificación. Apple tiene una [descripción en la Referencia CSS de Safari.](https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariCSSRef/Articles/StandardCSSProperties.html#//apple_ref/css/property/-webkit-overflow-scrolling)
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.properties.-webkit-overflow-scrolling")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/-webkit-text-fill-color/index.md
+++ b/files/es/web/css/-webkit-text-fill-color/index.md
@@ -13,9 +13,9 @@ La propiedad CSS -**`webkit-text-fill-color`** especifica el [color](/es/docs/We
 
 {{Specifications}}
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.properties.-webkit-text-fill-color")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/-webkit-text-stroke-color/index.md
+++ b/files/es/web/css/-webkit-text-stroke-color/index.md
@@ -38,9 +38,9 @@ La propiedad CSS **`-webkit-text-stroke-color`** especifica el [color](/es/docs/
 
 {{Specifications}}
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.properties.-webkit-text-stroke-color")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/-webkit-text-stroke-width/index.md
+++ b/files/es/web/css/-webkit-text-stroke-width/index.md
@@ -30,9 +30,9 @@ La propiedad [CSS](/es/docs/Web/CSS) **`-webkit-text-stroke-width`** especifica 
 
 {{Specifications}}
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.properties.-webkit-text-stroke-width")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/-webkit-text-stroke/index.md
+++ b/files/es/web/css/-webkit-text-stroke/index.md
@@ -58,9 +58,9 @@ La propiedad [CSS](/es/docs/Web/CSS) **`-webkit-text-stroke`** especifica la [an
 
 {{Specifications}}
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.properties.-webkit-text-stroke")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/-webkit-touch-callout/index.md
+++ b/files/es/web/css/-webkit-touch-callout/index.md
@@ -49,6 +49,6 @@ No es parte de ninguna especificación.
 
 Apple tiene una [descripcón en la Referencia CSS de Safari](https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariCSSRef/Articles/StandardCSSProperties.html#//apple_ref/doc/uid/TP30001266-_webkit_touch_callout).
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.properties.-webkit-touch-callout")}}
+{{Compat}}

--- a/files/es/web/css/@charset/index.md
+++ b/files/es/web/css/@charset/index.md
@@ -49,6 +49,6 @@ Habiendo diferentes maneras de definir la codificación de caracteres en una hoj
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.at-rules.charset")}}
+{{Compat}}

--- a/files/es/web/css/@counter-style/additive-symbols/index.md
+++ b/files/es/web/css/@counter-style/additive-symbols/index.md
@@ -57,9 +57,9 @@ additive-symbols: 3 "0", 2 url(symbol.png);
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.at-rules.counter-style.additive-symbols")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/css/@counter-style/index.md
+++ b/files/es/web/css/@counter-style/index.md
@@ -114,9 +114,9 @@ Checkout more examples on the [demo page](https://mdn.github.io/css-counter-styl
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("css.at-rules.counter-style")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/css/@counter-style/symbols/index.md
+++ b/files/es/web/css/@counter-style/symbols/index.md
@@ -69,9 +69,9 @@ symbols: indic-numbers;
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.at-rules.counter-style.symbols")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/css/@font-face/font-display/index.md
+++ b/files/es/web/css/@font-face/font-display/index.md
@@ -65,6 +65,6 @@ font-display: optional;
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.at-rules.font-face.font-display")}}
+{{Compat}}

--- a/files/es/web/css/@font-face/font-family/index.md
+++ b/files/es/web/css/@font-face/font-family/index.md
@@ -71,6 +71,6 @@ p {
 
 {{Specifications}}
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.at-rules.font-face.font-family")}}
+{{Compat}}

--- a/files/es/web/css/@font-face/font-style/index.md
+++ b/files/es/web/css/@font-face/font-style/index.md
@@ -63,6 +63,6 @@ Por otra parte, si existe un verdadera versión en _cursiva_ del estilo de fuent
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("css.at-rules.font-face.font-style")}}
+{{Compat}}

--- a/files/es/web/css/@font-face/src/index.md
+++ b/files/es/web/css/@font-face/src/index.md
@@ -59,6 +59,6 @@ src: local(font), url(path/to/font.svg) format("svg"),
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.at-rules.font-face.src")}}
+{{Compat}}

--- a/files/es/web/css/@font-face/unicode-range/index.md
+++ b/files/es/web/css/@font-face/unicode-range/index.md
@@ -60,4 +60,4 @@ div {
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.at-rules.font-face.unicode-range")}}
+{{Compat}}


### PR DESCRIPTION
This PR updates some of the browser compatibility data and specification sections for the Spanish locale. Part of work for #11594.

Note: this may also include other minor updates, such as removal of old sections or other small bits of cleanup.
