### PR TITLE
es: Update browser compat/spec sections (part 5)

### DIFF
--- a/files/es/web/css/@font-feature-values/index.md
+++ b/files/es/web/css/@font-feature-values/index.md
@@ -54,9 +54,9 @@ La regla-at `@font-feature-values` debe ser usada en la parte superior de la hoj
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.at-rules.font-feature-values")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/css/@import/index.md
+++ b/files/es/web/css/@import/index.md
@@ -43,6 +43,6 @@ Dónde :
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.at-rules.import")}}
+{{Compat}}

--- a/files/es/web/css/@keyframes/index.md
+++ b/files/es/web/css/@keyframes/index.md
@@ -81,9 +81,9 @@ Mira los ejemplos del [CSS animations](/en/CSS/CSS_animations).
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("css.at-rules.keyframes")}}
+{{Compat}}
 
 ## Vease también
 

--- a/files/es/web/css/@media/color/index.md
+++ b/files/es/web/css/@media/color/index.md
@@ -9,6 +9,6 @@ slug: Web/CSS/@media/color
 
 {{Specifications}}
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.at-rules.media.color")}}
+{{Compat}}

--- a/files/es/web/css/@media/display-mode/index.md
+++ b/files/es/web/css/@media/display-mode/index.md
@@ -35,6 +35,6 @@ La característica `display-mode` se especifica como un valor de palabra clave e
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("css.at-rules.media.display-mode")}}
+{{Compat}}

--- a/files/es/web/css/@media/height/index.md
+++ b/files/es/web/css/@media/height/index.md
@@ -55,4 +55,4 @@ La característica `height` es especificada como un valor {{cssxref("&lt;length&
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.at-rules.media.height")}}
+{{Compat}}

--- a/files/es/web/css/@media/hover/index.md
+++ b/files/es/web/css/@media/hover/index.md
@@ -42,6 +42,6 @@ La característica hover es especificada como un valor de palabra clave elegida 
 
 {{Specifications}}
 
-## Compatibilidad de los navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.at-rules.media.hover")}}
+{{Compat}}

--- a/files/es/web/css/@media/index.md
+++ b/files/es/web/css/@media/index.md
@@ -88,9 +88,9 @@ Cada _característica de medios_ verifica una característica específica del na
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.at-rules.media")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/css/@media/pointer/index.md
+++ b/files/es/web/css/@media/pointer/index.md
@@ -73,9 +73,9 @@ input[type="checkbox"]:checked {
 
 {{Specifications}}
 
-## Compatibilidad
+## Compatibilidad con navegadores
 
-{{Compat("css.at-rules.media.pointer")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/@media/resolution/index.md
+++ b/files/es/web/css/@media/resolution/index.md
@@ -12,4 +12,4 @@ original_slug: Web/CSS/@media/resolución
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.at-rules.media.resolution")}}
+{{Compat}}

--- a/files/es/web/css/@media/width/index.md
+++ b/files/es/web/css/@media/width/index.md
@@ -52,6 +52,6 @@ La característica `width` es especificada como {{cssxref("&lt;length&gt;")}} va
 
 {{Specifications}}
 
-## Navegadores Compatibles
+## Compatibilidad con navegadores
 
-{{Compat("css.at-rules.media.width")}}
+{{Compat}}

--- a/files/es/web/css/@namespace/index.md
+++ b/files/es/web/css/@namespace/index.md
@@ -51,6 +51,6 @@ En [HTML5](/es/docs/Glossary/HTML5), conocidos como[elementos externos](https://
 
 {{Specifications}}
 
-## Compatibilidad
+## Compatibilidad con navegadores
 
-{{Compat("css.at-rules.namespace")}}
+{{Compat}}

--- a/files/es/web/css/@page/index.md
+++ b/files/es/web/css/@page/index.md
@@ -45,6 +45,6 @@ Por favor dirígete a las [pseudo-classes](/es/docs/CSS/Pseudo-classes) de `@pag
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("css.at-rules.page")}}
+{{Compat}}

--- a/files/es/web/css/@supports/index.md
+++ b/files/es/web/css/@supports/index.md
@@ -132,7 +132,7 @@ es equivalente a:
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.at-rules.supports")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_-moz-focusring/index.md
+++ b/files/es/web/css/_colon_-moz-focusring/index.md
@@ -29,9 +29,9 @@ mybutton:-moz-focusring {
 
 Esta propiedad todavía no está definida en ninguna especificación, aunque fue [debatida en el grupo de trabajo](https://lists.w3.org/Archives/Public/www-style/2015Sep/0226.html) y se [decidió añadirla a los selectores 4 o 5](https://lists.w3.org/Archives/Public/www-style/2015Oct/0012.html).
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.-moz-focusring")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/_colon_-moz-submit-invalid/index.md
+++ b/files/es/web/css/_colon_-moz-submit-invalid/index.md
@@ -11,9 +11,9 @@ La [pseudo-clase](/es/CSS/Pseudo-classes) CSS `:-moz-submit-invalid` representa 
 
 Por defecto no se aplica ningún estilo. Puedes usar tu estilo para personalizar la apariencia del botón de enviar cuando existen campos no válidos en el formulario.
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.-moz-submit-invalid")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/_colon_-moz-window-inactive/index.md
+++ b/files/es/web/css/_colon_-moz-window-inactive/index.md
@@ -39,6 +39,6 @@ Puedes verlo aquí en un [ejemplo en directo](/samples/cssref/moz-window-inactiv
 
 No es parte de ninguna especificación.
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.-moz-window-inactive")}}
+{{Compat}}

--- a/files/es/web/css/_colon_active/index.md
+++ b/files/es/web/css/_colon_active/index.md
@@ -49,7 +49,7 @@ a:active { color: lime; }        /* Enlaces activos */
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.active")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_any-link/index.md
+++ b/files/es/web/css/_colon_any-link/index.md
@@ -51,4 +51,4 @@ a:-webkit-any-link {
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.any-link")}}
+{{Compat}}

--- a/files/es/web/css/_colon_autofill/index.md
+++ b/files/es/web/css/_colon_autofill/index.md
@@ -16,9 +16,9 @@ La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) CSS `:-webkit-autofill` CSS s
 
 No es parte de ninguna especificación.
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.autofill")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/_colon_blank/index.md
+++ b/files/es/web/css/_colon_blank/index.md
@@ -17,9 +17,9 @@ La [pseudo-clase CSS](/es/docs/Web/CSS) **`:blank`** selecciona elementos de ent
 
 {{Specifications}}
 
-## Compatibilidad de los navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.blank")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_checked/index.md
+++ b/files/es/web/css/_colon_checked/index.md
@@ -160,4 +160,4 @@ Puede usar la pseudoclase `:checked` para crear una galería de imágenes con im
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.checked")}}
+{{Compat}}

--- a/files/es/web/css/_colon_default/index.md
+++ b/files/es/web/css/_colon_default/index.md
@@ -62,4 +62,4 @@ input:default + label {
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.default")}}
+{{Compat}}

--- a/files/es/web/css/_colon_defined/index.md
+++ b/files/es/web/css/_colon_defined/index.md
@@ -90,7 +90,7 @@ Esto es útil si tiene un elemento personalizado complejo que demora un tiempo e
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.defined")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_dir/index.md
+++ b/files/es/web/css/_colon_dir/index.md
@@ -70,7 +70,7 @@ La pseudoclase `:dir()` requiere un parámetro, que representa la direccionalida
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.dir")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_disabled/index.md
+++ b/files/es/web/css/_colon_disabled/index.md
@@ -83,7 +83,7 @@ function toggleBilling() {
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.disabled")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_empty/index.md
+++ b/files/es/web/css/_colon_empty/index.md
@@ -74,4 +74,4 @@ El texto que proporciona el nombre accesible del control interactivo se puede oc
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.empty")}}
+{{Compat}}

--- a/files/es/web/css/_colon_enabled/index.md
+++ b/files/es/web/css/_colon_enabled/index.md
@@ -58,7 +58,7 @@ input:disabled {
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.enabled")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_first-child/index.md
+++ b/files/es/web/css/_colon_first-child/index.md
@@ -94,7 +94,7 @@ ul li:first-child {
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.first-child")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_first-of-type/index.md
+++ b/files/es/web/css/_colon_first-of-type/index.md
@@ -81,7 +81,7 @@ article :first-of-type {
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.first-of-type")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_first/index.md
+++ b/files/es/web/css/_colon_first/index.md
@@ -62,7 +62,7 @@ Presione el botón "Imprimir!" para imprimir el ejemplo. Las palabras en la prim
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.first")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_focus-visible/index.md
+++ b/files/es/web/css/_colon_focus-visible/index.md
@@ -104,9 +104,9 @@ Puede que no sea obvio por qué el indicador de enfoque aparece y desaparece si 
 
 {{Specifications}}
 
-## Compatibilidad de navegador
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.focus-visible")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/css/_colon_focus-within/index.md
+++ b/files/es/web/css/_colon_focus-within/index.md
@@ -67,7 +67,7 @@ input {
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.focus-within")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_focus/index.md
+++ b/files/es/web/css/_colon_focus/index.md
@@ -65,7 +65,7 @@ Nunca elimines el outline de un foco sin reemplazarlo por otro tipo de indicador
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.focus")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_fullscreen/index.md
+++ b/files/es/web/css/_colon_fullscreen/index.md
@@ -131,7 +131,7 @@ fullscreenButton.addEventListener('click', enterFullscreen);
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.fullscreen")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_has/index.md
+++ b/files/es/web/css/_colon_has/index.md
@@ -27,6 +27,6 @@ a:has(> img)
 
 {{Specifications}}
 
-## Compatibilidad entre los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.has")}}
+{{Compat}}

--- a/files/es/web/css/_colon_host/index.md
+++ b/files/es/web/css/_colon_host/index.md
@@ -57,9 +57,7 @@ La regla `:host { background: rgba(0,0,0,0.1); padding: 2px 5px; }` estiliza tod
 
 ## Compatibilidad con navegadores
 
-Compatible con Chrome y Safari.
-
-{{Compat("css.selectors.host")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_hover/index.md
+++ b/files/es/web/css/_colon_hover/index.md
@@ -61,7 +61,7 @@ Puede usar la pseudoclase `:hover` para crear una galería de imágenes con imá
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.hover")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_in-range/index.md
+++ b/files/es/web/css/_colon_in-range/index.md
@@ -78,7 +78,7 @@ input:out-of-range + label::after {
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.in-range")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_indeterminate/index.md
+++ b/files/es/web/css/_colon_indeterminate/index.md
@@ -97,4 +97,4 @@ progress:indeterminate {
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.indeterminate")}}
+{{Compat}}

--- a/files/es/web/css/_colon_invalid/index.md
+++ b/files/es/web/css/_colon_invalid/index.md
@@ -109,7 +109,7 @@ Puede inhabilitar el brillo con el siguiente CSS o anularlo por completo para mo
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.invalid")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_is/index.md
+++ b/files/es/web/css/_colon_is/index.md
@@ -136,6 +136,10 @@ y lo siguiente es rápido:
 :-moz-any(.a, .d) > .b, :-moz-any(.a, .d) > .c
 ```
 
-## Compatibilidad de navegadores
+## Especificaciones
 
-{{Compat("css.selectors.is")}}
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}

--- a/files/es/web/css/_colon_lang/index.md
+++ b/files/es/web/css/_colon_lang/index.md
@@ -57,7 +57,7 @@ En este ejemplo, la pseudo-clase `:lang()` se usa para hacer coincidir los eleme
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.lang")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_last-child/index.md
+++ b/files/es/web/css/_colon_last-child/index.md
@@ -94,7 +94,7 @@ ul li:last-child {
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.last-child")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_last-of-type/index.md
+++ b/files/es/web/css/_colon_last-of-type/index.md
@@ -80,7 +80,7 @@ article :last-of-type {
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.last-of-type")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_left/index.md
+++ b/files/es/web/css/_colon_left/index.md
@@ -36,7 +36,7 @@ La dirección principal de escritura del documento determina si una página es "
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.left")}}
+{{Compat}}
 
 ## Ver También
 

--- a/files/es/web/css/_colon_link/index.md
+++ b/files/es/web/css/_colon_link/index.md
@@ -53,7 +53,7 @@ a:link {
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.link")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_not/index.md
+++ b/files/es/web/css/_colon_not/index.md
@@ -79,4 +79,4 @@ body :not(.crazy, .fancy) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.not")}}
+{{Compat}}

--- a/files/es/web/css/_colon_nth-child/index.md
+++ b/files/es/web/css/_colon_nth-child/index.md
@@ -144,7 +144,7 @@ div em {
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.nth-child")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_nth-last-child/index.md
+++ b/files/es/web/css/_colon_nth-last-child/index.md
@@ -156,7 +156,7 @@ tr:nth-last-child(n+1){
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.nth-last-child")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_nth-last-of-type/index.md
+++ b/files/es/web/css/_colon_nth-last-of-type/index.md
@@ -61,7 +61,7 @@ span:nth-last-of-type(2) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.nth-last-of-type")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_nth-of-type/index.md
+++ b/files/es/web/css/_colon_nth-of-type/index.md
@@ -71,7 +71,7 @@ p:nth-of-type(1) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.nth-of-type")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_only-child/index.md
+++ b/files/es/web/css/_colon_only-child/index.md
@@ -96,7 +96,7 @@ li:only-child {
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.only-child")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_only-of-type/index.md
+++ b/files/es/web/css/_colon_only-of-type/index.md
@@ -56,7 +56,7 @@ main :only-of-type {
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.only-of-type")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_optional/index.md
+++ b/files/es/web/css/_colon_optional/index.md
@@ -41,7 +41,7 @@ Las entradas requeridas también deben indicarse visualmente, utilizando un trat
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.optional")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_out-of-range/index.md
+++ b/files/es/web/css/_colon_out-of-range/index.md
@@ -78,7 +78,7 @@ input:out-of-range + label::after {
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.out-of-range")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_placeholder-shown/index.md
+++ b/files/es/web/css/_colon_placeholder-shown/index.md
@@ -73,7 +73,7 @@ input:placeholder-shown {
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.placeholder-shown")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_read-only/index.md
+++ b/files/es/web/css/_colon_read-only/index.md
@@ -64,7 +64,7 @@ p[contenteditable="true"] { color: blue; }
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.read-only")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_read-write/index.md
+++ b/files/es/web/css/_colon_read-write/index.md
@@ -59,7 +59,7 @@ p[contenteditable="true"] { color: blue; }
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.read-write")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_required/index.md
+++ b/files/es/web/css/_colon_required/index.md
@@ -41,7 +41,7 @@ Si el formulario también contiene entradas opcionales, las entradas requeridas 
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.required")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_right/index.md
+++ b/files/es/web/css/_colon_right/index.md
@@ -36,7 +36,7 @@ Que una página dada sea "izquierda" o "derecha" está determinada por la direcc
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.right")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_root/index.md
+++ b/files/es/web/css/_colon_root/index.md
@@ -35,4 +35,4 @@ La [pseudo-clase](/es/docs/Web/CSS/Pseudo-classes) **`:root`** de [CSS](/es/docs
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.root")}}
+{{Compat}}

--- a/files/es/web/css/_colon_target/index.md
+++ b/files/es/web/css/_colon_target/index.md
@@ -184,7 +184,7 @@ Puede usar la pseudo-clase `:target` para crear un lightbox sin usar JavaScript.
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.target")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_user-invalid/index.md
+++ b/files/es/web/css/_colon_user-invalid/index.md
@@ -23,9 +23,9 @@ Por defecto Gecko aplica un estilo que crear un brillo rojo "glow" (usando la pr
 
 No es parte de ninguna especificación.
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.user-invalid")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/_colon_valid/index.md
+++ b/files/es/web/css/_colon_valid/index.md
@@ -37,7 +37,7 @@ El color verde se usa comúnmente para indicar una entrada válida. Las personas
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.valid")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_colon_visited/index.md
+++ b/files/es/web/css/_colon_visited/index.md
@@ -69,7 +69,7 @@ a:visited {
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.visited")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_doublecolon_-moz-color-swatch/index.md
+++ b/files/es/web/css/_doublecolon_-moz-color-swatch/index.md
@@ -38,9 +38,9 @@ input[type=color]::-moz-color-swatch {
 
 No es parte de ninguna especificacion. Es un pseudo-elemento patentado específicamente para Gecko.
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.-moz-color-swatch")}}
+{{Compat}}
 
 ## Ver tambien
 

--- a/files/es/web/css/_doublecolon_-moz-page-sequence/index.md
+++ b/files/es/web/css/_doublecolon_-moz-page-sequence/index.md
@@ -17,9 +17,9 @@ Necesita un eejemplo
 
 No es parte de ninguna especificación.
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.-moz-page-sequence")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/_doublecolon_-moz-range-progress/index.md
+++ b/files/es/web/css/_doublecolon_-moz-range-progress/index.md
@@ -44,9 +44,9 @@ Una barra de progreso que utilice este estilo se vería de la siguiente manera:
 
 No es parte de ninguna especificación. Es un pseudo-elemento propietario de Gecko.
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.-moz-range-progress")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/_doublecolon_-moz-range-thumb/index.md
+++ b/files/es/web/css/_doublecolon_-moz-range-thumb/index.md
@@ -43,9 +43,9 @@ Una barra de progreso que utilizara este estilo se visualizarías de la siguient
 
 No es parte de ninguna especificación. El un pseudo-elemento propietario de Gecko.
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.-moz-range-thumb")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/_doublecolon_-moz-range-track/index.md
+++ b/files/es/web/css/_doublecolon_-moz-range-track/index.md
@@ -41,7 +41,7 @@ Un barra de progreso con ese estilo tendrá una apariencia similar a la siguient
 
 ## Especificaciones
 
-{{Specifications}}
+No es parte de ninguna especificación.
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/_doublecolon_-moz-range-track/index.md
+++ b/files/es/web/css/_doublecolon_-moz-range-track/index.md
@@ -41,11 +41,11 @@ Un barra de progreso con ese estilo tendrá una apariencia similar a la siguient
 
 ## Especificaciones
 
-No es parte de ninguna especificación. Es un pseudo-elemento propietario específico del motor Gecko.
+{{Specifications}}
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.-moz-range-track")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/_doublecolon_-moz-scrolled-page-sequence/index.md
+++ b/files/es/web/css/_doublecolon_-moz-scrolled-page-sequence/index.md
@@ -11,7 +11,7 @@ El [pseudo-elemento](/es/docs/Web/CSS/Pseudo-elements) CSS `::-moz-scrolled-page
 
 ## Especificaciones
 
-{{Specifications}}
+No es parte de ninguna especificación.
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/css/_doublecolon_-moz-scrolled-page-sequence/index.md
+++ b/files/es/web/css/_doublecolon_-moz-scrolled-page-sequence/index.md
@@ -11,11 +11,11 @@ El [pseudo-elemento](/es/docs/Web/CSS/Pseudo-elements) CSS `::-moz-scrolled-page
 
 ## Especificaciones
 
-Not part of any specification.
+{{Specifications}}
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.-moz-scrolled-page-sequence")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/_doublecolon_-webkit-inner-spin-button/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-inner-spin-button/index.md
@@ -31,9 +31,9 @@ input::-webkit-inner-spin-button {
 
 No es parte de ninguna especificación. Es un elemento propietario y específico de WebKit/Blink.
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.-webkit-inner-spin-button")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/_doublecolon_-webkit-meter-bar/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-meter-bar/index.md
@@ -9,10 +9,6 @@ slug: Web/CSS/::-webkit-meter-bar
 
 La pseudo-clase `::-webkit-meter-bar` establece el estilo para el fondo del elemento meter que contiene el valor.
 
-## Especificaciones
-
-No es parte de ninguna especificación. Es un elemento propietario y específico de WebKit/Blink.
-
 ## Ejemplos
 
 ```html
@@ -38,9 +34,13 @@ meter::-webkit-meter-bar  {
 
 > **Nota:** Sólo funciona en navegadores basados en Webkit/Blink.
 
-## Compatibilidad con los distintos navegadores
+## Especificaciones
 
-{{Compat("css.selectors.-webkit-meter-bar")}}
+No es parte de ninguna especificación. Es un elemento propietario y específico de WebKit/Blink.
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/_doublecolon_-webkit-meter-even-less-good-value/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-meter-even-less-good-value/index.md
@@ -9,10 +9,6 @@ slug: Web/CSS/::-webkit-meter-even-less-good-value
 
 El pseudo-elemento `::-webkit-meter-even-less-good-value` da color rojo al elemento meter cuando el valor y el atributo optimum están fuera del rango establecido y en zonas opuestas. Por ejemplo valor < low < high < optimum o valor> high > low > optimum.
 
-## Especificaciones
-
-No es parte de ninguna especificación. Es un elemento propietario y específico de WebKit/Blink.
-
 ## Ejemplos
 
 ```html
@@ -31,9 +27,13 @@ meter::-webkit-meter-even-less-good-value {
 
 > **Nota:** This will only work in Webkit/Blink-based browsers.
 
-## Compatibilidad con los distintos navegadores
+## Especificaciones
 
-{{Compat("css.selectors.-webkit-meter-even-less-good-value")}}
+No es parte de ninguna especificación. Es un elemento propietario y específico de WebKit/Blink.
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/_doublecolon_-webkit-meter-inner-element/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-meter-inner-element/index.md
@@ -9,10 +9,6 @@ slug: Web/CSS/::-webkit-meter-inner-element
 
 `El pseudo-elemento CSS ::-webkit-meter-inner-element` es un pseudo-elemento propietario de WebKit CSS para seleccionar y aplicar estilo al contenedor exterior de un elemento {{htmlelement("meter")}}. Es necesario una marca adicional para mostrar este elemento como si fuera de sólo lectura.
 
-## Especificaciones
-
-No es parte de ninguna especificación. Es un pseudo-elemento propietario y específico de WebKit/Blink.
-
 ## Ejemplos
 
 ```html
@@ -38,9 +34,13 @@ meter::-webkit-meter-inner-element {
 
 > **Nota:** Sólo funcionará en navegadores basasdo en Webkit/Blink.
 
-## Compatibilidad con los distintos navegadores
+## Especificaciones
 
-{{Compat("css.selectors.-webkit-meter-inner-element")}}
+No es parte de ninguna especificación. Es un pseudo-elemento propietario y específico de WebKit/Blink.
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/_doublecolon_-webkit-meter-optimum-value/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-meter-optimum-value/index.md
@@ -11,10 +11,6 @@ El pseudo-elemento CSS `::-webkit-meter-optimum-value` da estilo al elemento met
 
 El color por defecto es verde.
 
-## Especificaciones
-
-No es parte de ninguna especificación. Es un pseudo-elemento propietario y específico de WebKit/Blink.
-
 ## Ejemplos
 
 ```html
@@ -38,9 +34,13 @@ meter::-webkit-meter-optimum-value {
 
 > **Nota:** Sólo funciona en navegadores basado en Webkit/Blink.
 
-## Compatibilidad con los distintos navegadores
+## Especificaciones
 
-{{Compat("css.selectors.-webkit-meter-optimum-value")}}
+No es parte de ninguna especificación. Es un pseudo-elemento propietario y específico de WebKit/Blink.
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/_doublecolon_-webkit-meter-suboptimum-value/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-meter-suboptimum-value/index.md
@@ -9,10 +9,6 @@ slug: Web/CSS/::-webkit-meter-suboptimum-value
 
 El pseudo-elemento CSS `::-webkit-meter-suboptimum-value` da color amarillo al elemento meter cuando su valor cae fuera del rango mix-max.
 
-## Especificaciones
-
-No es parte de ninguna especificación. Es un pseudo-elemento propietario y específico de WebKit/Blink.
-
 ## Ejemplos
 
 ```html
@@ -31,9 +27,13 @@ meter::-webkit-meter-suboptimum-value {
 
 > **Nota:** Sólo funciona en navegadores basados en Webkit/Blink
 
-## Compatibilidad con los distintos navegadores
+## Especificaciones
 
-{{Compat("css.selectors.-webkit-meter-suboptimum-value")}}
+No es parte de ninguna especificación. Es un pseudo-elemento propietario y específico de WebKit/Blink.
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/_doublecolon_-webkit-outer-spin-button/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-outer-spin-button/index.md
@@ -31,9 +31,9 @@ input::-webkit-outer-spin-button {
 
 No es parte de ninguna especificación. Es un pseudo-elemento propietario y específico de WebKit/Blink.
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.-webkit-outer-spin-button")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/_doublecolon_-webkit-progress-bar/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-progress-bar/index.md
@@ -11,10 +11,6 @@ El [pseudo-elemento](/es/docs/Web/CSS/Pseudo-elements) [CSS](/es/docs/Web/CSS) *
 
 > **Nota:** para que `::-webkit-progress-value` tenga efecto , en el elemento `<progress>` {{cssxref("-webkit-appearance")}} debe tener el valor _none_.
 
-## Especificaciones
-
-No es parte de ninguna especificación. Es un pseudo-elemento propietario y específico de WebKit/Blink.
-
 ## Ejemplo
 
 ### Contenido CSS
@@ -43,9 +39,13 @@ Una barra de progreso que use el estilo indicado anteriormente será similar a l
 
 ![](progress-bar.png)
 
-## Compatibilidad con los distintos navegadores
+## Especificaciones
 
-{{Compat("css.selectors.-webkit-progress-bar")}}
+No es parte de ninguna especificación. Es un pseudo-elemento propietario y específico de WebKit/Blink.
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/_doublecolon_-webkit-progress-inner-element/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-progress-inner-element/index.md
@@ -43,9 +43,9 @@ Una barra de progreso que use el estilo especificado anteriormente tendrá una a
 
 No es parte de ninguna especificación. Es un pseudo-elemento propitario y específico de WebKit/Blink.
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.-webkit-progress-inner-element")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/_doublecolon_-webkit-progress-value/index.md
+++ b/files/es/web/css/_doublecolon_-webkit-progress-value/index.md
@@ -11,10 +11,6 @@ El [pseudo-elemento](/es/docs/Web/CSS/Pseudo-elements) [CSS](/es/docs/Web/CSS) *
 
 > **Nota:** para que `::-webkit-progress-value` tenga efecto en el elemento \<progress> {{cssxref("-webkit-appearance")}} deberá tener _none_ como valor.
 
-## Especificaciones
-
-No es parte de ninguna especificación. Es un elemento propietario y específico de WebKit/Blink.
-
 ## Ejemplo
 
 ### Contenido CSS
@@ -43,9 +39,13 @@ Una barra de progreso con el estilo indicado anteriormente será similar a esta:
 
 ![](progress-value.png)
 
-## Compatibilidad con los distintos navegadores
+## Especificaciones
 
-{{Compat("css.selectors.-webkit-progress-value")}}
+No es parte de ninguna especificación. Es un elemento propietario y específico de WebKit/Blink.
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/_doublecolon_after/index.md
+++ b/files/es/web/css/_doublecolon_after/index.md
@@ -131,9 +131,9 @@ span[data-descr]:focus::after {
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.after")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/css/_doublecolon_backdrop/index.md
+++ b/files/es/web/css/_doublecolon_backdrop/index.md
@@ -15,9 +15,9 @@ No se hereda ni es heredado de ningún elemento. Tampoco se hacen restricciones 
 
 {{Specifications}}
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.backdrop")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/css/_doublecolon_before/index.md
+++ b/files/es/web/css/_doublecolon_before/index.md
@@ -186,9 +186,9 @@ li[aria-current='step']::after {
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.before")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/css/_doublecolon_cue/index.md
+++ b/files/es/web/css/_doublecolon_cue/index.md
@@ -75,9 +75,9 @@ El siguiente CSS ajusta el estilo de las anotaciones para que el texto sea blanc
 
 {{Specifications}}
 
-## Compatibilidad con los navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.cue")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_doublecolon_first-letter/index.md
+++ b/files/es/web/css/_doublecolon_first-letter/index.md
@@ -80,9 +80,9 @@ p::first-letter {
 
 {{Specifications}}
 
-## Compatibilidad
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.first-letter")}}
+{{Compat}}
 
 ## Ver También
 

--- a/files/es/web/css/_doublecolon_marker/index.md
+++ b/files/es/web/css/_doublecolon_marker/index.md
@@ -60,7 +60,7 @@ ul li::marker {
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.marker")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/css/_doublecolon_placeholder/index.md
+++ b/files/es/web/css/_doublecolon_placeholder/index.md
@@ -115,9 +115,9 @@ El texto provisional no es un reemplazo para el elemento {{htmlelement("label")}
 
 {{Specifications}}
 
-## Compatibilidad de los navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.placeholder")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/_doublecolon_selection/index.md
+++ b/files/es/web/css/_doublecolon_selection/index.md
@@ -39,6 +39,6 @@ El `::selection` CSS pseudo-elemento fue redactado selector CSS nivel 3 pero qui
 
 En estos momentos, el seudo elemento CSS `::selection` no esta en ninguna especificación.
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.selection")}}
+{{Compat}}

--- a/files/es/web/css/_doublecolon_spelling-error/index.md
+++ b/files/es/web/css/_doublecolon_spelling-error/index.md
@@ -38,7 +38,7 @@ Solo se puede usar un pequeño subconjunto de propiedades de CSS en una regla co
 
 ## Compatibilidad con navegadores
 
-{{Compat("css.selectors.spelling-error")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/adjacent_sibling_combinator/index.md
+++ b/files/es/web/css/adjacent_sibling_combinator/index.md
@@ -53,9 +53,9 @@ que coincidiría con los siguientes elementos {{HTMLElement("span")}} :
 
 {{Specifications}}
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.selectors.adjacent_sibling")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/css/align-content/index.md
+++ b/files/es/web/css/align-content/index.md
@@ -184,9 +184,9 @@ Su resultado es:
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.properties.align-content")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/css/align-items/index.md
+++ b/files/es/web/css/align-items/index.md
@@ -77,9 +77,9 @@ align-items: unset;
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.properties.align-items")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/css/align-self/index.md
+++ b/files/es/web/css/align-self/index.md
@@ -53,9 +53,9 @@ align-self: unset;
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.properties.align-self")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/css/all/index.md
+++ b/files/es/web/css/all/index.md
@@ -135,9 +135,9 @@ El elemento {{HTMLElement("blockquote")}} no usa los estilos predeterminados del
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.properties.all")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/css/angle/index.md
+++ b/files/es/web/css/angle/index.md
@@ -32,6 +32,6 @@ Aun cuando todas las unidades representan lo mismo para el valor `0`, la unidad 
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.types.angle")}}
+{{Compat}}

--- a/files/es/web/css/animation-delay/index.md
+++ b/files/es/web/css/animation-delay/index.md
@@ -43,9 +43,9 @@ Visitar [animaciones CSS](/es/CSS/Usando_animaciones_CSS) para ver algunos ejemp
 
 {{Specifications}}
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.properties.animation-delay")}}
+{{Compat}}
 
 ## Consulte también
 

--- a/files/es/web/css/animation-direction/index.md
+++ b/files/es/web/css/animation-direction/index.md
@@ -47,9 +47,9 @@ Visitar [animaciones CSS](/es/CSS/Usando_animaciones_CSS) para ver algunos ejemp
 
 {{Specifications}}
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.properties.animation-direction")}}
+{{Compat}}
 
 ## Consulte también
 

--- a/files/es/web/css/animation-duration/index.md
+++ b/files/es/web/css/animation-duration/index.md
@@ -43,9 +43,9 @@ Visitar [CSS animations](/es/CSS/Usando_animaciones_CSS) para ver algunos ejempl
 
 {{Specifications}}
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-{{Compat("css.properties.animation-duration")}}
+{{Compat}}
 
 ## Consultar también
 


### PR DESCRIPTION
This PR updates some of the browser compatibility data and specification sections for the Spanish locale. Part of work for #11594.

Note: this may also include other minor updates, such as removal of old sections or other small bits of cleanup.
