### PR TITLE
es: Update browser compat/spec sections (part 8)

### DIFF
--- a/files/es/web/html/element/content/index.md
+++ b/files/es/web/html/element/content/index.md
@@ -87,9 +87,9 @@ Si muestras esto en un explorador web , debe de verse como lo siguiente .
 
 {{Specifications}}
 
-## Compatibilidad con exploradores
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.content")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/element/content/index.md
+++ b/files/es/web/html/element/content/index.md
@@ -85,7 +85,7 @@ Si muestras esto en un explorador web , debe de verse como lo siguiente .
 
 ## Especificaciones
 
-{{Specifications}}
+Este elemento ya no está definido por ninguna especificación.
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/html/element/data/index.md
+++ b/files/es/web/html/element/data/index.md
@@ -39,9 +39,9 @@ El siguiente ejemplo muestra nombres de productos pero también asocia a cada un
 
 {{Specifications}}
 
-## Compatibilidad de navegador
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.data")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/element/datalist/index.md
+++ b/files/es/web/html/element/datalist/index.md
@@ -86,14 +86,9 @@ Este elemento no tiene otros atributos mas que los [atributos globales](/es/docs
 
 {{Specifications}}
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.datalist")}}
-
-## sección de relleno
-
-Incluya este polyfill para proporcionar soporte para navegadores antiguos y actualmente incompatibles:
-[datalist-polyfill](https://github.com/mfranzke/datalist-polyfill)
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/element/dd/index.md
+++ b/files/es/web/html/element/dd/index.md
@@ -82,9 +82,9 @@ Para un ejemplo, ver [ejemplos \<dl>](/es/docs/Web/HTML/Elemento/dl#Examples).
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.dd")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/element/details/index.md
+++ b/files/es/web/html/element/details/index.md
@@ -75,15 +75,13 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
 
 {{EmbedLiveSample("Example")}}
 
-> **Nota:** Si el el ejemplo de arriba no funciona , ver [Compatibilidad con navegadores](#compatibilidad_con_navegadores) para determinar si el navegador soporta esta característica .
-
 ## Especificaciones
 
 {{Specifications}}
 
 ## Compatibilidad con navegadores
 
-{{Compat("html.elements.details")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/element/dialog/index.md
+++ b/files/es/web/html/element/dialog/index.md
@@ -124,11 +124,9 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <https://github.com/mdn/browser-compat-data> and send us a pull request.
-
-{{Compat("html.elements.dialog")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/element/dl/index.md
+++ b/files/es/web/html/element/dl/index.md
@@ -208,9 +208,9 @@ Para cambiar la indentación de un término, usa la propiedad {{cssxref("margin"
 
 {{Specifications}}
 
-## Compatibilidad Web
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.dl")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/html/element/dt/index.md
+++ b/files/es/web/html/element/dt/index.md
@@ -81,9 +81,9 @@ Para ver un ejemplo, vea el [proveído por el elemento `<dl>`](/es/docs/Web/HTML
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.dt")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/html/element/figcaption/index.md
+++ b/files/es/web/html/element/figcaption/index.md
@@ -68,11 +68,9 @@ Para ejemplos con `<figcaption>`, por favor ver la página {{HTMLElement("figure
 
 {{Specifications}}
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-The compatibility table in this page is generated from structured data. If you'd like to contribute to the data, please check out <https://github.com/mdn/browser-compat-data> and send us a pull request.
-
-{{Compat("html.elements.figcaption")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/html/element/form/index.md
+++ b/files/es/web/html/element/form/index.md
@@ -110,9 +110,13 @@ Este elemento implementa la interfaz [`HTMLFormElement`](/es/DOM/HTMLFormElement
 </form>
 ```
 
-## Compatibilidad de navegadores
+## Especificaciones
 
-{{Compat("html.elements.form")}}
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Consulte también
 

--- a/files/es/web/html/element/head/index.md
+++ b/files/es/web/html/element/head/index.md
@@ -40,9 +40,9 @@ Navegadores modernos que cumplen con el estándar HTML5 construyen automáticame
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.head")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/html/element/heading_elements/index.md
+++ b/files/es/web/html/element/heading_elements/index.md
@@ -122,9 +122,9 @@ Las etiquetas de cabecera pueden anidarse para generar sub-secciones en nuestros
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.h1")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/html/element/hgroup/index.md
+++ b/files/es/web/html/element/hgroup/index.md
@@ -45,6 +45,10 @@ Este elemento implementa la interfaz `HTMLElement`.
 </hgroup>
 ```
 
-### Compatibilidad
+## Especificaciones
 
-{{Compat("html.elements.hgroup")}}
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}

--- a/files/es/web/html/element/html/index.md
+++ b/files/es/web/html/element/html/index.md
@@ -44,9 +44,9 @@ El DOCTYPE usado en el siguiente ejemplo indica que es un documento HTML5.
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.html")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/element/iframe/index.md
+++ b/files/es/web/html/element/iframe/index.md
@@ -249,10 +249,6 @@ En este ejemplo, se muestra un mapa de Google en un marco.
 
 {{Specifications}}
 
-## Notes
+## Compatibilidad con navegadores
 
-Starting in Gecko 6.0 (Firefox 6.0 / Thunderbird 6.0 / SeaMonkey 2.3), rendering of inline frames correctly respects the borders of their containing element when they're rounded using {{ cssxref("border-radius") }}.
-
-## Browser compatibility
-
-{{Compat("html.elements.iframe", 3)}}
+{{Compat}}

--- a/files/es/web/html/element/label/index.md
+++ b/files/es/web/html/element/label/index.md
@@ -46,9 +46,9 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
 
 {{Specifications}}
 
-## Compatibilidad
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.label")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/html/element/link/index.md
+++ b/files/es/web/html/element/link/index.md
@@ -132,9 +132,9 @@ function sheetError() {
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.link")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/html/element/main/index.md
+++ b/files/es/web/html/element/main/index.md
@@ -58,17 +58,9 @@ Algunos lectores de pantalla reconocen la etiqueta `main` y proveen un atajo par
 
 {{Specifications}}
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-Como una caracterisca nueva propuesta para HTML, el elemento `<main>` no está todavía ampliamente soportado. Es sumamente recomendable añadir el rol ARIA `"main"` a cualquier elemento `<main>`:
-
-```html
-<main role="main">
-  ...
-</main>
-```
-
-{{Compat("html.elements.main")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/element/mark/index.md
+++ b/files/es/web/html/element/mark/index.md
@@ -122,9 +122,9 @@ El resultado se vería:
 
 {{Specifications}}
 
-## Compatibilidad de navegador
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.mark")}}
+{{Compat}}
 
 ## Consulta también
 

--- a/files/es/web/html/element/marquee/index.md
+++ b/files/es/web/html/element/marquee/index.md
@@ -74,6 +74,6 @@ La etiqueta html `<marquee>` se utiliza para insertar un area de texto en movimi
 
 {{Specifications}}
 
-## Navegadores compatibles
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.marquee")}}
+{{Compat}}

--- a/files/es/web/html/element/nav/index.md
+++ b/files/es/web/html/element/nav/index.md
@@ -44,9 +44,9 @@ En este ejemplo, un bloque `<nav>` es usado para contener una lista no ordenada 
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.nav")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/element/object/index.md
+++ b/files/es/web/html/element/object/index.md
@@ -138,9 +138,9 @@ Este elemento incluye los [global attributes](/es/docs/Web/HTML/Global_attribute
 
 {{Specifications}}
 
-## Compatibilidad con Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.object")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/html/element/option/index.md
+++ b/files/es/web/html/element/option/index.md
@@ -37,9 +37,9 @@ Ver los ejemplos {{HTMLElement("select")}}.
 
 {{Specifications}}
 
-## Compatibilidad con los distintos navegadores
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.option")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/element/picture/index.md
+++ b/files/es/web/html/element/picture/index.md
@@ -58,9 +58,9 @@ El atributo `type` permite especificar un tipo MIME para los recursos dados en e
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.picture")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/element/pre/index.md
+++ b/files/es/web/html/element/pre/index.md
@@ -47,9 +47,9 @@ a   {
 
 {{Specifications}}
 
-## Compatibilidad con exploradores
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.pre")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/html/element/progress/index.md
+++ b/files/es/web/html/element/progress/index.md
@@ -52,9 +52,9 @@ En Windows, el resultante sería este:
 
 {{Specifications}}
 
-## Compatibilidad en los navegadores
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.progress")}}
+{{Compat}}
 
 ## Mira también
 

--- a/files/es/web/html/element/q/index.md
+++ b/files/es/web/html/element/q/index.md
@@ -91,11 +91,13 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
 
 ## Especificaciones
 
+## Especificaciones
+
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{ Compat("html.elements.q") }}
+{{Compat}}
 
 ## Ve también
 

--- a/files/es/web/html/element/q/index.md
+++ b/files/es/web/html/element/q/index.md
@@ -91,8 +91,6 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
 
 ## Especificaciones
 
-## Especificaciones
-
 {{Specifications}}
 
 ## Compatibilidad con navegadores

--- a/files/es/web/html/element/section/index.md
+++ b/files/es/web/html/element/section/index.md
@@ -69,9 +69,13 @@ Este elemento implementa la interfaz [`HTMLElement`](/en/DOM/element).
 </section>
 ```
 
-## Compatibilidad
+## Especificaciones
 
-{{Compat("html.elements.section")}}
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/html/element/select/index.md
+++ b/files/es/web/html/element/select/index.md
@@ -66,9 +66,9 @@ El siguiente ejemplo muestra como simular una lista con opciones editables, pero
 
 {{Specifications}}
 
-## Compatibilidad con Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.select")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/element/slot/index.md
+++ b/files/es/web/html/element/slot/index.md
@@ -108,7 +108,6 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
 ```
 
 > **Nota:** Puedes ver este ejemplo en accion en [element-details](https://github.com/mdn/web-components-examples/tree/master/element-details) (velo [running live](https://mdn.github.io/web-components-examples/element-details/)). Además, puedes encontrar una explicación en [Using templates and slots](/es/docs/Web/Web_Components/Using_templates_and_slots).
->
 ## Especificaciones
 
 {{Specifications}}

--- a/files/es/web/html/element/slot/index.md
+++ b/files/es/web/html/element/slot/index.md
@@ -108,6 +108,7 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
 ```
 
 > **Nota:** Puedes ver este ejemplo en accion en [element-details](https://github.com/mdn/web-components-examples/tree/master/element-details) (velo [running live](https://mdn.github.io/web-components-examples/element-details/)). Además, puedes encontrar una explicación en [Using templates and slots](/es/docs/Web/Web_Components/Using_templates_and_slots).
+
 ## Especificaciones
 
 {{Specifications}}

--- a/files/es/web/html/element/slot/index.md
+++ b/files/es/web/html/element/slot/index.md
@@ -108,11 +108,11 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
 ```
 
 > **Nota:** Puedes ver este ejemplo en accion en [element-details](https://github.com/mdn/web-components-examples/tree/master/element-details) (velo [running live](https://mdn.github.io/web-components-examples/element-details/)). Además, puedes encontrar una explicación en [Using templates and slots](/es/docs/Web/Web_Components/Using_templates_and_slots).
-
+>
 ## Especificaciones
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.slot")}}
+{{Compat}}

--- a/files/es/web/html/element/source/index.md
+++ b/files/es/web/html/element/source/index.md
@@ -106,9 +106,9 @@ Para obtener más ejemplos, consulte [Uso de audio y video en Firefox](/es/docs/
 
 {{Specifications}}
 
-## Compaibilidad entre navegadores
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.source")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/element/sub/index.md
+++ b/files/es/web/html/element/sub/index.md
@@ -37,9 +37,9 @@ Este elemento sólo incluye los [atributos globales](/es/docs/HTML/Global_attrib
 
 {{Specifications}}
 
-## Compatibilidad navegadores
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.sub")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/element/sup/index.md
+++ b/files/es/web/html/element/sup/index.md
@@ -106,14 +106,11 @@ Este elemento sólo incluye los [atributos globales](/es/docs/HTML/Global_attrib
 
 ## Especificaciones
 
-| Especificaciones                                                                                                                                                    | Estado          | Comentario |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ---------- |
-| [HTML Living Standard The definition of '\<sub> and \<sup>' in that specification.](https://html.spec.whatwg.org/multipage/semantics.html#the-sub-and-sup-elements) | Living Standard |            |
-| [HTML5 The definition of '\<sub> and \<sup>;' in that specification.](http://www.w3.org/TR/html5/textlevel-semantics.html#the-sub-and-sup-elements)                 | Recommendation  |            |
+{{Specifications}}
 
-## Compatibilidad navegadores
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.sup")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/element/table/index.md
+++ b/files/es/web/html/element/table/index.md
@@ -300,6 +300,10 @@ td, th {
 
 {{EmbedLiveSample("",500,500)}}
 
-### Compatibilidad de navegadores
+## Especificaciones
 
-{{Compat("html.elements.table")}}
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}

--- a/files/es/web/html/element/template/index.md
+++ b/files/es/web/html/element/template/index.md
@@ -100,9 +100,9 @@ table td {
 
 {{Specifications}}
 
-## Compatibilidad navegadores
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.template")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/element/textarea/index.md
+++ b/files/es/web/html/element/textarea/index.md
@@ -102,9 +102,9 @@ Un _textarea_ tiene dimensiones intrínsecas, como una imagen agrandada.
 
 {{Specifications}}
 
-## Compatibilidad en Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.textarea")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/html/element/th/index.md
+++ b/files/es/web/html/element/th/index.md
@@ -159,9 +159,9 @@ See {{HTMLElement("table")}} for examples on `<th>`.
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.th")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/html/element/time/index.md
+++ b/files/es/web/html/element/time/index.md
@@ -152,9 +152,9 @@ El valor de fecha y hora (el valor legible por el equipo) es el valor del atribu
 
 {{Specifications}}
 
-## Compatibilidad de los navegadores
+## Compatibilidad con navegadores
 
-{{Compat("html.elements.time")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/element/wbr/index.md
+++ b/files/es/web/html/element/wbr/index.md
@@ -38,6 +38,10 @@ La [guia de estilo de Yahoo](http://styleguide.yahoo.com/) recomienda [romper un
 
 {{EmbedLiveSample("Example")}}
 
-## Compatibilidad en exploradores
+## Especificaciones
 
-{{Compat("html.elements.wbr")}}
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}

--- a/files/es/web/html/global_attributes/accesskey/index.md
+++ b/files/es/web/html/global_attributes/accesskey/index.md
@@ -73,9 +73,9 @@ Notar que Firefox puede personalizar la tecla de modificación requerida por las
 
 {{Specifications}}
 
-## Compatibilidad con exploradores
+## Compatibilidad con navegadores
 
-{{Compat("html.global_attributes.accesskey")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/global_attributes/autocapitalize/index.md
+++ b/files/es/web/html/global_attributes/autocapitalize/index.md
@@ -21,6 +21,6 @@ El atributo {{HTMLAttrDef("autocapitalize")}} nunca hace que se habilite la auto
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("html.global_attributes.autocapitalize")}}
+{{Compat}}

--- a/files/es/web/html/global_attributes/class/index.md
+++ b/files/es/web/html/global_attributes/class/index.md
@@ -13,9 +13,9 @@ Aunque la especificación no define los requerimientos para el nombre de las cla
 
 {{Specifications}}
 
-## Compatibilidad en exploradores
+## Compatibilidad con navegadores
 
-{{Compat("html.global_attributes.class")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/global_attributes/contenteditable/index.md
+++ b/files/es/web/html/global_attributes/contenteditable/index.md
@@ -19,9 +19,9 @@ Este es un atributo enumerado y no uno _booleano ._ Esto significa que el uso ex
 
 {{Specifications}}
 
-## Compatiblidad en exploradores
+## Compatibilidad con navegadores
 
-{{Compat("html.global_attributes.contenteditable")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/global_attributes/contextmenu/index.md
+++ b/files/es/web/html/global_attributes/contextmenu/index.md
@@ -59,9 +59,9 @@ resulta en :
 
 {{Specifications}}
 
-## Compatibilidad en exploradores
+## Compatibilidad con navegadores
 
-{{Compat("html.global_attributes.contextmenu")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/global_attributes/contextmenu/index.md
+++ b/files/es/web/html/global_attributes/contextmenu/index.md
@@ -57,7 +57,7 @@ resulta en :
 
 ## Especificaciones
 
-{{Specifications}}
+El [atributo `contextmenu` está obsoleto](https://html.spec.whatwg.org/multipage/obsolete.html#attr-contextmenu) y se eliminará de todos los navegadores.
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/html/global_attributes/data-_star_/index.md
+++ b/files/es/web/html/global_attributes/data-_star_/index.md
@@ -20,9 +20,9 @@ Notar que la propiedad {{domxref("HTMLElement.dataset")}} es un {{domxref("Strin
 
 {{Specifications}}
 
-## Compatibilidad en exploradores
+## Compatibilidad con navegadores
 
-{{Compat("html.global_attributes.data_attributes")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/global_attributes/hidden/index.md
+++ b/files/es/web/html/global_attributes/hidden/index.md
@@ -18,9 +18,9 @@ Los elementos ocultos no deben de ser vinculados desde elementos no ocultos y el
 
 {{Specifications}}
 
-## Compatibilidad en exploradores
+## Compatibilidad con navegadores
 
-{{Compat("html.global_attributes.hidden")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/global_attributes/id/index.md
+++ b/files/es/web/html/global_attributes/id/index.md
@@ -17,9 +17,9 @@ El valor de este atributo no debe contener espacios en blanco. Los navegadores t
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("html.global_attributes.id")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/global_attributes/index.md
+++ b/files/es/web/html/global_attributes/index.md
@@ -100,9 +100,9 @@ Además de los atributos globales HTML básicos, también existen los siguientes
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("html.global_attributes")}}
+{{Compat}}
 
 ## Ve también
 

--- a/files/es/web/html/global_attributes/is/index.md
+++ b/files/es/web/html/global_attributes/is/index.md
@@ -39,9 +39,9 @@ customElements.define('word-count', WordCount, { extends: 'p' });
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("html.global_attributes.is")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/html/global_attributes/itemscope/index.md
+++ b/files/es/web/html/global_attributes/itemscope/index.md
@@ -236,9 +236,9 @@ Los siguientes son un ejemplo renderizado resultado del codigo del anterior ejem
 
 {{Specifications}}
 
-## Navegadores compatibles
+## Compatibilidad con navegadores
 
-{{Compat("html.global_attributes.itemscope")}}
+{{Compat}}
 
 ## Ver tambien
 

--- a/files/es/web/html/global_attributes/lang/index.md
+++ b/files/es/web/html/global_attributes/lang/index.md
@@ -16,9 +16,9 @@ Para la pseudo clase { cssxref(":lang") }} de CSS, dos nombres invalidos de leng
 
 {{Specifications}}
 
-## Compatibilidad en exploradores
+## Compatibilidad con navegadores
 
-{{Compat("html.global_attributes.lang")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/global_attributes/slot/index.md
+++ b/files/es/web/html/global_attributes/slot/index.md
@@ -12,9 +12,9 @@ El [atributo global](/es/docs/Web/HTML/Global_attributes) **slot** asigna un esp
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("html.global_attributes.slot")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/html/global_attributes/spellcheck/index.md
+++ b/files/es/web/html/global_attributes/spellcheck/index.md
@@ -186,9 +186,9 @@ El valor por default de este atributo es dependiente del explorador y del elemen
 
 {{Specifications}}
 
-## Compatibilidad con exploradores
+## Compatibilidad con navegadores
 
-{{Compat("html.global_attributes.spellcheck")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/global_attributes/style/index.md
+++ b/files/es/web/html/global_attributes/style/index.md
@@ -14,9 +14,9 @@ El [atributo global](/es/docs/Web/HTML/Atributos_Globales) **style** contiene de
 
 {{Specifications}}
 
-## Compatibilidad en exploradores
+## Compatibilidad con navegadores
 
-{{Compat("html.global_attributes.style")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/global_attributes/tabindex/index.md
+++ b/files/es/web/html/global_attributes/tabindex/index.md
@@ -21,6 +21,6 @@ Puede consultar [este artículo](/en/Focus_management_in_HTML) para ver una expl
 
 {{Specifications}}
 
-## Compatibilidad en exploradores
+## Compatibilidad con navegadores
 
-{{Compat("html.global_attributes.tabindex")}}
+{{Compat}}

--- a/files/es/web/html/global_attributes/title/index.md
+++ b/files/es/web/html/global_attributes/title/index.md
@@ -29,9 +29,9 @@ define un título de dos líneas .
 
 {{Specifications}}
 
-## Compatibilidad en exploradores
+## Compatibilidad con navegadores
 
-{{Compat("html.global_attributes.title")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/html/global_attributes/translate/index.md
+++ b/files/es/web/html/global_attributes/translate/index.md
@@ -15,9 +15,9 @@ El [atributo global](/es/docs/Web/HTML/Atributos_Globales) **translate** es un a
 
 {{Specifications}}
 
-## Compatibilidad en exploradores
+## Compatibilidad con navegadores
 
-{{Compat("html.global_attributes.translate")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/http/cors/index.md
+++ b/files/es/web/http/cors/index.md
@@ -413,9 +413,9 @@ Ejemplos de esta utilización pueden ser encontrados [arriba](/En/HTTP_access_co
 
 {{Specifications}}
 
-## Compatibilidad con Exploradores
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.Access-Control-Allow-Origin")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/http/headers/accept/index.md
+++ b/files/es/web/http/headers/accept/index.md
@@ -69,13 +69,11 @@ Accept: text/html, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8
 
 ## Especificaciones
 
-| Especificación                               | Titulo                                                        |
-| -------------------------------------------- | ------------------------------------------------------------- |
-| {{RFC("7231", "Accept", "5.3.2")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Context |
+{{Specifications}}
 
-## Compatibilidad con Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.Accept")}}
+{{Compat}}
 
 ## Tambien Ver
 

--- a/files/es/web/http/headers/access-control-allow-credentials/index.md
+++ b/files/es/web/http/headers/access-control-allow-credentials/index.md
@@ -59,9 +59,9 @@ fetch(url, {
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.Access-Control-Allow-Credentials")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/http/headers/access-control-allow-headers/index.md
+++ b/files/es/web/http/headers/access-control-allow-headers/index.md
@@ -38,16 +38,7 @@ Access-Control-Allow-Headers: X-Custom-Header
 
 ## Compatibilidad con navegadores
 
-{{Compat("http.headers.Access-Control-Allow-Headers")}}
-
-## Notas de compatibilidad
-
-- El carácter comodín (\*) que es mencionado en la última especificación, todavía no está implementado en los navegadores:
-
-  - Chromium: [Issue 615313](https://bugs.chromium.org/p/chromium/issues/detail?id=615313)
-  - Firefox: {{bug(1309358)}}
-  - Servo: [Issue 13283](https://github.com/servo/servo/issues/13283)
-  - WebKit: [Issue 165508](https://bugs.webkit.org/show_bug.cgi?id=165508)
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/http/headers/access-control-allow-methods/index.md
+++ b/files/es/web/http/headers/access-control-allow-methods/index.md
@@ -32,17 +32,9 @@ Access-Control-Allow-Methods: POST, GET, OPTIONS
 
 {{Specifications}}
 
-## Compatibilidad de navegador
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.Access-Control-Allow-Methods")}}
-
-## Notas de compatibilidad
-
-- The wildcard value (\*) that is mentioned in the latest specification, is not yet implemented in browsers:
-
-  - Chromium: [Issue 615313](https://bugs.chromium.org/p/chromium/issues/detail?id=615313)
-  - Firefox: {{bug(1309358)}}
-  - Servo: [Issue 13283](https://github.com/servo/servo/issues/13283)
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/http/headers/access-control-allow-origin/index.md
+++ b/files/es/web/http/headers/access-control-allow-origin/index.md
@@ -68,9 +68,9 @@ Vary: Origin
 
 {{Specifications}}
 
-## Compatibilidad del Navegador
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.Access-Control-Allow-Origin")}}
+{{Compat}}
 
 ## Veáse también
 

--- a/files/es/web/http/headers/access-control-expose-headers/index.md
+++ b/files/es/web/http/headers/access-control-expose-headers/index.md
@@ -69,17 +69,9 @@ Access-Control-Expose-Headers: *, Authorization
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.Access-Control-Expose-Headers")}}
-
-## Notas de compatibilidad
-
-- El valor asterisco (\*) indica que no es implementado en navegadores:
-
-  - Chromium: [Issue 615313](https://bugs.chromium.org/p/chromium/issues/detail?id=615313)
-  - Firefox: {{bug(1309358)}}
-  - Servo: [Issue 13283](https://github.com/servo/servo/issues/13283)
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/http/headers/age/index.md
+++ b/files/es/web/http/headers/age/index.md
@@ -28,13 +28,11 @@ Age: 24
 
 ## Especificaciones
 
-| Specification                            | Title                                           |
-| ---------------------------------------- | ----------------------------------------------- |
-| {{RFC("7234", "Age", "5.1")}} | Hypertext Transfer Protocol (HTTP/1.1): Caching |
+{{Specifications}}
 
-## Compatibilidad de Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.Age")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/http/headers/content-disposition/index.md
+++ b/files/es/web/http/headers/content-disposition/index.md
@@ -82,19 +82,11 @@ valor2
 
 ## Especificaciones
 
-| Especificación       | Título                                                                                                                                                                                                          |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| {{RFC("7578")}} | Returning Values from Forms: multipart/form-data (Retornando Valores desde Formularios: multipart/form-data)                                                                                                    |
-| {{RFC("6266")}} | Use of the Content-Disposition Header Field in the Hypertext Transfer Protocol (HTTP) (Uso del campo de encabezado Content-Disposition en HTML)                                                                 |
-| {{RFC("2183")}} | Communicating Presentation Information in Internet Messages: The Content-Disposition Header Field (Comunicando Información de Presentación en Mensajes de Internet: el Campo de Encabezado Content-Disposition) |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 
-{{Compat("http.headers.Content-Disposition")}}
-
-## Notas de compatibilidad
-
-- Firefox 5 maneja el encabezado de respuesta HTTP `Content-Disposition` más efectivamente si ambos parámetros `filename` y `filename*` están presentes; observa todos los nombres presentes, usando el parámetro `filename*` si uno está disponible, incluso si el parámetro `filename` está incluido antes. Previamente, el primer parámetro en encontrarse sería usado, de este modo se previene el uso de un nombre más apropiado. Mira {{bug(588781)}}.
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/http/headers/content-disposition/index.md
+++ b/files/es/web/http/headers/content-disposition/index.md
@@ -88,6 +88,10 @@ valor2
 
 {{Compat}}
 
+## Notas de compatibilidad
+
+- Firefox 5 maneja el encabezado de respuesta HTTP `Content-Disposition` más efectivamente si ambos parámetros `filename` y `filename*` están presentes; observa todos los nombres presentes, usando el parámetro `filename*` si uno está disponible, incluso si el parámetro `filename` está incluido antes. Previamente, el primer parámetro en encontrarse sería usado, de este modo se previene el uso de un nombre más apropiado. Mira {{bug(588781)}}.
+
 ## Ver también
 
 - [Formularios HTML](/es/docs/Web/Guide/HTML/Forms)

--- a/files/es/web/http/headers/content-length/index.md
+++ b/files/es/web/http/headers/content-length/index.md
@@ -24,13 +24,11 @@ Content-Length: <longitud>
 
 ## Especificaciones
 
-| Especificación                                           | Título                                                                                   |
-| -------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| {{RFC("7230", "Content-Length", "3.3.2")}} | Protocolo de Transferencia de Hipertexto (HTTP/1.1): Sintaxis y enrutamiento de mensajes |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 
-{{Compat("http.headers.Content-Length")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/http/headers/content-location/index.md
+++ b/files/es/web/http/headers/content-location/index.md
@@ -105,13 +105,11 @@ Content-Location: /mis-recibos/38
 
 ## Especificaciones
 
-| Especificación                                               | Título                                                        |
-| ------------------------------------------------------------ | ------------------------------------------------------------- |
-| {{RFC("7231", "Content-Location", "3.1.4.2")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.Content-Location")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/http/headers/content-type/index.md
+++ b/files/es/web/http/headers/content-type/index.md
@@ -67,14 +67,11 @@ Content-Type: text/plain
 
 ## Especificaciones
 
-| Specification                                                        | Title                                                         |
-| -------------------------------------------------------------------- | ------------------------------------------------------------- |
-| {{RFC("7233", "Content-Type in multipart", "4.1")}} | Hypertext Transfer Protocol (HTTP/1.1): Range Requests        |
-| {{RFC("7231", "Content-Type", "3.1.1.5")}}             | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
-## Compatibilidad de navegador
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.Content-Type")}}
+{{Compat}}
 
 ## Más sobre
 

--- a/files/es/web/http/headers/cookie/index.md
+++ b/files/es/web/http/headers/cookie/index.md
@@ -32,13 +32,11 @@ Cookie: PHPSESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;
 
 ## Especificaciones
 
-| Specification                                | Title                           |
-| -------------------------------------------- | ------------------------------- |
-| {{RFC("6265", "Cookie", "5.4")}} | HTTP State Management Mechanism |
+{{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.Cookie")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/http/headers/cross-origin-resource-policy/index.md
+++ b/files/es/web/http/headers/cross-origin-resource-policy/index.md
@@ -29,9 +29,9 @@ Cross-Origin-Resource-Policy: same-origin
 
 {{Specifications}}
 
-## Compatibilidad de los navegadores
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.Cross-Origin-Resource-Policy")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/http/headers/etag/index.md
+++ b/files/es/web/http/headers/etag/index.md
@@ -64,13 +64,11 @@ El servidor compara el `ETag` del cliente (enviado con un `If-None-Match`) con e
 
 ## Especificaciones
 
-| Especificación                           | Título                                                                         |
-| ---------------------------------------- | ------------------------------------------------------------------------------ |
-| {{RFC("7232", "ETag", "2.3")}} | Protocolo de Transferencia por Hipertexto (HTTP/1.1): Peticiones Condicionales |
+{{Specifications}}
 
-## Compatibilidad con Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.ETag")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/http/headers/expires/index.md
+++ b/files/es/web/http/headers/expires/index.md
@@ -35,13 +35,11 @@ Expires: Jue, 21 Oct 2017 07:28:00 GMT
 
 ## Especificaciones
 
-| Especificación                               | Título                                          |
-| -------------------------------------------- | ----------------------------------------------- |
-| {{RFC("7234", "Expires", "5.3")}} | Hypertext Transfer Protocol (HTTP/1.1): Caching |
+{{Specifications}}
 
-## Compatibilidad en Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.Expires")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/http/headers/host/index.md
+++ b/files/es/web/http/headers/host/index.md
@@ -36,13 +36,11 @@ Host: developer.mozilla.org
 
 ## Especificaciones
 
-| Specification                            | Title                                                              |
-| ---------------------------------------- | ------------------------------------------------------------------ |
-| {{RFC("7230", "Host", "5.4")}} | Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing |
+{{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.Host")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/http/headers/keep-alive/index.md
+++ b/files/es/web/http/headers/keep-alive/index.md
@@ -45,14 +45,11 @@ Server: Apache
 
 ## Especificaciones
 
-| Specification                                                                                                                     | Title                                                              |
-| --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| [HyperText Transport Protocol Keep-Alive Header](https://tools.ietf.org/id/draft-thomson-hybi-http-timeout-01.html#rfc.section.2) | The Keep-Alive Header (Experimental specification)                 |
-| {{RFC("7230", "Keep-Alive", "appendix-A.1.2")}}                                                                  | Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing |
+{{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.Keep-Alive")}}
+{{Compat}}
 
 ## Mirar tambien
 

--- a/files/es/web/http/headers/link/index.md
+++ b/files/es/web/http/headers/link/index.md
@@ -42,14 +42,11 @@ Link: <https://uno.ejemplo.com>; rel="preconnect", <https://dos.ejemplo.com>; re
 
 ## Especificaciones
 
-| Especificaciones                                                         | Estado   | Comentarios        |
-| ------------------------------------------------------------------------ | -------- | ------------------ |
-| {{RFC(8288, "Link Serialisation in HTTP Headers", 3)}} | IETF RFC |                    |
-| {{RFC(5988, "The Link Header Field", 5)}}                 | IETF RFC | Definición inicial |
+{{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.Link")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/http/headers/origin/index.md
+++ b/files/es/web/http/headers/origin/index.md
@@ -39,9 +39,9 @@ Origin: https://developer.mozilla.org
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.Origin")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/http/headers/pragma/index.md
+++ b/files/es/web/http/headers/pragma/index.md
@@ -49,19 +49,15 @@ Pragma: no-cache
 Pragma: no-cache
 ```
 
-## Especificación
+## Especificaciones
 
-| Especificación                               | Título                                                          |
-| -------------------------------------------- | --------------------------------------------------------------- |
-| {{RFC("7234", "Pragma", "5.4")}} | Hypertext Transfer Protocol (HTTP/1.1): almacenamiento en caché |
+{{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.Pragma")}}
+{{Compat}}
 
 ## Véase también
 
 - {{HTTPHeader("Cache-Control")}}
 - {{HTTPHeader("Expires")}}
-
-Traducción realizada por Ervin A. Santos R.

--- a/files/es/web/http/headers/referer/index.md
+++ b/files/es/web/http/headers/referer/index.md
@@ -39,13 +39,11 @@ Referer: https://developer.mozilla.org/es/docs/Web/JavaScript
 
 ## Especificaciones
 
-| Especificación                                   | Título                                                        |
-| ------------------------------------------------ | ------------------------------------------------------------- |
-| {{RFC("7231", "Referer", "5.5.2")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.Referer")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/http/headers/referrer-policy/index.md
+++ b/files/es/web/http/headers/referrer-policy/index.md
@@ -81,25 +81,11 @@ Referrer-Policy: unsafe-url
 
 ## Especificaciones
 
-| Especificación                                                                                     | Estado                   |
-| -------------------------------------------------------------------------------------------------- | ------------------------ |
-| [Directiva de referentes](https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-header) | Anteproyecto de editores |
+{{Specifications}}
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.Referrer-Policy")}}
-
-> **Nota:**
->
-> - A partir de la versión 53 en adelante, Gecko incluye una preferencia de `about:config` para permitir a los usuarios definir su directiva `Referrer-Policy` predeterminada: `network.http.referer.userControlPolicy`.
-> - A partir de la versión 59 (consulte el informe n.º [587523](https://bugzilla.mozilla.org/show_bug.cgi?id=587523)), esta preferencia ha cambiado de nombre: ahora son `network.http.referer.defaultPolicy` y `network.http.referer.defaultPolicy.pbmode`.
->
-> Los valores posibles son:
->
-> - 0: `no-referrer`
-> - 1: `same-origin`
-> - 2: `strict-origin-when-cross-origin`
-> - 3: `no-referrer-when-downgrade` (la predeterminada)
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/http/headers/server/index.md
+++ b/files/es/web/http/headers/server/index.md
@@ -32,13 +32,11 @@ Server: Apache/2.4.1 (Unix)
 
 ## Especificaciones
 
-| Especificación                               | Título                                                        |
-| -------------------------------------------- | ------------------------------------------------------------- |
-| {{RFC("7231", "Server", "7.4.2")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 
-{{Compat("http.headers.Server")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/http/headers/set-cookie/index.md
+++ b/files/es/web/http/headers/set-cookie/index.md
@@ -178,6 +178,10 @@ Set-Cookie: __Host-id=1; Secure; Path=/; domain=example.com
 
 {{Compat}}
 
+## Notas de compatibilidad
+
+- Empezando con Chrome 52 y Firefox 52, sitios inseguros (`http:`) no pueden definirse cookies con la directiva 'secure'.
+
 ## Ver también
 
 - [HTTP cookies](/es/docs/Web/HTTP/Cookies)

--- a/files/es/web/http/headers/set-cookie/index.md
+++ b/files/es/web/http/headers/set-cookie/index.md
@@ -172,18 +172,11 @@ Set-Cookie: __Host-id=1; Secure; Path=/; domain=example.com
 
 ## Especificaciones
 
-| Especificación                                                                                   | Título                                                        |
-| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
-| {{RFC("6265", "Set-Cookie", "4.1")}}                                                 | Mecanismo de gestión del estado HTTP                          |
-| [draft-ietf-httpbis-rfc6265bis-05](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-05) | Cookie Prefixes, Same-Site Cookies, and Strict Secure Cookies |
+{{Specifications}}
 
-## Compatibilidad de los navegadores
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.Set-Cookie", 5)}}
-
-## Notas de compatibilidad
-
-- Empezando con Chrome 52 y Firefox 52, sitios inseguros (`http:`) no pueden definirse cookies con la directiva 'secure'.
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/http/headers/transfer-encoding/index.md
+++ b/files/es/web/http/headers/transfer-encoding/index.md
@@ -65,13 +65,11 @@ Network\r\n
 
 ## Especificaciones
 
-| Especificación                                               | Título                                                             |
-| ------------------------------------------------------------ | ------------------------------------------------------------------ |
-| {{RFC("7230", "Transfer-Encoding", "3.3.1")}} | Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing |
+{{Specifications}}
 
-## Compatibilidad con el Navegador
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.Transfer-Encoding")}}
+{{Compat}}
 
 ## Ver además:
 

--- a/files/es/web/http/headers/vary/index.md
+++ b/files/es/web/http/headers/vary/index.md
@@ -45,6 +45,10 @@ Vary: User-Agent
 
 {{Compat}}
 
+## Notas de Compatibilidad
+
+- [Vary with care – Vary header problems in IE6-9](https://blogs.msdn.microsoft.com/ieinternals/2009/06/17/vary-with-care/)
+
 ## Vea tambien
 
 - {{HTTPHeader("Cache-Control")}}

--- a/files/es/web/http/headers/vary/index.md
+++ b/files/es/web/http/headers/vary/index.md
@@ -39,17 +39,11 @@ Vary: User-Agent
 
 ## Especificaciones
 
-| Specification                                | Title                                                         |
-| -------------------------------------------- | ------------------------------------------------------------- |
-| {{RFC("7231", "Vary", "7.1.4")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.Vary")}}
-
-## Notas de Compatibilidad
-
-- [Vary with care – Vary header problems in IE6-9](https://blogs.msdn.microsoft.com/ieinternals/2009/06/17/vary-with-care/)
+{{Compat}}
 
 ## Vea tambien
 

--- a/files/es/web/http/headers/www-authenticate/index.md
+++ b/files/es/web/http/headers/www-authenticate/index.md
@@ -40,16 +40,13 @@ WWW-Authenticate: Basic realm="Access to the staging site", charset="UTF-8"
 
 Vea también [HTTP authentication](/es/docs/Web/HTTP/Authentication) por ejemplos sobre como configurar un servidor Apache o nginx para proteger con contraseña tu sitio con autenticación básica HTTP.
 
-## Specifications
+## Especificaciones
 
-| Espeficicación                                           | Título                                 |
-| -------------------------------------------------------- | -------------------------------------- |
-| {{RFC("7235", "WWW-Authenticate", "4.1")}} | HTTP/1.1: Authentication               |
-| {{RFC("7617")}}                                     | The 'Basic' HTTP Authentication Scheme |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 
-{{Compat("http.headers.WWW-Authenticate")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/http/headers/x-content-type-options/index.md
+++ b/files/es/web/http/headers/x-content-type-options/index.md
@@ -34,9 +34,9 @@ X-Content-Type-Options: nosniff
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.X-Content-Type-Options")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/http/headers/x-forwarded-for/index.md
+++ b/files/es/web/http/headers/x-forwarded-for/index.md
@@ -49,7 +49,7 @@ X-ProxyUser-Ip: 203.0.113.19
 
 ## Especificaciones
 
-{{Specifications}}
+No es parte de especificación actual alguna. La versión estandarizada de este cabezal es {{HTTPHeader("Forwarded")}}.
 
 ## Compatibilidad con navegadores
 

--- a/files/es/web/http/headers/x-forwarded-for/index.md
+++ b/files/es/web/http/headers/x-forwarded-for/index.md
@@ -49,11 +49,11 @@ X-ProxyUser-Ip: 203.0.113.19
 
 ## Especificaciones
 
-No es parte de especificación actual alguna. La versión estandarizada de este cabezal es {{HTTPHeader("Forwarded")}}.
+{{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.X-Forwarded-For")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/http/headers/x-forwarded-for/index.md
+++ b/files/es/web/http/headers/x-forwarded-for/index.md
@@ -51,10 +51,6 @@ X-ProxyUser-Ip: 203.0.113.19
 
 No es parte de especificación actual alguna. La versión estandarizada de este cabezal es {{HTTPHeader("Forwarded")}}.
 
-## Compatibilidad con navegadores
-
-{{Compat}}
-
 ## See also
 
 - {{HTTPHeader("Forwarded")}}

--- a/files/es/web/http/headers/x-xss-protection/index.md
+++ b/files/es/web/http/headers/x-xss-protection/index.md
@@ -55,9 +55,9 @@ Apache (.htaccess)
 
 No forma parte de ninguna especificación o borrador.
 
-## Compatibilidad de los navegadores
+## Compatibilidad con navegadores
 
-{{Compat("http.headers.X-XSS-Protection")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/http/methods/connect/index.md
+++ b/files/es/web/http/methods/connect/index.md
@@ -5,7 +5,7 @@ slug: Web/HTTP/Methods/CONNECT
 
 {{HTTPSidebar}}
 
-El método **HTTP `CONNECT` **inicia la comunicación en dos caminos con la fuente del recurso solicitado. Puede ser usado para abrir una comunicación tunel.
+El método **HTTP `CONNECT`** inicia la comunicación en dos caminos con la fuente del recurso solicitado. Puede ser usado para abrir una comunicación tunel.
 
 Por ejemplo, el método `CONNECT` puede ser usado para acceder a sitios web que usan {{Glossary("SSL")}} ({{Glossary("HTTPS")}}). El cliente realiza la petición al Servidor Proxy HTTP para establecer una conexión tunel hacia un destino deseado. Entonces el servidor Proxy procede a realizar la conexión en nombre del cliente, una vez establecida la conexión con el servidor deseado, el servidor Proxy envía los datos desde y hacia el cliente.
 
@@ -37,13 +37,11 @@ Proxy-Authorization: basic aGVsbG86d29ybGQ=
 
 ## Especificaciones
 
-| Specificación                                    | Título                                                        |
-| ------------------------------------------------ | ------------------------------------------------------------- |
-| {{RFC("7231", "CONNECT", "4.3.6")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-{{Compat("http.methods.CONNECT")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/http/methods/get/index.md
+++ b/files/es/web/http/methods/get/index.md
@@ -23,13 +23,11 @@ GET /index.html
 
 ## Especificaciones
 
-| Especificación                           | Título                                                        |
-| ---------------------------------------- | ------------------------------------------------------------- |
-| {{RFC("7231", "GET", "4.3.1")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
-## Compatibilidad con Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("http.methods.GET")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/http/methods/post/index.md
+++ b/files/es/web/http/methods/post/index.md
@@ -69,13 +69,11 @@ value2
 
 ## Especificaciones
 
-| Specification                                | Title                                                         |
-| -------------------------------------------- | ------------------------------------------------------------- |
-| {{RFC("7231", "POST", "4.3.3")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
-## Navegadores compatibles
+## Compatibilidad con navegadores
 
-{{Compat("http.methods.POST")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/http/methods/put/index.md
+++ b/files/es/web/http/methods/put/index.md
@@ -77,13 +77,11 @@ Content-Location: /existente.html
 
 ## Especificaciones
 
-| Specification                            | Title                                                         |
-| ---------------------------------------- | ------------------------------------------------------------- |
-| {{RFC("7231", "PUT", "4.3.4")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
-## Navegadores compatibles
+## Compatibilidad con navegadores
 
-{{Compat("http.methods.PUT")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/http/methods/trace/index.md
+++ b/files/es/web/http/methods/trace/index.md
@@ -25,13 +25,11 @@ TRACE /index.html
 
 ## Especificaciones
 
-| Specification                                | Title                                                         |
-| -------------------------------------------- | ------------------------------------------------------------- |
-| {{RFC("7231", "TRACE", "4.3.8")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
-## Compatibilidad con Buscadores
+## Compatibilidad con navegadores
 
-{{Compat("http.methods.TRACE")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/http/status/100/index.md
+++ b/files/es/web/http/status/100/index.md
@@ -17,13 +17,11 @@ Para que un servidor verifique los encabezados de la solicitud, un cliente debe 
 
 ## Especificaciones
 
-| Especificación                                           | Título                                                        |
-| -------------------------------------------------------- | ------------------------------------------------------------- |
-| {{RFC("7231", "100 Continue" , "6.2.1")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("http.status.100")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/http/status/200/index.md
+++ b/files/es/web/http/status/200/index.md
@@ -24,13 +24,11 @@ El resultado exitoso de un método {{HTTPMethod("PUT")}} o uno {{HTTPMethod("DEL
 
 ## Especificaciones
 
-| Especificaciones                                 | Titulo                                                        |
-| ------------------------------------------------ | ------------------------------------------------------------- |
-| {{RFC("7231", "200 OK" , "6.3.1")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("http.status.200")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/http/status/201/index.md
+++ b/files/es/web/http/status/201/index.md
@@ -15,13 +15,11 @@ El caso de uso común de este código de estado es el resultado de una solicitud
 
 ## Especificaciones
 
-| Especificacion                                       | Titulo                                                                       |
-| ---------------------------------------------------- | ---------------------------------------------------------------------------- |
-| {{RFC("7231", "201 Created" , "6.3.2")}} | Protocolo de transferencia de hipertexto (HTTP / 1.1): Semántica y contenido |
+{{Specifications}}
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-{{Compat("http.status.201")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/http/status/206/index.md
+++ b/files/es/web/http/status/206/index.md
@@ -56,13 +56,11 @@ Content-Range: bytes 4590-7999/8000
 
 ## Especificaciones
 
-| Specification                                                | Title                                                  |
-| ------------------------------------------------------------ | ------------------------------------------------------ |
-| {{RFC("7233", "206 Partial Content" , "4.1")}} | Hypertext Transfer Protocol (HTTP/1.1): Range Requests |
+{{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("http.status.206")}}
+{{Compat}}
 
 ## Mira también
 

--- a/files/es/web/http/status/302/index.md
+++ b/files/es/web/http/status/302/index.md
@@ -19,13 +19,11 @@ En casos en los que quieras que el método usado para cambiar a {{HTTPMethod("GE
 
 ## Especificaciones
 
-| Especificación                                       | Título                                                        |
-| ---------------------------------------------------- | ------------------------------------------------------------- |
-| {{RFC("7231", "302 Found" , "6.4.3")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
-## Compatibilidad navegadores
+## Compatibilidad con navegadores
 
-{{Compat("http.status.302")}}
+{{Compat}}
 
 ## Mira también
 

--- a/files/es/web/http/status/304/index.md
+++ b/files/es/web/http/status/304/index.md
@@ -15,17 +15,11 @@ El código HTTP de redirección **`304 Not Modified`** en el response de la peti
 
 ## Especificaciones
 
-| Especificación                                           | Título                                                       |
-| -------------------------------------------------------- | ------------------------------------------------------------ |
-| {{RFC("7232", "304 Not Modified" , "4.1")}} | Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests |
+{{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("http.status.304")}}
-
-## Notas de compatibilidad
-
-- Browser behavior differs if this response erroneously includes a body on persistent connections See [204 No Content](/es/docs/Web/HTTP/Status/204) for more detail.
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/http/status/401/index.md
+++ b/files/es/web/http/status/401/index.md
@@ -27,13 +27,11 @@ WWW-Authenticate: Basic realm="Access to staging site"
 
 ## Especificaciones
 
-| Specification                                            | Title                    |
-| -------------------------------------------------------- | ------------------------ |
-| {{RFC("7235", "401 Unauthorized" , "3.1")}} | HTTP/1.1: Authentication |
+{{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("http.status.401")}}
+{{Compat}}
 
 ## Vea también
 


### PR DESCRIPTION
This PR updates some of the browser compatibility data and specification sections for the Spanish locale. Part of work for #11594.

Note: this may also include other minor updates, such as removal of old sections or other small bits of cleanup.
