### PR TITLE
es: Update browser compat/spec sections (part 9)

### DIFF
--- a/files/es/web/http/status/404/index.md
+++ b/files/es/web/http/status/404/index.md
@@ -35,13 +35,11 @@ Para una pagina 404 de ejemplo, mire la pagina [MDN 404](/es/404).
 
 ## Especificaciones
 
-| Especificacion                                           | Titulo                                                         |
-| -------------------------------------------------------- | -------------------------------------------------------------- |
-| {{RFC("7231", "404 Not Found" , "6.5.4")}} | Hypertext Transfer Protocol (HTTP/1.1): Semanticas y contenido |
+{{Specifications}}
 
-## Compatibilidad con Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("http.status.404")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/http/status/418/index.md
+++ b/files/es/web/http/status/418/index.md
@@ -13,13 +13,11 @@ El código de error HTTP **`418 Soy una tetera`** indica que el servidor se rehu
 
 ## Especificaciones
 
-| Especificación                                               | Título                                                                     |
-| ------------------------------------------------------------ | -------------------------------------------------------------------------- |
-| {{RFC("2324", "418 I'm a teapot" , "2.3.2")}} | Hyper Text Coffee Pot Control Protocol (HTCPCP/1.0): Semantics and Content |
+{{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("http.status.418")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/http/status/502/index.md
+++ b/files/es/web/http/status/502/index.md
@@ -17,13 +17,11 @@ El código de respuesta de error del servidor de HTTP **`502 Bad Gateway`** indi
 
 ## Especificaciones
 
-| Especificación                                               | Título                                                        |
-| ------------------------------------------------------------ | ------------------------------------------------------------- |
-| {{RFC("7231", "502 Bad Gateway" , "6.6.3")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 
-{{Compat("http.status.502")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/http/status/503/index.md
+++ b/files/es/web/http/status/503/index.md
@@ -21,15 +21,11 @@ Debe tenerse cuidado con las cabeceras relacionadas con la caché, ya que un est
 
 ## Especificaciones
 
-| Especificación                                                       | Título                                                                     |
-| -------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| {{RFC("7231", "503 Service Unavailable" , "6.6.4")}} | Protocolo de Transferencia de HiperTexto (HTTP/1.1): Semántica y Contenido |
+{{Specifications}}
 
-## Compatibilidad entre Navegadores
+## Compatibilidad con navegadores
 
-La información mostrada abajo ha sido obtenida desde el GitHub de MDN (<https://github.com/mdn/browser-compat-data>).
-
-{{Compat("http.status.503")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/http/status/504/index.md
+++ b/files/es/web/http/status/504/index.md
@@ -15,15 +15,11 @@ El código de respuesta de error del servidor de HTTP **`504 Gateway Timeout`** 
 
 ## Especificaciones
 
-| Especificación                                                   | Título                                                        |
-| ---------------------------------------------------------------- | ------------------------------------------------------------- |
-| {{RFC("7231", "504 Gateway Timeout" , "6.6.4")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 
-La información que se muestra a continuación fue extraída de la de cuenta de Github de MDN (<https://github.com/mdn/browser-compat-data>).
-
-{{Compat("http.status.504")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/guide/modules/index.md
+++ b/files/es/web/javascript/guide/modules/index.md
@@ -16,17 +16,9 @@ Por lo tanto, en los últimos años se ha comenzado a pensar en proporcionar mec
 
 La buena noticia es que los navegadores modernos han comenzado a admitir la funcionalidad de los módulos de forma nativa, y de esto se trata este artículo. Esto solo puede ser algo bueno — los navegadores pueden optimizar la carga de módulos, haciéndolo más eficiente que tener que usar una biblioteca y hacer todo ese procesamiento adicional de lado del cliente, ahorrando viajes de ida y vuelta adicionales.
 
-## Soporte del navegador
+## Compatibilidad con navegadores
 
-El uso de módulos JavaScript nativos depende de las declaraciones {{jsxref("Statements/import", "import")}} y {{jsxref("Statements/export", "export")}}; estas son compatibles con los navegadores de la siguiente manera:
-
-### import
-
-{{Compat("javascript.statements.import")}}
-
-### export
-
-{{Compat("javascript.statements.export")}}
+{{Compat}}
 
 ## Introducción — un ejemplo
 

--- a/files/es/web/javascript/guide/regular_expressions/index.md
+++ b/files/es/web/javascript/guide/regular_expressions/index.md
@@ -332,12 +332,4 @@ function testInfo(phoneInput) {
 - [Visualizador de expresiones regulares](https://extendsclass.com/regex-tester.html)
   - : Un probador de expresiones regulares visual en línea.
 
-## Especificaciones
-
-{{Specifications}}
-
-## Compatibilidad con navegadores
-
-{{Compat}}
-
 {{PreviousNext("Web/JavaScript/Guide/Text_formatting", "Web/JavaScript/Guide/Indexed_collections")}}

--- a/files/es/web/javascript/guide/regular_expressions/index.md
+++ b/files/es/web/javascript/guide/regular_expressions/index.md
@@ -336,8 +336,8 @@ function testInfo(phoneInput) {
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.RegExp")}}
+{{Compat}}
 
 {{PreviousNext("Web/JavaScript/Guide/Text_formatting", "Web/JavaScript/Guide/Indexed_collections")}}

--- a/files/es/web/javascript/reference/classes/constructor/index.md
+++ b/files/es/web/javascript/reference/classes/constructor/index.md
@@ -72,11 +72,9 @@ constructor(...args) {
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.classes.constructor")}}
-
-La tabla de compatibilidad de esta pagina está generada a partir de data estructurada. Si quieres contribuir a la data, por favor dirígete a <https://github.com/mdn/browser-compat-data> y envíanos una solicitud de extracción
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/classes/extends/index.md
+++ b/files/es/web/javascript/reference/classes/extends/index.md
@@ -81,9 +81,9 @@ Object.getPrototypeOf(nullExtends.prototype) // null
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.classes.extends")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/classes/index.md
+++ b/files/es/web/javascript/reference/classes/index.md
@@ -314,9 +314,9 @@ class Bar extends calculatorMixin(randomizerMixin(Foo)) { }
 
 {{Specifications}}
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.classes")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/classes/private_class_fields/index.md
+++ b/files/es/web/javascript/reference/classes/private_class_fields/index.md
@@ -185,9 +185,9 @@ new ClassWithPrivateAccessor();
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("javascript.classes.private_class_fields")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/javascript/reference/classes/public_class_fields/index.md
+++ b/files/es/web/javascript/reference/classes/public_class_fields/index.md
@@ -379,19 +379,11 @@ new ClassWithPrivateAccessor();
 
 ## Especificaciones
 
-| Especificación                                                                            | Estado  | Comentario |
-| ----------------------------------------------------------------------------------------- | ------- | ---------- |
-| [FieldDefinition production](https://tc39.es/proposal-class-fields/#prod-FieldDefinition) | Stage 3 |            |
+{{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-### Campos públicos de clse
-
-{{Compat("javascript.classes.public_class_fields")}}
-
-### Campos privados de clase
-
-{{Compat("javascript.classes.private_class_fields")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/classes/static/index.md
+++ b/files/es/web/javascript/reference/classes/static/index.md
@@ -47,9 +47,9 @@ console.log(tp.tripple()); //Logs 'tp.tripple is not a function'.
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.classes.static")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/javascript/reference/global_objects/aggregateerror/index.md
+++ b/files/es/web/javascript/reference/global_objects/aggregateerror/index.md
@@ -54,9 +54,9 @@ try {
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.AggregateError")}}
+{{Compat}}
 
 ## Ve también
 

--- a/files/es/web/javascript/reference/global_objects/array/@@iterator/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/@@iterator/index.md
@@ -50,7 +50,7 @@ console.log(eArr.next().value); // p
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.@@iterator")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/@@species/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/@@species/index.md
@@ -45,7 +45,7 @@ class MyArray extends Array {
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.@@species")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/@@unscopables/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/@@unscopables/index.md
@@ -44,7 +44,7 @@ Object.keys(Array.prototype[Symbol.unscopables]);
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.@@unscopables")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/concat/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/concat/index.md
@@ -104,7 +104,7 @@ console.log(nums);
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.concat")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/copywithin/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/copywithin/index.md
@@ -138,7 +138,7 @@ if (!Array.prototype.copyWithin) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.copyWithin")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/entries/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/entries/index.md
@@ -40,7 +40,7 @@ for (let e of iterator) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.entries")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/every/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/every/index.md
@@ -153,7 +153,7 @@ if (!Array.prototype.every) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.every")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/fill/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/fill/index.md
@@ -111,7 +111,7 @@ if (!Array.prototype.fill) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.fill")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/filter/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/filter/index.md
@@ -193,7 +193,7 @@ if (!Array.prototype.filter){
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.filter")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/find/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/find/index.md
@@ -195,9 +195,9 @@ Si necesitas dar soporte a motores de JavaScript realmente obsoletos que no sopo
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.find")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/findindex/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/findindex/index.md
@@ -147,9 +147,9 @@ Si necesita soporte para motores de JavaScript obsoletos que no soportan [`Objec
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.findIndex")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/flat/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/flat/index.md
@@ -136,13 +136,11 @@ if (!Array.prototype.flat) {
 
 ## Especificaciones
 
-| Especificación                                                                                       | Estado         | Comentario |
-| ---------------------------------------------------------------------------------------------------- | -------------- | ---------- |
-| [`Array.prototype.flat` proposal](https://tc39.github.io/proposal-flatMap/#sec-Array.prototype.flat) | Finalizado (4) |            |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.flat")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/flatmap/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/flatmap/index.md
@@ -95,13 +95,11 @@ if (!Array.prototype.flatMap) {
 
 ## Especificaciones
 
-| Especificación                                                                                    | Estado         | Comentario |
-| ------------------------------------------------------------------------------------------------- | -------------- | ---------- |
-| [`Array.prototype.flatMap`](https://tc39.github.io/proposal-flatMap/#sec-Array.prototype.flatMap) | Finalizado (4) |            |
+{{Specifications}}
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.flatMap")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/foreach/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/foreach/index.md
@@ -211,7 +211,7 @@ if (!Array.prototype.forEach) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.forEach")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/global_objects/array/from/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/from/index.md
@@ -212,7 +212,7 @@ if (!Array.from) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.from")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/includes/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/includes/index.md
@@ -142,7 +142,7 @@ Si necesita admitir motores de JavaScript realmente obsoletos que no son compati
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.includes")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/index.md
@@ -411,7 +411,7 @@ da como resultado:
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/indexof/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/indexof/index.md
@@ -205,11 +205,7 @@ if (!Array.prototype.indexOf) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.indexOf")}}
-
-## Notas de compatibilidad
-
-- Comenzando con Firefox 47 (Firefox 47 / Thunderbird 47 / SeaMonkey 2.44), este método ya no devolverá `-0`. Por ejemplo, `[0] .indexOf (0, -0)` siempre devolverá `+0` ({{bug(1242043)}}).
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/isarray/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/isarray/index.md
@@ -94,7 +94,7 @@ if (!Array.isArray) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.isArray")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/global_objects/array/join/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/join/index.md
@@ -64,7 +64,7 @@ f(1, 'a', true);
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.join")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/keys/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/keys/index.md
@@ -50,7 +50,7 @@ console.log(denseKeys);  // [0, 1, 2]
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.keys")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/lastindexof/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/lastindexof/index.md
@@ -118,11 +118,7 @@ De nuevo, darse cuenta que esta implementación tiene como objeto la completa co
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.lastIndexOf")}}
-
-## Notas de compatibilidad
-
-- Desde Firefox 47 (Firefox 47 / Thunderbird 47 / SeaMonkey 2.44), el método ya no devolverá `-0`. Por ejemplo, `[0].lastIndexOf(0, -0)` siempre devolverá `+0` ({{bug(1242043)}}).
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/length/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/length/index.md
@@ -103,7 +103,7 @@ console.log(numbers.length); // 3
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.length")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/map/index.md
@@ -279,7 +279,7 @@ if (!Array.prototype.map) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.map")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/javascript/reference/global_objects/array/of/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/of/index.md
@@ -63,7 +63,7 @@ if (!Array.of) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.of")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/pop/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/pop/index.md
@@ -50,7 +50,7 @@ console.log(popped); // 'sturgeon'
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.pop")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/global_objects/array/push/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/push/index.md
@@ -92,9 +92,9 @@ Tenga en cuenta que aunque `obj` no es un array, el método `push` ha incrementa
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.push")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/reduce/index.md
@@ -179,7 +179,7 @@ var integrado = [[0,1], [2,3], [4,5]].reduce(function(a,b) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.reduce")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/reverse/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/reverse/index.md
@@ -45,9 +45,9 @@ console.log(a); // [3, 2, 1]
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.reverse")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/shift/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/shift/index.md
@@ -45,9 +45,9 @@ console.log('Elemento eliminado: ' + eliminado);
 
 {{Specifications}}
 
-## Navegadores compatibles
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.shift")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/slice/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/slice/index.md
@@ -211,9 +211,7 @@ El _shim_ también soluciona que IE pueda tratar con el caso de que el segundo a
 
 ## Compatibilidad con navegadores
 
-La tabla de compatibilidad en esta página esta generada desde datos estructurados. Si desea contribuir con los datos, por favor _"checkout"_ [https://github.com/mdn/browser-compat-data](https://github.com/mdn/browser-compat-data)y envíenos un _"pull request"_.
-
-{{Compat("javascript.builtins.Array.slice")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/some/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/some/index.md
@@ -160,9 +160,9 @@ if (!Array.prototype.some) {
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.some")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/sort/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/sort/index.md
@@ -220,13 +220,9 @@ var result = mapped.map(function(el){
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.sort")}}
-
-## Compatibilidad en navegadores
-
-La tabla de compatibilidad en esta página es generada por una data estructurada. Si deseas contribuir a la data, por favor entra a <https://github.com/mdn/browser-compat-data> y envíanos un pull request.
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/splice/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/splice/index.md
@@ -115,7 +115,7 @@ var removed = myFish.splice(2);
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.splice")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/tolocalestring/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/tolocalestring/index.md
@@ -142,7 +142,7 @@ Si necesitas soportar motores de JavaScript obsoletos que no compatibilizan con 
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.toLocaleString")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/tostring/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/tostring/index.md
@@ -26,19 +26,13 @@ El objeto {{jsxref("Array")}} sustituye al método `toString` de {{jsxref("Objec
 
 JavaScript llama al método `toString` automáticamente cuando un array va a ser representado como un valor de texto o cuando se referencia a un array en una concatenación de caracteres.
 
-### Semántica de ECMAScript 5
-
-Desde JavaScript 1.8.5 (Firefox 4), y consistente con la 5ª edición de semántica de ECMAScript, el método `toString()` es genérico y puede ser usado con cualquier objeto. {{jsxref("Object.prototype.toString()")}} será llamado y devolverá el valor resultante.
-
 ## Especificaciones
 
 {{Specifications}}
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.toString")}}
-
-\>
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/global_objects/array/unshift/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/unshift/index.md
@@ -50,9 +50,9 @@ arr.unshift([-3]);
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.unshift")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/array/values/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/values/index.md
@@ -48,7 +48,7 @@ for (let letra of iterador) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Array.values")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/global_objects/arraybuffer/@@species/index.md
+++ b/files/es/web/javascript/reference/global_objects/arraybuffer/@@species/index.md
@@ -41,7 +41,7 @@ class MyArrayBuffer extends ArrayBuffer {
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.ArrayBuffer.@@species")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/arraybuffer/bytelength/index.md
+++ b/files/es/web/javascript/reference/global_objects/arraybuffer/bytelength/index.md
@@ -33,7 +33,7 @@ buffer.byteLength; // 8
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.ArrayBuffer.byteLength")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/boolean/boolean/index.md
+++ b/files/es/web/javascript/reference/global_objects/boolean/boolean/index.md
@@ -50,9 +50,9 @@ var bObjProto = new Boolean({});
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Boolean.Boolean")}}
+{{Compat}}
 
 ## Ve también
 

--- a/files/es/web/javascript/reference/global_objects/boolean/index.md
+++ b/files/es/web/javascript/reference/global_objects/boolean/index.md
@@ -92,9 +92,9 @@ var bObjProto = new Boolean({});
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Boolean")}}
+{{Compat}}
 
 ## Ve también
 

--- a/files/es/web/javascript/reference/global_objects/date/getdate/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/getdate/index.md
@@ -41,7 +41,7 @@ console.log(day); // 25
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Date.getDate")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/javascript/reference/global_objects/date/getday/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/getday/index.md
@@ -41,7 +41,7 @@ console.log(weekday); // 1
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Date.getDay")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/date/getfullyear/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/getfullyear/index.md
@@ -43,7 +43,7 @@ var year = today.getFullYear();
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Date.getFullYear")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/date/gethours/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/gethours/index.md
@@ -35,9 +35,9 @@ console.log(hours); // 23
 
 {{Specifications}}
 
-## Compatibilidad de navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Date.getHours")}}
+{{Compat}}
 
 ## Ver tambien
 

--- a/files/es/web/javascript/reference/global_objects/date/getminutes/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/getminutes/index.md
@@ -41,7 +41,7 @@ console.log(minutos); // 15
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Date.getMinutes")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/date/getmonth/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/getmonth/index.md
@@ -41,9 +41,9 @@ console.log(mes); // 11
 
 {{Specifications}}
 
-## Compatibilidad
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Date.getMonth")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/global_objects/date/getseconds/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/getseconds/index.md
@@ -39,7 +39,7 @@ console.log(seconds); // 30
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Date.getSeconds")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/javascript/reference/global_objects/date/gettime/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/gettime/index.md
@@ -54,9 +54,9 @@ console.log('Operation took ' + (end.getTime() - start.getTime()) + ' msec');
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Date.getTime")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/date/getutcfullyear/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/getutcfullyear/index.md
@@ -37,9 +37,9 @@ var year = today.getUTCFullYear();
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Date.getUTCFullYear")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/date/setfullyear/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/setfullyear/index.md
@@ -48,7 +48,7 @@ theBigDay.setFullYear(1997);
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Date.setFullYear")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/date/setmonth/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/setmonth/index.md
@@ -55,9 +55,9 @@ console.log(endOfMonth); //Wed Mar 02 2016 00:00:00
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Date.setMonth")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/date/todatestring/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/todatestring/index.md
@@ -41,9 +41,9 @@ console.log(d.toDateString()); // logs Wed Jun 28 1993
 
 {{Specifications}}
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Date.toDateString")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/global_objects/date/toisostring/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/toisostring/index.md
@@ -66,7 +66,7 @@ if (!Date.prototype.toISOString) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Date.toISOString")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/date/tojson/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/tojson/index.md
@@ -41,9 +41,9 @@ console.log(jsonDate); //2015-10-26T07:46:36.611Z
 
 {{Specifications}}
 
-## Compatibilidad en buscadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Date.toJSON")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/date/tolocalestring/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/tolocalestring/index.md
@@ -140,9 +140,9 @@ When formatting large numbers of dates, it is better to create an {{jsxref("Glob
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Date.toLocaleString")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/javascript/reference/global_objects/date/tolocaletimestring/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/tolocaletimestring/index.md
@@ -121,7 +121,7 @@ Cuando se da formato a un gran número de fechas, es mejor crear un objeto {{jsx
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Date.toLocaleTimeString")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/date/toutcstring/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/toutcstring/index.md
@@ -52,9 +52,9 @@ var UTCstring = today.toUTCString(); // Wed, 14 Jun 2017 07:00:00 GMT
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Date.toUTCString")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/escape/index.md
+++ b/files/es/web/javascript/reference/global_objects/escape/index.md
@@ -51,7 +51,7 @@ escape('@*_+-./');    // "@*_+-./"
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.escape")}}
+{{Compat}}
 
 ## Ver más
 

--- a/files/es/web/javascript/reference/global_objects/function/apply/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/apply/index.md
@@ -138,9 +138,9 @@ Este método es especialmente útil cuando quieres depurar eventos, o interfaces
 
 {{Specifications}}
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Function.apply")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/javascript/reference/global_objects/function/bind/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/bind/index.md
@@ -218,9 +218,9 @@ Por favor checa <https://github.com/Raynos/function-bind> para ver una solución
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Function.bind")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/function/caller/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/caller/index.md
@@ -71,11 +71,11 @@ function myFunc() {
 
 ## Especificación
 
-No es parte de ninguna especificación. Se implementa en JavaScript 1.5.
+No es parte de ninguna especificación.
 
 ## Compatiblilidad de Navegadores
 
-{{Compat("javascript.builtins.Function.caller")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/javascript/reference/global_objects/function/displayname/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/displayname/index.md
@@ -68,10 +68,10 @@ a.displayName = 'My Function';
 a; // "function My Function()"
 ```
 
-## Specifications
+## Especificaciones
 
-Not part of any specification.
+No es parte de ninguna especificación.
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Function.displayName")}}
+{{Compat}}

--- a/files/es/web/javascript/reference/global_objects/function/function/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/function/index.md
@@ -56,9 +56,9 @@ Los argumentos "`a`" y "`b`" son nombres de argumentos formales que se utilizan 
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Function.Function")}}
+{{Compat}}
 
 ## Ve también
 

--- a/files/es/web/javascript/reference/global_objects/function/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/index.md
@@ -74,9 +74,9 @@ Si bien este código funciona en los navegadores web, `f1()` producirá un `Refe
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Function")}}
+{{Compat}}
 
 ## Ve también
 

--- a/files/es/web/javascript/reference/global_objects/function/length/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/length/index.md
@@ -42,7 +42,7 @@ console.log((function(a, b = 1, c) {}).length); /* 1, solo parámetros antes del
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Function.length")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/function/name/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/name/index.md
@@ -116,14 +116,10 @@ var b = new a();
 console.log(b.constructor.name); // imprime "a"
 ```
 
-## Polyfill
-
-Para versiones de IE < 9, se puede usar `fn._name()` en su lugar. Para IE9 o posteriores se puede usar el siguiente [polyfill](https://github.com/JamesMGreene/Function.name).
-
 ## Especificaciones
 
 {{Specifications}}
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Function.name")}}
+{{Compat}}

--- a/files/es/web/javascript/reference/global_objects/function/tostring/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/tostring/index.md
@@ -40,12 +40,7 @@ Function.prototype.toString.call(proxy); // TypeError
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Function.toString")}}
-
-## Notas específicas para Gecko
-
-- Desde Gecko 17.0 (Firefox 17 / Thunderbird 17 / SeaMonkey 2.14), `Function.prototype.toString()` fue implementada salvando el código fuente de la función. El descompilador fue eliminado, de modo que el parámetro `indentation` ya no se necesita más. Ver {{bug("761723")}} para más detalles.
-- A partir de Gecko 38 (Firefox 38 / Thunderbird 38 / SeaMonkey 2.35), `Function.prototype.toString()` produce error para objetos {{jsxref("Proxy")}} ({{bug(1100936)}}).
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/generator/index.md
+++ b/files/es/web/javascript/reference/global_objects/generator/index.md
@@ -99,7 +99,7 @@ console.log(it.next());   // throws StopIteration (as the generator is now close
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Generator")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/global_objects/generator/next/index.md
+++ b/files/es/web/javascript/reference/global_objects/generator/next/index.md
@@ -74,9 +74,9 @@ g.next(2);
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Generator.next")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/javascript/reference/global_objects/generator/return/index.md
+++ b/files/es/web/javascript/reference/global_objects/generator/return/index.md
@@ -67,7 +67,7 @@ g.return(1); // { value: 1, done: true }
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Generator.return")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/generator/throw/index.md
+++ b/files/es/web/javascript/reference/global_objects/generator/throw/index.md
@@ -59,9 +59,9 @@ g.throw(new Error('Something went wrong'));
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Generator.throw")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/javascript/reference/global_objects/intl/index.md
+++ b/files/es/web/javascript/reference/global_objects/intl/index.md
@@ -64,9 +64,9 @@ One property is supported by all language sensitive constructors and functions: 
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Intl")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/javascript/reference/global_objects/intl/numberformat/format/index.md
+++ b/files/es/web/javascript/reference/global_objects/intl/numberformat/format/index.md
@@ -54,9 +54,9 @@ console.log(formatted.join('; '));
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Intl.NumberFormat.format")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/javascript/reference/global_objects/intl/relativetimeformat/index.md
+++ b/files/es/web/javascript/reference/global_objects/intl/relativetimeformat/index.md
@@ -76,9 +76,9 @@ rtf.formatToParts(100, "day");
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Intl.RelativeTimeFormat")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/isfinite/index.md
+++ b/files/es/web/javascript/reference/global_objects/isfinite/index.md
@@ -46,7 +46,7 @@ isFinite("0");         // verdadero, hubiera sido falso en el caso de usar Numbe
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.isFinite")}}
+{{Compat}}
 
 ## Vea También
 

--- a/files/es/web/javascript/reference/global_objects/isnan/index.md
+++ b/files/es/web/javascript/reference/global_objects/isnan/index.md
@@ -46,9 +46,9 @@ isNaN(12) //devuelve false
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.isNaN")}}
+{{Compat}}
 
 ### Vea También
 

--- a/files/es/web/javascript/reference/global_objects/json/index.md
+++ b/files/es/web/javascript/reference/global_objects/json/index.md
@@ -121,7 +121,7 @@ Los objectos [JSON2](https://github.com/douglascrockford/JSON-js) y [JSON3](http
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.JSON")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/global_objects/json/parse/index.md
+++ b/files/es/web/javascript/reference/global_objects/json/parse/index.md
@@ -81,9 +81,9 @@ JSON.parse('{"foo" : 1, }');
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.JSON.parse")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/javascript/reference/global_objects/json/stringify/index.md
+++ b/files/es/web/javascript/reference/global_objects/json/stringify/index.md
@@ -225,7 +225,7 @@ console.log(restoredSession);
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.JSON.stringify")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/math/abs/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/abs/index.md
@@ -52,9 +52,9 @@ Math.abs();         // NaN
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.abs")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/math/acos/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/acos/index.md
@@ -50,9 +50,9 @@ Para valores menores que -1 o mayores que 1, `Math.acos()` devuelve {{jsxref("Na
 
 {{Specifications}}
 
-## Compatibilidad con navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.acos")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/math/acosh/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/acosh/index.md
@@ -57,9 +57,9 @@ Math.acosh = Math.acosh || function(x) {
 
 {{Specifications}}
 
-## Compatibilidad de navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.acosh")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/math/asin/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/asin/index.md
@@ -50,9 +50,9 @@ For values less than -1 or greater than 1, `Math.asin()` returns {{jsxref("NaN")
 
 {{Specifications}}
 
-## Compatibilidad con Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.asin")}}
+{{Compat}}
 
 ## Ver Mas
 

--- a/files/es/web/javascript/reference/global_objects/math/asinh/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/asinh/index.md
@@ -58,9 +58,9 @@ Been formally correct it suffers from a number of issues related to floating poi
 
 {{Specifications}}
 
-## Compatibilidades de buscadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.asinh")}}
+{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
This PR updates some of the browser compatibility data and specification sections for the Spanish locale. Part of work for #11594.

Note: this may also include other minor updates, such as removal of old sections or other small bits of cleanup.
