### PR TITLE
es: Update browser compat/spec sections (part 10)

### DIFF
--- a/files/es/web/javascript/reference/global_objects/math/atan/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/atan/index.md
@@ -57,9 +57,9 @@ Nota que podrías querer evitar usar **±**`Infinity` por razones de estilo. En 
 
 {{Specifications}}
 
-## Compatibilidad con el navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.atan")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/math/atan2/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/atan2/index.md
@@ -58,7 +58,7 @@ Math.atan2(±Infinity, +Infinity); // ±PI/4.
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.atan2")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/math/atanh/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/atanh/index.md
@@ -60,9 +60,9 @@ Para valores mayores a 1 o menores a -1, {{jsxref("NaN")}} retorna.
 
 {{Specifications}}
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.atanh")}}
+{{Compat}}
 
 ## Puedes leer
 

--- a/files/es/web/javascript/reference/global_objects/math/cbrt/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/cbrt/index.md
@@ -66,11 +66,9 @@ Math.cbrt(2);  // 1.2599210498948732
 
 {{Specifications}}
 
-## Compatibilidad
+## Compatibilidad con navegadores
 
-[and send us a pull request.](https://github.com/mdn/browser-compat-data)
-
-[{{Compat("javascript.builtins.Math.cbrt")}}](https://github.com/mdn/browser-compat-data)
+{{Compat}}
 
 ## Puedes leer
 

--- a/files/es/web/javascript/reference/global_objects/math/ceil/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/ceil/index.md
@@ -121,9 +121,9 @@ Math.ceil10(-59, 1);       // -50
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.ceil")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/math/cos/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/cos/index.md
@@ -49,9 +49,9 @@ Math.cos(2 * Math.PI); // 1
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.cos")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/math/e/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/e/index.md
@@ -38,7 +38,7 @@ getNapier(); // 2.718281828459045
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.E")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/math/exp/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/exp/index.md
@@ -41,7 +41,7 @@ Math.exp(1);  // 2.718281828459045
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.exp")}}
+{{Compat}}
 
 ## Ve también
 

--- a/files/es/web/javascript/reference/global_objects/math/expm1/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/expm1/index.md
@@ -53,9 +53,9 @@ Math.expm1 = Math.expm1 || function(x) {
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.expm1")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/global_objects/math/hypot/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/hypot/index.md
@@ -90,9 +90,9 @@ Math.hypot = function (x, y) {
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.hypot")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/math/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/index.md
@@ -152,7 +152,7 @@ console.log(Math.gcd(20, 30, 15, 70, 40)); // `5`
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/math/ln10/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/ln10/index.md
@@ -36,7 +36,7 @@ getNatLog10(); // 2.302585092994046
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.LN10")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/math/ln2/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/ln2/index.md
@@ -36,7 +36,7 @@ getNatLog2(); // 0.6931471805599453
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.LN2")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/math/log/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/log/index.md
@@ -64,9 +64,9 @@ If you run `getBaseLog(10, 1000)` it returns `2.9999999999999996` due to floatin
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.log")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/javascript/reference/global_objects/math/log10/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/log10/index.md
@@ -59,9 +59,9 @@ Math.log10 = Math.log10 || function(x) {
 
 {{Specifications}}
 
-## Compatibilidad con Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.log10")}}
+{{Compat}}
 
 ## Vea Tambien
 

--- a/files/es/web/javascript/reference/global_objects/math/log10e/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/log10e/index.md
@@ -32,9 +32,9 @@ getLog10e(); // 0.4342944819032518
 
 {{Specifications}}
 
-## Navegadores Compatibles
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.LOG10E")}}
+{{Compat}}
 
 ## Ver tambien
 

--- a/files/es/web/javascript/reference/global_objects/math/log2/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/log2/index.md
@@ -62,9 +62,9 @@ Math.log2 = Math.log2 || function(x) {
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.log2")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/javascript/reference/global_objects/math/min/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/min/index.md
@@ -64,7 +64,7 @@ var x = Math.min(f(foo), limite);
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.min")}}
+{{Compat}}
 
 ## Ver además
 

--- a/files/es/web/javascript/reference/global_objects/math/pi/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/pi/index.md
@@ -32,9 +32,9 @@ calculaCircunferencia(1);  // 6.283185307179586
 
 {{Specifications}}
 
-## Navegadores Compatibles
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.PI")}}
+{{Compat}}
 
 ## Ver tambien
 

--- a/files/es/web/javascript/reference/global_objects/math/pow/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/pow/index.md
@@ -59,7 +59,7 @@ Math.pow(-7, 1/3); // NaN
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.pow")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/math/round/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/round/index.md
@@ -131,9 +131,9 @@ Math.ceil10(-59, 1);       // -50
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.round")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/javascript/reference/global_objects/math/sign/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/sign/index.md
@@ -71,7 +71,7 @@ if (!Math.sign) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.sign")}}
+{{Compat}}
 
 ## Ver También
 

--- a/files/es/web/javascript/reference/global_objects/math/sin/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/sin/index.md
@@ -43,7 +43,7 @@ Math.sin(Math.PI / 2); // 1
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.sin")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/math/sqrt/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/sqrt/index.md
@@ -46,9 +46,9 @@ Math.sqrt(-1); // NaN
 
 {{Specifications}}
 
-## Compatibilidad
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.sqrt")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/math/sqrt1_2/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/sqrt1_2/index.md
@@ -30,9 +30,9 @@ getRoot1_2(); // 0.7071067811865476
 
 {{Specifications}}
 
-## Navegadores Compatibles
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.SQRT1_2")}}
+{{Compat}}
 
 ## Ver Tambien
 

--- a/files/es/web/javascript/reference/global_objects/math/sqrt2/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/sqrt2/index.md
@@ -32,9 +32,9 @@ getRoot2(); // 1.4142135623730951
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.SQRT2")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/math/tan/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/tan/index.md
@@ -54,9 +54,9 @@ function getTanDeg(deg) {
 
 {{Specifications}}
 
-## Compatibilidad con el navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.tan")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/math/tanh/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/tanh/index.md
@@ -58,7 +58,7 @@ Math.tanh = Math.tanh || function(x){
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.tanh")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/math/trunc/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/trunc/index.md
@@ -60,9 +60,9 @@ Math.trunc = Math.trunc || function (x) {
 
 {{Specifications}}
 
-## Compatibilidad con navegadores.
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Math.trunc")}}
+{{Compat}}
 
 ## Vea también.
 

--- a/files/es/web/javascript/reference/global_objects/number/isfinite/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/isfinite/index.md
@@ -57,9 +57,9 @@ Number.isFinite = Number.isFinite || function(value) {
 
 {{Specifications}}
 
-## Compatibilidad de navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Number.isFinite")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/number/isinteger/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/isinteger/index.md
@@ -63,9 +63,9 @@ Number.isInteger = Number.isInteger || function(value) {
 
 {{Specifications}}
 
-## Compatitibilidad con navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Number.isInteger")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/number/isnan/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/isnan/index.md
@@ -64,9 +64,9 @@ Number.isNaN = Number.isNaN || function(value) {
 
 {{Specifications}}
 
-## Compatibilidad de navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Number.isNaN")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/number/issafeinteger/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/issafeinteger/index.md
@@ -61,7 +61,7 @@ Number.isSafeInteger = Number.isSafeInteger || function (value) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Number.isSafeInteger")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/number/max_safe_integer/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/max_safe_integer/index.md
@@ -35,7 +35,7 @@ Math.pow(2, 53) - 1     // 9007199254740991
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Number.MAX_SAFE_INTEGER")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/number/max_value/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/max_value/index.md
@@ -40,9 +40,9 @@ verificarValorMaximo(numero2); // El número es infinito
 
 {{Specifications}}
 
-## Compatibilidad
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Number.MAX_VALUE")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/number/min_value/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/min_value/index.md
@@ -36,9 +36,9 @@ if (num1 / num2 >= Number.MIN_VALUE) {
 
 {{Specifications}}
 
-## Compatibilidad de navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Number.MIN_VALUE")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/number/nan/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/nan/index.md
@@ -35,9 +35,9 @@ See [Testing against NaN](/es/docs/Web/JavaScript/Reference/Global_Objects/NaN#T
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Number.NaN")}}
+{{Compat}}
 
 ## Tambien mira
 

--- a/files/es/web/javascript/reference/global_objects/number/negative_infinity/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/negative_infinity/index.md
@@ -51,7 +51,7 @@ if (smallNumber === Number.NEGATIVE_INFINITY) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Number.NEGATIVE_INFINITY")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/number/parseint/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/parseint/index.md
@@ -53,9 +53,9 @@ if (Number.parseInt === undefined) {
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Number.parseInt")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/javascript/reference/global_objects/number/positive_infinity/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/positive_infinity/index.md
@@ -50,7 +50,7 @@ if (bigNumber === Number.POSITIVE_INFINITY) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Number.POSITIVE_INFINITY")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/number/tofixed/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/tofixed/index.md
@@ -58,9 +58,9 @@ numObj.toFixed(6);      // Returns '12345.678900': note added zeros
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Number.toFixed")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/javascript/reference/global_objects/number/tolocalestring/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/tolocalestring/index.md
@@ -130,9 +130,9 @@ console.log(num.toLocaleString(undefined, {minimumFractionDigits: 2, maximumFrac
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Number.toLocaleString")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/number/toprecision/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/toprecision/index.md
@@ -59,9 +59,9 @@ console.log((1234.5).toPrecision(2)); // logs '1.2e+3'
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Number.toPrecision")}}
+{{Compat}}
 
 ## Vea También
 

--- a/files/es/web/javascript/reference/global_objects/number/valueof/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/valueof/index.md
@@ -39,9 +39,9 @@ console.log(typeof num);    // número
 
 {{Specifications}}
 
-## Compatibilidad con navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Number.valueOf")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/object/__definegetter__/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/__definegetter__/index.md
@@ -59,9 +59,9 @@ console.log(o.gimmeFive); // 5
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.defineGetter")}}
+{{Compat}}
 
 ## Mira también
 

--- a/files/es/web/javascript/reference/global_objects/object/assign/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/assign/index.md
@@ -250,7 +250,7 @@ if (typeof Object.assign != 'function') {
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.assign")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/object/constructor/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/constructor/index.md
@@ -87,6 +87,6 @@ console.log( types.join( "\n" ) );
 
 {{Specifications}}
 
-## Compatibilidad con Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.constructor")}}
+{{Compat}}

--- a/files/es/web/javascript/reference/global_objects/object/create/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/create/index.md
@@ -346,7 +346,7 @@ Note that while the setting of `null` as `[[Prototype]]` is supported in the rea
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.create")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/object/defineproperties/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/defineproperties/index.md
@@ -114,11 +114,9 @@ function defineProperties(obj, properties) {
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-Basado en [Kangax's compat tables](http://kangax.github.com/es5-compat-table/).
-
-{{Compat("javascript.builtins.Object.defineProperties")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/object/defineproperty/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/defineproperty/index.md
@@ -309,7 +309,7 @@ console.log(instance.myname); // this is my name string
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.defineProperty")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/javascript/reference/global_objects/object/entries/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/entries/index.md
@@ -79,9 +79,9 @@ To add compatible `Object.entries` support in older environments that do not nat
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.entries")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/javascript/reference/global_objects/object/freeze/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/freeze/index.md
@@ -140,9 +140,9 @@ TypeError: 1 is not an object // Código ES5
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.freeze")}}
+{{Compat}}
 
 ## Mira también
 

--- a/files/es/web/javascript/reference/global_objects/object/fromentries/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/fromentries/index.md
@@ -73,9 +73,9 @@ console.log(object2);
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.fromEntries")}}
+{{Compat}}
 
 ## Véase tambien
 

--- a/files/es/web/javascript/reference/global_objects/object/getownpropertydescriptor/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/getownpropertydescriptor/index.md
@@ -81,7 +81,7 @@ Object.getOwnPropertyDescriptor("foo", 0);
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.getOwnPropertyDescriptor")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/object/getownpropertydescriptors/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/getownpropertydescriptors/index.md
@@ -79,9 +79,9 @@ subclass.prototype = Object.create(
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.getOwnPropertyDescriptors")}}
+{{Compat}}
 
 ## Ver también:
 

--- a/files/es/web/javascript/reference/global_objects/object/getownpropertynames/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/getownpropertynames/index.md
@@ -101,9 +101,9 @@ console.log(nonenum_only);
 
 {{Specifications}}
 
-## Compatibilidad con Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.getOwnPropertyNames")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/object/getownpropertysymbols/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/getownpropertysymbols/index.md
@@ -48,7 +48,7 @@ console.log(objectSymbols[0]);     // Symbol(a)
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.getOwnPropertySymbols")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/object/getprototypeof/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/getprototypeof/index.md
@@ -50,7 +50,7 @@ String.prototype                   // ES6 code
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.getPrototypeOf")}}
+{{Compat}}
 
 ## Mira también
 

--- a/files/es/web/javascript/reference/global_objects/object/hasownproperty/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/hasownproperty/index.md
@@ -103,9 +103,9 @@ Observe que en el último caso no han habido nuevos objetos creados.
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.hasOwnProperty")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/javascript/reference/global_objects/object/is/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/is/index.md
@@ -88,9 +88,9 @@ if (!Object.is) {
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.is")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/object/isextensible/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/isextensible/index.md
@@ -61,7 +61,7 @@ Object.isExtensible(1);
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.isExtensible")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/object/isfrozen/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/isfrozen/index.md
@@ -106,7 +106,7 @@ Object.isFrozen(1);
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.isFrozen")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/object/isprototypeof/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/isprototypeof/index.md
@@ -69,7 +69,7 @@ Esto, junto con el operador {{jsxref("Operators/instanceof", "instanceof")}} res
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.isPrototypeOf")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/object/issealed/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/issealed/index.md
@@ -93,9 +93,9 @@ Object.isSealed(1);
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.isSealed")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/javascript/reference/global_objects/object/keys/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/keys/index.md
@@ -122,7 +122,7 @@ Para un simple Polyfill del Navegador, mira [Javascript - Compatibilidad de Obje
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.keys")}}
+{{Compat}}
 
 ## Mira también
 

--- a/files/es/web/javascript/reference/global_objects/object/preventextensions/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/preventextensions/index.md
@@ -80,9 +80,9 @@ Object.preventExtensions(1);
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.preventExtensions")}}
+{{Compat}}
 
 ## Mira también
 

--- a/files/es/web/javascript/reference/global_objects/object/propertyisenumerable/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/propertyisenumerable/index.md
@@ -95,9 +95,9 @@ o.propertyIsEnumerable('firstMethod'); // regresa false
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.propertyIsEnumerable")}}
+{{Compat}}
 
 ## Notas específicas para Gecko
 

--- a/files/es/web/javascript/reference/global_objects/object/proto/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/proto/index.md
@@ -46,9 +46,9 @@ La propiedad `__proto__` es una simple propiedad de acceso a {{jsxref("Object.pr
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.proto")}}
+{{Compat}}
 
 ## Notas de compatibilidad
 

--- a/files/es/web/javascript/reference/global_objects/object/seal/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/seal/index.md
@@ -86,7 +86,7 @@ Object.seal(1);
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.seal")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/object/setprototypeof/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/setprototypeof/index.md
@@ -161,9 +161,9 @@ george(); // 'Hello guys!!'
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.setPrototypeOf")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/object/tolocalestring/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/tolocalestring/index.md
@@ -89,7 +89,7 @@ let numeroFrances = unNumero.toLocaleString('fr');
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.toLocaleString")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/object/valueof/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/valueof/index.md
@@ -69,9 +69,9 @@ myObj + 3; // 7
 
 {{Specifications}}
 
-## Compatibilidad con Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.valueOf")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/global_objects/object/values/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/values/index.md
@@ -60,9 +60,9 @@ Para dar soporte compatible con `Object.values()` a entornos antiguos que no la 
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Object.values")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/promise/all/index.md
+++ b/files/es/web/javascript/reference/global_objects/promise/all/index.md
@@ -90,9 +90,9 @@ Promise.all([p1, p2, p3, p4, p5]).then(values => {
 
 {{Specifications}}
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript/promise","Promise.all")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/global_objects/promise/finally/index.md
+++ b/files/es/web/javascript/reference/global_objects/promise/finally/index.md
@@ -63,9 +63,9 @@ fetch(myRequest).then(function(response) {
 
 {{Specifications}}
 
-## Compatibilidad en navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Promise.finally")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/promise/reject/index.md
+++ b/files/es/web/javascript/reference/global_objects/promise/reject/index.md
@@ -45,9 +45,9 @@ Promise.reject(new Error('fail')).then(function() {
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Promise.reject")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/promise/resolve/index.md
+++ b/files/es/web/javascript/reference/global_objects/promise/resolve/index.md
@@ -121,7 +121,7 @@ p3.then(function(v) {
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Promise.resolve")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/javascript/reference/global_objects/promise/then/index.md
+++ b/files/es/web/javascript/reference/global_objects/promise/then/index.md
@@ -277,9 +277,9 @@ const nextTick = (() => {
 
 {{Specifications}}
 
-## Compatibilidad en navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript/promise","Promise.prototype.then")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/proxy/proxy/getownpropertydescriptor/index.md
+++ b/files/es/web/javascript/reference/global_objects/proxy/proxy/getownpropertydescriptor/index.md
@@ -84,9 +84,9 @@ Object.getOwnPropertyDescriptor(p, 'a'); // TypeError is thrown
 
 {{Specifications}}
 
-## Compatibilidad con buscadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Proxy.handler.getOwnPropertyDescriptor")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/proxy/proxy/set/index.md
+++ b/files/es/web/javascript/reference/global_objects/proxy/proxy/set/index.md
@@ -80,9 +80,9 @@ console.log(p.a)       // 10
 
 {{Specifications}}
 
-## Compatibilidad con los buscadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Proxy.handler.set")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/referenceerror/index.md
+++ b/files/es/web/javascript/reference/global_objects/referenceerror/index.md
@@ -66,9 +66,9 @@ try {
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.ReferenceError")}}
+{{Compat}}
 
 ## Ve también
 

--- a/files/es/web/javascript/reference/global_objects/reflect/index.md
+++ b/files/es/web/javascript/reference/global_objects/reflect/index.md
@@ -46,9 +46,9 @@ El objeto `Reflect` proporciona las siguientes funciones estáticas con los mism
 
 {{Specifications}}
 
-## Compatibilidad en Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Reflect")}}
+{{Compat}}
 
 ## También ver
 

--- a/files/es/web/javascript/reference/global_objects/reflect/set/index.md
+++ b/files/es/web/javascript/reference/global_objects/reflect/set/index.md
@@ -68,7 +68,7 @@ Reflect.getOwnPropertyDescriptor(obj, 'undefined');
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Reflect.set")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/regexp/compile/index.md
+++ b/files/es/web/javascript/reference/global_objects/regexp/compile/index.md
@@ -48,9 +48,9 @@ regexObj.compile('new foo', 'g');
 
 {{Specifications}}
 
-## Compatiblidad con navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.RegExp.compile")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/regexp/exec/index.md
+++ b/files/es/web/javascript/reference/global_objects/regexp/exec/index.md
@@ -160,9 +160,9 @@ Esto logueará un mensaje que contiene 'hola mundo!'.
 
 {{Specifications}}
 
-## Compatiblidad con navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.RegExp.exec")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/regexp/ignorecase/index.md
+++ b/files/es/web/javascript/reference/global_objects/regexp/ignorecase/index.md
@@ -30,9 +30,9 @@ console.log(regex.ignoreCase); // true
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.RegExp.ignoreCase")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/regexp/index.md
+++ b/files/es/web/javascript/reference/global_objects/regexp/index.md
@@ -214,6 +214,26 @@ console.log(/[^.]+/.exec(url)[0].substr(7)) // registra 'xxx'
 
 {{Compat}}
 
+### Notas específicas de Firefox
+
+A partir de Firefox 34, en el caso de un grupo de captura con cuantificadores que impiden su ejercicio, el texto coincidente para un grupo de captura ahora es `undefined` en lugar de una cadena vacía:
+
+```js
+// Firefox 33 o anterior
+'x'.replace(/x(.)?/g, function(m, group) {
+  console.log("'grupo: " + group + "'");
+});
+// 'grupo: '
+
+// Firefox 34 o más reciente
+'x'.replace(/x(.)?/g, function(m, group) {
+  console.log("'grupo: " + group + "'");
+});
+// 'grupo: undefined'
+```
+
+Ten en cuenta que, debido a la compatibilidad web, `RegExp.$N` seguirá devolviendo una cadena vacía en lugar de `undefined` ({{bug(1053944)}}).
+
 ## Ve también
 
 - El capítulo de {{JSxRef("Guide/Regular_Expressions", "Expresiones regulares")}} en la {{JSxRef("Guide", "Guía de JavaScript")}}

--- a/files/es/web/javascript/reference/global_objects/regexp/index.md
+++ b/files/es/web/javascript/reference/global_objects/regexp/index.md
@@ -210,29 +210,9 @@ console.log(/[^.]+/.exec(url)[0].substr(7)) // registra 'xxx'
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.RegExp")}}
-
-### Notas específicas de Firefox
-
-A partir de Firefox 34, en el caso de un grupo de captura con cuantificadores que impiden su ejercicio, el texto coincidente para un grupo de captura ahora es `undefined` en lugar de una cadena vacía:
-
-```js
-// Firefox 33 o anterior
-'x'.replace(/x(.)?/g, function(m, group) {
-  console.log("'grupo: " + group + "'");
-});
-// 'grupo: '
-
-// Firefox 34 o más reciente
-'x'.replace(/x(.)?/g, function(m, group) {
-  console.log("'grupo: " + group + "'");
-});
-// 'grupo: undefined'
-```
-
-Ten en cuenta que, debido a la compatibilidad web, `RegExp.$N` seguirá devolviendo una cadena vacía en lugar de `undefined` ({{bug(1053944)}}).
+{{Compat}}
 
 ## Ve también
 

--- a/files/es/web/javascript/reference/global_objects/regexp/regexp/index.md
+++ b/files/es/web/javascript/reference/global_objects/regexp/regexp/index.md
@@ -78,9 +78,9 @@ El constructor del objeto de expresión regular, por ejemplo, `new RegExp('ab+c'
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.RegExp.RegExp")}}
+{{Compat}}
 
 ## Ve también
 

--- a/files/es/web/javascript/reference/global_objects/regexp/rightcontext/index.md
+++ b/files/es/web/javascript/reference/global_objects/regexp/rightcontext/index.md
@@ -36,11 +36,11 @@ RegExp["$'"];       // " mundo!"
 
 ## Especificaciones
 
-No estándar. No forma parte de ninguna especificación actual.
+{{Specifications}}
 
-## Navegadores compactibles
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.RegExp.rightContext")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/regexp/test/index.md
+++ b/files/es/web/javascript/reference/global_objects/regexp/test/index.md
@@ -59,9 +59,9 @@ function probarEntrada(regexp, cadena){
 
 {{Specifications}}
 
-## Compatibilidad en Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.RegExp.test")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/global_objects/regexp/tostring/index.md
+++ b/files/es/web/javascript/reference/global_objects/regexp/tostring/index.md
@@ -51,9 +51,9 @@ new RegExp('\n').toString() === "/\\n/"; // true, desde ES5
 
 {{Specifications}}
 
-## Compatibilidad en Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.RegExp.toString")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/global_objects/string/concat/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/concat/index.md
@@ -62,7 +62,7 @@ let greetList = ['Hello', ' ', 'Venkat', '!']
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.String.concat")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/string/fontcolor/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/fontcolor/index.md
@@ -53,7 +53,7 @@ document.getElementById('yourElemId').style.color = 'red';
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.String.fontcolor")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/string/fontsize/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/fontsize/index.md
@@ -51,9 +51,9 @@ document.getElementById('yourElemId').style.fontSize = '0.7em';
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.String.fontsize")}}
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/javascript/reference/global_objects/string/repeat/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/repeat/index.md
@@ -94,6 +94,6 @@ if (!String.prototype.repeat) {
 
 {{Specifications}}
 
-## Compatibilidad en Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.String.repeat")}}
+{{Compat}}

--- a/files/es/web/javascript/reference/global_objects/string/split/index.md
+++ b/files/es/web/javascript/reference/global_objects/string/split/index.md
@@ -146,9 +146,9 @@ var strReverse = str.split('').reverse().join(''); // 'lkjhgfdsa'
 
 {{Specifications}}
 
-## Compatibilidad con los navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.String.split")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/global_objects/typedarray/buffer/index.md
+++ b/files/es/web/javascript/reference/global_objects/typedarray/buffer/index.md
@@ -32,9 +32,9 @@ uint16.buffer; // ArrayBuffer { byteLength: 8 }
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.TypedArray.buffer")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/javascript/reference/global_objects/typedarray/index.md
+++ b/files/es/web/javascript/reference/global_objects/typedarray/index.md
@@ -190,9 +190,9 @@ Int8Array.prototype.foo = 'bar';
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.TypedArray")}}
+{{Compat}}
 
 ## Ve también
 

--- a/files/es/web/javascript/reference/global_objects/uint8array/index.md
+++ b/files/es/web/javascript/reference/global_objects/uint8array/index.md
@@ -139,23 +139,9 @@ var z = new Uint8Array(buffer, 1, 4);
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Uint8Array")}}
-
-## Notas de compatibilidad
-
-A partir de ECMAScript 2015 (ES6), los constructors de `Uint8Array` requiren ser construidos con un operador {{jsxref("Operators/new", "new")}}. Llamar a un contructor de `Uint8Array` como una función sin `new`, lanzará un {{jsxref("TypeError")}} de ahora en adelante.
-
-```js example-bad
-var dv = Uint8Array([1, 2, 3]);
-// TypeError: calling a builtin Uint8Array constructor
-// without new is forbidden
-```
-
-```js example-good
-var dv = new Uint8Array([1, 2, 3]);
-```
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/javascript/reference/global_objects/undefined/index.md
+++ b/files/es/web/javascript/reference/global_objects/undefined/index.md
@@ -104,6 +104,6 @@ if (y === void 0) {
 
 {{Specifications}}
 
-## Compatibilidad en Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.undefined")}}
+{{Compat}}


### PR DESCRIPTION
This PR updates some of the browser compatibility data and specification sections for the Spanish locale. Part of work for #11594.

Note: this may also include other minor updates, such as removal of old sections or other small bits of cleanup.
