### PR TITLE
es: Update browser compat/spec sections (part 11)

### DIFF
--- a/files/es/web/javascript/reference/global_objects/weakmap/delete/index.md
+++ b/files/es/web/javascript/reference/global_objects/weakmap/delete/index.md
@@ -42,11 +42,7 @@ wm.has(window);    // Devuelve false. El elemento window ya no es parte de WeakM
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.WeakMap.delete")}}
-
-## Notas especificas de Firefox
-
-- Anterior a SpiderMonkey 38 (Firefox 38 / Thunderbird 38 / SeaMonkey 2.35), este método lanzaba {{jsxref("TypeError")}} cuando el parámetro `key` no era un objeto. Esto ha sido corregido en la versión 38 y posteriormente devuelve `false` como parte del estándar de ES6 ({{bug(1127827)}}).
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/global_objects/weakmap/get/index.md
+++ b/files/es/web/javascript/reference/global_objects/weakmap/get/index.md
@@ -43,7 +43,7 @@ wm.get('baz');  // Devuelve undefined.
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.WeakMap.get")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/global_objects/weakmap/has/index.md
+++ b/files/es/web/javascript/reference/global_objects/weakmap/has/index.md
@@ -44,7 +44,7 @@ wm.has('baz');  // Devuelve false
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.WeakMap.has")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/global_objects/weakmap/set/index.md
+++ b/files/es/web/javascript/reference/global_objects/weakmap/set/index.md
@@ -47,11 +47,7 @@ wm.set(obj, 'baz');
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.WeakMap.set")}}
-
-## Notas específicas de Firefox
-
-- Antes de Firefox 33 (Firefox 33 / Thunderbird 33 / SeaMonkey 2.30), `WeakMap.prototype.set` devolvía `undefined` y no permitía el encadenamiento. Esto ha sido corregido ({{bug(1031632)}}). Este comportamiento puede encontrarse también en Chrome/v8 ([fallo](https://code.google.com/p/v8/issues/detail?id=3410)).
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/lexical_grammar/index.md
+++ b/files/es/web/javascript/reference/lexical_grammar/index.md
@@ -535,9 +535,9 @@ a + b;
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.grammar")}}
+{{Compat}}
 
 ## Ve también
 

--- a/files/es/web/javascript/reference/operators/addition/index.md
+++ b/files/es/web/javascript/reference/operators/addition/index.md
@@ -50,9 +50,9 @@ false + false // 0
 
 {{Specifications}}
 
-## Compatibilidad de Explorador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.operators.addition")}}
+{{Compat}}
 
 ## También revisa
 

--- a/files/es/web/javascript/reference/operators/assignment/index.md
+++ b/files/es/web/javascript/reference/operators/assignment/index.md
@@ -34,9 +34,9 @@ x = n = z // x = n (es decir 10) y z pisa el valor total remplazandolo por 25
 
 {{Specifications}}
 
-## Compatibilidad con Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.operators.assignment")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/operators/await/index.md
+++ b/files/es/web/javascript/reference/operators/await/index.md
@@ -74,7 +74,7 @@ f3();
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.operators.await")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/javascript/reference/operators/class/index.md
+++ b/files/es/web/javascript/reference/operators/class/index.md
@@ -75,9 +75,9 @@ Foo.name; // "NamedFoo"
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.operators.class")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/operators/comma_operator/index.md
+++ b/files/es/web/javascript/reference/operators/comma_operator/index.md
@@ -46,11 +46,11 @@ function myFunc () {
 
 ## Especificaciones
 
-{{Specificaciones}}
+{{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.operators.comma")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/operators/conditional_operator/index.md
+++ b/files/es/web/javascript/reference/operators/conditional_operator/index.md
@@ -89,9 +89,9 @@ location.assign(url); // "stop.html"
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.operators.conditional")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/javascript/reference/operators/decrement/index.md
+++ b/files/es/web/javascript/reference/operators/decrement/index.md
@@ -50,7 +50,7 @@ b = --a;
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.operators.decrement")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/operators/destructuring_assignment/index.md
+++ b/files/es/web/javascript/reference/operators/destructuring_assignment/index.md
@@ -435,9 +435,9 @@ const {self, prot} = obj;
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.operators.destructuring")}}
+{{Compat}}
 
 ## Ve también
 

--- a/files/es/web/javascript/reference/operators/division/index.md
+++ b/files/es/web/javascript/reference/operators/division/index.md
@@ -42,9 +42,9 @@ Math.floor(3 / 2) // 1
 
 {{Specifications}}
 
-## Compatibilidad con Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.operators.division")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/operators/equality/index.md
+++ b/files/es/web/javascript/reference/operators/equality/index.md
@@ -102,9 +102,9 @@ console.log(d == s);    //true
 
 {{Specifications}}
 
-## Compatibilidad con Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.operators.equality")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/operators/grouping/index.md
+++ b/files/es/web/javascript/reference/operators/grouping/index.md
@@ -44,9 +44,9 @@ a * c + b * c // 9
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.operators.grouping")}}
+{{Compat}}
 
 ## Temas relacionados
 

--- a/files/es/web/javascript/reference/operators/in/index.md
+++ b/files/es/web/javascript/reference/operators/in/index.md
@@ -93,9 +93,9 @@ El operador `in` devuelve `true` para propiedades en la cadena del prototipo.
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.operators.in")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/operators/index.md
+++ b/files/es/web/javascript/reference/operators/index.md
@@ -221,9 +221,9 @@ Un operador de asignación asigna un valor a su operando izquierdo basándose en
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.operators")}}
+{{Compat}}
 
 ## Ve también
 

--- a/files/es/web/javascript/reference/operators/new.target/index.md
+++ b/files/es/web/javascript/reference/operators/new.target/index.md
@@ -57,9 +57,9 @@ var b = new B(); // escribe en el log "B"
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.operators.new_target")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/operators/new/index.md
+++ b/files/es/web/javascript/reference/operators/new/index.md
@@ -146,9 +146,9 @@ car2.owner.name
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.operators.new")}}
+{{Compat}}
 
 ## Ve también
 

--- a/files/es/web/javascript/reference/operators/optional_chaining/index.md
+++ b/files/es/web/javascript/reference/operators/optional_chaining/index.md
@@ -171,9 +171,9 @@ console.log(customerCity); // Unknown city
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.operators.optional_chaining")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/operators/remainder/index.md
+++ b/files/es/web/javascript/reference/operators/remainder/index.md
@@ -60,7 +60,7 @@ Infinity % Infinity // NaN
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.operators.remainder")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/operators/spread_syntax/index.md
+++ b/files/es/web/javascript/reference/operators/spread_syntax/index.md
@@ -223,9 +223,9 @@ La sintaxis Rest luce exactamente como la sintaxis spread, pero esto es usado po
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.operators.spread")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/operators/strict_equality/index.md
+++ b/files/es/web/javascript/reference/operators/strict_equality/index.md
@@ -78,9 +78,9 @@ console.log(object1 === object1);  // true
 
 {{Specifications}}
 
-## Compatibilidad entre exploradores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.operators.strict_equality")}}
+{{Compat}}
 
 ## También revisa
 

--- a/files/es/web/javascript/reference/operators/subtraction/index.md
+++ b/files/es/web/javascript/reference/operators/subtraction/index.md
@@ -35,9 +35,9 @@ Operator: x - y
 
 {{Specifications}}
 
-## Compatibilidad entre exploradores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.operators.subtraction")}}
+{{Compat}}
 
 ## También revisa
 

--- a/files/es/web/javascript/reference/operators/super/index.md
+++ b/files/es/web/javascript/reference/operators/super/index.md
@@ -153,7 +153,7 @@ obj2.method2(); // logs "method 1"
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.operators.super")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/operators/yield/index.md
+++ b/files/es/web/javascript/reference/operators/yield/index.md
@@ -95,9 +95,9 @@ console.log(generatorFunc.next(10).value); // 26
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.operators.yield")}}
+{{Compat}}
 
 ## Ve también
 

--- a/files/es/web/javascript/reference/operators/yield_star_/index.md
+++ b/files/es/web/javascript/reference/operators/yield_star_/index.md
@@ -107,20 +107,7 @@ console.log(result);          // "foo"
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.operators.yield_star")}}
-
-## Notas específicas de Firefox
-
-- Iniciando con Gecko 33 (Firefox 33 / Thunderbird 33 / SeaMonkey 2.30), el análisis del yield expression ha sido actualizado para cumplir con la última especificación ES6 ({{bug(981599)}}):
-
-  - Ahora está implementada la restricción de salto de línea. No está permitido el salto de línea entre "yield" y "\*". Código como el siguiente lanzará una {{jsxref("SyntaxError")}}:
-
-    ```js
-    function* foo() {
-      yield
-      *[];
-    }
-    ```
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/statements/async_function/index.md
+++ b/files/es/web/javascript/reference/statements/async_function/index.md
@@ -123,9 +123,9 @@ Observe que, en el ejemplo anterior, no hay ninguna instrucción `await` dentro 
 
 {{Specifications}}
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.statements.async_function")}}
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/javascript/reference/statements/class/index.md
+++ b/files/es/web/javascript/reference/statements/class/index.md
@@ -51,9 +51,9 @@ class Square extends Polygon {
 
 {{Specifications}}
 
-## Compatibilidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.statements.class")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/statements/debugger/index.md
+++ b/files/es/web/javascript/reference/statements/debugger/index.md
@@ -36,7 +36,7 @@ Cuando el depurador es invocado, la ejecución se detiene en la sentencia debugg
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.statements.debugger")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/statements/empty/index.md
+++ b/files/es/web/javascript/reference/statements/empty/index.md
@@ -51,9 +51,9 @@ console.log(b); // 0
 
 {{Specifications}}
 
-## Compatibilidad en Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.statements.empty")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/statements/export/index.md
+++ b/files/es/web/javascript/reference/statements/export/index.md
@@ -153,9 +153,9 @@ Tenga en cuenta que no es posible usar `var`, `let` o `const` con `export defaul
 
 {{Specifications}}
 
-## Compatiblidad en navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.statements.export")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/statements/for-await...of/index.md
+++ b/files/es/web/javascript/reference/statements/for-await...of/index.md
@@ -115,9 +115,9 @@ getResponseSize('https://jsonplaceholder.typicode.com/photos');
 
 {{Specifications}}
 
-## Compatibilidad de Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.statements.for_await_of")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/statements/for...in/index.md
+++ b/files/es/web/javascript/reference/statements/for...in/index.md
@@ -102,27 +102,9 @@ for (const prop in obj) {
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.statements.for_in")}}
-
-### Compatibilidad: expresiones iniciadoras en modo estricto
-
-Antes de Firefox 40, era posible utilizar una expresión iniciadora (`i=0`) en un bucle `for...in`:
-
-```js example-bad
-var obj = {a: 1, b: 2, c: 3};
-for (var i = 0 in obj) {
-  console.log(obj[i]);
-}
-// 1
-// 2
-// 3
-```
-
-Este comportamiento no estándar ahora se ignora en la versión 40 y posteriores, y presentará un {{JSxRef("SyntaxError")}} ("{{JSxRef("errors/Invalid_for-in_initializer", "iniciador for...in no válido", "las declaraciones de encabezado del bucle for-in posiblemente no tengan iniciadores")}} en {{JSxRef("Strict_mode", "modo estricto")}} ({{bug(748550)}} y {{bug(1164741)}}").
-
-Otros motores como v8 (Chrome), Chakra (IE/Edge) y JSC (WebKit/Safari) están investigando si eliminar también el comportamiento no estándar.
+{{Compat}}
 
 ## Ve también
 

--- a/files/es/web/javascript/reference/statements/for...of/index.md
+++ b/files/es/web/javascript/reference/statements/for...of/index.md
@@ -246,9 +246,9 @@ for (let i of arr) {
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.statements.for_of")}}
+{{Compat}}
 
 ## Vea también
 

--- a/files/es/web/javascript/reference/statements/function_star_/index.md
+++ b/files/es/web/javascript/reference/statements/function_star_/index.md
@@ -83,7 +83,7 @@ console.log(gen.next().value); // 20
 
 ## Compatibilidad con navegadores
 
-{{Compat("javascript.statements.generator_function")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/statements/import/index.md
+++ b/files/es/web/javascript/reference/statements/import/index.md
@@ -155,11 +155,9 @@ getUsefulContents('http://www.example.com',
 
 {{Specifications}}
 
-## Compatibilidad entre navegadores
+## Compatibilidad con navegadores
 
-The compatibility table on this page is generated from structured data. If you'd like to contribute to the data, please check out <https://github.com/mdn/browser-compat-data> and send us a pull request.
-
-{{Compat("javascript.statements.import")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/statements/switch/index.md
+++ b/files/es/web/javascript/reference/statements/switch/index.md
@@ -188,13 +188,13 @@ La salida (output) de este ejemplo:
 | 4                                      | Salida: ?                                  |
 | 5                                      | Salida: !                                  |
 
-### Variables centradas en bloques sin un estamento de switch
+## Especificaciones
 
-Con ECMAScript 2015 (ES6)
+{{Specifications}}
 
-## Compatibilidad en Navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.statements.switch")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/reference/template_literals/index.md
+++ b/files/es/web/javascript/reference/template_literals/index.md
@@ -258,9 +258,9 @@ let bad = `bad escape sequence: \unicode`;
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("javascript.grammar.template_literals")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/javascript/typed_arrays/index.md
+++ b/files/es/web/javascript/typed_arrays/index.md
@@ -157,14 +157,6 @@ normalArray.length === 4;
 normalArray.constructor === Array;
 ```
 
-## Especificaciones
-
-{{Specifications}}
-
-## Compatibilidad con navegadores
-
-{{Compat}}
-
 ## Ve también
 
 - [Conseguir ArrayBuffers o arreglos tipados a partir de cadenas codificadas en Base64](/es/docs/Glossary/Base64#appendix.3a_decode_a_base64_string_to_uint8array_or_arraybuffer)

--- a/files/es/web/javascript/typed_arrays/index.md
+++ b/files/es/web/javascript/typed_arrays/index.md
@@ -161,9 +161,9 @@ normalArray.constructor === Array;
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("javascript.builtins.Int8Array")}}
+{{Compat}}
 
 ## Ve también
 

--- a/files/es/web/manifest/index.md
+++ b/files/es/web/manifest/index.md
@@ -253,4 +253,4 @@ Los manifiestos web se deben servir con el tipo MIME `application/manifest+json`
 
 ## Compatibilidad con navegadores
 
-{{Compat("html.manifest")}}
+{{Compat}}

--- a/files/es/web/mathml/element/math/index.md
+++ b/files/es/web/mathml/element/math/index.md
@@ -119,9 +119,9 @@ Además de los siguientes atributos, el elemento `<math>` acepta cualquier atrib
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("mathml.elements.math")}}
+{{Compat}}
 
 ## Notas específicas a Firefox
 

--- a/files/es/web/mathml/index.md
+++ b/files/es/web/mathml/index.md
@@ -47,6 +47,10 @@ Aquí encontrarás enlaces a documentación, ejemplos y herramientas que te ayud
 - [HTML](/es/docs/Web/HTML)
 - [SVG](/es/docs/Web/SVG)
 
-## Compatibilidad de navegadores
+## Especificaciones
 
-{{Compat("mathml.elements.math", 0)}}
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}

--- a/files/es/web/svg/attribute/stop-color/index.md
+++ b/files/es/web/svg/attribute/stop-color/index.md
@@ -24,9 +24,13 @@ El siguiente elemento puede usar el atributo `stop-color`
 
 - {{ SVGElement("stop") }}
 
-## Compatibilidad entre navegadores
+## Especificaciones
 
-{{Compat("svg.attributes.presentation.stop-color")}}
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/svg/element/a/index.md
+++ b/files/es/web/svg/element/a/index.md
@@ -111,6 +111,6 @@ svgns|a:hover, svgns|a:active {
 
 {{Specifications}}
 
-## Compatibilidad del navegador
+## Compatibilidad con navegadores
 
-{{Compat("svg.elements.a")}}
+{{Compat}}

--- a/files/es/web/svg/element/animate/index.md
+++ b/files/es/web/svg/element/animate/index.md
@@ -76,4 +76,4 @@ Para más información (en inglés):
 
 ## Compatibilidad con navegadores
 
-{{Compat("svg.elements.animate")}}
+{{Compat}}

--- a/files/es/web/svg/element/circle/index.md
+++ b/files/es/web/svg/element/circle/index.md
@@ -54,9 +54,13 @@ svg {
 
 Este elemento implementa la interfaz {{ domxref("SVGCircleElement") }}.
 
-## Compatibilidad de navegadores
+## Especificaciones
 
-{{Compat("svg.elements.circle")}}
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Relacionado
 

--- a/files/es/web/svg/element/g/index.md
+++ b/files/es/web/svg/element/g/index.md
@@ -46,6 +46,10 @@ _No hay atributos específicos_
 
 Este elemento implementa la interfaz [`SVGGElement`](/es/docs/DOM/SVGGElement).
 
+## Especificaciones
+
+{{Specifications}}
+
 ## Compatibilidad con navegadores
 
-{{Compat("svg.elements.g")}}
+{{Compat}}

--- a/files/es/web/svg/element/rect/index.md
+++ b/files/es/web/svg/element/rect/index.md
@@ -87,9 +87,13 @@ svg {
 
 Este elemento implementa la interfaz [`SVGRectElement`](/en/DOM/SVGRectElement).
 
-## Compatibilidad de los Navegadores
+## Especificaciones
 
-{{Compat("svg.elements.rect")}}
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/svg/element/script/index.md
+++ b/files/es/web/svg/element/script/index.md
@@ -117,9 +117,9 @@ Este elemento contiene los [atributos globales](/es/docs/Web/HTML/Atributos_Glob
 
 {{Specifications}}
 
-## Compatibilidad de navegadores
+## Compatibilidad con navegadores
 
-{{Compat("svg.elements.script")}}
+{{Compat}}
 
 ## Ver también
 

--- a/files/es/web/svg/element/style/index.md
+++ b/files/es/web/svg/element/style/index.md
@@ -50,9 +50,13 @@ Live result:
 
 Este elemento implementa la interfaz [`SVGStyleElement`](/en/DOM/SVGStyleElement).
 
-## Browser compatibility
+## Especificaciones
 
-{{Compat("svg.elements.style")}}
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## See also
 

--- a/files/es/web/svg/element/svg/index.md
+++ b/files/es/web/svg/element/svg/index.md
@@ -79,6 +79,6 @@ Este elemento implementa [`SVGSVGElement`](/es/docs/Web/API/SVGSVGElement) en la
 
 {{Specifications}}
 
-## Compatibilidad de Navegador
+## Compatibilidad con navegadores
 
-{{Compat("svg.elements.svg")}}
+{{Compat}}

--- a/files/es/web/svg/element/text/index.md
+++ b/files/es/web/svg/element/text/index.md
@@ -91,9 +91,13 @@ SVG text también puede ser estilizado
 
 Este elemento hereda la interfaz de [`SVGTextElement`](/en/DOM/SVGTextElement).
 
+## Especificaciones
+
+{{Specifications}}
+
 ## Compatibilidad con navegadores
 
-{{Compat("svg.elements.text")}}
+{{Compat}}
 
 ## Relacionados
 

--- a/files/es/web/svg/element/use/index.md
+++ b/files/es/web/svg/element/use/index.md
@@ -61,6 +61,10 @@ Por razones de seguridad, algunos navegadores podrían aplicar una política del
 
 Este elemento implementa la interface [`SVGUseElement`](/en/DOM/SVGUseElement).
 
-## Compatibilidad entre navegadores
+## Especificaciones
 
-{{Compat("svg.elements.use")}}
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}


### PR DESCRIPTION
This PR updates some of the browser compatibility data and specification sections for the Spanish locale. Part of work for #11594.

Note: this may also include other minor updates, such as removal of old sections or other small bits of cleanup.
