### PR TITLE
fr: Update browser compat/spec sections (part 1)

### DIFF
--- a/files/fr/learn/css/building_blocks/debugging_css/index.md
+++ b/files/fr/learn/css/building_blocks/debugging_css/index.md
@@ -162,7 +162,7 @@ Browsers simply ignore CSS they don't understand. If the property or value you a
 
 You can also take a look at the Browser compatibility tables at the bottom of each property page on MDN. These show you browser support for that property, often broken down if there is support for some usage of the property and not others. The below table shows the compat data for the {{cssxref("shape-outside")}} property.
 
-{{compat("css.shape-outside")}}
+{{Compat}}
 
 ### Is something else overriding your CSS?
 

--- a/files/fr/learn/css/first_steps/what_is_css/index.md
+++ b/files/fr/learn/css/first_steps/what_is_css/index.md
@@ -114,7 +114,7 @@ Nous étudierons ce point plus en détail dans l'article sur [le fonctionnement 
 
 Voici, par exemple, le tableau de compatibilité pour la propriété [`font-family`](/fr/docs/Web/CSS/font-family).
 
-{{Compat("css.properties.font-family")}}
+{{Compat}}
 
 ## Où continuer
 

--- a/files/fr/mozilla/add-ons/webextensions/api/alarms/alarm/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/alarms/alarm/index.md
@@ -29,9 +29,9 @@ Les valeurs de ce type sont des objets contenant les propriétés suivantes :
 - `periodInMinutes`{{optional_inline}}
   - : `double` Un nombre qui, s'il n'est pas `null`, indique que l'alarme est périodique et fournit la période.
 
-## Compatibilité des navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.alarms.Alarm")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/alarms/clear/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/alarms/clear/index.md
@@ -50,7 +50,7 @@ clearAlarm.then(onCleared);
 
 ## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.alarms.clear")}}
+{{Compat}}
 
 **Remerciements :**
 

--- a/files/fr/mozilla/add-ons/webextensions/api/alarms/clearall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/alarms/clearall/index.md
@@ -47,7 +47,7 @@ clearAlarms.then(onClearedAll);
 
 ## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.alarms.clearAll")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/alarms/create/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/alarms/create/index.md
@@ -82,9 +82,9 @@ browser.alarms.create("my-periodic-alarm", {
 });
 ```
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.alarms.create")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/alarms/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/alarms/get/index.md
@@ -50,9 +50,9 @@ getAlarm.then(gotAlarm);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.alarms.get")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/alarms/getall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/alarms/getall/index.md
@@ -51,7 +51,7 @@ getAlarms.then(gotAll);
 
 ## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.alarms.getAll")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/alarms/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/alarms/index.md
@@ -45,7 +45,7 @@ Pour pouvoir utiliser cette API, vous devez disposer de la [permission](/fr/Add-
 
 ## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.alarms")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/alarms/onalarm/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/alarms/onalarm/index.md
@@ -62,7 +62,7 @@ browser.alarms.onAlarm.addListener(handleAlarm);
 
 ## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.alarms.onAlarm")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
@@ -43,9 +43,9 @@ Un {{jsxref("object")}} avec les propriétés suivantes :
 - `url` {{optional_inline}}
   - : Un {{jsxref("string")}} qui représente l'URL du signet. Si le nœud représente un dossier, cette propriété est omise.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.bookmarks.BookmarkTreeNode", 10)}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodetype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodetype/index.md
@@ -25,8 +25,8 @@ Le type **`bookmarks.BookmarkTreeNodeType`** est utilisé pour décrire si un n�
 - `"folder"`: le noeud est un dossier.
 - `"separator"`: le noeud est un séparateur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.bookmarks.BookmarkTreeNodeType", 10)}}
+{{Compat}}
 
 {{WebExtExamples}}

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.md
@@ -22,9 +22,9 @@ Un type **`bookmarks.BookmarkTreeNodeUnmodifiable`** est utilisé pour indiquer 
 
 `bookmarks.BookmarkTreeNodeUnmodifiable` est un {{jsxref("string")}} qui ne peut actuellement avoir qu'une seule valeur : `"managed"`. Cela indique que le nœud de signet a été configuré par un administrateur ou par le dépositaire d'un utilisateur supervisé (tel qu'un parent, dans le cas des contrôles parentaux).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.bookmarks.BookmarkTreeNodeUnmodifiable")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/create/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/create/index.md
@@ -58,9 +58,9 @@ createBookmark.then(onCreated);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.bookmarks.create")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.md
@@ -33,9 +33,9 @@ Un {{jsxref("object")}} contenant une combinaison des champs suivants :
 - `url` {{optional_inline}}
   - : `string`. Un {{jsxref("string")}} qui spécifie l'URL de la page à mettre en signet. Si ceci est omis ou est `null`, un dossier est créé à la place d'un signet.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.bookmarks.CreateDetails", 10)}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/get/index.md
@@ -56,9 +56,9 @@ gettingBookmarks.then(onFulfilled, onRejected);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.bookmarks.get")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.md
@@ -58,9 +58,9 @@ gettingChildren.then(onFulfilled, onRejected);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.bookmarks.getChildren")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/getrecent/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/getrecent/index.md
@@ -58,9 +58,9 @@ gettingRecent.then(onFulfilled, onRejected);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.bookmarks.getRecent")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/getsubtree/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/getsubtree/index.md
@@ -78,9 +78,9 @@ gettingSubTree.then(logSubTree, onRejected);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.bookmarks.getSubTree")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/gettree/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/gettree/index.md
@@ -74,9 +74,9 @@ gettingTree.then(logTree, onRejected);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.bookmarks.getTree")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/index.md
@@ -76,7 +76,7 @@ Les extensions ne peuvent pas créer, modifier ou supprimer des signets dans le 
 
 ## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.bookmarks")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/move/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/move/index.md
@@ -69,9 +69,9 @@ movingBookmark.then(onMoved, onRejected);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.bookmarks.move")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onchanged/index.md
@@ -74,9 +74,9 @@ browser.browserAction.onClicked.addListener(handleClick);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.bookmarks.onChanged")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onchildrenreordered/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onchildrenreordered/index.md
@@ -58,9 +58,9 @@ Les événements ont trois fonctions :
 - `childIds`
   - : `array` de `string`. Tableau contenant les ID de tous les éléments de signets de ce dossier, dans l'ordre où ils apparaissent maintenant dans l'interface utilisateur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.bookmarks.onChildrenReordered")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/oncreated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/oncreated/index.md
@@ -64,9 +64,9 @@ browser.bookmarks.onCreated.addListener(handleCreated);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.bookmarks.onCreated")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onimportbegan/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onimportbegan/index.md
@@ -44,9 +44,9 @@ Les événements ont trois fonctions :
 - `callback`
   - : Fonction qui sera appelée lorsque cet événement se produit. Il n'y a pas de paramètres.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.bookmarks.onImportBegan")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onimportended/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onimportended/index.md
@@ -44,9 +44,9 @@ Les événements ont trois fonctions :
 - `callback`
   - : Fonction qui sera appelée lorsque cet événement se produit. Il n'a pas passé de paramètres.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.bookmarks.onImportEnded")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.md
@@ -64,9 +64,9 @@ Les événements ont trois fonctions :
 - `oldIndex`
   - : `integer`. L'ancien index de l'élément dans son parent.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.bookmarks.onMoved")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onremoved/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/onremoved/index.md
@@ -80,9 +80,9 @@ browser.browserAction.onClicked.addListener(handleClick);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.bookmarks.onRemoved")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/remove/index.md
@@ -59,9 +59,9 @@ removingBookmark.then(onRemoved, onRejected);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.bookmarks.remove")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.md
@@ -65,9 +65,9 @@ searchingBookmarks.then(removeMDN, onRejected);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.bookmarks.removeTree")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/search/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/search/index.md
@@ -97,9 +97,9 @@ browser.browserAction.onClicked.addListener(checkActiveTab);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.bookmarks.search")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/bookmarks/update/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/bookmarks/update/index.md
@@ -79,9 +79,9 @@ searching.then(updateFolders, onRejected);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.bookmarks.update")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/colorarray/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/colorarray/index.md
@@ -27,9 +27,9 @@ Un tableau de quatre nombres entiers entre 0-255 définie une couleur RGBA. Les 
 
 Par exemple , le rouge opaque est `[255, 0, 0, 255]`.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browserAction.ColorArray")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/disable/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/disable/index.md
@@ -31,9 +31,9 @@ browser.browserAction.disable(
 - `tabId`{{optional_inline}}
   - : `integer`. L'identifiant (ID) de l'onglet pour lequel vous souhaitez désactiver l'action du navigateur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browserAction.disable")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/enable/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/enable/index.md
@@ -31,9 +31,9 @@ browser.browserAction.enable(
 - `tabId`{{optional_inline}}
   - : `integer`. L'identifiant (ID) de l'onglet pour lequel vous souhaitez activer l'action du navigateur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browserAction.enable")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/getbadgebackgroundcolor/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/getbadgebackgroundcolor/index.md
@@ -48,10 +48,6 @@ browser.browserAction.getBadgeBackgroundColor (
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec la couleur récupérée en tant que {{WebExtAPIRef('browserAction.ColorArray')}}.
 
-## Compatibilité du navigateur
-
-{{Compat("webextensions.api.browserAction.getBadgeBackgroundColor",2)}}
-
 ## Exemples
 
 Enregistrez la couleur de fond du badge :
@@ -67,6 +63,10 @@ function onFailure(error) {
 
 browser.browserAction.getBadgeBackgroundColor({}).then(onGot, onFailure);
 ```
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.md
@@ -48,10 +48,6 @@ var gettingText = browser.browserAction.getBadgeText (
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec une chaîne contenant le texte du badge.
 
-## Compatibilité du navigateur
-
-{{Compat("webextensions.api.browserAction.getBadgeText",2)}}
-
 ## Exemples
 
 Enregistrez le texte du badge :
@@ -64,6 +60,10 @@ function gotBadgeText(text) {
 var gettingBadgeText = browser.browserAction.getBadgeText({});
 gettingBadgeText.then(gotBadgeText);
 ```
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/getbadgetextcolor/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/getbadgetextcolor/index.md
@@ -42,10 +42,6 @@ browser.browserAction.getBadgeTextColor(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Promise) qui sera remplie avec la couleur récupérée comme un {{WebExtAPIRef('browserAction.ColorArray')}}.
 
-## Compatibilité du navigateur
-
-{{Compat("webextensions.api.browserAction.getBadgeTextColor",2)}}
-
 ## Exemples
 
 Enregistrer la couleur du texte du badge :
@@ -61,6 +57,10 @@ function onFailure(error) {
 
 browser.browserAction.getBadgeTextColor({}).then(onGot, onFailure);
 ```
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.md
@@ -48,10 +48,6 @@ var gettingPopup = browser.browserAction.getPopup(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec une chaine cntenant l'URL du document contextuel. Ce sera une URL entièrement qualifiée, telle que `moz-extension://d1d8a2eb-fe60-f646-af30-a866c5b39942/popups/popup2.html`.
 
-## Compatibilité du navigateur
-
-{{Compat("webextensions.api.browserAction.getPopup",2)}}
-
 ## Exemples
 
 Obtenez l'URL du Popup:
@@ -64,6 +60,10 @@ function gotPopup(popupURL) {
 var gettingPopup = browser.browserAction.getPopup({});
 gettingPopup.then(gotPopup);
 ```
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.md
@@ -50,10 +50,6 @@ var gettingTitle = browser.browserAction.getTitle(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec une chaîne contenant le titre de l'action du navigateur.
 
-## Compatibilité du navigateur
-
-{{Compat("webextensions.api.browserAction.getTitle",2)}}
-
 ## Exemples
 
 Ce code change le titre entre "ceci" et "cela" chaque fois que l'utilisateur clique sur l'action du navigateur :
@@ -72,6 +68,10 @@ browser.browserAction.onClicked.addListener(() => {
   gettingTitle.then(toggleTitle);
 });
 ```
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/imagedatatype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/imagedatatype/index.md
@@ -22,9 +22,9 @@ Données en pixels pour une image. Doit être un objet [`ImageData`](/fr/docs/We
 
 Un objet [`ImageData`](/fr/docs/Web/API/ImageData).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browserAction.ImageDataType")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/index.md
@@ -75,9 +75,9 @@ Quand l'API `browserAction`, vous pouvez :
 - {{WebExtAPIRef("browserAction.onClicked")}}
   - : Action quand l'icone d'action du navigateur est cliqué. Cet événement ne déclenchera pas si l'action du navigateur comporte une fenêtre contextuelle.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browserAction")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/isenabled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/isenabled/index.md
@@ -47,10 +47,6 @@ let gettingIsEnabled = browser.browserAction.isEnabled(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec `true` si l'action du navigateur de l'extension est activée, et `false` dans le cas contraire.
 
-## Compatibilité du navigateur
-
-{{Compat("webextensions.api.browserAction.isEnabled",2)}}
-
 ## Exemples
 
 Vérifiez l'état global :
@@ -75,5 +71,9 @@ async function enabledInActiveTab() {
   console.log(enabled);
 }
 ```
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 {{WebExtExamples}}

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.md
@@ -48,9 +48,9 @@ Les événements ont trois fonctions :
     - `tab`
       - : {{WebExtAPIRef('tabs.Tab')}}. L'onglet qui était actif lorsque l'icône a été cliquée .
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browserAction.onClicked")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/openpopup/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/openpopup/index.md
@@ -31,9 +31,9 @@ None.
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) cela est résolu sans arguments.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browserAction.openPopup", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.md
@@ -54,12 +54,6 @@ browser.browserAction.setBadgeBackgroundColor(
 - Si `windowId` et `tabId` sont tous deux fournis, la fonction échoue et la couleur n'est pas définie.
 - Si `windowId` et `tabId` sont tous deux omis, la couleur d'arrière-plan du badge global est définie à la place.
 
-## Compatibilité du navigateur
-
-{{Compat("webextensions.api.browserAction.setBadgeBackgroundColor",2)}}
-
-La couleur par défaut dans Firefox est : `[217, 0, 0, 255]`.
-
 ## Exemples
 
 Une couleur d'arrière plan qui commence en rouge et devient verte lorsque l'action du navigateur est cliquée :
@@ -86,6 +80,10 @@ browser.browserAction.onClicked.addListener((tab)=> {
   });
 });
 ```
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.md
@@ -56,10 +56,6 @@ Cette API est également disponible sous `chrome.browserAction.setBadgeText()`.
 - si `windowId` et `tabId` sont tous les deux fournis, la fonction échoue.
 - si `windowId` et `tabId` sont tous les deux omis, le badge global est défini.
 
-## Compatibilité du navigateur
-
-{{Compat("webextensions.api.browserAction.setBadgeText",2)}}
-
 ## Exemples
 
 Ajouter un badge indiquant combien de fois l'utilisateur a cliqué sur le bouton :
@@ -73,6 +69,10 @@ function increment() {
 
 browser.browserAction.onClicked.addListener(increment);
 ```
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.md
@@ -49,10 +49,6 @@ browser.browserAction.setBadgeTextColor(
 - Si `windowId` et `tabId` sont tous deux fournis, la fonction échoue et la couleur n'est pas définie.
 - Si `windowId` et `tabId` sont tous deux omis, la couleur globale du texte du badge est définie à la place.
 
-## Compatibilité du navigateur
-
-{{Compat("webextensions.api.browserAction.setBadgeTextColor",2)}}
-
 ## Exemples
 
 Une couleur de texte de badge qui commence par le rouge et passe au vert lorsque l'on clique sur l'action du navigateur :
@@ -79,6 +75,10 @@ browser.browserAction.onClicked.addListener((tab)=> {
   });
 });
 ```
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
@@ -90,10 +90,6 @@ Si chaque `imageData` et `path` est un objet `undefined`, `null` ou vide :
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie sans arguments une fois que l'icône a été définie.
 
-## Compatibilité du navigateur
-
-{{Compat("webextensions.api.browserAction.setIcon",2)}}
-
 ## Exemples
 
 Le code ci-dessous utilise une action du navigateur pour basculer un auditeur pour {{WebExtAPIRef("webRequest.onHeadersReceived")}}, et utilise `setIcon()` pour indiquer si l'écoute est activée ou désactivée :
@@ -155,6 +151,10 @@ browser.browserAction.onClicked.addListener((tab) => {
   });
 });
 ```
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.md
@@ -57,10 +57,6 @@ browser.browserAction.setPopup(
 - Si `windowId` et `tabId` sont tous les deux fournis, la fonction échoue et le popup n'est pas défini.
 - Si `windowId` et `tabId` sont tous les deux omis, la fenêtre contextuelle globale est définie.
 
-## Compatibilité du navigateur
-
-{{Compat("webextensions.api.browserAction.setPopup",2)}}
-
 ## Exemples
 
 Ce code ajoute une paire d'éléments de menu contextuel que vous pouvez utiliser pour basculer entre deux fenêtres contextuelles. Notez que vous aurez besoin de la [permission](/fr/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) "contextMenus" définie dans le manifest de l'extension pour créer des éléments du menu contextuel.
@@ -98,6 +94,10 @@ browser.contextMenus.onClicked.addListener(function(info, tab) {
   }
 });
 ```
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browseraction/settitle/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browseraction/settitle/index.md
@@ -54,10 +54,6 @@ browser.browserAction.setTitle(
 - Si `windowId` et `tabId` sont tous deux fournis, la fonction échoue et le titre n'est pas défini.
 - Si `windowId` et `tabId` sont tous les deux omis, le titre global est défini.
 
-## Compatibilité du navigateur
-
-{{Compat("webextensions.api.browserAction.setTitle",10)}}
-
 ## Exemples
 
 Ce code change le titre entre "ceci" et "ça" chaque fois que l'utilisateur clique sur l'action du navigateur :
@@ -76,6 +72,10 @@ browser.browserAction.onClicked.addListener(() => {
   gettingTitle.then(toggleTitle);
 });
 ```
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/allowpopupsforuserevents/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/allowpopupsforuserevents/index.md
@@ -30,9 +30,9 @@ window.addEventListener("click", (e) => {
 
 Par défaut, cela ouvrira une fenêtre contextuelle. Si vos extensions définient `allowPopupsForUserEvents` à `false`, cela n'ouvrira pas la fenêtre contextuelle, et l'utilisateur sera informé que le popup était bloqué.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browserSettings.allowPopupsForUserEvents")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/cacheenabled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/cacheenabled/index.md
@@ -19,9 +19,9 @@ Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} qui peut êt
 
 La valeur sous-jacente est un booléen.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browserSettings.cacheEnabled")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/closetabsbydoubleclick/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/closetabsbydoubleclick/index.md
@@ -21,6 +21,6 @@ La valeur sous-jacente est un booléen.
 
 Par défaut, closeTabsByDoubleClick est faux. Le réglage peut être modifié par l'utilisateur dans about:config.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browserSettings.closeTabsByDoubleClick")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/contextmenushowevent/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/contextmenushowevent/index.md
@@ -21,9 +21,9 @@ Sa valeur sous-jacente est une chaîne qui peut être "mouseup" ou "mousedown".
 
 La valeur par défaut est "mouseup" sur Windows, et "mousedown" sur macOS et Linux. 'affectation à Windows n'a aucun effet - le paramètre est uniquement conçu pour permettre l'ouverture du menu contextuel sur mouseup au lieu de mousedown, pas l'inverse.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browserSettings.contextMenuShowEvent")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/ftpprotocolenabled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/ftpprotocolenabled/index.md
@@ -20,9 +20,9 @@ Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} qui détermi
 
 La valeur sous-jaccente est un booléen.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browserSettings.ftpProtocolEnabled")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/homepageoverride/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/homepageoverride/index.md
@@ -19,9 +19,9 @@ Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} qui peut êt
 
 Notez qu'il s'agit d'un paramètre en lecture seule. Pour changer la page d'accueil, voir [chrome_settings_overrides](/fr/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browserSettings.homepageOverride", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/imageanimationbehavior/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/imageanimationbehavior/index.md
@@ -22,9 +22,9 @@ La valeur sous-jacente est une chaîne qui peut prendre l'une des trois valeurs 
 - "none": n'anime pas les images du tout.
 - "once": joue une fois l'animation.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browserSettings.imageAnimationBehavior", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/index.md
@@ -53,8 +53,8 @@ Pour utiliser cette API, vous devez avoir la [permission](/fr/Add-ons/WebExtensi
 - {{WebExtAPIRef("browserSettings.zoomSiteSpecific")}}
   - : Contrôle si le zoom est appliqué sur un modèle par-site ou par-onglet. Si {{WebExtAPIRef("privacy.websites")}}`.resistFingerprinting` est à vrai, ce réglage n'a aucun effet et le modèle de zoom appliqué reste par-onglet.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browserSettings")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/newtabpageoverride/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/newtabpageoverride/index.md
@@ -19,9 +19,9 @@ Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} qui peut êt
 
 Notez qu'il s'agit d'un paramètre en lecture seule.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browserSettings.newTabPageOverride", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/newtabposition/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/newtabposition/index.md
@@ -14,9 +14,9 @@ La valeur sous-jacente est une chaîne qui peut prendre l'une des trois valeurs 
 - "relatedAfterCurrent": La valeur par défaut. Ouvrez les nouveaux onglets à côté de l'onglet en cours s'ils sont liés à l'onglet en cours (par exemple, s'ils ont été ouverts via un lien dans l'onglet en cours). Sinon, ouvrez les nouveaux onglets à la fin de la bande d'onglets.
 - "atEnd": ouvre tous les onglets à la fin de la bande d'onglets.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browserSettings.newTabPosition", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/openbookmarksinnewtabs/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/openbookmarksinnewtabs/index.md
@@ -19,10 +19,6 @@ Un objet {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} dont la vale
 
 Si la valeur est `true`, alors lorsque l'utilisateur sélectionne un signet, il sera ouvert dans un nouvel onglet. Si la valeur est `false` (valeur par défaut), les marque-pages sont ouverts dans l'onglet en cours.
 
-## Compatibilité de navigateur
-
-{{Compat("webextensions.api.browserSettings.openBookmarksInNewTabs")}}
-
 ## Exemples
 
 Définissez le paramètre sur `true`:
@@ -35,5 +31,9 @@ function logResult(result) {
 browser.browserSettings.openBookmarksInNewTabs.set({value: true}).
   then(logResult);
 ```
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 {{WebExtExamples}}

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/opensearchresultsinnewtabs/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/opensearchresultsinnewtabs/index.md
@@ -21,9 +21,9 @@ Si la valeur est définie à `true`, lorsque l'utilisateur sélectionne un terme
 
 Notez que cela n'affecte pas le comportement lors de la sélection des éléments de omnibox/awesomebar, uniquement la zone de recherche dédiée..
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browserSettings.openSearchResultsInNewTabs")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/openurlbarresultsinnewtabs/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/openurlbarresultsinnewtabs/index.md
@@ -21,9 +21,9 @@ Quand l'utilisateur facalise la barre d'adresse et commence à taper, le navigat
 
 Si la valeur est `true`, alors lorsque l'utiliseur sélectionne l'un des éléments, l'élément est ouvert dans un nouvel onglet. Si la valeur est `false` (valeur par défaut) l'élément est ouvert dans l'onglet en cours.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browserSettings.openUrlbarResultsInNewTabs")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/overridedocumentcolors/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/overridedocumentcolors/index.md
@@ -25,7 +25,7 @@ Sa valeur sous-jacente est une chaîne qui peut prendre l'une des valeurs suivan
 - "never": n'applique jamais les choix de l'utilisateur
 - "always": Toujours appliquer les choix de l'utilisateur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
 {{Compat}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/usedocumentfonts/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/usedocumentfonts/index.md
@@ -24,9 +24,9 @@ Sa valeur sous-jacente est un booléen :
 - `true`: utilise les polices spécifiées par la page Web. C'est la valeur par défaut.
 - `false`: utilise les polices du système.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browserSettings.useDocumentFonts")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/webnotificationsdisabled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/webnotificationsdisabled/index.md
@@ -27,9 +27,9 @@ Si vous définissez `browserSettings.webNotificationsDisabled` à `false` la val
 
 Notez que ce paramètre n'a aucun effet sur les notifications créées par des extensions à l'aide de l'API de [`notifications`](/fr/Add-ons/WebExtensions/API/notifications).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browserSettings.webNotificationsDisabled")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/zoomfullpage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/zoomfullpage/index.md
@@ -24,9 +24,9 @@ Valeurs du paramètre:
 - `true`: le zoom s'applique à la page web en entier (par défaut).
 - `false`: le zoom s'applique au texte de la page web seulement.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browserSettings.zoomFullPage")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsersettings/zoomsitespecific/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsersettings/zoomsitespecific/index.md
@@ -32,9 +32,9 @@ Lors de l'installation de Firefox, `browser.zoom.siteSpecific` est à vrai.
 
 Si [`privacy.websites`](/fr/docs/Mozilla/Add-ons/WebExtensions/API/privacy/websites)`.resistFingerprinting` est à vrai, ce réglage ne peut pas être changé et le niveau de zoom est appliqué sur le schéma par-onglet.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browserSettings.zoomSiteSpecific")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/datatypeset/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/datatypeset/index.md
@@ -53,9 +53,9 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `serviceWorkers` {{optional_inline}}
   - : `boolean`. Données mises en cache par les travailleurs du service.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browsingData.DataTypeSet")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/index.md
@@ -68,9 +68,9 @@ Pour utiliser cette API, vous devez disposer de l'[API permission](/fr/Add-ons/W
 - {{WebExtAPIRef("browsingData.settings()")}}
   - : Obtient la valeur actuelle des paramètres dans la fonction "Effacer l'historique" du navigateur
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browsingData", 2)}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.md
@@ -43,9 +43,9 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `since` {{optional_inline}}
   - : `number`. Jusqu'à quand remontent les données, données en [millisecondes depuis l'époque UNIX](https://en.wikipedia.org/wiki/Unix_time). Notez que lorsque vous supprimez le cache du navigateur, le cache entier est toujours supprimé et cette option est ignorée. Si la propriété `since` est omise, la valeur par défaut est 0, ce qui signifie "pour toujours".
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browsingData.RemovalOptions", 2)}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/remove/index.md
@@ -44,9 +44,9 @@ var removing = browser.browsingData.remove(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie sans argument lorsque la suppression est terminée. Si une erreur se produit, la promise sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browsingData.remove")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.md
@@ -38,9 +38,9 @@ var removing = browser.browsingData.removeCache(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera rempli sans arguments lorsque la suppression est terminée. Si une erreur se produit, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browsingData.removeCache")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.md
@@ -41,9 +41,9 @@ var removing = browser.browsingData.removeCookies(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie sans argument lorsque la suppression est terminée. Si une erreur se produit, la promise sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browsingData.removeCookies")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.md
@@ -41,9 +41,9 @@ var removing = browser.browsingData.removeDownloads(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie sans argument lorsque la suppression est terminée. Si une erreur se produit, la promise sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browsingData.removeDownloads")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.md
@@ -40,9 +40,9 @@ var removing = browser.browsingData.removeFormData(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie sans argument lorsque la suppression est terminée. Si une erreur se produit, la promise sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browsingData.removeFormData")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.md
@@ -41,9 +41,9 @@ var removing = browser.browsingData.removeHistory(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) sera rempli sans arguments lorsque la suppression est terminée. Si une erreur se produit, la promise sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browsingData.removeHistory", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.md
@@ -41,9 +41,9 @@ var removing = browser.browsingData.removeLocalStorage(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie sans argument lorsque la suppression est terminée. Si une erreur se produit, la promise sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browsingData.removeLocalStorage", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removepasswords/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removepasswords/index.md
@@ -41,9 +41,9 @@ var removing = browser.browsingData.removePasswords(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie sans arguments lorsque la suppression est terminée. Si une erreur se produit, la promise sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browsingData.removePasswords")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removeplugindata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/removeplugindata/index.md
@@ -41,9 +41,9 @@ var removing = browser.browsingData.removePluginData(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera rempli sans arguments lorsque la suppression est terminée. Si une erreur se produit, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browsingData.removePluginData")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/browsingdata/settings/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/browsingdata/settings/index.md
@@ -46,9 +46,9 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se
 
 Si une erreur se produit, la promise sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.browsingData.settings")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/captiveportal/canonicalurl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/captiveportal/canonicalurl/index.md
@@ -14,9 +14,9 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/captivePortal/canonicalURL
 
 Renvoyer l'URL canonique de la page de détection du portail des prisonniers. En lecture seule.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.captivePortal.canonicalURL")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/captiveportal/getlastchecked/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/captiveportal/getlastchecked/index.md
@@ -28,9 +28,9 @@ Une [Promise](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui est 
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.captivePortal.getLastChecked")}}
+{{Compat}}
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/fr/mozilla/add-ons/webextensions/api/captiveportal/getstate/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/captiveportal/getstate/index.md
@@ -28,9 +28,9 @@ Une [Promise](/fr/docs/Web/JavaScript/Reference/Global_Objects/Promise) qui est 
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.captivePortal.getState")}}
+{{Compat}}
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/fr/mozilla/add-ons/webextensions/api/captiveportal/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/captiveportal/index.md
@@ -39,9 +39,9 @@ Pour utiliser cette API, vous devez disposer de la [permission](/fr/docs/Mozilla
 - {{WebExtAPIRef("captivePortal.onStateChanged")}}
   - : S'allume lorsque l'état de portail captif change
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.captivePortal")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/captiveportal/onconnectivityavailable/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/captiveportal/onconnectivityavailable/index.md
@@ -58,9 +58,9 @@ browser.captivePortal.onConnectivityAvailable.addListener(handleConnectivity);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.captivePortal.onConnectivityAvailable")}}
+{{Compat}}
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/fr/mozilla/add-ons/webextensions/api/captiveportal/onstatechanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/captiveportal/onstatechanged/index.md
@@ -58,9 +58,9 @@ browser.captivePortal.onStateChanged.addListener(handlePortalStatus)
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.captivePortal.onStateChanged")}}
+{{Compat}}
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/fr/mozilla/add-ons/webextensions/api/clipboard/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/clipboard/index.md
@@ -28,9 +28,11 @@ Pour utiliser cette API, vous devez avoir la [permission](/fr/Add-ons/WebExtensi
 - {{WebExtAPIRef("clipboard.setImageData()")}}
   - : Copiez une image dans le presse-papiers.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.clipboard", 1, 1)}} {{WebExtExamples("h2")}}
+{{Compat}}
+
+{{WebExtExamples("h2")}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.md
@@ -45,9 +45,9 @@ browser.clipboard.setImageData(imageData, imageType)
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie sans arguments si l'opération a réussi, ou rejetée, s'il y a une erreur (par exemple parce que les données ne représentaient pas une image valide).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.clipboard.setImageData", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/commands/command/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/commands/command/index.md
@@ -31,9 +31,9 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `shortcut`{{optional_inline}}
   - : `string`. clef(s) utilisée pour exécuter cette commande , spécifiée comme une chaîne comme "Ctrl+Shift+Y".
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.commands.Command")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/commands/getall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/commands/getall/index.md
@@ -36,9 +36,9 @@ Aucun.
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera accompli avec un tableau d'objets `{{WebExtAPIRef('commands.Command')}}`, un pour chaque commande enregistrée pour l'extension. Si aucune n'a été enregistrée, le tableau sera vide.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.commands.getAll")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/commands/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/commands/index.md
@@ -37,7 +37,7 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/commands
 
 ## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.commands")}} {{WebExtExamples("h2")}}
+{{Compat}} {{WebExtExamples("h2")}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/commands/oncommand/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/commands/oncommand/index.md
@@ -44,9 +44,9 @@ Les événements ont trois fonctions :
     - `name`
       - : `string`. Nom de la commande. Cela correspond au nom donné à la commande dans son [entrée manifest.json](/fr/Add-ons/WebExtensions/manifest.json/commands).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.commands.onCommand")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/commands/reset/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/commands/reset/index.md
@@ -38,9 +38,9 @@ browser.commands.reset(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie sans arguments lorsque le raccourci a été réinitialisé.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.commands.reset")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/commands/update/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/commands/update/index.md
@@ -44,9 +44,9 @@ browser.commands.update(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie sans arguments lorsque le raccourci a été réinitialisé. La promesse sera rejetée avec une erreur si la commande n'a pas pu être trouvée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.commands.update")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/contentscripts/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contentscripts/index.md
@@ -33,8 +33,8 @@ Il n'y a pas de permission de l'API `contentScripts`, mais une extension doit di
 - {{WebExtAPIRef("contentScripts.register()")}}
   - : Enregistre les scripts de contenu donnés.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.contentScripts", 10, 1)}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}

--- a/files/fr/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
@@ -63,9 +63,9 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se
 
 Actuellement, les scripts de contenu ne sont pas enregistrés lorsque la page d'extension correspondante (à partir de laquelle les scripts de contenu ont été enregistrés) est déchargée, vous devez donc enregistrer un script de contenu depuis une page d'extension qui persiste au moins aussi longtemps que vous voulez que les scripts de contenu restent enregistrés.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.contentScripts.register", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/index.md
@@ -26,9 +26,9 @@ Il définit une seule fonction {{WebExtAPIRef("contentScripts.RegisteredContentS
 - {{WebExtAPIRef("contentScripts.RegisteredContentScript.unregister","unregister()")}}
   - : Annule l'inscription des scripts de contenu représentés par cet objet.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.contentScripts.RegisteredContentScript", 10)}}
+{{Compat}}
 
 ## Exemples
 


### PR DESCRIPTION
This PR updates some of the browser compatibility data and specification sections for the French locale. Part of work for #11594.

Note: this may also include other minor updates, such as removal of old sections or other small bits of cleanup.
