### PR TITLE
fr: Update browser compat/spec sections (part 2)

### DIFF
--- a/files/fr/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/unregister/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contentscripts/registeredcontentscript/unregister/index.md
@@ -28,9 +28,9 @@ None.
 
 None.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.contentScripts.RegisteredContentScript.unregister", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/contextualidentity/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/contextualidentity/index.md
@@ -64,6 +64,6 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `name`
   - : `string`. Nom de l'identité. Cela s'affichera dans la barre d'URL pour les onglets appartenant à cette identité. Notez que les noms ne doivent pas nécessairement être uniques .
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.contextualIdentities.ContextualIdentity")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/create/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/create/index.md
@@ -71,9 +71,9 @@ var createContext = browser.contextualIdentities.create(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un {{WebExtAPIRef('contextualIdentities.ContextualIdentity', 'ContextualIdentity')}} qui décrit la nouvelle identité. Si la fonctionnalité d'identités contextuelles n'est pas activée, la promesse est rejetée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.contextualIdentities.create")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/get/index.md
@@ -36,9 +36,9 @@ var getContext = browser.contextualIdentities.get(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un {{WebExtAPIRef('contextualIdentities.ContextualIdentity', 'ContextualIdentity')}} qui décrit l'identité. Si l'identité n'a pas pu être trouvée ou si la fonctionnalité d'identités contextuelles n'est pas activée, la promesse est rejetée.
 
-## Comptatiblité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.contextualIdentities.get")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/index.md
@@ -53,8 +53,8 @@ Pour utiliser cette API, vous devez inclure la [permission](/fr/docs/Mozilla/Add
 - {{WebExtAPIRef("contextualIdentities.onUpdated")}}
   - : Lancé lorsqu’une ou plusieurs propriétés d’une identité contextuelle sont mises à jour
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.contextualIdentities")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}

--- a/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/oncreated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/oncreated/index.md
@@ -45,9 +45,9 @@ Les événements ont trois fonctions :
     - `changeInfo`
       - : `object`. Un objet contenant une seule propriété, `contextualIdentity`, qui est un objet {{WebExtAPIRef("contextualIdentities.ContextualIdentity")}} représentant l'identité créée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.contextualIdentities.onCreated")}}
+{{Compat}}
 
 ## Examples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/onremoved/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/onremoved/index.md
@@ -45,9 +45,9 @@ Les événements ont trois fonctions :
     - `changeInfo`
       - : `object`. Un objet qui contient une seule propriété, `contextualIdentity`, qui est un objet {{WebExtAPIRef("contextualIdentities.ContextualIdentity")}} représentant l'identité qui a été supprimée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.contextualIdentities.onRemoved")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/onupdated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/onupdated/index.md
@@ -45,9 +45,9 @@ Events have three functions:
     - `changeInfo`
       - : `object`. Un objet qui contient une seule propriété, `contextualIdentity`, qui est un objet {{WebExtAPIRef("contextualIdentities.ContextualIdentity")}} représentant l'identité dont les propriétés ont été mises à jour.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.contextualIdentities.onUpdated")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/query/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/query/index.md
@@ -40,9 +40,9 @@ var getContext = browser.contextualIdentities.query(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un tableau d'objets {{WebExtAPIRef('contextualIdentities.ContextualIdentity', 'ContextualIdentity')}} chacun décrivant une seule identité. Si la fonctionnalité d'identités contextuelles n'est pas activée, la promesse est rejetée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.contextualIdentities.query")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/remove/index.md
@@ -37,9 +37,9 @@ var removeContext = browser.contextualIdentities.remove(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un {{WebExtAPIRef('contextualIdentities.ContextualIdentity', 'ContextualIdentity')}} décrivant l'identité qui a été supprimée. Si l'identité n'a pas pu être trouvée ou si la fonctionnalité d'identités contextuelles n'est pas activée, la promesse est rejetée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.contextualIdentities.remove")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/update/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/contextualidentities/update/index.md
@@ -74,9 +74,9 @@ var createContext = browser.contextualIdentities.update(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un {{WebExtAPIRef('contextualIdentities.ContextualIdentity', 'ContextualIdentity')}} qui décrit l'identité mise à jour. Si l'identité n'a pas pu être trouvée ou si la fonctionnalité d'identités contextuelles n'est pas activée, la promesse est rejetée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.contextualIdentities.update")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
@@ -47,9 +47,9 @@ Les valeurs de ce type sont des objets, qui peuvent contenir les propriétés su
 - `value`
   - : Une `chaîne` représentant la valeur du cookie.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.cookies.Cookie")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.md
@@ -31,9 +31,9 @@ Les valeurs de ce type sont des objets, qui peuvent contenir les propriétés su
 - `tabIds`
   - : Un `tableau` d'`entiers`, qui identifie tous les onglets du navigateur qui partagent ce cookie store.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.cookies.CookieStore")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/get/index.md
@@ -49,9 +49,9 @@ var getting = browser.cookies.get(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un objet {{WebExtAPIRef('cookies.Cookie', 'Cookie')}} contenant des détails sur le cookie, ou `null` si le cookie n'a pas été trouvé.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.cookies.get")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/getall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/getall/index.md
@@ -55,9 +55,9 @@ var getting = browser.cookies.getAll(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un tableau d'objets   `{{WebExtAPIRef('cookies.Cookie')}}` correspondant aux propriétés données dans le paramètre `details`. Seuls les cookies non expirés sont renvoyés. Les cookies retournés seront triés par longueur de chemin, du plus long au plus court. Si plusieurs cookies ont la même longueur de chemin, ceux dont l'heure de création est la plus proche seront les premiers.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.cookies.getAll")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/getallcookiestores/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/getallcookiestores/index.md
@@ -36,7 +36,7 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se
 
 ## Compatibibilité du navigateur
 
-{{Compat("webextensions.api.cookies.getAllCookieStores")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/index.md
@@ -106,9 +106,9 @@ Lorsque l'isolation de la première partie est désactivée, le paramètre `firs
 - {{WebExtAPIRef("cookies.onChanged")}}
   - : Détails quand un cookie est défini ou supprimé.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.cookies")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/onchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/onchanged/index.md
@@ -61,9 +61,9 @@ Les événements ont trois fonctions :
         - `cause`
           - : Une valeur {{WebExtAPIRef('cookies.OnChangedCause')}} représentant la raison sous-jacente de la modification du cookie.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.cookies.onChanged")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.md
@@ -33,9 +33,9 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 - `overwrite`
   - : Un appel à {{WebExtAPIRef("cookies.set()")}} a remplacé ce cookie par un autre.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.cookies.OnChangedCause")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/remove/index.md
@@ -49,9 +49,9 @@ var removing = browser.cookies.remove(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un objet {{WebExtAPIRef('cookies.Cookie')}} contenant des détails sur le cookie qui a été supprimé. Si un cookie correspondant au paramètre `details` n'a pas pu être trouvé, la promesse est remplie avec `null`. Si l'appel échoue pour une raison quelconque, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.cookies.remove")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/cookies/set/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/cookies/set/index.md
@@ -61,9 +61,9 @@ var setting = browser.cookies.set(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un objet {{WebExtAPIRef('cookies.Cookie')}} contenant les détails sur le cookie qui a été défini. Si l'appel échoue pour une quelconque raison, la promesse sera rejetée avec un message d’erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.cookies.set")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.md
@@ -86,7 +86,7 @@ Si une erreur s'est produite, l'élément 0 sera indéfini et l'élément 1 cont
 
 ## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.devtools.inspectedWindow.eval")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/index.md
@@ -32,9 +32,9 @@ Comme toutes les APIs de `devtools`, cette API n'est disponible que pour exécut
 - [`devtools.inspectedWindow.reload()`](/fr/Add-ons/WebExtensions/API/devtools.inspectedWindow/reload)
   - : Rechargez le document de la fenêtre destination.
 
-## Comptatibilité navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.devtools.inspectedWindow")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.md
@@ -38,9 +38,9 @@ browser.devtools.inspectedWindow.reload(
     - `injectedScript` {{optional_inline}}
       - : `string`. Injectez l'expression JavaScript donnée dans toutes les images de la page, avant tout autre script.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.devtools.inspectedWindow.reload")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.md
@@ -44,9 +44,9 @@ function handleMessage(request, sender, sendResponse) {
 browser.runtime.onMessage.addListener(handleMessage);
 ```
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.devtools.inspectedWindow.tabId")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/network/gethar/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/network/gethar/index.md
@@ -31,9 +31,9 @@ None.
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un objet contenant le journal HAR pour l'onglet en cours. Pour plus de détails sur ce que contient l'objet journal, reportez-vous à la [spécification HAR](http://www.softwareishard.com/blog/har-12-spec/#log).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.devtools.network.getHAR")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/network/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/network/index.md
@@ -30,9 +30,9 @@ Comme toutes les APIs de devtools, cette API est uniquement disponible pour le c
 - [`devtools.network.onRequestFinished`](/fr/Add-ons/WebExtensions/API/devtools.network/onRequestFinished)
   - : Lancé lorsque la demande réseau est terminée et que ses détails sont disponibles pour l'extension.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.devtools.network")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/network/onnavigated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/network/onnavigated/index.md
@@ -44,9 +44,9 @@ Les événements ont trois fonctions :
     - `url`
       - : `string`. La nouvelle URL pour la fenêtre.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.devtools.network.onNavigated")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/network/onrequestfinished/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/network/onrequestfinished/index.md
@@ -50,9 +50,9 @@ Les événements ont trois fonctions
     - `request`
       - : `object`. Un objet représentant la requête. Cet objet est un seul objet d'[entrée HAR](http://www.softwareishard.com/blog/har-12-spec/#entries). Il définit également une méthode `getContent()` asynchrone, qui renvoie une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se résout avec le corps de la réponse.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.devtools.network.onRequestFinished")}}
+{{Compat}}
 
 ## Examples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/create/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/create/index.md
@@ -42,9 +42,9 @@ var creating = browser.devtools.panels.create(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un objet [`ExtensionPanel`](/fr/Add-ons/WebExtensions/API/devtools.panels/ExtensionPanel) représentant le nouveau panneau.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.devtools.panels.create")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elements/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elements/index.md
@@ -17,9 +17,9 @@ original_slug: Mozilla/Add-ons/WebExtensions/API/devtools.panels/elements
 
 Un objet [`ElementsPanel`](/fr/Add-ons/WebExtensions/API/devtools.panels/ElementsPanel) qui représente l'inspecteur HTML/CSS du navigateur
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.devtools.panels.elements", 10)}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.md
@@ -46,9 +46,9 @@ var creating = browser.devtools.panels.elements.createSidebarPane(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un objet [`ExtensionSidebarPane`](/fr/Add-ons/WebExtensions/API/devtools.panels/ExtensionSidebarPane) représentant le nouveau volet.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.devtools.panels.ElementsPanel.createSidebarPane", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/index.md
@@ -28,9 +28,9 @@ Un `ElementsPanel` représente l'inspecteur HTML/CSS dans la devtools du navigat
 - [`devtools.panels.ElementsPanel.onSelectionChanged`](/fr/Add-ons/WebExtensions/API/devtools.panels/ElementsPanel/onSelectionChanged)
   - : Appèle lorsque l'utilisateur sélectionne un élément différent dans la page, par exemple en utilisant l'élément de menu contextuel "inspect élément".
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.devtools.panels.ElementsPanel", 10)}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.md
@@ -45,9 +45,9 @@ L'événement a trois fonctions :
 - `callback`
   - : Fonction qui sera appelée lors de l'événement. La fonction ne passera pas d'arguments.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.devtools.panels.ElementsPanel.onSelectionChanged", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionpanel/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionpanel/index.md
@@ -23,9 +23,9 @@ Les valeurs de ce type sont des objets. Définissez deux événements, `onShown`
 - `onShown` est émis lorsque le panneau est affiché dans les devtools (par exemple, quand l'utilisateur a cliqué sur le panneau dans la fenêtre des devtools).
 - `onHidden` est émis lorsque le panneau est caché (par exemple, quand l'utilisateur a basculé sur un onglet différent dans la fenêtre devtools).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.devtools.panels.ExtensionPanel")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/index.md
@@ -38,9 +38,9 @@ Pour créer un `ExtensionSidebarPane`, appelez la fonction [`browser.devtools.pa
 - [`devtools.panels.ExtensionSidebarPane.onHidden`](/fr/Add-ons/WebExtensions/API/devtools.panels/ExtensionSidebarPane/onHidden)
   - : Lancé lorsque le volet de la barre latérale est masqué.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.devtools.panels.ExtensionSidebarPane", 10)}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onhidden/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onhidden/index.md
@@ -45,9 +45,9 @@ Les événements ont trois fonctions:
 - `callback`
   - : Fonction appelée lorsque cet événement se produit. Cette fonction sera passée sans arguments.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.devtools.panels.ExtensionSidebarPane.onHidden", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onshown/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onshown/index.md
@@ -42,9 +42,9 @@ Les événements ont trois fonctions :
 - `callback`
   - : Fonction qui sera appelée lorsque cet événement se produit. La fonction sera passée sans arguments.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.devtools.panels.ExtensionSidebarPane.onShown", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setexpression/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setexpression/index.md
@@ -46,9 +46,9 @@ var evaluating = browser.devtools.panels.setExpression(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) sera remplie sans arguments, une fois l'expression évaluée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.devtools.panels.ExtensionSidebarPane.setExpression", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.md
@@ -44,9 +44,9 @@ var setting = browser.devtools.panels.setObject(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera accomplie sans arguments, une fois l'objet défini.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.devtools.panels.ExtensionSidebarPane.setObject", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setpage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setpage/index.md
@@ -47,9 +47,9 @@ function onCreated(sidebarPane) {
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.devtools.panels.ExtensionSidebarPane.setPage", 10)}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/index.md
@@ -50,9 +50,9 @@ Comme toutes les API de devtools, cette API est uniquement disponible pour le co
 - [`devtools.panels.onThemeChanged`](/fr/Add-ons/WebExtensions/API/devtools.panels/onThemeChanged)
   - : Mise en place lorsque le thème Devtools change.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.devtools.panels", 2)}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/onthemechanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/onthemechanged/index.md
@@ -45,9 +45,9 @@ Les événements ont trois fonctions :
     - `themeName`
       - : `string`. Nom du nouveau thème : ce sera l'une des valeurs autorisées pour [`devtools.panels.themeName`](/fr/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/themeName).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.devtools.panels.onThemeChanged")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/themename/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/devtools/panels/themename/index.md
@@ -23,9 +23,9 @@ Il s'agit d'une chaîne dont les valeurs possibles sont :
 - "foncé"
 - "firebug"
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.devtools.panels.themeName")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/dns/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/dns/index.md
@@ -17,8 +17,8 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/dns
 - {{WebExtAPIRef("dns.resolve()")}}
   - : Résout le nom d'hôte donné en un enregistrement DNS
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.dns")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}

--- a/files/fr/mozilla/add-ons/webextensions/api/dns/resolve/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/dns/resolve/index.md
@@ -89,6 +89,6 @@ resolving.then(resolved);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.dns.resolve")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/acceptdanger/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/acceptdanger/index.md
@@ -39,9 +39,9 @@ var prompting = browser.downloads.acceptDanger(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise). Lorsque la boîte de dialogue se ferme, la promesse sera remplie sans arguments.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.acceptDanger")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/booleandelta/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/booleandelta/index.md
@@ -27,9 +27,9 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `previous`{{optional_inline}}
   - : Un `boolean` représentant la valeur booléenne précédente.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.BooleanDelta")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/cancel/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/cancel/index.md
@@ -39,9 +39,9 @@ var canceling = browser.downloads.cancel(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise). Si la demande a été acceptée, la promesse sera remplie sans arguments. Si la demande a échoué, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.cancel")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/dangertype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/dangertype/index.md
@@ -43,9 +43,9 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 - `accepted`
   - : L'utilisateur a accepté le téléchargement dangereux.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.DangerType")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/doubledelta/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/doubledelta/index.md
@@ -27,9 +27,9 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `previous`{{optional_inline}}
   - : Un `number` représentant la valeur double précédente.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.DoubleDelta")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/download/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/download/index.md
@@ -73,9 +73,9 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise). Si le
 
 Si vous utilisez [URL.createObjectURL()](/fr/docs/Web/API/URL/createObjectURL) pour télécharger des données créées en JavaScript et que vous voulez révoquer l'URL de l'objet (avec [revokeObjectURL](/fr/docs/Web/API/URL/revokeObjectURL)) plus tard (comme il est fortement recommandé), vous devez le faire après le téléchargement. Pour ce faire, écoutez l'événement [downloads.onChanged](/fr/Add-ons/WebExtensions/API/downloads/onChanged).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.download")}}
+{{Compat}}
 
 ## Examples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.md
@@ -63,9 +63,9 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `url`
   - : Un `string` représentant l'URL absolue à partir de laquelle le fichier a été téléchargé.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.DownloadItem")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/downloadquery/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/downloadquery/index.md
@@ -74,9 +74,9 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `exists`{{optional_inline}}
   - : Un `boolean` si un fichier téléchargé existe toujours (`true`) ou non (`false`). Inclure seulement {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} avec cette valeur `existe`.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.DownloadQuery")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/downloadtime/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/downloadtime/index.md
@@ -30,9 +30,9 @@ Un `DownloadTime` peut être l'un de trois types différents :
 
 - un nombre : ceci est interprété comme le nombre de millisecondes écoulées depuis l'époque UNIX.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.DownloadTime")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/drag/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/drag/index.md
@@ -33,9 +33,9 @@ Cette API est également disponible en tant que `browser.downloads.drag()`.
 - `downloadId`
   - : Un `integer` représentant l'`id` du {{WebExtAPIRef("downloads.DownloadItem", "DownloadItem")}} ein question.
 
-## Browser compatibility
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.drag")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/erase/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/erase/index.md
@@ -42,9 +42,9 @@ var erasing = browser.downloads.erase(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise). Si l'appel a réussi, la promesse sera remplie avec un tableau d'entiers représentant les identifiants des {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} effacés. Si aucun élément correspondant au paramètre de requête n'a pu être trouvé, le tableau sera vide. Si l'appel a échoué, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.erase")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/filenameconflictaction/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/filenameconflictaction/index.md
@@ -31,9 +31,9 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 - `"prompt"`
   - : Le navigateur invitera l'utilisateur, lui demandant de choisir s'il souhaite l'uniquifier ou l'écraser.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.FilenameConflictAction")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.md
@@ -48,9 +48,9 @@ var gettingIcon = browser.downloads.getFileIcon(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise). Si la requête réussit, la promesse sera remplie avec une chaîne représentant l'URL absolue de l'icône. Si la requête échoue, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.getFileIcon")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/index.md
@@ -82,9 +82,9 @@ Pour utiliser cette API, vous devez disposer de l' [API permission](/fr/Add-ons/
 - {{WebExtAPIRef("downloads.onChanged")}}
   - : Lorsque l'une des propriétés de {{WebExtAPIRef("downloads.DownloadItem", "DownloadItem")}} sauf les changements `bytesReceived`, cet événement se déclenche avec le `downloadId` et un objet contenant les propriétés qui ont changé.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/interruptreason/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/interruptreason/index.md
@@ -63,9 +63,9 @@ Divers :
 
 - `"CRASH"`
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.InterruptReason")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/onchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/onchanged/index.md
@@ -84,9 +84,9 @@ L'objet `downloadDelta` a les propriétés suivantes disponibles :
 - `exists`{{optional_inline}}
   - : Un objet {{WebExtAPIRef('downloads.BooleanDelta')}} décrivant un changement dans un état {{WebExtAPIRef('downloads.DownloadItem')}}.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.onChanged")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/oncreated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/oncreated/index.md
@@ -48,9 +48,9 @@ Les événements ont trois fonctions :
     - `downloadItem`
       - : L'objet {{WebExtAPIRef('downloads.DownloadItem')}} en question.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.onCreated")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/onerased/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/onerased/index.md
@@ -48,9 +48,9 @@ Les événements ont trois fonctions :
     - `downloadId`
       - : Un `integer` représentant l'`id` du {{WebExtAPIRef('downloads.DownloadItem')}} qui a été effacé.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.onErased")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/open/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/open/index.md
@@ -39,9 +39,9 @@ var opening = browser.downloads.open(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise). Si la demande a été acceptée, la promesse sera remplie sans arguments. Si la demande a échoué, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.open")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/pause/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/pause/index.md
@@ -37,9 +37,9 @@ var pausing = browser.downloads.pause(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise). Si l'appel a réussi, le téléchargement sera mis en pause et la promesse sera satisfaite sans aucun argument. Si l'appel échoue, la promesse sera rejetée avec un message d'erreur. L'appel échouera si le téléchargement n'est pas actif: par exemple, parce qu'il a fini le téléchargement.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.pause")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/removefile/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/removefile/index.md
@@ -43,9 +43,9 @@ var removing = browser.downloads.removeFile(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise). Si la demande a été acceptée, la promesse sera remplie sans arguments. Si la demande a échoué, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.removeFile")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/resume/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/resume/index.md
@@ -37,9 +37,9 @@ var resuming = browser.downloads.resume(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise). Si la demande a été acceptée, la promesse sera remplie sans arguments. Si la demande a échoué, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.resume")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/search/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/search/index.md
@@ -36,9 +36,9 @@ var searching = browser.downloads.search(query);
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise). La promise est remplie avec un `tableau d'objets` `{{WebExtAPIRef('downloads.DownloadItem')}}` qui correspondent aux critères donnés.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.search")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/setshelfenabled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/setshelfenabled/index.md
@@ -35,9 +35,9 @@ Cette API est également disponible en tant que `browser.downloads.setShelfEnabl
 - `enabled`
   - : Un `boolean` l'état que vous souhaitez définir `setShelfEnabled()` à — `true` pour activer et `false` pour désactiver.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.setShelfEnabled")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/show/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/show/index.md
@@ -37,9 +37,9 @@ var showing = browser.downloads.show(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise). Si la demande est acceptée, la promise sera remplie avec un booléen indiquant si la demande a été acceptée. Si la demande échoue, la promise sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.show")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.md
@@ -29,9 +29,9 @@ browser.downloads.showDefaultFolder();
 
 Aucun
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.showDefaultFolder")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/state/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/state/index.md
@@ -33,9 +33,9 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 
 > **Note :** Ces constantes de chaîne ne changeront jamais, mais de nouvelles constantes peuvent être ajoutées.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.State")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/downloads/stringdelta/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/downloads/stringdelta/index.md
@@ -27,9 +27,9 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `previous`{{optional_inline}}
   - : Un `string` représentant la valeur de chaîne précédente.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.downloads.StringDelta")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/events/event/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/events/event/index.md
@@ -39,9 +39,9 @@ Les valeurs de ce type sont des objets.
 - {{WebExtAPIRef("events.Event.removeRules()")}}
   - : Annule l'inscription des règles actuellement enregistrées.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.events.Event")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/events/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/events/index.md
@@ -26,9 +26,9 @@ Types communs utilisés par les API qui distribuent les événements.
 - {{WebExtAPIRef("events.UrlFilter")}}
   - : Filtre les URL pour différents critères. Si un critère donné correspond, alors tout le filtre correspond.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.events")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/events/rule/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/events/rule/index.md
@@ -33,9 +33,9 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `priority`{{optional_inline}}
   - : `integer`. Priorité optionnelle de cette règle. Par défaut à 100.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.events.Rule")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/events/urlfilter/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/events/urlfilter/index.md
@@ -93,9 +93,9 @@ Toutefois, notez que ces deux derniers modèles ne correspondent pas au dernier 
 
     - Par exemple: `[80, 443, [1000, 1200]]` correspond à toutes les demandes sur les ports 80, 443, et dans la plage 1000-1200.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.events.UrlFilter")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/getbackgroundpage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/getbackgroundpage/index.md
@@ -34,9 +34,9 @@ Aucun
 
 `object`. [Window](/fr/docs/Web/API/Window) de la page d'arrière plan.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.extension.getBackgroundPage")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/getextensiontabs/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/getextensiontabs/index.md
@@ -39,9 +39,9 @@ Cette API est également disponible en tant que `browser.extension.getExtensionT
 
 `array` of `object`. Tableau d'objets de fenêtre globaux
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.extension.getExtensionTabs")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/geturl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/geturl/index.md
@@ -36,9 +36,9 @@ browser.extension.getURL(
 
 `string`. The fully-qualified URL to the resource.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.extension.getURL")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/getviews/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/getviews/index.md
@@ -48,9 +48,9 @@ var windows = browser.extension.getViews(
 
 `array` of `object`. Un tableau d'objets [Window](/fr/docs/Web/API/Window).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.extension.getViews")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/index.md
@@ -55,9 +55,9 @@ Utilitaires liés à votre extension. Obtenez des URL vers des packages de resso
 - {{WebExtAPIRef("extension.onRequestExternal")}} {{deprecated_inline}}
   - : Lancé lorsqu'une requête est envoyée depuis une autre extension.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.extension")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/inincognitocontext/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/inincognitocontext/index.md
@@ -18,9 +18,9 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/extension/inIncognitoContext
 
 Valeur booléenne, `true` pour les scripts de contenu s'exécutant dans les onglets de navigation privée et pour les pages d'extension exécutées dans un processus de navigation privé..
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.extension.inIncognitoContext")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/isallowedfileschemeaccess/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/isallowedfileschemeaccess/index.md
@@ -34,9 +34,9 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se
 
 Firefox retournera toujours `false`.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.extension.isAllowedFileSchemeAccess")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/isallowedincognitoaccess/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/isallowedincognitoaccess/index.md
@@ -47,9 +47,9 @@ isAllowed.then(logIsAllowed);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.extension.isAllowedIncognitoAccess")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/lasterror/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/lasterror/index.md
@@ -18,9 +18,9 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/extension/lastError
 
 Un alias de {{WebExtAPIRef("runtime.lastError")}}.
 
-## Compatibilité du navoigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.extension.lastError")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/onrequest/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/onrequest/index.md
@@ -61,9 +61,9 @@ Les événements ont trois fonctions :
     - `sendResponse`
       - : `function`. Fonction à appeler (au plus une fois) lorsque vous avez une réponse. L'argument doit être n'importe quel objet JSON-ifiable, ou undefined s'il n'y a pas de réponse. Si vous avez plus d'un écouteur `onRequest` dans le même document, un seul peut envoyer une réponse.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.extension.onRequest")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.md
@@ -62,9 +62,9 @@ Les événements ont trois fonctions :
     - `sendResponse`
       - : `function`. Fonction à appeler lorsque vous avez une réponse. L'argument doit être n'importe quel objet JSON-ifiable, ou undefined s'il n'y a pas de réponse.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.extension.onRequestExternal")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/sendrequest/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/sendrequest/index.md
@@ -45,9 +45,9 @@ Cette API est également disponible en tant que `browser.extension.sendRequest()
     - `response`
       - : `any`. Objet de réponse JSON envoyé par le gestionnaire de la requête. Si une erreur survient lors de la connexion à l'extension, le rappel sera appelé sans arguments et {{WebExtAPIRef('runtime.lastError')}} sera défini sur le message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.extension.sendRequest")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/setupdateurldata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/setupdateurldata/index.md
@@ -31,9 +31,9 @@ browser.extension.setUpdateUrlData(
 - `data`
   - : `string`.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.extension.setUpdateUrlData")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extension/viewtype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extension/viewtype/index.md
@@ -22,9 +22,9 @@ Le type de vue de l'extension.
 
 Les valeurs de ce type sont des chaînes. Les valeurs possibles sont : `"tab"`, `"popup"`, `"sidebar"`.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.extension.ViewType")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.md
@@ -27,9 +27,9 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `quality`{{optional_inline}}
   - : `integer`. Quand le format est `"jpeg"`, cela controle la qualité du résultat de l'image. C'est un nombre compris entre 0 et 100, qui est converti en une valeur entre 0 et 1 puis utilisé comme argument `encoderOptions` sur [`HTMLCanvasElement.toDataURL()`](/fr/docs/Web/API/HTMLCanvasElement/toDataURL). Si c'est choisi, 92 est utilisé. A mesure que la qualité baisse, le résultat de l'image aura plus d'artefacts visuel, et le nombre d'octets nécessaires pour le stocker diminuera. Cette valeur est ignorée pour les images PNG.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.extensionTypes.ImageDetails")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extensiontypes/imageformat/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extensiontypes/imageformat/index.md
@@ -22,9 +22,9 @@ Les valeurs de ce type sont des chaînes de caractères. Les valeurs possibles s
 
 Les valeurs de ce type sont des chaines. Les valeurs possibles sont : `"jpeg"`, `"png"`.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.extensionTypes.ImageFormat")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extensiontypes/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extensiontypes/index.md
@@ -30,9 +30,9 @@ Certains types communs utilisés dans d'autres APIs WebExtensions.
 - `extensionTypes.CSSOrigin`
   - : Indique si une feuille de style CSS injectée par [`tabs.insertCSS`](/fr/Add-ons/WebExtensions/API/tabs/insertCSS) doit être traitée comme une feuille de style "auteur" ou "utilisateur".
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.extensionTypes")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/extensiontypes/runat/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/extensiontypes/runat/index.md
@@ -28,9 +28,9 @@ Les valeurs de ce type sont des chaines. Les valeurs possibles sont : `"document
 
 La valeur par défaut est `"document_idle"`.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.extensionTypes.RunAt")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/find/find/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/find/find/index.md
@@ -104,9 +104,9 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se
     - `text`
       - : Le texte complet de comparaison, "You may" dans l'exemple ci-dessus.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.find.find", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/find/highlightresults/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/find/highlightresults/index.md
@@ -35,9 +35,9 @@ Aucun.
 
 Aucune.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.find.highlightResults", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/find/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/find/index.md
@@ -26,6 +26,6 @@ Pour utiliser cette API, vous devez disposez de la [permission](/fr/docs/Mozilla
 - {{WebExtAPIRef("find.removeHighlighting()")}}
   - : Supprimez toute mise en évidence.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.find", 1, 1)}} {{WebExtExamples("h2")}}
+{{Compat}} {{WebExtExamples("h2")}}

--- a/files/fr/mozilla/add-ons/webextensions/api/find/removehighlighting/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/find/removehighlighting/index.md
@@ -31,9 +31,9 @@ Aucun
 
 Aucune.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.find.removeHighlighting", 10)}}
+{{Compat}}
 
 ## Exemples
 


### PR DESCRIPTION
This PR updates some of the browser compatibility data and specification sections for the French locale. Part of work for #11594.

Note: this may also include other minor updates, such as removal of old sections or other small bits of cleanup.
