### PR TITLE
fr: Update browser compat/spec sections (part 3)

### DIFF
--- a/files/fr/mozilla/add-ons/webextensions/api/history/addurl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/addurl/index.md
@@ -47,9 +47,9 @@ var addingUrl = browser.history.addUrl(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) sera rempli sans paramètres lorsque l'élément a été ajouté.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.history.addUrl")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/history/deleteall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/deleteall/index.md
@@ -36,9 +36,9 @@ None.
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) sera remplie sans paramètre lorsque tout l'historique a été supprimé.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.history.deleteAll")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/history/deleterange/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/deleterange/index.md
@@ -43,9 +43,9 @@ var deletingRange = browser.history.deleteRange(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) sera remplie sans paramètre lorsque la plage a été supprimée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.history.deleteRange")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/history/deleteurl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/deleteurl/index.md
@@ -41,9 +41,9 @@ var deletingUrl = browser.history.deleteUrl(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) sera remplie sans paramètres lorsque les visites auront été supprimées.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.history.deleteUrl")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/history/getvisits/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/getvisits/index.md
@@ -41,9 +41,9 @@ var getting = browser.history.getVisits(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) sera remplie avec un tableau d'objets `{{WebExtAPIRef('history.VisitItem')}}` représentant chacun une visite à l'URL donnée. Les visites sont triées dans l'ordre chronologique inverse.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.history.getVisits")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/history/historyitem/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/historyitem/index.md
@@ -35,9 +35,9 @@ C'est un objet avec les propriétés suivantes :
 - `typedCount` {{optional_inline}}
   - : `number`. Le nombre de fois que l'utilisateur a navigué sur cette page en tapant l'adresse.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.history.HistoryItem")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/history/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/index.md
@@ -68,9 +68,9 @@ Pour utiliser cette API, une extension doit demander la [permission](/fr/Add-ons
 - {{WebExtAPIRef("history.onVisitRemoved")}}
   - : Lancé lorsqu'une URL est complètement supprimée de l'historique du navigateur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.history")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.md
@@ -44,9 +44,9 @@ Les événements ont trois fonctions :
     - `title`
       - : `String`. Title of the page visited.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.history.onTitleChanged")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/history/onvisited/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/onvisited/index.md
@@ -49,9 +49,9 @@ Les événements ont trois fonctions :
 
         Au moment où cet événement est envoyé, le navigateur ne connaît pas encore le titre de la page. Si le navigateur a déjà visité cette page et s'est souvenu de son ancien titre, l'objet `HistoryItem.title` contiendra l'ancien titre de la page. Si le navigateur n'a pas d'enregistrement de l'ancien titre de la page, alors `HistoryItem.title` sera vide. Pour obtenir les titres des pages dès qu'ils sont connus, écoutez {{WebExtAPIRef("history.onTitleChanged")}}.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.history.onVisited")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/history/onvisitremoved/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/onvisitremoved/index.md
@@ -54,9 +54,9 @@ Les événements ont trois fonctions:
         - Si cet événement se déclenche parce qu'il est clair, `allHistory` sera `true` et `urls` sera un tableau vide.
         - Dans le cas contraire, `allHistory` sera `false` et `urls` contiendront un qui est l'URL de la page supprimée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.history.onVisitRemoved")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/history/search/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/search/index.md
@@ -121,9 +121,9 @@ searching.then(onGot);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.history.search")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/history/transitiontype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/transitiontype/index.md
@@ -45,9 +45,9 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 - "keyword_generated"
   - : Correspond à une visite générée pour un mot clé.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.history.TransitionType")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/history/visititem/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/history/visititem/index.md
@@ -33,9 +33,9 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `transition`
   - : {{WebExtAPIRef('history.TransitionType')}}. Décrit comment le navigateur a navigué vers la page à cette occasion.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.history.VisitItem")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.md
@@ -48,9 +48,9 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se
     - `percentage`
       - : `integer`. Le pourcentage de la chaîne d'entrée qui était dans la langue détectée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.i18n.detectLanguage")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.md
@@ -34,9 +34,9 @@ None.
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un `array` d'objets `{{WebExtAPIRef('i18n.LanguageCode')}}`.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.i18n.getAcceptLanguages")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/i18n/getmessage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/i18n/getmessage/index.md
@@ -43,9 +43,9 @@ browser.i18n.getMessage(
 
 `string`. Message localisé pour les paramètres régionaux en cours.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.i18n.getMessage")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.md
@@ -32,9 +32,9 @@ Aucun
 
 `string`. Le code de langue de l'interface utilisateur du navigateur en tant que {{WebExtAPIRef("i18n.LanguageCode")}}.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.i18n.getUILanguage")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/i18n/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/i18n/index.md
@@ -40,7 +40,7 @@ Pour plus de détails sur l'utilisation de i18n pour votre extension, voir :
 
 ## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.i18n")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/i18n/languagecode/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/i18n/languagecode/index.md
@@ -23,9 +23,9 @@ Une [balise de langue](https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#se
 
 Les valeurs de ce type sont des chaînes.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.i18n.LanguageCode")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.md
@@ -35,9 +35,9 @@ None.
 
 Une chaîne contenant une valeur d'URL de redirection.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.identity.getRedirectURL")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/identity/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/identity/index.md
@@ -56,9 +56,9 @@ Cela aura tendance à être spécifique au fournisseur de services, mais en gén
 - {{WebExtAPIRef("identity.launchWebAuthFlow()")}}
   - : Lancement WAF.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.identity")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.md
@@ -71,9 +71,9 @@ var authorizing = browser.identity.launchWebAuthFlow(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise). Si l'extension est autorisée avec succès, elle sera remplie avec une chaîne contenant l'URL de redirection. L'URL inclura un paramètre qui est un jeton d'accès ou qui peut être échangé contre un jeton d'accès, en utilisant le flux documenté pour le fournisseur de services particulier.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.identity.launchWebAuthFlow")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/idle/idlestate/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/idle/idlestate/index.md
@@ -22,9 +22,9 @@ Chaîne d'écrivant l'état d'inactivité du périphérique.
 
 Les valeurs de ce type sont des chaînes. Les valeurs possibles sont : `"active"`, `"idle"`, `"locked"`.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.idle.IdleState")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/idle/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/idle/index.md
@@ -36,9 +36,9 @@ Pour utiliser cette API, vous disposez de la [permission](/fr/Add-ons/WebExtensi
 - {{WebExtAPIRef("idle.onStateChanged")}}
   - : Définit quand le système change d'état.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.idle")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/idle/onstatechanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/idle/onstatechanged/index.md
@@ -51,9 +51,9 @@ Les événements ont trois fonctions :
     - `newState`
       - : {{WebExtAPIRef('idle.IdleState')}}. Le nouvel état est inactif.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.idle.onStateChanged")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/idle/querystate/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/idle/querystate/index.md
@@ -38,9 +38,9 @@ var querying = browser.idle.queryState(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec une chaîne {{WebExtAPIRef('idle.IdleState')}}, indiquant l'état actuel.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.idle.queryState")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/idle/setdetectioninterval/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/idle/setdetectioninterval/index.md
@@ -33,9 +33,9 @@ browser.idle.setDetectionInterval(
 - `intervalInSeconds`
   - : `integer`. Seuil, en secondes, utilisé pour déterminer quand le système est dans un état inactif. La valeur minimum que vous pouvez fournir ici est 15.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.idle.setDetectionInterval")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/extensioninfo/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/extensioninfo/index.md
@@ -79,9 +79,9 @@ Il s'agit d'un objet avec les propriétés suivantes :
 - `versionName`
   - : `string`. Le nom descriptif pour la version de l'extension, tiré de la clé [version_name](/fr/Add-ons/WebExtensions/manifest.json/version_name) du manifest.json.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.management.ExtensionInfo")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/get/index.md
@@ -37,9 +37,9 @@ var gettingInfo = browser.management.get(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un objet {{WebExtAPIRef("management.ExtensionInfo", "ExtensionInfo")}} , contenant les informations sur l'extension. La promise sera rejetée si aucune extension avec l'ID donné n'est installée ou si l'appelant ne peut pas accéder à l'extension.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.management.get")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/getall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/getall/index.md
@@ -36,9 +36,9 @@ None.
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera rempli avec un ensemble d'objets {{WebExtAPIRef("management.ExtensionInfo", "ExtensionInfo")}}, un pour chaque extension installée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.management.getAll")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbyid/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbyid/index.md
@@ -37,9 +37,9 @@ var gettingWarnings = browser.management.getPermissionWarningsById(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un ensemble de chaînes, chacune contenant un texte d'un avertissement de permissions.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.management.getPermissionWarningsById")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.md
@@ -37,9 +37,9 @@ var gettingWarnings = browser.management.getPermissionWarningsByManifest(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera rempli avec un ensemble de chaînes, chacune contenant le texte un avertisseur de permission.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.management.getPermissionWarningsByManifest")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/getself/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/getself/index.md
@@ -34,9 +34,9 @@ Aucun.
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un objet {{WebExtAPIRef("management.ExtensionInfo", "ExtensionInfo")}}, contenant les informations sur l'extension.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.management.getSelf")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/index.md
@@ -62,9 +62,9 @@ La plupart de ces opérations requièrent les [permissions d'APIs](/fr/Add-ons/W
 - {{WebExtAPIRef("management.onDisabled")}}
   - : Action quand un module complémenaire est désactivé.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.management")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/install/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/install/index.md
@@ -34,9 +34,9 @@ let {id} = await browser.management.install({url});
 
 Une [Promise](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un objet, contenant l'`ExtensionID` défini pour le thème dans manifest.json.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.management.install")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/ondisabled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/ondisabled/index.md
@@ -46,9 +46,9 @@ Les événement ont trois fonctions :
     - `info`
       - : [`ExtensionInfo`](/fr/docs/Mozilla/Add-ons/WebExtensions/API/management/ExtensionInfo): informations de l'extension qui a été désactivé
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.management.onDisabled")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/onenabled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/onenabled/index.md
@@ -46,9 +46,9 @@ Les événements ont trois fonctions :
     - `info`
       - : [`ExtensionInfo`](/fr/Add-ons/WebExtensions/API/management/ExtensionInfo): informations de l'extension qui a été désinstallé.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.management.onEnabled")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/oninstalled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/oninstalled/index.md
@@ -46,9 +46,9 @@ Les événements ont trois fonctions :
     - `info`
       - : [`ExtensionInfo`](/fr/Add-ons/WebExtensions/API/management/ExtensionInfo): informations sur l'extension qui a été installée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.management.onInstalled")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/onuninstalled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/onuninstalled/index.md
@@ -46,9 +46,9 @@ Les événement ont trois fonctions :
     - `info`
       - : [`ExtensionInfo`](/fr/Add-ons/WebExtensions/API/management/ExtensionInfo): informations de l'extension qui a été désinstallé.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.management.onUninstalled")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/setenabled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/setenabled/index.md
@@ -42,9 +42,9 @@ var settingEnabled = browser.management.setEnabled(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promisee) qui sera remplie sans arguments lorsque l'extension a été désactivé ou activé.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.management.setEnabled")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/uninstall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/uninstall/index.md
@@ -44,9 +44,9 @@ var uninstalling = browser.management.uninstall(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera rejetée avec un message d'erreur si l'utilisateur a annulé la désintallatiion.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.management.uninstall")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/management/uninstallself/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/management/uninstallself/index.md
@@ -43,9 +43,9 @@ var uninstallingSelf = browser.management.uninstallSelf(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera rejetée avec un message d'erreur si l'utilisateur a annulé la désinstallation.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.management.uninstallSelf")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/action_menu_top_level_limit/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/action_menu_top_level_limit/index.md
@@ -22,9 +22,9 @@ Sa valeur est de `6` pour Firefox et Chrome.
 
 Pour la compatibilité avec d'autres navigateurs, Firefox rend cette propriété disponible via l'espace de noms `contextMenus` ainsi que l'espace de noms des `menus`.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.menus.ACTION_MENU_TOP_LEVEL_LIMIT", 10)}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/contexttype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/contexttype/index.md
@@ -56,9 +56,9 @@ Les valeurs de ce type sont des chaînes. L'élément est affiché lorsque le co
 
 Notez que "launcher" n'est pas supporté.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.menus.ContextType", 10)}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/create/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/create/index.md
@@ -180,9 +180,9 @@ browser.menus.onClicked.addListener(function(info, tab) {
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.menus.create", 10)}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/gettargetelement/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/gettargetelement/index.md
@@ -58,9 +58,9 @@ browser.menus.create({
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.menus.getTargetElement")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/index.md
@@ -153,9 +153,9 @@ browser.menus.create({
 - {{WebExtAPIRef("menus.onShown")}}
   - : Lancé lorsque le navigateur affiche un menu.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{ Compat("webextensions.api.menus", 1, "true") }}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/itemtype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/itemtype/index.md
@@ -31,9 +31,9 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont:
 - separator
   - : Une ligne séparant un groupe d'éléments.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.menus.ItemType", 10)}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/onclickdata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/onclickdata/index.md
@@ -59,9 +59,9 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `wasChecked` {{optional_inline}}
   - : `boolean`. Un indicateur indiquant si une case à cocher ou un élément radio a été vérifié avant d'avoir cliqué.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.menus.OnClickData", 10)}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/onclicked/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/onclicked/index.md
@@ -53,10 +53,6 @@ Les événements ont trois fonctions :
     - `tab`
       - : {{WebExtAPIRef('tabs.Tab')}}. Les détails de l'onglet où le clic a eu lieu. Si le clic n'a pas eu lieu dans ou sur un onglet, ce paramètre sera manquant.
 
-## Compatibilté du navigateur
-
-{{Compat("webextensions.api.menus.onClicked", 10)}}
-
 ## Exemples
 
 Cet exemple écoute les clics sur un élément de menu, puis enregistre l'ID de l'élément et l'ID de l'onglet :
@@ -73,6 +69,10 @@ browser.menus.onClicked.addListener((info, tab) => {
               "in tab " + tab.id);
 });
 ```
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/onhidden/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/onhidden/index.md
@@ -47,9 +47,9 @@ Les événements ont trois fonctions :
 - `callback`
   - : Fonction qui sera appelée lorsque cet événement se produit. La fonction sera transmise sans paramètre.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.menus.onHidden", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/onshown/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/onshown/index.md
@@ -121,9 +121,9 @@ Les événements ont trois fonctions :
     - `tab`
       - : {{WebExtAPIRef('tabs.Tab')}}. Les détails de l'onglet où le clic a eu lieu. Si le clic n'a pas eu lieu dans ou sur un onglet, ce paramètre sera manquant.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.menus.onShown", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/refresh/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/refresh/index.md
@@ -39,9 +39,9 @@ Aucun.
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se réalise sans arguments.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.menus.refresh", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/remove/index.md
@@ -68,9 +68,9 @@ browser.menus.onClicked.addListener(function(info, tab) {
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.menus.remove", 10)}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/removeall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/removeall/index.md
@@ -37,9 +37,9 @@ None.
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie sans argument lorsque tous les éléments ont été supprimés.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.menus.removeAll", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/menus/update/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/menus/update/index.md
@@ -147,9 +147,9 @@ browser.menus.onClicked.addListener(function(info, tab) {
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.menus.update", 10)}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/clear/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/clear/index.md
@@ -37,9 +37,9 @@ var clearing = browser.notifications.clear(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un booléen : `true` la notification a été effacée, ou `false` si ce n'est pas le cas (par exemple, parce que la notification référencée par `id` n'existe pas).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.notifications.clear")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/create/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/create/index.md
@@ -46,9 +46,9 @@ var creating = browser.notifications.create(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie lorsque la notification est créée et que le processus d'affichage a été démarré, avant que la notification ne s'affiche réellement à l'utilisateur. Il est rempli avec une chaîne représentant l'identifiant de la notification.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.notifications.create")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/getall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/getall/index.md
@@ -36,9 +36,9 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se
 
 Notez que vous pouvez définir explicitement un ID pour une notification en le passant dans {{WebExtAPIRef("notifications.create()")}}. Si vous ne le faites pas, le navigateur en générera un. Les ID spécifiés explicitement sont des chaînes, mais les ID générés sont des nombres.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.notifications.getAll")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/index.md
@@ -49,9 +49,9 @@ La notification est identique sur tous les systèmes d'exploitation de bureau. Q
 - {{WebExtAPIRef("notifications.onShown")}}
   - : Lancé immédiatement après l'affichage d'une notification.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.notifications")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.md
@@ -71,9 +71,9 @@ Les trois premières propriétés - `type`, `title`, `message` - sont obligatoir
 
 Notez que les propriétés `appIconMaskUrl` et `isClickable` ne sont pas supportées.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.notifications.NotificationOptions")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/onbuttonclicked/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/onbuttonclicked/index.md
@@ -48,9 +48,9 @@ Les événements ont trois fonctions :
     - `buttonIndex`
       - : `integer`. L'index [zero-based](https://en.wikipedia.org/wiki/Zero-based_numbering) du bouton sur lequel vous avez cliqué.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.notifications.onButtonClicked")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/onclicked/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/onclicked/index.md
@@ -46,9 +46,9 @@ Les événements ont trois fonctions :
     - `notificationId`
       - : `string`. ID de la notification sur laquelle l'utilisateur a cliqué.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.notifications.onClicked")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/onclosed/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/onclosed/index.md
@@ -48,9 +48,9 @@ Les événements ont trois fonctions :
     - `byUser`
       - : `boolean`. `true` si la notification a été fermée par l'utilisateur, ou `false`si elle a été fermée par le système. Cet argument n'est pas supporté dans Firefox.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.notifications.onClosed")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/onshown/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/onshown/index.md
@@ -45,9 +45,9 @@ Les événements ont trois fonctions :
     - `notificationId`
       - : `string`. ID de la notification qui a été affichée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.notifications.onShown")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/templatetype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/templatetype/index.md
@@ -46,9 +46,9 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 
 Actuellement Firefox ne supporte que "basic" ici.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.notifications.TemplateType")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/notifications/update/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/notifications/update/index.md
@@ -40,9 +40,9 @@ var updating = browser.notifications.update(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un booléen : `true` si la notification a été mise à jour, ou `false` si ce n'est pas le cas (par exemple, parce que la notification référencée par `id` n'existe pas).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.notifications.update")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/omnibox/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/omnibox/index.md
@@ -49,9 +49,9 @@ L'API omnibox fournit à l'extension un moyen de personnaliser les suggestions a
 - {{WebExtAPIRef("omnibox.onInputCancelled")}}
   - : Lancé lorsque l'utilisateur supprime la liste déroulante de la barre d'adresse, après avoir défini la barre d'adresse et tapé le mot clé omnibox de votre extension.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.omnibox")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputcancelled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputcancelled/index.md
@@ -38,9 +38,9 @@ Les événements ont trois fonctions :
 
 La fonction d'écouteur n'a pas de paramètres.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.omnibox.onInputCancelled")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputchanged/index.md
@@ -50,7 +50,7 @@ The listener function will be passed two parameters: a string `text`, and a call
 - `suggest`
   - : `Function`. Une fonction de rappel que l'écouteur d'événement peut appeler pour fournir des suggestions pour la liste déroulante de la barre d'adresse. La fonction de rappel s'attend à recevoir un tableau d'objets {{WebExtAPIRef("omnibox.SuggestResult")}} un pour chaque suggestion. Seules les six premières suggestions seront affichées.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
 {{Compat}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.md
@@ -50,9 +50,9 @@ La fonction d'écouteur recevra deux paramètres: une chaine de `text`, et un {{
 - `disposition`
   - : {{WebExtAPIRef("omnibox.OnInputEnteredDisposition", "OnInputEnteredDisposition")}}. Une {{WebExtAPIRef("omnibox.OnInputEnteredDisposition")}} énumération, indiquant si l'extension doit ouvrir la page dans l'onglet en cours, dans un nouvel onglet de premier plan ou dans un nouvel onglet d'arrière-plan.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.omnibox.onInputEntered")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputentereddisposition/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputentereddisposition/index.md
@@ -30,9 +30,9 @@ Les valeurs de ce type sont des chaînes. Ils peuvent prendre l'une des valeurs 
 - "newBackgroundTab"
   - : Ouvrez la sélection dans un nouvel onglet d'arrière-plan, en conservant l'onglet en cours au premier plan.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.omnibox.OnInputEnteredDisposition")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputstarted/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/omnibox/oninputstarted/index.md
@@ -43,9 +43,9 @@ Les événements ont trois fonctions :
 - `callback`
   - : Fonction qui sera appelée lorsque cet événement se produit. La fonction sera passée sans arguments.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.omnibox.onInputStarted")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/omnibox/setdefaultsuggestion/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/omnibox/setdefaultsuggestion/index.md
@@ -36,9 +36,9 @@ browser.omnibox.setDefaultSuggestion(
 
 None.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.omnibox.setDefaultSuggestion")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/omnibox/suggestresult/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/omnibox/suggestresult/index.md
@@ -28,9 +28,9 @@ Les valeurs de ce type sont des objets. Ils ont les propriétés suivantes :
 - `description`
   - : C'est la chaîne qui est affichée dans la liste déroulante de la barre d'adresse.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.omnibox.SuggestResult")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.md
@@ -41,9 +41,9 @@ var gettingPopup = browser.pageAction.getPopup(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera accompli avec une chaîne contenant l'URL du popup.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.pageAction.getPopup")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.md
@@ -41,9 +41,9 @@ var gettingTitle = browser.pageAction.getTitle(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera accomplie avec une chaîne contenant le titre de l'action de la page.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.pageAction.getTitle")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/hide/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/hide/index.md
@@ -33,9 +33,9 @@ browser.pageAction.hide(
 - `tabId`
   - : `integer`. L'ID de l'onglet pour lequel vous souhaitez masquer l'action de la page.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.pageAction.hide")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/imagedatatype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/imagedatatype/index.md
@@ -22,9 +22,9 @@ Données en pixel pour une image.
 
 Un objet [`ImageData`](/fr/docs/Web/API/ImageData) , par exemple à partir d'un élément {{htmlelement("canvas")}}.
 
-## Browser compatibility
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.pageAction.ImageDataType")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/index.md
@@ -58,9 +58,9 @@ Les actions de page sont pour des actions qui ne sont pertinentes que pour des p
 - {{WebExtAPIRef("pageAction.onClicked")}}
   - : Activé lorsqu'une icône d'action de page est cliquée. Cet événement ne se déclenchera pas si l'action de la page comporte une fenêtre contextuelle.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.pageAction")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/isshown/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/isshown/index.md
@@ -40,9 +40,9 @@ let gettingIsShown = browser.pageAction.isShown(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec `true` si l'action de page de l'extension est affichée pour l'onglet donné, et `false` dans le cas contraire.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.pageAction.isShown")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.md
@@ -48,9 +48,9 @@ Les événements ont trois fonctions :
     - `tab`
       - : Un objet {{WebExtAPIRef('tabs.Tab')}} représentant l'onglet dont l'action de la page a été cliquée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.pageAction.onClicked")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/openpopup/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/openpopup/index.md
@@ -31,9 +31,9 @@ None.
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui est résolue sans arguments.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.pageAction.openPopup", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/setpopup/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/setpopup/index.md
@@ -37,9 +37,9 @@ browser.pageAction.setPopup(
     - `popup`
       - : `string`. URL vers le fichier HTML à afficher dans un popup. Si elle est définie sur une chaîne vide (''), aucune fenêtre contextuelle n'est affichée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.pageAction.setPopup")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/settitle/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/settitle/index.md
@@ -37,9 +37,9 @@ browser.pageAction.setTitle(
     - `title`
       - : `string`. Le texte de l'info-bulle.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.pageAction.setTitle")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pageaction/show/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pageaction/show/index.md
@@ -39,9 +39,9 @@ browser.pageAction.show(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec `undefined`.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.pageAction.show")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/permissions/contains/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/permissions/contains/index.md
@@ -37,9 +37,9 @@ var getContains = browser.permissions.contains(
 
 Une [`Promesse`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Promise) qui sera remplie avec `true` si l'extension possède déjà toutes les permissions listées dans l'argument des `permissions` , ou `false` dans le cas contraire.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.permissions.contains")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/permissions/getall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/permissions/getall/index.md
@@ -32,9 +32,9 @@ None.
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un objet {{WebExtAPIRef("permissions.Permissions")}} contenant toutes les permissions actuellement accordées à l'extensions. Cela inclut toutes les permissions que l'extension à répertoriées dans la clé de [`permissions`](/fr/Add-ons/WebExtensions/manifest.json/permissions) , et toutes les permissions répertoriées dans [`optional_permissions`](/fr/Add-ons/WebExtensions/manifest.json/optional_permissions) que l'extension a été accordée en appelant {{WebExtAPIRef("permissions.request()")}}.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.permissions.getAll")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/permissions/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/permissions/index.md
@@ -51,9 +51,9 @@ Pour utiliser l'API de permissions, déterminez les permissions que votre extens
 - {{WebExtAPIRef("permissions.onRemoved")}}
   - : Déclenché lorsque une permission est supprimée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.permissions")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/permissions/onadded/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/permissions/onadded/index.md
@@ -44,9 +44,9 @@ Les événements ont trois fonctions :
     - `permissions`
       - : Objet {{WebExtAPIRef("permissions.Permissions")}} contenant les permissions qui ont été accordées.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.permissions.onAdded")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/permissions/onremoved/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/permissions/onremoved/index.md
@@ -44,9 +44,9 @@ Les événements ont trois fonctions :
     - `permissions`
       - : L'objet {{WebExtAPIRef("permissions.Permissions")}} contenant les permissions qui ont été supprimées.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.permissions.onRemoved")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/permissions/permissions/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/permissions/permissions/index.md
@@ -24,9 +24,9 @@ Un {{jsxref("object")}} avec les propriétés suivantes :
 - `permissions`{{optional_inline}}
   - : Un tableau de permissions nommées, y compris les [permissions d'API](/fr/Add-ons/WebExtensions/manifest.json/permissions#API_permissions) et les [permissions du presse-papiers](/fr/Add-ons/WebExtensions/manifest.json/permissions#Clipboard_access).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.permissions.Permissions")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/permissions/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/permissions/remove/index.md
@@ -37,10 +37,6 @@ var removing = browser.permissions.remove(
 
 Une [`Promesse`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Promise) qui sera remplie avec `true` si les permissions répertoriées dans l'argument `permissions` ont été supprimées, ou `false` dans le cas contraire.
 
-## Browser compatibility
-
-{{Compat("webextensions.api.permissions.remove")}}
-
 ## Exemples
 
 Ce code ajoute un gestionnaire de clic qui supprime une permission donnée.
@@ -59,6 +55,10 @@ function remove() {
 
 document.querySelector("#remove").addEventListener("click", remove);
 ```
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/permissions/request/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/permissions/request/index.md
@@ -43,9 +43,9 @@ var requesting = browser.permissions.request(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec `true` si l'extension a reçu toutes les permissions répertoriées dans l'argument des `permissions` , ou `false` dans le cas contraire.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.permissions.request")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pkcs11/getmoduleslots/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pkcs11/getmoduleslots/index.md
@@ -58,9 +58,9 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se
 
 Si le module n'a pas pu être trouvé ou qu'une autre erreur se produit, la promise sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.pkcs11.getModuleSlots")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pkcs11/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pkcs11/index.md
@@ -62,6 +62,6 @@ Pour plus de détails sur le contenu et l'emplacement du fichier de manifeste, v
 - {{WebExtAPIRef("pkcs11.uninstallModule()")}}
   - : Désinstalle le module PKCS # 11 nommé.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.pkcs11", 1, 1)}} {{WebExtExamples("h2")}}
+{{Compat}} {{WebExtExamples("h2")}}

--- a/files/fr/mozilla/add-ons/webextensions/api/pkcs11/installmodule/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pkcs11/installmodule/index.md
@@ -41,9 +41,9 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se
 
 Si le module n'a pas pu être trouvé ou qu'une autre erreur se produit, la promise sera rejetée avec un message d'erreur.
 
-## Browser compatibility
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.pkcs11.installModule", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pkcs11/ismoduleinstalled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pkcs11/ismoduleinstalled/index.md
@@ -38,9 +38,9 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se
 
 Si une erreur se produit dans le module, la promise sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.pkcs11.isModuleInstalled", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/pkcs11/uninstallmodule/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/pkcs11/uninstallmodule/index.md
@@ -38,9 +38,9 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se
 
 Si le module n'a pas pu être trouvé ou qu'une autre erreur se produit, la promise sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.pkcs11.uninstallModule", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/privacy/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/privacy/index.md
@@ -26,9 +26,9 @@ Pour utiliser l'API de confidentialité, vous devez avoir [l'autorisation de l'A
 - {{WebExtAPIRef("privacy.websites")}}
   - : Accès et modification des paramètres de confidentialité relatifs aux comportements des sites Web.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.privacy", 10, 1)}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 


### PR DESCRIPTION
This PR updates some of the browser compatibility data and specification sections for the French locale. Part of work for #11594.

Note: this may also include other minor updates, such as removal of old sections or other small bits of cleanup.
