### PR TITLE
fr: Update browser compat/spec sections (part 4)

### DIFF
--- a/files/fr/mozilla/add-ons/webextensions/api/privacy/network/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/privacy/network/index.md
@@ -29,9 +29,9 @@ Les valeurs par défaut de ces propriétés peuvent varier selon les navigateurs
   - : Un objet {{WebExtAPIRef("types.BrowserSetting")}} dont la valeur contenue est une chaîne de caractères. Ce paramètre permet aux utilisateurs de spécifier les compromissions de performance / confidentialité des médias qui affectent la façon dont le trafic WebRTC sera acheminé et la quantité d'informations d'adresse locale exposées. Il peut prendre l'une des valeurs suivantes :
     `"default" "default_public_and_private_interfaces" "default_public_interface_only" "disable_non_proxied_udp"`
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.privacy.network")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/privacy/services/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/privacy/services/index.md
@@ -21,9 +21,9 @@ La propriété {{WebExtAPIRef("privacy.services")}} contient des paramètres li�
 - `passwordSavingEnabled`
   - : Un objet {{WebExtAPIRef("types.BrowserSetting")}} dont la valeur contenue est un booléen. Si il est défini à `true`, le gestionnaire de mot de passe du navigateur proposera de stocker des mots de passe lorsque l'utilisateur les entrera. La valeur par défaut est : `true`.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.privacy.services", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/privacy/websites/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/privacy/websites/index.md
@@ -71,9 +71,9 @@ Les valeurs par défaut de ces propriétés ont tendance à varier selon les nav
     - `"never"`: La protection de suivi est désactivée.
     - `"private_browsing"`: La protection de suivi est activée uniquement dans les fenêtres de navigation privée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.privacy.websites")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/proxy/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/proxy/index.md
@@ -53,6 +53,6 @@ Pour utiliser cette API, vous devez disposer de la [permission](/fr/Add-ons/WebE
 
 {{WebExtExamples("h2")}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.proxy")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/api/proxy/onerror/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/proxy/onerror/index.md
@@ -49,6 +49,6 @@ Les événements ont trois fonctions :
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.proxy.onError")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/api/proxy/onrequest/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/proxy/onrequest/index.md
@@ -74,9 +74,9 @@ Les événements ont trois fonctions :
 - `extraInfoSpec` {{optional_inline}}
   - : `array` de `string`. Options supplémentaires pour l'événement. Vous pouvez passer une seule valeur, `"requestHeaders"`, pour inclure les en-têtes de demande dans l'objet de `details` transmis à l'écouteur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.proxy.onRequest", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.md
@@ -53,8 +53,8 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `connectionIsolationKey` {{optional_inline}}
   - : `string.` Une clé optionnelle utilisée pour l'isolation supplémentaire de cette connexion proxy.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.proxy.ProxyInfo")}}
+{{Compat}}
 
 {{WebExtExamples}}

--- a/files/fr/mozilla/add-ons/webextensions/api/proxy/register/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/proxy/register/index.md
@@ -157,9 +157,9 @@ browser.proxy.register(proxyScriptURL);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.proxy.register")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/proxy/requestdetails/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/proxy/requestdetails/index.md
@@ -50,8 +50,8 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `url`
   - : `string`. Cible de la demande.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.proxy.RequestDetails")}}
+{{Compat}}
 
 {{WebExtExamples}}

--- a/files/fr/mozilla/add-ons/webextensions/api/proxy/settings/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/proxy/settings/index.md
@@ -62,6 +62,6 @@ browser.proxy.settings.set({value: proxySettings});
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.proxy.settings", 10)}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/api/proxy/unregister/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/proxy/unregister/index.md
@@ -45,9 +45,9 @@ browser.proxy.unregister();
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.proxy.unregister")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/connect/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/connect/index.md
@@ -51,9 +51,9 @@ var port = browser.runtime.connect(
 
 {{WebExtAPIRef('runtime.Port')}}. Port à travers lequel les messages peuvent être envoyés et reçus. L'événement `onDisconnect` du port est déclenché si l'extension n'existe pas.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.connect")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/connectnative/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/connectnative/index.md
@@ -35,9 +35,9 @@ var port = browser.runtime.connectNative(
 
 Un objet {{WebExtAPIRef('runtime.Port')}}. Le port que l'appelant peut utiliser pour échanger des messages avec l'application native.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.connectNative")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/getbackgroundpage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/getbackgroundpage/index.md
@@ -42,9 +42,9 @@ None.
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec l'objet [Window](/fr/docs/User%3Amaybe/webidl_mdn/Window) pour la page d'arrière plan, s'il y en a une. Si l'extension n'inclut pas de page d'arrière-plan, la promise est rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.getBackgroundPage")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/getbrowserinfo/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/getbrowserinfo/index.md
@@ -38,9 +38,9 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se
 - **`version`**: Chaîne représentant la version du navigateur, par exemple "51.0" or "51.0a2".
 - **`buildID`**: Chaine représentant la version spécifique du navigateur, par exemple "20161018004015".
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.getBrowserInfo")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.md
@@ -30,9 +30,9 @@ None.
 
 Un `object` JSON représentant le manifest.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.getManifest")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/getpackagedirectoryentry/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/getpackagedirectoryentry/index.md
@@ -34,9 +34,9 @@ None.
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un objet `DirectoryEntry` représentant le répertoire du package.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.getPackageDirectoryEntry")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/getplatforminfo/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/getplatforminfo/index.md
@@ -34,9 +34,9 @@ None.
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec une valeur {{WebExtAPIRef('runtime.PlatformInfo')}} représentant la plate-forme actuelle.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.getPlatformInfo")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/geturl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/geturl/index.md
@@ -33,9 +33,9 @@ browser.runtime.getURL(
 
 `string`. L'URL complète de la ressource.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.getURL")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/id/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/id/index.md
@@ -28,9 +28,9 @@ var myAddonId = browser.runtime.id;
 
 Une `chaîne` représentant l'ID du module complémentaire. Si l'extension a spécifié un ID dans la clé manifest.json de ses [applications](/fr/Add-ons/WebExtensions/manifest.json/applications), `runtime.id` contiendra la valeur. SInon `runtime.id` contiendra l'ID généré pour l'extension.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.id")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/index.md
@@ -105,9 +105,9 @@ Il fournit également des API de messagerie vous permettant de:
 - {{WebExtAPIRef("runtime.onRestartRequired")}}
   - : Lancé lorsque le périphérique doit être redémarré.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/lasterror/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/lasterror/index.md
@@ -74,9 +74,9 @@ setCookie.then(logCookie, logError);
 
 > **Note :** `runtime.lastError` est un alias pour {{WebExtAPIRef("extension.lastError")}}: Ils sont ensemble, et la vérification de l'un fonctionnera.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.lastError")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/messagesender/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/messagesender/index.md
@@ -35,9 +35,9 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `tlsChannelId`{{optional_inline}}
   - : `string`. L'ID de canal TLS de la page ou du cadre qui a ouvert la connexion, si demandé par l'extension, et si disponible.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.MessageSender")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.md
@@ -42,9 +42,9 @@ Les événements ont trois fonctions :
 - `function`
   - : Une fonction de rappel qui sera appelée lorsque cet événement se produira.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.onBrowserUpdateAvailable")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onconnect/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onconnect/index.md
@@ -46,9 +46,9 @@ Les événements ont trois fonctions :
     - `port`
       - : Un objet {{WebExtAPIRef('runtime.Port')}} connectant le script courant à l'autre contexte auquel il se connecte.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.onConnect")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.md
@@ -50,9 +50,9 @@ Les événements ont trois fonctions :
     - `port`
       - : Un objet {{WebExtAPIRef('runtime.Port')}} connectant le script en cours à l'autre extension à laquelle il se connecte.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.onConnectExternal")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.md
@@ -58,9 +58,9 @@ Les événements ont trois fonctions :
         - `temporary`
           - : `boolean`. Vrai si le module complémentaire a été installé temporairement. Par exemple, en utilisant la page "about:debugging" dans Firefox ou en utilisant [web-ext run](/fr/Add-ons/WebExtensions/Getting_started_with_web-ext). Sinon faux.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.onInstalled", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/oninstalledreason/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/oninstalledreason/index.md
@@ -31,9 +31,9 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 - `"shared_module_update"`
   - : Une autre extension, qui contient un module utilisé par cette extension, a été mise à jour.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.OnInstalledReason")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
@@ -126,7 +126,7 @@ Les événements ont trois fonctions&nbsp;:
 
 ## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.onMessage")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onmessageexternal/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onmessageexternal/index.md
@@ -71,9 +71,9 @@ Les événements ont trois fonctions:
         - Soit garder une référence à l'argumen `sendResponse` et retourne `true` à partir de la fonction d'écouteur. Vous pourrez ensuite appeler `sendResponse` après le retour de la fonction d'écouteur..
         - ou retourne une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) de la fonction d'écouteur et résoudre la promesse lorsque la réponse est prête.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.onMessageExternal")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onrestartrequired/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onrestartrequired/index.md
@@ -46,9 +46,9 @@ Les événements ont trois fonctions :
     - `raison`
       - : Une valeur {{WebExtAPIRef('runtime.OnRestartRequiredReason')}} — La raison pour laquelle l'événemtn est envoyé.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.onRestartRequired")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onrestartrequiredreason/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onrestartrequiredreason/index.md
@@ -26,9 +26,9 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 - `"os_update"`: Le navigateur / Système d'exploitation est mise à jour vers une nouvelle verion plus récente.
 - `"periodic"`: Le système a fonctionné pendant plus logntemps que la durée de disponibilité autorisée dans la stratégie d'entreprise.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.OnRestartRequiredReason")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onstartup/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onstartup/index.md
@@ -92,6 +92,6 @@ browser.runtime.onStartup.addListener(handleStartup);
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.onStartup")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onsuspend/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onsuspend/index.md
@@ -44,9 +44,9 @@ Les événements ont trois fonctions :
 - `callback`
   - : Fonction dui sera appelée lorsque cet événement se produit
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.onSuspend")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onsuspendcanceled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onsuspendcanceled/index.md
@@ -42,9 +42,9 @@ Les événements ont trois fonctions :
 - `callback`
   - : Fonction qui sera appelée lorsque cet événement se produit.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.onSuspendCanceled")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/onupdateavailable/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/onupdateavailable/index.md
@@ -52,9 +52,9 @@ Les événements ont trois fonctions :
     - `details`
       - : `object`. Contient une seule propriété, une chaîne nommée `version`, qui représente le numéro de version de la mise à jour.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.onUpdateAvailable")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.md
@@ -22,9 +22,9 @@ None.
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie sans argument lorsque la page d'options a été créée avec succés, ou rejetée avec un message d'erreur si l'opération a échoué.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.openOptionsPage")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/platformarch/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/platformarch/index.md
@@ -29,9 +29,9 @@ Les valeurs de ce type sont des chaînes. Les valeurs possible sont :
 - `"x86-64"`
   - : La plateforme est basé sur l'architecture x86 64-bits.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.PlatformArch")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/platforminfo/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/platforminfo/index.md
@@ -29,9 +29,9 @@ Les valeurs de ce type sont des objets qui contiennent les propriétés suivante
 - `nacl_arch`
   - : {{WebExtAPIRef('runtime.PlatformNaclArch')}}. L'architecture du client natif Cela peut être différent de `arch` sur certaines plates-formes.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.PlatformInfo")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.md
@@ -22,9 +22,9 @@ L'architecture du client natif. Cela peut-etre différent de arch sur certaines 
 
 Les valeurs de type sont des chaînes. Les valeurs possible sont : `"arm"`, `"x86-32"`, `"x86-64"`.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.PlatformNaclArch")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/platformos/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/platformos/index.md
@@ -35,9 +35,9 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont:
 - `"openbsd"`
   - : Le système d'exploitation est sous Open/FreeBSD.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.PlatformOs")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/port/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/port/index.md
@@ -68,9 +68,9 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `sender`{{optional_inline}}
   - : {{WebExtAPIRef('runtime.MessageSender')}}. Contient des informations sur l'expéditeur du message. ette propriété ne sera présente que sur les ports transmis aux écouteurs `onConnect`/`onConnectExternal`.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.Port")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/reload/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/reload/index.md
@@ -30,9 +30,9 @@ browser.runtime.reload()
 
 Aucun.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.reload")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/requestupdatecheck/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/requestupdatecheck/index.md
@@ -43,9 +43,9 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se
     - `version`
       - : `string`. La version de la mise à jour.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.requestUpdateCheck")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/requestupdatecheckstatus/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/requestupdatecheckstatus/index.md
@@ -29,9 +29,9 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 - `"update_available"`
   - : Une mise à jour de l'extension est disponible.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.RequestUpdateCheckStatus")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
@@ -78,10 +78,6 @@ Notez qu'avant Firefox 55, le règles étaient différentes dans le cas des 2 ar
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise). Si le destinataire a envoyé une réponse, celle-ci sera remplie avec la réponse en tant qu'objet JSON. Sinon, il sera rempli sans arguments. si une erreur survient lors de la connexion à l'extension, la promessage sera rejetée avec un message d'erreur.
 
-## Compatibilité du navitageur
-
-{{Compat("webextensions.api.runtime.sendMessage")}}
-
 ## Exemples
 
 Voici un script de contenu qui envoie un message au script d'arrière-plan lorsque l'utilisateur clique sur la fenêtre de contenu. La charge utile du message est `{greeting: "Greeting from the content script"}`, et l'expéditeur s'attend également à recevoir une réponse, qui est gérée dans la fonction `handleResponse` :
@@ -120,6 +116,10 @@ function handleMessage(request, sender, sendResponse) {
 
 browser.runtime.onMessage.addListener(handleMessage);
 ```
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.md
@@ -46,9 +46,9 @@ var sending = browser.runtime.sendNativeMessage(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise). Si l'expéditeur a envoyé une réponse, celle-ci sera remplie avec la réponse en tant qu'objet JSON. Sinon, il sera rempli sans arguments. Si une erreur survient lors de la connexion à l'application native, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.sendNativeMessage")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/runtime/setuninstallurl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/runtime/setuninstallurl/index.md
@@ -37,9 +37,9 @@ var settingUrl = browser.runtime.setUninstallURL(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie sans argument lorsque l'URL a été définie ou rejetée avec un message d'erreur si l'opération a échoué.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.runtime.setUninstallURL")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/search/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/search/get/index.md
@@ -43,9 +43,9 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se
 - `favIconUrl`{{optional_inline}}
   - : `string`. L'icône du moteur de recherche, comme une donnée : URL.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.search.search", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/search/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/search/index.md
@@ -25,6 +25,6 @@ Pour utiliser cette API, vous devez avoir la [permission](/fr/Add-ons/WebExtensi
 - {{WebExtAPIRef("search.search()")}}
   - : Recherche à l'aide du moteur de recherche spécifié.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.search", 1, 1)}} {{WebExtExamples("h2")}}
+{{Compat}} {{WebExtExamples("h2")}}

--- a/files/fr/mozilla/add-ons/webextensions/api/search/search/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/search/search/index.md
@@ -48,9 +48,9 @@ browser.search.search(
 
 Aucune
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.search.search", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/filter/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/filter/index.md
@@ -25,9 +25,9 @@ Les valeurs de ce type sont des objets. Ils contiennent les proriétés suivante
 - `maxResults`{{optional_inline}}
   - : `number`. Le nombre maximal de résultats à retourner.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.sessions.Filter")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/forgetclosedtab/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/forgetclosedtab/index.md
@@ -39,9 +39,9 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise). Cela 
 
 Si une erreur se produit, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.sessions.forgetClosedTab")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/forgetclosedwindow/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/forgetclosedwindow/index.md
@@ -36,9 +36,9 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise). Cela 
 
 Si une erreur se produit, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.sessions.forgetClosedWindow")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.md
@@ -39,9 +39,9 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise). Cela 
 
 Si une erreur survient, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.sessions.getRecentlyClosed")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/gettabvalue/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/gettabvalue/index.md
@@ -41,9 +41,9 @@ var retrieving = browser.sessions.getTabValue(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera résolue avec la valeur si elle existe, ou `undefined`. Si elle n'existe pas. Si l'appel a échoué (par exemple, parce que l'ID de l'onglet n'a pas pu être trouvé), la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.sessions.getTabValue", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/getwindowvalue/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/getwindowvalue/index.md
@@ -41,9 +41,9 @@ var retrieving = browser.sessions.getWindowValue(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera résolue avec la valeur si elle existe, ou `undefined` si elle n'existe pas. Si l'appel a échoué (par exemple, parce que l'ID de la fenêtre n'a pas pu être trouvé), la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.sessions.getWindowValue", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/index.md
@@ -64,9 +64,9 @@ Pour utiliser l'API des sessions, vous devez avoir la [permission API](/fr/Add-o
 - {{WebExtAPIRef("sessions.onChanged")}}
   - : Mise en place lorsqu'un onglet ou une fenêtre est fermée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.sessions")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/max_session_results/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/max_session_results/index.md
@@ -18,9 +18,9 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/sessions/MAX_SESSION_RESULTS
 
 Le nombre maximum de sessions qui seront retournées par un appel à {{WebExtAPIRef("sessions.getRecentlyClosed()")}}. Il est en lecture seule pour le code des WebExtensions, et défini à 25.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.sessions.MAX_SESSION_RESULTS")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/onchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/onchanged/index.md
@@ -42,9 +42,9 @@ Les événements ont trois fonctions :
 - `callback`
   - : Fonction qui sera appelée lors de l'événement. Il ne passe aucun paramètre.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.sessions.onChanged")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/removetabvalue/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/removetabvalue/index.md
@@ -39,9 +39,9 @@ var removing = browser.sessions.removeTabValue(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui ne sera résolue aucun argument si l'élément a été supprimé avec succès. Si l'appel a échoué (par exemple, parce que l'ID de l'onglet n'a pas pu être trouvé), la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.sessions.removeTabValue", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/removewindowvalue/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/removewindowvalue/index.md
@@ -39,9 +39,9 @@ var removing = browser.sessions.removeWindowValue(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui ne sera résolue aucun argument si l'élément a été supprimé avec succès. Si l'appel a échoué (par exemple, parce que l'ID de la fenêtre n'a pas pu être trouvé), la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.sessions.removeWindowValue", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/restore/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/restore/index.md
@@ -36,9 +36,9 @@ var restoringSession = browser.sessions.restore(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise). Cela sera rempli avec un objet {{WebExtAPIRef("sessions.Session", "Session")}} représentant la session qui a été restaurée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.sessions.restore")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/session/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/session/index.md
@@ -38,9 +38,9 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `window`{{optional_inline}}
   - : `object`. Si l'objet représente une fenêtre fermée, cette propriété est présente et sera un objet {{WebExtAPIRef("windows.Window")}}.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.sessions.Session")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/settabvalue/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/settabvalue/index.md
@@ -44,9 +44,9 @@ var storing = browser.sessions.setTabValue(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera résolue sans argument si l'appel a réussi. Si l'appel a échoué (par exemple, parce que l'ID de l'onglet n'a pas pu être trouvé), la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.sessions.setTabValue", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sessions/setwindowvalue/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sessions/setwindowvalue/index.md
@@ -44,9 +44,9 @@ var storing = browser.sessions.setWindowValue(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera résolue sans argument si l'appel a réussi. Si l'appel a échoué (par exemple, parce que l'ID de la fenêtre n'a pas pu être trouvé), la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.sessions.setWindowValue", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/close/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/close/index.md
@@ -35,9 +35,9 @@ None.
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui est résolue sans arguments.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.sidebarAction.close", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.md
@@ -51,10 +51,6 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se
 moz-extension://d1d8a2eb-fe60-f646-af30-a866c5b39942/sidebar.html
 ```
 
-## Compatibilité du navigateur
-
-{{Compat("webextensions.api.sidebarAction.getPanel",2)}}
-
 ## Exemples
 
 Obtenez l'URL du panneau :
@@ -67,6 +63,10 @@ function onGot(sidebarUrl) {
 var gettingPanel = browser.sidebarAction.getPanel({});
 gettingPanel.then(onGot);
 ```
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.md
@@ -49,10 +49,6 @@ var gettingTitle = browser.sidebarAction.getTitle(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec une chaîne contenant le titre de la barre latérale.
 
-## Compatibilité du navigateur
-
-{{Compat("webextensions.api.sidebarAction.getTitle",2)}}
-
 ## Exemples
 
 Ce code bascule le titre entre "this" et "that" chaque fois que l'utilisateur clique sur l'action du navigateur
@@ -71,6 +67,10 @@ browser.browserAction.onClicked.addListener(() => {
   gettingTitle.then(toggleTitle);
 });
 ```
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/imagedatatype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/imagedatatype/index.md
@@ -21,9 +21,9 @@ Données de pixel pour une image. Doit être un objet [`ImageData`](/fr/docs/Web
 
 Un objet [`ImageData`](/fr/docs/Web/API/ImageData).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.sidebarAction.ImageDataType")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/index.md
@@ -49,9 +49,9 @@ L'API sidebarAction est basée sur l'[API sidebarAction](https://dev.opera.com/e
 - {{WebExtAPIRef("sidebarAction.toggle()")}}
   - : Permet de basculer la visibilité de la barre latérale.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.sidebarAction")}}
+{{Compat}}
 
 ## Exemple extensions
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/isopen/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/isopen/index.md
@@ -45,10 +45,6 @@ let gettingIsOpen = browser.sidebarAction.isOpen(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec `true` si la barre latérale de l'extension est ouverte dans la fenêtre donnée, ou `false` dans le cas contraire.
 
-## Compatibilité du navigateur
-
-{{Compat("webextensions.api.sidebarAction.isOpen",2)}}
-
 ## Exemples
 
 Vérifiez la fenêtre la plus haute :
@@ -73,5 +69,9 @@ browser.windows.getAll().then(all => {
   }
 });
 ```
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 {{WebExtExamples}}

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/open/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/open/index.md
@@ -32,9 +32,9 @@ Aucun
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui est résolue sans arguments..
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.sidebarAction.open", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
@@ -101,10 +101,6 @@ var settingIcon = browser.sidebarAction.setIcon(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie sans argument une fois l'icône définie.
 
-## Compatibilité du navigateur
-
-{{Compat("webextensions.api.sidebarAction.setIcon",2)}}
-
 ## Exemples
 
 Le code ci-dessous bascule l'icône de la barre latérale de l'onglet actif lorsque l'utilisateur clique sur une action du navigateur :
@@ -130,6 +126,10 @@ function toggle(tab) {
 
 browser.browserAction.onClicked.addListener(toggle);
 ```
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/setpanel/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/setpanel/index.md
@@ -21,7 +21,7 @@ Définit le panneau de la barre latérale: c'est-à-dire le document HTML qui d�
 
 Les barres latérales ont toujours un _"panneau manifest"_, qui est le panneau défini dans la clé de manifest [`sidebar_action`](/fr/Add-ons/WebExtensions/manifest.json/sidebar_action).
 
-Si vous définissez un nouveau panneau à l'aide de `setPanel()`, et incluez l'option `tabId` le panneau est défini uniquement pour l'onglet donné. Ce panneau est appelé "tab-specific panel"_.
+Si vous définissez un nouveau panneau à l'aide de `setPanel()`, et incluez l'option `tabId` le panneau est défini uniquement pour l'onglet donné. Ce panneau est appelé "tab-specific panel".
 
 Si vous définissez un nouveau panneau en utilisant `setPanel()`, et incluez l'option `windowId`, alors le panneau n'est défini que pour la fenêtre donnée. Ce panneau est appelé _"panneau spécifique à la fenêtre"_, et apparaîtra dans tous les onglets de cette fenêtre qui n'ont pas d'ensemble de panneaux spécifiques aux onglets.
 
@@ -84,11 +84,11 @@ browser.browserAction.onClicked.addListener(() => {
 });
 ```
 
+## Compatibilité des navigateurs
+
+{{Compat}}
+
 {{WebExtExamples}}
-
-## Compatibilité du navigateur
-
-{{Compat("webextensions.api.sidebarAction.setPanel",2)}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.md
@@ -63,10 +63,6 @@ browser.sidebarAction.setTitle(
 - Si `windowId` et `tabId` sont tous deux fournis, la fonction échoue et le titre n'est pas défini.
 - SI `windowId` et `tabId` sont tous les deux omis, le titre global est définit.
 
-## Compatibilité du navigateur
-
-{{Compat("webextensions.api.sidebarAction.setTitle",2)}}
-
 ## Exemples
 
 Ce code modifie le titre de la barre latérale lorsque l'utilisateur clique sur une action du navigateur, mais uniquement pour l'onglet en cours :
@@ -80,6 +76,10 @@ function setTitleForTab(tab) {
 
 browser.browserAction.onClicked.addListener(setTitleForTab);
 ```
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/toggle/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/sidebaraction/toggle/index.md
@@ -35,9 +35,9 @@ Aucune.
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui est résolue sans discussion.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.sidebarAction.toggle", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/index.md
@@ -55,9 +55,9 @@ Bien que cette API soit semblable à {{domxref("Window.localStorage")}} il est c
 - {{WebExtAPIRef("storage.onChanged")}}
   - : Activé quand un ou plusieurs items d'une zone de stockage sont modifiés.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.storage")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/local/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/local/index.md
@@ -44,9 +44,9 @@ L'objet `local` local implémente les méthodes définies sur le type {{WebExtAP
 - {{WebExtAPIRef("storage.StorageArea.clear()")}}
   - : Supprime tous les éléments de la zone de stockage.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.storage.local")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/managed/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/managed/index.md
@@ -99,9 +99,9 @@ Le fichier json ressemblerait à ceci :
 
 Pour plus d'informations, voir l'article de Chrome pour les zones de stockage [Manifeste pour les zones de stockage](https://developer.chrome.com/extensions/manifest/storage).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.storage.managed")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
@@ -51,9 +51,9 @@ Les événements ont trois fonctions:
     - `areaName`
       - : `string`. Le nom de la zone de stockage (`"sync"`, `"local"` or `"managed"`) auquel les modifications ont été apportées.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.storage.onChanged")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/clear/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/clear/index.md
@@ -37,9 +37,9 @@ None.
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie sans arguments si l'opération a réussi. Si l'opération a échoué, la promesse sera rejetée avec un message d'erreur..
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.storage.StorageArea.clear")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
@@ -43,9 +43,9 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se
 > **Attention :** Lorsqu'elle est utilisée dans un script de contenu dans les versions de Firefox antérieures à 52, la promesse retournée par `browser.storage.local.get()` est remplie avec un tableau contenant un objet. L'objet dans le tableau contient les `clefs` trouvées dans la zone de stockage, comme décrit ci-dessus. La promesse est correctement remplie avec un objet lorsqu'il est utilisé dans le contexte d'arrière-plan
 > (scripts d'arrière-plan, popups, pages d'options, etc.). Lorsque cette API est utilisée en tant que `chrome.storage.local.get()`, elle transmet correctement un objet à la fonction de rappel.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.storage.StorageArea.get")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.md
@@ -40,9 +40,9 @@ var gettingSpace = browser.storage.<storageType>.getBytesInUse(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un entier, `bytesUsed`, représentant l'espace de stockage utilisé par les objets spécifiés dans les `clefs`. Si l'opération a échoué, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.storage.StorageArea.getBytesInUse")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/index.md
@@ -35,9 +35,9 @@ Les valeurs de ce type sont des objets.
 - {{WebExtAPIRef("storage.StorageArea.clear()")}}
   - : Supprime tous les éléments de la zone de stockage.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.storage.StorageArea")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/remove/index.md
@@ -40,9 +40,9 @@ let removingItem = browser.storage.<storageType>.remove(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie sans arguments si l'opération a réussi. Si l'opération a échoué, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.storage.StorageArea.remove")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.md
@@ -47,9 +47,9 @@ let settingItem = browser.storage.<storageType>.set(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie sans arguments si l'opération a réussi. Si l'opération a échoué, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.storage.StorageArea.set")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/storage/storagechange/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/storage/storagechange/index.md
@@ -25,9 +25,9 @@ Les objets `StorageChange` contiennent les propriétés suivantes :
 - `newValue`{{optional_inline}}
   - : La nouvelle valeur de l'article, s'il y a une nouvelle valeur. Cela peut être n'importe quel type de données.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.storage.StorageChange")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/capturetab/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/capturetab/index.md
@@ -60,9 +60,9 @@ browser.browserAction.onClicked.addListener(function() {
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.captureTab")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.md
@@ -61,9 +61,9 @@ browser.browserAction.onClicked.addListener(function() {
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.captureVisibleTab")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/connect/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/connect/index.md
@@ -77,9 +77,9 @@ browser.browserAction.onClicked.addListener(function() {
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.connect")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/create/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/create/index.md
@@ -99,9 +99,9 @@ browser.browserAction.onClicked.addListener(function() {
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.create", 10)}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/detectlanguage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/detectlanguage/index.md
@@ -86,9 +86,9 @@ browser.browserAction.onClicked.addListener(function() {
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.detectLanguage")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/discard/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/discard/index.md
@@ -76,9 +76,9 @@ discarding.then(onDiscarded, onError);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.discard", 10)}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/executescript/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/executescript/index.md
@@ -143,7 +143,7 @@ executing.then(onExecuted, onError);
 
 ## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.executeScript")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/get/index.md
@@ -56,9 +56,9 @@ browser.tabs.onActivated.addListener(logListener);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.get")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/getallinwindow/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/getallinwindow/index.md
@@ -41,9 +41,9 @@ var getting = browser.tabs.getAllInWindow(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Promise) qui sera remplie avec un `tableau` d'ojets `{{WebExtAPIRef('tabs.Tab')}}` contenant des informations sur tous les onglets de la fenêtre. Si la fenêtre n'a pas pu être trouvée ou qu'une autre erreur se produit, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.getAllInWindow")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/getcurrent/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/getcurrent/index.md
@@ -55,9 +55,9 @@ gettingCurrent.then(onGot, onError);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.getCurrent")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/getselected/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/getselected/index.md
@@ -40,9 +40,9 @@ var gettingSelected = browser.tabs.getSelected(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un objet [`tabs.Tab`](/fr/Add-ons/WebExtensions/API/tabs/Tab) contenant des informations sur l'onglet sélectionné. Si l'onglet n'a pas pu être trouvé ou qu'une autre erreur se produit, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.getSelected")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/getzoom/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/getzoom/index.md
@@ -71,9 +71,9 @@ gettingZoom.then(onGot, onError);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.getZoom")}}
+{{Compat}}
 
 > **Note :**
 >


### PR DESCRIPTION
This PR updates some of the browser compatibility data and specification sections for the French locale. Part of work for #11594.

Note: this may also include other minor updates, such as removal of old sections or other small bits of cleanup.
