### PR TITLE
fr: Update browser compat/spec sections (part 5)

### DIFF
--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/getzoomsettings/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/getzoomsettings/index.md
@@ -56,9 +56,9 @@ gettingZoomSettings.then(onGot, onError);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.getZoomSettings")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/goback/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/goback/index.md
@@ -39,9 +39,9 @@ var withgoingBack = browser.tabs.goBack(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui est tenue lorsque la navigation sur la page se termine.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.goBack")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/goforward/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/goforward/index.md
@@ -39,9 +39,9 @@ var goingForward = browser.tabs.goForward(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Promise) qui est tenue lorsque la navigation sur la page se termine.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.goForward")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/hide/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/hide/index.md
@@ -86,6 +86,6 @@ browser.tabs.hide([15, 14, 1]).then(onHidden, onError);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.hide")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/highlight/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/highlight/index.md
@@ -47,9 +47,9 @@ var highlighting = browser.tabs.highlight(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Promise) qui sera remplie avec un objet {{WebExtAPIRef('windows.Window')}} contenant des détails sur la fenêtre dont les onglets ont été mis en surbrillance. Si la fenêtre n'a pas pu être trouvée ou qu'une autre erreur se produit, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.highlight",2)}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/index.md
@@ -169,7 +169,7 @@ De nombreuses opérations d'onglet utilisent un identifiant (`id`) d'onglet. Les
 
 ## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/insertcss/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/insertcss/index.md
@@ -99,9 +99,9 @@ browser.browserAction.onClicked.addListener(() => {
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.insertCSS")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/move/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/move/index.md
@@ -130,9 +130,9 @@ browser.browserAction.onClicked.addListener(function() {
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.move")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/moveinsuccession/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/moveinsuccession/index.md
@@ -46,6 +46,6 @@ browser.tabs.moveInSuccession([1, 3, 5, 7, 2, 9], 4, {insert:true})
     - `insert` {{optional_inline}}
       - : `boolean`. Détermine s'il faut lier les prédécesseurs ou successeurs actuels (selon `options.append`) de `tabId` à l'autre côté de la chaîne après son ajout ou son ajout. Si true, l'un des événements suivants se produit : si `options.append` est `false`, le premier onglet du tableau est défini comme successeur de tout prédécesseur actuel de `tabId`; Si `options.append` est `true`, le successeur actuel de tabId est défini comme le successeur du dernier onglet du tableau. La valeur par défaut est `false`.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.moveInSuccession", 10)}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/mutedinfo/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/mutedinfo/index.md
@@ -29,9 +29,9 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `reason`{{optional_inline}}
   - : {{WebExtAPIRef('tabs.MutedInfoReason')}}. La raison pour laquelle l'onglet a été désactivé ou désactivé. Non défini si l'état muet de l'onglet n'a jamais été modifié.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.MutedInfo")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/mutedinforeason/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/mutedinforeason/index.md
@@ -29,9 +29,9 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 - "user"
   - : L'utilisateur définit l'état muet.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.MutedInfoReason")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onactivated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onactivated/index.md
@@ -72,9 +72,9 @@ browser.tabs.onActivated.addListener(handleActivated);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.onActivated")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onactivechanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onactivechanged/index.md
@@ -63,9 +63,9 @@ Les événements ont trois fonctions :
 - `windowId`
   - : `integer`. L'ID de la fenêtre contenant l'onglet sélectionné.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.onActiveChanged")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onattached/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onattached/index.md
@@ -76,9 +76,9 @@ browser.tabs.onAttached.addListener(handleAttached);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.onAttached")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/oncreated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/oncreated/index.md
@@ -62,9 +62,9 @@ browser.tabs.onCreated.addListener(handleCreated);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.onCreated")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/ondetached/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/ondetached/index.md
@@ -76,9 +76,9 @@ browser.tabs.onDetached.addListener(handleDetached);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.onDetached")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onhighlightchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onhighlightchanged/index.md
@@ -58,9 +58,9 @@ Les événements ont trois fonctions :
 - `tabIds`
   - : `array` d'`integer`. Tous les onglets en surbrillance dans la fenêtre.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.onHighlightChanged")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onhighlighted/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onhighlighted/index.md
@@ -71,9 +71,9 @@ browser.tabs.onHighlighted.addListener(handleHighlighted);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.onHighlighted")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onmoved/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onmoved/index.md
@@ -80,9 +80,9 @@ browser.tabs.onMoved.addListener(handleMoved);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.onMoved")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onremoved/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onremoved/index.md
@@ -76,9 +76,9 @@ browser.tabs.onRemoved.addListener(handleRemoved);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.onRemoved")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onreplaced/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onreplaced/index.md
@@ -68,9 +68,9 @@ browser.tabs.onReplaced.addListener(handleReplaced);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.onReplaced")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onselectionchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onselectionchanged/index.md
@@ -61,9 +61,9 @@ Les événements ont trois fonctions:
 - `windowId`
   - : `integer`. L'ID de la fenêtre dans laquelle l'onglet sélectionné a changé.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.onSelectionChanged")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
@@ -226,9 +226,9 @@ browser.tabs.onUpdated.addListener(
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.onUpdated", 10)}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/onzoomchange/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/onzoomchange/index.md
@@ -75,9 +75,9 @@ browser.tabs.onZoomChange.addListener(handleZoomed);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.onZoomChange")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/pagesettings/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/pagesettings/index.md
@@ -76,8 +76,8 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `shrinkToFit` {{optional_inline}}
   - : `boolean`. Si le contenu de la page doit rétrécir pour s'adapter à la largeur de la page (remplace la mise à l'échelle). Par défaut : true.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.PageSettings")}}
+{{Compat}}
 
 {{WebExtExamples}}

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/print/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/print/index.md
@@ -44,6 +44,6 @@ browser.browserAction.onClicked.addListener(() => {
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.print")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/printpreview/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/printpreview/index.md
@@ -48,6 +48,6 @@ browser.browserAction.onClicked.addListener(() => {
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.printPreview")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/query/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/query/index.md
@@ -151,9 +151,9 @@ querying.then(logTabs, onError);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.query")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/reload/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/reload/index.md
@@ -75,9 +75,9 @@ reloading.then(onReloaded, onError);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.reload")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/remove/index.md
@@ -71,9 +71,9 @@ removing.then(onRemoved, onError);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.remove")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/removecss/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/removecss/index.md
@@ -78,9 +78,9 @@ browser.browserAction.onClicked.addListener(() => {
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.removeCSS")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/saveaspdf/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/saveaspdf/index.md
@@ -55,6 +55,6 @@ browser.browserAction.onClicked.addListener(() => {
 });
 ```
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.saveAsPDF")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/sendmessage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/sendmessage/index.md
@@ -97,9 +97,9 @@ browser.runtime.onMessage.addListener(request => {
 
 {{WebExtExamples}}
 
-## Compatiblité des navigateurs
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.sendMessage")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/sendrequest/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/sendrequest/index.md
@@ -42,9 +42,9 @@ var sending = browser.tabs.sendRequest(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec l'objet de réponse JSON envoyé par le gestionnaire du message dans le script de contenu, ou sans arguments si le script de contenu n'a pas envoyé de réponse. Si une erreur survient lors de la connexion à l'onglet spécifié ou si une autre erreur se produit, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.sendRequest")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/setzoom/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/setzoom/index.md
@@ -66,9 +66,9 @@ setting.then(null, onError);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.setZoom")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/setzoomsettings/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/setzoomsettings/index.md
@@ -59,9 +59,9 @@ setting.then(onSet, onError);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.setZoomSettings")}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/show/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/show/index.md
@@ -68,6 +68,6 @@ browser.tabs.show([15, 14, 1]).then(onShown, onError);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.show")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/tab/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/tab/index.md
@@ -85,9 +85,9 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `windowId`
   - : `integer`. L'ID de la fenêtre qui héberge cet onglet.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.Tab", 10)}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/tab_id_none/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/tab_id_none/index.md
@@ -18,9 +18,9 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/tabs/TAB_ID_NONE
 
 Une valeur d'ID spéciale donnée aux onglets qui ne sont pas des onglets du navigateur (par exemple, des onglets dans les fenêtres devtools).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.TAB_ID_NONE")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/tabstatus/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/tabstatus/index.md
@@ -22,9 +22,9 @@ Indique si l'onglet a terminé le chargement.
 
 Les valeurs de ce type sont des chaînes. Les valeurs possibles sont : `"loading"` et `"complete"`.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.TabStatus")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/togglereadermode/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/togglereadermode/index.md
@@ -73,6 +73,6 @@ browser.tabs.onUpdated.addListener(switchToReaderMode);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.toggleReaderMode")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/update/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/update/index.md
@@ -127,9 +127,9 @@ querying.then(updateFirstTab, onError);
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.update", 10)}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/windowtype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/windowtype/index.md
@@ -27,9 +27,9 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont:
 - **"panel"**
 - **"devtools"**
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.WindowType")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/zoomsettings/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/zoomsettings/index.md
@@ -29,9 +29,9 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `scope`{{optional_inline}}
   - : {{WebExtAPIRef('tabs.ZoomSettingsScope')}}. Définit si les changements de zoom persisteront pour l'origine de la page ou ne prendront effet que dans cet onglet.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.ZoomSettings")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/zoomsettingsmode/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/zoomsettingsmode/index.md
@@ -29,9 +29,9 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 - "manual"
   - : L'extension gère elle-même les changements de zoom, en écoutant l'événement {{WebExtAPIRef("tabs.onZoomChange")}} et en redimensionnant la page en conséquence. Ce mode ne prend pas en charge le zoom `per-origin` : il ignore la `portée` {{WebExtAPIRef("tabs.zoomSettings", "zoom setting")}} et utilise toujours la fonction `per-tab`.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.ZoomSettingsMode")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/tabs/zoomsettingsscope/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/tabs/zoomsettingsscope/index.md
@@ -27,9 +27,9 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 - "per-tab"
   - : Les changements de zoom ne prennent effet que dans cet onglet et les changements de zoom dans les autres onglets n'affectent pas le zoom de cet onglet. De plus, les changements de zoom `per-tab` ont réinitialisés lors de la navigation ; la navigation dans un onglet charge toujours les pages avec `per-origin` de zoom d'origine.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.tabs.ZoomSettingsScope")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/theme/getcurrent/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/theme/getcurrent/index.md
@@ -36,9 +36,9 @@ var getting = browser.theme.getCurrent(
 
 Un objet [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise). L'objet Promise sera résolu avec un objet {{WebExtAPIRef("theme.Theme")}} représentant le thème appliqué à la fenêtre spécifiée. Si aucun thème provenant d'une extension a été appliqué, l'objet Promise sera résolu avec un objet vide.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.theme.getCurrent", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/theme/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/theme/index.md
@@ -36,8 +36,8 @@ Pour utiliser cette API, une extension doit demander la [permission](/fr/Add-ons
 - {{WebExtAPIRef("theme.onUpdated")}}
   - : Emis quand le thème du navigateur change.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.theme")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}

--- a/files/fr/mozilla/add-ons/webextensions/api/theme/onupdated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/theme/onupdated/index.md
@@ -54,9 +54,9 @@ Les événements ont trois fonctions :
         - `windowId`{{optional_inline}}
           - : `integer`. L'ID de la fenêtre pour laquelle le thème a été mis à jour. Si cette propriété n'est pas présente, cela signifie que le thème a été mise à jour globalement.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.theme.onUpdated", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/theme/reset/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/theme/reset/index.md
@@ -30,9 +30,9 @@ browser.theme.reset( windowsId // integer )
 - `windowId` {{optional_inline}}
   - : `integer`. L'ID d'une fenêtre. Si cela est indiqué, le thème appliqué sur cette fenêtre sera réinitialisé. Sinon le thème sera réinitialisé sur toutes les fenêtres.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.theme.reset")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/theme/theme/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/theme/theme/index.md
@@ -17,8 +17,8 @@ Un objet thème représente la spécification d'un thème.
 
 Un [object](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Object) JSON qui prend les mêmes propriétés que la clé du manifest ["theme"](/fr/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.theme.Theme")}}
+{{Compat}}
 
 {{WebExtExamples}}

--- a/files/fr/mozilla/add-ons/webextensions/api/theme/update/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/theme/update/index.md
@@ -36,9 +36,9 @@ browser.theme.update(
 - `theme`
   - : `object`. Un objet {{WebExtAPIRef("theme.Theme", "Theme")}} spécifiant des valeurs pour les éléments de l'interface utilisateur que vous voulez modifier
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.theme.update", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/topsites/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/topsites/get/index.md
@@ -61,9 +61,9 @@ var gettingTopSites = browser.topSites.get()
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise). Ceci sera réalisé avec un tableau d'objets {{WebExtAPIRef("topSites.MostVisitedURL", "MostVisitedURL")}}, un pour chaque site listé dans la page "Nouvel onglet" du navigateur. Si une erreur se produit, la presse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.topSites.get")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/topsites/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/topsites/index.md
@@ -31,9 +31,9 @@ Pour utiliser l'API topSites, vous devez disposez de l' [API permission](/fr/Add
 - {{WebExtAPIRef("topSites.get()")}}
   - : Obtient un tableau contenant tous les sites répertoriés dans la page "Nouvel onglet" du navigateur. Notez que le nombre de sites renvoyés ici est spécifique au navigateur, et les sites particuliers retournés seront probablement spécifiques à l'utilisateur, en fonction de leur historique de navigation.
 
-## Compatibilité du Navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.topSites")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/topsites/mostvisitedurl/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/topsites/mostvisitedurl/index.md
@@ -29,9 +29,9 @@ Values of this type are objects. They contain the following properties:
 - `url`
   - : `String`. L'URL de la page.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.topSites.MostVisitedURL")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/clear/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/clear/index.md
@@ -38,7 +38,7 @@ var clearing = setting.clear(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera rempli avec un `booléen`: `true` Si le paramètre est effacé, `false` sinon.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
 Voir {{WebExtAPIRef("types.BrowserSetting")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/get/index.md
@@ -63,7 +63,7 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se
       </tbody>
     </table>
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
 Voir {{WebExtAPIRef("types.BrowserSetting")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/index.md
@@ -35,11 +35,9 @@ Notez que si cet objet est basé sur le type [ChromeSetting](https://developer.c
 - {{WebExtAPIRef("types.BrowserSetting.onChange")}}
   - : Définit lorsque la valeur du paramètre change.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-## Browser compatibility
-
-{{Compat("webextensions.api.types.BrowserSetting")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/onchange/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/onchange/index.md
@@ -74,9 +74,9 @@ Les événement ont trois fonctions :
               </tbody>
             </table>
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.types.BrowserSetting.onChange")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.md
@@ -54,7 +54,7 @@ var setting = setting.set(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un `booléen`: `true` si le paramètre a été modifié, `false` sinon (par exemple, parce que l'extension n'a pas contrôlé le paramètre).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
 Voir {{WebExtAPIRef("types.BrowserSetting")}}.
 

--- a/files/fr/mozilla/add-ons/webextensions/api/types/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/types/index.md
@@ -20,7 +20,7 @@ Définit le type `BrowserSetting` , qui est utilisé pour représenter un param�
 - {{WebExtAPIRef("types.BrowserSetting")}}
   - : Représente un paramètre de navigateur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/userscripts/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/userscripts/index.md
@@ -44,9 +44,9 @@ Pour utiliser l'API, appelez `{{WebExtAPIRef("userScripts.register","register()"
 - {{WebExtAPIRef("userScripts.onBeforeScript")}}
   - : Un événement disponible pour le script API, enregistré dans [`"user_scripts"`](/fr/docs/Mozilla/Add-ons/WebExtensions/manifest.json/user_scripts), qui s'exécute avant qu'un script utilisateur ne s'exécute. Utilisez-le pour déclencher l'exportation des API supplémentaires fournies par le script API, afin qu'elles soient disponibles pour le script utilisateur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.userScripts", 10, 1)}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/mozilla/add-ons/webextensions/api/userscripts/onbeforescript/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/userscripts/onbeforescript/index.md
@@ -36,9 +36,9 @@ browser.userScripts.onBeforeScript.hasListener(functionRef)
 
 Voir [ce billet de blog](https://blog.mozilla.org/addons/2019/03/26/extensions-in-firefox-67/#userscripts) pour des exemples détaillés
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.userScripts.onBeforeScript")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/mozilla/add-ons/webextensions/api/userscripts/register/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/userscripts/register/index.md
@@ -63,9 +63,9 @@ Une {{JSxRef("Promise")}} qui sera rempli avec un objet {{WebExtAPIRef("userScri
 
 > **Note :** Actuellement, les scripts utilisateur sont désenregistrés lorsque la page d'extension correspondante (à partir de laquelle les scripts utilisateur ont été enregistrés) est déchargée, vous devez donc enregistrer un script utilisateur depuis une page d'extension qui persiste au moins aussi longtemps que vous voulez que les scripts utilisateur restent enregistrés.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.userScripts.register", 10)}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/mozilla/add-ons/webextensions/api/userscripts/registereduserscript/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/userscripts/registereduserscript/index.md
@@ -24,6 +24,6 @@ L'objet définit une méthode unique, {{WebExtAPIRef("userScripts.RegisteredUser
 - {{WebExtAPIRef("userScripts.RegisteredUserScript.unregister","unregister()")}}
   - : Désenregistre les scripts utilisateurs représentés par cet objet.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.userScripts.RegisteredUserScript", 10)}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/api/userscripts/registereduserscript/unregister/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/userscripts/registereduserscript/unregister/index.md
@@ -36,9 +36,9 @@ Aucun
 
 Une {{JSxRef("Promise")}} qui sera résolu une fois le script utilisateur désenregistré. La promesse ne rapporte rien.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.userScripts.RegisteredUserScript.unregister")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/getallframes/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/getallframes/index.md
@@ -54,9 +54,9 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) sera a
 
 Si l'onglet spécifié n'a pas pu être trouvé ou qu'une autre erreur se produit, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webNavigation.getAllFrames")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/getframe/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/getframe/index.md
@@ -54,9 +54,9 @@ Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Global_Objects/Promise) qui se
 
 Si l'onglet ou l'ID de trame spécifié n'a pas pu être trouvé ou qu'une autre erreur se produit, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webNavigation.getFrame")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/index.md
@@ -80,9 +80,9 @@ Pour utiliser cette API, vous devez avoir la [permission](/fr/Add-ons/WebExtensi
 - {{WebExtAPIRef("webNavigation.onHistoryStateUpdated")}}
   - : Lancé lorsque la page a utilisé l' [API d'histoirique](http://diveintohtml5.info/history.html) pour mettre à jour l'URL affichée dans la barre d'adresse du navigateur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webNavigation")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onbeforenavigate/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onbeforenavigate/index.md
@@ -69,9 +69,9 @@ Les événements ont trois fonctions :
 - `timeStamp`
   - : `number`. L'heure à laquelle le navigateur est sur le point de démarrer la navigation, en [millisecondes depuis l'époque](https://en.wikipedia.org/wiki/Unix_time).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webNavigation.onBeforeNavigate")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.md
@@ -73,9 +73,9 @@ Les événements ont trois fonctions :
 - `transitionQualifiers`
   - : `Array` de `{{WebExtAPIRef("webNavigation.transitionQualifier", "transitionQualifier")}}`. Informations supplémentaires sur la navigation : par exemple, s'il existait une redirection de serveur ou de client.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webNavigation.onCommitted")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.md
@@ -67,9 +67,9 @@ Les événements ont trois fonctions :
 - `timeStamp`
   - : `number`. L'heure à laquelle la page a terminé le chargement, en [millisecondes depuis l'époque](https://en.wikipedia.org/wiki/Unix_time).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webNavigation.onCompleted")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.md
@@ -78,9 +78,9 @@ Les événements ont trois fonctions :
 - `windowId`
   - : number. L'ID de la fenêtre dans laquelle le nouvel onglet est créé.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webNavigation.onCreatedNavigationTarget")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
@@ -67,9 +67,9 @@ Les événements ont trois fonctions :
 - `timeStamp`
   - : `number`. L'heure à laquelle `DOMContentLoaded` a été déclenchée, en [millisecondes depuis l'époque](https://en.wikipedia.org/wiki/Unix_time).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webNavigation.onDOMContentLoaded")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.md
@@ -69,9 +69,9 @@ Les événements ont trois fonctions :
 - `error`
   - : `string`. Le code d'erreur. Il s'agit d'un code d'erreur interne qui n'est pas garanti pour rester identique ou être cohérent d'un navigateur à l'autre.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webNavigation.onErrorOccurred")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.md
@@ -71,9 +71,9 @@ Les événements ont trois fonctions :
 - `transitionQualifiers`
   - : `Array` de `{{WebExtAPIRef("webNavigation.transitionQualifier", "transitionQualifier")}}`. Informations supplémentaires sur la navigation : par exemple, s'il existait une redirection de serveur ou de client.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webNavigation.onHistoryStateUpdated")}}
+{{Compat}}
 
 ## Examples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
@@ -69,9 +69,9 @@ Les événements ont trois fonctions :
 - `transitionQualifiers`
   - : `Array` de `{{WebExtAPIRef("webNavigation.transitionQualifier", "transitionQualifier")}}`. Informations supplémentaires sur la navigation : par exemple, s'il existait une redirection de serveur ou de client.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webNavigation.onReferenceFragmentUpdated")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/ontabreplaced/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/ontabreplaced/index.md
@@ -60,9 +60,9 @@ Les événements ont trois fonctions :
 - `timeStamp`
   - : `number`. Le moment où le remplacement s'est produit, en [millisecondes depuis l'époque](https://en.wikipedia.org/wiki/Unix_time).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webNavigation.onTabReplaced")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/transitionqualifier/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/transitionqualifier/index.md
@@ -29,9 +29,9 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 - "from_address_bar"
   - : L'utilisateur a déclenché la navigation depuis la barre d'adresse.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webNavigation.TransitionQualifier")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webnavigation/transitiontype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webnavigation/transitiontype/index.md
@@ -47,9 +47,9 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 - "keyword_generated"
   - : Correspond à une visite générée pour un mot clé.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webNavigation.TransitionType")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.md
@@ -52,9 +52,9 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `upgradeToSecure`{{optional_inline}}
   - : `boolean`. Si la valeur `true` est est définie et que la requête originale est une requête HTTP, cela empêchera l'envoi de la requête originale et fera plutôt une requête sécurisée (HTTPS). Si une extension renvoie `redirectUrl` dans `onBeforeRequest`, alors `upgradeToSecure` sera ignoré pour cette requête. Vous ne pouvez définir cette propriété que dans {{WebExtAPIRef("webRequest.onBeforeRequest", "onBeforeRequest")}}.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.BlockingResponse")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/certificateinfo/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/certificateinfo/index.md
@@ -66,8 +66,8 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
     - `end`
       - : `Number`. La fin de la période de validité du certificat, en [millisecondes depuis l'époque](https://en.wikipedia.org/wiki/Unix_time).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.CertificateInfo", 10)}}
+{{Compat}}
 
 {{WebExtExamples}}

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
@@ -68,6 +68,6 @@ browser.webRequest.onBeforeRequest.addListener(
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.filterResponseData", 10)}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/getsecurityinfo/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/getsecurityinfo/index.md
@@ -50,9 +50,9 @@ var gettingInfo = browser.webRequest.getSecurityInfo(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui se résout en un objet {{WebExtAPIRef("webRequest.SecurityInfo", "SecurityInfo")}}.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.getSecurityInfo", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/handlerbehaviorchanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/handlerbehaviorchanged/index.md
@@ -47,9 +47,9 @@ None.
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie sans arguments, lorsque l'opération sera terminée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.handlerBehaviorChanged")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/httpheaders/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/httpheaders/index.md
@@ -29,9 +29,9 @@ Un `tableau` d'`objet`s. Chaque objet a les propriétés suivantes :
 - `binaryValue`{{optional_inline}}
   - : `array` d'`integer`. Valeur de l'en-tête HTTP s'il ne peut pas être représenté par UTF-8, représenté par en octets (0..255). Soit cette propriété ou cette `valeur` doit être présente.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.HttpHeaders")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/index.md
@@ -132,9 +132,9 @@ Pour ce faire, vous devez disposer de la permission de l'API "webRequestBlocking
 - {{WebExtAPIRef("webRequest.onErrorOccurred")}}
   - : Déclenché lorsqu'une erreur se produit.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest")}}
+{{Compat}}
 
 [Extra notes on Chrome incompatibilities](/fr/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities#webRequest_incompatibilities).
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/max_handler_behavior_changed_calls_per_10_minutes/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/max_handler_behavior_changed_calls_per_10_minutes/index.md
@@ -22,9 +22,9 @@ Le nombre maximum de fois que `{{WebExtAPIRef("webRequest.handlerBehaviorChanged
 
 Cette propriété est en lecture seule.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
@@ -165,9 +165,9 @@ Les événements ont trois fonctions :
 - `url`
   - : `string`. Cible de la demande.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.onAuthRequired", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.md
@@ -127,9 +127,9 @@ Les événements ont trois fonctions :
 - `url`
   - : `string`. Cible de la demande.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.onBeforeRedirect", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
@@ -153,9 +153,9 @@ Les événements ont trois fonctions :
 - `url`
   - : `string`. Cible de la demande.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.onBeforeRequest", 10)}}
+{{Compat}}
 
 ### Ordre de résolution DNS lorsque BlockingResponse est utilisé
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.md
@@ -142,9 +142,9 @@ Les événements ont trois fonctions :
 - `url`
   - : `string`. Cible de la demande.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.onBeforeSendHeaders", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.md
@@ -125,9 +125,9 @@ Les événements ont trois fonctions :
 - `url`
   - : `string`. Cible de la demande.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.onCompleted", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.md
@@ -119,9 +119,9 @@ Les événements ont trois fonctions :
 - `url`
   - : `string`. Cible de la demande.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.onErrorOccurred", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.md
@@ -132,9 +132,9 @@ Les événements ont trois fonctions :
 - `url`
   - : `string`. Cible de la demande.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.onHeadersReceived", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.md
@@ -125,9 +125,9 @@ Les événements ont trois fonctions :
 - `url`
   - : `string`. Cible de la demande.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.onResponseStarted", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.md
@@ -117,9 +117,9 @@ Les événements ont trois fonctions :
 - `url`
   - : `string`. Cible de la demande.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.onSendHeaders", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/requestfilter/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/requestfilter/index.md
@@ -33,9 +33,9 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - incognito {{optional_inline}}
   - : `boolean`. Si elles sont fournies, les demandes qui ne correspondent pas à l'état incognito (`true` ou `false`) seront filtrées.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.RequestFilter")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/resourcetype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/resourcetype/index.md
@@ -78,9 +78,9 @@ Les valeurs de ce type sont des chaînes de caractères. Les valeurs possibles s
 - `other`
   - : Ressources qui ne sont couvertes par aucun autre type disponible.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.ResourceType")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/securityinfo/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/securityinfo/index.md
@@ -85,8 +85,8 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `weaknessReasons` {{optional_inline}}
   - : `String`. Si l'`état` est "faible", cela indique la raison. Actuellement, il ne peut contenir qu'une seule valeur "chiffre", ce qui indique que la suite de chiffres négociée est considérée comme faible.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.SecurityInfo", 10)}}
+{{Compat}}
 
 {{WebExtExamples}}


### PR DESCRIPTION
This PR updates some of the browser compatibility data and specification sections for the French locale. Part of work for #11594.

Note: this may also include other minor updates, such as removal of old sections or other small bits of cleanup.
