### PR TITLE
fr: Update browser compat/spec sections (part 6)

### DIFF
--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/close/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/close/index.md
@@ -35,9 +35,9 @@ None.
 
 None.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.StreamFilter.close", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/disconnect/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/disconnect/index.md
@@ -31,9 +31,9 @@ None.
 
 None.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.StreamFilter.disconnect", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/error/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/error/index.md
@@ -16,9 +16,9 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/error
 
 Une chaîne de caractères qui contiendra un message d'erreur après le déclenchement de l'événement {{WebExtAPIRef("webRequest.StreamFilter.onerror", "onerror")}}.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.StreamFilter.error", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/index.md
@@ -82,9 +82,9 @@ Le filtre fournit également des fonctions à {{WebEXTAPIRef("webRequest.StreamF
 - {{WebExtAPIRef("webRequest.StreamFilter.status")}}
   - : Décrit l'état actuel du flux.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.StreamFilter", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.md
@@ -201,6 +201,6 @@ browser.webRequest.onBeforeRequest.addListener(
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.StreamFilter.ondata", 10)}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onerror/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onerror/index.md
@@ -20,9 +20,9 @@ Après le déclenchement de cet événement, la propriété {{WebExtAPIRef("webR
 
 Notez que cet événement n'est _pas_ déclenché pour les erreurs réseau.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.StreamFilter.onerror", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstart/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstart/index.md
@@ -16,9 +16,9 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/onstar
 
 Un gestionnaire d'événements qui sera appelé lorsque le flux est ouvert et est sur le point de commencer à livrer les données. A partir de ce point, l'extension peut utiliser des fonctions de filtrage telles que {{WebExtAPIRef("webRequest.StreamFilter.write()", "write()")}}, {{WebExtAPIRef("webRequest.StreamFilter.disconnect()", "disconnect()")}}, ou {{WebExtAPIRef("webRequest.StreamFilter.close()", "close()")}}.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.StreamFilter.onstart", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstop/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/onstop/index.md
@@ -16,9 +16,9 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter/onstop
 
 Un gestionnaire d'événements qui sera appelé lorsque le flux n'a plus de données à livrer. IDans le gestionnaire d'événements, vous pouvez toujours appeler des fonctions de filtrage telles que {{WebExtAPIRef("webRequest.StreamFilter.write()", "write()")}}, {{WebExtAPIRef("webRequest.StreamFilter.disconnect()", "disconnect()")}}, ou {{WebExtAPIRef("webRequest.StreamFilter.close()", "close()")}}.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.StreamFilter.onstop", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/resume/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/resume/index.md
@@ -32,9 +32,9 @@ None.
 
 None.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.StreamFilter.suspend", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/status/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/status/index.md
@@ -31,9 +31,9 @@ Une chaîne de caractères qui décrit l'état actuel de la demande. Ce sera l'u
 - `"failed"`
   - : Une erreur s'est produite et le filtre a été déconnecté de la requête. L'extension peut trouver un message d'erreur dans {{WebExtAPIRef("webRequest.StreamFilter.error", "error")}}, et ne peut appeler aucune fonction de filtrage.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.StreamFilter.status", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/suspend/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/suspend/index.md
@@ -32,9 +32,9 @@ None.
 
 None.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.StreamFilter.suspend", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/write/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/streamfilter/write/index.md
@@ -31,9 +31,9 @@ filter.write(
 
 None.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.StreamFilter.write", 10)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/uploaddata/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/uploaddata/index.md
@@ -27,9 +27,9 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `file`{{optional_inline}}
   - : `string`. Une chaîne de caractères avec le chemin et le nom du fichier.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.webRequest.UploadData")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/create/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/create/index.md
@@ -147,9 +147,9 @@ browser.browserAction.onClicked.addListener((tab) => {
 
 {{WebExtExamples}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.windows.create", 10)}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/createtype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/createtype/index.md
@@ -27,9 +27,9 @@ Les valeurs de ce type sont des objets `strings`. Les valeurs possibles sont :
 - `"panel"`
 - `"detached_panel"`
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.windows.CreateType")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/get/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/get/index.md
@@ -50,10 +50,6 @@ var getting = browser.windows.get(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un objet {{WebExtAPIRef('windows.Window')}} contenant les détails de la fenêtre. Si une erreur survient, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
-
-{{Compat("webextensions.api.windows.get",2)}}
-
 ## Exemples
 
 Cet exemple obtient la fenêtre actuelle et enregistre les URL des onglets qu'il contient. Notez que vous aurez besoin des [permission](/fr/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) "onglets" pour accéder aux URL des onglets.
@@ -76,6 +72,10 @@ browser.browserAction.onClicked.addListener((tab) => {
   getting.then(logTabs, onError);
 });
 ```
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/getall/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/getall/index.md
@@ -43,9 +43,9 @@ var gettingAll = browser.windows.getAll(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un ensemble d'objets {{WebExtAPIRef('windows.Window')}}, représentant toutes les fenêtres qui correspondent aux critères donnés. Si une erreur survient, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.windows.getAll")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/getcurrent/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/getcurrent/index.md
@@ -49,9 +49,9 @@ var gettingCurrent = browser.windows.getCurrent(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un objet [`windows.Window`](/fr/docs/Mozilla/Add-ons/WebExtensions/API/windows/Window) object contenant les détails de la fenêtre. Si une erreur survient, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.windows.getCurrent",2)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.md
@@ -47,9 +47,9 @@ var gettingWindow = browser.windows.getLastFocused(
 
 `Une Promise` qui sera remplie avec un objet {{WebExtAPIRef('windows.Window')}} contenant les détails de la dernière fenêtre ciblée. Si une erreur survient, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.windows.getLastFocused",2)}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/index.md
@@ -61,9 +61,9 @@ Intéragissez avec les fenêtres du navigateur. Vous pouvez utiliser cette API p
 - {{WebExtAPIRef("windows.onFocusChanged")}}
   - : Lancé quand la fenêtre courante change.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.windows")}}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/oncreated/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/oncreated/index.md
@@ -46,9 +46,9 @@ Les événements ont trois fonctions :
     - `window`
       - : Un objet {{WebExtAPIRef('windows.Window')}} contenant les détails de la fenêtre qui a été créée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.windows.onCreated")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/onfocuschanged/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/onfocuschanged/index.md
@@ -48,9 +48,9 @@ Les événements ont trois événements :
     - `windowId`
       - : `integer`. ID de la fenêtre nouvellement localisée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.windows.onFocusChanged")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/onremoved/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/onremoved/index.md
@@ -46,9 +46,9 @@ Les événements ont trois fonctions :
     - `windowId`
       - : `integer`. ID de la fenêtre fermée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.windows.onRemoved")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/remove/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/remove/index.md
@@ -37,9 +37,9 @@ var removing = browser.windows.remove(
 
 Une [`Promesse`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie sans arguments lorsque la fenêtre a été fermée. Si une erreur survient, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.windows.remove")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/update/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/update/index.md
@@ -58,9 +58,9 @@ var updating = browser.windows.update(
 
 Une [`Promise`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Promise) qui sera remplie avec un objet {{WebExtAPIRef('windows.Window')}} contenant les détails de la fenêtre mise à jour. Si une erreur survient, la promesse sera rejetée avec un message d'erreur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.windows.update")}}
+{{Compat}}
 
 ## Exemples
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/window/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/window/index.md
@@ -44,9 +44,9 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
 - `width`{{optional_inline}}
   - : `integer`. La largeur de la fenêtre, y compris le cadre, en pixels.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.windows.Window")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/window_id_current/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/window_id_current/index.md
@@ -17,9 +17,9 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/windows/WINDOW_ID_CURRENT
 
 `browser.windows.WINDOW_ID_CURRENT` est une valeur qui peut être utilisée comme paramètre `windowId` dans certaines APIs pour représenter la fenêtre courante.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.windows.WINDOW_ID_CURRENT")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/window_id_none/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/window_id_none/index.md
@@ -18,9 +18,9 @@ translation_of: Mozilla/Add-ons/WebExtensions/API/windows/WINDOW_ID_NONE
 
 La valeur `windowId` que représente l'absence d'une fenêtre du navigateur.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.windows.WINDOW_ID_NONE")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/windowstate/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/windowstate/index.md
@@ -35,9 +35,9 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont:
 
 Compatibilité macOS : A partir de macOS 10.10, le comportement de maximisation par défaut pour les fenêtres a été modifié pour exécuter les applications en plein écran au lieu des fenêtres "zoomées". `fullscreen` fait référence à la fois au navigateur fonctionnant en plein écran et lorsque le contenu dans un onglet utilise l'API Fullscreen.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.windows.WindowState")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/api/windows/windowtype/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/windows/windowtype/index.md
@@ -27,9 +27,9 @@ Les valeurs de ce type sont des chaînes. Les valeurs possibles sont :
 - `"panel"`
 - `"devtools"`
 
-## Browser compatibility
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.api.windows.WindowType")}}
+{{Compat}}
 
 {{WebExtExamples}}
 

--- a/files/fr/mozilla/add-ons/webextensions/browser_compatibility_for_manifest.json/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/browser_compatibility_for_manifest.json/index.md
@@ -10,11 +10,9 @@ translation_of: Mozilla/Add-ons/WebExtensions/Browser_compatibility_for_manifest
 
 {{AddonSidebar}}
 
-{{Compat("webextensions.manifest",2)}}
+## Compatibilité des navigateurs
 
-> **Note :**
->
-> Les données de compatibilité relatives à Microsoft Edge sont fournies par Microsoft Corporation et incluses ici sous la licence Creative Commons Attribution 3.0 pour les États-Unis.
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.md
@@ -159,13 +159,7 @@ Firefox prend en charge [la permission](/fr/docs/Mozilla/Add-ons/WebExtensions/m
 
 ## Compatibilité des navigateurs
 
-### `navigator.clipboard`
-
-{{Compat("api.Clipboard")}}
-
-### `clipboard.setImageData`
-
-{{Compat("webextensions.api.clipboard")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/author/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/author/index.md
@@ -40,4 +40,4 @@ Notez que Firefox ne supporte cette clé qu'à partir de la version 52 et que ce
 
 ## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.author")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/background/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/background/index.md
@@ -128,6 +128,6 @@ Chargez deux scripts de fond.
 
 Chargez une page d'arrière-plan personnalisée.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.background", 10)}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/browser_action/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/browser_action/index.md
@@ -362,9 +362,9 @@ Une action de navigateur avec une icône, un titre et une fenêtre contextuelle.
 
 Pour une extension simple, mais complète, qui utilise une action de navigateur, consultez le [tutoriel pas à pas](/fr/Add-ons/WebExtensions/Your_second_WebExtension).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.browser_action", 10)}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.md
@@ -116,4 +116,4 @@ Exemple avec toutes les clés possibles. Notez que vous n'incluez normalement ni
 
 ## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.browser_specific_settings")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/chrome_settings_overrides/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/chrome_settings_overrides/index.md
@@ -211,6 +211,6 @@ La clé `chrome_settings_overrides` est un objet qui peut avoir les propriétés
   </tbody>
 </table>
 
-## Compatibilité de navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.chrome_settings_overrides", 10)}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/chrome_url_overrides/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/chrome_url_overrides/index.md
@@ -119,6 +119,6 @@ Toutes les propriétés sont [localisables](/fr/Add-ons/WebExtensions/Internatio
 }
 ```
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.chrome_url_overrides")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/commands/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/commands/index.md
@@ -226,6 +226,6 @@ Définissez deux raccourcis clavier, l'un avec une combinaison de touches spéci
 }
 ```
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.commands")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
@@ -313,4 +313,4 @@ Les scripts de contenu ont la même vue du DOM et sont injectés dans l’ordre 
 
 ## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.content_scripts")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.md
@@ -133,4 +133,4 @@ La directive inclut le mot-clé non pris en charge `'unsafe-inline'`&nbsp;:
 
 ## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.content_security_policy")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/default_locale/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/default_locale/index.md
@@ -42,6 +42,6 @@ Voir [Internationalisation](/fr/Add-ons/WebExtensions/Internationalization).
 "default_locale": "fr"
 ```
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.default_locale")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/description/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/description/index.md
@@ -41,6 +41,6 @@ Ceci est une [propriété localisable](/fr/Add-ons/WebExtensions/Internationaliz
 "description": "Remplace des images par des portraits de chats."
 ```
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.description")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/developer/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/developer/index.md
@@ -49,6 +49,6 @@ Ceci est une [propriété localisable](/fr/Add-ons/WebExtensions/Internationaliz
 }
 ```
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.developer")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/devtools_page/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/devtools_page/index.md
@@ -45,6 +45,6 @@ Voir [Extension des outils développeurs](/fr/Add-ons/WebExtensions/Extending_th
 "devtools_page": "devtools/my-page.html"
 ```
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.devtools_page")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/dictionaries/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/dictionaries/index.md
@@ -46,4 +46,4 @@ Les clés des `dictionaries` specifie le `locale_code` pour lequel votre extensi
 
 ## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.dictionaries")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/externally_connectable/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/externally_connectable/index.md
@@ -60,6 +60,6 @@ Les correspondances permettent la communication entre cette extension et les pag
 
 > **Note :** Si `browser_action` n'est pas spécifié, la communication entre les extensions est toujours autorisée, comme si `browser_action` était `{"ids": ["*"] }`, par conséquent, si vous spécifiez `browser_action.matches` n'oubliez pas d'ajouter des identifiants si vous souhaitez toujours communiquer. avec d'autres extensions.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.externally_connectable")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/homepage_url/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/homepage_url/index.md
@@ -43,6 +43,6 @@ c'est une [proriété localisable](/fr/Add-ons/WebExtensions/Internationalizatio
 "homepage_url": "https://github.com/mdn/webextensions-examples/tree/master/beastify"
 ```
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.homepage_url")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/icons/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/icons/index.md
@@ -76,6 +76,6 @@ Vous pouvez utiliser SVG et le navigateur mettra à l'échelle appropriée votre
 
 > **Note :** si vous utilisez un programme comme Inkscape pour créer un SVG, vous voudrez peut-être l'enregistrer en tant que "SVG simple". Firefox peut être gêné par des espaces de noms spéciaux, et ne pas afficher votre icône.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.icons")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/incognito/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/incognito/index.md
@@ -61,6 +61,6 @@ Il s'agit d'une chaîne qui peut prendre l'une des valeurs suivantes:
 "incognito": "not_allowed"
 ```
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.incognito")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/manifest_version/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/manifest_version/index.md
@@ -37,6 +37,6 @@ Actuellement, cela doit toujours être 2.
 "manifest_version": 2
 ```
 
-## Comptabilité des navigateurs
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.manifest_version")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/name/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/name/index.md
@@ -39,6 +39,6 @@ C'est une [propriété localisable](/fr/Add-ons/WebExtensions/Internationalizati
 "name": "Mon extension"
 ```
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.name")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/offline_enabled/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/offline_enabled/index.md
@@ -39,6 +39,6 @@ A partir de Chrome 35, les applications (ChromeOS uniquement à partir de 2018) 
 
 La valeur `"offline_enabled"` est également utilisée pour déterminer si un contrôle de connectivité réseau sera effectué lors du lancement d'une application en [mode Chrome OS kiosk](https://developer.chrome.com/apps/manifest/kiosk_enabled). Une vérification de la connectivité réseau sera effectuée lorsque les applications ne sont pas activées hors ligne, et le lancement de l'application sera mis en attente jusqu'à ce que l'appareil obtienne la connectivité à Internet.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.offline_enabled")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/omnibox/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/omnibox/index.md
@@ -47,6 +47,6 @@ Si deux ou plusieurs extensions définissent le même mot-clé, l'extension qui 
 }
 ```
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.omnibox")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.md
@@ -102,6 +102,6 @@ Activez l'extension pour demander l'accès aux éléments privilégiés de l'API
 
 Activez l'extension pour demander les deux permissions ci-dessus.
 
-## Comptabilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.optional_permissions")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/options_page/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/options_page/index.md
@@ -49,9 +49,9 @@ Contrairement aux pages d'options spécifiées à l'aide de la nouvelle clé `op
 "options_page": "options/options.html"
 ```
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.options_page")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/options_ui/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/options_ui/index.md
@@ -127,9 +127,9 @@ La clé `options_ui` est un objet avec le contenu suivant :
   }
 ```
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.options_ui")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/page_action/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/page_action/index.md
@@ -283,9 +283,9 @@ Une action de page avec juste une icône spécifiée en 2 tailles différentes. 
 
 Une action de page avec une icône, un titre et une fenêtre contextuelle. Cette dernière s'affiche lorsque l'utilisateur clique sur l'icône.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.page_action")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/permissions/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/permissions/index.md
@@ -186,6 +186,6 @@ Demande d'accès aux éléments privilégiés de l'API `tabs.`
 
 Demande des deux permissions ci-dessus.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.permissions")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.md
@@ -82,6 +82,6 @@ Les gestionnaires peuvent également être des [pages d'extension](/fr/Add-ons/W
 ]
 ```
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.protocol_handlers")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/short_name/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/short_name/index.md
@@ -37,6 +37,6 @@ C'est une [propriété localisable](/fr/Add-ons/WebExtensions/Internationalizati
 "short_name": "MonExtension"
 ```
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.short_name")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/sidebar_action/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/sidebar_action/index.md
@@ -226,9 +226,9 @@ La clé `sidebar_action` est un objet qui peut avoir l'une des propriétés list
 
 Pour un exemple simple d'une extension qui utilise une barre latérale, regarder [annotate-page](https://github.com/mdn/webextensions-examples/tree/master/annotate-page).
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.sidebar_action")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/storage/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/storage/index.md
@@ -59,9 +59,9 @@ La clé de `storage` est un objet qui possède les propriétés requises suivant
   </tbody>
 </table>
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.storage", 10)}}
+{{Compat}}
 
 > **Note :**
 >

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/theme/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/theme/index.md
@@ -1417,38 +1417,6 @@ Il vous donnera un navigateur qui ressemble à ceci :
 
 Dans cette capture d'écran, `"toolbar_vertical_separator"` est la ligne verticale blanche dans la barre d'URL divisant l'icône du mode Lecteur des autres icônes.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.theme")}}
-
-### Couleurs
-
-{{Compat("webextensions.manifest.theme.colors", 10)}}
-
-### Images
-
-{{Compat("webextensions.manifest.theme.images", 10)}}
-
-### Propriétés
-
-{{Compat("webextensions.manifest.theme.properties", 10)}}
-
-### Compatibilité de Chrome
-
-Dans Chrome:
-
-- `colors/toolbar_text` n'est pas utilisé, utilisez `colors/bookmark_text` à la place.
-- `images/theme_frame` ancre l'image en haut à gauche de l'en-tête et si l'image ne remplit pas la zone de l'en-tête de l'image.
-- toutes les couleurs doivent être spécifiées sous la forme d'un tableau de valeurs RVB, comme ceci :
-
-```json
-"theme": {
-  "colors": {
-     "frame": [255, 0, 0],
-     "tab_background_text": [0, 255, 0],
-     "bookmark_text": [0, 0, 255]
-  }
-}
-```
-
-A partir de Firefox 59, la forme tableau et la forme couleur CSS sont acceptées pour toutes les propriétés. Avant cela, `colors/frame` et `colors/tab_background_text` nécessitaient la forme tableau, alors que d'autres propriétés nécessitaient la forme couleur CSS.
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/theme_experiment/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/theme_experiment/index.md
@@ -184,6 +184,6 @@ Ceci a pour effet de rendre l'icône de recharge orange.
 
 Cette propriété peut également être utilisée dans `browser.theme.update()`. `images` et `properties` travaillent de la même manière que `colors`.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.theme_experiment")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/version/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/version/index.md
@@ -59,4 +59,4 @@ console.log(browser.runtime.getManifest().version);
 
 ## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.version")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/version_name/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/version_name/index.md
@@ -31,6 +31,6 @@ En plus du champ [version](/fr/Add-ons/WebExtensions/manifest.json/version), qui
 
 Si aucun **version_name** n'est présent, le champ de **version** sera également utilisé à des fins d'affichage.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.version_name")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
@@ -103,6 +103,6 @@ Notez que si vous créez une page accessible sur le Web, n'importe quel site Web
 
 Crée un fichier dans "images/my-image.png" accessible sur le web.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
-{{Compat("webextensions.manifest.web_accessible_resources")}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/match_patterns/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/match_patterns/index.md
@@ -362,6 +362,4 @@ La valeur spéciale `<all_urls>` correspond à toutes les URL sous l’un des sc
 
 ## Compatibilité des navigateurs
 
-### schéma
-
-{{Compat("webextensions.match_patterns.scheme",10)}}
+{{Compat}}

--- a/files/fr/mozilla/add-ons/webextensions/user_interface/browser_styles/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/user_interface/browser_styles/index.md
@@ -100,7 +100,7 @@ La plupart des styles sont automatiquement appliqués, mais certains éléments 
 
 > **Note :** Voir le {{bug(1465256)}} pour la suppression de cette exigence inutile.
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
 {{Compat}}
 

--- a/files/fr/web/api/analysernode/mindecibels/index.md
+++ b/files/fr/web/api/analysernode/mindecibels/index.md
@@ -73,9 +73,9 @@ dessiner();
 
 {{Specifications}}
 
-## Compatibilité navigateurs
+## Compatibilité des navigateurs
 
-{{Compat("api.AnalyserNode.minDecibels")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/clipboard_api/index.md
+++ b/files/fr/web/api/clipboard_api/index.md
@@ -34,21 +34,11 @@ Ce bout de code analyse le texte à partir du presse-papiers et l'insère après
 
 ## Spécifications
 
-{{Specifications("api.Clipboard")}}
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-### Clipboard
-
-{{Compat("api.Clipboard")}}
-
-### ClipboardEvent
-
-{{Compat("api.ClipboardEvent")}}
-
-### ClipboardItem
-
-{{Compat("api.ClipboardItem")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/console_api/index.md
+++ b/files/fr/web/api/console_api/index.md
@@ -40,7 +40,7 @@ Consultez [la page de référence de la console](/fr/docs/Web/API/Console#exempl
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.console")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/css_counter_styles/index.md
+++ b/files/fr/web/api/css_counter_styles/index.md
@@ -15,13 +15,11 @@ Le module CSS Styles de compteurs (<i lang="en">Counter Styles</i>) permet de d�
 
 ## Spécifications
 
-{{Specifications("api.CSSCounterStyleRule")}}
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-### Interface `CSSCounterStyleRule`
-
-{{Compat("api.CSSCounterStyleRule")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/css_font_loading_api/index.md
+++ b/files/fr/web/api/css_font_loading_api/index.md
@@ -25,6 +25,6 @@ L'API CSS Font Loading API fournit des évènements et interfaces pour le charge
 
 {{Specifications("api.FontFace")}}
 
-## Compatibilité navigateur
+## Compatibilité des navigateurs
 
-{{Compat("api.FontFace")}}
+{{Compat}}

--- a/files/fr/web/api/document/alinkcolor/index.md
+++ b/files/fr/web/api/document/alinkcolor/index.md
@@ -35,4 +35,4 @@ Une autre alternative est `document.body.aLink`, même si elle est [obsolète da
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Document.alinkColor")}}
+{{Compat}}

--- a/files/fr/web/api/document/bgcolor/index.md
+++ b/files/fr/web/api/document/bgcolor/index.md
@@ -33,4 +33,4 @@ La valeur par défaut pour cette propriété sur Firefox est le blanc (`#ffffff`
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Document.bgColor")}}
+{{Compat}}

--- a/files/fr/web/api/document/clear/index.md
+++ b/files/fr/web/api/document/clear/index.md
@@ -32,4 +32,4 @@ document.clear()
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Document.clear")}}
+{{Compat}}

--- a/files/fr/web/api/document/execcommand/index.md
+++ b/files/fr/web/api/document/execcommand/index.md
@@ -155,13 +155,11 @@ Un exemple d'utilisation est disponible
 
 ## Spécifications
 
-| Spécification                                                  | État                   | Commentaires |
-| -------------------------------------------------------------- | ---------------------- | ------------ |
-| [execCommand](https://w3c.github.io/editing/docs/execCommand/) | Brouillon non officiel |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Document.execCommand")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/document/getelementsbyclassname/index.md
+++ b/files/fr/web/api/document/getelementsbyclassname/index.md
@@ -88,7 +88,7 @@ C'est la méthode d'opération la plus couramment utilisée.
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Document.getElementsByClassName")}}
+{{Compat}}
 
 ## Spécification
 

--- a/files/fr/web/api/document/lastmodified/index.md
+++ b/files/fr/web/api/document/lastmodified/index.md
@@ -72,4 +72,4 @@ HTML5
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Document.lastModified")}}
+{{Compat}}

--- a/files/fr/web/api/document/scrollingelement/index.md
+++ b/files/fr/web/api/document/scrollingelement/index.md
@@ -28,6 +28,6 @@ scrollElm.scrollTop = 0;
 
 {{Specifications}}
 
-## Compatibilité du navigateur
+## Compatibilité des navigateurs
 
 {{Compat}}

--- a/files/fr/web/api/dommatrix/index.md
+++ b/files/fr/web/api/dommatrix/index.md
@@ -13,11 +13,13 @@ original_slug: Web/API/CSSMatrix
 
 Une **`CSSMatrix`** représente une matrice homogène 4x4 dans laquelle il est possible d'appliquer des transformations 2D ou 3D. Cette classe faisait à un moment partie du module de transitions CSS (Level 3) mais elle n'a pas été propagée dans le brouillon de travail (_Working Draft_) actuel. Utilisez plutôt `DOMMatrix.`
 
-## Compatibilé des navigateurs
+## Spécifications
 
-{{Compat("api.DOMMatrix")}}
+{{Specifications}}
 
-{{Compat("api.WebKitCSSMatrix")}}
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/element/compositionupdate_event/index.md
+++ b/files/fr/web/api/element/compositionupdate_event/index.md
@@ -31,9 +31,13 @@ L'événement **compositionupdate** est déclenché lorsqu'un caractère est ajo
 | `data` {{ReadOnlyInline}}       | [`DOMString`](/fr/docs/Web/API/DOMString) (string) | La chaîne de caractères originale éditée ou une chaîne vide.                               |
 | `locale` {{ReadOnlyInline}}     | [`DOMString`](/fr/docs/Web/API/DOMString) (string) | Le code de la langue pour l'évènement de composition si disponible&nbsp;; sinon une chaîne vide. |
 
-## Compatibilités navigateur
+## Spécifications
 
-{{Compat("api.Element.compositionupdate_event")}}
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/element/focusin_event/index.md
+++ b/files/fr/web/api/element/focusin_event/index.md
@@ -32,9 +32,9 @@ L'événement **focusin** est déclenché lorsqu'un élément est sur le point d
 | `cancelable` {{readonlyInline}}    | {{jsxref("Boolean")}}                       | Whether the event is cancellable or not.   |
 | `relatedTarget` {{readonlyInline}} | {{domxref("EventTarget")}} (DOM element) | Event target receiving focus.              |
 
-## Compatibilité navigateur
+## Compatibilité des navigateurs
 
-{{Compat("api.Element.focusin_event")}}
+{{Compat}}
 
 ## Evénements liés
 

--- a/files/fr/web/api/element/focusout_event/index.md
+++ b/files/fr/web/api/element/focusout_event/index.md
@@ -34,7 +34,7 @@ L'évènement `focusout` est déclenché lorsqu'un élément du DOM est sur le p
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Element.focusout_event")}}
+{{Compat}}
 
 ## Evénements liés
 

--- a/files/fr/web/api/element/scrollintoviewifneeded/index.md
+++ b/files/fr/web/api/element/scrollintoviewifneeded/index.md
@@ -36,7 +36,7 @@ Ne fait partie d'aucune spécification. C'est une méthode propriétaire propre 
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Element.scrollIntoViewIfNeeded")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/element/scrollleftmax/index.md
+++ b/files/fr/web/api/element/scrollleftmax/index.md
@@ -20,7 +20,7 @@ _Cette propriété ne fait partie d'aucune spécification._
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Element.scrollLeftMax")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/encoding_api/index.md
+++ b/files/fr/web/api/encoding_api/index.md
@@ -33,10 +33,4 @@ L'API fournit quatres interfaces: {{domxref("TextDecoder")}}, {{domxref("TextEnc
 
 ## Compatibilité des navigateurs
 
-### `TextDecoder`
-
-{{Compat("api.TextDecoder")}}
-
-### `TextEncoder`
-
-{{Compat("api.TextEncoder")}}
+{{Compat}}

--- a/files/fr/web/api/event/returnvalue/index.md
+++ b/files/fr/web/api/event/returnvalue/index.md
@@ -29,4 +29,4 @@ Bien qu'elle ait été inclue [dans l'ancien brouillon de travail de W3C DOM niv
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Event.returnValue")}}
+{{Compat}}

--- a/files/fr/web/api/event/srcelement/index.md
+++ b/files/fr/web/api/event/srcelement/index.md
@@ -22,7 +22,7 @@ Ne fait partie d'aucune spécification.
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Event.srcElement")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/fullscreen_api/index.md
+++ b/files/fr/web/api/fullscreen_api/index.md
@@ -138,25 +138,7 @@ Pour le moment, tous les navigateurs n'ont pas implémenté la version sans pré
 
 ## Compatibilité des navigateurs
 
-### `Document.fullscreen`
-
-{{Compat("api.Document.fullscreen")}}
-
-### `Document.fullscreenElement`
-
-{{Compat("api.Document.fullscreenElement")}}
-
-### `Document.fullscreenEnabled`
-
-{{Compat("api.Document.fullscreenEnabled")}}
-
-### `Document.exitFullscreen`
-
-{{Compat("api.Document.exitFullscreen")}}
-
-### `Element.requestFullscreen`
-
-{{Compat("api.Element.requestFullscreen")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/geolocation_api/index.md
+++ b/files/fr/web/api/geolocation_api/index.md
@@ -56,7 +56,7 @@ Voir le guide [Utiliser l'API <i lang="en">Geolocation</i>](/fr/docs/Web/API/Geo
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Geolocation")}}
+{{Compat}}
 
 ### Disponibilité
 

--- a/files/fr/web/api/gestureevent/index.md
+++ b/files/fr/web/api/gestureevent/index.md
@@ -50,7 +50,7 @@ _Ne fait partie d'aucune spécification._ Apple a une [description dans la bibli
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.GestureEvent")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/htmlelement/outertext/index.md
+++ b/files/fr/web/api/htmlelement/outertext/index.md
@@ -28,7 +28,7 @@ Microsoft en a publié [une description sur MSDN](<https://msdn.microsoft.com/en
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.HTMLElement.outerText")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/htmlformelement/submit/index.md
+++ b/files/fr/web/api/htmlformelement/submit/index.md
@@ -37,4 +37,4 @@ document.forms["myform"].submit();
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.HTMLFormElement.submit")}}
+{{Compat}}

--- a/files/fr/web/api/htmloptionelement/option/index.md
+++ b/files/fr/web/api/htmloptionelement/option/index.md
@@ -86,6 +86,8 @@ options.forEach(function(element, key) {
 
 ## Spécifications
 
-| Spécification                                                                                                                             | État           | Commentaires |
-| ----------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ------------ |
-| [HTML5 La définition de Option dans cette spécification.](http://www.w3.org/TR/2012/WD-html5-20121025/the-option-element.html#dom-option) | Recommendation |              |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}

--- a/files/fr/web/api/htmlshadowelement/index.md
+++ b/files/fr/web/api/htmlshadowelement/index.md
@@ -33,7 +33,7 @@ Cette fonctionnalité n'est plus définie par aucune spécification.
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.HTMLShadowElement")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/idbindex/isautolocale/index.md
+++ b/files/fr/web/api/idbindex/isautolocale/index.md
@@ -69,7 +69,7 @@ Actuellement, cette propriété ne fait partie d'aucune spécification.
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.IDBIndex.isAutoLocale")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/media_capture_and_streams_api/index.md
+++ b/files/fr/web/api/media_capture_and_streams_api/index.md
@@ -67,7 +67,7 @@ Les articles qui suivent fournissent des manuels et guides pour utiliser cette A
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.MediaStream")}}
+{{Compat}}
 
 ## Voir aussi
 


### PR DESCRIPTION
This PR updates some of the browser compatibility data and specification sections for the French locale. Part of work for #11594.

Note: this may also include other minor updates, such as removal of old sections or other small bits of cleanup.
