### PR TITLE
fr: Update browser compat/spec sections (part 7)

### DIFF
--- a/files/fr/web/api/mediasource/mediasource/index.md
+++ b/files/fr/web/api/mediasource/mediasource/index.md
@@ -42,9 +42,9 @@ if ('MediaSource' in window && MediaSource.isTypeSupported(mimeCodec)) {
 ...
 ```
 
-## Compatibilitée des navigateurs
+## Compatibilité des navigateurs
 
-{{Compat("api.MediaSource.MediaSource")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/mediastreamevent/index.md
+++ b/files/fr/web/api/mediastreamevent/index.md
@@ -42,7 +42,7 @@ pc.onaddstream = function( ev ) {
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.MediaStreamEvent")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/network_information_api/index.md
+++ b/files/fr/web/api/network_information_api/index.md
@@ -56,13 +56,7 @@ if (connection) {
 
 ## Compatibilité des navigateurs
 
-### `NetworkInformation`
-
-{{Compat("api.NetworkInformation")}}
-
-### `Navigator.connection`
-
-{{Compat("api.Navigator.connection")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/node/nextsibling/index.md
+++ b/files/fr/web/api/node/nextsibling/index.md
@@ -76,7 +76,7 @@ L'inclusion possible de nœuds textes dans le DOM doit être prise en compte pou
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Node.nextSibling")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/node/nodename/index.md
+++ b/files/fr/web/api/node/nodename/index.md
@@ -66,4 +66,4 @@ Notez que la propriété [`tagName`](/fr/DOM/element.tagName) aurait pu être ui
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Node.nodeName")}}
+{{Compat}}

--- a/files/fr/web/api/node/nodevalue/index.md
+++ b/files/fr/web/api/node/nodevalue/index.md
@@ -88,4 +88,4 @@ Lorsque `nodeValue` est défini comme étant `null`, l'assignation n'a aucun eff
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Node.nodeValue")}}
+{{Compat}}

--- a/files/fr/web/api/node/parentnode/index.md
+++ b/files/fr/web/api/node/parentnode/index.md
@@ -40,7 +40,7 @@ Il renvoie également `null` si le nœud vient d'être créé et n'est pas encor
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Node.parentNode")}}
+{{Compat}}
 
 ## Spécification
 

--- a/files/fr/web/api/node/previoussibling/index.md
+++ b/files/fr/web/api/node/previoussibling/index.md
@@ -49,7 +49,7 @@ L'opération inverse [`Node.nextSibling`](/fr/docs/Web/API/Node/nextSibling) per
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Node.previousSibling")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/node/textcontent/index.md
+++ b/files/fr/web/api/node/textcontent/index.md
@@ -83,7 +83,7 @@ if (Object.defineProperty
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Node.textContent")}}
+{{Compat}}
 
 ## Spécifications
 

--- a/files/fr/web/api/nodelist/item/index.md
+++ b/files/fr/web/api/nodelist/item/index.md
@@ -47,4 +47,4 @@ var firstTable = tables.item(1); // ou simplement tables[1] - renvoie le second 
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.NodeList.item")}}
+{{Compat}}

--- a/files/fr/web/api/nodelist/length/index.md
+++ b/files/fr/web/api/nodelist/length/index.md
@@ -50,4 +50,4 @@ Malgré l'emplacement de cette page dans la référence, `length` n'est pas une 
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.NodeList.length")}}
+{{Compat}}

--- a/files/fr/web/api/notifications_api/using_the_notifications_api/index.md
+++ b/files/fr/web/api/notifications_api/using_the_notifications_api/index.md
@@ -251,7 +251,7 @@ Voir le résultat de cet exemple :
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Notification")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/offscreencanvas/index.md
+++ b/files/fr/web/api/offscreencanvas/index.md
@@ -119,7 +119,7 @@ onmessage = function(evt) {
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.OffscreenCanvas")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/performance/memory/index.md
+++ b/files/fr/web/api/performance/memory/index.md
@@ -33,7 +33,7 @@ Aucune
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Performance.memory")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/permissions_api/index.md
+++ b/files/fr/web/api/permissions_api/index.md
@@ -48,7 +48,7 @@ Vous pouvez également en lire plus sur le fonctionnement de cet exemple dans l'
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Permissions")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/proximity_events/index.md
+++ b/files/fr/web/api/proximity_events/index.md
@@ -46,13 +46,7 @@ window.addEventListener('userproximity', function(event) {
 
 ## Compatibilité des navigateurs
 
-### `DeviceProximityEvent`
-
-{{Compat("api.DeviceProximityEvent")}}
-
-### `UserProximityEvent`
-
-{{Compat("api.UserProximityEvent")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/push_api/index.md
+++ b/files/fr/web/api/push_api/index.md
@@ -67,13 +67,7 @@ Les ajouts à [l'API <i lang="en">Service Worker</i>](/fr/docs/Web/API/Service_W
 
 ## Compatibilité des navigateurs
 
-### `PushEvent`
-
-{{Compat("api.PushEvent")}}
-
-### `PushMessageData`
-
-{{Compat("api.PushMessageData")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/rtciceserver/index.md
+++ b/files/fr/web/api/rtciceserver/index.md
@@ -61,7 +61,7 @@ Une fois l'objet de configuration créé, il est passé dans le constructeur {{d
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.RTCIceServer")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/selection/index.md
+++ b/files/fr/web/api/selection/index.md
@@ -82,7 +82,7 @@ Autres mots clés utilisés dans cette section.
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Selection")}}
+{{Compat}}
 
 ### Voir aussi
 

--- a/files/fr/web/api/server-sent_events/using_server-sent_events/index.md
+++ b/files/fr/web/api/server-sent_events/using_server-sent_events/index.md
@@ -202,4 +202,4 @@ data: {"username": "bobby", "time": "02:34:11", "text": "Hi everyone."}
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.EventSource")}}
+{{Compat}}

--- a/files/fr/web/api/shadowroot/delegatesfocus/index.md
+++ b/files/fr/web/api/shadowroot/delegatesfocus/index.md
@@ -44,4 +44,4 @@ Cette fonctionnalité n'est actuellement décrite dans aucune spécification.
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.ShadowRoot.delegatesFocus")}}
+{{Compat}}

--- a/files/fr/web/api/shadowroot/innerhtml/index.md
+++ b/files/fr/web/api/shadowroot/innerhtml/index.md
@@ -41,4 +41,4 @@ Cette propriété ne fait pas encore partie d'une spécification. Voir [cette _i
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.ShadowRoot.innerHTML")}}
+{{Compat}}

--- a/files/fr/web/api/storage_api/index.md
+++ b/files/fr/web/api/storage_api/index.md
@@ -79,7 +79,7 @@ navigator.storage.estimate().then(estimate => {
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.StorageManager")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/streams_api/index.md
+++ b/files/fr/web/api/streams_api/index.md
@@ -94,13 +94,7 @@ Examples from other developers:
 
 ## Compatibilité des navigateurs
 
-### ReadableStream
-
-{{Compat("api.ReadableStream")}}
-
-### WritableStream
-
-{{Compat("api.WritableStream")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/web_crypto_api/index.md
+++ b/files/fr/web/api/web_crypto_api/index.md
@@ -25,10 +25,8 @@ Certains navigateurs implémentent une interface appelée [`Crypto`](/fr/docs/We
 
 ## Spécifications
 
-| Spécification                                            |
-| -------------------------------------------------------- |
-| [API Web Cryptography](https://w3c.github.io/webcrypto/) |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{compat}}
+{{Compat}}

--- a/files/fr/web/api/webvtt_api/index.md
+++ b/files/fr/web/api/webvtt_api/index.md
@@ -763,24 +763,8 @@ Où `p` et `a` sont les balises utilisées en HTML pour représenter les paragra
 
 ## Spécifications
 
-| Spécification                                                                  |
-| ------------------------------------------------------------------------------ |
-| [WebVTT&nbsp;: le format Web Video Text Tracks](https://w3c.github.io/webvtt/) |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-### Interface `VTTCue`
-
-{{Compat("api.VTTCue", 0)}}
-
-### Interface `TextTrack`
-
-{{Compat("api.TextTrack", 0)}}
-
-### Notes
-
-Avant Firefox 50, l'énumération `AlignSetting` (correspondant aux valeurs possibles de [`VTTCue.align`](/fr/docs/Web/API/VTTCue/align)) incluait par erreur la valeur `"middle"` au lieu de `"center"`. Ceci a été corrigé.
-
-WebVTT a été implémenté par Firefox 24 derrière la préférence `media.webvtt.enabled`, qui était désactivée par défaut. Cette fonctionnalité pouvait être activée en passant la préférence à `true`. WebVTT est activé par défaut à partir de Firefox 31 et peut être désactivé en passant la valeur de la préférence à `false`.
-
-Avant Firefox 58, le mot-clé `REGION` créait des objets [`VTTRegion`](/fr/docs/Web/API/VTTRegion), mais qui n'étaient pas utilisés. Firefox 58 prend complètement en charge `VTTRegion` et son utilisation&nbsp;; toutefois cette fonctionnalité est désactivée par défaut derrière la préférence `media.webvtt.regions.enabled` qu'il faut passer à `true` pour l'activer avec Firefox 58. Les régions sont activées par défaut à partir de Firefox 59 (voir les bugs [1338030](https://bugzilla.mozilla.org/show_bug.cgi?id=1338030) et [1415805](https://bugzilla.mozilla.org/show_bug.cgi?id=1415805)).
+{{Compat}}

--- a/files/fr/web/api/window/clearimmediate/index.md
+++ b/files/fr/web/api/window/clearimmediate/index.md
@@ -38,13 +38,11 @@ document.getElementById("bouton")
 
 ## Spécifications
 
-| Spécification                                                                                                                              | Statut         | Commentaire         |
-| ------------------------------------------------------------------------------------------------------------------------------------------ | -------------- | ------------------- |
-| [Efficient Script Yielding La définition de `setImmediate` dans cette spécification.](https://w3c.github.io/setImmediate/#si-setImmediate) | Editor's Draft | Initial definition. |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Window.clearImmediate")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/window/getdefaultcomputedstyle/index.md
+++ b/files/fr/web/api/window/getdefaultcomputedstyle/index.md
@@ -88,4 +88,4 @@ Proposé au groupe de travail CSS.
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Window.getDefaultComputedStyle")}}
+{{Compat}}

--- a/files/fr/web/api/window/mozinnerscreenx/index.md
+++ b/files/fr/web/api/window/mozinnerscreenx/index.md
@@ -36,7 +36,7 @@ Ne fait partie d'aucune spécification ou recommandation technique du W3C.
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Window.mozInnerScreenX")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/window/mozinnerscreeny/index.md
+++ b/files/fr/web/api/window/mozinnerscreeny/index.md
@@ -36,7 +36,7 @@ Ne fait partie d'aucune spécification ou recommandation technique du W3C.
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.Window.mozInnerScreenY")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/workerglobalscope/console/index.md
+++ b/files/fr/web/api/workerglobalscope/console/index.md
@@ -43,7 +43,7 @@ Ne fait pas encore parti d'une spécification.
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.WorkerGlobalScope.console")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/api/workerglobalscope/dump/index.md
+++ b/files/fr/web/api/workerglobalscope/dump/index.md
@@ -48,7 +48,7 @@ Cette méthode n’apparaît dans aucune spécification.
 
 ## Compatibilité des navigateurs
 
-{{Compat("api.WorkerGlobalScope.dump")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/-moz-image-region/index.md
+++ b/files/fr/web/css/-moz-image-region/index.md
@@ -65,7 +65,7 @@ Cette propriété est une propriété propriétaire liée à Mozilla/Gecko et ne
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.-moz-image-region")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/-moz-orient/index.md
+++ b/files/fr/web/css/-moz-orient/index.md
@@ -72,7 +72,7 @@ Bien que [proposée](https://lists.w3.org/Archives/Public/www-style/2014Jun/0396
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.-moz-orient")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/-moz-outline-radius/index.md
+++ b/files/fr/web/css/-moz-outline-radius/index.md
@@ -109,4 +109,4 @@ Cette propriété est une propriété propriétaire liée à Mozilla/Gecko et ne
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.-moz-outline-radius")}}
+{{Compat}}

--- a/files/fr/web/css/-moz-user-focus/index.md
+++ b/files/fr/web/css/-moz-user-focus/index.md
@@ -65,7 +65,7 @@ Cette propriété est une propriété propriétaire liée à Gecko/Mozilla et ne
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.-moz-user-focus")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/-moz-user-input/index.md
+++ b/files/fr/web/css/-moz-user-input/index.md
@@ -60,7 +60,7 @@ Cette propriété est une propriété propriétaire liée à Gecko/Mozilla et ne
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.-moz-user-input")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/-webkit-border-before/index.md
+++ b/files/fr/web/css/-webkit-border-before/index.md
@@ -85,7 +85,7 @@ Cette propriété est une propriété propriétaire liée à WebKit/Blink et ne 
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.-webkit-border-before")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/-webkit-box-reflect/index.md
+++ b/files/fr/web/css/-webkit-box-reflect/index.md
@@ -57,7 +57,7 @@ Cette propriété n'est pas en voie de standardisation et ne fera pas partie de 
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.-webkit-box-reflect")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/-webkit-mask-attachment/index.md
+++ b/files/fr/web/css/-webkit-mask-attachment/index.md
@@ -59,7 +59,7 @@ Cette propriété est une propriété propriétaire liée à WebKit/Blink et ne 
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.-webkit-mask-attachment")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/-webkit-mask-box-image/index.md
+++ b/files/fr/web/css/-webkit-mask-box-image/index.md
@@ -74,7 +74,7 @@ Cette propriété est une propriété propriétaire liée à WebKit/Blink et ne 
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.-webkit-mask-box-image")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/-webkit-mask-composite/index.md
+++ b/files/fr/web/css/-webkit-mask-composite/index.md
@@ -83,7 +83,7 @@ Cette propriété est une propriété propriétaire liée à WebKit/Blink et ne 
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.-webkit-mask-composite")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/-webkit-mask-position-x/index.md
+++ b/files/fr/web/css/-webkit-mask-position-x/index.md
@@ -77,7 +77,7 @@ Cette propriété est une propriété propriétaire liée à WebKit/Blink et ne 
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.-webkit-mask-position-x")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/-webkit-mask-position-y/index.md
+++ b/files/fr/web/css/-webkit-mask-position-y/index.md
@@ -79,7 +79,7 @@ Cette propriété est une propriété propriétaire liée à WebKit/Blink et ne 
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.-webkit-mask-position-y")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/-webkit-mask-repeat-x/index.md
+++ b/files/fr/web/css/-webkit-mask-repeat-x/index.md
@@ -77,7 +77,7 @@ Chaque image aura la valeur associée, dans le même ordre.
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.-webkit-mask-repeat-x")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/-webkit-mask-repeat-y/index.md
+++ b/files/fr/web/css/-webkit-mask-repeat-y/index.md
@@ -77,7 +77,7 @@ Chaque image aura la valeur associée, dans le même ordre.
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.-webkit-mask-repeat-y")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/-webkit-overflow-scrolling/index.md
+++ b/files/fr/web/css/-webkit-overflow-scrolling/index.md
@@ -77,7 +77,7 @@ Cette propriété est une propriété propriétaire liée à WebKit/Blink et ne 
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.-webkit-overflow-scrolling")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/-webkit-touch-callout/index.md
+++ b/files/fr/web/css/-webkit-touch-callout/index.md
@@ -53,4 +53,4 @@ Cette propriété est une propriété propriétaire liée à WebKit/Blink et ne 
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.-webkit-touch-callout")}}
+{{Compat}}

--- a/files/fr/web/css/@media/-moz-device-pixel-ratio/index.md
+++ b/files/fr/web/css/@media/-moz-device-pixel-ratio/index.md
@@ -39,4 +39,4 @@ La [caractéristique média](/fr/docs/Web/CSS/Media_Queries/Using_media_queries#
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.at-rules.media.-moz-device-pixel-ratio")}}
+{{Compat}}

--- a/files/fr/web/css/@media/-webkit-animation/index.md
+++ b/files/fr/web/css/@media/-webkit-animation/index.md
@@ -27,7 +27,7 @@ Cette caractéristique média est une caractéristique média propriétaire lié
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.at-rules.media.-webkit-animation")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/@media/-webkit-transform-2d/index.md
+++ b/files/fr/web/css/@media/-webkit-transform-2d/index.md
@@ -21,7 +21,7 @@ Cette caractéristique média est une caractéristique média propriétaire lié
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.at-rules.media.-webkit-transform-2d")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/@media/-webkit-transition/index.md
+++ b/files/fr/web/css/@media/-webkit-transition/index.md
@@ -34,7 +34,7 @@ Cette caractéristique média est une caractéristique média propriétaire lié
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.at-rules.media.-webkit-transition")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/@media/aural/index.md
+++ b/files/fr/web/css/@media/aural/index.md
@@ -17,9 +17,11 @@ Un [groupe de médias](/fr/docs/Web/CSS/@media#Groupes_de_médias) défini par l
 
 ## Spécifications
 
-| Spécification                                              | État         | Commentaires         |
-| ---------------------------------------------------------- | ------------ | -------------------- |
-| [CSS Level 2](https://www.w3.org/TR/CSS2/aural.html#q19.0) | Dépréciation | Définition initiale. |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/@media/shape/index.md
+++ b/files/fr/web/css/@media/shape/index.md
@@ -73,10 +73,8 @@ Ce fragment de code HTML permettra d'appliquer une feuille de style particulièr
 
 ## Spécifications
 
-| Spécification                                                              | État      | Commentaires         |
-| -------------------------------------------------------------------------- | --------- | -------------------- |
-| _[CSS Round Display Level 1](https://drafts.csswg.org/css-round-display/)_ | Brouillon | Définition initiale. |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.at-rules.media.shape")}}
+{{Compat}}

--- a/files/fr/web/css/_colon_-moz-focusring/index.md
+++ b/files/fr/web/css/_colon_-moz-focusring/index.md
@@ -54,7 +54,7 @@ Cette fonctionnalité ne fait partie d'aucune spécification bien qu'elle ait [d
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.selectors.-moz-focusring")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/_colon_-moz-submit-invalid/index.md
+++ b/files/fr/web/css/_colon_-moz-submit-invalid/index.md
@@ -27,7 +27,7 @@ Cette pseudo-classe est une pseudo-classe propriétaire liée à Gecko/Mozilla e
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.selectors.-moz-submit-invalid")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/_colon_-moz-window-inactive/index.md
+++ b/files/fr/web/css/_colon_-moz-window-inactive/index.md
@@ -51,4 +51,4 @@ Cette pseudo-classe est une pseudo-classe propriétaire liée à Gecko/Mozilla e
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.selectors.-moz-window-inactive")}}
+{{Compat}}

--- a/files/fr/web/css/_doublecolon_-moz-color-swatch/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-color-swatch/index.md
@@ -46,7 +46,7 @@ Ce pseudo-élément est spécifique à Gecko et ne fait partie d'aucune spécifi
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.selectors.-moz-color-swatch")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/_doublecolon_-moz-page-sequence/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-page-sequence/index.md
@@ -23,7 +23,7 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à Gecko/Mozilla 
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.selectors.-moz-page-sequence")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/_doublecolon_-moz-page/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-page/index.md
@@ -23,7 +23,7 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à Gecko/Mozilla 
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.selectors.-moz-page")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/_doublecolon_-moz-scrolled-page-sequence/index.md
+++ b/files/fr/web/css/_doublecolon_-moz-scrolled-page-sequence/index.md
@@ -23,7 +23,7 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à Gecko/Mozilla 
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.selectors.-moz-scrolled-page-sequence")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/_doublecolon_-webkit-inner-spin-button/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-inner-spin-button/index.md
@@ -39,7 +39,7 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.selectors.-webkit-inner-spin-button")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/_doublecolon_-webkit-meter-bar/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-meter-bar/index.md
@@ -50,7 +50,7 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.selectors.-webkit-meter-bar")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/_doublecolon_-webkit-meter-even-less-good-value/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-meter-even-less-good-value/index.md
@@ -43,7 +43,7 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.selectors.-webkit-meter-even-less-good-value")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/_doublecolon_-webkit-meter-inner-element/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-meter-inner-element/index.md
@@ -50,7 +50,7 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.selectors.-webkit-meter-inner-element")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/_doublecolon_-webkit-meter-optimum-value/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-meter-optimum-value/index.md
@@ -40,7 +40,7 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.selectors.-webkit-meter-optimum-value")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/_doublecolon_-webkit-meter-suboptimum-value/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-meter-suboptimum-value/index.md
@@ -38,7 +38,7 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.selectors.-webkit-meter-suboptimum-value")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/_doublecolon_-webkit-outer-spin-button/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-outer-spin-button/index.md
@@ -39,7 +39,7 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink, 
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.selectors.-webkit-outer-spin-button")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/_doublecolon_-webkit-progress-bar/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-progress-bar/index.md
@@ -49,7 +49,7 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.selectors.-webkit-progress-bar")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/_doublecolon_-webkit-progress-value/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-progress-value/index.md
@@ -49,7 +49,7 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.selectors.-webkit-progress-value")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/_doublecolon_-webkit-scrollbar/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-scrollbar/index.md
@@ -82,33 +82,7 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Compatibilité des navigateurs
 
-### `::-webkit-scrollbar`
-
-{{Compat("css.selectors.-webkit-scrollbar")}}
-
-### `::-webkit-scrollbar-button`
-
-{{Compat("css.selectors.-webkit-scrollbar-button")}}
-
-### `::-webkit-scrollbar-thumb`
-
-{{Compat("css.selectors.-webkit-scrollbar-thumb")}}
-
-### `::-webkit-scrollbar-track`
-
-{{Compat("css.selectors.-webkit-scrollbar-track")}}
-
-### `::-webkit-scrollbar-track-piece`
-
-{{Compat("css.selectors.-webkit-scrollbar-track-piece")}}
-
-### `::-webkit-scrollbar-corner`
-
-{{Compat("css.selectors.-webkit-scrollbar-corner")}}
-
-### `::-webkit-resizer`
-
-{{Compat("css.selectors.-webkit-resizer")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/_doublecolon_-webkit-search-cancel-button/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-search-cancel-button/index.md
@@ -25,7 +25,7 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.selectors.-webkit-search-cancel-button")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/_doublecolon_-webkit-search-results-button/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-search-results-button/index.md
@@ -25,7 +25,7 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.selectors.-webkit-search-results-button")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/_doublecolon_-webkit-slider-runnable-track/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-slider-runnable-track/index.md
@@ -19,7 +19,7 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.selectors.-webkit-slider-runnable-track")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/_doublecolon_-webkit-slider-thumb/index.md
+++ b/files/fr/web/css/_doublecolon_-webkit-slider-thumb/index.md
@@ -19,7 +19,7 @@ Ce pseudo-élément est un pseudo-élément propriétaire lié à WebKit/Blink e
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.selectors.-webkit-slider-thumb")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/box-flex/index.md
+++ b/files/fr/web/css/box-flex/index.md
@@ -99,7 +99,7 @@ Cette propriété n'est pas une propriété standard. [Une ancienne version de l
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.box-flex")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/box-pack/index.md
+++ b/files/fr/web/css/box-pack/index.md
@@ -136,7 +136,7 @@ Cette propriété n'est pas standard mais une propriété semblable est apparue 
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.box-pack")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/display-box/index.md
+++ b/files/fr/web/css/display-box/index.md
@@ -86,9 +86,7 @@ Via leur implémentation, la plupart des navigation retireront un élément de [
 
 ## Compatibilité des navigateurs
 
-### Prise en charge `contents`
-
-{{Compat("css.properties.display.contents", 10)}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/display-inside/index.md
+++ b/files/fr/web/css/display-inside/index.md
@@ -79,29 +79,7 @@ Dans l'exemple qui suit, la boîte parente est ciblée avec `display: flow-root`
 
 ## Compatibilité des navigateurs
 
-### Prise en charge des valeurs multiples
-
-{{Compat("css.properties.display.multi-keyword_values", 10)}}
-
-### Prise en charge de `flow-root`
-
-{{Compat("css.properties.display.flow-root", 10)}}
-
-### Prise en charge des tableaux
-
-{{Compat("css.properties.display.table_values", 10)}}
-
-### Prise en charge des grilles
-
-{{Compat("css.properties.display.grid", 10)}}
-
-### Prise en charge des boîtes flexibles
-
-{{Compat("css.properties.display.flex", 10)}}
-
-### Prise en charge des annotations ruby
-
-{{Compat("css.properties.display.ruby_values", 10)}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/display-internal/index.md
+++ b/files/fr/web/css/display-internal/index.md
@@ -43,17 +43,7 @@ Sauf mention contraire, le type d'affichage intérieur et extérieur sont défin
 
 ## Compatibilité des navigateurs
 
-### Prise en charge pour les valeurs liées à `table`
-
-`table`, `table-cell`, `table-column`, `table-column-group`, `table-footer-group`, `table-header-group`, `table-row` et `table-row-group`
-
-{{Compat("css.properties.display.table_values", 10)}}
-
-### Prise en charge pour les valeurs `ruby`
-
-`ruby`, `ruby-base`, `ruby-base-container`, `ruby-text` et `ruby-text-container`
-
-{{Compat("css.properties.display.ruby_values", 10)}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/display-legacy/index.md
+++ b/files/fr/web/css/display-legacy/index.md
@@ -79,21 +79,7 @@ Avec la nouvelle syntaxe, on peut décrire le conteneur avec deux valeurs : la p
 
 ## Compatibilité des navigateurs
 
-### Prise en charge de `inline-block`
-
-{{Compat("css.properties.display.inline-block", 10)}}
-
-### Prise en charge de `inline-table`
-
-{{Compat("css.properties.display.inline-table", 10)}}
-
-### Prise en charge de `inline-flex`
-
-{{Compat("css.properties.display.inline-flex", 10)}}
-
-### Prise en charge de `inline-grid`
-
-{{Compat("css.properties.display.inline-grid", 10)}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/display-listitem/index.md
+++ b/files/fr/web/css/display-listitem/index.md
@@ -45,9 +45,7 @@ Une valeur `list-item` indiquera à l'élément de se comporter comme un éléme
 
 ## Compatibilité des navigateurs
 
-### Prise en charge de `list-item`
-
-{{Compat("css.properties.display.list-item", 10)}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/display-outside/index.md
+++ b/files/fr/web/css/display-outside/index.md
@@ -62,9 +62,7 @@ span {
 
 ## Compatibilité des navigateurs
 
-### Prise en charge `run-in`
-
-{{Compat("css.properties.display.run-in", 10)}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/font-smooth/index.md
+++ b/files/fr/web/css/font-smooth/index.md
@@ -50,7 +50,7 @@ Bien que mentionnée dans les premiers brouillons pour [CSS3 Fonts](https://www.
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.font-smooth")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/layout_cookbook/breadcrumb_navigation/index.md
+++ b/files/fr/web/css/layout_cookbook/breadcrumb_navigation/index.md
@@ -34,9 +34,7 @@ On utilise ici les attributs `aria-label` et `aria-current` afin d'aider les uti
 
 ## Compatibilité des navigateurs
 
-### Boîtes flexibles
-
-{{Compat("css.properties.flex")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/layout_cookbook/card/index.md
+++ b/files/fr/web/css/layout_cookbook/card/index.md
@@ -61,15 +61,7 @@ Selon le contenu des cartes, il est possible voire souhaitable d'appliquer quelq
 
 ## Compatibilité des navigateurs
 
-Les différentes méthodes évoquées plus haut peuvent disposer d'une prise en charge différente selon les navigateurs, se référer à chacun des tableaux suivant pour plus de détails sur la prise en charge de chaque propriété.
-
-### grid-template-columns
-
-{{Compat("css.properties.grid-template-columns")}}
-
-### grid-template-rows
-
-{{Compat("css.properties.grid-template-rows")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/layout_cookbook/center_an_element/index.md
+++ b/files/fr/web/css/layout_cookbook/center_an_element/index.md
@@ -39,15 +39,7 @@ Cependant, sa prise en charge dans ce cas (disposition en bloc) est actuellement
 
 ## Compatibilité des navigateurs
 
-Les différentes méthodes de layout ont chacune leur compatibilité avec les navigateurs. Les tableaux ci-dessous détaillent le support de base pour chaque propriété.
-
-### `align-items`
-
-{{Compat("css.properties.align-items")}}
-
-### `justify-content`
-
-{{Compat("css.properties.justify-content")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/layout_cookbook/column_layouts/index.md
+++ b/files/fr/web/css/layout_cookbook/column_layouts/index.md
@@ -82,27 +82,7 @@ On utiliser les grilles CSS lorsque :
 
 ## Compatibilité des navigateurs
 
-Les différentes méthodes évoquées plus haut peuvent disposer d'une prise en charge différente selon les navigateurs, se référer à chacun des tableaux suivant pour plus de détails sur la prise en charge de chaque propriété.
-
-### column-width
-
-{{Compat("css.properties.column-width")}}
-
-### column-rule
-
-{{Compat("css.properties.column-rule")}}
-
-### flex
-
-{{Compat("css.properties.flex")}}
-
-### flex-wrap
-
-{{Compat("css.properties.flex-wrap")}}
-
-### grid-template-columns
-
-{{Compat("css.properties.grid-template-columns")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/layout_cookbook/contribute_a_recipe/cookbook_template/index.md
+++ b/files/fr/web/css/layout_cookbook/contribute_a_recipe/cookbook_template/index.md
@@ -44,13 +44,7 @@ _Inclure ici les aspects spécifiquement liés à l'accessibilité pour cette re
 
 ## Compatibilité des navigateurs
 
-Les différentes méthodes évoquées plus haut peuvent disposer d'une prise en charge différente selon les navigateurs, se référer à chacun des tableaux suivant pour plus de détails sur la prise en charge de chaque propriété.
-
-_Inclure ici les données de compatibilité pour les principales propriétés utilisées. Comme exemple, voici comment faire pour inclure les données concernant `align-items`._
-
-### align-items
-
-{{Compat("css.properties.align-items")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/layout_cookbook/grid_wrapper/index.md
+++ b/files/fr/web/css/layout_cookbook/grid_wrapper/index.md
@@ -68,9 +68,7 @@ Bien que les grilles CSS nous permettent potentiellement de positionner n'import
 
 ## Compatibilité des navigateurs
 
-### `grid-template-columns`
-
-{{Compat("css.properties.grid-template-columns")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/layout_cookbook/list_group_with_badges/index.md
+++ b/files/fr/web/css/layout_cookbook/list_group_with_badges/index.md
@@ -35,15 +35,7 @@ Pour aligner le contenu horizontalement, on utilise la propriété `align-items`
 
 ## Compatibilité des navigateurs
 
-Les différentes méthodes utilisées ici peuvent avoir une prise en charge différentes par les navigateurs. Se référer à chacun des tableaux pour avoir plus de détails.
-
-### justify-content
-
-{{Compat("css.properties.justify-content")}}
-
-### align-items
-
-{{Compat("css.properties.align-items")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/layout_cookbook/media_objects/index.md
+++ b/files/fr/web/css/layout_cookbook/media_objects/index.md
@@ -56,15 +56,7 @@ En revanche, il faudra retirer les marges appliquées aux objets et les largeurs
 
 ## Compatibilité des navigateurs
 
-Les différentes méthodes évoquées plus haut peuvent disposer d'une prise en charge différente selon les navigateurs, se référer à chacun des tableaux suivant pour plus de détails sur la prise en charge de chaque propriété.
-
-### grid-template-areas
-
-{{Compat("css.properties.grid-template-areas")}}
-
-### float
-
-{{Compat("css.properties.float")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/layout_cookbook/pagination/index.md
+++ b/files/fr/web/css/layout_cookbook/pagination/index.md
@@ -57,15 +57,7 @@ Voir la section « Voir aussi » en fin d'article pour divers liens portants sur
 
 ## Compatibilité des navigateurs
 
-Les différentes méthodes évoquées plus haut peuvent disposer d'une prise en charge différente selon les navigateurs, se référer à chacun des tableaux suivant pour plus de détails sur la prise en charge de chaque propriété.
-
-### justify-content
-
-{{Compat("css.properties.justify-content")}}
-
-### column-gap in Flex layout
-
-{{Compat("css.properties.column-gap.flex_context")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/layout_cookbook/split_navigation/index.md
+++ b/files/fr/web/css/layout_cookbook/split_navigation/index.md
@@ -35,9 +35,7 @@ Dans notre exemple, c'est la marge à gauche du dernier élément qui est automa
 
 ## Compatibilité des navigateurs
 
-#### Boîtes flexibles
-
-{{Compat("css.properties.flex")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/layout_cookbook/sticky_footers/index.md
+++ b/files/fr/web/css/layout_cookbook/sticky_footers/index.md
@@ -46,21 +46,7 @@ On commence de la même façon mais on utilise `display:flex` plutôt que `displ
 
 ## Compatibilité des navigateurs
 
-#### grid-template-rows
-
-{{Compat("css.properties.grid-template-rows")}}
-
-#### flex-direction
-
-{{Compat("css.properties.flex-direction")}}
-
-#### flex-grow
-
-{{Compat("css.properties.flex-grow")}}
-
-#### flex-shrink
-
-{{Compat("css.properties.flex-shrink")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/media_queries/testing_media_queries/index.md
+++ b/files/fr/web/css/media_queries/testing_media_queries/index.md
@@ -70,9 +70,7 @@ mql.removeListener(handleOrientationChange);
 
 ## Compatibilité des navigateurs
 
-### Interface `MediaQueryList`
-
-{{Compat("api.MediaQueryList")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/overflow-anchor/guide_to_scroll_anchoring/index.md
+++ b/files/fr/web/css/overflow-anchor/guide_to_scroll_anchoring/index.md
@@ -64,9 +64,7 @@ Les évènements en question sont les modifications des [valeurs calculées](/fr
 
 ## Compatibilité des navigateurs
 
-Si vous souhaitez appliquer une amélioration progressive et détecter si cette fonctionnalité est disponible dans le navigateur utilisé, vous pouvez utiliser [les requêtes de fonctionnalité](/fr/docs/Web/CSS/@supports) afin de tester la prise en charge de la propriété `overflow-anchor`.
-
-{{Compat("css.properties.overflow-anchor")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/scroll-snap-points-x/index.md
+++ b/files/fr/web/css/scroll-snap-points-x/index.md
@@ -93,4 +93,4 @@ Cette propriété avait été définie dans [un brouillon de spécification pour
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.scroll-snap-points-x")}}
+{{Compat}}

--- a/files/fr/web/css/scroll-snap-points-y/index.md
+++ b/files/fr/web/css/scroll-snap-points-y/index.md
@@ -95,4 +95,4 @@ Cette propriété avait été définie dans [un brouillon de spécification pour
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.scroll-snap-points-y")}}
+{{Compat}}

--- a/files/fr/web/css/scroll-snap-type-x/index.md
+++ b/files/fr/web/css/scroll-snap-type-x/index.md
@@ -52,4 +52,4 @@ Cette propriété ne fait partie d'aucune spécification.
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.scroll-snap-type-x")}}
+{{Compat}}


### PR DESCRIPTION
This PR updates some of the browser compatibility data and specification sections for the French locale. Part of work for #11594.

Note: this may also include other minor updates, such as removal of old sections or other small bits of cleanup.
