### PR TITLE
fr: Update browser compat/spec sections (part 8)

### DIFF
--- a/files/fr/web/css/scroll-snap-type-y/index.md
+++ b/files/fr/web/css/scroll-snap-type-y/index.md
@@ -52,4 +52,4 @@ Cette propriété ne fait partie d'aucune spécification.
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.scroll-snap-type-y")}}
+{{Compat}}

--- a/files/fr/web/css/text-underline-offset/index.md
+++ b/files/fr/web/css/text-underline-offset/index.md
@@ -84,7 +84,7 @@ p {
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.text-underline-offset")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/user-modify/index.md
+++ b/files/fr/web/css/user-modify/index.md
@@ -77,7 +77,7 @@ La propriété `user-modify` est définie grâce à un mot-clé parmi ceux de la
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.user-modify")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/css/using_css_custom_properties/index.md
+++ b/files/fr/web/css/using_css_custom_properties/index.md
@@ -278,7 +278,7 @@ element.style.setProperty("--ma-variable", varJS + 4);
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.custom-property")}}
+{{Compat}}
 
 > **Note :** Dans les versions antérieures de la spécification, le préfixe indiquant les propriétés personnalisées était `var-`. Ce préfixe a ensuite été modifié en `--`. et Firefox 31 et les versions ultérieures respectent cette spécification (cf. {{bug(985838)}})
 

--- a/files/fr/web/css/zoom/index.md
+++ b/files/fr/web/css/zoom/index.md
@@ -111,7 +111,7 @@ Cette propriété n'est pas standard et est née avec Internet Explorer. Apple l
 
 ## Compatibilité des navigateurs
 
-{{Compat("css.properties.zoom")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/exslt/exsl/index.md
+++ b/files/fr/web/exslt/exsl/index.md
@@ -12,4 +12,4 @@ Le paquet EXSLT <i lang="en">Common</i> fournit des fonctionnalités de base qui
 
 ## Compatibilité des navigateurs
 
-{{Compat("xslt.exslt.exsl")}}
+{{Compat}}

--- a/files/fr/web/exslt/math/index.md
+++ b/files/fr/web/exslt/math/index.md
@@ -12,4 +12,4 @@ Le paquet EXSLT Math fournit des fonctions pour manipuler des valeurs numérique
 
 ## Compatibilité des navigateurs
 
-{{Compat("xslt.exslt.math")}}
+{{Compat}}

--- a/files/fr/web/exslt/set/index.md
+++ b/files/fr/web/exslt/set/index.md
@@ -12,4 +12,4 @@ Le paquet EXSLT <i lang="en">Sets</i> fournit des fonctions pour manipuler des e
 
 ## Compatibilité des navigateurs
 
-{{Compat("xslt.exslt.set")}}
+{{Compat}}

--- a/files/fr/web/exslt/str/index.md
+++ b/files/fr/web/exslt/str/index.md
@@ -12,4 +12,4 @@ Le paquet EXSLT <i lang="en">Strings</i> fournit des fonctions pour la manipulat
 
 ## Compatibilité des navigateurs
 
-{{Compat("xslt.exslt.str")}}
+{{Compat}}

--- a/files/fr/web/html/element/image/index.md
+++ b/files/fr/web/html/element/image/index.md
@@ -20,13 +20,11 @@ Bien que les navigateurs essaient de convertir cet élément {{HTMLElement("img"
 
 ## Spécifications
 
-Cet élément ne fait partie d'aucune spécification.
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-La plupart du temps, les navigateurs essaieront de convertir cet élément en un élément `<img>` si l'attribut {{htmlattrxref("src", "img")}} est utilisé. Créer un élément `<image>` sans attribut entraînera la création d'un objet `HTMLElement` avec le nom "image". Si l'élément est créé avec un attribut `src`, ce sera un objet `HTMLImageElement` qui sera créé et son nom sera "img".
-
-{{Compat("html.elements.image")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/html/element/keygen/index.md
+++ b/files/fr/web/html/element/keygen/index.md
@@ -135,7 +135,7 @@ Voici un exemple d'un envoi de formulaire, tel qu'envoyé au programme CGI par l
 
 ## Compatibilité des navigateurs
 
-{{Compat("html.elements.keygen")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/html/element/plaintext/index.md
+++ b/files/fr/web/html/element/plaintext/index.md
@@ -33,7 +33,7 @@ Cet élément implémente l'interface {{domxref('HTMLElement')}}.
 
 ## Compatibilité des navigateurs
 
-{{Compat("html.elements.plaintext")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/html/element/shadow/index.md
+++ b/files/fr/web/html/element/shadow/index.md
@@ -115,7 +115,7 @@ Cet élément ne fait plus partie d'aucune spécification.
 
 ## Compatibilité des navigateurs
 
-{{Compat("html.elements.shadow")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/html/element/spacer/index.md
+++ b/files/fr/web/html/element/spacer/index.md
@@ -50,4 +50,4 @@ Cet élément ne fait partie d'aucune spécification.
 
 ## Compatibilité des navigateurs
 
-{{Compat("html.elements.spacer")}}
+{{Compat}}

--- a/files/fr/web/html/element/xmp/index.md
+++ b/files/fr/web/html/element/xmp/index.md
@@ -32,7 +32,7 @@ Cet élément implémente l'interface {{domxref('HTMLElement')}}.
 
 ## Compatibilité des navigateurs
 
-{{Compat("html.elements.xmp")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/basics_of_http/data_urls/index.md
+++ b/files/fr/web/http/basics_of_http/data_urls/index.md
@@ -93,13 +93,11 @@ beaucoup de texte...<p><a name="bottom">bottom</a>?arg=val
 
 ## Spécifications
 
-| Spécification        | Titre                  |
-| -------------------- | ---------------------- |
-| {{RFC("2397")}} | Le schéma d'URL "data" |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{compat("http.data-url")}}
+{{Compat}}
 
 ## Voir_aussi
 

--- a/files/fr/web/http/basics_of_http/identifying_resources_on_the_web/index.md
+++ b/files/fr/web/http/basics_of_http/identifying_resources_on_the_web/index.md
@@ -104,9 +104,11 @@ urn:isbn:9780141036144
 
 ## Spécifications
 
-| Spécification                                                            | Titre                                                              |
-| ------------------------------------------------------------------------ | ------------------------------------------------------------------ |
-| {{RFC("7230", "Uniform Resource Identifiers", "2.7")}} | Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/accept-charset/index.md
+++ b/files/fr/web/http/headers/accept-charset/index.md
@@ -53,15 +53,13 @@ Accept-Charset: utf-8, iso-8859-1;q=0.5
 Accept-Charset: utf-8, iso-8859-1;q=0.5, *;q=0.1
 ```
 
-## Specifications
+## Spécifications
 
-| Specification                                            | Titre                                                         |
-| -------------------------------------------------------- | ------------------------------------------------------------- |
-| {{RFC("7231", "Accept-Charset", "5.3.3")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Context |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("http.headers.Accept-Charset")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/accept-encoding/index.md
+++ b/files/fr/web/http/headers/accept-encoding/index.md
@@ -80,13 +80,11 @@ Accept-Encoding: br;q=1.0, gzip;q=0.8, *;q=0.1
 
 ## Spécifications
 
-| Specification                                                                                 | Title                                                         |
-| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| [RFC 7231, section 5.3.4: Accept-Encoding](https://tools.ietf.org/html/rfc7231#section-5.3.4) | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Context |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("http.headers.Accept-Encoding")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/accept-language/index.md
+++ b/files/fr/web/http/headers/accept-language/index.md
@@ -71,13 +71,11 @@ Accept-Language: en-US,en;q=0.5
 
 ## Spécifications
 
-| Spécification                                            | Titre                                                         |
-| -------------------------------------------------------- | ------------------------------------------------------------- |
-| {{RFC("7231", "Accept-Language", "5.3.5")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Context |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("http.headers.Accept-Language")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/accept/index.md
+++ b/files/fr/web/http/headers/accept/index.md
@@ -64,15 +64,13 @@ Accept: image/*
 Accept: text/html, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8
 ```
 
-## Specifications
+## Spécifications
 
-| Specification                                | Titre                                                              |
-| -------------------------------------------- | ------------------------------------------------------------------ |
-| {{RFC("7231", "Accept", "5.3.2")}} | Hypertext Transfer Protocol (HTTP/1.1): Vocabulaire et cas d'usage |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("http.headers.Accept")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/age/index.md
+++ b/files/fr/web/http/headers/age/index.md
@@ -42,13 +42,11 @@ Age: 24
 
 ## Spécifications
 
-| Spécification                            | Titre                                           |
-| ---------------------------------------- | ----------------------------------------------- |
-| {{RFC("7234", "Age", "5.1")}} | Hypertext Transfer Protocol (HTTP/1.1): Caching |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("http.headers.Age")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/allow/index.md
+++ b/files/fr/web/http/headers/allow/index.md
@@ -47,9 +47,11 @@ Allow: GET, POST, HEAD
 
 ## Spécifications
 
-| Spécification                                | Titre                                                         |
-| -------------------------------------------- | ------------------------------------------------------------- |
-| {{RFC("7231", "Allow", "7.4.1")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/authorization/index.md
+++ b/files/fr/web/http/headers/authorization/index.md
@@ -63,10 +63,11 @@ Voir aussi l'article [authentification HTTP](/fr/docs/Web/HTTP/Authentication) a
 
 ## Spécifications
 
-| Spécification                                        | Titre                                  |
-| ---------------------------------------------------- | -------------------------------------- |
-| {{RFC("7235", "Authorization", "4.2")}} | HTTP/1.1 : Authentification            |
-| {{RFC("7617")}}                                 | Schéma d'Authentification HTTP 'Basic' |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir
 

--- a/files/fr/web/http/headers/connection/index.md
+++ b/files/fr/web/http/headers/connection/index.md
@@ -50,4 +50,4 @@ Connection: close
 
 ## Compatibilité des navigateurs
 
-{{Compat("http.headers.Connection")}}
+{{Compat}}

--- a/files/fr/web/http/headers/content-disposition/index.md
+++ b/files/fr/web/http/headers/content-disposition/index.md
@@ -115,19 +115,11 @@ value2
 
 ## Spécifications
 
-| Spécification        | Titre                                                                                                                    |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| {{RFC("7578")}} | Retour des valeurs à partir des formulaires: multipart / form-data                                                       |
-| {{RFC("6266")}} | Utilisation du champ Header Content-Disposition dans le protocole de transfert hypertexte (HTTP)                         |
-| {{RFC("2183")}} | Communiquer des informations de présentation dans les messages Internet: le champ de l'en-tête de disposition de contenu |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
 {{Compat}}
-
-## Notes de compatibilité
-
-- Firefox 5 gère l'en-tête de réponse HTTP `Content-Disposition` plus efficacement si les deux paramètres du nom de fichier et du nom de fichier sont fournis. Il examine tous les noms fournis, en utilisant le paramètre \* du nom de fichier, s'il est disponible, même si un paramètre de nom de fichier est inclus en premier. Auparavant, le premier paramètre correspondant serait utilisé, empêchant ainsi un nom plus approprié d'être utilisé. Voir {{bug (588781)}}.
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/content-encoding/index.md
+++ b/files/fr/web/http/headers/content-encoding/index.md
@@ -78,15 +78,11 @@ Content-Encoding: gzip
 
 ## Spécifications
 
-| Spécification                                                    | Titre                                                         |
-| ---------------------------------------------------------------- | ------------------------------------------------------------- |
-| {{RFC("7932", "Brotli Compressed Data Format")}} | Brotli Compressed Data Format                                 |
-| {{RFC("7231", "Content-Encoding", "3.1.2.2")}}     | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
-| {{RFC("2616", "Content-Encoding", "14.11")}}     | Content-Encoding                                              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("http.headers.Content-Encoding")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/content-language/index.md
+++ b/files/fr/web/http/headers/content-language/index.md
@@ -90,13 +90,11 @@ Content-Language: de, en
 
 ## Spécifications
 
-| Spécification                                                | Titre                                                          |
-| ------------------------------------------------------------ | -------------------------------------------------------------- |
-| {{RFC("7231", "Content-Language", "3.1.3.2")}} | Hypertext Transfer Protocol (HTTP/1.1): Sémantiques et Contenu |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("http.headers.Content-Language")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/content-length/index.md
+++ b/files/fr/web/http/headers/content-length/index.md
@@ -38,9 +38,7 @@ Content-Length: <longueur>
 
 ## Spécifications
 
-| Spécification                                            | Titre                                                              |
-| -------------------------------------------------------- | ------------------------------------------------------------------ |
-| {{RFC("7230", "Content-Length", "3.3.2")}} | Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 

--- a/files/fr/web/http/headers/content-security-policy/require-trusted-types-for/index.md
+++ b/files/fr/web/http/headers/content-security-policy/require-trusted-types-for/index.md
@@ -55,9 +55,7 @@ Une [prothèse d'émulation pour les Trusted Types](https://github.com/w3c/webap
 
 ## Spécifications
 
-| Spécification                                                             | Statut | Commentaire          |
-| ------------------------------------------------------------------------- | ------ | -------------------- |
-| [Trusted Types](https://w3c.github.io/webappsec-trusted-types/dist/spec/) | Draft  | Définition initiale. |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 

--- a/files/fr/web/http/headers/content-security-policy/trusted-types/index.md
+++ b/files/fr/web/http/headers/content-security-policy/trusted-types/index.md
@@ -59,9 +59,7 @@ Un [prothèse d'émulation pour les Trusted Types](https://github.com/w3c/webapp
 
 ## Spécifications
 
-| Spécification                                                             | Statut | Commentaire          |
-| ------------------------------------------------------------------------- | ------ | -------------------- |
-| [Trusted Types](https://w3c.github.io/webappsec-trusted-types/dist/spec/) | Draft  | Définition initiale. |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 

--- a/files/fr/web/http/headers/content-type/index.md
+++ b/files/fr/web/http/headers/content-type/index.md
@@ -86,12 +86,9 @@ Content-Type: text/plain
 
 ## Spécifications
 
-| Spécification                                                        | Titre                                                         |
-| -------------------------------------------------------------------- | ------------------------------------------------------------- |
-| {{RFC("7233", "Content-Type in multipart", "4.1")}} | Hypertext Transfer Protocol (HTTP/1.1): Range Requests        |
-| {{RFC("7231", "Content-Type", "3.1.1.5")}}             | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
-## Compatibilité selon les navigateurs
+## Compatibilité des navigateurs
 
 {{Compat}}
 

--- a/files/fr/web/http/headers/date/index.md
+++ b/files/fr/web/http/headers/date/index.md
@@ -54,13 +54,11 @@ Date: Wed, 21 Oct 2015 07:28:00 GMT
 
 ## Spécifications
 
-| Spécifications                               | Titre                                                          |
-| -------------------------------------------- | -------------------------------------------------------------- |
-| {{RFC("7231", "Date", "7.1.1.2")}} | Hypertext Transfer Protocol (HTTP/1.1) : Sémantique et contenu |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("http.headers.Date")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/etag/index.md
+++ b/files/fr/web/http/headers/etag/index.md
@@ -79,13 +79,11 @@ Le serveur comparera l'`ETag` du client (envoyé avec `If-None-Match`) à l'`ETa
 
 ## Spécifications
 
-| Spécification                            | Titre                                                        |
-| ---------------------------------------- | ------------------------------------------------------------ |
-| {{RFC("7232", "ETag", "2.3")}} | Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("http.headers.ETag")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/expires/index.md
+++ b/files/fr/web/http/headers/expires/index.md
@@ -50,13 +50,11 @@ Expires: Wed, 21 Oct 2015 07:28:00 GMT
 
 ## Spécifications
 
-| Specification                                | Title                                           |
-| -------------------------------------------- | ----------------------------------------------- |
-| {{RFC("7234", "Expires", "5.3")}} | Hypertext Transfer Protocol (HTTP/1.1): Caching |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("http.headers.Expires")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/host/index.md
+++ b/files/fr/web/http/headers/host/index.md
@@ -54,13 +54,11 @@ Host: developer.mozilla.org
 
 ## Spécifications
 
-| Spécification                            | Titre                                                              |
-| ---------------------------------------- | ------------------------------------------------------------------ |
-| {{RFC("7230", "Host", "5.4")}} | Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("http.headers.Host")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/if-modified-since/index.md
+++ b/files/fr/web/http/headers/if-modified-since/index.md
@@ -59,15 +59,13 @@ If-Modified-Since: <label-jour>, <jour> <mois> <année> <heure>:<minute>:<second
 If-Modified-Since: Wed, 21 Oct 2015 07:28:00 GMT
 ```
 
-## Specifications
+## Spécifications
 
-| Specification                                            | Titre                                                        |
-| -------------------------------------------------------- | ------------------------------------------------------------ |
-| {{RFC("7232", "If-Modified-Since", "3.3")}} | Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests |
+{{Specifications}}
 
-## Compatibility avec les navigateurs
+## Compatibilité des navigateurs
 
-{{Compat("http.headers.If-Modified-Since")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/if-none-match/index.md
+++ b/files/fr/web/http/headers/if-none-match/index.md
@@ -63,13 +63,11 @@ If-None-Match: *
 
 ## Spécifications
 
-| Spécification                                        | Title                                                        |
-| ---------------------------------------------------- | ------------------------------------------------------------ |
-| {{RFC("7232", "If-None-Match", "3.2")}} | Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests |
+{{Specifications}}
 
-## Compatibilité navigateur
+## Compatibilité des navigateurs
 
-{{Compat("http.headers.If-None-Match")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/last-modified/index.md
+++ b/files/fr/web/http/headers/last-modified/index.md
@@ -65,13 +65,11 @@ Last-Modified: Wed, 21 Oct 2015 07:28:00 GMT
 
 ## Spécifications
 
-| Spécification                                        | Titre                                                        |
-| ---------------------------------------------------- | ------------------------------------------------------------ |
-| {{RFC("7232", "Last-Modified", "2.2")}} | Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests |
+{{Specifications}}
 
-## Compatibilité navigateurs
+## Compatibilité des navigateurs
 
-{{Compat("http.headers.Last-Modified")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/location/index.md
+++ b/files/fr/web/http/headers/location/index.md
@@ -51,13 +51,11 @@ Location: /index.html
 
 ## Spécifications
 
-| Specification                                    | Title                                                         |
-| ------------------------------------------------ | ------------------------------------------------------------- |
-| {{RFC("7231", "Location", "7.1.2")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
-## Compatibilité navigateurs
+## Compatibilité des navigateurs
 
-{{Compat("http.headers.Location")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/referer/index.md
+++ b/files/fr/web/http/headers/referer/index.md
@@ -59,13 +59,11 @@ Referer: https://developer.mozilla.org/fr/docs/Web/JavaScript
 
 ## Spécifications
 
-| Spécification                                    | Titre                                                                                                                                 |
-| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
-| {{RFC("7231", "Referer", "5.5.2")}} | _Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content_ (Protocole de transfert hypertext (HTTP/1.1): Sémantique et contenu). |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("http.headers.Referer")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/referrer-policy/index.md
+++ b/files/fr/web/http/headers/referrer-policy/index.md
@@ -217,25 +217,11 @@ Ici, `no-referrer` ne sera utilisée que si `strict-origin-when-cross-origin` n'
 
 ## Spécifications
 
-| Spécification                                                                              | Statut                  |
-| ------------------------------------------------------------------------------------------ | ----------------------- |
-| [Referrer Policy](https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-header) | Brouillon de l'éditeur. |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("http.headers.Referrer-Policy")}}
-
-> **Note :**
->
-> - Version 53 et plus, Gecko offre la possibilité aux utilisateurs de définir leur valeur par défaut de `Referrer-Policy` dans `about:config`, l'option s'appelant `network.http.referer.userControlPolicy`.
-> - Version 59 et plus (Voir [#587523](https://bugzilla.mozilla.org/show_bug.cgi?id=587523)), il a été remplacé par `network.http.referer.defaultPolicy` et `network.http.referer.defaultPolicy.pbmode`.
->
-> Les valeurs permises sont :
->
-> - 0 — `no-referrer`
-> - 1 — `same-origin`
-> - 2 — `strict-origin-when-cross-origin`
-> - 3 — `no-referrer-when-downgrade` (par défaut)
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/server/index.md
+++ b/files/fr/web/http/headers/server/index.md
@@ -47,13 +47,11 @@ Server: Apache/2.4.1 (Unix)
 
 ## Spécifications
 
-| Specification                                | Title                                                         |
-| -------------------------------------------- | ------------------------------------------------------------- |
-| {{RFC("7231", "Server", "7.4.2")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
-## Navigateurs compatibles
+## Compatibilité des navigateurs
 
-{{Compat("http.headers.Server")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/set-cookie/index.md
+++ b/files/fr/web/http/headers/set-cookie/index.md
@@ -187,18 +187,11 @@ Set-Cookie: __Host-id=1; Secure; Path=/; domain=example.com
 
 ## Spécifications
 
-| Spécification                                                                                    | Titre                                                         |
-| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
-| {{RFC("6265", "Set-Cookie", "4.1")}}                                                 | HTTP State Management Mechanism                               |
-| [draft-ietf-httpbis-rfc6265bis-05](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-05) | Cookie Prefixes, Same-Site Cookies, and Strict Secure Cookies |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("http.headers.Set-Cookie", 5)}}
-
-## Note de compatibilité
-
-- À partir de Chrome 52 et Firefox 52, les sites non sécurisés (`http:`) ne peuvent plus définir des cookies avec la directive `Secure`.
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/set-cookie/samesite/index.md
+++ b/files/fr/web/http/headers/set-cookie/samesite/index.md
@@ -91,14 +91,11 @@ RewriteRule "^admin/(.*)\.html$" "admin/index.php?nav=$1 [NC,L,QSA,CO=RewriteRul
 
 ## Spécifications
 
-| Spécification                                                                                    | Titre                                                         |
-| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
-| {{RFC("6265", "Set-Cookie", "4.1")}}                                                 | HTTP State Management Mechanism                               |
-| [draft-ietf-httpbis-rfc6265bis-05](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-05) | Cookie Prefixes, Same-Site Cookies, and Strict Secure Cookies |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("http.headers.Set-Cookie", 5)}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/trailer/index.md
+++ b/files/fr/web/http/headers/trailer/index.md
@@ -66,12 +66,9 @@ Expires: Wed, 21 Oct 2015 07:28:00 GMT
 
 ## Spécifications
 
-| Specification                                                    | Title                                                              |
-| ---------------------------------------------------------------- | ------------------------------------------------------------------ |
-| {{RFC("7230", "Trailer", "4.4")}}                     | Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing |
-| {{RFC("7230", "Chunked trailer part", "4.1.2")}} | Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing |
+{{Specifications}}
 
-## Compatibilités
+## Compatibilité des navigateurs
 
 {{Compat}}
 

--- a/files/fr/web/http/headers/vary/index.md
+++ b/files/fr/web/http/headers/vary/index.md
@@ -55,17 +55,11 @@ Vary: User-Agent
 
 ## Spécifications
 
-| Spécification                                | Titre                                                         |
-| -------------------------------------------- | ------------------------------------------------------------- |
-| {{RFC("7231", "Vary", "7.1.4")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("http.headers.Vary")}}
-
-## Notes de compatibilité
-
-- [Vary with care – Vary header problems in IE6-9](https://blogs.msdn.microsoft.com/ieinternals/2009/06/17/vary-with-care/)
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/headers/www-authenticate/index.md
+++ b/files/fr/web/http/headers/www-authenticate/index.md
@@ -51,10 +51,11 @@ Voir aussi [HTTP authentication](/fr/docs/Web/HTTP/Authentication) pour des exem
 
 ## Spécifications
 
-| Spécification                                            | Titre                                  |
-| -------------------------------------------------------- | -------------------------------------- |
-| {{RFC("7235", "WWW-Authenticate", "4.1")}} | HTTP/1.1: Authentication               |
-| {{RFC("7617")}}                                     | The 'Basic' HTTP Authentication Scheme |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/methods/connect/index.md
+++ b/files/fr/web/http/methods/connect/index.md
@@ -70,13 +70,11 @@ Proxy-Authorization: basic aGVsbG86d29ybGQ=
 
 ## Spécifications
 
-| Spécification                                    | Titre                                                         |
-| ------------------------------------------------ | ------------------------------------------------------------- |
-| {{RFC("7231", "CONNECT", "4.3.6")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("http/methods", "CONNECT")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/methods/delete/index.md
+++ b/files/fr/web/http/methods/delete/index.md
@@ -84,9 +84,11 @@ Date: Wed, 21 Oct 2015 07:28:00 GMT
 
 ## Spécifications
 
-| Spécification                                | Titre                                                         |
-| -------------------------------------------- | ------------------------------------------------------------- |
-| {{RFC("7231", "DELETE", "4.3.5")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/methods/get/index.md
+++ b/files/fr/web/http/methods/get/index.md
@@ -52,13 +52,11 @@ GET /index.html
 
 ## Spécifications
 
-| Spécification                            | Titre                                                         |
-| ---------------------------------------- | ------------------------------------------------------------- |
-| {{RFC("7231", "GET", "4.3.1")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("http/methods", "GET")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/methods/head/index.md
+++ b/files/fr/web/http/methods/head/index.md
@@ -60,13 +60,11 @@ HEAD /index.html
 
 ## Spécifications
 
-| Spécification                                | Titre                                                         |
-| -------------------------------------------- | ------------------------------------------------------------- |
-| {{RFC("7231", "HEAD", "4.3.2")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("http/methods", "HEAD")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/methods/index.md
+++ b/files/fr/web/http/methods/index.md
@@ -34,10 +34,7 @@ HTTP définit un ensemble de **méthodes de requête** qui indiquent l'action qu
 
 ## Spécifications
 
-| Spécification                                        | Titre                                                         | Commentaires                                                           |
-| ---------------------------------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| {{RFC("7231", "Request methods", "4")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content | Définition de GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS et TRACE. |
-| {{RFC("5789", "Patch method", "2")}}     | PATCH Method for HTTP                                         | Définition de PATCH.                                                   |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 

--- a/files/fr/web/http/methods/options/index.md
+++ b/files/fr/web/http/methods/options/index.md
@@ -111,13 +111,11 @@ Content-Type: text/plain
 
 ## Spécifications
 
-| Specification                                    | Title                                                         |
-| ------------------------------------------------ | ------------------------------------------------------------- |
-| {{RFC("7231", "OPTIONS", "4.3.7")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("http.methods.OPTIONS")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/methods/patch/index.md
+++ b/files/fr/web/http/methods/patch/index.md
@@ -80,9 +80,11 @@ ETag: "e0023aa4f"
 
 ## Spécifications
 
-| Spécification                    | Titre                                           |
-| -------------------------------- | ----------------------------------------------- |
-| {{RFC("5789", "PATCH")}} | Méthode PATCH pour HTTP (PATCH Method for HTTP) |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/methods/post/index.md
+++ b/files/fr/web/http/methods/post/index.md
@@ -100,13 +100,11 @@ value2
 
 ## Spécifications
 
-| Spécification                                | Titre                                                         |
-| -------------------------------------------- | ------------------------------------------------------------- |
-| {{RFC("7231", "POST", "4.3.3")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("http.methods.POST")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/methods/trace/index.md
+++ b/files/fr/web/http/methods/trace/index.md
@@ -50,15 +50,13 @@ Le destinataire final de la demande doit renvoyer au client le message reçu, à
 TRACE /index.html
 ```
 
-## Specifications
+## Spécifications
 
-| Specification                                | Title                                                         |
-| -------------------------------------------- | ------------------------------------------------------------- |
-| {{RFC("7231", "TRACE", "4.3.8")}} | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("http.methods.TRACE")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/status/101/index.md
+++ b/files/fr/web/http/status/101/index.md
@@ -28,9 +28,11 @@ Connection: Upgrade
 
 ## Spécifications
 
-| Spécification                                                        | Titre                                                         |
-| -------------------------------------------------------------------- | ------------------------------------------------------------- |
-| [RFC 7231, section 6.2.2: 101 Switching Protocol](https://datatracker.ietf.org/doc/html/rfc7231#section-6.2.2) | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/status/103/index.md
+++ b/files/fr/web/http/status/103/index.md
@@ -17,9 +17,7 @@ Le code de statut de réponse **`103 Early Hints`** est principalement utilisé 
 
 ## Spécifications
 
-| Spécification                                | État     | Commentaire      |
-| -------------------------------------------- | -------- | ---------------- |
-| [RFC 8297: 103 Early Hints](https://datatracker.ietf.org/doc/html/rfc8297) | IETF RFC | Première version |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 

--- a/files/fr/web/http/status/202/index.md
+++ b/files/fr/web/http/status/202/index.md
@@ -18,9 +18,11 @@ Cette réponse est sans suite (<i lang="en">non-committal</i>)&nbsp;: HTTP ne re
 
 ## Spécifications
 
-| Spécification                                            | Titre                                                         |
-| -------------------------------------------------------- | ------------------------------------------------------------- |
-| [RFC 7231, section 6.3.3: 202 Accepted](https://datatracker.ietf.org/doc/html/rfc7231#section-6.3.3) | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/status/203/index.md
+++ b/files/fr/web/http/status/203/index.md
@@ -18,9 +18,11 @@ La réponse 203 est similaire au code d'en-tête [`214` (Transformation Applied)
 
 ## Spécifications
 
-| Spécification                                                                        | Titre                                                         |
-| ------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
-| [RFC 7231, section 6.3.4: 203 Non-Authoritative Information](https://datatracker.ietf.org/doc/html/rfc7231#section-6.3.4) | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/status/205/index.md
+++ b/files/fr/web/http/status/205/index.md
@@ -16,13 +16,11 @@ Le code de statut de réponse HTTP **`205 Reset Content`** indique au client de 
 
 ## Spécifications
 
-| Spécification                                                | Titre                                                         |
-| ------------------------------------------------------------ | ------------------------------------------------------------- |
-| [RFC 7231, section 6.3.6: 205 Reset Content](https://datatracker.ietf.org/doc/html/rfc7231#section-6.3.6) | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
 
-## Notes de compatibilité
+## Compatibilité des navigateurs
 
-Le comportement des navigateurs varie selon que cette réponse inclut incorrectement un corps pour les connexions persistantes. Voir [`204 No Content`](/fr/docs/Web/HTTP/Status/204) pour plus de détails.
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/status/300/index.md
+++ b/files/fr/web/http/status/300/index.md
@@ -22,9 +22,11 @@ Consultez [cette page de w3.org à propos des réponses à choix multiples](http
 
 ## Spécifications
 
-| Spécification                                                    | Titre                                                         |
-| ---------------------------------------------------------------- | ------------------------------------------------------------- |
-| [RFC 7231, section 6.4.1: 300 Multiple Choices](https://datatracker.ietf.org/doc/html/rfc7231#section-6.4.1) | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/status/400/index.md
+++ b/files/fr/web/http/status/400/index.md
@@ -18,9 +18,11 @@ Le code de statut de réponse HTTP **`400 Bad Request`** indique que le serveur 
 
 ## Spécifications
 
-| Spécification                                                | Titre                                                         |
-| ------------------------------------------------------------ | ------------------------------------------------------------- |
-| [RFC 7231, section 6.5.1: 400 Bad Request](https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1) | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/status/402/index.md
+++ b/files/fr/web/http/status/402/index.md
@@ -26,9 +26,7 @@ Date: Wed, 21 Oct 2015 07:28:00 GMT
 
 ## Spécifications
 
-| Spécification                                                    | Titre                           |
-| ---------------------------------------------------------------- | ------------------------------- |
-| [RFC 7231, section 6.5.2: 402 Payment Required](https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.2) | HTTP/1.1: Semantics and Content |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 

--- a/files/fr/web/http/status/405/index.md
+++ b/files/fr/web/http/status/405/index.md
@@ -18,9 +18,11 @@ Le serveur doit générer un en-tête **`Allow`** en cas de réponse 405, conten
 
 ## Spécifications
 
-| Spécification                                                        | Titre                                                         |
-| -------------------------------------------------------------------- | ------------------------------------------------------------- |
-| [RFC 7231, section 6.5.5: 405 Method Not Allowed](https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.5) | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/status/408/index.md
+++ b/files/fr/web/http/status/408/index.md
@@ -22,9 +22,11 @@ Cette réponse est plus utilisée depuis que certains navigateurs, comme Chrome,
 
 ## Spécifications
 
-| Spécification                                                    | Titre                                                         |
-| ---------------------------------------------------------------- | ------------------------------------------------------------- |
-| [RFC 7231, section 6.5.7: 408 Request Timeout](https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.7) | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/status/411/index.md
+++ b/files/fr/web/http/status/411/index.md
@@ -18,9 +18,11 @@ Le code de réponse d'erreur HTTP **`411 Length Required`** indique que le serve
 
 ## Spécifications
 
-| Spécification                                                    | Titre                                                         |
-| ---------------------------------------------------------------- | ------------------------------------------------------------- |
-| [RFC 7231, section 6.5.10: 411 Length Required](https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.10) | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/status/413/index.md
+++ b/files/fr/web/http/status/413/index.md
@@ -16,9 +16,11 @@ Le code de statut de réponse **`413 Payload Too Large`** indique que la taille 
 
 ## Spécifications
 
-| Spécification                                                        | Titre                                                         |
-| -------------------------------------------------------------------- | ------------------------------------------------------------- |
-| [RFC 7231, section 6.5.11: 413 Payload Too Large](https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.11) | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/status/414/index.md
+++ b/files/fr/web/http/status/414/index.md
@@ -22,9 +22,11 @@ Il existe quelques rares cas de figure pour lesquels cela peut se produire&nbsp;
 
 ## Spécifications
 
-| Spécification                                                | Titre                                                         |
-| ------------------------------------------------------------ | ------------------------------------------------------------- |
-| [RFC 7231, section 6.5.12: 414 URI Too Long](https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.12) | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/status/415/index.md
+++ b/files/fr/web/http/status/415/index.md
@@ -18,9 +18,11 @@ Le problème de format peut être causé par les valeurs des en-têtes [`Content
 
 ## Spécifications
 
-| Spécification                                                                | Titre                                                         |
-| ---------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| [RFC 7231, section 6.5.13: 415 Unsupported Media Type](https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.13) | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/status/417/index.md
+++ b/files/fr/web/http/status/417/index.md
@@ -18,9 +18,11 @@ Voir la page sur l'en-tête [`Expect`](/fr/docs/Web/HTTP/Headers/Expect) pour pl
 
 ## Spécifications
 
-| Spécification                                                        | Titre                                                         |
-| -------------------------------------------------------------------- | ------------------------------------------------------------- |
-| [RFC 7231, section 6.5.14: 417 Expectation Failed](https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.14) | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/status/418/index.md
+++ b/files/fr/web/http/status/418/index.md
@@ -19,10 +19,7 @@ Certains sites web utilisent ce code de réponse pour les requêtes qu'ils ne so
 
 ## Spécifications
 
-| Spécification                                                | Titre                                                                                             |
-| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| [RFC 2324, section 2.3.2: 418 I'm a teapot](https://datatracker.ietf.org/doc/html/rfc2324#section-2.3.2) | Hyper Text Coffee Pot Control Protocol (HTCPCP/1.0): Semantics and Content                        |
-| [RFC 7168, section 2.3.3: 418 I'm a teapot](https://datatracker.ietf.org/doc/html/rfc7168#section-2.3.3) | The Hyper Text Coffee Pot Control Protocol for Tea Efflux Appliances (HTCPCP-TEA): Response Codes |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 

--- a/files/fr/web/http/status/422/index.md
+++ b/files/fr/web/http/status/422/index.md
@@ -18,6 +18,8 @@ Le code de statut de réponse HTTP **`422 Unprocessable Entity`** indique que le
 
 ## Spécifications
 
-| Spécification                                                        | Titre (en anglais)                                                    |
-| -------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| [RFC 4918, section 11.2: 422 Unprocessable Entity](https://datatracker.ietf.org/doc/html/rfc4918#section-11.2) | HTTP Extensions for Web Distributed Authoring and Versioning (WebDAV) |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}

--- a/files/fr/web/http/status/426/index.md
+++ b/files/fr/web/http/status/426/index.md
@@ -30,9 +30,11 @@ This service requires use of the HTTP/3.0 protocol
 
 ## Spécifications
 
-| Spécification                                                        | Titre                                                         |
-| -------------------------------------------------------------------- | ------------------------------------------------------------- |
-| [RFC 7231, section 6.5.15: 426 Upgrade Required](https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.15) | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/status/428/index.md
+++ b/files/fr/web/http/status/428/index.md
@@ -20,9 +20,11 @@ Lorsqu'un en-tête de précondition **ne correspond pas** à l'état du serveur,
 
 ## Spécifications
 
-| Spécification                                                        | Titre                        |
-| -------------------------------------------------------------------- | ---------------------------- |
-| [RFC 6585, section 3: 428 Precondition Required](https://datatracker.ietf.org/doc/html/rfc6585#section-3) | Additional HTTP Status Codes |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/status/429/index.md
+++ b/files/fr/web/http/status/429/index.md
@@ -26,9 +26,11 @@ Retry-After: 3600
 
 ## Spécifications
 
-| Spécification                                                | Titre                        |
-| ------------------------------------------------------------ | ---------------------------- |
-| [RFC 6585, section 4: 429 Too Many Requests](https://datatracker.ietf.org/doc/html/rfc6585#section-4) | Additional HTTP Status Codes |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/status/431/index.md
+++ b/files/fr/web/http/status/431/index.md
@@ -23,9 +23,11 @@ Les serveurs produiront généralement ce statut si&nbsp;:
 
 ## Spécifications
 
-| Spécification                                                                    | Titre                        |
-| -------------------------------------------------------------------------------- | ---------------------------- |
-| [RFC 6585, section 5: 431 Request Header Fields Too Large](https://datatracker.ietf.org/doc/html/rfc6585#section-5) | Additional HTTP Status Codes |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/status/505/index.md
+++ b/files/fr/web/http/status/505/index.md
@@ -16,9 +16,11 @@ Le code de réponse HTTP d'erreur serveur **`505 HTTP Version Not Supported`** i
 
 ## Spécifications
 
-| Spécification                                                                    | Titre                                                         |
-| -------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| [RFC 7231, section 6.6.6: 505 HTTP Version Not Supported](https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.6) | Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/status/506/index.md
+++ b/files/fr/web/http/status/506/index.md
@@ -18,6 +18,8 @@ Le statut **`Variant Also Negotiates`** indique une erreur de configuration inte
 
 ## Spécifications
 
-| Spécification                                                            | Titre                                   |
-| ------------------------------------------------------------------------ | --------------------------------------- |
-| [RFC 2295, section 8.1: 506 Variant Also Negotiates](https://datatracker.ietf.org/doc/html/rfc2295#section-8.1) | Transparent Content Negotiation in HTTP |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}

--- a/files/fr/web/http/status/507/index.md
+++ b/files/fr/web/http/status/507/index.md
@@ -18,6 +18,8 @@ Il indique que la méthode ne peut pas être traitée car le serveur ne peut pas
 
 ## Spécifications
 
-| Spécification                                                        | Titre                                    |
-| -------------------------------------------------------------------- | ---------------------------------------- |
-| [RFC 4918, section 11.5: 507 Insufficient Storage](https://datatracker.ietf.org/doc/html/rfc4918#section-11.5) | Web Distributed Authoring and Versioning |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}

--- a/files/fr/web/http/status/508/index.md
+++ b/files/fr/web/http/status/508/index.md
@@ -18,6 +18,8 @@ Il indique que le serveur termine une opération, car il rencontre une boucle in
 
 ## Spécifications
 
-| Spécification                                                | Titre                                    |
-| ------------------------------------------------------------ | ---------------------------------------- |
-| [RFC 5842, section 7.2: 508 Loop Detected](https://datatracker.ietf.org/doc/html/rfc5842#section-7.2) | Web Distributed Authoring and Versioning |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}

--- a/files/fr/web/http/status/510/index.md
+++ b/files/fr/web/http/status/510/index.md
@@ -18,6 +18,8 @@ Dans cette spécification, un client peut envoyer une demande qui contient une d
 
 ## Spécifications
 
-| Spécification                                            | Titre                                                          |
-| -------------------------------------------------------- | -------------------------------------------------------------- |
-| [RFC 2774, section 7: 510 Not Extended](https://datatracker.ietf.org/doc/html/rfc2774#section-7) | Cadre pour les extensions HTTP (<i lang="en">An HTTP Extension Framework</i>) |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}

--- a/files/fr/web/http/status/511/index.md
+++ b/files/fr/web/http/status/511/index.md
@@ -20,9 +20,11 @@ Les responsables des réseaux demandent parfois de s'authentifier, d'accepter de
 
 ## Spécifications
 
-| Spécification                                                                    | Titre                        |
-| -------------------------------------------------------------------------------- | ---------------------------- |
-| [RFC 6585, section 6: 511 Network Authentication Required](https://datatracker.ietf.org/doc/html/rfc6585#section-6) | Additional HTTP Status Codes |
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/http/status/index.md
+++ b/files/fr/web/http/status/index.md
@@ -163,7 +163,7 @@ Les codes de statut de réponse HTTP indiquent si une requête [HTTP](/fr/docs/W
 
 ## Compatibilité des navigateurs
 
-{{Compat("http.status")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/guide/modules/index.md
+++ b/files/fr/web/javascript/guide/modules/index.md
@@ -22,13 +22,7 @@ Cette implémentation permettra aux navigateurs d'optimiser le chargement des mo
 
 L'utilisation des modules natifs JavaScript repose sur les instructions [`import`](/fr/docs/Web/JavaScript/Reference/Statements/import) et [`export`](/fr/docs/Web/JavaScript/Reference/Statements/export) dont vous pouvez voir l'état de la compatibilité ici&nbsp;:
 
-### `import`
-
-{{Compat("javascript.statements.import")}}
-
-### `export`
-
-{{Compat("javascript.statements.export")}}
+{{Compat}}
 
 ## Commençons par un exemple
 

--- a/files/fr/web/javascript/reference/global_objects/array/flatmap/index.md
+++ b/files/fr/web/javascript/reference/global_objects/array/flatmap/index.md
@@ -98,13 +98,11 @@ arr.reduce((acc, x) => acc.concat([x, x * 2]), []);
 
 ## Spécifications
 
-| Spécification                                                                                              | État     | Commentaires         |
-| ---------------------------------------------------------------------------------------------------------- | -------- | -------------------- |
-| [ECMAScript 2019](https://www.ecma-international.org/ecma-262/10.0/index.html#sec-array.prototype.flatmap) | Finalisé | Proposition initiale |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Array.flatMap")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/bigint/asintn/index.md
+++ b/files/fr/web/javascript/reference/global_objects/bigint/asintn/index.md
@@ -50,13 +50,11 @@ BigInt.asIntN(64, max + 1n);
 
 ## Spécifications
 
-| Spécification                                                                | État                     |
-| ---------------------------------------------------------------------------- | ------------------------ |
-| [BigInt proposal](https://tc39.github.io/proposal-bigint/#sec-bigint.asintn) | Proposition de niveau 3. |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.BigInt.asIntN")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/bigint/asuintn/index.md
+++ b/files/fr/web/javascript/reference/global_objects/bigint/asuintn/index.md
@@ -51,13 +51,11 @@ BigInt.asUintN(64, max + 1n);
 
 ## Spécifications
 
-| Spécification                                                                         | État                    |
-| ------------------------------------------------------------------------------------- | ----------------------- |
-| [Proposition pour BigInt](https://tc39.github.io/proposal-bigint/#sec-bigint.asuintn) | Proposition de niveau 3 |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.BigInt.asUintN")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/bigint/tolocalestring/index.md
+++ b/files/fr/web/javascript/reference/global_objects/bigint/tolocalestring/index.md
@@ -109,13 +109,11 @@ Lorsqu'on souhaite mettre en forme une grande quantité de nombres, mieux vaudra
 
 ## Spécifications
 
-| Spécification                                                            | État                     |
-| ------------------------------------------------------------------------ | ------------------------ |
-| [`BigInt`](https://tc39.es/ecma402/#sup-bigint.prototype.tolocalestring) | Proposition de niveau 3. |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.BigInt.toLocaleString")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/bigint/tostring/index.md
+++ b/files/fr/web/javascript/reference/global_objects/bigint/tostring/index.md
@@ -70,13 +70,11 @@ BigInt(-0).toString(); // '0'
 
 ## Spécifications
 
-| Spécification                                                                                      | État                    |
-| -------------------------------------------------------------------------------------------------- | ----------------------- |
-| [Proposition pour `BigInt`](https://tc39.github.io/proposal-bigint/#sec-bigint.prototype.tostring) | Proposition de niveau 3 |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.BigInt.toString")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/bigint/valueof/index.md
+++ b/files/fr/web/javascript/reference/global_objects/bigint/valueof/index.md
@@ -39,13 +39,11 @@ typeof Object(1n).valueOf(); // bigint
 
 ## Spécifications
 
-| Spécification                                                                                     | État                    |
-| ------------------------------------------------------------------------------------------------- | ----------------------- |
-| [Proposition pour `BigInt`](https://tc39.github.io/proposal-bigint/#sec-bigint.prototype.valueof) | Proposition de niveau 3 |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.BigInt.valueOf")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/bigint64array/index.md
+++ b/files/fr/web/javascript/reference/global_objects/bigint64array/index.md
@@ -151,13 +151,11 @@ var BigInt64 = new BigInt64Array(iterable);
 
 ## Spécifications
 
-| Spécification                                                                                     | État                    | Commentaires |
-| ------------------------------------------------------------------------------------------------- | ----------------------- | ------------ |
-| [Proposition pour `BigInt`](https://tc39.github.io/proposal-bigint/#sec-typedarrays-and-dataview) | Proposition de niveau 3 |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.BigInt64Array")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/biguint64array/index.md
+++ b/files/fr/web/javascript/reference/global_objects/biguint64array/index.md
@@ -151,13 +151,11 @@ var BigInt64 = new BigUint64Array(iterable);
 
 ## Spécifications
 
-| Spécification                                                                                     | État                    | Commentaires |
-| ------------------------------------------------------------------------------------------------- | ----------------------- | ------------ |
-| [Proposition pour `BigInt`](https://tc39.github.io/proposal-bigint/#sec-typedarrays-and-dataview) | Proposition de niveau 3 |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.BigUint64Array")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/dataview/getbigint64/index.md
+++ b/files/fr/web/javascript/reference/global_objects/dataview/getbigint64/index.md
@@ -57,13 +57,11 @@ dataview.getBigInt64(0); // 0n
 
 ## Spécifications
 
-| Spécification                                                                                                                     | État | Commentaires |
-| --------------------------------------------------------------------------------------------------------------------------------- | ---- | ------------ |
-| [Proposition pour `DataView.prototype.getBigInt64()`](https://tc39.github.io/proposal-bigint/#sec-dataview.prototype.getbigint64) |      |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.DataView.getBigInt64")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/dataview/getbiguint64/index.md
+++ b/files/fr/web/javascript/reference/global_objects/dataview/getbiguint64/index.md
@@ -57,13 +57,11 @@ dataview.getBigUint64(0); // 0n
 
 ## Spécifications
 
-| Spécification                                                                                                                | État | Commentaires |
-| ---------------------------------------------------------------------------------------------------------------------------- | ---- | ------------ |
-| [Proposition pour `DataView.prototype.getBigUint64()`](https://tc39.es/proposal-bigint/#sec-dataview.prototype.getbiguint64) |      |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.DataView.getBigUint64")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/dataview/setbigint64/index.md
+++ b/files/fr/web/javascript/reference/global_objects/dataview/setbigint64/index.md
@@ -55,13 +55,11 @@ dataview.getInt32(0); // 3n
 
 ## Spécifications
 
-| Spécification                                                                                                                     | État |
-| --------------------------------------------------------------------------------------------------------------------------------- | ---- |
-| [Proposition pour `DataView.prototype.setBigInt64()`](https://tc39.github.io/proposal-bigint/#sec-dataview.prototype.setbigint64) |      |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.DataView.setBigInt64")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/dataview/setbiguint64/index.md
+++ b/files/fr/web/javascript/reference/global_objects/dataview/setbiguint64/index.md
@@ -56,13 +56,11 @@ dataview.getInt32(0); // 3n
 
 ## Spécifications
 
-| Spécification                                                                                                                       | État |
-| ----------------------------------------------------------------------------------------------------------------------------------- | ---- |
-| [Proposition pour `DataView.prototype.setBigUint64()`](https://tc39.github.io/proposal-bigint/#sec-dataview.prototype.setBigUint64) |      |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.DataView.setBigUint64")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/error/columnnumber/index.md
+++ b/files/fr/web/javascript/reference/global_objects/error/columnnumber/index.md
@@ -31,7 +31,7 @@ Ne fait partie d'aucune spécification. Non standard.
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Error.columnNumber")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/error/filename/index.md
+++ b/files/fr/web/javascript/reference/global_objects/error/filename/index.md
@@ -36,7 +36,7 @@ Ne fait partie d'aucune spécification. Non standard.
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Error.fileName")}}
+{{Compat}}
 
 ## Voir aussi
 


### PR DESCRIPTION
This PR updates some of the browser compatibility data and specification sections for the French locale. Part of work for #11594.

Note: this may also include other minor updates, such as removal of old sections or other small bits of cleanup.
