### PR TITLE
fr: Update browser compat/spec sections (part 9)

### DIFF
--- a/files/fr/web/javascript/reference/global_objects/error/linenumber/index.md
+++ b/files/fr/web/javascript/reference/global_objects/error/linenumber/index.md
@@ -42,7 +42,7 @@ Ne fait partie d'aucune spécification. Non standard.
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Error.lineNumber")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/error/stack/index.md
+++ b/files/fr/web/javascript/reference/global_objects/error/stack/index.md
@@ -117,7 +117,7 @@ Ne fait partie d'aucune spécification. Non-standard.
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Error.stack")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/function/caller/index.md
+++ b/files/fr/web/javascript/reference/global_objects/function/caller/index.md
@@ -79,7 +79,7 @@ Ne fait partie d'aucune spécification. Implémentée avec JavaScript 1.5.
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Function.caller")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/function/displayname/index.md
+++ b/files/fr/web/javascript/reference/global_objects/function/displayname/index.md
@@ -82,4 +82,4 @@ N'appartient à aucune spécification.
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Function.displayName")}}
+{{Compat}}

--- a/files/fr/web/javascript/reference/global_objects/globalthis/index.md
+++ b/files/fr/web/javascript/reference/global_objects/globalthis/index.md
@@ -67,10 +67,8 @@ if (typeof globalThis.setTimeout !== 'function') {
 
 ## Spécifications
 
-| Spécification                                                                                                             | État                                | Commentaires |
-| ------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ------------ |
-| [Proposition pour `globalThis`](https://tc39.github.io/proposal-global/#sec-other-properties-of-the-global-object-global) | Proposition de niveau 3 (_stage 3_) |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.globalThis")}}
+{{Compat}}

--- a/files/fr/web/javascript/reference/global_objects/intl/datetimeformat/formatrangetoparts/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/datetimeformat/formatrangetoparts/index.md
@@ -57,10 +57,8 @@ fmt.formatRangeToParts(date1, date2);
 
 ## Spécifications
 
-| Specification                                                                                                                                        | Status  | Comment |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------- |
-| [Intl.DateTimeFormat.prototype.formatRange](https://rawgit.com/fabalbon/proposal-intl-DateTimeFormat-formatRange/master/out/#datetimeformat-objects) | Stage 3 |         |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.DateTimeFormat.formatRangeToParts")}}
+{{Compat}}

--- a/files/fr/web/javascript/reference/global_objects/intl/listformat/format/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/listformat/format/index.md
@@ -40,13 +40,11 @@ Une chaîne de caractères représentant les éléments de la liste et mise en f
 
 ## Spécifications
 
-| Spécification                                                                                                                                 | État                    | Commentaires |
-| --------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------------ |
-| [Proposition pour `Intl.ListFormat.prototype.format`](https://tc39.github.io/proposal-intl-list-format/#sec-Intl.ListFormat.prototype.format) | Proposition de niveau 3 |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.ListFormat.format")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/intl/listformat/formattoparts/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/listformat/formattoparts/index.md
@@ -58,13 +58,11 @@ console.table(myListFormat.formatToParts(fruits));
 
 ## Spécifications
 
-| Spécification                                                                                                                                       | État    | Commentaires |
-| --------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------------ |
-| [`Intl.ListFormat.prototype.formatToParts` proposal](https://tc39.github.io/proposal-intl-list-format/#sec-Intl.ListFormat.prototype.formatToParts) | Stage 3 |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.ListFormat.formatToParts")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/intl/listformat/resolvedoptions/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/listformat/resolvedoptions/index.md
@@ -51,13 +51,11 @@ console.log(usedOptions.type);   // "conjunction" (la valeur par défaut)
 
 ## Spécifications
 
-| Spécification                                                                                                                                                     | État                    | Commentaires |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------------ |
-| [Proposition pour `Intl.ListFormat.prototype.resolvedOptions()`](https://tc39.github.io/proposal-intl-list-format/#sec-Intl.ListFormat.prototype.resolvedOptions) | Proposition de niveau 3 |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.ListFormat.resolvedOptions")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/intl/listformat/supportedlocalesof/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/listformat/supportedlocalesof/index.md
@@ -56,13 +56,11 @@ console.log(Intl.ListFormat.supportedLocalesOf(locales, options).join(', '));
 
 ## Spécifications
 
-| Spécification                                                                                                                                     | État                    | Commentaires |
-| ------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------------ |
-| [Proposition pour `Intl.ListFormat.supportedLocalesOf`](https://tc39.github.io/proposal-intl-list-format/#sec-Intl.ListFormat.supportedLocalesOf) | Proposition de niveau 3 |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.ListFormat.supportedLocalesOf")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/intl/locale/basename/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/locale/basename/index.md
@@ -55,13 +55,11 @@ console.log(dutch.baseName); // Prints out "nl-Latn-NL"
 
 ## Spécifications
 
-| Spécification                                                                                                                        | État                    | Commentaires |
-| ------------------------------------------------------------------------------------------------------------------------------------ | ----------------------- | ------------ |
-| [Proposition pour `Intl.Locale.prototype.baseName`](https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.baseName) | Proposition de niveau 3 |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.Locale.baseName")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/intl/locale/calendar/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/locale/calendar/index.md
@@ -156,13 +156,11 @@ console.log(frBuddhist.calendar); // affiche "buddhist" dans la console
 
 ## Spécifications
 
-| Spécification                                                                                                                        | État                    | Commentaires |
-| ------------------------------------------------------------------------------------------------------------------------------------ | ----------------------- | ------------ |
-| [Proposition pour `Intl.Locale.prototype.calendar`](https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.calendar) | Proposition de niveau 3 |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.Locale.calendar")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/intl/locale/casefirst/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/locale/casefirst/index.md
@@ -53,13 +53,11 @@ console.log(us12hour.caseFirst); // affichera "lower" dans la console.
 
 ## Spécifications
 
-| Spécification                                                                                                      | État                    | Commentaires |
-| ------------------------------------------------------------------------------------------------------------------ | ----------------------- | ------------ |
-| [Proposition pour `Intl.Locale`](https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.caseFirst) | Proposition de niveau 3 |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.Locale.caseFirst")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/intl/locale/collation/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/locale/collation/index.md
@@ -171,13 +171,11 @@ console.log(configColl.collation); // Affichera "emoji" dans la console
 
 ## Spécifications
 
-| Spécification                                                                                                                          | État                    | Commentaires |
-| -------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------------ |
-| [Proposition pour `Intl.Locale.prototype.collation`](https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.collation) | Proposition de niveau 3 |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.Locale.collation")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/intl/locale/hourcycle/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/locale/hourcycle/index.md
@@ -49,13 +49,11 @@ console.log(us12hour.hourCycle); // Affichera "h12" dans la console
 
 ## Spécifications
 
-| Spécification                                                                                                      | État                    | Commentaires |
-| ------------------------------------------------------------------------------------------------------------------ | ----------------------- | ------------ |
-| [Proposition pour `Intl.Locale`](https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.hourCycle) | Proposition de niveau 3 |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.Locale.hourCycle")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/intl/locale/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/locale/index.md
@@ -43,13 +43,11 @@ L'objet `Intl.Locale` possède les propriétés et méthodes suivantes.
 
 ## Spécifications
 
-| Spécification                                                                                 | État                    | Commentaires |
-| --------------------------------------------------------------------------------------------- | ----------------------- | ------------ |
-| [Proposition pour `Intl.Locale`](https://tc39.github.io/proposal-intl-locale/#locale-objects) | Proposition de niveau 3 |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.Locale")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/intl/locale/language/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/locale/language/index.md
@@ -44,13 +44,11 @@ console.log(langObj.language); // Affichera "es" dans la console
 
 ## Spécifications
 
-| Spécification                                                                                                                        | État                    | Commentaires |
-| ------------------------------------------------------------------------------------------------------------------------------------ | ----------------------- | ------------ |
-| [Proposition pour `Intl.Locale.prototype.language`](https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.language) | Proposition de niveau 3 |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.Locale.language")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/intl/locale/maximize/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/locale/maximize/index.md
@@ -50,13 +50,11 @@ console.log(myLocMaximized.toString());
 
 ## Spécifications
 
-| Spécification                                                                                                                          | État | Commentaires |
-| -------------------------------------------------------------------------------------------------------------------------------------- | ---- | ------------ |
-| [Proposition pour `Intl.Locale.prototype.maximize()`](https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.maximize) |      |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.Locale.maximize")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/intl/locale/minimize/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/locale/minimize/index.md
@@ -53,13 +53,11 @@ console.log(maLocMinimized.toString());
 
 ## Spécifications
 
-| Spécification                                                                                                                          | État | Commentaires |
-| -------------------------------------------------------------------------------------------------------------------------------------- | ---- | ------------ |
-| [Proposition pour `Intl.Locale.prototype.minimize()`](https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.minimize) |      |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.Locale.minimize")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/intl/locale/numberingsystem/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/locale/numberingsystem/index.md
@@ -135,13 +135,11 @@ console.log(us12hour.numberingSystem);
 
 ## Spécifications
 
-| Spécification                                                                                                            | État                    | Commentaires |
-| ------------------------------------------------------------------------------------------------------------------------ | ----------------------- | ------------ |
-| [Proposition pour `Intl.Locale`](https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.numberingSystem) | Proposition de niveau 3 |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.Locale.numberingSystem")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/intl/locale/numeric/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/locale/numeric/index.md
@@ -44,13 +44,11 @@ console.log(us12hour.numeric);
 
 ## Spécifications
 
-| Spécification                                                                                                    | État                    | Commentaires |
-| ---------------------------------------------------------------------------------------------------------------- | ----------------------- | ------------ |
-| [Proposition pour `Intl.Locale`](https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.numeric) | Proposition de niveau 3 |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.Locale.numeric")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/intl/locale/region/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/locale/region/index.md
@@ -46,13 +46,11 @@ console.log(regionObj.region);
 
 ## Spécifications
 
-| Spécification                                                                                                                    | État                    | Commentaires |
-| -------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------------ |
-| [Proposition pour `Intl.Locale.prototype.region`](https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.region) | Proposition de niveau 3 |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.Locale.region")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/intl/locale/script/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/locale/script/index.md
@@ -43,13 +43,11 @@ console.log(scriptObj.script); // Affichera "Latn" dans la console
 
 ## Spécifications
 
-| Spécification                                                                                                                    | État                    | Commentaires |
-| -------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------------ |
-| [Proposition pour `Intl.Locale.prototype.script`](https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.script) | Proposition de niveau 3 |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.Locale.script")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/intl/locale/tostring/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/locale/tostring/index.md
@@ -41,13 +41,11 @@ console.log(maLocale.toString()); // Affiche "fr-Latn-FR-u-ca-gregory-hc-h24"
 
 ## Spécifications
 
-| Spécification                                                                                                                          | État                    | Commentaires |
-| -------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------------ |
-| [Proposition pour `Intl.Locale.prototype.toString()`](https://tc39.github.io/proposal-intl-locale/#sec-Intl.Locale.prototype.toString) | Proposition de niveau 3 |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.Locale.toString")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/intl/pluralrules/resolvedoptions/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/pluralrules/resolvedoptions/index.md
@@ -63,13 +63,11 @@ usedOptions.type;                  // "cardinal"
 
 ## Spécifications
 
-| Spécification                                                                                                         | État      | Commentaires         |
-| --------------------------------------------------------------------------------------------------------------------- | --------- | -------------------- |
-| [Brouillon pour les règles de nombre avec `Intl`](https://rawgit.com/caridy/intl-plural-rules-spec/master/index.html) | Brouillon | Définition initiale. |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.PluralRules.resolvedOptions")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/intl/relativetimeformat/format/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/relativetimeformat/format/index.md
@@ -75,10 +75,8 @@ rtf.format(1, "day");
 
 ## Spécifications
 
-| Spécification                                                                                                                            | État                    | Commentaires |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------------ |
-| [Proposition pour `Intl.RelativeTime`](https://tc39.github.io/proposal-intl-relative-time/#sec-Intl.RelativeTimeFormat.prototype.format) | Proposition de niveau 3 |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.RelativeTimeFormat.format")}}
+{{Compat}}

--- a/files/fr/web/javascript/reference/global_objects/intl/relativetimeformat/formattoparts/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/relativetimeformat/formattoparts/index.md
@@ -55,13 +55,11 @@ rtf.formatToParts(100, "day");
 
 ## Spécifications
 
-| Spécifications                                                                                                                                  | État                    | Commentaires |
-| ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------------ |
-| [Proposition pour `Intl.RelativeTime`](https://tc39.github.io/proposal-intl-relative-time/#sec-Intl.RelativeTimeFormat.prototype.formatToParts) | Proposition de niveau 3 |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.RelativeTimeFormat.formatToParts")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/intl/relativetimeformat/resolvedoptions/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/relativetimeformat/resolvedoptions/index.md
@@ -70,14 +70,11 @@ usedOptions.numberingSystem; // "latn"
 
 ## Spécifications
 
-| Spécification                                                                                                                                     | État                    | Commentaires |
-| ------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------------ |
-|                                                                                                                                                   |                         |              |
-| [Proposition pour `Intl.RelativeTime`](https://tc39.github.io/proposal-intl-relative-time/#sec-intl.relativetimeformat.prototype.resolvedoptions) | Proposition de niveau 3 |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.RelativeTimeFormat.resolvedOptions")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/intl/relativetimeformat/supportedlocalesof/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/relativetimeformat/supportedlocalesof/index.md
@@ -57,13 +57,11 @@ var locales = ['ban', 'id-u-co-pinyin', 'de-ID'];var options = { localeMatcher: 
 
 ## Spécifications
 
-| Spécification                                                                                                                              | État                    | Commentaires |
-| ------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------- | ------------ |
-| [Proposition pour `Intl.RelativeTime`](https://tc39.github.io/proposal-intl-relative-time/#sec-Intl.RelativeTimeFormat.supportedLocalesOf) | Proposition de niveau 3 |              |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Intl.RelativeTimeFormat.supportedLocalesOf")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/regexp/dotall/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/dotall/index.md
@@ -33,7 +33,7 @@ Cette propriété est uniquement accessible en lecture et ne peut pas être modi
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.RegExp.dotAll")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/regexp/input/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/input/index.md
@@ -48,7 +48,7 @@ Cette propriété n'est pas standard. Elle ne fait partie d'aucune spécificatio
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.RegExp.input")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/regexp/lastmatch/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/lastmatch/index.md
@@ -47,7 +47,7 @@ Cette propriété n'est pas standard. Elle ne fait partie d'aucune spécificatio
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.RegExp.lastMatch")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/regexp/lastparen/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/lastparen/index.md
@@ -46,7 +46,7 @@ Cette propriété n'est pas standard. Elle ne fait partie d'aucune spécificatio
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.RegExp.lastParen")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/regexp/leftcontext/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/leftcontext/index.md
@@ -45,7 +45,7 @@ Cette propriété n'est pas standard et ne fait partie d'aucune spécification.
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.RegExp.leftContext")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/regexp/n/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/n/index.md
@@ -57,7 +57,7 @@ Ces propriétés ne sont pas standard, elles ne font partie d'aucune spécificat
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.RegExp.n")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/regexp/rightcontext/index.md
+++ b/files/fr/web/javascript/reference/global_objects/regexp/rightcontext/index.md
@@ -46,7 +46,7 @@ Cette propriété n'est pas standard, elle ne fait partie d'aucune spécificatio
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.RegExp.rightContext")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/string/trimend/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/trimend/index.md
@@ -56,13 +56,11 @@ console.log(str);        // "   toto"
 
 ## Spécifications
 
-| Spécification                                                                                                                                                        | État                  | Commentaires        |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- | ------------------- |
-| Proposition pour [`String.prototype.{trimStart,trimEnd}`](https://github.com/tc39/proposal-string-left-right-trim/#stringprototypetrimstart--stringprototypetrimend) | Brouillon de niveau 4 | Attendu pour ES2019 |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.String.trimEnd")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/string/trimstart/index.md
+++ b/files/fr/web/javascript/reference/global_objects/string/trimstart/index.md
@@ -56,13 +56,11 @@ console.log(str);        // "toto  "
 
 ## Spécifications
 
-| Spécification                                                                                                                                                        | État                  | Commentaires        |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- | ------------------- |
-| Proposition pour [`String.prototype.{trimStart,trimEnd}`](https://github.com/tc39/proposal-string-left-right-trim/#stringprototypetrimstart--stringprototypetrimend) | Brouillon de niveau 4 | Attendu pour ES2019 |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.String.trimStart")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/javascript/reference/global_objects/symbol/description/index.md
+++ b/files/fr/web/javascript/reference/global_objects/symbol/description/index.md
@@ -48,13 +48,11 @@ Symbol.for('toto').description; // "toto"
 
 ## Spécifications
 
-| Spécification                                                                                                                           | État                    |
-| --------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
-| [Proposition pour `Symbol.prototype.description`](https://tc39.github.io/proposal-Symbol-description/#sec-symbol.prototype.description) | Proposition de niveau 4 |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("javascript.builtins.Symbol.description")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/security/certificate_transparency/index.md
+++ b/files/fr/web/security/certificate_transparency/index.md
@@ -107,13 +107,11 @@ server.modules += ( "mod_setenv" )
 
 ## Spécifications
 
-| Spécification                                            | Description                                           |
-| -------------------------------------------------------- | ----------------------------------------------------- |
-| {{RFC("7469", "Public-Key-Pins", "2.1")}} | Extension de l'épinglage des clés publiques pour HTTP |
+{{Specifications}}
 
 ## Compatibilité des navigateurs
 
-{{Compat("http.headers.Public-Key-Pins")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/svg/attribute/color/index.md
+++ b/files/fr/web/svg/attribute/color/index.md
@@ -71,4 +71,4 @@ Les éléments suivants peuvent utiliser l'attribut `color`:
 
 ## Compatibilité des navigateurs
 
-{{Compat("svg.attributes.presentation.color")}}
+{{Compat}}

--- a/files/fr/web/svg/attribute/conditional_processing/index.md
+++ b/files/fr/web/svg/attribute/conditional_processing/index.md
@@ -28,4 +28,4 @@ Les _attributs SVG de traitement conditionnel_ sont tous les attributs qui peuve
 
 ## Compatibilité des navigateurs
 
-{{Compat("svg.attributes.conditional_processing")}}
+{{Compat}}

--- a/files/fr/web/svg/attribute/core/index.md
+++ b/files/fr/web/svg/attribute/core/index.md
@@ -50,4 +50,4 @@ Les _attributs SVG de base_ sont tous les attributs communs pouvant être spéci
 
 ## Compatibilité des navigateurs
 
-{{Compat("svg.attributes.core")}}
+{{Compat}}

--- a/files/fr/web/svg/attribute/presentation/index.md
+++ b/files/fr/web/svg/attribute/presentation/index.md
@@ -264,4 +264,4 @@ Les _attributs SVG de présentation_ sont des propriétés CSS pouvant être uti
 
 ## Compatibilité des navigateurs
 
-{{Compat("svg.attributes.presentation")}}
+{{Compat}}

--- a/files/fr/web/svg/attribute/style/index.md
+++ b/files/fr/web/svg/attribute/style/index.md
@@ -80,4 +80,4 @@ Les éléments suivants peuvent utiliser l'attribut `style`:
 
 ## Compatibilité des navigateurs
 
-{{Compat("svg.attributes.style.style")}}
+{{Compat}}

--- a/files/fr/web/svg/attribute/styling/index.md
+++ b/files/fr/web/svg/attribute/styling/index.md
@@ -20,4 +20,4 @@ Les _attributs SVG de style_ sont tous les attributs qui peuvent être spécifi�
 
 ## Compatibilité des navigateurs
 
-{{Compat("svg.attributes.style")}}
+{{Compat}}

--- a/files/fr/web/svg/element/circle/index.md
+++ b/files/fr/web/svg/element/circle/index.md
@@ -55,9 +55,9 @@ L'élément `circle` est un élément de la catégorie des Formes simples, utili
 
 Cet élément implémente l'interface {{ domxref("SVGCircleElement") }}.
 
-## Compatibilité avec les navigateurs
+## Compatibilité des navigateurs
 
-{{Compat("svg.elements.circle")}}
+{{Compat}}
 
 ## Corrélat
 

--- a/files/fr/web/svg/element/desc/index.md
+++ b/files/fr/web/svg/element/desc/index.md
@@ -34,9 +34,9 @@ _(Aucun)_
 
 Cet élément implémente l'interface [`SVGDescElement`](/fr/docs/Web/API/SVGDescElement).
 
-## Compatibilitée des navigateurs
+## Compatibilité des navigateurs
 
-{{Compat("svg.elements.desc")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/svg/element/image/index.md
+++ b/files/fr/web/svg/element/image/index.md
@@ -55,4 +55,4 @@ Cet élément implémente l'interface [`SVGImageElement`](/fr/DOM/SVGImageElemen
 
 ## Compatibilité des navigateurs
 
-{{Compat("svg.elements.image")}}
+{{Compat}}

--- a/files/fr/web/svg/element/line/index.md
+++ b/files/fr/web/svg/element/line/index.md
@@ -62,7 +62,7 @@ Cet élément implémente l'interface [`SVGLineElement`](/fr/DOM/SVGLineElement)
 
 ## Compatibilité des navigateurs
 
-{{Compat("svg.elements.line")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/svg/element/path/index.md
+++ b/files/fr/web/svg/element/path/index.md
@@ -52,7 +52,7 @@ Cet élément implémente l'interface [`SVGPathElement`](/fr/DOM/SVGPathElement)
 
 ## Compatibilité des navigateurs
 
-{{Compat("svg.elements.path")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/svg/element/rect/index.md
+++ b/files/fr/web/svg/element/rect/index.md
@@ -60,9 +60,9 @@ html,body,svg { height:100% }
 
 Cet élément implémente l'interface [`SVGRectElement`](/fr/DOM/SVGRectElement) .
 
-## Compatibilité avec les navigateurs
+## Compatibilité des navigateurs
 
-{{Compat("svg.elements.rect")}}
+{{Compat}}
 
 ## Voir aussi
 

--- a/files/fr/web/svg/element/text/index.md
+++ b/files/fr/web/svg/element/text/index.md
@@ -101,7 +101,7 @@ Cet élément implémente l'interface [`SVGTextElement`](/fr/DOM/SVGTextElement)
 
 ## Compatibilité des navigateurs
 
-{{Compat("svg.elements.text")}}
+{{Compat}}
 
 ## Articles liés
 


### PR DESCRIPTION
This PR updates some of the browser compatibility data and specification sections for the French locale. Part of work for #11594.

Note: this may also include other minor updates, such as removal of old sections or other small bits of cleanup.
