### PR TITLE
Rename ДМИП to ARIA

### DIFF
--- a/files/ru/web/html/element/heading_elements/index.md
+++ b/files/ru/web/html/element/heading_elements/index.md
@@ -11,7 +11,7 @@ translation_of: Web/HTML/Element/Heading_Elements
 | Разрешённый контент                                        | [Фразированное содержание](/ru/docs/Web/HTML/Content_categories#Phrasing_content).                                                                                                      |
 | Пропуск тега                                               | {{no_tag_omission}}                                                                                                                                                                     |
 | Разрешённые родители                                       | Любые элементы которые принимают [Содержание потока](/ru/docs/Web/HTML/Content_categories#Flow_content); не используй как дочерний {{HTMLElement("hgroup")}} элемент, сейчас он устарел |
-| Разрешённые роли ДМИП                                      | <code><a href="/ru/docs/Web/Accessibility/ARIA/Roles/tab_role">tab</a></code>, <code><a href="/ru/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code>          |
+| Разрешённые роли ARIA                                      | <code><a href="/ru/docs/Web/Accessibility/ARIA/Roles/tab_role">tab</a></code>, <code><a href="/ru/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code>          |
 | DOM интерфейс                                              | {{domxref("HTMLHeadingElement")}}                                                                                                                                                       |
 
 ## Атрибуты

--- a/files/ru/web/html/element/heading_elements/index.md
+++ b/files/ru/web/html/element/heading_elements/index.md
@@ -11,7 +11,7 @@ translation_of: Web/HTML/Element/Heading_Elements
 | Разрешённый контент                                        | [Фразированное содержание](/ru/docs/Web/HTML/Content_categories#Phrasing_content).                                                                                                      |
 | Пропуск тега                                               | {{no_tag_omission}}                                                                                                                                                                     |
 | Разрешённые родители                                       | Любые элементы которые принимают [Содержание потока](/ru/docs/Web/HTML/Content_categories#Flow_content); не используй как дочерний {{HTMLElement("hgroup")}} элемент, сейчас он устарел |
-| Разрешённые роли ARIA                                      | <code><a href="/ru/docs/Web/Accessibility/ARIA/Roles/tab_role">tab</a></code>, <code><a href="/ru/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code>          |
+| Разрешённые ARIA-роли                                      | <code><a href="/ru/docs/Web/Accessibility/ARIA/Roles/tab_role">tab</a></code>, <code><a href="/ru/docs/Web/Accessibility/ARIA/Roles/presentation_role">presentation</a></code>          |
 | DOM интерфейс                                              | {{domxref("HTMLHeadingElement")}}                                                                                                                                                       |
 
 ## Атрибуты


### PR DESCRIPTION
### Description

Fixed wrong translation of ARIA

### Motivation

The abbreviation ДМИП is not used in the russian speaking community for ARIA

### Related issues and pull requests

Fixes #11402
