### PR TITLE
fix: markdown bold rule invalid

### DIFF
--- a/files/zh-cn/web/api/window/sessionstorage/index.md
+++ b/files/zh-cn/web/api/window/sessionstorage/index.md
@@ -8,7 +8,7 @@ slug: Web/API/Window/sessionStorage
 `sessionStorage` 属性允许你访问一个，对应当前源的 session {{domxref("Storage")}} 对象。它与 {{domxref("Window.localStorage", "localStorage")}} 相似，不同之处在于 `localStorage` 里面存储的数据没有过期时间设置，而存储在 `sessionStorage` 里面的数据在页面会话结束时会被清除。
 
 - 页面会话在浏览器打开期间一直保持，并且重新加载或恢复页面仍会保持原来的页面会话。
-- **在新标签或窗口打开一个页面时会复制顶级浏览会话的上下文作为新会话的上下文，**这点和 session cookies 的运行方式不同。
+- **在新标签或窗口打开一个页面时会复制顶级浏览会话的上下文作为新会话的上下文，** 这点和 session cookies 的运行方式不同。
 - 打开多个相同的 URL 的 Tabs 页面，会创建各自的 `sessionStorage`。
 - 关闭对应浏览器标签或窗口，会清除对应的 `sessionStorage`。
 

--- a/files/zh-cn/web/api/window/sessionstorage/index.md
+++ b/files/zh-cn/web/api/window/sessionstorage/index.md
@@ -8,7 +8,7 @@ slug: Web/API/Window/sessionStorage
 `sessionStorage` 属性允许你访问一个，对应当前源的 session {{domxref("Storage")}} 对象。它与 {{domxref("Window.localStorage", "localStorage")}} 相似，不同之处在于 `localStorage` 里面存储的数据没有过期时间设置，而存储在 `sessionStorage` 里面的数据在页面会话结束时会被清除。
 
 - 页面会话在浏览器打开期间一直保持，并且重新加载或恢复页面仍会保持原来的页面会话。
-- **在新标签或窗口打开一个页面时会复制顶级浏览会话的上下文作为新会话的上下文，** 这点和 session cookies 的运行方式不同。
+- **在新标签或窗口打开一个页面时会复制顶级浏览会话的上下文作为新会话的上下文，这点和 session cookie 的运行方式不同。**
 - 打开多个相同的 URL 的 Tabs 页面，会创建各自的 `sessionStorage`。
 - 关闭对应浏览器标签或窗口，会清除对应的 `sessionStorage`。
 


### PR DESCRIPTION
Description
**在新标签或窗口打开一个页面时会复制顶级浏览会话的上下文作为新会话的上下文，**这点和 
As you can see，the above markdown rules are invalid，Because there is no space after **

Motivation
**在新标签或窗口打开一个页面时会复制顶级浏览会话的上下文作为新会话的上下文，** 这点和 
To make it effective, just add a space after **