### PR TITLE
fr: remove SeeCompatTable macro for scrollIntoView

### DIFF
--- a/files/fr/web/api/element/scrollintoview/index.md
+++ b/files/fr/web/api/element/scrollintoview/index.md
@@ -9,7 +9,7 @@ tags:
 translation_of: Web/API/Element/scrollIntoView
 ---
 
-{{ APIRef("DOM")}}{{SeeCompatTable}}
+{{ APIRef("DOM")}}
 
 La méthode **`Element.scrollIntoView()`** fait défiler la page de manière à rendre l'élément visible.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Remove SeeCompatTable macro for french scrollIntoView article

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The SeeCompatTable macro is not present in the english article, it should be removed in the french translation

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
