### PR TITLE
fr: add bigint in primitive type

### DIFF
--- a/files/fr/glossary/primitive/index.md
+++ b/files/fr/glossary/primitive/index.md
@@ -9,7 +9,7 @@ translation_of: Glossary/Primitive
 original_slug: Glossaire/Primitive
 ---
 
-Une **primitive** (valeur primitive ou structure de donnée primitive) est une donnée qui n'est pas un {{Glossary("object","objet")}} et n'a pas de {{glossary("method","méthode")}}. En {{Glossary("JavaScript")}}, il y a 6 types de données primitives: {{Glossary("String")}}, {{Glossary("Number")}}, {{Glossary("Boolean")}}, {{Glossary("Null")}}, {{Glossary("undefined")}}, {{Glossary("Symbol")}} (nouveauté d'{{Glossary("ECMAScript")}} 2015).
+Une **primitive** (valeur primitive ou structure de donnée primitive) est une donnée qui n'est pas un {{Glossary("object","objet")}} et n'a pas de {{glossary("method","méthode")}}. En {{Glossary("JavaScript")}}, il y a 7 types de données primitives: {{Glossary("String")}}, {{Glossary("Number")}}, {{Glossary("Boolean")}}, {{Glossary("Null")}}, {{Glossary("undefined")}}, {{Glossary("Symbol")}}, {{Glossary("Bigint")}} (nouveauté d'{{Glossary("ECMAScript")}} 2020).
 
 La plupart du temps, une valeur primitive est représentée directement au plus bas niveau dans l'implémentation du langage.
 
@@ -21,8 +21,9 @@ Excepté dans les cas de `null` ou `undefined`, pour chaque valeur primitive il 
 
 - {{jsxref("String")}} pour la primitive `string` ;
 - {{jsxref("Number")}} pour la primitive `number` ;
-- {{jsxref("Boolean")}} pour la primitive `boolean` ;
-- {{jsxref("Symbol")}} pour la primitive `symbol`
+- {{jsxref("Boolean")}} pour la primitive `boolean`;
+- {{jsxref("Symbol")}} pour la primitive `symbol`;
+- {{jsxref("Bigint")}} pour la primitive `bigint`;
 
 La méthode [`valueOf()`](/fr/docs/Web/JavaScript/Reference/Objets_globaux/Object/valueOf) de ces objets retourne la valeur primitive encapsulée correspondante.
 


### PR DESCRIPTION
### Description
Depuis ECMAScript 2020, BigInt est considéré comme un type primitif en JavaScript, hors bigint n'était pas listé, je 'lai rajouté.
Since ECMAScript 2020, BigInt is considered as a primitive type in JavaScript, but bigint was not listed, I added it.

