### PR TITLE
es: Sync HardwareConcurrency with en-US Slug

### DIFF
--- a/files/es/_redirects.txt
+++ b/files/es/_redirects.txt
@@ -1682,7 +1682,7 @@
 /es/docs/Web/API/Media_Streams_API/Taking_still_photos	/es/docs/Web/API/Media_Capture_and_Streams_API/Taking_still_photos
 /es/docs/Web/API/Navigator.getUserMedia	/es/docs/Web/API/Navigator/getUserMedia
 /es/docs/Web/API/NavigatorConcurrentHardware	/es/docs/orphaned/Web/API/NavigatorConcurrentHardware
-/es/docs/Web/API/NavigatorConcurrentHardware/hardwareConcurrency	/es/docs/orphaned/Web/API/NavigatorConcurrentHardware/hardwareConcurrency
+/es/docs/Web/API/NavigatorConcurrentHardware/hardwareConcurrency	/es/docs/Web/API/Navigator/hardwareConcurrency
 /es/docs/Web/API/NavigatorGeolocation/geolocation	/es/docs/Web/API/Navigator/geolocation
 /es/docs/Web/API/NavigatorLanguage	/es/docs/orphaned/Web/API/NavigatorLanguage
 /es/docs/Web/API/NavigatorLanguage/language	/es/docs/orphaned/Web/API/NavigatorLanguage/language
@@ -2879,4 +2879,5 @@
 /es/docs/en	/en-US/
 /es/docs/firefox_Web_Developer_(externo)	https://addons.mozilla.org/firefox/60/
 /es/docs/orphaned/MDN/Yari	/es/docs/MDN/Community/Contributing/Our_repositories
+/es/docs/orphaned/Web/API/NavigatorConcurrentHardware/hardwareConcurrency	/es/docs/Web/API/Navigator/hardwareConcurrency
 /es/docs/video	/es/docs/Web/HTML/Element/video

--- a/files/es/_wikihistory.json
+++ b/files/es/_wikihistory.json
@@ -4880,6 +4880,10 @@
       "maedca"
     ]
   },
+  "Web/API/Navigator/hardwareConcurrency": {
+    "modified": "2020-10-15T22:26:06.271Z",
+    "contributors": ["Gnuxdar"]
+  },
   "Web/API/Navigator/registerProtocolHandler": {
     "modified": "2019-03-23T23:53:04.318Z",
     "contributors": ["fscholz", "khalid32", "Nukeador", "HenryGR", "Mgjbot"]
@@ -15578,10 +15582,6 @@
   },
   "orphaned/Web/API/NavigatorConcurrentHardware": {
     "modified": "2020-10-15T22:25:58.692Z"
-  },
-  "orphaned/Web/API/NavigatorConcurrentHardware/hardwareConcurrency": {
-    "modified": "2020-10-15T22:26:06.271Z",
-    "contributors": ["Gnuxdar"]
   },
   "orphaned/Web/API/NavigatorLanguage": {
     "modified": "2019-03-23T22:46:20.556Z",

--- a/files/es/web/api/navigator/hardwareconcurrency/index.md
+++ b/files/es/web/api/navigator/hardwareconcurrency/index.md
@@ -1,8 +1,7 @@
 ---
 title: navigator.hardwareConcurrency
-slug: orphaned/Web/API/NavigatorConcurrentHardware/hardwareConcurrency
+slug: Web/API/Navigator/hardwareConcurrency
 original_slug: Web/API/NavigatorConcurrentHardware/hardwareConcurrency
-browser-compat: api.Navigator.hardwareConcurrency
 ---
 
 {{APIRef("HTML DOM")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix the slug for the page according to `en-US`

### Motivation

Sync according to https://github.com/mdn/content/pull/6637

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
