### PR TITLE
Add information in french about WHATWG specification of fetch

### DIFF
--- a/files/fr/web/api/fetch/index.md
+++ b/files/fr/web/api/fetch/index.md
@@ -47,10 +47,7 @@ const fetchResponsePromise = Promise<Response> fetch(entrée[, init]);
   - : Un objet qui contient les paramètres de votre requête. Les options possibles sont :
 
     - `method`
-      - : La méthode de la requête, par exemple `GET` ou `POST`. Notez que le header
-        {{httpheader("Origin")}} n'est pas défini à cause d'un bug, corrigé en version 65 de Firefox (voir [bug 1508661](https://bugzil.la/1508661)), 
-        dans les requêtes Fetch avec les méthodes {{HTTPMethod("HEAD")}} ou {{HTTPMethod("GET")}}.
-        Comme spécifié, dans la [spécification WHATWG](https://fetch.spec.whatwg.org/#methods), toute méthode définie dans la [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-overview ) sera automatiquement mise en majuscule. Si vous souhaitez utiliser une méthode exotique (comme `PATCH`), vous devrez la mettre en majuscule vous-même.
+      - : La méthode de la requête, par exemple `GET` ou `POST`. Comme spécifié, dans la [spécification WHATWG](https://fetch.spec.whatwg.org/#methods), toute méthode définie dans la [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-overview) sera automatiquement mise en majuscule. Si vous souhaitez utiliser une méthode exotique (comme `PATCH`), vous devrez la mettre en majuscule vous-même. Notez qu'e l'en-tête [`Origin`](/fr/docs/Web/HTTP/Headers/origin) n'était pas défini dans les requêtes `fetch()` avec les méthodes [`HEAD`](/fr/docs/Web/HTTP/Methods/HEAD) ou [`GET`](/fr/docs/Web/HTTP/Methods/GET) à cause d'un bug pour Firefox avant Firefox 65 (voir [bug 1508661](https://bugzil.la/1508661)).
     - `headers`
       - : Les entêtes à ajouter à votre requête, contenues dans un objet {{domxref("Headers")}} ou dans un objet avec des {{domxref("ByteString")}} pour valeurs.
     - `body`

--- a/files/fr/web/api/fetch/index.md
+++ b/files/fr/web/api/fetch/index.md
@@ -47,7 +47,10 @@ const fetchResponsePromise = Promise<Response> fetch(entrée[, init]);
   - : Un objet qui contient les paramètres de votre requête. Les options possibles sont :
 
     - `method`
-      - : La méthode de la requête, par exemple `GET` ou `POST`.
+      - : La méthode de la requête, par exemple `GET` ou `POST`. Notez que le header
+        {{httpheader("Origin")}} n'est pas défini à cause d'un bug, corrigé en version 65 de Firefox (voir [bug 1508661](https://bugzil.la/1508661)), 
+        dans les requêtes Fetch avec les méthodes {{HTTPMethod("HEAD")}} ou {{HTTPMethod("GET")}}.
+        Comme spécifié, dans la [spécification WHATWG](https://fetch.spec.whatwg.org/#methods), toute méthode définie dans la [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-overview ) sera automatiquement mise en majuscule. Si vous souhaitez utiliser une méthode exotique (comme `PATCH`), vous devrez la mettre en majuscule vous-même.
     - `headers`
       - : Les entêtes à ajouter à votre requête, contenues dans un objet {{domxref("Headers")}} ou dans un objet avec des {{domxref("ByteString")}} pour valeurs.
     - `body`


### PR DESCRIPTION
### Description

Adding information about `method` in `fetch`

### Motivation

Same call, using lowercased patch and lowercased post don't have the same behavior. I think we should document it.

```js
// method in HTTP will be `POST`
const res = await fetch(url, {
  method: 'post',
  headers: { "Authorization": token, "Content-Type": 'application/json' },
  body: JSON.stringify(payload)
});

// method in HTTP will be `patch`
const res = await fetch(url, {
  method: 'patch',
  body: JSON.stringify(payload)
});
```

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/25020