### PR TITLE
fix the broken webgl demo and update some broken links

### DIFF
--- a/files/es/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
+++ b/files/es/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
@@ -104,12 +104,12 @@ Has visto este código antes. Es prácticamente idéntico a la rutina de handleT
 
 ¡Esto es todo al respecto!
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample8/index.html', 670, 510) }}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample8/index.html', 670, 510) }}
 
-[Ver el código completo](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample8) | [Abrir esta demo en una nueva página](http://mdn.github.io/webgl-examples/tutorial/sample8/)
+[Ver el código completo](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample8) | [Abrir esta demo en una nueva página](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample8/)
 
 ## Artículos relacionados
 
-- [Usar audio y video en Firefox](/es/Using_HTML5_audio_and_video)
+- [Usar audio y video en Firefox](/es/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content)
 
 {{Previous("Web/API/WebGL_API/Tutorial/Lighting_in_WebGL")}}

--- a/files/fr/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
+++ b/files/fr/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
@@ -137,12 +137,12 @@ Si `copierVideo` est true, alors `mettreAJourTexture()` est appelé à chaque fo
 
 C'est tout pour ce qu'il y a à faire pour cela !
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample8/index.html', 670, 510) }}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample8/index.html', 670, 510) }}
 
-[Voir le code complet](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample8) | [Ouvrir cette démo dans une nouvelle page](http://mdn.github.io/webgl-examples/tutorial/sample8/)
+[Voir le code complet](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample8) | [Ouvrir cette démo dans une nouvelle page](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample8/)
 
 ## Voir aussi
 
-- [Utilisation de l'audio et de la video dans Firefox](/fr/Using_HTML5_audio_and_video)
+- [Utilisation de l'audio et de la video dans Firefox](/fr/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content)
 
 {{Previous("Web/API/WebGL_API/Tutorial/Lighting_in_WebGL")}}

--- a/files/ja/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
+++ b/files/ja/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
@@ -100,12 +100,12 @@ function updateTexture() {
 
 以上で完了です!
 
-{{EmbedGHLiveSample('webgl-examples/tutorial/sample8/index.html', 670, 510)}}
+{{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample8/index.html', 670, 510) }}
 
-[コードを確認する](https://github.com/mdn/webgl-examples/tree/gh-pages/tutorial/sample8) | [新しいページでデモを開く](http://mdn.github.io/webgl-examples/tutorial/sample8/)
+[コードを確認する](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample8) | [新しいページでデモを開く](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample8/)
 
 ## 関連情報
 
-- [HTML5 の audio 要素と video 要素の使用](/ja/docs/Using_HTML5_audio_and_video)
+- [HTML5 の audio 要素と video 要素の使用](/ja/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content)
 
 {{Previous("Web/API/WebGL_API/Tutorial/Lighting_in_WebGL")}}


### PR DESCRIPTION
### Description

fix the broken webgl demo and update some broken links

### Motivation

The GitHub webgl demo has been moved to the new repo, so update the links.

### Related issues and pull requests

Part of: #11981
