### PR TITLE
es: Replaced `{{HTMLRefTable}}` with markdown table

### DIFF
--- a/files/es/web/html/element/index.md
+++ b/files/es/web/html/element/index.md
@@ -93,9 +93,9 @@ Utilice la semántica del texto en línea HTML para definir el significado, estr
 | {{HTMLElement("kbd")}}    | **Sus etiquetas son**: \<kbd> y \</kbd> (ambas obligatorias) |
 | {{HTMLElement("mark")}}   | El **Elemento HTML Mark `<mark>`** representa un texto **marcado** o **resaltado** como referencia o anotación, debido a su relevancia o importancia en un contexto particular. |
 | {{HTMLElement("q")}}      | El **elemento HTML `<q>`** indica que el texto adjunto es una cita corta en línea. La mayoría de los navegadores modernos implementan esto rodeando el texto entre comillas. Este elemento está destinado a citas breves que no requieren saltos de párrafo; para citas de bloque independiente, utiliza el elemento {{HTMLElement("blockquote")}}. |
-| {{HTMLElement("rp")}}     | Used to provide fall-back parentheses for browsers that do not support display of ruby annotations using the {{HTMLElement("ruby")}} element. One `<rp>` element should enclose each of the opening and closing parentheses that wrap the {{HTMLElement("rt")}} element that contains the annotation's text. |
-| {{HTMLElement("rt")}}     | Specifies the ruby text component of a ruby annotation, which is used to provide pronunciation, translation, or transliteration information for East Asian typography. The `<rt>` element must always be contained within a {{HTMLElement("ruby")}} element. |
-| {{HTMLElement("ruby")}}   | Represents small annotations that are rendered above, below, or next to base text, usually used for showing the pronunciation of East Asian characters. It can also be used for annotating other kinds of text, but this usage is less common. |
+| {{HTMLElement("rp")}}     | Se utiliza para proporcionar paréntesis alternativos para navegadores que no admiten la visualización de anotaciones Ruby mediante el elemento {{HTMLElement("ruby")}}. Un elemento `<rp>` debe incluir cada uno de los paréntesis de apertura y cierre que envuelven el elemento {{HTMLElement("rt")}} que contiene el texto de la anotación. |
+| {{HTMLElement("rt")}}     | Especifica el componente de texto ruby de una anotación ruby, que se utiliza para proporcionar información de pronunciación, traducción o transliteración para la tipografía de Asia oriental. El elemento `<rt>` siempre debe estar contenido dentro de un elemento {{HTMLElement("ruby")}}. |
+| {{HTMLElement("ruby")}}   | Representa pequeñas anotaciones que se muestran encima, debajo o al lado del texto base, generalmente utilizadas para mostrar la pronunciación de los caracteres de Asia oriental. También se puede usar para anotar otros tipos de texto, pero este uso es menos común. |
 | {{HTMLElement("s")}}      | **Sus etiquetas son**: \<s> y \</s> (Ambas obligatorias) |
 | {{HTMLElement("samp")}}   | El elemento HTML Sample (**`<samp>`**) se utiliza para incluir texto en línea que representa una muestra (o cita) de la salida de un programa de ordenador. El contenido de esta etiqueta es renderizado generalmente usando la tipografía monoespaciada por defecto del navegador. |
 | {{HTMLElement("small")}}  | El **elemento HTML \<small>** hace el tamaño del texto una talla más pequeña (por ejemplo, de largo a mediano, o de pequeño a extra pequeño) que el tamaño mínimo de fuente del navegador. En HTML5, este elemento es reutilizado para representar comentarios laterales y letra pequeña, incluyendo derechos de autor y texto legal, independientemente de su estilo de presentación. |
@@ -127,16 +127,16 @@ Además de los contenidos multimedia habituales, HTML puede incluir otra varieda
 
 | Element | Description |
 | ------- | ----------- |
-| {{HTMLElement("embed")}}   | > **Nota:** este tema documenta sólo el elemento \<embed> que se define como parte de HTML5. No trata las implementaciones anteriores no estandarizadas del elemento `<embed>`. |
-| {{HTMLElement("iframe")}}  | El **elemento HTML `<iframe>`** (de inline frame) representa un {{Glossary("contexto de navegación")}} anidado, el cual permite incrustrar otra página HTML en la página actual. |
+| {{HTMLElement("embed")}}   | El _Elemento HTML Embed_ ( `<embed>` ) representa un punto de integración para una aplicación externa o de contenido interactivo (en otras palabras, un plug-in). |
+| {{HTMLElement("iframe")}}  | El **elemento HTML `<iframe>`** (de inline frame) representa un contexto de navegación anidado, el cual permite incrustar otra página HTML en la página actual. |
 | {{HTMLElement("object")}}  | El **elemento HTML `<object>`** representa un recurso externo, que puede ser tratado como una imagen, un contexto de navegación anidado, o como un recurso que debe ser manejado por un plugin. |
 | {{HTMLElement("picture")}} | El **elemento HTML `<picture>`** es un contenedor usado para especificar múltiples elementos {{HTMLElement("source")}} y un elemento {{HTMLElement("img")}} contenido en él para proveer versiones de una imagen para diferentes escenarios de dispositivos. Si no hay coincidencias con los elementos `<source>`, el archivo especificado en los atributos {{htmlattrxref("src", "img")}} del elemento `<img>` es utilizado. La imagen seleccionada es entonces presentada en el espacio ocupado por el elemento `<img>`. |
-| {{HTMLElement("portal")}}  | Enables the embedding of another HTML page into the current one for the purposes of allowing smoother navigation into new pages. |
+| {{HTMLElement("portal")}}  | Habilita la incrustación de otra página HTML en la actual con el fin de permitir una navegación más fluida en nuevas páginas. |
 | {{HTMLElement("source")}}  | El **elemento HTML `<source>`** especifica recursos de medios múltiples para los elementos {{HTMLElement("picture")}}, {{HTMLElement("audio")}}, o {{HTMLElement("video")}}. Es un elemento vacío. Normalmente se utiliza para servir el mismo contenido multimedia en [varios formatos soportados por diferentes navegadores](/es/docs/Media_formats_supported_by_the_audio_and_video_elements). |
 
 ## SVG and MathML
 
-You can embed [SVG](/es/docs/Web/SVG) and [MathML](/es/docs/Web/MathML) content directly into HTML documents, using the {{SVGElement("svg")}} and {{MathMLElement("math")}} elements.
+Puede incrustar contenido [SVG](/es/docs/Web/SVG) y [MathML](/es/docs/Web/MathML) directamente en documentos HTML, usando los elementos {{SVGElement("svg")}} y { {MathMLElement("math")}}.
 
 | Element | Description |
 | ------- | ----------- |
@@ -151,7 +151,7 @@ Con el fin de crear contenido dinámico y aplicaciones Web, HTML soporta el uso 
 | ------- | ----------- |
 | {{HTMLElement("canvas")}}   | El elemento HTML _canvas_ (\<canvas>) se puede utilizar para dibujar gráficos a través de secuencias de comandos (por lo general [JavaScript](/en/JavaScript) ). Por ejemplo, puede usarse para dibujar gráficos, hacer composiciones de fotos o incluso realizar animaciones. |
 | {{HTMLElement("noscript")}} | **Sus etiquetas son**: `<noscript>` y `</noscript>` (ambas obligatorias). |
-| {{HTMLElement("script")}}   | Used to embed executable code or data; this is typically used to embed or refer to JavaScript code. The `<script>` element can also be used with other languages, such as [WebGL](/es/docs/Web/API/WebGL_API)'s GLSL shader programming language and [JSON](/es/docs/Glossary/JSON). |
+| {{HTMLElement("script")}}   | Se utiliza para incrustar código ejecutable o datos; esto generalmente se usa para incrustar o hacer referencia al código JavaScript. El elemento `<script>` también se puede usar con otros lenguajes, como el lenguaje de programación de sombreado GLSL de [WebGL](/es/docs/Web/API/WebGL_API) y [JSON](/es/docs/Glossary/ JSON). |
 
 ## Ediciones demarcadas
 
@@ -172,11 +172,11 @@ Estos elementos son usados para crear y manejar datos tabulados.
 | {{HTMLElement("col")}}      | **Sus etiquetas son**: `<col>` (solo tiene una). |
 | {{HTMLElement("colgroup")}} | **Sus etiquetas son**: `<colgroup>` y `</colgroup>` (la de cierre es opcional). |
 | {{HTMLElement("table")}}    | El _Elemento de Tabla HTML_ (`<table>`) representa datos en dos o mas dimensiones. |
-| {{HTMLElement("tbody")}}    | Encapsulates a set of table rows ({{HTMLElement("tr")}} elements), indicating that they comprise the body of the table ({{HTMLElement("table")}}). |
+| {{HTMLElement("tbody")}}    | Encapsula un conjunto de filas de una tabla (elementos {{HTMLElement("tr")}}), lo que indica que abarcan el cuerpo de la tabla ({{HTMLElement("table")}}). |
 | {{HTMLElement("td")}}       | El elemento [HTML](/es/docs/Web/HTML) _Celda de tabla_ (**`<td>`**) define la celda de una tabla que contiene datos. Esta participa en el _modelo de tablas_. |
-| {{HTMLElement("tfoot")}}    | Defines a set of rows summarizing the columns of the table. |
+| {{HTMLElement("tfoot")}}    | Define un conjunto de filas que resumen las columnas de la tabla. |
 | {{HTMLElement("th")}}       | El elemento **HTML `<th>`** define una celda como encabezado de un grupo de celdas en una tabla. La naturaleza exacta de este grupo está definida por los atributos {{htmlattrxref("scope", "th")}} y {{htmlattrxref("headers", "th")}}. |
-| {{HTMLElement("thead")}}    | Defines a set of rows defining the head of the columns of the table. |
+| {{HTMLElement("thead")}}    | Define un conjunto de filas que definen el encabezado de las columnas de la tabla. |
 | {{HTMLElement("tr")}}       | El elemento HTML _fila de tabla_ (_table row_) `<tr>` define una fila de celdas en una tabla. Estas pueden ser una mezcla de elementos {{HTMLElement("td")}} y {{HTMLElement("th")}}. |
 
 ## Formularios
@@ -192,10 +192,10 @@ HTML provee un número de elementos que pueden usarse conjuntamente para crear f
 | {{HTMLElement("input")}}    | El elemento HTML `<input>` se usa para crear controles interactivos para formularios basados en la web con el fin de recibir datos del usuario.Hay disponible una amplia variedad de tipos de datos de entrada y widgets de control, que dependen del dispositivo y el agente de usuario ([user agent](/es/docs/Glossary/user_agent)).El elemento `<input>` es uno de los más potentes y complejos en todo HTML debido a la gran cantidad de combinaciones de tipos y atributos de entrada. |
 | {{HTMLElement("label")}}    | El **Elemento HTML `<label>`** representa una etiqueta para un elemento en una interfaz de usuario. Este puede estar asociado con un control ya sea mediante la utilizacion del atributo for, o ubicando el control dentro del elemento label. Tal control es llamado "el control etiquetado" del elemento label. |
 | {{HTMLElement("legend")}}   | **Sus etiquetas son**: \<legend> y \</legend> (ambas obligatorias). |
-| {{HTMLElement("meter")}}    | Represents either a scalar value within a known range or a fractional value. |
-| {{HTMLElement("optgroup")}} | Creates a grouping of options within a {{HTMLElement("select")}} element. |
+| {{HTMLElement("meter")}}    | Representa un valor escalar dentro de un rango conocido o un valor fraccionario. |
+| {{HTMLElement("optgroup")}} | Crea una agrupación de opciones dentro de un elemento {{HTMLElement("select")}}. |
 | {{HTMLElement("option")}}   | En un formulario Web , el **elemento** **HTML `<option>`** se usa para representar un item dentro de un {{HTMLElement("select")}}, un {{HTMLElement("optgroup")}} o un elemento HTML5 {{HTMLElement("datalist")}} . |
-| {{HTMLElement("output")}}   | Container element into which a site or app can inject the results of a calculation or the outcome of a user action. |
+| {{HTMLElement("output")}}   | Elemento contenedor en el que un sitio o aplicación puede inyectar los resultados de un cálculo o el resultado de una acción del usuario. |
 | {{HTMLElement("progress")}} | La etiqueta **HTML `<progress>`** se utiliza para visualizar el progreso de una tarea. Aunque los detalles de como se muestran depende directamente del navegador que utiliza el cliente, aunque básicamente aparece una barra de progreso. |
 | {{HTMLElement("select")}}   | El elemento select (`<select>`) de HTML representa un control que muestra un menú de opciones. Las opciones contenidas en el menú son representadas por elementos {{HTMLElement("option")}}, los cuales pueden ser agrupados por elementos {{HTMLElement("optgroup")}}. La opcion puede estar preseleccionada por el usuario. |
 | {{HTMLElement("textarea")}} | El **elemento** **HTML `<textarea>`** representa un control para la edición mutilínea de texto sin formato. |
@@ -208,7 +208,7 @@ HTML ofrece una selección de elementos que pueden ayudar a crear objetos de int
 | ------- | ----------- |
 | {{HTMLElement("details")}} | El elemento HTML Details **\<details>** es usado como un widget de revelación a través del cual el usuario puede obtener información adicional . |
 | {{HTMLElement("dialog")}}  | El **elemento** **HTML `<dialog>`** representa una caja de diálogo u otro componente interactivo, como inspector o ventana. |
-| {{HTMLElement("summary")}} | Specifies a summary, caption, or legend for a details element's disclosure box. Clicking the `<summary>` element toggles the state of the parent {{HTMLElement("details")}} element open and closed. |
+| {{HTMLElement("summary")}} | Especifica un resumen, un título o una leyenda para el cuadro de información de un elemento de detalles. Al hacer clic en el elemento `<summary>`, el estado del elemento principal {{HTMLElement("details")}} se abre y se cierra. |
 
 ## Componentes Web
 
@@ -225,30 +225,30 @@ Los Componentes Web son una tecnología relacionada con HTML que hacen que sea p
 
 | Element | Description |
 | ------- | ----------- |
-| {{HTMLElement("acronym")}}   | **acromym** de acromyn=acrónimo |
+| {{HTMLElement("acronym")}}   | Permite a los autores indicar claramente una secuencia de caracteres que componen un acrónimo o abreviatura de una palabra. |
 | {{HTMLElement("applet")}}    | **Sus etiquetas son**: \<applet> y \</applet> (ambas obligatorias) |
 | {{HTMLElement("bgsound")}}   | El elemento HTML de sonido de fondo (\<bgsound>) es un elemento de Internet Explorer que asocia un sonido de fondo con un página . |
 | {{HTMLElement("big")}}       | **big** de big=grande |
 | {{HTMLElement("blink")}}     | El elemento HTML blink (`<blink>`) no es un elemento estándar que causa que el texto encerrado parpadee lentamente . |
 | {{HTMLElement("center")}}    | **Sus etiquetas son**: \<center> y \</center> (ambas obligatorias). |
-| {{HTMLElement("content")}}   | El elemento [HTML](/es/docs/Web/HTML) `<content>` es usado dentro de un [Shadow DOM](/es/docs/Web/Web_Components/Using_shadow_DOM) como un {{glossary("insertion point")}} . No está pensado para ser usado en HTML ordinario . Es usado con [Web Components](/es/docs/Web/Web_Components). |
+| {{HTMLElement("content")}}   | El elemento [HTML](/es/docs/Web/HTML) `<content>` es usado dentro de un [Shadow DOM](/es/docs/Web/Web_Components/Using_shadow_DOM) como un punto de inserción . No está pensado para ser usado en HTML ordinario . Es usado con [Web Components](/es/docs/Web/Web_Components). |
 | {{HTMLElement("dir")}}       | **Sus etiquetas son**: \<dir> y \</dir> (ambas obligatorias). |
 | {{HTMLElement("font")}}      | **Sus etiquetas son**: \<font> y \</font> (ambas obligatorias). |
 | {{HTMLElement("frame")}}     | **Sus etiquetas son**: `<frame>` (solo tiene una). |
 | {{HTMLElement("frameset")}}  | **Sus etiquetas son**: `<frameset>` y `</frameset>` (ambas obligatorias). |
-| {{HTMLElement("image")}}     | El _elemento de grupo de cabeceras HTML_ (\<hgroup>) representa el encabezado de una sección. Define un solo título que participa de [la estructura del documento](/en/Sections_and_Outlines_of_an_HTML5_document) como el encabezado de la sección implícita o explícita a la que pertenece. |
-| {{HTMLElement("keygen")}}    | El elemento HTML `<image>` fue un elemento experimental diseñado para mostrar imágenes . Nuca fue implementado y el elemento estándar {{HTMLElement("img")}} debe de ser usado . |
-| {{HTMLElement("marquee")}}   | El elemento `keygen` de HTML existe para facilitar la generación de llaves, y el envío de la clave pública como parte de un formulario HTML. Este mecanismo está diseñado para utilizarse con sistemas de gestión de certificados basados en la Web. Se espera que el elemento `keygen` se utilice en un formulario HTML, junto con otra información necesaria para la construcción de una solicitud de certificado, y que el resultado del proceso será un certificado firmado. |
-| {{HTMLElement("menuitem")}}  | La etiqueta html `<marquee>` se utiliza para insertar un area de texto en movimiento. También se la conoce como marquesina. |
-| {{HTMLElement("nobr")}}      | Prevents the text it contains from automatically wrapping across multiple lines, potentially resulting in the user having to scroll horizontally to see the entire width of the text. |
-| {{HTMLElement("noembed")}}   | El elemento HTML `<nobr>` previene que una línea de texto se divida en una nueva línea, así, se presentará en una línea larga por lo que puede ser necesario hacer un desplazamiento de pantalla. Esta etiqueta no es un estándar HTML y no debería ser usada, en su lugar use la propiedad CSS {{Cssxref("white-space")}} como en este ejemplo: |
-| {{HTMLElement("noframes")}}  | Provides content to be presented in browsers that don't support (or have disabled support for) the {{HTMLElement("frame")}} element. Although most commonly-used browsers support frames, there are exceptions, including certain special-use browsers including some mobile browsers, as well as text-mode browsers. |
-| {{HTMLElement("param")}}     | **Sus etiquetas son**: `<noframes>` y `</noframes>` (ambas obligatorias). |
-| {{HTMLElement("plaintext")}} | **Sus etiquetas son**: `<param>` (solo tiene una). |
-| {{HTMLElement("rb")}}        | Used to delimit the base text component of a ruby annotation, i.e. the text that is being annotated. One `<rb>` element should wrap each separate atomic segment of the base text. |
-| {{HTMLElement("rtc")}}       | Embraces semantic annotations of characters presented in a ruby of {{HTMLElement("rb")}} elements used inside of {{HTMLElement("ruby")}} element. {{HTMLElement("rb")}} elements can have both pronunciation ({{HTMLElement("rt")}}) and semantic ({{HTMLElement("rtc")}}) annotations. |
-| {{HTMLElement("shadow")}}    | An obsolete part of the [Web Components](/es/docs/Web/Web_Components) technology suite that was intended to be used as a shadow DOM insertion point. You might have used it if you have created multiple shadow roots under a shadow host. |
-| {{HTMLElement("spacer")}}    | Allows insertion of empty spaces on pages. It was devised by Netscape to accomplish the same effect as a single-pixel layout image, which was something web designers used to use to add white spaces to web pages without actually using an image. However, `<spacer>` is no longer supported by any major browser and the same effects can now be achieved using simple CSS. |
-| {{HTMLElement("strike")}}    | Places a strikethrough (horizontal line) over text. |
-| {{HTMLElement("tt")}}        | **Sus etiquetas son**: \<strike> y \</strike> (Ambas obligatorias) |
-| {{HTMLElement("xmp")}}       | **Sus etiquetas son**: \<tt> y \</tt> (Ambas obligatorias) |
+| {{HTMLElement("image")}}     | El elemento HTML `<image>` fue un elemento experimental diseñado para mostrar imágenes . Nuca fue implementado y el elemento estándar {{HTMLElement("img")}} debe de ser usado . |
+| {{HTMLElement("keygen")}}    | El elemento `keygen` de HTML existe para facilitar la generación de llaves, y el envío de la clave pública como parte de un formulario HTML. Este mecanismo está diseñado para utilizarse con sistemas de gestión de certificados basados en la Web. Se espera que el elemento `keygen` se utilice en un formulario HTML, junto con otra información necesaria para la construcción de una solicitud de certificado, y que el resultado del proceso será un certificado firmado. |
+| {{HTMLElement("marquee")}}   | La etiqueta html `<marquee>` se utiliza para insertar un area de texto en movimiento. También se la conoce como marquesina. |
+| {{HTMLElement("menuitem")}}  | Representa un comando que un usuario puede invocar a través de un menú emergente. Esto incluye menús contextuales, así como menús que pueden adjuntarse a un botón de menú. |
+| {{HTMLElement("nobr")}}      | El elemento HTML `<nobr>` previene que una línea de texto se divida en una nueva línea, así, se presentará en una línea larga por lo que puede ser necesario hacer un desplazamiento de pantalla. Esta etiqueta no es un estándar HTML y no debería ser usada, en su lugar use la propiedad CSS {{Cssxref("white-space")}} como en este ejemplo: |
+| {{HTMLElement("noembed")}}   | Proporciona contenido para ser presentado en navegadores que no admiten (o han desactivado la compatibilidad) con el elemento {{HTMLElement("frame")}}. Aunque los navegadores más utilizados admiten marcos, existen excepciones, incluidos ciertos navegadores de uso especial, incluidos algunos navegadores móviles, así como navegadores en modo texto. |
+| {{HTMLElement("noframes")}}  | **Sus etiquetas son**: `<noframes>` y `</noframes>` (ambas obligatorias). |
+| {{HTMLElement("param")}}     | **Sus etiquetas son**: `<param>` (solo tiene una). |
+| {{HTMLElement("plaintext")}} | Muestra todo lo que sigue a la etiqueta de inicio como texto sin formato, ignorando cualquier código HTML siguiente. No hay una etiqueta de cierre, ya que todo lo que sigue se considera texto sin formato. |
+| {{HTMLElement("rb")}}        | Se utiliza para delimitar el componente de texto base de una anotación Ruby, es decir, el texto que se está anotando. Un elemento `<rb>` debe envolver cada segmento atómico separado del texto base. |
+| {{HTMLElement("rtc")}}       | Adopta anotaciones semánticas de caracteres presentados en un rubí de elementos {{HTMLElement("rb")}} utilizados dentro del elemento {{HTMLElement("ruby")}}. Los elementos {{HTMLElement("rb")}} pueden tener anotaciones de pronunciación ({{HTMLElement("rt")}}) y semánticas ({{HTMLElement("rtc")}}). |
+| {{HTMLElement("shadow")}}    | Una parte obsoleta de la suite de tecnología de [Componentes Web](/es/docs/Web/Web_Components) que estaba pensada para ser utilizada como un punto de inserción en el shadow DOM. Es posible que lo haya utilizado si ha creado varias raíces ocultas en un host oculto. |
+| {{HTMLElement("spacer")}}    | Permite la inserción de espacios vacíos en las páginas. Fue diseñado por Netscape para lograr el mismo efecto que una imagen de diseño de un solo píxel, que era algo que los diseñadores web solían usar para agregar espacios en blanco a las páginas web sin usar realmente una imagen. Sin embargo, `<spacer>` ya no es compatible con ninguno de los principales navegadores y ahora se pueden lograr los mismos efectos usando CSS simple. |
+| {{HTMLElement("strike")}}    | Coloca un tachado (línea horizontal) sobre el texto. |
+| {{HTMLElement("tt")}}        | **Sus etiquetas son**: \<tt> y \</tt> (Ambas obligatorias) |
+| {{HTMLElement("xmp")}}       | Muestra el texto entre las etiquetas de inicio y finalización sin interpretar el HTML intermedio y utilizando una fuente monoespaciada. La especificación HTML2 recomendaba que se representara lo suficientemente ancho como para permitir 80 caracteres por línea. |

--- a/files/es/web/html/element/index.md
+++ b/files/es/web/html/element/index.md
@@ -54,6 +54,41 @@ Además de los contenidos multimedia habituales, HTML puede incluir otra varieda
 
 {{HTMLRefTable({"include":["HTML embedded content"], "exclude":["multimedia"]})}}
 
+## SVG and MathML
+
+You can embed [SVG](/en-US/docs/Web/SVG) and [MathML](/en-US/docs/Web/MathML) content directly into HTML documents, using the {{SVGElement("svg")}} and {{MathMLElement("math")}} elements.
+
+<table class="no-markdown">
+  <thead>
+    <tr>
+      <th scope="col">Element</th>
+      <th scope="col">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{SVGElement("svg")}}</td>
+      <td>
+        The <code>svg</code> element is a container that defines a new
+        coordinate system and
+        <a href="/en-US/docs/Web/SVG/Attribute/viewBox">viewport</a>. It is used
+        as the outermost element of SVG documents, but it can also be used to
+        embed an SVG fragment inside an SVG or HTML document.
+      </td>
+    </tr>
+    <tr>
+      <td>{{MathMLElement("math")}}</td>
+      <td>
+        The top-level element in MathML is <code>&#x3C;math></code>. Every valid
+        MathML instance must be wrapped in <code>&#x3C;math></code> tags. In
+        addition you must not nest a second <code>&#x3C;math></code> element in
+        another, but you can have an arbitrary number of other child elements in
+        it.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 ## Scripting
 
 Con el fin de crear contenido dinámico y aplicaciones Web, HTML soporta el uso de lenguajes de scripting, el más prominente es JavaScript. Ciertos elementos soportan esta capacidad.

--- a/files/es/web/html/element/index.md
+++ b/files/es/web/html/element/index.md
@@ -12,112 +12,203 @@ Esta página lista todos los {{Glossary("Element","elementos")}} {{Glossary("HTM
 
 ## Raíz principal
 
-{{HTMLRefTable("HTML Root Element")}}
+| Element | Description |
+| ------- | ----------- |
+| {{HTMLElement("html")}} | El **elemento HTML `<html>`** (o _elemento HTML raiz_) representa la raiz de un documento HTML. El resto de elementos descienden de este elemento. |
 
 ## Metadatos del documento
 
 Los metadatos contienen información sobre la página. Esto incluye información sobre estilos, _scripts_ y datos que ayudan al _software_ ({{Glossary("search engine", "search engines")}}, {{Glossary("Browser","browsers")}}, etc.) a usar y generar la página. Los metadatos de estilos y _scripts_ pueden estar definidos en la página o estar enlazados a otro fichero que contiene la información.
 
-{{HTMLRefTable("HTML Document Metadata")}}
+| Element | Description |
+| ------- | ----------- |
+| {{HTMLElement("base")}}  | El **elemento HTML `<base>`** especifica la dirección URL base que se utilizará para todas las direcciones URL relativas contenidas dentro de un documento. Sólo puede haber un elemento \<base> en un documento. |
+| {{HTMLElement("head")}}  | El **elemento HTML `<head>`** provee información general (metadatos) acerca del documento, incluyendo su título y enlaces a scripts y hojas de estilos. |
+| {{HTMLElement("link")}}  | El **elemento HTML `<link>`** especifica la relación entre el documento actual y un recurso externo. Los usos posibles de este elemento incluyen la definición de un marco relacional para navegación. Este elemento es más frecuentemente usado para enlazar hojas de estilos. |
+| {{HTMLElement("meta")}}  | **Sus etiquetas son**: `<meta>` (solo tiene una). |
+| {{HTMLElement("style")}} | **Sus etiquetas son**: `<style>` y `</style>` (ambas obligatorias). |
+| {{HTMLElement("title")}} | El elemento **`<title>`** [HTML](/es/docs/Web/HTML) define el título del documento que se muestra en un {{glossary("Browser", "browser")}} la barra de título o la pestaña de una página. Solo contiene texto; las etiquetas dentro del elemento se ignoran. |
 
 ## Seccionamiento básico
 
-{{HTMLRefTable("Sectioning Root Element")}}
+| Element | Description |
+| ------- | ----------- |
+| {{HTMLElement("body")}} | El **elemento `<body>` de HTML** representa el contenido de un documento HTML. Solo puede haber un elemento `<body>` en un documento. |
 
 ## Seccionamiento del contenido
 
 Los elementos de seccionamiento del contenido te permiten organizar los contenidos del documento en partes lógicas. Usa los elementos de seccionado para crear una descripción amplia de los contenidos de tu página, incluyendo el encabezado y pie de página y elementos para identificar secciones.
 
-{{HTMLRefTable("HTML Sections")}}
+| Element | Description |
+| ------- | ----------- |
+| {{HTMLElement("address")}}                                                                                                                                                                                                                                                                                                                           | El **elemento HTML `<address>`** aporta información de contacto para su {{HTMLElement("article")}} más cercano o ancestro {{HTMLElement("body")}}; en el último caso lo aplica a todo el documento. |
+| {{HTMLElement("article")}}                                                                                                                                                                                                                                                                                                                           | El Elemento de HTML **`<article>`** representa una composición auto-contenida en un documento, una página, una aplicación o en un sitio, que se quiere que sea distribuíble y/o reutilizable de manera independiente, por ejemplo, en la redifusión. Algunos ejemplos podrían ser un mensaje en un foro, un artículo de una revista o un periódico, una entrada de blog, el comentario de un usuario, un widget o gadget interactivo, o cualquier otro elemento de contenido independiente. |
+| {{HTMLElement("aside")}}                                                                                                                                                                                                                                                                                                                             | El **elemento HTML `<aside>`** representa una sección de una página que consiste en contenido que está indirectamente relacionado con el contenido principal del documento. Estas secciones son a menudo representadas como barras laterales o como inserciones y contienen una explicación al margen como una definición de glosario, elementos relacionados indirectamente, como publicidad, la biografía del autor, o en aplicaciones web, la información de perfil o enlaces a blogs relacionados. |
+| {{HTMLElement("footer")}}                                                                                                                                                                                                                                                                                                                            | El _Elemento_ _HTML Footer_ (`<footer>`) representa un pie de página para el contenido de sección más cercano o el elemento [raíz de sección](/en/Sections_and_Outlines_of_an_HTML5_document#sectioning_root) (p.e, su ancestro mas cercano [`<article>`](/es/HTML/Element/article), [`<aside>`](/es/HTML/Element/aside), [`<nav>`](/es/HTML/Element/nav), [`<section>`](/es/HTML/Element/section),[`<blockquote>`](/es/HTML/Element/blockquote), [`<body>`](/es/HTML/Element/body), [`<details>`](/es/HTML/Element/details), [`<fieldset>`](/es/HTML/Element/fieldset), [`<figure>`](/es/HTML/Element/figure), [`<td>`](/es/HTML/Element/td)). Un pie de página típicamente contiene información acerca de el autor de la sección, datos de derechos de autor o enlaces a documentos relacionados. |
+| {{HTMLElement("header")}}                                                                                                                                                                                                                                                                                                                            | El _elemento de HTML Header_ (\<header>) representa un grupo de ayudas introductorias o de navegación. Puede contener algunos elementos de encabezado, así como también un logo, un formulario de búsqueda, un nombre de autor y otros componentes. |
+| [`<h1>`](/es/docs/Web/HTML/Element/Heading_Elements), [`<h2>`](/es/docs/Web/HTML/Element/Heading_Elements), [`<h3>`](/es/docs/Web/HTML/Element/Heading_Elements), [`<h4>`](/es/docs/Web/HTML/Element/Heading_Elements), [`<h5>`](/es/docs/Web/HTML/Element/Heading_Elements), [`<h6>`](/es/docs/Web/HTML/Element/Heading_Elements) | Los elementos de **encabezado** implementan seis niveles de encabezado del documento, `<h1>` es el más importante, y `<h6>`, el menos importante. Un elemento de encabezado describe brevemente el tema de la sección que presenta. La información de encabezado puede ser usada por los agentes usuarios, por ejemplo, para construir una tabla de contenidos para un documento automáticamente. |
+| {{HTMLElement("main")}}                                                                                                                                                                                                                                                                                                                              | El **elemento HTML `<main>`** representa el contenido principal del {{HTMLElement("body")}} de un documento o aplicación. El área principal del contenido consiste en el contenido que está directamente relacionado, o se expande sobre el tema central de un documento o la funcionalidad central de una aplicación. Este contenido debe ser único al documento, excluyendo cualquier contenido que se repita a través de un conjunto de documentos como barras laterales, enlaces de navegación, información de derechos de autor, logos del sitio y formularios de búsqueda (a menos, claro, que la función principal del documento sea un formulario de búsqueda). |
+| {{HTMLElement("nav")}}                                                                                                                                                                                                                                                                                                                               | El **elemento** **HTML `<nav>`** representa una sección de una página cuyo propósito es proporcionar enlaces de navegación, ya sea dentro del documento actual o a otros documentos. Ejemplos comunes de secciones de navegación son menús, tablas de contenido e índices. |
+| {{HTMLElement("section")}}                                                                                                                                                                                                                                                                                                                           | El elemento de _HTML section_ (`<section>`) representa una sección genérica de un documento. Sirve para determinar qué contenido corresponde a qué parte de un esquema. Piensa en el esquema como en el índice de contenido de un libro; un tema común y subsecciones relacionadas. Es, por lo tanto, una etiqueta semántica. Su funcionalidad principal es estructurar semánticamente un documento a la hora de ser representado por parte de un agente usuario. Por ejemplo, un agente de usuario que represente el documento en voz, podría exponer al usuario el índice de contenido por niveles para navegar rápidamente por las distintas partes. |
 
 ## Contenido del texto
 
 Utiliza los elementos HTML de contenido del texto para organizar bloques o secciones de contenido colocados entre los tags de apertura{{HTMLElement("body")}} y cierre. Es importante para la {{Glossary("accessibility")}} y el {{Glossary("SEO")}}, que estos elementos se identifiquen con el objetivo o la estructura de ese contenido.
 
-{{HTMLRefTable("HTML Grouping Content")}}
+| Element | Description |
+| ------- | ----------- |
+| {{HTMLElement("blockquote")}} | **Sus etiquetas son**: `<blockquote>` y `</blockquote>` (ambas obligatorias). |
+| {{HTMLElement("dd")}}         | El **elemento HTML `<dd>`** provee detalles acerca de o la definición de un término precedente ({{HTMLElement("dt")}}) en una lista de descripciones ({{HTMLElement("dl")}}). |
+| {{HTMLElement("div")}}        | **Sus etiquetas son**: `<div>` y `</div>` (ambas obligatorias). |
+| {{HTMLElement("dl")}}         | El elemento **HTML `<dl>`** representa una lista descriptiva. El elemento encierra una lista de grupos de términos (especificados con el uso del elemento {{HTMLElement("dt")}}) y de descripciones (proveídas con elementos {{HTMLElement("dd")}}). Algunos usos comunes para este elemento son implementar un glosario o para desplegar metadatos (lista de pares llave-valor). |
+| {{HTMLElement("dt")}}         | El **elemento HTML `<dt>`** especifica un término en una descripción o lista de definiciones, y como tal debe utilizarse dentro de un elemento {{HTMLElement("dl")}} Es usualmente seguido por un elemento {{HTMLElement("dd")}}; sin embargo, múltiples elementos `<dt>` en un renglón indican diferentes términos los cuales todos son definidos por el siguiente elemento {{HTMLElement("dd")}}. |
+| {{HTMLElement("figcaption")}} | El elemento **HTML `<figcaption>`** representa un subtítulo o leyenda asociado al contenido del elemento padre {{HTMLElement("figure")}}, pudiendo ser colocado como primer o último hijo. Es importante destacar que el elemento **`<figcaption>`** es opcional. |
+| {{HTMLElement("figure")}}     | El _elemento HTML_ \<figure> representa contenido independiente, a menudo con un título. Si bien se relaciona con el flujo principal, su posición es independiente de éste. Por lo general, se trata de una imagen, una ilustración, un diagrama, un fragmento de código, o un esquema al que se hace referencia en el texto principal, pero que se puede mover a otra página o a un apéndice sin que afecte al flujo principal. |
+| {{HTMLElement("hr")}}         | **Sus etiquetas son**: `<hr/>` (solo tiene una). |
+| {{HTMLElement("li")}}         | **Sus etiquetas son**: \<li> y \</li> (la de cierre es opcional). |
+| {{HTMLElement("menu")}}       | **Sus etiquetas son**: \<menu> y \</menu> (ambas obligatorias). |
+| {{HTMLElement("ol")}}         | **Sus etiquetas son**: \<ol> y \</ol> (ambas obligatorias). |
+| {{HTMLElement("p")}}          | **Sus etiquetas son**: \<p> y \</p> (la de cierre es opcional). |
+| {{HTMLElement("pre")}}        | El **Elemento** **HTML \<pre>** (o _Texto HTML Preformateado_) representa texto preformateado. El texto en este elemento típicamente se muestra en una fuente fija, no proporcional, exactamente como es mostrado en el archivo. Los espacios dentro de este elemento también son mostrados como están escritos. |
+| {{HTMLElement("ul")}}         | **Sus etiquetas son**: `<ul> y </ul>` (ambas obligatorias). |
 
 ## Semántica del texto en línea
 
 Utilice la semántica del texto en línea HTML para definir el significado, estructura, o el estilo de una palabra, una línea o cualquier pieza arbitraria de texto.
 
-{{HTMLRefTable("HTML Text-Level Semantics")}}
+| Element | Description |
+| ------- | ----------- |
+| {{HTMLElement("a")}}      | El _Elemento HTML `Anchor`_ **`<a>`** crea un enlace a otras páginas de internet, archivos o ubicaciones dentro de la misma página, direcciones de correo, o cualquier otra URL. |
+| {{HTMLElement("abbr")}}   | El **elemento HTML `<abbr>`** (_o Elemento de Abreviación HTML_) representa una abreviación o acrónimo; el atributo opcional {{htmlattrxref("title")}} puede ampliar o describir la abreviatura. Si está presente, el atributo `title` debe contener la descripción completa y nada más. |
+| {{HTMLElement("b")}}      | **b** de bold=negrita. |
+| {{HTMLElement("bdi")}}    | El elemento _HTML `<bdi>`_ (o elemento de aislamiento Bi-Direccional) aisla un trozo de texto para que pueda ser formateado con una dirección diferente al texto que hay fuera de él. |
+| {{HTMLElement("bdo")}}    | **bdo** Bi-Directional Overriding=Anulación de bidireccionalidad. |
+| {{HTMLElement("br")}}     | El elemento HTML _line break_ `<br>` produce un salto de línea en el texto (retorno de carro). Es útil para escribir un poema o una dirección, donde la división de las líneas es significante. |
+| {{HTMLElement("cite")}}   | **Sus etiquetas son**: \<cite> y \</cite> (ambas obligatorias) |
+| {{HTMLElement("code")}}   | **Sus etiquetas son**: \<code> y \</code> (ambas obligatorias) |
+| {{HTMLElement("data")}}   | El **Elemento HTML `<data>`** vincula un contenido dado con una traducción legible por una máquina. Si el contenido está relacionado con `time-` o `date-`, debe usarse el elemento {{HTMLElement("time")}}. |
+| {{HTMLElement("dfn")}}    | **Sus etiquetas son**: \<dfn> y \</dfn> (ambas obligatorias) |
+| {{HTMLElement("em")}}     | El **elemento HTML `<em>`** es el apropiado para marcar con énfasis las partes importantes de un texto. El elemento `<em>` puede ser anidado, con cada nivel de anidamiento indicando un mayor grado de énfasis. |
+| {{HTMLElement("i")}}      | **Sus etiquetas son**: \<i> y \</i> (Ambas obligatorias) |
+| {{HTMLElement("kbd")}}    | **Sus etiquetas son**: \<kbd> y \</kbd> (ambas obligatorias) |
+| {{HTMLElement("mark")}}   | El **Elemento HTML Mark `<mark>`** representa un texto **marcado** o **resaltado** como referencia o anotación, debido a su relevancia o importancia en un contexto particular. |
+| {{HTMLElement("q")}}      | El **elemento HTML `<q>`** indica que el texto adjunto es una cita corta en línea. La mayoría de los navegadores modernos implementan esto rodeando el texto entre comillas. Este elemento está destinado a citas breves que no requieren saltos de párrafo; para citas de bloque independiente, utiliza el elemento {{HTMLElement("blockquote")}}. |
+| {{HTMLElement("rp")}}     | Used to provide fall-back parentheses for browsers that do not support display of ruby annotations using the {{HTMLElement("ruby")}} element. One `<rp>` element should enclose each of the opening and closing parentheses that wrap the {{HTMLElement("rt")}} element that contains the annotation's text. |
+| {{HTMLElement("rt")}}     | Specifies the ruby text component of a ruby annotation, which is used to provide pronunciation, translation, or transliteration information for East Asian typography. The `<rt>` element must always be contained within a {{HTMLElement("ruby")}} element. |
+| {{HTMLElement("ruby")}}   | Represents small annotations that are rendered above, below, or next to base text, usually used for showing the pronunciation of East Asian characters. It can also be used for annotating other kinds of text, but this usage is less common. |
+| {{HTMLElement("s")}}      | **Sus etiquetas son**: \<s> y \</s> (Ambas obligatorias) |
+| {{HTMLElement("samp")}}   | El elemento HTML Sample (**`<samp>`**) se utiliza para incluir texto en línea que representa una muestra (o cita) de la salida de un programa de ordenador. El contenido de esta etiqueta es renderizado generalmente usando la tipografía monoespaciada por defecto del navegador. |
+| {{HTMLElement("small")}}  | El **elemento HTML \<small>** hace el tamaño del texto una talla más pequeña (por ejemplo, de largo a mediano, o de pequeño a extra pequeño) que el tamaño mínimo de fuente del navegador. En HTML5, este elemento es reutilizado para representar comentarios laterales y letra pequeña, incluyendo derechos de autor y texto legal, independientemente de su estilo de presentación. |
+| {{HTMLElement("span")}}   | **Sus etiquetas son**: `<span>` y `</span>` (ambas obligatorias). |
+| {{HTMLElement("strong")}} | **Sus etiquetas son**: \<strong> y \</strong> (ambas obligatorias) |
+| {{HTMLElement("sub")}}    | El **elemento HTML** \<sub> define un fragmento de texto que se debe mostrar, por razones tipográficas, más bajo, y generalmente más pequeño, que el tramo principal del texto, es decir, en subíndice. |
+| {{HTMLElement("sup")}}    | El **elemento HTML** \<sup> define un fragmento de texto que se debe mostrar, por razones tipográficas, más alto, y generalmente más pequeño, que el tramo principal del texto, es decir, en superíndice. |
+| {{HTMLElement("time")}}   | El **elemento HTML `<time>`** representa un periodo específico en el tiempo. Puede incluir el atributo `datetime` para convertir las fechas en un formato interno legible por un ordenador, permitiendo mejores resultados en los motores de búsqueda o características personalizadas como recordatorios. |
+| {{HTMLElement("u")}}      | **Sus etiquetas son**: \<u> y \</u> (Ambas obligatorias) |
+| {{HTMLElement("var")}}    | **Sus etiquetas son**: \<var> y \</var> (ambas obligatorias) |
+| {{HTMLElement("wbr")}}    | El elemento HTML _word break opportunity_ `<wbr>` representa una posición dentro del texto donde el explorador puede opcionalmente saltar una línea , aunque sus reglas de salto de línea de otra manera no crearían un salto en esa posición .En páginas codificadas en UTF-8 , \<wbr> se comporta como el punto de código `U+200B ZERO-WIDTH SPACE`. En particular se comporta como un punto de código unicode bidi BN , significando esto que no tiene efecto en ordenamiento bidi : `<div dir=rtl>123,<wbr>456</div>` muestra , cuando no se rompa en dos líneas , 123, 456 y no 456 , 123 . |
 
 ## Imagen y multimedia
 
 HTML soporta varios recursos multimedia como imágenes, audio, y video.
 
-{{HTMLRefTable("multimedia")}}
+| Element | Description |
+| ------- | ----------- |
+| {{HTMLElement("area")}}  | **area** de area=área |
+| {{HTMLElement("audio")}} | El elemento `audio` se usa para insertar contenido de audio en un documento HTML o XHTML. El elemento `audio` se agregó como parte de HTML 5. |
+| {{HTMLElement("img")}}   | El elemento de imagen HTML **`<img>`** representa una imagen en el documento. |
+| {{HTMLElement("map")}}   | **Sus etiquetas son**: \<map> y \</map> (ambas obligatorias). |
+| {{HTMLElement("track")}} | El elemento [HTML](/es/docs/Web/HTML) **`<track>`** se utiliza como elemento hijo de los elementos multimedia, {{HTMLElement("audio")}} y {{HTMLElement("video")}}. Le permite especificar pistas de texto cronometradas (o datos basados en el tiempo), por ejemplo, para manejar subtítulos automáticamente. Las pistas están formateadas en [formato WebVTT](/es/docs/Web/API/WebVTT_API) (archivos `.vtt`): _Web Video Text Tracks_ (pistas de texto de video web). |
+| {{HTMLElement("video")}} | El elemento `video` se utiliza para incrustar vídeos en un documento HTML o XHTML. |
 
 ## Contenido incrustado
 
 Además de los contenidos multimedia habituales, HTML puede incluir otra variedad de contenidos, aunque no siempre es fácil de interactuar con ellos.
 
-{{HTMLRefTable({"include":["HTML embedded content"], "exclude":["multimedia"]})}}
+| Element | Description |
+| ------- | ----------- |
+| {{HTMLElement("embed")}}   | > **Nota:** este tema documenta sólo el elemento \<embed> que se define como parte de HTML5. No trata las implementaciones anteriores no estandarizadas del elemento `<embed>`. |
+| {{HTMLElement("iframe")}}  | El **elemento HTML `<iframe>`** (de inline frame) representa un {{Glossary("contexto de navegación")}} anidado, el cual permite incrustrar otra página HTML en la página actual. |
+| {{HTMLElement("object")}}  | El **elemento HTML `<object>`** representa un recurso externo, que puede ser tratado como una imagen, un contexto de navegación anidado, o como un recurso que debe ser manejado por un plugin. |
+| {{HTMLElement("picture")}} | El **elemento HTML `<picture>`** es un contenedor usado para especificar múltiples elementos {{HTMLElement("source")}} y un elemento {{HTMLElement("img")}} contenido en él para proveer versiones de una imagen para diferentes escenarios de dispositivos. Si no hay coincidencias con los elementos `<source>`, el archivo especificado en los atributos {{htmlattrxref("src", "img")}} del elemento `<img>` es utilizado. La imagen seleccionada es entonces presentada en el espacio ocupado por el elemento `<img>`. |
+| {{HTMLElement("portal")}}  | Enables the embedding of another HTML page into the current one for the purposes of allowing smoother navigation into new pages. |
+| {{HTMLElement("source")}}  | El **elemento HTML `<source>`** especifica recursos de medios múltiples para los elementos {{HTMLElement("picture")}}, {{HTMLElement("audio")}}, o {{HTMLElement("video")}}. Es un elemento vacío. Normalmente se utiliza para servir el mismo contenido multimedia en [varios formatos soportados por diferentes navegadores](/es/docs/Media_formats_supported_by_the_audio_and_video_elements). |
 
 ## SVG and MathML
 
-You can embed [SVG](/en-US/docs/Web/SVG) and [MathML](/en-US/docs/Web/MathML) content directly into HTML documents, using the {{SVGElement("svg")}} and {{MathMLElement("math")}} elements.
+You can embed [SVG](/es/docs/Web/SVG) and [MathML](/es/docs/Web/MathML) content directly into HTML documents, using the {{SVGElement("svg")}} and {{MathMLElement("math")}} elements.
 
-<table class="no-markdown">
-  <thead>
-    <tr>
-      <th scope="col">Element</th>
-      <th scope="col">Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{SVGElement("svg")}}</td>
-      <td>
-        The <code>svg</code> element is a container that defines a new
-        coordinate system and
-        <a href="/en-US/docs/Web/SVG/Attribute/viewBox">viewport</a>. It is used
-        as the outermost element of SVG documents, but it can also be used to
-        embed an SVG fragment inside an SVG or HTML document.
-      </td>
-    </tr>
-    <tr>
-      <td>{{MathMLElement("math")}}</td>
-      <td>
-        The top-level element in MathML is <code>&#x3C;math></code>. Every valid
-        MathML instance must be wrapped in <code>&#x3C;math></code> tags. In
-        addition you must not nest a second <code>&#x3C;math></code> element in
-        another, but you can have an arbitrary number of other child elements in
-        it.
-      </td>
-    </tr>
-  </tbody>
-</table>
+| Element | Description |
+| ------- | ----------- |
+| {{SVGElement("svg")}}     | El elemento `svg` es un contenedor que define un nuevo sistema de coordenadas y [viewport](/es/docs/Web/SVG/Attribute/viewBox). Es usado como el elemento más externo de cualquier documento SVG, pero también puede ser usado para agregar un fragmento de un SVG dentro de un documento SVG o HTML. |
+| {{MathMLElement("math")}} | `<math>` es el elemento superior en MathML. Cada instancia válida de MathML debe estar rodeada de etiquetas `<math>`. Además, no debes anidar un segundo elemento `<math>` dentro de un primero, pero puedes tener un número arbitrario de otros elementos hijos en él. |
 
 ## Scripting
 
 Con el fin de crear contenido dinámico y aplicaciones Web, HTML soporta el uso de lenguajes de scripting, el más prominente es JavaScript. Ciertos elementos soportan esta capacidad.
 
-{{HTMLRefTable("HTML Scripting")}}
+| Element | Description |
+| ------- | ----------- |
+| {{HTMLElement("canvas")}}   | El elemento HTML _canvas_ (\<canvas>) se puede utilizar para dibujar gráficos a través de secuencias de comandos (por lo general [JavaScript](/en/JavaScript) ). Por ejemplo, puede usarse para dibujar gráficos, hacer composiciones de fotos o incluso realizar animaciones. |
+| {{HTMLElement("noscript")}} | **Sus etiquetas son**: `<noscript>` y `</noscript>` (ambas obligatorias). |
+| {{HTMLElement("script")}}   | Used to embed executable code or data; this is typically used to embed or refer to JavaScript code. The `<script>` element can also be used with other languages, such as [WebGL](/es/docs/Web/API/WebGL_API)'s GLSL shader programming language and [JSON](/es/docs/Glossary/JSON). |
 
 ## Ediciones demarcadas
 
 Estos elementos permiten proporcionar indicios de que determinadas partes del texto han sido alteradas.
 
-{{HTMLRefTable("HTML Edits")}}
+| Element | Description |
+| ------- | ----------- |
+| {{HTMLElement("del")}} | **Sus etiquetas son**: \<del> y \</del> (ambas obligatorias). |
+| {{HTMLElement("ins")}} | **Sus etiquetas son**: \<ins> e \</ins> (ambas obligatorias). |
 
 ## Tablas
 
 Estos elementos son usados para crear y manejar datos tabulados.
 
-{{HTMLRefTable("HTML tabular data")}}
+| Element | Description |
+| ------- | ----------- |
+| {{HTMLElement("caption")}}  | **Sus etiquetas son**: `<caption>` y `</caption>` (ambas obligatorias). |
+| {{HTMLElement("col")}}      | **Sus etiquetas son**: `<col>` (solo tiene una). |
+| {{HTMLElement("colgroup")}} | **Sus etiquetas son**: `<colgroup>` y `</colgroup>` (la de cierre es opcional). |
+| {{HTMLElement("table")}}    | El _Elemento de Tabla HTML_ (`<table>`) representa datos en dos o mas dimensiones. |
+| {{HTMLElement("tbody")}}    | Encapsulates a set of table rows ({{HTMLElement("tr")}} elements), indicating that they comprise the body of the table ({{HTMLElement("table")}}). |
+| {{HTMLElement("td")}}       | El elemento [HTML](/es/docs/Web/HTML) _Celda de tabla_ (**`<td>`**) define la celda de una tabla que contiene datos. Esta participa en el _modelo de tablas_. |
+| {{HTMLElement("tfoot")}}    | Defines a set of rows summarizing the columns of the table. |
+| {{HTMLElement("th")}}       | El elemento **HTML `<th>`** define una celda como encabezado de un grupo de celdas en una tabla. La naturaleza exacta de este grupo está definida por los atributos {{htmlattrxref("scope", "th")}} y {{htmlattrxref("headers", "th")}}. |
+| {{HTMLElement("thead")}}    | Defines a set of rows defining the head of the columns of the table. |
+| {{HTMLElement("tr")}}       | El elemento HTML _fila de tabla_ (_table row_) `<tr>` define una fila de celdas en una tabla. Estas pueden ser una mezcla de elementos {{HTMLElement("td")}} y {{HTMLElement("th")}}. |
 
 ## Formularios
 
 HTML provee un número de elementos que pueden usarse conjuntamente para crear formularios los cuales el usuario puede completar y enviar al sitio Web o a una aplicación. Hay una gran cantidad de información acerca de ésto disponible en la [HTML forms guide](/es/docs/Web/Guide/HTML/Forms).
 
-{{HTMLRefTable({"include": ["HTML forms"], "exclude":["Deprecated"]})}}
+| Element | Description |
+| ------- | ----------- |
+| {{HTMLElement("button")}}   | **button** = botón. |
+| {{HTMLElement("datalist")}} | El **elemento HTML `<datalist>`** contiene un conjunto de elementos {{HTMLElement("option")}} que representan los valores disponibles para otros controles. |
+| {{HTMLElement("fieldset")}} | **Sus etiquetas son**: \<fieldset> y \</fieldset> (ambas obligatorias). |
+| {{HTMLElement("form")}}     | El elemento HTML form (`<form>`) representa una sección de un documento que contiene controles interactivos que permiten a un usuario enviar información a un servidor web. |
+| {{HTMLElement("input")}}    | El elemento HTML `<input>` se usa para crear controles interactivos para formularios basados en la web con el fin de recibir datos del usuario.Hay disponible una amplia variedad de tipos de datos de entrada y widgets de control, que dependen del dispositivo y el agente de usuario ([user agent](/es/docs/Glossary/user_agent)).El elemento `<input>` es uno de los más potentes y complejos en todo HTML debido a la gran cantidad de combinaciones de tipos y atributos de entrada. |
+| {{HTMLElement("label")}}    | El **Elemento HTML `<label>`** representa una etiqueta para un elemento en una interfaz de usuario. Este puede estar asociado con un control ya sea mediante la utilizacion del atributo for, o ubicando el control dentro del elemento label. Tal control es llamado "el control etiquetado" del elemento label. |
+| {{HTMLElement("legend")}}   | **Sus etiquetas son**: \<legend> y \</legend> (ambas obligatorias). |
+| {{HTMLElement("meter")}}    | Represents either a scalar value within a known range or a fractional value. |
+| {{HTMLElement("optgroup")}} | Creates a grouping of options within a {{HTMLElement("select")}} element. |
+| {{HTMLElement("option")}}   | En un formulario Web , el **elemento** **HTML `<option>`** se usa para representar un item dentro de un {{HTMLElement("select")}}, un {{HTMLElement("optgroup")}} o un elemento HTML5 {{HTMLElement("datalist")}} . |
+| {{HTMLElement("output")}}   | Container element into which a site or app can inject the results of a calculation or the outcome of a user action. |
+| {{HTMLElement("progress")}} | La etiqueta **HTML `<progress>`** se utiliza para visualizar el progreso de una tarea. Aunque los detalles de como se muestran depende directamente del navegador que utiliza el cliente, aunque básicamente aparece una barra de progreso. |
+| {{HTMLElement("select")}}   | El elemento select (`<select>`) de HTML representa un control que muestra un menú de opciones. Las opciones contenidas en el menú son representadas por elementos {{HTMLElement("option")}}, los cuales pueden ser agrupados por elementos {{HTMLElement("optgroup")}}. La opcion puede estar preseleccionada por el usuario. |
+| {{HTMLElement("textarea")}} | El **elemento** **HTML `<textarea>`** representa un control para la edición mutilínea de texto sin formato. |
 
 ## Elementos Interactivos
 
 HTML ofrece una selección de elementos que pueden ayudar a crear objetos de interfaz de usuario interactivos.
 
-{{HTMLRefTable("HTML interactive elements")}}
+| Element | Description |
+| ------- | ----------- |
+| {{HTMLElement("details")}} | El elemento HTML Details **\<details>** es usado como un widget de revelación a través del cual el usuario puede obtener información adicional . |
+| {{HTMLElement("dialog")}}  | El **elemento** **HTML `<dialog>`** representa una caja de diálogo u otro componente interactivo, como inspector o ventana. |
+| {{HTMLElement("summary")}} | Specifies a summary, caption, or legend for a details element's disclosure box. Clicking the `<summary>` element toggles the state of the parent {{HTMLElement("details")}} element open and closed. |
 
 ## Componentes Web
 
@@ -129,4 +220,32 @@ Los Componentes Web son una tecnología relacionada con HTML que hacen que sea p
 
 > **Advertencia:** Estos son elementos HTML viejos los cuales están obsoletos y no deben usarse. **Nunca debería usarlos en un nuevo proyecto y debería reemplazarlos en proyectos viejos tan pronto como sea posible.** Se listan aquí solo con propósitos informativos.
 
-{{HTMLRefTable({"include":["Deprecated","Obsolete"]})}}
+| Element | Description |
+| ------- | ----------- |
+| {{HTMLElement("acronym")}}   | **acromym** de acromyn=acrónimo |
+| {{HTMLElement("applet")}}    | **Sus etiquetas son**: \<applet> y \</applet> (ambas obligatorias) |
+| {{HTMLElement("bgsound")}}   | El elemento HTML de sonido de fondo (\<bgsound>) es un elemento de Internet Explorer que asocia un sonido de fondo con un página . |
+| {{HTMLElement("big")}}       | **big** de big=grande |
+| {{HTMLElement("blink")}}     | {{Deprecated_header}} {{Non-standard_header}} |
+| {{HTMLElement("center")}}    | **Sus etiquetas son**: \<center> y \</center> (ambas obligatorias). |
+| {{HTMLElement("content")}}   | El elemento [HTML](/es/docs/Web/HTML) `<content>` es usado dentro de un [Shadow DOM](/es/docs/Web/Web_Components/Using_shadow_DOM) como un {{glossary("insertion point")}} . No está pensado para ser usado en HTML ordinario . Es usado con [Web Components](/es/docs/Web/Web_Components). |
+| {{HTMLElement("dir")}}       | **Sus etiquetas son**: \<dir> y \</dir> (ambas obligatorias). |
+| {{HTMLElement("font")}}      | **Sus etiquetas son**: \<font> y \</font> (ambas obligatorias). |
+| {{HTMLElement("frame")}}     | **Sus etiquetas son**: `<frame>` (solo tiene una). |
+| {{HTMLElement("frameset")}}  | **Sus etiquetas son**: `<frameset>` y `</frameset>` (ambas obligatorias). |
+| {{HTMLElement("image")}}     | El _elemento de grupo de cabeceras HTML_ (\<hgroup>) representa el encabezado de una sección. Define un solo título que participa de [la estructura del documento](/en/Sections_and_Outlines_of_an_HTML5_document) como el encabezado de la sección implícita o explícita a la que pertenece. |
+| {{HTMLElement("keygen")}}    | El elemento HTML `<image>` fue un elemento experimental diseñado para mostrar imágenes . Nuca fue implementado y el elemento estándar {{HTMLElement("img")}} debe de ser usado . |
+| {{HTMLElement("marquee")}}   | El elemento `keygen` de HTML existe para facilitar la generación de llaves, y el envío de la clave pública como parte de un formulario HTML. Este mecanismo está diseñado para utilizarse con sistemas de gestión de certificados basados en la Web. Se espera que el elemento `keygen` se utilice en un formulario HTML, junto con otra información necesaria para la construcción de una solicitud de certificado, y que el resultado del proceso será un certificado firmado. |
+| {{HTMLElement("menuitem")}}  | La etiqueta html `<marquee>` se utiliza para insertar un area de texto en movimiento. También se la conoce como marquesina. |
+| {{HTMLElement("nobr")}}      | Prevents the text it contains from automatically wrapping across multiple lines, potentially resulting in the user having to scroll horizontally to see the entire width of the text. |
+| {{HTMLElement("noembed")}}   | El elemento HTML `<nobr>` previene que una línea de texto se divida en una nueva línea, así, se presentará en una línea larga por lo que puede ser necesario hacer un desplazamiento de pantalla. Esta etiqueta no es un estándar HTML y no debería ser usada, en su lugar use la propiedad CSS {{Cssxref("white-space")}} como en este ejemplo: |
+| {{HTMLElement("noframes")}}  | Provides content to be presented in browsers that don't support (or have disabled support for) the {{HTMLElement("frame")}} element. Although most commonly-used browsers support frames, there are exceptions, including certain special-use browsers including some mobile browsers, as well as text-mode browsers. |
+| {{HTMLElement("param")}}     | **Sus etiquetas son**: `<noframes>` y `</noframes>` (ambas obligatorias). |
+| {{HTMLElement("plaintext")}} | **Sus etiquetas son**: `<param>` (solo tiene una). |
+| {{HTMLElement("rb")}}        | Used to delimit the base text component of a ruby annotation, i.e. the text that is being annotated. One `<rb>` element should wrap each separate atomic segment of the base text. |
+| {{HTMLElement("rtc")}}       | Embraces semantic annotations of characters presented in a ruby of {{HTMLElement("rb")}} elements used inside of {{HTMLElement("ruby")}} element. {{HTMLElement("rb")}} elements can have both pronunciation ({{HTMLElement("rt")}}) and semantic ({{HTMLElement("rtc")}}) annotations. |
+| {{HTMLElement("shadow")}}    | An obsolete part of the [Web Components](/es/docs/Web/Web_Components) technology suite that was intended to be used as a shadow DOM insertion point. You might have used it if you have created multiple shadow roots under a shadow host. |
+| {{HTMLElement("spacer")}}    | Allows insertion of empty spaces on pages. It was devised by Netscape to accomplish the same effect as a single-pixel layout image, which was something web designers used to use to add white spaces to web pages without actually using an image. However, `<spacer>` is no longer supported by any major browser and the same effects can now be achieved using simple CSS. |
+| {{HTMLElement("strike")}}    | Places a strikethrough (horizontal line) over text. |
+| {{HTMLElement("tt")}}        | **Sus etiquetas son**: \<strike> y \</strike> (Ambas obligatorias) |
+| {{HTMLElement("xmp")}}       | **Sus etiquetas son**: \<tt> y \</tt> (Ambas obligatorias) |

--- a/files/es/web/html/element/index.md
+++ b/files/es/web/html/element/index.md
@@ -12,7 +12,7 @@ Esta página lista todos los {{Glossary("Element","elementos")}} {{Glossary("HTM
 
 ## Raíz principal
 
-| Element | Description |
+| Elemento | Descripción |
 | ------- | ----------- |
 | {{HTMLElement("html")}} | El **elemento HTML `<html>`** (o _elemento HTML raiz_) representa la raiz de un documento HTML. El resto de elementos descienden de este elemento. |
 
@@ -20,7 +20,7 @@ Esta página lista todos los {{Glossary("Element","elementos")}} {{Glossary("HTM
 
 Los metadatos contienen información sobre la página. Esto incluye información sobre estilos, _scripts_ y datos que ayudan al _software_ ({{Glossary("search engine", "search engines")}}, {{Glossary("Browser","browsers")}}, etc.) a usar y generar la página. Los metadatos de estilos y _scripts_ pueden estar definidos en la página o estar enlazados a otro fichero que contiene la información.
 
-| Element | Description |
+| Elemento | Descripción |
 | ------- | ----------- |
 | {{HTMLElement("base")}}  | El **elemento HTML `<base>`** especifica la dirección URL base que se utilizará para todas las direcciones URL relativas contenidas dentro de un documento. Sólo puede haber un elemento \<base> en un documento. |
 | {{HTMLElement("head")}}  | El **elemento HTML `<head>`** provee información general (metadatos) acerca del documento, incluyendo su título y enlaces a scripts y hojas de estilos. |
@@ -31,7 +31,7 @@ Los metadatos contienen información sobre la página. Esto incluye información
 
 ## Seccionamiento básico
 
-| Element | Description |
+| Elemento | Descripción |
 | ------- | ----------- |
 | {{HTMLElement("body")}} | El **elemento `<body>` de HTML** representa el contenido de un documento HTML. Solo puede haber un elemento `<body>` en un documento. |
 
@@ -39,7 +39,7 @@ Los metadatos contienen información sobre la página. Esto incluye información
 
 Los elementos de seccionamiento del contenido te permiten organizar los contenidos del documento en partes lógicas. Usa los elementos de seccionado para crear una descripción amplia de los contenidos de tu página, incluyendo el encabezado y pie de página y elementos para identificar secciones.
 
-| Element | Description |
+| Elemento | Descripción |
 | ------- | ----------- |
 | {{HTMLElement("address")}}                                                                                                                                                                                                                                                                                                                           | El **elemento HTML `<address>`** aporta información de contacto para su {{HTMLElement("article")}} más cercano o ancestro {{HTMLElement("body")}}; en el último caso lo aplica a todo el documento. |
 | {{HTMLElement("article")}}                                                                                                                                                                                                                                                                                                                           | El Elemento de HTML **`<article>`** representa una composición auto-contenida en un documento, una página, una aplicación o en un sitio, que se quiere que sea distribuíble y/o reutilizable de manera independiente, por ejemplo, en la redifusión. Algunos ejemplos podrían ser un mensaje en un foro, un artículo de una revista o un periódico, una entrada de blog, el comentario de un usuario, un widget o gadget interactivo, o cualquier otro elemento de contenido independiente. |
@@ -55,7 +55,7 @@ Los elementos de seccionamiento del contenido te permiten organizar los contenid
 
 Utiliza los elementos HTML de contenido del texto para organizar bloques o secciones de contenido colocados entre los tags de apertura{{HTMLElement("body")}} y cierre. Es importante para la {{Glossary("accessibility")}} y el {{Glossary("SEO")}}, que estos elementos se identifiquen con el objetivo o la estructura de ese contenido.
 
-| Element | Description |
+| Elemento | Descripción |
 | ------- | ----------- |
 | {{HTMLElement("blockquote")}} | **Sus etiquetas son**: `<blockquote>` y `</blockquote>` (ambas obligatorias). |
 | {{HTMLElement("dd")}}         | El **elemento HTML `<dd>`** provee detalles acerca de o la definición de un término precedente ({{HTMLElement("dt")}}) en una lista de descripciones ({{HTMLElement("dl")}}). |
@@ -76,7 +76,7 @@ Utiliza los elementos HTML de contenido del texto para organizar bloques o secci
 
 Utilice la semántica del texto en línea HTML para definir el significado, estructura, o el estilo de una palabra, una línea o cualquier pieza arbitraria de texto.
 
-| Element | Description |
+| Elemento | Descripción |
 | ------- | ----------- |
 | {{HTMLElement("a")}}      | El _Elemento HTML `Anchor`_ **`<a>`** crea un enlace a otras páginas de internet, archivos o ubicaciones dentro de la misma página, direcciones de correo, o cualquier otra URL. |
 | {{HTMLElement("abbr")}}   | El **elemento HTML `<abbr>`** (_o Elemento de Abreviación HTML_) representa una abreviación o acrónimo; el atributo opcional {{htmlattrxref("title")}} puede ampliar o describir la abreviatura. Si está presente, el atributo `title` debe contener la descripción completa y nada más. |
@@ -112,7 +112,7 @@ Utilice la semántica del texto en línea HTML para definir el significado, estr
 
 HTML soporta varios recursos multimedia como imágenes, audio, y video.
 
-| Element | Description |
+| Elemento | Descripción |
 | ------- | ----------- |
 | {{HTMLElement("area")}}  | **area** de area=área |
 | {{HTMLElement("audio")}} | El elemento `audio` se usa para insertar contenido de audio en un documento HTML o XHTML. El elemento `audio` se agregó como parte de HTML 5. |
@@ -125,7 +125,7 @@ HTML soporta varios recursos multimedia como imágenes, audio, y video.
 
 Además de los contenidos multimedia habituales, HTML puede incluir otra variedad de contenidos, aunque no siempre es fácil de interactuar con ellos.
 
-| Element | Description |
+| Elemento | Descripción |
 | ------- | ----------- |
 | {{HTMLElement("embed")}}   | El _Elemento HTML Embed_ ( `<embed>` ) representa un punto de integración para una aplicación externa o de contenido interactivo (en otras palabras, un plug-in). |
 | {{HTMLElement("iframe")}}  | El **elemento HTML `<iframe>`** (de inline frame) representa un contexto de navegación anidado, el cual permite incrustar otra página HTML en la página actual. |
@@ -138,7 +138,7 @@ Además de los contenidos multimedia habituales, HTML puede incluir otra varieda
 
 Puede incrustar contenido [SVG](/es/docs/Web/SVG) y [MathML](/es/docs/Web/MathML) directamente en documentos HTML, usando los elementos {{SVGElement("svg")}} y { {MathMLElement("math")}}.
 
-| Element | Description |
+| Elemento | Descripción |
 | ------- | ----------- |
 | {{SVGElement("svg")}}     | El elemento `svg` es un contenedor que define un nuevo sistema de coordenadas y [viewport](/es/docs/Web/SVG/Attribute/viewBox). Es usado como el elemento más externo de cualquier documento SVG, pero también puede ser usado para agregar un fragmento de un SVG dentro de un documento SVG o HTML. |
 | {{MathMLElement("math")}} | `<math>` es el elemento superior en MathML. Cada instancia válida de MathML debe estar rodeada de etiquetas `<math>`. Además, no debes anidar un segundo elemento `<math>` dentro de un primero, pero puedes tener un número arbitrario de otros elementos hijos en él. |
@@ -147,7 +147,7 @@ Puede incrustar contenido [SVG](/es/docs/Web/SVG) y [MathML](/es/docs/Web/MathML
 
 Con el fin de crear contenido dinámico y aplicaciones Web, HTML soporta el uso de lenguajes de scripting, el más prominente es JavaScript. Ciertos elementos soportan esta capacidad.
 
-| Element | Description |
+| Elemento | Descripción |
 | ------- | ----------- |
 | {{HTMLElement("canvas")}}   | El elemento HTML _canvas_ (\<canvas>) se puede utilizar para dibujar gráficos a través de secuencias de comandos (por lo general [JavaScript](/en/JavaScript) ). Por ejemplo, puede usarse para dibujar gráficos, hacer composiciones de fotos o incluso realizar animaciones. |
 | {{HTMLElement("noscript")}} | **Sus etiquetas son**: `<noscript>` y `</noscript>` (ambas obligatorias). |
@@ -157,7 +157,7 @@ Con el fin de crear contenido dinámico y aplicaciones Web, HTML soporta el uso 
 
 Estos elementos permiten proporcionar indicios de que determinadas partes del texto han sido alteradas.
 
-| Element | Description |
+| Elemento | Descripción |
 | ------- | ----------- |
 | {{HTMLElement("del")}} | **Sus etiquetas son**: \<del> y \</del> (ambas obligatorias). |
 | {{HTMLElement("ins")}} | **Sus etiquetas son**: \<ins> e \</ins> (ambas obligatorias). |
@@ -166,7 +166,7 @@ Estos elementos permiten proporcionar indicios de que determinadas partes del te
 
 Estos elementos son usados para crear y manejar datos tabulados.
 
-| Element | Description |
+| Elemento | Descripción |
 | ------- | ----------- |
 | {{HTMLElement("caption")}}  | **Sus etiquetas son**: `<caption>` y `</caption>` (ambas obligatorias). |
 | {{HTMLElement("col")}}      | **Sus etiquetas son**: `<col>` (solo tiene una). |
@@ -183,7 +183,7 @@ Estos elementos son usados para crear y manejar datos tabulados.
 
 HTML provee un número de elementos que pueden usarse conjuntamente para crear formularios los cuales el usuario puede completar y enviar al sitio Web o a una aplicación. Hay una gran cantidad de información acerca de ésto disponible en la [HTML forms guide](/es/docs/Web/Guide/HTML/Forms).
 
-| Element | Description |
+| Elemento | Descripción |
 | ------- | ----------- |
 | {{HTMLElement("button")}}   | **button** = botón. |
 | {{HTMLElement("datalist")}} | El **elemento HTML `<datalist>`** contiene un conjunto de elementos {{HTMLElement("option")}} que representan los valores disponibles para otros controles. |
@@ -204,7 +204,7 @@ HTML provee un número de elementos que pueden usarse conjuntamente para crear f
 
 HTML ofrece una selección de elementos que pueden ayudar a crear objetos de interfaz de usuario interactivos.
 
-| Element | Description |
+| Elemento | Descripción |
 | ------- | ----------- |
 | {{HTMLElement("details")}} | El elemento HTML Details **\<details>** es usado como un widget de revelación a través del cual el usuario puede obtener información adicional . |
 | {{HTMLElement("dialog")}}  | El **elemento** **HTML `<dialog>`** representa una caja de diálogo u otro componente interactivo, como inspector o ventana. |
@@ -214,7 +214,7 @@ HTML ofrece una selección de elementos que pueden ayudar a crear objetos de int
 
 Los Componentes Web son una tecnología relacionada con HTML que hacen que sea posible, en esencia, crear y personalizar elementos como si fueran HTML normal. Además, pueden crear versiones personalizadas de los elementos HTML estándar.
 
-| Element | Description |
+| Elemento | Descripción |
 | ------- | ----------- |
 | {{HTMLElement("slot")}}     | **El elemento HTML `<slot>`** —parte de la suite tecnologica [Web Components](/es/docs/Web/Web_Components) — es un placeholder en un componente que tu puedes llenar con tu propio marcado, que te permite crear árboles DOM por separado y presentarlos juntos. |
 | {{HTMLElement("template")}} | El **elemento** **HTML `<template>`** es un mecanismo para mantener el contenido {{Glossary("HTML")}} del lado del cliente que no se renderiza cuando se carga una página, pero que posteriormente puede ser instanciado durante el tiempo de ejecución empleando JavaScript. |
@@ -223,7 +223,7 @@ Los Componentes Web son una tecnología relacionada con HTML que hacen que sea p
 
 > **Advertencia:** Estos son elementos HTML viejos los cuales están obsoletos y no deben usarse. **Nunca debería usarlos en un nuevo proyecto y debería reemplazarlos en proyectos viejos tan pronto como sea posible.** Se listan aquí solo con propósitos informativos.
 
-| Element | Description |
+| Elemento | Descripción |
 | ------- | ----------- |
 | {{HTMLElement("acronym")}}   | Permite a los autores indicar claramente una secuencia de caracteres que componen un acrónimo o abreviatura de una palabra. |
 | {{HTMLElement("applet")}}    | **Sus etiquetas son**: \<applet> y \</applet> (ambas obligatorias) |

--- a/files/es/web/html/element/index.md
+++ b/files/es/web/html/element/index.md
@@ -226,7 +226,7 @@ Los Componentes Web son una tecnología relacionada con HTML que hacen que sea p
 | {{HTMLElement("applet")}}    | **Sus etiquetas son**: \<applet> y \</applet> (ambas obligatorias) |
 | {{HTMLElement("bgsound")}}   | El elemento HTML de sonido de fondo (\<bgsound>) es un elemento de Internet Explorer que asocia un sonido de fondo con un página . |
 | {{HTMLElement("big")}}       | **big** de big=grande |
-| {{HTMLElement("blink")}}     | {{Deprecated_header}} {{Non-standard_header}} |
+| {{HTMLElement("blink")}}     | El elemento HTML blink (`<blink>`) no es un elemento estándar que causa que el texto encerrado parpadee lentamente . |
 | {{HTMLElement("center")}}    | **Sus etiquetas son**: \<center> y \</center> (ambas obligatorias). |
 | {{HTMLElement("content")}}   | El elemento [HTML](/es/docs/Web/HTML) `<content>` es usado dentro de un [Shadow DOM](/es/docs/Web/Web_Components/Using_shadow_DOM) como un {{glossary("insertion point")}} . No está pensado para ser usado en HTML ordinario . Es usado con [Web Components](/es/docs/Web/Web_Components). |
 | {{HTMLElement("dir")}}       | **Sus etiquetas son**: \<dir> y \</dir> (ambas obligatorias). |

--- a/files/es/web/html/element/index.md
+++ b/files/es/web/html/element/index.md
@@ -214,7 +214,10 @@ HTML ofrece una selección de elementos que pueden ayudar a crear objetos de int
 
 Los Componentes Web son una tecnología relacionada con HTML que hacen que sea posible, en esencia, crear y personalizar elementos como si fueran HTML normal. Además, pueden crear versiones personalizadas de los elementos HTML estándar.
 
-{{HTMLRefTable({"include":["Web Components"],"elements":["shadow"]})}}
+| Element | Description |
+| ------- | ----------- |
+| {{HTMLElement("slot")}}     | **El elemento HTML `<slot>`** —parte de la suite tecnologica [Web Components](/es/docs/Web/Web_Components) — es un placeholder en un componente que tu puedes llenar con tu propio marcado, que te permite crear árboles DOM por separado y presentarlos juntos. |
+| {{HTMLElement("template")}} | El **elemento** **HTML `<template>`** es un mecanismo para mantener el contenido {{Glossary("HTML")}} del lado del cliente que no se renderiza cuando se carga una página, pero que posteriormente puede ser instanciado durante el tiempo de ejecución empleando JavaScript. |
 
 ## Elementos obsoletos y en desuso
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
The `{{HTMLRefTable}}` macro became obsolete, and the entire table content was gone. So, I converted the macros as described below:

1. Get the markdown corresponding to the "Element" cell of each table from the English version
2. Set the markdowns to the "Element" cells in the translated version
3. For each element (=HTML tag), get the first line of the translated version of the page
(specifically, the first line that is not a front-matter, heading, or Lv1 list)
4. Set the retrieved line to the "Description" cell
5. If "Description" cell was empty, fill with en-US description (`{{HTMLRefTable}}` did not seem to have this process)

I am not entirely sure what the `{{HTMLRefTable}}` macro was actually doing.
I assumed it probably did something like the above.
A PR in the Japanese version (#11993) was determined that there was no problem.

I can't understand what the translated text means.
So, I would like the reviewer to do the following tasks:

1. Since I did the conversion semi-mechanically, there may be some strange things in the text. Please check it lightly.
2. Please compare with [WayBackMachine page](http://web.archive.org/web/20221209144013/https://developer.mozilla.org/es/docs/Web/HTML/Element) and check if there are any significant changes.
3. The chapters that existed in the English version but were not in the translated version (SVG and MathML) have been copied directly from the English version. Please translate them later.

I am writing this English text with using a translator. Sorry if there are parts that are difficult to read.

Thank you in advance.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
WayBackMachine page: http://web.archive.org/web/20221209144013/https://developer.mozilla.org/es/docs/Web/HTML/Element
current page: https://developer.mozilla.org/es/docs/Web/HTML/Element

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
Relates to #11953
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
