### PR TITLE
chore(ci): bump Python version in PR companion

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -71,7 +71,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.10"
 
       # See https://www.peterbe.com/plog/install-python-poetry-github-actions-faster
       - name: Load cached ~/.local


### PR DESCRIPTION
### Description

The required python version is `^3.10`, while the current installed python version is `3.8`

### Related issues and pull requests

https://github.com/mdn/translated-content/actions/runs/4350382504/jobs/7601032875#step:9:14

mdn/content#25104
