### PR TITLE
Reflect.get() is not bolded and displays an error

### DIFF
--- a/files/zh-cn/web/javascript/reference/global_objects/reflect/get/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/reflect/get/index.md
@@ -5,7 +5,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Reflect/get
 
 {{JSRef}}
 
-**`Reflect.get()`**方法与从 对象 (`target[propertyKey]`) 中读取属性类似，但它是通过一个函数执行来操作的。
+**`Reflect.get()`** 方法与从 对象 (`target[propertyKey]`) 中读取属性类似，但它是通过一个函数执行来操作的。
 
 ## 语法
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Reflect.get() is not bolded and displays an error, so I added a space to make sure it was displayed correctly

### Motivation

Correct form

### Additional details


### Related issues and pull requests

