### PR TITLE
Fix typo and grammar in Installable PWA page, in French

### DIFF
--- a/files/fr/web/progressive_web_apps/installable_pwas/index.md
+++ b/files/fr/web/progressive_web_apps/installable_pwas/index.md
@@ -1,5 +1,5 @@
 ---
-title: Comment rendre les PWAs installables
+title: Comment rendre les PWA installables
 slug: Web/Progressive_web_apps/Installable_PWAs
 translation_of: Web/Progressive_web_apps/Installable_PWAs
 ---
@@ -19,7 +19,7 @@ Pour rendre un site web installable, il a besoin que les éléments suivants soi
 - Un icone représentant l'application sur l'appareil
 - Un service worker enregistré pour permettre à l'application de fonctionner en mode déconnecté (ceci n'est actuellement imposé que par Chrome pour Android)
 
-### Le fichier manisfeste
+### Le fichier manifeste
 
 L'élément clef est un fichier manifeste web qui liste toutes les informations concernant le site web au format JSON.
 


### PR DESCRIPTION
Spotted while skimming (did not read the article, so there might be more):
- [Acronyms in French don’t take a plural form](https://www.academie-francaise.fr/questions-de-langue#80_strong-em-sigles-et-acronymes-diffrence-genre-pluriel-em-strong), even [when they refer to a foreign language](https://vitrinelinguistique.oqlf.gouv.qc.ca/21136/les-abreviations-et-les-symboles/les-sigles-et-les-acronymes/genre-et-nombre-des-sigles-et-acronymes#c64972).
- Typo in « manifeste ».