### PR TITLE
pt-br: Drop 'in this module' from Learn/Accessibility

### DIFF
--- a/files/pt-br/learn/accessibility/accessibility_troubleshooting/index.md
+++ b/files/pt-br/learn/accessibility/accessibility_troubleshooting/index.md
@@ -86,13 +86,3 @@ Você pode citar mais duas ideias de melhorias que poderiam tornar o site mais a
 Se você está fazendo esta avaliação como parte de um curso, você deverá entregar o seu trabalho para um professor para que possa corrigí-lo. Se você é auto-didata, então você pode obter o guia com a marcação correta perguntando no [tópico de discussão para este exercício](https://discourse.mozilla.org/t/accessibility-troubleshooting-assessment/24691&xid=17259,15700021,15700124,15700149,15700186,15700190,15700201,15700214&usg=ALkJrhh-F4r0i3lAG4IX8kI3Nk9lrJQa0A), ou no canal de IRC [#mdn](irc://irc.mozilla.org/mdn) no [IRC do Mozilla](https://wiki.mozilla.org/IRC&xid=17259,15700021,15700124,15700149,15700186,15700190,15700201,15700214&usg=ALkJrhgC5oFTH3iLqIFiwi9njruuEgsWHA). Experimente tentar fazer o exercício primeiro - você não ganhará nada trapaceando!
 
 {{PreviousMenu("Learn/Accessibility/Mobile", "Learn/Accessibility")}}
-
-## Neste módulo
-
-- [O que é acessibilidade?](/pt-BR/docs/Learn/Accessibility/What_is_accessibility&xid=17259,15700021,15700124,15700149,15700186,15700190,15700201,15700214&usg=ALkJrhjKbO6WIg9b4xWjdZSQcnXxP1foyg)
-- [HTML: uma boa base para acessibilidade](/pt-BR/docs/Learn/Accessibility/HTML&xid=17259,15700021,15700124,15700149,15700186,15700190,15700201,15700214&usg=ALkJrhg8RYEjwUHElGCpA1Q_60OiOtXeLg)
-- [Práticas recomendadas de acessibilidade de CSS e JavaScript](/pt-BR/docs/Learn/Accessibility/CSS_and_JavaScript&xid=17259,15700021,15700124,15700149,15700186,15700190,15700201,15700214&usg=ALkJrhjUFLV1YWbEtSBOMPU_Bt7V-OmzDw)
-- [Noções básicas de WAI-ARIA](/pt-BR/docs/Learn/Accessibility/WAI-ARIA_basics&xid=17259,15700021,15700124,15700149,15700186,15700190,15700201,15700214&usg=ALkJrhj5LnkD6EVmrTiupwf932KoV4VCTw)
-- [Multimídia acessível](/pt-BR/docs/Learn/Accessibility/Multimedia&xid=17259,15700021,15700124,15700149,15700186,15700190,15700201,15700214&usg=ALkJrhgWAjBOw_jwWHOvK_zBEob2xQdEmA)
-- [Acessibilidade móvel](/pt-BR/docs/Learn/Accessibility/Mobile&xid=17259,15700021,15700124,15700149,15700186,15700190,15700201,15700214&usg=ALkJrhgnwNfnWbOmqpMWRI1c1zBqGFfU1Q)
-- [Solução de problemas de acessibilidade](/pt-BR/docs/Learn/Accessibility/Accessibility_troubleshooting&xid=17259,15700021,15700124,15700149,15700186,15700190,15700201,15700214&usg=ALkJrhjy6mgQ3Y6D6sT4QvsOicr2-Fmt9Q)

--- a/files/pt-br/learn/accessibility/css_and_javascript/index.md
+++ b/files/pt-br/learn/accessibility/css_and_javascript/index.md
@@ -353,13 +353,3 @@ We hope this article has given you a good amount of detail and understanding abo
 Next up, WAI-ARIA!
 
 {{PreviousMenuNext("Learn/Accessibility/HTML","Learn/Accessibility/WAI-ARIA_basics", "Learn/Accessibility")}}
-
-## In this module
-
-- [What is accessibility?](/pt-BR/docs/Learn/Accessibility/What_is_accessibility)
-- [HTML: A good basis for accessibility](/pt-BR/docs/Learn/Accessibility/HTML)
-- [CSS and JavaScript accessibility best practices](/pt-BR/docs/Learn/Accessibility/CSS_and_JavaScript)
-- [WAI-ARIA basics](/pt-BR/docs/Learn/Accessibility/WAI-ARIA_basics)
-- [Accessible multimedia](/pt-BR/docs/Learn/Accessibility/Multimedia)
-- [Mobile accessibility](/pt-BR/docs/Learn/Accessibility/Mobile)
-- [Accessibility troubleshooting](/pt-BR/docs/Learn/Accessibility/Accessibility_troubleshooting)

--- a/files/pt-br/learn/accessibility/html/index.md
+++ b/files/pt-br/learn/accessibility/html/index.md
@@ -531,13 +531,3 @@ A razão para usar um `alt` vazio ao invés de não incluí-lo é porque muitos 
 Agora você deve estar familiarizado com a escrita de HTML acessível para a maioria das ocasiões. Nosso artigo básico do WAI-ARIA também preencherá algumas lacunas nesse conhecimento, mas este artigo cuidou do básico. Em seguida, exploraremos CSS e JavaScript e como a acessibilidade é afetada por seu uso bom ou ruim.
 
 {{PreviousMenuNext("Learn/Accessibility/What_is_Accessibility","Learn/Accessibility/CSS_and_JavaScript", "Learn/Accessibility")}}
-
-## Neste módulo
-
-- [O que é acessibilidade?](/pt-BR/docs/Learn/Accessibility/What_is_accessibility&xid=17259,15700021,15700124,15700149,15700186,15700190,15700201,15700214&usg=ALkJrhjKbO6WIg9b4xWjdZSQcnXxP1foyg)
-- [HTML: uma boa base para acessibilidade](/pt-BR/docs/Learn/Accessibility/HTML&xid=17259,15700021,15700124,15700149,15700186,15700190,15700201,15700214&usg=ALkJrhg8RYEjwUHElGCpA1Q_60OiOtXeLg)
-- [Práticas recomendadas de acessibilidade de CSS e JavaScript](/pt-BR/docs/Learn/Accessibility/CSS_and_JavaScript&xid=17259,15700021,15700124,15700149,15700186,15700190,15700201,15700214&usg=ALkJrhjUFLV1YWbEtSBOMPU_Bt7V-OmzDw)
-- [Noções básicas de WAI-ARIA](/pt-BR/docs/Learn/Accessibility/WAI-ARIA_basics&xid=17259,15700021,15700124,15700149,15700186,15700190,15700201,15700214&usg=ALkJrhj5LnkD6EVmrTiupwf932KoV4VCTw)
-- [Multimídia acessível](/pt-BR/docs/Learn/Accessibility/Multimedia&xid=17259,15700021,15700124,15700149,15700186,15700190,15700201,15700214&usg=ALkJrhgWAjBOw_jwWHOvK_zBEob2xQdEmA)
-- [Acessibilidade móvel](/pt-BR/docs/Learn/Accessibility/Mobile&xid=17259,15700021,15700124,15700149,15700186,15700190,15700201,15700214&usg=ALkJrhgnwNfnWbOmqpMWRI1c1zBqGFfU1Q)
-- [Solução de problemas de acessibilidade](/pt-BR/docs/Learn/Accessibility/Accessibility_troubleshooting&xid=17259,15700021,15700124,15700149,15700186,15700190,15700201,15700214&usg=ALkJrhjy6mgQ3Y6D6sT4QvsOicr2-Fmt9Q)


### PR DESCRIPTION
### Description

Drop 'in this module' from Learn/Accessibility

### Motivation

The chore of removing the redundant section

### Additional details

### Related issues and pull requests

Relates to #12199
