### PR TITLE
Fix #6815 Hard-code Formal syntax on -moz-float-edge

### DIFF
--- a/files/es/web/css/-moz-float-edge/index.md
+++ b/files/es/web/css/-moz-float-edge/index.md
@@ -39,7 +39,10 @@ La propiedad [CSS](/es/docs/Web/CSS) no estandarizada **`-moz-float-edge`** espe
 
 ## Sintaxis formal
 
-{{csssyntax}}
+```plain
+-moz-float-edge =
+  border-box | content-box | margin-box | padding-box
+```
 
 ## Ejemplo
 

--- a/files/fr/web/css/-moz-float-edge/index.md
+++ b/files/fr/web/css/-moz-float-edge/index.md
@@ -41,7 +41,10 @@ La propriété **`-moz-float-edge`** définit si les propriétés de hauteur et 
 
 ### Syntaxe formelle
 
-{{csssyntax}}
+```plain
+-moz-float-edge =
+  border-box | content-box | margin-box | padding-box
+```
 
 ## Exemples
 

--- a/files/ja/web/css/-moz-float-edge/index.md
+++ b/files/ja/web/css/-moz-float-edge/index.md
@@ -39,7 +39,10 @@ slug: Web/CSS/-moz-float-edge
 
 ## 形式文法
 
-{{csssyntax}}
+```plain
+-moz-float-edge =
+  border-box | content-box | margin-box | padding-box
+```
 
 <h2 id="Examples">例</h2>
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

 Hard-code Formal syntax on -moz-float-edge for `es`, `fr` and `ja` synchting section with `en-US` as https://github.com/mdn/content/pull/25327

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes #6815
Relates to https://github.com/mdn/content/pull/25327
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
