### PR TITLE
(ja) Glossary CORS-safelisted request header の翻訳

### DIFF
--- a/files/ja/glossary/cors-safelisted_request_header/index.md
+++ b/files/ja/glossary/cors-safelisted_request_header/index.md
@@ -1,5 +1,5 @@
 ---
-title: CORS-safelisted request header
+title: CORS-safelisted request header (CORS セーフリストリクエストヘッダー)
 slug: Glossary/CORS-safelisted_request_header
 page-type: glossary-definition
 l10n:

--- a/files/ja/glossary/cors-safelisted_request_header/index.md
+++ b/files/ja/glossary/cors-safelisted_request_header/index.md
@@ -17,7 +17,7 @@ l10n:
 
 {{HTTPHeader("Access-Control-Allow-Headers")}} ヘッダーを使うと、別のヘッダーをセーフリストとして追加したり、上記のヘッダーをリストアップすることで後述の追加要件を回避することができます:
 
-#### Additional restrictions
+#### 追加要件
 
 CORS-safelisted headers must also fulfill the following requirements in order to be a CORS-safelisted request header:
 
@@ -26,7 +26,7 @@ CORS-safelisted headers must also fulfill the following requirements in order to
 - For {{HTTPHeader("Content-Type")}}: needs to have a MIME type of its parsed value (ignoring parameters) of either `application/x-www-form-urlencoded`, `multipart/form-data`, or `text/plain`.
 - For any header: the value's length can't be greater than 128.
 
-## See also
+## 関連情報
 
 - {{Glossary("CORS-safelisted response header")}}
 - {{Glossary("Forbidden header name")}}

--- a/files/ja/glossary/cors-safelisted_request_header/index.md
+++ b/files/ja/glossary/cors-safelisted_request_header/index.md
@@ -15,7 +15,7 @@ l10n:
 
 リクエストがこれらのヘッダーのみを含んでいて、なおかつ値が後述の追加要件に合致する場合は、{{glossary("preflight request", "プリフライトリクエスト")}}を [CORS](/ja/docs/Glossary/CORS) のコンテキストにおいて送る必要がありません。
 
-You can safelist more headers using the {{HTTPHeader("Access-Control-Allow-Headers")}} header and also list the above headers there to circumvent the following additional restrictions:
+{{HTTPHeader("Access-Control-Allow-Headers")}} ヘッダーを使うと、別のヘッダーをセーフリストとして追加したり、上記のヘッダーをリストアップすることで後述の追加要件を回避することができます:
 
 #### Additional restrictions
 

--- a/files/ja/glossary/cors-safelisted_request_header/index.md
+++ b/files/ja/glossary/cors-safelisted_request_header/index.md
@@ -1,0 +1,33 @@
+---
+title: CORS-safelisted request header
+slug: Glossary/CORS-safelisted_request_header
+page-type: glossary-definition
+l10n:
+  sourceCommit: 4bd65a01204446af2254bb8864bd22ad87bc86b0
+---
+
+A [CORS-safelisted request header](https://fetch.spec.whatwg.org/#cors-safelisted-request-header) is one of the following [HTTP headers](/en-US/docs/Web/HTTP/Headers):
+
+- {{HTTPHeader("Accept")}},
+- {{HTTPHeader("Accept-Language")}},
+- {{HTTPHeader("Content-Language")}},
+- {{HTTPHeader("Content-Type")}}.
+
+When containing only these headers (and values that meet the additional requirements laid out below), a request doesn't need to send a {{glossary("preflight request")}} in the context of [CORS](/en-US/docs/Glossary/CORS).
+
+You can safelist more headers using the {{HTTPHeader("Access-Control-Allow-Headers")}} header and also list the above headers there to circumvent the following additional restrictions:
+
+#### Additional restrictions
+
+CORS-safelisted headers must also fulfill the following requirements in order to be a CORS-safelisted request header:
+
+- For {{HTTPHeader("Accept-Language")}} and {{HTTPHeader("Content-Language")}}: can only have values consisting of `0-9`, `A-Z`, `a-z`, space or `*,-.;=`.
+- For {{HTTPHeader("Accept")}} and {{HTTPHeader("Content-Type")}}: can't contain a _CORS-unsafe request header byte_: `0x00-0x1F` (except for `0x09 (HT)`, which is allowed), `"():<>?@[\]{}`, and `0x7F (DEL)`.
+- For {{HTTPHeader("Content-Type")}}: needs to have a MIME type of its parsed value (ignoring parameters) of either `application/x-www-form-urlencoded`, `multipart/form-data`, or `text/plain`.
+- For any header: the value's length can't be greater than 128.
+
+## See also
+
+- {{Glossary("CORS-safelisted response header")}}
+- {{Glossary("Forbidden header name")}}
+- {{Glossary("Request header")}}

--- a/files/ja/glossary/cors-safelisted_request_header/index.md
+++ b/files/ja/glossary/cors-safelisted_request_header/index.md
@@ -6,12 +6,12 @@ l10n:
   sourceCommit: 4bd65a01204446af2254bb8864bd22ad87bc86b0
 ---
 
-A [CORS-safelisted request header](https://fetch.spec.whatwg.org/#cors-safelisted-request-header) is one of the following [HTTP headers](/en-US/docs/Web/HTTP/Headers):
+[CORS セーフリストリクエストヘッダー](https://fetch.spec.whatwg.org/#cors-safelisted-request-header)は、次の [HTTP ヘッダー](/ja/docs/Web/HTTP/Headers)のうちの一つです:
 
-- {{HTTPHeader("Accept")}},
-- {{HTTPHeader("Accept-Language")}},
-- {{HTTPHeader("Content-Language")}},
-- {{HTTPHeader("Content-Type")}}.
+- {{HTTPHeader("Accept")}}
+- {{HTTPHeader("Accept-Language")}}
+- {{HTTPHeader("Content-Language")}}
+- {{HTTPHeader("Content-Type")}}
 
 When containing only these headers (and values that meet the additional requirements laid out below), a request doesn't need to send a {{glossary("preflight request")}} in the context of [CORS](/en-US/docs/Glossary/CORS).
 

--- a/files/ja/glossary/cors-safelisted_request_header/index.md
+++ b/files/ja/glossary/cors-safelisted_request_header/index.md
@@ -19,12 +19,12 @@ l10n:
 
 #### 追加要件
 
-CORS-safelisted headers must also fulfill the following requirements in order to be a CORS-safelisted request header:
+CORS セーフリストリクエストヘッダーとなるためには、次の要件も満たさなければなりません:
 
-- For {{HTTPHeader("Accept-Language")}} and {{HTTPHeader("Content-Language")}}: can only have values consisting of `0-9`, `A-Z`, `a-z`, space or `*,-.;=`.
-- For {{HTTPHeader("Accept")}} and {{HTTPHeader("Content-Type")}}: can't contain a _CORS-unsafe request header byte_: `0x00-0x1F` (except for `0x09 (HT)`, which is allowed), `"():<>?@[\]{}`, and `0x7F (DEL)`.
-- For {{HTTPHeader("Content-Type")}}: needs to have a MIME type of its parsed value (ignoring parameters) of either `application/x-www-form-urlencoded`, `multipart/form-data`, or `text/plain`.
-- For any header: the value's length can't be greater than 128.
+- {{HTTPHeader("Accept-Language")}} と {{HTTPHeader("Content-Language")}} については、値が次の文字のみで構成されていなければなりません: `0-9`・`A-Z`・`a-z`・空白・`*,-.;=`
+- {{HTTPHeader("Accept")}} と {{HTTPHeader("Content-Type")}} については、次の _CORS アンセーフリクエストヘッダーバイト_と呼ばれる文字を含んではいけません: `0x00-0x1F` (ただし、`0x09 (HT)` は含めても良い)・`"():<>?@[\]{}`・`0x7F (DEL)`.
+- {{HTTPHeader("Content-Type")}} について: 値をパースした結果（パラメーターを除く）が、`application/x-www-form-urlencoded` か、`multipart/form-data`、`text/plain` のうち、いずれかの MIME タイプでなければなりません。
+- すべてのヘッダーについて: 値の長さが128バイトを超えてはいけません。
 
 ## 関連情報
 

--- a/files/ja/glossary/cors-safelisted_request_header/index.md
+++ b/files/ja/glossary/cors-safelisted_request_header/index.md
@@ -13,7 +13,7 @@ l10n:
 - {{HTTPHeader("Content-Language")}}
 - {{HTTPHeader("Content-Type")}}
 
-When containing only these headers (and values that meet the additional requirements laid out below), a request doesn't need to send a {{glossary("preflight request")}} in the context of [CORS](/en-US/docs/Glossary/CORS).
+リクエストがこれらのヘッダーのみを含んでいて、なおかつ値が後述の追加要件に合致する場合は、{{glossary("preflight request", "プリフライトリクエスト")}}を [CORS](/ja/docs/Glossary/CORS) のコンテキストにおいて送る必要がありません。
 
 You can safelist more headers using the {{HTTPHeader("Access-Control-Allow-Headers")}} header and also list the above headers there to circumvent the following additional restrictions:
 


### PR DESCRIPTION
### Description

Glossary CORS-safelisted request header の翻訳

### Related issues and pull requests

Fix https://github.com/mozilla-japan/translation/issues/677
