### PR TITLE
pt-br: Drop 'in this module' from Learn/CSS

### DIFF
--- a/files/pt-br/learn/css/building_blocks/cascade_and_inheritance/index.md
+++ b/files/pt-br/learn/css/building_blocks/cascade_and_inheritance/index.md
@@ -251,24 +251,3 @@ Se você não entendeu totalmente a cascata, a especificidade e a herança, não
 Volte aqui se você começar a encontrar problemas estranhos com estilos que não se aplicam conforme o esperado. Pode ser um problema de especificidade.
 
 {{NextMenu("Learn/CSS/Building_blocks/Selectors", "Learn/CSS/Building_blocks")}}
-
-## In this module
-
-1. [Cascade and inheritance](/pt-BR/docs/Learn/CSS/Building_blocks/Cascade_and_inheritance)
-2. [CSS selectors](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors)
-
-    - [Type, class, and ID selectors](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors/Type_Class_and_ID_Selectors)
-    - [Attribute selectors](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors/Attribute_selectors)
-    - [Pseudo-classes and pseudo-elements](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements)
-    - [Combinators](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors/Combinators)
-
-3. [The box model](/pt-BR/docs/Learn/CSS/Building_blocks/The_box_model)
-4. [Backgrounds and borders](/pt-BR/docs/Learn/CSS/Building_blocks/Backgrounds_and_borders)
-5. [Handling different text directions](/pt-BR/docs/Learn/CSS/Building_blocks/Handling_different_text_directions)
-6. [Overflowing content](/pt-BR/docs/Learn/CSS/Building_blocks/Overflowing_content)
-7. [Values and units](/pt-BR/docs/Learn/CSS/Building_blocks/Values_and_units)
-8. [Sizing items in CSS](/pt-BR/docs/Learn/CSS/Building_blocks/Sizing_items_in_CSS)
-9. [Images, media, and form elements](/pt-BR/docs/Learn/CSS/Building_blocks/Images_media_form_elements)
-10. [Styling tables](/pt-BR/docs/Learn/CSS/Building_blocks/Styling_tables)
-11. [Debugging CSS](/pt-BR/docs/Learn/CSS/Building_blocks/Debugging_CSS)
-12. [Organizing your CSS](/pt-BR/docs/Learn/CSS/Building_blocks/Organizing)

--- a/files/pt-br/learn/css/building_blocks/selectors/attribute_selectors/index.md
+++ b/files/pt-br/learn/css/building_blocks/selectors/attribute_selectors/index.md
@@ -88,24 +88,3 @@ No exemplo abaixo, o primeiro seletor corresponderá a um valor que começa com 
 Agora que terminamos com os seletores de atributo, você pode continuar no próximo artigo e ler sobre [pseudo-class and pseudo-element selectors](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements).
 
 {{PreviousMenuNext("Learn/CSS/Building_blocks/Selectors/Type_Class_and_ID_Selectors", "Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements", "Learn/CSS/Building_blocks")}}
-
-## In this module
-
-1. [Cascade and inheritance](/pt-BR/docs/Learn/CSS/Building_blocks/Cascade_and_inheritance)
-2. [CSS selectors](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors)
-
-    - [Type, class, and ID selectors](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors/Type_Class_and_ID_Selectors)
-    - [Attribute selectors](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors/Attribute_selectors)
-    - [Pseudo-classes and pseudo-elements](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements)
-    - [Combinators](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors/Combinators)
-
-3. [The box model](/pt-BR/docs/Learn/CSS/Building_blocks/The_box_model)
-4. [Backgrounds and borders](/pt-BR/docs/Learn/CSS/Building_blocks/Backgrounds_and_borders)
-5. [Handling different text directions](/pt-BR/docs/Learn/CSS/Building_blocks/Handling_different_text_directions)
-6. [Overflowing content](/pt-BR/docs/Learn/CSS/Building_blocks/Overflowing_content)
-7. [Values and units](/pt-BR/docs/Learn/CSS/Building_blocks/Values_and_units)
-8. [Sizing items in CSS](/pt-BR/docs/Learn/CSS/Building_blocks/Sizing_items_in_CSS)
-9. [Images, media, and form elements](/pt-BR/docs/Learn/CSS/Building_blocks/Images_media_form_elements)
-10. [Styling tables](/pt-BR/docs/Learn/CSS/Building_blocks/Styling_tables)
-11. [Debugging CSS](/pt-BR/docs/Learn/CSS/Building_blocks/Debugging_CSS)
-12. [Organizing your CSS](/pt-BR/docs/Learn/CSS/Building_blocks/Organizing)

--- a/files/pt-br/learn/css/building_blocks/selectors/index.md
+++ b/files/pt-br/learn/css/building_blocks/selectors/index.md
@@ -189,24 +189,3 @@ A tabela a seguir fornece uma visão geral dos seletores disponíveis para uso, 
 | [Child combinator](/pt-BR/docs/Web/CSS/Child_combinator)                       | `article > p`       | [Child combinator](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors/Combinators#Child_combinator)                               |
 | [Adjacent sibling combinator](/pt-BR/docs/Web/CSS/Adjacent_sibling_combinator) | `h1 + p`            | [Adjacent sibling](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors/Combinators#Adjacent_sibling)                               |
 | [General sibling combinator](/pt-BR/docs/Web/CSS/General_sibling_combinator)   | `h1 ~ p`            | [General sibling](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors/Combinators#General_sibling)                                 |
-
-## In this module
-
-1. [Cascade and inheritance](/pt-BR/docs/Learn/CSS/Building_blocks/Cascade_and_inheritance)
-2. [CSS selectors](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors)
-
-    - [Type, class, and ID selectors](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors/Type_Class_and_ID_Selectors)
-    - [Attribute selectors](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors/Attribute_selectors)
-    - [Pseudo-classes and pseudo-elements](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements)
-    - [Combinators](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors/Combinators)
-
-3. [The box model](/pt-BR/docs/Learn/CSS/Building_blocks/The_box_model)
-4. [Backgrounds and borders](/pt-BR/docs/Learn/CSS/Building_blocks/Backgrounds_and_borders)
-5. [Handling different text directions](/pt-BR/docs/Learn/CSS/Building_blocks/Handling_different_text_directions)
-6. [Overflowing content](/pt-BR/docs/Learn/CSS/Building_blocks/Overflowing_content)
-7. [Values and units](/pt-BR/docs/Learn/CSS/Building_blocks/Values_and_units)
-8. [Sizing items in CSS](/pt-BR/docs/Learn/CSS/Building_blocks/Sizing_items_in_CSS)
-9. [Images, media, and form elements](/pt-BR/docs/Learn/CSS/Building_blocks/Images_media_form_elements)
-10. [Styling tables](/pt-BR/docs/Learn/CSS/Building_blocks/Styling_tables)
-11. [Debugging CSS](/pt-BR/docs/Learn/CSS/Building_blocks/Debugging_CSS)
-12. [Organizing your CSS](/pt-BR/docs/Learn/CSS/Building_blocks/Organizing)

--- a/files/pt-br/learn/css/building_blocks/the_box_model/index.md
+++ b/files/pt-br/learn/css/building_blocks/the_box_model/index.md
@@ -314,24 +314,3 @@ That's most of what you need to understand about the box model. You may want to 
 In the next lesson, we will take a look at how [backgrounds and borders](/pt-BR/docs/Learn/CSS/Building_blocks/Backgrounds_and_borders) can be used to make your plain boxes look more interesting.
 
 {{PreviousMenuNext("Learn/CSS/Building_blocks/Selectors/Combinators", "Learn/CSS/Building_blocks/Backgrounds_and_borders", "Learn/CSS/Building_blocks")}}
-
-## In this module
-
-1. [Cascade and inheritance](/pt-BR/docs/Learn/CSS/Building_blocks/Cascade_and_inheritance)
-2. [CSS selectors](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors)
-
-    - [Type, class, and ID selectors](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors/Type_Class_and_ID_Selectors)
-    - [Attribute selectors](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors/Attribute_selectors)
-    - [Pseudo-classes and pseudo-elements](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements)
-    - [Combinators](/pt-BR/docs/Learn/CSS/Building_blocks/Selectors/Combinators)
-
-3. [The box model](/pt-BR/docs/Learn/CSS/Building_blocks/The_box_model)
-4. [Backgrounds and borders](/pt-BR/docs/Learn/CSS/Building_blocks/Backgrounds_and_borders)
-5. [Handling different text directions](/pt-BR/docs/Learn/CSS/Building_blocks/Handling_different_text_directions)
-6. [Overflowing content](/pt-BR/docs/Learn/CSS/Building_blocks/Overflowing_content)
-7. [Values and units](/pt-BR/docs/Learn/CSS/Building_blocks/Values_and_units)
-8. [Sizing items in CSS](/pt-BR/docs/Learn/CSS/Building_blocks/Sizing_items_in_CSS)
-9. [Images, media, and form elements](/pt-BR/docs/Learn/CSS/Building_blocks/Images_media_form_elements)
-10. [Styling tables](/pt-BR/docs/Learn/CSS/Building_blocks/Styling_tables)
-11. [Debugging CSS](/pt-BR/docs/Learn/CSS/Building_blocks/Debugging_CSS)
-12. [Organizing your CSS](/pt-BR/docs/Learn/CSS/Building_blocks/Organizing)

--- a/files/pt-br/learn/css/css_layout/flexbox/index.md
+++ b/files/pt-br/learn/css/css_layout/flexbox/index.md
@@ -336,12 +336,3 @@ Isso conclui nosso tour sobre o básico de _flexbox_. Esperamos que você tenha 
 No próximo tópico, veremos outro aspecto importante dos Esquemas em CSS: os sistemas de _grid,_ como você pode ver nesse artigo sobre [CSS grid layout](https://blog.alura.com.br/criando-layouts-com-css-grid-layout/).
 
 {{PreviousMenuNext("Learn/CSS/CSS_layout/Practical_positioning_examples", "Learn/CSS/CSS_layout/Grids", "Learn/CSS/CSS_layout")}}
-
-## Neste módulo
-
-- [Introdução a Esquemas CSS](/pt-BR/docs/Learn/CSS/CSS_layout/Introduction)
-- [Flutuando Elementos com "float"](/pt-BR/docs/Learn/CSS/CSS_layout/Floats)
-- [Posicionamento de elementos](/pt-BR/docs/Learn/CSS/CSS_layout/Positioning)
-- [Exemplos práticos de posicionamento](/pt-BR/docs/Learn/CSS/CSS_layout/Practical_positioning_examples)
-- [Flexbox](/pt-BR/docs/Learn/CSS/CSS_layout/Flexbox)
-- [Grids](/pt-BR/docs/Learn/CSS/CSS_layout/Grids)

--- a/files/pt-br/learn/css/css_layout/introduction/index.md
+++ b/files/pt-br/learn/css/css_layout/introduction/index.md
@@ -678,18 +678,3 @@ body { max-width: 800px; margin: 0 auto; }
 This article has provided a brief summary of all the layout technologies you should know about. Read on for more information on each individual technology!
 
 {{NextMenu("Learn/CSS/CSS_layout/Normal_Flow", "Learn/CSS/CSS_layout")}}
-
-## In this module
-
-- [Introduction to CSS layout](/pt-BR/docs/Learn/CSS/CSS_layout/Introduction)
-- [Normal flow](/pt-BR/docs/Learn/CSS/CSS_layout/Normal_Flow)
-- [Flexbox](/pt-BR/docs/Learn/CSS/CSS_layout/Flexbox)
-- [Grid](/pt-BR/docs/Learn/CSS/CSS_layout/Grids)
-- [Floats](/pt-BR/docs/Learn/CSS/CSS_layout/Floats)
-- [Positioning](/pt-BR/docs/Learn/CSS/CSS_layout/Positioning)
-- [Multiple-column layout](/pt-BR/docs/Learn/CSS/CSS_layout/Multiple-column_Layout)
-- [Responsive design](/pt-BR/docs/Learn/CSS/CSS_layout/Responsive_Design)
-- [Beginner's guide to media queries](/pt-BR/docs/Learn/CSS/CSS_layout/Media_queries)
-- [Legacy layout methods](/pt-BR/docs/Learn/CSS/CSS_layout/Legacy_Layout_Methods)
-- [Supporting older browsers](/pt-BR/docs/Learn/CSS/CSS_layout/Supporting_Older_Browsers)
-- [Fundamental layout comprehension assessment](/pt-BR/docs/Learn/CSS/CSS_layout/Fundamental_Layout_Comprehension)

--- a/files/pt-br/learn/css/css_layout/multiple-column_layout/index.md
+++ b/files/pt-br/learn/css/css_layout/multiple-column_layout/index.md
@@ -397,18 +397,3 @@ You now know how to use the basic features of multiple-column layout, another to
 - [Using multi-column layouts](/pt-BR/docs/Web/CSS/CSS_Columns/Using_multi-column_layouts)
 
 {{PreviousMenuNext("Learn/CSS/CSS_layout/Positioning", "Learn/CSS/CSS_layout/Responsive_Design", "Learn/CSS/CSS_layout")}}
-
-## In this module
-
-- [Introduction to CSS layout](/pt-BR/docs/Learn/CSS/CSS_layout/Introduction)
-- [Normal flow](/pt-BR/docs/Learn/CSS/CSS_layout/Normal_Flow)
-- [Flexbox](/pt-BR/docs/Learn/CSS/CSS_layout/Flexbox)
-- [Grid](/pt-BR/docs/Learn/CSS/CSS_layout/Grids)
-- [Floats](/pt-BR/docs/Learn/CSS/CSS_layout/Floats)
-- [Positioning](/pt-BR/docs/Learn/CSS/CSS_layout/Positioning)
-- [Multiple-column layout](/pt-BR/docs/Learn/CSS/CSS_layout/Multiple-column_Layout)
-- [Responsive design](/pt-BR/docs/Learn/CSS/CSS_layout/Responsive_Design)
-- [Beginner's guide to media queries](/pt-BR/docs/Learn/CSS/CSS_layout/Media_queries)
-- [Legacy layout methods](/pt-BR/docs/Learn/CSS/CSS_layout/Legacy_Layout_Methods)
-- [Supporting older browsers](/pt-BR/docs/Learn/CSS/CSS_layout/Supporting_Older_Browsers)
-- [Fundamental layout comprehension assessment](/pt-BR/docs/Learn/CSS/CSS_layout/Fundamental_Layout_Comprehension)

--- a/files/pt-br/learn/css/css_layout/normal_flow/index.md
+++ b/files/pt-br/learn/css/css_layout/normal_flow/index.md
@@ -91,18 +91,3 @@ span {
 Now that you understand normal flow, and how the browser lays things out by default, move on to understand how to change this default display to create the layout needed by your design.
 
 {{PreviousMenuNext("Learn/CSS/CSS_layout/Introduction", "Learn/CSS/CSS_layout/Flexbox", "Learn/CSS/CSS_layout")}}
-
-## In this module
-
-- [Introduction to CSS layout](/pt-BR/docs/Learn/CSS/CSS_layout/Introduction)
-- [Normal flow](/pt-BR/docs/Learn/CSS/CSS_layout/Normal_Flow)
-- [Flexbox](/pt-BR/docs/Learn/CSS/CSS_layout/Flexbox)
-- [Grid](/pt-BR/docs/Learn/CSS/CSS_layout/Grids)
-- [Floats](/pt-BR/docs/Learn/CSS/CSS_layout/Floats)
-- [Positioning](/pt-BR/docs/Learn/CSS/CSS_layout/Positioning)
-- [Multiple-column layout](/pt-BR/docs/Learn/CSS/CSS_layout/Multiple-column_Layout)
-- [Responsive design](/pt-BR/docs/Learn/CSS/CSS_layout/Responsive_Design)
-- [Beginner's guide to media queries](/pt-BR/docs/Learn/CSS/CSS_layout/Media_queries)
-- [Legacy layout methods](/pt-BR/docs/Learn/CSS/CSS_layout/Legacy_Layout_Methods)
-- [Supporting older browsers](/pt-BR/docs/Learn/CSS/CSS_layout/Supporting_Older_Browsers)
-- [Fundamental layout comprehension assessment](/pt-BR/docs/Learn/CSS/CSS_layout/Fundamental_Layout_Comprehension)

--- a/files/pt-br/learn/css/css_layout/positioning/index.md
+++ b/files/pt-br/learn/css/css_layout/positioning/index.md
@@ -570,18 +570,3 @@ I'm sure you had fun playing with basic positioning; while it is not a method yo
 
 - The {{cssxref("position")}} property reference.
 - [Practical positioning examples](/pt-BR/docs/Learn/CSS/CSS_layout/Practical_positioning_examples), for some more useful ideas.
-
-## In this module
-
-- [Introduction to CSS layout](/pt-BR/docs/Learn/CSS/CSS_layout/Introduction)
-- [Normal flow](/pt-BR/docs/Learn/CSS/CSS_layout/Normal_Flow)
-- [Flexbox](/pt-BR/docs/Learn/CSS/CSS_layout/Flexbox)
-- [Grid](/pt-BR/docs/Learn/CSS/CSS_layout/Grids)
-- [Floats](/pt-BR/docs/Learn/CSS/CSS_layout/Floats)
-- [Positioning](/pt-BR/docs/Learn/CSS/CSS_layout/Positioning)
-- [Multiple-column layout](/pt-BR/docs/Learn/CSS/CSS_layout/Multiple-column_Layout)
-- [Responsive design](/pt-BR/docs/Learn/CSS/CSS_layout/Responsive_Design)
-- [Beginner's guide to media queries](/pt-BR/docs/Learn/CSS/CSS_layout/Media_queries)
-- [Legacy layout methods](/pt-BR/docs/Learn/CSS/CSS_layout/Legacy_Layout_Methods)
-- [Supporting older browsers](/pt-BR/docs/Learn/CSS/CSS_layout/Supporting_Older_Browsers)
-- [Fundamental layout comprehension assessment](/pt-BR/docs/Learn/CSS/CSS_layout/Fundamental_Layout_Comprehension)

--- a/files/pt-br/learn/css/css_layout/responsive_design/index.md
+++ b/files/pt-br/learn/css/css_layout/responsive_design/index.md
@@ -293,18 +293,3 @@ Responsive design refers to a site or application design that responds to the en
 It has also become much easier to achieve responsive designs with the help of the layout methods you have learned in these lessons. If you are new to web development today you have many more tools at your disposal than in the early days of responsive design. It is therefore worth checking the age of any materials you are referencing. While the historical articles are still useful, modern use of CSS and HTML makes it far easier to create elegant and useful designs, no matter what device your visitor views the site with.
 
 {{PreviousMenuNext("Learn/CSS/CSS_layout/Multiple-column_Layout", "Learn/CSS/CSS_layout/Media_queries", "Learn/CSS/CSS_layout")}}
-
-## In this module
-
-- [Introduction to CSS layout](/pt-BR/docs/Learn/CSS/CSS_layout/Introduction)
-- [Normal flow](/pt-BR/docs/Learn/CSS/CSS_layout/Normal_Flow)
-- [Flexbox](/pt-BR/docs/Learn/CSS/CSS_layout/Flexbox)
-- [Grid](/pt-BR/docs/Learn/CSS/CSS_layout/Grids)
-- [Floats](/pt-BR/docs/Learn/CSS/CSS_layout/Floats)
-- [Positioning](/pt-BR/docs/Learn/CSS/CSS_layout/Positioning)
-- [Multiple-column layout](/pt-BR/docs/Learn/CSS/CSS_layout/Multiple-column_Layout)
-- [Responsive design](/pt-BR/docs/Learn/CSS/CSS_layout/Responsive_Design)
-- [Beginner's guide to media queries](/pt-BR/docs/Learn/CSS/CSS_layout/Media_queries)
-- [Legacy layout methods](/pt-BR/docs/Learn/CSS/CSS_layout/Legacy_Layout_Methods)
-- [Supporting older browsers](/pt-BR/docs/Learn/CSS/CSS_layout/Supporting_Older_Browsers)
-- [Fundamental layout comprehension assessment](/pt-BR/docs/Learn/CSS/CSS_layout/Fundamental_Layout_Comprehension)

--- a/files/pt-br/learn/css/first_steps/getting_started/index.md
+++ b/files/pt-br/learn/css/first_steps/getting_started/index.md
@@ -285,11 +285,3 @@ Neste tutorial, demos uma olhada na quantidade de maneiras as quais pode-se esti
 Na próxima lição, veremos como o CSS é estruturado.
 
 {{PreviousMenuNext("Learn/CSS/First_steps/What_is_CSS", "Learn/CSS/First_steps/How_CSS_is_structured", "Learn/CSS/First_steps")}}
-
-## Neste módulo
-
-1. [O que é CSS?](/pt-BR/docs/Learn/CSS/First_steps/What_is_CSS)
-2. [Começando com CSS](/pt-BR/docs/Learn/CSS/First_steps/Getting_started)
-3. [Como o CSS é estruturado](/pt-BR/docs/Learn/CSS/First_steps/How_CSS_is_structured)
-4. [Como o CSS funciona](/pt-BR/docs/Learn/CSS/First_steps/How_CSS_works)
-5. [Usando o seu novo conhecimento](/pt-BR/docs/Learn/CSS/First_steps/Using_your_new_knowledge)

--- a/files/pt-br/learn/css/first_steps/how_css_is_structured/index.md
+++ b/files/pt-br/learn/css/first_steps/how_css_is_structured/index.md
@@ -541,11 +541,3 @@ padding- left: 10px;
 É útil entender um pouco sobre como o navegador pega seu HTML e CSS e transforma-o em uma página da web, então no próximo artigo — [Como CSS Funciona](/pt-BR/docs/Learn/CSS/First_steps/How_CSS_works) — vamos dar uma olhada nesse processo.
 
 {{PreviousMenuNext("Learn/CSS/First_steps/Getting_started", "Learn/CSS/First_steps/How_CSS_works", "Learn/CSS/First_steps")}}
-
-## Neste módulo
-
-1. [O que é CSS?](/pt-BR/docs/Learn/CSS/First_steps/What_is_CSS)
-2. [Começando com CSS](/pt-BR/docs/Learn/CSS/First_steps/Getting_started)
-3. [Como o CSS é estruturad](/pt-BR/docs/Learn/CSS/First_steps/How_CSS_is_structured)o
-4. [Como o CSS funciona](/pt-BR/docs/Learn/CSS/First_steps/How_CSS_works)
-5. [Usando seu novo conhecimento](/pt-BR/docs/Learn/CSS/First_steps/Using_your_new_knowledge)

--- a/files/pt-br/learn/css/first_steps/how_css_works/index.md
+++ b/files/pt-br/learn/css/first_steps/how_css_works/index.md
@@ -169,11 +169,3 @@ Iremos visualizar várias outras maneiras de auxiliar diferentes browsers em li�
 Você está quase encerrando este módulo; só temos mais uma tarefa para fazer. No próximo artigo, você utilizará seu novo conhecimento para reestilizar um exemplo, testando seus aprendizados de CSS no processo.
 
 {{PreviousMenuNext("Learn/CSS/First_steps/How_CSS_is_structured", "Learn/CSS/First_steps/Using_your_new_knowledge", "Learn/CSS/First_steps")}}
-
-## Neste módulo
-
-1. [O que é CSS?](/pt-BR/docs/Learn/CSS/First_steps/What_is_CSS)
-2. [Começando com CSS](/pt-BR/docs/Learn/CSS/First_steps/Getting_started)
-3. [Como o CSS é estruturado](/pt-BR/docs/Learn/CSS/First_steps/How_CSS_is_structured)
-4. [Como o CSS funciona](/pt-BR/docs/Learn/CSS/First_steps/How_CSS_works)
-5. [Utilizando seu novo conhecimento](/pt-BR/docs/Learn/CSS/First_steps/Using_your_new_knowledge)

--- a/files/pt-br/learn/css/first_steps/styling_a_biography_page/index.md
+++ b/files/pt-br/learn/css/first_steps/styling_a_biography_page/index.md
@@ -81,11 +81,3 @@ Se gostaria de ter seu trabalho avaliado, ou se ficou emperrado e gostaria de aj
 Parabéns por terminar seu primeiro módulo. Agora você deve ter uma boa compreensão geral de CSS, e ser capaz de entender boa parte do que acontece numa folha de estilos. No próximo módulo, [CSS building blocks](/pt-BR/docs/Learn/CSS/Building_blocks), iremos dar uma olhada com mais profundidade em várias áreas chave.
 
 {{PreviousMenu("Learn/CSS/First_steps/How_CSS_works", "Learn/CSS/First_steps")}}
-
-## Neste módulo
-
-1. [O que é CSS?](/pt-BR/docs/Learn/CSS/First_steps/What_is_CSS)
-2. [Começando com CSS](/pt-BR/docs/Learn/CSS/First_steps/Getting_started)
-3. [Como o CSS é estruturado](/pt-BR/docs/Learn/CSS/First_steps/How_CSS_is_structured)
-4. [Como o CSS funciona](/pt-BR/docs/Learn/CSS/First_steps/How_CSS_works)
-5. [Utilizando seu novo conhecimento](/pt-BR/docs/Learn/CSS/First_steps/Using_your_new_knowledge)

--- a/files/pt-br/learn/css/first_steps/what_is_css/index.md
+++ b/files/pt-br/learn/css/first_steps/what_is_css/index.md
@@ -120,11 +120,3 @@ A seguir, é apresentado o gráfico de dados compat para propriedade CSS [`font-
 Agora que você tem algum entendimento do que o CSS é, vamos ao [Iniciando com CSS](/pt-BR/docs/Learn/CSS/First_steps/Getting_started), onde pode começar a escrever alguma coisa, você mesmo.
 
 {{NextMenu("Learn/CSS/First_steps/Getting_started", "Learn/CSS/First_steps")}}
-
-## Neste módulo
-
-1. [O que é CSS?](/pt-BR/docs/Learn/CSS/First_steps/What_is_CSS)
-2. [Começando com CSS](/pt-BR/docs/Learn/CSS/First_steps/Getting_started)
-3. [Como o CSS é estruturado](/pt-BR/docs/Learn/CSS/First_steps/How_CSS_is_structured)
-4. [Como o CSS funciona](/pt-BR/docs/Learn/CSS/First_steps/How_CSS_works)
-5. [Usando o seu novo conhecimento](/pt-BR/docs/Learn/CSS/First_steps/Using_your_new_knowledge)


### PR DESCRIPTION
### Description

Drop 'in this module' from Learn/CSS

### Motivation

The chore of removing the redundant section

### Related issues and pull requests

Relates to https://github.com/mdn/translated-content/issues/12199