### PR TITLE
pt-br: Drop 'in this module' from Learn/Forms

### DIFF
--- a/files/pt-br/learn/forms/basic_native_form_controls/index.md
+++ b/files/pt-br/learn/forms/basic_native_form_controls/index.md
@@ -638,17 +638,3 @@ To dig into the different form widgets, there are some useful external resources
 - [HTML5 Tests - inputs](http://www.quirksmode.org/html5/inputs.html) on Quirksmode (also [available for mobile](http://www.quirksmode.org/html5/inputs_mobile.html) browsers)
 
 {{PreviousMenuNext("Learn/HTML/Forms/How_to_structure_an_HTML_form", "Learn/HTML/Forms/Sending_and_retrieving_form_data", "Learn/HTML/Forms")}}
-
-## In this module
-
-- [Your first HTML form](/pt-BR/docs/Learn/HTML/Forms/Your_first_HTML_form)
-- [How to structure an HTML form](/pt-BR/docs/Learn/HTML/Forms/How_to_structure_an_HTML_form)
-- [The native form widgets](/pt-BR/docs/Learn/HTML/Forms/The_native_form_widgets)
-- [Sending form data](/pt-BR/docs/Learn/HTML/Forms/Sending_and_retrieving_form_data)
-- [Form data validation](/pt-BR/docs/Learn/HTML/Forms/Form_validation)
-- [How to build custom form widgets](/pt-BR/docs/Learn/HTML/Forms/How_to_build_custom_form_widgets)
-- [Sending forms through JavaScript](/pt-BR/docs/Learn/HTML/Forms/Sending_forms_through_JavaScript)
-- [HTML forms in legacy browsers](/pt-BR/docs/Learn/HTML/Forms/HTML_forms_in_legacy_browsers)
-- [Styling HTML forms](/pt-BR/docs/Learn/HTML/Forms/Styling_HTML_forms)
-- [Advanced styling for HTML forms](/pt-BR/docs/Learn/HTML/Forms/Advanced_styling_for_HTML_forms)
-- [Property compatibility table for form widgets](/pt-BR/docs/Learn/HTML/Forms/Property_compatibility_table_for_form_widgets)

--- a/files/pt-br/learn/forms/form_validation/index.md
+++ b/files/pt-br/learn/forms/form_validation/index.md
@@ -740,17 +740,3 @@ A validação de formulário não requer JavaScript complexo, mas requer pensar 
 - Indique exatamente onde ocorre o erro (especialmente em formulários grandes).
 
 {{PreviousMenuNext("Learn/HTML/Forms/Sending_and_retrieving_form_data", "Learn/HTML/Forms/How_to_build_custom_form_widgets", "Learn/HTML/Forms")}}
-
-## Neste módulo
-
-- [Seu primeiro formulário HTML](/pt-BR/docs/Learn/HTML/Forms/Your_first_HTML_form)
-- [Como estruturar um formulário HTML](/pt-BR/docs/Learn/HTML/Forms/How_to_structure_an_HTML_form)
-- [Os widgets de formulário nativos](/pt-BR/docs/Learn/HTML/Forms/The_native_form_widgets)
-- [Enviando dados do formulário](/pt-BR/docs/Learn/HTML/Forms/Sending_and_retrieving_form_data)
-- [Validação de dados do formulário](/pt-BR/docs/Learn/HTML/Forms/Form_validation)
-- [Como criar widgets de formulário personalizados](/pt-BR/docs/Learn/HTML/Forms/How_to_build_custom_form_widgets)
-- [Enviando formulários por JavaScript](/pt-BR/docs/Learn/HTML/Forms/Sending_forms_through_JavaScript)
-- [Formulários HTML em navegadores legados](/pt-BR/docs/Learn/HTML/Forms/HTML_forms_in_legacy_browsers)
-- [Estilizando formulários HTML](/pt-BR/docs/Learn/HTML/Forms/Styling_HTML_forms)
-- [Estilo avançado para formulários HTML](/pt-BR/docs/Learn/HTML/Forms/Advanced_styling_for_HTML_forms)
-- [Tabela de compatibilidade de propriedades para widgets de formulário](/pt-BR/docs/Learn/HTML/Forms/Property_compatibility_table_for_form_widgets)

--- a/files/pt-br/learn/forms/how_to_structure_a_web_form/index.md
+++ b/files/pt-br/learn/forms/how_to_structure_a_web_form/index.md
@@ -298,17 +298,3 @@ You now have all the knowledge you'll need to properly structure your HTML forms
 - [A List Apart: _Sensible Forms: A Form Usability Checklist_](http://www.alistapart.com/articles/sensibleforms/)
 
 {{PreviousMenuNext("Learn/HTML/Forms/Your_first_HTML_form", "Learn/HTML/Forms/The_native_form_widgets", "Learn/HTML/Forms")}}
-
-## In this module
-
-- [Your first HTML form](/pt-BR/docs/Learn/HTML/Forms/Your_first_HTML_form)
-- [How to structure an HTML form](/pt-BR/docs/Learn/HTML/Forms/How_to_structure_an_HTML_form)
-- [The native form widgets](/pt-BR/docs/Learn/HTML/Forms/The_native_form_widgets)
-- [Sending form data](/pt-BR/docs/Learn/HTML/Forms/Sending_and_retrieving_form_data)
-- [Form data validation](/pt-BR/docs/Learn/HTML/Forms/Form_validation)
-- [How to build custom form widgets](/pt-BR/docs/Learn/HTML/Forms/How_to_build_custom_form_widgets)
-- [Sending forms through JavaScript](/pt-BR/docs/Learn/HTML/Forms/Sending_forms_through_JavaScript)
-- [HTML forms in legacy browsers](/pt-BR/docs/Learn/HTML/Forms/HTML_forms_in_legacy_browsers)
-- [Styling HTML forms](/pt-BR/docs/Learn/HTML/Forms/Styling_HTML_forms)
-- [Advanced styling for HTML forms](/pt-BR/docs/Learn/HTML/Forms/Advanced_styling_for_HTML_forms)
-- [Property compatibility table for form widgets](/pt-BR/docs/Learn/HTML/Forms/Property_compatibility_table_for_form_widgets)


### PR DESCRIPTION
### Description

Drop 'in this module' from Learn/Forms

### Motivation

The chore of removing the redundant section

### Related issues and pull requests

Relates to #12199