### PR TITLE
zh-CN: (Re)translate `margin-block*` and `margin-inline`

### DIFF
--- a/files/zh-cn/web/css/margin-block-end/index.md
+++ b/files/zh-cn/web/css/margin-block-end/index.md
@@ -1,0 +1,91 @@
+---
+title: margin-block-end
+slug: Web/CSS/margin-block-end
+---
+
+{{CSSRef}}
+
+[CSS](/zh-CN/docs/Web/CSS) 属性 **`margin-block-end`** 定义了元素的逻辑块末外边距，并根据元素的书写模式、行内方向和文本朝向对应至实体外边距。
+
+{{EmbedInteractiveExample("pages/css/margin-block-end.html")}}
+
+## 语法
+
+```css
+/* 长度值 */
+margin-block-end: 10px; /* 绝对长度 */
+margin-block-end: 1em; /* 相对于文本尺寸 */
+margin-block-end: 5%; /* 相对于最近包含块的宽度 */
+
+/* 关键词值 */
+margin-block-end: auto;
+
+/* 全局值 */
+margin-block-end: inherit;
+margin-block-end: initial;
+margin-block-end: revert;
+margin-block-end: revert-layer;
+margin-block-end: unset;
+```
+
+根据 {{CSSXref("writing-mode")}}、{{CSSXref("direction")}} 和 {{CSSXref("text-orientation")}} 所定义的值，此属性对应于 {{CSSXref("margin-top")}}、{{CSSXref("margin-right")}}、{{CSSXref("margin-bottom")}} 或 {{CSSXref("margin-left")}} 属性。
+
+与此属性相关的有 {{CSSXref("margin-block-start")}}、{{CSSXref("margin-inline-start")}} 和 {{CSSXref("margin-inline-end")}} 等定义元素的其他外边距的属性。
+
+### 取值
+
+`margin-block-end` 属性的取值与 {{CSSXref("margin-left")}} 属性相同。
+
+## 形式定义
+
+{{CSSInfo}}
+
+## 形式语法
+
+{{CSSSyntax}}
+
+## 示例
+
+### 设置块末外边距
+
+#### HTML
+
+```html
+<div>
+  <p class="exampleText">示例文本</p>
+</div>
+```
+
+#### CSS
+
+```css
+div {
+  background-color: yellow;
+  width: 120px;
+  height: 120px;
+}
+
+.exampleText {
+  writing-mode: vertical-rl;
+  margin-block-end: 20px;
+  background-color: #c8c800;
+}
+```
+
+#### 结果
+
+{{EmbedLiveSample("设置块末外边距", 140, 140)}}
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}
+
+## 参见
+
+- [CSS 逻辑属性与逻辑值](/zh-CN/docs/Web/CSS/CSS_Logical_Properties)
+- 对应的实体属性：{{CSSXref("margin-top")}}、{{CSSXref("margin-right")}}、{{CSSXref("margin-bottom")}} 和 {{CSSXref("margin-left")}}
+- {{CSSXref("writing-mode")}}、{{CSSXref("direction")}}、{{CSSXref("text-orientation")}}

--- a/files/zh-cn/web/css/margin-block-start/index.md
+++ b/files/zh-cn/web/css/margin-block-start/index.md
@@ -3,52 +3,60 @@ title: margin-block-start
 slug: Web/CSS/margin-block-start
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{CSSRef}}
 
-**`margin-block-start`** [CSS](/zh-CN/docs/Web/CSS) 属性定义了一个元素的逻辑块的开始边距，是用来根据元素的书写模式，方向和文本方向进行实际边界的衡量。
+[CSS](/zh-CN/docs/Web/CSS) 属性 **`margin-block-start`** 定义了元素的逻辑块首外边距，并根据元素的书写模式、行内方向和文本朝向对应至实体外边距。
+
+{{EmbedInteractiveExample("pages/css/margin-block-start.html")}}
+
+## 语法
 
 ```css
-/* <length> values */
-margin-block-start: 10px;  /* 绝对长度 */
-margin-block-start: 1em;   /* 文本的相对大小 */
-margin-block-start: 5%;    /* 相对于最近块容器的大小 */
+/* 长度值 */
+margin-block-start: 10px; /* 绝对长度 */
+margin-block-start: 1em; /* 相对于文本尺寸 */
+margin-block-start: 5%; /* 相对于最近包含块的宽度 */
 
-/* 关键字值 */
+/* 关键词值 */
 margin-block-start: auto;
 
 /* 全局值 */
 margin-block-start: inherit;
 margin-block-start: initial;
-margin-block-start: unset
+margin-block-start: revert;
+margin-block-start: revert-layer;
+margin-block-start: unset;
 ```
 
-{{cssxref("margin-top")}}, {{cssxref("margin-right")}}, {{cssxref("margin-bottom")}}, or {{cssxref("margin-left")}} 属性对应于 {{cssxref("writing-mode")}}, {{cssxref("direction")}}, 和{{cssxref("text-orientation")}}属性定义的值。
+根据 {{CSSXref("writing-mode")}}、{{CSSXref("direction")}} 和 {{CSSXref("text-orientation")}} 所定义的值，此属性对应于 {{CSSXref("margin-top")}}、{{CSSXref("margin-right")}}、{{CSSXref("margin-bottom")}} 或 {{CSSXref("margin-left")}} 属性。
 
-它涉及到 {{cssxref("margin-block-end")}}, {{cssxref("margin-inline-start")}},和 {{cssxref("margin-inline-end")}}属性，这些属性是用来定义其他元素的边界。
+与此属性相关的有 {{CSSXref("margin-block-end")}}、{{CSSXref("margin-inline-start")}} 和 {{CSSXref("margin-inline-end")}} 等定义元素的其他外边距的属性。
 
-{{cssinfo}}
+### 取值
 
-## 语法
+`margin-block-start` 属性的取值与 {{CSSXref("margin-left")}} 属性相同。
 
-### 值
+## 形式定义
 
-`margin-block-start` 属性有着和 {{cssxref("margin-left")}} 属性一样的值。
+{{CSSInfo}}
 
-### 形式语法
+## 形式语法
 
-{{csssyntax}}
+{{CSSSyntax}}
 
 ## 示例
 
-### HTML
+### 设置块首外边距
+
+#### HTML
 
 ```html
 <div>
-  <p class="exampleText">Example text</p>
+  <p class="exampleText">示例文本</p>
 </div>
 ```
 
-### CSS
+#### CSS
 
 ```css
 div {
@@ -64,7 +72,9 @@ div {
 }
 ```
 
-{{EmbedLiveSample("示例", 140, 140)}}
+#### 结果
+
+{{EmbedLiveSample("设置块首外边距", 140, 140)}}
 
 ## 规范
 
@@ -76,5 +86,6 @@ div {
 
 ## 参见
 
-- 标记的物理属性：{{cssxref("margin-top")}}, {{cssxref("margin-right")}}, {{cssxref("margin-bottom")}}, and {{cssxref("margin-left")}}
-- {{cssxref("writing-mode")}}, {{cssxref("direction")}}, {{cssxref("text-orientation")}}
+- [CSS 逻辑属性与逻辑值](/zh-CN/docs/Web/CSS/CSS_Logical_Properties)
+- 对应的实体属性：{{CSSXref("margin-top")}}、{{CSSXref("margin-right")}}、{{CSSXref("margin-bottom")}} 和 {{CSSXref("margin-left")}}
+- {{CSSXref("writing-mode")}}、{{CSSXref("direction")}}、{{CSSXref("text-orientation")}}

--- a/files/zh-cn/web/css/margin-block/index.md
+++ b/files/zh-cn/web/css/margin-block/index.md
@@ -3,73 +3,101 @@ title: margin-block
 slug: Web/CSS/margin-block
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{CSSRef}}
 
-**`margin-block`**这个[CSS](/zh-CN/docs/Web/CSS)属性定义了一个元素的逻辑块开始和结束边距，根据元素的写入模式、方向性和文本方向映射到物理边界。
+[CSS](/zh-CN/docs/Web/CSS) [简写属性](/en-US/docs/Web/CSS/Shorthand_properties) **`margin-block`** 定义了元素的逻辑块首和块末外边距，并根据元素的书写模式、行内方向和文本朝向对应至实体外边距。
 
-```css
-/* 有长度的具体的值 */
-margin-block: 10px 20px;  /* 一个绝对的长度值 */
-margin-block: 1em 2em;   /* 相对于文本大小的值 */
-margin-block: 5% 2%;    /* 相对于最近的块容器宽度的值 */
-margin-block: 10px; /* 设置开始值和结束值 */
+{{EmbedInteractiveExample("pages/css/margin-block.html")}}
 
-/* 关键字 值 */
-margin-block: auto;
+## 属性构成
 
-/* 全局 值 */
-margin-block: inherit;
-margin-block: initial;
-margin-block: unset;
-```
+此属性为下列 CSS 属性的简写属性：
 
-这些值对应的是{{CSSxRef("margin-top")}}和{{CSSxRef("margin-bottom")}}，或者 {{CSSxRef("margin-right")}}，和{{CSSxRef("margin-left")}}，这些属性取决于{{CSSxRef("writing-mode")}}，{{CSSxRef("direction")}}，和{{CSSxRef("text-orientation")}}。
-
-这些值可以单独设置为{{CSSxRef("margin-block-start")}}和{{CSSxRef("margin-block-end")}}。inline direction 属性是{{CSSxRef("margin-inline")}}，也可设置为{{CSSxRef("margin-inline-start")}}，和{{CSSxRef("margin-inline-end")}}。
+- {{CSSXref("margin-block-start")}}
+- {{CSSXref("margin-block-end")}}
 
 ## 语法
 
-### 值
+```css
+/* 长度值 */
+margin-block: 10px 20px; /* 绝对长度 */
+margin-block: 1em 2em; /* 相对于文本尺寸 */
+margin-block: 5% 2%; /* 相对于最近包含块的宽度 */
+margin-block: 10px; /* 同时设置块首和块末值 */
 
-`margin-block`属性采用和{{CSSxRef("margin-left")}}属性相同的值。
+/* 关键词值 */
+margin-block: auto;
 
-### 形式语法
+/* 全局值 */
+margin-block: inherit;
+margin-block: initial;
+margin-block: revert;
+margin-block: revert-layer;
+margin-block: unset;
+```
+
+根据 {{CSSXref("writing-mode")}}、{{CSSXref("direction")}} 和 {{CSSXref("text-orientation")}} 所定义的值，此属性对应于 {{CSSXref("margin-top")}} 和 {{CSSXref("margin-bottom")}}，或者 {{CSSXref("margin-right")}} 和 {{CSSXref("margin-left")}} 属性。
+
+`margin-block` 属性可用一个或两个值指定。
+
+- 用**一个**值指定时，**块首和块末**应用同样的外边距。
+- 用**两个**值指定时，第一个外边距应用于**块首**，第二个应用于**块末**。
+
+### 取值
+
+`margin-block` 属性的取值与 {{CSSXref("margin")}} 属性相同。
+
+## 形式定义
+
+{{CSSInfo}}
+
+## 形式语法
 
 {{CSSSyntax}}
 
 ## 示例
 
-### HTML
+### 设置块首和块末外边距
 
-```html
-<div>
-  <p class="exampleText">Example text</p>
-</div>
-```
-
-### CSS
+#### CSS
 
 ```css
 div {
   background-color: yellow;
   width: 120px;
-  height: 120px;
+  height: auto;
+  border: 1px solid green;
 }
 
-.exampleText {
-  writing-mode: vertical-rl;
+p {
+  margin: 0;
   margin-block: 20px 40px;
-  background-color: #c8c800;
+  background-color: tan;
+}
+
+.verticalExample {
+  writing-mode: vertical-rl;
 }
 ```
 
-{{EmbedLiveSample("示例", 140, 140)}}
+#### HTML
+
+```html
+<div>
+  <p>示例文本</p>
+</div>
+<div class="verticalExample">
+  <p>示例文本</p>
+</div>
+```
+
+#### 结果
+
+{{EmbedLiveSample("设置块首和块末外边距", 140, 200)}}
 
 ## 规范
 
 {{Specifications}}
-
-{{CSSInfo}}
 
 ## 浏览器兼容性
 
@@ -77,5 +105,6 @@ div {
 
 ## 参见
 
-- 所映射的物理特性： {{CSSxRef("margin-top")}}，{{CSSxRef("margin-right")}}，{{CSSxRef("margin-bottom")}}和{{CSSxRef("margin-left")}}
-- {{CSSxRef("writing-mode")}}，{{CSSxRef("direction")}}，{{CSSxRef("text-orientation")}}
+- [CSS 逻辑属性与逻辑值](/zh-CN/docs/Web/CSS/CSS_Logical_Properties)
+- 对应的实体属性：{{CSSXref("margin-top")}}、{{CSSXref("margin-right")}}、{{CSSXref("margin-bottom")}} 和 {{CSSXref("margin-left")}}
+- {{CSSXref("writing-mode")}}、{{CSSXref("direction")}}、{{CSSXref("text-orientation")}}

--- a/files/zh-cn/web/css/margin-inline/index.md
+++ b/files/zh-cn/web/css/margin-inline/index.md
@@ -1,0 +1,110 @@
+---
+title: margin-inline
+slug: Web/CSS/margin-inline
+---
+
+{{CSSRef}}
+
+[CSS](/zh-CN/docs/Web/CSS) [简写属性](/en-US/docs/Web/CSS/Shorthand_properties) **`margin-inline`** 定义了元素的逻辑行首和行末外边距，并根据元素的书写模式、行内方向和文本朝向对应至实体外边距。
+
+{{EmbedInteractiveExample("pages/css/margin-inline.html")}}
+
+## 属性构成
+
+此属性为下列 CSS 属性的简写属性：
+
+- {{CSSXref("margin-inline-start")}}
+- {{CSSXref("margin-inline-end")}}
+
+## 语法
+
+```css
+/* 长度值 */
+margin-inline: 10px 20px; /* 绝对长度 */
+margin-inline: 1em 2em; /* 相对于文本尺寸 */
+margin-inline: 5% 2%; /* 相对于最近包含块的宽度 */
+margin-inline: 10px; /* 同时设置行首和行末值 */
+
+/* 关键词值 */
+margin-inline: auto;
+
+/* 全局值 */
+margin-inline: inherit;
+margin-inline: initial;
+margin-inline: revert;
+margin-inline: revert-layer;
+margin-inline: unset;
+```
+
+根据 {{CSSXref("writing-mode")}}、{{CSSXref("direction")}} 和 {{CSSXref("text-orientation")}} 所定义的值，此属性对应于 {{CSSXref("margin-top")}} 和 {{CSSXref("margin-bottom")}}，或者 {{CSSXref("margin-right")}} 和 {{CSSXref("margin-left")}} 属性。
+
+`margin-inline` 属性可用一个或两个值指定。
+
+- 用**一个**值指定时，**行首和行末**应用同样的外边距。
+- 用**两个**值指定时，第一个外边距应用于**行首**，第二个应用于**行末**。
+
+### 取值
+
+`margin-inline` 属性的取值与 {{CSSXref("margin")}} 属性相同。
+
+## 形式定义
+
+{{CSSInfo}}
+
+## 形式语法
+
+{{CSSSyntax}}
+
+## 示例
+
+### 设置行首和行末外边距
+
+#### CSS
+
+```css
+div {
+  background-color: yellow;
+  width: 120px;
+  height: auto;
+  border: 1px solid green;
+}
+
+p {
+  margin: 0;
+  margin-inline: 20px 40px;
+  background-color: tan;
+}
+
+.verticalExample {
+  writing-mode: vertical-rl;
+}
+```
+
+#### HTML
+
+```html
+<div>
+  <p>示例文本</p>
+</div>
+<div class="verticalExample">
+  <p>示例文本</p>
+</div>
+```
+
+#### 结果
+
+{{EmbedLiveSample("设置行首和行末外边距", 140, 240)}}
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器规范性
+
+{{Compat}}
+
+## 参见
+
+- [CSS 逻辑属性与逻辑值](/zh-CN/docs/Web/CSS/CSS_Logical_Properties)
+- 对应的实体属性：{{CSSXref("margin-top")}}、{{CSSXref("margin-right")}}、{{CSSXref("margin-bottom")}} 和 {{CSSXref("margin-left")}}
+- {{CSSXref("writing-mode")}}、{{CSSXref("direction")}}、{{CSSXref("text-orientation")}}


### PR DESCRIPTION
### Description

### Motivation

### Additional details

 1. 所有内容均根据 `en-US` 版本统一翻译或重新翻译。
 2. [CSS 逻辑属性与逻辑值](https://developer.mozilla.org/zh-CN/docs/Web/CSS/CSS_Logical_Properties)（与页面现有标题略有区别）正在翻译中，随后补上链接。

### Related issues and pull requests