### PR TITLE
[zh-cn]: update 'jank' translation

### DIFF
--- a/files/zh-cn/web/performance/critical_rendering_path/index.md
+++ b/files/zh-cn/web/performance/critical_rendering_path/index.md
@@ -7,7 +7,7 @@ slug: Web/Performance/Critical_rendering_path
 
 在解析 HTML 时会创建文档对象模型。HTML 可以请求 JavaScript，而 JavaScript 反过来，又可以更改 DOM。HTML 包含或请求样式，依次来构建 CSS 对象模型。浏览器引擎将两者结合起来以创建渲染树。布局确定页面上所有内容的大小和位置。确定布局后，将像素绘制到屏幕上。
 
-优化关键渲染路径可以缩短首次渲染的时间。了解和优化关键渲染路径对于确保重排和重绘可以每秒 60 帧的速度进行，以确保高效的用户交互并避免讨厌是很重要的。
+优化关键渲染路径可以缩短首次渲染的时间。了解和优化关键渲染路径对于确保重排和重绘可以每秒 60 帧的速度进行，以确保高效的用户交互并避免[卡顿](https://developer.mozilla.org/zh-CN/docs/Glossary/Jank)是很重要的。
 
 ## 理解 CRP
 

--- a/files/zh-cn/web/performance/critical_rendering_path/index.md
+++ b/files/zh-cn/web/performance/critical_rendering_path/index.md
@@ -7,7 +7,7 @@ slug: Web/Performance/Critical_rendering_path
 
 在解析 HTML 时会创建文档对象模型。HTML 可以请求 JavaScript，而 JavaScript 反过来，又可以更改 DOM。HTML 包含或请求样式，依次来构建 CSS 对象模型。浏览器引擎将两者结合起来以创建渲染树。布局确定页面上所有内容的大小和位置。确定布局后，将像素绘制到屏幕上。
 
-优化关键渲染路径可以缩短首次渲染的时间。了解和优化关键渲染路径对于确保重排和重绘可以每秒 60 帧的速度进行，以确保高效的用户交互并避免[卡顿](https://developer.mozilla.org/zh-CN/docs/Glossary/Jank)是很重要的。
+优化关键渲染路径可以缩短首次渲染的时间。了解和优化关键渲染路径对于确保重排和重绘可以每秒 60 帧的速度进行，以确保高效的用户交互并避免[卡顿](/zh-CN/docs/Glossary/Jank)是很重要的。
 
 ## 理解 CRP
 


### PR DESCRIPTION
The Translation of jank was changed from '讨厌' to '卡顿'

### Description

原句是“优化关键渲染路径可以缩短首次渲染的时间。了解和优化关键渲染路径对于确保重排和重绘可以每秒 60 帧的速度进行，以确保高效的用户交互并避免讨厌是很重要的。”，“讨厌”在这里有点突兀且难以理解，参考至[卡顿](https://developer.mozilla.org/zh-CN/docs/Glossary/Jank)释义