### PR TITLE
zh-CN: Translate the `border-*-color` logical properties

### DIFF
--- a/files/zh-cn/web/css/border-block-color/index.md
+++ b/files/zh-cn/web/css/border-block-color/index.md
@@ -1,0 +1,85 @@
+---
+title: border-block-color
+slug: Web/CSS/border-block-color
+---
+
+{{CSSRef}}
+
+[CSS](/zh-CN/docs/Web/CSS) 属性 **`border-block-color`** 定义了元素的逻辑块向的边框颜色，并根据元素的书写模式、行内方向和文本朝向对应至实体边框颜色。根据 {{CSSXref("writing-mode")}}、{{CSSXref("direction")}} 和 {{CSSXref("text-orientation")}} 所定义的值，此属性对应于 {{CSSXref("border-top-color")}} 和 {{CSSXref("border-bottom-color")}}，或者 {{CSSXref("border-right-color")}} 和 {{CSSXref("border-left-color")}} 属性。
+
+{{EmbedInteractiveExample("pages/css/border-block-color.html")}}
+
+另一方向的边框颜色可用 {{CSSXref("border-inline-color")}} 设置，此属性会设置 {{CSSXref("border-inline-start-color")}} 和 {{CSSXref("border-inline-end-color")}}。
+
+## 语法
+
+```css
+border-block-color: yellow;
+border-block-color: #f5f6f7;
+
+/* 全局值 */
+border-block-color: inherit;
+border-block-color: initial;
+border-block-color: revert;
+border-block-color: revert-layer;
+border-block-color: unset;
+```
+
+### 取值
+
+- `<'color'>`
+  - : 边框颜色。见 {{CSSXref("color")}}。
+
+## 形式定义
+
+{{CSSInfo}}
+
+## 形式语法
+
+{{CSSSyntax}}
+
+## 示例
+
+### 竖排文本的边框
+
+#### HTML
+
+```html
+<div>
+  <p class="exampleText">示例文本</p>
+</div>
+```
+
+#### CSS
+
+```css
+div {
+  background-color: yellow;
+  width: 120px;
+  height: 120px;
+}
+
+.exampleText {
+  writing-mode: vertical-lr;
+  border: 10px solid blue;
+  border-block-color: red;
+}
+```
+
+#### 结果
+
+{{EmbedLiveSample("竖排文本的边框", 140, 140)}}
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}
+
+## 参见
+
+- [CSS 逻辑属性与逻辑值](/zh-CN/docs/Web/CSS/CSS_Logical_Properties)
+- 此属性对应的实体边框属性：{{CSSXref("border-top-color")}}、{{CSSXref("border-right-color")}}、{{CSSXref("border-bottom-color")}} 或 {{CSSXref("border-left-color")}}
+- {{CSSXref("writing-mode")}}、{{CSSXref("direction")}}、{{CSSXref("text-orientation")}}

--- a/files/zh-cn/web/css/border-block-end-color/index.md
+++ b/files/zh-cn/web/css/border-block-end-color/index.md
@@ -1,0 +1,85 @@
+---
+title: border-block-end-color
+slug: Web/CSS/border-block-end-color
+---
+
+{{CSSRef}}
+
+[CSS](/zh-CN/docs/Web/CSS) 属性 **`border-block-end-color`** 定义了元素的逻辑块末的边框颜色，并根据元素的书写模式、行内方向和文本朝向对应至实体边框颜色。根据 {{CSSXref("writing-mode")}}、{{CSSXref("direction")}} 和 {{CSSXref("text-orientation")}} 所定义的值，此属性对应于 {{CSSXref("border-top-color")}}、{{CSSXref("border-right-color")}}、{{CSSXref("border-bottom-color")}} 或 {{CSSXref("border-left-color")}} 属性。
+
+{{EmbedInteractiveExample("pages/css/border-block-end-color.html")}}
+
+## 语法
+
+```css
+border-block-end-color: yellow;
+border-block-end-color: #f5f6f7;
+
+/* 全局值 */
+border-block-end-color: inherit;
+border-block-end-color: initial;
+border-block-end-color: revert;
+border-block-end-color: revert-layer;
+border-block-end-color: unset;
+```
+
+与此相关的属性有 {{CSSXref("border-block-start-color")}}、{{CSSXref("border-inline-start-color")}} 和 {{CSSXref("border-inline-end-color")}}，这些属性定义了元素其他边框的颜色。
+
+### 取值
+
+- `<'color'>`
+  - : 边框颜色。见 {{CSSXref("color")}}。
+
+## 形式定义
+
+{{CSSInfo}}
+
+## 形式语法
+
+{{CSSSyntax}}
+
+## 示例
+
+### 竖排文本的边框颜色
+
+#### HTML
+
+```html
+<div>
+  <p class="exampleText">示例文本</p>
+</div>
+```
+
+#### CSS
+
+```css
+div {
+  background-color: yellow;
+  width: 120px;
+  height: 120px;
+}
+
+.exampleText {
+  writing-mode: vertical-lr;
+  border: 10px solid blue;
+  border-block-end-color: red;
+}
+```
+
+#### 结果
+
+{{EmbedLiveSample("竖排文本的边框颜色", 140, 140)}}
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}
+
+## 参见
+
+- [CSS 逻辑属性与逻辑值](/zh-CN/docs/Web/CSS/CSS_Logical_Properties)
+- 此属性对应的实体边框属性：{{CSSXref("border-top-color")}}、{{CSSXref("border-right-color")}}、{{CSSXref("border-bottom-color")}} 或 {{CSSXref("border-left-color")}}
+- {{CSSXref("writing-mode")}}、{{CSSXref("direction")}}、{{CSSXref("text-orientation")}}

--- a/files/zh-cn/web/css/border-block-start-color/index.md
+++ b/files/zh-cn/web/css/border-block-start-color/index.md
@@ -1,0 +1,85 @@
+---
+title: border-block-start-color
+slug: Web/CSS/border-block-start-color
+---
+
+{{CSSRef}}
+
+[CSS](/zh-CN/docs/Web/CSS) 属性 **`border-block-start-color`** 定义了元素的逻辑块首的边框颜色，并根据元素的书写模式、行内方向和文本朝向对应至实体边框颜色。根据 {{CSSXref("writing-mode")}}、{{CSSXref("direction")}} 和 {{CSSXref("text-orientation")}} 所定义的值，此属性对应于 {{CSSXref("border-top-color")}}、{{CSSXref("border-right-color")}}、{{CSSXref("border-bottom-color")}} 或 {{CSSXref("border-left-color")}} 属性。
+
+{{EmbedInteractiveExample("pages/css/border-block-start-color.html")}}
+
+## 语法
+
+```css
+border-block-start-color: blue;
+border-block-start-color: #4c5d21;
+
+/* 全局值 */
+border-block-start-color: inherit;
+border-block-start-color: initial;
+border-block-start-color: revert;
+border-block-start-color: revert-layer;
+border-block-start-color: unset;
+```
+
+与此相关的属性有 {{CSSXref("border-block-end-color")}}、{{CSSXref("border-inline-start-color")}} 和 {{CSSXref("border-inline-end-color")}}，这些属性定义了元素其他边框的颜色。
+
+### 取值
+
+- `<'color'>`
+  - : 见 {{CSSXref("border-color")}}
+
+## 形式定义
+
+{{CSSInfo}}
+
+## 形式语法
+
+{{CSSSyntax}}
+
+## 示例
+
+### 竖排文本的边框颜色
+
+#### HTML
+
+```html
+<div>
+  <p class="exampleText">示例文本</p>
+</div>
+```
+
+#### CSS
+
+```css
+div {
+  background-color: yellow;
+  width: 120px;
+  height: 120px;
+}
+
+.exampleText {
+  writing-mode: vertical-lr;
+  border: 10px solid blue;
+  border-block-start-color: red;
+}
+```
+
+#### 结果
+
+{{EmbedLiveSample("竖排文本的边框颜色", 140, 140)}}
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}
+
+## 参见
+
+- [CSS 逻辑属性与逻辑值](/zh-CN/docs/Web/CSS/CSS_Logical_Properties)
+- 此属性对应的实体边框属性：{{CSSXref("border-top-color")}}、{{CSSXref("border-right-color")}}、{{CSSXref("border-bottom-color")}} 或 {{CSSXref("border-left-color")}}
+- {{CSSXref("writing-mode")}}、{{CSSXref("direction")}}、{{CSSXref("text-orientation")}}

--- a/files/zh-cn/web/css/border-inline-color/index.md
+++ b/files/zh-cn/web/css/border-inline-color/index.md
@@ -5,39 +5,48 @@ slug: Web/CSS/border-inline-color
 
 {{CSSRef}}
 
-The **`border-inline-color`** [CSS](/zh-CN/docs/Web/CSS) property defines the color of the logical inline borders of an element, which maps to a physical border color depending on the element's writing mode, directionality, and text orientation. It corresponds to the {{cssxref("border-top-color")}} and {{cssxref("border-bottom-color")}}, or {{cssxref("border-right-color")}} and {{cssxref("border-left-color")}} property depending on the values defined for {{cssxref("writing-mode")}}, {{cssxref("direction")}}, and {{cssxref("text-orientation")}}.
+[CSS](/zh-CN/docs/Web/CSS) 属性 **`border-inline-color`** 定义了元素的逻辑行向的边框颜色，并根据元素的书写模式、行内方向和文本朝向对应至实体边框颜色。根据 {{CSSXref("writing-mode")}}、{{CSSXref("direction")}} 和 {{CSSXref("text-orientation")}} 所定义的值，此属性对应于 {{CSSXref("border-top-color")}} 和 {{CSSXref("border-bottom-color")}}，或者 {{CSSXref("border-right-color")}} 和 {{CSSXref("border-left-color")}} 属性。
+
+{{EmbedInteractiveExample("pages/css/border-inline-color.html")}}
+
+另一方向的边框颜色可用 {{CSSXref("border-block-color")}} 设置，此属性会设置 {{CSSXref("border-block-start-color")}} 和 {{CSSXref("border-block-end-color")}}。
+
+## 语法
 
 ```css
 border-inline-color: yellow;
-border-inline-color: #F5F6F7;
+border-inline-color: #f5f6f7;
+
+/* 全局值 */
+border-inline-color: inherit;
+border-inline-color: initial;
+border-inline-color: revert;
+border-inline-color: revert-layer;
+border-inline-color: unset;
 ```
 
-The border color in the other dimension can be set with {{cssxref("border-block-color")}} which sets {{cssxref("border-block-start-color")}}, and {{cssxref("border-block-end-color")}}.
-
-## Syntax
-
-### Values
+### 取值
 
 - `<'color'>`
-  - : The color of the border. See {{cssxref("color")}}.
+  - : 边框颜色。见 {{CSSXref("color")}}。
 
-## Formal definition
+## 形式定义
 
 {{CSSInfo}}
 
-## Formal syntax
+## 形式语法
 
-{{csssyntax}}
+{{CSSSyntax}}
 
-## Examples
+## 示例
 
-### Border color with vertical text
+### 竖排文本的边框颜色
 
 #### HTML
 
 ```html
 <div>
-  <p class="exampleText">Example text</p>
+  <p class="exampleText">示例文本</p>
 </div>
 ```
 
@@ -57,19 +66,20 @@ div {
 }
 ```
 
-#### Results
+#### 结果
 
-{{EmbedLiveSample("Border_color_with_vertical_text", 140, 140)}}
+{{EmbedLiveSample("竖排文本的边框颜色", 140, 140)}}
 
-## Specifications
+## 规范
 
 {{Specifications}}
 
-## Browser compatibility
+## 浏览器兼容性
 
 {{Compat}}
 
-## See also
+## 参见
 
-- This property maps to the physical border properties: {{cssxref("border-top-color")}}, {{cssxref("border-right-color")}}, {{cssxref("border-bottom-color")}}, or {{cssxref("border-left-color")}}.
-- {{cssxref("writing-mode")}}, {{cssxref("direction")}}, {{cssxref("text-orientation")}}+ bug 1297097
+- [CSS 逻辑属性与逻辑值](/zh-CN/docs/Web/CSS/CSS_Logical_Properties)
+- 此属性对应的实体边框属性：{{CSSXref("border-top-color")}}、{{CSSXref("border-right-color")}}、{{CSSXref("border-bottom-color")}} 或 {{CSSXref("border-left-color")}}
+- {{CSSXref("writing-mode")}}、{{CSSXref("direction")}}、{{CSSXref("text-orientation")}}

--- a/files/zh-cn/web/css/border-inline-end-color/index.md
+++ b/files/zh-cn/web/css/border-inline-end-color/index.md
@@ -1,0 +1,81 @@
+---
+title: border-inline-end-color
+slug: Web/CSS/border-inline-end-color
+---
+
+{{CSSRef}}
+
+[CSS](/zh-CN/docs/Web/CSS) 属性 **`border-inline-end-color`** 定义了元素的逻辑行末的边框颜色，并根据元素的书写模式、行内方向和文本朝向对应至实体边框颜色。根据 {{CSSXref("writing-mode")}}、{{CSSXref("direction")}} 和 {{CSSXref("text-orientation")}} 所定义的值，此属性对应于 {{CSSXref("border-top-color")}}、{{CSSXref("border-right-color")}}、{{CSSXref("border-bottom-color")}} 或 {{CSSXref("border-left-color")}} 属性。
+
+{{EmbedInteractiveExample("pages/css/border-inline-end-color.html")}}
+
+## 语法
+
+```css
+border-inline-end-color: rebeccapurple;
+border-inline-end-color: #663399;
+
+/* 全局值 */
+border-inline-end-color: inherit;
+border-inline-end-color: initial;
+border-inline-end-color: revert;
+border-inline-end-color: revert-layer;
+border-inline-end-color: unset;
+```
+
+与此相关的属性有 {{CSSXref("border-block-start-color")}}、{{CSSXref("border-block-end-color")}} 和 {{CSSXref("border-inline-start-color")}}，这些属性定义了元素其他边框的颜色。
+
+### 取值
+
+- `<'color'>`
+  - : 边框颜色。见 {{CSSXref("color")}}。
+
+## 形式定义
+
+{{CSSInfo}}
+
+## 形式语法
+
+{{CSSSyntax}}
+
+## 示例
+
+### HTML
+
+```html
+<div>
+  <p class="exampleText">示例文本</p>
+</div>
+```
+
+### CSS
+
+```css
+div {
+  background-color: yellow;
+  width: 120px;
+  height: 120px;
+}
+
+.exampleText {
+  writing-mode: vertical-lr;
+  border: 10px solid blue;
+  border-inline-end-color: red;
+}
+```
+
+{{EmbedLiveSample("示例", 140, 140)}}
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}
+
+## 参见
+
+- [CSS 逻辑属性与逻辑值](/zh-CN/docs/Web/CSS/CSS_Logical_Properties)
+- 此属性对应的实体边框属性：{{CSSXref("border-top-color")}}、{{CSSXref("border-right-color")}}、{{CSSXref("border-bottom-color")}} 或 {{CSSXref("border-left-color")}}
+- {{CSSXref("writing-mode")}}、{{CSSXref("direction")}}、{{CSSXref("text-orientation")}}

--- a/files/zh-cn/web/css/border-inline-start-color/index.md
+++ b/files/zh-cn/web/css/border-inline-start-color/index.md
@@ -1,0 +1,81 @@
+---
+title: border-inline-start-color
+slug: Web/CSS/border-inline-start-color
+---
+
+{{CSSRef}}
+
+[CSS](/zh-CN/docs/Web/CSS) 属性 **`border-inline-start-color`** 定义了元素的逻辑行首的边框颜色，并根据元素的书写模式、行内方向和文本朝向对应至实体边框颜色。根据 {{CSSXref("writing-mode")}}、{{CSSXref("direction")}} 和 {{CSSXref("text-orientation")}} 所定义的值，此属性对应于 {{CSSXref("border-top-color")}}、{{CSSXref("border-right-color")}}、{{CSSXref("border-bottom-color")}} 或 {{CSSXref("border-left-color")}} 属性。
+
+{{EmbedInteractiveExample("pages/css/border-inline-start-color.html")}}
+
+## 语法
+
+```css
+border-inline-start-color: red;
+border-inline-start-color: #ee4141;
+
+/* 全局值 */
+border-inline-start-color: inherit;
+border-inline-start-color: initial;
+border-inline-start-color: revert;
+border-inline-start-color: revert-layer;
+border-inline-start-color: unset;
+```
+
+与此相关的属性有 {{CSSXref("border-block-start-color")}}、{{CSSXref("border-block-end-color")}} 和 {{CSSXref("border-inline-end-color")}}，这些属性定义了元素其他边框的颜色。
+
+### 取值
+
+- `<'color'>`
+  - : 边框颜色。见 {{CSSXref("color")}}。
+
+## 形式定义
+
+{{CSSInfo}}
+
+## 形式语法
+
+{{CSSSyntax}}
+
+## 示例
+
+### HTML
+
+```html
+<div>
+  <p class="exampleText">示例文本</p>
+</div>
+```
+
+### CSS
+
+```css
+div {
+  background-color: yellow;
+  width: 120px;
+  height: 120px;
+}
+
+.exampleText {
+  writing-mode: vertical-lr;
+  border: 10px solid blue;
+  border-inline-start-color: red;
+}
+```
+
+{{EmbedLiveSample("示例", 140, 140)}}
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}
+
+## 参见
+
+- [CSS 逻辑属性与逻辑值](/zh-CN/docs/Web/CSS/CSS_Logical_Properties)
+- 此属性对应的实体边框属性：{{CSSXref("border-top-color")}}、{{CSSXref("border-right-color")}}、{{CSSXref("border-bottom-color")}} 和 {{CSSXref("border-left-color")}}
+- {{CSSXref("writing-mode")}}、{{CSSXref("direction")}}、{{CSSXref("text-orientation")}}


### PR DESCRIPTION
### Description

### Motivation

### Additional details

  1. 在现有页面的翻译中，border 有“边框”（= border frame）和“边界”（= boundary）两种译法。这里参考 Office 系列软件统一译为前者。
  2. 有些 `border-*-color` 的页面虽然有 `zh-CN` 的文件，但是内容几乎完全是英文的。

### Related issues and pull requests