### PR TITLE
fix: Console.groupCollapsed doc

### DIFF
--- a/files/zh-cn/web/api/console/groupcollapsed/index.md
+++ b/files/zh-cn/web/api/console/groupcollapsed/index.md
@@ -9,15 +9,24 @@ slug: Web/API/console/groupCollapsed
 
 在 [Web 控制台](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html)上创建一个新的分组。随后输出到控制台上的内容都会被添加一个缩进，表示该内容属于当前分组，直到调用 {{domxref("console.groupEnd()")}} 之后，当前分组结束。和 {{ domxref("console.group()") }}方法的不同点是，新建的分组默认是折叠的。用户必须点击一个按钮才能将折叠的内容打开。
 
+## 定义
+```plain
+Console.groupCollapsed(...label: any[]): void
+```
+
 ## 语法
 
 ```plain
 console.groupCollapsed();
+console.groupCollapsed(label, substr1, /* ..., */ substrN );
 ```
 
 ## 参数
 
-无
+- `label`
+  - : 一个 JavaScript 字符串，其中包含零个或多个替代字符串。如果提供了一个或多个‘标签’，则首先打印这些标签，而不需要额外的缩进。
+- `substr1` ... `substrN`
+  - : JavaScript 对象，用来依次替换 `label` 中的替代字符串。你可以在替代字符串中指定对象的输出格式。
 
 ## 备注
 

--- a/files/zh-cn/web/api/console/groupcollapsed/index.md
+++ b/files/zh-cn/web/api/console/groupcollapsed/index.md
@@ -1,45 +1,38 @@
 ---
-title: console.groupCollapsed
+title: console.groupCollapsed()
 slug: Web/API/console/groupCollapsed
 ---
 
-{{ ApiRef() }}
+{{APIRef("Console API")}}
 
-## 概述
+**`console.groupCollapsed()`** 方法在 Web 控制台上创建一个新的分组。与 {{domxref("console.group()")}} 方法的不同点是，新建的分组默认是折叠的。用户必须点击一个按钮才能将折叠的内容打开。
 
-在 [Web 控制台](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html)上创建一个新的分组。随后输出到控制台上的内容都会被添加一个缩进，表示该内容属于当前分组，直到调用 {{domxref("console.groupEnd()")}} 之后，当前分组结束。和 {{ domxref("console.group()") }}方法的不同点是，新建的分组默认是折叠的。用户必须点击一个按钮才能将折叠的内容打开。
+调用 {{domxref("console.groupEnd()")}} 以回到父级分组。
 
-## 定义
-```plain
-Console.groupCollapsed(...label: any[]): void
-```
+参见 {{domxref("console")}} 文档中的[在控制台中使用分组](/zh-CN/docs/Web/API/console#在_console_中使用编组)以获取详情和示例。
+
+{{AvailableInWorkers}}
 
 ## 语法
 
-```plain
-console.groupCollapsed();
-console.groupCollapsed(label, substr1, /* ..., */ substrN );
+```js-nolint
+groupCollapsed()
+groupCollapsed(label)
 ```
 
-## 参数
+### 参数
 
 - `label`
-  - : 一个 JavaScript 字符串，其中包含零个或多个替代字符串。如果提供了一个或多个‘标签’，则首先打印这些标签，而不需要额外的缩进。
-- `substr1` ... `substrN`
-  - : JavaScript 对象，用来依次替换 `label` 中的替代字符串。你可以在替代字符串中指定对象的输出格式。
+  - : 分组的标签，为可选值。
 
-## 备注
+### 返回值
 
-在文档{{ domxref("console") }}中查看[在控制台中使用分组](/zh-CN/DOM/console#Using_groups_in_the_console),了解更多详细内容。
+无（{{jsxref("undefined")}}）。
 
 ## 规范
 
-不属于任何公开的规范
+{{Specifications}}
 
-## 浏览器
+## 浏览器兼容性
 
 {{Compat}}
-
-## 相关链接
-
-- [Opera Dragonfly documentation: Console](http://www.opera.com/dragonfly/documentation/console/)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
fix console.groupCollapsed document details.
Legacy documentation problem: missing documentation and descriptions related to console.groupCollapsed parameters.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
