### PR TITLE
chore: remove `mediawiki.external` macro from pt-BR

### DIFF
--- a/files/pt-br/learn/javascript/client-side_web_apis/manipulating_documents/index.md
+++ b/files/pt-br/learn/javascript/client-side_web_apis/manipulating_documents/index.md
@@ -120,12 +120,13 @@ Esta wiki não suporta JavaScript nas páginas, então não é possível mostrar
   </tbody>
 </table>
 
-> **Nota:** **Notas importantes** sobre esta demonstração:- O documento HTML tem uma folha de estilo anexada, bem como um arquivo de script.
+> **Nota:** Sobre esta demonstração:
 >
+> - O documento HTML tem uma folha de estilo anexada, bem como um arquivo de script.
 > - O script trabalha com elementos individuais no DOM. Ele modifica o square's style diretamente. Ele modifica o estilo dos botões indiretamente mudando um atributo.
 > - Em JavaScript, `document.getElementById("square")` é similar em função ao seletor CSS `#square`.
 > - Em JavaScript, `backgroundColor` corresponde à propriedade CSS `background-color`. JavaScript não permite hífens em nomes, então "camelCase" é usada no lugar dele.
-> - Seu browser tem uma regra built-in CSS para `button{{ mediawiki.external('disabled=\"true\"') }}` ela muda a aparência dos botões quando está disabilitado.
+> - Seu browser tem uma regra built-in CSS para `button[disabled="true"]` ela muda a aparência dos botões quando está disabilitado.
 
 | Altere o script para que o quadrado salte 20 cm para a direita quando sua cor mudar e volte para trás quando retornar à cor base. |
 | --------------------------------------------------------------------------------------------------------------------------------- |

--- a/files/pt-br/mozilla/firefox/releases/3/index.md
+++ b/files/pt-br/mozilla/firefox/releases/3/index.md
@@ -127,7 +127,7 @@ If you're a developer trying to get a handle on all the new features in Firefox 
 - **Web-based protocol handlers.** Web applications, such as your favorite web mail provider, can now be used instead of desktop applications for handling `mailto:` links from other sites. Similar support is provided for other protocols as well. (Note that web applications do have to register themselves with Firefox before this will work.)
 - **Easy to use Download Actions.** A new Applications preferences pane provides an improved user interface for configuring handlers for various file types and protocol schemes.
 - **Improved look and feel.** Graphics and font handling have been improved to make web sites look better on your screen, including sharper text rendering and better support for fonts with ligatures and complex scripts. In addition, Mac and Linux (Gnome) users will find that Firefox feels more like a native application for their platform than ever, with a new, native, look and feel.
-- **Color management support.** By setting the `gfx.color_management.enabled` preference in `{{mediawiki.external('about:config')}}`, you can ask Firefox to use the color profiles embedded in images to adjust the colors to match your computer's display.
+- **Color management support.** By setting the `gfx.color_management.enabled` preference in `about:config`, you can ask Firefox to use the color profiles embedded in images to adjust the colors to match your computer's display.
 - **Offline support.** Web applications can take advantage of new features to support being used even when you don't have an Internet connection.
 
 ### Security and privacy


### PR DESCRIPTION
### Description

chore: remove `mediawiki.external` macro from pt-BR

### Related issues and pull requests

Part of: #5603
