### PR TITLE
zh-CN: Translate `overflow-(block|inline)`; sync `overflow-(x|y)` with en-US

### DIFF
--- a/files/zh-cn/web/css/@media/overflow-block/index.md
+++ b/files/zh-cn/web/css/@media/overflow-block/index.md
@@ -1,0 +1,65 @@
+---
+title: overflow-block
+slug: Web/CSS/@media/overflow-block
+---
+
+{{CSSRef}}
+
+[CSS](/zh-CN/docs/Web/CSS) [媒体特性](/zh-CN/docs/Web/CSS/@media#media_features#媒体特性) **`overflow-block`** 可用于测试输出设备如何处理沿块向轴溢出初始[包含块](/zh-CN/docs/Web/CSS/Containing_block)的内容。
+
+## 语法
+
+`overflow-block` 特性可指定为下列关键词值之一。
+
+- `none`
+  - : 不显示沿块向轴溢出的内容。
+- `scroll`
+  - : 可通过滚动看见沿块向轴溢出的内容。
+- `optional-paged`
+  - : 可通过滚动看见沿块向轴溢出的内容，但可手动触发分页（例如通过 {{CSSXref("break-inside")}} 等）使后续内容显示于下一页。
+- `paged`
+  - : 内容按页分开；沿块向轴溢出某页的内容显示于下一页。
+
+## 示例
+
+### HTML
+
+```html
+<p>
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam ac turpis
+  eleifend, fringilla velit ac, aliquam tellus. Vestibulum ante ipsum primis in
+  faucibus orci luctus et ultrices posuere cubilia Curae; Nunc velit erat,
+  tempus id rutrum sed, dapibus ut urna. Integer vehicula nibh a justo imperdiet
+  rutrum. Nam faucibus pretium orci imperdiet sollicitudin. Nunc id facilisis
+  dui. Proin elementum et massa et feugiat. Integer rutrum ullamcorper eleifend.
+  Proin sit amet tincidunt risus. Sed nec augue congue eros accumsan tincidunt
+  sed eget ex.
+</p>
+```
+
+### CSS
+
+```css
+@media (overflow-block: scroll) {
+  p {
+    color: red;
+  }
+}
+```
+
+### 结果
+
+{{EmbedLiveSample("示例")}}
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}
+
+## 参见
+
+- [使用媒体查询](/zh-CN/docs/Web/CSS/Media_Queries/Using_media_queries)
+- [@media](/zh-CN/docs/Web/CSS/@media)

--- a/files/zh-cn/web/css/@media/overflow-inline/index.md
+++ b/files/zh-cn/web/css/@media/overflow-inline/index.md
@@ -1,0 +1,60 @@
+---
+title: overflow-inline
+slug: Web/CSS/@media/overflow-inline
+---
+
+{{CSSRef}}
+
+[CSS](/zh-CN/docs/Web/CSS) [媒体特性](/zh-CN/docs/Web/CSS/@media#media_features#媒体特性) **`overflow-inline`** 可用于测试输出设备如何处理沿行向轴溢出初始[包含块](/zh-CN/docs/Web/CSS/Containing_block)的内容。
+
+## 语法
+
+`overflow-inline` 特性可指定为下列关键词值之一。
+
+- `none`
+  - : 不显示沿行向轴溢出的内容。
+- `scroll`
+  - : 可通过滚动看见沿行向轴溢出的内容。
+
+## 示例
+
+### HTML
+
+```html
+<p>
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam ac turpis
+  eleifend, fringilla velit ac, aliquam tellus. Vestibulum ante ipsum primis in
+  faucibus orci luctus et ultrices posuere cubilia Curae; Nunc velit erat,
+  tempus id rutrum sed, dapibus ut urna. Integer vehicula nibh a justo imperdiet
+  rutrum. Nam faucibus pretium orci imperdiet sollicitudin. Nunc id facilisis
+  dui. Proin elementum et massa et feugiat. Integer rutrum ullamcorper eleifend.
+  Proin sit amet tincidunt risus. Sed nec augue congue eros accumsan tincidunt
+  sed eget ex.
+</p>
+```
+
+### CSS
+
+```css
+p {
+  white-space: nowrap;
+}
+
+@media (overflow-inline: scroll) {
+  p {
+    color: red;
+  }
+}
+```
+
+### 结果
+
+{{EmbedLiveSample("示例")}}
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}

--- a/files/zh-cn/web/css/overflow-block/index.md
+++ b/files/zh-cn/web/css/overflow-block/index.md
@@ -5,73 +5,95 @@ slug: Web/CSS/overflow-block
 
 {{CSSRef}}
 
-The **`overflow-block`** [CSS](/zh-CN/docs/Web/CSS) property sets what shows when content overflows the block start and block end edges of a box. This may be nothing, a scroll bar, or the overflow content.
+[CSS](/zh-CN/docs/Web/CSS) 属性 **`overflow-block`** 设置了当内容溢出盒的块首和块末侧时所显示的内容。可以不显示，或者显示滚动条或溢出内容。
 
-> **备注：** The `overflow-block` property maps to {{Cssxref("overflow-y")}} or {{Cssxref("overflow-x")}} depending on the writing mode of the document.
+> **备注：**`overflow-block` 属性根据文档的书写模式对应于 {{CSSXref("overflow-y")}} 或 {{CSSXref("overflow-x")}}。
 
-## Syntax
+## 语法
 
 ```css
-/* Keyword values */
+/* 关键词值 */
 overflow-block: visible;
 overflow-block: hidden;
 overflow-block: scroll;
 overflow-block: auto;
 
-/* Global values */
+/* 全局值 */
 overflow-block: inherit;
 overflow-block: initial;
+overflow-block: revert;
+overflow-block: revert-layer;
 overflow-block: unset;
 ```
 
-The `overflow-block` property is specified as a single keyword chosen from the list of values below.
+`overflow-block` 属性可指定为下列关键词之一。
 
-### Values
+### 取值
 
 - `visible`
-  - : Content is not clipped and may be rendered outside the padding box's block start and block end edges.
+  - : 不裁剪内容且可在内边距盒的块首和块末侧外渲染内容。
 - `hidden`
-  - : Content is clipped if necessary to fit the block dimension in the padding box. No scrollbars are provided.
+  - : 若内边距盒在块向尺度上无法容纳内容则裁剪内容。不提供滚动条。
 - `scroll`
-  - : Content is clipped if necessary to fit in the block dimension in the padding box. Browsers display scrollbars whether or not any content is actually clipped. (This prevents scrollbars from appearing or disappearing when the content changes.) Printers may still print overflowing content.
+  - : 若内边距盒在块向尺度上无法容纳内容则裁剪内容。无论内容是否被裁剪，浏览器均显示滚动条。（。）打印机仍可能打印溢出内容。
 - `auto`
-  - : Depends on the user agent. If content fits inside the padding box, it looks the same as `visible`, but still establishes a new block-formatting context. Desktop browsers provide scrollbars if content overflows.
+  - : 取决于用户代理。若内边距盒可以容纳内容，则与 `visible` 表现相同，但仍建立新的块格式化上下文。若内容溢出则桌面浏览器提供滚动条。
 
-## Formal definition
+## 形式定义
 
 {{CSSInfo}}
 
-## Formal syntax
+## 形式语法
 
-{{csssyntax}}
+{{CSSSyntax}}
 
-## Examples
+## 示例
 
 ### HTML
 
 ```html
 <ul>
-  <li><code>overflow-block:hidden</code> — hides the text outside the box
-  <div id="div1">
-    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+  <li>
+    <code>overflow-block:hidden</code>——在盒外隐藏文本
+    <div id="div1">
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+      velit esse cillum dolore eu fugiat nulla pariatur.
     </div>
   </li>
 
-  <li><code>overflow-block:scroll</code> — always adds a scrollbar
-  <div id="div2">
-    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+  <li>
+    <code>overflow-block:scroll</code>——总是添加滚动条
+    <div id="div2">
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+      velit esse cillum dolore eu fugiat nulla pariatur.
     </div>
   </li>
 
-  <li><code>overflow-block:visible</code> — displays the text outside the box if needed
-  <div id="div3">
-    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+  <li>
+    <code>overflow-block:visible</code>——按需在盒外显示文本
+    <div id="div3">
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+      velit esse cillum dolore eu fugiat nulla pariatur.
     </div>
   </li>
 
-  <li><code>overflow-block:auto</code> — on most browser, equivalent to <code>scroll</code>
-  <div id="div4">
-    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+  <li>
+    <code>overflow-block:auto</code>——在多数浏览器上等价于 <code>scroll</code>
+    <div id="div4">
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+      velit esse cillum dolore eu fugiat nulla pariatur.
     </div>
   </li>
 </ul>
@@ -85,30 +107,42 @@ The `overflow-block` property is specified as a single keyword chosen from the l
 #div3,
 #div4 {
   border: 1px solid black;
-  width:  250px;
+  width: 250px;
   height: 100px;
 }
 
-#div1 { overflow-block: hidden; margin-bottom: 120px;}
-#div2 { overflow-block: scroll; margin-bottom: 120px;}
-#div3 { overflow-block: visible; margin-bottom: 120px;}
-#div4 { overflow-block: auto; margin-bottom: 120px;}
+#div1 {
+  overflow-block: hidden;
+  margin-bottom: 120px;
+}
+#div2 {
+  overflow-block: scroll;
+  margin-bottom: 120px;
+}
+#div3 {
+  overflow-block: visible;
+  margin-bottom: 120px;
+}
+#div4 {
+  overflow-block: auto;
+  margin-bottom: 120px;
+}
 ```
 
-### Result
+### 结果
 
-{{EmbedLiveSample("Examples", "100%", "780")}}
+{{EmbedLiveSample("示例", "100%", "780")}}
 
-## Specifications
+## 规范
 
-{{Specifications}}{{cssinfo}}
+{{Specifications}}
 
-## Browser compatibility
+## 浏览器兼容性
 
 {{Compat}}
 
-## See also
+## 参见
 
-- Related CSS properties: {{cssxref("text-overflow")}}, {{cssxref("white-space")}}, {{Cssxref("overflow")}}, {{Cssxref("overflow-inline")}}, {{Cssxref("overflow-x")}}, {{Cssxref("overflow-y")}}, {{Cssxref("clip")}}, {{Cssxref("display")}}
-- [CSS Logical Properties](/zh-CN/docs/Web/CSS/CSS_Logical_Properties)
-- [Writing Modes](/zh-CN/docs/Web/CSS/CSS_Writing_Modes)
+- 相关 CSS 属性：{{CSSXref("text-overflow")}}、{{CSSXref("white-space")}}、{{CSSXref("overflow")}}、{{CSSXref("overflow-inline")}}、{{CSSXref("overflow-x")}}、{{CSSXref("overflow-y")}}、{{CSSXref("clip")}}、{{CSSXref("display")}}
+- [CSS 逻辑属性](/zh-CN/docs/Web/CSS/CSS_Logical_Properties)
+- [书写模式](/zh-CN/docs/Web/CSS/CSS_Writing_Modes)

--- a/files/zh-cn/web/css/overflow-inline/index.md
+++ b/files/zh-cn/web/css/overflow-inline/index.md
@@ -1,0 +1,122 @@
+---
+title: overflow-inline
+slug: Web/CSS/overflow-inline
+---
+
+{{CSSRef}}
+
+[CSS](/zh-CN/docs/Web/CSS) 属性 **`overflow-inline`** 设置了当内容溢出盒的行首和行末侧时所显示的内容。可以不显示，或者显示滚动条或溢出内容。
+
+> **备注：**`overflow-inline` 属性根据文档的书写模式对应于 {{CSSXref("overflow-y")}} 或 {{CSSXref("overflow-x")}}。
+
+## 语法
+
+```css
+/* 关键词值 */
+overflow-inline: visible;
+overflow-inline: hidden;
+overflow-inline: scroll;
+overflow-inline: auto;
+
+/* 全局值 */
+overflow-inline: inherit;
+overflow-inline: initial;
+overflow-inline: revert;
+overflow-inline: revert-layer;
+overflow-inline: unset;
+```
+
+`overflow-inline` 属性可指定为下列关键词之一。
+
+### 取值
+
+- `visible`
+  - : 不裁剪内容且可在内边距盒的行首和行末侧外渲染内容。
+- `hidden`
+  - : 若内边距盒在行向尺度上无法容纳内容则裁剪内容。不提供滚动条。
+- `scroll`
+  - : 若内边距盒在行向尺度上无法容纳内容则裁剪内容。无论内容是否被裁剪，浏览器均显示滚动条。（由此可阻止滚动条在内容变化时显示或消失。）打印机仍可能打印溢出内容。
+- `auto`
+  - : 取决于用户代理。若内边距盒可以容纳内容，则与 `visible` 表现相同，但仍建立新的块格式化上下文。若内容溢出则桌面浏览器提供滚动条。
+
+## 形式定义
+
+{{CSSInfo}}
+
+## 形式语法
+
+{{CSSSyntax}}
+
+## 示例
+
+### 设置行向溢出行为
+
+#### HTML
+
+```html
+<ul>
+  <li>
+    <code>overflow-inline:hidden</code>——在盒外隐藏文本
+    <div id="div1">ABCDEFGHIJKLMOPQRSTUVWXYZABCDEFGHIJKLMOPQRSTUVWXYZ</div>
+  </li>
+
+  <li>
+    <code>overflow-block:scroll</code>——总是添加滚动条
+    <div id="div2">ABCDEFGHIJKLMOPQRSTUVWXYZABCDEFGHIJKLMOPQRSTUVWXYZ</div>
+  </li>
+
+  <li>
+    <code>overflow-block:visible</code>——按需在盒外显示文本
+    <div id="div3">ABCDEFGHIJKLMOPQRSTUVWXYZABCDEFGHIJKLMOPQRSTUVWXYZ</div>
+  </li>
+
+  <li>
+    <code>overflow-block:auto</code>——在多数浏览器上等价于 <code>scroll</code>
+    <div id="div4">ABCDEFGHIJKLMOPQRSTUVWXYZABCDEFGHIJKLMOPQRSTUVWXYZ</div>
+  </li>
+</ul>
+```
+
+#### CSS
+
+```css
+#div1,
+#div2,
+#div3,
+#div4 {
+  border: 1px solid black;
+  width: 250px;
+  margin-bottom: 12px;
+}
+
+#div1 {
+  overflow-inline: hidden;
+}
+#div2 {
+  overflow-inline: scroll;
+}
+#div3 {
+  overflow-inline: visible;
+}
+#div4 {
+  overflow-inline: auto;
+}
+```
+
+#### 结果
+
+{{EmbedLiveSample("设置行向溢出行为", "100%", "270")}}
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}
+
+## 参见
+
+- 相关 CSS 属性：{{CSSXref("text-overflow")}}、{{CSSXref("white-space")}}、{{CSSXref("overflow")}}、{{CSSXref("overflow-block")}}、{{CSSXref("overflow-x")}}、{{CSSXref("overflow-y")}}、{{CSSXref("clip")}}、{{CSSXref("display")}}
+- [CSS 逻辑属性](/zh-CN/docs/Web/CSS/CSS_Logical_Properties)
+- [书写模式](/zh-CN/docs/Web/CSS/CSS_Writing_Modes)

--- a/files/zh-cn/web/css/overflow-x/index.md
+++ b/files/zh-cn/web/css/overflow-x/index.md
@@ -3,32 +3,33 @@ title: overflow-x
 slug: Web/CSS/overflow-x
 ---
 
-{{ CSSRef() }}
+{{CSSRef}}
 
-{{ SeeCompatTable() }}
+[CSS](/zh-CN/docs/Web/CSS) 属性 **`overflow-x`** 设置了当内容溢出块级元素的左右两侧时所显示的内容。可以不显示，或者显示滚动条或溢出内容。
 
-## 概述
+{{EmbedInteractiveExample("pages/css/overflow-x.html")}}
 
-当一个块级元素的内容在水平方向发生溢出时，[CSS](/zh-CN/CSS)属性 overflow-x 决定应该截断溢出内容，或者显示滚动条，或者直接显示溢出内容。
+## 语法
 
-{{cssinfo}}
+```css
+/* 关键词值 */
+overflow-x: visible;
+overflow-x: hidden;
+overflow-x: clip;
+overflow-x: scroll;
+overflow-x: auto;
 
-## 用法
-
+/* 全局值 */
+overflow-x: inherit;
+overflow-x: initial;
+overflow-x: revert;
+overflow-x: revert-layer;
+overflow-x: unset;
 ```
-合法值: {{csssyntax("overflow-x")}}
-```
 
-```
-overflow-x: visible
-overflow-x: hidden
-overflow-x: scroll
-overflow-x: auto
+`overflow-x` 属性可指定为下列关键词之一。
 
-overflow-x: inherit
-```
-
-### 解释
+### 取值
 
 - `visible`
   - : 内容不会被截断，且可以显示在内容盒之外。当 {{cssxref("overflow-y")}} 的值为 `hidden`、`scroll` 或者 `auto`，而本属性的值为 `visible` 时，本属性会被隐式的计算为 `auto`。
@@ -39,11 +40,71 @@ overflow-x: inherit
 - `auto`
   - : 取决于浏览器本身。当内容发生溢出时，桌面浏览器如 Firefox 会显示滚动条。
 
+## 形式定义
+
+{{CSSInfo}}
+
+## 形式语法
+
+{{CSSSyntax}}
+
 ## 示例
 
+### HTML
+
+```html
+<ul>
+  <li>
+    <code>overflow-block:hidden</code>——在盒外隐藏文本
+    <div id="div1">ABCDEFGHIJKLMOPQRSTUVWXYZABCDEFGHIJKLMOPQRSTUVWXYZ</div>
+  </li>
+
+  <li>
+    <code>overflow-block:scroll</code>——总是添加滚动条
+    <div id="div2">ABCDEFGHIJKLMOPQRSTUVWXYZABCDEFGHIJKLMOPQRSTUVWXYZ</div>
+  </li>
+
+  <li>
+    <code>overflow-x:visible</code>——按需在盒外显示文本
+    <div id="div3">ABCDEFGHIJKLMOPQRSTUVWXYZABCDEFGHIJKLMOPQRSTUVWXYZ</div>
+  </li>
+
+  <li>
+    <code>overflow-x:auto</code>——在多数浏览器上等价于 <code>scroll</code>
+    <div id="div4">ABCDEFGHIJKLMOPQRSTUVWXYZABCDEFGHIJKLMOPQRSTUVWXYZ</div>
+  </li>
+</ul>
 ```
-[fixme]
+
+### CSS
+
+```css
+#div1,
+#div2,
+#div3,
+#div4 {
+  border: 1px solid black;
+  width: 250px;
+  margin-bottom: 12px;
+}
+
+#div1 {
+  overflow-x: hidden;
+}
+#div2 {
+  overflow-x: scroll;
+}
+#div3 {
+  overflow-x: visible;
+}
+#div4 {
+  overflow-x: auto;
+}
 ```
+
+### 结果
+
+{{EmbedLiveSample("示例", "100%", "270")}}
 
 ## 规范
 
@@ -55,4 +116,4 @@ overflow-x: inherit
 
 ## 参见
 
-- 相关 CSS 属性：{{ cssxref("text-overflow") }}, {{ cssxref("white-space") }}, {{ Cssxref("overflow") }}, {{ Cssxref("overflow-y") }}, {{ Cssxref("clip") }}, {{ Cssxref("display") }}
+- 相关 CSS 属性：{{CSSXref("text-overflow")}}、{{CSSXref("white-space")}}、{{CSSXref("overflow")}}、{{CSSXref("overflow-y")}}、{{CSSXref("clip")}}、{{CSSXref("display")}}

--- a/files/zh-cn/web/css/overflow-y/index.md
+++ b/files/zh-cn/web/css/overflow-y/index.md
@@ -5,39 +5,33 @@ slug: Web/CSS/overflow-y
 
 {{CSSRef}}
 
-## 概述
+[CSS](/zh-CN/docs/Web/CSS) 属性 **`overflow-y`** 设置了当内容溢出块级元素的上下两侧时所显示的内容。可以不显示，或者显示滚动条或溢出内容。
 
-当一个块级元素（div 元素、p 元素之类的）的内容在垂直方向发生溢出时，
-
-[CSS](/zh-CN/docs/Web/CSS)属性 `overflow-y` 决定如何处理溢出的内容。
-
-隐藏溢出内容（hidden），或者显示滚动条（scroll），或者直接显示溢出内容（visible），或者让浏览器来处理（auto）。
-
-{{cssinfo}}
+{{EmbedInteractiveExample("pages/css/overflow-y.html")}}
 
 ## 语法
 
+```css
+/* 关键词值 */
+overflow-y: visible;
+overflow-y: hidden;
+overflow-y: clip;
+overflow-y: scroll;
+overflow-y: auto;
+
+/* 全局值 */
+overflow-y: inherit;
+overflow-y: initial;
+overflow-y: revert;
+overflow-y: revert-layer;
+overflow-y: unset;
 ```
-/* 在当前 css 选择器元素下，元素内容在垂直方向上溢出时 */
 
-/* overflow-y 属性 可选值 */
-
-overflow-y: visible; /*内容可见*/
-overflow-y: hidden; /*内容隐藏*/
-overflow-y: scroll; /*总是显示滚动条*/
-overflow-y: auto; /*浏览器决定*/
-
-
-/* overflow-y 属性 全局可选值 */
-
-overflow-y: inherit; /*继承*/
-overflow-y: initial; /*默认值*/
-overflow-y: unset; /*未设置*/
-```
+`overflow-y` 属性可指定为下列关键词之一。
 
 当 {{cssxref("overflow-x")}} 值为 `hidden`、`scroll` 或者 `auto`，而本属性的值为 `visible`（默认值）时，本属性会被隐式的计算为 `auto`。
 
-### 可选值
+### 取值
 
 - `visible`
   - : 内容不会被截断，且可以显示在内容盒之外。
@@ -50,13 +44,19 @@ overflow-y: unset; /*未设置*/
 - `auto`
   - : 取决于浏览器本身。当内容发生溢出时，桌面浏览器如 Firefox 会显示滚动条。
 
-### 形式语法
+## 形式定义
 
-{{csssyntax("overflow-y")}}
+{{CSSInfo}}
+
+## 形式语法
+
+{{CSSSyntax}}
 
 ## 示例
 
-### HTML
+### 设置 overflow-y 行为
+
+#### HTML
 
 ```html
 <ul>
@@ -87,31 +87,39 @@ overflow-y: unset; /*未设置*/
 </ul>
 ```
 
-### CSS
+#### CSS
 
 ```css
 #div1,
 #div2,
 #div3,
 #div4 {
-  border: 1px solid black; /*元素边框 1px 宽 黑边*/
-  width:  280px;
-  height: 120px;
+  border: 1px solid black;
+  width: 250px;
+  height: 100px;
 }
 
-
-#div1 { overflow-y: scroll; margin-bottom: 12px; }
-
-#div2 { overflow-y: hidden; margin-bottom: 12px;  }
-
-#div3 { overflow-y: visible; margin-bottom: 150px;  }
-
-#div4 { overflow-y: auto; margin-bottom: 12px;  }
+#div1 {
+  overflow-y: hidden;
+  margin-bottom: 12px;
+}
+#div2 {
+  overflow-y: scroll;
+  margin-bottom: 12px;
+}
+#div3 {
+  overflow-y: visible;
+  margin-bottom: 120px;
+}
+#div4 {
+  overflow-y: auto;
+  margin-bottom: 120px;
+}
 ```
 
-### 结果
+#### 结果
 
-{{EmbedLiveSample("示例", "100%", "760")}}
+{{EmbedLiveSample("设置_overflow-y_行为", "100%", "780")}}
 
 ## 规范
 
@@ -123,4 +131,4 @@ overflow-y: unset; /*未设置*/
 
 ## 参见
 
-- 相关 CSS 属性：{{cssxref("text-overflow")}}, {{cssxref("white-space")}}, {{Cssxref("overflow")}}, {{Cssxref("overflow-y")}}, {{Cssxref("clip")}}, {{Cssxref("display")}}
+- 相关 CSS 属性：{{CSSXref("text-overflow")}}、{{CSSXref("white-space")}}、{{CSSXref("overflow")}}、{{CSSXref("overflow-x")}}、{{CSSXref("clip")}}、{{CSSXref("display")}}


### PR DESCRIPTION
### Description

### Motivation

### Additional details

### Related issues and pull requests