### PR TITLE
zh-CN: Translate `-webkit-text-stroke-*`; sync `-webkit-text-stroke` with en-US

### DIFF
--- a/files/zh-cn/web/css/-webkit-text-stroke-color/index.md
+++ b/files/zh-cn/web/css/-webkit-text-stroke-color/index.md
@@ -1,0 +1,86 @@
+---
+title: "-webkit-text-stroke-color"
+slug: Web/CSS/-webkit-text-stroke-color
+---
+
+{{CSSRef}}
+
+CSS 属性 **`-webkit-text-stroke-color`** 指定了文本字符的笔触[颜色](/zh-CN/docs/Web/CSS/color_value)。若未设置此属性，则使用 {{CSSXref("color")}} 属性的值。
+
+```css
+/* 颜色值 */
+-webkit-text-stroke-color: red;
+-webkit-text-stroke-color: #e08ab4;
+-webkit-text-stroke-color: rgb(200, 100, 0);
+
+/* 全局值 */
+-webkit-text-stroke-color: inherit;
+-webkit-text-stroke-color: initial;
+-webkit-text-stroke-color: revert;
+-webkit-text-stroke-color: revert-layer;
+-webkit-text-stroke-color: unset;
+```
+
+## 语法
+
+### 取值
+
+- `<color>`
+  - : 笔触颜色。
+
+## 形式定义
+
+{{CSSInfo}}
+
+## 形式语法
+
+{{CSSSyntax}}
+
+## 示例
+
+### 改变笔触颜色
+
+#### HTML
+
+```html
+<p>带笔触的文本</p>
+<input type="color" value="#ff0000" />
+```
+
+#### CSS
+
+```css
+p {
+  margin: 0;
+  font-size: 4em;
+  -webkit-text-stroke-width: 3px;
+  -webkit-text-stroke-color: #ff0000; /* 可在运行实例中被修改 */
+}
+```
+
+```js hidden
+const colorPicker = document.querySelector("input");
+colorPicker.addEventListener("change", (evt) => {
+  document.querySelector("p").style.webkitTextStrokeColor = evt.target.value;
+});
+```
+
+#### 结果
+
+{{EmbedLiveSample("改变笔触颜色", "500px", "100px")}}
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}
+
+## 参见
+
+- [宣布此特性的 Safari 博客文章](https://webkit.org/blog/85/introducing-text-stroke/)
+- [解释此特性的 CSS-Tricks 文章](https://css-tricks.com/adding-stroke-to-web-text/)
+- {{CSSXref("-webkit-text-fill-color")}}
+- {{CSSXref("-webkit-text-stroke-width")}}
+- {{CSSXref("-webkit-text-stroke")}}

--- a/files/zh-cn/web/css/-webkit-text-stroke-width/index.md
+++ b/files/zh-cn/web/css/-webkit-text-stroke-width/index.md
@@ -1,0 +1,97 @@
+---
+title: "-webkit-text-stroke-width"
+slug: Web/CSS/-webkit-text-stroke-width
+---
+
+{{CSSRef}}
+
+[CSS](/zh-CN/docs/Web/CSS) 属性 **`-webkit-text-stroke-width`** 指定了文本的笔触宽度。
+
+## 语法
+
+```css
+/* 关键词值 */
+-webkit-text-stroke-width: thin;
+-webkit-text-stroke-width: medium;
+-webkit-text-stroke-width: thick;
+
+/* 长度值 */
+-webkit-text-stroke-width: 2px;
+-webkit-text-stroke-width: 0.1em;
+-webkit-text-stroke-width: 1mm;
+-webkit-text-stroke-width: 5pt;
+
+/* 全局值 */
+-webkit-text-stroke-width: inherit;
+-webkit-text-stroke-width: initial;
+-webkit-text-stroke-width: revert;
+-webkit-text-stroke-width: revert-layer;
+-webkit-text-stroke-width: unset;
+```
+
+### 取值
+
+- `<line-width>`
+  - : 笔触宽度。
+
+## 形式定义
+
+{{CSSInfo}}
+
+## 形式语法
+
+{{CSSSyntax}}
+
+## 示例
+
+### 不同的笔触宽度
+
+#### CSS
+
+```css
+p {
+  margin: 0;
+  font-size: 4em;
+  -webkit-text-stroke-color: red;
+}
+
+#thin {
+  -webkit-text-stroke-width: thin;
+}
+
+#medium {
+  -webkit-text-stroke-width: 3px;
+}
+
+#thick {
+  -webkit-text-stroke-width: 1.5mm;
+}
+```
+
+#### HTML
+
+```html
+<p id="thin">细笔触</p>
+<p id="medium">中笔触</p>
+<p id="thick">粗笔触</p>
+```
+
+#### 结果
+
+{{EmbedLiveSample("不同的笔触宽度", "450px", "230px")}}
+
+## 规范
+
+{{Specifications}}
+
+## 浏览器兼容性
+
+{{Compat}}
+
+## 参见
+
+- [宣布此特性的 Safari 博客文章](https://webkit.org/blog/85/introducing-text-stroke/)
+- [解释此特性的 CSS-Tricks 文章](https://css-tricks.com/adding-stroke-to-web-text/)
+- {{CSSXref("-webkit-text-stroke-color")}}
+- {{CSSXref("-webkit-text-stroke")}}
+- {{CSSXref("-webkit-text-fill-color")}}

--- a/files/zh-cn/web/css/-webkit-text-stroke/index.md
+++ b/files/zh-cn/web/css/-webkit-text-stroke/index.md
@@ -5,39 +5,38 @@ slug: Web/CSS/-webkit-text-stroke
 
 {{CSSRef}}
 
-**`-webkit-text-stroke`** [CSS](/zh-CN/docs/Web/CSS) 属性为文本字符指定了[宽](/zh-CN/docs/Web/CSS/length)和[颜色](/zh-CN/docs/Web/CSS/color_value)。它是 {{cssxref("-webkit-text-stroke-width")}} 和 {{cssxref("-webkit-text-stroke-color")}} 属性的缩写。
+[CSS](/zh-CN/docs/Web/CSS) 属性 **`-webkit-text-stroke`** 指定了文本字符的笔触[宽度](/zh-CN/docs/Web/CSS/length)和笔触[颜色](/zh-CN/docs/Web/CSS/color_value)。此属性为全称属性 {{CSSXref("-webkit-text-stroke-width")}} 和 {{CSSXref("-webkit-text-stroke-color")}} 的简写属性。
 
 ## 语法
 
 ```css
-/* 宽度和颜色属性 */
+/* 宽度和颜色值 */
 -webkit-text-stroke: 4px navy;
 text-stroke: 4px navy;
 
-/* 全局属性 */
+/* 全局值 */
 -webkit-text-stroke: inherit;
 -webkit-text-stroke: initial;
+-webkit-text-stroke: revert;
+-webkit-text-stroke: revert-layer;
 -webkit-text-stroke: unset;
-text-stroke: inherit;
-text-stroke: initial;
-text-stroke: unset;
 ```
 
-## 复合属性
+## 属性构成
 
-该属性是以下 CSS 属性的简写：
+此属性为下列 CSS 属性的简写属性：
 
 - {{cssxref("-webkit-text-stroke-color")}}
 - {{cssxref("-webkit-text-stroke-width")}}
 
 ## 语法
 
-### 值
+### 取值
 
 - {{cssxref("&lt;length&gt;")}}
-  - : 文本宽。
+  - : 笔触宽度。
 - {{cssxref("&lt;color&gt;")}}
-  - : 文本颜色。
+  - : 笔触颜色。
 
 ## 形式定义
 
@@ -49,12 +48,12 @@ text-stroke: unset;
 
 ## 示例
 
-### 添加红色文字描边
+### 添加红色文本笔触
 
 #### HTML
 
 ```html
-<p id="example">The stroke of this text is red.</p>
+<p id="example">此文本的笔触为红色的。</p>
 ```
 
 #### CSS
@@ -69,7 +68,7 @@ text-stroke: unset;
 
 #### 结果
 
-{{EmbedLiveSample("添加红色文字描边", 600, 60)}}
+{{EmbedLiveSample("添加红色文本笔触", 600, 60)}}
 
 ## 规范
 


### PR DESCRIPTION
### Description

### Motivation

### Additional details

“笔触”（stroke）为 SVG 术语，此处对应 OpenType 的“轮廓”（outline）。

### Related issues and pull requests