### PR TITLE
zh-CN: Localize the `-webkit-line-clamp` example

### DIFF
--- a/files/zh-cn/web/css/-webkit-line-clamp/index.md
+++ b/files/zh-cn/web/css/-webkit-line-clamp/index.md
@@ -54,7 +54,7 @@ slug: Web/CSS/-webkit-line-clamp
 
 ```html
 <p>
-  在此示例中，<code>-webkit-line-clamp</code> 属性设置为 <code>3</code>，即文本在超过三行后将被截断。文本截断处将显示省略号。
+  在此示例中，<code>-webkit-line-clamp</code> 属性设置为 <code>2</code>，即文本在超过两行后将被截断。文本截断处将显示省略号。
 </p>
 ```
 
@@ -65,7 +65,7 @@ p {
   width: 300px;
   display: -webkit-box;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
+  -webkit-line-clamp: 2;
   overflow: hidden;
 }
 ```


### PR DESCRIPTION
### Description

### Motivation

当前示例文本内容无法演示属性效果。

### Additional details

### Related issues and pull requests

Relates to #12515.