### PR TITLE
add missing link to planets-data.txt file

### DIFF
--- a/files/fr/learn/html/tables/structuring_planet_data/index.md
+++ b/files/fr/learn/html/tables/structuring_planet_data/index.md
@@ -46,7 +46,7 @@ Vous pouvez aussi [regarder l'exemple ici](https://mdn.github.io/learning-area/h
 
 ## Étapes à suivre
 
-Les étapes suivantes décrivent ce que vous devez faire pour compléter l'exemple de tableau. Toutes les données dont vous avez besoin sont contenues dans le fichier [planets-data.txt](https://github.com/mdn/learning-area/blob/main/html/tables/assessment-start/planets-data.txt). Si vous avez du mal à visualiser les données, regardez l'exemple donné dans le lien ci-dessus, ou essayez de dessiner un diagramme.
+Les étapes suivantes décrivent ce que vous devez faire pour compléter l'exemple de tableau. Toutes les données dont vous avez besoin sont contenues dans le fichier [`planets-data.txt`](https://github.com/mdn/learning-area/blob/main/html/tables/assessment-start/planets-data.txt). Si vous avez du mal à visualiser les données, regardez l'exemple donné dans le lien ci-dessus, ou essayez de dessiner un diagramme.
 
 1. Ouvrez votre copie de `blank-template.html`, et commencez le tableau en lui donnant un conteneur extérieur, un en-tête et un corps de tableau. Vous n'avez pas besoin d'un pied de tableau dans cet exemple.
 2. Ajoutez la légende fournie à votre tableau.

--- a/files/fr/learn/html/tables/structuring_planet_data/index.md
+++ b/files/fr/learn/html/tables/structuring_planet_data/index.md
@@ -46,7 +46,7 @@ Vous pouvez aussi [regarder l'exemple ici](https://mdn.github.io/learning-area/h
 
 ## Étapes à suivre
 
-Les étapes suivantes décrivent ce que vous devez faire pour compléter l'exemple de tableau. Toutes les données dont vous avez besoin sont contenues dans le fichier `planets-data.txt`. Si vous avez du mal à visualiser les données, regardez l'exemple donné dans le lien ci-dessus, ou essayez de dessiner un diagramme.
+Les étapes suivantes décrivent ce que vous devez faire pour compléter l'exemple de tableau. Toutes les données dont vous avez besoin sont contenues dans le fichier [planets-data.txt](https://github.com/mdn/learning-area/blob/main/html/tables/assessment-start/planets-data.txt). Si vous avez du mal à visualiser les données, regardez l'exemple donné dans le lien ci-dessus, ou essayez de dessiner un diagramme.
 
 1. Ouvrez votre copie de `blank-template.html`, et commencez le tableau en lui donnant un conteneur extérieur, un en-tête et un corps de tableau. Vous n'avez pas besoin d'un pied de tableau dans cet exemple.
 2. Ajoutez la légende fournie à votre tableau.


### PR DESCRIPTION
Link was missing, add a link to download the file planets-data.txt

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Link was missing for downloading the file planets-data.txt, add a link to download the file.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
To access the link to download the file when clicking on the name

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
