### PR TITLE
missing links to download files

### DIFF
--- a/files/fr/learn/html/tables/structuring_planet_data/index.md
+++ b/files/fr/learn/html/tables/structuring_planet_data/index.md
@@ -30,7 +30,7 @@ Dans notre évaluation, nous vous fournissons des données sur les planètes de 
 
 ## Point de départ
 
-Pour commencer cette évaluation, créez des copies locales de blank-template.html, minimal-table.css et planets-data.txt dans un nouveau répertoire dans votre ordinateur.
+Pour commencer cette évaluation, créez des copies locales de [blank-template.html](https://github.com/mdn/learning-area/blob/main/html/tables/assessment-start/blank-template.html), [minimal-table.css](https://github.com/mdn/learning-area/blob/main/html/tables/assessment-start/minimal-table.css) et [planets-data.txt](https://github.com/mdn/learning-area/blob/main/html/tables/assessment-start/planets-data.txt) dans un nouveau répertoire dans votre ordinateur.
 
 > **Note :** Vous pouvez aussi utiliser un site comme[JSBin](https://jsbin.com/) ou [Thimble](https://thimble.mozilla.org/) pour votre évaluation. Vous pouvez coller les HTML, CSS et JavaScript dans l'un de ces éditeurs en ligne. Si votre éditeur en ligne n'a pas de panneaux séparés JavaScript/CSS, n'hésitez pas à les mettre en ligne `<script>`/`<style>` dans la page HTML.
 


### PR DESCRIPTION
missing links to github repo to download the files to do the exercise

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I saw there was link missing previously, i've just noticed the links to the 3 files were missing. Added them to download  them from github

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
To be able to do the exercise. Otherwise, they don't have the needed files to do it.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
