### PR TITLE
Correct French sentence for :first-child use

### DIFF
--- a/files/fr/learn/css/building_blocks/selectors/type_class_and_id_selectors/index.md
+++ b/files/fr/learn/css/building_blocks/selectors/type_class_and_id_selectors/index.md
@@ -55,7 +55,7 @@ On peut rencontrer ce type de comportement dans les "feuilles de style de réini
 
 ### Utiliser le sélecteur universel pour rendre les sélecteurs plus lisibles
 
-On peut utiliser `*` pour rendre les sélecteurs plus lisibles, pour clarifier leur fonctionnement. Par exemple, si je veux sélectionner le premier descendant de chaque élément `<article>` pour le mettre en gras, je peux utiliser le sélecteur {{cssxref(":first-child")}}, qu'on verra dans la leçon sur les [pseudo-classes et pseudo-éléments](/fr/docs/Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements)&nbsp;:
+On peut utiliser `*` pour rendre les sélecteurs plus lisibles, pour clarifier leur fonctionnement. Par exemple, si je veux sélectionner tout élément descendant de l'élément `<article>`, qui est le premier enfant de son parent, pour le mettre en gras, je peux utiliser le sélecteur {{cssxref(":first-child")}}, qu'on verra dans la leçon sur les [pseudo-classes et pseudo-éléments](/fr/docs/Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements)&nbsp;:
 
 ```css
 article :first-child {


### PR DESCRIPTION
Translation in French is wrong
" si je veux sélectionner le premier descendant de chaque élément `<article>` pour le mettre en gras" means "if I want to select the first descendant of each <article> element to make them bold". I understood that it means the first child of article would be bold, but when I did the test Selectors (CSS), task 3, it didn't give the expected result from the French documentation.

The English one is correct though, I've just checked it, so I based my French translation on it.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Translation in French was wrong. So when I did [task3 in Selectors test](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Selectors/Selectors_Tasks), the result wasn't what was explained in the French sentence.
I corrected the French translation to match more or less the English one which was fine.

### Motivation

French translation was mistranslated. The sentence was changed to match the expected results, to be able to do task 3 for French speakers. I hope it is correct, at least I undertand it just like the English version.

### Additional details
