### PR TITLE
Typofix/clarification for `webRequest.BlockingResponse`

### DIFF
--- a/files/fr/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.md
+++ b/files/fr/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.md
@@ -36,7 +36,7 @@ Les valeurs de ce type sont des objets. Ils contiennent les propriétés suivant
       - : `string`. Mot de passe à fournir.
 
 - `cancel`{{optional_inline}}
-  - : `boolean`. Si `true`, la demande est annulée. Vous ne pouvez définir cette propriété dans {{WebExtAPIRef("webRequest.onBeforeRequest", "onBeforeRequest")}}, {{WebExtAPIRef("webRequest.onBeforeSendHeaders", "onBeforeSendHeaders")}}, {{WebExtAPIRef("webRequest.onHeadersReceived", "onHeadersReceived")}}, et {{WebExtAPIRef("webRequest.onAuthRequired", "onAuthRequired")}}.
+  - : `boolean`. Si `true`, la demande est annulée. Vous pouvez définir cette propriété seulement dans {{WebExtAPIRef("webRequest.onBeforeRequest", "onBeforeRequest")}}, {{WebExtAPIRef("webRequest.onBeforeSendHeaders", "onBeforeSendHeaders")}}, {{WebExtAPIRef("webRequest.onHeadersReceived", "onHeadersReceived")}}, et {{WebExtAPIRef("webRequest.onAuthRequired", "onAuthRequired")}}.
 - `redirectUrl`{{optional_inline}}
 
   - : `string`. Il s'agit d'une URL, et si elle est définie, la requête originale est redirigée vers cette URL. Vous ne pouvez définir cette propriété que dans {{WebExtAPIRef("webRequest.onBeforeRequest", "onBeforeRequest")}} ou {{WebExtAPIRef("webRequest.onHeadersReceived", "onHeadersReceived")}}.


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Changes the french explanation that goes with the "cancel" value so it is more clear that is is restricted to some listeners (and not the other way around).


### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I struggled to understand whether I could use the "cancel' value in the "onBeforeRequest" listener, as the french translation was ambiguous. The original English text is clear on that point so I decided to correct the french one.

### Additional details

None.

### Related issues and pull requests

None that I know of.
