### PR TITLE
Added missing space, code/bolded second method mention

### DIFF
--- a/files/pt-br/web/javascript/reference/global_objects/array/shift/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/array/shift/index.md
@@ -7,7 +7,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Array/shift
 
 ## Sumário
 
-O método **`shift()`**remove o **primeiro** elemento de um array e retorna esse elemento. Este método muda o tamanho do array.
+O método **`shift()`** remove o **primeiro** elemento de um array e retorna esse elemento. Este método muda o tamanho do array.
 
 {{EmbedInteractiveExample("pages/js/array-shift.html")}}
 
@@ -48,7 +48,7 @@ console.log('Elemento removido: ' + shifted);
 
 ### Usando o método shift() dentro de um loop de while
 
-O médodo shift() é frequentemente usado como condição dentro de um loop de while. No exemplo a seguir, cada iteração removerá o elemento seguinte do array, até que ele esteja vazio:
+O médodo **`shift()`** é frequentemente usado como condição dentro de um loop de while. No exemplo a seguir, cada iteração removerá o elemento seguinte do array, até que ele esteja vazio:
 
 ```js
 var nomes = ["André", "Eduardo", "Paulo", "Cris", "João"];

--- a/files/pt-br/web/javascript/reference/global_objects/array/shift/index.md
+++ b/files/pt-br/web/javascript/reference/global_objects/array/shift/index.md
@@ -48,7 +48,7 @@ console.log('Elemento removido: ' + shifted);
 
 ### Usando o método shift() dentro de um loop de while
 
-O médodo **`shift()`** é frequentemente usado como condição dentro de um loop de while. No exemplo a seguir, cada iteração removerá o elemento seguinte do array, até que ele esteja vazio:
+O médodo `shift()` é frequentemente usado como condição dentro de um loop de while. No exemplo a seguir, cada iteração removerá o elemento seguinte do array, até que ele esteja vazio:
 
 ```js
 var nomes = ["André", "Eduardo", "Paulo", "Cris", "João"];


### PR DESCRIPTION
Minor nitpick changes that fix the formatting on the page for pt-BR language.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

The array method lacked a space after the double asterisk, which caused the text to not bold when converting Markdown to HTML. This PR fixes that issue.

At the bottom, I've also bolded and coded another mention of the array method, but it seems like the pages usually only bold the first mention of the method and wrap the other mentions in a simple code block, so I guess I'll only code that mention in a bit.
EDIT: It's only coded now, not bolded anymore.

<!-- ✍️ Summarize your changes in one or two sentences -->

This change will make the markdown formatting actually work for visitors.