### PR TITLE
Quelques macros manquantes sont ajoutées

### DIFF
--- a/files/fr/web/html/element/abbr/index.md
+++ b/files/fr/web/html/element/abbr/index.md
@@ -195,12 +195,16 @@ l'utiliser.</p>
 
 C'est une bonne pratique que d'épeler l'acronyme ou l'abréviation lorsqu'elle est utilisée pour la première fois. Cela permet au lecteur de mieux comprendre le terme, notamment si celui-ci est technique ou appartient à un jargon spécifique.
 
-#### Exemple
+#### Exemples
 
 ```html
 <p>JavaScript Object Notation (<abbr>JSON</abbr>) est un format léger
   d'échange de données.</p>
 ```
+
+##### Résltat
+
+{{EmbedliveSample('')}}
 
 Cela peut servir aux personnes qui découvrent ces concepts pour la première fois ou pour les personnes souffrant de troubles cognitifs.
 

--- a/files/fr/web/html/element/abbr/index.md
+++ b/files/fr/web/html/element/abbr/index.md
@@ -202,7 +202,7 @@ C'est une bonne pratique que d'épeler l'acronyme ou l'abréviation lorsqu'elle 
   d'échange de données.</p>
 ```
 
-##### Résltat
+##### Résultat
 
 {{EmbedliveSample('')}}
 

--- a/files/fr/web/html/element/acronym/index.md
+++ b/files/fr/web/html/element/acronym/index.md
@@ -30,7 +30,7 @@ Cet élément implémente l'interface [`HTMLElement`](/fr/docs/Web/API/HTMLEleme
 
 > **Note :** Jusqu'à Gecko 1.9.2 (inclus), Firefox implémente l'interface [`HTMLSpanElement`](/fr/docs/Web/API/HTMLSpanElement) pour cet élément.
 
-## Exemple
+## Exemples
 
 ```html
 <p>
@@ -38,6 +38,10 @@ Cet élément implémente l'interface [`HTMLElement`](/fr/docs/Web/API/HTMLEleme
    n'est qu'une facette d'Internet.
 </p>
 ```
+
+### Résultat
+
+{{EmbedLiveSample('')}}
 
 ## Style par défaut
 

--- a/files/fr/web/html/element/address/index.md
+++ b/files/fr/web/html/element/address/index.md
@@ -144,7 +144,7 @@ Cet élément n'a pas d'autres attributs que les [attributs universels](/fr/docs
 - Cet élément ne doit pas contenir plus d'informations que l'information de contact, par exemple une date de publication (qui appartiendrait à l'élément [`<time>`](/fr/docs/Web/HTML/Element/time)).
 - Typiquement un élément `<address>` peut être placé dans l'élément [`<footer>`](/fr/docs/Web/HTML/Element/footer) de la section courante, s'il y en a une.
 
-## Exemple
+## Exemples
 
 ```html
 <address>
@@ -163,7 +163,7 @@ Cet élément n'a pas d'autres attributs que les [attributs universels](/fr/docs
 
 ### Résultat
 
-{{EmbedLiveSample("Exemple", "100%", 190)}}
+{{EmbedLiveSample("Exemples", "100%", 190)}}
 
 Bien que le rendu par défaut du texte de l'élément `<address>` utilise le même style par défaut que les éléments [`<i>`](/fr/docs/Web/HTML/Element/i) ou [`<em>`](/fr/docs/Web/HTML/Element/em), il est plus approprié d'utiliser cet élément lorsque l'on traite d'informations de contact, étant donné qu'il apporte des informations sémantiques supplémentaires.
 

--- a/files/fr/web/html/element/applet/index.md
+++ b/files/fr/web/html/element/applet/index.md
@@ -118,7 +118,7 @@ Cet élément peut utiliser [les attributs universels](/fr/docs/Web/HTML/Global_
 - **`width`** {{deprecated_inline}}
   - : Cet attribut définit la largeur, en pixels, dont l'applet a besoin
 
-## Exemple
+## Exemples
 
 ### HTML
 

--- a/files/fr/web/html/element/area/index.md
+++ b/files/fr/web/html/element/area/index.md
@@ -161,7 +161,7 @@ Cet élément inclut les [attributs universels](/fr/docs/Web/HTML/Global_attribu
 - **`type`** {{deprecated_inline}}
   - : Sans effet car ignoré par les navigateurs.
 
-## Exemple
+## Exemples
 
 Dans cet exemple, la partie gauche est un lien vers une page et la partie droite est inactive.
 

--- a/files/fr/web/html/element/article/index.md
+++ b/files/fr/web/html/element/article/index.md
@@ -110,7 +110,7 @@ Cet élément n'a pas d'autres attributs que les [attributs universels](/fr/docs
 - Des informations à propos de l'auteur d'un élément `<article>` peuvent être fournies au travers de l'élément [`<address>`](/fr/docs/Web/HTML/Element/address), mais cela ne s'applique pas aux éléments `<article>` imbriqués.
 - La date et l'heure de publication d'un élément `<article>` peuvent être donnés en utilisant l'attribut [`datetime`](/fr/docs/Web/HTML/Element/time#attr-datetime) d'un élément [`<time>`](/fr/docs/Web/HTML/Element/time). _Notez que l'attribut [`pubdate`](/fr/docs/Web/HTML/Element/time#attr-pubdate) de [`<time>`](/fr/docs/Web/HTML/Element/time) ne fait plus partie de la norme W3C HTML 5._
 
-## Exemple
+## Exemples
 
 ```html
 <article class="film_review">
@@ -151,6 +151,10 @@ Cet élément n'a pas d'autres attributs que les [attributs universels](/fr/docs
   </footer>
 </article>
 ```
+
+### Résultat
+
+{{EmbedLiveSample('')}}
 
 ## Spécifications
 

--- a/files/fr/web/html/element/aside/index.md
+++ b/files/fr/web/html/element/aside/index.md
@@ -109,7 +109,7 @@ Cet élément ne comprend que les [attributs universels](/fr/docs/Web/HTML/Globa
 
 On ne doit pas utiliser l'élément `<aside>` pour marquer du texte entre parenthèses, ce type de texte est considéré comme faisant partie du flux principal.
 
-## Exemple
+## Exemples
 
 Dans cet exemple, on utilise `<aside>` afin de baliser un paragraphe d'un article. Ici, le paragraphe n'est pas directement lié au contenu principal de l'article et c'est pour cela qu'on utilise cet élément.
 

--- a/files/fr/web/html/element/audio/index.md
+++ b/files/fr/web/html/element/audio/index.md
@@ -120,10 +120,6 @@ Les navigateurs ne prennent pas tous en charge les mêmes [types de fichiers](/f
 </audio>
 ```
 
-### Résultat
-
-{{EmbedLiveSample('')}}
-
 Nous proposons un [guide substantiel et complet des types de fichiers médias](/fr/docs/Web/Media/Formats) et des [codecs audio qui peuvent être utilisés en leur sein](/fr/docs/Web/Media/Formats/Audio_codecs). Est également disponible [un guide des codecs supportés pour la vidéo](/fr/docs/Web/Media/Formats/Video_codecs).
 
 Autres notes d'utilisation :
@@ -202,10 +198,6 @@ Cet exemple précise quelle piste audio intégrer en utilisant l'attribut `src` 
 </audio>
 ```
 
-#### Résultat
-
-{{EmbedLiveSample('')}}
-
 ### Utilisation de plusieurs éléments `<source>`
 
 Dans l'exemple qui suit, le navigateur essaiera de jouer le premier fichier correspondant au premier élément (celui avec le codec Opus) : s'il peut le lire, il n'interprète pas les suivants ; s'il ne peut pas le lire, il tente de lire le deuxième puis, si ce n'est toujours pas possible, le troisième (au format MP3) :
@@ -217,10 +209,6 @@ Dans l'exemple qui suit, le navigateur essaiera de jouer le premier fichier corr
  <source src="toto.mp3" type="audio/mpeg"/>
 </audio>
 ```
-
-#### Résultat
-
-{{EmbedLiveSample('')}}
 
 ## Accessibilité
 
@@ -258,10 +246,6 @@ Une autre bonne pratique consiste à fournir du contenu comme un lien de téléc
   </p>
 </audio>
 ```
-
-#### Résultat
-
-{{EmbedLiveSample('')}}
 
 - [Sous-titrage sur le web](/fr/docs/Plugins/Flash_to_HTML5/Video/Subtitles_captions)
 - [Web Video Text Tracks Format (WebVTT)](/fr/docs/Web/API/WebVTT_API)

--- a/files/fr/web/html/element/audio/index.md
+++ b/files/fr/web/html/element/audio/index.md
@@ -120,6 +120,10 @@ Les navigateurs ne prennent pas tous en charge les mêmes [types de fichiers](/f
 </audio>
 ```
 
+### Résultat
+
+{{EmbedLiveSample('')}}
+
 Nous proposons un [guide substantiel et complet des types de fichiers médias](/fr/docs/Web/Media/Formats) et des [codecs audio qui peuvent être utilisés en leur sein](/fr/docs/Web/Media/Formats/Audio_codecs). Est également disponible [un guide des codecs supportés pour la vidéo](/fr/docs/Web/Media/Formats/Video_codecs).
 
 Autres notes d'utilisation :
@@ -198,6 +202,10 @@ Cet exemple précise quelle piste audio intégrer en utilisant l'attribut `src` 
 </audio>
 ```
 
+#### Résultat
+
+{{EmbedLiveSample('')}}
+
 ### Utilisation de plusieurs éléments `<source>`
 
 Dans l'exemple qui suit, le navigateur essaiera de jouer le premier fichier correspondant au premier élément (celui avec le codec Opus) : s'il peut le lire, il n'interprète pas les suivants ; s'il ne peut pas le lire, il tente de lire le deuxième puis, si ce n'est toujours pas possible, le troisième (au format MP3) :
@@ -209,6 +217,10 @@ Dans l'exemple qui suit, le navigateur essaiera de jouer le premier fichier corr
  <source src="toto.mp3" type="audio/mpeg"/>
 </audio>
 ```
+
+#### Résultat
+
+{{EmbedLiveSample('')}}
 
 ## Accessibilité
 
@@ -246,6 +258,10 @@ Une autre bonne pratique consiste à fournir du contenu comme un lien de téléc
   </p>
 </audio>
 ```
+
+#### Résultat
+
+{{EmbedLiveSample('')}}
 
 - [Sous-titrage sur le web](/fr/docs/Plugins/Flash_to_HTML5/Video/Subtitles_captions)
 - [Web Video Text Tracks Format (WebVTT)](/fr/docs/Web/API/WebVTT_API)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
J'ai ajouté quelques titres et macros aux éléments de HTML.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
[Ici](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/HTML_element_page_template) est mentionné que le titre des exemples doit être au pluriel, même s'il y a seulement un exemple:
 
> Note that we use the plural "Examples" even if the page only contains one example.

De plus j'ai ajouté les macros *live sample* aux éléments qui ne l'avaient pas.  

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

Les exemples d l'élément \<audio\> ne contiennent pas de fichiers sonores et rien ne se produit quand on appuie sur les buttons. Peut-être que l'ajout des fichiers peut améliorer la page.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
