### PR TITLE
[ko] fix arrow function

### DIFF
--- a/files/ko/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/ko/web/javascript/reference/functions/arrow_functions/index.md
@@ -8,7 +8,7 @@ original_slug: Web/JavaScript/Reference/Functions/애로우_펑션
 
 화살표 함수 표현(**arrow function expression**)은 [전통적인 함수표현(function)](/ko/docs/Web/JavaScript/Reference/Operators/function)의 간편한 대안입니다. 하지만, 화살표 함수는 몇 가지 제한점이 있고 모든 상황에 사용할 수는 없습니다.
 
-- [this](/ko/docs/Web/JavaScript/Reference/Operators/this), [arguments](/ko/docs/Web/JavaScript/Reference/Functions/arguments)나 [super](/ko/docs/Web/JavaScript/Reference/Operators/super)에 대한 자체 바인딩이 없고, [methods](/ko/docs/Glossary/Method) 로 사용될 수 없습니다.
+- [this](/ko/docs/Web/JavaScript/Reference/Operators/this), [arguments](/ko/docs/Web/JavaScript/Reference/Functions/arguments)나 [super](/ko/docs/Web/JavaScript/Reference/Operators/super)에 대한 자체 바인딩이 없고, [methods](/ko/docs/Glossary/Method)로 사용해서는 안됩니다.
 - [new.target](/ko/docs/Web/JavaScript/Reference/Operators/new.target)키워드가 없습니다.
 - 일반적으로 스코프를 지정할 때 사용하는 [call](/ko/docs/Web/JavaScript/Reference/Global_Objects/Function/call), [apply](/ko/docs/Web/JavaScript/Reference/Global_Objects/Function/apply), [bind](/ko/docs/Web/JavaScript/Reference/Global_Objects/Function/bind) methods를 이용할 수 없습니다.
 - 생성자[(Constructor)](/ko/docs/Web/JavaScript/Reference/Classes/constructor)로 사용할 수 없습니다.

--- a/files/ko/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/ko/web/javascript/reference/functions/arrow_functions/index.md
@@ -8,7 +8,7 @@ original_slug: Web/JavaScript/Reference/Functions/애로우_펑션
 
 화살표 함수 표현(**arrow function expression**)은 [전통적인 함수표현(function)](/ko/docs/Web/JavaScript/Reference/Operators/function)의 간편한 대안입니다. 하지만, 화살표 함수는 몇 가지 제한점이 있고 모든 상황에 사용할 수는 없습니다.
 
-- [this](/ko/docs/Web/JavaScript/Reference/Operators/this), [arguments](/ko/docs/Web/JavaScript/Reference/Functions/arguments)나 [super](/ko/docs/Web/JavaScript/Reference/Operators/super)에 대한 바인딩이 없고, [methods](/ko/docs/Glossary/Method) 로 사용될 수 없습니다.
+- [this](/ko/docs/Web/JavaScript/Reference/Operators/this), [arguments](/ko/docs/Web/JavaScript/Reference/Functions/arguments)나 [super](/ko/docs/Web/JavaScript/Reference/Operators/super)에 대한 자체 바인딩이 없고, [methods](/ko/docs/Glossary/Method) 로 사용될 수 없습니다.
 - [new.target](/ko/docs/Web/JavaScript/Reference/Operators/new.target)키워드가 없습니다.
 - 일반적으로 스코프를 지정할 때 사용하는 [call](/ko/docs/Web/JavaScript/Reference/Global_Objects/Function/call), [apply](/ko/docs/Web/JavaScript/Reference/Global_Objects/Function/apply), [bind](/ko/docs/Web/JavaScript/Reference/Global_Objects/Function/bind) methods를 이용할 수 없습니다.
 - 생성자[(Constructor)](/ko/docs/Web/JavaScript/Reference/Classes/constructor)로 사용할 수 없습니다.

--- a/files/ko/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/ko/web/javascript/reference/functions/arrow_functions/index.md
@@ -8,7 +8,7 @@ original_slug: Web/JavaScript/Reference/Functions/애로우_펑션
 
 화살표 함수 표현(**arrow function expression**)은 [전통적인 함수표현(function)](/ko/docs/Web/JavaScript/Reference/Operators/function)의 간편한 대안입니다. 하지만, 화살표 함수는 몇 가지 제한점이 있고 모든 상황에 사용할 수는 없습니다.
 
-- [this](/ko/docs/Web/JavaScript/Reference/Operators/this)나 [super](/ko/docs/Web/JavaScript/Reference/Operators/super)에 대한 바인딩이 없고, [methods](/ko/docs/Glossary/Method) 로 사용될 수 없습니다.
+- [this](/ko/docs/Web/JavaScript/Reference/Operators/this), [arguments](/ko/docs/Web/JavaScript/Reference/Functions/arguments)나 [super](/ko/docs/Web/JavaScript/Reference/Operators/super)에 대한 바인딩이 없고, [methods](/ko/docs/Glossary/Method) 로 사용될 수 없습니다.
 - [new.target](/ko/docs/Web/JavaScript/Reference/Operators/new.target)키워드가 없습니다.
 - 일반적으로 스코프를 지정할 때 사용하는 [call](/ko/docs/Web/JavaScript/Reference/Global_Objects/Function/call), [apply](/ko/docs/Web/JavaScript/Reference/Global_Objects/Function/apply), [bind](/ko/docs/Web/JavaScript/Reference/Global_Objects/Function/bind) methods를 이용할 수 없습니다.
 - 생성자[(Constructor)](/ko/docs/Web/JavaScript/Reference/Classes/constructor)로 사용할 수 없습니다.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

1. `arguments`객체 또한 바인딩이 되지 않는다는 것을 추가했습니다.
2. **`바인딩이 없고`에서 `자체 바인딩이 없고`로 수정했습니다.**
3. 메서드로 사용될 수는 있으나 권장되지 않는다는 문맥으로 수정했습니다.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

1. 화살표 함수는 바인딩이 아예 없는 것이 아니라 자체 바인딩이 없습니다. 원문에서도 `own binding`이 없다고 되어있습니다.
화살표 함수는 ‘정의될 때 렉시컬 환경의 this’가 정적으로 바인딩 되기 때문에 ‘바인딩이 없다.’는 오해의 소지가 있고, 설명을 보탤 필요가 있다고 생각했습니다.

2. 원문의 메서드는 단순히 객체의 프로퍼티인 함수를 의미합니다. 따라서 메서드로 사용될 수는 있습니다. 
다만, 원하는 대로 동작하지 않을 수 있음을 경고했습니다.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
