### PR TITLE
zh-CN: Update terms for the logical `padding-*` properties

### DIFF
--- a/files/zh-cn/web/css/padding-block-end/index.md
+++ b/files/zh-cn/web/css/padding-block-end/index.md
@@ -12,12 +12,12 @@ slug: Web/CSS/padding-block-end
 ## 语法
 
 ```css
-/* 长度值 */
+/* <length> 值 */
 padding-block-end: 10px; /* 绝对长度 */
 padding-block-end: 1em; /* 相对于文本尺寸的长度 */
 
-/* 百分比值 */
-padding-block-end: 5%; /* 相对于包含块宽度的内边距 */
+/* <percentage> 值 */
+padding-block-end: 5%; /* 相对于包含区块宽度的内边距 */
 
 /* 全局值 */
 padding-block-end: inherit;
@@ -32,7 +32,7 @@ padding-block-end: unset;
 - {{CSSXref("&lt;length&gt;")}}
   - : 以固定值指定的内边距尺寸。必须非负。
 - {{CSSXref("&lt;percentage&gt;")}}
-  - : 以百分比指定的内边距尺寸，参照[包含块](/zh-CN/docs/Web/CSS/Containing_block)的行向尺寸（即横排语言中的*宽度*，由 {{CSSXref("writing-mode")}} 所定义）。必须非负。
+  - : 以百分比指定的内边距尺寸，参照[包含区块](/zh-CN/docs/Web/CSS/Containing_block)的行向尺寸（即横向语言中的*宽度*，由 {{CSSXref("writing-mode")}} 所定义）。必须非负。
 
 ## 描述
 

--- a/files/zh-cn/web/css/padding-block-start/index.md
+++ b/files/zh-cn/web/css/padding-block-start/index.md
@@ -12,12 +12,12 @@ slug: Web/CSS/padding-block-start
 ## 语法
 
 ```css
-/* 长度值 */
+/* <length> 值 */
 padding-block-start: 10px; /* 绝对长度 */
 padding-block-start: 1em; /* 相对于文本尺寸的长度 */
 
-/* 百分比值 */
-padding-block-start: 5%; /* 相对于包含块宽度的内边距 */
+/* <percentage> 值 */
+padding-block-start: 5%; /* 相对于包含区块宽度的内边距 */
 
 /* 全局值 */
 padding-block-start: inherit;
@@ -32,7 +32,7 @@ padding-block-start: unset;
 - {{CSSXref("&lt;length&gt;")}}
   - : 以固定值指定的内边距尺寸。必须非负。
 - {{CSSXref("&lt;percentage&gt;")}}
-  - : 以百分比指定的内边距尺寸，参照[包含块](/zh-CN/docs/Web/CSS/Containing_block)的[行向尺寸](/zh-CN/docs/Web/CSS/CSS_Flow_Layout/Block_and_Inline_Layout_in_Normal_Flow)（即横排语言中的*宽度*，由 {{CSSXref("writing-mode")}} 所定义）。必须非负。
+  - : 以百分比指定的内边距尺寸，参照[包含区块](/zh-CN/docs/Web/CSS/Containing_block)的[行向尺寸](/zh-CN/docs/Web/CSS/CSS_Flow_Layout/Block_and_Inline_Layout_in_Normal_Flow)（即横向语言中的*宽度*，由 {{CSSXref("writing-mode")}} 所定义）。必须非负。
 
 ## 描述
 

--- a/files/zh-cn/web/css/padding-block/index.md
+++ b/files/zh-cn/web/css/padding-block/index.md
@@ -19,18 +19,19 @@ slug: Web/CSS/padding-block
 ## 语法
 
 ```css
-/* 长度值 */
+/* <length> 值 */
 padding-block: 10px 20px; /* 绝对长度 */
 padding-block: 1em 2em; /* 相对于文本尺寸 */
 padding-block: 10px; /* 同时设置块首和块末值 */
 
-/* 百分比值 */
-padding-block: 5% 2%; /* 相对于最近包含块的宽度 */
+/* <percentage> 值 */
+padding-block: 5% 2%; /* 相对于最近包含区块的宽度 */
 
 /* 全局值 */
 padding-block: inherit;
 padding-block: initial;
 padding-block: revert;
+padding-block: revert-layer;
 padding-block: unset;
 ```
 

--- a/files/zh-cn/web/css/padding-inline-end/index.md
+++ b/files/zh-cn/web/css/padding-inline-end/index.md
@@ -12,12 +12,12 @@ slug: Web/CSS/padding-inline-end
 ## 语法
 
 ```css
-/* 长度值 */
+/* <length> 值 */
 padding-inline-end: 10px; /* 绝对长度 */
 padding-inline-end: 1em; /* 相对于文本尺寸的长度 */
 
-/* 百分比值 */
-padding-inline-end: 5%; /* 相对于包含块宽度的内边距 */
+/* <percentage> 值 */
+padding-inline-end: 5%; /* 相对于包含区块宽度的内边距 */
 
 /* 全局值 */
 padding-inline-end: inherit;
@@ -32,7 +32,7 @@ padding-inline-end: unset;
 - {{CSSXref("&lt;length&gt;")}}
   - : 以固定值指定的内边距尺寸。必须非负。
 - {{CSSXref("&lt;percentage&gt;")}}
-  - : 以百分比指定的内边距尺寸，参照[包含块](/zh-CN/docs/Web/CSS/Containing_block)的[行向尺寸](/zh-CN/docs/Web/CSS/CSS_Flow_Layout/Block_and_Inline_Layout_in_Normal_Flow)（即横排语言中的*宽度*，由 {{CSSXref("writing-mode")}} 所定义）。必须非负。
+  - : 以百分比指定的内边距尺寸，参照[包含区块](/zh-CN/docs/Web/CSS/Containing_block)的[行向尺寸](/zh-CN/docs/Web/CSS/CSS_Flow_Layout/Block_and_Inline_Layout_in_Normal_Flow)（即横向语言中的*宽度*，由 {{CSSXref("writing-mode")}} 所定义）。必须非负。
 
 ## 描述
 

--- a/files/zh-cn/web/css/padding-inline-start/index.md
+++ b/files/zh-cn/web/css/padding-inline-start/index.md
@@ -12,12 +12,12 @@ slug: Web/CSS/padding-inline-start
 ## 语法
 
 ```css
-/* 长度值 */
+/* <length> 值 */
 padding-inline-start: 10px; /* 绝对长度 */
 padding-inline-start: 1em; /* 相对于文本尺寸的长度 */
 
-/* 百分比值 */
-padding-inline-start: 5%; /* 相对于包含块宽度的内边距 */
+/* <percentage> 值 */
+padding-inline-start: 5%; /* 相对于包含区块宽度的内边距 */
 
 /* 全局值 */
 padding-inline-start: inherit;
@@ -32,7 +32,7 @@ padding-inline-start: unset;
 - {{CSSXref("&lt;length&gt;")}}
   - : 以固定值指定的内边距尺寸。必须非负。
 - {{CSSXref("&lt;percentage&gt;")}}
-  - : 以百分比指定的内边距尺寸，参照[包含块](/zh-CN/docs/Web/CSS/Containing_block)的行向尺寸（即横排语言中的*宽度*，由 {{CSSXref("writing-mode")}} 所定义）。必须非负。
+  - : 以百分比指定的内边距尺寸，参照[包含区块](/zh-CN/docs/Web/CSS/Containing_block)的行向尺寸（即横向语言中的*宽度*，由 {{CSSXref("writing-mode")}} 所定义）。必须非负。
 
 ## 描述
 

--- a/files/zh-cn/web/css/padding-inline/index.md
+++ b/files/zh-cn/web/css/padding-inline/index.md
@@ -19,18 +19,19 @@ slug: Web/CSS/padding-inline
 ## 语法
 
 ```css
-/* 长度值 */
+/* <length> 值 */
 padding-inline: 10px 20px; /* 绝对长度 */
 padding-inline: 1em 2em; /* 相对于文本尺寸 */
 padding-inline: 10px; /* 同时设置行首和行末值 */
 
-/* 百分比值 */
-padding-inline: 5% 2%; /* 相对于最近包含块的宽度 */
+/* <percentage> 值 */
+padding-inline: 5% 2%; /* 相对于最近包含区块的宽度 */
 
 /* 全局值 */
 padding-inline: inherit;
 padding-inline: initial;
 padding-inline: revert;
+padding-inline: revert-layer;
 padding-inline: unset;
 ```
 
@@ -41,7 +42,7 @@ padding-inline: unset;
 - {{CSSXref("&lt;length&gt;")}}
   - : 以固定值指定的内边距尺寸。必须非负。
 - {{CSSXref("&lt;percentage&gt;")}}
-  - : 以百分比指定的内边距尺寸，参照[包含块](/zh-CN/docs/Web/CSS/Containing_block)的行向尺寸（即横排语言中的*宽度*，由 {{CSSXref("writing-mode")}} 所定义）。必须非负。
+  - : 以百分比指定的内边距尺寸，参照[包含区块](/zh-CN/docs/Web/CSS/Containing_block)的行向尺寸（即横向语言中的*宽度*，由 {{CSSXref("writing-mode")}} 所定义）。必须非负。
 
 ## 描述
 


### PR DESCRIPTION
### Description

此合并请求：

  1. 将“包含块”更新为“包含区块”；
  2. 将“横排语言”修正为“横向语言”；
  3. 修正了数据类型的译法；
  4. 与 en-US 版同步（见 https://github.com/mdn/content/pull/25980 ）。

### Motivation

### Additional details

### Related issues and pull requests