### PR TITLE
fix(zh-cn): update HTMLTemplateElement.content translation

### DIFF
--- a/files/zh-cn/web/api/htmltemplateelement/content/index.md
+++ b/files/zh-cn/web/api/htmltemplateelement/content/index.md
@@ -5,7 +5,7 @@ slug: Web/API/HTMLTemplateElement/content
 
 {{APIRef("Web Components")}}
 
-The **`HTMLTemplateElement.content`** 属性返回`<template>`元素的模板内容 (一个 {{domxref("DocumentFragment")}}).
+**`HTMLTemplateElement.content`** 属性返回 `<template>` 元素的模板内容 (一个 {{domxref("DocumentFragment")}})。
 
 ## 语法
 

--- a/files/zh-cn/web/api/htmltemplateelement/content/index.md
+++ b/files/zh-cn/web/api/htmltemplateelement/content/index.md
@@ -5,7 +5,7 @@ slug: Web/API/HTMLTemplateElement/content
 
 {{APIRef("Web Components")}}
 
-**`HTMLTemplateElement.content`** 属性返回 `<template>` 元素的模板内容 (一个 {{domxref("DocumentFragment")}})。
+**`HTMLTemplateElement.content`** 属性返回 `<template>` 元素的模板内容（一个 {{domxref("DocumentFragment")}}）。
 
 ## 语法
 

--- a/files/zh-cn/web/api/htmltemplateelement/content/index.md
+++ b/files/zh-cn/web/api/htmltemplateelement/content/index.md
@@ -5,7 +5,7 @@ slug: Web/API/HTMLTemplateElement/content
 
 {{APIRef("Web Components")}}
 
-The **`HTMLTemplateElement.content`**属性返回`<template>`元素的模板内容 (一个 {{domxref("DocumentFragment")}}).
+The **`HTMLTemplateElement.content`** 属性返回`<template>`元素的模板内容 (一个 {{domxref("DocumentFragment")}}).
 
 ## 语法
 


### PR DESCRIPTION
### Description

add whitespace after bold text
(which would cause render bug that would cause symbol * show directly instead of render to bold text)

### Motivation

help render correctly

### Additional details

None

### Related issues and pull requests

None
