### PR TITLE
[zh-cn] fix typo

### DIFF
--- a/files/zh-cn/learn/getting_started_with_the_web/javascript_basics/index.md
+++ b/files/zh-cn/learn/getting_started_with_the_web/javascript_basics/index.md
@@ -121,7 +121,7 @@ myVariable = '韩梅梅';
     <tr>
       <th scope="row">{{Glossary("String")}}</th>
       <td>
-        字符串（一串文本）：字符串的值必须用引号（单双均可，必须成对）扩起来。
+        字符串（一串文本）：字符串的值必须用引号（单双均可，必须成对）括起来。
       </td>
       <td><code>let myVariable = '李雷';</code></td>
     </tr>


### PR DESCRIPTION
### Description
修正一个错别字
- 原文中的“引号扩起来”，我觉得“扩”字改为“括”字更好
- 和引号一样的汉语符号括号也很常用，用括号括起来也是一个较为常用的说法
- 在新华字典中“括”字（“括”字在新华字典中说有“扎”，“束”的意思）比“扩”（“扩”字在新华字典中有“推广”，“伸张”，“放大”，“张大”的意思）更适合表达引号和字符串的关系