### PR TITLE
Suppression de chaines de charactère dans les macros

### DIFF
--- a/files/fr/web/html/element/summary/index.md
+++ b/files/fr/web/html/element/summary/index.md
@@ -53,7 +53,7 @@ Voir la section ci-après sur la compatibilité des navigateurs à ce sujet car 
 
 #### Résultat
 
-{{EmbedLiveSample("Exemple_simple","100%","160")}}
+{{EmbedLiveSample("","100%","160")}}
 
 ### Utilisation de titres
 
@@ -74,7 +74,7 @@ Il est possible d'utiliser des titres au sein d'un résumé.
 
 #### Résultat
 
-{{EmbedLiveSample("Utilisation_de_titres", 650, 120)}}
+{{EmbedLiveSample("", 650, 120)}}
 
 ### Utiliser avec divers éléments HTML
 
@@ -93,7 +93,7 @@ Il est possible d'utiliser des titres au sein d'un résumé.
 
 #### Résultat
 
-{{EmbedLiveSample("Utiliser_avec_divers_éléments_HTML", 650, 120)}}
+{{EmbedLiveSample("", 650, 120)}}
 
 ## Résumé technique
 

--- a/files/fr/web/html/element/sup/index.md
+++ b/files/fr/web/html/element/sup/index.md
@@ -62,7 +62,7 @@ Voici quelques cas d'utilisation (non exhaustifs) pour `<sup>` :
 
 #### Résultat
 
-{{EmbedLiveSample("Puissance_mathématique","100%","120")}}
+{{EmbedLiveSample("","100%","120")}}
 
 ### Lettres supérieures
 
@@ -78,7 +78,7 @@ Bien que, techniquement, le lettrage supérieur ne corresponde pas à la mise en
 
 #### Résultat
 
-{{EmbedLiveSample("Lettres_supérieures","650","80")}}
+{{EmbedLiveSample("","650","80")}}
 
 ### Nombres ordinaux
 
@@ -97,7 +97,7 @@ Bien que, techniquement, le lettrage supérieur ne corresponde pas à la mise en
 
 #### Résultat
 
-{{EmbedLiveSample("Nombres_ordinaux", 650, 160)}}
+{{EmbedLiveSample("", 650, 160)}}
 
 ## Résumé technique
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Il faut passer une chaine vide aux macros *Live Sample*, mais dans beaucoup entre elles le titre de la section est utilisé. Quelques chaines sont supprimées.    

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
