### PR TITLE
Translated to Spanish the page about Range HTTP header

### DIFF
--- a/files/es/web/http/headers/range/index.md
+++ b/files/es/web/http/headers/range/index.md
@@ -1,17 +1,18 @@
 ---
 title: Range
 slug: Web/HTTP/Headers/Range
-page-type: htttp-header
+l10n:
+  sourceCommit: 0880a90f3811475d78bc4b2c344eb4146f25f66c
 ---
 
 {{HTTPSidebar}}
 
-La cabezera de petición HTTP ,**`Range`**, indica qué parte de un documento debe devolver el servido. Varias partes pueden ser solicitadas con una sola cabezera de **`Rango`** a la vez, y el servidor puede enviar estas partes en un documento multipartes. Si el servidor devuelve rangos, utiliza {{HTTPStatus("206", "206 Contenido Parcial")}}. Si los rangos son inválidos, el servidor devuelve el error {{HTTPStatus("416", "416 No se puede satisfacer Rango")}}. El servidor también puede ignorar el encabezado de Rango y devolver el documento completo con un código de estado {{HTTPStatus("200")}}.
+La cabecera de petición HTTP, **`Range`**, indica qué parte de un documento debe devolver el servidor. Varias partes pueden ser solicitadas con una sola cabecera `Range` a la vez, y el servidor puede enviar estas partes en un documento multipartes. Si el servidor devuelve rangos, utiliza {{HTTPStatus("206", "206 Contenido Parcial")}}. Si los rangos son inválidos, el servidor devuelve el error {{HTTPStatus("416", "416 No se puede satisfacer Range")}}. El servidor también puede ignorar el encabezado de Rango y devolver el documento completo con un código de estado {{HTTPStatus("200")}}.
 
 <table class="properties">
   <tbody>
     <tr>
-      <th scope="row">Header type</th>
+      <th scope="row">Tipo de cabecera</th>
       <td>{{Glossary("Request header", "Encabezado de petición")}}</td>
     </tr>
     <tr>
@@ -44,7 +45,7 @@ Range: <unit>=-<suffix-length>
 
 ## Ejemplos
 
-Solicitando tres tanges de un archivo.
+Solicitando tres rangos de un archivo.
 
 ```http
 Range: bytes=200-1000, 2000-6576, 19000-
@@ -52,7 +53,7 @@ Range: bytes=200-1000, 2000-6576, 19000-
 
 El valor, `19000-`, del tercer rango especificado, indica que `19000` es la primera posición y omite la última posición `-`, para recuperar todos los bytes desde 19000 hasta el final del archivo.
 
-Solicitar los primeros y último 500 bytes de un archivo. La petición puede ser rechazada por el servidor si el rango sobrepasa la cantidad de bytes del archivo.
+Solicitar los primeros y últimos 500 bytes de un archivo. La petición puede ser rechazada por el servidor si los rangos se superponen.
 
 ```http
 Range: bytes=0-499, -500
@@ -61,6 +62,10 @@ Range: bytes=0-499, -500
 ## Especificaciones
 
 {{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
 
 ## Véase también
 

--- a/files/es/web/http/headers/range/index.md
+++ b/files/es/web/http/headers/range/index.md
@@ -1,0 +1,71 @@
+---
+title: Range
+slug: Web/HTTP/Headers/Range
+page-type: htttp-header
+---
+
+{{HTTPSidebar}}
+
+La cabezera de petición HTTP ,**`Range`**, indica qué parte de un documento debe devolver el servido. Varias partes pueden ser solicitadas con una sola cabezera de **`Rango`** a la vez, y el servidor puede enviar estas partes en un documento multipartes. Si el servidor devuelve rangos, utiliza {{HTTPStatus("206", "206 Contenido Parcial")}}. Si los rangos son inválidos, el servidor devuelve el error {{HTTPStatus("416", "416 No se puede satisfacer Rango")}}. El servidor también puede ignorar el encabezado de Rango y devolver el documento completo con un código de estado {{HTTPStatus("200")}}.
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Header type</th>
+      <td>{{Glossary("Request header", "Encabezado de petición")}}</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Forbidden header name", "Nombre de header prohibido")}}</th>
+      <td>no</td>
+    </tr>
+  </tbody>
+</table>
+
+## Sintáxis
+
+```http
+Range: <unit>=<range-start>-
+Range: <unit>=<range-start>-<range-end>
+Range: <unit>=<range-start>-<range-end>, <range-start>-<range-end>
+Range: <unit>=<range-start>-<range-end>, <range-start>-<range-end>, <range-start>-<range-end>
+Range: <unit>=-<suffix-length>
+```
+
+## Directivas
+
+- \<unit>
+  - : La unidad en la cual los rangos son especificados. Usualmente son `bytes`.
+- \<range-start>
+  - : Un número entero correspondiente a las unidades especificadas, indicando el principio del rango requerido.
+- \<range-end>
+  - : Un número entero correspondiente a las unidades especificadas, indicando el final del range requerido. Este valor es opcional, si es omitido el final del documento es considerando como el final del rango.
+- \<suffix-length>
+  - : Un número entero correspondiente a las unidades especificadas indicando el número de unidades al final del archivo devuelto.
+
+## Ejemplos
+
+Solicitando tres tanges de un archivo.
+
+```http
+Range: bytes=200-1000, 2000-6576, 19000-
+```
+
+El valor, `19000-`, del tercer rango especificado, indica que `19000` es la primera posición y omite la última posición `-`, para recuperar todos los bytes desde 19000 hasta el final del archivo.
+
+Solicitar los primeros y último 500 bytes de un archivo. La petición puede ser rechazada por el servidor si el rango sobrepasa la cantidad de bytes del archivo.
+
+```http
+Range: bytes=0-499, -500
+```
+
+## Especificaciones
+
+{{Specifications}}
+
+## Véase también
+
+- {{HTTPHeader("If-Range")}}
+- {{HTTPHeader("Content-Range")}}
+- {{HTTPHeader("Content-Type")}}
+- {{HTTPStatus("206", "206 Partial Content")}}
+- {{HTTPStatus("416", "416 Range Not Satisfiable")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Translated to Spanish the page about Range HTTP header

### Motivation

Some of my students doesn't understand English and needed badly this information

### Additional details

There are no additional details

### Related issues and pull requests

No related issues
