### PR TITLE
[ko] short-title 메타 데이터 필수 항목 추가

### DIFF
--- a/docs/ko/guides/glossary-guide.md
+++ b/docs/ko/guides/glossary-guide.md
@@ -35,6 +35,7 @@
 
 | 용어 | 번역 | 참고 링크 |
 | --- | --- | --- |
+| Access | 접근 | |
 | Accessibility concerns | 접근성 고려사항 | |
 | Advantages | 장점 | [링크][Introduction_to_HTML5_Game_Development] |
 | Aliasing | 별칭 | [링크](https://github.com/mdn/translated-content/pull/1779/files) |

--- a/docs/ko/guides/meta-data-guide.md
+++ b/docs/ko/guides/meta-data-guide.md
@@ -44,7 +44,7 @@ l10n:
 <summary>참고 문서</summary>
 
 - 2023.05.01: `original_slug` 필수 항목에서 제거 ([링크](https://github.com/mdn/translated-content/issues/7412#issuecomment-1518546547))
-- 2023.05.01: `short-title` 필수 항목 추가 ([링크](https://github.com/mdn/yari/issues/8647#issuecomment-1520722736))
+- 2023.05.01: `short-title` 필수 항목에 추가 ([링크](https://github.com/mdn/yari/issues/8647#issuecomment-1520722736))
 </details>
 
 ## 문서 갱신 표시

--- a/docs/ko/guides/meta-data-guide.md
+++ b/docs/ko/guides/meta-data-guide.md
@@ -2,7 +2,7 @@
 
 ## 메타데이터 사용
 
-문서의 상단에 있는 메타데이터는 `title`, `slug`, `original_slug` 그리고 `l10n.*`만 사용합니다. (참고: [#7412](https://github.com/mdn/translated-content/issues/7412))
+문서의 상단에 있는 메타데이터는 `title`, `short-title`, `slug` 그리고 `l10n.*`만 사용합니다. (참고: [#7412](https://github.com/mdn/translated-content/issues/7412))
 
 영어 원문
 
@@ -39,6 +39,13 @@ l10n:
 **`Proxy`** 객체는 기본적인 동작(속성 접근, 할당, 순회, 열거, 함수 ...
   :
 ```
+
+<details>
+<summary>참고 문서</summary>
+
+- 2023.05.01: `original_slug` 필수 항목에서 제거 ([링크](https://github.com/mdn/translated-content/issues/7412#issuecomment-1518546547))
+- 2023.05.01: `short-title` 필수 항목 추가 ([링크](https://github.com/mdn/yari/issues/8647#issuecomment-1520722736))
+</details>
 
 ## 문서 갱신 표시
 


### PR DESCRIPTION
### Description

- `original_slug` 필수 항목에서 제거 ([링크](https://github.com/mdn/translated-content/issues/7412#issuecomment-1518546547))
- `short-title` 필수 항목 추가 ([링크](https://github.com/mdn/yari/issues/8647#issuecomment-1520722736))
-  `access` glossary guide 추가

@mdn/yari-content-ko `short-title` 이 필수 메타데이터 항목에 추가되었습니다. 추후 리뷰시 참고 부탁드립니다. (cc. @alattalatta 님)

### Related issues and pull requests

- https://github.com/mdn/translated-content/issues/7412
- https://github.com/mdn/yari/issues/8647
