### PR TITLE
[fr] Fixed link to the 'content' meta attribute

### DIFF
--- a/files/fr/web/html/element/meta/name/theme-color/index.md
+++ b/files/fr/web/html/element/meta/name/theme-color/index.md
@@ -7,7 +7,7 @@ browser-compat: html.elements.meta.name.theme-color
 
 {{HTMLSidebar}}
 
-La valeur de **`theme-color`** comme attribut [`name`](/fr/docs/Web/HTML/Element/meta#attr-name) de l'élément [`<meta>`](/fr/docs/Web/HTML/Element/meta), indique une suggestion de couleur que les agents utilisateur devraient utiliser pour personnaliser l'affichage de la page ou l'interface utilisateur environnante. Si elle est utilisée, l'attribut [`content`](http://localhost:5042/fr/docs/Web/HTML/Element/meta#attr-content) devra avoir une valeur CSS de type [`<color>`](/fr/docs/Web/CSS/color_value).
+La valeur de **`theme-color`** comme attribut [`name`](/fr/docs/Web/HTML/Element/meta#attr-name) de l'élément [`<meta>`](/fr/docs/Web/HTML/Element/meta), indique une suggestion de couleur que les agents utilisateur devraient utiliser pour personnaliser l'affichage de la page ou l'interface utilisateur environnante. Si elle est utilisée, l'attribut [`content`](/fr/docs/Web/HTML/Element/meta#attr-content) devra avoir une valeur CSS de type [`<color>`](/fr/docs/Web/CSS/color_value).
 
 ## Exemple
 


### PR DESCRIPTION
### Description

Le lien vers l'attribute méta `content` était mort car il menait vers l'adresse absolue `http://localhost:5042/fr/docs/Web/HTML/Element/meta#attr-content` : elle est ici remplacée par l'adresse correcte et relative `/fr/docs/Web/HTML/Element/meta#attr-content`.

*The link to the `content` meta attribute was broken (it pointed to the absolute URL `http://localhost:5042/fr/docs/Web/HTML/Element/meta#attr-content`): it is replaced by the correct, relative URL (`/fr/docs/Web/HTML/Element/meta#attr-content`).*

### Motivation

Sur la version française de la [page de documentation sur `theme-color`](https://developer.mozilla.org/fr/docs/Web/HTML/Element/meta/name/theme-color), le lien vers l'attribut méta `content` est affiché comme étant un lien externe ; ce lien pointe vers une adresse absolue commençant par `http://localhost:5042/`. Cliquer sur le lien affiche une erreur indiquant que la page recherchée n'est pas disponible.

*In the French translation of the [`theme-color` documentation page](https://developer.mozilla.org/fr/docs/Web/HTML/Element/meta/name/theme-color), the link to the `content` meta attribute is displayed as an external link and points to an absolute URL starting with `http://localhost:5042/`. Navigating to the link will lead to an error, as the requested page isn't accessible.*

### Détails additionnels / *Additional details*
Aucun / *None*

### Problèmes et pull requests liés / *Related issues and pull requests*
Aucun dont je suis actuellement au courant

*None I'm currently aware of*