### PR TITLE
chore(zh-cn): link cleanup for github repo links

### DIFF
--- a/files/zh-cn/learn/accessibility/multimedia/index.md
+++ b/files/zh-cn/learn/accessibility/multimedia/index.md
@@ -218,7 +218,7 @@ player.ontimeupdate = () => {
 - [Video player styling basics](/zh-CN/docs/Web/Apps/Fundamentals/Audio_and_video_delivery/Video_player_styling_basics)
 - [Creating a cross-browser video player](/zh-CN/docs/Web/Apps/Fundamentals/Audio_and_video_delivery/cross_browser_video_player)
 
-我们还创建了一个高级示例，以演示如何创建面向对象的系统，该系统可查找页面上的每个视频和音频播放器 (无论有多少个视频和音频播放器),并将自定义控件添加到其中。请参阅[custom-controls-oojs](http://mdn.github.io/learning-area/accessibility/multimedia/custom-controls-OOJS/)([see the source code](https://github.com/mdn/learning-area/tree/master/accessibility/multimedia/custom-controls-OOJS))。
+我们还创建了一个高级示例，以演示如何创建面向对象的系统，该系统可查找页面上的每个视频和音频播放器 (无论有多少个视频和音频播放器),并将自定义控件添加到其中。请参阅 [custom-controls-oojs](http://mdn.github.io/learning-area/accessibility/multimedia/custom-controls-OOJS/)（[查看其源码](https://github.com/mdn/learning-area/tree/main/accessibility/multimedia/custom-controls-OOJS)）。
 
 ## 音频脚本
 
@@ -238,7 +238,7 @@ player.ontimeupdate = () => {
 
 如果使用自动服务，则可能需要使用该工具提供的用户界面。例如，查看[Audio Transcription Sample 1](https://www.youtube.com/watch?v=zFFBsj97Od8)并选择" _More > Transcript_"。
 
-如果要创建自己的用户界面来显示音频和相关脚本，您可以随心所欲地执行此操作，但将其包含在可显示/可隐藏面板中可能有意义;请参阅我们的[audio-transcript-ui](http://mdn.github.io/learning-area/accessibility/multimedia/audio-transcript-ui/) 示例 (另请参阅[source code](https://github.com/mdn/learning-area/tree/master/accessibility/multimedia/audio-transcript-ui))。
+如果要创建自己的用户界面来显示音频和相关脚本，您可以随心所欲地执行此操作，但将其包含在可显示/可隐藏面板中可能有意义;请参阅我们的[audio-transcript-ui](http://mdn.github.io/learning-area/accessibility/multimedia/audio-transcript-ui/) 示例（另请参阅[其源码](https://github.com/mdn/learning-area/tree/main/accessibility/multimedia/audio-transcript-ui)）。
 
 ### 音频描述
 

--- a/files/zh-cn/learn/accessibility/wai-aria_basics/index.md
+++ b/files/zh-cn/learn/accessibility/wai-aria_basics/index.md
@@ -112,7 +112,7 @@ slug: Learn/Accessibility/WAI-ARIA_basics
 
 ### 路牌/地标（**Signposts/Landmarks**）
 
-WAI-ARIA 给浏览器增加了 [`role`](https://www.w3.org/TR/wai-aria-1.1/#role_definitions) 属性，这允许我们给站点中的元素增加我们想要的语义属性。第一个主要区域便是用于为屏幕阅读器提供信息，以便用户可以找到常见的页面元素。我们来举个例子，一个[没有角色的站点](https://github.com/mdn/learning-area/tree/master/accessibility/aria/website-no-roles)的例子（[在线 demo](http://mdn.github.io/learning-area/accessibility/aria/website-no-roles/)）的页面结构：
+WAI-ARIA 给浏览器增加了 [`role`](https://www.w3.org/TR/wai-aria-1.1/#role_definitions) 属性，这允许我们给站点中的元素增加我们想要的语义属性。第一个主要区域便是用于为屏幕阅读器提供信息，以便用户可以找到常见的页面元素。我们来举个例子，一个[没有角色的站点](https://github.com/mdn/learning-area/tree/main/accessibility/aria/website-no-roles)的例子（[在线演示](http://mdn.github.io/learning-area/accessibility/aria/website-no-roles/)）的页面结构：
 
 ```html
 <header>

--- a/files/zh-cn/learn/css/building_blocks/backgrounds_and_borders/index.md
+++ b/files/zh-cn/learn/css/building_blocks/backgrounds_and_borders/index.md
@@ -190,7 +190,7 @@ background-position: 10px 20px,  top right;
 - `fixed`: 使元素的背景固定在视图端口上，这样当页面或元素内容滚动时，它就不会滚动。它将始终保持在屏幕上相同的位置。
 - `local`: 这个值是后来添加的 (它只在 Internet Explorer 9+中受支持，而其他的在 IE4+中受支持)，因为滚动值相当混乱，在很多情况下并不能真正实现您想要的功能。局部值将背景固定在设置的元素上，因此当您滚动元素时，背景也随之滚动。
 
-{{cssxref("background-attachment")}} 属性只有在有内容要滚动时才会有效果，所以我们做了一个示例来演示这三个值之间的区别——看看 [background-attachment.html](http://mdn.github.io/learning-area/css/styling-boxes/backgrounds/background-attachment.html) (或者看看这儿的 [源代码](https://github.com/mdn/learning-area/tree/master/css/styling-boxes/backgrounds)))。
+{{cssxref("background-attachment")}} 属性只有在有内容要滚动时才会有效果，所以我们做了一个示例来演示这三个值之间的区别——看看 [background-attachment.html](http://mdn.github.io/learning-area/css/styling-boxes/backgrounds/background-attachment.html)（或者看看这儿的[源代码](https://github.com/mdn/learning-area/tree/main/css/styling-boxes/backgrounds)）。
 
 ### 使用 background 的简写
 

--- a/files/zh-cn/learn/forms/styling_web_forms/index.md
+++ b/files/zh-cn/learn/forms/styling_web_forms/index.md
@@ -378,7 +378,7 @@ button:focus {
 
 瞧！
 
-> **备注：** 如果你的例子没有像你预期的那样工作，你想将它同我们的版本检查对比，你可以在 Github 上找到它 —— 查看 [在线演示](https://mdn.github.io/learning-area/html/forms/postcard-example/) (也可以查看[源代码](https://github.com/mdn/learning-area/tree/master/html/forms/postcard-example))。
+> **备注：** 如果你的例子没有像你预期的那样工作，你想将它同我们的版本检查对比，你可以在 Github 上找到它 —— 查看[在线演示](https://mdn.github.io/learning-area/html/forms/postcard-example/)（也可以查看[源代码](https://github.com/mdn/learning-area/tree/main/html/forms/postcard-example)）。
 
 ## 总结
 

--- a/files/zh-cn/learn/html/multimedia_and_embedding/video_and_audio_content/index.md
+++ b/files/zh-cn/learn/html/multimedia_and_embedding/video_and_audio_content/index.md
@@ -41,7 +41,7 @@ web 开发者们一直以来想在 Web 中使用音频和视频，自 21 世纪�
 
 传统的解决方案能够解决许多这样的问题，前提是它能够正确的工作。幸运的是，几年之后 {{glossary("HTML5")}} 标准提出，其中有许多的新特性，包括 {{htmlelement("video")}} 和 {{htmlelement("audio")}} 标签，以及一些 {{Glossary("JavaScript")}} 和 {{Glossary("API","APIs")}} 用于对其进行控制。在这里，我们不讨论有关 JavaScript 的问题，仅仅讲解有关 HTML 的基础。
 
-我们不会教你如何制作音频和视频，因为那需要完全不同的技术。我们已经为你的试验提供了一些视频和音频的文件（ [sample audio and video files and example code](https://github.com/mdn/learning-area/tree/master/html/multimedia-and-embedding/video-and-audio-content) ），以防止你自己没有。
+我们不会教你如何制作音频和视频，因为那需要完全不同的技术。我们已经为你的试验提供了一些视频和音频的文件（[示例音频和视频文件以及示例代码的链接](https://github.com/mdn/learning-area/tree/main/html/multimedia-and-embedding/video-and-audio-content)），以防止你自己没有。
 
 > **备注：** 在你开始之前，你应当了解一些 {{glossary("OVP","OVPs")}} (在线视频提供商) 例如 [YouTube](https://www.youtube.com/) 、[Dailymotion](http://www.dailymotion.com) 、[Vimeo](https://vimeo.com/)、[Bilibili](https://www.bilibili.com)等，以及在线音频提供商例如 [Soundcloud](https://soundcloud.com/)。这些公司提供方便、简单的方式来支持视频，所以你不必担心庞大的带宽消耗。OVPS 甚至提供现成的代码用于为你的 web 网页嵌入视频/音频。如果你使用这样的服务，你便可以避免在这篇文章中我们将讨论的一些难题。在下一篇文章中，我们将会再讨论这样的服务。
 
@@ -275,7 +275,7 @@ WEBVTT
 
 在这个实践学习当中，我们希望你能够走出去，并且记录一些你自己的视频或者音频 — 如今，大多数手机都能够非常方便的记录视频或者音频，并且你可以将他们上传到你的电脑上面，你可以使用这些功能来记录你的视频或音频。在这时候，你可能需要做一些格式转换，如果是视频的话，你需要将它们转化为 WebM 或者 MP4，如果是音频的话，你需要将它们转化为 MP3 或者 Ogg。不过你并不需要担心，有许多的程序都能够帮你解决这些问题，例如 [Miro Video Converter](http://www.mirovideoconverter.com/) 和 [Audacity](https://sourceforge.net/projects/audacity/)。我们非常希望你能够亲自动手实现它。
 
-如果你无法取得任意的音频或者视频，你可以使用我们已经为你提供的样本（[sample audio and video files](https://github.com/mdn/learning-area/tree/master/html/multimedia-and-embedding/video-and-audio-content)）。同时你也可以使用我们的代码来作为参考。
+如果你无法取得任意的音频或者视频，你可以使用我们已经为你提供的样本（[示例音频和视频文件](https://github.com/mdn/learning-area/tree/main/html/multimedia-and-embedding/video-and-audio-content)）。同时你也可以使用我们的代码来作为参考。
 
 我们希望你能够：
 

--- a/files/zh-cn/learn/html/multimedia_and_embedding/video_and_audio_content/test_your_skills_colon__multimedia_and_embedding/index.md
+++ b/files/zh-cn/learn/html/multimedia_and_embedding/video_and_audio_content/test_your_skills_colon__multimedia_and_embedding/index.md
@@ -24,7 +24,7 @@ Try updating the live code below to recreate the finished example:
 
 {{EmbedGHLiveSample("learning-area/html/multimedia-and-embedding/tasks/media-embed/mediaembed1.html", '100%', 700)}}
 
-> **备注：** [Download the starting point for this task](https://github.com/mdn/learning-area/tree/master/html/multimedia-and-embedding/tasks/media-embed/mediaembed1-download.html) to work in your own editor or in an online editor.
+> **备注：** [Download the starting point for this task](https://github.com/mdn/learning-area/tree/main/html/multimedia-and-embedding/tasks/media-embed/mediaembed1-download.html) to work in your own editor or in an online editor.
 
 ## Multimedia and embedding 2
 
@@ -42,7 +42,7 @@ Try updating the live code below to recreate the finished example:
 
 {{EmbedGHLiveSample("learning-area/html/multimedia-and-embedding/tasks/media-embed/mediaembed2.html", '100%', 700)}}
 
-> **备注：** [Download the starting point for this task](https://github.com/mdn/learning-area/tree/master/html/multimedia-and-embedding/tasks/media-embed/mediaembed2-download.html) to work in your own editor or in an online editor.
+> **备注：** [Download the starting point for this task](https://github.com/mdn/learning-area/tree/main/html/multimedia-and-embedding/tasks/media-embed/mediaembed2-download.html) to work in your own editor or in an online editor.
 
 ## Multimedia and embedding 3
 
@@ -55,7 +55,7 @@ Try updating the live code below to recreate the finished example:
 
 {{EmbedGHLiveSample("learning-area/html/multimedia-and-embedding/tasks/media-embed/mediaembed3.html", '100%', 700)}}
 
-> **备注：** [Download the starting point for this task](https://github.com/mdn/learning-area/tree/master/html/multimedia-and-embedding/tasks/media-embed/mediaembed3-download.html) to work in your own editor or in an online editor.
+> **备注：** [Download the starting point for this task](https://github.com/mdn/learning-area/tree/main/html/multimedia-and-embedding/tasks/media-embed/mediaembed3-download.html) to work in your own editor or in an online editor.
 
 ## Assessment or further help
 

--- a/files/zh-cn/learn/javascript/building_blocks/functions/index.md
+++ b/files/zh-cn/learn/javascript/building_blocks/functions/index.md
@@ -276,7 +276,7 @@ function greeting() {
 
 这两个函数都使用 `greeting()` 形式调用，但是你只能访问到 first.js 文件的`greeting()`函数（第二个文件被忽视了）。另外，第二次尝试使用 `let` 关键字定义 `name` 变量导致了一个错误。
 
-> **备注：** 您可以参考这个例子 [running live on GitHub](http://mdn.github.io/learning-area/javascript/building-blocks/functions/conflict.html) (查看完整 [源代码](https://github.com/mdn/learning-area/tree/master/javascript/building-blocks/functions)).
+> **备注：** 你可以[在 GitHub 上参考运行的实例](http://mdn.github.io/learning-area/javascript/building-blocks/functions/conflict.html) (查看完整[源代码](https://github.com/mdn/learning-area/tree/main/javascript/building-blocks/functions)）。
 
 将代码锁定在函数中的部分避免了这样的问题，并被认为是最佳实践。
 

--- a/files/zh-cn/learn/javascript/client-side_web_apis/client-side_storage/index.md
+++ b/files/zh-cn/learn/javascript/client-side_web_apis/client-side_storage/index.md
@@ -538,7 +538,7 @@ function deleteItem(e) {
 
 如上所述，IndexedDB 可用于存储不仅仅是简单的文本字符串。您可以存储任何您想要的东西，包括复杂的对象，如视频或图像 blob。并且它比任何其他类型的数据更难实现。
 
-为了演示如何操作，我们编写了另一个名为[IndexedDB 视频存储的](https://github.com/mdn/learning-area/tree/master/javascript/apis/client-side-storage/indexeddb/video-store)示例（请参阅[此处也可以在此处运行](https://mdn.github.io/learning-area/javascript/apis/client-side-storage/indexeddb/video-store/)）。首次运行示例时，它会从网络下载所有视频，将它们存储在 IndexedDB 数据库中，然后在 UI 内部 [`<video>`](/zh-CN/docs/Web/HTML/Element/video) 元素中显示视频。第二次运行它时，它会在数据库中找到视频并从那里获取它们而不是显示它们 - 这使得后续加载更快，占用空间更少。
+为了演示如何操作，我们编写了另一个名为[IndexedDB 视频存储的](https://github.com/mdn/learning-area/tree/main/javascript/apis/client-side-storage/indexeddb/video-store)示例（请参阅[此处也可以在此处运行](https://mdn.github.io/learning-area/javascript/apis/client-side-storage/indexeddb/video-store/)）。首次运行示例时，它会从网络下载所有视频，将它们存储在 IndexedDB 数据库中，然后在 UI 内部 [`<video>`](/zh-CN/docs/Web/HTML/Element/video) 元素中显示视频。第二次运行它时，它会在数据库中找到视频并从那里获取它们而不是显示它们 - 这使得后续加载更快，占用空间更少。
 
 让我们来看看这个例子中最有趣的部分。我们不会全部看 - 它的很多内容与上一个示例类似，代码注释得很好。
 
@@ -668,7 +668,7 @@ Cache API 是另一种客户端存储机制，略有不同 - 它旨在保存 HTT
 
 让我们看一个例子，让你对这可能是什么样子有所了解。我们已经创建了另一个版本的视频存储示例，我们在上一节中看到了 - 这个功能完全相同，只是它还通过服务工作者将 Cache，CSS 和 JavaScript 保存在 Cache API 中，允许示例脱机运行！
 
-请参阅[IndexedDB 视频存储，其中服务工作者正在运行](https://mdn.github.io/learning-area/javascript/apis/client-side-storage/cache-sw/video-store-offline/)，并且还可以[查看源代码](https://github.com/mdn/learning-area/tree/master/javascript/apis/client-side-storage/cache-sw/video-store-offline)。
+请参阅 [IndexedDB 视频存储，其中 service worker 在运行](https://mdn.github.io/learning-area/javascript/apis/client-side-storage/cache-sw/video-store-offline/)，并且还可以[查看源代码](https://github.com/mdn/learning-area/tree/main/javascript/apis/client-side-storage/cache-sw/video-store-offline)。
 
 #### 注册服务工作者
 

--- a/files/zh-cn/learn/javascript/client-side_web_apis/drawing_graphics/index.md
+++ b/files/zh-cn/learn/javascript/client-side_web_apis/drawing_graphics/index.md
@@ -483,7 +483,7 @@ ctx.fillText('Canvas text', 50, 150);
 
 浏览器自行处理诸如“使动画匀速运行”、“避免在不可见的内容浪费资源”等复杂细节问题。
 
-我们简单回顾一下“弹球”示例（[在线运行](https://mdn.github.io/learning-area/javascript/oojs/bouncing-balls/index-finished.html) 或查看 [源代码](https://github.com/mdn/learning-area/tree/master/javascript/oojs/bouncing-balls)），来探究一下原理。以下是让弹球持续运行的循环代码：
+我们简单回顾一下“弹球”示例（[在线运行](https://mdn.github.io/learning-area/javascript/oojs/bouncing-balls/index-finished.html) 或查看 [源代码](https://github.com/mdn/learning-area/tree/main/javascript/oojs/bouncing-balls)），来探究一下原理。以下是让弹球持续运行的循环代码：
 
 ```js
 function loop() {
@@ -797,9 +797,9 @@ WebGL 基于 [OpenGL](/zh-CN/docs/Glossary/OpenGL) 图形编程语言实现，�
 
 {{EmbedGHLiveSample("learning-area/javascript/apis/drawing-graphics/threejs-cube/index.html", '100%', 500)}}
 
-你可以 [到 Github 下载最终代码](https://github.com/mdn/learning-area/tree/master/javascript/apis/drawing-graphics/threejs-cube)。
+你可以 [到 Github 下载最终代码](https://github.com/mdn/learning-area/tree/main/javascript/apis/drawing-graphics/threejs-cube)。
 
-> **备注：** 在我们的 GitHub repo 还有另一个趣味 3D 魔方示例——[Three.js Video Cube](https://github.com/mdn/learning-area/tree/master/javascript/apis/drawing-graphics/threejs-video-cube)（在线查看）。其中通过 {{domxref("MediaDevices.getUserMedia", "getUserMedia()")}} 来从电脑摄像头获取一段视频，将其投影到魔方上作为纹理。
+> **备注：** 在我们的 GitHub repo 还有另一个趣味 3D 魔方示例——[Three.js Video Cube](https://github.com/mdn/learning-area/tree/main/javascript/apis/drawing-graphics/threejs-video-cube)（在线查看）。其中通过 {{domxref("MediaDevices.getUserMedia", "getUserMedia()")}} 来从电脑摄像头获取一段视频，将其投影到魔方上作为纹理。
 
 ## 小结
 

--- a/files/zh-cn/learn/javascript/client-side_web_apis/third_party_apis/index.md
+++ b/files/zh-cn/learn/javascript/client-side_web_apis/third_party_apis/index.md
@@ -426,7 +426,7 @@ function displayResults(json) {
 
 ![](youtube-example.png)
 
-本文不会对该示例做过多的叙述 — [源码](https://github.com/mdn/learning-area/tree/main/javascript/apis/third-party-apis/youtube) 中有详细的注释。
+本文不会对该示例做过多的叙述，[源码](https://github.com/mdn/learning-area/tree/main/javascript/apis/third-party-apis/youtube)中有详细的注释。
 
 运行源码需要：
 

--- a/files/zh-cn/learn/javascript/client-side_web_apis/third_party_apis/index.md
+++ b/files/zh-cn/learn/javascript/client-side_web_apis/third_party_apis/index.md
@@ -426,7 +426,7 @@ function displayResults(json) {
 
 ![](youtube-example.png)
 
-本文不会对该示例做过多的叙述 — [源码](https://github.com/mdn/learning-area/tree/master/javascript/apis/third-party-apis/youtube) 中有详细的注释。
+本文不会对该示例做过多的叙述 — [源码](https://github.com/mdn/learning-area/tree/main/javascript/apis/third-party-apis/youtube) 中有详细的注释。
 
 运行源码需要：
 

--- a/files/zh-cn/learn/javascript/objects/test_your_skills_colon__object-oriented_javascript/index.md
+++ b/files/zh-cn/learn/javascript/objects/test_your_skills_colon__object-oriented_javascript/index.md
@@ -26,7 +26,7 @@ Try updating the live code below to recreate the finished example:
 
 {{EmbedGHLiveSample("learning-area/javascript/oojs/tasks/oojs/oojs1.html", '100%', 400)}}
 
-> **备注：** [Download the starting point for this task](https://github.com/mdn/learning-area/tree/master/javascript/oojs/tasks/oojs/oojs1-download.html) to work in your own editor or in an online editor.
+> **备注：** [Download the starting point for this task](https://github.com/mdn/learning-area/tree/main/javascript/oojs/tasks/oojs/oojs1-download.html) to work in your own editor or in an online editor.
 
 ## OOJS 2
 
@@ -38,7 +38,7 @@ Try updating the live code below to recreate the finished example:
 
 {{EmbedGHLiveSample("learning-area/javascript/oojs/tasks/oojs/oojs2.html", '100%', 400)}}
 
-> **备注：** [Download the starting point for this task](https://github.com/mdn/learning-area/tree/master/javascript/oojs/tasks/oojs/oojs2-download.html) to work in your own editor or in an online editor.
+> **备注：** [Download the starting point for this task](https://github.com/mdn/learning-area/tree/main/javascript/oojs/tasks/oojs/oojs2-download.html) to work in your own editor or in an online editor.
 
 ## OOJS 3
 
@@ -52,7 +52,7 @@ Try updating the live code below to recreate the finished example:
 
 {{EmbedGHLiveSample("learning-area/javascript/oojs/tasks/oojs/oojs3.html", '100%', 400)}}
 
-> **备注：** [Download the starting point for this task](https://github.com/mdn/learning-area/tree/master/javascript/oojs/tasks/oojs/oojs3-download.html) to work in your own editor or in an online editor.
+> **备注：** [Download the starting point for this task](https://github.com/mdn/learning-area/tree/main/javascript/oojs/tasks/oojs/oojs3-download.html) to work in your own editor or in an online editor.
 
 ## Assessment or further help
 

--- a/files/zh-cn/learn/tools_and_testing/cross_browser_testing/javascript/index.md
+++ b/files/zh-cn/learn/tools_and_testing/cross_browser_testing/javascript/index.md
@@ -435,7 +435,7 @@ if (ua.includes('Firefox')) {
 - Chrome/Opera/Safari 会使用 `webkitObject`
 - Microsoft 会使用 `msObject`
 
-这里有一个例子，取自我们的 [violent-theremin demo](https://mdn.github.io/webaudio-examples/violent-theremin/)（见[源代码](https://github.com/mdn/webaudio-examples/tree/master/violent-theremin)），它使用 [Canvas API](/zh-CN/docs/Web/API/Canvas_API) 和 [Web Audio API](/zh-CN/docs/Web/API/Web_Audio_API) 的组合来创建一个有趣（和嘈杂）的绘画工具：
+这里有一个例子，取自我们的 [violent-theremin demo](https://mdn.github.io/webaudio-examples/violent-theremin/)（见[源代码](https://github.com/mdn/webaudio-examples/tree/main/violent-theremin)），它使用 [Canvas API](/zh-CN/docs/Web/API/Canvas_API) 和 [Web Audio API](/zh-CN/docs/Web/API/Web_Audio_API) 的组合来创建一个有趣（和嘈杂）的绘画工具：
 
 ```js
 const AudioContext = window.AudioContext || window.webkitAudioContext;

--- a/files/zh-cn/mdn/community/learn_forum/index.md
+++ b/files/zh-cn/mdn/community/learn_forum/index.md
@@ -70,11 +70,11 @@ slug: MDN/Community/Learn_forum
    - 众多“测试你的技能”文章中（如 [/zh-CN/docs/Learn/JavaScript/Building_blocks/conditionals#测试你的技能！](/zh-CN/docs/Learn/JavaScript/Building_blocks/conditionals#测试你的技能！)）
    - 在一些模块结束时更深入的评估部分（如 [/zh-CN/docs/Learn/JavaScript/Building_blocks/Image_gallery#评估或进一步帮助](/zh-CN/docs/Learn/JavaScript/Building_blocks/Image_gallery#评估或进一步帮助))
 
-3. 看一眼与学习区相关的 GitHub 仓库（大部分文件都在 <https://github.com/mdn/learning-area/> 中，还有一些文件在 <https://github.com/mdn/css-examples/tree/master/learn> 中）。初学者需要帮助的大部分例子都包含在这里。
+3. 看一眼与学习区相关的 GitHub 仓库（大部分文件都在 <https://github.com/mdn/learning-area/> 中，还有一些文件在 <https://github.com/mdn/css-examples/tree/main/learn> 中）。初学者需要帮助的大部分例子都包含在这里。
 4. 每项评估或测试都有相关的打分指南或推荐解法，可以帮助你评估他们的工作。
 5. 存在更容易找到这些资源的模式，如：
 
-   - 上述“测试你的技能”打分指南和资源可以在 <https://github.com/mdn/learning-area/tree/master/javascript/building-blocks/tasks/conditionals> 中找到。
-   - 上述评估打分指南和资源可以在 <https://github.com/mdn/learning-area/tree/master/javascript/building-blocks/gallery> 中找到。
+   - 上述“测试你的技能”打分指南和资源可以在 <https://github.com/mdn/learning-area/tree/main/javascript/building-blocks/tasks/conditionals> 中找到。
+   - 上述评估打分指南和资源可以在 <https://github.com/mdn/learning-area/tree/main/javascript/building-blocks/gallery> 中找到。
 
 开始时，浏览这些东西似乎很麻烦，但随着你对练习题目的熟悉，你会发现这个过程越来越容易。

--- a/files/zh-cn/mozilla/add-ons/webextensions/add_a_button_to_the_toolbar/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/add_a_button_to_the_toolbar/index.md
@@ -204,14 +204,14 @@ button/
 - [`browserAction`](/zh-CN/docs/Mozilla/Add-ons/WebExtensions/API/browserAction) API
 - Browser action examples:
 
-  - [beastify](https://github.com/mdn/webextensions-examples/tree/master/beastify)
-  - [Bookmark it!](https://github.com/mdn/webextensions-examples/tree/master/bookmark-it)
-  - [favourite-colour](https://github.com/mdn/webextensions-examples/tree/master/favourite-colour)
-  - [inpage-toolbar-ui](https://github.com/mdn/webextensions-examples/tree/master/inpage-toolbar-ui)
-  - [open-my-page-button](https://github.com/mdn/webextensions-examples/tree/master/open-my-page-button)
+  - [beastify](https://github.com/mdn/webextensions-examples/tree/main/beastify)
+  - [Bookmark it!](https://github.com/mdn/webextensions-examples/tree/main/bookmark-it)
+  - [favourite-colour](https://github.com/mdn/webextensions-examples/tree/main/favourite-colour)
+  - [inpage-toolbar-ui](https://github.com/mdn/webextensions-examples/tree/main/inpage-toolbar-ui)
+  - [open-my-page-button](https://github.com/mdn/webextensions-examples/tree/main/open-my-page-button)
 
 - [`page_action`](/zh-CN/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action) manifest key
 - [`pageAction`](/zh-CN/docs/Mozilla/Add-ons/WebExtensions/API/pageAction) API
 - Page action examples:
 
-  - [chill-out](https://github.com/mdn/webextensions-examples/tree/master/chill-out)
+  - [chill-out](https://github.com/mdn/webextensions-examples/tree/main/chill-out)

--- a/files/zh-cn/mozilla/add-ons/webextensions/content_scripts/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/content_scripts/index.md
@@ -224,7 +224,7 @@ function notify(message) {
 }
 ```
 
-这个示范代码从 Github 上的 [notify-link-clicks-i18n](https://github.com/mdn/webextensions-examples/tree/master/notify-link-clicks-i18n) 例子 修改而来。
+这个示范代码从 Github 上的 [notify-link-clicks-i18n](https://github.com/mdn/webextensions-examples/tree/main/notify-link-clicks-i18n) 示例修改而来。
 
 ### Connection-based messaging
 
@@ -293,8 +293,6 @@ browser.browserAction.onClicked.addListener(function() {
   portFromCS.postMessage({greeting: "they clicked the button!"});
 });
 ```
-
-[inpage-toolbar-ui](https://github.com/mdn/webextensions-examples/tree/master/inpage-toolbar-ui) 例子使用了 connection-based messaging.
 
 ## 网页通信
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/examples/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/examples/index.md
@@ -13,7 +13,7 @@ slug: Mozilla/Add-ons/WebExtensions/Examples
 
 1. 克隆代码库，通过 ["临时载入附加组件"](/zh-CN/Add-ons/WebExtensions/Temporary_Installation_in_Firefox) 功能直接从源文件夹中载入扩展组件。再重启浏览器前该扩展将一直存在。
 2. 克隆代码库，使用 [web-ext](/zh-CN/Add-ons/WebExtensions/Getting_started_with_web-ext) 命令行工具运行安装了扩展的 Firefox。
-3. 克隆代码库，进入 [build](https://github.com/mdn/webextensions-examples/tree/master/build) 文件夹。该文件夹包含所有示例的已构建、带签名版本。你可以在 Firefox 中打开（菜单栏->文件->打开文件）并且永久安装这些扩展。这些扩展和直接从 [addons.mozilla.org](https://addons.mozilla.org/en-US/firefox/) 安装的扩展别无二致。
+3. 克隆代码库，进入 [build](https://github.com/mdn/webextensions-examples/tree/main/build) 文件夹。该文件夹包含所有示例的已构建、带签名版本。你可以在 Firefox 中打开（菜单栏->文件->打开文件）并且永久安装这些扩展。这些扩展和直接从 [addons.mozilla.org](https://addons.mozilla.org/en-US/firefox/) 安装的扩展别无二致。
 
 > **警告：** 不要提交这些关于 WebExtension 例子的示例到 AMO (addons.mozilla.org) 上去，你无需为附加组件签名就能运行 WebExtension 的示例。只要按照上面的步骤来就可以了。
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/implement_a_settings_page/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/implement_a_settings_page/index.md
@@ -195,4 +195,4 @@ settings/
 - 使用[`runtime.openOptionsPage()`](/zh-CN/docs/Mozilla/Add-ons/WebExtensions/API/runtime/openOptionsPage) 直接打开你的设置页面
 - 另一个设置页面例子：
 
-  - [favourite-colour](https://github.com/mdn/webextensions-examples/tree/master/favourite-colour)
+  - [favourite-colour](https://github.com/mdn/webextensions-examples/tree/main/favourite-colour)

--- a/files/zh-cn/mozilla/add-ons/webextensions/internationalization/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/internationalization/index.md
@@ -7,7 +7,7 @@ slug: Mozilla/Add-ons/WebExtensions/Internationalization
 
 [WebExtensions](/zh-CN/docs/Mozilla/Add-ons/WebExtensions) API 有一个相当方便的模块可用于附加组件的国际化（[i18n](/zh-CN/docs/Mozilla/Add-ons/WebExtensions/API/i18n)）。我们将在本文中探讨其功能，并为它的运作方式提供一个实例。WebExtensions 的 i18n 系统类似常见的 i18n 用途 JavaScript 库，例如 [i18n.js](http://i18njs.com/)。
 
-> **备注：** 本文中的 WebExtension 实例 [notify-link-clicks-i18n](https://github.com/mdn/webextensions-examples/tree/master/notify-link-clicks-i18n) 可在 GitHub 上查阅。在您阅读下列章节时，可参照它的代码。
+> **备注：** 本文中的 WebExtension 实例 [notify-link-clicks-i18n](https://github.com/mdn/webextensions-examples/tree/main/notify-link-clicks-i18n) 可在 GitHub 上查阅。在阅读下列章节时，可参照它的代码。
 
 ## 剖析一个国际化的 WebExtension
 
@@ -53,7 +53,7 @@ slug: Mozilla/Add-ons/WebExtensions/Internationalization
 
 注意，如果子标签包含一个基本语言和一个区域变种，那么语言与变种之间通常会以连字号隔开，例如 "en-US"。但作为 `_locales` 的子目录，**它必须采用下划线来分隔**，如 "en_US"。
 
-因此[在我们这个示例应用](https://github.com/mdn/webextensions-examples/tree/master/notify-link-clicks-i18n/_locales)中，我们有如下几个目录："en"（英语）、"de"（德语）、"nl"（荷兰语）以及 "ja"（日语）。每个目录都包含一个 `messages.json` 文件。
+因此[在我们这个示例应用](https://github.com/mdn/webextensions-examples/tree/main/notify-link-clicks-i18n/_locales)中，我们有如下几个目录："en"（英语）、"de"（德语）、"nl"（荷兰语）以及 "ja"（日语）。每个目录都包含一个 `messages.json` 文件。
 
 现在我们来看其中一个文件（[\_locales/en/messages.json](https://github.com/mdn/webextensions-examples/blob/master/notify-link-clicks-i18n/_locales/en/messages.json)）的结构：
 
@@ -148,7 +148,7 @@ header {
 - {{WebExtAPIRef("i18n.getAcceptLanguages()")}} 和 {{WebExtAPIRef("i18n.getUILanguage()")}} 这两个方法可以在你需要根据语言区域自定义用户界面时使用 — 或许你希望根据用户想要的语言在首选项列表更高层显示首选项，或只显示和特定语言有关的文化信息，又或是按浏览器语言显示格式化过的日期。
 - {{WebExtAPIRef("i18n.detectLanguage()")}} 这个方法可以用来检测用户提交内容的语言，并将其正确格式化。
 
-在我们的 [notify-link-clicks-i18n](https://github.com/mdn/webextensions-examples/tree/master/notify-link-clicks-i18n) 示例中，[后台脚本](https://github.com/mdn/webextensions-examples/blob/master/notify-link-clicks-i18n/background-script.js)包含下列代码：
+在我们的 [notify-link-clicks-i18n](https://github.com/mdn/webextensions-examples/tree/main/notify-link-clicks-i18n) 示例中，[后台脚本](https://github.com/mdn/webextensions-examples/blob/master/notify-link-clicks-i18n/background-script.js)包含下列代码：
 
 ```js
 var title = browser.i18n.getMessage("notificationTitle");
@@ -378,7 +378,7 @@ padding-left: 1.5em;
 
 ## 测试你的 WebExtension
 
-从 Firefox 45 开始，你可以临时安装磁盘上的 WebExtensions — 另见[从磁盘加载。](/zh-CN/docs/Mozilla/Add-ons/WebExtensions/Packaging_and_installation#loading_from_disk)按上述步骤操作，然后尝试我们的 [notify-link-clicks-i18n](https://github.com/mdn/webextensions-examples/tree/master/notify-link-clicks-i18n) WebExtension。访问你喜欢的任何网站，然后点一下链接，查看是否有通知出现来显示所点击的链接网址。
+从 Firefox 45 开始，你可以临时安装磁盘上的 WebExtensions — 另见[从磁盘加载。](/zh-CN/docs/Mozilla/Add-ons/WebExtensions/Packaging_and_installation#loading_from_disk)按上述步骤操作，然后尝试我们的 [notify-link-clicks-i18n](https://github.com/mdn/webextensions-examples/tree/main/notify-link-clicks-i18n) WebExtension。访问你喜欢的任何网站，然后点一下链接，查看是否有通知出现来显示所点击的链接网址。
 
 接下来，将 Firefox 的语言区域更改为你想测试的扩展支持的某个语言区域。
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/manifest.json/browser_action/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/manifest.json/browser_action/index.md
@@ -76,7 +76,7 @@ slug: Mozilla/Add-ons/WebExtensions/manifest.json/browser_action
         </p>
         <p>
           <a
-            href="https://github.com/mdn/webextensions-examples/tree/master/latest-download"
+            href="https://github.com/mdn/webextensions-examples/tree/main/latest-download"
             >latest-download</a
           >
           中的示例扩展的弹窗使用了 <code>browser_style</code>。

--- a/files/zh-cn/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
@@ -32,7 +32,7 @@ slug: Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources
 
 你有时想将资源（如图片、HTML、CSS 或 JavaScript）与你的扩展应用合并打包，让网页能够访问它们。
 
-举个例子，[Beastify example extension](https://github.com/mdn/webextensions-examples/tree/master/beastify) 将用户选择的野兽图片来替换网页，这些图片与应用是经过合并打包的。该应用添加 [`<img>`](/zh-CN/docs/Web/HTML/Element/img)，其 `src` 指向图片，这样就使选中的图片可见了。网页要载入图片的话，这些图片就必须可经访问。
+举个例子，[Beastify example extension](https://github.com/mdn/webextensions-examples/tree/main/beastify) 将用户选择的野兽图片来替换网页，这些图片与应用是经过合并打包的。该应用添加 [`<img>`](/zh-CN/docs/Web/HTML/Element/img)，其 `src` 指向图片，这样就使选中的图片可见了。网页要载入图片的话，这些图片就必须可经访问。
 
 通过 `web_accessible_resources`，你列出资源，让它们可经网页访问。这些资源路径相对于 manifest.json 文件。
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/modify_a_web_page/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/modify_a_web_page/index.md
@@ -240,12 +240,11 @@ browser.runtime.onMessage.addListener(eatPage);
 - [`runtime.onMessage`](/zh-CN/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage)
 - 使用`content_scripts`的例子：
 
-  - [borderify](https://github.com/mdn/webextensions-examples/tree/master/borderify)
-  - [inpage-toolbar-ui](https://github.com/mdn/webextensions-examples/tree/master/inpage-toolbar-ui)
-  - [notify-link-clicks-i18n](https://github.com/mdn/webextensions-examples/tree/master/notify-link-clicks-i18n)
-  - [page-to-extension-messaging](https://github.com/mdn/webextensions-examples/tree/master/page-to-extension-messaging)
+  - [borderify](https://github.com/mdn/webextensions-examples/tree/main/borderify)
+  - [notify-link-clicks-i18n](https://github.com/mdn/webextensions-examples/tree/main/notify-link-clicks-i18n)
+  - [page-to-extension-messaging](https://github.com/mdn/webextensions-examples/tree/main/page-to-extension-messaging)
 
 - 使用`tabs.executeScript()`的例子：
 
-  - [beastify](https://github.com/mdn/webextensions-examples/tree/master/beastify)
-  - [context-menu-demo](https://github.com/mdn/webextensions-examples/tree/master/context-menu-demo)
+  - [beastify](https://github.com/mdn/webextensions-examples/tree/main/beastify)
+  - [context-menu-copy-link-with-types](https://github.com/mdn/webextensions-examples/tree/main/context-menu-copy-link-with-types)

--- a/files/zh-cn/mozilla/add-ons/webextensions/native_messaging/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/native_messaging/index.md
@@ -20,7 +20,7 @@ extension 必须在 manifest.json 中获得"nativeMessaging" [权限](/zh-CN/doc
 - 在 WebExtensions 中，原生应用的清单中的 "allowed_extensions" 字段是一个由 extension ID 组成的数组，而在 Chrome 中，清单中的 "allowed_origins" 字段是一个由 "chrome-extension" URLs 组成的数组
 - 原生应用清单的存储位置不一样
 
-Github 中的 [webextensions-examples 仓库](https://github.com/mdn/webextensions-examples)有一个[完整的关于 native messaging 的例子](https://github.com/mdn/webextensions-examples/tree/master/native-messaging)，文章中的大部分代码片段均出于此。
+Github 中的 [webextensions-examples 仓库](https://github.com/mdn/webextensions-examples)有一个[完整的关于 native messaging 的例子](https://github.com/mdn/webextensions-examples/tree/main/native-messaging)，文章中的大部分代码片段均出于此。
 
 ## 安装
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/user_interface/browser_action/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/user_interface/browser_action/index.md
@@ -48,5 +48,5 @@ browser.browserAction.onClicked.addListener(handleClick);
 
 在 Github 上的扩展范例库 [webextensions-examples](https://github.com/mdn/webextensions-examples) 中有两个实现浏览器动作的例子：
 
-- [bookmark-it](https://github.com/mdn/webextensions-examples/blob/master/bookmark-it/) uses a browser action without a popup.
-- [beastify](https://github.com/mdn/webextensions-examples/tree/master/beastify) uses a browser action with a popup.
+- [bookmark-it](https://github.com/mdn/webextensions-examples/blob/main/bookmark-it/)没有使用 popup 实现了浏览器动作。
+- [beastify](https://github.com/mdn/webextensions-examples/tree/main/beastify)使用 popup 实现了浏览器动作。

--- a/files/zh-cn/mozilla/add-ons/webextensions/user_interface/context_menu_items/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/user_interface/context_menu_items/index.md
@@ -46,5 +46,5 @@ browser.contextMenus.onClicked.addListener(function(info, tab) {
 
 The [webextensions-examples](https://github.com/mdn/webextensions-examples) repo on GitHub, contains several examples of extensions that use context menu items:
 
-- [menu-demo](https://github.com/mdn/webextensions-examples/tree/master/menu-demo) adds several items to the browser's context menu.
-- [context-menu-copy-link-with-types](https://github.com/mdn/webextensions-examples/tree/master/context-menu-copy-link-with-types) adds a context menu item to links that copies the URL to the clipboard, as plain text and rich HTML.
+- [menu-demo](https://github.com/mdn/webextensions-examples/tree/main/menu-demo) adds several items to the browser's context menu.
+- [context-menu-copy-link-with-types](https://github.com/mdn/webextensions-examples/tree/main/context-menu-copy-link-with-types) adds a context menu item to links that copies the URL to the clipboard, as plain text and rich HTML.

--- a/files/zh-cn/mozilla/add-ons/webextensions/user_interface/notifications/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/user_interface/notifications/index.md
@@ -19,7 +19,7 @@ slug: Mozilla/Add-ons/WebExtensions/user_interface/Notifications
 "permissions": ["notifications"]
 ```
 
-接下来，你可以使用 {{WebExtAPIRef("notifications.create")}} 来创建一个通知，这里有一个来自 [notify-link-clicks-i18n](https://github.com/mdn/webextensions-examples/tree/master/notify-link-clicks-i18n) 的简单示例：
+接下来，你可以使用 {{WebExtAPIRef("notifications.create")}} 来创建一个通知，这里有一个来自 [notify-link-clicks-i18n](https://github.com/mdn/webextensions-examples/tree/main/notify-link-clicks-i18n) 的简单示例：
 
 ```js
 const title = browser.i18n.getMessage("notificationTitle");
@@ -48,4 +48,4 @@ browser.notifications.onClicked.addListener(handleClick);
 
 ## 示例
 
-GitHub 仓库 [webextensions-examples](https://github.com/mdn/webextensions-examples) 中包含了通知的实现示例 [notify-link-clicks-i18n](https://github.com/mdn/webextensions-examples/tree/master/notify-link-clicks-i18n)
+GitHub 仓库 [webextensions-examples](https://github.com/mdn/webextensions-examples) 中包含了通知的实现示例 [notify-link-clicks-i18n](https://github.com/mdn/webextensions-examples/tree/main/notify-link-clicks-i18n)

--- a/files/zh-cn/mozilla/add-ons/webextensions/user_interface/page_actions/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/user_interface/page_actions/index.md
@@ -85,4 +85,4 @@ browser.pageAction.onClicked.addListener(handleClick);
 
 ## 示例
 
-GitHub 上的 [webextensions-examples](https://github.com/mdn/webextensions-examples) 库中包括了实现无 popup 地址栏按钮的例子 [chill-out](https://github.com/mdn/webextensions-examples/tree/master/chill-out) 。
+GitHub 上的 [webextensions-examples](https://github.com/mdn/webextensions-examples) 库中包括了实现无 popup 地址栏按钮的例子 [chill-out](https://github.com/mdn/webextensions-examples/tree/main/chill-out) 。

--- a/files/zh-cn/mozilla/add-ons/webextensions/user_interface/sidebars/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/user_interface/sidebars/index.md
@@ -23,7 +23,7 @@ browser.windows.getCurrent({populate: true}).then((windowInfo) => {
 });
 ```
 
-不同的窗口使用不同的侧边栏是非常有用的，这是一个实例，见["annotate-page" example](https://github.com/mdn/webextensions-examples/tree/master/annotate-page).
+不同的窗口使用不同的侧边栏是非常有用的，这是一个实例，见["annotate-page" example](https://github.com/mdn/webextensions-examples/tree/main/annotate-page).
 
 侧边栏俱有和后台程序以及弹出窗口相同的 API 权限，在非隐藏模式下，侧边栏使用 API {{WebExtAPIRef("runtime.getBackgroundPage()")}} 可以直接访问后台页面，使用 API 如{{WebExtAPIRef("tabs.sendMessage()")}} 与 content scripts 交互，使用 API 如 {{WebExtAPIRef("runtime.sendNativeMessage()")}} 与原生应用交互。
 
@@ -51,6 +51,6 @@ browser.windows.getCurrent({populate: true}).then((windowInfo) => {
 
 For details on how to design your sidebar's web page to match the style of Firefox, see the [Photon Design System](https://design.firefox.com/photon/index.html) documentation.
 
-## Example
+## 示例
 
-The [webextensions-examples](https://github.com/mdn/webextensions-examples) repository on GitHub includes the [annotate-page](https://github.com/mdn/webextensions-examples/tree/master/annotate-page) example which implements a sidebar.
+The [webextensions-examples](https://github.com/mdn/webextensions-examples) repository on GitHub includes the [annotate-page](https://github.com/mdn/webextensions-examples/tree/main/annotate-page) example which implements a sidebar.

--- a/files/zh-cn/mozilla/add-ons/webextensions/working_with_the_tabs_api/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/working_with_the_tabs_api/index.md
@@ -57,7 +57,7 @@ Where you want information about the current tab only, you can get a {{WebExtAPI
 
 ### How to example
 
-To see how {{WebExtAPIRef("tabs.query")}} and {{WebExtAPIRef("tabs.Tab")}} are used, let’s walk through how the [tabs-tabs-tabs](https://github.com/mdn/webextensions-examples/tree/master/tabs-tabs-tabs) example adds the list of "switch to tabs" to its toolbar button popup.
+To see how {{WebExtAPIRef("tabs.query")}} and {{WebExtAPIRef("tabs.Tab")}} are used, let’s walk through how the [tabs-tabs-tabs](https://github.com/mdn/webextensions-examples/tree/main/tabs-tabs-tabs) example adds the list of "switch to tabs" to its toolbar button popup.
 
 ![The tabs tabs tabs toolbar menu showing the switch to tap area](switch_to_tab.png)
 
@@ -270,7 +270,7 @@ The following functions are available:
 
 ### How to example
 
-The [tabs-tabs-tabs](https://github.com/mdn/webextensions-examples/tree/master/tabs-tabs-tabs) example exercises all of these features except for updating a tab's URL The way in which these APIs are used is similar, so we'll look at one of the more involved implementations, that of the "Move active tab to the beginning of the window list" option.
+The [tabs-tabs-tabs](https://github.com/mdn/webextensions-examples/tree/main/tabs-tabs-tabs) example exercises all of these features except for updating a tab's URL The way in which these APIs are used is similar, so we'll look at one of the more involved implementations, that of the "Move active tab to the beginning of the window list" option.
 
 But first, here is a demonstration of the feature in action:
 
@@ -387,17 +387,17 @@ In Firefox the default zoom settings are:
 
 ### How to example
 
-The [tabs-tabs-tabs](https://github.com/mdn/webextensions-examples/tree/master/tabs-tabs-tabs) example includes three demonstrations of the zoom feature: zoom in, zoom out, and reset zoom. Here is the feature in action:
+The [tabs-tabs-tabs](https://github.com/mdn/webextensions-examples/tree/main/tabs-tabs-tabs) example includes three demonstrations of the zoom feature: zoom in, zoom out, and reset zoom. Here is the feature in action:
 
 {{EmbedYouTube("RFr3oYBCg28")}}
 
 Let's take a look at how the zoom in is implemented.
 
-#### [manifest.json](https://github.com/mdn/webextensions-examples/blob/master/tabs-tabs-tabs/manifest.json)
+#### [manifest.json](https://github.com/mdn/webextensions-examples/blob/main/tabs-tabs-tabs/manifest.json)
 
 None of the zoom functions require permissions, so there are no features in the manifest.json file that need to be highlighted.
 
-#### [tabs.html](https://github.com/mdn/webextensions-examples/blob/master/tabs-tabs-tabs/tabs.html)
+#### [tabs.html](https://github.com/mdn/webextensions-examples/blob/main/tabs-tabs-tabs/tabs.html)
 
 We have already discussed how the tabs.html defines the options for this extension, nothing new or unique is done to provide the zoom options.
 
@@ -446,7 +446,7 @@ This can be useful, for example, if you want to highlight certain page elements 
 
 ### How to example
 
-The [apply-css](https://github.com/mdn/webextensions-examples/tree/master/apply-css) example uses these features to add a red border to the web page in the active tab. Here is the feature in action:
+The [apply-css](https://github.com/mdn/webextensions-examples/tree/main/apply-css) example uses these features to add a red border to the web page in the active tab. Here is the feature in action:
 
 {{EmbedYouTube("bcK-GT2Dyhs")}}
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/your_first_webextension/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/your_first_webextension/index.md
@@ -8,7 +8,7 @@ slug: Mozilla/Add-ons/WebExtensions/Your_first_WebExtension
 > **备注：** 如果你熟悉浏览器扩展的基本概念，你可以跳过这一章节，去阅读[如何把扩展文件组合在一起](/zh-CN/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension)。然后，阅读[参考文档](/zh-CN/docs/Mozilla/Add-ons/WebExtensions#reference)以构建你的扩展。访问 [Firefox 扩展工作站](https://extensionworkshop.com/?utm_source=developer.mozilla.org&utm_medium=documentation&utm_campaign=your-first-extension)，了解有关 Firefox 扩展测试、发布等更多信息。
 在这篇文章中，我们将为 Firefox 创建一个扩展。这个扩展只是给从“`mozilla.org`”或其任意子域名加载的任何页面添加一个红色边框。
 
-该示例的源代码位于 GitHub：<https://github.com/mdn/webextensions-examples/tree/master/borderify>
+该示例的源代码位于 GitHub：<https://github.com/mdn/webextensions-examples/tree/main/borderify>
 
 ## 编写扩展
 

--- a/files/zh-cn/mozilla/add-ons/webextensions/your_second_webextension/index.md
+++ b/files/zh-cn/mozilla/add-ons/webextensions/your_second_webextension/index.md
@@ -36,7 +36,7 @@ original_slug: Mozilla/Add-ons/WebExtensions/Walkthrough
 - content scripts 与扩展的其他部分之间的通信
 - 打包你的扩展的资源，使其可被网页所用
 
-你可以在 GitHub 找到[该扩展的完整的源代码](https://github.com/mdn/webextensions-examples/tree/master/beastify)。
+你可以在 GitHub 找到[该扩展的完整的源代码](https://github.com/mdn/webextensions-examples/tree/main/beastify)。
 
 写这个扩展，你需要 45 或更高版本的 firefox。
 
@@ -400,7 +400,7 @@ content script 做的第一件事是检查全局变量 `window.hasRun`：如果�
 
 最后，我们要加入包含动物们的图像。
 
-创建"beasts"文件夹，之后将图片放入并命名。你可以从 [the GitHub repository](https://github.com/mdn/webextensions-examples/tree/master/beastify/beasts),或这里下载图片：
+创建"beasts"文件夹，之后将图片放入并命名。你可以从 [GitHub 仓库](https://github.com/mdn/webextensions-examples/tree/main/beastify/beasts)或这里下载图片：
 
 ![](frog.jpg)![](snake.jpg)![](turtle.jpg)
 

--- a/files/zh-cn/web/api/abortcontroller/abort/index.md
+++ b/files/zh-cn/web/api/abortcontroller/abort/index.md
@@ -59,7 +59,7 @@ function fetchVideo() {
 
 > **备注：** 当 `abort()` 被调用时，`fetch()` promise 将会抛出 `DOMException` 类型的 `Error`（名称为 `AbortError`）。
 
-你可以在 github 上找到[完整的工作示例](https://github.com/mdn/dom-examples/tree/master/abort-api)；你还可以看它的[在线演示](https://mdn.github.io/dom-examples/abort-api/)。
+你可以在 github 上找到[完整的工作示例](https://github.com/mdn/dom-examples/tree/main/abort-api)；你还可以看它的[在线演示](https://mdn.github.io/dom-examples/abort-api/)。
 
 ## 规范
 

--- a/files/zh-cn/web/api/abortcontroller/abortcontroller/index.md
+++ b/files/zh-cn/web/api/abortcontroller/abortcontroller/index.md
@@ -53,7 +53,7 @@ function fetchVideo() {
 
 > **备注：** 当 `abort()` 被调用，`fetch()` promise 将会抛出 `AbortError`。
 
-你可以在 GitHub 上找到一个完整的使用示例——参见 [abort-api](https://github.com/mdn/dom-examples/tree/master/abort-api)（[也可以看在线演示](https://mdn.github.io/dom-examples/abort-api/)）。
+你可以在 GitHub 上找到一个完整的使用示例——参见 [abort-api](https://github.com/mdn/dom-examples/tree/main/abort-api)（[也可以看在线演示](https://mdn.github.io/dom-examples/abort-api/)）。
 
 ## 规范
 

--- a/files/zh-cn/web/api/abortcontroller/index.md
+++ b/files/zh-cn/web/api/abortcontroller/index.md
@@ -65,7 +65,7 @@ function fetchVideo() {
 
 > **备注：** 当 `abort()` 被调用时，这个 `fetch()` promise 将 `reject` 一个名为 `AbortError` 的 `DOMException`。
 
-您可以在 [GitHub](https://github.com/mdn/dom-examples/tree/master/abort-api) 上找到这个示例的完整源代码（也可以[在线运行](https://mdn.github.io/dom-examples/abort-api/)）。
+你可以在 [GitHub](https://github.com/mdn/dom-examples/tree/main/abort-api) 上找到这个示例的完整源代码（也可以[在线运行](https://mdn.github.io/dom-examples/abort-api/)）。
 
 ## 规范
 

--- a/files/zh-cn/web/api/abortcontroller/signal/index.md
+++ b/files/zh-cn/web/api/abortcontroller/signal/index.md
@@ -47,7 +47,7 @@ function fetchVideo() {
 
 > **备注：** 当 `abort()` 被调用，`fetch()` promise 将会抛出一个 `AbortError`.
 
-你可以在 github 上找到[完整的可以运行的示例](https://github.com/mdn/dom-examples/tree/master/abort-api)；你还可以看它的[在线演示](https://mdn.github.io/dom-examples/abort-api/)。
+你可以在 GitHub 上找到[完整的可以运行的示例](https://github.com/mdn/dom-examples/tree/main/abort-api)；你还可以看它的[在线演示](https://mdn.github.io/dom-examples/abort-api/)。
 
 ## 规范
 

--- a/files/zh-cn/web/api/abortsignal/index.md
+++ b/files/zh-cn/web/api/abortsignal/index.md
@@ -75,7 +75,7 @@ function fetchVideo() {
 
 > **备注：** 当调用 `abort()` 时，`fetch()` promise 会以“`AbortError`”`DOMException` 拒绝。
 
-你可以[在 github 上找到一个完整、可运行的示例](https://github.com/mdn/dom-examples/tree/master/abort-api)；你也可以参见[在线演示](https://mdn.github.io/dom-examples/abort-api/)。
+你可以[在 GitHub 上找到一个完整、可运行的示例](https://github.com/mdn/dom-examples/tree/main/abort-api)；你也可以参见[在线演示](https://mdn.github.io/dom-examples/abort-api/)。
 
 ### 中止超时的读取操作
 

--- a/files/zh-cn/web/api/audiobuffer/index.md
+++ b/files/zh-cn/web/api/audiobuffer/index.md
@@ -31,7 +31,7 @@ AudioBuffer 接口表示存在内存里的一段短小的音频资源，利用{{
 
 ## 例子
 
-以下的例子展示了如何构建一个 AudioBuffer 以及随机用白噪音填充。你可以在 [audio-buffer demo](https://github.com/mdn/webaudio-examples/tree/master/audio-buffer)库发现完整的源代码；一个[running live](https://mdn.github.io/webaudio-examples/audio-buffer/) 的版本也可获得。
+以下的例子展示了如何构建一个 AudioBuffer 以及随机用白噪音填充。你可以在 [audio-buffer 演示](https://github.com/mdn/webaudio-examples/tree/main/audio-buffer)库发现完整的源代码；也可以获得一个[实时运行的](https://mdn.github.io/webaudio-examples/audio-buffer/)的版本。
 
 ```js
 // Stereo

--- a/files/zh-cn/web/api/audiocontext/createmediaelementsource/index.md
+++ b/files/zh-cn/web/api/audiocontext/createmediaelementsource/index.md
@@ -29,7 +29,7 @@ var source = audioCtx.createMediaElementSource(myMediaElement);
 
 该示例由 {{htmlelement("audio") }} 元素，通过使用 `createMediaElementSource()` 方法，创建了一个音源，将其通过 {{ domxref("GainNode") }} 节点，输出到{{ domxref("AudioDestinationNode") }} 节点以播放。当鼠标指针移动时，`updatePage()` 函数被调用，该函数计算当前鼠标 Y 坐标与页面高度的比值，改变 {{ domxref("GainNode") }} 节点的值以调整音量。您就可以通过鼠标上下移动而改变音乐的音量了。
 
-> **备注：** 您也可以 [浏览该示例的在线演示](http://mdn.github.io/webaudio-examples/media-source-buffer/), 或者 [浏览源代码](https://github.com/mdn/webaudio-examples/tree/master/media-source-buffer).
+> **备注：** 也可以[浏览该示例的在线演示](http://mdn.github.io/webaudio-examples/media-source-buffer/), 或者[浏览源代码](https://github.com/mdn/webaudio-examples/tree/main/media-source-buffer)。
 
 ```js
 var audioCtx = new (window.AudioContext || window.webkitAudioContext)();

--- a/files/zh-cn/web/api/audiocontext/createmediastreamsource/index.md
+++ b/files/zh-cn/web/api/audiocontext/createmediastreamsource/index.md
@@ -31,7 +31,7 @@ var source = audioCtx.createMediaStreamSource(stream);
 
 {{ htmlelement("video") }} 元素下面滑动杆控制低音过滤器过滤的程度，滑动杆的值越大，低音更明显
 
-> **备注：** **注意：你可以查看** [在线演示](https://mdn.github.io/webaudio-examples/stream-source-buffer/)，或者 [查看源码](https://github.com/mdn/webaudio-examples/tree/master/stream-source-buffer)。
+> **备注：** 你可以查看[在线演示](https://mdn.github.io/webaudio-examples/stream-source-buffer/)，或者[查看源码](https://github.com/mdn/webaudio-examples/tree/main/stream-source-buffer)。
 
 ```js
 var pre = document.querySelector('pre');

--- a/files/zh-cn/web/api/baseaudiocontext/listener/index.md
+++ b/files/zh-cn/web/api/baseaudiocontext/listener/index.md
@@ -13,7 +13,7 @@ slug: Web/API/BaseAudioContext/listener
 
 ## 示例
 
-> **备注：** 如果需要完整的音频空间化例子，可以查看 [panner-node](https://github.com/mdn/webaudio-examples/tree/master/panner-node) 演示。
+> **备注：** 如果需要完整的音频空间化例子，可以查看 [panner-node](https://github.com/mdn/webaudio-examples/tree/main/panner-node) 演示。
 
 ```js
 const audioCtx = new AudioContext();

--- a/files/zh-cn/web/api/channel_messaging_api/index.md
+++ b/files/zh-cn/web/api/channel_messaging_api/index.md
@@ -32,8 +32,8 @@ slug: Web/API/Channel_Messaging_API
 
 ## 例子
 
-- 我们在 Github 上发布了 [channel messaging basic demo](https://github.com/mdn/dom-examples/tree/master/channel-messaging-basic)，在[这里](http://mdn.github.io/dom-examples/channel-messaging-basic/)直接尝试。这个例子展示了一次页面和嵌入 {{htmlelement("iframe")}} 间的真实而简易的消息传递。
-- 你也可以参考 [多个消息 demo](https://github.com/mdn/dom-examples/tree/master/channel-messaging-multimessage) ([在线演示](http://mdn.github.io/dom-examples/channel-messaging-multimessage/))。这个例子展示了稍微复杂些的设置，可以在主页面和 IFrame 之间传递多条消息。
+- 我们在 Github 上发布了 [channel messaging 基本演示](https://github.com/mdn/dom-examples/tree/main/channel-messaging-basic)，在[这里](http://mdn.github.io/dom-examples/channel-messaging-basic/)直接尝试。这个例子展示了一次页面和嵌入 {{htmlelement("iframe")}} 间的真实而简易的消息传递。
+- 你也可以参考[多个消息演示](https://github.com/mdn/dom-examples/tree/main/channel-messaging-multimessage)（[在线演示](http://mdn.github.io/dom-examples/channel-messaging-multimessage/)）。这个例子展示了稍微复杂些的设置，可以在主页面和 IFrame 之间传递多条消息。
 
 ## 规范
 

--- a/files/zh-cn/web/api/channel_messaging_api/using_channel_messaging/index.md
+++ b/files/zh-cn/web/api/channel_messaging_api/using_channel_messaging/index.md
@@ -21,9 +21,9 @@ Channel messaging 在这样的场景中特别有用：假如你有一个社交�
 
 ## 简单的例子
 
-为了帮助你开始，我们在 Github 上传了一些 demo. 一开始可以先看我们的 [channel messaging 基本示例](https://github.com/mdn/dom-examples/tree/master/channel-messaging-basic) ([也可以在线运行](https://mdn.github.io/dom-examples/channel-messaging-basic/))，它展示了一个非常简单的消息传递，发生在页面和内嵌 {{htmlelement("iframe")}} 之间。
+为了帮助你开始，我们在 Github 上传了一些 demo. 一开始可以先看我们的 [channel messaging 基本示例](https://github.com/mdn/dom-examples/tree/main/channel-messaging-basic)（[也可以在线运行](https://mdn.github.io/dom-examples/channel-messaging-basic/)），它展示了一个非常简单的消息传递，发生在页面和内嵌 {{htmlelement("iframe")}} 之间。
 
-然后，看看我们的 [multimessaging demo](https://github.com/mdn/dom-examples/tree/master/channel-messaging-multimessage) ([在线运行](https://mdn.github.io/dom-examples/channel-messaging-multimessage/))，它展示了一个稍微复杂一点的例子，可以在主页面和 IFrame 之间发送多条消息。
+然后，看看我们的 [multimessaging 演示](https://github.com/mdn/dom-examples/tree/main/channel-messaging-multimessage)（[在线运行](https://mdn.github.io/dom-examples/channel-messaging-multimessage/)），它展示了一个稍微复杂一点的例子，可以在主页面和 IFrame 之间发送多条消息。
 
 本文中，我们重点说后面的这个例子。它看起来像是这样：
 

--- a/files/zh-cn/web/api/customelementregistry/define/index.md
+++ b/files/zh-cn/web/api/customelementregistry/define/index.md
@@ -38,7 +38,7 @@ customElements.define(name, constructor, options);
 
 ### 自主定制元素
 
-以下代码取自我们的 [popup-info-box-web-component](https://github.com/mdn/web-components-examples/tree/master/popup-info-box-web-component) 示例 ([see it live also](https://mdn.github.io/web-components-examples/popup-info-box-web-component/))。
+以下代码取自我们的 [popup-info-box-web-component](https://github.com/mdn/web-components-examples/tree/main/popup-info-box-web-component) 示例（[查看实时运行版本](https://mdn.github.io/web-components-examples/popup-info-box-web-component/)）。
 
 ```js
 // Create a class for the element
@@ -128,7 +128,7 @@ customElements.define('popup-info', PopUpInfo);
 
 ### 自定义内置元素
 
-以下代码取自我们的 [word-count-web-component](https://github.com/mdn/web-components-examples/tree/master/word-count-web-component) 实例 ([查看实例效果](https://mdn.github.io/web-components-examples/word-count-web-component/)).
+以下代码取自我们的 [word-count-web-component](https://github.com/mdn/web-components-examples/tree/main/word-count-web-component) 实例（[查看实例效果](https://mdn.github.io/web-components-examples/word-count-web-component/)）。
 
 ```js
 // Create a class for the element

--- a/files/zh-cn/web/api/customelementregistry/index.md
+++ b/files/zh-cn/web/api/customelementregistry/index.md
@@ -20,7 +20,7 @@ slug: Web/API/CustomElementRegistry
 
 ## 示例
 
-以下代码来自我们的 [word-count-web-component](https://github.com/mdn/web-components-examples/tree/master/word-count-web-component) 示例（[see it live also](https://mdn.github.io/web-components-examples/word-count-web-component/)）。请注意我们如何使用 {{domxref("CustomElementRegistry.define()")}} 方法在创建其类后定义自定义元素。
+以下代码来自我们的 [word-count-web-component](https://github.com/mdn/web-components-examples/tree/main/word-count-web-component) 示例（[查看实时运行版本](https://mdn.github.io/web-components-examples/word-count-web-component/)）。请注意我们如何使用 {{domxref("CustomElementRegistry.define()")}} 方法在创建其类后定义自定义元素。
 
 ```js
 // Create a class for the element

--- a/files/zh-cn/web/javascript/guide/modules/index.md
+++ b/files/zh-cn/web/javascript/guide/modules/index.md
@@ -21,7 +21,7 @@ JavaScript 程序本来很小——在早期，它们大多被用来执行独立
 
 ## 介绍一个例子
 
-为了演示模块的使用，我们创建了一个 [simple set of examples](https://github.com/mdn/js-examples/tree/master/module-examples) ，你可以在 Github 上找到。这个例子演示了一个简单的模块的集合用来在 web 页面上创建了一个 {{htmlelement("canvas")}} 标签，在 canvas 上绘制 (并记录有关的信息) 不同形状。
+为了演示模块的使用，我们创建了[一系列简单的示例](https://github.com/mdn/js-examples/tree/main/module-examples) ，你可以在 GitHub 上找到。这个例子演示了一个简单的模块的集合用来在 web 页面上创建了一个 {{htmlelement("canvas")}} 标签，在 canvas 上绘制 (并记录有关的信息) 不同形状。
 
 这的确有点简单，但是保持足够简单能够清晰地演示模块。
 
@@ -29,7 +29,7 @@ JavaScript 程序本来很小——在早期，它们大多被用来执行独立
 
 ## 基本的示例文件的结构
 
-在我们的第一个例子 (see [basic-modules](https://github.com/mdn/js-examples/tree/master/module-examples/basic-modules)) 文件结构如下：
+在我们的第一个例子（参见 [basic-modules](https://github.com/mdn/js-examples/tree/main/module-examples/basic-modules)）文件结构如下：
 
 ```plain
 index.html
@@ -235,7 +235,7 @@ import { function1 as newFunctionName,
          function2 as anotherNewFunctionName } from '/modules/module.js';
 ```
 
-让我们看一个真实的例子。在我们的 [重命名](https://github.com/mdn/js-examples/tree/master/module-examples/renaming) 目录中，您将看到与上一个示例中相同的模块系统，除了我们添加了 `circle.js` 和 `triangle.js` 模块以绘制和报告圆和三角形。
+让我们看一个真实的例子。在我们的 [renaming](https://github.com/mdn/js-examples/tree/main/module-examples/renaming) 目录中，你将看到与上一个示例中相同的模块系统，除了我们添加了 `circle.js` 和 `triangle.js` 模块以绘制和报告圆和三角形。
 
 在每个模块中，我们都有 `export` 相同名称的功能，因此每个模块底部都有相同的导出语句：
 
@@ -300,12 +300,11 @@ import * as Module from '/modules/module.js';
 这将获取 `module.js` 中所有可用的导出，并使它们可以作为对象模块的成员使用，从而有效地为其提供自己的命名空间。例如：
 
 ```js
-Module.function1()
-Module.function2()
-etc.
+Module.function1();
+Module.function2();
 ```
 
-再次，让我们看一个真实的例子。如果您转到我们的 [module-objects](https://github.com/mdn/js-examples/tree/master/module-examples/module-objects) 目录，您将再次看到相同的示例，但利用上述的新语法进行重写。在模块中，导出都是以下简单形式：
+再次，让我们看一个真实的例子。如果你转到我们的 [module-objects](https://github.com/mdn/js-examples/tree/main/module-examples/module-objects) 目录，将再次看到相同的示例，但利用上述的新语法进行重写。在模块中，导出都是以下简单形式：
 
 ```js
 export { name, draw, reportArea, reportPerimeter };
@@ -335,19 +334,19 @@ Square.reportPerimeter(square1.length, reportList);
 
 正如我们之前提到的那样，您还可以导出和导入类；这是避免代码冲突的另一种选择，如果您已经以面向对象的方式编写了模块代码，那么它尤其有用。
 
-您可以在我们的 [classes](https://github.com/mdn/js-examples/tree/master/module-examples/classes) 目录中看到使用 ES 类重写的形状绘制模块的示例。例如，[`square.js`](https://github.com/mdn/js-examples/blob/master/module-examples/classes/modules/square.js) 文件现在包含单个类中的所有功能：
+你可以在我们的 [classes](https://github.com/mdn/js-examples/tree/main/module-examples/classes) 目录中看到使用 ES 类重写的形状绘制模块的示例。例如，[`square.js`](https://github.com/mdn/js-examples/blob/main/module-examples/classes/modules/square.js) 文件现在包含单个类中的所有功能：
 
 ```js
 class Square {
   constructor(ctx, listId, length, x, y, color) {
-    ...
+    // …
   }
 
   draw() {
-    ...
+    // …
   }
 
-  ...
+  // …
 }
 ```
 
@@ -357,7 +356,7 @@ class Square {
 export { Square };
 ```
 
-在 [`main.js`](https://github.com/mdn/js-examples/blob/master/module-examples/classes/main.js) 中，我们像这样导入它：
+在 [`main.js`](https://github.com/mdn/js-examples/blob/main/module-examples/classes/main.js) 中，我们像这样导入它：
 
 ```js
 import { Square } from './modules/square.js';
@@ -383,7 +382,7 @@ export { name } from 'x.js'
 
 > **备注：** 这实际上是导入后跟导出的简写，即“我导入模块 `x.js`，然后重新导出部分或全部导出”。
 
-有关示例，请参阅我们的 [module-aggregation](https://github.com/mdn/js-examples/tree/master/module-examples/module-aggregation)。在这个例子中（基于我们之前的类示例），我们有一个名为 `shapes.js` 的额外模块，它将 `circle.js`，`square.js` 和 `riangle.mjs` 中的所有功能聚合在一起。我们还将子模块移动到名为 shapes 的 modules 目录中的子目录中。所以模块结构现在是这样的：
+有关示例，请参阅我们的 [module-aggregation](https://github.com/mdn/js-examples/tree/main/module-examples/module-aggregation)。在这个例子中（基于我们之前的类示例），我们有一个名为 `shapes.js` 的额外模块，它将 `circle.js`，`square.js` 和 `riangle.mjs` 中的所有功能聚合在一起。我们还将子模块移动到名为 shapes 的 modules 目录中的子目录中。所以模块结构现在是这样的：
 
 ```plain
 modules/
@@ -442,7 +441,7 @@ import('/modules/mymodule.js')
   });
 ```
 
-我们来看一个例子。在 [dynamic-module-imports](https://github.com/mdn/js-examples/tree/master/module-examples/dynamic-module-imports) 目录中，我们有另一个基于类示例的示例。但是这次我们在示例加载时没有在画布上绘制任何东西。相反，我们包括三个按钮 -- “圆形”，“方形”和“三角形” -- 按下时，动态加载所需的模块，然后使用它来绘制相关的形状。
+我们来看一个例子。在 [dynamic-module-imports](https://github.com/mdn/js-examples/tree/main/module-examples/dynamic-module-imports) 目录中，我们有另一个基于类示例的示例。但是这次我们在示例加载时没有在画布上绘制任何东西。相反，我们包括三个按钮 -- “圆形”，“方形”和“三角形” -- 按下时，动态加载所需的模块，然后使用它来绘制相关的形状。
 
 在这个例子中，我们只对 [index.html](https://github.com/mdn/js-examples/blob/master/module-examples/dynamic-module-imports/index.html) 和 [main.js](https://github.com/mdn/js-examples/blob/master/module-examples/dynamic-module-imports/main.js) 文件进行了更改 -- 模块导出保持与以前相同。
 

--- a/files/zh-cn/web/javascript/reference/global_objects/promise/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/promise/index.md
@@ -394,7 +394,7 @@ if ("Promise" in window) {
 
 ### 使用 XHR 加载图像
 
-另一个使用 `Promise` 和 {{domxref("XMLHttpRequest")}} 加载一个图像的例子可在 MDN GitHub [js-examples](https://github.com/mdn/js-examples/tree/master/promises-test) 仓库中找到。你也可以[看它的实例](https://mdn.github.io/js-examples/promises-test/)。每一步都有注释可以让你详细的了解 Promise 和 XHR 架构。
+另一个使用 `Promise` 和 {{domxref("XMLHttpRequest")}} 加载一个图像的例子可在 MDN GitHub [js-examples](https://github.com/mdn/js-examples/tree/main/promises-test) 仓库中找到。你也可以[看它的实例](https://mdn.github.io/js-examples/promises-test/)。每一步都有注释可以让你详细的了解 Promise 和 XHR 架构。
 
 ## 规范
 

--- a/files/zh-cn/web/progressive_web_apps/guides/making_pwas_installable/index.md
+++ b/files/zh-cn/web/progressive_web_apps/guides/making_pwas_installable/index.md
@@ -16,7 +16,7 @@ Mobile Chrome / Android Webview 从 31 版开始支持 A2HS，Opera for Android 
 
 ## 如何使用？
 
-我们已经编写了一个非常简单的示例网站（[观看我们的在线演示](https://mdn.github.io/pwa-examples/a2hs/)，并[查看源代码](https://github.com/mdn/pwa-examples/tree/master/a2hs)），该网站虽然功能不多，但是实现 A2HS 所必须的代码都有包含，Service Worker 也使其可以脱机使用。这个示例展示了一系列的狐狸图片。
+我们已经编写了一个非常简单的示例网站（[观看我们的在线演示](https://mdn.github.io/pwa-examples/a2hs/)，并[查看源代码](https://github.com/mdn/pwa-examples/tree/main/a2hs)），该网站虽然功能不多，但是实现 A2HS 所必须的代码都有包含，Service Worker 也使其可以脱机使用。这个示例展示了一系列的狐狸图片。
 
 如果您有适用于 Android 的 Firefox，使用它打开我们的示例：`https://mdn.github.io/pwa-examples/a2hs/`。你将会看到狐狸图片，但更重要的是，你将会看到一个带有加号（+）的“主页”图标——这是为具有必要功能的任何站点显示的“添加到主屏幕”图标。
 

--- a/files/zh-cn/web/progressive_web_apps/tutorials/js13kgames/introduction/index.md
+++ b/files/zh-cn/web/progressive_web_apps/tutorials/js13kgames/introduction/index.md
@@ -78,7 +78,7 @@ PWA 所需的关键要素是 [Service Worker](/zh-CN/docs/Web/API/Service_Worker
 
 在本系列文章中，我们将研究一个超级简单网站的源代码，该网站列出了 [js13kGames 2017](http://2017.js13kgames.com/) 竞赛中提交给 [A-Frame category](http://js13kgames.com/aframe) 的游戏的相关信息。您不必考虑网站上的实际内容，这里主要是学习如何在您自己的项目中使用 PWA 功能。
 
-您可以在 [mdn.github.io/pwa-examples/js13kpwa](https://mdn.github.io/pwa-examples/js13kpwa/) 找到在线版本（另请[参阅源代码](https://github.com/mdn/pwa-examples/tree/master/js13kpwa)），我们将在接下来的几篇文章中对其进行详细解释。
+你可以在 [mdn.github.io/pwa-examples/js13kpwa](https://mdn.github.io/pwa-examples/js13kpwa/) 找到在线版本（另请[参阅源代码](https://github.com/mdn/pwa-examples/tree/main/js13kpwa)），我们将在接下来的几篇文章中对其进行详细解释。
 
 现在，让我们转到本系列的第二部分，我们来看看这个示例应用程序的结构。
 

--- a/files/zh-cn/web/progressive_web_apps/tutorials/js13kgames/loading/index.md
+++ b/files/zh-cn/web/progressive_web_apps/tutorials/js13kgames/loading/index.md
@@ -152,7 +152,7 @@ if('IntersectionObserver' in window) {
 
 ## 结语
 
-这就是这个系列的所有内容了。我们通过 [js13kPWA 示例应用的源码](https://github.com/mdn/pwa-examples/tree/master/js13kpwa) 学习了渐进式 Web 应用的的用法，包括 [PWA 介绍](/zh-CN/docs/Web/Apps/Progressive/Introduction)、[PWA 结构](/zh-CN/docs/Web/Apps/Progressive/App_structure)、[通过 Service Worker 让 PWA 离线工作](/zh-CN/docs/Web/Apps/Progressive/Offline_Service_workers)、[让 PWA 易于安装](/zh-CN/docs/Web/Apps/Progressive/Installable_PWAs)，以及最后的通知功能。在 [Service Worker Cookbook](https://github.com/mdn/serviceworker-cookbook/) 的帮助下，我们还解释了推送的原理。而在本篇文章中，我们探讨了渐进式加载的概念，包括一个使用了 [Intersection Observer API](/zh-CN/docs/Web/API/Intersection_Observer_API) 的有趣示例。
+这就是这个系列的所有内容了。我们通过 [js13kPWA 示例应用的源码](https://github.com/mdn/pwa-examples/tree/main/js13kpwa) 学习了渐进式 Web 应用的的用法，包括 [PWA 介绍](/zh-CN/docs/Web/Apps/Progressive/Introduction)、[PWA 结构](/zh-CN/docs/Web/Apps/Progressive/App_structure)、[通过 Service Worker 让 PWA 离线工作](/zh-CN/docs/Web/Apps/Progressive/Offline_Service_workers)、[让 PWA 易于安装](/zh-CN/docs/Web/Apps/Progressive/Installable_PWAs)，以及最后的通知功能。在 [Service Worker Cookbook](https://github.com/mdn/serviceworker-cookbook/) 的帮助下，我们还解释了推送的原理。而在本篇文章中，我们探讨了渐进式加载的概念，包括一个使用了 [Intersection Observer API](/zh-CN/docs/Web/API/Intersection_Observer_API) 的有趣示例。
 
 请随意试验这些代码，使用 PWA 的特性来让你现有的应用更加健壮，或者创作出一点新东西。相对于常规的 Web 应用，PWA 存在巨大的优势。
 

--- a/files/zh-cn/web/progressive_web_apps/tutorials/js13kgames/offline_service_workers/index.md
+++ b/files/zh-cn/web/progressive_web_apps/tutorials/js13kgames/offline_service_workers/index.md
@@ -6,7 +6,7 @@ original_slug: Web/Progressive_web_apps/Offline_Service_workers
 
 {{PWASidebar}} {{PreviousMenuNext("Web/Progressive_web_apps/Tutorials/js13kGames/App_structure", "Web/Progressive_web_apps/Tutorials/js13kGames/Installable_PWAs", "Web/Progressive_web_apps/Tutorials/js13kGames")}}
 
-我们已经看到了 js13kPWA 的结构，并且看到了 shell 启动和运行的基本方式，那么现在让我们把目光转向如何使用 Service Worker 实现离线功能。在本文，我们将看到它在 [js13kPWA example](https://mdn.github.io/pwa-examples/js13kpwa/) 中是如何使用的（[另请参阅源代码](https://github.com/mdn/pwa-examples/tree/master/js13kpwa)）。我们将研究如何添加脱机功能。
+我们已经看到了 js13kPWA 的结构，并且看到了 shell 启动和运行的基本方式，那么现在让我们把目光转向如何使用 Service Worker 实现离线功能。在本文，我们将看到它在 [js13kPWA example](https://mdn.github.io/pwa-examples/js13kpwa/) 中是如何使用的（[另请参阅源代码](https://github.com/mdn/pwa-examples/tree/main/js13kpwa)）。我们将研究如何添加脱机功能。
 
 ## Service Worker 解释
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This may be trival, but re-pointing links to `/main/` one may reduce redirects and prevent problem when GitHub doesn't provide a redirect anymore.

Also fixed some links that is not exist anymore.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
