### PR TITLE
remove css-animations part <浏览器兼容性>, Sync with en documents

### DIFF
--- a/files/zh-cn/web/css/css_animations/index.md
+++ b/files/zh-cn/web/css/css_animations/index.md
@@ -75,10 +75,6 @@ CSS 动画模块（CSS Animation）可以让你通过使用关键帧对 CSS 属�
 
 {{Specifications}}
 
-## 浏览器兼容性
-
-{{Compat}}
-
 ## 参见
 
 - {{Experimental_Inline}} CSS 滚动时间线 {{cssxref('scroll-timeline-name')}} 和 {{cssxref('scroll-timeline-axis')}} 属性，以及 {{cssxref('scroll-timeline')}} 简写属性，创建与滚动容器的滚动偏移相关的动画。


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The CN translation ,  "浏览器兼容性"  shows `{{Compat}}`. I checked EN page, there is no "Browser compatibility" part.

<img width="611" alt="image" src="https://github.com/mdn/translated-content/assets/11435907/f2d29ba5-4ecd-4b3e-b733-eb868f696d90">

and [the EN source code](https://github.com/mdn/content/blob/main/files/en-us/web/css/css_animations/index.md) still has no "Browser compatibility"

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
