### PR TITLE
[zh-CN] sync offline event with en-US

### DIFF
--- a/files/zh-cn/web/api/window/offline_event/index.md
+++ b/files/zh-cn/web/api/window/offline_event/index.md
@@ -1,38 +1,55 @@
 ---
-title: offline
+title: Window：offline 事件
 slug: Web/API/Window/offline_event
 ---
 
-当浏览器失去网络连接时，`offline`事件被触发。并且`navigator.onLine`的值变为 `false`。
+{{APIRef}}
 
-## 常规信息
+`offline` 事件在浏览器失去网络连接时，在 {{domxref("Window")}} 接口上触发。并且 {{domxref("Navigator.onLine")}} 的值变为 `false`。
 
-- 规范
-  - : [HTML5 Offline](http://www.whatwg.org/specs/web-apps/current-work/multipage/offline.html#event-offline)
-- 接口
-  - : Event
-- 是否冒泡
-  - : 否
-- 可取消默认行为
-  - : 否
-- 目标对象
-  - : 当前网页 (`<window>`)
-- 默认行为
-  - : 无
+## 语法
 
-## 属性
+在类似 {{domxref("EventTarget.addEventListener", "addEventListener()")}} 这样的方法中使用事件名称，或者设置事件处理器属性。
 
-| 属性                                  | 类型                                 | 描述                                         |
-| ------------------------------------- | ------------------------------------ | -------------------------------------------- |
-| `target` {{readonlyInline}}     | {{domxref("EventTarget")}} | 产生该事件的对象 (DOM 树中最顶级的那个对象). |
-| `type` {{readonlyInline}}       | {{domxref("DOMString")}}     | 事件类型。                                   |
-| `bubbles` {{readonlyInline}}    | {{jsxref("Boolean")}}         | 该事件是否冒泡。                             |
-| `cancelable` {{readonlyInline}} | {{jsxref("Boolean")}}         | 该事件是否可取消默认行为。                   |
+```js
+addEventListener("offline", (event) => {});
+onoffline = (event) => {};
+```
+
+## 事件类型
+
+一个 {{domxref("Event")}}。
+
+## 事件处理方法别名
+
+除了 `Window` 接口以外，事情处理方法属性 `onoffline` 同样可以用于以下目标：
+
+- {{domxref("HTMLBodyElement")}}
+- {{domxref("HTMLFrameSetElement")}}
+- {{domxref("SVGSVGElement")}}
+
+## 示例
+
+```js
+// addEventListener 版本
+window.addEventListener("offline", (event) => {
+  console.log("网络连接已断开。");
+});
+
+// onoffline 版本
+window.onoffline = (event) => {
+  console.log("网络连接已断开。");
+};
+```
 
 ## 规范
 
 {{Specifications}}
 
-## 相关事件
+## 浏览器兼容性
 
-- [`online`](/zh-CN/docs/Mozilla_event_reference/online)
+{{Compat}}
+
+## 参见
+
+- [`online`](/zh-CN/docs/Web/API/Window/online_event)


### PR DESCRIPTION
### Description

sync offline event with en-US

### Motivation

### Additional details

[https://developer.mozilla.org/zh-CN/docs/Web/API/Window/offline_event]()
[https://github.com/mdn/content/blob/main/files/en-us/web/api/window/offline_event/index.md?plain=1]()

### Related issues and pull requests
