### PR TITLE
[zh-CN] web worker example code: fix `this` scope problem

### DIFF
--- a/files/zh-cn/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/zh-cn/web/api/web_workers_api/using_web_workers/index.md
@@ -429,7 +429,7 @@ worker.onmessage = function(event) {
         event.data.hasOwnProperty('queryMethodArguments')) {
         listeners[event.data.queryMethodListener].apply(instance, event.data.queryMethodArguments);
     } else {
-        this.defaultListener.call(instance, event.data);
+        instance.defaultListener.call(instance, event.data);
     }
 }
 ```
@@ -508,7 +508,7 @@ onmessage = function(event) {
       if (oEvent.data instanceof Object && oEvent.data.hasOwnProperty("vo42t30") && oEvent.data.hasOwnProperty("rnb93qh")) {
         oListeners[oEvent.data.vo42t30].apply(oInstance, oEvent.data.rnb93qh);
       } else {
-        this.defaultListener.call(oInstance, oEvent.data);
+        instance.defaultListener.call(oInstance, oEvent.data);
       }
     };
     if (fOnError) { oWorker.onerror = fOnError; }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
the incorrect scope of `this`.defaultListener in the following code can result in `undefined` errors
```js
oWorker.onmessage = function (oEvent) {
                if (oEvent.data instanceof Object && oEvent.data.hasOwnProperty("vo42t30") && oEvent.data.hasOwnProperty("rnb93qh")) {
                    oListeners[oEvent.data.vo42t30].apply(oInstance, oEvent.data.rnb93qh);
                } else {
                    this.defaultListener.call(oInstance, oEvent.data);
                }
            };
```

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

make it to execute the `defaultListener` when a buildin method cannot be found

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
