### PR TITLE
Added "Tutoriais essenciais" section and removed non-existent page link

### DIFF
--- a/files/pt-br/web/accessibility/index.md
+++ b/files/pt-br/web/accessibility/index.md
@@ -10,16 +10,39 @@ Acessiblidade no desenvolvimento Web significa permitir que o máximo possível 
 
 "**A _Web_ é, fundamentalmente, projetada para funcionar para todas as pessoas**, independentemente de máquina, programas, língua, cultura, localização ou capacidade física ou mental de seus utilizadores. Quando a web atende a esses requisitos, ela se torna acessível a pessoas com dificuldades auditivas, motoras, visuais e cognitivas". [W3C - Acessibilidade](https://www.w3c.br/GT/GrupoAcessibilidade)
 
+## Tutoriais fundamentais
+
+A [área de aprendizado de acessibilidade](/pt-BR/docs/Learn/Accessibility) da MDN contém tutoriais modernos e atualizados que abordam os seguintes aspectos essenciais de acessibilidade: 
+
+- [O que é acessibilidade? (en-US)](/en-US/docs/Learn/Accessibility/What_is_accessibility)
+  - : Este artigo fornece uma visão geral do que é a acessibilidade - isso inclui quais grupos de pessoas devemos considerar e o motivo, quais ferramentas de acessibilidade são utilizadas para interagir com a web e como podemos fazer da acessibilidade web parte do nosso fluxo de desenvolvimento.
+- [HTML: A base para a acessibilidade](/pt-BR/docs/Learn/Accessibility/HTML)
+  - : Boa parte do conteúdo da Web pode ser 'acessível' apenas garantindo que as tags HTML sejam sempre usadas para a finalidade correta. Este artigo analisa detalhadamente como utilizar o HTML garantindo a máxima acessibilidade.
+- [CSS e JavaScript: accessibilidade e boas práticas](/pt-BR/docs/Learn/Accessibility/CSS_and_JavaScript)
+  - : CSS e JavaScript, usados corretamente, também podem proporcionar experiências acessíveis na web, mas se mal utilizadas, podem prejudicar a navegação. Este artigo descreve como utilizar o CSS e JS de forma a garantir que mesmo conteúdos complexos sejam acessíveis.
+- [Básico de WAI-ARIA (en-US)](/en-US/docs/Learn/Accessibility/WAI-ARIA_basics)
+  - : Continuando to tópico anterior, não é facil fazer interfaces web com HTML e conteúdo dinâmico atualizado por JavaScript. O WAI-ARIA é uma tecnologia que pode ajudar com esses problemas, adicionando mais propriedades semanticas que navegadores e tecnologias assistivas podem reconhecer e usar para permitir que os usuários saibam o que está acontecendo na tela. Aqui mostraremos o básico destas técnicas para melhorar a acessibilidade.
+- [Multimedia acessível (en-US)](/en-US/docs/Learn/Accessibility/Multimedia)
+  - : Outra categoria de conteúdo que pode criar problemas de acessibilidade é a multimédia - Audio, vídeo e imagens precisam de alternativas textuais, assim poderão ser compreendidas por tecnologias assistivas de seus usuários. Este artigo detalha como.
+- [Accessibilidade Mobile (en-US)](/en-US/docs/Learn/Accessibility/Mobile)
+  - : O acesso por dispositivos móveis e smartphones é muito popular, e plataformas como iOS e Android já possuem ferramentas bastante consolidadas, assim é importante considerar a acessibilidade do seu conteúdo também nestas plataformas. Este artigo faz considerações sobre acessibilidade mobile.
+
 ## Documentação
 
 - [Desenvolvimento Web](/pt-BR/docs/Accessibility/Web_Development)
   - : Uma coleção de artigos destinados a mostrar as principais questões de desenvolvimento web no mundo da acessibilidade.
+- [Introdução à cor e acessibilidade (en-US)](/en-US/docs/Web/Accessibility/Understanding_Colors_and_Luminance)
+  - : Este artigo discute nossa percepção de luz e cor, oferecendo a base para o uso de cores em designs acessíveis, e demonstra as melhores práticas para conteúdo visual e legível.
+- [Widgets JavaScript navegáveis pelo teclado (en-US)](/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets)
+  - : Até agora, os desenvolvedores web que desejavam tornar seus widgets baseados em `<div>` e `<span>` acessíveis têm enfrentado a falta de técnicas adequadas. A **acessibilidade por teclado** faz parte dos requisitos mínimos de acessibilidade, dos quais um desenvolvedor deve estar ciente.
 - [ARIA](/pt-BR/docs/Accessibility/ARIA)
   - : Uma coleção de artigos para aprender como usar ARIA e tornar seus documentos HTML mais acessíveis.
-- [Desenvolvimento de tecnologias assistivas (TA)](/pt-BR/docs/Accessibility/AT_Development)
-  - : Uma coleção de artigos direcionados a desenvolvedores de tecnologias assistivas.
 - [Acessibilidade em dispositivos móveis](/pt-BR/docs/Web/Accessibility/Mobile_accessibility_checklist)
   - : Esse documento fornece uma breve lista das necessidades da acessibilidade para desenvolvedores de aplicativos móveis.
+- [Acessibilidade cognitiva (en-US)](/en-US/docs/Web/Accessibility/Cognitive_accessibility)
+  - : Este artigo explica como assegurar que o conteúdo web que você está criando é acessível para pessoas com limitações cognitivas.
+- [Acessibilidade para distúrbios convulsivos (en-US)](/en-US/docs/Web/Accessibility/Seizure_disorders)
+  - : Alguns tipos de conteúdo visual na web podem induzir convulsões ou ataques epiléticos em pessoas com certos distúrbios cerebrais. Este artigo o auxilia a entender os tipos de conteúdo que podem ser problemáticos e a encontrar ferramentas e estratégias que ajudam a evitá-los.
 
 ## Ferramentas para desenvolvedores web
 

--- a/files/pt-br/web/accessibility/index.md
+++ b/files/pt-br/web/accessibility/index.md
@@ -13,6 +13,7 @@ Acessiblidade no desenvolvimento Web significa permitir que o máximo possível 
 ## Tutoriais fundamentais
 
 A [área de aprendizado de acessibilidade](/pt-BR/docs/Learn/Accessibility) da MDN contém tutoriais modernos e atualizados que abordam os seguintes aspectos essenciais de acessibilidade:
+
 - [O que é acessibilidade?](/pt-BR/docs/Learn/Accessibility/What_is_accessibility)
   - : Este artigo fornece uma visão geral do que é a acessibilidade - isso inclui quais grupos de pessoas devemos considerar e o motivo, quais ferramentas de acessibilidade são utilizadas para interagir com a web e como podemos fazer da acessibilidade web parte do nosso fluxo de desenvolvimento.
 - [HTML: A base para a acessibilidade](/pt-BR/docs/Learn/Accessibility/HTML)

--- a/files/pt-br/web/accessibility/index.md
+++ b/files/pt-br/web/accessibility/index.md
@@ -13,7 +13,6 @@ Acessiblidade no desenvolvimento Web significa permitir que o máximo possível 
 ## Tutoriais fundamentais
 
 A [área de aprendizado de acessibilidade](/pt-BR/docs/Learn/Accessibility) da MDN contém tutoriais modernos e atualizados que abordam os seguintes aspectos essenciais de acessibilidade: 
-
 - [O que é acessibilidade? (en-US)](/en-US/docs/Learn/Accessibility/What_is_accessibility)
   - : Este artigo fornece uma visão geral do que é a acessibilidade - isso inclui quais grupos de pessoas devemos considerar e o motivo, quais ferramentas de acessibilidade são utilizadas para interagir com a web e como podemos fazer da acessibilidade web parte do nosso fluxo de desenvolvimento.
 - [HTML: A base para a acessibilidade](/pt-BR/docs/Learn/Accessibility/HTML)

--- a/files/pt-br/web/accessibility/index.md
+++ b/files/pt-br/web/accessibility/index.md
@@ -12,18 +12,18 @@ Acessiblidade no desenvolvimento Web significa permitir que o máximo possível 
 
 ## Tutoriais fundamentais
 
-A [área de aprendizado de acessibilidade](/pt-BR/docs/Learn/Accessibility) da MDN contém tutoriais modernos e atualizados que abordam os seguintes aspectos essenciais de acessibilidade: 
-- [O que é acessibilidade? (en-US)](/en-US/docs/Learn/Accessibility/What_is_accessibility)
+A [área de aprendizado de acessibilidade](/pt-BR/docs/Learn/Accessibility) da MDN contém tutoriais modernos e atualizados que abordam os seguintes aspectos essenciais de acessibilidade:
+- [O que é acessibilidade?](/pt-BR/docs/Learn/Accessibility/What_is_accessibility)
   - : Este artigo fornece uma visão geral do que é a acessibilidade - isso inclui quais grupos de pessoas devemos considerar e o motivo, quais ferramentas de acessibilidade são utilizadas para interagir com a web e como podemos fazer da acessibilidade web parte do nosso fluxo de desenvolvimento.
 - [HTML: A base para a acessibilidade](/pt-BR/docs/Learn/Accessibility/HTML)
   - : Boa parte do conteúdo da Web pode ser 'acessível' apenas garantindo que as tags HTML sejam sempre usadas para a finalidade correta. Este artigo analisa detalhadamente como utilizar o HTML garantindo a máxima acessibilidade.
 - [CSS e JavaScript: accessibilidade e boas práticas](/pt-BR/docs/Learn/Accessibility/CSS_and_JavaScript)
   - : CSS e JavaScript, usados corretamente, também podem proporcionar experiências acessíveis na web, mas se mal utilizadas, podem prejudicar a navegação. Este artigo descreve como utilizar o CSS e JS de forma a garantir que mesmo conteúdos complexos sejam acessíveis.
-- [Básico de WAI-ARIA (en-US)](/en-US/docs/Learn/Accessibility/WAI-ARIA_basics)
+- [Básico de WAI-ARIA](/pt-BR/docs/Learn/Accessibility/WAI-ARIA_basics)
   - : Continuando to tópico anterior, não é facil fazer interfaces web com HTML e conteúdo dinâmico atualizado por JavaScript. O WAI-ARIA é uma tecnologia que pode ajudar com esses problemas, adicionando mais propriedades semanticas que navegadores e tecnologias assistivas podem reconhecer e usar para permitir que os usuários saibam o que está acontecendo na tela. Aqui mostraremos o básico destas técnicas para melhorar a acessibilidade.
-- [Multimedia acessível (en-US)](/en-US/docs/Learn/Accessibility/Multimedia)
+- [Multimedia acessível](/pt-BR/docs/Learn/Accessibility/Multimedia)
   - : Outra categoria de conteúdo que pode criar problemas de acessibilidade é a multimédia - Audio, vídeo e imagens precisam de alternativas textuais, assim poderão ser compreendidas por tecnologias assistivas de seus usuários. Este artigo detalha como.
-- [Accessibilidade Mobile (en-US)](/en-US/docs/Learn/Accessibility/Mobile)
+- [Accessibilidade Mobile](/pt-BR/docs/Learn/Accessibility/Mobile)
   - : O acesso por dispositivos móveis e smartphones é muito popular, e plataformas como iOS e Android já possuem ferramentas bastante consolidadas, assim é importante considerar a acessibilidade do seu conteúdo também nestas plataformas. Este artigo faz considerações sobre acessibilidade mobile.
 
 ## Documentação

--- a/files/pt-br/web/accessibility/index.md
+++ b/files/pt-br/web/accessibility/index.md
@@ -31,9 +31,9 @@ A [área de aprendizado de acessibilidade](/pt-BR/docs/Learn/Accessibility) da M
 
 - [Desenvolvimento Web](/pt-BR/docs/Accessibility/Web_Development)
   - : Uma coleção de artigos destinados a mostrar as principais questões de desenvolvimento web no mundo da acessibilidade.
-- [Introdução à cor e acessibilidade (en-US)](/en-US/docs/Web/Accessibility/Understanding_Colors_and_Luminance)
+- [Introdução à cor e acessibilidade](/pt-BR/docs/Web/Accessibility/Understanding_Colors_and_Luminance)
   - : Este artigo discute nossa percepção de luz e cor, oferecendo a base para o uso de cores em designs acessíveis, e demonstra as melhores práticas para conteúdo visual e legível.
-- [Widgets JavaScript navegáveis pelo teclado (en-US)](/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets)
+- [Widgets JavaScript navegáveis pelo teclado](/pt-BR/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets)
   - : Até agora, os desenvolvedores web que desejavam tornar seus widgets baseados em `<div>` e `<span>` acessíveis têm enfrentado a falta de técnicas adequadas. A **acessibilidade por teclado** faz parte dos requisitos mínimos de acessibilidade, dos quais um desenvolvedor deve estar ciente.
 - [ARIA](/pt-BR/docs/Accessibility/ARIA)
   - : Uma coleção de artigos para aprender como usar ARIA e tornar seus documentos HTML mais acessíveis.


### PR DESCRIPTION
### Description

I added a new section titled "Tutoriais essenciais" to the pt-BR/docs/Web/Accessibility page, providing additional information and resources. I also removed a link that was pointing to a non-existent page.

### Motivation

This page was lacking some essential resources on accessibility and how-to guides as well.

### Additional details

I also removed a link to a page that doesn't exist anywhere in the MDN domain [/pt-BR/docs/Accessibility/AT_Development].
