### PR TITLE
chore(zh): remove unnecessary code wrapper

### DIFF
--- a/files/zh-cn/web/javascript/reference/functions/default_parameters/index.md
+++ b/files/zh-cn/web/javascript/reference/functions/default_parameters/index.md
@@ -5,7 +5,7 @@ slug: Web/JavaScript/Reference/Functions/Default_parameters
 
 {{jsSidebar("Functions")}}
 
-**函数默认参数**允许在没有值或`undefined`被传入时使用默认形参。
+**函数默认参数**允许在没有值或 `undefined` 被传入时使用默认形参。
 
 {{EmbedInteractiveExample("pages/js/functions-default.html")}}
 
@@ -19,11 +19,11 @@ function [name]([param1[ = defaultValue1 ][, ..., paramN[ = defaultValueN ]]]) {
 
 ## 描述
 
-JavaScript 中函数的参数默认是`{{jsxref("undefined")}}`。然而，在某些情况下可能需要设置一个不同的默认值。这是默认参数可以帮助的地方。
+JavaScript 中函数的参数默认是 {{jsxref("undefined")}}。然而，在某些情况下可能需要设置一个不同的默认值。这是默认参数可以帮助的地方。
 
-以前，一般设置默认参数的方法是在函数体测试参数是否为`undefined`，如果是的话就设置为默认的值。
+以前，一般设置默认参数的方法是在函数体测试参数是否为 `undefined`，如果是的话就设置为默认的值。
 
-下面的例子中，如果在调用`multiply`时，参数`b`的值没有提供，那么它的值就为`undefined`。如果直接执行`a * b`，函数会返回 `NaN`。
+下面的例子中，如果在调用 `multiply` 时，参数 `b` 的值没有提供，那么它的值就为 `undefined`。如果直接执行 `a * b`，函数会返回 `NaN`。
 
 ```js
 function multiply(a, b) {

--- a/files/zh-cn/web/javascript/reference/global_objects/promise/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/promise/index.md
@@ -23,7 +23,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Promise
 
 待定状态的 Promise 对象要么会通过一个值*被兑现*，要么会通过一个原因（错误）*被拒绝*。当这些情况之一发生时，我们用 promise 的 `then` 方法排列起来的相关处理程序就会被调用。如果 promise 在一个相应的处理程序被绑定时就已经被兑现或被拒绝了，那么这个处理程序也同样会被调用，因此在完成异步操作和绑定处理方法之间不存在竞态条件。
 
-因为 `{{jsxref("Promise.then", "Promise.prototype.then")}}` 和 `{{jsxref("Promise.catch", "Promise.prototype.catch")}}` 方法返回的是 promise，所以它们可以被链式调用。
+因为 {{jsxref("Promise.then", "Promise.prototype.then")}} 和 {{jsxref("Promise.catch", "Promise.prototype.catch")}} 方法返回的是 promise，所以它们可以被链式调用。
 
 ![](promises.png)
 
@@ -33,7 +33,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Promise
 
 ### Promise 的链式调用
 
-我们可以用 `{{jsxref("Promise.prototype.then()")}}`、`{{jsxref("Promise.prototype.catch()")}}` 和 `{{jsxref("Promise.prototype.finally()")}}` 这些方法将进一步的操作与一个变为已敲定状态的 promise 关联起来。
+我们可以用 {{jsxref("Promise.prototype.then()")}}、{{jsxref("Promise.prototype.catch()")}} 和 {{jsxref("Promise.prototype.finally()")}} 这些方法将进一步的操作与一个变为已敲定状态的 promise 关联起来。
 
 例如 `.then()` 方法需要两个参数，第一个参数作为处理已兑现状态的回调函数，而第二个参数则作为处理已拒绝状态的回调函数。每一个 `.then()` 方法还会返回一个新生成的 promise 对象，这个对象可被用作链式调用，就像这样：
 

--- a/files/zh-cn/web/javascript/reference/global_objects/string/raw/index.md
+++ b/files/zh-cn/web/javascript/reference/global_objects/string/raw/index.md
@@ -30,7 +30,7 @@ String.raw`templateString`
 
 ### 异常
 
-- `{{jsxref("TypeError")}}`
+- {{jsxref("TypeError")}}
   - : 如果第一个参数没有传入一个格式正确的对象，则会抛出 `TypeError` 异常。
 
 ## 描述

--- a/files/zh-cn/web/javascript/reference/statements/async_function/index.md
+++ b/files/zh-cn/web/javascript/reference/statements/async_function/index.md
@@ -243,11 +243,11 @@ async function getProcessedData(url) {
 }
 ```
 
-注意，在上述示例中，`return` 语句中没有 `await` 操作符，因为 `async function` 的返回值将被隐式地传递给 `{{jsxref("Promise.resolve")}}`。
+注意，在上述示例中，`return` 语句中没有 `await` 运算符，因为 `async function` 的返回值将被隐式地传递给 {{jsxref("Promise.resolve")}}。
 
-返回值`隐式的传递给`{{jsxref("Promise.resolve")}}，并不意味着`return await promiseValue;和 return promiseValue;`在功能上相同。
+返回值隐式地传递给 {{jsxref("Promise.resolve")}}，并不意味着 `return await promiseValue;` 和 `return promiseValue;` 在功能上相同。
 
-看下下面重写的上面代码，在`processDataInWorker`抛出异常时返回了 null：
+看下下面重写的上面代码，在 `processDataInWorker` 抛出异常时返回了 null：
 
 ```js
 async function getProcessedData(url) {

--- a/files/zh-tw/web/api/event/event/index.md
+++ b/files/zh-tw/web/api/event/event/index.md
@@ -23,7 +23,7 @@ event = new Event(typeArg, eventInit);
 
     | 參數           | 可選 | 默認值  | 類型                           | 說明                              |
     | -------------- | ---- | ------- | ------------------------------ | --------------------------------- |
-    | `"bubbles"`    | ●    | `false` | `{{jsxref("Boolean")}}` | 表示該事件是否懸浮（bubble up）。 |
+    | `"bubbles"`    | ●    | `false` | {{jsxref("Boolean")}} | 表示該事件是否懸浮（bubble up）。 |
     | `"cancelable"` | ●    | `false` | {{jsxref("Boolean")}}   | 表示該事件是否已取消（canale）。  |
 
 ## 範例

--- a/files/zh-tw/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/array/map/index.md
@@ -184,7 +184,7 @@ function returnInt(element) {
 
 ## Polyfill
 
-`map` was added to the ECMA-262 standard in the 5th edition; as such it may not be present in all implementations of the standard. You can work around this by inserting the following code at the beginning of your scripts, allowing use of `map` in implementations which do not natively support it. This algorithm is exactly the one specified in ECMA-262, 5th edition, assuming {{jsxref("Object")}}, {{jsxref("TypeError")}}, and {{jsxref("Array")}} have their original values and that `callback.call` evaluates to the original value of `{{jsxref("Function.prototype.call")}}`.
+`map` was added to the ECMA-262 standard in the 5th edition; as such it may not be present in all implementations of the standard. You can work around this by inserting the following code at the beginning of your scripts, allowing use of `map` in implementations which do not natively support it. This algorithm is exactly the one specified in ECMA-262, 5th edition, assuming {{jsxref("Object")}}, {{jsxref("TypeError")}}, and {{jsxref("Array")}} have their original values and that `callback.call` evaluates to the original value of {{jsxref("Function.prototype.call")}}.
 
 ```js
 // Production steps of ECMA-262, Edition 5, 15.4.4.19

--- a/files/zh-tw/web/javascript/reference/global_objects/dataview/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/dataview/index.md
@@ -28,7 +28,7 @@ A new `DataView` object representing the specified data buffer.
 
 ### Errors thrown
 
-- `{{jsxref("RangeError")}}`
+- {{jsxref("RangeError")}}
   - : Thrown if the `byteOffset` and `byteLength` result in the specified view extending past the end of the buffer.
 
 ## 描述

--- a/files/zh-tw/web/javascript/reference/global_objects/promise/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/promise/index.md
@@ -35,7 +35,7 @@ new Promise( /* executor */ function(resolve, reject) { ... } );
 
 一個處於擱置狀態的 promise 能以一個值被實現（fulfilled），或是以一個原因或錯誤而被拒絕（rejected）。當上述任一狀態轉換發生時，那些透過 `then` 方法所繫結（associated）的處理函式列隊就會依序被調用。（若一個 promise 已被實現或拒絕，繫結（attached）於它的處理函式將立即被呼叫，因此完成非同步操作與繫結處理函式之間不存在競爭條件（race condition）。）
 
-由於 `{{jsxref("Promise.then", "Promise.prototype.then()")}}` 以及 `{{jsxref("Promise.catch", "Promise.prototype.catch()")}}` 方法都回傳 promise，它們可以被串接。
+由於 {{jsxref("Promise.then", "Promise.prototype.then()")}} 以及 {{jsxref("Promise.catch", "Promise.prototype.catch()")}} 方法都回傳 promise，它們可以被串接。
 
 ![](https://cdn.rawgit.com/Vectaio/a76330b025baf9bcdf07cb46e5a9ef9e/raw/26c4213a93dee1c39611dcd0ec12625811b20a26/js-promise.svg)
 


### PR DESCRIPTION
### Description

remove unnecessary code wrapper, as the macro `jsxref` would add `<code>` wrapper.

Using ``` `(\{\{\s*jsxref[^\}]+\}\})` ``` to find and replace them with `$1`.
