### PR TITLE
chore(fr): remove unnecessary code wrapper

### DIFF
--- a/files/fr/web/javascript/reference/global_objects/intl/locale/maximize/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/locale/maximize/index.md
@@ -25,7 +25,7 @@ locale.maximize()
 
 ### Valeur de retour
 
-Une instance {{jsxref("Locale", "Locale")}} dont la propriété `baseName` renvoie le résultat de l'algorithme de [vraisemblance des composantes](https://www.unicode.org/reports/tr35/#Likely_Subtags) lancé sur `{{jsxref("Locale/baseName", "locale.baseName")}}`.
+Une instance {{jsxref("Locale", "Locale")}} dont la propriété `baseName` renvoie le résultat de l'algorithme de [vraisemblance des composantes](https://www.unicode.org/reports/tr35/#Likely_Subtags) lancé sur {{jsxref("Locale/baseName", "locale.baseName")}}.
 
 ## Description
 

--- a/files/fr/web/javascript/reference/operators/nullish_coalescing/index.md
+++ b/files/fr/web/javascript/reference/operators/nullish_coalescing/index.md
@@ -14,7 +14,7 @@ original_slug: Web/JavaScript/Reference/Operators/Nullish_coalescing_operator
 
 {{JSSidebar("Operators")}}
 
-L'**opérateur de coalescence des nuls** (`??`), est un opérateur logique qui renvoie son opérande de droite lorsque son opérande de gauche vaut `{{jsxref("null")}}` ou `{{jsxref("undefined")}}` et qui renvoie son opérande de gauche sinon.
+L'**opérateur de coalescence des nuls** (`??`), est un opérateur logique qui renvoie son opérande de droite lorsque son opérande de gauche vaut {{jsxref("null")}} ou {{jsxref("undefined")}} et qui renvoie son opérande de gauche sinon.
 
 Contrairement à [l'opérateur logique OU (`||`)](/fr/docs/Web/JavaScript/Reference/Op%C3%A9rateurs/Op%C3%A9rateurs_logiques), l'opérande de gauche sera renvoyé s'il s'agit d'une [valeur équivalente à `false`](/fr/docs/Glossaire/Falsy) qui n'est ni `null`, ni `undefined`. En d'autres termes, si vous utilisez `||` pour fournir une valeur par défaut à une variable `foo`, vous pourriez rencontrer des comportements inattendus si vous considérez certaines valeurs _falsy_ comme utilisables (par exemple une chaine vide `''` ou `0`). Voir ci-dessous pour plus d'exemples.
 


### PR DESCRIPTION
### Description

remove unnecessary code wrapper, as the macro `jsxref` would add `<code>` wrapper.

Using ``` `(\{\{\s*jsxref[^\}]+\}\})` ``` to find and replace them with `$1`.
