### PR TITLE
[zh-CN] sync Notification event with en-US

### DIFF
--- a/files/zh-cn/web/api/notification/click_event/index.md
+++ b/files/zh-cn/web/api/notification/click_event/index.md
@@ -7,7 +7,7 @@ slug: Web/API/Notification/click_event
 
 {{domxref("Notification")}} 接口的 **`click`** 事件在用户点击显示的 {{domxref("Notification")}} 时候触发。
 
-默认的事件行为是将焦点移动到与通知相关的视窗的[浏览器上下文](https://html.spec.whatwg.org/multipage/browsers.html#browsing-context)。如果你不想要默认行为，在事件对象上调用 {{domxref("Event/preventDefault", "preventDefault()")}}。
+默认的事件行为是将焦点移动到与通知相关[浏览上下文](https://html.spec.whatwg.org/multipage/browsers.html#browsing-context)的视口上。如果你不想要默认行为，请在事件对象上调用 {{domxref("Event/preventDefault", "preventDefault()")}}。
 
 ## 语法
 
@@ -21,15 +21,15 @@ onclick = (event) => {};
 
 ## 事件类型
 
-一个 {{domxref("Event")}}。
+一个通用 {{domxref("Event")}}。
 
 ## 示例
 
-在下面这个例子中，我们使用 onclick 处理程序来监听点击通知的事件，并在新窗口（通过包含一个参数 `'_blank'`）打开一个页面：
+在下面这个例子中，我们使用 onclick 处理器来监听点击通知的事件，并在新窗口（通过包含一个参数 `'_blank'`）打开一个页面：
 
 ```js
 notification.onclick = (event) => {
-  event.preventDefault(); // 阻止浏览器在 Notification 的
+  event.preventDefault(); // 阻止浏览器聚焦于 Notification 的标签页
   window.open("http://www.mozilla.org", "_blank");
 };
 ```

--- a/files/zh-cn/web/api/notification/click_event/index.md
+++ b/files/zh-cn/web/api/notification/click_event/index.md
@@ -45,4 +45,4 @@ notification.onclick = (event) => {
 ## 参见
 
 - {{domxref("Notification")}}
-- [使用 Notifications API](/zh-CN/docs/Web/API/Notifications_API/Using_the_Notifications_API)
+- [使用 Notification API](/zh-CN/docs/Web/API/Notifications_API/Using_the_Notifications_API)

--- a/files/zh-cn/web/api/notification/click_event/index.md
+++ b/files/zh-cn/web/api/notification/click_event/index.md
@@ -1,42 +1,48 @@
 ---
-title: Notification.onclick
+title: Notification：click 事件
 slug: Web/API/Notification/click_event
 ---
 
-{{APIRef("Web Notifications")}}
+{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 
-{{domxref("Notification")}} 接口的 onclick 属性指定一个事件侦听器来接收 [`click`](/zh-CN/docs/Web/API/Element/click_event) 事件。
+{{domxref("Notification")}} 接口的 **`click`** 事件在用户点击显示的 {{domxref("Notification")}} 时候触发。
 
-当用户点击一个显示的{{domxref("Notification")}}时，会发生这些事件。
+默认的事件行为是将焦点移动到与通知相关的视窗的[浏览器上下文](https://html.spec.whatwg.org/multipage/browsers.html#browsing-context)。如果你不想要默认行为，在事件对象上调用 {{domxref("Event/preventDefault", "preventDefault()")}}。
 
-## Syntax
+## 语法
 
-```plain
-Notification.onclick = function(event) { ... };
-```
-
-该方法的默认行为是将焦点移到与该通知相关联的 [browsing context](https://html.spec.whatwg.org/multipage/browsers.html#browsing-context) 的窗口。如果你不希望这样，可以在 event 对象上调用 [`preventDefault()`](/zh-CN/docs/Web/API/Event/preventDefault).
-
-## Examples
-
-在下面这个例子中，我们使用 onclick 处理程序来监听点击通知的事件，并在新窗口 (通过包含一个参数`'_blank'`) 打开一个页面：
+在类似 {{domxref("EventTarget.addEventListener", "addEventListener()")}} 这样的方法中使用事件名称，或者设置事件处理器属性。
 
 ```js
-notification.onclick = function(event) {
-  event.preventDefault(); // prevent the browser from focusing the Notification's tab
-  window.open('http://www.mozilla.org', '_blank');
-}
+addEventListener("click", (event) => {});
+
+onclick = (event) => {};
 ```
 
-## Specifications
+## 事件类型
+
+一个 {{domxref("Event")}}。
+
+## 示例
+
+在下面这个例子中，我们使用 onclick 处理程序来监听点击通知的事件，并在新窗口（通过包含一个参数 `'_blank'`）打开一个页面：
+
+```js
+notification.onclick = (event) => {
+  event.preventDefault(); // 阻止浏览器在 Notification 的
+  window.open("http://www.mozilla.org", "_blank");
+};
+```
+
+## 规范
 
 {{Specifications}}
 
-## Browser compatibility
+## 浏览器兼容性
 
 {{Compat}}
 
-## See also
+## 参见
 
 - {{domxref("Notification")}}
-- [Using the Notifications API](/zh-CN/docs/Web/API/Notifications_API/Using_the_Notifications_API)
+- [使用 Notifications API](/zh-CN/docs/Web/API/Notifications_API/Using_the_Notifications_API)

--- a/files/zh-cn/web/api/notification/close_event/index.md
+++ b/files/zh-cn/web/api/notification/close_event/index.md
@@ -19,7 +19,7 @@ onclose = (event) => {};
 
 ## 事件类型
 
-一个 {{domxref("Event")}}。
+一个通用 {{domxref("Event")}}。
 
 ## 浏览器兼容性
 

--- a/files/zh-cn/web/api/notification/close_event/index.md
+++ b/files/zh-cn/web/api/notification/close_event/index.md
@@ -1,25 +1,31 @@
 ---
-title: Notification.onclose
+title: Notification：close 事件
 slug: Web/API/Notification/close_event
 ---
 
-{{APIRef("Web Notifications")}}
+{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 
-{{domxref("Notification")}} 接口的 **onclose** 属性指定一个事件侦听器来接收 `close` 事件。
+{{domxref("Notification")}} 接口上的 **`close`** 事件在一个 {{domxref("Notification")}} 被关闭时触发。
 
-当一个{{domxref("Notification")}}关闭时，会发生这些事件。
+## 语法
 
-## Syntax
+在类似 {{domxref("EventTarget.addEventListener", "addEventListener()")}} 这样的方法中使用事件名称，或者设置事件处理器属性。
 
-```plain
-Notification.onclose = function() { ... };
+```js
+addEventListener("close", (event) => {});
+
+onclose = (event) => {};
 ```
 
-## Browser compatibility
+## 事件类型
+
+一个 {{domxref("Event")}}。
+
+## 浏览器兼容性
 
 {{Compat}}
 
-## See also
+## 参见
 
 - {{domxref("Notification")}}
-- [Using the Notifications API](/zh-CN/docs/Web/API/Notifications_API/Using_the_Notifications_API)
+- [使用 Notification API](/zh-CN/docs/Web/API/Notifications_API/Using_the_Notifications_API)

--- a/files/zh-cn/web/api/notification/error_event/index.md
+++ b/files/zh-cn/web/api/notification/error_event/index.md
@@ -5,7 +5,7 @@ slug: Web/API/Notification/error_event
 
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 
-{{domxref("Notification")}} 接口的 **`error`** 事件在 {{domxref("Notification")}} 调用出错时候触发（在许多情况下，错误阻止通知被显示）。
+{{domxref("Notification")}} 接口的 **`error`** 事件在 {{domxref("Notification")}} 调用出错时候触发（在许多情况下，错误会阻止通知的显示）。
 
 ## 语法
 
@@ -19,7 +19,7 @@ onerror = (event) => {};
 
 ## 事件类型
 
-一个 {{domxref("Event")}}。
+一个通用 {{domxref("Event")}}。
 
 ## 规范
 

--- a/files/zh-cn/web/api/notification/error_event/index.md
+++ b/files/zh-cn/web/api/notification/error_event/index.md
@@ -1,23 +1,25 @@
 ---
-title: Notification.onerror
+title: Notification：error 事件
 slug: Web/API/Notification/error_event
 ---
 
-{{APIRef("Web Notifications")}}
+{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 
-{{domxref("Notification")}} 接口的 onerror 属性指定一个事件侦听器来接收 [`error`](/zh-CN/docs/Web/API/Element/error_event) 事件。
+{{domxref("Notification")}} 接口的 **`error`** 事件在 {{domxref("Notification")}} 调用出错时候触发（在许多情况下，错误阻止通知被显示）。
 
-当一个 {{domxref("Notification")}} 发生错误时，会发生这些事件（在许多情况下，一个错误阻止显示通知）。
+## 语法
 
-## Syntax
+在类似 {{domxref("EventTarget.addEventListener", "addEventListener()")}} 这样的方法中使用事件名称，或者设置事件处理器属性。
 
-```plain
-Notification.onerror = EventListener;
+```js
+addEventListener("error", (event) => {});
+
+onerror = (event) => {};
 ```
 
-### Value
+## 事件类型
 
-A {{jsxref("function")}} which serves as the event handler for the [`error`](/zh-CN/docs/Web/API/Element/error_event) event. When an error occurs, the specified function will be called. If `null`, no error handler is in effect.
+一个 {{domxref("Event")}}。
 
 ## 规范
 
@@ -27,7 +29,7 @@ A {{jsxref("function")}} which serves as the event handler for the [`error`](/zh
 
 {{Compat}}
 
-## See also
+## 参见
 
 - {{domxref("Notification")}}
-- [Using the Notifications API](/zh-CN/docs/Web/API/Notifications_API/Using_the_Notifications_API)
+- [使用 Notification API](/zh-CN/docs/Web/API/Notifications_API/Using_the_Notifications_API)

--- a/files/zh-cn/web/api/notification/show_event/index.md
+++ b/files/zh-cn/web/api/notification/show_event/index.md
@@ -19,7 +19,7 @@ onshow = (event) => {};
 
 ## 事件类型
 
-一个 {{domxref("Event")}}。
+一个通用 {{domxref("Event")}}。
 
 ## 浏览器兼容性
 

--- a/files/zh-cn/web/api/notification/show_event/index.md
+++ b/files/zh-cn/web/api/notification/show_event/index.md
@@ -1,25 +1,31 @@
 ---
-title: Notification.onshow
+title: Notification：show 事件
 slug: Web/API/Notification/show_event
 ---
 
-{{APIRef("Web Notifications")}}
+{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 
-{{domxref("Notification")}} 接口的 onshow 属性指定一个事件侦听器来接收 [`show`](/zh-CN/docs/Web/API/Element/show_event)事件。
+{{domxref("Notification")}} 接口上的 **`show`** 事件在一个 {{domxref("Notification")}} 显示时触发。
 
-当一个 {{domxref("Notification")}} 显示时，会发生这些事件。
+## 语法
 
-## Syntax
+在类似 {{domxref("EventTarget.addEventListener", "addEventListener()")}} 这样的方法中使用事件名称，或者设置事件处理器属性。
 
-```plain
-Notification.onshow = function() { ... };
+```js
+addEventListener("show", (event) => {});
+
+onshow = (event) => {};
 ```
 
-## Browser compatibility
+## 事件类型
+
+一个 {{domxref("Event")}}。
+
+## 浏览器兼容性
 
 {{Compat}}
 
-## See also
+## 参见
 
 - {{domxref("Notification")}}
-- [Using the Notifications API](/zh-CN/docs/Web/API/Notifications_API/Using_the_Notifications_API)
+- [使用 Notification API](/zh-CN/docs/Web/API/Notifications_API/Using_the_Notifications_API)


### PR DESCRIPTION
### Description

sync Notification event with en-US

### Motivation

### Additional details

[https://developer.mozilla.org/en-US/docs/Web/API/Notification/click_event]()
[https://developer.mozilla.org/en-US/docs/Web/API/Notification/close_event]()
[https://developer.mozilla.org/en-US/docs/Web/API/Notification/error_event]()
[https://developer.mozilla.org/en-US/docs/Web/API/Notification/show_event]()

### Related issues and pull requests
