### PR TITLE
refactor: migrate media.prod.mdn.mozit.cloud URLs

### DIFF
--- a/files/fr/web/api/filereader/readasdataurl/index.md
+++ b/files/fr/web/api/filereader/readasdataurl/index.md
@@ -103,7 +103,7 @@ function previewFiles() {
 }
 ```
 
-> **Note :** Le constructeur [`FileReader()`](/fr/docs/Web/API/FileReader) n'était pas pris en charge pour les versions d'Internet Explorer antérieures à IE 10. Vous pouvez voir [notre exemple de solution compatible entre les navigateurs pour la prévisualisation d'image](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3699/2c8cb1e94f0ee05b22c1c30a3790c70d/crossbrowser_image_preview.html), ainsi que [cet autre exemple encore plus puissant](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3698/391aef19653595a663cc601c42a67116/image_upload_preview.html).
+> **Note :** Le constructeur [`FileReader()`](/fr/docs/Web/API/FileReader) n'était pas pris en charge pour les versions d'Internet Explorer antérieures à IE 10. Vous pouvez voir [notre exemple de solution compatible entre les navigateurs pour la prévisualisation d'image](https://mdn.dev/archives/media/attachments/2012/07/09/3699/2c8cb1e94f0ee05b22c1c30a3790c70d/crossbrowser_image_preview.html), ainsi que [cet autre exemple encore plus puissant](https://mdn.dev/archives/media/attachments/2012/07/09/3698/391aef19653595a663cc601c42a67116/image_upload_preview.html).
 
 ## Spécifications
 

--- a/files/fr/web/css/filter-function/index.md
+++ b/files/fr/web/css/filter-function/index.md
@@ -78,7 +78,7 @@ Cet exemple fournit une image ainsi qu'un menu pour expérimenter les différent
 div {
   width: 300px;
   height: 300px;
-  background: url(https://media.prod.mdn.mozit.cloud/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png) no-repeat center;
+  background: url(https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png) no-repeat center;
 }
 
 li {

--- a/files/fr/web/css/scaling_of_svg_backgrounds/index.md
+++ b/files/fr/web/css/scaling_of_svg_backgrounds/index.md
@@ -34,7 +34,7 @@ Cette image ne possède ni dimension ni proportion. Quelle que soit sa taille, i
 
 ![](no-dimensions-or-ratio.png)
 
-[Fichier SVG source](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3469/6587a382ffb2c944462a6b110b079496/no-dimensions-or-ratio.svg)
+[Fichier SVG source](https://mdn.dev/archives/media/attachments/2012/07/09/3469/6587a382ffb2c944462a6b110b079496/no-dimensions-or-ratio.svg)
 
 ### Image sans proportion avec une dimension fixée
 
@@ -42,7 +42,7 @@ Cette image mesure 100 pixels de large mais n'a pas de hauteur ni de proportion 
 
 ![](100px-wide-no-height-or-ratio.png)
 
-[Fichier SVG source](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3468/af73bea307a10ffe2559df42fad199e3/100px-wide-no-height-or-ratio.svg)
+[Fichier SVG source](https://mdn.dev/archives/media/attachments/2012/07/09/3468/af73bea307a10ffe2559df42fad199e3/100px-wide-no-height-or-ratio.svg)
 
 ### Image avec une dimension fixée et des proportions intrinsèques
 
@@ -52,7 +52,7 @@ On a ici un cas très proche de l'image pour laquelle on définit une largeur et
 
 ![](100px-height-3x4-ratio.png)
 
-[Fichier SVG source](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3467/fd0c534c506be06d52f0a954a59863a6/100px-height-3x4-ratio.svg)
+[Fichier SVG source](https://mdn.dev/archives/media/attachments/2012/07/09/3467/fd0c534c506be06d52f0a954a59863a6/100px-height-3x4-ratio.svg)
 
 ### Image sans largeur ni hauteur mais avec des proportions intrinsèques
 
@@ -60,7 +60,7 @@ Cette image n'indique pas de hauteur ou de largeur mais un ratio intrinsèque de
 
 ![](no-dimensions-1x1-ratio.png)
 
-[Fichier SVG source](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3466/a3398e03c058d99fb2b7837167cdbc26/no-dimensions-1x1-ratio.svg)
+[Fichier SVG source](https://mdn.dev/archives/media/attachments/2012/07/09/3466/a3398e03c058d99fb2b7837167cdbc26/no-dimensions-1x1-ratio.svg)
 
 ## Exemples de redimensionnement
 

--- a/files/fr/web/events/creating_and_triggering_events/index.md
+++ b/files/fr/web/events/creating_and_triggering_events/index.md
@@ -120,7 +120,7 @@ textarea.addEventListener('input', function() {
 
 ## Déclencher des évènements natifs
 
-Cet exemple illustre la simulation d'un clic (ce qui revient à générer l'évènement d'un clic depuis le programme) sur une case à cocher grâce aux méthodes du DOM. [Voir l'exemple en action.](https://media.prod.mdn.mozit.cloud/samples/domref/dispatchEvent.html)
+Cet exemple illustre la simulation d'un clic (ce qui revient à générer l'évènement d'un clic depuis le programme) sur une case à cocher grâce aux méthodes du DOM. [Voir l'exemple en action.](https://mdn.dev/archives/media/samples/domref/dispatchEvent.html)
 
 ```js
 function simulateClick() {

--- a/files/fr/web/svg/tutorial/getting_started/index.md
+++ b/files/fr/web/svg/tutorial/getting_started/index.md
@@ -29,7 +29,7 @@ Commençons directement avec un exemple pratique. Jetez un coup d'œil au morcea
 </svg>
 ```
 
-Copiez le code précédent dans un document texte, puis enregistrez-le sous le nom de _demo1.svg_. Ouvrez le fichier dans Firefox. Vous obtiendrez alors l'image suivante (pour les utilisateurs de Firefox : cliquez [ici](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3075/89b1e0a26e8421e19f907e0522b188bd/svgdemo1.xml))
+Copiez le code précédent dans un document texte, puis enregistrez-le sous le nom de _demo1.svg_. Ouvrez le fichier dans Firefox. Vous obtiendrez alors l'image suivante (pour les utilisateurs de Firefox : cliquez [ici](https://mdn.dev/archives/media/attachments/2012/07/09/3075/89b1e0a26e8421e19f907e0522b188bd/svgdemo1.xml))
 
 ![une image avec un rectangle rouge contenant un disque vert dans lequel est écrit SVG en blanc](svgdemo1.png)
 

--- a/files/ja/learn/css/first_steps/styling_a_biography_page/index.md
+++ b/files/ja/learn/css/first_steps/styling_a_biography_page/index.md
@@ -41,7 +41,7 @@ original_slug: Learn/CSS/First_steps/Using_your_new_knowledge
 
 完成したら次の画像のようになるはずです。
 
-![](https://media.prod.mdn.mozit.cloud/attachments/2019/12/31/17035/da8ff2a04da214e57e18a6ea3ac6832e/learn-css-basics-assessment.png)
+![](https://mdn.dev/archives/media/attachments/2019/12/31/17035/da8ff2a04da214e57e18a6ea3ac6832e/learn-css-basics-assessment.png)
 
 それから、このページに書かれていない属性をみてみましょう。[MDN の CSS リファレンス](/ja/docs/Web/CSS/Reference) には冒険が待っています!
 

--- a/files/ja/web/api/document/beforescriptexecute_event/index.md
+++ b/files/ja/web/api/document/beforescriptexecute_event/index.md
@@ -34,7 +34,7 @@ document.addEventListener('beforescriptexecute', starting, true);
 document.onbeforescriptexecute = starting;
 ```
 
-[ライブ例を表示](https://media.prod.mdn.mozit.cloud/samples/html/currentScript.html)
+[ライブ例を表示](https://mdn.dev/archives/media/samples/html/currentScript.html)
 
 ## 仕様書
 

--- a/files/ja/web/api/document/currentscript/index.md
+++ b/files/ja/web/api/document/currentscript/index.md
@@ -27,7 +27,7 @@ if (document.currentScript.async) {
 }
 ```
 
-[実際の表示を確認](https://media.prod.mdn.mozit.cloud/samples/html/currentScript.html)
+[実際の表示を確認](https://mdn.dev/archives/media/samples/html/currentScript.html)
 
 ## 仕様書
 

--- a/files/ja/web/api/domimplementation/createhtmldocument/index.md
+++ b/files/ja/web/api/domimplementation/createhtmldocument/index.md
@@ -71,7 +71,7 @@ function makeDocument() {
 
 16 行目はフレームの `contentDocument` を取り出しています。これは新しいコンテンツを注入する文書内のものです。次の 2 行は、新しい文書のコンテンツを新しい文書のコンテキストにインポートする処理です。最後に、20 行目で実際にフレームのコンテンツを新しい文書のコンテンツに置き換えます。
 
-[ライブサンプルを見る](https://media.prod.mdn.mozit.cloud/samples/domref/createHTMLDocument.html)
+[ライブサンプルを見る](https://mdn.dev/archives/media/samples/domref/createHTMLDocument.html)
 
 返される文書は、以下の HTML であらかじめ構成されたものになります。
 

--- a/files/ja/web/api/element/setcapture/index.md
+++ b/files/ja/web/api/element/setcapture/index.md
@@ -76,7 +76,7 @@ setCapture(retargetToElement)
 </html>
 ```
 
-[ライブ例を表示](https://media.prod.mdn.mozit.cloud/samples/domref/mousecapture.html)
+[ライブ例を表示](https://mdn.dev/archives/media/samples/domref/mousecapture.html)
 
 ## メモ
 

--- a/files/ja/web/api/filereader/readasdataurl/index.md
+++ b/files/ja/web/api/filereader/readasdataurl/index.md
@@ -97,7 +97,7 @@ function previewFiles() {
 }
 ```
 
-> **メモ:** Internet Explorer 10 以前では [`FileReader()`](/ja/docs/Web/API/FileReader) コンストラクターに対応していません。十分な互換性が必要とされるときは、[画像プレビューのクロスブラウザー対応ソリューション](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3699/2c8cb1e94f0ee05b22c1c30a3790c70d/crossbrowser_image_preview.html)または[もっと強力な例](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3698/391aef19653595a663cc601c42a67116/image_upload_preview.html)を参照してください。
+> **メモ:** Internet Explorer 10 以前では [`FileReader()`](/ja/docs/Web/API/FileReader) コンストラクターに対応していません。十分な互換性が必要とされるときは、[画像プレビューのクロスブラウザー対応ソリューション](https://mdn.dev/archives/media/attachments/2012/07/09/3699/2c8cb1e94f0ee05b22c1c30a3790c70d/crossbrowser_image_preview.html)または[もっと強力な例](https://mdn.dev/archives/media/attachments/2012/07/09/3698/391aef19653595a663cc601c42a67116/image_upload_preview.html)を参照してください。
 
 ## 仕様書
 

--- a/files/ja/web/api/fullscreen_api/guide/index.md
+++ b/files/ja/web/api/fullscreen_api/guide/index.md
@@ -93,7 +93,7 @@ if (elem.requestFullscreen) {
 
 この例では、ウェブページの中に動画を表示しています。<kbd>Return</kbd> または <kbd>Enter</kbd> キーを押すと、ユーザーは動画のウィンドウ表示と全画面表示を切り替えて表示することができます。
 
-[ライブ例の表示](https://media.prod.mdn.mozit.cloud/samples/domref/fullscreen.html)
+[ライブ例の表示](https://mdn.dev/archives/media/samples/domref/fullscreen.html)
 
 ### Enter キーの監視
 

--- a/files/ja/web/css/background-position-x/index.md
+++ b/files/ja/web/css/background-position-x/index.md
@@ -83,7 +83,7 @@ div {
   width: 300px;
   height: 300px;
   background-color: skyblue;
-  background-image: url(https://media.prod.mdn.mozit.cloud/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png);
+  background-image: url(https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png);
   background-repeat: no-repeat;
   background-position-x: center;
   background-position-y: bottom 10px;

--- a/files/ja/web/css/background-position-y/index.md
+++ b/files/ja/web/css/background-position-y/index.md
@@ -83,7 +83,7 @@ div {
   width: 300px;
   height: 300px;
   background-color: skyblue;
-  background-image: url(https://media.prod.mdn.mozit.cloud/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png);
+  background-image: url(https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png);
   background-repeat: no-repeat;
   background-position-x: center;
   background-position-y: bottom 10px;

--- a/files/ja/web/css/blend-mode/index.md
+++ b/files/ja/web/css/blend-mode/index.md
@@ -386,7 +386,7 @@ l10n:
 div {
   width: 300px;
   height: 300px;
-  background: url(https://media.prod.mdn.mozit.cloud/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png)
+  background: url(https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png)
       no-repeat center, linear-gradient(to bottom, blue, orange);
 }
 ```

--- a/files/ja/web/css/box-decoration-break/index.md
+++ b/files/ja/web/css/box-decoration-break/index.md
@@ -92,13 +92,13 @@ box-decoration-break: clone;
 
 ![box-decoration-break:clone と例で与えられたスタイルでスタイル付けされたインライン要素のレンダリングの画面ショット](box-decoration-break-inline-clone.png)
 
-ブラウザーで[上記の 2 つのインラインの例を試してみる](https://media.prod.mdn.mozit.cloud/attachments/2014/07/12/8179/df096e9eb57177d8b7fdcd0c8f64ef18/box-decoration-break-inline.html)ことができます。
+ブラウザーで[上記の 2 つのインラインの例を試してみる](https://mdn.dev/archives/media/attachments/2014/07/12/8179/df096e9eb57177d8b7fdcd0c8f64ef18/box-decoration-break-inline.html)ことができます。
 
 これはインライン要素に大きな `border-radius` の値を使用した例です。二番目の `"iM"` には、 `"i"` と `"M"` の間に改行があります。それに対して、最初の `"iM"` には改行がありません。なお、２つの断片の描画結果を水平に並べると、断片化されていない描画結果と同じになります。
 
 ![2 つ目のインライン要素の例のレンダリングのスクリーンショット。](box-decoration-break-slice-inline-2.png)
 
-ブラウザーで[上の例を試してみる](https://media.prod.mdn.mozit.cloud/attachments/2014/07/12/8191/7a067e5731355081e856ea02b978ea2e/box-decoration-break-inline-extreme.html)ことができます。
+ブラウザーで[上の例を試してみる](https://mdn.dev/archives/media/attachments/2014/07/12/8191/7a067e5731355081e856ea02b978ea2e/box-decoration-break-inline-extreme.html)ことができます。
 
 ### ブロックボックスの断片化
 
@@ -118,7 +118,7 @@ box-decoration-break: clone;
 
 それぞれの断片に同じ境界線、ボックスの影、背景が複製されることに注意してください。
 
-ブラウザーで[上の例を試してみる](https://media.prod.mdn.mozit.cloud/attachments/2014/07/12/8187/6288bde9d276d78e203c9f8b9a26ff65/box-decoration-break-block.html)ことができます。
+ブラウザーで[上の例を試してみる](https://mdn.dev/archives/media/attachments/2014/07/12/8187/6288bde9d276d78e203c9f8b9a26ff65/box-decoration-break-block.html)ことができます。
 
 ## 仕様書
 

--- a/files/ja/web/css/break-inside/index.md
+++ b/files/ja/web/css/break-inside/index.md
@@ -82,7 +82,7 @@ break-inside: unset;
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla vitae fringilla mauris. Quisque commodo eget nisi sed pretium. Mauris luctus nec lacus in ultricies. Mauris vitae hendrerit arcu, ac scelerisque lacus. Aliquam lobortis in lacus sit amet posuere. Fusce iaculis urna id neque dapibus, eu lacinia lectus dictum.</p>
 
   <figure>
-    <img src="https://media.prod.mdn.mozit.cloud/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png">
+    <img src="https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png">
     <figcaption>The Firefox logo — fox wrapped around the world</figcaption>
   </figure>
 

--- a/files/ja/web/css/element/index.md
+++ b/files/ja/web/css/element/index.md
@@ -25,7 +25,7 @@ element(id)
 
 ## 例
 
-この例を[ライブで見る](https://media.prod.mdn.mozit.cloud/samples/cssref/moz-element.html)には、`-moz-element()` に対応している Firefox が必要です。
+この例を[ライブで見る](https://mdn.dev/archives/media/samples/cssref/moz-element.html)には、`-moz-element()` に対応している Firefox が必要です。
 
 <h3 id="A_somewhat_realistic_example">いくらか現実的な例</h3>
 

--- a/files/ja/web/css/filter-function/index.md
+++ b/files/ja/web/css/filter-function/index.md
@@ -73,7 +73,7 @@ slug: Web/CSS/filter-function
 div {
   width: 300px;
   height: 300px;
-  background: url(https://media.prod.mdn.mozit.cloud/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png) no-repeat center;
+  background: url(https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png) no-repeat center;
 }
 
 li {

--- a/files/ja/web/events/creating_and_triggering_events/index.md
+++ b/files/ja/web/events/creating_and_triggering_events/index.md
@@ -113,7 +113,7 @@ textarea.addEventListener('input', function() {
 
 ### 組み込みイベントの起動
 
-この例では、 DOM メソッドを使用してチェックボックスでクリック (プログラムでクリックイベントを生成する) をシミュレートする方法を示します。[デモを見る](https://media.prod.mdn.mozit.cloud/samples/domref/dispatchEvent.html)。
+この例では、 DOM メソッドを使用してチェックボックスでクリック (プログラムでクリックイベントを生成する) をシミュレートする方法を示します。[デモを見る](https://mdn.dev/archives/media/samples/domref/dispatchEvent.html)。
 
 ```js
 function simulateClick() {

--- a/files/ko/web/css/blend-mode/index.md
+++ b/files/ko/web/css/blend-mode/index.md
@@ -402,7 +402,7 @@ In the following example, we have a `<div>` with two background images set on it
 div {
   width: 300px;
   height: 300px;
-  background: url(https://media.prod.mdn.mozit.cloud/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png) no-repeat center,
+  background: url(https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png) no-repeat center,
   linear-gradient(to bottom, blue, orange);
 }
 ```

--- a/files/ko/web/css/filter-function/index.md
+++ b/files/ko/web/css/filter-function/index.md
@@ -72,7 +72,7 @@ slug: Web/CSS/filter-function
 div {
   width: 300px;
   height: 300px;
-  background: url(https://media.prod.mdn.mozit.cloud/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png) no-repeat center;
+  background: url(https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png) no-repeat center;
 }
 
 li {

--- a/files/ko/web/svg/tutorial/getting_started/index.md
+++ b/files/ko/web/svg/tutorial/getting_started/index.md
@@ -24,7 +24,7 @@ slug: Web/SVG/Tutorial/Getting_Started
 </svg>
 ```
 
-코드를 복사하여 demo1.svg로 저장하고, 파이어폭스 에서 실행해 봅시다. 아래와 같은 화면이 그려질 것입니다.(Firefox 사용자 : [링크](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3075/89b1e0a26e8421e19f907e0522b188bd/svgdemo1.xml))
+코드를 복사하여 demo1.svg로 저장하고, 파이어폭스 에서 실행해 봅시다. 아래와 같은 화면이 그려질 것입니다.(Firefox 사용자 : [링크](https://mdn.dev/archives/media/attachments/2012/07/09/3075/89b1e0a26e8421e19f907e0522b188bd/svgdemo1.xml))
 
 ![빨간색 배경 중앙에 녹색 원이 있습니다. 원 가운데에 있는 흰색 텍스트는 SVG입니다.](svgdemo1.png)
 

--- a/files/ru/mozilla/add-ons/webextensions/what_are_webextensions/index.md
+++ b/files/ru/mozilla/add-ons/webextensions/what_are_webextensions/index.md
@@ -15,37 +15,37 @@ translation_of: Mozilla/Add-ons/WebExtensions/What_are_WebExtensions
 
 **Расширять или дополнять сайты**: Используйте дополнения, чтобы предоставить информацию или дополнительные функции для браузера. Позвольте пользователям собирать информацию с посещённых ими страниц для улучшения предлагаемых вами услуг.
 
-![Пример использования Amazon Assistant for Firefox](https://media.prod.mdn.mozit.cloud/attachments/2018/02/13/15808/f81a8cc5b196af29cd9d558ee3c5dbdc/Amazon_add_on.png)
+![Пример использования Amazon Assistant for Firefox](https://mdn.dev/archives/media/attachments/2018/02/13/15808/f81a8cc5b196af29cd9d558ee3c5dbdc/Amazon_add_on.png)
 
 Примеры: [Amazon Assistant for Firefox](https://addons.mozilla.org/en-US/firefox/addon/amazon-browser-bar/), [OneNote Web Clipper](https://addons.mozilla.org/en-US/firefox/addon/onenote-clipper/) и [Grammarly for Firefox](https://addons.mozilla.org/en-US/firefox/addon/grammarly-1/).
 
 **Дайте пользователям продемонстрировать себя**: Дополнения могут управлять содержимым сайтов, например, позволять пользователям добавлять их любимые изображения как фоновые картинки для каждого сайта, которые они посещают. Ещё дополнения могут изменять и то, как выглядит сам интерфейс Firefox, делая это тем же способом, что и [обычные темы](/ru/docs/Mozilla/Add-ons/Themes/Theme_concepts).
 
-![Как расширение может изменить фоновую картинку сайта](https://media.prod.mdn.mozit.cloud/attachments/2018/02/13/15809/ce69d140dc91da804ce6eb8f20d03c07/MyWeb_New_Tab_add_on.png)
+![Как расширение может изменить фоновую картинку сайта](https://mdn.dev/archives/media/attachments/2018/02/13/15809/ce69d140dc91da804ce6eb8f20d03c07/MyWeb_New_Tab_add_on.png)
 
 Примеры: [MyWeb New Tab](https://addons.mozilla.org/en-US/firefox/addon/myweb-new-tab/), [Tabliss](https://addons.mozilla.org/en-US/firefox/addon/tabliss/) и [VivaldiFox](https://addons.mozilla.org/en-US/firefox/addon/vivaldifox/).
 
 **Добавьте или скройте содержимое веб-страниц**: Возможно, вы захотите помочь пользователям заблокировать назойливую рекламу, дать доступ к туристическим путеводителям, когда на странице упоминается страна или город, или отформатировать содержимое страницы так, чтобы дать незабываемый опыт прочтения. С доступом к HTML и CSS дополнения могут помогать пользователям смотреть на Интернет так, как они хотят.
 
-![Как работает uBlock Origin, популярный блокировщик рекламы](https://media.prod.mdn.mozit.cloud/attachments/2018/02/13/15807/4e85eb0560fc8d5945e64cf75a1a8e50/ublock_origin_add_on.png)
+![Как работает uBlock Origin, популярный блокировщик рекламы](https://mdn.dev/archives/media/attachments/2018/02/13/15807/4e85eb0560fc8d5945e64cf75a1a8e50/ublock_origin_add_on.png)
 
 Примеры: [uBlock Origin](https://addons.mozilla.org/en-US/firefox/addon/ublock-origin/), [Reader](https://addons.mozilla.org/en-US/firefox/addon/reader/) и [Toolbox for Google Play Store™](https://addons.mozilla.org/en-US/firefox/addon/toolbox-google-play-store/).
 
 **Дайте новые инструменты и функции**: Добавляйте новые пункты в список дел или генерируйте QR-коды для текста страницы или различных ссылок. При помощи гибких опций интерфейса и мощью WebExtensions API вы можете с лёгкостью добавлять новые функции в браузер. Причём вы можете расширить таким образом функциональность любого сайта, он не обязательно должен быть вашим.
 
-![Как выглядит генератор QR-кодов QRUTILS.com](https://media.prod.mdn.mozit.cloud/attachments/2018/02/13/15806/b9070a5f71c40c18d0a4ae722bca2e4a/QR_Code_Image_Generator_add_on.png)
+![Как выглядит генератор QR-кодов QRUTILS.com](https://mdn.dev/archives/media/attachments/2018/02/13/15806/b9070a5f71c40c18d0a4ae722bca2e4a/QR_Code_Image_Generator_add_on.png)
 
 Примеры: [Swimlanes for Trello](https://addons.mozilla.org/en-US/firefox/addon/swimlanes-for-trello/) и [Tomato Clock](https://addons.mozilla.org/en-US/firefox/addon/tomato-clock/).
 
 **Игры**: Давайте геймерам тот же опыт, что и в традиционных компьютерных играх - или же исследуйте новые игровые возможности, например, внедряя геймплей в ежедневный просмотр веб-страниц.
 
-![Пример игры Asteroids in Popup](https://media.prod.mdn.mozit.cloud/attachments/2018/02/13/15805/259d5d3c0620469521d43a897a7b653b/Asteroids_in_Popup_add_on%20.png)
+![Пример игры Asteroids in Popup](https://mdn.dev/archives/media/attachments/2018/02/13/15805/259d5d3c0620469521d43a897a7b653b/Asteroids_in_Popup_add_on%20.png)
 
 Примеры: [Asteroids in Popup](https://addons.mozilla.org/en-US/firefox/addon/asteroids-in-popup/), [Solitaire Card Game New Tab](https://addons.mozilla.org/en-US/firefox/addon/solitaire-card-game-new-tab/) и [2048 Prime](https://addons.mozilla.org/en-US/firefox/addon/2048-prime/).
 
 **Добавляйте инструменты для разработки**: вы можете предлагать инструменты разработки как часть вашего бизнеса, или же как то, что вы нового открыли для веб-разработки и чем хотите поделиться. Например, вы можете добавлять свои инструменты во встроенный набор инструментов разработчика Firefox.
 
-![То, как интегрируется aXe в инструменты разработчика Firefox](https://media.prod.mdn.mozit.cloud/attachments/2018/02/13/15804/a2f3ed2cd857626d42352dd0de550486/aXe_Developer_Tools_add_on.png)
+![То, как интегрируется aXe в инструменты разработчика Firefox](https://mdn.dev/archives/media/attachments/2018/02/13/15804/a2f3ed2cd857626d42352dd0de550486/aXe_Developer_Tools_add_on.png)
 
 Примеры: [Web Developer](https://addons.mozilla.org/en-US/firefox/addon/web-developer/), [Web React Developer Tools](https://addons.mozilla.org/en-US/firefox/addon/react-devtools/) и [aXe Developer Tools](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/).
 

--- a/files/zh-cn/web/api/filereader/readasdataurl/index.md
+++ b/files/zh-cn/web/api/filereader/readasdataurl/index.md
@@ -92,7 +92,7 @@ function previewFiles() {
 }
 ```
 
-> **备注：** Internet Explorer 10 之前的版本并不支持 [`FileReader()`](/zh-CN/docs/Web/API/FileReader)。关于图片文件预览的兼容性解决方案，可以查看[一种可能的跨浏览器图像预览解决方案](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3699/2c8cb1e94f0ee05b22c1c30a3790c70d/crossbrowser_image_preview.html)或者[这个更加完善的示例](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3698/391aef19653595a663cc601c42a67116/image_upload_preview.html)。
+> **备注：** Internet Explorer 10 之前的版本并不支持 [`FileReader()`](/zh-CN/docs/Web/API/FileReader)。关于图片文件预览的兼容性解决方案，可以查看[一种可能的跨浏览器图像预览解决方案](https://mdn.dev/archives/media/attachments/2012/07/09/3699/2c8cb1e94f0ee05b22c1c30a3790c70d/crossbrowser_image_preview.html)或者[这个更加完善的示例](https://mdn.dev/archives/media/attachments/2012/07/09/3698/391aef19653595a663cc601c42a67116/image_upload_preview.html)。
 
 ## 规范
 

--- a/files/zh-cn/web/api/fullscreen_api/guide/index.md
+++ b/files/zh-cn/web/api/fullscreen_api/guide/index.md
@@ -77,7 +77,7 @@ if (elem.requestFullscreen) {
 
 在这个例子中，网页中显示了一个视频。按下 <kbd>Return</kbd> 或 <kbd>Enter</kbd> 键让用户在视频的窗口显示和全屏显示之间切换。
 
-[View Live Examples](https://media.prod.mdn.mozit.cloud/samples/domref/fullscreen.html)
+[View Live Examples](https://mdn.dev/archives/media/samples/domref/fullscreen.html)
 
 ### 监听 <kbd>Enter</kbd> 键
 

--- a/files/zh-cn/web/css/blend-mode/index.md
+++ b/files/zh-cn/web/css/blend-mode/index.md
@@ -390,7 +390,7 @@ slug: Web/CSS/blend-mode
 div {
   width: 300px;
   height: 300px;
-  background: url(https://media.prod.mdn.mozit.cloud/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png)
+  background: url(https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png)
       no-repeat center, linear-gradient(to bottom, blue, orange);
 }
 ```

--- a/files/zh-cn/web/css/box-decoration-break/index.md
+++ b/files/zh-cn/web/css/box-decoration-break/index.md
@@ -89,13 +89,13 @@ box-decoration-break: clone;
 
 ![A screenshot of the rendering of an inline element styled with box-decoration-break:clone and styles given in the example](box-decoration-break-inline-clone.png)
 
-你可以[尝试这两个例子](https://media.prod.mdn.mozit.cloud/attachments/2014/07/12/8179/df096e9eb57177d8b7fdcd0c8f64ef18/box-decoration-break-inline.html)。
+你可以[尝试这两个例子](https://mdn.dev/archives/media/attachments/2014/07/12/8179/df096e9eb57177d8b7fdcd0c8f64ef18/box-decoration-break-inline.html)。
 
 下面是一个使用大圆角值的内联元素示例。第二个“iM”在“i”和“M”之间有一个分界线，作为比较，第一个“iM”是没有换行符的。请注意，如果您将两个片段的呈现水平地排列在一起，就会导致非分段呈现。
 
 ![A screenshot of the rendering of the second inline element example.](box-decoration-break-slice-inline-2.png)
 
-你可以[尝试这个例子](https://media.prod.mdn.mozit.cloud/attachments/2014/07/12/8191/7a067e5731355081e856ea02b978ea2e/box-decoration-break-inline-extreme.html)。
+你可以[尝试这个例子](https://mdn.dev/archives/media/attachments/2014/07/12/8191/7a067e5731355081e856ea02b978ea2e/box-decoration-break-inline-extreme.html)。
 
 ### 块状盒子片段
 
@@ -115,7 +115,7 @@ box-decoration-break: clone;
 
 请注意，每个片段都具有相同的 border、box-shadow 和 background。
 
-你可以[尝试这个例子](https://media.prod.mdn.mozit.cloud/attachments/2014/07/12/8187/6288bde9d276d78e203c9f8b9a26ff65/box-decoration-break-block.html)。
+你可以[尝试这个例子](https://mdn.dev/archives/media/attachments/2014/07/12/8187/6288bde9d276d78e203c9f8b9a26ff65/box-decoration-break-block.html)。
 
 ## 规范
 

--- a/files/zh-cn/web/css/scaling_of_svg_backgrounds/index.md
+++ b/files/zh-cn/web/css/scaling_of_svg_backgrounds/index.md
@@ -30,7 +30,7 @@ SVG 相比其他格式为我们提供了更多的灵活性，与此同时当我�
 
 ![no-dimensions-or-ratio.png](no-dimensions-or-ratio.png)
 
-[SVG 源码](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3469/6587a382ffb2c944462a6b110b079496/no-dimensions-or-ratio.svg)
+[SVG 源码](https://mdn.dev/archives/media/attachments/2012/07/09/3469/6587a382ffb2c944462a6b110b079496/no-dimensions-or-ratio.svg)
 
 ### 指定一个维度的尺寸，但无固定比例
 
@@ -38,7 +38,7 @@ SVG 相比其他格式为我们提供了更多的灵活性，与此同时当我�
 
 ![100px-wide-no-height-or-ratio.png](100px-wide-no-height-or-ratio.png)
 
-[SVG 源码](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3468/af73bea307a10ffe2559df42fad199e3/100px-wide-no-height-or-ratio.svg)
+[SVG 源码](https://mdn.dev/archives/media/attachments/2012/07/09/3468/af73bea307a10ffe2559df42fad199e3/100px-wide-no-height-or-ratio.svg)
 
 ### 指定一个维度的尺寸，有固定比例
 
@@ -46,7 +46,7 @@ SVG 相比其他格式为我们提供了更多的灵活性，与此同时当我�
 
 ![100px-height-3x4-ratio.png](100px-height-3x4-ratio.png)
 
-[SVG 源码](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3467/fd0c534c506be06d52f0a954a59863a6/100px-height-3x4-ratio.svg)
+[SVG 源码](https://mdn.dev/archives/media/attachments/2012/07/09/3467/fd0c534c506be06d52f0a954a59863a6/100px-height-3x4-ratio.svg)
 
 ### 无宽高，有固定比例
 
@@ -54,7 +54,7 @@ SVG 相比其他格式为我们提供了更多的灵活性，与此同时当我�
 
 ![no-dimensions-1x1-ratio.png](no-dimensions-1x1-ratio.png)
 
-[SVG 源码](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3466/a3398e03c058d99fb2b7837167cdbc26/no-dimensions-1x1-ratio.svg)
+[SVG 源码](https://mdn.dev/archives/media/attachments/2012/07/09/3466/a3398e03c058d99fb2b7837167cdbc26/no-dimensions-1x1-ratio.svg)
 
 ## 缩放示例
 

--- a/files/zh-cn/web/svg/svg_animation_with_smil/index.md
+++ b/files/zh-cn/web/svg/svg_animation_with_smil/index.md
@@ -91,7 +91,7 @@ Firefox 4 利用 [Synchronized Multimedia Integration Language](https://www.w3.o
 
 {{ EmbedLiveSample('示例 1：线性运动', '100%', 120) }}
 
-[查看示例](https://media.prod.mdn.mozit.cloud/samples/svg/svganimdemo1.html)
+[查看示例](https://mdn.dev/archives/media/samples/svg/svganimdemo1.html)
 
 ### 示例 2：曲线运动
 

--- a/files/zh-cn/web/svg/tutorial/getting_started/index.md
+++ b/files/zh-cn/web/svg/tutorial/getting_started/index.md
@@ -26,7 +26,7 @@ slug: Web/SVG/Tutorial/Getting_Started
 </svg>
 ```
 
-复制并粘贴代码到文件 demo1.svg。然后用 Firefox 打开该文件。它将会呈现为下面的截图。(Firefox 用户点击[这里](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3075/89b1e0a26e8421e19f907e0522b188bd/svgdemo1.xml))
+复制并粘贴代码到文件 demo1.svg。然后用 Firefox 打开该文件。它将会呈现为下面的截图。(Firefox 用户点击[这里](https://mdn.dev/archives/media/attachments/2012/07/09/3075/89b1e0a26e8421e19f907e0522b188bd/svgdemo1.xml))
 
 ![svgdemo1.png](svgdemo1.png)
 

--- a/files/zh-tw/web/svg/tutorial/getting_started/index.md
+++ b/files/zh-tw/web/svg/tutorial/getting_started/index.md
@@ -23,7 +23,7 @@ slug: Web/SVG/Tutorial/Getting_Started
 </svg>
 ```
 
-複製這段程式碼，在一個文件裡貼上，給該文件起名為 demo1.svg，然後用 Firefox 打開它，會渲染成下面截圖的樣子。(Firefox 用户: 點[這裡](https://media.prod.mdn.mozit.cloud/attachments/2012/07/09/3075/89b1e0a26e8421e19f907e0522b188bd/svgdemo1.xml))
+複製這段程式碼，在一個文件裡貼上，給該文件起名為 demo1.svg，然後用 Firefox 打開它，會渲染成下面截圖的樣子。(Firefox 用户: 點[這裡](https://mdn.dev/archives/media/attachments/2012/07/09/3075/89b1e0a26e8421e19f907e0522b188bd/svgdemo1.xml))
 
 ![svgdemo1.png](svgdemo1.png)
 


### PR DESCRIPTION
### Description

Migrates URLs linking to https://media.prod.mdn.mozit.cloud/ to point to the archived URL at https://mdn.dev/archives/media/.

### Motivation

The contents of https://media.prod.mdn.mozit.cloud/ have been archived at https://mdn.dev/archives/media/, and we will soon decommission the `media.prod.mdn.mozit.cloud` domain, so those links won't work afterwards.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Related:

- https://github.com/mdn/yari/pull/8873
- https://github.com/mdn/content/pull/26809