### PR TITLE
[ja] Fix polygon tag code for Live sample failed!

### DIFF
--- a/files/ja/web/svg/element/polygon/index.md
+++ b/files/ja/web/svg/element/polygon/index.md
@@ -19,8 +19,7 @@ html,body,svg { height:100% }
   <polygon points="0,100 50,25 50,75 100,0" />
 
   <!-- 同じ多角形で線を持ち塗りつぶされない例 -->
-  <polygon points="100,100 150,25 150,75 200,0"
-            fill="none" stroke="black" />
+  <polygon points="100,100 150,25 150,75 200,0" fill="none" stroke="black" />
 </svg>
 ```
 

--- a/files/ja/web/svg/element/polygon/index.md
+++ b/files/ja/web/svg/element/polygon/index.md
@@ -9,6 +9,8 @@ slug: Web/SVG/Element/polygon
 
 開いた図形については {{SVGElement("polyline")}} 要素をご覧ください。
 
+## 例
+
 ```css hidden
 html,body,svg { height:100% }
 ```
@@ -23,7 +25,7 @@ html,body,svg { height:100% }
 </svg>
 ```
 
-{{EmbedLiveSample('Example', 100, 100)}}
+{{EmbedLiveSample('例', 100, 100)}}
 
 ## 属性
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

It contained unnecessary line breaks in the code.
So, before I fixed it, I got the following error message on https://developer.mozilla.org/ja/docs/Web/SVG/Element/polygon .

```
Live sample failed!
An error occurred trying to render this live sample.
Consider filing an issue or trying your hands at a fix of your own.

Error details:

KumascriptError: unable to find any live code samples for "example" within /ja/docs/Web/SVG/Element/polygon
```

### Failure preview

||screenshot|
|-|-|
||<img width="500" alt="スクリーンショット_2023-05-18_6_38_03" src="https://github.com/mdn/translated-content/assets/27806269/7dd99a96-154a-4bac-bea6-4675f9b72ba0">|


### Additional details

I used the French translation as a reference.
https://github.com/mdn/translated-content/blob/main/files/fr/web/svg/element/polygon/index.md?plain=1#L29
