### PR TITLE
chore(zh): change all CSS spec URLs back to drafts.csswg.org

### DIFF
--- a/files/zh-cn/web/css/-webkit-line-clamp/index.md
+++ b/files/zh-cn/web/css/-webkit-line-clamp/index.md
@@ -13,7 +13,7 @@ slug: Web/CSS/-webkit-line-clamp
 
 当应用于锚（anchor）元素时，截断可以发生在文本中间，而不必在末尾。
 
-> **备注：** 该属性最初在 WebKit 中实现的，但存在一些问题。由于需要支持旧版本的浏览器，该属性已在 [CSS Overflow Module Level 4](https://w3c.github.io/csswg-drafts/css-overflow-4/#propdef--webkit-line-clamp) 中被标准化。[CSS Overflow Module Level 4](https://w3c.github.io/csswg-drafts/css-overflow-4/#propdef-line-clamp) 规范还定义了一个 {{cssxref("line-clamp")}} 属性，用来代替此属性并避免一些问题。
+> **备注：** 该属性最初在 WebKit 中实现的，但存在一些问题。由于需要支持旧版本的浏览器，该属性已在 [CSS Overflow Module Level 4](https://drafts.csswg.org/css-overflow-4/#propdef--webkit-line-clamp) 中被标准化。[CSS Overflow Module Level 4](https://drafts.csswg.org/css-overflow-4/#propdef-line-clamp) 规范还定义了一个 {{cssxref("line-clamp")}} 属性，用来代替此属性并避免一些问题。
 
 ## 语法
 

--- a/files/zh-cn/web/css/css_animated_properties/index.md
+++ b/files/zh-cn/web/css/css_animated_properties/index.md
@@ -5,7 +5,7 @@ slug: Web/CSS/CSS_animated_properties
 
 {{CSSRef}}
 
-[CSS 动画](/zh-CN/docs/Web/CSS/CSS_Animations)和[过渡](/zh-CN/docs/Web/CSS/CSS_Transitions)依赖于**动画性**属性这一概念，且所有 CSS 属性除非另有规定否则均有动画性。每个属性的*动画类型*决定了此属性的值如何[结合](https://w3c.github.io/csswg-drafts/css-values/#combining-values)——插值、相加或累积。过渡仅涉及插值，而动画可能使用所有三种结合方法。
+[CSS 动画](/zh-CN/docs/Web/CSS/CSS_Animations)和[过渡](/zh-CN/docs/Web/CSS/CSS_Transitions)依赖于**动画性**属性这一概念，且所有 CSS 属性除非另有规定否则均有动画性。每个属性的*动画类型*决定了此属性的值如何[结合](https://drafts.csswg.org/css-values/#combining-values)——插值、相加或累积。过渡仅涉及插值，而动画可能使用所有三种结合方法。
 
 > **备注：** 每个 CSS 属性的动画类型列于其“形式定义”表格中（如 {{CSSXref("color", "", "#形式定义")}}）。
 
@@ -13,7 +13,7 @@ slug: Web/CSS/CSS_animated_properties
 
 ## 动画类型
 
-在 [Web 动画](https://w3c.github.io/csswg-drafts/web-animations-1/#animating-properties)规范中主要定义了四种动画类型：
+在 [Web 动画](https://drafts.csswg.org/web-animations-1/#animating-properties)规范中主要定义了四种动画类型：
 
 - 无动画性
 

--- a/files/zh-cn/web/css/css_containment/index.md
+++ b/files/zh-cn/web/css/css_containment/index.md
@@ -131,18 +131,18 @@ contain: strict;
 
 ### 与用户相关
 
-此规范提及了[与用户相关](https://w3c.github.io/csswg-drafts/css-contain/#relevant-to-the-user)这一概念。与用户相关的元素因为可见或用户正在交互所以应被渲染。
+此规范提及了[与用户相关](https://drafts.csswg.org/css-contain/#relevant-to-the-user)这一概念。与用户相关的元素因为可见或用户正在交互所以应被渲染。
 
 确切而言，若下列任意条件为真则元素与用户相关：
 
 - 元素出现于视口或视口周围由用户代理所定义的外边距（视口尺度的 50%，给予应用在元素可见性改变时做准备的时间）内。
 - 元素或其内容获得焦点。
 - 元素或其内容被选中，例如用鼠标光标在文本上拖拽或进行其他突显操作。
-- 元素或其内容被置于[顶层](https://w3c.github.io/csswg-drafts/css-position-4/#top-layer)。
+- 元素或其内容被置于[顶层](https://drafts.csswg.org/css-position-4/#top-layer)。
 
 ### 跳过其内容
 
-此规范提及了[跳过其内容](https://w3c.github.io/csswg-drafts/css-contain/#skips-its-contents)这一概念。此概念意味着所指元素与用户无关，且为改善性能将不被渲染。
+此规范提及了[跳过其内容](https://drafts.csswg.org/css-contain/#skips-its-contents)这一概念。此概念意味着所指元素与用户无关，且为改善性能将不被渲染。
 
 确切而言，在元素跳过其内容时：
 

--- a/files/zh-cn/web/text_fragments/index.md
+++ b/files/zh-cn/web/text_fragments/index.md
@@ -98,7 +98,7 @@ https://example.com#:~:text=[prefix-,]textStart[,textEnd][,-suffix]
 
 ### 为匹配的文本片段添加样式
 
-浏览器可以自由地以它们选择的任何默认方式对突出显示的文本进行样式处理。[CSS 伪元素模块等级 4](https://w3c.github.io/csswg-drafts/css-pseudo/#selectordef-target-text) 定义了 {{cssxref("::target-text")}} 伪元素，它允许你指定自定义样式。
+浏览器可以自由地以它们选择的任何默认方式对突出显示的文本进行样式处理。[CSS 伪元素模块等级 4](https://drafts.csswg.org/css-pseudo/#selectordef-target-text) 定义了 {{cssxref("::target-text")}} 伪元素，它允许你指定自定义样式。
 
 例如，在我们的 [scroll-to-text 示例](https://mdn.github.io/css-examples/target-text/index.html#:~:text=From%20the%20foregoing%20remarks%20we%20may%20gather%20an%20idea%20of%20the%20importance)中我们有如下的 CSS 样式：
 


### PR DESCRIPTION
### Description

change all CSS spec URLs back to drafts.csswg.org

### Related issues and pull requests

Fixes: #13308
