### PR TITLE
Update README.md; fixed ko link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ subdirectories:
 - [Simplified Chinese Guide / 简体中文翻译指南](zh-cn/translation-guide.md)
 - [Traditional Chinese Guide / 正體中文翻譯指南](zh-tw/translation-guide.md)
 - [Spanish guide / Guía en español](es/README.md)
-- [Korean translation guide / 한국 번역 지침](ko/translation-guide.md)
+- [Korean translation guide / 한국 번역 지침](ko/README.md)
 
 If you want to add a guide to document some specific guidelines for your locale
 and it does not already appear here, you are welcome to add one, or


### PR DESCRIPTION
### Description

The document /docs/ko/translation-guide.md does not exist. Instead, /docs/ko/README.md exists.