### PR TITLE
chore: change https -> http for syntax highlighting

### DIFF
--- a/files/ja/web/http/authentication/index.md
+++ b/files/ja/web/http/authentication/index.md
@@ -147,7 +147,7 @@ location /status {
 
 多くのクライアントでは次のように、ユーザー名とパスワードを含むエンコードされた URL を使用してログインプロンプトを回避できます。
 
-```example-bad
+```http example-bad
 https://username:password@www.example.com/
 ```
 

--- a/files/ja/web/http/headers/link/index.md
+++ b/files/ja/web/http/headers/link/index.md
@@ -9,7 +9,7 @@ HTTP の **`Link`** エンティティヘッダーフィールドは、 HTTP ヘ
 
 ## 構文
 
-```
+```http
 Link: <uri-reference>; param1=value1; param2="value2"
 ```
 
@@ -24,11 +24,11 @@ Link: <uri-reference>; param1=value1; param2="value2"
 
 URI （絶対または相対）は `<` と `>` で囲む必要があります。
 
-```example-good
+```http example-good
 Link: <https://example.com>; rel="preconnect"
 ```
 
-```example-bad
+```http example-bad
 Link: https://bad.example; rel="preconnect"
 ```
 
@@ -36,7 +36,7 @@ Link: https://bad.example; rel="preconnect"
 
 カンマで区切られた複数のリンクを指定できます。次に例を示します。
 
-```
+```http
 Link: <https://one.example.com>; rel="preconnect", <https://two.example.com>; rel="preconnect", <https://three.example.com>; rel="preconnect"
 ```
 

--- a/files/ja/web/http/headers/www-authenticate/index.md
+++ b/files/ja/web/http/headers/www-authenticate/index.md
@@ -140,7 +140,7 @@ WWW-Authenticate: Basic realm="Access to the staging site", charset="UTF-8"
 
 このヘッダーを受け取ったユーザーエージェントは、まずユーザーにユーザー名とパスワードの入力を求め、それからリソースを再リクエストします。このとき、{{HTTPHeader("Authorization")}} ヘッダーに (エンコードされた) 認証情報を含めます。{{HTTPHeader("Authorization")}} ヘッダーは次のようになります。
 
-```https
+```http
 Authorization: Basic YWxhZGRpbjpvcGVuc2VzYW1l
 ```
 


### PR DESCRIPTION
There's a few build errors for these:

* changing to `http` instead of `https`
* using `http example-(bad|good)` instead of `example-bad`:

````md

```example-bad
// this is not a detected language
```


```js example-bad
// better
```

````
