### PR TITLE
[zh-CN] sync DOMStringMap with en-US

### DIFF
--- a/files/zh-cn/web/api/domstringmap/index.md
+++ b/files/zh-cn/web/api/domstringmap/index.md
@@ -5,7 +5,7 @@ slug: Web/API/DOMStringMap
 
 {{ APIRef("HTML DOM") }}
 
-**`DOMStringMap`** 接口使用于 {{domxref("HTMLElement.dataset")}} / {{domxref("SVGElement.dataset")}} 属性，表示添加到元素的自定义属性的数据。
+**`DOMStringMap`** 接口用于 {{domxref("HTMLElement.dataset")}} / {{domxref("SVGElement.dataset")}} 属性，表示添加到元素的自定义属性的数据。
 
 ## 规范
 

--- a/files/zh-cn/web/api/domstringmap/index.md
+++ b/files/zh-cn/web/api/domstringmap/index.md
@@ -18,4 +18,4 @@ slug: Web/API/DOMStringMap
 ## 参见
 
 - {{domxref("HTMLElement.dataset")}} / {{domxref("SVGElement.dataset")}}
-- [全局属性 - `data-*`](/zh-CN/docs/Web/HTML/Global_attributes/data-*)
+- [全局属性——`data-*`](/zh-CN/docs/Web/HTML/Global_attributes/data-*)

--- a/files/zh-cn/web/api/domstringmap/index.md
+++ b/files/zh-cn/web/api/domstringmap/index.md
@@ -5,7 +5,7 @@ slug: Web/API/DOMStringMap
 
 {{ APIRef("HTML DOM") }}
 
-**`DOMStringMap`** 接口在 {{ domxref("HTMLElement.dataset") }} 属性中被用到，被用于容纳和展示元素的自定义属性。
+**`DOMStringMap`** 接口使用于 {{domxref("HTMLElement.dataset")}} / {{domxref("SVGElement.dataset")}} 属性，表示添加到元素的自定义属性的数据。
 
 ## 规范
 
@@ -17,5 +17,5 @@ slug: Web/API/DOMStringMap
 
 ## 参见
 
-- {{ domxref("HTMLElement.dataset") }}
-- HTML [全局属性](/zh-CN/docs/Web/HTML/Global_attributes)中的 [data-\*](/zh-CN/docs/Web/HTML/Global_attributes#attr-data-*)
+- {{domxref("HTMLElement.dataset")}} / {{domxref("SVGElement.dataset")}}
+- [全局属性 - `data-*`](/zh-CN/docs/Web/HTML/Global_attributes/data-*)


### PR DESCRIPTION
### Description

sync DOMStringMap with en-US

### Motivation

### Additional details

[https://developer.mozilla.org/zh-CN/docs/Web/API/DOMStringMap]()
[https://developer.mozilla.org/en-US/docs/Web/API/DOMStringMap]()

### Related issues and pull requests
