### PR TITLE
[zh-CN] sync navigator.permissions with en-US

### DIFF
--- a/files/zh-cn/web/api/navigator/permissions/index.md
+++ b/files/zh-cn/web/api/navigator/permissions/index.md
@@ -1,32 +1,26 @@
 ---
-title: Navigator.permissions
+title: Navigator：permissions 属性
 slug: Web/API/Navigator/permissions
 ---
 
-{{APIRef("HTML DOM")}}{{SeeCompatTable}}
+{{APIRef("HTML DOM")}}
 
-**`permissions`** 是 **`Navigator`** 读属性，返回一个可用于查询或更新某些 APIs（由 [Permissions API](/zh-CN/docs/Web/API/Permissions_API) 覆盖）的权限状态的对象。
-
-## 语法
-
-```plain
-permissionsObj = globalObj.navigator.permissions
-```
+**`Navigator.permissions`** 只读属性返回一个 {{domxref("Permissions")}} 对象，可以用于查询或更新 [Permissions API](/en-US/docs/Web/API/Permissions_API) 涵盖的 API 状态。
 
 ## 值
 
 一个 {{domxref("Permissions")}} 对象。
 
-## 例子
+## 示例
 
 ```js
-navigator.permissions.query({name:'geolocation'}).then(function(result) {
-  if (result.state === 'granted') {
+navigator.permissions.query({ name: "geolocation" }).then((result) => {
+  if (result.state === "granted") {
     showMap();
-  } else if (result.state === 'prompt') {
+  } else if (result.state === "prompt") {
     showButtonToEnableMap();
   }
-  // 如果被拒绝，请不要做任何操作。
+  // 如果权限被拒绝，不要做任何操作。
 });
 ```
 


### PR DESCRIPTION
### Description

sync navigator.permissions with en-US

### Motivation

sync navigator.permissions with en-US

### Additional details

[https://developer.mozilla.org/en-US/docs/Web/API/Navigator/permissions]()
[https://developer.mozilla.org/zh-CN/docs/Web/API/Navigator/permissions]()

### Related issues and pull requests
