### PR TITLE
Use modern string syntax for console.log

### DIFF
--- a/files/fr/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
+++ b/files/fr/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
@@ -353,7 +353,7 @@ switch(expr) {
     // résultat attendu : "Les mangues et les papayes sont à 5,24 € le kilo."
     break;
   default:
-    console.log('Désolé, nous n'avons plus de ' + expr + '.');
+    console.log(`Désolé, nous n'avons plus de ${expr}.`);
 }
 ```
 


### PR DESCRIPTION
Correction d'une erreur liée à une apostrophe dans "Les instructions switch" (default).

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Small fix in a console.log in the default case of a switch.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
It's just a small error of a unescaped apostrophe that I've converted.

### Additional details
From: 
``console.log('Désolé, nous n'avons plus de ' + expr + '.');``
To:
``console.log(`Désolé, nous n'avons plus de ${expr}.`);``
But it would be possible to only escape the " ' ".:
``console.log('Désolé, nous n\'avons plus de ' + expr + '.');``

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
