### PR TITLE
[zh-CN] css property name typo

### DIFF
--- a/files/zh-cn/web/css/text-decoration/index.md
+++ b/files/zh-cn/web/css/text-decoration/index.md
@@ -5,7 +5,7 @@ slug: Web/CSS/text-decoration
 
 {{CSSRef}}
 
-**`text-decoration`** [简写](/zh-CN/docs/Web/CSS/Shorthand_properties) [CSS](/zh-CN/docs/Web/CSS) 属性设置文本上的装饰性线条的外观。它是 {{cssxref("text-decoration-line")}}、{{cssxref("text-decoration-line")}}、{{cssxref("text-decoration-style")}} 和较新的 {{cssxref("text-decoration-thickness")}} 属性的缩写。
+**`text-decoration`** [简写](/zh-CN/docs/Web/CSS/Shorthand_properties) [CSS](/zh-CN/docs/Web/CSS) 属性设置文本上的装饰性线条的外观。它是 {{cssxref("text-decoration-line")}}、{{cssxref("text-decoration-color")}}、{{cssxref("text-decoration-style")}} 和较新的 {{cssxref("text-decoration-thickness")}} 属性的缩写。
 
 {{EmbedInteractiveExample("pages/css/text-decoration.html")}}
 


### PR DESCRIPTION
### Description

Fix a misspelled css property name in S-Chinese version

### Motivation

User mentioned this in https://t.me/mozilla_china/7115

### Additional details

English original article: https://github.com/mdn/content/blob/main/files/en-us/web/css/text-decoration/index.md

### Related issues and pull requests

None
