### PR TITLE
chore(labeler): add "docs/ja/" entity to l10n-ja

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,6 +17,7 @@ l10n-fr:
 
 l10n-ja:
   - files/ja/**/*
+  - docs/ja/**/*
   - /.github/ISSUE_TEMPLATE/page-report-ja.yml
 
 l10n-ko:


### PR DESCRIPTION
### Description

add "docs/ja/" entity to l10n-ja

### Motivation

The l10n-ja translation guidelines doc is [just added to `docs/`](https://github.com/mdn/translated-content/pull/13353), so add this to auto labler.
