### PR TITLE
chore: change idl -> webidl for syntax highlighting

### DIFF
--- a/files/pt-br/web/api/element/scrollintoview/index.md
+++ b/files/pt-br/web/api/element/scrollintoview/index.md
@@ -28,7 +28,7 @@ element.scrollIntoView(scrollIntoViewOptions); // argumento Objeto
 
   - : Um booleano ou um objeto com as seguintes opções:
 
-    ```idl
+    ```webidl
     {
       behavior: "auto"  | "instant" | "smooth",
       block:    "start" | "center" | "end" | "nearest",

--- a/files/ru/web/api/pointer_lock_api/index.md
+++ b/files/ru/web/api/pointer_lock_api/index.md
@@ -109,7 +109,7 @@ function lockError(e) {
 
 The Pointer lock API extends the normal {{domxref("MouseEvent")}} interface with movement attributes.
 
-```idl
+```webidl
 partial interface MouseEvent {
     readonly attribute long movementX;
     readonly attribute long movementY;

--- a/files/zh-cn/web/api/pointer_lock_api/index.md
+++ b/files/zh-cn/web/api/pointer_lock_api/index.md
@@ -177,7 +177,7 @@ document.exitPointerLock();
 
 Pointer lock API 使用 movement 属性扩展了标准的 `MouseEvent`。
 
-```idl
+```webidl
 partial interface MouseEvent {
     readonly attribute long movementX;
     readonly attribute long movementY;


### PR DESCRIPTION
There's a few build errors for these:

* changing to `webidl` instead of `idl`

````md

```idl
// this is not a detected language
```


```webidl
// better
```

````

__Related pull requests:__

* https://github.com/mdn/yari/pull/8899