### PR TITLE
fixed ja link; docs//Web => docs/Web

### DIFF
--- a/files/ja/web/api/css_painting_api/guide/index.md
+++ b/files/ja/web/api/css_painting_api/guide/index.md
@@ -93,7 +93,7 @@ CSS.paintWorklet.addModule('https://mdn.github.io/houdini-examples/cssPaint/intr
 <h1 class="fancy">My Cool Header</h1>
 ```
 
-以下の例は、[CSS Painting API をサポートしているブラウザー](/ja/docs//Web/API/PaintWorklet#Browser_compatibility)では上の画像のようになります。
+以下の例は、[CSS Painting API をサポートしているブラウザー](/ja/docs/Web/API/CSS/paintWorklet_static#ブラウザーの互換性)では上の画像のようになります。
 
 {{EmbedLiveSample("paintapi", 120, 120)}}
 


### PR DESCRIPTION
### Description

URL のスラッシュが2連続になってしまっていて、変換後の URL が `docs_Web` のようになってしまっているリンクを修正します。ついでにリンク先が古くてアクセスできなかったので、新しいリンク先に修正しました。

### Motivation

#11562 の調査でリンクを解析しているときに見つけました。このパターンのミスはここの1箇所のみです。