### PR TITLE
fix punctuation mark and term in zh-tw

### DIFF
--- a/files/zh-tw/web/http/status/301/index.md
+++ b/files/zh-tw/web/http/status/301/index.md
@@ -5,9 +5,9 @@ slug: Web/HTTP/Status/301
 
 {{HTTPSidebar}}
 
-HTTP **`301 Moved Permanently`** 重定向回應碼代表所請求的資源已經被明確移動到 {{HTTPHeader("Location")}} 標頭所指示的 URL。瀏覽器會重新導向到此頁面，而搜尋引擎則會更新該資源的連結。用 SEO 的話來說，就是連結養分（link-juice）把你送到了新的 URL 去。
+HTTP **`301 Moved Permanently`** 重新導向狀態代碼代表所請求的資源已經被明確移動到 {{HTTPHeader("Location")}} 標頭所指示的 URL。瀏覽器會重新導向到此頁面，而搜尋引擎則會更新該資源的連結。用 SEO 的話來說，就是連結養分（link-juice）把你送到了新的 URL 去。
 
-儘管規範要求當執行重新導向時，請求方法 (以及主體) 不應該被更動，但並非所有的用戶代理皆遵循它 -- 你依然可以找到具有此類漏洞的軟體。因此，推薦只使用 `301` 回應碼作為 {{HTTPMethod("GET")}} 或 {{HTTPMethod("HEAD")}} 方法的回應， 另外使用 {{HTTPStatus("308", "308 Permanent Redirect")}} 作為 {{HTTPMethod("POST")}} 方法的替代，因為請求方法的更動在此狀態中是被明確禁止的。
+儘管規範要求當執行重新導向時，請求方法（以及主體）不應該被更動，但並非所有的用戶代理皆遵循它──你依然可以找到具有此類漏洞的軟體。因此，推薦只使用 `301` 回應碼作為 {{HTTPMethod("GET")}} 或 {{HTTPMethod("HEAD")}} 方法的回應， 另外使用 {{HTTPStatus("308", "308 Permanent Redirect")}} 作為 {{HTTPMethod("POST")}} 方法的替代，因為請求方法的更動在此狀態中是被明確禁止的。
 
 ## 狀態
 


### PR DESCRIPTION
path: web/http/status/301

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

fix punctuation mark and term in zh-tw

### Motivation

1. punctuation mark should be fullwidth
2. "redirect" is "重新導向" in Taiwan. "重定向" is used in China not Taiwan.

### Additional details

None.

### Related issues and pull requests

None.

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
