### PR TITLE
chore(fr): add HSTS redirect

### DIFF
--- a/files/fr/_redirects.txt
+++ b/files/fr/_redirects.txt
@@ -3445,6 +3445,7 @@
 /fr/docs/SVG:Tutoriel:Premiers_pas	/fr/docs/Web/SVG/Tutorial/Getting_Started
 /fr/docs/Server-sent_events	/fr/docs/Web/API/Server-sent_events
 /fr/docs/Server-sent_events/Using_server-sent_events	/fr/docs/Web/API/Server-sent_events/Using_server-sent_events
+/fr/docs/Sécurité/HTTP_Strict_Transport_Security	/fr/docs/Glossary/HSTS
 /fr/docs/Tools	https://firefox-source-docs.mozilla.org/devtools-user/index.html
 /fr/docs/Tools/3D_View	https://firefox-source-docs.mozilla.org/devtools-user/3d_view/index.html
 /fr/docs/Tools/Accessibility_inspector	https://firefox-source-docs.mozilla.org/devtools-user/accessibility_inspector/index.html


### PR DESCRIPTION
### Description

Redirect a frequently hit URL that 404s.

### Motivation

The URL gets about 700 weekly hits from https://france-visas.gouv.fr/, and it originally had the HSTS docs: https://web.archive.org/web/20200927142114/https://developer.mozilla.org/fr/docs/S%C3%A9curit%C3%A9/HTTP_Strict_Transport_Security

It is linked from here (currentlly in maintenance): https://web.archive.org/web/20221201140302/https://www.france-visas.gouv.fr/web/france-visas/compatibilite-navigateur
<img width="887" alt="image" src="https://github.com/mdn/translated-content/assets/495429/67c582e8-df23-4ab6-9f84-0455fe0a6e48">


### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
