### PR TITLE
fix: replace og:image

### DIFF
--- a/files/es/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/es/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -175,7 +175,7 @@ Por ejemplo, [Open Graph Data](http://ogp.me/) es un protocolo de metadatos que 
 ```html
 <meta
   property="og:image"
-  content="https://developer.mozilla.org/static/img/opengraph-logo.png"
+  content="/mdn-social-share.png"
 />
 <meta
   property="og:description"

--- a/files/es/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/es/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -175,7 +175,7 @@ Por ejemplo, [Open Graph Data](http://ogp.me/) es un protocolo de metadatos que 
 ```html
 <meta
   property="og:image"
-  content="/mdn-social-share.png"
+  content="https://developer.mozilla.org/mdn-social-share.png"
 />
 <meta
   property="og:description"

--- a/files/fr/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/fr/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -171,7 +171,7 @@ En parcourant le web, vous trouverez d'autres types de métadonnées. Beaucoup d
 Par exemple, [Open Graph Data](https://ogp.me/) est un protocole de métadonnées que Facebook a inventé pour fournir des métadonnées plus riches pour les sites webs. Dans le code source de MDN vous trouverez ceci :
 
 ```html
-<meta property="og:image" content="/mdn-social-share.png">
+<meta property="og:image" content="https://developer.mozilla.org/mdn-social-share.png">
 <meta property="og:description" content="MDN Web Docs fournit des
 informations sur les technologies web ouvertes comme HTML, CSS et les API
 utilisées pour les sites web et les applications web. On y trouve également

--- a/files/fr/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/fr/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -171,7 +171,7 @@ En parcourant le web, vous trouverez d'autres types de métadonnées. Beaucoup d
 Par exemple, [Open Graph Data](https://ogp.me/) est un protocole de métadonnées que Facebook a inventé pour fournir des métadonnées plus riches pour les sites webs. Dans le code source de MDN vous trouverez ceci :
 
 ```html
-<meta property="og:image" content="https://developer.mozilla.org/static/img/opengraph-logo.png">
+<meta property="og:image" content="/mdn-social-share.png">
 <meta property="og:description" content="MDN Web Docs fournit des
 informations sur les technologies web ouvertes comme HTML, CSS et les API
 utilisées pour les sites web et les applications web. On y trouve également

--- a/files/fr/web/api/performance/clearresourcetimings/index.md
+++ b/files/fr/web/api/performance/clearresourcetimings/index.md
@@ -35,7 +35,7 @@ Aucune.
 ```js
 function load_resource() {
   var image = new Image();
-  image.src = "https://developer.mozilla.org/static/img/opengraph-logo.png";
+  image.src = "https://developer.mozilla.org/mdn-social-share.png";
 }
 function clear_performance_timings() {
   if (performance === undefined) {

--- a/files/ja/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/ja/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -161,7 +161,7 @@ description は検索エンジンの結果ページにも使われます。練�
 例えば、 [Open Graph Data](https://ogp.me/) は Facebook が開発した、ウェブサイトにより豊富なメタデータを与えるメタデータプロトコルです。 MDN Web Docs のソースコードでは、次のようなものがあります。
 
 ```html
-<meta property="og:image" content="https://developer.mozilla.org/static/img/opengraph-logo.png">
+<meta property="og:image" content="/mdn-social-share.png">
 <meta property="og:description" content="The Mozilla Developer Network (MDN) provides
 information about Open Web technologies including HTML, CSS, and APIs for both Web sites
 and HTML Apps. It also documents Mozilla products, like Firefox OS.">

--- a/files/ja/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/ja/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -161,7 +161,7 @@ description は検索エンジンの結果ページにも使われます。練�
 例えば、 [Open Graph Data](https://ogp.me/) は Facebook が開発した、ウェブサイトにより豊富なメタデータを与えるメタデータプロトコルです。 MDN Web Docs のソースコードでは、次のようなものがあります。
 
 ```html
-<meta property="og:image" content="/mdn-social-share.png">
+<meta property="og:image" content="https://developer.mozilla.org/mdn-social-share.png">
 <meta property="og:description" content="The Mozilla Developer Network (MDN) provides
 information about Open Web technologies including HTML, CSS, and APIs for both Web sites
 and HTML Apps. It also documents Mozilla products, like Firefox OS.">

--- a/files/ja/web/api/performance/clearresourcetimings/index.md
+++ b/files/ja/web/api/performance/clearresourcetimings/index.md
@@ -30,7 +30,7 @@ performance.clearResourceTimings();
 ```js
 function load_resource() {
   var image = new Image();
-  image.src = "https://developer.mozilla.org/static/img/opengraph-logo.png";
+  image.src = "https://developer.mozilla.org/mdn-social-share.png";
 }
 function clear_performance_timings() {
   if (performance === undefined) {

--- a/files/ko/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/ko/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -164,7 +164,7 @@ started with developing web sites and applications.">
 [Open Graph Data](http://ogp.me/) 는 Facebook이 웹 사이트에 더 풍부한 메타 데이터를 제공하기 위해 발명한 메타 데이터 프로토콜이다. MDN 소스코드에서 다음과 같은 부분을 볼 수 있을 것이다.
 
 ```html
-<meta property="og:image" content="/mdn-social-share.png">
+<meta property="og:image" content="https://developer.mozilla.org/mdn-social-share.png">
 <meta property="og:description" content="The Mozilla Developer Network (MDN) provides
 information about Open Web technologies including HTML, CSS, and APIs for both Web sites
 and HTML5 Apps. It also documents Mozilla products, like Firefox OS.">

--- a/files/ko/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/ko/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -164,7 +164,7 @@ started with developing web sites and applications.">
 [Open Graph Data](http://ogp.me/) 는 Facebook이 웹 사이트에 더 풍부한 메타 데이터를 제공하기 위해 발명한 메타 데이터 프로토콜이다. MDN 소스코드에서 다음과 같은 부분을 볼 수 있을 것이다.
 
 ```html
-<meta property="og:image" content="https://developer.mozilla.org/static/img/opengraph-logo.png">
+<meta property="og:image" content="/mdn-social-share.png">
 <meta property="og:description" content="The Mozilla Developer Network (MDN) provides
 information about Open Web technologies including HTML, CSS, and APIs for both Web sites
 and HTML5 Apps. It also documents Mozilla products, like Firefox OS.">

--- a/files/ko/web/css/opacity/index.md
+++ b/files/ko/web/css/opacity/index.md
@@ -76,7 +76,7 @@ img.opacity:hover {
 ```
 
 ```html
-<img src="//developer.mozilla.org/static/img/opengraph-logo.png"
+<img src="https://developer.mozilla.org/mdn-social-share.png"
   alt="MDN logo" width="128" height="146"
   class="opacity">
 ```

--- a/files/pt-br/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/pt-br/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -175,7 +175,7 @@ Ao navegar pela web, você também encontrará outros tipos de metadados. Muitos
 Por exemplo, [Open Graph Data](http://ogp.me/) é um protocolo de metadados que o Facebook inventou para fornecer metadados mais ricos para sites. No código-fonte MDN, você encontrará isso:
 
 ```html
-<meta property="og:image" content="/mdn-social-share.png">
+<meta property="og:image" content="https://developer.mozilla.org/mdn-social-share.png">
 <meta property="og:description" content="A Mozilla Developer Network (MDN) fornece
 informações sobre tecnologias Open Web, incluindo HTML, CSS e APIs para ambos os sites da Web
 e aplicativos HTML5. Ele também documenta produtos Mozilla, como o sistema operacional Firefox.">

--- a/files/pt-br/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/pt-br/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -175,7 +175,7 @@ Ao navegar pela web, você também encontrará outros tipos de metadados. Muitos
 Por exemplo, [Open Graph Data](http://ogp.me/) é um protocolo de metadados que o Facebook inventou para fornecer metadados mais ricos para sites. No código-fonte MDN, você encontrará isso:
 
 ```html
-<meta property="og:image" content="https://developer.mozilla.org/static/img/opengraph-logo.png">
+<meta property="og:image" content="/mdn-social-share.png">
 <meta property="og:description" content="A Mozilla Developer Network (MDN) fornece
 informações sobre tecnologias Open Web, incluindo HTML, CSS e APIs para ambos os sites da Web
 e aplicativos HTML5. Ele também documenta produtos Mozilla, como o sistema operacional Firefox.">

--- a/files/ru/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/ru/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -165,7 +165,7 @@ original_slug: Learn/HTML/Введение_в_HTML/The_head_metadata_in_HTML
 Например, [Протокол Open Graph](https://ruogp.me/) создан Facebook чтобы предоставить сайтам дополнительные возможности использования метаданных. В исходном коде MDN Web Docs вы можете найти строки:
 
 ```html
-<meta property="og:image" content="/mdn-social-share.png">
+<meta property="og:image" content="https://developer.mozilla.org/mdn-social-share.png">
 <meta property="og:description" content="Веб-документация на MDN предоставляет
 собой информацию об открытых веб-технологиях, включая HTML, CSS и различные API для веб-сайтов
 и прогрессивных веб-приложений. Также на сайте содержатся материалы для разработчиков о таких

--- a/files/ru/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/ru/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -165,7 +165,7 @@ original_slug: Learn/HTML/Введение_в_HTML/The_head_metadata_in_HTML
 Например, [Протокол Open Graph](https://ruogp.me/) создан Facebook чтобы предоставить сайтам дополнительные возможности использования метаданных. В исходном коде MDN Web Docs вы можете найти строки:
 
 ```html
-<meta property="og:image" content="/static/img/opengraph-logo.72382e605ce3.png">
+<meta property="og:image" content="/mdn-social-share.png">
 <meta property="og:description" content="Веб-документация на MDN предоставляет
 собой информацию об открытых веб-технологиях, включая HTML, CSS и различные API для веб-сайтов
 и прогрессивных веб-приложений. Также на сайте содержатся материалы для разработчиков о таких

--- a/files/ru/web/css/opacity/index.md
+++ b/files/ru/web/css/opacity/index.md
@@ -82,7 +82,7 @@ img.opacity:hover {
 ```
 
 ```html
-<img src="//developer.mozilla.org/static/img/opengraph-logo.png"
+<img src="https://developer.mozilla.org/mdn-social-share.png"
   alt="MDN logo" width="128" height="146"
   class="opacity">
 ```

--- a/files/zh-cn/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/zh-cn/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -162,7 +162,7 @@ description 也被使用在搜索引擎显示的结果页中。下面通过一�
 ```html
 <meta
   property="og:image"
-  content="/mdn-social-share.png" />
+  content="https://developer.mozilla.org/mdn-social-share.png" />
 <meta
   property="og:description"
   content="The Mozilla Developer Network (MDN) provides

--- a/files/zh-cn/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/zh-cn/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -162,7 +162,7 @@ description 也被使用在搜索引擎显示的结果页中。下面通过一�
 ```html
 <meta
   property="og:image"
-  content="https://developer.mozilla.org/static/img/opengraph-logo.png" />
+  content="/mdn-social-share.png" />
 <meta
   property="og:description"
   content="The Mozilla Developer Network (MDN) provides

--- a/files/zh-cn/web/api/performance/clearresourcetimings/index.md
+++ b/files/zh-cn/web/api/performance/clearresourcetimings/index.md
@@ -29,7 +29,7 @@ performance.clearResourceTimings();
 ```js
 function load_resource() {
   var image = new Image();
-  image.src = "https://developer.mozilla.org/static/img/opengraph-logo.png";
+  image.src = "https://developer.mozilla.org/mdn-social-share.png";
 }
 function clear_performance_timings() {
   if (performance === undefined) {

--- a/files/zh-tw/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/zh-tw/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -168,7 +168,7 @@ For example, [Open Graph Data](http://ogp.me/) is a metadata protocol that Faceb
 ```html
 <meta
   property="og:image"
-  content="/mdn-social-share.png" />
+  content="https://developer.mozilla.org/mdn-social-share.png" />
 <meta
   property="og:description"
   content="The Mozilla Developer Network (MDN) provides

--- a/files/zh-tw/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/zh-tw/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -168,7 +168,7 @@ For example, [Open Graph Data](http://ogp.me/) is a metadata protocol that Faceb
 ```html
 <meta
   property="og:image"
-  content="https://developer.mozilla.org/static/img/opengraph-logo.png" />
+  content="/mdn-social-share.png" />
 <meta
   property="og:description"
   content="The Mozilla Developer Network (MDN) provides


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

We get 40k weekly hits on `https://developer.mozilla.org/static/img/opengraph-logo.72382e605ce3.png`, which 404s, because `opengraph-logo.png` has been replaced by [mdn-social-share.png](https://developer.mozilla.org/mdn-social-share.png).

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

See also https://github.com/mdn/content/pull/27046 for the same change in content.
