### PR TITLE
Typo in the docs

### DIFF
--- a/files/pt-br/web/javascript/reference/functions/get/index.md
+++ b/files/pt-br/web/javascript/reference/functions/get/index.md
@@ -67,7 +67,7 @@ var o = { a:0 }
 
 Object.defineProperty(o, "b", { get: function () { return this.a + 1; } });
 
-console.log(o.b) // Executa o getter, que retornará a + 1 (which is 1)
+console.log(o.b) // Executa o getter, que retornará a + 1 (que é 1)
 ```
 
 ### Usando uma propriedade com nome computado


### PR DESCRIPTION
Esqueceram de uma palavra em inglês no comentário.

### Description

Esqueceram de traduzir todo o comentário do código, com uma parte ficando em inglês.

### Motivation

### Additional details

### Related issues and pull requests
