### PR TITLE
export の「構文」の項目中のコードスニペットでjavascriptを有効に

### DIFF
--- a/files/ja/web/javascript/reference/statements/export/index.md
+++ b/files/ja/web/javascript/reference/statements/export/index.md
@@ -13,7 +13,7 @@ l10n:
 
 ## 構文
 
-```
+```js
 // 個々の機能をエクスポート
 export let name1, name2/*, … */; // var も
 export const name1 = 1, name2 = 2/*, … */; // var, let も


### PR DESCRIPTION
### Description

I have enabled JavaScript in the code snippets on the reference page for the export statement.
Link: https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Statements/export 

**Screenshot( before fixing )**

<img width="500" alt="スクリーンショット_2023-05-31_8_04_27" src="https://github.com/mdn/translated-content/assets/27806269/1c269c21-5731-4077-9e3b-ddcf99c62c38">
