### PR TITLE
security: replace Discord links

### DIFF
--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -90,7 +90,7 @@ Telegram: <https://t.me/+Dr6qKQCAepw4MjFj>
 
 Matrix: <https://chat.mozilla.org/#/room/#mdn-l10n-es:mozilla.org>
 
-MDN Discord, canal #spanish: <https://discord.gg/MkEg2ATW>
+MDN Discord, canal #spanish: <https://discord.gg/aZqEtMrbr7>
 
 <details>
   <summary><h2>Enlaces relevantes</h2></summary>

--- a/files/es/mdn/community/contributing/translated_content/index.md
+++ b/files/es/mdn/community/contributing/translated_content/index.md
@@ -48,7 +48,7 @@ Hemos _congelado_ todo el contenido localizado (lo que significa que no aceptare
 
 ### Español (es)
 
-- Discusiones: [Matrix (canal #mdn-l10n-es)](https://chat.mozilla.org/#/room/#mdn-l10n-es:mozilla.org), [Telegram (canal MDN l10n ES)](https://t.me/+Dr6qKQCAepw4MjFj), [Discord (MDN Web Docs Community ,canal #spanish)](https://discord.gg/MkEg2ATW)
+- Discusiones: [Matrix (canal #mdn-l10n-es)](https://chat.mozilla.org/#/room/#mdn-l10n-es:mozilla.org), [Telegram (canal MDN l10n ES)](https://t.me/+Dr6qKQCAepw4MjFj), [Discord (MDN Web Docs Community ,canal #spanish)](https://discord.gg/aZqEtMrbr7)
 - Colaboradores actuales: [Graywolf9](https://github.com/Graywolf9), [JuanVqz](https://github.com/JuanVqz), [Jalkhov](https://github.com/Jalkhov), [marcelozarate](https://github.com/marcelozarate), [davbrito](https://github.com/davbrito), [Vallejoanderson](https://github.com/Vallejoanderson).
 
 > **Nota:** Si quiere hablar sobre la posibilidad de _descongelar_ una localización, las [directrices sobre lo que se requiere se pueden encontrar aquí](https://github.com/mdn/translated-content/blob/main/PEERS_GUIDELINES.md#activating-a-locale)


### PR DESCRIPTION
This replaces a Discord invite link that has expired with a link that is set never to expire.