### PR TITLE
sync with english version for "Attrib copyright license"

### DIFF
--- a/files/zh-cn/mdn/writing_guidelines/attrib_copyright_license/index.md
+++ b/files/zh-cn/mdn/writing_guidelines/attrib_copyright_license/index.md
@@ -1,59 +1,72 @@
 ---
-title: 署名和版权许可协议
+title: 署名和版权许可
 slug: MDN/Writing_guidelines/Attrib_copyright_license
 ---
 
 {{MDNSidebar}}
 
-MDN 的内容是免费的，并在开源协议下提供。
+MDN Web 文档的内容是免费的，并在开源协议下提供。
 
 ## 使用 MDN Web 文档的内容
 
-本节涵盖了我们提供的内容类型，以及每种内容的版权和协议。
+本节涵盖了我们提供的内容类型，以及你在复用这些内容时每种内容具体的版权和许可。
 
 ### 文档
 
-> **备注：** MDN Web 文档中的内容来自于包括 Mozilla 基金会内部与外部编辑者的贡献。除非另有说明，文档基于[知识共享 署名 - 相同方式共享许可](https://creativecommons.org/licenses/by-sa/2.5/)（CC-BY-SA）V2.5 及以上版本发布。
+> **备注：** MDN Web 文档中的内容来自于包括 Mozilla 基金会内部与外部编辑者的贡献。除非另有说明，文档基于[知识共享 署名-相同方式共享](https://creativecommons.org/licenses/by-sa/2.5/deed.zh)（CC-BY-SA）V2.5 及以上版本发布。
 
-你复用的内容是在与内容相同的许可协议（CC-BY-SA v2.5 及以上的版本）下发布的。在复用 MDN Web 文档的内容时，你需要确保对属于“Mozilla 贡献者”的内容进行署名。包括源文档的超链接（在线内容）或 URL（印刷内容）。以*本*文为例，你可以这样署名：
+你复用的内容是在与内容相同的许可协议（CC-BY-SA v2.5 及以上的版本）下发布的。在复用 MDN Web 文档的内容时，你需要确保对属于“Mozilla 贡献者”的原始内容进行署名。包括源文档的超链接（在线内容）或 URL（印刷内容）。以*本*文为例，你可以这样署名：
 
-> 归属于 [Mozilla 贡献者](/zh-CN/docs/MDN/About/contributors.txt)的[署名和版权许可协议](MDN/Writing_guidelines/Attrib_copyright_license)在[知识共享 署名 - 相同方式共享许可 2.5](https://creativecommons.org/licenses/by-sa/2.5/) 下提供。
+> 归属于 [Mozilla 贡献者](/zh-CN/docs/MDN/About/contributors.txt)的[署名和版权许可](MDN/Writing_guidelines/Attrib_copyright_license)在[知识共享 署名-相同方式共享 2.5](https://creativecommons.org/licenses/by-sa/2.5/deed.zh) 许可下提供。
 
-注意在示例当中，“Mozilla 贡献者”链接了被引用页面的历史记录。参见[署名的最佳实践](https://wiki.creativecommons.org/wiki/Marking/Users)以获取更为详细的信息。
+在上述示例中，“Mozilla 贡献者”链接了被引用页面的历史记录。参见[署名的推荐做法](https://wiki.creativecommons.org/wiki/Recommended_practices_for_attribution)以获取更为详细的信息。
 
 ### 代码示例
 
-2010 年 8 月 20 日或之后添加的代码示例都属于[公有领域](https://creativecommons.org/publicdomain/zero/1.0/) （[CC0](https://creativecommons.org/publicdomain/zero/1.0/)）。不需要有意添加许可信息。如果你需要的话，可以使用：“版权属于公有领域：<https://creativecommons.org/publicdomain/zero/1.0/>”
+2010 年 8 月 20 日或之后添加的代码示例都属于[公有领域 CC0](https://creativecommons.org/publicdomain/zero/1.0/deed.zh)。不需要有意添加许可信息。如果你需要的话，可以使用：`版权属于公有领域：https://creativecommons.org/publicdomain/zero/1.0/deed.zh`
 
-2010 年 8 月 20 日之前的代码示例基于 [MIT license](https://opensource.org/licenses/mit-license.php)，你应该在 MIT 模板中插入以下署名信息：“© \<date of last wiki page revision> \<name of person who put it in the wiki>”
+2010 年 8 月 20 日之前的代码示例基于 [MIT 许可证](https://opensource.org/license/mit/)，你应该在 MIT 模板中插入以下署名信息：“© \<date of last wiki page revision> \<name of person who put it in the wiki>”
 
 自 2020 年 12 月 14 日推出新的 Yari MDN 平台以来，目前还无法确定你需要哪一个署名信息。我们正在进行这方面的工作，并将很快更新此内容。
 
 ### 贡献
 
-如果你想对 MDN Web 文档作出贡献，你必须在 Attribution-ShareAlike license（或者在你编辑的页面已经指定的其他版权许可）下发布你的文档，在 [Creative Commons CC-0](https://creativecommons.org/publicdomain/zero/1.0/)（专用于公有领域）下发布你的示例代码。
+如果你想对 MDN Web 文档作出贡献，你必须在署名-相同方式共享许可（Attribution-ShareAlike license），或者在你编辑的页面已经指定的其他版权许可下发布你的文档，在[知识共享许可协议 CC-0](https://creativecommons.org/publicdomain/zero/1.0/deed.zh)（专用于公有领域）下发布你的示例代码。
 
 > **警告：** 请不要在新建的页面使用其他版权许可。
 
-**贡献的内容的版权在作者未授予他人之前归原作者所有**。
+**贡献的内容的版权在作者未授予他人之前归原作者所有。**
 
-对于此处讨论的话题有任何问题，请联系 [MDN Web 文档团队](https://github.com/mdn/mdn-community/discussions)。
+对于此处讨论的话题有任何问题，请联系 [MDN Web 文档团队](/zh-CN/docs/MDN/Community/Communication_channels)。
 
 ### 徽标、商标、服务标记和文字标记
 
-Mozilla 基金会的商标、标识、服务标志以及网站的设计、外观不包含在基于知识共享许可的范围内。从某种意义上说，它们是内容的创造者（如图标和图形设计），而这些内容并不在上述许可范畴内发布。如果你也希望这样发布文档，或者你对这些许可条款还有任何的疑问，你可以联系 Mozilla 基金会以获得更多的帮助：[licensing@mozilla.org](mailto:licensing@mozilla.org)。
+Mozilla 基金会的徽标、商标、服务标志，以及网站的外观、视觉不包含在基于知识共享许可的范围内。从某种意义上说，它们是作者的作品（如图标和图形设计），而这些内容并不在上述许可范畴内发布。如果你希望使用文档的内容并获得标识的授权，或者你对遵守这些许可条款还有任何的疑问，你可以联系 Mozilla 基金会以获得更多的帮助：[licensing@mozilla.org](mailto:licensing@mozilla.org)。
 
 ## 使用 MDN Web 文档之外的内容
 
-通常，在 MDN Web 文档之外，网络上的其他地方还有关于某个主题的较为有用的内容。但是复制此类内容可能会遇到技术和法律方面的困难。
+通常，我们不赞成将其他来源的内容复制到 MDN 上。MDN 应尽可能地由原创内容组成。如果我们收到拉取请求（pull request），并发现其中包含抄袭内容，我们将关闭它并要求提交者重新提交更改，使用原创内容。
 
-在技术层面上，搜索引擎通常会因为一个网站复制了其他地方的内容而惩罚其排名。因此，最好在 MDN Web 文档上对内容进行原创，以提高 MDN Web 文档内容的搜索引擎排名。你可以链接到 MDN Web 文档中现有的内容。
+### 如果你想重复使用或重新发布内容
 
-在法律层面，你必须获得贡献内容的授权，并且其许可和署名必须与 MDN 许可协议兼容。
+> **备注：** 除非有充分的理由重新发布内容，否则我们可能会拒绝这些请求。MDN 编写团队会对其做出最终决定。
 
-- **如果你创建了新的内容**（出于你自己的目的，而非雇佣工作），并且愿意在 MDN 的许可下将其贡献给 MDN Web 文档，这是最简单的情况。你可以自由地贡献内容。
-- **如果内容的版权属于他人**，则必须获得与 MDN 的许可兼容的许可和署名。通常情况下，人们不知道哪些许可是兼容的。为了安全起见，请联系 [MDN Web 文档团队](https://github.com/mdn/mdn-community/discussions)的成员，如果有必要，他们可以联系 Mozilla 的法律团队以获得指导。
+如果有人想向 MDN 捐赠他们之前在其博客上发布的文章，或者将复杂的参考表格复制到 MDN 上，且这么做是有意义的，则可能有足够的理由重新发布它。对于这些情况，请事先与 MDN 团队讨论你的计划：
+
+- [创建一个 GitHub 议题](https://github.com/mdn/mdn/issues/new/choose)来解释你的意图。
+  - 描述你想要复制或重新发布的内容。
+  - 提供资源的 URL。
+  - 解释为什么你认为这是合适的。
+
+**如果内容是在封闭许可下发布的：**
+
+- 如果你拥有内容的版权，请说明这一点，并明确表示你同意在 MDN 上重新发布它。
+- 如果你并未拥有内容的版权，请在可能的情况下在议题中包含作者/出版商，或包含他们的联系方式，以便我们可以请求他们允许我们重新发布内容。
+
+**如果内容是在开放许可下发布的：**
+
+- 请说明下许可的类型，并提供其链接，以便我们可以检查它是否与 [MDN 的许可](https://github.com/mdn/content/blob/main/LICENSE.md)兼容。
 
 ### 链接到 MDN Web 文档中的文章
 
-我们经常会有用户问我们有关链接到 MDN Web 文档的问题，以及是否允许这样做。简单的答案是：**是的，你可以链接到 MDN Web 文档**！超文本链接不仅是 Web 的本质，它既是将你的用户指向宝贵资源的一种方式，也是对我们社区所做工作的信任。
+我们经常会有用户问我们有关链接到 MDN Web 文档的问题，以及是否允许这样做。简单的答案是：**是的，你可以链接到 MDN Web 文档**！超文本链接不仅是 web 的本质，它既是将你的用户指向宝贵资源的一种方式，也是对我们社区所做工作的信任。


### PR DESCRIPTION
### Description

sync with english version for "Attrib copyright license"

~blocked by: mdn/content#27132~
