### PR TITLE
Fix/link to css gradients

### DIFF
--- a/files/zh-cn/_redirects.txt
+++ b/files/zh-cn/_redirects.txt
@@ -55,7 +55,6 @@
 /zh-CN/docs/CSS/Understanding_z-index/Stacking_without_z-index	/zh-CN/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_without_z-index
 /zh-CN/docs/CSS/Understanding_z-index/The_stacking_context	/zh-CN/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context
 /zh-CN/docs/CSS/Universal_selectors	/zh-CN/docs/Web/CSS/Universal_selectors
-/zh-CN/docs/CSS/Using_CSS_gradients	/zh-CN/docs/Web/CSS/CSS_images/Using_CSS_gradients
 /zh-CN/docs/CSS/Value_definition_syntax	/zh-CN/docs/Web/CSS/Value_definition_syntax
 /zh-CN/docs/CSS/Visual_formatting_model	/zh-CN/docs/Web/CSS/Visual_formatting_model
 /zh-CN/docs/CSS/actual_value	/zh-CN/docs/Web/CSS/actual_value

--- a/files/zh-cn/_redirects.txt
+++ b/files/zh-cn/_redirects.txt
@@ -55,6 +55,7 @@
 /zh-CN/docs/CSS/Understanding_z-index/Stacking_without_z-index	/zh-CN/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_without_z-index
 /zh-CN/docs/CSS/Understanding_z-index/The_stacking_context	/zh-CN/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context
 /zh-CN/docs/CSS/Universal_selectors	/zh-CN/docs/Web/CSS/Universal_selectors
+/zh-CN/docs/CSS/Using_CSS_gradients	/zh-CN/docs/Web/CSS/CSS_images/Using_CSS_gradients
 /zh-CN/docs/CSS/Value_definition_syntax	/zh-CN/docs/Web/CSS/Value_definition_syntax
 /zh-CN/docs/CSS/Visual_formatting_model	/zh-CN/docs/Web/CSS/Visual_formatting_model
 /zh-CN/docs/CSS/actual_value	/zh-CN/docs/Web/CSS/actual_value

--- a/files/zh-cn/web/css/gradient/repeating-linear-gradient/index.md
+++ b/files/zh-cn/web/css/gradient/repeating-linear-gradient/index.md
@@ -134,5 +134,5 @@ div {
 
 ## 参见
 
-- [使用 CSS 渐变](/zh-CN/CSS/Using_CSS_gradients)
+- [使用 CSS 渐变](/zh-CN/docs/Web/CSS/CSS_images/Using_CSS_gradients)
 - 其他渐变方法：{{cssxref("linear-gradient")}}, {{cssxref("radial-gradient")}}, {{cssxref("repeating-radial-gradient")}}

--- a/files/zh-cn/web/css/gradient/repeating-linear-gradient/index.md
+++ b/files/zh-cn/web/css/gradient/repeating-linear-gradient/index.md
@@ -135,4 +135,9 @@ div {
 ## 参见
 
 - [使用 CSS 渐变](/zh-CN/docs/Web/CSS/CSS_images/Using_CSS_gradients)
-- 其他渐变方法：{{cssxref("linear-gradient")}}, {{cssxref("radial-gradient")}}, {{cssxref("repeating-radial-gradient")}}
+- 其他渐变函数：{{cssxref("gradient/linear-gradient", "linear-gradient()")}}、{{cssxref("gradient/radial-gradient", "radial-gradient()")}}、{{cssxref("gradient/repeating-radial-gradient", "repeating-radial-gradient()")}}、{{cssxref("gradient/conic-gradient", "conic-gradient()")}}、{{cssxref("gradient/repeating-conic-gradient", "repeating-conic-gradient()")}}
+- {{cssxref("&lt;image&gt;")}}
+- {{cssxref("image/image","image()")}}
+- {{cssxref("element", "element()")}}
+- {{cssxref("image/image-set","image-set()")}}
+- {{cssxref("cross-fade", "cross-fade()")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
fix links pointing to old `/zh-CN/docs/CSS/Using_CSS_gradients` and added the redirection
### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
[这个页面](https://developer.mozilla.org/zh-CN/docs/Web/CSS/gradient/repeating-linear-gradient#%E5%8F%82%E8%A7%81)最后的`参见`部分指向了不可用的地址，打开会提示Not Found
### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
