### PR TITLE
a要素のページの電話番号リンク箇所の脱字を修正

### DIFF
--- a/files/ja/web/html/element/a/index.md
+++ b/files/ja/web/html/element/a/index.md
@@ -247,7 +247,7 @@ a { display: block; margin-bottom: 0.5em }
 - 携帯電話ではその番号に自動ダイヤルします。
 - 多くのオペレーティングシステムには、 Skype や FaceTime のように電話をかけるプログラムがあります。
 - ウェブサイトは {{domxref("Navigator/registerProtocolHandler", "registerProtocolHandler")}} によって `web.skype.com` などを用いて電話を掛けることができます。
-- 他にも、連絡先の電話番号をしたり、他の端末へ電話番号を送信したりする動作があります。
+- 他にも、連絡先の電話番号を保存したり、他の端末へ電話番号を送信したりする動作があります。
 
 `tel` URL スキームについての構文、追加機能、その他の詳細について、詳しくは {{RFC(3966)}} をご覧ください。
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- 日本版の[a要素のページ](https://developer.mozilla.org/ja/docs/Web/HTML/Element/a)の電話番号リンクの説明文内の脱字を修正しました。
- 原文は`"save the number in your contacts"`ですが、日本版ページでは`"save"`の意味が抜けていると思われます。

### Motivation

- 読者に正確な情報を提供するため。

### Additional details

- 特になし

### Related issues and pull requests

- https://github.com/mozilla-japan/translation/issues/702
