### PR TITLE
fix(html): Broken link to HTMLVideoElement

### DIFF
--- a/files/es/web/html/element/video/index.md
+++ b/files/es/web/html/element/video/index.md
@@ -87,7 +87,7 @@ Su proveedor de alojamiento web puede proporcionar una interfaz fácil para los 
 
 ## Interfaz DOM
 
-- [HTMLVideoElement](/en/DOM/HTMLVideoElement)
+- {{domxref("HTMLVideoElement")}}
 
 ## Consulta también
 


### PR DESCRIPTION
This is a common 404. 

It should point to 
* https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement instead of 
* https://developer.mozilla.org/en-US/docs/DOM/HTMLVideoElement


