### PR TITLE
Update index.md

### DIFF
--- a/files/es/web/api/mediadevices/getusermedia/index.md
+++ b/files/es/web/api/mediadevices/getusermedia/index.md
@@ -5,7 +5,7 @@ slug: Web/API/MediaDevices/getUserMedia
 
 {{APIRef("WebRTC")}}{{SeeCompatTable}}
 
-El método **`MediaDevices.getUserMedia()`** solicita al usuario permisos para usar un dispositivo de entrada de vídeo y/o uno de audio como una cámara o compartir la pantalla y/o micrófono. Si el usuario proporciona los permisos, entonces le retornará un {{domxref("Promise")}} que es resuelto por el resultado del objeto [`MediaStream`](/en-US/docs/WebRTC/MediaStream_API#LocalMediaStream). Si el usuario niega el permiso, o si el recurso multimedia no es válido, entonces el promise es rechazado con `PermissionDeniedError` o `NotFoundError` respectivamente. Nótese que es posible que el promise retornado no sea ni resuelto ni rechazado, ya que no se requiere que el usuario tome una decisión.
+El método **`MediaDevices.getUserMedia()`** solicita al usuario permisos para usar un dispositivo de entrada de vídeo y/o uno de audio como una cámara o compartir la pantalla y/o micrófono. Si el usuario proporciona los permisos, entonces le retornará un {{domxref("Promise")}} que es resuelto por el resultado del objeto [`MediaStream`](/en-US/docs/WebRTC/MediaStream_API#LocalMediaStream). Si el usuario niega el permiso, o si el recurso multimedia no es válido, entonces el promise es rechazado con `NotAllowedError` o `NotFoundError` respectivamente. Nótese que es posible que el promise retornado no sea ni resuelto ni rechazado, ya que no se requiere que el usuario tome una decisión.
 
 ## Sintaxis
 


### PR DESCRIPTION
 without-permissions-getUserMedia-return-NotAllowedError

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Se puede tener problemas a la hora de manejar errores ejecutando el metodo getUserMedia. En la traduccion dice, que el metodo devuelve un "PermissionDeniedError" esto implica que ese es el nombre del error pero la verdad que el nombre es "NotAllowedError" y el mensaje es "Permission denied". Esto me causo conflictos ya que busque en la documentacion y no podia manejar el error ni mediante la propiedad "name" ni mediante la propiedad "message" debido a que PermissionDeniedError no lo obtenia en ningun lado.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
