### PR TITLE
fix: typo on compatible translated word - PT-BR

### DIFF
--- a/files/pt-br/web/http/csp/index.md
+++ b/files/pt-br/web/http/csp/index.md
@@ -17,7 +17,7 @@ Alternativamente, o elemento {{HTMLElement("meta")}} pode ser usado para configu
 
 Um objetivo primário do CSP é de mitigar e reportar ataques XSS. Os ataques de XSS exploram a confiaça do navegador sobre o conteúdo recebido pelo servidor. Scripts maliciosos são executados pelo navegador da vítima porque o navegador confia na origem do conteúdo, mesmo quando sua origem não está vindo de onde parece que está vindo.
 
-O CSP faz com que seja possível para administradores de servidores reduzirem ou eliminarem os vetores em que os ataques de XSS podem ocorrer, especificando os domínios que o navegador deve considerar como origens válidas de scripts para serem executados. Um navegador compátivel com o CSP só irá executar então scripts que vierem de arquivos que estejam presentes nos domínios que foram previamente especificados como confiáveis, ignorando todos os outros scripts (incluindo scripts inline e atributos HTML de manipulação de eventos).
+O CSP faz com que seja possível para administradores de servidores reduzirem ou eliminarem os vetores em que os ataques de XSS podem ocorrer, especificando os domínios que o navegador deve considerar como origens válidas de scripts para serem executados. Um navegador compatível com o CSP só irá executar então scripts que vierem de arquivos que estejam presentes nos domínios que foram previamente especificados como confiáveis, ignorando todos os outros scripts (incluindo scripts inline e atributos HTML de manipulação de eventos).
 
 Como uma forma de proteção final, os sites que querem nunca permitir a execução de scripts podem optar para desabilitar a execução globalmente.
 

--- a/files/pt-br/web/http/csp/index.md
+++ b/files/pt-br/web/http/csp/index.md
@@ -17,7 +17,7 @@ Alternativamente, o elemento {{HTMLElement("meta")}} pode ser usado para configu
 
 Um objetivo primário do CSP é de mitigar e reportar ataques XSS. Os ataques de XSS exploram a confiaça do navegador sobre o conteúdo recebido pelo servidor. Scripts maliciosos são executados pelo navegador da vítima porque o navegador confia na origem do conteúdo, mesmo quando sua origem não está vindo de onde parece que está vindo.
 
-O CSP faz com que seja possível para administradores de servidores reduzirem ou eliminarem os vetores em que os ataques de XSS podem ocorrer, especificando os domínios que o navegador deve considerar como origens válidas de scripts para serem executados. Um navegador comátivel com o CSP só irá executar então scripts que vierem de arquivos que estejam presentes nos domínios que foram previamente especificados como confiáveis, ignorando todos os outros scripts (incluindo scripts inline e atributos HTML de manipulação de eventos).
+O CSP faz com que seja possível para administradores de servidores reduzirem ou eliminarem os vetores em que os ataques de XSS podem ocorrer, especificando os domínios que o navegador deve considerar como origens válidas de scripts para serem executados. Um navegador compátivel com o CSP só irá executar então scripts que vierem de arquivos que estejam presentes nos domínios que foram previamente especificados como confiáveis, ignorando todos os outros scripts (incluindo scripts inline e atributos HTML de manipulação de eventos).
 
 Como uma forma de proteção final, os sites que querem nunca permitir a execução de scripts podem optar para desabilitar a execução globalmente.
 


### PR DESCRIPTION
The word was missing a letter and with wrong accentuation.  was: `comátivel`
should be: compatível

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
I was reading brazilian portuguese docs when i saw a word i don't reconize `comátivel`, switching to english version i see it supposed to be the translations of `compatible`. 
Firstly was missing a letter `p` to become `compátivel` but the accentuation was also incorrect. The right way to translate  `compatible` is `compatível`

### Motivation
Wrong and not existing word causing confusion when reading the docs.

### Additional details
<img width="1433" alt="Captura de Tela 2023-07-03 às 17 13 02" src="https://github.com/mdn/translated-content/assets/6757777/836fa96e-d49b-4a35-b622-e828d9a5c323">


### Related issues and pull requests
Havent found any