### PR TITLE
fix(ru): remove redundant compatibility snippet (#14028)

### DIFF
--- a/files/ru/web/api/cache/index.md
+++ b/files/ru/web/api/cache/index.md
@@ -4,7 +4,7 @@ slug: Web/API/Cache
 translation_of: Web/API/Cache
 ---
 
-{{APIRef("Service Workers API")}}{{SeeCompatTable}}
+{{APIRef("Service Workers API")}}
 
 Интерфейс **`Cache`** представляет собой механизм хранения пары объектов [`Request`](http://fetch.spec.whatwg.org/#request) / `Response,` которые кешируются, например, как часть жизненного цикла {{domxref("ServiceWorker")}}. Заметьте, что интерфейс Cache доступен как в области видимости окна, так и в области видимости воркеров. Не обязательно использовать его вместе с сервис воркерами, даже если интерфейс определён в их спецификации.
 


### PR DESCRIPTION
Sync compatibility flag on translated page.