### PR TITLE
es: Move ARIA Techniques as en-US

### DIFF
--- a/files/es/_redirects.txt
+++ b/files/es/_redirects.txt
@@ -1756,12 +1756,12 @@
 /es/docs/Web/Accesibilidad/Understanding_WCAG/Perceivable	/es/docs/Web/Accessibility/Understanding_WCAG/Perceivable
 /es/docs/Web/Accesibilidad/Understanding_WCAG/Perceivable/Color_contraste	/es/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast
 /es/docs/Web/Accesibilidad/Understanding_WCAG/Teclado	/es/docs/Web/Accessibility/Understanding_WCAG/Keyboard
-/es/docs/Web/Accessibility/ARIA/ARIA_Techniques/Usando_el_atributo_aria-required	/es/docs/orphaned/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_attribute
+/es/docs/Web/Accessibility/ARIA/ARIA_Techniques/Usando_el_atributo_aria-required	/es/docs/Web/Accessibility/ARIA/Attributes/aria-required
 /es/docs/Web/Accessibility/ARIA/ARIA_Techniques/Usando_el_rol_alertdialog	/es/docs/Web/Accessibility/ARIA/Roles/alertdialog_role
 /es/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role	/es/docs/Web/Accessibility/ARIA/Roles/alert_role
 /es/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alertdialog_role	/es/docs/Web/Accessibility/ARIA/Roles/alertdialog_role
-/es/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute	/es/docs/orphaned/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute
-/es/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_attribute	/es/docs/orphaned/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_attribute
+/es/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute	/es/docs/Web/Accessibility/ARIA/Attributes/aria-label
+/es/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_attribute	/es/docs/Web/Accessibility/ARIA/Attributes/aria-required
 /es/docs/Web/Accessibility/ARIA/forms	/es/docs/conflicting/Web/Accessibility/ARIA_44f49c8e1fe8e4c12920395d890bd793
 /es/docs/Web/Accessibility/ARIA/forms/Basic_form_hints	/es/docs/conflicting/Web/Accessibility/ARIA_64707ba1917a56654679cbe273e2f4ea
 /es/docs/Web/Accessibility/ARIA/forms/Etiquetas_complejas	/es/docs/Web/Accessibility/ARIA/Multipart_labels
@@ -2958,4 +2958,6 @@
 /es/docs/orphaned/Web/API/NavigatorOnLine	/es/docs/Web/API/Navigator
 /es/docs/orphaned/Web/API/NavigatorOnLine/Online_and_offline_events	/es/docs/Web/API/Navigator/onLine
 /es/docs/orphaned/Web/API/NavigatorOnLine/onLine	/es/docs/Web/API/Navigator/onLine
+/es/docs/orphaned/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute	/es/docs/Web/Accessibility/ARIA/Attributes/aria-label
+/es/docs/orphaned/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_attribute	/es/docs/Web/Accessibility/ARIA/Attributes/aria-required
 /es/docs/video	/es/docs/Web/HTML/Element/video

--- a/files/es/_wikihistory.json
+++ b/files/es/_wikihistory.json
@@ -6078,6 +6078,21 @@
     "modified": "2019-03-23T22:46:27.954Z",
     "contributors": ["chrisdavidmills"]
   },
+  "Web/Accessibility/ARIA/Attributes/aria-label": {
+    "modified": "2020-12-02T07:09:06.472Z",
+    "contributors": [
+      "AlePerez92",
+      "mitsurugi",
+      "fraboto",
+      "blanchart",
+      "ErikMj69",
+      "NelsonWF"
+    ]
+  },
+  "Web/Accessibility/ARIA/Attributes/aria-required": {
+    "modified": "2019-08-28T11:54:04.515Z",
+    "contributors": ["IsraelFloresDGA", "Karla_Glez"]
+  },
   "Web/Accessibility/ARIA/Multipart_labels": {
     "modified": "2019-11-27T15:16:55.571Z",
     "contributors": ["IsaacAaron", "IsraelFloresDGA"]
@@ -15555,21 +15570,6 @@
   "orphaned/Web/API/WindowEventHandlers": {
     "modified": "2019-03-23T23:01:29.892Z",
     "contributors": ["fscholz"]
-  },
-  "orphaned/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute": {
-    "modified": "2020-12-02T07:09:06.472Z",
-    "contributors": [
-      "AlePerez92",
-      "mitsurugi",
-      "fraboto",
-      "blanchart",
-      "ErikMj69",
-      "NelsonWF"
-    ]
-  },
-  "orphaned/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_attribute": {
-    "modified": "2019-08-28T11:54:04.515Z",
-    "contributors": ["IsraelFloresDGA", "Karla_Glez"]
   },
   "orphaned/Web/CSS/-moz-context-properties": {
     "modified": "2020-10-15T22:13:14.061Z",

--- a/files/es/web/accessibility/aria/attributes/aria-label/index.md
+++ b/files/es/web/accessibility/aria/attributes/aria-label/index.md
@@ -1,6 +1,6 @@
 ---
 title: Utilizando el atributo  aria-label
-slug: orphaned/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute
+slug: Web/Accessibility/ARIA/Attributes/aria-label
 original_slug: Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute
 ---
 

--- a/files/es/web/accessibility/aria/attributes/aria-required/index.md
+++ b/files/es/web/accessibility/aria/attributes/aria-required/index.md
@@ -1,6 +1,6 @@
 ---
 title: Usando el atributo aria-required
-slug: orphaned/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_attribute
+slug: Web/Accessibility/ARIA/Attributes/aria-required
 original_slug: Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_attribute
 ---
 

--- a/files/es/web/accessibility/aria/attributes/index.md
+++ b/files/es/web/accessibility/aria/attributes/index.md
@@ -1,0 +1,124 @@
+---
+title: Estados y propiedades de ARIA
+slug: Web/Accessibility/ARIA/Attributes
+l10n:
+  sourceCommit: f6d04a43eadf5ab26a3488942dfb318b58234eb5
+---
+
+Esta página enumera las páginas de referencia que cubren todos los atributos de <abbr>WAI-ARIA</abbr> discutidos en MDN.
+
+Los atributos <abbr>ARIA</abbr> permiten modificar los estados y las propiedades de un elemento tal como se define en el árbol d
+
+> **Nota:** ARIA solo modifica el árbol de accesibilidad, modificando cómo la tecnología de asistencia presenta el contenido a sus usuarios. ARIA no cambia nada sobre la función o el comportamiento de un elemento. Cuando no use elementos HTML semánticos para su propósito previsto y funcionalidad predeterminada, debe usar JavaScript para administrar el comportamiento, el enfoque y los estados ARIA.
+
+## Tipos de atributos ARIA
+
+Hay 4 categorías de estados y propiedades ARIA:
+
+1. ### Atributos de widgets
+
+   - [`aria-autocomplete`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-autocomplete)
+   - [`aria-checked`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-checked)
+   - [`aria-disabled`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-disabled)
+   - [`aria-errormessage`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-errormessage)
+   - [`aria-expanded`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-expanded)
+   - [`aria-haspopup`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup)
+   - [`aria-hidden`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-hidden)
+   - [`aria-invalid`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-invalid)
+   - [`aria-label`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-label)
+   - [`aria-level`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-level)
+   - [`aria-modal`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-modal)
+   - [`aria-multiline`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-multiline)
+   - [`aria-multiselectable`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-multiselectable)
+   - [`aria-orientation`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-orientation)
+   - [`aria-placeholder`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-placeholder)
+   - [`aria-pressed`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-pressed)
+   - [`aria-readonly`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-readonly)
+   - [`aria-required`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-required)
+   - [`aria-selected`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-selected)
+   - [`aria-sort`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-sort)
+   - [`aria-valuemax`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-valuemax)
+   - [`aria-valuemin`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-valuemin)
+   - [`aria-valuenow`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-valuenow)
+   - [`aria-valuetext`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-valuetext)
+
+2. ### Atributos de región en vivo
+
+   - [`aria-busy`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-busy)
+   - [`aria-live`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-live)
+   - [`aria-relevant`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-relevant)
+   - [`aria-atomic`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-atomic)
+
+3. ### Atributos de arrastrar y soltar
+
+   - [`aria-dropeffect`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-dropeffect)
+   - [`aria-grabbed`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-grabbed)
+
+4. ### Atributos de relación
+
+   - [`aria-activedescendant`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-activedescendant)
+   - [`aria-colcount`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-colcount)
+   - [`aria-colindex`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-colindex)
+   - [`aria-colspan`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-colspan)
+   - [`aria-controls`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-controls)
+   - [`aria-describedby`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-describedby)
+   - [`aria-description`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-description)
+   - [`aria-details`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-details)
+   - [`aria-errormessage`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-errormessage)
+   - [`aria-flowto`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-flowto)
+   - [`aria-labelledby`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby)
+   - [`aria-owns`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-owns)
+   - [`aria-posinset`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-posinset)
+   - [`aria-rowcount`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-rowcount)
+   - [`aria-rowindex`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex)
+   - [`aria-rowspan`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-rowspan)
+   - [`aria-setsize`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-setsize)
+
+## Atributos ARIA globales
+
+Algunos estados y propiedades se aplican a todos los elementos HTML independientemente de si se aplica una función ARIA. Estos se definen como atributos "Globales". Los estados y propiedades globales son compatibles con todos los roles y elementos de marcado base.
+
+Muchos de los atributos anteriores son globales, lo que significa que se pueden incluir en cualquier elemento a menos que se deshabilite específicamente:
+
+- [`aria-atomic`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-atomic)
+- [`aria-busy`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-busy)
+- [`aria-controls`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-controls)
+- [`aria-current`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-current)
+- [`aria-describedby`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-describedby)
+- [`aria-description`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-description)
+- [`aria-details`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-details)
+- [`aria-disabled`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-disabled)
+- [`aria-dropeffect`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-dropeffect)
+- [`aria-errormessage`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-errormessage)
+- [`aria-flowto`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-flowto)
+- [`aria-grabbed`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-grabbed)
+- [`aria-haspopup`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup)
+- [`aria-hidden`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-hidden)
+- [`aria-invalid`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-invalid)
+- [`aria-keyshortcuts`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-keyshortcuts)
+- [`aria-label`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-label)
+- [`aria-labelledby`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby)
+- [`aria-live`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-live)
+- [`aria-owns`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-owns)
+- [`aria-relevant`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-relevant)
+- [`aria-roledescription`](/es/docs/Web/Accessibility/ARIA/Attributes/aria-roledescription)
+
+Por "deshabilitar específicamente" se refiere a que, todos los atributos anteriores son globales excepto las propiedades `aria-label` y `aria-labelledby`, que no están permitidas en elementos con rol [`presentation`](/es/docs/Web/Accessibility/ARIA/Roles/presentation_role) ni su sinónimo el rol [`none`](/es/docs/Web/Accessibility/ARIA/Roles/none_role).
+
+## Estados y propiedades definidas en MDN
+
+Las siguientes son las páginas de referencia que cubren los estados y propiedades de <abbr>WAI-ARIA</abbr> discutidos en <abbr>MDN</abbr>.
+
+{{SubpagesWithSummaries}}
+
+## Véase también
+
+- [Uso de ARIA: funciones, estados y propiedades](/es/docs/Web/Accessibility/ARIA/ARIA_Techniques)
+
+<section id="Quick_links">
+
+1. [**Atributos <abbr>WAI-ARIA</abbr>**](/es/docs/Web/Accessibility/ARIA/Attributes)
+
+   {{ListSubpagesForSidebar("/es/docs/Web/Accessibility/ARIA/Attributes")}}
+
+</section>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Move ARIA Techniques as en-US in https://github.com/mdn/content/pull/11546

ARIA Techniques pages was removed and redirected in favour to ARIA/Attributes in `en-US` so I move the pages to follow the same structure and created the page ARIA/Attributes/index.md to make this possible

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
