### PR TITLE
There is a typo in the syntax section of page `Intl.PluralRules.selectRange()`(Both of `ja` and `fr`)

### DIFF
--- a/files/fr/web/javascript/reference/global_objects/intl/pluralrules/selectrange/index.md
+++ b/files/fr/web/javascript/reference/global_objects/intl/pluralrules/selectrange/index.md
@@ -12,7 +12,7 @@ La méthode **`Intl.PluralRules.prototype.selectRange()`** reçoit deux valeurs 
 ## Syntaxe
 
 ```js
-formatRange(debutIntervalle, finIntervalle)
+selectRange(debutIntervalle, finIntervalle)
 ```
 
 ### Valeur de retour

--- a/files/ja/web/javascript/reference/global_objects/intl/pluralrules/selectrange/index.md
+++ b/files/ja/web/javascript/reference/global_objects/intl/pluralrules/selectrange/index.md
@@ -10,7 +10,7 @@ slug: Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/selectRange
 ## 構文
 
 ```js
-formatRange(startRange, endRange)
+selectRange(startRange, endRange)
 ```
 
 ### 返値


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Target page
- [ja page](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/selectRange#%E6%A7%8B%E6%96%87)
- [fr page](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/selectRange#syntaxe)

In the syntax section of both pages, it is written `formatRange`, but it is correctly `selectRange()`.

(The original(English) version is correctly written as `selectRange()`.)

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Because of the typo.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

None.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

None.