### PR TITLE
[es] fix: Tipo in ESP doc (#13955)

### DIFF
--- a/files/es/web/http/headers/cookie/index.md
+++ b/files/es/web/http/headers/cookie/index.md
@@ -22,7 +22,7 @@ Cookie: nombre=valor; nombre2=valor2...nombreN=valorN;
 ```
 
 - \<cookie-lista>
-  - : Una lista de pares `nombre:valor` definidos como `<nombre-de-cookie=<valor-de-cookie>`. Los pares en la lista son separados por un punto y coma seguido de un espacio `('; ')`.
+  - : Una lista de pares `nombre:valor` definidos como `<nombre-de-cookie>=<valor-de-cookie>`. Los pares en la lista son separados por un punto y coma seguido de un espacio `('; ')`.
 
 ## Ejemplos
 


### PR DESCRIPTION
### Description

Fix typo in https://developer.mozilla.org/es/docs/Web/HTTP/Headers/Cookie

### Motivation

Fix es doc according to en doc

### Additional details
### Related issues and pull requests

Fixes #13955
