### PR TITLE
fix(ru): broken `EmbedLiveSample` in CSS gap-* articles

### DIFF
--- a/files/ru/web/css/column-gap/index.md
+++ b/files/ru/web/css/column-gap/index.md
@@ -88,7 +88,7 @@ column-gap: unset;
 
 #### Результат
 
-{{EmbedLiveSample("Flex_layout", "auto", "120px")}}
+{{EmbedLiveSample("Флексбокс-раскладка", "auto", "120px")}}
 
 ### Грид-раскладка
 
@@ -121,7 +121,7 @@ column-gap: unset;
 
 #### Результат
 
-{{EmbedLiveSample("Grid_layout", "auto", "120px")}}
+{{EmbedLiveSample("Грид-раскладка", "auto", "120px")}}
 
 ### Многоколоночная раскладка
 
@@ -145,7 +145,7 @@ column-gap: unset;
 
 #### Результат
 
-{{EmbedLiveSample("Multi-column_layout", "auto", "120px")}}
+{{EmbedLiveSample("Многоколоночная_раскладка", "auto", "120px")}}
 
 ## Спецификации
 

--- a/files/ru/web/css/gap/index.md
+++ b/files/ru/web/css/gap/index.md
@@ -70,7 +70,7 @@ gap: unset;
 
 ## Примеры
 
-### Флекс-раскладка
+### Флексбокс-раскладка
 
 #### HTML
 
@@ -106,7 +106,7 @@ gap: unset;
 
 #### Результат
 
-{{EmbedLiveSample("Flex_layout", "auto", 250)}}
+{{EmbedLiveSample("Флексбокс-раскладка", "auto", 250)}}
 
 ### Грид-раскладка
 
@@ -144,7 +144,7 @@ gap: unset;
 
 #### Результат
 
-{{EmbedLiveSample("Grid_layout", "auto", "250")}}
+{{EmbedLiveSample("Грид-раскладка", "auto", 250)}}
 
 ### Многоколоночная раскладка
 
@@ -168,7 +168,7 @@ gap: unset;
 
 #### Результат
 
-{{EmbedLiveSample("Multi-column_layout", "auto", "120px")}}
+{{EmbedLiveSample("Многоколоночная_раскладка", "auto", "120px")}}
 
 ## Спецификации
 

--- a/files/ru/web/css/row-gap/index.md
+++ b/files/ru/web/css/row-gap/index.md
@@ -85,7 +85,7 @@ row-gap: unset;
 
 #### Результат
 
-{{EmbedLiveSample('Flex_layout', "auto", "120px")}}
+{{EmbedLiveSample('Флексбокс-раскладка', "auto", "120px")}}
 
 ### Грид-раскладка
 
@@ -118,7 +118,7 @@ row-gap: unset;
 
 #### Результат
 
-{{EmbedLiveSample('Grid_layout', 'auto', 120)}}
+{{EmbedLiveSample('Грид-раскладка', 'auto', 120)}}
 
 ## Спецификации
 


### PR DESCRIPTION
Live samples was broken in https://github.com/mdn/translated-content/commit/c36c436cd4e939094c9782b5f4cd2b949b1b530e