### PR TITLE
Prettier: ignore auto-generated files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,6 @@
 build/
+/files/**/_wikihistory.json
+/files/**/_githistory.json
 
 # A full pass on all Markdown files is being performed.
 # When starting a new folder, please expand the glob pattern


### PR DESCRIPTION
This PR updates Prettier to ignore auto-generated files, specifically `_githistory.json` and `_wikihistory.json`.
