### PR TITLE
ru: Fix file extension and remove duplicated front-matter keys

### DIFF
--- a/files/ru/web/css/accent-color/index.md
+++ b/files/ru/web/css/accent-color/index.md
@@ -1,19 +1,6 @@
 ---
 title: accent-color
 slug: Web/CSS/accent-color
-page-type: css-property
-tags:
-  - CSS
-  - CSS Property
-  - CSS User Interface
-  - HTML Colors
-  - Input
-  - Reference
-  - Styling HTML
-  - accent-color
-  - recipe:css-property
-browser-compat: css.properties.accent-color
-translation_of: Web/CSS/accent-colors
 ---
 
 {{CSSRef}}


### PR DESCRIPTION
This PR fixes the file for Web/CSS/accent-color, which was incorrectly set to `.html` rather than `.md`.  This was caught due to Prettier improperly formatting the file.

Additionally, this removes duplicated frontmatter keys that aren't needed.
