### PR TITLE
Format root files with Prettier

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-content-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/new-content-suggestion.md
@@ -7,9 +7,11 @@ title: "Content suggestion: <TITLE OF SUGGESTION>"
 ---
 
 ## What is the new suggestion?
+
 <!-- include a short description of the content work suggestion  -->
 
 ## Why is it important or useful?
+
 <!-- Tell us why the idea is important or useful. Include any information you
 can think of that would be useful, for example:
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,11 +7,6 @@ build/
 # and remove the corresponding line from this file.
 # The following folders still need a full pass:
 
-# system files
-/.github/**/*.md
-/docs/README.md
-/README.md
-
 # es
 /docs/es/**/*.md
 /files/es/**/*.md

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ Now you need to fork and clone both the [content repo](https://github.com/mdn/co
 
 1. Navigate to your local clone of the content repository fork:
 
-    ```bash
-    cd ~/path/to/content
-    ```
+   ```bash
+   cd ~/path/to/content
+   ```
 
 2. Run the command `yarn install` to fetch the latest packages and get the local MDN testing environment set up. It is also recommended that you run `yarn install` before every update you do to the source, to make sure you have the latest packages.
 
-3. Next, create an environment variable called `CONTENT_TRANSLATED_ROOT` containing the path to the *translated-content* repo’s `files` directory. You could do this for a single session like so:
+3. Next, create an environment variable called `CONTENT_TRANSLATED_ROOT` containing the path to the _translated-content_ repo’s `files` directory. You could do this for a single session like so:
 
    ```bash
    export CONTENT_TRANSLATED_ROOT=/path/to/translated-content/files

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,7 @@ to link to from your translated page.
 In some of the article source code, you may find line breaks in the block-level
 elements that aren't strictly necessary, for example:
 
-```html
+```html-nolint
 <p>The
   <strong><code>HTMLCanvasElement.transferControlToOffscreen()</code></strong>
   method transfers control to an {{domxref("OffscreenCanvas")}} object, either on the main


### PR DESCRIPTION
This PR formats files in the root, in `.github`, and other non-locale specific files, with Prettier.
