### PR TITLE
ci: only run lint for locale matrix

### DIFF
--- a/.github/workflows/markdown-lint-fix.yml
+++ b/.github/workflows/markdown-lint-fix.yml
@@ -40,7 +40,8 @@ jobs:
 
       - name: Lint markdown files
         run: |
-          yarn fix:md "**/${{ matrix.lang }}/**/*.md"
+          yarn markdownlint-cli2-fix "**/${{ matrix.lang }}/**/*.md"
+          yarn prettier -w "**/${{ matrix.lang }}/**/*.md"
 
       - name: Create PR with only fixable issues
         if: success()


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Partial revert for https://github.com/mdn/translated-content/pull/14195#discussion_r1263757152 since the Yarn target would run on everything, not the locale specific job in the matrix

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
