### PR TITLE
Synchronize Markdownlint configuration with upstream

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -14,12 +14,19 @@
       "spaces_per_tab": 2
     },
     "MD013": false,
-    // Fixed upstream with "allow_different_nesting": true
     "MD024": false,
+    // XXX Replace with the following when ready:
+    // "MD024": {
+    //   "allow_different_nesting": true
+    // },
     "MD025": {
       "front_matter_title": "^\\s*title\\s*[:=]"
     },
     "MD026": false,
+    // XXX Replace with the following when ready:
+    // "MD026": {
+    //   "punctuation": ".,;:"
+    // },
     // Consecutive Notes/Callouts currently don't conform with this rule
     "MD028": false,
     // Force ordered numbering to catch accidental list ending from indenting
@@ -96,9 +103,9 @@
         "tr",
         "ul",
         "var",
-        "ruby", //Used in some Korean documents
-        "rp", //Used in some Korean documents
-        "rt", //Used in some Korean documents
+        "ruby", // Used in some Korean documents
+        "rp", // Used in some Korean documents
+        "rt", // Used in some Korean documents
         "i", // French translations use this for English literal text
         "q", // French translations use this for English literal text
         "h2", // Not always converted currently because of live samples using English IDs
@@ -107,20 +114,23 @@
       ]
     },
     "MD034": false,
-    // Fixed upstream, needs PRs in this repo
+    // XXX Fixed upstream, enable rule when fixed here
     "MD036": false,
-    // Upstream fixing in https://github.com/mdn/content/pull/20115
+    // Produces too many false positives
     "MD037": false,
     "MD040": false,
     // See https://github.com/mdn/content/pull/20026, as macros currently break this
     "MD042": false,
-    // Tracked upstream as part of https://github.com/mdn/content/pull/19334
+    // XXX Fixed upstream, enable rule when fixed here
     "MD045": false,
     "MD046": {
       "style": "fenced"
     },
-    // MD049 is set to underscore upstream, not yet fixed here
     "MD049": false,
+    // XXX Replace with the following when ready:
+    // "MD049": {
+    //   "style": "underscore"
+    // },
     "MD050": {
       "style": "asterisk"
     },
@@ -131,48 +141,85 @@
     "MD052": false,
     "search-replace": {
       "rules": [
+        // XXX Many instances still found in translated content
+        // {
+        //   "name": "curly-double-quotes",
+        //   "message": "Don't use curly double quotes",
+        //   "searchPattern": "/“|”/g",
+        //   "replace": "\"",
+        //   "searchScope": "text"
+        // },
+        // {
+        //   "name": "curly-single-quotes",
+        //   "message": "Don't use curly single quotes",
+        //   "searchPattern": "/‘|’/g",
+        //   "replace": "'",
+        //   "searchScope": "text"
+        // },
         {
           "name": "nbsp",
           "message": "Don't use no-break spaces",
           "searchPattern": "/ /g",
           "replace": " ",
-          "skipCode": false
+          "searchScope": "all"
         },
+        // XXX Many instances still found in translated content
+        // {
+        //   "name": "m-dash",
+        //   "message": "Don't use '--'. Use m-dash — instead",
+        //   "search": " -- ",
+        //   "replace": " — ",
+        //   "searchScope": "text"
+        // },
+        // {
+        //   "name": "relative-link",
+        //   "message": "Internal links should start with '/'",
+        //   "searchPattern": "/([\\(\"])[\\w\\-]+\\/docs/g",
+        //   "replace": "$1/en-US/docs",
+        //   "searchScope": "text"
+        // },
         {
           "name": "relative-link-path",
           "message": "Don't use relative paths",
           "search": "](..",
-          "skipCode": true
+          "searchScope": "text"
         },
         {
           "name": "trailing-spaces",
           "message": "Avoid trailing spaces",
           "searchPattern": "/  +$/gm",
           "replace": "",
-          "skipCode": false
+          "searchScope": "all"
         },
-        // This will be replaced with Prettier in the long run
         {
           "name": "double-spaces",
           "message": "Avoid double spaces",
           "searchPattern": "/([^\\s>])  ([^\\s|])/g",
           "replace": "$1 $2",
-          "skipCode": true
+          "searchScope": "text"
         },
         {
           "name": "stuck-definition",
           "message": "Character is stuck to definition description marker",
           "searchPattern": "/- :(\\w)/g",
           "replace": "- : $1",
-          "skipCode": true
+          "searchScope": "text"
         },
         {
           "name": "fqdn-moz-links",
-          "message": "Don't use developer.mozilla.org for links",
-          "search": "](https://developer.mozilla.org/",
+          "message": "Don't use developer.mozilla.org for links, except for blog posts",
+          "searchPattern": "/\\]\\(https:\\/\\/developer.mozilla.org\\/(?!en-US\\/blog\\/)/g",
           "replace": "](/",
-          "skipCode": true
+          "searchScope": "text"
         }
+        // XXX Many instances still found in translated content
+        // {
+        //   "name": "localhost-links",
+        //   "message": "Don't use localhost for links",
+        //   "searchPattern": "/\\]\\(https?:\\/\\/localhost:\\d+\\//g",
+        //   "replace": "](/",
+        //   "searchScope": "text"
+        // }
       ]
     }
   },


### PR DESCRIPTION
This PR synchronizes the Markdownlint configuration with upstream, adding commented-out versions of what the configuration should be when translated-content has caught up.
