### PR TITLE
zh: Add Markdownlint ignores for bad vs. good examples

### DIFF
--- a/docs/zh-cn/translation-guide.md
+++ b/docs/zh-cn/translation-guide.md
@@ -114,12 +114,16 @@ Reference to [Live sample macros](/en-US/docs/MDN/Structures/Live_samples#live_s
 
 #### 常见中/英文标点
 
+<!-- markdownlint-disable search-replace -->
+
 | 名称   | 中文 | 英文    |
 | ------ | ---- | ------- |
 | 括号   | （） | ()      |
 | 冒号   | ：   | :       |
 | 引号   | “”   | ""      |
 | 破折号 | ——   | -- 、 — |
+
+<!-- markdownlint-enable search-replace -->
 
 简体中文标点符号参考资源：
 

--- a/docs/zh-tw/translation-guide.md
+++ b/docs/zh-tw/translation-guide.md
@@ -89,12 +89,16 @@ For example, consider the [JavaScript](/en-US/docs/Web/JavaScript) guide, which 
 
 常見錯誤使用的標點符號（包含但不限於下列的例子）：
 
+<!-- markdownlint-disable search-replace -->
+
 | 名稱   | 正確     | 錯誤     |
 | ------ | -------- | -------- |
 | 夾注號 | （）     | ()       |
 | 冒號   | ：       | :        |
 | 引號   | 「『』」 | “” 、 "" |
 | 破折號 | ——       | -- 、 —  |
+
+<!-- markdownlint-enable search-replace -->
 
 #### 如何輸入全形標點符號
 


### PR DESCRIPTION
This PR adds an ignore for Markdownlint for example blocks showing bad vs. good syntax.  The Markdownlint rules that will be enabled are meant to remove the bad examples, so they would be replaced otherwise.
