### PR TITLE
es: Remove trailing punctuation in headers

### DIFF
--- a/files/es/glossary/blink/index.md
+++ b/files/es/glossary/blink/index.md
@@ -5,7 +5,7 @@ slug: Glossary/Blink
 
 Blink es un motor de renderizado para [navegadores](/es/docs/Glossary/Browser) de código abierto desarrollado por Google, que forma parte de Chromium (y por lo tanto también de [Chrome](/es/docs/Glossary/Google_Chrome)). Concretamente, Blink es una copia de la librería WebCore de [WebKit](/es/docs/Glossary/WebKit), que se encarga del diseño, renderizado, y del [DOM](/es/docs/Glossary/DOM).
 
-## Para saber más...
+## Para saber más
 
 ### Cultura General
 

--- a/files/es/glossary/browser/index.md
+++ b/files/es/glossary/browser/index.md
@@ -5,7 +5,7 @@ slug: Glossary/Browser
 
 Un _Navegador web_ es un programa o aplicación que da acceso a la [Web](/es/docs/Glossary/World_Wide_Web), y permite a los usuarios el acceso a más páginas a través de [hipervínculos](/es/docs/Glossary/Hyperlink).
 
-## Para saber más...
+## Para saber más
 
 ### Cultura general
 

--- a/files/es/glossary/browsing_context/index.md
+++ b/files/es/glossary/browsing_context/index.md
@@ -9,7 +9,7 @@ Cada contexto de navegación tiene un {{glossary("origen")}} específico, el ori
 
 La comunicación entre contextos de navegación está severamente restringida. Entre un contexto de navegación del mismo origen, se puede abrir y utilizar un {{domxref("BroadcastChannel")}}}.
 
-## Aprende más...
+## Aprende más
 
 ### Referencia técnica
 

--- a/files/es/glossary/copyleft/index.md
+++ b/files/es/glossary/copyleft/index.md
@@ -5,7 +5,7 @@ slug: Glossary/Copyleft
 
 _Copyleft_ es un término, que normalmente se refiere a una licencia, y que se utiliza para indicar que toda redistribución de un trabajo bajo esta licencia **es obligatorio** que esté sujeta a la **misma licencia** **que el original**. Un buen ejemplo de copyleft es la licencia GNU [GPL](/es/docs/Glossary/GPL) (para aplicaciones software) y la licencia _Creative Commons SA_ (_Share Alike_ en español Compartir Igual) (para trabajos y obras de arte).
 
-## Para saber más...
+## Para saber más
 
 ### Cultura General
 

--- a/files/es/glossary/dom/index.md
+++ b/files/es/glossary/dom/index.md
@@ -9,7 +9,7 @@ El DOM es una de las APIs más usadas en la [Web](/es/docs/Glossary/World_Wide_W
 
 El DOM surgió a partir de la implementación de [JavaScript](/es/docs/Glossary/JavaScript) en los navegadores. A esta primera versión también se la conoce como DOM 0 o "Legacy DOM". Hoy en día el grupo WHATWG es el encargado de actualizar el estándar de DOM.
 
-## Para saber más...
+## Para saber más
 
 ### Cultura General
 

--- a/files/es/glossary/google_chrome/index.md
+++ b/files/es/glossary/google_chrome/index.md
@@ -5,7 +5,7 @@ slug: Glossary/Google_Chrome
 
 _Google Chrome_ es un [navegador](/es/docs/Glossary/Browser) web gratuito desarrollado por Google. Está basado en el proyecto open source (código abierto / software libre) [Chromium](http://www.chromium.org/). Algunas de las principales diferencias se encuentran en [Chromium wiki](https://code.google.com/p/chromium/wiki/ChromiumBrowserVsGoogleChrome). El motor de diseño que utilizan ambos es una copia del motor [Blink](/es/docs/Glossary/Blink) de [WebKit](/es/docs/Glossary/WebKit). Cabe señalar que en la versión de Chrome en iOS se utiliza WebKit y no Blink.
 
-## Para saber más...
+## Para saber más
 
 ### Cultura general
 

--- a/files/es/glossary/gpl/index.md
+++ b/files/es/glossary/gpl/index.md
@@ -5,7 +5,7 @@ slug: Glossary/GPL
 
 La lincencia GNU _GPL_ (GNU General Public License en español **Licencia Pública General de GNU**) es una licencia de software libre [copyleft](/es/docs/Glossary/copyleft) publicada por la _Free Software Foundation_. Los usuarios de un programa con licencia GPL son libres para usarlo, acceder al código fuente, modificarlo y distribuir los cambios; siempre que redistribuyan el programa completo (modificado o no modificado) bajo la misma licencia.
 
-## Para saber más...
+## Para saber más
 
 ### Cultura General
 

--- a/files/es/glossary/hyperlink/index.md
+++ b/files/es/glossary/hyperlink/index.md
@@ -5,7 +5,7 @@ slug: Glossary/Hyperlink
 
 Los _Hipervínculos_ ó _enlaces_ permiten conectar entre sí datos ó páginas web. En [HTML](/es/docs/Glossary/HTML), los elementos {{HTMLElement("a")}} representan hipervínculos que tienen como origen un elemento de la página web (por ejemplo cadenas de texto o imágenes), y que pueden tener como destino un elemento de otro sitio web (incluso pueden enlazar a otro punto de la misma página).
 
-## Para saber más...
+## Para saber más
 
 ### Cultura General
 

--- a/files/es/glossary/lgpl/index.md
+++ b/files/es/glossary/lgpl/index.md
@@ -9,7 +9,7 @@ Esto supone que cualquier trabajo que use un elemento con licencia GPL **tiene l
 
 LGPL es usado habitualmente para licencias de componentes compartidos como por ejemplo librerías (`.dll`, `.so`, `.jar`, etc.).
 
-## Para saber más...
+## Para saber más
 
 ### Cultura General
 

--- a/files/es/glossary/rss/index.md
+++ b/files/es/glossary/rss/index.md
@@ -7,7 +7,7 @@ _RSS_ (Really Simple Syndication en español Sindicación Realmente Simple) hace
 
 Cuando te subscribes a un _feed_ RSS (boletín de noticias de servicios web), éste te envía información y actualizaciones al _feed_ de tu lector RSS, y de esta manera no es necesario que el usuario busque manuelmente en cada sitio web.
 
-## Para saber más...
+## Para saber más
 
 ### Cultura General
 

--- a/files/es/glossary/webkit/index.md
+++ b/files/es/glossary/webkit/index.md
@@ -9,7 +9,7 @@ WebKit comenzó como una copia del KHTML de KDE y sus librerías KJS, pero desde
 
 WebKit es una marca registrada de Apple, y es distribuido bajo la licencia BSD. Por otro lado, dos de sus más importantes componentes están bajo la licencia [LGPL](/es/docs/Glossary/LGPL): la libería de renderizado HTML de **WebCore** y el motor **JavaScriptCore**.
 
-## Para saber más...
+## Para saber más
 
 ### Cultura General
 

--- a/files/es/glossary/xml/index.md
+++ b/files/es/glossary/xml/index.md
@@ -9,7 +9,7 @@ Las etiquetas XML ó _tags_ son muy similares a las de [HTML](/es/docs/Glossary/
 
 Esto significa que XML tiene una mayor aplicación; por ejemplo, a través de XML los servicios web pueden intercambiar peticiones y respuestas.
 
-## Para saber más...
+## Para saber más
 
 ### General knowledge
 

--- a/files/es/learn/accessibility/mobile/index.md
+++ b/files/es/learn/accessibility/mobile/index.md
@@ -237,7 +237,7 @@ Usando viewport, es posible deshabilitar el zoom, usando un código como este en
 
 Nunca debe hacer esto si es posible: muchas personas confían en el zoom para poder ver el contenido de su sitio web, por lo que eliminar esta funcionalidad es una muy mala idea. Hay ciertas situaciones en las que el zoom podría romper la interfaz de usuario; en tales casos, si cree que necesita deshabilitar el zoom, debe proporcionar algún otro tipo de equivalente, como un control para aumentar el tamaño del texto de una manera que no rompa su interfaz de usuario.
 
-#### Mantener los menús accesibles.
+#### Mantener los menús accesibles
 
 Debido a que la pantalla es mucho más estrecha en los dispositivos móviles, es muy común utilizar consultas de medios y otras tecnologías para hacer que el menú de navegación se reduzca a un pequeño icono en la parte superior de la pantalla, que se puede presionar para mostrar el menú solo si es necesario - cuando el sitio se ve en el móvil. Esto suele representarse mediante un icono de "tres líneas horizontales" y, por lo tanto, el patrón de diseño se conoce como "menú de hamburguesas".
 

--- a/files/es/learn/common_questions/design_and_accessibility/common_web_layouts/index.md
+++ b/files/es/learn/common_questions/design_and_accessibility/common_web_layouts/index.md
@@ -80,7 +80,7 @@ Estudiemos algunos ejemplos más concretos tomados de sitios web bien conocidos.
 
 Bastante sencillo. Sólo recuerda que muchas personas navegarán por tu sitio desde escritorios, así que haz tu contenido también utilizable allí.
 
-### Diseño de dos columnas.
+### Diseño de dos columnas
 
 **[Abduzeedo](http://abduzeedo.com/typography-mania-261)**, un simple diseño de blog. Los blogs usualmente tienen dos columnas, una para el contenido principal que es más ancha y otra más estrecha para el contenido secundario (como widgets, niveles de navegación secundarios y anuncios).
 

--- a/files/es/learn/css/building_blocks/handling_different_text_directions/index.md
+++ b/files/es/learn/css/building_blocks/handling_different_text_directions/index.md
@@ -55,7 +55,7 @@ Los tres valores posibles para la propiedad [`writing-mode`](/es/docs/Web/CSS/wr
 
 Así, la propiedad `writing-mode` está configurando en realidad la direccion en que los elementos de nivel bloque son desplegados en la página - ya sea de arriba abajo, derecha a izquierda, o de izquierda a derecha. Luego señala la dirección del flujo de texto en las frases.
 
-## Modos de escritura y diseño en bloque y lineal.
+## Modos de escritura y diseño en bloque y lineal
 
 Ya hemos visto el diseño en bloque y lineal, y el hecho de que algunas cosas se muestran como elementos de bloque y otras como elementos lineales. Ésto se encuentra ligado al modo de escritura del documento, y no de la pantalla física. Los bloques sólo se presentan desde la parte superior a la inferior de la página si estas usando un modo de escritura que presente el texto horizontalmente, como el español.
 

--- a/files/es/learn/forms/sending_and_retrieving_form_data/index.md
+++ b/files/es/learn/forms/sending_and_retrieving_form_data/index.md
@@ -52,7 +52,7 @@ En el lado del cliente, un formulario HTML no es más que una manera fácil de u
 
 El elemento {{HTMLElement ( "form")}} define cómo se enviarán los datos. Todos sus atributos están diseñados para que pueda configurar la solicitud que se enviará cuando un usuario pulsa un botón de envío. Los dos atributos más importantes son [`acción`](/es/docs/Web/HTML/Element/forma#acción) y [`método`](/es/docs/Web/HTML/Element/forma#método).
 
-#### El atributo [`acción`](/es/docs/Web/HTML/Element/forma#acción).
+#### El atributo [`acción`](/es/docs/Web/HTML/Element/forma#acción)
 
 Este atributo define el lugar donde los datos se envian. Su valor debe ser una dirección URL válida. Si no se proporciona este atributo, los datos serán enviados a la dirección URL de la página que contiene el formulario.
 

--- a/files/es/learn/html/introduction_to_html/html_text_fundamentals/index.md
+++ b/files/es/learn/html/introduction_to_html/html_text_fundamentals/index.md
@@ -983,7 +983,7 @@ textarea.onkeyup = function () {
 
 {{ EmbedLiveSample('Código_reproducible_5', 700, 400, "", "", "hide-codepen-jsfiddle") }}
 
-### Cursiva, negrita, subrayado...
+### Cursiva, negrita, subrayado
 
 Los elementos que hemos comentado hasta ahora tienen asociada una semántica clara. La situación con {{HTMLElement("b")}} (negrita o «**bold**»), {{HTMLElement("i")}} (cursiva o «_italic_») y {{HTMLElement("u")}} (subrayado o «**underline**») es algo más complicada. Surgieron para que las personas pudieran escribir textos en negrita, cursiva o subrayado en un tiempo en el que pocos navegadores o ninguno admitían el CSS. Elementos como estos, que solo afectan a la presentación y no a la semántica, se conocen como **elementos de presentación** y no se deberían usar porque, como hemos visto, la semántica es muy importante para la accesibilidad y el SEO, entre otros aspectos.
 

--- a/files/es/learn/html/tables/basics/index.md
+++ b/files/es/learn/html/tables/basics/index.md
@@ -455,7 +455,7 @@ Usemos `colspan` y `rowspan` para mejorar esta tabla.
 
 > **Nota:** Puedes encontrar nuestro ejemplo terminado en [animals-table-fixed.html](https://github.com/mdn/learning-area/blob/master/html/tables/basic/animals-table-fixed.html) en GitHub ([o consultarlo en vivo](http://mdn.github.io/learning-area/html/tables/basic/animals-table-fixed.html)).
 
-## Proporcionar un estilo común a las columnas.
+## Proporcionar un estilo común a las columnas
 
 Hay una última característica de la que queremos hablar en este artículo antes de continuar. El HTML tiene un método para definir información de estilo para una columna completa de datos en un solo lugar: los elementos **[`<col>`](/es/docs/Web/HTML/Elemento/col)** y **[`<colgroup>`](/es/docs/Web/HTML/Elemento/colgroup)**. Estos atributos existen porque especificar el estilo de las columnas puede resultar enojoso e ineficiente; en general hay que especificar la información de estilo en _cada_ `<td>` o `<th>` de la columna, o utilizar un selector complejo como {{cssxref(":nth-child()")}}.
 

--- a/files/es/learn/javascript/building_blocks/build_your_own_function/index.md
+++ b/files/es/learn/javascript/building_blocks/build_your_own_function/index.md
@@ -12,7 +12,7 @@ Con la mayor parte de la teoría esencial tratada en el artículo anterior, este
 | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Objective:     | Para proporcionar algo de práctica en la construcción de una función personalizada, y explicar algunos detalles asociados más útiles.                                                                                                    |
 
-## Aprendizaje activo: construyamos una función.
+## Aprendizaje activo: construyamos una función
 
 La función personalizada que vamos a construir se llamará `displayMessage()`. Mostrará un cuadro de mensaje personalizado en una página web y actuará como un reemplazo personalizado para la función de [alert()](/es/docs/Web/API/Window/alert) incorporada de un navegador. Hemos visto esto antes, pero solo refresquemos nuestros recuerdos. Escriba lo siguiente en la consola de JavaScript de su navegador, en la página que desee:
 
@@ -161,7 +161,7 @@ y al guardar y volver a cargar, verás que aparece el cuadro de mensaje sin hace
 
 Si has intentado el último experimento, asegúrate de deshacer el último cambio antes de continuar.
 
-## Mejora de la función con parámetros.
+## Mejora de la función con parámetros
 
 Tal como está, la función aún no es muy útil, no queremos mostrar el mismo mensaje predeterminado cada vez. Mejoremos nuestra función agregando algunos parámetros, permitiéndonos llamarla con algunas opciones diferentes.
 
@@ -209,7 +209,7 @@ Tal como está, la función aún no es muy útil, no queremos mostrar el mismo m
 
 4. Vuelva a cargar e intenta el código nuevamente y verás que aún funciona bien, ¡excepto que ahora también puede variar el mensaje dentro del parámetro para obtener diferentes mensajes mostrados en el cuadro!
 
-### Un parámetro más complejo.
+### Un parámetro más complejo
 
 En el siguiente parámetro. Este va a implicar un poco más de trabajo: lo configuraremos de modo que, dependiendo de la configuración del parámetro msgType, la función mostrará un icono diferente y un color de fondo diferente.
 

--- a/files/es/learn/javascript/building_blocks/conditionals/index.md
+++ b/files/es/learn/javascript/building_blocks/conditionals/index.md
@@ -25,7 +25,7 @@ Echemos un vistazo a la declaración condicional más común que usarás en Java
 
 — El humilde [`if ... else`](/es/docs/Web/JavaScript/Reference/Statements/if...else)[statement](/es/docs/Web/JavaScript/Reference/Statements/if...else).
 
-### Sintaxis if ... else básica.
+### Sintaxis if ... else básica
 
 Una sintaxis básica `if...else` luce así. {{glossary("pseudocode")}}:
 

--- a/files/es/learn/javascript/first_steps/a_first_splash/index.md
+++ b/files/es/learn/javascript/first_steps/a_first_splash/index.md
@@ -459,7 +459,7 @@ for (let i = 0 ; i < resetParas.length ; i++) {
 
 Este código crea una variable que contiene una lista de todos los párrafos dentro de `<div class="resultParas">` usando el método {{domxref("document.querySelectorAll", "querySelectorAll()")}}, luego recorre cada uno de ellos, eliminando el texto contenido a su paso.
 
-### Una pequeña explicación sobre objetos.
+### Una pequeña explicación sobre objetos
 
 Agreguemos una mejora final más antes de entrar en esta explicación. Agrega la siguiente línea justo debajo de la línea `let resetButton;` cerca de la parte superior de tu JavaScript, luego guarda tu archivo:
 
@@ -528,7 +528,7 @@ Juguemos un poco con algunos objetos del navegador.
 
     Cada elemento de una página tiene una propiedad `style`, que a su vez contiene un objeto cuyas propiedades contienen todos los estilos CSS en línea aplicados a ese elemento. Esto nos permite establecer dinámicamente nuevos estilos CSS en elementos utilizando JavaScript.
 
-## Terminamos por ahora...
+## Terminamos por ahora
 
 Así que eso es todo para construir el ejemplo. Llegaste al final, ¡bien hecho! Prueba tu código final, o [juega con nuestra versión final aquí](http://mdn.github.io/learning-area/javascript/introduction-to-js-1/first-splash/number-guessing-game.html). Si no puedes hacer que el ejemplo funcione, compáralo con el [código fuente](https://github.com/mdn/learning-area/blob/master/javascript/introduction-to-js-1/first-splash/number-guessing-game.html).
 

--- a/files/es/learn/javascript/first_steps/math/index.md
+++ b/files/es/learn/javascript/first_steps/math/index.md
@@ -38,7 +38,7 @@ La segunda parte de las buenas noticias es que, a diferencia de otros lenguajes 
 
 > **Nota:** En realidad, JavaScript tiene un segundo tipo de número, {{Glossary("BigInt")}}, que se utiliza para números enteros muy, muy grandes. Pero para los propósitos de este curso, solo nos preocuparemos por los valores numéricos.
 
-### Para mí, todo son números.
+### Para mí, todo son números
 
 Juguemos un poco con algunos números para ponernos al día con la sintaxis básica que necesitamos. Coloca los comandos listados abajo en la [consola JavaScript de tus herramientas para desarrolladores](/es/docs/Learn/Common_questions/What_are_browser_developer_tools), o utiliza la sencilla consola integrada que verás abajo si lo prefieres.
 

--- a/files/es/learn/javascript/objects/adding_bouncing_balls_features/index.md
+++ b/files/es/learn/javascript/objects/adding_bouncing_balls_features/index.md
@@ -111,7 +111,7 @@ Este método actuará de una forma muy similar al método `collisionDetect()` de
 - En el exterior de la declaración `if`, ya no es necesario comprobar si la bola actual en la iteración es la misma que la bola que está haciendo la comprobación, porque ya no es una bola, ¡es el círculo del mal! En su lugar, debe hacer una prueba para ver si existe la bola que se está verificando (¿con qué propiedad podría hacerlo?). Si no existe, ya ha sido devorado por el círculo maligno, por lo que no es necesario volver a comprobarlo.
 - En el interior de la declaración `if`, ya no desea que los objetos cambien de color cuando se detecta una colisión; en cambio, desea que no existan más bolas que colisionen con el círculo maligno (una vez más, ¿cómo cree que haría eso?).
 
-### Trayendo el círculo del mal al programa.
+### Trayendo el círculo del mal al programa
 
 Ahora que hemos definido el círculo maligno, debemos hacerlo aparecer en nuestra escena. Para hacerlo, necesitas hacer alguno cambios a la función `loop()`.
 
@@ -119,7 +119,7 @@ Ahora que hemos definido el círculo maligno, debemos hacerlo aparecer en nuestr
 - En el punto en el que intera por todas las pelotas y llama a las funciones `draw()`, `update()`, y `collisionDetect()` para cada una, hazlo para que estas funciones solo sean llamadas si la bola actual existe.
 - Llama a los métodos de la instancia de la pelota maligna `draw()`, `checkBounds()`, y `collisionDetect()` en cada iteración del bucle.
 
-### Implementando el contador de puntuación.
+### Implementando el contador de puntuación
 
 Para implementar el contador de puntuación sigue estos pasos:
 

--- a/files/es/learn/server-side/django/deployment/index.md
+++ b/files/es/learn/server-side/django/deployment/index.md
@@ -457,7 +457,7 @@ python-3.5.2
 
 > **Nota:** Heroku sólo soporta un número pequeño de [Python runtimes](https://devcenter.heroku.com/articles/python-support#supported-python-runtimes). Tú puedes especificar valores de runtime de Python 3, pero en el momento de esta redacción la versión anterior será soportada como definida.
 
-#### Guardar los cambios en Github y volver a probar.
+#### Guardar los cambios en Github y volver a probar
 
 A continuacion, guardemos nuestros cambios en Github. En el terminal (dentro de nuestro respositorio), introduce los comandos siguientes:
 

--- a/files/es/mozilla/firefox/releases/2/index.md
+++ b/files/es/mozilla/firefox/releases/2/index.md
@@ -10,7 +10,7 @@ original_slug: Firefox_2_para_desarrolladores
 
 Firefox 2 aporta gran cantidad de funcionalidades nuevas, este artículo proporciona enlaces que describen estas nuevas capacidades.
 
-### Para desarrolladores de sitios y aplicaciones web.
+### Para desarrolladores de sitios y aplicaciones web
 
 - [MicroResúmenes (en)](https://wiki.mozilla.org/Microsummaries)
   - : Son breves recopilaciones actualizables de la información más importante en una página Web. Pueden ser proporcionados por los desarrolladores del sitio o por terceros. Cuando se añade a marcadores una página con esta funcionalidad, los usuarios pueden escoger que se muestre este microresúmen en vez del típico título estático.

--- a/files/es/web/accessibility/aria/attributes/aria-required/index.md
+++ b/files/es/web/accessibility/aria/attributes/aria-required/index.md
@@ -14,7 +14,7 @@ HTML5 ahora tiene el atributo `required`, pero aria-required todavía es útil p
 
 `true` o `false` (Default: `false`)
 
-### Posibles efectos en agentes de usuario y tecnología asistente.
+### Posibles efectos en agentes de usuario y tecnología asistente
 
 Los lectores de pantalla deben anunciar el campo como requerido.
 

--- a/files/es/web/accessibility/aria/multipart_labels/index.md
+++ b/files/es/web/accessibility/aria/multipart_labels/index.md
@@ -16,7 +16,7 @@ La solución esta en un atributo ARIA llamado **aria-labelledby**. Su parámetro
 
 Tanto **aria-labelledby** y **aria-describedby** se especifican en el elemento de formulario que debe etiquetarse, por ejemplo un \<input>. En ambos casos, la etiqueta for/label para ligar a los controles que puedan existir son anuladas por **aria-labelledby**. Si en una página se provee **aria-labelledby**, se debería colocar también una etiqueta para también soportar navegadores antiguos que no tengan aún soperte ARIA. Con Firefox 3, los usuarios ciegos tendrán automáticamente mejor accesibilidad con el nuevo atributo, pero los usuarios de navadores antiguos de esta forma no son dejados en la oscuridad.
 
-#### Ejemplo:
+#### Ejemplo
 
 {{EmbedLiveSample('')}}
 

--- a/files/es/web/accessibility/aria/roles/alertdialog_role/index.md
+++ b/files/es/web/accessibility/aria/roles/alertdialog_role/index.md
@@ -52,7 +52,7 @@ El fragmento de código siguiente muestra como marcar un díalogo de alerta que 
 </div>
 ```
 
-#### Ejemplos en funcionamiento:
+#### Ejemplos en funcionamiento
 
 Pendiente
 

--- a/files/es/web/accessibility/understanding_wcag/perceivable/index.md
+++ b/files/es/web/accessibility/understanding_wcag/perceivable/index.md
@@ -8,7 +8,7 @@ Este artículo ofrece consejos prácticos sobre cómo hacer que tu sitio web cum
 
 > **Nota:** Para leer las definiciones de la W3C sobre Percepción y las guías para cumplir con los criterios dirígete a [Principle 1: Perceivable - Information and user interface components must be presentable to users in ways they can perceive.](https://www.w3.org/TR/WCAG21/#perceivable)
 
-## Pauta 1.1 — Dar alternativas de texto para contenido no textual.
+## Pauta 1.1 — Dar alternativas de texto para contenido no textual
 
 La clave aquí es convertir el texto a otros formatos que puedan ser entendidos por personas con otras capacidades; ya sea si utilizan un screen-reader, zoom o un lector de braille. El contenido no textual se refiere a elementos multimedia como imágenes, audio y vídeo.
 
@@ -125,7 +125,7 @@ La clave aquí es convertir el texto a otros formatos que puedan ser entendidos 
 
 > **Nota:** Ver también [WCAG description for Guideline 1.1: Text alternatives](https://www.w3.org/TR/WCAG21/#text-alternatives).
 
-## Pauta 1.2 — Proporcionar alternativas para los medios tempo-dependientes.
+## Pauta 1.2 — Proporcionar alternativas para los medios tempo-dependientes
 
 Los medios tempo-dependientes se refieren a multimedia con una duración (audio y vídeo, por ejemplo). Ten en cuenta que si este contenido multimedia funciona como una alternativa a un contenido textual no necesitas proveer otra alternavtiva.
 

--- a/files/es/web/api/document/pointerlockchange_event/index.md
+++ b/files/es/web/api/document/pointerlockchange_event/index.md
@@ -46,6 +46,6 @@ document.addEventListener("pointerlockchange", function( event ) {
 
 - [`pointerlockerror`](/es/docs/Mozilla_event_reference/pointerlockerror)
 
-## Véase también:
+## Véase también
 
 - [Using Pointer Lock API](/es/docs/API/Pointer_Lock_API)

--- a/files/es/web/api/document/pointerlockelement/index.md
+++ b/files/es/web/api/document/pointerlockelement/index.md
@@ -26,7 +26,7 @@ Un {{domxref("Element")}} o `null`.
 
 {{Compat}}
 
-## Véase también:
+## Véase también
 
 - {{ domxref("Document.exitPointerLock()") }}
 - {{ domxref("Element.requestPointerLock()") }}

--- a/files/es/web/api/document_object_model/locating_dom_elements_using_selectors/index.md
+++ b/files/es/web/api/document_object_model/locating_dom_elements_using_selectors/index.md
@@ -37,7 +37,7 @@ luego de ejecutar el codigo de arriba, la variable `el` contiene el primer eleme
 
 Podes usar cualquier selector CSS con los metodos `querySelector()` y `querySelectorAll()`_._
 
-## Ver tambien.
+## Ver tambien
 
 - [Selectors API](http://www.w3.org/TR/selectors-api/)
 - {{domxref("Element.querySelector()")}}

--- a/files/es/web/api/network_information_api/index.md
+++ b/files/es/web/api/network_information_api/index.md
@@ -11,7 +11,7 @@ La Network Information (Información de red) API provee información sobre el si
 
 ## Examples
 
-### Detectar cambios de conexiónThis example watches for changes to the user's connection.
+### Detectar cambios de conexión
 
 ```js
 var connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection;

--- a/files/es/web/api/node/removechild/index.md
+++ b/files/es/web/api/node/removechild/index.md
@@ -81,7 +81,7 @@ while (element.firstChild) {
 }
 ```
 
-## Notas:
+## Notas
 
 **`removeChild()`** se debe invocar sobre el nodo padre del nodo que se va a eliminar.
 

--- a/files/es/web/api/setinterval/index.md
+++ b/files/es/web/api/setinterval/index.md
@@ -179,7 +179,7 @@ Es posible anidar intervalos; Es decir, la llamada de retorno de `setInterval()`
 Los navegadores pueden imponer valores mínimos aún más estrictos para el intervalo en determinadas circunstancias, aunque no deberían ser habituales. Tenga también en cuenta que la cantidad real de tiempo que transcurre entre las llamadas a la función callback puede ser mayor que el propio retardo (delay); Ver
 [Reasons for delays longer than specified](/es/docs/Web/API/setTimeout#reasons_for_delays_longer_than_specified) para ver ejemplos.
 
-### Garantizar que la duración de la ejecución sea inferior a la frecuecia del intervalo.
+### Garantizar que la duración de la ejecución sea inferior a la frecuecia del intervalo
 
 Si existe la posibilidad de que su lógica pueda tardar más en ejecutarse que el tiempo de intervalo, se recomienda llamar recursivamente a una función nombrada utilizando {{domxref("setTimeout()")}}. Por ejemplo, si utiliza `setInterval()` para sondear un servidor remoto cada cinco segundos, la latencia de la red, un servidor que no responde y una serie de otros problemas podrían impedir que la solicitud se complete en el tiempo asignado. Debido a esto, es posible que se encuentre con peticiones XHR en cola que no necesariamente retornarán en orden.
 

--- a/files/es/web/api/window/location/index.md
+++ b/files/es/web/api/window/location/index.md
@@ -52,7 +52,7 @@ function reloadPageWithHash() {
 
 > **Nota:** El ejemplo anterior funciona en situaciones cuando location.hash no necesita ser retenido. Sin embargo, en navegadores basados en Gecko, configurar `location.pathname` en esta manera eliminará cualquier información en location.hash, mientras que en WebKit (y posiblemente en otros navegadores), configurar el pathname no afectará el hash. Si necesitas cambiar el pathname pero mantener el hash como está, usa el método `replace()`, el cual funcionará consistentemente a través de los navegadores..
 
-### Ejemplo 4: Muestra las propiedades de la URL actual en una ventana emergente:
+### Ejemplo 4: Muestra las propiedades de la URL actual en una ventana emergente
 
 ```js
 function showLoc() {

--- a/files/es/web/api/window/menubar/index.md
+++ b/files/es/web/api/window/menubar/index.md
@@ -33,7 +33,7 @@ El siguiente ejemplo HTML completo muestra la forma en que es utilizada la propi
 </html>
 ```
 
-### Ver también:
+### Ver también
 
 [window.locationbar](/en/DOM/window.locationbar), [window.personalbar](/en/DOM/window.personalbar), [window.scrollbars](/en/DOM/window.scrollbars), [window.statusbar](/en/DOM/window.statusbar), [window.toolbar](/en/DOM/window.toolbar)
 

--- a/files/es/web/css/css_box_model/index.md
+++ b/files/es/web/css/css_box_model/index.md
@@ -12,7 +12,7 @@ original_slug: Web/CSS/CSS_Modelo_Caja
 
 ### Propiedades
 
-#### Propiedades que controlan el flujo del contenido en una caja.
+#### Propiedades que controlan el flujo del contenido en una caja
 
 - {{cssxref("box-decoration-break")}}
 - {{cssxref("box-sizing")}}
@@ -20,7 +20,7 @@ original_slug: Web/CSS/CSS_Modelo_Caja
 - {{cssxref("overflow-x")}}
 - {{cssxref("overflow-y")}}
 
-#### Propiedades que controlan el tamaño de una caja.
+#### Propiedades que controlan el tamaño de una caja
 
 - {{cssxref("height")}}
 - {{cssxref("width")}}
@@ -29,7 +29,7 @@ original_slug: Web/CSS/CSS_Modelo_Caja
 - {{cssxref("min-height")}}
 - {{cssxref("min-width")}}
 
-#### Propiedades que controlan los márgenes de una caja.
+#### Propiedades que controlan los márgenes de una caja
 
 - {{cssxref("margin")}}
 - {{cssxref("margin-bottom")}}

--- a/files/es/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.md
+++ b/files/es/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.md
@@ -15,7 +15,7 @@ Puedes echar un vistazo al código de este ejemplo a continuación. Cambia el ta
 
 {{EmbedGHLiveSample("css-examples/flexbox/alignment/intro.html", '100%', 700)}}
 
-## Propiedades que controlan la alineación.
+## Propiedades que controlan la alineación
 
 Las propiedades que veremos en esta guía son las siguientes.
 

--- a/files/es/web/css/float/index.md
+++ b/files/es/web/css/float/index.md
@@ -136,7 +136,7 @@ div {
 
 {{EmbedLiveSample('','400','180')}}
 
-### Limpiando (clearing) flotantes:
+### Limpiando (clearing) flotantes
 
 A veces querrás forzar un item a moverse por debajo de elementos flotantes. Por ejemplo, párrafos que han de permanecer adyacentes a elementos flotantes, pero forzar a los encabezados a estar en su propia línea. Para ello revisa el siguiente ejemplo: {{cssxref("clear")}}
 

--- a/files/es/web/css/grid-auto-columns/index.md
+++ b/files/es/web/css/grid-auto-columns/index.md
@@ -116,7 +116,7 @@ grid-auto-columns: unset;
 }
 ```
 
-### Resultado:
+### Resultado
 
 {{EmbedLiveSample("Example", "410px", "100px")}}
 

--- a/files/es/web/css/image-rendering/index.md
+++ b/files/es/web/css/image-rendering/index.md
@@ -63,7 +63,7 @@ div {
 
 ### Ejemplos interactivos
 
-#### image-rendering: auto;
+#### image-rendering: auto
 
 78% ![squares.gif](squares.gif) 100% ![squares.gif](squares.gif) 138% ![squares.gif](squares.gif) downsized ![hut.jpg](hut.jpg) upsized ![blumen.jpg](blumen.jpg)
 

--- a/files/es/web/css/outline-offset/index.md
+++ b/files/es/web/css/outline-offset/index.md
@@ -56,7 +56,7 @@ El código anterior producirá este efecto:
 
 {{ EmbedLiveSample('Examples', '', '', '') }}
 
-#### Otro ejemplo:
+#### Otro ejemplo
 
 ```html hidden
 <p>

--- a/files/es/web/css/replaced_element/index.md
+++ b/files/es/web/css/replaced_element/index.md
@@ -14,6 +14,6 @@ CSS gestiona elementos de reemplazo en casos concretos, por ejemplo al calcular 
 
 Recuerda que algunos elementos de reemplazo, no todos, tienen dimensiones intrinsecas o linea de base establecida, las cuales son utilizadas por propiedades de CSS como {{cssxref("vertical-align")}}.
 
-## Ver tambien:
+## Ver tambien
 
 - CSS Key Concepts: [CSS syntax](/es/docs/Web/CSS/Syntax), [at-rule](/es/docs/Web/CSS/At-rule), [comments](/es/docs/Web/CSS/Comments), [specificity](/es/docs/Web/CSS/Specificity) and [inheritance](/es/docs/Web/CSS/inheritance), the [box](/es/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model), [layout modes](/es/docs/Web/CSS/Layout_mode) and [visual formatting models](/es/docs/Web/CSS/Visual_formatting_model), and [margin collapsing](/es/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing), or the [initial](/es/docs/Web/CSS/initial_value), [computed](/es/docs/Web/CSS/computed_value), [resolved](/es/docs/Web/CSS/resolved_value), [specified](/es/docs/Web/CSS/specified_value), [used](/es/docs/Web/CSS/used_value), and [actual](/es/docs/Web/CSS/actual_value) values. Definitions of [value syntax](/es/docs/Web/CSS/Value_definition_syntax), [shorthand properties](/es/docs/Web/CSS/Shorthand_properties) and [replaced elements](/es/docs/Web/CSS/Replaced_element).

--- a/files/es/web/css/specificity/index.md
+++ b/files/es/web/css/specificity/index.md
@@ -61,7 +61,7 @@ Cuando se emplea `important` en una declaración de estilo, esta declaración so
     .myClass.myClass span { color: orange; }
     ```
 
-#### Cómo se debería usar !important:
+#### Cómo se debería usar !important
 
 ##### A) Sobrescribiendo los estilos en linea
 

--- a/files/es/web/css/transform-origin/index.md
+++ b/files/es/web/css/transform-origin/index.md
@@ -65,7 +65,7 @@ Las palabras clave son abreviaciones por convención que coinciden con los sigui
 
 Ver [Uso de CSS transforms](/En/CSS/Using_CSS_transforms) para más ejemplos.
 
-### Ejemplos en vivo:
+### Ejemplos en vivo
 
 | `transform: none;`                                         |     |
 | ---------------------------------------------------------- | --- |

--- a/files/es/web/html/element/samp/index.md
+++ b/files/es/web/html/element/samp/index.md
@@ -34,9 +34,9 @@ The source for this interactive example is stored in a GitHub repository. If you
 
 **Eventos**: onclick, ondblclick, onmousedown, onmouseup, onmouseover, onmousemove, onmouseout, onkeypress, onkeydown, onkeyup.
 
-##### Atributos Específicos - No tiene.
+##### Atributos Específicos - No tiene
 
-##### Atributos Transicionales - No tiene.
+##### Atributos Transicionales - No tiene
 
 ### Ejemplos
 

--- a/files/es/web/html/element/var/index.md
+++ b/files/es/web/html/element/var/index.md
@@ -28,9 +28,9 @@ original_slug: Web/HTML/Elemento/var
 
 **Eventos**: onclick, ondblclick, onmousedown, onmouseup, onmouseover, onmousemove, onmouseout, onkeypress, onkeydown, onkeyup.
 
-##### Atributos Específicos - No tiene.
+##### Atributos Específicos - No tiene
 
-##### Atributos Transicionales - No tiene.
+##### Atributos Transicionales - No tiene
 
 ### Ejemplos
 

--- a/files/es/web/http/basics_of_http/choosing_between_www_and_non-www_urls/index.md
+++ b/files/es/web/http/basics_of_http/choosing_between_www_and_non-www_urls/index.md
@@ -19,7 +19,7 @@ Un servidor no es necesariamente una máquina física: varios servidores pueden 
 
 Por lo tanto, ¡elija uno de sus dominios como su canónico! Hay dos técnicas a continuación para permitir que el dominio no canónico funcione aún.
 
-## Técnicas para las URL canónicas.
+## Técnicas para las URL canónicas
 
 Hay diferentes maneras de elegir qué sitio web es _canónico_.
 

--- a/files/es/web/http/basics_of_http/evolution_of_http/index.md
+++ b/files/es/web/http/basics_of_http/evolution_of_http/index.md
@@ -78,7 +78,7 @@ Content-Type: text/gif
 
 Estas innovaciones, no se desarrollaron de forma planeada, sino más bien con una aproximación de prueba y error, entre los años 1991 y 1995: un servidor y un navegador, añadían una nueva funcionalidad y se evaluaba su aceptación. Debido a esto, en ese periodo eran muy comunes los problemas de interoperatividad. En Noviembre de 1996, para poner fin a estos problemas se publicó un documento informativo que describía las prácticas adecuadas, {{RFC(1945)}}. Esté documento es la definición del protocolo HTTP/1.0. Resulta curioso, que realmente no es un estándar oficial.
 
-## HTTP/1.1 – El protocolo estándar.
+## HTTP/1.1 – El protocolo estándar
 
 En paralelo al uso, un poco desordenado, y las diversas implementaciones de HTTP/1.0, y desde el año 1995, un año antes de la publicación del documento del HTTP/1.0, un proceso de estandarización formal ya estaba en curso. La primera versión estandarizada de HTTP: el protocolo HTTP/1.1, se publicó en 1997, tan solo unos meses después del HTTP/1.0
 

--- a/files/es/web/http/conditional_requests/index.md
+++ b/files/es/web/http/conditional_requests/index.md
@@ -120,7 +120,7 @@ Las peticiones condicionales permiten implementar el _algoritmo de bloqueo optim
 
 Esto se implementa utilizando el encabezado {{HTTPHeader("If-Match")}} o {{HTTPHeader("If-Unmodified-Since")}}. Si la etag no coincide con el archivo original, o si el archivo ha sido modificado desde que se obtuvo, el cambio simplemente se rechaza con un error {{HTTPStatus("412")}} `Precondition Failed`. Depende entonces del cliente lidiar con el error: ya sea notificando al usuario que vuelva a comenzar (esta vez en la versión más reciente) o mostrándole al usuario una _diferencia_ entre ambas versiones, Ayudándoles a decidir qué cambios desean mantener.
 
-### Tratar con la primera subida de un recurso.
+### Tratar con la primera subida de un recurso
 
 La primera subida de un recurso es un caso similar al anterior. Como cualquier actualización de un recurso, está sujeta a una condición de carrera si dos clientes intentan realizarla en tiempos similares. Para evitar esto, se pueden utilizar peticiones condicionales: añadiendo el encabezado {{HTTPHeader("If-None-Match")}} con el valor especial `'*'`, representando cualquier etag. La petición sólo tendrá éxito si el recurso no existía antes:
 

--- a/files/es/web/http/headers/transfer-encoding/index.md
+++ b/files/es/web/http/headers/transfer-encoding/index.md
@@ -71,7 +71,7 @@ Network\r\n
 
 {{Compat}}
 
-## Ver además:
+## Ver además
 
 - {{HTTPHeader("Accept-Encoding")}}
 - {{HTTPHeader("Content-Encoding")}}

--- a/files/es/web/javascript/equality_comparisons_and_sameness/index.md
+++ b/files/es/web/javascript/equality_comparisons_and_sameness/index.md
@@ -185,7 +185,7 @@ El método [`Object.is`](/es/docs/Web/JavaScript/Reference/Global_Objects/Object
 
 Similar a la igualdad same-value, pero +0 y -0 son considerados iguales.
 
-## Igualdad abstracta, igualdad estricta e igualdad same value en la especificación.
+## Igualdad abstracta, igualdad estricta e igualdad same value en la especificación
 
 En la especificación ES5, la comparación [`==`](/es/docs/Web/JavaScript/Reference/Operators/Comparison_Operators) queda descrita en [Section 11.9.3, The Abstract Equality Algorithm](http://ecma-international.org/ecma-262/5.1/#sec-11.9.3). La comparación [`===`](/es/docs/Web/JavaScript/Reference/Operators/Comparison_Operators) en [11.9.6, The Strict Equality Algorithm](http://ecma-international.org/ecma-262/5.1/#sec-11.9.6). (Búscala y leela, son breves y fáciles de leer. Nota: lee el algoritmo de la igualdad estricta primero.) ES5 también describe, en [Section 9.12, The SameValue Algorithm](http://ecma-international.org/ecma-262/5.1/#sec-9.12) para uso interno del motor JS. Es, en su mayoría igual que el algoritmo de igualdad estricto, excepto porque 11.9..6.4 y 9.12.4 difieren en cómo tratar los [`Numbers`](/es/docs/Web/JavaScript/Reference/Global_Objects/Number). ES2015 simplemente propone exponer este algoritmo mediante el uso de[`Object.is`](/es/docs/Web/JavaScript/Reference/Global_Objects/Object/is).
 

--- a/files/es/web/javascript/memory_management/index.md
+++ b/files/es/web/javascript/memory_management/index.md
@@ -187,7 +187,7 @@ En el primer ejemplo, después de que la llamada a una función termina, los dos
 
 Lo mismo ocurre en el segundo ejemplo. Una vez que el elemento div y sus métodos se hacen inalcanzable desde los objetos raíz, ambos pueden ser recolectados a pesar de que estén referenciados los unos de los otros.
 
-#### Limitación: los objetos necesarios se hacen inalcanzables de forma explícita.
+#### Limitación: los objetos necesarios se hacen inalcanzables de forma explícita
 
 Aunque esto está marcado como una limitación, se puede encontrar muy poco en la práctica. Ésta es la razón por la cuál la recolección de basura es poco tomada en cuenta.
 

--- a/files/es/web/javascript/reference/errors/missing_semicolon_before_statement/index.md
+++ b/files/es/web/javascript/reference/errors/missing_semicolon_before_statement/index.md
@@ -64,7 +64,7 @@ var array = [];
 array[0] = 'mundo';
 ```
 
-## Ver también:
+## Ver también
 
 - [Automatic semicolon insertion (ASI)](/es/docs/Web/JavaScript/Reference/Lexical_grammar#Automatic_semicolon_insertion)
 - [JavaScript statements](/es/docs/Web/JavaScript/Reference/Statements)

--- a/files/es/web/javascript/reference/global_objects/array/foreach/index.md
+++ b/files/es/web/javascript/reference/global_objects/array/foreach/index.md
@@ -124,7 +124,7 @@ var o1 = {a:1, b:2};
 var o2 = copy(o1); // o2 ahora se parece a o1
 ```
 
-### Si el array se modifica durante la iteración, otros elementos pueden ser omitidos.
+### Si el array se modifica durante la iteración, otros elementos pueden ser omitidos
 
 El siguiente ejemplo muestra por consola "uno", "dos", "cuatro". Cuando se alcanza el registro que contiene el valor "dos", el primer registro del array se desplaza, lo que hace que los registros restantes se muevan una posición. Debido a que el elemento "cuatro" está ahora en una posición anterior en el array, "tres" se omitirá. `forEach()` no hace una copia del array antes de iterar.
 

--- a/files/es/web/javascript/reference/global_objects/date/gettime/index.md
+++ b/files/es/web/javascript/reference/global_objects/date/gettime/index.md
@@ -24,7 +24,7 @@ El valor devuelto por el método `getTime()` es un número de milisegundos desde
 
 ## Ejemplos
 
-### Ejemplo: Uso de `getTime()` para copiar fechas.
+### Ejemplo: Uso de `getTime()` para copiar fechas
 
 Construir un objeto de fecha con el mismo valor de tiempo.
 

--- a/files/es/web/javascript/reference/global_objects/error/linenumber/index.md
+++ b/files/es/web/javascript/reference/global_objects/error/linenumber/index.md
@@ -50,7 +50,7 @@ Tabla de compatibilidad
 | -------------- | ------------- | ------------------- | --------------------- | ------------- | ------------- | ------------- |
 | Soporte básico | No compatible | No compatible       | Compatible            | No compatible | No compatible | No compatible |
 
-## Vea también:
+## Vea también
 
 - {{jsxref("Error.prototype.stack")}} {{non-standard_inline}}
 - {{jsxref("Error.prototype.columnNumber")}} {{non-standard_inline}}

--- a/files/es/web/javascript/reference/global_objects/math/sign/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/sign/index.md
@@ -19,7 +19,7 @@ Math.sign(x)
 - `x`
   - : Un número.
 
-### Valor de retorno.
+### Valor de retorno
 
 Un número representando el signo del argumento dado. Si el argumento es un número positivo, negativo, cero positivo, o cero negativo, la función retornará `1`, `-1`, `0` or `-0` respectivamente. De lo contrario, retorna {{jsxref("NaN")}}.
 

--- a/files/es/web/javascript/reference/global_objects/math/trunc/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/trunc/index.md
@@ -8,22 +8,22 @@ original_slug: Web/JavaScript/Referencia/Objetos_globales/Math/trunc
 
 La función **`Math.trunc()`** devuelve la parte entera de un numero removiendo cualquier dígito decimal (dígitos situados después de la coma).
 
-## Sintaxis.
+## Sintaxis
 
 ```
 Math.trunc(x)
 ```
 
-### Parámetros.
+### Parámetros
 
 - `x`
   - : Un número.
 
-### Valor de retorno.
+### Valor de retorno
 
 La parte entera del número dado.
 
-## Descripción.
+## Descripción
 
 A diferencia de los otros tres métodos de `Math`: {{jsxref("Math.floor()")}}, {{jsxref("Math.ceil()")}} y {{jsxref("Math.round()")}}, la forma en que `Math.trunc()` funciona es muy simple. _trunca_ (corta) el punto y los dígitos a la derecha de él, sin importar si el argumento es un número positivo o negativo.
 
@@ -33,7 +33,7 @@ El argumento pasado a este método será convertido a un tipo numérico entero.
 
 Debido a que `trunc()` es un método estático de `Math`, siempre úsalo como `Math.trunc()`, en lugar de como un método de un objeto `Math` que hayas creado (`Math` no es un constructor).
 
-## Ejemplos.
+## Ejemplos
 
 ### Usando `Math.trunc()`
 
@@ -48,7 +48,7 @@ Math.trunc('foo');    // NaN
 Math.trunc();         // NaN
 ```
 
-## Polyfill.
+## Polyfill
 
 ```js
 Math.trunc = Math.trunc || function (x) {
@@ -64,7 +64,7 @@ Math.trunc = Math.trunc || function (x) {
 
 {{Compat}}
 
-## Vea también.
+## Vea también
 
 - {{jsxref("Math.abs()")}}
 - {{jsxref("Math.ceil()")}}

--- a/files/es/web/javascript/reference/global_objects/object/constructor/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/constructor/index.md
@@ -27,7 +27,7 @@ n.constructor === Number; // true
 
 ## Ejemplos
 
-### Ejemplo: Mostrando el constructor de un objeto.
+### Ejemplo: Mostrando el constructor de un objeto
 
 El siguiente ejemplo crea un prototipo, `Tree`, y un objeto de este tipo, `theTree`. El ejemplo muestra entonces la propiedad `constructor` para el objeto `theTree`.
 
@@ -48,7 +48,7 @@ theTree.constructor is function Tree (name) {
 }
 ```
 
-### Ejemplo: Cambiando el constructor de un objeto.
+### Ejemplo: Cambiando el constructor de un objeto
 
 El siguiente ejemplo demuestra como modificar el valor del constructor de objetos genéricos. Solo `true`, `1` y `"test"` no serán afectados ya que ellos tienen constructores nativos de solo lectura. Este ejemplo demuestra que no siempre es seguro confiar en la propiedad constructor de un objeto.
 

--- a/files/es/web/javascript/reference/global_objects/object/getownpropertydescriptors/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/getownpropertydescriptors/index.md
@@ -83,7 +83,7 @@ subclass.prototype = Object.create(
 
 {{Compat}}
 
-## Ver también:
+## Ver también
 
 - {{jsxref("Object.getOwnPropertyDescriptor()")}}
 - {{jsxref("Object.defineProperty()")}}

--- a/files/es/web/javascript/reference/global_objects/symbol/match/index.md
+++ b/files/es/web/javascript/reference/global_objects/symbol/match/index.md
@@ -20,7 +20,7 @@ Esta función también se utiliza para identificar si los objetos tienen el comp
 
 ## Ejemplos
 
-### Desactivar la comprobación de `isRegExp`.
+### Desactivar la comprobación de `isRegExp`
 
 El siguiente código lanzará un {{jsxref("TypeError")}}:
 

--- a/files/es/web/javascript/reference/operators/comma_operator/index.md
+++ b/files/es/web/javascript/reference/operators/comma_operator/index.md
@@ -32,7 +32,7 @@ for (var i = 0, j = 9; i <= 9; i++, j--)
   document.writeln("a[" + i + "][" + j + "] = " + a[i][j]);
 ```
 
-### Procesar y luego retornar:
+### Procesar y luego retornar
 
 Otro ejemplo de lo que se puede hacer con el operador coma es procesar antes de retornar. Como se mencionó, solo el último elemento será retornado pero todos los otros también van a ser evaluados. Así, se puede hacer:
 

--- a/files/es/web/javascript/reference/operators/destructuring_assignment/index.md
+++ b/files/es/web/javascript/reference/operators/destructuring_assignment/index.md
@@ -419,7 +419,7 @@ const [,, { name }] = props;
 console.log(name); // "FizzBuzz"
 ```
 
-#### Se busca la cadena de prototipos al desestructurar el objeto.
+#### Se busca la cadena de prototipos al desestructurar el objeto
 
 Al deconstruir un objeto, si no se accede a una propiedad en sí misma, continuará buscando a lo largo de la cadena de prototipos.
 

--- a/files/es/web/javascript/reference/statements/import/index.md
+++ b/files/es/web/javascript/reference/statements/import/index.md
@@ -39,7 +39,7 @@ import "module-name";
 
 El parámetro `name` es el nombre del objeto que recibirá los miembros exportados. El parámetro `member` especifica miembros individuales, mientras el parámetro `name` importa todos ellos. name puede también ser una función si el módulo exporta un sólo parámetro por defecto en lugar de una serie de miembros. Abajo hay ejemplos que explican la sintaxis.
 
-### Importa el contenido de todo un módulo.
+### Importa el contenido de todo un módulo
 
 Esto inserta `myModule` en el ámbito actual, que contiene todos los elementos exportados en el archivo ubicado en `/modules/my-module.js`.
 
@@ -53,7 +53,7 @@ Aquí, para acceder a los miembros exportados habrá que usar el alias del módu
 myModule.doAllTheAmazingThings();
 ```
 
-### Importa un solo miembro de un módulo.
+### Importa un solo miembro de un módulo
 
 Dado un objeto o valor llamado `myExport` que ha sido exportado del módulo `my-module` ya sea implícitamente (porque todo el módulo ha sido exportado) o explícitamente (usando la sentencia {{jsxref("Sentencias/export", "export")}} ), esto inserta `myExport` en el ámbito actual.
 
@@ -61,7 +61,7 @@ Dado un objeto o valor llamado `myExport` que ha sido exportado del módulo `my-
 import {myExport} from '/modules/my-module.js';
 ```
 
-### Importa multiples miembros de un módulo.
+### Importa multiples miembros de un módulo
 
 Esto inserta `foo` y `bar` en el ámbito actual.
 

--- a/files/es/web/media/dash_adaptive_streaming_for_html_5_video/index.md
+++ b/files/es/web/media/dash_adaptive_streaming_for_html_5_video/index.md
@@ -20,7 +20,7 @@ Lo primero que necesitas es convertir tu video WebM en un manifiesto DASH con to
 - libwebm - concretamente para la herramienta samplemuxer (git clone <https://gerrit.chromium.org/gerrit/p/webm/libwebm.git>).
 - webm-tools - concretamente para la herramienta de creación de manifiestos, webm_dash_manifest (git clone <https://gerrit.chromium.org/gerrit/p/webm/webm-tools.git>).
 
-### 1. Use your existing WebM file to create one audio file and multiple video files.
+### 1. Use your existing WebM file to create one audio file and multiple video files
 
 Por ejemplo:
 
@@ -38,7 +38,7 @@ ffmpeg -i my_master_file.webm -vcodec libvpx -vb 100k -keyint_min 150 -g 150 -an
 ffmpeg -i my_master_file.webm -vcodec libvpx -vb 50k -keyint_min 150 -g 150 -an my_video-50kbps.webm
 ```
 
-### 2. Align the clusters to enable switching at cluster boundaries.
+### 2. Align the clusters to enable switching at cluster boundaries
 
 For video:
 
@@ -53,7 +53,7 @@ Although we don't switch audio streams, it's still necessary to run it through s
 samplemuxer -i my_audio.webm -o my_audio-final.webm -output_cues 1 -cues_on_audio_track 1 -max_cluster_duration 2 -audio_track_number
 ```
 
-### 3. Create the manifest file:
+### 3. Create the manifest file
 
 ```
 webm_dash_manifest -o my_video_manifest.mpd \

--- a/files/es/web/performance/optimizing_startup_performance/index.md
+++ b/files/es/web/performance/optimizing_startup_performance/index.md
@@ -68,7 +68,7 @@ Hay otras cosas además de ir asíncrono, que pueden ayudarlo a mejorar el tiemp
 - [Apps](/es/docs/Web/Progressive_web_apps)
 - [Games](/es/docs/Games)
 
-## Información del Documento Original:
+## Información del Documento Original
 
 - Autor(s): Alon Zakai
 - Fuente: [BananaBread (or any compiled codebase) Startup Experience](http://mozakai.blogspot.com/2012/07/bananabread-or-any-compiled-codebase.html)


### PR DESCRIPTION
This PR removes trailing punctuation within headers for the Spanish locale.

Note: one header is also modified as it contains text it shouldn't.
