### PR TITLE
zh-tw: Make sure localized links are used rather than /en-US/*

### DIFF
--- a/files/zh-tw/glossary/html/index.md
+++ b/files/zh-tw/glossary/html/index.md
@@ -5,7 +5,7 @@ slug: Glossary/HTML
 
 {{GlossarySidebar}}
 
-{{QuickLinksWithSubpages("/en-US/docs/Glossary")}}
+{{QuickLinksWithSubpages("/zh-TW/docs/Glossary")}}
 
 超文件標示語言（**HTML**，HyperText Markup Language）是用於指定網頁結構的描述性語言。
 

--- a/files/zh-tw/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
+++ b/files/zh-tw/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
@@ -203,14 +203,14 @@ There are some serious [Security concerns](#security_concerns) to consider with 
 
 ```html
 <iframe
-  src="https://developer.mozilla.org/en-US/docs/Glossary"
+  src="https://developer.mozilla.org/zh-TW/docs/Glossary"
   width="100%"
   height="500"
   frameborder="0"
   allowfullscreen
   sandbox>
   <p>
-    <a href="https://developer.mozilla.org/en-US/docs/Glossary">
+    <a href="https://developer.mozilla.org/zh-TW/docs/Glossary">
       Fallback link for browsers that don't support iframes
     </a>
   </p>
@@ -242,7 +242,7 @@ Browser makers and Web developers have learned the hard way that iframes are a c
 
 > **備註：** [Clickjacking](https://zh.wikipedia.org/wiki/Clickjacking) is one kind of common iframe attack where hackers embed an invisible iframe into your document (or embed your document into their own malicious website) and use it to capture users' interactions. This is a common way to mislead users or steal sensitive data.
 
-A quick example first though — try loading the previous example we showed above into your browser — you can [find it live on Github](http://mdn.github.io/learning-area/html/multimedia-and-embedding/other-embedding-technologies/iframe-detail.html) ([see the source code](https://github.com/mdn/learning-area/blob/gh-pages/html/multimedia-and-embedding/other-embedding-technologies/iframe-detail.html) too.) You won't actually see anything displayed on the page, and if you look at the _Console_ in the [browser developer tools](/zh-TW/docs/Learn/Common_questions/What_are_browser_developer_tools), you'll see a message telling you why. In Firefox, you'll get told _Load denied by X-Frame-Options: "https://developer.mozilla.org/en-US/docs/Glossary" does not permit framing_. This is because the developers that built MDN have included a setting on the server that serves the website pages to disallow them from being embedded inside `<iframe>`s (see [Configure CSP directives](#configure_csp_directives), below.) This makes sense — an entire MDN page doesn't really make sense to be embedded in other pages unless you want to do something like embed them on your site and claim them as your own — or attempt to steal data via clickjacking, which are both really bad things to do. Plus if everybody started to do this, all the additional bandwidth would start to cost Mozilla a lot of money.
+A quick example first though — try loading the previous example we showed above into your browser — you can [find it live on Github](http://mdn.github.io/learning-area/html/multimedia-and-embedding/other-embedding-technologies/iframe-detail.html) ([see the source code](https://github.com/mdn/learning-area/blob/gh-pages/html/multimedia-and-embedding/other-embedding-technologies/iframe-detail.html) too.) You won't actually see anything displayed on the page, and if you look at the _Console_ in the [browser developer tools](/zh-TW/docs/Learn/Common_questions/What_are_browser_developer_tools), you'll see a message telling you why. In Firefox, you'll get told _Load denied by X-Frame-Options: "https://developer.mozilla.org/zh-TW/docs/Glossary" does not permit framing_. This is because the developers that built MDN have included a setting on the server that serves the website pages to disallow them from being embedded inside `<iframe>`s (see [Configure CSP directives](#configure_csp_directives), below.) This makes sense — an entire MDN page doesn't really make sense to be embedded in other pages unless you want to do something like embed them on your site and claim them as your own — or attempt to steal data via clickjacking, which are both really bad things to do. Plus if everybody started to do this, all the additional bandwidth would start to cost Mozilla a lot of money.
 
 #### Only embed when necessary
 

--- a/files/zh-tw/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
+++ b/files/zh-tw/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
@@ -75,7 +75,7 @@ original_slug: MDN/Contribute/Howto/Create_and_edit_pages
 為了建立一個非基於連結而建立的新頁面，您需要於 URL 區塊後輸入一個獨一無二的頁面名稱。舉例來說，若您輸入:
 
 ```plain
-https://developer.mozilla.org/en-US/docs/FooBar
+https://developer.mozilla.org/zh-TW/docs/FooBar
 ```
 
 MDN 會心建立一個標題為「FooBar」而且會於開啟編輯器讓您能夠編輯此新頁面。請參考 [Editing an existing page](#Editing_an_existing_page) section of this article for how to use the editor mode.

--- a/files/zh-tw/web/api/setinterval/index.md
+++ b/files/zh-tw/web/api/setinterval/index.md
@@ -359,7 +359,7 @@ As previously discussed, Internet Explorer versions 9 and below do not support t
 |*|  IE-specific polyfill that enables the passage of arbitrary arguments to the
 |*|  callback functions of javascript timers (HTML5 standard syntax).
 |*|
-|*|  https://developer.mozilla.org/en-US/docs/Web/API/window.setInterval
+|*|  https://developer.mozilla.org/zh-TW/docs/Web/API/window.setInterval
 |*|  https://developer.mozilla.org/User:fusionchess
 |*|
 |*|  Syntax:
@@ -534,7 +534,7 @@ In pages requiring many timers, it can often be difficult to keep track of all o
 |*|
 |*|  Revision #2 - September 26, 2014
 |*|
-|*|  https://developer.mozilla.org/en-US/docs/Web/API/window.setInterval
+|*|  https://developer.mozilla.org/zh-TW/docs/Web/API/window.setInterval
 |*|  https://developer.mozilla.org/User:fusionchess
 |*|  https://github.com/madmurphy/minidaemon.js
 |*|

--- a/files/zh-tw/web/api/xmlhttprequest/using_xmlhttprequest/index.md
+++ b/files/zh-tw/web/api/xmlhttprequest/using_xmlhttprequest/index.md
@@ -237,7 +237,7 @@ function loadEnd(e) {
 |*|
 |*|  :: XMLHttpRequest.prototype.sendAsBinary() Polyfill ::
 |*|
-|*|  https://developer.mozilla.org/en-US/docs/DOM/XMLHttpRequest#sendAsBinary()
+|*|  https://developer.mozilla.org/zh-TW/docs/DOM/XMLHttpRequest#sendAsBinary()
 \*/
 
       if (!XMLHttpRequest.prototype.sendAsBinary) {
@@ -257,7 +257,7 @@ function loadEnd(e) {
 |*|
 |*|  :: AJAX Form Submit Framework ::
 |*|
-|*|  https://developer.mozilla.org/en-US/docs/DOM/XMLHttpRequest/Using_XMLHttpRequest
+|*|  https://developer.mozilla.org/zh-TW/docs/DOM/XMLHttpRequest/Using_XMLHttpRequest
 |*|
 |*|  This framework is released under the GNU Public License, version 3 or later.
 |*|  https://www.gnu.org/licenses/gpl-3.0-standalone.html

--- a/files/zh-tw/web/javascript/reference/errors/not_defined/index.md
+++ b/files/zh-tw/web/javascript/reference/errors/not_defined/index.md
@@ -67,4 +67,4 @@ console.log(num1); // 2
 
 - {{Glossary("Scope")}}
 - [Declaring variables in the JavaScript Guide](/zh-TW/docs/Web/JavaScript/Guide/Grammar_and_types#Declaring_variables)
-- [Function scope in the JavaScript Guide](/zh-TW/docs/Web/JavaScript/Guide/Functions#Function_scope/en-US/docs/)
+- [Function scope in the JavaScript Guide](/zh-TW/docs/Web/JavaScript/Guide/Functions#Function_scope/zh-TW/docs/)

--- a/files/zh-tw/web/javascript/reference/errors/not_defined/index.md
+++ b/files/zh-tw/web/javascript/reference/errors/not_defined/index.md
@@ -67,4 +67,4 @@ console.log(num1); // 2
 
 - {{Glossary("Scope")}}
 - [Declaring variables in the JavaScript Guide](/zh-TW/docs/Web/JavaScript/Guide/Grammar_and_types#Declaring_variables)
-- [Function scope in the JavaScript Guide](/zh-TW/docs/Web/JavaScript/Guide/Functions#Function_scope/zh-TW/docs/)
+- [Function scope in the JavaScript Guide](/zh-TW/docs/Web/JavaScript/Guide/Functions#function_scope)

--- a/files/zh-tw/web/javascript/reference/global_objects/object/keys/index.md
+++ b/files/zh-tw/web/javascript/reference/global_objects/object/keys/index.md
@@ -75,7 +75,7 @@ Object.keys("foo");
 如需在原生不支援、較舊的環境中增加 `Object.keys` 的相容性，請複製以下片段：
 
 ```js
-// From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys
+// From https://developer.mozilla.org/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/Object/keys
 if (!Object.keys) {
   Object.keys = (function () {
     "use strict";

--- a/files/zh-tw/web/javascript/reference/operators/destructuring_assignment/index.md
+++ b/files/zh-tw/web/javascript/reference/operators/destructuring_assignment/index.md
@@ -311,7 +311,7 @@ const metadata = {
       title: "JavaScript-Umgebung",
     },
   ],
-  url: "/en-US/docs/Tools/Scratchpad",
+  url: "/zh-TW/docs/Tools/Scratchpad",
 };
 
 let {

--- a/files/zh-tw/web/media/formats/containers/index.md
+++ b/files/zh-tw/web/media/formats/containers/index.md
@@ -3,7 +3,7 @@ title: Media container formats (file types)
 slug: Web/Media/Formats/Containers
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/Media")}}
+{{QuickLinksWithSubpages("/zh-TW/docs/Web/Media")}}
 
 視訊與音訊的檔案格式被定義成兩個部分（當然如果一個檔案同時擁有影、音的話，那就有三個）：一個是音訊或/和視訊的編解碼器(codecs，由 compress 和 decompress 所組成的詞語)，另一個是媒體封裝的格式(media container format，即檔案類型)。在本次導覽中，我們將會看到網路上最常見的封裝格式，並介紹它們的基本規格、優點、限制，以及理想的使用情形。
 

--- a/files/zh-tw/web/media/formats/index.md
+++ b/files/zh-tw/web/media/formats/index.md
@@ -3,7 +3,7 @@ title: "Media type and format guide: image, audio, and video content"
 slug: Web/Media/Formats
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/Media")}}
+{{QuickLinksWithSubpages("/zh-TW/docs/Web/Media")}}
 
 Since nearly its beginning, the web has included support for some form of visual media presentation. Originally, these capabilities were limited, and were expanded organically, with different browsers finding their own solutions to the problems around including still and video imagery on the web. The modern web has powerful features to support the presentation and manipulation of media, with several media-related APIs supporting various types of content. Generally, the media formats supported by a browser are entirely up to the browser's creators, which can complicate the work of a web developer.
 

--- a/files/zh-tw/web/security/insecure_passwords/index.md
+++ b/files/zh-tw/web/security/insecure_passwords/index.md
@@ -19,4 +19,4 @@ slug: Web/Security/Insecure_passwords
 
 - [No More Passwords over HTTP, Please!](https://blog.mozilla.org/tanvi/2016/01/28/no-more-passwords-over-http-please/) — 提供詳細資訊和常見問題的部落格文章
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/Security")}}
+{{QuickLinksWithSubpages("/zh-TW/docs/Web/Security")}}


### PR DESCRIPTION
This PR fixes all of the links within the Traditional Chinese locale so that they no longer point to English content.
