### PR TITLE
ko: Format translator guides with Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -47,7 +47,6 @@ build/
 /files/ja/webassembly/**/*.md
 
 # ko
-/docs/ko/**/*.md
 /files/ko/games/**/*.md
 /files/ko/glossary/**/*.md
 /files/ko/learn/**/*.md

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -55,10 +55,10 @@ yari 가 content repo에 내장돼있습니다. 세부 절차는 [다음 링크]
 2. content 폴더에 들어가서 `yarn install`을 통해 yari 등 필요한 패키지를 다운받습니다.
 3. content 폴더 root에 .env 파일을 추가합니다. (translated-content/files 경로 추가, vscode editor의 경우 `EDITOR=code` 추가)
 
-    ```
-    CONTENT_TRANSLATED_ROOT=/path/to/translated-content/files
-    EDITOR=code
-    ```
+   ```
+   CONTENT_TRANSLATED_ROOT=/path/to/translated-content/files
+   EDITOR=code
+   ```
 
 4. `yarn start`
 

--- a/docs/ko/guides/archieved/html-guide.md
+++ b/docs/ko/guides/archieved/html-guide.md
@@ -7,13 +7,13 @@
 예를 들면:
 
 ```html
-<h2 id="tutorials"> Tutorials </h2> 
+<h2 id="tutorials">Tutorials</h2>
 ```
 
 `ko` 지역 에서
 
 ```html
-<h2 id="tutorials"> 튜토리얼 </h2>
+<h2 id="tutorials">튜토리얼</h2>
 ```
 
 일반적으로 모든 ID를 소문자로 작성하는 것이 좋습니다. 플랫폼은 어쨌든 렌더링시 자동으로 변환하지만 소문자로 유지하면 변환으로 인해 수동으로 만든 앵커 링크가 작동하지 않을 가능성이 적습니다.
@@ -23,13 +23,16 @@
 일부 기사 소스 코드에서, 반드시 필요하지 않은 블록 수준 요소에서 줄 바꿈을 찾을 수 있습니다. 예를 들면 다음과 같습니다.
 
 ```html
-<p>The
-  <code><strong>HTMLCanvasElement</strong></code><strong><code>.transferControlToOffscreen()</code></strong>
-  method transfers control to an {{domxref("OffscreenCanvas")}} object, either on the main
-  thread or on a worker.</p>
+<p>
+  The <code><strong>HTMLCanvasElement</strong></code
+  ><strong><code>.transferControlToOffscreen()</code></strong> method transfers
+  control to an {{domxref("OffscreenCanvas")}} object, either on the main thread
+  or on a worker.
+</p>
 
-<pre
-  class="brush: js">OffscreenCanvas HTMLCanvasElement.transferControlToOffscreen()</pre>
+<pre class="brush: js">
+OffscreenCanvas HTMLCanvasElement.transferControlToOffscreen()</pre
+>
 ```
 
 일반적으로 소스 코드에서 이와 같은 줄 바꿈을 사용하지 않으므로 원하는 경우 자유롭게 제거 할 수 있으며 새 번역을 만들 때 추가하지 마십시오. 그러나 최종 렌더링 결과에 영향을 미치지 않으므로 이를 제거하는 데 너무 많은 시간을 소비하지 마십시오.

--- a/docs/ko/guides/github-actions-guide.md
+++ b/docs/ko/guides/github-actions-guide.md
@@ -6,9 +6,9 @@
 
 ## Redirects Files
 
-보통의 경우 파일 삭제시 [_redirects.txt](https://github.com/mdn/translated-content/blob/main/files/ko/_redirects.txt)를 갱신해주어야 합니다.
+보통의 경우 파일 삭제시 [\_redirects.txt](https://github.com/mdn/translated-content/blob/main/files/ko/_redirects.txt)를 갱신해주어야 합니다.
 
-[yari](https://github.com/mdn/yari)에서 아래 명령어를 통해 [translated-content](https://github.com/mdn/translated-content)의 [_redirects.txt](https://github.com/mdn/translated-content/blob/main/files/ko/_redirects.txt) 파일을 검증 및 갱신할 수 있습니다.
+[yari](https://github.com/mdn/yari)에서 아래 명령어를 통해 [translated-content](https://github.com/mdn/translated-content)의 [\_redirects.txt](https://github.com/mdn/translated-content/blob/main/files/ko/_redirects.txt) 파일을 검증 및 갱신할 수 있습니다.
 
 ```bash
 yarn tool validate-redirects ko --strict

--- a/docs/ko/guides/glossary-guide.md
+++ b/docs/ko/guides/glossary-guide.md
@@ -33,42 +33,42 @@
 
 **사전 순으로 용어집을 편집해주세요.**
 
-| 용어 | 번역 | 참고 링크 |
-| --- | --- | --- |
-| Access | 접근 | |
-| Accessibility concerns | 접근성 고려사항 | |
-| Advantages | 장점 | [링크][Introduction_to_HTML5_Game_Development] |
-| Aliasing | 별칭 | [링크](https://github.com/mdn/translated-content/pull/1779/files) |
-| Brief history | 간략한 역사 | [링크][HTML#%EA%B0%84%EB%9E%B5%ED%95%9C_%EC%97%AD%EC%82%AC] |
-| Browser compatibility | 브라우저 호환성 | [링크](https://github.com/mdn/translated-content/pull/1779/files) |
-| Browser support | 브라우저 지원 | [링크][Using_IIR_filters] |
-| Concept | 개념 | |
-| Conclusion | 결론 | |
-| Contact us | 문의하기 | |
-| Demo | 데모 | [링크][GLSL_Shaders]
-| Description | 설명 | [링크][Array]
-| Example | 예제 | [링크][target] |
-| Examples | 예제 | [링크](https://github.com/mdn/translated-content/blob/main/files/ko/web/javascript/reference/global_objects/proxy/proxy/apply/index.md) |
-| Guides | 안내서 | |
-| In this module | 이번 과정에서는 | [링크][React_getting_started] |
-| Instance properties | 인스턴스 속성 | |
-| Instance methods | 인스턴스 메서드 | |
-| Learn More | 더 알아보기 | [링크][Mutable] |
-| Next steps | 다음 단계 | [링크][2D_breakout_game_Phaser] |
-| Polyfill | 폴리필 | [링크](https://github.com/mdn/translated-content/pull/1779/files) |
-| Reference | 참고서 | |
-| See also | 같이 보기 | [링크][target] |
-| Specifications | 명세서 | [링크](https://github.com/mdn/translated-content/pull/1779/files) |
-| Static properties | 정적 속성 | |
-| Static methods  | 정적 메서드 | |
-| Sticky activation | 고정 활성화 | |
-| Summary | 요약 | |
-| Syntax | 구문 | [링크][target] |
-| Tools & resources | 도구 & 리소스 | [링크][JavaScript] |
-| Transient activation | 임시 활성화 | |
-| Tutorial | 자습서 | |
-| Usage notes | 사용 일람 | |
-| Web Technologies | 웹 기술들 | [링크][Introduction_to_HTML5_Game_Development] |
+| 용어                   | 번역            | 참고 링크                                                                                                                               |
+| ---------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Access                 | 접근            |                                                                                                                                         |
+| Accessibility concerns | 접근성 고려사항 |                                                                                                                                         |
+| Advantages             | 장점            | [링크][Introduction_to_HTML5_Game_Development]                                                                                          |
+| Aliasing               | 별칭            | [링크](https://github.com/mdn/translated-content/pull/1779/files)                                                                       |
+| Brief history          | 간략한 역사     | [링크][HTML#%EA%B0%84%EB%9E%B5%ED%95%9C_%EC%97%AD%EC%82%AC]                                                                             |
+| Browser compatibility  | 브라우저 호환성 | [링크](https://github.com/mdn/translated-content/pull/1779/files)                                                                       |
+| Browser support        | 브라우저 지원   | [링크][Using_IIR_filters]                                                                                                               |
+| Concept                | 개념            |                                                                                                                                         |
+| Conclusion             | 결론            |                                                                                                                                         |
+| Contact us             | 문의하기        |                                                                                                                                         |
+| Demo                   | 데모            | [링크][GLSL_Shaders]                                                                                                                    |
+| Description            | 설명            | [링크][Array]                                                                                                                           |
+| Example                | 예제            | [링크][target]                                                                                                                          |
+| Examples               | 예제            | [링크](https://github.com/mdn/translated-content/blob/main/files/ko/web/javascript/reference/global_objects/proxy/proxy/apply/index.md) |
+| Guides                 | 안내서          |                                                                                                                                         |
+| In this module         | 이번 과정에서는 | [링크][React_getting_started]                                                                                                           |
+| Instance properties    | 인스턴스 속성   |                                                                                                                                         |
+| Instance methods       | 인스턴스 메서드 |                                                                                                                                         |
+| Learn More             | 더 알아보기     | [링크][Mutable]                                                                                                                         |
+| Next steps             | 다음 단계       | [링크][2D_breakout_game_Phaser]                                                                                                         |
+| Polyfill               | 폴리필          | [링크](https://github.com/mdn/translated-content/pull/1779/files)                                                                       |
+| Reference              | 참고서          |                                                                                                                                         |
+| See also               | 같이 보기       | [링크][target]                                                                                                                          |
+| Specifications         | 명세서          | [링크](https://github.com/mdn/translated-content/pull/1779/files)                                                                       |
+| Static properties      | 정적 속성       |                                                                                                                                         |
+| Static methods         | 정적 메서드     |                                                                                                                                         |
+| Sticky activation      | 고정 활성화     |                                                                                                                                         |
+| Summary                | 요약            |                                                                                                                                         |
+| Syntax                 | 구문            | [링크][target]                                                                                                                          |
+| Tools & resources      | 도구 & 리소스   | [링크][JavaScript]                                                                                                                      |
+| Transient activation   | 임시 활성화     |                                                                                                                                         |
+| Tutorial               | 자습서          |                                                                                                                                         |
+| Usage notes            | 사용 일람       |                                                                                                                                         |
+| Web Technologies       | 웹 기술들       | [링크][Introduction_to_HTML5_Game_Development]                                                                                          |
 
 ## Section Subtitle
 
@@ -76,60 +76,60 @@
 
 **사전 순으로 용어집을 편집해주세요.**
 
-| 용어 | 번역 | 참고 링크 |
-| --- | --- | --- |
-| Compatibility notes | 호환성 참고 사항 | [링크][target] |
-| Directives | 지시어 | [링크](https://github.com/mdn/translated-content/issues/11093#issuecomment-1411005106) |
-| Guide | 안내서 | [링크](https://github.com/mdn/translated-content/issues/11093#issuecomment-1411005106) |
-| Instruction | 지침 | [링크](https://github.com/mdn/translated-content/issues/11093#issuecomment-1411005106) |
-| Naming | 이름 지정 | |
-| Parameters | 매개변수 | [링크][AudioWorkletNode] |
-| Requirements | 요구 사항 | |
-| Value | 값 | [링크][target] |
+| 용어                | 번역             | 참고 링크                                                                              |
+| ------------------- | ---------------- | -------------------------------------------------------------------------------------- |
+| Compatibility notes | 호환성 참고 사항 | [링크][target]                                                                         |
+| Directives          | 지시어           | [링크](https://github.com/mdn/translated-content/issues/11093#issuecomment-1411005106) |
+| Guide               | 안내서           | [링크](https://github.com/mdn/translated-content/issues/11093#issuecomment-1411005106) |
+| Instruction         | 지침             | [링크](https://github.com/mdn/translated-content/issues/11093#issuecomment-1411005106) |
+| Naming              | 이름 지정        |                                                                                        |
+| Parameters          | 매개변수         | [링크][AudioWorkletNode]                                                               |
+| Requirements        | 요구 사항        |                                                                                        |
+| Value               | 값               | [링크][target]                                                                         |
 
 ## 공통 용어
 
 **사전 순으로 용어집을 편집해주세요.**
 
-| 용어 | 번역 | 기타 |
-| --- | --- | --- |
-| Application | 애플리케이션 | |
-| Assertion | 어설션 | |
-| Attribute | 특성 | |
-| Boolean | 불리언 | |
-| Class | 클래스 | |
-| Content(s) | 콘텐츠 | |
-| Context | 맥락 | |
-| Decoding | 디코딩 | [링크](https://github.com/mdn/translated-content/issues/12452) |
-| Document | 문서 | |
-| Element | 요소 | |
-| Encoding | 인코딩 | [링크](https://github.com/mdn/translated-content/issues/12452) |
-| Entity | 개체 | |
-| Enumerated | 열거형 | |
-| Expression | 표현식 또는 식 | |
-| Framework | 프레임워크 | |
-| Global | 전역 | |
-| Glossary | 용어 사전 | |
-| Grammar | 문법 | |
-| In modern browsers | 최신 브라우저 | |
-| Literal | 리터럴 | |
-| Mantissa | 가수부 | |
-| Method | 메서드 | [국립국어원 Method](https://www.korean.go.kr/front/onlineQna/onlineQnaView.do?mn_id=216&qna_seq=11976) |
-| Module | 모듈 | ESM에서 명시하는 모듈의 경우 '모듈'로 변역한다. | |
-| Module | 과정 | 어떠한 교육 과정, 단위에 의한 표현은 '과정'으로 번역한다. (예: In this module) | |
-| Object | 객체 | |
-| Origin | 출처 | |
-| Override | 재정의 | |
-| Primitive | 원시 (값) | |
-| Property | 속성 | |
-| Psuedo- | 의사- | |
-| Reference | 참고서 | |
-| Regular expression | 정규 표현식 | |
-| Rendering | 렌더링 | |
-| Section | 구획 | |
-| Statement | 명령문 또는 문 | |
-| short-circuit |
-| User agent | 사용자 에이전트 | |
+| 용어               | 번역            | 기타                                                                                                   |
+| ------------------ | --------------- | ------------------------------------------------------------------------------------------------------ | --- |
+| Application        | 애플리케이션    |                                                                                                        |
+| Assertion          | 어설션          |                                                                                                        |
+| Attribute          | 특성            |                                                                                                        |
+| Boolean            | 불리언          |                                                                                                        |
+| Class              | 클래스          |                                                                                                        |
+| Content(s)         | 콘텐츠          |                                                                                                        |
+| Context            | 맥락            |                                                                                                        |
+| Decoding           | 디코딩          | [링크](https://github.com/mdn/translated-content/issues/12452)                                         |
+| Document           | 문서            |                                                                                                        |
+| Element            | 요소            |                                                                                                        |
+| Encoding           | 인코딩          | [링크](https://github.com/mdn/translated-content/issues/12452)                                         |
+| Entity             | 개체            |                                                                                                        |
+| Enumerated         | 열거형          |                                                                                                        |
+| Expression         | 표현식 또는 식  |                                                                                                        |
+| Framework          | 프레임워크      |                                                                                                        |
+| Global             | 전역            |                                                                                                        |
+| Glossary           | 용어 사전       |                                                                                                        |
+| Grammar            | 문법            |                                                                                                        |
+| In modern browsers | 최신 브라우저   |                                                                                                        |
+| Literal            | 리터럴          |                                                                                                        |
+| Mantissa           | 가수부          |                                                                                                        |
+| Method             | 메서드          | [국립국어원 Method](https://www.korean.go.kr/front/onlineQna/onlineQnaView.do?mn_id=216&qna_seq=11976) |
+| Module             | 모듈            | ESM에서 명시하는 모듈의 경우 '모듈'로 변역한다.                                                        |     |
+| Module             | 과정            | 어떠한 교육 과정, 단위에 의한 표현은 '과정'으로 번역한다. (예: In this module)                         |     |
+| Object             | 객체            |                                                                                                        |
+| Origin             | 출처            |                                                                                                        |
+| Override           | 재정의          |                                                                                                        |
+| Primitive          | 원시 (값)       |                                                                                                        |
+| Property           | 속성            |                                                                                                        |
+| Psuedo-            | 의사-           |                                                                                                        |
+| Reference          | 참고서          |                                                                                                        |
+| Regular expression | 정규 표현식     |                                                                                                        |
+| Rendering          | 렌더링          |                                                                                                        |
+| Section            | 구획            |                                                                                                        |
+| Statement          | 명령문 또는 문  |                                                                                                        |
+| short-circuit      |
+| User agent         | 사용자 에이전트 |                                                                                                        |
 
 ## CSS
 
@@ -144,62 +144,62 @@
 
 **사전 순으로 용어집을 편집해주세요.**
 
-| 용어 | 번역 | 기타 | 참고 링크 |
-| --- | --- | --- | ------ |
-| At-rule | @규칙 | | |
-| Block | 블록 | | |
-| Border | 테두리 | | |
-| Box | 박스 | | |
-| Flexbox | 플렉스박스 | | |
-| Flow | 플로 | 레이아웃 방식일 경우에 한정 | |
-| Formal syntax | 형식 구문 | | |
-| Grid | 그리드 | | |
-| Inline | 인라인 | | |
-| Layout | 레이아웃 | | |
-| Longhand property | 본디 속성 | | |
-| Margin | 바깥 여백 | | |
-| Padding | 안쪽 여백(패딩) | | [CSS 기본 박스 모델 입문][] |
-| Shorthand property | 단축 속성 | | |
+| 용어               | 번역            | 기타                        | 참고 링크                   |
+| ------------------ | --------------- | --------------------------- | --------------------------- |
+| At-rule            | @규칙           |                             |                             |
+| Block              | 블록            |                             |                             |
+| Border             | 테두리          |                             |                             |
+| Box                | 박스            |                             |                             |
+| Flexbox            | 플렉스박스      |                             |                             |
+| Flow               | 플로            | 레이아웃 방식일 경우에 한정 |                             |
+| Formal syntax      | 형식 구문       |                             |                             |
+| Grid               | 그리드          |                             |                             |
+| Inline             | 인라인          |                             |                             |
+| Layout             | 레이아웃        |                             |                             |
+| Longhand property  | 본디 속성       |                             |                             |
+| Margin             | 바깥 여백       |                             |                             |
+| Padding            | 안쪽 여백(패딩) |                             | [CSS 기본 박스 모델 입문][] |
+| Shorthand property | 단축 속성       |                             |                             |
 
 ## API/JavaScript
 
 **사전 순으로 용어집을 편집해주세요.**
 
-| 용어 | 번역 | 기타 | 참고 링크 |
-| --- | --- | --- | ------ |
-| Argument | 전달인자, 인수 | | [참고 링크](https://github.com/mdn/translated-content/pull/3888) |
-| Blocking operation | 블로킹 연산 | | |
-| Callback | 콜백 | | |
-| Dictionary | 사전 | | [참고 링크](https://github.com/mdn/translated-content/pull/10976#discussion_r1073704799) |
-| Fulfilled | 이행(함) | | |
-| Handler | 처리기 | 이벤트 처리기 | |
-| Interface | 인터페이스 | | |
-| Iterate | 순회 | | |
-| Listener | 수신기 | 이벤트 수신기 | |
-| Mixin | 믹스인 | | |
-| Non-blocking operation | 논블로킹 연산 | | |
-| Parameter | 매개변수 | | |
-| Pending | 대기 | | |
-| Promise | 프로미스 | | [참고 링크](https://github.com/mdn/translated-content/pull/1081#issuecomment-878333558) |
-| Promise chaining | 프로미스 체이닝 | | |
-| Prototype | 프로토타입 | | |
-| Reject | 거부 | | |
-| Resolve | 이행 | | |
-| Rest parameters | 나머지 매개변수 | | [참고 링크](https://github.com/mdn/translated-content/pull/2549/files) |
-| Scope | 범위 | | |
-| Settled | 처리 | | |
-| Sparse array | 희소 배열 | | |
-| Temporal Dead Zone, TDZ | 시간상 사각지대 | | [참고 링크](https://github.com/mdn/translated-content/pull/2626/files) |
-| TypedArray | 형식화 배열 | | |
+| 용어                    | 번역            | 기타          | 참고 링크                                                                                |
+| ----------------------- | --------------- | ------------- | ---------------------------------------------------------------------------------------- |
+| Argument                | 전달인자, 인수  |               | [참고 링크](https://github.com/mdn/translated-content/pull/3888)                         |
+| Blocking operation      | 블로킹 연산     |               |                                                                                          |
+| Callback                | 콜백            |               |                                                                                          |
+| Dictionary              | 사전            |               | [참고 링크](https://github.com/mdn/translated-content/pull/10976#discussion_r1073704799) |
+| Fulfilled               | 이행(함)        |               |                                                                                          |
+| Handler                 | 처리기          | 이벤트 처리기 |                                                                                          |
+| Interface               | 인터페이스      |               |                                                                                          |
+| Iterate                 | 순회            |               |                                                                                          |
+| Listener                | 수신기          | 이벤트 수신기 |                                                                                          |
+| Mixin                   | 믹스인          |               |                                                                                          |
+| Non-blocking operation  | 논블로킹 연산   |               |                                                                                          |
+| Parameter               | 매개변수        |               |                                                                                          |
+| Pending                 | 대기            |               |                                                                                          |
+| Promise                 | 프로미스        |               | [참고 링크](https://github.com/mdn/translated-content/pull/1081#issuecomment-878333558)  |
+| Promise chaining        | 프로미스 체이닝 |               |                                                                                          |
+| Prototype               | 프로토타입      |               |                                                                                          |
+| Reject                  | 거부            |               |                                                                                          |
+| Resolve                 | 이행            |               |                                                                                          |
+| Rest parameters         | 나머지 매개변수 |               | [참고 링크](https://github.com/mdn/translated-content/pull/2549/files)                   |
+| Scope                   | 범위            |               |                                                                                          |
+| Settled                 | 처리            |               |                                                                                          |
+| Sparse array            | 희소 배열       |               |                                                                                          |
+| Temporal Dead Zone, TDZ | 시간상 사각지대 |               | [참고 링크](https://github.com/mdn/translated-content/pull/2626/files)                   |
+| TypedArray              | 형식화 배열     |               |                                                                                          |
 
 ## HTTP
 
-| 용어 | 번역 | 기타 | 참고 링크 |
-| --- | --- | --- | ------ |
-| Idempotent | 멱등성 | | |
-| Payload | 페이로드 | | [참고 링크](https://github.com/mdn/translated-content/pull/2737) |
-| Request Body | 요청 본문 | | |
-| Response Body | 응답 본문 | | |
+| 용어          | 번역      | 기타 | 참고 링크                                                        |
+| ------------- | --------- | ---- | ---------------------------------------------------------------- |
+| Idempotent    | 멱등성    |      |                                                                  |
+| Payload       | 페이로드  |      | [참고 링크](https://github.com/mdn/translated-content/pull/2737) |
+| Request Body  | 요청 본문 |      |                                                                  |
+| Response Body | 응답 본문 |      |                                                                  |
 
 [AudioWorkletNode]: https://developer.mozilla.org/en-US/docs/Web/API/AudioWorkletNode/AudioWorkletNode#parameters
 [Using_IIR_filters]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Using_IIR_filters#browser_support

--- a/docs/ko/guides/meta-data-guide.md
+++ b/docs/ko/guides/meta-data-guide.md
@@ -21,7 +21,7 @@ tags:
 {{JSRef}}
 
 The `Proxy` object enables you to create a proxy for another ...
-  :
+:
 ```
 
 번역본
@@ -37,7 +37,7 @@ l10n:
 {{JSRef}}
 
 **`Proxy`** 객체는 기본적인 동작(속성 접근, 할당, 순회, 열거, 함수 ...
-  :
+:
 ```
 
 <details>

--- a/docs/ko/guides/translation-guide.md
+++ b/docs/ko/guides/translation-guide.md
@@ -30,12 +30,12 @@
 
 **사전 순으로 용어집을 편집해주세요.**
 
-| 용어 | 번역 | 참고 링크 |
-| --- | --- | --- |
-| Note | 참고 | |
-| Warning | 경고 | |
-| Callout | 알림 | |
-| Objective | 목표 | [링크][What_is_accessibility] |
+| 용어          | 번역             | 참고 링크                     |
+| ------------- | ---------------- | ----------------------------- |
+| Note          | 참고             |                               |
+| Warning       | 경고             |                               |
+| Callout       | 알림             |                               |
+| Objective     | 목표             | [링크][What_is_accessibility] |
 | Prerequisites | 필요한 사전 지식 | [링크][What_is_accessibility] |
 
 ### 교육 과정 callout
@@ -56,10 +56,15 @@
 
 ```markdown
 # 참고
+
 > **Note:** This is a note.
+
 # 경고
+
 > **Warning:** This is a warning.
+
 # 알림
+
 > **Callout:** This is a callout.
 ```
 
@@ -67,10 +72,15 @@
 
 ```markdown
 # 참고
+
 > **참고:** 참고입니다.
+
 # 경고
+
 > **경고:** 경고입니다.
+
 # 알림
+
 > **알림:** 알림입니다.
 ```
 


### PR DESCRIPTION
This PR formats the Korean translation guides using Prettier.
