### PR TITLE
Prettier ignore: separate larger folders into smaller chunks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -17,6 +17,10 @@ build/
 /files/es/games/**/*.md
 /files/es/glossary/**/*.md
 /files/es/learn/**/*.md
+/files/es/learn/css/**/*.md
+/files/es/learn/html/**/*.md
+/files/es/learn/javascript/**/*.md
+/files/es/learn/server-side/**/*.md
 /files/es/mdn/**/*.md
 /files/es/mozilla/**/*.md
 /files/es/web/api/**/*.md
@@ -30,19 +34,39 @@ build/
 /files/fr/games/**/*.md
 /files/fr/glossary/**/*.md
 /files/fr/learn/**/*.md
+/files/fr/learn/css/**/*.md
+/files/fr/learn/html/**/*.md
+/files/fr/learn/javascript/**/*.md
+/files/fr/learn/server-side/**/*.md
 /files/fr/mdn/**/*.md
 /files/fr/mozilla/**/*.md
 /files/fr/web/**/*.md
+/files/fr/web/api/**/*.md
+/files/fr/web/css/**/*.md
+/files/fr/web/html/**/*.md
+/files/fr/web/http/**/*.md
+/files/fr/web/javascript/**/*.md
+/files/fr/web/svg/**/*.md
 /files/fr/webassembly/**/*.md
 
 # ja
 /files/ja/games/**/*.md
 /files/ja/glossary/**/*.md
 /files/ja/learn/**/*.md
+/files/ja/learn/css/**/*.md
+/files/ja/learn/html/**/*.md
+/files/ja/learn/javascript/**/*.md
+/files/ja/learn/server-side/**/*.md
 /files/ja/mdn/**/*.md
 /files/ja/mozilla/**/*.md
 /files/ja/related/**/*.md
 /files/ja/web/**/*.md
+/files/ja/web/api/**/*.md
+/files/ja/web/css/**/*.md
+/files/ja/web/html/**/*.md
+/files/ja/web/http/**/*.md
+/files/ja/web/javascript/**/*.md
+/files/ja/web/svg/**/*.md
 /files/ja/webassembly/**/*.md
 
 # ko
@@ -50,24 +74,48 @@ build/
 /files/ko/games/**/*.md
 /files/ko/glossary/**/*.md
 /files/ko/learn/**/*.md
+/files/ko/learn/css/**/*.md
+/files/ko/learn/html/**/*.md
+/files/ko/learn/javascript/**/*.md
+/files/ko/learn/server-side/**/*.md
 /files/ko/mdn/**/*.md
 /files/ko/mozilla/**/*.md
 /files/ko/web/**/*.md
+/files/ko/web/api/**/*.md
+/files/ko/web/css/**/*.md
+/files/ko/web/html/**/*.md
+/files/ko/web/http/**/*.md
+/files/ko/web/javascript/**/*.md
+/files/ko/web/svg/**/*.md
 /files/ko/webassembly/**/*.md
 
 # pt-br
 /files/pt-br/games/**/*.md
 /files/pt-br/glossary/**/*.md
 /files/pt-br/learn/**/*.md
+/files/pt-br/learn/css/**/*.md
+/files/pt-br/learn/html/**/*.md
+/files/pt-br/learn/javascript/**/*.md
+/files/pt-br/learn/server-side/**/*.md
 /files/pt-br/mdn/**/*.md
 /files/pt-br/mozilla/**/*.md
 /files/pt-br/web/**/*.md
+/files/pt-br/web/api/**/*.md
+/files/pt-br/web/css/**/*.md
+/files/pt-br/web/html/**/*.md
+/files/pt-br/web/http/**/*.md
+/files/pt-br/web/javascript/**/*.md
+/files/pt-br/web/svg/**/*.md
 /files/pt-br/webassembly/**/*.md
 
 # ru
 /files/ru/games/**/*.md
 /files/ru/glossary/**/*.md
 /files/ru/learn/**/*.md
+/files/ru/learn/css/**/*.md
+/files/ru/learn/html/**/*.md
+/files/ru/learn/javascript/**/*.md
+/files/ru/learn/server-side/**/*.md
 /files/ru/mdn/**/*.md
 /files/ru/mozilla/**/*.md
 /files/ru/web/api/**/*.md
@@ -80,6 +128,10 @@ build/
 
 # zh-cn
 /files/zh-cn/learn/**/*.md
+/files/zh-cn/learn/css/**/*.md
+/files/zh-cn/learn/html/**/*.md
+/files/zh-cn/learn/javascript/**/*.md
+/files/zh-cn/learn/server-side/**/*.md
 /files/zh-cn/mdn/**/*.md
 /files/zh-cn/web/api/**/*.md
 /files/zh-cn/web/css/**/*.md


### PR DESCRIPTION
This PR updates the `.prettierignore` to pre-emptively separate the larger folders into smaller chunks.
