### PR TITLE
es: Format /mdn using Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -21,7 +21,6 @@ build/
 /files/es/learn/html/**/*.md
 /files/es/learn/javascript/**/*.md
 /files/es/learn/server-side/**/*.md
-/files/es/mdn/**/*.md
 /files/es/mozilla/**/*.md
 /files/es/web/api/**/*.md
 /files/es/web/css/**/*.md

--- a/files/es/mdn/contribute/index.md
+++ b/files/es/mdn/contribute/index.md
@@ -144,7 +144,7 @@ Si estás más interesado en el código, puedes probar lo siguiente:
 - [Envía un parche al código base de Yari](https://github.com/mdn/yari) (1 hora)
 - [Escribe un ejemplo interactivo](https://github.com/mdn/interactive-examples/blob/master/CONTRIBUTING.md) (1 hora)
 
-Si estás interesado en las palabras *y* el código, puede intentar lo siguiente:
+Si estás interesado en las palabras _y_ el código, puede intentar lo siguiente:
 
 - [Escribir o actualizar una referencia de API](/es/docs/MDN/Contribute/Howto/Write_an_API_reference) (30 minutos a 2 horas, o más)
 - [Escribe un nuevo artículo sobre un tema con el que estés familiarizado.](https://github.com/mdn/content#adding-a-new-document) (1 hora o más)

--- a/files/es/mdn/writing_guidelines/howto/index.md
+++ b/files/es/mdn/writing_guidelines/howto/index.md
@@ -182,37 +182,37 @@ Los filtros de búsqueda no funcionarán adecuadamente a menos que etiquetamos c
 
 > **Nota:** Si varias etiquetas se muestran bajo "Nombre de etiqueta", significa que una o más de las etiquetas deben estar presentes en el artículo.
 
-| Grupo          | Nombre filtro          | Nombre de etiqueta                                                                                                    |
-| -------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| Tema           | Open Web Apps          | `Apps`                                                   |
-|                | HTML                   | `HTML`                                                   |
-|                | CSS                    | `CSS`                                                    |
-|                | JavaScript             | `JavaScript`                                             |
-|                | APIs and DOM           | `API`                                                    |
-|                | Canvas                 | `Canvas`                                                 |
-|                | SVG                    | `SVG`                                                    |
-|                | MathML                 | `MathML`                                                 |
-|                | WebGL                  | `WebGL`                                                  |
-|                | XUL                    | `XUL`                                                    |
-|                | Marketplace            | `Marketplace`                                            |
-|                | Firefox                | `Firefox`                                                |
-|                | Firefox para Android   | `Firefox Mobile`                                         |
-|                | Firefox para Desktop   | `Firefox Desktop`                                        |
-|                | Firefox OS             | `Firefox OS`                                             |
-|                | Movil                  | `Movil`                                                  |
-|                | Web Development        | `Web Development`                                        |
-|                | Add-ons & Extensions   | `Add-ons` \|\| `Extensions` \|\| `Plugins` \|\| `Themes` |
-|                | Juegos                 | `Juegos`                                                 |
-| Nivel          | Soy experto            | `Experto`                                                |
-|                | Intermedio             | `Intermedio`                                             |
-|                | Soy aprendiz           | `Aprendiz`                                               |
-| Tipo Documento | Docs                   | Restringirá la búsqueda al contenido de los docs, dejando fuera otros contenidos MDN.                                 |
-|                | Demostración           | Incluirá el contenido de demostración en los resultados de búsqueda.                                                  |
-|                | Herramientas           | `Herramientas`                                                                                      |
-|                | Ejemplo Código         | `Ejemplo`                                                                                              |
-|                | Como & Tutorial        | `Guia`                                                                                                  |
-|                | Perfiles Desarrollador | Incluirá perfiles de desarrolladores de MDN en los resultados de búsqueda.                                            |
-|                | Recurso externo        | Es algo que el equipo de desarrollo todavía está descifrando...                                                       |
+| Grupo          | Nombre filtro          | Nombre de etiqueta                                                                    |
+| -------------- | ---------------------- | ------------------------------------------------------------------------------------- |
+| Tema           | Open Web Apps          | `Apps`                                                                                |
+|                | HTML                   | `HTML`                                                                                |
+|                | CSS                    | `CSS`                                                                                 |
+|                | JavaScript             | `JavaScript`                                                                          |
+|                | APIs and DOM           | `API`                                                                                 |
+|                | Canvas                 | `Canvas`                                                                              |
+|                | SVG                    | `SVG`                                                                                 |
+|                | MathML                 | `MathML`                                                                              |
+|                | WebGL                  | `WebGL`                                                                               |
+|                | XUL                    | `XUL`                                                                                 |
+|                | Marketplace            | `Marketplace`                                                                         |
+|                | Firefox                | `Firefox`                                                                             |
+|                | Firefox para Android   | `Firefox Mobile`                                                                      |
+|                | Firefox para Desktop   | `Firefox Desktop`                                                                     |
+|                | Firefox OS             | `Firefox OS`                                                                          |
+|                | Movil                  | `Movil`                                                                               |
+|                | Web Development        | `Web Development`                                                                     |
+|                | Add-ons & Extensions   | `Add-ons` \|\| `Extensions` \|\| `Plugins` \|\| `Themes`                              |
+|                | Juegos                 | `Juegos`                                                                              |
+| Nivel          | Soy experto            | `Experto`                                                                             |
+|                | Intermedio             | `Intermedio`                                                                          |
+|                | Soy aprendiz           | `Aprendiz`                                                                            |
+| Tipo Documento | Docs                   | Restringirá la búsqueda al contenido de los docs, dejando fuera otros contenidos MDN. |
+|                | Demostración           | Incluirá el contenido de demostración en los resultados de búsqueda.                  |
+|                | Herramientas           | `Herramientas`                                                                        |
+|                | Ejemplo Código         | `Ejemplo`                                                                             |
+|                | Como & Tutorial        | `Guia`                                                                                |
+|                | Perfiles Desarrollador | Incluirá perfiles de desarrolladores de MDN en los resultados de búsqueda.            |
+|                | Recurso externo        | Es algo que el equipo de desarrollo todavía está descifrando...                       |
 
 ## Problemas de etiquetado que puedes solucionar
 

--- a/files/es/mdn/writing_guidelines/index.md
+++ b/files/es/mdn/writing_guidelines/index.md
@@ -72,7 +72,7 @@ Algunos contenidos antiguos se pusieron a disposición bajo una licencia distint
 
 Si tienes alguna pregunta o inquietud sobre algo expuesto aquí, por favor contacta con [Eric Shepherd](mailto:eshepherd@mozilla.com).
 
--------------
+---
 
 Los derechos sobre las marcas comerciales, logotipos, marcas al servicio de la Fundación Mozilla, así como la apariencia de este sitio Web, no se encuentran bajo la licencia Creative Commons, están exentos. Se reconoce que son obras de autoría (como logotipos y diseños gráficos), y no están incluidos en el trabajo que se autoriza bajo esos términos. Si utilizas el texto de los documentos, y deseas también usar cualquiera de estos derechos, o si tienes cualquier otra pregunta sobre el cumplimiento de nuestros términos de licencia para esta colección, contacta con la Fundación Mozilla por este medio: [licensing@mozilla.org](mailto:licensing@mozilla.org).
 

--- a/files/es/mdn/writing_guidelines/page_structures/macros/index.md
+++ b/files/es/mdn/writing_guidelines/page_structures/macros/index.md
@@ -4,7 +4,7 @@ slug: MDN/Writing_guidelines/Page_structures/Macros
 page-type: mdn-writing-guide
 l10n:
   sourceCommit: 92cbbdaf81325539eace880b5e78152e3cb8ba49
---- 
+---
 
 {{MDNSidebar}}
 
@@ -21,7 +21,7 @@ Las macros en MDN se implementan utilizando código [JavaScript](/es/docs/Web/Ja
 Para utilizar una macro, encierre la llamada a la macro en un par de llaves dobles incluyendo sus parámetros, si los hay.
 
 ```plain
-\{{nombredelamacro(lista-de-parámetros)}} 
+\{{nombredelamacro(lista-de-parámetros)}}
 ```
 
 Algunos apuntes sobre la llamada a las macros

--- a/files/es/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
+++ b/files/es/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
@@ -559,7 +559,7 @@ Las sentencias `switch` pueden ser un poco complicadas.
   ```
 
 > **Nota:** Tenga en cuenta que solo los errores _recuperables_ deben detectarse y manejarse.
-  Todos los errores no recuperables deben dejarse pasar y aumentar la pila de llamadas.
+> Todos los errores no recuperables deben dejarse pasar y aumentar la pila de llamadas.
 
 ## Objetos
 


### PR DESCRIPTION
This PR formats the `/mdn` folder in the Spanish locale using Prettier.
