### PR TITLE
[zh-tw]: Fix deprecated link

### DIFF
--- a/files/zh-tw/web/javascript/javascript_technologies_overview/index.md
+++ b/files/zh-tw/web/javascript/javascript_technologies_overview/index.md
@@ -27,7 +27,7 @@ JavaScript 的核心語言是由 ECMA TC-39 委員會統一標準，並且命名
 
 ### 瀏覽器支援
 
-根據以前的經驗，ECMAScript 的功能都有良好且互通的支援。截至 2011 年 6 月，ECMAScript 5 的支援在不同瀏覽器實作之間存在差異。[有些文件](http://kangax.github.com/es5-compat-table/)整理了各瀏覽器對 ECMAScript 5 的支援情形。
+根據以前的經驗，ECMAScript 的功能都有良好且互通的支援。截至 2011 年 6 月，ECMAScript 5 的支援在不同瀏覽器實作之間存在差異。[有些文件](https://kangax.github.io/compat-table/es5/)整理了各瀏覽器對 ECMAScript 5 的支援情形。
 
 ## DOM（文件物件模型）
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This pull request addresses a deprecated link issue. The previous link, `http://kangax.github.com/es5-compat-table/`, has become deprecated due to the deprecation of `*.github.com` ([GitHub Pages](https://github.blog/changelog/2021-01-29-github-pages-will-stop-redirecting-pages-sites-from-github-com-after-april-15-2021/)). I have made the necessary changes and replaced the deprecated link with the new valid URL: `https://kangax.github.io/compat-table/es5/`.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
