### PR TITLE
chore(prettierignore): remove code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -87,3 +87,4 @@
 /.github/     @mdn/core-dev
 /*            @mdn/core-dev
 /*.md         @mdn/core-dev @mdn/core-yari-content
+/.prettierignore

--- a/.github/workflows/system-file-changes.yml
+++ b/.github/workflows/system-file-changes.yml
@@ -8,6 +8,7 @@ on:
   pull_request_target:
     paths:
       - ".github/**"
+      - ".prettierignore"
       - package.json
       - yarn.lock
 

--- a/.github/workflows/system-file-changes.yml
+++ b/.github/workflows/system-file-changes.yml
@@ -8,7 +8,6 @@ on:
   pull_request_target:
     paths:
       - ".github/**"
-      - ".prettierignore"
       - package.json
       - yarn.lock
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Removes the code owners for `.prettierignore`, and adds the file to the `system-file-changes` check.

### Motivation

This means PRs changing the `.prettierignore` file no longer trigger a review request from `@mdn/core-dev`. However, the failing `system-file-changes` check ensures reviewers notice the changes.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
