### PR TITLE
Introduce frontmatter config for translated content

### DIFF
--- a/front-matter-config.json
+++ b/front-matter-config.json
@@ -1,0 +1,43 @@
+{
+  "lineWidth": -1,
+  "schema": {
+    "title": "Front matter schema",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["title", "slug"],
+    "properties": {
+      "title": {
+        "title": "Title",
+        "description": "Rendered page title and for SEO",
+        "type": "string",
+        "maxLength": 120
+      },
+      "short-title": {
+        "title": "Short Title",
+        "description": "To be used in sidebars",
+        "type": "string",
+        "maxLength": 60
+      },
+      "slug": {
+        "title": "slug",
+        "description": "URL path of the page",
+        "type": "string"
+      },
+      "l10n": {
+        "title": "Localization info",
+        "description": "Metadata about the localization",
+        "type": "object",
+        "properties": {
+          "sourceCommit": {
+            "title": "Source commit",
+            "description": "The full commit hash of the commit from upstream this localization is synchronized with. Used to track changes between upstream and localization.",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["sourceCommit"]
+      }
+    }
+  },
+  "attribute-order": ["title", "short-title", "slug", "l10n"]
+}


### PR DESCRIPTION
This PR is a cherry-pick of #14350 that adds a frontmatter config tailored for translated content.  This will allow us to lint the frontmatter in the near future.
