### PR TITLE
Update labeler rules

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,9 +1,11 @@
-# For more ideas, see https://github.com/actions/labeler#common-examples
-
 system:
+  - package.json
+  - yarn.lock
   - .github/**/*
   - .husky/**/*
+  - .vscode/**/*
   - .*
+  - front-matter-config.json
 
 l10n-de:
   - files/de/**/*


### PR DESCRIPTION
This PR updates the list of files that should get labeled as `system`.
