### PR TITLE
pt-br: Format /glossary using Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -96,7 +96,6 @@ build/
 
 # pt-br
 /files/pt-br/games/**/*.md
-/files/pt-br/glossary/**/*.md
 /files/pt-br/learn/**/*.md
 /files/pt-br/learn/css/**/*.md
 /files/pt-br/learn/html/**/*.md

--- a/files/pt-br/glossary/accessibility_tree/index.md
+++ b/files/pt-br/glossary/accessibility_tree/index.md
@@ -25,5 +25,5 @@ Enquanto continua em forma de rascunho na Web Incubator Community Group, o Model
 
 1. [Glossário](/pt-BR/docs/Glossario)
 
-    1. {{Glossary("Accessibility", "Acessibilidade")}}
-    2. {{Glossary("ARIA")}}
+   1. {{Glossary("Accessibility", "Acessibilidade")}}
+   2. {{Glossary("ARIA")}}

--- a/files/pt-br/glossary/base64/index.md
+++ b/files/pt-br/glossary/base64/index.md
@@ -150,7 +150,7 @@ function base64EncArr(aBytes) {
         uint6ToB64((nUint24 >>> 18) & 63),
         uint6ToB64((nUint24 >>> 12) & 63),
         uint6ToB64((nUint24 >>> 6) & 63),
-        uint6ToB64(nUint24 & 63)
+        uint6ToB64(nUint24 & 63),
       );
       nUint24 = 0;
     }
@@ -200,7 +200,7 @@ function UTF8ArrToStr(aBytes) {
         : nPart > 191 && nPart < 224 && nIdx + 1 < nLen /* two bytes */
         ? ((nPart - 192) << 6) + aBytes[++nIdx] - 128
         : /* nPart < 127 ? */ /* one byte */
-          nPart
+          nPart,
     );
   }
   return sView;
@@ -312,12 +312,12 @@ Essas funções nos permitem criar também [uint8Arrays](/pt-BR/docs/Web/JavaScr
 ```js
 // "Base 64 \u2014 Mozilla Developer Network"
 const myArray = base64DecToArr(
-  "QmFzZSA2NCDigJQgTW96aWxsYSBEZXZlbG9wZXIgTmV0d29yaw=="
+  "QmFzZSA2NCDigJQgTW96aWxsYSBEZXZlbG9wZXIgTmV0d29yaw==",
 );
 
 // "Base 64 \u2014 Mozilla Developer Network"
 const myBuffer = base64DecToArr(
-  "QmFzZSA2NCDigJQgTW96aWxsYSBEZXZlbG9wZXIgTmV0d29yaw=="
+  "QmFzZSA2NCDigJQgTW96aWxsYSBEZXZlbG9wZXIgTmV0d29yaw==",
 ).buffer;
 
 alert(myBuffer.byteLength);

--- a/files/pt-br/glossary/block-level_content/index.md
+++ b/files/pt-br/glossary/block-level_content/index.md
@@ -13,13 +13,18 @@ Navegadores normalmente mostram o elemento em nível de bloco com uma nova linha
 ### HTML
 
 ```html
-<p>Este parágrafo é um elemento block-level; seu plano de fundo foi colorido para exibir o elemento pai do parágrafo.</p>
+<p>
+  Este parágrafo é um elemento block-level; seu plano de fundo foi colorido para
+  exibir o elemento pai do parágrafo.
+</p>
 ```
 
 ### CSS
 
 ```css
-p { background-color: #8ABB55; }
+p {
+  background-color: #8abb55;
+}
 ```
 
 {{ EmbedLiveSample('Block-level_Example') }}

--- a/files/pt-br/glossary/call_stack/index.md
+++ b/files/pt-br/glossary/call_stack/index.md
@@ -15,12 +15,12 @@ A pilha de chamadas **(call stack)** é um mecanismo do interpretador de uma lin
 
 ```js
 function saudacao() {
-   // [1] Algum código aqui
-   digaOi();
-   // [2] Algum código aqui
+  // [1] Algum código aqui
+  digaOi();
+  // [2] Algum código aqui
 }
 function digaOi() {
-   return "Olá!";
+  return "Olá!";
 }
 
 // Chamando a função `saudacao`
@@ -34,22 +34,22 @@ O código acima será executado desta forma pelo interpretador:
 1. Todas as funções serão ignoradas, até chegar na chamada da função `saudacao()`.
 2. Adiciona a função `saudacao()` para a pilha de chamadas.
 
-    > **Nota:** Pilha de chamadas:
-    > \- saudacao
+   > **Nota:** Pilha de chamadas:
+   > \- saudacao
 
 3. Executa todas as linhas de código da função `saudacao()`.
 4. Chama a função `digaOi()`.
 5. Adiciona a função `digaOi()` na pilha de chamadas.
 
-    > **Nota:** Pilha de chamadas:
-    > \- `saudacao` > \- digaOi
+   > **Nota:** Pilha de chamadas:
+   > \- `saudacao` > \- digaOi
 
 6. Executa todas as linhas de código da função `digaOi()` até o final.
 7. Retorna a execução na linha onde foi chamada a função `digaOi()` e continua a execução do resto da função `saudacao()`.
 8. Deleta a função `digaOi()` da pilha de chamadas.
 
-    > **Nota:** Pilha de chamadas:
-    > \- `saudacao`
+   > **Nota:** Pilha de chamadas:
+   > \- `saudacao`
 
 9. Quando todas as linhas da função `saudacao()` forem executadas, retorna para a linha onde a função foi invocada, e continua a execução do resto do código.
 10. Deleta a função `saudacao()` da Pilha de chamadas.

--- a/files/pt-br/glossary/callback_function/index.md
+++ b/files/pt-br/glossary/callback_function/index.md
@@ -10,11 +10,11 @@ Aqui está um pequeno exemplo:
 
 ```js
 function greeting(name) {
-  alert('Olá ' + name);
+  alert("Olá " + name);
 }
 
 function processUserInput(callback) {
-  var name = prompt('Por favor insira seu nome.');
+  var name = prompt("Por favor insira seu nome.");
   callback(name);
 }
 

--- a/files/pt-br/glossary/character_encoding/index.md
+++ b/files/pt-br/glossary/character_encoding/index.md
@@ -9,7 +9,7 @@ Uma codificação define um mapeamento entre bytes e texto. Uma sequência de by
 Por exemplo, em HTML, normalmente declaramos uma codificação de caracteres UTF-8, usando a seguinte linha:
 
 ```html
-  <meta charset="utf-8">
+<meta charset="utf-8" />
 ```
 
 Isso garante que você possa usar caracteres de praticamente qualquer idioma humano em seu documento HTML e eles serão exibidos com de forma confiável.

--- a/files/pt-br/glossary/css/index.md
+++ b/files/pt-br/glossary/css/index.md
@@ -17,7 +17,7 @@ p {
   color: yellow;
 
   /* A propriedade "background-color" define a cor ao fundo, neste caso preto. */
-  background-color: black
+  background-color: black;
 }
 ```
 

--- a/files/pt-br/glossary/css_preprocessor/index.md
+++ b/files/pt-br/glossary/css_preprocessor/index.md
@@ -10,11 +10,11 @@ Para usar um pré-processador, você deve instalar um compilador CSS no seu serv
 
 1. Alguns dos pré-processadores CSS mais populares:
 
-    1. [Sass](http://sass-lang.com/)
-    2. [LESS](http://lesscss.org/)
-    3. [Stylus](http://stylus-lang.com/)
-    4. [PostCSS](http://postcss.org/)
+   1. [Sass](http://sass-lang.com/)
+   2. [LESS](http://lesscss.org/)
+   3. [Stylus](http://stylus-lang.com/)
+   4. [PostCSS](http://postcss.org/)
 
 2. [MDN Web Docs Glossário](/pt-BR/docs/Glossario)
 
-    1. {{Glossary("CSS")}}
+   1. {{Glossary("CSS")}}

--- a/files/pt-br/glossary/falsy/index.md
+++ b/files/pt-br/glossary/falsy/index.md
@@ -11,13 +11,40 @@ Um valor **falsy** é um valor que se traduz em falso quando avaliado em um cont
 Exemplos de valores _falsy_ em JavaScript (que se traduzirá em false e assim _ignorar_ o bloco `if`):
 
 ```js
-if (false)
-if (null)
-if (undefined)
-if (0)
-if (NaN)
-if ('')
-if (document.all) [1]
+if (false) {
+  // Not reachable
+}
+
+if (null) {
+  // Not reachable
+}
+
+if (undefined) {
+  // Not reachable
+}
+
+if (0) {
+  // Not reachable
+}
+
+if (-0) {
+  // Not reachable
+}
+
+if (0n) {
+  // Not reachable
+}
+
+if (NaN) {
+  // Not reachable
+}
+
+if ("") {
+  // Not reachable
+}
+if (document.all) {
+  // [1], not reachable
+}
 ```
 
 \[1] `document.all` tem sido utilizado para a detecção do navegador no passado e a especificação [HTML define uma violação intencional](https://html.spec.whatwg.org/multipage/obsolete.html#dom-document-all) do padrão ECMAScript aqui para manter a compatibilidade com código legado (`if (document.all) { // Internet Explorer code here }` ou usando `document.all` sem verificar sua presença em primeiro lugar: `document.all.foo`).

--- a/files/pt-br/glossary/first-class_function/index.md
+++ b/files/pt-br/glossary/first-class_function/index.md
@@ -11,9 +11,9 @@ Entende-se que uma linguagem de programação tem **Função First-class** quand
 ### JavaScript
 
 ```js
-const foo = function() {
-   console.log("foobar");
-}
+const foo = function () {
+  console.log("foobar");
+};
 // Chamar a função usando a variável
 foo();
 ```
@@ -28,7 +28,7 @@ Nós atribuímos uma `Função Anônima` à uma `Variável`, então usamos a var
 
 ```js
 function sayHello() {
-   return "Hello, ";
+  return "Hello, ";
 }
 function greeting(helloMessage, name) {
   console.log(helloMessage() + name);
@@ -47,9 +47,9 @@ Nós estamos passando a função `sayHello()` como um argumento pra função `gr
 
 ```js
 function sayHello() {
-   return function() {
-      console.log("Hello!");
-   }
+  return function () {
+    console.log("Hello!");
+  };
 }
 ```
 
@@ -62,11 +62,11 @@ De volta ao nosso exemplo; Agora, precisamos chamar a função `sayHello` e a `F
 ### 1- Usando uma variável
 
 ```js
-const sayHello = function() {
-   return function() {
-      console.log("Hello!");
-   }
-}
+const sayHello = function () {
+  return function () {
+    console.log("Hello!");
+  };
+};
 const myFunc = sayHello();
 myFunc();
 ```
@@ -79,9 +79,9 @@ Dessa maneira, ela retorna a mensagem `Hello!`.
 
 ```js
 function sayHello() {
-   return function() {
-      console.log("Hello!");
-   }
+  return function () {
+    console.log("Hello!");
+  };
 }
 sayHello()();
 ```

--- a/files/pt-br/glossary/flex/index.md
+++ b/files/pt-br/glossary/flex/index.md
@@ -3,6 +3,7 @@ title: Flex
 slug: Glossary/Flex
 original_slug: Glossario/Flex
 ---
+
 `flex` é um novo valor adicionado à propriedade {{cssxref("display")}}. Junto com o `inline-flex`, este valor faz com que o elemento aplicado seja um {{glossary("flex container")}}, e seus filhos se transformem então em {{glossary("flex item")}}.Os itens então farão parte de um layout flex, e todas as propriedades definidas no CSS Flexbox poderão ser aplicadas.
 
 A propriedade flex é um atalho para as propriedades flexbox`flex-grow`, `flex-shrink` e `flex-basis`.

--- a/files/pt-br/glossary/forbidden_response_header_name/index.md
+++ b/files/pt-br/glossary/forbidden_response_header_name/index.md
@@ -8,6 +8,6 @@ Um _nome de cabeçalho de resposta proibido_ é um nome de [cabeçalho HTTP](/pt
 
 ## Especificações
 
-| Especificação                                                                                                        | Status                   | Comentário |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | ---------- |
+| Especificação                                                                            | Status             | Comentário |
+| ---------------------------------------------------------------------------------------- | ------------------ | ---------- |
 | {{SpecName('Fetch','#forbidden-response-header-name','forbidden-response-header-name')}} | {{Spec2('Fetch')}} |            |

--- a/files/pt-br/glossary/function/index.md
+++ b/files/pt-br/glossary/function/index.md
@@ -21,7 +21,7 @@ function () {};
 Uma **função nomeada** é uma função com o nome da função:
 
 ```js
-function foo() {};
+function foo() {}
 // or using the ECMAScript 2015 arrow notation
 const foo = () => {};
 ```
@@ -29,16 +29,16 @@ const foo = () => {};
 Uma **função interna** é uma função dentro de outra função (`square` nesse caso). Uma **função externa** é uma função contendo uma função (`addSquares` nesse caso):
 
 ```js
-function addSquares(a,b) {
-   function square(x) {
-      return x * x;
-   }
-   return square(a) + square(b);
-};
+function addSquares(a, b) {
+  function square(x) {
+    return x * x;
+  }
+  return square(a) + square(b);
+}
 //Using ECMAScript 2015 arrow notation
-const addSquares = (a,b) => {
-   const square = x => x*x;
-   return square(a) + square(b);
+const addSquares = (a, b) => {
+  const square = (x) => x * x;
+  return square(a) + square(b);
 };
 ```
 
@@ -46,15 +46,13 @@ Uma **função recursiva** é uma função que invoca a si mesma. Veja {{Glossar
 
 ```js
 function loop(x) {
-   if (x >= 10)
-      return;
-   loop(x + 1);
-};
+  if (x >= 10) return;
+  loop(x + 1);
+}
 //Using ECMAScript 2015 arrow notation
-const loop = x => {
-   if (x >= 10)
-      return;
-   loop(x + 1);
+const loop = (x) => {
+  if (x >= 10) return;
+  loop(x + 1);
 };
 ```
 
@@ -69,11 +67,11 @@ function foo() {
 */
 
 (function foo() {
-    console.log("Hello Foo");
-}());
+  console.log("Hello Foo");
+})();
 
 (function food() {
-    console.log("Hello Food");
+  console.log("Hello Food");
 })();
 ```
 

--- a/files/pt-br/glossary/graceful_degradation/index.md
+++ b/files/pt-br/glossary/graceful_degradation/index.md
@@ -16,6 +16,6 @@ original_slug: Glossario/degradação_graciosa
 3. [Implementing feature detection](/pt-BR/docs/Learn/Tools_and_testing/Cross_browser_testing/Feature_detection)
 4. [MDN Web Docs Glossary](/pt-BR/docs/Glossary)
 
-    1. {{Glossary("Graceful degradation")}}
-    2. {{Glossary("Polyfill")}}
-    3. {{Glossary("Progressive enhancement")}}
+   1. {{Glossary("Graceful degradation")}}
+   2. {{Glossary("Polyfill")}}
+   3. {{Glossary("Progressive enhancement")}}

--- a/files/pt-br/glossary/grid/index.md
+++ b/files/pt-br/glossary/grid/index.md
@@ -13,20 +13,22 @@ Se você colocar o conteúdo fora dessa grade explícita ou se estiver utilizand
 No exemplo abaixo, criamos uma _grade explícita_ de três colunas e duas linhas. A terceira linha da grade é uma _faixa implícita de linha da grade_, formada por serem mais do que os seis os itens que preenchem as faixas explícitas.
 
 ```css hidden
-* {box-sizing: border-box;}
+* {
+  box-sizing: border-box;
+}
 
 .wrapper {
-    border: 2px solid #f76707;
-    border-radius: 5px;
-    background-color: #fff4e6;
+  border: 2px solid #f76707;
+  border-radius: 5px;
+  background-color: #fff4e6;
 }
 
 .wrapper > div {
-    border: 2px solid #ffa94d;
-    border-radius: 5px;
-    background-color: #ffd8a8;
-    padding: 1em;
-    color: #d9480f;
+  border: 2px solid #ffa94d;
+  border-radius: 5px;
+  background-color: #ffd8a8;
+  padding: 1em;
+  color: #d9480f;
 }
 ```
 
@@ -40,24 +42,24 @@ No exemplo abaixo, criamos uma _grade explícita_ de três colunas e duas linhas
 
 ```html
 <div class="wrapper">
-<div> Um </div>
-    <div> dois </div>
-    <div> três </div>
-    <div> quatro </div>
-    <div> cinco </div>
-    <div> seis </div>
-    <div> sete </div>
-    <div> oito </div>
+  <div>Um</div>
+  <div>dois</div>
+  <div>três</div>
+  <div>quatro</div>
+  <div>cinco</div>
+  <div>seis</div>
+  <div>sete</div>
+  <div>oito</div>
 </div>
 ```
 
 {{ EmbedLiveSample('example', '500', '330') }}
 
 1. CSS Grid Layout Guide:
-    _[Basic concepts of grid layout](/pt-BR/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout)_
+   _[Basic concepts of grid layout](/pt-BR/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout)_
 2. Property reference
 
-    1. {{cssxref("grid-template-columns")}}
-    2. {{cssxref("grid-template-rows")}}
-    3. {{cssxref("grid")}}
-    4. {{cssxref("grid-template")}}
+   1. {{cssxref("grid-template-columns")}}
+   2. {{cssxref("grid-template-rows")}}
+   3. {{cssxref("grid")}}
+   4. {{cssxref("grid-template")}}

--- a/files/pt-br/glossary/grid_areas/index.md
+++ b/files/pt-br/glossary/grid_areas/index.md
@@ -13,27 +13,29 @@ Um **grid area** é um ou mais {{glossary("grid cell", "grid cells")}} que comp�
 No exemplo abaixo temos um grid contêiner com dois items de grid, nomeamos esses com a propriedade {{cssxref("grid-area")}} e em seguida colocamos eles no grid usando {{cssxref("grid-template-areas")}}. Isso cria duas áreas de grid, uma cobrindo 4 áreas do grid e a outra duas áreas do grid.
 
 ```css hidden
-* {box-sizing: border-box;}
+* {
+  box-sizing: border-box;
+}
 
 .wrapper {
-    border: 2px solid #f76707;
-    border-radius: 5px;
-    background-color: #fff4e6;
+  border: 2px solid #f76707;
+  border-radius: 5px;
+  background-color: #fff4e6;
 }
 
 .wrapper > div {
-    border: 2px solid #ffa94d;
-    border-radius: 5px;
-    background-color: #ffd8a8;
-    padding: 1em;
-    color: #d9480f;
+  border: 2px solid #ffa94d;
+  border-radius: 5px;
+  background-color: #ffd8a8;
+  padding: 1em;
+  color: #d9480f;
 }
 ```
 
 ```css
 .wrapper {
   display: grid;
-  grid-template-columns: repeat(3,1fr);
+  grid-template-columns: repeat(3, 1fr);
   grid-template-rows: 100px 100px;
   grid-template-areas:
     "a a b"
@@ -49,8 +51,8 @@ No exemplo abaixo temos um grid contêiner com dois items de grid, nomeamos esse
 
 ```html
 <div class="wrapper">
-   <div class="item1">Item</div>
-   <div class="item2">Item</div>
+  <div class="item1">Item</div>
+  <div class="item2">Item</div>
 </div>
 ```
 

--- a/files/pt-br/glossary/hoisting/index.md
+++ b/files/pt-br/glossary/hoisting/index.md
@@ -79,8 +79,8 @@ console.log(num1 + " " + num2); //'3 4'
 var num2; //Declara num2 para hoisting
 
 //Example 3 - Hoists
-a = 'Cran'; //Inicializa a
-b = 'berry'; //Inicializa b
+a = "Cran"; //Inicializa a
+b = "berry"; //Inicializa b
 console.log(a + "" + b); // 'Cranberry'
 var a, b; //Declara ambos a & b para hoisting
 ```

--- a/files/pt-br/glossary/http_header/index.md
+++ b/files/pt-br/glossary/http_header/index.md
@@ -47,20 +47,20 @@ X-Cache-Info: cached
 
 1. Especificações
 
-    1. Sintaxe dos [cabeçalhos](https://tools.ietf.org/html/rfc7230#section-3.2) na especificação HTTP.
+   1. Sintaxe dos [cabeçalhos](https://tools.ietf.org/html/rfc7230#section-3.2) na especificação HTTP.
 
 2. Referência Técnica
 
-    1. [Lista de todos os cabeçalhos HTTP](/pt-BR/docs/Web/HTTP/Headers)
+   1. [Lista de todos os cabeçalhos HTTP](/pt-BR/docs/Web/HTTP/Headers)
 
 3. [Glossário](/pt-BR/docs/Glossario)
 
-    1. {{Glossary("HTTP header")}}
-    2. {{Glossary("General header")}}
-    3. {{Glossary("Request header")}}
-    4. {{Glossary("Response header")}}
-    5. {{Glossary("Entity header")}}
-    6. {{Glossary("Forbidden header name")}}
-    7. {{Glossary("Forbidden response header name")}}
-    8. {{Glossary("CORS-safelisted request header")}}
-    9. {{Glossary("CORS-safelisted response header")}}
+   1. {{Glossary("HTTP header")}}
+   2. {{Glossary("General header")}}
+   3. {{Glossary("Request header")}}
+   4. {{Glossary("Response header")}}
+   5. {{Glossary("Entity header")}}
+   6. {{Glossary("Forbidden header name")}}
+   7. {{Glossary("Forbidden response header name")}}
+   8. {{Glossary("CORS-safelisted request header")}}
+   9. {{Glossary("CORS-safelisted response header")}}

--- a/files/pt-br/glossary/iife/index.md
+++ b/files/pt-br/glossary/iife/index.md
@@ -16,18 +16,18 @@ A função se torna uma expressão que é imediatamente executada. A variável d
 
 ```js
 (function () {
-    var nome = "Felipe";
+  var nome = "Felipe";
 })();
 // A variável nome não é acessível fora do escopo da expressão
-nome // gerará o erro "Uncaught ReferenceError: nome is not defined"
+nome; // gerará o erro "Uncaught ReferenceError: nome is not defined"
 ```
 
 Atribuir uma IIFE a uma variável não armazenará a função em si, mas o **resultado da função.**
 
 ```js
 var result = (function () {
-    var nome = "Felipe";
-    return nome;
+  var nome = "Felipe";
+  return nome;
 })();
 // Imediatamente gera a saída:
 result; // "Felipe"

--- a/files/pt-br/glossary/ipv4/index.md
+++ b/files/pt-br/glossary/ipv4/index.md
@@ -3,6 +3,7 @@ title: IPv4
 slug: Glossary/IPv4
 original_slug: Glossario/IPv4
 ---
+
 IPv4 é a quarta versão do {{Glossary("protocolo")}} de comunicação subjacente à {{glossary("Internet")}} e a primeira versão a ser amplamente implantada.
 
 Formalizada primeiramente em 1981, o IPv4 traça suas raízes para o trabalho de desenvolvimento inicial do ARPAnet. IPv4 é um protocolo sem conexão para ser usado na comutação de dados em redes da camada de enlace de dados (ethernet). {{glossary("IPv6")}} está gradualmente substituindo o IPv4 devido a problemas de segurança que o IPv4 possui e as limitações de seus campos de endereços. (Versão número 5 foi atribuído em 1979 para o experimental _Internet Stream Protocol_, que no entanto, nunca foi chamado de IPv5).

--- a/files/pt-br/glossary/number/index.md
+++ b/files/pt-br/glossary/number/index.md
@@ -10,7 +10,7 @@ No {{Glossary("JavaScript")}}, **Number** é um tipo de dado numérico no [doubl
 
 ### Conhecimento Geral
 
-- [Inteiro_(ciência_da_computação)](<https://pt.wikipedia.org/wiki/Inteiro_(ciência_da_computação)>) no Wikipédia
+- [Inteiro\_(ciência_da_computação)](<https://pt.wikipedia.org/wiki/Inteiro_(ciência_da_computação)>) no Wikipédia
 - [Bignum](https://pt.wikipedia.org/wiki/Bignum) no Wikipédia
 - [Ponto_flutuante](https://pt.wikipedia.org/wiki/Ponto_flutuante) no Wikipédia
 

--- a/files/pt-br/glossary/object/index.md
+++ b/files/pt-br/glossary/object/index.md
@@ -3,6 +3,7 @@ title: Objeto
 slug: Glossary/Object
 original_slug: Glossario/Objeto
 ---
+
 [Objeto](/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Object) refere-se a uma estrutura de dados contendo dados e instruções para se trabalhar com estes dados. Objetos algumas vezes se referem a coisas do mundo real, por exemplo um objeto de carro ou um mapa em um jogo de corrida. {{glossary("JavaScript")}}, Java, C++, Python, e Ruby são exemplos de Linguagens orientadas à objeto ({{glossary("OOP","object-oriented programming")}}).
 
 ## Aprenda mais

--- a/files/pt-br/glossary/origin/index.md
+++ b/files/pt-br/glossary/origin/index.md
@@ -23,8 +23,8 @@ Algumas operações são restritas para conteúdos de mesma origem, e essa restr
 
 ## Especificações
 
-| Especificação                                                    | Status                           | Comentário |
-| ---------------------------------------------------------------- | -------------------------------- | ---------- |
+| Especificação                                    | Status                   | Comentário |
+| ------------------------------------------------ | ------------------------ | ---------- |
 | {{SpecName('HTML WHATWG', '#origin', 'origin')}} | {{Spec2('HTML WHATWG')}} |            |
 
 ## Aprenda mais

--- a/files/pt-br/glossary/semantics/index.md
+++ b/files/pt-br/glossary/semantics/index.md
@@ -27,7 +27,9 @@ Por padrão, a maioria das [folhas de estilo do agente do usuário](/pt-BR/docs/
 Por outro lado, você pode fazer qualquer elemento parecer um cabeçalho de nível superior. Considere o seguinte:
 
 ```html
-<span style="font-size: 32px; margin: 21px 0;">Is this a top level heading?</span>
+<span style="font-size: 32px; margin: 21px 0;"
+  >Is this a top level heading?</span
+>
 ```
 
 Isso fará com que pareça um cabeçalho de nível superior, mas não tem valor semântico. Portanto, não obterá nenhum benefício extra, conforme descrito acima. Assim, é uma boa idéia usar o elemento HTML certo, para o trabalho certo.

--- a/files/pt-br/glossary/sgml/index.md
+++ b/files/pt-br/glossary/sgml/index.md
@@ -3,6 +3,7 @@ title: SGML
 slug: Glossary/SGML
 original_slug: Glossario/SGML
 ---
+
 O _Standard Generalized Markup Language_ (**SGML**) é uma {{Glossary("ISO")}} especificação que veio para definir as declarações/sintaxe Linguagens de Marcação.
 
 On the web, {{Glossary("HTML")}} 4, {{Glossary("XHTML")}}, and {{Glossary("XML")}} are popular SGML-based languages. It is worth noting that since its fifth edition, HTML is no longer SGML-based and has its own parsing rules.

--- a/files/pt-br/glossary/three_js/index.md
+++ b/files/pt-br/glossary/three_js/index.md
@@ -3,6 +3,7 @@ title: Three js
 slug: Glossary/Three_js
 original_slug: Glossario/Three_js
 ---
+
 three.js é um motor {{Glossary("WebGL")}} baseado em {{Glossary("JavaScript")}} que pode executar jogos movidos com GPU ou outros aplicativos gráficos diretamente do {{Glossary("navegador")}}. A biblioteca three.js fornece várias funções e {{Glossary("API","APIs")}} para desenhar cenas 3D em seu navegador.
 
 ## Saiba mais

--- a/files/pt-br/glossary/viewport/index.md
+++ b/files/pt-br/glossary/viewport/index.md
@@ -10,12 +10,12 @@ A porção da viewport que está visível no momento é chamada de **visual view
 
 1. Conhecimentos gerais
 
-    1. [Viewport](https://en.wikipedia.org/wiki/Viewport) na Wikipedia (em inglês)
-    2. [O que é viewport ?](https://pt.stackoverflow.com/questions/272210/o-que-%C3%A9-view-port) em Stackoverflow (em português)
-    3. [Como obter a largura e altura da viewport com Javascript](https://andylangton.co.uk/blog/development/get-viewportwindow-size-width-and-height-javascript) (em inglês)
-    4. [O conto de duas viewports](https://www.quirksmode.org/mobile/viewports.html) (Quirksmode - em inglês)
-    5. [VisualViewport API](/pt-BR/docs/Web/API/Visual_Viewport_API)
+   1. [Viewport](https://en.wikipedia.org/wiki/Viewport) na Wikipedia (em inglês)
+   2. [O que é viewport ?](https://pt.stackoverflow.com/questions/272210/o-que-%C3%A9-view-port) em Stackoverflow (em português)
+   3. [Como obter a largura e altura da viewport com Javascript](https://andylangton.co.uk/blog/development/get-viewportwindow-size-width-and-height-javascript) (em inglês)
+   4. [O conto de duas viewports](https://www.quirksmode.org/mobile/viewports.html) (Quirksmode - em inglês)
+   5. [VisualViewport API](/pt-BR/docs/Web/API/Visual_Viewport_API)
 
 2. [MDN Web Docs Glossary](/pt-BR/docs/Glossary)
 
-    1. {{Glossary("Visual Viewport")}}
+   1. {{Glossary("Visual Viewport")}}

--- a/files/pt-br/glossary/xhtml/index.md
+++ b/files/pt-br/glossary/xhtml/index.md
@@ -15,26 +15,24 @@ O exemplo mostra um documento HTML e um XHTML incluindo os cabeçalhos relevante
 ### Documento HTML
 
 ```html
-HTTP/1.1 200 OK
-Content-Type: text/html
+<!-- Content-Type: text/html -->
 
-<!DOCTYPE html>
-<html lang=en>
+<!doctype html>
+<html lang="en">
   <head>
-    <meta charset=utf-8>
+    <meta charset="utf-8" />
     <title>HTML</title>
   </head>
   <body>
-    <p>Eu sou um documento HTML
+    <p>Eu sou um documento HTML</p>
   </body>
 </html>
 ```
 
 ### Documento XHTML
 
-```
-HTTP/1.1 200 OK
-Content-Type: application/xhtml+xml
+```xml
+<!-- Content-Type: application/xhtml+xml -->
 
 <html xml:lang="en" xmlns="https://www.w3.org/1999/xhtml">
   <head>


### PR DESCRIPTION
This PR formats the `/glossary` folder of the Portuguese Brazilian locale using Prettier.
