### PR TITLE
ja: Remove .prettierignore for /related

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -61,7 +61,6 @@ build/
 /files/ja/mozilla/add-ons/**/*.md
 /files/ja/mozilla/add-ons/webextensions/api/**/*.md
 /files/ja/mozilla/firefox**/*.md
-/files/ja/related/**/*.md
 /files/ja/web/**/*.md
 /files/ja/web/api/**/*.md
 /files/ja/web/css/**/*.md


### PR DESCRIPTION
This PR removes the `.prettierignore` for the `/related` folder in the Japanese locale.  The single file in that folder already adheres to Prettier formatting.
