### PR TITLE
ja: Format /webassembly using Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -67,7 +67,6 @@ build/
 /files/ja/web/http/**/*.md
 /files/ja/web/javascript/**/*.md
 /files/ja/web/svg/**/*.md
-/files/ja/webassembly/**/*.md
 
 # ko
 /files/ko/games/**/*.md

--- a/files/ja/webassembly/c_to_wasm/index.md
+++ b/files/ja/webassembly/c_to_wasm/index.md
@@ -30,20 +30,20 @@ Emscripten SDK を取得します。以下の指示に従ってください。<h
 
 1. まずはコンパイルするためのサンプルコードを用意します。以下の C のサンプルコードをコピーして `hello.c` としてローカルドライブの新しいディレクトリーに保存してください。
 
-    ```cpp
-    #include <stdio.h>
+   ```cpp
+   #include <stdio.h>
 
-    int main() {
-        printf("Hello World\n");
-        return 0;
-    }
-    ```
+   int main() {
+       printf("Hello World\n");
+       return 0;
+   }
+   ```
 
 2. Emscripten コンパイラー環境を導入したターミナルウィンドウを使用して、`hello.c` ファイルと同じディレクトリーに移動し、次のコマンドを実行します。
 
-    ```bash
-    emcc hello.c -o hello.html
-    ```
+   ```bash
+   emcc hello.c -o hello.html
+   ```
 
 このコマンドで渡されたオプションは次のとおりです。
 
@@ -59,7 +59,7 @@ Emscripten SDK を取得します。以下の指示に従ってください。<h
 
 WebAssembly に対応しているブラウザーで `hello.html` を読み込むだけです。既定で有効なのは Firefox 52, Chrome 57, Opera 44 以降です。
 
-> **メモ:** 生成された HTML ファイル (`hello.html`) をローカルのハードドライブから直接開こうとすると（例: `file://your_path/hello.html`）、 _`both async and sync fetching of the wasm failed` という複数行のエラーメッセージが表示されます。 HTML ファイルを HTTP サーバー (`http://`) で実行する必要があります。詳しくは [ローカルのテストサーバーを設定するには](/ja/docs/Learn/Common_questions/set_up_a_local_testing_server) を参照してください。
+> **メモ:** 生成された HTML ファイル (`hello.html`) をローカルのハードドライブから直接開こうとすると（例: `file://your_path/hello.html`）、 \_`both async and sync fetching of the wasm failed` という複数行のエラーメッセージが表示されます。 HTML ファイルを HTTP サーバー (`http://`) で実行する必要があります。詳しくは [ローカルのテストサーバーを設定するには](/ja/docs/Learn/Common_questions/set_up_a_local_testing_server) を参照してください。
 
 全てが計画通りに機能していれば、ウェブページ上の Emscripten コンソールに "Hello world" の出力が表示されるはずです。おめでとうございます、ようやく C を WebAssembly にコンパイルしてブラウザーで実行することができました。
 ![image](helloworld.png)
@@ -70,27 +70,27 @@ WebAssembly に対応しているブラウザーで `hello.html` を読み込む
 
 1. まず、次の C のコードを `hello2.c` として新しいディレクトリーに保存します。
 
-    ```cpp
-    #include <stdio.h>
+   ```cpp
+   #include <stdio.h>
 
-    int main() {
-        printf("Hello World\n");
-        return 0;
-    }
-    ```
+   int main() {
+       printf("Hello World\n");
+       return 0;
+   }
+   ```
 
 2. `shell_minimal.html` を emsdk リポジトリーから探します。先ほど作成した新しいディレクトリーに `html_template` というサブディレクトリーを作って、そこにコピーします。
 3. 新しいディレクトリーに移動して（Emscripten コンパイラー環境があるターミナルウィンドウで）、次のコマンドを実行します。
 
-    ```bash
-    emcc -o hello2.html hello2.c -O3 --shell-file html_template/shell_minimal.html
-    ```
+   ```bash
+   emcc -o hello2.html hello2.c -O3 --shell-file html_template/shell_minimal.html
+   ```
 
-    今回渡したオプションは少しだけ異なります。
+   今回渡したオプションは少しだけ異なります。
 
-    - `-o hello2.html` と指定したことで、今回コンパイラーは JavaScript グルーコードと `.html` を出力します。
-    - `-O3` はコードを最適化するために使用されます。 Emcc には他の C コンパイラと同様に、最適化レベルとして `-O0`（最適化しない）、`-O1`、`-O2`、`-Os`、`-Oz`、`-Og`、`-O3` があります。 `-O3` は、リリースビルドに適した設定です。
-    - さらに `--shell-file html_template/shell_minimal.html` と指定しました — これは例を実行する HTML を生成するための、HTML テンプレートパスです。
+   - `-o hello2.html` と指定したことで、今回コンパイラーは JavaScript グルーコードと `.html` を出力します。
+   - `-O3` はコードを最適化するために使用されます。 Emcc には他の C コンパイラと同様に、最適化レベルとして `-O0`（最適化しない）、`-O1`、`-O2`、`-Os`、`-Oz`、`-Og`、`-O3` があります。 `-O3` は、リリースビルドに適した設定です。
+   - さらに `--shell-file html_template/shell_minimal.html` と指定しました — これは例を実行する HTML を生成するための、HTML テンプレートパスです。
 
 4. この例を実行してみましょう。上記のコマンドで hello2.html が生成されます。これは生成された wasm コードに対してロード、実行などを行うグルーコードを含むテンプレートと同じ内容を持ちます。ブラウザーを開いて最後の例と同じ出力であることを確認してください。
 
@@ -104,59 +104,57 @@ C で定義された関数があって、それを JavaScript から呼び出し
 
 1. はじめに、次のコードを `hello3.c` として新しいディレクトリーに保存します。
 
-    ```cpp
-    #include <stdio.h>
-    #include <emscripten/emscripten.h>
+   ```cpp
+   #include <stdio.h>
+   #include <emscripten/emscripten.h>
 
-    int main() {
-        printf("Hello World\n");
-    }
+   int main() {
+       printf("Hello World\n");
+   }
 
-    #ifdef __cplusplus
-    #define EXTERN extern "C"
-    #else
-    #define EXTERN
-    #endif
+   #ifdef __cplusplus
+   #define EXTERN extern "C"
+   #else
+   #define EXTERN
+   #endif
 
-    EXTERN EMSCRIPTEN_KEEPALIVE void myFunction(int argc, char ** argv) {
-        printf("MyFunction Called\n");
-    }
-    ```
+   EXTERN EMSCRIPTEN_KEEPALIVE void myFunction(int argc, char ** argv) {
+       printf("MyFunction Called\n");
+   }
+   ```
 
-    既定では、 Emscripten が生成したコードは常に `main()` を呼び出し、他のデッドコードは削除されます。関数名の前に `EMSCRIPTEN_KEEPALIVE` を置くことによって、これが起こらなくなります。また、`EMSCRIPTEN_KEEPALIVE` を使用するために `emscripten.h` をインポートする必要があります。
+   既定では、 Emscripten が生成したコードは常に `main()` を呼び出し、他のデッドコードは削除されます。関数名の前に `EMSCRIPTEN_KEEPALIVE` を置くことによって、これが起こらなくなります。また、`EMSCRIPTEN_KEEPALIVE` を使用するために `emscripten.h` をインポートする必要があります。
 
-    > **メモ:** `#ifdef` ブロックを加えたことによって、C++ のコードからこの例をインクルードしようとしても動作するでしょう。 C と C++ の間でのマングリング規則によって、他の場合では壊れることもありますが、ここでは C++ を使用している場合に、外部の C の関数として扱うように設定しています。
+   > **メモ:** `#ifdef` ブロックを加えたことによって、C++ のコードからこの例をインクルードしようとしても動作するでしょう。 C と C++ の間でのマングリング規則によって、他の場合では壊れることもありますが、ここでは C++ を使用している場合に、外部の C の関数として扱うように設定しています。
 
 2. 便宜上、この新しいディレクトリーに `html_template/shell_minimal.html` （もちろん、このファイルはあなたの実際の開発環境に置きます）を加えます。
 3. さて、再びコンパイル手順を実行しましょう。あなたの最新のディレクトリーの中（そして、Emscripten コンパイラー環境の入っているターミナルウィンドウ）で、このように C のコードをコンパイルします（NO_EXIT_RUNTIME オプションを付与してコンパイルする必要があることに注意してください。そうしない場合、 main() 関数が終了したときにランタイムもシャットダウンされてしまい、コンパイルされたコードが正しく呼ばれなくなる可能性があります - 例えば、atexit の呼び出しなどの適切な C のエミュレーションに必要です）
 
-    ```bash
-    emcc -o hello3.html hello3.c -O3 --shell-file html_template/shell_minimal.html -s NO_EXIT_RUNTIME=1 -s "EXPORTED_RUNTIME_METHODS=['ccall']"
-    ```
+   ```bash
+   emcc -o hello3.html hello3.c -O3 --shell-file html_template/shell_minimal.html -s NO_EXIT_RUNTIME=1 -s "EXPORTED_RUNTIME_METHODS=['ccall']"
+   ```
 
 4. 例をブラウザーで読み込んだら、前と同じものが見られるでしょう。
 5. JavaScript から新しい `myFunction()` 関数を呼び出す必要があります。まずは、 hello3.html ファイルをテキストエディターで開いてください。
 6. 以下のような {{HTMLElement("button")}} を最初の `<script type='text/javascript'>` タグの上に加えましょう。
 
-    ```html
-    <button id="mybutton">Run myFunction</button>
-    ```
+   ```html
+   <button id="mybutton">Run myFunction</button>
+   ```
 
 7. そして、 {{HTMLElement("script")}} 要素内の最後に次のコードを追加します。
 
-    ```js
-    document
-      .getElementById("mybutton")
-      .addEventListener("click", () => {
-        alert("check console");
-        const result = Module.ccall(
-          "myFunction",  // name of C function
-          null,  // return type
-          null,  // argument types
-          null,  // arguments
-        );
-      });
-    ```
+   ```js
+   document.getElementById("mybutton").addEventListener("click", () => {
+     alert("check console");
+     const result = Module.ccall(
+       "myFunction", // name of C function
+       null, // return type
+       null, // argument types
+       null, // arguments
+     );
+   });
+   ```
 
 これはエクスポートされた関数をどのようにして `ccall()` を使用して呼び出すかを示しています。
 

--- a/files/ja/webassembly/existing_c_to_wasm/index.md
+++ b/files/ja/webassembly/existing_c_to_wasm/index.md
@@ -47,7 +47,7 @@ $ emcc -O3 -s WASM=1 -s EXTRA_EXPORTED_RUNTIME_METHODS='["cwrap"]' \
 <script>
   Module.onRuntimeInitialized = async () => {
     const api = {
-      version: Module.cwrap('version', 'number', []),
+      version: Module.cwrap("version", "number", []),
     };
     console.log(api.version());
   };
@@ -67,16 +67,16 @@ $ emcc -O3 -s WASM=1 -s EXTRA_EXPORTED_RUNTIME_METHODS='["cwrap"]' \
 最初に答えなければならない質問は、どうやって画像を wasm に入れるのかということです。libwebp の [Encoding API](https://developers.google.com/speed/webp/docs/api#simple_encoding_api) を見ると、RGB、RGBA、BGR、BGRA のバイト列を期待していることがわかります。幸いにも Canvas API には {{domxref("CanvasRenderingContext2D.getImageData")}} があり、RGBA の画像データを含む {{jsxref("Uint8ClampedArray")}}が得られます。
 
 ```js
- async function loadImage(src) {
+async function loadImage(src) {
   // Load image
   const imgBlob = await fetch(src).then((resp) => resp.blob());
   const img = await createImageBitmap(imgBlob);
   // Make canvas same size as image
-  const canvas = document.createElement('canvas');
+  const canvas = document.createElement("canvas");
   canvas.width = img.width;
   canvas.height = img.height;
   // Draw image onto canvas
-  const ctx = canvas.getContext('2d');
+  const ctx = canvas.getContext("2d");
   ctx.drawImage(img, 0, 0);
   return ctx.getImageData(0, 0, img.width, img.height);
 }
@@ -102,16 +102,16 @@ void destroy_buffer(uint8_t* p) {
 
 ```js
 const api = {
-  version: Module.cwrap('version', 'number', []),
-  create_buffer: Module.cwrap('create_buffer', 'number', ['number', 'number']),
-  destroy_buffer: Module.cwrap('destroy_buffer', '', ['number']),
-  encode: Module.cwrap("encode", "", ["number","number","number","number",]),
+  version: Module.cwrap("version", "number", []),
+  create_buffer: Module.cwrap("create_buffer", "number", ["number", "number"]),
+  destroy_buffer: Module.cwrap("destroy_buffer", "", ["number"]),
+  encode: Module.cwrap("encode", "", ["number", "number", "number", "number"]),
   free_result: Module.cwrap("free_result", "", ["number"]),
   get_result_pointer: Module.cwrap("get_result_pointer", "number", []),
   get_result_size: Module.cwrap("get_result_size", "number", []),
 };
 
-const image = await loadImage('./image.jpg');
+const image = await loadImage("./image.jpg");
 const p = api.create_buffer(image.width, image.height);
 Module.HEAP8.set(image.data, p);
 // ... call encoder ...
@@ -159,7 +159,11 @@ int get_result_size() {
 api.encode(p, image.width, image.height, 100);
 const resultPointer = api.get_result_pointer();
 const resultSize = api.get_result_size();
-const resultView = new Uint8Array(Module.HEAP8.buffer, resultPointer, resultSize);
+const resultView = new Uint8Array(
+  Module.HEAP8.buffer,
+  resultPointer,
+  resultSize,
+);
 const result = new Uint8Array(resultView);
 api.free_result(resultPointer);
 ```
@@ -175,11 +179,11 @@ api.free_result(resultPointer);
 これで完了です。 WebP エンコーダーをコンパイルし、 JPEG 画像を WebP にトランスコードしました。うまくいったことを証明するために、結果のバッファーを blob にして`<img>`要素で使用してください。
 
 ```js
-const blob = new Blob([result], {type: 'image/webp'});
+const blob = new Blob([result], { type: "image/webp" });
 const blobURL = URL.createObjectURL(blob);
-const img = document.createElement('img');
+const img = document.createElement("img");
 img.src = blobURL;
-document.body.appendChild(img)
+document.body.appendChild(img);
 ```
 
 見よ、新しい WebP 画像の栄光を。

--- a/files/ja/webassembly/exported_functions/index.md
+++ b/files/ja/webassembly/exported_functions/index.md
@@ -27,16 +27,15 @@ i10n:
 ```js
 const otherTable = new WebAssembly.Table({ element: "anyfunc", initial: 2 });
 
-WebAssembly.instantiateStreaming(fetch('table.wasm'))
-  .then((obj) => {
-    const tbl = obj.instance.exports.tbl;
-    console.log(tbl.get(0)());  // 13
-    console.log(tbl.get(1)());  // 42
-    otherTable.set(0,tbl.get(0));
-    otherTable.set(1,tbl.get(1));
-    console.log(otherTable.get(0)());
-    console.log(otherTable.get(1)());
-  });
+WebAssembly.instantiateStreaming(fetch("table.wasm")).then((obj) => {
+  const tbl = obj.instance.exports.tbl;
+  console.log(tbl.get(0)()); // 13
+  console.log(tbl.get(1)()); // 42
+  otherTable.set(0, tbl.get(0));
+  otherTable.set(1, tbl.get(1));
+  console.log(otherTable.get(0)());
+  console.log(otherTable.get(1)());
+});
 ```
 
 ここでは、{{jsxref("WebAssembly.Table")}} コンストラクターを使用して JavaScript からテーブル(`otherTable`)を作成し、 table.wasm をページに読み込むために {{jsxref("WebAssembly.instantiateStreaming()")}} ユーティリティ関数を使用しています。

--- a/files/ja/webassembly/javascript_interface/compile/index.md
+++ b/files/ja/webassembly/javascript_interface/compile/index.md
@@ -11,7 +11,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/compile
 ## 構文
 
 ```js
-WebAssembly.compile(bufferSource)
+WebAssembly.compile(bufferSource);
 ```
 
 ### 引数
@@ -37,13 +37,10 @@ WebAssembly.compile(bufferSource)
 ```js
 var worker = new Worker("wasm_worker.js");
 
-fetch('simple.wasm').then(response =>
-  response.arrayBuffer()
-).then(bytes =>
-  WebAssembly.compile(bytes)
-).then(mod =>
-  worker.postMessage(mod)
-);
+fetch("simple.wasm")
+  .then((response) => response.arrayBuffer())
+  .then((bytes) => WebAssembly.compile(bytes))
+  .then((mod) => worker.postMessage(mod));
 ```
 
 > **メモ:** おそらく多くの場合は {{jsxref("WebAssembly.compileStreaming()")}} を使用したほうが `compile()` よりも効率的なのでそちらの方がいいでしょう。

--- a/files/ja/webassembly/javascript_interface/compileerror/compileerror/index.md
+++ b/files/ja/webassembly/javascript_interface/compileerror/compileerror/index.md
@@ -11,10 +11,10 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError/
 ## 構文
 
 ```js
-new WebAssembly.CompileError()
-new WebAssembly.CompileError(message)
-new WebAssembly.CompileError(message, fileName)
-new WebAssembly.CompileError(message, fileName, lineNumber)
+new WebAssembly.CompileError();
+new WebAssembly.CompileError(message);
+new WebAssembly.CompileError(message, fileName);
+new WebAssembly.CompileError(message, fileName, lineNumber);
 ```
 
 ### 引数
@@ -34,15 +34,15 @@ new WebAssembly.CompileError(message, fileName, lineNumber)
 
 ```js
 try {
-  throw new WebAssembly.CompileError('Hello', 'someFile', 10);
+  throw new WebAssembly.CompileError("Hello", "someFile", 10);
 } catch (e) {
   console.log(e instanceof CompileError); // true
-  console.log(e.message);                 // "Hello"
-  console.log(e.name);                    // "CompileError"
-  console.log(e.fileName);                // "someFile"
-  console.log(e.lineNumber);              // 10
-  console.log(e.columnNumber);            // 0
-  console.log(e.stack);                   // コードの実行されていた位置を返す
+  console.log(e.message); // "Hello"
+  console.log(e.name); // "CompileError"
+  console.log(e.fileName); // "someFile"
+  console.log(e.lineNumber); // 10
+  console.log(e.columnNumber); // 0
+  console.log(e.stack); // コードの実行されていた位置を返す
 }
 ```
 

--- a/files/ja/webassembly/javascript_interface/compileerror/index.md
+++ b/files/ja/webassembly/javascript_interface/compileerror/index.md
@@ -43,15 +43,15 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError
 
 ```js
 try {
-  throw new WebAssembly.CompileError('Hello', 'someFile', 10);
+  throw new WebAssembly.CompileError("Hello", "someFile", 10);
 } catch (e) {
   console.log(e instanceof CompileError); // true
-  console.log(e.message);                 // "Hello"
-  console.log(e.name);                    // "CompileError"
-  console.log(e.fileName);                // "someFile"
-  console.log(e.lineNumber);              // 10
-  console.log(e.columnNumber);            // 0
-  console.log(e.stack);                   // コードが実行されていた位置を返す
+  console.log(e.message); // "Hello"
+  console.log(e.name); // "CompileError"
+  console.log(e.fileName); // "someFile"
+  console.log(e.lineNumber); // 10
+  console.log(e.columnNumber); // 0
+  console.log(e.stack); // コードが実行されていた位置を返す
 }
 ```
 

--- a/files/ja/webassembly/javascript_interface/compilestreaming/index.md
+++ b/files/ja/webassembly/javascript_interface/compilestreaming/index.md
@@ -39,7 +39,7 @@ WebAssembly.compileStreaming(source)
 
 ### ストリーミングのコンパイル
 
-次の例 (Github上のデモ [compile-streaming.html](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/compile-streaming.html) と、[動作例](https://mdn.github.io/webassembly-examples/js-api-examples/compile-streaming.html)を参照してください) では、ソースから直接 .wasm モジュールをストリームして、 [`WebAssembly.Module`](/ja/docs/WebAssembly/JavaScript_interface/Module) オブジェクトにコンパイルしています。`compileStreaming()`  関数は [`Response`](/ja/docs/Web/API/Response) オブジェクトを渡すプロミスを受け取るので、直接 [`fetch()`](/ja/docs/Web/API/fetch) の呼び出し結果を渡すことができます。
+次の例 (Github上のデモ [compile-streaming.html](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/compile-streaming.html) と、[動作例](https://mdn.github.io/webassembly-examples/js-api-examples/compile-streaming.html)を参照してください) では、ソースから直接 .wasm モジュールをストリームして、 [`WebAssembly.Module`](/ja/docs/WebAssembly/JavaScript_interface/Module) オブジェクトにコンパイルしています。`compileStreaming()` 関数は [`Response`](/ja/docs/Web/API/Response) オブジェクトを渡すプロミスを受け取るので、直接 [`fetch()`](/ja/docs/Web/API/fetch) の呼び出し結果を渡すことができます。
 
 ```js
 const importObject = { imports: { imported_func: (arg) => console.log(arg) } };

--- a/files/ja/webassembly/javascript_interface/global/global/index.md
+++ b/files/ja/webassembly/javascript_interface/global/global/index.md
@@ -11,7 +11,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Global/Global
 ## 構文
 
 ```js
-new WebAssembly.Global(descriptor, value)
+new WebAssembly.Global(descriptor, value);
 ```
 
 ### 引数
@@ -36,28 +36,36 @@ new WebAssembly.Global(descriptor, value)
 その後、グローバルの値は、まず `Global.value` プロパティを使用して `42` に変更され、次に `global.wasm` モジュールからエクスポートされた `incGlobal()` 関数を使用して 43 に変更されます (これは、与えられた値に 1 を追加してから新しい値を返します)。
 
 ```js
-const output = document.getElementById('output');
+const output = document.getElementById("output");
 
 function assertEq(msg, got, expected) {
   output.innerHTML += `Testing ${msg}: `;
   if (got !== expected)
     output.innerHTML += `FAIL!<br>Got: ${got}<br>Expected: ${expected}<br>`;
-  else
-    output.innerHTML += `SUCCESS! Got: ${got}<br>`;
+  else output.innerHTML += `SUCCESS! Got: ${got}<br>`;
 }
 
 assertEq("WebAssembly.Global exists", typeof WebAssembly.Global, "function");
 
-const global = new WebAssembly.Global({value:'i32', mutable:true}, 0);
+const global = new WebAssembly.Global({ value: "i32", mutable: true }, 0);
 
-WebAssembly.instantiateStreaming(fetch('global.wasm'), { js: { global } })
-.then(({instance}) => {
-    assertEq("getting initial value from wasm", instance.exports.getGlobal(), 0);
+WebAssembly.instantiateStreaming(fetch("global.wasm"), { js: { global } }).then(
+  ({ instance }) => {
+    assertEq(
+      "getting initial value from wasm",
+      instance.exports.getGlobal(),
+      0,
+    );
     global.value = 42;
-    assertEq("getting JS-updated value from wasm", instance.exports.getGlobal(), 42);
+    assertEq(
+      "getting JS-updated value from wasm",
+      instance.exports.getGlobal(),
+      42,
+    );
     instance.exports.incGlobal();
     assertEq("getting wasm-updated value from JS", global.value, 43);
-});
+  },
+);
 ```
 
 > **メモ:** この例は[GitHub 上の実行例](https://mdn.github.io/webassembly-examples/js-api-examples/global.html)で確認できます。また、[ソースコード](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/global.html)も参照してください。

--- a/files/ja/webassembly/javascript_interface/global/index.md
+++ b/files/ja/webassembly/javascript_interface/global/index.md
@@ -40,28 +40,36 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Global
 その後この値は、`Global.value` プロパティを使うことによって `42` に、`global.wasm` モジュールから公開された (どんな値が与えられても 1 を加算して、新しい値を返す) `incGlobal()` 関数を使うことによって `43` になります。
 
 ```js
-const output = document.getElementById('output');
+const output = document.getElementById("output");
 
 function assertEq(msg, got, expected) {
   output.innerHTML += `Testing ${msg}: `;
   if (got !== expected)
     output.innerHTML += `FAIL!<br>Got: ${got}<br>Expected: ${expected}<br>`;
-  else
-    output.innerHTML += `SUCCESS! Got: ${got}<br>`;
+  else output.innerHTML += `SUCCESS! Got: ${got}<br>`;
 }
 
 assertEq("WebAssembly.Global exists", typeof WebAssembly.Global, "function");
 
-const global = new WebAssembly.Global({value:'i32', mutable:true}, 0);
+const global = new WebAssembly.Global({ value: "i32", mutable: true }, 0);
 
-WebAssembly.instantiateStreaming(fetch('global.wasm'), { js: { global } })
-.then(({instance}) => {
-    assertEq("getting initial value from wasm", instance.exports.getGlobal(), 0);
+WebAssembly.instantiateStreaming(fetch("global.wasm"), { js: { global } }).then(
+  ({ instance }) => {
+    assertEq(
+      "getting initial value from wasm",
+      instance.exports.getGlobal(),
+      0,
+    );
     global.value = 42;
-    assertEq("getting JS-updated value from wasm", instance.exports.getGlobal(), 42);
+    assertEq(
+      "getting JS-updated value from wasm",
+      instance.exports.getGlobal(),
+      42,
+    );
     instance.exports.incGlobal();
     assertEq("getting wasm-updated value from JS", global.value, 43);
-});
+  },
+);
 ```
 
 > **メモ:** この例は[GitHub 上の実行例](https://mdn.github.io/webassembly-examples/js-api-examples/global.html)で確認できます。また、[ソースコード](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/global.html)も参照してください。

--- a/files/ja/webassembly/javascript_interface/index.md
+++ b/files/ja/webassembly/javascript_interface/index.md
@@ -57,10 +57,11 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly
 次の例 (GitHub 上の [instantiate-streaming.html](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/instantiate-streaming.html) のデモと、[動作例](https://mdn.github.io/webassembly-examples/js-api-examples/instantiate-streaming.html)も参照) は、基礎となるソースから .wasm モジュールを直接ストリーミングし、コンパイルしてインスタンス化し、 `ResultObject` で履行されるプロミスを返します。 `instantiateStreaming()` 関数は [`Response`](/ja/docs/Web/API/Response) オブジェクトのプロミスを受け付けるので、 [`fetch()`](/ja/docs/Web/API/fetch) の呼び出し結果を直接渡すと、履行されたときにレスポンスを関数に渡すことができます。
 
 ```js
-var importObject = { imports: { imported_func: arg => console.log(arg) } };
+var importObject = { imports: { imported_func: (arg) => console.log(arg) } };
 
-WebAssembly.instantiateStreaming(fetch('simple.wasm'), importObject)
-.then(obj => obj.instance.exports.exported_func());
+WebAssembly.instantiateStreaming(fetch("simple.wasm"), importObject).then(
+  (obj) => obj.instance.exports.exported_func(),
+);
 ```
 
 それから `ResultObject` の instance メンバーにアクセスすると、呼び出し対象のエクスポートされた関数が入っています。

--- a/files/ja/webassembly/javascript_interface/instance/exports/index.md
+++ b/files/ja/webassembly/javascript_interface/instance/exports/index.md
@@ -9,7 +9,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/expo
 **`exports`** は {{jsxref("WebAssembly.Instance")}} オブジェクトプロトタイプの読み取り専用プロパティで、 WebAssembly モジュールインスタンスからエクスポートされたすべての関数をメンバ－として持つオブジェクトを返します。これらは、 JavaScript からアクセスして使用することができます。
 
 ```js
-instance.exports
+instance.exports;
 ```
 
 ## 例
@@ -21,17 +21,19 @@ fetch を使用して WebAssembly バイトコードを読み取った後、 {{j
 ```js
 var importObject = {
   imports: {
-    imported_func: function(arg) {
+    imported_func: function (arg) {
       console.log(arg);
-    }
-  }
+    },
+  },
 };
 
-WebAssembly.instantiateStreaming(fetch('simple.wasm'), importObject)
-.then(obj => obj.instance.exports.exported_func());
+WebAssembly.instantiateStreaming(fetch("simple.wasm"), importObject).then(
+  (obj) => obj.instance.exports.exported_func(),
+);
 ```
 
 > **メモ:** この例は GitHub 上の [instantiate-streaming.html](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/instantiate-streaming.html) ([実行例](https://mdn.github.io/webassembly-examples/js-api-examples/instantiate-streaming.html)) で見ることができます。</p>
+
 </div>
 
 ## 仕様書

--- a/files/ja/webassembly/javascript_interface/instance/index.md
+++ b/files/ja/webassembly/javascript_interface/instance/index.md
@@ -27,19 +27,19 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance
 ```js
 const importObject = {
   imports: {
-    imported_func: function(arg) {
+    imported_func: function (arg) {
       console.log(arg);
-    }
-  }
+    },
+  },
 };
 
-fetch('simple.wasm').then(response =>
-  response.arrayBuffer()
-).then(bytes => {
-  let mod = new WebAssembly.Module(bytes);
-  let instance = new WebAssembly.Instance(mod, importObject);
-  instance.exports.exported_func();
-})
+fetch("simple.wasm")
+  .then((response) => response.arrayBuffer())
+  .then((bytes) => {
+    let mod = new WebAssembly.Module(bytes);
+    let instance = new WebAssembly.Instance(mod, importObject);
+    instance.exports.exported_func();
+  });
 ```
 
 `Instance` を取得するには非同期で行うことを推奨します。例えば、 {{jsxref("WebAssembly.instantiateStreaming()")}} 関数を使って次のようにします。
@@ -47,14 +47,15 @@ fetch('simple.wasm').then(response =>
 ```js
 const importObject = {
   imports: {
-    imported_func: function(arg) {
+    imported_func: function (arg) {
       console.log(arg);
-    }
-  }
+    },
+  },
 };
 
-WebAssembly.instantiateStreaming(fetch('simple.wasm'), importObject)
-.then(obj => obj.instance.exports.exported_func());
+WebAssembly.instantiateStreaming(fetch("simple.wasm"), importObject).then(
+  (obj) => obj.instance.exports.exported_func(),
+);
 ```
 
 また、これは `exports` プロパティを使ってエクスポートされた関数にアクセスする方法も紹介しています。

--- a/files/ja/webassembly/javascript_interface/instance/instance/index.md
+++ b/files/ja/webassembly/javascript_interface/instance/instance/index.md
@@ -13,7 +13,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/Inst
 > **警告:** 巨大なモジュールのインスタンス化は高コストになる可能性があるので、開発者が同期的な `Instance()` コンストラクターを使用するのは、絶対に必要な場合のみにするべきです。それ以外の場合はすべて、{{jsxref("WebAssembly.instantiateStreaming()")}} メソッドを使用してください。
 
 ```js
-new WebAssembly.Instance(module, importObject)
+new WebAssembly.Instance(module, importObject);
 ```
 
 ### 引数
@@ -32,19 +32,19 @@ new WebAssembly.Instance(module, importObject)
 ```js
 const importObject = {
   imports: {
-    imported_func: function(arg) {
+    imported_func: function (arg) {
       console.log(arg);
-    }
-  }
+    },
+  },
 };
 
-fetch('simple.wasm').then(response =>
-  response.arrayBuffer()
-).then(bytes => {
-  let mod = new WebAssembly.Module(bytes);
-  let instance = new WebAssembly.Instance(mod, importObject);
-  instance.exports.exported_func();
-})
+fetch("simple.wasm")
+  .then((response) => response.arrayBuffer())
+  .then((bytes) => {
+    let mod = new WebAssembly.Module(bytes);
+    let instance = new WebAssembly.Instance(mod, importObject);
+    instance.exports.exported_func();
+  });
 ```
 
 ただし、`Instance` を取得する方法としては、次のように、非同期の {{jsxref("WebAssembly.instantiateStreaming()")}} 関数を使用することをお勧めします。
@@ -52,14 +52,15 @@ fetch('simple.wasm').then(response =>
 ```js
 const importObject = {
   imports: {
-    imported_func: function(arg) {
+    imported_func: function (arg) {
       console.log(arg);
-    }
-  }
+    },
+  },
 };
 
-WebAssembly.instantiateStreaming(fetch('simple.wasm'), importObject)
-.then(obj => obj.instance.exports.exported_func());
+WebAssembly.instantiateStreaming(fetch("simple.wasm"), importObject).then(
+  (obj) => obj.instance.exports.exported_func(),
+);
 ```
 
 ## 仕様書

--- a/files/ja/webassembly/javascript_interface/instantiate/index.md
+++ b/files/ja/webassembly/javascript_interface/instantiate/index.md
@@ -73,19 +73,16 @@ fetch を使用して WebAssembly バイトコードを読み込んだ後、 {{j
 ```js
 var importObject = {
   imports: {
-    imported_func: function(arg) {
+    imported_func: function (arg) {
       console.log(arg);
-    }
-  }
+    },
+  },
 };
 
-fetch('simple.wasm').then(response =>
-  response.arrayBuffer()
-).then(bytes =>
-  WebAssembly.instantiate(bytes, importObject)
-).then(result =>
-  result.instance.exports.exported_func()
-);
+fetch("simple.wasm")
+  .then((response) => response.arrayBuffer())
+  .then((bytes) => WebAssembly.instantiate(bytes, importObject))
+  .then((result) => result.instance.exports.exported_func());
 ```
 
 > **メモ:** この例は Github 上の [index.html](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/index.html) でも見ることができます ([動作例](https://mdn.github.io/webassembly-examples/js-api-examples/))。
@@ -97,9 +94,8 @@ fetch('simple.wasm').then(response =>
 ```js
 var worker = new Worker("wasm_worker.js");
 
-WebAssembly.compileStreaming(fetch('simple.wasm'))
-.then(mod =>
-  worker.postMessage(mod)
+WebAssembly.compileStreaming(fetch("simple.wasm")).then((mod) =>
+  worker.postMessage(mod),
 );
 ```
 
@@ -108,17 +104,17 @@ WebAssembly.compileStreaming(fetch('simple.wasm'))
 ```js
 var importObject = {
   imports: {
-    imported_func: function(arg) {
+    imported_func: function (arg) {
       console.log(arg);
-    }
-  }
+    },
+  },
 };
 
-onmessage = function(e) {
-  console.log('module received from main thread');
+onmessage = function (e) {
+  console.log("module received from main thread");
   var mod = e.data;
 
-  WebAssembly.instantiate(mod, importObject).then(function(instance) {
+  WebAssembly.instantiate(mod, importObject).then(function (instance) {
     instance.exports.exported_func();
   });
 };

--- a/files/ja/webassembly/javascript_interface/instantiatestreaming/index.md
+++ b/files/ja/webassembly/javascript_interface/instantiatestreaming/index.md
@@ -48,7 +48,7 @@ WebAssembly.instantiateStreaming(source, importObject)
 const importObject = { imports: { imported_func: (arg) => console.log(arg) } };
 
 WebAssembly.instantiateStreaming(fetch("simple.wasm"), importObject).then(
-  (obj) => obj.instance.exports.exported_func()
+  (obj) => obj.instance.exports.exported_func(),
 );
 ```
 

--- a/files/ja/webassembly/javascript_interface/linkerror/index.md
+++ b/files/ja/webassembly/javascript_interface/linkerror/index.md
@@ -43,15 +43,15 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/LinkError
 
 ```js
 try {
-  throw new WebAssembly.LinkError('Hello', 'someFile', 10);
+  throw new WebAssembly.LinkError("Hello", "someFile", 10);
 } catch (e) {
   console.log(e instanceof LinkError); // true
-  console.log(e.message);                 // "Hello"
-  console.log(e.name);                    // "LinkError"
-  console.log(e.fileName);                // "someFile"
-  console.log(e.lineNumber);              // 10
-  console.log(e.columnNumber);            // 0
-  console.log(e.stack);                   // コードが実行されていた位置を返す
+  console.log(e.message); // "Hello"
+  console.log(e.name); // "LinkError"
+  console.log(e.fileName); // "someFile"
+  console.log(e.lineNumber); // 10
+  console.log(e.columnNumber); // 0
+  console.log(e.stack); // コードが実行されていた位置を返す
 }
 ```
 

--- a/files/ja/webassembly/javascript_interface/linkerror/linkerror/index.md
+++ b/files/ja/webassembly/javascript_interface/linkerror/linkerror/index.md
@@ -11,10 +11,10 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/LinkError/Lin
 ## 構文
 
 ```js
-new WebAssembly.LinkError()
-new WebAssembly.LinkError(message)
-new WebAssembly.LinkError(message, fileName)
-new WebAssembly.LinkError(message, fileName, lineNumber)
+new WebAssembly.LinkError();
+new WebAssembly.LinkError(message);
+new WebAssembly.LinkError(message, fileName);
+new WebAssembly.LinkError(message, fileName, lineNumber);
 ```
 
 ### 引数
@@ -34,15 +34,15 @@ new WebAssembly.LinkError(message, fileName, lineNumber)
 
 ```js
 try {
-  throw new WebAssembly.LinkError('Hello', 'someFile', 10);
+  throw new WebAssembly.LinkError("Hello", "someFile", 10);
 } catch (e) {
   console.log(e instanceof WebAssembly.LinkError); // true
-  console.log(e.message);                             // "Hello"
-  console.log(e.name);                                // "LinkError"
-  console.log(e.fileName);                            // "someFile"
-  console.log(e.lineNumber);                          // 10
-  console.log(e.columnNumber);                        // 0
-  console.log(e.stack);                               // コードの実行されていた位置を返す
+  console.log(e.message); // "Hello"
+  console.log(e.name); // "LinkError"
+  console.log(e.fileName); // "someFile"
+  console.log(e.lineNumber); // 10
+  console.log(e.columnNumber); // 0
+  console.log(e.stack); // コードの実行されていた位置を返す
 }
 ```
 

--- a/files/ja/webassembly/javascript_interface/memory/buffer/index.md
+++ b/files/ja/webassembly/javascript_interface/memory/buffer/index.md
@@ -15,8 +15,9 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/buffer
 次の例 (GitHub 上の [memory.html](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/memory.html) および[動作例](https://mdn.github.io/webassembly-examples/js-api-examples/memory.html)も参照) では、 memory.wasm バイトコードを {{jsxref("WebAssembly.instantiateStreaming()")}} メソッドを使用して読み込みんでインスタンス化し、その上の行で生成されたメモリーにインポートします。それから、メモリーにいくつかの値を格納し、関数をエクスポートして使用し、いくつかの値を合計します。
 
 ```js
-WebAssembly.instantiateStreaming(fetch('memory.wasm'), { js: { mem: memory } })
-.then(obj => {
+WebAssembly.instantiateStreaming(fetch("memory.wasm"), {
+  js: { mem: memory },
+}).then((obj) => {
   var i32 = new Uint32Array(memory.buffer);
   for (var i = 0; i < 10; i++) {
     i32[i] = i;

--- a/files/ja/webassembly/javascript_interface/memory/grow/index.md
+++ b/files/ja/webassembly/javascript_interface/memory/grow/index.md
@@ -11,7 +11,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/grow
 ## 構文
 
 ```js
-grow(number)
+grow(number);
 ```
 
 ## 引数
@@ -30,16 +30,16 @@ grow(number)
 以下の例では、新しい WebAssembly メモリーインスタンスを初期サイズ 1 ページ (64KiB)、最大サイズ 10 ページ (640KiB) で作成します。
 
 ```js
-var memory = new WebAssembly.Memory({initial:1, maximum:10});
+var memory = new WebAssembly.Memory({ initial: 1, maximum: 10 });
 ```
 
 それから、インスタンスを 1 ページ分拡張することができます。
 
 ```js
 const bytesPerPage = 64 * 1024;
-console.log(memory.buffer.byteLength / bytesPerPage);  // "1"
-console.log(memory.grow(1));                           // "1"
-console.log(memory.buffer.byteLength / bytesPerPage);  // "2"
+console.log(memory.buffer.byteLength / bytesPerPage); // "1"
+console.log(memory.grow(1)); // "1"
+console.log(memory.buffer.byteLength / bytesPerPage); // "2"
 ```
 
 なお、ここでの `grow()` の返値は直前の WebAssembly ページ数です。

--- a/files/ja/webassembly/javascript_interface/memory/index.md
+++ b/files/ja/webassembly/javascript_interface/memory/index.md
@@ -32,14 +32,15 @@ JavaScript または WebAssembly コードから生成されたメモリーは J
 `WebAssembly.Memory` オブジェクトを取得する方法は 2 つあります。 1 つ目は JavaScript から生成する方法です。以下の例では、初期サイズが 10 ページ (640KiB) 、最大サイズが 100 ページ (6.4MiB) で新しい WebAssembly Memory インスタンスを生成しています。その [`buffer`](/ja/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/buffer) プロパティは [`ArrayBuffer`](/ja/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) を返します。
 
 ```js
-var memory = new WebAssembly.Memory({initial:10, maximum:100});
+var memory = new WebAssembly.Memory({ initial: 10, maximum: 100 });
 ```
 
 次の例では (GitHub 上の [memory.html](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/memory.html) および[実行例](https://mdn.github.io/webassembly-examples/js-api-examples/memory.html)も参照)、 memory.wasm バイトコードを {{jsxref("WebAssembly.instantiateStreaming()")}} メソッドを使用して読み込みんでインスタンス化し、その上の行で生成されたメモリにインポートします。それから、メモリにいくつかの値を格納し、関数をエクスポートして使用し、いくつかの値を合計します。
 
 ```js
-WebAssembly.instantiateStreaming(fetch('memory.wasm'), { js: { mem: memory } })
-.then(obj => {
+WebAssembly.instantiateStreaming(fetch("memory.wasm"), {
+  js: { mem: memory },
+}).then((obj) => {
   var i32 = new Uint32Array(memory.buffer);
   for (var i = 0; i < 10; i++) {
     i32[i] = i;
@@ -52,11 +53,10 @@ WebAssembly.instantiateStreaming(fetch('memory.wasm'), { js: { mem: memory } })
 WebAssembly.Memory オブジェクトを取得する 2 つ目の方法は、 WebAssembly モジュールによってエクスポートされることです。このメモリは WebAssembly インスタンスの `exports` プロパティで (メモリーが WebAssembly モジュール内でエクスポートされた後に) アクセスできます。次のスニペットは、 WebAssembly からエクスポートされたメモリを `memory`という名前でインポートし、メモリーの最初の要素を Uint32Array として解釈して表示しています。
 
 ```js
-WebAssembly.instantiateStreaming(fetch('memory.wasm'))
-.then(obj => {
-   var i32 = new Uint32Array(obj.instance.exports.memory.buffer);
-   console.log(i32[0]);
- });
+WebAssembly.instantiateStreaming(fetch("memory.wasm")).then((obj) => {
+  var i32 = new Uint32Array(obj.instance.exports.memory.buffer);
+  console.log(i32[0]);
+});
 ```
 
 ### 共有メモリーの作成
@@ -65,7 +65,11 @@ WebAssembly.instantiateStreaming(fetch('memory.wasm'))
 の初期化オブジェクトに `shared: true` を渡します。
 
 ```js
-let memory = new WebAssembly.Memory({initial:10, maximum:100, shared: true});
+let memory = new WebAssembly.Memory({
+  initial: 10,
+  maximum: 100,
+  shared: true,
+});
 ```
 
 このメモリーの `buffer` プロパティは [`SharedArrayBuffer`](/ja/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) を返します。

--- a/files/ja/webassembly/javascript_interface/memory/memory/index.md
+++ b/files/ja/webassembly/javascript_interface/memory/memory/index.md
@@ -13,7 +13,7 @@ JavaScript または WebAssembly コードから生成されたメモリーは J
 ## 構文
 
 ```js
-new WebAssembly.Memory(memoryDescriptor)
+new WebAssembly.Memory(memoryDescriptor);
 ```
 
 ### 引数
@@ -43,14 +43,15 @@ new WebAssembly.Memory(memoryDescriptor)
 `WebAssembly.Memory` オブジェクトを取得する方法は 2 つあります。 1 つ目は JavaScript から構築する方法です。次の例では、新しい WebAssembly Memory インスタンスを初期サイズが 10 ページ (640KiB) 、最大サイズが 100 ページ (6.4MiB) で生成しています。この [`buffer`](/ja/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/buffer) プロパティは [`ArrayBuffer`](/ja/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) を返します。
 
 ```js
-var memory = new WebAssembly.Memory({initial:10, maximum:100});
+var memory = new WebAssembly.Memory({ initial: 10, maximum: 100 });
 ```
 
 2 つ目は WebAssembly モジュールからエクスポートされた `WebAssembly.Memory` オブジェクトを使用する方法です。次の例では (GitHub 上の [memory.html](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/memory.html) および[動作例](https://mdn.github.io/webassembly-examples/js-api-examples/memory.html)も参照)、 memory.wasm バイトコードを {{jsxref("WebAssembly.instantiateStreaming()")}} メソッドで読み込みんでインスタンス化し、その上の行で生成されたメモリーにインポートします。それから、メモリーにいくつかの値を格納し、関数をエクスポートして使用し、いくつかの値を合計します。
 
 ```js
-WebAssembly.instantiateStreaming(fetch('memory.wasm'), { js: { mem: memory } })
-.then(obj => {
+WebAssembly.instantiateStreaming(fetch("memory.wasm"), {
+  js: { mem: memory },
+}).then((obj) => {
   var i32 = new Uint32Array(memory.buffer);
   for (var i = 0; i < 10; i++) {
     i32[i] = i;
@@ -66,7 +67,11 @@ WebAssembly.instantiateStreaming(fetch('memory.wasm'), { js: { mem: memory } })
 の初期化オブジェクトに `shared: true` を渡してください。
 
 ```js
-let memory = new WebAssembly.Memory({initial:10, maximum:100, shared:true});
+let memory = new WebAssembly.Memory({
+  initial: 10,
+  maximum: 100,
+  shared: true,
+});
 ```
 
 このメモリーの `buffer` プロパティは [`SharedArrayBuffer`](/ja/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) を返します。

--- a/files/ja/webassembly/javascript_interface/module/customsections/index.md
+++ b/files/ja/webassembly/javascript_interface/module/customsections/index.md
@@ -11,7 +11,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/custom
 ## 構文
 
 ```js
-WebAssembly.Module.customSections(module, sectionName)
+WebAssembly.Module.customSections(module, sectionName);
 ```
 
 ### 引数
@@ -50,14 +50,15 @@ wast2wasm simple-name-section.was -o simple-name-section.wasm --debug-names
 それから、`WebAssembly.Module.customSections` を使用して `length` が 0 より大きいかチェックして、モジュールに "name" カスタムセクションが含まれているかどうかチェックします。この例では "name" カスタムセクションが存在するため、`ArrayBuffer` オブジェクトが返されます。
 
 ```js
-WebAssembly.compileStreaming(fetch('simple-name-section.wasm'))
-.then(function(mod) {
-  var nameSections = WebAssembly.Module.customSections(mod, "name");
-  if (nameSections.length != 0) {
-    console.log("Module contains a name section");
-    console.log(nameSections[0]);
-  };
-});
+WebAssembly.compileStreaming(fetch("simple-name-section.wasm")).then(
+  function (mod) {
+    var nameSections = WebAssembly.Module.customSections(mod, "name");
+    if (nameSections.length != 0) {
+      console.log("Module contains a name section");
+      console.log(nameSections[0]);
+    }
+  },
+);
 ```
 
 ## 仕様書

--- a/files/ja/webassembly/javascript_interface/module/exports/index.md
+++ b/files/ja/webassembly/javascript_interface/module/exports/index.md
@@ -11,7 +11,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/export
 ## 構文
 
 ```js
-WebAssembly.Module.exports(module)
+WebAssembly.Module.exports(module);
 ```
 
 ### 引数
@@ -36,9 +36,8 @@ WebAssembly.Module.exports(module)
 ```js
 var worker = new Worker("wasm_worker.js");
 
-WebAssembly.compileStreaming(fetch('simple.wasm'))
-.then(mod =>
-  worker.postMessage(mod)
+WebAssembly.compileStreaming(fetch("simple.wasm")).then((mod) =>
+  worker.postMessage(mod),
 );
 ```
 
@@ -47,17 +46,17 @@ WebAssembly.compileStreaming(fetch('simple.wasm'))
 ```js
 var importObject = {
   imports: {
-    imported_func: function(arg) {
+    imported_func: function (arg) {
       console.log(arg);
-    }
-  }
+    },
+  },
 };
 
-onmessage = function(e) {
-  console.log('module received from main thread');
+onmessage = function (e) {
+  console.log("module received from main thread");
   var mod = e.data;
 
-  WebAssembly.instantiate(mod, importObject).then(function(instance) {
+  WebAssembly.instantiate(mod, importObject).then(function (instance) {
     instance.exports.exported_func();
   });
 

--- a/files/ja/webassembly/javascript_interface/module/imports/index.md
+++ b/files/ja/webassembly/javascript_interface/module/imports/index.md
@@ -11,7 +11,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/import
 ## 構文
 
 ```js
-WebAssembly.Module.imports(module)
+WebAssembly.Module.imports(module);
 ```
 
 ### 引数
@@ -34,8 +34,7 @@ module が {{jsxref("WebAssembly.Module")}} オブジェクトインスタンス
 次の例では ([imports.html](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/imports.html) と[動作例](https://mdn.github.io/webassembly-examples/js-api-examples/imports.html)も参照)、読み込んだ simple.wasm モジュールをコンパイルします。このモジュールは imports から問い合わせされます。
 
 ```js
-WebAssembly.compileStreaming(fetch('simple.wasm'))
-.then(function(mod) {
+WebAssembly.compileStreaming(fetch("simple.wasm")).then(function (mod) {
   var imports = WebAssembly.Module.imports(mod);
   console.log(imports[0]);
 });

--- a/files/ja/webassembly/javascript_interface/module/index.md
+++ b/files/ja/webassembly/javascript_interface/module/index.md
@@ -31,9 +31,8 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module
 ```js
 var worker = new Worker("wasm_worker.js");
 
-WebAssembly.compileStreaming(fetch('simple.wasm'))
-.then(mod =>
-  worker.postMessage(mod)
+WebAssembly.compileStreaming(fetch("simple.wasm")).then((mod) =>
+  worker.postMessage(mod),
 );
 ```
 
@@ -42,17 +41,17 @@ WebAssembly.compileStreaming(fetch('simple.wasm'))
 ```js
 var importObject = {
   imports: {
-    imported_func: function(arg) {
+    imported_func: function (arg) {
       console.log(arg);
-    }
-  }
+    },
+  },
 };
 
-onmessage = function(e) {
-  console.log('module received from main thread');
+onmessage = function (e) {
+  console.log("module received from main thread");
   var mod = e.data;
 
-  WebAssembly.instantiate(mod, importObject).then(function(instance) {
+  WebAssembly.instantiate(mod, importObject).then(function (instance) {
     instance.exports.exported_func();
   });
 };

--- a/files/ja/webassembly/javascript_interface/module/module/index.md
+++ b/files/ja/webassembly/javascript_interface/module/module/index.md
@@ -16,7 +16,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/Module
 > **警告:** 大きなモジュールのコンパイルにはコストがかかるため、開発者はどうしても同期コンパイルが必要な場合にのみ `Module()` コンストラクターを使用し、それ以外の場合には非同期の {{jsxref("WebAssembly.compileStreaming()")}} メソッドを使用してください。
 
 ```js
-new WebAssembly.Module(bufferSource)
+new WebAssembly.Module(bufferSource);
 ```
 
 ### 引数
@@ -31,25 +31,24 @@ new WebAssembly.Module(bufferSource)
 ```js
 var importObject = {
   imports: {
-    imported_func: function(arg) {
+    imported_func: function (arg) {
       console.log(arg);
-    }
-  }
+    },
+  },
 };
 
 function createWasmModule(bytes) {
   return new WebAssembly.Module(bytes);
 }
 
-fetch('simple.wasm').then(response =>
-  response.arrayBuffer()
-).then(bytes => {
-  let mod = createWasmModule(bytes);
-  WebAssembly.instantiate(mod, importObject)
-  .then(result =>
-     result.exports.exported_func()
-  );
-})
+fetch("simple.wasm")
+  .then((response) => response.arrayBuffer())
+  .then((bytes) => {
+    let mod = createWasmModule(bytes);
+    WebAssembly.instantiate(mod, importObject).then((result) =>
+      result.exports.exported_func(),
+    );
+  });
 ```
 
 ## 仕様書

--- a/files/ja/webassembly/javascript_interface/runtimeerror/index.md
+++ b/files/ja/webassembly/javascript_interface/runtimeerror/index.md
@@ -43,15 +43,15 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError
 
 ```js
 try {
-  throw new WebAssembly.RuntimeError('Hello', 'someFile', 10);
+  throw new WebAssembly.RuntimeError("Hello", "someFile", 10);
 } catch (e) {
   console.log(e instanceof WebAssembly.RuntimeError); // true
-  console.log(e.message);                             // "Hello"
-  console.log(e.name);                                // "RuntimeError"
-  console.log(e.fileName);                            // "someFile"
-  console.log(e.lineNumber);                          // 10
-  console.log(e.columnNumber);                        // 0
-  console.log(e.stack);                               // コードが実行されていた位置を返す
+  console.log(e.message); // "Hello"
+  console.log(e.name); // "RuntimeError"
+  console.log(e.fileName); // "someFile"
+  console.log(e.lineNumber); // 10
+  console.log(e.columnNumber); // 0
+  console.log(e.stack); // コードが実行されていた位置を返す
 }
 ```
 

--- a/files/ja/webassembly/javascript_interface/runtimeerror/runtimeerror/index.md
+++ b/files/ja/webassembly/javascript_interface/runtimeerror/runtimeerror/index.md
@@ -11,10 +11,10 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError/
 ## 構文
 
 ```js
-new WebAssembly.RuntimeError()
-new WebAssembly.RuntimeError(message)
-new WebAssembly.RuntimeError(message, fileName)
-new WebAssembly.RuntimeError(message, fileName, lineNumber)
+new WebAssembly.RuntimeError();
+new WebAssembly.RuntimeError(message);
+new WebAssembly.RuntimeError(message, fileName);
+new WebAssembly.RuntimeError(message, fileName, lineNumber);
 ```
 
 ### 引数
@@ -34,15 +34,15 @@ new WebAssembly.RuntimeError(message, fileName, lineNumber)
 
 ```js
 try {
-  throw new WebAssembly.RuntimeError('Hello', 'someFile', 10);
+  throw new WebAssembly.RuntimeError("Hello", "someFile", 10);
 } catch (e) {
   console.log(e instanceof WebAssembly.RuntimeError); // true
-  console.log(e.message);                             // "Hello"
-  console.log(e.name);                                // "RuntimeError"
-  console.log(e.fileName);                            // "someFile"
-  console.log(e.lineNumber);                          // 10
-  console.log(e.columnNumber);                        // 0
-  console.log(e.stack);                               // コードの実行されていた位置を返す
+  console.log(e.message); // "Hello"
+  console.log(e.name); // "RuntimeError"
+  console.log(e.fileName); // "someFile"
+  console.log(e.lineNumber); // 10
+  console.log(e.columnNumber); // 0
+  console.log(e.stack); // コードの実行されていた位置を返す
 }
 ```
 

--- a/files/ja/webassembly/javascript_interface/table/get/index.md
+++ b/files/ja/webassembly/javascript_interface/table/get/index.md
@@ -11,7 +11,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/get
 ## 構文
 
 ```js
-get(index)
+get(index);
 ```
 
 ### 引数
@@ -35,11 +35,10 @@ _index_ が {{jsxref("WebAssembly/Table/length","Table.prototype.length")}} 以�
 {{jsxref("WebAssembly.instantiateStreaming()")}} メソッドを使用して読み取り、コンパイルしてインスタンス化しています。その後、エクスポートされたテーブルに格納された参照を取得します。
 
 ```js
-WebAssembly.instantiateStreaming(fetch('table.wasm'))
-.then(function(obj) {
+WebAssembly.instantiateStreaming(fetch("table.wasm")).then(function (obj) {
   var tbl = obj.instance.exports.tbl;
-  console.log(tbl.get(0)());  // 13
-  console.log(tbl.get(1)());  // 42
+  console.log(tbl.get(0)()); // 13
+  console.log(tbl.get(1)()); // 42
 });
 ```
 

--- a/files/ja/webassembly/javascript_interface/table/grow/index.md
+++ b/files/ja/webassembly/javascript_interface/table/grow/index.md
@@ -11,7 +11,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/grow
 ## 構文
 
 ```js
-grow(number)
+grow(number);
 ```
 
 ### 引数
@@ -34,15 +34,19 @@ grow(number)
 以下の例では、新しい WebAssembly Table のインスタンスを初期サイズ 2、最大サイズ 10 で生成しています。
 
 ```js
-var table = new WebAssembly.Table({ element: "anyfunc", initial: 2, maximum: 10 });
+var table = new WebAssembly.Table({
+  element: "anyfunc",
+  initial: 2,
+  maximum: 10,
+});
 ```
 
 以下のようにして、テーブルを 1 だけ拡張することができます。
 
 ```js
-console.log(table.length);   // "2"
-console.log(table.grow(1));  // "2"
-console.log(table.length);   // "3"
+console.log(table.length); // "2"
+console.log(table.grow(1)); // "2"
+console.log(table.length); // "3"
 ```
 
 ## 仕様書

--- a/files/ja/webassembly/javascript_interface/table/index.md
+++ b/files/ja/webassembly/javascript_interface/table/index.md
@@ -36,10 +36,10 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table
 次の例では ([table2.html](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/table2.html) と[動作例](https://mdn.github.io/webassembly-examples/js-api-examples/table2.html)を確認してください)、新しい WebAssembly Table メソッドを初期サイズ 2 要素で生成します。それからそのテーブルの長さと 2 つの位置の内容を ({{jsxref("WebAssembly/Table/get", "Table.prototype.get()")}} を使用して受け取って) 表示し、長さが 2 で両方の要素が {{jsxref("null")}} であることを示します。
 
 ```js
-var tbl = new WebAssembly.Table({initial:2, element:"anyfunc"});
-console.log(tbl.length);  // "2"
-console.log(tbl.get(0));  // "null"
-console.log(tbl.get(1));  // "null"
+var tbl = new WebAssembly.Table({ initial: 2, element: "anyfunc" });
+console.log(tbl.length); // "2"
+console.log(tbl.get(0)); // "null"
+console.log(tbl.get(1)); // "null"
 ```
 
 次に、テーブルを含むインポートオブジェクトを生成します。
@@ -47,8 +47,8 @@ console.log(tbl.get(1));  // "null"
 ```js
 var importObj = {
   js: {
-    tbl:tbl
-  }
+    tbl: tbl,
+  },
 };
 ```
 

--- a/files/ja/webassembly/javascript_interface/table/length/index.md
+++ b/files/ja/webassembly/javascript_interface/table/length/index.md
@@ -15,15 +15,19 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/length
 次の例では、新しい WebAssembly Table インスタンスを初期サイズ 2、最大サイズ 10 で作成します。
 
 ```js
-var table = new WebAssembly.Table({ element: "anyfunc", initial: 2, maximum: 10 });
+var table = new WebAssembly.Table({
+  element: "anyfunc",
+  initial: 2,
+  maximum: 10,
+});
 ```
 
 次のようにして、テーブルを 1 ずつ拡大することができます。
 
 ```js
-console.log(table.length);   // "2"
-console.log(table.grow(1));  // "2"
-console.log(table.length);   // "3"
+console.log(table.length); // "2"
+console.log(table.grow(1)); // "2"
+console.log(table.length); // "3"
 ```
 
 ## 仕様書

--- a/files/ja/webassembly/javascript_interface/table/set/index.md
+++ b/files/ja/webassembly/javascript_interface/table/set/index.md
@@ -11,7 +11,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/set
 ## 構文
 
 ```js
-set(index, value)
+set(index, value);
 ```
 
 ### 引数
@@ -37,7 +37,7 @@ set(index, value)
 次の例 (table2.html の[ソースコード](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/table2.html)と[動作例](https://mdn.github.io/webassembly-examples/blob/master/js-api-examples/table2.html)を確認してください) では、初期サイズが参照 2 つである WebAssembly Table インスタンスを生成しています。そして、テーブルの長さと 2 つの位置の内容 ({{jsxref("WebAssembly/Table/get","Table.prototype.get()")}} で取得) を出力して、長さが 2 であること、それぞれの位置には現在、関数の参照が含まれていないこと (現在は {{jsxref("null")}} を返すこと) を示しています。
 
 ```js
-var tbl = new WebAssembly.Table({initial:2, element:"anyfunc"});
+var tbl = new WebAssembly.Table({ initial: 2, element: "anyfunc" });
 console.log(tbl.length);
 console.log(tbl.get(0));
 console.log(tbl.get(1));
@@ -48,20 +48,21 @@ console.log(tbl.get(1));
 ```js
 var importObj = {
   js: {
-    tbl:tbl
-  }
+    tbl: tbl,
+  },
 };
 ```
 
 最後に、 wasm モジュール (table2.wasm) を {{jsxref("WebAssembly.instantiateStreaming()")}} を使用して読み込みインスタンス化します。テーブルの長さを記録し、テーブルに格納された 2 つの関数参照を呼び出します (table2.wasm モジュール ([テキスト表現](https://github.com/mdn/webassembly-examples/blob/master/text-format-examples/table2.was)) がテーブルに 2 つの関数の参照を追加し、どちらも単純な表示を表示します)。
 
 ```js
-WebAssembly.instantiateStreaming(fetch('table2.wasm'), importObject)
-.then(function(obj) {
-  console.log(tbl.length);
-  console.log(tbl.get(0)());
-  console.log(tbl.get(1)());
-});
+WebAssembly.instantiateStreaming(fetch("table2.wasm"), importObject).then(
+  function (obj) {
+    console.log(tbl.length);
+    console.log(tbl.get(0)());
+    console.log(tbl.get(1)());
+  },
+);
 ```
 
 内部の値を表示するためには、参照された関数のアクセサーの呼び出しの後に、 2 つ目の関数呼び出しを含める必要があることに注意して下さい (`get(0)` ではなく `get(0)()`)。

--- a/files/ja/webassembly/javascript_interface/table/table/index.md
+++ b/files/ja/webassembly/javascript_interface/table/table/index.md
@@ -11,7 +11,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/Table
 ## 構文
 
 ```js
-new WebAssembly.Table(tableDescriptor)
+new WebAssembly.Table(tableDescriptor);
 ```
 
 ### 引数
@@ -39,10 +39,10 @@ new WebAssembly.Table(tableDescriptor)
 次の例では (table2.html の[ソースコード](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/table2.html)と[実行例](https://mdn.github.io/webassembly-examples/js-api-examples/table2.html)はこちら) 新しく WebAssembly テーブルのインスタンスを、初期の大きさを 2 要素して生成します。それからテーブルの長さと 2 つの要素の中身を ({{jsxref("WebAssembly/Table/get", "Table.prototype.get()")}} で取得して) 表示し、長さは 2 で 2 つの要素は共に {{jsxref("null")}} となります。
 
 ```js
-var tbl = new WebAssembly.Table({initial:2, element:"anyfunc"});
-console.log(tbl.length);  // "2"
-console.log(tbl.get(0));  // "null"
-console.log(tbl.get(1));  // "null"
+var tbl = new WebAssembly.Table({ initial: 2, element: "anyfunc" });
+console.log(tbl.length); // "2"
+console.log(tbl.get(0)); // "null"
+console.log(tbl.get(1)); // "null"
 ```
 
 それからテーブルを含むインポートオブジェクトを作成します。
@@ -50,20 +50,21 @@ console.log(tbl.get(1));  // "null"
 ```js
 var importObj = {
   js: {
-    tbl:tbl
-  }
+    tbl: tbl,
+  },
 };
 ```
 
 最終的に、 wasm モジュール (table2.wasm) を {{jsxref("WebAssembly.instantiateStreaming()")}} メソッドを使用して読み込みインスタンス化します。 table2.wasm モジュールには 2 つの関数 (1 つは 42 を返し、もう 1 つは 83 を返す) が入っており、それぞれをインポートされたテーブルの要素 0 と 1 に格納します。 ([テキスト表現](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/table2.wat)をご覧ください)。インスタンス化した後で、テーブルは長さは 2 のままですが、要素には呼び出し可能な<a href="/ja/docs/WebAssembly/Exported_functions">エクスポートされた WebAssembly 関数</a>が入り、 JS から呼び出せるようになりました。
 
 ```js
-WebAssembly.instantiateStreaming(fetch('table2.wasm'), importObject)
-.then(function(obj) {
-  console.log(tbl.length);
-  console.log(tbl.get(0)());
-  console.log(tbl.get(1)());
-});
+WebAssembly.instantiateStreaming(fetch("table2.wasm"), importObject).then(
+  function (obj) {
+    console.log(tbl.length);
+    console.log(tbl.get(0)());
+    console.log(tbl.get(1)());
+  },
+);
 ```
 
 なお、関数呼び出し演算子がアクセサーの後に二重についており (例えば `get(0)()` を `get(0)` の代わりに使用)、実際に参照している関数を呼び出して、その中に格納された値をログ出力しています。

--- a/files/ja/webassembly/javascript_interface/validate/index.md
+++ b/files/ja/webassembly/javascript_interface/validate/index.md
@@ -11,7 +11,7 @@ original_slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/validate
 ## 構文
 
 ```js
-WebAssembly.validate(bufferSource)
+WebAssembly.validate(bufferSource);
 ```
 
 ### 引数
@@ -34,13 +34,14 @@ WebAssembly.validate(bufferSource)
 以下の例 (`validate.html` の[ソースコード](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/validate.html)と[動作例](https://mdn.github.io/webassembly-examples/js-api-examples/validate.html) をご確認ください) は .wasm モジュールを読み取って型付き配列に変換します。次に、 `validate()` メソッドを使用してモジュールが有効かどうかをチェックします。</p>
 
 ```js
-fetch('simple.wasm').then(response =>
-  response.arrayBuffer()
-).then(function(bytes) {
-  var valid = WebAssembly.validate(bytes);
-  console.log("The given bytes are "
-    + (valid ? "" : "not ") + "a valid wasm module");
-});
+fetch("simple.wasm")
+  .then((response) => response.arrayBuffer())
+  .then(function (bytes) {
+    var valid = WebAssembly.validate(bytes);
+    console.log(
+      "The given bytes are " + (valid ? "" : "not ") + "a valid wasm module",
+    );
+  });
 ```
 
 ## 仕様書

--- a/files/ja/webassembly/loading_and_running/index.md
+++ b/files/ja/webassembly/loading_and_running/index.md
@@ -26,22 +26,22 @@ WebAssembly は `<script type='module'>` または ES2015 の `import` 文とま
 wasm モジュールをフェッチする最も簡単で効率的な方法は、新しい {{jsxref("WebAssembly.instantiateStreaming()")}} メソッドを使用することです。このメソッドは最初の引数として `fetch()` を呼び出すことができ、1 つのステップでフェッチ、モジュールをインスタンス化し、サーバからストリームされる生のバイトコードにアクセスします。
 
 ```js
-WebAssembly.instantiateStreaming(fetch('simple.wasm'), importObject)
-.then((results) => {
-  // Do something with the results!
-});
+WebAssembly.instantiateStreaming(fetch("simple.wasm"), importObject).then(
+  (results) => {
+    // Do something with the results!
+  },
+);
 ```
 
 直接ストリームでは動作しない古い {{jsxref("WebAssembly.instantiate()")}} メソッドを使用した場合、フェッチされたバイトコードを {{jsxref("ArrayBuffer")}} に変換する必要があります。次のようにです。
 
 ```js
-fetch('module.wasm').then((response) =>
-  response.arrayBuffer()
-).then((bytes) =>
-  WebAssembly.instantiate(bytes, importObject)
-).then((results) => {
-  // コンパイルされた結果 (results) で何かする!
-});
+fetch("module.wasm")
+  .then((response) => response.arrayBuffer())
+  .then((bytes) => WebAssembly.instantiate(bytes, importObject))
+  .then((results) => {
+    // コンパイルされた結果 (results) で何かする!
+  });
 ```
 
 ### 余談: instantiate() のオーバーロード
@@ -64,18 +64,19 @@ fetch('module.wasm').then((response) =>
 JavaScript 内で WebAssembly インスタンスが有効になったら {{jsxref("WebAssembly.Instance/exports", "WebAssembly.Instance.exports")}} プロパティを通してエクスポートされた機能を使い始めることができます。コードは以下のようになります。
 
 ```js
-WebAssembly.instantiateStreaming(fetch('myModule.wasm'), importObject)
-.then((obj) => {
-  // Call an exported function:
-  obj.instance.exports.exported_func();
+WebAssembly.instantiateStreaming(fetch("myModule.wasm"), importObject).then(
+  (obj) => {
+    // Call an exported function:
+    obj.instance.exports.exported_func();
 
-  // or access the buffer contents of an exported memory:
-  const i32 = new Uint32Array(obj.instance.exports.memory.buffer);
+    // or access the buffer contents of an exported memory:
+    const i32 = new Uint32Array(obj.instance.exports.memory.buffer);
 
-  // or access the elements of an exported table:
-  const table = obj.instance.exports.table;
-  console.log(table.get(0)());
-})
+    // or access the elements of an exported table:
+    const table = obj.instance.exports.table;
+    console.log(table.get(0)());
+  },
+);
 ```
 
 > **メモ:** WebAssembly モジュールからのエクスポートの仕組みの詳細については [WebAssembly JavaScript API の使用](/ja/docs/WebAssembly/Using_the_JavaScript_API) と [WebAssembly テキストフォーマットを理解する](/ja/docs/WebAssembly/Understanding_the_text_format) を参照してください。
@@ -93,8 +94,8 @@ WebAssembly.instantiateStreaming(fetch('myModule.wasm'), importObject)
 
 ```js
 const request = new XMLHttpRequest();
-request.open('GET', 'simple.wasm');
-request.responseType = 'arraybuffer';
+request.open("GET", "simple.wasm");
+request.responseType = "arraybuffer";
 request.send();
 
 request.onload = () => {

--- a/files/ja/webassembly/rust_to_wasm/index.md
+++ b/files/ja/webassembly/rust_to_wasm/index.md
@@ -205,19 +205,18 @@ wasm-pack build --target web
 まず、プロジェクトのルートに `index.html` という名前のファイルを作成し、以下のような内容にしてみましょう。
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en-US">
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>hello-wasm example</title>
   </head>
   <body>
     <script type="module">
-      import init, {greet} from "./pkg/hello_wasm.js";
-      init()
-        .then(() => {
-          greet("WebAssembly")
-        });
+      import init, { greet } from "./pkg/hello_wasm.js";
+      init().then(() => {
+        greet("WebAssembly");
+      });
     </script>
   </body>
 </html>
@@ -290,14 +289,14 @@ npm link hello-wasm
 次に、Webpack を設定する必要があります。`webpack.config.js` を作成し、そこに次のことを記入してください。
 
 ```js
-const path = require('path');
+const path = require("path");
 module.exports = {
   entry: "./index.js",
   output: {
     path: path.resolve(__dirname, "dist"),
     filename: "index.js",
   },
-  mode: "development"
+  mode: "development",
 };
 ```
 
@@ -314,10 +313,10 @@ import("./node_modules/hello-wasm/hello_wasm.js").then((js) => {
 最後に HTML ファイルが必要です。 `index.html` を作成し、次の内容を追加してください。
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en-US">
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>hello-wasm example</title>
   </head>
   <body>

--- a/files/ja/webassembly/text_format_to_wasm/index.md
+++ b/files/ja/webassembly/text_format_to_wasm/index.md
@@ -34,9 +34,9 @@ WebAssembly 関数 `exported_func` は私たちの環境（WebAssembly モジュ
 3. ツールをビルドしたら、 `/wabt/out/clang/Debug` ディレクトリーをシステムの `PATH` に追加します。
 4. 次に、wat2wasm プログラムを実行します。入力ファイルパス、続いて `-o` 引数と、その後に出力ファイルパスを指定します。
 
-    ```bash
-    wat2wasm simple.wat -o simple.wasm
-    ```
+   ```bash
+   wat2wasm simple.wat -o simple.wasm
+   ```
 
 これで `simple.wasm` という名前のファイルに wasm が出力されます。これには `.wasm` アセンブリーのコードが含まれます。
 

--- a/files/ja/webassembly/understanding_the_text_format/index.md
+++ b/files/ja/webassembly/understanding_the_text_format/index.md
@@ -172,10 +172,9 @@ WebAssembly のバリデーションルールはスタックが正確に一致�
 次に、 `addCode` という名前の型付き配列にバイナリー読み込み（[WebAssembly コードのロードと実行](/ja/docs/WebAssembly/Loading_and_running) で説明されています）、コンパイル、インスタンス化して、JavaScript で `add` 関数を実行します（`add()` はインスタンスの [`exports`](/ja/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/exports) プロパティから見つけることができます）。
 
 ```js
-WebAssembly.instantiateStreaming(fetch('add.wasm'))
-  .then(obj => {
-    console.log(obj.instance.exports.add(1, 2));  // "3"
-  });
+WebAssembly.instantiateStreaming(fetch("add.wasm")).then((obj) => {
+  console.log(obj.instance.exports.add(1, 2)); // "3"
+});
 ```
 
 > **メモ:** この例は GitHub の[add.html](https://github.com/mdn/webassembly-examples/blob/master/understanding-text-format/add.html) ([動作例](https://mdn.github.io/webassembly-examples/understanding-text-format/add.html)) にあります。関数のインスタンス化についての詳細は {{JSxRef("WebAssembly.instantiateStreaming()")}} も合わせて参照してください。
@@ -211,10 +210,9 @@ WebAssembly.instantiateStreaming(fetch('add.wasm'))
 上のモジュールを呼び出す JavaScript コードは次のようになります。
 
 ```js
-WebAssembly.instantiateStreaming(fetch('call.wasm'))
- .then(obj => {
-    console.log(obj.instance.exports.getAnswerPlus1());  // "43"
-  });
+WebAssembly.instantiateStreaming(fetch("call.wasm")).then((obj) => {
+  console.log(obj.instance.exports.getAnswerPlus1()); // "43"
+});
 ```
 
 ### JavaScript から関数をインポートする
@@ -242,16 +240,17 @@ JavaScript 関数にはシグネチャの概念がないため、インポート
 ```js
 var importObject = {
   console: {
-    log: function(arg) {
+    log: function (arg) {
       console.log(arg);
-    }
-  }
+    },
+  },
 };
 
-WebAssembly.instantiateStreaming(fetch('logger.wasm'), importObject)
-  .then(obj => {
+WebAssembly.instantiateStreaming(fetch("logger.wasm"), importObject).then(
+  (obj) => {
     obj.instance.exports.logIt();
-  });
+  },
+);
 ```
 
 > **メモ:** この例は GitHub の [logger.html](https://github.com/mdn/webassembly-examples/blob/master/understanding-text-format/logger.html) ([動作例](https://mdn.github.io/webassembly-examples/understanding-text-format/logger.html))を参照してください。
@@ -278,7 +277,7 @@ WebAssembly のテキスト形式では、次のようになります (GitHub �
 JavaScript を使用して同等の値を作成するには、 {{JSxRef("WebAssembly.Global()")}} コンストラクターを使用してください。
 
 ```js
-const global = new WebAssembly.Global({value: "i32", mutable: true}, 0);
+const global = new WebAssembly.Global({ value: "i32", mutable: true }, 0);
 ```
 
 ### WebAssembly メモリー
@@ -304,7 +303,7 @@ JavaScript 側では、バイト列を簡単に JavaScript 文字列にデコー
 ```js
 function consoleLogString(offset, length) {
   var bytes = new Uint8Array(memory.buffer, offset, length);
-  var string = new TextDecoder('utf8').decode(bytes);
+  var string = new TextDecoder("utf8").decode(bytes);
   console.log(string);
 }
 ```
@@ -339,14 +338,15 @@ function consoleLogString(offset, length) {
 ここで、JavaScript から 1 ページ分のサイズを持つ Memory を作成してそれに渡すことができます。結果としてコンソールに "Hi" と出力されます。
 
 ```js
-var memory = new WebAssembly.Memory({initial:1});
+var memory = new WebAssembly.Memory({ initial: 1 });
 
 var importObject = { console: { log: consoleLogString }, js: { mem: memory } };
 
-WebAssembly.instantiateStreaming(fetch('logger2.wasm'), importObject)
-  .then(obj => {
+WebAssembly.instantiateStreaming(fetch("logger2.wasm"), importObject).then(
+  (obj) => {
     obj.instance.exports.writeHi();
-  });
+  },
+);
 ```
 
 > **メモ:** 完全なソースは GitHub の [logger2.html](https://github.com/mdn/webassembly-examples/blob/master/understanding-text-format/logger2.html) ([動作例](https://mdn.github.io/webassembly-examples/understanding-text-format/logger2.html)) を参照してください。
@@ -432,7 +432,7 @@ function() {
 
 より高級な、JavaScript のような表現力の高い言語では、関数を含む配列 (あるいはオブジェクトかもしれません) で同じことができることが想像できますよね。擬似コードだとこれは `tbl[i]()` のようになります。
 
-型チェックの話に戻ります。WebAssembly は型チェックされていて、 `funcref`  は「任意の関数シグネチャ」を意味するので、呼び出し先の (推定される) シグネチャを指定する必要があります。そのため、 `$return_i32` 型を指定することで、プログラムに関数が `i32` を返すはずだと知らせます。もし呼び出し先のシグネチャが一致しない (代わりに `f32` が返されるような) 場合は {{JSxRef("WebAssembly.RuntimeError")}} 例外が発生します。
+型チェックの話に戻ります。WebAssembly は型チェックされていて、 `funcref` は「任意の関数シグネチャ」を意味するので、呼び出し先の (推定される) シグネチャを指定する必要があります。そのため、 `$return_i32` 型を指定することで、プログラムに関数が `i32` を返すはずだと知らせます。もし呼び出し先のシグネチャが一致しない (代わりに `f32` が返されるような) 場合は {{JSxRef("WebAssembly.RuntimeError")}} 例外が発生します。
 
 さて、呼び出しを行うときにどのようにテーブルに `call_indirect` をリンクさせているのでしょうか? 答えは、現在モジュールインスタンスごとに1つのテーブルしか許容されないため、`call_indirect` はそれを暗黙的に呼び出します。将来的に複数のテーブルを持てるようになったとき、以下の行のように、何らかのテーブル識別子を指定する必要があるでしょう。
 
@@ -460,12 +460,11 @@ call_indirect $my_spicy_table (type $i32_to_void)
 次の JavaScript を使用してウェブページに読み込んでみましょう。
 
 ```js
-WebAssembly.instantiateStreaming(fetch('wasm-table.wasm'))
-  .then(obj => {
-    console.log(obj.instance.exports.callByIndex(0)); // returns 42
-    console.log(obj.instance.exports.callByIndex(1)); // returns 13
-    console.log(obj.instance.exports.callByIndex(2)); // returns an error, because there is no index position 2 in the table
-  });
+WebAssembly.instantiateStreaming(fetch("wasm-table.wasm")).then((obj) => {
+  console.log(obj.instance.exports.callByIndex(0)); // returns 42
+  console.log(obj.instance.exports.callByIndex(1)); // returns 13
+  console.log(obj.instance.exports.callByIndex(2)); // returns an error, because there is no index position 2 in the table
+});
 ```
 
 > **メモ:** 例は GitHub の [wasm-table.html](https://github.com/mdn/webassembly-examples/blob/master/understanding-text-format/wasm-table.html) ([動作例](https://mdn.github.io/webassembly-examples/understanding-text-format/wasm-table.html)) を参照してください。
@@ -531,16 +530,16 @@ JavaScript は関数参照にフルアクセスできるため、 Table オブ�
 ```js
 var importObj = {
   js: {
-    memory : new WebAssembly.Memory({ initial: 1 }),
-    table : new WebAssembly.Table({ initial: 1, element: "anyfunc" })
-  }
+    memory: new WebAssembly.Memory({ initial: 1 }),
+    table: new WebAssembly.Table({ initial: 1, element: "anyfunc" }),
+  },
 };
 
 Promise.all([
-  WebAssembly.instantiateStreaming(fetch('shared0.wasm'), importObj),
-  WebAssembly.instantiateStreaming(fetch('shared1.wasm'), importObj)
-]).then(function(results) {
-  console.log(results[1].instance.exports.doIt());  // prints 42
+  WebAssembly.instantiateStreaming(fetch("shared0.wasm"), importObj),
+  WebAssembly.instantiateStreaming(fetch("shared1.wasm"), importObj),
+]).then(function (results) {
+  console.log(results[1].instance.exports.doIt()); // prints 42
 });
 ```
 
@@ -607,13 +606,17 @@ WebAssembly スレッド ([Firefox 79](/ja/docs/Mozilla/Firefox/Releases/79) 以
 JavaScript API 側では、[`WebAssembly.Memory()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory) コンストラクタの初期化オブジェクトに `shared` プロパティを追加し、 `true` に設定すると共有メモリを作成するようになりました。
 
 ```js
-let memory = new WebAssembly.Memory({initial:10, maximum:100, shared:true});
+let memory = new WebAssembly.Memory({
+  initial: 10,
+  maximum: 100,
+  shared: true,
+});
 ```
 
 メモリーの [`buffer`](/ja/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/buffer) プロパティは `SharedArrayBuffer` を返すようになり、普通の `ArrayBuffer` ではなくなりました。
 
 ```js
-memory.buffer // returns SharedArrayBuffer
+memory.buffer; // returns SharedArrayBuffer
 ```
 
 テキスト形式の上では、 `shared` キーワードを使って、次のように共有メモリーを作成することができます。

--- a/files/ja/webassembly/using_the_javascript_api/index.md
+++ b/files/ja/webassembly/using_the_javascript_api/index.md
@@ -23,21 +23,21 @@ WebAssembly JavaScript API の使用方法と、wasm モジュールを読み込
 2. 次に、 wasm ファイルと同じディレクトリーに `index.html` という名前でシンプルな HTML ファイルを作成しましょう（簡単に利用できるテンプレートを持っていないのであれば、[単純なテンプレート](https://github.com/mdn/webassembly-examples/blob/master/template/template.html)が利用できます）。
 3. ここで、何が起こっているのか理解を助けるために、 wasm モジュールのテキスト表現を見てみましょう（[WebAssembly 形式から wasm への変換](/ja/docs/WebAssembly/Text_format_to_wasm)も参照してください）。
 
-    ```wasm
-    (module
-      (func $i (import "imports" "imported_func") (param i32))
-      (func (export "exported_func")
-        i32.const 42
-        call $i))
-    ```
+   ```wasm
+   (module
+     (func $i (import "imports" "imported_func") (param i32))
+     (func (export "exported_func")
+       i32.const 42
+       call $i))
+   ```
 
 4. 2 行目に 2 階層の名前空間を持つインポートの宣言があります。 — 内部関数 `$i` は `imports.imported_func` からインポートされています。wasm モジュールにインポートするオブジェクトを記述するときに、この 2 階層の名前空間を JavaScript に反映させる必要があります。 `<script></script>` 要素を HTML 内に作成して、次のコードを追加してください。
 
-    ```js
-    const importObject = {
-      imports: { imported_func: (arg) => console.log(arg) }
-    };
-    ```
+   ```js
+   const importObject = {
+     imports: { imported_func: (arg) => console.log(arg) },
+   };
+   ```
 
 ### WebAssembly モジュールをストリーミングする
 
@@ -49,7 +49,7 @@ Firefox 58 の新機能として、 WebAssembly モジュールを基礎とな�
 
 ```js
 WebAssembly.instantiateStreaming(fetch("simple.wasm"), importObject).then(
-  (obj) => obj.instance.exports.exported_func()
+  (obj) => obj.instance.exports.exported_func(),
 );
 ```
 
@@ -95,23 +95,23 @@ JavaScript では、Memory インスタンスはリサイズ可能な [`ArrayBuf
 1. もう 1 つのシンプルな HTML ページを（[単純なテンプレート](https://github.com/mdn/webassembly-examples/blob/master/template/template.html)をコピーして）作成し、 `memory.html` という名前を付けてください。このページに `<script></script>` 要素を追加してください。
 2. メモリーインスタンスを作成するために、次の行をスクリプトに追加します。
 
-    ```js
-    const memory = new WebAssembly.Memory({ initial: 10, maximum: 100 });
-    ```
+   ```js
+   const memory = new WebAssembly.Memory({ initial: 10, maximum: 100 });
+   ```
 
-    `initial` と `maximum` の単位は WebAssembly ページです。これらは 64KB に固定されています。上の例では、メモリーインスタンスは初期サイズが 640KB、最大サイズが 6.4MB であることを意味しています。
+   `initial` と `maximum` の単位は WebAssembly ページです。これらは 64KB に固定されています。上の例では、メモリーインスタンスは初期サイズが 640KB、最大サイズが 6.4MB であることを意味しています。
 
-    WebAssembly メモリーが持つバイト列は ArrayBuffer として buffer ゲッター/セッターから公開されています。例えば、線形メモリーの先頭ワードに直接、 42 を書き込むには次のようにします。
+   WebAssembly メモリーが持つバイト列は ArrayBuffer として buffer ゲッター/セッターから公開されています。例えば、線形メモリーの先頭ワードに直接、 42 を書き込むには次のようにします。
 
-    ```js
-    new Uint32Array(memory.buffer)[0] = 42;
-    ```
+   ```js
+   new Uint32Array(memory.buffer)[0] = 42;
+   ```
 
-    その後で同じ値を返すことができます。
+   その後で同じ値を返すことができます。
 
-    ```js
-    new Uint32Array(memory.buffer)[0]
-    ```
+   ```js
+   new Uint32Array(memory.buffer)[0];
+   ```
 
 3. デモで試してみましょう。これまでに追加した内容を保存してブラウザーで読み込んだ後、JavaScript コンソールで上の 2 行を入力してみてください。
 
@@ -135,30 +135,30 @@ Memory インスタンスの作成時に最大値が指定していて、この�
 
 1. `memory.wasm` のローカルコピーを以前と同じディレクトリーに作成します。
 
-    > **メモ:** モジュールのテキスト表現は [memory.wat](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/memory.wat) を参照してください。
+   > **メモ:** モジュールのテキスト表現は [memory.wat](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/memory.wat) を参照してください。
 
 2. `memory.html` サンプルファイルに戻って、以前と同じように wasm モジュールを読み取り、コンパイル、インスタンス化します。以下のものをスクリプトの最後に追加してください。
 
-    ```js
-    WebAssembly.instantiateStreaming(fetch("memory.wasm"), {
-      js: { mem: memory },
-    }).then((results) => {
-      // ここにコードを追加
-    });
-    ```
+   ```js
+   WebAssembly.instantiateStreaming(fetch("memory.wasm"), {
+     js: { mem: memory },
+   }).then((results) => {
+     // ここにコードを追加
+   });
+   ```
 
 3. このモジュールはモジュール内部のメモリーをエクスポートします。 instance という名前でモジュールの Instance が取得され、エクスポートされた関数 `accumulate()` を使用してモジュールの線形メモリー (`mem`) に直接入力された配列を合計する事ができます。指定された場所に、次のコードを追加してみましょう。
 
-    ```js
-    const i32 = new Uint32Array(memory.buffer);
+   ```js
+   const i32 = new Uint32Array(memory.buffer);
 
-    for (let i = 0; i < 10; i++) {
-      i32[i] = i;
-    }
+   for (let i = 0; i < 10; i++) {
+     i32[i] = i;
+   }
 
-    const sum = results.instance.exports.accumulate(0, 10);
-    console.log(sum);
-    ```
+   const sum = results.instance.exports.accumulate(0, 10);
+   console.log(sum);
+   ```
 
 Memory オブジェクト自体でなく、Memory オブジェクトの buffer ([`Memory.prototype.buffer`](/ja/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/buffer)) から {{jsxref("Uint32Array")}} ビューを作成していることに注意してください。
 
@@ -171,7 +171,7 @@ Memory オブジェクト自体でなく、Memory オブジェクトの buffer (
 
 ## テーブル
 
-WebAssembly Table は JavaScript と WebAssembly コードの両方でアクセスできるリサイズ可能な [参照](https://en.wikipedia.org/wiki/Reference_(computer_science)) の型付き配列です。Memory はリサイズ可能な生のバイト列を提供しますが、参照はエンジンに保証された値（このバイト列は安全性、移植性、安定性の理由からコンテンツによって直接読み書きしてはいけない）であるため、参照を格納するために使用することは安全ではありません。
+WebAssembly Table は JavaScript と WebAssembly コードの両方でアクセスできるリサイズ可能な [参照](<https://en.wikipedia.org/wiki/Reference_(computer_science)>) の型付き配列です。Memory はリサイズ可能な生のバイト列を提供しますが、参照はエンジンに保証された値（このバイト列は安全性、移植性、安定性の理由からコンテンツによって直接読み書きしてはいけない）であるため、参照を格納するために使用することは安全ではありません。
 
 テーブルは要素の型を持ち、テーブルに格納できる参照の型が制限されます。WebAssembly の現バージョンでは WebAssembly コード内で必要な参照の型は関数型の1つだけです。そして、これが唯一の正しい要素の型となります。将来のバージョンでは、さらに多くの要素の型が追加される予定です。
 
@@ -187,24 +187,24 @@ WebAssembly Table は JavaScript と WebAssembly コードの両方でアクセ�
 
 1. `table.wasm` をローカルの新しいディレクトリーにコピーします。
 
-    > **メモ:** このモジュールのテキスト表現は [table.wat](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/table.wat) を参照してください。
+   > **メモ:** このモジュールのテキスト表現は [table.wat](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/table.wat) を参照してください。
 
 2. [HTML template](https://github.com/mdn/webassembly-examples/blob/master/template/template.html) を `table.html` という名前で同じディレクトリーにコピーします。
 3. 前と同じように、wasm モジュールを読み取り、コンパイル、インスタンス化します。次のコードを HTML の body の末尾の {{htmlelement("script")}} 要素に追加してください。
 
-    ```js
-    WebAssembly.instantiateStreaming(fetch("table.wasm")).then((results) => {
-      // add code here
-    });
-    ```
+   ```js
+   WebAssembly.instantiateStreaming(fetch("table.wasm")).then((results) => {
+     // add code here
+   });
+   ```
 
 4. 今度はテーブル内のデータにアクセスしてみましょう。コードの指定された場所に次の行を追加してください。
 
-    ```js
-    const tbl = results.instance.exports.tbl;
-    console.log(tbl.get(0)()); // 13
-    console.log(tbl.get(1)()); // 42
-    ```
+   ```js
+   const tbl = results.instance.exports.tbl;
+   console.log(tbl.get(0)()); // 13
+   console.log(tbl.get(1)()); // 42
+   ```
 
 このコードはテーブルに格納されている各関数参照に順番にアクセスし、内包した値をコンソールに書き出すためにインスタンス化します。 [`Table.prototype.get()`](/ja/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/get) で各関数参照を取得した後、関数を実行するためには括弧を追加することに注意してください。
 
@@ -237,7 +237,10 @@ const global = new WebAssembly.Global({ value: "i32", mutable: true }, 0);
 const output = document.getElementById("output");
 
 function assertEq(msg, got, expected) {
-  const result = got === expected ? `SUCCESS! Got: ${got}<br>` : `FAIL!<br>Got: ${got}<br>Expected: ${expected}<br>`;
+  const result =
+    got === expected
+      ? `SUCCESS! Got: ${got}<br>`
+      : `FAIL!<br>Got: ${got}<br>Expected: ${expected}<br>`;
   output.innerHTML += `Testing ${msg}: ${result}`;
 }
 
@@ -250,17 +253,17 @@ WebAssembly.instantiateStreaming(fetch("global.wasm"), { js: { global } }).then(
     assertEq(
       "getting initial value from wasm",
       instance.exports.getGlobal(),
-      0
+      0,
     );
     global.value = 42;
     assertEq(
       "getting JS-updated value from wasm",
       instance.exports.getGlobal(),
-      42
+      42,
     );
     instance.exports.incGlobal();
     assertEq("getting wasm-updated value from JS", global.value, 43);
-  }
+  },
 );
 ```
 


### PR DESCRIPTION
This PR formats the `/webassembly` folder of the Japanese locale using Prettier.
