### PR TITLE
es: add DELETE HTTP verb translation

### DIFF
--- a/files/es/web/http/methods/delete/index.md
+++ b/files/es/web/http/methods/delete/index.md
@@ -13,11 +13,11 @@ El método HTTP `DELETE` elimina el recurso especificado.
   <tbody>
     <tr>
       <th scope="row">Petición con cuerpo</th>
-      <td>Puede</td>
+      <td>Posible</td>
     </tr>
     <tr>
       <th scope="row">Respuesta válida con cuerpo</th>
-      <td>Puede</td>
+      <td>Posible</td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Seguro")}}</th>
@@ -25,7 +25,7 @@ El método HTTP `DELETE` elimina el recurso especificado.
     </tr>
     <tr>
       <th scope="row">{{Glossary("Idempotent")}}</th>
-      <td>Yes</td>
+      <td>Si</td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Cacheable")}}</th>
@@ -33,7 +33,7 @@ El método HTTP `DELETE` elimina el recurso especificado.
     </tr>
     <tr>
       <th scope="row">
-        Permitido en <a href="/es/docs/Learn/Forms">HTML forms</a>
+        Permitido en <a href="/es/docs/Learn/Forms">formularios</a>
       </th>
       <td>No</td>
     </tr>

--- a/files/es/web/http/methods/delete/index.md
+++ b/files/es/web/http/methods/delete/index.md
@@ -1,0 +1,90 @@
+---
+title: DELETE
+slug: Web/HTTP/Methods/DELETE
+l10n:
+  sourceCommit: 0880a90f3811475d78bc4b2c344eb4146f25f66c
+---
+
+{{HTTPSidebar}}
+
+El método HTTP `DELETE` elimina el recurso especificado.
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Petición con cuerpo</th>
+      <td>Puede</td>
+    </tr>
+    <tr>
+      <th scope="row">Respuesta válida con cuerpo</th>
+      <td>Puede</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Seguro")}}</th>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Idempotent")}}</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Cacheable")}}</th>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th scope="row">
+        Permitido en <a href="/es/docs/Learn/Forms">HTML forms</a>
+      </th>
+      <td>No</td>
+    </tr>
+  </tbody>
+</table>
+
+## Sintaxis
+
+```http
+DELETE /archivo.html HTTP/1.1
+```
+
+## Ejemplo
+
+### Petición
+
+```http
+DELETE /archivo.html HTTP/1.1
+Host: ejemplo.com
+```
+
+### Respuestas
+
+Si se aplica correctamente el método `DELETE`, hay varios códigos de estado de respuesta posibles:
+
+- Un código de estado {{HTTPStatus("202")}} (`Accepted`) si la acción ha sido
+  exitosa pero aún no se ha ejecutado.
+- Un código de estado {{HTTPStatus("204")}} (`No Content`) si la acción se ha
+  ejecutado y no se debe proporcionar más información.
+- Un código de estado {{HTTPStatus("200")}} (`OK`) si la acción se ha ejecutado
+  y el mensaje de respuesta incluye una representación que describe el estado.
+
+```http
+HTTP/1.1 200 OK
+Date: Wed, 21 Oct 2015 07:28:00 GMT
+
+<html>
+  <body>
+    <h1>Archivo eliminado.</h1>
+  </body>
+</html>
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- HTTP status: {{HTTPStatus("200")}}, {{HTTPStatus("202")}}, {{HTTPStatus("204")}}

--- a/files/es/web/http/methods/delete/index.md
+++ b/files/es/web/http/methods/delete/index.md
@@ -77,14 +77,14 @@ Date: Wed, 21 Oct 2015 07:28:00 GMT
 </html>
 ```
 
-## Specifications
+## Especificaciones
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibilidad con navegadores
 
 {{Compat}}
 
-## See also
+## Véase también
 
 - HTTP status: {{HTTPStatus("200")}}, {{HTTPStatus("202")}}, {{HTTPStatus("204")}}

--- a/files/es/web/http/methods/delete/index.md
+++ b/files/es/web/http/methods/delete/index.md
@@ -7,33 +7,33 @@ l10n:
 
 {{HTTPSidebar}}
 
-El método HTTP `DELETE` elimina el recurso especificado.
+El **método de solicitud HTTP `DELETE`** elimina el recurso especificado.
 
 <table class="properties">
   <tbody>
     <tr>
       <th scope="row">Petición con cuerpo</th>
-      <td>Posible</td>
+      <td>Puede</td>
     </tr>
     <tr>
       <th scope="row">Respuesta válida con cuerpo</th>
-      <td>Posible</td>
+      <td>Puede</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Seguro")}}</th>
+      <th scope="row">{{Glossary("Safe/HTTP", "Seguro")}}</th>
       <td>No</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Idempotent")}}</th>
+      <th scope="row">{{Glossary("Idempotent","Idempotente")}}</th>
       <td>Si</td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Cacheable")}}</th>
+      <th scope="row">{{Glossary("Cacheable","Se puede almacenar en Cache")}}</th>
       <td>No</td>
     </tr>
     <tr>
       <th scope="row">
-        Permitido en <a href="/es/docs/Learn/Forms">formularios</a>
+        Permitido en <a href="/es/docs/Learn/Forms">formularios HTML</a>
       </th>
       <td>No</td>
     </tr>
@@ -43,7 +43,7 @@ El método HTTP `DELETE` elimina el recurso especificado.
 ## Sintaxis
 
 ```http
-DELETE /archivo.html HTTP/1.1
+DELETE /file.html HTTP/1.1
 ```
 
 ## Ejemplo
@@ -51,8 +51,8 @@ DELETE /archivo.html HTTP/1.1
 ### Petición
 
 ```http
-DELETE /archivo.html HTTP/1.1
-Host: ejemplo.com
+DELETE /file.html HTTP/1.1
+Host: example.com
 ```
 
 ### Respuestas
@@ -87,4 +87,4 @@ Date: Wed, 21 Oct 2015 07:28:00 GMT
 
 ## Véase también
 
-- HTTP status: {{HTTPStatus("200")}}, {{HTTPStatus("202")}}, {{HTTPStatus("204")}}
+- Estado HTTP: {{HTTPStatus("200")}}, {{HTTPStatus("202")}}, {{HTTPStatus("204")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Agregar traducción para [https://developer.mozilla.org/es/docs/Web/HTTP/Methods/DELETE](https://developer.mozilla.org/es/docs/Web/HTTP/Methods/DELETE)

### Motivation

Actualizar documentación en Español

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Relates to [#14024](https://github.com/mdn/translated-content/issues/14024)
