### PR TITLE
Markdownlint config: use named rules vs. numerical rules

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,44 +1,46 @@
+// This file defines our configuration for Markdownlint. See
+// https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+// for more details on each rule.
+
 {
   "config": {
     "default": true,
-    // MD001 - Heading levels should only increment by one level at a time.
-    // -> Disabled, as some callouts include headings.
-    "MD001": false,
-    "MD004": {
+    // Disabled, as some callouts include headings.
+    "header-increment": false,
+    "ul-style": {
       "style": "dash"
     },
-    "MD007": {
+    "ul-indent": {
       "indent": 2
     },
-    "MD010": {
+    "no-hard-tabs": {
       "spaces_per_tab": 2
     },
-    "MD013": false,
-    "MD024": false,
+    "line-length": false,
+    "no-duplicate-header": false,
     // XXX Replace with the following when ready:
-    // "MD024": {
+    // "no-duplicate-header": {
     //   "allow_different_nesting": true
     // },
-    "MD025": {
+    "single-title": {
       "front_matter_title": "^\\s*title\\s*[:=]"
     },
-    "MD026": false,
+    "no-trailing-punctuation": false,
     // XXX Replace with the following when ready:
-    // "MD026": {
+    // "no-trailing-punctuation": {
     //   "punctuation": ".,;:"
     // },
     // Consecutive Notes/Callouts currently don't conform with this rule
-    "MD028": false,
+    "no-blanks-blockquote": false,
     // Force ordered numbering to catch accidental list ending from indenting
-    "MD029": {
+    "ol-prefix": {
       "style": "ordered"
     },
-    "MD033": {
+    "no-inline-html": {
       "allowed_elements": [
         "a",
         "abbr",
         "annotation",
-        "base",
         "br",
         "caption",
         "code",
@@ -46,7 +48,6 @@
         "colgroup",
         "dd",
         "details",
-        "dfn",
         "div",
         "dl",
         "dt",
@@ -88,6 +89,7 @@
         "ol",
         "p",
         "pre",
+        "q",
         "section",
         "semantics",
         "strong",
@@ -103,45 +105,47 @@
         "tr",
         "ul",
         "var",
+        "dfn", // XXX Still used in some translated content
         "ruby", // Used in some Korean documents
         "rp", // Used in some Korean documents
         "rt", // Used in some Korean documents
         "i", // French translations use this for English literal text
-        "q", // French translations use this for English literal text
-        "h2", // Not always converted currently because of live samples using English IDs
-        "h3", // Not always converted currently because of live samples using English IDs
-        "h6" // Not always converted currently because of live samples using English IDs
+        "h2", // XXX Not always converted currently because of live samples using English IDs
+        "h3", // XXX Not always converted currently because of live samples using English IDs
+        "h6" // XXX Not always converted currently because of live samples using English IDs
       ]
     },
-    "MD034": false,
-    // XXX Fixed upstream, enable rule when fixed here
-    "MD036": false,
+    "no-bare-urls": false,
+    // XXX Fixed upstream, remove next line when fixed here
+    "no-emphasis-as-header": false,
     // Produces too many false positives
-    "MD037": false,
-    "MD040": false,
+    "no-space-in-emphasis": false,
+    "fenced-code-language": false,
     // See https://github.com/mdn/content/pull/20026, as macros currently break this
-    "MD042": false,
-    // XXX Fixed upstream, enable rule when fixed here
-    "MD045": false,
-    "MD046": {
+    "no-empty-links": false,
+    // XXX Fixed upstream, remove next line when fixed here
+    "no-alt-text": false,
+    "code-block-style": {
       "style": "fenced"
     },
-    "MD049": false,
+    "emphasis-style": false,
     // XXX Replace with the following when ready:
-    // "MD049": {
+    // "emphasis-style": {
     //   "style": "underscore"
     // },
-    "MD050": {
+    "strong-style": {
       "style": "asterisk"
     },
-    // MD051 - Link fragments should be valid.
-    // -> Disabled, as yari generates link fragments by replacing spaces with underscores, not dashes.
-    "MD051": false,
-    // Incompatible with brackets in macros like MD042
-    "MD052": false,
+    // Disabled, as yari generates link fragments by replacing spaces with underscores, not dashes.
+    "link-fragments": false,
+    // XXX Fixed upstream, remove next line when fixed here
+    "reference-links-images": false,
+
+    // https://github.com/OnkarRuikar/markdownlint-rule-search-replace
     "search-replace": {
       "rules": [
         // XXX Many instances still found in translated content
+        // XXX Need to disable this for zh-cn due to grammatical accuracy
         // {
         //   "name": "curly-double-quotes",
         //   "message": "Don't use curly double quotes",
@@ -164,6 +168,7 @@
           "searchScope": "all"
         },
         // XXX Many instances still found in translated content
+        // XXX zh-cn/zh-tw prefers em-dash instead
         // {
         //   "name": "m-dash",
         //   "message": "Don't use '--'. Use m-dash — instead",


### PR DESCRIPTION
This PR updates the Markdownlint config to use named rules in place of the numerical rules like we currently have. This makes it MUCH easier to immediately understand what each rule means without having to refer to a separate document to translate what each rule number means.

Additionally, this adds a few extra comments, one at the top to point to the Markdownlint version we're using, and a link to the repository for the custom search-replace rule we're using.

Finally, this also performs a small bit of synchronization between upstream's config and our config.

_Please do not merge unless https://github.com/mdn/content/pull/28069 is approved and merged._
