### PR TITLE
ja: Remove strange third-party link from Firefox v36 release notes

### DIFF
--- a/files/ja/mozilla/firefox/releases/36/index.md
+++ b/files/ja/mozilla/firefox/releases/36/index.md
@@ -138,7 +138,7 @@ _変更なし。_
 ### JavaScript コードモジュール
 
 - `PromiseUtils.resolveOrTimeout` を実装しました ([Firefox バグ 1080466](https://bugzil.la/1080466))。
-- [PromiseUtils.defer](<https://contest-server.cs.uchicago.edu/ref/JavaScript/developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/PromiseUtils.html#defer()>) (`Promise.defer()` を置き換えるもの) を実装しました ([Firefox バグ 1093021](https://bugzil.la/1093021))。
+- `PromiseUtils.defer` (`Promise.defer()` を置き換えるもの) を実装しました ([Firefox バグ 1093021](https://bugzil.la/1093021))。
 
 ### インターフェイス
 


### PR DESCRIPTION
This PR removes a strange link to a third-party mirror of pre-Yari MDN from the Firefox v36 release notes of the Japanese locale.

Note: a PR has been opened to perform the same changes upstream (https://github.com/mdn/content/pull/28084).  This should not be merged unless the other PR is approved.
