### PR TITLE
Update curl example in "Command line crash course"

### DIFF
--- a/files/fr/learn/tools_and_testing/understanding_client-side_tools/command_line/index.md
+++ b/files/fr/learn/tools_and_testing/understanding_client-side_tools/command_line/index.md
@@ -281,7 +281,7 @@ En fait, cette URL est celle de l'ancien emplacement de la page. Lorsque vous l'
 Par conséquent, si vous utilisez curl pour faire une requête à `https://developer.mozilla.org/docs/Web/API/fetch`, vous n'aurez pas de résultat. Essayez :
 
 ```bash
-curl https://developer.mozilla.org/en-US/docs/Web/API/fetch
+curl https://developer.mozilla.org/docs/Web/API/fetch
 ```
 
 Nous devons dire explicitement à `curl` de suivre les redirections en utilisant l'option `-L`.

--- a/files/fr/learn/tools_and_testing/understanding_client-side_tools/command_line/index.md
+++ b/files/fr/learn/tools_and_testing/understanding_client-side_tools/command_line/index.md
@@ -278,7 +278,7 @@ Occupons-nous maintenant de quelque chose d'un peu plus compliqué. Nous allons 
 
 En fait, cette URL est celle de l'ancien emplacement de la page. Lorsque vous l'entrez dans un nouvel onglet de votre navigateur, vous êtes (finalement) redirigé sur [https://developer.mozilla.org/fr/docs/Web/API/WindowOrWorkerGlobalScope/fetch](/fr/docs/Web/API/WindowOrWorkerGlobalScope/fetch).
 
-Par conséquent, si vous utilisez curl pour faire une requête à `https://developer.mozilla.org/docs/Web/API/fetch`, vous n'aurez pas de résultat. Essayez :
+Par conséquent, si vous utilisez curl pour faire une requête à `https://developer.mozilla.org/fr/docs/Web/API/fetch`, vous n'aurez pas de résultat. Essayez :
 
 ```bash
 curl https://developer.mozilla.org/fr/docs/Web/API/fetch
@@ -291,7 +291,7 @@ Examinons également les en-têtes retournées par `developer.mozilla.org` en ut
 Essayez maintenant la ligne suivante, et vous allez constater qu'il y a en fait trois redirections avant d'atteindre la page finale :
 
 ```bash
-curl https://developer.mozilla.org/docs/Web/API/fetch -L -I | grep location
+curl https://developer.mozilla.org/fr/docs/Web/API/fetch -L -I | grep location
 ```
 
 Votre sortie devrait ressembler à ceci (`curl` va d'abord afficher des compteurs et autres informations de téléchargement) :
@@ -308,7 +308,7 @@ Bien que ce résultat soit artificiel, nous pourrions le pousser un peu plus loi
 Essayez de lancer cette commande :
 
 ```bash
-curl https://developer.mozilla.org/docs/Web/API/fetch -L -I | grep location | awk '{ print "https://developer.mozilla.org" $2 }'
+curl https://developer.mozilla.org/fr/docs/Web/API/fetch -L -I | grep location | awk '{ print "https://developer.mozilla.org" $2 }'
 ```
 
 Votre sortie finale devrait ressembler à ceci :

--- a/files/fr/learn/tools_and_testing/understanding_client-side_tools/command_line/index.md
+++ b/files/fr/learn/tools_and_testing/understanding_client-side_tools/command_line/index.md
@@ -278,10 +278,10 @@ Occupons-nous maintenant de quelque chose d'un peu plus compliqué. Nous allons 
 
 En fait, cette URL est celle de l'ancien emplacement de la page. Lorsque vous l'entrez dans un nouvel onglet de votre navigateur, vous êtes (finalement) redirigé sur [https://developer.mozilla.org/fr/docs/Web/API/WindowOrWorkerGlobalScope/fetch](/fr/docs/Web/API/WindowOrWorkerGlobalScope/fetch).
 
-Par conséquent, si vous utilisez curl pour faire une requête à `https://developer.mozilla.org/fr/docs/Web/API/fetch`, vous n'aurez pas de résultat. Essayez :
+Par conséquent, si vous utilisez curl pour faire une requête à `https://developer.mozilla.org/docs/Web/API/fetch`, vous n'aurez pas de résultat. Essayez :
 
 ```bash
-curl https://developer.mozilla.org/fr/docs/Web/API/fetch
+curl https://developer.mozilla.org/en-US/docs/Web/API/fetch
 ```
 
 Nous devons dire explicitement à `curl` de suivre les redirections en utilisant l'option `-L`.
@@ -291,16 +291,16 @@ Examinons également les en-têtes retournées par `developer.mozilla.org` en ut
 Essayez maintenant la ligne suivante, et vous allez constater qu'il y a en fait trois redirections avant d'atteindre la page finale :
 
 ```bash
-curl https://developer.mozilla.org/fr/docs/Web/API/fetch -L -I | grep location
+curl https://developer.mozilla.org/docs/Web/API/fetch -L -I | grep location
 ```
 
 Votre sortie devrait ressembler à ceci (`curl` va d'abord afficher des compteurs et autres informations de téléchargement) :
 
 ```bash
-location: /fr/docs/Web/API/fetch
-location: /fr/docs/Web/API/GlobalFetch/GlobalFetch.fetch()
-location: /fr/docs/Web/API/GlobalFetch/fetch
-location: /fr/docs/Web/API/WindowOrWorkerGlobalScope/fetch
+location: /en-US/docs/Web/API/fetch
+location: /en-US/docs/Web/API/GlobalFetch/GlobalFetch.fetch()
+location: /en-US/docs/Web/API/GlobalFetch/fetch
+location: /en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch
 ```
 
 Bien que ce résultat soit artificiel, nous pourrions le pousser un peu plus loin et remplacer `location:` par le nom de domaine, de façon à avoir des URLs complètes. Pour cela, nous allons ajouter `awk` à notre formule (il s'agit d'un langage de programmation tout comme JavaScript, Ruby ou Python, mais beaucoup plus ancien !).

--- a/files/ja/learn/tools_and_testing/understanding_client-side_tools/command_line/index.md
+++ b/files/ja/learn/tools_and_testing/understanding_client-side_tools/command_line/index.md
@@ -264,11 +264,11 @@ ls | wc -l
 
 もう少し複雑なことを見てみましょう。
 
-最初に、MDN の「fetch」ページ `https://developer.mozilla.org/ja/docs/Web/API/WindowOrWorkerGlobalScope/fetch` を `curl` コマンド (URL からコンテンツを要求するために使用できる) を使用してコンテンツを取得します。
+最初に、MDN の「fetch」ページ `https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch` を `curl` コマンド (URL からコンテンツを要求するために使用できる) を使用してコンテンツを取得します。
 やってみよう:
 
 ```bash
-curl https://developer.mozilla.org/ja/docs/Web/API/WindowOrWorkerGlobalScope/fetch
+curl https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch
 ```
 
 ページが ([/Web/API/fetch](/en-US/docs/Web/API/fetch) に) リダイレクトされているため、出力は得られません。
@@ -279,7 +279,7 @@ curl https://developer.mozilla.org/ja/docs/Web/API/WindowOrWorkerGlobalScope/fet
 以下を実行してみてください (最終ページに到達する前にリダイレクトが 1 つだけあることがわかります)。
 
 ```bash
-curl https://developer.mozilla.org/ja/docs/Web/API/WindowOrWorkerGlobalScope/fetch -L -I | grep location
+curl https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch -L -I | grep location
 ```
 
 出力は次のようになります (`curl` は最初にいくつかのダウンロードカウンターなどを出力します)。
@@ -294,13 +294,13 @@ location: /en-US/docs/Web/API/fetch
 これを実行してみてください:
 
 ```bash
-curl https://developer.mozilla.org/ja/docs/Web/API/WindowOrWorkerGlobalScope/fetch -L -I | grep location | awk '{ print "https://developer.mozilla.org" $2 }'
+curl https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch -L -I | grep location | awk '{ print "https://developer.mozilla.org" $2 }'
 ```
 
 最終的な出力は次のようになります:
 
 ```bash
-https://developer.mozilla.org/ja/docs/Web/API/fetch
+https://developer.mozilla.org/en-US/docs/Web/API/fetch
 ```
 
 これらのコマンドを組み合わせることで、`/docs/Web/API/WindowOrWorkerGlobalScope/fetch` URL をリクエストしたときに Mozilla サーバーがリダイレクトしている完全な URL を表示するように出力をカスタマイズしました。

--- a/files/ja/learn/tools_and_testing/understanding_client-side_tools/command_line/index.md
+++ b/files/ja/learn/tools_and_testing/understanding_client-side_tools/command_line/index.md
@@ -264,11 +264,11 @@ ls | wc -l
 
 もう少し複雑なことを見てみましょう。
 
-最初に、MDN の「fetch」ページ `https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch` を `curl` コマンド (URL からコンテンツを要求するために使用できる) を使用してコンテンツを取得します。
+最初に、MDN の「fetch」ページ `https://developer.mozilla.org/ja/docs/Web/API/WindowOrWorkerGlobalScope/fetch` を `curl` コマンド (URL からコンテンツを要求するために使用できる) を使用してコンテンツを取得します。
 やってみよう:
 
 ```bash
-curl https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch
+curl https://developer.mozilla.org/ja/docs/Web/API/WindowOrWorkerGlobalScope/fetch
 ```
 
 ページが ([/Web/API/fetch](/en-US/docs/Web/API/fetch) に) リダイレクトされているため、出力は得られません。
@@ -279,7 +279,7 @@ curl https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/
 以下を実行してみてください (最終ページに到達する前にリダイレクトが 1 つだけあることがわかります)。
 
 ```bash
-curl https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch -L -I | grep location
+curl https://developer.mozilla.org/ja/docs/Web/API/WindowOrWorkerGlobalScope/fetch -L -I | grep location
 ```
 
 出力は次のようになります (`curl` は最初にいくつかのダウンロードカウンターなどを出力します)。
@@ -294,13 +294,13 @@ location: /en-US/docs/Web/API/fetch
 これを実行してみてください:
 
 ```bash
-curl https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch -L -I | grep location | awk '{ print "https://developer.mozilla.org" $2 }'
+curl https://developer.mozilla.org/ja/docs/Web/API/WindowOrWorkerGlobalScope/fetch -L -I | grep location | awk '{ print "https://developer.mozilla.org" $2 }'
 ```
 
 最終的な出力は次のようになります:
 
 ```bash
-https://developer.mozilla.org/en-US/docs/Web/API/fetch
+https://developer.mozilla.org/ja/docs/Web/API/fetch
 ```
 
 これらのコマンドを組み合わせることで、`/docs/Web/API/WindowOrWorkerGlobalScope/fetch` URL をリクエストしたときに Mozilla サーバーがリダイレクトしている完全な URL を表示するように出力をカスタマイズしました。

--- a/files/zh-cn/learn/tools_and_testing/understanding_client-side_tools/command_line/index.md
+++ b/files/zh-cn/learn/tools_and_testing/understanding_client-side_tools/command_line/index.md
@@ -272,7 +272,7 @@ ls | wc -l
 
 但是，这个 URL 是页面的旧位置。如果您在一个新的浏览器标签中输入它，您将 (最终) 被重定向到[https://developer.mozilla.org/en-US/docs/Web/API/fetch](/zh-CN/docs/Web/API/fetch).
 
-因此，如果您使用 curl 请求 `https://developer.mozilla.org/docs/Web/API/fetch`，则不会得到输出。现在就试试：
+因此，如果您使用 curl 请求 `https://developer.mozilla.org/zh-CN/docs/Web/API/fetch`，则不会得到输出。现在就试试：
 
 ```bash
 curl https://developer.mozilla.org/zh-CN/docs/Web/API/fetch
@@ -285,13 +285,13 @@ curl https://developer.mozilla.org/zh-CN/docs/Web/API/fetch
 尝试运行以下代码，您将看到在到达最终页面之前，实际上发生了三次重定向
 
 ```bash
-curl https://developer.mozilla.org/docs/Web/API/fetch -L -I | grep location
+curl https://developer.mozilla.org/zh-CN/docs/Web/API/fetch -L -I | grep location
 ```
 
 输出应该是这样的 (`curl` 首先会输出一些下载计数器之类的东西):
 
 ```bash
-location: /en-US/docs/Web/API/fetch
+location: /zh-CN/docs/Web/API/fetch
 ```
 
 尽管有些做作，我们可以把这个结果做得更深入一点，并变换 `location:` 行内容，将基本的起点添加到每个起点的开始，这样我们就可以打印出完整的 url。为此，我们将在混合中添加 awk(它是一种类似于 JavaScript、Ruby 或 Python 的编程语言，只是要老得多 !)
@@ -299,13 +299,13 @@ location: /en-US/docs/Web/API/fetch
 尝试运行这个：
 
 ```bash
-curl https://developer.mozilla.org/docs/Web/API/fetch -L -I | grep location | awk '{ print "https://developer.mozilla.org" $2 }'
+curl https://developer.mozilla.org/zh-CN/docs/Web/API/fetch -L -I | grep location | awk '{ print "https://developer.mozilla.org" $2 }'
 ```
 
 最终的输出应该是这样的
 
 ```bash
-https://developer.mozilla.org/en-US/docs/Web/API/fetch
+https://developer.mozilla.org/zh-CN/docs/Web/API/fetch
 ```
 
 通过组合这些命令，我们定制了输出以显示完整的 url，当我们请求时，Mozilla 服务器将通过这些 url 重定向`/docs/Web/API/fetch` URL.了解您的系统将在未来几年证明是有用的，您将了解这些单一服务工具是如何工作的，以及它们如何成为您解决小众问题的工具库的一部分。

--- a/files/zh-cn/learn/tools_and_testing/understanding_client-side_tools/command_line/index.md
+++ b/files/zh-cn/learn/tools_and_testing/understanding_client-side_tools/command_line/index.md
@@ -272,10 +272,10 @@ ls | wc -l
 
 但是，这个 URL 是页面的旧位置。如果您在一个新的浏览器标签中输入它，您将 (最终) 被重定向到[https://developer.mozilla.org/en-US/docs/Web/API/fetch](/zh-CN/docs/Web/API/fetch).
 
-因此，如果您使用 curl 请求 `https://developer.mozilla.org/zh-CN/docs/Web/API/fetch`，则不会得到输出。现在就试试：
+因此，如果您使用 curl 请求 `https://developer.mozilla.org/docs/Web/API/fetch`，则不会得到输出。现在就试试：
 
 ```bash
-curl https://developer.mozilla.org/zh-CN/docs/Web/API/fetch
+curl https://developer.mozilla.org/docs/Web/API/fetch
 ```
 
 我们想精确的告诉 `curl` 遵循重定向使用`-L` 标签。
@@ -285,13 +285,13 @@ curl https://developer.mozilla.org/zh-CN/docs/Web/API/fetch
 尝试运行以下代码，您将看到在到达最终页面之前，实际上发生了三次重定向
 
 ```bash
-curl https://developer.mozilla.org/zh-CN/docs/Web/API/fetch -L -I | grep location
+curl https://developer.mozilla.org/docs/Web/API/fetch -L -I | grep location
 ```
 
 输出应该是这样的 (`curl` 首先会输出一些下载计数器之类的东西):
 
 ```bash
-location: /zh-CN/docs/Web/API/fetch
+location: /en-US/docs/Web/API/fetch
 ```
 
 尽管有些做作，我们可以把这个结果做得更深入一点，并变换 `location:` 行内容，将基本的起点添加到每个起点的开始，这样我们就可以打印出完整的 url。为此，我们将在混合中添加 awk(它是一种类似于 JavaScript、Ruby 或 Python 的编程语言，只是要老得多 !)
@@ -299,13 +299,13 @@ location: /zh-CN/docs/Web/API/fetch
 尝试运行这个：
 
 ```bash
-curl https://developer.mozilla.org/zh-CN/docs/Web/API/fetch -L -I | grep location | awk '{ print "https://developer.mozilla.org" $2 }'
+curl https://developer.mozilla.org/docs/Web/API/fetch -L -I | grep location | awk '{ print "https://developer.mozilla.org" $2 }'
 ```
 
 最终的输出应该是这样的
 
 ```bash
-https://developer.mozilla.org/zh-CN/docs/Web/API/fetch
+https://developer.mozilla.org/en-US/docs/Web/API/fetch
 ```
 
 通过组合这些命令，我们定制了输出以显示完整的 url，当我们请求时，Mozilla 服务器将通过这些 url 重定向`/docs/Web/API/fetch` URL.了解您的系统将在未来几年证明是有用的，您将了解这些单一服务工具是如何工作的，以及它们如何成为您解决小众问题的工具库的一部分。


### PR DESCRIPTION
This PR updates the examples for using `curl` across all locales, updating them to use localized links instead.
