### PR TITLE
es: Format /web/html using Prettier (part 2)

### DIFF
--- a/files/es/web/html/attributes/accept/index.md
+++ b/files/es/web/html/attributes/accept/index.md
@@ -11,16 +11,18 @@ Debido a que un determinado tipo de archivo se puede identificar de más de una 
 Por ejemplo, hay varias formas de identificar los archivos de Microsoft Word, por lo que un sitio que acepta archivos de Word puede usar un `<input>` como este:
 
 ```html
-<input type="file" id="docpicker"
-  accept=".doc,.docx,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document">
+<input
+  type="file"
+  id="docpicker"
+  accept=".doc,.docx,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document" />
 ```
 
 Mientras que si aceptas un archivo multimedia, es posible que desees incluir cualquier formato de ese tipo de medio:
 
 ```html
-<input type="file" id="soundFile" accept="audio/*">
-<input type="file" id="videoFile" accept="video/*">
-<input type="file" id="imageFile" accept="image/*">
+<input type="file" id="soundFile" accept="audio/*" />
+<input type="file" id="videoFile" accept="video/*" />
+<input type="file" id="imageFile" accept="image/*" />
 ```
 
 El atributo `accept` no valida los tipos de archivos seleccionados; simplemente proporciona sugerencias para los navegadores para guiar a los usuarios hacia la selección de los tipos de archivo correctos. Todavía es posible (en la mayoría de los casos) que los usuarios cambien una opción en el selector de archivos que hace posible anular esto y seleccionar cualquier archivo que deseen, y luego elegir tipos de archivo incorrectos.
@@ -34,15 +36,15 @@ Cuando se configura en un tipo de entrada de archivo, el selector de archivos na
 ```html
 <p>
   <label for="soundFile">Selecciona un archivo de audio:</label>
-  <input type="file" id="soundFile" accept="audio/*">
+  <input type="file" id="soundFile" accept="audio/*" />
 </p>
 <p>
   <label for="videoFile">Selecciona un archivo de video:</label>
-  <input type="file" id="videoFile" accept="video/*">
+  <input type="file" id="videoFile" accept="video/*" />
 </p>
 <p>
   <label for="imageFile">Selecciona algunas imágenes:</label>
-  <input type="file" id="imageFile" accept="image/*" multiple>
+  <input type="file" id="imageFile" accept="image/*" multiple />
 </p>
 ```
 
@@ -63,7 +65,7 @@ Un **especificador de tipo de archivo único** es una cadena que describe un tip
 El atributo `accept` toma como valor una cadena que contiene uno o más de estos especificadores de tipo de archivo únicos, separados por comas. Por ejemplo, un selector de archivos que necesita contenido que se puede presentar como una imagen, incluidos los formatos de imagen estándar y los archivos PDF, podría verse así:
 
 ```html
-<input type="file" accept="image/*,.pdf">
+<input type="file" accept="image/*,.pdf" />
 ```
 
 ## Usar inputs de archivo
@@ -72,13 +74,13 @@ El atributo `accept` toma como valor una cadena que contiene uno o más de estos
 
 ```html
 <form method="post" enctype="multipart/form-data">
- <div>
-   <label for="file">Elige el archivo a cargar</label>
-   <input type="file" id="file" name="file" multiple>
- </div>
- <div>
-   <button>Enviar</button>
- </div>
+  <div>
+    <label for="file">Elige el archivo a cargar</label>
+    <input type="file" id="file" name="file" multiple />
+  </div>
+  <div>
+    <button>Enviar</button>
+  </div>
 </form>
 ```
 
@@ -115,8 +117,11 @@ Veamos un ejemplo más completo:
 <form method="post" enctype="multipart/form-data">
   <div>
     <label for="profile_pic">Elige el archivo para cargar</label>
-    <input type="file" id="profile_pic" name="profile_pic"
-          accept=".jpg, .jpeg, .png">
+    <input
+      type="file"
+      id="profile_pic"
+      name="profile_pic"
+      accept=".jpg, .jpeg, .png" />
   </div>
   <div>
     <button>Enviar</button>

--- a/files/es/web/html/attributes/min/index.md
+++ b/files/es/web/html/attributes/min/index.md
@@ -47,7 +47,7 @@ input:invalid {
 Luego define un {{HTMLElement("input")}} con un valor mínimo de 7.2, omitiendo el atributo `step`, en donde el valor predeterminado es 1.
 
 ```html
-<input id="myNumber" name="myNumber" type="number" min="7.2" value="8">
+<input id="myNumber" name="myNumber" type="number" min="7.2" value="8" />
 ```
 
 Dado que `step` tiene el valor predeterminado de 1, los valores válidos incluyen `7.2`, `8.2`, `9.2` y así sucesivamente. El valor 8 no es válido. Dado que incluye un valor no válido, los navegadores compatibles mostrarán el valor como no válido.

--- a/files/es/web/html/attributes/minlength/index.md
+++ b/files/es/web/html/attributes/minlength/index.md
@@ -13,7 +13,10 @@ El **`<input>`** fallará la restricción de validación si la longitud del valo
 Al agregar `minlength="5"`, el valor debe estar vacío o tener cinco caracteres o más para ser válido.
 
 ```html
-<label for="fruit">Ingresa un nombre de fruta que tenga al menos 5 letras</label> <input type="text" minlength="5" id="fruit">
+<label for="fruit"
+  >Ingresa un nombre de fruta que tenga al menos 5 letras</label
+>
+<input type="text" minlength="5" id="fruit" />
 ```
 
 Podemos usar pseudoclases para estilizar el elemento en función de si el valor es válido. El valor será válido siempre que sea `null` (vacío) o tenga cinco o más caracteres. _Lima_ no es válido, _limón es válido_.

--- a/files/es/web/html/attributes/multiple/index.md
+++ b/files/es/web/html/attributes/multiple/index.md
@@ -53,8 +53,7 @@ Cuando se especifica [`multiple`](/es/docs/Web/HTML/Element/input#multiple), la 
   id="emails"
   list="drawfemails"
   required
-  size="64"
-/>
+  size="64" />
 
 <datalist id="drawfemails">
   <option value="gruñón@woodworkers.com">Gruñón</option>
@@ -92,8 +91,7 @@ Cuando se establece [`multiple`](/es/docs/Web/HTML/Element/input#multiple) en el
       id="uploads"
       name="uploads"
       accept=".jpg, .jpeg, .png, .svg, .gif"
-      multiple
-    />
+      multiple />
   </p>
   <p>
     <label for="text">Elige un archivo de texto para cargar: </label>

--- a/files/es/web/html/cors_enabled_image/index.md
+++ b/files/es/web/html/cors_enabled_image/index.md
@@ -34,24 +34,25 @@ Puedes utilizar este fragemto de la configuración del servidor Apache del Boile
 Dado que está todo ordenado, serás capás de guardar esas imagenes en el almacenamiento del DOM, así como si fueran solicitados de tu dominio.
 
 ```js
-var img = new Image,
-    canvas = document.createElement("canvas"),
-    ctx = canvas.getContext("2d"),
-    src = "http://example.com/image"; // insert image url here
+var img = new Image(),
+  canvas = document.createElement("canvas"),
+  ctx = canvas.getContext("2d"),
+  src = "http://example.com/image"; // insert image url here
 
 img.crossOrigin = "Anonymous";
 
-img.onload = function() {
-    canvas.width = img.width;
-    canvas.height = img.height;
-    ctx.drawImage( img, 0, 0 );
-    localStorage.setItem( "savedImageData", canvas.toDataURL("image/png") );
-}
+img.onload = function () {
+  canvas.width = img.width;
+  canvas.height = img.height;
+  ctx.drawImage(img, 0, 0);
+  localStorage.setItem("savedImageData", canvas.toDataURL("image/png"));
+};
 img.src = src;
 // make sure the load event fires for cached images too
-if ( img.complete || img.complete === undefined ) {
-    img.src = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
-    img.src = src;
+if (img.complete || img.complete === undefined) {
+  img.src =
+    "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+  img.src = src;
 }
 ```
 

--- a/files/es/web/html/element/a/index.md
+++ b/files/es/web/html/element/a/index.md
@@ -144,9 +144,7 @@ Este elemento incluye los [atributos globales](/es/docs/HTML/Global_attributes).
 
 ```html
 <!-- anclaje a un archivo externo -->
-<a href="https://www.mozilla.com/">
-Enlace externo
-</a>
+<a href="https://www.mozilla.com/">Enlace externo</a>
 ```
 
 #### Resultado
@@ -157,9 +155,7 @@ Enlace externo
 
 ```html
 <!-- enlace a un elemento en esta página con id="attr-href" -->
-<a href="#attr-href">
-Descripción de enlaces de la misma página
-</a>
+<a href="#attr-href">Descripción de enlaces de la misma página</a>
 ```
 
 #### Resultado
@@ -172,8 +168,7 @@ Este ejemplo utiliza una imagen que enlaza a la página de inicio de MDN. La pá
 
 ```html
 <a href="https://developer.mozilla.org/en-US/" target="_blank">
-  <img src="mdn_logo.png"
-       alt="MDN logo" />
+  <img src="mdn_logo.png" alt="MDN logo" />
 </a>
 ```
 
@@ -210,13 +205,17 @@ Para detalles adicionales acerca del esquema de la URL `tel`, consultar {{RFC(28
 Si deseas permitir a los usurios descargar una elemento HTML {{HTMLElement("canvas")}} como una imagen, puedes crear un enlace con una atributo `download` y la información canvas como un archivo URL:
 
 ```js
-var link = document.createElement('a');
-link.innerHTML = 'download image';
+var link = document.createElement("a");
+link.innerHTML = "download image";
 
-link.addEventListener('click', function(ev) {
+link.addEventListener(
+  "click",
+  function (ev) {
     link.href = canvas.toDataURL();
     link.download = "mypainting.png";
-}, false);
+  },
+  false,
+);
 
 document.body.appendChild(link);
 ```

--- a/files/es/web/html/element/address/index.md
+++ b/files/es/web/html/element/address/index.md
@@ -28,16 +28,18 @@ Este elemento solo incluye los [atributos globales](/es/docs/Web/HTML/Atributos_
 ## Example
 
 ```html
-  <address>
-    You can contact author at <a href="http://www.somedomain.com/contact">www.somedomain.com</a>.<br>
-    If you see any bugs, please <a href="mailto:webmaster@somedomain.com">contact webmaster</a>.<br>
-    You may also want to visit us:<br>
-    Mozilla Foundation<br>
-    1981 Landings Drive<br>
-    Building K<br>
-    Mountain View, CA 94043-0801<br>
-    USA
-  </address>
+<address>
+  You can contact author at
+  <a href="http://www.somedomain.com/contact">www.somedomain.com</a>.<br />
+  If you see any bugs, please
+  <a href="mailto:webmaster@somedomain.com">contact webmaster</a>.<br />
+  You may also want to visit us:<br />
+  Mozilla Foundation<br />
+  1981 Landings Drive<br />
+  Building K<br />
+  Mountain View, CA 94043-0801<br />
+  USA
+</address>
 ```
 
 Above HTML will output:

--- a/files/es/web/html/element/audio/index.md
+++ b/files/es/web/html/element/audio/index.md
@@ -56,8 +56,7 @@ Las compensaciones de tiempo se especifican como valores float que indican el n√
 ## Ejemplos
 
 ```html
-<audio src="audiotest_(1).ogg"
-       autoplay>
+<audio src="audiotest_(1).ogg" autoplay>
   Your browser does not support the <code>audio</code> element.
 </audio>
 ```

--- a/files/es/web/html/element/base/index.md
+++ b/files/es/web/html/element/base/index.md
@@ -83,8 +83,8 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
 ## Ejemplos
 
 ```html
-<base href="http://www.example.com/page.html">
-<base target="_blank" href="http://www.example.com/page.html">
+<base href="http://www.example.com/page.html" />
+<base target="_blank" href="http://www.example.com/page.html" />
 ```
 
 ## Especificaciones

--- a/files/es/web/html/element/bdi/index.md
+++ b/files/es/web/html/element/bdi/index.md
@@ -26,7 +26,10 @@ Como los demás elementos HTML , este elemento tiene los [global attributes](/es
 ## Ejemplo
 
 ```html
-<p dir="ltr">Esta palabara arábica<bdi>ARABIC_PLACEHOLDER</bdi> se muestra automáticamente de derecha a izquierda.</p>
+<p dir="ltr">
+  Esta palabara arábica<bdi>ARABIC_PLACEHOLDER</bdi> se muestra automáticamente
+  de derecha a izquierda.
+</p>
 ```
 
 ### Resultado

--- a/files/es/web/html/element/big/index.md
+++ b/files/es/web/html/element/big/index.md
@@ -226,7 +226,13 @@ original_slug: Web/HTML/Elemento/big
 
 ```html
 <p>
-  Texto normal y texto <big> cada <big> vez <big> más <big> grande. </big></big></big></big>
+  Texto normal y texto
+  <big>
+    cada
+    <big>
+      vez <big> más <big> grande. </big></big></big
+    ></big
+  >
 </p>
 ```
 

--- a/files/es/web/html/element/br/index.md
+++ b/files/es/web/html/element/br/index.md
@@ -29,10 +29,10 @@ Este elemento incluye los [atributos globales](/es/docs/HTML/Global_attributes).
 ## Ejemplo
 
 ```html
-Mozilla Foundation<br>
-1981 Landings Drive<br>
-Building K<br>
-Mountain View, CA 94043-0801<br>
+Mozilla Foundation<br />
+1981 Landings Drive<br />
+Building K<br />
+Mountain View, CA 94043-0801<br />
 USA
 ```
 

--- a/files/es/web/html/element/caption/index.md
+++ b/files/es/web/html/element/caption/index.md
@@ -220,9 +220,13 @@ original_slug: Web/HTML/Elemento/caption
 El siguiente código:
 
 ```html
-<table border='1'>
-  <caption>Tabla con caption</caption>
-  <tr> <td> tabla de una celda. </td>  </tr>
+<table border="1">
+  <caption>
+    Tabla con caption
+  </caption>
+  <tr>
+    <td>tabla de una celda.</td>
+  </tr>
 </table>
 ```
 

--- a/files/es/web/html/element/cite/index.md
+++ b/files/es/web/html/element/cite/index.md
@@ -196,7 +196,7 @@ original_slug: Web/HTML/Elemento/cite
 código:
 
 ```html
-<p> <cite>Galileo</cite> dijo: "... y sin embargo, se mueve." </p>
+<p><cite>Galileo</cite> dijo: "... y sin embargo, se mueve."</p>
 ```
 
 Resultado:

--- a/files/es/web/html/element/data/index.md
+++ b/files/es/web/html/element/data/index.md
@@ -29,9 +29,9 @@ El siguiente ejemplo muestra nombres de productos pero también asocia a cada un
 ```html
 <p>New Products</p>
 <ul>
- <li><data value="3967381398">Mini Ketchup</data></li>
- <li><data value="3967381399">Jumbo Ketchup</data></li>
- <li><data value="3967381400">Mega Jumbo Ketchup</data></li>
+  <li><data value="3967381398">Mini Ketchup</data></li>
+  <li><data value="3967381399">Jumbo Ketchup</data></li>
+  <li><data value="3967381400">Mega Jumbo Ketchup</data></li>
 </ul>
 ```
 

--- a/files/es/web/html/element/datalist/index.md
+++ b/files/es/web/html/element/datalist/index.md
@@ -66,15 +66,16 @@ Este elemento no tiene otros atributos mas que los [atributos globales](/es/docs
 ## Ejemplos
 
 ```html
-<label>Choose a browser from this list:
-<input list="browsers" name="myBrowser" /></label>
+<label
+  >Choose a browser from this list: <input list="browsers" name="myBrowser"
+/></label>
 <datalist id="browsers">
-  <option value="Chrome">
-  <option value="Firefox">
-  <option value="Internet Explorer">
-  <option value="Opera">
-  <option value="Safari">
-  <option value="Microsoft Edge">
+  <option value="Chrome"></option>
+  <option value="Firefox"></option>
+  <option value="Internet Explorer"></option>
+  <option value="Opera"></option>
+  <option value="Safari"></option>
+  <option value="Microsoft Edge"></option>
 </datalist>
 ```
 

--- a/files/es/web/html/element/del/index.md
+++ b/files/es/web/html/element/del/index.md
@@ -113,19 +113,13 @@ El siguiente código:
 
 ```html
 Ejemplo de ins en linea:
-<p>
-  El agua es insípida <del>y húmeda.</del> <ins>inodora e incolora.</ins>
-</p>
+<p>El agua es insípida <del>y húmeda.</del> <ins>inodora e incolora.</ins></p>
 
 Ejemplo de ins en bloque:
-<p>
-  El agua es insípida.
-</p>
+<p>El agua es insípida.</p>
 
 <del>
-  <p>
-    y húmeda.
-  </p>
+  <p>y húmeda.</p>
 </del>
 ```
 

--- a/files/es/web/html/element/dialog/index.md
+++ b/files/es/web/html/element/dialog/index.md
@@ -81,13 +81,15 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
 <dialog id="favDialog">
   <form method="dialog">
     <section>
-      <p><label for="favAnimal">Favorite animal:</label>
-      <select id="favAnimal">
-        <option></option>
-        <option>Brine shrimp</option>
-        <option>Red panda</option>
-        <option>Spider monkey</option>
-      </select></p>
+      <p>
+        <label for="favAnimal">Favorite animal:</label>
+        <select id="favAnimal">
+          <option></option>
+          <option>Brine shrimp</option>
+          <option>Red panda</option>
+          <option>Spider monkey</option>
+        </select>
+      </p>
     </section>
     <menu>
       <button id="cancel" type="reset">Cancel</button>
@@ -101,21 +103,20 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
 </menu>
 
 <script>
-  (function() {
-    var updateButton = document.getElementById('updateDetails');
-    var cancelButton = document.getElementById('cancel');
-    var favDialog = document.getElementById('favDialog');
+  (function () {
+    var updateButton = document.getElementById("updateDetails");
+    var cancelButton = document.getElementById("cancel");
+    var favDialog = document.getElementById("favDialog");
 
     // Update button opens a modal dialog
-    updateButton.addEventListener('click', function() {
+    updateButton.addEventListener("click", function () {
       favDialog.showModal();
     });
 
     // Form cancel button closes the dialog box
-    cancelButton.addEventListener('click', function() {
+    cancelButton.addEventListener("click", function () {
       favDialog.close();
     });
-
   })();
 </script>
 ```

--- a/files/es/web/html/element/div/index.md
+++ b/files/es/web/html/element/div/index.md
@@ -228,7 +228,7 @@ código:
 
 ```html
 <div style="color: blue;">
- <h2> Ejemplo de div y span </h2>
+  <h2>Ejemplo de div y span</h2>
   <p>
     Esto es un párrafo dentro de un div,
     <span style="color: red;"> y esto un span dentro de un párrafo.</span>

--- a/files/es/web/html/element/dl/index.md
+++ b/files/es/web/html/element/dl/index.md
@@ -82,10 +82,8 @@ Los atributos de este elemento incluyen los [atributos globales](/es/docs/Web/HT
 <dl>
   <dt>Firefox</dt>
   <dd>
-    A free, open source, cross-platform,
-    graphical web browser developed by the
-    Mozilla Corporation and hundreds of
-    volunteers.
+    A free, open source, cross-platform, graphical web browser developed by the
+    Mozilla Corporation and hundreds of volunteers.
   </dd>
 
   <!-- Other terms and descriptions -->
@@ -104,10 +102,8 @@ Salida:
   <dt>Mozilla Firefox</dt>
   <dt>Fx</dt>
   <dd>
-    A free, open source, cross-platform,
-    graphical web browser developed by the
-    Mozilla Corporation and hundreds of
-    volunteers.
+    A free, open source, cross-platform, graphical web browser developed by the
+    Mozilla Corporation and hundreds of volunteers.
   </dd>
 
   <!-- Other terms and descriptions -->
@@ -124,16 +120,12 @@ Salida:
 <dl>
   <dt>Firefox</dt>
   <dd>
-    A free, open source, cross-platform,
-    graphical web browser developed by the
-    Mozilla Corporation and hundreds of
-    volunteers.
+    A free, open source, cross-platform, graphical web browser developed by the
+    Mozilla Corporation and hundreds of volunteers.
   </dd>
   <dd>
-    The Red Panda also known as the Lesser
-    Panda, Wah, Bear Cat or Firefox, is a
-    mostly herbivorous mammal, slightly larger
-    than a domestic cat (60 cm long).
+    The Red Panda also known as the Lesser Panda, Wah, Bear Cat or Firefox, is a
+    mostly herbivorous mammal, slightly larger than a domestic cat (60 cm long).
   </dd>
 
   <!-- Other terms and descriptions -->

--- a/files/es/web/html/element/font/index.md
+++ b/files/es/web/html/element/font/index.md
@@ -229,8 +229,8 @@ código:
 
 ```html
 <p>
- Texto normal y ...
- <font size="5" color="#0000ff"> Texto distinto. </font>
+  Texto normal y ...
+  <font size="5" color="#0000ff"> Texto distinto. </font>
 </p>
 ```
 

--- a/files/es/web/html/element/form/index.md
+++ b/files/es/web/html/element/form/index.md
@@ -90,22 +90,23 @@ Este elemento implementa la interfaz [`HTMLFormElement`](/es/DOM/HTMLFormElement
 <!-- Formulario simple que enviará una petición GET -->
 <form action="">
   <label for="GET-name">Nombre:</label>
-  <input id="GET-name" type="text" name="name">
-  <input type="submit" value="Save">
+  <input id="GET-name" type="text" name="name" />
+  <input type="submit" value="Save" />
 </form>
 
 <!-- Formulario simple que enviará una petición POST -->
 <form action="" method="post">
   <label for="POST-name">Nombre:</label>
-  <input id="POST-name" type="text" name="name">
-  <input type="submit" value="Save">
+  <input id="POST-name" type="text" name="name" />
+  <input type="submit" value="Save" />
 </form>
 
 <!-- Formulario con conjunto de campos, leyenda y etiqueta -->
 <form action="" method="post">
   <fieldset>
     <legend>Título</legend>
-    <input type="radio" name="radio" id="radio"> <label for="radio">Clic aquí</label>
+    <input type="radio" name="radio" id="radio" />
+    <label for="radio">Clic aquí</label>
   </fieldset>
 </form>
 ```

--- a/files/es/web/html/element/html/index.md
+++ b/files/es/web/html/element/html/index.md
@@ -33,10 +33,14 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
 El DOCTYPE usado en el siguiente ejemplo indica que es un documento HTML5.
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html>
-  <head>...</head>
-  <body>...</body>
+  <head>
+    ...
+  </head>
+  <body>
+    ...
+  </body>
 </html>
 ```
 

--- a/files/es/web/html/element/iframe/index.md
+++ b/files/es/web/html/element/iframe/index.md
@@ -217,7 +217,11 @@ Un `<iframe>` en acción. Después de crear el marco, cuando el usuario hace cli
 #### HTML
 
 ```html
-<iframe src="https://example.org" title="iframe Example 1" width="400" height="300">
+<iframe
+  src="https://example.org"
+  title="iframe Example 1"
+  width="400"
+  height="300">
   <p>Your browser does not support iframes.</p>
 </iframe>
 ```
@@ -233,11 +237,13 @@ En este ejemplo, se muestra un mapa de Google en un marco.
 #### HTML
 
 ```html
-<iframe id="Example2"
-    title="iframe Example 2"
-    width="400" height="300"
-    style="border:none"
-    src="https://maps.google.com/maps?f=q&source=s_q&q=buenos+aires&sll=37.0625,-95.677068&sspn=38.638819,80.859375&t=h&hnear=Buenos+Aires,+Argentina&z=11&ll=-34.603723,-58.381593&output=embed">
+<iframe
+  id="Example2"
+  title="iframe Example 2"
+  width="400"
+  height="300"
+  style="border:none"
+  src="https://maps.google.com/maps?f=q&source=s_q&q=buenos+aires&sll=37.0625,-95.677068&sspn=38.638819,80.859375&t=h&hnear=Buenos+Aires,+Argentina&z=11&ll=-34.603723,-58.381593&output=embed">
 </iframe>
 ```
 

--- a/files/es/web/html/element/img/index.md
+++ b/files/es/web/html/element/img/index.md
@@ -168,7 +168,7 @@ Dependiendo de su tipo, una imagen puede tener ancho y alto intrínseco, pero no
 ## Ejemplo 1
 
 ```html
-<img src="mdn-logo-sm.png" alt="MDN">
+<img src="mdn-logo-sm.png" alt="MDN" />
 ```
 
 ![MDN](/static/img/favicon144.png)
@@ -176,7 +176,9 @@ Dependiendo de su tipo, una imagen puede tener ancho y alto intrínseco, pero no
 ## Ejemplo 2: Enlace con imagen
 
 ```html
-<a href="https://developer.mozilla.org/"><img src="mdn-logo-sm.png" alt="MDN"></a>
+<a href="https://developer.mozilla.org/"
+  ><img src="mdn-logo-sm.png" alt="MDN"
+/></a>
 ```
 
 [![MDN](/static/img/favicon144.png)](/)
@@ -186,9 +188,7 @@ Dependiendo de su tipo, una imagen puede tener ancho y alto intrínseco, pero no
 El atributo `src` es un candidato en agentes de usuario `1x` que soporta `srcset.`
 
 ```html
-<img src="mdn-logo-sm.png"
-      alt="MDN"
-      srcset="mdn-logo-HD.png 2x">
+<img src="mdn-logo-sm.png" alt="MDN" srcset="mdn-logo-HD.png 2x" />
 ```
 
 ## Ejemplo 4: Uso de atributos `srcset` y `sizes`
@@ -196,10 +196,11 @@ El atributo `src` es un candidato en agentes de usuario `1x` que soporta `srcset
 El atributo`src` es ignorado en agentes de usuario que soportan `srcset` cuando usan descriptores `'w'`. Cuando la condición de media `(min-width: 600px)` encaja, la imagen será 200px de ancho, de otra manera será 50vw de ancho (50% del ancho del dispositivo).
 
 ```html
-<img src="clock-demo-thumb-200.png"
-      alt="Clock"
-      srcset="clock-demo-thumb-200.png 200w, clock-demo-thumb-400.png 400w"
-      sizes="(min-width: 600px) 200px, 50vw">
+<img
+  src="clock-demo-thumb-200.png"
+  alt="Clock"
+  srcset="clock-demo-thumb-200.png 200w, clock-demo-thumb-400.png 400w"
+  sizes="(min-width: 600px) 200px, 50vw" />
 ```
 
 ## Especificaciones

--- a/files/es/web/html/element/input/button/index.md
+++ b/files/es/web/html/element/input/button/index.md
@@ -167,7 +167,7 @@ Este elemento puede tener cualquiera de los [atributos globales](/es/docs/HTML/G
 Se crea un nuevo input tipo botón con el valor 'Click me'.
 
 ```html
-<input type="button" value="Click me">
+<input type="button" value="Click me" />
 ```
 
 ## Especificaciones

--- a/files/es/web/html/element/input/checkbox/index.md
+++ b/files/es/web/html/element/input/checkbox/index.md
@@ -21,9 +21,13 @@ Este elemento posee los "[atributos globales](/es/docs/HTML/Global_attributes)".
 ## Ejemplo
 
 ```html
-<label><input type="checkbox" id="cbox1" value="first_checkbox"> Este es mi primer checkbox</label><br>
+<label
+  ><input type="checkbox" id="cbox1" value="first_checkbox" /> Este es mi primer
+  checkbox</label
+><br />
 
-<input type="checkbox" id="cbox2" value="second_checkbox"> <label for="cbox2">Este es mi segundo checkbox</label>
+<input type="checkbox" id="cbox2" value="second_checkbox" />
+<label for="cbox2">Este es mi segundo checkbox</label>
 ```
 
 Esto crea dos casillas de verificación, que se ven así:

--- a/files/es/web/html/element/input/color/index.md
+++ b/files/es/web/html/element/input/color/index.md
@@ -13,7 +13,7 @@ La presentación del elemento puede variar considerablamente entre navegadores y
 ## Ejemplo
 
 ```html
-<input type="color">
+<input type="color" />
 ```
 
 {{EmbedLiveSample("summary_example1", 700, 30)}}
@@ -40,7 +40,7 @@ Las entradas del tipo «`color`» son sencillas debido al número limitado de at
 Puede actualizar el ejemplo simple anterior para definir un valor predeterminado, de manera que el botón muestrario de colores tenga precargado ese color y el selector de colores (si lo hay) se abra con ese color preseleccionado también:
 
 ```html
-<input type="color" value="#ff0000">
+<input type="color" value="#ff0000" />
 ```
 
 {{EmbedLiveSample("Providing_a_default_color", 700, 30)}}
@@ -58,7 +58,7 @@ colorPicker.addEventListener("input", actualizarPrimero, false);
 colorPicker.addEventListener("change", watchColorPicker, false);
 
 function watchColorPicker(event) {
-  document.querySelectorAll("p").forEach(function(p) {
+  document.querySelectorAll("p").forEach(function (p) {
     p.style.color = event.target.value;
   });
 }
@@ -85,16 +85,22 @@ Creemos un ejemplo que realice algo más con la entrada de color a través de la
 El código HTML es bastante sencillo: un par de párrafos de material descriptivo con un {{HTMLElement("input")}} del tipo «`color`» con el identificador «`muestrario`», el cual utilizaremos para modificar el color del texto de los párrafos.
 
 ```html
-<p>Este ejemplo demuestra la utilización del control <code>&lt;input type="color"&gt;</code>.</p>
+<p>
+  Este ejemplo demuestra la utilización del control
+  <code>&lt;input type="color"&gt;</code>.
+</p>
 
 <label for="muestrario">Color:</label>
-<input type="color" value="#ff0000" id="muestrario">
+<input type="color" value="#ff0000" id="muestrario" />
 
-<p>Observe cómo el color de los párrafos cambia cuando manipula el selector de colores.
-   A medida que realiza cambios en el selector, el color del primer párrafo cambia,
-   a manera de previsualización (esto usa el suceso <code>input</code>).
-   Cuando cierra el selector, se desencadena el suceso <code>change</code>
-   y podemos detectarlo para cambiar todos los párrafos al color elegido.</p>
+<p>
+  Observe cómo el color de los párrafos cambia cuando manipula el selector de
+  colores. A medida que realiza cambios en el selector, el color del primer
+  párrafo cambia, a manera de previsualización (esto usa el suceso
+  <code>input</code>). Cuando cierra el selector, se desencadena el suceso
+  <code>change</code> y podemos detectarlo para cambiar todos los párrafos al
+  color elegido.
+</p>
 ```
 
 ### JavaScript
@@ -144,7 +150,7 @@ Cuando se cierre el selector de colores, señalando que el valor dejará de camb
 
 ```js
 function actualizarTodo(event) {
-  document.querySelectorAll("p").forEach(function(p) {
+  document.querySelectorAll("p").forEach(function (p) {
     p.style.color = event.target.value;
   });
 }

--- a/files/es/web/html/element/input/date/index.md
+++ b/files/es/web/html/element/input/date/index.md
@@ -178,8 +178,7 @@ Veamos un ejemplo con fecha mínima y máxima y, también, estableciendo el camp
       name="party"
       min="2017-04-01"
       max="2017-04-20"
-      required
-    />
+      required />
     <span class="validity"></span>
   </label>
 

--- a/files/es/web/html/element/input/datetime-local/index.md
+++ b/files/es/web/html/element/input/datetime-local/index.md
@@ -4,7 +4,7 @@ slug: Web/HTML/Element/input/datetime-local
 original_slug: Web/HTML/Element/input/datetime
 ---
 
-_El HTML_` <input type="datetime"> `es un control para ingresar tiempo y fecha (hora, minuto, segundo y fracción de segundo) basado en la zona horaria UTC .
+_El HTML_ `<input type="datetime">` es un control para ingresar tiempo y fecha (hora, minuto, segundo y fracción de segundo) basado en la zona horaria UTC .
 
 - [Categorías de contenido](/es/docs/Web/Guide/HTML/categorias_de_contenido) : Contenido dinámico , listed , submittable , resettable , contenido asociado a un formulario , contenido estático o de texto . Si `type` no tiene el valor `hidden`, elemenento labelable , contenido palpable .
 

--- a/files/es/web/html/element/input/email/index.md
+++ b/files/es/web/html/element/input/email/index.md
@@ -313,8 +313,7 @@ label::after {
       required
       placeholder="username@beststartupever.com"
       pattern=".+@beststartupever\.com"
-      title="Proporcione solo una dirección de correo electrónico corporativa de Best Startup Ever"
-    />
+      title="Proporcione solo una dirección de correo electrónico corporativa de Best Startup Ever" />
   </div>
 
   <div class="messageBox">
@@ -324,8 +323,7 @@ label::after {
       cols="80"
       rows="8"
       required
-      placeholder="Mis zapatos están demasiado apretados y he olvidado cómo bailar."
-    ></textarea>
+      placeholder="Mis zapatos están demasiado apretados y he olvidado cómo bailar."></textarea>
   </div>
   <input type="submit" value="Enviar solicitud" />
 </form>
@@ -368,8 +366,7 @@ Adicionalmente, el elemento {{HTMLElement("label")}} se utiliza para establecer 
   list="defaultEmails"
   size="64"
   maxlength="256"
-  multiple
-/>
+  multiple />
 
 <datalist id="defaultEmails">
   <option value="jbond007@mi6.defence.gov.uk"></option>

--- a/files/es/web/html/element/input/hidden/index.md
+++ b/files/es/web/html/element/input/hidden/index.md
@@ -13,7 +13,7 @@ original_slug: Web/HTML/Elemento/input/hidden
 ## Ejemplo
 
 ```html
-<input id="prodId" name="prodId" type="hidden" value="xm234jq">
+<input id="prodId" name="prodId" type="hidden" value="xm234jq" />
 ```
 
 {{ EmbedLiveSample('Basic_example', 600, 40) }}
@@ -69,7 +69,11 @@ El formulario HTML puede verse un como como este:
 <form>
   <div>
     <label for="title">Título del artículo:</label>
-    <input type="text" id="titulo" name="titulo" value="Mi excelente artículo del blog">
+    <input
+      type="text"
+      id="titulo"
+      name="titulo"
+      value="Mi excelente artículo del blog" />
   </div>
   <div>
     <label for="content">Contenido del artículo:</label>
@@ -80,7 +84,7 @@ Este es el contenido de mi excelente actículo del blog. ¡Espero lo disfrutes!
   <div>
     <button type="submit">Actualizar artículo</button>
   </div>
-  <input type="hidden" id="acticuloId" name="articuloId" value="34657">
+  <input type="hidden" id="acticuloId" name="articuloId" value="34657" />
 </form>
 ```
 
@@ -107,7 +111,8 @@ label {
   padding-right: 20px;
 }
 
-input, textarea {
+input,
+textarea {
   flex: 7;
   font-family: sans-serif;
   font-size: 1.1rem;

--- a/files/es/web/html/element/input/index.md
+++ b/files/es/web/html/element/input/index.md
@@ -331,7 +331,9 @@ e.value = "foo";
 Para que Firefox presente un mensaje de error personalizado cuando la validación de un campo falla, se puede usar el atributo `x-moz-errormessage`:
 
 ```html
-<input type="email" x-moz-errormessage="Por favor, especifique una dirección de correo válida.">
+<input
+  type="email"
+  x-moz-errormessage="Por favor, especifique una dirección de correo válida." />
 ```
 
 Nótese, sin embargo, que esto no es estándar, y no tendrá efecto en otros navegadores.
@@ -344,7 +346,7 @@ Nótese, sin embargo, que esto no es estándar, y no tendrá efecto en otros nav
 
 ```html
 <p>Simple input box</p>
-<input type="text" value="Type here">
+<input type="text" value="Type here" />
 ```
 
 ### Resultado
@@ -358,10 +360,10 @@ Nótese, sin embargo, que esto no es estándar, y no tendrá efecto en otros nav
 ```html
 <p>A common form that includes input tags</p>
 <form action="getform.php" method="get">
-    <label>First name: <input type="text"></label><br>
-     <label>Last name: <input type="text"></label><br>
-        <label>E-mail: <input type="email"></label><br>
-<input type="submit" value="Submit">
+  <label>First name: <input type="text" /></label><br />
+  <label>Last name: <input type="text" /></label><br />
+  <label>E-mail: <input type="email" /></label><br />
+  <input type="submit" value="Submit" />
 </form>
 ```
 
@@ -374,7 +376,7 @@ Nótese, sin embargo, que esto no es estándar, y no tendrá efecto en otros nav
 Se puede usar el atributo [`mozactionhint`](/es/docs/Web/HTML/Element/input#mozactionhint) para especificar el texto para la etiqueta de la tecla Enter en el teclado virtual cuando el formulario es mostrado en Firefox mobile. Por ejemplo, para mostrar una etiqueta "Next", se puede hacer esto:
 
 ```html
-<input type="text" mozactionhint="next">
+<input type="text" mozactionhint="next" />
 ```
 
 El resultado es:

--- a/files/es/web/html/element/input/number/index.md
+++ b/files/es/web/html/element/input/number/index.md
@@ -186,7 +186,13 @@ Los elementos {{HTMLElement("input")}} de tipo `number` no soportan atributos de
 Por ejemplo, para ajustar el ancho de la entrada para que sea tan ancho como se necesita para ingresar un número de tres dígitos, podemos cambiar nuestro HTML para incluir un [`id`](/es/docs/Web/HTML/Global_attributes#id) y acortar nuestro marcador de posición ya que el campo es demasiado ancho para el texto que hemos estado usando hasta ahora:
 
 ```html
-<input type="number" placeholder="x10" step="10" min="0" max="100" id="number">
+<input
+  type="number"
+  placeholder="x10"
+  step="10"
+  min="0"
+  max="100"
+  id="number" />
 ```
 
 Entonces añadimos un poco de CSS para acortar el ancho del elemento con el selector `id` `#number`:
@@ -235,7 +241,14 @@ El siguiente ejemplo presenta todas las características anteriores, así como e
 <form>
   <div>
     <label for="balloons">Número de globos a comprar (múltiplos de 10):</label>
-    <input id="balloons" type="number" name="balloons" step="10" min="0" max="100" required>
+    <input
+      id="balloons"
+      type="number"
+      name="balloons"
+      step="10"
+      min="0"
+      max="100"
+      required />
     <span class="validity"></span>
   </div>
   <div>
@@ -296,7 +309,14 @@ El HTML se ve así:
 <form>
   <div class="metersInputGroup">
     <label for="meters">Introduce tu estatura en metros:</label>
-    <input id="meters" type="number" name="meters" step="0.01" min="0" placeholder="p. ej. 1.78" required>
+    <input
+      id="meters"
+      type="number"
+      name="meters"
+      step="0.01"
+      min="0"
+      placeholder="p. ej. 1.78"
+      required />
     <span class="validity"></span>
   </div>
   <div class="feetInputGroup" style="display: none;">
@@ -309,7 +329,10 @@ El HTML se ve así:
     <span class="validity"></span>
   </div>
   <div>
-    <input type="button" class="meters" value="Introduce la altura en pies y pulgadas">
+    <input
+      type="button"
+      class="meters"
+      value="Introduce la altura en pies y pulgadas" />
   </div>
   <div>
     <input type="submit" value="Enviar formulario" />

--- a/files/es/web/html/element/input/password/index.md
+++ b/files/es/web/html/element/input/password/index.md
@@ -95,13 +95,13 @@ Además de los atributos listados abajo, este elemento puede tener cualquier [gl
 Para crear un widget que muestre una constraseña, use:
 
 ```html
-<input type="password">
+<input type="password" />
 ```
 
 Para crear un widget que muestre una contraseña con un patrón o diseño, use:
 
 ```html
-<input type="password" pattern=".{6,}">
+<input type="password" pattern=".{6,}" />
 ```
 
 El ejemplo de arriba creará un elemento password que deberá contener 6 o más carácteres.

--- a/files/es/web/html/element/input/range/index.md
+++ b/files/es/web/html/element/input/range/index.md
@@ -11,7 +11,7 @@ El elemento {{HTMLElement("input")}} del tipo **`"range"`** permite que el usuar
 ### Ejemplo
 
 ```html
-<input type="range">
+<input type="range" />
 ```
 
 {{EmbedLiveSample("summary_sample1", 600, 40)}}
@@ -66,8 +66,10 @@ Si el navegador del usuario no soporta el tipo `"range"`, será tratado como un 
 El atributo [`value`](/es/docs/Web/HTML/Element/input#value) contiene un {{domxref("DOMString")}} que es la representación de tipo cadena del número seleccionado. El valor nunca es una cadena vacía (`""`). El valor por defecto es el punto intermedio entre los valores mínimo y máximo especificados, a menos que el valor máximo sea menor que el valor mínimo, en cuyo caso el valor por defecto será el valor del atributo `min`. El algoritmo de determina el valor por defecto es:
 
 ```js
-defaultValue = (rangeElem.max < rangeElem.min) ? rangeElem.min
-               : rangeElem.min + (rangeElem.max - rangeElem.min)/2;
+defaultValue =
+  rangeElem.max < rangeElem.min
+    ? rangeElem.min
+    : rangeElem.min + (rangeElem.max - rangeElem.min) / 2;
 ```
 
 Si se intenta establecer un valor inferior al mínimo definido, el valor será igual al mínimo. De manera similar, un intento de establecer un valor superior al máximo da como resultado el valor máximo.
@@ -92,7 +94,7 @@ Por defecto, el valor mínimo es 0 y el máximo es 100. Si es necesario modifica
 Por ejemplo, para usar un rango entre -10 y 10, usaremos:
 
 ```html
-<input type="range" min="-10" max="10">
+<input type="range" min="-10" max="10" />
 ```
 
 {{EmbedLiveSample("Specifying_the_minimum_and_maximum", 600, 40)}}
@@ -102,7 +104,7 @@ Por ejemplo, para usar un rango entre -10 y 10, usaremos:
 Por defecto, cada salto tiene valor 1, es decir el valor será siempre un número entero. Podemos cambiarlo mediante el atributo [`step`](/es/docs/Web/HTML/Global_attributes#step). Si necesitas, por ejemplo, un valor entre 5 y 10 con una precisión de dos decimales, debes indicar que el valor de `step` es 0.01:
 
 ```html
-<input type="range" min="5" max="10" step="0.01">
+<input type="range" min="5" max="10" step="0.01" />
 ```
 
 {{EmbedLiveSample("Granularity_sample1", 600, 40)}}
@@ -112,7 +114,7 @@ Por defecto, cada salto tiene valor 1, es decir el valor será siempre un númer
 Si quieres aceptar cualquier valor independientemente de la cantidad de decimales, puede especificar un valor de `"any"` al atrtibuto [`step`](/es/docs/Web/HTML/Element/input#step):
 
 ```html
-<input type="range" min="0" max="3.14" step="any">
+<input type="range" min="0" max="3.14" step="any" />
 ```
 
 {{EmbedLiveSample("Granularity_sample2", 600, 40)}}
@@ -134,7 +136,7 @@ Cuando no especificas un atributo [`list`](/es/docs/Web/HTML/Element/input#list)
 HTML
 
 ```html
-<input type="range">
+<input type="range" />
 ```
 
 Captura de pantalla
@@ -147,20 +149,20 @@ El siguiente rango utiliza el atributo `list` (al cual le especificamos el ID de
 HTML
 
 ```html
-<input type="range" list="tickmarks">
+<input type="range" list="tickmarks" />
 
 <datalist id="tickmarks">
-  <option value="0">
-  <option value="10">
-  <option value="20">
-  <option value="30">
-  <option value="40">
-  <option value="50">
-  <option value="60">
-  <option value="70">
-  <option value="80">
-  <option value="90">
-  <option value="100">
+  <option value="0"></option>
+  <option value="10"></option>
+  <option value="20"></option>
+  <option value="30"></option>
+  <option value="40"></option>
+  <option value="50"></option>
+  <option value="60"></option>
+  <option value="70"></option>
+  <option value="80"></option>
+  <option value="90"></option>
+  <option value="100"></option>
 </datalist>
 ```
 
@@ -174,20 +176,20 @@ Puedes añadir etiquetas a tu control range usando el atributo [`label`](/es/doc
 HTML
 
 ```html
-<input type="range" list="tickmarks">
+<input type="range" list="tickmarks" />
 
 <datalist id="tickmarks">
-  <option value="0" label="0%">
-  <option value="10">
-  <option value="20">
-  <option value="30">
-  <option value="40">
-  <option value="50" label="50%">
-  <option value="60">
-  <option value="70">
-  <option value="80">
-  <option value="90">
-  <option value="100" label="100%">
+  <option value="0" label="0%"></option>
+  <option value="10"></option>
+  <option value="20"></option>
+  <option value="30"></option>
+  <option value="40"></option>
+  <option value="50" label="50%"></option>
+  <option value="60"></option>
+  <option value="70"></option>
+  <option value="80"></option>
+  <option value="90"></option>
+  <option value="100" label="100%"></option>
 </datalist>
 ```
 
@@ -205,7 +207,7 @@ Por defecto, si un navegador renderiza un input range, lo mostrará como un "sli
 Si tenemos el siguiente control range:
 
 ```html
-<input type="range" id="volume" min="0" max="11" value="7" step="1">
+<input type="range" id="volume" min="0" max="11" value="7" step="1" />
 ```
 
 {{EmbedLiveSample("Orientation_sample1", 200, 200, "orientation_sample1.png")}}
@@ -224,7 +226,7 @@ Dicho control se muestra en horizontal (al menos en los principales navegadores,
 #### HTML
 
 ```html
-<input type="range" id="volume" min="0" max="11" value="7" step="1">
+<input type="range" id="volume" min="0" max="11" value="7" step="1" />
 ```
 
 #### Result
@@ -241,7 +243,7 @@ El HTML necesita que el elemento {{HTMLElement("input")}} esté dentro de un ele
 
 ```html
 <div class="slider-wrapper">
-  <input type="range" min="0" max="11" value="7" step="1">
+  <input type="range" min="0" max="11" value="7" step="1" />
 </div>
 ```
 

--- a/files/es/web/html/element/input/text/index.md
+++ b/files/es/web/html/element/input/text/index.md
@@ -182,7 +182,7 @@ Los elementos {{HTMLElement("input")}} de tipo `text` crean entradas básicas de
 <form>
   <div>
     <label for="uname">Elige un nombre de usuario: </label>
-    <input type="text" id="uname" name="name">
+    <input type="text" id="uname" name="name" />
   </div>
   <div>
     <button>Enviar</button>
@@ -204,8 +204,11 @@ Puedes proporcionar un marcador de posición útil dentro de tu entrada de texto
 <form>
   <div>
     <label for="uname">Elige un nombre de usuario: </label>
-    <input type="text" id="uname" name="name"
-           placeholder="Una sola palabra, en minúsculas">
+    <input
+      type="text"
+      id="uname"
+      name="name"
+      placeholder="Una sola palabra, en minúsculas" />
   </div>
   <div>
     <button>Enviar</button>
@@ -227,9 +230,12 @@ El tamaño físico del cuadro de entrada se puede controlar mediante el atributo
 <form>
   <div>
     <label for="uname">Elige un nombre de usuario: </label>
-    <input type="text" id="uname" name="name"
-           placeholder="Una sola palabra, en minúsculas"
-           size="30">
+    <input
+      type="text"
+      id="uname"
+      name="name"
+      placeholder="Una sola palabra, en minúsculas"
+      size="30" />
   </div>
   <div>
     <button>Enviar</button>
@@ -259,14 +265,15 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
-  position: absolute; content: '✖';
+input:invalid + span:after {
+  position: absolute;
+  content: "✖";
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid + span:after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```
@@ -281,7 +288,7 @@ Puedes usar el atributo [`required`](/es/docs/Web/HTML/Element/input#required) c
 <form>
   <div>
     <label for="uname">Elige un nombre de usuario: </label>
-    <input type="text" id="uname" name="name" required>
+    <input type="text" id="uname" name="name" required />
     <span class="validity"></span>
   </div>
   <div>
@@ -291,7 +298,23 @@ Puedes usar el atributo [`required`](/es/docs/Web/HTML/Element/input#required) c
 ```
 
 ```css hidden
-div { margin-bottom: 10px; position: relative; } input + span { padding-right: 30px; } input:invalid+span:after { position: absolute; content: '✖'; padding-left: 5px; } input:valid+span:after { position: absolute; content: '✓'; padding-left: 5px; }
+div {
+  margin-bottom: 10px;
+  position: relative;
+}
+input + span {
+  padding-right: 30px;
+}
+input:invalid + span:after {
+  position: absolute;
+  content: "✖";
+  padding-left: 5px;
+}
+input:valid + span:after {
+  position: absolute;
+  content: "✓";
+  padding-left: 5px;
+}
 ```
 
 Esto se renderiza así:
@@ -310,9 +333,15 @@ El siguiente ejemplo requiere que el valor ingresado tenga entre 4 y 8 caractere
 <form>
   <div>
     <label for="uname">Elige un nombre de usuario: </label>
-    <input type="text" id="uname" name="name" required size="10"
-           placeholder="nombreusuario"
-           minlength="4" maxlength="8">
+    <input
+      type="text"
+      id="uname"
+      name="name"
+      required
+      size="10"
+      placeholder="nombreusuario"
+      minlength="4"
+      maxlength="8" />
     <span class="validity"></span>
   </div>
   <div>
@@ -322,7 +351,23 @@ El siguiente ejemplo requiere que el valor ingresado tenga entre 4 y 8 caractere
 ```
 
 ```css hidden
-div { margin-bottom: 10px; position: relative; } input + span { padding-right: 30px; } input:invalid+span:after { position: absolute; content: '✖'; padding-left: 5px; } input:valid+span:after { position: absolute; content: '✓'; padding-left: 5px; }
+div {
+  margin-bottom: 10px;
+  position: relative;
+}
+input + span {
+  padding-right: 30px;
+}
+input:invalid + span:after {
+  position: absolute;
+  content: "✖";
+  padding-left: 5px;
+}
+input:valid + span:after {
+  position: absolute;
+  content: "✓";
+  padding-left: 5px;
+}
 ```
 
 Esto se renderiza así:
@@ -343,10 +388,18 @@ El siguiente ejemplo restringe el valor a 4-8 caracteres y requiere que contenga
 <form>
   <div>
     <label for="uname">Elige un nombre de usuario: </label>
-    <input type="text" id="uname" name="name" required size="45"
-           pattern="[a-z]{4,8}">
+    <input
+      type="text"
+      id="uname"
+      name="name"
+      required
+      size="45"
+      pattern="[a-z]{4,8}" />
     <span class="validity"></span>
-    <p>Los nombres de usuario deben estar en minúsculas y tener entre 4 y 8 caracteres de longitud.</p>
+    <p>
+      Los nombres de usuario deben estar en minúsculas y tener entre 4 y 8
+      caracteres de longitud.
+    </p>
   </div>
   <div>
     <button>Enviar</button>
@@ -369,15 +422,15 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid + span:after {
   position: absolute;
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid + span:after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```

--- a/files/es/web/html/element/ins/index.md
+++ b/files/es/web/html/element/ins/index.md
@@ -112,12 +112,12 @@ original_slug: Web/HTML/Elemento/ins
 El siguiente código:
 
 ```html
- Ejemplo de ins en linea:
-   <p> El agua es insipida, <ins>inodora e incolora.</ins> </p>
+Ejemplo de ins en linea:
+<p>El agua es insipida, <ins>inodora e incolora.</ins></p>
 
- Ejemplo de ins en bloque:
-   <p> El agua es insipida. </p>
-   <ins> <p> Y además inodora e incolora. </p> </ins>
+Ejemplo de ins en bloque:
+<p>El agua es insipida.</p>
+<ins> <p>Y además inodora e incolora.</p> </ins>
 ```
 
 Se visualiza así:

--- a/files/es/web/html/element/link/index.md
+++ b/files/es/web/html/element/link/index.md
@@ -85,7 +85,7 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
 Para incluir una hoja de estilos en una página, use la siguiente sintaxis:
 
 ```html
-<link href="style.css" rel="stylesheet">
+<link href="style.css" rel="stylesheet" />
 ```
 
 ### Proporcionando hojas de estilos alternativas
@@ -95,9 +95,9 @@ También se pueden especificar [hojas de estilos alternativas](/es/docs/Web/CSS/
 El usuario puede elegir cuál hoja de estilos usar, seleccionándola desde el menú Ver > Estilo de Página. Esto proporciona una manera en que los usuarios pueden ver múltiples versiones de una misma página.
 
 ```html
-<link href="default.css" rel="stylesheet" title="Default Style">
-<link href="fancy.css" rel="alternate stylesheet" title="Fancy">
-<link href="basic.css" rel="alternate stylesheet" title="Basic">
+<link href="default.css" rel="stylesheet" title="Default Style" />
+<link href="fancy.css" rel="alternate stylesheet" title="Fancy" />
+<link href="basic.css" rel="alternate stylesheet" title="Basic" />
 ```
 
 ### Eventos de carga de hojas de estilos
@@ -106,16 +106,20 @@ Se puede determinar cuando una hoja de estilos fue cargada estableciendo la ejec
 
 ```html
 <script>
-function sheetLoaded() {
-  // Hacer algo interesante; la hoja de estilos ha sido cargada
-}
+  function sheetLoaded() {
+    // Hacer algo interesante; la hoja de estilos ha sido cargada
+  }
 
-function sheetError() {
-  alert("¡Ocurrió un error al cargar la hoja de estilos!");
-}
+  function sheetError() {
+    alert("¡Ocurrió un error al cargar la hoja de estilos!");
+  }
 </script>
 
-<link rel="stylesheet" href="mystylesheet.css" onload="sheetLoaded()" onerror="sheetError()">
+<link
+  rel="stylesheet"
+  href="mystylesheet.css"
+  onload="sheetLoaded()"
+  onerror="sheetError()" />
 ```
 
 > **Nota:** El evento `load` se dispara una vez que la hoja de estilos y todo su contenido importado ha sido cargado y procesado, e inmediatamente antes de que los estilos sean aplicados al contenido.

--- a/files/es/web/html/element/main/index.md
+++ b/files/es/web/html/element/main/index.md
@@ -31,20 +31,19 @@ Este elemento solo incluye [atributos globales.](/es/docs/Web/HTML/Global_attrib
 
   <article>
     <h2>Red Delicious</h2>
-    <p>These bright red apples are the most common found in many
-    supermarkets.</p>
-    <p>... </p>
-    <p>... </p>
+    <p>
+      These bright red apples are the most common found in many supermarkets.
+    </p>
+    <p>...</p>
+    <p>...</p>
   </article>
 
   <article>
     <h2>Granny Smith</h2>
-    <p>These juicy, green apples make a great filling for
-    apple pies.</p>
-    <p>... </p>
-    <p>... </p>
+    <p>These juicy, green apples make a great filling for apple pies.</p>
+    <p>...</p>
+    <p>...</p>
   </article>
-
 </main>
 
 <!-- other content -->

--- a/files/es/web/html/element/mark/index.md
+++ b/files/es/web/html/element/mark/index.md
@@ -83,11 +83,10 @@ En este ejemplo, \<mark> se utiliza para resaltar texto en una cita que es de pa
 
 ```html
 <blockquote>
-  It is a period of civil war. Rebel spaceships, striking from a
-  hidden base, have won their first victory against the evil
-  Galactic Empire. During the battle, <mark>Rebel spies managed
-  to steal secret plans</mark> to the Empire’s ultimate weapon,
-  the DEATH STAR, an armored space station with enough power to
+  It is a period of civil war. Rebel spaceships, striking from a hidden base,
+  have won their first victory against the evil Galactic Empire. During the
+  battle, <mark>Rebel spies managed to steal secret plans</mark> to the Empire’s
+  ultimate weapon, the DEATH STAR, an armored space station with enough power to
   destroy an entire planet.
 </blockquote>
 ```
@@ -101,15 +100,17 @@ El resultado sería:
 Este ejemplo demuestra el uso de `<mark>` para marcar resultados de búsqueda en el fragmento.
 
 ```html
-<p>It is a dark time for the Rebellion. Although the Death
-Star has been destroyed, <mark class="match">Imperial</mark>
-troops have driven the Rebel forces from their hidden base and
-pursued them across the galaxy.</p>
+<p>
+  It is a dark time for the Rebellion. Although the Death Star has been
+  destroyed, <mark class="match">Imperial</mark> troops have driven the Rebel
+  forces from their hidden base and pursued them across the galaxy.
+</p>
 
-<p>Evading the dreaded <mark class="match">Imperial</mark>
-Starfleet, a group of freedom fighters led by Luke Skywalker
-has established a new secret base on the remote ice world of
-Hoth.</p>
+<p>
+  Evading the dreaded <mark class="match">Imperial</mark> Starfleet, a group of
+  freedom fighters led by Luke Skywalker has established a new secret base on
+  the remote ice world of Hoth.
+</p>
 ```
 
 Para ayudar a distinguir el uso de `<mark>` en los resultados de búsqueda de otro uso potencial, este ejemplo aplica la clase "match" a cada coincidencia.

--- a/files/es/web/html/element/marquee/index.md
+++ b/files/es/web/html/element/marquee/index.md
@@ -61,7 +61,12 @@ La etiqueta html `<marquee>` se utiliza para insertar un area de texto en movimi
 
 <marquee direction="up">Este texto se mueve de abajo hacia arriba</marquee>
 
-<marquee direction="down" width="250" height="200" behavior="alternate" style="border:solid">
+<marquee
+  direction="down"
+  width="250"
+  height="200"
+  behavior="alternate"
+  style="border:solid">
   <marquee behavior="alternate">
     Este texto rebotará dentro de la marquesina.
   </marquee>

--- a/files/es/web/html/element/object/index.md
+++ b/files/es/web/html/element/object/index.md
@@ -125,12 +125,11 @@ Este elemento incluye los [global attributes](/es/docs/Web/HTML/Global_attribute
 
 ```html
 <!-- Incrustar una película flash -->
-<object data="movie.swf"
-  type="application/x-shockwave-flash"></object>
+<object data="movie.swf" type="application/x-shockwave-flash"></object>
 
 <!-- Incrustar una película flash con parámetros -->
 <object data="movie.swf" type="application/x-shockwave-flash">
-  <param name="foo" value="bar">
+  <param name="foo" value="bar" />
 </object>
 ```
 

--- a/files/es/web/html/element/picture/index.md
+++ b/files/es/web/html/element/picture/index.md
@@ -38,8 +38,8 @@ El atributo `media` permite especificar una media query que el agente de usuario
 
 ```html
 <picture>
- <source srcset="mdn-logo-wide.png" media="(min-width: 600px)">
- <img src="mdn-logo-narrow.png" alt="MDN">
+  <source srcset="mdn-logo-wide.png" media="(min-width: 600px)" />
+  <img src="mdn-logo-narrow.png" alt="MDN" />
 </picture>
 ```
 
@@ -49,8 +49,8 @@ El atributo `type` permite especificar un tipo MIME para los recursos dados en e
 
 ```html
 <picture>
- <source srcset="mdn-logo.svg" type="image/svg+xml">
- <img src="mdn-logo.png" alt="MDN">
+  <source srcset="mdn-logo.svg" type="image/svg+xml" />
+  <img src="mdn-logo.png" alt="MDN" />
 </picture>
 ```
 

--- a/files/es/web/html/element/q/index.md
+++ b/files/es/web/html/element/q/index.md
@@ -81,10 +81,12 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
 ## Ejemplo
 
 ```html
-<p>Conforme al sitio web de Mozilla,
-  <q
-  cite="https://www.mozilla.org/en-US/about/history/details/">Firefox 1.0
-  fue lanzado en 2004 y se convirtió en un gran éxito.</q></p>
+<p>
+  Conforme al sitio web de Mozilla,
+  <q cite="https://www.mozilla.org/en-US/about/history/details/"
+    >Firefox 1.0 fue lanzado en 2004 y se convirtió en un gran éxito.</q
+  >
+</p>
 ```
 
 {{EmbedLiveSample('Ejemplo')}}

--- a/files/es/web/html/element/section/index.md
+++ b/files/es/web/html/element/section/index.md
@@ -56,7 +56,7 @@ Este elemento implementa la interfaz [`HTMLElement`](/en/DOM/element).
 ```html
 <div>
   <h2>Encabezado</h2>
-  <img src="roble.jpg" alt="un roble">
+  <img src="roble.jpg" alt="un roble" />
 </div>
 ```
 
@@ -65,7 +65,7 @@ Este elemento implementa la interfaz [`HTMLElement`](/en/DOM/element).
 ```html
 <section>
   <h2>Encabezado</h2>
-  <img src="roble.jpg" alt="un roble">
+  <img src="roble.jpg" alt="un roble" />
 </section>
 ```
 

--- a/files/es/web/html/element/slot/index.md
+++ b/files/es/web/html/element/slot/index.md
@@ -82,19 +82,43 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
 ```html
 <template id="element-details-template">
   <style>
-    details {font-family: "Open Sans Light",Helvetica,Arial}
-    .name {font-weight: bold; color: #217ac0; font-size: 120%}
-    h4 { margin: 10px 0 -8px 0; }
-    h4 span { background: #217ac0; padding: 2px 6px 2px 6px }
-    h4 span { border: 1px solid #cee9f9; border-radius: 4px }
-    h4 span { color: white }
-    .attributes { margin-left: 22px; font-size: 90% }
-    .attributes p { margin-left: 16px; font-style: italic }
+    details {
+      font-family: "Open Sans Light", Helvetica, Arial;
+    }
+    .name {
+      font-weight: bold;
+      color: #217ac0;
+      font-size: 120%;
+    }
+    h4 {
+      margin: 10px 0 -8px 0;
+    }
+    h4 span {
+      background: #217ac0;
+      padding: 2px 6px 2px 6px;
+    }
+    h4 span {
+      border: 1px solid #cee9f9;
+      border-radius: 4px;
+    }
+    h4 span {
+      color: white;
+    }
+    .attributes {
+      margin-left: 22px;
+      font-size: 90%;
+    }
+    .attributes p {
+      margin-left: 16px;
+      font-style: italic;
+    }
   </style>
   <details>
     <summary>
       <span>
-        <code class="name">&lt;<slot name="element-name">NEED NAME</slot>&gt;</code>
+        <code class="name"
+          >&lt;<slot name="element-name">NEED NAME</slot>&gt;</code
+        >
         <i class="desc"><slot name="description">NEED DESCRIPTION</slot></i>
       </span>
     </summary>
@@ -103,7 +127,7 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Global_attribut
       <slot name="attributes"><p>None</p></slot>
     </div>
   </details>
-  <hr>
+  <hr />
 </template>
 ```
 

--- a/files/es/web/html/element/source/index.md
+++ b/files/es/web/html/element/source/index.md
@@ -93,9 +93,9 @@ Este ejemplo muestra cómo ofrecer un video en formato Ogg para usuarios cuyos n
 
 ```html
 <video controls>
-  <source src="foo.webm" type="video/webm">
-  <source src="foo.ogg" type="video/ogg">
-  <source src="foo.mov" type="video/quicktime">
+  <source src="foo.webm" type="video/webm" />
+  <source src="foo.ogg" type="video/ogg" />
+  <source src="foo.mov" type="video/quicktime" />
   Lo lamento; su navegador no soporta video HTML5.
 </video>
 ```

--- a/files/es/web/html/element/span/index.md
+++ b/files/es/web/html/element/span/index.md
@@ -223,7 +223,7 @@ código:
 
 ```html
 <div style="border: 1px dotted blue;">
-  <h4>Ejemplo de div y span </h4>
+  <h4>Ejemplo de div y span</h4>
   <p>
     Esto es un párrafo dentro de un div,
     <span style="color: red;"> y esto un span dentro de un párrafo. </span>

--- a/files/es/web/html/element/table/index.md
+++ b/files/es/web/html/element/table/index.md
@@ -261,8 +261,8 @@ Este elemento implementa la interfaz [`HTMLTableElement`](/es/docs/DOM/HTMLTable
 <!-- Table with colgroup and col -->
 <table>
   <colgroup>
-    <col class="column1">
-    <col class="columns2plus3" span="2">
+    <col class="column1" />
+    <col class="columns2plus3" span="2" />
   </colgroup>
   <tr>
     <th>Lime</th>
@@ -278,7 +278,9 @@ Este elemento implementa la interfaz [`HTMLTableElement`](/es/docs/DOM/HTMLTable
 
 <!-- Simple table with caption -->
 <table>
-  <caption>Awesome caption</caption>
+  <caption>
+    Awesome caption
+  </caption>
   <tr>
     <td>Awesome data</td>
   </tr>
@@ -293,7 +295,8 @@ table {
   width: 100%;
   margin-top: 1rem;
 }
-td, th {
+td,
+th {
   border: 1px solid black;
 }
 ```

--- a/files/es/web/html/element/template/index.md
+++ b/files/es/web/html/element/template/index.md
@@ -59,8 +59,8 @@ if ('content' in document.createElement('template')) {
 
   // Instanciar la tabla con el tbody existente
   // y la fila con el template
-  var t = document.querySelector('#productrow'),
-  td = t.content.querySelectorAll("td");
+  var t = document.querySelector("#productrow"),
+    td = t.content.querySelectorAll("td");
   td[0].textContent = "1235646565";
   td[1].textContent = "Stuff";
 

--- a/files/es/web/html/element/time/index.md
+++ b/files/es/web/html/element/time/index.md
@@ -140,8 +140,7 @@ El valor de fecha y hora (el valor legible por el equipo) es el valor del atribu
 #### HTML
 
 ```html
-<p>El concierto fué el <time
-  datetime="2001-05-15T19:00">15 de Mayo</time>.</p>
+<p>El concierto fué el <time datetime="2001-05-15T19:00">15 de Mayo</time>.</p>
 ```
 
 #### Output

--- a/files/es/web/html/element/title/index.md
+++ b/files/es/web/html/element/title/index.md
@@ -102,7 +102,9 @@ Una técnica de navegación común para los usuarios de tecnología de asistenci
 ### Ejemplo
 
 ```html
-<title>Menú - Comida china Blue House - FoodYum: ¡Comida a domicilio en línea hoy!</title>
+<title>
+  Menú - Comida china Blue House - FoodYum: ¡Comida a domicilio en línea hoy!
+</title>
 ```
 
 Si el envío de un formulario contiene errores y el envío vuelve a representar la página actual, el título se puede usar para ayudar a que los usuarios se den cuenta de cualquier error en su envío. Por ejemplo, actualice el valor de `title` de la página para reflejar cambios significativos en el estado de la página (como problemas de validación de formularios).
@@ -110,7 +112,10 @@ Si el envío de un formulario contiene errores y el envío vuelve a representar 
 ### Ejemplo
 
 ```html
-<title>2 errores - Tu orden - Comida china Blue House - FoodYum: ¡Comida a domicilio en línea hoy!</title>
+<title>
+  2 errores - Tu orden - Comida china Blue House - FoodYum: ¡Comida a domicilio
+  en línea hoy!
+</title>
 ```
 
 > **Nota:** Actualmente, los lectores de pantalla no anunciarán automáticamente la actualización dinámica del título de una página. Si va a actualizar el título de la página para reflejar cambios significativos en el estado de una página, entonces también puede ser necesario el uso de [regiones en vivo de ARIA](/es/docs/Web/Accessibility/ARIA/ARIA_Live_Regions).

--- a/files/es/web/html/element/tr/index.md
+++ b/files/es/web/html/element/tr/index.md
@@ -53,7 +53,7 @@ Este elemento incluye los [global attributes](/es/docs/HTML/Global_attributes).
     - `bottom`,que pondrá el texto tan cerca de la parte inferior de la célula como sae posible;
     - `middle`,que centrará el texto en la celda;
     - y `top`, que pondrá el texto como cerca de la parte superior de la célula como es posible.
-    > **Nota:** No utilice este atributo, ya que está obsoleto (y no es compatible) en el último estándar: {{cssxref("vertical-align")}} en su lugar establecer la propiedad CSS en él.
+      > **Nota:** No utilice este atributo, ya que está obsoleto (y no es compatible) en el último estándar: {{cssxref("vertical-align")}} en su lugar establecer la propiedad CSS en él.
 
 ## Interfaz DOM
 

--- a/files/es/web/html/element/track/index.md
+++ b/files/es/web/html/element/track/index.md
@@ -117,7 +117,7 @@ Si la pista _está_ asociada con un elemento de medios, usando el elemento {{HTM
 ```js
 let textTrackElem = document.getElementById("texttrack");
 
-textTrackElem.addEventListener("cuechange", event => {
+textTrackElem.addEventListener("cuechange", (event) => {
   let cues = event.target.track.activeCues;
 });
 ```
@@ -126,24 +126,20 @@ textTrackElem.addEventListener("cuechange", event => {
 
 ```html
 <video controls poster="/images/sample.gif">
-   <source src="sample.mp4" type="video/mp4">
-   <source src="sample.ogv" type="video/ogv">
-   <track kind="captions" src="sampleCaptions.vtt" srclang="en">
-   <track kind="descriptions"
-     src="sampleDescriptions.vtt" srclang="en">
-   <track kind="chapters" src="sampleChapters.vtt" srclang="en">
-   <track kind="subtitles" src="sampleSubtitles_de.vtt" srclang="de">
-   <track kind="subtitles" src="sampleSubtitles_en.vtt" srclang="en">
-   <track kind="subtitles" src="sampleSubtitles_ja.vtt" srclang="ja">
-   <track kind="subtitles" src="sampleSubtitles_oz.vtt" srclang="oz">
-   <track kind="metadata" src="keyStage1.vtt" srclang="en"
-     label="Key Stage 1">
-   <track kind="metadata" src="keyStage2.vtt" srclang="en"
-     label="Key Stage 2">
-   <track kind="metadata" src="keyStage3.vtt" srclang="en"
-     label="Key Stage 3">
-   <!-- Fallback -->
-   ...
+  <source src="sample.mp4" type="video/mp4" />
+  <source src="sample.ogv" type="video/ogv" />
+  <track kind="captions" src="sampleCaptions.vtt" srclang="en" />
+  <track kind="descriptions" src="sampleDescriptions.vtt" srclang="en" />
+  <track kind="chapters" src="sampleChapters.vtt" srclang="en" />
+  <track kind="subtitles" src="sampleSubtitles_de.vtt" srclang="de" />
+  <track kind="subtitles" src="sampleSubtitles_en.vtt" srclang="en" />
+  <track kind="subtitles" src="sampleSubtitles_ja.vtt" srclang="ja" />
+  <track kind="subtitles" src="sampleSubtitles_oz.vtt" srclang="oz" />
+  <track kind="metadata" src="keyStage1.vtt" srclang="en" label="Key Stage 1" />
+  <track kind="metadata" src="keyStage2.vtt" srclang="en" label="Key Stage 2" />
+  <track kind="metadata" src="keyStage3.vtt" srclang="en" label="Key Stage 3" />
+  <!-- Fallback -->
+  ...
 </video>
 ```
 

--- a/files/es/web/html/element/wbr/index.md
+++ b/files/es/web/html/element/wbr/index.md
@@ -33,7 +33,9 @@ Este elemento implementa la interface [HTMLElement](/es/docs/Web/API/HTMLElement
 La [guia de estilo de Yahoo](http://styleguide.yahoo.com/) recomienda [romper una URL antes de la puntuación](https://shopping.yahoo.com/9780312569846-yahoo-style-guide/) , para evitar dejar una marca de puntuación en el final de la línea , lo cual el lector podría confundir con el final de la URL .
 
 ```html
-<p>http://this<wbr>.is<wbr>.a<wbr>.really<wbr>.long<wbr>.example<wbr>.com/With<wbr>/deeper<wbr>/level<wbr>/pages<wbr>/deeper<wbr>/level<wbr>/pages<wbr>/deeper<wbr>/level<wbr>/pages<wbr>/deeper<wbr>/level<wbr>/pages<wbr>/deeper<wbr>/level<wbr>/pages</p>
+<p>
+  http://this<wbr />.is<wbr />.a<wbr />.really<wbr />.long<wbr />.example<wbr />.com/With<wbr />/deeper<wbr />/level<wbr />/pages<wbr />/deeper<wbr />/level<wbr />/pages<wbr />/deeper<wbr />/level<wbr />/pages<wbr />/deeper<wbr />/level<wbr />/pages<wbr />/deeper<wbr />/level<wbr />/pages
+</p>
 ```
 
 {{EmbedLiveSample("Example")}}

--- a/files/es/web/html/global_attributes/contextmenu/index.md
+++ b/files/es/web/html/global_attributes/contextmenu/index.md
@@ -39,15 +39,18 @@ Un _menu contextual_ es un menu que aparece sobre la interacción del usuario , 
 en conjunto con este Javascript
 
 ```js
-function incFont(){
-  document.getElementById("fontSizing").style.fontSize="larger";
+function incFont() {
+  document.getElementById("fontSizing").style.fontSize = "larger";
 }
-function decFont(){
-  document.getElementById("fontSizing").style.fontSize="smaller";
+function decFont() {
+  document.getElementById("fontSizing").style.fontSize = "smaller";
 }
-function changeImage(){
-  var j = Math.ceil((Math.random()*39)+1);
-  document.images[0].src="https://developer.mozilla.org/media/img/promote/promobutton_mdn" + j + ".png";
+function changeImage() {
+  var j = Math.ceil(Math.random() * 39 + 1);
+  document.images[0].src =
+    "https://developer.mozilla.org/media/img/promote/promobutton_mdn" +
+    j +
+    ".png";
 }
 ```
 

--- a/files/es/web/html/global_attributes/itemid/index.md
+++ b/files/es/web/html/global_attributes/itemid/index.md
@@ -48,19 +48,20 @@ Este ejemplo utiliza atributos de microdatos para representar los siguientes dat
 #### HTML
 
 ```html
-<dl itemscope
+<dl
+  itemscope
   itemtype="https://schema.org/Book"
   itemid="urn:isbn:0-374-22848-5<">
- <dt>Título
-   <dd
-    itemprop="title">Owls of the Eastern Ice
- <dt>Autor
-   <dd
-     itemprop="author">Jonathan C Slaght
- <dt>Fecha de publicación
- <dd><time
-   itemprop="datePublished"
-   datetime="2020-08-04">4 de Agosto del 2020</time>
+  <dt>Título</dt>
+  <dd itemprop="title">Owls of the Eastern Ice</dd>
+  <dt>Autor</dt>
+  <dd itemprop="author">Jonathan C Slaght</dd>
+  <dt>Fecha de publicación</dt>
+  <dd>
+    <time itemprop="datePublished" datetime="2020-08-04"
+      >4 de Agosto del 2020</time
+    >
+  </dd>
 </dl>
 ```
 

--- a/files/es/web/html/global_attributes/itemprop/index.md
+++ b/files/es/web/html/global_attributes/itemprop/index.md
@@ -11,9 +11,14 @@ Aquí hay un ejemplo .
 ```html
 <div itemscope itemtype="http://schema.org/Movie">
   <h1 itemprop="name">Avatar</h1>
-  <span>Director: <span itemprop="director">James Cameron</span> (born August 16, 1954)</span>
+  <span
+    >Director: <span itemprop="director">James Cameron</span> (born August 16,
+    1954)</span
+  >
   <span itemprop="genre">Ciencia ficcion</span>
-  <a href="../movies/avatar-theatrical-trailer.html" itemprop="trailer">Trailer</a>
+  <a href="../movies/avatar-theatrical-trailer.html" itemprop="trailer"
+    >Trailer</a
+  >
 </div>
 ```
 

--- a/files/es/web/html/global_attributes/itemref/index.md
+++ b/files/es/web/html/global_attributes/itemref/index.md
@@ -18,11 +18,11 @@ El atributo itemref puede ser solo especificado en elementos que tienen un atrib
 
 ```html
 <div itemscope id="amanda" itemref="a b"></div>
-<p id="a">Name: <span itemprop="name">Amanda</span> </p>
+<p id="a">Name: <span itemprop="name">Amanda</span></p>
 <div id="b" itemprop="band" itemscope itemref="c"></div>
 <div id="c">
-    <p>Band: <span itemprop="name">Jazz Band</span> </p>
-    <p>Size: <span itemprop="size">12</span> players</p>
+  <p>Band: <span itemprop="name">Jazz Band</span></p>
+  <p>Size: <span itemprop="size">12</span> players</p>
 </div>
 ```
 

--- a/files/es/web/html/global_attributes/itemscope/index.md
+++ b/files/es/web/html/global_attributes/itemscope/index.md
@@ -21,7 +21,10 @@ El siguiente ejemplo especifica que el atributo `itemscope`. El ejemplo especifi
 ```html
 <div itemscope itemtype="http://schema.org/Movie">
   <h1 itemprop="nombre">Avatar</h1>
-  <span>Director: <span itemprop="director">James Cameron</span> (born August 16, 1954)</span>
+  <span
+    >Director: <span itemprop="director">James Cameron</span> (born August 16,
+    1954)</span
+  >
   <span itemprop="genero">Ciencia ficcion</span>
   <a href="https://youtu.be/0AY1XIkX7bY" itemprop="trailer">Trailer</a>
 </div>

--- a/files/es/web/html/global_attributes/title/index.md
+++ b/files/es/web/html/global_attributes/title/index.md
@@ -20,7 +20,10 @@ Semánticas adicionales se adjuntan a los atributos de **title** de los elemento
 El atributo **title** puede contener varias líneas . Cada `U+000A LINE FEED` (`LF`) insertada representa una línea nueva . Se debe tener precaución ya que esto significa que :
 
 ```html
-<p>Líneas nuevas en title deben de tomarse en cuenta , como esta <abbr title="Este es un título multilínea">ejemplo </abbr>.</p>
+<p>
+  Líneas nuevas en title deben de tomarse en cuenta , como esta
+  <abbr title="Este es un título multilínea">ejemplo </abbr>.
+</p>
 ```
 
 define un título de dos líneas .


### PR DESCRIPTION
This PR formats the `/web/html` folder of the Spanish locale using Prettier.  This is the second part.
