### PR TITLE
Remove broken Compat section (not in en-us doc)

### DIFF
--- a/files/fr/web/http/status/422/index.md
+++ b/files/fr/web/http/status/422/index.md
@@ -19,7 +19,3 @@ Le code de statut de réponse HTTP **`422 Unprocessable Entity`** indique que le
 ## Spécifications
 
 {{Specifications}}
-
-## Compatibilité des navigateurs
-
-{{Compat}}


### PR DESCRIPTION
Removed empty 'Compatibility' section

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The Compatibility section is not present on the English version of the page and doesn't work on the French one so I removed it
The section on the French one before changes:
![Screenshot 2023-07-21 at 12 01 36](https://github.com/mdn/translated-content/assets/7305620/201c2333-c2ed-4124-9a6f-c6e50f27a6ae)

<!-- ✍️ Summarize your changes in one or two sentences -->
