### PR TITLE
ko: HTML 디버깅 페이지 일부 번역

### DIFF
--- a/files/ko/learn/html/introduction_to_html/debugging_html/index.md
+++ b/files/ko/learn/html/introduction_to_html/debugging_html/index.md
@@ -67,7 +67,7 @@ HTML은 Rust만큼 복잡하지 않습니다. HTML은 브라우저가 구문 분
 유연한 성질의 HTML 코드를 배울 시간입니다.
 
 1. 첫째로, 우리의 [debug-example demo](https://github.com/mdn/learning-area/blob/master/html/introduction-to-html/debugging-html/debug-example.html)를 다운로드하고 Local에 저장하세요. This demo is deliberately written to have some errors in it for us to explore (the HTML markup is said to be **badly-formed**, as opposed to **well-formed**).
-2. Next, open it in a browser. You will see something like this:![A simple HTML document with a title of HTML debugging examples, and some information about common HTML errors, such as unclosed elements, badly nested elements, and unclosed attributes. ](badly-formed-html.png)
+2. 다음으로, 브라우저에서 다운로드 받은 파일을 여세요. 그렇다면 브라우저에서 아래와 같이 보일겁니다.![A simple HTML document with a title of HTML debugging examples, and some information about common HTML errors, such as unclosed elements, badly nested elements, and unclosed attributes. ](badly-formed-html.png)
 3. This immediately doesn't look great; let's look at the source code to see if we can work out why (only the body contents are shown):
 
     ```html

--- a/files/ko/learn/html/introduction_to_html/debugging_html/index.md
+++ b/files/ko/learn/html/introduction_to_html/debugging_html/index.md
@@ -66,9 +66,9 @@ HTML은 Rust만큼 복잡하지 않습니다. HTML은 브라우저가 구문 분
 
 유연한 성질의 HTML 코드를 배울 시간입니다.
 
-1. 첫째로, 우리의 [debug-example demo](https://github.com/mdn/learning-area/blob/master/html/introduction-to-html/debugging-html/debug-example.html)를 다운로드하고 Local에 저장하세요. This demo is deliberately written to have some errors in it for us to explore (the HTML markup is said to be **badly-formed**, as opposed to **well-formed**).
-2. 다음으로, 브라우저에서 다운로드 받은 파일을 여세요. 그렇다면 브라우저에서 아래와 같이 보일겁니다.![A simple HTML document with a title of HTML debugging examples, and some information about common HTML errors, such as unclosed elements, badly nested elements, and unclosed attributes. ](badly-formed-html.png)
-3. This immediately doesn't look great; let's look at the source code to see if we can work out why (only the body contents are shown):
+1. 첫째로, 우리의 [디버그 예제 데모](https://github.com/mdn/learning-area/blob/master/html/introduction-to-html/debugging-html/debug-example.html)를 다운로드하고 Local에 저장하세요. 이 데모는 일부러 오류를 갖고 있도록 쓰여졌습니다.(HTML 마크업은 **well-formed** 대신 **badly-formed**이라고 합니다.).
+2. 다음으로, 브라우저에서 다운로드 받은 파일을 여세요. 그렇다면 브라우저에서 아래와 같이 보일겁니다.![제목과 함꼐한 HTML 디버깅을 위한 간단한 HTML 문서, 그리고 닫히지 않은 요소들에 대한 HTML 오류, 잘못된 중첩 요소들, 그리고 닫히지 않은 속성. ](badly-formed-html.png)
+3. 이것은 매우 좋지 않습니다. 왜 그런지 이 소스코드를 보도록 하겠습니다. (오직 body의 내용만 확인하세요)
 
     ```html
     <h1>HTML debugging examples</h1>
@@ -89,7 +89,7 @@ HTML은 Rust만큼 복잡하지 않습니다. HTML은 브라우저가 구문 분
     </ul>
     ```
 
-4. Let's review the problems:
+4. 함께 리뷰해봅시다.
 
     - The {{htmlelement("p","paragraph")}} and {{htmlelement("li","list item")}} elements have no closing tags. Looking at the image above, this doesn't seem to have affected the markup rendering too badly, as it is easy to infer where one element should end and another should begin.
     - The first {{htmlelement("strong")}} element has no closing tag. This is a bit more problematic, as it isn't easy to tell where the element is supposed to end. In fact, the whole of the rest of the text has been strongly emphasised.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

영어 문장을 한글로 일부 번역했습니다.

`Next, open it in a browser. You will see something like this:`

위 문장을 아래와 같이 번역하였습니다.

`다음으로, 브라우저에서 다운로드 받은 파일을 여세요. 그렇다면 브라우저에서 아래와 같이 보일겁니다.`

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

아직 언어의 장벽을 넘지 못한 한국인들이 너무나 많습니다.

이런 현실에 조금이나마 개발자 교육에 기여하고 싶어서 기여를 하게 되었습니다.
