### PR TITLE
pt-br/zh-cn: Fix Learn/CSS/Building_blocks/Selectors

### DIFF
--- a/files/pt-br/learn/css/building_blocks/selectors/index.md
+++ b/files/pt-br/learn/css/building_blocks/selectors/index.md
@@ -65,9 +65,8 @@ h1 {
 
 Eu também poderia combiná-los em uma lista de seletores, adicionando uma vírgula entre eles.
 
-```css
-h1,
-.special {
+```css-nolint
+h1, .special {
   color: blue;
 }
 ```
@@ -94,7 +93,7 @@ h1 {
   color: blue;
 }
 
-.special {
+..special {
   color: blue;
 }
 ```
@@ -103,7 +102,7 @@ Quando combinados, no entanto, nem o `h1` nem a classe terão o estilo, pois a r
 
 ```css
 h1,
-.special {
+..special {
   color: blue;
 }
 ```

--- a/files/zh-cn/learn/css/building_blocks/selectors/index.md
+++ b/files/zh-cn/learn/css/building_blocks/selectors/index.md
@@ -61,9 +61,8 @@ h1 {
 
 我也可以将它们组合起来，在它们之间加上一个逗号，变为选择器列表。
 
-```css
-h1,
-.special {
+```css-nolint
+h1, .special {
   color: blue;
 }
 ```


### PR DESCRIPTION
This PR fixes some undesired formatting performed on `Learn/CSS/Building_blocks/Selectors` for both Portuguese Brazilian and Simplified Chinese.
