### PR TITLE
Fix Markdownlint ignores

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -228,5 +228,11 @@
     }
   },
   "customRules": ["markdownlint-rule-search-replace"],
-  "ignores": ["node_modules", "**/conflicting/**", "**/orphaned/**", ".github/"]
+  "ignores": [
+    "node_modules",
+    ".git",
+    ".github",
+    "**/conflicting/**",
+    "**/orphaned/**"
+  ]
 }


### PR DESCRIPTION
This PR updates the Markdownlint's ignores to ignore `.git` as well.
