### PR TITLE
es: Format /web/api and /web/html using Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -28,9 +28,7 @@ build/
 # The following folders still need a full pass:
 
 # es
-/files/es/web/api/**/*.md
 /files/es/web/css/**/*.md
-/files/es/web/html/**/*.md
 /files/es/web/javascript/reference/**/*.md
 
 # fr

--- a/files/es/web/api/document_object_model/whitespace/index.md
+++ b/files/es/web/api/document_object_model/whitespace/index.md
@@ -18,8 +18,8 @@ En el caso de HTML, los espacios en blanco se ignoran en gran medida: los espaci
 
 ### HTML largely ignores whitespace?
 
-```html
-<!DOCTYPE html>
+```html-nolint
+<!doctype html>
 
     <h1>       ¡Hola      mundo!     </h1>
 ```
@@ -41,18 +41,18 @@ Cualquier carácter de espacio en blanco que esté fuera de los elementos HTML d
 
 Tomemos el siguiente documento, por ejemplo:
 
-```html
-<!DOCTYPE html>
+```html-nolint
+<!doctype html>
 <html>
-<head>
-  <title>Mi Documento</title>
-</head>
-<body>
-  <h1>Encabezado</h1>
-  <p>
-    Párrafo
-  </p>
-</body>
+  <head>
+    <title>Mi Documento</title>
+  </head>
+  <body>
+    <h1>Encabezado</h1>
+    <p>
+      Párrafo
+    </p>
+  </body>
 </html>
 ```
 
@@ -70,7 +70,7 @@ Tomemos otro ejemplo realmente simple. Para hacerlo más fácil, ilustramos todo
 
 Este ejemplo:
 
-```html
+```html-nolint
 <h1>◦◦◦¡Hola◦⏎
 ⇥⇥⇥⇥<span>◦mundo!</span>⇥◦◦</h1>
 ```
@@ -79,7 +79,7 @@ se representa en el navegador así:
 
 #### Ejemplo
 
-```html hidden
+```html-nolint hidden
 <h1>   ¡Hola
     <span> mundo!</span>   </h1>
 ```
@@ -100,35 +100,35 @@ Dentro de este contexto, el procesamiento de caracteres de espacio en blanco se 
 
 1. Primero, todos los espacios y tabulaciones inmediatamente antes y después de un salto de línea se ignoran, por lo que, si tomamos nuestro marcado de ejemplo anterior y aplicamos esta primera regla, obtenemos:
 
-    ```html
-    <h1>◦◦◦¡Hola⏎
-    <span>◦mundo!</span>⇥◦◦</h1>
-    ```
+   ```html-nolint
+   <h1>◦◦◦¡Hola⏎
+   <span>◦mundo!</span>⇥◦◦</h1>
+   ```
 
 2. A continuación, todos los caracteres de tabulación se tratan como caracteres de espacio, por lo que el ejemplo se convierte en:
 
-    ```html
-    <h1>◦◦◦¡Hola⏎
-    <span>◦mundo!</span>◦◦◦</h1>
-    ```
+   ```html-nolint
+   <h1>◦◦◦¡Hola⏎
+   <span>◦mundo!</span>◦◦◦</h1>
+   ```
 
 3. A continuación, los saltos de línea se convierten en espacios:
 
-    ```html
-    <h1>◦◦◦¡Hola◦<span>◦mundo!</span>◦◦◦</h1>
-    ```
+   ```html
+   <h1>◦◦◦¡Hola◦<span>◦mundo!</span>◦◦◦</h1>
+   ```
 
 4. Después de eso, cualquier espacio inmediatamente después de otro espacio (incluso a través de dos elementos en línea separados) se ignora, por lo que terminamos con:
 
-    ```html
-    <h1>◦¡Hola◦<span>mundo!</span>◦</h1>
-    ```
+   ```html
+   <h1>◦¡Hola◦<span>mundo!</span>◦</h1>
+   ```
 
 5. Y finalmente, las secuencias de espacios al principio y al final de una línea se eliminan, por lo que eventualmente obtenemos esto:
 
-    ```html
-    <h1>¡Hola◦<span>mundo!</span></h1>
-    ```
+   ```html
+   <h1>¡Hola◦<span>mundo!</span></h1>
+   ```
 
 Es por eso que las personas que visitan la página web simplemente verán la frase "¡Hola mundo!" muy bien escrita en la parte superior de la página, en lugar de un "!Hola" con una sangría extraña, seguido de un "mundo!" en la línea debajo de esa.
 
@@ -140,7 +140,7 @@ Anteriormente, solo miramos elementos que contienen elementos en línea y contex
 
 En este contexto, los espacios en blanco se tratan de manera muy diferente. Veamos un ejemplo para explicar cómo. Hemos marcado los espacios en blanco como antes.
 
-```html
+```html-nolint
 <body>⏎
 ⇥<div>◦◦¡Hola◦◦</div>⏎
 ⏎
@@ -154,7 +154,7 @@ Esto se renderiza así:
 
 #### Ejemplo
 
-```html hidden
+```html-nolint hidden
 <body>
   <div>  ¡Hola  </div>
 
@@ -170,23 +170,23 @@ Podemos resumir cómo se maneja el espacio en blanco aquí de la siguiente maner
 
 1. Debido a que estamos dentro de un contexto de formato de bloque, todo debe ser un bloque, por lo que nuestros 3 nodos de texto también se convierten en bloques, al igual que los 2 `<div>`s. Los bloques ocupan todo el ancho disponible y se apilan unos encima de los otros, lo cual significa que terminamos con un diseño compuesto por esta lista de bloques:
 
-    ```html
-    <block>⏎⇥</block>
-    <block>◦◦¡Hola◦◦</block>
-    <block>⏎◦◦◦</block>
-    <block>◦◦mundo!◦◦</block>
-    <block>◦◦⏎</block>
-    ```
+   ```html
+   <block>⏎⇥</block>
+   <block>◦◦¡Hola◦◦</block>
+   <block>⏎◦◦◦</block>
+   <block>◦◦mundo!◦◦</block>
+   <block>◦◦⏎</block>
+   ```
 
 2. Esto luego se simplifica aún más aplicando las reglas de procesamiento para espacios en blanco en contextos de formato en línea a estos bloques:
 
-    ```html
-    <block></block>
-    <block>¡Hola</block>
-    <block></block>
-    <block>mundo!</block>
-    <block></block>
-    ```
+   ```html
+   <block></block>
+   <block>¡Hola</block>
+   <block></block>
+   <block>mundo!</block>
+   <block></block>
+   ```
 
 3. Los 3 bloques vacíos que tenemos ahora no van a ocupar ningún espacio en el diseño final, porque no contienen nada, así que terminaremos con solo 2 bloques ocupando espacio en la página. Las personas que visitan la página web ven las palabras "!Hola" y "mundo!" en 2 líneas separadas, ya que esperarías que se distribuyeran 2 `<div>`s. El motor del navegador esencialmente ha ignorado todos los espacios en blanco que se agregaron en el código fuente.
 
@@ -218,7 +218,7 @@ Considera este ejemplo (nuevamente, los espacios en blanco en el HTML están mar
 }
 ```
 
-```html
+```html-nolint
 <ul class="people-list">⏎
 
 ◦◦<li></li>⏎
@@ -239,13 +239,22 @@ Esto se traduce de la siguiente manera:
 #### Ejemplo
 
 ```css hidden
-.people-list { list-style-type: none; margin: 0; padding: 0; }
-.people-list li { display: inline-block; width: 2em; height: 2em; background: #f06; border: 1px solid; }
+.people-list {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+.people-list li {
+  display: inline-block;
+  width: 2em;
+  height: 2em;
+  background: #f06;
+  border: 1px solid;
+}
 ```
 
 ```html hidden
 <ul class="people-list">
-
   <li></li>
 
   <li></li>
@@ -255,7 +264,6 @@ Esto se traduce de la siguiente manera:
   <li></li>
 
   <li></li>
-
 </ul>
 ```
 
@@ -311,7 +319,7 @@ li {
 
 También puedes resolver este problema colocando los elementos de tu lista en la misma línea en la fuente, lo cual hace que los nodos de espacios en blanco no se creen en primer lugar:
 
-```html
+```html-nolint
 <li></li><li></li><li></li><li></li><li></li>
 ```
 
@@ -337,7 +345,6 @@ El siguiente código JavaScript define varias funciones que facilitan el manejo 
  * espacios irrompibles (y también algunos otros caracteres).
  */
 
-
 /**
  * Determina si el contenido de texto de un nodo es completamente de espacios en blanco.
  *
@@ -346,12 +353,10 @@ El siguiente código JavaScript define varias funciones que facilitan el manejo 
  * @return     True si todo el contenido de texto de |nod| es espacio en blanco,
  *             de lo contrario false.
  */
-function is_all_ws( nod )
-{
+function is_all_ws(nod) {
   // Usa las características de String y RegExp de ECMA-262 Edición 3
-  return !(/[^\t\n\r ]/.test(nod.textContent));
+  return !/[^\t\n\r ]/.test(nod.textContent);
 }
-
 
 /**
  * Determina si un nodo debe ser ignorado por las funciones del iterador.
@@ -363,10 +368,11 @@ function is_all_ws( nod )
  *             y de lo contrario false.
  */
 
-function is_ignorable( nod )
-{
-  return ( nod.nodeType == 8) || // Un nodo comment
-         ( (nod.nodeType == 3) && is_all_ws(nod) ); // un nodo text, todo es eeb
+function is_ignorable(nod) {
+  return (
+    nod.nodeType == 8 || // Un nodo comment
+    (nod.nodeType == 3 && is_all_ws(nod))
+  ); // un nodo text, todo es eeb
 }
 
 /**
@@ -382,8 +388,7 @@ function is_ignorable( nod )
  *                  ignorable según |is_ignorable|, o
  *               2) null si no existe tal nodo.
  */
-function node_before( sib )
-{
+function node_before(sib) {
   while ((sib = sib.previousSibling)) {
     if (!is_ignorable(sib)) return sib;
   }
@@ -400,8 +405,7 @@ function node_before( sib )
  *                  ignorable según |is_ignorable|, o
  *               2) null si no existe tal nodo.
  */
-function node_after( sib )
-{
+function node_after(sib) {
   while ((sib = sib.nextSibling)) {
     if (!is_ignorable(sib)) return sib;
   }
@@ -420,9 +424,8 @@ function node_after( sib )
  *                  ignorable según |is_ignorable|, o
  *               2) null si no existe tal nodo.
  */
-function last_child( par )
-{
-  var res=par.lastChild;
+function last_child(par) {
+  var res = par.lastChild;
   while (res) {
     if (!is_ignorable(res)) return res;
     res = res.previousSibling;
@@ -440,9 +443,8 @@ function last_child( par )
  *                  ignorable según |is_ignorable|, o
  *               2) null si no existe tal nodo.
  */
-function first_child( par )
-{
-  var res=par.firstChild;
+function first_child(par) {
+  var res = par.firstChild;
   while (res) {
     if (!is_ignorable(res)) return res;
     res = res.nextSibling;
@@ -459,13 +461,11 @@ function first_child( par )
  * @return     Una cadena que proporciona el contenido del nodo de texto con
  *             espacios en blanco colapsados.
  */
-function data_of( txt )
-{
+function data_of(txt) {
   var data = txt.textContent;
   // Usa las características de String y RegExp de ECMA-262 Edición 3
   data = data.replace(/[\t\n\r ]+/g, " ");
-  if (data.charAt(0) == " ")
-    data = data.substring(1, data.length);
+  if (data.charAt(0) == " ") data = data.substring(1, data.length);
   if (data.charAt(data.length - 1) == " ")
     data = data.substring(0, data.length - 1);
   return data;
@@ -478,10 +478,8 @@ El siguiente código demuestra el uso de las funciones anteriores. Itera sobre l
 
 ```js
 var cur = first_child(document.getElementById("test"));
-while (cur)
-{
-  if (data_of(cur.firstChild) == "Este es el tercer párrafo.")
-  {
+while (cur) {
+  if (data_of(cur.firstChild) == "Este es el tercer párrafo.") {
     cur.className = "magic";
     cur.firstChild.textContent = "Este es el párrafo mágico.";
   }

--- a/files/es/web/api/element/innerhtml/index.md
+++ b/files/es/web/api/element/innerhtml/index.md
@@ -59,9 +59,8 @@ document.body.innerHTML = ""; // Reemplaza el contenido de <body> con una cadena
 El siguiente ejemplo recupera la sintaxis HTML actual del documento y reemplaza los caracteres "`<`" con la entidad HTML "`&lt;`", convirtiendo esencialmente el HTML en texto plano. Esto luego se envuelve en un elemento [\<pre>](/es/docs/Web/HTML/Element/pre). Entonces el valor de innerHTML se cambia a esta nueva cadena. Como resultado, se muestra en pantalla el código fuente completo de la página.
 
 ```js
-document.documentElement.innerHTML = "<pre>" +
-         document.documentElement.innerHTML.replace(/</g,"&lt;") +
-            "</pre>";
+document.documentElement.innerHTML =
+  "<pre>" + document.documentElement.innerHTML.replace(/</g, "&lt;") + "</pre>";
 ```
 
 > **Nota:** Esta propiedad fue inicialmente implementada por navegadores web, y luego especificada por el WHATWG y el W3C en HTML5. Implementaciones antiguas no la implementarán exactamente igual. Por ejemplo, cuando el texto es ingresado en una caja de **texto multilinea (elemento `textarea`)**, Internet Explorer cambiará el valor de la propiedad `innerHTML` del **elemento `textarea`**, mientras que los navegadores Gecko no lo hacen.

--- a/files/es/web/api/htmlimageelement/index.md
+++ b/files/es/web/api/htmlimageelement/index.md
@@ -69,13 +69,13 @@ _Heredados de su padre, {{domxref("HTMLElement")}}._
 
 ```js
 var img1 = new Image(); // HTML5 Constructor
-img1.src = 'image1.png';
-img1.alt = 'alt';
+img1.src = "image1.png";
+img1.alt = "alt";
 document.body.appendChild(img1);
 
-var img2 = document.createElement('img'); // Uso DOM HTMLImageElement
-img2.src = 'image2.jpg';
-img2.alt = 'alt text';
+var img2 = document.createElement("img"); // Uso DOM HTMLImageElement
+img2.src = "image2.jpg";
+img2.alt = "alt text";
 document.body.appendChild(img2);
 
 // Usando la primera imagen en el documento

--- a/files/es/web/api/htmlselectelement/index.md
+++ b/files/es/web/api/htmlselectelement/index.md
@@ -82,13 +82,13 @@ _This interface inherits the methods of {{domxref("HTMLElement")}}, and of {{dom
 </select>
 */
 
-var select = document.getElementById('s');
+var select = document.getElementById("s");
 
 // return the index of the selected option
 console.log(select.selectedIndex); // 1
 
 // return the value of the selected option
-console.log(select.options[select.selectedIndex].value) // Second
+console.log(select.options[select.selectedIndex].value); // Second
 ```
 
 A better way to track changes to the user's selection is to watch for the [`change`](/es/docs/Web/Reference/Events/change) event to occur on the `<select>`. This will tell you when the value changes, and you can then update anything you need to. See [the example provided](/es/docs/Web/Events/change#Example_Change_event_on_a_select) in the documentation for the `change` event for details.

--- a/files/es/web/api/idbdatabase/index.md
+++ b/files/es/web/api/idbdatabase/index.md
@@ -99,7 +99,7 @@ In the following code snippet, we open a database asynchronously ({{domxref("IDB
 This next line opens up a transaction on the Database, then opens an object store that we can then manipulate the data inside of.
 
 ```js
-    var objectStore = db.transaction('toDoList').objectStore('toDoList');
+var objectStore = db.transaction("toDoList").objectStore("toDoList");
 ```
 
 ## Especificaciones

--- a/files/es/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
+++ b/files/es/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
@@ -17,7 +17,8 @@ El primer paso es añadir el HTML para crear el elemento {{ HTMLElement("video")
 
 ```html
 <video id="video">
-  Parece ser que tu navegador no soporta el elemento HTML5. <code>&lt;video&gt;</code>
+  Parece ser que tu navegador no soporta el elemento HTML5.
+  <code>&lt;video&gt;</code>
 </video>
 ```
 

--- a/files/es/web/html/element/link/index.md
+++ b/files/es/web/html/element/link/index.md
@@ -35,6 +35,7 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
     >
     > - Si el atributo `disabled` fue añadido directamente al elemento en la página, no incluya el elemento {{HTMLElement("link")}} en vez de eso;
     > - Establezca la **propiedad** `disabled` del objeto DOM `StyleSheet` vía programación.
+
 - `href`
   - : Este atributo especifica la {{glossary("URL")}} del recurso enlazado. La URL debe ser absoluta o relativa.
 - `hreflang`

--- a/files/es/web/html/element/link/index.md
+++ b/files/es/web/html/element/link/index.md
@@ -35,7 +35,6 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
     >
     > - Si el atributo `disabled` fue añadido directamente al elemento en la página, no incluya el elemento {{HTMLElement("link")}} en vez de eso;
     > - Establezca la **propiedad** `disabled` del objeto DOM `StyleSheet` vía programación.
-    >
 - `href`
   - : Este atributo especifica la {{glossary("URL")}} del recurso enlazado. La URL debe ser absoluta o relativa.
 - `hreflang`

--- a/files/es/web/html/element/link/index.md
+++ b/files/es/web/html/element/link/index.md
@@ -30,6 +30,7 @@ Este elemento incluye los [atributos globales](/es/docs/Web/HTML/Atributos_Globa
     - `"use-credentials"`
       - : Una solicitud a un origen cruzado (esto es, con el encabezado HTTP `Origin:`) es realizada, enviando credenciales (es decir, se envían cookies, certificado y autenticación básica HTTP). Si el servidor no otorga credenciales al sitio de origen (a través del encabezado HTTP `Access-Control-Allow-Credentials:`), la imagen estará _corrupta_, y su uso estará restringido.Si no está presente, el recurso es obtenido sin una solicitud CORS (sin enviar el encabezado HTTP `Origin:`), previniendo así su uso no corrupto en elementos {{HTMLElement('canvas')}}. Si se introduce un valor no permitido, se maneja como si usara el valor **anonymous**. Véase [atributos de configuración CORS](/es/docs/Web/HTML/Atributos_de_configuracion_CORS) para más información.
 - `disabled` {{Non-standard_inline}}
+
   - : Este atributo es usado para deshabilitar una relación de enlace. Agregando programación, este atributo puede ser usado para habilitar o deshabilitar la relación con distintas hojas de estilos.
     > **Nota:** Aunque no hay atributo `disabled` en el estándar de HTML, **sí** hay un atributo `disabled` en el objeto DOM `HTMLLinkElement`.El uso de `disabled` como atributo HTML no es estándar, y solo puede ser usado en algunos navegadores ([W3 #27677](https://www.w3.org/Bugs/Public/show_bug.cgi?id=27677)). **No debe usarse**. Para lograr un efecto similar, se puede usar una de las siguientes técnicas:
     >


### PR DESCRIPTION
This PR formats the `/web/api` and `/web/html` folders of the Spanish locale using Prettier.  Most of the work has been performed in other PRs; this just performs the final pieces and enforces formatting in the Prettier config.
