### PR TITLE
es: Format /web/javascript using Prettier (part 2)

### DIFF
--- a/files/es/web/javascript/reference/global_objects/error/index.md
+++ b/files/es/web/javascript/reference/global_objects/error/index.md
@@ -73,9 +73,9 @@ Normalmente, creas un objeto `Error` con la intención de generarlo utilizando l
 
 ```js
 try {
-  throw new Error('¡Ups!')
+  throw new Error("¡Ups!");
 } catch (e) {
-  console.error(e.name + ': ' + e.message)
+  console.error(e.name + ": " + e.message);
 }
 ```
 
@@ -85,12 +85,12 @@ Puede elegir manejar solo tipos de error específicos probando el tipo de error 
 
 ```js
 try {
-  foo.bar()
+  foo.bar();
 } catch (e) {
   if (e instanceof EvalError) {
-    console.error(e.name + ': ' + e.message)
+    console.error(e.name + ": " + e.message);
   } else if (e instanceof RangeError) {
-    console.error(e.name + ': ' + e.message)
+    console.error(e.name + ": " + e.message);
   }
   // ... etc
 }
@@ -110,29 +110,29 @@ Consulta ["¿Cuál es una buena manera de extender `Error` en JavaScript?"](http
 
 ```js
 class CustomError extends Error {
-  constructor(foo = 'bar', ...params) {
+  constructor(foo = "bar", ...params) {
     // Pasa los argumentos restantes (incluidos los específicos del proveedor) al constructor padre
-    super(...params)
+    super(...params);
 
     // Mantiene un seguimiento adecuado de la pila para el lugar donde se lanzó nuestro error (solo disponible en V8)
     if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, CustomError)
+      Error.captureStackTrace(this, CustomError);
     }
 
-    this.name = 'CustomError'
+    this.name = "CustomError";
     // Información de depuración personalizada
-    this.foo = foo
-    this.date = new Date()
+    this.foo = foo;
+    this.date = new Date();
   }
 }
 
 try {
-  throw new CustomError('baz', 'bazMessage')
-} catch(e) {
-  console.error(e.name)    // CustomError
-  console.error(e.foo)     // baz
-  console.error(e.message) // bazMessage
-  console.error(e.stack)   // stacktrace
+  throw new CustomError("baz", "bazMessage");
+} catch (e) {
+  console.error(e.name); // CustomError
+  console.error(e.foo); // baz
+  console.error(e.message); // bazMessage
+  console.error(e.stack); // stacktrace
 }
 ```
 
@@ -143,7 +143,7 @@ try {
 ```js
 function CustomError(foo, message, fileName, lineNumber) {
   var instance = new Error(message, fileName, lineNumber);
-  instance.name = 'CustomError';
+  instance.name = "CustomError";
   instance.foo = foo;
   Object.setPrototypeOf(instance, Object.getPrototypeOf(this));
   if (Error.captureStackTrace) {
@@ -157,19 +157,19 @@ CustomError.prototype = Object.create(Error.prototype, {
     value: Error,
     enumerable: false,
     writable: true,
-    configurable: true
-  }
+    configurable: true,
+  },
 });
 
-if (Object.setPrototypeOf){
+if (Object.setPrototypeOf) {
   Object.setPrototypeOf(CustomError, Error);
 } else {
   CustomError.__proto__ = Error;
 }
 
 try {
-  throw new CustomError('baz', 'bazMessage');
-} catch(e){
+  throw new CustomError("baz", "bazMessage");
+} catch (e) {
   console.error(e.name); // CustomError
   console.error(e.foo); // baz
   console.error(e.message); // bazMessage

--- a/files/es/web/javascript/reference/global_objects/error/linenumber/index.md
+++ b/files/es/web/javascript/reference/global_objects/error/linenumber/index.md
@@ -15,18 +15,18 @@ La propiedad **lineNumber** contiene el número de linea en el archivo que arroj
 ### Utilizando `lineNumber`
 
 ```js
-var e = new Error('No fue posible analizar el dato introducido');
+var e = new Error("No fue posible analizar el dato introducido");
 throw e;
-console.log(e.lineNumber) // 2
+console.log(e.lineNumber); // 2
 ```
 
 ### Ejemplo alternativo utilizando el evento '`error'`
 
 ```js
-window.addEventListener('error', function(e) {
+window.addEventListener("error", function (e) {
   console.log(e.lineno); // 5
 });
-var e = new Error('No fue posible analizar el dato introducido');
+var e = new Error("No fue posible analizar el dato introducido");
 throw e;
 ```
 

--- a/files/es/web/javascript/reference/global_objects/error/message/index.md
+++ b/files/es/web/javascript/reference/global_objects/error/message/index.md
@@ -26,7 +26,7 @@ Por defecto, la propiedad `message` es una cadena vacía, pero se puede especifi
 ### Lanzar un error personalizado
 
 ```js
-var e = new Error('No se pudo analizar la entrada');
+var e = new Error("No se pudo analizar la entrada");
 // e.message es 'No se pudo analizar la entrada'
 throw e;
 ```

--- a/files/es/web/javascript/reference/global_objects/error/name/index.md
+++ b/files/es/web/javascript/reference/global_objects/error/name/index.md
@@ -17,9 +17,9 @@ De forma predeterminada, las instancias {{JSxRef("Error")}} reciben el nombre "E
 ### Lanzar un error personalizado
 
 ```js
-var e = new Error('Entrada mal formada'); // e.name es 'Error'
+var e = new Error("Entrada mal formada"); // e.name es 'Error'
 
-e.name = 'ParseError';
+e.name = "ParseError";
 throw e;
 // e.toString() devolverá 'ParseError: Entrada mal formada'
 ```

--- a/files/es/web/javascript/reference/global_objects/error/tostring/index.md
+++ b/files/es/web/javascript/reference/global_objects/error/tostring/index.md
@@ -23,8 +23,8 @@ Una cadena que representa el objeto {{JSxRef("Error")}} especificado.
 El objeto {{JSxRef("Error")}} redefine el método {{JSxRef("Object.prototype.toString()")}} heredado por todos los objetos. Su semántica es la siguiente (asumiendo que {{JSxRef("Object")}} y {{JSxRef("String")}} tienen sus valores originales):
 
 ```js
-Error.prototype.toString = function() {
-  'use strict';
+Error.prototype.toString = function () {
+  "use strict";
 
   var obj = Object(this);
   if (obj !== this) {
@@ -32,19 +32,19 @@ Error.prototype.toString = function() {
   }
 
   var name = this.name;
-  name = (name === undefined) ? 'Error' : String(name);
+  name = name === undefined ? "Error" : String(name);
 
   var msg = this.message;
-  msg = (msg === undefined) ? '' : String(msg);
+  msg = msg === undefined ? "" : String(msg);
 
-  if (name === '') {
+  if (name === "") {
     return msg;
   }
-  if (msg === '') {
+  if (msg === "") {
     return name;
   }
 
-  return name + ': ' + msg;
+  return name + ": " + msg;
 };
 ```
 
@@ -53,19 +53,19 @@ Error.prototype.toString = function() {
 ### Usar `toString()`
 
 ```js
-var e = new Error('fatal error');
+var e = new Error("fatal error");
 console.log(e.toString()); // 'Error: error fatal'
 
 e.name = undefined;
 console.log(e.toString()); // 'Error: error fatal'
 
-e.name = '';
+e.name = "";
 console.log(e.toString()); // 'error fatal'
 
 e.message = undefined;
 console.log(e.toString()); // ''
 
-e.name = 'hola';
+e.name = "hola";
 console.log(e.toString()); // 'hola'
 ```
 

--- a/files/es/web/javascript/reference/global_objects/escape/index.md
+++ b/files/es/web/javascript/reference/global_objects/escape/index.md
@@ -7,6 +7,7 @@ original_slug: Web/JavaScript/Referencia/Objetos_globales/escape
 {{Deprecated_header}}
 
 > **Advertencia:** `escape()` no esta estrictamente en desuso("eliminada por los estándares Web"), esta definida en [Anexo B](https://www.ecma-international.org/ecma-262/9.0/index.html#sec-additional-ecmascript-features-for-web-browsers) El estándar ECMA-262 , cuya introducción establece:
+>
 > > … Todos las características especificas y comportamientos del lenguaje en este anexo tienen mas de una caracterísitca indeseable y en ausencia del legado sera eliminada de esta especificación. …
 > >
 > > … Los programadores no deben usar o suponer la existencia de estas características y/o comportamientos al escribir nuevo código ECMAScript …
@@ -37,12 +38,12 @@ La forma hexadecimal de los caracteres cuyo valor es 0xFF o menor, es una secuen
 ## Ejemplos
 
 ```js
-escape('abc123');     // "abc123"
-escape('äöü');        // "%E4%F6%FC"
-escape('ć');          // "%u0107"
+escape("abc123"); // "abc123"
+escape("äöü"); // "%E4%F6%FC"
+escape("ć"); // "%u0107"
 
 // caracteres especiales
-escape('@*_+-./');    // "@*_+-./"
+escape("@*_+-./"); // "@*_+-./"
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/eval/index.md
+++ b/files/es/web/javascript/reference/global_objects/eval/index.md
@@ -51,8 +51,9 @@ Si utiliza la función `eval()` _indirectamente_, invocándola a través de una 
 
 ```js
 function test() {
-  var x = 2, y = 4;
-  console.log(eval("x + y"));  // Llamada directa, utiliza el ámbito local, el resultado es 6
+  var x = 2,
+    y = 4;
+  console.log(eval("x + y")); // Llamada directa, utiliza el ámbito local, el resultado es 6
   var geval = eval;
   console.log(geval("x + y")); // Llamada indirecta, utiliza el ámbito global, através de ReferenceError por que `x` es indefinida
 }
@@ -86,9 +87,9 @@ Considere ahora este nuevo ejemplo, en donde la propiedad del objeto a ser acces
 
 ```js
 var obj = { a: 20, b: 30 };
-var nombreProp = obtenerNombreProp();  // devuelve "a" o "b"
+var nombreProp = obtenerNombreProp(); // devuelve "a" o "b"
 
-eval( "var resultado = obj." + nombreProp );
+eval("var resultado = obj." + nombreProp);
 ```
 
 Y con el uso de los [accesores de propiedades](/es/docs/Web/JavaScript/Reference/Operators/Property_Accessors) (artículo en inglés), el cual es mucho más rápido y seguro, sería así:
@@ -96,16 +97,16 @@ Y con el uso de los [accesores de propiedades](/es/docs/Web/JavaScript/Reference
 ```js
 var obj = { a: 20, b: 30 };
 var nombreProp = obtenerNombreProp(); // devuelve "a" o "b"
-var resultado = obj[ nombreProp ];  //  obj[ "a" ] es el mismo que obj.a
+var resultado = obj[nombreProp]; //  obj[ "a" ] es el mismo que obj.a
 ```
 
 Puede incluso utilizar este método para acceder a las propiedades de los descendientes. Utilizando `eval()` esto sería de la siguiente forma:
 
 ```js
-var obj = {a: {b: {c: 0}}};
-var propPath = getPropPath();  // returns e.g. "a.b.c"
+var obj = { a: { b: { c: 0 } } };
+var propPath = getPropPath(); // returns e.g. "a.b.c"
 
-eval( "var result = obj." + propPath );
+eval("var result = obj." + propPath);
 ```
 
 Evitando `eval()`, esto podría hacerse dividiendo la ruta de propiedad y haciendo un bucle a través de las diferentes propiedades:
@@ -113,14 +114,14 @@ Evitando `eval()`, esto podría hacerse dividiendo la ruta de propiedad y hacien
 ```js
 function getDescendantProp(obj, desc) {
   var arr = desc.split(".");
-  while(arr.length) {
+  while (arr.length) {
     obj = obj[arr.shift()];
   }
   return obj;
 }
 
-var obj = {a: {b: {c: 0}}};
-var propPath = getPropPath();  // returns e.g. "a.b.c"
+var obj = { a: { b: { c: 0 } } };
+var propPath = getPropPath(); // returns e.g. "a.b.c"
 var result = getDescendantProp(obj, propPath);
 ```
 
@@ -129,15 +130,15 @@ Estableciendo una propiedad que funcione de modo similar:
 ```js
 function setDescendantProp(obj, desc, value) {
   var arr = desc.split(".");
-  while(arr.length > 1) {
+  while (arr.length > 1) {
     obj = obj[arr.shift()];
   }
   obj[arr[0]] = value;
 }
 
-var obj = {a: {b: {c: 0}}};
-var propPath = getPropPath();  // returns e.g. "a.b.c"
-var result = setDescendantProp(obj, propPath, 1);  // test.a.b.c will now be 1
+var obj = { a: { b: { c: 0 } } };
+var propPath = getPropPath(); // returns e.g. "a.b.c"
+var result = setDescendantProp(obj, propPath, 1); // test.a.b.c will now be 1
 ```
 
 ### Utilice funciones en lugar de evaluar fragmentos de código
@@ -202,12 +203,12 @@ document.write("<P>z es ", eval(str));
 ```js
 var str = "if ( a ) { 1+1; } else { 1+2; }";
 var a = true;
-var b = eval(str);  // devuelve 2
+var b = eval(str); // devuelve 2
 
 console.log("b is : " + b);
 
 a = false;
-b = eval(str);  // devuelve 3
+b = eval(str); // devuelve 3
 
 console.log("b is : " + b);
 ```
@@ -215,10 +216,10 @@ console.log("b is : " + b);
 ### `eval` como una cadena de caracteres (string) definiendo funciones requiere "(" y ")" como prefijo y sufijo
 
 ```js
-var fctStr1 = "function a() {}"
-var fctStr2 = "(function a() {})"
-var fct1 = eval(fctStr1)  // devuelve undefined
-var fct2 = eval(fctStr2)  // deuelve una función
+var fctStr1 = "function a() {}";
+var fctStr2 = "(function a() {})";
+var fct1 = eval(fctStr1); // devuelve undefined
+var fct2 = eval(fctStr2); // deuelve una función
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/evalerror/evalerror/index.md
+++ b/files/es/web/javascript/reference/global_objects/evalerror/evalerror/index.md
@@ -10,10 +10,10 @@ El constructor **`EvalError`** crea un nuevo error relacionado con la función g
 ## Sintaxis
 
 ```js
-new EvalError()
-new EvalError(message)
-new EvalError(message, fileName)
-new EvalError(message, fileName, lineNumber)
+new EvalError();
+new EvalError(message);
+new EvalError(message, fileName);
+new EvalError(message, fileName, lineNumber);
 ```
 
 ### Parámetros
@@ -33,16 +33,15 @@ El objeto `EvalError` no se utiliza en la especificación actual de ECMAScript y
 
 ```js
 try {
-  throw new EvalError('Hello', 'someFile.js', 10);
+  throw new EvalError("Hello", "someFile.js", 10);
 } catch (e) {
-
   console.log(e instanceof EvalError); // true
-  console.log(e.message);              // "Hello"
-  console.log(e.name);                 // "EvalError"
-  console.log(e.fileName);             // "someFile.js"
-  console.log(e.lineNumber);           // 10
-  console.log(e.columnNumber);         // 0
-  console.log(e.stack);                // "@Scratchpad/2:2:9\n"
+  console.log(e.message); // "Hello"
+  console.log(e.name); // "EvalError"
+  console.log(e.fileName); // "someFile.js"
+  console.log(e.lineNumber); // 10
+  console.log(e.columnNumber); // 0
+  console.log(e.stack); // "@Scratchpad/2:2:9\n"
 }
 ```
 

--- a/files/es/web/javascript/reference/global_objects/evalerror/index.md
+++ b/files/es/web/javascript/reference/global_objects/evalerror/index.md
@@ -35,15 +35,15 @@ El objeto `EvalError` no se utiliza en la especificación actual de ECMAScript y
 
 ```js
 try {
-  throw new EvalError('Hello', 'someFile.js', 10);
+  throw new EvalError("Hello", "someFile.js", 10);
 } catch (e) {
   console.log(e instanceof EvalError); // true
-  console.log(e.message);              // "Hello"
-  console.log(e.name);                 // "EvalError"
-  console.log(e.fileName);             // "someFile.js"
-  console.log(e.lineNumber);           // 10
-  console.log(e.columnNumber);         // 0
-  console.log(e.stack);                // "@Scratchpad/2:2:9\n"
+  console.log(e.message); // "Hello"
+  console.log(e.name); // "EvalError"
+  console.log(e.fileName); // "someFile.js"
+  console.log(e.lineNumber); // 10
+  console.log(e.columnNumber); // 0
+  console.log(e.stack); // "@Scratchpad/2:2:9\n"
 }
 ```
 

--- a/files/es/web/javascript/reference/global_objects/function/apply/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/apply/index.md
@@ -49,19 +49,22 @@ Puedes utilizar `apply` para encadenar {{jsxref("Operators/new", "constructors")
 
 ```js
 Function.prototype.construct = function (aArgs) {
-    var fConstructor = this, fNewConstr = function () { fConstructor.apply(this, aArgs); };
-    fNewConstr.prototype = fConstructor.prototype;
-    return new fNewConstr();
+  var fConstructor = this,
+    fNewConstr = function () {
+      fConstructor.apply(this, aArgs);
+    };
+  fNewConstr.prototype = fConstructor.prototype;
+  return new fNewConstr();
 };
 ```
 
 Ejemplo de uso:
 
 ```js
-function MyConstructor () {
-    for (var nProp = 0; nProp < arguments.length; nProp++) {
-        this["property" + nProp] = arguments[nProp];
-    }
+function MyConstructor() {
+  for (var nProp = 0; nProp < arguments.length; nProp++) {
+    this["property" + nProp] = arguments[nProp];
+  }
 }
 
 var myArray = [4, "Hello world!", false];
@@ -83,17 +86,18 @@ El uso inteligente de **`apply`** permite utilizar funciones built-in para algun
 var numbers = [5, 6, 2, 3, 7];
 
 /* using Math.min/Math.max apply */
-var max = Math.max.apply(null, numbers); /* This about equal to Math.max(numbers[0], ...) or Math.max(5, 6, ..) */
+var max = Math.max.apply(
+  null,
+  numbers,
+); /* This about equal to Math.max(numbers[0], ...) or Math.max(5, 6, ..) */
 var min = Math.min.apply(null, numbers);
 
 /* vs. simple loop based algorithm */
-max = -Infinity, min = +Infinity;
+(max = -Infinity), (min = +Infinity);
 
 for (var i = 0; i < numbers.length; i++) {
-  if (numbers[i] > max)
-    max = numbers[i];
-  if (numbers[i] < min)
-    min = numbers[i];
+  if (numbers[i] > max) max = numbers[i];
+  if (numbers[i] < min) min = numbers[i];
 }
 ```
 
@@ -123,16 +127,16 @@ var min = minOfArray([5, 6, 2, 3, 7]);
 
 ```js
 var originalfoo = someobject.foo;
-someobject.foo = function() {
+someobject.foo = function () {
   // Haz algo antes de llamar a la función
   console.log(arguments);
   // Llama a la función como la hubieras llamado normalmente
   originalfoo.apply(this, arguments);
   // Aquí, ejecuta algo después
-}
+};
 ```
 
-Este método es especialmente útil cuando quieres depurar eventos, o interfaces con algún elemento que no tiene API, al igual que los diversos `.on` (eventos` [event]..., `como los que se usan en el [Devtools Inspector](/es/docs/Tools/Page_Inspector#Developer_API))
+Este método es especialmente útil cuando quieres depurar eventos, o interfaces con algún elemento que no tiene API, al igual que los diversos `.on` (eventos`[event]...,`como los que se usan en el [Devtools Inspector](/es/docs/Tools/Page_Inspector#Developer_API))
 
 ## Especificaciones
 

--- a/files/es/web/javascript/reference/global_objects/function/arguments/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/arguments/index.md
@@ -21,14 +21,15 @@ En caso de recursividad, es decir, si la función `f` aparece varias veces en la
 ### Ejemplo
 
 ```js
-function f(n) { g(n-1) }
+function f(n) {
+  g(n - 1);
+}
 function g(n) {
   print("antes: " + g.arguments[0]);
-  if(n>0)
-    f(n);
+  if (n > 0) f(n);
   print("después: " + g.arguments[0]);
 }
-f(2)
+f(2);
 ```
 
 resultados:

--- a/files/es/web/javascript/reference/global_objects/function/bind/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/bind/index.md
@@ -45,7 +45,9 @@ El uso más simple de `bind()` es hacer que una función que, sin importar cómo
 this.x = 9;
 var module = {
   x: 81,
-  getX: function() { return this.x; }
+  getX: function () {
+    return this.x;
+  },
 };
 
 module.getX(); // 81
@@ -86,13 +88,12 @@ function LateBloomer() {
 }
 
 // Declare bloom after a delay of 1 second
-LateBloomer.prototype.bloom = function() {
+LateBloomer.prototype.bloom = function () {
   window.setTimeout(this.declare.bind(this), 1000);
 };
 
-LateBloomer.prototype.declare = function() {
-  console.log('I am a beautiful flower with ' +
-    this.petalCount + ' petals!');
+LateBloomer.prototype.declare = function () {
+  console.log("I am a beautiful flower with " + this.petalCount + " petals!");
 };
 ```
 
@@ -108,19 +109,18 @@ function Point(x, y) {
   this.y = y;
 }
 
-Point.prototype.toString = function() {
-  return this.x + ',' + this.y;
+Point.prototype.toString = function () {
+  return this.x + "," + this.y;
 };
 
 var p = new Point(1, 2);
 p.toString(); // '1,2'
 
-
 var emptyObj = {};
-var YAxisPoint = Point.bind(emptyObj, 0/*x*/);
+var YAxisPoint = Point.bind(emptyObj, 0 /*x*/);
 // not supported in the polyfill below,
 // works fine with native bind:
-var YAxisPoint = Point.bind(null, 0/*x*/);
+var YAxisPoint = Point.bind(null, 0 /*x*/);
 
 var axisPoint = new YAxisPoint(5);
 axisPoint.toString(); // '0,5'
@@ -140,7 +140,7 @@ Note que no necesita hacer nada especial para crear una función ligada para usa
 // (aunque es usualmente indeseable)
 YAxisPoint(13);
 
-emptyObj.x + ',' + emptyObj.y;
+emptyObj.x + "," + emptyObj.y;
 // >  '0,13'
 ```
 
@@ -178,22 +178,24 @@ La función `bind()` fue añadida a la especificación ECMA-262, 5a edición; po
 
 ```js
 if (!Function.prototype.bind) {
-  Function.prototype.bind = function(oThis) {
-    if (typeof this !== 'function') {
+  Function.prototype.bind = function (oThis) {
+    if (typeof this !== "function") {
       // closest thing possible to the ECMAScript 5
       // internal IsCallable function
-      throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
+      throw new TypeError(
+        "Function.prototype.bind - what is trying to be bound is not callable",
+      );
     }
 
-    var aArgs   = Array.prototype.slice.call(arguments, 1),
-        fToBind = this,
-        fNOP    = function() {},
-        fBound  = function() {
-          return fToBind.apply(this instanceof fNOP && oThis
-                 ? this
-                 : oThis,
-                 aArgs.concat(Array.prototype.slice.call(arguments)));
-        };
+    var aArgs = Array.prototype.slice.call(arguments, 1),
+      fToBind = this,
+      fNOP = function () {},
+      fBound = function () {
+        return fToBind.apply(
+          this instanceof fNOP && oThis ? this : oThis,
+          aArgs.concat(Array.prototype.slice.call(arguments)),
+        );
+      };
 
     fNOP.prototype = this.prototype;
     fBound.prototype = new fNOP();

--- a/files/es/web/javascript/reference/global_objects/function/call/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/call/index.md
@@ -57,24 +57,26 @@ function Producto(nombre, precio) {
   this.precio = precio;
 
   if (precio < 0)
-    throw RangeError('No se puede crear el producto "' + nombre + '" con un precio negativo');
+    throw RangeError(
+      'No se puede crear el producto "' + nombre + '" con un precio negativo',
+    );
   return this;
 }
 
 function Comida(nombre, precio) {
   Producto.call(this, nombre, precio);
-  this.categoria = 'comida';
+  this.categoria = "comida";
 }
 Comida.prototype = new Producto();
 
 function Juguete(nombre, precio) {
   Producto.call(this, nombre, precio);
-  this.categoria = 'juguete';
+  this.categoria = "juguete";
 }
 Juguete.prototype = new Producto();
 
-var queso = new Comida('feta', 5);
-var diversion = new Juguete('robot', 40);
+var queso = new Comida("feta", 5);
+var diversion = new Juguete("robot", 40);
 ```
 
 ### Usando `call` para invocar una función anónima
@@ -87,15 +89,15 @@ El propósito principal de la función anónima aquí es agregar una función `p
 
 ```js
 var animales = [
-  {especie: 'Leon', nombre: 'Rey'},
-  {especie: 'Whale', nombre: 'Fail'}
+  { especie: "Leon", nombre: "Rey" },
+  { especie: "Whale", nombre: "Fail" },
 ];
 
 for (var i = 0; i < animales.length; i++) {
   (function (i) {
     this.imprimir = function () {
-      console.log('#' + i  + ' ' + this.especie + ': ' + this.nombre);
-    }
+      console.log("#" + i + " " + this.especie + ": " + this.nombre);
+    };
     this.imprimir();
   }).call(animales[i], i);
 }

--- a/files/es/web/javascript/reference/global_objects/function/caller/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/caller/index.md
@@ -23,8 +23,16 @@ la propiedad especial `__caller__`, la cual retornaba el objeto de activación d
 En caso de recursión se puede reconstruir la pila de llamada utilizando esta propiedad, tal como se muestra a continuación:
 
 ```js
-function f(n) { g(n - 1); }
-function g(n) { if (n > 0) { f(n); } else { stop(); } }
+function f(n) {
+  g(n - 1);
+}
+function g(n) {
+  if (n > 0) {
+    f(n);
+  } else {
+    stop();
+  }
+}
 f(2);
 ```
 
@@ -44,9 +52,9 @@ Por lo tanto si se intenta obtener el rastro de llamadas (stack trace) de la fun
 
 ```js
 var f = stop;
-var stack = 'Stack trace:';
+var stack = "Stack trace:";
 while (f) {
-  stack += '\n' + f.name;
+  stack += "\n" + f.name;
   f = f.caller;
 }
 ```
@@ -62,9 +70,9 @@ El siguiente código verifica el valor de la propiedad `caller` de una función.
 ```js
 function myFunc() {
   if (myFunc.caller == null) {
-    return 'The function was called from the top!';
+    return "The function was called from the top!";
   } else {
-    return 'This function\'s caller was ' + myFunc.caller;
+    return "This function's caller was " + myFunc.caller;
   }
 }
 ```

--- a/files/es/web/javascript/reference/global_objects/function/displayname/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/displayname/index.md
@@ -17,9 +17,11 @@ function doSomething() {}
 
 console.log(doSomething.displayName); // "undefined"
 
-var popup = function(content) { console.log(content); };
+var popup = function (content) {
+  console.log(content);
+};
 
-popup.displayName = 'Show Popup';
+popup.displayName = "Show Popup";
 
 console.log(popup.displayName); // "Show Popup"
 ```
@@ -28,14 +30,18 @@ Tu puedes definir una funcion con un nombre a mostrar en un {{jsxref("Functions"
 
 ```js
 var object = {
-  someMethod: function() {}
+  someMethod: function () {},
 };
 
-object.someMethod.displayName = 'someMethod';
+object.someMethod.displayName = "someMethod";
 
 console.log(object.someMethod.displayName); // logs "someMethod"
 
-try { someMethod } catch(e) { console.log(e); }
+try {
+  someMethod;
+} catch (e) {
+  console.log(e);
+}
 // ReferenceError: someMethod is not defined
 ```
 
@@ -44,14 +50,14 @@ Puedes cambiar dinámicamente el `displayName` de una función:
 ```js
 var object = {
   // anonymous
-  someMethod: function(value) {
-    arguments.callee.displayName = 'someMethod (' + value + ')';
-  }
+  someMethod: function (value) {
+    arguments.callee.displayName = "someMethod (" + value + ")";
+  },
 };
 
 console.log(object.someMethod.displayName); // "undefined"
 
-object.someMethod('123')
+object.someMethod("123");
 console.log(object.someMethod.displayName); // "someMethod (123)"
 ```
 
@@ -62,8 +68,8 @@ Normalmente, se prefiere por consolas y profilers sobre {{jsxref("Function.name"
 Al ingresar lo siguiente en una consola, debería mostrarse como algo así como "`function My Function()`":
 
 ```js
-var a = function() {};
-a.displayName = 'My Function';
+var a = function () {};
+a.displayName = "My Function";
 
 a; // "function My Function()"
 ```

--- a/files/es/web/javascript/reference/global_objects/function/function/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/function/index.md
@@ -43,7 +43,7 @@ El siguiente código crea un objeto `Function` que toma dos argumentos.
 // El ejemplo se puede ejecutar directamente en tu consola JavaScript
 
 // Crea una función que toma dos argumentos y devuelve la suma de esos argumentos
-const adder = new Function('a', 'b', 'return a + b');
+const adder = new Function("a", "b", "return a + b");
 
 // Llama a la función
 adder(2, 6);

--- a/files/es/web/javascript/reference/global_objects/function/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/index.md
@@ -50,22 +50,22 @@ Las funciones creadas con el constructor `Function` no crean cierres para sus co
 var x = 10;
 
 function createFunction1() {
-    var x = 20;
-    return new Function('return x;'); // esta |x| se refiere a la |x| global
+  var x = 20;
+  return new Function("return x;"); // esta |x| se refiere a la |x| global
 }
 
 function createFunction2() {
-    var x = 20;
-    function f() {
-        return x; // esta |x| se refiere a la |x| local
-    }
-    return f;
+  var x = 20;
+  function f() {
+    return x; // esta |x| se refiere a la |x| local
+  }
+  return f;
 }
 
 var f1 = createFunction1();
-console.log(f1());          // 10
+console.log(f1()); // 10
 var f2 = createFunction2();
-console.log(f2());          // 20
+console.log(f2()); // 20
 ```
 
 Si bien este código funciona en los navegadores web, `f1()` producirá un `ReferenceError` en Node.js, ya que no encontrará a `x`. Esto se debe a que el ámbito de nivel superior en Node no es el ámbito global, y `x` será local para el módulo.

--- a/files/es/web/javascript/reference/global_objects/function/length/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/length/index.md
@@ -29,11 +29,15 @@ La propiedad length del {{jsxref("Global_Objects/Function", "Function")}} objeto
 ```js
 console.log(Function.length); /* 1 */
 
-console.log((function()        {}).length); /* 0 */
-console.log((function(a)       {}).length); /* 1 */
-console.log((function(a, b)    {}).length); /* 2 etc. */
-console.log((function(...args) {}).length); /* 0, resto de parámetros no se contemplan */
-console.log((function(a, b = 1, c) {}).length); /* 1, solo parámetros antes del primero con un valor por defecto son contados */
+console.log(function () {}.length); /* 0 */
+console.log(function (a) {}.length); /* 1 */
+console.log(function (a, b) {}.length); /* 2 etc. */
+console.log(
+  function (...args) {}.length,
+); /* 0, resto de parámetros no se contemplan */
+console.log(
+  function (a, b = 1, c) {}.length,
+); /* 1, solo parámetros antes del primero con un valor por defecto son contados */
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/function/name/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/name/index.md
@@ -27,13 +27,13 @@ console.log(doSomething.name); // imprime en pantalla "doSomething"
 Las funciones creadas con la sintaxis `new Function(...)` o simplemente `Function(...)` tienen como propiedad `name` una cadena vacía. En los ejemplos a continuación se crean funciones anónimas, tales que su `name` retorna una cadena vacía:
 
 ```js
-var f = function() {};
+var f = function () {};
 var object = {
-  someMethod: function() {}
+  someMethod: function () {},
 };
 
-console.log(f.name == ''); // true
-console.log(object.someMethod.name == ''); // también true
+console.log(f.name == ""); // true
+console.log(object.someMethod.name == ""); // también true
 ```
 
 ### Nombres de función inferidos
@@ -41,7 +41,7 @@ console.log(object.someMethod.name == ''); // también true
 Los navegadores que implementan funciones ES2015 pueden inferir el nombre de una función anónima de su posición sintáctica. Por ejemplo:
 
 ```js
-var f = function() {};
+var f = function () {};
 console.log(f.name); // "f"
 ```
 
@@ -49,11 +49,15 @@ Se puede definir una función con un nombre en un {{jsxref("Operators/Function",
 
 ```js
 var object = {
-  someMethod: function object_someMethod() {}
+  someMethod: function object_someMethod() {},
 };
 console.log(object.someMethod.name); // imprime "object_someMethod"
 
-try { object_someMethod } catch(e) { console.log(e); }
+try {
+  object_someMethod;
+} catch (e) {
+  console.log(e);
+}
 // ReferenceError: object_someMethod is not defined
 ```
 
@@ -62,10 +66,10 @@ No se puede cambiar el nombre de una función, esta propiedad es de solo lectura
 ```js
 var object = {
   // anonymous
-  someMethod: function() {}
+  someMethod: function () {},
 };
 
-object.someMethod.name = 'someMethod';
+object.someMethod.name = "someMethod";
 console.log(object.someMethod.name); // cadena vacía, someMethod es anónimo
 ```
 
@@ -75,7 +79,7 @@ Sin embargo, se puede usar {{jsxref("Object.defineProperty()")}} para cambiarlo.
 
 ```js
 var o = {
-  foo(){}
+  foo() {},
 };
 o.foo.name; // "foo";
 ```
@@ -85,7 +89,7 @@ o.foo.name; // "foo";
 {{jsxref("Function.bind()")}} produce una función cuyo nombre es igual a "bound " seguido del nombre de la función original.
 
 ```js
-function foo() {};
+function foo() {}
 foo.bind({}).name; // "bound foo"
 ```
 
@@ -95,8 +99,8 @@ Cuando se usan [`get`](/es/docs/Web/JavaScript/Reference/Functions/get) y `set,`
 
 ```js
 var o = {
-  get foo(){},
-  set foo(x){}
+  get foo() {},
+  set foo(x) {},
 };
 
 var descriptor = Object.getOwnPropertyDescriptor(o, "foo");

--- a/files/es/web/javascript/reference/global_objects/function/tostring/index.md
+++ b/files/es/web/javascript/reference/global_objects/function/tostring/index.md
@@ -30,7 +30,7 @@ El método `toString()` producirá una excepción {{jsxref("TypeError")}} ("Func
 ```js example-bad
 Function.prototype.toString.call("foo"); // TypeError
 
-var proxy = new Proxy(function() {}, {});
+var proxy = new Proxy(function () {}, {});
 Function.prototype.toString.call(proxy); // TypeError
 ```
 

--- a/files/es/web/javascript/reference/global_objects/generator/index.md
+++ b/files/es/web/javascript/reference/global_objects/generator/index.md
@@ -14,9 +14,9 @@ Este objeto no puede ser instanciado directamente. En su lugar, una instancia de
 
 ```js
 function* gen() {
-    yield 1;
-    yield 2;
-    yield 3;
+  yield 1;
+  yield 2;
+  yield 3;
 }
 
 var g = gen(); // "Generator { }"
@@ -38,6 +38,7 @@ _Tambien hereda propiedades de {{JSxRef("Iterator")}}_
 _Tambien hereda propiedades de {{JSxRef("Iterator")}}_
 
 - `Generator.prototype.constructor`
+
   - : Especifica la funciòn que construye el prototipo del objeto.
 
 - `Generator.prototype[@@toStringTag]`
@@ -50,8 +51,7 @@ _Tambien hereda propiedades de {{JSxRef("Iterator")}}_
 ```js
 function* idMaker() {
   var index = 0;
-  while(true)
-    yield index++;
+  while (true) yield index++;
 }
 
 var gen = idMaker(); // "Generator { }"

--- a/files/es/web/javascript/reference/global_objects/generator/next/index.md
+++ b/files/es/web/javascript/reference/global_objects/generator/next/index.md
@@ -44,10 +44,10 @@ function* gen() {
 }
 
 var g = gen(); // "Generator { }"
-g.next();      // "Object { value: 1, done: false }"
-g.next();      // "Object { value: 2, done: false }"
-g.next();      // "Object { value: 3, done: false }"
-g.next();      // "Object { value: undefined, done: true }"
+g.next(); // "Object { value: 1, done: false }"
+g.next(); // "Object { value: 2, done: false }"
+g.next(); // "Object { value: 3, done: false }"
+g.next(); // "Object { value: undefined, done: true }"
 ```
 
 ### Sending values to the generator
@@ -56,7 +56,7 @@ In this example, `next` is called with a value. Note that the first call did not
 
 ```js
 function* gen() {
-  while(true) {
+  while (true) {
     var value = yield null;
     console.log(value);
   }

--- a/files/es/web/javascript/reference/global_objects/generator/return/index.md
+++ b/files/es/web/javascript/reference/global_objects/generator/return/index.md
@@ -38,9 +38,9 @@ function* gen() {
 
 var g = gen();
 
-g.next();        // { value: 1, done: false }
-g.return('foo'); // { value: "foo", done: true }
-g.next();        // { value: undefined, done: true }
+g.next(); // { value: 1, done: false }
+g.return("foo"); // { value: "foo", done: true }
+g.next(); // { value: undefined, done: true }
 ```
 
 Si `return(valor)` es invocado en un generador que ya está en su estado "completado", el generador permanecerá en estado "completado". Si no se da ningún argumento, el objeto regresado es el mismo a que si se invocara `.next()`. Si se da un argumento, éste se asignará como valor en la propiedad `value` del objeto regresado.

--- a/files/es/web/javascript/reference/global_objects/generator/throw/index.md
+++ b/files/es/web/javascript/reference/global_objects/generator/throw/index.md
@@ -38,11 +38,11 @@ The following example shows a simple generator and an error that is thrown using
 
 ```js
 function* gen() {
-  while(true) {
+  while (true) {
     try {
-       yield 42;
-    } catch(e) {
-      console.log('Error caught!');
+      yield 42;
+    } catch (e) {
+      console.log("Error caught!");
     }
   }
 }
@@ -50,7 +50,7 @@ function* gen() {
 var g = gen();
 g.next();
 // { value: 42, done: false }
-g.throw(new Error('Something went wrong'));
+g.throw(new Error("Something went wrong"));
 // "Error caught!"
 // { value: 42, done: false }
 ```

--- a/files/es/web/javascript/reference/global_objects/internalerror/index.md
+++ b/files/es/web/javascript/reference/global_objects/internalerror/index.md
@@ -43,7 +43,8 @@ Esta función recursiva se ejecuta 10 veces, según la condición de salida.
 
 ```js
 function loop(x) {
-  if (x >= 10) // "x >= 10" es la condición de salida
+  if (x >= 10)
+    // "x >= 10" es la condición de salida
     return;
   // hacer cosas
   loop(x + 1); // la llamada recursiva
@@ -55,8 +56,7 @@ Establecer esta condición en un valor extremadamente alto, no funcionará:
 
 ```js example-bad
 function loop(x) {
-  if (x >= 1000000000000)
-    return;
+  if (x >= 1000000000000) return;
   // hacer cosas
   loop(x + 1);
 }

--- a/files/es/web/javascript/reference/global_objects/intl/index.md
+++ b/files/es/web/javascript/reference/global_objects/intl/index.md
@@ -3,6 +3,7 @@ title: Intl
 slug: Web/JavaScript/Reference/Global_Objects/Intl
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Intl
 ---
+
 {{JSRef}}
 
 El objeto de ámbito global **`Intl`** es el espacio de nombres para el API de Internacionalización de ECMAScript, éste provee comparación de cadenas y formato de números, fechas y tiempos con sensibilidad al lenguaje. Los constructores para los objetos {{jsxref("Collator")}}, {{jsxref("NumberFormat")}}, y {{jsxref("DateTimeFormat")}} son propiedades del objeto `Intl`. En ésta página se documentan tales propiedades, así como la funcionalidad común a los constructores de internacionalización y otras funciones sensibles al lenguaje.

--- a/files/es/web/javascript/reference/global_objects/intl/numberformat/format/index.md
+++ b/files/es/web/javascript/reference/global_objects/intl/numberformat/format/index.md
@@ -32,8 +32,8 @@ The `format` getter function formats a number into a string according to the loc
 Use the `format` getter function for formatting a single currency value, here for Russia:
 
 ```js
-var options = { style: 'currency', currency: 'RUB' };
-var numberFormat = new Intl.NumberFormat('ru-RU', options);
+var options = { style: "currency", currency: "RUB" };
+var numberFormat = new Intl.NumberFormat("ru-RU", options);
 console.log(numberFormat.format(654321.987));
 // → "654 321,99 руб."
 ```
@@ -44,9 +44,9 @@ Use the `format` getter function for formatting all numbers in an array. Note th
 
 ```js
 var a = [123456.789, 987654.321, 456789.123];
-var numberFormat = new Intl.NumberFormat('es-ES');
+var numberFormat = new Intl.NumberFormat("es-ES");
 var formatted = a.map(numberFormat.format);
-console.log(formatted.join('; '));
+console.log(formatted.join("; "));
 // → "123.456,789; 987.654,321; 456.789,123"
 ```
 

--- a/files/es/web/javascript/reference/global_objects/intl/numberformat/index.md
+++ b/files/es/web/javascript/reference/global_objects/intl/numberformat/index.md
@@ -57,24 +57,24 @@ Para obtener el formato del idioma usado en la interfaz de usuario de tu aplicac
 var number = 123456.789;
 
 // En el alemán la coma se utiliza como separador decimal y el punto para los millares
-console.log(new Intl.NumberFormat('de-DE').format(number));
+console.log(new Intl.NumberFormat("de-DE").format(number));
 // → 123.456,789
 
 // En la mayoría de los países de lengua arábiga se utilizan también símbolos arábigos
-console.log(new Intl.NumberFormat('ar-EG').format(number));
+console.log(new Intl.NumberFormat("ar-EG").format(number));
 // → ١٢٣٤٥٦٫٧٨٩
 
 // En la India se utilizan separadores millares/lakh/crore
-console.log(new Intl.NumberFormat('en-IN').format(number));
+console.log(new Intl.NumberFormat("en-IN").format(number));
 // → 1,23,456.789
 
 // La clave de extensión nu requiere un sistema de numeración, p.ej. el decimal chino
-console.log(new Intl.NumberFormat('zh-Hans-CN-u-nu-hanidec').format(number));
+console.log(new Intl.NumberFormat("zh-Hans-CN-u-nu-hanidec").format(number));
 // → 一二三,四五六.七八九
 
 // Cuando se requiera un lenguaje que pudiera no ser soportado, como es el caso del Balinés
 // se recomienda incluir un lenguaje alternativo, en éste caso Indonesio
-console.log(new Intl.NumberFormat(['ban', 'id']).format(number));
+console.log(new Intl.NumberFormat(["ban", "id"]).format(number));
 // → 123.456,789
 ```
 
@@ -86,32 +86,48 @@ Los resultados se pueden personalizar usando el argumento `opciones`:
 var number = 123456.789;
 
 // Se establece un formato de divisa
-console.log(new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(number));
+console.log(
+  new Intl.NumberFormat("de-DE", { style: "currency", currency: "EUR" }).format(
+    number,
+  ),
+);
 // → 123.456,79 €
 
 // El yen japonés no tiene ninguna unidad menor
-console.log(new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(number));
+console.log(
+  new Intl.NumberFormat("ja-JP", { style: "currency", currency: "JPY" }).format(
+    number,
+  ),
+);
 // → ￥123,457
 
 // Limitamos a tres los dígitos significativos
-console.log(new Intl.NumberFormat('en-IN', { maximumSignificantDigits: 3 }).format(number));
+console.log(
+  new Intl.NumberFormat("en-IN", { maximumSignificantDigits: 3 }).format(
+    number,
+  ),
+);
 // → 1,23,000
 ```
 
 ### Usando estilos y unidades
 
 ```js
-console.log(new Intl.NumberFormat('pt-PT',  {
-    style: 'unit',
-    unit: 'kilometer-per-hour'
-}).format(50));
+console.log(
+  new Intl.NumberFormat("pt-PT", {
+    style: "unit",
+    unit: "kilometer-per-hour",
+  }).format(50),
+);
 // → 50 km/h
 
-console.log((16).toLocaleString('en-GB', {
-    style: 'unit',
-    unit: 'liter',
-    unitDisplay: 'long'
-}));
+console.log(
+  (16).toLocaleString("en-GB", {
+    style: "unit",
+    unit: "liter",
+    unitDisplay: "long",
+  }),
+);
 // → 16 litros
 ```
 

--- a/files/es/web/javascript/reference/global_objects/intl/relativetimeformat/index.md
+++ b/files/es/web/javascript/reference/global_objects/intl/relativetimeformat/index.md
@@ -41,9 +41,9 @@ El siguiente ejemplo muestra cómo conseguir el tiempo relativo para el mejor id
 // Crea un formateador de tiempo relativo en tu lenguaje
 // con los valores por defectos pasados expresamente.
 const rtf = new Intl.RelativeTimeFormat("en", {
-    localeMatcher: "best fit", // otros valores: "lookup"
-    numeric: "always", // otros valores: "auto"
-    style: "long", // otros valores: "short" or "narrow"
+  localeMatcher: "best fit", // otros valores: "lookup"
+  numeric: "always", // otros valores: "auto"
+  style: "long", // otros valores: "short" or "narrow"
 });
 
 // Formatea el tiempo relativo con valores negativos (-1).

--- a/files/es/web/javascript/reference/global_objects/isfinite/index.md
+++ b/files/es/web/javascript/reference/global_objects/isfinite/index.md
@@ -30,14 +30,14 @@ Puede usar esta función para determinar si un número es un número finito. La 
 ## Ejemplos
 
 ```js
-isFinite(Infinity);    // falso
-isFinite(NaN);         // falso
-isFinite(-Inifinity);  // falso
+isFinite(Infinity); // falso
+isFinite(NaN); // falso
+isFinite(-Inifinity); // falso
 
-isFinite(0);           // verdadero
-isFinite(2e64);        // verdadero
+isFinite(0); // verdadero
+isFinite(2e64); // verdadero
 
-isFinite("0");         // verdadero, hubiera sido falso en el caso de usar Number.isFinite("0") que es mas robusta
+isFinite("0"); // verdadero, hubiera sido falso en el caso de usar Number.isFinite("0") que es mas robusta
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/isnan/index.md
+++ b/files/es/web/javascript/reference/global_objects/isnan/index.md
@@ -36,10 +36,10 @@ Esta función es útil ya que el valor {{jsxref("Objetos_globales/NaN", "NaN")}}
 ### Ejemplos
 
 ```js
-isNaN(NaN) //devuelve true
-isNaN("string") //devuelve true
-isNaN("12") //devuelve false
-isNaN(12) //devuelve false
+isNaN(NaN); //devuelve true
+isNaN("string"); //devuelve true
+isNaN("12"); //devuelve false
+isNaN(12); //devuelve false
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/json/index.md
+++ b/files/es/web/javascript/reference/global_objects/json/index.md
@@ -16,15 +16,15 @@ El objeto JSON contiene métodos para analizar [JavaScript Object Notation](http
 
 JSON es una sintaxis para serializar objetos, arreglos, números, cadenas, booleanos y nulos. Está basado sobre sintaxis JavaScript pero es diferente a ella: algo JavaScript no es JSON, y algo JSON no es JavaScript. Mira también: [JSON: The JavaScript subset that isn't](http://timelessrepo.com/json-isnt-a-javascript-subset).
 
-| Tipo JavaScript    | Diferencia JSON                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Objetos y arreglos | Los nombres de las propiedades deben tener doble comilla; las comas finales están prohibidas.                                                                                                                                                                                                                                                                                                                                                          |
-| Números            | Los ceros a la izquierda están prohibidos; un punto decimal debe ser seguido al menos por un dígito.                                                                                                                                                                                                                                                                                                                                                   |
+| Tipo JavaScript    | Diferencia JSON                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Objetos y arreglos | Los nombres de las propiedades deben tener doble comilla; las comas finales están prohibidas.                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| Números            | Los ceros a la izquierda están prohibidos; un punto decimal debe ser seguido al menos por un dígito.                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | Cadenas            | Solo un limitado conjunto de caracteres pueden ser de escape; ciertos caracteres de control estan prohibidos; los caracteres de separador de linea Unicode (U+2028) y el separador de parrafo (U+2029) son permitidos; las cadenas deben estar entre comillas dobles. Mira el siguiente ejemplo donde {{jsxref("JSON.parse")}} funciona bien y un{{jsxref("SyntaxError")}} es generado cuando se evalua el codigo como JavaScript: <pre lang="js">var code = '"\u2028\u2029"';<br>JSON.parse(code); // works fine<br>eval(code); // fails</pre> |
 
 La sintaxis JSON completa es la siguiente:
 
-```js
+```js-nolint
 JSON = null
     or true or false
     or JSONNumber
@@ -72,15 +72,16 @@ JSONArray = [ ]
           or [ ArrayElements ]
 ArrayElements = JSON
               or ArrayElements , JSON
+```
 
 Espacios en blanco insignificantes pueden estar presentes en cualquier lugar excepto en un _JSONNumber_ (los números no deben contener ningún espacio) o en una _JSONString_ (donde es interpretado como el caracter correspondiente en la cadena, o podría causar un error). Los caracteres de Tabulación (U+0009), de retorno de carro (U+000D), de nueva línea (U+000A), y de espacio (U+0020) son los únicos caracteres de espacios en blanco válidos.
 
 ## Métodos
 
-*   {{jsxref("JSON.parse()")}}
-    *   : Analiza una cadena de texto JSON, opcionalmente transformando el valor producido y sus propiedades, retornando el valor.
-*   {{jsxref("JSON.stringify()")}}
-    *   : Devuelve un string JSON correspondiente al valor especificado, incluyendo opcionalmente ciertas propiedades o reemplazando valores de propiedades de la manera definida por el usuario.
+- {{jsxref("JSON.parse()")}}
+  - : Analiza una cadena de texto JSON, opcionalmente transformando el valor producido y sus propiedades, retornando el valor.
+- {{jsxref("JSON.stringify()")}}
+  - : Devuelve un string JSON correspondiente al valor especificado, incluyendo opcionalmente ciertas propiedades o reemplazando valores de propiedades de la manera definida por el usuario.
 
 ## Polyfill
 
@@ -91,27 +92,40 @@ El siguiente algoritmo es una imitación del objeto JSON nativo:
 ```js
 if (!window.JSON) {
   window.JSON = {
-    parse: function (sJSON) { return eval("(" + sJSON + ")"); },
+    parse: function (sJSON) {
+      return eval("(" + sJSON + ")");
+    },
     stringify: function (vContent) {
       if (vContent instanceof Object) {
         var sOutput = "";
         if (vContent.constructor === Array) {
-          for (var nId = 0; nId < vContent.length; sOutput += this.stringify(vContent[nId]) + ",", nId++);
-            return "[" + sOutput.substr(0, sOutput.length - 1) + "]";
+          for (
+            var nId = 0;
+            nId < vContent.length;
+            sOutput += this.stringify(vContent[nId]) + ",", nId++
+          );
+          return "[" + sOutput.substr(0, sOutput.length - 1) + "]";
         }
         if (vContent.toString !== Object.prototype.toString) {
-          return "\"" + vContent.toString().replace(/"/g, "\\$&") + "\"";
+          return '"' + vContent.toString().replace(/"/g, "\\$&") + '"';
         }
         for (var sProp in vContent) {
-          sOutput += "\"" + sProp.replace(/"/g, "\\$&") + "\":" + this.stringify(vContent[sProp]) + ",";
+          sOutput +=
+            '"' +
+            sProp.replace(/"/g, "\\$&") +
+            '":' +
+            this.stringify(vContent[sProp]) +
+            ",";
         }
         return "{" + sOutput.substr(0, sOutput.length - 1) + "}";
-     }
-     return typeof vContent === "string" ? "\"" + vContent.replace(/"/g, "\\$&") + "\"" : String(vContent);
-    }
+      }
+      return typeof vContent === "string"
+        ? '"' + vContent.replace(/"/g, "\\$&") + '"'
+        : String(vContent);
+    },
   };
 }
-````
+```
 
 Los objectos [JSON2](https://github.com/douglascrockford/JSON-js) y [JSON3](http://bestiejs.github.com/json3) son mas complejos que el objeto JSON ya que manejan [polyfills](http://remysharp.com/2010/10/08/what-is-a-polyfill/).
 

--- a/files/es/web/javascript/reference/global_objects/json/parse/index.md
+++ b/files/es/web/javascript/reference/global_objects/json/parse/index.md
@@ -36,11 +36,11 @@ Lanza una excepción {{jsxref("SyntaxError")}} si la cadena a transformar no es 
 ### Ejemplo: Usando `JSON.parse()`
 
 ```js
-JSON.parse('{}');              // {}
-JSON.parse('true');            // true
-JSON.parse('"foo"');           // "foo"
+JSON.parse("{}"); // {}
+JSON.parse("true"); // true
+JSON.parse('"foo"'); // "foo"
 JSON.parse('[1, 5, "false"]'); // [1, 5, "false"]
-JSON.parse('null');            // null
+JSON.parse("null"); // null
 ```
 
 ### Ejemplo: `Usando el parámetro reviver`
@@ -51,13 +51,13 @@ El `reviver` es llamada último con la cadena vacía y el valor más alto para p
 
 ```js
 JSON.parse('{"p": 5}', function (k, v) {
-    if(k === "") return v;     // if topmost value, return it,
-    return v * 2;              // else return v * 2.
-});                            // { p: 10 }
+  if (k === "") return v; // if topmost value, return it,
+  return v * 2; // else return v * 2.
+}); // { p: 10 }
 
 JSON.parse('{"1": 1, "2": 2,"3": {"4": 4, "5": {"6": 6}}}', function (k, v) {
-    console.log(k);            // log the current property name, the last is "".
-    return v;                  // return the unchanged property value.
+  console.log(k); // log the current property name, the last is "".
+  return v; // return the unchanged property value.
 });
 
 // 1
@@ -73,7 +73,7 @@ JSON.parse('{"1": 1, "2": 2,"3": {"4": 4, "5": {"6": 6}}}', function (k, v) {
 
 ```js example-bad example-bad
 // ambos lanzarán un SyntaxError
-JSON.parse('[1, 2, 3, 4, ]');
+JSON.parse("[1, 2, 3, 4, ]");
 JSON.parse('{"foo" : 1, }');
 ```
 

--- a/files/es/web/javascript/reference/global_objects/json/stringify/index.md
+++ b/files/es/web/javascript/reference/global_objects/json/stringify/index.md
@@ -46,62 +46,83 @@ Lanza una excepción {{JSxRef("TypeError")}} ("cyclic object value") cuando encu
 - El resto de instancias de {{JSxRef("Object")}} (incluyendo {{JSxRef("Map")}}, {{JSxRef("Set")}}, {{JSxRef("WeakMap")}}, y {{JSxRef("WeakSet")}}) sólo tendrán serializadas sus propiedades enumerables.
 
 ```js
-JSON.stringify({});                    // '{}'
-JSON.stringify(true);                  // 'true'
-JSON.stringify('foo');                 // '"foo"'
-JSON.stringify([1, 'false', false]);   // '[1,"false",false]'
+JSON.stringify({}); // '{}'
+JSON.stringify(true); // 'true'
+JSON.stringify("foo"); // '"foo"'
+JSON.stringify([1, "false", false]); // '[1,"false",false]'
 JSON.stringify([NaN, null, Infinity]); // '[null,null,null]'
-JSON.stringify({ x: 5 });              // '{"x":5}'
+JSON.stringify({ x: 5 }); // '{"x":5}'
 
-JSON.stringify(new Date(2006, 0, 2, 15, 4, 5))
+JSON.stringify(new Date(2006, 0, 2, 15, 4, 5));
 // '"2006-01-02T15:04:05.000Z"'
 
 JSON.stringify({ x: 5, y: 6 });
 // '{"x":5,"y":6}'
-JSON.stringify([new Number(3), new String('false'), new Boolean(false)]);
+JSON.stringify([new Number(3), new String("false"), new Boolean(false)]);
 // '[3,"false",false]'
 
 // Elementos de array identificados por string no son enumerables y no tienen sentido en JSON
-let a = ['foo', 'bar'];
-a['baz'] = 'quux';      // a: [ 0: 'foo', 1: 'bar', baz: 'quux' ]
+let a = ["foo", "bar"];
+a["baz"] = "quux"; // a: [ 0: 'foo', 1: 'bar', baz: 'quux' ]
 JSON.stringify(a);
 // '["foo","bar"]'
 
-JSON.stringify({ x: [10, undefined, function(){}, Symbol('')] });
+JSON.stringify({ x: [10, undefined, function () {}, Symbol("")] });
 // '{"x":[10,null,null,null]}'
 
 // Estructuras de datos standard
-JSON.stringify([new Set([1]), new Map([[1, 2]]), new WeakSet([{a: 1}]), new WeakMap([[{a: 1}, 2]])]);
+JSON.stringify([
+  new Set([1]),
+  new Map([[1, 2]]),
+  new WeakSet([{ a: 1 }]),
+  new WeakMap([[{ a: 1 }, 2]]),
+]);
 // '[{},{},{},{}]'
 
 // TypedArray
 JSON.stringify([new Int8Array([1]), new Int16Array([1]), new Int32Array([1])]);
 // '[{"0":1},{"0":1},{"0":1}]'
-JSON.stringify([new Uint8Array([1]), new Uint8ClampedArray([1]), new Uint16Array([1]), new Uint32Array([1])]);
+JSON.stringify([
+  new Uint8Array([1]),
+  new Uint8ClampedArray([1]),
+  new Uint16Array([1]),
+  new Uint32Array([1]),
+]);
 // '[{"0":1},{"0":1},{"0":1},{"0":1}]'
 JSON.stringify([new Float32Array([1]), new Float64Array([1])]);
 // '[{"0":1},{"0":1}]'
 
 // toJSON()
-JSON.stringify({ x: 5, y: 6, toJSON(){ return this.x + this.y; } });
+JSON.stringify({
+  x: 5,
+  y: 6,
+  toJSON() {
+    return this.x + this.y;
+  },
+});
 // '11'
 
 // Símbolos:
-JSON.stringify({ x: undefined, y: Object, z: Symbol('') });
+JSON.stringify({ x: undefined, y: Object, z: Symbol("") });
 // '{}'
-JSON.stringify({ [Symbol('foo')]: 'foo' });
+JSON.stringify({ [Symbol("foo")]: "foo" });
 // '{}'
-JSON.stringify({ [Symbol.for('foo')]: 'foo' }, [Symbol.for('foo')]);
+JSON.stringify({ [Symbol.for("foo")]: "foo" }, [Symbol.for("foo")]);
 // '{}'
-JSON.stringify({ [Symbol.for('foo')]: 'foo' }, function(k, v) {
-  if (typeof k === 'symbol') {
-    return 'a symbol';
+JSON.stringify({ [Symbol.for("foo")]: "foo" }, function (k, v) {
+  if (typeof k === "symbol") {
+    return "a symbol";
   }
 });
 // undefined
 
 // Propiedades no enumerables:
-JSON.stringify( Object.create(null, { x: { value: 'x', enumerable: false }, y: { value: 'y', enumerable: true } }) );
+JSON.stringify(
+  Object.create(null, {
+    x: { value: "x", enumerable: false },
+    y: { value: "y", enumerable: true },
+  }),
+);
 // '{"y":"y"}'
 ```
 
@@ -134,7 +155,13 @@ function replacer(key, value) {
   return value;
 }
 
-var foo = {foundation: "Mozilla", model: "box", week: 45, transport: "car", month: 7};
+var foo = {
+  foundation: "Mozilla",
+  model: "box",
+  week: 45,
+  transport: "car",
+  month: 7,
+};
 var jsonString = JSON.stringify(foo, replacer);
 // '{"week":45, "month":7}'
 ```
@@ -146,7 +173,7 @@ Ejemplo con un array
 Si el reemplazo es un array, los valores indican los nombres de las propiedades del objeto que se va a incluir en la cadena JSON resultado.
 
 ```js
-JSON.stringify(foo, ['week', 'month']);
+JSON.stringify(foo, ["week", "month"]);
 // '{"week":45,"month":7}', sólo mantiene las propiedades de "week" y de "month"
 ```
 
@@ -155,7 +182,7 @@ JSON.stringify(foo, ['week', 'month']);
 Este argumento puede ser empleado para controlar el espaciado en la cadena final. Si es un número, los niveles sucesivos del proceso serán identados cada uno por tantos espacios como se indique (hasta 10). Si es una cadena, serán identados con dicha cadena (o los primeros diez caracteres de la misma).
 
 ```js
-JSON.stringify({ a: 2 }, null, ' ');
+JSON.stringify({ a: 2 }, null, " ");
 // regresa la cadena de texto:
 // '{
 //  "a": 2
@@ -165,7 +192,7 @@ JSON.stringify({ a: 2 }, null, ' ');
 Usar el carácter tabulador simula la apariencia de impresión:
 
 ```js
-JSON.stringify({ uno: 1, dos : 2 }, null, '\t')
+JSON.stringify({ uno: 1, dos: 2 }, null, "\t");
 // devuelve el string:
 // '{            \
 //     "uno": 1, \
@@ -179,12 +206,12 @@ Si un objeto que sera estringificado tiene una propiedad llamada toJSON donde su
 
 ```js
 var obj = {
-  foo: 'foo',
+  foo: "foo",
   toJSON: function () {
-    return 'bar';
-  }
+    return "bar";
+  },
 };
-var json = JSON.stringify({x: obj}); // '{"x":"bar"}'.
+var json = JSON.stringify({ x: obj }); // '{"x":"bar"}'.
 ```
 
 ### Ejemplo de como usar `JSON.stringify()` con `localStorage`
@@ -196,23 +223,23 @@ En dado caso en el cual se requiera que un objeto creado por el usuario y al cua
 ```js
 // Creando un ejemplo de JSON
 var session = {
-  'screens': [],
-  'state': true
+  screens: [],
+  state: true,
 };
-session.screens.push({ 'name': 'screenA', 'width': 450, 'height': 250 });
-session.screens.push({ 'name': 'screenB', 'width': 650, 'height': 350 });
-session.screens.push({ 'name': 'screenC', 'width': 750, 'height': 120 });
-session.screens.push({ 'name': 'screenD', 'width': 250, 'height': 60 });
-session.screens.push({ 'name': 'screenE', 'width': 390, 'height': 120 });
-session.screens.push({ 'name': 'screenF', 'width': 1240, 'height': 650 });
+session.screens.push({ name: "screenA", width: 450, height: 250 });
+session.screens.push({ name: "screenB", width: 650, height: 350 });
+session.screens.push({ name: "screenC", width: 750, height: 120 });
+session.screens.push({ name: "screenD", width: 250, height: 60 });
+session.screens.push({ name: "screenE", width: 390, height: 120 });
+session.screens.push({ name: "screenF", width: 1240, height: 650 });
 
 // Convirte el JSON string con JSON.stringify()
 // entonces guarda con localStorage con el nombre de la sesión
-localStorage.setItem('session', JSON.stringify(session));
+localStorage.setItem("session", JSON.stringify(session));
 
 // Ejemplo de como transformar el String generado usando
 // JSON.stringify() y guardándolo en localStorage como objeto JSON otra vez
-var restoredSession = JSON.parse(localStorage.getItem('session'));
+var restoredSession = JSON.parse(localStorage.getItem("session"));
 
 // Ahora la variable restoredSession contiene el objeto que fue guardado
 // en localStorage

--- a/files/es/web/javascript/reference/global_objects/math/abs/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/abs/index.md
@@ -36,16 +36,16 @@ Como `abs()` es un método estático de `Math`, deberías siempre usar `Math.abs
 Pasando un string no-numérico o una variable {{jsxref("undefined")}}/empty retorna {{jsxref("NaN")}}. Pasando {{jsxref("null")}} retorna 0.
 
 ```js
-Math.abs('-1');     // 1
-Math.abs(-2);       // 2
-Math.abs(null);     // 0
-Math.abs('');       // 0
-Math.abs([]);       // 0
-Math.abs([2]);      // 2
-Math.abs([1,2]);    // NaN
-Math.abs({});       // NaN
-Math.abs('string'); // NaN
-Math.abs();         // NaN
+Math.abs("-1"); // 1
+Math.abs(-2); // 2
+Math.abs(null); // 0
+Math.abs(""); // 0
+Math.abs([]); // 0
+Math.abs([2]); // 2
+Math.abs([1, 2]); // NaN
+Math.abs({}); // NaN
+Math.abs("string"); // NaN
+Math.abs(); // NaN
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/math/acos/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/acos/index.md
@@ -36,12 +36,12 @@ Debido a que `acos()` es un método estático de `Math`, siempre debe usarse com
 ### Usando `Math.acos()`
 
 ```js
-Math.acos(-2);  // NaN
-Math.acos(-1);  // 3.141592653589793
-Math.acos(0);   // 1.5707963267948966
+Math.acos(-2); // NaN
+Math.acos(-1); // 3.141592653589793
+Math.acos(0); // 1.5707963267948966
 Math.acos(0.5); // 1.0471975511965979
-Math.acos(1);   // 0
-Math.acos(2);   // NaN
+Math.acos(1); // 0
+Math.acos(2); // NaN
 ```
 
 Para valores menores que -1 o mayores que 1, `Math.acos()` devuelve {{jsxref("NaN")}}.

--- a/files/es/web/javascript/reference/global_objects/math/acosh/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/acosh/index.md
@@ -34,11 +34,11 @@ Como `acosh()` es un método estático de `Math`, siempre debe ser usado como `M
 ### Utilizando `Math.acosh()`
 
 ```js
-Math.acosh(-1);  // NaN
-Math.acosh(0);   // NaN
+Math.acosh(-1); // NaN
+Math.acosh(0); // NaN
 Math.acosh(0.5); // NaN
-Math.acosh(1);   // 0
-Math.acosh(2);   // 1.3169578969248166
+Math.acosh(1); // 0
+Math.acosh(2); // 1.3169578969248166
 ```
 
 Para valores menores que 1 `Math.acosh()` retorna {{jsxref("NaN")}}.
@@ -48,9 +48,11 @@ Para valores menores que 1 `Math.acosh()` retorna {{jsxref("NaN")}}.
 Para todo <math><semantics><mrow><mi>x</mi><mo>≥</mo><mn>1</mn></mrow><annotation encoding="TeX">x mayor ó igual a 1</annotation></semantics></math>, se tiene que el arcosh(x) <math><semantics><annotation encoding="TeX">= ln(x + la raiz cuadrada de(x cuadrado - 1)) </annotation></semantics></math> y esto puede ser emulado con la siguiente funcion:
 
 ```js
-Math.acosh = Math.acosh || function(x) {
-  return Math.log(x + Math.sqrt(x * x - 1));
-};
+Math.acosh =
+  Math.acosh ||
+  function (x) {
+    return Math.log(x + Math.sqrt(x * x - 1));
+  };
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/math/asin/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/asin/index.md
@@ -36,12 +36,12 @@ Because `asin()` is a static method of `Math`, you always use it as `Math.asin()
 ### Usando `Math.asin()`
 
 ```js
-Math.asin(-2);  // NaN
-Math.asin(-1);  // -1.5707963267948966 (-pi/2)
-Math.asin(0);   // 0
+Math.asin(-2); // NaN
+Math.asin(-1); // -1.5707963267948966 (-pi/2)
+Math.asin(0); // 0
 Math.asin(0.5); // 0.5235987755982989
-Math.asin(1);   // 1.5707963267948966 (pi/2)
-Math.asin(2);   // NaN
+Math.asin(1); // 1.5707963267948966 (pi/2)
+Math.asin(2); // NaN
 ```
 
 For values less than -1 or greater than 1, `Math.asin()` returns {{jsxref("NaN")}}.

--- a/files/es/web/javascript/reference/global_objects/math/asinh/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/asinh/index.md
@@ -13,7 +13,7 @@ La función **`Math.asinh()`** retorna el arcoseno hyperbólico de un número, e
 ## Sintáxis
 
 ```js
-Math.asinh(x)
+Math.asinh(x);
 ```
 
 ### Parámetros
@@ -34,8 +34,8 @@ Debido a que `asinh()` es un método estático de `Math`, siempre hay que usarlo
 ### Usos de `Math.asinh()`
 
 ```js
-Math.asinh(1);  // 0.881373587019543
-Math.asinh(0);  // 0
+Math.asinh(1); // 0.881373587019543
+Math.asinh(0); // 0
 ```
 
 ## Polyfill
@@ -43,13 +43,15 @@ Math.asinh(0);  // 0
 As a quick and dirty hack the expression <math><semantics><mrow><mo lspace="0em" rspace="thinmathspace">arsinh</mo><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo><mo>=</mo><mo lspace="0em" rspace="0em">ln</mo><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><msqrt><mrow><msup><mi>x</mi><mn>2</mn></msup><mo>+</mo><mn>1</mn></mrow></msqrt></mrow><mo>)</mo></mrow></mrow><annotation encoding="TeX">\operatorname {arsinh} (x) = \ln \left(x + \sqrt{x^{2} + 1} \right)</annotation></semantics></math> may be used directly for a coarse emulation by the following function:
 
 ```js
-Math.asinh = Math.asinh || function(x) {
-  if (x === -Infinity) {
-    return x;
-  } else {
-    return Math.log(x + Math.sqrt(x * x + 1));
-  }
-};
+Math.asinh =
+  Math.asinh ||
+  function (x) {
+    if (x === -Infinity) {
+      return x;
+    } else {
+      return Math.log(x + Math.sqrt(x * x + 1));
+    }
+  };
 ```
 
 Been formally correct it suffers from a number of issues related to floating point computations. Accurate result requires special handling of positive/negative, small/large arguments as it done e.g. in [glibc](https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/ieee754/dbl-64/s_asinh.c) or [GNU Scientific Library](http://git.savannah.gnu.org/cgit/gsl.git/tree/sys/invhyp.c).

--- a/files/es/web/javascript/reference/global_objects/math/atan/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/atan/index.md
@@ -40,12 +40,12 @@ Dado que `atan()` es un método estático de `Math`, siempre debes usarlo como `
 ### Usando `Math.atan()`
 
 ```js
-Math.atan(1);   // 0.7853981633974483
-Math.atan(0);   // 0
-Math.atan(-0);  // -0
+Math.atan(1); // 0.7853981633974483
+Math.atan(0); // 0
+Math.atan(-0); // -0
 
-Math.atan(Infinity);   //  1.5707963267948966
-Math.atan(-Infinity);  // -1.5707963267948966
+Math.atan(Infinity); //  1.5707963267948966
+Math.atan(-Infinity); // -1.5707963267948966
 
 // El ángulo que la línea [(0,0);(x,y)] forma con el eje-x en un sistema de coordenadas Cartesianas.
 Math.atan(y / x);

--- a/files/es/web/javascript/reference/global_objects/math/atanh/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/atanh/index.md
@@ -36,9 +36,11 @@ Por que `atanh()` es un metodo estatico de `Math`, tu siempre puedes usar eso co
 Para <math><semantics><mrow><mrow><mo>|</mo><mi>x</mi><mo>|</mo></mrow><mo>&#x3C;</mo><mn>1</mn></mrow><annotation encoding="TeX">\left|x\right| &#x3C; 1</annotation></semantics></math>, tenemos <math><semantics><mrow><mo lspace="0em" rspace="thinmathspace">artanh</mo><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo><mo>=</mo><mfrac><mn>1</mn><mn>2</mn></mfrac><mo lspace="0em" rspace="0em">ln</mo><mrow><mo>(</mo><mfrac><mrow><mn>1</mn><mo>+</mo><mi>x</mi></mrow><mrow><mn>1</mn><mo>-</mo><mi>x</mi></mrow></mfrac><mo>)</mo></mrow></mrow><annotation encoding="TeX">\operatorname {artanh} (x) = \frac{1}{2}\ln \left( \frac{1 + x}{1 - x} \right)</annotation></semantics></math> por lo que esto puede estar emulado con la siguiente función:
 
 ```js
-Math.atanh = Math.atanh || function(x) {
-  return Math.log((1+x)/(1-x)) / 2;
-};
+Math.atanh =
+  Math.atanh ||
+  function (x) {
+    return Math.log((1 + x) / (1 - x)) / 2;
+  };
 ```
 
 ## Ejemplos
@@ -46,12 +48,12 @@ Math.atanh = Math.atanh || function(x) {
 ### Using `Math.atanh()`
 
 ```js
-Math.atanh(-2);  // NaN
-Math.atanh(-1);  // -Infinito
-Math.atanh(0);   // 0
+Math.atanh(-2); // NaN
+Math.atanh(-1); // -Infinito
+Math.atanh(0); // 0
 Math.atanh(0.5); // 0.5493061443340548
-Math.atanh(1);   // Infinito
-Math.atanh(2);   // NaN
+Math.atanh(1); // Infinito
+Math.atanh(2); // NaN
 ```
 
 Para valores mayores a 1 o menores a -1, {{jsxref("NaN")}} retorna.

--- a/files/es/web/javascript/reference/global_objects/math/cbrt/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/cbrt/index.md
@@ -37,10 +37,10 @@ Para <math><semantics><mrow><mi>x</mi><mo>≥</mo><mn>0</mn></mrow><annotation e
 
 ```js
 if (!Math.cbrt) {
-  Math.cbrt = (function(pow) {
-    return function cbrt(x){
+  Math.cbrt = (function (pow) {
+    return function cbrt(x) {
       // Esto asegura que numeros negativos sigan siendo negativos
-      return x < 0 ? -pow(-x, 1/3) : pow(x, 1/3);
+      return x < 0 ? -pow(-x, 1 / 3) : pow(x, 1 / 3);
     };
   })(Math.pow); // Localiza Math.pow para una mayor eficiencía
 }
@@ -59,7 +59,7 @@ Math.cbrt(0); // 0
 Math.cbrt(1); // 1
 Math.cbrt(Infinity); // Infinito
 Math.cbrt(null); // 0
-Math.cbrt(2);  // 1.2599210498948732
+Math.cbrt(2); // 1.2599210498948732
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/math/ceil/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/ceil/index.md
@@ -36,11 +36,11 @@ Como `ceil()` es un método estático de `Math`, siempre debe usarlo como `Math.
 El siguiente ejemplo muestra el uso de `Math.ceil()`.
 
 ```js
-Math.ceil(.95);    // 1
-Math.ceil(4);      // 4
-Math.ceil(7.004);  // 8
-Math.ceil(-0.95);  // -0
-Math.ceil(-4);     // -4
+Math.ceil(0.95); // 1
+Math.ceil(4); // 4
+Math.ceil(7.004); // 8
+Math.ceil(-0.95); // -0
+Math.ceil(-4); // -4
 Math.ceil(-7.004); // -7
 ```
 
@@ -48,7 +48,7 @@ Math.ceil(-7.004); // -7
 
 ```js
 // Closure
-(function() {
+(function () {
   /**
    * Ajuste decimal de un número.
    *
@@ -59,62 +59,62 @@ Math.ceil(-7.004); // -7
    */
   function decimalAdjust(type, value, exp) {
     // Si exp es undefined o cero...
-    if (typeof exp === 'undefined' || +exp === 0) {
+    if (typeof exp === "undefined" || +exp === 0) {
       return Math[type](value);
     }
     value = +value;
     exp = +exp;
     // Si el valor no es un número o exp no es un entero...
-    if (isNaN(value) || !(typeof exp === 'number' && exp % 1 === 0)) {
+    if (isNaN(value) || !(typeof exp === "number" && exp % 1 === 0)) {
       return NaN;
     }
     // Shift
-    value = value.toString().split('e');
-    value = Math[type](+(value[0] + 'e' + (value[1] ? (+value[1] - exp) : -exp)));
+    value = value.toString().split("e");
+    value = Math[type](+(value[0] + "e" + (value[1] ? +value[1] - exp : -exp)));
     // Shift back
-    value = value.toString().split('e');
-    return +(value[0] + 'e' + (value[1] ? (+value[1] + exp) : exp));
+    value = value.toString().split("e");
+    return +(value[0] + "e" + (value[1] ? +value[1] + exp : exp));
   }
 
   // Decimal round
   if (!Math.round10) {
-    Math.round10 = function(value, exp) {
-      return decimalAdjust('round', value, exp);
+    Math.round10 = function (value, exp) {
+      return decimalAdjust("round", value, exp);
     };
   }
   // Decimal floor
   if (!Math.floor10) {
-    Math.floor10 = function(value, exp) {
-      return decimalAdjust('floor', value, exp);
+    Math.floor10 = function (value, exp) {
+      return decimalAdjust("floor", value, exp);
     };
   }
   // Decimal ceil
   if (!Math.ceil10) {
-    Math.ceil10 = function(value, exp) {
-      return decimalAdjust('ceil', value, exp);
+    Math.ceil10 = function (value, exp) {
+      return decimalAdjust("ceil", value, exp);
     };
   }
 })();
 
 // Round
-Math.round10(55.55, -1);   // 55.6
-Math.round10(55.549, -1);  // 55.5
-Math.round10(55, 1);       // 60
-Math.round10(54.9, 1);     // 50
-Math.round10(-55.55, -1);  // -55.5
+Math.round10(55.55, -1); // 55.6
+Math.round10(55.549, -1); // 55.5
+Math.round10(55, 1); // 60
+Math.round10(54.9, 1); // 50
+Math.round10(-55.55, -1); // -55.5
 Math.round10(-55.551, -1); // -55.6
-Math.round10(-55, 1);      // -50
-Math.round10(-55.1, 1);    // -60
+Math.round10(-55, 1); // -50
+Math.round10(-55.1, 1); // -60
 // Floor
-Math.floor10(55.59, -1);   // 55.5
-Math.floor10(59, 1);       // 50
-Math.floor10(-55.51, -1);  // -55.6
-Math.floor10(-51, 1);      // -60
+Math.floor10(55.59, -1); // 55.5
+Math.floor10(59, 1); // 50
+Math.floor10(-55.51, -1); // -55.6
+Math.floor10(-51, 1); // -60
 // Ceil
-Math.ceil10(55.51, -1);    // 55.6
-Math.ceil10(51, 1);        // 60
-Math.ceil10(-55.59, -1);   // -55.5
-Math.ceil10(-59, 1);       // -50
+Math.ceil10(55.51, -1); // 55.6
+Math.ceil10(51, 1); // 60
+Math.ceil10(-55.59, -1); // -55.5
+Math.ceil10(-59, 1); // -50
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/math/cos/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/cos/index.md
@@ -38,10 +38,10 @@ Debido a que `cos()` es un método estático de `Math`, siempre debes utilizarlo
 ### Usando `Math.cos()`
 
 ```js
-Math.cos(0);           // 1
-Math.cos(1);           // 0.5403023058681398
+Math.cos(0); // 1
+Math.cos(1); // 0.5403023058681398
 
-Math.cos(Math.PI);     // -1
+Math.cos(Math.PI); // -1
 Math.cos(2 * Math.PI); // 1
 ```
 

--- a/files/es/web/javascript/reference/global_objects/math/e/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/e/index.md
@@ -26,7 +26,7 @@ La función siguiente devuelve e:
 
 ```js
 function getNapier() {
-   return Math.E
+  return Math.E;
 }
 
 getNapier(); // 2.718281828459045

--- a/files/es/web/javascript/reference/global_objects/math/exp/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/exp/index.md
@@ -31,8 +31,8 @@ Porque `exp()` es un método estático de `Math`, siempre úsalo como `Math.exp(
 
 ```js
 Math.exp(-1); // 0.36787944117144233
-Math.exp(0);  // 1
-Math.exp(1);  // 2.718281828459045
+Math.exp(0); // 1
+Math.exp(1); // 2.718281828459045
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/math/expm1/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/expm1/index.md
@@ -35,8 +35,8 @@ Debido a que `expm1()` es un método estático de `Math`, uselo siempre como `Ma
 
 ```js
 Math.expm1(-1); // -0.6321205588285577
-Math.expm1(0);  // 0
-Math.expm1(1);  // 1.718281828459045
+Math.expm1(0); // 0
+Math.expm1(1); // 1.718281828459045
 ```
 
 ## Polyfill
@@ -44,9 +44,11 @@ Math.expm1(1);  // 1.718281828459045
 Esto puede ser emulado con la ayuda de la función {{jsxref("Math.exp()")}}:
 
 ```js
-Math.expm1 = Math.expm1 || function(x) {
-  return Math.exp(x) - 1;
-};
+Math.expm1 =
+  Math.expm1 ||
+  function (x) {
+    return Math.exp(x) - 1;
+  };
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/math/floor/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/floor/index.md
@@ -33,7 +33,7 @@ La siguiente función devuelve el valor entero redondeado más bajo de la variab
 
 ```js
 function getFloor(x) {
-   return Math.floor(x);
+  return Math.floor(x);
 }
 ```
 
@@ -43,8 +43,7 @@ Si se pasa `45.95` a `getFloor`, éste devuelve `45`; si se le pasa `-45.95`, de
 
 ```js
 // Cierre
-(function(){
-
+(function () {
   /**
    * Ajuste decimal de un número.
    *
@@ -55,42 +54,41 @@ Si se pasa `45.95` a `getFloor`, éste devuelve `45`; si se le pasa `-45.95`, de
    */
   function decimalAdjust(type, value, exp) {
     // Si el exp es indefinido o cero...
-    if (typeof exp === 'undefined' || +exp === 0) {
+    if (typeof exp === "undefined" || +exp === 0) {
       return Math[type](value);
     }
     value = +value;
     exp = +exp;
     // Si el valor no es un número o el exp no es un entero...
-    if (isNaN(value) || !(typeof exp === 'number' && exp % 1 === 0)) {
+    if (isNaN(value) || !(typeof exp === "number" && exp % 1 === 0)) {
       return NaN;
     }
     // Cambio
-    value = value.toString().split('e');
-    value = Math[type](+(value[0] + 'e' + (value[1] ? (+value[1] - exp) : -exp)));
+    value = value.toString().split("e");
+    value = Math[type](+(value[0] + "e" + (value[1] ? +value[1] - exp : -exp)));
     // Volver a cambiar
-    value = value.toString().split('e');
-    return +(value[0] + 'e' + (value[1] ? (+value[1] + exp) : exp));
+    value = value.toString().split("e");
+    return +(value[0] + "e" + (value[1] ? +value[1] + exp : exp));
   }
 
   // Redondeo decimal
   if (!Math.round10) {
-    Math.round10 = function(value, exp) {
-      return decimalAdjust('round', value, exp);
+    Math.round10 = function (value, exp) {
+      return decimalAdjust("round", value, exp);
     };
   }
   // Redondeo hacia abajo
   if (!Math.floor10) {
-    Math.floor10 = function(value, exp) {
-      return decimalAdjust('floor', value, exp);
+    Math.floor10 = function (value, exp) {
+      return decimalAdjust("floor", value, exp);
     };
   }
   // Redondeo hacia arriba
   if (!Math.ceil10) {
-    Math.ceil10 = function(value, exp) {
-      return decimalAdjust('ceil', value, exp);
+    Math.ceil10 = function (value, exp) {
+      return decimalAdjust("ceil", value, exp);
     };
   }
-
 })();
 
 // Redondeo

--- a/files/es/web/javascript/reference/global_objects/math/hypot/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/hypot/index.md
@@ -46,13 +46,13 @@ Con sólo un argumento, `Math.hypot()` retornaría lo mismo que `Math.abs()`.
 ### Usando `Math.hypot()`
 
 ```js
-Math.hypot(3, 4);        // 5
-Math.hypot(3, 4, 5);     // 7.0710678118654755
-Math.hypot();            // 0
-Math.hypot(NaN);         // NaN
-Math.hypot(3, 4, 'foo'); // NaN, +'foo' => NaN
-Math.hypot(3, 4, '5');   // 7.0710678118654755, +'5' => 5
-Math.hypot(-3);          // 3, lo mismo que Math.abs(-3)
+Math.hypot(3, 4); // 5
+Math.hypot(3, 4, 5); // 7.0710678118654755
+Math.hypot(); // 0
+Math.hypot(NaN); // NaN
+Math.hypot(3, 4, "foo"); // NaN, +'foo' => NaN
+Math.hypot(3, 4, "5"); // 7.0710678118654755, +'5' => 5
+Math.hypot(-3); // 3, lo mismo que Math.abs(-3)
 ```
 
 ## Polyfill
@@ -60,11 +60,14 @@ Math.hypot(-3);          // 3, lo mismo que Math.abs(-3)
 Esto puede ser emulado usando la siguiente función:
 
 ```js
-Math.hypot = Math.hypot || function() {
-  var y = 0, i = arguments.length;
-  while (i--) y += arguments[i] * arguments[i];
-  return Math.sqrt(y);
-};
+Math.hypot =
+  Math.hypot ||
+  function () {
+    var y = 0,
+      i = arguments.length;
+    while (i--) y += arguments[i] * arguments[i];
+    return Math.sqrt(y);
+  };
 ```
 
 Un polyfill que evita subdesbordamientos (underflows) y desbordamientos (overflows):

--- a/files/es/web/javascript/reference/global_objects/math/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/index.md
@@ -125,18 +125,16 @@ Como demostración, el siguiente ejemplo agrega un método al objeto `Math` para
 
 ```js
 /* Función variádica -- Retorna el máximo común divisor de una lista de argumentos */
-Math.gcd = function() {
-    if (arguments.length == 2) {
-        if (arguments[1] == 0)
-            return arguments[0];
-        else
-            return Math.gcd(arguments[1], arguments[0] % arguments[1]);
-    } else if (arguments.length > 2) {
-        var result = Math.gcd(arguments[0], arguments[1]);
-        for (var i = 2; i < arguments.length; i++)
-            result = Math.gcd(result, arguments[i]);
-        return result;
-    }
+Math.gcd = function () {
+  if (arguments.length == 2) {
+    if (arguments[1] == 0) return arguments[0];
+    else return Math.gcd(arguments[1], arguments[0] % arguments[1]);
+  } else if (arguments.length > 2) {
+    var result = Math.gcd(arguments[0], arguments[1]);
+    for (var i = 2; i < arguments.length; i++)
+      result = Math.gcd(result, arguments[i]);
+    return result;
+  }
 };
 ```
 

--- a/files/es/web/javascript/reference/global_objects/math/ln10/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/ln10/index.md
@@ -24,7 +24,7 @@ La función siguiente devuelve el logaritmo natural de 10:
 
 ```js
 function getNatLog10() {
-   return Math.LN10
+  return Math.LN10;
 }
 
 getNatLog10(); // 2.302585092994046

--- a/files/es/web/javascript/reference/global_objects/math/log/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/log/index.md
@@ -43,8 +43,8 @@ If you need the natural log of 2 or 10, use the constants {{jsxref("Math.LN2")}}
 
 ```js
 Math.log(-1); // NaN, out of range
-Math.log(0);  // -Infinity
-Math.log(1);  // 0
+Math.log(0); // -Infinity
+Math.log(1); // 0
 Math.log(10); // 2.302585092994046
 ```
 

--- a/files/es/web/javascript/reference/global_objects/math/log10/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/log10/index.md
@@ -38,10 +38,10 @@ Esta función es equivalente de Math.log(x) / Math.log(10). Para log10(e) use la
 ### usando `Math.log10()`
 
 ```js
-Math.log10(2);      // 0.3010299956639812
-Math.log10(1);      // 0
-Math.log10(0);      // -Infinito
-Math.log10(-2);     // NaN
+Math.log10(2); // 0.3010299956639812
+Math.log10(1); // 0
+Math.log10(0); // -Infinito
+Math.log10(-2); // NaN
 Math.log10(100000); // 5
 ```
 
@@ -50,9 +50,11 @@ Math.log10(100000); // 5
 Puede ser emulada con la siguiente función
 
 ```js
-Math.log10 = Math.log10 || function(x) {
-  return Math.log(x) * Math.LOG10E;
-};
+Math.log10 =
+  Math.log10 ||
+  function (x) {
+    return Math.log(x) * Math.LOG10E;
+  };
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/math/log2/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/log2/index.md
@@ -40,11 +40,11 @@ Esta función es equivalente a Math.log(x) / Math.log(2). Para log2(e) use la co
 ### Usando `Math.log2()`
 
 ```js
-Math.log2(3);    // 1.584962500721156
-Math.log2(2);    // 1
-Math.log2(1);    // 0
-Math.log2(0);    // -Infinity
-Math.log2(-2);   // NaN
+Math.log2(3); // 1.584962500721156
+Math.log2(2); // 1
+Math.log2(1); // 0
+Math.log2(0); // -Infinity
+Math.log2(-2); // NaN
 Math.log2(1024); // 10
 ```
 
@@ -53,9 +53,11 @@ Math.log2(1024); // 10
 This Polyfill emulates the `Math.log2` function. Note that it returns imprecise values on some inputs (like 1 << 29), wrap into {{jsxref("Math.round()")}} if working with bit masks.
 
 ```js
-Math.log2 = Math.log2 || function(x) {
-  return Math.log(x) * Math.LOG2E;
-};
+Math.log2 =
+  Math.log2 ||
+  function (x) {
+    return Math.log(x) * Math.LOG2E;
+  };
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/math/log2e/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/log2e/index.md
@@ -24,7 +24,7 @@ La función siguiente devuelve el base 2 del logaritmo natural del `E`:
 
 ```js
 function getLog2e() {
-   return Math.LOG2E
+  return Math.LOG2E;
 }
 ```
 

--- a/files/es/web/javascript/reference/global_objects/math/max/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/max/index.md
@@ -12,10 +12,10 @@ La función **`Math.max()`** retorna el mayor de cero o más números dados como
 ## Sintaxis
 
 ```js
-Math.max()
-Math.max(valor0)
-Math.max(valor0, valor1)
-Math.max(valor0, valor1, /* ... ,*/ valorN)
+Math.max();
+Math.max(valor0);
+Math.max(valor0, valor1);
+Math.max(valor0, valor1, /* ... ,*/ valorN);
 ```
 
 ### Parámetros
@@ -45,9 +45,9 @@ Si al menos uno de los argumentos no puede ser convertido a número, el resultad
 ### Usando Math.max()
 
 ```js
-Math.max(10, 20);   //  20
+Math.max(10, 20); //  20
 Math.max(-10, -20); // -10
-Math.max(-10, 20);  //  20
+Math.max(-10, 20); //  20
 ```
 
 ### Obteniendo el elemento máximo de un arreglo
@@ -56,9 +56,9 @@ Se puede usar {{jsxref("Array.prototype.reduce", "Array.reduce()")}} para encont
 elemento máximo en un arreglo numérico, comparando cada valor:
 
 ```js
-var arr = [1,2,3];
-var max = arr.reduce(function(a, b) {
-    return Math.max(a, b);
+var arr = [1, 2, 3];
+var max = arr.reduce(function (a, b) {
+  return Math.max(a, b);
 }, -Infinity);
 ```
 

--- a/files/es/web/javascript/reference/global_objects/math/min/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/min/index.md
@@ -34,7 +34,8 @@ Si al menos uno de los argumentos no puede ser convertido a número, el resultad
 Lo siguiente encuentra el mínimo de `x` e `y` y lo asigna a `z`:
 
 ```js
-var x = 10, y = -20;
+var x = 10,
+  y = -20;
 var z = Math.min(x, y);
 ```
 

--- a/files/es/web/javascript/reference/global_objects/math/pi/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/pi/index.md
@@ -25,7 +25,7 @@ function calculaCircunferencia(radio) {
   return 2 * Math.PI * radio;
 }
 
-calculaCircunferencia(1);  // 6.283185307179586
+calculaCircunferencia(1); // 6.283185307179586
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/math/pow/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/pow/index.md
@@ -35,22 +35,22 @@ Puesto que `pow()` es un método estático de `Math`, siempre se utiliza como `M
 
 ```js
 // simple
-Math.pow(7, 2);    // 49
-Math.pow(7, 3);    // 343
-Math.pow(2, 10);   // 1024
+Math.pow(7, 2); // 49
+Math.pow(7, 3); // 343
+Math.pow(2, 10); // 1024
 // exponentes fraccionales
-Math.pow(4, 0.5);  // 2 (raíz cuadrada de 4)
-Math.pow(8, 1/3);  // 2 (raíz cúbica de 8)
-Math.pow(2, 0.5);  // 1.412135623730951 (raíz cuadrada de 2)
-Math.pow(2, 1/3);  // 1.2599210498948732 (raíz cúbica de 2)
+Math.pow(4, 0.5); // 2 (raíz cuadrada de 4)
+Math.pow(8, 1 / 3); // 2 (raíz cúbica de 8)
+Math.pow(2, 0.5); // 1.412135623730951 (raíz cuadrada de 2)
+Math.pow(2, 1 / 3); // 1.2599210498948732 (raíz cúbica de 2)
 // exponentes con signo
-Math.pow(7, -2);   // 0.02040816326530612 (1/49)
-Math.pow(8, -1/3); // 0.5
+Math.pow(7, -2); // 0.02040816326530612 (1/49)
+Math.pow(8, -1 / 3); // 0.5
 // bases con signo
-Math.pow(-7, 2);   // 49 (los cuadrados son positivos)
-Math.pow(-7, 3);   // -343 (El cubo de una base negativa puede ser negativo)
+Math.pow(-7, 2); // 49 (los cuadrados son positivos)
+Math.pow(-7, 3); // -343 (El cubo de una base negativa puede ser negativo)
 Math.pow(-7, 0.5); // NaN (Los números negativos no tienen raíz cuadrada real)
-Math.pow(-7, 1/3); // NaN
+Math.pow(-7, 1 / 3); // NaN
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/math/round/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/round/index.md
@@ -50,14 +50,14 @@ x = Math.round(-20.51);
 // Retorna el valor 1 (!)
 // Note el error de redondeo debido a la inexactitud del punto aritmético.
 // Compare esto con Math.round10(1.005, -2) de el ejemplo de abajo.
-x = Math.round(1.005*100)/100;
+x = Math.round(1.005 * 100) / 100;
 ```
 
 ### Redondeo decimal
 
 ```js
 // Conclusión
-(function() {
+(function () {
   /**
    * Ajuste decimal de un número.
    *
@@ -68,63 +68,63 @@ x = Math.round(1.005*100)/100;
    */
   function decimalAdjust(type, value, exp) {
     // Si el exp no está definido o es cero...
-    if (typeof exp === 'undefined' || +exp === 0) {
+    if (typeof exp === "undefined" || +exp === 0) {
       return Math[type](value);
     }
     value = +value;
     exp = +exp;
     // Si el valor no es un número o el exp no es un entero...
-    if (isNaN(value) || !(typeof exp === 'number' && exp % 1 === 0)) {
+    if (isNaN(value) || !(typeof exp === "number" && exp % 1 === 0)) {
       return NaN;
     }
     // Shift
-    value = value.toString().split('e');
-    value = Math[type](+(value[0] + 'e' + (value[1] ? (+value[1] - exp) : -exp)));
+    value = value.toString().split("e");
+    value = Math[type](+(value[0] + "e" + (value[1] ? +value[1] - exp : -exp)));
     // Shift back
-    value = value.toString().split('e');
-    return +(value[0] + 'e' + (value[1] ? (+value[1] + exp) : exp));
+    value = value.toString().split("e");
+    return +(value[0] + "e" + (value[1] ? +value[1] + exp : exp));
   }
 
   // Decimal round
   if (!Math.round10) {
-    Math.round10 = function(value, exp) {
-      return decimalAdjust('round', value, exp);
+    Math.round10 = function (value, exp) {
+      return decimalAdjust("round", value, exp);
     };
   }
   // Decimal floor
   if (!Math.floor10) {
-    Math.floor10 = function(value, exp) {
-      return decimalAdjust('floor', value, exp);
+    Math.floor10 = function (value, exp) {
+      return decimalAdjust("floor", value, exp);
     };
   }
   // Decimal ceil
   if (!Math.ceil10) {
-    Math.ceil10 = function(value, exp) {
-      return decimalAdjust('ceil', value, exp);
+    Math.ceil10 = function (value, exp) {
+      return decimalAdjust("ceil", value, exp);
     };
   }
 })();
 
 // Round
-Math.round10(55.55, -1);   // 55.6
-Math.round10(55.549, -1);  // 55.5
-Math.round10(55, 1);       // 60
-Math.round10(54.9, 1);     // 50
-Math.round10(-55.55, -1);  // -55.5
+Math.round10(55.55, -1); // 55.6
+Math.round10(55.549, -1); // 55.5
+Math.round10(55, 1); // 60
+Math.round10(54.9, 1); // 50
+Math.round10(-55.55, -1); // -55.5
 Math.round10(-55.551, -1); // -55.6
-Math.round10(-55, 1);      // -50
-Math.round10(-55.1, 1);    // -60
-Math.round10(1.005, -2);   // 1.01 -- compare this with Math.round(1.005*100)/100 above
+Math.round10(-55, 1); // -50
+Math.round10(-55.1, 1); // -60
+Math.round10(1.005, -2); // 1.01 -- compare this with Math.round(1.005*100)/100 above
 // Floor
-Math.floor10(55.59, -1);   // 55.5
-Math.floor10(59, 1);       // 50
-Math.floor10(-55.51, -1);  // -55.6
-Math.floor10(-51, 1);      // -60
+Math.floor10(55.59, -1); // 55.5
+Math.floor10(59, 1); // 50
+Math.floor10(-55.51, -1); // -55.6
+Math.floor10(-51, 1); // -60
 // Ceil
-Math.ceil10(55.51, -1);    // 55.6
-Math.ceil10(51, 1);        // 60
-Math.ceil10(-55.59, -1);   // -55.5
-Math.ceil10(-59, 1);       // -50
+Math.ceil10(55.51, -1); // 55.6
+Math.ceil10(51, 1); // 60
+Math.ceil10(-55.59, -1); // -55.5
+Math.ceil10(-59, 1); // -50
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/math/sign/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/sign/index.md
@@ -36,21 +36,21 @@ El argumento pasado a esta función será convertido a tipo `x` implicitamente.
 ### Usando `Math.sign()`
 
 ```js
-Math.sign(3);     //  1
-Math.sign(-3);    // -1
-Math.sign('-3');  // -1
-Math.sign(0);     //  0
-Math.sign(-0);    // -0
-Math.sign(NaN);   // NaN
-Math.sign('foo'); // NaN
-Math.sign();      // NaN
+Math.sign(3); //  1
+Math.sign(-3); // -1
+Math.sign("-3"); // -1
+Math.sign(0); //  0
+Math.sign(-0); // -0
+Math.sign(NaN); // NaN
+Math.sign("foo"); // NaN
+Math.sign(); // NaN
 ```
 
 ## Polyfill
 
 ```js
 if (!Math.sign) {
-  Math.sign = function(x) {
+  Math.sign = function (x) {
     // Si x es NaN, el resultado es NaN.
     // Si x es -0, el resultado es -0.
     // Si x es +0, el resultado es +0.

--- a/files/es/web/javascript/reference/global_objects/math/sin/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/sin/index.md
@@ -31,8 +31,8 @@ Debido a que `sin()` es un método estático de `Math`, siempre se usa como `Mat
 ### Ejemplo: Usando `Math.sin()`
 
 ```js
-Math.sin(0);           // 0
-Math.sin(1);           // 0.8414709848078965
+Math.sin(0); // 0
+Math.sin(1); // 0.8414709848078965
 
 Math.sin(Math.PI / 2); // 1
 ```

--- a/files/es/web/javascript/reference/global_objects/math/sqrt/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/sqrt/index.md
@@ -37,8 +37,8 @@ Debido a que `sqrt()` es un método estático de `Math`, siempre úsalo como `Ma
 Math.sqrt(9); // 3
 Math.sqrt(2); // 1.414213562373095
 
-Math.sqrt(1);  // 1
-Math.sqrt(0);  // 0
+Math.sqrt(1); // 1
+Math.sqrt(0); // 0
 Math.sqrt(-1); // NaN
 ```
 

--- a/files/es/web/javascript/reference/global_objects/math/tan/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/tan/index.md
@@ -45,7 +45,7 @@ Ya que la función `Math.tan()` acepta radianes, pero es más fácil trabajar co
 
 ```js
 function getTanDeg(deg) {
-  var rad = deg * Math.PI/180;
+  var rad = (deg * Math.PI) / 180;
   return Math.tan(rad);
 }
 ```

--- a/files/es/web/javascript/reference/global_objects/math/tanh/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/tanh/index.md
@@ -36,9 +36,9 @@ Porque `tanh()` es un metodo estatico de `Math`, siempre se usa como `Math.tanh(
 ### Usando `Math.tanh()`
 
 ```js
-Math.tanh(0);        // 0
+Math.tanh(0); // 0
 Math.tanh(Infinity); // 1
-Math.tanh(1);        // 0.7615941559557649
+Math.tanh(1); // 0.7615941559557649
 ```
 
 ## Polyfill
@@ -46,10 +46,13 @@ Math.tanh(1);        // 0.7615941559557649
 Esto puede ser emulado con ayuda de {{jsxref("Math.exp()")}} funcion:
 
 ```js
-Math.tanh = Math.tanh || function(x){
-    var a = Math.exp(+x), b = Math.exp(-x);
+Math.tanh =
+  Math.tanh ||
+  function (x) {
+    var a = Math.exp(+x),
+      b = Math.exp(-x);
     return a == Infinity ? 1 : b == Infinity ? -1 : (a - b) / (a + b);
-}
+  };
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/math/trunc/index.md
+++ b/files/es/web/javascript/reference/global_objects/math/trunc/index.md
@@ -38,22 +38,24 @@ Debido a que `trunc()` es un método estático de `Math`, siempre úsalo como `M
 ### Usando `Math.trunc()`
 
 ```js
-Math.trunc(13.37);    // 13
-Math.trunc(42.84);    // 42
-Math.trunc(0.123);    //  0
-Math.trunc(-0.123);   // -0
-Math.trunc('-1.123'); // -1
-Math.trunc(NaN);      // NaN
-Math.trunc('foo');    // NaN
-Math.trunc();         // NaN
+Math.trunc(13.37); // 13
+Math.trunc(42.84); // 42
+Math.trunc(0.123); //  0
+Math.trunc(-0.123); // -0
+Math.trunc("-1.123"); // -1
+Math.trunc(NaN); // NaN
+Math.trunc("foo"); // NaN
+Math.trunc(); // NaN
 ```
 
 ## Polyfill
 
 ```js
-Math.trunc = Math.trunc || function (x) {
-    return (x < 0 ? Math.ceil(x) : Math.floor(x));
-}
+Math.trunc =
+  Math.trunc ||
+  function (x) {
+    return x < 0 ? Math.ceil(x) : Math.floor(x);
+  };
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/number/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/index.md
@@ -12,8 +12,8 @@ original_slug: Web/JavaScript/Referencia/Objetos_globales/Number
 
 ```js
 new Number(value);
-var a = new Number('123'); // a === 123 es false
-var b = Number('123'); // b === 123 es true
+var a = new Number("123"); // a === 123 es false
+var b = Number("123"); // b === 123 es true
 a instanceof Number; // es true
 b instanceof Number; // es false
 ```
@@ -30,19 +30,19 @@ Los principales usos del objeto `Number(valor)` son convertir un string u otro v
 ### Literal syntax
 
 ```js
-123    // one-hundred twenty-three
-123.0  // same
-123 === 123.0  // true
+123; // one-hundred twenty-three
+123.0; // same
+123 === 123.0; // true
 ```
 
 ### Function syntax
 
 ```js
-Number('123')  // retorna el número 123
-Number('123') === 123  // retorna true
+Number("123"); // retorna el número 123
+Number("123") === 123; // retorna true
 
-Number("unicorn")  // NaN
-Number(undefined)  // NaN
+Number("unicorn"); // NaN
+Number(undefined); // NaN
 ```
 
 ## Constructor
@@ -95,6 +95,7 @@ Todas las instancias `Number` heredan de {{jsxref("Number.prototype")}}. El obje
 ### Métodos
 
 - {{jsxref("Number.prototype.toExponential()" ,"Number.prototype.toExponential(<var>fractionDigits</var>)")}}
+
   - : Devuelve una cadena que representa el número en notación exponencial.
 
 - {{jsxref("Number.prototype.toFixed()", "Number.prototype.toFixed(<var>digits</var>)")}}
@@ -109,11 +110,11 @@ Todas las instancias `Number` heredan de {{jsxref("Number.prototype")}}. El obje
 El siguiente ejemplo utiliza las propiedades del objeto `Number` para asignar valores a varias variables numéricas:
 
 ```js
-const masGrandeNum    = Number.MAX_VALUE;
-const masPequeNum     = Number.MIN_VALUE;
-const infinitoNum     = Number.POSITIVE_INFINITY;
-const notInfinitoNum  = Number.NEGATIVE_INFINITY;
-const noEsNum         = Number.NaN;
+const masGrandeNum = Number.MAX_VALUE;
+const masPequeNum = Number.MIN_VALUE;
+const infinitoNum = Number.POSITIVE_INFINITY;
+const notInfinitoNum = Number.NEGATIVE_INFINITY;
+const noEsNum = Number.NaN;
 ```
 
 ### Intervalo de enteros para Number
@@ -127,8 +128,8 @@ Una posible solución es usar {{jsxref ("String")}} en su lugar.
 Los números más grandes se pueden representar usando el tipo {{jsxref ("BigInt")}}.
 
 ```js
-const biggestInt  = Number.MAX_SAFE_INTEGER  //  (253 - 1) =>  9007199254740991
-const smallestInt = Number.MIN_SAFE_INTEGER  // -(253 - 1) => -9007199254740991
+const biggestInt = Number.MAX_SAFE_INTEGER; //  (253 - 1) =>  9007199254740991
+const smallestInt = Number.MIN_SAFE_INTEGER; // -(253 - 1) => -9007199254740991
 ```
 
 ### Ejemplo: Utilizando el objeto `Number` para modificar todos los objetos `Number`
@@ -146,7 +147,7 @@ miNúmero.descripción = "velocidad del viento";
 El siguiente ejemplo convierte el objeto {{jsxref ("Date")}} a un valor numérico usando `Number` como función:
 
 ```js
-var d = new Date('December 17, 1995 03:24:00');
+var d = new Date("December 17, 1995 03:24:00");
 console.log(Number(d));
 ```
 
@@ -155,17 +156,17 @@ Esto muestra "819199440000".
 ### Convierte cadenas numéricas a números
 
 ```js
-Number('123')     // 123
-Number('12.3')    // 12.3
-Number('123e-1')  // 12.3
-Number('')        // 0
-Number('0x11')    // 17
-Number('0b11')    // 3
-Number('0o11')    // 9
-Number('foo')     // NaN
-Number('100a')    // NaN
+Number("123"); // 123
+Number("12.3"); // 12.3
+Number("123e-1"); // 12.3
+Number(""); // 0
+Number("0x11"); // 17
+Number("0b11"); // 3
+Number("0o11"); // 9
+Number("foo"); // NaN
+Number("100a"); // NaN
 
-Number('-Infinity') //-Infinity
+Number("-Infinity"); //-Infinity
 ```
 
 ### Vea También

--- a/files/es/web/javascript/reference/global_objects/number/isfinite/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/isfinite/index.md
@@ -32,25 +32,27 @@ En comparación con la funcion global {{jsxref("isFinite", "isFinite()")}} , est
 ## Ejemplos
 
 ```js
-Number.isFinite(Infinity);  // false
-Number.isFinite(NaN);       // false
+Number.isFinite(Infinity); // false
+Number.isFinite(NaN); // false
 Number.isFinite(-Infinity); // false
 
-Number.isFinite(0);         // true
-Number.isFinite(2e64);      // true
+Number.isFinite(0); // true
+Number.isFinite(2e64); // true
 
-Number.isFinite('0');       // false, retornaría true con la función
-                            // global isFinite('0')
-Number.isFinite(null);      // false, retornaría true con la función
-                            // global isFinite(null)
+Number.isFinite("0"); // false, retornaría true con la función
+// global isFinite('0')
+Number.isFinite(null); // false, retornaría true con la función
+// global isFinite(null)
 ```
 
 ## Polyfill
 
 ```js
-Number.isFinite = Number.isFinite || function(value) {
-    return typeof value === 'number' && isFinite(value);
-}
+Number.isFinite =
+  Number.isFinite ||
+  function (value) {
+    return typeof value === "number" && isFinite(value);
+  };
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/number/isinteger/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/isinteger/index.md
@@ -32,31 +32,35 @@ Si el valor seleccionado es un entero, devuelve `true`, de lo contrario `false`.
 ## Ejemplos
 
 ```js
-Number.isInteger(0);         // true
-Number.isInteger(1);         // true
-Number.isInteger(-100000);   // true
+Number.isInteger(0); // true
+Number.isInteger(1); // true
+Number.isInteger(-100000); // true
 Number.isInteger(99999999999999999999999); // true
 
-Number.isInteger(0.1);       // false
-Number.isInteger(Math.PI);   // false
+Number.isInteger(0.1); // false
+Number.isInteger(Math.PI); // false
 
-Number.isInteger(NaN);       // false
-Number.isInteger(Infinity);  // false
+Number.isInteger(NaN); // false
+Number.isInteger(Infinity); // false
 Number.isInteger(-Infinity); // false
-Number.isInteger('10');      // false
-Number.isInteger(true);      // false
-Number.isInteger(false);     // false
-Number.isInteger([1]);       // false
+Number.isInteger("10"); // false
+Number.isInteger(true); // false
+Number.isInteger(false); // false
+Number.isInteger([1]); // false
 ```
 
 ## Polyfill
 
 ```js
-Number.isInteger = Number.isInteger || function(value) {
-  return typeof value === 'number' &&
-    isFinite(value) &&
-    Math.floor(value) === value;
-};
+Number.isInteger =
+  Number.isInteger ||
+  function (value) {
+    return (
+      typeof value === "number" &&
+      isFinite(value) &&
+      Math.floor(value) === value
+    );
+  };
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/number/isnan/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/isnan/index.md
@@ -3,6 +3,7 @@ title: Number.isNaN()
 slug: Web/JavaScript/Reference/Global_Objects/Number/isNaN
 original_slug: Web/JavaScript/Referencia/Objetos_globales/Number/isNaN
 ---
+
 {{JSRef}}
 
 El método **`Number.isNaN()`** determina si el valor pasado es {{jsxref("NaN")}}. Versión más robusta de la función global {{jsxref("isNaN", "isNaN()")}}.
@@ -27,15 +28,15 @@ En comparación a la función global {{jsxref("isNaN", "isNaN()")}}, `Number.isN
 ## Examples
 
 ```js
-Number.isNaN(NaN);        // true
+Number.isNaN(NaN); // true
 Number.isNaN(Number.NaN); // true
-Number.isNaN(0 / 0)       // true
+Number.isNaN(0 / 0); // true
 
 // e.g. estos hubiesen sido true con la función global isNaN()
-Number.isNaN("NaN");      // false
-Number.isNaN(undefined);  // false
-Number.isNaN({});         // false
-Number.isNaN("blabla");   // false
+Number.isNaN("NaN"); // false
+Number.isNaN(undefined); // false
+Number.isNaN({}); // false
+Number.isNaN("blabla"); // false
 
 // Todos retornan false
 Number.isNaN(true);
@@ -50,14 +51,18 @@ Number.isNaN(" ");
 ## Polyfill
 
 ```js
-Number.isNaN = Number.isNaN || function(value) {
+Number.isNaN =
+  Number.isNaN ||
+  function (value) {
     return typeof value === "number" && isNaN(value);
-}
+  };
 
 // O
-Number.isNaN = Number.isNaN || function(value) {
+Number.isNaN =
+  Number.isNaN ||
+  function (value) {
     return value !== value;
-}
+  };
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/number/issafeinteger/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/issafeinteger/index.md
@@ -37,22 +37,26 @@ Un {{jsxref("Boolean")}} que indica si el valor dado es un número que es entero
 ## Ejemplos
 
 ```js
-Number.isSafeInteger(3);                    // true
-Number.isSafeInteger(Math.pow(2, 53));      // false
-Number.isSafeInteger(Math.pow(2, 53) - 1);  // true
-Number.isSafeInteger(NaN);                  // false
-Number.isSafeInteger(Infinity);             // false
-Number.isSafeInteger('3');                  // false
-Number.isSafeInteger(3.1);                  // false
-Number.isSafeInteger(3.0);                  // true
+Number.isSafeInteger(3); // true
+Number.isSafeInteger(Math.pow(2, 53)); // false
+Number.isSafeInteger(Math.pow(2, 53) - 1); // true
+Number.isSafeInteger(NaN); // false
+Number.isSafeInteger(Infinity); // false
+Number.isSafeInteger("3"); // false
+Number.isSafeInteger(3.1); // false
+Number.isSafeInteger(3.0); // true
 ```
 
 ## Polyfill
 
 ```js
-Number.isSafeInteger = Number.isSafeInteger || function (value) {
-   return Number.isInteger(value) && Math.abs(value) <= Number.MAX_SAFE_INTEGER;
-};
+Number.isSafeInteger =
+  Number.isSafeInteger ||
+  function (value) {
+    return (
+      Number.isInteger(value) && Math.abs(value) <= Number.MAX_SAFE_INTEGER
+    );
+  };
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/number/max_safe_integer/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/max_safe_integer/index.md
@@ -25,8 +25,8 @@ Debido a que `MAX_SAFE_INTEGER` es una propiedad estática de {{jsxref("Number")
 ## Ejemplos
 
 ```js
-Number.MAX_SAFE_INTEGER // 9007199254740991
-Math.pow(2, 53) - 1     // 9007199254740991
+Number.MAX_SAFE_INTEGER; // 9007199254740991
+Math.pow(2, 53) - 1; // 9007199254740991
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/number/max_value/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/max_value/index.md
@@ -19,17 +19,15 @@ Dado que `MAX_VALUE` es una propiedad estática de {{jsxref("Number")}}, siempre
 La función _verificarValorMaximo_ recibe un número como parámetro que se compara con _Number.MAX_VALUE._ Si el número es menor se imprime por consola _"El número no es infinito"_, de ser mayor _"El número es infinito"_.
 
 ```js
-var numero1 = 1.79E+307;
-var numero2 = 1.79E+310;
+var numero1 = 1.79e307;
+var numero2 = 1.79e310;
 
-function verificarValorMaximo(num){
-
+function verificarValorMaximo(num) {
   if (num <= Number.MAX_VALUE) {
     console.log("El número no es infinito");
   } else {
     console.log("El número es infinito");
   }
-
 }
 
 verificarValorMaximo(numero1); // El número no es infinito

--- a/files/es/web/javascript/reference/global_objects/number/negative_infinity/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/negative_infinity/index.md
@@ -38,10 +38,10 @@ Podrías utilizar la propiedad `Number.NEGATIVE_INFINITY` para indicar una condi
 En el siguiente ejemplo, a la variable `smallNumber` se le asigna un valor mucho mas pequeño al valor minimo. Cuando la sentencia `if` es ejecutada, `smallNumber` tiene el valor "`-Infinity`", por lo cual a `smallNumber` le es asignado un valor finito mas manejable antes de continuar.
 
 ```js
-var smallNumber = (-Number.MAX_VALUE) * 2
+var smallNumber = -Number.MAX_VALUE * 2;
 
 if (smallNumber === Number.NEGATIVE_INFINITY) {
- smallNumber = returnFinite();
+  smallNumber = returnFinite();
 }
 ```
 

--- a/files/es/web/javascript/reference/global_objects/number/parsefloat/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/parsefloat/index.md
@@ -13,7 +13,7 @@ El método **`Number.parseFloat()`** analiza un argumento y devuelve un número 
 ## Sintaxis
 
 ```js
-Number.parseFloat(string)
+Number.parseFloat(string);
 ```
 
 ### Parámetros

--- a/files/es/web/javascript/reference/global_objects/number/parseint/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/parseint/index.md
@@ -36,7 +36,7 @@ If the `radix` is smaller than `2` or bigger than `36`, and the first non-whites
 This method has the same functionality as the global {{jsxref("parseInt", "parseInt()")}} function:
 
 ```js
-Number.parseInt === parseInt // true
+Number.parseInt === parseInt; // true
 ```
 
 and is part of ECMAScript 2015 (its purpose is modularization of globals). Please see {{jsxref("parseInt", "parseInt()")}} for more detail and examples.
@@ -45,7 +45,7 @@ and is part of ECMAScript 2015 (its purpose is modularization of globals). Pleas
 
 ```js
 if (Number.parseInt === undefined) {
-    Number.parseInt = window.parseInt
+  Number.parseInt = window.parseInt;
 }
 ```
 

--- a/files/es/web/javascript/reference/global_objects/number/tofixed/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/tofixed/index.md
@@ -43,15 +43,15 @@ Una cadena que representa el número dado, usando notación de punto fijo.
 ```js
 var numObj = 12345.6789;
 
-numObj.toFixed();       // Returns '12346': note rounding, no fractional part
-numObj.toFixed(1);      // Returns '12345.7': note rounding
-numObj.toFixed(6);      // Returns '12345.678900': note added zeros
-(1.23e+20).toFixed(2);  // Returns '123000000000000000000.00'
-(1.23e-10).toFixed(2);  // Returns '0.00'
-2.34.toFixed(1);        // Returns '2.3'
-2.35.toFixed(1);        // Returns '2.4'. Note that it rounds up in this case.
--2.34.toFixed(1);       // Returns -2.3 (due to operator precedence, negative number literals don't return a string...)
-(-2.34).toFixed(1);     // Returns '-2.3' (...unless you use parentheses)
+numObj.toFixed(); // Returns '12346': note rounding, no fractional part
+numObj.toFixed(1); // Returns '12345.7': note rounding
+numObj.toFixed(6); // Returns '12345.678900': note added zeros
+(1.23e20).toFixed(2); // Returns '123000000000000000000.00'
+(1.23e-10).toFixed(2); // Returns '0.00'
+(2.34).toFixed(1); // Returns '2.3'
+(2.35).toFixed(1); // Returns '2.4'. Note that it rounds up in this case.
+-(2.34).toFixed(1); // Returns -2.3 (due to operator precedence, negative number literals don't return a string...)
+(-2.34).toFixed(1); // Returns '-2.3' (...unless you use parentheses)
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/number/tolocalestring/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/tolocalestring/index.md
@@ -50,9 +50,9 @@ Los parámetros `locales` y `options` no son soportados aún por todos los naveg
 function toLocaleStringSupportsLocales() {
   var number = 0;
   try {
-    number.toLocaleString('i');
+    number.toLocaleString("i");
   } catch (e) {
-    return e.name === 'RangeError';
+    return e.name === "RangeError";
   }
   return false;
 }
@@ -64,7 +64,11 @@ Para verificar que funciona todos los navegadores, incluyendo aquellos que sopor
 
 ```js
 function toLocaleStringSupportsOptions() {
-  return !!(typeof Intl == 'object' && Intl && typeof Intl.NumberFormat == 'function');
+  return !!(
+    typeof Intl == "object" &&
+    Intl &&
+    typeof Intl.NumberFormat == "function"
+  );
 }
 ```
 
@@ -78,24 +82,24 @@ Este ejemplo muestra alguna de las variaciones en los formatos de números local
 var number = 123456.789;
 
 // Aleman utiliza comas como separador decimal y puntos miles
-console.log(number.toLocaleString('de-DE'));
+console.log(number.toLocaleString("de-DE"));
 // → 123.456,789
 
 // Arabe en la mayoría de países de habla Arabe utilizan numerales Eastern Arabic
-console.log(number.toLocaleString('ar-EG'));
+console.log(number.toLocaleString("ar-EG"));
 // → ١٢٣٤٥٦٫٧٨٩
 
 // India utiliza separadores de miles/lakh/crore
-console.log(number.toLocaleString('en-IN'));
+console.log(number.toLocaleString("en-IN"));
 // → 1,23,456.789
 
 // la extensión nu requiere un sistema numerico, e.g. Decimales Chino
-console.log(number.toLocaleString('zh-Hans-CN-u-nu-hanidec'));
+console.log(number.toLocaleString("zh-Hans-CN-u-nu-hanidec"));
 // → 一二三,四五六.七八九
 
 // cuando solicitas un lenguage que podria no ser soportado, como
 // Balinese, incluye un lenguaje de respaldo, en este caso Indonesio
-console.log(number.toLocaleString(['ban', 'id']));
+console.log(number.toLocaleString(["ban", "id"]));
 // → 123.456,789
 ```
 
@@ -107,20 +111,29 @@ El resultado proveido por `toLocaleString` puede ser personalizado utilizando el
 var number = 123456.789;
 
 // solicitar un formato de moneda
-console.log(number.toLocaleString('de-DE', { style: 'currency', currency: 'EUR' }));
+console.log(
+  number.toLocaleString("de-DE", { style: "currency", currency: "EUR" }),
+);
 // → 123.456,79 €
 
 // en Japones yen no utiliza una moneda menor
-console.log(number.toLocaleString('ja-JP', { style: 'currency', currency: 'JPY' }))
+console.log(
+  number.toLocaleString("ja-JP", { style: "currency", currency: "JPY" }),
+);
 // → ￥123,457
 
 // limitar a tres digitos el significante
-console.log(number.toLocaleString('en-IN', { maximumSignificantDigits: 3 }));
+console.log(number.toLocaleString("en-IN", { maximumSignificantDigits: 3 }));
 // → 1,23,000
 
 // Utilizar el lenguaje por defecto del host con opciones para el formato del número
 var num = 30000.65;
-console.log(num.toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2}));
+console.log(
+  num.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }),
+);
 // → "30,000.65" donde English es el lenguaje por defecto, o
 // → "30.000,65" donde Aleman es el lenguaje por defecto, o
 // → "30 000,65" donde French es el lenguaje por defecto

--- a/files/es/web/javascript/reference/global_objects/number/toprecision/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/toprecision/index.md
@@ -39,17 +39,17 @@ Si el parámetro `precision` es omitido, se comporta como {{jsxref("Number.proto
 ```js
 var numObj = 5.123456;
 
-console.log(numObj.toPrecision());    // logs '5.123456'
-console.log(numObj.toPrecision(5));   // logs '5.1235'
-console.log(numObj.toPrecision(2));   // logs '5.1'
-console.log(numObj.toPrecision(1));   // logs '5'
+console.log(numObj.toPrecision()); // logs '5.123456'
+console.log(numObj.toPrecision(5)); // logs '5.1235'
+console.log(numObj.toPrecision(2)); // logs '5.1'
+console.log(numObj.toPrecision(1)); // logs '5'
 
-numObj = 0.000123
+numObj = 0.000123;
 
-console.log(numObj.toPrecision());    // logs '0.000123'
-console.log(numObj.toPrecision(5));   // logs '0.00012300'
-console.log(numObj.toPrecision(2));   // logs '0.00012'
-console.log(numObj.toPrecision(1));   // logs '0.0001'
+console.log(numObj.toPrecision()); // logs '0.000123'
+console.log(numObj.toPrecision(5)); // logs '0.00012300'
+console.log(numObj.toPrecision(2)); // logs '0.00012'
+console.log(numObj.toPrecision(1)); // logs '0.0001'
 
 // observe que bajo algunas circunstancias el valor retornado es en notación exponencial
 console.log((1234.5).toPrecision(2)); // logs '1.2e+3'

--- a/files/es/web/javascript/reference/global_objects/number/tostring/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/tostring/index.md
@@ -40,10 +40,10 @@ var howMany = 10;
 
 alert("howMany.toString() is " + howMany.toString()); // displays "10"
 
-alert("45 .toString() is " + 45 .toString()); //displays "45"
+alert("45 .toString() is " + (45).toString()); //displays "45"
 
 var x = 7;
-alert(x.toString(2))      // Displays "111"
+alert(x.toString(2)); // Displays "111"
 ```
 
 ## Vea También

--- a/files/es/web/javascript/reference/global_objects/number/valueof/index.md
+++ b/files/es/web/javascript/reference/global_objects/number/valueof/index.md
@@ -31,8 +31,8 @@ var numObj = new Number(10);
 console.log(typeof numObj); // objeto
 
 var num = numObj.valueOf();
-console.log(num);           // 10
-console.log(typeof num);    // número
+console.log(num); // 10
+console.log(typeof num); // número
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/object/__definegetter__/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/__definegetter__/index.md
@@ -35,22 +35,27 @@ The `__defineGetter__` allows a {{jsxref("Operators/get", "getter", "", 1)}} to 
 // Forma no-estándar y obsoleta
 
 var o = {};
-o.__defineGetter__('gimmeFive', function() { return 5; });
+o.__defineGetter__("gimmeFive", function () {
+  return 5;
+});
 console.log(o.gimmeFive); // 5
-
 
 // Formas compatibles con el estándar
 
 // Usando el operador get
-var o = { get gimmeFive() { return 5; } };
+var o = {
+  get gimmeFive() {
+    return 5;
+  },
+};
 console.log(o.gimmeFive); // 5
 
 // Usando Object.defineProperty
 var o = {};
-Object.defineProperty(o, 'gimmeFive', {
-  get: function() {
+Object.defineProperty(o, "gimmeFive", {
+  get: function () {
     return 5;
-  }
+  },
 });
 console.log(o.gimmeFive); // 5
 ```

--- a/files/es/web/javascript/reference/global_objects/object/assign/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/assign/index.md
@@ -55,9 +55,9 @@ Para un clonado profundo, necesitamos usar otra alternativa ya que `Object.assig
 
 ```js
 function test() {
-  'use strict';
+  "use strict";
 
-  let obj1 = { a: 0 , b: { c: 0}};
+  let obj1 = { a: 0, b: { c: 0 } };
   let obj2 = Object.assign({}, obj1);
   console.log(JSON.stringify(obj2)); // { a: 0, b: { c: 0}}
 
@@ -74,7 +74,7 @@ function test() {
   console.log(JSON.stringify(obj2)); // { a: 2, b: { c: 3}}
 
   // Deep Clone
-  obj1 = { a: 0 , b: { c: 0}};
+  obj1 = { a: 0, b: { c: 0 } };
   let obj3 = JSON.parse(JSON.stringify(obj1));
   obj1.a = 4;
   obj1.b.c = 4;
@@ -93,7 +93,7 @@ var o3 = { c: 3 };
 
 var obj = Object.assign(o1, o2, o3);
 console.log(obj); // { a: 1, b: 2, c: 3 }
-console.log(o1);  // { a: 1, b: 2, c: 3 }, target object itself is changed.
+console.log(o1); // { a: 1, b: 2, c: 3 }, target object itself is changed.
 ```
 
 ### Fusionando objetos con las mismas propiedades
@@ -113,7 +113,7 @@ Las propiedades también son sobreescritas por otros objetos que aparecen poster
 
 ```js
 var o1 = { a: 1 };
-var o2 = { [Symbol('foo')]: 2 };
+var o2 = { [Symbol("foo")]: 2 };
 
 var obj = Object.assign({}, o1, o2);
 console.log(obj); // { a : 1, [Symbol("foo")]: 2 } (cf. bug 1207182 on Firefox)
@@ -123,15 +123,19 @@ Object.getOwnPropertySymbols(obj); // [Symbol(foo)]
 ### Las propiedades heredadas y las no enumerables no pueden ser copiadas
 
 ```js
-var obj = Object.create({ foo: 1 }, { // foo es una propiedad heredada.
-  bar: {
-    value: 2  // bar es una propiedad no enumerable.
+var obj = Object.create(
+  { foo: 1 },
+  {
+    // foo es una propiedad heredada.
+    bar: {
+      value: 2, // bar es una propiedad no enumerable.
+    },
+    baz: {
+      value: 3,
+      enumerable: true, // baz es una propiedad propia enumerable.
+    },
   },
-  baz: {
-    value: 3,
-    enumerable: true  // baz es una propiedad propia enumerable.
-  }
-});
+);
 
 var copy = Object.assign({}, obj);
 console.log(copy); // { baz: 3 }
@@ -140,10 +144,10 @@ console.log(copy); // { baz: 3 }
 ### Los tipos primitivos serán encapsulados en objetos
 
 ```js
-var v1 = 'abc';
+var v1 = "abc";
 var v2 = true;
 var v3 = 10;
-var v4 = Symbol('foo')
+var v4 = Symbol("foo");
 
 var obj = Object.assign({}, v1, null, v2, undefined, v3, v4);
 // Los tipos primitivos son encapsulados en objetos y se ignoran las propiedades con valor null o undefined.
@@ -154,20 +158,20 @@ console.log(obj); // { "0": "a", "1": "b", "2": "c" }
 ### Las excepciones interrumpen la tarea de copiado
 
 ```js
-var target = Object.defineProperty({}, 'foo', {
+var target = Object.defineProperty({}, "foo", {
   value: 1,
-  writeable: false
+  writeable: false,
 }); // target.foo es una propiedad de sólo lectura
 
 Object.assign(target, { bar: 2 }, { foo2: 3, foo: 3, foo3: 3 }, { baz: 4 });
 // TypeError: "foo" es de sólo lectura
 // La excepción se lanza cuando se intenta asignar un valor a target.foo
 
-console.log(target.bar);  // 2, la primera fuente fue copiada.
+console.log(target.bar); // 2, la primera fuente fue copiada.
 console.log(target.foo2); // 3, la primera propiedad del segundo objeto fuente se copió correctamente.
-console.log(target.foo);  // 1, se lanza la excepción.
+console.log(target.foo); // 1, se lanza la excepción.
 console.log(target.foo3); // undefined, el método assign ha finalizado, no se copiará foo3.
-console.log(target.baz);  // undefined, tampoco se copiará el tercer objecto fuente.
+console.log(target.baz); // undefined, tampoco se copiará el tercer objecto fuente.
 ```
 
 ### Copiando métodos de acceso
@@ -177,7 +181,7 @@ var obj = {
   foo: 1,
   get bar() {
     return 2;
-  }
+  },
 };
 
 var copy = Object.assign({}, obj);
@@ -186,13 +190,13 @@ console.log(copy);
 
 // This is an assign function that copies full descriptors
 function completeAssign(target, ...sources) {
-  sources.forEach(source => {
+  sources.forEach((source) => {
     let descriptors = Object.keys(source).reduce((descriptors, key) => {
       descriptors[key] = Object.getOwnPropertyDescriptor(source, key);
       return descriptors;
     }, {});
     // by default, Object.assign copies enumerable Symbols too
-    Object.getOwnPropertySymbols(source).forEach(sym => {
+    Object.getOwnPropertySymbols(source).forEach((sym) => {
       let descriptor = Object.getOwnPropertyDescriptor(source, sym);
       if (descriptor.enumerable) {
         descriptors[sym] = descriptor;
@@ -213,13 +217,15 @@ console.log(copy);
 Este {{Glossary("Polyfill","polyfill")}} no soporta propiedades símbolo, ya que ES5 no tiene símbolos.
 
 ```js
-if (typeof Object.assign != 'function') {
+if (typeof Object.assign != "function") {
   // Must be writable: true, enumerable: false, configurable: true
   Object.defineProperty(Object, "assign", {
-    value: function assign(target, varArgs) { // .length of function is 2
-      'use strict';
-      if (target == null) { // TypeError if undefined or null
-        throw new TypeError('Cannot convert undefined or null to object');
+    value: function assign(target, varArgs) {
+      // .length of function is 2
+      "use strict";
+      if (target == null) {
+        // TypeError if undefined or null
+        throw new TypeError("Cannot convert undefined or null to object");
       }
 
       var to = Object(target);
@@ -227,7 +233,8 @@ if (typeof Object.assign != 'function') {
       for (var index = 1; index < arguments.length; index++) {
         var nextSource = arguments[index];
 
-        if (nextSource != null) { // Skip over if undefined or null
+        if (nextSource != null) {
+          // Skip over if undefined or null
           for (var nextKey in nextSource) {
             // Avoid bugs when hasOwnProperty is shadowed
             if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
@@ -239,7 +246,7 @@ if (typeof Object.assign != 'function') {
       return to;
     },
     writable: true,
-    configurable: true
+    configurable: true,
   });
 }
 ```

--- a/files/es/web/javascript/reference/global_objects/object/constructor/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/constructor/index.md
@@ -32,12 +32,12 @@ n.constructor === Number; // true
 El siguiente ejemplo crea un prototipo, `Tree`, y un objeto de este tipo, `theTree`. El ejemplo muestra entonces la propiedad `constructor` para el objeto `theTree`.
 
 ```js
-function Tree (name) {
-   this.name = name;
+function Tree(name) {
+  this.name = name;
 }
 
-var theTree = new Tree( "Redwood" );
-console.log( "theTree.constructor is " + theTree.constructor );
+var theTree = new Tree("Redwood");
+console.log("theTree.constructor is " + theTree.constructor);
 ```
 
 Este ejemplo muestra la siguiente salida:
@@ -53,34 +53,38 @@ theTree.constructor is function Tree (name) {
 El siguiente ejemplo demuestra como modificar el valor del constructor de objetos genéricos. Solo `true`, `1` y `"test"` no serán afectados ya que ellos tienen constructores nativos de solo lectura. Este ejemplo demuestra que no siempre es seguro confiar en la propiedad constructor de un objeto.
 
 ```js
-function Type () {}
+function Type() {}
 
 var types = [
-    new Array(),
-    [],
-    new Boolean(),
-    true,             // no cambia
-    new Date(),
-    new Error(),
-    new Function(),
-    function () {},
-    Math,
-    new Number(),
-    1,                // no cambia
-    new Object(),
-    {},
-    new RegExp(),
-    /(?:)/,
-    new String(),
-    "test"            // no cambia
+  new Array(),
+  [],
+  new Boolean(),
+  true, // no cambia
+  new Date(),
+  new Error(),
+  new Function(),
+  function () {},
+  Math,
+  new Number(),
+  1, // no cambia
+  new Object(),
+  {},
+  new RegExp(),
+  /(?:)/,
+  new String(),
+  "test", // no cambia
 ];
 
-for( var i = 0; i < types.length; i++ ) {
-    types[i].constructor = Type;
-    types[i] = [ types[i].constructor, types[i] instanceof Type, types[i].toString() ];
+for (var i = 0; i < types.length; i++) {
+  types[i].constructor = Type;
+  types[i] = [
+    types[i].constructor,
+    types[i] instanceof Type,
+    types[i].toString(),
+  ];
 }
 
-console.log( types.join( "\n" ) );
+console.log(types.join("\n"));
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/object/create/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/create/index.md
@@ -45,10 +45,10 @@ function Shape() {
 }
 
 // método de la superclase
-Shape.prototype.move = function(x, y) {
-    this.x += x;
-    this.y += y;
-    console.info("Shape moved.");
+Shape.prototype.move = function (x, y) {
+  this.x += x;
+  this.y += y;
+  console.info("Shape moved.");
 };
 
 // Rectangle - subclase
@@ -62,10 +62,8 @@ Rectangle.prototype.constructor = Rectangle;
 
 var rect = new Rectangle();
 
-console.log('¿Es rect una instancia de Rectangle?',
-  rect instanceof Rectangle); // true
-console.log('¿Es rect una instancia de Shape?',
-  rect instanceof Shape); // true
+console.log("¿Es rect una instancia de Rectangle?", rect instanceof Rectangle); // true
+console.log("¿Es rect una instancia de Shape?", rect instanceof Shape); // true
 rect.move(1, 1); // Imprime, 'Shape moved.'
 ```
 
@@ -84,7 +82,7 @@ Object.assign(MyClass.prototype, OtherSuperClass.prototype);
 // re-assign constructor
 MyClass.prototype.constructor = MyClass;
 
-MyClass.prototype.myMethod = function() {
+MyClass.prototype.myMethod = function () {
   // do something
 };
 ```
@@ -99,59 +97,65 @@ var o;
 // crea un objeto con un prototipo como null
 o = Object.create(null);
 
-
 o = {};
 // esto equivale a:
 o = Object.create(Object.prototype);
-
 
 // Ejemplo en donde creamos un objeto con un par de propiedades de ejemplo.
 // (Note que el segundo parámetro mapea claves para los *descriptores de propiedad*.)
 o = Object.create(Object.prototype, {
   // foo es un habitual "propiedad de valor"
-  foo: { writable:true, configurable:true, value: "hello" },
+  foo: { writable: true, configurable: true, value: "hello" },
   // bar es una propiedad getter-and-setter (de acceso)
   bar: {
     configurable: false,
-    get: function() { return 10 },
-    set: function(value) { console.log("Setting `o.bar` to", value) }
-}});
+    get: function () {
+      return 10;
+    },
+    set: function (value) {
+      console.log("Setting `o.bar` to", value);
+    },
+  },
+});
 
-
-function Constructor(){}
+function Constructor() {}
 o = new Constructor();
 // es equivalente a:
 o = Object.create(Constructor.prototype);
 // Por supuesto, si hay un código de inicialización en la
 // función Constructor, el Object.create no puede reflejar esta.
 
-
 // crear un nuevo objeto cuyo prototipo es un nuevo, objeto vacío
 // y agregar una única propiedad 'p', con el valor 42
-o = Object.create({}, { p: { value: 42 } })
+o = Object.create({}, { p: { value: 42 } });
 
 // por defecto las propiedades NO SON editables, enumerables o configurables:
-o.p = 24
-o.p
+o.p = 24;
+o.p;
 // 42
 
-o.q = 12
+o.q = 12;
 for (var prop in o) {
-   console.log(prop)
+  console.log(prop);
 }
 // "q"
 
-delete o.p
+delete o.p;
 // false
 
 // para especificar una propiedad en ES3
 
-o2 = Object.create({}, { p: {
+o2 = Object.create(
+  {},
+  {
+    p: {
       value: 42,
       writable: true,
       enumerable: true,
-      configurable: true }
-});
+      configurable: true,
+    },
+  },
+);
 ```
 
 ## Objetos personalizados y nulos
@@ -205,8 +209,10 @@ _Una función simple de depuración:_
 
 ```js
 // mostrar nombre de propiedad de nivel superior: pares de valores de un objeto dado
-function ShowProperties( b ){
-  for( var i in b ){  console.log( i + ": " + b[i] + "\n" )  }
+function ShowProperties(b) {
+  for (var i in b) {
+    console.log(i + ": " + b[i] + "\n");
+  }
 }
 ```
 
@@ -297,7 +303,7 @@ ob={}; ob.pn=ocn; ob.po=oco; // create a compound object (same as before)
 However, setting the generic **prototype** as the new object's prototype works even better:
 
 ```js
-ocn = Object.create( null );                  // create "null" object (same as before)
+ocn = Object.create(null); // create "null" object (same as before)
 Object.setPrototypeOf(ocn, Object.prototype); // set new object's prototype to the "generic" object (NOT standard-object)
 ```
 
@@ -320,23 +326,27 @@ Este polyfill cubre el caso de uso principal el cual es la creación de un nuevo
 Note that while the setting of `null` as `[[Prototype]]` is supported in the real ES5 `Object.create`, this polyfill cannot support it due to a limitation inherent in versions of ECMAScript lower than 5.
 
 ```js
- if (typeof Object.create !== "function") {
-    Object.create = function (proto, propertiesObject) {
-        if (typeof proto !== 'object' && typeof proto !== 'function') {
-            throw new TypeError('Object prototype may only be an Object: ' + proto);
-        } else if (proto === null) {
-            throw new Error("This browser's implementation of Object.create is a shim and doesn't support 'null' as the first argument.");
-        }
+if (typeof Object.create !== "function") {
+  Object.create = function (proto, propertiesObject) {
+    if (typeof proto !== "object" && typeof proto !== "function") {
+      throw new TypeError("Object prototype may only be an Object: " + proto);
+    } else if (proto === null) {
+      throw new Error(
+        "This browser's implementation of Object.create is a shim and doesn't support 'null' as the first argument.",
+      );
+    }
 
-        if (typeof propertiesObject != 'undefined') {
-            throw new Error("This browser's implementation of Object.create is a shim and doesn't support a second argument.");
-        }
+    if (typeof propertiesObject != "undefined") {
+      throw new Error(
+        "This browser's implementation of Object.create is a shim and doesn't support a second argument.",
+      );
+    }
 
-        function F() {}
-        F.prototype = proto;
+    function F() {}
+    F.prototype = proto;
 
-        return new F();
-    };
+    return new F();
+  };
 }
 ```
 

--- a/files/es/web/javascript/reference/global_objects/object/defineproperties/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/defineproperties/index.md
@@ -13,7 +13,7 @@ El metodo **`Object.defineProperties()`** define nuevas o modifica propiedades e
 ## Sintáxis
 
 ```js
-Object.defineProperties(obj, propiedades)
+Object.defineProperties(obj, propiedades);
 ```
 
 ### Parámetros
@@ -31,14 +31,14 @@ Object.defineProperties(obj, propiedades)
 
 ```js
 Object.defineProperties(obj, {
-  "property1": {
+  property1: {
     value: true,
-    writable: true
+    writable: true,
   },
-  "property2": {
+  property2: {
     value: "Hello",
-    writable: false
-  }
+    writable: false,
+  },
   // etc. etc.
 });
 ```

--- a/files/es/web/javascript/reference/global_objects/object/defineproperty/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/defineproperty/index.md
@@ -68,37 +68,37 @@ Hay que tener en cuenta que estas opciones también pueden heredarse; es decir, 
 
 ```js
 // Usando __proto__
-Object.defineProperty(obj, 'key', {
+Object.defineProperty(obj, "key", {
   __proto__: null, // no aceptar propiedades heredadas
-  value: 'static'  // no enumerable
-                   // no configurable
-                   // no modificable
-                   // como opciones por defecto
+  value: "static", // no enumerable
+  // no configurable
+  // no modificable
+  // como opciones por defecto
 });
 
 // Definiendo todo explicitamente
-Object.defineProperty(obj, 'key', {
+Object.defineProperty(obj, "key", {
   enumerable: false,
   configurable: false,
   writable: false,
-  value: 'static'
+  value: "static",
 });
 
 // Reciclando el mismo objeto
 function withValue(value) {
-  var d = withValue.d || (
-    withValue.d = {
+  var d =
+    withValue.d ||
+    (withValue.d = {
       enumerable: false,
       writable: false,
       configurable: false,
-      value: null
-    }
-  );
+      value: null,
+    });
   d.value = value;
   return d;
 }
 // ... y ...
-Object.defineProperty(obj, 'key', withValue('static'));
+Object.defineProperty(obj, "key", withValue("static"));
 
 // Si está disponible freeze, previene añadir o eliminar
 //del prototipo del objeto las propiedades
@@ -118,30 +118,36 @@ Cuando la propiedad especificada no existe en el objeto, `Object.defineProperty(
 var o = {}; // Creates a new object
 
 // Example of an object property added with defineProperty with a data property descriptor
-Object.defineProperty(o, 'a', {
+Object.defineProperty(o, "a", {
   value: 37,
   writable: true,
   enumerable: true,
-  configurable: true
+  configurable: true,
 });
 // 'a' property exists in the o object and its value is 37
 
 // Example of an object property added with defineProperty with an accessor property descriptor
 var bValue = 38;
-Object.defineProperty(o, 'b', {
-  get: function() { return bValue; },
-  set: function(newValue) { bValue = newValue; },
+Object.defineProperty(o, "b", {
+  get: function () {
+    return bValue;
+  },
+  set: function (newValue) {
+    bValue = newValue;
+  },
   enumerable: true,
-  configurable: true
+  configurable: true,
 });
 o.b; // 38
 // 'b' property exists in the o object and its value is 38
 // The value of o.b is now always identical to bValue, unless o.b is redefined
 
 // You cannot try to mix both:
-Object.defineProperty(o, 'conflict', {
+Object.defineProperty(o, "conflict", {
   value: 0x9f91102,
-  get: function() { return 0xdeadbeef; }
+  get: function () {
+    return 0xdeadbeef;
+  },
 });
 // throws a TypeError: value appears only in data descriptors, get appears only in accessor descriptors
 ```
@@ -161,9 +167,9 @@ Cuando la propiedad de un atributo `writable` es establecido to `false`, la prop
 ```js
 var o = {}; // Crea un objeto nuevo
 
-Object.defineProperty(o, 'a', {
+Object.defineProperty(o, "a", {
   value: 37,
-  writable: false
+  writable: false,
 });
 
 console.log(o.a); // logs 37
@@ -179,9 +185,9 @@ El atributo de la propiedad `enumerable` se define si la propiedad aparece en un
 
 ```js
 var o = {};
-Object.defineProperty(o, 'a', { value: 1, enumerable: true });
-Object.defineProperty(o, 'b', { value: 2, enumerable: false });
-Object.defineProperty(o, 'c', { value: 3 }); // enumerable defaults to false
+Object.defineProperty(o, "a", { value: 1, enumerable: true });
+Object.defineProperty(o, "b", { value: 2, enumerable: false });
+Object.defineProperty(o, "c", { value: 3 }); // enumerable defaults to false
 o.d = 4; // enumerable defaults to true when creating a property by setting it
 
 for (var i in o) {
@@ -191,9 +197,9 @@ for (var i in o) {
 
 Object.keys(o); // ['a', 'd']
 
-o.propertyIsEnumerable('a'); // true
-o.propertyIsEnumerable('b'); // false
-o.propertyIsEnumerable('c'); // false
+o.propertyIsEnumerable("a"); // true
+o.propertyIsEnumerable("b"); // false
+o.propertyIsEnumerable("c"); // false
 ```
 
 #### Atributo configurable
@@ -202,16 +208,22 @@ El atributo `configurable` define si la propiedad puede ser eliminada del objeto
 
 ```js
 var o = {};
-Object.defineProperty(o, 'a', {
-  get: function() { return 1; },
-  configurable: false
+Object.defineProperty(o, "a", {
+  get: function () {
+    return 1;
+  },
+  configurable: false,
 });
 
-Object.defineProperty(o, 'a', { configurable: true }); // arroja TypeError
-Object.defineProperty(o, 'a', { enumerable: true }); //  arroja  TypeError
-Object.defineProperty(o, 'a', { set: function() {} }); //  arroja  TypeError (set estaba definido como undefined)
-Object.defineProperty(o, 'a', { get: function() { return 1; } }); // arroja TypeError (incluso aunque los get hacen lo mismo)
-Object.defineProperty(o, 'a', { value: 12 }); // arroja TypeError
+Object.defineProperty(o, "a", { configurable: true }); // arroja TypeError
+Object.defineProperty(o, "a", { enumerable: true }); //  arroja  TypeError
+Object.defineProperty(o, "a", { set: function () {} }); //  arroja  TypeError (set estaba definido como undefined)
+Object.defineProperty(o, "a", {
+  get: function () {
+    return 1;
+  },
+}); // arroja TypeError (incluso aunque los get hacen lo mismo)
+Object.defineProperty(o, "a", { value: 12 }); // arroja TypeError
 
 console.log(o.a); // logs 1
 delete o.a; // No hace nada
@@ -229,22 +241,21 @@ var o = {};
 
 o.a = 1;
 // es equivalente a :
-Object.defineProperty(o, 'a', {
+Object.defineProperty(o, "a", {
   value: 1,
   writable: true,
   configurable: true,
-  enumerable: true
+  enumerable: true,
 });
 
-
 // Sin embargo,
-Object.defineProperty(o, 'a', { value: 1 });
+Object.defineProperty(o, "a", { value: 1 });
 // es equivalente a :
-Object.defineProperty(o, 'a', {
+Object.defineProperty(o, "a", {
   value: 1,
   writable: false,
   configurable: false,
-  enumerable: false
+  enumerable: false,
 });
 ```
 
@@ -257,18 +268,20 @@ function Archiver() {
   var temperature = null;
   var archive = [];
 
-  Object.defineProperty(this, 'temperature', {
-    get: function() {
-      console.log('get!');
+  Object.defineProperty(this, "temperature", {
+    get: function () {
+      console.log("get!");
       return temperature;
     },
-    set: function(value) {
+    set: function (value) {
       temperature = value;
       archive.push({ val: temperature });
-    }
+    },
   });
 
-  this.getArchive = function() { return archive; };
+  this.getArchive = function () {
+    return archive;
+  };
 }
 
 var arc = new Archiver();
@@ -282,22 +295,20 @@ or
 
 ```js
 var pattern = {
-    get: function () {
-        return 'I always return this string, whatever you have assigned';
-    },
-    set: function () {
-        this.myname = 'this is my name string';
-    }
+  get: function () {
+    return "I always return this string, whatever you have assigned";
+  },
+  set: function () {
+    this.myname = "this is my name string";
+  },
 };
 
-
 function TestDefineSetAndGet() {
-    Object.defineProperty(this, 'myproperty', pattern);
+  Object.defineProperty(this, "myproperty", pattern);
 }
 
-
 var instance = new TestDefineSetAndGet();
-instance.myproperty = 'test';
+instance.myproperty = "test";
 console.log(instance.myproperty); // I always return this string, whatever you have assigned
 
 console.log(instance.myname); // this is my name string

--- a/files/es/web/javascript/reference/global_objects/object/entries/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/entries/index.md
@@ -30,34 +30,43 @@ An array of the given object's own enumerable property `[key, value]` pairs.
 ## Ejemplos
 
 ```js
-var obj = { foo: 'bar', baz: 42 };
+var obj = { foo: "bar", baz: 42 };
 console.log(Object.entries(obj)); // [ ['foo', 'bar'], ['baz', 42] ]
 
 // array like object
-var obj = { 0: 'a', 1: 'b', 2: 'c' };
+var obj = { 0: "a", 1: "b", 2: "c" };
 console.log(Object.entries(obj)); // [ ['0', 'a'], ['1', 'b'], ['2', 'c'] ]
 
 // array like object with random key ordering
-var an_obj = { 100: 'a', 2: 'b', 7: 'c' };
+var an_obj = { 100: "a", 2: "b", 7: "c" };
 console.log(Object.entries(an_obj)); // [ ['2', 'b'], ['7', 'c'], ['100', 'a'] ]
 
 // getFoo is property which isn't enumerable
-var my_obj = Object.create({}, { getFoo: { value: function() { return this.foo; } } });
-my_obj.foo = 'bar';
+var my_obj = Object.create(
+  {},
+  {
+    getFoo: {
+      value: function () {
+        return this.foo;
+      },
+    },
+  },
+);
+my_obj.foo = "bar";
 console.log(Object.entries(my_obj)); // [ ['foo', 'bar'] ]
 
 // non-object argument will be coerced to an object
-console.log(Object.entries('foo')); // [ ['0', 'f'], ['1', 'o'], ['2', 'o'] ]
+console.log(Object.entries("foo")); // [ ['0', 'f'], ['1', 'o'], ['2', 'o'] ]
 
 // iterate through key-value gracefully
-var obj = {a: 5, b: 7, c: 9};
+var obj = { a: 5, b: 7, c: 9 };
 for (var [key, value] of Object.entries(obj)) {
-    console.log(key + ' ' + value); // "a 5", "b 7", "c 9"
+  console.log(key + " " + value); // "a 5", "b 7", "c 9"
 }
 
 // Or, using array extras
 Object.entries(obj).forEach(([key, value]) => {
-    console.log(key + ' ' + value); // "a 5", "b 7", "c 9"
+  console.log(key + " " + value); // "a 5", "b 7", "c 9"
 });
 ```
 
@@ -66,7 +75,7 @@ Object.entries(obj).forEach(([key, value]) => {
 The {{jsxref("Map", "new Map()")}} constructor accepts an iterable of `entries`. With `Object.entries`, you can easily convert from {{jsxref("Object")}} to {{jsxref("Map")}}:
 
 ```js
-var obj = { foo: 'bar', baz: 42 };
+var obj = { foo: "bar", baz: 42 };
 var map = new Map(Object.entries(obj));
 console.log(map); // Map { foo: "bar", baz: 42 }
 ```

--- a/files/es/web/javascript/reference/global_objects/object/freeze/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/freeze/index.md
@@ -41,14 +41,14 @@ La función retorna el mismo objeto pasado en ella, no crea una copia _congelada
 
 ```js
 var obj = {
-  prop: function() {},
-  foo: 'bar'
+  prop: function () {},
+  foo: "bar",
 };
 
 // Nuevas propiedades pueden ser agregadas,
 // propiedades existentes pueden cambiar o removerse
-obj.foo = 'baz';
-obj.lumpy = 'woof';
+obj.foo = "baz";
+obj.lumpy = "woof";
 delete obj.prop;
 
 // Ambos, el objeto pasado como argumento tanto como el que se regresa
@@ -60,54 +60,53 @@ var o = Object.freeze(obj);
 assert(Object.isFrozen(obj) === true);
 
 // Ahora cualquier cambio fallará
-obj.foo = 'quux'; // No hace nada de manera silenciosa
-obj.quaxxor = 'the friendly duck'; // No agrega una nueva propiedad, de manera silenciosa
+obj.foo = "quux"; // No hace nada de manera silenciosa
+obj.quaxxor = "the friendly duck"; // No agrega una nueva propiedad, de manera silenciosa
 
 // ...y en modo estrico tal intento arrojará TypeErrors
-function fail(){
-  'use strict';
-  obj.foo = 'sparky'; // arroja un TypeError
+function fail() {
+  "use strict";
+  obj.foo = "sparky"; // arroja un TypeError
   delete obj.quaxxor; // arroja un TypeError
-  obj.sparky = 'arf'; // arroja un TypeError
+  obj.sparky = "arf"; // arroja un TypeError
 }
 
 fail();
 
 // Los intentos utilizando Object.defineProperty tambien arrojarán una excepción...
-Object.defineProperty(obj, 'ohai', { value: 17 }); // arroja un TypeError
-Object.defineProperty(obj, 'foo', { value: 'eit' }); // arroja un TypeError
+Object.defineProperty(obj, "ohai", { value: 17 }); // arroja un TypeError
+Object.defineProperty(obj, "foo", { value: "eit" }); // arroja un TypeError
 
 // Es imposible cambiar un prototipo
 // Estos ejemplos retornan un error TypeError
-Object.setPrototype(obj,{x:20})
-obj.__proto__ = {x:20}
+Object.setPrototype(obj, { x: 20 });
+obj.__proto__ = { x: 20 };
 ```
 
 El siguiente ejemplo muestra que los valores de objetos en un objeto congelado pueden ser mutados (la congelación es superficial).
 
 ```js
 obj1 = {
-  internal: {}
+  internal: {},
 };
 
 Object.freeze(obj1);
-obj1.internal.a = 'aValue';
+obj1.internal.a = "aValue";
 
-obj1.internal.a // 'aValue'
+obj1.internal.a; // 'aValue'
 
 // Para hacer obj completamente inmutable, congelamos cada objeto en obj.
 // Para hacerlo, usamos esta función.
 function deepFreeze(obj) {
-
   // Recuperamos el nombre de las propiedades en obj
   var propNames = Object.getOwnPropertyNames(obj);
 
   // Congelamos las propiedades antes de congelar a obj
-  propNames.forEach(function(name) {
+  propNames.forEach(function (name) {
     var prop = obj[name];
 
     // Si la propiedad es un objeto, llamaremos a deepFreezze para que congele las propiedades de ese objeto
-    if (typeof prop == 'object' && prop !== null && !Object.isFrozen(prop))
+    if (typeof prop == "object" && prop !== null && !Object.isFrozen(prop))
       deepFreeze(prop);
   });
 
@@ -116,11 +115,11 @@ function deepFreeze(obj) {
 }
 
 obj2 = {
-  internal: {}
+  internal: {},
 };
 
 deepFreeze(obj2);
-obj2.internal.a = 'anotherValue';
+obj2.internal.a = "anotherValue";
 obj2.internal.a; // undefined
 ```
 

--- a/files/es/web/javascript/reference/global_objects/object/fromentries/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/fromentries/index.md
@@ -38,7 +38,10 @@ El método `Object.fromEntries()` toma una lista de pares con clave-valor y devu
 Con `Object.fromEntries`, puedes convertir de un {{jsxref("Map")}} a un {{jsxref("Object")}}:
 
 ```js
-const map = new Map([ ['foo', 'bar'], ['baz', 42] ]);
+const map = new Map([
+  ["foo", "bar"],
+  ["baz", 42],
+]);
 const obj = Object.fromEntries(map);
 console.log(obj); // { foo: "bar", baz: 42 }
 ```
@@ -48,7 +51,11 @@ console.log(obj); // { foo: "bar", baz: 42 }
 Con `Object.fromEntries`, puedes convertir de un {{jsxref("Array")}} a un {{jsxref("Object")}}:
 
 ```js
-const arr = [ ['0', 'a'], ['1', 'b'], ['2', 'c'] ];
+const arr = [
+  ["0", "a"],
+  ["1", "b"],
+  ["2", "c"],
+];
 const obj = Object.fromEntries(arr);
 console.log(obj); // { 0: "a", 1: "b", 2: "c" }
 ```
@@ -61,8 +68,7 @@ Con `Object.fromEntries`, su método inverso {{jsxref("Object.entries()")}}, y [
 const object1 = { a: 1, b: 2, c: 3 };
 
 const object2 = Object.fromEntries(
-  Object.entries(object1)
-  .map(([ key, val ]) => [ key, val * 2 ])
+  Object.entries(object1).map(([key, val]) => [key, val * 2]),
 );
 
 console.log(object2);

--- a/files/es/web/javascript/reference/global_objects/object/getownpropertydescriptor/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/getownpropertydescriptor/index.md
@@ -49,17 +49,25 @@ Una descripción de propiedad es un registro con alguno de los siguientes atribu
 ```js
 var o, d;
 
-o = { get foo() { return 17; } };
-d = Object.getOwnPropertyDescriptor(o, 'foo');
+o = {
+  get foo() {
+    return 17;
+  },
+};
+d = Object.getOwnPropertyDescriptor(o, "foo");
 // d is { configurable: true, enumerable: true, get: /* la función de acceso */, set: undefined }
 
 o = { bar: 42 };
-d = Object.getOwnPropertyDescriptor(o, 'bar');
+d = Object.getOwnPropertyDescriptor(o, "bar");
 // d is { configurable: true, enumerable: true, value: 42, writable: true }
 
 o = {};
-Object.defineProperty(o, 'baz', { value: 8675309, writable: false, enumerable: false });
-d = Object.getOwnPropertyDescriptor(o, 'baz');
+Object.defineProperty(o, "baz", {
+  value: 8675309,
+  writable: false,
+  enumerable: false,
+});
+d = Object.getOwnPropertyDescriptor(o, "baz");
 // d es { value: 8675309, writable: false, enumerable: false, configurable: false }
 ```
 

--- a/files/es/web/javascript/reference/global_objects/object/getownpropertydescriptors/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/getownpropertydescriptors/index.md
@@ -13,7 +13,7 @@ El método **`Object.getOwnPropertyDescriptors()`** regresa todos los descriptor
 ## Sintáxis
 
 ```js
-Object.getOwnPropertyDescriptors(obj)
+Object.getOwnPropertyDescriptors(obj);
 ```
 
 ### Parámetros
@@ -53,7 +53,7 @@ Mientras el método {{jsxref("Object.assign()")}} solo copiará las propiedades 
 ```js
 Object.create(
   Object.getPrototypeOf(obj),
-  Object.getOwnPropertyDescriptors(obj)
+  Object.getOwnPropertyDescriptors(obj),
 );
 ```
 
@@ -67,12 +67,9 @@ superclass.prototype = {
   // Define tus métodos y propiedades aquí
 };
 function subclass() {}
-subclass.prototype = Object.create(
-  superclass.prototype,
-  {
-    // Define tus métodos y propiedades aquí
-  }
-);
+subclass.prototype = Object.create(superclass.prototype, {
+  // Define tus métodos y propiedades aquí
+});
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/object/getownpropertynames/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/getownpropertynames/index.md
@@ -32,11 +32,11 @@ var arr = ["a", "b", "c"];
 print(Object.getOwnPropertyNames(arr).sort()); // imprime "0,1,2,length"
 
 // Objeto similar a Array
-var obj = { 0: "a", 1: "b", 2: "c"};
+var obj = { 0: "a", 1: "b", 2: "c" };
 print(Object.getOwnPropertyNames(obj).sort()); // imprime "0,1,2"
 
 // Imprime nombres de variables y valores usando Array.forEach
-Object.getOwnPropertyNames(obj).forEach(function(val, idx, array) {
+Object.getOwnPropertyNames(obj).forEach(function (val, idx, array) {
   print(val + " -> " + obj[val]);
 });
 // imprime
@@ -45,7 +45,17 @@ Object.getOwnPropertyNames(obj).forEach(function(val, idx, array) {
 // 2 -> c
 
 // propiedad no-numerable
-var my_obj = Object.create({}, { getFoo: { value: function() { return this.foo; }, enumerable: false } });
+var my_obj = Object.create(
+  {},
+  {
+    getFoo: {
+      value: function () {
+        return this.foo;
+      },
+      enumerable: false,
+    },
+  },
+);
 my_obj.foo = 1;
 
 print(Object.getOwnPropertyNames(my_obj).sort()); // imprime "foo, getFoo"
@@ -56,24 +66,21 @@ Si se quiere solo las propiedades numerables, ver {{jsxref("Object.keys")}} o us
 Items de la cadena _prototype_ no se listan:
 
 ```js
-function ParentClass () {
-}
-ParentClass.prototype.inheritedMethod = function () {
-};
+function ParentClass() {}
+ParentClass.prototype.inheritedMethod = function () {};
 
-function ChildClass () {
+function ChildClass() {
   this.prop = 5;
   this.method = function () {};
 }
-ChildClass.prototype = new ParentClass;
-ChildClass.prototype.prototypeMethod = function () {
-};
+ChildClass.prototype = new ParentClass();
+ChildClass.prototype.prototypeMethod = function () {};
 
 alert(
   Object.getOwnPropertyNames(
-    new ChildClass() // ["prop", "method"]
-  )
-)
+    new ChildClass(), // ["prop", "method"]
+  ),
+);
 ```
 
 ### Get Non-Enumerable Only
@@ -84,8 +91,8 @@ Aquí se usa la función Array.prototype.filter para quitar las _keys_ numerable
 var target = myObject;
 var enum_and_nonenum = Object.getOwnPropertyNames(target);
 var enum_only = Object.keys(target);
-var nonenum_only = enum_and_nonenum.filter(function(key) {
-  var indexInEnum = enum_only.indexOf(key)
+var nonenum_only = enum_and_nonenum.filter(function (key) {
+  var indexInEnum = enum_only.indexOf(key);
   if (indexInEnum == -1) {
     //no encontrada en las keys de enum_only, por lo que se trata de una key numerable, se devuelve true para mantenerla en filter
     return true;

--- a/files/es/web/javascript/reference/global_objects/object/getownpropertysymbols/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/getownpropertysymbols/index.md
@@ -29,17 +29,17 @@ Cómo todos los objetos no tienen inicialmente propiedades simbolos propios, `Ob
 
 ```js
 var obj = {};
-var a = Symbol('a');
-var b = Symbol.for('b');
+var a = Symbol("a");
+var b = Symbol.for("b");
 
-obj[a] = 'localSymbol';
-obj[b] = 'globalSymbol';
+obj[a] = "localSymbol";
+obj[b] = "globalSymbol";
 
 var objectSymbols = Object.getOwnPropertySymbols(obj);
 
 console.log(objectSymbols.length); // 2
-console.log(objectSymbols);        // [Symbol(a), Symbol(b)]
-console.log(objectSymbols[0]);     // Symbol(a)
+console.log(objectSymbols); // [Symbol(a), Symbol(b)]
+console.log(objectSymbols[0]); // Symbol(a)
 ```
 
 ## Especificaciones

--- a/files/es/web/javascript/reference/global_objects/object/getprototypeof/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/getprototypeof/index.md
@@ -29,7 +29,7 @@ El prototipo del objeto dado. Si no existen propiedades heredadas se devolverá 
 
 ```js
 var proto = {};
-var obj= Object.create(proto);
+var obj = Object.create(proto);
 Object.getPrototypeOf(obj) === proto; // true
 ```
 

--- a/files/es/web/javascript/reference/global_objects/object/hasown/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/hasown/index.md
@@ -46,16 +46,16 @@ El siguiente código muestra como determinar si el objeto `example` contiene una
 
 ```js
 const example = {};
-Object.hasOwn(example, 'prop');   // false - 'prop' no ha sido definido
+Object.hasOwn(example, "prop"); // false - 'prop' no ha sido definido
 
-example.prop = 'existe';
-Object.hasOwn(example, 'prop');   // true - 'prop' ha sido definido
+example.prop = "existe";
+Object.hasOwn(example, "prop"); // true - 'prop' ha sido definido
 
 example.prop = null;
-Object.hasOwn(example, 'prop');   // true - la propiedad existe con valor nulo
+Object.hasOwn(example, "prop"); // true - la propiedad existe con valor nulo
 
 example.prop = undefined;
-Object.hasOwn(example, 'prop');   // true - la propiedad existe con valor de indefinido
+Object.hasOwn(example, "prop"); // true - la propiedad existe con valor de indefinido
 ```
 
 ### Propiedades directas vs. heredadas
@@ -64,17 +64,17 @@ El siguiente ejemplo diferencía entre propiedades directas y propiedades hereda
 
 ```js
 const example = {};
-example.prop = 'existe';
+example.prop = "existe";
 
 // `hasOwn` solo devolverá verdadero para propiedades directas:
-Object.hasOwn(example, 'prop');                      // Devuelve verdadero
-Object.hasOwn(example, 'toString');                 // Devuelve falso
-Object.hasOwn(example, 'hasOwnProperty');   // Devuelve falso
+Object.hasOwn(example, "prop"); // Devuelve verdadero
+Object.hasOwn(example, "toString"); // Devuelve falso
+Object.hasOwn(example, "hasOwnProperty"); // Devuelve falso
 
 // El operador `in` devolverá verdadero para propiedades directas o heredadas:
-'prop' in example;                                   // Devuelve verdadero
-'toString' in example;                              // Devuelve verdadero
-'hasOwnProperty' in example;                // Devuelve verdadero
+"prop" in example; // Devuelve verdadero
+"toString" in example; // Devuelve verdadero
+"hasOwnProperty" in example; // Devuelve verdadero
 ```
 
 ### Iterando sobre las propiedades de un objeto
@@ -104,9 +104,9 @@ for (const name in example) {
 Los elementos de un {{jsxref("Array")}} son definidos como propiedades directas, asi que se puede usar el método `hasOwn()` para comprobar si existe un índice en particular:
 
 ```js
-const fruits = ['Apple', 'Banana', 'Watermelon', 'Orange'];
-Object.hasOwn(fruits, 3);   // true ('Orange')
-Object.hasOwn(fruits, 4);   // false - not defined
+const fruits = ["Apple", "Banana", "Watermelon", "Orange"];
+Object.hasOwn(fruits, 3); // true ('Orange')
+Object.hasOwn(fruits, 4); // false - not defined
 ```
 
 ### Casos problematicos de hasOwnProperty
@@ -118,10 +118,10 @@ const foo = {
   hasOwnProperty() {
     return false;
   },
-  bar: 'Los dragones están fuera de la oficina',
+  bar: "Los dragones están fuera de la oficina",
 };
 
-if (Object.hasOwn(foo, 'bar')) {
+if (Object.hasOwn(foo, "bar")) {
   console.log(foo.bar); //true - la reimplementación de hasOwnProperty() no afecta a Object
 }
 ```
@@ -131,8 +131,8 @@ También se puede usar para probar objetos creados usando
 
 ```js
 const foo = Object.create(null);
-foo.prop = 'existe';
-if (Object.hasOwn(foo, 'prop')) {
+foo.prop = "existe";
+if (Object.hasOwn(foo, "prop")) {
   console.log(foo.prop); //true - funciona independientemente de cómo se crea el objeto.
 }
 ```

--- a/files/es/web/javascript/reference/global_objects/object/hasownproperty/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/hasownproperty/index.md
@@ -33,16 +33,16 @@ El siguiente ejemplo determina si el objeto `o` contiene una propiedad llamada `
 
 ```js
 o = new Object();
-o.prop = 'exists';
+o.prop = "exists";
 
 function changeO() {
   o.newprop = o.prop;
   delete o.prop;
 }
 
-o.hasOwnProperty('prop');   // returns true
+o.hasOwnProperty("prop"); // returns true
 changeO();
-o.hasOwnProperty('prop');   // returns false
+o.hasOwnProperty("prop"); // returns false
 ```
 
 ### Ejemplo: Directo versus propiedades heredadas
@@ -51,10 +51,10 @@ El siguiente ejemplo diferencia entre propiedades directas y propiedades heredad
 
 ```js
 o = new Object();
-o.prop = 'exists';
-o.hasOwnProperty('prop');             // returns true
-o.hasOwnProperty('toString');         // returns false
-o.hasOwnProperty('hasOwnProperty');   // returns false
+o.prop = "exists";
+o.hasOwnProperty("prop"); // returns true
+o.hasOwnProperty("toString"); // returns false
+o.hasOwnProperty("hasOwnProperty"); // returns false
 ```
 
 ### Ejemplo: Iterando sobre las propiedades de un objeto
@@ -63,16 +63,15 @@ El siguiente ejemplo muestra como iterar sobre las propiedades de un objeto sin 
 
 ```js
 var buz = {
-    fog: 'stack'
+  fog: "stack",
 };
 
 for (var name in buz) {
-    if (buz.hasOwnProperty(name)) {
-        alert("this is fog (" + name + ") for sure. Value: " + buz[name]);
-    }
-    else {
-        alert(name); // toString or something else
-    }
+  if (buz.hasOwnProperty(name)) {
+    alert("this is fog (" + name + ") for sure. Value: " + buz[name]);
+  } else {
+    alert(name); // toString or something else
+  }
 }
 ```
 
@@ -82,19 +81,19 @@ JavaScript no protege el nombre de la propiedad `hasOwnProperty`; en consecuenci
 
 ```js
 var foo = {
-    hasOwnProperty: function() {
-        return false;
-    },
-    bar: 'Here be dragons'
+  hasOwnProperty: function () {
+    return false;
+  },
+  bar: "Here be dragons",
 };
 
-foo.hasOwnProperty('bar'); // always returns false
+foo.hasOwnProperty("bar"); // always returns false
 
 // Use another Object's hasOwnProperty and call it with 'this' set to foo
-({}).hasOwnProperty.call(foo, 'bar'); // true
+({}).hasOwnProperty.call(foo, "bar"); // true
 
 // It's also possible to use the hasOwnProperty property from the Object property for this purpose
-Object.prototype.hasOwnProperty.call(foo, 'bar'); // true
+Object.prototype.hasOwnProperty.call(foo, "bar"); // true
 ```
 
 Observe que en el último caso no han habido nuevos objetos creados.

--- a/files/es/web/javascript/reference/global_objects/object/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/index.md
@@ -163,7 +163,7 @@ Object.prototype.valueOf = function () {
     // A pesar de que valueOf() no tome ningún argumento, puede hacerlo.
     return current.apply(this, arguments);
   }
-}
+};
 ```
 
 Ya que JavaScript no tiene exactamente objetos sub-clase, el prototipo sirve para crear objetos que actúen como "clase base" para ciertas funciones que actúan como objetos y así mitigar esta limitación. Por ejemplo:

--- a/files/es/web/javascript/reference/global_objects/object/is/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/is/index.md
@@ -48,21 +48,21 @@ Esta _tampoco_ es igual a la que realiza el operador {{jsxref("Operators/Compari
 ## Ejemplos
 
 ```js
-Object.is('foo', 'foo');     // true
-Object.is(window, window);   // true
+Object.is("foo", "foo"); // true
+Object.is(window, window); // true
 
-Object.is('foo', 'bar');     // false
-Object.is([], []);           // false
+Object.is("foo", "bar"); // false
+Object.is([], []); // false
 
 var test = { a: 1 };
-Object.is(test, test);       // true
+Object.is(test, test); // true
 
-Object.is(null, null);       // true
+Object.is(null, null); // true
 
 // Special Cases
-Object.is(0, -0);            // false
-Object.is(-0, -0);           // true
-Object.is(NaN, 0/0);         // true
+Object.is(0, -0); // false
+Object.is(-0, -0); // true
+Object.is(NaN, 0 / 0); // true
 ```
 
 ## [Polyfill](https://en.wikipedia.org/wiki/Polyfill) para navegadores no ES6
@@ -71,9 +71,10 @@ Object.is(NaN, 0/0);         // true
 
 ```js
 if (!Object.is) {
-  Object.is = function(x, y) {
+  Object.is = function (x, y) {
     // SameValue algorithm
-    if (x === y) { // Steps 1-5, 7-10
+    if (x === y) {
+      // Steps 1-5, 7-10
       // Steps 6.b-6.e: +0 != -0
       return x !== 0 || 1 / x === 1 / y;
     } else {

--- a/files/es/web/javascript/reference/global_objects/object/isfrozen/index.md
+++ b/files/es/web/javascript/reference/global_objects/object/isfrozen/index.md
@@ -47,32 +47,36 @@ delete oneProp.p;
 Object.isFrozen(oneProp); // === true
 
 // Un ojbeto no-extendible con una propiedad sin capacidad de escritura pero si con capacidad de configuración no está congelado.
-var nonWritable = { e: 'plep' };
+var nonWritable = { e: "plep" };
 Object.preventExtensions(nonWritable);
-Object.defineProperty(nonWritable, 'e', { writable: false }); // Le quita la capacidad de escritura.
+Object.defineProperty(nonWritable, "e", { writable: false }); // Le quita la capacidad de escritura.
 Object.isFrozen(nonWritable); // === false
 
 // Quitarle la capacidad de configuración a una propiedad congela el objeto.
-Object.defineProperty(nonWritable, 'e', { configurable: false }); // le quita la capacidad de configuración.
+Object.defineProperty(nonWritable, "e", { configurable: false }); // le quita la capacidad de configuración.
 Object.isFrozen(nonWritable); // === true
 
 // Un objeto no-extendible con una propiedad sin capacidad de configuración pero con capacidad de escritura no congela a dicho objeto.
-var nonConfigurable = { release: 'the kraken!' };
+var nonConfigurable = { release: "the kraken!" };
 Object.preventExtensions(nonConfigurable);
-Object.defineProperty(nonConfigurable, 'release', { configurable: false });
+Object.defineProperty(nonConfigurable, "release", { configurable: false });
 Object.isFrozen(nonConfigurable); // === false
 
 // Quitarle la capacidad de configuración a esa propiedad congela el objeto.
-Object.defineProperty(nonConfigurable, 'release', { writable: false });
+Object.defineProperty(nonConfigurable, "release", { writable: false });
 Object.isFrozen(nonConfigurable); // === true
 
 // A non-extensible object with a configurable accessor property isn't frozen.
-var accessor = { get food() { return 'yum'; } };
+var accessor = {
+  get food() {
+    return "yum";
+  },
+};
 Object.preventExtensions(accessor);
 Object.isFrozen(accessor); // === false
 
 // ...but make that property non-configurable and it becomes frozen.
-Object.defineProperty(accessor, 'food', { configurable: false });
+Object.defineProperty(accessor, "food", { configurable: false });
 Object.isFrozen(accessor); // === true
 
 // But the easiest way for an object to be frozen is if Object.freeze has been called on it.


### PR DESCRIPTION
This PR formats the `/web/javascript` of the Spanish locale using Prettier.  This is the second part.
